### PR TITLE
feat: apps conformance — test server + 21-test suite (#98, #99)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,9 @@ test-ui: ## Run UI extension sub-module tests
 test-e2e: ## Run all E2E tests (auth, apps — no Docker)
 	cd tests/e2e && go test ./... -count=1 -timeout 60s
 
+test-apps-playwright: ## Run ext-apps Playwright tests against testserver (needs Node.js + Playwright)
+	bash scripts/apps-playwright-test.sh
+
 testkcl: ## Run Keycloak auth interop tests (requires Docker, run upkcl first)
 	cd tests/keycloak && go test ./... -count=1 -timeout 120s -v
 
@@ -271,5 +274,5 @@ setup: setup-tools setup-hooks ## Full development setup
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-18s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: build test test-race test-v test-auth test-ui test-e2e testkcl testkcl-auto testall test-report smoke testconfall testconf testconfauth vet lint vulncheck seccheck secrets audit ci ci-full serve serve-streamable serve-both tidy tag tag-push setup-tools setup-hooks setup upkcl downkcl kcllogs help
+.PHONY: build test test-race test-v test-auth test-ui test-e2e test-apps-playwright testkcl testkcl-auto testall test-report smoke testconfall testconf testconfauth vet lint vulncheck seccheck secrets audit ci ci-full serve serve-streamable serve-both tidy tag tag-push setup-tools setup-hooks setup upkcl downkcl kcllogs help
 .DEFAULT_GOAL := help

--- a/cmd/testserver/conformance_apps.go
+++ b/cmd/testserver/conformance_apps.go
@@ -1,0 +1,158 @@
+package main
+
+// Conformance test tools and resources for the MCP Apps extension
+// (io.modelcontextprotocol/ui). These exercise metadata, visibility,
+// resource serving, and resource change notifications.
+
+import (
+	"context"
+	"fmt"
+
+	core "github.com/panyam/mcpkit/core"
+	server "github.com/panyam/mcpkit/server"
+)
+
+// testUIExtension declares the MCP Apps extension for the test server.
+// Inlined here to avoid the root module depending on ext/ui.
+type testUIExtension struct{}
+
+func (testUIExtension) Extension() core.Extension {
+	return core.Extension{
+		ID:          core.UIExtensionID,
+		SpecVersion: "2026-01-26",
+		Stability:   core.Experimental,
+	}
+}
+
+// registerConformanceApps adds UI tools and resources to the test server
+// for MCP Apps conformance testing.
+func registerConformanceApps(srv *server.Server) {
+	border := false
+
+	// show-dashboard: tool with full UI metadata
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "show-dashboard",
+			Description: "Shows the dashboard UI",
+			InputSchema: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{},
+			},
+			Meta: &core.ToolMeta{
+				UI: &core.UIMetadata{
+					ResourceUri: "ui://dashboard/view",
+					Visibility:  []core.UIVisibility{core.UIVisibilityModel, core.UIVisibilityApp},
+					CSP: &core.UICSPConfig{
+						ResourceDomains: []string{"cdn.example.com"},
+					},
+					Permissions:   []string{"clipboard-write"},
+					PrefersBorder: &border,
+				},
+			},
+		},
+		func(ctx context.Context, req core.ToolRequest) (core.ToolResult, error) {
+			return core.TextResult("Dashboard displayed"), nil
+		},
+	)
+
+	// navigate-dashboard: app-only tool (not visible to model)
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "navigate-dashboard",
+			Description: "Navigates within the dashboard (app-only)",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"page": map[string]any{"type": "string"},
+				},
+			},
+			Meta: &core.ToolMeta{
+				UI: &core.UIMetadata{
+					Visibility: []core.UIVisibility{core.UIVisibilityApp},
+				},
+			},
+		},
+		func(ctx context.Context, req core.ToolRequest) (core.ToolResult, error) {
+			var args struct {
+				Page string `json:"page"`
+			}
+			req.Bind(&args)
+			return core.TextResult(fmt.Sprintf("Navigated to %s", args.Page)), nil
+		},
+	)
+
+	// dashboard-data: model+app tool sharing the same resourceUri as show-dashboard
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "dashboard-data",
+			Description: "Returns dashboard data",
+			InputSchema: map[string]any{"type": "object"},
+			Meta: &core.ToolMeta{
+				UI: &core.UIMetadata{
+					ResourceUri: "ui://dashboard/view",
+					Visibility:  []core.UIVisibility{core.UIVisibilityModel, core.UIVisibilityApp},
+				},
+			},
+		},
+		func(ctx context.Context, req core.ToolRequest) (core.ToolResult, error) {
+			return core.TextResult("Dashboard data: {\"widgets\": 5}"), nil
+		},
+	)
+
+	// mutate-dashboard: mutates state and sends resource change notification
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "mutate-dashboard",
+			Description: "Mutates dashboard state and notifies resource change",
+			InputSchema: map[string]any{"type": "object"},
+			Meta: &core.ToolMeta{
+				UI: &core.UIMetadata{
+					ResourceUri: "ui://dashboard/view",
+					Visibility:  []core.UIVisibility{core.UIVisibilityModel, core.UIVisibilityApp},
+				},
+			},
+		},
+		func(ctx context.Context, req core.ToolRequest) (core.ToolResult, error) {
+			core.NotifyResourcesChanged(ctx)
+			return core.TextResult("Dashboard mutated"), nil
+		},
+	)
+
+	// ui://dashboard/view — static HTML resource for the dashboard
+	srv.RegisterResource(
+		core.ResourceDef{
+			URI:      "ui://dashboard/view",
+			Name:     "Dashboard View",
+			MimeType: core.AppMIMEType,
+		},
+		func(ctx context.Context, req core.ResourceRequest) (core.ResourceResult, error) {
+			return core.ResourceResult{Contents: []core.ResourceReadContent{{
+				URI:      req.URI,
+				MimeType: core.AppMIMEType,
+				Text:     `<!DOCTYPE html><html><head><title>Dashboard</title></head><body><h1>Dashboard</h1></body></html>`,
+				Meta: &core.ResourceContentMeta{
+					UI: &core.UIMetadata{
+						ResourceUri: "ui://dashboard/view",
+						Permissions: []string{"clipboard-write"},
+					},
+				},
+			}}}, nil
+		},
+	)
+
+	// ui://apps/{id}/view — parameterized template resource
+	srv.RegisterResourceTemplate(
+		core.ResourceTemplate{
+			URITemplate: "ui://apps/{id}/view",
+			Name:        "App View",
+			MimeType:    core.AppMIMEType,
+		},
+		func(ctx context.Context, uri string, params map[string]string) (core.ResourceResult, error) {
+			return core.ResourceResult{Contents: []core.ResourceReadContent{{
+				URI:      uri,
+				MimeType: core.AppMIMEType,
+				Text:     fmt.Sprintf(`<!DOCTYPE html><html><body><h1>App %s</h1></body></html>`, params["id"]),
+			}}}, nil
+		},
+	)
+}

