### PR TITLE
feat(tasks): Phase 3 — session isolation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ Sub-module commands: see `ext/ui/Makefile`, `experimental/ext/protogen/Makefile`
 - **Sub-module go.sum drift**: New `core/` imports break sub-modules until `make tidy-all`
 - **Telegram long-polling vs webhooks**: Mutually exclusive — delete webhook before using `GetUpdatesChan`
 - **MCP App CSP**: Host iframes enforce strict CSP (`script-src 'unsafe-inline'`, no `connect-src`). No external CDN scripts, no `fetch()` to server. Use inline JS + bridge events only.
-- **Background goroutine requestFunc**: Task goroutines inherit a dead POST-scoped `requestFunc`. Use `core.DetachForBackground(ctx)` instead of `context.WithoutCancel(ctx)` — it replaces with the session-level persistent push.
+- **Background goroutine requestFunc**: Task goroutines inherit a dead POST-scoped `requestFunc`. Use `core.DetachForBackground(ctx)` instead of `context.WithoutCancel(ctx)` — it replaces both `requestFunc` and `notifyFunc` with the session-level persistent push.
 - **Tasks side-channel**: `TaskElicit`/`TaskSample` send via the `tasks/result` handler's live connection, not the background goroutine's dead one. The handler proxies requests from a channel.
 
 Module-specific gotchas live in their READMEs (protogen templates, App Bridge escaping, etc.).

--- a/core/background.go
+++ b/core/background.go
@@ -44,9 +44,22 @@ func ReplaceSessionRequestFunc(ctx context.Context, fn RequestFunc) context.Cont
 	if sc == nil {
 		return ctx
 	}
-	// Create a shallow copy of the session context with the new requestFunc.
-	// We can't mutate the original because other goroutines may still reference it.
 	newSC := *sc
 	newSC.request = fn
+	return context.WithValue(ctx, sessionCtxKey, &newSC)
+}
+
+// ReplaceSessionNotifyFunc returns a new context with the session's
+// notifyFunc replaced. Used by detach strategies to swap the dead
+// POST-scoped notifyFunc with a live session-level one.
+//
+// No-op if the context has no session.
+func ReplaceSessionNotifyFunc(ctx context.Context, fn NotifyFunc) context.Context {
+	sc := sessionFromContext(ctx)
+	if sc == nil {
+		return ctx
+	}
+	newSC := *sc
+	newSC.notify = fn
 	return context.WithValue(ctx, sessionCtxKey, &newSC)
 }

--- a/core/handler_context.go
+++ b/core/handler_context.go
@@ -102,6 +102,15 @@ func (bc BaseContext) EmitLog(level LogLevel, logger string, data any) {
 	})
 }
 
