### PR TITLE
feat(tasks): Phase 2 — TTL enforcement with timer-per-task

### DIFF
--- a/examples/tasks/README.md
+++ b/examples/tasks/README.md
@@ -110,9 +110,9 @@ Shows all tasks with their current status.
 
 ---
 
-## Phase 2: TTL Enforcement 🔲
+## Phase 2: TTL Enforcement ✅
 
-> **Status**: Not yet implemented. These exercises will fail today — tasks never expire.
+> **Status**: Implemented. Tasks are automatically cleaned up after TTL expires.
 
 ### 9. Task expires after TTL
 
@@ -133,8 +133,8 @@ curl -s http://localhost:8080/mcp \
   -d '{"jsonrpc":"2.0","id":11,"method":"tasks/get","params":{"taskId":"<task-id>"}}'
 ```
 
-**Expected (after Phase 2):** Task not found — it was cleaned up after TTL expired.
-**Today:** Task is still there. Tasks live forever in memory.
+**Expected:** Task not found — it was cleaned up after TTL expired.
+**Behavior:** Timer resets on result storage and cancellation, so the TTL window starts fresh from the last state change.
 
 ---
 

--- a/experimental/ext/tasks/TASKS_GAP_PLAN.md
+++ b/experimental/ext/tasks/TASKS_GAP_PLAN.md
@@ -38,21 +38,12 @@ Key TS files:
 
 **Wire format parity verified** via `test-side-by-side.sh` against TS SDK.
 
-## Phase 2: TTL Enforcement
+## Phase 2: TTL Enforcement ✅ COMPLETE
 **Goal**: Tasks auto-expire after TTL.
 
-- [ ] **2a. Add cleanup timer to InMemoryStore**
-  - On `Create()`: schedule cleanup with `time.AfterFunc(ttl, cleanup)`
-  - On `StoreResult()`: reset timer to start from now
-  - On terminal status: reset timer
-  - Store timer handle alongside task in taskEntry
-  - Ref: `stores/inMemory.ts:66-76, 118-131, 170-182`
-
-- [ ] **2b. Add `Cleanup()` method**
-  - Stop all timers, clear all tasks
-  - For graceful shutdown and testing
-
-- [ ] **2c. Tests** — TTL expiry, timer reset on result, cleanup on shutdown
+- [x] **2a.** Timer per task on `taskEntry` — `time.AfterFunc` on Create, reset on SetResult/Cancel
+- [x] **2b.** `Cleanup()` method — stops all timers, clears all tasks
+- [x] **2c.** Tests: 6 unit (expiry, reset on result, reset on cancel, null no-expiry, cleanup, cleanup stops timers) + 1 e2e (exercise 9)
 
 ## Phase 3: Session Isolation
 **Goal**: Tasks are scoped to the session that created them.

--- a/experimental/ext/tasks/store.go
+++ b/experimental/ext/tasks/store.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/panyam/mcpkit/core"
 )
@@ -54,13 +55,18 @@ type TaskStore interface {
 	// Cancel transitions a non-terminal task to cancelled. Returns an error
 	// if the task is already terminal or doesn't exist.
 	Cancel(taskID string) (core.TaskInfo, error)
+
+	// Cleanup removes all tasks and stops any background timers.
+	// Used for graceful shutdown and testing.
+	Cleanup()
 }
 
 // taskEntry holds all state for a single task in the in-memory store.
 type taskEntry struct {
 	info    core.TaskInfo
-	result  json.RawMessage  // stored tool result (nil until terminal)
-	waiters []chan struct{}   // channels to notify on status/result changes
+	result  json.RawMessage // stored tool result (nil until terminal)
+	waiters []chan struct{}  // channels to notify on status/result changes
+	timer   *time.Timer     // TTL cleanup timer; nil if TTL is null/unlimited
 }
 
 // notify wakes all waiters for this task entry.
@@ -95,7 +101,15 @@ func (s *InMemoryTaskStore) Create(info core.TaskInfo) error {
 	if _, exists := s.tasks[info.TaskID]; exists {
 		return fmt.Errorf("task %q already exists", info.TaskID)
 	}
-	s.tasks[info.TaskID] = &taskEntry{info: info}
+	entry := &taskEntry{info: info}
+	// Schedule TTL cleanup if TTL is set and positive.
+	if info.TTL != nil && *info.TTL > 0 {
+		taskID := info.TaskID
+		entry.timer = time.AfterFunc(time.Duration(*info.TTL)*time.Millisecond, func() {
+			s.deleteTask(taskID)
+		})
+	}
+	s.tasks[info.TaskID] = entry
 	s.order = append(s.order, info.TaskID)
 	return nil
 }
@@ -134,6 +148,8 @@ func (s *InMemoryTaskStore) SetResult(taskID string, result core.ToolResult) err
 		return fmt.Errorf("task %q not found", taskID)
 	}
 	entry.result = raw
+	// Reset TTL timer — task gets a fresh TTL window from now.
+	s.resetTimer(entry)
 	entry.notify()
 	return nil
 }
@@ -267,6 +283,54 @@ func (s *InMemoryTaskStore) Cancel(taskID string) (core.TaskInfo, error) {
 		raw, _ := json.Marshal(cancelResult)
 		entry.result = raw
 	}
+	// Reset TTL timer — cancelled task gets a fresh TTL window for cleanup.
+	s.resetTimer(entry)
 	entry.notify()
 	return entry.info, nil
+}
+
+// deleteTask removes a task from the store. Called by the TTL timer when
+// it fires. Thread-safe — acquires its own lock.
+func (s *InMemoryTaskStore) deleteTask(taskID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if entry, ok := s.tasks[taskID]; ok {
+		if entry.timer != nil {
+			entry.timer.Stop()
+		}
+		entry.notify() // wake any waiters so they see "not found"
+		delete(s.tasks, taskID)
+	}
+}
+
+// resetTimer stops the existing TTL timer (if any) and starts a new one
+// with the task's TTL. Called when the task's lifetime should restart
+// (e.g., result stored, status changed to terminal).
+// Must be called with s.mu held.
+func (s *InMemoryTaskStore) resetTimer(entry *taskEntry) {
+	if entry.info.TTL == nil || *entry.info.TTL <= 0 {
+		return
+	}
+	if entry.timer != nil {
+		entry.timer.Stop()
+	}
+	taskID := entry.info.TaskID
+	entry.timer = time.AfterFunc(time.Duration(*entry.info.TTL)*time.Millisecond, func() {
+		s.deleteTask(taskID)
+	})
+}
+
+// Cleanup removes all tasks and stops all TTL timers.
+// Used for graceful shutdown and testing.
+func (s *InMemoryTaskStore) Cleanup() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, entry := range s.tasks {
+		if entry.timer != nil {
+			entry.timer.Stop()
+		}
+		entry.notify()
+	}
+	s.tasks = make(map[string]*taskEntry)
+	s.order = nil
 }

--- a/experimental/ext/tasks/store_test.go
+++ b/experimental/ext/tasks/store_test.go
@@ -384,3 +384,147 @@ func TestStoreConcurrentAccess(t *testing.T) {
 		t.Errorf("got %d tasks, want %d", len(tasks), n)
 	}
 }
+
+// --- TTL enforcement tests (Phase 2) ---
+
+// TestStoreTTLExpiry verifies that a task with a short TTL is automatically
+// removed from the store after the TTL elapses. This is the core TTL
+// enforcement behavior — exercise 9 in the tasks README.
+func TestStoreTTLExpiry(t *testing.T) {
+	s := NewInMemoryStore()
+	info := newTestInfo("t1", core.TaskWorking)
+	info.TTL = core.IntPtr(100) // 100ms TTL
+	s.Create(info)
+
+	// Task should be accessible immediately.
+	_, ok := s.Get("t1")
+	if !ok {
+		t.Fatal("task should exist immediately after creation")
+	}
+
+	// Wait for TTL to expire.
+	time.Sleep(150 * time.Millisecond)
+
+	// Task should be gone.
+	_, ok = s.Get("t1")
+	if ok {
+		t.Error("task should have been removed after TTL expired")
+	}
+}
+
+// TestStoreTTLResetOnResult verifies that storing a result resets the TTL
+// timer — the task gets a fresh TTL window from the time the result is
+// stored, not from creation. This matches the TS SDK behavior where
+// completed tasks remain queryable for a TTL period after completion.
+func TestStoreTTLResetOnResult(t *testing.T) {
+	s := NewInMemoryStore()
+	info := newTestInfo("t1", core.TaskWorking)
+	info.TTL = core.IntPtr(200) // 200ms TTL
+	s.Create(info)
+
+	// Wait 100ms (half the TTL), then store result.
+	time.Sleep(100 * time.Millisecond)
+	s.SetResult("t1", core.TextResult("done"))
+	s.Update("t1", func(i *core.TaskInfo) { i.Status = core.TaskCompleted })
+
+	// Wait another 150ms — past the original TTL but within the reset window.
+	time.Sleep(150 * time.Millisecond)
+
+	// Task should still be accessible (timer was reset on SetResult).
+	_, ok := s.Get("t1")
+	if !ok {
+		t.Error("task should still exist — TTL should have reset when result was stored")
+	}
+
+	// Wait for the full reset TTL to expire.
+	time.Sleep(100 * time.Millisecond)
+
+	_, ok = s.Get("t1")
+	if ok {
+		t.Error("task should have been removed after reset TTL expired")
+	}
+}
+
+// TestStoreTTLResetOnCancel verifies that cancelling a task resets the TTL
+// timer so the cancelled task remains queryable for the TTL period.
+func TestStoreTTLResetOnCancel(t *testing.T) {
+	s := NewInMemoryStore()
+	info := newTestInfo("t1", core.TaskWorking)
+	info.TTL = core.IntPtr(200) // 200ms TTL
+	s.Create(info)
+
+	// Wait 100ms, then cancel.
+	time.Sleep(100 * time.Millisecond)
+	s.Cancel("t1")
+
+	// Wait 150ms — past original TTL but within reset window.
+	time.Sleep(150 * time.Millisecond)
+
+	_, ok := s.Get("t1")
+	if !ok {
+		t.Error("cancelled task should still exist within reset TTL window")
+	}
+}
+
+// TestStoreTTLNullNoExpiry verifies that a task with TTL=nil (null per spec,
+// meaning unlimited lifetime) is never automatically removed.
+func TestStoreTTLNullNoExpiry(t *testing.T) {
+	s := NewInMemoryStore()
+	info := newTestInfo("t1", core.TaskWorking)
+	info.TTL = nil // null = unlimited
+	s.Create(info)
+
+	time.Sleep(100 * time.Millisecond)
+
+	_, ok := s.Get("t1")
+	if !ok {
+		t.Error("task with nil TTL should never expire")
+	}
+}
+
+// TestStoreCleanup verifies that Cleanup() removes all tasks and stops
+// all TTL timers. Used for graceful shutdown and testing.
+func TestStoreCleanup(t *testing.T) {
+	s := NewInMemoryStore()
+	for i := 0; i < 5; i++ {
+		info := newTestInfo("t"+string(rune('0'+i)), core.TaskWorking)
+		info.TTL = core.IntPtr(60000) // long TTL — won't expire during test
+		s.Create(info)
+	}
+
+	s.Cleanup()
+
+	for i := 0; i < 5; i++ {
+		_, ok := s.Get("t" + string(rune('0'+i)))
+		if ok {
+			t.Errorf("task t%d should have been removed by Cleanup", i)
+		}
+	}
+
+	tasks, _ := s.List("", 100)
+	if len(tasks) != 0 {
+		t.Errorf("List should return empty after Cleanup, got %d", len(tasks))
+	}
+}
+
+// TestStoreCleanupStopsTimers verifies that Cleanup() stops pending TTL
+// timers so they don't fire after cleanup (which would panic or corrupt
+// state on a reused store).
+func TestStoreCleanupStopsTimers(t *testing.T) {
+	s := NewInMemoryStore()
+	info := newTestInfo("t1", core.TaskWorking)
+	info.TTL = core.IntPtr(50) // very short TTL
+	s.Create(info)
+
+	// Cleanup before the timer fires.
+	s.Cleanup()
+
+	// Wait past the original TTL — timer should have been stopped.
+	time.Sleep(100 * time.Millisecond)
+
+	// No panic, no corruption. The store is empty and stable.
+	tasks, _ := s.List("", 100)
+	if len(tasks) != 0 {
+		t.Errorf("store should be empty after Cleanup, got %d", len(tasks))
+	}
+}

--- a/experimental/ext/tasks/tasks_test.go
+++ b/experimental/ext/tasks/tasks_test.go
@@ -1203,3 +1203,54 @@ func TestTaskSampleE2E(t *testing.T) {
 		t.Errorf("unexpected result: %q", result.Content[0].Text)
 	}
 }
+
+// --- Phase 2: TTL enforcement ---
+
+// TestTaskTTLExpiryE2E exercises README exercise 9: create a task with a
+// short TTL, wait for it to expire, then verify tasks/get returns an error.
+// This is the end-to-end validation that TTL enforcement works through
+// the full HTTP stack.
+func TestTaskTTLExpiryE2E(t *testing.T) {
+	srv, unblock := newTaskServer(t)
+	defer close(unblock)
+	c := connectClient(t, srv)
+
+	// Create a task with a 200ms TTL via raw tools/call (ToolCallAsTask
+	// doesn't expose TTL granularity for this test).
+	result, err := c.Call("tools/call", map[string]any{
+		"name":      "slow",
+		"arguments": map[string]any{"data": "ttl-test"},
+		"task":      map[string]any{"ttl": 200},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var created core.CreateTaskResult
+	json.Unmarshal(result.Raw, &created)
+	taskID := created.Task.TaskID
+
+	// Unblock the tool so it completes.
+	unblock <- struct{}{}
+
+	// Wait for task to complete.
+	for i := 0; i < 20; i++ {
+		got, err := GetTask(c, taskID)
+		if err != nil {
+			break // task might have been cleaned up already
+		}
+		if got.Status.IsTerminal() {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Wait for TTL to expire (200ms from result storage).
+	time.Sleep(300 * time.Millisecond)
+
+	// Task should be gone.
+	_, err = GetTask(c, taskID)
+	if err == nil {
+		t.Error("expected error — task should have been cleaned up after TTL expired")
+	}
+}

--- a/tests/reports/report.html
+++ b/tests/reports/report.html
@@ -15,7 +15,7 @@ th { background: #f5f5f5; font-weight: 600; }
 pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto; font-size: 13px; max-height: 400px; overflow-y: auto; }
 </style></head><body>
 <h1>MCPKit Test Report</h1>
-<div class='meta'>Branch: <strong>feat/tasks-capability</strong> | Commit: <code>b65a426</code> | Date: 2026-04-19 22:39:14</div>
+<div class='meta'>Branch: <strong>feat/tasks-ttl-phase2</strong> | Commit: <code>8fd49cc</code> | Date: 2026-04-19 23:39:28</div>
 <table><tr><th>Stage</th><th>Result</th></tr>
 <tr><td>unit+coverage</td><td class='pass'>PASS</td></tr>
 <tr><td>race</td><td class='pass'>PASS</td></tr>
@@ -31,35 +31,35 @@ pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto; 
 <div class='summary-pass'>All 10 stages passed</div>
 <h2>Full Log</h2><pre>
 === MCPKit Comprehensive Test Suite ===
-Started: Sun Apr 19 22:36:23 PDT 2026
+Started: Sun Apr 19 23:36:39 PDT 2026
 
 --- [1/10] unit+coverage ---
   PASS: unit+coverage
 go test -coverprofile=tests/reports/coverage.out ./... -count=1 -timeout 30s
-ok  	github.com/panyam/mcpkit/client	8.731s	coverage: 67.1% of statements
+ok  	github.com/panyam/mcpkit/client	8.548s	coverage: 67.1% of statements
 	github.com/panyam/mcpkit/cmd/testserver		coverage: 0.0% of statements
-ok  	github.com/panyam/mcpkit/core	0.867s	coverage: 52.4% of statements
-ok  	github.com/panyam/mcpkit/server	8.109s	coverage: 77.4% of statements
-ok  	github.com/panyam/mcpkit/testutil	1.614s	coverage: 69.4% of statements
+ok  	github.com/panyam/mcpkit/core	0.745s	coverage: 52.4% of statements
+ok  	github.com/panyam/mcpkit/server	7.658s	coverage: 77.4% of statements
+ok  	github.com/panyam/mcpkit/testutil	1.061s	coverage: 69.4% of statements
 go tool cover -html=tests/reports/coverage.out -o tests/reports/coverage.html
 Coverage report: tests/reports/coverage.html
 --- [2/10] race ---
   PASS: race
 go test -race ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/client	9.365s
+ok  	github.com/panyam/mcpkit/client	9.612s
 ?   	github.com/panyam/mcpkit/cmd/testserver	[no test files]
-ok  	github.com/panyam/mcpkit/core	3.262s
-ok  	github.com/panyam/mcpkit/server	11.676s
-ok  	github.com/panyam/mcpkit/testutil	4.036s
+ok  	github.com/panyam/mcpkit/core	2.632s
+ok  	github.com/panyam/mcpkit/server	9.616s
+ok  	github.com/panyam/mcpkit/testutil	2.885s
 --- [3/10] auth ---
   PASS: auth
 cd ext/auth &amp;&amp; go test ./... -count=1 -timeout 30s
-ok  	github.com/panyam/mcpkit/ext/auth	0.380s
+ok  	github.com/panyam/mcpkit/ext/auth	0.345s
 --- [4/10] ui ---
   PASS: ui
 cd ext/ui &amp;&amp; /Library/Developer/CommandLineTools/usr/bin/make test
 go test ./... -count=1 -timeout 30s
-ok  	github.com/panyam/mcpkit/ext/ui	0.341s
+ok  	github.com/panyam/mcpkit/ext/ui	0.355s
 cd assets &amp;&amp; pnpm install --frozen-lockfile --silent &amp;&amp; pnpm test
 
 &gt; @mcpkit/app-bridge@0.1.0 test /Users/dzshrh/newstack/mcpkit/main/ext/ui/assets
@@ -68,21 +68,21 @@ cd assets &amp;&amp; pnpm install --frozen-lockfile --silent &amp;&amp; pnpm tes
 
  RUN  v3.2.4 /Users/dzshrh/newstack/mcpkit/main/ext/ui/assets
 
- ✓ mcp-app-bridge.test.ts (33 tests) 379ms
+ ✓ mcp-app-bridge.test.ts (33 tests) 384ms
 
  Test Files  1 passed (1)
       Tests  33 passed (33)
-   Start at  22:36:49
-   Duration  1.27s (transform 36ms, setup 0ms, collect 30ms, tests 379ms, environment 397ms, prepare 120ms)
+   Start at  23:37:02
+   Duration  995ms (transform 26ms, setup 0ms, collect 26ms, tests 384ms, environment 316ms, prepare 101ms)
 
 --- [5/10] protogen ---
   PASS: protogen
 cd experimental/ext/protogen &amp;&amp; go test ./... -count=1 -timeout 30s &amp;&amp; /Library/Developer/CommandLineTools/usr/bin/make test-e2e
 ?   	github.com/panyam/mcpkit/experimental/ext/protogen/cmd/protoc-gen-go-mcp	[no test files]
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/generator	0.287s
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/proto/mcp/v1	1.014s
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/runtime	0.513s
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/schema	0.760s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/generator	1.240s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/proto/mcp/v1	0.648s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/runtime	0.383s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/schema	0.953s
 ?   	github.com/panyam/mcpkit/experimental/ext/protogen/testutil	[no test files]
 go build -o bin/protoc-gen-go-mcp ./cmd/protoc-gen-go-mcp
 go install ./cmd/protoc-gen-go-mcp
@@ -91,23 +91,23 @@ cd ../../../examples/protogen/bookservice &amp;&amp; rm -rf gen &amp;&amp; buf g
 [33mWARN[0m	plugin "protoc-gen-go-mcp" does not support required features.
   Feature "proto3 optional" is required by 1 file(s):
     bookservice/v1/service.proto
-ok  	github.com/panyam/mcpkit/examples/protogen/bookservice	0.391s
+ok  	github.com/panyam/mcpkit/examples/protogen/bookservice	0.425s
 ==&gt; e2e: passed
 --- [6/10] e2e ---
   PASS: e2e
 cd tests/e2e &amp;&amp; go test ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/tests/e2e	4.090s
-ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.457s
+ok  	github.com/panyam/mcpkit/tests/e2e	3.751s
+ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.422s
 --- [7/10] experimental ---
   PASS: experimental
 cd experimental/telegram-events &amp;&amp; go test ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/experimental/telegram-events	5.270s
+ok  	github.com/panyam/mcpkit/experimental/telegram-events	5.234s
 --- [8/10] conformance ---
   PASS: conformance
 bash scripts/conformance-test.sh
 Killing stale process on port 18799...
 === Starting test server on :18799 (Streamable HTTP) ===
-Waiting for server....2026/04/19 22:37:06 MCP test server listening on :18799 (Streamable HTTP at /mcp)
+Waiting for server....2026/04/19 23:37:20 MCP test server listening on :18799 (Streamable HTTP at /mcp)
  ready
 
 === Running MCP conformance suite ===
@@ -118,295 +118,295 @@ Running active suite (30 scenarios) against http://localhost:18799/mcp
 
 === Running scenario: server-initialize ===
 Running client scenario 'server-initialize' against server: http://localhost:18799/mcp
-2026/04/19 22:37:08 Starting MCP-GET-SSE SSE connection: 73f9293319165089326ea4328caf3abb
-2026/04/19 22:37:08 SSEHub: registered connection 73f9293319165089326ea4328caf3abb (total: 1)
-2026/04/19 22:37:08 SSEHub: unregistered connection 73f9293319165089326ea4328caf3abb (total: 0)
-2026/04/19 22:37:08 Received kill signal.  Quitting Writer. stop 0x6c67e803c1c0
-2026/04/19 22:37:08 Cleaning up writer...
-2026/04/19 22:37:08 Finished cleaning up writer:  0x6c67e803c1c0
-2026/04/19 22:37:08 Closed MCP-GET-SSE SSE connection: 73f9293319165089326ea4328caf3abb
+2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: 199953dc2d69f6c6b6455f8bb4b1d1e4
+2026/04/19 23:37:22 SSEHub: registered connection 199953dc2d69f6c6b6455f8bb4b1d1e4 (total: 1)
+2026/04/19 23:37:22 SSEHub: unregistered connection 199953dc2d69f6c6b6455f8bb4b1d1e4 (total: 0)
+2026/04/19 23:37:22 Received kill signal.  Quitting Writer. stop 0x31b4a0f38150
+2026/04/19 23:37:22 Cleaning up writer...
+2026/04/19 23:37:22 Finished cleaning up writer:  0x31b4a0f38150
+2026/04/19 23:37:22 Closed MCP-GET-SSE SSE connection: 199953dc2d69f6c6b6455f8bb4b1d1e4
 
 === Running scenario: logging-set-level ===
 Running client scenario 'logging-set-level' against server: http://localhost:18799/mcp
-2026/04/19 22:37:08 Starting MCP-GET-SSE SSE connection: 8123234150e6e1838fb799c45eff283b
-2026/04/19 22:37:08 SSEHub: registered connection 8123234150e6e1838fb799c45eff283b (total: 1)
-2026/04/19 22:37:08 SSEHub: unregistered connection 8123234150e6e1838fb799c45eff283b (total: 0)
-2026/04/19 22:37:08 Received kill signal.  Quitting Writer. stop 0x6c67e7d3c2a0
-2026/04/19 22:37:08 Cleaning up writer...
-2026/04/19 22:37:08 Finished cleaning up writer:  0x6c67e7d3c2a0
-2026/04/19 22:37:08 Closed MCP-GET-SSE SSE connection: 8123234150e6e1838fb799c45eff283b
+2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: aa39c6bee73cdb5838e490382e214970
+2026/04/19 23:37:22 SSEHub: registered connection aa39c6bee73cdb5838e490382e214970 (total: 1)
+2026/04/19 23:37:22 SSEHub: unregistered connection aa39c6bee73cdb5838e490382e214970 (total: 0)
+2026/04/19 23:37:22 Received kill signal.  Quitting Writer. stop 0x31b4a0e36230
+2026/04/19 23:37:22 Cleaning up writer...
+2026/04/19 23:37:22 Finished cleaning up writer:  0x31b4a0e36230
+2026/04/19 23:37:22 Closed MCP-GET-SSE SSE connection: aa39c6bee73cdb5838e490382e214970
 
 === Running scenario: ping ===
 Running client scenario 'ping' against server: http://localhost:18799/mcp
-2026/04/19 22:37:08 Starting MCP-GET-SSE SSE connection: e7afe81a8c5c400091e17ed0d07bb0c0
-2026/04/19 22:37:08 SSEHub: registered connection e7afe81a8c5c400091e17ed0d07bb0c0 (total: 1)
-2026/04/19 22:37:08 SSEHub: unregistered connection e7afe81a8c5c400091e17ed0d07bb0c0 (total: 0)
-2026/04/19 22:37:08 Received kill signal.  Quitting Writer. stop 0x6c67e7d3c540
-2026/04/19 22:37:08 Cleaning up writer...
-2026/04/19 22:37:08 Finished cleaning up writer:  0x6c67e7d3c540
-2026/04/19 22:37:08 Closed MCP-GET-SSE SSE connection: e7afe81a8c5c400091e17ed0d07bb0c0
+2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: 993e660ec0575e457a77ac88540e9a39
+2026/04/19 23:37:22 SSEHub: registered connection 993e660ec0575e457a77ac88540e9a39 (total: 1)
+2026/04/19 23:37:22 SSEHub: unregistered connection 993e660ec0575e457a77ac88540e9a39 (total: 0)
+2026/04/19 23:37:22 Received kill signal.  Quitting Writer. stop 0x31b4a0e364d0
+2026/04/19 23:37:22 Cleaning up writer...
+2026/04/19 23:37:22 Finished cleaning up writer:  0x31b4a0e364d0
+2026/04/19 23:37:22 Closed MCP-GET-SSE SSE connection: 993e660ec0575e457a77ac88540e9a39
 
 === Running scenario: completion-complete ===
 Running client scenario 'completion-complete' against server: http://localhost:18799/mcp
-2026/04/19 22:37:08 Starting MCP-GET-SSE SSE connection: 84c427d761020e6f1ab55588990c5798
-2026/04/19 22:37:08 SSEHub: registered connection 84c427d761020e6f1ab55588990c5798 (total: 1)
-2026/04/19 22:37:08 SSEHub: unregistered connection 84c427d761020e6f1ab55588990c5798 (total: 0)
-2026/04/19 22:37:08 Received kill signal.  Quitting Writer. stop 0x6c67e803c4d0
-2026/04/19 22:37:08 Cleaning up writer...
-2026/04/19 22:37:08 Finished cleaning up writer:  0x6c67e803c4d0
-2026/04/19 22:37:08 Closed MCP-GET-SSE SSE connection: 84c427d761020e6f1ab55588990c5798
+2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: 7c7809131a91c729822f93f9ae911728
+2026/04/19 23:37:22 SSEHub: registered connection 7c7809131a91c729822f93f9ae911728 (total: 1)
+2026/04/19 23:37:22 SSEHub: unregistered connection 7c7809131a91c729822f93f9ae911728 (total: 0)
+2026/04/19 23:37:22 Received kill signal.  Quitting Writer. stop 0x31b4a0b14a10
+2026/04/19 23:37:22 Cleaning up writer...
+2026/04/19 23:37:22 Finished cleaning up writer:  0x31b4a0b14a10
+2026/04/19 23:37:22 Closed MCP-GET-SSE SSE connection: 7c7809131a91c729822f93f9ae911728
 
 === Running scenario: tools-list ===
 Running client scenario 'tools-list' against server: http://localhost:18799/mcp
-2026/04/19 22:37:08 Starting MCP-GET-SSE SSE connection: bd1f4dd62ae2b7722343700950edfc8e
-2026/04/19 22:37:08 SSEHub: registered connection bd1f4dd62ae2b7722343700950edfc8e (total: 1)
-2026/04/19 22:37:08 SSEHub: unregistered connection bd1f4dd62ae2b7722343700950edfc8e (total: 0)
-2026/04/19 22:37:08 Received kill signal.  Quitting Writer. stop 0x6c67e7c5ce00
-2026/04/19 22:37:08 Cleaning up writer...
-2026/04/19 22:37:08 Finished cleaning up writer:  0x6c67e7c5ce00
-2026/04/19 22:37:08 Closed MCP-GET-SSE SSE connection: bd1f4dd62ae2b7722343700950edfc8e
+2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: 933c84a2644c4379fccf13a19fb835ba
+2026/04/19 23:37:22 SSEHub: registered connection 933c84a2644c4379fccf13a19fb835ba (total: 1)
 
 === Running scenario: tools-call-simple-text ===
+2026/04/19 23:37:22 SSEHub: unregistered connection 933c84a2644c4379fccf13a19fb835ba (total: 0)
 Running client scenario 'tools-call-simple-text' against server: http://localhost:18799/mcp
-2026/04/19 22:37:08 Starting MCP-GET-SSE SSE connection: 1f5c6beb99a4dbc3d009b3a4609447cf
-2026/04/19 22:37:08 SSEHub: registered connection 1f5c6beb99a4dbc3d009b3a4609447cf (total: 1)
-2026/04/19 22:37:08 SSEHub: unregistered connection 1f5c6beb99a4dbc3d009b3a4609447cf (total: 0)
-2026/04/19 22:37:08 Received kill signal.  Quitting Writer. stop 0x6c67e7d3c850
-2026/04/19 22:37:08 Cleaning up writer...
-2026/04/19 22:37:08 Finished cleaning up writer:  0x6c67e7d3c850
-2026/04/19 22:37:08 Closed MCP-GET-SSE SSE connection: 1f5c6beb99a4dbc3d009b3a4609447cf
+2026/04/19 23:37:22 Received kill signal.  Quitting Writer. stop 0x31b4a0b14c40
+2026/04/19 23:37:22 Cleaning up writer...
+2026/04/19 23:37:22 Finished cleaning up writer:  0x31b4a0b14c40
+2026/04/19 23:37:22 Closed MCP-GET-SSE SSE connection: 933c84a2644c4379fccf13a19fb835ba
+2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: f374b21d34ec91c720f89b4cbc55527b
+2026/04/19 23:37:22 SSEHub: registered connection f374b21d34ec91c720f89b4cbc55527b (total: 1)
+2026/04/19 23:37:22 SSEHub: unregistered connection f374b21d34ec91c720f89b4cbc55527b (total: 0)
+2026/04/19 23:37:22 Received kill signal.  Quitting Writer. stop 0x31b4a0b14e70
+2026/04/19 23:37:22 Cleaning up writer...
+2026/04/19 23:37:22 Finished cleaning up writer:  0x31b4a0b14e70
+2026/04/19 23:37:22 Closed MCP-GET-SSE SSE connection: f374b21d34ec91c720f89b4cbc55527b
 
 === Running scenario: tools-call-image ===
 Running client scenario 'tools-call-image' against server: http://localhost:18799/mcp
-2026/04/19 22:37:08 Starting MCP-GET-SSE SSE connection: fcd768a78d2e6813fd5b92ccfbd06fc8
-2026/04/19 22:37:08 SSEHub: registered connection fcd768a78d2e6813fd5b92ccfbd06fc8 (total: 1)
-2026/04/19 22:37:08 SSEHub: unregistered connection fcd768a78d2e6813fd5b92ccfbd06fc8 (total: 0)
-2026/04/19 22:37:08 Received kill signal.  Quitting Writer. stop 0x6c67e803c150
-2026/04/19 22:37:08 Cleaning up writer...
-2026/04/19 22:37:08 Finished cleaning up writer:  0x6c67e803c150
-2026/04/19 22:37:08 Closed MCP-GET-SSE SSE connection: fcd768a78d2e6813fd5b92ccfbd06fc8
+2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: 2dc9e9e7cd2a5a5f86e6e21389d10a0f
+2026/04/19 23:37:22 SSEHub: registered connection 2dc9e9e7cd2a5a5f86e6e21389d10a0f (total: 1)
+2026/04/19 23:37:22 SSEHub: unregistered connection 2dc9e9e7cd2a5a5f86e6e21389d10a0f (total: 0)
+2026/04/19 23:37:22 Received kill signal.  Quitting Writer. stop 0x31b4a0e36850
+2026/04/19 23:37:22 Cleaning up writer...
+2026/04/19 23:37:22 Finished cleaning up writer:  0x31b4a0e36850
+2026/04/19 23:37:22 Closed MCP-GET-SSE SSE connection: 2dc9e9e7cd2a5a5f86e6e21389d10a0f
 
 === Running scenario: tools-call-audio ===
 Running client scenario 'tools-call-audio' against server: http://localhost:18799/mcp
-2026/04/19 22:37:08 Starting MCP-GET-SSE SSE connection: 1da32359eb43ff84f10902feb54e5ce2
-2026/04/19 22:37:08 SSEHub: registered connection 1da32359eb43ff84f10902feb54e5ce2 (total: 1)
-2026/04/19 22:37:08 SSEHub: unregistered connection 1da32359eb43ff84f10902feb54e5ce2 (total: 0)
+2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: 6c4635a21f83c810dbfd1718f2d50ace
+2026/04/19 23:37:22 SSEHub: registered connection 6c4635a21f83c810dbfd1718f2d50ace (total: 1)
+2026/04/19 23:37:22 SSEHub: unregistered connection 6c4635a21f83c810dbfd1718f2d50ace (total: 0)
+2026/04/19 23:37:22 Received kill signal.  Quitting Writer. stop 0x31b4a0a623f0
+2026/04/19 23:37:22 Cleaning up writer...
+2026/04/19 23:37:22 Finished cleaning up writer:  0x31b4a0a623f0
+2026/04/19 23:37:22 Closed MCP-GET-SSE SSE connection: 6c4635a21f83c810dbfd1718f2d50ace
 
 === Running scenario: tools-call-embedded-resource ===
-2026/04/19 22:37:08 Received kill signal.  Quitting Writer. stop 0x6c67e7c5c3f0
-2026/04/19 22:37:08 Cleaning up writer...
 Running client scenario 'tools-call-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/19 22:37:08 Finished cleaning up writer:  0x6c67e7c5c3f0
-2026/04/19 22:37:08 Closed MCP-GET-SSE SSE connection: 1da32359eb43ff84f10902feb54e5ce2
-2026/04/19 22:37:08 Starting MCP-GET-SSE SSE connection: 81b7e601704f91d44ad81b22b5e4ae14
-2026/04/19 22:37:08 SSEHub: registered connection 81b7e601704f91d44ad81b22b5e4ae14 (total: 1)
-2026/04/19 22:37:08 SSEHub: unregistered connection 81b7e601704f91d44ad81b22b5e4ae14 (total: 0)
-2026/04/19 22:37:08 Received kill signal.  Quitting Writer. stop 0x6c67e803c5b0
-2026/04/19 22:37:08 Cleaning up writer...
-2026/04/19 22:37:08 Finished cleaning up writer:  0x6c67e803c5b0
-2026/04/19 22:37:08 Closed MCP-GET-SSE SSE connection: 81b7e601704f91d44ad81b22b5e4ae14
+2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: 01c6ebf03176df1b52be5bf2321af125
+2026/04/19 23:37:22 SSEHub: registered connection 01c6ebf03176df1b52be5bf2321af125 (total: 1)
+2026/04/19 23:37:22 SSEHub: unregistered connection 01c6ebf03176df1b52be5bf2321af125 (total: 0)
+2026/04/19 23:37:22 Received kill signal.  Quitting Writer. stop 0x31b4a0f38380
+2026/04/19 23:37:22 Cleaning up writer...
+2026/04/19 23:37:22 Finished cleaning up writer:  0x31b4a0f38380
+2026/04/19 23:37:22 Closed MCP-GET-SSE SSE connection: 01c6ebf03176df1b52be5bf2321af125
 
 === Running scenario: tools-call-mixed-content ===
 Running client scenario 'tools-call-mixed-content' against server: http://localhost:18799/mcp
-2026/04/19 22:37:08 Starting MCP-GET-SSE SSE connection: 78e2d5e8252d419fd3e8c3587c5412b4
-2026/04/19 22:37:08 SSEHub: registered connection 78e2d5e8252d419fd3e8c3587c5412b4 (total: 1)
-2026/04/19 22:37:08 SSEHub: unregistered connection 78e2d5e8252d419fd3e8c3587c5412b4 (total: 0)
-2026/04/19 22:37:08 Received kill signal.  Quitting Writer. stop 0x6c67e803c7e0
-2026/04/19 22:37:08 Cleaning up writer...
-2026/04/19 22:37:08 Finished cleaning up writer:  0x6c67e803c7e0
-2026/04/19 22:37:08 Closed MCP-GET-SSE SSE connection: 78e2d5e8252d419fd3e8c3587c5412b4
+2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: cf622a8d18a72911d7660a0042d0dd96
+2026/04/19 23:37:22 SSEHub: registered connection cf622a8d18a72911d7660a0042d0dd96 (total: 1)
 
 === Running scenario: tools-call-with-logging ===
+2026/04/19 23:37:22 SSEHub: unregistered connection cf622a8d18a72911d7660a0042d0dd96 (total: 0)
 Running client scenario 'tools-call-with-logging' against server: http://localhost:18799/mcp
-2026/04/19 22:37:08 Starting MCP-GET-SSE SSE connection: ef2fa703a44f03b117dc9fb631af9b3b
-2026/04/19 22:37:08 SSEHub: registered connection ef2fa703a44f03b117dc9fb631af9b3b (total: 1)
-2026/04/19 22:37:09 SSEHub: unregistered connection ef2fa703a44f03b117dc9fb631af9b3b (total: 0)
-2026/04/19 22:37:09 Received kill signal.  Quitting Writer. stop 0x6c67e803ca80
-2026/04/19 22:37:09 Cleaning up writer...
-2026/04/19 22:37:09 Finished cleaning up writer:  0x6c67e803ca80
-2026/04/19 22:37:09 Closed MCP-GET-SSE SSE connection: ef2fa703a44f03b117dc9fb631af9b3b
+2026/04/19 23:37:22 Received kill signal.  Quitting Writer. stop 0x31b4a0f385b0
+2026/04/19 23:37:22 Cleaning up writer...
+2026/04/19 23:37:22 Finished cleaning up writer:  0x31b4a0f385b0
+2026/04/19 23:37:22 Closed MCP-GET-SSE SSE connection: cf622a8d18a72911d7660a0042d0dd96
+2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: 5c3c94cc470dc4a860808d372aefbd3f
+2026/04/19 23:37:22 SSEHub: registered connection 5c3c94cc470dc4a860808d372aefbd3f (total: 1)
+2026/04/19 23:37:23 SSEHub: unregistered connection 5c3c94cc470dc4a860808d372aefbd3f (total: 0)
+2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0e36d20
+2026/04/19 23:37:23 Cleaning up writer...
+2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0e36d20
+2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 5c3c94cc470dc4a860808d372aefbd3f
 
 === Running scenario: tools-call-error ===
 Running client scenario 'tools-call-error' against server: http://localhost:18799/mcp
-2026/04/19 22:37:09 Starting MCP-GET-SSE SSE connection: 490c70808e32cb986bf3d658b5a97fcc
-2026/04/19 22:37:09 SSEHub: registered connection 490c70808e32cb986bf3d658b5a97fcc (total: 1)
-2026/04/19 22:37:09 SSEHub: unregistered connection 490c70808e32cb986bf3d658b5a97fcc (total: 0)
-2026/04/19 22:37:09 Received kill signal.  Quitting Writer. stop 0x6c67e803cd20
-2026/04/19 22:37:09 Cleaning up writer...
-2026/04/19 22:37:09 Finished cleaning up writer:  0x6c67e803cd20
-2026/04/19 22:37:09 Closed MCP-GET-SSE SSE connection: 490c70808e32cb986bf3d658b5a97fcc
+2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 4d4f605f8b6a3c6e7b976677a7c78fac
+2026/04/19 23:37:23 SSEHub: registered connection 4d4f605f8b6a3c6e7b976677a7c78fac (total: 1)
+2026/04/19 23:37:23 SSEHub: unregistered connection 4d4f605f8b6a3c6e7b976677a7c78fac (total: 0)
+2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0b15180
+2026/04/19 23:37:23 Cleaning up writer...
+2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0b15180
+2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 4d4f605f8b6a3c6e7b976677a7c78fac
 
 === Running scenario: tools-call-with-progress ===
 Running client scenario 'tools-call-with-progress' against server: http://localhost:18799/mcp
-2026/04/19 22:37:09 Starting MCP-GET-SSE SSE connection: 315713c5fe0070a0120b8910e2a1aec9
-2026/04/19 22:37:09 SSEHub: registered connection 315713c5fe0070a0120b8910e2a1aec9 (total: 1)
-2026/04/19 22:37:09 SSEHub: unregistered connection 315713c5fe0070a0120b8910e2a1aec9 (total: 0)
-2026/04/19 22:37:09 Received kill signal.  Quitting Writer. stop 0x6c67e8078460
-2026/04/19 22:37:09 Cleaning up writer...
-2026/04/19 22:37:09 Finished cleaning up writer:  0x6c67e8078460
-2026/04/19 22:37:09 Closed MCP-GET-SSE SSE connection: 315713c5fe0070a0120b8910e2a1aec9
+2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 1b88cbbe8aeeb56da6696e97ec93fd5f
+2026/04/19 23:37:23 SSEHub: registered connection 1b88cbbe8aeeb56da6696e97ec93fd5f (total: 1)
+2026/04/19 23:37:23 SSEHub: unregistered connection 1b88cbbe8aeeb56da6696e97ec93fd5f (total: 0)
+2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0f388c0
+2026/04/19 23:37:23 Cleaning up writer...
+2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0f388c0
+2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 1b88cbbe8aeeb56da6696e97ec93fd5f
 
 === Running scenario: tools-call-sampling ===
 Running client scenario 'tools-call-sampling' against server: http://localhost:18799/mcp
-2026/04/19 22:37:09 Starting MCP-GET-SSE SSE connection: 53376020e54b40eeb5bbf297ad8ee07e
-2026/04/19 22:37:09 SSEHub: registered connection 53376020e54b40eeb5bbf297ad8ee07e (total: 1)
-2026/04/19 22:37:09 SSEHub: unregistered connection 53376020e54b40eeb5bbf297ad8ee07e (total: 0)
-2026/04/19 22:37:09 Received kill signal.  Quitting Writer. stop 0x6c67e8078770
-2026/04/19 22:37:09 Cleaning up writer...
-2026/04/19 22:37:09 Finished cleaning up writer:  0x6c67e8078770
-2026/04/19 22:37:09 Closed MCP-GET-SSE SSE connection: 53376020e54b40eeb5bbf297ad8ee07e
+2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 086d4eacc6f20d40ea4258dfd911be7d
+2026/04/19 23:37:23 SSEHub: registered connection 086d4eacc6f20d40ea4258dfd911be7d (total: 1)
+2026/04/19 23:37:23 SSEHub: unregistered connection 086d4eacc6f20d40ea4258dfd911be7d (total: 0)
 
 === Running scenario: tools-call-elicitation ===
+2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0f38b60
+2026/04/19 23:37:23 Cleaning up writer...
 Running client scenario 'tools-call-elicitation' against server: http://localhost:18799/mcp
-2026/04/19 22:37:09 Starting MCP-GET-SSE SSE connection: 4c5ce16679909373615743b397a8ded2
-2026/04/19 22:37:09 SSEHub: registered connection 4c5ce16679909373615743b397a8ded2 (total: 1)
-2026/04/19 22:37:09 SSEHub: unregistered connection 4c5ce16679909373615743b397a8ded2 (total: 0)
-2026/04/19 22:37:09 Received kill signal.  Quitting Writer. stop 0x6c67e8078b60
-2026/04/19 22:37:09 Cleaning up writer...
-2026/04/19 22:37:09 Finished cleaning up writer:  0x6c67e8078b60
-2026/04/19 22:37:09 Closed MCP-GET-SSE SSE connection: 4c5ce16679909373615743b397a8ded2
+2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0f38b60
+2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 086d4eacc6f20d40ea4258dfd911be7d
+2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 0e7021f6fa4825de1c9624c63bedffc3
+2026/04/19 23:37:23 SSEHub: registered connection 0e7021f6fa4825de1c9624c63bedffc3 (total: 1)
+2026/04/19 23:37:23 SSEHub: unregistered connection 0e7021f6fa4825de1c9624c63bedffc3 (total: 0)
+2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0f38f50
+2026/04/19 23:37:23 Cleaning up writer...
+2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0f38f50
+2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 0e7021f6fa4825de1c9624c63bedffc3
 
 === Running scenario: elicitation-sep1034-defaults ===
 Running client scenario 'elicitation-sep1034-defaults' against server: http://localhost:18799/mcp
-2026/04/19 22:37:09 Starting MCP-GET-SSE SSE connection: 7028ff83b29d107d888a8473c4daea20
-2026/04/19 22:37:09 SSEHub: registered connection 7028ff83b29d107d888a8473c4daea20 (total: 1)
+2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 477d10535fc22ca961eb8b870a592b2a
+2026/04/19 23:37:23 SSEHub: registered connection 477d10535fc22ca961eb8b870a592b2a (total: 1)
+2026/04/19 23:37:23 SSEHub: unregistered connection 477d10535fc22ca961eb8b870a592b2a (total: 0)
+2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0a62a10
+2026/04/19 23:37:23 Cleaning up writer...
+2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0a62a10
+2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 477d10535fc22ca961eb8b870a592b2a
 
 === Running scenario: server-sse-multiple-streams ===
-2026/04/19 22:37:09 SSEHub: unregistered connection 7028ff83b29d107d888a8473c4daea20 (total: 0)
 Running client scenario 'server-sse-multiple-streams' against server: http://localhost:18799/mcp
-2026/04/19 22:37:09 Received kill signal.  Quitting Writer. stop 0x6c67e8078e00
-2026/04/19 22:37:09 Cleaning up writer...
-2026/04/19 22:37:09 Finished cleaning up writer:  0x6c67e8078e00
-2026/04/19 22:37:09 Closed MCP-GET-SSE SSE connection: 7028ff83b29d107d888a8473c4daea20
-2026/04/19 22:37:09 Starting MCP-GET-SSE SSE connection: 3eb7caee29b93a7759b7910ecb3bccf9
-2026/04/19 22:37:09 SSEHub: registered connection 3eb7caee29b93a7759b7910ecb3bccf9 (total: 1)
-2026/04/19 22:37:09 SSEHub: unregistered connection 3eb7caee29b93a7759b7910ecb3bccf9 (total: 0)
-2026/04/19 22:37:09 Received kill signal.  Quitting Writer. stop 0x6c67e7c5d180
-2026/04/19 22:37:09 Cleaning up writer...
+2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 9d6f6d4f1641ac895133bb086d425fc4
+2026/04/19 23:37:23 SSEHub: registered connection 9d6f6d4f1641ac895133bb086d425fc4 (total: 1)
+2026/04/19 23:37:23 SSEHub: unregistered connection 9d6f6d4f1641ac895133bb086d425fc4 (total: 0)
+2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0b15490
+2026/04/19 23:37:23 Cleaning up writer...
 
 === Running scenario: elicitation-sep1330-enums ===
-2026/04/19 22:37:09 Finished cleaning up writer:  0x6c67e7c5d180
-2026/04/19 22:37:09 Closed MCP-GET-SSE SSE connection: 3eb7caee29b93a7759b7910ecb3bccf9
+2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0b15490
 Running client scenario 'elicitation-sep1330-enums' against server: http://localhost:18799/mcp
-2026/04/19 22:37:09 Starting MCP-GET-SSE SSE connection: 89a6d8d2fd390b9a6d1927e15b0e0f48
-2026/04/19 22:37:09 SSEHub: registered connection 89a6d8d2fd390b9a6d1927e15b0e0f48 (total: 1)
-2026/04/19 22:37:09 SSEHub: unregistered connection 89a6d8d2fd390b9a6d1927e15b0e0f48 (total: 0)
-2026/04/19 22:37:09 Received kill signal.  Quitting Writer. stop 0x6c67e7c5d490
-2026/04/19 22:37:09 Cleaning up writer...
-2026/04/19 22:37:09 Finished cleaning up writer:  0x6c67e7c5d490
-2026/04/19 22:37:09 Closed MCP-GET-SSE SSE connection: 89a6d8d2fd390b9a6d1927e15b0e0f48
+2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 9d6f6d4f1641ac895133bb086d425fc4
+2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: cb0ac37cc1852d3213f7ee30717df7cd
+2026/04/19 23:37:23 SSEHub: registered connection cb0ac37cc1852d3213f7ee30717df7cd (total: 1)
+2026/04/19 23:37:23 SSEHub: unregistered connection cb0ac37cc1852d3213f7ee30717df7cd (total: 0)
+2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0b15810
+2026/04/19 23:37:23 Cleaning up writer...
+2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0b15810
+2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: cb0ac37cc1852d3213f7ee30717df7cd
 
 === Running scenario: resources-list ===
 Running client scenario 'resources-list' against server: http://localhost:18799/mcp
-2026/04/19 22:37:09 Starting MCP-GET-SSE SSE connection: acca92f2aa185838923fee9e286d57cb
-2026/04/19 22:37:09 SSEHub: registered connection acca92f2aa185838923fee9e286d57cb (total: 1)
-2026/04/19 22:37:09 SSEHub: unregistered connection acca92f2aa185838923fee9e286d57cb (total: 0)
-2026/04/19 22:37:09 Received kill signal.  Quitting Writer. stop 0x6c67e7c5d6c0
-2026/04/19 22:37:09 Cleaning up writer...
-2026/04/19 22:37:09 Finished cleaning up writer:  0x6c67e7c5d6c0
+2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 17ba27e0fac9c99ebbfa2a1e2a34e6ef
+2026/04/19 23:37:23 SSEHub: registered connection 17ba27e0fac9c99ebbfa2a1e2a34e6ef (total: 1)
+2026/04/19 23:37:23 SSEHub: unregistered connection 17ba27e0fac9c99ebbfa2a1e2a34e6ef (total: 0)
 
 === Running scenario: resources-read-text ===
-2026/04/19 22:37:09 Closed MCP-GET-SSE SSE connection: acca92f2aa185838923fee9e286d57cb
+2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0a62e00
+2026/04/19 23:37:23 Cleaning up writer...
 Running client scenario 'resources-read-text' against server: http://localhost:18799/mcp
-2026/04/19 22:37:09 Starting MCP-GET-SSE SSE connection: d536edd4e4c3b77b13e47fdf3f9b0ba0
-2026/04/19 22:37:09 SSEHub: registered connection d536edd4e4c3b77b13e47fdf3f9b0ba0 (total: 1)
-2026/04/19 22:37:09 SSEHub: unregistered connection d536edd4e4c3b77b13e47fdf3f9b0ba0 (total: 0)
-2026/04/19 22:37:09 Received kill signal.  Quitting Writer. stop 0x6c67e7c5d960
-2026/04/19 22:37:09 Cleaning up writer...
-2026/04/19 22:37:09 Finished cleaning up writer:  0x6c67e7c5d960
+2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0a62e00
+2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 17ba27e0fac9c99ebbfa2a1e2a34e6ef
+2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 25c118c25e1f64d4963e336f26f8ec86
+2026/04/19 23:37:23 SSEHub: registered connection 25c118c25e1f64d4963e336f26f8ec86 (total: 1)
+2026/04/19 23:37:23 SSEHub: unregistered connection 25c118c25e1f64d4963e336f26f8ec86 (total: 0)
+2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0e373b0
+2026/04/19 23:37:23 Cleaning up writer...
 
 === Running scenario: resources-read-binary ===
-2026/04/19 22:37:09 Closed MCP-GET-SSE SSE connection: d536edd4e4c3b77b13e47fdf3f9b0ba0
+2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0e373b0
 Running client scenario 'resources-read-binary' against server: http://localhost:18799/mcp
-2026/04/19 22:37:09 Starting MCP-GET-SSE SSE connection: 36016bd9adb9f0612b9d4aab9de1fde5
-2026/04/19 22:37:09 SSEHub: registered connection 36016bd9adb9f0612b9d4aab9de1fde5 (total: 1)
-2026/04/19 22:37:09 SSEHub: unregistered connection 36016bd9adb9f0612b9d4aab9de1fde5 (total: 0)
+2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 25c118c25e1f64d4963e336f26f8ec86
+2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 9ec716cb233e869cbac5ef4694f7f7d8
+2026/04/19 23:37:23 SSEHub: registered connection 9ec716cb233e869cbac5ef4694f7f7d8 (total: 1)
+2026/04/19 23:37:23 SSEHub: unregistered connection 9ec716cb233e869cbac5ef4694f7f7d8 (total: 0)
 
 === Running scenario: resources-templates-read ===
-2026/04/19 22:37:09 Received kill signal.  Quitting Writer. stop 0x6c67e7c5db90
-2026/04/19 22:37:09 Cleaning up writer...
+2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0b15b20
+2026/04/19 23:37:23 Cleaning up writer...
 Running client scenario 'resources-templates-read' against server: http://localhost:18799/mcp
-2026/04/19 22:37:09 Finished cleaning up writer:  0x6c67e7c5db90
-2026/04/19 22:37:09 Closed MCP-GET-SSE SSE connection: 36016bd9adb9f0612b9d4aab9de1fde5
-2026/04/19 22:37:09 Starting MCP-GET-SSE SSE connection: 8c8632727a32afbdc504733ae7227f7d
-2026/04/19 22:37:09 SSEHub: registered connection 8c8632727a32afbdc504733ae7227f7d (total: 1)
-2026/04/19 22:37:09 SSEHub: unregistered connection 8c8632727a32afbdc504733ae7227f7d (total: 0)
-2026/04/19 22:37:09 Received kill signal.  Quitting Writer. stop 0x6c67e8079260
-2026/04/19 22:37:09 Cleaning up writer...
-2026/04/19 22:37:09 Finished cleaning up writer:  0x6c67e8079260
-2026/04/19 22:37:09 Closed MCP-GET-SSE SSE connection: 8c8632727a32afbdc504733ae7227f7d
+2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0b15b20
+2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 9ec716cb233e869cbac5ef4694f7f7d8
+2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 2a3fe347294da8127767e1dc06d000c2
+2026/04/19 23:37:23 SSEHub: registered connection 2a3fe347294da8127767e1dc06d000c2 (total: 1)
+2026/04/19 23:37:23 SSEHub: unregistered connection 2a3fe347294da8127767e1dc06d000c2 (total: 0)
+2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0e30150
+2026/04/19 23:37:23 Cleaning up writer...
+2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0e30150
 
 === Running scenario: resources-subscribe ===
+2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 2a3fe347294da8127767e1dc06d000c2
 Running client scenario 'resources-subscribe' against server: http://localhost:18799/mcp
-2026/04/19 22:37:09 Starting MCP-GET-SSE SSE connection: affdc63dba4d88f5d392938e596971ca
-2026/04/19 22:37:09 SSEHub: registered connection affdc63dba4d88f5d392938e596971ca (total: 1)
-2026/04/19 22:37:09 SSEHub: unregistered connection affdc63dba4d88f5d392938e596971ca (total: 0)
-2026/04/19 22:37:09 Received kill signal.  Quitting Writer. stop 0x6c67e8079570
-2026/04/19 22:37:09 Cleaning up writer...
-2026/04/19 22:37:09 Finished cleaning up writer:  0x6c67e8079570
+2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 96c5814ee364aa0e72ac38f20de40773
+2026/04/19 23:37:23 SSEHub: registered connection 96c5814ee364aa0e72ac38f20de40773 (total: 1)
+2026/04/19 23:37:23 SSEHub: unregistered connection 96c5814ee364aa0e72ac38f20de40773 (total: 0)
+2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0b15d50
+2026/04/19 23:37:23 Cleaning up writer...
+2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0b15d50
+2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 96c5814ee364aa0e72ac38f20de40773
 
 === Running scenario: resources-unsubscribe ===
-2026/04/19 22:37:09 Closed MCP-GET-SSE SSE connection: affdc63dba4d88f5d392938e596971ca
 Running client scenario 'resources-unsubscribe' against server: http://localhost:18799/mcp
-2026/04/19 22:37:09 Starting MCP-GET-SSE SSE connection: fd25980e02f4ba53a60c2374e36c082c
-2026/04/19 22:37:09 SSEHub: registered connection fd25980e02f4ba53a60c2374e36c082c (total: 1)
-2026/04/19 22:37:09 SSEHub: unregistered connection fd25980e02f4ba53a60c2374e36c082c (total: 0)
-2026/04/19 22:37:09 Received kill signal.  Quitting Writer. stop 0x6c67e7e12230
-2026/04/19 22:37:09 Cleaning up writer...
-2026/04/19 22:37:09 Finished cleaning up writer:  0x6c67e7e12230
-2026/04/19 22:37:09 Closed MCP-GET-SSE SSE connection: fd25980e02f4ba53a60c2374e36c082c
+2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 02792683620fb595bcefb04fb332a473
+2026/04/19 23:37:23 SSEHub: registered connection 02792683620fb595bcefb04fb332a473 (total: 1)
+2026/04/19 23:37:23 SSEHub: unregistered connection 02792683620fb595bcefb04fb332a473 (total: 0)
+2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0e30460
+2026/04/19 23:37:23 Cleaning up writer...
+2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0e30460
+2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 02792683620fb595bcefb04fb332a473
 
 === Running scenario: prompts-list ===
 Running client scenario 'prompts-list' against server: http://localhost:18799/mcp
-2026/04/19 22:37:09 Starting MCP-GET-SSE SSE connection: ddaf7548171104afb7f8882ca3830fab
-2026/04/19 22:37:09 SSEHub: registered connection ddaf7548171104afb7f8882ca3830fab (total: 1)
-2026/04/19 22:37:09 SSEHub: unregistered connection ddaf7548171104afb7f8882ca3830fab (total: 0)
-2026/04/19 22:37:09 Received kill signal.  Quitting Writer. stop 0x6c67e803d500
-2026/04/19 22:37:09 Cleaning up writer...
-2026/04/19 22:37:09 Finished cleaning up writer:  0x6c67e803d500
+2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 9b7508e663f11e45ced3313184ca73e4
+2026/04/19 23:37:23 SSEHub: registered connection 9b7508e663f11e45ced3313184ca73e4 (total: 1)
+2026/04/19 23:37:23 SSEHub: unregistered connection 9b7508e663f11e45ced3313184ca73e4 (total: 0)
+2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0cd80e0
+2026/04/19 23:37:23 Cleaning up writer...
+2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0cd80e0
 
 === Running scenario: prompts-get-simple ===
-2026/04/19 22:37:09 Closed MCP-GET-SSE SSE connection: ddaf7548171104afb7f8882ca3830fab
+2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 9b7508e663f11e45ced3313184ca73e4
 Running client scenario 'prompts-get-simple' against server: http://localhost:18799/mcp
-2026/04/19 22:37:09 Starting MCP-GET-SSE SSE connection: 8183709211aa71b479b83c90e31fb09e
-2026/04/19 22:37:09 SSEHub: registered connection 8183709211aa71b479b83c90e31fb09e (total: 1)
-2026/04/19 22:37:09 SSEHub: unregistered connection 8183709211aa71b479b83c90e31fb09e (total: 0)
+2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 9569eaf0b71eec1a57a48e8884dc5e9d
+2026/04/19 23:37:23 SSEHub: registered connection 9569eaf0b71eec1a57a48e8884dc5e9d (total: 1)
+2026/04/19 23:37:23 SSEHub: unregistered connection 9569eaf0b71eec1a57a48e8884dc5e9d (total: 0)
+2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0cd8380
+2026/04/19 23:37:23 Cleaning up writer...
+2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0cd8380
+2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 9569eaf0b71eec1a57a48e8884dc5e9d
 
 === Running scenario: prompts-get-with-args ===
 Running client scenario 'prompts-get-with-args' against server: http://localhost:18799/mcp
-2026/04/19 22:37:09 Received kill signal.  Quitting Writer. stop 0x6c67e7e124d0
-2026/04/19 22:37:09 Cleaning up writer...
-2026/04/19 22:37:09 Finished cleaning up writer:  0x6c67e7e124d0
-2026/04/19 22:37:09 Closed MCP-GET-SSE SSE connection: 8183709211aa71b479b83c90e31fb09e
-2026/04/19 22:37:09 Starting MCP-GET-SSE SSE connection: 72691916950544516c9f5ba297afbaf1
-2026/04/19 22:37:09 SSEHub: registered connection 72691916950544516c9f5ba297afbaf1 (total: 1)
-2026/04/19 22:37:09 SSEHub: unregistered connection 72691916950544516c9f5ba297afbaf1 (total: 0)
-2026/04/19 22:37:09 Received kill signal.  Quitting Writer. stop 0x6c67e8079ab0
-2026/04/19 22:37:09 Cleaning up writer...
-2026/04/19 22:37:09 Finished cleaning up writer:  0x6c67e8079ab0
-2026/04/19 22:37:09 Closed MCP-GET-SSE SSE connection: 72691916950544516c9f5ba297afbaf1
+2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 8a8fa096ad8bcabd021f7838e5a7d6ea
+2026/04/19 23:37:23 SSEHub: registered connection 8a8fa096ad8bcabd021f7838e5a7d6ea (total: 1)
+2026/04/19 23:37:23 SSEHub: unregistered connection 8a8fa096ad8bcabd021f7838e5a7d6ea (total: 0)
+2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0e37650
+2026/04/19 23:37:23 Cleaning up writer...
+2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0e37650
+2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 8a8fa096ad8bcabd021f7838e5a7d6ea
 
 === Running scenario: prompts-get-embedded-resource ===
 Running client scenario 'prompts-get-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/19 22:37:09 Starting MCP-GET-SSE SSE connection: 49b759701f4de31d6cd87fd918ee0c86
-2026/04/19 22:37:09 SSEHub: registered connection 49b759701f4de31d6cd87fd918ee0c86 (total: 1)
-2026/04/19 22:37:09 SSEHub: unregistered connection 49b759701f4de31d6cd87fd918ee0c86 (total: 0)
-2026/04/19 22:37:09 Received kill signal.  Quitting Writer. stop 0x6c67e8079dc0
-2026/04/19 22:37:09 Cleaning up writer...
-2026/04/19 22:37:09 Finished cleaning up writer:  0x6c67e8079dc0
-2026/04/19 22:37:09 Closed MCP-GET-SSE SSE connection: 49b759701f4de31d6cd87fd918ee0c86
+2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: ba09f56cdd75b3b3ed848afe2f9a385a
+2026/04/19 23:37:23 SSEHub: registered connection ba09f56cdd75b3b3ed848afe2f9a385a (total: 1)
+2026/04/19 23:37:23 SSEHub: unregistered connection ba09f56cdd75b3b3ed848afe2f9a385a (total: 0)
+2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0e307e0
+2026/04/19 23:37:23 Cleaning up writer...
+2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0e307e0
 
 === Running scenario: prompts-get-with-image ===
+2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: ba09f56cdd75b3b3ed848afe2f9a385a
 Running client scenario 'prompts-get-with-image' against server: http://localhost:18799/mcp
-2026/04/19 22:37:09 Starting MCP-GET-SSE SSE connection: ff822b266502acbc623f9c5134d616fa
-2026/04/19 22:37:09 SSEHub: registered connection ff822b266502acbc623f9c5134d616fa (total: 1)
-2026/04/19 22:37:09 SSEHub: unregistered connection ff822b266502acbc623f9c5134d616fa (total: 0)
-2026/04/19 22:37:09 Received kill signal.  Quitting Writer. stop 0x6c67e7ea41c0
-2026/04/19 22:37:09 Cleaning up writer...
+2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 512b0f815ce7e93ac6b685c0a3dfaa38
+2026/04/19 23:37:23 SSEHub: registered connection 512b0f815ce7e93ac6b685c0a3dfaa38 (total: 1)
+2026/04/19 23:37:23 SSEHub: unregistered connection 512b0f815ce7e93ac6b685c0a3dfaa38 (total: 0)
+2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0cd8620
+2026/04/19 23:37:23 Cleaning up writer...
+2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0cd8620
+2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 512b0f815ce7e93ac6b685c0a3dfaa38
 
 === Running scenario: dns-rebinding-protection ===
-2026/04/19 22:37:09 Finished cleaning up writer:  0x6c67e7ea41c0
-2026/04/19 22:37:09 Closed MCP-GET-SSE SSE connection: ff822b266502acbc623f9c5134d616fa
 Running client scenario 'dns-rebinding-protection' against server: http://localhost:18799/mcp
 
 
@@ -470,22 +470,22 @@ Starting scenario: auth/token-endpoint-auth-basic
 Starting scenario: auth/token-endpoint-auth-post
 Starting scenario: auth/token-endpoint-auth-none
 Starting scenario: auth/pre-registration
-Executing client: ./bin/testclient http://localhost:64439/mcp
-Executing client: ./bin/testclient http://localhost:64440/mcp
-Executing client: ./bin/testclient http://localhost:64441/mcp
-Executing client: ./bin/testclient http://localhost:64442/mcp
-Executing client: ./bin/testclient http://localhost:64443/mcp
-Executing client: ./bin/testclient http://localhost:64444/mcp
-Executing client: ./bin/testclient http://localhost:64445/mcp
-Executing client: ./bin/testclient http://localhost:64446/mcp
-Executing client: ./bin/testclient http://localhost:64447/mcp
-Executing client: ./bin/testclient http://localhost:64448/mcp
-Executing client: ./bin/testclient http://localhost:64449/mcp
-Executing client: ./bin/testclient http://localhost:64450/mcp
-Executing client: ./bin/testclient http://localhost:64451/mcp
-Executing client: ./bin/testclient http://localhost:64452/mcp
+Executing client: ./bin/testclient http://localhost:61533/mcp
+Executing client: ./bin/testclient http://localhost:61534/mcp
+Executing client: ./bin/testclient http://localhost:61535/mcp
+Executing client: ./bin/testclient http://localhost:61536/mcp
+Executing client: ./bin/testclient http://localhost:61537/mcp
+Executing client: ./bin/testclient http://localhost:61538/mcp
+Executing client: ./bin/testclient http://localhost:61539/mcp
+Executing client: ./bin/testclient http://localhost:61540/mcp
+Executing client: ./bin/testclient http://localhost:61541/mcp
+Executing client: ./bin/testclient http://localhost:61542/mcp
+Executing client: ./bin/testclient http://localhost:61543/mcp
+Executing client: ./bin/testclient http://localhost:61544/mcp
+Executing client: ./bin/testclient http://localhost:61545/mcp
+Executing client: ./bin/testclient http://localhost:61546/mcp
 With context: {"client_id":"pre-registered-client","client_secret":"pre-registered-secret"}
-(node:56882) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
+(node:98398) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
 (Use `node --trace-deprecation ...` to show where the warning was created)
 
 === SUITE SUMMARY ===
@@ -559,10 +559,10 @@ Waiting for Keycloak realm...
     token_refresh_test.go:22: Keycloak not reachable at http://localhost:8180: Get "http://localhost:8180/realms/mcpkit-test": dial tcp [::1]:8180: connect: connection refused (run 'make upkcl' to start)
 --- SKIP: TestKeycloak_TokenRefresh_PasswordGrant (0.00s)
 PASS
-ok  	github.com/panyam/mcpkit/tests/keycloak	0.407s
+ok  	github.com/panyam/mcpkit/tests/keycloak	0.417s
 make[2]: *** No rule to make target `downkcl'.  Stop.
 
 === Results: 10 passed, 0 failed ===