--- a/cmd/testserver/main.go
+++ b/cmd/testserver/main.go
@@ -35,6 +35,7 @@ func main() {
 		server.WithListen(listenAddr()),
 		server.WithToolTimeout(30*time.Second),
 		server.WithSubscriptions(),
+		server.WithExtension(testUIExtension{}),
 	)
 	// Enable HTTP-level request logging if VERBOSE is set
 	if os.Getenv("VERBOSE") == "1" {
@@ -118,6 +119,7 @@ func main() {
 	registerConformanceTools(srv)
 	registerConformanceResources(srv)
 	registerConformancePrompts(srv)
+	registerConformanceApps(srv)
 
 	var transportOpts []server.TransportOption
 	switch {

--- a/scripts/apps-playwright-test.sh
+++ b/scripts/apps-playwright-test.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Run the ext-apps Playwright test suite against mcpkit's test server.
+#
+# Prerequisites:
+#   - Node.js 22+ with npx
+#   - Playwright browsers installed (npx playwright install)
+#
+# Usage:
+#   make test-apps-playwright
+#   # or directly:
+#   bash scripts/apps-playwright-test.sh
+#
+# Environment:
+#   PORT          Test server port (default: 18799)
+#   VERBOSE       Set to 1 for verbose output
+#   EXT_APPS_DIR  Path to ext-apps checkout (default: /tmp/ext-apps)
+
+set -euo pipefail
+
+PORT="${PORT:-18799}"
+EXT_APPS_DIR="${EXT_APPS_DIR:-/tmp/ext-apps}"
+EXT_APPS_REPO="https://github.com/modelcontextprotocol/ext-apps.git"
+SERVER_PID=""
+
+cleanup() {
+    if [ -n "$SERVER_PID" ]; then
+        kill "$SERVER_PID" 2>/dev/null || true
+        wait "$SERVER_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+# Check prerequisites
+if ! command -v npx &>/dev/null; then
+    echo "ERROR: npx not found. Install Node.js 22+."
+    exit 1
+fi
+
+# Clone or update ext-apps
+if [ -d "$EXT_APPS_DIR/.git" ]; then
+    echo "Updating ext-apps in $EXT_APPS_DIR..."
+    (cd "$EXT_APPS_DIR" && git pull --quiet)
+else
+    echo "Cloning ext-apps to $EXT_APPS_DIR..."
+    git clone --quiet "$EXT_APPS_REPO" "$EXT_APPS_DIR"
+fi
+
+# Install Playwright deps if needed
+(cd "$EXT_APPS_DIR" && npm install --silent 2>/dev/null && npx playwright install --with-deps chromium 2>/dev/null) || {
+    echo "WARNING: Playwright setup failed. Run manually:"
+    echo "  cd $EXT_APPS_DIR && npm install && npx playwright install"
+    exit 1
+}
+
+# Kill stale process on port
+if lsof -ti:$PORT >/dev/null 2>&1; then
+    echo "Killing stale process on port $PORT..."
+    lsof -ti:$PORT | xargs kill -9 2>/dev/null || true
+    sleep 1
+fi
+
+# Start mcpkit test server
+echo "Starting mcpkit test server on port $PORT..."
+STREAMABLE=1 PORT=$PORT go run ./cmd/testserver &
+SERVER_PID=$!
+
+# Wait for server readiness
+echo "Waiting for server..."
+for i in $(seq 1 30); do
+    if curl -sf -X POST "http://localhost:$PORT/mcp" \
+        -H "Content-Type: application/json" \
+        -H "Accept: application/json, text/event-stream" \
+        -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"probe","version":"0.0.0"}}}' \
+        -o /dev/null 2>/dev/null; then
+        echo "Server ready."
+        break
+    fi
+    if [ "$i" -eq 30 ]; then
+        echo "ERROR: Server failed to start within 30 seconds."
+        exit 1
+    fi
+    sleep 1
+done
+
+# Run Playwright tests
+echo ""
+echo "=== Running ext-apps Playwright tests ==="
+echo "Server: http://localhost:$PORT/mcp"
+echo ""
+
+PLAYWRIGHT_ARGS=""
+if [ "${VERBOSE:-}" = "1" ]; then
+    PLAYWRIGHT_ARGS="--reporter=verbose"
+fi
+
+cd "$EXT_APPS_DIR"
+MCP_SERVER_URL="http://localhost:$PORT/mcp" npx playwright test $PLAYWRIGHT_ARGS
+EXIT_CODE=$?
+
+if [ $EXIT_CODE -eq 0 ]; then
+    echo ""
+    echo "=== Playwright tests PASSED ==="
+else
+    echo ""
+    echo "=== Playwright tests FAILED (exit $EXIT_CODE) ==="
+fi
+
+exit $EXIT_CODE

--- a/tests/e2e/apps/fallback_test.go
+++ b/tests/e2e/apps/fallback_test.go
@@ -1,0 +1,54 @@
+package apps_test
+
+import (
+	"testing"
+)
+
+// TestToolResultHasText verifies that tools with UI metadata still return
+// text content in their result. This is critical for text-only fallback —
+// clients that don't support UI should still get a useful text response.
+func TestToolResultHasText(t *testing.T) {
+	c := setupConformanceClient(t)
+
+	// show-dashboard has _meta.ui but should return text
+	text, err := c.ToolCall("show-dashboard", nil)
+	if err != nil {
+		t.Fatalf("ToolCall: %v", err)
+	}
+	if text == "" {
+		t.Error("tool with UI metadata should still return text content")
+	}
+	if text != "Dashboard displayed" {
+		t.Errorf("text = %q, want 'Dashboard displayed'", text)
+	}
+}
+
+// TestMutationNotifiesResourceChange verifies that a tool calling
+// NotifyResourcesChanged(ctx) sends the notifications/resources/list_changed
+// notification to the client. Hosts use this to know when to re-fetch
+// resources/list after a state-mutating tool call.
+func TestMutationNotifiesResourceChange(t *testing.T) {
+	c := setupConformanceClient(t)
+
+	// The notification callback is set on the client in setupConformanceClient
+	// but we need a fresh client with notification tracking for this test
+	notifCh := make(chan string, 10)
+	c = setupConformanceClientWithNotify(t, func(method string, params any) {
+		notifCh <- method
+	})
+
+	_, err := c.ToolCall("mutate-dashboard", nil)
+	if err != nil {
+		t.Fatalf("ToolCall: %v", err)
+	}
+
+	// Check notification was received
+	select {
+	case method := <-notifCh:
+		if method != "notifications/resources/list_changed" {
+			t.Errorf("notification method = %q, want %q", method, "notifications/resources/list_changed")
+		}
+	default:
+		t.Error("expected notifications/resources/list_changed notification, got none")
+	}
+}

--- a/tests/e2e/apps/resources_test.go
+++ b/tests/e2e/apps/resources_test.go
@@ -1,0 +1,127 @@
+package apps_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	core "github.com/panyam/mcpkit/core"
+)
+
+// TestUIResourceServesHTML verifies that the ui://dashboard/view resource
+// returns content with the MCP App MIME type (text/html;profile=mcp-app).
+// Hosts use this MIME type to decide whether to render in a sandboxed iframe.
+func TestUIResourceServesHTML(t *testing.T) {
+	c := setupConformanceClient(t)
+
+	result, err := c.Call("resources/read", map[string]string{"uri": "ui://dashboard/view"})
+	if err != nil {
+		t.Fatalf("resources/read: %v", err)
+	}
+	var resp core.ResourceResult
+	result.Unmarshal(&resp)
+
+	if len(resp.Contents) != 1 {
+		t.Fatalf("got %d contents, want 1", len(resp.Contents))
+	}
+	if resp.Contents[0].MimeType != core.AppMIMEType {
+		t.Errorf("mimeType = %q, want %q", resp.Contents[0].MimeType, core.AppMIMEType)
+	}
+}
+
+// TestUIResourceContent verifies that the ui:// resource returns non-empty
+// HTML content. The content should be a valid HTML document that hosts can
+// render in an iframe.
+func TestUIResourceContent(t *testing.T) {
+	c := setupConformanceClient(t)
+
+	result, err := c.Call("resources/read", map[string]string{"uri": "ui://dashboard/view"})
+	if err != nil {
+		t.Fatalf("resources/read: %v", err)
+	}
+	var resp core.ResourceResult
+	result.Unmarshal(&resp)
+
+	text := resp.Contents[0].Text
+	if text == "" {
+		t.Error("resource text is empty")
+	}
+	if len(text) < 10 {
+		t.Errorf("resource text suspiciously short: %q", text)
+	}
+}
+
+// TestUITemplateResource verifies that parameterized ui:// resources resolve
+// via URI templates. The server registers ui://apps/{id}/view as a template,
+// and requesting ui://apps/42/view should return HTML with the ID embedded.
+func TestUITemplateResource(t *testing.T) {
+	c := setupConformanceClient(t)
+
+	result, err := c.Call("resources/read", map[string]string{"uri": "ui://apps/42/view"})
+	if err != nil {
+		t.Fatalf("resources/read: %v", err)
+	}
+	var resp core.ResourceResult
+	result.Unmarshal(&resp)
+
+	if len(resp.Contents) != 1 {
+		t.Fatalf("got %d contents, want 1", len(resp.Contents))
+	}
+	if resp.Contents[0].MimeType != core.AppMIMEType {
+		t.Errorf("mimeType = %q, want %q", resp.Contents[0].MimeType, core.AppMIMEType)
+	}
+	if resp.Contents[0].Text == "" {
+		t.Error("template resource text is empty")
+	}
+}
+
+// TestPlainResourceNoMeta verifies that non-UI resources do not have _meta.ui
+// in their response. This ensures _meta is only present when explicitly set.
+func TestPlainResourceNoMeta(t *testing.T) {
+	c := setupConformanceClient(t)
+
+	result, err := c.Call("resources/read", map[string]string{"uri": "test://plain-resource"})
+	if err != nil {
+		t.Fatalf("resources/read: %v", err)
+	}
+
+	// Check at wire level that _meta is absent
+	var raw struct {
+		Contents []json.RawMessage `json:"contents"`
+	}
+	result.Unmarshal(&raw)
+	if len(raw.Contents) != 1 {
+		t.Fatalf("got %d contents", len(raw.Contents))
+	}
+
+	var content map[string]json.RawMessage
+	json.Unmarshal(raw.Contents[0], &content)
+	if _, ok := content["_meta"]; ok {
+		t.Error("plain resource should not have _meta")
+	}
+}
+
+// TestResourceMetaPrecedence verifies that per-content _meta.ui on
+// ResourceReadContent is present and carries its own metadata. Per the
+// MCP Apps spec, per-content metadata takes precedence over resource-level
+// metadata from resources/list.
+func TestResourceMetaPrecedence(t *testing.T) {
+	c := setupConformanceClient(t)
+
+	result, err := c.Call("resources/read", map[string]string{"uri": "ui://dashboard/view"})
+	if err != nil {
+		t.Fatalf("resources/read: %v", err)
+	}
+	var resp core.ResourceResult
+	result.Unmarshal(&resp)
+
+	content := resp.Contents[0]
+	if content.Meta == nil || content.Meta.UI == nil {
+		t.Fatal("per-content _meta.ui is nil")
+	}
+	if content.Meta.UI.ResourceUri != "ui://dashboard/view" {
+		t.Errorf("per-content resourceUri = %q", content.Meta.UI.ResourceUri)
+	}
+	if len(content.Meta.UI.Permissions) != 1 || content.Meta.UI.Permissions[0] != "clipboard-write" {
+		t.Errorf("per-content permissions = %v", content.Meta.UI.Permissions)
+	}
+}

