### PR TITLE
feat: client extension negotiation + ListToolsForModel (#97)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ mcpkit/
 │   └── pagination.go          cursor-based pagination
 │
 ├── client/                  ← Client + all client transports
-│   ├── client.go              Client, NewClient, Connect, ToolCall, WithTransport
+│   ├── client.go              Client, NewClient, Connect, ToolCall, WithTransport, WithExtension, WithUIExtension, ServerSupportsExtension, ServerSupportsUI, ListToolsForModel
 │   ├── client_logging.go      loggingTransport, WithClientLogging
 │   └── client_reconnect.go    WithMaxRetries, WithReconnectBackoff
 │

--- a/client/client.go
+++ b/client/client.go
@@ -81,6 +81,27 @@ func WithNotificationCallback(fn func(method string, params any)) ClientOption {
 	return func(c *Client) { c.onNotify = fn }
 }
 
+// WithExtension advertises support for an extension during the initialize
+// handshake. The extension ID and capability are included in the client's
+// capabilities.extensions map, allowing the server to detect client support
+// via core.ClientSupportsExtension(ctx, id) in tool handlers.
+func WithExtension(id string, cap core.ClientExtensionCap) ClientOption {
+	return func(c *Client) {
+		if c.extensions == nil {
+			c.extensions = make(map[string]core.ClientExtensionCap)
+		}
+		c.extensions[id] = cap
+	}
+}
+
+// WithUIExtension is a convenience wrapper that advertises MCP Apps
+// (io.modelcontextprotocol/ui) support with the standard app MIME type.
+func WithUIExtension() ClientOption {
+	return WithExtension(core.UIExtensionID, core.ClientExtensionCap{
+		MIMETypes: []string{core.AppMIMEType},
+	})
+}
+
 // WithTransport sets a core.Transport for the client, bypassing the default
 // HTTP transport creation. Use with server.NewInProcessTransport for testing
 // or embedded scenarios.
@@ -157,6 +178,10 @@ type Client struct {
 	transport   clientTransport
 	logger      *log.Logger // optional transport logging (nil = disabled)
 
+	// Extension support
+	extensions       map[string]core.ClientExtensionCap // client extensions to advertise in initialize
+	serverExtensions map[string]json.RawMessage         // parsed from server's initialize response
+
 	// Server-to-client request handlers
 	samplingHandler    SamplingHandler
 	elicitationHandler ElicitationHandler
@@ -226,6 +251,13 @@ func (c *Client) Connect() error {
 	if c.elicitationHandler != nil {
 		caps["elicitation"] = map[string]any{}
 	}
+	if len(c.extensions) > 0 {
+		exts := make(map[string]any, len(c.extensions))
+		for id, cap := range c.extensions {
+			exts[id] = cap
+		}
+		caps["extensions"] = exts
+	}
 
 	// Initialize handshake
 	resp, err := c.rawCall("initialize", map[string]any{
@@ -237,11 +269,22 @@ func (c *Client) Connect() error {
 		return fmt.Errorf("initialize failed: %w", err)
 	}
 
-	// Extract server info
+	// Extract server info and capabilities from initialize response
 	if result, ok := resp.Result.(map[string]any); ok {
 		if si, ok := result["serverInfo"].(map[string]any); ok {
 			c.ServerInfo.Name, _ = si["name"].(string)
 			c.ServerInfo.Version, _ = si["version"].(string)
+		}
+		// Parse server extensions from capabilities
+		if capObj, ok := result["capabilities"].(map[string]any); ok {
+			if exts, ok := capObj["extensions"].(map[string]any); ok {
+				c.serverExtensions = make(map[string]json.RawMessage, len(exts))
+				for id, v := range exts {
+					if raw, err := json.Marshal(v); err == nil {
+						c.serverExtensions[id] = raw
+					}
+				}
+			}
 		}
 	}
 
@@ -411,6 +454,53 @@ func (c *Client) ListTools() ([]core.ToolDef, error) {
 		return nil, err
 	}
 	return resp.Tools, nil
+}
+
+// ListToolsForModel returns tools visible to the LLM, filtering out tools
+// that are only visible to apps (visibility: ["app"]). Tools with no visibility
+// set (nil/empty) are included — the default means visible to both model and app.
+// This is a client-side convenience; the server always returns all tools.
+func (c *Client) ListToolsForModel() ([]core.ToolDef, error) {
+	tools, err := c.ListTools()
+	if err != nil {
+		return nil, err
+	}
+	var filtered []core.ToolDef
+	for _, t := range tools {
+		if isModelVisible(t) {
+			filtered = append(filtered, t)
+		}
+	}
+	return filtered, nil
+}
+
+// isModelVisible returns true if the tool should be visible to the LLM.
+// A tool is model-visible if it has no visibility set (default) or if its
+// visibility list includes "model".
+func isModelVisible(t core.ToolDef) bool {
+	if t.Meta == nil || t.Meta.UI == nil || len(t.Meta.UI.Visibility) == 0 {
+		return true // default: visible to model
+	}
+	for _, v := range t.Meta.UI.Visibility {
+		if v == core.UIVisibilityModel {
+			return true
+		}
+	}
+	return false
+}
+
+// ServerSupportsExtension checks whether the server advertised support for the
+// given extension ID in its initialize response. Call after Connect().
+func (c *Client) ServerSupportsExtension(id string) bool {
+	_, ok := c.serverExtensions[id]
+	return ok
+}
+
+// ServerSupportsUI checks whether the server advertised MCP Apps
+// (io.modelcontextprotocol/ui) support. Convenience wrapper around
+// ServerSupportsExtension.
+func (c *Client) ServerSupportsUI() bool {
+	return c.ServerSupportsExtension(core.UIExtensionID)
 }
 
 // ListResources returns all registered static resources.

--- a/client/client_ext_test.go
+++ b/client/client_ext_test.go
@@ -1,0 +1,257 @@
+package client_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	client "github.com/panyam/mcpkit/client"
+	core "github.com/panyam/mcpkit/core"
+	server "github.com/panyam/mcpkit/server"
+)
+
+// testUIExtension is a minimal ExtensionProvider for testing without importing ext/ui.
+type testUIExtension struct{}
+
+func (testUIExtension) Extension() core.Extension {
+	return core.Extension{
+		ID:          core.UIExtensionID,
+		SpecVersion: "2026-01-26",
+		Stability:   core.Experimental,
+	}
+}
+
+// newUITestServer creates a server with UIExtension registered and tools with
+// various visibility settings for testing ListToolsForModel filtering.
+func newUITestServer() *server.Server {
+	srv := server.NewServer(
+		core.ServerInfo{Name: "ui-test-server", Version: "1.0.0"},
+		server.WithExtension(testUIExtension{}),
+	)
+
+	// Tool visible to both model and app (default — no visibility set)
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "public_tool",
+			Description: "Visible to everyone",
+			InputSchema: map[string]any{"type": "object"},
+		},
+		func(ctx context.Context, req core.ToolRequest) (core.ToolResult, error) {
+			return core.TextResult("public"), nil
+		},
+	)
+
+	// Tool explicitly visible to model
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "model_tool",
+			Description: "Visible to model",
+			InputSchema: map[string]any{"type": "object"},
+			Meta: &core.ToolMeta{
+				UI: &core.UIMetadata{
+					Visibility: []core.UIVisibility{core.UIVisibilityModel},
+				},
+			},
+		},
+		func(ctx context.Context, req core.ToolRequest) (core.ToolResult, error) {
+			return core.TextResult("model"), nil
+		},
+	)
+
+	// Tool visible to both model and app
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "both_tool",
+			Description: "Visible to model and app",
+			InputSchema: map[string]any{"type": "object"},
+			Meta: &core.ToolMeta{
+				UI: &core.UIMetadata{
+					Visibility:  []core.UIVisibility{core.UIVisibilityModel, core.UIVisibilityApp},
+					ResourceUri: "ui://test/view",
+				},
+			},
+		},
+		func(ctx context.Context, req core.ToolRequest) (core.ToolResult, error) {
+			return core.TextResult("both"), nil
+		},
+	)
+
+	// Tool visible ONLY to apps (should be filtered out by ListToolsForModel)
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "app_only_tool",
+			Description: "Only for apps",
+			InputSchema: map[string]any{"type": "object"},
+			Meta: &core.ToolMeta{
+				UI: &core.UIMetadata{
+					Visibility: []core.UIVisibility{core.UIVisibilityApp},
+				},
+			},
+		},
+		func(ctx context.Context, req core.ToolRequest) (core.ToolResult, error) {
+			return core.TextResult("app-only"), nil
+		},
+	)
+
+	// Tool that reports whether client supports UI (for negotiation test)
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "check_ui",
+			Description: "Reports client UI support",
+			InputSchema: map[string]any{"type": "object"},
+		},
+		func(ctx context.Context, req core.ToolRequest) (core.ToolResult, error) {
+			if core.ClientSupportsUI(ctx) {
+				return core.TextResult("ui: yes"), nil
+			}
+			return core.TextResult("ui: no"), nil
+		},
+	)
+
+	return srv
+}
+
+// setupUIStreamableClient creates an httptest.Server with UIExtension and a
+// connected Client configured with WithUIExtension.
+func setupUIStreamableClient(t *testing.T, opts ...client.ClientOption) (*client.Client, *httptest.Server) {
+	t.Helper()
+	srv := newUITestServer()
+	handler := srv.Handler(server.WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	allOpts := append([]client.ClientOption{client.WithUIExtension()}, opts...)
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "ui-test-client", Version: "1.0"}, allOpts...)
+	if err := c.Connect(); err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+	return c, ts
+}
+
+// TestClientWithUIExtension verifies that a client configured with
+// WithUIExtension() advertises UI support during initialize, which the server
+// can detect via core.ClientSupportsUI(ctx) inside a tool handler. This
+// validates the client→server direction of extension negotiation.
+func TestClientWithUIExtension(t *testing.T) {
+	c, _ := setupUIStreamableClient(t)
+
+	text, err := c.ToolCall("check_ui", nil)
+	if err != nil {
+		t.Fatalf("ToolCall: %v", err)
+	}
+	if text != "ui: yes" {
+		t.Errorf("result = %q, want 'ui: yes'", text)
+	}
+}
+
+// TestClientWithoutUIExtension verifies that a client without WithUIExtension()
+// does NOT advertise UI support, so the server reports no UI capability.
+func TestClientWithoutUIExtension(t *testing.T) {
+	srv := newUITestServer()
+	handler := srv.Handler(server.WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "plain-client", Version: "1.0"})
+	if err := c.Connect(); err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+
+	text, err := c.ToolCall("check_ui", nil)
+	if err != nil {
+		t.Fatalf("ToolCall: %v", err)
+	}
+	if text != "ui: no" {
+		t.Errorf("result = %q, want 'ui: no'", text)
+	}
+}
+
+// TestClientServerSupportsUI verifies that ServerSupportsUI() returns true
+// when the server has UIExtension registered, and false when it doesn't.
+// This validates the server→client direction of extension negotiation.
+func TestClientServerSupportsUI(t *testing.T) {
+	t.Run("server with UI", func(t *testing.T) {
+		c, _ := setupUIStreamableClient(t)
+		if !c.ServerSupportsUI() {
+			t.Error("ServerSupportsUI() should be true")
+		}
+	})
+
+	t.Run("server without UI", func(t *testing.T) {
+		srv := server.NewServer(core.ServerInfo{Name: "plain", Version: "1.0"})
+		srv.RegisterTool(
+			core.ToolDef{Name: "noop", Description: "noop", InputSchema: map[string]any{"type": "object"}},
+			func(ctx context.Context, req core.ToolRequest) (core.ToolResult, error) {
+				return core.TextResult("ok"), nil
+			},
+		)
+		handler := srv.Handler(server.WithStreamableHTTP(true))
+		ts := httptest.NewServer(handler)
+		t.Cleanup(ts.Close)
+
+		c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "test", Version: "1.0"})
+		if err := c.Connect(); err != nil {
+			t.Fatalf("Connect failed: %v", err)
+		}
+		if c.ServerSupportsUI() {
+			t.Error("ServerSupportsUI() should be false")
+		}
+	})
+}
+
+// TestClientServerSupportsExtension verifies the general ServerSupportsExtension
+// method works for any extension ID, not just UI.
+func TestClientServerSupportsExtension(t *testing.T) {
+	c, _ := setupUIStreamableClient(t)
+
+	if !c.ServerSupportsExtension(core.UIExtensionID) {
+		t.Error("should support UI extension")
+	}
+	if c.ServerSupportsExtension("io.example/nonexistent") {
+		t.Error("should not support unknown extension")
+	}
+}
+
+// TestClientListToolsForModel verifies that ListToolsForModel() filters tools
+// based on visibility metadata. Tools with no visibility (default), visibility
+// including "model", or visibility ["model", "app"] are included. Tools with
+// visibility ["app"] only are excluded. ListTools() still returns all tools.
+func TestClientListToolsForModel(t *testing.T) {
+	c, _ := setupUIStreamableClient(t)
+
+	// ListTools returns ALL tools (unfiltered)
+	allTools, err := c.ListTools()
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	if len(allTools) != 5 {
+		t.Fatalf("ListTools: got %d tools, want 5", len(allTools))
+	}
+
+	// ListToolsForModel excludes app-only tools
+	modelTools, err := c.ListToolsForModel()
+	if err != nil {
+		t.Fatalf("ListToolsForModel: %v", err)
+	}
+
+	names := make(map[string]bool)
+	for _, tool := range modelTools {
+		names[tool.Name] = true
+	}
+
+	// These should be included
+	for _, want := range []string{"public_tool", "model_tool", "both_tool", "check_ui"} {
+		if !names[want] {
+			t.Errorf("ListToolsForModel should include %q", want)
+		}
+	}
+
+	// This should be excluded
+	if names["app_only_tool"] {
+		t.Error("ListToolsForModel should NOT include app_only_tool")
+	}
+
+	if len(modelTools) != 4 {
+		t.Errorf("ListToolsForModel: got %d tools, want 4", len(modelTools))
+	}
+}

