### PR TITLE
feat(tasks): Phase 5 (cancellation) + Phase 6 (status notifications)

### DIFF
--- a/docs/TASKS_GAP_PLAN.md
+++ b/docs/TASKS_GAP_PLAN.md
@@ -68,27 +68,20 @@ Key TS files:
 
 - [ ] **4d. Migrate middleware to use new atomic API**
 
-## Phase 5: Cancellation Propagation
+## Phase 5: Cancellation Propagation ✅ COMPLETE
 **Goal**: Cancelled tasks stop their goroutines.
 
-- [ ] **5a. Use `context.WithCancel` inside `DetachForBackground`**
-  - Store cancel func in taskRuntime
-  - `Cancel()` calls cancel func after marking status
+- [x] **5a.** `context.WithCancel` on detached context, cancel func in `activeTask` struct (C2)
+- [x] **5b.** Cancel handler calls `rt.cancelTask()` → goroutine's `ctx.Done()` fires
+- [x] **5c.** `TestTaskCancelStopsGoroutine` + example `slow_compute` checks `ctx.Err()`
 
-- [ ] **5b. Tool handlers receive cancelled context**
-
-- [ ] **5c. Tests** — cancel while running, verify goroutine exits
-
-## Phase 6: Status Notifications
+## Phase 6: Status Notifications ✅ COMPLETE (Option 1)
 **Goal**: Clients receive push notifications on status changes.
 