--- a/tests/e2e/apps/testenv_test.go
+++ b/tests/e2e/apps/testenv_test.go
@@ -1,0 +1,206 @@
+// Package apps_test contains conformance tests for the MCP Apps extension
+// (io.modelcontextprotocol/ui). These validate server-side metadata correctness,
+// capability negotiation, visibility filtering, and resource serving.
+//
+// Run via "make test-e2e" from the project root, or
+// "cd tests/e2e && go test ./apps/ -v" directly.
+package apps_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	client "github.com/panyam/mcpkit/client"
+	core "github.com/panyam/mcpkit/core"
+	ui "github.com/panyam/mcpkit/ext/ui"
+	server "github.com/panyam/mcpkit/server"
+)
+
+// newConformanceServer creates the standard MCP Apps conformance server with
+// UI tools and resources matching cmd/testserver/conformance_apps.go. This
+// allows the test suite to run without starting the external test server.
+func newConformanceServer() *server.Server {
+	srv := server.NewServer(
+		core.ServerInfo{Name: "apps-conformance", Version: "0.1.0"},
+		server.WithExtension(ui.UIExtension{}),
+		server.WithSubscriptions(),
+	)
+
+	border := false
+
+	// show-dashboard: full UI metadata
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "show-dashboard",
+			Description: "Shows the dashboard UI",
+			InputSchema: map[string]any{"type": "object"},
+			Meta: &core.ToolMeta{
+				UI: &core.UIMetadata{
+					ResourceUri: "ui://dashboard/view",
+					Visibility:  []core.UIVisibility{core.UIVisibilityModel, core.UIVisibilityApp},
+					CSP: &core.UICSPConfig{
+						ResourceDomains: []string{"cdn.example.com"},
+					},
+					Permissions:   []string{"clipboard-write"},
+					PrefersBorder: &border,
+				},
+			},
+		},
+		func(ctx context.Context, req core.ToolRequest) (core.ToolResult, error) {
+			return core.TextResult("Dashboard displayed"), nil
+		},
+	)
+
+	// navigate-dashboard: app-only (not visible to model)
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "navigate-dashboard",
+			Description: "Navigates within the dashboard (app-only)",
+			InputSchema: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{"page": map[string]any{"type": "string"}},
+			},
+			Meta: &core.ToolMeta{
+				UI: &core.UIMetadata{
+					Visibility: []core.UIVisibility{core.UIVisibilityApp},
+				},
+			},
+		},
+		func(ctx context.Context, req core.ToolRequest) (core.ToolResult, error) {
+			var args struct{ Page string `json:"page"` }
+			req.Bind(&args)
+			return core.TextResult("Navigated to " + args.Page), nil
+		},
+	)
+
+	// dashboard-data: model+app, same resourceUri
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "dashboard-data",
+			Description: "Returns dashboard data",
+			InputSchema: map[string]any{"type": "object"},
+			Meta: &core.ToolMeta{
+				UI: &core.UIMetadata{
+					ResourceUri: "ui://dashboard/view",
+					Visibility:  []core.UIVisibility{core.UIVisibilityModel, core.UIVisibilityApp},
+				},
+			},
+		},
+		func(ctx context.Context, req core.ToolRequest) (core.ToolResult, error) {
+			return core.TextResult(`Dashboard data: {"widgets": 5}`), nil
+		},
+	)
+
+	// mutate-dashboard: sends resource change notification
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "mutate-dashboard",
+			Description: "Mutates dashboard state and notifies",
+			InputSchema: map[string]any{"type": "object"},
+			Meta: &core.ToolMeta{
+				UI: &core.UIMetadata{
+					ResourceUri: "ui://dashboard/view",
+					Visibility:  []core.UIVisibility{core.UIVisibilityModel, core.UIVisibilityApp},
+				},
+			},
+		},
+		func(ctx context.Context, req core.ToolRequest) (core.ToolResult, error) {
+			core.NotifyResourcesChanged(ctx)
+			return core.TextResult("Dashboard mutated"), nil
+		},
+	)
+
+	// plain-tool: no UI metadata at all
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "plain-tool",
+			Description: "Tool without UI metadata",
+			InputSchema: map[string]any{"type": "object"},
+		},
+		func(ctx context.Context, req core.ToolRequest) (core.ToolResult, error) {
+			return core.TextResult("plain result"), nil
+		},
+	)
+
+	// ui://dashboard/view — HTML resource with per-content _meta
+	srv.RegisterResource(
+		core.ResourceDef{URI: "ui://dashboard/view", Name: "Dashboard View", MimeType: core.AppMIMEType},
+		func(ctx context.Context, req core.ResourceRequest) (core.ResourceResult, error) {
+			return core.ResourceResult{Contents: []core.ResourceReadContent{{
+				URI:      req.URI,
+				MimeType: core.AppMIMEType,
+				Text:     `<!DOCTYPE html><html><body><h1>Dashboard</h1></body></html>`,
+				Meta: &core.ResourceContentMeta{
+					UI: &core.UIMetadata{
+						ResourceUri: "ui://dashboard/view",
+						Permissions: []string{"clipboard-write"},
+					},
+				},
+			}}}, nil
+		},
+	)
+
+	// ui://apps/{id}/view — parameterized template resource
+	srv.RegisterResourceTemplate(
+		core.ResourceTemplate{URITemplate: "ui://apps/{id}/view", Name: "App View", MimeType: core.AppMIMEType},
+		func(ctx context.Context, uri string, params map[string]string) (core.ResourceResult, error) {
+			return core.ResourceResult{Contents: []core.ResourceReadContent{{
+				URI:      uri,
+				MimeType: core.AppMIMEType,
+				Text:     `<!DOCTYPE html><html><body><h1>App ` + params["id"] + `</h1></body></html>`,
+			}}}, nil
+		},
+	)
+
+	// test://plain-resource — non-UI resource for comparison
+	srv.RegisterResource(
+		core.ResourceDef{URI: "test://plain-resource", Name: "Plain Resource", MimeType: "text/plain"},
+		func(ctx context.Context, req core.ResourceRequest) (core.ResourceResult, error) {
+			return core.ResourceResult{Contents: []core.ResourceReadContent{{
+				URI: req.URI, MimeType: "text/plain", Text: "plain content",
+			}}}, nil
+		},
+	)
+
+	return srv
+}
+
+// setupConformanceClient creates an httptest.Server with the conformance server
+// and a connected client with WithUIExtension.
+func setupConformanceClient(t *testing.T) *client.Client {
+	t.Helper()
+	srv := newConformanceServer()
+	handler := srv.Handler(server.WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "apps-conformance-client", Version: "1.0"},
+		client.WithUIExtension(),
+	)
+	if err := c.Connect(); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+	return c
+}
+
+// setupConformanceClientWithNotify creates a conformance client with a custom
+// notification callback for testing server-to-client notifications.
+func setupConformanceClientWithNotify(t *testing.T, onNotify func(method string, params any)) *client.Client {
+	t.Helper()
+	srv := newConformanceServer()
+	handler := srv.Handler(server.WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "apps-conformance-client", Version: "1.0"},
+		client.WithUIExtension(),
+		client.WithNotificationCallback(onNotify),
+	)
+	if err := c.Connect(); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+	return c
+}