--- a/tests/e2e/apps/extension_test.go
+++ b/tests/e2e/apps/extension_test.go
@@ -49,23 +49,17 @@ func TestUIExtensionNegotiationE2E(t *testing.T) {
 	ts := httptest.NewServer(handler)
 	t.Cleanup(ts.Close)
 
-	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "ui-test-client", Version: "1.0"})
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "ui-test-client", Version: "1.0"},
+		client.WithUIExtension(),
+	)
 	if err := c.Connect(); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { c.Close() })
 
-	// Verify server advertised UI extension in initialize response
-	result, err := c.Call("tools/list", nil)
-	if err != nil {
-		t.Fatalf("tools/list: %v", err)
-	}
-	var toolsResp struct {
-		Tools []core.ToolDef `json:"tools"`
-	}
-	result.Unmarshal(&toolsResp)
-	if len(toolsResp.Tools) != 1 {
-		t.Fatalf("expected 1 tool, got %d", len(toolsResp.Tools))
+	// Verify server advertised UI extension — client should detect it
+	if !c.ServerSupportsUI() {
+		t.Error("ServerSupportsUI() should be true")
 	}
 
 	// Call the tool to check ClientSupportsUI from handler context
@@ -73,11 +67,9 @@ func TestUIExtensionNegotiationE2E(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ToolCall: %v", err)
 	}
-	// Note: the standard client doesn't send extensions in initialize yet
-	// (that's a client-side feature), so ClientSupportsUI will be false.
-	// This test validates the server-side plumbing works.
-	if text != "ui: no" {
-		t.Errorf("result = %q, want 'ui: no' (client doesn't advertise extensions yet)", text)
+	// Client sends WithUIExtension(), so server-side ClientSupportsUI(ctx) is true
+	if text != "ui: yes" {
+		t.Errorf("result = %q, want 'ui: yes'", text)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add general `WithExtension(id, cap)` client option — any extension can advertise support during initialize
- Add `WithUIExtension()` convenience wrapper for MCP Apps
- Parse server extensions from initialize response → `ServerSupportsExtension(id)` and `ServerSupportsUI()`
- Add `ListToolsForModel()` — filters out app-only tools (visibility: `["app"]`), keeps default and model-visible tools
- Updated e2e test to validate full bidirectional extension negotiation (was `"ui: no"`, now `"ui: yes"`)

## Test plan

- [x] `client/client_ext_test.go` — 5 tests:
  - `TestClientWithUIExtension` — client→server: server detects UI support
  - `TestClientWithoutUIExtension` — no extension → server reports no UI
  - `TestClientServerSupportsUI` — server→client: with/without UIExtension
  - `TestClientServerSupportsExtension` — general extension detection
  - `TestClientListToolsForModel` — visibility filtering (4 of 5 tools pass filter)
- [x] `tests/e2e/apps/extension_test.go` — updated to use `WithUIExtension()`, validates bidirectional negotiation
- [x] `make test` passes
- [x] `make test-e2e` passes

Closes #97