-Finished: Sun Apr 19 22:39:14 PDT 2026
+Finished: Sun Apr 19 23:39:28 PDT 2026
 </pre>
 </body></html>

--- a/tests/reports/run.log
+++ b/tests/reports/run.log
@@ -1,33 +1,33 @@
 === MCPKit Comprehensive Test Suite ===
-Started: Sun Apr 19 22:36:23 PDT 2026
+Started: Sun Apr 19 23:36:39 PDT 2026
 
 --- [1/10] unit+coverage ---
   PASS: unit+coverage
 go test -coverprofile=tests/reports/coverage.out ./... -count=1 -timeout 30s
-ok  	github.com/panyam/mcpkit/client	8.731s	coverage: 67.1% of statements
+ok  	github.com/panyam/mcpkit/client	8.548s	coverage: 67.1% of statements
 	github.com/panyam/mcpkit/cmd/testserver		coverage: 0.0% of statements
-ok  	github.com/panyam/mcpkit/core	0.867s	coverage: 52.4% of statements
-ok  	github.com/panyam/mcpkit/server	8.109s	coverage: 77.4% of statements
-ok  	github.com/panyam/mcpkit/testutil	1.614s	coverage: 69.4% of statements
+ok  	github.com/panyam/mcpkit/core	0.745s	coverage: 52.4% of statements
+ok  	github.com/panyam/mcpkit/server	7.658s	coverage: 77.4% of statements
+ok  	github.com/panyam/mcpkit/testutil	1.061s	coverage: 69.4% of statements
 go tool cover -html=tests/reports/coverage.out -o tests/reports/coverage.html
 Coverage report: tests/reports/coverage.html
 --- [2/10] race ---
   PASS: race
 go test -race ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/client	9.365s
