### PR TITLE
feat: stdio transport (#3)

### DIFF
--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -42,12 +42,13 @@
 - mcp-client-auth-retry: Client transport 401/403 handling — doWithAuthRetry, ScopeAwareTokenSource, ClientAuthError
 - mcp-sub-packages: core/server/client package split — types in core, server+transports in server/, client in client/
 - mcp-in-process-transport: server.NewInProcessTransport + client.WithTransport — typed *Request/*Response, no HTTP (for tests/embedded)
+- mcp-stdio-transport: Content-Length framed JSON-RPC over stdin/stdout — Server.RunStdio() + client.WithStdioTransport() for editor-spawned MCP servers (Cursor, Claude Desktop)
 - mcp-stateless-mode: WithStateless — no sessions, fresh dispatcher per request (for serverless/CLI)
 - mcp-session-management: Server.CloseSession/CloseAllSessions — programmatic session teardown
 - mcp-structured-output: StructuredContent + OutputSchema on ToolDef/ToolResult — typed tool output
 - mcp-server-run: Server.Run(addr) — simple blocking entry point defaulting to Streamable HTTP
 - mcp-error-codes: ErrCodeServerError (-32000) + documented JSON-RPC error code ranges
-- mcp-parametric-tests: forAllTransports — core client tests run against all 3 transports as subtests
+- mcp-parametric-tests: forAllTransports — core client tests run against all 4 transports as subtests (Streamable HTTP, SSE, in-memory, stdio)
 - mcp-apps-extension: MCP Apps (io.modelcontextprotocol/ui) extension negotiation — server advertises via WithExtension(UIExtension{}), client detects via ServerSupportsUI()
 - mcp-apps-ui-metadata: UIMetadata, UICSPConfig, UIVisibility types on ToolDef._meta.ui and ResourceReadContent._meta.ui
 - mcp-apps-resource-serving: ui:// resources with text/html;profile=mcp-app MIME type, template resources for parameterized URIs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 Go library for building production-grade MCP servers and clients. Split into three packages:
 - **`core/`** — Protocol types (Request, Response, ToolDef, Content, Claims, etc.) and tool-handler APIs (Sample, Elicit, EmitLog)
-- **`server/`** — Server, Dispatcher, transports (SSE + Streamable HTTP), middleware, subscriptions
+- **`server/`** — Server, Dispatcher, transports (SSE + Streamable HTTP + Stdio), middleware, subscriptions
 - **`client/`** — Client, HTTP transports, reconnection, logging
 - **`ext/auth/`** — Separate Go module: JWTValidator, MountAuth (PRM), OAuthTokenSource, DCR, CIMD
 
@@ -54,6 +54,7 @@ mcpkit/
 │   ├── dispatch.go            Dispatcher, JSON-RPC routing, all method handlers
 │   ├── transport.go           SSE transport
 │   ├── streamable_transport.go Streamable HTTP transport
+│   ├── stdio_transport.go     Stdio transport (Content-Length framed JSON-RPC)
 │   ├── memory_transport.go    InProcessTransport (core.Transport impl)
 │   ├── request.go             sendServerRequest, routeServerResponse, pending map
 │   ├── middleware.go          Middleware, LoggingMiddleware, WithMiddleware
@@ -61,6 +62,7 @@ mcpkit/
 │
 ├── client/                  ← Client + all client transports
 │   ├── client.go              Client, NewClient, Connect, ToolCall, WithTransport, WithExtension, WithUIExtension, ServerSupportsExtension, ServerSupportsUI, ListToolsForModel, ResolveEndpointURL, HTTPStatusError, DoWithAuthRetry
+│   ├── stdio_transport.go     StdioTransport, NewStdioTransport, WithStdioTransport
 │   ├── client_logging.go      loggingTransport, WithClientLogging
 │   └── client_reconnect.go    WithMaxRetries, WithReconnectBackoff, IsTransientError
 │
@@ -97,7 +99,8 @@ mcpkit/
 - **SSE endpoint event data must be raw text**, not JSON-encoded. Use `SSEText(url)` not `SSEJSON()`.
 - **SSE endpoint URL resolution**: Client resolves the endpoint event URL against the SSE connection URL via `ResolveEndpointURL` (RFC 3986). Handles absolute URLs, absolute paths, and relative paths.
 - **Per-session Dispatchers**: each connection gets its own `Dispatcher` via `newSession()`. Registries shared by reference.
-- **SSE transport sessions** die with the connection. **Streamable HTTP sessions** persist until DELETE or server restart.
+- **SSE transport sessions** die with the connection. **Streamable HTTP sessions** persist until DELETE or server restart. **Stdio sessions** last for the process lifetime (1:1 mapping).
+- **Stdio transport** uses Content-Length framed JSON-RPC over stdin/stdout. Server-side: `srv.RunStdio(ctx)`. Client-side: `client.WithStdioTransport(reader, writer)`. No HTTP, no auth — process boundary is the trust boundary. Debug logging goes to stderr.
 - **Notification delivery order**: notifications arrive before tool results across all transports.
 - **HTTP error classification**: Both transports return `HTTPStatusError` for non-2xx responses (excluding 401/403, handled by `DoWithAuthRetry`). `IsTransientError` classifies 5xx as transient (retriable via `WithMaxRetries`), 4xx as terminal.
 - **SSE reader death**: `call()` uses dual-select on the response channel and the done channel — returns a transient error immediately if the background reader dies, instead of blocking forever.
@@ -124,8 +127,8 @@ mcpkit/
 - **Design doc**: see `docs/APPS_DESIGN.md` for full architecture, protocol flows, and conformance strategy.
 
 ### Testing
-- **`forAllTransports`**: parametric tests run against Streamable HTTP, SSE, and in-memory. Use for any cross-transport test.
-- **In-process transport skips JSON envelope serialization** — catches logic bugs. HTTP tests catch wire format bugs. Both needed.
+- **`forAllTransports`**: parametric tests run against Streamable HTTP, SSE, in-memory, and stdio. Use for any cross-transport test.
+- **In-process transport skips JSON envelope serialization** — catches logic bugs. HTTP tests catch wire format bugs. Stdio tests catch Content-Length framing bugs. All needed.
 - **Conformance baseline**: when a feature passes, remove from `conformance/baseline.yml`. Stale entries cause CI failure.
 
 ## Conformance Status
@@ -141,5 +144,4 @@ mcpkit/
 
 ## What's Not Implemented Yet
 
-- stdio transport (#3)
 - Streamable HTTP GET SSE stream (server-initiated notifications without a request)

--- a/client/client.go
+++ b/client/client.go
@@ -197,6 +197,10 @@ type Client struct {
 	// onNotify is an optional callback for server-to-client notifications.
 	// Currently only used by the in-memory transport.
 	onNotify func(method string, params any)
+
+	// Stdio transport fields (set by WithStdioTransport).
+	stdioReader io.Reader
+	stdioWriter io.Writer
 }
 
 // NewClient creates a new MCP client targeting the given server URL.
@@ -218,7 +222,22 @@ func NewClient(url string, info core.ClientInfo, opts ...ClientOption) *Client {
 func (c *Client) Connect() error {
 	// Create transport (skip if already set, e.g., by WithInMemoryServer)
 	if c.transport == nil {
-		if c.useSSE {
+		if c.stdioReader != nil && c.stdioWriter != nil {
+			st := NewStdioTransport(c.stdioReader, c.stdioWriter)
+			st.serverReqHandler = func(_ context.Context, req *core.Request) *core.Response {
+				return c.HandleServerRequest(req)
+			}
+			if c.onNotify != nil {
+				st.notifyHandler = func(method string, params []byte) {
+					var parsed any
+					if len(params) > 0 {
+						json.Unmarshal(params, &parsed)
+					}
+					c.onNotify(method, parsed)
+				}
+			}
+			c.transport = &coreTransportAdapter{inner: st}
+		} else if c.useSSE {
 			st := newSSEClientTransport(c.url, c.tokenSource)
 			st.serverReqHandler = c.HandleServerRequest
 			if c.onNotify != nil {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,17 +1,19 @@
 package client_test
 
 import (
-	"encoding/json"
 	"context"
+	"encoding/json"
 	"fmt"
-	client "github.com/panyam/mcpkit/client"
-	core "github.com/panyam/mcpkit/core"
-	server "github.com/panyam/mcpkit/server"
+	"io"
 	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	client "github.com/panyam/mcpkit/client"
+	core "github.com/panyam/mcpkit/core"
+	server "github.com/panyam/mcpkit/server"
 )
 
 // newTestMCPServer creates a server with an echo tool, a fail tool,
@@ -137,8 +139,8 @@ func setupSSEClient(t *testing.T) (*client.Client, *httptest.Server) {
 	return c, ts
 }
 
-// forAllTransports runs a test function against all 3 client transports:
-// Streamable HTTP, SSE, and in-memory. This is the Go equivalent of
+// forAllTransports runs a test function against all 4 client transports:
+// Streamable HTTP, SSE, in-memory, and stdio. This is the Go equivalent of
 // parametric tests — each transport variant runs as a subtest.
 func forAllTransports(t *testing.T, fn func(t *testing.T, c *client.Client)) {
 	t.Helper()
@@ -160,6 +162,43 @@ func forAllTransports(t *testing.T, fn func(t *testing.T, c *client.Client)) {
 		t.Cleanup(func() { c.Close() })
 		fn(t, c)
 	})
+	t.Run("stdio", func(t *testing.T) {
+		c := setupStdioClient(t)
+		fn(t, c)
+	})
+}
+
+// setupStdioClient creates a server with stdio transport and a connected Client.
+// Uses io.Pipe pairs to connect client and server over Content-Length framed JSON-RPC.
+func setupStdioClient(t *testing.T) *client.Client {
+	t.Helper()
+	srv := newTestMCPServer()
+
+	// Two pipes: server reads what client writes, client reads what server writes.
+	sr, cw := io.Pipe() // server reads from sr, client writes to cw
+	cr, sw := io.Pipe() // client reads from cr, server writes to sw
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		srv.RunStdio(ctx, server.WithStdioInput(sr), server.WithStdioOutput(sw))
+		// Close the server's write end so the client's read loop sees EOF.
+		sw.Close()
+	}()
+
+	c := client.NewClient("stdio://", core.ClientInfo{Name: "test-client", Version: "1.0"},
+		client.WithStdioTransport(cr, cw))
+	if err := c.Connect(); err != nil {
+		cancel()
+		t.Fatalf("Stdio Connect failed: %v", err)
+	}
+
+	t.Cleanup(func() {
+		c.Close()
+		cancel()
+	})
+
+	return c
 }
 
 // --- Parametric transport tests (run against Streamable, SSE, and in-memory) ---

--- a/client/stdio_transport.go
+++ b/client/stdio_transport.go
@@ -1,0 +1,261 @@
+package client
+
+// Stdio client transport for Content-Length framed JSON-RPC over reader/writer pairs.
+//
+// Implements core.Transport so it can be used with client.WithTransport().
+// Designed for editor-spawned MCP servers where the client communicates with
+// a child process over stdin/stdout pipes.
+//
+// The transport runs a background read loop that:
+//   - Routes JSON-RPC responses to pending Call() waiters
+//   - Dispatches server-to-client requests (sampling, elicitation) to the handler
+//   - Delivers notifications to the notification handler
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"sync"
+
+	core "github.com/panyam/mcpkit/core"
+)
+
+// StdioTransport implements core.Transport over Content-Length framed JSON-RPC.
+// Messages are read from r and written to w using the same framing as the
+// MCP stdio server transport (Content-Length: N\r\n\r\n<body>).
+type StdioTransport struct {
+	r io.Reader
+	w io.Writer
+
+	// Handlers set by the client before Connect().
+	serverReqHandler core.ServerRequestHandler
+	notifyHandler    core.NotificationHandler
+
+	// Internal state.
+	reader   *bufio.Reader
+	writeMu  sync.Mutex
+	pending  sync.Map // id (string) → chan *core.Response
+	done     chan struct{}
+	closeErr error
+}
+
+// NewStdioTransport creates a client transport that communicates via
+// Content-Length framed JSON-RPC over the given reader/writer pair.
+//
+// Typically the reader is connected to the server's stdout and the writer
+// to the server's stdin (or pipe ends in tests).
+//
+// Example:
+//
+//	cmd := exec.Command("my-mcp-server")
+//	stdin, _ := cmd.StdinPipe()
+//	stdout, _ := cmd.StdoutPipe()
+//	cmd.Start()
+//	transport := client.NewStdioTransport(stdout, stdin)
+//	c := client.NewClient("stdio://", info, client.WithTransport(transport))
+func NewStdioTransport(r io.Reader, w io.Writer) *StdioTransport {
+	return &StdioTransport{r: r, w: w}
+}
+
+// WithStdioTransport configures a Client to use stdio transport over the given
+// reader/writer pair. Unlike WithTransport(NewStdioTransport(...)), this option
+// wires the client's sampling/elicitation handlers and notification callback into
+// the stdio transport automatically.
+func WithStdioTransport(r io.Reader, w io.Writer) ClientOption {
+	return func(c *Client) {
+		c.stdioReader = r
+		c.stdioWriter = w
+	}
+}
+
+// Connect starts the background read loop.
+func (t *StdioTransport) Connect(ctx context.Context) error {
+	t.reader = bufio.NewReader(t.r)
+	t.done = make(chan struct{})
+	go t.readLoop()
+	return nil
+}
+
+// Call sends a JSON-RPC request and waits for the matching response.
+func (t *StdioTransport) Call(ctx context.Context, req *core.Request) (*core.Response, error) {
+	// Extract request ID as string key for pending map.
+	var idStr string
+	if req.ID != nil {
+		if err := json.Unmarshal(req.ID, &idStr); err != nil {
+			// Numeric or other ID — use raw string.
+			idStr = string(req.ID)
+		}
+	}
+
+	ch := make(chan *core.Response, 1)
+	t.pending.Store(idStr, ch)
+	defer t.pending.Delete(idStr)
+
+	// Marshal and send.
+	data, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+	if err := t.writeFrame(data); err != nil {
+		return nil, fmt.Errorf("write request: %w", err)
+	}
+
+	// Wait for response or cancellation.
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case resp := <-ch:
+		return resp, nil
+	case <-t.done:
+		return nil, fmt.Errorf("stdio transport closed")
+	}
+}
+
+// Notify sends a JSON-RPC notification (no response expected).
+func (t *StdioTransport) Notify(ctx context.Context, req *core.Request) error {
+	data, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("marshal notification: %w", err)
+	}
+	return t.writeFrame(data)
+}
+
+// Close shuts down the transport and waits for the read loop to exit.
+func (t *StdioTransport) Close() error {
+	// Close the writer to signal EOF to the server.
+	if closer, ok := t.w.(io.Closer); ok {
+		closer.Close()
+	}
+	// Wait for read loop to finish (it will hit EOF or read error).
+	if t.done != nil {
+		<-t.done
+	}
+	return t.closeErr
+}
+
+// SessionID returns "stdio" for the stdio transport.
+func (t *StdioTransport) SessionID() string { return "stdio" }
+
+// writeFrame writes a Content-Length framed message, protected by mutex.
+func (t *StdioTransport) writeFrame(data []byte) error {
+	t.writeMu.Lock()
+	defer t.writeMu.Unlock()
+	header := fmt.Sprintf("Content-Length: %d\r\n\r\n", len(data))
+	if _, err := io.WriteString(t.w, header); err != nil {
+		return err
+	}
+	_, err := t.w.Write(data)
+	return err
+}
+
+// readLoop reads Content-Length framed messages and routes them.
+func (t *StdioTransport) readLoop() {
+	defer close(t.done)
+
+	for {
+		data, err := readClientFrame(t.reader)
+		if err != nil {
+			if err != io.EOF {
+				t.closeErr = err
+			}
+			return
+		}
+
+		// Detect message type.
+		if core.IsJSONRPCResponse(data) {
+			// Response to a pending Call().
+			var resp core.Response
+			if err := json.Unmarshal(data, &resp); err != nil {
+				continue
+			}
+			t.routeResponse(&resp)
+			continue
+		}
+
+		// It's a request or notification from the server.
+		var req core.Request
+		if err := json.Unmarshal(data, &req); err != nil {
+			continue
+		}
+
+		if req.IsNotification() {
+			// Server-to-client notification.
+			if t.notifyHandler != nil {
+				t.notifyHandler(req.Method, req.Params)
+			}
+			continue
+		}
+
+		// Server-to-client request (sampling, elicitation).
+		if t.serverReqHandler != nil {
+			resp := t.serverReqHandler(context.Background(), &req)
+			if resp != nil {
+				raw, err := json.Marshal(resp)
+				if err != nil {
+					continue
+				}
+				_ = t.writeFrame(raw)
+			}
+		}
+	}
+}
+
+// routeResponse delivers a response to the waiting Call() goroutine.
+func (t *StdioTransport) routeResponse(resp *core.Response) {
+	if resp.ID == nil {
+		return
+	}
+	var idStr string
+	if err := json.Unmarshal(resp.ID, &idStr); err != nil {
+		idStr = string(resp.ID)
+	}
+	if val, ok := t.pending.Load(idStr); ok {
+		ch := val.(chan *core.Response)
+		ch <- resp
+	}
+}
+
+// readClientFrame reads a Content-Length framed message from a bufio.Reader.
+// Same framing as the server side — shared protocol, separate implementation
+// to keep the client package independent of the server package.
+func readClientFrame(r *bufio.Reader) ([]byte, error) {
+	contentLength := -1
+
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+		line = strings.TrimRight(line, "\r\n")
+		if line == "" {
+			break
+		}
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("malformed header: %q", line)
+		}
+		name := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+		if strings.EqualFold(name, "Content-Length") {
+			n, err := strconv.Atoi(value)
+			if err != nil {
+				return nil, fmt.Errorf("invalid Content-Length %q: %w", value, err)
+			}
+			contentLength = n
+		}
+	}
+
+	if contentLength < 0 {
+		return nil, fmt.Errorf("missing Content-Length header")
+	}
+
+	body := make([]byte, contentLength)
+	if _, err := io.ReadFull(r, body); err != nil {
+		return nil, fmt.Errorf("reading body (%d bytes): %w", contentLength, err)
+	}
+	return body, nil
+}

--- a/cmd/testserver/main.go
+++ b/cmd/testserver/main.go
@@ -2,12 +2,14 @@
 // It registers three tools (echo, add, fail) and serves MCP transports on :8787.
 //
 // By default, serves SSE transport. Set STREAMABLE=1 for Streamable HTTP,
-// or BOTH=1 for both transports simultaneously.
+// BOTH=1 for both transports simultaneously, or STDIO=1 for stdio transport
+// (Content-Length framed JSON-RPC over stdin/stdout).
 //
 // Usage:
 //
 //	go run ./cmd/testserver
 //	STREAMABLE=1 go run ./cmd/testserver
+//	STDIO=1 go run ./cmd/testserver
 package main
 
 import (
@@ -120,6 +122,18 @@ func main() {
 	registerConformanceResources(srv)
 	registerConformancePrompts(srv)
 	registerConformanceApps(srv)
+
+	// Stdio mode: Content-Length framed JSON-RPC over stdin/stdout.
+	// No HTTP server — the process communicates directly via stdio.
+	if os.Getenv("STDIO") == "1" {
+		log.SetOutput(os.Stderr) // Keep debug output on stderr, not stdout
+		log.Printf("MCP test server running on stdio")
+		ctx := context.Background()
+		if err := srv.RunStdio(ctx, server.WithStdioLogger(log.Default())); err != nil {
+			log.Fatal(err)
+		}
+		return
+	}
 
 	var transportOpts []server.TransportOption
 	switch {

--- a/server/stdio_transport.go
+++ b/server/stdio_transport.go
@@ -1,0 +1,285 @@
+package server
+
+// Stdio transport for editor-spawned MCP servers (Cursor, Claude Desktop, etc.).
+//
+// Implements Content-Length framed JSON-RPC over stdin/stdout per the MCP spec
+// (https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#stdio).
+//
+// Key spec requirements:
+//   - Messages delimited by Content-Length header with \r\n\r\n separator
+//   - Server MUST NOT write non-JSON-RPC data to stdout
+//   - Server MAY write debug/log output to stderr
+//   - Clean EOF handling on client disconnect
+//
+// Architecture: single session (stdio = 1 client = 1 connection). Uses the same
+// dispatch path as HTTP transports: newSession() → dispatchWithNotifyAndRequest().
+// Notifications and server-to-client requests (sampling, elicitation) are written
+// to stdout as Content-Length framed messages, protected by a write mutex.
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+
+	core "github.com/panyam/mcpkit/core"
+)
+
+// StdioOption configures the stdio transport.
+type StdioOption func(*stdioConfig)
+
+type stdioConfig struct {
+	input  io.Reader
+	output io.Writer
+	logger *log.Logger
+}
+
+// WithStdioInput overrides stdin for the stdio transport.
+// Primarily used for testing with pipe pairs.
+func WithStdioInput(r io.Reader) StdioOption {
+	return func(c *stdioConfig) { c.input = r }
+}
+
+// WithStdioOutput overrides stdout for the stdio transport.
+// Primarily used for testing with pipe pairs.
+func WithStdioOutput(w io.Writer) StdioOption {
+	return func(c *stdioConfig) { c.output = w }
+}
+
+// WithStdioLogger sets a logger for debug output on stderr.
+// Debug logging is separate from the MCP protocol — it goes to stderr,
+// never to stdout.
+func WithStdioLogger(l *log.Logger) StdioOption {
+	return func(c *stdioConfig) { c.logger = l }
+}
+
+// RunStdio runs the MCP server over stdio using Content-Length framed JSON-RPC.
+// Blocks until ctx is cancelled or the input stream reaches EOF.
+//
+// This is the primary entry point for editor-spawned MCP servers. The server
+// reads JSON-RPC messages from stdin (or the configured input), dispatches them
+// through the standard Server dispatch pipeline, and writes responses to stdout
+// (or the configured output).
+//
+// Example:
+//
+//	srv := server.NewServer(core.ServerInfo{Name: "my-server", Version: "1.0"})
+//	srv.RegisterTool(def, handler)
+//	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+//	defer cancel()
+//	if err := srv.RunStdio(ctx); err != nil {
+//	    log.Fatal(err)
+//	}
+func (s *Server) RunStdio(ctx context.Context, opts ...StdioOption) error {
+	cfg := stdioConfig{
+		input:  os.Stdin,
+		output: os.Stdout,
+	}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	// Validate extension refs at startup (same as Handler() for HTTP transports).
+	s.validateExtensionRefs()
+
+	// Single session — stdio is always 1:1 client-to-server.
+	dispatcher := s.newSession()
+	dispatcher.sessionID = "stdio"
+	defer dispatcher.Close()
+
+	// Write mutex prevents interleaved writes from concurrent notifications
+	// and responses on stdout.
+	var writeMu sync.Mutex
+	writer := cfg.output
+
+	// writeFrameLocked writes a Content-Length framed message to stdout.
+	writeFrameLocked := func(data []byte) error {
+		writeMu.Lock()
+		defer writeMu.Unlock()
+		return writeFrame(writer, data)
+	}
+
+	// Wire notifyFunc for server-to-client notifications (logging, progress, etc.).
+	dispatcher.notifyFunc = func(method string, params any) {
+		raw, err := core.MarshalNotification(method, params)
+		if err != nil {
+			if cfg.logger != nil {
+				cfg.logger.Printf("stdio: marshal notification %s: %v", method, err)
+			}
+			return
+		}
+		if err := writeFrameLocked(raw); err != nil {
+			if cfg.logger != nil {
+				cfg.logger.Printf("stdio: write notification: %v", err)
+			}
+		}
+	}
+
+	// Wire pushRequest for server-to-client requests (sampling, elicitation).
+	dispatcher.pushRequest = func(raw json.RawMessage) {
+		if err := writeFrameLocked(raw); err != nil {
+			if cfg.logger != nil {
+				cfg.logger.Printf("stdio: write server request: %v", err)
+			}
+		}
+	}
+
+	// Build request func for server-to-client request/response matching.
+	requestFunc := dispatcher.makeRequestFunc(dispatcher.pushRequest)
+
+	reader := bufio.NewReader(cfg.input)
+
+	// Use a channel to decouple the blocking read from context cancellation.
+	type readResult struct {
+		data []byte
+		err  error
+	}
+	readCh := make(chan readResult, 1)
+
+	for {
+		// Start a read in a goroutine so we can select on ctx.Done().
+		go func() {
+			data, err := readFrame(reader)
+			readCh <- readResult{data, err}
+		}()
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case result := <-readCh:
+			if result.err != nil {
+				if result.err == io.EOF {
+					// Client disconnected — clean shutdown.
+					return nil
+				}
+				// Frame-level parse error: write a JSON-RPC error response.
+				// Use null ID since we couldn't parse the request.
+				errResp := core.NewErrorResponse(
+					json.RawMessage("null"),
+					core.ErrCodeParse,
+					fmt.Sprintf("parse error: %v", result.err),
+				)
+				raw, _ := json.Marshal(errResp)
+				if writeErr := writeFrameLocked(raw); writeErr != nil {
+					return fmt.Errorf("stdio: write error response: %w", writeErr)
+				}
+				continue
+			}
+
+			// Detect if the incoming message is a response to a server-to-client request.
+			if core.IsJSONRPCResponse(result.data) {
+				var resp core.Response
+				if err := json.Unmarshal(result.data, &resp); err == nil {
+					dispatcher.RouteResponse(&resp)
+				}
+				continue
+			}
+
+			// Parse as a JSON-RPC request.
+			var req core.Request
+			if err := json.Unmarshal(result.data, &req); err != nil {
+				errResp := core.NewErrorResponse(
+					json.RawMessage("null"),
+					core.ErrCodeParse,
+					fmt.Sprintf("invalid JSON: %v", err),
+				)
+				raw, _ := json.Marshal(errResp)
+				_ = writeFrameLocked(raw)
+				continue
+			}
+
+			// Dispatch through the standard server pipeline.
+			resp := s.dispatchWithNotifyAndRequest(
+				dispatcher, ctx, nil,
+				dispatcher.notifyFunc, requestFunc, &req,
+			)
+
+			// Notifications produce no response.
+			if resp == nil {
+				continue
+			}
+
+			raw, err := json.Marshal(resp)
+			if err != nil {
+				if cfg.logger != nil {
+					cfg.logger.Printf("stdio: marshal response: %v", err)
+				}
+				continue
+			}
+			if err := writeFrameLocked(raw); err != nil {
+				return fmt.Errorf("stdio: write response: %w", err)
+			}
+		}
+	}
+}
+
+// writeFrame writes a Content-Length framed message.
+// Format: Content-Length: <n>\r\n\r\n<body>
+func writeFrame(w io.Writer, data []byte) error {
+	header := fmt.Sprintf("Content-Length: %d\r\n\r\n", len(data))
+	if _, err := io.WriteString(w, header); err != nil {
+		return err
+	}
+	_, err := w.Write(data)
+	return err
+}
+
+// readFrame reads a Content-Length framed message.
+// Parses HTTP-like headers until \r\n\r\n, extracts Content-Length, reads the body.
+// Handles multiple headers (only Content-Length is used, others are ignored).
+func readFrame(r *bufio.Reader) ([]byte, error) {
+	contentLength := -1
+
+	// Read headers until empty line (\r\n).
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+
+		// Trim trailing \r\n or \n.
+		line = strings.TrimRight(line, "\r\n")
+
+		// Empty line = end of headers.
+		if line == "" {
+			break
+		}
+
+		// Parse header.
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("malformed header: %q", line)
+		}
+		name := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+
+		if strings.EqualFold(name, "Content-Length") {
+			n, err := strconv.Atoi(value)
+			if err != nil {
+				return nil, fmt.Errorf("invalid Content-Length %q: %w", value, err)
+			}
+			if n < 0 {
+				return nil, fmt.Errorf("negative Content-Length: %d", n)
+			}
+			contentLength = n
+		}
+		// Ignore other headers per spec.
+	}
+
+	if contentLength < 0 {
+		return nil, fmt.Errorf("missing Content-Length header")
+	}
+
+	body := make([]byte, contentLength)
+	if _, err := io.ReadFull(r, body); err != nil {
+		return nil, fmt.Errorf("reading body (%d bytes): %w", contentLength, err)
+	}
+
+	return body, nil
+}

--- a/server/stdio_transport_test.go
+++ b/server/stdio_transport_test.go
@@ -1,0 +1,399 @@
+package server
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/panyam/mcpkit/core"
+)
+
+// TestStdioFrameRoundTrip verifies that writeFrame and readFrame produce and
+// consume Content-Length framed messages correctly. A message written with
+// writeFrame should be readable by readFrame with identical content.
+func TestStdioFrameRoundTrip(t *testing.T) {
+	msg := `{"jsonrpc":"2.0","id":1,"method":"test"}`
+
+	var buf bytes.Buffer
+	if err := writeFrame(&buf, []byte(msg)); err != nil {
+		t.Fatalf("writeFrame: %v", err)
+	}
+
+	// Verify wire format: header + separator + body.
+	raw := buf.String()
+	expected := fmt.Sprintf("Content-Length: %d\r\n\r\n%s", len(msg), msg)
+	if raw != expected {
+		t.Errorf("unexpected wire format:\n got: %q\nwant: %q", raw, expected)
+	}
+
+	// Read it back.
+	reader := bufio.NewReader(&buf)
+	body, err := readFrame(reader)
+	if err != nil {
+		t.Fatalf("readFrame: %v", err)
+	}
+	if string(body) != msg {
+		t.Errorf("readFrame body = %q, want %q", body, msg)
+	}
+}
+
+// TestStdioFrameMultipleHeaders verifies that readFrame correctly handles
+// messages with multiple headers, ignoring unknown headers and extracting
+// only Content-Length.
+func TestStdioFrameMultipleHeaders(t *testing.T) {
+	msg := `{"test":true}`
+	frame := "Content-Type: application/json\r\nContent-Length: 13\r\nX-Custom: foo\r\n\r\n" + msg
+
+	reader := bufio.NewReader(strings.NewReader(frame))
+	body, err := readFrame(reader)
+	if err != nil {
+		t.Fatalf("readFrame: %v", err)
+	}
+	if string(body) != msg {
+		t.Errorf("body = %q, want %q", body, msg)
+	}
+}
+
+// TestStdioFrameMalformedHeader verifies that readFrame returns an error
+// for headers that cannot be parsed (missing colon separator).
+func TestStdioFrameMalformedHeader(t *testing.T) {
+	frame := "BADHEADER\r\n\r\n"
+	reader := bufio.NewReader(strings.NewReader(frame))
+	_, err := readFrame(reader)
+	if err == nil {
+		t.Fatal("expected error for malformed header")
+	}
+	if !strings.Contains(err.Error(), "malformed header") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestStdioFrameInvalidContentLength verifies that readFrame returns an error
+// when Content-Length is not a valid integer.
+func TestStdioFrameInvalidContentLength(t *testing.T) {
+	frame := "Content-Length: abc\r\n\r\n"
+	reader := bufio.NewReader(strings.NewReader(frame))
+	_, err := readFrame(reader)
+	if err == nil {
+		t.Fatal("expected error for invalid Content-Length")
+	}
+	if !strings.Contains(err.Error(), "invalid Content-Length") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestStdioFrameMissingContentLength verifies that readFrame returns an error
+// when no Content-Length header is present in the message headers.
+func TestStdioFrameMissingContentLength(t *testing.T) {
+	frame := "Content-Type: application/json\r\n\r\n"
+	reader := bufio.NewReader(strings.NewReader(frame))
+	_, err := readFrame(reader)
+	if err == nil {
+		t.Fatal("expected error for missing Content-Length")
+	}
+	if !strings.Contains(err.Error(), "missing Content-Length") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestStdioFrameNegativeContentLength verifies that readFrame rejects
+// negative Content-Length values.
+func TestStdioFrameNegativeContentLength(t *testing.T) {
+	frame := "Content-Length: -5\r\n\r\n"
+	reader := bufio.NewReader(strings.NewReader(frame))
+	_, err := readFrame(reader)
+	if err == nil {
+		t.Fatal("expected error for negative Content-Length")
+	}
+	if !strings.Contains(err.Error(), "negative Content-Length") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestStdioFramePartialRead verifies that readFrame returns an error when
+// the body is shorter than what Content-Length declares (EOF mid-body).
+func TestStdioFramePartialRead(t *testing.T) {
+	frame := "Content-Length: 100\r\n\r\nshort"
+	reader := bufio.NewReader(strings.NewReader(frame))
+	_, err := readFrame(reader)
+	if err == nil {
+		t.Fatal("expected error for partial body read")
+	}
+}
+
+// TestStdioParseError verifies that the stdio transport returns a JSON-RPC
+// parse error response when it receives malformed JSON, rather than silently
+// skipping the message. This is a key spec requirement and the fix for the
+// bug described in issue #3.
+func TestStdioParseError(t *testing.T) {
+	// Send a valid frame with invalid JSON content.
+	badJSON := "not json at all"
+	var input bytes.Buffer
+	writeFrame(&input, []byte(badJSON))
+
+	var output bytes.Buffer
+	srv := newTestServer()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- srv.RunStdio(ctx, WithStdioInput(&input), WithStdioOutput(&output))
+	}()
+
+	// Wait for the server to process (EOF from input will cause clean exit).
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("RunStdio: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		cancel()
+		t.Fatal("RunStdio did not exit")
+	}
+
+	// Read the error response from output.
+	reader := bufio.NewReader(&output)
+	body, err := readFrame(reader)
+	if err != nil {
+		t.Fatalf("readFrame from output: %v", err)
+	}
+
+	var resp core.Response
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if resp.Error == nil {
+		t.Fatal("expected error response")
+	}
+	if resp.Error.Code != core.ErrCodeParse {
+		t.Errorf("error code = %d, want %d (parse error)", resp.Error.Code, core.ErrCodeParse)
+	}
+}
+
+// TestStdioEOFCleanShutdown verifies that the stdio transport exits cleanly
+// (returns nil error) when the input stream reaches EOF, simulating a client
+// disconnect.
+func TestStdioEOFCleanShutdown(t *testing.T) {
+	// Empty input → immediate EOF.
+	var input bytes.Buffer
+	var output bytes.Buffer
+	srv := newTestServer()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- srv.RunStdio(context.Background(), WithStdioInput(&input), WithStdioOutput(&output))
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("RunStdio should return nil on EOF, got: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("RunStdio did not exit on EOF")
+	}
+}
+
+// TestStdioCancellation verifies that the stdio transport exits promptly
+// when the context is cancelled, supporting clean shutdown via signal handling.
+func TestStdioCancellation(t *testing.T) {
+	// Use a pipe that never sends data — the server blocks on read.
+	pr, pw := io.Pipe()
+	defer pw.Close()
+
+	var output bytes.Buffer
+	srv := newTestServer()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- srv.RunStdio(ctx, WithStdioInput(pr), WithStdioOutput(&output))
+	}()
+
+	// Cancel after a short delay.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != context.Canceled {
+			t.Fatalf("expected context.Canceled, got: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("RunStdio did not exit on cancellation")
+	}
+}
+
+// TestStdioRequestResponse verifies the full request-response cycle over stdio:
+// send a JSON-RPC initialize request, receive a valid response with server info.
+func TestStdioRequestResponse(t *testing.T) {
+	srv := newTestServer()
+	sr, cw := io.Pipe() // server reads from sr, client writes to cw
+	cr, sw := io.Pipe() // client reads from cr, server writes to sw
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go srv.RunStdio(ctx, WithStdioInput(sr), WithStdioOutput(sw))
+
+	// Send initialize request.
+	initReq := `{"jsonrpc":"2.0","id":"1","method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}`
+	writeFrame(cw, []byte(initReq))
+
+	// Read response.
+	reader := bufio.NewReader(cr)
+	body, err := readFrame(reader)
+	if err != nil {
+		t.Fatalf("readFrame: %v", err)
+	}
+
+	var resp core.Response
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+
+	// Check server info in result.
+	var result struct {
+		ServerInfo core.ServerInfo `json:"serverInfo"`
+	}
+	json.Unmarshal(resp.Result, &result)
+	if result.ServerInfo.Name != "test-server" {
+		t.Errorf("server name = %q, want test-server", result.ServerInfo.Name)
+	}
+
+	// Clean shutdown.
+	cw.Close()
+}
+
+// TestStdioNotificationDelivery verifies that server-to-client notifications
+// (e.g., logging messages emitted during tool execution) are written to stdout
+// as Content-Length framed messages.
+func TestStdioNotificationDelivery(t *testing.T) {
+	srv := newTestServer()
+
+	// Register a tool that emits a log notification.
+	srv.RegisterTool(
+		core.ToolDef{Name: "log-test", Description: "emits a log", InputSchema: json.RawMessage(`{"type":"object"}`)},
+		func(ctx context.Context, req core.ToolRequest) (core.ToolResult, error) {
+			core.EmitLog(ctx, core.LogInfo, "test-logger", "hello from stdio")
+			return core.ToolResult{Content: []core.Content{{Type: "text", Text: "ok"}}}, nil
+		},
+	)
+
+	sr, cw := io.Pipe()
+	cr, sw := io.Pipe()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go srv.RunStdio(ctx, WithStdioInput(sr), WithStdioOutput(sw))
+
+	reader := bufio.NewReader(cr)
+
+	// Initialize.
+	initReq := `{"jsonrpc":"2.0","id":"1","method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}`
+	writeFrame(cw, []byte(initReq))
+	readFrame(reader) // consume init response
+
+	// Send initialized notification.
+	initedNotif := `{"jsonrpc":"2.0","method":"notifications/initialized"}`
+	writeFrame(cw, []byte(initedNotif))
+
+	// Set log level so notifications are emitted.
+	setLevel := `{"jsonrpc":"2.0","id":"2","method":"logging/setLevel","params":{"level":"info"}}`
+	writeFrame(cw, []byte(setLevel))
+	readFrame(reader) // consume setLevel response
+
+	// Call the tool that emits a log.
+	toolCall := `{"jsonrpc":"2.0","id":"3","method":"tools/call","params":{"name":"log-test","arguments":{}}}`
+	writeFrame(cw, []byte(toolCall))
+
+	// We should receive a notification before the tool result.
+	// Read frames until we get the tool response.
+	var gotNotification bool
+	for i := 0; i < 5; i++ {
+		body, err := readFrame(reader)
+		if err != nil {
+			t.Fatalf("readFrame: %v", err)
+		}
+
+		var msg struct {
+			Method string          `json:"method"`
+			ID     json.RawMessage `json:"id"`
+		}
+		json.Unmarshal(body, &msg)
+
+		if msg.Method == "notifications/message" {
+			gotNotification = true
+			continue
+		}
+		if msg.ID != nil && string(msg.ID) == `"3"` {
+			// Tool response received.
+			break
+		}
+	}
+
+	if !gotNotification {
+		t.Error("expected notifications/message before tool result")
+	}
+
+	cw.Close()
+}
+
+// TestStdioMultipleFrames verifies that multiple Content-Length framed messages
+// can be written and read sequentially from the same stream.
+func TestStdioMultipleFrames(t *testing.T) {
+	var buf bytes.Buffer
+	msgs := []string{
+		`{"a":1}`,
+		`{"b":2}`,
+		`{"c":3}`,
+	}
+	for _, msg := range msgs {
+		if err := writeFrame(&buf, []byte(msg)); err != nil {
+			t.Fatalf("writeFrame: %v", err)
+		}
+	}
+
+	reader := bufio.NewReader(&buf)
+	for _, want := range msgs {
+		body, err := readFrame(reader)
+		if err != nil {
+			t.Fatalf("readFrame: %v", err)
+		}
+		if string(body) != want {
+			t.Errorf("got %q, want %q", body, want)
+		}
+	}
+}
+
+// newTestServer creates a minimal MCP server with an echo tool for testing.
+func newTestServer() *Server {
+	srv := NewServer(core.ServerInfo{Name: "test-server", Version: "1.0"})
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "echo",
+			Description: "echoes input",
+			InputSchema: json.RawMessage(`{"type":"object","properties":{"message":{"type":"string"}}}`),
+		},
+		func(ctx context.Context, req core.ToolRequest) (core.ToolResult, error) {
+			var args struct{ Message string }
+			json.Unmarshal(req.Arguments, &args)
+			return core.ToolResult{
+				Content: []core.Content{{Type: "text", Text: "echo: " + args.Message}},
+			}, nil
+		},
+	)
+	return srv
+}


### PR DESCRIPTION
## Summary

- Adds Content-Length framed JSON-RPC stdio transport per MCP spec (2025-11-25)
- Server-side: `Server.RunStdio(ctx)` with `WithStdioInput`/`WithStdioOutput`/`WithStdioLogger` options
- Client-side: `client.WithStdioTransport(reader, writer)` for editor-spawned servers
- Testserver: `STDIO=1 go run ./cmd/testserver` for manual testing
- 13 server-side unit tests covering framing, parse errors, EOF, cancellation, notifications
- All parametric client tests (`forAllTransports`) now run against 4 transports: Streamable HTTP, SSE, in-memory, and stdio

Closes #3. Unblocks #9 (slyds migration) and #27 (NotificationSender).

## Test plan

- [x] `go test ./server/... -run TestStdio -v` — all 13 server stdio tests pass
- [x] `go test ./client/... -v` — all parametric tests pass with stdio subtest
- [x] `go test ./... -count=1` — full suite passes (core, server, client, testutil)
- [x] `go vet ./...` — clean
- [x] Manual: `STDIO=1 go run ./cmd/testserver` responds to Content-Length framed requests on stdin