### PR TITLE
refactor(server): extract shared SSE transport wiring (#199)

### DIFF
--- a/server/session_wiring.go
+++ b/server/session_wiring.go
@@ -1,0 +1,93 @@
+package server
+
+import (
+	"encoding/json"
+
+	core "github.com/panyam/mcpkit/core"
+	gohttp "github.com/panyam/servicekit/http"
+)
+
+// sseWiring bundles the closures that SSE-based transports (SSE and
+// Streamable HTTP GET SSE) install on a session dispatcher during
+// OnStart. Both transports share the same pipeline:
+//
+//	notification → core.MarshalNotification → emitSSEEvent → hub.SendEventWithID
+//
+// and the same keepalive construction pattern. Extracting the shared
+// wiring into this struct eliminates ~30 lines of near-identical code
+// between mcpSSEConn.OnStart and streamableSSEConn.OnStart.
+//
+// Stdio and in-process transports have different I/O shapes (frame-based
+// stdout, synchronous function calls) and are NOT wired through this
+// helper — forcing them into the same abstraction would be worse than
+// the duplication.
+//
+// Issue #199.
+type sseWiring struct {
+	dispatcher *Dispatcher
+	hub        *gohttp.SSEHub[SSEData]
+	sessionID  string
+	store      gohttp.EventStore // nil when event persistence is not configured
+	cfg        transportConfig   // for keepaliveInterval, keepaliveMaxFails
+	onDeath    func()            // called when keepalive max failures reached (closeSession or expireSession)
+	onPingFail func(int)         // called on each keepalive ping failure
+}
+
+// wire installs notifyFunc and pushRequest on the dispatcher, and
+// optionally constructs a sessionKeepalive (nil if keepalive is not
+// configured, i.e. cfg.keepaliveInterval == 0). Returns the pushFunc
+// closure for callers that need it after wiring (e.g., for SSE event
+// replay on reconnect).
+//
+// Idempotent: calling wire() on the same dispatcher overwrites the
+// previous notifyFunc and pushRequest. This is the expected behavior
+// on SSE reconnect (grace period), where the closures must be refreshed
+// to point at the new hub connection.
+func (w *sseWiring) wire() (pushFunc func(json.RawMessage), keepalive *sessionKeepalive) {
+	sessionID := w.sessionID
+	hub := w.hub
+	store := w.store
+	eventIDs := w.dispatcher.eventIDs
+
+	// hubSend is the leaf writer: sends a single SSE event to the hub
+	// connection identified by sessionID.
+	hubSend := func(id string, data json.RawMessage) {
+		hub.SendEventWithID(sessionID, "message", id, SSEJSON(data))
+	}
+
+	// notifyFunc: marshal a JSON-RPC notification → emit as an SSE event
+	// with a unique ID (for Last-Event-ID replay on reconnect).
+	w.dispatcher.SetNotifyFunc(func(method string, params any) {
+		raw, err := core.MarshalNotification(method, params)
+		if err != nil {
+			return
+		}
+		emitSSEEvent(eventIDs, store, sessionID, raw, hubSend)
+	})
+
+	// pushFunc: write a raw JSON-RPC request/response as an SSE event.
+	// Used by server-to-client requests (roots/list, sampling, elicitation,
+	// keepalive ping) and by the caller for event replay after reconnect.
+	pushFunc = func(raw json.RawMessage) {
+		emitSSEEvent(eventIDs, store, sessionID, raw, hubSend)
+	}
+	w.dispatcher.SetPushRequest(pushFunc)
+
+	// Keepalive: periodic ping via the push function. Only constructed
+	// when the server has configured a keepalive interval.
+	if w.cfg.keepaliveInterval > 0 {
+		maxFails := w.cfg.keepaliveMaxFails
+		if maxFails <= 0 {
+			maxFails = 3
+		}
+		keepalive = &sessionKeepalive{
+			interval:    w.cfg.keepaliveInterval,
+			maxFailures: maxFails,
+			requestFunc: w.dispatcher.makeRequestFunc(pushFunc),
+			onDeath:     w.onDeath,
+			onPingFail:  w.onPingFail,
+		}
+	}
+
+	return pushFunc, keepalive
+}

--- a/server/streamable_transport.go
+++ b/server/streamable_transport.go
@@ -496,53 +496,30 @@ func (c *streamableSSEConn) OnStart(w http.ResponseWriter, r *http.Request) erro
 		c.entry.getConn.Store(c)
 	}
 
-	// Wire the dispatcher's notifyFunc to push to the SSE hub.
-	// This enables core.EmitLog/core.Notify from tool handlers to reach the GET stream.
+	// Wire notifyFunc, pushRequest, and keepalive via the shared SSE
+	// transport wiring helper (#199).
 	sessionID := c.sessionID
