### PR TITLE
feat(ext/ui): auto-generate concrete fallback for template resourceUri

### DIFF
--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -1,7 +1,7 @@
 # MCPKit
 
 ## Version
-0.1.1
+0.2.3
 
 ## Provides
 - mcp-protocol-negotiation: Version negotiation supporting MCP 2025-11-25 and 2024-11-05
@@ -63,8 +63,11 @@
 - mcp-apps-register-helper: RegisterAppTool (ext/ui) — registers tool + resource pair in one call via ToolResourceRegistrar interface. Auto-detects template URIs (containing `{`) and routes to RegisterResourceTemplate; concrete URIs use RegisterResource.
 - mcp-apps-display-modes: UIMetadata.SupportedDisplayModes — apps declare inline/fullscreen/pip support. RequestDisplayMode(ctx, mode) emits notifications/ui/displayMode. (#185)
 - mcp-apps-template-resources: RegisterAppTool auto-detects template URIs and registers resource templates. TemplateHandler field on AppToolConfig for parameterized HTML serving (SSR). (#190)
+- mcp-apps-template-fallback: RegisterAppTool auto-generates concrete fallback resource (`ui://{host}/{tool}/latest`) for template URIs when TemplateHandler is provided. Wraps tool handler to capture args, delegates fallback to TemplateHandler with stored params. Transparent to consumers — removed when hosts support template substitution. (#213)
+- mcp-uri-template-helpers: core.URITemplateVars/core.IsTemplateURI — RFC 6570 template detection using yosida95/uritemplate (replaces string-based `{` checks)
 - mcp-apps-elicitation-meta: ElicitationRequest._meta.ui and CreateMessageRequest._meta.ui — app metadata on server-to-client requests. ElicitWithApp/SampleWithApp helpers in ext/ui. (#191)
 - mcp-apps-conformance: 21 MCP Apps conformance tests (tool metadata, resources, visibility, fallback, negotiation)
+- mcp-protogen: ext/protogen — protoc plugin (protoc-gen-go-mcp) generates MCP tool registrations from proto service definitions. In-process, gRPC forwarding, and ConnectRPC forwarding variants. Proto annotations (mcp_tool, mcp_resource, mcp_prompt) for semantic mapping. JSON Schema derived from proto messages. Uses typed handler contexts (core.ToolContext). (#211)
 - mcp-dynamic-registration: Registry.AddTool/RemoveTool/AddResource/RemoveResource/AddPrompt/RemovePrompt — thread-safe runtime registration with automatic notifications/*/list_changed broadcast via OnChange callback
 - mcp-session-timeout: WithSessionTimeout — idle session cleanup for Streamable HTTP (timer + ref counting to avoid closing mid-execution)
 - mcp-sse-resumption: WithSSEGracePeriod — SSE sessions survive brief disconnects with grace timer. Client reconnects via ?sessionId= query param; server replays missed events via Last-Event-ID header. Principal-bound for security.
@@ -86,10 +89,13 @@ newstack/mcpkit/main
 ## Stack Dependencies
 
 ### Core module (github.com/panyam/mcpkit)
-- servicekit (github.com/panyam/servicekit) v0.0.22 — SSEConn/SSEHub, ListenAndServeGraceful, StreamableServe, HTTPStatusError (with Header), MaxErrorBodySize
+- servicekit (github.com/panyam/servicekit) v0.0.25 — SSEConn/SSEHub, ListenAndServeGraceful, StreamableServe, HTTPStatusError (with Header), MaxErrorBodySize
 
 ### Sub-module: ext/auth (github.com/panyam/mcpkit/ext/auth)
-- oneauth (github.com/panyam/oneauth) v0.0.64 — JWT/OIDC validation, testutil.TestAuthServer; separate go.mod
+- oneauth (github.com/panyam/oneauth) v0.0.71 — JWT/OIDC validation, testutil.TestAuthServer; separate go.mod
+
+### Sub-module: ext/protogen (github.com/panyam/mcpkit/ext/protogen)
+- protokit (github.com/panyam/protokit) v0.0.2 — proto descriptor test utilities
 
 ## Integration
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## What This Is
 
-Go library for building production-grade MCP servers and clients. Three packages (`core/`, `server/`, `client/`) plus sub-modules (`ext/auth/`, `ext/ui/`).
+Go library for building production-grade MCP servers and clients. Three packages (`core/`, `server/`, `client/`) plus sub-modules (`ext/auth/`, `ext/ui/`, `ext/protogen/`).
 
 ## Quick Commands
 
@@ -27,6 +27,7 @@ make upkcl / downkcl  # Keycloak container lifecycle
 - **`client/`** — Client, HTTP/Stdio/Command transports, reconnection, auth retry
 - **`ext/auth/`** — Separate Go module: JWT validation, PRM, OAuth token sources. See `ext/auth/docs/DESIGN.md`
 - **`ext/ui/`** — Separate Go module: MCP Apps extension. See `docs/APPS_DESIGN.md`
+- **`ext/protogen/`** — Separate Go module: proto annotation-driven MCP code generation. See `ext/protogen/docs/DESIGN.md`
 - **`testutil/`** — `NewTestServer`, `ForAllTransports`, `TestClient`
 - **`cmd/testserver/`** — Conformance test server
 - **`tests/e2e/`, `tests/keycloak/`** — Separate Go modules with `replace` directives
@@ -45,13 +46,15 @@ func myTool(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error)
 
 ### Registration
 - Two-arg: `srv.RegisterTool(def, handler)` / Single-struct: `srv.Register(server.Tool{Def, Handler})`
-- `ext/ui.RegisterAppTool(reg, cfg)` — registers tool + resource in one call, auto-detects template URIs
+- `ext/ui.RegisterAppTool(reg, cfg)` — registers tool + resource in one call, auto-detects template URIs. With `TemplateHandler`: auto-generates concrete fallback for hosts that don't substitute template vars. Without: manual hybrid path.
 - Schema validation panics at registration for malformed schemas
 
 ### Sub-Modules
-- `ext/auth/` and `ext/ui/` have separate `go.mod` — `make test` does NOT cover them
-- Release order: tag root → `make bump-root V=vX.Y.Z` → tag sub-modules. Don't retag published versions.
+- `ext/auth/`, `ext/ui/`, and `ext/protogen/` have separate `go.mod` — `make test` does NOT cover them
+- Release order: tag root → `make bump-root V=vX.Y.Z` → tag sub-modules (`ext/auth/vX.Y.Z`, `ext/ui/vX.Y.Z`, `ext/protogen/vX.Y.Z`). Don't retag published versions.
 - `scripts/verify-submodule-deps.sh` catches `v0.0.0` placeholder bugs (wired into pre-push hook)
+- `SUB_MODS_ALL` in Makefile lists all sub-modules for `tidy-all` and `bump-root`
+- **New core deps propagate**: adding imports to `core/` (e.g., `uritemplate`) requires `go mod tidy` in every sub-module to update their `go.sum`
 
 ## Gotchas
 
@@ -61,6 +64,8 @@ func myTool(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error)
 - **Ping before initialize**: Always handled regardless of init state.
 - **Error codes**: App errors use -31xxx range, JSON-RPC reserved range is -32xxx.
 - **`GH_TOKEN="$GH_PERSONAL_TOKEN"`**: Use personal token for GitHub operations (EMU account can't access personal repos).
+- **Template URI detection**: Use `core.IsTemplateURI()` (RFC 6570 parsing), not `strings.Contains("{")`.
+- **Sub-module go.sum drift**: Adding a new import in `core/` breaks sub-module builds until `make tidy-all` runs. Always run `make testall` after touching core imports.
 
 ## Deeper Documentation
 
@@ -69,6 +74,7 @@ func myTool(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error)
 | Architecture | `docs/ARCHITECTURE.md` |
 | Auth design & spec compliance | `ext/auth/docs/DESIGN.md` |
 | MCP Apps design | `docs/APPS_DESIGN.md` |
+| Protogen design | `ext/protogen/docs/DESIGN.md` |
 | Capabilities list | `CAPABILITIES.md` |
 | Constraints | `core/CONSTRAINTS.md`, `server/CONSTRAINTS.md`, `client/CONSTRAINTS.md` |
 | Conformance baseline | `conformance/baseline.yml` |

--- a/cmd/testclient/go.mod
+++ b/cmd/testclient/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/panyam/gocurrent v0.1.0 // indirect
 	github.com/panyam/goutils v0.1.8 // indirect
 	github.com/panyam/servicekit v0.0.25 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	golang.org/x/crypto v0.46.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
 	golang.org/x/sys v0.39.0 // indirect

--- a/core/uritemplate.go
+++ b/core/uritemplate.go
@@ -1,0 +1,24 @@
+package core
+
+import uritemplate "github.com/yosida95/uritemplate/v3"
+
+// URITemplateVars parses uri as an RFC 6570 URI template and returns the
+// variable names it contains.  Returns nil when uri is not a valid template
+// or contains no variables (i.e. is a concrete URI).
+func URITemplateVars(uri string) []string {
+	tmpl, err := uritemplate.New(uri)
+	if err != nil {
+		return nil
+	}
+	names := tmpl.Varnames()
+	if len(names) == 0 {
+		return nil
+	}
+	return names
+}
+
+// IsTemplateURI reports whether uri is a valid RFC 6570 URI template with
+// at least one variable expression.
+func IsTemplateURI(uri string) bool {
+	return URITemplateVars(uri) != nil
+}

--- a/ext/auth/go.mod
+++ b/ext/auth/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/fernet/fernet-go v0.0.0-20240119011108-303da6aec611 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	golang.org/x/crypto v0.46.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/ext/auth/go.sum
+++ b/ext/auth/go.sum
@@ -19,6 +19,8 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 golang.org/x/crypto v0.46.0 h1:cKRW/pmt1pKAfetfu+RCEvjvZkA9RimPbh7bhFjGVBU=
 golang.org/x/crypto v0.46.0/go.mod h1:Evb/oLKmMraqjZ2iQTwDwvCtJkczlDuTmdJXoZVzqU0=
 golang.org/x/oauth2 v0.34.0 h1:hqK/t4AKgbqWkdkcAeI8XLmbK+4m4G5YeQRrmiotGlw=

--- a/ext/ui/app_helpers_test.go
+++ b/ext/ui/app_helpers_test.go
@@ -122,26 +122,33 @@ func TestValidateRefsNoMetaSkipped(t *testing.T) {
 
 // mockRegistrar captures RegisterTool, RegisterResource, and RegisterResourceTemplate calls for testing.
 type mockRegistrar struct {
-	tools     []core.ToolDef
-	resources []core.ResourceDef
-	templates []core.ResourceTemplate
+	tools            []core.ToolDef
+	toolHandlers     []core.ToolHandler
+	resources        []core.ResourceDef
+	resourceHandlers []core.ResourceHandler
+	templates        []core.ResourceTemplate
+	templateHandlers []core.TemplateHandler
 }
 
-func (m *mockRegistrar) RegisterTool(def core.ToolDef, _ core.ToolHandler) {
+func (m *mockRegistrar) RegisterTool(def core.ToolDef, h core.ToolHandler) {
 	m.tools = append(m.tools, def)
+	m.toolHandlers = append(m.toolHandlers, h)
 }
 
-func (m *mockRegistrar) RegisterResource(def core.ResourceDef, _ core.ResourceHandler) {
+func (m *mockRegistrar) RegisterResource(def core.ResourceDef, h core.ResourceHandler) {
 	m.resources = append(m.resources, def)
+	m.resourceHandlers = append(m.resourceHandlers, h)
 }
 
-func (m *mockRegistrar) RegisterResourceTemplate(def core.ResourceTemplate, _ core.TemplateHandler) {
+func (m *mockRegistrar) RegisterResourceTemplate(def core.ResourceTemplate, h core.TemplateHandler) {
 	m.templates = append(m.templates, def)
+	m.templateHandlers = append(m.templateHandlers, h)
 }
 
 // TestRegisterAppToolTemplate verifies that RegisterAppTool detects a template
-// URI (contains "{") and routes registration to RegisterResourceTemplate instead
-// of RegisterResource.
+// URI, registers both a template resource and a concrete fallback, and
+// advertises the concrete fallback URI in the tool's _meta.ui.resourceUri
+// so hosts that don't support template variable substitution can fetch it.
 func TestRegisterAppToolTemplate(t *testing.T) {
 	reg := &mockRegistrar{}
 
@@ -158,11 +165,9 @@ func TestRegisterAppToolTemplate(t *testing.T) {
 		},
 	})
 
+	// Template resource is always registered for smart clients.
 	if len(reg.templates) != 1 {
 		t.Fatalf("expected 1 template, got %d", len(reg.templates))
-	}
-	if len(reg.resources) != 0 {
-		t.Errorf("expected 0 resources, got %d", len(reg.resources))
 	}
 	tmpl := reg.templates[0]
 	if tmpl.URITemplate != "ui://pizzas/{pizzaId}/details" {
@@ -172,15 +177,24 @@ func TestRegisterAppToolTemplate(t *testing.T) {
 		t.Errorf("MimeType = %q, want %q", tmpl.MimeType, core.AppMIMEType)
 	}
 
-	// Tool should still have the correct _meta.ui.resourceUri
+	// Concrete fallback resource is auto-generated for current hosts.
+	wantConcreteURI := "ui://pizzas/show_pizza/latest"
+	if len(reg.resources) != 1 {
+		t.Fatalf("expected 1 concrete fallback resource, got %d", len(reg.resources))
+	}
+	if reg.resources[0].URI != wantConcreteURI {
+		t.Errorf("concrete resource URI = %q, want %q", reg.resources[0].URI, wantConcreteURI)
+	}
+
+	// Tool's _meta.ui.resourceUri should point to the concrete fallback.
 	if len(reg.tools) != 1 {
 		t.Fatalf("expected 1 tool, got %d", len(reg.tools))
 	}
 	if reg.tools[0].Meta == nil || reg.tools[0].Meta.UI == nil {
 		t.Fatal("tool Meta.UI is nil")
 	}
-	if reg.tools[0].Meta.UI.ResourceUri != "ui://pizzas/{pizzaId}/details" {
-		t.Errorf("resourceUri = %q, want template URI", reg.tools[0].Meta.UI.ResourceUri)
+	if reg.tools[0].Meta.UI.ResourceUri != wantConcreteURI {
+		t.Errorf("resourceUri = %q, want %q", reg.tools[0].Meta.UI.ResourceUri, wantConcreteURI)
 	}
 }
 
@@ -257,5 +271,117 @@ func TestRegisterAppToolSupportedDisplayModes(t *testing.T) {
 	}
 	if ui.SupportedDisplayModes[1] != core.DisplayModeFullscreen {
 		t.Errorf("SupportedDisplayModes[1] = %q, want %q", ui.SupportedDisplayModes[1], core.DisplayModeFullscreen)
+	}
+}
+
+// TestTemplateManualHybrid verifies that providing a template URI with a
+// ResourceHandler (no TemplateHandler) falls through to the manual hybrid
+// path — no auto-generated fallback, consumer owns the concrete resource.
+func TestTemplateManualHybrid(t *testing.T) {
+	reg := &mockRegistrar{}
+
+	RegisterAppTool(reg, AppToolConfig{
+		Name:        "manual_tool",
+		Description: "Manual hybrid",
+		InputSchema: map[string]any{"type": "object"},
+		ResourceURI: "ui://app/{id}/view",
+		ToolHandler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+			return core.TextResult("ok"), nil
+		},
+		ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
+			return core.ResourceResult{}, nil
+		},
+		// TemplateHandler intentionally nil — manual hybrid
+	})
+
+	// No template registered (manual pattern owns everything).
+	if len(reg.templates) != 0 {
+		t.Errorf("expected 0 templates, got %d", len(reg.templates))
+	}
+	// Resource registered with the original template URI as-is.
+	if len(reg.resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(reg.resources))
+	}
+	if reg.resources[0].URI != "ui://app/{id}/view" {
+		t.Errorf("resource URI = %q, want %q", reg.resources[0].URI, "ui://app/{id}/view")
+	}
+	// Tool's resourceUri is the original (consumer manages it).
+	if reg.tools[0].Meta.UI.ResourceUri != "ui://app/{id}/view" {
+		t.Errorf("resourceUri = %q, want original template URI", reg.tools[0].Meta.UI.ResourceUri)
+	}
+}
+
+// TestConcreteFallbackURI verifies the synthetic URI generation.
+func TestConcreteFallbackURI(t *testing.T) {
+	tests := []struct {
+		templateURI string
+		toolName    string
+		want        string
+	}{
+		{"ui://slyds/decks/{deck}/preview", "preview_deck", "ui://slyds/preview_deck/latest"},
+		{"ui://pizzas/{pizzaId}/details", "show_pizza", "ui://pizzas/show_pizza/latest"},
+		{"ui://app/{a}/{b}/view", "my_tool", "ui://app/my_tool/latest"},
+		{"not-a-uri", "tool", "ui://tool/latest"}, // malformed URI fallback
+	}
+	for _, tt := range tests {
+		got := concreteFallbackURI(tt.templateURI, tt.toolName)
+		if got != tt.want {
+			t.Errorf("concreteFallbackURI(%q, %q) = %q, want %q", tt.templateURI, tt.toolName, got, tt.want)
+		}
+	}
+}
+
+// TestExtractTemplateParams verifies extraction of template variable values
+// from tool arguments JSON.
+func TestExtractTemplateParams(t *testing.T) {
+	tests := []struct {
+		name string
+		vars []string
+		args string
+		want map[string]string
+	}{
+		{
+			name: "string values",
+			vars: []string{"deck", "slide"},
+			args: `{"deck": "q3-review", "slide": "intro", "extra": "ignored"}`,
+			want: map[string]string{"deck": "q3-review", "slide": "intro"},
+		},
+		{
+			name: "numeric value stringified",
+			vars: []string{"id"},
+			args: `{"id": 42}`,
+			want: map[string]string{"id": "42"},
+		},
+		{
+			name: "missing var",
+			vars: []string{"deck", "missing"},
+			args: `{"deck": "hello"}`,
+			want: map[string]string{"deck": "hello"},
+		},
+		{
+			name: "empty args",
+			vars: []string{"x"},
+			args: ``,
+			want: map[string]string{},
+		},
+		{
+			name: "null args",
+			vars: []string{"x"},
+			args: `null`,
+			want: map[string]string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractTemplateParams(tt.vars, []byte(tt.args))
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for k, v := range tt.want {
+				if got[k] != v {
+					t.Errorf("params[%q] = %q, want %q", k, got[k], v)
+				}
+			}
+		})
 	}
 }

--- a/ext/ui/extension.go
+++ b/ext/ui/extension.go
@@ -15,8 +15,11 @@ package ui
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/url"
 	"strings"
+	"sync/atomic"
 
 	"github.com/panyam/mcpkit/core"
 )
@@ -147,6 +150,78 @@ func RegisterAppTool(reg ToolResourceRegistrar, cfg AppToolConfig) {
 		SupportedDisplayModes: cfg.SupportedDisplayModes,
 	}
 
+	templateVars := core.URITemplateVars(cfg.ResourceURI)
+	if len(templateVars) > 0 && cfg.TemplateHandler != nil {
+		// Auto-fallback path: consumer provides a TemplateHandler and mcpkit
+		// generates the concrete fallback transparently. If TemplateHandler
+		// is nil the template URI falls through to the concrete path below,
+		// letting consumers manage the hybrid pattern manually.
+
+		// Always register the template resource for clients that support
+		// template variable substitution.
+		reg.RegisterResourceTemplate(
+			core.ResourceTemplate{
+				URITemplate: cfg.ResourceURI,
+				Name:        cfg.Name + " UI",
+				MimeType:    core.AppMIMEType,
+			},
+			cfg.TemplateHandler,
+		)
+
+		// Generate a concrete fallback for current hosts that fetch
+		// _meta.ui.resourceUri literally without substituting variables.
+		concreteURI := concreteFallbackURI(cfg.ResourceURI, cfg.Name)
+		uiMeta.ResourceUri = concreteURI
+
+		// Atomic storage for the last tool-call params.
+		var lastParams atomic.Pointer[map[string]string]
+
+		// Wrap the tool handler to capture template variable values
+		// from tool arguments after each successful call.
+		origHandler := cfg.ToolHandler
+		wrappedHandler := func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+			result, err := origHandler(ctx, req)
+			if err == nil {
+				params := extractTemplateParams(templateVars, req.Arguments)
+				lastParams.Store(&params)
+			}
+			return result, err
+		}
+
+		// Concrete fallback handler delegates to TemplateHandler with
+		// the params captured from the most recent tool call.
+		tmplHandler := cfg.TemplateHandler
+		reg.RegisterResource(
+			core.ResourceDef{
+				URI:      concreteURI,
+				Name:     cfg.Name + " UI",
+				MimeType: core.AppMIMEType,
+			},
+			func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
+				params := lastParams.Load()
+				if params == nil {
+					empty := map[string]string{}
+					params = &empty
+				}
+				return tmplHandler(ctx, req.URI, *params)
+			},
+		)
+
+		// Register tool with the wrapped handler and concrete
+		// resourceUri in _meta.ui.
+		reg.RegisterTool(
+			core.ToolDef{
+				Name:        cfg.Name,
+				Description: cfg.Description,
+				InputSchema: cfg.InputSchema,
+				Meta:        &core.ToolMeta{UI: uiMeta},
+			},
+			wrappedHandler,
+		)
+		return
+	}
+
+	// Concrete URI path: register tool and resource directly.
 	reg.RegisterTool(
 		core.ToolDef{
 			Name:        cfg.Name,
@@ -157,31 +232,20 @@ func RegisterAppTool(reg ToolResourceRegistrar, cfg AppToolConfig) {
 		cfg.ToolHandler,
 	)
 
-	if strings.Contains(cfg.ResourceURI, "{") {
-		if cfg.TemplateHandler == nil {
-			panic("RegisterAppTool: template URI " + cfg.ResourceURI + " requires TemplateHandler, got nil")
+	if cfg.ResourceHandler == nil {
+		if core.IsTemplateURI(cfg.ResourceURI) {
+			panic("RegisterAppTool: template URI " + cfg.ResourceURI + " requires TemplateHandler or ResourceHandler, got neither")
 		}
-		reg.RegisterResourceTemplate(
-			core.ResourceTemplate{
-				URITemplate: cfg.ResourceURI,
-				Name:        cfg.Name + " UI",
-				MimeType:    core.AppMIMEType,
-			},
-			cfg.TemplateHandler,
-		)
-	} else {
-		if cfg.ResourceHandler == nil {
-			panic("RegisterAppTool: concrete URI " + cfg.ResourceURI + " requires ResourceHandler, got nil")
-		}
-		reg.RegisterResource(
-			core.ResourceDef{
-				URI:      cfg.ResourceURI,
-				Name:     cfg.Name + " UI",
-				MimeType: core.AppMIMEType,
-			},
-			cfg.ResourceHandler,
-		)
+		panic("RegisterAppTool: concrete URI " + cfg.ResourceURI + " requires ResourceHandler, got nil")
 	}
+	reg.RegisterResource(
+		core.ResourceDef{
+			URI:      cfg.ResourceURI,
+			Name:     cfg.Name + " UI",
+			MimeType: core.AppMIMEType,
+		},
+		cfg.ResourceHandler,
+	)
 }
 
 // RequestDisplayMode sends a display mode change notification to the client.
@@ -242,4 +306,45 @@ func matchesAnyTemplate(uri string, templates []string) bool {
 		}
 	}
 	return false
+}
+
+// concreteFallbackURI generates a synthetic concrete URI from a template URI
+// and tool name. The authority (host) portion of the template URI is preserved
+// so the concrete fallback lives in the same namespace.
+//
+// Example: "ui://slyds/decks/{deck}/preview", "preview_deck" → "ui://slyds/preview_deck/latest"
+func concreteFallbackURI(templateURI, toolName string) string {
+	u, err := url.Parse(templateURI)
+	if err != nil || u.Host == "" {
+		// Fallback: use the tool name alone.
+		return "ui://" + toolName + "/latest"
+	}
+	return "ui://" + u.Host + "/" + toolName + "/latest"
+}
+
+// extractTemplateParams extracts template variable values from tool arguments.
+// For each variable name in vars, if a matching key exists in the JSON
+// arguments object, its string value is included in the result map.
+func extractTemplateParams(vars []string, args json.RawMessage) map[string]string {
+	params := make(map[string]string, len(vars))
+	if len(args) == 0 {
+		return params
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(args, &m); err != nil {
+		return params
+	}
+	for _, v := range vars {
+		raw, ok := m[v]
+		if !ok {
+			continue
+		}
+		// Try to unquote a JSON string; fall back to raw literal.
+		var s string
+		if err := json.Unmarshal(raw, &s); err != nil {
+			s = string(raw)
+		}
+		params[v] = s
+	}
+	return params
 }

--- a/ext/ui/go.mod
+++ b/ext/ui/go.mod
@@ -4,4 +4,6 @@ go 1.26.1
 
 require github.com/panyam/mcpkit v0.2.3
 
+require github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
+
 replace github.com/panyam/mcpkit => ../../

--- a/ext/ui/go.sum
+++ b/ext/ui/go.sum
@@ -4,5 +4,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/tests/reports/report.html
+++ b/tests/reports/report.html
@@ -15,7 +15,7 @@ th { background: #f5f5f5; font-weight: 600; }
 pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto; font-size: 13px; max-height: 400px; overflow-y: auto; }
 </style></head><body>
 <h1>MCPKit Test Report</h1>
-<div class='meta'>Branch: <strong>main</strong> | Commit: <code>512bf5b</code> | Date: 2026-04-13 13:50:46</div>
+<div class='meta'>Branch: <strong>feat/completions-59</strong> | Commit: <code>3d9d68d</code> | Date: 2026-04-13 15:18:08</div>
 <table><tr><th>Stage</th><th>Result</th></tr>
 <tr><td>unit+coverage</td><td class='pass'>PASS</td></tr>
 <tr><td>race</td><td class='pass'>PASS</td></tr>
@@ -29,37 +29,39 @@ pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto; 
 <div class='summary-pass'>All 8 stages passed</div>
 <h2>Full Log</h2><pre>
 === MCPKit Comprehensive Test Suite ===
-Started: Mon Apr 13 13:49:56 PDT 2026
+Started: Mon Apr 13 15:17:26 PDT 2026
 
 --- [1/8] unit+coverage ---
-ok  	github.com/panyam/mcpkit/client	7.645s	coverage: 67.4% of statements
+ok  	github.com/panyam/mcpkit/client	7.230s	coverage: 67.4% of statements
 	github.com/panyam/mcpkit/cmd/testserver		coverage: 0.0% of statements
-ok  	github.com/panyam/mcpkit/core	0.633s	coverage: 49.2% of statements
-ok  	github.com/panyam/mcpkit/server	14.001s	coverage: 78.4% of statements
-ok  	github.com/panyam/mcpkit/testutil	1.023s	coverage: 70.5% of statements
+ok  	github.com/panyam/mcpkit/core	0.377s	coverage: 48.0% of statements
+ok  	github.com/panyam/mcpkit/server	13.879s	coverage: 78.4% of statements
+ok  	github.com/panyam/mcpkit/testutil	0.540s	coverage: 70.5% of statements
 Coverage report: tests/reports/coverage.html
   PASS: unit+coverage
 --- [2/8] race ---
-ok  	github.com/panyam/mcpkit/client	8.910s
+ok  	github.com/panyam/mcpkit/client	8.712s
 ?   	github.com/panyam/mcpkit/cmd/testserver	[no test files]
-ok  	github.com/panyam/mcpkit/core	1.688s
-ok  	github.com/panyam/mcpkit/server	15.100s
-ok  	github.com/panyam/mcpkit/testutil	1.929s
+ok  	github.com/panyam/mcpkit/core	1.451s
+ok  	github.com/panyam/mcpkit/server	14.614s
+ok  	github.com/panyam/mcpkit/testutil	1.914s
   PASS: race
 --- [3/8] auth ---
-ok  	github.com/panyam/mcpkit/ext/auth	0.379s
+ok  	github.com/panyam/mcpkit/ext/auth	0.237s
   PASS: auth
 --- [4/8] ui ---
-ok  	github.com/panyam/mcpkit/ext/ui	0.313s
+ok  	github.com/panyam/mcpkit/ext/ui	0.209s
   PASS: ui
 --- [5/8] e2e ---
-ok  	github.com/panyam/mcpkit/tests/e2e	3.787s
-ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.887s
+ok  	github.com/panyam/mcpkit/tests/e2e	3.047s
+ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.285s
   PASS: e2e
 --- [6/8] conformance ---
 Killing stale process on port 18799...
+2026/04/13 15:18:02 Received signal terminated, shutting down...
+2026/04/13 15:18:02 Server shut down gracefully
 === Starting test server on :18799 (Streamable HTTP) ===
-Waiting for server.....2026/04/13 13:50:39 MCP test server listening on :18799 (Streamable HTTP at /mcp)
+Waiting for server....2026/04/13 15:18:03 MCP test server listening on :18799 (Streamable HTTP at /mcp)
  ready
 
 === Running MCP conformance suite ===
@@ -70,296 +72,296 @@ Running active suite (30 scenarios) against http://localhost:18799/mcp
 
 === Running scenario: server-initialize ===
 Running client scenario 'server-initialize' against server: http://localhost:18799/mcp
-2026/04/13 13:50:41 Starting MCP-GET-SSE SSE connection: 5581df5336bd796495f76e799cb27937
-2026/04/13 13:50:41 SSEHub: registered connection 5581df5336bd796495f76e799cb27937 (total: 1)
-2026/04/13 13:50:41 SSEHub: unregistered connection 5581df5336bd796495f76e799cb27937 (total: 0)
-2026/04/13 13:50:41 Received kill signal.  Quitting Writer. stop 0x6583684b42a0
-2026/04/13 13:50:41 Cleaning up writer...
-2026/04/13 13:50:41 Finished cleaning up writer:  0x6583684b42a0
-2026/04/13 13:50:41 Closed MCP-GET-SSE SSE connection: 5581df5336bd796495f76e799cb27937
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: 642fa6b1255588496f1b9f349dfb65e0
+2026/04/13 15:18:05 SSEHub: registered connection 642fa6b1255588496f1b9f349dfb65e0 (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection 642fa6b1255588496f1b9f349dfb65e0 (total: 0)
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12f2e1c0
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12f2e1c0
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: 642fa6b1255588496f1b9f349dfb65e0
 
 === Running scenario: logging-set-level ===
 Running client scenario 'logging-set-level' against server: http://localhost:18799/mcp
-2026/04/13 13:50:41 Starting MCP-GET-SSE SSE connection: 1f0bc73ea5ff37166d8ea1a9ac289a96
-2026/04/13 13:50:41 SSEHub: registered connection 1f0bc73ea5ff37166d8ea1a9ac289a96 (total: 1)
-2026/04/13 13:50:41 SSEHub: unregistered connection 1f0bc73ea5ff37166d8ea1a9ac289a96 (total: 0)
-2026/04/13 13:50:41 Received kill signal.  Quitting Writer. stop 0x6583681929a0
-2026/04/13 13:50:41 Cleaning up writer...
-2026/04/13 13:50:41 Finished cleaning up writer:  0x6583681929a0
-2026/04/13 13:50:41 Closed MCP-GET-SSE SSE connection: 1f0bc73ea5ff37166d8ea1a9ac289a96
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: 7a37a9b3ce7f6aecb08dcb8973885f40
+2026/04/13 15:18:05 SSEHub: registered connection 7a37a9b3ce7f6aecb08dcb8973885f40 (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection 7a37a9b3ce7f6aecb08dcb8973885f40 (total: 0)
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12a90af0
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12a90af0
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: 7a37a9b3ce7f6aecb08dcb8973885f40
 
 === Running scenario: ping ===
 Running client scenario 'ping' against server: http://localhost:18799/mcp
-2026/04/13 13:50:41 Starting MCP-GET-SSE SSE connection: 3b4e46b0757f5592c1342b33998ae78a
-2026/04/13 13:50:41 SSEHub: registered connection 3b4e46b0757f5592c1342b33998ae78a (total: 1)
-2026/04/13 13:50:41 SSEHub: unregistered connection 3b4e46b0757f5592c1342b33998ae78a (total: 0)
-2026/04/13 13:50:41 Received kill signal.  Quitting Writer. stop 0x65836852e230
-2026/04/13 13:50:41 Cleaning up writer...
-2026/04/13 13:50:41 Finished cleaning up writer:  0x65836852e230
-2026/04/13 13:50:41 Closed MCP-GET-SSE SSE connection: 3b4e46b0757f5592c1342b33998ae78a
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: e098481d22af5369fa3e071d013c0d61
+2026/04/13 15:18:05 SSEHub: registered connection e098481d22af5369fa3e071d013c0d61 (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection e098481d22af5369fa3e071d013c0d61 (total: 0)
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12bc8310
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12bc8310
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: e098481d22af5369fa3e071d013c0d61
 
 === Running scenario: completion-complete ===
 Running client scenario 'completion-complete' against server: http://localhost:18799/mcp
-2026/04/13 13:50:41 Starting MCP-GET-SSE SSE connection: 93a7316aee695943437743480fa90430
-2026/04/13 13:50:41 SSEHub: registered connection 93a7316aee695943437743480fa90430 (total: 1)
-2026/04/13 13:50:41 SSEHub: unregistered connection 93a7316aee695943437743480fa90430 (total: 0)
-2026/04/13 13:50:41 Received kill signal.  Quitting Writer. stop 0x6583684b45b0
-2026/04/13 13:50:41 Cleaning up writer...
-2026/04/13 13:50:41 Finished cleaning up writer:  0x6583684b45b0
-2026/04/13 13:50:41 Closed MCP-GET-SSE SSE connection: 93a7316aee695943437743480fa90430
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: fe277ed4e26528cab00893cc232107b4
+2026/04/13 15:18:05 SSEHub: registered connection fe277ed4e26528cab00893cc232107b4 (total: 1)
 
 === Running scenario: tools-list ===
+2026/04/13 15:18:05 SSEHub: unregistered connection fe277ed4e26528cab00893cc232107b4 (total: 0)
 Running client scenario 'tools-list' against server: http://localhost:18799/mcp
-2026/04/13 13:50:41 Starting MCP-GET-SSE SSE connection: 5f1e1e07908d3ef123ea2652c229e7b3
-2026/04/13 13:50:41 SSEHub: registered connection 5f1e1e07908d3ef123ea2652c229e7b3 (total: 1)
-2026/04/13 13:50:41 SSEHub: unregistered connection 5f1e1e07908d3ef123ea2652c229e7b3 (total: 0)
-2026/04/13 13:50:41 Received kill signal.  Quitting Writer. stop 0x6583681929a0
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12f2e3f0
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12f2e3f0
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: fe277ed4e26528cab00893cc232107b4
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: 7563831b7124f588cbfd8b8e5ddd3998
+2026/04/13 15:18:05 SSEHub: registered connection 7563831b7124f588cbfd8b8e5ddd3998 (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection 7563831b7124f588cbfd8b8e5ddd3998 (total: 0)
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12bc81c0
+2026/04/13 15:18:05 Cleaning up writer...
 
 === Running scenario: tools-call-simple-text ===
-2026/04/13 13:50:41 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12bc81c0
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: 7563831b7124f588cbfd8b8e5ddd3998
 Running client scenario 'tools-call-simple-text' against server: http://localhost:18799/mcp
-2026/04/13 13:50:41 Finished cleaning up writer:  0x6583681929a0
-2026/04/13 13:50:41 Closed MCP-GET-SSE SSE connection: 5f1e1e07908d3ef123ea2652c229e7b3
-2026/04/13 13:50:41 Starting MCP-GET-SSE SSE connection: 4945e837c03bacf7f962bd93c33069c2
-2026/04/13 13:50:41 SSEHub: registered connection 4945e837c03bacf7f962bd93c33069c2 (total: 1)
-2026/04/13 13:50:41 SSEHub: unregistered connection 4945e837c03bacf7f962bd93c33069c2 (total: 0)
-2026/04/13 13:50:41 Received kill signal.  Quitting Writer. stop 0x65836852e1c0
-2026/04/13 13:50:41 Cleaning up writer...
-2026/04/13 13:50:41 Finished cleaning up writer:  0x65836852e1c0
-2026/04/13 13:50:41 Closed MCP-GET-SSE SSE connection: 4945e837c03bacf7f962bd93c33069c2
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: 0ceab6c96363b2efad53fa69b473b5ec
+2026/04/13 15:18:05 SSEHub: registered connection 0ceab6c96363b2efad53fa69b473b5ec (total: 1)
 
 === Running scenario: tools-call-image ===
 Running client scenario 'tools-call-image' against server: http://localhost:18799/mcp
-2026/04/13 13:50:41 Starting MCP-GET-SSE SSE connection: b641cecc0c45518227e1ddc04321b43d
-2026/04/13 13:50:41 SSEHub: registered connection b641cecc0c45518227e1ddc04321b43d (total: 1)
-2026/04/13 13:50:41 SSEHub: unregistered connection b641cecc0c45518227e1ddc04321b43d (total: 0)
-2026/04/13 13:50:41 Received kill signal.  Quitting Writer. stop 0x6583684b4310
-2026/04/13 13:50:41 Cleaning up writer...
-2026/04/13 13:50:41 Finished cleaning up writer:  0x6583684b4310
-2026/04/13 13:50:41 Closed MCP-GET-SSE SSE connection: b641cecc0c45518227e1ddc04321b43d
+2026/04/13 15:18:05 SSEHub: unregistered connection 0ceab6c96363b2efad53fa69b473b5ec (total: 0)
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12a90af0
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12a90af0
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: 0ceab6c96363b2efad53fa69b473b5ec
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: b537dbcf4a8ed08d01f2168a9008cdb4
+2026/04/13 15:18:05 SSEHub: registered connection b537dbcf4a8ed08d01f2168a9008cdb4 (total: 1)
 
 === Running scenario: tools-call-audio ===
 Running client scenario 'tools-call-audio' against server: http://localhost:18799/mcp
-2026/04/13 13:50:41 Starting MCP-GET-SSE SSE connection: 94c30035c820aa45060818520e700dad
-2026/04/13 13:50:41 SSEHub: registered connection 94c30035c820aa45060818520e700dad (total: 1)
-2026/04/13 13:50:41 SSEHub: unregistered connection 94c30035c820aa45060818520e700dad (total: 0)
+2026/04/13 15:18:05 SSEHub: unregistered connection b537dbcf4a8ed08d01f2168a9008cdb4 (total: 0)
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12c0e2a0
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12c0e2a0
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: b537dbcf4a8ed08d01f2168a9008cdb4
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: 2973166007dbe989c4110e830ae4c33c
+2026/04/13 15:18:05 SSEHub: registered connection 2973166007dbe989c4110e830ae4c33c (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection 2973166007dbe989c4110e830ae4c33c (total: 0)
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12bc84d0
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12bc84d0
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: 2973166007dbe989c4110e830ae4c33c
 
 === Running scenario: tools-call-embedded-resource ===
-2026/04/13 13:50:41 Received kill signal.  Quitting Writer. stop 0x6583684b4850
-2026/04/13 13:50:41 Cleaning up writer...
-2026/04/13 13:50:41 Finished cleaning up writer:  0x6583684b4850
-2026/04/13 13:50:41 Closed MCP-GET-SSE SSE connection: 94c30035c820aa45060818520e700dad
 Running client scenario 'tools-call-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/13 13:50:41 Starting MCP-GET-SSE SSE connection: 64021534bbb3fc463e22dda1008c9e5b
-2026/04/13 13:50:41 SSEHub: registered connection 64021534bbb3fc463e22dda1008c9e5b (total: 1)
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: fbeab33ddc402640f688af3ea8e7257a
+2026/04/13 15:18:05 SSEHub: registered connection fbeab33ddc402640f688af3ea8e7257a (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection fbeab33ddc402640f688af3ea8e7257a (total: 0)
 
 === Running scenario: tools-call-mixed-content ===
-2026/04/13 13:50:41 SSEHub: unregistered connection 64021534bbb3fc463e22dda1008c9e5b (total: 0)
-2026/04/13 13:50:41 Received kill signal.  Quitting Writer. stop 0x65836852e5b0
-2026/04/13 13:50:41 Cleaning up writer...
-2026/04/13 13:50:41 Finished cleaning up writer:  0x65836852e5b0
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12c0e540
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12c0e540
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: fbeab33ddc402640f688af3ea8e7257a
 Running client scenario 'tools-call-mixed-content' against server: http://localhost:18799/mcp
-2026/04/13 13:50:41 Closed MCP-GET-SSE SSE connection: 64021534bbb3fc463e22dda1008c9e5b
-2026/04/13 13:50:41 Starting MCP-GET-SSE SSE connection: 7b9c3ccafdc7daef9667f0d05bddc4d0
-2026/04/13 13:50:41 SSEHub: registered connection 7b9c3ccafdc7daef9667f0d05bddc4d0 (total: 1)
-2026/04/13 13:50:41 SSEHub: unregistered connection 7b9c3ccafdc7daef9667f0d05bddc4d0 (total: 0)
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: 211c8af1284d4d109bfc49504f4a958e
+2026/04/13 15:18:05 SSEHub: registered connection 211c8af1284d4d109bfc49504f4a958e (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection 211c8af1284d4d109bfc49504f4a958e (total: 0)
 
 === Running scenario: tools-call-with-logging ===
-2026/04/13 13:50:41 Received kill signal.  Quitting Writer. stop 0x6583684b4bd0
-2026/04/13 13:50:41 Cleaning up writer...
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12a90e00
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12a90e00
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: 211c8af1284d4d109bfc49504f4a958e
 Running client scenario 'tools-call-with-logging' against server: http://localhost:18799/mcp
-2026/04/13 13:50:41 Finished cleaning up writer:  0x6583684b4bd0
-2026/04/13 13:50:41 Closed MCP-GET-SSE SSE connection: 7b9c3ccafdc7daef9667f0d05bddc4d0
-2026/04/13 13:50:41 Starting MCP-GET-SSE SSE connection: d9b716ebe6035cb5237dd5185f3f7cb7
-2026/04/13 13:50:41 SSEHub: registered connection d9b716ebe6035cb5237dd5185f3f7cb7 (total: 1)
-2026/04/13 13:50:42 SSEHub: unregistered connection d9b716ebe6035cb5237dd5185f3f7cb7 (total: 0)
-2026/04/13 13:50:42 Received kill signal.  Quitting Writer. stop 0x6583684b4e00
-2026/04/13 13:50:42 Cleaning up writer...
-2026/04/13 13:50:42 Finished cleaning up writer:  0x6583684b4e00
-2026/04/13 13:50:42 Closed MCP-GET-SSE SSE connection: d9b716ebe6035cb5237dd5185f3f7cb7
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: a415b8b7671a5602cd30d4c07aaddffd
+2026/04/13 15:18:05 SSEHub: registered connection a415b8b7671a5602cd30d4c07aaddffd (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection a415b8b7671a5602cd30d4c07aaddffd (total: 0)
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12c0e770
+2026/04/13 15:18:05 Cleaning up writer...
 
 === Running scenario: tools-call-error ===
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12c0e770
 Running client scenario 'tools-call-error' against server: http://localhost:18799/mcp
-2026/04/13 13:50:42 Starting MCP-GET-SSE SSE connection: 3477937fcfc706e82f27baa4b66febc1
-2026/04/13 13:50:42 SSEHub: registered connection 3477937fcfc706e82f27baa4b66febc1 (total: 1)
-2026/04/13 13:50:42 SSEHub: unregistered connection 3477937fcfc706e82f27baa4b66febc1 (total: 0)
-2026/04/13 13:50:42 Received kill signal.  Quitting Writer. stop 0x6583680ee690
-2026/04/13 13:50:42 Cleaning up writer...
-2026/04/13 13:50:42 Finished cleaning up writer:  0x6583680ee690
-2026/04/13 13:50:42 Closed MCP-GET-SSE SSE connection: 3477937fcfc706e82f27baa4b66febc1
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: a415b8b7671a5602cd30d4c07aaddffd
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: 114a43e2ab6267fbe08acfd927c0cf79
+2026/04/13 15:18:05 SSEHub: registered connection 114a43e2ab6267fbe08acfd927c0cf79 (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection 114a43e2ab6267fbe08acfd927c0cf79 (total: 0)
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12d2c310
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12d2c310
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: 114a43e2ab6267fbe08acfd927c0cf79
 
 === Running scenario: tools-call-with-progress ===
 Running client scenario 'tools-call-with-progress' against server: http://localhost:18799/mcp
-2026/04/13 13:50:42 Starting MCP-GET-SSE SSE connection: 8c95d562d93c7f4b6084f99c68ff986b
-2026/04/13 13:50:42 SSEHub: registered connection 8c95d562d93c7f4b6084f99c68ff986b (total: 1)
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: 471a9204290f333868ec7e89d3598e90
+2026/04/13 15:18:05 SSEHub: registered connection 471a9204290f333868ec7e89d3598e90 (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection 471a9204290f333868ec7e89d3598e90 (total: 0)
 
 === Running scenario: tools-call-sampling ===
-2026/04/13 13:50:42 SSEHub: unregistered connection 8c95d562d93c7f4b6084f99c68ff986b (total: 0)
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12c0eb60
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12c0eb60
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: 471a9204290f333868ec7e89d3598e90
 Running client scenario 'tools-call-sampling' against server: http://localhost:18799/mcp
-2026/04/13 13:50:42 Received kill signal.  Quitting Writer. stop 0x658368192c40
-2026/04/13 13:50:42 Cleaning up writer...
-2026/04/13 13:50:42 Finished cleaning up writer:  0x658368192c40
-2026/04/13 13:50:42 Closed MCP-GET-SSE SSE connection: 8c95d562d93c7f4b6084f99c68ff986b
-2026/04/13 13:50:42 Starting MCP-GET-SSE SSE connection: 18fcab9d86d9bb0ffc8399deaa7ea9a2
-2026/04/13 13:50:42 SSEHub: registered connection 18fcab9d86d9bb0ffc8399deaa7ea9a2 (total: 1)
-2026/04/13 13:50:42 SSEHub: unregistered connection 18fcab9d86d9bb0ffc8399deaa7ea9a2 (total: 0)
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: b2d927d09d7bbbc92b463e7b1f697e07
+2026/04/13 15:18:05 SSEHub: registered connection b2d927d09d7bbbc92b463e7b1f697e07 (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection b2d927d09d7bbbc92b463e7b1f697e07 (total: 0)
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12a91180
+2026/04/13 15:18:05 Cleaning up writer...
 
 === Running scenario: tools-call-elicitation ===
-2026/04/13 13:50:42 Received kill signal.  Quitting Writer. stop 0x658368192e70
-2026/04/13 13:50:42 Cleaning up writer...
-2026/04/13 13:50:42 Finished cleaning up writer:  0x658368192e70
-2026/04/13 13:50:42 Closed MCP-GET-SSE SSE connection: 18fcab9d86d9bb0ffc8399deaa7ea9a2
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12a91180
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: b2d927d09d7bbbc92b463e7b1f697e07
 Running client scenario 'tools-call-elicitation' against server: http://localhost:18799/mcp
-2026/04/13 13:50:42 Starting MCP-GET-SSE SSE connection: fc5ab414a0ce502352f3a021a3f03ea2
-2026/04/13 13:50:42 SSEHub: registered connection fc5ab414a0ce502352f3a021a3f03ea2 (total: 1)
-2026/04/13 13:50:42 SSEHub: unregistered connection fc5ab414a0ce502352f3a021a3f03ea2 (total: 0)
-2026/04/13 13:50:42 Received kill signal.  Quitting Writer. stop 0x6583684b51f0
-2026/04/13 13:50:42 Cleaning up writer...
-2026/04/13 13:50:42 Finished cleaning up writer:  0x6583684b51f0
-2026/04/13 13:50:42 Closed MCP-GET-SSE SSE connection: fc5ab414a0ce502352f3a021a3f03ea2
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: a971a64bfc397557820e72a9f9b2d859
+2026/04/13 15:18:05 SSEHub: registered connection a971a64bfc397557820e72a9f9b2d859 (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection a971a64bfc397557820e72a9f9b2d859 (total: 0)
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12bc8a10
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12bc8a10
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: a971a64bfc397557820e72a9f9b2d859
 
 === Running scenario: elicitation-sep1034-defaults ===
 Running client scenario 'elicitation-sep1034-defaults' against server: http://localhost:18799/mcp
-2026/04/13 13:50:42 Starting MCP-GET-SSE SSE connection: 4fe7805cfc39643975b2236c5e406672
-2026/04/13 13:50:42 SSEHub: registered connection 4fe7805cfc39643975b2236c5e406672 (total: 1)
-2026/04/13 13:50:42 SSEHub: unregistered connection 4fe7805cfc39643975b2236c5e406672 (total: 0)
-2026/04/13 13:50:42 Received kill signal.  Quitting Writer. stop 0x6583681930a0
-2026/04/13 13:50:42 Cleaning up writer...
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: a4ef09066dbf66c19d49ae6517902141
+2026/04/13 15:18:05 SSEHub: registered connection a4ef09066dbf66c19d49ae6517902141 (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection a4ef09066dbf66c19d49ae6517902141 (total: 0)
 
 === Running scenario: server-sse-multiple-streams ===
-2026/04/13 13:50:42 Finished cleaning up writer:  0x6583681930a0
-2026/04/13 13:50:42 Closed MCP-GET-SSE SSE connection: 4fe7805cfc39643975b2236c5e406672
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12a913b0
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12a913b0
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: a4ef09066dbf66c19d49ae6517902141
 Running client scenario 'server-sse-multiple-streams' against server: http://localhost:18799/mcp
-2026/04/13 13:50:42 Starting MCP-GET-SSE SSE connection: a80d84dde43a020a20d6080a9dd72958
-2026/04/13 13:50:42 SSEHub: registered connection a80d84dde43a020a20d6080a9dd72958 (total: 1)
-2026/04/13 13:50:42 SSEHub: unregistered connection a80d84dde43a020a20d6080a9dd72958 (total: 0)
-2026/04/13 13:50:42 Received kill signal.  Quitting Writer. stop 0x65836852ec40
-2026/04/13 13:50:42 Cleaning up writer...
-2026/04/13 13:50:42 Finished cleaning up writer:  0x65836852ec40
-2026/04/13 13:50:42 Closed MCP-GET-SSE SSE connection: a80d84dde43a020a20d6080a9dd72958
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: 45a559749ba691ffa228b3db0011d7e1
+2026/04/13 15:18:05 SSEHub: registered connection 45a559749ba691ffa228b3db0011d7e1 (total: 1)
 
 === Running scenario: elicitation-sep1330-enums ===
+2026/04/13 15:18:05 SSEHub: unregistered connection 45a559749ba691ffa228b3db0011d7e1 (total: 0)
 Running client scenario 'elicitation-sep1330-enums' against server: http://localhost:18799/mcp
-2026/04/13 13:50:42 Starting MCP-GET-SSE SSE connection: 62fc87e1b357e585f036ace8648197b1
-2026/04/13 13:50:42 SSEHub: registered connection 62fc87e1b357e585f036ace8648197b1 (total: 1)
-2026/04/13 13:50:42 SSEHub: unregistered connection 62fc87e1b357e585f036ace8648197b1 (total: 0)
-2026/04/13 13:50:42 Received kill signal.  Quitting Writer. stop 0x6583684b56c0
-2026/04/13 13:50:42 Cleaning up writer...
-2026/04/13 13:50:42 Finished cleaning up writer:  0x6583684b56c0
-2026/04/13 13:50:42 Closed MCP-GET-SSE SSE connection: 62fc87e1b357e585f036ace8648197b1
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12a91880
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12a91880
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: 45a559749ba691ffa228b3db0011d7e1
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: e37e7aa519b5c9f04d6542515d34808d
+2026/04/13 15:18:05 SSEHub: registered connection e37e7aa519b5c9f04d6542515d34808d (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection e37e7aa519b5c9f04d6542515d34808d (total: 0)
 
 === Running scenario: resources-list ===
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12a91c70
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12a91c70
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: e37e7aa519b5c9f04d6542515d34808d
 Running client scenario 'resources-list' against server: http://localhost:18799/mcp
-2026/04/13 13:50:42 Starting MCP-GET-SSE SSE connection: 4ef7aa77b969bf264d35834ed32d2518
-2026/04/13 13:50:42 SSEHub: registered connection 4ef7aa77b969bf264d35834ed32d2518 (total: 1)
-2026/04/13 13:50:42 SSEHub: unregistered connection 4ef7aa77b969bf264d35834ed32d2518 (total: 0)
-2026/04/13 13:50:42 Received kill signal.  Quitting Writer. stop 0x6583680eebd0
-2026/04/13 13:50:42 Cleaning up writer...
-2026/04/13 13:50:42 Finished cleaning up writer:  0x6583680eebd0
-2026/04/13 13:50:42 Closed MCP-GET-SSE SSE connection: 4ef7aa77b969bf264d35834ed32d2518
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: b59ee6a8aa15f5ff5c2e4aaaffc6c95c
+2026/04/13 15:18:05 SSEHub: registered connection b59ee6a8aa15f5ff5c2e4aaaffc6c95c (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection b59ee6a8aa15f5ff5c2e4aaaffc6c95c (total: 0)
 
 === Running scenario: resources-read-text ===
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12d2caf0
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12d2caf0
 Running client scenario 'resources-read-text' against server: http://localhost:18799/mcp
-2026/04/13 13:50:42 Starting MCP-GET-SSE SSE connection: 5040783f471bff07ccd0d9f8fbf51730
-2026/04/13 13:50:42 SSEHub: registered connection 5040783f471bff07ccd0d9f8fbf51730 (total: 1)
-2026/04/13 13:50:42 SSEHub: unregistered connection 5040783f471bff07ccd0d9f8fbf51730 (total: 0)
-2026/04/13 13:50:42 Received kill signal.  Quitting Writer. stop 0x658368193500
-2026/04/13 13:50:42 Cleaning up writer...
-2026/04/13 13:50:42 Finished cleaning up writer:  0x658368193500
-2026/04/13 13:50:42 Closed MCP-GET-SSE SSE connection: 5040783f471bff07ccd0d9f8fbf51730
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: b59ee6a8aa15f5ff5c2e4aaaffc6c95c
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: f732d437a7dccaea464f8511841f9cb1
+2026/04/13 15:18:05 SSEHub: registered connection f732d437a7dccaea464f8511841f9cb1 (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection f732d437a7dccaea464f8511841f9cb1 (total: 0)
 
 === Running scenario: resources-read-binary ===
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12f2e770
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12f2e770
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: f732d437a7dccaea464f8511841f9cb1
 Running client scenario 'resources-read-binary' against server: http://localhost:18799/mcp
-2026/04/13 13:50:42 Starting MCP-GET-SSE SSE connection: ec5dbe77a1b8ef9ed105e38a70dc89a6
-2026/04/13 13:50:42 SSEHub: registered connection ec5dbe77a1b8ef9ed105e38a70dc89a6 (total: 1)
-2026/04/13 13:50:42 SSEHub: unregistered connection ec5dbe77a1b8ef9ed105e38a70dc89a6 (total: 0)
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: 33fa213636579169eacad26d746c87db
+2026/04/13 15:18:05 SSEHub: registered connection 33fa213636579169eacad26d746c87db (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection 33fa213636579169eacad26d746c87db (total: 0)
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12d2cd90
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12d2cd90
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: 33fa213636579169eacad26d746c87db
 
 === Running scenario: resources-templates-read ===
-2026/04/13 13:50:42 Received kill signal.  Quitting Writer. stop 0x6583684b58f0
-2026/04/13 13:50:42 Cleaning up writer...
-2026/04/13 13:50:42 Finished cleaning up writer:  0x6583684b58f0
-2026/04/13 13:50:42 Closed MCP-GET-SSE SSE connection: ec5dbe77a1b8ef9ed105e38a70dc89a6
 Running client scenario 'resources-templates-read' against server: http://localhost:18799/mcp
-2026/04/13 13:50:42 Starting MCP-GET-SSE SSE connection: f9dfeea2c6bfac4adf19f50f4bc4a53f
-2026/04/13 13:50:42 SSEHub: registered connection f9dfeea2c6bfac4adf19f50f4bc4a53f (total: 1)
-2026/04/13 13:50:42 SSEHub: unregistered connection f9dfeea2c6bfac4adf19f50f4bc4a53f (total: 0)
-2026/04/13 13:50:42 Received kill signal.  Quitting Writer. stop 0x658368193960
-2026/04/13 13:50:42 Cleaning up writer...
-2026/04/13 13:50:42 Finished cleaning up writer:  0x658368193960
-2026/04/13 13:50:42 Closed MCP-GET-SSE SSE connection: f9dfeea2c6bfac4adf19f50f4bc4a53f
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: 84f965cad498ee21811e8a34222755fd
+2026/04/13 15:18:05 SSEHub: registered connection 84f965cad498ee21811e8a34222755fd (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection 84f965cad498ee21811e8a34222755fd (total: 0)
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12f2ea80
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12f2ea80
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: 84f965cad498ee21811e8a34222755fd
 
 === Running scenario: resources-subscribe ===
 Running client scenario 'resources-subscribe' against server: http://localhost:18799/mcp
-2026/04/13 13:50:42 Starting MCP-GET-SSE SSE connection: bfae56b0f0376d3217e2244494d4448d
-2026/04/13 13:50:42 SSEHub: registered connection bfae56b0f0376d3217e2244494d4448d (total: 1)
-2026/04/13 13:50:42 SSEHub: unregistered connection bfae56b0f0376d3217e2244494d4448d (total: 0)
-2026/04/13 13:50:42 Received kill signal.  Quitting Writer. stop 0x65836852f030
-2026/04/13 13:50:42 Cleaning up writer...
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: c035ae6971a25759e7eb3688cf1729f3
+2026/04/13 15:18:05 SSEHub: registered connection c035ae6971a25759e7eb3688cf1729f3 (total: 1)
 
 === Running scenario: resources-unsubscribe ===
-2026/04/13 13:50:42 Finished cleaning up writer:  0x65836852f030
 Running client scenario 'resources-unsubscribe' against server: http://localhost:18799/mcp
-2026/04/13 13:50:42 Closed MCP-GET-SSE SSE connection: bfae56b0f0376d3217e2244494d4448d
-2026/04/13 13:50:42 Starting MCP-GET-SSE SSE connection: ce512a56567c7768ccc7e03133f5c4e7
-2026/04/13 13:50:42 SSEHub: registered connection ce512a56567c7768ccc7e03133f5c4e7 (total: 1)
-2026/04/13 13:50:42 SSEHub: unregistered connection ce512a56567c7768ccc7e03133f5c4e7 (total: 0)
-2026/04/13 13:50:42 Received kill signal.  Quitting Writer. stop 0x6583684b5b90
-2026/04/13 13:50:42 Cleaning up writer...
-2026/04/13 13:50:42 Finished cleaning up writer:  0x6583684b5b90
-2026/04/13 13:50:42 Closed MCP-GET-SSE SSE connection: ce512a56567c7768ccc7e03133f5c4e7
+2026/04/13 15:18:05 SSEHub: unregistered connection c035ae6971a25759e7eb3688cf1729f3 (total: 0)
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12f2ed90
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12f2ed90
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: c035ae6971a25759e7eb3688cf1729f3
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: 6b841c353cc364bcac04bc60c5543a85
+2026/04/13 15:18:05 SSEHub: registered connection 6b841c353cc364bcac04bc60c5543a85 (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection 6b841c353cc364bcac04bc60c5543a85 (total: 0)
 
 === Running scenario: prompts-list ===
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12f2efc0
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12f2efc0
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: 6b841c353cc364bcac04bc60c5543a85
 Running client scenario 'prompts-list' against server: http://localhost:18799/mcp
-2026/04/13 13:50:42 Starting MCP-GET-SSE SSE connection: b3c18c2ffac5e59b3c05df915d471664
-2026/04/13 13:50:42 SSEHub: registered connection b3c18c2ffac5e59b3c05df915d471664 (total: 1)
-2026/04/13 13:50:42 SSEHub: unregistered connection b3c18c2ffac5e59b3c05df915d471664 (total: 0)
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: d9acd954d0eb5e77b868bc9a4b191cb5
+2026/04/13 15:18:05 SSEHub: registered connection d9acd954d0eb5e77b868bc9a4b191cb5 (total: 1)
 
 === Running scenario: prompts-get-simple ===
-2026/04/13 13:50:42 Received kill signal.  Quitting Writer. stop 0x6583684b5ea0
-2026/04/13 13:50:42 Cleaning up writer...
-2026/04/13 13:50:42 Finished cleaning up writer:  0x6583684b5ea0
-2026/04/13 13:50:42 Closed MCP-GET-SSE SSE connection: b3c18c2ffac5e59b3c05df915d471664
 Running client scenario 'prompts-get-simple' against server: http://localhost:18799/mcp
-2026/04/13 13:50:42 Starting MCP-GET-SSE SSE connection: c487bf924e354d06ad19bbc977e98490
-2026/04/13 13:50:42 SSEHub: registered connection c487bf924e354d06ad19bbc977e98490 (total: 1)
-2026/04/13 13:50:42 SSEHub: unregistered connection c487bf924e354d06ad19bbc977e98490 (total: 0)
+2026/04/13 15:18:05 SSEHub: unregistered connection d9acd954d0eb5e77b868bc9a4b191cb5 (total: 0)
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12f2f260
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12f2f260
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: d9acd954d0eb5e77b868bc9a4b191cb5
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: c884f9999ad2e4933a05c42502b830bc
+2026/04/13 15:18:05 SSEHub: registered connection c884f9999ad2e4933a05c42502b830bc (total: 1)
 
 === Running scenario: prompts-get-with-args ===
-2026/04/13 13:50:42 Received kill signal.  Quitting Writer. stop 0x658368193d50
-2026/04/13 13:50:42 Cleaning up writer...
-2026/04/13 13:50:42 Finished cleaning up writer:  0x658368193d50
-2026/04/13 13:50:42 Closed MCP-GET-SSE SSE connection: c487bf924e354d06ad19bbc977e98490
+2026/04/13 15:18:05 SSEHub: unregistered connection c884f9999ad2e4933a05c42502b830bc (total: 0)
 Running client scenario 'prompts-get-with-args' against server: http://localhost:18799/mcp
-2026/04/13 13:50:42 Starting MCP-GET-SSE SSE connection: 9c0e816c613aecc835e6bde448ef569e
-2026/04/13 13:50:42 SSEHub: registered connection 9c0e816c613aecc835e6bde448ef569e (total: 1)
-2026/04/13 13:50:42 SSEHub: unregistered connection 9c0e816c613aecc835e6bde448ef569e (total: 0)
-2026/04/13 13:50:42 Received kill signal.  Quitting Writer. stop 0x6583680ef030
-2026/04/13 13:50:42 Cleaning up writer...
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12f2f500
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12f2f500
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: c884f9999ad2e4933a05c42502b830bc
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: 094d86c879be1ec1b01c7aff38f3278f
+2026/04/13 15:18:05 SSEHub: registered connection 094d86c879be1ec1b01c7aff38f3278f (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection 094d86c879be1ec1b01c7aff38f3278f (total: 0)
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12d2d0a0
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12d2d0a0
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: 094d86c879be1ec1b01c7aff38f3278f
 
 === Running scenario: prompts-get-embedded-resource ===
-2026/04/13 13:50:42 Finished cleaning up writer:  0x6583680ef030
-2026/04/13 13:50:42 Closed MCP-GET-SSE SSE connection: 9c0e816c613aecc835e6bde448ef569e
 Running client scenario 'prompts-get-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/13 13:50:42 Starting MCP-GET-SSE SSE connection: a9b050e814f28049557cb93e99b985e3
-2026/04/13 13:50:42 SSEHub: registered connection a9b050e814f28049557cb93e99b985e3 (total: 1)
-2026/04/13 13:50:42 SSEHub: unregistered connection a9b050e814f28049557cb93e99b985e3 (total: 0)
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: 375ae238a802171e8463957d5245d718
+2026/04/13 15:18:05 SSEHub: registered connection 375ae238a802171e8463957d5245d718 (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection 375ae238a802171e8463957d5245d718 (total: 0)
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12f2f7a0
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12f2f7a0
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: 375ae238a802171e8463957d5245d718
 
 === Running scenario: prompts-get-with-image ===
-2026/04/13 13:50:42 Received kill signal.  Quitting Writer. stop 0x65836852f340
-2026/04/13 13:50:42 Cleaning up writer...
-2026/04/13 13:50:42 Finished cleaning up writer:  0x65836852f340
-2026/04/13 13:50:42 Closed MCP-GET-SSE SSE connection: a9b050e814f28049557cb93e99b985e3
 Running client scenario 'prompts-get-with-image' against server: http://localhost:18799/mcp
-2026/04/13 13:50:42 Starting MCP-GET-SSE SSE connection: 45184d4c2e2554942204da48a7fd36f8
-2026/04/13 13:50:42 SSEHub: registered connection 45184d4c2e2554942204da48a7fd36f8 (total: 1)
-2026/04/13 13:50:42 SSEHub: unregistered connection 45184d4c2e2554942204da48a7fd36f8 (total: 0)
-2026/04/13 13:50:42 Received kill signal.  Quitting Writer. stop 0x658368268070
-2026/04/13 13:50:42 Cleaning up writer...
-2026/04/13 13:50:42 Finished cleaning up writer:  0x658368268070
-2026/04/13 13:50:42 Closed MCP-GET-SSE SSE connection: 45184d4c2e2554942204da48a7fd36f8
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: fb73295efe37ea6c77fcf2d4a00c3f6a
+2026/04/13 15:18:05 SSEHub: registered connection fb73295efe37ea6c77fcf2d4a00c3f6a (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection fb73295efe37ea6c77fcf2d4a00c3f6a (total: 0)
 
 === Running scenario: dns-rebinding-protection ===
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12c0ee00
+2026/04/13 15:18:05 Cleaning up writer...
 Running client scenario 'dns-rebinding-protection' against server: http://localhost:18799/mcp
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12c0ee00
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: fb73295efe37ea6c77fcf2d4a00c3f6a
 
 
 === SUMMARY ===
@@ -421,22 +423,22 @@ Starting scenario: auth/token-endpoint-auth-basic
 Starting scenario: auth/token-endpoint-auth-post
 Starting scenario: auth/token-endpoint-auth-none
 Starting scenario: auth/pre-registration
-Executing client: ./bin/testclient http://localhost:54548/mcp
-Executing client: ./bin/testclient http://localhost:54549/mcp
-Executing client: ./bin/testclient http://localhost:54550/mcp
-Executing client: ./bin/testclient http://localhost:54551/mcp
-Executing client: ./bin/testclient http://localhost:54552/mcp
-Executing client: ./bin/testclient http://localhost:54553/mcp
-Executing client: ./bin/testclient http://localhost:54554/mcp
-Executing client: ./bin/testclient http://localhost:54555/mcp
-Executing client: ./bin/testclient http://localhost:54556/mcp
-Executing client: ./bin/testclient http://localhost:54557/mcp
-Executing client: ./bin/testclient http://localhost:54558/mcp
-Executing client: ./bin/testclient http://localhost:54559/mcp
-Executing client: ./bin/testclient http://localhost:54560/mcp
-Executing client: ./bin/testclient http://localhost:54561/mcp
+Executing client: ./bin/testclient http://localhost:63243/mcp
+Executing client: ./bin/testclient http://localhost:63244/mcp
+Executing client: ./bin/testclient http://localhost:63245/mcp
+Executing client: ./bin/testclient http://localhost:63246/mcp
+Executing client: ./bin/testclient http://localhost:63247/mcp
+Executing client: ./bin/testclient http://localhost:63248/mcp
+Executing client: ./bin/testclient http://localhost:63249/mcp
+Executing client: ./bin/testclient http://localhost:63250/mcp
+Executing client: ./bin/testclient http://localhost:63251/mcp
+Executing client: ./bin/testclient http://localhost:63252/mcp
+Executing client: ./bin/testclient http://localhost:63253/mcp
+Executing client: ./bin/testclient http://localhost:63254/mcp
+Executing client: ./bin/testclient http://localhost:63255/mcp
+Executing client: ./bin/testclient http://localhost:63256/mcp
 With context: {"client_id":"pre-registered-client","client_secret":"pre-registered-secret"}
-(node:30137) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
+(node:84908) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
 (Use `node --trace-deprecation ...` to show where the warning was created)
 
 === SUITE SUMMARY ===
@@ -469,7 +471,7 @@ Total: 210 passed, 0 failed, 1 warnings
 === RUN   TestKeycloak_MCPServer_ValidToken
 --- PASS: TestKeycloak_MCPServer_ValidToken (0.02s)
 === RUN   TestKeycloak_MCPServer_TamperedToken
---- PASS: TestKeycloak_MCPServer_TamperedToken (0.02s)
+--- PASS: TestKeycloak_MCPServer_TamperedToken (0.01s)
 === RUN   TestKeycloak_MCPServer_ScopeAllowed
 --- PASS: TestKeycloak_MCPServer_ScopeAllowed (0.01s)
 === RUN   TestKeycloak_MCPServer_ScopeDenied
@@ -479,12 +481,12 @@ Total: 210 passed, 0 failed, 1 warnings
 === RUN   TestKeycloak_MCPServer_WWWAuthenticate
 --- PASS: TestKeycloak_MCPServer_WWWAuthenticate (0.01s)
 === RUN   TestKeycloak_MCPServer_PasswordGrant
---- PASS: TestKeycloak_MCPServer_PasswordGrant (0.05s)
+--- PASS: TestKeycloak_MCPServer_PasswordGrant (0.04s)
 PASS
-ok  	github.com/panyam/mcpkit/tests/keycloak	0.737s
+ok  	github.com/panyam/mcpkit/tests/keycloak	0.381s
   PASS: keycloak
 
 === Results: 8 passed, 0 failed ===
-Finished: Mon Apr 13 13:50:45 PDT 2026
+Finished: Mon Apr 13 15:18:08 PDT 2026
 </pre>
 </body></html>

--- a/tests/reports/run.log
+++ b/tests/reports/run.log
@@ -1,35 +1,37 @@
 === MCPKit Comprehensive Test Suite ===
-Started: Mon Apr 13 13:49:56 PDT 2026
+Started: Mon Apr 13 15:17:26 PDT 2026
 
 --- [1/8] unit+coverage ---
-ok  	github.com/panyam/mcpkit/client	7.645s	coverage: 67.4% of statements
+ok  	github.com/panyam/mcpkit/client	7.230s	coverage: 67.4% of statements
 	github.com/panyam/mcpkit/cmd/testserver		coverage: 0.0% of statements
-ok  	github.com/panyam/mcpkit/core	0.633s	coverage: 49.2% of statements
-ok  	github.com/panyam/mcpkit/server	14.001s	coverage: 78.4% of statements
-ok  	github.com/panyam/mcpkit/testutil	1.023s	coverage: 70.5% of statements
+ok  	github.com/panyam/mcpkit/core	0.377s	coverage: 48.0% of statements
+ok  	github.com/panyam/mcpkit/server	13.879s	coverage: 78.4% of statements
+ok  	github.com/panyam/mcpkit/testutil	0.540s	coverage: 70.5% of statements
 Coverage report: tests/reports/coverage.html
   PASS: unit+coverage
 --- [2/8] race ---
-ok  	github.com/panyam/mcpkit/client	8.910s
+ok  	github.com/panyam/mcpkit/client	8.712s
 ?   	github.com/panyam/mcpkit/cmd/testserver	[no test files]
-ok  	github.com/panyam/mcpkit/core	1.688s
-ok  	github.com/panyam/mcpkit/server	15.100s
-ok  	github.com/panyam/mcpkit/testutil	1.929s
+ok  	github.com/panyam/mcpkit/core	1.451s
+ok  	github.com/panyam/mcpkit/server	14.614s
+ok  	github.com/panyam/mcpkit/testutil	1.914s
   PASS: race
 --- [3/8] auth ---
-ok  	github.com/panyam/mcpkit/ext/auth	0.379s
+ok  	github.com/panyam/mcpkit/ext/auth	0.237s
   PASS: auth
 --- [4/8] ui ---
-ok  	github.com/panyam/mcpkit/ext/ui	0.313s
+ok  	github.com/panyam/mcpkit/ext/ui	0.209s
   PASS: ui
 --- [5/8] e2e ---
-ok  	github.com/panyam/mcpkit/tests/e2e	3.787s
-ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.887s
+ok  	github.com/panyam/mcpkit/tests/e2e	3.047s
+ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.285s
   PASS: e2e
 --- [6/8] conformance ---
 Killing stale process on port 18799...
+2026/04/13 15:18:02 Received signal terminated, shutting down...
+2026/04/13 15:18:02 Server shut down gracefully
 === Starting test server on :18799 (Streamable HTTP) ===
-Waiting for server.....2026/04/13 13:50:39 MCP test server listening on :18799 (Streamable HTTP at /mcp)
+Waiting for server....2026/04/13 15:18:03 MCP test server listening on :18799 (Streamable HTTP at /mcp)
  ready
 
 === Running MCP conformance suite ===
@@ -40,296 +42,296 @@ Running active suite (30 scenarios) against http://localhost:18799/mcp
 
 === Running scenario: server-initialize ===
 Running client scenario 'server-initialize' against server: http://localhost:18799/mcp
-2026/04/13 13:50:41 Starting MCP-GET-SSE SSE connection: 5581df5336bd796495f76e799cb27937
-2026/04/13 13:50:41 SSEHub: registered connection 5581df5336bd796495f76e799cb27937 (total: 1)
-2026/04/13 13:50:41 SSEHub: unregistered connection 5581df5336bd796495f76e799cb27937 (total: 0)
-2026/04/13 13:50:41 Received kill signal.  Quitting Writer. stop 0x6583684b42a0
-2026/04/13 13:50:41 Cleaning up writer...
-2026/04/13 13:50:41 Finished cleaning up writer:  0x6583684b42a0
-2026/04/13 13:50:41 Closed MCP-GET-SSE SSE connection: 5581df5336bd796495f76e799cb27937
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: 642fa6b1255588496f1b9f349dfb65e0
+2026/04/13 15:18:05 SSEHub: registered connection 642fa6b1255588496f1b9f349dfb65e0 (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection 642fa6b1255588496f1b9f349dfb65e0 (total: 0)
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12f2e1c0
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12f2e1c0
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: 642fa6b1255588496f1b9f349dfb65e0
 
 === Running scenario: logging-set-level ===
 Running client scenario 'logging-set-level' against server: http://localhost:18799/mcp
-2026/04/13 13:50:41 Starting MCP-GET-SSE SSE connection: 1f0bc73ea5ff37166d8ea1a9ac289a96
-2026/04/13 13:50:41 SSEHub: registered connection 1f0bc73ea5ff37166d8ea1a9ac289a96 (total: 1)
-2026/04/13 13:50:41 SSEHub: unregistered connection 1f0bc73ea5ff37166d8ea1a9ac289a96 (total: 0)
-2026/04/13 13:50:41 Received kill signal.  Quitting Writer. stop 0x6583681929a0
-2026/04/13 13:50:41 Cleaning up writer...
-2026/04/13 13:50:41 Finished cleaning up writer:  0x6583681929a0
-2026/04/13 13:50:41 Closed MCP-GET-SSE SSE connection: 1f0bc73ea5ff37166d8ea1a9ac289a96
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: 7a37a9b3ce7f6aecb08dcb8973885f40
+2026/04/13 15:18:05 SSEHub: registered connection 7a37a9b3ce7f6aecb08dcb8973885f40 (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection 7a37a9b3ce7f6aecb08dcb8973885f40 (total: 0)
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12a90af0
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12a90af0
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: 7a37a9b3ce7f6aecb08dcb8973885f40
 
 === Running scenario: ping ===
 Running client scenario 'ping' against server: http://localhost:18799/mcp
-2026/04/13 13:50:41 Starting MCP-GET-SSE SSE connection: 3b4e46b0757f5592c1342b33998ae78a
-2026/04/13 13:50:41 SSEHub: registered connection 3b4e46b0757f5592c1342b33998ae78a (total: 1)
-2026/04/13 13:50:41 SSEHub: unregistered connection 3b4e46b0757f5592c1342b33998ae78a (total: 0)
-2026/04/13 13:50:41 Received kill signal.  Quitting Writer. stop 0x65836852e230
-2026/04/13 13:50:41 Cleaning up writer...
-2026/04/13 13:50:41 Finished cleaning up writer:  0x65836852e230
-2026/04/13 13:50:41 Closed MCP-GET-SSE SSE connection: 3b4e46b0757f5592c1342b33998ae78a
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: e098481d22af5369fa3e071d013c0d61
+2026/04/13 15:18:05 SSEHub: registered connection e098481d22af5369fa3e071d013c0d61 (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection e098481d22af5369fa3e071d013c0d61 (total: 0)
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12bc8310
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12bc8310
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: e098481d22af5369fa3e071d013c0d61
 
 === Running scenario: completion-complete ===
 Running client scenario 'completion-complete' against server: http://localhost:18799/mcp
-2026/04/13 13:50:41 Starting MCP-GET-SSE SSE connection: 93a7316aee695943437743480fa90430
-2026/04/13 13:50:41 SSEHub: registered connection 93a7316aee695943437743480fa90430 (total: 1)
-2026/04/13 13:50:41 SSEHub: unregistered connection 93a7316aee695943437743480fa90430 (total: 0)
-2026/04/13 13:50:41 Received kill signal.  Quitting Writer. stop 0x6583684b45b0
-2026/04/13 13:50:41 Cleaning up writer...
-2026/04/13 13:50:41 Finished cleaning up writer:  0x6583684b45b0
-2026/04/13 13:50:41 Closed MCP-GET-SSE SSE connection: 93a7316aee695943437743480fa90430
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: fe277ed4e26528cab00893cc232107b4
+2026/04/13 15:18:05 SSEHub: registered connection fe277ed4e26528cab00893cc232107b4 (total: 1)
 
 === Running scenario: tools-list ===
+2026/04/13 15:18:05 SSEHub: unregistered connection fe277ed4e26528cab00893cc232107b4 (total: 0)
 Running client scenario 'tools-list' against server: http://localhost:18799/mcp
-2026/04/13 13:50:41 Starting MCP-GET-SSE SSE connection: 5f1e1e07908d3ef123ea2652c229e7b3
-2026/04/13 13:50:41 SSEHub: registered connection 5f1e1e07908d3ef123ea2652c229e7b3 (total: 1)
-2026/04/13 13:50:41 SSEHub: unregistered connection 5f1e1e07908d3ef123ea2652c229e7b3 (total: 0)
-2026/04/13 13:50:41 Received kill signal.  Quitting Writer. stop 0x6583681929a0
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12f2e3f0
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12f2e3f0
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: fe277ed4e26528cab00893cc232107b4
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: 7563831b7124f588cbfd8b8e5ddd3998
+2026/04/13 15:18:05 SSEHub: registered connection 7563831b7124f588cbfd8b8e5ddd3998 (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection 7563831b7124f588cbfd8b8e5ddd3998 (total: 0)
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12bc81c0
+2026/04/13 15:18:05 Cleaning up writer...
 
 === Running scenario: tools-call-simple-text ===
-2026/04/13 13:50:41 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12bc81c0
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: 7563831b7124f588cbfd8b8e5ddd3998
 Running client scenario 'tools-call-simple-text' against server: http://localhost:18799/mcp
-2026/04/13 13:50:41 Finished cleaning up writer:  0x6583681929a0
-2026/04/13 13:50:41 Closed MCP-GET-SSE SSE connection: 5f1e1e07908d3ef123ea2652c229e7b3
-2026/04/13 13:50:41 Starting MCP-GET-SSE SSE connection: 4945e837c03bacf7f962bd93c33069c2
-2026/04/13 13:50:41 SSEHub: registered connection 4945e837c03bacf7f962bd93c33069c2 (total: 1)
-2026/04/13 13:50:41 SSEHub: unregistered connection 4945e837c03bacf7f962bd93c33069c2 (total: 0)
-2026/04/13 13:50:41 Received kill signal.  Quitting Writer. stop 0x65836852e1c0
-2026/04/13 13:50:41 Cleaning up writer...
-2026/04/13 13:50:41 Finished cleaning up writer:  0x65836852e1c0
-2026/04/13 13:50:41 Closed MCP-GET-SSE SSE connection: 4945e837c03bacf7f962bd93c33069c2
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: 0ceab6c96363b2efad53fa69b473b5ec
+2026/04/13 15:18:05 SSEHub: registered connection 0ceab6c96363b2efad53fa69b473b5ec (total: 1)
 
 === Running scenario: tools-call-image ===
 Running client scenario 'tools-call-image' against server: http://localhost:18799/mcp
-2026/04/13 13:50:41 Starting MCP-GET-SSE SSE connection: b641cecc0c45518227e1ddc04321b43d
-2026/04/13 13:50:41 SSEHub: registered connection b641cecc0c45518227e1ddc04321b43d (total: 1)
-2026/04/13 13:50:41 SSEHub: unregistered connection b641cecc0c45518227e1ddc04321b43d (total: 0)
-2026/04/13 13:50:41 Received kill signal.  Quitting Writer. stop 0x6583684b4310
-2026/04/13 13:50:41 Cleaning up writer...
-2026/04/13 13:50:41 Finished cleaning up writer:  0x6583684b4310
-2026/04/13 13:50:41 Closed MCP-GET-SSE SSE connection: b641cecc0c45518227e1ddc04321b43d
+2026/04/13 15:18:05 SSEHub: unregistered connection 0ceab6c96363b2efad53fa69b473b5ec (total: 0)
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12a90af0
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12a90af0
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: 0ceab6c96363b2efad53fa69b473b5ec
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: b537dbcf4a8ed08d01f2168a9008cdb4
+2026/04/13 15:18:05 SSEHub: registered connection b537dbcf4a8ed08d01f2168a9008cdb4 (total: 1)
 
 === Running scenario: tools-call-audio ===
 Running client scenario 'tools-call-audio' against server: http://localhost:18799/mcp
-2026/04/13 13:50:41 Starting MCP-GET-SSE SSE connection: 94c30035c820aa45060818520e700dad
-2026/04/13 13:50:41 SSEHub: registered connection 94c30035c820aa45060818520e700dad (total: 1)
-2026/04/13 13:50:41 SSEHub: unregistered connection 94c30035c820aa45060818520e700dad (total: 0)
+2026/04/13 15:18:05 SSEHub: unregistered connection b537dbcf4a8ed08d01f2168a9008cdb4 (total: 0)
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12c0e2a0
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12c0e2a0
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: b537dbcf4a8ed08d01f2168a9008cdb4
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: 2973166007dbe989c4110e830ae4c33c
+2026/04/13 15:18:05 SSEHub: registered connection 2973166007dbe989c4110e830ae4c33c (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection 2973166007dbe989c4110e830ae4c33c (total: 0)
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12bc84d0
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12bc84d0
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: 2973166007dbe989c4110e830ae4c33c
 
 === Running scenario: tools-call-embedded-resource ===
-2026/04/13 13:50:41 Received kill signal.  Quitting Writer. stop 0x6583684b4850
-2026/04/13 13:50:41 Cleaning up writer...
-2026/04/13 13:50:41 Finished cleaning up writer:  0x6583684b4850
-2026/04/13 13:50:41 Closed MCP-GET-SSE SSE connection: 94c30035c820aa45060818520e700dad
 Running client scenario 'tools-call-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/13 13:50:41 Starting MCP-GET-SSE SSE connection: 64021534bbb3fc463e22dda1008c9e5b
-2026/04/13 13:50:41 SSEHub: registered connection 64021534bbb3fc463e22dda1008c9e5b (total: 1)
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: fbeab33ddc402640f688af3ea8e7257a
+2026/04/13 15:18:05 SSEHub: registered connection fbeab33ddc402640f688af3ea8e7257a (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection fbeab33ddc402640f688af3ea8e7257a (total: 0)
 
 === Running scenario: tools-call-mixed-content ===
-2026/04/13 13:50:41 SSEHub: unregistered connection 64021534bbb3fc463e22dda1008c9e5b (total: 0)
-2026/04/13 13:50:41 Received kill signal.  Quitting Writer. stop 0x65836852e5b0
-2026/04/13 13:50:41 Cleaning up writer...
-2026/04/13 13:50:41 Finished cleaning up writer:  0x65836852e5b0
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12c0e540
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12c0e540
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: fbeab33ddc402640f688af3ea8e7257a
 Running client scenario 'tools-call-mixed-content' against server: http://localhost:18799/mcp
-2026/04/13 13:50:41 Closed MCP-GET-SSE SSE connection: 64021534bbb3fc463e22dda1008c9e5b
-2026/04/13 13:50:41 Starting MCP-GET-SSE SSE connection: 7b9c3ccafdc7daef9667f0d05bddc4d0
-2026/04/13 13:50:41 SSEHub: registered connection 7b9c3ccafdc7daef9667f0d05bddc4d0 (total: 1)
-2026/04/13 13:50:41 SSEHub: unregistered connection 7b9c3ccafdc7daef9667f0d05bddc4d0 (total: 0)
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: 211c8af1284d4d109bfc49504f4a958e
+2026/04/13 15:18:05 SSEHub: registered connection 211c8af1284d4d109bfc49504f4a958e (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection 211c8af1284d4d109bfc49504f4a958e (total: 0)
 
 === Running scenario: tools-call-with-logging ===
-2026/04/13 13:50:41 Received kill signal.  Quitting Writer. stop 0x6583684b4bd0
-2026/04/13 13:50:41 Cleaning up writer...
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12a90e00
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12a90e00
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: 211c8af1284d4d109bfc49504f4a958e
 Running client scenario 'tools-call-with-logging' against server: http://localhost:18799/mcp
-2026/04/13 13:50:41 Finished cleaning up writer:  0x6583684b4bd0
-2026/04/13 13:50:41 Closed MCP-GET-SSE SSE connection: 7b9c3ccafdc7daef9667f0d05bddc4d0
-2026/04/13 13:50:41 Starting MCP-GET-SSE SSE connection: d9b716ebe6035cb5237dd5185f3f7cb7
-2026/04/13 13:50:41 SSEHub: registered connection d9b716ebe6035cb5237dd5185f3f7cb7 (total: 1)
-2026/04/13 13:50:42 SSEHub: unregistered connection d9b716ebe6035cb5237dd5185f3f7cb7 (total: 0)
-2026/04/13 13:50:42 Received kill signal.  Quitting Writer. stop 0x6583684b4e00
-2026/04/13 13:50:42 Cleaning up writer...
-2026/04/13 13:50:42 Finished cleaning up writer:  0x6583684b4e00
-2026/04/13 13:50:42 Closed MCP-GET-SSE SSE connection: d9b716ebe6035cb5237dd5185f3f7cb7
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: a415b8b7671a5602cd30d4c07aaddffd
+2026/04/13 15:18:05 SSEHub: registered connection a415b8b7671a5602cd30d4c07aaddffd (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection a415b8b7671a5602cd30d4c07aaddffd (total: 0)
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12c0e770
+2026/04/13 15:18:05 Cleaning up writer...
 
 === Running scenario: tools-call-error ===
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12c0e770
 Running client scenario 'tools-call-error' against server: http://localhost:18799/mcp
-2026/04/13 13:50:42 Starting MCP-GET-SSE SSE connection: 3477937fcfc706e82f27baa4b66febc1
-2026/04/13 13:50:42 SSEHub: registered connection 3477937fcfc706e82f27baa4b66febc1 (total: 1)
-2026/04/13 13:50:42 SSEHub: unregistered connection 3477937fcfc706e82f27baa4b66febc1 (total: 0)
-2026/04/13 13:50:42 Received kill signal.  Quitting Writer. stop 0x6583680ee690
-2026/04/13 13:50:42 Cleaning up writer...
-2026/04/13 13:50:42 Finished cleaning up writer:  0x6583680ee690
-2026/04/13 13:50:42 Closed MCP-GET-SSE SSE connection: 3477937fcfc706e82f27baa4b66febc1
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: a415b8b7671a5602cd30d4c07aaddffd
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: 114a43e2ab6267fbe08acfd927c0cf79
+2026/04/13 15:18:05 SSEHub: registered connection 114a43e2ab6267fbe08acfd927c0cf79 (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection 114a43e2ab6267fbe08acfd927c0cf79 (total: 0)
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12d2c310
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12d2c310
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: 114a43e2ab6267fbe08acfd927c0cf79
 
 === Running scenario: tools-call-with-progress ===
 Running client scenario 'tools-call-with-progress' against server: http://localhost:18799/mcp
-2026/04/13 13:50:42 Starting MCP-GET-SSE SSE connection: 8c95d562d93c7f4b6084f99c68ff986b
-2026/04/13 13:50:42 SSEHub: registered connection 8c95d562d93c7f4b6084f99c68ff986b (total: 1)
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: 471a9204290f333868ec7e89d3598e90
+2026/04/13 15:18:05 SSEHub: registered connection 471a9204290f333868ec7e89d3598e90 (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection 471a9204290f333868ec7e89d3598e90 (total: 0)
 
 === Running scenario: tools-call-sampling ===
-2026/04/13 13:50:42 SSEHub: unregistered connection 8c95d562d93c7f4b6084f99c68ff986b (total: 0)
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12c0eb60
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12c0eb60
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: 471a9204290f333868ec7e89d3598e90
 Running client scenario 'tools-call-sampling' against server: http://localhost:18799/mcp
-2026/04/13 13:50:42 Received kill signal.  Quitting Writer. stop 0x658368192c40
-2026/04/13 13:50:42 Cleaning up writer...
-2026/04/13 13:50:42 Finished cleaning up writer:  0x658368192c40
-2026/04/13 13:50:42 Closed MCP-GET-SSE SSE connection: 8c95d562d93c7f4b6084f99c68ff986b
-2026/04/13 13:50:42 Starting MCP-GET-SSE SSE connection: 18fcab9d86d9bb0ffc8399deaa7ea9a2
-2026/04/13 13:50:42 SSEHub: registered connection 18fcab9d86d9bb0ffc8399deaa7ea9a2 (total: 1)
-2026/04/13 13:50:42 SSEHub: unregistered connection 18fcab9d86d9bb0ffc8399deaa7ea9a2 (total: 0)
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: b2d927d09d7bbbc92b463e7b1f697e07
+2026/04/13 15:18:05 SSEHub: registered connection b2d927d09d7bbbc92b463e7b1f697e07 (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection b2d927d09d7bbbc92b463e7b1f697e07 (total: 0)
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12a91180
+2026/04/13 15:18:05 Cleaning up writer...
 
 === Running scenario: tools-call-elicitation ===
-2026/04/13 13:50:42 Received kill signal.  Quitting Writer. stop 0x658368192e70
-2026/04/13 13:50:42 Cleaning up writer...
-2026/04/13 13:50:42 Finished cleaning up writer:  0x658368192e70
-2026/04/13 13:50:42 Closed MCP-GET-SSE SSE connection: 18fcab9d86d9bb0ffc8399deaa7ea9a2
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12a91180
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: b2d927d09d7bbbc92b463e7b1f697e07
 Running client scenario 'tools-call-elicitation' against server: http://localhost:18799/mcp
-2026/04/13 13:50:42 Starting MCP-GET-SSE SSE connection: fc5ab414a0ce502352f3a021a3f03ea2
-2026/04/13 13:50:42 SSEHub: registered connection fc5ab414a0ce502352f3a021a3f03ea2 (total: 1)
-2026/04/13 13:50:42 SSEHub: unregistered connection fc5ab414a0ce502352f3a021a3f03ea2 (total: 0)
-2026/04/13 13:50:42 Received kill signal.  Quitting Writer. stop 0x6583684b51f0
-2026/04/13 13:50:42 Cleaning up writer...
-2026/04/13 13:50:42 Finished cleaning up writer:  0x6583684b51f0
-2026/04/13 13:50:42 Closed MCP-GET-SSE SSE connection: fc5ab414a0ce502352f3a021a3f03ea2
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: a971a64bfc397557820e72a9f9b2d859
+2026/04/13 15:18:05 SSEHub: registered connection a971a64bfc397557820e72a9f9b2d859 (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection a971a64bfc397557820e72a9f9b2d859 (total: 0)
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12bc8a10
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12bc8a10
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: a971a64bfc397557820e72a9f9b2d859
 
 === Running scenario: elicitation-sep1034-defaults ===
 Running client scenario 'elicitation-sep1034-defaults' against server: http://localhost:18799/mcp
-2026/04/13 13:50:42 Starting MCP-GET-SSE SSE connection: 4fe7805cfc39643975b2236c5e406672
-2026/04/13 13:50:42 SSEHub: registered connection 4fe7805cfc39643975b2236c5e406672 (total: 1)
-2026/04/13 13:50:42 SSEHub: unregistered connection 4fe7805cfc39643975b2236c5e406672 (total: 0)
-2026/04/13 13:50:42 Received kill signal.  Quitting Writer. stop 0x6583681930a0
-2026/04/13 13:50:42 Cleaning up writer...
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: a4ef09066dbf66c19d49ae6517902141
+2026/04/13 15:18:05 SSEHub: registered connection a4ef09066dbf66c19d49ae6517902141 (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection a4ef09066dbf66c19d49ae6517902141 (total: 0)
 
 === Running scenario: server-sse-multiple-streams ===
-2026/04/13 13:50:42 Finished cleaning up writer:  0x6583681930a0
-2026/04/13 13:50:42 Closed MCP-GET-SSE SSE connection: 4fe7805cfc39643975b2236c5e406672
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12a913b0
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12a913b0
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: a4ef09066dbf66c19d49ae6517902141
 Running client scenario 'server-sse-multiple-streams' against server: http://localhost:18799/mcp
-2026/04/13 13:50:42 Starting MCP-GET-SSE SSE connection: a80d84dde43a020a20d6080a9dd72958
-2026/04/13 13:50:42 SSEHub: registered connection a80d84dde43a020a20d6080a9dd72958 (total: 1)
-2026/04/13 13:50:42 SSEHub: unregistered connection a80d84dde43a020a20d6080a9dd72958 (total: 0)
-2026/04/13 13:50:42 Received kill signal.  Quitting Writer. stop 0x65836852ec40
-2026/04/13 13:50:42 Cleaning up writer...
-2026/04/13 13:50:42 Finished cleaning up writer:  0x65836852ec40
-2026/04/13 13:50:42 Closed MCP-GET-SSE SSE connection: a80d84dde43a020a20d6080a9dd72958
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: 45a559749ba691ffa228b3db0011d7e1
+2026/04/13 15:18:05 SSEHub: registered connection 45a559749ba691ffa228b3db0011d7e1 (total: 1)
 
 === Running scenario: elicitation-sep1330-enums ===
+2026/04/13 15:18:05 SSEHub: unregistered connection 45a559749ba691ffa228b3db0011d7e1 (total: 0)
 Running client scenario 'elicitation-sep1330-enums' against server: http://localhost:18799/mcp
-2026/04/13 13:50:42 Starting MCP-GET-SSE SSE connection: 62fc87e1b357e585f036ace8648197b1
-2026/04/13 13:50:42 SSEHub: registered connection 62fc87e1b357e585f036ace8648197b1 (total: 1)
-2026/04/13 13:50:42 SSEHub: unregistered connection 62fc87e1b357e585f036ace8648197b1 (total: 0)
-2026/04/13 13:50:42 Received kill signal.  Quitting Writer. stop 0x6583684b56c0
-2026/04/13 13:50:42 Cleaning up writer...
-2026/04/13 13:50:42 Finished cleaning up writer:  0x6583684b56c0
-2026/04/13 13:50:42 Closed MCP-GET-SSE SSE connection: 62fc87e1b357e585f036ace8648197b1
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12a91880
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12a91880
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: 45a559749ba691ffa228b3db0011d7e1
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: e37e7aa519b5c9f04d6542515d34808d
+2026/04/13 15:18:05 SSEHub: registered connection e37e7aa519b5c9f04d6542515d34808d (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection e37e7aa519b5c9f04d6542515d34808d (total: 0)
 
 === Running scenario: resources-list ===
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12a91c70
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12a91c70
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: e37e7aa519b5c9f04d6542515d34808d
 Running client scenario 'resources-list' against server: http://localhost:18799/mcp
-2026/04/13 13:50:42 Starting MCP-GET-SSE SSE connection: 4ef7aa77b969bf264d35834ed32d2518
-2026/04/13 13:50:42 SSEHub: registered connection 4ef7aa77b969bf264d35834ed32d2518 (total: 1)
-2026/04/13 13:50:42 SSEHub: unregistered connection 4ef7aa77b969bf264d35834ed32d2518 (total: 0)
-2026/04/13 13:50:42 Received kill signal.  Quitting Writer. stop 0x6583680eebd0
-2026/04/13 13:50:42 Cleaning up writer...
-2026/04/13 13:50:42 Finished cleaning up writer:  0x6583680eebd0
-2026/04/13 13:50:42 Closed MCP-GET-SSE SSE connection: 4ef7aa77b969bf264d35834ed32d2518
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: b59ee6a8aa15f5ff5c2e4aaaffc6c95c
+2026/04/13 15:18:05 SSEHub: registered connection b59ee6a8aa15f5ff5c2e4aaaffc6c95c (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection b59ee6a8aa15f5ff5c2e4aaaffc6c95c (total: 0)
 
 === Running scenario: resources-read-text ===
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12d2caf0
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12d2caf0
 Running client scenario 'resources-read-text' against server: http://localhost:18799/mcp
-2026/04/13 13:50:42 Starting MCP-GET-SSE SSE connection: 5040783f471bff07ccd0d9f8fbf51730
-2026/04/13 13:50:42 SSEHub: registered connection 5040783f471bff07ccd0d9f8fbf51730 (total: 1)
-2026/04/13 13:50:42 SSEHub: unregistered connection 5040783f471bff07ccd0d9f8fbf51730 (total: 0)
-2026/04/13 13:50:42 Received kill signal.  Quitting Writer. stop 0x658368193500
-2026/04/13 13:50:42 Cleaning up writer...
-2026/04/13 13:50:42 Finished cleaning up writer:  0x658368193500
-2026/04/13 13:50:42 Closed MCP-GET-SSE SSE connection: 5040783f471bff07ccd0d9f8fbf51730
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: b59ee6a8aa15f5ff5c2e4aaaffc6c95c
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: f732d437a7dccaea464f8511841f9cb1
+2026/04/13 15:18:05 SSEHub: registered connection f732d437a7dccaea464f8511841f9cb1 (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection f732d437a7dccaea464f8511841f9cb1 (total: 0)
 
 === Running scenario: resources-read-binary ===
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12f2e770
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12f2e770
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: f732d437a7dccaea464f8511841f9cb1
 Running client scenario 'resources-read-binary' against server: http://localhost:18799/mcp
-2026/04/13 13:50:42 Starting MCP-GET-SSE SSE connection: ec5dbe77a1b8ef9ed105e38a70dc89a6
-2026/04/13 13:50:42 SSEHub: registered connection ec5dbe77a1b8ef9ed105e38a70dc89a6 (total: 1)
-2026/04/13 13:50:42 SSEHub: unregistered connection ec5dbe77a1b8ef9ed105e38a70dc89a6 (total: 0)
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: 33fa213636579169eacad26d746c87db
+2026/04/13 15:18:05 SSEHub: registered connection 33fa213636579169eacad26d746c87db (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection 33fa213636579169eacad26d746c87db (total: 0)
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12d2cd90
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12d2cd90
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: 33fa213636579169eacad26d746c87db
 
 === Running scenario: resources-templates-read ===
-2026/04/13 13:50:42 Received kill signal.  Quitting Writer. stop 0x6583684b58f0
-2026/04/13 13:50:42 Cleaning up writer...
-2026/04/13 13:50:42 Finished cleaning up writer:  0x6583684b58f0
-2026/04/13 13:50:42 Closed MCP-GET-SSE SSE connection: ec5dbe77a1b8ef9ed105e38a70dc89a6
 Running client scenario 'resources-templates-read' against server: http://localhost:18799/mcp
-2026/04/13 13:50:42 Starting MCP-GET-SSE SSE connection: f9dfeea2c6bfac4adf19f50f4bc4a53f
-2026/04/13 13:50:42 SSEHub: registered connection f9dfeea2c6bfac4adf19f50f4bc4a53f (total: 1)
-2026/04/13 13:50:42 SSEHub: unregistered connection f9dfeea2c6bfac4adf19f50f4bc4a53f (total: 0)
-2026/04/13 13:50:42 Received kill signal.  Quitting Writer. stop 0x658368193960
-2026/04/13 13:50:42 Cleaning up writer...
-2026/04/13 13:50:42 Finished cleaning up writer:  0x658368193960
-2026/04/13 13:50:42 Closed MCP-GET-SSE SSE connection: f9dfeea2c6bfac4adf19f50f4bc4a53f
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: 84f965cad498ee21811e8a34222755fd
+2026/04/13 15:18:05 SSEHub: registered connection 84f965cad498ee21811e8a34222755fd (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection 84f965cad498ee21811e8a34222755fd (total: 0)
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12f2ea80
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12f2ea80
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: 84f965cad498ee21811e8a34222755fd
 
 === Running scenario: resources-subscribe ===
 Running client scenario 'resources-subscribe' against server: http://localhost:18799/mcp
-2026/04/13 13:50:42 Starting MCP-GET-SSE SSE connection: bfae56b0f0376d3217e2244494d4448d
-2026/04/13 13:50:42 SSEHub: registered connection bfae56b0f0376d3217e2244494d4448d (total: 1)
-2026/04/13 13:50:42 SSEHub: unregistered connection bfae56b0f0376d3217e2244494d4448d (total: 0)
-2026/04/13 13:50:42 Received kill signal.  Quitting Writer. stop 0x65836852f030
-2026/04/13 13:50:42 Cleaning up writer...
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: c035ae6971a25759e7eb3688cf1729f3
+2026/04/13 15:18:05 SSEHub: registered connection c035ae6971a25759e7eb3688cf1729f3 (total: 1)
 
 === Running scenario: resources-unsubscribe ===
-2026/04/13 13:50:42 Finished cleaning up writer:  0x65836852f030
 Running client scenario 'resources-unsubscribe' against server: http://localhost:18799/mcp
-2026/04/13 13:50:42 Closed MCP-GET-SSE SSE connection: bfae56b0f0376d3217e2244494d4448d
-2026/04/13 13:50:42 Starting MCP-GET-SSE SSE connection: ce512a56567c7768ccc7e03133f5c4e7
-2026/04/13 13:50:42 SSEHub: registered connection ce512a56567c7768ccc7e03133f5c4e7 (total: 1)
-2026/04/13 13:50:42 SSEHub: unregistered connection ce512a56567c7768ccc7e03133f5c4e7 (total: 0)
-2026/04/13 13:50:42 Received kill signal.  Quitting Writer. stop 0x6583684b5b90
-2026/04/13 13:50:42 Cleaning up writer...
-2026/04/13 13:50:42 Finished cleaning up writer:  0x6583684b5b90
-2026/04/13 13:50:42 Closed MCP-GET-SSE SSE connection: ce512a56567c7768ccc7e03133f5c4e7
+2026/04/13 15:18:05 SSEHub: unregistered connection c035ae6971a25759e7eb3688cf1729f3 (total: 0)
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12f2ed90
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12f2ed90
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: c035ae6971a25759e7eb3688cf1729f3
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: 6b841c353cc364bcac04bc60c5543a85
+2026/04/13 15:18:05 SSEHub: registered connection 6b841c353cc364bcac04bc60c5543a85 (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection 6b841c353cc364bcac04bc60c5543a85 (total: 0)
 
 === Running scenario: prompts-list ===
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12f2efc0
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12f2efc0
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: 6b841c353cc364bcac04bc60c5543a85
 Running client scenario 'prompts-list' against server: http://localhost:18799/mcp
-2026/04/13 13:50:42 Starting MCP-GET-SSE SSE connection: b3c18c2ffac5e59b3c05df915d471664
-2026/04/13 13:50:42 SSEHub: registered connection b3c18c2ffac5e59b3c05df915d471664 (total: 1)
-2026/04/13 13:50:42 SSEHub: unregistered connection b3c18c2ffac5e59b3c05df915d471664 (total: 0)
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: d9acd954d0eb5e77b868bc9a4b191cb5
+2026/04/13 15:18:05 SSEHub: registered connection d9acd954d0eb5e77b868bc9a4b191cb5 (total: 1)
 
 === Running scenario: prompts-get-simple ===
-2026/04/13 13:50:42 Received kill signal.  Quitting Writer. stop 0x6583684b5ea0
-2026/04/13 13:50:42 Cleaning up writer...
-2026/04/13 13:50:42 Finished cleaning up writer:  0x6583684b5ea0
-2026/04/13 13:50:42 Closed MCP-GET-SSE SSE connection: b3c18c2ffac5e59b3c05df915d471664
 Running client scenario 'prompts-get-simple' against server: http://localhost:18799/mcp
-2026/04/13 13:50:42 Starting MCP-GET-SSE SSE connection: c487bf924e354d06ad19bbc977e98490
-2026/04/13 13:50:42 SSEHub: registered connection c487bf924e354d06ad19bbc977e98490 (total: 1)
-2026/04/13 13:50:42 SSEHub: unregistered connection c487bf924e354d06ad19bbc977e98490 (total: 0)
+2026/04/13 15:18:05 SSEHub: unregistered connection d9acd954d0eb5e77b868bc9a4b191cb5 (total: 0)
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12f2f260
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12f2f260
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: d9acd954d0eb5e77b868bc9a4b191cb5
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: c884f9999ad2e4933a05c42502b830bc
+2026/04/13 15:18:05 SSEHub: registered connection c884f9999ad2e4933a05c42502b830bc (total: 1)
 
 === Running scenario: prompts-get-with-args ===
-2026/04/13 13:50:42 Received kill signal.  Quitting Writer. stop 0x658368193d50
-2026/04/13 13:50:42 Cleaning up writer...
-2026/04/13 13:50:42 Finished cleaning up writer:  0x658368193d50
-2026/04/13 13:50:42 Closed MCP-GET-SSE SSE connection: c487bf924e354d06ad19bbc977e98490
+2026/04/13 15:18:05 SSEHub: unregistered connection c884f9999ad2e4933a05c42502b830bc (total: 0)
 Running client scenario 'prompts-get-with-args' against server: http://localhost:18799/mcp
-2026/04/13 13:50:42 Starting MCP-GET-SSE SSE connection: 9c0e816c613aecc835e6bde448ef569e
-2026/04/13 13:50:42 SSEHub: registered connection 9c0e816c613aecc835e6bde448ef569e (total: 1)
-2026/04/13 13:50:42 SSEHub: unregistered connection 9c0e816c613aecc835e6bde448ef569e (total: 0)
-2026/04/13 13:50:42 Received kill signal.  Quitting Writer. stop 0x6583680ef030
-2026/04/13 13:50:42 Cleaning up writer...
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12f2f500
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12f2f500
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: c884f9999ad2e4933a05c42502b830bc
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: 094d86c879be1ec1b01c7aff38f3278f
+2026/04/13 15:18:05 SSEHub: registered connection 094d86c879be1ec1b01c7aff38f3278f (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection 094d86c879be1ec1b01c7aff38f3278f (total: 0)
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12d2d0a0
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12d2d0a0
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: 094d86c879be1ec1b01c7aff38f3278f
 
 === Running scenario: prompts-get-embedded-resource ===
-2026/04/13 13:50:42 Finished cleaning up writer:  0x6583680ef030
-2026/04/13 13:50:42 Closed MCP-GET-SSE SSE connection: 9c0e816c613aecc835e6bde448ef569e
 Running client scenario 'prompts-get-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/13 13:50:42 Starting MCP-GET-SSE SSE connection: a9b050e814f28049557cb93e99b985e3
-2026/04/13 13:50:42 SSEHub: registered connection a9b050e814f28049557cb93e99b985e3 (total: 1)
-2026/04/13 13:50:42 SSEHub: unregistered connection a9b050e814f28049557cb93e99b985e3 (total: 0)
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: 375ae238a802171e8463957d5245d718
+2026/04/13 15:18:05 SSEHub: registered connection 375ae238a802171e8463957d5245d718 (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection 375ae238a802171e8463957d5245d718 (total: 0)
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12f2f7a0
+2026/04/13 15:18:05 Cleaning up writer...
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12f2f7a0
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: 375ae238a802171e8463957d5245d718
 
 === Running scenario: prompts-get-with-image ===
-2026/04/13 13:50:42 Received kill signal.  Quitting Writer. stop 0x65836852f340
-2026/04/13 13:50:42 Cleaning up writer...
-2026/04/13 13:50:42 Finished cleaning up writer:  0x65836852f340
-2026/04/13 13:50:42 Closed MCP-GET-SSE SSE connection: a9b050e814f28049557cb93e99b985e3
 Running client scenario 'prompts-get-with-image' against server: http://localhost:18799/mcp
-2026/04/13 13:50:42 Starting MCP-GET-SSE SSE connection: 45184d4c2e2554942204da48a7fd36f8
-2026/04/13 13:50:42 SSEHub: registered connection 45184d4c2e2554942204da48a7fd36f8 (total: 1)
-2026/04/13 13:50:42 SSEHub: unregistered connection 45184d4c2e2554942204da48a7fd36f8 (total: 0)
-2026/04/13 13:50:42 Received kill signal.  Quitting Writer. stop 0x658368268070
-2026/04/13 13:50:42 Cleaning up writer...
-2026/04/13 13:50:42 Finished cleaning up writer:  0x658368268070
-2026/04/13 13:50:42 Closed MCP-GET-SSE SSE connection: 45184d4c2e2554942204da48a7fd36f8
+2026/04/13 15:18:05 Starting MCP-GET-SSE SSE connection: fb73295efe37ea6c77fcf2d4a00c3f6a
+2026/04/13 15:18:05 SSEHub: registered connection fb73295efe37ea6c77fcf2d4a00c3f6a (total: 1)
+2026/04/13 15:18:05 SSEHub: unregistered connection fb73295efe37ea6c77fcf2d4a00c3f6a (total: 0)
 
 === Running scenario: dns-rebinding-protection ===
+2026/04/13 15:18:05 Received kill signal.  Quitting Writer. stop 0x52b12c0ee00
+2026/04/13 15:18:05 Cleaning up writer...
 Running client scenario 'dns-rebinding-protection' against server: http://localhost:18799/mcp
+2026/04/13 15:18:05 Finished cleaning up writer:  0x52b12c0ee00
+2026/04/13 15:18:05 Closed MCP-GET-SSE SSE connection: fb73295efe37ea6c77fcf2d4a00c3f6a
 
 
 === SUMMARY ===
@@ -391,22 +393,22 @@ Starting scenario: auth/token-endpoint-auth-basic
 Starting scenario: auth/token-endpoint-auth-post
 Starting scenario: auth/token-endpoint-auth-none
 Starting scenario: auth/pre-registration
-Executing client: ./bin/testclient http://localhost:54548/mcp
-Executing client: ./bin/testclient http://localhost:54549/mcp
-Executing client: ./bin/testclient http://localhost:54550/mcp
-Executing client: ./bin/testclient http://localhost:54551/mcp
-Executing client: ./bin/testclient http://localhost:54552/mcp
-Executing client: ./bin/testclient http://localhost:54553/mcp
-Executing client: ./bin/testclient http://localhost:54554/mcp
-Executing client: ./bin/testclient http://localhost:54555/mcp
-Executing client: ./bin/testclient http://localhost:54556/mcp
-Executing client: ./bin/testclient http://localhost:54557/mcp
-Executing client: ./bin/testclient http://localhost:54558/mcp
-Executing client: ./bin/testclient http://localhost:54559/mcp
-Executing client: ./bin/testclient http://localhost:54560/mcp
-Executing client: ./bin/testclient http://localhost:54561/mcp
+Executing client: ./bin/testclient http://localhost:63243/mcp
+Executing client: ./bin/testclient http://localhost:63244/mcp
+Executing client: ./bin/testclient http://localhost:63245/mcp
+Executing client: ./bin/testclient http://localhost:63246/mcp
+Executing client: ./bin/testclient http://localhost:63247/mcp
+Executing client: ./bin/testclient http://localhost:63248/mcp
+Executing client: ./bin/testclient http://localhost:63249/mcp
+Executing client: ./bin/testclient http://localhost:63250/mcp
+Executing client: ./bin/testclient http://localhost:63251/mcp
+Executing client: ./bin/testclient http://localhost:63252/mcp
+Executing client: ./bin/testclient http://localhost:63253/mcp
+Executing client: ./bin/testclient http://localhost:63254/mcp
+Executing client: ./bin/testclient http://localhost:63255/mcp
+Executing client: ./bin/testclient http://localhost:63256/mcp
 With context: {"client_id":"pre-registered-client","client_secret":"pre-registered-secret"}
-(node:30137) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
+(node:84908) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
 (Use `node --trace-deprecation ...` to show where the warning was created)
 
 === SUITE SUMMARY ===
@@ -439,7 +441,7 @@ Total: 210 passed, 0 failed, 1 warnings
 === RUN   TestKeycloak_MCPServer_ValidToken
 --- PASS: TestKeycloak_MCPServer_ValidToken (0.02s)
 === RUN   TestKeycloak_MCPServer_TamperedToken
---- PASS: TestKeycloak_MCPServer_TamperedToken (0.02s)
+--- PASS: TestKeycloak_MCPServer_TamperedToken (0.01s)
 === RUN   TestKeycloak_MCPServer_ScopeAllowed
 --- PASS: TestKeycloak_MCPServer_ScopeAllowed (0.01s)
 === RUN   TestKeycloak_MCPServer_ScopeDenied
@@ -449,10 +451,10 @@ Total: 210 passed, 0 failed, 1 warnings
 === RUN   TestKeycloak_MCPServer_WWWAuthenticate
 --- PASS: TestKeycloak_MCPServer_WWWAuthenticate (0.01s)
 === RUN   TestKeycloak_MCPServer_PasswordGrant
---- PASS: TestKeycloak_MCPServer_PasswordGrant (0.05s)
+--- PASS: TestKeycloak_MCPServer_PasswordGrant (0.04s)
 PASS
-ok  	github.com/panyam/mcpkit/tests/keycloak	0.737s
+ok  	github.com/panyam/mcpkit/tests/keycloak	0.381s
   PASS: keycloak
 
 === Results: 8 passed, 0 failed ===
-Finished: Mon Apr 13 13:50:45 PDT 2026
+Finished: Mon Apr 13 15:18:08 PDT 2026


### PR DESCRIPTION
## Summary

- When `RegisterAppTool` receives a template URI with a `TemplateHandler`, it now auto-generates a concrete fallback resource (`ui://{host}/{tool}/latest`) for hosts that don't support template variable substitution
- Adds `core.URITemplateVars()` / `core.IsTemplateURI()` using RFC 6570 parsing (replaces fragile `strings.Contains("{")` checks)
- Three registration paths: auto-fallback (new), manual hybrid (unchanged), direct concrete (unchanged)
- Fixes missing `go.sum` entries for `uritemplate` in ext/auth and cmd/testclient

## Design

The concrete fallback is internal — consumers just provide a `TemplateHandler`. When hosts eventually support template URI substitution, the fallback gets removed internally with zero consumer API changes. Manual hybrid (template URI + `ResourceHandler`, no `TemplateHandler`) still works for consumers who want full control.

## Test plan

- [x] `make testall` — 8/8 passing (unit, race, auth, ui, e2e, conformance, auth-conformance, keycloak)
- [x] New tests: `TestRegisterAppToolTemplate`, `TestTemplateManualHybrid`, `TestConcreteFallbackURI`, `TestExtractTemplateParams` (5 sub-cases)
- [x] 14 ext/ui tests passing

Closes #213