### PR TITLE
feat: dynamic registration + session idle timeout (#60, #64)

### DIFF
--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -58,6 +58,9 @@
 - mcp-apps-resource-notification: NotifyResourcesChanged(ctx) — tool handlers signal resource list changes to clients
 - mcp-apps-register-helper: RegisterAppTool (ext/ui) — registers tool + resource pair in one call via ToolResourceRegistrar interface
 - mcp-apps-conformance: 21 MCP Apps conformance tests (tool metadata, resources, visibility, fallback, negotiation)
+- mcp-dynamic-registration: Registry.AddTool/RemoveTool/AddResource/RemoveResource/AddPrompt/RemovePrompt — thread-safe runtime registration with automatic notifications/*/list_changed broadcast via OnChange callback
+- mcp-session-timeout: WithSessionTimeout — idle session cleanup for Streamable HTTP (timer + ref counting to avoid closing mid-execution)
+- mcp-server-capabilities-typed: core.ServerCapabilities, ToolsCap, ResourcesCap, PromptsCap — typed structs for initialize response capabilities
 
 ## Module
 github.com/panyam/mcpkit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,13 +44,14 @@ mcpkit/
 │   ├── sampling.go            CreateMessageRequest/Result, Sample()
 │   ├── elicitation.go         ElicitationRequest/Result, Elicit()
 │   ├── request.go             RequestFunc, ErrNoRequestFunc
-│   ├── protocol.go            ServerInfo, ClientInfo, ClientCapabilities
+│   ├── protocol.go            ServerInfo, ClientInfo, ClientCapabilities, ServerCapabilities, ToolsCap, ResourcesCap, PromptsCap
 │   ├── interfaces.go          Transport, ServerRequestHandler, NotificationHandler
 │   ├── ui.go                  UIMetadata, UICSPConfig, UIVisibility, AppMIMEType, ToolMeta, ResourceContentMeta
 │   └── www_authenticate.go    ParseWWWAuthenticate
 │
 ├── server/                  ← Server + Dispatcher + transports
-│   ├── server.go              Server, NewServer, options, Handler(), Run(), Broadcast()
+│   ├── server.go              Server, NewServer, options, Handler(), Run(), Broadcast(), Registry()
+│   ├── registry.go            Registry, AddTool/RemoveTool, AddResource/RemoveResource, AddPrompt/RemovePrompt, OnChange
 │   ├── dispatch.go            Dispatcher, JSON-RPC routing, all method handlers
 │   ├── transport.go           SSE transport
 │   ├── streamable_transport.go Streamable HTTP transport
@@ -98,8 +99,9 @@ mcpkit/
 ### Transports
 - **SSE endpoint event data must be raw text**, not JSON-encoded. Use `SSEText(url)` not `SSEJSON()`.
 - **SSE endpoint URL resolution**: Client resolves the endpoint event URL against the SSE connection URL via `ResolveEndpointURL` (RFC 3986). Handles absolute URLs, absolute paths, and relative paths.
-- **Per-session Dispatchers**: each connection gets its own `Dispatcher` via `newSession()`. Registries shared by reference.
-- **SSE transport sessions** die with the connection. **Streamable HTTP sessions** persist until DELETE or server restart. **Stdio sessions** last for the process lifetime (1:1 mapping).
+- **Per-session Dispatchers**: each connection gets its own `Dispatcher` via `newSession()`. The `Registry` is shared by pointer — all sessions see the same tools/resources/prompts.
+- **SSE transport sessions** die with the connection. **Streamable HTTP sessions** persist until DELETE, idle timeout, or server restart. **Stdio sessions** last for the process lifetime (1:1 mapping).
+- **Session idle timeout**: `WithSessionTimeout(d)` enables automatic cleanup of abandoned Streamable HTTP sessions. Timer pauses during active requests (ref counting via `sessionEntry.acquire/release`). Default is 0 (no timeout).
 - **Stdio transport** uses Content-Length framed JSON-RPC over stdin/stdout. Server-side: `srv.RunStdio(ctx)`. Client-side: `client.WithStdioTransport(reader, writer)`. No HTTP, no auth — process boundary is the trust boundary. Debug logging goes to stderr.
 - **Notification delivery order**: notifications arrive before tool results across all transports.
 - **HTTP error classification**: Both transports return `HTTPStatusError` for non-2xx responses (excluding 401/403, handled by `DoWithAuthRetry`). `IsTransientError` classifies 5xx as transient (retriable via `WithMaxRetries`), 4xx as terminal.
@@ -107,6 +109,13 @@ mcpkit/
 - **Client GET SSE stream**: Opt-in via `WithGetSSEStream()`. Opens a background `GET /mcp` SSE stream after Connect() for receiving server-initiated notifications outside POST request-response cycles (Streamable HTTP only). Notification callback (`WithNotificationCallback`) must be goroutine-safe when enabled. Re-established automatically on reconnection.
 - **Dispatcher.notifyFunc thread safety**: `notifyFunc` is protected by `notifyMu` (RWMutex). Use `SetNotifyFunc()` / `getNotifyFunc()` — never access the field directly.
 - **Broadcast vs NotifyResourceUpdated**: `Server.Broadcast(method, params)` fans out to ALL connected sessions unconditionally. `NotifyResourceUpdated(uri)` only targets sessions that called `resources/subscribe`. Broadcast only reaches HTTP transport sessions (SSE + Streamable HTTP), not in-process — consistent with `CloseSession`/`CloseAllSessions`.
+
+### Dynamic Registration
+- **`Registry`** is the shared, thread-safe registry for tools, resources, prompts, and completions. Access via `srv.Registry()`. All session dispatchers share the same `*Registry` pointer.
+- **`Registry.AddTool` / `RemoveTool`** (and Resource, Prompt variants) acquire write lock, modify the registry, then call `OnChange` to broadcast `notifications/*/list_changed` to all sessions.
+- **`Registry.OnChange`** is wired by `NewServer` to `Server.Broadcast`. Pre-serve `RegisterTool` calls also trigger OnChange but Broadcast is a no-op with zero sessions.
+- **RLock scoping in handlers**: `handleToolsCall` acquires RLock only for the map lookup, releases before executing the handler. Tool execution is never under lock.
+- **`listChanged: true`** is always advertised in capabilities for tools, resources, and prompts, regardless of current registry contents.
 
 ### Auth
 - **Auth spec is 2025-11-25**: See `ext/auth/docs/DESIGN.md` for spec compliance (all C1-C23, X1-X5 requirements Done).

--- a/core/protocol.go
+++ b/core/protocol.go
@@ -43,6 +43,33 @@ type RootsCap struct {
 	ListChanged bool `json:"listChanged,omitempty"`
 }
 
+// ServerCapabilities describes the features the server supports,
+// returned in the initialize response.
+type ServerCapabilities struct {
+	Tools       *ToolsCap       `json:"tools,omitempty"`
+	Resources   *ResourcesCap   `json:"resources,omitempty"`
+	Prompts     *PromptsCap     `json:"prompts,omitempty"`
+	Logging     *struct{}       `json:"logging,omitempty"`
+	Completions *struct{}       `json:"completions,omitempty"`
+	Extensions  map[string]any  `json:"extensions,omitempty"`
+}
+
+// ToolsCap describes the server's tools capability.
+type ToolsCap struct {
+	ListChanged bool `json:"listChanged,omitempty"`
+}
+
+// ResourcesCap describes the server's resources capability.
+type ResourcesCap struct {
+	Subscribe   bool `json:"subscribe,omitempty"`
+	ListChanged bool `json:"listChanged,omitempty"`
+}
+
+// PromptsCap describes the server's prompts capability.
+type PromptsCap struct {
+	ListChanged bool `json:"listChanged,omitempty"`
+}
+
 // StreamableHTTPAccept is the Accept header value for Streamable HTTP requests.
 // Per MCP spec: clients MUST include both application/json and text/event-stream.
 const StreamableHTTPAccept = "application/json, text/event-stream"

--- a/server/auth_integration_test.go
+++ b/server/auth_integration_test.go
@@ -246,7 +246,7 @@ func TestAnnotationsOnToolDef(t *testing.T) {
 		},
 	)
 
-	entry, ok := srv.dispatcher.tools["beta-tool"]
+	entry, ok := srv.dispatcher.Reg.tools["beta-tool"]
 	if !ok {
 		t.Fatal("tool not registered")
 	}

--- a/server/dispatch.go
+++ b/server/dispatch.go
@@ -23,19 +23,8 @@ type pendingMap = sync.Map
 
 // Dispatcher routes JSON-RPC requests to the appropriate handler.
 type Dispatcher struct {
-	tools      map[string]toolEntry
-	toolOrder  []string // preserves registration order for tools/list
+	Reg        *Registry
 	serverInfo core.ServerInfo
-
-	resources     map[string]resourceEntry
-	resourceOrder []string
-	templates     map[string]templateEntry
-	templateOrder []string
-
-	prompts     map[string]promptEntry
-	promptOrder []string
-
-	completions map[string]core.CompletionHandler // key: "ref/prompt:name" or "ref/resource:uri"
 
 	// extensions registered via WithExtension, keyed by extension ID.
 	extensions map[string]core.Extension
@@ -134,31 +123,19 @@ type initializeParams struct {
 // NewDispatcher creates a dispatcher with the given server identity.
 func NewDispatcher(info core.ServerInfo) *Dispatcher {
 	return &Dispatcher{
-		tools:       make(map[string]toolEntry),
-		resources:   make(map[string]resourceEntry),
-		templates:   make(map[string]templateEntry),
-		prompts:     make(map[string]promptEntry),
-		completions: make(map[string]core.CompletionHandler),
-		extensions:  make(map[string]core.Extension),
-		serverInfo:  info,
+		Reg:        NewRegistry(),
+		extensions: make(map[string]core.Extension),
+		serverInfo: info,
 	}
 }
 
-// newSession creates a new Dispatcher that shares all registries from d
+// newSession creates a new Dispatcher that shares the registry from d
 // but has fresh session state (not initialized, no client info).
-// Registries are shared by reference — safe because they are populated
-// before serving begins and never modified after.
+// The registry pointer is shared — all sessions see the same tools,
+// resources, and prompts. Thread-safe via registry.mu.
 func (d *Dispatcher) newSession() *Dispatcher {
 	return &Dispatcher{
-		tools:                d.tools,
-		toolOrder:            d.toolOrder,
-		resources:            d.resources,
-		resourceOrder:        d.resourceOrder,
-		templates:            d.templates,
-		templateOrder:        d.templateOrder,
-		prompts:              d.prompts,
-		promptOrder:          d.promptOrder,
-		completions:          d.completions,
+		Reg:                  d.Reg,
 		extensions:           d.extensions,
 		serverInfo:           d.serverInfo,
 		subscriptionsEnabled: d.subscriptionsEnabled,
@@ -171,34 +148,30 @@ func (d *Dispatcher) NegotiatedVersion() string {
 	return d.negotiatedVersion
 }
 
-// RegisterTool adds a tool to the dispatcher.
+// RegisterTool adds a tool to the dispatcher's registry.
 func (d *Dispatcher) RegisterTool(def core.ToolDef, handler core.ToolHandler) {
-	d.tools[def.Name] = toolEntry{def: def, handler: handler}
-	d.toolOrder = append(d.toolOrder, def.Name)
+	d.Reg.AddTool(def, handler)
 }
 
-// RegisterResource adds a resource to the dispatcher.
+// RegisterResource adds a resource to the dispatcher's registry.
 func (d *Dispatcher) RegisterResource(def core.ResourceDef, handler core.ResourceHandler) {
-	d.resources[def.URI] = resourceEntry{def: def, handler: handler}
-	d.resourceOrder = append(d.resourceOrder, def.URI)
+	d.Reg.AddResource(def, handler)
 }
 
-// RegisterResourceTemplate adds a URI template resource to the dispatcher.
+// RegisterResourceTemplate adds a URI template resource to the dispatcher's registry.
 func (d *Dispatcher) RegisterResourceTemplate(def core.ResourceTemplate, handler core.TemplateHandler) {
-	d.templates[def.URITemplate] = templateEntry{def: def, handler: handler}
-	d.templateOrder = append(d.templateOrder, def.URITemplate)
+	d.Reg.AddResourceTemplate(def, handler)
 }
 
-// RegisterPrompt adds a prompt to the dispatcher.
+// RegisterPrompt adds a prompt to the dispatcher's registry.
 func (d *Dispatcher) RegisterPrompt(def core.PromptDef, handler core.PromptHandler) {
-	d.prompts[def.Name] = promptEntry{def: def, handler: handler}
-	d.promptOrder = append(d.promptOrder, def.Name)
+	d.Reg.AddPrompt(def, handler)
 }
 
 // RegisterCompletion registers a completion handler for a specific reference.
 // refType is "ref/prompt" or "ref/resource". name is the prompt name or resource URI template.
 func (d *Dispatcher) RegisterCompletion(refType, name string, handler core.CompletionHandler) {
-	d.completions[refType+":"+name] = handler
+	d.Reg.AddCompletion(refType, name, handler)
 }
 
 // Dispatch routes a JSON-RPC request and returns the response.
@@ -288,20 +261,16 @@ func (d *Dispatcher) handleInitialize(id json.RawMessage, params json.RawMessage
 	d.clientCaps = p.Capabilities
 	d.clientInfo = p.ClientInfo
 
-	caps := map[string]any{
-		"tools":       map[string]any{},
-		"logging":     map[string]any{},
-		"completions": map[string]any{},
-	}
-	if len(d.resources) > 0 || len(d.templates) > 0 {
-		resCap := map[string]any{}
-		if d.subscriptionsEnabled {
-			resCap["subscribe"] = true
-		}
-		caps["resources"] = resCap
-	}
-	if len(d.prompts) > 0 {
-		caps["prompts"] = map[string]any{}
+	// Advertise listChanged: true for tools, resources, and prompts so
+	// clients know to listen for list_changed notifications. This is always
+	// safe — it just means "I might send list_changed notifications." Servers
+	// that never mutate the registry will simply never send them.
+	caps := core.ServerCapabilities{
+		Tools:       &core.ToolsCap{ListChanged: true},
+		Resources:   &core.ResourcesCap{ListChanged: true, Subscribe: d.subscriptionsEnabled},
+		Prompts:     &core.PromptsCap{ListChanged: true},
+		Logging:     &struct{}{},
+		Completions: &struct{}{},
 	}
 	if len(d.extensions) > 0 {
 		exts := make(map[string]any, len(d.extensions))
@@ -311,7 +280,7 @@ func (d *Dispatcher) handleInitialize(id json.RawMessage, params json.RawMessage
 				"stability":  string(ext.Stability),
 			}
 		}
-		caps["extensions"] = exts
+		caps.Extensions = exts
 	}
 
 	result := map[string]any{
@@ -323,12 +292,14 @@ func (d *Dispatcher) handleInitialize(id json.RawMessage, params json.RawMessage
 }
 
 func (d *Dispatcher) handleToolsList(id json.RawMessage, params json.RawMessage) *core.Response {
-	tools := make([]core.ToolDef, 0, len(d.toolOrder))
-	for _, name := range d.toolOrder {
-		if entry, ok := d.tools[name]; ok {
+	d.Reg.mu.RLock()
+	tools := make([]core.ToolDef, 0, len(d.Reg.toolOrder))
+	for _, name := range d.Reg.toolOrder {
+		if entry, ok := d.Reg.tools[name]; ok {
 			tools = append(tools, entry.def)
 		}
 	}
+	d.Reg.mu.RUnlock()
 	return core.NewResponse(id, map[string]any{"tools": tools})
 }
 
@@ -344,7 +315,9 @@ func (d *Dispatcher) handleToolsCall(ctx context.Context, id json.RawMessage, pa
 		return core.NewErrorResponse(id, core.ErrCodeInvalidParams, err.Error())
 	}
 
-	entry, ok := d.tools[envelope.Name]
+	d.Reg.mu.RLock()
+	entry, ok := d.Reg.tools[envelope.Name]
+	d.Reg.mu.RUnlock()
 	if !ok {
 		return core.NewErrorResponse(id, core.ErrCodeInvalidParams, "unknown tool: "+envelope.Name)
 	}
@@ -369,12 +342,14 @@ func (d *Dispatcher) handleToolsCall(ctx context.Context, id json.RawMessage, pa
 // --- Resources ---
 
 func (d *Dispatcher) handleResourcesList(id json.RawMessage, params json.RawMessage) *core.Response {
-	resources := make([]core.ResourceDef, 0, len(d.resourceOrder))
-	for _, uri := range d.resourceOrder {
-		if entry, ok := d.resources[uri]; ok {
+	d.Reg.mu.RLock()
+	resources := make([]core.ResourceDef, 0, len(d.Reg.resourceOrder))
+	for _, uri := range d.Reg.resourceOrder {
+		if entry, ok := d.Reg.resources[uri]; ok {
 			resources = append(resources, entry.def)
 		}
 	}
+	d.Reg.mu.RUnlock()
 	return core.NewResponse(id, map[string]any{"resources": resources})
 }
 
@@ -386,8 +361,10 @@ func (d *Dispatcher) handleResourcesRead(ctx context.Context, id json.RawMessage
 		return core.NewErrorResponse(id, core.ErrCodeInvalidParams, err.Error())
 	}
 
-	// Try exact match first
-	if entry, ok := d.resources[envelope.URI]; ok {
+	// Look up handler under RLock, execute outside lock
+	d.Reg.mu.RLock()
+	if entry, ok := d.Reg.resources[envelope.URI]; ok {
+		d.Reg.mu.RUnlock()
 		result, err := entry.handler(ctx, core.ResourceRequest{URI: envelope.URI})
 		if err != nil {
 			return core.NewErrorResponse(id, core.ErrCodeInternal, fmt.Sprintf("resource %q: %v", envelope.URI, err))
@@ -396,27 +373,41 @@ func (d *Dispatcher) handleResourcesRead(ctx context.Context, id json.RawMessage
 	}
 
 	// Try template match
-	for _, tmplURI := range d.templateOrder {
-		entry := d.templates[tmplURI]
-		if params, matched := matchTemplate(entry.def.URITemplate, envelope.URI); matched {
-			result, err := entry.handler(ctx, envelope.URI, params)
-			if err != nil {
-				return core.NewErrorResponse(id, core.ErrCodeInternal, fmt.Sprintf("resource template %q: %v", tmplURI, err))
-			}
-			return core.NewResponse(id, result)
+	var matchedHandler core.TemplateHandler
+	var matchedURI, matchedTmplURI string
+	var matchedParams map[string]string
+	for _, tmplURI := range d.Reg.templateOrder {
+		entry := d.Reg.templates[tmplURI]
+		if p, matched := matchTemplate(entry.def.URITemplate, envelope.URI); matched {
+			matchedHandler = entry.handler
+			matchedURI = envelope.URI
+			matchedTmplURI = tmplURI
+			matchedParams = p
+			break
 		}
+	}
+	d.Reg.mu.RUnlock()
+
+	if matchedHandler != nil {
+		result, err := matchedHandler(ctx, matchedURI, matchedParams)
+		if err != nil {
+			return core.NewErrorResponse(id, core.ErrCodeInternal, fmt.Sprintf("resource template %q: %v", matchedTmplURI, err))
+		}
+		return core.NewResponse(id, result)
 	}
 
 	return core.NewErrorResponse(id, core.ErrCodeInvalidParams, "unknown resource: "+envelope.URI)
 }
 
 func (d *Dispatcher) handleResourcesTemplatesList(id json.RawMessage, params json.RawMessage) *core.Response {
-	templates := make([]core.ResourceTemplate, 0, len(d.templateOrder))
-	for _, uri := range d.templateOrder {
-		if entry, ok := d.templates[uri]; ok {
+	d.Reg.mu.RLock()
+	templates := make([]core.ResourceTemplate, 0, len(d.Reg.templateOrder))
+	for _, uri := range d.Reg.templateOrder {
+		if entry, ok := d.Reg.templates[uri]; ok {
 			templates = append(templates, entry.def)
 		}
 	}
+	d.Reg.mu.RUnlock()
 	return core.NewResponse(id, map[string]any{"resourceTemplates": templates})
 }
 
@@ -456,12 +447,14 @@ func (d *Dispatcher) handleResourcesUnsubscribe(id json.RawMessage, params json.
 // --- Prompts ---
 
 func (d *Dispatcher) handlePromptsList(id json.RawMessage, params json.RawMessage) *core.Response {
-	prompts := make([]core.PromptDef, 0, len(d.promptOrder))
-	for _, name := range d.promptOrder {
-		if entry, ok := d.prompts[name]; ok {
+	d.Reg.mu.RLock()
+	prompts := make([]core.PromptDef, 0, len(d.Reg.promptOrder))
+	for _, name := range d.Reg.promptOrder {
+		if entry, ok := d.Reg.prompts[name]; ok {
 			prompts = append(prompts, entry.def)
 		}
 	}
+	d.Reg.mu.RUnlock()
 	return core.NewResponse(id, map[string]any{"prompts": prompts})
 }
 
@@ -474,7 +467,9 @@ func (d *Dispatcher) handlePromptsGet(ctx context.Context, id json.RawMessage, p
 		return core.NewErrorResponse(id, core.ErrCodeInvalidParams, err.Error())
 	}
 
-	entry, ok := d.prompts[envelope.Name]
+	d.Reg.mu.RLock()
+	entry, ok := d.Reg.prompts[envelope.Name]
+	d.Reg.mu.RUnlock()
 	if !ok {
 		return core.NewErrorResponse(id, core.ErrCodeInvalidParams, "unknown prompt: "+envelope.Name)
 	}
@@ -515,7 +510,9 @@ func (d *Dispatcher) handleCompletionComplete(ctx context.Context, id json.RawMe
 		key += p.Ref.URI
 	}
 
-	handler, ok := d.completions[key]
+	d.Reg.mu.RLock()
+	handler, ok := d.Reg.completions[key]
+	d.Reg.mu.RUnlock()
 	if !ok {
 		// No handler registered — return empty completion (graceful fallback)
 		return core.NewResponse(id, map[string]any{

--- a/server/dynamic_test.go
+++ b/server/dynamic_test.go
@@ -1,0 +1,422 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	core "github.com/panyam/mcpkit/core"
+)
+
+// helper: creates an initialized dispatcher with an empty registry.
+func testDynamicDispatcher() *Dispatcher {
+	d := NewDispatcher(core.ServerInfo{Name: "dynamic-test", Version: "1.0.0"})
+	initDispatcher(d)
+	return d
+}
+
+// helper: creates a server with a session wired to capture broadcast notifications.
+// Returns the server and a function that returns all captured notification methods.
+func testDynamicServer() (*Server, func() []string) {
+	srv := NewServer(core.ServerInfo{Name: "dynamic-test", Version: "1.0.0"})
+
+	d := srv.newSession()
+	d.sessionID = "test-session"
+
+	var mu sync.Mutex
+	var methods []string
+	d.SetNotifyFunc(func(method string, params any) {
+		mu.Lock()
+		defer mu.Unlock()
+		methods = append(methods, method)
+	})
+
+	srv.registerTransportSessions(
+		func(id string) bool { return false },
+		func() {},
+		func(method string, params any) {
+			if fn := d.getNotifyFunc(); fn != nil {
+				fn(method, params)
+			}
+		},
+	)
+
+	return srv, func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		out := make([]string, len(methods))
+		copy(out, methods)
+		methods = methods[:0] // drain on read
+		return out
+	}
+}
+
+// TestAddToolAfterServing verifies that a tool added via Registry().AddTool
+// after sessions are connected appears in the tools/list response. This is
+// the core dynamic registration test — tools registered at runtime must be
+// visible to existing sessions because the registry is shared by pointer.
+func TestAddToolAfterServing(t *testing.T) {
+	d := testDynamicDispatcher()
+
+	// Initially no tools
+	resp := d.Dispatch(context.Background(), &core.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "tools/list",
+	})
+	assertToolCount(t, resp, 0)
+
+	// Add a tool at runtime
+	d.Reg.AddTool(
+		core.ToolDef{Name: "dynamic", Description: "Added at runtime"},
+		func(ctx context.Context, req core.ToolRequest) (core.ToolResult, error) {
+			return core.TextResult("dynamic"), nil
+		},
+	)
+
+	// Now tools/list should return it
+	resp = d.Dispatch(context.Background(), &core.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`2`), Method: "tools/list",
+	})
+	assertToolCount(t, resp, 1)
+}
+
+// TestRemoveTool verifies that removing a tool via Registry().RemoveTool
+// causes it to disappear from tools/list and makes tools/call return an error.
+func TestRemoveTool(t *testing.T) {
+	d := testDynamicDispatcher()
+
+	d.Reg.AddTool(
+		core.ToolDef{Name: "ephemeral", Description: "Will be removed"},
+		func(ctx context.Context, req core.ToolRequest) (core.ToolResult, error) {
+			return core.TextResult("here"), nil
+		},
+	)
+
+	// Tool works
+	resp := d.Dispatch(context.Background(), &core.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "tools/call",
+		Params: json.RawMessage(`{"name":"ephemeral"}`),
+	})
+	if resp.Error != nil {
+		t.Fatalf("tool call before removal failed: %s", resp.Error.Message)
+	}
+
+	// Remove it
+	if !d.Reg.RemoveTool("ephemeral") {
+		t.Fatal("RemoveTool returned false for existing tool")
+	}
+
+	// tools/list should be empty
+	resp = d.Dispatch(context.Background(), &core.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`2`), Method: "tools/list",
+	})
+	assertToolCount(t, resp, 0)
+
+	// tools/call should fail
+	resp = d.Dispatch(context.Background(), &core.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`3`), Method: "tools/call",
+		Params: json.RawMessage(`{"name":"ephemeral"}`),
+	})
+	if resp.Error == nil {
+		t.Fatal("tool call after removal should fail")
+	}
+}
+
+// TestRemoveToolNotFound verifies that RemoveTool returns false for a
+// tool that does not exist, and does not panic or modify the registry.
+func TestRemoveToolNotFound(t *testing.T) {
+	reg := NewRegistry()
+	if reg.RemoveTool("nonexistent") {
+		t.Fatal("RemoveTool returned true for nonexistent tool")
+	}
+}
+
+// TestAddToolBroadcastsListChanged verifies that adding a tool via
+// Registry().AddTool triggers an automatic notifications/tools/list_changed
+// broadcast to all connected sessions via the OnChange callback.
+func TestAddToolBroadcastsListChanged(t *testing.T) {
+	srv, captured := testDynamicServer()
+
+	srv.Registry().AddTool(
+		core.ToolDef{Name: "notified", Description: "triggers broadcast"},
+		func(ctx context.Context, req core.ToolRequest) (core.ToolResult, error) {
+			return core.TextResult("ok"), nil
+		},
+	)
+
+	methods := captured()
+	if len(methods) != 1 || methods[0] != "notifications/tools/list_changed" {
+		t.Fatalf("expected [notifications/tools/list_changed], got %v", methods)
+	}
+}
+
+// TestRemoveToolBroadcastsListChanged verifies that removing a tool
+// broadcasts notifications/tools/list_changed, but removing a nonexistent
+// tool does not broadcast.
+func TestRemoveToolBroadcastsListChanged(t *testing.T) {
+	srv, captured := testDynamicServer()
+
+	srv.Registry().AddTool(
+		core.ToolDef{Name: "temp", Description: "temp"},
+		func(ctx context.Context, req core.ToolRequest) (core.ToolResult, error) {
+			return core.TextResult("ok"), nil
+		},
+	)
+
+	// Clear captured from AddTool
+	_ = captured()
+
+	// Remove existing tool — should broadcast
+	srv.Registry().RemoveTool("temp")
+	methods := captured()
+	if len(methods) != 1 || methods[0] != "notifications/tools/list_changed" {
+		t.Fatalf("expected [notifications/tools/list_changed] on remove, got %v", methods)
+	}
+
+	// Remove nonexistent — should NOT broadcast
+	srv.Registry().RemoveTool("temp")
+	methods = captured()
+	if len(methods) != 0 {
+		t.Fatalf("expected no broadcast on remove-nonexistent, got %v", methods)
+	}
+}
+
+// TestAddResourceAfterServing verifies that dynamically added resources
+// appear in resources/list and can be read via resources/read.
+func TestAddResourceAfterServing(t *testing.T) {
+	d := testDynamicDispatcher()
+
+	d.Reg.AddResource(
+		core.ResourceDef{URI: "test://dynamic", Name: "Dynamic Resource"},
+		func(ctx context.Context, req core.ResourceRequest) (core.ResourceResult, error) {
+			return core.ResourceResult{Contents: []core.ResourceReadContent{
+				{URI: req.URI, Text: "dynamic content"},
+			}}, nil
+		},
+	)
+
+	// resources/list
+	resp := d.Dispatch(context.Background(), &core.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "resources/list",
+	})
+	raw, _ := json.Marshal(resp.Result)
+	if !json.Valid(raw) {
+		t.Fatal("invalid result JSON")
+	}
+	var result struct {
+		Resources []core.ResourceDef `json:"resources"`
+	}
+	json.Unmarshal(raw, &result)
+	if len(result.Resources) != 1 || result.Resources[0].URI != "test://dynamic" {
+		t.Fatalf("unexpected resources: %+v", result.Resources)
+	}
+}
+
+// TestRemoveResource verifies that removing a resource makes it disappear
+// from resources/list and makes resources/read return an error.
+func TestRemoveResource(t *testing.T) {
+	d := testDynamicDispatcher()
+
+	d.Reg.AddResource(
+		core.ResourceDef{URI: "test://temp", Name: "Temp"},
+		func(ctx context.Context, req core.ResourceRequest) (core.ResourceResult, error) {
+			return core.ResourceResult{Contents: []core.ResourceReadContent{
+				{URI: req.URI, Text: "temp"},
+			}}, nil
+		},
+	)
+
+	if !d.Reg.RemoveResource("test://temp") {
+		t.Fatal("RemoveResource returned false")
+	}
+
+	resp := d.Dispatch(context.Background(), &core.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "resources/read",
+		Params: json.RawMessage(`{"uri":"test://temp"}`),
+	})
+	if resp.Error == nil {
+		t.Fatal("resources/read should fail after removal")
+	}
+}
+
+// TestAddResourceBroadcastsListChanged verifies that adding a resource
+// triggers notifications/resources/list_changed.
+func TestAddResourceBroadcastsListChanged(t *testing.T) {
+	srv, captured := testDynamicServer()
+
+	srv.Registry().AddResource(
+		core.ResourceDef{URI: "test://r", Name: "R"},
+		func(ctx context.Context, req core.ResourceRequest) (core.ResourceResult, error) {
+			return core.ResourceResult{}, nil
+		},
+	)
+
+	methods := captured()
+	if len(methods) != 1 || methods[0] != "notifications/resources/list_changed" {
+		t.Fatalf("expected [notifications/resources/list_changed], got %v", methods)
+	}
+}
+
+// TestAddPromptAfterServing verifies that dynamically added prompts
+// appear in prompts/list and can be retrieved via prompts/get.
+func TestAddPromptAfterServing(t *testing.T) {
+	d := testDynamicDispatcher()
+
+	d.Reg.AddPrompt(
+		core.PromptDef{Name: "dynamic-prompt", Description: "Added at runtime"},
+		func(ctx context.Context, req core.PromptRequest) (core.PromptResult, error) {
+			return core.PromptResult{Messages: []core.PromptMessage{
+				{Role: "assistant", Content: core.Content{Type: "text", Text: "dynamic"}},
+			}}, nil
+		},
+	)
+
+	resp := d.Dispatch(context.Background(), &core.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "prompts/list",
+	})
+	raw, _ := json.Marshal(resp.Result)
+	var result struct {
+		Prompts []core.PromptDef `json:"prompts"`
+	}
+	json.Unmarshal(raw, &result)
+	if len(result.Prompts) != 1 || result.Prompts[0].Name != "dynamic-prompt" {
+		t.Fatalf("unexpected prompts: %+v", result.Prompts)
+	}
+}
+
+// TestRemovePrompt verifies that removing a prompt makes it disappear
+// from prompts/list and makes prompts/get return an error.
+func TestRemovePrompt(t *testing.T) {
+	d := testDynamicDispatcher()
+
+	d.Reg.AddPrompt(
+		core.PromptDef{Name: "temp-prompt", Description: "Temp"},
+		func(ctx context.Context, req core.PromptRequest) (core.PromptResult, error) {
+			return core.PromptResult{}, nil
+		},
+	)
+
+	if !d.Reg.RemovePrompt("temp-prompt") {
+		t.Fatal("RemovePrompt returned false")
+	}
+
+	resp := d.Dispatch(context.Background(), &core.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "prompts/get",
+		Params: json.RawMessage(`{"name":"temp-prompt"}`),
+	})
+	if resp.Error == nil {
+		t.Fatal("prompts/get should fail after removal")
+	}
+}
+
+// TestAddPromptBroadcastsListChanged verifies that adding a prompt
+// triggers notifications/prompts/list_changed.
+func TestAddPromptBroadcastsListChanged(t *testing.T) {
+	srv, captured := testDynamicServer()
+
+	srv.Registry().AddPrompt(
+		core.PromptDef{Name: "p", Description: "P"},
+		func(ctx context.Context, req core.PromptRequest) (core.PromptResult, error) {
+			return core.PromptResult{}, nil
+		},
+	)
+
+	methods := captured()
+	if len(methods) != 1 || methods[0] != "notifications/prompts/list_changed" {
+		t.Fatalf("expected [notifications/prompts/list_changed], got %v", methods)
+	}
+}
+
+// TestConcurrentAddAndList verifies that concurrent AddTool and tools/list
+// operations do not race. This test is meaningful under -race; without the
+// race detector it will pass even with broken locking, but with -race it
+// catches missing synchronization.
+func TestConcurrentAddAndList(t *testing.T) {
+	d := testDynamicDispatcher()
+
+	var wg sync.WaitGroup
+	var adds atomic.Int32
+
+	// 10 goroutines adding tools
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			d.Reg.AddTool(
+				core.ToolDef{Name: json.Number(json.Number(string(rune('a'+i)))).String(), Description: "concurrent"},
+				func(ctx context.Context, req core.ToolRequest) (core.ToolResult, error) {
+					return core.TextResult("ok"), nil
+				},
+			)
+			adds.Add(1)
+		}(i)
+	}
+
+	// 10 goroutines listing tools
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			d.Dispatch(context.Background(), &core.Request{
+				JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "tools/list",
+			})
+		}()
+	}
+
+	wg.Wait()
+
+	if adds.Load() != 10 {
+		t.Fatalf("expected 10 adds, got %d", adds.Load())
+	}
+}
+
+// TestListChangedCapabilityAdvertised verifies that the initialize response
+// includes listChanged: true for tools, resources, and prompts capabilities,
+// so clients know to listen for list_changed notifications.
+func TestListChangedCapabilityAdvertised(t *testing.T) {
+	d := NewDispatcher(core.ServerInfo{Name: "test", Version: "1.0"})
+
+	resp := d.Dispatch(context.Background(), &core.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "initialize",
+		Params: json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`),
+	})
+
+	raw, _ := json.Marshal(resp.Result)
+	var result struct {
+		Capabilities struct {
+			Tools     struct{ ListChanged bool `json:"listChanged"` } `json:"tools"`
+			Resources struct{ ListChanged bool `json:"listChanged"` } `json:"resources"`
+			Prompts   struct{ ListChanged bool `json:"listChanged"` } `json:"prompts"`
+		} `json:"capabilities"`
+	}
+	if err := json.Unmarshal(raw, &result); err != nil {
+		t.Fatalf("failed to parse result: %v", err)
+	}
+	if !result.Capabilities.Tools.ListChanged {
+		t.Error("tools.listChanged should be true")
+	}
+	if !result.Capabilities.Resources.ListChanged {
+		t.Error("resources.listChanged should be true")
+	}
+	if !result.Capabilities.Prompts.ListChanged {
+		t.Error("prompts.listChanged should be true")
+	}
+}
+
+// assertToolCount is a helper that verifies a tools/list response contains
+// exactly n tools.
+func assertToolCount(t *testing.T, resp *core.Response, n int) {
+	t.Helper()
+	if resp.Error != nil {
+		t.Fatalf("tools/list failed: %s", resp.Error.Message)
+	}
+	raw, _ := json.Marshal(resp.Result)
+	var result struct {
+		Tools []core.ToolDef `json:"tools"`
+	}
+	json.Unmarshal(raw, &result)
+	if len(result.Tools) != n {
+		t.Fatalf("expected %d tools, got %d", n, len(result.Tools))
+	}
+}

