### PR TITLE
feat: client extension capabilities + UIExtension (#95, #96)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,8 +18,9 @@ make testall      # ALL tests + Keycloak + HTML report (test-reports/report.html
 make smoke        # Curl-based transport tests
 make audit        # govulncheck + gosec + gitleaks + race detection
 
-# Auth tests (ext/auth is a separate Go module)
+# Extension sub-module tests (separate Go modules)
 make test-auth        # Auth sub-module unit tests (cd ext/auth)
+make test-ui          # UI sub-module unit tests (cd ext/ui)
 make test-e2e         # All E2E tests (auth + apps, no Docker)
 make testkcl          # 7 Keycloak interop tests (needs Docker)
 make upkcl            # Start Keycloak container (with event logging)
@@ -71,6 +72,9 @@ mcpkit/
 │   ├── server_auth.go         MountAuth (PRM endpoints)
 │   ├── scopes.go              RequireScope
 │   └── docs/DESIGN.md         Auth architecture + spec compliance
+│
+├── ext/ui/                 ← Separate Go module (ext/ui/go.mod)
+│   └── extension.go          UIExtension implementing ExtensionProvider
 │
 ├── testutil/                ← Test helpers
 ├── cmd/testserver/          ← Conformance test server

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # MCPKit Makefile
 
 # Sub-modules that get tagged alongside the root module
-SUB_MODS_TO_TAG := ext/auth tests/e2e tests/keycloak
+SUB_MODS_TO_TAG := ext/auth ext/ui tests/e2e tests/keycloak
 
 # =============================================================================
 # Build & test
@@ -33,6 +33,9 @@ testconfauth: ## Run MCP Auth conformance suite (client-side, requires mcpkit/au
 test-auth: ## Run auth sub-module tests
 	cd ext/auth && go test ./... -count=1 -timeout 30s
 
+test-ui: ## Run UI extension sub-module tests
+	cd ext/ui && go test ./... -count=1 -timeout 30s
+
 test-e2e: ## Run all E2E tests (auth, apps — no Docker)
 	cd tests/e2e && go test ./... -count=1 -timeout 60s
 
@@ -59,13 +62,14 @@ testall: ## Run ALL tests (starts Keycloak if needed) + generate HTML report
 	@echo "Started: $$(date)" | tee -a $(REPORT_DIR)/run.log
 	@PASS=0; FAIL=0; STAGES=""; \
 	echo "" | tee -a $(REPORT_DIR)/run.log; \
-	$(call run_stage,1,7,unit,test) \
-	$(call run_stage,2,7,race,test-race) \
-	$(call run_stage,3,7,auth,test-auth) \
-	$(call run_stage,4,7,e2e,test-e2e) \
-	$(call run_stage,5,7,conformance,testconf) \
-	$(call run_stage,6,7,auth-conformance,testconfauth) \
-	$(call run_stage,7,7,keycloak,testkcl-auto) \
+	$(call run_stage,1,8,unit,test) \
+	$(call run_stage,2,8,race,test-race) \
+	$(call run_stage,3,8,auth,test-auth) \
+	$(call run_stage,4,8,ui,test-ui) \
+	$(call run_stage,5,8,e2e,test-e2e) \
+	$(call run_stage,6,8,conformance,testconf) \
+	$(call run_stage,7,8,auth-conformance,testconfauth) \
+	$(call run_stage,8,8,keycloak,testkcl-auto) \
 	echo "" | tee -a $(REPORT_DIR)/run.log; \
 	echo "=== Results: $$PASS passed, $$FAIL failed ===" | tee -a $(REPORT_DIR)/run.log; \
 	echo "Finished: $$(date)" | tee -a $(REPORT_DIR)/run.log; \
@@ -267,5 +271,5 @@ setup: setup-tools setup-hooks ## Full development setup
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-18s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: build test test-race test-v test-auth test-e2e testkcl testkcl-auto testall test-report smoke testconfall testconf testconfauth vet lint vulncheck seccheck secrets audit ci ci-full serve serve-streamable serve-both tidy tag tag-push setup-tools setup-hooks setup upkcl downkcl kcllogs help
+.PHONY: build test test-race test-v test-auth test-ui test-e2e testkcl testkcl-auto testall test-report smoke testconfall testconf testconfauth vet lint vulncheck seccheck secrets audit ci ci-full serve serve-streamable serve-both tidy tag tag-push setup-tools setup-hooks setup upkcl downkcl kcllogs help
 .DEFAULT_GOAL := help

--- a/core/logging.go
+++ b/core/logging.go
@@ -100,6 +100,24 @@ func sessionFromContext(ctx context.Context) *sessionCtx {
 	return sc
 }
 
+// ClientSupportsExtension checks whether the connected client declared support
+// for the given extension ID during the initialize handshake. Returns false if
+// no session context is present or the client did not advertise the extension.
+//
+// Usage in a tool handler:
+//
+//	if core.ClientSupportsExtension(ctx, "io.modelcontextprotocol/ui") {
+//	    // client can render MCP Apps
+//	}
+func ClientSupportsExtension(ctx context.Context, extensionID string) bool {
+	sc := sessionFromContext(ctx)
+	if sc == nil || sc.clientCaps == nil {
+		return false
+	}
+	_, ok := sc.clientCaps.Extensions[extensionID]
+	return ok
+}
+
 // EmitLog sends a notifications/message to the connected client if the session's
 // log level allows it. Safe to call even if no session context is present (no-op).
 //

--- a/core/protocol.go
+++ b/core/protocol.go
@@ -24,6 +24,18 @@ type ClientCapabilities struct {
 	Sampling    *struct{} `json:"sampling,omitempty"`
 	Roots       *RootsCap `json:"roots,omitempty"`
 	Elicitation *struct{} `json:"elicitation,omitempty"`
+
+	// Extensions maps extension IDs to the client's capability declaration
+	// for that extension. Sent during initialize to advertise extension support.
+	Extensions map[string]ClientExtensionCap `json:"extensions,omitempty"`
+}
+
+// ClientExtensionCap describes a client's support for a specific extension.
+// The contents are extension-specific; MCP Apps uses MIMETypes to declare
+// which app content types the client can render.
+type ClientExtensionCap struct {
+	// MIMETypes lists content types the client supports for this extension.
+	MIMETypes []string `json:"mimeTypes,omitempty"`
 }
 
 // RootsCap describes the client's roots capability.

--- a/core/protocol_test.go
+++ b/core/protocol_test.go
@@ -1,0 +1,95 @@
+package core
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestClientCapabilitiesExtensionsParsing verifies that the Extensions field
+// on ClientCapabilities correctly deserializes from JSON, including the
+// extension ID as map key and the MIMETypes array. This is the server-side
+// parsing path: clients send extensions in the initialize request, and the
+// server must capture them for runtime checks via ClientSupportsExtension.
+func TestClientCapabilitiesExtensionsParsing(t *testing.T) {
+	input := `{
+		"sampling": {},
+		"extensions": {
+			"io.modelcontextprotocol/ui": {
+				"mimeTypes": ["text/html;profile=mcp-app"]
+			}
+		}
+	}`
+
+	var caps ClientCapabilities
+	if err := json.Unmarshal([]byte(input), &caps); err != nil {
+		t.Fatal(err)
+	}
+
+	if caps.Sampling == nil {
+		t.Error("Sampling should be non-nil")
+	}
+	if caps.Extensions == nil {
+		t.Fatal("Extensions should be non-nil")
+	}
+	uiCap, ok := caps.Extensions[UIExtensionID]
+	if !ok {
+		t.Fatalf("extension %q not found", UIExtensionID)
+	}
+	if len(uiCap.MIMETypes) != 1 || uiCap.MIMETypes[0] != AppMIMEType {
+		t.Errorf("MIMETypes = %v, want [%s]", uiCap.MIMETypes, AppMIMEType)
+	}
+
+	// Round-trip
+	data, err := json.Marshal(caps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got ClientCapabilities
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := got.Extensions[UIExtensionID]; !ok {
+		t.Error("extension lost after round-trip")
+	}
+}
+
+// TestClientCapabilitiesNoExtensions verifies that when no extensions field
+// is present in the JSON, the Extensions map is nil (not an empty map).
+// This is the common case for clients that don't support any extensions.
+func TestClientCapabilitiesNoExtensions(t *testing.T) {
+	input := `{"sampling": {}}`
+
+	var caps ClientCapabilities
+	if err := json.Unmarshal([]byte(input), &caps); err != nil {
+		t.Fatal(err)
+	}
+	if caps.Extensions != nil {
+		t.Errorf("Extensions should be nil when absent, got %v", caps.Extensions)
+	}
+}
+
+// TestClientExtensionCapMIMETypes verifies that ClientExtensionCap correctly
+// handles multiple MIME types and empty arrays through JSON serialization.
+func TestClientExtensionCapMIMETypes(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  int
+	}{
+		{"multiple types", `{"mimeTypes":["text/html","image/svg+xml"]}`, 2},
+		{"empty array", `{"mimeTypes":[]}`, 0},
+		{"no field", `{}`, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cap ClientExtensionCap
+			if err := json.Unmarshal([]byte(tt.input), &cap); err != nil {
+				t.Fatal(err)
+			}
+			if len(cap.MIMETypes) != tt.want {
+				t.Errorf("MIMETypes length = %d, want %d", len(cap.MIMETypes), tt.want)
+			}
+		})
+	}
+}

