### PR TITLE
feat(ext/ui): display modes, template resources, app elicitation (#185, #190, #191)

### DIFF
--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -59,7 +59,10 @@
 - mcp-apps-visibility: Tool visibility filtering — UIVisibilityModel/UIVisibilityApp, client-side ListToolsForModel() excludes app-only tools
 - mcp-apps-ref-validation: RefValidator interface — extensions validate tool-to-resource references at server startup
 - mcp-apps-resource-notification: NotifyResourcesChanged(ctx) — tool handlers signal resource list changes to clients
-- mcp-apps-register-helper: RegisterAppTool (ext/ui) — registers tool + resource pair in one call via ToolResourceRegistrar interface
+- mcp-apps-register-helper: RegisterAppTool (ext/ui) — registers tool + resource pair in one call via ToolResourceRegistrar interface. Auto-detects template URIs (containing `{`) and routes to RegisterResourceTemplate; concrete URIs use RegisterResource.
+- mcp-apps-display-modes: UIMetadata.SupportedDisplayModes — apps declare inline/fullscreen/pip support. RequestDisplayMode(ctx, mode) emits notifications/ui/displayMode. (#185)
+- mcp-apps-template-resources: RegisterAppTool auto-detects template URIs and registers resource templates. TemplateHandler field on AppToolConfig for parameterized HTML serving (SSR). (#190)
+- mcp-apps-elicitation-meta: ElicitationRequest._meta.ui and CreateMessageRequest._meta.ui — app metadata on server-to-client requests. ElicitWithApp/SampleWithApp helpers in ext/ui. (#191)
 - mcp-apps-conformance: 21 MCP Apps conformance tests (tool metadata, resources, visibility, fallback, negotiation)
 - mcp-dynamic-registration: Registry.AddTool/RemoveTool/AddResource/RemoveResource/AddPrompt/RemovePrompt — thread-safe runtime registration with automatic notifications/*/list_changed broadcast via OnChange callback
 - mcp-session-timeout: WithSessionTimeout — idle session cleanup for Streamable HTTP (timer + ref counting to avoid closing mid-execution)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ mcpkit/
 │   ├── request.go             RequestFunc, ErrNoRequestFunc
 │   ├── protocol.go            ServerInfo, ClientInfo, ClientCapabilities, ServerCapabilities, ToolsCap, ResourcesCap, PromptsCap, InitializeResult, ExtensionCapability
 │   ├── interfaces.go          Transport, ServerRequestHandler, NotificationHandler
-│   ├── ui.go                  UIMetadata, UICSPConfig, UIVisibility, AppMIMEType, ToolMeta, ResourceContentMeta
+│   ├── ui.go                  UIMetadata, UICSPConfig, UIVisibility, DisplayMode, AppMIMEType, ToolMeta, ResourceContentMeta
 │   └── www_authenticate.go    ParseWWWAuthenticate
 │
 ├── server/                  ← Server + Dispatcher + transports
@@ -82,7 +82,7 @@ mcpkit/
 │         mergeScopes → core.UnionScopes. Type aliases preserved for compat.
 │
 ├── ext/ui/                 ← Separate Go module (ext/ui/go.mod)
-│   └── extension.go          UIExtension (ExtensionProvider + RefValidator), RegisterAppTool, AppToolConfig
+│   └── extension.go          UIExtension (ExtensionProvider + RefValidator), RegisterAppTool, AppToolConfig, RequestDisplayMode, ElicitWithApp, SampleWithApp
 │
 ├── testutil/                ← Test helpers (NewTestServer, ForAllTransports, TestClient)
 ├── cmd/testserver/          ← Conformance test server
@@ -276,9 +276,11 @@ mcpkit/
 - **Server-side detection**: `core.ClientSupportsUI(ctx)` in tool handlers checks if client declared UI extension support.
 - **Client-side detection**: `client.ServerSupportsUI()` checks if server advertised the extension.
 - **`NotifyResourcesChanged(ctx)`** — call from tool handlers after mutating state so clients know to re-fetch resources.
-- **`RegisterAppTool`** lives in `ext/ui/`, takes a `ToolResourceRegistrar` interface (not `*server.Server`) to avoid cross-module import.
+- **`RegisterAppTool`** lives in `ext/ui/`, takes a `ToolResourceRegistrar` interface (not `*server.Server`) to avoid cross-module import. Auto-detects template URIs (containing `{`) and routes to `RegisterResourceTemplate` instead of `RegisterResource`. Template URIs require `TemplateHandler` in `AppToolConfig` (panics if nil).
 - **`RefValidator`** interface on `ExtensionProvider` — `UIExtension` validates `_meta.ui.resourceUri` refs at `Handler()` startup. Warnings only, no errors.
 - **`PrefersBorder`** is `*bool` tri-state: nil (host decides), true (border), false (no border).
+- **Display mode negotiation (#185)**: `UIMetadata.SupportedDisplayModes []DisplayMode` declares which modes an app supports (`inline`, `fullscreen`, `pip`). `ui.RequestDisplayMode(ctx, mode)` sends `notifications/ui/displayMode` to request the host change display. Fire-and-forget; host may ignore.
+- **App metadata on elicitation/sampling (#191)**: `ElicitationRequest.Meta *ElicitationMeta` and `CreateMessageRequest.Meta *SamplingMeta` carry `_meta.ui` on the wire. `ui.ElicitWithApp(ctx, req, uiMeta)` and `ui.SampleWithApp(ctx, req, uiMeta)` are convenience wrappers.
 - **`ListToolsForModel()`** is client-side filtering — server always returns all tools including app-only. Visibility is a presentation hint, not access control.
 - **Playwright tests**: `make test-apps-playwright` runs the upstream ext-apps Playwright suite against our testserver. Not in `testall` — run manually when needed.
 - **Design doc**: see `docs/APPS_DESIGN.md` for full architecture, protocol flows, and conformance strategy.

--- a/cmd/testserver/conformance_apps.go
+++ b/cmd/testserver/conformance_apps.go
@@ -45,8 +45,9 @@ func registerConformanceApps(srv *server.Server) {
 					CSP: &core.UICSPConfig{
 						ResourceDomains: []string{"cdn.example.com"},
 					},
-					Permissions:   []string{"clipboard-write"},
-					PrefersBorder: &border,
+					Permissions:           []string{"clipboard-write"},
+					PrefersBorder:         &border,
+					SupportedDisplayModes: []core.DisplayMode{core.DisplayModeInline, core.DisplayModeFullscreen},
 				},
 			},
 		},
@@ -115,6 +116,57 @@ func registerConformanceApps(srv *server.Server) {
 		func(ctx context.Context, req core.ToolRequest) (core.ToolResult, error) {
 			core.NotifyResourcesChanged(ctx)
 			return core.TextResult("Dashboard mutated"), nil
+		},
+	)
+
+	// request-fullscreen: requests display mode change via notification
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "request-fullscreen",
+			Description: "Requests fullscreen display mode",
+			InputSchema: map[string]any{"type": "object"},
+			Meta: &core.ToolMeta{
+				UI: &core.UIMetadata{
+					ResourceUri:           "ui://dashboard/view",
+					Visibility:            []core.UIVisibility{core.UIVisibilityApp},
+					SupportedDisplayModes: []core.DisplayMode{core.DisplayModeInline, core.DisplayModeFullscreen},
+				},
+			},
+		},
+		func(ctx context.Context, req core.ToolRequest) (core.ToolResult, error) {
+			core.Notify(ctx, "notifications/ui/displayMode", map[string]any{
+				"displayMode": core.DisplayModeFullscreen,
+			})
+			return core.TextResult("Fullscreen requested"), nil
+		},
+	)
+
+	// elicit-with-ui: demonstrates app-backed elicitation with _meta.ui
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "elicit-with-ui",
+			Description: "Elicits input using an MCP App UI",
+			InputSchema: map[string]any{"type": "object"},
+			Meta: &core.ToolMeta{
+				UI: &core.UIMetadata{
+					ResourceUri: "ui://dashboard/view",
+					Visibility:  []core.UIVisibility{core.UIVisibilityModel, core.UIVisibilityApp},
+				},
+			},
+		},
+		func(ctx context.Context, req core.ToolRequest) (core.ToolResult, error) {
+			result, err := core.Elicit(ctx, core.ElicitationRequest{
+				Message: "Choose a dashboard widget",
+				Meta: &core.ElicitationMeta{
+					UI: &core.UIMetadata{
+						ResourceUri: "ui://dashboard/view",
+					},
+				},
+			})
+			if err != nil {
+				return core.ErrorResult(err.Error()), nil
+			}
+			return core.TextResult(fmt.Sprintf("Action: %s", result.Action)), nil
 		},
 	)
 

--- a/core/elicitation.go
+++ b/core/elicitation.go
@@ -9,11 +9,21 @@ import (
 // Sentinel errors for elicitation.
 var ErrElicitationNotSupported = errors.New("client does not support elicitation")
 
+// ElicitationMeta holds protocol-level metadata for an elicitation request.
+// Serialized as "_meta" in the elicitation/create params.
+type ElicitationMeta struct {
+	// UI contains MCP Apps presentation metadata.
+	// When set, the host can render a UI resource during input collection
+	// instead of falling back to the default schema-driven form.
+	UI *UIMetadata `json:"ui,omitempty"`
+}
+
 // ElicitationRequest is the params for an elicitation/create server-to-client request.
 // The server sends this to ask the client to collect structured user input.
 type ElicitationRequest struct {
-	Message         string          `json:"message"`
-	RequestedSchema json.RawMessage `json:"requestedSchema,omitempty"`
+	Message         string           `json:"message"`
+	RequestedSchema json.RawMessage  `json:"requestedSchema,omitempty"`
+	Meta            *ElicitationMeta `json:"_meta,omitempty"`
 }
 
 // ElicitationResult is the client's response to an elicitation/create request.

--- a/core/elicitation_test.go
+++ b/core/elicitation_test.go
@@ -1,0 +1,64 @@
+package core
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestElicitationRequestMetaSerialization verifies that ElicitationRequest
+// serializes _meta.ui correctly: present when Meta is set, absent when nil.
+func TestElicitationRequestMetaSerialization(t *testing.T) {
+	t.Run("with meta", func(t *testing.T) {
+		req := ElicitationRequest{
+			Message:         "Which pizza?",
+			RequestedSchema: json.RawMessage(`{"type":"object"}`),
+			Meta: &ElicitationMeta{
+				UI: &UIMetadata{ResourceUri: "ui://pizzas/picker"},
+			},
+		}
+
+		data, err := json.Marshal(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(data, &raw); err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := raw["_meta"]; !ok {
+			t.Fatal("expected _meta key in JSON output")
+		}
+
+		// Round-trip
+		var got ElicitationRequest
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatal(err)
+		}
+		if got.Meta == nil || got.Meta.UI == nil {
+			t.Fatal("Meta or Meta.UI is nil after round-trip")
+		}
+		if got.Meta.UI.ResourceUri != "ui://pizzas/picker" {
+			t.Errorf("ResourceUri = %q, want %q", got.Meta.UI.ResourceUri, "ui://pizzas/picker")
+		}
+	})
+
+	t.Run("nil meta omitted", func(t *testing.T) {
+		req := ElicitationRequest{
+			Message: "Pick one",
+		}
+
+		data, err := json.Marshal(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(data, &raw); err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := raw["_meta"]; ok {
+			t.Errorf("_meta should be absent when Meta is nil, got %s", raw["_meta"])
+		}
+	})
+}

--- a/core/sampling.go
+++ b/core/sampling.go
@@ -46,6 +46,14 @@ type ModelPreferences struct {
 	IntelligencePriority *float64   `json:"intelligencePriority,omitempty"`
 }
 
+// SamplingMeta holds protocol-level metadata for a sampling request.
+// Serialized as "_meta" in the sampling/createMessage params.
+type SamplingMeta struct {
+	// UI contains MCP Apps presentation metadata.
+	// When set, the host can associate the sampling request with a UI resource.
+	UI *UIMetadata `json:"ui,omitempty"`
+}
+
 // CreateMessageRequest is the params for a sampling/createMessage server-to-client request.
 // The server sends this to ask the client to perform LLM inference.
 type CreateMessageRequest struct {
@@ -57,6 +65,7 @@ type CreateMessageRequest struct {
 	ModelPreferences *ModelPreferences `json:"modelPreferences,omitempty"`
 	StopSequences    []string          `json:"stopSequences,omitempty"`
 	Metadata         map[string]any    `json:"metadata,omitempty"`
+	Meta             *SamplingMeta     `json:"_meta,omitempty"`
 }
 
 // CreateMessageResult is the client's response to a sampling/createMessage request.

--- a/core/sampling_test.go
+++ b/core/sampling_test.go
@@ -1,0 +1,65 @@
+package core
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestCreateMessageRequestMetaSerialization verifies that CreateMessageRequest
+// serializes _meta.ui correctly: present when Meta is set, absent when nil.
+func TestCreateMessageRequestMetaSerialization(t *testing.T) {
+	t.Run("with meta", func(t *testing.T) {
+		req := CreateMessageRequest{
+			Messages:  []SamplingMessage{{Role: "user", Content: Content{Type: "text", Text: "hello"}}},
+			MaxTokens: 100,
+			Meta: &SamplingMeta{
+				UI: &UIMetadata{ResourceUri: "ui://dashboard/view"},
+			},
+		}
+
+		data, err := json.Marshal(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(data, &raw); err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := raw["_meta"]; !ok {
+			t.Fatal("expected _meta key in JSON output")
+		}
+
+		// Round-trip
+		var got CreateMessageRequest
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatal(err)
+		}
+		if got.Meta == nil || got.Meta.UI == nil {
+			t.Fatal("Meta or Meta.UI is nil after round-trip")
+		}
+		if got.Meta.UI.ResourceUri != "ui://dashboard/view" {
+			t.Errorf("ResourceUri = %q, want %q", got.Meta.UI.ResourceUri, "ui://dashboard/view")
+		}
+	})
+
+	t.Run("nil meta omitted", func(t *testing.T) {
+		req := CreateMessageRequest{
+			Messages:  []SamplingMessage{{Role: "user", Content: Content{Type: "text", Text: "hi"}}},
+			MaxTokens: 50,
+		}
+
+		data, err := json.Marshal(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(data, &raw); err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := raw["_meta"]; ok {
+			t.Errorf("_meta should be absent when Meta is nil, got %s", raw["_meta"])
+		}
+	})
+}

--- a/core/ui.go
+++ b/core/ui.go
@@ -40,6 +40,10 @@ type UIMetadata struct {
 	// Domain requests a dedicated sandbox origin for the app.
 	// Format is host-dependent (e.g., "myapp" → myapp.claudemcpcontent.com).
 	Domain string `json:"domain,omitempty"`
+
+	// SupportedDisplayModes declares which display modes this app can render in.
+	// Nil means the host decides. Hosts use this to offer mode switching UI.
+	SupportedDisplayModes []DisplayMode `json:"supportedDisplayModes,omitempty"`
 }
 
 // UICSPConfig declares external domains for Content-Security-Policy construction.
@@ -67,6 +71,20 @@ const (
 
 	// UIVisibilityApp means the tool is callable by apps from the same server.
 	UIVisibilityApp UIVisibility = "app"
+)
+
+// DisplayMode represents an iframe display mode for MCP Apps.
+type DisplayMode string
+
+const (
+	// DisplayModeInline renders the app inline within the host UI.
+	DisplayModeInline DisplayMode = "inline"
+
+	// DisplayModeFullscreen renders the app in a fullscreen overlay.
+	DisplayModeFullscreen DisplayMode = "fullscreen"
+
+	// DisplayModePIP renders the app in a picture-in-picture window.
+	DisplayModePIP DisplayMode = "pip"
 )
 
 // AppMIMEType is the MIME type for MCP App HTML resources.

--- a/core/ui_test.go
+++ b/core/ui_test.go
@@ -219,7 +219,7 @@ func TestUIMetadataOmitEmpty(t *testing.T) {
 	if _, ok := raw["resourceUri"]; !ok {
 		t.Error("resourceUri should be present")
 	}
-	for _, key := range []string{"visibility", "csp", "permissions", "prefersBorder", "domain"} {
+	for _, key := range []string{"visibility", "csp", "permissions", "prefersBorder", "domain", "supportedDisplayModes"} {
 		if _, ok := raw[key]; ok {
 			t.Errorf("key %q should be omitted for zero value, got %s", key, raw[key])
 		}
@@ -379,6 +379,67 @@ func TestClientSupportsUI(t *testing.T) {
 func TestUIExtensionIDConstant(t *testing.T) {
 	if UIExtensionID != "io.modelcontextprotocol/ui" {
 		t.Errorf("UIExtensionID = %q, want %q", UIExtensionID, "io.modelcontextprotocol/ui")
+	}
+}
+
+// TestDisplayModeConstants verifies the wire values of DisplayMode constants.
+func TestDisplayModeConstants(t *testing.T) {
+	if DisplayModeInline != "inline" {
+		t.Errorf("DisplayModeInline = %q, want %q", DisplayModeInline, "inline")
+	}
+	if DisplayModeFullscreen != "fullscreen" {
+		t.Errorf("DisplayModeFullscreen = %q, want %q", DisplayModeFullscreen, "fullscreen")
+	}
+	if DisplayModePIP != "pip" {
+		t.Errorf("DisplayModePIP = %q, want %q", DisplayModePIP, "pip")
+	}
+}
+
+// TestUIMetadataDisplayModesRoundTrip verifies that SupportedDisplayModes
+// survives a JSON round-trip on UIMetadata.
+func TestUIMetadataDisplayModesRoundTrip(t *testing.T) {
+	original := UIMetadata{
+		ResourceUri:           "ui://app/view",
+		SupportedDisplayModes: []DisplayMode{DisplayModeInline, DisplayModeFullscreen},
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got UIMetadata
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(got.SupportedDisplayModes) != 2 {
+		t.Fatalf("SupportedDisplayModes length = %d, want 2", len(got.SupportedDisplayModes))
+	}
+	if got.SupportedDisplayModes[0] != DisplayModeInline {
+		t.Errorf("[0] = %q, want %q", got.SupportedDisplayModes[0], DisplayModeInline)
+	}
+	if got.SupportedDisplayModes[1] != DisplayModeFullscreen {
+		t.Errorf("[1] = %q, want %q", got.SupportedDisplayModes[1], DisplayModeFullscreen)
+	}
+}
+
+// TestUIMetadataDisplayModesOmitEmpty verifies that SupportedDisplayModes
+// is omitted from JSON when nil.
+func TestUIMetadataDisplayModesOmitEmpty(t *testing.T) {
+	meta := UIMetadata{ResourceUri: "ui://minimal"}
+
+	data, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := raw["supportedDisplayModes"]; ok {
+		t.Errorf("supportedDisplayModes should be omitted when nil, got %s", raw["supportedDisplayModes"])
 	}
 }
 

--- a/ext/ui/app_helpers_test.go
+++ b/ext/ui/app_helpers_test.go
@@ -121,10 +121,11 @@ func TestValidateRefsNoMetaSkipped(t *testing.T) {
 	}
 }
 
-// mockRegistrar captures RegisterTool and RegisterResource calls for testing.
+// mockRegistrar captures RegisterTool, RegisterResource, and RegisterResourceTemplate calls for testing.
 type mockRegistrar struct {
 	tools     []core.ToolDef
 	resources []core.ResourceDef
+	templates []core.ResourceTemplate
 }
 
 func (m *mockRegistrar) RegisterTool(def core.ToolDef, _ core.ToolHandler) {
@@ -133,4 +134,107 @@ func (m *mockRegistrar) RegisterTool(def core.ToolDef, _ core.ToolHandler) {
 
 func (m *mockRegistrar) RegisterResource(def core.ResourceDef, _ core.ResourceHandler) {
 	m.resources = append(m.resources, def)
+}
+
+func (m *mockRegistrar) RegisterResourceTemplate(def core.ResourceTemplate, _ core.TemplateHandler) {
+	m.templates = append(m.templates, def)
+}
+
+// TestRegisterAppToolTemplate verifies that RegisterAppTool detects a template
+// URI (contains "{") and routes registration to RegisterResourceTemplate instead
+// of RegisterResource.
+func TestRegisterAppToolTemplate(t *testing.T) {
+	reg := &mockRegistrar{}
+
+	RegisterAppTool(reg, AppToolConfig{
+		Name:        "show_pizza",
+		Description: "Show a pizza",
+		InputSchema: map[string]any{"type": "object"},
+		ResourceURI: "ui://pizzas/{pizzaId}/details",
+		ToolHandler: func(ctx context.Context, req core.ToolRequest) (core.ToolResult, error) {
+			return core.TextResult("ok"), nil
+		},
+		TemplateHandler: func(ctx context.Context, uri string, params map[string]string) (core.ResourceResult, error) {
+			return core.ResourceResult{}, nil
+		},
+	})
+
+	if len(reg.templates) != 1 {
+		t.Fatalf("expected 1 template, got %d", len(reg.templates))
+	}
+	if len(reg.resources) != 0 {
+		t.Errorf("expected 0 resources, got %d", len(reg.resources))
+	}
+	tmpl := reg.templates[0]
+	if tmpl.URITemplate != "ui://pizzas/{pizzaId}/details" {
+		t.Errorf("URITemplate = %q, want %q", tmpl.URITemplate, "ui://pizzas/{pizzaId}/details")
+	}
+	if tmpl.MimeType != core.AppMIMEType {
+		t.Errorf("MimeType = %q, want %q", tmpl.MimeType, core.AppMIMEType)
+	}
+
+	// Tool should still have the correct _meta.ui.resourceUri
+	if len(reg.tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(reg.tools))
+	}
+	if reg.tools[0].Meta == nil || reg.tools[0].Meta.UI == nil {
+		t.Fatal("tool Meta.UI is nil")
+	}
+	if reg.tools[0].Meta.UI.ResourceUri != "ui://pizzas/{pizzaId}/details" {
+		t.Errorf("resourceUri = %q, want template URI", reg.tools[0].Meta.UI.ResourceUri)
+	}
+}
+
+// TestRegisterAppToolTemplateNilHandlerPanics verifies that RegisterAppTool
+// panics when a template URI is used without a TemplateHandler.
+func TestRegisterAppToolTemplateNilHandlerPanics(t *testing.T) {
+	reg := &mockRegistrar{}
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic for template URI without TemplateHandler")
+		}
+	}()
+
+	RegisterAppTool(reg, AppToolConfig{
+		Name:        "bad_template",
+		ResourceURI: "ui://items/{id}/view",
+		ToolHandler: func(ctx context.Context, req core.ToolRequest) (core.ToolResult, error) {
+			return core.TextResult("ok"), nil
+		},
+		// TemplateHandler intentionally nil
+	})
+}
+
+// TestRegisterAppToolSupportedDisplayModes verifies that SupportedDisplayModes
+// flows through from AppToolConfig to the tool's _meta.ui.
+func TestRegisterAppToolSupportedDisplayModes(t *testing.T) {
+	reg := &mockRegistrar{}
+
+	RegisterAppTool(reg, AppToolConfig{
+		Name:        "dashboard",
+		ResourceURI: "ui://dashboard/view",
+		ToolHandler: func(ctx context.Context, req core.ToolRequest) (core.ToolResult, error) {
+			return core.TextResult("ok"), nil
+		},
+		ResourceHandler: func(ctx context.Context, req core.ResourceRequest) (core.ResourceResult, error) {
+			return core.ResourceResult{}, nil
+		},
+		SupportedDisplayModes: []core.DisplayMode{core.DisplayModeInline, core.DisplayModeFullscreen},
+	})
+
+	if len(reg.tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(reg.tools))
+	}
+	ui := reg.tools[0].Meta.UI
+	if len(ui.SupportedDisplayModes) != 2 {
+		t.Fatalf("SupportedDisplayModes length = %d, want 2", len(ui.SupportedDisplayModes))
+	}
+	if ui.SupportedDisplayModes[0] != core.DisplayModeInline {
+		t.Errorf("SupportedDisplayModes[0] = %q, want %q", ui.SupportedDisplayModes[0], core.DisplayModeInline)
+	}
+	if ui.SupportedDisplayModes[1] != core.DisplayModeFullscreen {
+		t.Errorf("SupportedDisplayModes[1] = %q, want %q", ui.SupportedDisplayModes[1], core.DisplayModeFullscreen)
+	}
 }

--- a/ext/ui/extension.go
+++ b/ext/ui/extension.go
@@ -14,6 +14,7 @@
 package ui
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -67,10 +68,11 @@ func (UIExtension) ValidateRefs(tools []core.ToolDef, resourceURIs []string, tem
 }
 
 // ToolResourceRegistrar is the interface needed by RegisterAppTool to register
-// tools and resources. Satisfied by *server.Server without importing it.
+// tools, resources, and resource templates. Satisfied by *server.Server without importing it.
 type ToolResourceRegistrar interface {
 	RegisterTool(def core.ToolDef, handler core.ToolHandler)
 	RegisterResource(def core.ResourceDef, handler core.ResourceHandler)
+	RegisterResourceTemplate(def core.ResourceTemplate, handler core.TemplateHandler)
 }
 
 // AppToolConfig configures a tool + resource pair for RegisterAppTool.
@@ -108,6 +110,16 @@ type AppToolConfig struct {
 
 	// Domain requests a dedicated sandbox origin for the app.
 	Domain string
+
+	// SupportedDisplayModes declares which display modes this app supports.
+	// Nil means the host decides.
+	SupportedDisplayModes []core.DisplayMode
+
+	// TemplateHandler serves HTML content for a ui:// resource template.
+	// Required when ResourceURI contains "{" (template variable).
+	// When set, RegisterAppTool registers a resource template instead of
+	// a concrete resource.
+	TemplateHandler core.TemplateHandler
 }
 
 // RegisterAppTool registers both a tool (with _meta.ui metadata) and its
@@ -126,12 +138,13 @@ type AppToolConfig struct {
 //	})
 func RegisterAppTool(reg ToolResourceRegistrar, cfg AppToolConfig) {
 	uiMeta := &core.UIMetadata{
-		ResourceUri:   cfg.ResourceURI,
-		Visibility:    cfg.Visibility,
-		CSP:           cfg.CSP,
-		Permissions:   cfg.Permissions,
-		PrefersBorder: cfg.PrefersBorder,
-		Domain:        cfg.Domain,
+		ResourceUri:           cfg.ResourceURI,
+		Visibility:            cfg.Visibility,
+		CSP:                   cfg.CSP,
+		Permissions:           cfg.Permissions,
+		PrefersBorder:         cfg.PrefersBorder,
+		Domain:                cfg.Domain,
+		SupportedDisplayModes: cfg.SupportedDisplayModes,
 	}
 
 	reg.RegisterTool(
@@ -144,14 +157,56 @@ func RegisterAppTool(reg ToolResourceRegistrar, cfg AppToolConfig) {
 		cfg.ToolHandler,
 	)
 
-	reg.RegisterResource(
-		core.ResourceDef{
-			URI:      cfg.ResourceURI,
-			Name:     cfg.Name + " UI",
-			MimeType: core.AppMIMEType,
-		},
-		cfg.ResourceHandler,
-	)
+	if strings.Contains(cfg.ResourceURI, "{") {
+		if cfg.TemplateHandler == nil {
+			panic("RegisterAppTool: template URI " + cfg.ResourceURI + " requires TemplateHandler, got nil")
+		}
+		reg.RegisterResourceTemplate(
+			core.ResourceTemplate{
+				URITemplate: cfg.ResourceURI,
+				Name:        cfg.Name + " UI",
+				MimeType:    core.AppMIMEType,
+			},
+			cfg.TemplateHandler,
+		)
+	} else {
+		reg.RegisterResource(
+			core.ResourceDef{
+				URI:      cfg.ResourceURI,
+				Name:     cfg.Name + " UI",
+				MimeType: core.AppMIMEType,
+			},
+			cfg.ResourceHandler,
+		)
+	}
+}
+
+// RequestDisplayMode sends a display mode change notification to the client.
+// Call this from a tool handler to request the host to change how the app
+// is displayed (e.g., switch from inline to fullscreen).
+//
+// The notification is fire-and-forget; the host may ignore it if the
+// requested mode is not supported.
+func RequestDisplayMode(ctx context.Context, mode core.DisplayMode) {
+	core.Notify(ctx, "notifications/ui/displayMode", map[string]any{
+		"displayMode": mode,
+	})
+}
+
+// ElicitWithApp sends an elicitation/create request with MCP Apps metadata.
+// This is a convenience wrapper around core.Elicit that populates _meta.ui
+// so the host can render a UI resource during input collection.
+func ElicitWithApp(ctx context.Context, req core.ElicitationRequest, ui *core.UIMetadata) (core.ElicitationResult, error) {
+	req.Meta = &core.ElicitationMeta{UI: ui}
+	return core.Elicit(ctx, req)
+}
+
+// SampleWithApp sends a sampling/createMessage request with MCP Apps metadata.
+// This is a convenience wrapper around core.Sample that populates _meta.ui
+// so the host can associate the sampling request with a UI resource.
+func SampleWithApp(ctx context.Context, req core.CreateMessageRequest, ui *core.UIMetadata) (core.CreateMessageResult, error) {
+	req.Meta = &core.SamplingMeta{UI: ui}
+	return core.Sample(ctx, req)
 }
 
 // matchesAnyTemplate checks if a URI matches any of the given URI templates.

--- a/tests/reports/report.html
+++ b/tests/reports/report.html
@@ -15,7 +15,7 @@ th { background: #f5f5f5; font-weight: 600; }
 pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto; font-size: 13px; max-height: 400px; overflow-y: auto; }
 </style></head><body>
 <h1>MCPKit Test Report</h1>
-<div class='meta'>Branch: <strong>feature/handler-notify-resource-updated-208</strong> | Commit: <code>f7b171a</code> | Date: 2026-04-13 10:07:51</div>
+<div class='meta'>Branch: <strong>feature/apps-display-template-elicit-185-190-191</strong> | Commit: <code>4d487e5</code> | Date: 2026-04-13 10:55:41</div>
 <table><tr><th>Stage</th><th>Result</th></tr>
 <tr><td>unit+coverage</td><td class='pass'>PASS</td></tr>
 <tr><td>race</td><td class='pass'>PASS</td></tr>
@@ -29,37 +29,37 @@ pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto; 
 <div class='summary-pass'>All 8 stages passed</div>
 <h2>Full Log</h2><pre>
 === MCPKit Comprehensive Test Suite ===
-Started: Mon Apr 13 10:07:02 PDT 2026
+Started: Mon Apr 13 10:54:51 PDT 2026
 
 --- [1/8] unit+coverage ---
-ok  	github.com/panyam/mcpkit/client	8.614s	coverage: 67.4% of statements
+ok  	github.com/panyam/mcpkit/client	7.710s	coverage: 67.4% of statements
 	github.com/panyam/mcpkit/cmd/testserver		coverage: 0.0% of statements
-ok  	github.com/panyam/mcpkit/core	0.699s	coverage: 62.5% of statements
-ok  	github.com/panyam/mcpkit/server	14.366s	coverage: 78.4% of statements
-ok  	github.com/panyam/mcpkit/testutil	0.785s	coverage: 70.5% of statements
+ok  	github.com/panyam/mcpkit/core	0.749s	coverage: 62.5% of statements
+ok  	github.com/panyam/mcpkit/server	13.943s	coverage: 78.4% of statements
+ok  	github.com/panyam/mcpkit/testutil	1.026s	coverage: 70.5% of statements
 Coverage report: tests/reports/coverage.html
   PASS: unit+coverage
 --- [2/8] race ---
-ok  	github.com/panyam/mcpkit/client	8.860s
+ok  	github.com/panyam/mcpkit/client	9.546s
 ?   	github.com/panyam/mcpkit/cmd/testserver	[no test files]
-ok  	github.com/panyam/mcpkit/core	1.760s
-ok  	github.com/panyam/mcpkit/server	15.359s
-ok  	github.com/panyam/mcpkit/testutil	1.572s
+ok  	github.com/panyam/mcpkit/core	1.421s
+ok  	github.com/panyam/mcpkit/server	15.063s
+ok  	github.com/panyam/mcpkit/testutil	1.942s
   PASS: race
 --- [3/8] auth ---
-ok  	github.com/panyam/mcpkit/ext/auth	0.297s
+ok  	github.com/panyam/mcpkit/ext/auth	0.857s
   PASS: auth
 --- [4/8] ui ---
-ok  	github.com/panyam/mcpkit/ext/ui	0.475s
+ok  	github.com/panyam/mcpkit/ext/ui	0.361s
   PASS: ui
 --- [5/8] e2e ---
-ok  	github.com/panyam/mcpkit/tests/e2e	4.156s
-ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.602s
+ok  	github.com/panyam/mcpkit/tests/e2e	4.134s
+ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.594s
   PASS: e2e
 --- [6/8] conformance ---
 Killing stale process on port 18799...
 === Starting test server on :18799 (Streamable HTTP) ===
-Waiting for server....2026/04/13 10:07:45 MCP test server listening on :18799 (Streamable HTTP at /mcp)
+Waiting for server....2026/04/13 10:55:35 MCP test server listening on :18799 (Streamable HTTP at /mcp)
  ready
 
 === Running MCP conformance suite ===
@@ -70,293 +70,293 @@ Running active suite (30 scenarios) against http://localhost:18799/mcp
 
 === Running scenario: server-initialize ===
 Running client scenario 'server-initialize' against server: http://localhost:18799/mcp
-2026/04/13 10:07:47 Starting MCP-GET-SSE SSE connection: 44fd2611de14f57f8cd3c42516019c3d
-2026/04/13 10:07:47 SSEHub: registered connection 44fd2611de14f57f8cd3c42516019c3d (total: 1)
-2026/04/13 10:07:47 SSEHub: unregistered connection 44fd2611de14f57f8cd3c42516019c3d (total: 0)
-2026/04/13 10:07:47 Received kill signal.  Quitting Writer. stop 0x2d64c78be230
-2026/04/13 10:07:47 Cleaning up writer...
-2026/04/13 10:07:47 Finished cleaning up writer:  0x2d64c78be230
-2026/04/13 10:07:47 Closed MCP-GET-SSE SSE connection: 44fd2611de14f57f8cd3c42516019c3d
+2026/04/13 10:55:36 Starting MCP-GET-SSE SSE connection: fe2ac031f81c05bb3747f6811463db9f
+2026/04/13 10:55:36 SSEHub: registered connection fe2ac031f81c05bb3747f6811463db9f (total: 1)
+2026/04/13 10:55:36 SSEHub: unregistered connection fe2ac031f81c05bb3747f6811463db9f (total: 0)
+2026/04/13 10:55:36 Received kill signal.  Quitting Writer. stop 0x64b660eae1c0
+2026/04/13 10:55:36 Cleaning up writer...
+2026/04/13 10:55:36 Finished cleaning up writer:  0x64b660eae1c0
+2026/04/13 10:55:36 Closed MCP-GET-SSE SSE connection: fe2ac031f81c05bb3747f6811463db9f
 
 === Running scenario: logging-set-level ===
 Running client scenario 'logging-set-level' against server: http://localhost:18799/mcp
-2026/04/13 10:07:47 Starting MCP-GET-SSE SSE connection: fdc0017ad3faabd8405f670a8a0544a2
-2026/04/13 10:07:47 SSEHub: registered connection fdc0017ad3faabd8405f670a8a0544a2 (total: 1)
-2026/04/13 10:07:47 SSEHub: unregistered connection fdc0017ad3faabd8405f670a8a0544a2 (total: 0)
-2026/04/13 10:07:47 Received kill signal.  Quitting Writer. stop 0x2d64c7d361c0
-2026/04/13 10:07:47 Cleaning up writer...
-2026/04/13 10:07:47 Finished cleaning up writer:  0x2d64c7d361c0
-2026/04/13 10:07:47 Closed MCP-GET-SSE SSE connection: fdc0017ad3faabd8405f670a8a0544a2
+2026/04/13 10:55:36 Starting MCP-GET-SSE SSE connection: 6b3464420de097c82b2737fa01678bd3
+2026/04/13 10:55:36 SSEHub: registered connection 6b3464420de097c82b2737fa01678bd3 (total: 1)
 
 === Running scenario: ping ===
+2026/04/13 10:55:36 SSEHub: unregistered connection 6b3464420de097c82b2737fa01678bd3 (total: 0)
 Running client scenario 'ping' against server: http://localhost:18799/mcp
-2026/04/13 10:07:47 Starting MCP-GET-SSE SSE connection: e0b14e6a1ce34c15f411ab278e8eeda0
-2026/04/13 10:07:47 SSEHub: registered connection e0b14e6a1ce34c15f411ab278e8eeda0 (total: 1)
-2026/04/13 10:07:47 SSEHub: unregistered connection e0b14e6a1ce34c15f411ab278e8eeda0 (total: 0)
-2026/04/13 10:07:47 Received kill signal.  Quitting Writer. stop 0x2d64c7d36460
-2026/04/13 10:07:47 Cleaning up writer...
+2026/04/13 10:55:36 Received kill signal.  Quitting Writer. stop 0x64b660a484d0
+2026/04/13 10:55:36 Cleaning up writer...
+2026/04/13 10:55:36 Finished cleaning up writer:  0x64b660a484d0
+2026/04/13 10:55:36 Closed MCP-GET-SSE SSE connection: 6b3464420de097c82b2737fa01678bd3
+2026/04/13 10:55:36 Starting MCP-GET-SSE SSE connection: 9be87270ae4e1141df7afee7c7c4e09a
+2026/04/13 10:55:36 SSEHub: registered connection 9be87270ae4e1141df7afee7c7c4e09a (total: 1)
+2026/04/13 10:55:36 SSEHub: unregistered connection 9be87270ae4e1141df7afee7c7c4e09a (total: 0)
+2026/04/13 10:55:36 Received kill signal.  Quitting Writer. stop 0x64b660b80930
+2026/04/13 10:55:36 Cleaning up writer...
+2026/04/13 10:55:36 Finished cleaning up writer:  0x64b660b80930
+2026/04/13 10:55:36 Closed MCP-GET-SSE SSE connection: 9be87270ae4e1141df7afee7c7c4e09a
 
 === Running scenario: completion-complete ===
-2026/04/13 10:07:47 Finished cleaning up writer:  0x2d64c7d36460
-2026/04/13 10:07:47 Closed MCP-GET-SSE SSE connection: e0b14e6a1ce34c15f411ab278e8eeda0
 Running client scenario 'completion-complete' against server: http://localhost:18799/mcp
-2026/04/13 10:07:47 Starting MCP-GET-SSE SSE connection: a3a4ef72f9aed1f88448ccd353ec4300
-2026/04/13 10:07:47 SSEHub: registered connection a3a4ef72f9aed1f88448ccd353ec4300 (total: 1)
-2026/04/13 10:07:47 SSEHub: unregistered connection a3a4ef72f9aed1f88448ccd353ec4300 (total: 0)
-2026/04/13 10:07:47 Received kill signal.  Quitting Writer. stop 0x2d64c7d36700
-2026/04/13 10:07:47 Cleaning up writer...
+2026/04/13 10:55:36 Starting MCP-GET-SSE SSE connection: 0ae6b6b0661fa6d70a86fc5836054568
+2026/04/13 10:55:36 SSEHub: registered connection 0ae6b6b0661fa6d70a86fc5836054568 (total: 1)
+2026/04/13 10:55:36 SSEHub: unregistered connection 0ae6b6b0661fa6d70a86fc5836054568 (total: 0)
+2026/04/13 10:55:36 Received kill signal.  Quitting Writer. stop 0x64b660a48620
+2026/04/13 10:55:36 Cleaning up writer...
+2026/04/13 10:55:36 Finished cleaning up writer:  0x64b660a48620
+2026/04/13 10:55:36 Closed MCP-GET-SSE SSE connection: 0ae6b6b0661fa6d70a86fc5836054568
 
 === Running scenario: tools-list ===
-2026/04/13 10:07:47 Finished cleaning up writer:  0x2d64c7d36700
 Running client scenario 'tools-list' against server: http://localhost:18799/mcp
-2026/04/13 10:07:47 Closed MCP-GET-SSE SSE connection: a3a4ef72f9aed1f88448ccd353ec4300
-2026/04/13 10:07:47 Starting MCP-GET-SSE SSE connection: 8dfc7696852b80586b4e96b4559af18c
-2026/04/13 10:07:47 SSEHub: registered connection 8dfc7696852b80586b4e96b4559af18c (total: 1)
-2026/04/13 10:07:47 SSEHub: unregistered connection 8dfc7696852b80586b4e96b4559af18c (total: 0)
+2026/04/13 10:55:36 Starting MCP-GET-SSE SSE connection: 68f6cccfbff79ee2898dcb65a62e28f7
+2026/04/13 10:55:36 SSEHub: registered connection 68f6cccfbff79ee2898dcb65a62e28f7 (total: 1)
 
 === Running scenario: tools-call-simple-text ===
-2026/04/13 10:07:47 Received kill signal.  Quitting Writer. stop 0x2d64c780c3f0
-2026/04/13 10:07:47 Cleaning up writer...
+2026/04/13 10:55:36 SSEHub: unregistered connection 68f6cccfbff79ee2898dcb65a62e28f7 (total: 0)
 Running client scenario 'tools-call-simple-text' against server: http://localhost:18799/mcp
-2026/04/13 10:07:47 Finished cleaning up writer:  0x2d64c780c3f0
-2026/04/13 10:07:47 Closed MCP-GET-SSE SSE connection: 8dfc7696852b80586b4e96b4559af18c
-2026/04/13 10:07:47 Starting MCP-GET-SSE SSE connection: ab70e60793866f04f69000dd41b18c6f
-2026/04/13 10:07:47 SSEHub: registered connection ab70e60793866f04f69000dd41b18c6f (total: 1)
-2026/04/13 10:07:47 SSEHub: unregistered connection ab70e60793866f04f69000dd41b18c6f (total: 0)
-2026/04/13 10:07:47 Received kill signal.  Quitting Writer. stop 0x2d64c7d369a0
-2026/04/13 10:07:47 Cleaning up writer...
-2026/04/13 10:07:47 Finished cleaning up writer:  0x2d64c7d369a0
-2026/04/13 10:07:47 Closed MCP-GET-SSE SSE connection: ab70e60793866f04f69000dd41b18c6f
+2026/04/13 10:55:36 Received kill signal.  Quitting Writer. stop 0x64b660b80c40
+2026/04/13 10:55:36 Cleaning up writer...
+2026/04/13 10:55:36 Finished cleaning up writer:  0x64b660b80c40
+2026/04/13 10:55:36 Closed MCP-GET-SSE SSE connection: 68f6cccfbff79ee2898dcb65a62e28f7
+2026/04/13 10:55:36 Starting MCP-GET-SSE SSE connection: 948745f25d150226256795797fef6a3c
+2026/04/13 10:55:36 SSEHub: registered connection 948745f25d150226256795797fef6a3c (total: 1)
+2026/04/13 10:55:36 SSEHub: unregistered connection 948745f25d150226256795797fef6a3c (total: 0)
+2026/04/13 10:55:36 Received kill signal.  Quitting Writer. stop 0x64b660a48930
+2026/04/13 10:55:36 Cleaning up writer...
+2026/04/13 10:55:36 Finished cleaning up writer:  0x64b660a48930
+2026/04/13 10:55:36 Closed MCP-GET-SSE SSE connection: 948745f25d150226256795797fef6a3c
 
 === Running scenario: tools-call-image ===
 Running client scenario 'tools-call-image' against server: http://localhost:18799/mcp
-2026/04/13 10:07:47 Starting MCP-GET-SSE SSE connection: bf136235816bb4533fbdc99fa66ac43c
-2026/04/13 10:07:47 SSEHub: registered connection bf136235816bb4533fbdc99fa66ac43c (total: 1)
+2026/04/13 10:55:36 Starting MCP-GET-SSE SSE connection: 6058c30efa96283f151fe390d0e6ecf7
+2026/04/13 10:55:36 SSEHub: registered connection 6058c30efa96283f151fe390d0e6ecf7 (total: 1)
+2026/04/13 10:55:36 SSEHub: unregistered connection 6058c30efa96283f151fe390d0e6ecf7 (total: 0)
 
 === Running scenario: tools-call-audio ===
-2026/04/13 10:07:47 SSEHub: unregistered connection bf136235816bb4533fbdc99fa66ac43c (total: 0)
+2026/04/13 10:55:36 Received kill signal.  Quitting Writer. stop 0x64b660fb0310
+2026/04/13 10:55:36 Cleaning up writer...
+2026/04/13 10:55:36 Finished cleaning up writer:  0x64b660fb0310
+2026/04/13 10:55:36 Closed MCP-GET-SSE SSE connection: 6058c30efa96283f151fe390d0e6ecf7
 Running client scenario 'tools-call-audio' against server: http://localhost:18799/mcp
-2026/04/13 10:07:47 Received kill signal.  Quitting Writer. stop 0x2d64c7984af0
-2026/04/13 10:07:47 Cleaning up writer...
-2026/04/13 10:07:47 Finished cleaning up writer:  0x2d64c7984af0
-2026/04/13 10:07:47 Closed MCP-GET-SSE SSE connection: bf136235816bb4533fbdc99fa66ac43c
-2026/04/13 10:07:47 Starting MCP-GET-SSE SSE connection: 57587ff5e630c576bf330bd7fb5ec5aa
-2026/04/13 10:07:47 SSEHub: registered connection 57587ff5e630c576bf330bd7fb5ec5aa (total: 1)
-2026/04/13 10:07:47 SSEHub: unregistered connection 57587ff5e630c576bf330bd7fb5ec5aa (total: 0)
-2026/04/13 10:07:47 Received kill signal.  Quitting Writer. stop 0x2d64c7d36d20
-2026/04/13 10:07:47 Cleaning up writer...
-2026/04/13 10:07:47 Finished cleaning up writer:  0x2d64c7d36d20
-2026/04/13 10:07:47 Closed MCP-GET-SSE SSE connection: 57587ff5e630c576bf330bd7fb5ec5aa
+2026/04/13 10:55:36 Starting MCP-GET-SSE SSE connection: b150bcd4d1d098f9e6c6e13808589bd6
+2026/04/13 10:55:36 SSEHub: registered connection b150bcd4d1d098f9e6c6e13808589bd6 (total: 1)
+2026/04/13 10:55:36 SSEHub: unregistered connection b150bcd4d1d098f9e6c6e13808589bd6 (total: 0)
 
 === Running scenario: tools-call-embedded-resource ===
+2026/04/13 10:55:36 Received kill signal.  Quitting Writer. stop 0x64b660a48c40
+2026/04/13 10:55:36 Cleaning up writer...
 Running client scenario 'tools-call-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/13 10:07:47 Starting MCP-GET-SSE SSE connection: c5e0ba3117aaf33ada0dc06a1f16c8ff
-2026/04/13 10:07:47 SSEHub: registered connection c5e0ba3117aaf33ada0dc06a1f16c8ff (total: 1)
+2026/04/13 10:55:36 Finished cleaning up writer:  0x64b660a48c40
+2026/04/13 10:55:36 Closed MCP-GET-SSE SSE connection: b150bcd4d1d098f9e6c6e13808589bd6
+2026/04/13 10:55:36 Starting MCP-GET-SSE SSE connection: f6ac9b716aa80b98a48523230fa08864
+2026/04/13 10:55:36 SSEHub: registered connection f6ac9b716aa80b98a48523230fa08864 (total: 1)
+2026/04/13 10:55:36 SSEHub: unregistered connection f6ac9b716aa80b98a48523230fa08864 (total: 0)
+2026/04/13 10:55:36 Received kill signal.  Quitting Writer. stop 0x64b660fb05b0
+2026/04/13 10:55:36 Cleaning up writer...
+2026/04/13 10:55:36 Finished cleaning up writer:  0x64b660fb05b0
+2026/04/13 10:55:36 Closed MCP-GET-SSE SSE connection: f6ac9b716aa80b98a48523230fa08864
 
 === Running scenario: tools-call-mixed-content ===
-2026/04/13 10:07:47 SSEHub: unregistered connection c5e0ba3117aaf33ada0dc06a1f16c8ff (total: 0)
-2026/04/13 10:07:47 Received kill signal.  Quitting Writer. stop 0x2d64c7d36fc0
-2026/04/13 10:07:47 Cleaning up writer...
 Running client scenario 'tools-call-mixed-content' against server: http://localhost:18799/mcp
-2026/04/13 10:07:47 Finished cleaning up writer:  0x2d64c7d36fc0
-2026/04/13 10:07:47 Closed MCP-GET-SSE SSE connection: c5e0ba3117aaf33ada0dc06a1f16c8ff
-2026/04/13 10:07:47 Starting MCP-GET-SSE SSE connection: c001612efeaff464937ef6a45f100754
-2026/04/13 10:07:47 SSEHub: registered connection c001612efeaff464937ef6a45f100754 (total: 1)
-2026/04/13 10:07:47 SSEHub: unregistered connection c001612efeaff464937ef6a45f100754 (total: 0)
-2026/04/13 10:07:47 Received kill signal.  Quitting Writer. stop 0x2d64c780c700
-2026/04/13 10:07:47 Cleaning up writer...
+2026/04/13 10:55:36 Starting MCP-GET-SSE SSE connection: e305db16f5c6baf66a756d34b9c8a162
+2026/04/13 10:55:36 SSEHub: registered connection e305db16f5c6baf66a756d34b9c8a162 (total: 1)
+2026/04/13 10:55:36 SSEHub: unregistered connection e305db16f5c6baf66a756d34b9c8a162 (total: 0)
+2026/04/13 10:55:36 Received kill signal.  Quitting Writer. stop 0x64b660b81180
+2026/04/13 10:55:36 Cleaning up writer...
+2026/04/13 10:55:36 Finished cleaning up writer:  0x64b660b81180
+2026/04/13 10:55:36 Closed MCP-GET-SSE SSE connection: e305db16f5c6baf66a756d34b9c8a162
 
 === Running scenario: tools-call-with-logging ===
-2026/04/13 10:07:47 Finished cleaning up writer:  0x2d64c780c700
 Running client scenario 'tools-call-with-logging' against server: http://localhost:18799/mcp
-2026/04/13 10:07:47 Closed MCP-GET-SSE SSE connection: c001612efeaff464937ef6a45f100754
-2026/04/13 10:07:47 Starting MCP-GET-SSE SSE connection: 258f6b28015e0b4d1046056479e9d5be
-2026/04/13 10:07:47 SSEHub: registered connection 258f6b28015e0b4d1046056479e9d5be (total: 1)
-2026/04/13 10:07:47 SSEHub: unregistered connection 258f6b28015e0b4d1046056479e9d5be (total: 0)
-2026/04/13 10:07:47 Received kill signal.  Quitting Writer. stop 0x2d64c7d37260
-2026/04/13 10:07:47 Cleaning up writer...
-2026/04/13 10:07:47 Finished cleaning up writer:  0x2d64c7d37260
-2026/04/13 10:07:47 Closed MCP-GET-SSE SSE connection: 258f6b28015e0b4d1046056479e9d5be
+2026/04/13 10:55:36 Starting MCP-GET-SSE SSE connection: f4fd00efe9a4e36fa3b4255153d00abb
+2026/04/13 10:55:36 SSEHub: registered connection f4fd00efe9a4e36fa3b4255153d00abb (total: 1)
 
 === Running scenario: tools-call-error ===
+2026/04/13 10:55:37 SSEHub: unregistered connection f4fd00efe9a4e36fa3b4255153d00abb (total: 0)
+2026/04/13 10:55:37 Received kill signal.  Quitting Writer. stop 0x64b660afc150
 Running client scenario 'tools-call-error' against server: http://localhost:18799/mcp
-2026/04/13 10:07:47 Starting MCP-GET-SSE SSE connection: c57b299a1d604d8a76c0eb3d2c1792f9
-2026/04/13 10:07:47 SSEHub: registered connection c57b299a1d604d8a76c0eb3d2c1792f9 (total: 1)
-2026/04/13 10:07:47 SSEHub: unregistered connection c57b299a1d604d8a76c0eb3d2c1792f9 (total: 0)
-2026/04/13 10:07:47 Received kill signal.  Quitting Writer. stop 0x2d64c7d37490
-2026/04/13 10:07:47 Cleaning up writer...
-2026/04/13 10:07:47 Finished cleaning up writer:  0x2d64c7d37490
-2026/04/13 10:07:47 Closed MCP-GET-SSE SSE connection: c57b299a1d604d8a76c0eb3d2c1792f9
+2026/04/13 10:55:37 Cleaning up writer...
+2026/04/13 10:55:37 Finished cleaning up writer:  0x64b660afc150
+2026/04/13 10:55:37 Closed MCP-GET-SSE SSE connection: f4fd00efe9a4e36fa3b4255153d00abb
+2026/04/13 10:55:37 Starting MCP-GET-SSE SSE connection: 0efa36a5cdd0de94bd243c732aa0456e
 
 === Running scenario: tools-call-with-progress ===
+2026/04/13 10:55:37 SSEHub: registered connection 0efa36a5cdd0de94bd243c732aa0456e (total: 1)
 Running client scenario 'tools-call-with-progress' against server: http://localhost:18799/mcp
-2026/04/13 10:07:47 Starting MCP-GET-SSE SSE connection: 8290967fb14a0e0ab7d58d8c7261ac2c
-2026/04/13 10:07:47 SSEHub: registered connection 8290967fb14a0e0ab7d58d8c7261ac2c (total: 1)
-2026/04/13 10:07:47 SSEHub: unregistered connection 8290967fb14a0e0ab7d58d8c7261ac2c (total: 0)
-2026/04/13 10:07:47 Received kill signal.  Quitting Writer. stop 0x2d64c7a0e540
-2026/04/13 10:07:47 Cleaning up writer...
-2026/04/13 10:07:47 Finished cleaning up writer:  0x2d64c7a0e540
-2026/04/13 10:07:47 Closed MCP-GET-SSE SSE connection: 8290967fb14a0e0ab7d58d8c7261ac2c
+2026/04/13 10:55:37 SSEHub: unregistered connection 0efa36a5cdd0de94bd243c732aa0456e (total: 0)
+2026/04/13 10:55:37 Received kill signal.  Quitting Writer. stop 0x64b660a491f0
+2026/04/13 10:55:37 Cleaning up writer...
+2026/04/13 10:55:37 Finished cleaning up writer:  0x64b660a491f0
+2026/04/13 10:55:37 Closed MCP-GET-SSE SSE connection: 0efa36a5cdd0de94bd243c732aa0456e
+2026/04/13 10:55:37 Starting MCP-GET-SSE SSE connection: bf12235f7cdf4a62a3167e7b32f6a9c2
+2026/04/13 10:55:37 SSEHub: registered connection bf12235f7cdf4a62a3167e7b32f6a9c2 (total: 1)
+2026/04/13 10:55:37 SSEHub: unregistered connection bf12235f7cdf4a62a3167e7b32f6a9c2 (total: 0)
 
 === Running scenario: tools-call-sampling ===
+2026/04/13 10:55:37 Received kill signal.  Quitting Writer. stop 0x64b660a49420
+2026/04/13 10:55:37 Cleaning up writer...
+2026/04/13 10:55:37 Finished cleaning up writer:  0x64b660a49420
 Running client scenario 'tools-call-sampling' against server: http://localhost:18799/mcp
-2026/04/13 10:07:47 Starting MCP-GET-SSE SSE connection: 81da6837c3d5e9f89fc7988319895934
-2026/04/13 10:07:47 SSEHub: registered connection 81da6837c3d5e9f89fc7988319895934 (total: 1)
-2026/04/13 10:07:48 SSEHub: unregistered connection 81da6837c3d5e9f89fc7988319895934 (total: 0)
-2026/04/13 10:07:48 Received kill signal.  Quitting Writer. stop 0x2d64c7a0e770
-2026/04/13 10:07:48 Cleaning up writer...
-2026/04/13 10:07:48 Finished cleaning up writer:  0x2d64c7a0e770
-2026/04/13 10:07:48 Closed MCP-GET-SSE SSE connection: 81da6837c3d5e9f89fc7988319895934
+2026/04/13 10:55:37 Closed MCP-GET-SSE SSE connection: bf12235f7cdf4a62a3167e7b32f6a9c2
+2026/04/13 10:55:37 Starting MCP-GET-SSE SSE connection: fa7c9578e33dea086300d1263e8e8640
+2026/04/13 10:55:37 SSEHub: registered connection fa7c9578e33dea086300d1263e8e8640 (total: 1)
+2026/04/13 10:55:37 SSEHub: unregistered connection fa7c9578e33dea086300d1263e8e8640 (total: 0)
+2026/04/13 10:55:37 Received kill signal.  Quitting Writer. stop 0x64b660a496c0
+2026/04/13 10:55:37 Cleaning up writer...
+2026/04/13 10:55:37 Finished cleaning up writer:  0x64b660a496c0
+2026/04/13 10:55:37 Closed MCP-GET-SSE SSE connection: fa7c9578e33dea086300d1263e8e8640
 
 === Running scenario: tools-call-elicitation ===
 Running client scenario 'tools-call-elicitation' against server: http://localhost:18799/mcp
-2026/04/13 10:07:48 Starting MCP-GET-SSE SSE connection: a6c130b4d6ac6e321de4be9887cbfe6f
-2026/04/13 10:07:48 SSEHub: registered connection a6c130b4d6ac6e321de4be9887cbfe6f (total: 1)
-2026/04/13 10:07:48 SSEHub: unregistered connection a6c130b4d6ac6e321de4be9887cbfe6f (total: 0)
-2026/04/13 10:07:48 Received kill signal.  Quitting Writer. stop 0x2d64c780caf0
-2026/04/13 10:07:48 Cleaning up writer...
-2026/04/13 10:07:48 Finished cleaning up writer:  0x2d64c780caf0
-2026/04/13 10:07:48 Closed MCP-GET-SSE SSE connection: a6c130b4d6ac6e321de4be9887cbfe6f
+2026/04/13 10:55:37 Starting MCP-GET-SSE SSE connection: 61446d4f0d13efff1f9a39d30fb05d26
+2026/04/13 10:55:37 SSEHub: registered connection 61446d4f0d13efff1f9a39d30fb05d26 (total: 1)
+2026/04/13 10:55:37 SSEHub: unregistered connection 61446d4f0d13efff1f9a39d30fb05d26 (total: 0)
+2026/04/13 10:55:37 Received kill signal.  Quitting Writer. stop 0x64b660a498f0
+2026/04/13 10:55:37 Cleaning up writer...
+2026/04/13 10:55:37 Finished cleaning up writer:  0x64b660a498f0
 
 === Running scenario: elicitation-sep1034-defaults ===
+2026/04/13 10:55:37 Closed MCP-GET-SSE SSE connection: 61446d4f0d13efff1f9a39d30fb05d26
 Running client scenario 'elicitation-sep1034-defaults' against server: http://localhost:18799/mcp
-2026/04/13 10:07:48 Starting MCP-GET-SSE SSE connection: bc2fb2c8213c9143af02cdcc6e04dfd8
-2026/04/13 10:07:48 SSEHub: registered connection bc2fb2c8213c9143af02cdcc6e04dfd8 (total: 1)
-2026/04/13 10:07:48 SSEHub: unregistered connection bc2fb2c8213c9143af02cdcc6e04dfd8 (total: 0)
+2026/04/13 10:55:37 Starting MCP-GET-SSE SSE connection: c27fdee2564ec5bd6ffbf5073ab2c73b
+2026/04/13 10:55:37 SSEHub: registered connection c27fdee2564ec5bd6ffbf5073ab2c73b (total: 1)
+2026/04/13 10:55:37 SSEHub: unregistered connection c27fdee2564ec5bd6ffbf5073ab2c73b (total: 0)
 
 === Running scenario: server-sse-multiple-streams ===
-2026/04/13 10:07:48 Received kill signal.  Quitting Writer. stop 0x2d64c780cf50
-2026/04/13 10:07:48 Cleaning up writer...
+2026/04/13 10:55:37 Received kill signal.  Quitting Writer. stop 0x64b660afc460
+2026/04/13 10:55:37 Cleaning up writer...
+2026/04/13 10:55:37 Finished cleaning up writer:  0x64b660afc460
+2026/04/13 10:55:37 Closed MCP-GET-SSE SSE connection: c27fdee2564ec5bd6ffbf5073ab2c73b
 Running client scenario 'server-sse-multiple-streams' against server: http://localhost:18799/mcp
-2026/04/13 10:07:48 Finished cleaning up writer:  0x2d64c780cf50
-2026/04/13 10:07:48 Closed MCP-GET-SSE SSE connection: bc2fb2c8213c9143af02cdcc6e04dfd8
-2026/04/13 10:07:48 Starting MCP-GET-SSE SSE connection: b92fe5ae677afa0b30bfe106d1be0c2d
-2026/04/13 10:07:48 SSEHub: registered connection b92fe5ae677afa0b30bfe106d1be0c2d (total: 1)
+2026/04/13 10:55:37 Starting MCP-GET-SSE SSE connection: c24ef1bc5e7373be0955fab1df60bcb2
+2026/04/13 10:55:37 SSEHub: registered connection c24ef1bc5e7373be0955fab1df60bcb2 (total: 1)
 
 === Running scenario: elicitation-sep1330-enums ===
+2026/04/13 10:55:37 SSEHub: unregistered connection c24ef1bc5e7373be0955fab1df60bcb2 (total: 0)
 Running client scenario 'elicitation-sep1330-enums' against server: http://localhost:18799/mcp
-2026/04/13 10:07:48 SSEHub: unregistered connection b92fe5ae677afa0b30bfe106d1be0c2d (total: 0)
-2026/04/13 10:07:48 Received kill signal.  Quitting Writer. stop 0x2d64c7a0ebd0
-2026/04/13 10:07:48 Cleaning up writer...
-2026/04/13 10:07:48 Finished cleaning up writer:  0x2d64c7a0ebd0
-2026/04/13 10:07:48 Closed MCP-GET-SSE SSE connection: b92fe5ae677afa0b30bfe106d1be0c2d
-2026/04/13 10:07:48 Starting MCP-GET-SSE SSE connection: 4aeca845fff7062e34c67ac4fb8035ce
-2026/04/13 10:07:48 SSEHub: registered connection 4aeca845fff7062e34c67ac4fb8035ce (total: 1)
-2026/04/13 10:07:48 SSEHub: unregistered connection 4aeca845fff7062e34c67ac4fb8035ce (total: 0)
-2026/04/13 10:07:48 Received kill signal.  Quitting Writer. stop 0x2d64c7cae620
-2026/04/13 10:07:48 Cleaning up writer...
-2026/04/13 10:07:48 Finished cleaning up writer:  0x2d64c7cae620
-2026/04/13 10:07:48 Closed MCP-GET-SSE SSE connection: 4aeca845fff7062e34c67ac4fb8035ce
+2026/04/13 10:55:37 Received kill signal.  Quitting Writer. stop 0x64b660fb0e70
+2026/04/13 10:55:37 Cleaning up writer...
+2026/04/13 10:55:37 Finished cleaning up writer:  0x64b660fb0e70
+2026/04/13 10:55:37 Closed MCP-GET-SSE SSE connection: c24ef1bc5e7373be0955fab1df60bcb2
+2026/04/13 10:55:37 Starting MCP-GET-SSE SSE connection: b8f401c75723f87467f64fb556ca144d
+2026/04/13 10:55:37 SSEHub: registered connection b8f401c75723f87467f64fb556ca144d (total: 1)
+2026/04/13 10:55:37 SSEHub: unregistered connection b8f401c75723f87467f64fb556ca144d (total: 0)
+2026/04/13 10:55:37 Received kill signal.  Quitting Writer. stop 0x64b660afc700
+2026/04/13 10:55:37 Cleaning up writer...
+2026/04/13 10:55:37 Finished cleaning up writer:  0x64b660afc700
+2026/04/13 10:55:37 Closed MCP-GET-SSE SSE connection: b8f401c75723f87467f64fb556ca144d
 
 === Running scenario: resources-list ===
 Running client scenario 'resources-list' against server: http://localhost:18799/mcp
-2026/04/13 10:07:48 Starting MCP-GET-SSE SSE connection: a5d0af207d8b1fae28d49bb47646c91e
-2026/04/13 10:07:48 SSEHub: registered connection a5d0af207d8b1fae28d49bb47646c91e (total: 1)
+2026/04/13 10:55:37 Starting MCP-GET-SSE SSE connection: fa47b2ee8a112df2de8c2c97468337b3
+2026/04/13 10:55:37 SSEHub: registered connection fa47b2ee8a112df2de8c2c97468337b3 (total: 1)
+2026/04/13 10:55:37 SSEHub: unregistered connection fa47b2ee8a112df2de8c2c97468337b3 (total: 0)
+2026/04/13 10:55:37 Received kill signal.  Quitting Writer. stop 0x64b660a49dc0
+2026/04/13 10:55:37 Cleaning up writer...
+2026/04/13 10:55:37 Finished cleaning up writer:  0x64b660a49dc0
+2026/04/13 10:55:37 Closed MCP-GET-SSE SSE connection: fa47b2ee8a112df2de8c2c97468337b3
 
 === Running scenario: resources-read-text ===
 Running client scenario 'resources-read-text' against server: http://localhost:18799/mcp
-2026/04/13 10:07:48 SSEHub: unregistered connection a5d0af207d8b1fae28d49bb47646c91e (total: 0)
-2026/04/13 10:07:48 Received kill signal.  Quitting Writer. stop 0x2d64c7cae9a0
-2026/04/13 10:07:48 Cleaning up writer...
-2026/04/13 10:07:48 Finished cleaning up writer:  0x2d64c7cae9a0
-2026/04/13 10:07:48 Closed MCP-GET-SSE SSE connection: a5d0af207d8b1fae28d49bb47646c91e
-2026/04/13 10:07:48 Starting MCP-GET-SSE SSE connection: 5f86daef1da88af571f44c6b8489cb74
-2026/04/13 10:07:48 SSEHub: registered connection 5f86daef1da88af571f44c6b8489cb74 (total: 1)
+2026/04/13 10:55:37 Starting MCP-GET-SSE SSE connection: 9790f29d62537fdf07ac1d2302a08a87
+2026/04/13 10:55:37 SSEHub: registered connection 9790f29d62537fdf07ac1d2302a08a87 (total: 1)
+2026/04/13 10:55:37 SSEHub: unregistered connection 9790f29d62537fdf07ac1d2302a08a87 (total: 0)
+2026/04/13 10:55:37 Received kill signal.  Quitting Writer. stop 0x64b660afca10
+2026/04/13 10:55:37 Cleaning up writer...
+2026/04/13 10:55:37 Finished cleaning up writer:  0x64b660afca10
+2026/04/13 10:55:37 Closed MCP-GET-SSE SSE connection: 9790f29d62537fdf07ac1d2302a08a87
 
 === Running scenario: resources-read-binary ===
-2026/04/13 10:07:48 SSEHub: unregistered connection 5f86daef1da88af571f44c6b8489cb74 (total: 0)
 Running client scenario 'resources-read-binary' against server: http://localhost:18799/mcp
-2026/04/13 10:07:48 Received kill signal.  Quitting Writer. stop 0x2d64c7caebd0
-2026/04/13 10:07:48 Cleaning up writer...
-2026/04/13 10:07:48 Finished cleaning up writer:  0x2d64c7caebd0
-2026/04/13 10:07:48 Closed MCP-GET-SSE SSE connection: 5f86daef1da88af571f44c6b8489cb74
-2026/04/13 10:07:48 Starting MCP-GET-SSE SSE connection: 5783428598e2e0ebf2b855a1afa0cacf
-2026/04/13 10:07:48 SSEHub: registered connection 5783428598e2e0ebf2b855a1afa0cacf (total: 1)
-2026/04/13 10:07:48 SSEHub: unregistered connection 5783428598e2e0ebf2b855a1afa0cacf (total: 0)
-2026/04/13 10:07:48 Received kill signal.  Quitting Writer. stop 0x2d64c7caeee0
-2026/04/13 10:07:48 Cleaning up writer...
+2026/04/13 10:55:37 Starting MCP-GET-SSE SSE connection: 1f2fcf9f98b702b94244d1f6331d1025
+2026/04/13 10:55:37 SSEHub: registered connection 1f2fcf9f98b702b94244d1f6331d1025 (total: 1)
+2026/04/13 10:55:37 SSEHub: unregistered connection 1f2fcf9f98b702b94244d1f6331d1025 (total: 0)
+2026/04/13 10:55:37 Received kill signal.  Quitting Writer. stop 0x64b660fb11f0
+2026/04/13 10:55:37 Cleaning up writer...
+2026/04/13 10:55:37 Finished cleaning up writer:  0x64b660fb11f0
+2026/04/13 10:55:37 Closed MCP-GET-SSE SSE connection: 1f2fcf9f98b702b94244d1f6331d1025
 
 === Running scenario: resources-templates-read ===
-2026/04/13 10:07:48 Finished cleaning up writer:  0x2d64c7caeee0
-2026/04/13 10:07:48 Closed MCP-GET-SSE SSE connection: 5783428598e2e0ebf2b855a1afa0cacf
 Running client scenario 'resources-templates-read' against server: http://localhost:18799/mcp
-2026/04/13 10:07:48 Starting MCP-GET-SSE SSE connection: 19d9aed274c0a378397f8e13b8039bc6
-2026/04/13 10:07:48 SSEHub: registered connection 19d9aed274c0a378397f8e13b8039bc6 (total: 1)
-2026/04/13 10:07:48 SSEHub: unregistered connection 19d9aed274c0a378397f8e13b8039bc6 (total: 0)
-2026/04/13 10:07:48 Received kill signal.  Quitting Writer. stop 0x2d64c7caf180
-2026/04/13 10:07:48 Cleaning up writer...
-2026/04/13 10:07:48 Finished cleaning up writer:  0x2d64c7caf180
-2026/04/13 10:07:48 Closed MCP-GET-SSE SSE connection: 19d9aed274c0a378397f8e13b8039bc6
+2026/04/13 10:55:37 Starting MCP-GET-SSE SSE connection: abec7ac9b8364f92f15337012b5e18bc
+2026/04/13 10:55:37 SSEHub: registered connection abec7ac9b8364f92f15337012b5e18bc (total: 1)
+2026/04/13 10:55:37 SSEHub: unregistered connection abec7ac9b8364f92f15337012b5e18bc (total: 0)
+2026/04/13 10:55:37 Received kill signal.  Quitting Writer. stop 0x64b660afcd90
+2026/04/13 10:55:37 Cleaning up writer...
+2026/04/13 10:55:37 Finished cleaning up writer:  0x64b660afcd90
+2026/04/13 10:55:37 Closed MCP-GET-SSE SSE connection: abec7ac9b8364f92f15337012b5e18bc
 
 === Running scenario: resources-subscribe ===
 Running client scenario 'resources-subscribe' against server: http://localhost:18799/mcp
-2026/04/13 10:07:48 Starting MCP-GET-SSE SSE connection: 932c58c244b126d90140de876f20f6e8
-2026/04/13 10:07:48 SSEHub: registered connection 932c58c244b126d90140de876f20f6e8 (total: 1)
+2026/04/13 10:55:37 Starting MCP-GET-SSE SSE connection: 779ffd0898f79357e7b1b2c04a925c98
+2026/04/13 10:55:37 SSEHub: registered connection 779ffd0898f79357e7b1b2c04a925c98 (total: 1)
+2026/04/13 10:55:37 SSEHub: unregistered connection 779ffd0898f79357e7b1b2c04a925c98 (total: 0)
+2026/04/13 10:55:37 Received kill signal.  Quitting Writer. stop 0x64b660fb1420
+2026/04/13 10:55:37 Cleaning up writer...
+2026/04/13 10:55:37 Finished cleaning up writer:  0x64b660fb1420
+2026/04/13 10:55:37 Closed MCP-GET-SSE SSE connection: 779ffd0898f79357e7b1b2c04a925c98
 
 === Running scenario: resources-unsubscribe ===
-2026/04/13 10:07:48 SSEHub: unregistered connection 932c58c244b126d90140de876f20f6e8 (total: 0)
 Running client scenario 'resources-unsubscribe' against server: http://localhost:18799/mcp
-2026/04/13 10:07:48 Received kill signal.  Quitting Writer. stop 0x2d64c7caf500
-2026/04/13 10:07:48 Cleaning up writer...
-2026/04/13 10:07:48 Finished cleaning up writer:  0x2d64c7caf500
-2026/04/13 10:07:48 Closed MCP-GET-SSE SSE connection: 932c58c244b126d90140de876f20f6e8
-2026/04/13 10:07:48 Starting MCP-GET-SSE SSE connection: fd386c902dce1bad3c90bf63edfa7ad2
-2026/04/13 10:07:48 SSEHub: registered connection fd386c902dce1bad3c90bf63edfa7ad2 (total: 1)
-2026/04/13 10:07:48 SSEHub: unregistered connection fd386c902dce1bad3c90bf63edfa7ad2 (total: 0)
-2026/04/13 10:07:48 Received kill signal.  Quitting Writer. stop 0x2d64c7caf730
-2026/04/13 10:07:48 Cleaning up writer...
-2026/04/13 10:07:48 Finished cleaning up writer:  0x2d64c7caf730
-2026/04/13 10:07:48 Closed MCP-GET-SSE SSE connection: fd386c902dce1bad3c90bf63edfa7ad2
+2026/04/13 10:55:37 Starting MCP-GET-SSE SSE connection: 088197ec23b38b37378807821a041e0a
+2026/04/13 10:55:37 SSEHub: registered connection 088197ec23b38b37378807821a041e0a (total: 1)
+2026/04/13 10:55:37 SSEHub: unregistered connection 088197ec23b38b37378807821a041e0a (total: 0)
+2026/04/13 10:55:37 Received kill signal.  Quitting Writer. stop 0x64b660b81650
+2026/04/13 10:55:37 Cleaning up writer...
+2026/04/13 10:55:37 Finished cleaning up writer:  0x64b660b81650
+2026/04/13 10:55:37 Closed MCP-GET-SSE SSE connection: 088197ec23b38b37378807821a041e0a
 
 === Running scenario: prompts-list ===
 Running client scenario 'prompts-list' against server: http://localhost:18799/mcp
-2026/04/13 10:07:48 Starting MCP-GET-SSE SSE connection: 38feec4df1caf86ced568c1494a14380
-2026/04/13 10:07:48 SSEHub: registered connection 38feec4df1caf86ced568c1494a14380 (total: 1)
-2026/04/13 10:07:48 SSEHub: unregistered connection 38feec4df1caf86ced568c1494a14380 (total: 0)
-2026/04/13 10:07:48 Received kill signal.  Quitting Writer. stop 0x2d64c7a0efc0
-2026/04/13 10:07:48 Cleaning up writer...
-2026/04/13 10:07:48 Finished cleaning up writer:  0x2d64c7a0efc0
-2026/04/13 10:07:48 Closed MCP-GET-SSE SSE connection: 38feec4df1caf86ced568c1494a14380
+2026/04/13 10:55:37 Starting MCP-GET-SSE SSE connection: ccb94c9a2ca9be2fef192cf45d83056e
+2026/04/13 10:55:37 SSEHub: registered connection ccb94c9a2ca9be2fef192cf45d83056e (total: 1)
+2026/04/13 10:55:37 SSEHub: unregistered connection ccb94c9a2ca9be2fef192cf45d83056e (total: 0)
+2026/04/13 10:55:37 Received kill signal.  Quitting Writer. stop 0x64b660afd2d0
+2026/04/13 10:55:37 Cleaning up writer...
 
 === Running scenario: prompts-get-simple ===
+2026/04/13 10:55:37 Finished cleaning up writer:  0x64b660afd2d0
+2026/04/13 10:55:37 Closed MCP-GET-SSE SSE connection: ccb94c9a2ca9be2fef192cf45d83056e
 Running client scenario 'prompts-get-simple' against server: http://localhost:18799/mcp
-2026/04/13 10:07:48 Starting MCP-GET-SSE SSE connection: 87343d3c717f97204b6aea321aaab114
-2026/04/13 10:07:48 SSEHub: registered connection 87343d3c717f97204b6aea321aaab114 (total: 1)
-2026/04/13 10:07:48 SSEHub: unregistered connection 87343d3c717f97204b6aea321aaab114 (total: 0)
-2026/04/13 10:07:48 Received kill signal.  Quitting Writer. stop 0x2d64c7caf9d0
-2026/04/13 10:07:48 Cleaning up writer...
-2026/04/13 10:07:48 Finished cleaning up writer:  0x2d64c7caf9d0
-2026/04/13 10:07:48 Closed MCP-GET-SSE SSE connection: 87343d3c717f97204b6aea321aaab114
+2026/04/13 10:55:37 Starting MCP-GET-SSE SSE connection: 80e5249e3a5ea821148fecb0f852e8ca
+2026/04/13 10:55:37 SSEHub: registered connection 80e5249e3a5ea821148fecb0f852e8ca (total: 1)
+2026/04/13 10:55:37 SSEHub: unregistered connection 80e5249e3a5ea821148fecb0f852e8ca (total: 0)
+2026/04/13 10:55:37 Received kill signal.  Quitting Writer. stop 0x64b660afd570
+2026/04/13 10:55:37 Cleaning up writer...
+2026/04/13 10:55:37 Finished cleaning up writer:  0x64b660afd570
+2026/04/13 10:55:37 Closed MCP-GET-SSE SSE connection: 80e5249e3a5ea821148fecb0f852e8ca
 
 === Running scenario: prompts-get-with-args ===
 Running client scenario 'prompts-get-with-args' against server: http://localhost:18799/mcp
-2026/04/13 10:07:48 Starting MCP-GET-SSE SSE connection: acdcd769c1d5ff823ea7b6cdab58eec8
-2026/04/13 10:07:48 SSEHub: registered connection acdcd769c1d5ff823ea7b6cdab58eec8 (total: 1)
-2026/04/13 10:07:48 SSEHub: unregistered connection acdcd769c1d5ff823ea7b6cdab58eec8 (total: 0)
-2026/04/13 10:07:48 Received kill signal.  Quitting Writer. stop 0x2d64c780d500
-2026/04/13 10:07:48 Cleaning up writer...
-2026/04/13 10:07:48 Finished cleaning up writer:  0x2d64c780d500
-2026/04/13 10:07:48 Closed MCP-GET-SSE SSE connection: acdcd769c1d5ff823ea7b6cdab58eec8
+2026/04/13 10:55:37 Starting MCP-GET-SSE SSE connection: 1df22345eef21dca9cf22f1e532d4876
+2026/04/13 10:55:37 SSEHub: registered connection 1df22345eef21dca9cf22f1e532d4876 (total: 1)
+2026/04/13 10:55:37 SSEHub: unregistered connection 1df22345eef21dca9cf22f1e532d4876 (total: 0)
+2026/04/13 10:55:37 Received kill signal.  Quitting Writer. stop 0x64b660afd810
+2026/04/13 10:55:37 Cleaning up writer...
+2026/04/13 10:55:37 Finished cleaning up writer:  0x64b660afd810
+2026/04/13 10:55:37 Closed MCP-GET-SSE SSE connection: 1df22345eef21dca9cf22f1e532d4876
 
 === Running scenario: prompts-get-embedded-resource ===
 Running client scenario 'prompts-get-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/13 10:07:48 Starting MCP-GET-SSE SSE connection: a07e70b996cad9cbcdab4d4630ffc08e
-2026/04/13 10:07:48 SSEHub: registered connection a07e70b996cad9cbcdab4d4630ffc08e (total: 1)
-2026/04/13 10:07:48 SSEHub: unregistered connection a07e70b996cad9cbcdab4d4630ffc08e (total: 0)
-2026/04/13 10:07:48 Received kill signal.  Quitting Writer. stop 0x2d64c7d379d0
-2026/04/13 10:07:48 Cleaning up writer...
-2026/04/13 10:07:48 Finished cleaning up writer:  0x2d64c7d379d0
-2026/04/13 10:07:48 Closed MCP-GET-SSE SSE connection: a07e70b996cad9cbcdab4d4630ffc08e
+2026/04/13 10:55:37 Starting MCP-GET-SSE SSE connection: f036c02b353cc68289a414d0a99638c4
+2026/04/13 10:55:37 SSEHub: registered connection f036c02b353cc68289a414d0a99638c4 (total: 1)
+2026/04/13 10:55:37 SSEHub: unregistered connection f036c02b353cc68289a414d0a99638c4 (total: 0)
+2026/04/13 10:55:37 Received kill signal.  Quitting Writer. stop 0x64b660b819d0
+2026/04/13 10:55:37 Cleaning up writer...
+2026/04/13 10:55:37 Finished cleaning up writer:  0x64b660b819d0
+2026/04/13 10:55:37 Closed MCP-GET-SSE SSE connection: f036c02b353cc68289a414d0a99638c4
 
 === Running scenario: prompts-get-with-image ===
 Running client scenario 'prompts-get-with-image' against server: http://localhost:18799/mcp
-2026/04/13 10:07:48 Starting MCP-GET-SSE SSE connection: eda8d63d3b7341dbf4d4331f151cec20
-2026/04/13 10:07:48 SSEHub: registered connection eda8d63d3b7341dbf4d4331f151cec20 (total: 1)
-2026/04/13 10:07:48 SSEHub: unregistered connection eda8d63d3b7341dbf4d4331f151cec20 (total: 0)
-2026/04/13 10:07:48 Received kill signal.  Quitting Writer. stop 0x2d64c7cafe30
-2026/04/13 10:07:48 Cleaning up writer...
-2026/04/13 10:07:48 Finished cleaning up writer:  0x2d64c7cafe30
-2026/04/13 10:07:48 Closed MCP-GET-SSE SSE connection: eda8d63d3b7341dbf4d4331f151cec20
+2026/04/13 10:55:37 Starting MCP-GET-SSE SSE connection: 4dc9629a4e8dd03885912af70fca2885
+2026/04/13 10:55:37 SSEHub: registered connection 4dc9629a4e8dd03885912af70fca2885 (total: 1)
+2026/04/13 10:55:37 SSEHub: unregistered connection 4dc9629a4e8dd03885912af70fca2885 (total: 0)
+2026/04/13 10:55:37 Received kill signal.  Quitting Writer. stop 0x64b660fb16c0
+2026/04/13 10:55:37 Cleaning up writer...
+2026/04/13 10:55:37 Finished cleaning up writer:  0x64b660fb16c0
+2026/04/13 10:55:37 Closed MCP-GET-SSE SSE connection: 4dc9629a4e8dd03885912af70fca2885
 
 === Running scenario: dns-rebinding-protection ===
 Running client scenario 'dns-rebinding-protection' against server: http://localhost:18799/mcp
@@ -421,22 +421,22 @@ Starting scenario: auth/token-endpoint-auth-basic
 Starting scenario: auth/token-endpoint-auth-post
 Starting scenario: auth/token-endpoint-auth-none
 Starting scenario: auth/pre-registration
-Executing client: ./bin/testclient http://localhost:65046/mcp
-Executing client: ./bin/testclient http://localhost:65047/mcp
-Executing client: ./bin/testclient http://localhost:65048/mcp
-Executing client: ./bin/testclient http://localhost:65049/mcp
-Executing client: ./bin/testclient http://localhost:65050/mcp
-Executing client: ./bin/testclient http://localhost:65051/mcp
-Executing client: ./bin/testclient http://localhost:65052/mcp
-Executing client: ./bin/testclient http://localhost:65053/mcp
-Executing client: ./bin/testclient http://localhost:65054/mcp
-Executing client: ./bin/testclient http://localhost:65055/mcp
-Executing client: ./bin/testclient http://localhost:65056/mcp
-Executing client: ./bin/testclient http://localhost:65057/mcp
-Executing client: ./bin/testclient http://localhost:65058/mcp
-Executing client: ./bin/testclient http://localhost:65059/mcp
+Executing client: ./bin/testclient http://localhost:52515/mcp
+Executing client: ./bin/testclient http://localhost:52516/mcp
+Executing client: ./bin/testclient http://localhost:52517/mcp
+Executing client: ./bin/testclient http://localhost:52518/mcp
+Executing client: ./bin/testclient http://localhost:52519/mcp
+Executing client: ./bin/testclient http://localhost:52520/mcp
+Executing client: ./bin/testclient http://localhost:52521/mcp
+Executing client: ./bin/testclient http://localhost:52522/mcp
+Executing client: ./bin/testclient http://localhost:52523/mcp
+Executing client: ./bin/testclient http://localhost:52524/mcp
+Executing client: ./bin/testclient http://localhost:52525/mcp
+Executing client: ./bin/testclient http://localhost:52526/mcp
+Executing client: ./bin/testclient http://localhost:52527/mcp
+Executing client: ./bin/testclient http://localhost:52528/mcp
 With context: {"client_id":"pre-registered-client","client_secret":"pre-registered-secret"}
-(node:12615) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
+(node:34703) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
 (Use `node --trace-deprecation ...` to show where the warning was created)
 
 === SUITE SUMMARY ===
@@ -467,7 +467,7 @@ Total: 210 passed, 0 failed, 1 warnings
   PASS: auth-conformance
 --- [8/8] keycloak ---
 === RUN   TestKeycloak_MCPServer_ValidToken
---- PASS: TestKeycloak_MCPServer_ValidToken (0.03s)
+--- PASS: TestKeycloak_MCPServer_ValidToken (0.02s)
 === RUN   TestKeycloak_MCPServer_TamperedToken
 --- PASS: TestKeycloak_MCPServer_TamperedToken (0.01s)
 === RUN   TestKeycloak_MCPServer_ScopeAllowed
@@ -479,12 +479,12 @@ Total: 210 passed, 0 failed, 1 warnings
 === RUN   TestKeycloak_MCPServer_WWWAuthenticate
 --- PASS: TestKeycloak_MCPServer_WWWAuthenticate (0.01s)
 === RUN   TestKeycloak_MCPServer_PasswordGrant
---- PASS: TestKeycloak_MCPServer_PasswordGrant (0.05s)
+--- PASS: TestKeycloak_MCPServer_PasswordGrant (0.04s)
 PASS
-ok  	github.com/panyam/mcpkit/tests/keycloak	0.738s
+ok  	github.com/panyam/mcpkit/tests/keycloak	1.232s
   PASS: keycloak
 
 === Results: 8 passed, 0 failed ===
-Finished: Mon Apr 13 10:07:51 PDT 2026
+Finished: Mon Apr 13 10:55:41 PDT 2026
 </pre>
 </body></html>

--- a/tests/reports/run.log
+++ b/tests/reports/run.log
@@ -1,35 +1,35 @@
 === MCPKit Comprehensive Test Suite ===
-Started: Mon Apr 13 10:07:02 PDT 2026
+Started: Mon Apr 13 10:54:51 PDT 2026
 
 --- [1/8] unit+coverage ---
-ok  	github.com/panyam/mcpkit/client	8.614s	coverage: 67.4% of statements
+ok  	github.com/panyam/mcpkit/client	7.710s	coverage: 67.4% of statements
 	github.com/panyam/mcpkit/cmd/testserver		coverage: 0.0% of statements
-ok  	github.com/panyam/mcpkit/core	0.699s	coverage: 62.5% of statements
-ok  	github.com/panyam/mcpkit/server	14.366s	coverage: 78.4% of statements
-ok  	github.com/panyam/mcpkit/testutil	0.785s	coverage: 70.5% of statements
+ok  	github.com/panyam/mcpkit/core	0.749s	coverage: 62.5% of statements
+ok  	github.com/panyam/mcpkit/server	13.943s	coverage: 78.4% of statements
+ok  	github.com/panyam/mcpkit/testutil	1.026s	coverage: 70.5% of statements
 Coverage report: tests/reports/coverage.html
   PASS: unit+coverage
 --- [2/8] race ---
-ok  	github.com/panyam/mcpkit/client	8.860s
+ok  	github.com/panyam/mcpkit/client	9.546s
 ?   	github.com/panyam/mcpkit/cmd/testserver	[no test files]
-ok  	github.com/panyam/mcpkit/core	1.760s
-ok  	github.com/panyam/mcpkit/server	15.359s
-ok  	github.com/panyam/mcpkit/testutil	1.572s
+ok  	github.com/panyam/mcpkit/core	1.421s
+ok  	github.com/panyam/mcpkit/server	15.063s
+ok  	github.com/panyam/mcpkit/testutil	1.942s
   PASS: race
 --- [3/8] auth ---
-ok  	github.com/panyam/mcpkit/ext/auth	0.297s
+ok  	github.com/panyam/mcpkit/ext/auth	0.857s
   PASS: auth
 --- [4/8] ui ---
-ok  	github.com/panyam/mcpkit/ext/ui	0.475s
+ok  	github.com/panyam/mcpkit/ext/ui	0.361s
   PASS: ui
 --- [5/8] e2e ---
-ok  	github.com/panyam/mcpkit/tests/e2e	4.156s
-ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.602s
+ok  	github.com/panyam/mcpkit/tests/e2e	4.134s
+ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.594s
   PASS: e2e
 --- [6/8] conformance ---
 Killing stale process on port 18799...
 === Starting test server on :18799 (Streamable HTTP) ===
-Waiting for server....2026/04/13 10:07:45 MCP test server listening on :18799 (Streamable HTTP at /mcp)
+Waiting for server....2026/04/13 10:55:35 MCP test server listening on :18799 (Streamable HTTP at /mcp)
  ready
 
 === Running MCP conformance suite ===
@@ -40,293 +40,293 @@ Running active suite (30 scenarios) against http://localhost:18799/mcp
 
 === Running scenario: server-initialize ===
 Running client scenario 'server-initialize' against server: http://localhost:18799/mcp
-2026/04/13 10:07:47 Starting MCP-GET-SSE SSE connection: 44fd2611de14f57f8cd3c42516019c3d
-2026/04/13 10:07:47 SSEHub: registered connection 44fd2611de14f57f8cd3c42516019c3d (total: 1)
-2026/04/13 10:07:47 SSEHub: unregistered connection 44fd2611de14f57f8cd3c42516019c3d (total: 0)
-2026/04/13 10:07:47 Received kill signal.  Quitting Writer. stop 0x2d64c78be230
-2026/04/13 10:07:47 Cleaning up writer...
-2026/04/13 10:07:47 Finished cleaning up writer:  0x2d64c78be230
-2026/04/13 10:07:47 Closed MCP-GET-SSE SSE connection: 44fd2611de14f57f8cd3c42516019c3d
+2026/04/13 10:55:36 Starting MCP-GET-SSE SSE connection: fe2ac031f81c05bb3747f6811463db9f
+2026/04/13 10:55:36 SSEHub: registered connection fe2ac031f81c05bb3747f6811463db9f (total: 1)
+2026/04/13 10:55:36 SSEHub: unregistered connection fe2ac031f81c05bb3747f6811463db9f (total: 0)
+2026/04/13 10:55:36 Received kill signal.  Quitting Writer. stop 0x64b660eae1c0
+2026/04/13 10:55:36 Cleaning up writer...
+2026/04/13 10:55:36 Finished cleaning up writer:  0x64b660eae1c0
+2026/04/13 10:55:36 Closed MCP-GET-SSE SSE connection: fe2ac031f81c05bb3747f6811463db9f
 
 === Running scenario: logging-set-level ===
 Running client scenario 'logging-set-level' against server: http://localhost:18799/mcp
-2026/04/13 10:07:47 Starting MCP-GET-SSE SSE connection: fdc0017ad3faabd8405f670a8a0544a2
-2026/04/13 10:07:47 SSEHub: registered connection fdc0017ad3faabd8405f670a8a0544a2 (total: 1)
-2026/04/13 10:07:47 SSEHub: unregistered connection fdc0017ad3faabd8405f670a8a0544a2 (total: 0)
-2026/04/13 10:07:47 Received kill signal.  Quitting Writer. stop 0x2d64c7d361c0
-2026/04/13 10:07:47 Cleaning up writer...
-2026/04/13 10:07:47 Finished cleaning up writer:  0x2d64c7d361c0
-2026/04/13 10:07:47 Closed MCP-GET-SSE SSE connection: fdc0017ad3faabd8405f670a8a0544a2
+2026/04/13 10:55:36 Starting MCP-GET-SSE SSE connection: 6b3464420de097c82b2737fa01678bd3
+2026/04/13 10:55:36 SSEHub: registered connection 6b3464420de097c82b2737fa01678bd3 (total: 1)
 
 === Running scenario: ping ===
+2026/04/13 10:55:36 SSEHub: unregistered connection 6b3464420de097c82b2737fa01678bd3 (total: 0)
 Running client scenario 'ping' against server: http://localhost:18799/mcp
-2026/04/13 10:07:47 Starting MCP-GET-SSE SSE connection: e0b14e6a1ce34c15f411ab278e8eeda0
-2026/04/13 10:07:47 SSEHub: registered connection e0b14e6a1ce34c15f411ab278e8eeda0 (total: 1)
-2026/04/13 10:07:47 SSEHub: unregistered connection e0b14e6a1ce34c15f411ab278e8eeda0 (total: 0)
-2026/04/13 10:07:47 Received kill signal.  Quitting Writer. stop 0x2d64c7d36460
-2026/04/13 10:07:47 Cleaning up writer...
+2026/04/13 10:55:36 Received kill signal.  Quitting Writer. stop 0x64b660a484d0
+2026/04/13 10:55:36 Cleaning up writer...
+2026/04/13 10:55:36 Finished cleaning up writer:  0x64b660a484d0
+2026/04/13 10:55:36 Closed MCP-GET-SSE SSE connection: 6b3464420de097c82b2737fa01678bd3
+2026/04/13 10:55:36 Starting MCP-GET-SSE SSE connection: 9be87270ae4e1141df7afee7c7c4e09a
+2026/04/13 10:55:36 SSEHub: registered connection 9be87270ae4e1141df7afee7c7c4e09a (total: 1)
+2026/04/13 10:55:36 SSEHub: unregistered connection 9be87270ae4e1141df7afee7c7c4e09a (total: 0)
+2026/04/13 10:55:36 Received kill signal.  Quitting Writer. stop 0x64b660b80930
+2026/04/13 10:55:36 Cleaning up writer...
+2026/04/13 10:55:36 Finished cleaning up writer:  0x64b660b80930
+2026/04/13 10:55:36 Closed MCP-GET-SSE SSE connection: 9be87270ae4e1141df7afee7c7c4e09a
 
 === Running scenario: completion-complete ===
-2026/04/13 10:07:47 Finished cleaning up writer:  0x2d64c7d36460
-2026/04/13 10:07:47 Closed MCP-GET-SSE SSE connection: e0b14e6a1ce34c15f411ab278e8eeda0
 Running client scenario 'completion-complete' against server: http://localhost:18799/mcp
-2026/04/13 10:07:47 Starting MCP-GET-SSE SSE connection: a3a4ef72f9aed1f88448ccd353ec4300
-2026/04/13 10:07:47 SSEHub: registered connection a3a4ef72f9aed1f88448ccd353ec4300 (total: 1)
-2026/04/13 10:07:47 SSEHub: unregistered connection a3a4ef72f9aed1f88448ccd353ec4300 (total: 0)
-2026/04/13 10:07:47 Received kill signal.  Quitting Writer. stop 0x2d64c7d36700
-2026/04/13 10:07:47 Cleaning up writer...
+2026/04/13 10:55:36 Starting MCP-GET-SSE SSE connection: 0ae6b6b0661fa6d70a86fc5836054568
+2026/04/13 10:55:36 SSEHub: registered connection 0ae6b6b0661fa6d70a86fc5836054568 (total: 1)
+2026/04/13 10:55:36 SSEHub: unregistered connection 0ae6b6b0661fa6d70a86fc5836054568 (total: 0)
+2026/04/13 10:55:36 Received kill signal.  Quitting Writer. stop 0x64b660a48620
+2026/04/13 10:55:36 Cleaning up writer...
+2026/04/13 10:55:36 Finished cleaning up writer:  0x64b660a48620
+2026/04/13 10:55:36 Closed MCP-GET-SSE SSE connection: 0ae6b6b0661fa6d70a86fc5836054568
 
 === Running scenario: tools-list ===
-2026/04/13 10:07:47 Finished cleaning up writer:  0x2d64c7d36700
 Running client scenario 'tools-list' against server: http://localhost:18799/mcp
-2026/04/13 10:07:47 Closed MCP-GET-SSE SSE connection: a3a4ef72f9aed1f88448ccd353ec4300
-2026/04/13 10:07:47 Starting MCP-GET-SSE SSE connection: 8dfc7696852b80586b4e96b4559af18c
-2026/04/13 10:07:47 SSEHub: registered connection 8dfc7696852b80586b4e96b4559af18c (total: 1)
-2026/04/13 10:07:47 SSEHub: unregistered connection 8dfc7696852b80586b4e96b4559af18c (total: 0)
+2026/04/13 10:55:36 Starting MCP-GET-SSE SSE connection: 68f6cccfbff79ee2898dcb65a62e28f7
+2026/04/13 10:55:36 SSEHub: registered connection 68f6cccfbff79ee2898dcb65a62e28f7 (total: 1)
 
 === Running scenario: tools-call-simple-text ===
-2026/04/13 10:07:47 Received kill signal.  Quitting Writer. stop 0x2d64c780c3f0
-2026/04/13 10:07:47 Cleaning up writer...
+2026/04/13 10:55:36 SSEHub: unregistered connection 68f6cccfbff79ee2898dcb65a62e28f7 (total: 0)
 Running client scenario 'tools-call-simple-text' against server: http://localhost:18799/mcp
-2026/04/13 10:07:47 Finished cleaning up writer:  0x2d64c780c3f0
-2026/04/13 10:07:47 Closed MCP-GET-SSE SSE connection: 8dfc7696852b80586b4e96b4559af18c
-2026/04/13 10:07:47 Starting MCP-GET-SSE SSE connection: ab70e60793866f04f69000dd41b18c6f
-2026/04/13 10:07:47 SSEHub: registered connection ab70e60793866f04f69000dd41b18c6f (total: 1)
-2026/04/13 10:07:47 SSEHub: unregistered connection ab70e60793866f04f69000dd41b18c6f (total: 0)
-2026/04/13 10:07:47 Received kill signal.  Quitting Writer. stop 0x2d64c7d369a0
-2026/04/13 10:07:47 Cleaning up writer...
-2026/04/13 10:07:47 Finished cleaning up writer:  0x2d64c7d369a0
-2026/04/13 10:07:47 Closed MCP-GET-SSE SSE connection: ab70e60793866f04f69000dd41b18c6f
+2026/04/13 10:55:36 Received kill signal.  Quitting Writer. stop 0x64b660b80c40
+2026/04/13 10:55:36 Cleaning up writer...
+2026/04/13 10:55:36 Finished cleaning up writer:  0x64b660b80c40
+2026/04/13 10:55:36 Closed MCP-GET-SSE SSE connection: 68f6cccfbff79ee2898dcb65a62e28f7
+2026/04/13 10:55:36 Starting MCP-GET-SSE SSE connection: 948745f25d150226256795797fef6a3c
+2026/04/13 10:55:36 SSEHub: registered connection 948745f25d150226256795797fef6a3c (total: 1)
+2026/04/13 10:55:36 SSEHub: unregistered connection 948745f25d150226256795797fef6a3c (total: 0)
+2026/04/13 10:55:36 Received kill signal.  Quitting Writer. stop 0x64b660a48930
+2026/04/13 10:55:36 Cleaning up writer...
+2026/04/13 10:55:36 Finished cleaning up writer:  0x64b660a48930
+2026/04/13 10:55:36 Closed MCP-GET-SSE SSE connection: 948745f25d150226256795797fef6a3c
 
 === Running scenario: tools-call-image ===
 Running client scenario 'tools-call-image' against server: http://localhost:18799/mcp
-2026/04/13 10:07:47 Starting MCP-GET-SSE SSE connection: bf136235816bb4533fbdc99fa66ac43c
-2026/04/13 10:07:47 SSEHub: registered connection bf136235816bb4533fbdc99fa66ac43c (total: 1)
+2026/04/13 10:55:36 Starting MCP-GET-SSE SSE connection: 6058c30efa96283f151fe390d0e6ecf7
+2026/04/13 10:55:36 SSEHub: registered connection 6058c30efa96283f151fe390d0e6ecf7 (total: 1)
+2026/04/13 10:55:36 SSEHub: unregistered connection 6058c30efa96283f151fe390d0e6ecf7 (total: 0)
 
 === Running scenario: tools-call-audio ===
-2026/04/13 10:07:47 SSEHub: unregistered connection bf136235816bb4533fbdc99fa66ac43c (total: 0)
+2026/04/13 10:55:36 Received kill signal.  Quitting Writer. stop 0x64b660fb0310
+2026/04/13 10:55:36 Cleaning up writer...
+2026/04/13 10:55:36 Finished cleaning up writer:  0x64b660fb0310
+2026/04/13 10:55:36 Closed MCP-GET-SSE SSE connection: 6058c30efa96283f151fe390d0e6ecf7
 Running client scenario 'tools-call-audio' against server: http://localhost:18799/mcp
-2026/04/13 10:07:47 Received kill signal.  Quitting Writer. stop 0x2d64c7984af0
-2026/04/13 10:07:47 Cleaning up writer...
-2026/04/13 10:07:47 Finished cleaning up writer:  0x2d64c7984af0
-2026/04/13 10:07:47 Closed MCP-GET-SSE SSE connection: bf136235816bb4533fbdc99fa66ac43c
-2026/04/13 10:07:47 Starting MCP-GET-SSE SSE connection: 57587ff5e630c576bf330bd7fb5ec5aa
-2026/04/13 10:07:47 SSEHub: registered connection 57587ff5e630c576bf330bd7fb5ec5aa (total: 1)
-2026/04/13 10:07:47 SSEHub: unregistered connection 57587ff5e630c576bf330bd7fb5ec5aa (total: 0)
-2026/04/13 10:07:47 Received kill signal.  Quitting Writer. stop 0x2d64c7d36d20
-2026/04/13 10:07:47 Cleaning up writer...
-2026/04/13 10:07:47 Finished cleaning up writer:  0x2d64c7d36d20
-2026/04/13 10:07:47 Closed MCP-GET-SSE SSE connection: 57587ff5e630c576bf330bd7fb5ec5aa
+2026/04/13 10:55:36 Starting MCP-GET-SSE SSE connection: b150bcd4d1d098f9e6c6e13808589bd6
+2026/04/13 10:55:36 SSEHub: registered connection b150bcd4d1d098f9e6c6e13808589bd6 (total: 1)
+2026/04/13 10:55:36 SSEHub: unregistered connection b150bcd4d1d098f9e6c6e13808589bd6 (total: 0)
 
 === Running scenario: tools-call-embedded-resource ===
+2026/04/13 10:55:36 Received kill signal.  Quitting Writer. stop 0x64b660a48c40
+2026/04/13 10:55:36 Cleaning up writer...
 Running client scenario 'tools-call-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/13 10:07:47 Starting MCP-GET-SSE SSE connection: c5e0ba3117aaf33ada0dc06a1f16c8ff
-2026/04/13 10:07:47 SSEHub: registered connection c5e0ba3117aaf33ada0dc06a1f16c8ff (total: 1)
+2026/04/13 10:55:36 Finished cleaning up writer:  0x64b660a48c40
+2026/04/13 10:55:36 Closed MCP-GET-SSE SSE connection: b150bcd4d1d098f9e6c6e13808589bd6
+2026/04/13 10:55:36 Starting MCP-GET-SSE SSE connection: f6ac9b716aa80b98a48523230fa08864
+2026/04/13 10:55:36 SSEHub: registered connection f6ac9b716aa80b98a48523230fa08864 (total: 1)
+2026/04/13 10:55:36 SSEHub: unregistered connection f6ac9b716aa80b98a48523230fa08864 (total: 0)
+2026/04/13 10:55:36 Received kill signal.  Quitting Writer. stop 0x64b660fb05b0
+2026/04/13 10:55:36 Cleaning up writer...
+2026/04/13 10:55:36 Finished cleaning up writer:  0x64b660fb05b0
+2026/04/13 10:55:36 Closed MCP-GET-SSE SSE connection: f6ac9b716aa80b98a48523230fa08864
 
 === Running scenario: tools-call-mixed-content ===
-2026/04/13 10:07:47 SSEHub: unregistered connection c5e0ba3117aaf33ada0dc06a1f16c8ff (total: 0)
-2026/04/13 10:07:47 Received kill signal.  Quitting Writer. stop 0x2d64c7d36fc0
-2026/04/13 10:07:47 Cleaning up writer...
 Running client scenario 'tools-call-mixed-content' against server: http://localhost:18799/mcp
-2026/04/13 10:07:47 Finished cleaning up writer:  0x2d64c7d36fc0
-2026/04/13 10:07:47 Closed MCP-GET-SSE SSE connection: c5e0ba3117aaf33ada0dc06a1f16c8ff
-2026/04/13 10:07:47 Starting MCP-GET-SSE SSE connection: c001612efeaff464937ef6a45f100754
-2026/04/13 10:07:47 SSEHub: registered connection c001612efeaff464937ef6a45f100754 (total: 1)
-2026/04/13 10:07:47 SSEHub: unregistered connection c001612efeaff464937ef6a45f100754 (total: 0)
-2026/04/13 10:07:47 Received kill signal.  Quitting Writer. stop 0x2d64c780c700
-2026/04/13 10:07:47 Cleaning up writer...
+2026/04/13 10:55:36 Starting MCP-GET-SSE SSE connection: e305db16f5c6baf66a756d34b9c8a162
+2026/04/13 10:55:36 SSEHub: registered connection e305db16f5c6baf66a756d34b9c8a162 (total: 1)
+2026/04/13 10:55:36 SSEHub: unregistered connection e305db16f5c6baf66a756d34b9c8a162 (total: 0)
+2026/04/13 10:55:36 Received kill signal.  Quitting Writer. stop 0x64b660b81180
+2026/04/13 10:55:36 Cleaning up writer...
+2026/04/13 10:55:36 Finished cleaning up writer:  0x64b660b81180
+2026/04/13 10:55:36 Closed MCP-GET-SSE SSE connection: e305db16f5c6baf66a756d34b9c8a162
 
 === Running scenario: tools-call-with-logging ===
-2026/04/13 10:07:47 Finished cleaning up writer:  0x2d64c780c700
 Running client scenario 'tools-call-with-logging' against server: http://localhost:18799/mcp
-2026/04/13 10:07:47 Closed MCP-GET-SSE SSE connection: c001612efeaff464937ef6a45f100754
-2026/04/13 10:07:47 Starting MCP-GET-SSE SSE connection: 258f6b28015e0b4d1046056479e9d5be
-2026/04/13 10:07:47 SSEHub: registered connection 258f6b28015e0b4d1046056479e9d5be (total: 1)
-2026/04/13 10:07:47 SSEHub: unregistered connection 258f6b28015e0b4d1046056479e9d5be (total: 0)
-2026/04/13 10:07:47 Received kill signal.  Quitting Writer. stop 0x2d64c7d37260
-2026/04/13 10:07:47 Cleaning up writer...
-2026/04/13 10:07:47 Finished cleaning up writer:  0x2d64c7d37260
-2026/04/13 10:07:47 Closed MCP-GET-SSE SSE connection: 258f6b28015e0b4d1046056479e9d5be
+2026/04/13 10:55:36 Starting MCP-GET-SSE SSE connection: f4fd00efe9a4e36fa3b4255153d00abb
+2026/04/13 10:55:36 SSEHub: registered connection f4fd00efe9a4e36fa3b4255153d00abb (total: 1)
 
 === Running scenario: tools-call-error ===
+2026/04/13 10:55:37 SSEHub: unregistered connection f4fd00efe9a4e36fa3b4255153d00abb (total: 0)
+2026/04/13 10:55:37 Received kill signal.  Quitting Writer. stop 0x64b660afc150
 Running client scenario 'tools-call-error' against server: http://localhost:18799/mcp
-2026/04/13 10:07:47 Starting MCP-GET-SSE SSE connection: c57b299a1d604d8a76c0eb3d2c1792f9
-2026/04/13 10:07:47 SSEHub: registered connection c57b299a1d604d8a76c0eb3d2c1792f9 (total: 1)
-2026/04/13 10:07:47 SSEHub: unregistered connection c57b299a1d604d8a76c0eb3d2c1792f9 (total: 0)
-2026/04/13 10:07:47 Received kill signal.  Quitting Writer. stop 0x2d64c7d37490
-2026/04/13 10:07:47 Cleaning up writer...
-2026/04/13 10:07:47 Finished cleaning up writer:  0x2d64c7d37490
-2026/04/13 10:07:47 Closed MCP-GET-SSE SSE connection: c57b299a1d604d8a76c0eb3d2c1792f9
+2026/04/13 10:55:37 Cleaning up writer...
+2026/04/13 10:55:37 Finished cleaning up writer:  0x64b660afc150
+2026/04/13 10:55:37 Closed MCP-GET-SSE SSE connection: f4fd00efe9a4e36fa3b4255153d00abb
+2026/04/13 10:55:37 Starting MCP-GET-SSE SSE connection: 0efa36a5cdd0de94bd243c732aa0456e
 
 === Running scenario: tools-call-with-progress ===
+2026/04/13 10:55:37 SSEHub: registered connection 0efa36a5cdd0de94bd243c732aa0456e (total: 1)
 Running client scenario 'tools-call-with-progress' against server: http://localhost:18799/mcp
-2026/04/13 10:07:47 Starting MCP-GET-SSE SSE connection: 8290967fb14a0e0ab7d58d8c7261ac2c
-2026/04/13 10:07:47 SSEHub: registered connection 8290967fb14a0e0ab7d58d8c7261ac2c (total: 1)
-2026/04/13 10:07:47 SSEHub: unregistered connection 8290967fb14a0e0ab7d58d8c7261ac2c (total: 0)
-2026/04/13 10:07:47 Received kill signal.  Quitting Writer. stop 0x2d64c7a0e540
-2026/04/13 10:07:47 Cleaning up writer...
-2026/04/13 10:07:47 Finished cleaning up writer:  0x2d64c7a0e540
-2026/04/13 10:07:47 Closed MCP-GET-SSE SSE connection: 8290967fb14a0e0ab7d58d8c7261ac2c
+2026/04/13 10:55:37 SSEHub: unregistered connection 0efa36a5cdd0de94bd243c732aa0456e (total: 0)
+2026/04/13 10:55:37 Received kill signal.  Quitting Writer. stop 0x64b660a491f0
+2026/04/13 10:55:37 Cleaning up writer...
+2026/04/13 10:55:37 Finished cleaning up writer:  0x64b660a491f0
+2026/04/13 10:55:37 Closed MCP-GET-SSE SSE connection: 0efa36a5cdd0de94bd243c732aa0456e
+2026/04/13 10:55:37 Starting MCP-GET-SSE SSE connection: bf12235f7cdf4a62a3167e7b32f6a9c2
+2026/04/13 10:55:37 SSEHub: registered connection bf12235f7cdf4a62a3167e7b32f6a9c2 (total: 1)
+2026/04/13 10:55:37 SSEHub: unregistered connection bf12235f7cdf4a62a3167e7b32f6a9c2 (total: 0)
 
 === Running scenario: tools-call-sampling ===
+2026/04/13 10:55:37 Received kill signal.  Quitting Writer. stop 0x64b660a49420
+2026/04/13 10:55:37 Cleaning up writer...
+2026/04/13 10:55:37 Finished cleaning up writer:  0x64b660a49420
 Running client scenario 'tools-call-sampling' against server: http://localhost:18799/mcp
-2026/04/13 10:07:47 Starting MCP-GET-SSE SSE connection: 81da6837c3d5e9f89fc7988319895934
-2026/04/13 10:07:47 SSEHub: registered connection 81da6837c3d5e9f89fc7988319895934 (total: 1)
-2026/04/13 10:07:48 SSEHub: unregistered connection 81da6837c3d5e9f89fc7988319895934 (total: 0)
-2026/04/13 10:07:48 Received kill signal.  Quitting Writer. stop 0x2d64c7a0e770
-2026/04/13 10:07:48 Cleaning up writer...
-2026/04/13 10:07:48 Finished cleaning up writer:  0x2d64c7a0e770
-2026/04/13 10:07:48 Closed MCP-GET-SSE SSE connection: 81da6837c3d5e9f89fc7988319895934
+2026/04/13 10:55:37 Closed MCP-GET-SSE SSE connection: bf12235f7cdf4a62a3167e7b32f6a9c2
+2026/04/13 10:55:37 Starting MCP-GET-SSE SSE connection: fa7c9578e33dea086300d1263e8e8640
+2026/04/13 10:55:37 SSEHub: registered connection fa7c9578e33dea086300d1263e8e8640 (total: 1)
+2026/04/13 10:55:37 SSEHub: unregistered connection fa7c9578e33dea086300d1263e8e8640 (total: 0)
+2026/04/13 10:55:37 Received kill signal.  Quitting Writer. stop 0x64b660a496c0
+2026/04/13 10:55:37 Cleaning up writer...
+2026/04/13 10:55:37 Finished cleaning up writer:  0x64b660a496c0
+2026/04/13 10:55:37 Closed MCP-GET-SSE SSE connection: fa7c9578e33dea086300d1263e8e8640
 
 === Running scenario: tools-call-elicitation ===
 Running client scenario 'tools-call-elicitation' against server: http://localhost:18799/mcp
-2026/04/13 10:07:48 Starting MCP-GET-SSE SSE connection: a6c130b4d6ac6e321de4be9887cbfe6f
-2026/04/13 10:07:48 SSEHub: registered connection a6c130b4d6ac6e321de4be9887cbfe6f (total: 1)
-2026/04/13 10:07:48 SSEHub: unregistered connection a6c130b4d6ac6e321de4be9887cbfe6f (total: 0)
-2026/04/13 10:07:48 Received kill signal.  Quitting Writer. stop 0x2d64c780caf0
-2026/04/13 10:07:48 Cleaning up writer...
-2026/04/13 10:07:48 Finished cleaning up writer:  0x2d64c780caf0
-2026/04/13 10:07:48 Closed MCP-GET-SSE SSE connection: a6c130b4d6ac6e321de4be9887cbfe6f
+2026/04/13 10:55:37 Starting MCP-GET-SSE SSE connection: 61446d4f0d13efff1f9a39d30fb05d26
+2026/04/13 10:55:37 SSEHub: registered connection 61446d4f0d13efff1f9a39d30fb05d26 (total: 1)
+2026/04/13 10:55:37 SSEHub: unregistered connection 61446d4f0d13efff1f9a39d30fb05d26 (total: 0)
+2026/04/13 10:55:37 Received kill signal.  Quitting Writer. stop 0x64b660a498f0
+2026/04/13 10:55:37 Cleaning up writer...
+2026/04/13 10:55:37 Finished cleaning up writer:  0x64b660a498f0
 
 === Running scenario: elicitation-sep1034-defaults ===
+2026/04/13 10:55:37 Closed MCP-GET-SSE SSE connection: 61446d4f0d13efff1f9a39d30fb05d26
 Running client scenario 'elicitation-sep1034-defaults' against server: http://localhost:18799/mcp
-2026/04/13 10:07:48 Starting MCP-GET-SSE SSE connection: bc2fb2c8213c9143af02cdcc6e04dfd8
-2026/04/13 10:07:48 SSEHub: registered connection bc2fb2c8213c9143af02cdcc6e04dfd8 (total: 1)
-2026/04/13 10:07:48 SSEHub: unregistered connection bc2fb2c8213c9143af02cdcc6e04dfd8 (total: 0)
+2026/04/13 10:55:37 Starting MCP-GET-SSE SSE connection: c27fdee2564ec5bd6ffbf5073ab2c73b
+2026/04/13 10:55:37 SSEHub: registered connection c27fdee2564ec5bd6ffbf5073ab2c73b (total: 1)
+2026/04/13 10:55:37 SSEHub: unregistered connection c27fdee2564ec5bd6ffbf5073ab2c73b (total: 0)
 
 === Running scenario: server-sse-multiple-streams ===
-2026/04/13 10:07:48 Received kill signal.  Quitting Writer. stop 0x2d64c780cf50
-2026/04/13 10:07:48 Cleaning up writer...
+2026/04/13 10:55:37 Received kill signal.  Quitting Writer. stop 0x64b660afc460
+2026/04/13 10:55:37 Cleaning up writer...
+2026/04/13 10:55:37 Finished cleaning up writer:  0x64b660afc460
+2026/04/13 10:55:37 Closed MCP-GET-SSE SSE connection: c27fdee2564ec5bd6ffbf5073ab2c73b
 Running client scenario 'server-sse-multiple-streams' against server: http://localhost:18799/mcp
-2026/04/13 10:07:48 Finished cleaning up writer:  0x2d64c780cf50
-2026/04/13 10:07:48 Closed MCP-GET-SSE SSE connection: bc2fb2c8213c9143af02cdcc6e04dfd8
-2026/04/13 10:07:48 Starting MCP-GET-SSE SSE connection: b92fe5ae677afa0b30bfe106d1be0c2d
-2026/04/13 10:07:48 SSEHub: registered connection b92fe5ae677afa0b30bfe106d1be0c2d (total: 1)
+2026/04/13 10:55:37 Starting MCP-GET-SSE SSE connection: c24ef1bc5e7373be0955fab1df60bcb2
+2026/04/13 10:55:37 SSEHub: registered connection c24ef1bc5e7373be0955fab1df60bcb2 (total: 1)
 
 === Running scenario: elicitation-sep1330-enums ===
+2026/04/13 10:55:37 SSEHub: unregistered connection c24ef1bc5e7373be0955fab1df60bcb2 (total: 0)
 Running client scenario 'elicitation-sep1330-enums' against server: http://localhost:18799/mcp
-2026/04/13 10:07:48 SSEHub: unregistered connection b92fe5ae677afa0b30bfe106d1be0c2d (total: 0)
-2026/04/13 10:07:48 Received kill signal.  Quitting Writer. stop 0x2d64c7a0ebd0
-2026/04/13 10:07:48 Cleaning up writer...
-2026/04/13 10:07:48 Finished cleaning up writer:  0x2d64c7a0ebd0
-2026/04/13 10:07:48 Closed MCP-GET-SSE SSE connection: b92fe5ae677afa0b30bfe106d1be0c2d
-2026/04/13 10:07:48 Starting MCP-GET-SSE SSE connection: 4aeca845fff7062e34c67ac4fb8035ce
-2026/04/13 10:07:48 SSEHub: registered connection 4aeca845fff7062e34c67ac4fb8035ce (total: 1)
-2026/04/13 10:07:48 SSEHub: unregistered connection 4aeca845fff7062e34c67ac4fb8035ce (total: 0)
-2026/04/13 10:07:48 Received kill signal.  Quitting Writer. stop 0x2d64c7cae620
-2026/04/13 10:07:48 Cleaning up writer...
-2026/04/13 10:07:48 Finished cleaning up writer:  0x2d64c7cae620
-2026/04/13 10:07:48 Closed MCP-GET-SSE SSE connection: 4aeca845fff7062e34c67ac4fb8035ce
+2026/04/13 10:55:37 Received kill signal.  Quitting Writer. stop 0x64b660fb0e70
+2026/04/13 10:55:37 Cleaning up writer...
+2026/04/13 10:55:37 Finished cleaning up writer:  0x64b660fb0e70
+2026/04/13 10:55:37 Closed MCP-GET-SSE SSE connection: c24ef1bc5e7373be0955fab1df60bcb2
+2026/04/13 10:55:37 Starting MCP-GET-SSE SSE connection: b8f401c75723f87467f64fb556ca144d
+2026/04/13 10:55:37 SSEHub: registered connection b8f401c75723f87467f64fb556ca144d (total: 1)
+2026/04/13 10:55:37 SSEHub: unregistered connection b8f401c75723f87467f64fb556ca144d (total: 0)
+2026/04/13 10:55:37 Received kill signal.  Quitting Writer. stop 0x64b660afc700
+2026/04/13 10:55:37 Cleaning up writer...
+2026/04/13 10:55:37 Finished cleaning up writer:  0x64b660afc700
+2026/04/13 10:55:37 Closed MCP-GET-SSE SSE connection: b8f401c75723f87467f64fb556ca144d
 
 === Running scenario: resources-list ===
 Running client scenario 'resources-list' against server: http://localhost:18799/mcp
-2026/04/13 10:07:48 Starting MCP-GET-SSE SSE connection: a5d0af207d8b1fae28d49bb47646c91e
-2026/04/13 10:07:48 SSEHub: registered connection a5d0af207d8b1fae28d49bb47646c91e (total: 1)
+2026/04/13 10:55:37 Starting MCP-GET-SSE SSE connection: fa47b2ee8a112df2de8c2c97468337b3
+2026/04/13 10:55:37 SSEHub: registered connection fa47b2ee8a112df2de8c2c97468337b3 (total: 1)
+2026/04/13 10:55:37 SSEHub: unregistered connection fa47b2ee8a112df2de8c2c97468337b3 (total: 0)
+2026/04/13 10:55:37 Received kill signal.  Quitting Writer. stop 0x64b660a49dc0
+2026/04/13 10:55:37 Cleaning up writer...
+2026/04/13 10:55:37 Finished cleaning up writer:  0x64b660a49dc0
+2026/04/13 10:55:37 Closed MCP-GET-SSE SSE connection: fa47b2ee8a112df2de8c2c97468337b3
 
 === Running scenario: resources-read-text ===
 Running client scenario 'resources-read-text' against server: http://localhost:18799/mcp
-2026/04/13 10:07:48 SSEHub: unregistered connection a5d0af207d8b1fae28d49bb47646c91e (total: 0)
-2026/04/13 10:07:48 Received kill signal.  Quitting Writer. stop 0x2d64c7cae9a0
-2026/04/13 10:07:48 Cleaning up writer...
-2026/04/13 10:07:48 Finished cleaning up writer:  0x2d64c7cae9a0
-2026/04/13 10:07:48 Closed MCP-GET-SSE SSE connection: a5d0af207d8b1fae28d49bb47646c91e
-2026/04/13 10:07:48 Starting MCP-GET-SSE SSE connection: 5f86daef1da88af571f44c6b8489cb74
-2026/04/13 10:07:48 SSEHub: registered connection 5f86daef1da88af571f44c6b8489cb74 (total: 1)
+2026/04/13 10:55:37 Starting MCP-GET-SSE SSE connection: 9790f29d62537fdf07ac1d2302a08a87
+2026/04/13 10:55:37 SSEHub: registered connection 9790f29d62537fdf07ac1d2302a08a87 (total: 1)
+2026/04/13 10:55:37 SSEHub: unregistered connection 9790f29d62537fdf07ac1d2302a08a87 (total: 0)
+2026/04/13 10:55:37 Received kill signal.  Quitting Writer. stop 0x64b660afca10
+2026/04/13 10:55:37 Cleaning up writer...
+2026/04/13 10:55:37 Finished cleaning up writer:  0x64b660afca10
+2026/04/13 10:55:37 Closed MCP-GET-SSE SSE connection: 9790f29d62537fdf07ac1d2302a08a87
 
 === Running scenario: resources-read-binary ===
-2026/04/13 10:07:48 SSEHub: unregistered connection 5f86daef1da88af571f44c6b8489cb74 (total: 0)
 Running client scenario 'resources-read-binary' against server: http://localhost:18799/mcp
-2026/04/13 10:07:48 Received kill signal.  Quitting Writer. stop 0x2d64c7caebd0
-2026/04/13 10:07:48 Cleaning up writer...
-2026/04/13 10:07:48 Finished cleaning up writer:  0x2d64c7caebd0
-2026/04/13 10:07:48 Closed MCP-GET-SSE SSE connection: 5f86daef1da88af571f44c6b8489cb74
-2026/04/13 10:07:48 Starting MCP-GET-SSE SSE connection: 5783428598e2e0ebf2b855a1afa0cacf
-2026/04/13 10:07:48 SSEHub: registered connection 5783428598e2e0ebf2b855a1afa0cacf (total: 1)
-2026/04/13 10:07:48 SSEHub: unregistered connection 5783428598e2e0ebf2b855a1afa0cacf (total: 0)
-2026/04/13 10:07:48 Received kill signal.  Quitting Writer. stop 0x2d64c7caeee0
-2026/04/13 10:07:48 Cleaning up writer...
+2026/04/13 10:55:37 Starting MCP-GET-SSE SSE connection: 1f2fcf9f98b702b94244d1f6331d1025
+2026/04/13 10:55:37 SSEHub: registered connection 1f2fcf9f98b702b94244d1f6331d1025 (total: 1)
+2026/04/13 10:55:37 SSEHub: unregistered connection 1f2fcf9f98b702b94244d1f6331d1025 (total: 0)
+2026/04/13 10:55:37 Received kill signal.  Quitting Writer. stop 0x64b660fb11f0
+2026/04/13 10:55:37 Cleaning up writer...
+2026/04/13 10:55:37 Finished cleaning up writer:  0x64b660fb11f0
+2026/04/13 10:55:37 Closed MCP-GET-SSE SSE connection: 1f2fcf9f98b702b94244d1f6331d1025
 
 === Running scenario: resources-templates-read ===
-2026/04/13 10:07:48 Finished cleaning up writer:  0x2d64c7caeee0
-2026/04/13 10:07:48 Closed MCP-GET-SSE SSE connection: 5783428598e2e0ebf2b855a1afa0cacf
 Running client scenario 'resources-templates-read' against server: http://localhost:18799/mcp
-2026/04/13 10:07:48 Starting MCP-GET-SSE SSE connection: 19d9aed274c0a378397f8e13b8039bc6
-2026/04/13 10:07:48 SSEHub: registered connection 19d9aed274c0a378397f8e13b8039bc6 (total: 1)
-2026/04/13 10:07:48 SSEHub: unregistered connection 19d9aed274c0a378397f8e13b8039bc6 (total: 0)
-2026/04/13 10:07:48 Received kill signal.  Quitting Writer. stop 0x2d64c7caf180
-2026/04/13 10:07:48 Cleaning up writer...
-2026/04/13 10:07:48 Finished cleaning up writer:  0x2d64c7caf180
-2026/04/13 10:07:48 Closed MCP-GET-SSE SSE connection: 19d9aed274c0a378397f8e13b8039bc6
+2026/04/13 10:55:37 Starting MCP-GET-SSE SSE connection: abec7ac9b8364f92f15337012b5e18bc
+2026/04/13 10:55:37 SSEHub: registered connection abec7ac9b8364f92f15337012b5e18bc (total: 1)
+2026/04/13 10:55:37 SSEHub: unregistered connection abec7ac9b8364f92f15337012b5e18bc (total: 0)
+2026/04/13 10:55:37 Received kill signal.  Quitting Writer. stop 0x64b660afcd90
+2026/04/13 10:55:37 Cleaning up writer...
+2026/04/13 10:55:37 Finished cleaning up writer:  0x64b660afcd90
+2026/04/13 10:55:37 Closed MCP-GET-SSE SSE connection: abec7ac9b8364f92f15337012b5e18bc
 
 === Running scenario: resources-subscribe ===
 Running client scenario 'resources-subscribe' against server: http://localhost:18799/mcp
-2026/04/13 10:07:48 Starting MCP-GET-SSE SSE connection: 932c58c244b126d90140de876f20f6e8
-2026/04/13 10:07:48 SSEHub: registered connection 932c58c244b126d90140de876f20f6e8 (total: 1)
+2026/04/13 10:55:37 Starting MCP-GET-SSE SSE connection: 779ffd0898f79357e7b1b2c04a925c98
+2026/04/13 10:55:37 SSEHub: registered connection 779ffd0898f79357e7b1b2c04a925c98 (total: 1)
+2026/04/13 10:55:37 SSEHub: unregistered connection 779ffd0898f79357e7b1b2c04a925c98 (total: 0)
+2026/04/13 10:55:37 Received kill signal.  Quitting Writer. stop 0x64b660fb1420
+2026/04/13 10:55:37 Cleaning up writer...
+2026/04/13 10:55:37 Finished cleaning up writer:  0x64b660fb1420
+2026/04/13 10:55:37 Closed MCP-GET-SSE SSE connection: 779ffd0898f79357e7b1b2c04a925c98
 
 === Running scenario: resources-unsubscribe ===
-2026/04/13 10:07:48 SSEHub: unregistered connection 932c58c244b126d90140de876f20f6e8 (total: 0)
 Running client scenario 'resources-unsubscribe' against server: http://localhost:18799/mcp
-2026/04/13 10:07:48 Received kill signal.  Quitting Writer. stop 0x2d64c7caf500
-2026/04/13 10:07:48 Cleaning up writer...
-2026/04/13 10:07:48 Finished cleaning up writer:  0x2d64c7caf500
-2026/04/13 10:07:48 Closed MCP-GET-SSE SSE connection: 932c58c244b126d90140de876f20f6e8
-2026/04/13 10:07:48 Starting MCP-GET-SSE SSE connection: fd386c902dce1bad3c90bf63edfa7ad2
-2026/04/13 10:07:48 SSEHub: registered connection fd386c902dce1bad3c90bf63edfa7ad2 (total: 1)
-2026/04/13 10:07:48 SSEHub: unregistered connection fd386c902dce1bad3c90bf63edfa7ad2 (total: 0)
-2026/04/13 10:07:48 Received kill signal.  Quitting Writer. stop 0x2d64c7caf730
-2026/04/13 10:07:48 Cleaning up writer...
-2026/04/13 10:07:48 Finished cleaning up writer:  0x2d64c7caf730
-2026/04/13 10:07:48 Closed MCP-GET-SSE SSE connection: fd386c902dce1bad3c90bf63edfa7ad2
+2026/04/13 10:55:37 Starting MCP-GET-SSE SSE connection: 088197ec23b38b37378807821a041e0a
+2026/04/13 10:55:37 SSEHub: registered connection 088197ec23b38b37378807821a041e0a (total: 1)
+2026/04/13 10:55:37 SSEHub: unregistered connection 088197ec23b38b37378807821a041e0a (total: 0)
+2026/04/13 10:55:37 Received kill signal.  Quitting Writer. stop 0x64b660b81650
+2026/04/13 10:55:37 Cleaning up writer...
+2026/04/13 10:55:37 Finished cleaning up writer:  0x64b660b81650
+2026/04/13 10:55:37 Closed MCP-GET-SSE SSE connection: 088197ec23b38b37378807821a041e0a
 
 === Running scenario: prompts-list ===
 Running client scenario 'prompts-list' against server: http://localhost:18799/mcp
-2026/04/13 10:07:48 Starting MCP-GET-SSE SSE connection: 38feec4df1caf86ced568c1494a14380
-2026/04/13 10:07:48 SSEHub: registered connection 38feec4df1caf86ced568c1494a14380 (total: 1)
-2026/04/13 10:07:48 SSEHub: unregistered connection 38feec4df1caf86ced568c1494a14380 (total: 0)
-2026/04/13 10:07:48 Received kill signal.  Quitting Writer. stop 0x2d64c7a0efc0
-2026/04/13 10:07:48 Cleaning up writer...
-2026/04/13 10:07:48 Finished cleaning up writer:  0x2d64c7a0efc0
-2026/04/13 10:07:48 Closed MCP-GET-SSE SSE connection: 38feec4df1caf86ced568c1494a14380
+2026/04/13 10:55:37 Starting MCP-GET-SSE SSE connection: ccb94c9a2ca9be2fef192cf45d83056e
+2026/04/13 10:55:37 SSEHub: registered connection ccb94c9a2ca9be2fef192cf45d83056e (total: 1)
+2026/04/13 10:55:37 SSEHub: unregistered connection ccb94c9a2ca9be2fef192cf45d83056e (total: 0)
+2026/04/13 10:55:37 Received kill signal.  Quitting Writer. stop 0x64b660afd2d0
+2026/04/13 10:55:37 Cleaning up writer...
 
 === Running scenario: prompts-get-simple ===
+2026/04/13 10:55:37 Finished cleaning up writer:  0x64b660afd2d0
+2026/04/13 10:55:37 Closed MCP-GET-SSE SSE connection: ccb94c9a2ca9be2fef192cf45d83056e
 Running client scenario 'prompts-get-simple' against server: http://localhost:18799/mcp
-2026/04/13 10:07:48 Starting MCP-GET-SSE SSE connection: 87343d3c717f97204b6aea321aaab114
-2026/04/13 10:07:48 SSEHub: registered connection 87343d3c717f97204b6aea321aaab114 (total: 1)
-2026/04/13 10:07:48 SSEHub: unregistered connection 87343d3c717f97204b6aea321aaab114 (total: 0)
-2026/04/13 10:07:48 Received kill signal.  Quitting Writer. stop 0x2d64c7caf9d0
-2026/04/13 10:07:48 Cleaning up writer...
-2026/04/13 10:07:48 Finished cleaning up writer:  0x2d64c7caf9d0
-2026/04/13 10:07:48 Closed MCP-GET-SSE SSE connection: 87343d3c717f97204b6aea321aaab114
+2026/04/13 10:55:37 Starting MCP-GET-SSE SSE connection: 80e5249e3a5ea821148fecb0f852e8ca
+2026/04/13 10:55:37 SSEHub: registered connection 80e5249e3a5ea821148fecb0f852e8ca (total: 1)
+2026/04/13 10:55:37 SSEHub: unregistered connection 80e5249e3a5ea821148fecb0f852e8ca (total: 0)
+2026/04/13 10:55:37 Received kill signal.  Quitting Writer. stop 0x64b660afd570
+2026/04/13 10:55:37 Cleaning up writer...
+2026/04/13 10:55:37 Finished cleaning up writer:  0x64b660afd570
+2026/04/13 10:55:37 Closed MCP-GET-SSE SSE connection: 80e5249e3a5ea821148fecb0f852e8ca
 
 === Running scenario: prompts-get-with-args ===
 Running client scenario 'prompts-get-with-args' against server: http://localhost:18799/mcp
-2026/04/13 10:07:48 Starting MCP-GET-SSE SSE connection: acdcd769c1d5ff823ea7b6cdab58eec8
-2026/04/13 10:07:48 SSEHub: registered connection acdcd769c1d5ff823ea7b6cdab58eec8 (total: 1)
-2026/04/13 10:07:48 SSEHub: unregistered connection acdcd769c1d5ff823ea7b6cdab58eec8 (total: 0)
-2026/04/13 10:07:48 Received kill signal.  Quitting Writer. stop 0x2d64c780d500
-2026/04/13 10:07:48 Cleaning up writer...
-2026/04/13 10:07:48 Finished cleaning up writer:  0x2d64c780d500
-2026/04/13 10:07:48 Closed MCP-GET-SSE SSE connection: acdcd769c1d5ff823ea7b6cdab58eec8
+2026/04/13 10:55:37 Starting MCP-GET-SSE SSE connection: 1df22345eef21dca9cf22f1e532d4876
+2026/04/13 10:55:37 SSEHub: registered connection 1df22345eef21dca9cf22f1e532d4876 (total: 1)
+2026/04/13 10:55:37 SSEHub: unregistered connection 1df22345eef21dca9cf22f1e532d4876 (total: 0)
+2026/04/13 10:55:37 Received kill signal.  Quitting Writer. stop 0x64b660afd810
+2026/04/13 10:55:37 Cleaning up writer...
+2026/04/13 10:55:37 Finished cleaning up writer:  0x64b660afd810
+2026/04/13 10:55:37 Closed MCP-GET-SSE SSE connection: 1df22345eef21dca9cf22f1e532d4876
 
 === Running scenario: prompts-get-embedded-resource ===
 Running client scenario 'prompts-get-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/13 10:07:48 Starting MCP-GET-SSE SSE connection: a07e70b996cad9cbcdab4d4630ffc08e
-2026/04/13 10:07:48 SSEHub: registered connection a07e70b996cad9cbcdab4d4630ffc08e (total: 1)
-2026/04/13 10:07:48 SSEHub: unregistered connection a07e70b996cad9cbcdab4d4630ffc08e (total: 0)
-2026/04/13 10:07:48 Received kill signal.  Quitting Writer. stop 0x2d64c7d379d0
-2026/04/13 10:07:48 Cleaning up writer...
-2026/04/13 10:07:48 Finished cleaning up writer:  0x2d64c7d379d0
-2026/04/13 10:07:48 Closed MCP-GET-SSE SSE connection: a07e70b996cad9cbcdab4d4630ffc08e
+2026/04/13 10:55:37 Starting MCP-GET-SSE SSE connection: f036c02b353cc68289a414d0a99638c4
+2026/04/13 10:55:37 SSEHub: registered connection f036c02b353cc68289a414d0a99638c4 (total: 1)
+2026/04/13 10:55:37 SSEHub: unregistered connection f036c02b353cc68289a414d0a99638c4 (total: 0)
+2026/04/13 10:55:37 Received kill signal.  Quitting Writer. stop 0x64b660b819d0
+2026/04/13 10:55:37 Cleaning up writer...
+2026/04/13 10:55:37 Finished cleaning up writer:  0x64b660b819d0
+2026/04/13 10:55:37 Closed MCP-GET-SSE SSE connection: f036c02b353cc68289a414d0a99638c4
 
 === Running scenario: prompts-get-with-image ===
 Running client scenario 'prompts-get-with-image' against server: http://localhost:18799/mcp
-2026/04/13 10:07:48 Starting MCP-GET-SSE SSE connection: eda8d63d3b7341dbf4d4331f151cec20
-2026/04/13 10:07:48 SSEHub: registered connection eda8d63d3b7341dbf4d4331f151cec20 (total: 1)
-2026/04/13 10:07:48 SSEHub: unregistered connection eda8d63d3b7341dbf4d4331f151cec20 (total: 0)
-2026/04/13 10:07:48 Received kill signal.  Quitting Writer. stop 0x2d64c7cafe30
-2026/04/13 10:07:48 Cleaning up writer...
-2026/04/13 10:07:48 Finished cleaning up writer:  0x2d64c7cafe30
-2026/04/13 10:07:48 Closed MCP-GET-SSE SSE connection: eda8d63d3b7341dbf4d4331f151cec20
+2026/04/13 10:55:37 Starting MCP-GET-SSE SSE connection: 4dc9629a4e8dd03885912af70fca2885
+2026/04/13 10:55:37 SSEHub: registered connection 4dc9629a4e8dd03885912af70fca2885 (total: 1)
+2026/04/13 10:55:37 SSEHub: unregistered connection 4dc9629a4e8dd03885912af70fca2885 (total: 0)
+2026/04/13 10:55:37 Received kill signal.  Quitting Writer. stop 0x64b660fb16c0
+2026/04/13 10:55:37 Cleaning up writer...
+2026/04/13 10:55:37 Finished cleaning up writer:  0x64b660fb16c0
+2026/04/13 10:55:37 Closed MCP-GET-SSE SSE connection: 4dc9629a4e8dd03885912af70fca2885
 
 === Running scenario: dns-rebinding-protection ===
 Running client scenario 'dns-rebinding-protection' against server: http://localhost:18799/mcp
@@ -391,22 +391,22 @@ Starting scenario: auth/token-endpoint-auth-basic
 Starting scenario: auth/token-endpoint-auth-post
 Starting scenario: auth/token-endpoint-auth-none
 Starting scenario: auth/pre-registration
-Executing client: ./bin/testclient http://localhost:65046/mcp
-Executing client: ./bin/testclient http://localhost:65047/mcp
-Executing client: ./bin/testclient http://localhost:65048/mcp
-Executing client: ./bin/testclient http://localhost:65049/mcp
-Executing client: ./bin/testclient http://localhost:65050/mcp
-Executing client: ./bin/testclient http://localhost:65051/mcp
-Executing client: ./bin/testclient http://localhost:65052/mcp
-Executing client: ./bin/testclient http://localhost:65053/mcp
-Executing client: ./bin/testclient http://localhost:65054/mcp
-Executing client: ./bin/testclient http://localhost:65055/mcp
-Executing client: ./bin/testclient http://localhost:65056/mcp
-Executing client: ./bin/testclient http://localhost:65057/mcp
-Executing client: ./bin/testclient http://localhost:65058/mcp
-Executing client: ./bin/testclient http://localhost:65059/mcp
+Executing client: ./bin/testclient http://localhost:52515/mcp
+Executing client: ./bin/testclient http://localhost:52516/mcp
+Executing client: ./bin/testclient http://localhost:52517/mcp
+Executing client: ./bin/testclient http://localhost:52518/mcp
+Executing client: ./bin/testclient http://localhost:52519/mcp
+Executing client: ./bin/testclient http://localhost:52520/mcp
+Executing client: ./bin/testclient http://localhost:52521/mcp
+Executing client: ./bin/testclient http://localhost:52522/mcp
+Executing client: ./bin/testclient http://localhost:52523/mcp
+Executing client: ./bin/testclient http://localhost:52524/mcp
+Executing client: ./bin/testclient http://localhost:52525/mcp
+Executing client: ./bin/testclient http://localhost:52526/mcp
+Executing client: ./bin/testclient http://localhost:52527/mcp
+Executing client: ./bin/testclient http://localhost:52528/mcp
 With context: {"client_id":"pre-registered-client","client_secret":"pre-registered-secret"}
-(node:12615) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
+(node:34703) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
 (Use `node --trace-deprecation ...` to show where the warning was created)
 
 === SUITE SUMMARY ===
@@ -437,7 +437,7 @@ Total: 210 passed, 0 failed, 1 warnings
   PASS: auth-conformance
 --- [8/8] keycloak ---
 === RUN   TestKeycloak_MCPServer_ValidToken
---- PASS: TestKeycloak_MCPServer_ValidToken (0.03s)
+--- PASS: TestKeycloak_MCPServer_ValidToken (0.02s)
 === RUN   TestKeycloak_MCPServer_TamperedToken
 --- PASS: TestKeycloak_MCPServer_TamperedToken (0.01s)
 === RUN   TestKeycloak_MCPServer_ScopeAllowed
@@ -449,10 +449,10 @@ Total: 210 passed, 0 failed, 1 warnings
 === RUN   TestKeycloak_MCPServer_WWWAuthenticate
 --- PASS: TestKeycloak_MCPServer_WWWAuthenticate (0.01s)
 === RUN   TestKeycloak_MCPServer_PasswordGrant
---- PASS: TestKeycloak_MCPServer_PasswordGrant (0.05s)
+--- PASS: TestKeycloak_MCPServer_PasswordGrant (0.04s)
 PASS
-ok  	github.com/panyam/mcpkit/tests/keycloak	0.738s
+ok  	github.com/panyam/mcpkit/tests/keycloak	1.232s
   PASS: keycloak
 
 === Results: 8 passed, 0 failed ===
-Finished: Mon Apr 13 10:07:51 PDT 2026
+Finished: Mon Apr 13 10:55:41 PDT 2026


### PR DESCRIPTION
## Summary

- **Display mode negotiation (#185)**: `UIMetadata.SupportedDisplayModes` declares inline/fullscreen/pip support. `ui.RequestDisplayMode(ctx, mode)` emits `notifications/ui/displayMode` for runtime mode switching. Fixes iframe sizing bugs (e.g., slyds in VS Code).
- **URI template resources (#190)**: `RegisterAppTool` auto-detects template URIs (containing `{`) and routes to `RegisterResourceTemplate`. `TemplateHandler` field on `AppToolConfig` for parameterized HTML serving (SSR).
- **App metadata on elicitation/sampling (#191)**: `ElicitationRequest.Meta` and `CreateMessageRequest.Meta` carry `_meta.ui` on the wire. `ui.ElicitWithApp` and `ui.SampleWithApp` convenience wrappers in ext/ui.

## Files changed

| Area | Files | What |
|------|-------|------|
| core types | `core/ui.go` | `DisplayMode` type + 3 constants, `SupportedDisplayModes` on `UIMetadata` |
| core types | `core/elicitation.go` | `ElicitationMeta`, `Meta` field on `ElicitationRequest` |
| core types | `core/sampling.go` | `SamplingMeta`, `Meta` field on `CreateMessageRequest` |
| ext/ui | `ext/ui/extension.go` | Widened `ToolResourceRegistrar`, template detection, `RequestDisplayMode`, `ElicitWithApp`, `SampleWithApp` |
| tests | `core/*_test.go`, `ext/ui/*_test.go` | 6 new test cases |
| conformance | `cmd/testserver/conformance_apps.go` | `request-fullscreen` and `elicit-with-ui` tools |
| docs | `CLAUDE.md`, `CAPABILITIES.md` | Updated with new features |

## Test plan

- [x] `make test` — all core/server/client tests pass
- [x] `make test-ui` — ext/ui unit tests pass (including new template/display mode tests)
- [x] `make test-e2e` — e2e apps conformance
- [x] `make testconf` — full MCP conformance suite

Closes #185, closes #190, closes #191.
Downstream: panyam/slyds#93