### PR TITLE
ext/ui: bridge enhancements — styles, AbortSignal, bidirectional (#235)

### DIFF
--- a/ext/ui/assets/mcp-app-bridge.d.ts
+++ b/ext/ui/assets/mcp-app-bridge.d.ts
@@ -25,6 +25,11 @@ interface HostContext {
   theme?: string;
   locale?: string;
   dimensions?: { width: number; height: number };
+  styles?: {
+    variables?: Record<string, string>;
+    css?: { fonts?: string };
+  };
+  safeAreaInsets?: { top: number; right: number; bottom: number; left: number };
   [key: string]: unknown;
 }
 
@@ -37,6 +42,14 @@ interface MCPAppEventMap {
   toolcancelled: { tool: string };
   hostcontextchanged: { hostContext: HostContext };
   teardown: Record<string, never>;
+}
+
+/** Options for request methods. */
+interface RequestOptions {
+  /** AbortSignal for cancellation. */
+  signal?: AbortSignal;
+  /** Timeout in milliseconds (shorthand for AbortSignal.timeout). */
+  timeout?: number;
 }
 
 /** Result from callTool(). */
@@ -58,16 +71,31 @@ interface ResourceReadResult {
   [key: string]: unknown;
 }
 
+/** Handler for incoming tool calls from the host. */
+type CallToolHandler = (params: {
+  name: string;
+  arguments: Record<string, unknown>;
+}) => unknown | Promise<unknown>;
+
+/** Handler for incoming list-tools requests from the host. */
+type ListToolsHandler = () =>
+  | Array<{ name: string; description?: string; inputSchema?: unknown }>
+  | Promise<
+      Array<{ name: string; description?: string; inputSchema?: unknown }>
+    >;
+
 /** The global MCPApp bridge singleton. */
 interface MCPAppBridge {
   /** True after the ui/initialize handshake completes with the host. */
   readonly connected: boolean;
 
-  /** Host context (theme, locale, dimensions) from initialization. */
+  /** Host context (theme, locale, dimensions, styles) from initialization. */
   readonly hostContext: HostContext | null;
 
   /** Host capabilities from initialization. */
   readonly hostCapabilities: Record<string, unknown> | null;
+
+  // --- Events ---
 
   /** Subscribe to an event. Returns an unsubscribe function. */
   on<E extends MCPAppEvent>(
@@ -87,20 +115,23 @@ interface MCPAppBridge {
     handler: (data: MCPAppEventMap[E]) => void
   ): () => void;
 
+  // --- Host-bound methods ---
+
   /** Call a tool on the MCP server (proxied through the host). */
   callTool(
     name: string,
-    args?: Record<string, unknown>
+    args?: Record<string, unknown>,
+    options?: RequestOptions
   ): Promise<ToolCallResult>;
 
   /** Read a resource from the MCP server. */
-  readResource(uri: string): Promise<ResourceReadResult>;
+  readResource(uri: string, options?: RequestOptions): Promise<ResourceReadResult>;
 
   /** Send a message to the conversation. */
-  sendMessage(message: unknown): Promise<unknown>;
+  sendMessage(message: unknown, options?: RequestOptions): Promise<unknown>;
 
   /** Update the model context visible to the LLM. */
-  updateModelContext(context: unknown): Promise<unknown>;
+  updateModelContext(context: unknown, options?: RequestOptions): Promise<unknown>;
 
   /** Open a URL in the host browser (not inside the iframe). */
   openLink(url: string): void;
@@ -109,13 +140,40 @@ interface MCPAppBridge {
   downloadFile(url: string, filename?: string): void;
 
   /** Request a display mode change (inline, fullscreen, pip). */
-  requestDisplayMode(mode: string): Promise<unknown>;
+  requestDisplayMode(mode: string, options?: RequestOptions): Promise<unknown>;
 
   /** Request app teardown. */
   requestTeardown(): void;
 
   /** Send a log message to the host. */
   log(level: string, message: string, data?: unknown): void;
+
+  // --- Style utilities ---
+
+  /** Apply theme to document root (sets data-theme + color-scheme). */
+  applyTheme(theme: string): void;
+
+  /** Apply CSS custom properties from host styles. */
+  applyStyleVariables(
+    variables: Record<string, string>,
+    root?: HTMLElement
+  ): void;
+
+  /** Inject host font CSS (idempotent — only injects once). */
+  applyFonts(fontCss: string): void;
+
+  /** Apply all available styles from a host context (theme + variables + fonts). */
+  applyHostStyles(ctx: HostContext): void;
+
+  // --- Bidirectional handlers (host → app) ---
+
+  /** Handler for tools/call requests from the host. */
+  oncalltool: CallToolHandler | null;
+
+  /** Handler for tools/list requests from the host. */
+  onlisttools: ListToolsHandler | null;
+
+  // --- Utility ---
 
   /** Returns true if running inside an MCP Apps host. */
   isHosted(): boolean;

--- a/ext/ui/assets/mcp-app-bridge.js
+++ b/ext/ui/assets/mcp-app-bridge.js
@@ -32,6 +32,9 @@
     let _connected = false;
     let _hostContext = null;
     let _hostCapabilities = null;
+    // Bidirectional handlers (host → app requests).
+    let _oncalltool = null;
+    let _onlisttools = null;
     // --- Event emitter -------------------------------------------------------
     function on(event, handler) {
         let set = listeners.get(event);
@@ -79,21 +82,45 @@
             window.parent.postMessage(msg, "*");
         }
     }
-    function request(method, params) {
+    function request(method, params, options) {
         if (!_connected && method !== "ui/initialize") {
             return Promise.reject(new Error("Not connected to MCP host"));
         }
+        // Resolve signal: explicit signal > timeout shorthand > default 30s.
+        let signal = options === null || options === void 0 ? void 0 : options.signal;
+        if (!signal && (options === null || options === void 0 ? void 0 : options.timeout)) {
+            signal = AbortSignal.timeout(options.timeout);
+        }
         return new Promise((resolve, reject) => {
+            var _a;
             const id = nextId++;
+            const cleanup = () => { pending.delete(id); };
             pending.set(id, { resolve, reject });
             send({ jsonrpc: "2.0", id, method, params: params || {} });
-            // Timeout after 30 seconds.
-            setTimeout(() => {
-                if (pending.has(id)) {
-                    pending.delete(id);
-                    reject(new Error("Request timeout: " + method));
+            // AbortSignal-based cancellation.
+            if (signal) {
+                if (signal.aborted) {
+                    cleanup();
+                    reject(new Error(((_a = signal.reason) === null || _a === void 0 ? void 0 : _a.message) || "Aborted"));
+                    return;
                 }
-            }, 30000);
+                signal.addEventListener("abort", () => {
+                    var _a;
+                    if (pending.has(id)) {
+                        cleanup();
+                        reject(new Error(((_a = signal.reason) === null || _a === void 0 ? void 0 : _a.message) || "Aborted: " + method));
+                    }
+                }, { once: true });
+            }
+            else {
+                // Default 30s timeout when no signal provided.
+                setTimeout(() => {
+                    if (pending.has(id)) {
+                        cleanup();
+                        reject(new Error("Request timeout: " + method));
+                    }
+                }, 30000);
+            }
         });
     }
     function notify(method, params) {
@@ -124,8 +151,13 @@
             }
             return;
         }
-        // Notification or request from host.
+        // Request from host (has both id and method) — bidirectional call.
         const req = msg;
+        if (req.id != null && req.method) {
+            handleHostRequest(req);
+            return;
+        }
+        // Notification from host (no id, only method).
         switch (req.method) {
             case "ui/notifications/tool-input": {
                 const p = (req.params || {});
@@ -153,6 +185,7 @@
             case "ui/notifications/host-context-changed": {
                 const p = (req.params || {});
                 _hostContext = p.hostContext || p;
+                applyHostStyles(_hostContext);
                 emit("hostcontextchanged", { hostContext: _hostContext });
                 break;
             }
@@ -194,6 +227,94 @@
             });
         }
     }
+    // --- Style utilities -----------------------------------------------------
+    function applyTheme(theme) {
+        const root = document.documentElement;
+        root.setAttribute("data-theme", theme);
+        root.style.colorScheme = theme;
+    }
+    function applyStyleVariables(variables, root = document.documentElement) {
+        for (const [key, value] of Object.entries(variables)) {
+            if (value !== undefined) {
+                root.style.setProperty(key, value);
+            }
+        }
+    }
+    const FONTS_STYLE_ID = "__mcp-host-fonts";
+    function applyFonts(fontCss) {
+        if (document.getElementById(FONTS_STYLE_ID))
+            return;
+        const style = document.createElement("style");
+        style.id = FONTS_STYLE_ID;
+        style.textContent = fontCss;
+        document.head.appendChild(style);
+    }
+    /** Apply all available styles from the host context. */
+    function applyHostStyles(ctx) {
+        var _a, _b, _c;
+        if (ctx.theme)
+            applyTheme(ctx.theme);
+        if ((_a = ctx.styles) === null || _a === void 0 ? void 0 : _a.variables)
+            applyStyleVariables(ctx.styles.variables);
+        if ((_c = (_b = ctx.styles) === null || _b === void 0 ? void 0 : _b.css) === null || _c === void 0 ? void 0 : _c.fonts)
+            applyFonts(ctx.styles.css.fonts);
+    }
+    // --- Bidirectional handlers (host → app requests) -----------------------
+    /** Respond to a JSON-RPC request from the host. */
+    function respond(id, result, error) {
+        if (error) {
+            send({
+                jsonrpc: "2.0",
+                id,
+                error: {
+                    code: -32000,
+                    message: String(error),
+                },
+            });
+        }
+        else {
+            send({ jsonrpc: "2.0", id, result });
+        }
+    }
+    async function handleHostRequest(req) {
+        if (req.id == null)
+            return; // Not a request, just a notification.
+        const id = req.id;
+        const params = (req.params || {});
+        try {
+            switch (req.method) {
+                case "tools/call": {
+                    if (_oncalltool) {
+                        const result = await _oncalltool({
+                            name: params.name || "",
+                            arguments: params.arguments || {},
+                        });
+                        respond(id, result);
+                    }
+                    else {
+                        respond(id, null, "No oncalltool handler registered");
+                    }
+                    break;
+                }
+                case "tools/list": {
+                    if (_onlisttools) {
+                        const tools = await _onlisttools();
+                        respond(id, { tools });
+                    }
+                    else {
+                        respond(id, { tools: [] });
+                    }
+                    break;
+                }
+                default:
+                    respond(id, null, "Method not found: " + req.method);
+                    break;
+            }
+        }
+        catch (e) {
+            respond(id, null, e instanceof Error ? e.message : String(e));
+        }
+    }
     // --- Initialize handshake ------------------------------------------------
     function initialize() {
         // Only attempt if we're inside an iframe.
@@ -213,6 +334,8 @@
             _connected = true;
             _hostContext = (result === null || result === void 0 ? void 0 : result.hostContext) || result || {};
             _hostCapabilities = (result === null || result === void 0 ? void 0 : result.capabilities) || {};
+            // Auto-apply host styles on connect.
+            applyHostStyles(_hostContext);
             emit("connected", {
                 hostContext: _hostContext,
                 capabilities: _hostCapabilities,
@@ -242,21 +365,21 @@
         on,
         off,
         once,
-        // Host-bound methods.
-        callTool(name, args) {
+        // Host-bound methods (all support optional RequestOptions).
+        callTool(name, args, options) {
             return request("tools/call", {
                 name,
                 arguments: args || {},
-            });
+            }, options);
         },
-        readResource(uri) {
-            return request("resources/read", { uri });
+        readResource(uri, options) {
+            return request("resources/read", { uri }, options);
         },
-        sendMessage(message) {
-            return request("ui/message", { message });
+        sendMessage(message, options) {
+            return request("ui/message", { message }, options);
         },
-        updateModelContext(context) {
-            return request("ui/update-model-context", { context });
+        updateModelContext(context, options) {
+            return request("ui/update-model-context", { context }, options);
         },
         openLink(url) {
             notify("ui/open-link", { url });
@@ -264,8 +387,8 @@
         downloadFile(url, filename) {
             notify("ui/download-file", { url, filename });
         },
-        requestDisplayMode(mode) {
-            return request("ui/request-display-mode", { mode });
+        requestDisplayMode(mode, options) {
+            return request("ui/request-display-mode", { mode }, options);
         },
         requestTeardown() {
             notify("ui/teardown", {});
@@ -273,6 +396,16 @@
         log(level, message, data) {
             notify("ui/log", { level, message, data });
         },
+        // Style utilities.
+        applyTheme,
+        applyStyleVariables,
+        applyFonts,
+        applyHostStyles,
+        // Bidirectional handlers (set these before connecting).
+        set oncalltool(handler) { _oncalltool = handler; },
+        get oncalltool() { return _oncalltool; },
+        set onlisttools(handler) { _onlisttools = handler; },
+        get onlisttools() { return _onlisttools; },
         // Utility.
         isHosted() {
             return _connected;

--- a/ext/ui/assets/mcp-app-bridge.test.ts
+++ b/ext/ui/assets/mcp-app-bridge.test.ts
@@ -373,6 +373,176 @@ describe("outbound requests", () => {
   });
 });
 
+describe("style utilities", () => {
+  beforeEach(async () => {
+    autoRespondToInitialize();
+    await waitForConnect();
+  });
+
+  it("auto-applies theme on connect", async () => {
+    // The auto-respond sends theme: "dark"
+    expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+    expect(document.documentElement.style.colorScheme).toBe("dark");
+  });
+
+  it("applyTheme sets data-theme and color-scheme", () => {
+    (window as any).MCPApp.applyTheme("light");
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+    expect(document.documentElement.style.colorScheme).toBe("light");
+  });
+
+  it("applyStyleVariables sets CSS custom properties", () => {
+    (window as any).MCPApp.applyStyleVariables({
+      "--color-bg": "#fff",
+      "--color-text": "#000",
+    });
+    expect(
+      document.documentElement.style.getPropertyValue("--color-bg")
+    ).toBe("#fff");
+    expect(
+      document.documentElement.style.getPropertyValue("--color-text")
+    ).toBe("#000");
+  });
+
+  it("applyFonts injects style tag once", () => {
+    (window as any).MCPApp.applyFonts("@font-face { font-family: Test; }");
+    const style = document.getElementById("__mcp-host-fonts");
+    expect(style).toBeDefined();
+    expect(style?.textContent).toContain("@font-face");
+
+    // Second call is a no-op.
+    (window as any).MCPApp.applyFonts("@font-face { font-family: Other; }");
+    expect(document.querySelectorAll("#__mcp-host-fonts").length).toBe(1);
+  });
+
+  it("auto-applies styles on host-context-changed", () => {
+    hostSends({
+      jsonrpc: "2.0",
+      method: "ui/notifications/host-context-changed",
+      params: {
+        hostContext: {
+          theme: "light",
+          styles: { variables: { "--accent": "blue" } },
+        },
+      },
+    });
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+    expect(
+      document.documentElement.style.getPropertyValue("--accent")
+    ).toBe("blue");
+  });
+});
+
+describe("AbortSignal support", () => {
+  beforeEach(async () => {
+    autoRespondToInitialize();
+    await waitForConnect();
+  });
+
+  it("callTool with timeout rejects on timeout", async () => {
+    const promise = (window as any).MCPApp.callTool("slow", {}, { timeout: 50 });
+    // Don't respond — let it timeout.
+    await expect(promise).rejects.toThrow(/abort|timed out/i);
+  });
+
+  it("callTool with signal rejects on abort", async () => {
+    const controller = new AbortController();
+    const promise = (window as any).MCPApp.callTool("test", {}, {
+      signal: controller.signal,
+    });
+    controller.abort(new Error("user cancelled"));
+    await expect(promise).rejects.toThrow("user cancelled");
+  });
+
+  it("callTool with pre-aborted signal rejects immediately", async () => {
+    const signal = AbortSignal.abort(new Error("already aborted"));
+    await expect(
+      (window as any).MCPApp.callTool("test", {}, { signal })
+    ).rejects.toThrow("already aborted");
+  });
+});
+
+describe("bidirectional tool calls", () => {
+  beforeEach(async () => {
+    autoRespondToInitialize();
+    await waitForConnect();
+  });
+
+  it("oncalltool handles incoming tools/call request", async () => {
+    (window as any).MCPApp.oncalltool = (params: any) => {
+      return { content: [{ type: "text", text: "result:" + params.name }] };
+    };
+
+    hostSends({
+      jsonrpc: "2.0",
+      id: 999,
+      method: "tools/call",
+      params: { name: "app-tool", arguments: { x: 1 } },
+    });
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    const resp = sentMessages.find(
+      (m) => m.id === 999 && m.result
+    );
+    expect(resp).toBeDefined();
+    expect(resp.result.content[0].text).toBe("result:app-tool");
+  });
+
+  it("onlisttools handles incoming tools/list request", async () => {
+    (window as any).MCPApp.onlisttools = () => {
+      return [{ name: "app-tool", description: "An app tool" }];
+    };
+
+    hostSends({
+      jsonrpc: "2.0",
+      id: 888,
+      method: "tools/list",
+      params: {},
+    });
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    const resp = sentMessages.find((m) => m.id === 888 && m.result);
+    expect(resp).toBeDefined();
+    expect(resp.result.tools[0].name).toBe("app-tool");
+  });
+
+  it("returns error when no oncalltool handler set", async () => {
+    (window as any).MCPApp.oncalltool = null;
+
+    hostSends({
+      jsonrpc: "2.0",
+      id: 777,
+      method: "tools/call",
+      params: { name: "missing" },
+    });
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    const resp = sentMessages.find((m) => m.id === 777 && m.error);
+    expect(resp).toBeDefined();
+    expect(resp.error.message).toContain("No oncalltool handler");
+  });
+
+  it("returns empty tools when no onlisttools handler set", async () => {
+    (window as any).MCPApp.onlisttools = null;
+
+    hostSends({
+      jsonrpc: "2.0",
+      id: 666,
+      method: "tools/list",
+      params: {},
+    });
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    const resp = sentMessages.find((m) => m.id === 666 && m.result);
+    expect(resp).toBeDefined();
+    expect(resp.result.tools).toEqual([]);
+  });
+});
+
 describe("graceful degradation", () => {
   it("callTool rejects when not connected", async () => {
     expect((window as any).MCPApp.connected).toBe(false);

--- a/ext/ui/assets/mcp-app-bridge.ts
+++ b/ext/ui/assets/mcp-app-bridge.ts
@@ -40,8 +40,37 @@ interface HostContext {
   theme?: string;
   locale?: string;
   dimensions?: { width: number; height: number };
+  styles?: {
+    variables?: Record<string, string>;
+    css?: { fonts?: string };
+  };
+  safeAreaInsets?: {
+    top: number;
+    right: number;
+    bottom: number;
+    left: number;
+  };
   [key: string]: unknown;
 }
+
+/** Options for request methods (callTool, readResource, etc.). */
+interface RequestOptions {
+  /** AbortSignal for cancellation. */
+  signal?: AbortSignal;
+  /** Timeout in milliseconds (shorthand for AbortSignal.timeout). */
+  timeout?: number;
+}
+
+/** Handler for incoming tool calls from the host. */
+type CallToolHandler = (params: {
+  name: string;
+  arguments: Record<string, unknown>;
+}) => unknown | Promise<unknown>;
+
+/** Handler for incoming list-tools requests from the host. */
+type ListToolsHandler = () =>
+  | Array<{ name: string; description?: string; inputSchema?: unknown }>
+  | Promise<Array<{ name: string; description?: string; inputSchema?: unknown }>>;
 
 interface ToolCallResult {
   content?: Array<{ type: string; text?: string; [k: string]: unknown }>;
@@ -109,6 +138,10 @@ type JsonRpcMessage = JsonRpcRequest | JsonRpcResponse;
   let _hostContext: HostContext | null = null;
   let _hostCapabilities: Record<string, unknown> | null = null;
 
+  // Bidirectional handlers (host → app requests).
+  let _oncalltool: CallToolHandler | null = null;
+  let _onlisttools: ListToolsHandler | null = null;
+
   // --- Event emitter -------------------------------------------------------
 
   function on<E extends MCPAppEvent>(
@@ -171,21 +204,50 @@ type JsonRpcMessage = JsonRpcRequest | JsonRpcResponse;
     }
   }
 
-  function request(method: string, params?: unknown): Promise<unknown> {
+  function request(
+    method: string,
+    params?: unknown,
+    options?: RequestOptions
+  ): Promise<unknown> {
     if (!_connected && method !== "ui/initialize") {
       return Promise.reject(new Error("Not connected to MCP host"));
     }
+
+    // Resolve signal: explicit signal > timeout shorthand > default 30s.
+    let signal = options?.signal;
+    if (!signal && options?.timeout) {
+      signal = AbortSignal.timeout(options.timeout);
+    }
+
     return new Promise((resolve, reject) => {
       const id = nextId++;
+      const cleanup = () => { pending.delete(id); };
+
       pending.set(id, { resolve, reject });
       send({ jsonrpc: "2.0", id, method, params: params || {} });
-      // Timeout after 30 seconds.
-      setTimeout(() => {
-        if (pending.has(id)) {
-          pending.delete(id);
-          reject(new Error("Request timeout: " + method));
+
+      // AbortSignal-based cancellation.
+      if (signal) {
+        if (signal.aborted) {
+          cleanup();
+          reject(new Error(signal.reason?.message || "Aborted"));
+          return;
         }
-      }, 30000);
+        signal.addEventListener("abort", () => {
+          if (pending.has(id)) {
+            cleanup();
+            reject(new Error(signal!.reason?.message || "Aborted: " + method));
+          }
+        }, { once: true });
+      } else {
+        // Default 30s timeout when no signal provided.
+        setTimeout(() => {
+          if (pending.has(id)) {
+            cleanup();
+            reject(new Error("Request timeout: " + method));
+          }
+        }, 30000);
+      }
     });
   }
 
@@ -222,8 +284,14 @@ type JsonRpcMessage = JsonRpcRequest | JsonRpcResponse;
       return;
     }
 
-    // Notification or request from host.
+    // Request from host (has both id and method) — bidirectional call.
     const req = msg as JsonRpcRequest;
+    if (req.id != null && req.method) {
+      handleHostRequest(req);
+      return;
+    }
+
+    // Notification from host (no id, only method).
     switch (req.method) {
       case "ui/notifications/tool-input": {
         const p = (req.params || {}) as any;
@@ -251,6 +319,7 @@ type JsonRpcMessage = JsonRpcRequest | JsonRpcResponse;
       case "ui/notifications/host-context-changed": {
         const p = (req.params || {}) as any;
         _hostContext = p.hostContext || p;
+        applyHostStyles(_hostContext!);
         emit("hostcontextchanged", { hostContext: _hostContext! });
         break;
       }
@@ -292,6 +361,98 @@ type JsonRpcMessage = JsonRpcRequest | JsonRpcResponse;
     }
   }
 
+  // --- Style utilities -----------------------------------------------------
+
+  function applyTheme(theme: string): void {
+    const root = document.documentElement;
+    root.setAttribute("data-theme", theme);
+    root.style.colorScheme = theme;
+  }
+
+  function applyStyleVariables(
+    variables: Record<string, string>,
+    root: HTMLElement = document.documentElement
+  ): void {
+    for (const [key, value] of Object.entries(variables)) {
+      if (value !== undefined) {
+        root.style.setProperty(key, value);
+      }
+    }
+  }
+
+  const FONTS_STYLE_ID = "__mcp-host-fonts";
+
+  function applyFonts(fontCss: string): void {
+    if (document.getElementById(FONTS_STYLE_ID)) return;
+    const style = document.createElement("style");
+    style.id = FONTS_STYLE_ID;
+    style.textContent = fontCss;
+    document.head.appendChild(style);
+  }
+
+  /** Apply all available styles from the host context. */
+  function applyHostStyles(ctx: HostContext): void {
+    if (ctx.theme) applyTheme(ctx.theme);
+    if (ctx.styles?.variables) applyStyleVariables(ctx.styles.variables);
+    if (ctx.styles?.css?.fonts) applyFonts(ctx.styles.css.fonts);
+  }
+
+  // --- Bidirectional handlers (host → app requests) -----------------------
+
+  /** Respond to a JSON-RPC request from the host. */
+  function respond(id: number, result: unknown, error?: unknown): void {
+    if (error) {
+      send({
+        jsonrpc: "2.0",
+        id,
+        error: {
+          code: -32000,
+          message: String(error),
+        },
+      } as any);
+    } else {
+      send({ jsonrpc: "2.0", id, result } as any);
+    }
+  }
+
+  async function handleHostRequest(req: JsonRpcRequest): Promise<void> {
+    if (req.id == null) return; // Not a request, just a notification.
+
+    const id = req.id;
+    const params = (req.params || {}) as any;
+
+    try {
+      switch (req.method) {
+        case "tools/call": {
+          if (_oncalltool) {
+            const result = await _oncalltool({
+              name: params.name || "",
+              arguments: params.arguments || {},
+            });
+            respond(id, result);
+          } else {
+            respond(id, null, "No oncalltool handler registered");
+          }
+          break;
+        }
+        case "tools/list": {
+          if (_onlisttools) {
+            const tools = await _onlisttools();
+            respond(id, { tools });
+          } else {
+            respond(id, { tools: [] });
+          }
+          break;
+        }
+        default:
+          respond(id, null, "Method not found: " + req.method);
+          break;
+      }
+    } catch (e) {
+      respond(id, null, e instanceof Error ? e.message : String(e));
+    }
+  }
+
   // --- Initialize handshake ------------------------------------------------
 
   function initialize(): void {
@@ -313,6 +474,8 @@ type JsonRpcMessage = JsonRpcRequest | JsonRpcResponse;
         _connected = true;
         _hostContext = result?.hostContext || result || {};
         _hostCapabilities = result?.capabilities || {};
+        // Auto-apply host styles on connect.
+        applyHostStyles(_hostContext!);
         emit("connected", {
           hostContext: _hostContext!,
           capabilities: _hostCapabilities!,
@@ -346,27 +509,28 @@ type JsonRpcMessage = JsonRpcRequest | JsonRpcResponse;
     off,
     once,
 
-    // Host-bound methods.
+    // Host-bound methods (all support optional RequestOptions).
     callTool(
       name: string,
-      args?: Record<string, unknown>
+      args?: Record<string, unknown>,
+      options?: RequestOptions
     ): Promise<ToolCallResult> {
       return request("tools/call", {
         name,
         arguments: args || {},
-      }) as Promise<ToolCallResult>;
+      }, options) as Promise<ToolCallResult>;
     },
 
-    readResource(uri: string): Promise<ResourceReadResult> {
-      return request("resources/read", { uri }) as Promise<ResourceReadResult>;
+    readResource(uri: string, options?: RequestOptions): Promise<ResourceReadResult> {
+      return request("resources/read", { uri }, options) as Promise<ResourceReadResult>;
     },
 
-    sendMessage(message: unknown): Promise<unknown> {
-      return request("ui/message", { message });
+    sendMessage(message: unknown, options?: RequestOptions): Promise<unknown> {
+      return request("ui/message", { message }, options);
     },
 
-    updateModelContext(context: unknown): Promise<unknown> {
-      return request("ui/update-model-context", { context });
+    updateModelContext(context: unknown, options?: RequestOptions): Promise<unknown> {
+      return request("ui/update-model-context", { context }, options);
     },
 
     openLink(url: string): void {
@@ -377,8 +541,8 @@ type JsonRpcMessage = JsonRpcRequest | JsonRpcResponse;
       notify("ui/download-file", { url, filename });
     },
 
-    requestDisplayMode(mode: string): Promise<unknown> {
-      return request("ui/request-display-mode", { mode });
+    requestDisplayMode(mode: string, options?: RequestOptions): Promise<unknown> {
+      return request("ui/request-display-mode", { mode }, options);
     },
 
     requestTeardown(): void {
@@ -388,6 +552,18 @@ type JsonRpcMessage = JsonRpcRequest | JsonRpcResponse;
     log(level: string, message: string, data?: unknown): void {
       notify("ui/log", { level, message, data });
     },
+
+    // Style utilities.
+    applyTheme,
+    applyStyleVariables,
+    applyFonts,
+    applyHostStyles,
+
+    // Bidirectional handlers (set these before connecting).
+    set oncalltool(handler: CallToolHandler | null) { _oncalltool = handler; },
+    get oncalltool(): CallToolHandler | null { return _oncalltool; },
+    set onlisttools(handler: ListToolsHandler | null) { _onlisttools = handler; },
+    get onlisttools(): ListToolsHandler | null { return _onlisttools; },
 
     // Utility.
     isHosted(): boolean {

--- a/ext/ui/tests/playwright/app.html
+++ b/ext/ui/tests/playwright/app.html
@@ -12,6 +12,7 @@
   <div id="status">not connected</div>
   <div id="result">no result</div>
   <div id="theme">no theme</div>
+  <div id="style-var">no style var</div>
   <button id="call-tool">Call Tool</button>
   <button id="open-link">Open Link</button>
 
@@ -22,6 +23,7 @@
     var statusEl = document.getElementById('status');
     var resultEl = document.getElementById('result');
     var themeEl = document.getElementById('theme');
+    var styleVarEl = document.getElementById('style-var');
 
     MCPApp.on('connected', function(data) {
       statusEl.textContent = 'connected';
@@ -37,6 +39,21 @@
       }
       resultEl.textContent = text || JSON.stringify(data.result);
     });
+
+    MCPApp.on('hostcontextchanged', function(data) {
+      themeEl.textContent = data.hostContext.theme || themeEl.textContent;
+      var accent = getComputedStyle(document.documentElement).getPropertyValue('--accent');
+      if (accent) styleVarEl.textContent = accent.trim();
+    });
+
+    // Register app-side tool for bidirectional tests.
+    MCPApp.oncalltool = function(params) {
+      return { content: [{ type: 'text', text: 'app-handled:' + params.name }] };
+    };
+
+    MCPApp.onlisttools = function() {
+      return [{ name: 'app-tool', description: 'A tool provided by the app' }];
+    };
 
     document.getElementById('call-tool').addEventListener('click', function() {
       MCPApp.callTool('test_tool', { value: 42 }).then(function(res) {

--- a/ext/ui/tests/playwright/bridge.spec.ts
+++ b/ext/ui/tests/playwright/bridge.spec.ts
@@ -109,23 +109,71 @@ test.describe("MCP App Bridge — fake host integration", () => {
     expect(logs.length).toBeGreaterThan(0);
   });
 
-  test("host-context-changed updates iframe", async ({ page }) => {
+  test("host-context-changed applies theme and style variables", async ({
+    page,
+  }) => {
     const frame = page.frameLocator("#app-frame");
 
-    // Verify initial theme.
+    // Verify initial theme from connect.
     await expect(frame.locator("#theme")).toHaveText("dark");
 
-    // The app.html doesn't have a hostcontextchanged handler that updates
-    // the UI, but we can verify the bridge processes it without error.
+    // Send context change with theme + style variables.
     await page.evaluate(() => {
       (window as any).__sendToApp({
         jsonrpc: "2.0",
         method: "ui/notifications/host-context-changed",
-        params: { hostContext: { theme: "light" } },
+        params: {
+          hostContext: {
+            theme: "light",
+            styles: { variables: { "--accent": "blue" } },
+          },
+        },
       });
     });
 
-    // No crash — bridge handled it gracefully.
-    await expect(frame.locator("#status")).toHaveText("connected");
+    await expect(frame.locator("#theme")).toHaveText("light");
+    await expect(frame.locator("#style-var")).toHaveText("blue");
+  });
+
+  test("bidirectional: host calls tool on app", async ({ page }) => {
+    // Host sends a tools/call request to the app iframe.
+    await page.evaluate(() => {
+      (window as any).__sendToApp({
+        jsonrpc: "2.0",
+        id: 9001,
+        method: "tools/call",
+        params: { name: "app-action", arguments: { key: "val" } },
+      });
+    });
+
+    await page.waitForTimeout(100);
+
+    // Verify the app responded.
+    const resp = await page.evaluate(() => {
+      return (window as any).__hostLog.find(
+        (m: any) => m.direction === "in" && m.id === 9001
+      );
+    });
+    expect(resp).toBeDefined();
+  });
+
+  test("bidirectional: host lists app tools", async ({ page }) => {
+    await page.evaluate(() => {
+      (window as any).__sendToApp({
+        jsonrpc: "2.0",
+        id: 9002,
+        method: "tools/list",
+        params: {},
+      });
+    });
+
+    await page.waitForTimeout(100);
+
+    const resp = await page.evaluate(() => {
+      return (window as any).__hostLog.find(
+        (m: any) => m.direction === "in" && m.id === 9002
+      );
+    });
+    expect(resp).toBeDefined();
   });
 });

--- a/tests/reports/report.html
+++ b/tests/reports/report.html
@@ -15,7 +15,7 @@ th { background: #f5f5f5; font-weight: 600; }
 pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto; font-size: 13px; max-height: 400px; overflow-y: auto; }
 </style></head><body>
 <h1>MCPKit Test Report</h1>
-<div class='meta'>Branch: <strong>main</strong> | Commit: <code>c7fd499</code> | Date: 2026-04-15 02:31:34</div>
+<div class='meta'>Branch: <strong>feature/bridge-enhancements</strong> | Commit: <code>61fa4ee</code> | Date: 2026-04-15 03:04:36</div>
 <table><tr><th>Stage</th><th>Result</th></tr>
 <tr><td>unit+coverage</td><td class='pass'>PASS</td></tr>
 <tr><td>race</td><td class='pass'>PASS</td></tr>
@@ -30,66 +30,66 @@ pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto; 
 <div class='summary-pass'>All 9 stages passed</div>
 <h2>Full Log</h2><pre>
 === MCPKit Comprehensive Test Suite ===
-Started: Wed Apr 15 02:28:31 PDT 2026
+Started: Wed Apr 15 03:01:42 PDT 2026
 
 --- [1/9] unit+coverage ---
-ok  	github.com/panyam/mcpkit/client	8.913s	coverage: 67.5% of statements
+ok  	github.com/panyam/mcpkit/client	9.105s	coverage: 67.5% of statements
 	github.com/panyam/mcpkit/cmd/testserver		coverage: 0.0% of statements
-ok  	github.com/panyam/mcpkit/core	0.519s	coverage: 49.3% of statements
-ok  	github.com/panyam/mcpkit/server	14.032s	coverage: 78.4% of statements
-ok  	github.com/panyam/mcpkit/testutil	0.913s	coverage: 70.5% of statements
+ok  	github.com/panyam/mcpkit/core	0.327s	coverage: 49.3% of statements
+ok  	github.com/panyam/mcpkit/server	13.876s	coverage: 78.4% of statements
+ok  	github.com/panyam/mcpkit/testutil	1.278s	coverage: 70.5% of statements
 Coverage report: tests/reports/coverage.html
   PASS: unit+coverage
 --- [2/9] race ---
-ok  	github.com/panyam/mcpkit/client	8.999s
+ok  	github.com/panyam/mcpkit/client	9.026s
 ?   	github.com/panyam/mcpkit/cmd/testserver	[no test files]
-ok  	github.com/panyam/mcpkit/core	1.666s
-ok  	github.com/panyam/mcpkit/server	15.182s
-ok  	github.com/panyam/mcpkit/testutil	1.813s
+ok  	github.com/panyam/mcpkit/core	2.035s
+ok  	github.com/panyam/mcpkit/server	14.795s
+ok  	github.com/panyam/mcpkit/testutil	2.429s
   PASS: race
 --- [3/9] auth ---
-ok  	github.com/panyam/mcpkit/ext/auth	0.634s
+ok  	github.com/panyam/mcpkit/ext/auth	0.377s
   PASS: auth
 --- [4/9] ui ---
-ok  	github.com/panyam/mcpkit/ext/ui	0.547s
+ok  	github.com/panyam/mcpkit/ext/ui	0.276s
 
-&gt; @mcpkit/app-bridge@0.1.0 test /Users/dzshrh/newstack/mcpkit/protocol-bundle/ext/ui/assets
+&gt; @mcpkit/app-bridge@0.1.0 test /Users/dzshrh/newstack/mcpkit/main/ext/ui/assets
 &gt; vitest run
 
 
- RUN  v3.2.4 /Users/dzshrh/newstack/mcpkit/protocol-bundle/ext/ui/assets
+ RUN  v3.2.4 /Users/dzshrh/newstack/mcpkit/main/ext/ui/assets
 
- ✓ mcp-app-bridge.test.ts (21 tests) 142ms
+ ✓ mcp-app-bridge.test.ts (33 tests) 389ms
 
  Test Files  1 passed (1)
-      Tests  21 passed (21)
-   Start at  02:29:10
-   Duration  848ms (transform 26ms, setup 0ms, collect 27ms, tests 142ms, environment 342ms, prepare 131ms)
+      Tests  33 passed (33)
+   Start at  03:02:15
+   Duration  964ms (transform 30ms, setup 0ms, collect 27ms, tests 389ms, environment 290ms, prepare 83ms)
 
   PASS: ui
 --- [5/9] protogen ---
 ?   	github.com/panyam/mcpkit/ext/protogen/cmd/protoc-gen-go-mcp	[no test files]
-ok  	github.com/panyam/mcpkit/ext/protogen/generator	0.620s
-ok  	github.com/panyam/mcpkit/ext/protogen/proto/mcp/v1	0.659s
-ok  	github.com/panyam/mcpkit/ext/protogen/runtime	1.191s
-ok  	github.com/panyam/mcpkit/ext/protogen/schema	1.240s
+ok  	github.com/panyam/mcpkit/ext/protogen/generator	1.170s
+ok  	github.com/panyam/mcpkit/ext/protogen/proto/mcp/v1	0.864s
+ok  	github.com/panyam/mcpkit/ext/protogen/runtime	1.467s
+ok  	github.com/panyam/mcpkit/ext/protogen/schema	0.608s
 ?   	github.com/panyam/mcpkit/ext/protogen/testutil	[no test files]
 ==&gt; e2e: bookservice example
 [33mWARN[0m	plugin "protoc-gen-go-mcp" does not support required features.
   Feature "proto3 optional" is required by 1 file(s):
     bookservice/v1/service.proto
-ok  	github.com/panyam/mcpkit/ext/protogen/examples/bookservice	0.818s
+ok  	github.com/panyam/mcpkit/ext/protogen/examples/bookservice	0.661s
 ==&gt; e2e: passed
   PASS: protogen
 --- [6/9] e2e ---
-ok  	github.com/panyam/mcpkit/tests/e2e	3.962s
-ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.712s
+ok  	github.com/panyam/mcpkit/tests/e2e	3.508s
+ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.945s
   PASS: e2e
 --- [7/9] conformance ---
 Killing stale process on port 18799...
 === Starting test server on :18799 (Streamable HTTP) ===
-Waiting for server....2026/04/15 02:29:24 MCP test server listening on :18799 (Streamable HTTP at /mcp)
-. ready
+Waiting for server....2026/04/15 03:02:28 MCP test server listening on :18799 (Streamable HTTP at /mcp)
+ ready
 
 === Running MCP conformance suite ===
 Command: npx -y @modelcontextprotocol/conformance server --url http://localhost:18799/mcp --expected-failures conformance/baseline.yml
@@ -99,293 +99,293 @@ Running active suite (30 scenarios) against http://localhost:18799/mcp
 
 === Running scenario: server-initialize ===
 Running client scenario 'server-initialize' against server: http://localhost:18799/mcp
-2026/04/15 02:29:27 Starting MCP-GET-SSE SSE connection: b8bd2d97a2386e0eb9b334c9321a4170
-2026/04/15 02:29:27 SSEHub: registered connection b8bd2d97a2386e0eb9b334c9321a4170 (total: 1)
-2026/04/15 02:29:27 SSEHub: unregistered connection b8bd2d97a2386e0eb9b334c9321a4170 (total: 0)
-2026/04/15 02:29:27 Received kill signal.  Quitting Writer. stop 0x54f4d474c460
-2026/04/15 02:29:27 Cleaning up writer...
-2026/04/15 02:29:27 Finished cleaning up writer:  0x54f4d474c460
-2026/04/15 02:29:27 Closed MCP-GET-SSE SSE connection: b8bd2d97a2386e0eb9b334c9321a4170
+2026/04/15 03:02:30 Starting MCP-GET-SSE SSE connection: 0dd5d82e91e86a006936610f50cf81ed
+2026/04/15 03:02:30 SSEHub: registered connection 0dd5d82e91e86a006936610f50cf81ed (total: 1)
+2026/04/15 03:02:30 SSEHub: unregistered connection 0dd5d82e91e86a006936610f50cf81ed (total: 0)
+2026/04/15 03:02:30 Received kill signal.  Quitting Writer. stop 0x4f2a810b61c0
+2026/04/15 03:02:30 Cleaning up writer...
+2026/04/15 03:02:30 Finished cleaning up writer:  0x4f2a810b61c0
+2026/04/15 03:02:30 Closed MCP-GET-SSE SSE connection: 0dd5d82e91e86a006936610f50cf81ed
 
 === Running scenario: logging-set-level ===
 Running client scenario 'logging-set-level' against server: http://localhost:18799/mcp
-2026/04/15 02:29:27 Starting MCP-GET-SSE SSE connection: d781bc4ccbdec3a4437dfc9663cb5348
-2026/04/15 02:29:27 SSEHub: registered connection d781bc4ccbdec3a4437dfc9663cb5348 (total: 1)
-2026/04/15 02:29:27 SSEHub: unregistered connection d781bc4ccbdec3a4437dfc9663cb5348 (total: 0)
-2026/04/15 02:29:27 Received kill signal.  Quitting Writer. stop 0x54f4d474c700
-2026/04/15 02:29:27 Cleaning up writer...
-2026/04/15 02:29:27 Finished cleaning up writer:  0x54f4d474c700
-2026/04/15 02:29:27 Closed MCP-GET-SSE SSE connection: d781bc4ccbdec3a4437dfc9663cb5348
+2026/04/15 03:02:30 Starting MCP-GET-SSE SSE connection: 150039cf984ce8794e2fa7e0cc7abc15
+2026/04/15 03:02:30 SSEHub: registered connection 150039cf984ce8794e2fa7e0cc7abc15 (total: 1)
+2026/04/15 03:02:30 SSEHub: unregistered connection 150039cf984ce8794e2fa7e0cc7abc15 (total: 0)
+2026/04/15 03:02:30 Received kill signal.  Quitting Writer. stop 0x4f2a80c90310
+2026/04/15 03:02:30 Cleaning up writer...
+2026/04/15 03:02:30 Finished cleaning up writer:  0x4f2a80c90310
+2026/04/15 03:02:30 Closed MCP-GET-SSE SSE connection: 150039cf984ce8794e2fa7e0cc7abc15
 
 === Running scenario: ping ===
 Running client scenario 'ping' against server: http://localhost:18799/mcp
-2026/04/15 02:29:27 Starting MCP-GET-SSE SSE connection: f83e0a5a50534f01dc7f296ac72448f7
-2026/04/15 02:29:27 SSEHub: registered connection f83e0a5a50534f01dc7f296ac72448f7 (total: 1)
-2026/04/15 02:29:27 SSEHub: unregistered connection f83e0a5a50534f01dc7f296ac72448f7 (total: 0)
-2026/04/15 02:29:27 Received kill signal.  Quitting Writer. stop 0x54f4d474c9a0
-2026/04/15 02:29:27 Cleaning up writer...
-2026/04/15 02:29:27 Finished cleaning up writer:  0x54f4d474c9a0
+2026/04/15 03:02:30 Starting MCP-GET-SSE SSE connection: a3f44105324c5648570980786bf5226f
+2026/04/15 03:02:30 SSEHub: registered connection a3f44105324c5648570980786bf5226f (total: 1)
+2026/04/15 03:02:30 SSEHub: unregistered connection a3f44105324c5648570980786bf5226f (total: 0)
+2026/04/15 03:02:30 Received kill signal.  Quitting Writer. stop 0x4f2a810b6460
+2026/04/15 03:02:30 Cleaning up writer...
+2026/04/15 03:02:30 Finished cleaning up writer:  0x4f2a810b6460
+2026/04/15 03:02:30 Closed MCP-GET-SSE SSE connection: a3f44105324c5648570980786bf5226f
 
 === Running scenario: completion-complete ===
-2026/04/15 02:29:27 Closed MCP-GET-SSE SSE connection: f83e0a5a50534f01dc7f296ac72448f7
 Running client scenario 'completion-complete' against server: http://localhost:18799/mcp
-2026/04/15 02:29:27 Starting MCP-GET-SSE SSE connection: d87658b3265dda3224a71cabc193675d
-2026/04/15 02:29:27 SSEHub: registered connection d87658b3265dda3224a71cabc193675d (total: 1)
-2026/04/15 02:29:27 SSEHub: unregistered connection d87658b3265dda3224a71cabc193675d (total: 0)
-2026/04/15 02:29:27 Received kill signal.  Quitting Writer. stop 0x54f4d474c310
-2026/04/15 02:29:27 Cleaning up writer...
-2026/04/15 02:29:27 Finished cleaning up writer:  0x54f4d474c310
-2026/04/15 02:29:27 Closed MCP-GET-SSE SSE connection: d87658b3265dda3224a71cabc193675d
+2026/04/15 03:02:30 Starting MCP-GET-SSE SSE connection: 0c80e36e2e7f7d03b2cf225abd775d42
+2026/04/15 03:02:30 SSEHub: registered connection 0c80e36e2e7f7d03b2cf225abd775d42 (total: 1)
+2026/04/15 03:02:30 SSEHub: unregistered connection 0c80e36e2e7f7d03b2cf225abd775d42 (total: 0)
+2026/04/15 03:02:30 Received kill signal.  Quitting Writer. stop 0x4f2a80d4a3f0
+2026/04/15 03:02:30 Cleaning up writer...
+2026/04/15 03:02:30 Finished cleaning up writer:  0x4f2a80d4a3f0
+2026/04/15 03:02:30 Closed MCP-GET-SSE SSE connection: 0c80e36e2e7f7d03b2cf225abd775d42
 
 === Running scenario: tools-list ===
 Running client scenario 'tools-list' against server: http://localhost:18799/mcp
-2026/04/15 02:29:27 Starting MCP-GET-SSE SSE connection: 816da42a2c5ad63f8e17e8ef6e31f428
-2026/04/15 02:29:27 SSEHub: registered connection 816da42a2c5ad63f8e17e8ef6e31f428 (total: 1)
-2026/04/15 02:29:27 SSEHub: unregistered connection 816da42a2c5ad63f8e17e8ef6e31f428 (total: 0)
-2026/04/15 02:29:27 Received kill signal.  Quitting Writer. stop 0x54f4d474c690
-2026/04/15 02:29:27 Cleaning up writer...
-2026/04/15 02:29:27 Finished cleaning up writer:  0x54f4d474c690
-2026/04/15 02:29:27 Closed MCP-GET-SSE SSE connection: 816da42a2c5ad63f8e17e8ef6e31f428
+2026/04/15 03:02:30 Starting MCP-GET-SSE SSE connection: 1f84ecd78d25da8fedafda8b166a7234
+2026/04/15 03:02:30 SSEHub: registered connection 1f84ecd78d25da8fedafda8b166a7234 (total: 1)
+2026/04/15 03:02:30 SSEHub: unregistered connection 1f84ecd78d25da8fedafda8b166a7234 (total: 0)
+2026/04/15 03:02:30 Received kill signal.  Quitting Writer. stop 0x4f2a80d4a150
 
 === Running scenario: tools-call-simple-text ===
+2026/04/15 03:02:30 Cleaning up writer...
 Running client scenario 'tools-call-simple-text' against server: http://localhost:18799/mcp
-2026/04/15 02:29:27 Starting MCP-GET-SSE SSE connection: a4f07b20ae38aa8867d7cbfa1ce5f6e6
-2026/04/15 02:29:27 SSEHub: registered connection a4f07b20ae38aa8867d7cbfa1ce5f6e6 (total: 1)
-2026/04/15 02:29:27 SSEHub: unregistered connection a4f07b20ae38aa8867d7cbfa1ce5f6e6 (total: 0)
-2026/04/15 02:29:27 Received kill signal.  Quitting Writer. stop 0x54f4d474c930
-2026/04/15 02:29:27 Cleaning up writer...
-2026/04/15 02:29:27 Finished cleaning up writer:  0x54f4d474c930
-2026/04/15 02:29:27 Closed MCP-GET-SSE SSE connection: a4f07b20ae38aa8867d7cbfa1ce5f6e6
+2026/04/15 03:02:30 Finished cleaning up writer:  0x4f2a80d4a150
+2026/04/15 03:02:30 Closed MCP-GET-SSE SSE connection: 1f84ecd78d25da8fedafda8b166a7234
+2026/04/15 03:02:30 Starting MCP-GET-SSE SSE connection: 51328831cd98b9d995c6e4c4b58d6991
+2026/04/15 03:02:30 SSEHub: registered connection 51328831cd98b9d995c6e4c4b58d6991 (total: 1)
+2026/04/15 03:02:30 SSEHub: unregistered connection 51328831cd98b9d995c6e4c4b58d6991 (total: 0)
+2026/04/15 03:02:30 Received kill signal.  Quitting Writer. stop 0x4f2a80d4a690
+2026/04/15 03:02:30 Cleaning up writer...
+2026/04/15 03:02:30 Finished cleaning up writer:  0x4f2a80d4a690
+2026/04/15 03:02:30 Closed MCP-GET-SSE SSE connection: 51328831cd98b9d995c6e4c4b58d6991
 
 === Running scenario: tools-call-image ===
 Running client scenario 'tools-call-image' against server: http://localhost:18799/mcp
-2026/04/15 02:29:27 Starting MCP-GET-SSE SSE connection: e1f39eb48f6b11335b67ac1405f5a9cb
-2026/04/15 02:29:27 SSEHub: registered connection e1f39eb48f6b11335b67ac1405f5a9cb (total: 1)
-2026/04/15 02:29:27 SSEHub: unregistered connection e1f39eb48f6b11335b67ac1405f5a9cb (total: 0)
-2026/04/15 02:29:27 Received kill signal.  Quitting Writer. stop 0x54f4d4812af0
-2026/04/15 02:29:27 Cleaning up writer...
-2026/04/15 02:29:27 Finished cleaning up writer:  0x54f4d4812af0
-2026/04/15 02:29:27 Closed MCP-GET-SSE SSE connection: e1f39eb48f6b11335b67ac1405f5a9cb
+2026/04/15 03:02:30 Starting MCP-GET-SSE SSE connection: f8f7589cc3eab31add156a19992c941d
+2026/04/15 03:02:30 SSEHub: registered connection f8f7589cc3eab31add156a19992c941d (total: 1)
+2026/04/15 03:02:30 SSEHub: unregistered connection f8f7589cc3eab31add156a19992c941d (total: 0)
+2026/04/15 03:02:30 Received kill signal.  Quitting Writer. stop 0x4f2a80d4a8c0
 
 === Running scenario: tools-call-audio ===
+2026/04/15 03:02:30 Cleaning up writer...
 Running client scenario 'tools-call-audio' against server: http://localhost:18799/mcp
-2026/04/15 02:29:27 Starting MCP-GET-SSE SSE connection: a0aa1df6af4dab08dfd2f32565350fb0
-2026/04/15 02:29:27 SSEHub: registered connection a0aa1df6af4dab08dfd2f32565350fb0 (total: 1)
-2026/04/15 02:29:27 SSEHub: unregistered connection a0aa1df6af4dab08dfd2f32565350fb0 (total: 0)
-2026/04/15 02:29:27 Received kill signal.  Quitting Writer. stop 0x54f4d4812d20
-2026/04/15 02:29:27 Cleaning up writer...
-2026/04/15 02:29:27 Finished cleaning up writer:  0x54f4d4812d20
-2026/04/15 02:29:27 Closed MCP-GET-SSE SSE connection: a0aa1df6af4dab08dfd2f32565350fb0
+2026/04/15 03:02:30 Finished cleaning up writer:  0x4f2a80d4a8c0
+2026/04/15 03:02:30 Closed MCP-GET-SSE SSE connection: f8f7589cc3eab31add156a19992c941d
+2026/04/15 03:02:30 Starting MCP-GET-SSE SSE connection: 2745f16b7b7bb7587bcc43069faa1c63
+2026/04/15 03:02:30 SSEHub: registered connection 2745f16b7b7bb7587bcc43069faa1c63 (total: 1)
+2026/04/15 03:02:30 SSEHub: unregistered connection 2745f16b7b7bb7587bcc43069faa1c63 (total: 0)
+2026/04/15 03:02:30 Received kill signal.  Quitting Writer. stop 0x4f2a810b6310
+2026/04/15 03:02:30 Cleaning up writer...
+2026/04/15 03:02:30 Finished cleaning up writer:  0x4f2a810b6310
+2026/04/15 03:02:30 Closed MCP-GET-SSE SSE connection: 2745f16b7b7bb7587bcc43069faa1c63
 
 === Running scenario: tools-call-embedded-resource ===
 Running client scenario 'tools-call-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/15 02:29:27 Starting MCP-GET-SSE SSE connection: 5ff99272670130367655141f6c3e1e51
-2026/04/15 02:29:27 SSEHub: registered connection 5ff99272670130367655141f6c3e1e51 (total: 1)
-2026/04/15 02:29:27 SSEHub: unregistered connection 5ff99272670130367655141f6c3e1e51 (total: 0)
-2026/04/15 02:29:27 Received kill signal.  Quitting Writer. stop 0x54f4d4813030
-2026/04/15 02:29:27 Cleaning up writer...
-2026/04/15 02:29:27 Finished cleaning up writer:  0x54f4d4813030
-2026/04/15 02:29:27 Closed MCP-GET-SSE SSE connection: 5ff99272670130367655141f6c3e1e51
+2026/04/15 03:02:30 Starting MCP-GET-SSE SSE connection: 20f6b72dff9fbc61c7047146d2bef265
+2026/04/15 03:02:30 SSEHub: registered connection 20f6b72dff9fbc61c7047146d2bef265 (total: 1)
+2026/04/15 03:02:30 SSEHub: unregistered connection 20f6b72dff9fbc61c7047146d2bef265 (total: 0)
+2026/04/15 03:02:30 Received kill signal.  Quitting Writer. stop 0x4f2a80d8cbd0
+2026/04/15 03:02:30 Cleaning up writer...
+2026/04/15 03:02:30 Finished cleaning up writer:  0x4f2a80d8cbd0
+2026/04/15 03:02:30 Closed MCP-GET-SSE SSE connection: 20f6b72dff9fbc61c7047146d2bef265
 
 === Running scenario: tools-call-mixed-content ===
 Running client scenario 'tools-call-mixed-content' against server: http://localhost:18799/mcp
-2026/04/15 02:29:27 Starting MCP-GET-SSE SSE connection: b7054e97a885ccfc223a2e8bd69581fd
-2026/04/15 02:29:27 SSEHub: registered connection b7054e97a885ccfc223a2e8bd69581fd (total: 1)
-2026/04/15 02:29:27 SSEHub: unregistered connection b7054e97a885ccfc223a2e8bd69581fd (total: 0)
-2026/04/15 02:29:27 Received kill signal.  Quitting Writer. stop 0x54f4d4813260
-2026/04/15 02:29:27 Cleaning up writer...
-2026/04/15 02:29:27 Finished cleaning up writer:  0x54f4d4813260
-2026/04/15 02:29:27 Closed MCP-GET-SSE SSE connection: b7054e97a885ccfc223a2e8bd69581fd
+2026/04/15 03:02:30 Starting MCP-GET-SSE SSE connection: 9373f8a8f2235080689ee3a73c885947
+2026/04/15 03:02:30 SSEHub: registered connection 9373f8a8f2235080689ee3a73c885947 (total: 1)
+2026/04/15 03:02:30 SSEHub: unregistered connection 9373f8a8f2235080689ee3a73c885947 (total: 0)
+2026/04/15 03:02:30 Received kill signal.  Quitting Writer. stop 0x4f2a810b6690
+2026/04/15 03:02:30 Cleaning up writer...
+2026/04/15 03:02:30 Finished cleaning up writer:  0x4f2a810b6690
+2026/04/15 03:02:30 Closed MCP-GET-SSE SSE connection: 9373f8a8f2235080689ee3a73c885947
 
 === Running scenario: tools-call-with-logging ===
 Running client scenario 'tools-call-with-logging' against server: http://localhost:18799/mcp
-2026/04/15 02:29:27 Starting MCP-GET-SSE SSE connection: 2508ed2d75f02352e0965fae950e6085
-2026/04/15 02:29:27 SSEHub: registered connection 2508ed2d75f02352e0965fae950e6085 (total: 1)
-2026/04/15 02:29:27 SSEHub: unregistered connection 2508ed2d75f02352e0965fae950e6085 (total: 0)
-2026/04/15 02:29:27 Received kill signal.  Quitting Writer. stop 0x54f4d4c223f0
-2026/04/15 02:29:27 Cleaning up writer...
-2026/04/15 02:29:27 Finished cleaning up writer:  0x54f4d4c223f0
-2026/04/15 02:29:27 Closed MCP-GET-SSE SSE connection: 2508ed2d75f02352e0965fae950e6085
+2026/04/15 03:02:30 Starting MCP-GET-SSE SSE connection: 7e5325719435c6d0e27899818b193d49
+2026/04/15 03:02:30 SSEHub: registered connection 7e5325719435c6d0e27899818b193d49 (total: 1)
+2026/04/15 03:02:31 SSEHub: unregistered connection 7e5325719435c6d0e27899818b193d49 (total: 0)
 
 === Running scenario: tools-call-error ===
+2026/04/15 03:02:31 Received kill signal.  Quitting Writer. stop 0x4f2a80d4abd0
+2026/04/15 03:02:31 Cleaning up writer...
+2026/04/15 03:02:31 Finished cleaning up writer:  0x4f2a80d4abd0
 Running client scenario 'tools-call-error' against server: http://localhost:18799/mcp
-2026/04/15 02:29:27 Starting MCP-GET-SSE SSE connection: 52bea4186f1a057510e136befc26b8d6
-2026/04/15 02:29:27 SSEHub: registered connection 52bea4186f1a057510e136befc26b8d6 (total: 1)
+2026/04/15 03:02:31 Closed MCP-GET-SSE SSE connection: 7e5325719435c6d0e27899818b193d49
+2026/04/15 03:02:31 Starting MCP-GET-SSE SSE connection: 8f30a6c40f804472be8800da8b5207b9
+2026/04/15 03:02:31 SSEHub: registered connection 8f30a6c40f804472be8800da8b5207b9 (total: 1)
+2026/04/15 03:02:31 SSEHub: unregistered connection 8f30a6c40f804472be8800da8b5207b9 (total: 0)
+2026/04/15 03:02:31 Received kill signal.  Quitting Writer. stop 0x4f2a80d4ae00
+2026/04/15 03:02:31 Cleaning up writer...
+2026/04/15 03:02:31 Finished cleaning up writer:  0x4f2a80d4ae00
+2026/04/15 03:02:31 Closed MCP-GET-SSE SSE connection: 8f30a6c40f804472be8800da8b5207b9
 
 === Running scenario: tools-call-with-progress ===
-2026/04/15 02:29:27 SSEHub: unregistered connection 52bea4186f1a057510e136befc26b8d6 (total: 0)
 Running client scenario 'tools-call-with-progress' against server: http://localhost:18799/mcp
-2026/04/15 02:29:27 Received kill signal.  Quitting Writer. stop 0x54f4d489c150
-2026/04/15 02:29:27 Cleaning up writer...
-2026/04/15 02:29:27 Finished cleaning up writer:  0x54f4d489c150
-2026/04/15 02:29:27 Closed MCP-GET-SSE SSE connection: 52bea4186f1a057510e136befc26b8d6
-2026/04/15 02:29:27 Starting MCP-GET-SSE SSE connection: ea602dd5b7f6a1ea8e08dedd9f3658b5
-2026/04/15 02:29:27 SSEHub: registered connection ea602dd5b7f6a1ea8e08dedd9f3658b5 (total: 1)
-2026/04/15 02:29:28 SSEHub: unregistered connection ea602dd5b7f6a1ea8e08dedd9f3658b5 (total: 0)
-2026/04/15 02:29:28 Received kill signal.  Quitting Writer. stop 0x54f4d4c227e0
-2026/04/15 02:29:28 Cleaning up writer...
-2026/04/15 02:29:28 Finished cleaning up writer:  0x54f4d4c227e0
-2026/04/15 02:29:28 Closed MCP-GET-SSE SSE connection: ea602dd5b7f6a1ea8e08dedd9f3658b5
+2026/04/15 03:02:31 Starting MCP-GET-SSE SSE connection: f269a7116c3eae8512d18363e89b1ec1
+2026/04/15 03:02:31 SSEHub: registered connection f269a7116c3eae8512d18363e89b1ec1 (total: 1)
+2026/04/15 03:02:31 SSEHub: unregistered connection f269a7116c3eae8512d18363e89b1ec1 (total: 0)
+2026/04/15 03:02:31 Received kill signal.  Quitting Writer. stop 0x4f2a810b6a10
+2026/04/15 03:02:31 Cleaning up writer...
+2026/04/15 03:02:31 Finished cleaning up writer:  0x4f2a810b6a10
+2026/04/15 03:02:31 Closed MCP-GET-SSE SSE connection: f269a7116c3eae8512d18363e89b1ec1
 
 === Running scenario: tools-call-sampling ===
 Running client scenario 'tools-call-sampling' against server: http://localhost:18799/mcp
-2026/04/15 02:29:28 Starting MCP-GET-SSE SSE connection: a639d24179acb98d608b6a2347e9e853
-2026/04/15 02:29:28 SSEHub: registered connection a639d24179acb98d608b6a2347e9e853 (total: 1)
-2026/04/15 02:29:28 SSEHub: unregistered connection a639d24179acb98d608b6a2347e9e853 (total: 0)
-2026/04/15 02:29:28 Received kill signal.  Quitting Writer. stop 0x54f4d4813570
-2026/04/15 02:29:28 Cleaning up writer...
-2026/04/15 02:29:28 Finished cleaning up writer:  0x54f4d4813570
-2026/04/15 02:29:28 Closed MCP-GET-SSE SSE connection: a639d24179acb98d608b6a2347e9e853
+2026/04/15 03:02:31 Starting MCP-GET-SSE SSE connection: 9ee38589d6fc2d47a52a26551558ee40
+2026/04/15 03:02:31 SSEHub: registered connection 9ee38589d6fc2d47a52a26551558ee40 (total: 1)
+2026/04/15 03:02:31 SSEHub: unregistered connection 9ee38589d6fc2d47a52a26551558ee40 (total: 0)
+2026/04/15 03:02:31 Received kill signal.  Quitting Writer. stop 0x4f2a80c905b0
+2026/04/15 03:02:31 Cleaning up writer...
+2026/04/15 03:02:31 Finished cleaning up writer:  0x4f2a80c905b0
+2026/04/15 03:02:31 Closed MCP-GET-SSE SSE connection: 9ee38589d6fc2d47a52a26551558ee40
 
 === Running scenario: tools-call-elicitation ===
 Running client scenario 'tools-call-elicitation' against server: http://localhost:18799/mcp
-2026/04/15 02:29:28 Starting MCP-GET-SSE SSE connection: e19ddda2b0be4c4962db01594696fef1
-2026/04/15 02:29:28 SSEHub: registered connection e19ddda2b0be4c4962db01594696fef1 (total: 1)
-2026/04/15 02:29:28 SSEHub: unregistered connection e19ddda2b0be4c4962db01594696fef1 (total: 0)
-2026/04/15 02:29:28 Received kill signal.  Quitting Writer. stop 0x54f4d489c770
-2026/04/15 02:29:28 Cleaning up writer...
-2026/04/15 02:29:28 Finished cleaning up writer:  0x54f4d489c770
-2026/04/15 02:29:28 Closed MCP-GET-SSE SSE connection: e19ddda2b0be4c4962db01594696fef1
+2026/04/15 03:02:31 Starting MCP-GET-SSE SSE connection: fd103350700f2fc8f36e0483543ef055
+2026/04/15 03:02:31 SSEHub: registered connection fd103350700f2fc8f36e0483543ef055 (total: 1)
+2026/04/15 03:02:31 SSEHub: unregistered connection fd103350700f2fc8f36e0483543ef055 (total: 0)
 
 === Running scenario: elicitation-sep1034-defaults ===
+2026/04/15 03:02:31 Received kill signal.  Quitting Writer. stop 0x4f2a80d4b110
 Running client scenario 'elicitation-sep1034-defaults' against server: http://localhost:18799/mcp
-2026/04/15 02:29:28 Starting MCP-GET-SSE SSE connection: aff9727c850b143d73a1e4c6bfa22e0f
-2026/04/15 02:29:28 SSEHub: registered connection aff9727c850b143d73a1e4c6bfa22e0f (total: 1)
-2026/04/15 02:29:28 SSEHub: unregistered connection aff9727c850b143d73a1e4c6bfa22e0f (total: 0)
-2026/04/15 02:29:28 Received kill signal.  Quitting Writer. stop 0x54f4d474ce70
-2026/04/15 02:29:28 Cleaning up writer...
+2026/04/15 03:02:31 Cleaning up writer...
+2026/04/15 03:02:31 Finished cleaning up writer:  0x4f2a80d4b110
+2026/04/15 03:02:31 Closed MCP-GET-SSE SSE connection: fd103350700f2fc8f36e0483543ef055
+2026/04/15 03:02:31 Starting MCP-GET-SSE SSE connection: dad9bc88dec971e2ea32cf0f2cd0c137
+2026/04/15 03:02:31 SSEHub: registered connection dad9bc88dec971e2ea32cf0f2cd0c137 (total: 1)
+2026/04/15 03:02:31 SSEHub: unregistered connection dad9bc88dec971e2ea32cf0f2cd0c137 (total: 0)
+2026/04/15 03:02:31 Received kill signal.  Quitting Writer. stop 0x4f2a80d8cf50
+2026/04/15 03:02:31 Cleaning up writer...
+2026/04/15 03:02:31 Finished cleaning up writer:  0x4f2a80d8cf50
+2026/04/15 03:02:31 Closed MCP-GET-SSE SSE connection: dad9bc88dec971e2ea32cf0f2cd0c137
 
 === Running scenario: server-sse-multiple-streams ===
-2026/04/15 02:29:28 Finished cleaning up writer:  0x54f4d474ce70
-2026/04/15 02:29:28 Closed MCP-GET-SSE SSE connection: aff9727c850b143d73a1e4c6bfa22e0f
 Running client scenario 'server-sse-multiple-streams' against server: http://localhost:18799/mcp
-2026/04/15 02:29:28 Starting MCP-GET-SSE SSE connection: d401f2fdf9d457107f5bc6c8275dd582
-2026/04/15 02:29:28 SSEHub: registered connection d401f2fdf9d457107f5bc6c8275dd582 (total: 1)
-2026/04/15 02:29:28 SSEHub: unregistered connection d401f2fdf9d457107f5bc6c8275dd582 (total: 0)
+2026/04/15 03:02:31 Starting MCP-GET-SSE SSE connection: 7f549a093b071c0b9edc1fcd2743beec
+2026/04/15 03:02:31 SSEHub: registered connection 7f549a093b071c0b9edc1fcd2743beec (total: 1)
 
 === Running scenario: elicitation-sep1330-enums ===
-2026/04/15 02:29:28 Received kill signal.  Quitting Writer. stop 0x54f4d474d110
-2026/04/15 02:29:28 Cleaning up writer...
-2026/04/15 02:29:28 Finished cleaning up writer:  0x54f4d474d110
 Running client scenario 'elicitation-sep1330-enums' against server: http://localhost:18799/mcp
-2026/04/15 02:29:28 Closed MCP-GET-SSE SSE connection: d401f2fdf9d457107f5bc6c8275dd582
-2026/04/15 02:29:28 Starting MCP-GET-SSE SSE connection: a4e2aac513d8fa84565a7aa087fee0ee
-2026/04/15 02:29:28 SSEHub: registered connection a4e2aac513d8fa84565a7aa087fee0ee (total: 1)
-2026/04/15 02:29:28 SSEHub: unregistered connection a4e2aac513d8fa84565a7aa087fee0ee (total: 0)
-2026/04/15 02:29:28 Received kill signal.  Quitting Writer. stop 0x54f4d4c22b60
-2026/04/15 02:29:28 Cleaning up writer...
-2026/04/15 02:29:28 Finished cleaning up writer:  0x54f4d4c22b60
-2026/04/15 02:29:28 Closed MCP-GET-SSE SSE connection: a4e2aac513d8fa84565a7aa087fee0ee
+2026/04/15 03:02:31 SSEHub: unregistered connection 7f549a093b071c0b9edc1fcd2743beec (total: 0)
+2026/04/15 03:02:31 Received kill signal.  Quitting Writer. stop 0x4f2a80d4b730
+2026/04/15 03:02:31 Cleaning up writer...
+2026/04/15 03:02:31 Finished cleaning up writer:  0x4f2a80d4b730
+2026/04/15 03:02:31 Closed MCP-GET-SSE SSE connection: 7f549a093b071c0b9edc1fcd2743beec
+2026/04/15 03:02:31 Starting MCP-GET-SSE SSE connection: a6857aa3abe32e20ab8aa489cdd9b1de
+2026/04/15 03:02:31 SSEHub: registered connection a6857aa3abe32e20ab8aa489cdd9b1de (total: 1)
 
 === Running scenario: resources-list ===
+2026/04/15 03:02:31 SSEHub: unregistered connection a6857aa3abe32e20ab8aa489cdd9b1de (total: 0)
 Running client scenario 'resources-list' against server: http://localhost:18799/mcp
-2026/04/15 02:29:28 Starting MCP-GET-SSE SSE connection: 905dfc6e49ab9b640692eb0ba1ef6f55
-2026/04/15 02:29:28 SSEHub: registered connection 905dfc6e49ab9b640692eb0ba1ef6f55 (total: 1)
-2026/04/15 02:29:28 SSEHub: unregistered connection 905dfc6e49ab9b640692eb0ba1ef6f55 (total: 0)
-2026/04/15 02:29:28 Received kill signal.  Quitting Writer. stop 0x54f4d4813ab0
-2026/04/15 02:29:28 Cleaning up writer...
-2026/04/15 02:29:28 Finished cleaning up writer:  0x54f4d4813ab0
-2026/04/15 02:29:28 Closed MCP-GET-SSE SSE connection: 905dfc6e49ab9b640692eb0ba1ef6f55
+2026/04/15 03:02:31 Received kill signal.  Quitting Writer. stop 0x4f2a810b6f50
+2026/04/15 03:02:31 Cleaning up writer...
+2026/04/15 03:02:31 Finished cleaning up writer:  0x4f2a810b6f50
+2026/04/15 03:02:31 Closed MCP-GET-SSE SSE connection: a6857aa3abe32e20ab8aa489cdd9b1de
+2026/04/15 03:02:31 Starting MCP-GET-SSE SSE connection: 4361b460e25ef436e9a29325deb86aa5
+2026/04/15 03:02:31 SSEHub: registered connection 4361b460e25ef436e9a29325deb86aa5 (total: 1)
+2026/04/15 03:02:31 SSEHub: unregistered connection 4361b460e25ef436e9a29325deb86aa5 (total: 0)
+2026/04/15 03:02:31 Received kill signal.  Quitting Writer. stop 0x4f2a80c90b60
+2026/04/15 03:02:31 Cleaning up writer...
+2026/04/15 03:02:31 Finished cleaning up writer:  0x4f2a80c90b60
+2026/04/15 03:02:31 Closed MCP-GET-SSE SSE connection: 4361b460e25ef436e9a29325deb86aa5
 
 === Running scenario: resources-read-text ===
 Running client scenario 'resources-read-text' against server: http://localhost:18799/mcp
-2026/04/15 02:29:28 Starting MCP-GET-SSE SSE connection: 3dd99bb29cad45cb1f81cce19aa63f76
-2026/04/15 02:29:28 SSEHub: registered connection 3dd99bb29cad45cb1f81cce19aa63f76 (total: 1)
-2026/04/15 02:29:28 SSEHub: unregistered connection 3dd99bb29cad45cb1f81cce19aa63f76 (total: 0)
-2026/04/15 02:29:28 Received kill signal.  Quitting Writer. stop 0x54f4d4c22e70
-2026/04/15 02:29:28 Cleaning up writer...
+2026/04/15 03:02:31 Starting MCP-GET-SSE SSE connection: b7e1697b8e213df3a5872d0ba9063f6b
+2026/04/15 03:02:31 SSEHub: registered connection b7e1697b8e213df3a5872d0ba9063f6b (total: 1)
 
 === Running scenario: resources-read-binary ===
-2026/04/15 02:29:28 Finished cleaning up writer:  0x54f4d4c22e70
 Running client scenario 'resources-read-binary' against server: http://localhost:18799/mcp
-2026/04/15 02:29:28 Closed MCP-GET-SSE SSE connection: 3dd99bb29cad45cb1f81cce19aa63f76
-2026/04/15 02:29:28 Starting MCP-GET-SSE SSE connection: eee129a54a8e596d11984bc5eedb0416
-2026/04/15 02:29:28 SSEHub: registered connection eee129a54a8e596d11984bc5eedb0416 (total: 1)
-2026/04/15 02:29:28 SSEHub: unregistered connection eee129a54a8e596d11984bc5eedb0416 (total: 0)
-2026/04/15 02:29:28 Received kill signal.  Quitting Writer. stop 0x54f4d4c23110
-2026/04/15 02:29:28 Cleaning up writer...
+2026/04/15 03:02:31 SSEHub: unregistered connection b7e1697b8e213df3a5872d0ba9063f6b (total: 0)
+2026/04/15 03:02:31 Received kill signal.  Quitting Writer. stop 0x4f2a80d8d2d0
+2026/04/15 03:02:31 Cleaning up writer...
+2026/04/15 03:02:31 Finished cleaning up writer:  0x4f2a80d8d2d0
+2026/04/15 03:02:31 Closed MCP-GET-SSE SSE connection: b7e1697b8e213df3a5872d0ba9063f6b
+2026/04/15 03:02:31 Starting MCP-GET-SSE SSE connection: 8e88b9a5c4f0db79b644575592d2d832
+2026/04/15 03:02:31 SSEHub: registered connection 8e88b9a5c4f0db79b644575592d2d832 (total: 1)
+2026/04/15 03:02:31 SSEHub: unregistered connection 8e88b9a5c4f0db79b644575592d2d832 (total: 0)
 
 === Running scenario: resources-templates-read ===
-2026/04/15 02:29:28 Finished cleaning up writer:  0x54f4d4c23110
+2026/04/15 03:02:31 Received kill signal.  Quitting Writer. stop 0x4f2a80d4b9d0
+2026/04/15 03:02:31 Cleaning up writer...
+2026/04/15 03:02:31 Finished cleaning up writer:  0x4f2a80d4b9d0
+2026/04/15 03:02:31 Closed MCP-GET-SSE SSE connection: 8e88b9a5c4f0db79b644575592d2d832
 Running client scenario 'resources-templates-read' against server: http://localhost:18799/mcp
-2026/04/15 02:29:28 Closed MCP-GET-SSE SSE connection: eee129a54a8e596d11984bc5eedb0416
-2026/04/15 02:29:28 Starting MCP-GET-SSE SSE connection: f741a6887cba9aa1e35344334cd4bcdf
-2026/04/15 02:29:28 SSEHub: registered connection f741a6887cba9aa1e35344334cd4bcdf (total: 1)
-2026/04/15 02:29:28 SSEHub: unregistered connection f741a6887cba9aa1e35344334cd4bcdf (total: 0)
-2026/04/15 02:29:28 Received kill signal.  Quitting Writer. stop 0x54f4d4813ce0
-2026/04/15 02:29:28 Cleaning up writer...
-2026/04/15 02:29:28 Finished cleaning up writer:  0x54f4d4813ce0
-2026/04/15 02:29:28 Closed MCP-GET-SSE SSE connection: f741a6887cba9aa1e35344334cd4bcdf
+2026/04/15 03:02:31 Starting MCP-GET-SSE SSE connection: 354b879ed0b1bc37c50b2b5ca2b6e855
+2026/04/15 03:02:31 SSEHub: registered connection 354b879ed0b1bc37c50b2b5ca2b6e855 (total: 1)
+2026/04/15 03:02:31 SSEHub: unregistered connection 354b879ed0b1bc37c50b2b5ca2b6e855 (total: 0)
+2026/04/15 03:02:31 Received kill signal.  Quitting Writer. stop 0x4f2a80d8d5e0
+2026/04/15 03:02:31 Cleaning up writer...
 
 === Running scenario: resources-subscribe ===
+2026/04/15 03:02:31 Finished cleaning up writer:  0x4f2a80d8d5e0
 Running client scenario 'resources-subscribe' against server: http://localhost:18799/mcp
-2026/04/15 02:29:28 Starting MCP-GET-SSE SSE connection: 1fe10bafc4fff678781e8a8c9c4aa3f2
-2026/04/15 02:29:28 SSEHub: registered connection 1fe10bafc4fff678781e8a8c9c4aa3f2 (total: 1)
-2026/04/15 02:29:28 SSEHub: unregistered connection 1fe10bafc4fff678781e8a8c9c4aa3f2 (total: 0)
-2026/04/15 02:29:28 Received kill signal.  Quitting Writer. stop 0x54f4d4c233b0
-2026/04/15 02:29:28 Cleaning up writer...
-2026/04/15 02:29:28 Finished cleaning up writer:  0x54f4d4c233b0
-2026/04/15 02:29:28 Closed MCP-GET-SSE SSE connection: 1fe10bafc4fff678781e8a8c9c4aa3f2
+2026/04/15 03:02:31 Closed MCP-GET-SSE SSE connection: 354b879ed0b1bc37c50b2b5ca2b6e855
+2026/04/15 03:02:31 Starting MCP-GET-SSE SSE connection: 656e99badeeec3c35889ba88d39d9ad8
+2026/04/15 03:02:31 SSEHub: registered connection 656e99badeeec3c35889ba88d39d9ad8 (total: 1)
+2026/04/15 03:02:31 SSEHub: unregistered connection 656e99badeeec3c35889ba88d39d9ad8 (total: 0)
+2026/04/15 03:02:31 Received kill signal.  Quitting Writer. stop 0x4f2a810b72d0
 
 === Running scenario: resources-unsubscribe ===
+2026/04/15 03:02:31 Cleaning up writer...
 Running client scenario 'resources-unsubscribe' against server: http://localhost:18799/mcp
-2026/04/15 02:29:28 Starting MCP-GET-SSE SSE connection: 3c790c9c92d944b7ccd68cc5d71d6032
-2026/04/15 02:29:28 SSEHub: registered connection 3c790c9c92d944b7ccd68cc5d71d6032 (total: 1)
-2026/04/15 02:29:28 SSEHub: unregistered connection 3c790c9c92d944b7ccd68cc5d71d6032 (total: 0)
-2026/04/15 02:29:28 Received kill signal.  Quitting Writer. stop 0x54f4d49ac000
-2026/04/15 02:29:28 Cleaning up writer...
-2026/04/15 02:29:28 Finished cleaning up writer:  0x54f4d49ac000
-2026/04/15 02:29:28 Closed MCP-GET-SSE SSE connection: 3c790c9c92d944b7ccd68cc5d71d6032
+2026/04/15 03:02:31 Finished cleaning up writer:  0x4f2a810b72d0
+2026/04/15 03:02:31 Closed MCP-GET-SSE SSE connection: 656e99badeeec3c35889ba88d39d9ad8
+2026/04/15 03:02:31 Starting MCP-GET-SSE SSE connection: e034ac37ad4dc0a4826c7af2134fb180
+2026/04/15 03:02:31 SSEHub: registered connection e034ac37ad4dc0a4826c7af2134fb180 (total: 1)
+2026/04/15 03:02:31 SSEHub: unregistered connection e034ac37ad4dc0a4826c7af2134fb180 (total: 0)
+2026/04/15 03:02:31 Received kill signal.  Quitting Writer. stop 0x4f2a80d4bc70
+2026/04/15 03:02:31 Cleaning up writer...
+2026/04/15 03:02:31 Finished cleaning up writer:  0x4f2a80d4bc70
+2026/04/15 03:02:31 Closed MCP-GET-SSE SSE connection: e034ac37ad4dc0a4826c7af2134fb180
 
 === Running scenario: prompts-list ===
 Running client scenario 'prompts-list' against server: http://localhost:18799/mcp
-2026/04/15 02:29:28 Starting MCP-GET-SSE SSE connection: 7193ee150d47a76b295c1bfb6186b44d
-2026/04/15 02:29:28 SSEHub: registered connection 7193ee150d47a76b295c1bfb6186b44d (total: 1)
-2026/04/15 02:29:28 SSEHub: unregistered connection 7193ee150d47a76b295c1bfb6186b44d (total: 0)
-2026/04/15 02:29:28 Received kill signal.  Quitting Writer. stop 0x54f4d4c236c0
-2026/04/15 02:29:28 Cleaning up writer...
-2026/04/15 02:29:28 Finished cleaning up writer:  0x54f4d4c236c0
-2026/04/15 02:29:28 Closed MCP-GET-SSE SSE connection: 7193ee150d47a76b295c1bfb6186b44d
+2026/04/15 03:02:31 Starting MCP-GET-SSE SSE connection: 43e0bf2475ff2389d667ba4c6fc30a0f
+2026/04/15 03:02:31 SSEHub: registered connection 43e0bf2475ff2389d667ba4c6fc30a0f (total: 1)
+2026/04/15 03:02:31 SSEHub: unregistered connection 43e0bf2475ff2389d667ba4c6fc30a0f (total: 0)
+2026/04/15 03:02:31 Received kill signal.  Quitting Writer. stop 0x4f2a80d4bea0
+2026/04/15 03:02:31 Cleaning up writer...
+2026/04/15 03:02:31 Finished cleaning up writer:  0x4f2a80d4bea0
+2026/04/15 03:02:31 Closed MCP-GET-SSE SSE connection: 43e0bf2475ff2389d667ba4c6fc30a0f
 
 === Running scenario: prompts-get-simple ===
 Running client scenario 'prompts-get-simple' against server: http://localhost:18799/mcp
-2026/04/15 02:29:28 Starting MCP-GET-SSE SSE connection: 2ed9bc23162c16796ce309d86cb68221
-2026/04/15 02:29:28 SSEHub: registered connection 2ed9bc23162c16796ce309d86cb68221 (total: 1)
-2026/04/15 02:29:28 SSEHub: unregistered connection 2ed9bc23162c16796ce309d86cb68221 (total: 0)
-2026/04/15 02:29:28 Received kill signal.  Quitting Writer. stop 0x54f4d474d730
-2026/04/15 02:29:28 Cleaning up writer...
+2026/04/15 03:02:31 Starting MCP-GET-SSE SSE connection: ba4c12b03c298b4adc8bf6f5d9cb0e1e
+2026/04/15 03:02:31 SSEHub: registered connection ba4c12b03c298b4adc8bf6f5d9cb0e1e (total: 1)
+2026/04/15 03:02:31 SSEHub: unregistered connection ba4c12b03c298b4adc8bf6f5d9cb0e1e (total: 0)
+2026/04/15 03:02:31 Received kill signal.  Quitting Writer. stop 0x4f2a80c90fc0
+2026/04/15 03:02:31 Cleaning up writer...
+2026/04/15 03:02:31 Finished cleaning up writer:  0x4f2a80c90fc0
+2026/04/15 03:02:31 Closed MCP-GET-SSE SSE connection: ba4c12b03c298b4adc8bf6f5d9cb0e1e
 
 === Running scenario: prompts-get-with-args ===
-2026/04/15 02:29:28 Finished cleaning up writer:  0x54f4d474d730
 Running client scenario 'prompts-get-with-args' against server: http://localhost:18799/mcp
-2026/04/15 02:29:28 Closed MCP-GET-SSE SSE connection: 2ed9bc23162c16796ce309d86cb68221
-2026/04/15 02:29:28 Starting MCP-GET-SSE SSE connection: 556e857bc0ca173e1369574601724fab
-2026/04/15 02:29:28 SSEHub: registered connection 556e857bc0ca173e1369574601724fab (total: 1)
-2026/04/15 02:29:28 SSEHub: unregistered connection 556e857bc0ca173e1369574601724fab (total: 0)
-2026/04/15 02:29:28 Received kill signal.  Quitting Writer. stop 0x54f4d474d9d0
-2026/04/15 02:29:28 Cleaning up writer...
-2026/04/15 02:29:28 Finished cleaning up writer:  0x54f4d474d9d0
-2026/04/15 02:29:28 Closed MCP-GET-SSE SSE connection: 556e857bc0ca173e1369574601724fab
+2026/04/15 03:02:31 Starting MCP-GET-SSE SSE connection: 3ee2c229635ff9481e272aed0b1695dd
+2026/04/15 03:02:31 SSEHub: registered connection 3ee2c229635ff9481e272aed0b1695dd (total: 1)
+2026/04/15 03:02:31 SSEHub: unregistered connection 3ee2c229635ff9481e272aed0b1695dd (total: 0)
+2026/04/15 03:02:31 Received kill signal.  Quitting Writer. stop 0x4f2a81242230
+2026/04/15 03:02:31 Cleaning up writer...
+2026/04/15 03:02:31 Finished cleaning up writer:  0x4f2a81242230
+2026/04/15 03:02:31 Closed MCP-GET-SSE SSE connection: 3ee2c229635ff9481e272aed0b1695dd
 
 === Running scenario: prompts-get-embedded-resource ===
 Running client scenario 'prompts-get-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/15 02:29:28 Starting MCP-GET-SSE SSE connection: 1167d24f8fd7dac1d6b9af0e45b6e86d
-2026/04/15 02:29:28 SSEHub: registered connection 1167d24f8fd7dac1d6b9af0e45b6e86d (total: 1)
-2026/04/15 02:29:28 SSEHub: unregistered connection 1167d24f8fd7dac1d6b9af0e45b6e86d (total: 0)
-2026/04/15 02:29:28 Received kill signal.  Quitting Writer. stop 0x54f4d474dc70
-2026/04/15 02:29:28 Cleaning up writer...
-2026/04/15 02:29:28 Finished cleaning up writer:  0x54f4d474dc70
-2026/04/15 02:29:28 Closed MCP-GET-SSE SSE connection: 1167d24f8fd7dac1d6b9af0e45b6e86d
+2026/04/15 03:02:31 Starting MCP-GET-SSE SSE connection: 982aa898bd72c20d7f7b5d8292a02080
+2026/04/15 03:02:31 SSEHub: registered connection 982aa898bd72c20d7f7b5d8292a02080 (total: 1)
+2026/04/15 03:02:31 SSEHub: unregistered connection 982aa898bd72c20d7f7b5d8292a02080 (total: 0)
+2026/04/15 03:02:31 Received kill signal.  Quitting Writer. stop 0x4f2a81242460
+2026/04/15 03:02:31 Cleaning up writer...
+2026/04/15 03:02:31 Finished cleaning up writer:  0x4f2a81242460
+2026/04/15 03:02:31 Closed MCP-GET-SSE SSE connection: 982aa898bd72c20d7f7b5d8292a02080
 
 === Running scenario: prompts-get-with-image ===
 Running client scenario 'prompts-get-with-image' against server: http://localhost:18799/mcp
-2026/04/15 02:29:28 Starting MCP-GET-SSE SSE connection: 3c6d63867e35b46c229aec92078cefaf
-2026/04/15 02:29:28 SSEHub: registered connection 3c6d63867e35b46c229aec92078cefaf (total: 1)
-2026/04/15 02:29:28 SSEHub: unregistered connection 3c6d63867e35b46c229aec92078cefaf (total: 0)
-2026/04/15 02:29:28 Received kill signal.  Quitting Writer. stop 0x54f4d4c23960
-2026/04/15 02:29:28 Cleaning up writer...
-2026/04/15 02:29:28 Finished cleaning up writer:  0x54f4d4c23960
-2026/04/15 02:29:28 Closed MCP-GET-SSE SSE connection: 3c6d63867e35b46c229aec92078cefaf
+2026/04/15 03:02:31 Starting MCP-GET-SSE SSE connection: e18e9e90f78ae1129da82bf355714a43
+2026/04/15 03:02:31 SSEHub: registered connection e18e9e90f78ae1129da82bf355714a43 (total: 1)
+2026/04/15 03:02:31 SSEHub: unregistered connection e18e9e90f78ae1129da82bf355714a43 (total: 0)
+2026/04/15 03:02:31 Received kill signal.  Quitting Writer. stop 0x4f2a80d8d9d0
+2026/04/15 03:02:31 Cleaning up writer...
+2026/04/15 03:02:31 Finished cleaning up writer:  0x4f2a80d8d9d0
+2026/04/15 03:02:31 Closed MCP-GET-SSE SSE connection: e18e9e90f78ae1129da82bf355714a43
 
 === Running scenario: dns-rebinding-protection ===
 Running client scenario 'dns-rebinding-protection' against server: http://localhost:18799/mcp
@@ -450,22 +450,22 @@ Starting scenario: auth/token-endpoint-auth-basic
 Starting scenario: auth/token-endpoint-auth-post
 Starting scenario: auth/token-endpoint-auth-none
 Starting scenario: auth/pre-registration
-Executing client: ./bin/testclient http://localhost:62644/mcp
-Executing client: ./bin/testclient http://localhost:62645/mcp
-Executing client: ./bin/testclient http://localhost:62646/mcp
-Executing client: ./bin/testclient http://localhost:62647/mcp
-Executing client: ./bin/testclient http://localhost:62648/mcp
-Executing client: ./bin/testclient http://localhost:62649/mcp
-Executing client: ./bin/testclient http://localhost:62650/mcp
-Executing client: ./bin/testclient http://localhost:62651/mcp
-Executing client: ./bin/testclient http://localhost:62652/mcp
-Executing client: ./bin/testclient http://localhost:62653/mcp
-Executing client: ./bin/testclient http://localhost:62654/mcp
-Executing client: ./bin/testclient http://localhost:62655/mcp
-Executing client: ./bin/testclient http://localhost:62656/mcp
-Executing client: ./bin/testclient http://localhost:62657/mcp
+Executing client: ./bin/testclient http://localhost:61068/mcp
+Executing client: ./bin/testclient http://localhost:61069/mcp
+Executing client: ./bin/testclient http://localhost:61070/mcp
+Executing client: ./bin/testclient http://localhost:61071/mcp
+Executing client: ./bin/testclient http://localhost:61072/mcp
+Executing client: ./bin/testclient http://localhost:61073/mcp
+Executing client: ./bin/testclient http://localhost:61074/mcp
+Executing client: ./bin/testclient http://localhost:61075/mcp
+Executing client: ./bin/testclient http://localhost:61076/mcp
+Executing client: ./bin/testclient http://localhost:61077/mcp
+Executing client: ./bin/testclient http://localhost:61078/mcp
+Executing client: ./bin/testclient http://localhost:61079/mcp
+Executing client: ./bin/testclient http://localhost:61080/mcp
+Executing client: ./bin/testclient http://localhost:61081/mcp
 With context: {"client_id":"pre-registered-client","client_secret":"pre-registered-secret"}
-(node:32337) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
+(node:52122) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
 (Use `node --trace-deprecation ...` to show where the warning was created)
 
 === SUITE SUMMARY ===
@@ -523,11 +523,11 @@ Waiting for Keycloak realm...
     interop_test.go:167: Keycloak not reachable at http://localhost:8180: Get "http://localhost:8180/realms/mcpkit-test": dial tcp [::1]:8180: connect: connection refused (run 'make upkcl' to start)
 --- SKIP: TestKeycloak_MCPServer_PasswordGrant (0.00s)
 PASS
-ok  	github.com/panyam/mcpkit/tests/keycloak	0.713s
+ok  	github.com/panyam/mcpkit/tests/keycloak	0.514s
 make[2]: *** No rule to make target `downkcl'.  Stop.
   PASS: keycloak
 
 === Results: 9 passed, 0 failed ===
-Finished: Wed Apr 15 02:31:34 PDT 2026
+Finished: Wed Apr 15 03:04:36 PDT 2026
 </pre>
 </body></html>

--- a/tests/reports/run.log
+++ b/tests/reports/run.log
@@ -1,64 +1,64 @@
 === MCPKit Comprehensive Test Suite ===
-Started: Wed Apr 15 02:28:31 PDT 2026
+Started: Wed Apr 15 03:01:42 PDT 2026
 
 --- [1/9] unit+coverage ---
-ok  	github.com/panyam/mcpkit/client	8.913s	coverage: 67.5% of statements
+ok  	github.com/panyam/mcpkit/client	9.105s	coverage: 67.5% of statements
 	github.com/panyam/mcpkit/cmd/testserver		coverage: 0.0% of statements
-ok  	github.com/panyam/mcpkit/core	0.519s	coverage: 49.3% of statements
-ok  	github.com/panyam/mcpkit/server	14.032s	coverage: 78.4% of statements
-ok  	github.com/panyam/mcpkit/testutil	0.913s	coverage: 70.5% of statements
+ok  	github.com/panyam/mcpkit/core	0.327s	coverage: 49.3% of statements
+ok  	github.com/panyam/mcpkit/server	13.876s	coverage: 78.4% of statements
+ok  	github.com/panyam/mcpkit/testutil	1.278s	coverage: 70.5% of statements
 Coverage report: tests/reports/coverage.html
   PASS: unit+coverage
 --- [2/9] race ---
-ok  	github.com/panyam/mcpkit/client	8.999s
+ok  	github.com/panyam/mcpkit/client	9.026s
 ?   	github.com/panyam/mcpkit/cmd/testserver	[no test files]
-ok  	github.com/panyam/mcpkit/core	1.666s
-ok  	github.com/panyam/mcpkit/server	15.182s
-ok  	github.com/panyam/mcpkit/testutil	1.813s
+ok  	github.com/panyam/mcpkit/core	2.035s
+ok  	github.com/panyam/mcpkit/server	14.795s
+ok  	github.com/panyam/mcpkit/testutil	2.429s
   PASS: race
 --- [3/9] auth ---
-ok  	github.com/panyam/mcpkit/ext/auth	0.634s
+ok  	github.com/panyam/mcpkit/ext/auth	0.377s
   PASS: auth
 --- [4/9] ui ---
-ok  	github.com/panyam/mcpkit/ext/ui	0.547s
+ok  	github.com/panyam/mcpkit/ext/ui	0.276s
 
-> @mcpkit/app-bridge@0.1.0 test /Users/dzshrh/newstack/mcpkit/protocol-bundle/ext/ui/assets
+> @mcpkit/app-bridge@0.1.0 test /Users/dzshrh/newstack/mcpkit/main/ext/ui/assets
 > vitest run
 
 
- RUN  v3.2.4 /Users/dzshrh/newstack/mcpkit/protocol-bundle/ext/ui/assets
+ RUN  v3.2.4 /Users/dzshrh/newstack/mcpkit/main/ext/ui/assets
 
- ✓ mcp-app-bridge.test.ts (21 tests) 142ms
+ ✓ mcp-app-bridge.test.ts (33 tests) 389ms
 
  Test Files  1 passed (1)
-      Tests  21 passed (21)
-   Start at  02:29:10
-   Duration  848ms (transform 26ms, setup 0ms, collect 27ms, tests 142ms, environment 342ms, prepare 131ms)
+      Tests  33 passed (33)
+   Start at  03:02:15
+   Duration  964ms (transform 30ms, setup 0ms, collect 27ms, tests 389ms, environment 290ms, prepare 83ms)
 
   PASS: ui
 --- [5/9] protogen ---
 ?   	github.com/panyam/mcpkit/ext/protogen/cmd/protoc-gen-go-mcp	[no test files]
-ok  	github.com/panyam/mcpkit/ext/protogen/generator	0.620s
-ok  	github.com/panyam/mcpkit/ext/protogen/proto/mcp/v1	0.659s
-ok  	github.com/panyam/mcpkit/ext/protogen/runtime	1.191s
-ok  	github.com/panyam/mcpkit/ext/protogen/schema	1.240s
+ok  	github.com/panyam/mcpkit/ext/protogen/generator	1.170s
+ok  	github.com/panyam/mcpkit/ext/protogen/proto/mcp/v1	0.864s
+ok  	github.com/panyam/mcpkit/ext/protogen/runtime	1.467s
+ok  	github.com/panyam/mcpkit/ext/protogen/schema	0.608s
 ?   	github.com/panyam/mcpkit/ext/protogen/testutil	[no test files]
 ==> e2e: bookservice example
 [33mWARN[0m	plugin "protoc-gen-go-mcp" does not support required features.
   Feature "proto3 optional" is required by 1 file(s):
     bookservice/v1/service.proto
-ok  	github.com/panyam/mcpkit/ext/protogen/examples/bookservice	0.818s
+ok  	github.com/panyam/mcpkit/ext/protogen/examples/bookservice	0.661s
 ==> e2e: passed
   PASS: protogen
 --- [6/9] e2e ---
-ok  	github.com/panyam/mcpkit/tests/e2e	3.962s
-ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.712s
+ok  	github.com/panyam/mcpkit/tests/e2e	3.508s
+ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.945s
   PASS: e2e
 --- [7/9] conformance ---
 Killing stale process on port 18799...
 === Starting test server on :18799 (Streamable HTTP) ===
-Waiting for server....2026/04/15 02:29:24 MCP test server listening on :18799 (Streamable HTTP at /mcp)
-. ready
+Waiting for server....2026/04/15 03:02:28 MCP test server listening on :18799 (Streamable HTTP at /mcp)
+ ready
 
 === Running MCP conformance suite ===
 Command: npx -y @modelcontextprotocol/conformance server --url http://localhost:18799/mcp --expected-failures conformance/baseline.yml
@@ -68,293 +68,293 @@ Running active suite (30 scenarios) against http://localhost:18799/mcp
 
 === Running scenario: server-initialize ===
 Running client scenario 'server-initialize' against server: http://localhost:18799/mcp
-2026/04/15 02:29:27 Starting MCP-GET-SSE SSE connection: b8bd2d97a2386e0eb9b334c9321a4170
-2026/04/15 02:29:27 SSEHub: registered connection b8bd2d97a2386e0eb9b334c9321a4170 (total: 1)
-2026/04/15 02:29:27 SSEHub: unregistered connection b8bd2d97a2386e0eb9b334c9321a4170 (total: 0)
-2026/04/15 02:29:27 Received kill signal.  Quitting Writer. stop 0x54f4d474c460
-2026/04/15 02:29:27 Cleaning up writer...
-2026/04/15 02:29:27 Finished cleaning up writer:  0x54f4d474c460
-2026/04/15 02:29:27 Closed MCP-GET-SSE SSE connection: b8bd2d97a2386e0eb9b334c9321a4170
+2026/04/15 03:02:30 Starting MCP-GET-SSE SSE connection: 0dd5d82e91e86a006936610f50cf81ed
+2026/04/15 03:02:30 SSEHub: registered connection 0dd5d82e91e86a006936610f50cf81ed (total: 1)
+2026/04/15 03:02:30 SSEHub: unregistered connection 0dd5d82e91e86a006936610f50cf81ed (total: 0)
+2026/04/15 03:02:30 Received kill signal.  Quitting Writer. stop 0x4f2a810b61c0
+2026/04/15 03:02:30 Cleaning up writer...
+2026/04/15 03:02:30 Finished cleaning up writer:  0x4f2a810b61c0
+2026/04/15 03:02:30 Closed MCP-GET-SSE SSE connection: 0dd5d82e91e86a006936610f50cf81ed
 
 === Running scenario: logging-set-level ===
 Running client scenario 'logging-set-level' against server: http://localhost:18799/mcp
-2026/04/15 02:29:27 Starting MCP-GET-SSE SSE connection: d781bc4ccbdec3a4437dfc9663cb5348
-2026/04/15 02:29:27 SSEHub: registered connection d781bc4ccbdec3a4437dfc9663cb5348 (total: 1)
-2026/04/15 02:29:27 SSEHub: unregistered connection d781bc4ccbdec3a4437dfc9663cb5348 (total: 0)
-2026/04/15 02:29:27 Received kill signal.  Quitting Writer. stop 0x54f4d474c700
-2026/04/15 02:29:27 Cleaning up writer...
-2026/04/15 02:29:27 Finished cleaning up writer:  0x54f4d474c700
-2026/04/15 02:29:27 Closed MCP-GET-SSE SSE connection: d781bc4ccbdec3a4437dfc9663cb5348
+2026/04/15 03:02:30 Starting MCP-GET-SSE SSE connection: 150039cf984ce8794e2fa7e0cc7abc15
+2026/04/15 03:02:30 SSEHub: registered connection 150039cf984ce8794e2fa7e0cc7abc15 (total: 1)
+2026/04/15 03:02:30 SSEHub: unregistered connection 150039cf984ce8794e2fa7e0cc7abc15 (total: 0)
+2026/04/15 03:02:30 Received kill signal.  Quitting Writer. stop 0x4f2a80c90310
+2026/04/15 03:02:30 Cleaning up writer...
+2026/04/15 03:02:30 Finished cleaning up writer:  0x4f2a80c90310
+2026/04/15 03:02:30 Closed MCP-GET-SSE SSE connection: 150039cf984ce8794e2fa7e0cc7abc15
 
 === Running scenario: ping ===
 Running client scenario 'ping' against server: http://localhost:18799/mcp
-2026/04/15 02:29:27 Starting MCP-GET-SSE SSE connection: f83e0a5a50534f01dc7f296ac72448f7
-2026/04/15 02:29:27 SSEHub: registered connection f83e0a5a50534f01dc7f296ac72448f7 (total: 1)
-2026/04/15 02:29:27 SSEHub: unregistered connection f83e0a5a50534f01dc7f296ac72448f7 (total: 0)
-2026/04/15 02:29:27 Received kill signal.  Quitting Writer. stop 0x54f4d474c9a0
-2026/04/15 02:29:27 Cleaning up writer...
-2026/04/15 02:29:27 Finished cleaning up writer:  0x54f4d474c9a0
+2026/04/15 03:02:30 Starting MCP-GET-SSE SSE connection: a3f44105324c5648570980786bf5226f
+2026/04/15 03:02:30 SSEHub: registered connection a3f44105324c5648570980786bf5226f (total: 1)
+2026/04/15 03:02:30 SSEHub: unregistered connection a3f44105324c5648570980786bf5226f (total: 0)
+2026/04/15 03:02:30 Received kill signal.  Quitting Writer. stop 0x4f2a810b6460
+2026/04/15 03:02:30 Cleaning up writer...
+2026/04/15 03:02:30 Finished cleaning up writer:  0x4f2a810b6460
+2026/04/15 03:02:30 Closed MCP-GET-SSE SSE connection: a3f44105324c5648570980786bf5226f
 
 === Running scenario: completion-complete ===
-2026/04/15 02:29:27 Closed MCP-GET-SSE SSE connection: f83e0a5a50534f01dc7f296ac72448f7
 Running client scenario 'completion-complete' against server: http://localhost:18799/mcp
-2026/04/15 02:29:27 Starting MCP-GET-SSE SSE connection: d87658b3265dda3224a71cabc193675d
-2026/04/15 02:29:27 SSEHub: registered connection d87658b3265dda3224a71cabc193675d (total: 1)
-2026/04/15 02:29:27 SSEHub: unregistered connection d87658b3265dda3224a71cabc193675d (total: 0)
-2026/04/15 02:29:27 Received kill signal.  Quitting Writer. stop 0x54f4d474c310
-2026/04/15 02:29:27 Cleaning up writer...
-2026/04/15 02:29:27 Finished cleaning up writer:  0x54f4d474c310
-2026/04/15 02:29:27 Closed MCP-GET-SSE SSE connection: d87658b3265dda3224a71cabc193675d
+2026/04/15 03:02:30 Starting MCP-GET-SSE SSE connection: 0c80e36e2e7f7d03b2cf225abd775d42
+2026/04/15 03:02:30 SSEHub: registered connection 0c80e36e2e7f7d03b2cf225abd775d42 (total: 1)
+2026/04/15 03:02:30 SSEHub: unregistered connection 0c80e36e2e7f7d03b2cf225abd775d42 (total: 0)
+2026/04/15 03:02:30 Received kill signal.  Quitting Writer. stop 0x4f2a80d4a3f0
+2026/04/15 03:02:30 Cleaning up writer...
+2026/04/15 03:02:30 Finished cleaning up writer:  0x4f2a80d4a3f0
+2026/04/15 03:02:30 Closed MCP-GET-SSE SSE connection: 0c80e36e2e7f7d03b2cf225abd775d42
 
 === Running scenario: tools-list ===
 Running client scenario 'tools-list' against server: http://localhost:18799/mcp
-2026/04/15 02:29:27 Starting MCP-GET-SSE SSE connection: 816da42a2c5ad63f8e17e8ef6e31f428
-2026/04/15 02:29:27 SSEHub: registered connection 816da42a2c5ad63f8e17e8ef6e31f428 (total: 1)
-2026/04/15 02:29:27 SSEHub: unregistered connection 816da42a2c5ad63f8e17e8ef6e31f428 (total: 0)
-2026/04/15 02:29:27 Received kill signal.  Quitting Writer. stop 0x54f4d474c690
-2026/04/15 02:29:27 Cleaning up writer...
-2026/04/15 02:29:27 Finished cleaning up writer:  0x54f4d474c690
-2026/04/15 02:29:27 Closed MCP-GET-SSE SSE connection: 816da42a2c5ad63f8e17e8ef6e31f428
+2026/04/15 03:02:30 Starting MCP-GET-SSE SSE connection: 1f84ecd78d25da8fedafda8b166a7234
+2026/04/15 03:02:30 SSEHub: registered connection 1f84ecd78d25da8fedafda8b166a7234 (total: 1)
+2026/04/15 03:02:30 SSEHub: unregistered connection 1f84ecd78d25da8fedafda8b166a7234 (total: 0)
+2026/04/15 03:02:30 Received kill signal.  Quitting Writer. stop 0x4f2a80d4a150
 
 === Running scenario: tools-call-simple-text ===
+2026/04/15 03:02:30 Cleaning up writer...
 Running client scenario 'tools-call-simple-text' against server: http://localhost:18799/mcp
-2026/04/15 02:29:27 Starting MCP-GET-SSE SSE connection: a4f07b20ae38aa8867d7cbfa1ce5f6e6
-2026/04/15 02:29:27 SSEHub: registered connection a4f07b20ae38aa8867d7cbfa1ce5f6e6 (total: 1)
-2026/04/15 02:29:27 SSEHub: unregistered connection a4f07b20ae38aa8867d7cbfa1ce5f6e6 (total: 0)
-2026/04/15 02:29:27 Received kill signal.  Quitting Writer. stop 0x54f4d474c930
-2026/04/15 02:29:27 Cleaning up writer...
-2026/04/15 02:29:27 Finished cleaning up writer:  0x54f4d474c930
-2026/04/15 02:29:27 Closed MCP-GET-SSE SSE connection: a4f07b20ae38aa8867d7cbfa1ce5f6e6
+2026/04/15 03:02:30 Finished cleaning up writer:  0x4f2a80d4a150
+2026/04/15 03:02:30 Closed MCP-GET-SSE SSE connection: 1f84ecd78d25da8fedafda8b166a7234
+2026/04/15 03:02:30 Starting MCP-GET-SSE SSE connection: 51328831cd98b9d995c6e4c4b58d6991
+2026/04/15 03:02:30 SSEHub: registered connection 51328831cd98b9d995c6e4c4b58d6991 (total: 1)
+2026/04/15 03:02:30 SSEHub: unregistered connection 51328831cd98b9d995c6e4c4b58d6991 (total: 0)
+2026/04/15 03:02:30 Received kill signal.  Quitting Writer. stop 0x4f2a80d4a690
+2026/04/15 03:02:30 Cleaning up writer...
+2026/04/15 03:02:30 Finished cleaning up writer:  0x4f2a80d4a690
+2026/04/15 03:02:30 Closed MCP-GET-SSE SSE connection: 51328831cd98b9d995c6e4c4b58d6991
 
 === Running scenario: tools-call-image ===
 Running client scenario 'tools-call-image' against server: http://localhost:18799/mcp
-2026/04/15 02:29:27 Starting MCP-GET-SSE SSE connection: e1f39eb48f6b11335b67ac1405f5a9cb
-2026/04/15 02:29:27 SSEHub: registered connection e1f39eb48f6b11335b67ac1405f5a9cb (total: 1)
-2026/04/15 02:29:27 SSEHub: unregistered connection e1f39eb48f6b11335b67ac1405f5a9cb (total: 0)
-2026/04/15 02:29:27 Received kill signal.  Quitting Writer. stop 0x54f4d4812af0
-2026/04/15 02:29:27 Cleaning up writer...
-2026/04/15 02:29:27 Finished cleaning up writer:  0x54f4d4812af0
-2026/04/15 02:29:27 Closed MCP-GET-SSE SSE connection: e1f39eb48f6b11335b67ac1405f5a9cb
+2026/04/15 03:02:30 Starting MCP-GET-SSE SSE connection: f8f7589cc3eab31add156a19992c941d
+2026/04/15 03:02:30 SSEHub: registered connection f8f7589cc3eab31add156a19992c941d (total: 1)
+2026/04/15 03:02:30 SSEHub: unregistered connection f8f7589cc3eab31add156a19992c941d (total: 0)
+2026/04/15 03:02:30 Received kill signal.  Quitting Writer. stop 0x4f2a80d4a8c0
 
 === Running scenario: tools-call-audio ===
+2026/04/15 03:02:30 Cleaning up writer...
 Running client scenario 'tools-call-audio' against server: http://localhost:18799/mcp
-2026/04/15 02:29:27 Starting MCP-GET-SSE SSE connection: a0aa1df6af4dab08dfd2f32565350fb0
-2026/04/15 02:29:27 SSEHub: registered connection a0aa1df6af4dab08dfd2f32565350fb0 (total: 1)
-2026/04/15 02:29:27 SSEHub: unregistered connection a0aa1df6af4dab08dfd2f32565350fb0 (total: 0)
-2026/04/15 02:29:27 Received kill signal.  Quitting Writer. stop 0x54f4d4812d20
-2026/04/15 02:29:27 Cleaning up writer...
-2026/04/15 02:29:27 Finished cleaning up writer:  0x54f4d4812d20
-2026/04/15 02:29:27 Closed MCP-GET-SSE SSE connection: a0aa1df6af4dab08dfd2f32565350fb0
+2026/04/15 03:02:30 Finished cleaning up writer:  0x4f2a80d4a8c0
+2026/04/15 03:02:30 Closed MCP-GET-SSE SSE connection: f8f7589cc3eab31add156a19992c941d
+2026/04/15 03:02:30 Starting MCP-GET-SSE SSE connection: 2745f16b7b7bb7587bcc43069faa1c63
+2026/04/15 03:02:30 SSEHub: registered connection 2745f16b7b7bb7587bcc43069faa1c63 (total: 1)
+2026/04/15 03:02:30 SSEHub: unregistered connection 2745f16b7b7bb7587bcc43069faa1c63 (total: 0)
+2026/04/15 03:02:30 Received kill signal.  Quitting Writer. stop 0x4f2a810b6310
+2026/04/15 03:02:30 Cleaning up writer...
+2026/04/15 03:02:30 Finished cleaning up writer:  0x4f2a810b6310
+2026/04/15 03:02:30 Closed MCP-GET-SSE SSE connection: 2745f16b7b7bb7587bcc43069faa1c63
 
 === Running scenario: tools-call-embedded-resource ===
 Running client scenario 'tools-call-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/15 02:29:27 Starting MCP-GET-SSE SSE connection: 5ff99272670130367655141f6c3e1e51
-2026/04/15 02:29:27 SSEHub: registered connection 5ff99272670130367655141f6c3e1e51 (total: 1)
-2026/04/15 02:29:27 SSEHub: unregistered connection 5ff99272670130367655141f6c3e1e51 (total: 0)
-2026/04/15 02:29:27 Received kill signal.  Quitting Writer. stop 0x54f4d4813030
-2026/04/15 02:29:27 Cleaning up writer...
-2026/04/15 02:29:27 Finished cleaning up writer:  0x54f4d4813030
-2026/04/15 02:29:27 Closed MCP-GET-SSE SSE connection: 5ff99272670130367655141f6c3e1e51
+2026/04/15 03:02:30 Starting MCP-GET-SSE SSE connection: 20f6b72dff9fbc61c7047146d2bef265
+2026/04/15 03:02:30 SSEHub: registered connection 20f6b72dff9fbc61c7047146d2bef265 (total: 1)
+2026/04/15 03:02:30 SSEHub: unregistered connection 20f6b72dff9fbc61c7047146d2bef265 (total: 0)
+2026/04/15 03:02:30 Received kill signal.  Quitting Writer. stop 0x4f2a80d8cbd0
+2026/04/15 03:02:30 Cleaning up writer...
+2026/04/15 03:02:30 Finished cleaning up writer:  0x4f2a80d8cbd0
+2026/04/15 03:02:30 Closed MCP-GET-SSE SSE connection: 20f6b72dff9fbc61c7047146d2bef265
 
 === Running scenario: tools-call-mixed-content ===
 Running client scenario 'tools-call-mixed-content' against server: http://localhost:18799/mcp
-2026/04/15 02:29:27 Starting MCP-GET-SSE SSE connection: b7054e97a885ccfc223a2e8bd69581fd
-2026/04/15 02:29:27 SSEHub: registered connection b7054e97a885ccfc223a2e8bd69581fd (total: 1)
-2026/04/15 02:29:27 SSEHub: unregistered connection b7054e97a885ccfc223a2e8bd69581fd (total: 0)
-2026/04/15 02:29:27 Received kill signal.  Quitting Writer. stop 0x54f4d4813260
-2026/04/15 02:29:27 Cleaning up writer...
-2026/04/15 02:29:27 Finished cleaning up writer:  0x54f4d4813260
-2026/04/15 02:29:27 Closed MCP-GET-SSE SSE connection: b7054e97a885ccfc223a2e8bd69581fd
+2026/04/15 03:02:30 Starting MCP-GET-SSE SSE connection: 9373f8a8f2235080689ee3a73c885947
+2026/04/15 03:02:30 SSEHub: registered connection 9373f8a8f2235080689ee3a73c885947 (total: 1)
+2026/04/15 03:02:30 SSEHub: unregistered connection 9373f8a8f2235080689ee3a73c885947 (total: 0)
+2026/04/15 03:02:30 Received kill signal.  Quitting Writer. stop 0x4f2a810b6690
+2026/04/15 03:02:30 Cleaning up writer...
+2026/04/15 03:02:30 Finished cleaning up writer:  0x4f2a810b6690
+2026/04/15 03:02:30 Closed MCP-GET-SSE SSE connection: 9373f8a8f2235080689ee3a73c885947
 
 === Running scenario: tools-call-with-logging ===
 Running client scenario 'tools-call-with-logging' against server: http://localhost:18799/mcp
-2026/04/15 02:29:27 Starting MCP-GET-SSE SSE connection: 2508ed2d75f02352e0965fae950e6085
-2026/04/15 02:29:27 SSEHub: registered connection 2508ed2d75f02352e0965fae950e6085 (total: 1)
-2026/04/15 02:29:27 SSEHub: unregistered connection 2508ed2d75f02352e0965fae950e6085 (total: 0)
-2026/04/15 02:29:27 Received kill signal.  Quitting Writer. stop 0x54f4d4c223f0
-2026/04/15 02:29:27 Cleaning up writer...
-2026/04/15 02:29:27 Finished cleaning up writer:  0x54f4d4c223f0
-2026/04/15 02:29:27 Closed MCP-GET-SSE SSE connection: 2508ed2d75f02352e0965fae950e6085
+2026/04/15 03:02:30 Starting MCP-GET-SSE SSE connection: 7e5325719435c6d0e27899818b193d49
+2026/04/15 03:02:30 SSEHub: registered connection 7e5325719435c6d0e27899818b193d49 (total: 1)
+2026/04/15 03:02:31 SSEHub: unregistered connection 7e5325719435c6d0e27899818b193d49 (total: 0)
 
 === Running scenario: tools-call-error ===
+2026/04/15 03:02:31 Received kill signal.  Quitting Writer. stop 0x4f2a80d4abd0
+2026/04/15 03:02:31 Cleaning up writer...
+2026/04/15 03:02:31 Finished cleaning up writer:  0x4f2a80d4abd0
 Running client scenario 'tools-call-error' against server: http://localhost:18799/mcp
-2026/04/15 02:29:27 Starting MCP-GET-SSE SSE connection: 52bea4186f1a057510e136befc26b8d6
-2026/04/15 02:29:27 SSEHub: registered connection 52bea4186f1a057510e136befc26b8d6 (total: 1)
+2026/04/15 03:02:31 Closed MCP-GET-SSE SSE connection: 7e5325719435c6d0e27899818b193d49
+2026/04/15 03:02:31 Starting MCP-GET-SSE SSE connection: 8f30a6c40f804472be8800da8b5207b9
+2026/04/15 03:02:31 SSEHub: registered connection 8f30a6c40f804472be8800da8b5207b9 (total: 1)
+2026/04/15 03:02:31 SSEHub: unregistered connection 8f30a6c40f804472be8800da8b5207b9 (total: 0)
+2026/04/15 03:02:31 Received kill signal.  Quitting Writer. stop 0x4f2a80d4ae00
+2026/04/15 03:02:31 Cleaning up writer...
+2026/04/15 03:02:31 Finished cleaning up writer:  0x4f2a80d4ae00
+2026/04/15 03:02:31 Closed MCP-GET-SSE SSE connection: 8f30a6c40f804472be8800da8b5207b9
 
 === Running scenario: tools-call-with-progress ===
-2026/04/15 02:29:27 SSEHub: unregistered connection 52bea4186f1a057510e136befc26b8d6 (total: 0)
 Running client scenario 'tools-call-with-progress' against server: http://localhost:18799/mcp
-2026/04/15 02:29:27 Received kill signal.  Quitting Writer. stop 0x54f4d489c150
-2026/04/15 02:29:27 Cleaning up writer...
-2026/04/15 02:29:27 Finished cleaning up writer:  0x54f4d489c150
-2026/04/15 02:29:27 Closed MCP-GET-SSE SSE connection: 52bea4186f1a057510e136befc26b8d6
-2026/04/15 02:29:27 Starting MCP-GET-SSE SSE connection: ea602dd5b7f6a1ea8e08dedd9f3658b5
-2026/04/15 02:29:27 SSEHub: registered connection ea602dd5b7f6a1ea8e08dedd9f3658b5 (total: 1)
-2026/04/15 02:29:28 SSEHub: unregistered connection ea602dd5b7f6a1ea8e08dedd9f3658b5 (total: 0)
-2026/04/15 02:29:28 Received kill signal.  Quitting Writer. stop 0x54f4d4c227e0
-2026/04/15 02:29:28 Cleaning up writer...
-2026/04/15 02:29:28 Finished cleaning up writer:  0x54f4d4c227e0
-2026/04/15 02:29:28 Closed MCP-GET-SSE SSE connection: ea602dd5b7f6a1ea8e08dedd9f3658b5
+2026/04/15 03:02:31 Starting MCP-GET-SSE SSE connection: f269a7116c3eae8512d18363e89b1ec1
+2026/04/15 03:02:31 SSEHub: registered connection f269a7116c3eae8512d18363e89b1ec1 (total: 1)
+2026/04/15 03:02:31 SSEHub: unregistered connection f269a7116c3eae8512d18363e89b1ec1 (total: 0)
+2026/04/15 03:02:31 Received kill signal.  Quitting Writer. stop 0x4f2a810b6a10
+2026/04/15 03:02:31 Cleaning up writer...
+2026/04/15 03:02:31 Finished cleaning up writer:  0x4f2a810b6a10
+2026/04/15 03:02:31 Closed MCP-GET-SSE SSE connection: f269a7116c3eae8512d18363e89b1ec1
 
 === Running scenario: tools-call-sampling ===
 Running client scenario 'tools-call-sampling' against server: http://localhost:18799/mcp
-2026/04/15 02:29:28 Starting MCP-GET-SSE SSE connection: a639d24179acb98d608b6a2347e9e853
-2026/04/15 02:29:28 SSEHub: registered connection a639d24179acb98d608b6a2347e9e853 (total: 1)
-2026/04/15 02:29:28 SSEHub: unregistered connection a639d24179acb98d608b6a2347e9e853 (total: 0)
-2026/04/15 02:29:28 Received kill signal.  Quitting Writer. stop 0x54f4d4813570
-2026/04/15 02:29:28 Cleaning up writer...
-2026/04/15 02:29:28 Finished cleaning up writer:  0x54f4d4813570
-2026/04/15 02:29:28 Closed MCP-GET-SSE SSE connection: a639d24179acb98d608b6a2347e9e853
+2026/04/15 03:02:31 Starting MCP-GET-SSE SSE connection: 9ee38589d6fc2d47a52a26551558ee40
+2026/04/15 03:02:31 SSEHub: registered connection 9ee38589d6fc2d47a52a26551558ee40 (total: 1)
+2026/04/15 03:02:31 SSEHub: unregistered connection 9ee38589d6fc2d47a52a26551558ee40 (total: 0)
+2026/04/15 03:02:31 Received kill signal.  Quitting Writer. stop 0x4f2a80c905b0
+2026/04/15 03:02:31 Cleaning up writer...
+2026/04/15 03:02:31 Finished cleaning up writer:  0x4f2a80c905b0
+2026/04/15 03:02:31 Closed MCP-GET-SSE SSE connection: 9ee38589d6fc2d47a52a26551558ee40
 
 === Running scenario: tools-call-elicitation ===
 Running client scenario 'tools-call-elicitation' against server: http://localhost:18799/mcp
-2026/04/15 02:29:28 Starting MCP-GET-SSE SSE connection: e19ddda2b0be4c4962db01594696fef1
-2026/04/15 02:29:28 SSEHub: registered connection e19ddda2b0be4c4962db01594696fef1 (total: 1)
-2026/04/15 02:29:28 SSEHub: unregistered connection e19ddda2b0be4c4962db01594696fef1 (total: 0)
-2026/04/15 02:29:28 Received kill signal.  Quitting Writer. stop 0x54f4d489c770
-2026/04/15 02:29:28 Cleaning up writer...
-2026/04/15 02:29:28 Finished cleaning up writer:  0x54f4d489c770
-2026/04/15 02:29:28 Closed MCP-GET-SSE SSE connection: e19ddda2b0be4c4962db01594696fef1
+2026/04/15 03:02:31 Starting MCP-GET-SSE SSE connection: fd103350700f2fc8f36e0483543ef055
+2026/04/15 03:02:31 SSEHub: registered connection fd103350700f2fc8f36e0483543ef055 (total: 1)
+2026/04/15 03:02:31 SSEHub: unregistered connection fd103350700f2fc8f36e0483543ef055 (total: 0)
 
 === Running scenario: elicitation-sep1034-defaults ===
+2026/04/15 03:02:31 Received kill signal.  Quitting Writer. stop 0x4f2a80d4b110
 Running client scenario 'elicitation-sep1034-defaults' against server: http://localhost:18799/mcp
-2026/04/15 02:29:28 Starting MCP-GET-SSE SSE connection: aff9727c850b143d73a1e4c6bfa22e0f
-2026/04/15 02:29:28 SSEHub: registered connection aff9727c850b143d73a1e4c6bfa22e0f (total: 1)
-2026/04/15 02:29:28 SSEHub: unregistered connection aff9727c850b143d73a1e4c6bfa22e0f (total: 0)
-2026/04/15 02:29:28 Received kill signal.  Quitting Writer. stop 0x54f4d474ce70
-2026/04/15 02:29:28 Cleaning up writer...
+2026/04/15 03:02:31 Cleaning up writer...
+2026/04/15 03:02:31 Finished cleaning up writer:  0x4f2a80d4b110
+2026/04/15 03:02:31 Closed MCP-GET-SSE SSE connection: fd103350700f2fc8f36e0483543ef055
+2026/04/15 03:02:31 Starting MCP-GET-SSE SSE connection: dad9bc88dec971e2ea32cf0f2cd0c137
+2026/04/15 03:02:31 SSEHub: registered connection dad9bc88dec971e2ea32cf0f2cd0c137 (total: 1)
+2026/04/15 03:02:31 SSEHub: unregistered connection dad9bc88dec971e2ea32cf0f2cd0c137 (total: 0)
+2026/04/15 03:02:31 Received kill signal.  Quitting Writer. stop 0x4f2a80d8cf50
+2026/04/15 03:02:31 Cleaning up writer...
+2026/04/15 03:02:31 Finished cleaning up writer:  0x4f2a80d8cf50
+2026/04/15 03:02:31 Closed MCP-GET-SSE SSE connection: dad9bc88dec971e2ea32cf0f2cd0c137
 
 === Running scenario: server-sse-multiple-streams ===
-2026/04/15 02:29:28 Finished cleaning up writer:  0x54f4d474ce70
-2026/04/15 02:29:28 Closed MCP-GET-SSE SSE connection: aff9727c850b143d73a1e4c6bfa22e0f
 Running client scenario 'server-sse-multiple-streams' against server: http://localhost:18799/mcp
-2026/04/15 02:29:28 Starting MCP-GET-SSE SSE connection: d401f2fdf9d457107f5bc6c8275dd582
-2026/04/15 02:29:28 SSEHub: registered connection d401f2fdf9d457107f5bc6c8275dd582 (total: 1)
-2026/04/15 02:29:28 SSEHub: unregistered connection d401f2fdf9d457107f5bc6c8275dd582 (total: 0)
+2026/04/15 03:02:31 Starting MCP-GET-SSE SSE connection: 7f549a093b071c0b9edc1fcd2743beec
+2026/04/15 03:02:31 SSEHub: registered connection 7f549a093b071c0b9edc1fcd2743beec (total: 1)
 
 === Running scenario: elicitation-sep1330-enums ===
-2026/04/15 02:29:28 Received kill signal.  Quitting Writer. stop 0x54f4d474d110
-2026/04/15 02:29:28 Cleaning up writer...
-2026/04/15 02:29:28 Finished cleaning up writer:  0x54f4d474d110
 Running client scenario 'elicitation-sep1330-enums' against server: http://localhost:18799/mcp
-2026/04/15 02:29:28 Closed MCP-GET-SSE SSE connection: d401f2fdf9d457107f5bc6c8275dd582
-2026/04/15 02:29:28 Starting MCP-GET-SSE SSE connection: a4e2aac513d8fa84565a7aa087fee0ee
-2026/04/15 02:29:28 SSEHub: registered connection a4e2aac513d8fa84565a7aa087fee0ee (total: 1)
-2026/04/15 02:29:28 SSEHub: unregistered connection a4e2aac513d8fa84565a7aa087fee0ee (total: 0)
-2026/04/15 02:29:28 Received kill signal.  Quitting Writer. stop 0x54f4d4c22b60
-2026/04/15 02:29:28 Cleaning up writer...
-2026/04/15 02:29:28 Finished cleaning up writer:  0x54f4d4c22b60
-2026/04/15 02:29:28 Closed MCP-GET-SSE SSE connection: a4e2aac513d8fa84565a7aa087fee0ee
+2026/04/15 03:02:31 SSEHub: unregistered connection 7f549a093b071c0b9edc1fcd2743beec (total: 0)
+2026/04/15 03:02:31 Received kill signal.  Quitting Writer. stop 0x4f2a80d4b730
+2026/04/15 03:02:31 Cleaning up writer...
+2026/04/15 03:02:31 Finished cleaning up writer:  0x4f2a80d4b730
+2026/04/15 03:02:31 Closed MCP-GET-SSE SSE connection: 7f549a093b071c0b9edc1fcd2743beec
+2026/04/15 03:02:31 Starting MCP-GET-SSE SSE connection: a6857aa3abe32e20ab8aa489cdd9b1de
+2026/04/15 03:02:31 SSEHub: registered connection a6857aa3abe32e20ab8aa489cdd9b1de (total: 1)
 
 === Running scenario: resources-list ===
+2026/04/15 03:02:31 SSEHub: unregistered connection a6857aa3abe32e20ab8aa489cdd9b1de (total: 0)
 Running client scenario 'resources-list' against server: http://localhost:18799/mcp
-2026/04/15 02:29:28 Starting MCP-GET-SSE SSE connection: 905dfc6e49ab9b640692eb0ba1ef6f55
-2026/04/15 02:29:28 SSEHub: registered connection 905dfc6e49ab9b640692eb0ba1ef6f55 (total: 1)
-2026/04/15 02:29:28 SSEHub: unregistered connection 905dfc6e49ab9b640692eb0ba1ef6f55 (total: 0)
-2026/04/15 02:29:28 Received kill signal.  Quitting Writer. stop 0x54f4d4813ab0
-2026/04/15 02:29:28 Cleaning up writer...
-2026/04/15 02:29:28 Finished cleaning up writer:  0x54f4d4813ab0
-2026/04/15 02:29:28 Closed MCP-GET-SSE SSE connection: 905dfc6e49ab9b640692eb0ba1ef6f55
+2026/04/15 03:02:31 Received kill signal.  Quitting Writer. stop 0x4f2a810b6f50
+2026/04/15 03:02:31 Cleaning up writer...
+2026/04/15 03:02:31 Finished cleaning up writer:  0x4f2a810b6f50
+2026/04/15 03:02:31 Closed MCP-GET-SSE SSE connection: a6857aa3abe32e20ab8aa489cdd9b1de
+2026/04/15 03:02:31 Starting MCP-GET-SSE SSE connection: 4361b460e25ef436e9a29325deb86aa5
+2026/04/15 03:02:31 SSEHub: registered connection 4361b460e25ef436e9a29325deb86aa5 (total: 1)
+2026/04/15 03:02:31 SSEHub: unregistered connection 4361b460e25ef436e9a29325deb86aa5 (total: 0)
+2026/04/15 03:02:31 Received kill signal.  Quitting Writer. stop 0x4f2a80c90b60
+2026/04/15 03:02:31 Cleaning up writer...
+2026/04/15 03:02:31 Finished cleaning up writer:  0x4f2a80c90b60
+2026/04/15 03:02:31 Closed MCP-GET-SSE SSE connection: 4361b460e25ef436e9a29325deb86aa5
 
 === Running scenario: resources-read-text ===
 Running client scenario 'resources-read-text' against server: http://localhost:18799/mcp
-2026/04/15 02:29:28 Starting MCP-GET-SSE SSE connection: 3dd99bb29cad45cb1f81cce19aa63f76
-2026/04/15 02:29:28 SSEHub: registered connection 3dd99bb29cad45cb1f81cce19aa63f76 (total: 1)
-2026/04/15 02:29:28 SSEHub: unregistered connection 3dd99bb29cad45cb1f81cce19aa63f76 (total: 0)
-2026/04/15 02:29:28 Received kill signal.  Quitting Writer. stop 0x54f4d4c22e70
-2026/04/15 02:29:28 Cleaning up writer...
+2026/04/15 03:02:31 Starting MCP-GET-SSE SSE connection: b7e1697b8e213df3a5872d0ba9063f6b
+2026/04/15 03:02:31 SSEHub: registered connection b7e1697b8e213df3a5872d0ba9063f6b (total: 1)
 
 === Running scenario: resources-read-binary ===
-2026/04/15 02:29:28 Finished cleaning up writer:  0x54f4d4c22e70
 Running client scenario 'resources-read-binary' against server: http://localhost:18799/mcp
-2026/04/15 02:29:28 Closed MCP-GET-SSE SSE connection: 3dd99bb29cad45cb1f81cce19aa63f76
-2026/04/15 02:29:28 Starting MCP-GET-SSE SSE connection: eee129a54a8e596d11984bc5eedb0416
-2026/04/15 02:29:28 SSEHub: registered connection eee129a54a8e596d11984bc5eedb0416 (total: 1)
-2026/04/15 02:29:28 SSEHub: unregistered connection eee129a54a8e596d11984bc5eedb0416 (total: 0)
-2026/04/15 02:29:28 Received kill signal.  Quitting Writer. stop 0x54f4d4c23110
-2026/04/15 02:29:28 Cleaning up writer...
+2026/04/15 03:02:31 SSEHub: unregistered connection b7e1697b8e213df3a5872d0ba9063f6b (total: 0)
+2026/04/15 03:02:31 Received kill signal.  Quitting Writer. stop 0x4f2a80d8d2d0
+2026/04/15 03:02:31 Cleaning up writer...
+2026/04/15 03:02:31 Finished cleaning up writer:  0x4f2a80d8d2d0
+2026/04/15 03:02:31 Closed MCP-GET-SSE SSE connection: b7e1697b8e213df3a5872d0ba9063f6b
+2026/04/15 03:02:31 Starting MCP-GET-SSE SSE connection: 8e88b9a5c4f0db79b644575592d2d832
+2026/04/15 03:02:31 SSEHub: registered connection 8e88b9a5c4f0db79b644575592d2d832 (total: 1)
+2026/04/15 03:02:31 SSEHub: unregistered connection 8e88b9a5c4f0db79b644575592d2d832 (total: 0)
 
 === Running scenario: resources-templates-read ===
-2026/04/15 02:29:28 Finished cleaning up writer:  0x54f4d4c23110
+2026/04/15 03:02:31 Received kill signal.  Quitting Writer. stop 0x4f2a80d4b9d0
+2026/04/15 03:02:31 Cleaning up writer...
+2026/04/15 03:02:31 Finished cleaning up writer:  0x4f2a80d4b9d0
+2026/04/15 03:02:31 Closed MCP-GET-SSE SSE connection: 8e88b9a5c4f0db79b644575592d2d832
 Running client scenario 'resources-templates-read' against server: http://localhost:18799/mcp
-2026/04/15 02:29:28 Closed MCP-GET-SSE SSE connection: eee129a54a8e596d11984bc5eedb0416
-2026/04/15 02:29:28 Starting MCP-GET-SSE SSE connection: f741a6887cba9aa1e35344334cd4bcdf
-2026/04/15 02:29:28 SSEHub: registered connection f741a6887cba9aa1e35344334cd4bcdf (total: 1)
-2026/04/15 02:29:28 SSEHub: unregistered connection f741a6887cba9aa1e35344334cd4bcdf (total: 0)
-2026/04/15 02:29:28 Received kill signal.  Quitting Writer. stop 0x54f4d4813ce0
-2026/04/15 02:29:28 Cleaning up writer...
-2026/04/15 02:29:28 Finished cleaning up writer:  0x54f4d4813ce0
-2026/04/15 02:29:28 Closed MCP-GET-SSE SSE connection: f741a6887cba9aa1e35344334cd4bcdf
+2026/04/15 03:02:31 Starting MCP-GET-SSE SSE connection: 354b879ed0b1bc37c50b2b5ca2b6e855
+2026/04/15 03:02:31 SSEHub: registered connection 354b879ed0b1bc37c50b2b5ca2b6e855 (total: 1)
+2026/04/15 03:02:31 SSEHub: unregistered connection 354b879ed0b1bc37c50b2b5ca2b6e855 (total: 0)
+2026/04/15 03:02:31 Received kill signal.  Quitting Writer. stop 0x4f2a80d8d5e0
+2026/04/15 03:02:31 Cleaning up writer...
 
 === Running scenario: resources-subscribe ===
+2026/04/15 03:02:31 Finished cleaning up writer:  0x4f2a80d8d5e0
 Running client scenario 'resources-subscribe' against server: http://localhost:18799/mcp
-2026/04/15 02:29:28 Starting MCP-GET-SSE SSE connection: 1fe10bafc4fff678781e8a8c9c4aa3f2
-2026/04/15 02:29:28 SSEHub: registered connection 1fe10bafc4fff678781e8a8c9c4aa3f2 (total: 1)
-2026/04/15 02:29:28 SSEHub: unregistered connection 1fe10bafc4fff678781e8a8c9c4aa3f2 (total: 0)
-2026/04/15 02:29:28 Received kill signal.  Quitting Writer. stop 0x54f4d4c233b0
-2026/04/15 02:29:28 Cleaning up writer...
-2026/04/15 02:29:28 Finished cleaning up writer:  0x54f4d4c233b0
-2026/04/15 02:29:28 Closed MCP-GET-SSE SSE connection: 1fe10bafc4fff678781e8a8c9c4aa3f2
+2026/04/15 03:02:31 Closed MCP-GET-SSE SSE connection: 354b879ed0b1bc37c50b2b5ca2b6e855
+2026/04/15 03:02:31 Starting MCP-GET-SSE SSE connection: 656e99badeeec3c35889ba88d39d9ad8
+2026/04/15 03:02:31 SSEHub: registered connection 656e99badeeec3c35889ba88d39d9ad8 (total: 1)
+2026/04/15 03:02:31 SSEHub: unregistered connection 656e99badeeec3c35889ba88d39d9ad8 (total: 0)
+2026/04/15 03:02:31 Received kill signal.  Quitting Writer. stop 0x4f2a810b72d0
 
 === Running scenario: resources-unsubscribe ===
+2026/04/15 03:02:31 Cleaning up writer...
 Running client scenario 'resources-unsubscribe' against server: http://localhost:18799/mcp
-2026/04/15 02:29:28 Starting MCP-GET-SSE SSE connection: 3c790c9c92d944b7ccd68cc5d71d6032
-2026/04/15 02:29:28 SSEHub: registered connection 3c790c9c92d944b7ccd68cc5d71d6032 (total: 1)
-2026/04/15 02:29:28 SSEHub: unregistered connection 3c790c9c92d944b7ccd68cc5d71d6032 (total: 0)
-2026/04/15 02:29:28 Received kill signal.  Quitting Writer. stop 0x54f4d49ac000
-2026/04/15 02:29:28 Cleaning up writer...
-2026/04/15 02:29:28 Finished cleaning up writer:  0x54f4d49ac000
-2026/04/15 02:29:28 Closed MCP-GET-SSE SSE connection: 3c790c9c92d944b7ccd68cc5d71d6032
+2026/04/15 03:02:31 Finished cleaning up writer:  0x4f2a810b72d0
+2026/04/15 03:02:31 Closed MCP-GET-SSE SSE connection: 656e99badeeec3c35889ba88d39d9ad8
+2026/04/15 03:02:31 Starting MCP-GET-SSE SSE connection: e034ac37ad4dc0a4826c7af2134fb180
+2026/04/15 03:02:31 SSEHub: registered connection e034ac37ad4dc0a4826c7af2134fb180 (total: 1)
+2026/04/15 03:02:31 SSEHub: unregistered connection e034ac37ad4dc0a4826c7af2134fb180 (total: 0)
+2026/04/15 03:02:31 Received kill signal.  Quitting Writer. stop 0x4f2a80d4bc70
+2026/04/15 03:02:31 Cleaning up writer...
+2026/04/15 03:02:31 Finished cleaning up writer:  0x4f2a80d4bc70
+2026/04/15 03:02:31 Closed MCP-GET-SSE SSE connection: e034ac37ad4dc0a4826c7af2134fb180
 
 === Running scenario: prompts-list ===
 Running client scenario 'prompts-list' against server: http://localhost:18799/mcp
-2026/04/15 02:29:28 Starting MCP-GET-SSE SSE connection: 7193ee150d47a76b295c1bfb6186b44d
-2026/04/15 02:29:28 SSEHub: registered connection 7193ee150d47a76b295c1bfb6186b44d (total: 1)
-2026/04/15 02:29:28 SSEHub: unregistered connection 7193ee150d47a76b295c1bfb6186b44d (total: 0)
-2026/04/15 02:29:28 Received kill signal.  Quitting Writer. stop 0x54f4d4c236c0
-2026/04/15 02:29:28 Cleaning up writer...
-2026/04/15 02:29:28 Finished cleaning up writer:  0x54f4d4c236c0
-2026/04/15 02:29:28 Closed MCP-GET-SSE SSE connection: 7193ee150d47a76b295c1bfb6186b44d
+2026/04/15 03:02:31 Starting MCP-GET-SSE SSE connection: 43e0bf2475ff2389d667ba4c6fc30a0f
+2026/04/15 03:02:31 SSEHub: registered connection 43e0bf2475ff2389d667ba4c6fc30a0f (total: 1)
+2026/04/15 03:02:31 SSEHub: unregistered connection 43e0bf2475ff2389d667ba4c6fc30a0f (total: 0)
+2026/04/15 03:02:31 Received kill signal.  Quitting Writer. stop 0x4f2a80d4bea0
+2026/04/15 03:02:31 Cleaning up writer...
+2026/04/15 03:02:31 Finished cleaning up writer:  0x4f2a80d4bea0
+2026/04/15 03:02:31 Closed MCP-GET-SSE SSE connection: 43e0bf2475ff2389d667ba4c6fc30a0f
 
 === Running scenario: prompts-get-simple ===
 Running client scenario 'prompts-get-simple' against server: http://localhost:18799/mcp
-2026/04/15 02:29:28 Starting MCP-GET-SSE SSE connection: 2ed9bc23162c16796ce309d86cb68221
-2026/04/15 02:29:28 SSEHub: registered connection 2ed9bc23162c16796ce309d86cb68221 (total: 1)
-2026/04/15 02:29:28 SSEHub: unregistered connection 2ed9bc23162c16796ce309d86cb68221 (total: 0)
-2026/04/15 02:29:28 Received kill signal.  Quitting Writer. stop 0x54f4d474d730
-2026/04/15 02:29:28 Cleaning up writer...
+2026/04/15 03:02:31 Starting MCP-GET-SSE SSE connection: ba4c12b03c298b4adc8bf6f5d9cb0e1e
+2026/04/15 03:02:31 SSEHub: registered connection ba4c12b03c298b4adc8bf6f5d9cb0e1e (total: 1)
+2026/04/15 03:02:31 SSEHub: unregistered connection ba4c12b03c298b4adc8bf6f5d9cb0e1e (total: 0)
+2026/04/15 03:02:31 Received kill signal.  Quitting Writer. stop 0x4f2a80c90fc0
+2026/04/15 03:02:31 Cleaning up writer...
+2026/04/15 03:02:31 Finished cleaning up writer:  0x4f2a80c90fc0
+2026/04/15 03:02:31 Closed MCP-GET-SSE SSE connection: ba4c12b03c298b4adc8bf6f5d9cb0e1e
 
 === Running scenario: prompts-get-with-args ===
-2026/04/15 02:29:28 Finished cleaning up writer:  0x54f4d474d730
 Running client scenario 'prompts-get-with-args' against server: http://localhost:18799/mcp
-2026/04/15 02:29:28 Closed MCP-GET-SSE SSE connection: 2ed9bc23162c16796ce309d86cb68221
-2026/04/15 02:29:28 Starting MCP-GET-SSE SSE connection: 556e857bc0ca173e1369574601724fab
-2026/04/15 02:29:28 SSEHub: registered connection 556e857bc0ca173e1369574601724fab (total: 1)
-2026/04/15 02:29:28 SSEHub: unregistered connection 556e857bc0ca173e1369574601724fab (total: 0)
-2026/04/15 02:29:28 Received kill signal.  Quitting Writer. stop 0x54f4d474d9d0
-2026/04/15 02:29:28 Cleaning up writer...
-2026/04/15 02:29:28 Finished cleaning up writer:  0x54f4d474d9d0
-2026/04/15 02:29:28 Closed MCP-GET-SSE SSE connection: 556e857bc0ca173e1369574601724fab
+2026/04/15 03:02:31 Starting MCP-GET-SSE SSE connection: 3ee2c229635ff9481e272aed0b1695dd
+2026/04/15 03:02:31 SSEHub: registered connection 3ee2c229635ff9481e272aed0b1695dd (total: 1)
+2026/04/15 03:02:31 SSEHub: unregistered connection 3ee2c229635ff9481e272aed0b1695dd (total: 0)
+2026/04/15 03:02:31 Received kill signal.  Quitting Writer. stop 0x4f2a81242230
+2026/04/15 03:02:31 Cleaning up writer...
+2026/04/15 03:02:31 Finished cleaning up writer:  0x4f2a81242230
+2026/04/15 03:02:31 Closed MCP-GET-SSE SSE connection: 3ee2c229635ff9481e272aed0b1695dd
 
 === Running scenario: prompts-get-embedded-resource ===
 Running client scenario 'prompts-get-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/15 02:29:28 Starting MCP-GET-SSE SSE connection: 1167d24f8fd7dac1d6b9af0e45b6e86d
-2026/04/15 02:29:28 SSEHub: registered connection 1167d24f8fd7dac1d6b9af0e45b6e86d (total: 1)
-2026/04/15 02:29:28 SSEHub: unregistered connection 1167d24f8fd7dac1d6b9af0e45b6e86d (total: 0)
-2026/04/15 02:29:28 Received kill signal.  Quitting Writer. stop 0x54f4d474dc70
-2026/04/15 02:29:28 Cleaning up writer...
-2026/04/15 02:29:28 Finished cleaning up writer:  0x54f4d474dc70
-2026/04/15 02:29:28 Closed MCP-GET-SSE SSE connection: 1167d24f8fd7dac1d6b9af0e45b6e86d
+2026/04/15 03:02:31 Starting MCP-GET-SSE SSE connection: 982aa898bd72c20d7f7b5d8292a02080
+2026/04/15 03:02:31 SSEHub: registered connection 982aa898bd72c20d7f7b5d8292a02080 (total: 1)
+2026/04/15 03:02:31 SSEHub: unregistered connection 982aa898bd72c20d7f7b5d8292a02080 (total: 0)
+2026/04/15 03:02:31 Received kill signal.  Quitting Writer. stop 0x4f2a81242460
+2026/04/15 03:02:31 Cleaning up writer...
+2026/04/15 03:02:31 Finished cleaning up writer:  0x4f2a81242460
+2026/04/15 03:02:31 Closed MCP-GET-SSE SSE connection: 982aa898bd72c20d7f7b5d8292a02080
 
 === Running scenario: prompts-get-with-image ===
 Running client scenario 'prompts-get-with-image' against server: http://localhost:18799/mcp
-2026/04/15 02:29:28 Starting MCP-GET-SSE SSE connection: 3c6d63867e35b46c229aec92078cefaf
-2026/04/15 02:29:28 SSEHub: registered connection 3c6d63867e35b46c229aec92078cefaf (total: 1)
-2026/04/15 02:29:28 SSEHub: unregistered connection 3c6d63867e35b46c229aec92078cefaf (total: 0)
-2026/04/15 02:29:28 Received kill signal.  Quitting Writer. stop 0x54f4d4c23960
-2026/04/15 02:29:28 Cleaning up writer...
-2026/04/15 02:29:28 Finished cleaning up writer:  0x54f4d4c23960
-2026/04/15 02:29:28 Closed MCP-GET-SSE SSE connection: 3c6d63867e35b46c229aec92078cefaf
+2026/04/15 03:02:31 Starting MCP-GET-SSE SSE connection: e18e9e90f78ae1129da82bf355714a43
+2026/04/15 03:02:31 SSEHub: registered connection e18e9e90f78ae1129da82bf355714a43 (total: 1)
+2026/04/15 03:02:31 SSEHub: unregistered connection e18e9e90f78ae1129da82bf355714a43 (total: 0)
+2026/04/15 03:02:31 Received kill signal.  Quitting Writer. stop 0x4f2a80d8d9d0
+2026/04/15 03:02:31 Cleaning up writer...
+2026/04/15 03:02:31 Finished cleaning up writer:  0x4f2a80d8d9d0
+2026/04/15 03:02:31 Closed MCP-GET-SSE SSE connection: e18e9e90f78ae1129da82bf355714a43
 
 === Running scenario: dns-rebinding-protection ===
 Running client scenario 'dns-rebinding-protection' against server: http://localhost:18799/mcp
@@ -419,22 +419,22 @@ Starting scenario: auth/token-endpoint-auth-basic
 Starting scenario: auth/token-endpoint-auth-post
 Starting scenario: auth/token-endpoint-auth-none
 Starting scenario: auth/pre-registration
-Executing client: ./bin/testclient http://localhost:62644/mcp
-Executing client: ./bin/testclient http://localhost:62645/mcp
-Executing client: ./bin/testclient http://localhost:62646/mcp
-Executing client: ./bin/testclient http://localhost:62647/mcp
-Executing client: ./bin/testclient http://localhost:62648/mcp
-Executing client: ./bin/testclient http://localhost:62649/mcp
-Executing client: ./bin/testclient http://localhost:62650/mcp
-Executing client: ./bin/testclient http://localhost:62651/mcp
-Executing client: ./bin/testclient http://localhost:62652/mcp
-Executing client: ./bin/testclient http://localhost:62653/mcp
-Executing client: ./bin/testclient http://localhost:62654/mcp
-Executing client: ./bin/testclient http://localhost:62655/mcp
-Executing client: ./bin/testclient http://localhost:62656/mcp
-Executing client: ./bin/testclient http://localhost:62657/mcp
+Executing client: ./bin/testclient http://localhost:61068/mcp
+Executing client: ./bin/testclient http://localhost:61069/mcp
+Executing client: ./bin/testclient http://localhost:61070/mcp
+Executing client: ./bin/testclient http://localhost:61071/mcp
+Executing client: ./bin/testclient http://localhost:61072/mcp
+Executing client: ./bin/testclient http://localhost:61073/mcp
+Executing client: ./bin/testclient http://localhost:61074/mcp
+Executing client: ./bin/testclient http://localhost:61075/mcp
+Executing client: ./bin/testclient http://localhost:61076/mcp
+Executing client: ./bin/testclient http://localhost:61077/mcp
+Executing client: ./bin/testclient http://localhost:61078/mcp
+Executing client: ./bin/testclient http://localhost:61079/mcp
+Executing client: ./bin/testclient http://localhost:61080/mcp
+Executing client: ./bin/testclient http://localhost:61081/mcp
 With context: {"client_id":"pre-registered-client","client_secret":"pre-registered-secret"}
-(node:32337) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
+(node:52122) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
 (Use `node --trace-deprecation ...` to show where the warning was created)
 
 === SUITE SUMMARY ===
@@ -492,9 +492,9 @@ Waiting for Keycloak realm...
     interop_test.go:167: Keycloak not reachable at http://localhost:8180: Get "http://localhost:8180/realms/mcpkit-test": dial tcp [::1]:8180: connect: connection refused (run 'make upkcl' to start)
 --- SKIP: TestKeycloak_MCPServer_PasswordGrant (0.00s)
 PASS
-ok  	github.com/panyam/mcpkit/tests/keycloak	0.713s
+ok  	github.com/panyam/mcpkit/tests/keycloak	0.514s
 make[2]: *** No rule to make target `downkcl'.  Stop.
   PASS: keycloak
 
 === Results: 9 passed, 0 failed ===
-Finished: Wed Apr 15 02:31:34 PDT 2026
+Finished: Wed Apr 15 03:04:36 PDT 2026


### PR DESCRIPTION
## Summary

Three enhancements bringing the MCP App Bridge to near-parity with the upstream ext-apps SDK.

### 1. Style Utilities
- `applyTheme()`, `applyStyleVariables()`, `applyFonts()`, `applyHostStyles()`
- Auto-applies on `connected` and `hostcontextchanged` events
- Matches upstream `@modelcontextprotocol/ext-apps` styles API

### 2. AbortSignal Support
- Optional `RequestOptions` param: `{ signal?, timeout? }`
- `callTool("slow", {}, { timeout: 5000 })` or `{ signal: controller.signal }`
- Cleans up pending requests on abort

### 3. Bidirectional Tool Calls
- `MCPApp.oncalltool` — host calls tools ON the app
- `MCPApp.onlisttools` — host queries app's available tools
- Bridge responds to incoming JSON-RPC requests (not just notifications)

## Test plan

- [x] 33 vitest unit tests (was 21) — all passing
- [x] 8 Playwright fake-host tests (was 6) — all passing
- [x] `make test-ui` green
- [x] `.d.ts` updated with all new APIs

Closes #235.