+ok  	github.com/panyam/mcpkit/client	9.612s
 ?   	github.com/panyam/mcpkit/cmd/testserver	[no test files]
-ok  	github.com/panyam/mcpkit/core	3.262s
-ok  	github.com/panyam/mcpkit/server	11.676s
-ok  	github.com/panyam/mcpkit/testutil	4.036s
+ok  	github.com/panyam/mcpkit/core	2.632s
+ok  	github.com/panyam/mcpkit/server	9.616s
+ok  	github.com/panyam/mcpkit/testutil	2.885s
 --- [3/10] auth ---
   PASS: auth
 cd ext/auth && go test ./... -count=1 -timeout 30s
-ok  	github.com/panyam/mcpkit/ext/auth	0.380s
+ok  	github.com/panyam/mcpkit/ext/auth	0.345s
 --- [4/10] ui ---
   PASS: ui
 cd ext/ui && /Library/Developer/CommandLineTools/usr/bin/make test
 go test ./... -count=1 -timeout 30s
-ok  	github.com/panyam/mcpkit/ext/ui	0.341s
+ok  	github.com/panyam/mcpkit/ext/ui	0.355s
 cd assets && pnpm install --frozen-lockfile --silent && pnpm test
 
 > @mcpkit/app-bridge@0.1.0 test /Users/dzshrh/newstack/mcpkit/main/ext/ui/assets