--- a/tests/e2e/apps/tools_test.go
+++ b/tests/e2e/apps/tools_test.go
@@ -1,0 +1,121 @@
+package apps_test
+
+import (
+	"testing"
+
+	core "github.com/panyam/mcpkit/core"
+)
+
+// TestToolMetaResourceUri verifies that the show-dashboard tool carries
+// _meta.ui.resourceUri in the tools/list response. This is how hosts discover
+// which resource to fetch for rendering the tool's UI.
+func TestToolMetaResourceUri(t *testing.T) {
+	c := setupConformanceClient(t)
+
+	tools, err := c.ListTools()
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+
+	tool := findTool(t, tools, "show-dashboard")
+	if tool.Meta == nil || tool.Meta.UI == nil {
+		t.Fatal("show-dashboard: _meta.ui is nil")
+	}
+	if tool.Meta.UI.ResourceUri != "ui://dashboard/view" {
+		t.Errorf("resourceUri = %q, want %q", tool.Meta.UI.ResourceUri, "ui://dashboard/view")
+	}
+}
+
+// TestToolMetaVisibilityDefaults verifies that a tool without explicit visibility
+// metadata is included by ListToolsForModel (default = visible to both model and
+// app). This ensures backward compatibility — existing tools work without UI config.
+func TestToolMetaVisibilityDefaults(t *testing.T) {
+	c := setupConformanceClient(t)
+
+	modelTools, err := c.ListToolsForModel()
+	if err != nil {
+		t.Fatalf("ListToolsForModel: %v", err)
+	}
+
+	if findToolOptional(modelTools, "plain-tool") == nil {
+		t.Error("plain-tool (no visibility set) should be included in ListToolsForModel")
+	}
+}
+
+// TestToolMetaCSP verifies that CSP (Content-Security-Policy) declarations on
+// a tool's _meta.ui survive the wire round-trip. Hosts use these to construct
+// the CSP header for the app's iframe sandbox.
+func TestToolMetaCSP(t *testing.T) {
+	c := setupConformanceClient(t)
+
+	tools, err := c.ListTools()
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+
+	tool := findTool(t, tools, "show-dashboard")
+	if tool.Meta.UI.CSP == nil {
+		t.Fatal("CSP is nil")
+	}
+	if len(tool.Meta.UI.CSP.ResourceDomains) != 1 || tool.Meta.UI.CSP.ResourceDomains[0] != "cdn.example.com" {
+		t.Errorf("CSP.ResourceDomains = %v, want [cdn.example.com]", tool.Meta.UI.CSP.ResourceDomains)
+	}
+}
+
+// TestToolMetaPermissions verifies that the permissions array on _meta.ui
+// survives the wire round-trip. Hosts use these to set iframe permission policy.
+func TestToolMetaPermissions(t *testing.T) {
+	c := setupConformanceClient(t)
+
+	tools, err := c.ListTools()
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+
+	tool := findTool(t, tools, "show-dashboard")
+	if len(tool.Meta.UI.Permissions) != 1 || tool.Meta.UI.Permissions[0] != "clipboard-write" {
+		t.Errorf("Permissions = %v, want [clipboard-write]", tool.Meta.UI.Permissions)
+	}
+}
+
+// TestToolMetaPrefersBorder verifies that the prefersBorder tri-state field
+// survives the wire round-trip. The show-dashboard tool sets it to false,
+// hinting that the host should not draw a border around the iframe.
+func TestToolMetaPrefersBorder(t *testing.T) {
+	c := setupConformanceClient(t)
+
+	tools, err := c.ListTools()
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+
+	tool := findTool(t, tools, "show-dashboard")
+	if tool.Meta.UI.PrefersBorder == nil {
+		t.Fatal("PrefersBorder is nil, want false")
+	}
+	if *tool.Meta.UI.PrefersBorder != false {
+		t.Errorf("PrefersBorder = %v, want false", *tool.Meta.UI.PrefersBorder)
+	}
+}
+
+// findTool returns the tool with the given name, or fails the test.
+func findTool(t *testing.T, tools []core.ToolDef, name string) core.ToolDef {
+	t.Helper()
+	for _, tool := range tools {
+		if tool.Name == name {
+			return tool
+		}
+	}
+	t.Fatalf("tool %q not found in tools/list (%d tools)", name, len(tools))
+	return core.ToolDef{}
+}
+
+// findToolOptional returns a pointer to the tool with the given name, or nil.
+func findToolOptional(tools []core.ToolDef, name string) *core.ToolDef {
+	for i := range tools {
+		if tools[i].Name == name {
+			return &tools[i]
+		}
+	}
+	return nil
+}

