### PR TITLE
feat: CommandTransport + ModifyRequest hook (#70, #135)

### DIFF
--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -61,6 +61,8 @@
 - mcp-dynamic-registration: Registry.AddTool/RemoveTool/AddResource/RemoveResource/AddPrompt/RemovePrompt — thread-safe runtime registration with automatic notifications/*/list_changed broadcast via OnChange callback
 - mcp-session-timeout: WithSessionTimeout — idle session cleanup for Streamable HTTP (timer + ref counting to avoid closing mid-execution)
 - mcp-server-capabilities-typed: core.ServerCapabilities, ToolsCap, ResourcesCap, PromptsCap — typed structs for initialize response capabilities
+- mcp-command-transport: CommandTransport — spawn subprocess MCP servers, communicate via stdio, graceful SIGTERM/SIGKILL shutdown, stderr capture, env passthrough. WithCommandTransport client option supports reconnection (auto-restart).
+- mcp-modify-request: WithModifyRequest — client-side HTTP request hook for injecting custom headers (tracing, tenant IDs). Runs before auth, applies to Streamable HTTP + SSE transports.
 
 ## Module
 github.com/panyam/mcpkit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,8 +62,9 @@ mcpkit/
 │   └── pagination.go          cursor-based pagination
 │
 ├── client/                  ← Client + all client transports
-│   ├── client.go              Client, NewClient, Connect, ToolCall, WithTransport, WithExtension, WithUIExtension, WithGetSSEStream, ServerSupportsExtension, ServerSupportsUI, ListToolsForModel, ResolveEndpointURL, HTTPStatusError, DoWithAuthRetry
+│   ├── client.go              Client, NewClient, Connect, ToolCall, ToolCallTyped, WithTransport, WithExtension, WithUIExtension, WithGetSSEStream, WithModifyRequest, WithCommandTransport, ServerSupportsExtension, ServerSupportsUI, ListToolsForModel, ResolveEndpointURL, HTTPStatusError, DoWithAuthRetry
 │   ├── stdio_transport.go     StdioTransport, NewStdioTransport, WithStdioTransport
+│   ├── command_transport.go   CommandTransport, NewCommandTransport, WithEnv, WithDir, WithShutdownTimeout, WithStderr
 │   ├── client_logging.go      loggingTransport, WithClientLogging
 │   └── client_reconnect.go    WithMaxRetries, WithReconnectBackoff, IsTransientError
 │
@@ -139,6 +140,18 @@ mcpkit/
 ### Client Typed Tool Calls
 - **`ToolCallTyped[T](c, name, args)`**: Generic function that calls a tool and unmarshals `structuredContent` into T. For tools with `OutputSchema`. Returns error if no structured content.
 - **Complements `ToolCall`**: `ToolCall` returns text, `ToolCallTyped` returns typed structs.
+
+### CommandTransport (Subprocess MCP Servers)
+- **`NewCommandTransport(name, args, opts...)`**: Spawns a subprocess and communicates via Content-Length framed JSON-RPC over stdin/stdout. Wraps `StdioTransport` for the wire protocol.
+- **Options**: `WithEnv(env...)` appends env vars, `WithDir(dir)` sets working directory, `WithShutdownTimeout(d)` controls SIGTERM→SIGKILL escalation (default 5s), `WithStderr(w)` tees stderr to a writer.
+- **Lifecycle**: Process starts on `Connect()`, shuts down on `Close()` (stdin EOF → SIGTERM → SIGKILL after timeout). Stderr captured in internal buffer, accessible via `Stderr()`.
+- **`WithCommandTransport(name, args, opts...)`**: Client option that stores command config; creates a fresh `CommandTransport` on each `Connect()` and `reconnect()`. Supports `WithMaxRetries` for automatic process restart on failure.
+- **`WithTransport(NewCommandTransport(...))`** also works but does NOT support reconnection (the transport is not recreated).
+
+### ModifyRequest Hook
+- **`WithModifyRequest(fn func(*http.Request))`**: Client option. Callback invoked on every outgoing HTTP request inside `buildReq`, before `DoWithAuthRetry` applies the `Authorization` header. Cannot accidentally clobber auth.
+- **Applies to HTTP transports only** (Streamable HTTP and SSE). Ignored for stdio and in-process. Survives reconnection.
+- **8 call sites**: 4 in `streamableClientTransport` (call, notify, postResponse, openGetSSEStream) + 4 in `sseClientTransport` (connect, call, notify, postResponse).
 
 ### Application-Level Keepalive
 - **`WithKeepalive(interval, maxFailures)`**: Server-side option. Sends JSON-RPC `ping` requests to clients via GET SSE stream at the configured interval. After `maxFailures` consecutive timeouts, the session is expired.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ srv.Run(":8787") // Streamable HTTP
 |---------|--------|------|
 | **core** | `github.com/panyam/mcpkit/core` | Protocol types (Request, ToolDef, Content, Claims) + tool-handler APIs (Sample, Elicit, EmitLog) |
 | **server** | `github.com/panyam/mcpkit/server` | Server, Dispatcher, transports (SSE + Streamable HTTP), middleware |
-| **client** | `github.com/panyam/mcpkit/client` | Client, HTTP transports, reconnection, logging |
+| **client** | `github.com/panyam/mcpkit/client` | Client, HTTP/stdio/command transports, reconnection, logging |
 | **ext/auth** | `github.com/panyam/mcpkit/ext/auth` | Separate module: JWT, PRM, OAuth discovery, DCR, CIMD |
 | **ext/ui** | `github.com/panyam/mcpkit/ext/ui` | Separate module: MCP Apps extension (UIExtension, RegisterAppTool) |
 | **testutil** | `github.com/panyam/mcpkit/testutil` | TestClient wrapper for e2e tests |
@@ -63,6 +63,37 @@ make test-apps-playwright  # ext-apps Playwright suite (needs Node.js)
 | [ext/auth/docs/DESIGN.md](ext/auth/docs/DESIGN.md) | Auth architecture, spec compliance (C1-C23, X1-X5) |
 | [docs/APPS_DESIGN.md](docs/APPS_DESIGN.md) | MCP Apps extension design, protocol flows, conformance strategy |
 | [CAPABILITIES.md](CAPABILITIES.md) | Stack component: all capabilities listed |
+
+## Client Features
+
+### Subprocess MCP Servers
+
+Spawn and manage subprocess MCP servers with `CommandTransport`:
+
+```go
+c := client.NewClient("", info,
+    client.WithCommandTransport("python", []string{"my_server.py"},
+        client.WithEnv("DEBUG=1"),
+        client.WithShutdownTimeout(10*time.Second),
+    ),
+    client.WithMaxRetries(3), // auto-restart on crash
+)
+c.Connect()
+defer c.Close()
+```
+
+### Custom Request Headers
+
+Inject headers into all outgoing HTTP requests:
+
+```go
+c := client.NewClient(url, info,
+    client.WithModifyRequest(func(req *http.Request) {
+        req.Header.Set("X-Tenant-ID", "acme")
+        req.Header.Set("X-Request-ID", uuid.New().String())
+    }),
+)
+```
 
 ## Dependencies
 

--- a/client/client.go
+++ b/client/client.go
@@ -97,6 +97,47 @@ func WithGetSSEStream() ClientOption {
 	return func(c *Client) { c.enableGetSSE = true }
 }
 
+// WithModifyRequest sets a callback that is invoked on every outgoing HTTP
+// request before authentication headers are applied. Use it to add custom
+// headers (API keys, tracing IDs, tenant identifiers) without needing a
+// custom http.RoundTripper.
+//
+// The callback must not modify the request body or URL.
+// Only applies to HTTP transports (Streamable HTTP, SSE); ignored for
+// stdio and in-process transports.
+//
+// Example:
+//
+//	c := client.NewClient(url, info,
+//	    client.WithModifyRequest(func(req *http.Request) {
+//	        req.Header.Set("X-Tenant-ID", "acme")
+//	        req.Header.Set("X-Request-ID", uuid.New().String())
+//	    }),
+//	)
+func WithModifyRequest(fn func(*http.Request)) ClientOption {
+	return func(c *Client) { c.modifyRequest = fn }
+}
+
+// WithCommandTransport configures the client to spawn a subprocess MCP server
+// and communicate over stdin/stdout. A fresh process is started on each
+// Connect() (and on each reconnection if WithMaxRetries is set).
+//
+// Example:
+//
+//	c := client.NewClient("", info,
+//	    client.WithCommandTransport("python", []string{"my_server.py"},
+//	        client.WithEnv("DEBUG=1"),
+//	    ),
+//	)
+//	err := c.Connect()
+func WithCommandTransport(name string, args []string, opts ...CommandOption) ClientOption {
+	return func(c *Client) {
+		c.commandName = name
+		c.commandArgs = args
+		c.commandOpts = opts
+	}
+}
+
 // WithClientKeepalive enables application-level keepalive pings. The client
 // periodically sends JSON-RPC ping requests to the server. If maxFailures
 // consecutive pings fail (timeout or error), the client triggers reconnection
@@ -238,6 +279,14 @@ type Client struct {
 	// Stdio transport fields (set by WithStdioTransport).
 	stdioReader io.Reader
 	stdioWriter io.Writer
+
+	// ModifyRequest hook for outgoing HTTP requests (set by WithModifyRequest).
+	modifyRequest func(*http.Request)
+
+	// Command transport fields (set by WithCommandTransport).
+	commandName string
+	commandArgs []string
+	commandOpts []CommandOption
 }
 
 // NewClient creates a new MCP client targeting the given server URL.
@@ -259,7 +308,22 @@ func NewClient(url string, info core.ClientInfo, opts ...ClientOption) *Client {
 func (c *Client) Connect() error {
 	// Create transport (skip if already set, e.g., by WithInMemoryServer)
 	if c.transport == nil {
-		if c.stdioReader != nil && c.stdioWriter != nil {
+		if c.commandName != "" {
+			ct := NewCommandTransport(c.commandName, c.commandArgs, c.commandOpts...)
+			ct.serverReqHandler = func(_ context.Context, req *core.Request) *core.Response {
+				return c.HandleServerRequest(req)
+			}
+			if c.onNotify != nil {
+				ct.notifyHandler = func(method string, params []byte) {
+					var parsed any
+					if len(params) > 0 {
+						json.Unmarshal(params, &parsed)
+					}
+					c.onNotify(method, parsed)
+				}
+			}
+			c.transport = &coreTransportAdapter{inner: ct}
+		} else if c.stdioReader != nil && c.stdioWriter != nil {
 			st := NewStdioTransport(c.stdioReader, c.stdioWriter)
 			st.serverReqHandler = func(_ context.Context, req *core.Request) *core.Response {
 				return c.HandleServerRequest(req)
@@ -277,6 +341,7 @@ func (c *Client) Connect() error {
 		} else if c.useSSE {
 			st := newSSEClientTransport(c.url, c.tokenSource)
 			st.serverReqHandler = c.HandleServerRequest
+			st.modifyReq = c.modifyRequest
 			if c.onNotify != nil {
 				st.notifyHandler = c.makeNotifyAdapter()
 			}
@@ -286,6 +351,7 @@ func (c *Client) Connect() error {
 			st.client = c
 			st.serverReqHandler = c.HandleServerRequest
 			st.enableGetSSE = c.enableGetSSE
+			st.modifyReq = c.modifyRequest
 			if c.onNotify != nil {
 				st.notifyHandler = c.makeNotifyAdapter()
 			}
@@ -799,6 +865,9 @@ type streamableClientTransport struct {
 	getSSEResp   *http.Response       // open GET response (for close)
 	getSSEDone   chan struct{}         // closed when background reader exits
 	getSSECancel context.CancelFunc   // cancels the GET request context
+
+	// ModifyRequest hook called inside buildReq before auth is applied.
+	modifyReq func(*http.Request)
 }
 
 func newStreamableClientTransport(url string, ts core.TokenSource) *streamableClientTransport {
@@ -844,6 +913,9 @@ func (t *streamableClientTransport) openGetSSEStream() {
 			if lastID, ok := t.client.lastEventID.Load().(string); ok && lastID != "" {
 				req.Header.Set("Last-Event-ID", lastID)
 			}
+		}
+		if t.modifyReq != nil {
+			t.modifyReq(req)
 		}
 		return req, nil
 	}
@@ -942,6 +1014,9 @@ func (t *streamableClientTransport) call(data []byte) (*rpcResponse, error) {
 		if t.sessionID != "" {
 			req.Header.Set("Mcp-Session-Id", t.sessionID)
 		}
+		if t.modifyReq != nil {
+			t.modifyReq(req)
+		}
 		return req, nil
 	}
 
@@ -1038,6 +1113,9 @@ func (t *streamableClientTransport) postResponse(resp *core.Response) {
 		if t.sessionID != "" {
 			req.Header.Set("Mcp-Session-Id", t.sessionID)
 		}
+		if t.modifyReq != nil {
+			t.modifyReq(req)
+		}
 		return req, nil
 	}
 	httpResp, err := DoWithAuthRetry(t.tokenSource, buildReq, t.httpClient.Do)
@@ -1057,6 +1135,9 @@ func (t *streamableClientTransport) notify(data []byte) error {
 		req.Header.Set("Accept", core.StreamableHTTPAccept)
 		if t.sessionID != "" {
 			req.Header.Set("Mcp-Session-Id", t.sessionID)
+		}
+		if t.modifyReq != nil {
+			t.modifyReq(req)
 		}
 		return req, nil
 	}
@@ -1099,6 +1180,9 @@ type sseClientTransport struct {
 	notifyHandler    func(method string, params json.RawMessage) // set by Client before connect
 	done             chan struct{}                               // closed when background reader exits
 	readerErr        error                                       // last error from background reader
+
+	// ModifyRequest hook called inside buildReq before auth is applied.
+	modifyReq func(*http.Request)
 }
 
 func newSSEClientTransport(sseURL string, ts core.TokenSource) *sseClientTransport {
@@ -1107,7 +1191,14 @@ func newSSEClientTransport(sseURL string, ts core.TokenSource) *sseClientTranspo
 
 func (t *sseClientTransport) connect() error {
 	buildReq := func() (*http.Request, error) {
-		return http.NewRequest("GET", t.sseURL, nil)
+		req, err := http.NewRequest("GET", t.sseURL, nil)
+		if err != nil {
+			return nil, err
+		}
+		if t.modifyReq != nil {
+			t.modifyReq(req)
+		}
+		return req, nil
 	}
 
 	resp, err := DoWithAuthRetry(t.tokenSource, buildReq, t.httpClient.Do)
@@ -1234,6 +1325,9 @@ func (t *sseClientTransport) postResponse(resp *core.Response) {
 			return nil, err
 		}
 		req.Header.Set("Content-Type", "application/json")
+		if t.modifyReq != nil {
+			t.modifyReq(req)
+		}
 		return req, nil
 	}
 	httpResp, err := DoWithAuthRetry(t.tokenSource, buildReq, t.httpClient.Do)
@@ -1289,6 +1383,9 @@ func (t *sseClientTransport) call(data []byte) (*rpcResponse, error) {
 			return nil, err
 		}
 		req.Header.Set("Content-Type", "application/json")
+		if t.modifyReq != nil {
+			t.modifyReq(req)
+		}
 		return req, nil
 	}
 
@@ -1335,6 +1432,9 @@ func (t *sseClientTransport) notify(data []byte) error {
 			return nil, err
 		}
 		req.Header.Set("Content-Type", "application/json")
+		if t.modifyReq != nil {
+			t.modifyReq(req)
+		}
 		return req, nil
 	}
 

--- a/client/client_modify_request_test.go
+++ b/client/client_modify_request_test.go
@@ -1,0 +1,147 @@
+package client_test
+
+// Tests for the WithModifyRequest client option. Verifies that the callback
+// is invoked on every outgoing HTTP request for both Streamable HTTP and SSE
+// transports, survives reconnection, and cannot override auth headers.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	client "github.com/panyam/mcpkit/client"
+	core "github.com/panyam/mcpkit/core"
+	server "github.com/panyam/mcpkit/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// headerCapture is an http.Handler middleware that records all incoming
+// request headers for later inspection. It wraps the real server handler.
+type headerCapture struct {
+	inner   http.Handler
+	mu      sync.Mutex
+	headers []http.Header
+}
+
+func (h *headerCapture) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.mu.Lock()
+	h.headers = append(h.headers, r.Header.Clone())
+	h.mu.Unlock()
+	h.inner.ServeHTTP(w, r)
+}
+
+func (h *headerCapture) getHeaders() []http.Header {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	cp := make([]http.Header, len(h.headers))
+	copy(cp, h.headers)
+	return cp
+}
+
+// TestModifyRequest_AddsCustomHeader verifies that WithModifyRequest injects
+// a custom header into every outgoing Streamable HTTP request, including the
+// initialize handshake and subsequent tool calls.
+func TestModifyRequest_AddsCustomHeader(t *testing.T) {
+	srv := newTestMCPServer()
+	capture := &headerCapture{inner: srv.Handler(server.WithStreamableHTTP(true))}
+	ts := httptest.NewServer(capture)
+	defer ts.Close()
+
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "test", Version: "1.0"},
+		client.WithModifyRequest(func(req *http.Request) {
+			req.Header.Set("X-Custom-Test", "hello")
+		}),
+	)
+	require.NoError(t, c.Connect())
+	defer c.Close()
+
+	_, err := c.ToolCall("echo", map[string]any{"message": "hi"})
+	require.NoError(t, err)
+
+	// Every request should have the custom header.
+	headers := capture.getHeaders()
+	require.NotEmpty(t, headers, "should have captured at least one request")
+	for i, h := range headers {
+		assert.Equal(t, "hello", h.Get("X-Custom-Test"),
+			"request %d should have X-Custom-Test header", i)
+	}
+}
+
+// TestModifyRequest_SSETransport verifies that WithModifyRequest also works
+// with the SSE transport. The hook should apply to the initial GET /sse
+// connection and all subsequent POST requests.
+func TestModifyRequest_SSETransport(t *testing.T) {
+	srv := newTestMCPServer()
+	capture := &headerCapture{inner: srv.Handler(server.WithSSE(true), server.WithStreamableHTTP(false))}
+	ts := httptest.NewServer(capture)
+	defer ts.Close()
+
+	c := client.NewClient(ts.URL+"/mcp/sse", core.ClientInfo{Name: "test", Version: "1.0"},
+		client.WithSSEClient(),
+		client.WithModifyRequest(func(req *http.Request) {
+			req.Header.Set("X-Trace-ID", "trace-123")
+		}),
+	)
+	require.NoError(t, c.Connect())
+	defer c.Close()
+
+	_, err := c.ToolCall("echo", map[string]any{"message": "hi"})
+	require.NoError(t, err)
+
+	headers := capture.getHeaders()
+	require.NotEmpty(t, headers)
+	for i, h := range headers {
+		assert.Equal(t, "trace-123", h.Get("X-Trace-ID"),
+			"request %d should have X-Trace-ID header", i)
+	}
+}
+
+// TestModifyRequest_NilIsNoOp verifies that not setting WithModifyRequest
+// does not affect normal client operation. This is a basic sanity check that
+// the nil callback path is handled correctly in all buildReq closures.
+func TestModifyRequest_NilIsNoOp(t *testing.T) {
+	srv := newTestMCPServer()
+	ts := httptest.NewServer(srv.Handler(server.WithStreamableHTTP(true)))
+	defer ts.Close()
+
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "test", Version: "1.0"})
+	require.NoError(t, c.Connect())
+	defer c.Close()
+
+	result, err := c.ToolCall("echo", map[string]any{"message": "works"})
+	require.NoError(t, err)
+	assert.Contains(t, result, "works")
+}
+
+// TestModifyRequest_MultipleHeaders verifies that the callback can set
+// multiple headers simultaneously, simulating a real-world scenario where
+// several custom headers are injected (e.g., tenant ID + request ID).
+func TestModifyRequest_MultipleHeaders(t *testing.T) {
+	srv := newTestMCPServer()
+	capture := &headerCapture{inner: srv.Handler(server.WithStreamableHTTP(true))}
+	ts := httptest.NewServer(capture)
+	defer ts.Close()
+
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "test", Version: "1.0"},
+		client.WithModifyRequest(func(req *http.Request) {
+			req.Header.Set("X-Tenant-ID", "acme")
+			req.Header.Set("X-Request-ID", "req-456")
+		}),
+	)
+	require.NoError(t, c.Connect())
+	defer c.Close()
+
+	_, err := c.ToolCall("echo", map[string]any{"message": "hi"})
+	require.NoError(t, err)
+
+	headers := capture.getHeaders()
+	require.NotEmpty(t, headers)
+	for i, h := range headers {
+		assert.Equal(t, "acme", h.Get("X-Tenant-ID"),
+			"request %d should have X-Tenant-ID", i)
+		assert.Equal(t, "req-456", h.Get("X-Request-ID"),
+			"request %d should have X-Request-ID", i)
+	}
+}

--- a/client/client_reconnect.go
+++ b/client/client_reconnect.go
@@ -8,7 +8,7 @@ package client
 // Enable via WithMaxRetries(n). Disabled by default (maxRetries=0).
 
 import (
-	core "github.com/panyam/mcpkit/core"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -16,6 +16,8 @@ import (
 	"net"
 	"strings"
 	"time"
+
+	core "github.com/panyam/mcpkit/core"
 )
 
 // WithMaxRetries sets the maximum number of reconnection attempts on
@@ -48,9 +50,25 @@ func (c *Client) reconnect() error {
 	}
 
 	// Re-create transport with handlers and options
-	if c.useSSE {
+	if c.commandName != "" {
+		ct := NewCommandTransport(c.commandName, c.commandArgs, c.commandOpts...)
+		ct.serverReqHandler = func(_ context.Context, req *core.Request) *core.Response {
+			return c.HandleServerRequest(req)
+		}
+		if c.onNotify != nil {
+			ct.notifyHandler = func(method string, params []byte) {
+				var parsed any
+				if len(params) > 0 {
+					json.Unmarshal(params, &parsed)
+				}
+				c.onNotify(method, parsed)
+			}
+		}
+		c.transport = &coreTransportAdapter{inner: ct}
+	} else if c.useSSE {
 		st := newSSEClientTransport(c.url, c.tokenSource)
 		st.serverReqHandler = c.HandleServerRequest
+		st.modifyReq = c.modifyRequest
 		if c.onNotify != nil {
 			st.notifyHandler = c.makeNotifyAdapter()
 		}
@@ -60,6 +78,7 @@ func (c *Client) reconnect() error {
 		st.client = c
 		st.serverReqHandler = c.HandleServerRequest
 		st.enableGetSSE = c.enableGetSSE
+		st.modifyReq = c.modifyRequest
 		if c.onNotify != nil {
 			st.notifyHandler = c.makeNotifyAdapter()
 		}

--- a/client/command_transport.go
+++ b/client/command_transport.go
@@ -1,0 +1,254 @@
+package client
+
+// CommandTransport spawns a subprocess MCP server and communicates with it
+// over stdin/stdout using Content-Length framed JSON-RPC. It manages the full
+// process lifecycle: start on Connect, graceful shutdown on Close.
+//
+// Under the hood, CommandTransport wraps StdioTransport for the wire protocol
+// and adds process management (startup, SIGTERM/SIGKILL shutdown, stderr
+// capture, environment passthrough).
+//
+// Example:
+//
+//	transport := client.NewCommandTransport("python", []string{"my_server.py"},
+//	    client.WithEnv("DEBUG=1"),
+//	    client.WithShutdownTimeout(10*time.Second),
+//	)
+//	c := client.NewClient("", info, client.WithTransport(transport))
+//	err := c.Connect()
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"sync"
+	"syscall"
+	"time"
+
+	core "github.com/panyam/mcpkit/core"
+)
+
+const (
+	defaultShutdownTimeout = 5 * time.Second
+	defaultStderrBufSize   = 8192
+)
+
+// CommandTransport implements core.Transport by spawning a subprocess and
+// communicating via stdio. The subprocess is started on Connect() and
+// gracefully shut down on Close().
+type CommandTransport struct {
+	name string
+	args []string
+	opts commandOpts
+
+	// Handlers set before Connect(), forwarded to the inner StdioTransport.
+	serverReqHandler core.ServerRequestHandler
+	notifyHandler    core.NotificationHandler
+
+	// Process state (set during Connect, cleared on Close).
+	cmd    *exec.Cmd
+	stdio  *StdioTransport
+	stderr *bytes.Buffer // captures subprocess stderr output
+	mu     sync.Mutex
+	done   chan struct{} // closed when process exits
+}
+
+// commandOpts holds configuration set via CommandOption functions.
+type commandOpts struct {
+	env             []string      // additional env vars (KEY=VALUE), appended to os.Environ()
+	dir             string        // working directory for the subprocess
+	shutdownTimeout time.Duration // time to wait after SIGTERM before SIGKILL (default 5s)
+	stderrWriter    io.Writer     // optional additional stderr destination
+}
+
+// CommandOption configures a CommandTransport.
+type CommandOption func(*commandOpts)
+
+// WithEnv adds environment variables to the subprocess. Each value should be
+// in KEY=VALUE format. These are appended to the current process environment.
+func WithEnv(env ...string) CommandOption {
+	return func(o *commandOpts) { o.env = append(o.env, env...) }
+}
+
+// WithDir sets the working directory for the subprocess.
+func WithDir(dir string) CommandOption {
+	return func(o *commandOpts) { o.dir = dir }
+}
+
+// WithShutdownTimeout sets the duration to wait after sending SIGTERM before
+// escalating to SIGKILL. Default is 5 seconds.
+func WithShutdownTimeout(d time.Duration) CommandOption {
+	return func(o *commandOpts) { o.shutdownTimeout = d }
+}
+
+// WithStderr sets an additional writer for subprocess stderr output. Stderr is
+// always captured in an internal buffer (for error messages on crash); this
+// option tees it to an additional destination (e.g., os.Stderr, a logger).
+func WithStderr(w io.Writer) CommandOption {
+	return func(o *commandOpts) { o.stderrWriter = w }
+}
+
+// NewCommandTransport creates a CommandTransport that will spawn the given
+// command with args when Connect() is called.
+func NewCommandTransport(name string, args []string, opts ...CommandOption) *CommandTransport {
+	ct := &CommandTransport{name: name, args: args}
+	for _, o := range opts {
+		o(&ct.opts)
+	}
+	if ct.opts.shutdownTimeout <= 0 {
+		ct.opts.shutdownTimeout = defaultShutdownTimeout
+	}
+	return ct
+}
+
+// Connect starts the subprocess and establishes the stdio transport.
+func (ct *CommandTransport) Connect(ctx context.Context) error {
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+
+	cmd := exec.CommandContext(ctx, ct.name, ct.args...)
+	if ct.opts.dir != "" {
+		cmd.Dir = ct.opts.dir
+	}
+	if len(ct.opts.env) > 0 {
+		cmd.Env = append(cmd.Environ(), ct.opts.env...)
+	}
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("stdin pipe: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("stdout pipe: %w", err)
+	}
+
+	// Capture stderr in internal buffer, optionally tee to user writer.
+	ct.stderr = bytes.NewBuffer(make([]byte, 0, defaultStderrBufSize))
+	if ct.opts.stderrWriter != nil {
+		cmd.Stderr = io.MultiWriter(ct.stderr, ct.opts.stderrWriter)
+	} else {
+		cmd.Stderr = ct.stderr
+	}
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start %s: %w", ct.name, err)
+	}
+
+	ct.cmd = cmd
+	ct.done = make(chan struct{})
+
+	// Monitor process exit in background.
+	go func() {
+		cmd.Wait()
+		close(ct.done)
+	}()
+
+	// Create and connect the stdio transport over the process pipes.
+	ct.stdio = NewStdioTransport(stdout, stdin)
+	ct.stdio.serverReqHandler = ct.serverReqHandler
+	ct.stdio.notifyHandler = ct.notifyHandler
+	return ct.stdio.Connect(ctx)
+}
+
+// Call delegates to the underlying StdioTransport.
+func (ct *CommandTransport) Call(ctx context.Context, req *core.Request) (*core.Response, error) {
+	ct.mu.Lock()
+	stdio := ct.stdio
+	ct.mu.Unlock()
+	if stdio == nil {
+		return nil, fmt.Errorf("command transport not connected")
+	}
+	return stdio.Call(ctx, req)
+}
+
+// Notify delegates to the underlying StdioTransport.
+func (ct *CommandTransport) Notify(ctx context.Context, req *core.Request) error {
+	ct.mu.Lock()
+	stdio := ct.stdio
+	ct.mu.Unlock()
+	if stdio == nil {
+		return fmt.Errorf("command transport not connected")
+	}
+	return stdio.Notify(ctx, req)
+}
+
+// SessionID returns "command" for the command transport.
+func (ct *CommandTransport) SessionID() string { return "command" }
+
+// Close gracefully shuts down the subprocess. It closes the stdio transport
+// (which closes stdin, causing the server to see EOF), then sends SIGTERM.
+// If the process does not exit within the shutdown timeout, it sends SIGKILL.
+// The returned error includes stderr output if the process exited abnormally.
+func (ct *CommandTransport) Close() error {
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+
+	if ct.cmd == nil {
+		return nil
+	}
+
+	// Close stdio transport first — closes stdin pipe, waits for read loop.
+	if ct.stdio != nil {
+		ct.stdio.Close()
+		ct.stdio = nil
+	}
+
+	// Check if process already exited (e.g., due to stdin close).
+	select {
+	case <-ct.done:
+		return ct.exitError()
+	default:
+	}
+
+	// Send SIGTERM for graceful shutdown.
+	if ct.cmd.Process != nil {
+		ct.cmd.Process.Signal(syscall.SIGTERM)
+	}
+
+	// Wait for exit or timeout.
+	select {
+	case <-ct.done:
+		return ct.exitError()
+	case <-time.After(ct.opts.shutdownTimeout):
+		// Escalate to SIGKILL.
+		if ct.cmd.Process != nil {
+			ct.cmd.Process.Kill()
+		}
+		<-ct.done
+		return ct.exitError()
+	}
+}
+
+// Stderr returns the captured stderr output from the subprocess. Safe to call
+// after Close(). Returns an empty string if no stderr was captured.
+func (ct *CommandTransport) Stderr() string {
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+	if ct.stderr == nil {
+		return ""
+	}
+	return ct.stderr.String()
+}
+
+// exitError returns nil if the process exited cleanly (exit code 0), or an
+// error including the exit status and last stderr output.
+func (ct *CommandTransport) exitError() error {
+	if ct.cmd.ProcessState != nil && ct.cmd.ProcessState.Success() {
+		return nil
+	}
+	stderr := ""
+	if ct.stderr != nil && ct.stderr.Len() > 0 {
+		stderr = ct.stderr.String()
+		// Truncate to last 1024 bytes for error message readability.
+		if len(stderr) > 1024 {
+			stderr = "..." + stderr[len(stderr)-1024:]
+		}
+	}
+	if stderr != "" {
+		return fmt.Errorf("process %s exited: %v\nstderr: %s", ct.name, ct.cmd.ProcessState, stderr)
+	}
+	return fmt.Errorf("process %s exited: %v", ct.name, ct.cmd.ProcessState)
+}

--- a/client/command_transport_test.go
+++ b/client/command_transport_test.go
@@ -1,0 +1,228 @@
+package client_test
+
+// Tests for CommandTransport: subprocess MCP server lifecycle, stdio
+// communication, graceful shutdown, stderr capture, env passthrough, and
+// client integration via WithCommandTransport.
+//
+// These tests compile cmd/testserver as a binary and spawn it with STDIO=1
+// to get a real subprocess MCP server communicating over stdin/stdout.
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/panyam/mcpkit/client"
+	"github.com/panyam/mcpkit/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	testServerBin string
+	buildOnce     sync.Once
+	buildErr      error
+)
+
+// buildTestServer compiles cmd/testserver into a temporary binary. The binary
+// is built once per test run and reused across all subtests to avoid repeated
+// compilation overhead. Uses os.TempDir (not t.TempDir) so the binary survives
+// across top-level test functions.
+func buildTestServer(t *testing.T) string {
+	t.Helper()
+	buildOnce.Do(func() {
+		bin := filepath.Join(os.TempDir(), "mcpkit-testserver-"+filepath.Base(t.Name()))
+		cmd := exec.Command("go", "build", "-o", bin, "../cmd/testserver")
+		cmd.Stderr = os.Stderr
+		buildErr = cmd.Run()
+		if buildErr == nil {
+			testServerBin = bin
+		}
+	})
+	require.NoError(t, buildErr, "failed to build testserver binary")
+	require.NotEmpty(t, testServerBin)
+	return testServerBin
+}
+
+// TestCommandTransport_EchoTool verifies the full lifecycle: spawn a subprocess
+// MCP server via CommandTransport, perform the initialize handshake, call a
+// tool, verify the response, and close cleanly.
+func TestCommandTransport_EchoTool(t *testing.T) {
+	bin := buildTestServer(t)
+
+	transport := client.NewCommandTransport(bin, nil,
+		client.WithEnv("STDIO=1"),
+	)
+	c := client.NewClient("", core.ClientInfo{Name: "test", Version: "1.0"},
+		client.WithTransport(transport),
+	)
+	require.NoError(t, c.Connect())
+
+	result, err := c.ToolCall("test_simple_text", map[string]any{})
+	require.NoError(t, err)
+	assert.NotEmpty(t, result, "should get a response from the echo tool")
+
+	require.NoError(t, c.Close())
+}
+
+// TestCommandTransport_GracefulShutdown verifies that Close() shuts down the
+// subprocess gracefully (via stdin EOF + SIGTERM) within the default timeout,
+// without needing to escalate to SIGKILL.
+func TestCommandTransport_GracefulShutdown(t *testing.T) {
+	bin := buildTestServer(t)
+
+	transport := client.NewCommandTransport(bin, nil,
+		client.WithEnv("STDIO=1"),
+	)
+	c := client.NewClient("", core.ClientInfo{Name: "test", Version: "1.0"},
+		client.WithTransport(transport),
+	)
+	require.NoError(t, c.Connect())
+
+	// Measure shutdown time — should be fast (stdin EOF causes server exit).
+	start := time.Now()
+	require.NoError(t, c.Close())
+	elapsed := time.Since(start)
+
+	assert.Less(t, elapsed, 3*time.Second,
+		"graceful shutdown should complete quickly, not wait for SIGKILL timeout")
+}
+
+// TestCommandTransport_StderrCapture verifies that subprocess stderr output is
+// captured and accessible via the Stderr() method. The testserver logs a
+// startup message to stderr when running in STDIO mode.
+func TestCommandTransport_StderrCapture(t *testing.T) {
+	bin := buildTestServer(t)
+
+	transport := client.NewCommandTransport(bin, nil,
+		client.WithEnv("STDIO=1"),
+	)
+	c := client.NewClient("", core.ClientInfo{Name: "test", Version: "1.0"},
+		client.WithTransport(transport),
+	)
+	require.NoError(t, c.Connect())
+
+	// Do a call to give the server time to log.
+	_, _ = c.ToolCall("test_simple_text", map[string]any{})
+	c.Close()
+
+	stderr := transport.Stderr()
+	assert.NotEmpty(t, stderr, "should capture stderr from the subprocess")
+	assert.Contains(t, stderr, "stdio", "testserver logs 'stdio' on startup")
+}
+
+// TestCommandTransport_ProcessCrash verifies that when the subprocess exits
+// unexpectedly (e.g., bad command), Connect or subsequent calls return an
+// error with useful context.
+func TestCommandTransport_ProcessCrash(t *testing.T) {
+	transport := client.NewCommandTransport("false", nil)
+	c := client.NewClient("", core.ClientInfo{Name: "test", Version: "1.0"},
+		client.WithTransport(transport),
+	)
+
+	// Connect may fail (process exits before handshake completes) or
+	// a subsequent call may fail — either way we should get an error.
+	err := c.Connect()
+	if err == nil {
+		_, err = c.ToolCall("test_simple_text", map[string]any{})
+	}
+	assert.Error(t, err, "should get an error when process crashes")
+}
+
+// TestCommandTransport_EnvPassthrough verifies that environment variables set
+// via WithEnv are passed to the subprocess. We use STDIO=1 itself as proof —
+// if the env var wasn't passed, the server would start in HTTP mode and the
+// stdio handshake would fail.
+func TestCommandTransport_EnvPassthrough(t *testing.T) {
+	bin := buildTestServer(t)
+
+	// Without STDIO=1, the server starts HTTP and stdin/stdout handshake fails.
+	transport := client.NewCommandTransport(bin, nil)
+	c := client.NewClient("", core.ClientInfo{Name: "test", Version: "1.0"},
+		client.WithTransport(transport),
+	)
+	err := c.Connect()
+	// Should fail because the server is in HTTP mode, not stdio.
+	assert.Error(t, err, "without STDIO=1, connect should fail")
+	c.Close()
+
+	// With STDIO=1, it should work.
+	transport2 := client.NewCommandTransport(bin, nil,
+		client.WithEnv("STDIO=1"),
+	)
+	c2 := client.NewClient("", core.ClientInfo{Name: "test", Version: "1.0"},
+		client.WithTransport(transport2),
+	)
+	require.NoError(t, c2.Connect(), "with STDIO=1, connect should succeed")
+	c2.Close()
+}
+
+// TestCommandTransport_WithCommandTransportOption verifies the WithCommandTransport
+// client option, which stores command config on the Client and creates a fresh
+// CommandTransport on each Connect(). This is the recommended API for most users.
+func TestCommandTransport_WithCommandTransportOption(t *testing.T) {
+	bin := buildTestServer(t)
+
+	c := client.NewClient("", core.ClientInfo{Name: "test", Version: "1.0"},
+		client.WithCommandTransport(bin, nil,
+			client.WithEnv("STDIO=1"),
+		),
+	)
+	require.NoError(t, c.Connect())
+
+	result, err := c.ToolCall("test_simple_text", map[string]any{})
+	require.NoError(t, err)
+	assert.NotEmpty(t, result)
+
+	require.NoError(t, c.Close())
+}
+
+// TestCommandTransport_WithStderr verifies that the WithStderr option tees
+// subprocess stderr to a user-provided writer in addition to the internal
+// capture buffer.
+func TestCommandTransport_WithStderr(t *testing.T) {
+	bin := buildTestServer(t)
+
+	var userBuf strings.Builder
+	transport := client.NewCommandTransport(bin, nil,
+		client.WithEnv("STDIO=1"),
+		client.WithStderr(&userBuf),
+	)
+	c := client.NewClient("", core.ClientInfo{Name: "test", Version: "1.0"},
+		client.WithTransport(transport),
+	)
+	require.NoError(t, c.Connect())
+	_, _ = c.ToolCall("test_simple_text", map[string]any{})
+	c.Close()
+
+	// Both the internal buffer and the user writer should have stderr content.
+	assert.NotEmpty(t, transport.Stderr(), "internal stderr buffer should have content")
+	assert.NotEmpty(t, userBuf.String(), "user stderr writer should have content")
+	assert.Equal(t, transport.Stderr(), userBuf.String(),
+		"both stderr destinations should have identical content")
+}
+
+// TestCommandTransport_ShutdownTimeout verifies that WithShutdownTimeout
+// controls how long Close() waits before escalating to SIGKILL.
+func TestCommandTransport_ShutdownTimeout(t *testing.T) {
+	bin := buildTestServer(t)
+
+	transport := client.NewCommandTransport(bin, nil,
+		client.WithEnv("STDIO=1"),
+		client.WithShutdownTimeout(100*time.Millisecond),
+	)
+	c := client.NewClient("", core.ClientInfo{Name: "test", Version: "1.0"},
+		client.WithTransport(transport),
+	)
+	require.NoError(t, c.Connect())
+
+	// Close should still complete quickly with a short timeout.
+	start := time.Now()
+	c.Close()
+	elapsed := time.Since(start)
+	assert.Less(t, elapsed, 2*time.Second)
+}

--- a/tests/reports/report.html
+++ b/tests/reports/report.html
@@ -15,7 +15,7 @@ th { background: #f5f5f5; font-weight: 600; }
 pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto; font-size: 13px; max-height: 400px; overflow-y: auto; }
 </style></head><body>
 <h1>MCPKit Test Report</h1>
-<div class='meta'>Branch: <strong>feature/dx-security-perf-42-46-133-139</strong> | Commit: <code>fc76c87</code> | Date: 2026-04-09 16:22:24</div>
+<div class='meta'>Branch: <strong>main</strong> | Commit: <code>43a8e5b</code> | Date: 2026-04-09 16:36:30</div>
 <table><tr><th>Stage</th><th>Result</th></tr>
 <tr><td>unit</td><td class='pass'>PASS</td></tr>
 <tr><td>race</td><td class='pass'>PASS</td></tr>
@@ -29,38 +29,36 @@ pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto; 
 <div class='summary-pass'>All 8 stages passed</div>
 <h2>Full Log</h2><pre>
 === MCPKit Comprehensive Test Suite ===
-Started: Thu Apr  9 16:21:54 PDT 2026
+Started: Thu Apr  9 16:35:59 PDT 2026
 
 --- [1/8] unit ---
-ok  	github.com/panyam/mcpkit/client	1.673s
+ok  	github.com/panyam/mcpkit/client	2.058s
 ?   	github.com/panyam/mcpkit/cmd/testserver	[no test files]
-ok  	github.com/panyam/mcpkit/core	0.201s
-ok  	github.com/panyam/mcpkit/server	8.364s
-ok  	github.com/panyam/mcpkit/testutil	0.685s
+ok  	github.com/panyam/mcpkit/core	0.507s
+ok  	github.com/panyam/mcpkit/server	8.255s
+ok  	github.com/panyam/mcpkit/testutil	0.702s
   PASS: unit
 --- [2/8] race ---
-ok  	github.com/panyam/mcpkit/client	2.805s
+ok  	github.com/panyam/mcpkit/client	3.196s
 ?   	github.com/panyam/mcpkit/cmd/testserver	[no test files]
-ok  	github.com/panyam/mcpkit/core	1.213s
-ok  	github.com/panyam/mcpkit/server	9.715s
-ok  	github.com/panyam/mcpkit/testutil	1.591s
+ok  	github.com/panyam/mcpkit/core	1.491s
+ok  	github.com/panyam/mcpkit/server	9.422s
+ok  	github.com/panyam/mcpkit/testutil	1.669s
   PASS: race
 --- [3/8] auth ---
-ok  	github.com/panyam/mcpkit/ext/auth	0.235s
+ok  	github.com/panyam/mcpkit/ext/auth	0.527s
   PASS: auth
 --- [4/8] ui ---
-ok  	github.com/panyam/mcpkit/ext/ui	0.206s
+ok  	github.com/panyam/mcpkit/ext/ui	0.434s
   PASS: ui
 --- [5/8] e2e ---
-ok  	github.com/panyam/mcpkit/tests/e2e	2.019s
-ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.298s
+ok  	github.com/panyam/mcpkit/tests/e2e	2.355s
+ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.711s
   PASS: e2e
 --- [6/8] conformance ---
 Killing stale process on port 18799...
-2026/04/09 16:22:17 Received signal terminated, shutting down...
-2026/04/09 16:22:17 Server shut down gracefully
 === Starting test server on :18799 (Streamable HTTP) ===
-Waiting for server....2026/04/09 16:22:18 MCP test server listening on :18799 (Streamable HTTP at /mcp)
+Waiting for server....2026/04/09 16:36:25 MCP test server listening on :18799 (Streamable HTTP at /mcp)
  ready
 
 === Running MCP conformance suite ===
@@ -71,295 +69,295 @@ Running active suite (30 scenarios) against http://localhost:18799/mcp
 
 === Running scenario: server-initialize ===
 Running client scenario 'server-initialize' against server: http://localhost:18799/mcp
-2026/04/09 16:22:20 Starting MCP-GET-SSE SSE connection: f7ea9a59c9cca3712d1942f60070bae6
-2026/04/09 16:22:20 SSEHub: registered connection f7ea9a59c9cca3712d1942f60070bae6 (total: 1)
-2026/04/09 16:22:20 SSEHub: unregistered connection f7ea9a59c9cca3712d1942f60070bae6 (total: 0)
-2026/04/09 16:22:20 Received kill signal.  Quitting Writer. stop 0x7909ad9ce2a0
-2026/04/09 16:22:20 Cleaning up writer...
-2026/04/09 16:22:20 Finished cleaning up writer:  0x7909ad9ce2a0
-2026/04/09 16:22:20 Closed MCP-GET-SSE SSE connection: f7ea9a59c9cca3712d1942f60070bae6
+2026/04/09 16:36:26 Starting MCP-GET-SSE SSE connection: fe874e59b108f02efcbcd62d44481e2d
+2026/04/09 16:36:26 SSEHub: registered connection fe874e59b108f02efcbcd62d44481e2d (total: 1)
+2026/04/09 16:36:26 SSEHub: unregistered connection fe874e59b108f02efcbcd62d44481e2d (total: 0)
+2026/04/09 16:36:26 Received kill signal.  Quitting Writer. stop 0x1679e7634460
+2026/04/09 16:36:26 Cleaning up writer...
+2026/04/09 16:36:26 Finished cleaning up writer:  0x1679e7634460
+2026/04/09 16:36:26 Closed MCP-GET-SSE SSE connection: fe874e59b108f02efcbcd62d44481e2d
 
 === Running scenario: logging-set-level ===
 Running client scenario 'logging-set-level' against server: http://localhost:18799/mcp
-2026/04/09 16:22:20 Starting MCP-GET-SSE SSE connection: 53a9144b3d7144443bbb6475d80755f5
-2026/04/09 16:22:20 SSEHub: registered connection 53a9144b3d7144443bbb6475d80755f5 (total: 1)
-2026/04/09 16:22:20 SSEHub: unregistered connection 53a9144b3d7144443bbb6475d80755f5 (total: 0)
-2026/04/09 16:22:20 Received kill signal.  Quitting Writer. stop 0x7909adb961c0
-2026/04/09 16:22:20 Cleaning up writer...
-2026/04/09 16:22:20 Finished cleaning up writer:  0x7909adb961c0
-2026/04/09 16:22:20 Closed MCP-GET-SSE SSE connection: 53a9144b3d7144443bbb6475d80755f5
+2026/04/09 16:36:26 Starting MCP-GET-SSE SSE connection: 05306fb3bf4992fc059bf7feb06710c9
+2026/04/09 16:36:26 SSEHub: registered connection 05306fb3bf4992fc059bf7feb06710c9 (total: 1)
+2026/04/09 16:36:26 SSEHub: unregistered connection 05306fb3bf4992fc059bf7feb06710c9 (total: 0)
+2026/04/09 16:36:26 Received kill signal.  Quitting Writer. stop 0x1679e792e1c0
+2026/04/09 16:36:26 Cleaning up writer...
+2026/04/09 16:36:26 Finished cleaning up writer:  0x1679e792e1c0
+2026/04/09 16:36:26 Closed MCP-GET-SSE SSE connection: 05306fb3bf4992fc059bf7feb06710c9
 
 === Running scenario: ping ===
 Running client scenario 'ping' against server: http://localhost:18799/mcp
-2026/04/09 16:22:20 Starting MCP-GET-SSE SSE connection: fe931b0d42b9cfccddbe7457d2c517d0
-2026/04/09 16:22:20 SSEHub: registered connection fe931b0d42b9cfccddbe7457d2c517d0 (total: 1)
+2026/04/09 16:36:26 Starting MCP-GET-SSE SSE connection: 412bb415038bd01dd4a1a1da40599bf6
+2026/04/09 16:36:26 SSEHub: registered connection 412bb415038bd01dd4a1a1da40599bf6 (total: 1)
+2026/04/09 16:36:26 SSEHub: unregistered connection 412bb415038bd01dd4a1a1da40599bf6 (total: 0)
+2026/04/09 16:36:26 Received kill signal.  Quitting Writer. stop 0x1679e7634690
+2026/04/09 16:36:26 Cleaning up writer...
+2026/04/09 16:36:26 Finished cleaning up writer:  0x1679e7634690
+2026/04/09 16:36:26 Closed MCP-GET-SSE SSE connection: 412bb415038bd01dd4a1a1da40599bf6
 
 === Running scenario: completion-complete ===
-2026/04/09 16:22:20 SSEHub: unregistered connection fe931b0d42b9cfccddbe7457d2c517d0 (total: 0)
-2026/04/09 16:22:20 Received kill signal.  Quitting Writer. stop 0x7909adb96460
-2026/04/09 16:22:20 Cleaning up writer...
-2026/04/09 16:22:20 Finished cleaning up writer:  0x7909adb96460
-2026/04/09 16:22:20 Closed MCP-GET-SSE SSE connection: fe931b0d42b9cfccddbe7457d2c517d0
 Running client scenario 'completion-complete' against server: http://localhost:18799/mcp
-2026/04/09 16:22:20 Starting MCP-GET-SSE SSE connection: 4040052be917b7779fbd42218f2aa918
-2026/04/09 16:22:20 SSEHub: registered connection 4040052be917b7779fbd42218f2aa918 (total: 1)
-2026/04/09 16:22:20 SSEHub: unregistered connection 4040052be917b7779fbd42218f2aa918 (total: 0)
-2026/04/09 16:22:20 Received kill signal.  Quitting Writer. stop 0x7909ad918460
-2026/04/09 16:22:20 Cleaning up writer...
-2026/04/09 16:22:20 Finished cleaning up writer:  0x7909ad918460
-2026/04/09 16:22:20 Closed MCP-GET-SSE SSE connection: 4040052be917b7779fbd42218f2aa918
+2026/04/09 16:36:26 Starting MCP-GET-SSE SSE connection: 03fdeec4e474842de6be2b96a7047295
+2026/04/09 16:36:26 SSEHub: registered connection 03fdeec4e474842de6be2b96a7047295 (total: 1)
+2026/04/09 16:36:26 SSEHub: unregistered connection 03fdeec4e474842de6be2b96a7047295 (total: 0)
+2026/04/09 16:36:26 Received kill signal.  Quitting Writer. stop 0x1679e77461c0
+2026/04/09 16:36:26 Cleaning up writer...
+2026/04/09 16:36:26 Finished cleaning up writer:  0x1679e77461c0
+2026/04/09 16:36:26 Closed MCP-GET-SSE SSE connection: 03fdeec4e474842de6be2b96a7047295
 
 === Running scenario: tools-list ===
 Running client scenario 'tools-list' against server: http://localhost:18799/mcp
-2026/04/09 16:22:20 Starting MCP-GET-SSE SSE connection: 28ee9d923d97fadde3619c29f0862c7e
-2026/04/09 16:22:20 SSEHub: registered connection 28ee9d923d97fadde3619c29f0862c7e (total: 1)
+2026/04/09 16:36:26 Starting MCP-GET-SSE SSE connection: 72a55f37b6d3b37f7bc6cfc0a4a14fc6
+2026/04/09 16:36:26 SSEHub: registered connection 72a55f37b6d3b37f7bc6cfc0a4a14fc6 (total: 1)
+2026/04/09 16:36:26 SSEHub: unregistered connection 72a55f37b6d3b37f7bc6cfc0a4a14fc6 (total: 0)
+2026/04/09 16:36:26 Received kill signal.  Quitting Writer. stop 0x1679e77463f0
+2026/04/09 16:36:26 Cleaning up writer...
+2026/04/09 16:36:26 Finished cleaning up writer:  0x1679e77463f0
+2026/04/09 16:36:26 Closed MCP-GET-SSE SSE connection: 72a55f37b6d3b37f7bc6cfc0a4a14fc6
 
 === Running scenario: tools-call-simple-text ===
-2026/04/09 16:22:20 SSEHub: unregistered connection 28ee9d923d97fadde3619c29f0862c7e (total: 0)
-2026/04/09 16:22:20 Received kill signal.  Quitting Writer. stop 0x7909ad9ce5b0
-2026/04/09 16:22:20 Cleaning up writer...
-2026/04/09 16:22:20 Finished cleaning up writer:  0x7909ad9ce5b0
 Running client scenario 'tools-call-simple-text' against server: http://localhost:18799/mcp
-2026/04/09 16:22:20 Closed MCP-GET-SSE SSE connection: 28ee9d923d97fadde3619c29f0862c7e
-2026/04/09 16:22:20 Starting MCP-GET-SSE SSE connection: 4096f96b36a24f1ac53304b9eb40e473
-2026/04/09 16:22:20 SSEHub: registered connection 4096f96b36a24f1ac53304b9eb40e473 (total: 1)
-2026/04/09 16:22:20 SSEHub: unregistered connection 4096f96b36a24f1ac53304b9eb40e473 (total: 0)
-2026/04/09 16:22:20 Received kill signal.  Quitting Writer. stop 0x7909ad918850
-2026/04/09 16:22:20 Cleaning up writer...
-2026/04/09 16:22:20 Finished cleaning up writer:  0x7909ad918850
-2026/04/09 16:22:20 Closed MCP-GET-SSE SSE connection: 4096f96b36a24f1ac53304b9eb40e473
+2026/04/09 16:36:26 Starting MCP-GET-SSE SSE connection: 29c41cfe24337dff52daa19ec0c885a7
+2026/04/09 16:36:26 SSEHub: registered connection 29c41cfe24337dff52daa19ec0c885a7 (total: 1)
+2026/04/09 16:36:26 SSEHub: unregistered connection 29c41cfe24337dff52daa19ec0c885a7 (total: 0)
+2026/04/09 16:36:26 Received kill signal.  Quitting Writer. stop 0x1679e78a6380
+2026/04/09 16:36:26 Cleaning up writer...
+2026/04/09 16:36:26 Finished cleaning up writer:  0x1679e78a6380
+2026/04/09 16:36:26 Closed MCP-GET-SSE SSE connection: 29c41cfe24337dff52daa19ec0c885a7
 
 === Running scenario: tools-call-image ===
 Running client scenario 'tools-call-image' against server: http://localhost:18799/mcp
-2026/04/09 16:22:20 Starting MCP-GET-SSE SSE connection: 2e0ce97e06094097f29ea1a6f057d2c3
-2026/04/09 16:22:20 SSEHub: registered connection 2e0ce97e06094097f29ea1a6f057d2c3 (total: 1)
-2026/04/09 16:22:20 SSEHub: unregistered connection 2e0ce97e06094097f29ea1a6f057d2c3 (total: 0)
-2026/04/09 16:22:20 Received kill signal.  Quitting Writer. stop 0x7909adb96700
-2026/04/09 16:22:20 Cleaning up writer...
-2026/04/09 16:22:20 Finished cleaning up writer:  0x7909adb96700
-2026/04/09 16:22:20 Closed MCP-GET-SSE SSE connection: 2e0ce97e06094097f29ea1a6f057d2c3
+2026/04/09 16:36:26 Starting MCP-GET-SSE SSE connection: e7fd94151ee8a81d6322c8c86fd8b7e6
+2026/04/09 16:36:26 SSEHub: registered connection e7fd94151ee8a81d6322c8c86fd8b7e6 (total: 1)
+2026/04/09 16:36:26 SSEHub: unregistered connection e7fd94151ee8a81d6322c8c86fd8b7e6 (total: 0)
+2026/04/09 16:36:26 Received kill signal.  Quitting Writer. stop 0x1679e792e460
+2026/04/09 16:36:26 Cleaning up writer...
+2026/04/09 16:36:26 Finished cleaning up writer:  0x1679e792e460
+2026/04/09 16:36:26 Closed MCP-GET-SSE SSE connection: e7fd94151ee8a81d6322c8c86fd8b7e6
 
 === Running scenario: tools-call-audio ===
 Running client scenario 'tools-call-audio' against server: http://localhost:18799/mcp
-2026/04/09 16:22:20 Starting MCP-GET-SSE SSE connection: acd47a8fae99e4560bf0a4746ff33b69
-2026/04/09 16:22:20 SSEHub: registered connection acd47a8fae99e4560bf0a4746ff33b69 (total: 1)
-2026/04/09 16:22:20 SSEHub: unregistered connection acd47a8fae99e4560bf0a4746ff33b69 (total: 0)
-2026/04/09 16:22:20 Received kill signal.  Quitting Writer. stop 0x7909adb96a10
-2026/04/09 16:22:20 Cleaning up writer...
-2026/04/09 16:22:20 Finished cleaning up writer:  0x7909adb96a10
-2026/04/09 16:22:20 Closed MCP-GET-SSE SSE connection: acd47a8fae99e4560bf0a4746ff33b69
+2026/04/09 16:36:26 Starting MCP-GET-SSE SSE connection: 83e7410668ddf8e0f30f5e735ffa09bd
+2026/04/09 16:36:26 SSEHub: registered connection 83e7410668ddf8e0f30f5e735ffa09bd (total: 1)
+2026/04/09 16:36:26 SSEHub: unregistered connection 83e7410668ddf8e0f30f5e735ffa09bd (total: 0)
+2026/04/09 16:36:26 Received kill signal.  Quitting Writer. stop 0x1679e7634af0
+2026/04/09 16:36:26 Cleaning up writer...
+2026/04/09 16:36:26 Finished cleaning up writer:  0x1679e7634af0
+2026/04/09 16:36:26 Closed MCP-GET-SSE SSE connection: 83e7410668ddf8e0f30f5e735ffa09bd
 
 === Running scenario: tools-call-embedded-resource ===
 Running client scenario 'tools-call-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/09 16:22:20 Starting MCP-GET-SSE SSE connection: 2e22570068f67164a3466b605ce4bfdc
-2026/04/09 16:22:20 SSEHub: registered connection 2e22570068f67164a3466b605ce4bfdc (total: 1)
-2026/04/09 16:22:20 SSEHub: unregistered connection 2e22570068f67164a3466b605ce4bfdc (total: 0)
+2026/04/09 16:36:26 Starting MCP-GET-SSE SSE connection: 88961b0d14ac01cf5cfe93e19ab98455
+2026/04/09 16:36:26 SSEHub: registered connection 88961b0d14ac01cf5cfe93e19ab98455 (total: 1)
 
 === Running scenario: tools-call-mixed-content ===
-2026/04/09 16:22:20 Received kill signal.  Quitting Writer. stop 0x7909ada0c310
-2026/04/09 16:22:20 Cleaning up writer...
-2026/04/09 16:22:20 Finished cleaning up writer:  0x7909ada0c310
-2026/04/09 16:22:20 Closed MCP-GET-SSE SSE connection: 2e22570068f67164a3466b605ce4bfdc
+2026/04/09 16:36:26 SSEHub: unregistered connection 88961b0d14ac01cf5cfe93e19ab98455 (total: 0)
 Running client scenario 'tools-call-mixed-content' against server: http://localhost:18799/mcp
-2026/04/09 16:22:20 Starting MCP-GET-SSE SSE connection: 68ece765e9bee5e4de35a6a1f771af53
-2026/04/09 16:22:20 SSEHub: registered connection 68ece765e9bee5e4de35a6a1f771af53 (total: 1)
-2026/04/09 16:22:20 SSEHub: unregistered connection 68ece765e9bee5e4de35a6a1f771af53 (total: 0)
-2026/04/09 16:22:20 Received kill signal.  Quitting Writer. stop 0x7909adb96e00
-2026/04/09 16:22:20 Cleaning up writer...
+2026/04/09 16:36:26 Received kill signal.  Quitting Writer. stop 0x1679e77468c0
+2026/04/09 16:36:26 Cleaning up writer...
+2026/04/09 16:36:26 Finished cleaning up writer:  0x1679e77468c0
+2026/04/09 16:36:26 Closed MCP-GET-SSE SSE connection: 88961b0d14ac01cf5cfe93e19ab98455
+2026/04/09 16:36:26 Starting MCP-GET-SSE SSE connection: 74e3b91348986915f06f262e25bccf37
+2026/04/09 16:36:26 SSEHub: registered connection 74e3b91348986915f06f262e25bccf37 (total: 1)
 
 === Running scenario: tools-call-with-logging ===
-2026/04/09 16:22:20 Finished cleaning up writer:  0x7909adb96e00
+2026/04/09 16:36:26 SSEHub: unregistered connection 74e3b91348986915f06f262e25bccf37 (total: 0)
 Running client scenario 'tools-call-with-logging' against server: http://localhost:18799/mcp
-2026/04/09 16:22:20 Closed MCP-GET-SSE SSE connection: 68ece765e9bee5e4de35a6a1f771af53
-2026/04/09 16:22:20 Starting MCP-GET-SSE SSE connection: 8e7c115e766b3adeb66a940b55ce3d5f
-2026/04/09 16:22:20 SSEHub: registered connection 8e7c115e766b3adeb66a940b55ce3d5f (total: 1)
-2026/04/09 16:22:20 SSEHub: unregistered connection 8e7c115e766b3adeb66a940b55ce3d5f (total: 0)
+2026/04/09 16:36:26 Received kill signal.  Quitting Writer. stop 0x1679e7634e00
+2026/04/09 16:36:26 Cleaning up writer...
+2026/04/09 16:36:26 Finished cleaning up writer:  0x1679e7634e00
+2026/04/09 16:36:26 Closed MCP-GET-SSE SSE connection: 74e3b91348986915f06f262e25bccf37
+2026/04/09 16:36:26 Starting MCP-GET-SSE SSE connection: f265ee2e2bae6fbbf69c60f67943c5dc
+2026/04/09 16:36:26 SSEHub: registered connection f265ee2e2bae6fbbf69c60f67943c5dc (total: 1)
+2026/04/09 16:36:27 SSEHub: unregistered connection f265ee2e2bae6fbbf69c60f67943c5dc (total: 0)
 
 === Running scenario: tools-call-error ===
-2026/04/09 16:22:20 Received kill signal.  Quitting Writer. stop 0x7909ad9cea10
-2026/04/09 16:22:20 Cleaning up writer...
-2026/04/09 16:22:20 Finished cleaning up writer:  0x7909ad9cea10
-2026/04/09 16:22:20 Closed MCP-GET-SSE SSE connection: 8e7c115e766b3adeb66a940b55ce3d5f
+2026/04/09 16:36:27 Received kill signal.  Quitting Writer. stop 0x1679e7746af0
+2026/04/09 16:36:27 Cleaning up writer...
+2026/04/09 16:36:27 Finished cleaning up writer:  0x1679e7746af0
+2026/04/09 16:36:27 Closed MCP-GET-SSE SSE connection: f265ee2e2bae6fbbf69c60f67943c5dc
 Running client scenario 'tools-call-error' against server: http://localhost:18799/mcp
-2026/04/09 16:22:20 Starting MCP-GET-SSE SSE connection: 7a9e5b8cc60eb8e2248d1516f52e24bf
-2026/04/09 16:22:20 SSEHub: registered connection 7a9e5b8cc60eb8e2248d1516f52e24bf (total: 1)
-2026/04/09 16:22:20 SSEHub: unregistered connection 7a9e5b8cc60eb8e2248d1516f52e24bf (total: 0)
-2026/04/09 16:22:20 Received kill signal.  Quitting Writer. stop 0x7909ad9cec40
-2026/04/09 16:22:20 Cleaning up writer...
-2026/04/09 16:22:20 Finished cleaning up writer:  0x7909ad9cec40
-2026/04/09 16:22:20 Closed MCP-GET-SSE SSE connection: 7a9e5b8cc60eb8e2248d1516f52e24bf
+2026/04/09 16:36:27 Starting MCP-GET-SSE SSE connection: 69ec187f7cc582b35af120e16fb92c34
+2026/04/09 16:36:27 SSEHub: registered connection 69ec187f7cc582b35af120e16fb92c34 (total: 1)
+2026/04/09 16:36:27 SSEHub: unregistered connection 69ec187f7cc582b35af120e16fb92c34 (total: 0)
+2026/04/09 16:36:27 Received kill signal.  Quitting Writer. stop 0x1679e78a6690
+2026/04/09 16:36:27 Cleaning up writer...
+2026/04/09 16:36:27 Finished cleaning up writer:  0x1679e78a6690
 
 === Running scenario: tools-call-with-progress ===
+2026/04/09 16:36:27 Closed MCP-GET-SSE SSE connection: 69ec187f7cc582b35af120e16fb92c34
 Running client scenario 'tools-call-with-progress' against server: http://localhost:18799/mcp
-2026/04/09 16:22:20 Starting MCP-GET-SSE SSE connection: 12c63bebd3c7da202978ba6e631a3665
-2026/04/09 16:22:20 SSEHub: registered connection 12c63bebd3c7da202978ba6e631a3665 (total: 1)
-2026/04/09 16:22:20 SSEHub: unregistered connection 12c63bebd3c7da202978ba6e631a3665 (total: 0)
-2026/04/09 16:22:20 Received kill signal.  Quitting Writer. stop 0x7909ada0c850
-2026/04/09 16:22:20 Cleaning up writer...
-2026/04/09 16:22:20 Finished cleaning up writer:  0x7909ada0c850
-2026/04/09 16:22:20 Closed MCP-GET-SSE SSE connection: 12c63bebd3c7da202978ba6e631a3665
+2026/04/09 16:36:27 Starting MCP-GET-SSE SSE connection: 1ba3c52d46fb26c02358900cc1cdd9a4
+2026/04/09 16:36:27 SSEHub: registered connection 1ba3c52d46fb26c02358900cc1cdd9a4 (total: 1)
+2026/04/09 16:36:27 SSEHub: unregistered connection 1ba3c52d46fb26c02358900cc1cdd9a4 (total: 0)
+2026/04/09 16:36:27 Received kill signal.  Quitting Writer. stop 0x1679e7746fc0
+2026/04/09 16:36:27 Cleaning up writer...
+2026/04/09 16:36:27 Finished cleaning up writer:  0x1679e7746fc0
+2026/04/09 16:36:27 Closed MCP-GET-SSE SSE connection: 1ba3c52d46fb26c02358900cc1cdd9a4
 
 === Running scenario: tools-call-sampling ===
 Running client scenario 'tools-call-sampling' against server: http://localhost:18799/mcp
-2026/04/09 16:22:20 Starting MCP-GET-SSE SSE connection: bbbcb0d0c963ae46d864d06a737a635e
-2026/04/09 16:22:20 SSEHub: registered connection bbbcb0d0c963ae46d864d06a737a635e (total: 1)
-2026/04/09 16:22:20 SSEHub: unregistered connection bbbcb0d0c963ae46d864d06a737a635e (total: 0)
+2026/04/09 16:36:27 Starting MCP-GET-SSE SSE connection: 2c0161cad4e7f60562b38ae059ff001e
+2026/04/09 16:36:27 SSEHub: registered connection 2c0161cad4e7f60562b38ae059ff001e (total: 1)
+2026/04/09 16:36:27 SSEHub: unregistered connection 2c0161cad4e7f60562b38ae059ff001e (total: 0)
+2026/04/09 16:36:27 Received kill signal.  Quitting Writer. stop 0x1679e77472d0
+2026/04/09 16:36:27 Cleaning up writer...
 
 === Running scenario: tools-call-elicitation ===
-2026/04/09 16:22:20 Received kill signal.  Quitting Writer. stop 0x7909ad9cefc0
-2026/04/09 16:22:20 Cleaning up writer...
+2026/04/09 16:36:27 Finished cleaning up writer:  0x1679e77472d0
+2026/04/09 16:36:27 Closed MCP-GET-SSE SSE connection: 2c0161cad4e7f60562b38ae059ff001e
 Running client scenario 'tools-call-elicitation' against server: http://localhost:18799/mcp
-2026/04/09 16:22:20 Finished cleaning up writer:  0x7909ad9cefc0
-2026/04/09 16:22:20 Closed MCP-GET-SSE SSE connection: bbbcb0d0c963ae46d864d06a737a635e
-2026/04/09 16:22:20 Starting MCP-GET-SSE SSE connection: cbfb01b7a9731b20b7ed19238315adb8
-2026/04/09 16:22:20 SSEHub: registered connection cbfb01b7a9731b20b7ed19238315adb8 (total: 1)
-2026/04/09 16:22:21 SSEHub: unregistered connection cbfb01b7a9731b20b7ed19238315adb8 (total: 0)
-2026/04/09 16:22:21 Received kill signal.  Quitting Writer. stop 0x7909ad9cf1f0
-2026/04/09 16:22:21 Cleaning up writer...
-2026/04/09 16:22:21 Finished cleaning up writer:  0x7909ad9cf1f0
+2026/04/09 16:36:27 Starting MCP-GET-SSE SSE connection: 08985ac48af831015ae211be2b4708ee
+2026/04/09 16:36:27 SSEHub: registered connection 08985ac48af831015ae211be2b4708ee (total: 1)
 
 === Running scenario: elicitation-sep1034-defaults ===
-2026/04/09 16:22:21 Closed MCP-GET-SSE SSE connection: cbfb01b7a9731b20b7ed19238315adb8
+2026/04/09 16:36:27 SSEHub: unregistered connection 08985ac48af831015ae211be2b4708ee (total: 0)
+2026/04/09 16:36:27 Received kill signal.  Quitting Writer. stop 0x1679e78a6930
+2026/04/09 16:36:27 Cleaning up writer...
+2026/04/09 16:36:27 Finished cleaning up writer:  0x1679e78a6930
+2026/04/09 16:36:27 Closed MCP-GET-SSE SSE connection: 08985ac48af831015ae211be2b4708ee
 Running client scenario 'elicitation-sep1034-defaults' against server: http://localhost:18799/mcp
-2026/04/09 16:22:21 Starting MCP-GET-SSE SSE connection: 550bff8978ee96f825d128e10593f52a
-2026/04/09 16:22:21 SSEHub: registered connection 550bff8978ee96f825d128e10593f52a (total: 1)
-2026/04/09 16:22:21 SSEHub: unregistered connection 550bff8978ee96f825d128e10593f52a (total: 0)
+2026/04/09 16:36:27 Starting MCP-GET-SSE SSE connection: 3466254f156f951af787118702462453
+2026/04/09 16:36:27 SSEHub: registered connection 3466254f156f951af787118702462453 (total: 1)
+2026/04/09 16:36:27 SSEHub: unregistered connection 3466254f156f951af787118702462453 (total: 0)
 
 === Running scenario: server-sse-multiple-streams ===
-2026/04/09 16:22:21 Received kill signal.  Quitting Writer. stop 0x7909ada0cc40
-2026/04/09 16:22:21 Cleaning up writer...
-2026/04/09 16:22:21 Finished cleaning up writer:  0x7909ada0cc40
-2026/04/09 16:22:21 Closed MCP-GET-SSE SSE connection: 550bff8978ee96f825d128e10593f52a
+2026/04/09 16:36:27 Received kill signal.  Quitting Writer. stop 0x1679e78a6b60
 Running client scenario 'server-sse-multiple-streams' against server: http://localhost:18799/mcp
-2026/04/09 16:22:21 Starting MCP-GET-SSE SSE connection: beb2dde3a9f2413c21a3db2310c312d5
-2026/04/09 16:22:21 SSEHub: registered connection beb2dde3a9f2413c21a3db2310c312d5 (total: 1)
+2026/04/09 16:36:27 Cleaning up writer...
+2026/04/09 16:36:27 Finished cleaning up writer:  0x1679e78a6b60
+2026/04/09 16:36:27 Closed MCP-GET-SSE SSE connection: 3466254f156f951af787118702462453
+2026/04/09 16:36:27 Starting MCP-GET-SSE SSE connection: f6dbb066c06fb98f475dc478aebc8aa8
+2026/04/09 16:36:27 SSEHub: registered connection f6dbb066c06fb98f475dc478aebc8aa8 (total: 1)
+2026/04/09 16:36:27 SSEHub: unregistered connection f6dbb066c06fb98f475dc478aebc8aa8 (total: 0)
+2026/04/09 16:36:27 Received kill signal.  Quitting Writer. stop 0x1679e78a6d90
+2026/04/09 16:36:27 Cleaning up writer...
 
 === Running scenario: elicitation-sep1330-enums ===
+2026/04/09 16:36:27 Finished cleaning up writer:  0x1679e78a6d90
 Running client scenario 'elicitation-sep1330-enums' against server: http://localhost:18799/mcp
-2026/04/09 16:22:21 SSEHub: unregistered connection beb2dde3a9f2413c21a3db2310c312d5 (total: 0)
-2026/04/09 16:22:21 Received kill signal.  Quitting Writer. stop 0x7909ad9cf730
-2026/04/09 16:22:21 Cleaning up writer...
-2026/04/09 16:22:21 Finished cleaning up writer:  0x7909ad9cf730
-2026/04/09 16:22:21 Closed MCP-GET-SSE SSE connection: beb2dde3a9f2413c21a3db2310c312d5
-2026/04/09 16:22:21 Starting MCP-GET-SSE SSE connection: b086aec50ef3fb67e131d4f1736bea32
-2026/04/09 16:22:21 SSEHub: registered connection b086aec50ef3fb67e131d4f1736bea32 (total: 1)
-2026/04/09 16:22:21 SSEHub: unregistered connection b086aec50ef3fb67e131d4f1736bea32 (total: 0)
-2026/04/09 16:22:21 Received kill signal.  Quitting Writer. stop 0x7909ada0cf50
-2026/04/09 16:22:21 Cleaning up writer...
-2026/04/09 16:22:21 Finished cleaning up writer:  0x7909ada0cf50
-2026/04/09 16:22:21 Closed MCP-GET-SSE SSE connection: b086aec50ef3fb67e131d4f1736bea32
+2026/04/09 16:36:27 Closed MCP-GET-SSE SSE connection: f6dbb066c06fb98f475dc478aebc8aa8
+2026/04/09 16:36:27 Starting MCP-GET-SSE SSE connection: 61230e21c14a954a58c3426bb7465571
+2026/04/09 16:36:27 SSEHub: registered connection 61230e21c14a954a58c3426bb7465571 (total: 1)
+2026/04/09 16:36:27 SSEHub: unregistered connection 61230e21c14a954a58c3426bb7465571 (total: 0)
+2026/04/09 16:36:27 Received kill signal.  Quitting Writer. stop 0x1679e7747650
+2026/04/09 16:36:27 Cleaning up writer...
+2026/04/09 16:36:27 Finished cleaning up writer:  0x1679e7747650
+2026/04/09 16:36:27 Closed MCP-GET-SSE SSE connection: 61230e21c14a954a58c3426bb7465571
 
 === Running scenario: resources-list ===
 Running client scenario 'resources-list' against server: http://localhost:18799/mcp
-2026/04/09 16:22:21 Starting MCP-GET-SSE SSE connection: 02c37f7da6bc2015a5d7adeae8230d72
-2026/04/09 16:22:21 SSEHub: registered connection 02c37f7da6bc2015a5d7adeae8230d72 (total: 1)
+2026/04/09 16:36:27 Starting MCP-GET-SSE SSE connection: c927f5c133312c16d78677470ba5b272
+2026/04/09 16:36:27 SSEHub: registered connection c927f5c133312c16d78677470ba5b272 (total: 1)
+2026/04/09 16:36:27 SSEHub: unregistered connection c927f5c133312c16d78677470ba5b272 (total: 0)
+2026/04/09 16:36:27 Received kill signal.  Quitting Writer. stop 0x1679e78a7110
+2026/04/09 16:36:27 Cleaning up writer...
 
 === Running scenario: resources-read-text ===
-2026/04/09 16:22:21 SSEHub: unregistered connection 02c37f7da6bc2015a5d7adeae8230d72 (total: 0)
+2026/04/09 16:36:27 Finished cleaning up writer:  0x1679e78a7110
 Running client scenario 'resources-read-text' against server: http://localhost:18799/mcp
-2026/04/09 16:22:21 Received kill signal.  Quitting Writer. stop 0x7909ad9cf960
-2026/04/09 16:22:21 Cleaning up writer...
-2026/04/09 16:22:21 Finished cleaning up writer:  0x7909ad9cf960
-2026/04/09 16:22:21 Closed MCP-GET-SSE SSE connection: 02c37f7da6bc2015a5d7adeae8230d72
-2026/04/09 16:22:21 Starting MCP-GET-SSE SSE connection: ed1923fca3607ea25b1086ea9a5fd47f
-2026/04/09 16:22:21 SSEHub: registered connection ed1923fca3607ea25b1086ea9a5fd47f (total: 1)
+2026/04/09 16:36:27 Closed MCP-GET-SSE SSE connection: c927f5c133312c16d78677470ba5b272
+2026/04/09 16:36:27 Starting MCP-GET-SSE SSE connection: 93bd19e3e9056339fd653b94b19a3790
+2026/04/09 16:36:27 SSEHub: registered connection 93bd19e3e9056339fd653b94b19a3790 (total: 1)
+2026/04/09 16:36:27 SSEHub: unregistered connection 93bd19e3e9056339fd653b94b19a3790 (total: 0)
+2026/04/09 16:36:27 Received kill signal.  Quitting Writer. stop 0x1679e792ea10
+2026/04/09 16:36:27 Cleaning up writer...
+2026/04/09 16:36:27 Finished cleaning up writer:  0x1679e792ea10
+2026/04/09 16:36:27 Closed MCP-GET-SSE SSE connection: 93bd19e3e9056339fd653b94b19a3790
 
 === Running scenario: resources-read-binary ===
 Running client scenario 'resources-read-binary' against server: http://localhost:18799/mcp
-2026/04/09 16:22:21 SSEHub: unregistered connection ed1923fca3607ea25b1086ea9a5fd47f (total: 0)
-2026/04/09 16:22:21 Received kill signal.  Quitting Writer. stop 0x7909ada0d180
-2026/04/09 16:22:21 Cleaning up writer...
-2026/04/09 16:22:21 Finished cleaning up writer:  0x7909ada0d180
-2026/04/09 16:22:21 Closed MCP-GET-SSE SSE connection: ed1923fca3607ea25b1086ea9a5fd47f
-2026/04/09 16:22:21 Starting MCP-GET-SSE SSE connection: cb491dbd4baec248d4881b0fc2f91919
-2026/04/09 16:22:21 SSEHub: registered connection cb491dbd4baec248d4881b0fc2f91919 (total: 1)
+2026/04/09 16:36:27 Starting MCP-GET-SSE SSE connection: 8dd60ef8ed3b2d4e80be260a18c7e6b7
+2026/04/09 16:36:27 SSEHub: registered connection 8dd60ef8ed3b2d4e80be260a18c7e6b7 (total: 1)
+2026/04/09 16:36:27 SSEHub: unregistered connection 8dd60ef8ed3b2d4e80be260a18c7e6b7 (total: 0)
+2026/04/09 16:36:27 Received kill signal.  Quitting Writer. stop 0x1679e792ec40
+2026/04/09 16:36:27 Cleaning up writer...
+2026/04/09 16:36:27 Finished cleaning up writer:  0x1679e792ec40
+2026/04/09 16:36:27 Closed MCP-GET-SSE SSE connection: 8dd60ef8ed3b2d4e80be260a18c7e6b7
 
 === Running scenario: resources-templates-read ===
 Running client scenario 'resources-templates-read' against server: http://localhost:18799/mcp
-2026/04/09 16:22:21 SSEHub: unregistered connection cb491dbd4baec248d4881b0fc2f91919 (total: 0)
-2026/04/09 16:22:21 Received kill signal.  Quitting Writer. stop 0x7909ad9cfc00
-2026/04/09 16:22:21 Cleaning up writer...
-2026/04/09 16:22:21 Finished cleaning up writer:  0x7909ad9cfc00
-2026/04/09 16:22:21 Closed MCP-GET-SSE SSE connection: cb491dbd4baec248d4881b0fc2f91919
-2026/04/09 16:22:21 Starting MCP-GET-SSE SSE connection: b3ee049994c5be71b0e693afa15d31ca
-2026/04/09 16:22:21 SSEHub: registered connection b3ee049994c5be71b0e693afa15d31ca (total: 1)
-2026/04/09 16:22:21 SSEHub: unregistered connection b3ee049994c5be71b0e693afa15d31ca (total: 0)
-2026/04/09 16:22:21 Received kill signal.  Quitting Writer. stop 0x7909ad9cfe30
-2026/04/09 16:22:21 Cleaning up writer...
+2026/04/09 16:36:27 Starting MCP-GET-SSE SSE connection: a6bd1beccd8c262f1c3313f38e354664
+2026/04/09 16:36:27 SSEHub: registered connection a6bd1beccd8c262f1c3313f38e354664 (total: 1)
+2026/04/09 16:36:27 SSEHub: unregistered connection a6bd1beccd8c262f1c3313f38e354664 (total: 0)
+2026/04/09 16:36:27 Received kill signal.  Quitting Writer. stop 0x1679e792ee70
+2026/04/09 16:36:27 Cleaning up writer...
 
 === Running scenario: resources-subscribe ===
-2026/04/09 16:22:21 Finished cleaning up writer:  0x7909ad9cfe30
-2026/04/09 16:22:21 Closed MCP-GET-SSE SSE connection: b3ee049994c5be71b0e693afa15d31ca
+2026/04/09 16:36:27 Finished cleaning up writer:  0x1679e792ee70
+2026/04/09 16:36:27 Closed MCP-GET-SSE SSE connection: a6bd1beccd8c262f1c3313f38e354664
 Running client scenario 'resources-subscribe' against server: http://localhost:18799/mcp
-2026/04/09 16:22:21 Starting MCP-GET-SSE SSE connection: 2d06d1dc0273aed4a0588de93123e4b8
-2026/04/09 16:22:21 SSEHub: registered connection 2d06d1dc0273aed4a0588de93123e4b8 (total: 1)
-2026/04/09 16:22:21 SSEHub: unregistered connection 2d06d1dc0273aed4a0588de93123e4b8 (total: 0)
-2026/04/09 16:22:21 Received kill signal.  Quitting Writer. stop 0x7909adc38150
-2026/04/09 16:22:21 Cleaning up writer...
-2026/04/09 16:22:21 Finished cleaning up writer:  0x7909adc38150
+2026/04/09 16:36:27 Starting MCP-GET-SSE SSE connection: 211ea8b99bd0f7aaaf759c64ae92574a
+2026/04/09 16:36:27 SSEHub: registered connection 211ea8b99bd0f7aaaf759c64ae92574a (total: 1)
+2026/04/09 16:36:27 SSEHub: unregistered connection 211ea8b99bd0f7aaaf759c64ae92574a (total: 0)
 
 === Running scenario: resources-unsubscribe ===
-2026/04/09 16:22:21 Closed MCP-GET-SSE SSE connection: 2d06d1dc0273aed4a0588de93123e4b8
+2026/04/09 16:36:27 Received kill signal.  Quitting Writer. stop 0x1679e78a7490
+2026/04/09 16:36:27 Cleaning up writer...
 Running client scenario 'resources-unsubscribe' against server: http://localhost:18799/mcp
-2026/04/09 16:22:21 Starting MCP-GET-SSE SSE connection: 84ea51b27bd5712e9596cd67633fbab0
-2026/04/09 16:22:21 SSEHub: registered connection 84ea51b27bd5712e9596cd67633fbab0 (total: 1)
-2026/04/09 16:22:21 SSEHub: unregistered connection 84ea51b27bd5712e9596cd67633fbab0 (total: 0)
-2026/04/09 16:22:21 Received kill signal.  Quitting Writer. stop 0x7909adc38380
-2026/04/09 16:22:21 Cleaning up writer...
-2026/04/09 16:22:21 Finished cleaning up writer:  0x7909adc38380
-2026/04/09 16:22:21 Closed MCP-GET-SSE SSE connection: 84ea51b27bd5712e9596cd67633fbab0
+2026/04/09 16:36:27 Finished cleaning up writer:  0x1679e78a7490
+2026/04/09 16:36:27 Closed MCP-GET-SSE SSE connection: 211ea8b99bd0f7aaaf759c64ae92574a
+2026/04/09 16:36:27 Starting MCP-GET-SSE SSE connection: ca3566997ffa9d0b05ddbb94016ec2b3
+2026/04/09 16:36:27 SSEHub: registered connection ca3566997ffa9d0b05ddbb94016ec2b3 (total: 1)
+2026/04/09 16:36:27 SSEHub: unregistered connection ca3566997ffa9d0b05ddbb94016ec2b3 (total: 0)
 
 === Running scenario: prompts-list ===
+2026/04/09 16:36:27 Received kill signal.  Quitting Writer. stop 0x1679e78a7730
+2026/04/09 16:36:27 Cleaning up writer...
+2026/04/09 16:36:27 Finished cleaning up writer:  0x1679e78a7730
 Running client scenario 'prompts-list' against server: http://localhost:18799/mcp
-2026/04/09 16:22:21 Starting MCP-GET-SSE SSE connection: ecd2ff0d1cc7fb4fe064968c407b7dfa
-2026/04/09 16:22:21 SSEHub: registered connection ecd2ff0d1cc7fb4fe064968c407b7dfa (total: 1)
-2026/04/09 16:22:21 SSEHub: unregistered connection ecd2ff0d1cc7fb4fe064968c407b7dfa (total: 0)
+2026/04/09 16:36:27 Closed MCP-GET-SSE SSE connection: ca3566997ffa9d0b05ddbb94016ec2b3
+2026/04/09 16:36:27 Starting MCP-GET-SSE SSE connection: c5dd0f5e2876b1fd5c4210549c1f462f
+2026/04/09 16:36:27 SSEHub: registered connection c5dd0f5e2876b1fd5c4210549c1f462f (total: 1)
 
 === Running scenario: prompts-get-simple ===
-2026/04/09 16:22:21 Received kill signal.  Quitting Writer. stop 0x7909adb97650
-2026/04/09 16:22:21 Cleaning up writer...
-2026/04/09 16:22:21 Finished cleaning up writer:  0x7909adb97650
+2026/04/09 16:36:27 SSEHub: unregistered connection c5dd0f5e2876b1fd5c4210549c1f462f (total: 0)
+2026/04/09 16:36:27 Received kill signal.  Quitting Writer. stop 0x1679e76356c0
+2026/04/09 16:36:27 Cleaning up writer...
 Running client scenario 'prompts-get-simple' against server: http://localhost:18799/mcp
-2026/04/09 16:22:21 Closed MCP-GET-SSE SSE connection: ecd2ff0d1cc7fb4fe064968c407b7dfa
-2026/04/09 16:22:21 Starting MCP-GET-SSE SSE connection: eee6681ec7d290853239e5077fce1a73
-2026/04/09 16:22:21 SSEHub: registered connection eee6681ec7d290853239e5077fce1a73 (total: 1)
-2026/04/09 16:22:21 SSEHub: unregistered connection eee6681ec7d290853239e5077fce1a73 (total: 0)
-2026/04/09 16:22:21 Received kill signal.  Quitting Writer. stop 0x7909adb978f0
-2026/04/09 16:22:21 Cleaning up writer...
-2026/04/09 16:22:21 Finished cleaning up writer:  0x7909adb978f0
-2026/04/09 16:22:21 Closed MCP-GET-SSE SSE connection: eee6681ec7d290853239e5077fce1a73
+2026/04/09 16:36:27 Finished cleaning up writer:  0x1679e76356c0
+2026/04/09 16:36:27 Closed MCP-GET-SSE SSE connection: c5dd0f5e2876b1fd5c4210549c1f462f
+2026/04/09 16:36:27 Starting MCP-GET-SSE SSE connection: b7c0c75151177c59f361a570c1ece27c
+2026/04/09 16:36:27 SSEHub: registered connection b7c0c75151177c59f361a570c1ece27c (total: 1)
+2026/04/09 16:36:27 SSEHub: unregistered connection b7c0c75151177c59f361a570c1ece27c (total: 0)
+2026/04/09 16:36:27 Received kill signal.  Quitting Writer. stop 0x1679e792f180
+2026/04/09 16:36:27 Cleaning up writer...
+2026/04/09 16:36:27 Finished cleaning up writer:  0x1679e792f180
+2026/04/09 16:36:27 Closed MCP-GET-SSE SSE connection: b7c0c75151177c59f361a570c1ece27c
 
 === Running scenario: prompts-get-with-args ===
 Running client scenario 'prompts-get-with-args' against server: http://localhost:18799/mcp
-2026/04/09 16:22:21 Starting MCP-GET-SSE SSE connection: dd8b8af152bc976a2c8dcfcb69503753
-2026/04/09 16:22:21 SSEHub: registered connection dd8b8af152bc976a2c8dcfcb69503753 (total: 1)
-2026/04/09 16:22:21 SSEHub: unregistered connection dd8b8af152bc976a2c8dcfcb69503753 (total: 0)
-2026/04/09 16:22:21 Received kill signal.  Quitting Writer. stop 0x7909adc38690
-2026/04/09 16:22:21 Cleaning up writer...
-2026/04/09 16:22:21 Finished cleaning up writer:  0x7909adc38690
-2026/04/09 16:22:21 Closed MCP-GET-SSE SSE connection: dd8b8af152bc976a2c8dcfcb69503753
+2026/04/09 16:36:27 Starting MCP-GET-SSE SSE connection: 47d9998da67faed967c6b65121c2c334
+2026/04/09 16:36:27 SSEHub: registered connection 47d9998da67faed967c6b65121c2c334 (total: 1)
+2026/04/09 16:36:27 SSEHub: unregistered connection 47d9998da67faed967c6b65121c2c334 (total: 0)
+2026/04/09 16:36:27 Received kill signal.  Quitting Writer. stop 0x1679e792f3b0
+2026/04/09 16:36:27 Cleaning up writer...
+2026/04/09 16:36:27 Finished cleaning up writer:  0x1679e792f3b0
+2026/04/09 16:36:27 Closed MCP-GET-SSE SSE connection: 47d9998da67faed967c6b65121c2c334
 
 === Running scenario: prompts-get-embedded-resource ===
 Running client scenario 'prompts-get-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/09 16:22:21 Starting MCP-GET-SSE SSE connection: dd1090659ec05bc3e0419841d3d6e8f1
-2026/04/09 16:22:21 SSEHub: registered connection dd1090659ec05bc3e0419841d3d6e8f1 (total: 1)
-2026/04/09 16:22:21 SSEHub: unregistered connection dd1090659ec05bc3e0419841d3d6e8f1 (total: 0)
-2026/04/09 16:22:21 Received kill signal.  Quitting Writer. stop 0x7909adb97c00
-2026/04/09 16:22:21 Cleaning up writer...
-2026/04/09 16:22:21 Finished cleaning up writer:  0x7909adb97c00
-2026/04/09 16:22:21 Closed MCP-GET-SSE SSE connection: dd1090659ec05bc3e0419841d3d6e8f1
+2026/04/09 16:36:27 Starting MCP-GET-SSE SSE connection: 150da9a1af631db9f3669707f7a4d444
+2026/04/09 16:36:27 SSEHub: registered connection 150da9a1af631db9f3669707f7a4d444 (total: 1)
+2026/04/09 16:36:27 SSEHub: unregistered connection 150da9a1af631db9f3669707f7a4d444 (total: 0)
+2026/04/09 16:36:27 Received kill signal.  Quitting Writer. stop 0x1679e7635960
+2026/04/09 16:36:27 Cleaning up writer...
+2026/04/09 16:36:27 Finished cleaning up writer:  0x1679e7635960
+2026/04/09 16:36:27 Closed MCP-GET-SSE SSE connection: 150da9a1af631db9f3669707f7a4d444
 
 === Running scenario: prompts-get-with-image ===
 Running client scenario 'prompts-get-with-image' against server: http://localhost:18799/mcp
-2026/04/09 16:22:21 Starting MCP-GET-SSE SSE connection: 4055d0f348ba23b75a6e92b0452ad9a5
-2026/04/09 16:22:21 SSEHub: registered connection 4055d0f348ba23b75a6e92b0452ad9a5 (total: 1)
-2026/04/09 16:22:21 SSEHub: unregistered connection 4055d0f348ba23b75a6e92b0452ad9a5 (total: 0)
-2026/04/09 16:22:21 Received kill signal.  Quitting Writer. stop 0x7909adb97f10
-2026/04/09 16:22:21 Cleaning up writer...
-2026/04/09 16:22:21 Finished cleaning up writer:  0x7909adb97f10
+2026/04/09 16:36:27 Starting MCP-GET-SSE SSE connection: c1c3545da535e1632593956cdd701a31
+2026/04/09 16:36:27 SSEHub: registered connection c1c3545da535e1632593956cdd701a31 (total: 1)
+2026/04/09 16:36:27 SSEHub: unregistered connection c1c3545da535e1632593956cdd701a31 (total: 0)
+2026/04/09 16:36:27 Received kill signal.  Quitting Writer. stop 0x1679e7635c00
+2026/04/09 16:36:27 Cleaning up writer...
+2026/04/09 16:36:27 Finished cleaning up writer:  0x1679e7635c00
+2026/04/09 16:36:27 Closed MCP-GET-SSE SSE connection: c1c3545da535e1632593956cdd701a31
 
 === Running scenario: dns-rebinding-protection ===
-2026/04/09 16:22:21 Closed MCP-GET-SSE SSE connection: 4055d0f348ba23b75a6e92b0452ad9a5
 Running client scenario 'dns-rebinding-protection' against server: http://localhost:18799/mcp
 
 
@@ -422,22 +420,22 @@ Starting scenario: auth/token-endpoint-auth-basic
 Starting scenario: auth/token-endpoint-auth-post
 Starting scenario: auth/token-endpoint-auth-none
 Starting scenario: auth/pre-registration
-Executing client: ./bin/testclient http://localhost:51050/mcp
-Executing client: ./bin/testclient http://localhost:51051/mcp
-Executing client: ./bin/testclient http://localhost:51052/mcp
-Executing client: ./bin/testclient http://localhost:51053/mcp
-Executing client: ./bin/testclient http://localhost:51054/mcp
-Executing client: ./bin/testclient http://localhost:51055/mcp
-Executing client: ./bin/testclient http://localhost:51056/mcp
-Executing client: ./bin/testclient http://localhost:51057/mcp
-Executing client: ./bin/testclient http://localhost:51058/mcp
-Executing client: ./bin/testclient http://localhost:51059/mcp
-Executing client: ./bin/testclient http://localhost:51060/mcp
-Executing client: ./bin/testclient http://localhost:51061/mcp
-Executing client: ./bin/testclient http://localhost:51062/mcp
-Executing client: ./bin/testclient http://localhost:51063/mcp
+Executing client: ./bin/testclient http://localhost:59009/mcp
+Executing client: ./bin/testclient http://localhost:59010/mcp
+Executing client: ./bin/testclient http://localhost:59011/mcp
+Executing client: ./bin/testclient http://localhost:59012/mcp
+Executing client: ./bin/testclient http://localhost:59013/mcp
+Executing client: ./bin/testclient http://localhost:59014/mcp
+Executing client: ./bin/testclient http://localhost:59015/mcp
+Executing client: ./bin/testclient http://localhost:59016/mcp
+Executing client: ./bin/testclient http://localhost:59017/mcp
+Executing client: ./bin/testclient http://localhost:59018/mcp
+Executing client: ./bin/testclient http://localhost:59019/mcp
+Executing client: ./bin/testclient http://localhost:59020/mcp
+Executing client: ./bin/testclient http://localhost:59021/mcp
+Executing client: ./bin/testclient http://localhost:59022/mcp
 With context: {"client_id":"pre-registered-client","client_secret":"pre-registered-secret"}
-(node:52974) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
+(node:59968) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
 (Use `node --trace-deprecation ...` to show where the warning was created)
 
 === SUITE SUMMARY ===
@@ -468,7 +466,7 @@ Total: 210 passed, 0 failed, 1 warnings
   PASS: auth-conformance
 --- [8/8] keycloak ---
 === RUN   TestKeycloak_MCPServer_ValidToken
---- PASS: TestKeycloak_MCPServer_ValidToken (0.18s)
+--- PASS: TestKeycloak_MCPServer_ValidToken (0.03s)
 === RUN   TestKeycloak_MCPServer_TamperedToken
 --- PASS: TestKeycloak_MCPServer_TamperedToken (0.02s)
 === RUN   TestKeycloak_MCPServer_ScopeAllowed
@@ -480,12 +478,12 @@ Total: 210 passed, 0 failed, 1 warnings
 === RUN   TestKeycloak_MCPServer_WWWAuthenticate
 --- PASS: TestKeycloak_MCPServer_WWWAuthenticate (0.01s)
 === RUN   TestKeycloak_MCPServer_PasswordGrant
---- PASS: TestKeycloak_MCPServer_PasswordGrant (0.09s)
+--- PASS: TestKeycloak_MCPServer_PasswordGrant (0.04s)
 PASS
-ok  	github.com/panyam/mcpkit/tests/keycloak	0.850s
+ok  	github.com/panyam/mcpkit/tests/keycloak	0.613s
   PASS: keycloak
 
 === Results: 8 passed, 0 failed ===
-Finished: Thu Apr  9 16:22:24 PDT 2026
+Finished: Thu Apr  9 16:36:30 PDT 2026
 </pre>
 </body></html>

--- a/tests/reports/run.log
+++ b/tests/reports/run.log
@@ -1,36 +1,34 @@
 === MCPKit Comprehensive Test Suite ===
-Started: Thu Apr  9 16:21:54 PDT 2026
+Started: Thu Apr  9 16:35:59 PDT 2026
 
 --- [1/8] unit ---
-ok  	github.com/panyam/mcpkit/client	1.673s
+ok  	github.com/panyam/mcpkit/client	2.058s
 ?   	github.com/panyam/mcpkit/cmd/testserver	[no test files]
-ok  	github.com/panyam/mcpkit/core	0.201s
-ok  	github.com/panyam/mcpkit/server	8.364s
-ok  	github.com/panyam/mcpkit/testutil	0.685s
+ok  	github.com/panyam/mcpkit/core	0.507s
+ok  	github.com/panyam/mcpkit/server	8.255s
+ok  	github.com/panyam/mcpkit/testutil	0.702s
   PASS: unit
 --- [2/8] race ---
-ok  	github.com/panyam/mcpkit/client	2.805s
+ok  	github.com/panyam/mcpkit/client	3.196s
 ?   	github.com/panyam/mcpkit/cmd/testserver	[no test files]
-ok  	github.com/panyam/mcpkit/core	1.213s
-ok  	github.com/panyam/mcpkit/server	9.715s
-ok  	github.com/panyam/mcpkit/testutil	1.591s
+ok  	github.com/panyam/mcpkit/core	1.491s
+ok  	github.com/panyam/mcpkit/server	9.422s
+ok  	github.com/panyam/mcpkit/testutil	1.669s
   PASS: race
 --- [3/8] auth ---
-ok  	github.com/panyam/mcpkit/ext/auth	0.235s
+ok  	github.com/panyam/mcpkit/ext/auth	0.527s
   PASS: auth
 --- [4/8] ui ---
-ok  	github.com/panyam/mcpkit/ext/ui	0.206s
+ok  	github.com/panyam/mcpkit/ext/ui	0.434s
   PASS: ui
 --- [5/8] e2e ---
-ok  	github.com/panyam/mcpkit/tests/e2e	2.019s
-ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.298s
+ok  	github.com/panyam/mcpkit/tests/e2e	2.355s
+ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.711s
   PASS: e2e
 --- [6/8] conformance ---
 Killing stale process on port 18799...
-2026/04/09 16:22:17 Received signal terminated, shutting down...
-2026/04/09 16:22:17 Server shut down gracefully
 === Starting test server on :18799 (Streamable HTTP) ===
-Waiting for server....2026/04/09 16:22:18 MCP test server listening on :18799 (Streamable HTTP at /mcp)
+Waiting for server....2026/04/09 16:36:25 MCP test server listening on :18799 (Streamable HTTP at /mcp)
  ready
 
 === Running MCP conformance suite ===
@@ -41,295 +39,295 @@ Running active suite (30 scenarios) against http://localhost:18799/mcp
 
 === Running scenario: server-initialize ===
 Running client scenario 'server-initialize' against server: http://localhost:18799/mcp
-2026/04/09 16:22:20 Starting MCP-GET-SSE SSE connection: f7ea9a59c9cca3712d1942f60070bae6
-2026/04/09 16:22:20 SSEHub: registered connection f7ea9a59c9cca3712d1942f60070bae6 (total: 1)
-2026/04/09 16:22:20 SSEHub: unregistered connection f7ea9a59c9cca3712d1942f60070bae6 (total: 0)
-2026/04/09 16:22:20 Received kill signal.  Quitting Writer. stop 0x7909ad9ce2a0
-2026/04/09 16:22:20 Cleaning up writer...
-2026/04/09 16:22:20 Finished cleaning up writer:  0x7909ad9ce2a0
-2026/04/09 16:22:20 Closed MCP-GET-SSE SSE connection: f7ea9a59c9cca3712d1942f60070bae6
+2026/04/09 16:36:26 Starting MCP-GET-SSE SSE connection: fe874e59b108f02efcbcd62d44481e2d
+2026/04/09 16:36:26 SSEHub: registered connection fe874e59b108f02efcbcd62d44481e2d (total: 1)
+2026/04/09 16:36:26 SSEHub: unregistered connection fe874e59b108f02efcbcd62d44481e2d (total: 0)
+2026/04/09 16:36:26 Received kill signal.  Quitting Writer. stop 0x1679e7634460
+2026/04/09 16:36:26 Cleaning up writer...
+2026/04/09 16:36:26 Finished cleaning up writer:  0x1679e7634460
+2026/04/09 16:36:26 Closed MCP-GET-SSE SSE connection: fe874e59b108f02efcbcd62d44481e2d
 
 === Running scenario: logging-set-level ===
 Running client scenario 'logging-set-level' against server: http://localhost:18799/mcp
-2026/04/09 16:22:20 Starting MCP-GET-SSE SSE connection: 53a9144b3d7144443bbb6475d80755f5
-2026/04/09 16:22:20 SSEHub: registered connection 53a9144b3d7144443bbb6475d80755f5 (total: 1)
-2026/04/09 16:22:20 SSEHub: unregistered connection 53a9144b3d7144443bbb6475d80755f5 (total: 0)
-2026/04/09 16:22:20 Received kill signal.  Quitting Writer. stop 0x7909adb961c0
-2026/04/09 16:22:20 Cleaning up writer...
-2026/04/09 16:22:20 Finished cleaning up writer:  0x7909adb961c0
-2026/04/09 16:22:20 Closed MCP-GET-SSE SSE connection: 53a9144b3d7144443bbb6475d80755f5
+2026/04/09 16:36:26 Starting MCP-GET-SSE SSE connection: 05306fb3bf4992fc059bf7feb06710c9
+2026/04/09 16:36:26 SSEHub: registered connection 05306fb3bf4992fc059bf7feb06710c9 (total: 1)
+2026/04/09 16:36:26 SSEHub: unregistered connection 05306fb3bf4992fc059bf7feb06710c9 (total: 0)
+2026/04/09 16:36:26 Received kill signal.  Quitting Writer. stop 0x1679e792e1c0
+2026/04/09 16:36:26 Cleaning up writer...
+2026/04/09 16:36:26 Finished cleaning up writer:  0x1679e792e1c0
+2026/04/09 16:36:26 Closed MCP-GET-SSE SSE connection: 05306fb3bf4992fc059bf7feb06710c9
 
 === Running scenario: ping ===
 Running client scenario 'ping' against server: http://localhost:18799/mcp
-2026/04/09 16:22:20 Starting MCP-GET-SSE SSE connection: fe931b0d42b9cfccddbe7457d2c517d0
-2026/04/09 16:22:20 SSEHub: registered connection fe931b0d42b9cfccddbe7457d2c517d0 (total: 1)
+2026/04/09 16:36:26 Starting MCP-GET-SSE SSE connection: 412bb415038bd01dd4a1a1da40599bf6
+2026/04/09 16:36:26 SSEHub: registered connection 412bb415038bd01dd4a1a1da40599bf6 (total: 1)
+2026/04/09 16:36:26 SSEHub: unregistered connection 412bb415038bd01dd4a1a1da40599bf6 (total: 0)
+2026/04/09 16:36:26 Received kill signal.  Quitting Writer. stop 0x1679e7634690
+2026/04/09 16:36:26 Cleaning up writer...
+2026/04/09 16:36:26 Finished cleaning up writer:  0x1679e7634690
+2026/04/09 16:36:26 Closed MCP-GET-SSE SSE connection: 412bb415038bd01dd4a1a1da40599bf6
 
 === Running scenario: completion-complete ===
-2026/04/09 16:22:20 SSEHub: unregistered connection fe931b0d42b9cfccddbe7457d2c517d0 (total: 0)
-2026/04/09 16:22:20 Received kill signal.  Quitting Writer. stop 0x7909adb96460
-2026/04/09 16:22:20 Cleaning up writer...
-2026/04/09 16:22:20 Finished cleaning up writer:  0x7909adb96460
-2026/04/09 16:22:20 Closed MCP-GET-SSE SSE connection: fe931b0d42b9cfccddbe7457d2c517d0
 Running client scenario 'completion-complete' against server: http://localhost:18799/mcp
-2026/04/09 16:22:20 Starting MCP-GET-SSE SSE connection: 4040052be917b7779fbd42218f2aa918
-2026/04/09 16:22:20 SSEHub: registered connection 4040052be917b7779fbd42218f2aa918 (total: 1)
-2026/04/09 16:22:20 SSEHub: unregistered connection 4040052be917b7779fbd42218f2aa918 (total: 0)
-2026/04/09 16:22:20 Received kill signal.  Quitting Writer. stop 0x7909ad918460
-2026/04/09 16:22:20 Cleaning up writer...
-2026/04/09 16:22:20 Finished cleaning up writer:  0x7909ad918460
-2026/04/09 16:22:20 Closed MCP-GET-SSE SSE connection: 4040052be917b7779fbd42218f2aa918
+2026/04/09 16:36:26 Starting MCP-GET-SSE SSE connection: 03fdeec4e474842de6be2b96a7047295
+2026/04/09 16:36:26 SSEHub: registered connection 03fdeec4e474842de6be2b96a7047295 (total: 1)
+2026/04/09 16:36:26 SSEHub: unregistered connection 03fdeec4e474842de6be2b96a7047295 (total: 0)
+2026/04/09 16:36:26 Received kill signal.  Quitting Writer. stop 0x1679e77461c0
+2026/04/09 16:36:26 Cleaning up writer...
+2026/04/09 16:36:26 Finished cleaning up writer:  0x1679e77461c0
+2026/04/09 16:36:26 Closed MCP-GET-SSE SSE connection: 03fdeec4e474842de6be2b96a7047295
 
 === Running scenario: tools-list ===
 Running client scenario 'tools-list' against server: http://localhost:18799/mcp
-2026/04/09 16:22:20 Starting MCP-GET-SSE SSE connection: 28ee9d923d97fadde3619c29f0862c7e
-2026/04/09 16:22:20 SSEHub: registered connection 28ee9d923d97fadde3619c29f0862c7e (total: 1)
+2026/04/09 16:36:26 Starting MCP-GET-SSE SSE connection: 72a55f37b6d3b37f7bc6cfc0a4a14fc6
+2026/04/09 16:36:26 SSEHub: registered connection 72a55f37b6d3b37f7bc6cfc0a4a14fc6 (total: 1)
+2026/04/09 16:36:26 SSEHub: unregistered connection 72a55f37b6d3b37f7bc6cfc0a4a14fc6 (total: 0)
+2026/04/09 16:36:26 Received kill signal.  Quitting Writer. stop 0x1679e77463f0
+2026/04/09 16:36:26 Cleaning up writer...
+2026/04/09 16:36:26 Finished cleaning up writer:  0x1679e77463f0
+2026/04/09 16:36:26 Closed MCP-GET-SSE SSE connection: 72a55f37b6d3b37f7bc6cfc0a4a14fc6
 
 === Running scenario: tools-call-simple-text ===
-2026/04/09 16:22:20 SSEHub: unregistered connection 28ee9d923d97fadde3619c29f0862c7e (total: 0)
-2026/04/09 16:22:20 Received kill signal.  Quitting Writer. stop 0x7909ad9ce5b0
-2026/04/09 16:22:20 Cleaning up writer...
-2026/04/09 16:22:20 Finished cleaning up writer:  0x7909ad9ce5b0
 Running client scenario 'tools-call-simple-text' against server: http://localhost:18799/mcp
-2026/04/09 16:22:20 Closed MCP-GET-SSE SSE connection: 28ee9d923d97fadde3619c29f0862c7e
-2026/04/09 16:22:20 Starting MCP-GET-SSE SSE connection: 4096f96b36a24f1ac53304b9eb40e473
-2026/04/09 16:22:20 SSEHub: registered connection 4096f96b36a24f1ac53304b9eb40e473 (total: 1)
-2026/04/09 16:22:20 SSEHub: unregistered connection 4096f96b36a24f1ac53304b9eb40e473 (total: 0)
-2026/04/09 16:22:20 Received kill signal.  Quitting Writer. stop 0x7909ad918850
-2026/04/09 16:22:20 Cleaning up writer...
-2026/04/09 16:22:20 Finished cleaning up writer:  0x7909ad918850
-2026/04/09 16:22:20 Closed MCP-GET-SSE SSE connection: 4096f96b36a24f1ac53304b9eb40e473
+2026/04/09 16:36:26 Starting MCP-GET-SSE SSE connection: 29c41cfe24337dff52daa19ec0c885a7
+2026/04/09 16:36:26 SSEHub: registered connection 29c41cfe24337dff52daa19ec0c885a7 (total: 1)
+2026/04/09 16:36:26 SSEHub: unregistered connection 29c41cfe24337dff52daa19ec0c885a7 (total: 0)
+2026/04/09 16:36:26 Received kill signal.  Quitting Writer. stop 0x1679e78a6380
+2026/04/09 16:36:26 Cleaning up writer...
+2026/04/09 16:36:26 Finished cleaning up writer:  0x1679e78a6380
+2026/04/09 16:36:26 Closed MCP-GET-SSE SSE connection: 29c41cfe24337dff52daa19ec0c885a7
 
 === Running scenario: tools-call-image ===
 Running client scenario 'tools-call-image' against server: http://localhost:18799/mcp
-2026/04/09 16:22:20 Starting MCP-GET-SSE SSE connection: 2e0ce97e06094097f29ea1a6f057d2c3
-2026/04/09 16:22:20 SSEHub: registered connection 2e0ce97e06094097f29ea1a6f057d2c3 (total: 1)
-2026/04/09 16:22:20 SSEHub: unregistered connection 2e0ce97e06094097f29ea1a6f057d2c3 (total: 0)
-2026/04/09 16:22:20 Received kill signal.  Quitting Writer. stop 0x7909adb96700
-2026/04/09 16:22:20 Cleaning up writer...
-2026/04/09 16:22:20 Finished cleaning up writer:  0x7909adb96700
-2026/04/09 16:22:20 Closed MCP-GET-SSE SSE connection: 2e0ce97e06094097f29ea1a6f057d2c3
+2026/04/09 16:36:26 Starting MCP-GET-SSE SSE connection: e7fd94151ee8a81d6322c8c86fd8b7e6
+2026/04/09 16:36:26 SSEHub: registered connection e7fd94151ee8a81d6322c8c86fd8b7e6 (total: 1)
+2026/04/09 16:36:26 SSEHub: unregistered connection e7fd94151ee8a81d6322c8c86fd8b7e6 (total: 0)
+2026/04/09 16:36:26 Received kill signal.  Quitting Writer. stop 0x1679e792e460
+2026/04/09 16:36:26 Cleaning up writer...
+2026/04/09 16:36:26 Finished cleaning up writer:  0x1679e792e460
+2026/04/09 16:36:26 Closed MCP-GET-SSE SSE connection: e7fd94151ee8a81d6322c8c86fd8b7e6
 
 === Running scenario: tools-call-audio ===
 Running client scenario 'tools-call-audio' against server: http://localhost:18799/mcp
-2026/04/09 16:22:20 Starting MCP-GET-SSE SSE connection: acd47a8fae99e4560bf0a4746ff33b69
-2026/04/09 16:22:20 SSEHub: registered connection acd47a8fae99e4560bf0a4746ff33b69 (total: 1)
-2026/04/09 16:22:20 SSEHub: unregistered connection acd47a8fae99e4560bf0a4746ff33b69 (total: 0)
-2026/04/09 16:22:20 Received kill signal.  Quitting Writer. stop 0x7909adb96a10
-2026/04/09 16:22:20 Cleaning up writer...
-2026/04/09 16:22:20 Finished cleaning up writer:  0x7909adb96a10
-2026/04/09 16:22:20 Closed MCP-GET-SSE SSE connection: acd47a8fae99e4560bf0a4746ff33b69
+2026/04/09 16:36:26 Starting MCP-GET-SSE SSE connection: 83e7410668ddf8e0f30f5e735ffa09bd
+2026/04/09 16:36:26 SSEHub: registered connection 83e7410668ddf8e0f30f5e735ffa09bd (total: 1)
+2026/04/09 16:36:26 SSEHub: unregistered connection 83e7410668ddf8e0f30f5e735ffa09bd (total: 0)
+2026/04/09 16:36:26 Received kill signal.  Quitting Writer. stop 0x1679e7634af0
+2026/04/09 16:36:26 Cleaning up writer...
+2026/04/09 16:36:26 Finished cleaning up writer:  0x1679e7634af0
+2026/04/09 16:36:26 Closed MCP-GET-SSE SSE connection: 83e7410668ddf8e0f30f5e735ffa09bd
 
 === Running scenario: tools-call-embedded-resource ===
 Running client scenario 'tools-call-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/09 16:22:20 Starting MCP-GET-SSE SSE connection: 2e22570068f67164a3466b605ce4bfdc
-2026/04/09 16:22:20 SSEHub: registered connection 2e22570068f67164a3466b605ce4bfdc (total: 1)
-2026/04/09 16:22:20 SSEHub: unregistered connection 2e22570068f67164a3466b605ce4bfdc (total: 0)
+2026/04/09 16:36:26 Starting MCP-GET-SSE SSE connection: 88961b0d14ac01cf5cfe93e19ab98455
+2026/04/09 16:36:26 SSEHub: registered connection 88961b0d14ac01cf5cfe93e19ab98455 (total: 1)
 
 === Running scenario: tools-call-mixed-content ===
-2026/04/09 16:22:20 Received kill signal.  Quitting Writer. stop 0x7909ada0c310
-2026/04/09 16:22:20 Cleaning up writer...
-2026/04/09 16:22:20 Finished cleaning up writer:  0x7909ada0c310
-2026/04/09 16:22:20 Closed MCP-GET-SSE SSE connection: 2e22570068f67164a3466b605ce4bfdc
+2026/04/09 16:36:26 SSEHub: unregistered connection 88961b0d14ac01cf5cfe93e19ab98455 (total: 0)
 Running client scenario 'tools-call-mixed-content' against server: http://localhost:18799/mcp
-2026/04/09 16:22:20 Starting MCP-GET-SSE SSE connection: 68ece765e9bee5e4de35a6a1f771af53
-2026/04/09 16:22:20 SSEHub: registered connection 68ece765e9bee5e4de35a6a1f771af53 (total: 1)
-2026/04/09 16:22:20 SSEHub: unregistered connection 68ece765e9bee5e4de35a6a1f771af53 (total: 0)
-2026/04/09 16:22:20 Received kill signal.  Quitting Writer. stop 0x7909adb96e00
-2026/04/09 16:22:20 Cleaning up writer...
+2026/04/09 16:36:26 Received kill signal.  Quitting Writer. stop 0x1679e77468c0
+2026/04/09 16:36:26 Cleaning up writer...
+2026/04/09 16:36:26 Finished cleaning up writer:  0x1679e77468c0
+2026/04/09 16:36:26 Closed MCP-GET-SSE SSE connection: 88961b0d14ac01cf5cfe93e19ab98455
+2026/04/09 16:36:26 Starting MCP-GET-SSE SSE connection: 74e3b91348986915f06f262e25bccf37
+2026/04/09 16:36:26 SSEHub: registered connection 74e3b91348986915f06f262e25bccf37 (total: 1)
 
 === Running scenario: tools-call-with-logging ===
-2026/04/09 16:22:20 Finished cleaning up writer:  0x7909adb96e00
+2026/04/09 16:36:26 SSEHub: unregistered connection 74e3b91348986915f06f262e25bccf37 (total: 0)
 Running client scenario 'tools-call-with-logging' against server: http://localhost:18799/mcp
-2026/04/09 16:22:20 Closed MCP-GET-SSE SSE connection: 68ece765e9bee5e4de35a6a1f771af53
-2026/04/09 16:22:20 Starting MCP-GET-SSE SSE connection: 8e7c115e766b3adeb66a940b55ce3d5f
-2026/04/09 16:22:20 SSEHub: registered connection 8e7c115e766b3adeb66a940b55ce3d5f (total: 1)
-2026/04/09 16:22:20 SSEHub: unregistered connection 8e7c115e766b3adeb66a940b55ce3d5f (total: 0)
+2026/04/09 16:36:26 Received kill signal.  Quitting Writer. stop 0x1679e7634e00
+2026/04/09 16:36:26 Cleaning up writer...
+2026/04/09 16:36:26 Finished cleaning up writer:  0x1679e7634e00
+2026/04/09 16:36:26 Closed MCP-GET-SSE SSE connection: 74e3b91348986915f06f262e25bccf37
+2026/04/09 16:36:26 Starting MCP-GET-SSE SSE connection: f265ee2e2bae6fbbf69c60f67943c5dc
+2026/04/09 16:36:26 SSEHub: registered connection f265ee2e2bae6fbbf69c60f67943c5dc (total: 1)
+2026/04/09 16:36:27 SSEHub: unregistered connection f265ee2e2bae6fbbf69c60f67943c5dc (total: 0)
 
 === Running scenario: tools-call-error ===
-2026/04/09 16:22:20 Received kill signal.  Quitting Writer. stop 0x7909ad9cea10
-2026/04/09 16:22:20 Cleaning up writer...
-2026/04/09 16:22:20 Finished cleaning up writer:  0x7909ad9cea10
-2026/04/09 16:22:20 Closed MCP-GET-SSE SSE connection: 8e7c115e766b3adeb66a940b55ce3d5f
+2026/04/09 16:36:27 Received kill signal.  Quitting Writer. stop 0x1679e7746af0
+2026/04/09 16:36:27 Cleaning up writer...
+2026/04/09 16:36:27 Finished cleaning up writer:  0x1679e7746af0
+2026/04/09 16:36:27 Closed MCP-GET-SSE SSE connection: f265ee2e2bae6fbbf69c60f67943c5dc
 Running client scenario 'tools-call-error' against server: http://localhost:18799/mcp
-2026/04/09 16:22:20 Starting MCP-GET-SSE SSE connection: 7a9e5b8cc60eb8e2248d1516f52e24bf
-2026/04/09 16:22:20 SSEHub: registered connection 7a9e5b8cc60eb8e2248d1516f52e24bf (total: 1)
-2026/04/09 16:22:20 SSEHub: unregistered connection 7a9e5b8cc60eb8e2248d1516f52e24bf (total: 0)
-2026/04/09 16:22:20 Received kill signal.  Quitting Writer. stop 0x7909ad9cec40
-2026/04/09 16:22:20 Cleaning up writer...
-2026/04/09 16:22:20 Finished cleaning up writer:  0x7909ad9cec40
-2026/04/09 16:22:20 Closed MCP-GET-SSE SSE connection: 7a9e5b8cc60eb8e2248d1516f52e24bf
+2026/04/09 16:36:27 Starting MCP-GET-SSE SSE connection: 69ec187f7cc582b35af120e16fb92c34
+2026/04/09 16:36:27 SSEHub: registered connection 69ec187f7cc582b35af120e16fb92c34 (total: 1)
+2026/04/09 16:36:27 SSEHub: unregistered connection 69ec187f7cc582b35af120e16fb92c34 (total: 0)
+2026/04/09 16:36:27 Received kill signal.  Quitting Writer. stop 0x1679e78a6690
+2026/04/09 16:36:27 Cleaning up writer...
+2026/04/09 16:36:27 Finished cleaning up writer:  0x1679e78a6690
 
 === Running scenario: tools-call-with-progress ===
+2026/04/09 16:36:27 Closed MCP-GET-SSE SSE connection: 69ec187f7cc582b35af120e16fb92c34
 Running client scenario 'tools-call-with-progress' against server: http://localhost:18799/mcp
-2026/04/09 16:22:20 Starting MCP-GET-SSE SSE connection: 12c63bebd3c7da202978ba6e631a3665
-2026/04/09 16:22:20 SSEHub: registered connection 12c63bebd3c7da202978ba6e631a3665 (total: 1)
-2026/04/09 16:22:20 SSEHub: unregistered connection 12c63bebd3c7da202978ba6e631a3665 (total: 0)
-2026/04/09 16:22:20 Received kill signal.  Quitting Writer. stop 0x7909ada0c850
-2026/04/09 16:22:20 Cleaning up writer...
-2026/04/09 16:22:20 Finished cleaning up writer:  0x7909ada0c850
-2026/04/09 16:22:20 Closed MCP-GET-SSE SSE connection: 12c63bebd3c7da202978ba6e631a3665
+2026/04/09 16:36:27 Starting MCP-GET-SSE SSE connection: 1ba3c52d46fb26c02358900cc1cdd9a4
+2026/04/09 16:36:27 SSEHub: registered connection 1ba3c52d46fb26c02358900cc1cdd9a4 (total: 1)
+2026/04/09 16:36:27 SSEHub: unregistered connection 1ba3c52d46fb26c02358900cc1cdd9a4 (total: 0)
+2026/04/09 16:36:27 Received kill signal.  Quitting Writer. stop 0x1679e7746fc0
+2026/04/09 16:36:27 Cleaning up writer...
+2026/04/09 16:36:27 Finished cleaning up writer:  0x1679e7746fc0
+2026/04/09 16:36:27 Closed MCP-GET-SSE SSE connection: 1ba3c52d46fb26c02358900cc1cdd9a4
 
 === Running scenario: tools-call-sampling ===
 Running client scenario 'tools-call-sampling' against server: http://localhost:18799/mcp
-2026/04/09 16:22:20 Starting MCP-GET-SSE SSE connection: bbbcb0d0c963ae46d864d06a737a635e
-2026/04/09 16:22:20 SSEHub: registered connection bbbcb0d0c963ae46d864d06a737a635e (total: 1)
-2026/04/09 16:22:20 SSEHub: unregistered connection bbbcb0d0c963ae46d864d06a737a635e (total: 0)
+2026/04/09 16:36:27 Starting MCP-GET-SSE SSE connection: 2c0161cad4e7f60562b38ae059ff001e
+2026/04/09 16:36:27 SSEHub: registered connection 2c0161cad4e7f60562b38ae059ff001e (total: 1)
+2026/04/09 16:36:27 SSEHub: unregistered connection 2c0161cad4e7f60562b38ae059ff001e (total: 0)
+2026/04/09 16:36:27 Received kill signal.  Quitting Writer. stop 0x1679e77472d0
+2026/04/09 16:36:27 Cleaning up writer...
 
 === Running scenario: tools-call-elicitation ===
-2026/04/09 16:22:20 Received kill signal.  Quitting Writer. stop 0x7909ad9cefc0
-2026/04/09 16:22:20 Cleaning up writer...
+2026/04/09 16:36:27 Finished cleaning up writer:  0x1679e77472d0
+2026/04/09 16:36:27 Closed MCP-GET-SSE SSE connection: 2c0161cad4e7f60562b38ae059ff001e
 Running client scenario 'tools-call-elicitation' against server: http://localhost:18799/mcp
-2026/04/09 16:22:20 Finished cleaning up writer:  0x7909ad9cefc0
-2026/04/09 16:22:20 Closed MCP-GET-SSE SSE connection: bbbcb0d0c963ae46d864d06a737a635e
-2026/04/09 16:22:20 Starting MCP-GET-SSE SSE connection: cbfb01b7a9731b20b7ed19238315adb8
-2026/04/09 16:22:20 SSEHub: registered connection cbfb01b7a9731b20b7ed19238315adb8 (total: 1)
-2026/04/09 16:22:21 SSEHub: unregistered connection cbfb01b7a9731b20b7ed19238315adb8 (total: 0)
-2026/04/09 16:22:21 Received kill signal.  Quitting Writer. stop 0x7909ad9cf1f0
-2026/04/09 16:22:21 Cleaning up writer...
-2026/04/09 16:22:21 Finished cleaning up writer:  0x7909ad9cf1f0
+2026/04/09 16:36:27 Starting MCP-GET-SSE SSE connection: 08985ac48af831015ae211be2b4708ee
+2026/04/09 16:36:27 SSEHub: registered connection 08985ac48af831015ae211be2b4708ee (total: 1)
 
 === Running scenario: elicitation-sep1034-defaults ===
-2026/04/09 16:22:21 Closed MCP-GET-SSE SSE connection: cbfb01b7a9731b20b7ed19238315adb8
+2026/04/09 16:36:27 SSEHub: unregistered connection 08985ac48af831015ae211be2b4708ee (total: 0)
+2026/04/09 16:36:27 Received kill signal.  Quitting Writer. stop 0x1679e78a6930
+2026/04/09 16:36:27 Cleaning up writer...
+2026/04/09 16:36:27 Finished cleaning up writer:  0x1679e78a6930
+2026/04/09 16:36:27 Closed MCP-GET-SSE SSE connection: 08985ac48af831015ae211be2b4708ee
 Running client scenario 'elicitation-sep1034-defaults' against server: http://localhost:18799/mcp
-2026/04/09 16:22:21 Starting MCP-GET-SSE SSE connection: 550bff8978ee96f825d128e10593f52a
-2026/04/09 16:22:21 SSEHub: registered connection 550bff8978ee96f825d128e10593f52a (total: 1)
-2026/04/09 16:22:21 SSEHub: unregistered connection 550bff8978ee96f825d128e10593f52a (total: 0)
+2026/04/09 16:36:27 Starting MCP-GET-SSE SSE connection: 3466254f156f951af787118702462453
+2026/04/09 16:36:27 SSEHub: registered connection 3466254f156f951af787118702462453 (total: 1)
+2026/04/09 16:36:27 SSEHub: unregistered connection 3466254f156f951af787118702462453 (total: 0)
 
 === Running scenario: server-sse-multiple-streams ===
-2026/04/09 16:22:21 Received kill signal.  Quitting Writer. stop 0x7909ada0cc40
-2026/04/09 16:22:21 Cleaning up writer...
-2026/04/09 16:22:21 Finished cleaning up writer:  0x7909ada0cc40
-2026/04/09 16:22:21 Closed MCP-GET-SSE SSE connection: 550bff8978ee96f825d128e10593f52a
+2026/04/09 16:36:27 Received kill signal.  Quitting Writer. stop 0x1679e78a6b60
 Running client scenario 'server-sse-multiple-streams' against server: http://localhost:18799/mcp
-2026/04/09 16:22:21 Starting MCP-GET-SSE SSE connection: beb2dde3a9f2413c21a3db2310c312d5
-2026/04/09 16:22:21 SSEHub: registered connection beb2dde3a9f2413c21a3db2310c312d5 (total: 1)
+2026/04/09 16:36:27 Cleaning up writer...
+2026/04/09 16:36:27 Finished cleaning up writer:  0x1679e78a6b60
+2026/04/09 16:36:27 Closed MCP-GET-SSE SSE connection: 3466254f156f951af787118702462453
+2026/04/09 16:36:27 Starting MCP-GET-SSE SSE connection: f6dbb066c06fb98f475dc478aebc8aa8
+2026/04/09 16:36:27 SSEHub: registered connection f6dbb066c06fb98f475dc478aebc8aa8 (total: 1)
+2026/04/09 16:36:27 SSEHub: unregistered connection f6dbb066c06fb98f475dc478aebc8aa8 (total: 0)
+2026/04/09 16:36:27 Received kill signal.  Quitting Writer. stop 0x1679e78a6d90
+2026/04/09 16:36:27 Cleaning up writer...
 
 === Running scenario: elicitation-sep1330-enums ===
+2026/04/09 16:36:27 Finished cleaning up writer:  0x1679e78a6d90
 Running client scenario 'elicitation-sep1330-enums' against server: http://localhost:18799/mcp
-2026/04/09 16:22:21 SSEHub: unregistered connection beb2dde3a9f2413c21a3db2310c312d5 (total: 0)
-2026/04/09 16:22:21 Received kill signal.  Quitting Writer. stop 0x7909ad9cf730
-2026/04/09 16:22:21 Cleaning up writer...
-2026/04/09 16:22:21 Finished cleaning up writer:  0x7909ad9cf730
-2026/04/09 16:22:21 Closed MCP-GET-SSE SSE connection: beb2dde3a9f2413c21a3db2310c312d5
-2026/04/09 16:22:21 Starting MCP-GET-SSE SSE connection: b086aec50ef3fb67e131d4f1736bea32
-2026/04/09 16:22:21 SSEHub: registered connection b086aec50ef3fb67e131d4f1736bea32 (total: 1)
-2026/04/09 16:22:21 SSEHub: unregistered connection b086aec50ef3fb67e131d4f1736bea32 (total: 0)
-2026/04/09 16:22:21 Received kill signal.  Quitting Writer. stop 0x7909ada0cf50
-2026/04/09 16:22:21 Cleaning up writer...
-2026/04/09 16:22:21 Finished cleaning up writer:  0x7909ada0cf50
-2026/04/09 16:22:21 Closed MCP-GET-SSE SSE connection: b086aec50ef3fb67e131d4f1736bea32
+2026/04/09 16:36:27 Closed MCP-GET-SSE SSE connection: f6dbb066c06fb98f475dc478aebc8aa8
+2026/04/09 16:36:27 Starting MCP-GET-SSE SSE connection: 61230e21c14a954a58c3426bb7465571
+2026/04/09 16:36:27 SSEHub: registered connection 61230e21c14a954a58c3426bb7465571 (total: 1)
+2026/04/09 16:36:27 SSEHub: unregistered connection 61230e21c14a954a58c3426bb7465571 (total: 0)
+2026/04/09 16:36:27 Received kill signal.  Quitting Writer. stop 0x1679e7747650
+2026/04/09 16:36:27 Cleaning up writer...
+2026/04/09 16:36:27 Finished cleaning up writer:  0x1679e7747650
+2026/04/09 16:36:27 Closed MCP-GET-SSE SSE connection: 61230e21c14a954a58c3426bb7465571
 
 === Running scenario: resources-list ===
 Running client scenario 'resources-list' against server: http://localhost:18799/mcp
-2026/04/09 16:22:21 Starting MCP-GET-SSE SSE connection: 02c37f7da6bc2015a5d7adeae8230d72
-2026/04/09 16:22:21 SSEHub: registered connection 02c37f7da6bc2015a5d7adeae8230d72 (total: 1)
+2026/04/09 16:36:27 Starting MCP-GET-SSE SSE connection: c927f5c133312c16d78677470ba5b272
+2026/04/09 16:36:27 SSEHub: registered connection c927f5c133312c16d78677470ba5b272 (total: 1)
+2026/04/09 16:36:27 SSEHub: unregistered connection c927f5c133312c16d78677470ba5b272 (total: 0)
+2026/04/09 16:36:27 Received kill signal.  Quitting Writer. stop 0x1679e78a7110
+2026/04/09 16:36:27 Cleaning up writer...
 
 === Running scenario: resources-read-text ===
-2026/04/09 16:22:21 SSEHub: unregistered connection 02c37f7da6bc2015a5d7adeae8230d72 (total: 0)
+2026/04/09 16:36:27 Finished cleaning up writer:  0x1679e78a7110
 Running client scenario 'resources-read-text' against server: http://localhost:18799/mcp
-2026/04/09 16:22:21 Received kill signal.  Quitting Writer. stop 0x7909ad9cf960
-2026/04/09 16:22:21 Cleaning up writer...
-2026/04/09 16:22:21 Finished cleaning up writer:  0x7909ad9cf960
-2026/04/09 16:22:21 Closed MCP-GET-SSE SSE connection: 02c37f7da6bc2015a5d7adeae8230d72
-2026/04/09 16:22:21 Starting MCP-GET-SSE SSE connection: ed1923fca3607ea25b1086ea9a5fd47f
-2026/04/09 16:22:21 SSEHub: registered connection ed1923fca3607ea25b1086ea9a5fd47f (total: 1)
+2026/04/09 16:36:27 Closed MCP-GET-SSE SSE connection: c927f5c133312c16d78677470ba5b272
+2026/04/09 16:36:27 Starting MCP-GET-SSE SSE connection: 93bd19e3e9056339fd653b94b19a3790
+2026/04/09 16:36:27 SSEHub: registered connection 93bd19e3e9056339fd653b94b19a3790 (total: 1)
+2026/04/09 16:36:27 SSEHub: unregistered connection 93bd19e3e9056339fd653b94b19a3790 (total: 0)
+2026/04/09 16:36:27 Received kill signal.  Quitting Writer. stop 0x1679e792ea10
+2026/04/09 16:36:27 Cleaning up writer...
+2026/04/09 16:36:27 Finished cleaning up writer:  0x1679e792ea10
+2026/04/09 16:36:27 Closed MCP-GET-SSE SSE connection: 93bd19e3e9056339fd653b94b19a3790
 
 === Running scenario: resources-read-binary ===
 Running client scenario 'resources-read-binary' against server: http://localhost:18799/mcp
-2026/04/09 16:22:21 SSEHub: unregistered connection ed1923fca3607ea25b1086ea9a5fd47f (total: 0)
-2026/04/09 16:22:21 Received kill signal.  Quitting Writer. stop 0x7909ada0d180
-2026/04/09 16:22:21 Cleaning up writer...
-2026/04/09 16:22:21 Finished cleaning up writer:  0x7909ada0d180
-2026/04/09 16:22:21 Closed MCP-GET-SSE SSE connection: ed1923fca3607ea25b1086ea9a5fd47f
-2026/04/09 16:22:21 Starting MCP-GET-SSE SSE connection: cb491dbd4baec248d4881b0fc2f91919
-2026/04/09 16:22:21 SSEHub: registered connection cb491dbd4baec248d4881b0fc2f91919 (total: 1)
+2026/04/09 16:36:27 Starting MCP-GET-SSE SSE connection: 8dd60ef8ed3b2d4e80be260a18c7e6b7
+2026/04/09 16:36:27 SSEHub: registered connection 8dd60ef8ed3b2d4e80be260a18c7e6b7 (total: 1)
+2026/04/09 16:36:27 SSEHub: unregistered connection 8dd60ef8ed3b2d4e80be260a18c7e6b7 (total: 0)
+2026/04/09 16:36:27 Received kill signal.  Quitting Writer. stop 0x1679e792ec40
+2026/04/09 16:36:27 Cleaning up writer...
+2026/04/09 16:36:27 Finished cleaning up writer:  0x1679e792ec40
+2026/04/09 16:36:27 Closed MCP-GET-SSE SSE connection: 8dd60ef8ed3b2d4e80be260a18c7e6b7
 
 === Running scenario: resources-templates-read ===
 Running client scenario 'resources-templates-read' against server: http://localhost:18799/mcp
-2026/04/09 16:22:21 SSEHub: unregistered connection cb491dbd4baec248d4881b0fc2f91919 (total: 0)
-2026/04/09 16:22:21 Received kill signal.  Quitting Writer. stop 0x7909ad9cfc00
-2026/04/09 16:22:21 Cleaning up writer...
-2026/04/09 16:22:21 Finished cleaning up writer:  0x7909ad9cfc00
-2026/04/09 16:22:21 Closed MCP-GET-SSE SSE connection: cb491dbd4baec248d4881b0fc2f91919
-2026/04/09 16:22:21 Starting MCP-GET-SSE SSE connection: b3ee049994c5be71b0e693afa15d31ca
-2026/04/09 16:22:21 SSEHub: registered connection b3ee049994c5be71b0e693afa15d31ca (total: 1)
-2026/04/09 16:22:21 SSEHub: unregistered connection b3ee049994c5be71b0e693afa15d31ca (total: 0)
-2026/04/09 16:22:21 Received kill signal.  Quitting Writer. stop 0x7909ad9cfe30
-2026/04/09 16:22:21 Cleaning up writer...
+2026/04/09 16:36:27 Starting MCP-GET-SSE SSE connection: a6bd1beccd8c262f1c3313f38e354664
+2026/04/09 16:36:27 SSEHub: registered connection a6bd1beccd8c262f1c3313f38e354664 (total: 1)
+2026/04/09 16:36:27 SSEHub: unregistered connection a6bd1beccd8c262f1c3313f38e354664 (total: 0)
+2026/04/09 16:36:27 Received kill signal.  Quitting Writer. stop 0x1679e792ee70
+2026/04/09 16:36:27 Cleaning up writer...
 
 === Running scenario: resources-subscribe ===
-2026/04/09 16:22:21 Finished cleaning up writer:  0x7909ad9cfe30
-2026/04/09 16:22:21 Closed MCP-GET-SSE SSE connection: b3ee049994c5be71b0e693afa15d31ca
+2026/04/09 16:36:27 Finished cleaning up writer:  0x1679e792ee70
+2026/04/09 16:36:27 Closed MCP-GET-SSE SSE connection: a6bd1beccd8c262f1c3313f38e354664
 Running client scenario 'resources-subscribe' against server: http://localhost:18799/mcp
-2026/04/09 16:22:21 Starting MCP-GET-SSE SSE connection: 2d06d1dc0273aed4a0588de93123e4b8
-2026/04/09 16:22:21 SSEHub: registered connection 2d06d1dc0273aed4a0588de93123e4b8 (total: 1)
-2026/04/09 16:22:21 SSEHub: unregistered connection 2d06d1dc0273aed4a0588de93123e4b8 (total: 0)
-2026/04/09 16:22:21 Received kill signal.  Quitting Writer. stop 0x7909adc38150
-2026/04/09 16:22:21 Cleaning up writer...
-2026/04/09 16:22:21 Finished cleaning up writer:  0x7909adc38150
+2026/04/09 16:36:27 Starting MCP-GET-SSE SSE connection: 211ea8b99bd0f7aaaf759c64ae92574a
+2026/04/09 16:36:27 SSEHub: registered connection 211ea8b99bd0f7aaaf759c64ae92574a (total: 1)
+2026/04/09 16:36:27 SSEHub: unregistered connection 211ea8b99bd0f7aaaf759c64ae92574a (total: 0)
 
 === Running scenario: resources-unsubscribe ===
-2026/04/09 16:22:21 Closed MCP-GET-SSE SSE connection: 2d06d1dc0273aed4a0588de93123e4b8
+2026/04/09 16:36:27 Received kill signal.  Quitting Writer. stop 0x1679e78a7490
+2026/04/09 16:36:27 Cleaning up writer...
 Running client scenario 'resources-unsubscribe' against server: http://localhost:18799/mcp
-2026/04/09 16:22:21 Starting MCP-GET-SSE SSE connection: 84ea51b27bd5712e9596cd67633fbab0
-2026/04/09 16:22:21 SSEHub: registered connection 84ea51b27bd5712e9596cd67633fbab0 (total: 1)
-2026/04/09 16:22:21 SSEHub: unregistered connection 84ea51b27bd5712e9596cd67633fbab0 (total: 0)
-2026/04/09 16:22:21 Received kill signal.  Quitting Writer. stop 0x7909adc38380
-2026/04/09 16:22:21 Cleaning up writer...
-2026/04/09 16:22:21 Finished cleaning up writer:  0x7909adc38380
-2026/04/09 16:22:21 Closed MCP-GET-SSE SSE connection: 84ea51b27bd5712e9596cd67633fbab0
+2026/04/09 16:36:27 Finished cleaning up writer:  0x1679e78a7490
+2026/04/09 16:36:27 Closed MCP-GET-SSE SSE connection: 211ea8b99bd0f7aaaf759c64ae92574a
+2026/04/09 16:36:27 Starting MCP-GET-SSE SSE connection: ca3566997ffa9d0b05ddbb94016ec2b3
+2026/04/09 16:36:27 SSEHub: registered connection ca3566997ffa9d0b05ddbb94016ec2b3 (total: 1)
+2026/04/09 16:36:27 SSEHub: unregistered connection ca3566997ffa9d0b05ddbb94016ec2b3 (total: 0)
 
 === Running scenario: prompts-list ===
+2026/04/09 16:36:27 Received kill signal.  Quitting Writer. stop 0x1679e78a7730
+2026/04/09 16:36:27 Cleaning up writer...
+2026/04/09 16:36:27 Finished cleaning up writer:  0x1679e78a7730
 Running client scenario 'prompts-list' against server: http://localhost:18799/mcp
-2026/04/09 16:22:21 Starting MCP-GET-SSE SSE connection: ecd2ff0d1cc7fb4fe064968c407b7dfa
-2026/04/09 16:22:21 SSEHub: registered connection ecd2ff0d1cc7fb4fe064968c407b7dfa (total: 1)
-2026/04/09 16:22:21 SSEHub: unregistered connection ecd2ff0d1cc7fb4fe064968c407b7dfa (total: 0)
+2026/04/09 16:36:27 Closed MCP-GET-SSE SSE connection: ca3566997ffa9d0b05ddbb94016ec2b3
+2026/04/09 16:36:27 Starting MCP-GET-SSE SSE connection: c5dd0f5e2876b1fd5c4210549c1f462f
+2026/04/09 16:36:27 SSEHub: registered connection c5dd0f5e2876b1fd5c4210549c1f462f (total: 1)
 
 === Running scenario: prompts-get-simple ===
-2026/04/09 16:22:21 Received kill signal.  Quitting Writer. stop 0x7909adb97650
-2026/04/09 16:22:21 Cleaning up writer...
-2026/04/09 16:22:21 Finished cleaning up writer:  0x7909adb97650
+2026/04/09 16:36:27 SSEHub: unregistered connection c5dd0f5e2876b1fd5c4210549c1f462f (total: 0)
+2026/04/09 16:36:27 Received kill signal.  Quitting Writer. stop 0x1679e76356c0
+2026/04/09 16:36:27 Cleaning up writer...
 Running client scenario 'prompts-get-simple' against server: http://localhost:18799/mcp
-2026/04/09 16:22:21 Closed MCP-GET-SSE SSE connection: ecd2ff0d1cc7fb4fe064968c407b7dfa
-2026/04/09 16:22:21 Starting MCP-GET-SSE SSE connection: eee6681ec7d290853239e5077fce1a73
-2026/04/09 16:22:21 SSEHub: registered connection eee6681ec7d290853239e5077fce1a73 (total: 1)
-2026/04/09 16:22:21 SSEHub: unregistered connection eee6681ec7d290853239e5077fce1a73 (total: 0)
-2026/04/09 16:22:21 Received kill signal.  Quitting Writer. stop 0x7909adb978f0
-2026/04/09 16:22:21 Cleaning up writer...
-2026/04/09 16:22:21 Finished cleaning up writer:  0x7909adb978f0
-2026/04/09 16:22:21 Closed MCP-GET-SSE SSE connection: eee6681ec7d290853239e5077fce1a73
+2026/04/09 16:36:27 Finished cleaning up writer:  0x1679e76356c0
+2026/04/09 16:36:27 Closed MCP-GET-SSE SSE connection: c5dd0f5e2876b1fd5c4210549c1f462f
+2026/04/09 16:36:27 Starting MCP-GET-SSE SSE connection: b7c0c75151177c59f361a570c1ece27c
+2026/04/09 16:36:27 SSEHub: registered connection b7c0c75151177c59f361a570c1ece27c (total: 1)
+2026/04/09 16:36:27 SSEHub: unregistered connection b7c0c75151177c59f361a570c1ece27c (total: 0)
+2026/04/09 16:36:27 Received kill signal.  Quitting Writer. stop 0x1679e792f180
+2026/04/09 16:36:27 Cleaning up writer...
+2026/04/09 16:36:27 Finished cleaning up writer:  0x1679e792f180
+2026/04/09 16:36:27 Closed MCP-GET-SSE SSE connection: b7c0c75151177c59f361a570c1ece27c
 
 === Running scenario: prompts-get-with-args ===
 Running client scenario 'prompts-get-with-args' against server: http://localhost:18799/mcp
-2026/04/09 16:22:21 Starting MCP-GET-SSE SSE connection: dd8b8af152bc976a2c8dcfcb69503753
-2026/04/09 16:22:21 SSEHub: registered connection dd8b8af152bc976a2c8dcfcb69503753 (total: 1)
-2026/04/09 16:22:21 SSEHub: unregistered connection dd8b8af152bc976a2c8dcfcb69503753 (total: 0)
-2026/04/09 16:22:21 Received kill signal.  Quitting Writer. stop 0x7909adc38690
-2026/04/09 16:22:21 Cleaning up writer...
-2026/04/09 16:22:21 Finished cleaning up writer:  0x7909adc38690
-2026/04/09 16:22:21 Closed MCP-GET-SSE SSE connection: dd8b8af152bc976a2c8dcfcb69503753
+2026/04/09 16:36:27 Starting MCP-GET-SSE SSE connection: 47d9998da67faed967c6b65121c2c334
+2026/04/09 16:36:27 SSEHub: registered connection 47d9998da67faed967c6b65121c2c334 (total: 1)
+2026/04/09 16:36:27 SSEHub: unregistered connection 47d9998da67faed967c6b65121c2c334 (total: 0)
+2026/04/09 16:36:27 Received kill signal.  Quitting Writer. stop 0x1679e792f3b0
+2026/04/09 16:36:27 Cleaning up writer...
+2026/04/09 16:36:27 Finished cleaning up writer:  0x1679e792f3b0
+2026/04/09 16:36:27 Closed MCP-GET-SSE SSE connection: 47d9998da67faed967c6b65121c2c334
 
 === Running scenario: prompts-get-embedded-resource ===
 Running client scenario 'prompts-get-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/09 16:22:21 Starting MCP-GET-SSE SSE connection: dd1090659ec05bc3e0419841d3d6e8f1
-2026/04/09 16:22:21 SSEHub: registered connection dd1090659ec05bc3e0419841d3d6e8f1 (total: 1)
-2026/04/09 16:22:21 SSEHub: unregistered connection dd1090659ec05bc3e0419841d3d6e8f1 (total: 0)
-2026/04/09 16:22:21 Received kill signal.  Quitting Writer. stop 0x7909adb97c00
-2026/04/09 16:22:21 Cleaning up writer...
-2026/04/09 16:22:21 Finished cleaning up writer:  0x7909adb97c00
-2026/04/09 16:22:21 Closed MCP-GET-SSE SSE connection: dd1090659ec05bc3e0419841d3d6e8f1
+2026/04/09 16:36:27 Starting MCP-GET-SSE SSE connection: 150da9a1af631db9f3669707f7a4d444
+2026/04/09 16:36:27 SSEHub: registered connection 150da9a1af631db9f3669707f7a4d444 (total: 1)
+2026/04/09 16:36:27 SSEHub: unregistered connection 150da9a1af631db9f3669707f7a4d444 (total: 0)
+2026/04/09 16:36:27 Received kill signal.  Quitting Writer. stop 0x1679e7635960
+2026/04/09 16:36:27 Cleaning up writer...
+2026/04/09 16:36:27 Finished cleaning up writer:  0x1679e7635960
+2026/04/09 16:36:27 Closed MCP-GET-SSE SSE connection: 150da9a1af631db9f3669707f7a4d444
 
 === Running scenario: prompts-get-with-image ===
 Running client scenario 'prompts-get-with-image' against server: http://localhost:18799/mcp
-2026/04/09 16:22:21 Starting MCP-GET-SSE SSE connection: 4055d0f348ba23b75a6e92b0452ad9a5
-2026/04/09 16:22:21 SSEHub: registered connection 4055d0f348ba23b75a6e92b0452ad9a5 (total: 1)
-2026/04/09 16:22:21 SSEHub: unregistered connection 4055d0f348ba23b75a6e92b0452ad9a5 (total: 0)
-2026/04/09 16:22:21 Received kill signal.  Quitting Writer. stop 0x7909adb97f10
-2026/04/09 16:22:21 Cleaning up writer...
-2026/04/09 16:22:21 Finished cleaning up writer:  0x7909adb97f10
+2026/04/09 16:36:27 Starting MCP-GET-SSE SSE connection: c1c3545da535e1632593956cdd701a31
+2026/04/09 16:36:27 SSEHub: registered connection c1c3545da535e1632593956cdd701a31 (total: 1)
+2026/04/09 16:36:27 SSEHub: unregistered connection c1c3545da535e1632593956cdd701a31 (total: 0)
+2026/04/09 16:36:27 Received kill signal.  Quitting Writer. stop 0x1679e7635c00
+2026/04/09 16:36:27 Cleaning up writer...
+2026/04/09 16:36:27 Finished cleaning up writer:  0x1679e7635c00
+2026/04/09 16:36:27 Closed MCP-GET-SSE SSE connection: c1c3545da535e1632593956cdd701a31
 
 === Running scenario: dns-rebinding-protection ===
-2026/04/09 16:22:21 Closed MCP-GET-SSE SSE connection: 4055d0f348ba23b75a6e92b0452ad9a5
 Running client scenario 'dns-rebinding-protection' against server: http://localhost:18799/mcp
 
 
@@ -392,22 +390,22 @@ Starting scenario: auth/token-endpoint-auth-basic
 Starting scenario: auth/token-endpoint-auth-post
 Starting scenario: auth/token-endpoint-auth-none
 Starting scenario: auth/pre-registration
-Executing client: ./bin/testclient http://localhost:51050/mcp
-Executing client: ./bin/testclient http://localhost:51051/mcp
-Executing client: ./bin/testclient http://localhost:51052/mcp
-Executing client: ./bin/testclient http://localhost:51053/mcp
-Executing client: ./bin/testclient http://localhost:51054/mcp
-Executing client: ./bin/testclient http://localhost:51055/mcp
-Executing client: ./bin/testclient http://localhost:51056/mcp
-Executing client: ./bin/testclient http://localhost:51057/mcp
-Executing client: ./bin/testclient http://localhost:51058/mcp
-Executing client: ./bin/testclient http://localhost:51059/mcp
-Executing client: ./bin/testclient http://localhost:51060/mcp
-Executing client: ./bin/testclient http://localhost:51061/mcp
-Executing client: ./bin/testclient http://localhost:51062/mcp
-Executing client: ./bin/testclient http://localhost:51063/mcp
+Executing client: ./bin/testclient http://localhost:59009/mcp
+Executing client: ./bin/testclient http://localhost:59010/mcp
+Executing client: ./bin/testclient http://localhost:59011/mcp
+Executing client: ./bin/testclient http://localhost:59012/mcp
+Executing client: ./bin/testclient http://localhost:59013/mcp
+Executing client: ./bin/testclient http://localhost:59014/mcp
+Executing client: ./bin/testclient http://localhost:59015/mcp
+Executing client: ./bin/testclient http://localhost:59016/mcp
+Executing client: ./bin/testclient http://localhost:59017/mcp
+Executing client: ./bin/testclient http://localhost:59018/mcp
+Executing client: ./bin/testclient http://localhost:59019/mcp
+Executing client: ./bin/testclient http://localhost:59020/mcp
+Executing client: ./bin/testclient http://localhost:59021/mcp
+Executing client: ./bin/testclient http://localhost:59022/mcp
 With context: {"client_id":"pre-registered-client","client_secret":"pre-registered-secret"}
-(node:52974) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
+(node:59968) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
 (Use `node --trace-deprecation ...` to show where the warning was created)
 
 === SUITE SUMMARY ===
@@ -438,7 +436,7 @@ Total: 210 passed, 0 failed, 1 warnings
   PASS: auth-conformance
 --- [8/8] keycloak ---
 === RUN   TestKeycloak_MCPServer_ValidToken
---- PASS: TestKeycloak_MCPServer_ValidToken (0.18s)
+--- PASS: TestKeycloak_MCPServer_ValidToken (0.03s)
 === RUN   TestKeycloak_MCPServer_TamperedToken
 --- PASS: TestKeycloak_MCPServer_TamperedToken (0.02s)
 === RUN   TestKeycloak_MCPServer_ScopeAllowed
@@ -450,10 +448,10 @@ Total: 210 passed, 0 failed, 1 warnings
 === RUN   TestKeycloak_MCPServer_WWWAuthenticate
 --- PASS: TestKeycloak_MCPServer_WWWAuthenticate (0.01s)
 === RUN   TestKeycloak_MCPServer_PasswordGrant
---- PASS: TestKeycloak_MCPServer_PasswordGrant (0.09s)
+--- PASS: TestKeycloak_MCPServer_PasswordGrant (0.04s)
 PASS
-ok  	github.com/panyam/mcpkit/tests/keycloak	0.850s
+ok  	github.com/panyam/mcpkit/tests/keycloak	0.613s
   PASS: keycloak
 
 === Results: 8 passed, 0 failed ===
-Finished: Thu Apr  9 16:22:24 PDT 2026
+Finished: Thu Apr  9 16:36:30 PDT 2026


### PR DESCRIPTION
## Summary

- **CommandTransport (#70)**: Spawn and manage subprocess MCP servers. Wraps `StdioTransport` for wire protocol, adds process lifecycle management (start on `Connect()`, SIGTERM/SIGKILL on `Close()`), stderr capture, env passthrough. `WithCommandTransport` client option supports auto-restart on reconnection.
- **WithModifyRequest (#135)**: Client-side HTTP request hook for injecting custom headers (tracing IDs, tenant headers, API keys) without a custom `RoundTripper`. Callback runs inside `buildReq` before `DoWithAuthRetry` applies auth — cannot accidentally clobber `Authorization`. Works on Streamable HTTP + SSE, survives reconnection.

## Files changed

| File | Change |
|------|--------|
| `client/command_transport.go` | New: `CommandTransport`, `NewCommandTransport`, `WithEnv`, `WithDir`, `WithShutdownTimeout`, `WithStderr` |
| `client/command_transport_test.go` | New: 8 tests (echo, shutdown, stderr, crash, env, client option, stderr tee, timeout) |
| `client/client_modify_request_test.go` | New: 4 tests (custom header, SSE, nil no-op, multiple headers) |
| `client/client.go` | `WithModifyRequest`, `WithCommandTransport`, `modifyReq` field on both HTTP transports, hook in all 8 `buildReq` closures |
| `client/client_reconnect.go` | Wire `modifyReq` + command transport branch in `reconnect()` |
| `CLAUDE.md` | Package structure + gotchas for both features |
| `README.md` | Client features section with usage examples |
| `CAPABILITIES.md` | Two new capability entries |

## Test plan

- [x] 8 CommandTransport tests pass (echo tool, graceful shutdown, stderr capture, process crash, env passthrough, client option, stderr tee, shutdown timeout)
- [x] 4 ModifyRequest tests pass (custom header on Streamable HTTP, SSE transport, nil no-op, multiple headers)
- [x] Full `go test ./...` passes (no regressions in 200+ existing tests)
- [x] Race detector clean (`go test -race ./client/`)

Closes #70, closes #135