--- a/server/registry.go
+++ b/server/registry.go
@@ -1,0 +1,178 @@
+package server
+
+import (
+	core "github.com/panyam/mcpkit/core"
+	"sync"
+)
+
+// RegistryChangeFunc is called after a registry mutation with the
+// notification method that should be broadcast (e.g.,
+// "notifications/tools/list_changed").
+type RegistryChangeFunc func(method string)
+
+// Registry holds all tool, resource, prompt, and completion registrations.
+// Shared by reference across all session Dispatchers so that dynamic
+// adds/removes are immediately visible to every session.
+// Protected by mu: readers (list/call handlers) acquire RLock,
+// writers (AddTool/RemoveTool etc.) acquire Lock.
+//
+// When OnChange is set, it is called after every mutation with the
+// appropriate list_changed notification method. The Server wires this
+// to Broadcast so that connected clients are notified automatically.
+type Registry struct {
+	mu       sync.RWMutex
+	OnChange RegistryChangeFunc // called after mutations; nil = no notification
+
+	tools     map[string]toolEntry
+	toolOrder []string
+
+	resources     map[string]resourceEntry
+	resourceOrder []string
+	templates     map[string]templateEntry
+	templateOrder []string
+
+	prompts     map[string]promptEntry
+	promptOrder []string
+
+	completions map[string]core.CompletionHandler // key: "ref/prompt:name" or "ref/resource:uri"
+}
+
+// NewRegistry creates an empty registry with initialized maps.
+func NewRegistry() *Registry {
+	return &Registry{
+		tools:       make(map[string]toolEntry),
+		resources:   make(map[string]resourceEntry),
+		templates:   make(map[string]templateEntry),
+		prompts:     make(map[string]promptEntry),
+		completions: make(map[string]core.CompletionHandler),
+	}
+}
+
+// notify calls OnChange if set. Must be called outside the write lock.
+func (r *Registry) notify(method string) {
+	if r.OnChange != nil {
+		r.OnChange(method)
+	}
+}
+
+// AddTool adds a tool to the registry. Thread-safe.
+// Broadcasts notifications/tools/list_changed if OnChange is set.
+func (r *Registry) AddTool(def core.ToolDef, handler core.ToolHandler) {
+	r.mu.Lock()
+	r.tools[def.Name] = toolEntry{def: def, handler: handler}
+	r.toolOrder = append(r.toolOrder, def.Name)
+	r.mu.Unlock()
+	r.notify("notifications/tools/list_changed")
+}
+
+// RemoveTool removes a tool by name. Returns true if it existed. Thread-safe.
+// Broadcasts notifications/tools/list_changed if the tool was removed.
+func (r *Registry) RemoveTool(name string) bool {
+	r.mu.Lock()
+	_, ok := r.tools[name]
+	if ok {
+		delete(r.tools, name)
+		r.toolOrder = removeFromOrder(r.toolOrder, name)
+	}
+	r.mu.Unlock()
+	if ok {
+		r.notify("notifications/tools/list_changed")
+	}
+	return ok
+}
+
+// AddResource adds a resource to the registry. Thread-safe.
+// Broadcasts notifications/resources/list_changed if OnChange is set.
+func (r *Registry) AddResource(def core.ResourceDef, handler core.ResourceHandler) {
+	r.mu.Lock()
+	r.resources[def.URI] = resourceEntry{def: def, handler: handler}
+	r.resourceOrder = append(r.resourceOrder, def.URI)
+	r.mu.Unlock()
+	r.notify("notifications/resources/list_changed")
+}
+
+// RemoveResource removes a resource by URI. Returns true if it existed. Thread-safe.
+// Broadcasts notifications/resources/list_changed if the resource was removed.
+func (r *Registry) RemoveResource(uri string) bool {
+	r.mu.Lock()
+	_, ok := r.resources[uri]
+	if ok {
+		delete(r.resources, uri)
+		r.resourceOrder = removeFromOrder(r.resourceOrder, uri)
+	}
+	r.mu.Unlock()
+	if ok {
+		r.notify("notifications/resources/list_changed")
+	}
+	return ok
+}
+
+// AddResourceTemplate adds a resource template to the registry. Thread-safe.
+// Broadcasts notifications/resources/list_changed if OnChange is set.
+func (r *Registry) AddResourceTemplate(def core.ResourceTemplate, handler core.TemplateHandler) {
+	r.mu.Lock()
+	r.templates[def.URITemplate] = templateEntry{def: def, handler: handler}
+	r.templateOrder = append(r.templateOrder, def.URITemplate)
+	r.mu.Unlock()
+	r.notify("notifications/resources/list_changed")
+}
+
+// RemoveResourceTemplate removes a resource template by URI template.
+// Returns true if it existed. Thread-safe.
+// Broadcasts notifications/resources/list_changed if the template was removed.
+func (r *Registry) RemoveResourceTemplate(uriTemplate string) bool {
+	r.mu.Lock()
+	_, ok := r.templates[uriTemplate]
+	if ok {
+		delete(r.templates, uriTemplate)
+		r.templateOrder = removeFromOrder(r.templateOrder, uriTemplate)
+	}
+	r.mu.Unlock()
+	if ok {
+		r.notify("notifications/resources/list_changed")
+	}
+	return ok
+}
+
+// AddPrompt adds a prompt to the registry. Thread-safe.
+// Broadcasts notifications/prompts/list_changed if OnChange is set.
+func (r *Registry) AddPrompt(def core.PromptDef, handler core.PromptHandler) {
+	r.mu.Lock()
+	r.prompts[def.Name] = promptEntry{def: def, handler: handler}
+	r.promptOrder = append(r.promptOrder, def.Name)
+	r.mu.Unlock()
+	r.notify("notifications/prompts/list_changed")
+}
+
+// RemovePrompt removes a prompt by name. Returns true if it existed. Thread-safe.
+// Broadcasts notifications/prompts/list_changed if the prompt was removed.
+func (r *Registry) RemovePrompt(name string) bool {
+	r.mu.Lock()
+	_, ok := r.prompts[name]
+	if ok {
+		delete(r.prompts, name)
+		r.promptOrder = removeFromOrder(r.promptOrder, name)
+	}
+	r.mu.Unlock()
+	if ok {
+		r.notify("notifications/prompts/list_changed")
+	}
+	return ok
+}
+
+// AddCompletion adds a completion handler. Thread-safe.
+func (r *Registry) AddCompletion(refType, name string, handler core.CompletionHandler) {
+	r.mu.Lock()
+	r.completions[refType+":"+name] = handler
+	r.mu.Unlock()
+}
+
+// removeFromOrder removes the first occurrence of key from a string slice.
+func removeFromOrder(order []string, key string) []string {
+	for i, v := range order {
+		if v == key {
+			return append(order[:i], order[i+1:]...)
+		}
+	}
+	return order
+}

