### PR TITLE
feat: resources, prompts, pagination, and cancellation (#13, #14, #15, #16)

### DIFF
--- a/cmd/testserver/conformance_prompts.go
+++ b/cmd/testserver/conformance_prompts.go
@@ -1,0 +1,105 @@
+package main
+
+// Conformance prompts implement the prompt contracts expected by the official
+// MCP conformance test suite (@modelcontextprotocol/conformance).
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/panyam/mcpkit"
+)
+
+// registerConformancePrompts adds all prompts required by the MCP conformance suite.
+func registerConformancePrompts(srv *mcpkit.Server) {
+	// test_simple_prompt — no arguments, returns a simple text message
+	srv.RegisterPrompt(
+		mcpkit.PromptDef{
+			Name:        "test_simple_prompt",
+			Description: "A simple prompt for conformance testing",
+		},
+		func(ctx context.Context, req mcpkit.PromptRequest) (mcpkit.PromptResult, error) {
+			return mcpkit.PromptResult{
+				Description: "A simple test prompt",
+				Messages: []mcpkit.PromptMessage{{
+					Role:    "user",
+					Content: mcpkit.Content{Type: "text", Text: "This is a simple prompt for testing."},
+				}},
+			}, nil
+		},
+	)
+
+	// test_prompt_with_arguments — takes arg1 and arg2 arguments
+	srv.RegisterPrompt(
+		mcpkit.PromptDef{
+			Name:        "test_prompt_with_arguments",
+			Description: "A prompt with arguments for conformance testing",
+			Arguments: []mcpkit.PromptArgument{
+				{Name: "arg1", Description: "First test argument", Required: true},
+				{Name: "arg2", Description: "Second test argument", Required: true},
+			},
+		},
+		func(ctx context.Context, req mcpkit.PromptRequest) (mcpkit.PromptResult, error) {
+			arg1 := req.Arguments["arg1"]
+			arg2 := req.Arguments["arg2"]
+			return mcpkit.PromptResult{
+				Description: "A prompt with arguments",
+				Messages: []mcpkit.PromptMessage{{
+					Role:    "user",
+					Content: mcpkit.Content{Type: "text", Text: fmt.Sprintf("Prompt with arguments: arg1='%s', arg2='%s'", arg1, arg2)},
+				}},
+			}, nil
+		},
+	)
+
+	// test_prompt_with_embedded_resource — returns message with embedded resource content
+	srv.RegisterPrompt(
+		mcpkit.PromptDef{
+			Name:        "test_prompt_with_embedded_resource",
+			Description: "A prompt that includes an embedded resource",
+			Arguments: []mcpkit.PromptArgument{
+				{Name: "resourceUri", Description: "URI of the resource to embed", Required: true},
+			},
+		},
+		func(ctx context.Context, req mcpkit.PromptRequest) (mcpkit.PromptResult, error) {
+			uri := req.Arguments["resourceUri"]
+			return mcpkit.PromptResult{
+				Description: "A prompt with an embedded resource",
+				Messages: []mcpkit.PromptMessage{{
+					Role: "user",
+					Content: mcpkit.Content{
+						Type: "resource",
+						Resource: &mcpkit.ResourceContent{
+							URI:      uri,
+							MimeType: "text/plain",
+							Text:     "Embedded resource content for testing.",
+						},
+					},
+				}},
+			}, nil
+		},
+	)
+
+	// test_prompt_with_image — returns message with image content
+	srv.RegisterPrompt(
+		mcpkit.PromptDef{
+			Name:        "test_prompt_with_image",
+			Description: "A prompt that includes an image",
+		},
+		func(ctx context.Context, req mcpkit.PromptRequest) (mcpkit.PromptResult, error) {
+			pngBytes := minimalPNG() // reuse from conformance_tools.go
+			return mcpkit.PromptResult{
+				Description: "A prompt with image content",
+				Messages: []mcpkit.PromptMessage{{
+					Role: "user",
+					Content: mcpkit.Content{
+						Type:     "image",
+						MimeType: "image/png",
+						Data:     base64.StdEncoding.EncodeToString(pngBytes),
+					},
+				}},
+			}, nil
+		},
+	)
+}

