### PR TITLE
feat: Streamable HTTP SSE streaming responses (#36)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ make serve-both   # Both transports
 - **Conformance baseline**: when a feature passes its conformance test, remove it from `conformance/baseline.yml`. Stale entries cause CI failure.
 - **SSE transport sessions** die with the connection (no TTL needed). **Streamable HTTP sessions** persist until DELETE or server restart.
 - **Capabilities auto-advertise**: resources/prompts capabilities only appear in initialize response when resources/prompts are actually registered. Logging is always advertised.
-- **Server-to-client notifications** (logging, progress) work over SSE transport but are silently dropped over Streamable HTTP (no GET SSE stream yet). The `NotifyFunc` is nil for Streamable HTTP sessions. Use `EmitLog(ctx, level, logger, data)` in tool handlers — it's a safe no-op when notifications can't be delivered.
+- **Server-to-client notifications** (logging, progress) work over both transports. SSE: pushed via hub. Streamable HTTP: POST response switches to SSE streaming (`Content-Type: text/event-stream`) when client sends `Accept: text/event-stream`. Falls back to synchronous JSON if client doesn't accept SSE.
 
 ## Architecture
 
@@ -50,7 +50,7 @@ See `ARCHITECTURE.md` for transport design, type definitions, and protocol detai
 
 ## Conformance Status
 
-19/30 MCP conformance scenarios passing. Failing scenarios are tracked in `conformance/baseline.yml` with issue references. See `README.md` for testing instructions.
+20/30 MCP conformance scenarios passing. Failing scenarios are tracked in `conformance/baseline.yml` with issue references. See `README.md` for testing instructions.
 
 ## What's Not Implemented Yet
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ make serve-streamable  # Streamable HTTP on :8787
 
 ### Conformance Suite
 
-Validated against the [official MCP conformance test suite](https://github.com/modelcontextprotocol/conformance). Current status: **19/30 scenarios passing** (remaining require progress, sampling, elicitation, subscriptions, and Streamable HTTP SSE streaming — tracked in `conformance/baseline.yml`).
+Validated against the [official MCP conformance test suite](https://github.com/modelcontextprotocol/conformance). Current status: **20/30 scenarios passing** (remaining require progress, sampling, elicitation, subscriptions, and Streamable HTTP SSE streaming — tracked in `conformance/baseline.yml`).
 
 ```bash
 bash scripts/conformance-test.sh                    # full suite

--- a/conformance/baseline.yml
+++ b/conformance/baseline.yml
@@ -18,8 +18,7 @@ server:
   - elicitation-sep1034-defaults   # Issue: #23
   - elicitation-sep1330-enums      # Issue: #23
 
-  # Tool scenarios requiring server-to-client features (Streamable HTTP SSE response)
-  - tools-call-with-logging     # Logging works over SSE but Streamable HTTP POST can't push notifications yet
+  # Tool scenarios requiring server-to-client features
   - tools-call-with-progress    # Requires progress notifications (#18)
   - tools-call-sampling         # Requires sampling/createMessage (#22)
   - tools-call-elicitation      # Requires elicitation/create (#23)

--- a/streamable_transport.go
+++ b/streamable_transport.go
@@ -3,6 +3,7 @@ package mcpkit
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -120,16 +121,24 @@ func (t *streamableTransport) handlePost(w http.ResponseWriter, r *http.Request)
 		}
 	}
 
-	// Dispatch
+	// If client supports SSE and this is a request (not notification), use SSE streaming
+	// so server-to-client notifications (logging, progress) can be delivered mid-request.
+	wantsSSE := strings.Contains(r.Header.Get("Accept"), "text/event-stream")
+	isRequest := !req.IsNotification()
+
+	if wantsSSE && isRequest {
+		t.handlePostSSE(w, r, dispatcher, &req)
+		return
+	}
+
+	// Synchronous JSON path (no mid-request notifications)
 	resp := t.server.dispatchWith(dispatcher, r.Context(), &req)
 
-	// Notification/response (no JSON-RPC response expected)
 	if resp == nil {
 		w.WriteHeader(http.StatusAccepted)
 		return
 	}
 
-	// Request → JSON response
 	w.Header().Set("Content-Type", "application/json")
 	raw, err := json.Marshal(resp)
 	if err != nil {
@@ -137,6 +146,63 @@ func (t *streamableTransport) handlePost(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	w.Write(raw)
+}
+
+// handlePostSSE handles a POST request using SSE streaming, allowing the server
+// to send notifications (logging, progress) as SSE events before the final
+// JSON-RPC response. Per MCP spec: "the server MUST either return
+// Content-Type: text/event-stream, to initiate an SSE stream, or
+// Content-Type: application/json, to return one JSON object."
+func (t *streamableTransport) handlePostSSE(w http.ResponseWriter, r *http.Request, d *Dispatcher, req *Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		// Fall back to synchronous JSON if flushing not supported
+		resp := t.server.dispatchWith(d, r.Context(), req)
+		if resp == nil {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		raw, _ := json.Marshal(resp)
+		w.Write(raw)
+		return
+	}
+
+	// Set SSE headers
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	var mu sync.Mutex
+	writeSSE := func(data []byte) {
+		mu.Lock()
+		defer mu.Unlock()
+		fmt.Fprintf(w, "event: message\ndata: %s\n\n", data)
+		flusher.Flush()
+	}
+
+	// Wire notifyFunc to SSE writer for this request.
+	// This enables EmitLog() and Notify() calls in tool handlers to push
+	// notifications as SSE events during request execution.
+	prevNotify := d.notifyFunc
+	d.notifyFunc = func(method string, params any) {
+		raw, err := marshalNotification(method, params)
+		if err != nil {
+			return
+		}
+		writeSSE(raw)
+	}
+	defer func() { d.notifyFunc = prevNotify }()
+
+	// Dispatch (synchronous — notifications stream as events during execution)
+	resp := t.server.dispatchWith(d, r.Context(), req)
+
+	// Write the JSON-RPC response as the final SSE event
+	if resp != nil {
+		raw, _ := json.Marshal(resp)
+		writeSSE(raw)
+	}
 }
 
 // handleInitialize handles POST initialize: creates session, dispatches, returns

--- a/streamable_transport_test.go
+++ b/streamable_transport_test.go
@@ -1,6 +1,7 @@
 package mcpkit
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -40,11 +41,13 @@ func testStreamableServer(opts ...TransportOption) *httptest.Server {
 
 // streamablePost sends a JSON-RPC request to the streamable endpoint and returns
 // the HTTP response. Adds Mcp-Session-Id header if sessionID is non-empty.
+// streamablePost sends a JSON-RPC request expecting a synchronous JSON response.
+// Uses Accept: application/json only — no SSE streaming.
 func streamablePost(url, sessionID string, body any) (*http.Response, error) {
 	raw, _ := json.Marshal(body)
 	req, _ := http.NewRequest(http.MethodPost, url, bytes.NewReader(raw))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("Accept", "application/json")
 	if sessionID != "" {
 		req.Header.Set(mcpSessionIDHeader, sessionID)
 	}
@@ -481,6 +484,245 @@ func TestStreamableCustomPrefix(t *testing.T) {
 	}
 	if resp.Header.Get(mcpSessionIDHeader) == "" {
 		t.Error("missing Mcp-Session-Id header")
+	}
+}
+
+// testStreamableServerWithLogging creates a test server that has a tool which emits
+// log notifications during execution, for testing SSE streaming responses.
+func testStreamableServerWithLogging(opts ...TransportOption) *httptest.Server {
+	srv := NewServer(ServerInfo{Name: "test-streamable-sse", Version: "0.1.0"})
+	srv.RegisterTool(
+		ToolDef{Name: "echo", Description: "Echoes input", InputSchema: map[string]any{"type": "object"}},
+		func(ctx context.Context, req ToolRequest) (ToolResult, error) {
+			return TextResult("ok"), nil
+		},
+	)
+	srv.RegisterTool(
+		ToolDef{Name: "log_tool", Description: "Emits logs", InputSchema: map[string]any{"type": "object"}},
+		func(ctx context.Context, req ToolRequest) (ToolResult, error) {
+			EmitLog(ctx, LogInfo, "test", "step one")
+			EmitLog(ctx, LogInfo, "test", "step two")
+			return TextResult("done"), nil
+		},
+	)
+	allOpts := append([]TransportOption{WithStreamableHTTP(true), WithSSE(false)}, opts...)
+	return httptest.NewServer(srv.Handler(allOpts...))
+}
+
+// streamableInitWithLogging initializes a session and enables logging on it.
+func streamableInitWithLogging(t *testing.T, url string) string {
+	t.Helper()
+	sessionID := streamableInit(t, url)
+
+	// Enable logging at debug level
+	resp, err := streamablePost(url+"/mcp", sessionID, &Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`99`),
+		Method:  "logging/setLevel",
+		Params:  json.RawMessage(`{"level":"debug"}`),
+	})
+	if err != nil {
+		t.Fatalf("logging/setLevel failed: %v", err)
+	}
+	resp.Body.Close()
+	return sessionID
+}
+
+// streamablePostSSE sends a JSON-RPC request with Accept: text/event-stream
+// and returns the raw response for SSE parsing.
+func streamablePostSSE(url, sessionID string, body any) (*http.Response, error) {
+	raw, _ := json.Marshal(body)
+	req, _ := http.NewRequest(http.MethodPost, url, bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "text/event-stream")
+	if sessionID != "" {
+		req.Header.Set(mcpSessionIDHeader, sessionID)
+	}
+	return http.DefaultClient.Do(req)
+}
+
+// readSSEEvents reads all SSE events from a response body until EOF.
+func readSSEEvents(t *testing.T, body io.Reader) []sseEvent {
+	t.Helper()
+	var events []sseEvent
+	scanner := bufio.NewScanner(body)
+	var event, data string
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			if data != "" || event != "" {
+				events = append(events, sseEvent{Event: event, Data: data})
+				event, data = "", ""
+			}
+			continue
+		}
+		if strings.HasPrefix(line, "event:") {
+			event = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+		} else if strings.HasPrefix(line, "data:") {
+			data = strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		}
+	}
+	return events
+}
+
+// TestStreamableSSEResponse verifies that when a tool emits log notifications during
+// execution and the client sends Accept: text/event-stream, the response is an SSE
+// stream containing notification events followed by the JSON-RPC response.
+func TestStreamableSSEResponse(t *testing.T) {
+	ts := testStreamableServerWithLogging()
+	defer ts.Close()
+
+	sessionID := streamableInitWithLogging(t, ts.URL)
+
+	resp, err := streamablePostSSE(ts.URL+"/mcp", sessionID, &Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  "tools/call",
+		Params:  json.RawMessage(`{"name":"log_tool","arguments":{}}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
+		t.Fatalf("Content-Type = %q, want text/event-stream", ct)
+	}
+
+	events := readSSEEvents(t, resp.Body)
+	if len(events) < 3 {
+		t.Fatalf("got %d events, want at least 3 (2 notifications + 1 response)", len(events))
+	}
+
+	// First two events should be log notifications
+	for i := 0; i < 2; i++ {
+		if !strings.Contains(events[i].Data, "notifications/message") {
+			t.Errorf("event[%d] = %q, want notifications/message", i, events[i].Data)
+		}
+	}
+
+	// Last event should be the JSON-RPC response
+	last := events[len(events)-1]
+	if !strings.Contains(last.Data, `"id":1`) {
+		t.Errorf("last event missing response id: %q", last.Data)
+	}
+	if !strings.Contains(last.Data, `"result"`) {
+		t.Errorf("last event missing result: %q", last.Data)
+	}
+}
+
+// TestStreamableSSEFallback verifies that when the client does NOT include
+// Accept: text/event-stream, the response is synchronous JSON (not SSE),
+// preserving backward compatibility.
+func TestStreamableSSEFallback(t *testing.T) {
+	ts := testStreamableServerWithLogging()
+	defer ts.Close()
+
+	sessionID := streamableInitWithLogging(t, ts.URL)
+
+	// POST with Accept: application/json only (no text/event-stream) — should get JSON
+	body, _ := json.Marshal(&Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  "tools/call",
+		Params:  json.RawMessage(`{"name":"log_tool","arguments":{}}`),
+	})
+	httpReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/mcp", bytes.NewReader(body))
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "application/json") // no text/event-stream
+	httpReq.Header.Set(mcpSessionIDHeader, sessionID)
+	resp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Fatalf("Content-Type = %q, want application/json", ct)
+	}
+
+	var rpcResp Response
+	json.NewDecoder(resp.Body).Decode(&rpcResp)
+	if rpcResp.Error != nil {
+		t.Fatalf("JSON-RPC error: %s", rpcResp.Error.Message)
+	}
+}
+
+// TestStreamableSSENotificationOrder verifies that notifications appear before
+// the JSON-RPC response in the SSE event stream.
+func TestStreamableSSENotificationOrder(t *testing.T) {
+	ts := testStreamableServerWithLogging()
+	defer ts.Close()
+
+	sessionID := streamableInitWithLogging(t, ts.URL)
+
+	resp, err := streamablePostSSE(ts.URL+"/mcp", sessionID, &Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  "tools/call",
+		Params:  json.RawMessage(`{"name":"log_tool","arguments":{}}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	events := readSSEEvents(t, resp.Body)
+	// Find the response event (has "id" field)
+	responseIdx := -1
+	for i, ev := range events {
+		if strings.Contains(ev.Data, `"id":1`) && strings.Contains(ev.Data, `"result"`) {
+			responseIdx = i
+			break
+		}
+	}
+	if responseIdx < 0 {
+		t.Fatal("no response event found in SSE stream")
+	}
+
+	// All events before the response should be notifications
+	for i := 0; i < responseIdx; i++ {
+		if !strings.Contains(events[i].Data, "notifications/") {
+			t.Errorf("event[%d] before response is not a notification: %q", i, events[i].Data)
+		}
+	}
+
+	// Response should be the last event
+	if responseIdx != len(events)-1 {
+		t.Errorf("response at index %d, but %d events total — response should be last", responseIdx, len(events))
+	}
+}
+
+// TestStreamableSSENoNotifications verifies that when a tool doesn't emit any
+// notifications, the SSE stream still works — containing only the response event.
+func TestStreamableSSENoNotifications(t *testing.T) {
+	ts := testStreamableServerWithLogging()
+	defer ts.Close()
+
+	sessionID := streamableInitWithLogging(t, ts.URL)
+
+	// Call echo tool which doesn't emit logs
+	resp, err := streamablePostSSE(ts.URL+"/mcp", sessionID, &Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  "tools/call",
+		Params:  json.RawMessage(`{"name":"echo","arguments":{}}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
+		t.Fatalf("Content-Type = %q, want text/event-stream", ct)
+	}
+
+	events := readSSEEvents(t, resp.Body)
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1 (response only)", len(events))
+	}
+	if !strings.Contains(events[0].Data, `"result"`) {
+		t.Errorf("event missing result: %q", events[0].Data)
 	}
 }
 


