### PR TITLE
fix: tool error semantics and protocol version negotiation (#17, #12)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests
+        run: go test ./... -v
+
+      - name: Vet
+        run: go vet ./...

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -90,9 +90,52 @@ type Middleware func(next http.Handler) http.Handler
 
 // AuthValidator is the interface for auth strategies
 type AuthValidator interface {
-    Validate(r *http.Request) (Claims, error)
+    Validate(r *http.Request) error
+}
+
+// ServerInfo identifies this MCP server (with optional 2025-11-25 fields)
+type ServerInfo struct {
+    Name, Version                          string
+    Title, Description, Instructions       string // optional
+    WebsiteURL                             string // optional
+}
+
+// ClientInfo + ClientCapabilities are stored after initialize
+type ClientInfo struct { Name, Version string }
+type ClientCapabilities struct {
+    Sampling, Elicitation *struct{}
+    Roots                 *RootsCap
 }
 ```
+
+## Protocol Version Negotiation
+
+The dispatcher supports MCP protocol versions `2025-11-25` and `2024-11-05`. During `initialize`:
+
+1. Client sends `protocolVersion` in params
+2. Server checks if the version is in its supported list
+3. If supported → responds with that version as `protocolVersion`
+4. If not → returns JSON-RPC error `-32602` with `{"supported": [...]}` in error data
+
+## Initialization Lifecycle
+
+The MCP spec requires a strict initialization handshake before the server processes requests:
+
+1. Client sends `initialize` → server responds with capabilities and negotiated version
+2. Client sends `notifications/initialized` → server marks session as ready
+3. Only after step 2 does the server accept `tools/list`, `tools/call`, etc.
+4. `ping` is exempt — allowed at any time as a keepalive
+
+Requests sent before the handshake completes receive a JSON-RPC error `-32600` ("server not initialized").
+
+## Tool Error Semantics
+
+Per the MCP spec, tool execution failures and protocol errors are handled differently:
+
+- **Handler returns `error`** → JSON-RPC success with `isError: true` in the tool result. The error message is included in the content.
+- **Protocol failure** (bad params, unknown tool, malformed JSON) → JSON-RPC error response with appropriate error code.
+
+This distinction matters: clients should check `result.isError` for tool-level failures, not the JSON-RPC error field.
 
 ## Session Lifecycle (HTTP+SSE)
 

--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -4,6 +4,9 @@
 0.0.1
 
 ## Provides
+- mcp-protocol-negotiation: Version negotiation supporting MCP 2025-11-25 and 2024-11-05
+- mcp-initialization-gating: Enforces initialize/initialized handshake before accepting requests
+- mcp-tool-error-semantics: Spec-compliant isError tool results (not JSON-RPC errors) for handler failures
 - mcp-http-transport: Production-grade MCP HTTP+SSE server with session management
 - mcp-stdio-transport: Content-Length framed JSON-RPC stdio transport
 - mcp-auth-middleware: Bearer token, JWT (via oneauth), API key authentication for MCP endpoints

--- a/README.md
+++ b/README.md
@@ -11,36 +11,54 @@ package main
 
 import (
     "context"
+    "time"
     "github.com/panyam/mcpkit"
 )
 
 func main() {
     srv := mcpkit.NewServer(
+        mcpkit.ServerInfo{Name: "my-server", Version: "0.1.0"},
         mcpkit.WithListen(":8787"),
         mcpkit.WithBearerToken("my-secret"),
         mcpkit.WithToolTimeout(30 * time.Second),
     )
 
-    srv.RegisterTool("greet", mcpkit.ToolDef{
-        Description: "Say hello",
-        InputSchema: map[string]any{
-            "type": "object",
-            "properties": map[string]any{
-                "name": map[string]any{"type": "string"},
+    srv.RegisterTool(
+        mcpkit.ToolDef{
+            Name:        "greet",
+            Description: "Say hello",
+            InputSchema: map[string]any{
+                "type": "object",
+                "properties": map[string]any{
+                    "name": map[string]any{"type": "string"},
+                },
+                "required": []string{"name"},
             },
         },
-    }, func(ctx context.Context, req mcpkit.ToolRequest) (mcpkit.ToolResult, error) {
-        name := req.StringArg("name")
-        return mcpkit.TextResult("Hello, " + name + "!"), nil
-    })
+        func(ctx context.Context, req mcpkit.ToolRequest) (mcpkit.ToolResult, error) {
+            var args struct {
+                Name string `json:"name"`
+            }
+            if err := req.Bind(&args); err != nil {
+                return mcpkit.ErrorResult(err.Error()), nil
+            }
+            return mcpkit.TextResult("Hello, " + args.Name + "!"), nil
+        },
+    )
 
     srv.ListenAndServe(context.Background())
 }
 ```
 
+## Protocol Support
+
+MCPKit supports MCP protocol versions **2025-11-25** and **2024-11-05** with automatic version negotiation during the `initialize` handshake. The server validates the client's requested version and responds with the negotiated version, or rejects with the list of supported versions.
+
 ## Features
 
 - **Two transports**: HTTP+SSE (MCP 2024-11-05) and stdio (Content-Length framed)
+- **Protocol negotiation**: Supports MCP 2025-11-25 and 2024-11-05 with version handshake
+- **Initialization gating**: Enforces the MCP lifecycle — requests are rejected until the full `initialize` / `notifications/initialized` handshake completes
 - **Auth**: Constant-time bearer token, JWT/OIDC via oneauth (optional)
 - **Rate limiting**: Per-session and per-IP token bucket
 - **Observability**: Structured logging (slog), Prometheus metrics, health endpoint
@@ -48,6 +66,15 @@ func main() {
 - **Graceful shutdown**: SIGTERM → drain SSE → exit
 - **Session management**: Concurrency-safe SSE hub with per-session write mutex
 - **CORS**: Configurable origins with OPTIONS preflight
+
+## Tool Error Handling
+
+MCPKit follows the MCP spec for error semantics:
+
+- **Tool execution failures** (handler returns `error`) → JSON-RPC success with `isError: true` in the tool result
+- **Protocol errors** (bad params, unknown tool) → JSON-RPC error response
+
+This means clients should check `result.isError`, not the JSON-RPC error field, to detect tool-level failures.
 
 ## Stack Dependencies
 

--- a/dispatch.go
+++ b/dispatch.go
@@ -6,11 +6,22 @@ import (
 	"fmt"
 )
 
+// supportedProtocolVersions lists the MCP protocol versions this server supports,
+// ordered newest-first. During initialization the server picks the client's requested
+// version if it appears in this list; otherwise it rejects with the full list.
+var supportedProtocolVersions = []string{"2025-11-25", "2024-11-05"}
+
 // Dispatcher routes JSON-RPC requests to the appropriate handler.
 type Dispatcher struct {
 	tools      map[string]toolEntry
 	toolOrder  []string // preserves registration order for tools/list
 	serverInfo ServerInfo
+
+	// Session state set during initialization handshake.
+	negotiatedVersion string             // set by initialize
+	clientCaps        ClientCapabilities // set by initialize
+	clientInfo        ClientInfo         // set by initialize
+	initialized       bool               // set to true by notifications/initialized
 	// TODO: resources, prompts registries
 }
 
@@ -21,8 +32,38 @@ type toolEntry struct {
 
 // ServerInfo identifies this MCP server in the initialize response.
 type ServerInfo struct {
+	Name         string `json:"name"`
+	Version      string `json:"version"`
+	Title        string `json:"title,omitempty"`
+	Description  string `json:"description,omitempty"`
+	Instructions string `json:"instructions,omitempty"`
+	WebsiteURL   string `json:"websiteUrl,omitempty"`
+}
+
+// ClientInfo identifies the MCP client from the initialize request.
+type ClientInfo struct {
 	Name    string `json:"name"`
 	Version string `json:"version"`
+}
+
+// ClientCapabilities describes features the client supports.
+// These are used for server-to-client requests (sampling, elicitation, roots).
+type ClientCapabilities struct {
+	Sampling    *struct{} `json:"sampling,omitempty"`
+	Roots       *RootsCap `json:"roots,omitempty"`
+	Elicitation *struct{} `json:"elicitation,omitempty"`
+}
+
+// RootsCap describes the client's roots capability.
+type RootsCap struct {
+	ListChanged bool `json:"listChanged,omitempty"`
+}
+
+// initializeParams is the params object sent by the client in an initialize request.
+type initializeParams struct {
+	ProtocolVersion string             `json:"protocolVersion"`
+	Capabilities    ClientCapabilities `json:"capabilities"`
+	ClientInfo      ClientInfo         `json:"clientInfo"`
 }
 
 // NewDispatcher creates a dispatcher with the given server identity.
@@ -49,31 +90,62 @@ func (d *Dispatcher) Dispatch(ctx context.Context, req *Request) *Response {
 
 	switch req.Method {
 	case "initialize":
-		return d.handleInitialize(id)
+		return d.handleInitialize(id, req.Params)
 
 	case "notifications/initialized", "initialized":
+		d.initialized = true
 		return nil
 
 	case "ping":
+		// Ping is allowed at any time, even before initialization.
 		return NewResponse(id, map[string]any{})
 
-	case "tools/list":
-		return d.handleToolsList(id)
-
-	case "tools/call":
-		return d.handleToolsCall(ctx, id, req.Params)
-
 	default:
-		return NewErrorResponse(id, ErrCodeMethodNotFound, "method not found: "+req.Method)
+		// All other methods require a completed initialization handshake.
+		if !d.initialized {
+			return NewErrorResponse(id, ErrCodeInvalidRequest, "server not initialized")
+		}
+
+		switch req.Method {
+		case "tools/list":
+			return d.handleToolsList(id)
+		case "tools/call":
+			return d.handleToolsCall(ctx, id, req.Params)
+		default:
+			return NewErrorResponse(id, ErrCodeMethodNotFound, "method not found: "+req.Method)
+		}
 	}
 }
 
-func (d *Dispatcher) handleInitialize(id json.RawMessage) *Response {
+func (d *Dispatcher) handleInitialize(id json.RawMessage, params json.RawMessage) *Response {
+	var p initializeParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return NewErrorResponse(id, ErrCodeInvalidParams, "invalid initialize params: "+err.Error())
+	}
+
+	// Negotiate protocol version: accept if client's version is in our supported list.
+	negotiated := ""
+	for _, sv := range supportedProtocolVersions {
+		if sv == p.ProtocolVersion {
+			negotiated = sv
+			break
+		}
+	}
+	if negotiated == "" {
+		return NewErrorResponseWithData(id, ErrCodeInvalidParams,
+			"unsupported protocol version: "+p.ProtocolVersion,
+			map[string]any{"supported": supportedProtocolVersions})
+	}
+
+	d.negotiatedVersion = negotiated
+	d.clientCaps = p.Capabilities
+	d.clientInfo = p.ClientInfo
+
 	caps := map[string]any{
 		"tools": map[string]any{},
 	}
 	result := map[string]any{
-		"protocolVersion": "2024-11-05",
+		"protocolVersion": negotiated,
 		"capabilities":    caps,
 		"serverInfo":      d.serverInfo,
 	}
@@ -112,7 +184,7 @@ func (d *Dispatcher) handleToolsCall(ctx context.Context, id json.RawMessage, pa
 
 	result, err := entry.handler(ctx, req)
 	if err != nil {
-		return NewErrorResponse(id, ErrCodeInternal, fmt.Sprintf("tool %q: %v", envelope.Name, err))
+		result = ErrorResult(fmt.Sprintf("tool %q: %v", envelope.Name, err))
 	}
 
 	return NewResponse(id, result)

--- a/dispatch_test.go
+++ b/dispatch_test.go
@@ -3,8 +3,24 @@ package mcpkit
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 )
+
+// initDispatcher performs the full MCP initialization handshake on a dispatcher
+// (initialize + notifications/initialized) so subsequent tool calls are accepted.
+func initDispatcher(d *Dispatcher) {
+	d.Dispatch(context.Background(), &Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`0`),
+		Method:  "initialize",
+		Params:  json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`),
+	})
+	d.Dispatch(context.Background(), &Request{
+		JSONRPC: "2.0",
+		Method:  "notifications/initialized",
+	})
+}
 
 func testDispatcher() *Dispatcher {
 	d := NewDispatcher(ServerInfo{Name: "test-server", Version: "1.0.0"})
@@ -30,6 +46,7 @@ func testDispatcher() *Dispatcher {
 			return TextResult("echo: " + args.Message), nil
 		},
 	)
+	initDispatcher(d)
 	return d
 }
 
@@ -240,6 +257,51 @@ func TestDispatchNullID(t *testing.T) {
 	}
 }
 
+// TestDispatchToolsCallHandlerError verifies that when a ToolHandler returns a Go error,
+// the dispatcher wraps it as a JSON-RPC success with isError: true in the tool result,
+// NOT as a JSON-RPC error response. Per the MCP spec, JSON-RPC errors are reserved for
+// protocol-level failures (bad params, unknown tool). Tool execution failures use isError.
+func TestDispatchToolsCallHandlerError(t *testing.T) {
+	d := testDispatcher()
+	// Register a tool that always returns a Go error
+	d.RegisterTool(
+		ToolDef{Name: "failing", Description: "always fails"},
+		func(ctx context.Context, req ToolRequest) (ToolResult, error) {
+			return ToolResult{}, fmt.Errorf("something broke")
+		},
+	)
+
+	resp := d.Dispatch(context.Background(), &Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`10`),
+		Method:  "tools/call",
+		Params:  json.RawMessage(`{"name":"failing","arguments":{}}`),
+	})
+
+	if resp == nil {
+		t.Fatal("response is nil")
+	}
+	// Must NOT be a JSON-RPC error — tool failures are reported via isError in the result
+	if resp.Error != nil {
+		t.Fatalf("got JSON-RPC error (code %d: %s), want JSON-RPC success with isError in result",
+			resp.Error.Code, resp.Error.Message)
+	}
+
+	var result ToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if !result.IsError {
+		t.Error("result.IsError = false, want true")
+	}
+	if len(result.Content) == 0 {
+		t.Fatal("result has no content")
+	}
+	if result.Content[0].Text == "" {
+		t.Error("error content text is empty")
+	}
+}
+
 func TestDispatchToolOrder(t *testing.T) {
 	d := NewDispatcher(ServerInfo{Name: "test", Version: "1.0"})
 	for _, name := range []string{"charlie", "alpha", "bravo"} {
@@ -247,6 +309,7 @@ func TestDispatchToolOrder(t *testing.T) {
 			return TextResult(name), nil
 		})
 	}
+	initDispatcher(d)
 
 	resp := d.Dispatch(context.Background(), &Request{
 		JSONRPC: "2.0",
@@ -269,5 +332,199 @@ func TestDispatchToolOrder(t *testing.T) {
 		if result.Tools[i].Name != name {
 			t.Errorf("tools[%d].Name = %q, want %q", i, result.Tools[i].Name, name)
 		}
+	}
+}
+
+// TestDispatchInitializeVersion2025 verifies that the server correctly negotiates
+// protocol version 2025-11-25 when the client requests it. The server should respond
+// with the same version in protocolVersion, confirming mutual support.
+func TestDispatchInitializeVersion2025(t *testing.T) {
+	d := testDispatcher()
+	resp := d.Dispatch(context.Background(), &Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  "initialize",
+		Params:  json.RawMessage(`{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`),
+	})
+
+	if resp == nil {
+		t.Fatal("response is nil")
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: code=%d msg=%s", resp.Error.Code, resp.Error.Message)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result["protocolVersion"] != "2025-11-25" {
+		t.Errorf("protocolVersion = %v, want 2025-11-25", result["protocolVersion"])
+	}
+}
+
+// TestDispatchInitializeUnsupportedVersion verifies that the server rejects an unknown
+// protocol version with a JSON-RPC error code -32602 (invalid params) and includes
+// the list of supported versions in the error data, per the MCP spec.
+func TestDispatchInitializeUnsupportedVersion(t *testing.T) {
+	d := testDispatcher()
+	resp := d.Dispatch(context.Background(), &Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  "initialize",
+		Params:  json.RawMessage(`{"protocolVersion":"1999-01-01","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`),
+	})
+
+	if resp == nil {
+		t.Fatal("response is nil")
+	}
+	if resp.Error == nil {
+		t.Fatal("expected error for unsupported version, got success")
+	}
+	if resp.Error.Code != ErrCodeInvalidParams {
+		t.Errorf("error code = %d, want %d", resp.Error.Code, ErrCodeInvalidParams)
+	}
+	// Error data must contain a "supported" array listing valid versions.
+	// Round-trip through JSON to normalize types (the in-memory struct uses
+	// concrete Go types, but a real client would see JSON).
+	raw, err := json.Marshal(resp.Error.Data)
+	if err != nil {
+		t.Fatalf("failed to marshal error data: %v", err)
+	}
+	var data map[string][]string
+	if err := json.Unmarshal(raw, &data); err != nil {
+		t.Fatalf("failed to unmarshal error data: %v", err)
+	}
+	versions := data["supported"]
+	if len(versions) < 2 {
+		t.Errorf("expected at least 2 supported versions, got %d", len(versions))
+	}
+}
+
+// TestDispatchInitializeMissingParams verifies that sending initialize with nil params
+// returns a JSON-RPC error (invalid params), not a panic or success.
+func TestDispatchInitializeMissingParams(t *testing.T) {
+	d := testDispatcher()
+	resp := d.Dispatch(context.Background(), &Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  "initialize",
+	})
+
+	if resp == nil {
+		t.Fatal("response is nil")
+	}
+	if resp.Error == nil {
+		t.Fatal("expected error for missing params")
+	}
+	if resp.Error.Code != ErrCodeInvalidParams {
+		t.Errorf("error code = %d, want %d", resp.Error.Code, ErrCodeInvalidParams)
+	}
+}
+
+// TestDispatchInitializeStoresClientInfo verifies that the dispatcher stores the
+// client info and capabilities from the initialize request, making them available
+// for server-to-client feature detection.
+func TestDispatchInitializeStoresClientInfo(t *testing.T) {
+	d := NewDispatcher(ServerInfo{Name: "test", Version: "1.0"})
+	d.Dispatch(context.Background(), &Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  "initialize",
+		Params:  json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{"roots":{"listChanged":true}},"clientInfo":{"name":"my-client","version":"2.0"}}`),
+	})
+
+	if d.clientInfo.Name != "my-client" {
+		t.Errorf("clientInfo.Name = %q, want my-client", d.clientInfo.Name)
+	}
+	if d.clientInfo.Version != "2.0" {
+		t.Errorf("clientInfo.Version = %q, want 2.0", d.clientInfo.Version)
+	}
+	if d.negotiatedVersion != "2024-11-05" {
+		t.Errorf("negotiatedVersion = %q, want 2024-11-05", d.negotiatedVersion)
+	}
+}
+
+// TestDispatchBeforeInitialized verifies that the server rejects tool calls when
+// initialize has been called but notifications/initialized has not yet been received.
+// The MCP spec requires the full initialization handshake before processing requests.
+func TestDispatchBeforeInitialized(t *testing.T) {
+	d := NewDispatcher(ServerInfo{Name: "test", Version: "1.0"})
+	d.RegisterTool(
+		ToolDef{Name: "echo", Description: "echoes"},
+		func(ctx context.Context, req ToolRequest) (ToolResult, error) {
+			return TextResult("hi"), nil
+		},
+	)
+	// Send initialize but NOT notifications/initialized
+	d.Dispatch(context.Background(), &Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  "initialize",
+		Params:  json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`),
+	})
+
+	resp := d.Dispatch(context.Background(), &Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`2`),
+		Method:  "tools/list",
+	})
+
+	if resp == nil {
+		t.Fatal("response is nil")
+	}
+	if resp.Error == nil {
+		t.Fatal("expected error for request before initialized notification")
+	}
+	if resp.Error.Code != ErrCodeInvalidRequest {
+		t.Errorf("error code = %d, want %d", resp.Error.Code, ErrCodeInvalidRequest)
+	}
+}
+
+// TestDispatchToolsCallBeforeAnyInit verifies that tool calls are rejected when
+// no initialization has occurred at all (neither initialize nor notifications/initialized).
+func TestDispatchToolsCallBeforeAnyInit(t *testing.T) {
+	d := NewDispatcher(ServerInfo{Name: "test", Version: "1.0"})
+	d.RegisterTool(
+		ToolDef{Name: "echo", Description: "echoes"},
+		func(ctx context.Context, req ToolRequest) (ToolResult, error) {
+			return TextResult("hi"), nil
+		},
+	)
+
+	resp := d.Dispatch(context.Background(), &Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  "tools/call",
+		Params:  json.RawMessage(`{"name":"echo","arguments":{}}`),
+	})
+
+	if resp == nil {
+		t.Fatal("response is nil")
+	}
+	if resp.Error == nil {
+		t.Fatal("expected error for request before any initialization")
+	}
+	if resp.Error.Code != ErrCodeInvalidRequest {
+		t.Errorf("error code = %d, want %d", resp.Error.Code, ErrCodeInvalidRequest)
+	}
+}
+
+// TestDispatchPingBeforeInitialized verifies that ping works at any time,
+// even before the initialization handshake is complete. The MCP spec allows
+// ping as a keepalive mechanism regardless of session state.
+func TestDispatchPingBeforeInitialized(t *testing.T) {
+	d := NewDispatcher(ServerInfo{Name: "test", Version: "1.0"})
+	resp := d.Dispatch(context.Background(), &Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  "ping",
+	})
+
+	if resp == nil {
+		t.Fatal("response is nil")
+	}
+	if resp.Error != nil {
+		t.Fatalf("ping should work before init, got error: %s", resp.Error.Message)
 	}
 }

