### PR TITLE
feat(ext/protogen): completion annotations and codegen

### DIFF
--- a/ext/protogen/examples/bookservice/bookservice_test.go
+++ b/ext/protogen/examples/bookservice/bookservice_test.go
@@ -20,6 +20,7 @@ func newTestServer() *server.Server {
 	booksv1.RegisterBookServiceMCP(srv, impl)
 	booksv1.RegisterBookServiceMCPResources(srv, impl)
 	booksv1.RegisterBookServiceMCPPrompts(srv, impl)
+	booksv1.RegisterBookServiceMCPCompletions(srv, impl)
 	return srv
 }
 
@@ -148,4 +149,34 @@ func TestListResources(t *testing.T) {
 	}
 	assert.Contains(t, templateURIs, "book://{book_id}")
 	assert.Contains(t, templateURIs, "author://{author_id}/books")
+}
+
+// TestCompletion verifies that completion/complete works end-to-end for
+// the book_id field on the resource template.
+func TestCompletion(t *testing.T) {
+	srv := newTestServer()
+	handler := srv.Handler(server.WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "test", Version: "1.0"})
+	require.NoError(t, c.Connect())
+	defer c.Close()
+
+	// Complete book_id on the resource template.
+	result, err := c.Call("completion/complete", map[string]any{
+		"ref": map[string]any{
+			"type": "ref/resource",
+			"uri":  "book://{book_id}",
+		},
+		"argument": map[string]any{
+			"name":  "book_id",
+			"value": "1",
+		},
+	})
+	require.NoError(t, err)
+
+	var completeResult core.CompletionCompleteResult
+	require.NoError(t, result.Unmarshal(&completeResult))
+	assert.Contains(t, completeResult.Completion.Values, "1")
 }

--- a/ext/protogen/examples/bookservice/gen/bookservice/v1/service.pb.go
+++ b/ext/protogen/examples/bookservice/gen/bookservice/v1/service.pb.go
@@ -652,16 +652,16 @@ const file_bookservice_v1_service_proto_rawDesc = "" +
 	"\x05genre\x18\x04 \x01(\tR\x05genre\x12\x12\n" +
 	"\x04year\x18\x05 \x01(\x05R\x04year\x12\x1a\n" +
 	"\bsynopsis\x18\x06 \x01(\tR\bsynopsis\x12\x16\n" +
-	"\x06rating\x18\a \x01(\x02R\x06rating2\x82\x06\n" +
+	"\x06rating\x18\a \x01(\x02R\x06rating2\x95\x06\n" +
 	"\vBookService\x12\xa3\x01\n" +
 	"\vSearchBooks\x12\".bookservice.v1.SearchBooksRequest\x1a#.bookservice.v1.SearchBooksResponse\"K\xca\xf3\x18G\n" +
-	"\x06search\x12\x17Search the book catalog \x01*\"Found {total} books matching query\x12\x7f\n" +
-	"\aGetBook\x12\x1e.bookservice.v1.GetBookRequest\x1a\x1f.bookservice.v1.GetBookResponse\"3\xd2\xf3\x18/\n" +
-	"\x10book://{book_id}\x12\x04Book\"\x15A book in the catalog\x12\xa1\x01\n" +
+	"\x06search\x12\x17Search the book catalog \x01*\"Found {total} books matching query\x12\x88\x01\n" +
+	"\aGetBook\x12\x1e.bookservice.v1.GetBookRequest\x1a\x1f.bookservice.v1.GetBookResponse\"<\xd2\xf3\x188\n" +
+	"\x10book://{book_id}\x12\x04Book\"\x15A book in the catalog*\abook_id\x12\xa1\x01\n" +
 	"\x0eGetAuthorBooks\x12%.bookservice.v1.GetAuthorBooksRequest\x1a&.bookservice.v1.GetAuthorBooksResponse\"@\xd2\xf3\x18<\n" +
-	"\x1aauthor://{author_id}/books\x12\fAuthor Books\x1a\x10application/json\x12\x8b\x01\n" +
-	"\rSummarizeBook\x12$.bookservice.v1.SummarizeBookRequest\x1a%.bookservice.v1.SummarizeBookResponse\"-\xda\xf3\x18)\n" +
-	"\tsummarize\x12\x1cGenerate a summary of a book\x12\x8c\x01\n" +
+	"\x1aauthor://{author_id}/books\x12\fAuthor Books\x1a\x10application/json\x12\x94\x01\n" +
+	"\rSummarizeBook\x12$.bookservice.v1.SummarizeBookRequest\x1a%.bookservice.v1.SummarizeBookResponse\"6\xda\xf3\x182\n" +
+	"\tsummarize\x12\x1cGenerate a summary of a book\x1a\abook_id\x12\x8c\x01\n" +
 	"\x0eRecommendBooks\x12%.bookservice.v1.RecommendBooksRequest\x1a&.bookservice.v1.RecommendBooksResponse\"+\xda\xf3\x18'\x12%Get personalized book recommendations\x1a\v\x92\xf4\x18\a\n" +
 	"\x05booksBWZUgithub.com/panyam/mcpkit/ext/protogen/examples/bookservice/gen/bookservice/v1;booksv1b\x06proto3"
 

--- a/ext/protogen/examples/bookservice/gen/bookservice/v1/service.pb.mcp.go
+++ b/ext/protogen/examples/bookservice/gen/bookservice/v1/service.pb.mcp.go
@@ -157,3 +157,29 @@ func RegisterBookServiceMCPPrompts(srv *server.Server, impl BookServiceMCPPrompt
 		},
 	)
 }
+
+// BookServiceMCPCompleter provides auto-completion for resource template params
+// and prompt arguments. Each method handles one completable field.
+type BookServiceMCPCompleter interface {
+	CompleteBookId(ctx mcpcore.PromptContext, ref mcpcore.CompletionRef, arg mcpcore.CompletionArgument) (mcpcore.CompletionResult, error)
+}
+
+// RegisterBookServiceMCPCompletions registers auto-completion handlers from BookService.
+func RegisterBookServiceMCPCompletions(srv *server.Server, completer BookServiceMCPCompleter) {
+	srv.RegisterCompletion("ref/resource", "book://{book_id}", func(ctx mcpcore.PromptContext, ref mcpcore.CompletionRef, arg mcpcore.CompletionArgument) (mcpcore.CompletionResult, error) {
+		switch arg.Name {
+		case "book_id":
+			return completer.CompleteBookId(ctx, ref, arg)
+		default:
+			return mcpcore.CompletionResult{}, nil
+		}
+	})
+	srv.RegisterCompletion("ref/prompt", "books_summarize", func(ctx mcpcore.PromptContext, ref mcpcore.CompletionRef, arg mcpcore.CompletionArgument) (mcpcore.CompletionResult, error) {
+		switch arg.Name {
+		case "book_id":
+			return completer.CompleteBookId(ctx, ref, arg)
+		default:
+			return mcpcore.CompletionResult{}, nil
+		}
+	})
+}

--- a/ext/protogen/examples/bookservice/gen/mcp/v1/annotations.pb.go
+++ b/ext/protogen/examples/bookservice/gen/mcp/v1/annotations.pb.go
@@ -149,9 +149,13 @@ type MCPResourceOptions struct {
 	// MIME type of the resource content.
 	MimeType string `protobuf:"bytes,3,opt,name=mime_type,json=mimeType,proto3" json:"mime_type,omitempty"`
 	// Human-readable description.
-	Description   string `protobuf:"bytes,4,opt,name=description,proto3" json:"description,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Description string `protobuf:"bytes,4,opt,name=description,proto3" json:"description,omitempty"`
+	// Fields from the URI template that support auto-completion.
+	// Each name must match a {param} in uri_template.
+	// Generates a Completer interface method per field.
+	CompletableFields []string `protobuf:"bytes,5,rep,name=completable_fields,json=completableFields,proto3" json:"completable_fields,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *MCPResourceOptions) Reset() {
@@ -212,15 +216,25 @@ func (x *MCPResourceOptions) GetDescription() string {
 	return ""
 }
 
+func (x *MCPResourceOptions) GetCompletableFields() []string {
+	if x != nil {
+		return x.CompletableFields
+	}
+	return nil
+}
+
 // MCPPromptOptions exposes a gRPC method as an MCP prompt.
 type MCPPromptOptions struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Custom prompt name. Defaults to snake_case of the method name.
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	// Human-readable description.
-	Description   string `protobuf:"bytes,2,opt,name=description,proto3" json:"description,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Description string `protobuf:"bytes,2,opt,name=description,proto3" json:"description,omitempty"`
+	// Request message fields that support auto-completion.
+	// Generates a Completer interface method per field.
+	CompletableFields []string `protobuf:"bytes,3,rep,name=completable_fields,json=completableFields,proto3" json:"completable_fields,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *MCPPromptOptions) Reset() {
@@ -265,6 +279,13 @@ func (x *MCPPromptOptions) GetDescription() string {
 		return x.Description
 	}
 	return ""
+}
+
+func (x *MCPPromptOptions) GetCompletableFields() []string {
+	if x != nil {
+		return x.CompletableFields
+	}
+	return nil
 }
 
 // MCPServiceOptions configures service-level MCP settings.
@@ -375,15 +396,17 @@ const file_mcp_v1_annotations_proto_rawDesc = "" +
 	"\vdescription\x18\x02 \x01(\tR\vdescription\x12\x18\n" +
 	"\atimeout\x18\x03 \x01(\tR\atimeout\x12+\n" +
 	"\x11structured_output\x18\x04 \x01(\bR\x10structuredOutput\x12%\n" +
-	"\x0eresult_summary\x18\x05 \x01(\tR\rresultSummary\"\x8a\x01\n" +
+	"\x0eresult_summary\x18\x05 \x01(\tR\rresultSummary\"\xb9\x01\n" +
 	"\x12MCPResourceOptions\x12!\n" +
 	"\furi_template\x18\x01 \x01(\tR\vuriTemplate\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x1b\n" +
 	"\tmime_type\x18\x03 \x01(\tR\bmimeType\x12 \n" +
-	"\vdescription\x18\x04 \x01(\tR\vdescription\"H\n" +
+	"\vdescription\x18\x04 \x01(\tR\vdescription\x12-\n" +
+	"\x12completable_fields\x18\x05 \x03(\tR\x11completableFields\"w\n" +
 	"\x10MCPPromptOptions\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12 \n" +
-	"\vdescription\x18\x02 \x01(\tR\vdescription\"1\n" +
+	"\vdescription\x18\x02 \x01(\tR\vdescription\x12-\n" +
+	"\x12completable_fields\x18\x03 \x03(\tR\x11completableFields\"1\n" +
 	"\x11MCPServiceOptions\x12\x1c\n" +
 	"\tnamespace\x18\x01 \x01(\tR\tnamespace:S\n" +
 	"\bmcp_tool\x12\x1e.google.protobuf.MethodOptions\x18\xb9\x8e\x03 \x01(\v2\x16.mcp.v1.MCPToolOptionsR\amcpTool:_\n" +

--- a/ext/protogen/examples/bookservice/main.go
+++ b/ext/protogen/examples/bookservice/main.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/panyam/mcpkit/core"
 	"github.com/panyam/mcpkit/server"
@@ -85,6 +86,21 @@ func (s *bookService) RecommendBooks(_ context.Context, req *booksv1.RecommendBo
 	}, nil
 }
 
+// CompleteBookId returns book ID suggestions matching the partial input.
+func (s *bookService) CompleteBookId(_ core.PromptContext, _ core.CompletionRef, arg core.CompletionArgument) (core.CompletionResult, error) {
+	var values []string
+	for _, b := range catalog {
+		if strings.HasPrefix(b.Id, arg.Value) || strings.Contains(strings.ToLower(b.Title), strings.ToLower(arg.Value)) {
+			values = append(values, b.Id)
+		}
+	}
+	return core.CompletionResult{
+		Values:  values,
+		Total:   len(values),
+		HasMore: false,
+	}, nil
+}
+
 func main() {
 	impl := &bookService{}
 
@@ -93,10 +109,11 @@ func main() {
 		Version: "0.1.0",
 	})
 
-	// Register all three MCP primitives from the generated code.
+	// Register all MCP primitives from the generated code.
 	booksv1.RegisterBookServiceMCP(srv, impl)
 	booksv1.RegisterBookServiceMCPResources(srv, impl)
 	booksv1.RegisterBookServiceMCPPrompts(srv, impl)
+	booksv1.RegisterBookServiceMCPCompletions(srv, impl)
 
 	log.Println("Book service MCP server starting on :8787")
 	if err := srv.Run(":8787"); err != nil {

--- a/ext/protogen/examples/bookservice/proto/bookservice/v1/service.proto
+++ b/ext/protogen/examples/bookservice/proto/bookservice/v1/service.proto
@@ -26,6 +26,7 @@ service BookService {
       uri_template: "book://{book_id}"
       name: "Book"
       description: "A book in the catalog"
+      completable_fields: "book_id"
     };
   }
 
@@ -43,6 +44,7 @@ service BookService {
     option (mcp.v1.mcp_prompt) = {
       name: "summarize"
       description: "Generate a summary of a book"
+      completable_fields: "book_id"
     };
   }
 

--- a/ext/protogen/generator/generator.go
+++ b/ext/protogen/generator/generator.go
@@ -95,16 +95,52 @@ type fileData struct {
 
 // serviceData holds data for one proto service.
 type serviceData struct {
-	Name      string // Go name (e.g. "UserService")
-	Namespace string // from mcp_service annotation
-	Tools     []toolData
-	Resources []resourceData
-	Prompts   []promptData
+	Name        string // Go name (e.g. "UserService")
+	Namespace   string // from mcp_service annotation
+	Tools       []toolData
+	Resources   []resourceData
+	Prompts     []promptData
+	Completions []completionData
 }
 
 // HasContent reports whether the service has any tools, resources, or prompts to generate.
 func (sd serviceData) HasContent() bool {
 	return len(sd.Tools) > 0 || len(sd.Resources) > 0 || len(sd.Prompts) > 0
+}
+
+// CompleterMethods returns the deduplicated set of methods for the Completer
+// interface, derived from all completion registrations.
+func (sd serviceData) CompleterMethods() []completerMethod {
+	seen := map[string]bool{}
+	var methods []completerMethod
+	for _, c := range sd.Completions {
+		for _, f := range c.Fields {
+			if !seen[f.GoMethod] {
+				seen[f.GoMethod] = true
+				methods = append(methods, completerMethod{GoMethod: f.GoMethod, Field: f.Name})
+			}
+		}
+	}
+	return methods
+}
+
+// completionData groups completable fields for one (refType, refName) pair.
+type completionData struct {
+	RefType string           // "ref/prompt" or "ref/resource"
+	RefName string           // prompt name or resource URI template
+	Fields  []completionField // fields that support completion
+}
+
+// completionField is a single completable field within a completion registration.
+type completionField struct {
+	Name     string // argument/param name (e.g. "book_id")
+	GoMethod string // Go method name on the Completer interface (e.g. "CompleteBookId")
+}
+
+// completerMethod describes a unique method on the Completer interface.
+type completerMethod struct {
+	GoMethod string // e.g. "CompleteBookId"
+	Field    string // e.g. "book_id"
 }
 
 // resourceData holds data for one MCP resource generated from a unary RPC.
@@ -220,12 +256,34 @@ func collectServiceData(svc *protogen.Service, gf *protogen.GeneratedFile) (serv
 				return sd, err
 			}
 			sd.Resources = append(sd.Resources, rd)
+			// Collect completions for resource template params.
+			if len(resOpts.CompletableFields) > 0 {
+				cd := completionData{RefType: "ref/resource", RefName: rd.URI}
+				for _, field := range resOpts.CompletableFields {
+					cd.Fields = append(cd.Fields, completionField{
+						Name:     field,
+						GoMethod: completeMethodName(field),
+					})
+				}
+				sd.Completions = append(sd.Completions, cd)
+			}
 			continue
 		}
 
 		if promptOpts != nil {
 			pd := collectPrompt(method, promptOpts, sd.Namespace, reqType, respType)
 			sd.Prompts = append(sd.Prompts, pd)
+			// Collect completions for prompt arguments.
+			if len(promptOpts.CompletableFields) > 0 {
+				cd := completionData{RefType: "ref/prompt", RefName: pd.PromptName}
+				for _, field := range promptOpts.CompletableFields {
+					cd.Fields = append(cd.Fields, completionField{
+						Name:     field,
+						GoMethod: completeMethodName(field),
+					})
+				}
+				sd.Completions = append(sd.Completions, cd)
+			}
 			continue
 		}
 