--- a/tests/e2e/apps/visibility_test.go
+++ b/tests/e2e/apps/visibility_test.go
@@ -1,0 +1,73 @@
+package apps_test
+
+import (
+	"testing"
+)
+
+// TestListToolsIncludesAll verifies that tools/list returns ALL tools including
+// app-only tools. The MCP spec places visibility filtering responsibility on the
+// host, not the server — servers always return the complete tool set.
+func TestListToolsIncludesAll(t *testing.T) {
+	c := setupConformanceClient(t)
+
+	tools, err := c.ListTools()
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+
+	names := make(map[string]bool)
+	for _, tool := range tools {
+		names[tool.Name] = true
+	}
+
+	// All tools must be present, including app-only
+	for _, want := range []string{"show-dashboard", "navigate-dashboard", "dashboard-data", "mutate-dashboard", "plain-tool"} {
+		if !names[want] {
+			t.Errorf("tools/list should include %q", want)
+		}
+	}
+}
+
+// TestListToolsForModelFilters verifies that ListToolsForModel excludes tools
+// with visibility ["app"] only, while including tools with default visibility,
+// visibility ["model"], or visibility ["model", "app"].
+func TestListToolsForModelFilters(t *testing.T) {
+	c := setupConformanceClient(t)
+
+	modelTools, err := c.ListToolsForModel()
+	if err != nil {
+		t.Fatalf("ListToolsForModel: %v", err)
+	}
+
+	names := make(map[string]bool)
+	for _, tool := range modelTools {
+		names[tool.Name] = true
+	}
+
+	// These should be included (model-visible)
+	for _, want := range []string{"show-dashboard", "dashboard-data", "mutate-dashboard", "plain-tool"} {
+		if !names[want] {
+			t.Errorf("ListToolsForModel should include %q", want)
+		}
+	}
+
+	// This should be excluded (app-only)
+	if names["navigate-dashboard"] {
+		t.Error("ListToolsForModel should NOT include navigate-dashboard (app-only)")
+	}
+}
+
+// TestAppOnlyToolCallable verifies that app-only tools (visibility: ["app"])
+// can still be called via tools/call. Visibility is a presentation hint for
+// hosts, not an access control mechanism — the server executes all tools.
+func TestAppOnlyToolCallable(t *testing.T) {
+	c := setupConformanceClient(t)
+
+	text, err := c.ToolCall("navigate-dashboard", map[string]string{"page": "settings"})
+	if err != nil {
+		t.Fatalf("ToolCall navigate-dashboard: %v", err)
+	}
+	if text != "Navigated to settings" {
+		t.Errorf("result = %q, want 'Navigated to settings'", text)
+	}
+}


