### PR TITLE
feat(client): add ToolCallFull for typed tool results with isError

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -800,6 +800,25 @@ func (c *Client) ToolCall(name string, args any) (string, error) {
 	return extractToolText(result.Raw)
 }
 
+// ToolCallFull invokes a tool and returns the complete result including
+// IsError, all content blocks, and the raw JSON. Unlike ToolCall, tool-level
+// errors (isError: true) are returned in the result, not as Go errors.
+// Only transport/protocol failures produce a Go error.
+func (c *Client) ToolCallFull(name string, args any) (*core.ToolResult, error) {
+	result, err := c.Call("tools/call", map[string]any{
+		"name":      name,
+		"arguments": args,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var toolResult core.ToolResult
+	if err := json.Unmarshal(result.Raw, &toolResult); err != nil {
+		return nil, fmt.Errorf("unmarshal tool result: %w", err)
+	}
+	return &toolResult, nil
+}
+
 // ReadResource reads a resource by URI and returns the first text content.
 func (c *Client) ReadResource(uri string) (string, error) {
 	result, err := c.Call("resources/read", map[string]string{"uri": uri})

--- a/client/typed_call_test.go
+++ b/client/typed_call_test.go
@@ -1,6 +1,7 @@
 package client_test
 
 import (
+	"encoding/json"
 	"net/http/httptest"
 	"testing"
 
@@ -107,4 +108,123 @@ func TestToolCallTypedToolError(t *testing.T) {
 	_, err := client.ToolCallTyped[Anything](c, "fail", nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "tool error")
+}
+
+// TestToolCallFullSuccess verifies that ToolCallFull returns the complete
+// ToolResult on success, preserving all content blocks.
+func TestToolCallFullSuccess(t *testing.T) {
+	srv := server.NewServer(core.ServerInfo{Name: "test", Version: "1.0"})
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "greet",
+			Description: "Returns a greeting",
+			InputSchema: map[string]any{"type": "object"},
+		},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+			return core.TextResult("hello world"), nil
+		},
+	)
+
+	handler := srv.Handler(server.WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "test", Version: "1.0"})
+	require.NoError(t, c.Connect())
+	defer c.Close()
+
+	result, err := c.ToolCallFull("greet", nil)
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	require.Len(t, result.Content, 1)
+	assert.Equal(t, "hello world", result.Content[0].Text)
+}
+
+// TestToolCallFullError verifies that ToolCallFull returns tool-level errors
+// in the result (IsError: true) instead of as Go errors — preserving
+// structured error data that ToolCall would flatten.
+func TestToolCallFullError(t *testing.T) {
+	srv := server.NewServer(core.ServerInfo{Name: "test", Version: "1.0"})
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "conflict",
+			Description: "Returns a structured error",
+			InputSchema: map[string]any{"type": "object"},
+		},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+			return core.StructuredError("version conflict", map[string]any{
+				"error":           "version_conflict",
+				"current_version": 5,
+			}), nil
+		},
+	)
+
+	handler := srv.Handler(server.WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "test", Version: "1.0"})
+	require.NoError(t, c.Connect())
+	defer c.Close()
+
+	// ToolCallFull should NOT return a Go error for tool-level errors.
+	result, err := c.ToolCallFull("conflict", nil)
+	require.NoError(t, err, "transport should succeed even when tool errors")
+	assert.True(t, result.IsError)
+	require.Len(t, result.Content, 1)
+	assert.Equal(t, "version conflict", result.Content[0].Text)
+
+	// StructuredContent should be preserved (not flattened).
+	require.NotNil(t, result.StructuredContent)
+	raw, err := json.Marshal(result.StructuredContent)
+	require.NoError(t, err)
+	var conflict map[string]any
+	require.NoError(t, json.Unmarshal(raw, &conflict))
+	assert.Equal(t, "version_conflict", conflict["error"])
+	assert.Equal(t, float64(5), conflict["current_version"])
+
+	// Contrast: ToolCall would flatten this to a Go error, losing the data.
+	_, toolCallErr := c.ToolCall("conflict", nil)
+	assert.Error(t, toolCallErr, "ToolCall should return Go error for isError:true")
+	assert.Contains(t, toolCallErr.Error(), "version conflict")
+}
+
+// TestToolCallFullStructuredSuccess verifies that ToolCallFull preserves
+// structured content on successful results.
+func TestToolCallFullStructuredSuccess(t *testing.T) {
+	type SearchResult struct {
+		Items []string `json:"items"`
+		Total int      `json:"total"`
+	}
+
+	srv := server.NewServer(core.ServerInfo{Name: "test", Version: "1.0"})
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:         "search",
+			Description:  "Returns structured results",
+			InputSchema:  map[string]any{"type": "object"},
+			OutputSchema: map[string]any{"type": "object"},
+		},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+			return core.StructuredResult("found 2 items", SearchResult{
+				Items: []string{"a", "b"},
+				Total: 2,
+			}), nil
+		},
+	)
+
+	handler := srv.Handler(server.WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "test", Version: "1.0"})
+	require.NoError(t, c.Connect())
+	defer c.Close()
+
+	result, err := c.ToolCallFull("search", nil)
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	require.Len(t, result.Content, 1)
+	assert.Equal(t, "found 2 items", result.Content[0].Text)
+	require.NotNil(t, result.StructuredContent)
 }


### PR DESCRIPTION
## Summary

- Adds `Client.ToolCallFull(name, args) (*core.ToolResult, error)` — returns the complete result including `IsError`, all `Content` blocks, and `StructuredContent`
- Tool-level errors (`isError: true`) are returned in the result, not as Go errors — only transport/protocol failures produce a Go error
- Uses `core.ToolResult` directly (no new type needed)
- Existing `ToolCall` and `ToolCallTyped` unchanged for backward compat

## Test plan

- [x] `TestToolCallFullSuccess` — verifies text content preserved
- [x] `TestToolCallFullError` — verifies `IsError` + `StructuredContent` preserved, contrasts with `ToolCall` behavior
- [x] `TestToolCallFullStructuredSuccess` — verifies structured content on success
- [x] All existing `ToolCall`/`ToolCallTyped` tests still pass (no regressions)
- [x] `make test` — all core tests passing

Closes #215