+// SessionID returns the transport-assigned session ID for this request.
+// Empty for stateless or stdio transports.
+func (bc BaseContext) SessionID() string {
+	if bc.sc == nil {
+		return ""
+	}
+	return bc.sc.sessionID
+}
+
 // Sample sends a sampling/createMessage request to the connected client.
 func (bc BaseContext) Sample(req CreateMessageRequest) (CreateMessageResult, error) {
 	if bc.sc == nil || bc.sc.request == nil {

--- a/core/session.go
+++ b/core/session.go
@@ -21,6 +21,7 @@ type sessionCtx struct {
 	logLevel   *atomic.Pointer[LogLevel] // nil pointer in atomic = logging disabled
 	clientCaps *ClientCapabilities       // parsed from initialize; nil before handshake
 	claims     *Claims                   // nil when no auth or validator doesn't provide claims
+	sessionID  string                    // transport-assigned session ID; empty for stateless/stdio
 
 	// sseRetry emits a raw SSE "retry:" hint on the session's stream.
 	// Non-SSE transports (stdio, in-process, Streamable HTTP JSON path) leave
@@ -57,6 +58,25 @@ func ContextWithSession(ctx context.Context, notify NotifyFunc, request RequestF
 		clientCaps: clientCaps,
 		claims:     claims,
 	})
+}
+
+// SetSessionID sets the transport-assigned session ID on the session context.
+// Called by the server dispatch layer after session creation.
+// No-op if no session context is present.
+func SetSessionID(ctx context.Context, id string) {
+	if sc := sessionFromContext(ctx); sc != nil {
+		sc.sessionID = id
+	}
+}
+
+// GetSessionID returns the session ID from a raw context.Context.
+// For use in middleware that doesn't have a typed BaseContext.
+// Returns empty string if no session context is present.
+func GetSessionID(ctx context.Context) string {
+	if sc := sessionFromContext(ctx); sc != nil {
+		return sc.sessionID
+	}
+	return ""
 }
 
 // sessionFromContext retrieves the session context, or nil if absent.

--- a/examples/tasks/README.md
+++ b/examples/tasks/README.md
@@ -343,9 +343,9 @@ mcp http://localhost:$PORT/mcp \
 
 ---
 
-## Phase 3: Session Isolation 🔲
+## Phase 3: Session Isolation ✅
 
-> **Status**: Not yet implemented. These exercises will fail today — any session can access any task.
+> **Status**: Implemented. Tasks are scoped to the session that created them.
 
 ### 10. Cross-session task access denied
 
@@ -404,8 +404,8 @@ mcp http://localhost:$PORT/mcp \
   -d "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tasks/get\",\"params\":{\"taskId\":\"$TASK_ID\"}}"
 ```
 
-**Expected (after Phase 3):** Task not found — session B can't see session A's tasks.
-**Today:** Session B can access session A's tasks.
+**Expected:** Task not found — session B can't see session A's tasks.
+**Behavior:** Empty sessionID (backward compat) allows access to all tasks.
 
 ---
 

--- a/examples/tasks/README.md
+++ b/examples/tasks/README.md
@@ -480,9 +480,9 @@ curl -N http://localhost:$PORT/mcp \
 
 ---
 
-## Phase 7: Progress Token Tracking 🔲
+## Phase 7: Progress Notifications ✅ PARTIAL
 
-> **Status**: Not yet implemented.
+> **Status**: Progress notifications work from async tasks. Original progressToken preservation is pending.
 
 ### 14. Progress notifications flow through tasks
 

--- a/examples/tasks/main.go
+++ b/examples/tasks/main.go
@@ -78,7 +78,18 @@ func main() {
 			}
 
 			log.Printf("[slow_compute] starting %q: sleeping %ds...", args.Label, args.Seconds)
-			time.Sleep(time.Duration(args.Seconds) * time.Second)
+			// Emit progress notifications per second. For async tasks,
+			// DetachForBackground replaces the notifyFunc with the session-level
+			// one so notifications reach the client via GET SSE.
+			// Use the task ID as the progress token if running as a task.
+			var progressToken any
+			if tc := tasks.GetTaskContext(ctx); tc != nil {
+				progressToken = tc.TaskID()
+			}
+			for i := 1; i <= args.Seconds; i++ {
+				time.Sleep(1 * time.Second)
+				ctx.EmitProgress(progressToken, float64(i), float64(args.Seconds), fmt.Sprintf("%s: %d/%d", args.Label, i, args.Seconds))
+			}
 			log.Printf("[slow_compute] finished %q", args.Label)
 
 			return core.TextResult(fmt.Sprintf("Computation %q completed after %d seconds. Result: 42.", args.Label, args.Seconds)), nil

--- a/examples/tasks/run-exercises.sh
+++ b/examples/tasks/run-exercises.sh
@@ -272,10 +272,34 @@ else
 fi
 
 # ============================================================================
-exercise 14 "Progress tokens (Phase 7) 🔲"
+exercise 14 "Progress notifications (Phase 7) 🔲"
 # ============================================================================
-echo -e "${YELLOW}Note: Phase 7 requires tool handlers that emit progress. Not testable via${NC}"
-echo -e "${YELLOW}current example tools. Will be tested after progress-emitting tools are added.${NC}"
+cmd 'Open SSE stream, run 3-second computation, check for notifications/progress'
+expect 'SSE stream receives progress notifications (1/3, 2/3, 3/3)'
+
+# Start SSE listener in background
+curl -s -N "$BASE" -H "$ACCEPT" -H "Mcp-Session-Id: $SESSION_ID" > /tmp/sse-progress.txt 2>&1 &
+PROG_PID=$!
+sleep 0.5
+
+# Create a 3-second computation task
+mcp "$BASE" -H "$SH" -H "$CT" -H "$ACCEPT" \
+  -d '{"jsonrpc":"2.0","id":40,"method":"tools/call","params":{"name":"slow_compute","arguments":{"seconds":3,"label":"progress-test"},"task":{}}}'
+sleep 4
+
+# Kill SSE listener and check
+kill $PROG_PID 2>/dev/null || true
+sleep 0.5
+kill -9 $PROG_PID 2>/dev/null || true
+wait $PROG_PID 2>/dev/null || true
+
+if grep -q 'notifications/progress' /tmp/sse-progress.txt 2>/dev/null; then
+  PROG_COUNT=$(grep -c 'notifications/progress' /tmp/sse-progress.txt)
+  echo -e "${GREEN}✓ Received $PROG_COUNT progress notifications${NC}"
+  grep 'notifications/progress' /tmp/sse-progress.txt | head -3 | sed 's/^data: //' | jq -S . 2>/dev/null
+else
+  echo -e "${YELLOW}✗ No progress notifications received (Phase 7 not implemented in this server)${NC}"
+fi
 
 # ============================================================================
 exercise 15 "Sub-task fan-out/join (Phase 8) 🔲"

--- a/examples/tasks/run-exercises.sh
+++ b/examples/tasks/run-exercises.sh
@@ -259,10 +259,10 @@ mcp "$BASE" -H "$SH" -H "$CT" -H "$ACCEPT" \
 sleep 2
 
 # Kill SSE listener and check for notifications
-kill $SSE_PID 2>/dev/null
+kill $SSE_PID 2>/dev/null || true
 sleep 0.5
-kill -9 $SSE_PID 2>/dev/null
-wait $SSE_PID 2>/dev/null 2>&1
+kill -9 $SSE_PID 2>/dev/null || true
+wait $SSE_PID 2>/dev/null || true
 
 if grep -q 'notifications/tasks/status' /tmp/sse-notifications.txt 2>/dev/null; then
   echo -e "${GREEN}✓ Received notifications/tasks/status on SSE stream${NC}"

--- a/examples/tasks/run-exercises.sh
+++ b/examples/tasks/run-exercises.sh
@@ -260,7 +260,9 @@ sleep 2
 
 # Kill SSE listener and check for notifications
 kill $SSE_PID 2>/dev/null
-wait $SSE_PID 2>/dev/null
+sleep 0.5
+kill -9 $SSE_PID 2>/dev/null
+wait $SSE_PID 2>/dev/null 2>&1
 
 if grep -q 'notifications/tasks/status' /tmp/sse-notifications.txt 2>/dev/null; then
   echo -e "${GREEN}✓ Received notifications/tasks/status on SSE stream${NC}"

--- a/examples/tasks/run-exercises.sh
+++ b/examples/tasks/run-exercises.sh
@@ -116,7 +116,7 @@ mcp "$BASE" -H "$SH" -H "$CT" -H "$ACCEPT" \
 exercise 5 "Elicitation from task (confirm_delete) — partial"
 # ============================================================================
 cmd 'tools/call confirm_delete {filename: "important.txt"} + task hint'
-expect 'CreateTaskResult, then status → input_required (stuck — curl cannot respond)'
+expect 'CreateTaskResult (status: working or input_required depending on timing), then tasks/get → input_required'
 mcp "$BASE" -H "$SH" -H "$CT" -H "$ACCEPT" \
   -d '{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"confirm_delete","arguments":{"filename":"important.txt"},"task":{}}}'
 ELICIT_ID=$(python3 -c "import json; print(json.load(open('/tmp/mcp-body.json')).get('result',{}).get('task',{}).get('taskId',''))" 2>/dev/null)
@@ -129,7 +129,7 @@ mcp "$BASE" -H "$SH" -H "$CT" -H "$ACCEPT" \
 exercise 6 "Sampling from task (write_haiku) — partial"
 # ============================================================================
 cmd 'tools/call write_haiku {topic: "ocean"} + task hint'
-expect 'CreateTaskResult, then status → input_required (stuck — curl cannot respond)'
+expect 'CreateTaskResult (status: working or input_required depending on timing), then tasks/get → input_required'
 mcp "$BASE" -H "$SH" -H "$CT" -H "$ACCEPT" \
   -d '{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"write_haiku","arguments":{"topic":"ocean"},"task":{}}}'
 SAMPLE_ID=$(python3 -c "import json; print(json.load(open('/tmp/mcp-body.json')).get('result',{}).get('task',{}).get('taskId',''))" 2>/dev/null)

--- a/examples/tasks/run-exercises.sh
+++ b/examples/tasks/run-exercises.sh
@@ -187,8 +187,113 @@ mcp "$BASE" -H "$SH" -H "$CT" -H "$ACCEPT" \
   -d "{\"jsonrpc\":\"2.0\",\"id\":17,\"method\":\"tasks/result\",\"params\":{\"taskId\":\"$TASK_ID\"}}"
 
 # ============================================================================
+exercise 10 "Session isolation (Phase 3)"
+# ============================================================================
+cmd 'Initialize a second session, try to access first session task'
+
+# Initialize session B
+RAW_B=$(curl -s -D /tmp/mcp-headers-b.txt "$BASE" -H "$CT" -H "$ACCEPT" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"session-b","version":"1.0"}}}')
+SESSION_B=$(grep -i mcp-session-id /tmp/mcp-headers-b.txt | awk '{print $2}' | tr -d '\r\n')
+curl -s "$BASE" -H "$CT" -H "$ACCEPT" -H "Mcp-Session-Id: $SESSION_B" \
+  -d '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}' > /dev/null 2>&1
+echo "Session B: $SESSION_B"
+
+# Create a task in session A (reuse $SESSION_ID)
+mcp "$BASE" -H "$SH" -H "$CT" -H "$ACCEPT" \
+  -d '{"jsonrpc":"2.0","id":20,"method":"tools/call","params":{"name":"slow_compute","arguments":{"seconds":10,"label":"session-test"},"task":{}}}'
+ISO_TASK_ID=$(jq -r '.result.task.taskId' /tmp/mcp-body.json 2>/dev/null)
+echo "Task created in session A: $ISO_TASK_ID"
+
+cmd "Session B tries tasks/get on session A's task"
+expect 'Error: task not found (cross-session access denied)'
+mcp "$BASE" -H "Mcp-Session-Id: $SESSION_B" -H "$CT" -H "$ACCEPT" \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":21,\"method\":\"tasks/get\",\"params\":{\"taskId\":\"$ISO_TASK_ID\"}}"
+
+cmd "Session A can still access its own task"
+expect 'Task info with status: working'
+mcp "$BASE" -H "$SH" -H "$CT" -H "$ACCEPT" \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":22,\"method\":\"tasks/get\",\"params\":{\"taskId\":\"$ISO_TASK_ID\"}}"
+
+cmd "Session B's tasks/list should NOT include session A's tasks"
+expect 'Empty or only session B tasks'
+mcp "$BASE" -H "Mcp-Session-Id: $SESSION_B" -H "$CT" -H "$ACCEPT" \
+  -d '{"jsonrpc":"2.0","id":23,"method":"tasks/list","params":{}}'
+
+# ============================================================================
+exercise 11 "Store API: double-complete rejected (Phase 4) 🔲"
+# ============================================================================
+cmd 'Create task, wait for completion, try tasks/result twice'
+expect 'Both calls return same result (no error on second call — but store should guard internally)'
+echo -e "${YELLOW}Note: Phase 4 is internal store safety — not directly observable via protocol.${NC}"
+echo -e "${YELLOW}The test suite (TestStoreAtomicResult) covers this.${NC}"
+
+# ============================================================================
+exercise 12 "Cancel propagation (Phase 5) 🔲"
+# ============================================================================
+cmd 'Start 60s computation, cancel, check if goroutine actually stops'
+mcp "$BASE" -H "$SH" -H "$CT" -H "$ACCEPT" \
+  -d '{"jsonrpc":"2.0","id":30,"method":"tools/call","params":{"name":"slow_compute","arguments":{"seconds":60,"label":"cancel-propagation"},"task":{}}}'
+PROP_ID=$(jq -r '.result.task.taskId' /tmp/mcp-body.json 2>/dev/null)
+mcp "$BASE" -H "$SH" -H "$CT" -H "$ACCEPT" \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":31,\"method\":\"tasks/cancel\",\"params\":{\"taskId\":\"$PROP_ID\"}}"
+expect 'Status: cancelled (immediate). Server log should NOT show "finished cancel-propagation" after 60s.'
+echo -e "${YELLOW}Today: status shows cancelled, but goroutine keeps sleeping for 60s.${NC}"
+echo -e "${YELLOW}After Phase 5: goroutine receives context cancellation and exits immediately.${NC}"
+
+# ============================================================================
+exercise 13 "Status notifications (Phase 6) 🔲"
+# ============================================================================
+cmd 'Open GET SSE stream, create task, watch for notifications/tasks/status'
+expect 'SSE stream receives working → completed notifications'
+echo -e "${YELLOW}Testing SSE notifications requires a background listener...${NC}"
+
+# Start SSE listener in background
+curl -s -N "$BASE" -H "$ACCEPT" -H "Mcp-Session-Id: $SESSION_ID" > /tmp/sse-notifications.txt 2>&1 &
+SSE_PID=$!
+sleep 0.5
+
+# Create a fast task to trigger notifications
+mcp "$BASE" -H "$SH" -H "$CT" -H "$ACCEPT" \
+  -d '{"jsonrpc":"2.0","id":32,"method":"tools/call","params":{"name":"slow_compute","arguments":{"seconds":1,"label":"notify-test"},"task":{}}}'
+sleep 2
+
+# Kill SSE listener and check for notifications
+kill $SSE_PID 2>/dev/null
+wait $SSE_PID 2>/dev/null
+
+if grep -q 'notifications/tasks/status' /tmp/sse-notifications.txt 2>/dev/null; then
+  echo -e "${GREEN}✓ Received notifications/tasks/status on SSE stream${NC}"
+  grep 'notifications/tasks/status' /tmp/sse-notifications.txt | head -2 | sed 's/^data: //' | jq -S . 2>/dev/null
+else
+  echo -e "${YELLOW}✗ No notifications/tasks/status received (Phase 6 not implemented)${NC}"
+fi
+
+# ============================================================================
+exercise 14 "Progress tokens (Phase 7) 🔲"
+# ============================================================================
+echo -e "${YELLOW}Note: Phase 7 requires tool handlers that emit progress. Not testable via${NC}"
+echo -e "${YELLOW}current example tools. Will be tested after progress-emitting tools are added.${NC}"
+
+# ============================================================================
+exercise 15 "Sub-task fan-out/join (Phase 8) 🔲"
+# ============================================================================
+echo -e "${YELLOW}Note: Phase 8 requires TaskContext.SpawnTool which is not yet implemented.${NC}"
+echo -e "${YELLOW}Will be tested with a deploy tool (build + test in parallel).${NC}"
+echo -e "${YELLOW}Tracked in panyam/mcpkit#281.${NC}"
+
+# ============================================================================
+exercise 16 "Cascade cancel (Phase 8) 🔲"
+# ============================================================================
+echo -e "${YELLOW}Note: Phase 8. Cancel parent → all children cancelled.${NC}"
+echo -e "${YELLOW}Requires sub-task support (#281).${NC}"
+
+# ============================================================================
 echo ""
 echo -e "${GREEN}═══════════════════════════════════════${NC}"
 echo -e "${GREEN}  All exercises complete!${NC}"
 echo -e "${GREEN}═══════════════════════════════════════${NC}"
+echo ""
+echo "Exercises 1-10: Phase 1-3 (implemented)"
+echo "Exercises 11-16: Phase 4-8 (future — see status markers)"
 echo ""

--- a/examples/tasks/ts-reference-server.mjs
+++ b/examples/tasks/ts-reference-server.mjs
@@ -76,6 +76,35 @@ const TOOLS = [
 ];
 
 // ============================================================================
+// Status notification helper — sends notifications/tasks/status after
+// every status change (Phase 6 parity with RequestTaskStore pattern)
+// ============================================================================
+
+async function updateStatus(server, taskId, status, statusMessage, sessionId) {
+    await taskStore.updateTaskStatus(taskId, status, statusMessage, sessionId);
+    const task = await taskStore.getTask(taskId, sessionId);
+    if (task) {
+        try {
+            await server.notification({ method: 'notifications/tasks/status', params: task });
+        } catch (e) {
+            // Notification delivery is best-effort — don't fail the operation
+        }
+    }
+}
+
+async function storeResult(server, taskId, status, result, sessionId) {
+    await taskStore.storeTaskResult(taskId, status, result, sessionId);
+    const task = await taskStore.getTask(taskId, sessionId);
+    if (task) {
+        try {
+            await server.notification({ method: 'notifications/tasks/status', params: task });
+        } catch (e) {
+            // Best-effort
+        }
+    }
+}
+
+// ============================================================================
 // Tool handlers
 // ============================================================================
 
@@ -106,11 +135,20 @@ async function handleToolCall(server, request, ctx) {
         console.log(`[slow_compute] async: task ${task.taskId}, sleeping ${seconds}s...`);
 
         (async () => {
-            await new Promise(r => setTimeout(r, seconds * 1000));
+            // Emit progress notifications during computation (Phase 7)
+            for (let i = 1; i <= seconds; i++) {
+                await new Promise(r => setTimeout(r, 1000));
+                try {
+                    await server.notification({
+                        method: 'notifications/progress',
+                        params: { progressToken: task.taskId, progress: i, total: seconds }
+                    });
+                } catch (e) { /* best-effort */ }
+            }
             console.log(`[slow_compute] finished "${label}"`);
-            await taskStore.storeTaskResult(task.taskId, 'completed', {
+            await storeResult(server, task.taskId, 'completed', {
                 content: [{ type: 'text', text: `Computation "${label}" completed after ${seconds} seconds. Result: 42.` }]
-            });
+            }, ctx.sessionId);
         })();
 
         return { task };
@@ -124,9 +162,9 @@ async function handleToolCall(server, request, ctx) {
         );
         (async () => {
             await new Promise(r => setTimeout(r, 1000));
-            await taskStore.storeTaskResult(task.taskId, 'failed', {
+            await storeResult(server, task.taskId, 'failed', {
                 content: [{ type: 'text', text: 'simulated failure: job crashed' }], isError: true
-            });
+            }, ctx.sessionId);
         })();
         return { task };
     }
@@ -142,20 +180,20 @@ async function handleToolCall(server, request, ctx) {
 
         (async () => {
             try {
-                await taskStore.updateTaskStatus(task.taskId, 'input_required');
+                await updateStatus(server, task.taskId, 'input_required', undefined, ctx.sessionId);
                 const result = await server.elicitInput({
                     message: `Are you sure you want to delete '${filename}'?`,
                     requestedSchema: { type: 'object', properties: { confirm: { type: 'boolean' } }, required: ['confirm'] },
                     mode: 'form'
                 });
-                await taskStore.updateTaskStatus(task.taskId, 'working');
+                await updateStatus(server, task.taskId, 'working', undefined, ctx.sessionId);
                 const text = (result.action === 'accept' && result.content?.confirm)
                     ? `Deleted '${filename}'` : 'Deletion cancelled';
-                await taskStore.storeTaskResult(task.taskId, 'completed', { content: [{ type: 'text', text }] });
+                await storeResult(server, task.taskId, 'completed', { content: [{ type: 'text', text }] }, ctx.sessionId);
             } catch (e) {
-                await taskStore.storeTaskResult(task.taskId, 'failed', {
+                await storeResult(server, task.taskId, 'failed', {
                     content: [{ type: 'text', text: `Error: ${e}` }], isError: true
-                });
+                }, ctx.sessionId);
             }
         })();
 
@@ -173,20 +211,20 @@ async function handleToolCall(server, request, ctx) {
 
         (async () => {
             try {
-                await taskStore.updateTaskStatus(task.taskId, 'input_required');
+                await updateStatus(server, task.taskId, 'input_required', undefined, ctx.sessionId);
                 const result = await server.createMessage({
                     messages: [{ role: 'user', content: { type: 'text', text: `Write a haiku about ${topic}` } }],
                     maxTokens: 50
                 });
-                await taskStore.updateTaskStatus(task.taskId, 'working');
+                await updateStatus(server, task.taskId, 'working', undefined, ctx.sessionId);
                 const haiku = result.content?.text || 'No response';
-                await taskStore.storeTaskResult(task.taskId, 'completed', {
+                await storeResult(server, task.taskId, 'completed', {
                     content: [{ type: 'text', text: `Haiku about ${topic}:\n${haiku}` }]
-                });
+                }, ctx.sessionId);
             } catch (e) {
-                await taskStore.storeTaskResult(task.taskId, 'failed', {
+                await storeResult(server, task.taskId, 'failed', {
                     content: [{ type: 'text', text: `Error: ${e}` }], isError: true
-                });
+                }, ctx.sessionId);
             }
         })();
 
@@ -223,7 +261,7 @@ function createMCPServer() {
         const task = await taskStore.getTask(req.params.taskId, ctx.sessionId);
         if (!task) throw new Error(`Task ${req.params.taskId} not found`);
         if (isTerminal(task.status)) throw new Error(`Cannot cancel terminal task: ${task.status}`);
-        await taskStore.updateTaskStatus(req.params.taskId, 'cancelled', 'task was cancelled', ctx.sessionId);
+        await updateStatus(server, req.params.taskId, 'cancelled', 'task was cancelled', ctx.sessionId);
         return await taskStore.getTask(req.params.taskId, ctx.sessionId);
     });
 

--- a/examples/tasks/ts-reference-server.mjs
+++ b/examples/tasks/ts-reference-server.mjs
@@ -209,31 +209,31 @@ function createMCPServer() {
     server.setRequestHandler('tools/list', async () => ({ tools: TOOLS }));
     server.setRequestHandler('tools/call', (req, ctx) => handleToolCall(server, req, ctx));
 
-    server.setRequestHandler('tasks/get', async (req) => {
-        const task = await taskStore.getTask(req.params.taskId);
+    server.setRequestHandler('tasks/get', async (req, ctx) => {
+        const task = await taskStore.getTask(req.params.taskId, ctx.sessionId);
         if (!task) throw new Error(`Task ${req.params.taskId} not found`);
         return task;
     });
 
-    server.setRequestHandler('tasks/list', async (req) => {
-        return await taskStore.listTasks(req.params?.cursor);
+    server.setRequestHandler('tasks/list', async (req, ctx) => {
+        return await taskStore.listTasks(req.params?.cursor, ctx.sessionId);
     });
 
-    server.setRequestHandler('tasks/cancel', async (req) => {
-        const task = await taskStore.getTask(req.params.taskId);
+    server.setRequestHandler('tasks/cancel', async (req, ctx) => {
+        const task = await taskStore.getTask(req.params.taskId, ctx.sessionId);
         if (!task) throw new Error(`Task ${req.params.taskId} not found`);
         if (isTerminal(task.status)) throw new Error(`Cannot cancel terminal task: ${task.status}`);
-        await taskStore.updateTaskStatus(req.params.taskId, 'cancelled', 'task was cancelled');
-        return await taskStore.getTask(req.params.taskId);
+        await taskStore.updateTaskStatus(req.params.taskId, 'cancelled', 'task was cancelled', ctx.sessionId);
+        return await taskStore.getTask(req.params.taskId, ctx.sessionId);
     });
 
-    server.setRequestHandler('tasks/result', async (req) => {
+    server.setRequestHandler('tasks/result', async (req, ctx) => {
         const { taskId } = req.params;
         while (true) {
-            const task = await taskStore.getTask(taskId);
+            const task = await taskStore.getTask(taskId, ctx.sessionId);
             if (!task) throw new Error(`Task ${taskId} not found`);
             if (isTerminal(task.status)) {
-                const result = await taskStore.getTaskResult(taskId);
+                const result = await taskStore.getTaskResult(taskId, ctx.sessionId);
                 return { ...result, _meta: { ...result._meta, [RELATED_TASK_META_KEY]: { taskId } } };
             }
             await new Promise(r => setTimeout(r, 1000));

--- a/experimental/ext/tasks/TASKS_GAP_PLAN.md
+++ b/experimental/ext/tasks/TASKS_GAP_PLAN.md
@@ -45,20 +45,12 @@ Key TS files:
 - [x] **2b.** `Cleanup()` method — stops all timers, clears all tasks
 - [x] **2c.** Tests: 6 unit (expiry, reset on result, reset on cancel, null no-expiry, cleanup, cleanup stops timers) + 1 e2e (exercise 9)
 
-## Phase 3: Session Isolation
+## Phase 3: Session Isolation ✅ COMPLETE
 **Goal**: Tasks are scoped to the session that created them.
 
-- [ ] **3a. Add `sessionID` parameter to TaskStore interface methods**
-  - `Create(info, sessionID)` — store sessionID with task
-  - `Get(taskID, sessionID)` — return not-found if session mismatch
-  - `Update(taskID, fn, sessionID)`
-  - `Cancel(taskID, sessionID)`
-  - `List(cursor, limit, sessionID)` — filter by session
-  - Ref: `stores/inMemory.ts:82-93`
-
-- [ ] **3b. Pass session ID from middleware/handler context**
-
-- [ ] **3c. Tests** — cross-session access denied, same-session access allowed
+- [x] **3a.** `sessionID` on all TaskStore methods + `sessionAllowed()` check on taskEntry
+- [x] **3b.** `core.SetSessionID` / `core.GetSessionID` / `BaseContext.SessionID()` — server dispatch sets it
+- [x] **3c.** 5 unit tests (Get, Update, Cancel, List isolation + empty backward compat)
 
 ## Phase 4: Store API Alignment
 **Goal**: Match TS SDK's atomic operations and guards.

--- a/experimental/ext/tasks/TASKS_GAP_PLAN.md
+++ b/experimental/ext/tasks/TASKS_GAP_PLAN.md
@@ -90,11 +90,13 @@ Key TS files:
 
 - [ ] **6c. Tests** — client receives notification after status change
 
-## Phase 7: Progress Token Tracking (P2)
+## Phase 7: Progress Notifications ✅ PARTIAL
 **Goal**: Progress notifications flow through task lifecycle.
 
-- [ ] **7a. Preserve progress token when CreateTaskResult is returned**
-- [ ] **7b. Clean up progress handler on terminal state**
+- [x] **7a.** `DetachForBackground` replaces notifyFunc with session-level one — progress from background goroutines reaches client via GET SSE
+- [x] **7b.** Go `slow_compute` emits per-second progress (matching TS reference server)
+- [ ] **7c.** Preserve original `_meta.progressToken` from `tools/call` through to task goroutine (currently uses taskId as token)
+- [ ] **7d.** Clean up progress handler on terminal state
 
 ## Phase 8: Sub-Task Threading (#281)
 **Goal**: Tasks can spawn sub-tasks with ParentTaskID linkage.

--- a/experimental/ext/tasks/session.go
+++ b/experimental/ext/tasks/session.go
@@ -42,9 +42,10 @@ type sideChannelResponse struct {
 //	}
 type TaskContext struct {
 	core.ToolContext
-	taskID   string
-	store    TaskStore
-	requests chan sideChannelRequest // read by tasks/result handler
+	taskID    string
+	sessionID string
+	store     TaskStore
+	requests  chan sideChannelRequest // read by tasks/result handler
 }
 
 type taskContextKey struct{}
@@ -77,7 +78,7 @@ func (tc *TaskContext) TaskID() string {
 // Status transitions: working → input_required → (wait for client) → working
 func (tc *TaskContext) TaskElicit(req core.ElicitationRequest) (core.ElicitationResult, error) {
 	// Transition to input_required.
-	if err := tc.store.Update(tc.taskID, func(t *core.TaskInfo) {
+	if err := tc.store.Update(tc.taskID, tc.sessionID, func(t *core.TaskInfo) {
 		t.Status = core.TaskInputRequired
 	}); err != nil {
 		return core.ElicitationResult{}, fmt.Errorf("task %s: failed to set input_required: %w", tc.taskID, err)
@@ -92,7 +93,7 @@ func (tc *TaskContext) TaskElicit(req core.ElicitationRequest) (core.Elicitation
 	// Serialize params.
 	params, err := core.MarshalJSON(req)
 	if err != nil {
-		tc.store.Update(tc.taskID, func(t *core.TaskInfo) { t.Status = core.TaskWorking })
+		tc.store.Update(tc.taskID, tc.sessionID, func(t *core.TaskInfo) { t.Status = core.TaskWorking })
 		return core.ElicitationResult{}, fmt.Errorf("marshal elicitation request: %w", err)
 	}
 
@@ -100,7 +101,7 @@ func (tc *TaskContext) TaskElicit(req core.ElicitationRequest) (core.Elicitation
 	resp, err := tc.sendSideChannel("elicitation/create", params)
 
 	// Transition back to working.
-	tc.store.Update(tc.taskID, func(t *core.TaskInfo) {
+	tc.store.Update(tc.taskID, tc.sessionID, func(t *core.TaskInfo) {
 		t.Status = core.TaskWorking
 	})
 
@@ -121,7 +122,7 @@ func (tc *TaskContext) TaskElicit(req core.ElicitationRequest) (core.Elicitation
 // Status transitions: working → input_required → (wait for client) → working
 func (tc *TaskContext) TaskSample(req core.CreateMessageRequest) (core.CreateMessageResult, error) {
 	// Transition to input_required.
-	if err := tc.store.Update(tc.taskID, func(t *core.TaskInfo) {
+	if err := tc.store.Update(tc.taskID, tc.sessionID, func(t *core.TaskInfo) {
 		t.Status = core.TaskInputRequired
 	}); err != nil {
 		return core.CreateMessageResult{}, fmt.Errorf("task %s: failed to set input_required: %w", tc.taskID, err)
@@ -136,7 +137,7 @@ func (tc *TaskContext) TaskSample(req core.CreateMessageRequest) (core.CreateMes
 	// Serialize params.
 	params, err := core.MarshalJSON(req)
 	if err != nil {
-		tc.store.Update(tc.taskID, func(t *core.TaskInfo) { t.Status = core.TaskWorking })
+		tc.store.Update(tc.taskID, tc.sessionID, func(t *core.TaskInfo) { t.Status = core.TaskWorking })
 		return core.CreateMessageResult{}, fmt.Errorf("marshal sampling request: %w", err)
 	}
 
@@ -144,7 +145,7 @@ func (tc *TaskContext) TaskSample(req core.CreateMessageRequest) (core.CreateMes
 	resp, err := tc.sendSideChannel("sampling/createMessage", params)
 
 	// Transition back to working.
-	tc.store.Update(tc.taskID, func(t *core.TaskInfo) {
+	tc.store.Update(tc.taskID, tc.sessionID, func(t *core.TaskInfo) {
 		t.Status = core.TaskWorking
 	})
 

--- a/experimental/ext/tasks/store.go
+++ b/experimental/ext/tasks/store.go
@@ -22,51 +22,61 @@ import (
 
 // TaskStore is the interface for task state persistence. Implementations
 // must be safe for concurrent use.
+//
+// All methods accept a sessionID parameter for session isolation.
+// Empty sessionID means no session binding (backward compatible).
+// When both the task and the caller have a sessionID, they must match.
 type TaskStore interface {
-	// Create persists a new task. Returns an error if the taskId already exists.
-	Create(info core.TaskInfo) error
+	// Create persists a new task bound to the given session.
+	Create(info core.TaskInfo, sessionID string) error
 
-	// Get returns a task by ID, or false if not found.
-	Get(taskID string) (core.TaskInfo, bool)
+	// Get returns a task by ID, or false if not found or session mismatch.
+	Get(taskID, sessionID string) (core.TaskInfo, bool)
 
 	// Update atomically modifies a task via the provided function.
-	// Returns an error if the task doesn't exist.
-	Update(taskID string, fn func(*core.TaskInfo)) error
+	// Returns an error if the task doesn't exist or session mismatch.
+	Update(taskID, sessionID string, fn func(*core.TaskInfo)) error
 
 	// SetResult stores the tool result for a completed task.
-	SetResult(taskID string, result core.ToolResult) error
+	SetResult(taskID, sessionID string, result core.ToolResult) error
 
 	// GetResult returns the stored tool result, or false if not yet available.
-	GetResult(taskID string) (core.ToolResult, bool)
+	GetResult(taskID, sessionID string) (core.ToolResult, bool)
 
 	// WaitForResult blocks until the task reaches a terminal state, then
-	// returns the result. Returns an error if the task doesn't exist.
-	// Respects context cancellation.
-	WaitForResult(ctx context.Context, taskID string) (core.ToolResult, core.TaskInfo, error)
+	// returns the result. Respects context cancellation.
+	WaitForResult(ctx context.Context, taskID, sessionID string) (core.ToolResult, core.TaskInfo, error)
 
-	// List returns tasks with cursor-based pagination. An empty cursor
-	// starts from the beginning.
-	List(cursor string, limit int) ([]core.TaskInfo, string)
+	// List returns tasks for the given session with cursor-based pagination.
+	List(cursor string, limit int, sessionID string) ([]core.TaskInfo, string)
 
-	// WaitForUpdate blocks until the task's state changes (status or result),
-	// or the context is cancelled. Used by the tasks/result long-poll loop.
-	WaitForUpdate(ctx context.Context, taskID string) error
+	// WaitForUpdate blocks until the task's state changes, or the context
+	// is cancelled. Used by the tasks/result long-poll loop.
+	WaitForUpdate(ctx context.Context, taskID, sessionID string) error
 
-	// Cancel transitions a non-terminal task to cancelled. Returns an error
-	// if the task is already terminal or doesn't exist.
-	Cancel(taskID string) (core.TaskInfo, error)
+	// Cancel transitions a non-terminal task to cancelled.
+	Cancel(taskID, sessionID string) (core.TaskInfo, error)
 
 	// Cleanup removes all tasks and stops any background timers.
-	// Used for graceful shutdown and testing.
 	Cleanup()
 }
 
 // taskEntry holds all state for a single task in the in-memory store.
 type taskEntry struct {
-	info    core.TaskInfo
-	result  json.RawMessage // stored tool result (nil until terminal)
-	waiters []chan struct{}  // channels to notify on status/result changes
-	timer   *time.Timer     // TTL cleanup timer; nil if TTL is null/unlimited
+	info      core.TaskInfo
+	result    json.RawMessage // stored tool result (nil until terminal)
+	waiters   []chan struct{}  // channels to notify on status/result changes
+	timer     *time.Timer     // TTL cleanup timer; nil if TTL is null/unlimited
+	sessionID string          // session that created this task; empty = no binding
+}
+
+// sessionAllowed checks if the caller's session can access this task.
+// Access is allowed if either side has no sessionID (backward compat).
+func (e *taskEntry) sessionAllowed(callerSession string) bool {
+	if callerSession == "" || e.sessionID == "" {
+		return true
+	}
+	return callerSession == e.sessionID
 }
 
 // notify wakes all waiters for this task entry.
@@ -95,13 +105,13 @@ func NewInMemoryStore() *InMemoryTaskStore {
 	}
 }
 
-func (s *InMemoryTaskStore) Create(info core.TaskInfo) error {
+func (s *InMemoryTaskStore) Create(info core.TaskInfo, sessionID string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if _, exists := s.tasks[info.TaskID]; exists {
 		return fmt.Errorf("task %q already exists", info.TaskID)
 	}
-	entry := &taskEntry{info: info}
+	entry := &taskEntry{info: info, sessionID: sessionID}
 	// Schedule TTL cleanup if TTL is set and positive.
 	if info.TTL != nil && *info.TTL > 0 {
 		taskID := info.TaskID
@@ -114,20 +124,30 @@ func (s *InMemoryTaskStore) Create(info core.TaskInfo) error {
 	return nil
 }
 
-func (s *InMemoryTaskStore) Get(taskID string) (core.TaskInfo, bool) {
+// getEntry returns the task entry if it exists and the caller's session
+// is allowed. Must be called with at least s.mu.RLock held.
+func (s *InMemoryTaskStore) getEntry(taskID, sessionID string) (*taskEntry, bool) {
+	entry, ok := s.tasks[taskID]
+	if !ok || !entry.sessionAllowed(sessionID) {
+		return nil, false
+	}
+	return entry, true
+}
+
+func (s *InMemoryTaskStore) Get(taskID, sessionID string) (core.TaskInfo, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	entry, ok := s.tasks[taskID]
+	entry, ok := s.getEntry(taskID, sessionID)
 	if !ok {
 		return core.TaskInfo{}, false
 	}
 	return entry.info, true
 }
 
-func (s *InMemoryTaskStore) Update(taskID string, fn func(*core.TaskInfo)) error {
+func (s *InMemoryTaskStore) Update(taskID, sessionID string, fn func(*core.TaskInfo)) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	entry, ok := s.tasks[taskID]
+	entry, ok := s.getEntry(taskID, sessionID)
 	if !ok {
 		return fmt.Errorf("task %q not found", taskID)
 	}
@@ -136,28 +156,27 @@ func (s *InMemoryTaskStore) Update(taskID string, fn func(*core.TaskInfo)) error
 	return nil
 }
 
-func (s *InMemoryTaskStore) SetResult(taskID string, result core.ToolResult) error {
+func (s *InMemoryTaskStore) SetResult(taskID, sessionID string, result core.ToolResult) error {
 	raw, err := json.Marshal(result)
 	if err != nil {
 		return fmt.Errorf("marshal result: %w", err)
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	entry, ok := s.tasks[taskID]
+	entry, ok := s.getEntry(taskID, sessionID)
 	if !ok {
 		return fmt.Errorf("task %q not found", taskID)
 	}
 	entry.result = raw
-	// Reset TTL timer — task gets a fresh TTL window from now.
 	s.resetTimer(entry)
 	entry.notify()
 	return nil
 }
 
-func (s *InMemoryTaskStore) GetResult(taskID string) (core.ToolResult, bool) {
+func (s *InMemoryTaskStore) GetResult(taskID, sessionID string) (core.ToolResult, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	entry, ok := s.tasks[taskID]
+	entry, ok := s.getEntry(taskID, sessionID)
 	if !ok || entry.result == nil {
 		return core.ToolResult{}, false
 	}
@@ -166,14 +185,10 @@ func (s *InMemoryTaskStore) GetResult(taskID string) (core.ToolResult, bool) {
 	return result, true
 }
 
-// WaitForResult blocks until the task reaches a terminal state and a result
-// is available, or the context is cancelled. Returns context.Canceled if
-// the context is done before the task completes.
-func (s *InMemoryTaskStore) WaitForResult(ctx context.Context, taskID string) (core.ToolResult, core.TaskInfo, error) {
+func (s *InMemoryTaskStore) WaitForResult(ctx context.Context, taskID, sessionID string) (core.ToolResult, core.TaskInfo, error) {
 	for {
-		// Check current state under lock.
 		s.mu.Lock()
-		entry, ok := s.tasks[taskID]
+		entry, ok := s.getEntry(taskID, sessionID)
 		if !ok {
 			s.mu.Unlock()
 			return core.ToolResult{}, core.TaskInfo{}, fmt.Errorf("task %q not found", taskID)
@@ -188,15 +203,12 @@ func (s *InMemoryTaskStore) WaitForResult(ctx context.Context, taskID string) (c
 			return result, info, nil
 		}
 
-		// Not terminal — register a waiter channel and wait.
 		ch := make(chan struct{}, 1)
 		entry.waiters = append(entry.waiters, ch)
 		s.mu.Unlock()
 
-		// Wait for either an update or context cancellation.
 		select {
 		case <-ch:
-			// Task was updated — loop back to check state.
 			continue
 		case <-ctx.Done():
 			return core.ToolResult{}, core.TaskInfo{}, ctx.Err()
@@ -204,7 +216,7 @@ func (s *InMemoryTaskStore) WaitForResult(ctx context.Context, taskID string) (c
 	}
 }
 
-func (s *InMemoryTaskStore) List(cursor string, limit int) ([]core.TaskInfo, string) {
+func (s *InMemoryTaskStore) List(cursor string, limit int, sessionID string) ([]core.TaskInfo, string) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -212,7 +224,6 @@ func (s *InMemoryTaskStore) List(cursor string, limit int) ([]core.TaskInfo, str
 		limit = 50
 	}
 
-	// Find starting index from cursor (cursor is a task ID).
 	start := 0
 	if cursor != "" {
 		for i, id := range s.order {
@@ -227,7 +238,9 @@ func (s *InMemoryTaskStore) List(cursor string, limit int) ([]core.TaskInfo, str
 	var nextCursor string
 	for i := start; i < len(s.order) && len(tasks) < limit; i++ {
 		if entry, ok := s.tasks[s.order[i]]; ok {
-			tasks = append(tasks, entry.info)
+			if entry.sessionAllowed(sessionID) {
+				tasks = append(tasks, entry.info)
+			}
 		}
 	}
 	if start+limit < len(s.order) && len(tasks) == limit {
@@ -237,12 +250,9 @@ func (s *InMemoryTaskStore) List(cursor string, limit int) ([]core.TaskInfo, str
 	return tasks, nextCursor
 }
 
-// WaitForUpdate blocks until the task's state changes or the context is cancelled.
-// Returns nil on update, context error on cancellation, or an error if the task
-// doesn't exist.
-func (s *InMemoryTaskStore) WaitForUpdate(ctx context.Context, taskID string) error {
+func (s *InMemoryTaskStore) WaitForUpdate(ctx context.Context, taskID, sessionID string) error {
 	s.mu.Lock()
-	entry, ok := s.tasks[taskID]
+	entry, ok := s.getEntry(taskID, sessionID)
 	if !ok {
 		s.mu.Unlock()
 		return fmt.Errorf("task %q not found", taskID)
@@ -262,10 +272,10 @@ func (s *InMemoryTaskStore) WaitForUpdate(ctx context.Context, taskID string) er
 
 var errTaskTerminal = errors.New("task is already in a terminal state")
 
-func (s *InMemoryTaskStore) Cancel(taskID string) (core.TaskInfo, error) {
+func (s *InMemoryTaskStore) Cancel(taskID, sessionID string) (core.TaskInfo, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	entry, ok := s.tasks[taskID]
+	entry, ok := s.getEntry(taskID, sessionID)
 	if !ok {
 		return core.TaskInfo{}, fmt.Errorf("task %q not found", taskID)
 	}
@@ -274,7 +284,6 @@ func (s *InMemoryTaskStore) Cancel(taskID string) (core.TaskInfo, error) {
 	}
 	entry.info.Status = core.TaskCancelled
 	entry.info.StatusMessage = "task was cancelled"
-	// Store a cancellation result so tasks/result can return it.
 	if entry.result == nil {
 		cancelResult := core.ToolResult{
 			Content: []core.Content{{Type: "text", Text: "task was cancelled"}},
@@ -283,7 +292,6 @@ func (s *InMemoryTaskStore) Cancel(taskID string) (core.TaskInfo, error) {
 		raw, _ := json.Marshal(cancelResult)
 		entry.result = raw
 	}
-	// Reset TTL timer — cancelled task gets a fresh TTL window for cleanup.
 	s.resetTimer(entry)
 	entry.notify()
 	return entry.info, nil

--- a/experimental/ext/tasks/store_test.go
+++ b/experimental/ext/tasks/store_test.go
@@ -25,11 +25,11 @@ func TestStoreCreateAndGet(t *testing.T) {
 	s := NewInMemoryStore()
 
 	info := newTestInfo("t1", core.TaskWorking)
-	if err := s.Create(info); err != nil {
+	if err := s.Create(info, ""); err != nil {
 		t.Fatal(err)
 	}
 
-	got, ok := s.Get("t1")
+	got, ok := s.Get("t1", "")
 	if !ok {
 		t.Fatal("expected to find task t1")
 	}
@@ -41,17 +41,17 @@ func TestStoreCreateAndGet(t *testing.T) {
 func TestStoreCreateDuplicate(t *testing.T) {
 	s := NewInMemoryStore()
 	info := newTestInfo("t1", core.TaskWorking)
-	if err := s.Create(info); err != nil {
+	if err := s.Create(info, ""); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.Create(info); err == nil {
+	if err := s.Create(info, ""); err == nil {
 		t.Error("expected error on duplicate create")
 	}
 }
 
 func TestStoreGetNotFound(t *testing.T) {
 	s := NewInMemoryStore()
-	_, ok := s.Get("nonexistent")
+	_, ok := s.Get("nonexistent", "")
 	if ok {
 		t.Error("expected not found")
 	}
@@ -59,9 +59,9 @@ func TestStoreGetNotFound(t *testing.T) {
 
 func TestStoreUpdate(t *testing.T) {
 	s := NewInMemoryStore()
-	s.Create(newTestInfo("t1", core.TaskWorking))
+	s.Create(newTestInfo("t1", core.TaskWorking), "")
 
-	err := s.Update("t1", func(info *core.TaskInfo) {
+	err := s.Update("t1", "", func(info *core.TaskInfo) {
 		info.Status = core.TaskCompleted
 		info.StatusMessage = "done"
 	})
@@ -69,7 +69,7 @@ func TestStoreUpdate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, _ := s.Get("t1")
+	got, _ := s.Get("t1", "")
 	if got.Status != core.TaskCompleted {
 		t.Errorf("status = %q, want completed", got.Status)
 	}
@@ -80,7 +80,7 @@ func TestStoreUpdate(t *testing.T) {
 
 func TestStoreUpdateNotFound(t *testing.T) {
 	s := NewInMemoryStore()
-	err := s.Update("nonexistent", func(*core.TaskInfo) {})
+	err := s.Update("nonexistent", "", func(*core.TaskInfo) {})
 	if err == nil {
 		t.Error("expected error on update of nonexistent task")
 	}
@@ -88,14 +88,14 @@ func TestStoreUpdateNotFound(t *testing.T) {
 
 func TestStoreSetAndGetResult(t *testing.T) {
 	s := NewInMemoryStore()
-	s.Create(newTestInfo("t1", core.TaskWorking))
+	s.Create(newTestInfo("t1", core.TaskWorking), "")
 
 	result := core.TextResult("hello world")
-	if err := s.SetResult("t1", result); err != nil {
+	if err := s.SetResult("t1", "", result); err != nil {
 		t.Fatal(err)
 	}
 
-	got, ok := s.GetResult("t1")
+	got, ok := s.GetResult("t1", "")
 	if !ok {
 		t.Fatal("expected result to be present")
 	}
@@ -109,9 +109,9 @@ func TestStoreSetAndGetResult(t *testing.T) {
 
 func TestStoreGetResultNotReady(t *testing.T) {
 	s := NewInMemoryStore()
-	s.Create(newTestInfo("t1", core.TaskWorking))
+	s.Create(newTestInfo("t1", core.TaskWorking), "")
 
-	_, ok := s.GetResult("t1")
+	_, ok := s.GetResult("t1", "")
 	if ok {
 		t.Error("expected no result yet")
 	}
@@ -119,7 +119,7 @@ func TestStoreGetResultNotReady(t *testing.T) {
 
 func TestStoreWaitForResult(t *testing.T) {
 	s := NewInMemoryStore()
-	s.Create(newTestInfo("t1", core.TaskWorking))
+	s.Create(newTestInfo("t1", core.TaskWorking), "")
 
 	done := make(chan struct{})
 	var gotResult core.ToolResult
@@ -127,7 +127,7 @@ func TestStoreWaitForResult(t *testing.T) {
 	var gotErr error
 
 	go func() {
-		gotResult, gotInfo, gotErr = s.WaitForResult(context.Background(), "t1")
+		gotResult, gotInfo, gotErr = s.WaitForResult(context.Background(), "t1", "")
 		close(done)
 	}()
 
@@ -136,8 +136,8 @@ func TestStoreWaitForResult(t *testing.T) {
 
 	// Store result first, then transition to terminal (Update broadcasts
 	// to waiters, so the result must be available before wake-up).
-	s.SetResult("t1", core.TextResult("waited"))
-	s.Update("t1", func(info *core.TaskInfo) {
+	s.SetResult("t1", "", core.TextResult("waited"))
+	s.Update("t1", "", func(info *core.TaskInfo) {
 		info.Status = core.TaskCompleted
 	})
 
@@ -160,7 +160,7 @@ func TestStoreWaitForResult(t *testing.T) {
 
 func TestStoreWaitForResultNotFound(t *testing.T) {
 	s := NewInMemoryStore()
-	_, _, err := s.WaitForResult(context.Background(), "nonexistent")
+	_, _, err := s.WaitForResult(context.Background(), "nonexistent", "")
 	if err == nil {
 		t.Error("expected error for nonexistent task")
 	}
@@ -168,9 +168,9 @@ func TestStoreWaitForResultNotFound(t *testing.T) {
 
 func TestStoreCancel(t *testing.T) {
 	s := NewInMemoryStore()
-	s.Create(newTestInfo("t1", core.TaskWorking))
+	s.Create(newTestInfo("t1", core.TaskWorking), "")
 
-	info, err := s.Cancel("t1")
+	info, err := s.Cancel("t1", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -179,7 +179,7 @@ func TestStoreCancel(t *testing.T) {
 	}
 
 	// Re-cancel should fail (already terminal).
-	_, err = s.Cancel("t1")
+	_, err = s.Cancel("t1", "")
 	if err == nil {
 		t.Error("expected error when cancelling already-terminal task")
 	}
@@ -187,7 +187,7 @@ func TestStoreCancel(t *testing.T) {
 
 func TestStoreCancelNotFound(t *testing.T) {
 	s := NewInMemoryStore()
-	_, err := s.Cancel("nonexistent")
+	_, err := s.Cancel("nonexistent", "")
 	if err == nil {
 		t.Error("expected error for nonexistent task")
 	}
@@ -195,18 +195,18 @@ func TestStoreCancelNotFound(t *testing.T) {
 
 func TestStoreCancelUnblocksWaiter(t *testing.T) {
 	s := NewInMemoryStore()
-	s.Create(newTestInfo("t1", core.TaskWorking))
+	s.Create(newTestInfo("t1", core.TaskWorking), "")
 
 	done := make(chan struct{})
 	var gotInfo core.TaskInfo
 
 	go func() {
-		_, gotInfo, _ = s.WaitForResult(context.Background(), "t1")
+		_, gotInfo, _ = s.WaitForResult(context.Background(), "t1", "")
 		close(done)
 	}()
 
 	time.Sleep(50 * time.Millisecond)
-	s.Cancel("t1")
+	s.Cancel("t1", "")
 
 	select {
 	case <-done:
@@ -221,13 +221,13 @@ func TestStoreCancelUnblocksWaiter(t *testing.T) {
 
 func TestStoreWaitForResultContextCancelled(t *testing.T) {
 	s := NewInMemoryStore()
-	s.Create(newTestInfo("t1", core.TaskWorking))
+	s.Create(newTestInfo("t1", core.TaskWorking), "")
 
 	ctx, cancel := context.WithCancel(context.Background())
 
 	done := make(chan error, 1)
 	go func() {
-		_, _, err := s.WaitForResult(ctx, "t1")
+		_, _, err := s.WaitForResult(ctx, "t1", "")
 		done <- err
 	}()
 
@@ -246,16 +246,16 @@ func TestStoreWaitForResultContextCancelled(t *testing.T) {
 
 func TestStoreWaitForUpdateWakesOnUpdate(t *testing.T) {
 	s := NewInMemoryStore()
-	s.Create(newTestInfo("t1", core.TaskWorking))
+	s.Create(newTestInfo("t1", core.TaskWorking), "")
 
 	done := make(chan error, 1)
 	go func() {
-		done <- s.WaitForUpdate(context.Background(), "t1")
+		done <- s.WaitForUpdate(context.Background(), "t1", "")
 	}()
 
 	time.Sleep(50 * time.Millisecond)
 	// Any Update should wake the waiter — not just terminal.
-	s.Update("t1", func(info *core.TaskInfo) {
+	s.Update("t1", "", func(info *core.TaskInfo) {
 		info.StatusMessage = "progress 50%"
 	})
 
@@ -271,15 +271,15 @@ func TestStoreWaitForUpdateWakesOnUpdate(t *testing.T) {
 
 func TestStoreWaitForUpdateWakesOnSetResult(t *testing.T) {
 	s := NewInMemoryStore()
-	s.Create(newTestInfo("t1", core.TaskWorking))
+	s.Create(newTestInfo("t1", core.TaskWorking), "")
 
 	done := make(chan error, 1)
 	go func() {
-		done <- s.WaitForUpdate(context.Background(), "t1")
+		done <- s.WaitForUpdate(context.Background(), "t1", "")
 	}()
 
 	time.Sleep(50 * time.Millisecond)
-	s.SetResult("t1", core.TextResult("partial"))
+	s.SetResult("t1", "", core.TextResult("partial"))
 
 	select {
 	case err := <-done:
@@ -293,12 +293,12 @@ func TestStoreWaitForUpdateWakesOnSetResult(t *testing.T) {
 
 func TestStoreWaitForUpdateContextCancelled(t *testing.T) {
 	s := NewInMemoryStore()
-	s.Create(newTestInfo("t1", core.TaskWorking))
+	s.Create(newTestInfo("t1", core.TaskWorking), "")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
-		done <- s.WaitForUpdate(ctx, "t1")
+		done <- s.WaitForUpdate(ctx, "t1", "")
 	}()
 
 	time.Sleep(50 * time.Millisecond)
@@ -316,7 +316,7 @@ func TestStoreWaitForUpdateContextCancelled(t *testing.T) {
 
 func TestStoreWaitForUpdateNotFound(t *testing.T) {
 	s := NewInMemoryStore()
-	err := s.WaitForUpdate(context.Background(), "nonexistent")
+	err := s.WaitForUpdate(context.Background(), "nonexistent", "")
 	if err == nil {
 		t.Error("expected error for nonexistent task")
 	}
@@ -325,11 +325,11 @@ func TestStoreWaitForUpdateNotFound(t *testing.T) {
 func TestStoreListPagination(t *testing.T) {
 	s := NewInMemoryStore()
 	for i := 0; i < 5; i++ {
-		s.Create(newTestInfo("t"+string(rune('0'+i)), core.TaskWorking))
+		s.Create(newTestInfo("t"+string(rune('0'+i)), core.TaskWorking), "")
 	}
 
 	// First page: limit 3.
-	tasks, cursor := s.List("", 3)
+	tasks, cursor := s.List("", 3, "")
 	if len(tasks) != 3 {
 		t.Fatalf("page 1: got %d tasks, want 3", len(tasks))
 	}
@@ -338,7 +338,7 @@ func TestStoreListPagination(t *testing.T) {
 	}
 
 	// Second page from cursor.
-	tasks2, cursor2 := s.List(cursor, 3)
+	tasks2, cursor2 := s.List(cursor, 3, "")
 	if len(tasks2) != 2 {
 		t.Fatalf("page 2: got %d tasks, want 2", len(tasks2))
 	}
@@ -349,7 +349,7 @@ func TestStoreListPagination(t *testing.T) {
 
 func TestStoreListEmpty(t *testing.T) {
 	s := NewInMemoryStore()
-	tasks, cursor := s.List("", 10)
+	tasks, cursor := s.List("", 10, "")
 	if len(tasks) != 0 {
 		t.Errorf("expected 0 tasks, got %d", len(tasks))
 	}
@@ -368,18 +368,18 @@ func TestStoreConcurrentAccess(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			id := "t" + time.Now().Format("150405.000000000") + "-" + string(rune('A'+i%26))
-			s.Create(newTestInfo(id, core.TaskWorking))
-			s.Get(id)
-			s.Update(id, func(info *core.TaskInfo) {
+			s.Create(newTestInfo(id, core.TaskWorking), "")
+			s.Get(id, "")
+			s.Update(id, "", func(info *core.TaskInfo) {
 				info.Status = core.TaskCompleted
 			})
-			s.SetResult(id, core.TextResult("done"))
-			s.GetResult(id)
+			s.SetResult(id, "", core.TextResult("done"))
+			s.GetResult(id, "")
 		}(i)
 	}
 	wg.Wait()
 
-	tasks, _ := s.List("", 100)
+	tasks, _ := s.List("", 100, "")
 	if len(tasks) != n {
 		t.Errorf("got %d tasks, want %d", len(tasks), n)
 	}
@@ -394,10 +394,10 @@ func TestStoreTTLExpiry(t *testing.T) {
 	s := NewInMemoryStore()
 	info := newTestInfo("t1", core.TaskWorking)
 	info.TTL = core.IntPtr(100) // 100ms TTL
-	s.Create(info)
+	s.Create(info, "")
 
 	// Task should be accessible immediately.
-	_, ok := s.Get("t1")
+	_, ok := s.Get("t1", "")
 	if !ok {
 		t.Fatal("task should exist immediately after creation")
 	}
@@ -406,7 +406,7 @@ func TestStoreTTLExpiry(t *testing.T) {
 	time.Sleep(150 * time.Millisecond)
 
 	// Task should be gone.
-	_, ok = s.Get("t1")
+	_, ok = s.Get("t1", "")
 	if ok {
 		t.Error("task should have been removed after TTL expired")
 	}
@@ -420,18 +420,18 @@ func TestStoreTTLResetOnResult(t *testing.T) {
 	s := NewInMemoryStore()
 	info := newTestInfo("t1", core.TaskWorking)
 	info.TTL = core.IntPtr(200) // 200ms TTL
-	s.Create(info)
+	s.Create(info, "")
 
 	// Wait 100ms (half the TTL), then store result.
 	time.Sleep(100 * time.Millisecond)
-	s.SetResult("t1", core.TextResult("done"))
-	s.Update("t1", func(i *core.TaskInfo) { i.Status = core.TaskCompleted })
+	s.SetResult("t1", "", core.TextResult("done"))
+	s.Update("t1", "", func(i *core.TaskInfo) { i.Status = core.TaskCompleted })
 
 	// Wait another 150ms — past the original TTL but within the reset window.
 	time.Sleep(150 * time.Millisecond)
 
 	// Task should still be accessible (timer was reset on SetResult).
-	_, ok := s.Get("t1")
+	_, ok := s.Get("t1", "")
 	if !ok {
 		t.Error("task should still exist — TTL should have reset when result was stored")
 	}
@@ -439,7 +439,7 @@ func TestStoreTTLResetOnResult(t *testing.T) {
 	// Wait for the full reset TTL to expire.
 	time.Sleep(100 * time.Millisecond)
 
-	_, ok = s.Get("t1")
+	_, ok = s.Get("t1", "")
 	if ok {
 		t.Error("task should have been removed after reset TTL expired")
 	}
@@ -451,16 +451,16 @@ func TestStoreTTLResetOnCancel(t *testing.T) {
 	s := NewInMemoryStore()
 	info := newTestInfo("t1", core.TaskWorking)
 	info.TTL = core.IntPtr(200) // 200ms TTL
-	s.Create(info)
+	s.Create(info, "")
 
 	// Wait 100ms, then cancel.
 	time.Sleep(100 * time.Millisecond)
-	s.Cancel("t1")
+	s.Cancel("t1", "")
 
 	// Wait 150ms — past original TTL but within reset window.
 	time.Sleep(150 * time.Millisecond)
 
-	_, ok := s.Get("t1")
+	_, ok := s.Get("t1", "")
 	if !ok {
 		t.Error("cancelled task should still exist within reset TTL window")
 	}
@@ -472,11 +472,11 @@ func TestStoreTTLNullNoExpiry(t *testing.T) {
 	s := NewInMemoryStore()
 	info := newTestInfo("t1", core.TaskWorking)
 	info.TTL = nil // null = unlimited
-	s.Create(info)
+	s.Create(info, "")
 
 	time.Sleep(100 * time.Millisecond)
 
-	_, ok := s.Get("t1")
+	_, ok := s.Get("t1", "")
 	if !ok {
 		t.Error("task with nil TTL should never expire")
 	}
@@ -489,19 +489,19 @@ func TestStoreCleanup(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		info := newTestInfo("t"+string(rune('0'+i)), core.TaskWorking)
 		info.TTL = core.IntPtr(60000) // long TTL — won't expire during test
-		s.Create(info)
+		s.Create(info, "")
 	}
 
 	s.Cleanup()
 
 	for i := 0; i < 5; i++ {
-		_, ok := s.Get("t" + string(rune('0'+i)))
+		_, ok := s.Get("t" + string(rune('0'+i)), "")
 		if ok {
 			t.Errorf("task t%d should have been removed by Cleanup", i)
 		}
 	}
 
-	tasks, _ := s.List("", 100)
+	tasks, _ := s.List("", 100, "")
 	if len(tasks) != 0 {
 		t.Errorf("List should return empty after Cleanup, got %d", len(tasks))
 	}
@@ -514,7 +514,7 @@ func TestStoreCleanupStopsTimers(t *testing.T) {
 	s := NewInMemoryStore()
 	info := newTestInfo("t1", core.TaskWorking)
 	info.TTL = core.IntPtr(50) // very short TTL
-	s.Create(info)
+	s.Create(info, "")
 
 	// Cleanup before the timer fires.
 	s.Cleanup()
@@ -523,8 +523,122 @@ func TestStoreCleanupStopsTimers(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	// No panic, no corruption. The store is empty and stable.
-	tasks, _ := s.List("", 100)
+	tasks, _ := s.List("", 100, "")
 	if len(tasks) != 0 {
 		t.Errorf("store should be empty after Cleanup, got %d", len(tasks))
+	}
+}
+
+// --- Session isolation tests (Phase 3) ---
+
+// TestStoreSessionIsolationGet verifies that a task created by session A
+// is not visible to session B via Get.
+func TestStoreSessionIsolationGet(t *testing.T) {
+	s := NewInMemoryStore()
+	s.Create(newTestInfo("t1", core.TaskWorking), "session-a")
+
+	// Session A can see it.
+	_, ok := s.Get("t1", "session-a")
+	if !ok {
+		t.Error("session A should see its own task")
+	}
+
+	// Session B cannot.
+	_, ok = s.Get("t1", "session-b")
+	if ok {
+		t.Error("session B should NOT see session A's task")
+	}
+
+	// Empty session can see everything (backward compat).
+	_, ok = s.Get("t1", "")
+	if !ok {
+		t.Error("empty session should see all tasks")
+	}
+}
+
+// TestStoreSessionIsolationUpdate verifies that session B cannot update
+// session A's task.
+func TestStoreSessionIsolationUpdate(t *testing.T) {
+	s := NewInMemoryStore()
+	s.Create(newTestInfo("t1", core.TaskWorking), "session-a")
+
+	err := s.Update("t1", "session-b", func(info *core.TaskInfo) {
+		info.StatusMessage = "hijacked"
+	})
+	if err == nil {
+		t.Error("session B should NOT be able to update session A's task")
+	}
+
+	// Session A can update.
+	err = s.Update("t1", "session-a", func(info *core.TaskInfo) {
+		info.StatusMessage = "legit"
+	})
+	if err != nil {
+		t.Errorf("session A should be able to update its own task: %v", err)
+	}
+}
+
+// TestStoreSessionIsolationCancel verifies that session B cannot cancel
+// session A's task.
+func TestStoreSessionIsolationCancel(t *testing.T) {
+	s := NewInMemoryStore()
+	s.Create(newTestInfo("t1", core.TaskWorking), "session-a")
+
+	_, err := s.Cancel("t1", "session-b")
+	if err == nil {
+		t.Error("session B should NOT be able to cancel session A's task")
+	}
+
+	_, err = s.Cancel("t1", "session-a")
+	if err != nil {
+		t.Errorf("session A should be able to cancel its own task: %v", err)
+	}
+}
+
+// TestStoreSessionIsolationList verifies that List only returns tasks
+// belonging to the caller's session.
+func TestStoreSessionIsolationList(t *testing.T) {
+	s := NewInMemoryStore()
+	s.Create(newTestInfo("t1", core.TaskWorking), "session-a")
+	s.Create(newTestInfo("t2", core.TaskWorking), "session-b")
+	s.Create(newTestInfo("t3", core.TaskWorking), "session-a")
+
+	// Session A sees only t1 and t3.
+	tasks, _ := s.List("", 50, "session-a")
+	if len(tasks) != 2 {
+		t.Fatalf("session A: got %d tasks, want 2", len(tasks))
+	}
+
+	// Session B sees only t2.
+	tasks, _ = s.List("", 50, "session-b")
+	if len(tasks) != 1 {
+		t.Fatalf("session B: got %d tasks, want 1", len(tasks))
+	}
+
+	// Empty session sees all.
+	tasks, _ = s.List("", 50, "")
+	if len(tasks) != 3 {
+		t.Fatalf("empty session: got %d tasks, want 3", len(tasks))
+	}
+}
+
+// TestStoreSessionEmptyAllowsAccess verifies that tasks created without
+// a session are accessible by any session (backward compat).
+func TestStoreSessionEmptyAllowsAccess(t *testing.T) {
+	s := NewInMemoryStore()
+	s.Create(newTestInfo("t1", core.TaskWorking), "") // no session
+
+	// Any session can see it.
+	_, ok := s.Get("t1", "any-session")
+	if !ok {
+		t.Error("task with empty session should be accessible by any session")
+	}
+
+	// Can also update.
+	err := s.Update("t1", "any-session", func(info *core.TaskInfo) {
+		info.StatusMessage = "updated"
+	})
+	if err != nil {
+		t.Errorf("should be able to update session-less task: %v", err)
 	}
 }

--- a/experimental/ext/tasks/tasks.go
+++ b/experimental/ext/tasks/tasks.go
@@ -200,20 +200,23 @@ func taskMiddleware(reg *server.Registry, rt *taskRuntime, cfg Config) server.Mi
 			PollInterval:  pollMs,
 		}
 		store := rt.store
-		if err := store.Create(info); err != nil {
+		sessionID := core.GetSessionID(ctx)
+		if err := store.Create(info, sessionID); err != nil {
 			return core.NewErrorResponse(req.ID, -32603, "failed to create task: "+err.Error())
 		}
 
 		// Run the tool asynchronously. Detach from client context so
 		// the tool continues even if the client disconnects.
+		// The sessionID is captured here so the background goroutine
+		// uses the same session for all store operations.
 		go func() {
 			defer func() {
 				rt.unregisterChannel(taskID)
 				if r := recover(); r != nil {
 					now := time.Now().UTC().Format(time.RFC3339)
 					msg := fmt.Sprintf("panic: %v", r)
-					store.SetResult(taskID, core.ErrorResult(msg))
-					store.Update(taskID, func(t *core.TaskInfo) {
+					store.SetResult(taskID, sessionID, core.ErrorResult(msg))
+					store.Update(taskID, sessionID, func(t *core.TaskInfo) {
 						t.Status = core.TaskFailed
 						t.StatusMessage = msg
 						t.LastUpdatedAt = now
@@ -222,22 +225,17 @@ func taskMiddleware(reg *server.Registry, rt *taskRuntime, cfg Config) server.Mi
 			}()
 
 			bgCtx := core.DetachForBackground(ctx)
-			// Inject TaskContext so tool handlers can call TaskElicit/TaskSample.
-			// The requests channel is read by the tasks/result handler to proxy
-			// elicitation/sampling through its live connection.
 			reqCh := make(chan sideChannelRequest, 1)
-			tc := &TaskContext{taskID: taskID, store: store, requests: reqCh}
+			tc := &TaskContext{taskID: taskID, sessionID: sessionID, store: store, requests: reqCh}
 			bgCtx = WithTaskContext(bgCtx, tc)
 			rt.registerChannel(taskID, reqCh)
 			resp := next(bgCtx, req)
 
 			now := time.Now().UTC().Format(time.RFC3339)
 
-			// Store result BEFORE updating status to terminal. Update broadcasts
-			// to WaitForResult waiters, so the result must be available first.
 			if resp.Error != nil {
-				store.SetResult(taskID, core.ErrorResult(resp.Error.Message))
-				store.Update(taskID, func(t *core.TaskInfo) {
+				store.SetResult(taskID, sessionID, core.ErrorResult(resp.Error.Message))
+				store.Update(taskID, sessionID, func(t *core.TaskInfo) {
 					t.Status = core.TaskFailed
 					t.StatusMessage = resp.Error.Message
 					t.LastUpdatedAt = now
@@ -245,11 +243,10 @@ func taskMiddleware(reg *server.Registry, rt *taskRuntime, cfg Config) server.Mi
 				return
 			}
 
-			// resp.Result is any — marshal then unmarshal to get ToolResult.
 			raw, err := json.Marshal(resp.Result)
 			if err != nil {
-				store.SetResult(taskID, core.ErrorResult("failed to marshal tool result"))
-				store.Update(taskID, func(t *core.TaskInfo) {
+				store.SetResult(taskID, sessionID, core.ErrorResult("failed to marshal tool result"))
+				store.Update(taskID, sessionID, func(t *core.TaskInfo) {
 					t.Status = core.TaskFailed
 					t.StatusMessage = "failed to marshal tool result"
 					t.LastUpdatedAt = now
@@ -259,8 +256,8 @@ func taskMiddleware(reg *server.Registry, rt *taskRuntime, cfg Config) server.Mi
 
 			var toolResult core.ToolResult
 			if err := json.Unmarshal(raw, &toolResult); err != nil {
-				store.SetResult(taskID, core.ErrorResult("failed to unmarshal tool result"))
-				store.Update(taskID, func(t *core.TaskInfo) {
+				store.SetResult(taskID, sessionID, core.ErrorResult("failed to unmarshal tool result"))
+				store.Update(taskID, sessionID, func(t *core.TaskInfo) {
 					t.Status = core.TaskFailed
 					t.StatusMessage = "failed to unmarshal tool result"
 					t.LastUpdatedAt = now
@@ -272,8 +269,8 @@ func taskMiddleware(reg *server.Registry, rt *taskRuntime, cfg Config) server.Mi
 			if toolResult.IsError {
 				status = core.TaskFailed
 			}
-			store.SetResult(taskID, toolResult)
-			store.Update(taskID, func(t *core.TaskInfo) {
+			store.SetResult(taskID, sessionID, toolResult)
+			store.Update(taskID, sessionID, func(t *core.TaskInfo) {
 				t.Status = status
 				t.LastUpdatedAt = now
 			})
@@ -299,11 +296,10 @@ func makeGetHandler(store TaskStore) server.MethodHandler {
 		if err := json.Unmarshal(params, &p); err != nil {
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, err.Error())
 		}
-		info, ok := store.Get(p.TaskID)
+		info, ok := store.Get(p.TaskID, ctx.SessionID())
 		if !ok {
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, "task not found: "+p.TaskID)
 		}
-		// Per spec: tasks/get returns flat Result & Task (no wrapper).
 		return core.NewResponse(id, core.GetTaskResult{TaskInfo: info})
 	}
 }
@@ -340,19 +336,17 @@ func makeResultHandler(rt *taskRuntime) server.MethodHandler {
 			}
 
 			// 2. Check if the task is terminal.
-			info, found := store.Get(p.TaskID)
+			sid := ctx.SessionID()
+			info, found := store.Get(p.TaskID, sid)
 			if !found {
 				return core.NewErrorResponse(id, core.ErrCodeInvalidParams, "task not found: "+p.TaskID)
 			}
 
 			if info.Status.IsTerminal() {
-				result, _ := store.GetResult(p.TaskID)
+				result, _ := store.GetResult(p.TaskID, sid)
 
-				// Clean up any remaining queued messages.
 				rt.queue.DequeueAll(p.TaskID)
 
-				// Per spec: tasks/result returns the stored ToolResult for ALL
-				// terminal states with _meta["io.modelcontextprotocol/related-task"].
 				if result.Meta == nil {
 					result.Meta = &core.ToolResultMeta{}
 				}
@@ -361,7 +355,7 @@ func makeResultHandler(rt *taskRuntime) server.MethodHandler {
 			}
 
 			// 3. Wait for a task update or context cancellation.
-			if err := store.WaitForUpdate(ctx, p.TaskID); err != nil {
+			if err := store.WaitForUpdate(ctx, p.TaskID, sid); err != nil {
 				return core.NewErrorResponse(id, core.ErrCodeInvalidParams, err.Error())
 			}
 		}
@@ -376,7 +370,7 @@ func makeListHandler(store TaskStore) server.MethodHandler {
 		if params != nil {
 			json.Unmarshal(params, &p)
 		}
-		tasks, nextCursor := store.List(p.Cursor, 50)
+		tasks, nextCursor := store.List(p.Cursor, 50, ctx.SessionID())
 		if tasks == nil {
 			tasks = []core.TaskInfo{}
 		}
@@ -395,7 +389,7 @@ func makeCancelHandler(rt *taskRuntime) server.MethodHandler {
 		if err := json.Unmarshal(params, &p); err != nil {
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, err.Error())
 		}
-		info, err := rt.store.Cancel(p.TaskID)
+		info, err := rt.store.Cancel(p.TaskID, ctx.SessionID())
 		if err != nil {
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, err.Error())
 		}

--- a/experimental/ext/tasks/tasks_test.go
+++ b/experimental/ext/tasks/tasks_test.go
@@ -891,7 +891,7 @@ func TestTaskInputRequiredTransition(t *testing.T) {
 				return core.TextResult("no task context"), nil
 			}
 			// Simulate what TaskElicit does: transition to input_required.
-			tc.store.Update(tc.taskID, func(info *core.TaskInfo) {
+			tc.store.Update(tc.taskID, "", func(info *core.TaskInfo) {
 				info.Status = core.TaskInputRequired
 			})
 			// Signal that we're in input_required.
@@ -899,7 +899,7 @@ func TestTaskInputRequiredTransition(t *testing.T) {
 			// Wait for the test to observe it.
 			<-observed
 			// Transition back to working (like TaskElicit does after response).
-			tc.store.Update(tc.taskID, func(info *core.TaskInfo) {
+			tc.store.Update(tc.taskID, "", func(info *core.TaskInfo) {
 				info.Status = core.TaskWorking
 			})
 			return core.TextResult("done"), nil

--- a/server/server.go
+++ b/server/server.go
@@ -452,14 +452,11 @@ func (s *Server) dispatchWithOpts(d *Dispatcher, ctx context.Context, claims *co
 	// (elicitation, sampling) after the original HTTP request has returned.
 	ctx = core.SetDetachStrategy(ctx, func(c context.Context) context.Context {
 		c = context.WithoutCancel(c)
+		// Replace transport-scoped functions. Each Replace* returns a new
+		// context — chain them so both replacements take effect.
 		if push := d.getPushRequest(); push != nil {
-			bgRequest := d.makeRequestFunc(push)
-			c = core.ReplaceSessionRequestFunc(c, bgRequest)
+			c = core.ReplaceSessionRequestFunc(c, d.makeRequestFunc(push))
 		}
-		// Also replace notifyFunc if the session has a persistent one
-		// (e.g., GET SSE stream). Don't replace if nil — keep the
-		// POST-scoped one as fallback (it may be the only option in
-		// test/stdio contexts without a GET SSE stream).
 		if bgNotify := d.getNotifyFunc(); bgNotify != nil {
 			c = core.ReplaceSessionNotifyFunc(c, bgNotify)
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -441,6 +441,9 @@ func (s *Server) dispatchWithOpts(d *Dispatcher, ctx context.Context, claims *co
 	// and access authenticated claims and client capabilities.
 	ctx = core.ContextWithSession(ctx, notify, request, &d.logLevel, &d.clientCaps, claims)
 
+	// Set the session ID so middleware and handlers can access it via ctx.SessionID().
+	core.SetSessionID(ctx, d.sessionID)
+
 	// Register a detach strategy for background goroutines (e.g., async tasks).
 	// The strategy replaces the POST-scoped requestFunc (which writes to the
 	// now-closed response stream) with one that uses the session's persistent

--- a/server/server.go
+++ b/server/server.go
@@ -445,16 +445,23 @@ func (s *Server) dispatchWithOpts(d *Dispatcher, ctx context.Context, claims *co
 	core.SetSessionID(ctx, d.sessionID)
 
 	// Register a detach strategy for background goroutines (e.g., async tasks).
-	// The strategy replaces the POST-scoped requestFunc (which writes to the
-	// now-closed response stream) with one that uses the session's persistent
-	// push function (GET SSE stream). This allows background goroutines to
-	// send server-to-client requests (elicitation, sampling) after the
-	// original HTTP request has returned.
+	// The strategy replaces the POST-scoped requestFunc and notifyFunc (which
+	// write to the now-closed response stream) with session-level equivalents
+	// that use the persistent GET SSE stream. This allows background goroutines
+	// to send notifications (progress, logging) and server-to-client requests
+	// (elicitation, sampling) after the original HTTP request has returned.
 	ctx = core.SetDetachStrategy(ctx, func(c context.Context) context.Context {
 		c = context.WithoutCancel(c)
 		if push := d.getPushRequest(); push != nil {
 			bgRequest := d.makeRequestFunc(push)
 			c = core.ReplaceSessionRequestFunc(c, bgRequest)
+		}
+		// Also replace notifyFunc if the session has a persistent one
+		// (e.g., GET SSE stream). Don't replace if nil — keep the
+		// POST-scoped one as fallback (it may be the only option in
+		// test/stdio contexts without a GET SSE stream).
+		if bgNotify := d.getNotifyFunc(); bgNotify != nil {
+			c = core.ReplaceSessionNotifyFunc(c, bgNotify)
 		}
 		return c
 	})

--- a/tests/reports/report.html
+++ b/tests/reports/report.html
@@ -15,7 +15,7 @@ th { background: #f5f5f5; font-weight: 600; }
 pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto; font-size: 13px; max-height: 400px; overflow-y: auto; }
 </style></head><body>
 <h1>MCPKit Test Report</h1>
-<div class='meta'>Branch: <strong>feat/tasks-ttl-phase2</strong> | Commit: <code>8fd49cc</code> | Date: 2026-04-19 23:39:28</div>
+<div class='meta'>Branch: <strong>feat/tasks-session-isolation-phase3</strong> | Commit: <code>daf2039</code> | Date: 2026-04-20 02:16:58</div>
 <table><tr><th>Stage</th><th>Result</th></tr>
 <tr><td>unit+coverage</td><td class='pass'>PASS</td></tr>
 <tr><td>race</td><td class='pass'>PASS</td></tr>
@@ -31,35 +31,35 @@ pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto; 
 <div class='summary-pass'>All 10 stages passed</div>
 <h2>Full Log</h2><pre>
 === MCPKit Comprehensive Test Suite ===
-Started: Sun Apr 19 23:36:39 PDT 2026
+Started: Mon Apr 20 02:14:02 PDT 2026
 
 --- [1/10] unit+coverage ---
   PASS: unit+coverage
 go test -coverprofile=tests/reports/coverage.out ./... -count=1 -timeout 30s
-ok  	github.com/panyam/mcpkit/client	8.548s	coverage: 67.1% of statements
+ok  	github.com/panyam/mcpkit/client	8.833s	coverage: 67.1% of statements
 	github.com/panyam/mcpkit/cmd/testserver		coverage: 0.0% of statements
-ok  	github.com/panyam/mcpkit/core	0.745s	coverage: 52.4% of statements
-ok  	github.com/panyam/mcpkit/server	7.658s	coverage: 77.4% of statements
-ok  	github.com/panyam/mcpkit/testutil	1.061s	coverage: 69.4% of statements
+ok  	github.com/panyam/mcpkit/core	0.725s	coverage: 51.6% of statements
+ok  	github.com/panyam/mcpkit/server	7.877s	coverage: 77.4% of statements
+ok  	github.com/panyam/mcpkit/testutil	0.944s	coverage: 69.4% of statements
 go tool cover -html=tests/reports/coverage.out -o tests/reports/coverage.html
 Coverage report: tests/reports/coverage.html
 --- [2/10] race ---
   PASS: race
 go test -race ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/client	9.612s
+ok  	github.com/panyam/mcpkit/client	9.307s
 ?   	github.com/panyam/mcpkit/cmd/testserver	[no test files]
-ok  	github.com/panyam/mcpkit/core	2.632s
-ok  	github.com/panyam/mcpkit/server	9.616s
-ok  	github.com/panyam/mcpkit/testutil	2.885s
+ok  	github.com/panyam/mcpkit/core	1.362s
+ok  	github.com/panyam/mcpkit/server	8.860s
+ok  	github.com/panyam/mcpkit/testutil	1.818s
 --- [3/10] auth ---
   PASS: auth
 cd ext/auth &amp;&amp; go test ./... -count=1 -timeout 30s
-ok  	github.com/panyam/mcpkit/ext/auth	0.345s
+ok  	github.com/panyam/mcpkit/ext/auth	0.597s
 --- [4/10] ui ---
   PASS: ui
 cd ext/ui &amp;&amp; /Library/Developer/CommandLineTools/usr/bin/make test
 go test ./... -count=1 -timeout 30s
-ok  	github.com/panyam/mcpkit/ext/ui	0.355s
+ok  	github.com/panyam/mcpkit/ext/ui	0.646s
 cd assets &amp;&amp; pnpm install --frozen-lockfile --silent &amp;&amp; pnpm test
 
 &gt; @mcpkit/app-bridge@0.1.0 test /Users/dzshrh/newstack/mcpkit/main/ext/ui/assets
@@ -68,21 +68,21 @@ cd assets &amp;&amp; pnpm install --frozen-lockfile --silent &amp;&amp; pnpm tes
 
  RUN  v3.2.4 /Users/dzshrh/newstack/mcpkit/main/ext/ui/assets
 
- ✓ mcp-app-bridge.test.ts (33 tests) 384ms
+ ✓ mcp-app-bridge.test.ts (33 tests) 385ms
 
  Test Files  1 passed (1)
       Tests  33 passed (33)
-   Start at  23:37:02
-   Duration  995ms (transform 26ms, setup 0ms, collect 26ms, tests 384ms, environment 316ms, prepare 101ms)
+   Start at  02:14:28
+   Duration  1.05s (transform 35ms, setup 0ms, collect 29ms, tests 385ms, environment 297ms, prepare 124ms)
 
 --- [5/10] protogen ---
   PASS: protogen
 cd experimental/ext/protogen &amp;&amp; go test ./... -count=1 -timeout 30s &amp;&amp; /Library/Developer/CommandLineTools/usr/bin/make test-e2e
 ?   	github.com/panyam/mcpkit/experimental/ext/protogen/cmd/protoc-gen-go-mcp	[no test files]
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/generator	1.240s
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/proto/mcp/v1	0.648s
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/runtime	0.383s
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/schema	0.953s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/generator	0.591s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/proto/mcp/v1	1.249s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/runtime	0.888s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/schema	0.955s
 ?   	github.com/panyam/mcpkit/experimental/ext/protogen/testutil	[no test files]
 go build -o bin/protoc-gen-go-mcp ./cmd/protoc-gen-go-mcp
 go install ./cmd/protoc-gen-go-mcp
@@ -91,23 +91,23 @@ cd ../../../examples/protogen/bookservice &amp;&amp; rm -rf gen &amp;&amp; buf g
 [33mWARN[0m	plugin "protoc-gen-go-mcp" does not support required features.
   Feature "proto3 optional" is required by 1 file(s):
     bookservice/v1/service.proto
-ok  	github.com/panyam/mcpkit/examples/protogen/bookservice	0.425s
+ok  	github.com/panyam/mcpkit/examples/protogen/bookservice	0.746s
 ==&gt; e2e: passed
 --- [6/10] e2e ---
   PASS: e2e
 cd tests/e2e &amp;&amp; go test ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/tests/e2e	3.751s
-ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.422s
+ok  	github.com/panyam/mcpkit/tests/e2e	4.415s
+ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.795s
 --- [7/10] experimental ---
   PASS: experimental
 cd experimental/telegram-events &amp;&amp; go test ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/experimental/telegram-events	5.234s
+ok  	github.com/panyam/mcpkit/experimental/telegram-events	5.474s
 --- [8/10] conformance ---
   PASS: conformance
 bash scripts/conformance-test.sh
 Killing stale process on port 18799...
 === Starting test server on :18799 (Streamable HTTP) ===
-Waiting for server....2026/04/19 23:37:20 MCP test server listening on :18799 (Streamable HTTP at /mcp)
+Waiting for server.....2026/04/20 02:14:49 MCP test server listening on :18799 (Streamable HTTP at /mcp)
  ready
 
 === Running MCP conformance suite ===
@@ -118,293 +118,293 @@ Running active suite (30 scenarios) against http://localhost:18799/mcp
 
 === Running scenario: server-initialize ===
 Running client scenario 'server-initialize' against server: http://localhost:18799/mcp
-2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: 199953dc2d69f6c6b6455f8bb4b1d1e4
-2026/04/19 23:37:22 SSEHub: registered connection 199953dc2d69f6c6b6455f8bb4b1d1e4 (total: 1)
-2026/04/19 23:37:22 SSEHub: unregistered connection 199953dc2d69f6c6b6455f8bb4b1d1e4 (total: 0)
-2026/04/19 23:37:22 Received kill signal.  Quitting Writer. stop 0x31b4a0f38150
-2026/04/19 23:37:22 Cleaning up writer...
-2026/04/19 23:37:22 Finished cleaning up writer:  0x31b4a0f38150
-2026/04/19 23:37:22 Closed MCP-GET-SSE SSE connection: 199953dc2d69f6c6b6455f8bb4b1d1e4
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: ca583b0c95c320a571e897e57a4e5af9
+2026/04/20 02:14:51 SSEHub: registered connection ca583b0c95c320a571e897e57a4e5af9 (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection ca583b0c95c320a571e897e57a4e5af9 (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc36b61c0
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc36b61c0
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: ca583b0c95c320a571e897e57a4e5af9
 
 === Running scenario: logging-set-level ===
 Running client scenario 'logging-set-level' against server: http://localhost:18799/mcp
-2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: aa39c6bee73cdb5838e490382e214970
-2026/04/19 23:37:22 SSEHub: registered connection aa39c6bee73cdb5838e490382e214970 (total: 1)
-2026/04/19 23:37:22 SSEHub: unregistered connection aa39c6bee73cdb5838e490382e214970 (total: 0)
-2026/04/19 23:37:22 Received kill signal.  Quitting Writer. stop 0x31b4a0e36230
-2026/04/19 23:37:22 Cleaning up writer...
-2026/04/19 23:37:22 Finished cleaning up writer:  0x31b4a0e36230
-2026/04/19 23:37:22 Closed MCP-GET-SSE SSE connection: aa39c6bee73cdb5838e490382e214970
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: 0115ace1d87619020a7f9de954031fdb
+2026/04/20 02:14:51 SSEHub: registered connection 0115ace1d87619020a7f9de954031fdb (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection 0115ace1d87619020a7f9de954031fdb (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc338c8c0
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc338c8c0
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: 0115ace1d87619020a7f9de954031fdb
 
 === Running scenario: ping ===
 Running client scenario 'ping' against server: http://localhost:18799/mcp
-2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: 993e660ec0575e457a77ac88540e9a39
-2026/04/19 23:37:22 SSEHub: registered connection 993e660ec0575e457a77ac88540e9a39 (total: 1)
-2026/04/19 23:37:22 SSEHub: unregistered connection 993e660ec0575e457a77ac88540e9a39 (total: 0)
-2026/04/19 23:37:22 Received kill signal.  Quitting Writer. stop 0x31b4a0e364d0
-2026/04/19 23:37:22 Cleaning up writer...
-2026/04/19 23:37:22 Finished cleaning up writer:  0x31b4a0e364d0
-2026/04/19 23:37:22 Closed MCP-GET-SSE SSE connection: 993e660ec0575e457a77ac88540e9a39
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: 66cf6d51799e69ae2138c7f9928f828a
+2026/04/20 02:14:51 SSEHub: registered connection 66cf6d51799e69ae2138c7f9928f828a (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection 66cf6d51799e69ae2138c7f9928f828a (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc36b61c0
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc36b61c0
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: 66cf6d51799e69ae2138c7f9928f828a
 
 === Running scenario: completion-complete ===
 Running client scenario 'completion-complete' against server: http://localhost:18799/mcp
-2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: 7c7809131a91c729822f93f9ae911728
-2026/04/19 23:37:22 SSEHub: registered connection 7c7809131a91c729822f93f9ae911728 (total: 1)
-2026/04/19 23:37:22 SSEHub: unregistered connection 7c7809131a91c729822f93f9ae911728 (total: 0)
-2026/04/19 23:37:22 Received kill signal.  Quitting Writer. stop 0x31b4a0b14a10
-2026/04/19 23:37:22 Cleaning up writer...
-2026/04/19 23:37:22 Finished cleaning up writer:  0x31b4a0b14a10
-2026/04/19 23:37:22 Closed MCP-GET-SSE SSE connection: 7c7809131a91c729822f93f9ae911728
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: ae8a4be050dec976005ee75171f7e6d5
+2026/04/20 02:14:51 SSEHub: registered connection ae8a4be050dec976005ee75171f7e6d5 (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection ae8a4be050dec976005ee75171f7e6d5 (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc338cd90
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc338cd90
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: ae8a4be050dec976005ee75171f7e6d5
 
 === Running scenario: tools-list ===
 Running client scenario 'tools-list' against server: http://localhost:18799/mcp
-2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: 933c84a2644c4379fccf13a19fb835ba
-2026/04/19 23:37:22 SSEHub: registered connection 933c84a2644c4379fccf13a19fb835ba (total: 1)
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: 485a2a2c277de96ae25e489f0e482673
+2026/04/20 02:14:51 SSEHub: registered connection 485a2a2c277de96ae25e489f0e482673 (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection 485a2a2c277de96ae25e489f0e482673 (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc36b6460
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc36b6460
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: 485a2a2c277de96ae25e489f0e482673
 
 === Running scenario: tools-call-simple-text ===
-2026/04/19 23:37:22 SSEHub: unregistered connection 933c84a2644c4379fccf13a19fb835ba (total: 0)
 Running client scenario 'tools-call-simple-text' against server: http://localhost:18799/mcp
-2026/04/19 23:37:22 Received kill signal.  Quitting Writer. stop 0x31b4a0b14c40
-2026/04/19 23:37:22 Cleaning up writer...
-2026/04/19 23:37:22 Finished cleaning up writer:  0x31b4a0b14c40
-2026/04/19 23:37:22 Closed MCP-GET-SSE SSE connection: 933c84a2644c4379fccf13a19fb835ba
-2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: f374b21d34ec91c720f89b4cbc55527b
-2026/04/19 23:37:22 SSEHub: registered connection f374b21d34ec91c720f89b4cbc55527b (total: 1)
-2026/04/19 23:37:22 SSEHub: unregistered connection f374b21d34ec91c720f89b4cbc55527b (total: 0)
-2026/04/19 23:37:22 Received kill signal.  Quitting Writer. stop 0x31b4a0b14e70
-2026/04/19 23:37:22 Cleaning up writer...
-2026/04/19 23:37:22 Finished cleaning up writer:  0x31b4a0b14e70
-2026/04/19 23:37:22 Closed MCP-GET-SSE SSE connection: f374b21d34ec91c720f89b4cbc55527b
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: a36a895f51a1f6cf0e3abec8384ab09d
+2026/04/20 02:14:51 SSEHub: registered connection a36a895f51a1f6cf0e3abec8384ab09d (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection a36a895f51a1f6cf0e3abec8384ab09d (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc3246310
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc3246310
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: a36a895f51a1f6cf0e3abec8384ab09d
 
 === Running scenario: tools-call-image ===
 Running client scenario 'tools-call-image' against server: http://localhost:18799/mcp
-2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: 2dc9e9e7cd2a5a5f86e6e21389d10a0f
-2026/04/19 23:37:22 SSEHub: registered connection 2dc9e9e7cd2a5a5f86e6e21389d10a0f (total: 1)
-2026/04/19 23:37:22 SSEHub: unregistered connection 2dc9e9e7cd2a5a5f86e6e21389d10a0f (total: 0)
-2026/04/19 23:37:22 Received kill signal.  Quitting Writer. stop 0x31b4a0e36850
-2026/04/19 23:37:22 Cleaning up writer...
-2026/04/19 23:37:22 Finished cleaning up writer:  0x31b4a0e36850
-2026/04/19 23:37:22 Closed MCP-GET-SSE SSE connection: 2dc9e9e7cd2a5a5f86e6e21389d10a0f
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: 839d97dc317bb0adae96c799053ad652
+2026/04/20 02:14:51 SSEHub: registered connection 839d97dc317bb0adae96c799053ad652 (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection 839d97dc317bb0adae96c799053ad652 (total: 0)
 
 === Running scenario: tools-call-audio ===
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc3340380
+2026/04/20 02:14:51 Cleaning up writer...
 Running client scenario 'tools-call-audio' against server: http://localhost:18799/mcp
-2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: 6c4635a21f83c810dbfd1718f2d50ace
-2026/04/19 23:37:22 SSEHub: registered connection 6c4635a21f83c810dbfd1718f2d50ace (total: 1)
-2026/04/19 23:37:22 SSEHub: unregistered connection 6c4635a21f83c810dbfd1718f2d50ace (total: 0)
-2026/04/19 23:37:22 Received kill signal.  Quitting Writer. stop 0x31b4a0a623f0
-2026/04/19 23:37:22 Cleaning up writer...
-2026/04/19 23:37:22 Finished cleaning up writer:  0x31b4a0a623f0
-2026/04/19 23:37:22 Closed MCP-GET-SSE SSE connection: 6c4635a21f83c810dbfd1718f2d50ace
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc3340380
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: 839d97dc317bb0adae96c799053ad652
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: e6549e95cf5331fe9fceefa5f88881ca
+2026/04/20 02:14:51 SSEHub: registered connection e6549e95cf5331fe9fceefa5f88881ca (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection e6549e95cf5331fe9fceefa5f88881ca (total: 0)
 
 === Running scenario: tools-call-embedded-resource ===
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc3340700
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc3340700
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: e6549e95cf5331fe9fceefa5f88881ca
 Running client scenario 'tools-call-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: 01c6ebf03176df1b52be5bf2321af125
-2026/04/19 23:37:22 SSEHub: registered connection 01c6ebf03176df1b52be5bf2321af125 (total: 1)
-2026/04/19 23:37:22 SSEHub: unregistered connection 01c6ebf03176df1b52be5bf2321af125 (total: 0)
-2026/04/19 23:37:22 Received kill signal.  Quitting Writer. stop 0x31b4a0f38380
-2026/04/19 23:37:22 Cleaning up writer...
-2026/04/19 23:37:22 Finished cleaning up writer:  0x31b4a0f38380
-2026/04/19 23:37:22 Closed MCP-GET-SSE SSE connection: 01c6ebf03176df1b52be5bf2321af125
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: 82947507b05388be8258dd3c1e1e3e4d
+2026/04/20 02:14:51 SSEHub: registered connection 82947507b05388be8258dd3c1e1e3e4d (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection 82947507b05388be8258dd3c1e1e3e4d (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc338d2d0
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc338d2d0
 
 === Running scenario: tools-call-mixed-content ===
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: 82947507b05388be8258dd3c1e1e3e4d
 Running client scenario 'tools-call-mixed-content' against server: http://localhost:18799/mcp
-2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: cf622a8d18a72911d7660a0042d0dd96
-2026/04/19 23:37:22 SSEHub: registered connection cf622a8d18a72911d7660a0042d0dd96 (total: 1)
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: d32682b0c5ce94e4c2eb1369764dff50
+2026/04/20 02:14:51 SSEHub: registered connection d32682b0c5ce94e4c2eb1369764dff50 (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection d32682b0c5ce94e4c2eb1369764dff50 (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc338d500
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc338d500
 
 === Running scenario: tools-call-with-logging ===
-2026/04/19 23:37:22 SSEHub: unregistered connection cf622a8d18a72911d7660a0042d0dd96 (total: 0)
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: d32682b0c5ce94e4c2eb1369764dff50
 Running client scenario 'tools-call-with-logging' against server: http://localhost:18799/mcp
-2026/04/19 23:37:22 Received kill signal.  Quitting Writer. stop 0x31b4a0f385b0
-2026/04/19 23:37:22 Cleaning up writer...
-2026/04/19 23:37:22 Finished cleaning up writer:  0x31b4a0f385b0
-2026/04/19 23:37:22 Closed MCP-GET-SSE SSE connection: cf622a8d18a72911d7660a0042d0dd96
-2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: 5c3c94cc470dc4a860808d372aefbd3f
-2026/04/19 23:37:22 SSEHub: registered connection 5c3c94cc470dc4a860808d372aefbd3f (total: 1)
-2026/04/19 23:37:23 SSEHub: unregistered connection 5c3c94cc470dc4a860808d372aefbd3f (total: 0)
-2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0e36d20
-2026/04/19 23:37:23 Cleaning up writer...
-2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0e36d20
-2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 5c3c94cc470dc4a860808d372aefbd3f
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: 8e9b4400794f8ce8aac6e01a803c9b14
+2026/04/20 02:14:51 SSEHub: registered connection 8e9b4400794f8ce8aac6e01a803c9b14 (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection 8e9b4400794f8ce8aac6e01a803c9b14 (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc32467e0
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc32467e0
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: 8e9b4400794f8ce8aac6e01a803c9b14
 
 === Running scenario: tools-call-error ===
 Running client scenario 'tools-call-error' against server: http://localhost:18799/mcp
-2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 4d4f605f8b6a3c6e7b976677a7c78fac
-2026/04/19 23:37:23 SSEHub: registered connection 4d4f605f8b6a3c6e7b976677a7c78fac (total: 1)
-2026/04/19 23:37:23 SSEHub: unregistered connection 4d4f605f8b6a3c6e7b976677a7c78fac (total: 0)
-2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0b15180
-2026/04/19 23:37:23 Cleaning up writer...
-2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0b15180
-2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 4d4f605f8b6a3c6e7b976677a7c78fac
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: ca4b0479819862d9094f8ca402e7c0a5
+2026/04/20 02:14:51 SSEHub: registered connection ca4b0479819862d9094f8ca402e7c0a5 (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection ca4b0479819862d9094f8ca402e7c0a5 (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc3340a80
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc3340a80
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: ca4b0479819862d9094f8ca402e7c0a5
 
 === Running scenario: tools-call-with-progress ===
 Running client scenario 'tools-call-with-progress' against server: http://localhost:18799/mcp
-2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 1b88cbbe8aeeb56da6696e97ec93fd5f
-2026/04/19 23:37:23 SSEHub: registered connection 1b88cbbe8aeeb56da6696e97ec93fd5f (total: 1)
-2026/04/19 23:37:23 SSEHub: unregistered connection 1b88cbbe8aeeb56da6696e97ec93fd5f (total: 0)
-2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0f388c0
-2026/04/19 23:37:23 Cleaning up writer...
-2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0f388c0
-2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 1b88cbbe8aeeb56da6696e97ec93fd5f
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: fb14e696228293c784a5aa9bde8be138
+2026/04/20 02:14:51 SSEHub: registered connection fb14e696228293c784a5aa9bde8be138 (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection fb14e696228293c784a5aa9bde8be138 (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc36b67e0
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc36b67e0
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: fb14e696228293c784a5aa9bde8be138
 
 === Running scenario: tools-call-sampling ===
 Running client scenario 'tools-call-sampling' against server: http://localhost:18799/mcp
-2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 086d4eacc6f20d40ea4258dfd911be7d
-2026/04/19 23:37:23 SSEHub: registered connection 086d4eacc6f20d40ea4258dfd911be7d (total: 1)
-2026/04/19 23:37:23 SSEHub: unregistered connection 086d4eacc6f20d40ea4258dfd911be7d (total: 0)
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: 2e44ca1cf0c992f661f90489e8450b17
+2026/04/20 02:14:51 SSEHub: registered connection 2e44ca1cf0c992f661f90489e8450b17 (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection 2e44ca1cf0c992f661f90489e8450b17 (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc3246a80
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc3246a80
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: 2e44ca1cf0c992f661f90489e8450b17
 
 === Running scenario: tools-call-elicitation ===
-2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0f38b60
-2026/04/19 23:37:23 Cleaning up writer...
 Running client scenario 'tools-call-elicitation' against server: http://localhost:18799/mcp
-2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0f38b60
-2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 086d4eacc6f20d40ea4258dfd911be7d
-2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 0e7021f6fa4825de1c9624c63bedffc3
-2026/04/19 23:37:23 SSEHub: registered connection 0e7021f6fa4825de1c9624c63bedffc3 (total: 1)
-2026/04/19 23:37:23 SSEHub: unregistered connection 0e7021f6fa4825de1c9624c63bedffc3 (total: 0)
-2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0f38f50
-2026/04/19 23:37:23 Cleaning up writer...
-2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0f38f50
-2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 0e7021f6fa4825de1c9624c63bedffc3
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: 727113de984db481e5507b6acbac453a
+2026/04/20 02:14:51 SSEHub: registered connection 727113de984db481e5507b6acbac453a (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection 727113de984db481e5507b6acbac453a (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc3246cb0
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc3246cb0
 
 === Running scenario: elicitation-sep1034-defaults ===
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: 727113de984db481e5507b6acbac453a
 Running client scenario 'elicitation-sep1034-defaults' against server: http://localhost:18799/mcp
-2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 477d10535fc22ca961eb8b870a592b2a
-2026/04/19 23:37:23 SSEHub: registered connection 477d10535fc22ca961eb8b870a592b2a (total: 1)
-2026/04/19 23:37:23 SSEHub: unregistered connection 477d10535fc22ca961eb8b870a592b2a (total: 0)
-2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0a62a10
-2026/04/19 23:37:23 Cleaning up writer...
-2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0a62a10
-2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 477d10535fc22ca961eb8b870a592b2a
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: 1a27a6e19d98324aae861eb9d0fee768
+2026/04/20 02:14:51 SSEHub: registered connection 1a27a6e19d98324aae861eb9d0fee768 (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection 1a27a6e19d98324aae861eb9d0fee768 (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc3247110
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc3247110
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: 1a27a6e19d98324aae861eb9d0fee768
 
 === Running scenario: server-sse-multiple-streams ===
 Running client scenario 'server-sse-multiple-streams' against server: http://localhost:18799/mcp
-2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 9d6f6d4f1641ac895133bb086d425fc4
-2026/04/19 23:37:23 SSEHub: registered connection 9d6f6d4f1641ac895133bb086d425fc4 (total: 1)
-2026/04/19 23:37:23 SSEHub: unregistered connection 9d6f6d4f1641ac895133bb086d425fc4 (total: 0)
-2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0b15490
-2026/04/19 23:37:23 Cleaning up writer...
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: ed20fa5a641788c5873387ee14c2544d
+2026/04/20 02:14:51 SSEHub: registered connection ed20fa5a641788c5873387ee14c2544d (total: 1)
 
 === Running scenario: elicitation-sep1330-enums ===
-2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0b15490
+2026/04/20 02:14:51 SSEHub: unregistered connection ed20fa5a641788c5873387ee14c2544d (total: 0)
 Running client scenario 'elicitation-sep1330-enums' against server: http://localhost:18799/mcp
-2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 9d6f6d4f1641ac895133bb086d425fc4
-2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: cb0ac37cc1852d3213f7ee30717df7cd
-2026/04/19 23:37:23 SSEHub: registered connection cb0ac37cc1852d3213f7ee30717df7cd (total: 1)
-2026/04/19 23:37:23 SSEHub: unregistered connection cb0ac37cc1852d3213f7ee30717df7cd (total: 0)
-2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0b15810
-2026/04/19 23:37:23 Cleaning up writer...
-2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0b15810
-2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: cb0ac37cc1852d3213f7ee30717df7cd
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc3340ee0
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc3340ee0
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: ed20fa5a641788c5873387ee14c2544d
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: 71c43442f5321bbd8aa449b61cbeb22f
+2026/04/20 02:14:51 SSEHub: registered connection 71c43442f5321bbd8aa449b61cbeb22f (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection 71c43442f5321bbd8aa449b61cbeb22f (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc33411f0
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc33411f0
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: 71c43442f5321bbd8aa449b61cbeb22f
 
 === Running scenario: resources-list ===
 Running client scenario 'resources-list' against server: http://localhost:18799/mcp
-2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 17ba27e0fac9c99ebbfa2a1e2a34e6ef
-2026/04/19 23:37:23 SSEHub: registered connection 17ba27e0fac9c99ebbfa2a1e2a34e6ef (total: 1)
-2026/04/19 23:37:23 SSEHub: unregistered connection 17ba27e0fac9c99ebbfa2a1e2a34e6ef (total: 0)
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: 39efa5997d37f7f6bf5b96e3437b03cb
+2026/04/20 02:14:51 SSEHub: registered connection 39efa5997d37f7f6bf5b96e3437b03cb (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection 39efa5997d37f7f6bf5b96e3437b03cb (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc338d7a0
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc338d7a0
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: 39efa5997d37f7f6bf5b96e3437b03cb
 
 === Running scenario: resources-read-text ===
-2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0a62e00
-2026/04/19 23:37:23 Cleaning up writer...
 Running client scenario 'resources-read-text' against server: http://localhost:18799/mcp
-2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0a62e00
-2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 17ba27e0fac9c99ebbfa2a1e2a34e6ef
-2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 25c118c25e1f64d4963e336f26f8ec86
-2026/04/19 23:37:23 SSEHub: registered connection 25c118c25e1f64d4963e336f26f8ec86 (total: 1)
-2026/04/19 23:37:23 SSEHub: unregistered connection 25c118c25e1f64d4963e336f26f8ec86 (total: 0)
-2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0e373b0
-2026/04/19 23:37:23 Cleaning up writer...
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: bde4cb00d5d65a0e84da0e90e5dbed5e
+2026/04/20 02:14:51 SSEHub: registered connection bde4cb00d5d65a0e84da0e90e5dbed5e (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection bde4cb00d5d65a0e84da0e90e5dbed5e (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc36b6f50
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc36b6f50
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: bde4cb00d5d65a0e84da0e90e5dbed5e
 
 === Running scenario: resources-read-binary ===
-2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0e373b0
 Running client scenario 'resources-read-binary' against server: http://localhost:18799/mcp
-2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 25c118c25e1f64d4963e336f26f8ec86
-2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 9ec716cb233e869cbac5ef4694f7f7d8
-2026/04/19 23:37:23 SSEHub: registered connection 9ec716cb233e869cbac5ef4694f7f7d8 (total: 1)
-2026/04/19 23:37:23 SSEHub: unregistered connection 9ec716cb233e869cbac5ef4694f7f7d8 (total: 0)
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: 8cce76ca38ba7ff275e648883b5959b7
+2026/04/20 02:14:51 SSEHub: registered connection 8cce76ca38ba7ff275e648883b5959b7 (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection 8cce76ca38ba7ff275e648883b5959b7 (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc36b7180
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc36b7180
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: 8cce76ca38ba7ff275e648883b5959b7
 
 === Running scenario: resources-templates-read ===
-2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0b15b20
-2026/04/19 23:37:23 Cleaning up writer...
 Running client scenario 'resources-templates-read' against server: http://localhost:18799/mcp
-2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0b15b20
-2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 9ec716cb233e869cbac5ef4694f7f7d8
-2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 2a3fe347294da8127767e1dc06d000c2
-2026/04/19 23:37:23 SSEHub: registered connection 2a3fe347294da8127767e1dc06d000c2 (total: 1)
-2026/04/19 23:37:23 SSEHub: unregistered connection 2a3fe347294da8127767e1dc06d000c2 (total: 0)
-2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0e30150
-2026/04/19 23:37:23 Cleaning up writer...
-2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0e30150
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: da0ef1c6ab078925dcb9e8ac84ea984b
+2026/04/20 02:14:51 SSEHub: registered connection da0ef1c6ab078925dcb9e8ac84ea984b (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection da0ef1c6ab078925dcb9e8ac84ea984b (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc338dab0
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc338dab0
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: da0ef1c6ab078925dcb9e8ac84ea984b
 
 === Running scenario: resources-subscribe ===
-2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 2a3fe347294da8127767e1dc06d000c2
 Running client scenario 'resources-subscribe' against server: http://localhost:18799/mcp
-2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 96c5814ee364aa0e72ac38f20de40773
-2026/04/19 23:37:23 SSEHub: registered connection 96c5814ee364aa0e72ac38f20de40773 (total: 1)
-2026/04/19 23:37:23 SSEHub: unregistered connection 96c5814ee364aa0e72ac38f20de40773 (total: 0)
-2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0b15d50
-2026/04/19 23:37:23 Cleaning up writer...
-2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0b15d50
-2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 96c5814ee364aa0e72ac38f20de40773
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: c834663119e2f6ecaf9a616871e616d9
+2026/04/20 02:14:51 SSEHub: registered connection c834663119e2f6ecaf9a616871e616d9 (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection c834663119e2f6ecaf9a616871e616d9 (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc3341500
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc3341500
 
 === Running scenario: resources-unsubscribe ===
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: c834663119e2f6ecaf9a616871e616d9
 Running client scenario 'resources-unsubscribe' against server: http://localhost:18799/mcp
-2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 02792683620fb595bcefb04fb332a473
-2026/04/19 23:37:23 SSEHub: registered connection 02792683620fb595bcefb04fb332a473 (total: 1)
-2026/04/19 23:37:23 SSEHub: unregistered connection 02792683620fb595bcefb04fb332a473 (total: 0)
-2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0e30460
-2026/04/19 23:37:23 Cleaning up writer...
-2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0e30460
-2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 02792683620fb595bcefb04fb332a473
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: 3a8dc0954f3ce86bf12b39020ea9bd48
+2026/04/20 02:14:51 SSEHub: registered connection 3a8dc0954f3ce86bf12b39020ea9bd48 (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection 3a8dc0954f3ce86bf12b39020ea9bd48 (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc3341730
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc3341730
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: 3a8dc0954f3ce86bf12b39020ea9bd48
 
 === Running scenario: prompts-list ===
 Running client scenario 'prompts-list' against server: http://localhost:18799/mcp
-2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 9b7508e663f11e45ced3313184ca73e4
-2026/04/19 23:37:23 SSEHub: registered connection 9b7508e663f11e45ced3313184ca73e4 (total: 1)
-2026/04/19 23:37:23 SSEHub: unregistered connection 9b7508e663f11e45ced3313184ca73e4 (total: 0)
-2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0cd80e0
-2026/04/19 23:37:23 Cleaning up writer...
-2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0cd80e0
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: e5b0395a991f9ab9a9d305b83d000fc1
+2026/04/20 02:14:51 SSEHub: registered connection e5b0395a991f9ab9a9d305b83d000fc1 (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection e5b0395a991f9ab9a9d305b83d000fc1 (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc338dd50
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc338dd50
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: e5b0395a991f9ab9a9d305b83d000fc1
 
 === Running scenario: prompts-get-simple ===
-2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 9b7508e663f11e45ced3313184ca73e4
 Running client scenario 'prompts-get-simple' against server: http://localhost:18799/mcp
-2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 9569eaf0b71eec1a57a48e8884dc5e9d
-2026/04/19 23:37:23 SSEHub: registered connection 9569eaf0b71eec1a57a48e8884dc5e9d (total: 1)
-2026/04/19 23:37:23 SSEHub: unregistered connection 9569eaf0b71eec1a57a48e8884dc5e9d (total: 0)
-2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0cd8380
-2026/04/19 23:37:23 Cleaning up writer...
-2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0cd8380
-2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 9569eaf0b71eec1a57a48e8884dc5e9d
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: 5e089648c1df1fedbd26ff9b3b26d8cb
+2026/04/20 02:14:51 SSEHub: registered connection 5e089648c1df1fedbd26ff9b3b26d8cb (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection 5e089648c1df1fedbd26ff9b3b26d8cb (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc3341960
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc3341960
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: 5e089648c1df1fedbd26ff9b3b26d8cb
 
 === Running scenario: prompts-get-with-args ===
 Running client scenario 'prompts-get-with-args' against server: http://localhost:18799/mcp
-2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 8a8fa096ad8bcabd021f7838e5a7d6ea
-2026/04/19 23:37:23 SSEHub: registered connection 8a8fa096ad8bcabd021f7838e5a7d6ea (total: 1)
-2026/04/19 23:37:23 SSEHub: unregistered connection 8a8fa096ad8bcabd021f7838e5a7d6ea (total: 0)
-2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0e37650
-2026/04/19 23:37:23 Cleaning up writer...
-2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0e37650
-2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 8a8fa096ad8bcabd021f7838e5a7d6ea
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: b8b965149a3167cb5dbf48084b06ce6d
+2026/04/20 02:14:51 SSEHub: registered connection b8b965149a3167cb5dbf48084b06ce6d (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection b8b965149a3167cb5dbf48084b06ce6d (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc36141c0
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc36141c0
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: b8b965149a3167cb5dbf48084b06ce6d
 
 === Running scenario: prompts-get-embedded-resource ===
 Running client scenario 'prompts-get-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: ba09f56cdd75b3b3ed848afe2f9a385a
-2026/04/19 23:37:23 SSEHub: registered connection ba09f56cdd75b3b3ed848afe2f9a385a (total: 1)
-2026/04/19 23:37:23 SSEHub: unregistered connection ba09f56cdd75b3b3ed848afe2f9a385a (total: 0)
-2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0e307e0
-2026/04/19 23:37:23 Cleaning up writer...
-2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0e307e0
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: 6c85cf675bb28b76081c02e9f1e3fd31
+2026/04/20 02:14:51 SSEHub: registered connection 6c85cf675bb28b76081c02e9f1e3fd31 (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection 6c85cf675bb28b76081c02e9f1e3fd31 (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc36b7420
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc36b7420
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: 6c85cf675bb28b76081c02e9f1e3fd31
 
 === Running scenario: prompts-get-with-image ===
-2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: ba09f56cdd75b3b3ed848afe2f9a385a
 Running client scenario 'prompts-get-with-image' against server: http://localhost:18799/mcp
-2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 512b0f815ce7e93ac6b685c0a3dfaa38
-2026/04/19 23:37:23 SSEHub: registered connection 512b0f815ce7e93ac6b685c0a3dfaa38 (total: 1)
-2026/04/19 23:37:23 SSEHub: unregistered connection 512b0f815ce7e93ac6b685c0a3dfaa38 (total: 0)
-2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0cd8620
-2026/04/19 23:37:23 Cleaning up writer...
-2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0cd8620
-2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 512b0f815ce7e93ac6b685c0a3dfaa38
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: de2f7eead9094acfff009b1a451155c3
+2026/04/20 02:14:51 SSEHub: registered connection de2f7eead9094acfff009b1a451155c3 (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection de2f7eead9094acfff009b1a451155c3 (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc3614540
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc3614540
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: de2f7eead9094acfff009b1a451155c3
 
 === Running scenario: dns-rebinding-protection ===
 Running client scenario 'dns-rebinding-protection' against server: http://localhost:18799/mcp
@@ -470,22 +470,22 @@ Starting scenario: auth/token-endpoint-auth-basic
 Starting scenario: auth/token-endpoint-auth-post
 Starting scenario: auth/token-endpoint-auth-none
 Starting scenario: auth/pre-registration
-Executing client: ./bin/testclient http://localhost:61533/mcp
-Executing client: ./bin/testclient http://localhost:61534/mcp
-Executing client: ./bin/testclient http://localhost:61535/mcp
-Executing client: ./bin/testclient http://localhost:61536/mcp
-Executing client: ./bin/testclient http://localhost:61537/mcp
-Executing client: ./bin/testclient http://localhost:61538/mcp
-Executing client: ./bin/testclient http://localhost:61539/mcp
-Executing client: ./bin/testclient http://localhost:61540/mcp
-Executing client: ./bin/testclient http://localhost:61541/mcp
-Executing client: ./bin/testclient http://localhost:61542/mcp
-Executing client: ./bin/testclient http://localhost:61543/mcp
-Executing client: ./bin/testclient http://localhost:61544/mcp
-Executing client: ./bin/testclient http://localhost:61545/mcp
-Executing client: ./bin/testclient http://localhost:61546/mcp
+Executing client: ./bin/testclient http://localhost:59425/mcp
+Executing client: ./bin/testclient http://localhost:59426/mcp
+Executing client: ./bin/testclient http://localhost:59427/mcp
+Executing client: ./bin/testclient http://localhost:59428/mcp
+Executing client: ./bin/testclient http://localhost:59429/mcp
+Executing client: ./bin/testclient http://localhost:59430/mcp
+Executing client: ./bin/testclient http://localhost:59431/mcp
+Executing client: ./bin/testclient http://localhost:59432/mcp
+Executing client: ./bin/testclient http://localhost:59433/mcp
+Executing client: ./bin/testclient http://localhost:59434/mcp
+Executing client: ./bin/testclient http://localhost:59435/mcp
+Executing client: ./bin/testclient http://localhost:59436/mcp
+Executing client: ./bin/testclient http://localhost:59437/mcp
+Executing client: ./bin/testclient http://localhost:59438/mcp
 With context: {"client_id":"pre-registered-client","client_secret":"pre-registered-secret"}
-(node:98398) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
+(node:74182) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
 (Use `node --trace-deprecation ...` to show where the warning was created)
 
 === SUITE SUMMARY ===
@@ -559,10 +559,10 @@ Waiting for Keycloak realm...
     token_refresh_test.go:22: Keycloak not reachable at http://localhost:8180: Get "http://localhost:8180/realms/mcpkit-test": dial tcp [::1]:8180: connect: connection refused (run 'make upkcl' to start)
 --- SKIP: TestKeycloak_TokenRefresh_PasswordGrant (0.00s)
 PASS
-ok  	github.com/panyam/mcpkit/tests/keycloak	0.417s
+ok  	github.com/panyam/mcpkit/tests/keycloak	0.645s
 make[2]: *** No rule to make target `downkcl'.  Stop.
 
 === Results: 10 passed, 0 failed ===
-Finished: Sun Apr 19 23:39:28 PDT 2026
+Finished: Mon Apr 20 02:16:58 PDT 2026
 </pre>
 </body></html>

--- a/tests/reports/run.log
+++ b/tests/reports/run.log
@@ -1,33 +1,33 @@
 === MCPKit Comprehensive Test Suite ===
-Started: Sun Apr 19 23:36:39 PDT 2026
+Started: Mon Apr 20 02:14:02 PDT 2026
 
 --- [1/10] unit+coverage ---
   PASS: unit+coverage
 go test -coverprofile=tests/reports/coverage.out ./... -count=1 -timeout 30s
-ok  	github.com/panyam/mcpkit/client	8.548s	coverage: 67.1% of statements
+ok  	github.com/panyam/mcpkit/client	8.833s	coverage: 67.1% of statements
 	github.com/panyam/mcpkit/cmd/testserver		coverage: 0.0% of statements
-ok  	github.com/panyam/mcpkit/core	0.745s	coverage: 52.4% of statements
-ok  	github.com/panyam/mcpkit/server	7.658s	coverage: 77.4% of statements
-ok  	github.com/panyam/mcpkit/testutil	1.061s	coverage: 69.4% of statements
+ok  	github.com/panyam/mcpkit/core	0.725s	coverage: 51.6% of statements
+ok  	github.com/panyam/mcpkit/server	7.877s	coverage: 77.4% of statements
+ok  	github.com/panyam/mcpkit/testutil	0.944s	coverage: 69.4% of statements
 go tool cover -html=tests/reports/coverage.out -o tests/reports/coverage.html
 Coverage report: tests/reports/coverage.html
 --- [2/10] race ---
   PASS: race
 go test -race ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/client	9.612s
+ok  	github.com/panyam/mcpkit/client	9.307s
 ?   	github.com/panyam/mcpkit/cmd/testserver	[no test files]
-ok  	github.com/panyam/mcpkit/core	2.632s
-ok  	github.com/panyam/mcpkit/server	9.616s
-ok  	github.com/panyam/mcpkit/testutil	2.885s
+ok  	github.com/panyam/mcpkit/core	1.362s
+ok  	github.com/panyam/mcpkit/server	8.860s
+ok  	github.com/panyam/mcpkit/testutil	1.818s
 --- [3/10] auth ---
   PASS: auth
 cd ext/auth && go test ./... -count=1 -timeout 30s
-ok  	github.com/panyam/mcpkit/ext/auth	0.345s
+ok  	github.com/panyam/mcpkit/ext/auth	0.597s
 --- [4/10] ui ---
   PASS: ui
 cd ext/ui && /Library/Developer/CommandLineTools/usr/bin/make test
 go test ./... -count=1 -timeout 30s
-ok  	github.com/panyam/mcpkit/ext/ui	0.355s
+ok  	github.com/panyam/mcpkit/ext/ui	0.646s
 cd assets && pnpm install --frozen-lockfile --silent && pnpm test
 
 > @mcpkit/app-bridge@0.1.0 test /Users/dzshrh/newstack/mcpkit/main/ext/ui/assets
@@ -36,21 +36,21 @@ cd assets && pnpm install --frozen-lockfile --silent && pnpm test
 
  RUN  v3.2.4 /Users/dzshrh/newstack/mcpkit/main/ext/ui/assets
 
- ✓ mcp-app-bridge.test.ts (33 tests) 384ms
+ ✓ mcp-app-bridge.test.ts (33 tests) 385ms
 
  Test Files  1 passed (1)
       Tests  33 passed (33)
-   Start at  23:37:02
-   Duration  995ms (transform 26ms, setup 0ms, collect 26ms, tests 384ms, environment 316ms, prepare 101ms)
+   Start at  02:14:28
+   Duration  1.05s (transform 35ms, setup 0ms, collect 29ms, tests 385ms, environment 297ms, prepare 124ms)
 
 --- [5/10] protogen ---
   PASS: protogen
 cd experimental/ext/protogen && go test ./... -count=1 -timeout 30s && /Library/Developer/CommandLineTools/usr/bin/make test-e2e
 ?   	github.com/panyam/mcpkit/experimental/ext/protogen/cmd/protoc-gen-go-mcp	[no test files]
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/generator	1.240s
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/proto/mcp/v1	0.648s
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/runtime	0.383s
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/schema	0.953s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/generator	0.591s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/proto/mcp/v1	1.249s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/runtime	0.888s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/schema	0.955s
 ?   	github.com/panyam/mcpkit/experimental/ext/protogen/testutil	[no test files]
 go build -o bin/protoc-gen-go-mcp ./cmd/protoc-gen-go-mcp
 go install ./cmd/protoc-gen-go-mcp
@@ -59,23 +59,23 @@ cd ../../../examples/protogen/bookservice && rm -rf gen && buf generate && go te
 [33mWARN[0m	plugin "protoc-gen-go-mcp" does not support required features.
   Feature "proto3 optional" is required by 1 file(s):
     bookservice/v1/service.proto
-ok  	github.com/panyam/mcpkit/examples/protogen/bookservice	0.425s
+ok  	github.com/panyam/mcpkit/examples/protogen/bookservice	0.746s
 ==> e2e: passed
 --- [6/10] e2e ---
   PASS: e2e
 cd tests/e2e && go test ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/tests/e2e	3.751s
-ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.422s
+ok  	github.com/panyam/mcpkit/tests/e2e	4.415s
+ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.795s
 --- [7/10] experimental ---
   PASS: experimental
 cd experimental/telegram-events && go test ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/experimental/telegram-events	5.234s
+ok  	github.com/panyam/mcpkit/experimental/telegram-events	5.474s
 --- [8/10] conformance ---
   PASS: conformance
 bash scripts/conformance-test.sh
 Killing stale process on port 18799...
 === Starting test server on :18799 (Streamable HTTP) ===
-Waiting for server....2026/04/19 23:37:20 MCP test server listening on :18799 (Streamable HTTP at /mcp)
+Waiting for server.....2026/04/20 02:14:49 MCP test server listening on :18799 (Streamable HTTP at /mcp)
  ready
 
 === Running MCP conformance suite ===
@@ -86,293 +86,293 @@ Running active suite (30 scenarios) against http://localhost:18799/mcp
 
 === Running scenario: server-initialize ===
 Running client scenario 'server-initialize' against server: http://localhost:18799/mcp
-2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: 199953dc2d69f6c6b6455f8bb4b1d1e4
-2026/04/19 23:37:22 SSEHub: registered connection 199953dc2d69f6c6b6455f8bb4b1d1e4 (total: 1)
-2026/04/19 23:37:22 SSEHub: unregistered connection 199953dc2d69f6c6b6455f8bb4b1d1e4 (total: 0)
-2026/04/19 23:37:22 Received kill signal.  Quitting Writer. stop 0x31b4a0f38150
-2026/04/19 23:37:22 Cleaning up writer...
-2026/04/19 23:37:22 Finished cleaning up writer:  0x31b4a0f38150
-2026/04/19 23:37:22 Closed MCP-GET-SSE SSE connection: 199953dc2d69f6c6b6455f8bb4b1d1e4
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: ca583b0c95c320a571e897e57a4e5af9
+2026/04/20 02:14:51 SSEHub: registered connection ca583b0c95c320a571e897e57a4e5af9 (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection ca583b0c95c320a571e897e57a4e5af9 (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc36b61c0
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc36b61c0
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: ca583b0c95c320a571e897e57a4e5af9
 
 === Running scenario: logging-set-level ===
 Running client scenario 'logging-set-level' against server: http://localhost:18799/mcp
-2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: aa39c6bee73cdb5838e490382e214970
-2026/04/19 23:37:22 SSEHub: registered connection aa39c6bee73cdb5838e490382e214970 (total: 1)
-2026/04/19 23:37:22 SSEHub: unregistered connection aa39c6bee73cdb5838e490382e214970 (total: 0)
-2026/04/19 23:37:22 Received kill signal.  Quitting Writer. stop 0x31b4a0e36230
-2026/04/19 23:37:22 Cleaning up writer...
-2026/04/19 23:37:22 Finished cleaning up writer:  0x31b4a0e36230
-2026/04/19 23:37:22 Closed MCP-GET-SSE SSE connection: aa39c6bee73cdb5838e490382e214970
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: 0115ace1d87619020a7f9de954031fdb
+2026/04/20 02:14:51 SSEHub: registered connection 0115ace1d87619020a7f9de954031fdb (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection 0115ace1d87619020a7f9de954031fdb (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc338c8c0
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc338c8c0
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: 0115ace1d87619020a7f9de954031fdb
 
 === Running scenario: ping ===
 Running client scenario 'ping' against server: http://localhost:18799/mcp
-2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: 993e660ec0575e457a77ac88540e9a39
-2026/04/19 23:37:22 SSEHub: registered connection 993e660ec0575e457a77ac88540e9a39 (total: 1)
-2026/04/19 23:37:22 SSEHub: unregistered connection 993e660ec0575e457a77ac88540e9a39 (total: 0)
-2026/04/19 23:37:22 Received kill signal.  Quitting Writer. stop 0x31b4a0e364d0
-2026/04/19 23:37:22 Cleaning up writer...
-2026/04/19 23:37:22 Finished cleaning up writer:  0x31b4a0e364d0
-2026/04/19 23:37:22 Closed MCP-GET-SSE SSE connection: 993e660ec0575e457a77ac88540e9a39
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: 66cf6d51799e69ae2138c7f9928f828a
+2026/04/20 02:14:51 SSEHub: registered connection 66cf6d51799e69ae2138c7f9928f828a (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection 66cf6d51799e69ae2138c7f9928f828a (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc36b61c0
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc36b61c0
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: 66cf6d51799e69ae2138c7f9928f828a
 
 === Running scenario: completion-complete ===
 Running client scenario 'completion-complete' against server: http://localhost:18799/mcp
-2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: 7c7809131a91c729822f93f9ae911728
-2026/04/19 23:37:22 SSEHub: registered connection 7c7809131a91c729822f93f9ae911728 (total: 1)
-2026/04/19 23:37:22 SSEHub: unregistered connection 7c7809131a91c729822f93f9ae911728 (total: 0)
-2026/04/19 23:37:22 Received kill signal.  Quitting Writer. stop 0x31b4a0b14a10
-2026/04/19 23:37:22 Cleaning up writer...
-2026/04/19 23:37:22 Finished cleaning up writer:  0x31b4a0b14a10
-2026/04/19 23:37:22 Closed MCP-GET-SSE SSE connection: 7c7809131a91c729822f93f9ae911728
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: ae8a4be050dec976005ee75171f7e6d5
+2026/04/20 02:14:51 SSEHub: registered connection ae8a4be050dec976005ee75171f7e6d5 (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection ae8a4be050dec976005ee75171f7e6d5 (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc338cd90
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc338cd90
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: ae8a4be050dec976005ee75171f7e6d5
 
 === Running scenario: tools-list ===
 Running client scenario 'tools-list' against server: http://localhost:18799/mcp
-2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: 933c84a2644c4379fccf13a19fb835ba
-2026/04/19 23:37:22 SSEHub: registered connection 933c84a2644c4379fccf13a19fb835ba (total: 1)
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: 485a2a2c277de96ae25e489f0e482673
+2026/04/20 02:14:51 SSEHub: registered connection 485a2a2c277de96ae25e489f0e482673 (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection 485a2a2c277de96ae25e489f0e482673 (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc36b6460
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc36b6460
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: 485a2a2c277de96ae25e489f0e482673
 
 === Running scenario: tools-call-simple-text ===
-2026/04/19 23:37:22 SSEHub: unregistered connection 933c84a2644c4379fccf13a19fb835ba (total: 0)
 Running client scenario 'tools-call-simple-text' against server: http://localhost:18799/mcp
-2026/04/19 23:37:22 Received kill signal.  Quitting Writer. stop 0x31b4a0b14c40
-2026/04/19 23:37:22 Cleaning up writer...
-2026/04/19 23:37:22 Finished cleaning up writer:  0x31b4a0b14c40
-2026/04/19 23:37:22 Closed MCP-GET-SSE SSE connection: 933c84a2644c4379fccf13a19fb835ba
-2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: f374b21d34ec91c720f89b4cbc55527b
-2026/04/19 23:37:22 SSEHub: registered connection f374b21d34ec91c720f89b4cbc55527b (total: 1)
-2026/04/19 23:37:22 SSEHub: unregistered connection f374b21d34ec91c720f89b4cbc55527b (total: 0)
-2026/04/19 23:37:22 Received kill signal.  Quitting Writer. stop 0x31b4a0b14e70
-2026/04/19 23:37:22 Cleaning up writer...
-2026/04/19 23:37:22 Finished cleaning up writer:  0x31b4a0b14e70
-2026/04/19 23:37:22 Closed MCP-GET-SSE SSE connection: f374b21d34ec91c720f89b4cbc55527b
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: a36a895f51a1f6cf0e3abec8384ab09d
+2026/04/20 02:14:51 SSEHub: registered connection a36a895f51a1f6cf0e3abec8384ab09d (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection a36a895f51a1f6cf0e3abec8384ab09d (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc3246310
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc3246310
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: a36a895f51a1f6cf0e3abec8384ab09d
 
 === Running scenario: tools-call-image ===
 Running client scenario 'tools-call-image' against server: http://localhost:18799/mcp
-2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: 2dc9e9e7cd2a5a5f86e6e21389d10a0f
-2026/04/19 23:37:22 SSEHub: registered connection 2dc9e9e7cd2a5a5f86e6e21389d10a0f (total: 1)
-2026/04/19 23:37:22 SSEHub: unregistered connection 2dc9e9e7cd2a5a5f86e6e21389d10a0f (total: 0)
-2026/04/19 23:37:22 Received kill signal.  Quitting Writer. stop 0x31b4a0e36850
-2026/04/19 23:37:22 Cleaning up writer...
-2026/04/19 23:37:22 Finished cleaning up writer:  0x31b4a0e36850
-2026/04/19 23:37:22 Closed MCP-GET-SSE SSE connection: 2dc9e9e7cd2a5a5f86e6e21389d10a0f
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: 839d97dc317bb0adae96c799053ad652
+2026/04/20 02:14:51 SSEHub: registered connection 839d97dc317bb0adae96c799053ad652 (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection 839d97dc317bb0adae96c799053ad652 (total: 0)
 
 === Running scenario: tools-call-audio ===
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc3340380
+2026/04/20 02:14:51 Cleaning up writer...
 Running client scenario 'tools-call-audio' against server: http://localhost:18799/mcp
-2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: 6c4635a21f83c810dbfd1718f2d50ace
-2026/04/19 23:37:22 SSEHub: registered connection 6c4635a21f83c810dbfd1718f2d50ace (total: 1)
-2026/04/19 23:37:22 SSEHub: unregistered connection 6c4635a21f83c810dbfd1718f2d50ace (total: 0)
-2026/04/19 23:37:22 Received kill signal.  Quitting Writer. stop 0x31b4a0a623f0
-2026/04/19 23:37:22 Cleaning up writer...
-2026/04/19 23:37:22 Finished cleaning up writer:  0x31b4a0a623f0
-2026/04/19 23:37:22 Closed MCP-GET-SSE SSE connection: 6c4635a21f83c810dbfd1718f2d50ace
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc3340380
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: 839d97dc317bb0adae96c799053ad652
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: e6549e95cf5331fe9fceefa5f88881ca
+2026/04/20 02:14:51 SSEHub: registered connection e6549e95cf5331fe9fceefa5f88881ca (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection e6549e95cf5331fe9fceefa5f88881ca (total: 0)
 
 === Running scenario: tools-call-embedded-resource ===
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc3340700
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc3340700
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: e6549e95cf5331fe9fceefa5f88881ca
 Running client scenario 'tools-call-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: 01c6ebf03176df1b52be5bf2321af125
-2026/04/19 23:37:22 SSEHub: registered connection 01c6ebf03176df1b52be5bf2321af125 (total: 1)
-2026/04/19 23:37:22 SSEHub: unregistered connection 01c6ebf03176df1b52be5bf2321af125 (total: 0)
-2026/04/19 23:37:22 Received kill signal.  Quitting Writer. stop 0x31b4a0f38380
-2026/04/19 23:37:22 Cleaning up writer...
-2026/04/19 23:37:22 Finished cleaning up writer:  0x31b4a0f38380
-2026/04/19 23:37:22 Closed MCP-GET-SSE SSE connection: 01c6ebf03176df1b52be5bf2321af125
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: 82947507b05388be8258dd3c1e1e3e4d
+2026/04/20 02:14:51 SSEHub: registered connection 82947507b05388be8258dd3c1e1e3e4d (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection 82947507b05388be8258dd3c1e1e3e4d (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc338d2d0
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc338d2d0
 
 === Running scenario: tools-call-mixed-content ===
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: 82947507b05388be8258dd3c1e1e3e4d
 Running client scenario 'tools-call-mixed-content' against server: http://localhost:18799/mcp
-2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: cf622a8d18a72911d7660a0042d0dd96
-2026/04/19 23:37:22 SSEHub: registered connection cf622a8d18a72911d7660a0042d0dd96 (total: 1)
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: d32682b0c5ce94e4c2eb1369764dff50
+2026/04/20 02:14:51 SSEHub: registered connection d32682b0c5ce94e4c2eb1369764dff50 (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection d32682b0c5ce94e4c2eb1369764dff50 (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc338d500
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc338d500
 
 === Running scenario: tools-call-with-logging ===
-2026/04/19 23:37:22 SSEHub: unregistered connection cf622a8d18a72911d7660a0042d0dd96 (total: 0)
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: d32682b0c5ce94e4c2eb1369764dff50
 Running client scenario 'tools-call-with-logging' against server: http://localhost:18799/mcp
-2026/04/19 23:37:22 Received kill signal.  Quitting Writer. stop 0x31b4a0f385b0
-2026/04/19 23:37:22 Cleaning up writer...
-2026/04/19 23:37:22 Finished cleaning up writer:  0x31b4a0f385b0
-2026/04/19 23:37:22 Closed MCP-GET-SSE SSE connection: cf622a8d18a72911d7660a0042d0dd96
-2026/04/19 23:37:22 Starting MCP-GET-SSE SSE connection: 5c3c94cc470dc4a860808d372aefbd3f
-2026/04/19 23:37:22 SSEHub: registered connection 5c3c94cc470dc4a860808d372aefbd3f (total: 1)
-2026/04/19 23:37:23 SSEHub: unregistered connection 5c3c94cc470dc4a860808d372aefbd3f (total: 0)
-2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0e36d20
-2026/04/19 23:37:23 Cleaning up writer...
-2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0e36d20
-2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 5c3c94cc470dc4a860808d372aefbd3f
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: 8e9b4400794f8ce8aac6e01a803c9b14
+2026/04/20 02:14:51 SSEHub: registered connection 8e9b4400794f8ce8aac6e01a803c9b14 (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection 8e9b4400794f8ce8aac6e01a803c9b14 (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc32467e0
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc32467e0
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: 8e9b4400794f8ce8aac6e01a803c9b14
 
 === Running scenario: tools-call-error ===
 Running client scenario 'tools-call-error' against server: http://localhost:18799/mcp
-2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 4d4f605f8b6a3c6e7b976677a7c78fac
-2026/04/19 23:37:23 SSEHub: registered connection 4d4f605f8b6a3c6e7b976677a7c78fac (total: 1)
-2026/04/19 23:37:23 SSEHub: unregistered connection 4d4f605f8b6a3c6e7b976677a7c78fac (total: 0)
-2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0b15180
-2026/04/19 23:37:23 Cleaning up writer...
-2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0b15180
-2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 4d4f605f8b6a3c6e7b976677a7c78fac
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: ca4b0479819862d9094f8ca402e7c0a5
+2026/04/20 02:14:51 SSEHub: registered connection ca4b0479819862d9094f8ca402e7c0a5 (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection ca4b0479819862d9094f8ca402e7c0a5 (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc3340a80
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc3340a80
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: ca4b0479819862d9094f8ca402e7c0a5
 
 === Running scenario: tools-call-with-progress ===
 Running client scenario 'tools-call-with-progress' against server: http://localhost:18799/mcp
-2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 1b88cbbe8aeeb56da6696e97ec93fd5f
-2026/04/19 23:37:23 SSEHub: registered connection 1b88cbbe8aeeb56da6696e97ec93fd5f (total: 1)
-2026/04/19 23:37:23 SSEHub: unregistered connection 1b88cbbe8aeeb56da6696e97ec93fd5f (total: 0)
-2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0f388c0
-2026/04/19 23:37:23 Cleaning up writer...
-2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0f388c0
-2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 1b88cbbe8aeeb56da6696e97ec93fd5f
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: fb14e696228293c784a5aa9bde8be138
+2026/04/20 02:14:51 SSEHub: registered connection fb14e696228293c784a5aa9bde8be138 (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection fb14e696228293c784a5aa9bde8be138 (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc36b67e0
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc36b67e0
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: fb14e696228293c784a5aa9bde8be138
 
 === Running scenario: tools-call-sampling ===
 Running client scenario 'tools-call-sampling' against server: http://localhost:18799/mcp
-2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 086d4eacc6f20d40ea4258dfd911be7d
-2026/04/19 23:37:23 SSEHub: registered connection 086d4eacc6f20d40ea4258dfd911be7d (total: 1)
-2026/04/19 23:37:23 SSEHub: unregistered connection 086d4eacc6f20d40ea4258dfd911be7d (total: 0)
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: 2e44ca1cf0c992f661f90489e8450b17
+2026/04/20 02:14:51 SSEHub: registered connection 2e44ca1cf0c992f661f90489e8450b17 (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection 2e44ca1cf0c992f661f90489e8450b17 (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc3246a80
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc3246a80
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: 2e44ca1cf0c992f661f90489e8450b17
 
 === Running scenario: tools-call-elicitation ===
-2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0f38b60
-2026/04/19 23:37:23 Cleaning up writer...
 Running client scenario 'tools-call-elicitation' against server: http://localhost:18799/mcp
-2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0f38b60
-2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 086d4eacc6f20d40ea4258dfd911be7d
-2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 0e7021f6fa4825de1c9624c63bedffc3
-2026/04/19 23:37:23 SSEHub: registered connection 0e7021f6fa4825de1c9624c63bedffc3 (total: 1)
-2026/04/19 23:37:23 SSEHub: unregistered connection 0e7021f6fa4825de1c9624c63bedffc3 (total: 0)
-2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0f38f50
-2026/04/19 23:37:23 Cleaning up writer...
-2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0f38f50
-2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 0e7021f6fa4825de1c9624c63bedffc3
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: 727113de984db481e5507b6acbac453a
+2026/04/20 02:14:51 SSEHub: registered connection 727113de984db481e5507b6acbac453a (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection 727113de984db481e5507b6acbac453a (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc3246cb0
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc3246cb0
 
 === Running scenario: elicitation-sep1034-defaults ===
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: 727113de984db481e5507b6acbac453a
 Running client scenario 'elicitation-sep1034-defaults' against server: http://localhost:18799/mcp
-2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 477d10535fc22ca961eb8b870a592b2a
-2026/04/19 23:37:23 SSEHub: registered connection 477d10535fc22ca961eb8b870a592b2a (total: 1)
-2026/04/19 23:37:23 SSEHub: unregistered connection 477d10535fc22ca961eb8b870a592b2a (total: 0)
-2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0a62a10
-2026/04/19 23:37:23 Cleaning up writer...
-2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0a62a10
-2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 477d10535fc22ca961eb8b870a592b2a
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: 1a27a6e19d98324aae861eb9d0fee768
+2026/04/20 02:14:51 SSEHub: registered connection 1a27a6e19d98324aae861eb9d0fee768 (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection 1a27a6e19d98324aae861eb9d0fee768 (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc3247110
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc3247110
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: 1a27a6e19d98324aae861eb9d0fee768
 
 === Running scenario: server-sse-multiple-streams ===
 Running client scenario 'server-sse-multiple-streams' against server: http://localhost:18799/mcp
-2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 9d6f6d4f1641ac895133bb086d425fc4
-2026/04/19 23:37:23 SSEHub: registered connection 9d6f6d4f1641ac895133bb086d425fc4 (total: 1)
-2026/04/19 23:37:23 SSEHub: unregistered connection 9d6f6d4f1641ac895133bb086d425fc4 (total: 0)
-2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0b15490
-2026/04/19 23:37:23 Cleaning up writer...
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: ed20fa5a641788c5873387ee14c2544d
+2026/04/20 02:14:51 SSEHub: registered connection ed20fa5a641788c5873387ee14c2544d (total: 1)
 
 === Running scenario: elicitation-sep1330-enums ===
-2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0b15490
+2026/04/20 02:14:51 SSEHub: unregistered connection ed20fa5a641788c5873387ee14c2544d (total: 0)
 Running client scenario 'elicitation-sep1330-enums' against server: http://localhost:18799/mcp
-2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 9d6f6d4f1641ac895133bb086d425fc4
-2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: cb0ac37cc1852d3213f7ee30717df7cd
-2026/04/19 23:37:23 SSEHub: registered connection cb0ac37cc1852d3213f7ee30717df7cd (total: 1)
-2026/04/19 23:37:23 SSEHub: unregistered connection cb0ac37cc1852d3213f7ee30717df7cd (total: 0)
-2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0b15810
-2026/04/19 23:37:23 Cleaning up writer...
-2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0b15810
-2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: cb0ac37cc1852d3213f7ee30717df7cd
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc3340ee0
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc3340ee0
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: ed20fa5a641788c5873387ee14c2544d
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: 71c43442f5321bbd8aa449b61cbeb22f
+2026/04/20 02:14:51 SSEHub: registered connection 71c43442f5321bbd8aa449b61cbeb22f (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection 71c43442f5321bbd8aa449b61cbeb22f (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc33411f0
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc33411f0
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: 71c43442f5321bbd8aa449b61cbeb22f
 
 === Running scenario: resources-list ===
 Running client scenario 'resources-list' against server: http://localhost:18799/mcp
-2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 17ba27e0fac9c99ebbfa2a1e2a34e6ef
-2026/04/19 23:37:23 SSEHub: registered connection 17ba27e0fac9c99ebbfa2a1e2a34e6ef (total: 1)
-2026/04/19 23:37:23 SSEHub: unregistered connection 17ba27e0fac9c99ebbfa2a1e2a34e6ef (total: 0)
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: 39efa5997d37f7f6bf5b96e3437b03cb
+2026/04/20 02:14:51 SSEHub: registered connection 39efa5997d37f7f6bf5b96e3437b03cb (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection 39efa5997d37f7f6bf5b96e3437b03cb (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc338d7a0
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc338d7a0
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: 39efa5997d37f7f6bf5b96e3437b03cb
 
 === Running scenario: resources-read-text ===
-2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0a62e00
-2026/04/19 23:37:23 Cleaning up writer...
 Running client scenario 'resources-read-text' against server: http://localhost:18799/mcp
-2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0a62e00
-2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 17ba27e0fac9c99ebbfa2a1e2a34e6ef
-2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 25c118c25e1f64d4963e336f26f8ec86
-2026/04/19 23:37:23 SSEHub: registered connection 25c118c25e1f64d4963e336f26f8ec86 (total: 1)
-2026/04/19 23:37:23 SSEHub: unregistered connection 25c118c25e1f64d4963e336f26f8ec86 (total: 0)
-2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0e373b0
-2026/04/19 23:37:23 Cleaning up writer...
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: bde4cb00d5d65a0e84da0e90e5dbed5e
+2026/04/20 02:14:51 SSEHub: registered connection bde4cb00d5d65a0e84da0e90e5dbed5e (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection bde4cb00d5d65a0e84da0e90e5dbed5e (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc36b6f50
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc36b6f50
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: bde4cb00d5d65a0e84da0e90e5dbed5e
 
 === Running scenario: resources-read-binary ===
-2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0e373b0
 Running client scenario 'resources-read-binary' against server: http://localhost:18799/mcp
-2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 25c118c25e1f64d4963e336f26f8ec86
-2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 9ec716cb233e869cbac5ef4694f7f7d8
-2026/04/19 23:37:23 SSEHub: registered connection 9ec716cb233e869cbac5ef4694f7f7d8 (total: 1)
-2026/04/19 23:37:23 SSEHub: unregistered connection 9ec716cb233e869cbac5ef4694f7f7d8 (total: 0)
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: 8cce76ca38ba7ff275e648883b5959b7
+2026/04/20 02:14:51 SSEHub: registered connection 8cce76ca38ba7ff275e648883b5959b7 (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection 8cce76ca38ba7ff275e648883b5959b7 (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc36b7180
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc36b7180
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: 8cce76ca38ba7ff275e648883b5959b7
 
 === Running scenario: resources-templates-read ===
-2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0b15b20
-2026/04/19 23:37:23 Cleaning up writer...
 Running client scenario 'resources-templates-read' against server: http://localhost:18799/mcp
-2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0b15b20
-2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 9ec716cb233e869cbac5ef4694f7f7d8
-2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 2a3fe347294da8127767e1dc06d000c2
-2026/04/19 23:37:23 SSEHub: registered connection 2a3fe347294da8127767e1dc06d000c2 (total: 1)
-2026/04/19 23:37:23 SSEHub: unregistered connection 2a3fe347294da8127767e1dc06d000c2 (total: 0)
-2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0e30150
-2026/04/19 23:37:23 Cleaning up writer...
-2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0e30150
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: da0ef1c6ab078925dcb9e8ac84ea984b
+2026/04/20 02:14:51 SSEHub: registered connection da0ef1c6ab078925dcb9e8ac84ea984b (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection da0ef1c6ab078925dcb9e8ac84ea984b (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc338dab0
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc338dab0
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: da0ef1c6ab078925dcb9e8ac84ea984b
 
 === Running scenario: resources-subscribe ===
-2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 2a3fe347294da8127767e1dc06d000c2
 Running client scenario 'resources-subscribe' against server: http://localhost:18799/mcp
-2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 96c5814ee364aa0e72ac38f20de40773
-2026/04/19 23:37:23 SSEHub: registered connection 96c5814ee364aa0e72ac38f20de40773 (total: 1)
-2026/04/19 23:37:23 SSEHub: unregistered connection 96c5814ee364aa0e72ac38f20de40773 (total: 0)
-2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0b15d50
-2026/04/19 23:37:23 Cleaning up writer...
-2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0b15d50
-2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 96c5814ee364aa0e72ac38f20de40773
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: c834663119e2f6ecaf9a616871e616d9
+2026/04/20 02:14:51 SSEHub: registered connection c834663119e2f6ecaf9a616871e616d9 (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection c834663119e2f6ecaf9a616871e616d9 (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc3341500
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc3341500
 
 === Running scenario: resources-unsubscribe ===
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: c834663119e2f6ecaf9a616871e616d9
 Running client scenario 'resources-unsubscribe' against server: http://localhost:18799/mcp
-2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 02792683620fb595bcefb04fb332a473
-2026/04/19 23:37:23 SSEHub: registered connection 02792683620fb595bcefb04fb332a473 (total: 1)
-2026/04/19 23:37:23 SSEHub: unregistered connection 02792683620fb595bcefb04fb332a473 (total: 0)
-2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0e30460
-2026/04/19 23:37:23 Cleaning up writer...
-2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0e30460
-2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 02792683620fb595bcefb04fb332a473
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: 3a8dc0954f3ce86bf12b39020ea9bd48
+2026/04/20 02:14:51 SSEHub: registered connection 3a8dc0954f3ce86bf12b39020ea9bd48 (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection 3a8dc0954f3ce86bf12b39020ea9bd48 (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc3341730
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc3341730
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: 3a8dc0954f3ce86bf12b39020ea9bd48
 
 === Running scenario: prompts-list ===
 Running client scenario 'prompts-list' against server: http://localhost:18799/mcp
-2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 9b7508e663f11e45ced3313184ca73e4
-2026/04/19 23:37:23 SSEHub: registered connection 9b7508e663f11e45ced3313184ca73e4 (total: 1)
-2026/04/19 23:37:23 SSEHub: unregistered connection 9b7508e663f11e45ced3313184ca73e4 (total: 0)
-2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0cd80e0
-2026/04/19 23:37:23 Cleaning up writer...
-2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0cd80e0
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: e5b0395a991f9ab9a9d305b83d000fc1
+2026/04/20 02:14:51 SSEHub: registered connection e5b0395a991f9ab9a9d305b83d000fc1 (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection e5b0395a991f9ab9a9d305b83d000fc1 (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc338dd50
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc338dd50
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: e5b0395a991f9ab9a9d305b83d000fc1
 
 === Running scenario: prompts-get-simple ===
-2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 9b7508e663f11e45ced3313184ca73e4
 Running client scenario 'prompts-get-simple' against server: http://localhost:18799/mcp
-2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 9569eaf0b71eec1a57a48e8884dc5e9d
-2026/04/19 23:37:23 SSEHub: registered connection 9569eaf0b71eec1a57a48e8884dc5e9d (total: 1)
-2026/04/19 23:37:23 SSEHub: unregistered connection 9569eaf0b71eec1a57a48e8884dc5e9d (total: 0)
-2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0cd8380
-2026/04/19 23:37:23 Cleaning up writer...
-2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0cd8380
-2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 9569eaf0b71eec1a57a48e8884dc5e9d
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: 5e089648c1df1fedbd26ff9b3b26d8cb
+2026/04/20 02:14:51 SSEHub: registered connection 5e089648c1df1fedbd26ff9b3b26d8cb (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection 5e089648c1df1fedbd26ff9b3b26d8cb (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc3341960
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc3341960
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: 5e089648c1df1fedbd26ff9b3b26d8cb
 
 === Running scenario: prompts-get-with-args ===
 Running client scenario 'prompts-get-with-args' against server: http://localhost:18799/mcp
-2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 8a8fa096ad8bcabd021f7838e5a7d6ea
-2026/04/19 23:37:23 SSEHub: registered connection 8a8fa096ad8bcabd021f7838e5a7d6ea (total: 1)
-2026/04/19 23:37:23 SSEHub: unregistered connection 8a8fa096ad8bcabd021f7838e5a7d6ea (total: 0)
-2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0e37650
-2026/04/19 23:37:23 Cleaning up writer...
-2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0e37650
-2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 8a8fa096ad8bcabd021f7838e5a7d6ea
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: b8b965149a3167cb5dbf48084b06ce6d
+2026/04/20 02:14:51 SSEHub: registered connection b8b965149a3167cb5dbf48084b06ce6d (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection b8b965149a3167cb5dbf48084b06ce6d (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc36141c0
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc36141c0
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: b8b965149a3167cb5dbf48084b06ce6d
 
 === Running scenario: prompts-get-embedded-resource ===
 Running client scenario 'prompts-get-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: ba09f56cdd75b3b3ed848afe2f9a385a
-2026/04/19 23:37:23 SSEHub: registered connection ba09f56cdd75b3b3ed848afe2f9a385a (total: 1)
-2026/04/19 23:37:23 SSEHub: unregistered connection ba09f56cdd75b3b3ed848afe2f9a385a (total: 0)
-2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0e307e0
-2026/04/19 23:37:23 Cleaning up writer...
-2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0e307e0
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: 6c85cf675bb28b76081c02e9f1e3fd31
+2026/04/20 02:14:51 SSEHub: registered connection 6c85cf675bb28b76081c02e9f1e3fd31 (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection 6c85cf675bb28b76081c02e9f1e3fd31 (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc36b7420
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc36b7420
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: 6c85cf675bb28b76081c02e9f1e3fd31
 
 === Running scenario: prompts-get-with-image ===
-2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: ba09f56cdd75b3b3ed848afe2f9a385a
 Running client scenario 'prompts-get-with-image' against server: http://localhost:18799/mcp
-2026/04/19 23:37:23 Starting MCP-GET-SSE SSE connection: 512b0f815ce7e93ac6b685c0a3dfaa38
-2026/04/19 23:37:23 SSEHub: registered connection 512b0f815ce7e93ac6b685c0a3dfaa38 (total: 1)
-2026/04/19 23:37:23 SSEHub: unregistered connection 512b0f815ce7e93ac6b685c0a3dfaa38 (total: 0)
-2026/04/19 23:37:23 Received kill signal.  Quitting Writer. stop 0x31b4a0cd8620
-2026/04/19 23:37:23 Cleaning up writer...
-2026/04/19 23:37:23 Finished cleaning up writer:  0x31b4a0cd8620
-2026/04/19 23:37:23 Closed MCP-GET-SSE SSE connection: 512b0f815ce7e93ac6b685c0a3dfaa38
+2026/04/20 02:14:51 Starting MCP-GET-SSE SSE connection: de2f7eead9094acfff009b1a451155c3
+2026/04/20 02:14:51 SSEHub: registered connection de2f7eead9094acfff009b1a451155c3 (total: 1)
+2026/04/20 02:14:51 SSEHub: unregistered connection de2f7eead9094acfff009b1a451155c3 (total: 0)
+2026/04/20 02:14:51 Received kill signal.  Quitting Writer. stop 0xdbc3614540
+2026/04/20 02:14:51 Cleaning up writer...
+2026/04/20 02:14:51 Finished cleaning up writer:  0xdbc3614540
+2026/04/20 02:14:51 Closed MCP-GET-SSE SSE connection: de2f7eead9094acfff009b1a451155c3
 
 === Running scenario: dns-rebinding-protection ===
 Running client scenario 'dns-rebinding-protection' against server: http://localhost:18799/mcp
@@ -438,22 +438,22 @@ Starting scenario: auth/token-endpoint-auth-basic
 Starting scenario: auth/token-endpoint-auth-post
 Starting scenario: auth/token-endpoint-auth-none
 Starting scenario: auth/pre-registration
-Executing client: ./bin/testclient http://localhost:61533/mcp
-Executing client: ./bin/testclient http://localhost:61534/mcp
-Executing client: ./bin/testclient http://localhost:61535/mcp
-Executing client: ./bin/testclient http://localhost:61536/mcp
-Executing client: ./bin/testclient http://localhost:61537/mcp
-Executing client: ./bin/testclient http://localhost:61538/mcp
-Executing client: ./bin/testclient http://localhost:61539/mcp
-Executing client: ./bin/testclient http://localhost:61540/mcp
-Executing client: ./bin/testclient http://localhost:61541/mcp
-Executing client: ./bin/testclient http://localhost:61542/mcp
-Executing client: ./bin/testclient http://localhost:61543/mcp
-Executing client: ./bin/testclient http://localhost:61544/mcp
-Executing client: ./bin/testclient http://localhost:61545/mcp
-Executing client: ./bin/testclient http://localhost:61546/mcp
+Executing client: ./bin/testclient http://localhost:59425/mcp
+Executing client: ./bin/testclient http://localhost:59426/mcp
+Executing client: ./bin/testclient http://localhost:59427/mcp
+Executing client: ./bin/testclient http://localhost:59428/mcp
+Executing client: ./bin/testclient http://localhost:59429/mcp
+Executing client: ./bin/testclient http://localhost:59430/mcp
+Executing client: ./bin/testclient http://localhost:59431/mcp
+Executing client: ./bin/testclient http://localhost:59432/mcp
+Executing client: ./bin/testclient http://localhost:59433/mcp
+Executing client: ./bin/testclient http://localhost:59434/mcp
+Executing client: ./bin/testclient http://localhost:59435/mcp
+Executing client: ./bin/testclient http://localhost:59436/mcp
+Executing client: ./bin/testclient http://localhost:59437/mcp
+Executing client: ./bin/testclient http://localhost:59438/mcp
 With context: {"client_id":"pre-registered-client","client_secret":"pre-registered-secret"}
-(node:98398) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
+(node:74182) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
 (Use `node --trace-deprecation ...` to show where the warning was created)
 
 === SUITE SUMMARY ===
@@ -527,8 +527,8 @@ Waiting for Keycloak realm...
     token_refresh_test.go:22: Keycloak not reachable at http://localhost:8180: Get "http://localhost:8180/realms/mcpkit-test": dial tcp [::1]:8180: connect: connection refused (run 'make upkcl' to start)
 --- SKIP: TestKeycloak_TokenRefresh_PasswordGrant (0.00s)
 PASS
-ok  	github.com/panyam/mcpkit/tests/keycloak	0.417s
+ok  	github.com/panyam/mcpkit/tests/keycloak	0.645s
 make[2]: *** No rule to make target `downkcl'.  Stop.
 
 === Results: 10 passed, 0 failed ===
-Finished: Sun Apr 19 23:39:28 PDT 2026
+Finished: Mon Apr 20 02:16:58 PDT 2026


### PR DESCRIPTION
## Summary

Tasks are scoped to the session that created them. Cross-session access denied.

## What changed

| Layer | Change |
|-------|--------|
| `core/session.go` | `sessionID` on `sessionCtx`, `SetSessionID`/`GetSessionID`, `BaseContext.SessionID()` |
| `server/server.go` | `dispatchWithOpts` sets sessionID from dispatcher |
| `TaskStore` interface | All methods take `sessionID` parameter |
| `InMemoryTaskStore` | `sessionAllowed()` check, `getEntry()` helper |
| Middleware | Captures sessionID, passes to `store.Create()` |
| Method handlers | Use `ctx.SessionID()` for all store calls |
| `TaskContext` | Stores sessionID for background goroutine store calls |

Empty sessionID = no restriction (backward compatible with tests, stateless mode, stdio).

## Tests (5 new, 73 total)

| Test | What |
|------|------|
| `TestStoreSessionIsolationGet` | Session B can't see session A's task |
| `TestStoreSessionIsolationUpdate` | Session B can't update session A's task |
| `TestStoreSessionIsolationCancel` | Session B can't cancel session A's task |
| `TestStoreSessionIsolationList` | List filters by session |
| `TestStoreSessionEmptyAllowsAccess` | Empty session = access all (backward compat) |

## run-exercises.sh

Added exercises 10-16 covering all phases:
- 10: session isolation (passes now)
- 11-16: phases 4-8 (show expected vs actual for unimplemented phases)

## Test plan

- [x] `cd experimental/ext/tasks && go test ./...` — 73 tests pass
- [x] `go test ./core/ ./server/` — no regressions
- [ ] `bash run-exercises.sh` against Go server
- [ ] `bash run-exercises.sh` against TS reference server