### PR DESCRIPTION
## Summary

Enables server-to-client notifications (logging, progress) over Streamable HTTP POST responses by switching to SSE streaming when the client supports it. Previously, notifications were silently dropped for Streamable HTTP sessions.

**Conformance: 19/30 → 20/30** (`tools-call-with-logging` now passes)

## How it works

When a POST request arrives with `Accept: text/event-stream` and is a JSON-RPC request (has ID):
1. Server sets `Content-Type: text/event-stream` and SSE headers
2. Wires `dispatcher.notifyFunc` to write SSE events to the ResponseWriter
3. Dispatches the request — notifications stream as events during execution
4. Writes the JSON-RPC response as the final SSE event

When the client doesn't include `text/event-stream` in Accept, falls back to synchronous JSON (unchanged behavior).

## Wire format

```
event: message
data: {"jsonrpc":"2.0","method":"notifications/message","params":{"level":"info","data":"processing"}}

event: message
data: {"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"done"}]}}
```

## Changes

| File | What changed |
|------|-------------|
| `streamable_transport.go` | `handlePostSSE` method: SSE headers, per-request notifyFunc, mutex writes |
| `streamable_transport_test.go` | 4 new tests + fixed `streamablePost` Accept header |
| `conformance/baseline.yml` | Removed `tools-call-with-logging` |
| `CLAUDE.md`, `README.md` | Updated conformance count and notification docs |

## Test plan

- [x] `TestStreamableSSEResponse` — tool emits logs, verify SSE stream with notifications + response
- [x] `TestStreamableSSEFallback` — Accept: application/json only → synchronous JSON
- [x] `TestStreamableSSENotificationOrder` — notifications before response
- [x] `TestStreamableSSENoNotifications` — response-only SSE stream
- [x] All 83 tests pass, `go vet` clean
- [x] Conformance: 20/30 passing, baseline check passes

Closes #36