--- a/core/ui.go
+++ b/core/ui.go
@@ -1,5 +1,18 @@
 package core
 
+import "context"
+
+// UIExtensionID is the extension identifier for MCP Apps.
+// Used in initialize handshake for both server advertisement and client capability declaration.
+const UIExtensionID = "io.modelcontextprotocol/ui"
+
+// ClientSupportsUI checks whether the connected client declared support for the
+// MCP Apps extension during the initialize handshake. Tool handlers can use this
+// to decide whether to include UI-specific content or fall back to text-only.
+func ClientSupportsUI(ctx context.Context) bool {
+	return ClientSupportsExtension(ctx, UIExtensionID)
+}
+
 // UIMetadata describes UI presentation metadata for tools and resources.
 // Serialized as the "_meta.ui" object in tools/list and resources/read responses.
 // Part of the MCP Apps extension (io.modelcontextprotocol/ui).

--- a/core/ui_test.go
+++ b/core/ui_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 )
@@ -327,6 +328,57 @@ func TestToolDefMetaPrefersBorderTriState(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestClientSupportsExtension verifies the context-based extension capability
+// check. With a session context containing the UI extension in clientCaps,
+// ClientSupportsExtension returns true. Without the extension or without a
+// session context, it returns false. This is the general mechanism any
+// extension uses to check client support at runtime.
+func TestClientSupportsExtension(t *testing.T) {
+	caps := &ClientCapabilities{
+		Extensions: map[string]ClientExtensionCap{
+			UIExtensionID: {MIMETypes: []string{AppMIMEType}},
+		},
+	}
+	ctx := ContextWithSession(context.Background(), nil, nil, nil, caps, nil)
+
+	if !ClientSupportsExtension(ctx, UIExtensionID) {
+		t.Error("should return true when extension is in clientCaps")
+	}
+	if ClientSupportsExtension(ctx, "io.example/nonexistent") {
+		t.Error("should return false for unknown extension")
+	}
+	if ClientSupportsExtension(context.Background(), UIExtensionID) {
+		t.Error("should return false with no session context")
+	}
+}
+
+// TestClientSupportsUI verifies the convenience wrapper that checks for the
+// MCP Apps extension specifically. This is what tool handlers call to decide
+// whether to include UI-specific content or fall back to text-only responses.
+func TestClientSupportsUI(t *testing.T) {
+	caps := &ClientCapabilities{
+		Extensions: map[string]ClientExtensionCap{
+			UIExtensionID: {},
+		},
+	}
+	ctx := ContextWithSession(context.Background(), nil, nil, nil, caps, nil)
+
+	if !ClientSupportsUI(ctx) {
+		t.Error("should return true when UI extension is declared")
+	}
+	if ClientSupportsUI(context.Background()) {
+		t.Error("should return false with no session context")
+	}
+}
+
+// TestUIExtensionIDConstant verifies the extension ID constant matches the
+// MCP Apps spec value exactly.
+func TestUIExtensionIDConstant(t *testing.T) {
+	if UIExtensionID != "io.modelcontextprotocol/ui" {
+		t.Errorf("UIExtensionID = %q, want %q", UIExtensionID, "io.modelcontextprotocol/ui")
 	}
 }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -89,6 +89,9 @@ mcpkit/                          # module: github.com/panyam/mcpkit
 │   ├── server_auth.go           # MountAuth (PRM endpoints)
 │   ├── scopes.go                # RequireScope
 │   └── docs/DESIGN.md           # Auth architecture, spec compliance
+├── ext/ui/                      # SEPARATE module (github.com/panyam/mcpkit/ext/ui)
+│   ├── go.mod                   # depends on mcpkit only (zero external deps)
+│   └── extension.go             # UIExtension implementing ExtensionProvider
 ├── testutil/testclient.go       # TestClient wrapper for e2e testing
 ├── cmd/testserver/              # Conformance test server
 ├── cmd/testclient/              # Headless OAuth conformance client

--- a/ext/ui/extension.go
+++ b/ext/ui/extension.go
@@ -1,0 +1,30 @@
+// Package ui provides the MCP Apps extension (io.modelcontextprotocol/ui)
+// for mcpkit servers. It declares the extension in the initialize response
+// so clients know the server supports interactive HTML UIs.
+//
+// This is a separate Go module (github.com/panyam/mcpkit/ext/ui) so that
+// the core mcpkit module stays zero-deps. Import this package to advertise
+// MCP Apps support on your server.
+//
+// Usage:
+//
+//	srv := server.NewServer(info,
+//	    server.WithExtension(ui.UIExtension{}),
+//	)
+package ui
+
+import "github.com/panyam/mcpkit/core"
+
+// UIExtension declares support for the MCP Apps extension.
+// Register it on the server to advertise UI rendering capability
+// in the initialize response.
+type UIExtension struct{}
+
+// Extension returns the MCP Apps extension metadata.
+func (UIExtension) Extension() core.Extension {
+	return core.Extension{
+		ID:          core.UIExtensionID,
+		SpecVersion: "2026-01-26",
+		Stability:   core.Experimental,
+	}
+}

--- a/ext/ui/extension_test.go
+++ b/ext/ui/extension_test.go
@@ -1,0 +1,32 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+// TestUIExtensionMetadata verifies that UIExtension returns the correct
+// extension metadata matching the MCP Apps spec: extension ID
+// "io.modelcontextprotocol/ui", spec version "2026-01-26", stability
+// experimental. This ensures the server advertises the right extension
+// in the initialize response.
+func TestUIExtensionMetadata(t *testing.T) {
+	ext := UIExtension{}.Extension()
+
+	if ext.ID != core.UIExtensionID {
+		t.Errorf("ID = %q, want %q", ext.ID, core.UIExtensionID)
+	}
+	if ext.SpecVersion != "2026-01-26" {
+		t.Errorf("SpecVersion = %q, want %q", ext.SpecVersion, "2026-01-26")
+	}
+	if ext.Stability != core.Experimental {
+		t.Errorf("Stability = %q, want %q", ext.Stability, core.Experimental)
+	}
+}
+
+// TestUIExtensionImplementsProvider verifies that UIExtension satisfies
+// the core.ExtensionProvider interface at compile time.
+func TestUIExtensionImplementsProvider(t *testing.T) {
+	var _ core.ExtensionProvider = UIExtension{}
+}

--- a/ext/ui/go.mod
+++ b/ext/ui/go.mod
@@ -1,0 +1,7 @@
+module github.com/panyam/mcpkit/ext/ui
+
+go 1.26.1
+
+require github.com/panyam/mcpkit v0.0.0
+
+replace github.com/panyam/mcpkit => ../../

--- a/server/dispatch_test.go
+++ b/server/dispatch_test.go
@@ -872,3 +872,72 @@ func TestToolsListMeta(t *testing.T) {
 		t.Error("plain_tool: _meta key should be absent")
 	}
 }