--- a/server/server.go
+++ b/server/server.go
@@ -118,6 +118,11 @@ func NewServer(info core.ServerInfo, opts ...Option) *Server {
 		e := ext.Extension()
 		s.dispatcher.extensions[e.ID] = e
 	}
+	// Wire registry change notifications to Server.Broadcast so that
+	// dynamic adds/removes automatically notify all connected sessions.
+	s.dispatcher.Reg.OnChange = func(method string) {
+		s.Broadcast(method, nil)
+	}
 	// Initialize subscription support if enabled
 	if s.options.subscriptionsEnabled {
 		s.subRegistry = &subscriptionRegistry{
@@ -152,17 +157,20 @@ func (s *Server) validateExtensionRefs() {
 		logger = log.Default()
 	}
 
-	// Collect tool defs, resource URIs, and template URIs
-	tools := make([]core.ToolDef, 0, len(s.dispatcher.toolOrder))
-	for _, name := range s.dispatcher.toolOrder {
-		if entry, ok := s.dispatcher.tools[name]; ok {
+	// Collect tool defs, resource URIs, and template URIs under read lock
+	reg := s.dispatcher.Reg
+	reg.mu.RLock()
+	tools := make([]core.ToolDef, 0, len(reg.toolOrder))
+	for _, name := range reg.toolOrder {
+		if entry, ok := reg.tools[name]; ok {
 			tools = append(tools, entry.def)
 		}
 	}
-	resourceURIs := make([]string, len(s.dispatcher.resourceOrder))
-	copy(resourceURIs, s.dispatcher.resourceOrder)
-	templateURIs := make([]string, len(s.dispatcher.templateOrder))
-	copy(templateURIs, s.dispatcher.templateOrder)
+	resourceURIs := make([]string, len(reg.resourceOrder))
+	copy(resourceURIs, reg.resourceOrder)
+	templateURIs := make([]string, len(reg.templateOrder))
+	copy(templateURIs, reg.templateOrder)
+	reg.mu.RUnlock()
 
 	for _, ext := range s.options.extensions {
 		if rv, ok := ext.(core.RefValidator); ok {
@@ -209,6 +217,15 @@ func (s *Server) RegisterExperimentalPrompt(def core.PromptDef, handler core.Pro
 // refType is "ref/prompt" or "ref/resource". name is the prompt name or resource URI template.
 func (s *Server) RegisterCompletion(refType, name string, handler core.CompletionHandler) {
 	s.dispatcher.RegisterCompletion(refType, name, handler)
+}
+
+// Registry returns the server's shared registry. All session dispatchers
+// share this registry, so changes (AddTool, RemoveTool, etc.) are
+// immediately visible to every session. When the server has active
+// sessions, mutations automatically broadcast the appropriate
+// notifications/*/list_changed notification.
+func (s *Server) Registry() *Registry {
+	return s.dispatcher.Reg
 }
 
 // Dispatch routes a JSON-RPC request through the server's dispatch layer.
@@ -514,7 +531,8 @@ type transportConfig struct {
 	allowedOrigins []string // allowed Origin values for DNS rebinding protection
 	streamableHTTP bool     // enable Streamable HTTP transport
 	sse            bool     // enable legacy SSE transport
-	stateless      bool     // stateless mode: no sessions, fresh dispatcher per request
+	stateless      bool          // stateless mode: no sessions, fresh dispatcher per request
+	sessionTimeout time.Duration // idle timeout for Streamable HTTP sessions (0 = no timeout)
 }
 
 func defaultTransportConfig() transportConfig {
@@ -561,6 +579,15 @@ func WithStreamableHTTP(enabled bool) TransportOption {
 // WithSSE enables or disables the legacy SSE transport (MCP 2024-11-05).
 func WithSSE(enabled bool) TransportOption {
 	return func(c *transportConfig) { c.sse = enabled }
+}
+
+// WithSessionTimeout sets the idle timeout for Streamable HTTP sessions.
+// Sessions that receive no POST requests for this duration are automatically
+// expired and cleaned up. Active requests (in-flight tool calls, open GET SSE
+// streams) pause the timer so sessions are never closed mid-execution.
+// Default is 0 (no timeout — sessions persist until explicit DELETE or server restart).
+func WithSessionTimeout(d time.Duration) TransportOption {
+	return func(c *transportConfig) { c.sessionTimeout = d }
 }
 
 // WithStateless enables stateless mode for the Streamable HTTP transport.

--- a/server/session_timeout_test.go
+++ b/server/session_timeout_test.go
@@ -1,0 +1,203 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	core "github.com/panyam/mcpkit/core"
+)
+
+// testStreamableServerWithTimeout creates an httptest.Server with a configurable
+// session timeout and an echo tool. Accepts additional transport options.
+func testStreamableServerWithTimeout(timeout time.Duration, opts ...TransportOption) (*httptest.Server, *Server) {
+	srv := NewServer(core.ServerInfo{Name: "timeout-test", Version: "1.0"})
+	srv.RegisterTool(
+		core.ToolDef{Name: "echo", Description: "Echoes input", InputSchema: map[string]any{
+			"type": "object", "properties": map[string]any{"message": map[string]any{"type": "string"}},
+		}},
+		func(ctx context.Context, req core.ToolRequest) (core.ToolResult, error) {
+			var p struct{ Message string `json:"message"` }
+			req.Bind(&p)
+			return core.TextResult("echo: " + p.Message), nil
+		},
+	)
+	allOpts := append([]TransportOption{
+		WithStreamableHTTP(true), WithSSE(false),
+		WithSessionTimeout(timeout),
+	}, opts...)
+	ts := httptest.NewServer(srv.Handler(allOpts...))
+	return ts, srv
+}
+
+// TestSessionExpiresAfterTimeout verifies that a Streamable HTTP session is
+// automatically removed after the configured idle timeout elapses with no
+// activity. After expiry, subsequent requests with the old session ID
+// receive HTTP 404 "session not found".
+func TestSessionExpiresAfterTimeout(t *testing.T) {
+	ts, _ := testStreamableServerWithTimeout(100 * time.Millisecond)
+	defer ts.Close()
+
+	sessionID := streamableInit(t, ts.URL)
+
+	// Wait for timeout to fire
+	time.Sleep(250 * time.Millisecond)
+
+	// Session should be gone
+	resp, err := streamablePost(ts.URL+"/mcp", sessionID, &core.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "tools/list",
+	})
+	if err != nil {
+		t.Fatalf("POST failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 404 after timeout, got %d: %s", resp.StatusCode, body)
+	}
+}
+
+// TestSessionTimeoutResetsOnActivity verifies that each POST request to a
+// session resets the idle timer. If the client sends requests at intervals
+// shorter than the timeout, the session should remain alive indefinitely.
+func TestSessionTimeoutResetsOnActivity(t *testing.T) {
+	ts, _ := testStreamableServerWithTimeout(200 * time.Millisecond)
+	defer ts.Close()
+
+	sessionID := streamableInit(t, ts.URL)
+
+	// Send activity at 100ms intervals (< 200ms timeout) — session should survive
+	for i := 0; i < 4; i++ {
+		time.Sleep(100 * time.Millisecond)
+		resp, err := streamablePost(ts.URL+"/mcp", sessionID, &core.Request{
+			JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "tools/list",
+		})
+		if err != nil {
+			t.Fatalf("POST %d failed: %v", i, err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("POST %d status = %d, want 200 (session should still be alive)", i, resp.StatusCode)
+		}
+	}
+}
+
+// TestSessionTimeoutPausesDuringActiveRequest verifies that the idle timer
+// is paused while a tool call is executing. Even if the timeout duration
+// elapses during execution, the session must not be expired because the
+// acquire/release ref counting prevents it.
+func TestSessionTimeoutPausesDuringActiveRequest(t *testing.T) {
+	// Use a very short timeout (50ms) with a tool that takes 300ms
+	srv := NewServer(core.ServerInfo{Name: "slow-test", Version: "1.0"})
+	var called atomic.Bool
+	srv.RegisterTool(
+		core.ToolDef{Name: "slow", Description: "Takes a while"},
+		func(ctx context.Context, req core.ToolRequest) (core.ToolResult, error) {
+			called.Store(true)
+			time.Sleep(300 * time.Millisecond)
+			return core.TextResult("done"), nil
+		},
+	)
+	ts := httptest.NewServer(srv.Handler(
+		WithStreamableHTTP(true), WithSSE(false),
+		WithSessionTimeout(50*time.Millisecond),
+	))
+	defer ts.Close()
+
+	sessionID := streamableInit(t, ts.URL)
+
+	// Call slow tool — takes 300ms, timeout is 50ms
+	resp, err := streamablePost(ts.URL+"/mcp", sessionID, &core.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "tools/call",
+		Params: json.RawMessage(`{"name":"slow"}`),
+	})
+	if err != nil {
+		t.Fatalf("slow tool call failed: %v", err)
+	}
+	resp.Body.Close()
+
+	if !called.Load() {
+		t.Fatal("slow tool was not called")
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("slow tool call status = %d, want 200", resp.StatusCode)
+	}
+
+	// Session should still be alive immediately after (timer restarts on release)
+	resp2, err := streamablePost(ts.URL+"/mcp", sessionID, &core.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`2`), Method: "tools/list",
+	})
+	if err != nil {
+		t.Fatalf("POST after slow tool failed: %v", err)
+	}
+	resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("session died during active request: status = %d", resp2.StatusCode)
+	}
+}
+
+// TestSessionDeleteStopsTimer verifies that explicitly deleting a session
+// via HTTP DELETE stops the idle timer cleanly, with no crash or double-close.
+func TestSessionDeleteStopsTimer(t *testing.T) {
+	ts, _ := testStreamableServerWithTimeout(1 * time.Second)
+	defer ts.Close()
+
+	sessionID := streamableInit(t, ts.URL)
+
+	// DELETE the session
+	req, _ := http.NewRequest(http.MethodDelete, ts.URL+"/mcp", nil)
+	req.Header.Set(mcpSessionIDHeader, sessionID)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE failed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("DELETE status = %d, want 200", resp.StatusCode)
+	}
+
+	// Wait past the original timeout — should not panic
+	time.Sleep(200 * time.Millisecond)
+
+	// Verify session is gone
+	resp2, err := streamablePost(ts.URL+"/mcp", sessionID, &core.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "tools/list",
+	})
+	if err != nil {
+		t.Fatalf("POST after DELETE failed: %v", err)
+	}
+	resp2.Body.Close()
+	if resp2.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404 after DELETE, got %d", resp2.StatusCode)
+	}
+}
+
+// TestNoTimeoutByDefault verifies that sessions without WithSessionTimeout
+// persist indefinitely (until explicit DELETE or server restart). This is
+// the backward-compatible default behavior.
+func TestNoTimeoutByDefault(t *testing.T) {
+	ts := testStreamableServer() // no WithSessionTimeout
+	defer ts.Close()
+
+	sessionID := streamableInit(t, ts.URL)
+
+	// Wait a while
+	time.Sleep(200 * time.Millisecond)
+
+	// Session should still be alive
+	resp, err := streamablePost(ts.URL+"/mcp", sessionID, &core.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "tools/list",
+	})
+	if err != nil {
+		t.Fatalf("POST failed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("session expired without timeout configured: status = %d", resp.StatusCode)
+	}
+}

--- a/server/streamable_transport.go
+++ b/server/streamable_transport.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	gohttp "github.com/panyam/servicekit/http"
 )
@@ -22,17 +24,61 @@ const (
 
 // streamableTransport implements the MCP Streamable HTTP transport (2025-03-26 spec).
 // Each session is tracked via the Mcp-Session-Id header. Sessions are created on
-// initialize and cleaned up via DELETE or server restart.
+// initialize and cleaned up via DELETE, idle timeout (WithSessionTimeout), or
+// server restart.
 //
 // Unlike the SSE transport, there are no long-lived connections — each request is
 // independent HTTP with the response returned directly in the body. Sessions are
-// lightweight map entries (a Dispatcher with negotiation state), so abandoned
-// sessions have minimal cost.
+// wrapped in sessionEntry which adds idle-timeout support with ref counting to
+// prevent expiry during active requests.
 type streamableTransport struct {
 	server   *Server
-	sessions sync.Map // sessionID → *Dispatcher
+	sessions sync.Map // sessionID → *sessionEntry
 	sseHub   *gohttp.SSEHub[SSEData] // for GET SSE streams (server-initiated notifications)
 	config   transportConfig
+}
+
+// sessionEntry wraps a Dispatcher with idle-timeout support. When a session
+// timeout is configured, the timer fires after the session has been idle
+// (no active POST requests or GET SSE streams) for the configured duration.
+// Active requests are tracked via acquire/release to prevent expiry mid-execution.
+type sessionEntry struct {
+	dispatcher *Dispatcher
+	timer      *time.Timer   // nil if no timeout configured
+	mu         sync.Mutex    // protects active count and timer reset
+	active     int           // number of in-flight requests (POST dispatch + GET SSE)
+	timeout    time.Duration // 0 means no timeout
+}
+
+// acquire marks a request as active and stops the idle timer.
+// Must be paired with a deferred release().
+func (e *sessionEntry) acquire() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.active++
+	if e.timer != nil {
+		e.timer.Stop()
+	}
+}
+
+// release marks a request as complete. If no requests remain active and a
+// timeout is configured, the idle timer is restarted.
+func (e *sessionEntry) release() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.active--
+	if e.active == 0 && e.timer != nil {
+		e.timer.Reset(e.timeout)
+	}
+}
+
+// stopTimer stops the idle timer if one is running. Safe to call multiple times.
+func (e *sessionEntry) stopTimer() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.timer != nil {
+		e.timer.Stop()
+	}
 }
 
 // newStreamableTransport creates a Streamable HTTP transport.
@@ -72,6 +118,29 @@ func (t *streamableTransport) handleRoot(w http.ResponseWriter, r *http.Request)
 	}
 }
 