-- [ ] **6a. Wrap store with `RequestTaskStore` pattern**
-  - Auto-send `notifications/tasks/status` on every status change
-  - Ref: `taskManager.ts:657-712`
-
-- [ ] **6b. Define `TaskStatusNotification` type** in `core/task.go`
-
-- [ ] **6c. Tests** — client receives notification after status change
+- [x] **6a.** `notifyTaskStatus()` sends `notifications/tasks/status` after status changes
+- [x] **6b.** Cancel handler + tasks/result handler + TaskContext.SetStatus all notify
+- [x] **6c.** `TestTaskStatusNotificationOnComplete` + `TestTaskStatusNotificationOnCancel`
+- [ ] **6d.** Queue-based notification storage for replay/reliability (#288)
 
 ## Phase 7: Progress Notifications ✅ PARTIAL
 **Goal**: Progress notifications flow through task lifecycle.

--- a/examples/tasks/README.md
+++ b/examples/tasks/README.md
@@ -422,9 +422,9 @@ Complete a task, then try to store another result (internal API — no curl equi
 
 ---
 
-## Phase 5: Cancellation Propagation 🔲
+## Phase 5: Cancellation Propagation ✅
 
-> **Status**: Not yet implemented. Cancel marks the status but doesn't stop the goroutine.
+> **Status**: Implemented. Cancel stops the background goroutine via context cancellation.
 
 ### 12. Cancel actually stops the work
 
@@ -451,14 +451,14 @@ mcp http://localhost:$PORT/mcp \
   -d "{\"jsonrpc\":\"2.0\",\"id\":21,\"method\":\"tasks/cancel\",\"params\":{\"taskId\":\"$TASK_ID\"}}"
 ```
 
-**Expected (after Phase 5):** The server log shows the goroutine exited. Server resource usage drops.
-**Today:** Status shows `cancelled` but the goroutine keeps sleeping for 60 seconds. Server log shows `[slow_compute] finished "long"` after 60s even though it was cancelled.
+**Expected:** Server log shows `[slow_compute] cancelled "long" at N/60`. Goroutine exits immediately.
+**Behavior:** `context.WithCancel` propagates to the tool handler's `ctx.Done()` channel.
 
 ---
 
-## Phase 6: Status Notifications 🔲
+## Phase 6: Status Notifications ✅
 
-> **Status**: Not yet implemented. Clients must poll — no push notifications.
+> **Status**: Implemented. Status notifications sent via cancel handler and tasks/result handler.
 
 ### 13. Receive status change notifications
 

--- a/examples/tasks/main.go
+++ b/examples/tasks/main.go
@@ -86,8 +86,14 @@ func main() {
 				progressToken = tc.TaskID()
 			}
 			for i := 1; i <= args.Seconds; i++ {
-				time.Sleep(1 * time.Second)
-				ctx.EmitProgress(progressToken, float64(i), float64(args.Seconds), fmt.Sprintf("%s: %d/%d", args.Label, i, args.Seconds))
+				select {
+				case <-ctx.Done():
+					// Task was cancelled (Phase 5) — exit early.
+					log.Printf("[slow_compute] cancelled %q at %d/%d", args.Label, i, args.Seconds)
+					return core.TextResult(fmt.Sprintf("Computation %q cancelled at %d/%d.", args.Label, i, args.Seconds)), nil
+				case <-time.After(1 * time.Second):
+					ctx.EmitProgress(progressToken, float64(i), float64(args.Seconds), fmt.Sprintf("%s: %d/%d", args.Label, i, args.Seconds))
+				}
 			}
 			log.Printf("[slow_compute] finished %q", args.Label)
 

--- a/server/task_session.go
+++ b/server/task_session.go
@@ -71,12 +71,16 @@ func (tc *TaskContext) TaskID() string {
 	return tc.taskID
 }
 
-// SetStatus transitions the task to a new status. Exposed for testing
-// and advanced use cases where direct status control is needed.
+// SetStatus transitions the task to a new status and sends a
+// notifications/tasks/status notification (Phase 6).
 func (tc *TaskContext) SetStatus(status core.TaskStatus) error {
-	return tc.store.Update(tc.taskID, tc.sessionID, func(t *core.TaskInfo) {
+	err := tc.store.Update(tc.taskID, tc.sessionID, func(t *core.TaskInfo) {
 		t.Status = status
 	})
+	if err == nil {
+		notifyTaskStatus(tc.Context, tc.store, tc.taskID, tc.sessionID)
+	}
+	return err
 }
 
 // TaskElicit sends an elicitation request to the client via the tasks/result

--- a/server/tasks_experimental.go
+++ b/server/tasks_experimental.go
@@ -53,35 +53,41 @@ func (c *TasksConfig) defaults() {
 	}
 }
 
+// activeTask holds per-task runtime state for a running async task (C2: consolidated struct).
+type activeTask struct {
+	requests chan sideChannelRequest // read by tasks/result handler for side-channel proxying
+	cancel   context.CancelFunc     // cancels the background goroutine's context (Phase 5)
+}
+
 // taskRuntime holds the per-registration state shared between the middleware
 // and the tasks/* method handlers. Scoped to a single Register() call —
 // no package-level globals.
 type taskRuntime struct {
-	store   TaskStore
-	queue   TaskMessageQueue
-	mu      sync.Mutex
-	channels map[string]chan sideChannelRequest // taskID → side-channel request channel
+	store  TaskStore
+	queue  TaskMessageQueue
+	mu     sync.Mutex
+	active map[string]*activeTask
 }
 
 func newTaskRuntime(store TaskStore, queue TaskMessageQueue) *taskRuntime {
 	return &taskRuntime{
-		store:    store,
-		queue:    queue,
-		channels: make(map[string]chan sideChannelRequest),
+		store:  store,
+		queue:  queue,
+		active: make(map[string]*activeTask),
 	}
 }
 
-// registerChannel stores the side-channel request channel for a task.
-func (rt *taskRuntime) registerChannel(taskID string, ch chan sideChannelRequest) {
+// register stores the active task entry.
+func (rt *taskRuntime) register(taskID string, at *activeTask) {
 	rt.mu.Lock()
-	rt.channels[taskID] = ch
+	rt.active[taskID] = at
 	rt.mu.Unlock()
 }
 
-// unregisterChannel removes the side-channel request channel for a task.
-func (rt *taskRuntime) unregisterChannel(taskID string) {
+// unregister removes the active task entry.
+func (rt *taskRuntime) unregister(taskID string) {
 	rt.mu.Lock()
-	delete(rt.channels, taskID)
+	delete(rt.active, taskID)
 	rt.mu.Unlock()
 }
 
@@ -89,7 +95,19 @@ func (rt *taskRuntime) unregisterChannel(taskID string) {
 func (rt *taskRuntime) getChannel(taskID string) chan sideChannelRequest {
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
-	return rt.channels[taskID]
+	if at := rt.active[taskID]; at != nil {
+		return at.requests
+	}
+	return nil
+}
+
+// cancelTask cancels the background goroutine for a task (Phase 5).
+func (rt *taskRuntime) cancelTask(taskID string) {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	if at := rt.active[taskID]; at != nil && at.cancel != nil {
+		at.cancel()
+	}
 }
 
 // Register hooks up tasks support on the given server:
@@ -206,11 +224,20 @@ func taskMiddleware(reg *Registry, rt *taskRuntime, cfg TasksConfig) Middleware 
 
 		// Run the tool asynchronously. Detach from client context so
 		// the tool continues even if the client disconnects.
-		// The sessionID is captured here so the background goroutine
-		// uses the same session for all store operations.
+		// context.WithCancel gives us a cancel func (Phase 5) so
+		// Cancel() can stop the goroutine.
 		go func() {
+			bgCtx := core.DetachForBackground(ctx)
+			bgCtx, cancelFunc := context.WithCancel(bgCtx)
+
+			reqCh := make(chan sideChannelRequest, 1)
+			tc := &TaskContext{taskID: taskID, sessionID: sessionID, store: store, requests: reqCh}
+			bgCtx = WithTaskContext(bgCtx, tc)
+			rt.register(taskID, &activeTask{requests: reqCh, cancel: cancelFunc})
+
 			defer func() {
-				rt.unregisterChannel(taskID)
+				cancelFunc() // ensure cancel is called on exit
+				rt.unregister(taskID)
 				if r := recover(); r != nil {
 					now := time.Now().UTC().Format(time.RFC3339)
 					msg := fmt.Sprintf("panic: %v", r)
@@ -220,47 +247,45 @@ func taskMiddleware(reg *Registry, rt *taskRuntime, cfg TasksConfig) Middleware 
 						t.StatusMessage = msg
 						t.LastUpdatedAt = now
 					})
+					notifyTaskStatus(bgCtx, store, taskID, sessionID)
 				}
 			}()
 
-			bgCtx := core.DetachForBackground(ctx)
-			reqCh := make(chan sideChannelRequest, 1)
-			tc := &TaskContext{taskID: taskID, sessionID: sessionID, store: store, requests: reqCh}
-			bgCtx = WithTaskContext(bgCtx, tc)
-			rt.registerChannel(taskID, reqCh)
 			resp := next(bgCtx, req)
+
+			// If the task was already cancelled (Phase 5), don't overwrite
+			// the terminal status. The cancel handler already set it.
+			if info, ok := store.Get(taskID, sessionID); ok && info.Status.IsTerminal() {
+				return
+			}
 
 			now := time.Now().UTC().Format(time.RFC3339)
 
-			if resp.Error != nil {
-				store.SetResult(taskID, sessionID, core.ErrorResult(resp.Error.Message))
+			// Helper: set terminal status + send notification (Phase 6).
+			setTerminal := func(status core.TaskStatus, result core.ToolResult, statusMsg string) {
+				store.SetResult(taskID, sessionID, result)
 				store.Update(taskID, sessionID, func(t *core.TaskInfo) {
-					t.Status = core.TaskFailed
-					t.StatusMessage = resp.Error.Message
+					t.Status = status
+					t.StatusMessage = statusMsg
 					t.LastUpdatedAt = now
 				})
+				notifyTaskStatus(bgCtx, store, taskID, sessionID)
+			}
+
+			if resp.Error != nil {
+				setTerminal(core.TaskFailed, core.ErrorResult(resp.Error.Message), resp.Error.Message)
 				return
 			}
 
 			raw, err := json.Marshal(resp.Result)
 			if err != nil {
-				store.SetResult(taskID, sessionID, core.ErrorResult("failed to marshal tool result"))
-				store.Update(taskID, sessionID, func(t *core.TaskInfo) {
-					t.Status = core.TaskFailed
-					t.StatusMessage = "failed to marshal tool result"
-					t.LastUpdatedAt = now
-				})
+				setTerminal(core.TaskFailed, core.ErrorResult("failed to marshal tool result"), "failed to marshal tool result")
 				return
 			}
 
 			var toolResult core.ToolResult
 			if err := json.Unmarshal(raw, &toolResult); err != nil {
-				store.SetResult(taskID, sessionID, core.ErrorResult("failed to unmarshal tool result"))
-				store.Update(taskID, sessionID, func(t *core.TaskInfo) {
-					t.Status = core.TaskFailed
-					t.StatusMessage = "failed to unmarshal tool result"
-					t.LastUpdatedAt = now
-				})
+				setTerminal(core.TaskFailed, core.ErrorResult("failed to unmarshal tool result"), "failed to unmarshal tool result")
 				return
 			}
 
@@ -268,11 +293,7 @@ func taskMiddleware(reg *Registry, rt *taskRuntime, cfg TasksConfig) Middleware 
 			if toolResult.IsError {
 				status = core.TaskFailed
 			}
-			store.SetResult(taskID, sessionID, toolResult)
-			store.Update(taskID, sessionID, func(t *core.TaskInfo) {
-				t.Status = status
-				t.LastUpdatedAt = now
-			})
+			setTerminal(status, toolResult, "")
 		}()
 
 		return core.NewResponse(req.ID, core.CreateTaskResult{Task: info})
@@ -346,6 +367,11 @@ func makeResultHandler(rt *taskRuntime) MethodHandler {
 
 				rt.queue.DequeueAll(p.TaskID)
 
+				// Send status notification from this live handler context (Phase 6).
+				// The background goroutine's context may have a dead notifyFunc,
+				// but this handler's MethodContext is always alive.
+				ctx.Notify("notifications/tasks/status", info)
+
 				if result.Meta == nil {
 					result.Meta = &core.ToolResultMeta{}
 				}
@@ -392,8 +418,12 @@ func makeCancelHandler(rt *taskRuntime) MethodHandler {
 		if err != nil {
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, err.Error())
 		}
+		// Stop the background goroutine (Phase 5).
+		rt.cancelTask(p.TaskID)
 		// Clean up any queued messages for the cancelled task.
 		rt.queue.DequeueAll(p.TaskID)
+		// Send status notification (Phase 6).
+		ctx.Notify("notifications/tasks/status", info)
 		// Per spec: tasks/cancel returns flat Result & Task (no wrapper).
 		return core.NewResponse(id, core.CancelTaskResult{TaskInfo: info})
 	}
@@ -405,6 +435,17 @@ func generateTaskID() string {
 	b := make([]byte, 12)
 	rand.Read(b)
 	return "task-" + hex.EncodeToString(b)
+}
+
+// notifyTaskStatus sends a notifications/tasks/status notification with the
+// current task state. Called after every status change (Phase 6).
+// Best-effort — silently drops if no notification channel is available.
+func notifyTaskStatus(ctx context.Context, store TaskStore, taskID, sessionID string) {
+	info, ok := store.Get(taskID, sessionID)
+	if !ok {
+		return
+	}
+	core.Notify(ctx, "notifications/tasks/status", info)
 }
 
 // proxySideChannel proxies a side-channel request (elicitation/sampling)

--- a/server/tasks_experimental_test.go
+++ b/server/tasks_experimental_test.go
@@ -44,7 +44,12 @@ func newTaskServer(t *testing.T) (*Server, chan struct{}) {
 			Execution: &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
 		},
 		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
-			<-unblock
+			// Wait for unblock signal OR context cancellation (Phase 5).
+			select {
+			case <-unblock:
+			case <-ctx.Done():
+				return core.TextResult("cancelled"), nil
+			}
 			var args struct {
 				Data string `json:"data"`
 			}
@@ -1296,4 +1301,155 @@ func TestTaskProgressFromBackgroundNoPanic(t *testing.T) {
 		time.Sleep(50 * time.Millisecond)
 	}
 	t.Fatal("task did not complete in time")
+}
+
+// --- Phase 5+6 tests ---
+
+// TestTaskCancelStopsGoroutine verifies that cancelling a task actually
+// stops the background goroutine via context cancellation (Phase 5).
+// Before Phase 5, the goroutine would keep running after cancel.
+func TestTaskCancelStopsGoroutine(t *testing.T) {
+	srv := NewServer(core.ServerInfo{Name: "cancel-stop-test", Version: "0.0.1"})
+
+	goroutineStopped := make(chan struct{})
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "long-task",
+			Description: "Runs until cancelled",
+			InputSchema: map[string]any{"type": "object"},
+			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
+		},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+			// Wait for cancellation or timeout.
+			select {
+			case <-ctx.Done():
+				close(goroutineStopped)
+				return core.TextResult("cancelled"), nil
+			case <-time.After(30 * time.Second):
+				return core.TextResult("completed"), nil
+			}
+		},
+	)
+	RegisterTasks(TasksConfig{Server: srv})
+	c := connectClient(t, srv)
+
+	created, err := client.ToolCallAsTask(c, "long-task", nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Cancel the task.
+	_, err = client.CancelTask(c, created.Task.TaskID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The goroutine should have exited via ctx.Done().
+	select {
+	case <-goroutineStopped:
+		// success — goroutine received cancellation
+	case <-time.After(2 * time.Second):
+		t.Fatal("goroutine did not stop after cancel — context cancellation not propagated")
+	}
+}
+
+// TestTaskStatusNotificationOnComplete verifies that fetching a completed
+// task's result via tasks/result sends a notifications/tasks/status
+// notification to the client (Phase 6, Option 1).
+func TestTaskStatusNotificationOnComplete(t *testing.T) {
+	srv := NewServer(core.ServerInfo{Name: "notify-test", Version: "0.0.1"})
+
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "fast",
+			Description: "Completes immediately",
+			InputSchema: map[string]any{"type": "object"},
+			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
+		},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+			return core.TextResult("done"), nil
+		},
+	)
+	RegisterTasks(TasksConfig{Server: srv})
+
+	notifications := make(chan core.TaskInfo, 10)
+	c := connectClient(t, srv, client.WithNotificationCallback(func(method string, params any) {
+		if method == "notifications/tasks/status" {
+			raw, _ := json.Marshal(params)
+			var info core.TaskInfo
+			json.Unmarshal(raw, &info)
+			notifications <- info
+		}
+	}))
+
+	created, err := client.ToolCallAsTask(c, "fast", nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Call tasks/result — this triggers the notification (Option 1).
+	client.GetTaskPayload(c, created.Task.TaskID)
+
+	// Wait for the completion notification.
+	select {
+	case info := <-notifications:
+		if info.TaskID != created.Task.TaskID {
+			t.Errorf("notification taskId = %q, want %q", info.TaskID, created.Task.TaskID)
+		}
+		if info.Status != core.TaskCompleted {
+			t.Errorf("notification status = %q, want completed", info.Status)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not receive notifications/tasks/status for completed task")
+	}
+}
+
+// TestTaskStatusNotificationOnCancel verifies that cancelling a task
+// sends a notifications/tasks/status notification (Phase 6).
+func TestTaskStatusNotificationOnCancel(t *testing.T) {
+	srv := NewServer(core.ServerInfo{Name: "notify-cancel-test", Version: "0.0.1"})
+
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "blocking",
+			Description: "Blocks until cancelled",
+			InputSchema: map[string]any{"type": "object"},
+			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
+		},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+			<-ctx.Done()
+			return core.TextResult("cancelled"), nil
+		},
+	)
+	RegisterTasks(TasksConfig{Server: srv})
+
+	notifications := make(chan core.TaskInfo, 10)
+	c := connectClient(t, srv, client.WithNotificationCallback(func(method string, params any) {
+		if method == "notifications/tasks/status" {
+			raw, _ := json.Marshal(params)
+			var info core.TaskInfo
+			json.Unmarshal(raw, &info)
+			notifications <- info
+		}
+	}))
+
+	created, err := client.ToolCallAsTask(c, "blocking", nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.CancelTask(c, created.Task.TaskID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should receive cancelled notification.
+	select {
+	case info := <-notifications:
+		if info.Status != core.TaskCancelled {
+			t.Errorf("notification status = %q, want cancelled", info.Status)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not receive notifications/tasks/status for cancelled task")
+	}
 }

--- a/tests/reports/report.html
+++ b/tests/reports/report.html
@@ -15,7 +15,7 @@ th { background: #f5f5f5; font-weight: 600; }
 pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto; font-size: 13px; max-height: 400px; overflow-y: auto; }
 </style></head><body>
 <h1>MCPKit Test Report</h1>
-<div class='meta'>Branch: <strong>refactor/tasks-to-core</strong> | Commit: <code>7e7db38</code> | Date: 2026-04-20 23:08:25</div>
+<div class='meta'>Branch: <strong>feat/tasks-cancel-notify-phase5-6</strong> | Commit: <code>45498cb</code> | Date: 2026-04-20 23:52:01</div>
 <table><tr><th>Stage</th><th>Result</th></tr>
 <tr><td>unit+coverage</td><td class='pass'>PASS</td></tr>
 <tr><td>race</td><td class='pass'>PASS</td></tr>
@@ -31,35 +31,35 @@ pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto; 
 <div class='summary-pass'>All 10 stages passed</div>
 <h2>Full Log</h2><pre>
 === MCPKit Comprehensive Test Suite ===
-Started: Mon Apr 20 23:05:23 PDT 2026
+Started: Mon Apr 20 23:49:06 PDT 2026
 
 --- [1/10] unit+coverage ---
   PASS: unit+coverage
 go test -coverprofile=tests/reports/coverage.out ./... -count=1 -timeout 30s
-ok  	github.com/panyam/mcpkit/client	8.822s	coverage: 64.7% of statements
+ok  	github.com/panyam/mcpkit/client	9.210s	coverage: 64.7% of statements
 	github.com/panyam/mcpkit/cmd/testserver		coverage: 0.0% of statements
-ok  	github.com/panyam/mcpkit/core	0.622s	coverage: 51.0% of statements
-ok  	github.com/panyam/mcpkit/server	10.109s	coverage: 80.2% of statements
-ok  	github.com/panyam/mcpkit/testutil	0.627s	coverage: 69.4% of statements
+ok  	github.com/panyam/mcpkit/core	0.271s	coverage: 51.0% of statements
+ok  	github.com/panyam/mcpkit/server	9.520s	coverage: 80.9% of statements
+ok  	github.com/panyam/mcpkit/testutil	0.771s	coverage: 69.4% of statements
 go tool cover -html=tests/reports/coverage.out -o tests/reports/coverage.html
 Coverage report: tests/reports/coverage.html
 --- [2/10] race ---
   PASS: race
 go test -race ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/client	9.273s
+ok  	github.com/panyam/mcpkit/client	9.141s
 ?   	github.com/panyam/mcpkit/cmd/testserver	[no test files]
-ok  	github.com/panyam/mcpkit/core	1.577s
-ok  	github.com/panyam/mcpkit/server	11.381s
-ok  	github.com/panyam/mcpkit/testutil	1.523s
+ok  	github.com/panyam/mcpkit/core	1.984s
+ok  	github.com/panyam/mcpkit/server	11.286s
+ok  	github.com/panyam/mcpkit/testutil	2.210s
 --- [3/10] auth ---
   PASS: auth
 cd ext/auth &amp;&amp; go test ./... -count=1 -timeout 30s
-ok  	github.com/panyam/mcpkit/ext/auth	0.598s
+ok  	github.com/panyam/mcpkit/ext/auth	0.294s
 --- [4/10] ui ---
   PASS: ui
 cd ext/ui &amp;&amp; /Library/Developer/CommandLineTools/usr/bin/make test
 go test ./... -count=1 -timeout 30s
-ok  	github.com/panyam/mcpkit/ext/ui	0.570s
+ok  	github.com/panyam/mcpkit/ext/ui	0.288s
 cd assets &amp;&amp; pnpm install --frozen-lockfile --silent &amp;&amp; pnpm test
 
 &gt; @mcpkit/app-bridge@0.1.0 test /Users/dzshrh/newstack/mcpkit/main/ext/ui/assets
@@ -68,21 +68,21 @@ cd assets &amp;&amp; pnpm install --frozen-lockfile --silent &amp;&amp; pnpm tes
 
  RUN  v3.2.4 /Users/dzshrh/newstack/mcpkit/main/ext/ui/assets
 
- ✓ mcp-app-bridge.test.ts (33 tests) 393ms
+ ✓ mcp-app-bridge.test.ts (33 tests) 386ms
 
  Test Files  1 passed (1)
       Tests  33 passed (33)
-   Start at  23:05:54
-   Duration  1.06s (transform 28ms, setup 0ms, collect 26ms, tests 393ms, environment 357ms, prepare 102ms)
+   Start at  23:49:32
+   Duration  1.00s (transform 31ms, setup 0ms, collect 26ms, tests 386ms, environment 272ms, prepare 103ms)
 
 --- [5/10] protogen ---
   PASS: protogen
 cd experimental/ext/protogen &amp;&amp; go test ./... -count=1 -timeout 30s &amp;&amp; /Library/Developer/CommandLineTools/usr/bin/make test-e2e
 ?   	github.com/panyam/mcpkit/experimental/ext/protogen/cmd/protoc-gen-go-mcp	[no test files]
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/generator	0.598s
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/proto/mcp/v1	0.613s
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/runtime	1.161s
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/schema	1.194s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/generator	0.263s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/proto/mcp/v1	0.465s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/runtime	0.703s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/schema	0.930s
 ?   	github.com/panyam/mcpkit/experimental/ext/protogen/testutil	[no test files]
 go build -o bin/protoc-gen-go-mcp ./cmd/protoc-gen-go-mcp
 go install ./cmd/protoc-gen-go-mcp
@@ -91,23 +91,23 @@ cd ../../../examples/protogen/bookservice &amp;&amp; rm -rf gen &amp;&amp; buf g
 [33mWARN[0m	plugin "protoc-gen-go-mcp" does not support required features.
   Feature "proto3 optional" is required by 1 file(s):
     bookservice/v1/service.proto
-ok  	github.com/panyam/mcpkit/examples/protogen/bookservice	0.686s
+ok  	github.com/panyam/mcpkit/examples/protogen/bookservice	0.734s
 ==&gt; e2e: passed
 --- [6/10] e2e ---
   PASS: e2e
 cd tests/e2e &amp;&amp; go test ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/tests/e2e	3.989s
-ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.944s
+ok  	github.com/panyam/mcpkit/tests/e2e	4.562s
+ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.947s
 --- [7/10] experimental ---
   PASS: experimental
 cd experimental/telegram-events &amp;&amp; go test ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/experimental/telegram-events	6.506s
+ok  	github.com/panyam/mcpkit/experimental/telegram-events	6.387s
 --- [8/10] conformance ---
   PASS: conformance
 bash scripts/conformance-test.sh
 Killing stale process on port 18799...
 === Starting test server on :18799 (Streamable HTTP) ===
-Waiting for server.....2026/04/20 23:06:15 MCP test server listening on :18799 (Streamable HTTP at /mcp)
+Waiting for server.....2026/04/20 23:49:53 MCP test server listening on :18799 (Streamable HTTP at /mcp)
  ready
 
 === Running MCP conformance suite ===
@@ -118,293 +118,293 @@ Running active suite (30 scenarios) against http://localhost:18799/mcp
 
 === Running scenario: server-initialize ===
 Running client scenario 'server-initialize' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: e91de6c74b0cb7543bbe6920d31eca74
-2026/04/20 23:06:18 SSEHub: registered connection e91de6c74b0cb7543bbe6920d31eca74 (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection e91de6c74b0cb7543bbe6920d31eca74 (total: 0)
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 4a7cc5c131dc659ce3ff97906d3387b3
+2026/04/20 23:49:55 SSEHub: registered connection 4a7cc5c131dc659ce3ff97906d3387b3 (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection 4a7cc5c131dc659ce3ff97906d3387b3 (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf800f83f0
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf800f83f0
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 4a7cc5c131dc659ce3ff97906d3387b3
 
 === Running scenario: logging-set-level ===
 Running client scenario 'logging-set-level' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c3792640150
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c3792640150
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: e91de6c74b0cb7543bbe6920d31eca74
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: a7ce93a0335a0b12521efa6ae576bdf4
-2026/04/20 23:06:18 SSEHub: registered connection a7ce93a0335a0b12521efa6ae576bdf4 (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection a7ce93a0335a0b12521efa6ae576bdf4 (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c3792640380
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c3792640380
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: a7ce93a0335a0b12521efa6ae576bdf4
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: b9cc0ba05c6690bd330f0c2e2989578e
+2026/04/20 23:49:55 SSEHub: registered connection b9cc0ba05c6690bd330f0c2e2989578e (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection b9cc0ba05c6690bd330f0c2e2989578e (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf802048c0
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf802048c0
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: b9cc0ba05c6690bd330f0c2e2989578e
 
 === Running scenario: ping ===
 Running client scenario 'ping' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: f8b8f1ccc81bf9686291ba40e7cf3d8e
-2026/04/20 23:06:18 SSEHub: registered connection f8b8f1ccc81bf9686291ba40e7cf3d8e (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection f8b8f1ccc81bf9686291ba40e7cf3d8e (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c3792640620
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c3792640620
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: f8b8f1ccc81bf9686291ba40e7cf3d8e
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: af36410c09a54eb48b4f2756a0091f4f
+2026/04/20 23:49:55 SSEHub: registered connection af36410c09a54eb48b4f2756a0091f4f (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection af36410c09a54eb48b4f2756a0091f4f (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf80536230
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf80536230
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: af36410c09a54eb48b4f2756a0091f4f
 
 === Running scenario: completion-complete ===
 Running client scenario 'completion-complete' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: 6b8ecc08b725cc3e8bd7ed41f6733ada
-2026/04/20 23:06:18 SSEHub: registered connection 6b8ecc08b725cc3e8bd7ed41f6733ada (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection 6b8ecc08b725cc3e8bd7ed41f6733ada (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c37922e02a0
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c37922e02a0
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: 6b8ecc08b725cc3e8bd7ed41f6733ada
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 7013611f41b8c17bae537bd49aecabef
+2026/04/20 23:49:55 SSEHub: registered connection 7013611f41b8c17bae537bd49aecabef (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection 7013611f41b8c17bae537bd49aecabef (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf8061c230
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf8061c230
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 7013611f41b8c17bae537bd49aecabef
 
 === Running scenario: tools-list ===
 Running client scenario 'tools-list' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: 94e87a6b4a20eef31e4e787ffe3d27ff
-2026/04/20 23:06:18 SSEHub: registered connection 94e87a6b4a20eef31e4e787ffe3d27ff (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection 94e87a6b4a20eef31e4e787ffe3d27ff (total: 0)
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: a660d23ca4977e3d61bbd72bf598ccff
+2026/04/20 23:49:55 SSEHub: registered connection a660d23ca4977e3d61bbd72bf598ccff (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection a660d23ca4977e3d61bbd72bf598ccff (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf8061c460
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf8061c460
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: a660d23ca4977e3d61bbd72bf598ccff
 
 === Running scenario: tools-call-simple-text ===
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c379230c230
-2026/04/20 23:06:18 Cleaning up writer...
 Running client scenario 'tools-call-simple-text' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c379230c230
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: 94e87a6b4a20eef31e4e787ffe3d27ff
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: b06ccd3a1cfc18df188564956e4f3732
-2026/04/20 23:06:18 SSEHub: registered connection b06ccd3a1cfc18df188564956e4f3732 (total: 1)
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 8cc8fddc4516f858f08895519a1ef961
+2026/04/20 23:49:55 SSEHub: registered connection 8cc8fddc4516f858f08895519a1ef961 (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection 8cc8fddc4516f858f08895519a1ef961 (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf800f8380
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf800f8380
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 8cc8fddc4516f858f08895519a1ef961
 
 === Running scenario: tools-call-image ===
-2026/04/20 23:06:18 SSEHub: unregistered connection b06ccd3a1cfc18df188564956e4f3732 (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c379230cc40
 Running client scenario 'tools-call-image' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c379230cc40
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: b06ccd3a1cfc18df188564956e4f3732
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: c8da5137c35d114b0698819037e265dd
-2026/04/20 23:06:18 SSEHub: registered connection c8da5137c35d114b0698819037e265dd (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection c8da5137c35d114b0698819037e265dd (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c37922e05b0
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c37922e05b0
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: c8da5137c35d114b0698819037e265dd
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 58c96fe4b94f8eacbee4812221a5672a
+2026/04/20 23:49:55 SSEHub: registered connection 58c96fe4b94f8eacbee4812221a5672a (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection 58c96fe4b94f8eacbee4812221a5672a (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf80536690
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf80536690
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 58c96fe4b94f8eacbee4812221a5672a
 
 === Running scenario: tools-call-audio ===
 Running client scenario 'tools-call-audio' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: 1fe35db89cd1868f6ecfda53860a6747
-2026/04/20 23:06:18 SSEHub: registered connection 1fe35db89cd1868f6ecfda53860a6747 (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection 1fe35db89cd1868f6ecfda53860a6747 (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c37922283f0
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c37922283f0
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 92a032d11b40ac252f62c2c1284d11c4
+2026/04/20 23:49:55 SSEHub: registered connection 92a032d11b40ac252f62c2c1284d11c4 (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection 92a032d11b40ac252f62c2c1284d11c4 (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf8061c7e0
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf8061c7e0
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 92a032d11b40ac252f62c2c1284d11c4
 
 === Running scenario: tools-call-embedded-resource ===
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: 1fe35db89cd1868f6ecfda53860a6747
 Running client scenario 'tools-call-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: 0cc370fb04ce28fdbcdc107f1fbe0d45
-2026/04/20 23:06:18 SSEHub: registered connection 0cc370fb04ce28fdbcdc107f1fbe0d45 (total: 1)
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 4c6ce64e1e2c75a72c48fe548aa93f57
+2026/04/20 23:49:55 SSEHub: registered connection 4c6ce64e1e2c75a72c48fe548aa93f57 (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection 4c6ce64e1e2c75a72c48fe548aa93f57 (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf8061caf0
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf8061caf0
 
 === Running scenario: tools-call-mixed-content ===
-2026/04/20 23:06:18 SSEHub: unregistered connection 0cc370fb04ce28fdbcdc107f1fbe0d45 (total: 0)
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 4c6ce64e1e2c75a72c48fe548aa93f57
 Running client scenario 'tools-call-mixed-content' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c3792228700
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c3792228700
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: 0cc370fb04ce28fdbcdc107f1fbe0d45
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: 960c64283149b0f1ead3feec567215be
-2026/04/20 23:06:18 SSEHub: registered connection 960c64283149b0f1ead3feec567215be (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection 960c64283149b0f1ead3feec567215be (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c3792228930
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c3792228930
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 33df72dd504788985f2d8475e609c63d
+2026/04/20 23:49:55 SSEHub: registered connection 33df72dd504788985f2d8475e609c63d (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection 33df72dd504788985f2d8475e609c63d (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf80204d90
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf80204d90
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 33df72dd504788985f2d8475e609c63d
 
 === Running scenario: tools-call-with-logging ===
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: 960c64283149b0f1ead3feec567215be
 Running client scenario 'tools-call-with-logging' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: 86f83b3b83d2a606541e9cdab6fd76ed
-2026/04/20 23:06:18 SSEHub: registered connection 86f83b3b83d2a606541e9cdab6fd76ed (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection 86f83b3b83d2a606541e9cdab6fd76ed (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c379230cf50
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c379230cf50
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: 86f83b3b83d2a606541e9cdab6fd76ed
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 9a830fc05d2489a52c56bca5dcd3be5f
+2026/04/20 23:49:55 SSEHub: registered connection 9a830fc05d2489a52c56bca5dcd3be5f (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection 9a830fc05d2489a52c56bca5dcd3be5f (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf80536a10
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf80536a10
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 9a830fc05d2489a52c56bca5dcd3be5f
 
 === Running scenario: tools-call-error ===
 Running client scenario 'tools-call-error' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: 03425942904d7ec9e001686bf30be0ca
-2026/04/20 23:06:18 SSEHub: registered connection 03425942904d7ec9e001686bf30be0ca (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection 03425942904d7ec9e001686bf30be0ca (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c3792228b60
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c3792228b60
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: 03425942904d7ec9e001686bf30be0ca
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: ddc109dcfc44924a8fe2e8c88ec3e919
+2026/04/20 23:49:55 SSEHub: registered connection ddc109dcfc44924a8fe2e8c88ec3e919 (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection ddc109dcfc44924a8fe2e8c88ec3e919 (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf80536cb0
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf80536cb0
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: ddc109dcfc44924a8fe2e8c88ec3e919
 
 === Running scenario: tools-call-with-progress ===
 Running client scenario 'tools-call-with-progress' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: bd9737cc8c2423741e28124b97ca7ea4
-2026/04/20 23:06:18 SSEHub: registered connection bd9737cc8c2423741e28124b97ca7ea4 (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection bd9737cc8c2423741e28124b97ca7ea4 (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c3792640ee0
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c3792640ee0
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: bd9737cc8c2423741e28124b97ca7ea4
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 43b28c4895c30473cd8b09757a087a14
+2026/04/20 23:49:55 SSEHub: registered connection 43b28c4895c30473cd8b09757a087a14 (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection 43b28c4895c30473cd8b09757a087a14 (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf8061ce70
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf8061ce70
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 43b28c4895c30473cd8b09757a087a14
 
 === Running scenario: tools-call-sampling ===
 Running client scenario 'tools-call-sampling' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: eb8828d477683ef4f7e75d0f67e291af
-2026/04/20 23:06:18 SSEHub: registered connection eb8828d477683ef4f7e75d0f67e291af (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection eb8828d477683ef4f7e75d0f67e291af (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c3792228f50
-2026/04/20 23:06:18 Cleaning up writer...
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: a30065cc742dc4555886a1d22aeef40f
+2026/04/20 23:49:55 SSEHub: registered connection a30065cc742dc4555886a1d22aeef40f (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection a30065cc742dc4555886a1d22aeef40f (total: 0)
 
 === Running scenario: tools-call-elicitation ===
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c3792228f50
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf800f87e0
+2026/04/20 23:49:55 Cleaning up writer...
 Running client scenario 'tools-call-elicitation' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: eb8828d477683ef4f7e75d0f67e291af
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: ebf14fda815ee1a58c609e7733471c86
-2026/04/20 23:06:18 SSEHub: registered connection ebf14fda815ee1a58c609e7733471c86 (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection ebf14fda815ee1a58c609e7733471c86 (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c37922e09a0
-2026/04/20 23:06:18 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf800f87e0
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: a30065cc742dc4555886a1d22aeef40f
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: d080bc01952949c0fa4ffdbeba423833
+2026/04/20 23:49:55 SSEHub: registered connection d080bc01952949c0fa4ffdbeba423833 (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection d080bc01952949c0fa4ffdbeba423833 (total: 0)
 
 === Running scenario: elicitation-sep1034-defaults ===
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c37922e09a0
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf8061d1f0
+2026/04/20 23:49:55 Cleaning up writer...
 Running client scenario 'elicitation-sep1034-defaults' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: ebf14fda815ee1a58c609e7733471c86
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: 11ac92cd71a8d278e313940e91b9ffa6
-2026/04/20 23:06:18 SSEHub: registered connection 11ac92cd71a8d278e313940e91b9ffa6 (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection 11ac92cd71a8d278e313940e91b9ffa6 (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c3792229340
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c3792229340
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: 11ac92cd71a8d278e313940e91b9ffa6
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf8061d1f0
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: d080bc01952949c0fa4ffdbeba423833
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 6cf0f9a071c1c3bc9af539daa39686f4
+2026/04/20 23:49:55 SSEHub: registered connection 6cf0f9a071c1c3bc9af539daa39686f4 (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection 6cf0f9a071c1c3bc9af539daa39686f4 (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf8061d5e0
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf8061d5e0
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 6cf0f9a071c1c3bc9af539daa39686f4
 
 === Running scenario: server-sse-multiple-streams ===
 Running client scenario 'server-sse-multiple-streams' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: e15ea418b30d8b24d7f17554a526f58d
-2026/04/20 23:06:18 SSEHub: registered connection e15ea418b30d8b24d7f17554a526f58d (total: 1)
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 6d2a3f408376fad5cfde906f4a4b44c7
+2026/04/20 23:49:55 SSEHub: registered connection 6d2a3f408376fad5cfde906f4a4b44c7 (total: 1)
 
 === Running scenario: elicitation-sep1330-enums ===
-2026/04/20 23:06:18 SSEHub: unregistered connection e15ea418b30d8b24d7f17554a526f58d (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c3792229570
+2026/04/20 23:49:55 SSEHub: unregistered connection 6d2a3f408376fad5cfde906f4a4b44c7 (total: 0)
 Running client scenario 'elicitation-sep1330-enums' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c3792229570
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: e15ea418b30d8b24d7f17554a526f58d
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: 3fa29996adc10b823a978484c067f106
-2026/04/20 23:06:18 SSEHub: registered connection 3fa29996adc10b823a978484c067f106 (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection 3fa29996adc10b823a978484c067f106 (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c37922e0bd0
-2026/04/20 23:06:18 Cleaning up writer...
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf8061d810
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf8061d810
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 6d2a3f408376fad5cfde906f4a4b44c7
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 45ce25f2735f9ab35d8034c94a27c84d
+2026/04/20 23:49:55 SSEHub: registered connection 45ce25f2735f9ab35d8034c94a27c84d (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection 45ce25f2735f9ab35d8034c94a27c84d (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf800f8bd0
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf800f8bd0
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 45ce25f2735f9ab35d8034c94a27c84d
 
 === Running scenario: resources-list ===
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c37922e0bd0
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: 3fa29996adc10b823a978484c067f106
 Running client scenario 'resources-list' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: 139e5ee3876c76ff55554cf7981ec977
-2026/04/20 23:06:18 SSEHub: registered connection 139e5ee3876c76ff55554cf7981ec977 (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection 139e5ee3876c76ff55554cf7981ec977 (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c37922e0f50
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c37922e0f50
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: 139e5ee3876c76ff55554cf7981ec977
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 135977b04edc7b1ef3db9309699810b4
+2026/04/20 23:49:55 SSEHub: registered connection 135977b04edc7b1ef3db9309699810b4 (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection 135977b04edc7b1ef3db9309699810b4 (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf800f8e00
+2026/04/20 23:49:55 Cleaning up writer...
 
 === Running scenario: resources-read-text ===
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf800f8e00
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 135977b04edc7b1ef3db9309699810b4
 Running client scenario 'resources-read-text' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: f52516e8f30c38e5dd6f97761526c42e
-2026/04/20 23:06:18 SSEHub: registered connection f52516e8f30c38e5dd6f97761526c42e (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection f52516e8f30c38e5dd6f97761526c42e (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c379230d5e0
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c379230d5e0
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: f52516e8f30c38e5dd6f97761526c42e
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 82b275d419d5d2a40281158d5f74e5b7
+2026/04/20 23:49:55 SSEHub: registered connection 82b275d419d5d2a40281158d5f74e5b7 (total: 1)
 
 === Running scenario: resources-read-binary ===
+2026/04/20 23:49:55 SSEHub: unregistered connection 82b275d419d5d2a40281158d5f74e5b7 (total: 0)
 Running client scenario 'resources-read-binary' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: 1d5c5fcfd498ca4825101e7cd8da4fc5
-2026/04/20 23:06:18 SSEHub: registered connection 1d5c5fcfd498ca4825101e7cd8da4fc5 (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection 1d5c5fcfd498ca4825101e7cd8da4fc5 (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c37922e11f0
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c37922e11f0
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: 1d5c5fcfd498ca4825101e7cd8da4fc5
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf80205030
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf80205030
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 82b275d419d5d2a40281158d5f74e5b7
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 7a06c6b2fb4da6200eaecc48fa428503
+2026/04/20 23:49:55 SSEHub: registered connection 7a06c6b2fb4da6200eaecc48fa428503 (total: 1)
 
 === Running scenario: resources-templates-read ===
+2026/04/20 23:49:55 SSEHub: unregistered connection 7a06c6b2fb4da6200eaecc48fa428503 (total: 0)
 Running client scenario 'resources-templates-read' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: 7944e994d117a0de3333ade994a8ee25
-2026/04/20 23:06:18 SSEHub: registered connection 7944e994d117a0de3333ade994a8ee25 (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection 7944e994d117a0de3333ade994a8ee25 (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c3792641500
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c3792641500
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: 7944e994d117a0de3333ade994a8ee25
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf80537500
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf80537500
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 7a06c6b2fb4da6200eaecc48fa428503
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 976568bfa66b86fef86234c4e38c0a19
+2026/04/20 23:49:55 SSEHub: registered connection 976568bfa66b86fef86234c4e38c0a19 (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection 976568bfa66b86fef86234c4e38c0a19 (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf800f90a0
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf800f90a0
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 976568bfa66b86fef86234c4e38c0a19
 
 === Running scenario: resources-subscribe ===
 Running client scenario 'resources-subscribe' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: 6f2f3f9ed62803938b9b5f266589e3c8
-2026/04/20 23:06:18 SSEHub: registered connection 6f2f3f9ed62803938b9b5f266589e3c8 (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection 6f2f3f9ed62803938b9b5f266589e3c8 (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c37922e1490
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c37922e1490
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: 6f2f3f9ed62803938b9b5f266589e3c8
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 96597ee23d7b2cf74034f486ec12ac52
+2026/04/20 23:49:55 SSEHub: registered connection 96597ee23d7b2cf74034f486ec12ac52 (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection 96597ee23d7b2cf74034f486ec12ac52 (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf80537810
 
 === Running scenario: resources-unsubscribe ===
+2026/04/20 23:49:55 Cleaning up writer...
 Running client scenario 'resources-unsubscribe' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: 1e0bba3d7a4de652401f904bf4236169
-2026/04/20 23:06:18 SSEHub: registered connection 1e0bba3d7a4de652401f904bf4236169 (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection 1e0bba3d7a4de652401f904bf4236169 (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c37926417a0
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c37926417a0
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: 1e0bba3d7a4de652401f904bf4236169
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf80537810
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 96597ee23d7b2cf74034f486ec12ac52
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: b5e93f225edfba6d341a0b62d850152e
+2026/04/20 23:49:55 SSEHub: registered connection b5e93f225edfba6d341a0b62d850152e (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection b5e93f225edfba6d341a0b62d850152e (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf80537a40
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf80537a40
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: b5e93f225edfba6d341a0b62d850152e
 
 === Running scenario: prompts-list ===
 Running client scenario 'prompts-list' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: a66018cee54edfcd04cd4c51e780ea02
-2026/04/20 23:06:18 SSEHub: registered connection a66018cee54edfcd04cd4c51e780ea02 (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection a66018cee54edfcd04cd4c51e780ea02 (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c37926419d0
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c37926419d0
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: a66018cee54edfcd04cd4c51e780ea02
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 74c153c360dabeafdeea91c4b1193833
+2026/04/20 23:49:55 SSEHub: registered connection 74c153c360dabeafdeea91c4b1193833 (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection 74c153c360dabeafdeea91c4b1193833 (total: 0)
 
 === Running scenario: prompts-get-simple ===
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf802053b0
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf802053b0
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 74c153c360dabeafdeea91c4b1193833
 Running client scenario 'prompts-get-simple' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: 845ae5985013bb5091b40efccb5e11ad
-2026/04/20 23:06:18 SSEHub: registered connection 845ae5985013bb5091b40efccb5e11ad (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection 845ae5985013bb5091b40efccb5e11ad (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c3792641c00
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c3792641c00
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: 845ae5985013bb5091b40efccb5e11ad
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 239622ffcae14e52104b3241b9ba08e7
+2026/04/20 23:49:55 SSEHub: registered connection 239622ffcae14e52104b3241b9ba08e7 (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection 239622ffcae14e52104b3241b9ba08e7 (total: 0)
 
 === Running scenario: prompts-get-with-args ===
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf802055e0
+2026/04/20 23:49:55 Cleaning up writer...
 Running client scenario 'prompts-get-with-args' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: c2b7a40821c39cfc6cd8151f24b0f75f
-2026/04/20 23:06:18 SSEHub: registered connection c2b7a40821c39cfc6cd8151f24b0f75f (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection c2b7a40821c39cfc6cd8151f24b0f75f (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c379230db20
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c379230db20
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: c2b7a40821c39cfc6cd8151f24b0f75f
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf802055e0
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 239622ffcae14e52104b3241b9ba08e7
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: d6d7ea0beaad07baac31c0f28e0119da
+2026/04/20 23:49:55 SSEHub: registered connection d6d7ea0beaad07baac31c0f28e0119da (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection d6d7ea0beaad07baac31c0f28e0119da (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf80537ea0
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf80537ea0
 
 === Running scenario: prompts-get-embedded-resource ===
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: d6d7ea0beaad07baac31c0f28e0119da
 Running client scenario 'prompts-get-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: 68551478bde149615e56008bc1574b60
-2026/04/20 23:06:18 SSEHub: registered connection 68551478bde149615e56008bc1574b60 (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection 68551478bde149615e56008bc1574b60 (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c3792641ea0
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c3792641ea0
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: 68551478bde149615e56008bc1574b60
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 38aab1a2cca4220bb3c614f58dc42ba1
+2026/04/20 23:49:55 SSEHub: registered connection 38aab1a2cca4220bb3c614f58dc42ba1 (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection 38aab1a2cca4220bb3c614f58dc42ba1 (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf804922a0
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf804922a0
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 38aab1a2cca4220bb3c614f58dc42ba1
 
 === Running scenario: prompts-get-with-image ===
 Running client scenario 'prompts-get-with-image' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: be8af615ea6a1bcf2ee299640a5f3a49
-2026/04/20 23:06:18 SSEHub: registered connection be8af615ea6a1bcf2ee299640a5f3a49 (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection be8af615ea6a1bcf2ee299640a5f3a49 (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c379230dd50
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c379230dd50
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: be8af615ea6a1bcf2ee299640a5f3a49
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 8207039a77e0a83bfa853ec9886c68cd
+2026/04/20 23:49:55 SSEHub: registered connection 8207039a77e0a83bfa853ec9886c68cd (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection 8207039a77e0a83bfa853ec9886c68cd (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf804925b0
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf804925b0
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 8207039a77e0a83bfa853ec9886c68cd
 
 === Running scenario: dns-rebinding-protection ===
 Running client scenario 'dns-rebinding-protection' against server: http://localhost:18799/mcp
@@ -470,22 +470,22 @@ Starting scenario: auth/token-endpoint-auth-basic
 Starting scenario: auth/token-endpoint-auth-post
 Starting scenario: auth/token-endpoint-auth-none
 Starting scenario: auth/pre-registration
-Executing client: ./bin/testclient http://localhost:49975/mcp
-Executing client: ./bin/testclient http://localhost:49976/mcp
-Executing client: ./bin/testclient http://localhost:49977/mcp
-Executing client: ./bin/testclient http://localhost:49978/mcp
-Executing client: ./bin/testclient http://localhost:49979/mcp
-Executing client: ./bin/testclient http://localhost:49980/mcp
-Executing client: ./bin/testclient http://localhost:49981/mcp
-Executing client: ./bin/testclient http://localhost:49982/mcp
-Executing client: ./bin/testclient http://localhost:49983/mcp
-Executing client: ./bin/testclient http://localhost:49984/mcp
-Executing client: ./bin/testclient http://localhost:49985/mcp
-Executing client: ./bin/testclient http://localhost:49986/mcp
-Executing client: ./bin/testclient http://localhost:49987/mcp
-Executing client: ./bin/testclient http://localhost:49988/mcp
+Executing client: ./bin/testclient http://localhost:61795/mcp
+Executing client: ./bin/testclient http://localhost:61796/mcp
+Executing client: ./bin/testclient http://localhost:61797/mcp
+Executing client: ./bin/testclient http://localhost:61798/mcp
+Executing client: ./bin/testclient http://localhost:61799/mcp
+Executing client: ./bin/testclient http://localhost:61800/mcp
+Executing client: ./bin/testclient http://localhost:61801/mcp
+Executing client: ./bin/testclient http://localhost:61802/mcp
+Executing client: ./bin/testclient http://localhost:61803/mcp
+Executing client: ./bin/testclient http://localhost:61804/mcp
+Executing client: ./bin/testclient http://localhost:61805/mcp
+Executing client: ./bin/testclient http://localhost:61806/mcp
+Executing client: ./bin/testclient http://localhost:61807/mcp
+Executing client: ./bin/testclient http://localhost:61808/mcp
 With context: {"client_id":"pre-registered-client","client_secret":"pre-registered-secret"}
-(node:68700) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
+(node:99572) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
 (Use `node --trace-deprecation ...` to show where the warning was created)
 
 === SUITE SUMMARY ===
@@ -559,10 +559,10 @@ Waiting for Keycloak realm...
     token_refresh_test.go:22: Keycloak not reachable at http://localhost:8180: Get "http://localhost:8180/realms/mcpkit-test": dial tcp [::1]:8180: connect: connection refused (run 'make upkcl' to start)
 --- SKIP: TestKeycloak_TokenRefresh_PasswordGrant (0.00s)
 PASS
-ok  	github.com/panyam/mcpkit/tests/keycloak	0.660s
+ok  	github.com/panyam/mcpkit/tests/keycloak	0.334s
 make[2]: *** No rule to make target `downkcl'.  Stop.
 
 === Results: 10 passed, 0 failed ===
-Finished: Mon Apr 20 23:08:25 PDT 2026
+Finished: Mon Apr 20 23:52:01 PDT 2026
 </pre>
 </body></html>

--- a/tests/reports/run.log
+++ b/tests/reports/run.log
@@ -1,33 +1,33 @@
 === MCPKit Comprehensive Test Suite ===
-Started: Mon Apr 20 23:05:23 PDT 2026
+Started: Mon Apr 20 23:49:06 PDT 2026
 
 --- [1/10] unit+coverage ---
   PASS: unit+coverage
 go test -coverprofile=tests/reports/coverage.out ./... -count=1 -timeout 30s
-ok  	github.com/panyam/mcpkit/client	8.822s	coverage: 64.7% of statements
+ok  	github.com/panyam/mcpkit/client	9.210s	coverage: 64.7% of statements
 	github.com/panyam/mcpkit/cmd/testserver		coverage: 0.0% of statements
-ok  	github.com/panyam/mcpkit/core	0.622s	coverage: 51.0% of statements
-ok  	github.com/panyam/mcpkit/server	10.109s	coverage: 80.2% of statements
-ok  	github.com/panyam/mcpkit/testutil	0.627s	coverage: 69.4% of statements
+ok  	github.com/panyam/mcpkit/core	0.271s	coverage: 51.0% of statements
+ok  	github.com/panyam/mcpkit/server	9.520s	coverage: 80.9% of statements
+ok  	github.com/panyam/mcpkit/testutil	0.771s	coverage: 69.4% of statements
 go tool cover -html=tests/reports/coverage.out -o tests/reports/coverage.html
 Coverage report: tests/reports/coverage.html
 --- [2/10] race ---
   PASS: race
 go test -race ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/client	9.273s
+ok  	github.com/panyam/mcpkit/client	9.141s
 ?   	github.com/panyam/mcpkit/cmd/testserver	[no test files]
-ok  	github.com/panyam/mcpkit/core	1.577s
-ok  	github.com/panyam/mcpkit/server	11.381s
-ok  	github.com/panyam/mcpkit/testutil	1.523s
+ok  	github.com/panyam/mcpkit/core	1.984s
+ok  	github.com/panyam/mcpkit/server	11.286s
+ok  	github.com/panyam/mcpkit/testutil	2.210s
 --- [3/10] auth ---
   PASS: auth
 cd ext/auth && go test ./... -count=1 -timeout 30s
-ok  	github.com/panyam/mcpkit/ext/auth	0.598s
+ok  	github.com/panyam/mcpkit/ext/auth	0.294s
 --- [4/10] ui ---
   PASS: ui
 cd ext/ui && /Library/Developer/CommandLineTools/usr/bin/make test
 go test ./... -count=1 -timeout 30s
-ok  	github.com/panyam/mcpkit/ext/ui	0.570s
+ok  	github.com/panyam/mcpkit/ext/ui	0.288s
 cd assets && pnpm install --frozen-lockfile --silent && pnpm test
 
 > @mcpkit/app-bridge@0.1.0 test /Users/dzshrh/newstack/mcpkit/main/ext/ui/assets
@@ -36,21 +36,21 @@ cd assets && pnpm install --frozen-lockfile --silent && pnpm test
 
  RUN  v3.2.4 /Users/dzshrh/newstack/mcpkit/main/ext/ui/assets
 
- ✓ mcp-app-bridge.test.ts (33 tests) 393ms
+ ✓ mcp-app-bridge.test.ts (33 tests) 386ms
 
  Test Files  1 passed (1)
       Tests  33 passed (33)
-   Start at  23:05:54
-   Duration  1.06s (transform 28ms, setup 0ms, collect 26ms, tests 393ms, environment 357ms, prepare 102ms)
+   Start at  23:49:32
+   Duration  1.00s (transform 31ms, setup 0ms, collect 26ms, tests 386ms, environment 272ms, prepare 103ms)
 
 --- [5/10] protogen ---
   PASS: protogen
 cd experimental/ext/protogen && go test ./... -count=1 -timeout 30s && /Library/Developer/CommandLineTools/usr/bin/make test-e2e
 ?   	github.com/panyam/mcpkit/experimental/ext/protogen/cmd/protoc-gen-go-mcp	[no test files]
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/generator	0.598s
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/proto/mcp/v1	0.613s
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/runtime	1.161s
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/schema	1.194s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/generator	0.263s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/proto/mcp/v1	0.465s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/runtime	0.703s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/schema	0.930s
 ?   	github.com/panyam/mcpkit/experimental/ext/protogen/testutil	[no test files]
 go build -o bin/protoc-gen-go-mcp ./cmd/protoc-gen-go-mcp
 go install ./cmd/protoc-gen-go-mcp
@@ -59,23 +59,23 @@ cd ../../../examples/protogen/bookservice && rm -rf gen && buf generate && go te
 [33mWARN[0m	plugin "protoc-gen-go-mcp" does not support required features.
   Feature "proto3 optional" is required by 1 file(s):
     bookservice/v1/service.proto
-ok  	github.com/panyam/mcpkit/examples/protogen/bookservice	0.686s
+ok  	github.com/panyam/mcpkit/examples/protogen/bookservice	0.734s
 ==> e2e: passed
 --- [6/10] e2e ---
   PASS: e2e
 cd tests/e2e && go test ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/tests/e2e	3.989s
-ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.944s
+ok  	github.com/panyam/mcpkit/tests/e2e	4.562s
+ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.947s
 --- [7/10] experimental ---
   PASS: experimental
 cd experimental/telegram-events && go test ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/experimental/telegram-events	6.506s
+ok  	github.com/panyam/mcpkit/experimental/telegram-events	6.387s
 --- [8/10] conformance ---
   PASS: conformance
 bash scripts/conformance-test.sh
 Killing stale process on port 18799...
 === Starting test server on :18799 (Streamable HTTP) ===
-Waiting for server.....2026/04/20 23:06:15 MCP test server listening on :18799 (Streamable HTTP at /mcp)
+Waiting for server.....2026/04/20 23:49:53 MCP test server listening on :18799 (Streamable HTTP at /mcp)
  ready
 
 === Running MCP conformance suite ===
@@ -86,293 +86,293 @@ Running active suite (30 scenarios) against http://localhost:18799/mcp
 
 === Running scenario: server-initialize ===
 Running client scenario 'server-initialize' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: e91de6c74b0cb7543bbe6920d31eca74
-2026/04/20 23:06:18 SSEHub: registered connection e91de6c74b0cb7543bbe6920d31eca74 (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection e91de6c74b0cb7543bbe6920d31eca74 (total: 0)
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 4a7cc5c131dc659ce3ff97906d3387b3
+2026/04/20 23:49:55 SSEHub: registered connection 4a7cc5c131dc659ce3ff97906d3387b3 (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection 4a7cc5c131dc659ce3ff97906d3387b3 (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf800f83f0
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf800f83f0
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 4a7cc5c131dc659ce3ff97906d3387b3
 
 === Running scenario: logging-set-level ===
 Running client scenario 'logging-set-level' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c3792640150
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c3792640150
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: e91de6c74b0cb7543bbe6920d31eca74
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: a7ce93a0335a0b12521efa6ae576bdf4
-2026/04/20 23:06:18 SSEHub: registered connection a7ce93a0335a0b12521efa6ae576bdf4 (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection a7ce93a0335a0b12521efa6ae576bdf4 (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c3792640380
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c3792640380
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: a7ce93a0335a0b12521efa6ae576bdf4
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: b9cc0ba05c6690bd330f0c2e2989578e
+2026/04/20 23:49:55 SSEHub: registered connection b9cc0ba05c6690bd330f0c2e2989578e (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection b9cc0ba05c6690bd330f0c2e2989578e (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf802048c0
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf802048c0
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: b9cc0ba05c6690bd330f0c2e2989578e
 
 === Running scenario: ping ===
 Running client scenario 'ping' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: f8b8f1ccc81bf9686291ba40e7cf3d8e
-2026/04/20 23:06:18 SSEHub: registered connection f8b8f1ccc81bf9686291ba40e7cf3d8e (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection f8b8f1ccc81bf9686291ba40e7cf3d8e (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c3792640620
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c3792640620
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: f8b8f1ccc81bf9686291ba40e7cf3d8e
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: af36410c09a54eb48b4f2756a0091f4f
+2026/04/20 23:49:55 SSEHub: registered connection af36410c09a54eb48b4f2756a0091f4f (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection af36410c09a54eb48b4f2756a0091f4f (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf80536230
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf80536230
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: af36410c09a54eb48b4f2756a0091f4f
 
 === Running scenario: completion-complete ===
 Running client scenario 'completion-complete' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: 6b8ecc08b725cc3e8bd7ed41f6733ada
-2026/04/20 23:06:18 SSEHub: registered connection 6b8ecc08b725cc3e8bd7ed41f6733ada (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection 6b8ecc08b725cc3e8bd7ed41f6733ada (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c37922e02a0
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c37922e02a0
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: 6b8ecc08b725cc3e8bd7ed41f6733ada
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 7013611f41b8c17bae537bd49aecabef
+2026/04/20 23:49:55 SSEHub: registered connection 7013611f41b8c17bae537bd49aecabef (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection 7013611f41b8c17bae537bd49aecabef (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf8061c230
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf8061c230
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 7013611f41b8c17bae537bd49aecabef
 
 === Running scenario: tools-list ===
 Running client scenario 'tools-list' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: 94e87a6b4a20eef31e4e787ffe3d27ff
-2026/04/20 23:06:18 SSEHub: registered connection 94e87a6b4a20eef31e4e787ffe3d27ff (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection 94e87a6b4a20eef31e4e787ffe3d27ff (total: 0)
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: a660d23ca4977e3d61bbd72bf598ccff
+2026/04/20 23:49:55 SSEHub: registered connection a660d23ca4977e3d61bbd72bf598ccff (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection a660d23ca4977e3d61bbd72bf598ccff (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf8061c460
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf8061c460
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: a660d23ca4977e3d61bbd72bf598ccff
 
 === Running scenario: tools-call-simple-text ===
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c379230c230
-2026/04/20 23:06:18 Cleaning up writer...
 Running client scenario 'tools-call-simple-text' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c379230c230
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: 94e87a6b4a20eef31e4e787ffe3d27ff
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: b06ccd3a1cfc18df188564956e4f3732
-2026/04/20 23:06:18 SSEHub: registered connection b06ccd3a1cfc18df188564956e4f3732 (total: 1)
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 8cc8fddc4516f858f08895519a1ef961
+2026/04/20 23:49:55 SSEHub: registered connection 8cc8fddc4516f858f08895519a1ef961 (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection 8cc8fddc4516f858f08895519a1ef961 (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf800f8380
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf800f8380
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 8cc8fddc4516f858f08895519a1ef961
 
 === Running scenario: tools-call-image ===
-2026/04/20 23:06:18 SSEHub: unregistered connection b06ccd3a1cfc18df188564956e4f3732 (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c379230cc40
 Running client scenario 'tools-call-image' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c379230cc40
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: b06ccd3a1cfc18df188564956e4f3732
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: c8da5137c35d114b0698819037e265dd
-2026/04/20 23:06:18 SSEHub: registered connection c8da5137c35d114b0698819037e265dd (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection c8da5137c35d114b0698819037e265dd (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c37922e05b0
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c37922e05b0
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: c8da5137c35d114b0698819037e265dd
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 58c96fe4b94f8eacbee4812221a5672a
+2026/04/20 23:49:55 SSEHub: registered connection 58c96fe4b94f8eacbee4812221a5672a (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection 58c96fe4b94f8eacbee4812221a5672a (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf80536690
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf80536690
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 58c96fe4b94f8eacbee4812221a5672a
 
 === Running scenario: tools-call-audio ===
 Running client scenario 'tools-call-audio' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: 1fe35db89cd1868f6ecfda53860a6747
-2026/04/20 23:06:18 SSEHub: registered connection 1fe35db89cd1868f6ecfda53860a6747 (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection 1fe35db89cd1868f6ecfda53860a6747 (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c37922283f0
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c37922283f0
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 92a032d11b40ac252f62c2c1284d11c4
+2026/04/20 23:49:55 SSEHub: registered connection 92a032d11b40ac252f62c2c1284d11c4 (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection 92a032d11b40ac252f62c2c1284d11c4 (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf8061c7e0
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf8061c7e0
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 92a032d11b40ac252f62c2c1284d11c4
 
 === Running scenario: tools-call-embedded-resource ===
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: 1fe35db89cd1868f6ecfda53860a6747
 Running client scenario 'tools-call-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: 0cc370fb04ce28fdbcdc107f1fbe0d45
-2026/04/20 23:06:18 SSEHub: registered connection 0cc370fb04ce28fdbcdc107f1fbe0d45 (total: 1)
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 4c6ce64e1e2c75a72c48fe548aa93f57
+2026/04/20 23:49:55 SSEHub: registered connection 4c6ce64e1e2c75a72c48fe548aa93f57 (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection 4c6ce64e1e2c75a72c48fe548aa93f57 (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf8061caf0
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf8061caf0
 
 === Running scenario: tools-call-mixed-content ===
-2026/04/20 23:06:18 SSEHub: unregistered connection 0cc370fb04ce28fdbcdc107f1fbe0d45 (total: 0)
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 4c6ce64e1e2c75a72c48fe548aa93f57
 Running client scenario 'tools-call-mixed-content' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c3792228700
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c3792228700
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: 0cc370fb04ce28fdbcdc107f1fbe0d45
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: 960c64283149b0f1ead3feec567215be
-2026/04/20 23:06:18 SSEHub: registered connection 960c64283149b0f1ead3feec567215be (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection 960c64283149b0f1ead3feec567215be (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c3792228930
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c3792228930
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 33df72dd504788985f2d8475e609c63d
+2026/04/20 23:49:55 SSEHub: registered connection 33df72dd504788985f2d8475e609c63d (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection 33df72dd504788985f2d8475e609c63d (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf80204d90
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf80204d90
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 33df72dd504788985f2d8475e609c63d
 
 === Running scenario: tools-call-with-logging ===
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: 960c64283149b0f1ead3feec567215be
 Running client scenario 'tools-call-with-logging' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: 86f83b3b83d2a606541e9cdab6fd76ed
-2026/04/20 23:06:18 SSEHub: registered connection 86f83b3b83d2a606541e9cdab6fd76ed (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection 86f83b3b83d2a606541e9cdab6fd76ed (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c379230cf50
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c379230cf50
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: 86f83b3b83d2a606541e9cdab6fd76ed
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 9a830fc05d2489a52c56bca5dcd3be5f
+2026/04/20 23:49:55 SSEHub: registered connection 9a830fc05d2489a52c56bca5dcd3be5f (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection 9a830fc05d2489a52c56bca5dcd3be5f (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf80536a10
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf80536a10
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 9a830fc05d2489a52c56bca5dcd3be5f
 
 === Running scenario: tools-call-error ===
 Running client scenario 'tools-call-error' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: 03425942904d7ec9e001686bf30be0ca
-2026/04/20 23:06:18 SSEHub: registered connection 03425942904d7ec9e001686bf30be0ca (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection 03425942904d7ec9e001686bf30be0ca (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c3792228b60
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c3792228b60
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: 03425942904d7ec9e001686bf30be0ca
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: ddc109dcfc44924a8fe2e8c88ec3e919
+2026/04/20 23:49:55 SSEHub: registered connection ddc109dcfc44924a8fe2e8c88ec3e919 (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection ddc109dcfc44924a8fe2e8c88ec3e919 (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf80536cb0
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf80536cb0
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: ddc109dcfc44924a8fe2e8c88ec3e919
 
 === Running scenario: tools-call-with-progress ===
 Running client scenario 'tools-call-with-progress' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: bd9737cc8c2423741e28124b97ca7ea4
-2026/04/20 23:06:18 SSEHub: registered connection bd9737cc8c2423741e28124b97ca7ea4 (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection bd9737cc8c2423741e28124b97ca7ea4 (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c3792640ee0
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c3792640ee0
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: bd9737cc8c2423741e28124b97ca7ea4
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 43b28c4895c30473cd8b09757a087a14
+2026/04/20 23:49:55 SSEHub: registered connection 43b28c4895c30473cd8b09757a087a14 (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection 43b28c4895c30473cd8b09757a087a14 (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf8061ce70
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf8061ce70
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 43b28c4895c30473cd8b09757a087a14
 
 === Running scenario: tools-call-sampling ===
 Running client scenario 'tools-call-sampling' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: eb8828d477683ef4f7e75d0f67e291af
-2026/04/20 23:06:18 SSEHub: registered connection eb8828d477683ef4f7e75d0f67e291af (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection eb8828d477683ef4f7e75d0f67e291af (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c3792228f50
-2026/04/20 23:06:18 Cleaning up writer...
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: a30065cc742dc4555886a1d22aeef40f
+2026/04/20 23:49:55 SSEHub: registered connection a30065cc742dc4555886a1d22aeef40f (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection a30065cc742dc4555886a1d22aeef40f (total: 0)
 
 === Running scenario: tools-call-elicitation ===
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c3792228f50
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf800f87e0
+2026/04/20 23:49:55 Cleaning up writer...
 Running client scenario 'tools-call-elicitation' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: eb8828d477683ef4f7e75d0f67e291af
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: ebf14fda815ee1a58c609e7733471c86
-2026/04/20 23:06:18 SSEHub: registered connection ebf14fda815ee1a58c609e7733471c86 (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection ebf14fda815ee1a58c609e7733471c86 (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c37922e09a0
-2026/04/20 23:06:18 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf800f87e0
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: a30065cc742dc4555886a1d22aeef40f
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: d080bc01952949c0fa4ffdbeba423833
+2026/04/20 23:49:55 SSEHub: registered connection d080bc01952949c0fa4ffdbeba423833 (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection d080bc01952949c0fa4ffdbeba423833 (total: 0)
 
 === Running scenario: elicitation-sep1034-defaults ===
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c37922e09a0
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf8061d1f0
+2026/04/20 23:49:55 Cleaning up writer...
 Running client scenario 'elicitation-sep1034-defaults' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: ebf14fda815ee1a58c609e7733471c86
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: 11ac92cd71a8d278e313940e91b9ffa6
-2026/04/20 23:06:18 SSEHub: registered connection 11ac92cd71a8d278e313940e91b9ffa6 (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection 11ac92cd71a8d278e313940e91b9ffa6 (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c3792229340
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c3792229340
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: 11ac92cd71a8d278e313940e91b9ffa6
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf8061d1f0
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: d080bc01952949c0fa4ffdbeba423833
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 6cf0f9a071c1c3bc9af539daa39686f4
+2026/04/20 23:49:55 SSEHub: registered connection 6cf0f9a071c1c3bc9af539daa39686f4 (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection 6cf0f9a071c1c3bc9af539daa39686f4 (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf8061d5e0
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf8061d5e0
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 6cf0f9a071c1c3bc9af539daa39686f4
 
 === Running scenario: server-sse-multiple-streams ===
 Running client scenario 'server-sse-multiple-streams' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: e15ea418b30d8b24d7f17554a526f58d
-2026/04/20 23:06:18 SSEHub: registered connection e15ea418b30d8b24d7f17554a526f58d (total: 1)
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 6d2a3f408376fad5cfde906f4a4b44c7
+2026/04/20 23:49:55 SSEHub: registered connection 6d2a3f408376fad5cfde906f4a4b44c7 (total: 1)
 
 === Running scenario: elicitation-sep1330-enums ===
-2026/04/20 23:06:18 SSEHub: unregistered connection e15ea418b30d8b24d7f17554a526f58d (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c3792229570
+2026/04/20 23:49:55 SSEHub: unregistered connection 6d2a3f408376fad5cfde906f4a4b44c7 (total: 0)
 Running client scenario 'elicitation-sep1330-enums' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c3792229570
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: e15ea418b30d8b24d7f17554a526f58d
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: 3fa29996adc10b823a978484c067f106
-2026/04/20 23:06:18 SSEHub: registered connection 3fa29996adc10b823a978484c067f106 (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection 3fa29996adc10b823a978484c067f106 (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c37922e0bd0
-2026/04/20 23:06:18 Cleaning up writer...
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf8061d810
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf8061d810
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 6d2a3f408376fad5cfde906f4a4b44c7
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 45ce25f2735f9ab35d8034c94a27c84d
+2026/04/20 23:49:55 SSEHub: registered connection 45ce25f2735f9ab35d8034c94a27c84d (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection 45ce25f2735f9ab35d8034c94a27c84d (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf800f8bd0
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf800f8bd0
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 45ce25f2735f9ab35d8034c94a27c84d
 
 === Running scenario: resources-list ===
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c37922e0bd0
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: 3fa29996adc10b823a978484c067f106
 Running client scenario 'resources-list' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: 139e5ee3876c76ff55554cf7981ec977
-2026/04/20 23:06:18 SSEHub: registered connection 139e5ee3876c76ff55554cf7981ec977 (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection 139e5ee3876c76ff55554cf7981ec977 (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c37922e0f50
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c37922e0f50
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: 139e5ee3876c76ff55554cf7981ec977
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 135977b04edc7b1ef3db9309699810b4
+2026/04/20 23:49:55 SSEHub: registered connection 135977b04edc7b1ef3db9309699810b4 (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection 135977b04edc7b1ef3db9309699810b4 (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf800f8e00
+2026/04/20 23:49:55 Cleaning up writer...
 
 === Running scenario: resources-read-text ===
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf800f8e00
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 135977b04edc7b1ef3db9309699810b4
 Running client scenario 'resources-read-text' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: f52516e8f30c38e5dd6f97761526c42e
-2026/04/20 23:06:18 SSEHub: registered connection f52516e8f30c38e5dd6f97761526c42e (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection f52516e8f30c38e5dd6f97761526c42e (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c379230d5e0
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c379230d5e0
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: f52516e8f30c38e5dd6f97761526c42e
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 82b275d419d5d2a40281158d5f74e5b7
+2026/04/20 23:49:55 SSEHub: registered connection 82b275d419d5d2a40281158d5f74e5b7 (total: 1)
 
 === Running scenario: resources-read-binary ===
+2026/04/20 23:49:55 SSEHub: unregistered connection 82b275d419d5d2a40281158d5f74e5b7 (total: 0)
 Running client scenario 'resources-read-binary' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: 1d5c5fcfd498ca4825101e7cd8da4fc5
-2026/04/20 23:06:18 SSEHub: registered connection 1d5c5fcfd498ca4825101e7cd8da4fc5 (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection 1d5c5fcfd498ca4825101e7cd8da4fc5 (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c37922e11f0
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c37922e11f0
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: 1d5c5fcfd498ca4825101e7cd8da4fc5
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf80205030
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf80205030
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 82b275d419d5d2a40281158d5f74e5b7
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 7a06c6b2fb4da6200eaecc48fa428503
+2026/04/20 23:49:55 SSEHub: registered connection 7a06c6b2fb4da6200eaecc48fa428503 (total: 1)
 
 === Running scenario: resources-templates-read ===
+2026/04/20 23:49:55 SSEHub: unregistered connection 7a06c6b2fb4da6200eaecc48fa428503 (total: 0)
 Running client scenario 'resources-templates-read' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: 7944e994d117a0de3333ade994a8ee25
-2026/04/20 23:06:18 SSEHub: registered connection 7944e994d117a0de3333ade994a8ee25 (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection 7944e994d117a0de3333ade994a8ee25 (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c3792641500
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c3792641500
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: 7944e994d117a0de3333ade994a8ee25
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf80537500
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf80537500
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 7a06c6b2fb4da6200eaecc48fa428503
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 976568bfa66b86fef86234c4e38c0a19
+2026/04/20 23:49:55 SSEHub: registered connection 976568bfa66b86fef86234c4e38c0a19 (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection 976568bfa66b86fef86234c4e38c0a19 (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf800f90a0
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf800f90a0
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 976568bfa66b86fef86234c4e38c0a19
 
 === Running scenario: resources-subscribe ===
 Running client scenario 'resources-subscribe' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: 6f2f3f9ed62803938b9b5f266589e3c8
-2026/04/20 23:06:18 SSEHub: registered connection 6f2f3f9ed62803938b9b5f266589e3c8 (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection 6f2f3f9ed62803938b9b5f266589e3c8 (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c37922e1490
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c37922e1490
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: 6f2f3f9ed62803938b9b5f266589e3c8
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 96597ee23d7b2cf74034f486ec12ac52
+2026/04/20 23:49:55 SSEHub: registered connection 96597ee23d7b2cf74034f486ec12ac52 (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection 96597ee23d7b2cf74034f486ec12ac52 (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf80537810
 
 === Running scenario: resources-unsubscribe ===
+2026/04/20 23:49:55 Cleaning up writer...
 Running client scenario 'resources-unsubscribe' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: 1e0bba3d7a4de652401f904bf4236169
-2026/04/20 23:06:18 SSEHub: registered connection 1e0bba3d7a4de652401f904bf4236169 (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection 1e0bba3d7a4de652401f904bf4236169 (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c37926417a0
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c37926417a0
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: 1e0bba3d7a4de652401f904bf4236169
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf80537810
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 96597ee23d7b2cf74034f486ec12ac52
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: b5e93f225edfba6d341a0b62d850152e
+2026/04/20 23:49:55 SSEHub: registered connection b5e93f225edfba6d341a0b62d850152e (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection b5e93f225edfba6d341a0b62d850152e (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf80537a40
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf80537a40
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: b5e93f225edfba6d341a0b62d850152e
 
 === Running scenario: prompts-list ===
 Running client scenario 'prompts-list' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: a66018cee54edfcd04cd4c51e780ea02
-2026/04/20 23:06:18 SSEHub: registered connection a66018cee54edfcd04cd4c51e780ea02 (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection a66018cee54edfcd04cd4c51e780ea02 (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c37926419d0
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c37926419d0
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: a66018cee54edfcd04cd4c51e780ea02
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 74c153c360dabeafdeea91c4b1193833
+2026/04/20 23:49:55 SSEHub: registered connection 74c153c360dabeafdeea91c4b1193833 (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection 74c153c360dabeafdeea91c4b1193833 (total: 0)
 
 === Running scenario: prompts-get-simple ===
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf802053b0
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf802053b0
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 74c153c360dabeafdeea91c4b1193833
 Running client scenario 'prompts-get-simple' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: 845ae5985013bb5091b40efccb5e11ad
-2026/04/20 23:06:18 SSEHub: registered connection 845ae5985013bb5091b40efccb5e11ad (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection 845ae5985013bb5091b40efccb5e11ad (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c3792641c00
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c3792641c00
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: 845ae5985013bb5091b40efccb5e11ad
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 239622ffcae14e52104b3241b9ba08e7
+2026/04/20 23:49:55 SSEHub: registered connection 239622ffcae14e52104b3241b9ba08e7 (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection 239622ffcae14e52104b3241b9ba08e7 (total: 0)
 
 === Running scenario: prompts-get-with-args ===
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf802055e0
+2026/04/20 23:49:55 Cleaning up writer...
 Running client scenario 'prompts-get-with-args' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: c2b7a40821c39cfc6cd8151f24b0f75f
-2026/04/20 23:06:18 SSEHub: registered connection c2b7a40821c39cfc6cd8151f24b0f75f (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection c2b7a40821c39cfc6cd8151f24b0f75f (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c379230db20
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c379230db20
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: c2b7a40821c39cfc6cd8151f24b0f75f
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf802055e0
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 239622ffcae14e52104b3241b9ba08e7
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: d6d7ea0beaad07baac31c0f28e0119da
+2026/04/20 23:49:55 SSEHub: registered connection d6d7ea0beaad07baac31c0f28e0119da (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection d6d7ea0beaad07baac31c0f28e0119da (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf80537ea0
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf80537ea0
 
 === Running scenario: prompts-get-embedded-resource ===
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: d6d7ea0beaad07baac31c0f28e0119da
 Running client scenario 'prompts-get-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: 68551478bde149615e56008bc1574b60
-2026/04/20 23:06:18 SSEHub: registered connection 68551478bde149615e56008bc1574b60 (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection 68551478bde149615e56008bc1574b60 (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c3792641ea0
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c3792641ea0
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: 68551478bde149615e56008bc1574b60
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 38aab1a2cca4220bb3c614f58dc42ba1
+2026/04/20 23:49:55 SSEHub: registered connection 38aab1a2cca4220bb3c614f58dc42ba1 (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection 38aab1a2cca4220bb3c614f58dc42ba1 (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf804922a0
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf804922a0
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 38aab1a2cca4220bb3c614f58dc42ba1
 
 === Running scenario: prompts-get-with-image ===
 Running client scenario 'prompts-get-with-image' against server: http://localhost:18799/mcp
-2026/04/20 23:06:18 Starting MCP-GET-SSE SSE connection: be8af615ea6a1bcf2ee299640a5f3a49
-2026/04/20 23:06:18 SSEHub: registered connection be8af615ea6a1bcf2ee299640a5f3a49 (total: 1)
-2026/04/20 23:06:18 SSEHub: unregistered connection be8af615ea6a1bcf2ee299640a5f3a49 (total: 0)
-2026/04/20 23:06:18 Received kill signal.  Quitting Writer. stop 0x2c379230dd50
-2026/04/20 23:06:18 Cleaning up writer...
-2026/04/20 23:06:18 Finished cleaning up writer:  0x2c379230dd50
-2026/04/20 23:06:18 Closed MCP-GET-SSE SSE connection: be8af615ea6a1bcf2ee299640a5f3a49
+2026/04/20 23:49:55 Starting MCP-GET-SSE SSE connection: 8207039a77e0a83bfa853ec9886c68cd
+2026/04/20 23:49:55 SSEHub: registered connection 8207039a77e0a83bfa853ec9886c68cd (total: 1)
+2026/04/20 23:49:55 SSEHub: unregistered connection 8207039a77e0a83bfa853ec9886c68cd (total: 0)
+2026/04/20 23:49:55 Received kill signal.  Quitting Writer. stop 0x3fbf804925b0
+2026/04/20 23:49:55 Cleaning up writer...
+2026/04/20 23:49:55 Finished cleaning up writer:  0x3fbf804925b0
+2026/04/20 23:49:55 Closed MCP-GET-SSE SSE connection: 8207039a77e0a83bfa853ec9886c68cd
 
 === Running scenario: dns-rebinding-protection ===
 Running client scenario 'dns-rebinding-protection' against server: http://localhost:18799/mcp
@@ -438,22 +438,22 @@ Starting scenario: auth/token-endpoint-auth-basic
 Starting scenario: auth/token-endpoint-auth-post
 Starting scenario: auth/token-endpoint-auth-none
 Starting scenario: auth/pre-registration
-Executing client: ./bin/testclient http://localhost:49975/mcp
-Executing client: ./bin/testclient http://localhost:49976/mcp
-Executing client: ./bin/testclient http://localhost:49977/mcp
-Executing client: ./bin/testclient http://localhost:49978/mcp
-Executing client: ./bin/testclient http://localhost:49979/mcp
-Executing client: ./bin/testclient http://localhost:49980/mcp
-Executing client: ./bin/testclient http://localhost:49981/mcp
-Executing client: ./bin/testclient http://localhost:49982/mcp
-Executing client: ./bin/testclient http://localhost:49983/mcp
-Executing client: ./bin/testclient http://localhost:49984/mcp
-Executing client: ./bin/testclient http://localhost:49985/mcp
-Executing client: ./bin/testclient http://localhost:49986/mcp
-Executing client: ./bin/testclient http://localhost:49987/mcp
-Executing client: ./bin/testclient http://localhost:49988/mcp
+Executing client: ./bin/testclient http://localhost:61795/mcp
+Executing client: ./bin/testclient http://localhost:61796/mcp
+Executing client: ./bin/testclient http://localhost:61797/mcp
+Executing client: ./bin/testclient http://localhost:61798/mcp
+Executing client: ./bin/testclient http://localhost:61799/mcp
+Executing client: ./bin/testclient http://localhost:61800/mcp
+Executing client: ./bin/testclient http://localhost:61801/mcp
+Executing client: ./bin/testclient http://localhost:61802/mcp
+Executing client: ./bin/testclient http://localhost:61803/mcp
+Executing client: ./bin/testclient http://localhost:61804/mcp
+Executing client: ./bin/testclient http://localhost:61805/mcp
+Executing client: ./bin/testclient http://localhost:61806/mcp
+Executing client: ./bin/testclient http://localhost:61807/mcp
+Executing client: ./bin/testclient http://localhost:61808/mcp
 With context: {"client_id":"pre-registered-client","client_secret":"pre-registered-secret"}
-(node:68700) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
+(node:99572) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
 (Use `node --trace-deprecation ...` to show where the warning was created)
 
 === SUITE SUMMARY ===
@@ -527,8 +527,8 @@ Waiting for Keycloak realm...
     token_refresh_test.go:22: Keycloak not reachable at http://localhost:8180: Get "http://localhost:8180/realms/mcpkit-test": dial tcp [::1]:8180: connect: connection refused (run 'make upkcl' to start)
 --- SKIP: TestKeycloak_TokenRefresh_PasswordGrant (0.00s)
 PASS
-ok  	github.com/panyam/mcpkit/tests/keycloak	0.660s
+ok  	github.com/panyam/mcpkit/tests/keycloak	0.334s
 make[2]: *** No rule to make target `downkcl'.  Stop.
 
 === Results: 10 passed, 0 failed ===
-Finished: Mon Apr 20 23:08:25 PDT 2026
+Finished: Mon Apr 20 23:52:01 PDT 2026


### PR DESCRIPTION
## Summary

Two phases in one PR — they complement each other (cancel sends notification).

### Phase 5: Cancellation Propagation
- \`context.WithCancel\` on background goroutine
- Cancel handler calls \`rt.cancelTask()\` → goroutine's \`ctx.Done()\` fires
- \`activeTask\` struct consolidates channel + cancel func (C2 constraint)
- Goroutine checks terminal status before overwriting (prevents cancel→completed race)
- Example \`slow_compute\` uses \`select{ctx.Done, time.After}\` for clean exit

### Phase 6: Status Notifications (Option 1)
- \`notifyTaskStatus()\` helper sends \`notifications/tasks/status\`
- Cancel handler: via live MethodContext
- tasks/result handler: when detecting terminal status
- \`TaskContext.SetStatus()\`: after each update
- Queue-based delivery deferred to #288

## Tests (4 new)

| Test | What |
|------|------|
| \`TestTaskCancelStopsGoroutine\` | Goroutine exits via ctx.Done() on cancel |
| \`TestTaskStatusNotificationOnComplete\` | Client receives completed notification via tasks/result |
| \`TestTaskStatusNotificationOnCancel\` | Client receives cancelled notification |
| \`TestTaskProgressFromBackgroundNoPanic\` | Progress from dead writer doesn't panic |

## Test plan

- [x] \`go test ./core/ ./server/ ./client/\` — all pass
- [x] Example builds
- [ ] \`bash run-exercises.sh\` — exercise 12 (cancel stops goroutine), exercise 13 (notifications)