--- a/jsonrpc.go
+++ b/jsonrpc.go
@@ -55,3 +55,13 @@ func NewErrorResponse(id json.RawMessage, code int, message string) *Response {
 		Error:   &Error{Code: code, Message: message},
 	}
 }
+
+// NewErrorResponseWithData creates an error response with additional structured data.
+// Used for protocol errors that carry machine-readable context (e.g., supported versions).
+func NewErrorResponseWithData(id json.RawMessage, code int, message string, data any) *Response {
+	return &Response{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error:   &Error{Code: code, Message: message, Data: data},
+	}
+}

--- a/jsonrpc_test.go
+++ b/jsonrpc_test.go
@@ -49,6 +49,42 @@ func TestNewErrorResponse(t *testing.T) {
 	}
 }
 
+// TestNewErrorResponseWithData verifies that the error response constructor correctly
+// sets the Data field, which is used to carry machine-readable context like the list
+// of supported protocol versions in a version negotiation failure.
+func TestNewErrorResponseWithData(t *testing.T) {
+	id := json.RawMessage(`1`)
+	data := map[string]any{"supported": []string{"2025-11-25", "2024-11-05"}}
+	resp := NewErrorResponseWithData(id, ErrCodeInvalidParams, "unsupported version", data)
+
+	if resp.Error == nil {
+		t.Fatal("Error is nil")
+	}
+	if resp.Error.Code != ErrCodeInvalidParams {
+		t.Errorf("Error.Code = %d, want %d", resp.Error.Code, ErrCodeInvalidParams)
+	}
+	if resp.Error.Data == nil {
+		t.Fatal("Error.Data is nil")
+	}
+
+	// Verify data round-trips through JSON
+	raw, err := json.Marshal(resp.Error)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var parsed struct {
+		Data struct {
+			Supported []string `json:"supported"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	if len(parsed.Data.Supported) != 2 {
+		t.Errorf("got %d supported versions, want 2", len(parsed.Data.Supported))
+	}
+}
+
 func TestRequestIsNotification(t *testing.T) {
 	tests := []struct {
 		name string

--- a/server_test.go
+++ b/server_test.go
@@ -9,6 +9,21 @@ import (
 	"time"
 )
 
+// initServer performs the full MCP initialization handshake on a server
+// (initialize + notifications/initialized) so subsequent tool calls are accepted.
+func initServer(srv *Server) {
+	srv.Dispatch(context.Background(), &Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`0`),
+		Method:  "initialize",
+		Params:  json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`),
+	})
+	srv.Dispatch(context.Background(), &Request{
+		JSONRPC: "2.0",
+		Method:  "notifications/initialized",
+	})
+}
+
 func TestServerDispatch(t *testing.T) {
 	srv := NewServer(ServerInfo{Name: "test", Version: "0.1.0"})
 	srv.RegisterTool(
@@ -17,6 +32,7 @@ func TestServerDispatch(t *testing.T) {
 			return TextResult("hi"), nil
 		},
 	)
+	initServer(srv)
 
 	resp := srv.Dispatch(context.Background(), &Request{
 		JSONRPC: "2.0",
@@ -51,6 +67,7 @@ func TestServerToolTimeout(t *testing.T) {
 			}
 		},
 	)
+	initServer(srv)
 
 	resp := srv.Dispatch(context.Background(), &Request{
 		JSONRPC: "2.0",


### PR DESCRIPTION
## Summary

- **#17 — Tool error semantics**: Handler errors now return JSON-RPC success with `isError: true` in the tool result, not JSON-RPC error responses. Per MCP spec, JSON-RPC errors are reserved for protocol-level failures (bad params, unknown tool).
- **#12 — Protocol version negotiation**: `handleInitialize` now parses client params, negotiates protocol version (supports `2025-11-25` and `2024-11-05`), stores client info/capabilities, and rejects unsupported versions with the supported list in error data.
- **Initialization gating**: Requests are rejected with `-32600` until the full `initialize` + `notifications/initialized` handshake completes. `ping` is exempt.
- **CI**: Added GitHub Actions workflow (`go test` + `go vet`) and pre-push git hook.

## Changes

| File | What changed |
|------|-------------|
| `dispatch.go` | Handler error → `ErrorResult`, version negotiation, init gating, new types (`ClientInfo`, `ClientCapabilities`, expanded `ServerInfo`) |
| `jsonrpc.go` | Added `NewErrorResponseWithData` |
| `dispatch_test.go` | 8 new tests + `initDispatcher` helper |
| `server_test.go` | `initServer` helper, updated 2 tests |
| `jsonrpc_test.go` | 1 new test (`NewErrorResponseWithData`) |
| `ARCHITECTURE.md` | Added Protocol Negotiation, Init Lifecycle, Tool Error Semantics sections |
| `README.md` | Fixed Quick Start API, added Protocol Support and Error Handling sections |
| `CAPABILITIES.md` | Added 3 new capabilities |
| `.github/workflows/test.yml` | CI pipeline |

## Test plan

- [x] `TestDispatchToolsCallHandlerError` — handler error returns isError, not JSON-RPC error
- [x] `TestDispatchInitializeVersion2025` — negotiate 2025-11-25
- [x] `TestDispatchInitializeUnsupportedVersion` — reject with supported list
- [x] `TestDispatchInitializeMissingParams` — nil params error
- [x] `TestDispatchInitializeStoresClientInfo` — client info stored
- [x] `TestDispatchBeforeInitialized` — gated before notifications/initialized
- [x] `TestDispatchToolsCallBeforeAnyInit` — gated with no init at all
- [x] `TestDispatchPingBeforeInitialized` — ping works without init
- [x] `TestNewErrorResponseWithData` — data field round-trips
- [x] All 27 tests pass, `go vet` clean
- [ ] Manual test with real MCP client (see note below)

Closes #17, Closes #12