@@ -36,21 +36,21 @@ cd assets && pnpm install --frozen-lockfile --silent && pnpm test
 
  RUN  v3.2.4 /Users/dzshrh/newstack/mcpkit/main/ext/ui/assets
 
- ✓ mcp-app-bridge.test.ts (33 tests) 379ms
+ ✓ mcp-app-bridge.test.ts (33 tests) 384ms
 
  Test Files  1 passed (1)
       Tests  33 passed (33)
-   Start at  22:36:49
-   Duration  1.27s (transform 36ms, setup 0ms, collect 30ms, tests 379ms, environment 397ms, prepare 120ms)
+   Start at  23:37:02
+   Duration  995ms (transform 26ms, setup 0ms, collect 26ms, tests 384ms, environment 316ms, prepare 101ms)
 
 --- [5/10] protogen ---
   PASS: protogen
 cd experimental/ext/protogen && go test ./... -count=1 -timeout 30s && /Library/Developer/CommandLineTools/usr/bin/make test-e2e
 ?   	github.com/panyam/mcpkit/experimental/ext/protogen/cmd/protoc-gen-go-mcp	[no test files]
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/generator	0.287s
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/proto/mcp/v1	1.014s
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/runtime	0.513s
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/schema	0.760s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/generator	1.240s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/proto/mcp/v1	0.648s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/runtime	0.383s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/schema	0.953s
 ?   	github.com/panyam/mcpkit/experimental/ext/protogen/testutil	[no test files]
 go build -o bin/protoc-gen-go-mcp ./cmd/protoc-gen-go-mcp
 go install ./cmd/protoc-gen-go-mcp