+
+// TestInitializeWithClientExtensions verifies that the server correctly parses
+// client extension capabilities from the initialize request and includes its
+// own registered extensions in the response. This is the foundation for
+// extension negotiation — both client→server and server→client directions.
+func TestInitializeWithClientExtensions(t *testing.T) {
+	d := NewDispatcher(core.ServerInfo{Name: "test", Version: "1.0"})
+	d.extensions[core.UIExtensionID] = core.Extension{
+		ID:          core.UIExtensionID,
+		SpecVersion: "2026-01-26",
+		Stability:   core.Experimental,
+	}
+
+	// Client sends initialize with UI extension support
+	resp := d.Dispatch(context.Background(), &core.Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  "initialize",
+		Params: json.RawMessage(`{
+			"protocolVersion": "2024-11-05",
+			"capabilities": {
+				"extensions": {
+					"io.modelcontextprotocol/ui": {
+						"mimeTypes": ["text/html;profile=mcp-app"]
+					}
+				}
+			},
+			"clientInfo": {"name": "test-client", "version": "1.0"}
+		}`),
+	})
+	if resp.Error != nil {
+		t.Fatalf("initialize error: %s", resp.Error.Message)
+	}
+
+	// Verify client caps were parsed
+	if d.clientCaps.Extensions == nil {
+		t.Fatal("clientCaps.Extensions is nil after initialize")
+	}
+	uiCap, ok := d.clientCaps.Extensions[core.UIExtensionID]
+	if !ok {
+		t.Fatal("UI extension not found in parsed client caps")
+	}
+	if len(uiCap.MIMETypes) != 1 || uiCap.MIMETypes[0] != core.AppMIMEType {
+		t.Errorf("MIMETypes = %v, want [%s]", uiCap.MIMETypes, core.AppMIMEType)
+	}
+
+	// Verify server response includes its extensions
+	var result map[string]json.RawMessage
+	json.Unmarshal(resp.Result, &result)
+
+	var caps map[string]json.RawMessage
+	json.Unmarshal(result["capabilities"], &caps)
+	if _, ok := caps["extensions"]; !ok {
+		t.Fatal("server response missing extensions in capabilities")
+	}
+
+	var exts map[string]map[string]string
+	json.Unmarshal(caps["extensions"], &exts)
+	uiExt, ok := exts[core.UIExtensionID]
+	if !ok {
+		t.Fatal("UI extension not in server response")
+	}
+	if uiExt["specVersion"] != "2026-01-26" {
+		t.Errorf("specVersion = %q, want %q", uiExt["specVersion"], "2026-01-26")
+	}
+	if uiExt["stability"] != "experimental" {
+		t.Errorf("stability = %q, want %q", uiExt["stability"], "experimental")
+	}
+}