@@ -365,6 +423,20 @@ func resolveToolName(namespace string, method *protogen.Method, opts *mcpv1.MCPT
 		name = MethodToSnakeCase(method.GoName)
 	}
 	return PrefixWithNamespace(namespace, name), nil
+}
+
+// completeMethodName converts a proto field name to a Go Completer method name.
+// "book_id" → "CompleteBookId"
+func completeMethodName(field string) string {
+	parts := strings.Split(field, "_")
+	var b strings.Builder
+	b.WriteString("Complete")
+	for _, p := range parts {
+		if len(p) > 0 {
+			b.WriteString(strings.ToUpper(p[:1]) + p[1:])
+		}
+	}
+	return b.String()
 }
 
 // escapeString escapes a string for use in a Go string literal.

--- a/ext/protogen/generator/generator_test.go
+++ b/ext/protogen/generator/generator_test.go
@@ -31,6 +31,11 @@ func buildExtensionBytes(extField protowire.Number, fields map[protowire.Number]
 			} else {
 				inner = protowire.AppendVarint(inner, 0)
 			}
+		case []string:
+			for _, s := range v {
+				inner = protowire.AppendTag(inner, num, protowire.BytesType)
+				inner = protowire.AppendString(inner, s)
+			}
 		}
 	}
 	// Wrap as an extension field in the parent options message.
@@ -590,4 +595,144 @@ func TestResultSummaryAnnotation(t *testing.T) {
 	require.Len(t, tools, 1)
 	assert.True(t, tools[0].Structured)
 	assert.Equal(t, "User {name} retrieved (id: {user_id})", tools[0].ResultSummary)
+}
+
+// --- Completion annotation tests ---
+
+// TestCompletionFromPrompt verifies that completable_fields on a prompt
+// annotation generates completion data with the correct ref type and fields.
+func TestCompletionFromPrompt(t *testing.T) {
+	plugin := ptestutil.CreatePlugin(t, &ptestutil.ProtoSet{
+		Files: []ptestutil.File{{
+			Name: "test.proto",
+			Pkg:  "test.v1",
+			Messages: []ptestutil.Message{
+				{Name: "SummarizeRequest", Fields: []ptestutil.Field{
+					{Name: "book_id", Number: 1, TypeName: "string"},
+					{Name: "style", Number: 2, TypeName: "string"},
+				}},
+				{Name: "SummarizeResponse", Fields: []ptestutil.Field{
+					{Name: "summary", Number: 1, TypeName: "string"},
+				}},
+			},
+			Services: []ptestutil.Service{{
+				Name: "BookService",
+				Options: serviceOptionsWithNamespace("books"),
+				Methods: []ptestutil.Method{{
+					Name:       "SummarizeBook",
+					InputType:  "test.v1.SummarizeRequest",
+					OutputType: "test.v1.SummarizeResponse",
+					Options: methodOptionsWithPrompt(map[protowire.Number]any{
+						1: "summarize",                       // name
+						3: []string{"book_id", "style"},      // completable_fields
+					}),
+				}},
+			}},
+		}},
+	})
+
+	protoSvc := ptestutil.FindService(t, plugin, "BookService")
+	gf := plugin.NewGeneratedFile("_test.go", "")
+	sd, err := collectServiceData(protoSvc, gf)
+	require.NoError(t, err)
+
+	require.Len(t, sd.Completions, 1)
+	c := sd.Completions[0]
+	assert.Equal(t, "ref/prompt", c.RefType)
+	assert.Equal(t, "books_summarize", c.RefName)
+	require.Len(t, c.Fields, 2)
+	assert.Equal(t, "book_id", c.Fields[0].Name)
+	assert.Equal(t, "CompleteBookId", c.Fields[0].GoMethod)
+	assert.Equal(t, "style", c.Fields[1].Name)
+	assert.Equal(t, "CompleteStyle", c.Fields[1].GoMethod)
+}
+
+// TestCompletionFromResource verifies that completable_fields on a resource
+// annotation generates completion data with ref/resource type.
+func TestCompletionFromResource(t *testing.T) {
+	plugin := makePlugin(t, ptestutil.Service{
+		Name: "BookService",
+		Methods: []ptestutil.Method{{
+			Name:       "GetBook",
+			InputType:  "test.v1.GetUserRequest",
+			OutputType: "test.v1.GetUserResponse",
+			Options: methodOptionsWithResource(map[protowire.Number]any{
+				1: "book://{book_id}",           // uri_template
+				5: []string{"book_id"},           // completable_fields
+			}),
+		}},
+	})
+
+	protoSvc := ptestutil.FindService(t, plugin, "BookService")
+	gf := plugin.NewGeneratedFile("_test.go", "")
+	sd, err := collectServiceData(protoSvc, gf)
+	require.NoError(t, err)
+
+	require.Len(t, sd.Completions, 1)
+	c := sd.Completions[0]
+	assert.Equal(t, "ref/resource", c.RefType)
+	assert.Equal(t, "book://{book_id}", c.RefName)
+	require.Len(t, c.Fields, 1)
+	assert.Equal(t, "book_id", c.Fields[0].Name)
+	assert.Equal(t, "CompleteBookId", c.Fields[0].GoMethod)
+}
+
+// TestCompleterMethodsDeduplication verifies that CompleterMethods deduplicates
+// methods when the same field appears in both a prompt and resource.
+func TestCompleterMethodsDeduplication(t *testing.T) {
+	sd := serviceData{
+		Completions: []completionData{
+			{
+				RefType: "ref/prompt",
+				RefName: "summarize",
+				Fields:  []completionField{{Name: "book_id", GoMethod: "CompleteBookId"}},
+			},
+			{
+				RefType: "ref/resource",
+				RefName: "book://{book_id}",
+				Fields:  []completionField{{Name: "book_id", GoMethod: "CompleteBookId"}},
+			},
+		},
+	}
+
+	methods := sd.CompleterMethods()
+	require.Len(t, methods, 1, "should deduplicate across ref types")
+	assert.Equal(t, "CompleteBookId", methods[0].GoMethod)
+}
+
+// TestNoCompletions verifies that services without completable_fields
+// produce no completion data.
+func TestNoCompletions(t *testing.T) {
+	plugin := makePlugin(t, ptestutil.Service{
+		Name: "SimpleService",
+		Methods: []ptestutil.Method{{
+			Name:       "GetUser",
+			InputType:  "test.v1.GetUserRequest",
+			OutputType: "test.v1.GetUserResponse",
+			Options: methodOptionsWithPrompt(map[protowire.Number]any{
+				1: "get_user",
+				// no completable_fields
+			}),
+		}},
+	})
+
+	protoSvc := ptestutil.FindService(t, plugin, "SimpleService")
+	gf := plugin.NewGeneratedFile("_test.go", "")
+	sd, err := collectServiceData(protoSvc, gf)
+	require.NoError(t, err)
+
+	assert.Empty(t, sd.Completions)
+}
+
+// TestCompleteMethodName verifies the field-to-method name conversion.
+func TestCompleteMethodName(t *testing.T) {
+	tests := []struct{ field, want string }{
+		{"book_id", "CompleteBookId"},
+		{"genre", "CompleteGenre"},
+		{"user_name", "CompleteUserName"},
+		{"id", "CompleteId"},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, completeMethodName(tt.field), "field=%q", tt.field)
+	}
 }