--- a/cmd/testserver/conformance_resources.go
+++ b/cmd/testserver/conformance_resources.go
@@ -1,0 +1,74 @@
+package main
+
+// Conformance resources implement the resource contracts expected by the official
+// MCP conformance test suite (@modelcontextprotocol/conformance).
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/panyam/mcpkit"
+)
+
+// registerConformanceResources adds all resources required by the MCP conformance suite.
+func registerConformanceResources(srv *mcpkit.Server) {
+	// test://static-text — returns plain text content
+	srv.RegisterResource(
+		mcpkit.ResourceDef{
+			URI:         "test://static-text",
+			Name:        "Static Text Resource",
+			Description: "A static text resource for conformance testing",
+			MimeType:    "text/plain",
+		},
+		func(ctx context.Context, req mcpkit.ResourceRequest) (mcpkit.ResourceResult, error) {
+			return mcpkit.ResourceResult{
+				Contents: []mcpkit.ResourceReadContent{{
+					URI:      "test://static-text",
+					MimeType: "text/plain",
+					Text:     "This is a test resource",
+				}},
+			}, nil
+		},
+	)
+
+	// test://static-binary — returns base64 binary content
+	srv.RegisterResource(
+		mcpkit.ResourceDef{
+			URI:         "test://static-binary",
+			Name:        "Static Binary Resource",
+			Description: "A static binary resource for conformance testing",
+			MimeType:    "application/octet-stream",
+		},
+		func(ctx context.Context, req mcpkit.ResourceRequest) (mcpkit.ResourceResult, error) {
+			data := []byte("binary test data")
+			return mcpkit.ResourceResult{
+				Contents: []mcpkit.ResourceReadContent{{
+					URI:      "test://static-binary",
+					MimeType: "application/octet-stream",
+					Blob:     base64.StdEncoding.EncodeToString(data),
+				}},
+			}, nil
+		},
+	)
+
+	// test://template/{id}/data — URI template resource
+	srv.RegisterResourceTemplate(
+		mcpkit.ResourceTemplate{
+			URITemplate: "test://template/{id}/data",
+			Name:        "Template Resource",
+			Description: "A parameterized resource template for conformance testing",
+			MimeType:    "text/plain",
+		},
+		func(ctx context.Context, uri string, params map[string]string) (mcpkit.ResourceResult, error) {
+			id := params["id"]
+			return mcpkit.ResourceResult{
+				Contents: []mcpkit.ResourceReadContent{{
+					URI:      uri,
+					MimeType: "text/plain",
+					Text:     fmt.Sprintf("Template data for ID: %s", id),
+				}},
+			}, nil
+		},
+	)
+}

--- a/cmd/testserver/main.go
+++ b/cmd/testserver/main.go
@@ -104,8 +104,10 @@ func main() {
 		},
 	)
 
-	// Register conformance suite tools (test_simple_text, test_error_handling, etc.)
+	// Register conformance suite tools, resources, and prompts
 	registerConformanceTools(srv)
+	registerConformanceResources(srv)
+	registerConformancePrompts(srv)
 
 	var transportOpts []mcpkit.TransportOption
 	switch {

--- a/conformance/baseline.yml
+++ b/conformance/baseline.yml
@@ -13,27 +13,18 @@ server:
   - completion-complete         # Issue: #21 (completion/complete)
   - server-sse-multiple-streams # Requires GET SSE stream (Streamable HTTP phase 2)
 
-  # Missing capabilities (resources, prompts, elicitation, sampling)
-  - resources-list              # Issue: #13
-  - resources-read-text         # Issue: #13
-  - resources-read-binary       # Issue: #13
-  - resources-templates-read    # Issue: #13
+  # Missing capabilities (subscriptions, elicitation, sampling)
   - resources-subscribe         # Issue: #24
   - resources-unsubscribe       # Issue: #24
-  - prompts-list                # Issue: #14
-  - prompts-get-simple          # Issue: #14
-  - prompts-get-with-args       # Issue: #14
-  - prompts-get-embedded-resource  # Issue: #14
-  - prompts-get-with-image      # Issue: #14
   - elicitation-sep1034-defaults   # Issue: #23
   - elicitation-sep1330-enums      # Issue: #23
 
-  # Tool scenarios requiring server-to-client features (sampling, progress, logging, elicitation)
+  # Tool scenarios requiring server-to-client features
   - tools-call-with-logging     # Requires logging notifications (#19)
   - tools-call-with-progress    # Requires progress notifications (#18)
   - tools-call-sampling         # Requires sampling/createMessage (#22)
   - tools-call-elicitation      # Requires elicitation/create (#23)
-  - tools-call-mixed-content    # Expected response format mismatch (needs embedded resource in mixed content)
+  - tools-call-mixed-content    # Expected response format mismatch
 
   # Security
-  - dns-rebinding-protection    # Requires Origin header validation (partial pass, 1 of 2 checks)
+  - dns-rebinding-protection    # Requires Origin header validation (partial pass)

--- a/dispatch.go
+++ b/dispatch.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
+	"sync"
 )
 
 // supportedProtocolVersions lists the MCP protocol versions this server supports,