+// expireSession removes an idle session and cleans up its resources.
+// Called by the session timer when the idle timeout fires.
+func (t *streamableTransport) expireSession(id string) {
+	val, ok := t.sessions.LoadAndDelete(id)
+	if !ok {
+		return
+	}
+	entry := val.(*sessionEntry)
+	entry.dispatcher.Close()
+	// Close any GET SSE streams for this session
+	t.sseHub.Unregister(id)
+	log.Printf("mcpkit: session %s expired after %s idle", id, entry.timeout)
+}
+
+// loadSession loads a sessionEntry by ID. Returns (entry, true) or (nil, false).
+func (t *streamableTransport) loadSession(id string) (*sessionEntry, bool) {
+	val, ok := t.sessions.Load(id)
+	if !ok {
+		return nil, false
+	}
+	return val.(*sessionEntry), true
+}
+
 // handlePost handles POST requests: JSON-RPC dispatch with session management.
 func (t *streamableTransport) handlePost(w http.ResponseWriter, r *http.Request) {
 	// NOTE: Per MCP spec (2025-11-25, Streamable HTTP transport), clients MUST include
@@ -104,15 +173,16 @@ func (t *streamableTransport) handlePost(w http.ResponseWriter, r *http.Request)
 			http.Error(w, "missing "+mcpSessionIDHeader+" header", http.StatusBadRequest)
 			return
 		}
-		dispVal, ok := t.sessions.Load(sessionID)
+		entry, ok := t.loadSession(sessionID)
 		if !ok {
 			http.Error(w, "session not found", http.StatusNotFound)
 			return
 		}
-		dispatcher := dispVal.(*Dispatcher)
+		entry.acquire()
+		defer entry.release()
 		var resp core.Response
 		if err := json.Unmarshal(body, &resp); err == nil {
-			dispatcher.RouteResponse(&resp)
+			entry.dispatcher.RouteResponse(&resp)
 		}
 		w.WriteHeader(http.StatusAccepted)
 		return