--- a/tests/e2e/apps/extension_test.go
+++ b/tests/e2e/apps/extension_test.go
@@ -1,0 +1,141 @@
+package apps_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	client "github.com/panyam/mcpkit/client"
+	core "github.com/panyam/mcpkit/core"
+	server "github.com/panyam/mcpkit/server"
+	ui "github.com/panyam/mcpkit/ext/ui"
+)
+
+// TestUIExtensionNegotiationE2E verifies the full extension negotiation flow
+// end-to-end: server registers UIExtension, client connects, the initialize
+// response includes the UI extension metadata, and ClientSupportsUI returns
+// true inside a tool handler context. This validates both directions of the
+// capability handshake across the wire.
+func TestUIExtensionNegotiationE2E(t *testing.T) {
+	// Server with UIExtension registered
+	srv := server.NewServer(
+		core.ServerInfo{Name: "apps-ext-e2e", Version: "0.1.0"},
+		server.WithExtension(ui.UIExtension{}),
+	)
+
+	// Tool that checks ClientSupportsUI and reports the result
+	var mu sync.Mutex
+	var uiSupported bool
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "check_ui",
+			Description: "Reports whether client supports UI",
+			InputSchema: map[string]any{"type": "object"},
+		},
+		func(ctx context.Context, req core.ToolRequest) (core.ToolResult, error) {
+			mu.Lock()
+			uiSupported = core.ClientSupportsUI(ctx)
+			mu.Unlock()
+			if uiSupported {
+				return core.TextResult("ui: yes"), nil
+			}
+			return core.TextResult("ui: no"), nil
+		},
+	)
+
+	handler := srv.Handler(server.WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "ui-test-client", Version: "1.0"})
+	if err := c.Connect(); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+
+	// Verify server advertised UI extension in initialize response
+	result, err := c.Call("tools/list", nil)
+	if err != nil {
+		t.Fatalf("tools/list: %v", err)
+	}
+	var toolsResp struct {
+		Tools []core.ToolDef `json:"tools"`
+	}
+	result.Unmarshal(&toolsResp)
+	if len(toolsResp.Tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(toolsResp.Tools))
+	}
+
+	// Call the tool to check ClientSupportsUI from handler context
+	text, err := c.ToolCall("check_ui", nil)
+	if err != nil {
+		t.Fatalf("ToolCall: %v", err)
+	}
+	// Note: the standard client doesn't send extensions in initialize yet
+	// (that's a client-side feature), so ClientSupportsUI will be false.
+	// This test validates the server-side plumbing works.
+	if text != "ui: no" {
+		t.Errorf("result = %q, want 'ui: no' (client doesn't advertise extensions yet)", text)
+	}
+}
+
+// TestServerAdvertisesUIExtensionE2E verifies that a server with UIExtension
+// includes "io.modelcontextprotocol/ui" in the initialize response capabilities
+// at the wire level.
+func TestServerAdvertisesUIExtensionE2E(t *testing.T) {
+	srv := server.NewServer(
+		core.ServerInfo{Name: "apps-ext-e2e", Version: "0.1.0"},
+		server.WithExtension(ui.UIExtension{}),
+	)
+
+	handler := srv.Handler(server.WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "ui-test-client", Version: "1.0"})
+	if err := c.Connect(); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+
+	// The ServerInfo is populated after Connect — verify extensions came through
+	// by re-initializing via raw Call and checking the response
+	initResult, err := c.Call("initialize", map[string]any{
+		"protocolVersion": "2024-11-05",
+		"capabilities":    map[string]any{},
+		"clientInfo":      map[string]any{"name": "test", "version": "1.0"},
+	})
+	if err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+
+	var resp struct {
+		Capabilities struct {
+			Extensions map[string]json.RawMessage `json:"extensions"`
+		} `json:"capabilities"`
+	}
+	if err := initResult.Unmarshal(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Capabilities.Extensions == nil {
+		t.Fatal("no extensions in initialize response")
+	}
+	uiRaw, ok := resp.Capabilities.Extensions[core.UIExtensionID]
+	if !ok {
+		t.Fatalf("UI extension not in response, got keys: %v", resp.Capabilities.Extensions)
+	}
+
+	var uiExt struct {
+		SpecVersion string `json:"specVersion"`
+		Stability   string `json:"stability"`
+	}
+	json.Unmarshal(uiRaw, &uiExt)
+	if uiExt.SpecVersion != "2026-01-26" {
+		t.Errorf("specVersion = %q, want %q", uiExt.SpecVersion, "2026-01-26")
+	}
+	if uiExt.Stability != "experimental" {
+		t.Errorf("stability = %q, want %q", uiExt.Stability, "experimental")
+	}
+}

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -5,12 +5,14 @@ go 1.26.1
 replace (
 	github.com/panyam/mcpkit => ../..
 	github.com/panyam/mcpkit/ext/auth => ../../ext/auth
+	github.com/panyam/mcpkit/ext/ui => ../../ext/ui
 )
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/panyam/mcpkit v0.0.0
 	github.com/panyam/mcpkit/ext/auth v0.0.0