### PR DESCRIPTION
## Summary

- **#98 — Test server**: Add `cmd/testserver/conformance_apps.go` with UI tools (`show-dashboard`, `navigate-dashboard`, `dashboard-data`, `mutate-dashboard`) and resources (`ui://dashboard/view`, `ui://apps/{id}/view` template). Server now registers `UIExtension` for extension negotiation.
- **#99 — Conformance tests**: 21 tests in `tests/e2e/apps/` across 5 files covering tool metadata (5), resource serving (5), visibility filtering (3), text fallback + notifications (2), plus existing extension/meta tests (6).
- **Playwright target**: `make test-apps-playwright` runs the upstream ext-apps Playwright suite against our testserver (separate from `testall`, needs Node.js + Playwright).

## Test plan

- [x] 21 apps conformance tests pass (`make test-e2e`)
- [x] Existing MCP conformance 30/30 unaffected (`make testconf`)
- [x] `make test` passes (all unit tests)
- [x] `make test-ui` passes (ext/ui tests)

### Test coverage by category

| Category | Tests | File |
|----------|-------|------|
| Tool metadata | 5 | `tools_test.go` |
| Resource serving | 5 | `resources_test.go` |
| Visibility filtering | 3 | `visibility_test.go` |
| Text fallback + integration | 2 | `fallback_test.go` |
| Extension negotiation + helpers | 6 | `extension_test.go`, `app_helpers_test.go`, `meta_test.go` |

Closes #98, closes #99