@@ -159,12 +229,14 @@ func (t *streamableTransport) handlePost(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	dispVal, ok := t.sessions.Load(sessionID)
+	entry, ok := t.loadSession(sessionID)
 	if !ok {
 		http.Error(w, "session not found", http.StatusNotFound)
 		return
 	}
-	dispatcher := dispVal.(*Dispatcher)
+	entry.acquire()
+	defer entry.release()
+	dispatcher := entry.dispatcher
 
 	// Validate MCP-Protocol-Version if present.
 	// Per spec: "If the server receives a request with an invalid or unsupported
@@ -298,7 +370,16 @@ func (t *streamableTransport) handleInitialize(w http.ResponseWriter, r *http.Re
 	// Success: create session and return with Mcp-Session-Id
 	sessionID := generateSessionID()
 	dispatcher.sessionID = sessionID
-	t.sessions.Store(sessionID, dispatcher)
+	entry := &sessionEntry{
+		dispatcher: dispatcher,
+		timeout:    t.config.sessionTimeout,
+	}
+	if t.config.sessionTimeout > 0 {
+		entry.timer = time.AfterFunc(t.config.sessionTimeout, func() {
+			t.expireSession(sessionID)
+		})
+	}
+	t.sessions.Store(sessionID, entry)
 
 	w.Header().Set(mcpSessionIDHeader, sessionID)
 	w.Header().Set("Content-Type", "application/json")
@@ -337,6 +418,7 @@ type streamableSSEConn struct {
 	sessionID  string
 	transport  *streamableTransport
 	dispatcher *Dispatcher
+	entry      *sessionEntry // non-nil if attached to an existing session (for release on close)
 }
 
 func (h *streamableSSEHandler) Validate(w http.ResponseWriter, r *http.Request) (*streamableSSEConn, bool) {
@@ -351,12 +433,13 @@ func (h *streamableSSEHandler) Validate(w http.ResponseWriter, r *http.Request) 
 	sessionID := r.Header.Get(mcpSessionIDHeader)
 	var dispatcher *Dispatcher
 	if sessionID != "" {
-		dispVal, ok := h.transport.sessions.Load(sessionID)
+		entry, ok := h.transport.loadSession(sessionID)
 		if !ok {
 			http.Error(w, "session not found", http.StatusNotFound)
 			return nil, false
 		}
-		dispatcher = dispVal.(*Dispatcher)
+		entry.acquire() // released in OnClose
+		dispatcher = entry.dispatcher
 	} else {
 		// No session — create a temporary dispatcher for this SSE stream
 		sessionID = generateSessionID()
@@ -364,6 +447,11 @@ func (h *streamableSSEHandler) Validate(w http.ResponseWriter, r *http.Request) 
 		dispatcher.initialized = true
 	}
 
+	// Look up the entry for release tracking (nil for session-independent streams)
+	var connEntry *sessionEntry
+	if r.Header.Get(mcpSessionIDHeader) != "" {
+		connEntry, _ = h.transport.loadSession(sessionID)
+	}
 	conn := &streamableSSEConn{
 		BaseSSEConn: gohttp.BaseSSEConn[SSEData]{
 			Codec:     &sseDataCodec{},
@@ -373,6 +461,7 @@ func (h *streamableSSEHandler) Validate(w http.ResponseWriter, r *http.Request) 
 		sessionID:  sessionID,
 		transport:  h.transport,
 		dispatcher: dispatcher,
+		entry:      connEntry,
 	}
 	return conn, true
 }
@@ -402,6 +491,9 @@ func (c *streamableSSEConn) OnStart(w http.ResponseWriter, r *http.Request) erro
 
 func (c *streamableSSEConn) OnClose() {
 	c.transport.sseHub.Unregister(c.ConnId())
+	if c.entry != nil {
+		c.entry.release()
+	}
 	c.BaseSSEConn.OnClose()
 }
 
@@ -419,21 +511,25 @@ func (t *streamableTransport) handleDelete(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	d, ok := t.sessions.LoadAndDelete(sessionID)
+	val, ok := t.sessions.LoadAndDelete(sessionID)
 	if !ok {
 		http.Error(w, "session not found", http.StatusNotFound)
 		return
 	}
-	d.(*Dispatcher).Close()
+	entry := val.(*sessionEntry)
+	entry.stopTimer()
+	entry.dispatcher.Close()
 
 	w.WriteHeader(http.StatusOK)
 }
 
 // closeSession terminates a single session by ID. Returns true if found.
 func (t *streamableTransport) closeSession(id string) bool {
-	d, ok := t.sessions.LoadAndDelete(id)
+	val, ok := t.sessions.LoadAndDelete(id)
 	if ok {
-		d.(*Dispatcher).Close()
+		entry := val.(*sessionEntry)
+		entry.stopTimer()
+		entry.dispatcher.Close()
 	}
 	return ok
 }
@@ -441,7 +537,9 @@ func (t *streamableTransport) closeSession(id string) bool {
 // closeAllSessions terminates all active sessions.
 func (t *streamableTransport) closeAllSessions() {
 	t.sessions.Range(func(key, value any) bool {
-		value.(*Dispatcher).Close()
+		entry := value.(*sessionEntry)
+		entry.stopTimer()
+		entry.dispatcher.Close()
 		t.sessions.Delete(key)
 		return true
 	})
@@ -451,7 +549,7 @@ func (t *streamableTransport) closeAllSessions() {
 // Sessions without a GET SSE stream have nil notifyFunc and are skipped safely.
 func (t *streamableTransport) broadcast(method string, params any) {
 	t.sessions.Range(func(key, value any) bool {
-		d := value.(*Dispatcher)
+		d := value.(*sessionEntry).dispatcher
 		if fn := d.getNotifyFunc(); fn != nil {
 			fn(method, params)
 		}

--- a/tests/reports/report.html
+++ b/tests/reports/report.html
@@ -15,7 +15,7 @@ th { background: #f5f5f5; font-weight: 600; }
 pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto; font-size: 13px; max-height: 400px; overflow-y: auto; }
 </style></head><body>
 <h1>MCPKit Test Report</h1>
-<div class='meta'>Branch: <strong>feat/broadcast-notifications</strong> | Commit: <code>c2b03a7</code> | Date: 2026-04-07 20:54:30</div>
+<div class='meta'>Branch: <strong>feat/dynamic-registration-session-timeout</strong> | Commit: <code>4deb447</code> | Date: 2026-04-08 10:42:57</div>
 <table><tr><th>Stage</th><th>Result</th></tr>
 <tr><td>unit</td><td class='pass'>PASS</td></tr>
 <tr><td>race</td><td class='pass'>PASS</td></tr>
@@ -29,36 +29,36 @@ pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto; 
 <div class='summary-pass'>All 8 stages passed</div>
 <h2>Full Log</h2><pre>
 === MCPKit Comprehensive Test Suite ===
-Started: Tue Apr  7 20:53:55 PDT 2026
+Started: Wed Apr  8 10:42:20 PDT 2026
 
 --- [1/8] unit ---
-ok  	github.com/panyam/mcpkit/client	1.210s
+ok  	github.com/panyam/mcpkit/client	2.121s
 ?   	github.com/panyam/mcpkit/cmd/testserver	[no test files]
-ok  	github.com/panyam/mcpkit/core	0.354s
-ok  	github.com/panyam/mcpkit/server	6.601s
-ok  	github.com/panyam/mcpkit/testutil	1.043s
+ok  	github.com/panyam/mcpkit/core	0.301s
+ok  	github.com/panyam/mcpkit/server	7.819s
+ok  	github.com/panyam/mcpkit/testutil	1.371s
   PASS: unit
 --- [2/8] race ---
-ok  	github.com/panyam/mcpkit/client	2.569s
+ok  	github.com/panyam/mcpkit/client	3.001s
 ?   	github.com/panyam/mcpkit/cmd/testserver	[no test files]
-ok  	github.com/panyam/mcpkit/core	1.361s
-ok  	github.com/panyam/mcpkit/server	7.501s
-ok  	github.com/panyam/mcpkit/testutil	1.863s
+ok  	github.com/panyam/mcpkit/core	1.292s
+ok  	github.com/panyam/mcpkit/server	8.556s
+ok  	github.com/panyam/mcpkit/testutil	2.093s
   PASS: race
 --- [3/8] auth ---
-ok  	github.com/panyam/mcpkit/ext/auth	0.377s
+ok  	github.com/panyam/mcpkit/ext/auth	0.360s
   PASS: auth
 --- [4/8] ui ---
-ok  	github.com/panyam/mcpkit/ext/ui	0.322s
+ok  	github.com/panyam/mcpkit/ext/ui	0.281s
   PASS: ui
 --- [5/8] e2e ---
-ok  	github.com/panyam/mcpkit/tests/e2e	3.319s
-ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.935s
+ok  	github.com/panyam/mcpkit/tests/e2e	2.838s
+ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.924s
   PASS: e2e
 --- [6/8] conformance ---
 Killing stale process on port 18799...
 === Starting test server on :18799 (Streamable HTTP) ===
-Waiting for server.......2026/04/07 20:54:22 MCP test server listening on :18799 (Streamable HTTP at /mcp)
+Waiting for server.....2026/04/08 10:42:49 MCP test server listening on :18799 (Streamable HTTP at /mcp)
  ready
 
 === Running MCP conformance suite ===
@@ -69,295 +69,295 @@ Running active suite (30 scenarios) against http://localhost:18799/mcp
 
 === Running scenario: server-initialize ===
 Running client scenario 'server-initialize' against server: http://localhost:18799/mcp
-2026/04/07 20:54:25 Starting MCP-GET-SSE SSE connection: 64604f55c93b398e73c7201874040c0c
-2026/04/07 20:54:25 SSEHub: registered connection 64604f55c93b398e73c7201874040c0c (total: 1)
-2026/04/07 20:54:25 SSEHub: unregistered connection 64604f55c93b398e73c7201874040c0c (total: 0)
-2026/04/07 20:54:25 Received kill signal.  Quitting Writer. stop 0x1824671c2230
-2026/04/07 20:54:25 Cleaning up writer...
-2026/04/07 20:54:25 Finished cleaning up writer:  0x1824671c2230
-2026/04/07 20:54:25 Closed MCP-GET-SSE SSE connection: 64604f55c93b398e73c7201874040c0c
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 0a4c4608e78b47ed05720380c6b66a59
+2026/04/08 10:42:52 SSEHub: registered connection 0a4c4608e78b47ed05720380c6b66a59 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 0a4c4608e78b47ed05720380c6b66a59 (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e336230
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e336230
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 0a4c4608e78b47ed05720380c6b66a59
 
 === Running scenario: logging-set-level ===
 Running client scenario 'logging-set-level' against server: http://localhost:18799/mcp
-2026/04/07 20:54:25 Starting MCP-GET-SSE SSE connection: 83fb5a891d519d31620d404d63a920bf
-2026/04/07 20:54:25 SSEHub: registered connection 83fb5a891d519d31620d404d63a920bf (total: 1)
-2026/04/07 20:54:25 SSEHub: unregistered connection 83fb5a891d519d31620d404d63a920bf (total: 0)
-2026/04/07 20:54:25 Received kill signal.  Quitting Writer. stop 0x18246732e2a0
-2026/04/07 20:54:25 Cleaning up writer...
-2026/04/07 20:54:25 Finished cleaning up writer:  0x18246732e2a0
-2026/04/07 20:54:25 Closed MCP-GET-SSE SSE connection: 83fb5a891d519d31620d404d63a920bf
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: b2a6bc40f0dcb2953343a3beb7ffed38
+2026/04/08 10:42:52 SSEHub: registered connection b2a6bc40f0dcb2953343a3beb7ffed38 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection b2a6bc40f0dcb2953343a3beb7ffed38 (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e3ac150
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e3ac150
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: b2a6bc40f0dcb2953343a3beb7ffed38
 
 === Running scenario: ping ===
 Running client scenario 'ping' against server: http://localhost:18799/mcp
-2026/04/07 20:54:25 Starting MCP-GET-SSE SSE connection: 144e75b4e12327e994a07cba1dc16654
-2026/04/07 20:54:25 SSEHub: registered connection 144e75b4e12327e994a07cba1dc16654 (total: 1)
-2026/04/07 20:54:25 SSEHub: unregistered connection 144e75b4e12327e994a07cba1dc16654 (total: 0)
-2026/04/07 20:54:25 Received kill signal.  Quitting Writer. stop 0x1824671c24d0
-2026/04/07 20:54:25 Cleaning up writer...
-2026/04/07 20:54:25 Finished cleaning up writer:  0x1824671c24d0
-2026/04/07 20:54:25 Closed MCP-GET-SSE SSE connection: 144e75b4e12327e994a07cba1dc16654
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 93d578ab4c9d01ed8e42143798a3a000
+2026/04/08 10:42:52 SSEHub: registered connection 93d578ab4c9d01ed8e42143798a3a000 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 93d578ab4c9d01ed8e42143798a3a000 (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e3ac3f0
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e3ac3f0
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 93d578ab4c9d01ed8e42143798a3a000
 
 === Running scenario: completion-complete ===
 Running client scenario 'completion-complete' against server: http://localhost:18799/mcp
-2026/04/07 20:54:25 Starting MCP-GET-SSE SSE connection: 02d64818adea414fd986c626671fa073
-2026/04/07 20:54:25 SSEHub: registered connection 02d64818adea414fd986c626671fa073 (total: 1)
-2026/04/07 20:54:25 SSEHub: unregistered connection 02d64818adea414fd986c626671fa073 (total: 0)
-2026/04/07 20:54:25 Received kill signal.  Quitting Writer. stop 0x1824670b6380
-2026/04/07 20:54:25 Cleaning up writer...
-2026/04/07 20:54:25 Finished cleaning up writer:  0x1824670b6380
-2026/04/07 20:54:25 Closed MCP-GET-SSE SSE connection: 02d64818adea414fd986c626671fa073
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 88ceb3113ad3094366c5599d82a44d4a
+2026/04/08 10:42:52 SSEHub: registered connection 88ceb3113ad3094366c5599d82a44d4a (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 88ceb3113ad3094366c5599d82a44d4a (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e3ac690
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e3ac690
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 88ceb3113ad3094366c5599d82a44d4a
 
 === Running scenario: tools-list ===
 Running client scenario 'tools-list' against server: http://localhost:18799/mcp
-2026/04/07 20:54:25 Starting MCP-GET-SSE SSE connection: 52b2c8e742912f9b32e1f4ad6bc47d38
-2026/04/07 20:54:25 SSEHub: registered connection 52b2c8e742912f9b32e1f4ad6bc47d38 (total: 1)
-2026/04/07 20:54:25 SSEHub: unregistered connection 52b2c8e742912f9b32e1f4ad6bc47d38 (total: 0)
-2026/04/07 20:54:25 Received kill signal.  Quitting Writer. stop 0x18246732e540
-2026/04/07 20:54:25 Cleaning up writer...
-2026/04/07 20:54:25 Finished cleaning up writer:  0x18246732e540
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 274dc3c585e0769cb4f006adcfcaac99
+2026/04/08 10:42:52 SSEHub: registered connection 274dc3c585e0769cb4f006adcfcaac99 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 274dc3c585e0769cb4f006adcfcaac99 (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e14c380
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e14c380
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 274dc3c585e0769cb4f006adcfcaac99
 
 === Running scenario: tools-call-simple-text ===
-2026/04/07 20:54:25 Closed MCP-GET-SSE SSE connection: 52b2c8e742912f9b32e1f4ad6bc47d38
 Running client scenario 'tools-call-simple-text' against server: http://localhost:18799/mcp
-2026/04/07 20:54:25 Starting MCP-GET-SSE SSE connection: d92e378701401269f9d5c9a137571c8c
-2026/04/07 20:54:25 SSEHub: registered connection d92e378701401269f9d5c9a137571c8c (total: 1)
-2026/04/07 20:54:25 SSEHub: unregistered connection d92e378701401269f9d5c9a137571c8c (total: 0)
-2026/04/07 20:54:25 Received kill signal.  Quitting Writer. stop 0x18246732e770
-2026/04/07 20:54:25 Cleaning up writer...
-2026/04/07 20:54:25 Finished cleaning up writer:  0x18246732e770
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: e7e2767b84a90cbab2e34437ee0c3359
+2026/04/08 10:42:52 SSEHub: registered connection e7e2767b84a90cbab2e34437ee0c3359 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection e7e2767b84a90cbab2e34437ee0c3359 (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e236230
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e236230
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: e7e2767b84a90cbab2e34437ee0c3359
 
 === Running scenario: tools-call-image ===
-2026/04/07 20:54:25 Closed MCP-GET-SSE SSE connection: d92e378701401269f9d5c9a137571c8c
 Running client scenario 'tools-call-image' against server: http://localhost:18799/mcp
-2026/04/07 20:54:25 Starting MCP-GET-SSE SSE connection: 99b395e1d691dc1363e53439c7f33a78
-2026/04/07 20:54:25 SSEHub: registered connection 99b395e1d691dc1363e53439c7f33a78 (total: 1)
-2026/04/07 20:54:25 SSEHub: unregistered connection 99b395e1d691dc1363e53439c7f33a78 (total: 0)
-2026/04/07 20:54:25 Received kill signal.  Quitting Writer. stop 0x1824670b6700
-2026/04/07 20:54:25 Cleaning up writer...
-2026/04/07 20:54:25 Finished cleaning up writer:  0x1824670b6700
-2026/04/07 20:54:25 Closed MCP-GET-SSE SSE connection: 99b395e1d691dc1363e53439c7f33a78
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 530a8372abfc6ddb09989b77c1584185
+2026/04/08 10:42:52 SSEHub: registered connection 530a8372abfc6ddb09989b77c1584185 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 530a8372abfc6ddb09989b77c1584185 (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e336690
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e336690
 
 === Running scenario: tools-call-audio ===
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 530a8372abfc6ddb09989b77c1584185
 Running client scenario 'tools-call-audio' against server: http://localhost:18799/mcp
-2026/04/07 20:54:25 Starting MCP-GET-SSE SSE connection: c32a685ff852315f2f2c161211fa5543
-2026/04/07 20:54:25 SSEHub: registered connection c32a685ff852315f2f2c161211fa5543 (total: 1)
-2026/04/07 20:54:25 SSEHub: unregistered connection c32a685ff852315f2f2c161211fa5543 (total: 0)
-2026/04/07 20:54:25 Received kill signal.  Quitting Writer. stop 0x18246732eb60
-2026/04/07 20:54:25 Cleaning up writer...
-2026/04/07 20:54:25 Finished cleaning up writer:  0x18246732eb60
-2026/04/07 20:54:25 Closed MCP-GET-SSE SSE connection: c32a685ff852315f2f2c161211fa5543
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: cab41786ae1223f16660a9a85b6c3544
+2026/04/08 10:42:52 SSEHub: registered connection cab41786ae1223f16660a9a85b6c3544 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection cab41786ae1223f16660a9a85b6c3544 (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e3369a0
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e3369a0
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: cab41786ae1223f16660a9a85b6c3544
 
 === Running scenario: tools-call-embedded-resource ===
 Running client scenario 'tools-call-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/07 20:54:25 Starting MCP-GET-SSE SSE connection: 53a48eb79abe3f800ec6d7202fb9ea63
-2026/04/07 20:54:25 SSEHub: registered connection 53a48eb79abe3f800ec6d7202fb9ea63 (total: 1)
-2026/04/07 20:54:25 SSEHub: unregistered connection 53a48eb79abe3f800ec6d7202fb9ea63 (total: 0)
-2026/04/07 20:54:25 Received kill signal.  Quitting Writer. stop 0x1824671c2930
-2026/04/07 20:54:25 Cleaning up writer...
-2026/04/07 20:54:25 Finished cleaning up writer:  0x1824671c2930
-2026/04/07 20:54:25 Closed MCP-GET-SSE SSE connection: 53a48eb79abe3f800ec6d7202fb9ea63
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 41651b6c7567affcc9b9eeea4b361fd9
+2026/04/08 10:42:52 SSEHub: registered connection 41651b6c7567affcc9b9eeea4b361fd9 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 41651b6c7567affcc9b9eeea4b361fd9 (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e3aca10
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e3aca10
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 41651b6c7567affcc9b9eeea4b361fd9
 
 === Running scenario: tools-call-mixed-content ===
 Running client scenario 'tools-call-mixed-content' against server: http://localhost:18799/mcp
-2026/04/07 20:54:25 Starting MCP-GET-SSE SSE connection: 714b908ac5fb5c19effad757c168f53a
-2026/04/07 20:54:25 SSEHub: registered connection 714b908ac5fb5c19effad757c168f53a (total: 1)
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 5044eeb9b91d63d109a78dda575c4858
+2026/04/08 10:42:52 SSEHub: registered connection 5044eeb9b91d63d109a78dda575c4858 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 5044eeb9b91d63d109a78dda575c4858 (total: 0)
 
 === Running scenario: tools-call-with-logging ===
-2026/04/07 20:54:25 SSEHub: unregistered connection 714b908ac5fb5c19effad757c168f53a (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e336cb0
 Running client scenario 'tools-call-with-logging' against server: http://localhost:18799/mcp
-2026/04/07 20:54:25 Received kill signal.  Quitting Writer. stop 0x1824671c2c40
-2026/04/07 20:54:25 Cleaning up writer...
-2026/04/07 20:54:25 Finished cleaning up writer:  0x1824671c2c40
-2026/04/07 20:54:25 Closed MCP-GET-SSE SSE connection: 714b908ac5fb5c19effad757c168f53a
-2026/04/07 20:54:25 Starting MCP-GET-SSE SSE connection: 291e619f3e09fe8d34f0aca7497e02d2
-2026/04/07 20:54:25 SSEHub: registered connection 291e619f3e09fe8d34f0aca7497e02d2 (total: 1)
-2026/04/07 20:54:26 SSEHub: unregistered connection 291e619f3e09fe8d34f0aca7497e02d2 (total: 0)
-2026/04/07 20:54:26 Received kill signal.  Quitting Writer. stop 0x1824671c2e70
-2026/04/07 20:54:26 Cleaning up writer...
-2026/04/07 20:54:26 Finished cleaning up writer:  0x1824671c2e70
-2026/04/07 20:54:26 Closed MCP-GET-SSE SSE connection: 291e619f3e09fe8d34f0aca7497e02d2
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e336cb0
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 5044eeb9b91d63d109a78dda575c4858
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 267b2e6d4f2c541fc3eaa87cd03c4d1f
+2026/04/08 10:42:52 SSEHub: registered connection 267b2e6d4f2c541fc3eaa87cd03c4d1f (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 267b2e6d4f2c541fc3eaa87cd03c4d1f (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e2365b0
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e2365b0
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 267b2e6d4f2c541fc3eaa87cd03c4d1f
 
 === Running scenario: tools-call-error ===
 Running client scenario 'tools-call-error' against server: http://localhost:18799/mcp
-2026/04/07 20:54:26 Starting MCP-GET-SSE SSE connection: 723988b9f9c195c462326d0cbfb31124
-2026/04/07 20:54:26 SSEHub: registered connection 723988b9f9c195c462326d0cbfb31124 (total: 1)
-2026/04/07 20:54:26 SSEHub: unregistered connection 723988b9f9c195c462326d0cbfb31124 (total: 0)
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 5fd60aefa85da1b4b4a6f3c024c2e5a3
+2026/04/08 10:42:52 SSEHub: registered connection 5fd60aefa85da1b4b4a6f3c024c2e5a3 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 5fd60aefa85da1b4b4a6f3c024c2e5a3 (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e3acd90
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e3acd90
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 5fd60aefa85da1b4b4a6f3c024c2e5a3
 
 === Running scenario: tools-call-with-progress ===
-2026/04/07 20:54:26 Received kill signal.  Quitting Writer. stop 0x1824674be150
-2026/04/07 20:54:26 Cleaning up writer...
-2026/04/07 20:54:26 Finished cleaning up writer:  0x1824674be150
 Running client scenario 'tools-call-with-progress' against server: http://localhost:18799/mcp
-2026/04/07 20:54:26 Closed MCP-GET-SSE SSE connection: 723988b9f9c195c462326d0cbfb31124
-2026/04/07 20:54:26 Starting MCP-GET-SSE SSE connection: 6ce72cecedad56c95eacacd87a193fa8
-2026/04/07 20:54:26 SSEHub: registered connection 6ce72cecedad56c95eacacd87a193fa8 (total: 1)
-2026/04/07 20:54:26 SSEHub: unregistered connection 6ce72cecedad56c95eacacd87a193fa8 (total: 0)
-2026/04/07 20:54:26 Received kill signal.  Quitting Writer. stop 0x18246732f180
-2026/04/07 20:54:26 Cleaning up writer...
-2026/04/07 20:54:26 Finished cleaning up writer:  0x18246732f180
-2026/04/07 20:54:26 Closed MCP-GET-SSE SSE connection: 6ce72cecedad56c95eacacd87a193fa8
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 76ad47856e91027f4f5ecb5299811bd8
+2026/04/08 10:42:52 SSEHub: registered connection 76ad47856e91027f4f5ecb5299811bd8 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 76ad47856e91027f4f5ecb5299811bd8 (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e236930
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e236930
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 76ad47856e91027f4f5ecb5299811bd8
 
 === Running scenario: tools-call-sampling ===
 Running client scenario 'tools-call-sampling' against server: http://localhost:18799/mcp
-2026/04/07 20:54:26 Starting MCP-GET-SSE SSE connection: 820746347f3c591dd9932fa1ccc32d04
-2026/04/07 20:54:26 SSEHub: registered connection 820746347f3c591dd9932fa1ccc32d04 (total: 1)
-2026/04/07 20:54:26 SSEHub: unregistered connection 820746347f3c591dd9932fa1ccc32d04 (total: 0)
-2026/04/07 20:54:26 Received kill signal.  Quitting Writer. stop 0x18246732f3b0
-2026/04/07 20:54:26 Cleaning up writer...
-2026/04/07 20:54:26 Finished cleaning up writer:  0x18246732f3b0
-2026/04/07 20:54:26 Closed MCP-GET-SSE SSE connection: 820746347f3c591dd9932fa1ccc32d04
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: c840b66592a717c6c375b1097d32f26d
+2026/04/08 10:42:52 SSEHub: registered connection c840b66592a717c6c375b1097d32f26d (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection c840b66592a717c6c375b1097d32f26d (total: 0)
 
 === Running scenario: tools-call-elicitation ===
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e3acfc0
+2026/04/08 10:42:52 Cleaning up writer...
 Running client scenario 'tools-call-elicitation' against server: http://localhost:18799/mcp
-2026/04/07 20:54:26 Starting MCP-GET-SSE SSE connection: 8a7db4e668f53802c99e5f19ac31c812
-2026/04/07 20:54:26 SSEHub: registered connection 8a7db4e668f53802c99e5f19ac31c812 (total: 1)
-2026/04/07 20:54:26 SSEHub: unregistered connection 8a7db4e668f53802c99e5f19ac31c812 (total: 0)
-2026/04/07 20:54:26 Received kill signal.  Quitting Writer. stop 0x1824670b69a0
-2026/04/07 20:54:26 Cleaning up writer...
-2026/04/07 20:54:26 Finished cleaning up writer:  0x1824670b69a0
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e3acfc0
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: c840b66592a717c6c375b1097d32f26d
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 0360c44abf053ac97094d00e80c7e679
+2026/04/08 10:42:52 SSEHub: registered connection 0360c44abf053ac97094d00e80c7e679 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 0360c44abf053ac97094d00e80c7e679 (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e3370a0
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e3370a0
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 0360c44abf053ac97094d00e80c7e679
 
 === Running scenario: elicitation-sep1034-defaults ===
-2026/04/07 20:54:26 Closed MCP-GET-SSE SSE connection: 8a7db4e668f53802c99e5f19ac31c812
 Running client scenario 'elicitation-sep1034-defaults' against server: http://localhost:18799/mcp
-2026/04/07 20:54:26 Starting MCP-GET-SSE SSE connection: 7e6b302bded55f8994b5333114f3ee22
-2026/04/07 20:54:26 SSEHub: registered connection 7e6b302bded55f8994b5333114f3ee22 (total: 1)
-2026/04/07 20:54:26 SSEHub: unregistered connection 7e6b302bded55f8994b5333114f3ee22 (total: 0)
-2026/04/07 20:54:26 Received kill signal.  Quitting Writer. stop 0x18246732f7a0
-2026/04/07 20:54:26 Cleaning up writer...
-2026/04/07 20:54:26 Finished cleaning up writer:  0x18246732f7a0
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 57acce210190d393101bfc2d70075fba
+2026/04/08 10:42:52 SSEHub: registered connection 57acce210190d393101bfc2d70075fba (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 57acce210190d393101bfc2d70075fba (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e3372d0
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e3372d0
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 57acce210190d393101bfc2d70075fba
 
 === Running scenario: server-sse-multiple-streams ===
-2026/04/07 20:54:26 Closed MCP-GET-SSE SSE connection: 7e6b302bded55f8994b5333114f3ee22
 Running client scenario 'server-sse-multiple-streams' against server: http://localhost:18799/mcp
-2026/04/07 20:54:26 Starting MCP-GET-SSE SSE connection: 0ed7993365aaee31ce5ba430e6441e89
-2026/04/07 20:54:26 SSEHub: registered connection 0ed7993365aaee31ce5ba430e6441e89 (total: 1)
-2026/04/07 20:54:26 SSEHub: unregistered connection 0ed7993365aaee31ce5ba430e6441e89 (total: 0)
-2026/04/07 20:54:26 Received kill signal.  Quitting Writer. stop 0x1824674be7e0
-2026/04/07 20:54:26 Cleaning up writer...
-2026/04/07 20:54:26 Finished cleaning up writer:  0x1824674be7e0
-2026/04/07 20:54:26 Closed MCP-GET-SSE SSE connection: 0ed7993365aaee31ce5ba430e6441e89
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: e65e255c440f876a758759fd79ce19e9
+2026/04/08 10:42:52 SSEHub: registered connection e65e255c440f876a758759fd79ce19e9 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection e65e255c440f876a758759fd79ce19e9 (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e337500
 
 === Running scenario: elicitation-sep1330-enums ===
+2026/04/08 10:42:52 Cleaning up writer...
 Running client scenario 'elicitation-sep1330-enums' against server: http://localhost:18799/mcp
-2026/04/07 20:54:26 Starting MCP-GET-SSE SSE connection: 38506a21aa5cd9a8fb4218f2d8ac3773
-2026/04/07 20:54:26 SSEHub: registered connection 38506a21aa5cd9a8fb4218f2d8ac3773 (total: 1)
-2026/04/07 20:54:26 SSEHub: unregistered connection 38506a21aa5cd9a8fb4218f2d8ac3773 (total: 0)
-2026/04/07 20:54:26 Received kill signal.  Quitting Writer. stop 0x1824674beaf0
-2026/04/07 20:54:26 Cleaning up writer...
-2026/04/07 20:54:26 Finished cleaning up writer:  0x1824674beaf0
-2026/04/07 20:54:26 Closed MCP-GET-SSE SSE connection: 38506a21aa5cd9a8fb4218f2d8ac3773
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e337500
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: e65e255c440f876a758759fd79ce19e9
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 30955bdff128a735615627e713e034e0
+2026/04/08 10:42:52 SSEHub: registered connection 30955bdff128a735615627e713e034e0 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 30955bdff128a735615627e713e034e0 (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e3ad340
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e3ad340
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 30955bdff128a735615627e713e034e0
 
 === Running scenario: resources-list ===
 Running client scenario 'resources-list' against server: http://localhost:18799/mcp
-2026/04/07 20:54:26 Starting MCP-GET-SSE SSE connection: d6410bbdb77f451e82787e279630e6f6
-2026/04/07 20:54:26 SSEHub: registered connection d6410bbdb77f451e82787e279630e6f6 (total: 1)
-2026/04/07 20:54:26 SSEHub: unregistered connection d6410bbdb77f451e82787e279630e6f6 (total: 0)
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 316df31d5f563b5ef21474086331ba14
+2026/04/08 10:42:52 SSEHub: registered connection 316df31d5f563b5ef21474086331ba14 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 316df31d5f563b5ef21474086331ba14 (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e337a40
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e337a40
 
 === Running scenario: resources-read-text ===
-2026/04/07 20:54:26 Received kill signal.  Quitting Writer. stop 0x1824670b6d90
-2026/04/07 20:54:26 Cleaning up writer...
-2026/04/07 20:54:26 Finished cleaning up writer:  0x1824670b6d90
-2026/04/07 20:54:26 Closed MCP-GET-SSE SSE connection: d6410bbdb77f451e82787e279630e6f6
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 316df31d5f563b5ef21474086331ba14
 Running client scenario 'resources-read-text' against server: http://localhost:18799/mcp
-2026/04/07 20:54:26 Starting MCP-GET-SSE SSE connection: 7b9e7a4589777a9cbbedd9036ccb610f
-2026/04/07 20:54:26 SSEHub: registered connection 7b9e7a4589777a9cbbedd9036ccb610f (total: 1)
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 7adf5cdad6213b925bd14124241f4a02
+2026/04/08 10:42:52 SSEHub: registered connection 7adf5cdad6213b925bd14124241f4a02 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 7adf5cdad6213b925bd14124241f4a02 (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e3ad570
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e3ad570
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 7adf5cdad6213b925bd14124241f4a02
 
 === Running scenario: resources-read-binary ===
-2026/04/07 20:54:26 SSEHub: unregistered connection 7b9e7a4589777a9cbbedd9036ccb610f (total: 0)
 Running client scenario 'resources-read-binary' against server: http://localhost:18799/mcp
-2026/04/07 20:54:26 Received kill signal.  Quitting Writer. stop 0x1824674bed90
-2026/04/07 20:54:26 Cleaning up writer...
-2026/04/07 20:54:26 Finished cleaning up writer:  0x1824674bed90
-2026/04/07 20:54:26 Closed MCP-GET-SSE SSE connection: 7b9e7a4589777a9cbbedd9036ccb610f
-2026/04/07 20:54:26 Starting MCP-GET-SSE SSE connection: be8f13292a825e9d868198bb7ac38976
-2026/04/07 20:54:26 SSEHub: registered connection be8f13292a825e9d868198bb7ac38976 (total: 1)
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 3bab85b6cc1446eea487b4fa03740db2
+2026/04/08 10:42:52 SSEHub: registered connection 3bab85b6cc1446eea487b4fa03740db2 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 3bab85b6cc1446eea487b4fa03740db2 (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e337d50
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e337d50
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 3bab85b6cc1446eea487b4fa03740db2
 
 === Running scenario: resources-templates-read ===
-2026/04/07 20:54:26 SSEHub: unregistered connection be8f13292a825e9d868198bb7ac38976 (total: 0)
 Running client scenario 'resources-templates-read' against server: http://localhost:18799/mcp
-2026/04/07 20:54:26 Received kill signal.  Quitting Writer. stop 0x18246732fb20
-2026/04/07 20:54:26 Cleaning up writer...
-2026/04/07 20:54:26 Finished cleaning up writer:  0x18246732fb20
-2026/04/07 20:54:26 Closed MCP-GET-SSE SSE connection: be8f13292a825e9d868198bb7ac38976
-2026/04/07 20:54:26 Starting MCP-GET-SSE SSE connection: a8bfc8fa6c35ecbce6191198eef42581
-2026/04/07 20:54:26 SSEHub: registered connection a8bfc8fa6c35ecbce6191198eef42581 (total: 1)
-2026/04/07 20:54:26 SSEHub: unregistered connection a8bfc8fa6c35ecbce6191198eef42581 (total: 0)
-2026/04/07 20:54:26 Received kill signal.  Quitting Writer. stop 0x18246732fd50
-2026/04/07 20:54:26 Cleaning up writer...
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 3604c447a0d23fbfb346b197b91cfe03
+2026/04/08 10:42:52 SSEHub: registered connection 3604c447a0d23fbfb346b197b91cfe03 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 3604c447a0d23fbfb346b197b91cfe03 (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e2370a0
+2026/04/08 10:42:52 Cleaning up writer...
 
 === Running scenario: resources-subscribe ===
-2026/04/07 20:54:26 Finished cleaning up writer:  0x18246732fd50
-2026/04/07 20:54:26 Closed MCP-GET-SSE SSE connection: a8bfc8fa6c35ecbce6191198eef42581
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e2370a0
 Running client scenario 'resources-subscribe' against server: http://localhost:18799/mcp
-2026/04/07 20:54:26 Starting MCP-GET-SSE SSE connection: 35f2dff2f665775956786b3a3e1d93cf
-2026/04/07 20:54:26 SSEHub: registered connection 35f2dff2f665775956786b3a3e1d93cf (total: 1)
-2026/04/07 20:54:26 SSEHub: unregistered connection 35f2dff2f665775956786b3a3e1d93cf (total: 0)
-2026/04/07 20:54:26 Received kill signal.  Quitting Writer. stop 0x1824670b7110
-2026/04/07 20:54:26 Cleaning up writer...
-2026/04/07 20:54:26 Finished cleaning up writer:  0x1824670b7110
-2026/04/07 20:54:26 Closed MCP-GET-SSE SSE connection: 35f2dff2f665775956786b3a3e1d93cf
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 3604c447a0d23fbfb346b197b91cfe03
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: a930602cfc6d0be12dd9073de4d61d6e
+2026/04/08 10:42:52 SSEHub: registered connection a930602cfc6d0be12dd9073de4d61d6e (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection a930602cfc6d0be12dd9073de4d61d6e (total: 0)
 
 === Running scenario: resources-unsubscribe ===
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e0a0a10
 Running client scenario 'resources-unsubscribe' against server: http://localhost:18799/mcp
-2026/04/07 20:54:26 Starting MCP-GET-SSE SSE connection: 273b79e1e66ba71ca23afcdb5b30808d
-2026/04/07 20:54:26 SSEHub: registered connection 273b79e1e66ba71ca23afcdb5b30808d (total: 1)
-2026/04/07 20:54:26 SSEHub: unregistered connection 273b79e1e66ba71ca23afcdb5b30808d (total: 0)
-2026/04/07 20:54:26 Received kill signal.  Quitting Writer. stop 0x1824671c3650
-2026/04/07 20:54:26 Cleaning up writer...
-2026/04/07 20:54:26 Finished cleaning up writer:  0x1824671c3650
-2026/04/07 20:54:26 Closed MCP-GET-SSE SSE connection: 273b79e1e66ba71ca23afcdb5b30808d
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e0a0a10
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: a930602cfc6d0be12dd9073de4d61d6e
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 4c9ce409b01db87894e94b04abcbc761
+2026/04/08 10:42:52 SSEHub: registered connection 4c9ce409b01db87894e94b04abcbc761 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 4c9ce409b01db87894e94b04abcbc761 (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e3ad810
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e3ad810
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 4c9ce409b01db87894e94b04abcbc761
 
 === Running scenario: prompts-list ===
 Running client scenario 'prompts-list' against server: http://localhost:18799/mcp
-2026/04/07 20:54:26 Starting MCP-GET-SSE SSE connection: 85469165e326585cc2025a3127b0e05a
-2026/04/07 20:54:26 SSEHub: registered connection 85469165e326585cc2025a3127b0e05a (total: 1)
-2026/04/07 20:54:26 SSEHub: unregistered connection 85469165e326585cc2025a3127b0e05a (total: 0)
-2026/04/07 20:54:26 Received kill signal.  Quitting Writer. stop 0x1824671c3960
-2026/04/07 20:54:26 Cleaning up writer...
-2026/04/07 20:54:26 Finished cleaning up writer:  0x1824671c3960
-2026/04/07 20:54:26 Closed MCP-GET-SSE SSE connection: 85469165e326585cc2025a3127b0e05a
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 1abe9e78839082ee228282640ee3da54
+2026/04/08 10:42:52 SSEHub: registered connection 1abe9e78839082ee228282640ee3da54 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 1abe9e78839082ee228282640ee3da54 (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e3adb20
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e3adb20
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 1abe9e78839082ee228282640ee3da54
 
 === Running scenario: prompts-get-simple ===
 Running client scenario 'prompts-get-simple' against server: http://localhost:18799/mcp
-2026/04/07 20:54:26 Starting MCP-GET-SSE SSE connection: 13f570609d8d685188b708ba9e257f8e
-2026/04/07 20:54:26 SSEHub: registered connection 13f570609d8d685188b708ba9e257f8e (total: 1)
-2026/04/07 20:54:26 SSEHub: unregistered connection 13f570609d8d685188b708ba9e257f8e (total: 0)
-2026/04/07 20:54:26 Received kill signal.  Quitting Writer. stop 0x182467438150
-2026/04/07 20:54:26 Cleaning up writer...
-2026/04/07 20:54:26 Finished cleaning up writer:  0x182467438150
-2026/04/07 20:54:26 Closed MCP-GET-SSE SSE connection: 13f570609d8d685188b708ba9e257f8e
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 13597c9392010cd01aea5eafc1bcfd34
+2026/04/08 10:42:52 SSEHub: registered connection 13597c9392010cd01aea5eafc1bcfd34 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 13597c9392010cd01aea5eafc1bcfd34 (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e0a0d20
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e0a0d20
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 13597c9392010cd01aea5eafc1bcfd34
 
 === Running scenario: prompts-get-with-args ===
 Running client scenario 'prompts-get-with-args' against server: http://localhost:18799/mcp
-2026/04/07 20:54:26 Starting MCP-GET-SSE SSE connection: d0dea2d09744384ee942c2eb75f25848
-2026/04/07 20:54:26 SSEHub: registered connection d0dea2d09744384ee942c2eb75f25848 (total: 1)
-2026/04/07 20:54:26 SSEHub: unregistered connection d0dea2d09744384ee942c2eb75f25848 (total: 0)
-2026/04/07 20:54:26 Received kill signal.  Quitting Writer. stop 0x1824674bf0a0
-2026/04/07 20:54:26 Cleaning up writer...
-2026/04/07 20:54:26 Finished cleaning up writer:  0x1824674bf0a0
-2026/04/07 20:54:26 Closed MCP-GET-SSE SSE connection: d0dea2d09744384ee942c2eb75f25848
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 7dd88422a46134db8f1f4e3eccd85bbd
+2026/04/08 10:42:52 SSEHub: registered connection 7dd88422a46134db8f1f4e3eccd85bbd (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 7dd88422a46134db8f1f4e3eccd85bbd (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e0a0fc0
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e0a0fc0
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 7dd88422a46134db8f1f4e3eccd85bbd
 
 === Running scenario: prompts-get-embedded-resource ===
 Running client scenario 'prompts-get-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/07 20:54:26 Starting MCP-GET-SSE SSE connection: 6969261c0f6835da5bf3bc4e498d39f6
-2026/04/07 20:54:26 SSEHub: registered connection 6969261c0f6835da5bf3bc4e498d39f6 (total: 1)
-2026/04/07 20:54:26 SSEHub: unregistered connection 6969261c0f6835da5bf3bc4e498d39f6 (total: 0)
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 1ecb34bf02088efd0d5db28c7cc1d4fe
+2026/04/08 10:42:52 SSEHub: registered connection 1ecb34bf02088efd0d5db28c7cc1d4fe (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 1ecb34bf02088efd0d5db28c7cc1d4fe (total: 0)
 
 === Running scenario: prompts-get-with-image ===
-2026/04/07 20:54:26 Received kill signal.  Quitting Writer. stop 0x1824671c3c00
-2026/04/07 20:54:26 Cleaning up writer...
-2026/04/07 20:54:26 Finished cleaning up writer:  0x1824671c3c00
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e2373b0
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e2373b0
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 1ecb34bf02088efd0d5db28c7cc1d4fe
 Running client scenario 'prompts-get-with-image' against server: http://localhost:18799/mcp
-2026/04/07 20:54:26 Closed MCP-GET-SSE SSE connection: 6969261c0f6835da5bf3bc4e498d39f6
-2026/04/07 20:54:26 Starting MCP-GET-SSE SSE connection: 5e13c7d5f81080b7529f73d154906e2d
-2026/04/07 20:54:26 SSEHub: registered connection 5e13c7d5f81080b7529f73d154906e2d (total: 1)
-2026/04/07 20:54:26 SSEHub: unregistered connection 5e13c7d5f81080b7529f73d154906e2d (total: 0)
-2026/04/07 20:54:26 Received kill signal.  Quitting Writer. stop 0x1824670b7500
-2026/04/07 20:54:26 Cleaning up writer...
-2026/04/07 20:54:26 Finished cleaning up writer:  0x1824670b7500
-2026/04/07 20:54:26 Closed MCP-GET-SSE SSE connection: 5e13c7d5f81080b7529f73d154906e2d
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 5fa4d7673fef6998f79a5f4fb7a3047d
+2026/04/08 10:42:52 SSEHub: registered connection 5fa4d7673fef6998f79a5f4fb7a3047d (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 5fa4d7673fef6998f79a5f4fb7a3047d (total: 0)
 
 === Running scenario: dns-rebinding-protection ===
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e2376c0
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e2376c0
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 5fa4d7673fef6998f79a5f4fb7a3047d
 Running client scenario 'dns-rebinding-protection' against server: http://localhost:18799/mcp
 
 
@@ -420,22 +420,22 @@ Starting scenario: auth/token-endpoint-auth-basic
 Starting scenario: auth/token-endpoint-auth-post
 Starting scenario: auth/token-endpoint-auth-none
 Starting scenario: auth/pre-registration
-Executing client: ./bin/testclient http://localhost:60735/mcp
-Executing client: ./bin/testclient http://localhost:60736/mcp
-Executing client: ./bin/testclient http://localhost:60737/mcp
-Executing client: ./bin/testclient http://localhost:60738/mcp
-Executing client: ./bin/testclient http://localhost:60739/mcp
-Executing client: ./bin/testclient http://localhost:60740/mcp
-Executing client: ./bin/testclient http://localhost:60741/mcp
-Executing client: ./bin/testclient http://localhost:60742/mcp
-Executing client: ./bin/testclient http://localhost:60743/mcp
-Executing client: ./bin/testclient http://localhost:60744/mcp
-Executing client: ./bin/testclient http://localhost:60745/mcp
-Executing client: ./bin/testclient http://localhost:60746/mcp
-Executing client: ./bin/testclient http://localhost:60747/mcp
-Executing client: ./bin/testclient http://localhost:60748/mcp
+Executing client: ./bin/testclient http://localhost:58354/mcp
+Executing client: ./bin/testclient http://localhost:58355/mcp
+Executing client: ./bin/testclient http://localhost:58356/mcp
+Executing client: ./bin/testclient http://localhost:58357/mcp
+Executing client: ./bin/testclient http://localhost:58358/mcp
+Executing client: ./bin/testclient http://localhost:58359/mcp
+Executing client: ./bin/testclient http://localhost:58360/mcp
+Executing client: ./bin/testclient http://localhost:58361/mcp
+Executing client: ./bin/testclient http://localhost:58362/mcp
+Executing client: ./bin/testclient http://localhost:58363/mcp
+Executing client: ./bin/testclient http://localhost:58364/mcp
+Executing client: ./bin/testclient http://localhost:58365/mcp
+Executing client: ./bin/testclient http://localhost:58366/mcp
+Executing client: ./bin/testclient http://localhost:58367/mcp
 With context: {"client_id":"pre-registered-client","client_secret":"pre-registered-secret"}
-(node:4923) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
+(node:43768) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
 (Use `node --trace-deprecation ...` to show where the warning was created)
 
 === SUITE SUMMARY ===
@@ -466,7 +466,7 @@ Total: 210 passed, 0 failed, 1 warnings
   PASS: auth-conformance
 --- [8/8] keycloak ---
 === RUN   TestKeycloak_MCPServer_ValidToken
---- PASS: TestKeycloak_MCPServer_ValidToken (0.23s)
+--- PASS: TestKeycloak_MCPServer_ValidToken (0.25s)
 === RUN   TestKeycloak_MCPServer_TamperedToken
 --- PASS: TestKeycloak_MCPServer_TamperedToken (0.02s)
 === RUN   TestKeycloak_MCPServer_ScopeAllowed
@@ -478,12 +478,12 @@ Total: 210 passed, 0 failed, 1 warnings
 === RUN   TestKeycloak_MCPServer_WWWAuthenticate
 --- PASS: TestKeycloak_MCPServer_WWWAuthenticate (0.01s)
 === RUN   TestKeycloak_MCPServer_PasswordGrant
---- PASS: TestKeycloak_MCPServer_PasswordGrant (0.12s)
+--- PASS: TestKeycloak_MCPServer_PasswordGrant (0.13s)
 PASS
-ok  	github.com/panyam/mcpkit/tests/keycloak	1.113s
+ok  	github.com/panyam/mcpkit/tests/keycloak	1.204s
   PASS: keycloak
 
 === Results: 8 passed, 0 failed ===
-Finished: Tue Apr  7 20:54:30 PDT 2026
+Finished: Wed Apr  8 10:42:57 PDT 2026
 </pre>
 </body></html>

--- a/tests/reports/run.log
+++ b/tests/reports/run.log
@@ -1,34 +1,34 @@
 === MCPKit Comprehensive Test Suite ===
-Started: Tue Apr  7 20:53:55 PDT 2026
+Started: Wed Apr  8 10:42:20 PDT 2026
 
 --- [1/8] unit ---
-ok  	github.com/panyam/mcpkit/client	1.210s
+ok  	github.com/panyam/mcpkit/client	2.121s
 ?   	github.com/panyam/mcpkit/cmd/testserver	[no test files]
-ok  	github.com/panyam/mcpkit/core	0.354s
-ok  	github.com/panyam/mcpkit/server	6.601s
-ok  	github.com/panyam/mcpkit/testutil	1.043s
+ok  	github.com/panyam/mcpkit/core	0.301s
+ok  	github.com/panyam/mcpkit/server	7.819s
+ok  	github.com/panyam/mcpkit/testutil	1.371s
   PASS: unit
 --- [2/8] race ---
-ok  	github.com/panyam/mcpkit/client	2.569s
+ok  	github.com/panyam/mcpkit/client	3.001s
 ?   	github.com/panyam/mcpkit/cmd/testserver	[no test files]
-ok  	github.com/panyam/mcpkit/core	1.361s
-ok  	github.com/panyam/mcpkit/server	7.501s
-ok  	github.com/panyam/mcpkit/testutil	1.863s
+ok  	github.com/panyam/mcpkit/core	1.292s
+ok  	github.com/panyam/mcpkit/server	8.556s
+ok  	github.com/panyam/mcpkit/testutil	2.093s
   PASS: race
 --- [3/8] auth ---
-ok  	github.com/panyam/mcpkit/ext/auth	0.377s
+ok  	github.com/panyam/mcpkit/ext/auth	0.360s
   PASS: auth
 --- [4/8] ui ---
-ok  	github.com/panyam/mcpkit/ext/ui	0.322s
+ok  	github.com/panyam/mcpkit/ext/ui	0.281s
   PASS: ui
 --- [5/8] e2e ---
-ok  	github.com/panyam/mcpkit/tests/e2e	3.319s
-ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.935s
+ok  	github.com/panyam/mcpkit/tests/e2e	2.838s
+ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.924s
   PASS: e2e
 --- [6/8] conformance ---
 Killing stale process on port 18799...
 === Starting test server on :18799 (Streamable HTTP) ===
-Waiting for server.......2026/04/07 20:54:22 MCP test server listening on :18799 (Streamable HTTP at /mcp)
+Waiting for server.....2026/04/08 10:42:49 MCP test server listening on :18799 (Streamable HTTP at /mcp)
  ready
 
 === Running MCP conformance suite ===
@@ -39,295 +39,295 @@ Running active suite (30 scenarios) against http://localhost:18799/mcp
 
 === Running scenario: server-initialize ===
 Running client scenario 'server-initialize' against server: http://localhost:18799/mcp
-2026/04/07 20:54:25 Starting MCP-GET-SSE SSE connection: 64604f55c93b398e73c7201874040c0c
-2026/04/07 20:54:25 SSEHub: registered connection 64604f55c93b398e73c7201874040c0c (total: 1)
-2026/04/07 20:54:25 SSEHub: unregistered connection 64604f55c93b398e73c7201874040c0c (total: 0)
-2026/04/07 20:54:25 Received kill signal.  Quitting Writer. stop 0x1824671c2230
-2026/04/07 20:54:25 Cleaning up writer...
-2026/04/07 20:54:25 Finished cleaning up writer:  0x1824671c2230
-2026/04/07 20:54:25 Closed MCP-GET-SSE SSE connection: 64604f55c93b398e73c7201874040c0c
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 0a4c4608e78b47ed05720380c6b66a59
+2026/04/08 10:42:52 SSEHub: registered connection 0a4c4608e78b47ed05720380c6b66a59 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 0a4c4608e78b47ed05720380c6b66a59 (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e336230
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e336230
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 0a4c4608e78b47ed05720380c6b66a59
 
 === Running scenario: logging-set-level ===
 Running client scenario 'logging-set-level' against server: http://localhost:18799/mcp
-2026/04/07 20:54:25 Starting MCP-GET-SSE SSE connection: 83fb5a891d519d31620d404d63a920bf
-2026/04/07 20:54:25 SSEHub: registered connection 83fb5a891d519d31620d404d63a920bf (total: 1)
-2026/04/07 20:54:25 SSEHub: unregistered connection 83fb5a891d519d31620d404d63a920bf (total: 0)
-2026/04/07 20:54:25 Received kill signal.  Quitting Writer. stop 0x18246732e2a0
-2026/04/07 20:54:25 Cleaning up writer...
-2026/04/07 20:54:25 Finished cleaning up writer:  0x18246732e2a0
-2026/04/07 20:54:25 Closed MCP-GET-SSE SSE connection: 83fb5a891d519d31620d404d63a920bf
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: b2a6bc40f0dcb2953343a3beb7ffed38
+2026/04/08 10:42:52 SSEHub: registered connection b2a6bc40f0dcb2953343a3beb7ffed38 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection b2a6bc40f0dcb2953343a3beb7ffed38 (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e3ac150
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e3ac150
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: b2a6bc40f0dcb2953343a3beb7ffed38
 
 === Running scenario: ping ===
 Running client scenario 'ping' against server: http://localhost:18799/mcp
-2026/04/07 20:54:25 Starting MCP-GET-SSE SSE connection: 144e75b4e12327e994a07cba1dc16654
-2026/04/07 20:54:25 SSEHub: registered connection 144e75b4e12327e994a07cba1dc16654 (total: 1)
-2026/04/07 20:54:25 SSEHub: unregistered connection 144e75b4e12327e994a07cba1dc16654 (total: 0)
-2026/04/07 20:54:25 Received kill signal.  Quitting Writer. stop 0x1824671c24d0
-2026/04/07 20:54:25 Cleaning up writer...
-2026/04/07 20:54:25 Finished cleaning up writer:  0x1824671c24d0
-2026/04/07 20:54:25 Closed MCP-GET-SSE SSE connection: 144e75b4e12327e994a07cba1dc16654
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 93d578ab4c9d01ed8e42143798a3a000
+2026/04/08 10:42:52 SSEHub: registered connection 93d578ab4c9d01ed8e42143798a3a000 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 93d578ab4c9d01ed8e42143798a3a000 (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e3ac3f0
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e3ac3f0
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 93d578ab4c9d01ed8e42143798a3a000
 
 === Running scenario: completion-complete ===
 Running client scenario 'completion-complete' against server: http://localhost:18799/mcp
-2026/04/07 20:54:25 Starting MCP-GET-SSE SSE connection: 02d64818adea414fd986c626671fa073
-2026/04/07 20:54:25 SSEHub: registered connection 02d64818adea414fd986c626671fa073 (total: 1)
-2026/04/07 20:54:25 SSEHub: unregistered connection 02d64818adea414fd986c626671fa073 (total: 0)
-2026/04/07 20:54:25 Received kill signal.  Quitting Writer. stop 0x1824670b6380
-2026/04/07 20:54:25 Cleaning up writer...
-2026/04/07 20:54:25 Finished cleaning up writer:  0x1824670b6380
-2026/04/07 20:54:25 Closed MCP-GET-SSE SSE connection: 02d64818adea414fd986c626671fa073
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 88ceb3113ad3094366c5599d82a44d4a
+2026/04/08 10:42:52 SSEHub: registered connection 88ceb3113ad3094366c5599d82a44d4a (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 88ceb3113ad3094366c5599d82a44d4a (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e3ac690
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e3ac690
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 88ceb3113ad3094366c5599d82a44d4a
 
 === Running scenario: tools-list ===
 Running client scenario 'tools-list' against server: http://localhost:18799/mcp
-2026/04/07 20:54:25 Starting MCP-GET-SSE SSE connection: 52b2c8e742912f9b32e1f4ad6bc47d38
-2026/04/07 20:54:25 SSEHub: registered connection 52b2c8e742912f9b32e1f4ad6bc47d38 (total: 1)
-2026/04/07 20:54:25 SSEHub: unregistered connection 52b2c8e742912f9b32e1f4ad6bc47d38 (total: 0)
-2026/04/07 20:54:25 Received kill signal.  Quitting Writer. stop 0x18246732e540
-2026/04/07 20:54:25 Cleaning up writer...
-2026/04/07 20:54:25 Finished cleaning up writer:  0x18246732e540
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 274dc3c585e0769cb4f006adcfcaac99
+2026/04/08 10:42:52 SSEHub: registered connection 274dc3c585e0769cb4f006adcfcaac99 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 274dc3c585e0769cb4f006adcfcaac99 (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e14c380
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e14c380
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 274dc3c585e0769cb4f006adcfcaac99
 
 === Running scenario: tools-call-simple-text ===
-2026/04/07 20:54:25 Closed MCP-GET-SSE SSE connection: 52b2c8e742912f9b32e1f4ad6bc47d38
 Running client scenario 'tools-call-simple-text' against server: http://localhost:18799/mcp
-2026/04/07 20:54:25 Starting MCP-GET-SSE SSE connection: d92e378701401269f9d5c9a137571c8c
-2026/04/07 20:54:25 SSEHub: registered connection d92e378701401269f9d5c9a137571c8c (total: 1)
-2026/04/07 20:54:25 SSEHub: unregistered connection d92e378701401269f9d5c9a137571c8c (total: 0)
-2026/04/07 20:54:25 Received kill signal.  Quitting Writer. stop 0x18246732e770
-2026/04/07 20:54:25 Cleaning up writer...
-2026/04/07 20:54:25 Finished cleaning up writer:  0x18246732e770
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: e7e2767b84a90cbab2e34437ee0c3359
+2026/04/08 10:42:52 SSEHub: registered connection e7e2767b84a90cbab2e34437ee0c3359 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection e7e2767b84a90cbab2e34437ee0c3359 (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e236230
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e236230
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: e7e2767b84a90cbab2e34437ee0c3359
 
 === Running scenario: tools-call-image ===
-2026/04/07 20:54:25 Closed MCP-GET-SSE SSE connection: d92e378701401269f9d5c9a137571c8c
 Running client scenario 'tools-call-image' against server: http://localhost:18799/mcp
-2026/04/07 20:54:25 Starting MCP-GET-SSE SSE connection: 99b395e1d691dc1363e53439c7f33a78
-2026/04/07 20:54:25 SSEHub: registered connection 99b395e1d691dc1363e53439c7f33a78 (total: 1)
-2026/04/07 20:54:25 SSEHub: unregistered connection 99b395e1d691dc1363e53439c7f33a78 (total: 0)
-2026/04/07 20:54:25 Received kill signal.  Quitting Writer. stop 0x1824670b6700
-2026/04/07 20:54:25 Cleaning up writer...
-2026/04/07 20:54:25 Finished cleaning up writer:  0x1824670b6700
-2026/04/07 20:54:25 Closed MCP-GET-SSE SSE connection: 99b395e1d691dc1363e53439c7f33a78
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 530a8372abfc6ddb09989b77c1584185
+2026/04/08 10:42:52 SSEHub: registered connection 530a8372abfc6ddb09989b77c1584185 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 530a8372abfc6ddb09989b77c1584185 (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e336690
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e336690
 
 === Running scenario: tools-call-audio ===
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 530a8372abfc6ddb09989b77c1584185
 Running client scenario 'tools-call-audio' against server: http://localhost:18799/mcp
-2026/04/07 20:54:25 Starting MCP-GET-SSE SSE connection: c32a685ff852315f2f2c161211fa5543
-2026/04/07 20:54:25 SSEHub: registered connection c32a685ff852315f2f2c161211fa5543 (total: 1)
-2026/04/07 20:54:25 SSEHub: unregistered connection c32a685ff852315f2f2c161211fa5543 (total: 0)
-2026/04/07 20:54:25 Received kill signal.  Quitting Writer. stop 0x18246732eb60
-2026/04/07 20:54:25 Cleaning up writer...
-2026/04/07 20:54:25 Finished cleaning up writer:  0x18246732eb60
-2026/04/07 20:54:25 Closed MCP-GET-SSE SSE connection: c32a685ff852315f2f2c161211fa5543
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: cab41786ae1223f16660a9a85b6c3544
+2026/04/08 10:42:52 SSEHub: registered connection cab41786ae1223f16660a9a85b6c3544 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection cab41786ae1223f16660a9a85b6c3544 (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e3369a0
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e3369a0
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: cab41786ae1223f16660a9a85b6c3544
 
 === Running scenario: tools-call-embedded-resource ===
 Running client scenario 'tools-call-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/07 20:54:25 Starting MCP-GET-SSE SSE connection: 53a48eb79abe3f800ec6d7202fb9ea63
-2026/04/07 20:54:25 SSEHub: registered connection 53a48eb79abe3f800ec6d7202fb9ea63 (total: 1)
-2026/04/07 20:54:25 SSEHub: unregistered connection 53a48eb79abe3f800ec6d7202fb9ea63 (total: 0)
-2026/04/07 20:54:25 Received kill signal.  Quitting Writer. stop 0x1824671c2930
-2026/04/07 20:54:25 Cleaning up writer...
-2026/04/07 20:54:25 Finished cleaning up writer:  0x1824671c2930
-2026/04/07 20:54:25 Closed MCP-GET-SSE SSE connection: 53a48eb79abe3f800ec6d7202fb9ea63
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 41651b6c7567affcc9b9eeea4b361fd9
+2026/04/08 10:42:52 SSEHub: registered connection 41651b6c7567affcc9b9eeea4b361fd9 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 41651b6c7567affcc9b9eeea4b361fd9 (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e3aca10
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e3aca10
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 41651b6c7567affcc9b9eeea4b361fd9
 
 === Running scenario: tools-call-mixed-content ===
 Running client scenario 'tools-call-mixed-content' against server: http://localhost:18799/mcp
-2026/04/07 20:54:25 Starting MCP-GET-SSE SSE connection: 714b908ac5fb5c19effad757c168f53a
-2026/04/07 20:54:25 SSEHub: registered connection 714b908ac5fb5c19effad757c168f53a (total: 1)
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 5044eeb9b91d63d109a78dda575c4858
+2026/04/08 10:42:52 SSEHub: registered connection 5044eeb9b91d63d109a78dda575c4858 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 5044eeb9b91d63d109a78dda575c4858 (total: 0)
 
 === Running scenario: tools-call-with-logging ===
-2026/04/07 20:54:25 SSEHub: unregistered connection 714b908ac5fb5c19effad757c168f53a (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e336cb0
 Running client scenario 'tools-call-with-logging' against server: http://localhost:18799/mcp
-2026/04/07 20:54:25 Received kill signal.  Quitting Writer. stop 0x1824671c2c40
-2026/04/07 20:54:25 Cleaning up writer...
-2026/04/07 20:54:25 Finished cleaning up writer:  0x1824671c2c40
-2026/04/07 20:54:25 Closed MCP-GET-SSE SSE connection: 714b908ac5fb5c19effad757c168f53a
-2026/04/07 20:54:25 Starting MCP-GET-SSE SSE connection: 291e619f3e09fe8d34f0aca7497e02d2
-2026/04/07 20:54:25 SSEHub: registered connection 291e619f3e09fe8d34f0aca7497e02d2 (total: 1)
-2026/04/07 20:54:26 SSEHub: unregistered connection 291e619f3e09fe8d34f0aca7497e02d2 (total: 0)
-2026/04/07 20:54:26 Received kill signal.  Quitting Writer. stop 0x1824671c2e70
-2026/04/07 20:54:26 Cleaning up writer...
-2026/04/07 20:54:26 Finished cleaning up writer:  0x1824671c2e70
-2026/04/07 20:54:26 Closed MCP-GET-SSE SSE connection: 291e619f3e09fe8d34f0aca7497e02d2
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e336cb0
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 5044eeb9b91d63d109a78dda575c4858
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 267b2e6d4f2c541fc3eaa87cd03c4d1f
+2026/04/08 10:42:52 SSEHub: registered connection 267b2e6d4f2c541fc3eaa87cd03c4d1f (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 267b2e6d4f2c541fc3eaa87cd03c4d1f (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e2365b0
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e2365b0
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 267b2e6d4f2c541fc3eaa87cd03c4d1f
 
 === Running scenario: tools-call-error ===
 Running client scenario 'tools-call-error' against server: http://localhost:18799/mcp
-2026/04/07 20:54:26 Starting MCP-GET-SSE SSE connection: 723988b9f9c195c462326d0cbfb31124
-2026/04/07 20:54:26 SSEHub: registered connection 723988b9f9c195c462326d0cbfb31124 (total: 1)
-2026/04/07 20:54:26 SSEHub: unregistered connection 723988b9f9c195c462326d0cbfb31124 (total: 0)
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 5fd60aefa85da1b4b4a6f3c024c2e5a3
+2026/04/08 10:42:52 SSEHub: registered connection 5fd60aefa85da1b4b4a6f3c024c2e5a3 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 5fd60aefa85da1b4b4a6f3c024c2e5a3 (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e3acd90
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e3acd90
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 5fd60aefa85da1b4b4a6f3c024c2e5a3
 
 === Running scenario: tools-call-with-progress ===
-2026/04/07 20:54:26 Received kill signal.  Quitting Writer. stop 0x1824674be150
-2026/04/07 20:54:26 Cleaning up writer...
-2026/04/07 20:54:26 Finished cleaning up writer:  0x1824674be150
 Running client scenario 'tools-call-with-progress' against server: http://localhost:18799/mcp
-2026/04/07 20:54:26 Closed MCP-GET-SSE SSE connection: 723988b9f9c195c462326d0cbfb31124
-2026/04/07 20:54:26 Starting MCP-GET-SSE SSE connection: 6ce72cecedad56c95eacacd87a193fa8
-2026/04/07 20:54:26 SSEHub: registered connection 6ce72cecedad56c95eacacd87a193fa8 (total: 1)
-2026/04/07 20:54:26 SSEHub: unregistered connection 6ce72cecedad56c95eacacd87a193fa8 (total: 0)
-2026/04/07 20:54:26 Received kill signal.  Quitting Writer. stop 0x18246732f180
-2026/04/07 20:54:26 Cleaning up writer...
-2026/04/07 20:54:26 Finished cleaning up writer:  0x18246732f180
-2026/04/07 20:54:26 Closed MCP-GET-SSE SSE connection: 6ce72cecedad56c95eacacd87a193fa8
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 76ad47856e91027f4f5ecb5299811bd8
+2026/04/08 10:42:52 SSEHub: registered connection 76ad47856e91027f4f5ecb5299811bd8 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 76ad47856e91027f4f5ecb5299811bd8 (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e236930
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e236930
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 76ad47856e91027f4f5ecb5299811bd8
 
 === Running scenario: tools-call-sampling ===
 Running client scenario 'tools-call-sampling' against server: http://localhost:18799/mcp
-2026/04/07 20:54:26 Starting MCP-GET-SSE SSE connection: 820746347f3c591dd9932fa1ccc32d04
-2026/04/07 20:54:26 SSEHub: registered connection 820746347f3c591dd9932fa1ccc32d04 (total: 1)
-2026/04/07 20:54:26 SSEHub: unregistered connection 820746347f3c591dd9932fa1ccc32d04 (total: 0)
-2026/04/07 20:54:26 Received kill signal.  Quitting Writer. stop 0x18246732f3b0
-2026/04/07 20:54:26 Cleaning up writer...
-2026/04/07 20:54:26 Finished cleaning up writer:  0x18246732f3b0
-2026/04/07 20:54:26 Closed MCP-GET-SSE SSE connection: 820746347f3c591dd9932fa1ccc32d04
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: c840b66592a717c6c375b1097d32f26d
+2026/04/08 10:42:52 SSEHub: registered connection c840b66592a717c6c375b1097d32f26d (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection c840b66592a717c6c375b1097d32f26d (total: 0)
 
 === Running scenario: tools-call-elicitation ===
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e3acfc0
+2026/04/08 10:42:52 Cleaning up writer...
 Running client scenario 'tools-call-elicitation' against server: http://localhost:18799/mcp
-2026/04/07 20:54:26 Starting MCP-GET-SSE SSE connection: 8a7db4e668f53802c99e5f19ac31c812
-2026/04/07 20:54:26 SSEHub: registered connection 8a7db4e668f53802c99e5f19ac31c812 (total: 1)
-2026/04/07 20:54:26 SSEHub: unregistered connection 8a7db4e668f53802c99e5f19ac31c812 (total: 0)
-2026/04/07 20:54:26 Received kill signal.  Quitting Writer. stop 0x1824670b69a0
-2026/04/07 20:54:26 Cleaning up writer...
-2026/04/07 20:54:26 Finished cleaning up writer:  0x1824670b69a0
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e3acfc0
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: c840b66592a717c6c375b1097d32f26d
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 0360c44abf053ac97094d00e80c7e679
+2026/04/08 10:42:52 SSEHub: registered connection 0360c44abf053ac97094d00e80c7e679 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 0360c44abf053ac97094d00e80c7e679 (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e3370a0
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e3370a0
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 0360c44abf053ac97094d00e80c7e679
 
 === Running scenario: elicitation-sep1034-defaults ===
-2026/04/07 20:54:26 Closed MCP-GET-SSE SSE connection: 8a7db4e668f53802c99e5f19ac31c812
 Running client scenario 'elicitation-sep1034-defaults' against server: http://localhost:18799/mcp
-2026/04/07 20:54:26 Starting MCP-GET-SSE SSE connection: 7e6b302bded55f8994b5333114f3ee22
-2026/04/07 20:54:26 SSEHub: registered connection 7e6b302bded55f8994b5333114f3ee22 (total: 1)
-2026/04/07 20:54:26 SSEHub: unregistered connection 7e6b302bded55f8994b5333114f3ee22 (total: 0)
-2026/04/07 20:54:26 Received kill signal.  Quitting Writer. stop 0x18246732f7a0
-2026/04/07 20:54:26 Cleaning up writer...
-2026/04/07 20:54:26 Finished cleaning up writer:  0x18246732f7a0
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 57acce210190d393101bfc2d70075fba
+2026/04/08 10:42:52 SSEHub: registered connection 57acce210190d393101bfc2d70075fba (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 57acce210190d393101bfc2d70075fba (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e3372d0
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e3372d0
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 57acce210190d393101bfc2d70075fba
 
 === Running scenario: server-sse-multiple-streams ===
-2026/04/07 20:54:26 Closed MCP-GET-SSE SSE connection: 7e6b302bded55f8994b5333114f3ee22
 Running client scenario 'server-sse-multiple-streams' against server: http://localhost:18799/mcp
-2026/04/07 20:54:26 Starting MCP-GET-SSE SSE connection: 0ed7993365aaee31ce5ba430e6441e89
-2026/04/07 20:54:26 SSEHub: registered connection 0ed7993365aaee31ce5ba430e6441e89 (total: 1)
-2026/04/07 20:54:26 SSEHub: unregistered connection 0ed7993365aaee31ce5ba430e6441e89 (total: 0)
-2026/04/07 20:54:26 Received kill signal.  Quitting Writer. stop 0x1824674be7e0
-2026/04/07 20:54:26 Cleaning up writer...
-2026/04/07 20:54:26 Finished cleaning up writer:  0x1824674be7e0
-2026/04/07 20:54:26 Closed MCP-GET-SSE SSE connection: 0ed7993365aaee31ce5ba430e6441e89
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: e65e255c440f876a758759fd79ce19e9
+2026/04/08 10:42:52 SSEHub: registered connection e65e255c440f876a758759fd79ce19e9 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection e65e255c440f876a758759fd79ce19e9 (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e337500
 
 === Running scenario: elicitation-sep1330-enums ===
+2026/04/08 10:42:52 Cleaning up writer...
 Running client scenario 'elicitation-sep1330-enums' against server: http://localhost:18799/mcp
-2026/04/07 20:54:26 Starting MCP-GET-SSE SSE connection: 38506a21aa5cd9a8fb4218f2d8ac3773
-2026/04/07 20:54:26 SSEHub: registered connection 38506a21aa5cd9a8fb4218f2d8ac3773 (total: 1)
-2026/04/07 20:54:26 SSEHub: unregistered connection 38506a21aa5cd9a8fb4218f2d8ac3773 (total: 0)
-2026/04/07 20:54:26 Received kill signal.  Quitting Writer. stop 0x1824674beaf0
-2026/04/07 20:54:26 Cleaning up writer...
-2026/04/07 20:54:26 Finished cleaning up writer:  0x1824674beaf0
-2026/04/07 20:54:26 Closed MCP-GET-SSE SSE connection: 38506a21aa5cd9a8fb4218f2d8ac3773
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e337500
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: e65e255c440f876a758759fd79ce19e9
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 30955bdff128a735615627e713e034e0
+2026/04/08 10:42:52 SSEHub: registered connection 30955bdff128a735615627e713e034e0 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 30955bdff128a735615627e713e034e0 (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e3ad340
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e3ad340
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 30955bdff128a735615627e713e034e0
 
 === Running scenario: resources-list ===
 Running client scenario 'resources-list' against server: http://localhost:18799/mcp
-2026/04/07 20:54:26 Starting MCP-GET-SSE SSE connection: d6410bbdb77f451e82787e279630e6f6
-2026/04/07 20:54:26 SSEHub: registered connection d6410bbdb77f451e82787e279630e6f6 (total: 1)
-2026/04/07 20:54:26 SSEHub: unregistered connection d6410bbdb77f451e82787e279630e6f6 (total: 0)
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 316df31d5f563b5ef21474086331ba14
+2026/04/08 10:42:52 SSEHub: registered connection 316df31d5f563b5ef21474086331ba14 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 316df31d5f563b5ef21474086331ba14 (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e337a40
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e337a40
 
 === Running scenario: resources-read-text ===
-2026/04/07 20:54:26 Received kill signal.  Quitting Writer. stop 0x1824670b6d90
-2026/04/07 20:54:26 Cleaning up writer...
-2026/04/07 20:54:26 Finished cleaning up writer:  0x1824670b6d90
-2026/04/07 20:54:26 Closed MCP-GET-SSE SSE connection: d6410bbdb77f451e82787e279630e6f6
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 316df31d5f563b5ef21474086331ba14
 Running client scenario 'resources-read-text' against server: http://localhost:18799/mcp
-2026/04/07 20:54:26 Starting MCP-GET-SSE SSE connection: 7b9e7a4589777a9cbbedd9036ccb610f
-2026/04/07 20:54:26 SSEHub: registered connection 7b9e7a4589777a9cbbedd9036ccb610f (total: 1)
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 7adf5cdad6213b925bd14124241f4a02
+2026/04/08 10:42:52 SSEHub: registered connection 7adf5cdad6213b925bd14124241f4a02 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 7adf5cdad6213b925bd14124241f4a02 (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e3ad570
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e3ad570
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 7adf5cdad6213b925bd14124241f4a02
 
 === Running scenario: resources-read-binary ===
-2026/04/07 20:54:26 SSEHub: unregistered connection 7b9e7a4589777a9cbbedd9036ccb610f (total: 0)
 Running client scenario 'resources-read-binary' against server: http://localhost:18799/mcp
-2026/04/07 20:54:26 Received kill signal.  Quitting Writer. stop 0x1824674bed90
-2026/04/07 20:54:26 Cleaning up writer...
-2026/04/07 20:54:26 Finished cleaning up writer:  0x1824674bed90
-2026/04/07 20:54:26 Closed MCP-GET-SSE SSE connection: 7b9e7a4589777a9cbbedd9036ccb610f
-2026/04/07 20:54:26 Starting MCP-GET-SSE SSE connection: be8f13292a825e9d868198bb7ac38976
-2026/04/07 20:54:26 SSEHub: registered connection be8f13292a825e9d868198bb7ac38976 (total: 1)
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 3bab85b6cc1446eea487b4fa03740db2
+2026/04/08 10:42:52 SSEHub: registered connection 3bab85b6cc1446eea487b4fa03740db2 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 3bab85b6cc1446eea487b4fa03740db2 (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e337d50
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e337d50
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 3bab85b6cc1446eea487b4fa03740db2
 
 === Running scenario: resources-templates-read ===
-2026/04/07 20:54:26 SSEHub: unregistered connection be8f13292a825e9d868198bb7ac38976 (total: 0)
 Running client scenario 'resources-templates-read' against server: http://localhost:18799/mcp
-2026/04/07 20:54:26 Received kill signal.  Quitting Writer. stop 0x18246732fb20
-2026/04/07 20:54:26 Cleaning up writer...
-2026/04/07 20:54:26 Finished cleaning up writer:  0x18246732fb20
-2026/04/07 20:54:26 Closed MCP-GET-SSE SSE connection: be8f13292a825e9d868198bb7ac38976
-2026/04/07 20:54:26 Starting MCP-GET-SSE SSE connection: a8bfc8fa6c35ecbce6191198eef42581
-2026/04/07 20:54:26 SSEHub: registered connection a8bfc8fa6c35ecbce6191198eef42581 (total: 1)
-2026/04/07 20:54:26 SSEHub: unregistered connection a8bfc8fa6c35ecbce6191198eef42581 (total: 0)
-2026/04/07 20:54:26 Received kill signal.  Quitting Writer. stop 0x18246732fd50
-2026/04/07 20:54:26 Cleaning up writer...
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 3604c447a0d23fbfb346b197b91cfe03
+2026/04/08 10:42:52 SSEHub: registered connection 3604c447a0d23fbfb346b197b91cfe03 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 3604c447a0d23fbfb346b197b91cfe03 (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e2370a0
+2026/04/08 10:42:52 Cleaning up writer...
 
 === Running scenario: resources-subscribe ===
-2026/04/07 20:54:26 Finished cleaning up writer:  0x18246732fd50
-2026/04/07 20:54:26 Closed MCP-GET-SSE SSE connection: a8bfc8fa6c35ecbce6191198eef42581
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e2370a0
 Running client scenario 'resources-subscribe' against server: http://localhost:18799/mcp
-2026/04/07 20:54:26 Starting MCP-GET-SSE SSE connection: 35f2dff2f665775956786b3a3e1d93cf
-2026/04/07 20:54:26 SSEHub: registered connection 35f2dff2f665775956786b3a3e1d93cf (total: 1)
-2026/04/07 20:54:26 SSEHub: unregistered connection 35f2dff2f665775956786b3a3e1d93cf (total: 0)
-2026/04/07 20:54:26 Received kill signal.  Quitting Writer. stop 0x1824670b7110
-2026/04/07 20:54:26 Cleaning up writer...
-2026/04/07 20:54:26 Finished cleaning up writer:  0x1824670b7110
-2026/04/07 20:54:26 Closed MCP-GET-SSE SSE connection: 35f2dff2f665775956786b3a3e1d93cf
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 3604c447a0d23fbfb346b197b91cfe03
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: a930602cfc6d0be12dd9073de4d61d6e
+2026/04/08 10:42:52 SSEHub: registered connection a930602cfc6d0be12dd9073de4d61d6e (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection a930602cfc6d0be12dd9073de4d61d6e (total: 0)
 
 === Running scenario: resources-unsubscribe ===
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e0a0a10
 Running client scenario 'resources-unsubscribe' against server: http://localhost:18799/mcp
-2026/04/07 20:54:26 Starting MCP-GET-SSE SSE connection: 273b79e1e66ba71ca23afcdb5b30808d
-2026/04/07 20:54:26 SSEHub: registered connection 273b79e1e66ba71ca23afcdb5b30808d (total: 1)
-2026/04/07 20:54:26 SSEHub: unregistered connection 273b79e1e66ba71ca23afcdb5b30808d (total: 0)
-2026/04/07 20:54:26 Received kill signal.  Quitting Writer. stop 0x1824671c3650
-2026/04/07 20:54:26 Cleaning up writer...
-2026/04/07 20:54:26 Finished cleaning up writer:  0x1824671c3650
-2026/04/07 20:54:26 Closed MCP-GET-SSE SSE connection: 273b79e1e66ba71ca23afcdb5b30808d
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e0a0a10
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: a930602cfc6d0be12dd9073de4d61d6e
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 4c9ce409b01db87894e94b04abcbc761
+2026/04/08 10:42:52 SSEHub: registered connection 4c9ce409b01db87894e94b04abcbc761 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 4c9ce409b01db87894e94b04abcbc761 (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e3ad810
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e3ad810
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 4c9ce409b01db87894e94b04abcbc761
 
 === Running scenario: prompts-list ===
 Running client scenario 'prompts-list' against server: http://localhost:18799/mcp
-2026/04/07 20:54:26 Starting MCP-GET-SSE SSE connection: 85469165e326585cc2025a3127b0e05a
-2026/04/07 20:54:26 SSEHub: registered connection 85469165e326585cc2025a3127b0e05a (total: 1)
-2026/04/07 20:54:26 SSEHub: unregistered connection 85469165e326585cc2025a3127b0e05a (total: 0)
-2026/04/07 20:54:26 Received kill signal.  Quitting Writer. stop 0x1824671c3960
-2026/04/07 20:54:26 Cleaning up writer...
-2026/04/07 20:54:26 Finished cleaning up writer:  0x1824671c3960
-2026/04/07 20:54:26 Closed MCP-GET-SSE SSE connection: 85469165e326585cc2025a3127b0e05a
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 1abe9e78839082ee228282640ee3da54
+2026/04/08 10:42:52 SSEHub: registered connection 1abe9e78839082ee228282640ee3da54 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 1abe9e78839082ee228282640ee3da54 (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e3adb20
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e3adb20
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 1abe9e78839082ee228282640ee3da54
 
 === Running scenario: prompts-get-simple ===
 Running client scenario 'prompts-get-simple' against server: http://localhost:18799/mcp
-2026/04/07 20:54:26 Starting MCP-GET-SSE SSE connection: 13f570609d8d685188b708ba9e257f8e
-2026/04/07 20:54:26 SSEHub: registered connection 13f570609d8d685188b708ba9e257f8e (total: 1)
-2026/04/07 20:54:26 SSEHub: unregistered connection 13f570609d8d685188b708ba9e257f8e (total: 0)
-2026/04/07 20:54:26 Received kill signal.  Quitting Writer. stop 0x182467438150
-2026/04/07 20:54:26 Cleaning up writer...
-2026/04/07 20:54:26 Finished cleaning up writer:  0x182467438150
-2026/04/07 20:54:26 Closed MCP-GET-SSE SSE connection: 13f570609d8d685188b708ba9e257f8e
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 13597c9392010cd01aea5eafc1bcfd34
+2026/04/08 10:42:52 SSEHub: registered connection 13597c9392010cd01aea5eafc1bcfd34 (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 13597c9392010cd01aea5eafc1bcfd34 (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e0a0d20
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e0a0d20
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 13597c9392010cd01aea5eafc1bcfd34
 
 === Running scenario: prompts-get-with-args ===
 Running client scenario 'prompts-get-with-args' against server: http://localhost:18799/mcp
-2026/04/07 20:54:26 Starting MCP-GET-SSE SSE connection: d0dea2d09744384ee942c2eb75f25848
-2026/04/07 20:54:26 SSEHub: registered connection d0dea2d09744384ee942c2eb75f25848 (total: 1)
-2026/04/07 20:54:26 SSEHub: unregistered connection d0dea2d09744384ee942c2eb75f25848 (total: 0)
-2026/04/07 20:54:26 Received kill signal.  Quitting Writer. stop 0x1824674bf0a0
-2026/04/07 20:54:26 Cleaning up writer...
-2026/04/07 20:54:26 Finished cleaning up writer:  0x1824674bf0a0
-2026/04/07 20:54:26 Closed MCP-GET-SSE SSE connection: d0dea2d09744384ee942c2eb75f25848
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 7dd88422a46134db8f1f4e3eccd85bbd
+2026/04/08 10:42:52 SSEHub: registered connection 7dd88422a46134db8f1f4e3eccd85bbd (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 7dd88422a46134db8f1f4e3eccd85bbd (total: 0)
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e0a0fc0
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e0a0fc0
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 7dd88422a46134db8f1f4e3eccd85bbd
 
 === Running scenario: prompts-get-embedded-resource ===
 Running client scenario 'prompts-get-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/07 20:54:26 Starting MCP-GET-SSE SSE connection: 6969261c0f6835da5bf3bc4e498d39f6
-2026/04/07 20:54:26 SSEHub: registered connection 6969261c0f6835da5bf3bc4e498d39f6 (total: 1)
-2026/04/07 20:54:26 SSEHub: unregistered connection 6969261c0f6835da5bf3bc4e498d39f6 (total: 0)
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 1ecb34bf02088efd0d5db28c7cc1d4fe
+2026/04/08 10:42:52 SSEHub: registered connection 1ecb34bf02088efd0d5db28c7cc1d4fe (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 1ecb34bf02088efd0d5db28c7cc1d4fe (total: 0)
 
 === Running scenario: prompts-get-with-image ===
-2026/04/07 20:54:26 Received kill signal.  Quitting Writer. stop 0x1824671c3c00
-2026/04/07 20:54:26 Cleaning up writer...
-2026/04/07 20:54:26 Finished cleaning up writer:  0x1824671c3c00
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e2373b0
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e2373b0
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 1ecb34bf02088efd0d5db28c7cc1d4fe
 Running client scenario 'prompts-get-with-image' against server: http://localhost:18799/mcp
-2026/04/07 20:54:26 Closed MCP-GET-SSE SSE connection: 6969261c0f6835da5bf3bc4e498d39f6
-2026/04/07 20:54:26 Starting MCP-GET-SSE SSE connection: 5e13c7d5f81080b7529f73d154906e2d
-2026/04/07 20:54:26 SSEHub: registered connection 5e13c7d5f81080b7529f73d154906e2d (total: 1)
-2026/04/07 20:54:26 SSEHub: unregistered connection 5e13c7d5f81080b7529f73d154906e2d (total: 0)
-2026/04/07 20:54:26 Received kill signal.  Quitting Writer. stop 0x1824670b7500
-2026/04/07 20:54:26 Cleaning up writer...
-2026/04/07 20:54:26 Finished cleaning up writer:  0x1824670b7500
-2026/04/07 20:54:26 Closed MCP-GET-SSE SSE connection: 5e13c7d5f81080b7529f73d154906e2d
+2026/04/08 10:42:52 Starting MCP-GET-SSE SSE connection: 5fa4d7673fef6998f79a5f4fb7a3047d
+2026/04/08 10:42:52 SSEHub: registered connection 5fa4d7673fef6998f79a5f4fb7a3047d (total: 1)
+2026/04/08 10:42:52 SSEHub: unregistered connection 5fa4d7673fef6998f79a5f4fb7a3047d (total: 0)
 
 === Running scenario: dns-rebinding-protection ===
+2026/04/08 10:42:52 Received kill signal.  Quitting Writer. stop 0x2b913e2376c0
+2026/04/08 10:42:52 Cleaning up writer...
+2026/04/08 10:42:52 Finished cleaning up writer:  0x2b913e2376c0
+2026/04/08 10:42:52 Closed MCP-GET-SSE SSE connection: 5fa4d7673fef6998f79a5f4fb7a3047d
 Running client scenario 'dns-rebinding-protection' against server: http://localhost:18799/mcp
 
 
@@ -390,22 +390,22 @@ Starting scenario: auth/token-endpoint-auth-basic
 Starting scenario: auth/token-endpoint-auth-post
 Starting scenario: auth/token-endpoint-auth-none
 Starting scenario: auth/pre-registration
-Executing client: ./bin/testclient http://localhost:60735/mcp
-Executing client: ./bin/testclient http://localhost:60736/mcp
-Executing client: ./bin/testclient http://localhost:60737/mcp
-Executing client: ./bin/testclient http://localhost:60738/mcp
-Executing client: ./bin/testclient http://localhost:60739/mcp
-Executing client: ./bin/testclient http://localhost:60740/mcp
-Executing client: ./bin/testclient http://localhost:60741/mcp
-Executing client: ./bin/testclient http://localhost:60742/mcp
-Executing client: ./bin/testclient http://localhost:60743/mcp
-Executing client: ./bin/testclient http://localhost:60744/mcp
-Executing client: ./bin/testclient http://localhost:60745/mcp
-Executing client: ./bin/testclient http://localhost:60746/mcp
-Executing client: ./bin/testclient http://localhost:60747/mcp
-Executing client: ./bin/testclient http://localhost:60748/mcp
+Executing client: ./bin/testclient http://localhost:58354/mcp
+Executing client: ./bin/testclient http://localhost:58355/mcp
+Executing client: ./bin/testclient http://localhost:58356/mcp
+Executing client: ./bin/testclient http://localhost:58357/mcp
+Executing client: ./bin/testclient http://localhost:58358/mcp
+Executing client: ./bin/testclient http://localhost:58359/mcp
+Executing client: ./bin/testclient http://localhost:58360/mcp
+Executing client: ./bin/testclient http://localhost:58361/mcp
+Executing client: ./bin/testclient http://localhost:58362/mcp
+Executing client: ./bin/testclient http://localhost:58363/mcp
+Executing client: ./bin/testclient http://localhost:58364/mcp
+Executing client: ./bin/testclient http://localhost:58365/mcp
+Executing client: ./bin/testclient http://localhost:58366/mcp
+Executing client: ./bin/testclient http://localhost:58367/mcp
 With context: {"client_id":"pre-registered-client","client_secret":"pre-registered-secret"}
-(node:4923) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
+(node:43768) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
 (Use `node --trace-deprecation ...` to show where the warning was created)
 
 === SUITE SUMMARY ===
@@ -436,7 +436,7 @@ Total: 210 passed, 0 failed, 1 warnings
   PASS: auth-conformance
 --- [8/8] keycloak ---
 === RUN   TestKeycloak_MCPServer_ValidToken
---- PASS: TestKeycloak_MCPServer_ValidToken (0.23s)
+--- PASS: TestKeycloak_MCPServer_ValidToken (0.25s)
 === RUN   TestKeycloak_MCPServer_TamperedToken
 --- PASS: TestKeycloak_MCPServer_TamperedToken (0.02s)
 === RUN   TestKeycloak_MCPServer_ScopeAllowed
@@ -448,10 +448,10 @@ Total: 210 passed, 0 failed, 1 warnings
 === RUN   TestKeycloak_MCPServer_WWWAuthenticate
 --- PASS: TestKeycloak_MCPServer_WWWAuthenticate (0.01s)
 === RUN   TestKeycloak_MCPServer_PasswordGrant
---- PASS: TestKeycloak_MCPServer_PasswordGrant (0.12s)
+--- PASS: TestKeycloak_MCPServer_PasswordGrant (0.13s)
 PASS
-ok  	github.com/panyam/mcpkit/tests/keycloak	1.113s
+ok  	github.com/panyam/mcpkit/tests/keycloak	1.204s
   PASS: keycloak
 
 === Results: 8 passed, 0 failed ===
-Finished: Tue Apr  7 20:54:30 PDT 2026
+Finished: Wed Apr  8 10:42:57 PDT 2026


### PR DESCRIPTION
## Summary

- **Dynamic tool/resource/prompt registration (#64)**: Thread-safe `Registry` type with `AddTool`/`RemoveTool`, `AddResource`/`RemoveResource`, `AddPrompt`/`RemovePrompt`. Mutations automatically broadcast `notifications/*/list_changed` to all connected sessions via `OnChange` callback. All dispatcher handlers use `RLock` for map lookups only (never during handler execution). Typed `ServerCapabilities` struct replaces `map[string]any` in initialize response.
- **Session idle timeout (#60)**: `WithSessionTimeout(d)` transport option for Streamable HTTP. `sessionEntry` wrapper adds per-session idle timer with acquire/release ref counting — timer pauses during active POST dispatches and GET SSE streams, preventing session expiry mid-execution. Expired sessions are logged and cleaned up automatically.

## Test plan

- [x] 13 dynamic registration tests (add/remove tools/resources/prompts, list_changed broadcast, concurrent add+list under `-race`, capability advertisement)
- [x] 5 session timeout tests (expiry, timer reset on activity, pause during active request, DELETE stops timer, no timeout by default)
- [x] All existing unit tests pass with `-race` (core, server, client, testutil)
- [x] MCP conformance: 40/40 server scenarios passing
- [x] E2E tests pass (auth + apps)
- [x] Sub-module tests pass (ext/auth, ext/ui)

Closes #60, closes #64