-	hub := c.transport.sseHub
-	store := c.transport.config.eventStore
-	c.dispatcher.SetNotifyFunc(func(method string, params any) {
-		raw, err := core.MarshalNotification(method, params)
-		if err != nil {
-			return
-		}
-		emitSSEEvent(c.dispatcher.eventIDs, store, sessionID, raw, func(id string, data json.RawMessage) {
-			hub.SendEventWithID(sessionID, "message", id, SSEJSON(data))
-		})
-	})
-
-	// Persistent push function for server-initiated JSON-RPC requests
-	// (roots/list, keepalive, etc.). Writes via emitSSEEvent so event IDs and
-	// the optional event store stay consistent with notifyFunc's output.
-	pushFunc := func(raw json.RawMessage) {
-		emitSSEEvent(c.dispatcher.eventIDs, store, sessionID, raw, func(id string, data json.RawMessage) {
-			hub.SendEventWithID(sessionID, "message", id, SSEJSON(data))
-		})
+	wiring := &sseWiring{
+		dispatcher: c.dispatcher,
+		hub:        c.transport.sseHub,
+		sessionID:  sessionID,
+		store:      c.transport.config.eventStore,
+		cfg:        c.transport.config,
+		onDeath:    func() { c.transport.expireSession(sessionID) },
+		onPingFail: func(failures int) { c.transport.server.notifyKeepaliveFailure(sessionID, failures) },
 	}
-	c.dispatcher.SetPushRequest(pushFunc)
+	_, c.keepalive = wiring.wire()
 
-	// Replay missed events if client reconnected with Last-Event-ID
-	if lastID := r.Header.Get("Last-Event-ID"); lastID != "" && store != nil {
-		events, _ := store.Replay(sessionID, lastID)
+	// Replay missed events if client reconnected with Last-Event-ID.
+	// Must happen AFTER wiring so pushFunc is set (replay uses the hub).
+	if lastID := r.Header.Get("Last-Event-ID"); lastID != "" && c.transport.config.eventStore != nil {
+		events, _ := c.transport.config.eventStore.Replay(sessionID, lastID)
 		for _, ev := range events {
 			c.SendEventWithID(ev.Event, ev.ID, SSEJSON(ev.Data))
 		}
 	}
 
-	// Start keepalive pings if configured. Reuses the persistent pushFunc.
-	cfg := c.transport.config
-	if cfg.keepaliveInterval > 0 && c.entry != nil {
-		maxFails := cfg.keepaliveMaxFails
-		if maxFails <= 0 {
-			maxFails = 3
-		}
-		c.keepalive = &sessionKeepalive{
-			interval:    cfg.keepaliveInterval,
-			maxFailures: maxFails,
-			requestFunc: c.dispatcher.makeRequestFunc(pushFunc),
-			onDeath:     func() { c.transport.expireSession(sessionID) },
-			onPingFail:  func(failures int) { c.transport.server.notifyKeepaliveFailure(sessionID, failures) },
-		}
+	if c.keepalive != nil && c.entry != nil {
 		c.keepalive.start()
 	}
 

--- a/server/transport.go
+++ b/server/transport.go
@@ -319,42 +319,19 @@ func (c *mcpSSEConn) OnStart(w http.ResponseWriter, r *http.Request) error {
 		c.transport.sessions.Store(sessionID, entry)
 	}
 
-	// Wire up (or re-wire) server-to-client notifications via the SSE stream.
-	// The closure captures the current hub connection, so it must be refreshed
-	// on reconnect to point to the new connection.
-	dispatcher.SetNotifyFunc(func(method string, params any) {
-		raw, err := core.MarshalNotification(method, params)
-		if err != nil {
-			return
-		}
-		emitSSEEvent(dispatcher.eventIDs, store, sessionID, raw, func(id string, data json.RawMessage) {
-			hub.SendEventWithID(sessionID, "message", id, SSEJSON(data))
-		})
-	})
-
-	// Persistent push function for server-initiated JSON-RPC requests
-	// (roots/list, keepalive ping, any future out-of-band request). Re-wired
-	// on reconnect so the closure points to the current hub connection.
-	pushFunc := func(raw json.RawMessage) {
-		emitSSEEvent(dispatcher.eventIDs, cfg.eventStore, sessionID, raw, func(id string, data json.RawMessage) {
-			hub.SendEventWithID(sessionID, "message", id, SSEJSON(data))
-		})
-	}
-	dispatcher.SetPushRequest(pushFunc)
-
-	// Start keepalive pings if configured.
-	if cfg.keepaliveInterval > 0 {
-		maxFails := cfg.keepaliveMaxFails
-		if maxFails <= 0 {
-			maxFails = 3
-		}
-		c.keepalive = &sessionKeepalive{
-			interval:    cfg.keepaliveInterval,
-			maxFailures: maxFails,
-			requestFunc: dispatcher.makeRequestFunc(pushFunc),
-			onDeath:     func() { c.transport.closeSession(sessionID) },
-			onPingFail:  func(failures int) { c.transport.server.notifyKeepaliveFailure(sessionID, failures) },
-		}
+	// Wire notifyFunc, pushRequest, and keepalive via the shared SSE
+	// transport wiring helper (#199). The closures capture the current hub
+	// connection and are refreshed on reconnect (grace period).
+	_, c.keepalive = (&sseWiring{
+		dispatcher: dispatcher,
+		hub:        hub,
+		sessionID:  sessionID,
+		store:      store,
+		cfg:        cfg,
+		onDeath:    func() { c.transport.closeSession(sessionID) },
+		onPingFail: func(failures int) { c.transport.server.notifyKeepaliveFailure(sessionID, failures) },
+	}).wire()
+	if c.keepalive != nil {
 		c.keepalive.start()
 	}
 

--- a/tests/reports/report.html
+++ b/tests/reports/report.html
@@ -15,7 +15,7 @@ th { background: #f5f5f5; font-weight: 600; }
 pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto; font-size: 13px; max-height: 400px; overflow-y: auto; }
 </style></head><body>
 <h1>MCPKit Test Report</h1>
-<div class='meta'>Branch: <strong>feature/roots-timeout-and-sandbox-197-198</strong> | Commit: <code>40bb4d1</code> | Date: 2026-04-12 02:25:36</div>
+<div class='meta'>Branch: <strong>refactor/transport-wiring-199</strong> | Commit: <code>c553e29</code> | Date: 2026-04-12 18:12:57</div>
 <table><tr><th>Stage</th><th>Result</th></tr>
 <tr><td>unit+coverage</td><td class='pass'>PASS</td></tr>
 <tr><td>race</td><td class='pass'>PASS</td></tr>
@@ -29,37 +29,37 @@ pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto; 
 <div class='summary-pass'>All 8 stages passed</div>
 <h2>Full Log</h2><pre>
 === MCPKit Comprehensive Test Suite ===
-Started: Sun Apr 12 02:24:48 PDT 2026
+Started: Sun Apr 12 18:12:11 PDT 2026
 
 --- [1/8] unit+coverage ---
-ok  	github.com/panyam/mcpkit/client	7.625s	coverage: 67.4% of statements
+ok  	github.com/panyam/mcpkit/client	8.561s	coverage: 67.4% of statements
 	github.com/panyam/mcpkit/cmd/testserver		coverage: 0.0% of statements
-ok  	github.com/panyam/mcpkit/core	0.786s	coverage: 61.4% of statements
-ok  	github.com/panyam/mcpkit/server	14.023s	coverage: 77.9% of statements
-ok  	github.com/panyam/mcpkit/testutil	1.114s	coverage: 70.5% of statements
+ok  	github.com/panyam/mcpkit/core	0.641s	coverage: 61.4% of statements
+ok  	github.com/panyam/mcpkit/server	14.045s	coverage: 78.3% of statements
+ok  	github.com/panyam/mcpkit/testutil	0.592s	coverage: 70.5% of statements
 Coverage report: tests/reports/coverage.html
   PASS: unit+coverage
 --- [2/8] race ---
-ok  	github.com/panyam/mcpkit/client	8.983s
+ok  	github.com/panyam/mcpkit/client	8.928s
 ?   	github.com/panyam/mcpkit/cmd/testserver	[no test files]
-ok  	github.com/panyam/mcpkit/core	1.422s
-ok  	github.com/panyam/mcpkit/server	15.437s
-ok  	github.com/panyam/mcpkit/testutil	2.316s
+ok  	github.com/panyam/mcpkit/core	1.368s
+ok  	github.com/panyam/mcpkit/server	15.499s
+ok  	github.com/panyam/mcpkit/testutil	2.456s
   PASS: race
 --- [3/8] auth ---
-ok  	github.com/panyam/mcpkit/ext/auth	0.285s
+ok  	github.com/panyam/mcpkit/ext/auth	0.379s
   PASS: auth
 --- [4/8] ui ---
-ok  	github.com/panyam/mcpkit/ext/ui	0.497s
+ok  	github.com/panyam/mcpkit/ext/ui	0.452s
   PASS: ui
 --- [5/8] e2e ---
-ok  	github.com/panyam/mcpkit/tests/e2e	4.086s
-ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.658s
+ok  	github.com/panyam/mcpkit/tests/e2e	3.832s
+ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.419s
   PASS: e2e
 --- [6/8] conformance ---
 Killing stale process on port 18799...
 === Starting test server on :18799 (Streamable HTTP) ===
-Waiting for server....2026/04/12 02:25:31 MCP test server listening on :18799 (Streamable HTTP at /mcp)
+Waiting for server....2026/04/12 18:12:51 MCP test server listening on :18799 (Streamable HTTP at /mcp)
  ready
 
 === Running MCP conformance suite ===
@@ -70,296 +70,296 @@ Running active suite (30 scenarios) against http://localhost:18799/mcp
 
 === Running scenario: server-initialize ===
 Running client scenario 'server-initialize' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: 0d0448cc3b8932134d76f7e2846be896
-2026/04/12 02:25:32 SSEHub: registered connection 0d0448cc3b8932134d76f7e2846be896 (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection 0d0448cc3b8932134d76f7e2846be896 (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8bbe230
-2026/04/12 02:25:32 Cleaning up writer...
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8bbe230
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: 0d0448cc3b8932134d76f7e2846be896
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: 4b7769ac3c52cea21d2da3e2ddf118fb
+2026/04/12 18:12:53 SSEHub: registered connection 4b7769ac3c52cea21d2da3e2ddf118fb (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection 4b7769ac3c52cea21d2da3e2ddf118fb (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b9256be230
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b9256be230
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: 4b7769ac3c52cea21d2da3e2ddf118fb
 
 === Running scenario: logging-set-level ===
 Running client scenario 'logging-set-level' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: 716a5e0e07cec74c5d38c6f774345138
-2026/04/12 02:25:32 SSEHub: registered connection 716a5e0e07cec74c5d38c6f774345138 (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection 716a5e0e07cec74c5d38c6f774345138 (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8bbe4d0
-2026/04/12 02:25:32 Cleaning up writer...
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8bbe4d0
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: 716a5e0e07cec74c5d38c6f774345138
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: c44d5247ba7eebecc879d21e06500306
+2026/04/12 18:12:53 SSEHub: registered connection c44d5247ba7eebecc879d21e06500306 (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection c44d5247ba7eebecc879d21e06500306 (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b925a2e230
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b925a2e230
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: c44d5247ba7eebecc879d21e06500306
 
 === Running scenario: ping ===
 Running client scenario 'ping' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: e2a64f1855fd7274a785e2a93919c006
-2026/04/12 02:25:32 SSEHub: registered connection e2a64f1855fd7274a785e2a93919c006 (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection e2a64f1855fd7274a785e2a93919c006 (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8bbe770
-2026/04/12 02:25:32 Cleaning up writer...
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: 67558f1d77ad2199e90a4b5cf49ef5fe
+2026/04/12 18:12:53 SSEHub: registered connection 67558f1d77ad2199e90a4b5cf49ef5fe (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection 67558f1d77ad2199e90a4b5cf49ef5fe (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b9257049a0
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b9257049a0
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: 67558f1d77ad2199e90a4b5cf49ef5fe
 
 === Running scenario: completion-complete ===
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8bbe770
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: e2a64f1855fd7274a785e2a93919c006
 Running client scenario 'completion-complete' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: 9703a8fedfc60779aca4d9ecf7bf76d0
-2026/04/12 02:25:32 SSEHub: registered connection 9703a8fedfc60779aca4d9ecf7bf76d0 (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection 9703a8fedfc60779aca4d9ecf7bf76d0 (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8bbea10
-2026/04/12 02:25:32 Cleaning up writer...
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: cedc370df7a9c117289ff7ba13b6799a
+2026/04/12 18:12:53 SSEHub: registered connection cedc370df7a9c117289ff7ba13b6799a (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection cedc370df7a9c117289ff7ba13b6799a (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b925704bd0
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b925704bd0
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: cedc370df7a9c117289ff7ba13b6799a
 
 === Running scenario: tools-list ===
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8bbea10
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: 9703a8fedfc60779aca4d9ecf7bf76d0
 Running client scenario 'tools-list' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: c00f26e5aa3c62421bbafe3e2fc73e82
-2026/04/12 02:25:32 SSEHub: registered connection c00f26e5aa3c62421bbafe3e2fc73e82 (total: 1)
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: 0980ca342a025dd6af2897333455ffc0
+2026/04/12 18:12:53 SSEHub: registered connection 0980ca342a025dd6af2897333455ffc0 (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection 0980ca342a025dd6af2897333455ffc0 (total: 0)
 
 === Running scenario: tools-call-simple-text ===
-2026/04/12 02:25:32 SSEHub: unregistered connection c00f26e5aa3c62421bbafe3e2fc73e82 (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f883c310
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b925704e00
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b925704e00
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: 0980ca342a025dd6af2897333455ffc0
 Running client scenario 'tools-call-simple-text' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Cleaning up writer...
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f883c310
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: c00f26e5aa3c62421bbafe3e2fc73e82
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: 981e43a292521907464f4c7ae2c73786
-2026/04/12 02:25:32 SSEHub: registered connection 981e43a292521907464f4c7ae2c73786 (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection 981e43a292521907464f4c7ae2c73786 (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8726cb0
-2026/04/12 02:25:32 Cleaning up writer...
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8726cb0
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: 8a0d905adc0d20a2ae29573de83ee3b6
+2026/04/12 18:12:53 SSEHub: registered connection 8a0d905adc0d20a2ae29573de83ee3b6 (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection 8a0d905adc0d20a2ae29573de83ee3b6 (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b925705030
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b925705030
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: 8a0d905adc0d20a2ae29573de83ee3b6
 
 === Running scenario: tools-call-image ===
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: 981e43a292521907464f4c7ae2c73786
 Running client scenario 'tools-call-image' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: b8259d05703c97fb8234d66be474cdec
-2026/04/12 02:25:32 SSEHub: registered connection b8259d05703c97fb8234d66be474cdec (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection b8259d05703c97fb8234d66be474cdec (total: 0)
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: 85b55ab77c80db06fcb319596e677fc1
+2026/04/12 18:12:53 SSEHub: registered connection 85b55ab77c80db06fcb319596e677fc1 (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection 85b55ab77c80db06fcb319596e677fc1 (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b925b181c0
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b925b181c0
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: 85b55ab77c80db06fcb319596e677fc1
 
 === Running scenario: tools-call-audio ===
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f883c620
-2026/04/12 02:25:32 Cleaning up writer...
 Running client scenario 'tools-call-audio' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f883c620
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: b8259d05703c97fb8234d66be474cdec
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: 6162a1c2b7ac6d8efa418d89361e2d06
-2026/04/12 02:25:32 SSEHub: registered connection 6162a1c2b7ac6d8efa418d89361e2d06 (total: 1)
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: dec5ff143d7f96716780daab661903a2
+2026/04/12 18:12:53 SSEHub: registered connection dec5ff143d7f96716780daab661903a2 (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection dec5ff143d7f96716780daab661903a2 (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b925705340
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b925705340
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: dec5ff143d7f96716780daab661903a2
 
 === Running scenario: tools-call-embedded-resource ===
-2026/04/12 02:25:32 SSEHub: unregistered connection 6162a1c2b7ac6d8efa418d89361e2d06 (total: 0)
 Running client scenario 'tools-call-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f87270a0
-2026/04/12 02:25:32 Cleaning up writer...
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f87270a0
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: 6162a1c2b7ac6d8efa418d89361e2d06
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: 590d5815524ac1ab96823b8b9b903021
-2026/04/12 02:25:32 SSEHub: registered connection 590d5815524ac1ab96823b8b9b903021 (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection 590d5815524ac1ab96823b8b9b903021 (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8bbee70
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: 22c5cd73c9d8af65e9725ab84827d6e9
+2026/04/12 18:12:53 SSEHub: registered connection 22c5cd73c9d8af65e9725ab84827d6e9 (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection 22c5cd73c9d8af65e9725ab84827d6e9 (total: 0)
 
 === Running scenario: tools-call-mixed-content ===
-2026/04/12 02:25:32 Cleaning up writer...
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b925b18540
+2026/04/12 18:12:53 Cleaning up writer...
 Running client scenario 'tools-call-mixed-content' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8bbee70
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: 590d5815524ac1ab96823b8b9b903021
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: c42698a7e801d2427e41bbbd60682ff4
-2026/04/12 02:25:32 SSEHub: registered connection c42698a7e801d2427e41bbbd60682ff4 (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection c42698a7e801d2427e41bbbd60682ff4 (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8bbef50
-2026/04/12 02:25:32 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b925b18540
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: 22c5cd73c9d8af65e9725ab84827d6e9
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: 8e6ab1336c116d61a6c9962c1f9a922f
+2026/04/12 18:12:53 SSEHub: registered connection 8e6ab1336c116d61a6c9962c1f9a922f (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection 8e6ab1336c116d61a6c9962c1f9a922f (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b925b18770
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b925b18770
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: 8e6ab1336c116d61a6c9962c1f9a922f
 
 === Running scenario: tools-call-with-logging ===
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8bbef50
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: c42698a7e801d2427e41bbbd60682ff4
 Running client scenario 'tools-call-with-logging' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: 909d4e39ec148ab0039e88b3881209ca
-2026/04/12 02:25:32 SSEHub: registered connection 909d4e39ec148ab0039e88b3881209ca (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection 909d4e39ec148ab0039e88b3881209ca (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f883c770
-2026/04/12 02:25:32 Cleaning up writer...
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f883c770
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: 909d4e39ec148ab0039e88b3881209ca
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: c8ca9aff1cf20834f2399402d60f0eea
+2026/04/12 18:12:53 SSEHub: registered connection c8ca9aff1cf20834f2399402d60f0eea (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection c8ca9aff1cf20834f2399402d60f0eea (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b925705730
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b925705730
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: c8ca9aff1cf20834f2399402d60f0eea
 
 === Running scenario: tools-call-error ===
 Running client scenario 'tools-call-error' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: 1a3c248f9dc2477885fb63b93a991653
-2026/04/12 02:25:32 SSEHub: registered connection 1a3c248f9dc2477885fb63b93a991653 (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection 1a3c248f9dc2477885fb63b93a991653 (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8dae380
-2026/04/12 02:25:32 Cleaning up writer...
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8dae380
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: 1a3c248f9dc2477885fb63b93a991653
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: 94bde63db3a785d4825b377d3fab65b1
+2026/04/12 18:12:53 SSEHub: registered connection 94bde63db3a785d4825b377d3fab65b1 (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection 94bde63db3a785d4825b377d3fab65b1 (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b925705a40
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b925705a40
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: 94bde63db3a785d4825b377d3fab65b1
 
 === Running scenario: tools-call-with-progress ===
 Running client scenario 'tools-call-with-progress' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: 1d5356706819ae049f287c28b7c65b5f
-2026/04/12 02:25:32 SSEHub: registered connection 1d5356706819ae049f287c28b7c65b5f (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection 1d5356706819ae049f287c28b7c65b5f (total: 0)
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: a426f0ec588f1369d77d079d82f79262
+2026/04/12 18:12:53 SSEHub: registered connection a426f0ec588f1369d77d079d82f79262 (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection a426f0ec588f1369d77d079d82f79262 (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b925705e30
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b925705e30
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: a426f0ec588f1369d77d079d82f79262
 
 === Running scenario: tools-call-sampling ===
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8bbf340
-2026/04/12 02:25:32 Cleaning up writer...
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8bbf340
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: 1d5356706819ae049f287c28b7c65b5f
 Running client scenario 'tools-call-sampling' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: b93048e88f54d1a71080ef5e8900e0f9
-2026/04/12 02:25:32 SSEHub: registered connection b93048e88f54d1a71080ef5e8900e0f9 (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection b93048e88f54d1a71080ef5e8900e0f9 (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8dae700
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: df8501add262cb98073e90f23de9f8cb
+2026/04/12 18:12:53 SSEHub: registered connection df8501add262cb98073e90f23de9f8cb (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection df8501add262cb98073e90f23de9f8cb (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b925a2e930
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b925a2e930
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: df8501add262cb98073e90f23de9f8cb
 
 === Running scenario: tools-call-elicitation ===
-2026/04/12 02:25:32 Cleaning up writer...
 Running client scenario 'tools-call-elicitation' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8dae700
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: b93048e88f54d1a71080ef5e8900e0f9
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: ad2273c0616cabdf9fa054a3213080f0
-2026/04/12 02:25:32 SSEHub: registered connection ad2273c0616cabdf9fa054a3213080f0 (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection ad2273c0616cabdf9fa054a3213080f0 (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8bbf570
-2026/04/12 02:25:32 Cleaning up writer...
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8bbf570
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: ad2273c0616cabdf9fa054a3213080f0
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: 835d099d9fc91bae29b5dea7a07125a8
+2026/04/12 18:12:53 SSEHub: registered connection 835d099d9fc91bae29b5dea7a07125a8 (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection 835d099d9fc91bae29b5dea7a07125a8 (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b9256be5b0
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b9256be5b0
 
 === Running scenario: elicitation-sep1034-defaults ===
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: 835d099d9fc91bae29b5dea7a07125a8
 Running client scenario 'elicitation-sep1034-defaults' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: bcf90a1f1dedb3e5358df982888d0774
-2026/04/12 02:25:32 SSEHub: registered connection bcf90a1f1dedb3e5358df982888d0774 (total: 1)
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: d9c1da61e9d26febd25abf7289d0ca03
+2026/04/12 18:12:53 SSEHub: registered connection d9c1da61e9d26febd25abf7289d0ca03 (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection d9c1da61e9d26febd25abf7289d0ca03 (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b925a2eb60
+2026/04/12 18:12:53 Cleaning up writer...
 
 === Running scenario: server-sse-multiple-streams ===
-2026/04/12 02:25:32 SSEHub: unregistered connection bcf90a1f1dedb3e5358df982888d0774 (total: 0)
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b925a2eb60
 Running client scenario 'server-sse-multiple-streams' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8bbf7a0
-2026/04/12 02:25:32 Cleaning up writer...
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8bbf7a0
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: bcf90a1f1dedb3e5358df982888d0774
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: 9a93bfdc1f08107b1871870cb62eb440
-2026/04/12 02:25:32 SSEHub: registered connection 9a93bfdc1f08107b1871870cb62eb440 (total: 1)
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: d9c1da61e9d26febd25abf7289d0ca03
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: 3ce88896f21c401bb7cde1fcafdb9f5c
+2026/04/12 18:12:53 SSEHub: registered connection 3ce88896f21c401bb7cde1fcafdb9f5c (total: 1)
 
 === Running scenario: elicitation-sep1330-enums ===
+2026/04/12 18:12:53 SSEHub: unregistered connection 3ce88896f21c401bb7cde1fcafdb9f5c (total: 0)
 Running client scenario 'elicitation-sep1330-enums' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 SSEHub: unregistered connection 9a93bfdc1f08107b1871870cb62eb440 (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f883cd20
-2026/04/12 02:25:32 Cleaning up writer...
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f883cd20
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: 9a93bfdc1f08107b1871870cb62eb440
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: 8cee62732078cf623d6c72fae3c04194
-2026/04/12 02:25:32 SSEHub: registered connection 8cee62732078cf623d6c72fae3c04194 (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection 8cee62732078cf623d6c72fae3c04194 (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8daeb60
-2026/04/12 02:25:32 Cleaning up writer...
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8daeb60
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b9255f4460
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b9255f4460
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: 3ce88896f21c401bb7cde1fcafdb9f5c
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: d7a820dfe19cf32342edc84f73a7fb30
+2026/04/12 18:12:53 SSEHub: registered connection d7a820dfe19cf32342edc84f73a7fb30 (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection d7a820dfe19cf32342edc84f73a7fb30 (total: 0)
 
 === Running scenario: resources-list ===
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: 8cee62732078cf623d6c72fae3c04194
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b925b18a10
 Running client scenario 'resources-list' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: a4411a48ec1b2b9d9957bd28b62085ba
-2026/04/12 02:25:32 SSEHub: registered connection a4411a48ec1b2b9d9957bd28b62085ba (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection a4411a48ec1b2b9d9957bd28b62085ba (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f87276c0
-2026/04/12 02:25:32 Cleaning up writer...
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b925b18a10
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: d7a820dfe19cf32342edc84f73a7fb30
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: fc594e528833c6d105721ecd1f1b0bfd
+2026/04/12 18:12:53 SSEHub: registered connection fc594e528833c6d105721ecd1f1b0bfd (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection fc594e528833c6d105721ecd1f1b0bfd (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b9256beaf0
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b9256beaf0
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: fc594e528833c6d105721ecd1f1b0bfd
 
 === Running scenario: resources-read-text ===
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f87276c0
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: a4411a48ec1b2b9d9957bd28b62085ba
 Running client scenario 'resources-read-text' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: e14782edde27bef2e6df8519c0400bbd
-2026/04/12 02:25:32 SSEHub: registered connection e14782edde27bef2e6df8519c0400bbd (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection e14782edde27bef2e6df8519c0400bbd (total: 0)
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: b236e01dc7bc839c09430bf653789d1b
+2026/04/12 18:12:53 SSEHub: registered connection b236e01dc7bc839c09430bf653789d1b (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection b236e01dc7bc839c09430bf653789d1b (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b925a2f0a0
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b925a2f0a0
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: b236e01dc7bc839c09430bf653789d1b
 
 === Running scenario: resources-read-binary ===
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8bbfa40
 Running client scenario 'resources-read-binary' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Cleaning up writer...
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8bbfa40
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: e14782edde27bef2e6df8519c0400bbd
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: 5db8ff0c5c4b43fb93362cf2e3ba64d3
-2026/04/12 02:25:32 SSEHub: registered connection 5db8ff0c5c4b43fb93362cf2e3ba64d3 (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection 5db8ff0c5c4b43fb93362cf2e3ba64d3 (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8916230
-2026/04/12 02:25:32 Cleaning up writer...
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8916230
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: 5db8ff0c5c4b43fb93362cf2e3ba64d3
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: a1ff56eabb6f40a66441f85e5344d3db
+2026/04/12 18:12:53 SSEHub: registered connection a1ff56eabb6f40a66441f85e5344d3db (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection a1ff56eabb6f40a66441f85e5344d3db (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b9255f4a10
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b9255f4a10
 
 === Running scenario: resources-templates-read ===
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: a1ff56eabb6f40a66441f85e5344d3db
 Running client scenario 'resources-templates-read' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: 7b3e5e89439db21dfce24add99a77ada
-2026/04/12 02:25:32 SSEHub: registered connection 7b3e5e89439db21dfce24add99a77ada (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection 7b3e5e89439db21dfce24add99a77ada (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8daee00
-2026/04/12 02:25:32 Cleaning up writer...
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8daee00
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: 7b3e5e89439db21dfce24add99a77ada
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: bc03a05ef2f1699a2d26d13c37dc18a9
+2026/04/12 18:12:53 SSEHub: registered connection bc03a05ef2f1699a2d26d13c37dc18a9 (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection bc03a05ef2f1699a2d26d13c37dc18a9 (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b9255f4cb0
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b9255f4cb0
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: bc03a05ef2f1699a2d26d13c37dc18a9
 
 === Running scenario: resources-subscribe ===
 Running client scenario 'resources-subscribe' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: 33840f12f06ad121d6f5648e62a90029
-2026/04/12 02:25:32 SSEHub: registered connection 33840f12f06ad121d6f5648e62a90029 (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection 33840f12f06ad121d6f5648e62a90029 (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f89164d0
-2026/04/12 02:25:32 Cleaning up writer...
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f89164d0
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: 33840f12f06ad121d6f5648e62a90029
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: b97effad7c3e4c9e9e466555ebebb94b
+2026/04/12 18:12:53 SSEHub: registered connection b97effad7c3e4c9e9e466555ebebb94b (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection b97effad7c3e4c9e9e466555ebebb94b (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b9255f4fc0
 
 === Running scenario: resources-unsubscribe ===
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b9255f4fc0
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: b97effad7c3e4c9e9e466555ebebb94b
 Running client scenario 'resources-unsubscribe' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: 3ba20314631323a049f8a6b511f68e4b
-2026/04/12 02:25:32 SSEHub: registered connection 3ba20314631323a049f8a6b511f68e4b (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection 3ba20314631323a049f8a6b511f68e4b (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8916700
-2026/04/12 02:25:32 Cleaning up writer...
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8916700
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: 3ba20314631323a049f8a6b511f68e4b
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: 0a1389f8b8564ab775759bf596cc8c90
+2026/04/12 18:12:53 SSEHub: registered connection 0a1389f8b8564ab775759bf596cc8c90 (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection 0a1389f8b8564ab775759bf596cc8c90 (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b925a2f3b0
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b925a2f3b0
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: 0a1389f8b8564ab775759bf596cc8c90
 
 === Running scenario: prompts-list ===
 Running client scenario 'prompts-list' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: aafce81c0339912478343e72bb1d64ab
-2026/04/12 02:25:32 SSEHub: registered connection aafce81c0339912478343e72bb1d64ab (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection aafce81c0339912478343e72bb1d64ab (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8daf180
-2026/04/12 02:25:32 Cleaning up writer...
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8daf180
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: bbb5647ebb2c4c437df51caea38906f0
+2026/04/12 18:12:53 SSEHub: registered connection bbb5647ebb2c4c437df51caea38906f0 (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection bbb5647ebb2c4c437df51caea38906f0 (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b9256bee70
 
 === Running scenario: prompts-get-simple ===
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: aafce81c0339912478343e72bb1d64ab
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b9256bee70
 Running client scenario 'prompts-get-simple' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: 40285a1207c031224355c6f1ec33b267
-2026/04/12 02:25:32 SSEHub: registered connection 40285a1207c031224355c6f1ec33b267 (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection 40285a1207c031224355c6f1ec33b267 (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8916a80
-2026/04/12 02:25:32 Cleaning up writer...
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: bbb5647ebb2c4c437df51caea38906f0
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: 546c7e3451205c0c7d5b90279a1c0800
+2026/04/12 18:12:53 SSEHub: registered connection 546c7e3451205c0c7d5b90279a1c0800 (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection 546c7e3451205c0c7d5b90279a1c0800 (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b9256bf110
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b9256bf110
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: 546c7e3451205c0c7d5b90279a1c0800
 
 === Running scenario: prompts-get-with-args ===
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8916a80
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: 40285a1207c031224355c6f1ec33b267
 Running client scenario 'prompts-get-with-args' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: 627f6b60008857bb87fc3bfc69746ed8
-2026/04/12 02:25:32 SSEHub: registered connection 627f6b60008857bb87fc3bfc69746ed8 (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection 627f6b60008857bb87fc3bfc69746ed8 (total: 0)
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: 2a4649604eed2ce327e1e45db5189a03
+2026/04/12 18:12:53 SSEHub: registered connection 2a4649604eed2ce327e1e45db5189a03 (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection 2a4649604eed2ce327e1e45db5189a03 (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b9256bf420
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b9256bf420
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: 2a4649604eed2ce327e1e45db5189a03
 
 === Running scenario: prompts-get-embedded-resource ===
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8bbff10
-2026/04/12 02:25:32 Cleaning up writer...
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8bbff10
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: 627f6b60008857bb87fc3bfc69746ed8
 Running client scenario 'prompts-get-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: 16ff5640166a40ba4bf10822520dd9c4
-2026/04/12 02:25:32 SSEHub: registered connection 16ff5640166a40ba4bf10822520dd9c4 (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection 16ff5640166a40ba4bf10822520dd9c4 (total: 0)
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: 2019a48d986d50c4ba17b75a3d725e8f
+2026/04/12 18:12:53 SSEHub: registered connection 2019a48d986d50c4ba17b75a3d725e8f (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection 2019a48d986d50c4ba17b75a3d725e8f (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b9256bf650
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b9256bf650
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: 2019a48d986d50c4ba17b75a3d725e8f
 
 === Running scenario: prompts-get-with-image ===
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8916d20
-2026/04/12 02:25:32 Cleaning up writer...
 Running client scenario 'prompts-get-with-image' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8916d20
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: 16ff5640166a40ba4bf10822520dd9c4
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: 2840f66c143fb7b8d91cd516e900ffc5
-2026/04/12 02:25:32 SSEHub: registered connection 2840f66c143fb7b8d91cd516e900ffc5 (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection 2840f66c143fb7b8d91cd516e900ffc5 (total: 0)
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: 3d20df3d693b7c594f9208847259e0b6
+2026/04/12 18:12:53 SSEHub: registered connection 3d20df3d693b7c594f9208847259e0b6 (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection 3d20df3d693b7c594f9208847259e0b6 (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b9256bf880
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b9256bf880
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: 3d20df3d693b7c594f9208847259e0b6
 
 === Running scenario: dns-rebinding-protection ===
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8b662a0
 Running client scenario 'dns-rebinding-protection' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Cleaning up writer...
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8b662a0
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: 2840f66c143fb7b8d91cd516e900ffc5
 
 
 === SUMMARY ===
@@ -421,22 +421,22 @@ Starting scenario: auth/token-endpoint-auth-basic
 Starting scenario: auth/token-endpoint-auth-post
 Starting scenario: auth/token-endpoint-auth-none
 Starting scenario: auth/pre-registration
-Executing client: ./bin/testclient http://localhost:51591/mcp
-Executing client: ./bin/testclient http://localhost:51592/mcp
-Executing client: ./bin/testclient http://localhost:51593/mcp
-Executing client: ./bin/testclient http://localhost:51594/mcp
-Executing client: ./bin/testclient http://localhost:51595/mcp
-Executing client: ./bin/testclient http://localhost:51596/mcp
-Executing client: ./bin/testclient http://localhost:51597/mcp
-Executing client: ./bin/testclient http://localhost:51598/mcp
-Executing client: ./bin/testclient http://localhost:51599/mcp
-Executing client: ./bin/testclient http://localhost:51600/mcp
-Executing client: ./bin/testclient http://localhost:51601/mcp
-Executing client: ./bin/testclient http://localhost:51602/mcp
-Executing client: ./bin/testclient http://localhost:51603/mcp
-Executing client: ./bin/testclient http://localhost:51604/mcp
+Executing client: ./bin/testclient http://localhost:58366/mcp
+Executing client: ./bin/testclient http://localhost:58367/mcp
+Executing client: ./bin/testclient http://localhost:58368/mcp
+Executing client: ./bin/testclient http://localhost:58369/mcp
+Executing client: ./bin/testclient http://localhost:58370/mcp
+Executing client: ./bin/testclient http://localhost:58371/mcp
+Executing client: ./bin/testclient http://localhost:58372/mcp
+Executing client: ./bin/testclient http://localhost:58373/mcp
+Executing client: ./bin/testclient http://localhost:58374/mcp
+Executing client: ./bin/testclient http://localhost:58375/mcp
+Executing client: ./bin/testclient http://localhost:58376/mcp
+Executing client: ./bin/testclient http://localhost:58377/mcp
+Executing client: ./bin/testclient http://localhost:58378/mcp
+Executing client: ./bin/testclient http://localhost:58379/mcp
 With context: {"client_id":"pre-registered-client","client_secret":"pre-registered-secret"}
-(node:27867) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
+(node:62343) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
 (Use `node --trace-deprecation ...` to show where the warning was created)
 
 === SUITE SUMMARY ===
@@ -479,12 +479,12 @@ Total: 210 passed, 0 failed, 1 warnings
 === RUN   TestKeycloak_MCPServer_WWWAuthenticate
 --- PASS: TestKeycloak_MCPServer_WWWAuthenticate (0.01s)
 === RUN   TestKeycloak_MCPServer_PasswordGrant
---- PASS: TestKeycloak_MCPServer_PasswordGrant (0.05s)
+--- PASS: TestKeycloak_MCPServer_PasswordGrant (0.06s)
 PASS
-ok  	github.com/panyam/mcpkit/tests/keycloak	0.759s
+ok  	github.com/panyam/mcpkit/tests/keycloak	0.782s
   PASS: keycloak
 
 === Results: 8 passed, 0 failed ===
-Finished: Sun Apr 12 02:25:36 PDT 2026
+Finished: Sun Apr 12 18:12:57 PDT 2026
 </pre>
 </body></html>

--- a/tests/reports/run.log
+++ b/tests/reports/run.log
@@ -1,35 +1,35 @@
 === MCPKit Comprehensive Test Suite ===
-Started: Sun Apr 12 02:24:48 PDT 2026
+Started: Sun Apr 12 18:12:11 PDT 2026
 
 --- [1/8] unit+coverage ---
-ok  	github.com/panyam/mcpkit/client	7.625s	coverage: 67.4% of statements
+ok  	github.com/panyam/mcpkit/client	8.561s	coverage: 67.4% of statements
 	github.com/panyam/mcpkit/cmd/testserver		coverage: 0.0% of statements
-ok  	github.com/panyam/mcpkit/core	0.786s	coverage: 61.4% of statements
-ok  	github.com/panyam/mcpkit/server	14.023s	coverage: 77.9% of statements
-ok  	github.com/panyam/mcpkit/testutil	1.114s	coverage: 70.5% of statements
+ok  	github.com/panyam/mcpkit/core	0.641s	coverage: 61.4% of statements
+ok  	github.com/panyam/mcpkit/server	14.045s	coverage: 78.3% of statements
+ok  	github.com/panyam/mcpkit/testutil	0.592s	coverage: 70.5% of statements
 Coverage report: tests/reports/coverage.html
   PASS: unit+coverage
 --- [2/8] race ---
-ok  	github.com/panyam/mcpkit/client	8.983s
+ok  	github.com/panyam/mcpkit/client	8.928s
 ?   	github.com/panyam/mcpkit/cmd/testserver	[no test files]
-ok  	github.com/panyam/mcpkit/core	1.422s
-ok  	github.com/panyam/mcpkit/server	15.437s
-ok  	github.com/panyam/mcpkit/testutil	2.316s
+ok  	github.com/panyam/mcpkit/core	1.368s
+ok  	github.com/panyam/mcpkit/server	15.499s
+ok  	github.com/panyam/mcpkit/testutil	2.456s
   PASS: race
 --- [3/8] auth ---
-ok  	github.com/panyam/mcpkit/ext/auth	0.285s
+ok  	github.com/panyam/mcpkit/ext/auth	0.379s
   PASS: auth
 --- [4/8] ui ---
-ok  	github.com/panyam/mcpkit/ext/ui	0.497s
+ok  	github.com/panyam/mcpkit/ext/ui	0.452s
   PASS: ui
 --- [5/8] e2e ---
-ok  	github.com/panyam/mcpkit/tests/e2e	4.086s
-ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.658s
+ok  	github.com/panyam/mcpkit/tests/e2e	3.832s
+ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.419s
   PASS: e2e
 --- [6/8] conformance ---
 Killing stale process on port 18799...
 === Starting test server on :18799 (Streamable HTTP) ===
-Waiting for server....2026/04/12 02:25:31 MCP test server listening on :18799 (Streamable HTTP at /mcp)
+Waiting for server....2026/04/12 18:12:51 MCP test server listening on :18799 (Streamable HTTP at /mcp)
  ready
 
 === Running MCP conformance suite ===
@@ -40,296 +40,296 @@ Running active suite (30 scenarios) against http://localhost:18799/mcp
 
 === Running scenario: server-initialize ===
 Running client scenario 'server-initialize' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: 0d0448cc3b8932134d76f7e2846be896
-2026/04/12 02:25:32 SSEHub: registered connection 0d0448cc3b8932134d76f7e2846be896 (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection 0d0448cc3b8932134d76f7e2846be896 (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8bbe230
-2026/04/12 02:25:32 Cleaning up writer...
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8bbe230
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: 0d0448cc3b8932134d76f7e2846be896
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: 4b7769ac3c52cea21d2da3e2ddf118fb
+2026/04/12 18:12:53 SSEHub: registered connection 4b7769ac3c52cea21d2da3e2ddf118fb (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection 4b7769ac3c52cea21d2da3e2ddf118fb (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b9256be230
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b9256be230
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: 4b7769ac3c52cea21d2da3e2ddf118fb
 
 === Running scenario: logging-set-level ===
 Running client scenario 'logging-set-level' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: 716a5e0e07cec74c5d38c6f774345138
-2026/04/12 02:25:32 SSEHub: registered connection 716a5e0e07cec74c5d38c6f774345138 (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection 716a5e0e07cec74c5d38c6f774345138 (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8bbe4d0
-2026/04/12 02:25:32 Cleaning up writer...
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8bbe4d0
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: 716a5e0e07cec74c5d38c6f774345138
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: c44d5247ba7eebecc879d21e06500306
+2026/04/12 18:12:53 SSEHub: registered connection c44d5247ba7eebecc879d21e06500306 (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection c44d5247ba7eebecc879d21e06500306 (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b925a2e230
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b925a2e230
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: c44d5247ba7eebecc879d21e06500306
 
 === Running scenario: ping ===
 Running client scenario 'ping' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: e2a64f1855fd7274a785e2a93919c006
-2026/04/12 02:25:32 SSEHub: registered connection e2a64f1855fd7274a785e2a93919c006 (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection e2a64f1855fd7274a785e2a93919c006 (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8bbe770
-2026/04/12 02:25:32 Cleaning up writer...
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: 67558f1d77ad2199e90a4b5cf49ef5fe
+2026/04/12 18:12:53 SSEHub: registered connection 67558f1d77ad2199e90a4b5cf49ef5fe (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection 67558f1d77ad2199e90a4b5cf49ef5fe (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b9257049a0
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b9257049a0
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: 67558f1d77ad2199e90a4b5cf49ef5fe
 
 === Running scenario: completion-complete ===
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8bbe770
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: e2a64f1855fd7274a785e2a93919c006
 Running client scenario 'completion-complete' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: 9703a8fedfc60779aca4d9ecf7bf76d0
-2026/04/12 02:25:32 SSEHub: registered connection 9703a8fedfc60779aca4d9ecf7bf76d0 (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection 9703a8fedfc60779aca4d9ecf7bf76d0 (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8bbea10
-2026/04/12 02:25:32 Cleaning up writer...
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: cedc370df7a9c117289ff7ba13b6799a
+2026/04/12 18:12:53 SSEHub: registered connection cedc370df7a9c117289ff7ba13b6799a (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection cedc370df7a9c117289ff7ba13b6799a (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b925704bd0
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b925704bd0
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: cedc370df7a9c117289ff7ba13b6799a
 
 === Running scenario: tools-list ===
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8bbea10
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: 9703a8fedfc60779aca4d9ecf7bf76d0
 Running client scenario 'tools-list' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: c00f26e5aa3c62421bbafe3e2fc73e82
-2026/04/12 02:25:32 SSEHub: registered connection c00f26e5aa3c62421bbafe3e2fc73e82 (total: 1)
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: 0980ca342a025dd6af2897333455ffc0
+2026/04/12 18:12:53 SSEHub: registered connection 0980ca342a025dd6af2897333455ffc0 (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection 0980ca342a025dd6af2897333455ffc0 (total: 0)
 
 === Running scenario: tools-call-simple-text ===
-2026/04/12 02:25:32 SSEHub: unregistered connection c00f26e5aa3c62421bbafe3e2fc73e82 (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f883c310
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b925704e00
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b925704e00
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: 0980ca342a025dd6af2897333455ffc0
 Running client scenario 'tools-call-simple-text' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Cleaning up writer...
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f883c310
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: c00f26e5aa3c62421bbafe3e2fc73e82
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: 981e43a292521907464f4c7ae2c73786
-2026/04/12 02:25:32 SSEHub: registered connection 981e43a292521907464f4c7ae2c73786 (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection 981e43a292521907464f4c7ae2c73786 (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8726cb0
-2026/04/12 02:25:32 Cleaning up writer...
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8726cb0
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: 8a0d905adc0d20a2ae29573de83ee3b6
+2026/04/12 18:12:53 SSEHub: registered connection 8a0d905adc0d20a2ae29573de83ee3b6 (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection 8a0d905adc0d20a2ae29573de83ee3b6 (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b925705030
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b925705030
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: 8a0d905adc0d20a2ae29573de83ee3b6
 
 === Running scenario: tools-call-image ===
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: 981e43a292521907464f4c7ae2c73786
 Running client scenario 'tools-call-image' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: b8259d05703c97fb8234d66be474cdec
-2026/04/12 02:25:32 SSEHub: registered connection b8259d05703c97fb8234d66be474cdec (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection b8259d05703c97fb8234d66be474cdec (total: 0)
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: 85b55ab77c80db06fcb319596e677fc1
+2026/04/12 18:12:53 SSEHub: registered connection 85b55ab77c80db06fcb319596e677fc1 (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection 85b55ab77c80db06fcb319596e677fc1 (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b925b181c0
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b925b181c0
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: 85b55ab77c80db06fcb319596e677fc1
 
 === Running scenario: tools-call-audio ===
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f883c620
-2026/04/12 02:25:32 Cleaning up writer...
 Running client scenario 'tools-call-audio' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f883c620
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: b8259d05703c97fb8234d66be474cdec
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: 6162a1c2b7ac6d8efa418d89361e2d06
-2026/04/12 02:25:32 SSEHub: registered connection 6162a1c2b7ac6d8efa418d89361e2d06 (total: 1)
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: dec5ff143d7f96716780daab661903a2
+2026/04/12 18:12:53 SSEHub: registered connection dec5ff143d7f96716780daab661903a2 (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection dec5ff143d7f96716780daab661903a2 (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b925705340
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b925705340
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: dec5ff143d7f96716780daab661903a2
 
 === Running scenario: tools-call-embedded-resource ===
-2026/04/12 02:25:32 SSEHub: unregistered connection 6162a1c2b7ac6d8efa418d89361e2d06 (total: 0)
 Running client scenario 'tools-call-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f87270a0
-2026/04/12 02:25:32 Cleaning up writer...
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f87270a0
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: 6162a1c2b7ac6d8efa418d89361e2d06
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: 590d5815524ac1ab96823b8b9b903021
-2026/04/12 02:25:32 SSEHub: registered connection 590d5815524ac1ab96823b8b9b903021 (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection 590d5815524ac1ab96823b8b9b903021 (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8bbee70
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: 22c5cd73c9d8af65e9725ab84827d6e9
+2026/04/12 18:12:53 SSEHub: registered connection 22c5cd73c9d8af65e9725ab84827d6e9 (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection 22c5cd73c9d8af65e9725ab84827d6e9 (total: 0)
 
 === Running scenario: tools-call-mixed-content ===
-2026/04/12 02:25:32 Cleaning up writer...
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b925b18540
+2026/04/12 18:12:53 Cleaning up writer...
 Running client scenario 'tools-call-mixed-content' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8bbee70
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: 590d5815524ac1ab96823b8b9b903021
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: c42698a7e801d2427e41bbbd60682ff4
-2026/04/12 02:25:32 SSEHub: registered connection c42698a7e801d2427e41bbbd60682ff4 (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection c42698a7e801d2427e41bbbd60682ff4 (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8bbef50
-2026/04/12 02:25:32 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b925b18540
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: 22c5cd73c9d8af65e9725ab84827d6e9
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: 8e6ab1336c116d61a6c9962c1f9a922f
+2026/04/12 18:12:53 SSEHub: registered connection 8e6ab1336c116d61a6c9962c1f9a922f (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection 8e6ab1336c116d61a6c9962c1f9a922f (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b925b18770
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b925b18770
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: 8e6ab1336c116d61a6c9962c1f9a922f
 
 === Running scenario: tools-call-with-logging ===
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8bbef50
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: c42698a7e801d2427e41bbbd60682ff4
 Running client scenario 'tools-call-with-logging' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: 909d4e39ec148ab0039e88b3881209ca
-2026/04/12 02:25:32 SSEHub: registered connection 909d4e39ec148ab0039e88b3881209ca (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection 909d4e39ec148ab0039e88b3881209ca (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f883c770
-2026/04/12 02:25:32 Cleaning up writer...
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f883c770
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: 909d4e39ec148ab0039e88b3881209ca
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: c8ca9aff1cf20834f2399402d60f0eea
+2026/04/12 18:12:53 SSEHub: registered connection c8ca9aff1cf20834f2399402d60f0eea (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection c8ca9aff1cf20834f2399402d60f0eea (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b925705730
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b925705730
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: c8ca9aff1cf20834f2399402d60f0eea
 
 === Running scenario: tools-call-error ===
 Running client scenario 'tools-call-error' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: 1a3c248f9dc2477885fb63b93a991653
-2026/04/12 02:25:32 SSEHub: registered connection 1a3c248f9dc2477885fb63b93a991653 (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection 1a3c248f9dc2477885fb63b93a991653 (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8dae380
-2026/04/12 02:25:32 Cleaning up writer...
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8dae380
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: 1a3c248f9dc2477885fb63b93a991653
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: 94bde63db3a785d4825b377d3fab65b1
+2026/04/12 18:12:53 SSEHub: registered connection 94bde63db3a785d4825b377d3fab65b1 (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection 94bde63db3a785d4825b377d3fab65b1 (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b925705a40
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b925705a40
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: 94bde63db3a785d4825b377d3fab65b1
 
 === Running scenario: tools-call-with-progress ===
 Running client scenario 'tools-call-with-progress' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: 1d5356706819ae049f287c28b7c65b5f
-2026/04/12 02:25:32 SSEHub: registered connection 1d5356706819ae049f287c28b7c65b5f (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection 1d5356706819ae049f287c28b7c65b5f (total: 0)
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: a426f0ec588f1369d77d079d82f79262
+2026/04/12 18:12:53 SSEHub: registered connection a426f0ec588f1369d77d079d82f79262 (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection a426f0ec588f1369d77d079d82f79262 (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b925705e30
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b925705e30
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: a426f0ec588f1369d77d079d82f79262
 
 === Running scenario: tools-call-sampling ===
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8bbf340
-2026/04/12 02:25:32 Cleaning up writer...
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8bbf340
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: 1d5356706819ae049f287c28b7c65b5f
 Running client scenario 'tools-call-sampling' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: b93048e88f54d1a71080ef5e8900e0f9
-2026/04/12 02:25:32 SSEHub: registered connection b93048e88f54d1a71080ef5e8900e0f9 (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection b93048e88f54d1a71080ef5e8900e0f9 (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8dae700
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: df8501add262cb98073e90f23de9f8cb
+2026/04/12 18:12:53 SSEHub: registered connection df8501add262cb98073e90f23de9f8cb (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection df8501add262cb98073e90f23de9f8cb (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b925a2e930
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b925a2e930
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: df8501add262cb98073e90f23de9f8cb
 
 === Running scenario: tools-call-elicitation ===
-2026/04/12 02:25:32 Cleaning up writer...
 Running client scenario 'tools-call-elicitation' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8dae700
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: b93048e88f54d1a71080ef5e8900e0f9
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: ad2273c0616cabdf9fa054a3213080f0
-2026/04/12 02:25:32 SSEHub: registered connection ad2273c0616cabdf9fa054a3213080f0 (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection ad2273c0616cabdf9fa054a3213080f0 (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8bbf570
-2026/04/12 02:25:32 Cleaning up writer...
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8bbf570
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: ad2273c0616cabdf9fa054a3213080f0
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: 835d099d9fc91bae29b5dea7a07125a8
+2026/04/12 18:12:53 SSEHub: registered connection 835d099d9fc91bae29b5dea7a07125a8 (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection 835d099d9fc91bae29b5dea7a07125a8 (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b9256be5b0
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b9256be5b0
 
 === Running scenario: elicitation-sep1034-defaults ===
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: 835d099d9fc91bae29b5dea7a07125a8
 Running client scenario 'elicitation-sep1034-defaults' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: bcf90a1f1dedb3e5358df982888d0774
-2026/04/12 02:25:32 SSEHub: registered connection bcf90a1f1dedb3e5358df982888d0774 (total: 1)
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: d9c1da61e9d26febd25abf7289d0ca03
+2026/04/12 18:12:53 SSEHub: registered connection d9c1da61e9d26febd25abf7289d0ca03 (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection d9c1da61e9d26febd25abf7289d0ca03 (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b925a2eb60
+2026/04/12 18:12:53 Cleaning up writer...
 
 === Running scenario: server-sse-multiple-streams ===
-2026/04/12 02:25:32 SSEHub: unregistered connection bcf90a1f1dedb3e5358df982888d0774 (total: 0)
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b925a2eb60
 Running client scenario 'server-sse-multiple-streams' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8bbf7a0
-2026/04/12 02:25:32 Cleaning up writer...
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8bbf7a0
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: bcf90a1f1dedb3e5358df982888d0774
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: 9a93bfdc1f08107b1871870cb62eb440
-2026/04/12 02:25:32 SSEHub: registered connection 9a93bfdc1f08107b1871870cb62eb440 (total: 1)
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: d9c1da61e9d26febd25abf7289d0ca03
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: 3ce88896f21c401bb7cde1fcafdb9f5c
+2026/04/12 18:12:53 SSEHub: registered connection 3ce88896f21c401bb7cde1fcafdb9f5c (total: 1)
 
 === Running scenario: elicitation-sep1330-enums ===
+2026/04/12 18:12:53 SSEHub: unregistered connection 3ce88896f21c401bb7cde1fcafdb9f5c (total: 0)
 Running client scenario 'elicitation-sep1330-enums' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 SSEHub: unregistered connection 9a93bfdc1f08107b1871870cb62eb440 (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f883cd20
-2026/04/12 02:25:32 Cleaning up writer...
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f883cd20
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: 9a93bfdc1f08107b1871870cb62eb440
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: 8cee62732078cf623d6c72fae3c04194
-2026/04/12 02:25:32 SSEHub: registered connection 8cee62732078cf623d6c72fae3c04194 (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection 8cee62732078cf623d6c72fae3c04194 (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8daeb60
-2026/04/12 02:25:32 Cleaning up writer...
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8daeb60
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b9255f4460
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b9255f4460
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: 3ce88896f21c401bb7cde1fcafdb9f5c
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: d7a820dfe19cf32342edc84f73a7fb30
+2026/04/12 18:12:53 SSEHub: registered connection d7a820dfe19cf32342edc84f73a7fb30 (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection d7a820dfe19cf32342edc84f73a7fb30 (total: 0)
 
 === Running scenario: resources-list ===
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: 8cee62732078cf623d6c72fae3c04194
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b925b18a10
 Running client scenario 'resources-list' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: a4411a48ec1b2b9d9957bd28b62085ba
-2026/04/12 02:25:32 SSEHub: registered connection a4411a48ec1b2b9d9957bd28b62085ba (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection a4411a48ec1b2b9d9957bd28b62085ba (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f87276c0
-2026/04/12 02:25:32 Cleaning up writer...
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b925b18a10
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: d7a820dfe19cf32342edc84f73a7fb30
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: fc594e528833c6d105721ecd1f1b0bfd
+2026/04/12 18:12:53 SSEHub: registered connection fc594e528833c6d105721ecd1f1b0bfd (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection fc594e528833c6d105721ecd1f1b0bfd (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b9256beaf0
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b9256beaf0
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: fc594e528833c6d105721ecd1f1b0bfd
 
 === Running scenario: resources-read-text ===
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f87276c0
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: a4411a48ec1b2b9d9957bd28b62085ba
 Running client scenario 'resources-read-text' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: e14782edde27bef2e6df8519c0400bbd
-2026/04/12 02:25:32 SSEHub: registered connection e14782edde27bef2e6df8519c0400bbd (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection e14782edde27bef2e6df8519c0400bbd (total: 0)
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: b236e01dc7bc839c09430bf653789d1b
+2026/04/12 18:12:53 SSEHub: registered connection b236e01dc7bc839c09430bf653789d1b (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection b236e01dc7bc839c09430bf653789d1b (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b925a2f0a0
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b925a2f0a0
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: b236e01dc7bc839c09430bf653789d1b
 
 === Running scenario: resources-read-binary ===
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8bbfa40
 Running client scenario 'resources-read-binary' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Cleaning up writer...
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8bbfa40
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: e14782edde27bef2e6df8519c0400bbd
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: 5db8ff0c5c4b43fb93362cf2e3ba64d3
-2026/04/12 02:25:32 SSEHub: registered connection 5db8ff0c5c4b43fb93362cf2e3ba64d3 (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection 5db8ff0c5c4b43fb93362cf2e3ba64d3 (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8916230
-2026/04/12 02:25:32 Cleaning up writer...
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8916230
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: 5db8ff0c5c4b43fb93362cf2e3ba64d3
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: a1ff56eabb6f40a66441f85e5344d3db
+2026/04/12 18:12:53 SSEHub: registered connection a1ff56eabb6f40a66441f85e5344d3db (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection a1ff56eabb6f40a66441f85e5344d3db (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b9255f4a10
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b9255f4a10
 
 === Running scenario: resources-templates-read ===
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: a1ff56eabb6f40a66441f85e5344d3db
 Running client scenario 'resources-templates-read' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: 7b3e5e89439db21dfce24add99a77ada
-2026/04/12 02:25:32 SSEHub: registered connection 7b3e5e89439db21dfce24add99a77ada (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection 7b3e5e89439db21dfce24add99a77ada (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8daee00
-2026/04/12 02:25:32 Cleaning up writer...
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8daee00
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: 7b3e5e89439db21dfce24add99a77ada
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: bc03a05ef2f1699a2d26d13c37dc18a9
+2026/04/12 18:12:53 SSEHub: registered connection bc03a05ef2f1699a2d26d13c37dc18a9 (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection bc03a05ef2f1699a2d26d13c37dc18a9 (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b9255f4cb0
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b9255f4cb0
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: bc03a05ef2f1699a2d26d13c37dc18a9
 
 === Running scenario: resources-subscribe ===
 Running client scenario 'resources-subscribe' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: 33840f12f06ad121d6f5648e62a90029
-2026/04/12 02:25:32 SSEHub: registered connection 33840f12f06ad121d6f5648e62a90029 (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection 33840f12f06ad121d6f5648e62a90029 (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f89164d0
-2026/04/12 02:25:32 Cleaning up writer...
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f89164d0
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: 33840f12f06ad121d6f5648e62a90029
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: b97effad7c3e4c9e9e466555ebebb94b
+2026/04/12 18:12:53 SSEHub: registered connection b97effad7c3e4c9e9e466555ebebb94b (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection b97effad7c3e4c9e9e466555ebebb94b (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b9255f4fc0
 
 === Running scenario: resources-unsubscribe ===
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b9255f4fc0
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: b97effad7c3e4c9e9e466555ebebb94b
 Running client scenario 'resources-unsubscribe' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: 3ba20314631323a049f8a6b511f68e4b
-2026/04/12 02:25:32 SSEHub: registered connection 3ba20314631323a049f8a6b511f68e4b (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection 3ba20314631323a049f8a6b511f68e4b (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8916700
-2026/04/12 02:25:32 Cleaning up writer...
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8916700
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: 3ba20314631323a049f8a6b511f68e4b
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: 0a1389f8b8564ab775759bf596cc8c90
+2026/04/12 18:12:53 SSEHub: registered connection 0a1389f8b8564ab775759bf596cc8c90 (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection 0a1389f8b8564ab775759bf596cc8c90 (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b925a2f3b0
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b925a2f3b0
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: 0a1389f8b8564ab775759bf596cc8c90
 
 === Running scenario: prompts-list ===
 Running client scenario 'prompts-list' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: aafce81c0339912478343e72bb1d64ab
-2026/04/12 02:25:32 SSEHub: registered connection aafce81c0339912478343e72bb1d64ab (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection aafce81c0339912478343e72bb1d64ab (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8daf180
-2026/04/12 02:25:32 Cleaning up writer...
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8daf180
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: bbb5647ebb2c4c437df51caea38906f0
+2026/04/12 18:12:53 SSEHub: registered connection bbb5647ebb2c4c437df51caea38906f0 (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection bbb5647ebb2c4c437df51caea38906f0 (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b9256bee70
 
 === Running scenario: prompts-get-simple ===
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: aafce81c0339912478343e72bb1d64ab
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b9256bee70
 Running client scenario 'prompts-get-simple' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: 40285a1207c031224355c6f1ec33b267
-2026/04/12 02:25:32 SSEHub: registered connection 40285a1207c031224355c6f1ec33b267 (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection 40285a1207c031224355c6f1ec33b267 (total: 0)
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8916a80
-2026/04/12 02:25:32 Cleaning up writer...
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: bbb5647ebb2c4c437df51caea38906f0
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: 546c7e3451205c0c7d5b90279a1c0800
+2026/04/12 18:12:53 SSEHub: registered connection 546c7e3451205c0c7d5b90279a1c0800 (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection 546c7e3451205c0c7d5b90279a1c0800 (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b9256bf110
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b9256bf110
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: 546c7e3451205c0c7d5b90279a1c0800
 
 === Running scenario: prompts-get-with-args ===
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8916a80
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: 40285a1207c031224355c6f1ec33b267
 Running client scenario 'prompts-get-with-args' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: 627f6b60008857bb87fc3bfc69746ed8
-2026/04/12 02:25:32 SSEHub: registered connection 627f6b60008857bb87fc3bfc69746ed8 (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection 627f6b60008857bb87fc3bfc69746ed8 (total: 0)
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: 2a4649604eed2ce327e1e45db5189a03
+2026/04/12 18:12:53 SSEHub: registered connection 2a4649604eed2ce327e1e45db5189a03 (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection 2a4649604eed2ce327e1e45db5189a03 (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b9256bf420
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b9256bf420
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: 2a4649604eed2ce327e1e45db5189a03
 
 === Running scenario: prompts-get-embedded-resource ===
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8bbff10
-2026/04/12 02:25:32 Cleaning up writer...
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8bbff10
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: 627f6b60008857bb87fc3bfc69746ed8
 Running client scenario 'prompts-get-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: 16ff5640166a40ba4bf10822520dd9c4
-2026/04/12 02:25:32 SSEHub: registered connection 16ff5640166a40ba4bf10822520dd9c4 (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection 16ff5640166a40ba4bf10822520dd9c4 (total: 0)
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: 2019a48d986d50c4ba17b75a3d725e8f
+2026/04/12 18:12:53 SSEHub: registered connection 2019a48d986d50c4ba17b75a3d725e8f (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection 2019a48d986d50c4ba17b75a3d725e8f (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b9256bf650
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b9256bf650
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: 2019a48d986d50c4ba17b75a3d725e8f
 
 === Running scenario: prompts-get-with-image ===
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8916d20
-2026/04/12 02:25:32 Cleaning up writer...
 Running client scenario 'prompts-get-with-image' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8916d20
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: 16ff5640166a40ba4bf10822520dd9c4
-2026/04/12 02:25:32 Starting MCP-GET-SSE SSE connection: 2840f66c143fb7b8d91cd516e900ffc5
-2026/04/12 02:25:32 SSEHub: registered connection 2840f66c143fb7b8d91cd516e900ffc5 (total: 1)
-2026/04/12 02:25:32 SSEHub: unregistered connection 2840f66c143fb7b8d91cd516e900ffc5 (total: 0)
+2026/04/12 18:12:53 Starting MCP-GET-SSE SSE connection: 3d20df3d693b7c594f9208847259e0b6
+2026/04/12 18:12:53 SSEHub: registered connection 3d20df3d693b7c594f9208847259e0b6 (total: 1)
+2026/04/12 18:12:53 SSEHub: unregistered connection 3d20df3d693b7c594f9208847259e0b6 (total: 0)
+2026/04/12 18:12:53 Received kill signal.  Quitting Writer. stop 0x11b9256bf880
+2026/04/12 18:12:53 Cleaning up writer...
+2026/04/12 18:12:53 Finished cleaning up writer:  0x11b9256bf880
+2026/04/12 18:12:53 Closed MCP-GET-SSE SSE connection: 3d20df3d693b7c594f9208847259e0b6
 
 === Running scenario: dns-rebinding-protection ===
-2026/04/12 02:25:32 Received kill signal.  Quitting Writer. stop 0x5ef1f8b662a0
 Running client scenario 'dns-rebinding-protection' against server: http://localhost:18799/mcp
-2026/04/12 02:25:32 Cleaning up writer...
-2026/04/12 02:25:32 Finished cleaning up writer:  0x5ef1f8b662a0
-2026/04/12 02:25:32 Closed MCP-GET-SSE SSE connection: 2840f66c143fb7b8d91cd516e900ffc5
 
 
 === SUMMARY ===
@@ -391,22 +391,22 @@ Starting scenario: auth/token-endpoint-auth-basic
 Starting scenario: auth/token-endpoint-auth-post
 Starting scenario: auth/token-endpoint-auth-none
 Starting scenario: auth/pre-registration
-Executing client: ./bin/testclient http://localhost:51591/mcp
-Executing client: ./bin/testclient http://localhost:51592/mcp
-Executing client: ./bin/testclient http://localhost:51593/mcp
-Executing client: ./bin/testclient http://localhost:51594/mcp
-Executing client: ./bin/testclient http://localhost:51595/mcp
-Executing client: ./bin/testclient http://localhost:51596/mcp
-Executing client: ./bin/testclient http://localhost:51597/mcp
-Executing client: ./bin/testclient http://localhost:51598/mcp
-Executing client: ./bin/testclient http://localhost:51599/mcp
-Executing client: ./bin/testclient http://localhost:51600/mcp
-Executing client: ./bin/testclient http://localhost:51601/mcp
-Executing client: ./bin/testclient http://localhost:51602/mcp
-Executing client: ./bin/testclient http://localhost:51603/mcp
-Executing client: ./bin/testclient http://localhost:51604/mcp
+Executing client: ./bin/testclient http://localhost:58366/mcp
+Executing client: ./bin/testclient http://localhost:58367/mcp
+Executing client: ./bin/testclient http://localhost:58368/mcp
+Executing client: ./bin/testclient http://localhost:58369/mcp
+Executing client: ./bin/testclient http://localhost:58370/mcp
+Executing client: ./bin/testclient http://localhost:58371/mcp
+Executing client: ./bin/testclient http://localhost:58372/mcp
+Executing client: ./bin/testclient http://localhost:58373/mcp
+Executing client: ./bin/testclient http://localhost:58374/mcp
+Executing client: ./bin/testclient http://localhost:58375/mcp
+Executing client: ./bin/testclient http://localhost:58376/mcp
+Executing client: ./bin/testclient http://localhost:58377/mcp
+Executing client: ./bin/testclient http://localhost:58378/mcp
+Executing client: ./bin/testclient http://localhost:58379/mcp
 With context: {"client_id":"pre-registered-client","client_secret":"pre-registered-secret"}
-(node:27867) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
+(node:62343) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
 (Use `node --trace-deprecation ...` to show where the warning was created)
 
 === SUITE SUMMARY ===
@@ -449,10 +449,10 @@ Total: 210 passed, 0 failed, 1 warnings
 === RUN   TestKeycloak_MCPServer_WWWAuthenticate
 --- PASS: TestKeycloak_MCPServer_WWWAuthenticate (0.01s)
 === RUN   TestKeycloak_MCPServer_PasswordGrant
---- PASS: TestKeycloak_MCPServer_PasswordGrant (0.05s)
+--- PASS: TestKeycloak_MCPServer_PasswordGrant (0.06s)
 PASS
-ok  	github.com/panyam/mcpkit/tests/keycloak	0.759s
+ok  	github.com/panyam/mcpkit/tests/keycloak	0.782s
   PASS: keycloak
 
 === Results: 8 passed, 0 failed ===
-Finished: Sun Apr 12 02:25:36 PDT 2026
+Finished: Sun Apr 12 18:12:57 PDT 2026


### PR DESCRIPTION
Closes #199.

## Problem

SSE transport (\`mcpSSEConn.OnStart\`) and Streamable HTTP (\`streamableSSEConn.OnStart\`) contained ~30 lines of near-identical code wiring three things onto each session's dispatcher:

1. \`SetNotifyFunc\` — marshal notification → emitSSEEvent → hub
2. \`SetPushRequest\` — write raw JSON-RPC → emitSSEEvent → hub (same pipeline)
3. \`sessionKeepalive\` — interval, maxFailures, requestFunc, onDeath, onPingFail

The only differences: variable names (\`dispatcher\` vs \`c.dispatcher\`), the \`onDeath\` callback (\`closeSession\` vs \`expireSession\`), and a guard on keepalive start.

## Fix

New \`server/session_wiring.go\` (~90 LOC) extracts the shared pattern:

\`\`\`go
type sseWiring struct {
    dispatcher *Dispatcher
    hub        *gohttp.SSEHub[SSEData]
    sessionID  string
    store      gohttp.EventStore
    cfg        transportConfig
    onDeath    func()
    onPingFail func(int)
}

func (w *sseWiring) wire() (pushFunc func(json.RawMessage), keepalive *sessionKeepalive)
\`\`\`

Each transport's \`OnStart\` now constructs an \`sseWiring\` struct and calls \`wire()\` — ~10 lines instead of ~30.

### What's NOT refactored

**Stdio and in-process transports** stay as-is. Their I/O shapes are genuinely different:
- Stdio uses \`writeFrameLocked\` (Content-Length framed stdout, optional logger)
- In-process uses synchronous function calls + \`RouteResponse\`

Forcing them into the same abstraction would add indirection without reducing code.

## Verification

This is a pure refactor — no behavior change, no new API, no new server options. The existing test suite IS the test suite:

| Suite | Result | What it covers |
|---|---|---|
| \`make test\` (200+ tests) | Green | Transport wiring, notify delivery, push-request routing |
| \`make test-race\` | Green | Closure capture concurrency (same goroutine structure) |
| \`make test-e2e\` | Green | Full client → transport → dispatch pipeline |
| \`make testconf\` | Running | 40/40 MCP conformance (SSE + Streamable HTTP scenarios) |

No new tests added — the refactor replaces identical code with a shared call. Adding a test for "the helper produces the same closures" would test implementation, not behavior.

## Diff stats

\`\`\`
 server/session_wiring.go       | 93 ++++++++ (new)
 server/streamable_transport.go | 55 ++---  (-30 lines)
 server/transport.go            | 49 ++--- (-25 lines)
 3 files changed, 122 insertions(+), 75 deletions(-)
\`\`\`

Net: +47 LOC (the helper + doc comments are longer than the raw duplicated code, but the two call sites each shrank by ~25 lines and the helper is the single source of truth going forward).