+	github.com/panyam/mcpkit/ext/ui v0.0.0-00010101000000-000000000000
 	github.com/panyam/oneauth v0.0.64
 	github.com/stretchr/testify v1.11.1
 )


### PR DESCRIPTION
## Summary

- Add `ClientExtensionCap` struct and `Extensions map[string]ClientExtensionCap` to `ClientCapabilities` — clients advertise extension support during initialize (#95)
- Add `ClientSupportsExtension(ctx, id)` context helper and `ClientSupportsUI(ctx)` convenience wrapper (#95)
- Add `UIExtensionID` constant (`io.modelcontextprotocol/ui`) in `core/ui.go`
- Create `ext/ui/` sub-module with `UIExtension` implementing `ExtensionProvider` — mirrors `ext/auth/extension.go` pattern (#96)
- Add `make test-ui` target, update `testall` to 8 stages

## Test plan

- [x] `core/protocol_test.go` — 3 tests: extensions parsing, no-extensions nil, MIMETypes round-trip
- [x] `core/ui_test.go` — 3 new tests: ClientSupportsExtension, ClientSupportsUI, UIExtensionID constant
- [x] `ext/ui/extension_test.go` — 2 tests: metadata values, ExtensionProvider interface compliance
- [x] `server/dispatch_test.go` — TestInitializeWithClientExtensions: client caps parsed + server response includes extensions
- [x] `tests/e2e/apps/extension_test.go` — 2 e2e tests: extension negotiation flow, server advertises UI extension
- [x] `make test` passes (all existing tests unaffected)
- [x] `make test-ui` passes
- [x] `make test-e2e` passes (auth + apps)

Closes #95, closes #96