@@ -59,23 +59,23 @@ cd ../../../examples/protogen/bookservice && rm -rf gen && buf generate && go te
 [33mWARN[0m	plugin "protoc-gen-go-mcp" does not support required features.
   Feature "proto3 optional" is required by 1 file(s):
     bookservice/v1/service.proto
-ok  	github.com/panyam/mcpkit/examples/protogen/bookservice	0.391s
+ok  	github.com/panyam/mcpkit/examples/protogen/bookservice	0.425s
 ==> e2e: passed
 --- [6/10] e2e ---
   PASS: e2e
 cd tests/e2e && go test ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/tests/e2e	4.090s
-ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.457s
+ok  	github.com/panyam/mcpkit/tests/e2e	3.751s
+ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.422s
 --- [7/10] experimental ---
   PASS: experimental
 cd experimental/telegram-events && go test ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/experimental/telegram-events	5.270s
+ok  	github.com/panyam/mcpkit/experimental/telegram-events	5.234s
 --- [8/10] conformance ---
   PASS: conformance
 bash scripts/conformance-test.sh
 Killing stale process on port 18799...
 === Starting test server on :18799 (Streamable HTTP) ===
-Waiting for server....2026/04/19 22:37:06 MCP test server listening on :18799 (Streamable HTTP at /mcp)
+Waiting for server....2026/04/19 23:37:20 MCP test server listening on :18799 (Streamable HTTP at /mcp)
  ready
 
 === Running MCP conformance suite ===
@@ -86,295 +86,295 @@ Running active suite (30 scenarios) against http://localhost:18799/mcp
 
 === Running scenario: server-initialize ===
 Running client scenario 'server-initialize' against server: http://localhost:18799/mcp
-2026/04/19 22:37:08 Starting MCP-GET-SSE SSE connection: 73f9293319165089326ea4328caf3abb
-2026/04/19 22:37:08 SSEHub: registered connection 73f9293319165089326ea4328caf3abb (total: 1)
-2026/04/19 22:37:08 SSEHub: unregistered connection 73f9293319165089326ea4328caf3abb (total: 0)
-2026/04/19 22:37:08 Received kill signal.  Quitting Writer. stop 0x6c67e803c1c0
-2026/04/19 22:37:08 Cleaning up writer...
-2026/04/19 22:37:08 Finished cleaning up writer:  0x6c67e803c1c0
-2026/04/19 22:37:08 Closed MCP-GET-SSE SSE connection: 73f9293319165089326ea4328caf3abb
+2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: 199953dc2d69f6c6b6455f8bb4b1d1e4
+2026/04/19 23:37:22 SSEHub: registered connection 199953dc2d69f6c6b6455f8bb4b1d1e4 (total: 1)
+2026/04/19 23:37:22 SSEHub: unregistered connection 199953dc2d69f6c6b6455f8bb4b1d1e4 (total: 0)
+2026/04/19 23:37:22 Received kill signal.  Quitting Writer. stop 0x31b4a0f38150
+2026/04/19 23:37:22 Cleaning up writer...
+2026/04/19 23:37:22 Finished cleaning up writer:  0x31b4a0f38150
+2026/04/19 23:37:22 Closed MCP-GET-SSE SSE connection: 199953dc2d69f6c6b6455f8bb4b1d1e4
 
 === Running scenario: logging-set-level ===
 Running client scenario 'logging-set-level' against server: http://localhost:18799/mcp
-2026/04/19 22:37:08 Starting MCP-GET-SSE SSE connection: 8123234150e6e1838fb799c45eff283b
-2026/04/19 22:37:08 SSEHub: registered connection 8123234150e6e1838fb799c45eff283b (total: 1)
-2026/04/19 22:37:08 SSEHub: unregistered connection 8123234150e6e1838fb799c45eff283b (total: 0)
-2026/04/19 22:37:08 Received kill signal.  Quitting Writer. stop 0x6c67e7d3c2a0
-2026/04/19 22:37:08 Cleaning up writer...
-2026/04/19 22:37:08 Finished cleaning up writer:  0x6c67e7d3c2a0
-2026/04/19 22:37:08 Closed MCP-GET-SSE SSE connection: 8123234150e6e1838fb799c45eff283b
+2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: aa39c6bee73cdb5838e490382e214970
+2026/04/19 23:37:22 SSEHub: registered connection aa39c6bee73cdb5838e490382e214970 (total: 1)
+2026/04/19 23:37:22 SSEHub: unregistered connection aa39c6bee73cdb5838e490382e214970 (total: 0)
+2026/04/19 23:37:22 Received kill signal.  Quitting Writer. stop 0x31b4a0e36230
+2026/04/19 23:37:22 Cleaning up writer...
+2026/04/19 23:37:22 Finished cleaning up writer:  0x31b4a0e36230
+2026/04/19 23:37:22 Closed MCP-GET-SSE SSE connection: aa39c6bee73cdb5838e490382e214970
 
 === Running scenario: ping ===
 Running client scenario 'ping' against server: http://localhost:18799/mcp
-2026/04/19 22:37:08 Starting MCP-GET-SSE SSE connection: e7afe81a8c5c400091e17ed0d07bb0c0
-2026/04/19 22:37:08 SSEHub: registered connection e7afe81a8c5c400091e17ed0d07bb0c0 (total: 1)
-2026/04/19 22:37:08 SSEHub: unregistered connection e7afe81a8c5c400091e17ed0d07bb0c0 (total: 0)
-2026/04/19 22:37:08 Received kill signal.  Quitting Writer. stop 0x6c67e7d3c540
-2026/04/19 22:37:08 Cleaning up writer...
-2026/04/19 22:37:08 Finished cleaning up writer:  0x6c67e7d3c540
-2026/04/19 22:37:08 Closed MCP-GET-SSE SSE connection: e7afe81a8c5c400091e17ed0d07bb0c0
+2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: 993e660ec0575e457a77ac88540e9a39
+2026/04/19 23:37:22 SSEHub: registered connection 993e660ec0575e457a77ac88540e9a39 (total: 1)
+2026/04/19 23:37:22 SSEHub: unregistered connection 993e660ec0575e457a77ac88540e9a39 (total: 0)
+2026/04/19 23:37:22 Received kill signal.  Quitting Writer. stop 0x31b4a0e364d0
+2026/04/19 23:37:22 Cleaning up writer...
+2026/04/19 23:37:22 Finished cleaning up writer:  0x31b4a0e364d0
+2026/04/19 23:37:22 Closed MCP-GET-SSE SSE connection: 993e660ec0575e457a77ac88540e9a39
 
 === Running scenario: completion-complete ===
 Running client scenario 'completion-complete' against server: http://localhost:18799/mcp
-2026/04/19 22:37:08 Starting MCP-GET-SSE SSE connection: 84c427d761020e6f1ab55588990c5798
-2026/04/19 22:37:08 SSEHub: registered connection 84c427d761020e6f1ab55588990c5798 (total: 1)
-2026/04/19 22:37:08 SSEHub: unregistered connection 84c427d761020e6f1ab55588990c5798 (total: 0)
-2026/04/19 22:37:08 Received kill signal.  Quitting Writer. stop 0x6c67e803c4d0
-2026/04/19 22:37:08 Cleaning up writer...
-2026/04/19 22:37:08 Finished cleaning up writer:  0x6c67e803c4d0
-2026/04/19 22:37:08 Closed MCP-GET-SSE SSE connection: 84c427d761020e6f1ab55588990c5798
+2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: 7c7809131a91c729822f93f9ae911728
+2026/04/19 23:37:22 SSEHub: registered connection 7c7809131a91c729822f93f9ae911728 (total: 1)
+2026/04/19 23:37:22 SSEHub: unregistered connection 7c7809131a91c729822f93f9ae911728 (total: 0)
+2026/04/19 23:37:22 Received kill signal.  Quitting Writer. stop 0x31b4a0b14a10
+2026/04/19 23:37:22 Cleaning up writer...
+2026/04/19 23:37:22 Finished cleaning up writer:  0x31b4a0b14a10
+2026/04/19 23:37:22 Closed MCP-GET-SSE SSE connection: 7c7809131a91c729822f93f9ae911728
 
 === Running scenario: tools-list ===
 Running client scenario 'tools-list' against server: http://localhost:18799/mcp
-2026/04/19 22:37:08 Starting MCP-GET-SSE SSE connection: bd1f4dd62ae2b7722343700950edfc8e
-2026/04/19 22:37:08 SSEHub: registered connection bd1f4dd62ae2b7722343700950edfc8e (total: 1)
-2026/04/19 22:37:08 SSEHub: unregistered connection bd1f4dd62ae2b7722343700950edfc8e (total: 0)
-2026/04/19 22:37:08 Received kill signal.  Quitting Writer. stop 0x6c67e7c5ce00
-2026/04/19 22:37:08 Cleaning up writer...
-2026/04/19 22:37:08 Finished cleaning up writer:  0x6c67e7c5ce00
-2026/04/19 22:37:08 Closed MCP-GET-SSE SSE connection: bd1f4dd62ae2b7722343700950edfc8e
+2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: 933c84a2644c4379fccf13a19fb835ba
+2026/04/19 23:37:22 SSEHub: registered connection 933c84a2644c4379fccf13a19fb835ba (total: 1)
 
 === Running scenario: tools-call-simple-text ===
+2026/04/19 23:37:22 SSEHub: unregistered connection 933c84a2644c4379fccf13a19fb835ba (total: 0)
 Running client scenario 'tools-call-simple-text' against server: http://localhost:18799/mcp
-2026/04/19 22:37:08 Starting MCP-GET-SSE SSE connection: 1f5c6beb99a4dbc3d009b3a4609447cf
-2026/04/19 22:37:08 SSEHub: registered connection 1f5c6beb99a4dbc3d009b3a4609447cf (total: 1)
-2026/04/19 22:37:08 SSEHub: unregistered connection 1f5c6beb99a4dbc3d009b3a4609447cf (total: 0)
-2026/04/19 22:37:08 Received kill signal.  Quitting Writer. stop 0x6c67e7d3c850
-2026/04/19 22:37:08 Cleaning up writer...
-2026/04/19 22:37:08 Finished cleaning up writer:  0x6c67e7d3c850
-2026/04/19 22:37:08 Closed MCP-GET-SSE SSE connection: 1f5c6beb99a4dbc3d009b3a4609447cf
+2026/04/19 23:37:22 Received kill signal.  Quitting Writer. stop 0x31b4a0b14c40
+2026/04/19 23:37:22 Cleaning up writer...
+2026/04/19 23:37:22 Finished cleaning up writer:  0x31b4a0b14c40
+2026/04/19 23:37:22 Closed MCP-GET-SSE SSE connection: 933c84a2644c4379fccf13a19fb835ba
+2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: f374b21d34ec91c720f89b4cbc55527b
+2026/04/19 23:37:22 SSEHub: registered connection f374b21d34ec91c720f89b4cbc55527b (total: 1)
+2026/04/19 23:37:22 SSEHub: unregistered connection f374b21d34ec91c720f89b4cbc55527b (total: 0)
+2026/04/19 23:37:22 Received kill signal.  Quitting Writer. stop 0x31b4a0b14e70
+2026/04/19 23:37:22 Cleaning up writer...
+2026/04/19 23:37:22 Finished cleaning up writer:  0x31b4a0b14e70
+2026/04/19 23:37:22 Closed MCP-GET-SSE SSE connection: f374b21d34ec91c720f89b4cbc55527b
 
 === Running scenario: tools-call-image ===
 Running client scenario 'tools-call-image' against server: http://localhost:18799/mcp
-2026/04/19 22:37:08 Starting MCP-GET-SSE SSE connection: fcd768a78d2e6813fd5b92ccfbd06fc8
-2026/04/19 22:37:08 SSEHub: registered connection fcd768a78d2e6813fd5b92ccfbd06fc8 (total: 1)
-2026/04/19 22:37:08 SSEHub: unregistered connection fcd768a78d2e6813fd5b92ccfbd06fc8 (total: 0)
-2026/04/19 22:37:08 Received kill signal.  Quitting Writer. stop 0x6c67e803c150
-2026/04/19 22:37:08 Cleaning up writer...
-2026/04/19 22:37:08 Finished cleaning up writer:  0x6c67e803c150
-2026/04/19 22:37:08 Closed MCP-GET-SSE SSE connection: fcd768a78d2e6813fd5b92ccfbd06fc8
+2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: 2dc9e9e7cd2a5a5f86e6e21389d10a0f
+2026/04/19 23:37:22 SSEHub: registered connection 2dc9e9e7cd2a5a5f86e6e21389d10a0f (total: 1)
+2026/04/19 23:37:22 SSEHub: unregistered connection 2dc9e9e7cd2a5a5f86e6e21389d10a0f (total: 0)
+2026/04/19 23:37:22 Received kill signal.  Quitting Writer. stop 0x31b4a0e36850
+2026/04/19 23:37:22 Cleaning up writer...
+2026/04/19 23:37:22 Finished cleaning up writer:  0x31b4a0e36850
+2026/04/19 23:37:22 Closed MCP-GET-SSE SSE connection: 2dc9e9e7cd2a5a5f86e6e21389d10a0f
 
 === Running scenario: tools-call-audio ===
 Running client scenario 'tools-call-audio' against server: http://localhost:18799/mcp
-2026/04/19 22:37:08 Starting MCP-GET-SSE SSE connection: 1da32359eb43ff84f10902feb54e5ce2
-2026/04/19 22:37:08 SSEHub: registered connection 1da32359eb43ff84f10902feb54e5ce2 (total: 1)
-2026/04/19 22:37:08 SSEHub: unregistered connection 1da32359eb43ff84f10902feb54e5ce2 (total: 0)
+2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: 6c4635a21f83c810dbfd1718f2d50ace
+2026/04/19 23:37:22 SSEHub: registered connection 6c4635a21f83c810dbfd1718f2d50ace (total: 1)
+2026/04/19 23:37:22 SSEHub: unregistered connection 6c4635a21f83c810dbfd1718f2d50ace (total: 0)
+2026/04/19 23:37:22 Received kill signal.  Quitting Writer. stop 0x31b4a0a623f0
+2026/04/19 23:37:22 Cleaning up writer...
+2026/04/19 23:37:22 Finished cleaning up writer:  0x31b4a0a623f0
+2026/04/19 23:37:22 Closed MCP-GET-SSE SSE connection: 6c4635a21f83c810dbfd1718f2d50ace
 
 === Running scenario: tools-call-embedded-resource ===
-2026/04/19 22:37:08 Received kill signal.  Quitting Writer. stop 0x6c67e7c5c3f0
-2026/04/19 22:37:08 Cleaning up writer...
 Running client scenario 'tools-call-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/19 22:37:08 Finished cleaning up writer:  0x6c67e7c5c3f0
-2026/04/19 22:37:08 Closed MCP-GET-SSE SSE connection: 1da32359eb43ff84f10902feb54e5ce2
-2026/04/19 22:37:08 Starting MCP-GET-SSE SSE connection: 81b7e601704f91d44ad81b22b5e4ae14
-2026/04/19 22:37:08 SSEHub: registered connection 81b7e601704f91d44ad81b22b5e4ae14 (total: 1)
-2026/04/19 22:37:08 SSEHub: unregistered connection 81b7e601704f91d44ad81b22b5e4ae14 (total: 0)
-2026/04/19 22:37:08 Received kill signal.  Quitting Writer. stop 0x6c67e803c5b0
-2026/04/19 22:37:08 Cleaning up writer...
-2026/04/19 22:37:08 Finished cleaning up writer:  0x6c67e803c5b0
-2026/04/19 22:37:08 Closed MCP-GET-SSE SSE connection: 81b7e601704f91d44ad81b22b5e4ae14
+2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: 01c6ebf03176df1b52be5bf2321af125
+2026/04/19 23:37:22 SSEHub: registered connection 01c6ebf03176df1b52be5bf2321af125 (total: 1)
+2026/04/19 23:37:22 SSEHub: unregistered connection 01c6ebf03176df1b52be5bf2321af125 (total: 0)
+2026/04/19 23:37:22 Received kill signal.  Quitting Writer. stop 0x31b4a0f38380
+2026/04/19 23:37:22 Cleaning up writer...
+2026/04/19 23:37:22 Finished cleaning up writer:  0x31b4a0f38380
+2026/04/19 23:37:22 Closed MCP-GET-SSE SSE connection: 01c6ebf03176df1b52be5bf2321af125
 
 === Running scenario: tools-call-mixed-content ===
 Running client scenario 'tools-call-mixed-content' against server: http://localhost:18799/mcp
-2026/04/19 22:37:08 Starting MCP-GET-SSE SSE connection: 78e2d5e8252d419fd3e8c3587c5412b4
-2026/04/19 22:37:08 SSEHub: registered connection 78e2d5e8252d419fd3e8c3587c5412b4 (total: 1)
-2026/04/19 22:37:08 SSEHub: unregistered connection 78e2d5e8252d419fd3e8c3587c5412b4 (total: 0)
-2026/04/19 22:37:08 Received kill signal.  Quitting Writer. stop 0x6c67e803c7e0
-2026/04/19 22:37:08 Cleaning up writer...
-2026/04/19 22:37:08 Finished cleaning up writer:  0x6c67e803c7e0
-2026/04/19 22:37:08 Closed MCP-GET-SSE SSE connection: 78e2d5e8252d419fd3e8c3587c5412b4
+2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: cf622a8d18a72911d7660a0042d0dd96
+2026/04/19 23:37:22 SSEHub: registered connection cf622a8d18a72911d7660a0042d0dd96 (total: 1)
 
 === Running scenario: tools-call-with-logging ===
+2026/04/19 23:37:22 SSEHub: unregistered connection cf622a8d18a72911d7660a0042d0dd96 (total: 0)
 Running client scenario 'tools-call-with-logging' against server: http://localhost:18799/mcp
-2026/04/19 22:37:08 Starting MCP-GET-SSE SSE connection: ef2fa703a44f03b117dc9fb631af9b3b
-2026/04/19 22:37:08 SSEHub: registered connection ef2fa703a44f03b117dc9fb631af9b3b (total: 1)
-2026/04/19 22:37:09 SSEHub: unregistered connection ef2fa703a44f03b117dc9fb631af9b3b (total: 0)
-2026/04/19 22:37:09 Received kill signal.  Quitting Writer. stop 0x6c67e803ca80
-2026/04/19 22:37:09 Cleaning up writer...
-2026/04/19 22:37:09 Finished cleaning up writer:  0x6c67e803ca80
-2026/04/19 22:37:09 Closed MCP-GET-SSE SSE connection: ef2fa703a44f03b117dc9fb631af9b3b
+2026/04/19 23:37:22 Received kill signal.  Quitting Writer. stop 0x31b4a0f385b0
+2026/04/19 23:37:22 Cleaning up writer...
+2026/04/19 23:37:22 Finished cleaning up writer:  0x31b4a0f385b0
+2026/04/19 23:37:22 Closed MCP-GET-SSE SSE connection: cf622a8d18a72911d7660a0042d0dd96
+2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: 5c3c94cc470dc4a860808d372aefbd3f
+2026/04/19 23:37:22 SSEHub: registered connection 5c3c94cc470dc4a860808d372aefbd3f (total: 1)
+2026/04/19 23:37:23 SSEHub: unregistered connection 5c3c94cc470dc4a860808d372aefbd3f (total: 0)
+2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0e36d20
+2026/04/19 23:37:23 Cleaning up writer...
+2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0e36d20
+2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 5c3c94cc470dc4a860808d372aefbd3f
 
 === Running scenario: tools-call-error ===
 Running client scenario 'tools-call-error' against server: http://localhost:18799/mcp
-2026/04/19 22:37:09 Starting MCP-GET-SSE SSE connection: 490c70808e32cb986bf3d658b5a97fcc
-2026/04/19 22:37:09 SSEHub: registered connection 490c70808e32cb986bf3d658b5a97fcc (total: 1)
-2026/04/19 22:37:09 SSEHub: unregistered connection 490c70808e32cb986bf3d658b5a97fcc (total: 0)
-2026/04/19 22:37:09 Received kill signal.  Quitting Writer. stop 0x6c67e803cd20
-2026/04/19 22:37:09 Cleaning up writer...
-2026/04/19 22:37:09 Finished cleaning up writer:  0x6c67e803cd20
-2026/04/19 22:37:09 Closed MCP-GET-SSE SSE connection: 490c70808e32cb986bf3d658b5a97fcc
+2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 4d4f605f8b6a3c6e7b976677a7c78fac
+2026/04/19 23:37:23 SSEHub: registered connection 4d4f605f8b6a3c6e7b976677a7c78fac (total: 1)
+2026/04/19 23:37:23 SSEHub: unregistered connection 4d4f605f8b6a3c6e7b976677a7c78fac (total: 0)
+2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0b15180
+2026/04/19 23:37:23 Cleaning up writer...
+2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0b15180
+2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 4d4f605f8b6a3c6e7b976677a7c78fac
 
 === Running scenario: tools-call-with-progress ===
 Running client scenario 'tools-call-with-progress' against server: http://localhost:18799/mcp
-2026/04/19 22:37:09 Starting MCP-GET-SSE SSE connection: 315713c5fe0070a0120b8910e2a1aec9
-2026/04/19 22:37:09 SSEHub: registered connection 315713c5fe0070a0120b8910e2a1aec9 (total: 1)
-2026/04/19 22:37:09 SSEHub: unregistered connection 315713c5fe0070a0120b8910e2a1aec9 (total: 0)
-2026/04/19 22:37:09 Received kill signal.  Quitting Writer. stop 0x6c67e8078460
-2026/04/19 22:37:09 Cleaning up writer...
-2026/04/19 22:37:09 Finished cleaning up writer:  0x6c67e8078460
-2026/04/19 22:37:09 Closed MCP-GET-SSE SSE connection: 315713c5fe0070a0120b8910e2a1aec9
+2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 1b88cbbe8aeeb56da6696e97ec93fd5f
+2026/04/19 23:37:23 SSEHub: registered connection 1b88cbbe8aeeb56da6696e97ec93fd5f (total: 1)
+2026/04/19 23:37:23 SSEHub: unregistered connection 1b88cbbe8aeeb56da6696e97ec93fd5f (total: 0)
+2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0f388c0
+2026/04/19 23:37:23 Cleaning up writer...
+2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0f388c0
+2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 1b88cbbe8aeeb56da6696e97ec93fd5f
 
 === Running scenario: tools-call-sampling ===
 Running client scenario 'tools-call-sampling' against server: http://localhost:18799/mcp
-2026/04/19 22:37:09 Starting MCP-GET-SSE SSE connection: 53376020e54b40eeb5bbf297ad8ee07e
-2026/04/19 22:37:09 SSEHub: registered connection 53376020e54b40eeb5bbf297ad8ee07e (total: 1)
-2026/04/19 22:37:09 SSEHub: unregistered connection 53376020e54b40eeb5bbf297ad8ee07e (total: 0)
-2026/04/19 22:37:09 Received kill signal.  Quitting Writer. stop 0x6c67e8078770
-2026/04/19 22:37:09 Cleaning up writer...
-2026/04/19 22:37:09 Finished cleaning up writer:  0x6c67e8078770
-2026/04/19 22:37:09 Closed MCP-GET-SSE SSE connection: 53376020e54b40eeb5bbf297ad8ee07e
+2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 086d4eacc6f20d40ea4258dfd911be7d
+2026/04/19 23:37:23 SSEHub: registered connection 086d4eacc6f20d40ea4258dfd911be7d (total: 1)
+2026/04/19 23:37:23 SSEHub: unregistered connection 086d4eacc6f20d40ea4258dfd911be7d (total: 0)
 
 === Running scenario: tools-call-elicitation ===
+2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0f38b60
+2026/04/19 23:37:23 Cleaning up writer...
 Running client scenario 'tools-call-elicitation' against server: http://localhost:18799/mcp
-2026/04/19 22:37:09 Starting MCP-GET-SSE SSE connection: 4c5ce16679909373615743b397a8ded2
-2026/04/19 22:37:09 SSEHub: registered connection 4c5ce16679909373615743b397a8ded2 (total: 1)
-2026/04/19 22:37:09 SSEHub: unregistered connection 4c5ce16679909373615743b397a8ded2 (total: 0)
-2026/04/19 22:37:09 Received kill signal.  Quitting Writer. stop 0x6c67e8078b60
-2026/04/19 22:37:09 Cleaning up writer...
-2026/04/19 22:37:09 Finished cleaning up writer:  0x6c67e8078b60
-2026/04/19 22:37:09 Closed MCP-GET-SSE SSE connection: 4c5ce16679909373615743b397a8ded2
+2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0f38b60
+2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 086d4eacc6f20d40ea4258dfd911be7d
+2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 0e7021f6fa4825de1c9624c63bedffc3
+2026/04/19 23:37:23 SSEHub: registered connection 0e7021f6fa4825de1c9624c63bedffc3 (total: 1)
+2026/04/19 23:37:23 SSEHub: unregistered connection 0e7021f6fa4825de1c9624c63bedffc3 (total: 0)
+2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0f38f50
+2026/04/19 23:37:23 Cleaning up writer...
+2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0f38f50
+2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 0e7021f6fa4825de1c9624c63bedffc3
 
 === Running scenario: elicitation-sep1034-defaults ===
 Running client scenario 'elicitation-sep1034-defaults' against server: http://localhost:18799/mcp
-2026/04/19 22:37:09 Starting MCP-GET-SSE SSE connection: 7028ff83b29d107d888a8473c4daea20
-2026/04/19 22:37:09 SSEHub: registered connection 7028ff83b29d107d888a8473c4daea20 (total: 1)
+2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 477d10535fc22ca961eb8b870a592b2a
+2026/04/19 23:37:23 SSEHub: registered connection 477d10535fc22ca961eb8b870a592b2a (total: 1)
+2026/04/19 23:37:23 SSEHub: unregistered connection 477d10535fc22ca961eb8b870a592b2a (total: 0)
+2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0a62a10
+2026/04/19 23:37:23 Cleaning up writer...
+2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0a62a10
+2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 477d10535fc22ca961eb8b870a592b2a
 
 === Running scenario: server-sse-multiple-streams ===
-2026/04/19 22:37:09 SSEHub: unregistered connection 7028ff83b29d107d888a8473c4daea20 (total: 0)
 Running client scenario 'server-sse-multiple-streams' against server: http://localhost:18799/mcp
-2026/04/19 22:37:09 Received kill signal.  Quitting Writer. stop 0x6c67e8078e00
-2026/04/19 22:37:09 Cleaning up writer...
-2026/04/19 22:37:09 Finished cleaning up writer:  0x6c67e8078e00
-2026/04/19 22:37:09 Closed MCP-GET-SSE SSE connection: 7028ff83b29d107d888a8473c4daea20
-2026/04/19 22:37:09 Starting MCP-GET-SSE SSE connection: 3eb7caee29b93a7759b7910ecb3bccf9
-2026/04/19 22:37:09 SSEHub: registered connection 3eb7caee29b93a7759b7910ecb3bccf9 (total: 1)
-2026/04/19 22:37:09 SSEHub: unregistered connection 3eb7caee29b93a7759b7910ecb3bccf9 (total: 0)
-2026/04/19 22:37:09 Received kill signal.  Quitting Writer. stop 0x6c67e7c5d180
-2026/04/19 22:37:09 Cleaning up writer...
+2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 9d6f6d4f1641ac895133bb086d425fc4
+2026/04/19 23:37:23 SSEHub: registered connection 9d6f6d4f1641ac895133bb086d425fc4 (total: 1)
+2026/04/19 23:37:23 SSEHub: unregistered connection 9d6f6d4f1641ac895133bb086d425fc4 (total: 0)
+2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0b15490
+2026/04/19 23:37:23 Cleaning up writer...
 
 === Running scenario: elicitation-sep1330-enums ===
-2026/04/19 22:37:09 Finished cleaning up writer:  0x6c67e7c5d180
-2026/04/19 22:37:09 Closed MCP-GET-SSE SSE connection: 3eb7caee29b93a7759b7910ecb3bccf9
+2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0b15490
 Running client scenario 'elicitation-sep1330-enums' against server: http://localhost:18799/mcp
-2026/04/19 22:37:09 Starting MCP-GET-SSE SSE connection: 89a6d8d2fd390b9a6d1927e15b0e0f48
-2026/04/19 22:37:09 SSEHub: registered connection 89a6d8d2fd390b9a6d1927e15b0e0f48 (total: 1)
-2026/04/19 22:37:09 SSEHub: unregistered connection 89a6d8d2fd390b9a6d1927e15b0e0f48 (total: 0)
-2026/04/19 22:37:09 Received kill signal.  Quitting Writer. stop 0x6c67e7c5d490
-2026/04/19 22:37:09 Cleaning up writer...
-2026/04/19 22:37:09 Finished cleaning up writer:  0x6c67e7c5d490
-2026/04/19 22:37:09 Closed MCP-GET-SSE SSE connection: 89a6d8d2fd390b9a6d1927e15b0e0f48
+2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 9d6f6d4f1641ac895133bb086d425fc4
+2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: cb0ac37cc1852d3213f7ee30717df7cd
+2026/04/19 23:37:23 SSEHub: registered connection cb0ac37cc1852d3213f7ee30717df7cd (total: 1)
+2026/04/19 23:37:23 SSEHub: unregistered connection cb0ac37cc1852d3213f7ee30717df7cd (total: 0)
+2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0b15810
+2026/04/19 23:37:23 Cleaning up writer...
+2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0b15810
+2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: cb0ac37cc1852d3213f7ee30717df7cd
 
 === Running scenario: resources-list ===
 Running client scenario 'resources-list' against server: http://localhost:18799/mcp
-2026/04/19 22:37:09 Starting MCP-GET-SSE SSE connection: acca92f2aa185838923fee9e286d57cb
-2026/04/19 22:37:09 SSEHub: registered connection acca92f2aa185838923fee9e286d57cb (total: 1)
-2026/04/19 22:37:09 SSEHub: unregistered connection acca92f2aa185838923fee9e286d57cb (total: 0)
-2026/04/19 22:37:09 Received kill signal.  Quitting Writer. stop 0x6c67e7c5d6c0
-2026/04/19 22:37:09 Cleaning up writer...
-2026/04/19 22:37:09 Finished cleaning up writer:  0x6c67e7c5d6c0
+2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 17ba27e0fac9c99ebbfa2a1e2a34e6ef
+2026/04/19 23:37:23 SSEHub: registered connection 17ba27e0fac9c99ebbfa2a1e2a34e6ef (total: 1)
+2026/04/19 23:37:23 SSEHub: unregistered connection 17ba27e0fac9c99ebbfa2a1e2a34e6ef (total: 0)
 
 === Running scenario: resources-read-text ===
-2026/04/19 22:37:09 Closed MCP-GET-SSE SSE connection: acca92f2aa185838923fee9e286d57cb
+2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0a62e00
+2026/04/19 23:37:23 Cleaning up writer...
 Running client scenario 'resources-read-text' against server: http://localhost:18799/mcp
-2026/04/19 22:37:09 Starting MCP-GET-SSE SSE connection: d536edd4e4c3b77b13e47fdf3f9b0ba0
-2026/04/19 22:37:09 SSEHub: registered connection d536edd4e4c3b77b13e47fdf3f9b0ba0 (total: 1)
-2026/04/19 22:37:09 SSEHub: unregistered connection d536edd4e4c3b77b13e47fdf3f9b0ba0 (total: 0)
-2026/04/19 22:37:09 Received kill signal.  Quitting Writer. stop 0x6c67e7c5d960
-2026/04/19 22:37:09 Cleaning up writer...
-2026/04/19 22:37:09 Finished cleaning up writer:  0x6c67e7c5d960
+2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0a62e00
+2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 17ba27e0fac9c99ebbfa2a1e2a34e6ef
+2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 25c118c25e1f64d4963e336f26f8ec86
+2026/04/19 23:37:23 SSEHub: registered connection 25c118c25e1f64d4963e336f26f8ec86 (total: 1)
+2026/04/19 23:37:23 SSEHub: unregistered connection 25c118c25e1f64d4963e336f26f8ec86 (total: 0)
+2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0e373b0
+2026/04/19 23:37:23 Cleaning up writer...
 
 === Running scenario: resources-read-binary ===
-2026/04/19 22:37:09 Closed MCP-GET-SSE SSE connection: d536edd4e4c3b77b13e47fdf3f9b0ba0
+2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0e373b0
 Running client scenario 'resources-read-binary' against server: http://localhost:18799/mcp
-2026/04/19 22:37:09 Starting MCP-GET-SSE SSE connection: 36016bd9adb9f0612b9d4aab9de1fde5
-2026/04/19 22:37:09 SSEHub: registered connection 36016bd9adb9f0612b9d4aab9de1fde5 (total: 1)
-2026/04/19 22:37:09 SSEHub: unregistered connection 36016bd9adb9f0612b9d4aab9de1fde5 (total: 0)
+2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 25c118c25e1f64d4963e336f26f8ec86
+2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 9ec716cb233e869cbac5ef4694f7f7d8
+2026/04/19 23:37:23 SSEHub: registered connection 9ec716cb233e869cbac5ef4694f7f7d8 (total: 1)
+2026/04/19 23:37:23 SSEHub: unregistered connection 9ec716cb233e869cbac5ef4694f7f7d8 (total: 0)
 
 === Running scenario: resources-templates-read ===
-2026/04/19 22:37:09 Received kill signal.  Quitting Writer. stop 0x6c67e7c5db90
-2026/04/19 22:37:09 Cleaning up writer...
+2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0b15b20
+2026/04/19 23:37:23 Cleaning up writer...
 Running client scenario 'resources-templates-read' against server: http://localhost:18799/mcp
-2026/04/19 22:37:09 Finished cleaning up writer:  0x6c67e7c5db90
-2026/04/19 22:37:09 Closed MCP-GET-SSE SSE connection: 36016bd9adb9f0612b9d4aab9de1fde5
-2026/04/19 22:37:09 Starting MCP-GET-SSE SSE connection: 8c8632727a32afbdc504733ae7227f7d
-2026/04/19 22:37:09 SSEHub: registered connection 8c8632727a32afbdc504733ae7227f7d (total: 1)
-2026/04/19 22:37:09 SSEHub: unregistered connection 8c8632727a32afbdc504733ae7227f7d (total: 0)
-2026/04/19 22:37:09 Received kill signal.  Quitting Writer. stop 0x6c67e8079260
-2026/04/19 22:37:09 Cleaning up writer...
-2026/04/19 22:37:09 Finished cleaning up writer:  0x6c67e8079260
-2026/04/19 22:37:09 Closed MCP-GET-SSE SSE connection: 8c8632727a32afbdc504733ae7227f7d
+2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0b15b20
+2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 9ec716cb233e869cbac5ef4694f7f7d8
+2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 2a3fe347294da8127767e1dc06d000c2
+2026/04/19 23:37:23 SSEHub: registered connection 2a3fe347294da8127767e1dc06d000c2 (total: 1)
+2026/04/19 23:37:23 SSEHub: unregistered connection 2a3fe347294da8127767e1dc06d000c2 (total: 0)
+2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0e30150
+2026/04/19 23:37:23 Cleaning up writer...
+2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0e30150
 
 === Running scenario: resources-subscribe ===
+2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 2a3fe347294da8127767e1dc06d000c2
 Running client scenario 'resources-subscribe' against server: http://localhost:18799/mcp
-2026/04/19 22:37:09 Starting MCP-GET-SSE SSE connection: affdc63dba4d88f5d392938e596971ca
-2026/04/19 22:37:09 SSEHub: registered connection affdc63dba4d88f5d392938e596971ca (total: 1)
-2026/04/19 22:37:09 SSEHub: unregistered connection affdc63dba4d88f5d392938e596971ca (total: 0)
-2026/04/19 22:37:09 Received kill signal.  Quitting Writer. stop 0x6c67e8079570
-2026/04/19 22:37:09 Cleaning up writer...
-2026/04/19 22:37:09 Finished cleaning up writer:  0x6c67e8079570
+2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 96c5814ee364aa0e72ac38f20de40773
+2026/04/19 23:37:23 SSEHub: registered connection 96c5814ee364aa0e72ac38f20de40773 (total: 1)
+2026/04/19 23:37:23 SSEHub: unregistered connection 96c5814ee364aa0e72ac38f20de40773 (total: 0)
+2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0b15d50
+2026/04/19 23:37:23 Cleaning up writer...
+2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0b15d50
+2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 96c5814ee364aa0e72ac38f20de40773
 
 === Running scenario: resources-unsubscribe ===
-2026/04/19 22:37:09 Closed MCP-GET-SSE SSE connection: affdc63dba4d88f5d392938e596971ca
 Running client scenario 'resources-unsubscribe' against server: http://localhost:18799/mcp
-2026/04/19 22:37:09 Starting MCP-GET-SSE SSE connection: fd25980e02f4ba53a60c2374e36c082c
-2026/04/19 22:37:09 SSEHub: registered connection fd25980e02f4ba53a60c2374e36c082c (total: 1)
-2026/04/19 22:37:09 SSEHub: unregistered connection fd25980e02f4ba53a60c2374e36c082c (total: 0)
-2026/04/19 22:37:09 Received kill signal.  Quitting Writer. stop 0x6c67e7e12230
-2026/04/19 22:37:09 Cleaning up writer...
-2026/04/19 22:37:09 Finished cleaning up writer:  0x6c67e7e12230
-2026/04/19 22:37:09 Closed MCP-GET-SSE SSE connection: fd25980e02f4ba53a60c2374e36c082c
+2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 02792683620fb595bcefb04fb332a473
+2026/04/19 23:37:23 SSEHub: registered connection 02792683620fb595bcefb04fb332a473 (total: 1)
+2026/04/19 23:37:23 SSEHub: unregistered connection 02792683620fb595bcefb04fb332a473 (total: 0)
+2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0e30460
+2026/04/19 23:37:23 Cleaning up writer...
+2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0e30460
+2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 02792683620fb595bcefb04fb332a473
 
 === Running scenario: prompts-list ===
 Running client scenario 'prompts-list' against server: http://localhost:18799/mcp
-2026/04/19 22:37:09 Starting MCP-GET-SSE SSE connection: ddaf7548171104afb7f8882ca3830fab
-2026/04/19 22:37:09 SSEHub: registered connection ddaf7548171104afb7f8882ca3830fab (total: 1)
-2026/04/19 22:37:09 SSEHub: unregistered connection ddaf7548171104afb7f8882ca3830fab (total: 0)
-2026/04/19 22:37:09 Received kill signal.  Quitting Writer. stop 0x6c67e803d500
-2026/04/19 22:37:09 Cleaning up writer...
-2026/04/19 22:37:09 Finished cleaning up writer:  0x6c67e803d500
+2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 9b7508e663f11e45ced3313184ca73e4
+2026/04/19 23:37:23 SSEHub: registered connection 9b7508e663f11e45ced3313184ca73e4 (total: 1)
+2026/04/19 23:37:23 SSEHub: unregistered connection 9b7508e663f11e45ced3313184ca73e4 (total: 0)
+2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0cd80e0
+2026/04/19 23:37:23 Cleaning up writer...
+2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0cd80e0
 
 === Running scenario: prompts-get-simple ===
-2026/04/19 22:37:09 Closed MCP-GET-SSE SSE connection: ddaf7548171104afb7f8882ca3830fab
+2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 9b7508e663f11e45ced3313184ca73e4
 Running client scenario 'prompts-get-simple' against server: http://localhost:18799/mcp
-2026/04/19 22:37:09 Starting MCP-GET-SSE SSE connection: 8183709211aa71b479b83c90e31fb09e
-2026/04/19 22:37:09 SSEHub: registered connection 8183709211aa71b479b83c90e31fb09e (total: 1)
-2026/04/19 22:37:09 SSEHub: unregistered connection 8183709211aa71b479b83c90e31fb09e (total: 0)
+2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 9569eaf0b71eec1a57a48e8884dc5e9d
+2026/04/19 23:37:23 SSEHub: registered connection 9569eaf0b71eec1a57a48e8884dc5e9d (total: 1)
+2026/04/19 23:37:23 SSEHub: unregistered connection 9569eaf0b71eec1a57a48e8884dc5e9d (total: 0)
+2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0cd8380
+2026/04/19 23:37:23 Cleaning up writer...
+2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0cd8380
+2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 9569eaf0b71eec1a57a48e8884dc5e9d
 
 === Running scenario: prompts-get-with-args ===
 Running client scenario 'prompts-get-with-args' against server: http://localhost:18799/mcp
-2026/04/19 22:37:09 Received kill signal.  Quitting Writer. stop 0x6c67e7e124d0
-2026/04/19 22:37:09 Cleaning up writer...
-2026/04/19 22:37:09 Finished cleaning up writer:  0x6c67e7e124d0
-2026/04/19 22:37:09 Closed MCP-GET-SSE SSE connection: 8183709211aa71b479b83c90e31fb09e
-2026/04/19 22:37:09 Starting MCP-GET-SSE SSE connection: 72691916950544516c9f5ba297afbaf1
-2026/04/19 22:37:09 SSEHub: registered connection 72691916950544516c9f5ba297afbaf1 (total: 1)
-2026/04/19 22:37:09 SSEHub: unregistered connection 72691916950544516c9f5ba297afbaf1 (total: 0)
-2026/04/19 22:37:09 Received kill signal.  Quitting Writer. stop 0x6c67e8079ab0
-2026/04/19 22:37:09 Cleaning up writer...
-2026/04/19 22:37:09 Finished cleaning up writer:  0x6c67e8079ab0
-2026/04/19 22:37:09 Closed MCP-GET-SSE SSE connection: 72691916950544516c9f5ba297afbaf1
+2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 8a8fa096ad8bcabd021f7838e5a7d6ea
+2026/04/19 23:37:23 SSEHub: registered connection 8a8fa096ad8bcabd021f7838e5a7d6ea (total: 1)
+2026/04/19 23:37:23 SSEHub: unregistered connection 8a8fa096ad8bcabd021f7838e5a7d6ea (total: 0)
+2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0e37650
+2026/04/19 23:37:23 Cleaning up writer...
+2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0e37650
+2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 8a8fa096ad8bcabd021f7838e5a7d6ea
 
 === Running scenario: prompts-get-embedded-resource ===
 Running client scenario 'prompts-get-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/19 22:37:09 Starting MCP-GET-SSE SSE connection: 49b759701f4de31d6cd87fd918ee0c86
-2026/04/19 22:37:09 SSEHub: registered connection 49b759701f4de31d6cd87fd918ee0c86 (total: 1)
-2026/04/19 22:37:09 SSEHub: unregistered connection 49b759701f4de31d6cd87fd918ee0c86 (total: 0)
-2026/04/19 22:37:09 Received kill signal.  Quitting Writer. stop 0x6c67e8079dc0
-2026/04/19 22:37:09 Cleaning up writer...
-2026/04/19 22:37:09 Finished cleaning up writer:  0x6c67e8079dc0
-2026/04/19 22:37:09 Closed MCP-GET-SSE SSE connection: 49b759701f4de31d6cd87fd918ee0c86
+2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: ba09f56cdd75b3b3ed848afe2f9a385a
+2026/04/19 23:37:23 SSEHub: registered connection ba09f56cdd75b3b3ed848afe2f9a385a (total: 1)
+2026/04/19 23:37:23 SSEHub: unregistered connection ba09f56cdd75b3b3ed848afe2f9a385a (total: 0)
+2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0e307e0
+2026/04/19 23:37:23 Cleaning up writer...
+2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0e307e0
 
 === Running scenario: prompts-get-with-image ===
+2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: ba09f56cdd75b3b3ed848afe2f9a385a
 Running client scenario 'prompts-get-with-image' against server: http://localhost:18799/mcp
-2026/04/19 22:37:09 Starting MCP-GET-SSE SSE connection: ff822b266502acbc623f9c5134d616fa
-2026/04/19 22:37:09 SSEHub: registered connection ff822b266502acbc623f9c5134d616fa (total: 1)
-2026/04/19 22:37:09 SSEHub: unregistered connection ff822b266502acbc623f9c5134d616fa (total: 0)
-2026/04/19 22:37:09 Received kill signal.  Quitting Writer. stop 0x6c67e7ea41c0
-2026/04/19 22:37:09 Cleaning up writer...
+2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 512b0f815ce7e93ac6b685c0a3dfaa38
+2026/04/19 23:37:23 SSEHub: registered connection 512b0f815ce7e93ac6b685c0a3dfaa38 (total: 1)
+2026/04/19 23:37:23 SSEHub: unregistered connection 512b0f815ce7e93ac6b685c0a3dfaa38 (total: 0)
+2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0cd8620
+2026/04/19 23:37:23 Cleaning up writer...
+2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0cd8620
+2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 512b0f815ce7e93ac6b685c0a3dfaa38
 
 === Running scenario: dns-rebinding-protection ===
-2026/04/19 22:37:09 Finished cleaning up writer:  0x6c67e7ea41c0
-2026/04/19 22:37:09 Closed MCP-GET-SSE SSE connection: ff822b266502acbc623f9c5134d616fa
 Running client scenario 'dns-rebinding-protection' against server: http://localhost:18799/mcp
 
 
@@ -438,22 +438,22 @@ Starting scenario: auth/token-endpoint-auth-basic
 Starting scenario: auth/token-endpoint-auth-post
 Starting scenario: auth/token-endpoint-auth-none
 Starting scenario: auth/pre-registration
-Executing client: ./bin/testclient http://localhost:64439/mcp
-Executing client: ./bin/testclient http://localhost:64440/mcp
-Executing client: ./bin/testclient http://localhost:64441/mcp
-Executing client: ./bin/testclient http://localhost:64442/mcp
-Executing client: ./bin/testclient http://localhost:64443/mcp
-Executing client: ./bin/testclient http://localhost:64444/mcp
-Executing client: ./bin/testclient http://localhost:64445/mcp
-Executing client: ./bin/testclient http://localhost:64446/mcp
-Executing client: ./bin/testclient http://localhost:64447/mcp
-Executing client: ./bin/testclient http://localhost:64448/mcp
-Executing client: ./bin/testclient http://localhost:64449/mcp
-Executing client: ./bin/testclient http://localhost:64450/mcp
-Executing client: ./bin/testclient http://localhost:64451/mcp
-Executing client: ./bin/testclient http://localhost:64452/mcp
+Executing client: ./bin/testclient http://localhost:61533/mcp
+Executing client: ./bin/testclient http://localhost:61534/mcp
+Executing client: ./bin/testclient http://localhost:61535/mcp
+Executing client: ./bin/testclient http://localhost:61536/mcp
+Executing client: ./bin/testclient http://localhost:61537/mcp
+Executing client: ./bin/testclient http://localhost:61538/mcp
+Executing client: ./bin/testclient http://localhost:61539/mcp
+Executing client: ./bin/testclient http://localhost:61540/mcp
+Executing client: ./bin/testclient http://localhost:61541/mcp
+Executing client: ./bin/testclient http://localhost:61542/mcp
+Executing client: ./bin/testclient http://localhost:61543/mcp
+Executing client: ./bin/testclient http://localhost:61544/mcp
+Executing client: ./bin/testclient http://localhost:61545/mcp
+Executing client: ./bin/testclient http://localhost:61546/mcp
 With context: {"client_id":"pre-registered-client","client_secret":"pre-registered-secret"}
-(node:56882) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
+(node:98398) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
 (Use `node --trace-deprecation ...` to show where the warning was created)
 
 === SUITE SUMMARY ===
@@ -527,8 +527,8 @@ Waiting for Keycloak realm...
     token_refresh_test.go:22: Keycloak not reachable at http://localhost:8180: Get "http://localhost:8180/realms/mcpkit-test": dial tcp [::1]:8180: connect: connection refused (run 'make upkcl' to start)
 --- SKIP: TestKeycloak_TokenRefresh_PasswordGrant (0.00s)
 PASS
-ok  	github.com/panyam/mcpkit/tests/keycloak	0.407s
+ok  	github.com/panyam/mcpkit/tests/keycloak	0.417s
 make[2]: *** No rule to make target `downkcl'.  Stop.
 
 === Results: 10 passed, 0 failed ===
-Finished: Sun Apr 19 22:39:14 PDT 2026
+Finished: Sun Apr 19 23:39:28 PDT 2026


### PR DESCRIPTION
## Summary

Tasks are automatically cleaned up after their TTL expires. Timer-per-task approach matching the TS SDK's `InMemoryTaskStore`.

## What changed

| Method | Change |
|--------|--------|
| `Create()` | Schedules `time.AfterFunc(ttl, deleteTask)` if TTL > 0 |
| `SetResult()` | Resets timer — fresh TTL window from result storage |
| `Cancel()` | Resets timer — cancelled tasks remain queryable for TTL |
| `Cleanup()` | NEW — stops all timers, clears all tasks (shutdown/testing) |
| `deleteTask()` | NEW — internal, called by timer, removes task from store |
| `resetTimer()` | NEW — internal, stops old timer, starts new one |

Null TTL (`ttl: null` per spec) means unlimited — no timer, task lives forever.

## Tests (7 new, 68 total)

| Test | What |
|------|------|
| `TestStoreTTLExpiry` | Task removed after 100ms TTL |
| `TestStoreTTLResetOnResult` | Timer restarts when result is stored |
| `TestStoreTTLResetOnCancel` | Timer restarts on cancellation |
| `TestStoreTTLNullNoExpiry` | nil TTL = no automatic expiry |
| `TestStoreCleanup` | Removes all tasks |
| `TestStoreCleanupStopsTimers` | No race/panic after cleanup |
| `TestTaskTTLExpiryE2E` | Full stack: exercise 9 from README |

## Test plan

- [x] `cd experimental/ext/tasks && go test ./...` — 68 tests pass
- [ ] Exercise 9 from README via curl walkthrough
- [ ] Verify no regressions in Phase 1 tests