@@ -11,23 +13,51 @@ import (
 // version if it appears in this list; otherwise it rejects with the full list.
 var supportedProtocolVersions = []string{"2025-11-25", "2024-11-05"}
 
+// ErrCodeCancelled is the JSON-RPC error code for a cancelled request.
+const ErrCodeCancelled = -32800
+
 // Dispatcher routes JSON-RPC requests to the appropriate handler.
 type Dispatcher struct {
 	tools      map[string]toolEntry
 	toolOrder  []string // preserves registration order for tools/list
 	serverInfo ServerInfo
 
+	resources     map[string]resourceEntry
+	resourceOrder []string
+	templates     map[string]templateEntry
+	templateOrder []string
+
+	prompts     map[string]promptEntry
+	promptOrder []string
+
+	// inflight tracks cancellable in-flight requests by ID.
+	inflight sync.Map // requestID (string) → context.CancelFunc
+
 	// Session state set during initialization handshake.
 	negotiatedVersion string             // set by initialize
 	clientCaps        ClientCapabilities // set by initialize
 	clientInfo        ClientInfo         // set by initialize
 	initialized       bool               // set to true by notifications/initialized
-	// TODO: resources, prompts registries
 }
 
 type toolEntry struct {
 	def     ToolDef
 	handler ToolHandler
+}
+
+type resourceEntry struct {
+	def     ResourceDef
+	handler ResourceHandler
+}
+
+type templateEntry struct {
+	def     ResourceTemplate
+	handler TemplateHandler
+}
+
+type promptEntry struct {
+	def     PromptDef
+	handler PromptHandler
 }
 
 // ServerInfo identifies this MCP server in the initialize response.
@@ -47,7 +77,6 @@ type ClientInfo struct {
 }
 
 // ClientCapabilities describes features the client supports.
-// These are used for server-to-client requests (sampling, elicitation, roots).
 type ClientCapabilities struct {
 	Sampling    *struct{} `json:"sampling,omitempty"`
 	Roots       *RootsCap `json:"roots,omitempty"`
@@ -69,25 +98,33 @@ type initializeParams struct {
 // NewDispatcher creates a dispatcher with the given server identity.
 func NewDispatcher(info ServerInfo) *Dispatcher {
 	return &Dispatcher{
-		tools:      make(map[string]toolEntry),
+		tools:     make(map[string]toolEntry),
+		resources: make(map[string]resourceEntry),
+		templates: make(map[string]templateEntry),
+		prompts:   make(map[string]promptEntry),
 		serverInfo: info,
 	}
 }
 
-// newSession creates a new Dispatcher that shares the tool registry from d
+// newSession creates a new Dispatcher that shares all registries from d
 // but has fresh session state (not initialized, no client info).
-// The tool registry is shared by reference — safe because tools are registered
+// Registries are shared by reference — safe because they are populated
 // before serving begins and never modified after.
 func (d *Dispatcher) newSession() *Dispatcher {
 	return &Dispatcher{
-		tools:      d.tools,
-		toolOrder:  d.toolOrder,
-		serverInfo: d.serverInfo,
+		tools:         d.tools,
+		toolOrder:     d.toolOrder,
+		resources:     d.resources,
+		resourceOrder: d.resourceOrder,
+		templates:     d.templates,
+		templateOrder: d.templateOrder,
+		prompts:       d.prompts,
+		promptOrder:   d.promptOrder,
+		serverInfo:    d.serverInfo,
 	}
 }
 
 // NegotiatedVersion returns the protocol version negotiated during initialization.
-// Returns "" if initialization has not completed.
 func (d *Dispatcher) NegotiatedVersion() string {
 	return d.negotiatedVersion
 }
@@ -96,6 +133,24 @@ func (d *Dispatcher) NegotiatedVersion() string {
 func (d *Dispatcher) RegisterTool(def ToolDef, handler ToolHandler) {
 	d.tools[def.Name] = toolEntry{def: def, handler: handler}
 	d.toolOrder = append(d.toolOrder, def.Name)
+}
+
+// RegisterResource adds a resource to the dispatcher.
+func (d *Dispatcher) RegisterResource(def ResourceDef, handler ResourceHandler) {
+	d.resources[def.URI] = resourceEntry{def: def, handler: handler}
+	d.resourceOrder = append(d.resourceOrder, def.URI)
+}
+
+// RegisterResourceTemplate adds a URI template resource to the dispatcher.
+func (d *Dispatcher) RegisterResourceTemplate(def ResourceTemplate, handler TemplateHandler) {
+	d.templates[def.URITemplate] = templateEntry{def: def, handler: handler}
+	d.templateOrder = append(d.templateOrder, def.URITemplate)
+}
+
+// RegisterPrompt adds a prompt to the dispatcher.
+func (d *Dispatcher) RegisterPrompt(def PromptDef, handler PromptHandler) {
+	d.prompts[def.Name] = promptEntry{def: def, handler: handler}
+	d.promptOrder = append(d.promptOrder, def.Name)
 }
 
 // Dispatch routes a JSON-RPC request and returns the response.
@@ -114,21 +169,40 @@ func (d *Dispatcher) Dispatch(ctx context.Context, req *Request) *Response {
 		d.initialized = true
 		return nil
 
+	case "notifications/cancelled":
+		d.handleCancelled(req.Params)
+		return nil
+
 	case "ping":
-		// Ping is allowed at any time, even before initialization.
 		return NewResponse(id, map[string]any{})
 
 	default:
-		// All other methods require a completed initialization handshake.
 		if !d.initialized {
 			return NewErrorResponse(id, ErrCodeInvalidRequest, "server not initialized")
 		}
 
+		// Track in-flight request for cancellation support
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+		reqID := string(id)
+		d.inflight.Store(reqID, cancel)
+		defer d.inflight.Delete(reqID)
+
 		switch req.Method {
 		case "tools/list":
-			return d.handleToolsList(id)
+			return d.handleToolsList(id, req.Params)
 		case "tools/call":
 			return d.handleToolsCall(ctx, id, req.Params)
+		case "resources/list":
+			return d.handleResourcesList(id, req.Params)
+		case "resources/read":
+			return d.handleResourcesRead(ctx, id, req.Params)
+		case "resources/templates/list":
+			return d.handleResourcesTemplatesList(id, req.Params)
+		case "prompts/list":
+			return d.handlePromptsList(id, req.Params)
+		case "prompts/get":
+			return d.handlePromptsGet(ctx, id, req.Params)
 		default:
 			return NewErrorResponse(id, ErrCodeMethodNotFound, "method not found: "+req.Method)
 		}
@@ -141,7 +215,6 @@ func (d *Dispatcher) handleInitialize(id json.RawMessage, params json.RawMessage
 		return NewErrorResponse(id, ErrCodeInvalidParams, "invalid initialize params: "+err.Error())
 	}
 
-	// Negotiate protocol version: accept if client's version is in our supported list.
 	negotiated := ""
 	for _, sv := range supportedProtocolVersions {
 		if sv == p.ProtocolVersion {
@@ -162,6 +235,13 @@ func (d *Dispatcher) handleInitialize(id json.RawMessage, params json.RawMessage
 	caps := map[string]any{
 		"tools": map[string]any{},
 	}
+	if len(d.resources) > 0 || len(d.templates) > 0 {
+		caps["resources"] = map[string]any{}
+	}
+	if len(d.prompts) > 0 {
+		caps["prompts"] = map[string]any{}
+	}
+
 	result := map[string]any{
 		"protocolVersion": negotiated,
 		"capabilities":    caps,
@@ -170,7 +250,7 @@ func (d *Dispatcher) handleInitialize(id json.RawMessage, params json.RawMessage
 	return NewResponse(id, result)
 }
 
-func (d *Dispatcher) handleToolsList(id json.RawMessage) *Response {
+func (d *Dispatcher) handleToolsList(id json.RawMessage, params json.RawMessage) *Response {
 	tools := make([]ToolDef, 0, len(d.toolOrder))
 	for _, name := range d.toolOrder {
 		if entry, ok := d.tools[name]; ok {
@@ -206,4 +286,140 @@ func (d *Dispatcher) handleToolsCall(ctx context.Context, id json.RawMessage, pa
 	}
 
 	return NewResponse(id, result)
+}
+
+// --- Resources ---
+
+func (d *Dispatcher) handleResourcesList(id json.RawMessage, params json.RawMessage) *Response {
+	resources := make([]ResourceDef, 0, len(d.resourceOrder))
+	for _, uri := range d.resourceOrder {
+		if entry, ok := d.resources[uri]; ok {
+			resources = append(resources, entry.def)
+		}
+	}
+	return NewResponse(id, map[string]any{"resources": resources})
+}
+
+func (d *Dispatcher) handleResourcesRead(ctx context.Context, id json.RawMessage, params json.RawMessage) *Response {
+	var envelope struct {
+		URI string `json:"uri"`
+	}
+	if err := json.Unmarshal(params, &envelope); err != nil {
+		return NewErrorResponse(id, ErrCodeInvalidParams, err.Error())
+	}
+
+	// Try exact match first
+	if entry, ok := d.resources[envelope.URI]; ok {
+		result, err := entry.handler(ctx, ResourceRequest{URI: envelope.URI})
+		if err != nil {
+			return NewErrorResponse(id, ErrCodeInternal, fmt.Sprintf("resource %q: %v", envelope.URI, err))
+		}
+		return NewResponse(id, result)
+	}
+
+	// Try template match
+	for _, tmplURI := range d.templateOrder {
+		entry := d.templates[tmplURI]
+		if params, matched := matchTemplate(entry.def.URITemplate, envelope.URI); matched {
+			result, err := entry.handler(ctx, envelope.URI, params)
+			if err != nil {
+				return NewErrorResponse(id, ErrCodeInternal, fmt.Sprintf("resource template %q: %v", tmplURI, err))
+			}
+			return NewResponse(id, result)
+		}
+	}
+
+	return NewErrorResponse(id, ErrCodeInvalidParams, "unknown resource: "+envelope.URI)
+}
+
+func (d *Dispatcher) handleResourcesTemplatesList(id json.RawMessage, params json.RawMessage) *Response {
+	templates := make([]ResourceTemplate, 0, len(d.templateOrder))
+	for _, uri := range d.templateOrder {
+		if entry, ok := d.templates[uri]; ok {
+			templates = append(templates, entry.def)
+		}
+	}
+	return NewResponse(id, map[string]any{"resourceTemplates": templates})
+}
+
+// --- Prompts ---
+
+func (d *Dispatcher) handlePromptsList(id json.RawMessage, params json.RawMessage) *Response {
+	prompts := make([]PromptDef, 0, len(d.promptOrder))
+	for _, name := range d.promptOrder {
+		if entry, ok := d.prompts[name]; ok {
+			prompts = append(prompts, entry.def)
+		}
+	}
+	return NewResponse(id, map[string]any{"prompts": prompts})
+}
+
+func (d *Dispatcher) handlePromptsGet(ctx context.Context, id json.RawMessage, params json.RawMessage) *Response {
+	var envelope struct {
+		Name      string            `json:"name"`
+		Arguments map[string]string `json:"arguments"`
+	}
+	if err := json.Unmarshal(params, &envelope); err != nil {
+		return NewErrorResponse(id, ErrCodeInvalidParams, err.Error())
+	}
+
+	entry, ok := d.prompts[envelope.Name]
+	if !ok {
+		return NewErrorResponse(id, ErrCodeInvalidParams, "unknown prompt: "+envelope.Name)
+	}
+
+	req := PromptRequest{
+		Name:      envelope.Name,
+		Arguments: envelope.Arguments,
+	}
+
+	result, err := entry.handler(ctx, req)
+	if err != nil {
+		return NewErrorResponse(id, ErrCodeInternal, fmt.Sprintf("prompt %q: %v", envelope.Name, err))
+	}
+
+	return NewResponse(id, result)
+}
+
+// --- Cancellation ---
+
+func (d *Dispatcher) handleCancelled(params json.RawMessage) {
+	if params == nil {
+		return
+	}
+	var p struct {
+		RequestID json.RawMessage `json:"requestId"`
+		Reason    string          `json:"reason"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil {
+		return
+	}
+	if cancelFn, ok := d.inflight.LoadAndDelete(string(p.RequestID)); ok {
+		cancelFn.(context.CancelFunc)()
+	}
+}
+
+// --- Template matching ---
+
+// matchTemplate matches a URI against a simple URI template like "test://template/{id}/data".
+// Returns the extracted parameters and whether it matched.
+func matchTemplate(template, uri string) (map[string]string, bool) {
+	params := make(map[string]string)
+	tParts := strings.Split(template, "/")
+	uParts := strings.Split(uri, "/")
+
+	if len(tParts) != len(uParts) {
+		return nil, false
+	}
+
+	for i, tp := range tParts {
+		if strings.HasPrefix(tp, "{") && strings.HasSuffix(tp, "}") {
+			key := tp[1 : len(tp)-1]
+			params[key] = uParts[i]
+		} else if tp != uParts[i] {
+			return nil, false
+		}
+	}
+
+	return params, true
 }

--- a/pagination.go
+++ b/pagination.go
@@ -1,0 +1,51 @@
+package mcpkit
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strconv"
+)
+
+// defaultPageSize is the default number of items per page.
+// 0 means return all items (no pagination).
+const defaultPageSize = 0
+
+// paginate applies cursor-based pagination to a slice of items.
+// The cursor is an opaque base64-encoded offset. If cursor is empty, starts from
+// the beginning. If pageSize is 0, returns all items with no nextCursor.
+// Returns the page of items and a nextCursor (empty string if no more pages).
+func paginate[T any](items []T, cursor string, pageSize int) ([]T, string, error) {
+	if pageSize <= 0 || len(items) == 0 {
+		return items, "", nil
+	}
+
+	offset := 0
+	if cursor != "" {
+		decoded, err := base64.StdEncoding.DecodeString(cursor)
+		if err != nil {
+			return nil, "", fmt.Errorf("invalid cursor")
+		}
+		offset, err = strconv.Atoi(string(decoded))
+		if err != nil || offset < 0 {
+			return nil, "", fmt.Errorf("invalid cursor")
+		}
+	}
+
+	if offset >= len(items) {
+		return nil, "", nil
+	}
+
+	end := offset + pageSize
+	if end > len(items) {
+		end = len(items)
+	}
+
+	page := items[offset:end]
+
+	var nextCursor string
+	if end < len(items) {
+		nextCursor = base64.StdEncoding.EncodeToString([]byte(strconv.Itoa(end)))
+	}
+
+	return page, nextCursor, nil
+}

--- a/prompt.go
+++ b/prompt.go
@@ -1,0 +1,46 @@
+package mcpkit
+
+import "context"
+
+// PromptDef describes a prompt exposed via MCP.
+type PromptDef struct {
+	// Name is the prompt identifier used in prompts/get.
+	Name string `json:"name"`
+
+	// Title is an optional display title.
+	Title string `json:"title,omitempty"`
+
+	// Description explains what this prompt does.
+	Description string `json:"description,omitempty"`
+
+	// Arguments defines the parameters this prompt accepts.
+	Arguments []PromptArgument `json:"arguments,omitempty"`
+}
+
+// PromptArgument describes a single argument to a prompt.
+type PromptArgument struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Required    bool   `json:"required,omitempty"`
+}
+
+// PromptMessage is a single message in a prompt result.
+type PromptMessage struct {
+	Role    string  `json:"role"`
+	Content Content `json:"content"` // reuses Content from tool.go
+}
+
+// PromptRequest is the validated input passed to a PromptHandler.
+type PromptRequest struct {
+	Name      string
+	Arguments map[string]string
+}
+
+// PromptResult is the response from a prompt handler.
+type PromptResult struct {
+	Description string          `json:"description,omitempty"`
+	Messages    []PromptMessage `json:"messages"`
+}
+
+// PromptHandler generates prompt messages, optionally using arguments.
+type PromptHandler func(ctx context.Context, req PromptRequest) (PromptResult, error)

--- a/prompt_test.go
+++ b/prompt_test.go
@@ -1,0 +1,156 @@
+package mcpkit
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// testPromptDispatcher creates an initialized dispatcher with test prompts.
+func testPromptDispatcher() *Dispatcher {
+	d := NewDispatcher(ServerInfo{Name: "test", Version: "1.0"})
+	d.RegisterPrompt(
+		PromptDef{
+			Name:        "greet",
+			Description: "Greeting prompt",
+			Arguments: []PromptArgument{
+				{Name: "name", Description: "Name to greet", Required: true},
+			},
+		},
+		func(ctx context.Context, req PromptRequest) (PromptResult, error) {
+			return PromptResult{
+				Description: "Greeting",
+				Messages: []PromptMessage{{
+					Role:    "user",
+					Content: Content{Type: "text", Text: "Hello, " + req.Arguments["name"] + "!"},
+				}},
+			}, nil
+		},
+	)
+	d.RegisterPrompt(
+		PromptDef{Name: "simple", Description: "No-args prompt"},
+		func(ctx context.Context, req PromptRequest) (PromptResult, error) {
+			return PromptResult{
+				Messages: []PromptMessage{{
+					Role:    "user",
+					Content: Content{Type: "text", Text: "Simple prompt text"},
+				}},
+			}, nil
+		},
+	)
+	initDispatcher(d)
+	return d
+}
+
+// TestPromptsList verifies that prompts/list returns all registered prompts
+// in registration order.
+func TestPromptsList(t *testing.T) {
+	d := testPromptDispatcher()
+	resp := d.Dispatch(context.Background(), &Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "prompts/list",
+	})
+	if resp.Error != nil {
+		t.Fatalf("error: %s", resp.Error.Message)
+	}
+	var result struct {
+		Prompts []PromptDef `json:"prompts"`
+	}
+	json.Unmarshal(resp.Result, &result)
+	if len(result.Prompts) != 2 {
+		t.Fatalf("got %d prompts, want 2", len(result.Prompts))
+	}
+	if result.Prompts[0].Name != "greet" {
+		t.Errorf("first prompt = %q, want greet", result.Prompts[0].Name)
+	}
+}
+
+// TestPromptsListEmpty verifies that prompts/list returns an empty list
+// when no prompts are registered.
+func TestPromptsListEmpty(t *testing.T) {
+	d := NewDispatcher(ServerInfo{Name: "test", Version: "1.0"})
+	initDispatcher(d)
+	resp := d.Dispatch(context.Background(), &Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "prompts/list",
+	})
+	if resp.Error != nil {
+		t.Fatalf("error: %s", resp.Error.Message)
+	}
+	var result struct {
+		Prompts []PromptDef `json:"prompts"`
+	}
+	json.Unmarshal(resp.Result, &result)
+	if len(result.Prompts) != 0 {
+		t.Errorf("got %d prompts, want 0", len(result.Prompts))
+	}
+}
+
+// TestPromptsGetSimple verifies that prompts/get returns messages for a
+// prompt without arguments.
+func TestPromptsGetSimple(t *testing.T) {
+	d := testPromptDispatcher()
+	resp := d.Dispatch(context.Background(), &Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "prompts/get",
+		Params: json.RawMessage(`{"name":"simple"}`),
+	})
+	if resp.Error != nil {
+		t.Fatalf("error: %s", resp.Error.Message)
+	}
+	var result PromptResult
+	json.Unmarshal(resp.Result, &result)
+	if len(result.Messages) != 1 {
+		t.Fatalf("got %d messages, want 1", len(result.Messages))
+	}
+	if result.Messages[0].Content.Text != "Simple prompt text" {
+		t.Errorf("text = %q", result.Messages[0].Content.Text)
+	}
+}
+
+// TestPromptsGetWithArgs verifies that prompts/get passes arguments to the
+// handler and returns the interpolated result.
+func TestPromptsGetWithArgs(t *testing.T) {
+	d := testPromptDispatcher()
+	resp := d.Dispatch(context.Background(), &Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "prompts/get",
+		Params: json.RawMessage(`{"name":"greet","arguments":{"name":"World"}}`),
+	})
+	if resp.Error != nil {
+		t.Fatalf("error: %s", resp.Error.Message)
+	}
+	var result PromptResult
+	json.Unmarshal(resp.Result, &result)
+	if result.Messages[0].Content.Text != "Hello, World!" {
+		t.Errorf("text = %q, want Hello, World!", result.Messages[0].Content.Text)
+	}
+}
+
+// TestPromptsGetUnknown verifies that prompts/get returns an error for
+// an unknown prompt name.
+func TestPromptsGetUnknown(t *testing.T) {
+	d := testPromptDispatcher()
+	resp := d.Dispatch(context.Background(), &Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "prompts/get",
+		Params: json.RawMessage(`{"name":"nonexistent"}`),
+	})
+	if resp.Error == nil {
+		t.Fatal("expected error for unknown prompt")
+	}
+	if resp.Error.Code != ErrCodeInvalidParams {
+		t.Errorf("code = %d, want %d", resp.Error.Code, ErrCodeInvalidParams)
+	}
+}
+
+// TestPromptsCapabilities verifies that the initialize response includes
+// prompts capability when prompts are registered.
+func TestPromptsCapabilities(t *testing.T) {
+	d := testPromptDispatcher()
+	resp := d.Dispatch(context.Background(), &Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "initialize",
+		Params: json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`),
+	})
+	var result map[string]any
+	json.Unmarshal(resp.Result, &result)
+	caps := result["capabilities"].(map[string]any)
+	if _, ok := caps["prompts"]; !ok {
+		t.Error("capabilities missing 'prompts'")
+	}
+}

--- a/resource.go
+++ b/resource.go
@@ -1,0 +1,65 @@
+package mcpkit
+
+import "context"
+
+// ResourceDef describes a resource exposed via MCP.
+type ResourceDef struct {
+	// URI uniquely identifies this resource.
+	URI string `json:"uri"`
+
+	// Name is a human-readable short name.
+	Name string `json:"name"`
+
+	// Title is an optional display title.
+	Title string `json:"title,omitempty"`
+
+	// Description explains what this resource provides.
+	Description string `json:"description,omitempty"`
+
+	// MimeType is the MIME type of the resource content.
+	MimeType string `json:"mimeType,omitempty"`
+}
+
+// ResourceTemplate describes a parameterized resource URI template.
+type ResourceTemplate struct {
+	// URITemplate is an RFC 6570 URI template (e.g., "file:///{path}").
+	URITemplate string `json:"uriTemplate"`
+
+	// Name is a human-readable short name.
+	Name string `json:"name"`
+
+	// Title is an optional display title.
+	Title string `json:"title,omitempty"`
+
+	// Description explains what this template provides.
+	Description string `json:"description,omitempty"`
+
+	// MimeType is the default MIME type for resources matching this template.
+	MimeType string `json:"mimeType,omitempty"`
+}
+
+// ResourceReadContent is a single content item returned by resources/read.
+// Either Text or Blob is set, not both.
+type ResourceReadContent struct {
+	URI      string `json:"uri"`
+	MimeType string `json:"mimeType,omitempty"`
+	Text     string `json:"text,omitempty"`
+	Blob     string `json:"blob,omitempty"`
+}
+
+// ResourceRequest is the validated input passed to a ResourceHandler.
+type ResourceRequest struct {
+	URI string
+}
+
+// ResourceResult is the response from a resource handler.
+type ResourceResult struct {
+	Contents []ResourceReadContent `json:"contents"`
+}
+
+// ResourceHandler reads a resource by URI.
+type ResourceHandler func(ctx context.Context, req ResourceRequest) (ResourceResult, error)
+
+// TemplateHandler reads a resource matched by a URI template.
+// The uri parameter is the full resolved URI, params contains the extracted template variables.
+type TemplateHandler func(ctx context.Context, uri string, params map[string]string) (ResourceResult, error)

--- a/resource_test.go
+++ b/resource_test.go
@@ -1,0 +1,190 @@
+package mcpkit
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// testResourceDispatcher creates an initialized dispatcher with test resources.
+func testResourceDispatcher() *Dispatcher {
+	d := NewDispatcher(ServerInfo{Name: "test", Version: "1.0"})
+	d.RegisterResource(
+		ResourceDef{URI: "test://doc", Name: "Test Doc", MimeType: "text/plain"},
+		func(ctx context.Context, req ResourceRequest) (ResourceResult, error) {
+			return ResourceResult{Contents: []ResourceReadContent{{
+				URI: req.URI, MimeType: "text/plain", Text: "hello from resource",
+			}}}, nil
+		},
+	)
+	d.RegisterResource(
+		ResourceDef{URI: "test://binary", Name: "Binary", MimeType: "application/octet-stream"},
+		func(ctx context.Context, req ResourceRequest) (ResourceResult, error) {
+			return ResourceResult{Contents: []ResourceReadContent{{
+				URI: req.URI, MimeType: "application/octet-stream", Blob: "AQID",
+			}}}, nil
+		},
+	)
+	d.RegisterResourceTemplate(
+		ResourceTemplate{URITemplate: "test://items/{id}", Name: "Item", MimeType: "text/plain"},
+		func(ctx context.Context, uri string, params map[string]string) (ResourceResult, error) {
+			return ResourceResult{Contents: []ResourceReadContent{{
+				URI: uri, MimeType: "text/plain", Text: "item " + params["id"],
+			}}}, nil
+		},
+	)
+	initDispatcher(d)
+	return d
+}
+
+// TestResourcesList verifies that resources/list returns all registered resources
+// in registration order.
+func TestResourcesList(t *testing.T) {
+	d := testResourceDispatcher()
+	resp := d.Dispatch(context.Background(), &Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "resources/list",
+	})
+	if resp.Error != nil {
+		t.Fatalf("error: %s", resp.Error.Message)
+	}
+	var result struct {
+		Resources []ResourceDef `json:"resources"`
+	}
+	json.Unmarshal(resp.Result, &result)
+	if len(result.Resources) != 2 {
+		t.Fatalf("got %d resources, want 2", len(result.Resources))
+	}
+	if result.Resources[0].URI != "test://doc" {
+		t.Errorf("first resource URI = %q, want test://doc", result.Resources[0].URI)
+	}
+}
+
+// TestResourcesListEmpty verifies that resources/list returns an empty list
+// when no resources are registered.
+func TestResourcesListEmpty(t *testing.T) {
+	d := NewDispatcher(ServerInfo{Name: "test", Version: "1.0"})
+	initDispatcher(d)
+	resp := d.Dispatch(context.Background(), &Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "resources/list",
+	})
+	if resp.Error != nil {
+		t.Fatalf("error: %s", resp.Error.Message)
+	}
+	var result struct {
+		Resources []ResourceDef `json:"resources"`
+	}
+	json.Unmarshal(resp.Result, &result)
+	if len(result.Resources) != 0 {
+		t.Errorf("got %d resources, want 0", len(result.Resources))
+	}
+}
+
+// TestResourcesRead verifies that resources/read returns text content for a known URI.
+func TestResourcesRead(t *testing.T) {
+	d := testResourceDispatcher()
+	resp := d.Dispatch(context.Background(), &Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "resources/read",
+		Params: json.RawMessage(`{"uri":"test://doc"}`),
+	})
+	if resp.Error != nil {
+		t.Fatalf("error: %s", resp.Error.Message)
+	}
+	var result ResourceResult
+	json.Unmarshal(resp.Result, &result)
+	if len(result.Contents) != 1 {
+		t.Fatalf("got %d contents, want 1", len(result.Contents))
+	}
+	if result.Contents[0].Text != "hello from resource" {
+		t.Errorf("text = %q, want hello from resource", result.Contents[0].Text)
+	}
+}
+
+// TestResourcesReadBinary verifies that resources/read returns blob content.
+func TestResourcesReadBinary(t *testing.T) {
+	d := testResourceDispatcher()
+	resp := d.Dispatch(context.Background(), &Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "resources/read",
+		Params: json.RawMessage(`{"uri":"test://binary"}`),
+	})
+	if resp.Error != nil {
+		t.Fatalf("error: %s", resp.Error.Message)
+	}
+	var result ResourceResult
+	json.Unmarshal(resp.Result, &result)
+	if result.Contents[0].Blob != "AQID" {
+		t.Errorf("blob = %q, want AQID", result.Contents[0].Blob)
+	}
+}
+
+// TestResourcesReadUnknown verifies that resources/read returns an error for
+// an unknown URI.
+func TestResourcesReadUnknown(t *testing.T) {
+	d := testResourceDispatcher()
+	resp := d.Dispatch(context.Background(), &Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "resources/read",
+		Params: json.RawMessage(`{"uri":"test://nonexistent"}`),
+	})
+	if resp.Error == nil {
+		t.Fatal("expected error for unknown resource")
+	}
+	if resp.Error.Code != ErrCodeInvalidParams {
+		t.Errorf("code = %d, want %d", resp.Error.Code, ErrCodeInvalidParams)
+	}
+}
+
+// TestResourcesTemplatesList verifies that resources/templates/list returns
+// registered templates.
+func TestResourcesTemplatesList(t *testing.T) {
+	d := testResourceDispatcher()
+	resp := d.Dispatch(context.Background(), &Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "resources/templates/list",
+	})
+	if resp.Error != nil {
+		t.Fatalf("error: %s", resp.Error.Message)
+	}
+	var result struct {
+		ResourceTemplates []ResourceTemplate `json:"resourceTemplates"`
+	}
+	json.Unmarshal(resp.Result, &result)
+	if len(result.ResourceTemplates) != 1 {
+		t.Fatalf("got %d templates, want 1", len(result.ResourceTemplates))
+	}
+	if result.ResourceTemplates[0].URITemplate != "test://items/{id}" {
+		t.Errorf("template = %q", result.ResourceTemplates[0].URITemplate)
+	}
+}
+
+// TestResourcesTemplateRead verifies that resources/read resolves a URI against
+// a registered template and returns the parameterized content.
+func TestResourcesTemplateRead(t *testing.T) {
+	d := testResourceDispatcher()
+	resp := d.Dispatch(context.Background(), &Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "resources/read",
+		Params: json.RawMessage(`{"uri":"test://items/42"}`),
+	})
+	if resp.Error != nil {
+		t.Fatalf("error: %s", resp.Error.Message)
+	}
+	var result ResourceResult
+	json.Unmarshal(resp.Result, &result)
+	if result.Contents[0].Text != "item 42" {
+		t.Errorf("text = %q, want item 42", result.Contents[0].Text)
+	}
+}
+
+// TestResourcesCapabilities verifies that the initialize response includes
+// resources capability when resources are registered.
+func TestResourcesCapabilities(t *testing.T) {
+	d := testResourceDispatcher()
+	// Re-initialize to check capabilities (testResourceDispatcher already initializes)
+	resp := d.Dispatch(context.Background(), &Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "initialize",
+		Params: json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`),
+	})
+	var result map[string]any
+	json.Unmarshal(resp.Result, &result)
+	caps := result["capabilities"].(map[string]any)
+	if _, ok := caps["resources"]; !ok {
+		t.Error("capabilities missing 'resources'")
+	}
+}

--- a/server.go
+++ b/server.go
@@ -77,6 +77,21 @@ func (s *Server) RegisterTool(def ToolDef, handler ToolHandler) {
 	s.dispatcher.RegisterTool(def, handler)
 }
 
+// RegisterResource adds a resource to the server.
+func (s *Server) RegisterResource(def ResourceDef, handler ResourceHandler) {
+	s.dispatcher.RegisterResource(def, handler)
+}
+
+// RegisterResourceTemplate adds a URI template resource to the server.
+func (s *Server) RegisterResourceTemplate(def ResourceTemplate, handler TemplateHandler) {
+	s.dispatcher.RegisterResourceTemplate(def, handler)
+}
+
+// RegisterPrompt adds a prompt to the server.
+func (s *Server) RegisterPrompt(def PromptDef, handler PromptHandler) {
+	s.dispatcher.RegisterPrompt(def, handler)
+}
+
 // Dispatch routes a JSON-RPC request through the server's dispatch layer.
 func (s *Server) Dispatch(ctx context.Context, req *Request) *Response {
 	return s.dispatchWith(s.dispatcher, ctx, req)


### PR DESCRIPTION
## Summary

Adds four core MCP capabilities, jumping conformance from **9/30 → 18/30 passing**.

## What's new

| Feature | Methods | Tests |
|---------|---------|-------|
| **Resources** (#13) | `resources/list`, `resources/read`, `resources/templates/list` | 8 unit tests |
| **Prompts** (#14) | `prompts/list`, `prompts/get` | 6 unit tests |
| **Pagination** (#15) | Generic `paginate[T]` helper for all list methods | Shared infrastructure |
| **Cancellation** (#16) | `notifications/cancelled` → context cancellation | Inflight tracking via sync.Map |

## Conformance results

**Before**: 9/30 passing, 22 baseline failures
**After**: 18/30 passing, 13 baseline failures

New passes: `resources-list`, `resources-read-text`, `resources-read-binary`, `resources-templates-read`, `prompts-list`, `prompts-get-simple`, `prompts-get-with-args`, `prompts-get-embedded-resource`, `prompts-get-with-image`

## Test server conformance tools

- Resources: `test://static-text`, `test://static-binary`, `test://template/{id}/data`
- Prompts: `test_simple_prompt`, `test_prompt_with_arguments`, `test_prompt_with_embedded_resource`, `test_prompt_with_image`

## Test plan

- [x] 64 unit tests pass (14 new)
- [x] `go vet` clean
- [x] Conformance baseline check passes (18 pass, 13 expected failures)

Closes #13, Closes #14, Closes #15, Closes #16