### PR TITLE
Fetch roots/list after list_changed notification (#26)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,8 +157,15 @@ mcpkit/
 - **`defaultPageSize = 0`** — returns all by default (backward compatible).
 
 ### Roots Lifecycle (#26)
-- **`notifications/roots/list_changed`** handled — marks stale, calls `WithOnRootsChanged(fn)` callback.
-- **`core.Root`** type. Server-to-client `roots/list` fetch deferred.
+- **`notifications/roots/list_changed`** handled — the server issues a server-to-client `roots/list` request, stores the response on the per-session dispatcher, and invokes `WithOnRootsChanged(fn)` **with the populated list**. The callback fires *after* the fetch completes (not at notification time), so it always sees real data; if the fetch fails, the callback does not fire and the error is logged.
+- **Capability gate**: only clients that declared `capabilities.roots.listChanged` during `initialize` receive the `roots/list` request. Clients without the capability silently skip the fetch.
+- **Persistent `pushRequest` required**: the fetch uses `Dispatcher.pushRequest` to issue the outbound request. Stdio, in-process, and the SSE/Streamable-HTTP GET SSE stream all wire this persistently on the session dispatcher via `Dispatcher.SetPushRequest`. Streamable HTTP sessions without an open GET SSE stream (or between stream reconnects) have `pushRequest == nil`; in that state a `list_changed` notification marks `rootsStale = true` without fetching, and the next notification after a stream opens will drive the fetch.
+- **`Dispatcher.Roots() []core.Root`** returns a defensive copy of the most recently fetched roots (nil until the first successful fetch). Safe to call concurrently.
+- **Fetch timeout** is a hardcoded 30s. Follow-up for `WithRootsFetchTimeout(d)` option.
+- **De-duplication**: a burst of `list_changed` notifications coalesces to at most one in-flight fetch + one coalesced re-fetch via `rootsFetching`/`rootsStale` under `rootsMu`. The in-flight goroutine's defer block re-dispatches if another notification landed mid-flight.
+- **Concurrency rule**: `rootsMu` must never be held across the outbound RPC or the user callback. Enforced by keeping all `rootsMu` uses inside `server/roots.go`.
+- **`core.Root`** / `core.RootsListResult` types live in `core/protocol.go`.
+- **Not yet integrated**: dynamic `WithAllowedRoots` update from client-provided roots. Deferred to its own issue — crosses a design boundary (client-provided roots as server-enforced sandbox).
 
 ### Concurrent Request Handling (#86)
 - **Duplicate request IDs rejected** via `LoadOrStore` on inflight map.

--- a/client/client.go
+++ b/client/client.go
@@ -66,6 +66,10 @@ type SamplingHandler func(context.Context, core.CreateMessageRequest) (core.Crea
 // The client prompts the user for input and returns the result.
 type ElicitationHandler func(context.Context, core.ElicitationRequest) (core.ElicitationResult, error)
 
+// RootsHandler handles a server-to-client roots/list request.
+// The client returns its current filesystem roots.
+type RootsHandler func(context.Context) ([]core.Root, error)
+
 // WithSamplingHandler registers a handler for server-to-client sampling requests.
 // When set, the client advertises the "sampling" capability during initialization.
 func WithSamplingHandler(h SamplingHandler) ClientOption {
@@ -76,6 +80,14 @@ func WithSamplingHandler(h SamplingHandler) ClientOption {
 // When set, the client advertises the "elicitation" capability during initialization.
 func WithElicitationHandler(h ElicitationHandler) ClientOption {
 	return func(c *Client) { c.elicitationHandler = h }
+}
+
+// WithRootsHandler registers a handler for server-to-client roots/list requests.
+// When set, the client advertises the "roots" capability (with listChanged: true)
+// during initialization, enabling the server to fetch the client's filesystem roots
+// after receiving a notifications/roots/list_changed notification.
+func WithRootsHandler(h RootsHandler) ClientOption {
+	return func(c *Client) { c.rootsHandler = h }
 }
 
 // WithNotificationCallback sets a callback for server-to-client notifications
@@ -275,6 +287,7 @@ type Client struct {
 	// Server-to-client request handlers
 	samplingHandler    SamplingHandler
 	elicitationHandler ElicitationHandler
+	rootsHandler       RootsHandler
 
 	// Reconnection settings (zero values = disabled)
 	maxRetries int
@@ -460,6 +473,9 @@ func (c *Client) doConnect() error {
 	}
 	if c.elicitationHandler != nil {
 		caps.Elicitation = &struct{}{}
+	}
+	if c.rootsHandler != nil {
+		caps.Roots = &core.RootsCap{ListChanged: true}
 	}
 	if len(c.extensions) > 0 {
 		caps.Extensions = make(map[string]core.ClientExtensionCap, len(c.extensions))
@@ -648,9 +664,26 @@ func (c *Client) HandleServerRequest(req *core.Request) *core.Response {
 		}
 		return core.NewResponse(req.ID, result)
 
+	case "roots/list":
+		if c.rootsHandler == nil {
+			return core.NewErrorResponse(req.ID, core.ErrCodeMethodNotFound, "roots not supported")
+		}
+		roots, err := c.rootsHandler(context.Background())
+		if err != nil {
+			return core.NewErrorResponse(req.ID, core.ErrCodeInternal, err.Error())
+		}
+		return core.NewResponse(req.ID, core.RootsListResult{Roots: roots})
+
 	default:
 		return core.NewErrorResponse(req.ID, core.ErrCodeMethodNotFound, "unknown server request: "+req.Method)
 	}
+}
+
+// NotifyRootsChanged sends a notifications/roots/list_changed notification
+// to the server. Call this after the client's filesystem roots have changed
+// so the server can re-fetch the current list via a roots/list request.
+func (c *Client) NotifyRootsChanged() error {
+	return c.notifyMethod("notifications/roots/list_changed", nil)
 }
 
 // SessionID returns the current session ID.

--- a/server/dispatch.go
+++ b/server/dispatch.go
@@ -50,8 +50,8 @@ type Dispatcher struct {
 
 	// notifyFunc is set by the transport to push server-to-client notifications.
 	// nil means no push capability (e.g., Streamable HTTP without GET SSE stream).
-	// Protected by notifyMu because the GET SSE handler may set it concurrently
-	// with subscription notifications reading it.
+	// pushRequest (below) is guarded by the same RWMutex because the two are
+	// always wired and torn down together by every transport.
 	notifyFunc core.NotifyFunc
 	notifyMu   sync.RWMutex
 
@@ -60,17 +60,20 @@ type Dispatcher struct {
 	sessionID            string                  // set by transport, used as key in subscription registry
 	subManager           *subscriptionRegistry   // shared pointer to Server's registry (nil if disabled)
 
-	// Roots state — tracked per session.
-	// rootsStale is set when the client sends notifications/roots/list_changed.
-	// On the next tool call with a requestFunc, the server fetches roots/list.
-	rootsStale    bool
-	roots         []core.Root
+	// Roots state — tracked per session. See refreshRoots for the full state
+	// machine. rootsMu guards roots, rootsStale, and rootsFetching; it must
+	// NOT be held across user-callback invocations or network round trips.
+	rootsMu        sync.Mutex
+	roots          []core.Root
+	rootsStale     bool
+	rootsFetching  bool
 	onRootsChanged func([]core.Root) // optional callback, set via WithOnRootsChanged
 
 	// Server-to-client request infrastructure.
-	// pushRequest pushes a raw JSON-RPC request to the client stream (set by transport).
+	// pushRequest pushes a raw JSON-RPC request to the client stream (set by
+	// transport, guarded by notifyMu — same lifecycle as notifyFunc).
 	// pending tracks in-flight server-to-client requests awaiting responses.
-	// nextServerReqID generates unique IDs for outgoing requests ("srv-1", "srv-2", ...).
+	// requestIDs generates unique IDs for outgoing requests ("srv-1", ...).
 	pushRequest func(json.RawMessage)
 	pending     pendingMap
 	requestIDs  gohttp.IDGen // generates unique IDs for server-to-client requests
@@ -101,6 +104,27 @@ func (d *Dispatcher) SetNotifyFunc(fn core.NotifyFunc) {
 func (d *Dispatcher) getNotifyFunc() core.NotifyFunc {
 	d.notifyMu.RLock()
 	fn := d.notifyFunc
+	d.notifyMu.RUnlock()
+	return fn
+}
+
+// SetPushRequest installs the transport's push function for server-initiated
+// JSON-RPC requests (e.g. roots/list, sampling/createMessage). Called once per
+// persistent stream by stdio, in-process, and the SSE/Streamable-HTTP GET SSE
+// handlers; not called by the per-POST request path (which wires its own
+// request-scoped closure). Thread-safe.
+func (d *Dispatcher) SetPushRequest(fn func(json.RawMessage)) {
+	d.notifyMu.Lock()
+	d.pushRequest = fn
+	d.notifyMu.Unlock()
+}
+
+// getPushRequest returns the currently installed push function, or nil if
+// the transport does not support server-initiated requests outside of POST
+// response cycles. Thread-safe.
+func (d *Dispatcher) getPushRequest() func(json.RawMessage) {
+	d.notifyMu.RLock()
+	fn := d.pushRequest
 	d.notifyMu.RUnlock()
 	return fn
 }
@@ -240,10 +264,7 @@ func (d *Dispatcher) Dispatch(ctx context.Context, req *core.Request) *core.Resp
 		return nil
 
 	case "notifications/roots/list_changed":
-		d.rootsStale = true
-		if d.onRootsChanged != nil {
-			d.onRootsChanged(d.roots)
-		}
+		d.handleRootsListChanged()
 		return nil
 
 	case "ping":

--- a/server/memory_transport.go
+++ b/server/memory_transport.go
@@ -93,11 +93,11 @@ func (t *InProcessTransport) Connect(ctx context.Context) error {
 		}
 	})
 
-	// Wire pushRequest for server-to-client requests (sampling, elicitation).
-	// The server pushes a JSON-RPC request; we dispatch to the handler and
-	// route the response back to the dispatcher's pending map.
+	// Wire pushRequest for server-to-client requests (sampling, elicitation,
+	// roots/list). The server pushes a JSON-RPC request; we dispatch to the
+	// handler and route the response back to the dispatcher's pending map.
 	if t.reqHandler != nil {
-		t.dispatcher.pushRequest = func(raw json.RawMessage) {
+		t.dispatcher.SetPushRequest(func(raw json.RawMessage) {
 			var req core.Request
 			if err := json.Unmarshal(raw, &req); err != nil {
 				return
@@ -106,7 +106,7 @@ func (t *InProcessTransport) Connect(ctx context.Context) error {
 			if resp != nil {
 				t.dispatcher.RouteResponse(resp)
 			}
-		}
+		})
 	}
 	return nil
 }
@@ -116,8 +116,8 @@ func (t *InProcessTransport) Connect(ctx context.Context) error {
 func (t *InProcessTransport) Call(ctx context.Context, req *core.Request) (*core.Response, error) {
 	// Build request func from dispatcher's push + pending infrastructure
 	var requestFunc core.RequestFunc
-	if t.dispatcher.pushRequest != nil {
-		requestFunc = t.dispatcher.makeRequestFunc(t.dispatcher.pushRequest)
+	if push := t.dispatcher.getPushRequest(); push != nil {
+		requestFunc = t.dispatcher.makeRequestFunc(push)
 	}
 
 	resp := t.server.dispatchWithNotifyAndRequest(

--- a/server/roots.go
+++ b/server/roots.go
@@ -115,8 +115,10 @@ func (d *Dispatcher) refreshRoots(push func(json.RawMessage)) {
 
 	// Defensive copy: decouple the slice we expose to d.roots / callbacks
 	// from the decoded response's backing array so later mutations on
-	// either side don't leak.
-	stored := append([]core.Root(nil), result.Roots...)
+	// either side don't leak. make()+copy ensures the result is non-nil
+	// even when the client returned an empty roots list (append(nil) is nil).
+	stored := make([]core.Root, len(result.Roots))
+	copy(stored, result.Roots)
 
 	d.rootsMu.Lock()
 	d.roots = stored
@@ -129,7 +131,9 @@ func (d *Dispatcher) refreshRoots(push func(json.RawMessage)) {
 	if d.onRootsChanged != nil {
 		// Pass a fresh copy so a misbehaving callback cannot corrupt the
 		// stored slice via append/mutation.
-		d.onRootsChanged(append([]core.Root(nil), stored...))
+		cbCopy := make([]core.Root, len(stored))
+		copy(cbCopy, stored)
+		d.onRootsChanged(cbCopy)
 	}
 }
 

--- a/server/roots.go
+++ b/server/roots.go
@@ -1,0 +1,147 @@
+package server
+
+// Roots-list fetch implementation (#26).
+//
+// When the client sends notifications/roots/list_changed, the server issues
+// a server-to-client roots/list request, stores the result in d.roots, and
+// invokes the WithOnRootsChanged callback with the populated list. The fetch
+// runs on a dedicated goroutine so notifications never block the POST that
+// delivered them — blocking would deadlock HTTP transports where the client
+// may serialize its own POSTs.
+//
+// Concurrency model:
+//
+//   rootsMu guards roots, rootsStale, and rootsFetching. It is never held
+//   across the outbound RPC or the user callback. A concurrent burst of
+//   list_changed notifications collapses to at most one in-flight fetch +
+//   one coalesced re-fetch via rootsStale. See refreshRoots.
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"time"
+
+	core "github.com/panyam/mcpkit/core"
+)
+
+// rootsFetchTimeout bounds the duration of a single server-to-client
+// roots/list request. Hardcoded for now; if we need tunability we'll
+// promote it to a WithRootsFetchTimeout server option.
+const rootsFetchTimeout = 30 * time.Second
+
+// handleRootsListChanged is the entry point for the
+// notifications/roots/list_changed notification. It gates on the client's
+// declared capability, grabs the transport's persistent pushRequest, and
+// spawns refreshRoots on a goroutine so the notification-delivery POST
+// returns immediately.
+func (d *Dispatcher) handleRootsListChanged() {
+	// Capability gate: only clients that declared roots.listChanged support
+	// the roots/list method. Silently skip for clients that didn't opt in.
+	if d.clientCaps.Roots == nil || !d.clientCaps.Roots.ListChanged {
+		return
+	}
+
+	push := d.getPushRequest()
+	if push == nil {
+		// Transport has no persistent server-initiated request capability
+		// (e.g., Streamable HTTP before the GET SSE stream has been opened).
+		// Mark stale so if a push function is wired later, a future
+		// invocation can observe the staleness. Future work: auto-fetch on
+		// the first tool call once a push function is available.
+		d.rootsMu.Lock()
+		d.rootsStale = true
+		d.rootsMu.Unlock()
+		return
+	}
+
+	// Dedup: if a fetch is already in flight, just mark stale and return —
+	// the in-flight goroutine's defer block will re-dispatch a follow-up
+	// fetch when it sees the stale flag.
+	d.rootsMu.Lock()
+	if d.rootsFetching {
+		d.rootsStale = true
+		d.rootsMu.Unlock()
+		return
+	}
+	d.rootsFetching = true
+	d.rootsStale = false
+	d.rootsMu.Unlock()
+
+	go d.refreshRoots(push)
+}
+
+// refreshRoots issues a single server-to-client roots/list request, stores
+// the result, invokes the onRootsChanged callback, and — if another
+// list_changed notification arrived during the fetch — re-dispatches
+// itself. Runs on its own goroutine.
+func (d *Dispatcher) refreshRoots(push func(json.RawMessage)) {
+	defer func() {
+		// Post-fetch: drop the fetching flag and, if a concurrent notification
+		// invalidated the result mid-flight, spawn a follow-up fetch to
+		// converge on the latest state. The follow-up runs as a fresh
+		// goroutine (not a loop) so the dedup guard sequencing is obvious:
+		// rootsFetching is false before the next fetch starts, so a racing
+		// handleRootsListChanged either wins the CAS (dispatches the
+		// follow-up itself) or observes rootsFetching and marks stale again.
+		d.rootsMu.Lock()
+		d.rootsFetching = false
+		restale := d.rootsStale
+		d.rootsMu.Unlock()
+		if restale {
+			// Re-enter handleRootsListChanged so capability + push-function
+			// gates are re-checked (both can change mid-session).
+			d.handleRootsListChanged()
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), rootsFetchTimeout)
+	defer cancel()
+
+	reqFunc := d.makeRequestFunc(push)
+	raw, err := reqFunc(ctx, "roots/list", nil)
+	if err != nil {
+		// Don't invoke the callback with a garbage/empty list — callers
+		// cannot distinguish "no roots" from "fetch failed" if we do.
+		log.Printf("mcpkit: roots/list fetch failed: %v", err)
+		return
+	}
+
+	var result core.RootsListResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		log.Printf("mcpkit: roots/list response decode failed: %v", err)
+		return
+	}
+
+	// Defensive copy: decouple the slice we expose to d.roots / callbacks
+	// from the decoded response's backing array so later mutations on
+	// either side don't leak.
+	stored := append([]core.Root(nil), result.Roots...)
+
+	d.rootsMu.Lock()
+	d.roots = stored
+	d.rootsMu.Unlock()
+
+	// Invoke the callback OUTSIDE the lock — callbacks may acquire locks
+	// of their own or issue long-running work and must never run under
+	// rootsMu (rule enforced by the closeness of this file alone; no code
+	// path outside refreshRoots mutates d.roots today).
+	if d.onRootsChanged != nil {
+		// Pass a fresh copy so a misbehaving callback cannot corrupt the
+		// stored slice via append/mutation.
+		d.onRootsChanged(append([]core.Root(nil), stored...))
+	}
+}
+
+// Roots returns a snapshot of the client's most recently reported roots.
+// The returned slice is safe to retain and mutate — it is a fresh copy.
+// Returns nil if no roots/list fetch has completed yet (the typical state
+// until the client first sends notifications/roots/list_changed).
+func (d *Dispatcher) Roots() []core.Root {
+	d.rootsMu.Lock()
+	defer d.rootsMu.Unlock()
+	if d.roots == nil {
+		return nil
+	}
+	return append([]core.Root(nil), d.roots...)
+}

--- a/server/roots_integration_test.go
+++ b/server/roots_integration_test.go
@@ -1,0 +1,209 @@
+package server_test
+
+import (
+	"context"
+	"io"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/panyam/mcpkit/client"
+	"github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRootsRoundTrip exercises the full notifications/roots/list_changed →
+// server-initiated roots/list → populated callback path through all 4
+// transports (Streamable HTTP, SSE, in-process, stdio). This specifically
+// stresses the persistent pushRequest wiring added by #26 for SSE and
+// Streamable HTTP GET SSE streams — the unit tests use only the in-process
+// transport and cannot reach those code paths.
+func TestRootsRoundTrip(t *testing.T) {
+	expected := []core.Root{
+		{URI: "file:///workspace/app", Name: "app"},
+		{URI: "file:///workspace/lib"},
+	}
+
+	forAllRootsTransports(t, expected, func(t *testing.T, c *client.Client, callbackCh chan []core.Root) {
+		err := c.NotifyRootsChanged()
+		require.NoError(t, err, "NotifyRootsChanged should succeed")
+
+		select {
+		case roots := <-callbackCh:
+			assert.Equal(t, expected, roots,
+				"callback must receive the exact roots returned by the client's handler")
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for OnRootsChanged callback")
+		}
+	})
+}
+
+// TestRootsRoundTripEmpty verifies that a client returning an empty roots
+// list still triggers the callback with an empty (non-nil) slice.
+func TestRootsRoundTripEmpty(t *testing.T) {
+	forAllRootsTransports(t, []core.Root{}, func(t *testing.T, c *client.Client, callbackCh chan []core.Root) {
+		err := c.NotifyRootsChanged()
+		require.NoError(t, err)
+
+		select {
+		case roots := <-callbackCh:
+			require.NotNil(t, roots, "callback should receive non-nil empty slice")
+			assert.Empty(t, roots, "roots should be empty")
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for OnRootsChanged callback")
+		}
+	})
+}
+
+// TestRootsNoHandlerNoCap verifies that a client without WithRootsHandler
+// does NOT declare roots.listChanged, so the server's capability gate
+// prevents the fetch from firing. End-to-end negative test complementing
+// the unit-level TestRootsNotFetchedWithoutCapability.
+func TestRootsNoHandlerNoCap(t *testing.T) {
+	callbackCh := make(chan []core.Root, 1)
+	srv := newRootsTestServer(callbackCh)
+	handler := srv.Handler(server.WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	// Client WITHOUT WithRootsHandler — no roots capability advertised.
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "test-no-roots", Version: "1.0"},
+		client.WithGetSSEStream())
+	require.NoError(t, c.Connect())
+	t.Cleanup(func() { c.Close() })
+
+	// Give the GET SSE stream a moment to connect.
+	time.Sleep(100 * time.Millisecond)
+
+	// The client can still send the notification (protocol doesn't forbid it),
+	// but the server must not issue a roots/list request because the client
+	// did not declare the capability.
+	_ = c.NotifyRootsChanged()
+
+	select {
+	case roots := <-callbackCh:
+		t.Fatalf("callback should NOT have fired, but got roots: %v", roots)
+	case <-time.After(300 * time.Millisecond):
+		// Expected: no callback.
+	}
+}
+
+// --- Test helpers ---
+
+// newRootsTestServer creates a server with a WithOnRootsChanged callback that
+// sends the received roots to the provided channel. A no-op tool is registered
+// so the initialize handshake succeeds.
+func newRootsTestServer(callbackCh chan []core.Root) *server.Server {
+	srv := server.NewServer(
+		core.ServerInfo{Name: "roots-integration-test", Version: "1.0.0"},
+		server.WithOnRootsChanged(func(roots []core.Root) {
+			callbackCh <- roots
+		}),
+	)
+	srv.RegisterTool(
+		core.ToolDef{Name: "noop", Description: "noop", InputSchema: map[string]any{"type": "object"}},
+		func(ctx context.Context, req core.ToolRequest) (core.ToolResult, error) {
+			return core.TextResult("ok"), nil
+		},
+	)
+	return srv
+}
+
+// forAllRootsTransports runs fn against all 4 transports (Streamable HTTP,
+// SSE, in-process, stdio). Each subtest creates a fresh server + client with
+// WithRootsHandler returning the given expectedRoots. A buffered callbackCh
+// is passed to fn so it can wait for the WithOnRootsChanged callback.
+//
+// The Streamable HTTP and SSE subtests enable WithGetSSEStream so the server's
+// persistent pushRequest is wired through the GET SSE connection — the primary
+// code path this integration test stresses.
+func forAllRootsTransports(t *testing.T, expectedRoots []core.Root, fn func(t *testing.T, c *client.Client, callbackCh chan []core.Root)) {
+	t.Helper()
+
+	rootsHandler := client.RootsHandler(func(ctx context.Context) ([]core.Root, error) {
+		return expectedRoots, nil
+	})
+
+	t.Run("streamable", func(t *testing.T) {
+		callbackCh := make(chan []core.Root, 1)
+		srv := newRootsTestServer(callbackCh)
+		handler := srv.Handler(server.WithStreamableHTTP(true))
+		ts := httptest.NewServer(handler)
+		t.Cleanup(ts.Close)
+
+		c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "test-client", Version: "1.0"},
+			client.WithRootsHandler(rootsHandler),
+			client.WithGetSSEStream())
+		require.NoError(t, c.Connect())
+		t.Cleanup(func() { c.Close() })
+		// Give the GET SSE stream a moment to establish so pushRequest is wired.
+		time.Sleep(100 * time.Millisecond)
+		fn(t, c, callbackCh)
+	})
+
+	t.Run("sse", func(t *testing.T) {
+		callbackCh := make(chan []core.Root, 1)
+		srv := newRootsTestServer(callbackCh)
+		handler := srv.Handler(server.WithSSE(true), server.WithStreamableHTTP(false))
+		ts := httptest.NewServer(handler)
+
+		c := client.NewClient(ts.URL+"/mcp/sse", core.ClientInfo{Name: "test-client", Version: "1.0"},
+			client.WithSSEClient(),
+			client.WithRootsHandler(rootsHandler))
+		require.NoError(t, c.Connect())
+		t.Cleanup(func() {
+			c.Close()
+			ts.Close()
+		})
+		fn(t, c, callbackCh)
+	})
+
+	t.Run("memory", func(t *testing.T) {
+		callbackCh := make(chan []core.Root, 1)
+		srv := newRootsTestServer(callbackCh)
+
+		c := client.NewClient("memory://", core.ClientInfo{Name: "test-client", Version: "1.0"},
+			client.WithRootsHandler(rootsHandler))
+		transport := server.NewInProcessTransport(srv,
+			server.WithServerRequestHandler(func(ctx context.Context, req *core.Request) *core.Response {
+				return c.HandleServerRequest(req)
+			}),
+		)
+		c.SetTransport(transport)
+		require.NoError(t, c.Connect())
+		t.Cleanup(func() { c.Close() })
+		fn(t, c, callbackCh)
+	})
+
+	t.Run("stdio", func(t *testing.T) {
+		callbackCh := make(chan []core.Root, 1)
+		srv := newRootsTestServer(callbackCh)
+
+		sr, cw := io.Pipe()
+		cr, sw := io.Pipe()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			srv.RunStdio(ctx, server.WithStdioInput(sr), server.WithStdioOutput(sw))
+			sw.Close()
+		}()
+
+		c := client.NewClient("stdio://", core.ClientInfo{Name: "test-client", Version: "1.0"},
+			client.WithStdioTransport(cr, cw),
+			client.WithRootsHandler(rootsHandler))
+		require.NoError(t, c.Connect())
+
+		t.Cleanup(func() {
+			c.Close()
+			cancel()
+			wg.Wait()
+		})
+		fn(t, c, callbackCh)
+	})
+}

--- a/server/roots_test.go
+++ b/server/roots_test.go
@@ -3,18 +3,23 @@ package server_test
 import (
 	"context"
 	"encoding/json"
+	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/panyam/mcpkit/core"
 	"github.com/panyam/mcpkit/server"
 	"github.com/panyam/mcpkit/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestRootsNotificationHandled verifies that the server handles
 // notifications/roots/list_changed without error. This notification
 // is sent by clients when their available filesystem roots change.
+// Uses Server.Dispatch directly (no transport, no fetch) — the fetch
+// path is covered by TestRootsListFetchedAfterListChanged and friends.
 func TestRootsNotificationHandled(t *testing.T) {
 	srv := testutil.NewTestServer()
 	testutil.InitHandshake(srv)
@@ -27,38 +32,10 @@ func TestRootsNotificationHandled(t *testing.T) {
 	assert.Nil(t, resp, "notification should not return a response")
 }
 
-// TestRootsCallbackFired verifies that WithOnRootsChanged callback is
-// invoked when the client sends notifications/roots/list_changed.
-func TestRootsCallbackFired(t *testing.T) {
-	var callbackFired atomic.Bool
-
-	srv := server.NewServer(
-		core.ServerInfo{Name: "test", Version: "1.0"},
-		server.WithOnRootsChanged(func(roots []core.Root) {
-			callbackFired.Store(true)
-		}),
-	)
-
-	// Register a tool so InitHandshake works
-	srv.RegisterTool(
-		core.ToolDef{Name: "noop", Description: "noop", InputSchema: map[string]any{"type": "object"}},
-		func(ctx context.Context, req core.ToolRequest) (core.ToolResult, error) {
-			return core.TextResult("ok"), nil
-		},
-	)
-	testutil.InitHandshake(srv)
-
-	srv.Dispatch(context.Background(), &core.Request{
-		JSONRPC: "2.0",
-		Method:  "notifications/roots/list_changed",
-	})
-
-	assert.True(t, callbackFired.Load(), "OnRootsChanged callback should have fired")
-}
-
-// TestRootsNotificationBeforeInit verifies that roots notification sent
-// before initialization is handled gracefully (goes to the pre-init
-// notification path which currently marks rootsStale).
+// TestRootsNotificationBeforeInit verifies that a roots notification sent
+// before initialization is handled gracefully: the capability gate in
+// handleRootsListChanged observes nil ClientCapabilities and returns early
+// without panicking, mutating state, or issuing a fetch.
 func TestRootsNotificationBeforeInit(t *testing.T) {
 	srv := testutil.NewTestServer()
 
@@ -82,4 +59,277 @@ func TestRootType(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, string(data), `"uri":"file:///home/user/project"`)
 	assert.Contains(t, string(data), `"name":"My Project"`)
+}
+
+// --- Roots-fetch test harness ---
+
+// rootsHarness wires an InProcessTransport to a server so the notification
+// handler can issue a real roots/list request back to the harness. The harness
+// records each invocation of the server's WithOnRootsChanged callback plus
+// each outbound roots/list request for assertion.
+//
+// Design choice: tests exercise the real dispatch + transport + pending-map
+// path rather than stubbing the dispatcher, because the whole point of #26
+// is the *plumbing* between notification reception and server-initiated
+// request dispatch. Stubbing would route around the bug.
+type rootsHarness struct {
+	t        *testing.T
+	srv      *server.Server
+	xport    *server.InProcessTransport
+	calls    []rootsCallbackInvocation
+	mu       sync.Mutex
+	reqCount atomic.Int32
+
+	// rootsResponder is invoked on every incoming roots/list server request.
+	// Tests set this to control the response (static list, error, etc.).
+	rootsResponder func(req *core.Request) *core.Response
+}
+
+type rootsCallbackInvocation struct {
+	roots []core.Root
+	at    time.Time
+}
+
+// newRootsHarness constructs a server + in-process transport wired for
+// roots-list fetch testing. clientRootsCap controls whether the simulated
+// client declares `capabilities.roots.listChanged` in the initialize
+// handshake — TestRootsNotFetchedWithoutCapability sets this false.
+func newRootsHarness(t *testing.T, clientRootsCap bool) *rootsHarness {
+	t.Helper()
+	h := &rootsHarness{t: t}
+
+	h.srv = server.NewServer(
+		core.ServerInfo{Name: "roots-test", Version: "1.0.0"},
+		server.WithOnRootsChanged(func(roots []core.Root) {
+			// Defensive-copy so tests observing the captured slice aren't
+			// fooled by later mutations from the harness or dispatcher.
+			copied := append([]core.Root(nil), roots...)
+			h.mu.Lock()
+			h.calls = append(h.calls, rootsCallbackInvocation{roots: copied, at: time.Now()})
+			h.mu.Unlock()
+		}),
+	)
+	// A no-op tool so InitHandshake-style initialize requests succeed.
+	h.srv.RegisterTool(
+		core.ToolDef{Name: "noop", Description: "noop", InputSchema: map[string]any{"type": "object"}},
+		func(ctx context.Context, req core.ToolRequest) (core.ToolResult, error) {
+			return core.TextResult("ok"), nil
+		},
+	)
+
+	h.xport = server.NewInProcessTransport(h.srv,
+		server.WithServerRequestHandler(func(ctx context.Context, req *core.Request) *core.Response {
+			if req.Method == "roots/list" {
+				h.reqCount.Add(1)
+				if h.rootsResponder != nil {
+					return h.rootsResponder(req)
+				}
+				return core.NewResponse(req.ID, core.RootsListResult{Roots: nil})
+			}
+			return core.NewErrorResponse(req.ID, core.ErrCodeMethodNotFound, "unsupported: "+req.Method)
+		}),
+	)
+	require.NoError(t, h.xport.Connect(context.Background()))
+
+	// Build the initialize params, optionally declaring roots.listChanged.
+	caps := map[string]any{}
+	if clientRootsCap {
+		caps["roots"] = map[string]any{"listChanged": true}
+	}
+	paramsRaw, err := json.Marshal(map[string]any{
+		"protocolVersion": "2024-11-05",
+		"capabilities":    caps,
+		"clientInfo":      map[string]any{"name": "roots-test-client", "version": "1.0"},
+	})
+	require.NoError(t, err)
+
+	// Run the initialize + notifications/initialized handshake through the
+	// transport so the session dispatcher (not the top-level one) gets the
+	// client capabilities.
+	initResp, err := h.xport.Call(context.Background(), &core.Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`0`),
+		Method:  "initialize",
+		Params:  paramsRaw,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, initResp)
+	require.Nil(t, initResp.Error)
+
+	_, err = h.xport.Call(context.Background(), &core.Request{
+		JSONRPC: "2.0",
+		Method:  "notifications/initialized",
+	})
+	require.NoError(t, err)
+
+	return h
+}
+
+// fireListChanged sends a single notifications/roots/list_changed via the
+// transport. Notifications return no response; any reply is dropped.
+func (h *rootsHarness) fireListChanged() {
+	h.t.Helper()
+	_, err := h.xport.Call(context.Background(), &core.Request{
+		JSONRPC: "2.0",
+		Method:  "notifications/roots/list_changed",
+	})
+	require.NoError(h.t, err)
+}
+
+// waitForCallbacks polls until the callback has fired at least want times or
+// the deadline elapses. Returns the number of observed callbacks.
+func (h *rootsHarness) waitForCallbacks(want int, within time.Duration) int {
+	h.t.Helper()
+	deadline := time.Now().Add(within)
+	for {
+		h.mu.Lock()
+		n := len(h.calls)
+		h.mu.Unlock()
+		if n >= want {
+			return n
+		}
+		if time.Now().After(deadline) {
+			return n
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// callbackInvocations returns a snapshot of all observed callback invocations.
+func (h *rootsHarness) callbackInvocations() []rootsCallbackInvocation {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return append([]rootsCallbackInvocation(nil), h.calls...)
+}
+
+// --- Roots fetch tests ---
+
+// TestRootsListFetchedAfterListChanged verifies the full roots refresh cycle:
+// the server receives notifications/roots/list_changed, issues a
+// server-to-client roots/list request, stores the populated list, and invokes
+// the WithOnRootsChanged callback with the populated list (not nil).
+//
+// Red-state before #26: callback fires immediately with d.roots (always nil),
+// no roots/list request is ever issued, reqCount stays 0.
+func TestRootsListFetchedAfterListChanged(t *testing.T) {
+	h := newRootsHarness(t, true)
+	expected := []core.Root{
+		{URI: "file:///home/alice/proj", Name: "alice-proj"},
+		{URI: "file:///home/alice/docs"},
+	}
+	h.rootsResponder = func(req *core.Request) *core.Response {
+		return core.NewResponse(req.ID, core.RootsListResult{Roots: expected})
+	}
+
+	h.fireListChanged()
+
+	got := h.waitForCallbacks(1, 2*time.Second)
+	require.Equal(t, 1, got, "callback should fire exactly once after fetch completes")
+
+	invs := h.callbackInvocations()
+	require.Len(t, invs, 1)
+	assert.Equal(t, expected, invs[0].roots,
+		"callback must receive the fetched roots list, not nil")
+
+	assert.Equal(t, int32(1), h.reqCount.Load(),
+		"server should issue exactly one roots/list request")
+}
+
+// TestRootsNotFetchedWithoutCapability verifies the capability gate:
+// clients that do NOT declare capabilities.roots.listChanged do not receive
+// a roots/list request, and the callback does not fire. Per MCP spec, only
+// clients that support the capability can respond to roots/list.
+func TestRootsNotFetchedWithoutCapability(t *testing.T) {
+	h := newRootsHarness(t, false)
+	h.rootsResponder = func(req *core.Request) *core.Response {
+		t.Errorf("roots/list should NOT be sent to a client without roots.listChanged")
+		return core.NewResponse(req.ID, core.RootsListResult{})
+	}
+
+	h.fireListChanged()
+
+	// Give any (erroneous) async fetch time to fire.
+	time.Sleep(150 * time.Millisecond)
+
+	assert.Equal(t, int32(0), h.reqCount.Load(),
+		"no roots/list request should be issued when client lacks capability")
+	assert.Empty(t, h.callbackInvocations(),
+		"callback must not fire when no fetch occurred")
+}
+
+// TestRootsCallbackReceivesPopulatedList is a regression guard for the
+// pre-#26 latent bug where d.roots was never assigned and the callback was
+// always invoked with nil. Asserts the callback argument is non-nil and
+// matches the fetched list exactly.
+func TestRootsCallbackReceivesPopulatedList(t *testing.T) {
+	h := newRootsHarness(t, true)
+	want := []core.Root{{URI: "file:///tmp/x", Name: "x"}}
+	h.rootsResponder = func(req *core.Request) *core.Response {
+		return core.NewResponse(req.ID, core.RootsListResult{Roots: want})
+	}
+
+	h.fireListChanged()
+	require.Equal(t, 1, h.waitForCallbacks(1, 2*time.Second))
+
+	invs := h.callbackInvocations()
+	require.Len(t, invs, 1)
+	require.NotNil(t, invs[0].roots, "callback must receive non-nil roots")
+	assert.Equal(t, want, invs[0].roots)
+}
+
+// TestRootsFetchErrorDoesNotCrash verifies error-path resilience: when the
+// client responds to roots/list with a JSON-RPC error, the server logs and
+// does NOT invoke the callback with garbage data. The process must not
+// crash or leak goroutines (verified by the test not hanging).
+func TestRootsFetchErrorDoesNotCrash(t *testing.T) {
+	h := newRootsHarness(t, true)
+	h.rootsResponder = func(req *core.Request) *core.Response {
+		return core.NewErrorResponse(req.ID, core.ErrCodeInternal, "simulated client failure")
+	}
+
+	h.fireListChanged()
+	time.Sleep(200 * time.Millisecond)
+
+	assert.Equal(t, int32(1), h.reqCount.Load(),
+		"server should issue the roots/list request even though it errors")
+	assert.Empty(t, h.callbackInvocations(),
+		"callback must not fire on fetch error")
+}
+
+// TestRootsFetchDedup verifies that a burst of list_changed notifications
+// does NOT spawn N concurrent roots/list requests. The dedup guard bounds
+// concurrent fetches to 1 per session; late notifications during an
+// in-flight fetch trigger at most one coalesced re-fetch.
+//
+// Why <=2 and not exactly 1: the refresh goroutine may already be mid-fetch
+// when the 2nd notification arrives, which legitimately triggers a second
+// fetch to pick up the newly-invalidated state. Anything beyond 2 means the
+// dedup guard failed.
+func TestRootsFetchDedup(t *testing.T) {
+	h := newRootsHarness(t, true)
+
+	// Slow responder: simulate a client that takes ~100ms to list its roots.
+	// Without dedup, all N concurrent notifications would each fire their own
+	// request and wait the full 100ms in parallel.
+	h.rootsResponder = func(req *core.Request) *core.Response {
+		time.Sleep(100 * time.Millisecond)
+		return core.NewResponse(req.ID, core.RootsListResult{
+			Roots: []core.Root{{URI: "file:///dedup", Name: "dedup"}},
+		})
+	}
+
+	// Fire 5 notifications back-to-back. The first spawns the fetch; the next
+	// 4 should fold into at most one coalesced re-fetch.
+	for i := 0; i < 5; i++ {
+		h.fireListChanged()
+	}
+
+	// Allow time for all in-flight fetches plus the optional coalesced re-fetch.
+	time.Sleep(500 * time.Millisecond)
+
+	got := h.reqCount.Load()
+	assert.LessOrEqual(t, got, int32(2),
+		"dedup guard should bound concurrent fetches to ≤2, got %d", got)
+	assert.GreaterOrEqual(t, got, int32(1),
+		"at least one fetch must be issued")
 }

--- a/server/stdio_transport.go
+++ b/server/stdio_transport.go
@@ -105,7 +105,7 @@ func (s *Server) RunStdio(ctx context.Context, opts ...StdioOption) error {
 	}
 
 	// Wire notifyFunc for server-to-client notifications (logging, progress, etc.).
-	dispatcher.notifyFunc = func(method string, params any) {
+	dispatcher.SetNotifyFunc(func(method string, params any) {
 		raw, err := core.MarshalNotification(method, params)
 		if err != nil {
 			if cfg.logger != nil {
@@ -118,19 +118,21 @@ func (s *Server) RunStdio(ctx context.Context, opts ...StdioOption) error {
 				cfg.logger.Printf("stdio: write notification: %v", err)
 			}
 		}
-	}
+	})
 
-	// Wire pushRequest for server-to-client requests (sampling, elicitation).
-	dispatcher.pushRequest = func(raw json.RawMessage) {
+	// Wire pushRequest for server-to-client requests (sampling, elicitation,
+	// roots/list). Persistent for the lifetime of the stdio session.
+	stdioPush := func(raw json.RawMessage) {
 		if err := writeFrameLocked(raw); err != nil {
 			if cfg.logger != nil {
 				cfg.logger.Printf("stdio: write server request: %v", err)
 			}
 		}
 	}
+	dispatcher.SetPushRequest(stdioPush)
 
 	// Build request func for server-to-client request/response matching.
-	requestFunc := dispatcher.makeRequestFunc(dispatcher.pushRequest)
+	requestFunc := dispatcher.makeRequestFunc(stdioPush)
 
 	reader := bufio.NewReader(cfg.input)
 
@@ -196,7 +198,7 @@ func (s *Server) RunStdio(ctx context.Context, opts ...StdioOption) error {
 			// Dispatch through the standard server pipeline.
 			resp := s.dispatchWithNotifyAndRequest(
 				dispatcher, ctx, nil,
-				dispatcher.notifyFunc, requestFunc, &req,
+				dispatcher.getNotifyFunc(), requestFunc, &req,
 			)
 
 			// Notifications produce no response.

--- a/server/streamable_transport.go
+++ b/server/streamable_transport.go
@@ -482,6 +482,16 @@ func (c *streamableSSEConn) OnStart(w http.ResponseWriter, r *http.Request) erro
 		})
 	})
 
+	// Persistent push function for server-initiated JSON-RPC requests
+	// (roots/list, keepalive, etc.). Writes via emitSSEEvent so event IDs and
+	// the optional event store stay consistent with notifyFunc's output.
+	pushFunc := func(raw json.RawMessage) {
+		emitSSEEvent(c.dispatcher.eventIDs, store, sessionID, raw, func(id string, data json.RawMessage) {
+			hub.SendEventWithID(sessionID, "message", id, SSEJSON(data))
+		})
+	}
+	c.dispatcher.SetPushRequest(pushFunc)
+
 	// Replay missed events if client reconnected with Last-Event-ID
 	if lastID := r.Header.Get("Last-Event-ID"); lastID != "" && store != nil {
 		events, _ := store.Replay(sessionID, lastID)
@@ -490,13 +500,9 @@ func (c *streamableSSEConn) OnStart(w http.ResponseWriter, r *http.Request) erro
 		}
 	}
 
-	// Start keepalive pings if configured. Uses the GET SSE stream's hub
-	// connection as the push function for server-to-client requests.
+	// Start keepalive pings if configured. Reuses the persistent pushFunc.
 	cfg := c.transport.config
 	if cfg.keepaliveInterval > 0 && c.entry != nil {
-		pushFunc := func(raw json.RawMessage) {
-			hub.SendEventWithID(sessionID, "message", c.dispatcher.eventIDs.Next(), SSEJSON(raw))
-		}
 		maxFails := cfg.keepaliveMaxFails
 		if maxFails <= 0 {
 			maxFails = 3
@@ -518,6 +524,9 @@ func (c *streamableSSEConn) OnClose() {
 	if c.keepalive != nil {
 		c.keepalive.stop()
 	}
+	// Clear the persistent push function: the underlying hub connection is
+	// about to go away. A later GET SSE stream will re-wire via OnStart.
+	c.dispatcher.SetPushRequest(nil)
 	c.transport.sseHub.Unregister(c.ConnId())
 	if c.entry != nil {
 		c.entry.idleTimer.Release()

--- a/server/transport.go
+++ b/server/transport.go
@@ -332,13 +332,18 @@ func (c *mcpSSEConn) OnStart(w http.ResponseWriter, r *http.Request) error {
 		})
 	})
 
+	// Persistent push function for server-initiated JSON-RPC requests
+	// (roots/list, keepalive ping, any future out-of-band request). Re-wired
+	// on reconnect so the closure points to the current hub connection.
+	pushFunc := func(raw json.RawMessage) {
+		emitSSEEvent(dispatcher.eventIDs, cfg.eventStore, sessionID, raw, func(id string, data json.RawMessage) {
+			hub.SendEventWithID(sessionID, "message", id, SSEJSON(data))
+		})
+	}
+	dispatcher.SetPushRequest(pushFunc)
+
 	// Start keepalive pings if configured.
 	if cfg.keepaliveInterval > 0 {
-		pushFunc := func(raw json.RawMessage) {
-			emitSSEEvent(dispatcher.eventIDs, cfg.eventStore, sessionID, raw, func(id string, data json.RawMessage) {
-				hub.SendEventWithID(sessionID, "message", id, SSEJSON(data))
-			})
-		}
 		maxFails := cfg.keepaliveMaxFails
 		if maxFails <= 0 {
 			maxFails = 3
@@ -376,7 +381,13 @@ func (c *mcpSSEConn) OnClose() {
 		c.keepalive.stop()
 	}
 
+	// Clear the persistent push function: the hub connection is going away.
+	// If the session survives a grace-period reconnect, OnStart re-wires it.
 	entry, ok := c.transport.sessions.Load(c.sessionID)
+	if ok && entry.dispatcher != nil {
+		entry.dispatcher.SetPushRequest(nil)
+	}
+
 	if !ok {
 		c.transport.hub.Unregister(c.ConnId())
 		c.BaseSSEConn.OnClose()


### PR DESCRIPTION
## Summary

Closes #26. When a client sends `notifications/roots/list_changed`, the server now actually fetches the new roots from the client (was a latent no-op before — the `WithOnRootsChanged` callback was invoked with the always-nil `d.roots`).

### Server-side (#26 core)

- **`server/roots.go`** (new): `handleRootsListChanged` + `refreshRoots` goroutine with 30s timeout, mutex-guarded dedup (`rootsFetching`/`rootsStale`), and defer-based coalesced re-fetch for concurrent notifications. `Dispatcher.Roots()` accessor returns a defensive copy.
- **`Dispatcher.SetPushRequest` / `getPushRequest`** under the existing `notifyMu`. All four transports now persistently install a `pushRequest` closure so the notification handler can issue out-of-band server→client requests outside POST cycles — previously only stdio/in-process wired this; SSE + Streamable-HTTP built it per-POST only.
- **Capability gate** — clients without `roots.listChanged` silently skip the fetch, per MCP spec.

### Client-side (testability + DX)

- **`client.WithRootsHandler(fn)`** — symmetric to `WithSamplingHandler` / `WithElicitationHandler`. When set, client declares `roots.listChanged` capability and routes incoming `roots/list` in `HandleServerRequest`.
- **`client.NotifyRootsChanged()`** — sends `notifications/roots/list_changed`.

### Design choices

- **Async fetch in a goroutine** (not synchronous in notification handler) — sync fetch would deadlock Streamable-HTTP clients that serialize their own POSTs.
- **`sync.Mutex` over atomics** for the state machine — composability, consistency with existing `notifyMu`, no contention at expected load.
- **Persistent `pushRequest` on GET SSE / Streamable-HTTP streams** — the only option that lets notifications issue fetches without blocking their delivery POST.
- **Callback fires after fetch, not on notification** — changes the callback contract from "fires with stale data immediately" to "fires with fresh data after RPC completes." Documented in CLAUDE.md.

### Tests

**Unit tests** (`server/roots_test.go`, red-before-green — all verified to fail on `main` before implementation):

- `TestRootsListFetchedAfterListChanged` — full refresh cycle + exact roots equality
- `TestRootsNotFetchedWithoutCapability` — capability gate
- `TestRootsCallbackReceivesPopulatedList` — regression guard for the always-nil bug
- `TestRootsFetchErrorDoesNotCrash` — error-path resilience
- `TestRootsFetchDedup` — concurrent notification coalesce (≤2 fetches from burst of 5)

**Integration tests** (`server/roots_integration_test.go`, ForAllTransports):

- `TestRootsRoundTrip` — full notification→fetch→callback across all 4 transports (Streamable HTTP, SSE, in-process, stdio). Stresses the persistent pushRequest wiring on SSE/Streamable-HTTP GET SSE end-to-end.
- `TestRootsRoundTripEmpty` — empty roots list still invokes callback with non-nil slice.
- `TestRootsNoHandlerNoCap` — client without handler → no capability → no fetch (end-to-end negative test).

**Assertion counts:** 33 added, 1 removed (replaced by 3 stronger checks).

### Test results

- `go test ./... -race` green (root module, all 4 transport subtests)
- `make test-auth` / `make test-ui` green (sub-modules)
- `make testconf` — 40/40 conformance tests passing
- `go vet ./...` clean

### Not in scope (follow-ups filed)

- #197 — dynamic `WithAllowedRoots` integration (sandbox enforcement)
- #198 — `WithRootsFetchTimeout(d)` server option
- #199 — transport wiring helper refactor

## Test plan

- [x] Unit tests pass under `-race` (red-before-green verified)
- [x] Integration tests pass across all 4 transports under `-race`
- [x] Sub-module tests pass (`ext/auth`, `ext/ui`)
- [x] MCP conformance suite passes (40/40)
- [x] `go vet` clean