--- a/ext/protogen/generator/templates/file.go.tmpl
+++ b/ext/protogen/generator/templates/file.go.tmpl
@@ -73,6 +73,10 @@ var (
 {{ template "forwardPromptToConnect" . }}
 {{- end }}
 {{- end }}
+{{- if .Completions }}
+{{ template "completerInterface" . }}
+{{ template "registerCompletions" . }}
+{{- end }}
 {{ end }}
 
 {{- define "serverInterface" -}}
@@ -489,5 +493,33 @@ func Forward{{ .Name }}PromptsToConnect(srv *server.Server, client Connect{{ .Na
 		},
 {{- end }}
 	)
+}
+{{ end }}
+
+{{- define "completerInterface" -}}
+// {{ .Name }}MCPCompleter provides auto-completion for resource template params
+// and prompt arguments. Each method handles one completable field.
+type {{ .Name }}MCPCompleter interface {
+{{- range .CompleterMethods }}
+	{{ .GoMethod }}(ctx mcpcore.PromptContext, ref mcpcore.CompletionRef, arg mcpcore.CompletionArgument) (mcpcore.CompletionResult, error)
+{{- end }}
+}
+{{ end }}
+
+{{- define "registerCompletions" -}}
+// Register{{ .Name }}MCPCompletions registers auto-completion handlers from {{ .Name }}.
+func Register{{ .Name }}MCPCompletions(srv *server.Server, completer {{ .Name }}MCPCompleter) {
+{{- range .Completions }}
+	srv.RegisterCompletion("{{ .RefType }}", "{{ .RefName }}", func(ctx mcpcore.PromptContext, ref mcpcore.CompletionRef, arg mcpcore.CompletionArgument) (mcpcore.CompletionResult, error) {
+		switch arg.Name {
+		{{- range .Fields }}
+		case "{{ .Name }}":
+			return completer.{{ .GoMethod }}(ctx, ref, arg)
+		{{- end }}
+		default:
+			return mcpcore.CompletionResult{}, nil
+		}
+	})
+{{- end }}
 }
 {{ end }}

--- a/ext/protogen/proto/mcp/v1/annotations.pb.go
+++ b/ext/protogen/proto/mcp/v1/annotations.pb.go
@@ -19,16 +19,18 @@ type MCPToolOptions struct {
 
 // MCPResourceOptions exposes a gRPC method as an MCP resource or resource template.
 type MCPResourceOptions struct {
-	URITemplate string `json:"uri_template,omitempty"`
-	Name        string `json:"name,omitempty"`
-	MimeType    string `json:"mime_type,omitempty"`
-	Description string `json:"description,omitempty"`
+	URITemplate      string   `json:"uri_template,omitempty"`
+	Name             string   `json:"name,omitempty"`
+	MimeType         string   `json:"mime_type,omitempty"`
+	Description      string   `json:"description,omitempty"`
+	CompletableFields []string `json:"completable_fields,omitempty"`
 }
 
 // MCPPromptOptions exposes a gRPC method as an MCP prompt.
 type MCPPromptOptions struct {
-	Name        string `json:"name,omitempty"`
-	Description string `json:"description,omitempty"`
+	Name              string   `json:"name,omitempty"`
+	Description       string   `json:"description,omitempty"`
+	CompletableFields []string `json:"completable_fields,omitempty"`
 }
 
 // MCPServiceOptions configures service-level MCP settings.
@@ -148,6 +150,39 @@ func decodeBool(raw []byte, fieldNum protowire.Number) bool {
 	return false
 }
 
+// decodeRepeatedString collects all string values for a repeated field.
+func decodeRepeatedString(raw []byte, fieldNum protowire.Number) []string {
+	var result []string
+	for len(raw) > 0 {
+		num, wtype, n := protowire.ConsumeTag(raw)
+		if n < 0 {
+			return result
+		}
+		raw = raw[n:]
+		switch wtype {
+		case protowire.VarintType:
+			_, n = protowire.ConsumeVarint(raw)
+		case protowire.Fixed32Type:
+			_, n = protowire.ConsumeFixed32(raw)
+		case protowire.Fixed64Type:
+			_, n = protowire.ConsumeFixed64(raw)
+		case protowire.BytesType:
+			var val []byte
+			val, n = protowire.ConsumeBytes(raw)
+			if n >= 0 && num == fieldNum {
+				result = append(result, string(val))
+			}
+		default:
+			return result
+		}
+		if n < 0 {
+			return result
+		}
+		raw = raw[n:]
+	}
+	return result
+}
+
 // GetToolOptions extracts MCPToolOptions from method options.
 // Returns nil if the mcp_tool annotation is not present.
 func GetToolOptions(opts proto.Message) *MCPToolOptions {
@@ -172,10 +207,11 @@ func GetResourceOptions(opts proto.Message) *MCPResourceOptions {
 		return nil
 	}
 	return &MCPResourceOptions{
-		URITemplate: decodeString(raw, 1),
-		Name:        decodeString(raw, 2),
-		MimeType:    decodeString(raw, 3),
-		Description: decodeString(raw, 4),
+		URITemplate:       decodeString(raw, 1),
+		Name:              decodeString(raw, 2),
+		MimeType:          decodeString(raw, 3),
+		Description:       decodeString(raw, 4),
+		CompletableFields: decodeRepeatedString(raw, 5),
 	}
 }
 
@@ -187,8 +223,9 @@ func GetPromptOptions(opts proto.Message) *MCPPromptOptions {
 		return nil
 	}
 	return &MCPPromptOptions{
-		Name:        decodeString(raw, 1),
-		Description: decodeString(raw, 2),
+		Name:              decodeString(raw, 1),
+		Description:       decodeString(raw, 2),
+		CompletableFields: decodeRepeatedString(raw, 3),
 	}
 }
 

--- a/ext/protogen/proto/mcp/v1/annotations.proto
+++ b/ext/protogen/proto/mcp/v1/annotations.proto
@@ -70,6 +70,11 @@ message MCPResourceOptions {
 
   // Human-readable description.
   string description = 4;
+
+  // Fields from the URI template that support auto-completion.
+  // Each name must match a {param} in uri_template.
+  // Generates a Completer interface method per field.
+  repeated string completable_fields = 5;
 }
 
 // MCPPromptOptions exposes a gRPC method as an MCP prompt.
@@ -79,6 +84,10 @@ message MCPPromptOptions {
 
   // Human-readable description.
   string description = 2;
+
+  // Request message fields that support auto-completion.
+  // Generates a Completer interface method per field.
+  repeated string completable_fields = 3;
 }
 
 // MCPServiceOptions configures service-level MCP settings.

--- a/tests/reports/report.html
+++ b/tests/reports/report.html
@@ -15,7 +15,7 @@ th { background: #f5f5f5; font-weight: 600; }
 pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto; font-size: 13px; max-height: 400px; overflow-y: auto; }
 </style></head><body>
 <h1>MCPKit Test Report</h1>
-<div class='meta'>Branch: <strong>main</strong> | Commit: <code>320dddb</code> | Date: 2026-04-14 01:08:59</div>
+<div class='meta'>Branch: <strong>feature/protogen-completions-219</strong> | Commit: <code>539d51b</code> | Date: 2026-04-14 02:14:08</div>
 <table><tr><th>Stage</th><th>Result</th></tr>
 <tr><td>unit+coverage</td><td class='pass'>PASS</td></tr>
 <tr><td>race</td><td class='pass'>PASS</td></tr>
@@ -30,53 +30,53 @@ pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto; 
 <div class='summary-pass'>All 9 stages passed</div>
 <h2>Full Log</h2><pre>
 === MCPKit Comprehensive Test Suite ===
-Started: Tue Apr 14 01:06:06 PDT 2026
+Started: Tue Apr 14 02:11:15 PDT 2026
 
 --- [1/9] unit+coverage ---
-ok  	github.com/panyam/mcpkit/client	8.477s	coverage: 67.4% of statements
+ok  	github.com/panyam/mcpkit/client	8.770s	coverage: 67.4% of statements
 	github.com/panyam/mcpkit/cmd/testserver		coverage: 0.0% of statements
-ok  	github.com/panyam/mcpkit/core	0.632s	coverage: 48.0% of statements
-ok  	github.com/panyam/mcpkit/server	14.551s	coverage: 78.4% of statements
-ok  	github.com/panyam/mcpkit/testutil	0.952s	coverage: 70.5% of statements
+ok  	github.com/panyam/mcpkit/core	0.932s	coverage: 48.0% of statements
+ok  	github.com/panyam/mcpkit/server	14.542s	coverage: 78.4% of statements
+ok  	github.com/panyam/mcpkit/testutil	0.410s	coverage: 70.5% of statements
 Coverage report: tests/reports/coverage.html
   PASS: unit+coverage
 --- [2/9] race ---
-ok  	github.com/panyam/mcpkit/client	9.483s
+ok  	github.com/panyam/mcpkit/client	9.314s
 ?   	github.com/panyam/mcpkit/cmd/testserver	[no test files]
-ok  	github.com/panyam/mcpkit/core	1.378s
-ok  	github.com/panyam/mcpkit/server	15.156s
-ok  	github.com/panyam/mcpkit/testutil	2.468s
+ok  	github.com/panyam/mcpkit/core	1.354s
+ok  	github.com/panyam/mcpkit/server	15.075s
+ok  	github.com/panyam/mcpkit/testutil	2.418s
   PASS: race
 --- [3/9] auth ---
 ok  	github.com/panyam/mcpkit/ext/auth	0.367s
   PASS: auth
 --- [4/9] ui ---
-ok  	github.com/panyam/mcpkit/ext/ui	0.257s
+ok  	github.com/panyam/mcpkit/ext/ui	0.323s
   PASS: ui
 --- [5/9] protogen ---
 ?   	github.com/panyam/mcpkit/ext/protogen/cmd/protoc-gen-go-mcp	[no test files]
-ok  	github.com/panyam/mcpkit/ext/protogen/generator	1.191s
-ok  	github.com/panyam/mcpkit/ext/protogen/proto/mcp/v1	0.900s
-ok  	github.com/panyam/mcpkit/ext/protogen/runtime	0.361s
-ok  	github.com/panyam/mcpkit/ext/protogen/schema	0.665s
+ok  	github.com/panyam/mcpkit/ext/protogen/generator	0.662s
+ok  	github.com/panyam/mcpkit/ext/protogen/proto/mcp/v1	1.178s
+ok  	github.com/panyam/mcpkit/ext/protogen/runtime	0.382s
+ok  	github.com/panyam/mcpkit/ext/protogen/schema	0.953s
 ?   	github.com/panyam/mcpkit/ext/protogen/testutil	[no test files]
 ==&gt; e2e: bookservice example
 [33mWARN[0m	plugin "protoc-gen-go-mcp" does not support required features.
   Feature "proto3 optional" is required by 1 file(s):
     bookservice/v1/service.proto
-ok  	github.com/panyam/mcpkit/ext/protogen/examples/bookservice	0.439s
+ok  	github.com/panyam/mcpkit/ext/protogen/examples/bookservice	0.341s
 ==&gt; e2e: passed
   PASS: protogen
 --- [6/9] e2e ---
-ok  	github.com/panyam/mcpkit/tests/e2e	3.754s
-ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.933s
+ok  	github.com/panyam/mcpkit/tests/e2e	3.931s
+ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.408s
   PASS: e2e
 --- [7/9] conformance ---
 Killing stale process on port 18799...
-2026/04/14 01:06:49 Received signal terminated, shutting down...
-2026/04/14 01:06:49 Server shut down gracefully
+2026/04/14 02:11:58 Received signal terminated, shutting down...
+2026/04/14 02:11:58 Server shut down gracefully
 === Starting test server on :18799 (Streamable HTTP) ===
-Waiting for server....2026/04/14 01:06:50 MCP test server listening on :18799 (Streamable HTTP at /mcp)
+Waiting for server....2026/04/14 02:11:59 MCP test server listening on :18799 (Streamable HTTP at /mcp)
  ready
 
 === Running MCP conformance suite ===
@@ -87,293 +87,293 @@ Running active suite (30 scenarios) against http://localhost:18799/mcp
 
 === Running scenario: server-initialize ===
 Running client scenario 'server-initialize' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: e1c23150140dd01304422cb64867564c
-2026/04/14 01:06:53 SSEHub: registered connection e1c23150140dd01304422cb64867564c (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection e1c23150140dd01304422cb64867564c (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e4c0150
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e4c0150
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: e1c23150140dd01304422cb64867564c
+2026/04/14 02:12:01 Starting MCP-GET-SSE SSE connection: 932649a28a03c789b0d3a8deeddf6cff
+2026/04/14 02:12:01 SSEHub: registered connection 932649a28a03c789b0d3a8deeddf6cff (total: 1)
+2026/04/14 02:12:01 SSEHub: unregistered connection 932649a28a03c789b0d3a8deeddf6cff (total: 0)
+2026/04/14 02:12:01 Received kill signal.  Quitting Writer. stop 0x2a2df8cba150
+2026/04/14 02:12:01 Cleaning up writer...
+2026/04/14 02:12:01 Finished cleaning up writer:  0x2a2df8cba150
+2026/04/14 02:12:01 Closed MCP-GET-SSE SSE connection: 932649a28a03c789b0d3a8deeddf6cff
 
 === Running scenario: logging-set-level ===
 Running client scenario 'logging-set-level' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: 268ccbf757fcdd990578bbfd5d7cc77f
-2026/04/14 01:06:53 SSEHub: registered connection 268ccbf757fcdd990578bbfd5d7cc77f (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection 268ccbf757fcdd990578bbfd5d7cc77f (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e4c03f0
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e4c03f0
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: 268ccbf757fcdd990578bbfd5d7cc77f
+2026/04/14 02:12:01 Starting MCP-GET-SSE SSE connection: 21a3299498d06e36719aeaad3c90ad12
+2026/04/14 02:12:01 SSEHub: registered connection 21a3299498d06e36719aeaad3c90ad12 (total: 1)
+2026/04/14 02:12:01 SSEHub: unregistered connection 21a3299498d06e36719aeaad3c90ad12 (total: 0)
+2026/04/14 02:12:01 Received kill signal.  Quitting Writer. stop 0x2a2df893e310
+2026/04/14 02:12:01 Cleaning up writer...
+2026/04/14 02:12:01 Finished cleaning up writer:  0x2a2df893e310
+2026/04/14 02:12:01 Closed MCP-GET-SSE SSE connection: 21a3299498d06e36719aeaad3c90ad12
 
 === Running scenario: ping ===
 Running client scenario 'ping' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: 968bea1e9f96e009b6a3bb02ce5b95ed
-2026/04/14 01:06:53 SSEHub: registered connection 968bea1e9f96e009b6a3bb02ce5b95ed (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection 968bea1e9f96e009b6a3bb02ce5b95ed (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e4c0150
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e4c0150
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: 968bea1e9f96e009b6a3bb02ce5b95ed
+2026/04/14 02:12:01 Starting MCP-GET-SSE SSE connection: 0373459c01df87b3a20c2d1d2663716c
+2026/04/14 02:12:01 SSEHub: registered connection 0373459c01df87b3a20c2d1d2663716c (total: 1)
+2026/04/14 02:12:01 SSEHub: unregistered connection 0373459c01df87b3a20c2d1d2663716c (total: 0)
+2026/04/14 02:12:01 Received kill signal.  Quitting Writer. stop 0x2a2df893e540
+2026/04/14 02:12:01 Cleaning up writer...
+2026/04/14 02:12:01 Finished cleaning up writer:  0x2a2df893e540
+2026/04/14 02:12:01 Closed MCP-GET-SSE SSE connection: 0373459c01df87b3a20c2d1d2663716c
 
 === Running scenario: completion-complete ===
 Running client scenario 'completion-complete' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: da1910722662c6c3b1d9992cdec97660
-2026/04/14 01:06:53 SSEHub: registered connection da1910722662c6c3b1d9992cdec97660 (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection da1910722662c6c3b1d9992cdec97660 (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e090310
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e090310
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: da1910722662c6c3b1d9992cdec97660
+2026/04/14 02:12:01 Starting MCP-GET-SSE SSE connection: 8e6ae9a5e0121ed98af321c50d0bc084
+2026/04/14 02:12:01 SSEHub: registered connection 8e6ae9a5e0121ed98af321c50d0bc084 (total: 1)
+2026/04/14 02:12:01 SSEHub: unregistered connection 8e6ae9a5e0121ed98af321c50d0bc084 (total: 0)
+2026/04/14 02:12:01 Received kill signal.  Quitting Writer. stop 0x2a2df893e7e0
+2026/04/14 02:12:01 Cleaning up writer...
+2026/04/14 02:12:01 Finished cleaning up writer:  0x2a2df893e7e0
+2026/04/14 02:12:01 Closed MCP-GET-SSE SSE connection: 8e6ae9a5e0121ed98af321c50d0bc084
 
 === Running scenario: tools-list ===
 Running client scenario 'tools-list' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: 55a5e8bc58064fe461611061051f31fa
-2026/04/14 01:06:53 SSEHub: registered connection 55a5e8bc58064fe461611061051f31fa (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection 55a5e8bc58064fe461611061051f31fa (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e090690
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e090690
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: 55a5e8bc58064fe461611061051f31fa
+2026/04/14 02:12:01 Starting MCP-GET-SSE SSE connection: ceec6b223ed18e9644c79a57c8c262a1
+2026/04/14 02:12:01 SSEHub: registered connection ceec6b223ed18e9644c79a57c8c262a1 (total: 1)
+2026/04/14 02:12:01 SSEHub: unregistered connection ceec6b223ed18e9644c79a57c8c262a1 (total: 0)
+2026/04/14 02:12:01 Received kill signal.  Quitting Writer. stop 0x2a2df8cba150
+2026/04/14 02:12:01 Cleaning up writer...
+2026/04/14 02:12:01 Finished cleaning up writer:  0x2a2df8cba150
+2026/04/14 02:12:01 Closed MCP-GET-SSE SSE connection: ceec6b223ed18e9644c79a57c8c262a1
 
 === Running scenario: tools-call-simple-text ===
 Running client scenario 'tools-call-simple-text' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: ddad93022012e44770c015cb53684594
-2026/04/14 01:06:53 SSEHub: registered connection ddad93022012e44770c015cb53684594 (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection ddad93022012e44770c015cb53684594 (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e192a80
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e192a80
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: ddad93022012e44770c015cb53684594
+2026/04/14 02:12:01 Starting MCP-GET-SSE SSE connection: 8514a50a203e74f584c88069dd52f769
+2026/04/14 02:12:01 SSEHub: registered connection 8514a50a203e74f584c88069dd52f769 (total: 1)
+2026/04/14 02:12:01 SSEHub: unregistered connection 8514a50a203e74f584c88069dd52f769 (total: 0)
+2026/04/14 02:12:01 Received kill signal.  Quitting Writer. stop 0x2a2df8c38230
+2026/04/14 02:12:01 Cleaning up writer...
+2026/04/14 02:12:01 Finished cleaning up writer:  0x2a2df8c38230
+2026/04/14 02:12:01 Closed MCP-GET-SSE SSE connection: 8514a50a203e74f584c88069dd52f769
 
 === Running scenario: tools-call-image ===
 Running client scenario 'tools-call-image' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: cc9ac27eabfde6be205a8a1cae4935f6
-2026/04/14 01:06:53 SSEHub: registered connection cc9ac27eabfde6be205a8a1cae4935f6 (total: 1)
+2026/04/14 02:12:01 Starting MCP-GET-SSE SSE connection: ff4fa5615db3c9de720cad379a692cc3
+2026/04/14 02:12:01 SSEHub: registered connection ff4fa5615db3c9de720cad379a692cc3 (total: 1)
+2026/04/14 02:12:01 SSEHub: unregistered connection ff4fa5615db3c9de720cad379a692cc3 (total: 0)
 
 === Running scenario: tools-call-audio ===
-2026/04/14 01:06:53 SSEHub: unregistered connection cc9ac27eabfde6be205a8a1cae4935f6 (total: 0)
+2026/04/14 02:12:01 Received kill signal.  Quitting Writer. stop 0x2a2df893e3f0
+2026/04/14 02:12:01 Cleaning up writer...
 Running client scenario 'tools-call-audio' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e4c05b0
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e4c05b0
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: cc9ac27eabfde6be205a8a1cae4935f6
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: 092e8bcdf67b99e9ab483ed0523bd5ca
-2026/04/14 01:06:53 SSEHub: registered connection 092e8bcdf67b99e9ab483ed0523bd5ca (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection 092e8bcdf67b99e9ab483ed0523bd5ca (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e20e380
-2026/04/14 01:06:53 Cleaning up writer...
+2026/04/14 02:12:01 Finished cleaning up writer:  0x2a2df893e3f0
+2026/04/14 02:12:01 Closed MCP-GET-SSE SSE connection: ff4fa5615db3c9de720cad379a692cc3
+2026/04/14 02:12:01 Starting MCP-GET-SSE SSE connection: c870e10b08fb783dcf1a15d2973a2aa8
+2026/04/14 02:12:01 SSEHub: registered connection c870e10b08fb783dcf1a15d2973a2aa8 (total: 1)
+2026/04/14 02:12:01 SSEHub: unregistered connection c870e10b08fb783dcf1a15d2973a2aa8 (total: 0)
+2026/04/14 02:12:01 Received kill signal.  Quitting Writer. stop 0x2a2df8f242a0
+2026/04/14 02:12:01 Cleaning up writer...
+2026/04/14 02:12:01 Finished cleaning up writer:  0x2a2df8f242a0
+2026/04/14 02:12:01 Closed MCP-GET-SSE SSE connection: c870e10b08fb783dcf1a15d2973a2aa8
 
 === Running scenario: tools-call-embedded-resource ===
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e20e380
 Running client scenario 'tools-call-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: 092e8bcdf67b99e9ab483ed0523bd5ca
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: fe165bbd84e0ef7ccea94062ef82639a
-2026/04/14 01:06:53 SSEHub: registered connection fe165bbd84e0ef7ccea94062ef82639a (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection fe165bbd84e0ef7ccea94062ef82639a (total: 0)
+2026/04/14 02:12:01 Starting MCP-GET-SSE SSE connection: 59bb2a8d9a29b3d2be1109522c2b2a5b
+2026/04/14 02:12:01 SSEHub: registered connection 59bb2a8d9a29b3d2be1109522c2b2a5b (total: 1)
+2026/04/14 02:12:01 SSEHub: unregistered connection 59bb2a8d9a29b3d2be1109522c2b2a5b (total: 0)
+2026/04/14 02:12:01 Received kill signal.  Quitting Writer. stop 0x2a2df893e930
+2026/04/14 02:12:01 Cleaning up writer...
+2026/04/14 02:12:01 Finished cleaning up writer:  0x2a2df893e930
+2026/04/14 02:12:01 Closed MCP-GET-SSE SSE connection: 59bb2a8d9a29b3d2be1109522c2b2a5b
 
 === Running scenario: tools-call-mixed-content ===
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e20e5b0
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e20e5b0
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: fe165bbd84e0ef7ccea94062ef82639a
 Running client scenario 'tools-call-mixed-content' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: 4139fa923128b09a7f7775cc24996a9a
-2026/04/14 01:06:53 SSEHub: registered connection 4139fa923128b09a7f7775cc24996a9a (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection 4139fa923128b09a7f7775cc24996a9a (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e090af0
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e090af0
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: 4139fa923128b09a7f7775cc24996a9a
+2026/04/14 02:12:01 Starting MCP-GET-SSE SSE connection: 01992bd06fda164021c4c353ecf83469
+2026/04/14 02:12:01 SSEHub: registered connection 01992bd06fda164021c4c353ecf83469 (total: 1)
+2026/04/14 02:12:01 SSEHub: unregistered connection 01992bd06fda164021c4c353ecf83469 (total: 0)
+2026/04/14 02:12:01 Received kill signal.  Quitting Writer. stop 0x2a2df8cba460
+2026/04/14 02:12:01 Cleaning up writer...
+2026/04/14 02:12:01 Finished cleaning up writer:  0x2a2df8cba460
+2026/04/14 02:12:01 Closed MCP-GET-SSE SSE connection: 01992bd06fda164021c4c353ecf83469
 
 === Running scenario: tools-call-with-logging ===
 Running client scenario 'tools-call-with-logging' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: 851826ce9e8979aa120888c86c7d2102
-2026/04/14 01:06:53 SSEHub: registered connection 851826ce9e8979aa120888c86c7d2102 (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection 851826ce9e8979aa120888c86c7d2102 (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e090d20
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e090d20
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: 851826ce9e8979aa120888c86c7d2102
+2026/04/14 02:12:01 Starting MCP-GET-SSE SSE connection: aef562cd9b2bcb75e7205c35ac2e6138
+2026/04/14 02:12:01 SSEHub: registered connection aef562cd9b2bcb75e7205c35ac2e6138 (total: 1)
+2026/04/14 02:12:02 SSEHub: unregistered connection aef562cd9b2bcb75e7205c35ac2e6138 (total: 0)
+2026/04/14 02:12:02 Received kill signal.  Quitting Writer. stop 0x2a2df893ecb0
+2026/04/14 02:12:02 Cleaning up writer...
+2026/04/14 02:12:02 Finished cleaning up writer:  0x2a2df893ecb0
+2026/04/14 02:12:02 Closed MCP-GET-SSE SSE connection: aef562cd9b2bcb75e7205c35ac2e6138
 
 === Running scenario: tools-call-error ===
 Running client scenario 'tools-call-error' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: 543156d7cc08d3af3dc9bb57d76f7e2e
-2026/04/14 01:06:53 SSEHub: registered connection 543156d7cc08d3af3dc9bb57d76f7e2e (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection 543156d7cc08d3af3dc9bb57d76f7e2e (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e192d20
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e192d20
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: 543156d7cc08d3af3dc9bb57d76f7e2e
+2026/04/14 02:12:02 Starting MCP-GET-SSE SSE connection: 4e35f2b278d242f6bee3be8d8fb0a365
+2026/04/14 02:12:02 SSEHub: registered connection 4e35f2b278d242f6bee3be8d8fb0a365 (total: 1)
+2026/04/14 02:12:02 SSEHub: unregistered connection 4e35f2b278d242f6bee3be8d8fb0a365 (total: 0)
+2026/04/14 02:12:02 Received kill signal.  Quitting Writer. stop 0x2a2df8f24850
+2026/04/14 02:12:02 Cleaning up writer...
+2026/04/14 02:12:02 Finished cleaning up writer:  0x2a2df8f24850
+2026/04/14 02:12:02 Closed MCP-GET-SSE SSE connection: 4e35f2b278d242f6bee3be8d8fb0a365
 
 === Running scenario: tools-call-with-progress ===
 Running client scenario 'tools-call-with-progress' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: 1360e451e018635d15c2151b661f2c82
-2026/04/14 01:06:53 SSEHub: registered connection 1360e451e018635d15c2151b661f2c82 (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection 1360e451e018635d15c2151b661f2c82 (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e4c0a80
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e4c0a80
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: 1360e451e018635d15c2151b661f2c82
+2026/04/14 02:12:02 Starting MCP-GET-SSE SSE connection: f4970bc0110b2e543b521df6b700cadc
+2026/04/14 02:12:02 SSEHub: registered connection f4970bc0110b2e543b521df6b700cadc (total: 1)
+2026/04/14 02:12:02 SSEHub: unregistered connection f4970bc0110b2e543b521df6b700cadc (total: 0)
+2026/04/14 02:12:02 Received kill signal.  Quitting Writer. stop 0x2a2df8cba690
+2026/04/14 02:12:02 Cleaning up writer...
+2026/04/14 02:12:02 Finished cleaning up writer:  0x2a2df8cba690
+2026/04/14 02:12:02 Closed MCP-GET-SSE SSE connection: f4970bc0110b2e543b521df6b700cadc
 
 === Running scenario: tools-call-sampling ===
 Running client scenario 'tools-call-sampling' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: ec688ccee31e8963fd8fdc3dd872eae9
-2026/04/14 01:06:53 SSEHub: registered connection ec688ccee31e8963fd8fdc3dd872eae9 (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection ec688ccee31e8963fd8fdc3dd872eae9 (total: 0)
+2026/04/14 02:12:02 Starting MCP-GET-SSE SSE connection: 37d539c2fd7294bae8a3034bd4f3094d
+2026/04/14 02:12:02 SSEHub: registered connection 37d539c2fd7294bae8a3034bd4f3094d (total: 1)
+2026/04/14 02:12:02 SSEHub: unregistered connection 37d539c2fd7294bae8a3034bd4f3094d (total: 0)
+2026/04/14 02:12:02 Received kill signal.  Quitting Writer. stop 0x2a2df8cba8c0
+2026/04/14 02:12:02 Cleaning up writer...
+2026/04/14 02:12:02 Finished cleaning up writer:  0x2a2df8cba8c0
+2026/04/14 02:12:02 Closed MCP-GET-SSE SSE connection: 37d539c2fd7294bae8a3034bd4f3094d
 
 === Running scenario: tools-call-elicitation ===
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e193180
-2026/04/14 01:06:53 Cleaning up writer...
 Running client scenario 'tools-call-elicitation' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e193180
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: ec688ccee31e8963fd8fdc3dd872eae9
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: 9aba27937d595b603ffe287718146770
-2026/04/14 01:06:53 SSEHub: registered connection 9aba27937d595b603ffe287718146770 (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection 9aba27937d595b603ffe287718146770 (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e090f50
-2026/04/14 01:06:53 Cleaning up writer...
+2026/04/14 02:12:02 Starting MCP-GET-SSE SSE connection: 08a13fa589c03278d005dab93c6bd730
+2026/04/14 02:12:02 SSEHub: registered connection 08a13fa589c03278d005dab93c6bd730 (total: 1)
+2026/04/14 02:12:02 SSEHub: unregistered connection 08a13fa589c03278d005dab93c6bd730 (total: 0)
+2026/04/14 02:12:02 Received kill signal.  Quitting Writer. stop 0x2a2df893ef50
+2026/04/14 02:12:02 Cleaning up writer...
+2026/04/14 02:12:02 Finished cleaning up writer:  0x2a2df893ef50
+2026/04/14 02:12:02 Closed MCP-GET-SSE SSE connection: 08a13fa589c03278d005dab93c6bd730
 
 === Running scenario: elicitation-sep1034-defaults ===
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e090f50
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: 9aba27937d595b603ffe287718146770
 Running client scenario 'elicitation-sep1034-defaults' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: 4de55e2b9a898d61690b71c9c58fb785
-2026/04/14 01:06:53 SSEHub: registered connection 4de55e2b9a898d61690b71c9c58fb785 (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection 4de55e2b9a898d61690b71c9c58fb785 (total: 0)
+2026/04/14 02:12:02 Starting MCP-GET-SSE SSE connection: ae664c25da2e0d774b3f405f80e985cd
+2026/04/14 02:12:02 SSEHub: registered connection ae664c25da2e0d774b3f405f80e985cd (total: 1)
+2026/04/14 02:12:02 SSEHub: unregistered connection ae664c25da2e0d774b3f405f80e985cd (total: 0)
+2026/04/14 02:12:02 Received kill signal.  Quitting Writer. stop 0x2a2df893f2d0
+2026/04/14 02:12:02 Cleaning up writer...
+2026/04/14 02:12:02 Finished cleaning up writer:  0x2a2df893f2d0
+2026/04/14 02:12:02 Closed MCP-GET-SSE SSE connection: ae664c25da2e0d774b3f405f80e985cd
 
 === Running scenario: server-sse-multiple-streams ===
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e193570
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e193570
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: 4de55e2b9a898d61690b71c9c58fb785
 Running client scenario 'server-sse-multiple-streams' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: 9c53b09bcd6c625fda01b093f77527b0
-2026/04/14 01:06:53 SSEHub: registered connection 9c53b09bcd6c625fda01b093f77527b0 (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection 9c53b09bcd6c625fda01b093f77527b0 (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e20e930
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e20e930
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: 9c53b09bcd6c625fda01b093f77527b0
+2026/04/14 02:12:02 Starting MCP-GET-SSE SSE connection: 34f131662d120da4248e563f97971725
+2026/04/14 02:12:02 SSEHub: registered connection 34f131662d120da4248e563f97971725 (total: 1)
+2026/04/14 02:12:02 SSEHub: unregistered connection 34f131662d120da4248e563f97971725 (total: 0)
+2026/04/14 02:12:02 Received kill signal.  Quitting Writer. stop 0x2a2df8cbacb0
+2026/04/14 02:12:02 Cleaning up writer...
+2026/04/14 02:12:02 Finished cleaning up writer:  0x2a2df8cbacb0
+2026/04/14 02:12:02 Closed MCP-GET-SSE SSE connection: 34f131662d120da4248e563f97971725
 
 === Running scenario: elicitation-sep1330-enums ===
 Running client scenario 'elicitation-sep1330-enums' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: be585f14e8f60ccac2fc1c9fc5cd6ef2
-2026/04/14 01:06:53 SSEHub: registered connection be585f14e8f60ccac2fc1c9fc5cd6ef2 (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection be585f14e8f60ccac2fc1c9fc5cd6ef2 (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e20ed20
+2026/04/14 02:12:02 Starting MCP-GET-SSE SSE connection: df7bac5f9d6caae080cf1196f27669a9
+2026/04/14 02:12:02 SSEHub: registered connection df7bac5f9d6caae080cf1196f27669a9 (total: 1)
+2026/04/14 02:12:02 SSEHub: unregistered connection df7bac5f9d6caae080cf1196f27669a9 (total: 0)
+2026/04/14 02:12:02 Received kill signal.  Quitting Writer. stop 0x2a2df8cbafc0
+2026/04/14 02:12:02 Cleaning up writer...
+2026/04/14 02:12:02 Finished cleaning up writer:  0x2a2df8cbafc0
+2026/04/14 02:12:02 Closed MCP-GET-SSE SSE connection: df7bac5f9d6caae080cf1196f27669a9
 
 === Running scenario: resources-list ===
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e20ed20
 Running client scenario 'resources-list' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: be585f14e8f60ccac2fc1c9fc5cd6ef2
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: c0006345443f8de762bb828a74fe1de4
-2026/04/14 01:06:53 SSEHub: registered connection c0006345443f8de762bb828a74fe1de4 (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection c0006345443f8de762bb828a74fe1de4 (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e1937a0
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e1937a0
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: c0006345443f8de762bb828a74fe1de4
+2026/04/14 02:12:02 Starting MCP-GET-SSE SSE connection: 857a9f0155445c999403f89f60893749
+2026/04/14 02:12:02 SSEHub: registered connection 857a9f0155445c999403f89f60893749 (total: 1)
+2026/04/14 02:12:02 SSEHub: unregistered connection 857a9f0155445c999403f89f60893749 (total: 0)
+2026/04/14 02:12:02 Received kill signal.  Quitting Writer. stop 0x2a2df8cbb1f0
+2026/04/14 02:12:02 Cleaning up writer...
+2026/04/14 02:12:02 Finished cleaning up writer:  0x2a2df8cbb1f0
+2026/04/14 02:12:02 Closed MCP-GET-SSE SSE connection: 857a9f0155445c999403f89f60893749
 
 === Running scenario: resources-read-text ===
 Running client scenario 'resources-read-text' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: cd80156225a77b292dfa3d8b7c5c641a
-2026/04/14 01:06:53 SSEHub: registered connection cd80156225a77b292dfa3d8b7c5c641a (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection cd80156225a77b292dfa3d8b7c5c641a (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e1939d0
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e1939d0
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: cd80156225a77b292dfa3d8b7c5c641a
+2026/04/14 02:12:02 Starting MCP-GET-SSE SSE connection: b072828f3ba648210b4a827604c44fbb
+2026/04/14 02:12:02 SSEHub: registered connection b072828f3ba648210b4a827604c44fbb (total: 1)
+2026/04/14 02:12:02 SSEHub: unregistered connection b072828f3ba648210b4a827604c44fbb (total: 0)
+2026/04/14 02:12:02 Received kill signal.  Quitting Writer. stop 0x2a2df8f25030
+2026/04/14 02:12:02 Cleaning up writer...
+2026/04/14 02:12:02 Finished cleaning up writer:  0x2a2df8f25030
+2026/04/14 02:12:02 Closed MCP-GET-SSE SSE connection: b072828f3ba648210b4a827604c44fbb
 
 === Running scenario: resources-read-binary ===
 Running client scenario 'resources-read-binary' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: 1e9a556f34144207362c1e08ac0be81c
-2026/04/14 01:06:53 SSEHub: registered connection 1e9a556f34144207362c1e08ac0be81c (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection 1e9a556f34144207362c1e08ac0be81c (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e193c00
-2026/04/14 01:06:53 Cleaning up writer...
+2026/04/14 02:12:02 Starting MCP-GET-SSE SSE connection: e736fee3728305e196cc39aee8c5b546
+2026/04/14 02:12:02 SSEHub: registered connection e736fee3728305e196cc39aee8c5b546 (total: 1)
+2026/04/14 02:12:02 SSEHub: unregistered connection e736fee3728305e196cc39aee8c5b546 (total: 0)
+2026/04/14 02:12:02 Received kill signal.  Quitting Writer. stop 0x2a2df8f252d0
+2026/04/14 02:12:02 Cleaning up writer...
+2026/04/14 02:12:02 Finished cleaning up writer:  0x2a2df8f252d0
+2026/04/14 02:12:02 Closed MCP-GET-SSE SSE connection: e736fee3728305e196cc39aee8c5b546
 
 === Running scenario: resources-templates-read ===
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e193c00
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: 1e9a556f34144207362c1e08ac0be81c
 Running client scenario 'resources-templates-read' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: 04a89d2c80ed675c9049f7eef760a5d8
-2026/04/14 01:06:53 SSEHub: registered connection 04a89d2c80ed675c9049f7eef760a5d8 (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection 04a89d2c80ed675c9049f7eef760a5d8 (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e4c0fc0
-2026/04/14 01:06:53 Cleaning up writer...
+2026/04/14 02:12:02 Starting MCP-GET-SSE SSE connection: de78f6d21da8a18dce843e750f5591f9
+2026/04/14 02:12:02 SSEHub: registered connection de78f6d21da8a18dce843e750f5591f9 (total: 1)
+2026/04/14 02:12:02 SSEHub: unregistered connection de78f6d21da8a18dce843e750f5591f9 (total: 0)
+2026/04/14 02:12:02 Received kill signal.  Quitting Writer. stop 0x2a2df8c387e0
+2026/04/14 02:12:02 Cleaning up writer...
+2026/04/14 02:12:02 Finished cleaning up writer:  0x2a2df8c387e0
+2026/04/14 02:12:02 Closed MCP-GET-SSE SSE connection: de78f6d21da8a18dce843e750f5591f9
 
 === Running scenario: resources-subscribe ===
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e4c0fc0
 Running client scenario 'resources-subscribe' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: 04a89d2c80ed675c9049f7eef760a5d8
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: e3b46385114357c6360089e8db0133b4
-2026/04/14 01:06:53 SSEHub: registered connection e3b46385114357c6360089e8db0133b4 (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection e3b46385114357c6360089e8db0133b4 (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e4c12d0
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e4c12d0
+2026/04/14 02:12:02 Starting MCP-GET-SSE SSE connection: 43647aea70f3e3fc5b734dcf73b3c356
+2026/04/14 02:12:02 SSEHub: registered connection 43647aea70f3e3fc5b734dcf73b3c356 (total: 1)
+2026/04/14 02:12:02 SSEHub: unregistered connection 43647aea70f3e3fc5b734dcf73b3c356 (total: 0)
+2026/04/14 02:12:02 Received kill signal.  Quitting Writer. stop 0x2a2df8c38a80
+2026/04/14 02:12:02 Cleaning up writer...
+2026/04/14 02:12:02 Finished cleaning up writer:  0x2a2df8c38a80
+2026/04/14 02:12:02 Closed MCP-GET-SSE SSE connection: 43647aea70f3e3fc5b734dcf73b3c356
 
 === Running scenario: resources-unsubscribe ===
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: e3b46385114357c6360089e8db0133b4
 Running client scenario 'resources-unsubscribe' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: 12c69241353fdd3e51a85d98e7b20f52
-2026/04/14 01:06:53 SSEHub: registered connection 12c69241353fdd3e51a85d98e7b20f52 (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection 12c69241353fdd3e51a85d98e7b20f52 (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e091880
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e091880
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: 12c69241353fdd3e51a85d98e7b20f52
+2026/04/14 02:12:02 Starting MCP-GET-SSE SSE connection: 64e9ffe51057ad63a965b250f8ef56af
+2026/04/14 02:12:02 SSEHub: registered connection 64e9ffe51057ad63a965b250f8ef56af (total: 1)
+2026/04/14 02:12:02 SSEHub: unregistered connection 64e9ffe51057ad63a965b250f8ef56af (total: 0)
+2026/04/14 02:12:02 Received kill signal.  Quitting Writer. stop 0x2a2df8cbb6c0
+2026/04/14 02:12:02 Cleaning up writer...
+2026/04/14 02:12:02 Finished cleaning up writer:  0x2a2df8cbb6c0
+2026/04/14 02:12:02 Closed MCP-GET-SSE SSE connection: 64e9ffe51057ad63a965b250f8ef56af
 
 === Running scenario: prompts-list ===
 Running client scenario 'prompts-list' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: 8d3993eb218709879c071b68904b6da4
-2026/04/14 01:06:53 SSEHub: registered connection 8d3993eb218709879c071b68904b6da4 (total: 1)
+2026/04/14 02:12:02 Starting MCP-GET-SSE SSE connection: 2b7a56cacc436faa940484dd46a03385
+2026/04/14 02:12:02 SSEHub: registered connection 2b7a56cacc436faa940484dd46a03385 (total: 1)
+2026/04/14 02:12:02 SSEHub: unregistered connection 2b7a56cacc436faa940484dd46a03385 (total: 0)
+2026/04/14 02:12:02 Received kill signal.  Quitting Writer. stop 0x2a2df8c38d20
+2026/04/14 02:12:02 Cleaning up writer...
+2026/04/14 02:12:02 Finished cleaning up writer:  0x2a2df8c38d20
+2026/04/14 02:12:02 Closed MCP-GET-SSE SSE connection: 2b7a56cacc436faa940484dd46a03385
 
 === Running scenario: prompts-get-simple ===
-2026/04/14 01:06:53 SSEHub: unregistered connection 8d3993eb218709879c071b68904b6da4 (total: 0)
 Running client scenario 'prompts-get-simple' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e091ab0
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e091ab0
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: 8d3993eb218709879c071b68904b6da4
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: ff2c620bf33780fa5f9af90f25ada377
-2026/04/14 01:06:53 SSEHub: registered connection ff2c620bf33780fa5f9af90f25ada377 (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection ff2c620bf33780fa5f9af90f25ada377 (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e091ce0
+2026/04/14 02:12:02 Starting MCP-GET-SSE SSE connection: 708e8f13b7910669e5f1d6d86645a738
+2026/04/14 02:12:02 SSEHub: registered connection 708e8f13b7910669e5f1d6d86645a738 (total: 1)
+2026/04/14 02:12:02 SSEHub: unregistered connection 708e8f13b7910669e5f1d6d86645a738 (total: 0)
+2026/04/14 02:12:02 Received kill signal.  Quitting Writer. stop 0x2a2df8c38f50
+2026/04/14 02:12:02 Cleaning up writer...
+2026/04/14 02:12:02 Finished cleaning up writer:  0x2a2df8c38f50
+2026/04/14 02:12:02 Closed MCP-GET-SSE SSE connection: 708e8f13b7910669e5f1d6d86645a738
 
 === Running scenario: prompts-get-with-args ===
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e091ce0
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: ff2c620bf33780fa5f9af90f25ada377
 Running client scenario 'prompts-get-with-args' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: 609f5b259a49213fc98603cb7cabb5a6
-2026/04/14 01:06:53 SSEHub: registered connection 609f5b259a49213fc98603cb7cabb5a6 (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection 609f5b259a49213fc98603cb7cabb5a6 (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e20f180
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e20f180
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: 609f5b259a49213fc98603cb7cabb5a6
+2026/04/14 02:12:02 Starting MCP-GET-SSE SSE connection: d5b98287e63b757929cd96731c06dece
+2026/04/14 02:12:02 SSEHub: registered connection d5b98287e63b757929cd96731c06dece (total: 1)
+2026/04/14 02:12:02 SSEHub: unregistered connection d5b98287e63b757929cd96731c06dece (total: 0)
+2026/04/14 02:12:02 Received kill signal.  Quitting Writer. stop 0x2a2df8f25730
+2026/04/14 02:12:02 Cleaning up writer...
+2026/04/14 02:12:02 Finished cleaning up writer:  0x2a2df8f25730
 
 === Running scenario: prompts-get-embedded-resource ===
+2026/04/14 02:12:02 Closed MCP-GET-SSE SSE connection: d5b98287e63b757929cd96731c06dece
 Running client scenario 'prompts-get-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: d1d046fc136c67b2d2b92a41577c05ee
-2026/04/14 01:06:53 SSEHub: registered connection d1d046fc136c67b2d2b92a41577c05ee (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection d1d046fc136c67b2d2b92a41577c05ee (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e324070
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e324070
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: d1d046fc136c67b2d2b92a41577c05ee
+2026/04/14 02:12:02 Starting MCP-GET-SSE SSE connection: 9faa1d743984a84a6637cd6bf534c158
+2026/04/14 02:12:02 SSEHub: registered connection 9faa1d743984a84a6637cd6bf534c158 (total: 1)
+2026/04/14 02:12:02 SSEHub: unregistered connection 9faa1d743984a84a6637cd6bf534c158 (total: 0)
+2026/04/14 02:12:02 Received kill signal.  Quitting Writer. stop 0x2a2df8f259d0
+2026/04/14 02:12:02 Cleaning up writer...
+2026/04/14 02:12:02 Finished cleaning up writer:  0x2a2df8f259d0
+2026/04/14 02:12:02 Closed MCP-GET-SSE SSE connection: 9faa1d743984a84a6637cd6bf534c158
 
 === Running scenario: prompts-get-with-image ===
 Running client scenario 'prompts-get-with-image' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: 0731674d6d72abf517bf3d38fea4518f
-2026/04/14 01:06:53 SSEHub: registered connection 0731674d6d72abf517bf3d38fea4518f (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection 0731674d6d72abf517bf3d38fea4518f (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e3242a0
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e3242a0
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: 0731674d6d72abf517bf3d38fea4518f
+2026/04/14 02:12:02 Starting MCP-GET-SSE SSE connection: 7cbb9e259a35672ba9ac6d98e0f6f702
+2026/04/14 02:12:02 SSEHub: registered connection 7cbb9e259a35672ba9ac6d98e0f6f702 (total: 1)
+2026/04/14 02:12:02 SSEHub: unregistered connection 7cbb9e259a35672ba9ac6d98e0f6f702 (total: 0)
+2026/04/14 02:12:02 Received kill signal.  Quitting Writer. stop 0x2a2df8c392d0
+2026/04/14 02:12:02 Cleaning up writer...
+2026/04/14 02:12:02 Finished cleaning up writer:  0x2a2df8c392d0
+2026/04/14 02:12:02 Closed MCP-GET-SSE SSE connection: 7cbb9e259a35672ba9ac6d98e0f6f702
 
 === Running scenario: dns-rebinding-protection ===
 Running client scenario 'dns-rebinding-protection' against server: http://localhost:18799/mcp
@@ -438,22 +438,22 @@ Starting scenario: auth/token-endpoint-auth-basic
 Starting scenario: auth/token-endpoint-auth-post
 Starting scenario: auth/token-endpoint-auth-none
 Starting scenario: auth/pre-registration
-Executing client: ./bin/testclient http://localhost:63278/mcp
-Executing client: ./bin/testclient http://localhost:63279/mcp
-Executing client: ./bin/testclient http://localhost:63280/mcp
-Executing client: ./bin/testclient http://localhost:63281/mcp
-Executing client: ./bin/testclient http://localhost:63282/mcp
-Executing client: ./bin/testclient http://localhost:63283/mcp
-Executing client: ./bin/testclient http://localhost:63284/mcp
-Executing client: ./bin/testclient http://localhost:63285/mcp
-Executing client: ./bin/testclient http://localhost:63286/mcp
-Executing client: ./bin/testclient http://localhost:63287/mcp
-Executing client: ./bin/testclient http://localhost:63288/mcp
-Executing client: ./bin/testclient http://localhost:63289/mcp
-Executing client: ./bin/testclient http://localhost:63290/mcp
-Executing client: ./bin/testclient http://localhost:63291/mcp
+Executing client: ./bin/testclient http://localhost:52059/mcp
+Executing client: ./bin/testclient http://localhost:52060/mcp
+Executing client: ./bin/testclient http://localhost:52061/mcp
+Executing client: ./bin/testclient http://localhost:52062/mcp
+Executing client: ./bin/testclient http://localhost:52063/mcp
+Executing client: ./bin/testclient http://localhost:52064/mcp
+Executing client: ./bin/testclient http://localhost:52065/mcp
+Executing client: ./bin/testclient http://localhost:52066/mcp
+Executing client: ./bin/testclient http://localhost:52067/mcp
+Executing client: ./bin/testclient http://localhost:52068/mcp
+Executing client: ./bin/testclient http://localhost:52069/mcp
+Executing client: ./bin/testclient http://localhost:52070/mcp
+Executing client: ./bin/testclient http://localhost:52071/mcp
+Executing client: ./bin/testclient http://localhost:52072/mcp
 With context: {"client_id":"pre-registered-client","client_secret":"pre-registered-secret"}
-(node:42698) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
+(node:69435) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
 (Use `node --trace-deprecation ...` to show where the warning was created)
 
 === SUITE SUMMARY ===
@@ -511,11 +511,11 @@ Waiting for Keycloak realm...
     interop_test.go:167: Keycloak not reachable at http://localhost:8180: Get "http://localhost:8180/realms/mcpkit-test": dial tcp [::1]:8180: connect: connection refused (run 'make upkcl' to start)
 --- SKIP: TestKeycloak_MCPServer_PasswordGrant (0.00s)
 PASS
-ok  	github.com/panyam/mcpkit/tests/keycloak	0.425s
+ok  	github.com/panyam/mcpkit/tests/keycloak	0.494s
 make[2]: *** No rule to make target `downkcl'.  Stop.
   PASS: keycloak
 
 === Results: 9 passed, 0 failed ===
-Finished: Tue Apr 14 01:08:59 PDT 2026
+Finished: Tue Apr 14 02:14:07 PDT 2026
 </pre>
 </body></html>

--- a/tests/reports/run.log
+++ b/tests/reports/run.log
@@ -1,51 +1,51 @@
 === MCPKit Comprehensive Test Suite ===
-Started: Tue Apr 14 01:06:06 PDT 2026
+Started: Tue Apr 14 02:11:15 PDT 2026
 
 --- [1/9] unit+coverage ---
-ok  	github.com/panyam/mcpkit/client	8.477s	coverage: 67.4% of statements
+ok  	github.com/panyam/mcpkit/client	8.770s	coverage: 67.4% of statements
 	github.com/panyam/mcpkit/cmd/testserver		coverage: 0.0% of statements
-ok  	github.com/panyam/mcpkit/core	0.632s	coverage: 48.0% of statements
-ok  	github.com/panyam/mcpkit/server	14.551s	coverage: 78.4% of statements
-ok  	github.com/panyam/mcpkit/testutil	0.952s	coverage: 70.5% of statements
+ok  	github.com/panyam/mcpkit/core	0.932s	coverage: 48.0% of statements
+ok  	github.com/panyam/mcpkit/server	14.542s	coverage: 78.4% of statements
+ok  	github.com/panyam/mcpkit/testutil	0.410s	coverage: 70.5% of statements
 Coverage report: tests/reports/coverage.html
   PASS: unit+coverage
 --- [2/9] race ---
-ok  	github.com/panyam/mcpkit/client	9.483s
+ok  	github.com/panyam/mcpkit/client	9.314s
 ?   	github.com/panyam/mcpkit/cmd/testserver	[no test files]
-ok  	github.com/panyam/mcpkit/core	1.378s
-ok  	github.com/panyam/mcpkit/server	15.156s
-ok  	github.com/panyam/mcpkit/testutil	2.468s
+ok  	github.com/panyam/mcpkit/core	1.354s
+ok  	github.com/panyam/mcpkit/server	15.075s
+ok  	github.com/panyam/mcpkit/testutil	2.418s
   PASS: race
 --- [3/9] auth ---
 ok  	github.com/panyam/mcpkit/ext/auth	0.367s
   PASS: auth
 --- [4/9] ui ---
-ok  	github.com/panyam/mcpkit/ext/ui	0.257s
+ok  	github.com/panyam/mcpkit/ext/ui	0.323s
   PASS: ui
 --- [5/9] protogen ---
 ?   	github.com/panyam/mcpkit/ext/protogen/cmd/protoc-gen-go-mcp	[no test files]
-ok  	github.com/panyam/mcpkit/ext/protogen/generator	1.191s
-ok  	github.com/panyam/mcpkit/ext/protogen/proto/mcp/v1	0.900s
-ok  	github.com/panyam/mcpkit/ext/protogen/runtime	0.361s
-ok  	github.com/panyam/mcpkit/ext/protogen/schema	0.665s
+ok  	github.com/panyam/mcpkit/ext/protogen/generator	0.662s
+ok  	github.com/panyam/mcpkit/ext/protogen/proto/mcp/v1	1.178s
+ok  	github.com/panyam/mcpkit/ext/protogen/runtime	0.382s
+ok  	github.com/panyam/mcpkit/ext/protogen/schema	0.953s
 ?   	github.com/panyam/mcpkit/ext/protogen/testutil	[no test files]
 ==> e2e: bookservice example
 [33mWARN[0m	plugin "protoc-gen-go-mcp" does not support required features.
   Feature "proto3 optional" is required by 1 file(s):
     bookservice/v1/service.proto
-ok  	github.com/panyam/mcpkit/ext/protogen/examples/bookservice	0.439s
+ok  	github.com/panyam/mcpkit/ext/protogen/examples/bookservice	0.341s
 ==> e2e: passed
   PASS: protogen
 --- [6/9] e2e ---
-ok  	github.com/panyam/mcpkit/tests/e2e	3.754s
-ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.933s
+ok  	github.com/panyam/mcpkit/tests/e2e	3.931s
+ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.408s
   PASS: e2e
 --- [7/9] conformance ---
 Killing stale process on port 18799...
-2026/04/14 01:06:49 Received signal terminated, shutting down...
-2026/04/14 01:06:49 Server shut down gracefully
+2026/04/14 02:11:58 Received signal terminated, shutting down...
+2026/04/14 02:11:58 Server shut down gracefully
 === Starting test server on :18799 (Streamable HTTP) ===
-Waiting for server....2026/04/14 01:06:50 MCP test server listening on :18799 (Streamable HTTP at /mcp)
+Waiting for server....2026/04/14 02:11:59 MCP test server listening on :18799 (Streamable HTTP at /mcp)
  ready
 
 === Running MCP conformance suite ===
@@ -56,293 +56,293 @@ Running active suite (30 scenarios) against http://localhost:18799/mcp
 
 === Running scenario: server-initialize ===
 Running client scenario 'server-initialize' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: e1c23150140dd01304422cb64867564c
-2026/04/14 01:06:53 SSEHub: registered connection e1c23150140dd01304422cb64867564c (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection e1c23150140dd01304422cb64867564c (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e4c0150
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e4c0150
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: e1c23150140dd01304422cb64867564c
+2026/04/14 02:12:01 Starting MCP-GET-SSE SSE connection: 932649a28a03c789b0d3a8deeddf6cff
+2026/04/14 02:12:01 SSEHub: registered connection 932649a28a03c789b0d3a8deeddf6cff (total: 1)
+2026/04/14 02:12:01 SSEHub: unregistered connection 932649a28a03c789b0d3a8deeddf6cff (total: 0)
+2026/04/14 02:12:01 Received kill signal.  Quitting Writer. stop 0x2a2df8cba150
+2026/04/14 02:12:01 Cleaning up writer...
+2026/04/14 02:12:01 Finished cleaning up writer:  0x2a2df8cba150
+2026/04/14 02:12:01 Closed MCP-GET-SSE SSE connection: 932649a28a03c789b0d3a8deeddf6cff
 
 === Running scenario: logging-set-level ===
 Running client scenario 'logging-set-level' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: 268ccbf757fcdd990578bbfd5d7cc77f
-2026/04/14 01:06:53 SSEHub: registered connection 268ccbf757fcdd990578bbfd5d7cc77f (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection 268ccbf757fcdd990578bbfd5d7cc77f (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e4c03f0
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e4c03f0
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: 268ccbf757fcdd990578bbfd5d7cc77f
+2026/04/14 02:12:01 Starting MCP-GET-SSE SSE connection: 21a3299498d06e36719aeaad3c90ad12
+2026/04/14 02:12:01 SSEHub: registered connection 21a3299498d06e36719aeaad3c90ad12 (total: 1)
+2026/04/14 02:12:01 SSEHub: unregistered connection 21a3299498d06e36719aeaad3c90ad12 (total: 0)
+2026/04/14 02:12:01 Received kill signal.  Quitting Writer. stop 0x2a2df893e310
+2026/04/14 02:12:01 Cleaning up writer...
+2026/04/14 02:12:01 Finished cleaning up writer:  0x2a2df893e310
+2026/04/14 02:12:01 Closed MCP-GET-SSE SSE connection: 21a3299498d06e36719aeaad3c90ad12
 
 === Running scenario: ping ===
 Running client scenario 'ping' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: 968bea1e9f96e009b6a3bb02ce5b95ed
-2026/04/14 01:06:53 SSEHub: registered connection 968bea1e9f96e009b6a3bb02ce5b95ed (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection 968bea1e9f96e009b6a3bb02ce5b95ed (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e4c0150
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e4c0150
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: 968bea1e9f96e009b6a3bb02ce5b95ed
+2026/04/14 02:12:01 Starting MCP-GET-SSE SSE connection: 0373459c01df87b3a20c2d1d2663716c
+2026/04/14 02:12:01 SSEHub: registered connection 0373459c01df87b3a20c2d1d2663716c (total: 1)
+2026/04/14 02:12:01 SSEHub: unregistered connection 0373459c01df87b3a20c2d1d2663716c (total: 0)
+2026/04/14 02:12:01 Received kill signal.  Quitting Writer. stop 0x2a2df893e540
+2026/04/14 02:12:01 Cleaning up writer...
+2026/04/14 02:12:01 Finished cleaning up writer:  0x2a2df893e540
+2026/04/14 02:12:01 Closed MCP-GET-SSE SSE connection: 0373459c01df87b3a20c2d1d2663716c
 
 === Running scenario: completion-complete ===
 Running client scenario 'completion-complete' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: da1910722662c6c3b1d9992cdec97660
-2026/04/14 01:06:53 SSEHub: registered connection da1910722662c6c3b1d9992cdec97660 (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection da1910722662c6c3b1d9992cdec97660 (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e090310
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e090310
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: da1910722662c6c3b1d9992cdec97660
+2026/04/14 02:12:01 Starting MCP-GET-SSE SSE connection: 8e6ae9a5e0121ed98af321c50d0bc084
+2026/04/14 02:12:01 SSEHub: registered connection 8e6ae9a5e0121ed98af321c50d0bc084 (total: 1)
+2026/04/14 02:12:01 SSEHub: unregistered connection 8e6ae9a5e0121ed98af321c50d0bc084 (total: 0)
+2026/04/14 02:12:01 Received kill signal.  Quitting Writer. stop 0x2a2df893e7e0
+2026/04/14 02:12:01 Cleaning up writer...
+2026/04/14 02:12:01 Finished cleaning up writer:  0x2a2df893e7e0
+2026/04/14 02:12:01 Closed MCP-GET-SSE SSE connection: 8e6ae9a5e0121ed98af321c50d0bc084
 
 === Running scenario: tools-list ===
 Running client scenario 'tools-list' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: 55a5e8bc58064fe461611061051f31fa
-2026/04/14 01:06:53 SSEHub: registered connection 55a5e8bc58064fe461611061051f31fa (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection 55a5e8bc58064fe461611061051f31fa (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e090690
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e090690
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: 55a5e8bc58064fe461611061051f31fa
+2026/04/14 02:12:01 Starting MCP-GET-SSE SSE connection: ceec6b223ed18e9644c79a57c8c262a1
+2026/04/14 02:12:01 SSEHub: registered connection ceec6b223ed18e9644c79a57c8c262a1 (total: 1)
+2026/04/14 02:12:01 SSEHub: unregistered connection ceec6b223ed18e9644c79a57c8c262a1 (total: 0)
+2026/04/14 02:12:01 Received kill signal.  Quitting Writer. stop 0x2a2df8cba150
+2026/04/14 02:12:01 Cleaning up writer...
+2026/04/14 02:12:01 Finished cleaning up writer:  0x2a2df8cba150
+2026/04/14 02:12:01 Closed MCP-GET-SSE SSE connection: ceec6b223ed18e9644c79a57c8c262a1
 
 === Running scenario: tools-call-simple-text ===
 Running client scenario 'tools-call-simple-text' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: ddad93022012e44770c015cb53684594
-2026/04/14 01:06:53 SSEHub: registered connection ddad93022012e44770c015cb53684594 (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection ddad93022012e44770c015cb53684594 (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e192a80
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e192a80
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: ddad93022012e44770c015cb53684594
+2026/04/14 02:12:01 Starting MCP-GET-SSE SSE connection: 8514a50a203e74f584c88069dd52f769
+2026/04/14 02:12:01 SSEHub: registered connection 8514a50a203e74f584c88069dd52f769 (total: 1)
+2026/04/14 02:12:01 SSEHub: unregistered connection 8514a50a203e74f584c88069dd52f769 (total: 0)
+2026/04/14 02:12:01 Received kill signal.  Quitting Writer. stop 0x2a2df8c38230
+2026/04/14 02:12:01 Cleaning up writer...
+2026/04/14 02:12:01 Finished cleaning up writer:  0x2a2df8c38230
+2026/04/14 02:12:01 Closed MCP-GET-SSE SSE connection: 8514a50a203e74f584c88069dd52f769
 
 === Running scenario: tools-call-image ===
 Running client scenario 'tools-call-image' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: cc9ac27eabfde6be205a8a1cae4935f6
-2026/04/14 01:06:53 SSEHub: registered connection cc9ac27eabfde6be205a8a1cae4935f6 (total: 1)
+2026/04/14 02:12:01 Starting MCP-GET-SSE SSE connection: ff4fa5615db3c9de720cad379a692cc3
+2026/04/14 02:12:01 SSEHub: registered connection ff4fa5615db3c9de720cad379a692cc3 (total: 1)
+2026/04/14 02:12:01 SSEHub: unregistered connection ff4fa5615db3c9de720cad379a692cc3 (total: 0)
 
 === Running scenario: tools-call-audio ===
-2026/04/14 01:06:53 SSEHub: unregistered connection cc9ac27eabfde6be205a8a1cae4935f6 (total: 0)
+2026/04/14 02:12:01 Received kill signal.  Quitting Writer. stop 0x2a2df893e3f0
+2026/04/14 02:12:01 Cleaning up writer...
 Running client scenario 'tools-call-audio' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e4c05b0
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e4c05b0
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: cc9ac27eabfde6be205a8a1cae4935f6
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: 092e8bcdf67b99e9ab483ed0523bd5ca
-2026/04/14 01:06:53 SSEHub: registered connection 092e8bcdf67b99e9ab483ed0523bd5ca (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection 092e8bcdf67b99e9ab483ed0523bd5ca (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e20e380
-2026/04/14 01:06:53 Cleaning up writer...
+2026/04/14 02:12:01 Finished cleaning up writer:  0x2a2df893e3f0
+2026/04/14 02:12:01 Closed MCP-GET-SSE SSE connection: ff4fa5615db3c9de720cad379a692cc3
+2026/04/14 02:12:01 Starting MCP-GET-SSE SSE connection: c870e10b08fb783dcf1a15d2973a2aa8
+2026/04/14 02:12:01 SSEHub: registered connection c870e10b08fb783dcf1a15d2973a2aa8 (total: 1)
+2026/04/14 02:12:01 SSEHub: unregistered connection c870e10b08fb783dcf1a15d2973a2aa8 (total: 0)
+2026/04/14 02:12:01 Received kill signal.  Quitting Writer. stop 0x2a2df8f242a0
+2026/04/14 02:12:01 Cleaning up writer...
+2026/04/14 02:12:01 Finished cleaning up writer:  0x2a2df8f242a0
+2026/04/14 02:12:01 Closed MCP-GET-SSE SSE connection: c870e10b08fb783dcf1a15d2973a2aa8
 
 === Running scenario: tools-call-embedded-resource ===
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e20e380
 Running client scenario 'tools-call-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: 092e8bcdf67b99e9ab483ed0523bd5ca
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: fe165bbd84e0ef7ccea94062ef82639a
-2026/04/14 01:06:53 SSEHub: registered connection fe165bbd84e0ef7ccea94062ef82639a (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection fe165bbd84e0ef7ccea94062ef82639a (total: 0)
+2026/04/14 02:12:01 Starting MCP-GET-SSE SSE connection: 59bb2a8d9a29b3d2be1109522c2b2a5b
+2026/04/14 02:12:01 SSEHub: registered connection 59bb2a8d9a29b3d2be1109522c2b2a5b (total: 1)
+2026/04/14 02:12:01 SSEHub: unregistered connection 59bb2a8d9a29b3d2be1109522c2b2a5b (total: 0)
+2026/04/14 02:12:01 Received kill signal.  Quitting Writer. stop 0x2a2df893e930
+2026/04/14 02:12:01 Cleaning up writer...
+2026/04/14 02:12:01 Finished cleaning up writer:  0x2a2df893e930
+2026/04/14 02:12:01 Closed MCP-GET-SSE SSE connection: 59bb2a8d9a29b3d2be1109522c2b2a5b
 
 === Running scenario: tools-call-mixed-content ===
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e20e5b0
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e20e5b0
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: fe165bbd84e0ef7ccea94062ef82639a
 Running client scenario 'tools-call-mixed-content' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: 4139fa923128b09a7f7775cc24996a9a
-2026/04/14 01:06:53 SSEHub: registered connection 4139fa923128b09a7f7775cc24996a9a (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection 4139fa923128b09a7f7775cc24996a9a (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e090af0
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e090af0
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: 4139fa923128b09a7f7775cc24996a9a
+2026/04/14 02:12:01 Starting MCP-GET-SSE SSE connection: 01992bd06fda164021c4c353ecf83469
+2026/04/14 02:12:01 SSEHub: registered connection 01992bd06fda164021c4c353ecf83469 (total: 1)
+2026/04/14 02:12:01 SSEHub: unregistered connection 01992bd06fda164021c4c353ecf83469 (total: 0)
+2026/04/14 02:12:01 Received kill signal.  Quitting Writer. stop 0x2a2df8cba460
+2026/04/14 02:12:01 Cleaning up writer...
+2026/04/14 02:12:01 Finished cleaning up writer:  0x2a2df8cba460
+2026/04/14 02:12:01 Closed MCP-GET-SSE SSE connection: 01992bd06fda164021c4c353ecf83469
 
 === Running scenario: tools-call-with-logging ===
 Running client scenario 'tools-call-with-logging' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: 851826ce9e8979aa120888c86c7d2102
-2026/04/14 01:06:53 SSEHub: registered connection 851826ce9e8979aa120888c86c7d2102 (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection 851826ce9e8979aa120888c86c7d2102 (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e090d20
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e090d20
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: 851826ce9e8979aa120888c86c7d2102
+2026/04/14 02:12:01 Starting MCP-GET-SSE SSE connection: aef562cd9b2bcb75e7205c35ac2e6138
+2026/04/14 02:12:01 SSEHub: registered connection aef562cd9b2bcb75e7205c35ac2e6138 (total: 1)
+2026/04/14 02:12:02 SSEHub: unregistered connection aef562cd9b2bcb75e7205c35ac2e6138 (total: 0)
+2026/04/14 02:12:02 Received kill signal.  Quitting Writer. stop 0x2a2df893ecb0
+2026/04/14 02:12:02 Cleaning up writer...
+2026/04/14 02:12:02 Finished cleaning up writer:  0x2a2df893ecb0
+2026/04/14 02:12:02 Closed MCP-GET-SSE SSE connection: aef562cd9b2bcb75e7205c35ac2e6138
 
 === Running scenario: tools-call-error ===
 Running client scenario 'tools-call-error' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: 543156d7cc08d3af3dc9bb57d76f7e2e
-2026/04/14 01:06:53 SSEHub: registered connection 543156d7cc08d3af3dc9bb57d76f7e2e (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection 543156d7cc08d3af3dc9bb57d76f7e2e (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e192d20
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e192d20
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: 543156d7cc08d3af3dc9bb57d76f7e2e
+2026/04/14 02:12:02 Starting MCP-GET-SSE SSE connection: 4e35f2b278d242f6bee3be8d8fb0a365
+2026/04/14 02:12:02 SSEHub: registered connection 4e35f2b278d242f6bee3be8d8fb0a365 (total: 1)
+2026/04/14 02:12:02 SSEHub: unregistered connection 4e35f2b278d242f6bee3be8d8fb0a365 (total: 0)
+2026/04/14 02:12:02 Received kill signal.  Quitting Writer. stop 0x2a2df8f24850
+2026/04/14 02:12:02 Cleaning up writer...
+2026/04/14 02:12:02 Finished cleaning up writer:  0x2a2df8f24850
+2026/04/14 02:12:02 Closed MCP-GET-SSE SSE connection: 4e35f2b278d242f6bee3be8d8fb0a365
 
 === Running scenario: tools-call-with-progress ===
 Running client scenario 'tools-call-with-progress' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: 1360e451e018635d15c2151b661f2c82
-2026/04/14 01:06:53 SSEHub: registered connection 1360e451e018635d15c2151b661f2c82 (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection 1360e451e018635d15c2151b661f2c82 (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e4c0a80
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e4c0a80
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: 1360e451e018635d15c2151b661f2c82
+2026/04/14 02:12:02 Starting MCP-GET-SSE SSE connection: f4970bc0110b2e543b521df6b700cadc
+2026/04/14 02:12:02 SSEHub: registered connection f4970bc0110b2e543b521df6b700cadc (total: 1)
+2026/04/14 02:12:02 SSEHub: unregistered connection f4970bc0110b2e543b521df6b700cadc (total: 0)
+2026/04/14 02:12:02 Received kill signal.  Quitting Writer. stop 0x2a2df8cba690
+2026/04/14 02:12:02 Cleaning up writer...
+2026/04/14 02:12:02 Finished cleaning up writer:  0x2a2df8cba690
+2026/04/14 02:12:02 Closed MCP-GET-SSE SSE connection: f4970bc0110b2e543b521df6b700cadc
 
 === Running scenario: tools-call-sampling ===
 Running client scenario 'tools-call-sampling' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: ec688ccee31e8963fd8fdc3dd872eae9
-2026/04/14 01:06:53 SSEHub: registered connection ec688ccee31e8963fd8fdc3dd872eae9 (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection ec688ccee31e8963fd8fdc3dd872eae9 (total: 0)
+2026/04/14 02:12:02 Starting MCP-GET-SSE SSE connection: 37d539c2fd7294bae8a3034bd4f3094d
+2026/04/14 02:12:02 SSEHub: registered connection 37d539c2fd7294bae8a3034bd4f3094d (total: 1)
+2026/04/14 02:12:02 SSEHub: unregistered connection 37d539c2fd7294bae8a3034bd4f3094d (total: 0)
+2026/04/14 02:12:02 Received kill signal.  Quitting Writer. stop 0x2a2df8cba8c0
+2026/04/14 02:12:02 Cleaning up writer...
+2026/04/14 02:12:02 Finished cleaning up writer:  0x2a2df8cba8c0
+2026/04/14 02:12:02 Closed MCP-GET-SSE SSE connection: 37d539c2fd7294bae8a3034bd4f3094d
 
 === Running scenario: tools-call-elicitation ===
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e193180
-2026/04/14 01:06:53 Cleaning up writer...
 Running client scenario 'tools-call-elicitation' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e193180
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: ec688ccee31e8963fd8fdc3dd872eae9
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: 9aba27937d595b603ffe287718146770
-2026/04/14 01:06:53 SSEHub: registered connection 9aba27937d595b603ffe287718146770 (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection 9aba27937d595b603ffe287718146770 (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e090f50
-2026/04/14 01:06:53 Cleaning up writer...
+2026/04/14 02:12:02 Starting MCP-GET-SSE SSE connection: 08a13fa589c03278d005dab93c6bd730
+2026/04/14 02:12:02 SSEHub: registered connection 08a13fa589c03278d005dab93c6bd730 (total: 1)
+2026/04/14 02:12:02 SSEHub: unregistered connection 08a13fa589c03278d005dab93c6bd730 (total: 0)
+2026/04/14 02:12:02 Received kill signal.  Quitting Writer. stop 0x2a2df893ef50
+2026/04/14 02:12:02 Cleaning up writer...
+2026/04/14 02:12:02 Finished cleaning up writer:  0x2a2df893ef50
+2026/04/14 02:12:02 Closed MCP-GET-SSE SSE connection: 08a13fa589c03278d005dab93c6bd730
 
 === Running scenario: elicitation-sep1034-defaults ===
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e090f50
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: 9aba27937d595b603ffe287718146770
 Running client scenario 'elicitation-sep1034-defaults' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: 4de55e2b9a898d61690b71c9c58fb785
-2026/04/14 01:06:53 SSEHub: registered connection 4de55e2b9a898d61690b71c9c58fb785 (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection 4de55e2b9a898d61690b71c9c58fb785 (total: 0)
+2026/04/14 02:12:02 Starting MCP-GET-SSE SSE connection: ae664c25da2e0d774b3f405f80e985cd
+2026/04/14 02:12:02 SSEHub: registered connection ae664c25da2e0d774b3f405f80e985cd (total: 1)
+2026/04/14 02:12:02 SSEHub: unregistered connection ae664c25da2e0d774b3f405f80e985cd (total: 0)
+2026/04/14 02:12:02 Received kill signal.  Quitting Writer. stop 0x2a2df893f2d0
+2026/04/14 02:12:02 Cleaning up writer...
+2026/04/14 02:12:02 Finished cleaning up writer:  0x2a2df893f2d0
+2026/04/14 02:12:02 Closed MCP-GET-SSE SSE connection: ae664c25da2e0d774b3f405f80e985cd
 
 === Running scenario: server-sse-multiple-streams ===
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e193570
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e193570
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: 4de55e2b9a898d61690b71c9c58fb785
 Running client scenario 'server-sse-multiple-streams' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: 9c53b09bcd6c625fda01b093f77527b0
-2026/04/14 01:06:53 SSEHub: registered connection 9c53b09bcd6c625fda01b093f77527b0 (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection 9c53b09bcd6c625fda01b093f77527b0 (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e20e930
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e20e930
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: 9c53b09bcd6c625fda01b093f77527b0
+2026/04/14 02:12:02 Starting MCP-GET-SSE SSE connection: 34f131662d120da4248e563f97971725
+2026/04/14 02:12:02 SSEHub: registered connection 34f131662d120da4248e563f97971725 (total: 1)
+2026/04/14 02:12:02 SSEHub: unregistered connection 34f131662d120da4248e563f97971725 (total: 0)
+2026/04/14 02:12:02 Received kill signal.  Quitting Writer. stop 0x2a2df8cbacb0
+2026/04/14 02:12:02 Cleaning up writer...
+2026/04/14 02:12:02 Finished cleaning up writer:  0x2a2df8cbacb0
+2026/04/14 02:12:02 Closed MCP-GET-SSE SSE connection: 34f131662d120da4248e563f97971725
 
 === Running scenario: elicitation-sep1330-enums ===
 Running client scenario 'elicitation-sep1330-enums' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: be585f14e8f60ccac2fc1c9fc5cd6ef2
-2026/04/14 01:06:53 SSEHub: registered connection be585f14e8f60ccac2fc1c9fc5cd6ef2 (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection be585f14e8f60ccac2fc1c9fc5cd6ef2 (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e20ed20
+2026/04/14 02:12:02 Starting MCP-GET-SSE SSE connection: df7bac5f9d6caae080cf1196f27669a9
+2026/04/14 02:12:02 SSEHub: registered connection df7bac5f9d6caae080cf1196f27669a9 (total: 1)
+2026/04/14 02:12:02 SSEHub: unregistered connection df7bac5f9d6caae080cf1196f27669a9 (total: 0)
+2026/04/14 02:12:02 Received kill signal.  Quitting Writer. stop 0x2a2df8cbafc0
+2026/04/14 02:12:02 Cleaning up writer...
+2026/04/14 02:12:02 Finished cleaning up writer:  0x2a2df8cbafc0
+2026/04/14 02:12:02 Closed MCP-GET-SSE SSE connection: df7bac5f9d6caae080cf1196f27669a9
 
 === Running scenario: resources-list ===
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e20ed20
 Running client scenario 'resources-list' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: be585f14e8f60ccac2fc1c9fc5cd6ef2
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: c0006345443f8de762bb828a74fe1de4
-2026/04/14 01:06:53 SSEHub: registered connection c0006345443f8de762bb828a74fe1de4 (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection c0006345443f8de762bb828a74fe1de4 (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e1937a0
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e1937a0
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: c0006345443f8de762bb828a74fe1de4
+2026/04/14 02:12:02 Starting MCP-GET-SSE SSE connection: 857a9f0155445c999403f89f60893749
+2026/04/14 02:12:02 SSEHub: registered connection 857a9f0155445c999403f89f60893749 (total: 1)
+2026/04/14 02:12:02 SSEHub: unregistered connection 857a9f0155445c999403f89f60893749 (total: 0)
+2026/04/14 02:12:02 Received kill signal.  Quitting Writer. stop 0x2a2df8cbb1f0
+2026/04/14 02:12:02 Cleaning up writer...
+2026/04/14 02:12:02 Finished cleaning up writer:  0x2a2df8cbb1f0
+2026/04/14 02:12:02 Closed MCP-GET-SSE SSE connection: 857a9f0155445c999403f89f60893749
 
 === Running scenario: resources-read-text ===
 Running client scenario 'resources-read-text' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: cd80156225a77b292dfa3d8b7c5c641a
-2026/04/14 01:06:53 SSEHub: registered connection cd80156225a77b292dfa3d8b7c5c641a (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection cd80156225a77b292dfa3d8b7c5c641a (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e1939d0
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e1939d0
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: cd80156225a77b292dfa3d8b7c5c641a
+2026/04/14 02:12:02 Starting MCP-GET-SSE SSE connection: b072828f3ba648210b4a827604c44fbb
+2026/04/14 02:12:02 SSEHub: registered connection b072828f3ba648210b4a827604c44fbb (total: 1)
+2026/04/14 02:12:02 SSEHub: unregistered connection b072828f3ba648210b4a827604c44fbb (total: 0)
+2026/04/14 02:12:02 Received kill signal.  Quitting Writer. stop 0x2a2df8f25030
+2026/04/14 02:12:02 Cleaning up writer...
+2026/04/14 02:12:02 Finished cleaning up writer:  0x2a2df8f25030
+2026/04/14 02:12:02 Closed MCP-GET-SSE SSE connection: b072828f3ba648210b4a827604c44fbb
 
 === Running scenario: resources-read-binary ===
 Running client scenario 'resources-read-binary' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: 1e9a556f34144207362c1e08ac0be81c
-2026/04/14 01:06:53 SSEHub: registered connection 1e9a556f34144207362c1e08ac0be81c (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection 1e9a556f34144207362c1e08ac0be81c (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e193c00
-2026/04/14 01:06:53 Cleaning up writer...
+2026/04/14 02:12:02 Starting MCP-GET-SSE SSE connection: e736fee3728305e196cc39aee8c5b546
+2026/04/14 02:12:02 SSEHub: registered connection e736fee3728305e196cc39aee8c5b546 (total: 1)
+2026/04/14 02:12:02 SSEHub: unregistered connection e736fee3728305e196cc39aee8c5b546 (total: 0)
+2026/04/14 02:12:02 Received kill signal.  Quitting Writer. stop 0x2a2df8f252d0
+2026/04/14 02:12:02 Cleaning up writer...
+2026/04/14 02:12:02 Finished cleaning up writer:  0x2a2df8f252d0
+2026/04/14 02:12:02 Closed MCP-GET-SSE SSE connection: e736fee3728305e196cc39aee8c5b546
 
 === Running scenario: resources-templates-read ===
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e193c00
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: 1e9a556f34144207362c1e08ac0be81c
 Running client scenario 'resources-templates-read' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: 04a89d2c80ed675c9049f7eef760a5d8
-2026/04/14 01:06:53 SSEHub: registered connection 04a89d2c80ed675c9049f7eef760a5d8 (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection 04a89d2c80ed675c9049f7eef760a5d8 (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e4c0fc0
-2026/04/14 01:06:53 Cleaning up writer...
+2026/04/14 02:12:02 Starting MCP-GET-SSE SSE connection: de78f6d21da8a18dce843e750f5591f9
+2026/04/14 02:12:02 SSEHub: registered connection de78f6d21da8a18dce843e750f5591f9 (total: 1)
+2026/04/14 02:12:02 SSEHub: unregistered connection de78f6d21da8a18dce843e750f5591f9 (total: 0)
+2026/04/14 02:12:02 Received kill signal.  Quitting Writer. stop 0x2a2df8c387e0
+2026/04/14 02:12:02 Cleaning up writer...
+2026/04/14 02:12:02 Finished cleaning up writer:  0x2a2df8c387e0
+2026/04/14 02:12:02 Closed MCP-GET-SSE SSE connection: de78f6d21da8a18dce843e750f5591f9
 
 === Running scenario: resources-subscribe ===
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e4c0fc0
 Running client scenario 'resources-subscribe' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: 04a89d2c80ed675c9049f7eef760a5d8
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: e3b46385114357c6360089e8db0133b4
-2026/04/14 01:06:53 SSEHub: registered connection e3b46385114357c6360089e8db0133b4 (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection e3b46385114357c6360089e8db0133b4 (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e4c12d0
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e4c12d0
+2026/04/14 02:12:02 Starting MCP-GET-SSE SSE connection: 43647aea70f3e3fc5b734dcf73b3c356
+2026/04/14 02:12:02 SSEHub: registered connection 43647aea70f3e3fc5b734dcf73b3c356 (total: 1)
+2026/04/14 02:12:02 SSEHub: unregistered connection 43647aea70f3e3fc5b734dcf73b3c356 (total: 0)
+2026/04/14 02:12:02 Received kill signal.  Quitting Writer. stop 0x2a2df8c38a80
+2026/04/14 02:12:02 Cleaning up writer...
+2026/04/14 02:12:02 Finished cleaning up writer:  0x2a2df8c38a80
+2026/04/14 02:12:02 Closed MCP-GET-SSE SSE connection: 43647aea70f3e3fc5b734dcf73b3c356
 
 === Running scenario: resources-unsubscribe ===
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: e3b46385114357c6360089e8db0133b4
 Running client scenario 'resources-unsubscribe' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: 12c69241353fdd3e51a85d98e7b20f52
-2026/04/14 01:06:53 SSEHub: registered connection 12c69241353fdd3e51a85d98e7b20f52 (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection 12c69241353fdd3e51a85d98e7b20f52 (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e091880
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e091880
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: 12c69241353fdd3e51a85d98e7b20f52
+2026/04/14 02:12:02 Starting MCP-GET-SSE SSE connection: 64e9ffe51057ad63a965b250f8ef56af
+2026/04/14 02:12:02 SSEHub: registered connection 64e9ffe51057ad63a965b250f8ef56af (total: 1)
+2026/04/14 02:12:02 SSEHub: unregistered connection 64e9ffe51057ad63a965b250f8ef56af (total: 0)
+2026/04/14 02:12:02 Received kill signal.  Quitting Writer. stop 0x2a2df8cbb6c0
+2026/04/14 02:12:02 Cleaning up writer...
+2026/04/14 02:12:02 Finished cleaning up writer:  0x2a2df8cbb6c0
+2026/04/14 02:12:02 Closed MCP-GET-SSE SSE connection: 64e9ffe51057ad63a965b250f8ef56af
 
 === Running scenario: prompts-list ===
 Running client scenario 'prompts-list' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: 8d3993eb218709879c071b68904b6da4
-2026/04/14 01:06:53 SSEHub: registered connection 8d3993eb218709879c071b68904b6da4 (total: 1)
+2026/04/14 02:12:02 Starting MCP-GET-SSE SSE connection: 2b7a56cacc436faa940484dd46a03385
+2026/04/14 02:12:02 SSEHub: registered connection 2b7a56cacc436faa940484dd46a03385 (total: 1)
+2026/04/14 02:12:02 SSEHub: unregistered connection 2b7a56cacc436faa940484dd46a03385 (total: 0)
+2026/04/14 02:12:02 Received kill signal.  Quitting Writer. stop 0x2a2df8c38d20
+2026/04/14 02:12:02 Cleaning up writer...
+2026/04/14 02:12:02 Finished cleaning up writer:  0x2a2df8c38d20
+2026/04/14 02:12:02 Closed MCP-GET-SSE SSE connection: 2b7a56cacc436faa940484dd46a03385
 
 === Running scenario: prompts-get-simple ===
-2026/04/14 01:06:53 SSEHub: unregistered connection 8d3993eb218709879c071b68904b6da4 (total: 0)
 Running client scenario 'prompts-get-simple' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e091ab0
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e091ab0
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: 8d3993eb218709879c071b68904b6da4
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: ff2c620bf33780fa5f9af90f25ada377
-2026/04/14 01:06:53 SSEHub: registered connection ff2c620bf33780fa5f9af90f25ada377 (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection ff2c620bf33780fa5f9af90f25ada377 (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e091ce0
+2026/04/14 02:12:02 Starting MCP-GET-SSE SSE connection: 708e8f13b7910669e5f1d6d86645a738
+2026/04/14 02:12:02 SSEHub: registered connection 708e8f13b7910669e5f1d6d86645a738 (total: 1)
+2026/04/14 02:12:02 SSEHub: unregistered connection 708e8f13b7910669e5f1d6d86645a738 (total: 0)
+2026/04/14 02:12:02 Received kill signal.  Quitting Writer. stop 0x2a2df8c38f50
+2026/04/14 02:12:02 Cleaning up writer...
+2026/04/14 02:12:02 Finished cleaning up writer:  0x2a2df8c38f50
+2026/04/14 02:12:02 Closed MCP-GET-SSE SSE connection: 708e8f13b7910669e5f1d6d86645a738
 
 === Running scenario: prompts-get-with-args ===
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e091ce0
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: ff2c620bf33780fa5f9af90f25ada377
 Running client scenario 'prompts-get-with-args' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: 609f5b259a49213fc98603cb7cabb5a6
-2026/04/14 01:06:53 SSEHub: registered connection 609f5b259a49213fc98603cb7cabb5a6 (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection 609f5b259a49213fc98603cb7cabb5a6 (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e20f180
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e20f180
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: 609f5b259a49213fc98603cb7cabb5a6
+2026/04/14 02:12:02 Starting MCP-GET-SSE SSE connection: d5b98287e63b757929cd96731c06dece
+2026/04/14 02:12:02 SSEHub: registered connection d5b98287e63b757929cd96731c06dece (total: 1)
+2026/04/14 02:12:02 SSEHub: unregistered connection d5b98287e63b757929cd96731c06dece (total: 0)
+2026/04/14 02:12:02 Received kill signal.  Quitting Writer. stop 0x2a2df8f25730
+2026/04/14 02:12:02 Cleaning up writer...
+2026/04/14 02:12:02 Finished cleaning up writer:  0x2a2df8f25730
 
 === Running scenario: prompts-get-embedded-resource ===
+2026/04/14 02:12:02 Closed MCP-GET-SSE SSE connection: d5b98287e63b757929cd96731c06dece
 Running client scenario 'prompts-get-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: d1d046fc136c67b2d2b92a41577c05ee
-2026/04/14 01:06:53 SSEHub: registered connection d1d046fc136c67b2d2b92a41577c05ee (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection d1d046fc136c67b2d2b92a41577c05ee (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e324070
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e324070
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: d1d046fc136c67b2d2b92a41577c05ee
+2026/04/14 02:12:02 Starting MCP-GET-SSE SSE connection: 9faa1d743984a84a6637cd6bf534c158
+2026/04/14 02:12:02 SSEHub: registered connection 9faa1d743984a84a6637cd6bf534c158 (total: 1)
+2026/04/14 02:12:02 SSEHub: unregistered connection 9faa1d743984a84a6637cd6bf534c158 (total: 0)
+2026/04/14 02:12:02 Received kill signal.  Quitting Writer. stop 0x2a2df8f259d0
+2026/04/14 02:12:02 Cleaning up writer...
+2026/04/14 02:12:02 Finished cleaning up writer:  0x2a2df8f259d0
+2026/04/14 02:12:02 Closed MCP-GET-SSE SSE connection: 9faa1d743984a84a6637cd6bf534c158
 
 === Running scenario: prompts-get-with-image ===
 Running client scenario 'prompts-get-with-image' against server: http://localhost:18799/mcp
-2026/04/14 01:06:53 Starting MCP-GET-SSE SSE connection: 0731674d6d72abf517bf3d38fea4518f
-2026/04/14 01:06:53 SSEHub: registered connection 0731674d6d72abf517bf3d38fea4518f (total: 1)
-2026/04/14 01:06:53 SSEHub: unregistered connection 0731674d6d72abf517bf3d38fea4518f (total: 0)
-2026/04/14 01:06:53 Received kill signal.  Quitting Writer. stop 0x5db91e3242a0
-2026/04/14 01:06:53 Cleaning up writer...
-2026/04/14 01:06:53 Finished cleaning up writer:  0x5db91e3242a0
-2026/04/14 01:06:53 Closed MCP-GET-SSE SSE connection: 0731674d6d72abf517bf3d38fea4518f
+2026/04/14 02:12:02 Starting MCP-GET-SSE SSE connection: 7cbb9e259a35672ba9ac6d98e0f6f702
+2026/04/14 02:12:02 SSEHub: registered connection 7cbb9e259a35672ba9ac6d98e0f6f702 (total: 1)
+2026/04/14 02:12:02 SSEHub: unregistered connection 7cbb9e259a35672ba9ac6d98e0f6f702 (total: 0)
+2026/04/14 02:12:02 Received kill signal.  Quitting Writer. stop 0x2a2df8c392d0
+2026/04/14 02:12:02 Cleaning up writer...
+2026/04/14 02:12:02 Finished cleaning up writer:  0x2a2df8c392d0
+2026/04/14 02:12:02 Closed MCP-GET-SSE SSE connection: 7cbb9e259a35672ba9ac6d98e0f6f702
 
 === Running scenario: dns-rebinding-protection ===
 Running client scenario 'dns-rebinding-protection' against server: http://localhost:18799/mcp
@@ -407,22 +407,22 @@ Starting scenario: auth/token-endpoint-auth-basic
 Starting scenario: auth/token-endpoint-auth-post
 Starting scenario: auth/token-endpoint-auth-none
 Starting scenario: auth/pre-registration
-Executing client: ./bin/testclient http://localhost:63278/mcp
-Executing client: ./bin/testclient http://localhost:63279/mcp
-Executing client: ./bin/testclient http://localhost:63280/mcp
-Executing client: ./bin/testclient http://localhost:63281/mcp
-Executing client: ./bin/testclient http://localhost:63282/mcp
-Executing client: ./bin/testclient http://localhost:63283/mcp
-Executing client: ./bin/testclient http://localhost:63284/mcp
-Executing client: ./bin/testclient http://localhost:63285/mcp
-Executing client: ./bin/testclient http://localhost:63286/mcp
-Executing client: ./bin/testclient http://localhost:63287/mcp
-Executing client: ./bin/testclient http://localhost:63288/mcp
-Executing client: ./bin/testclient http://localhost:63289/mcp
-Executing client: ./bin/testclient http://localhost:63290/mcp
-Executing client: ./bin/testclient http://localhost:63291/mcp
+Executing client: ./bin/testclient http://localhost:52059/mcp
+Executing client: ./bin/testclient http://localhost:52060/mcp
+Executing client: ./bin/testclient http://localhost:52061/mcp
+Executing client: ./bin/testclient http://localhost:52062/mcp
+Executing client: ./bin/testclient http://localhost:52063/mcp
+Executing client: ./bin/testclient http://localhost:52064/mcp
+Executing client: ./bin/testclient http://localhost:52065/mcp
+Executing client: ./bin/testclient http://localhost:52066/mcp
+Executing client: ./bin/testclient http://localhost:52067/mcp
+Executing client: ./bin/testclient http://localhost:52068/mcp
+Executing client: ./bin/testclient http://localhost:52069/mcp
+Executing client: ./bin/testclient http://localhost:52070/mcp
+Executing client: ./bin/testclient http://localhost:52071/mcp
+Executing client: ./bin/testclient http://localhost:52072/mcp
 With context: {"client_id":"pre-registered-client","client_secret":"pre-registered-secret"}
-(node:42698) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
+(node:69435) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
 (Use `node --trace-deprecation ...` to show where the warning was created)
 
 === SUITE SUMMARY ===
@@ -480,9 +480,9 @@ Waiting for Keycloak realm...
     interop_test.go:167: Keycloak not reachable at http://localhost:8180: Get "http://localhost:8180/realms/mcpkit-test": dial tcp [::1]:8180: connect: connection refused (run 'make upkcl' to start)
 --- SKIP: TestKeycloak_MCPServer_PasswordGrant (0.00s)
 PASS
-ok  	github.com/panyam/mcpkit/tests/keycloak	0.425s
+ok  	github.com/panyam/mcpkit/tests/keycloak	0.494s
 make[2]: *** No rule to make target `downkcl'.  Stop.
   PASS: keycloak
 
 === Results: 9 passed, 0 failed ===
-Finished: Tue Apr 14 01:08:59 PDT 2026
+Finished: Tue Apr 14 02:14:07 PDT 2026


### PR DESCRIPTION
## Summary

Adds auto-completion support to protogen via `completable_fields` on `mcp_resource` and `mcp_prompt` annotations.

### Proto annotations
```proto
rpc GetBook(GetBookRequest) returns (GetBookResponse) {
  option (mcp.v1.mcp_resource) = {
    uri_template: "book://{book_id}"
    completable_fields: "book_id"
  };
};

rpc SummarizeBook(SummarizeRequest) returns (SummarizeResponse) {
  option (mcp.v1.mcp_prompt) = {
    name: "summarize"
    completable_fields: "book_id"
  };
};
```

### Generated code
- `BookServiceMCPCompleter` interface with `CompleteBookId(ctx, ref, arg)` 
- `RegisterBookServiceMCPCompletions(srv, completer)` — registers handlers with switch dispatch
- Shared fields across prompts/resources produce one deduplicated interface method

### Design decisions
- Method-level annotation (not field-level) — keeps all MCP annotations at method/service level
- Interface per field, not per ref — user implements `CompleteBookId` once, shared across resource and prompt
- No `context.arguments` support yet — draft spec feature, will add when stable

## Test plan
- [x] 5 new generator tests: prompt completion, resource completion, deduplication, no completions, method name conversion
- [x] 1 new e2e test: completion/complete round-trip through bookservice
- [x] All existing tests pass (no regressions)
- [x] `make test-e2e` passes with regenerated bookservice

Also created #227 for maxItems=100 enforcement in core.

Closes #219