### PR TITLE
docs: sync stdio transport into ARCHITECTURE.md and CONSTRAINTS.md

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,7 +15,7 @@ MCPKit is a Go library for building production-grade MCP (Model Context Protocol
 │  │ HTTP+SSE    │  │ Auth (bearer)    │  │tools/list││
 │  │ Streamable  │  │ Tool timeout     │  │tools/call││
 │  │  HTTP       │  │ Allowed-roots    │  │initialize││
-│  │ stdio (tbd) │  │ Tool authz       │  │resources/││
+│  │ stdio       │  │ Tool authz       │  │resources/││
 │  └────────────┘  │ MCP metrics      │  │ prompts/ ││
 │                  └─────────────────┘  │ logging/ ││
 │  ┌────────────────────────────────┐   └──────────┘│
@@ -72,12 +72,14 @@ mcpkit/                          # module: github.com/panyam/mcpkit
 │   ├── dispatch.go              # Dispatcher, routing, handlers, subscriptions
 │   ├── transport.go             # SSE server transport
 │   ├── streamable_transport.go  # Streamable HTTP transport
+│   ├── stdio_transport.go       # Stdio transport (Content-Length framed JSON-RPC)
 │   ├── memory_transport.go      # InProcessTransport (core.Transport)
 │   ├── request.go               # sendServerRequest, routeServerResponse
 │   ├── middleware.go            # Middleware, LoggingMiddleware
 │   └── pagination.go            # cursor-based pagination
-├── client/                      # Client + HTTP transports
+├── client/                      # Client + transports
 │   ├── client.go                # Client, NewClient, Connect, ToolCall, WithTransport
+│   ├── stdio_transport.go       # StdioTransport, NewStdioTransport, WithStdioTransport
 │   ├── client_logging.go        # loggingTransport, WithClientLogging
 │   └── client_reconnect.go      # WithMaxRetries, WithReconnectBackoff
 ├── ext/auth/                    # SEPARATE module (github.com/panyam/mcpkit/ext/auth)

--- a/server/CONSTRAINTS.md
+++ b/server/CONSTRAINTS.md
@@ -11,5 +11,5 @@ If you're adding a type that the client also needs, put it in core/, not here.
 Examples: Request, Response, ToolDef, ServerInfo.
 
 ## C3: Transport implementations are server-internal
-SSE transport, Streamable HTTP transport, and InProcessTransport live here.
+SSE, Streamable HTTP, stdio, and InProcessTransport live here.
 They satisfy `core.Transport` but their internals (hub, session map, etc.) are unexported.


### PR DESCRIPTION
## Summary

- Update `docs/ARCHITECTURE.md`: mark stdio as implemented (not "tbd"), add stdio_transport.go to package listing
- Update `server/CONSTRAINTS.md`: include stdio in transport list

Follow-up to #149 (stdio transport).

## Test plan

- Docs-only change, no code changes