### PR TITLE
Per-tool TaskCallbacks + conformance scenarios 10-11

### DIFF
--- a/conformance/tasks/README.md
+++ b/conformance/tasks/README.md
@@ -11,6 +11,7 @@ The target server MUST register these tools:
 | `greet` | forbidden (absent) | Returns `Hello, {name}!` |
 | `slow_compute` | optional | Sleeps `seconds` seconds, returns result |
 | `failing_job` | required | Fails after 1 second |
+| `external_job` | required | Completes after 1s (uses TaskCallbacks for proxy pattern) |
 
 Both the Go example (`examples/tasks/main.go`) and TS reference server (`examples/tasks/ts-reference-server.mjs`) provide these tools.
 
@@ -46,6 +47,8 @@ SERVER_URL=http://localhost:8080/mcp npx tsx --test tasks/scenarios.test.ts
 | 07 | Task list | tasks/list returns array |
 | 08 | Required without hint | Error when required tool called without task hint |
 | 09 | Forbidden with hint | Error when forbidden tool called with task hint |
+| 10 | External proxy lifecycle | external_job completes via TaskCallbacks path |
+| 11 | External proxy tasks/get | external_job tasks/get returns valid state |
 
 ## Future scenarios
 

--- a/conformance/tasks/scenarios.test.ts
+++ b/conformance/tasks/scenarios.test.ts
@@ -192,4 +192,46 @@ describe('MCP Tasks Conformance', () => {
         }
     });
 
+    // ========================================================================
+    // Scenario 10: External proxy tool — full lifecycle via callbacks
+    // ========================================================================
+    test('scenario 10: external proxy tool completes via task callbacks', async () => {
+        // The external_job tool uses TaskCallbacks (server-side) to override
+        // tasks/get and tasks/result. From the client's perspective, the
+        // protocol is identical — this scenario verifies the tool works
+        // end-to-end through the callback dispatch path.
+        const task = await createTask('external_job', { job_id: 'conformance-10' });
+        assert.equal(task.status, 'working', 'initial status should be working');
+
+        // Poll tasks/get until terminal.
+        const terminal = await waitForTerminal(task.taskId);
+        assert.equal(terminal.status, 'completed', 'task should complete');
+
+        // Fetch result via tasks/result.
+        const result = await client.experimental.tasks.getTaskResult(task.taskId);
+        assert.ok(result, 'should return a result');
+        const meta = (result as any)._meta;
+        assert.ok(meta, 'result should have _meta');
+        const related = meta['io.modelcontextprotocol/related-task'];
+        assert.ok(related, 'should have related-task in _meta');
+        assert.equal(related.taskId, task.taskId, 'related taskId should match');
+    });
+
+    // ========================================================================
+    // Scenario 11: External proxy tool — tasks/get returns correct state
+    // ========================================================================
+    test('scenario 11: external proxy tool tasks/get returns task info', async () => {
+        const task = await createTask('external_job', { job_id: 'conformance-11' });
+
+        // Immediately poll — should get valid task info.
+        const info = await client.experimental.tasks.getTask(task.taskId);
+        assert.ok(info.taskId, 'should have taskId');
+        assert.ok(info.status, 'should have status');
+        // Status can be working or completed depending on timing.
+        assert.ok(
+            ['working', 'completed'].includes(info.status),
+            `status should be working or completed, got ${info.status}`
+        );
+    });
+
 });

--- a/docs/TASKS_V2_PLAN.md
+++ b/docs/TASKS_V2_PLAN.md
@@ -1,0 +1,291 @@
+# Tasks V2 Plan (SEP-2557)
+
+Tracking issue: panyam/mcpkit#296
+SEP: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2557
+Related SEPs:
+- SEP-2322: Multi Round-Trip Requests (MRTR) — accepted 2026-04-20
+- SEP-2260: Server requests associated with client requests
+- SEP-2567: Sessionless MCP via Explicit State Handles
+- SEP-2549: TTL units alignment (seconds, not milliseconds)
+
+Status: SEP-2557 is **Draft**, targeted for **2026-06-30-RC** milestone.
+Deadline: Conformance test suite by **2026-05-15** (per maintainer guidance).
+
+TS SDK reference: `~/projects/typescript-sdk`
+- Branch `origin/fweinberger/tooltask-handlers` — v1 fix only (getTask/getTaskResult dispatch)
+- No v2 implementation exists in TS SDK yet — we would be **first**
+
+## V1 vs V2 Protocol Comparison
+
+| Aspect | V1 (spec 2025-11-25) | V2 (SEP-2557) |
+|--------|----------------------|---------------|
+| Task creation | Client sends `task` param in tools/call | Server decides unilaterally; can return CreateTaskResult even without client hint |
+| `tasks/get` | Returns TaskInfo only | Returns full state: status + inlined result/error/inputRequests |
+| `tasks/result` | Separate blocking long-poll method | **Removed** — consolidated into `tasks/get` |
+| `tasks/list` | Session-scoped task list | **Removed** — sessions going away (SEP-2567) |
+| Capabilities | Negotiated via `TasksCap` in initialize | **Removed** — tasks are core protocol |
+| `execution.taskSupport` | Per-tool field (forbidden/optional/required) | **Removed** — simplified |
+| Elicitation mid-task | Side-channel via `tasks/result` SSE long-poll | Inline `inputRequests`/`inputResponses` in `tasks/get` (MRTR model) |
+| Sampling mid-task | Side-channel via `tasks/result` SSE long-poll | Same MRTR model |
+| `tasks/cancel` | Optional | **Required** (cooperative cancellation) |
+| TTL units | Milliseconds | **Seconds** (per SEP-2549) |
+| `requestState` | N/A | Opaque server-provided state, echoed by client in subsequent requests |
+| Status notifications | `notifications/tasks/status` with TaskInfo | Same, but with `DetailedTask` types (inlined result/error/inputRequests) |
+| `Mcp-Name` header | N/A | Required on `tasks/get` and `tasks/cancel` for routing |
+
+## Key Schema Changes
+
+### Task Object — New Discriminated Types
+
+V2 introduces subtypes of Task based on status:
+
+```
+Task (base)
+├── InputRequiredTask  — has inputRequests[]
+├── CompletedTask      — has result (ToolResult inlined)
+└── FailedTask         — has error (inlined)
+```
+
+The `tasks/get` response returns the appropriate subtype based on current status.
+
+### tasks/get — Consolidated Response
+
+V1:
+```json
+// tasks/get returns:
+{"task": {"taskId": "...", "status": "working", ...}}
+
+// tasks/result (separate method) returns:
+{"content": [...], "_meta": {"io.modelcontextprotocol/related-task": {"taskId": "..."}}}
+```
+
+V2:
+```json
+// tasks/get returns everything:
+{
+  "taskId": "...",
+  "status": "completed",
+  "result": {"content": [...]},      // inlined when completed
+  "requestState": "opaque-server-state"
+}
+
+// Or for input_required:
+{
+  "taskId": "...",
+  "status": "input_required",
+  "inputRequests": [{"method": "elicitation/create", ...}],
+  "requestState": "opaque-server-state"
+}
+```
+
+### tasks/cancel — Now Required + requestState
+
+```json
+// Request
+{"method": "tasks/cancel", "params": {"taskId": "..."}}
+
+// Response includes requestState
+{"taskId": "...", "status": "cancelled", "requestState": "..."}
+```
+
+### requestState Flow
+
+1. Server returns `requestState` in `tasks/get` and `tasks/cancel` responses
+2. Client echoes `requestState` in subsequent `tasks/get` and `tasks/cancel` requests
+3. Enables stateless server deployments (Step Functions, load-balanced)
+4. "Last writer wins" semantics for parallel `tasks/get` calls
+
+### notifications/tasks/status — DetailedTask
+
+Terminal status notifications now include inlined results:
+```json
+{
+  "method": "notifications/tasks/status",
+  "params": {
+    "taskId": "...",
+    "status": "completed",
+    "result": {"content": [...]}
+  }
+}
+```
+
+## Architecture: V1 and V2 Coexist
+
+```
+server/
+├── tasks_experimental.go     ← v1 (current, spec 2025-11-25)
+├── tasks_v2.go               ← v2 (SEP-2557)
+├── task_callbacks.go          ← shared: TaskCallbacks (per-tool overrides)
+├── task_store.go              ← shared: TaskStore (both versions)
+├── task_store_v2.go           ← v2 additions (requestState, inlined results)
+��── task_session.go            ← v1: TaskContext (side-channel model)
+├── task_session_v2.go         ← v2: TaskContextV2 (MRTR model)
+└── task_queue.go              ← v1 only: message queue (v2 doesn't need it)
+
+client/
+├── tasks.go                   ← v1 helpers
+└── tasks_v2.go                ← v2 helpers (tasks/get returns everything)
+
+core/
+├── task.go                    ← shared types + v2 DetailedTask types
+
+conformance/
+├── tasks/scenarios.test.ts    ← v1 conformance (9+ scenarios)
+└── tasks-v2/scenarios.test.ts ← v2 conformance (new scenarios)
+
+examples/tasks/
+├── main.go                    ← supports both v1 and v2 (flag: --tasks-version)
+└── ts-reference-server.mjs    ← same
+```
+
+### Registration
+
+```go
+// v1 (current)
+server.RegisterTasks(server.TasksConfig{Server: srv})
+
+// v2 (new)
+server.RegisterTasksV2(server.TasksV2Config{Server: srv})
+```
+
+### What's Shared
+
+- `TaskStore` interface (v2 adds `SetRequestState`/`GetRequestState`)
+- `InMemoryTaskStore` (TTL, terminal guards)
+- `TaskCallbacks` (per-tool getTask/getResult overrides)
+- `core.TaskInfo`, `core.TaskStatus`, `core.CreateTaskResult`
+- `taskRuntime` (active task tracking, cancel propagation)
+
+### What's V2-Only
+
+- Inlined result/error/inputRequests in `tasks/get` response
+- `requestState` field on requests and responses
+- `DetailedTask` types (`CompletedTask`, `FailedTask`, `InputRequiredTask`)
+- MRTR-based elicitation (no side-channel queue)
+- No `tasks/result` handler
+- No `tasks/list` handler
+- No capability advertisement (tasks are core)
+- TTL in seconds (not milliseconds)
+- `Mcp-Name` header requirement
+
+## Implementation Phases
+
+### Phase V2-1: Core Types + tasks/get Handler
+**Goal**: Basic v2 task lifecycle — create, poll, complete.
+
+- [ ] **V2-1a.** `core/task.go`: `DetailedTask` types (CompletedTask, FailedTask, InputRequiredTask)
+- [ ] **V2-1b.** `core/task.go`: `RequestState` field on `GetTaskResult`
+- [ ] **V2-1c.** `server/task_store_v2.go`: `requestState` storage on taskEntry
+- [ ] **V2-1d.** `server/tasks_v2.go`: `RegisterTasksV2()` + `TasksV2Config`
+- [ ] **V2-1e.** `server/tasks_v2.go`: `tasks/get` handler — returns inlined result/error for terminal tasks
+- [ ] **V2-1f.** `server/tasks_v2.go`: `tasks/cancel` handler — cooperative, required
+- [ ] **V2-1g.** No `tasks/result`, no `tasks/list`, no capability advertisement
+- [ ] **V2-1h.** TTL in seconds (not milliseconds)
+- [ ] **V2-1i.** Tests: basic lifecycle, inlined results, cancel
+
+### Phase V2-2: Server-Directed Task Creation
+**Goal**: Server returns CreateTaskResult without client task hint.
+
+- [ ] **V2-2a.** Middleware: always return CreateTaskResult for task-capable tools (no `task` param needed)
+- [ ] **V2-2b.** Server can return immediate result even when task was created
+- [ ] **V2-2c.** Tests: unsolicited task creation, immediate result shortcut
+
+### Phase V2-3: MRTR Elicitation/Sampling (inputRequests/inputResponses)
+**Goal**: Mid-task elicitation via inline model, not side-channel.
+
+- [ ] **V2-3a.** `TaskContextV2` with `RequestInput()` — sets status to `input_required`, stores `inputRequests`
+- [ ] **V2-3b.** `tasks/get` returns `inputRequests` when `input_required`
+- [ ] **V2-3c.** Client sends `inputResponses` in next `tasks/get` call
+- [ ] **V2-3d.** Handler receives `inputResponses`, resumes work
+- [ ] **V2-3e.** Tests: elicitation round-trip, sampling round-trip
+
+### Phase V2-4: requestState
+**Goal**: Stateless server support.
+
+- [ ] **V2-4a.** `requestState` returned in `tasks/get` and `tasks/cancel` responses
+- [ ] **V2-4b.** Client echoes `requestState` in subsequent requests
+- [ ] **V2-4c.** Server uses `requestState` for routing (opaque passthrough)
+- [ ] **V2-4d.** Tests: requestState round-trip, last-writer-wins
+
+### Phase V2-5: Status Notifications with DetailedTask
+**Goal**: Terminal notifications include inlined results.
+
+- [ ] **V2-5a.** `notifications/tasks/status` uses DetailedTask for terminal states
+- [ ] **V2-5b.** Non-terminal notifications remain lightweight
+- [ ] **V2-5c.** Tests: notification payloads for completed/failed/input_required
+
+### Phase V2-6: Client Helpers
+**Goal**: Client auto-detects and handles v2 responses.
+
+- [ ] **V2-6a.** `client/tasks_v2.go`: `CallToolV2()` — handles CreateTaskResult, polls via tasks/get
+- [ ] **V2-6b.** `WaitForTaskV2()` — polls tasks/get, extracts inlined result
+- [ ] **V2-6c.** `HandleInputRequired()` — sends inputResponses
+- [ ] **V2-6d.** Tests: full client-side workflow
+
+### Phase V2-7: Conformance Suite
+**Goal**: TS conformance tests against both Go and TS servers.
+
+- [ ] **V2-7a.** `conformance/tasks-v2/scenarios.test.ts` — full scenario suite
+- [ ] **V2-7b.** Example server with `--tasks-version=v2` flag
+- [ ] **V2-7c.** TS reference server v2 mode
+- [ ] **V2-7d.** `make testconf-tasks-v2` target
+- [ ] **V2-7e.** Wire format comparison (`test-side-by-side.sh` v2 mode)
+
+### Phase V2-8: Documentation
+- [ ] **V2-8a.** Update CLAUDE.md with v2 entries
+- [ ] **V2-8b.** Update examples/tasks/README.md
+- [ ] **V2-8c.** Update conformance/tasks/README.md → tasks-v2
+- [ ] **V2-8d.** Update docs/ARCHITECTURE.md
+
+## V2 Conformance Scenarios (Phase V2-7)
+
+| # | Scenario | What it tests |
+|---|----------|---------------|
+| 01 | Sync tool call (no task) | Tool returns immediately, no CreateTaskResult |
+| 02 | Server-directed task creation | Server returns CreateTaskResult without client hint |
+| 03 | tasks/get returns working status | Poll non-terminal task |
+| 04 | tasks/get returns completed + inlined result | Terminal poll returns result |
+| 05 | tasks/get returns failed + inlined error | Failed task returns error inline |
+| 06 | tasks/cancel (cooperative) | Cancel returns cancelled status |
+| 07 | tasks/cancel on terminal task | Error: can't cancel completed/failed |
+| 08 | TTL in seconds | Verify TTL field is seconds, not ms |
+| 09 | requestState round-trip | Server returns state, client echoes |
+| 10 | inputRequests via tasks/get | input_required status + inputRequests |
+| 11 | inputResponses via tasks/get | Client sends responses, task resumes |
+| 12 | Status notification with DetailedTask | Terminal notification includes result |
+| 13 | No tasks/result method | Server rejects tasks/result call |
+| 14 | No tasks/list method | Server rejects tasks/list call |
+| 15 | No capabilities advertisement | tasks not in initialize.capabilities |
+| 16 | Immediate result shortcut | Server returns result directly (skip polling) |
+
+## TS SDK Reference (Research Snapshot, 2026-04-21)
+
+### Key files on `origin/fweinberger/tooltask-handlers`:
+- `packages/core/src/shared/taskManager.ts` — Central orchestration (862 lines)
+  - `requestStream()` — AsyncGenerator: task creation → poll → result
+  - `handleGetTask()` — checks overrides first, falls through to TaskStore
+  - `handleGetTaskPayload()` — long-poll with queue draining + override dispatch
+  - `extractInboundTaskContext()` — builds TaskContext from request
+  - `wrapSendRequest()` — auto-sets `input_required` status before elicit/sample
+- `packages/server/src/experimental/tasks/interfaces.ts` — ToolTaskHandler interface
+  - `createTask` (required), `getTask` (optional), `getTaskResult` (optional)
+- `packages/server/src/experimental/tasks/mcpServer.ts` — ExperimentalMcpServerTasks
+  - `_taskToTool` map: taskId → toolName (in-memory only)
+  - `_dispatch()` — routes getTask/getTaskResult to per-tool handlers
+  - `_installOverrides()` — hooks into TaskManager
+
+### Design notes:
+- TS SDK uses `_taskToTool` map (in-memory) — same approach we should use
+- Override handlers are optional; omitting falls through to TaskStore
+- `getTaskResult` mapping cleaned up only after handler resolves (not on error)
+- No v2 implementation exists yet in TS SDK
+
+## Open Questions
+
+1. **requestState semantics**: How does the server generate/validate requestState? Is it JWT-like, or opaque blob?
+2. **MRTR interaction**: How exactly do inputResponses flow back? Is it a new field on tasks/get params, or a separate method?
+3. **Backward compat**: Can a server advertise both v1 and v2? Or does protocol version determine which?
+4. **Mcp-Name header**: Is this transport-level or protocol-level? Does it affect stdio transport?
+5. **Session removal**: SEP-2567 removes sessions — how does this affect TaskStore session isolation?
+
+These will resolve as SEP-2557 moves from Draft to accepted. Monitor the PR for updates.

--- a/examples/tasks/README.md
+++ b/examples/tasks/README.md
@@ -9,6 +9,7 @@ Demonstrates MCP Tasks (spec 2025-11-25) — async tool execution with lifecycle
 | Core | `core.ToolDef.Execution`, `core.TaskSupportOptional`, `core.TaskSupportRequired`, `core.DetachForBackground` |
 | Server | `server.RegisterTasks`, `server.TasksConfig`, `server.TaskContext`, `server.GetTaskContext` |
 | Side-channel | `TaskContext.TaskElicit` (elicitation from background task), `TaskContext.TaskSample` (sampling from background task) |
+| Callbacks | `server.TaskCallbacks` (per-tool `GetTask`/`GetResult` overrides for external proxy pattern) |
 | MCP methods | `tasks/get`, `tasks/result`, `tasks/cancel`, `tasks/list` |
 
 ## Setup
@@ -23,7 +24,7 @@ go run . -addr :$PORT
 
 ### TS SDK reference server (for comparison)
 
-A TypeScript reference server with the same 5 tools is included for side-by-side wire format comparison. It imports the official [MCP TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk) as a dependency:
+A TypeScript reference server with the same 6 tools is included for side-by-side wire format comparison. It imports the official [MCP TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk) as a dependency:
 
 ```bash
 cd examples/tasks
@@ -47,6 +48,7 @@ MCPJam, VS Code, or any MCP client: `http://localhost:$PORT/mcp`
 | `failing_job` | required | Always fails after 1s. Must be called as a task. |
 | `confirm_delete` | required + elicitation | Asks user for confirmation before deleting. |
 | `write_haiku` | required + sampling | Asks the LLM to write a haiku on a topic. |
+| `external_job` | required + TaskCallbacks | Simulates proxying an external job system. |
 
 ## Important: Host Support Required
 
@@ -540,12 +542,13 @@ Create a task and send progress notifications from the tool handler.
 
 | File | What |
 |------|------|
-| `main.go` | Go server: 5 tools, `server.RegisterTasks()` |
-| `ts-reference-server.mjs` | TS SDK reference server: same 5 tools, for comparison |
+| `main.go` | Go server: 6 tools, `server.RegisterTasks()` |
+| `ts-reference-server.mjs` | TS SDK reference server: same 6 tools, for comparison |
 | `run-exercises.sh` | Runs all README exercises against a running server (Go or TS) |
 | `test-side-by-side.sh` | Starts both servers, compares wire format side-by-side |
 | `package.json` | TS SDK dependencies for the reference server |
 | `../../server/tasks_experimental.go` | Tasks middleware, handlers, RegisterTasks |
+| `../../server/task_callbacks.go` | TaskCallbacks struct (per-tool GetTask/GetResult overrides) |
 | `../../server/task_store.go` | TaskStore interface + InMemoryTaskStore |
 | `../../server/task_session.go` | TaskContext, TaskElicit, TaskSample |
 | `../../client/tasks.go` | Client helpers: GetTask, ToolCallAsTask, etc. |

--- a/examples/tasks/main.go
+++ b/examples/tasks/main.go
@@ -1,9 +1,12 @@
 // Example: MCP Tasks — async tool execution with lifecycle tracking.
 //
-// Demonstrates three tools with different task support modes:
-//   - greet:        sync-only (no Execution field = forbidden per spec)
-//   - slow_compute: optional task support (client chooses sync or async)
-//   - failing_job:  required task support (must be invoked as task)
+// Demonstrates tools with different task support modes:
+//   - greet:          sync-only (no Execution field = forbidden per spec)
+//   - slow_compute:   optional task support (client chooses sync or async)
+//   - failing_job:    required task support (must be invoked as task)
+//   - confirm_delete: required task + elicitation (asks user before deleting)
+//   - write_haiku:    required task + sampling (asks LLM to write a haiku)
+//   - external_job:   required task + TaskCallbacks (external proxy pattern)
 //
 // Run:  go run . -addr :8080
 // Connect MCPJam or VS Code to http://localhost:8080/mcp
@@ -226,6 +229,53 @@ func main() {
 			return core.TextResult(fmt.Sprintf("Haiku about %s:\n%s", args.Topic, result.Content.Text)), nil
 		},
 	)
+
+	// external_job: demonstrates TaskCallbacks (per-tool getTask/getResult overrides).
+	// Simulates proxying an external job system where the tool provides custom
+	// task state lookup instead of relying on the default TaskStore.
+	srv.Register(server.Tool{
+		ToolDef: core.ToolDef{
+			Name:        "external_job",
+			Description: "Simulates an external job system with custom task state lookup. Demonstrates TaskCallbacks for the external proxy pattern.",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"job_id": map[string]any{
+						"type":        "string",
+						"description": "External job ID to track",
+						"default":     "job-001",
+					},
+				},
+			},
+			Execution: &core.ToolExecution{TaskSupport: core.TaskSupportRequired},
+		},
+		Handler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+			var args struct {
+				JobID string `json:"job_id"`
+			}
+			json.Unmarshal(req.Arguments, &args)
+			if args.JobID == "" {
+				args.JobID = "job-001"
+			}
+			log.Printf("[external_job] started external job %s", args.JobID)
+			time.Sleep(1 * time.Second)
+			log.Printf("[external_job] external job %s completed", args.JobID)
+			return core.TextResult(fmt.Sprintf("External job %s completed", args.JobID)), nil
+		},
+		TaskCallbacks: &server.TaskCallbacks{
+			GetTask: func(ctx core.MethodContext, taskID string) (core.GetTaskResult, bool) {
+				// In a real system, this would query an external API (Step Functions, etc.)
+				// For demo purposes, we augment the status message.
+				log.Printf("[external_job] custom getTask for %s", taskID)
+				return core.GetTaskResult{}, false // fall through to store
+			},
+			GetResult: func(ctx core.MethodContext, taskID string) (core.ToolResult, bool) {
+				// In a real system, this would fetch the result from the external system.
+				log.Printf("[external_job] custom getResult for %s", taskID)
+				return core.ToolResult{}, false // fall through to store
+			},
+		},
+	})
 
 	// Register tasks capability on the server.
 	server.RegisterTasks(server.TasksConfig{Server: srv})

--- a/examples/tasks/ts-reference-server.mjs
+++ b/examples/tasks/ts-reference-server.mjs
@@ -75,6 +75,15 @@ const TOOLS = [
             properties: { topic: { type: 'string', description: 'Topic for the haiku', default: 'nature' } }
         },
         execution: { taskSupport: 'required' }
+    },
+    {
+        name: 'external_job',
+        description: 'Simulates an external job system with custom task state lookup. Demonstrates the external proxy pattern.',
+        inputSchema: {
+            type: 'object',
+            properties: { job_id: { type: 'string', description: 'External job ID to track', default: 'job-001' } }
+        },
+        execution: { taskSupport: 'required' }
     }
 ];
 
@@ -253,6 +262,24 @@ async function handleToolCall(server, request, ctx) {
         return { task };
     }
 
+    if (name === 'external_job') {
+        if (!taskParams) throw new Error('Tool "external_job" requires task invocation');
+        const task = await taskStore.createTask(
+            { ttl: taskParams.ttl, pollInterval: taskParams.pollInterval ?? 1000 },
+            ctx.mcpReq.id, request, ctx.sessionId
+        );
+        const jobId = args?.job_id || 'job-001';
+        console.log(`[external_job] started external job ${jobId}, task ${task.taskId}`);
+        (async () => {
+            await new Promise(r => setTimeout(r, 1000));
+            console.log(`[external_job] external job ${jobId} completed`);
+            await storeResult(server, task.taskId, 'completed', {
+                content: [{ type: 'text', text: `External job ${jobId} completed` }]
+            }, ctx.sessionId);
+        })();
+        return { task };
+    }
+
     throw new Error(`Unknown tool: ${name}`);
 }
 
@@ -343,7 +370,7 @@ const httpServer = createServer(async (req, res) => {
 
 httpServer.listen(PORT, () => {
     console.log(`TS reference server on http://localhost:${PORT}/mcp`);
-    console.log('Tools: greet, slow_compute, failing_job, confirm_delete, write_haiku');
+    console.log('Tools: greet, slow_compute, failing_job, confirm_delete, write_haiku, external_job');
 });
 
 process.on('SIGINT', () => { process.exit(0); });

--- a/server/dispatch.go
+++ b/server/dispatch.go
@@ -157,6 +157,9 @@ type toolEntry struct {
 	// arguments before the handler is invoked. nil if the tool declared
 	// no schema (bypass validation).
 	schema *compiledSchema
+	// taskCallbacks are optional per-tool overrides for tasks/get and
+	// tasks/result. Nil means use the TaskStore directly.
+	taskCallbacks *TaskCallbacks
 }
 
 type resourceEntry struct {

--- a/server/registration.go
+++ b/server/registration.go
@@ -19,6 +19,10 @@ import core "github.com/panyam/mcpkit/core"
 type Tool struct {
 	core.ToolDef
 	Handler core.ToolHandler
+	// TaskCallbacks provides optional per-tool overrides for tasks/get and
+	// tasks/result handlers. When set, the task protocol consults these
+	// callbacks before falling through to the TaskStore. See [TaskCallbacks].
+	TaskCallbacks *TaskCallbacks
 }
 
 // Resource bundles a resource definition with its handler.
@@ -58,6 +62,9 @@ func (s *Server) Register(items ...any) {
 		switch v := item.(type) {
 		case Tool:
 			s.RegisterTool(v.ToolDef, v.Handler)
+			if v.TaskCallbacks != nil {
+				s.Registry().SetToolCallbacks(v.Name, v.TaskCallbacks)
+			}
 		case core.TypedToolResult:
 			s.RegisterTool(v.ToolDef, v.Handler)
 		case Resource:

--- a/server/registry.go
+++ b/server/registry.go
@@ -71,6 +71,30 @@ func (r *Registry) ToolDef(name string) (core.ToolDef, bool) {
 	return entry.def, true
 }
 
+// SetToolCallbacks associates per-tool task callbacks with a registered tool.
+// The tool must already be registered. Thread-safe.
+func (r *Registry) SetToolCallbacks(name string, cb *TaskCallbacks) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	entry, ok := r.tools[name]
+	if !ok {
+		return
+	}
+	entry.taskCallbacks = cb
+	r.tools[name] = entry
+}
+
+// ToolCallbacks returns the per-tool task callbacks for a tool, or nil.
+func (r *Registry) ToolCallbacks(name string) *TaskCallbacks {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	entry, ok := r.tools[name]
+	if !ok {
+		return nil
+	}
+	return entry.taskCallbacks
+}
+
 // AddTool adds a tool to the registry. Thread-safe.
 // Broadcasts notifications/tools/list_changed if OnChange is set.
 //

--- a/server/task_callbacks.go
+++ b/server/task_callbacks.go
@@ -1,0 +1,45 @@
+package server
+
+import "github.com/panyam/mcpkit/core"
+
+// TaskCallbacks provides optional per-tool overrides for task protocol
+// handlers. When a tool registers callbacks, the tasks/get and tasks/result
+// handlers consult them before falling through to the TaskStore.
+//
+// This enables the "external proxy" pattern where a tool wraps an external
+// job system (e.g., AWS Step Functions, CI/CD pipelines) and the external
+// system is the source of truth for task state — not the in-memory store.
+//
+// Designed for extensibility: v2 (SEP-2557) will add OnCancel and
+// OnInputResponse fields without structural changes.
+//
+// Example:
+//
+//	srv.Register(server.Tool{
+//	    ToolDef: core.ToolDef{
+//	        Name:      "deploy",
+//	        Execution: &core.ToolExecution{TaskSupport: core.TaskSupportRequired},
+//	    },
+//	    Handler: deployHandler,
+//	    TaskCallbacks: &server.TaskCallbacks{
+//	        GetTask: func(ctx core.MethodContext, taskID string) (core.GetTaskResult, bool) {
+//	            // Query external system for task state
+//	            state, err := stepFunctions.DescribeExecution(taskID)
+//	            if err != nil {
+//	                return core.GetTaskResult{}, false // fall through to store
+//	            }
+//	            return core.GetTaskResult{TaskInfo: toTaskInfo(state)}, true
+//	        },
+//	    },
+//	})
+type TaskCallbacks struct {
+	// GetTask overrides the default TaskStore lookup for tasks/get.
+	// Return (result, true) to use the override response.
+	// Return (_, false) to fall through to the TaskStore.
+	GetTask func(ctx core.MethodContext, taskID string) (core.GetTaskResult, bool)
+
+	// GetResult overrides the default TaskStore lookup for tasks/result.
+	// Return (result, true) to use the override response.
+	// Return (_, false) to fall through to the TaskStore.
+	GetResult func(ctx core.MethodContext, taskID string) (core.ToolResult, bool)
+}

--- a/server/task_callbacks_test.go
+++ b/server/task_callbacks_test.go
@@ -1,0 +1,218 @@
+package server_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/panyam/mcpkit/client"
+	"github.com/panyam/mcpkit/core"
+	. "github.com/panyam/mcpkit/server"
+)
+
+// TestTaskCallbacksGetTask verifies that a tool with a custom GetTask
+// callback is consulted by the tasks/get handler before the TaskStore.
+func TestTaskCallbacksGetTask(t *testing.T) {
+	srv := NewServer(core.ServerInfo{Name: "cb-test", Version: "0.0.1"})
+
+	// Tool with custom GetTask callback that augments the status message.
+	var getTaskCalled atomic.Int32
+	unblock := make(chan struct{}, 1)
+
+	srv.Register(Tool{
+		ToolDef: core.ToolDef{
+			Name:        "proxy-job",
+			Description: "Simulates an external job with custom getTask",
+			InputSchema: map[string]any{"type": "object"},
+			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
+		},
+		Handler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+			select {
+			case <-unblock:
+			case <-ctx.Done():
+			}
+			return core.TextResult("done"), nil
+		},
+		TaskCallbacks: &TaskCallbacks{
+			GetTask: func(ctx core.MethodContext, taskID string) (core.GetTaskResult, bool) {
+				getTaskCalled.Add(1)
+				return core.GetTaskResult{
+					TaskInfo: core.TaskInfo{
+						TaskID:        taskID,
+						Status:        core.TaskWorking,
+						StatusMessage: "custom-override",
+					},
+				}, true
+			},
+		},
+	})
+
+	RegisterTasks(TasksConfig{Server: srv})
+
+	c := connectClient(t, srv)
+
+	// Create a task.
+	created, err := client.ToolCallAsTask(c, "proxy-job", map[string]any{})
+	if err != nil {
+		t.Fatalf("ToolCallAsTask: %v", err)
+	}
+
+	// Poll via tasks/get — should hit the custom callback.
+	got, err := client.GetTask(c, created.Task.TaskID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+
+	if getTaskCalled.Load() == 0 {
+		t.Error("GetTask callback was not invoked")
+	}
+	if got.StatusMessage != "custom-override" {
+		t.Errorf("StatusMessage = %q, want %q", got.StatusMessage, "custom-override")
+	}
+
+	// Unblock so the goroutine can finish cleanly.
+	close(unblock)
+}
+
+// TestTaskCallbacksGetResult verifies that a tool with a custom GetResult
+// callback is consulted by the tasks/result handler before the TaskStore.
+func TestTaskCallbacksGetResult(t *testing.T) {
+	srv := NewServer(core.ServerInfo{Name: "cb-test", Version: "0.0.1"})
+
+	var getResultCalled atomic.Int32
+
+	srv.Register(Tool{
+		ToolDef: core.ToolDef{
+			Name:        "proxy-result",
+			Description: "Simulates an external job with custom getResult",
+			InputSchema: map[string]any{"type": "object"},
+			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
+		},
+		Handler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+			return core.TextResult("store-result"), nil
+		},
+		TaskCallbacks: &TaskCallbacks{
+			GetResult: func(ctx core.MethodContext, taskID string) (core.ToolResult, bool) {
+				getResultCalled.Add(1)
+				return core.ToolResult{
+					Content: []core.Content{{Type: "text", Text: "custom-result"}},
+				}, true
+			},
+		},
+	})
+
+	RegisterTasks(TasksConfig{Server: srv})
+
+	c := connectClient(t, srv)
+
+	// Create task — tool returns immediately, task completes fast.
+	created, err := client.ToolCallAsTask(c, "proxy-result", map[string]any{})
+	if err != nil {
+		t.Fatalf("ToolCallAsTask: %v", err)
+	}
+
+	// Wait for terminal state via tasks/get polling.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err = client.WaitForTask(ctx, c, created.Task.TaskID, 50*time.Millisecond)
+	if err != nil {
+		t.Fatalf("WaitForTask: %v", err)
+	}
+
+	// Now call tasks/result — should hit the custom GetResult callback.
+	result, _, err := client.GetTaskPayload(c, created.Task.TaskID)
+	if err != nil {
+		t.Fatalf("GetTaskPayload: %v", err)
+	}
+
+	if getResultCalled.Load() == 0 {
+		t.Error("GetResult callback was not invoked")
+	}
+
+	// The custom callback returns "custom-result", not "store-result".
+	if len(result.Content) == 0 || result.Content[0].Text != "custom-result" {
+		var got string
+		if len(result.Content) > 0 {
+			got = result.Content[0].Text
+		}
+		t.Errorf("result text = %q, want %q", got, "custom-result")
+	}
+}
+
+// TestTaskCallbacksFallthrough verifies that when a callback returns false,
+// the handler falls through to the TaskStore.
+func TestTaskCallbacksFallthrough(t *testing.T) {
+	srv := NewServer(core.ServerInfo{Name: "cb-test", Version: "0.0.1"})
+
+	var getTaskCalled atomic.Int32
+
+	srv.Register(Tool{
+		ToolDef: core.ToolDef{
+			Name:        "fallthrough-job",
+			Description: "Callback returns false to fall through",
+			InputSchema: map[string]any{"type": "object"},
+			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
+		},
+		Handler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+			return core.TextResult("real-result"), nil
+		},
+		TaskCallbacks: &TaskCallbacks{
+			GetTask: func(ctx core.MethodContext, taskID string) (core.GetTaskResult, bool) {
+				getTaskCalled.Add(1)
+				return core.GetTaskResult{}, false // fall through to store
+			},
+		},
+	})
+
+	RegisterTasks(TasksConfig{Server: srv})
+
+	c := connectClient(t, srv)
+
+	created, err := client.ToolCallAsTask(c, "fallthrough-job", map[string]any{})
+	if err != nil {
+		t.Fatalf("ToolCallAsTask: %v", err)
+	}
+
+	// Wait for completion so the store has the task.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	client.WaitForTask(ctx, c, created.Task.TaskID, 50*time.Millisecond)
+
+	// Poll via tasks/get — callback returns false, so store handles it.
+	got, err := client.GetTask(c, created.Task.TaskID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+
+	if getTaskCalled.Load() == 0 {
+		t.Error("GetTask callback should still be called (before fallthrough)")
+	}
+	// Store has the real status — completed (since tool returned successfully).
+	if got.Status != core.TaskCompleted {
+		t.Errorf("status = %q, want %q", got.Status, core.TaskCompleted)
+	}
+}
+
+// TestTaskCallbacksNoCallbacks verifies that tools without TaskCallbacks
+// work exactly as before (pure TaskStore path).
+func TestTaskCallbacksNoCallbacks(t *testing.T) {
+	srv, unblock := newTaskServer(t) // uses default tools, no callbacks
+	c := connectClient(t, srv)
+
+	created, err := client.ToolCallAsTask(c, "slow", map[string]any{"data": "x"})
+	if err != nil {
+		t.Fatalf("ToolCallAsTask: %v", err)
+	}
+
+	// Should still work via TaskStore.
+	got, err := client.GetTask(c, created.Task.TaskID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if got.Status != core.TaskWorking {
+		t.Errorf("status = %q, want working", got.Status)
+	}
+
+	close(unblock)
+}

--- a/server/tasks_experimental.go
+++ b/server/tasks_experimental.go
@@ -63,32 +63,60 @@ type activeTask struct {
 // and the tasks/* method handlers. Scoped to a single Register() call —
 // no package-level globals.
 type taskRuntime struct {
-	store  TaskStore
-	queue  TaskMessageQueue
-	mu     sync.Mutex
-	active map[string]*activeTask
+	store    TaskStore
+	queue    TaskMessageQueue
+	registry *Registry // for looking up per-tool TaskCallbacks
+	mu       sync.Mutex
+	active   map[string]*activeTask
+	creatorToolForTask map[string]string // taskID → tool name (for callback dispatch)
 }
 
-func newTaskRuntime(store TaskStore, queue TaskMessageQueue) *taskRuntime {
+func newTaskRuntime(store TaskStore, queue TaskMessageQueue, reg *Registry) *taskRuntime {
 	return &taskRuntime{
-		store:  store,
-		queue:  queue,
-		active: make(map[string]*activeTask),
+		store:    store,
+		queue:    queue,
+		registry: reg,
+		active:   make(map[string]*activeTask),
+		creatorToolForTask: make(map[string]string),
 	}
 }
 
-// register stores the active task entry.
-func (rt *taskRuntime) register(taskID string, at *activeTask) {
+// register stores the active task entry and its tool name.
+func (rt *taskRuntime) register(taskID, tool string, at *activeTask) {
 	rt.mu.Lock()
 	rt.active[taskID] = at
+	rt.creatorToolForTask[taskID] = tool
 	rt.mu.Unlock()
 }
 
-// unregister removes the active task entry.
+// unregister removes the active task entry. The creatorToolForTask mapping
+// is kept so that tasks/get and tasks/result can still dispatch to per-tool
+// callbacks after the background goroutine finishes (matching TS SDK
+// behavior where getTaskResult cleans up only after the handler resolves).
 func (rt *taskRuntime) unregister(taskID string) {
 	rt.mu.Lock()
 	delete(rt.active, taskID)
 	rt.mu.Unlock()
+}
+
+// cleanupToolName removes the creatorToolForTask mapping. Called after
+// tasks/result handler resolves for a terminal task.
+func (rt *taskRuntime) cleanupToolName(taskID string) {
+	rt.mu.Lock()
+	delete(rt.creatorToolForTask, taskID)
+	rt.mu.Unlock()
+}
+
+// getToolCallbacks returns the TaskCallbacks for the tool that created
+// the given task, or nil if no callbacks are registered.
+func (rt *taskRuntime) getToolCallbacks(taskID string) *TaskCallbacks {
+	rt.mu.Lock()
+	name := rt.creatorToolForTask[taskID]
+	rt.mu.Unlock()
+	if name == "" || rt.registry == nil {
+		return nil
+	}
+	return rt.registry.ToolCallbacks(name)
 }
 
 // getChannel returns the side-channel request channel for a task, or nil.
@@ -121,13 +149,13 @@ func RegisterTasks(cfg TasksConfig) {
 	srv := cfg.Server
 	store := cfg.Store
 	reg := srv.Registry()
-	rt := newTaskRuntime(store, cfg.MessageQueue)
+	rt := newTaskRuntime(store, cfg.MessageQueue, reg)
 
 	// Install middleware for tools/call interception.
 	srv.UseMiddleware(taskMiddleware(reg, rt, cfg))
 
 	// Register tasks/* protocol methods.
-	srv.HandleMethod("tasks/get", makeGetHandler(store))
+	srv.HandleMethod("tasks/get", makeGetHandler(rt))
 	srv.HandleMethod("tasks/result", makeResultHandler(rt))
 	srv.HandleMethod("tasks/list", makeListHandler(store))
 	srv.HandleMethod("tasks/cancel", makeCancelHandler(rt))
@@ -245,7 +273,7 @@ func taskMiddleware(reg *Registry, rt *taskRuntime, cfg TasksConfig) Middleware 
 				progressToken: progressToken,
 			}
 			bgCtx = WithTaskContext(bgCtx, tc)
-			rt.register(taskID, &activeTask{requests: reqCh, cancel: cancelFunc})
+			rt.register(taskID, envelope.Name, &activeTask{requests: reqCh, cancel: cancelFunc})
 
 			defer func() {
 				cancelFunc()
@@ -302,7 +330,7 @@ type taskHint struct {
 
 // --- Method Handlers ---
 
-func makeGetHandler(store TaskStore) MethodHandler {
+func makeGetHandler(rt *taskRuntime) MethodHandler {
 	return func(ctx core.MethodContext, id json.RawMessage, params json.RawMessage) *core.Response {
 		var p struct {
 			TaskID string `json:"taskId"`
@@ -310,7 +338,16 @@ func makeGetHandler(store TaskStore) MethodHandler {
 		if err := json.Unmarshal(params, &p); err != nil {
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, err.Error())
 		}
-		info, ok := store.Get(p.TaskID, ctx.SessionID())
+
+		// Check per-tool callbacks first (external proxy pattern).
+		if cb := rt.getToolCallbacks(p.TaskID); cb != nil && cb.GetTask != nil {
+			if result, ok := cb.GetTask(ctx, p.TaskID); ok {
+				return core.NewResponse(id, result)
+			}
+		}
+
+		// Fall through to TaskStore.
+		info, ok := rt.store.Get(p.TaskID, ctx.SessionID())
 		if !ok {
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, "task not found: "+p.TaskID)
 		}
@@ -357,9 +394,22 @@ func makeResultHandler(rt *taskRuntime) MethodHandler {
 			}
 
 			if info.Status.IsTerminal() {
-				result, _ := store.GetResult(p.TaskID, sid)
+				// Check per-tool GetResult callback first (external proxy pattern).
+				var result core.ToolResult
+				if cb := rt.getToolCallbacks(p.TaskID); cb != nil && cb.GetResult != nil {
+					if overrideResult, ok := cb.GetResult(ctx, p.TaskID); ok {
+						result = overrideResult
+					} else {
+						result, _ = store.GetResult(p.TaskID, sid)
+					}
+				} else {
+					result, _ = store.GetResult(p.TaskID, sid)
+				}
 
 				rt.queue.DequeueAll(p.TaskID)
+				// Clean up creatorToolForTask mapping after result is served (matches
+				// TS SDK: delete _taskToTool after handler resolves).
+				rt.cleanupToolName(p.TaskID)
 
 				// Send status notification from this live handler context (Phase 6).
 				// The background goroutine's context may have a dead notifyFunc,

--- a/tests/reports/report.html
+++ b/tests/reports/report.html
@@ -19,7 +19,7 @@ pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto; 
 code.cmd { background: #f0f0f0; padding: 2px 6px; border-radius: 3px; font-size: 13px; }
 </style></head><body>
 <h1>MCPKit Test Report</h1>
-<div class='meta'>Branch: <strong>feat/conformance-tasks-277</strong> | Commit: <code>18883f9</code> | Date: 2026-04-21 12:54:20</div>
+<div class='meta'>Branch: <strong>feat/task-callbacks-conformance-297</strong> | Commit: <code>7ea6852</code> | Date: 2026-04-22 13:33:00</div>
 <table><tr><th>Stage</th><th>Result</th><th>Re-run</th></tr>
 <tr><td><a href='#log-unit+coverage'>unit+coverage</a></td><td class='pass'>PASS</td><td><code class='cmd'>make cover-html</code></td></tr>
 <tr><td><a href='#log-race'>race</a></td><td class='pass'>PASS</td><td><code class='cmd'>make test-race</code></td></tr>
@@ -36,41 +36,41 @@ code.cmd { background: #f0f0f0; padding: 2px 6px; border-radius: 3px; font-size:
 <h2>Stage Logs</h2>
 <details id='log-unit+coverage'><summary class='pass'>unit+coverage — PASS</summary><pre>
 === Stage 1/10: unit+coverage (make cover-html) ===
-Started: Tue Apr 21 12:53:35 PDT 2026
+Started: Wed Apr 22 13:29:53 PDT 2026
 go test -coverprofile=tests/reports/coverage.out ./... -count=1 -timeout 30s
-ok  	github.com/panyam/mcpkit/client	7.254s	coverage: 63.8% of statements
+ok  	github.com/panyam/mcpkit/client	8.421s	coverage: 63.8% of statements
 	github.com/panyam/mcpkit/cmd/testserver		coverage: 0.0% of statements
-ok  	github.com/panyam/mcpkit/core	0.384s	coverage: 51.0% of statements
-ok  	github.com/panyam/mcpkit/server	9.907s	coverage: 80.7% of statements
-ok  	github.com/panyam/mcpkit/testutil	0.744s	coverage: 69.4% of statements
+ok  	github.com/panyam/mcpkit/core	0.537s	coverage: 51.0% of statements
+ok  	github.com/panyam/mcpkit/server	10.102s	coverage: 80.9% of statements
+ok  	github.com/panyam/mcpkit/testutil	1.065s	coverage: 69.4% of statements
 go tool cover -html=tests/reports/coverage.out -o tests/reports/coverage.html
 Coverage report: tests/reports/coverage.html
-Finished: Tue Apr 21 12:53:46 PDT 2026
+Finished: Wed Apr 22 13:30:05 PDT 2026
 </pre></details>
 <details id='log-race'><summary class='pass'>race — PASS</summary><pre>
 === Stage 2/10: race (make test-race) ===
-Started: Tue Apr 21 12:53:46 PDT 2026
+Started: Wed Apr 22 13:30:05 PDT 2026
 go test -race ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/client	8.554s
+ok  	github.com/panyam/mcpkit/client	9.567s
 ?   	github.com/panyam/mcpkit/cmd/testserver	[no test files]
-ok  	github.com/panyam/mcpkit/core	1.241s
-ok  	github.com/panyam/mcpkit/server	11.174s
-ok  	github.com/panyam/mcpkit/testutil	1.839s
-Finished: Tue Apr 21 12:53:58 PDT 2026
+ok  	github.com/panyam/mcpkit/core	1.600s
+ok  	github.com/panyam/mcpkit/server	11.578s
+ok  	github.com/panyam/mcpkit/testutil	1.637s
+Finished: Wed Apr 22 13:30:27 PDT 2026
 </pre></details>
 <details id='log-auth'><summary class='pass'>auth — PASS</summary><pre>
 === Stage 3/10: auth (make test-auth) ===
-Started: Tue Apr 21 12:53:58 PDT 2026
+Started: Wed Apr 22 13:30:27 PDT 2026
 cd ext/auth &amp;&amp; go test ./... -count=1 -timeout 30s
-ok  	github.com/panyam/mcpkit/ext/auth	0.232s
-Finished: Tue Apr 21 12:53:59 PDT 2026
+ok  	github.com/panyam/mcpkit/ext/auth	0.334s
+Finished: Wed Apr 22 13:30:28 PDT 2026
 </pre></details>
 <details id='log-ui'><summary class='pass'>ui — PASS</summary><pre>
 === Stage 4/10: ui (make test-ui) ===
-Started: Tue Apr 21 12:53:59 PDT 2026
+Started: Wed Apr 22 13:30:28 PDT 2026
 cd ext/ui &amp;&amp; /Library/Developer/CommandLineTools/usr/bin/make test
 go test ./... -count=1 -timeout 30s
-ok  	github.com/panyam/mcpkit/ext/ui	0.228s
+ok  	github.com/panyam/mcpkit/ext/ui	0.328s
 cd assets &amp;&amp; pnpm install --frozen-lockfile --silent &amp;&amp; pnpm test
 
 &gt; @mcpkit/app-bridge@0.1.0 test /Users/dzshrh/newstack/mcpkit/main/ext/ui/assets
@@ -79,24 +79,24 @@ cd assets &amp;&amp; pnpm install --frozen-lockfile --silent &amp;&amp; pnpm tes
 
  RUN  v3.2.4 /Users/dzshrh/newstack/mcpkit/main/ext/ui/assets
 
- ✓ mcp-app-bridge.test.ts (33 tests) 385ms
+ ✓ mcp-app-bridge.test.ts (33 tests) 388ms
 
  Test Files  1 passed (1)
       Tests  33 passed (33)
-   Start at  12:54:00
-   Duration  929ms (transform 55ms, setup 0ms, collect 21ms, tests 385ms, environment 272ms, prepare 102ms)
+   Start at  13:30:30
+   Duration  1.08s (transform 21ms, setup 0ms, collect 20ms, tests 388ms, environment 386ms, prepare 126ms)
 
-Finished: Tue Apr 21 12:54:01 PDT 2026
+Finished: Wed Apr 22 13:30:31 PDT 2026
 </pre></details>
 <details id='log-protogen'><summary class='pass'>protogen — PASS</summary><pre>
 === Stage 5/10: protogen (make test-protogen) ===
-Started: Tue Apr 21 12:54:01 PDT 2026
+Started: Wed Apr 22 13:30:31 PDT 2026
 cd experimental/ext/protogen &amp;&amp; go test ./... -count=1 -timeout 30s &amp;&amp; /Library/Developer/CommandLineTools/usr/bin/make test-e2e
 ?   	github.com/panyam/mcpkit/experimental/ext/protogen/cmd/protoc-gen-go-mcp	[no test files]
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/generator	0.219s
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/proto/mcp/v1	0.368s
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/runtime	0.514s
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/schema	0.673s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/generator	0.324s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/proto/mcp/v1	0.553s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/runtime	1.041s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/schema	0.801s
 ?   	github.com/panyam/mcpkit/experimental/ext/protogen/testutil	[no test files]
 go build -o bin/protoc-gen-go-mcp ./cmd/protoc-gen-go-mcp
 go install ./cmd/protoc-gen-go-mcp
@@ -105,32 +105,32 @@ cd ../../../examples/protogen/bookservice &amp;&amp; rm -rf gen &amp;&amp; buf g
 [33mWARN[0m	plugin "protoc-gen-go-mcp" does not support required features.
   Feature "proto3 optional" is required by 1 file(s):
     bookservice/v1/service.proto
-ok  	github.com/panyam/mcpkit/examples/protogen/bookservice	0.268s
+ok  	github.com/panyam/mcpkit/examples/protogen/bookservice	0.590s
 ==&gt; e2e: passed
-Finished: Tue Apr 21 12:54:04 PDT 2026
+Finished: Wed Apr 22 13:30:37 PDT 2026
 </pre></details>
 <details id='log-e2e'><summary class='pass'>e2e — PASS</summary><pre>
 === Stage 6/10: e2e (make test-e2e) ===
-Started: Tue Apr 21 12:54:04 PDT 2026
+Started: Wed Apr 22 13:30:37 PDT 2026
 cd tests/e2e &amp;&amp; go test ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/tests/e2e	2.626s
-ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.460s
-Finished: Tue Apr 21 12:54:07 PDT 2026
+ok  	github.com/panyam/mcpkit/tests/e2e	3.248s
+ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.784s
+Finished: Wed Apr 22 13:30:41 PDT 2026
 </pre></details>
 <details id='log-experimental'><summary class='pass'>experimental — PASS</summary><pre>
 === Stage 7/10: experimental (make test-experimental) ===
-Started: Tue Apr 21 12:54:07 PDT 2026
+Started: Wed Apr 22 13:30:41 PDT 2026
 cd experimental/telegram-events &amp;&amp; go test ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/experimental/telegram-events	5.162s
-Finished: Tue Apr 21 12:54:13 PDT 2026
+ok  	github.com/panyam/mcpkit/experimental/telegram-events	6.119s
+Finished: Wed Apr 22 13:30:48 PDT 2026
 </pre></details>
 <details id='log-conformance'><summary class='pass'>conformance — PASS</summary><pre>
 === Stage 8/10: conformance (make testconf) ===
-Started: Tue Apr 21 12:54:13 PDT 2026
+Started: Wed Apr 22 13:30:48 PDT 2026
 bash scripts/conformance-test.sh
 Killing stale process on port 18799...
 === Starting test server on :18799 (Streamable HTTP) ===
-Waiting for server....2026/04/21 12:54:14 MCP test server listening on :18799 (Streamable HTTP at /mcp)
+Waiting for server....2026/04/22 13:30:50 MCP test server listening on :18799 (Streamable HTTP at /mcp)
  ready
 
 === Running MCP conformance suite ===
@@ -141,296 +141,296 @@ Running active suite (30 scenarios) against http://localhost:18799/mcp
 
 === Running scenario: server-initialize ===
 Running client scenario 'server-initialize' against server: http://localhost:18799/mcp
-2026/04/21 12:54:16 Starting MCP-GET-SSE SSE connection: 227ade805f7c2e9bd2efa3c5c4faa654
-2026/04/21 12:54:16 SSEHub: registered connection 227ade805f7c2e9bd2efa3c5c4faa654 (total: 1)
-2026/04/21 12:54:16 SSEHub: unregistered connection 227ade805f7c2e9bd2efa3c5c4faa654 (total: 0)
-2026/04/21 12:54:16 Received kill signal.  Quitting Writer. stop 0x492c45f72e70
-2026/04/21 12:54:16 Cleaning up writer...
-2026/04/21 12:54:16 Finished cleaning up writer:  0x492c45f72e70
-2026/04/21 12:54:16 Closed MCP-GET-SSE SSE connection: 227ade805f7c2e9bd2efa3c5c4faa654
+2026/04/22 13:30:52 Starting MCP-GET-SSE SSE connection: 4646daa377d680c41e48f59f8f9e8cc4
+2026/04/22 13:30:52 SSEHub: registered connection 4646daa377d680c41e48f59f8f9e8cc4 (total: 1)
+2026/04/22 13:30:52 SSEHub: unregistered connection 4646daa377d680c41e48f59f8f9e8cc4 (total: 0)
+2026/04/22 13:30:52 Received kill signal.  Quitting Writer. stop 0x6e6b2afc02a0
+2026/04/22 13:30:52 Cleaning up writer...
+2026/04/22 13:30:52 Finished cleaning up writer:  0x6e6b2afc02a0
+2026/04/22 13:30:52 Closed MCP-GET-SSE SSE connection: 4646daa377d680c41e48f59f8f9e8cc4
 
 === Running scenario: logging-set-level ===
 Running client scenario 'logging-set-level' against server: http://localhost:18799/mcp
-2026/04/21 12:54:16 Starting MCP-GET-SSE SSE connection: d1246ad5baa1345384c7054f81f6a081
-2026/04/21 12:54:16 SSEHub: registered connection d1246ad5baa1345384c7054f81f6a081 (total: 1)
-2026/04/21 12:54:16 SSEHub: unregistered connection d1246ad5baa1345384c7054f81f6a081 (total: 0)
-2026/04/21 12:54:16 Received kill signal.  Quitting Writer. stop 0x492c4603c310
-2026/04/21 12:54:16 Cleaning up writer...
-2026/04/21 12:54:16 Finished cleaning up writer:  0x492c4603c310
-2026/04/21 12:54:16 Closed MCP-GET-SSE SSE connection: d1246ad5baa1345384c7054f81f6a081
+2026/04/22 13:30:52 Starting MCP-GET-SSE SSE connection: 5b09e3a8ef59babb7f85f70f60f9ab6c
+2026/04/22 13:30:52 SSEHub: registered connection 5b09e3a8ef59babb7f85f70f60f9ab6c (total: 1)
+2026/04/22 13:30:52 SSEHub: unregistered connection 5b09e3a8ef59babb7f85f70f60f9ab6c (total: 0)
+2026/04/22 13:30:52 Received kill signal.  Quitting Writer. stop 0x6e6b2b3ae2a0
+2026/04/22 13:30:52 Cleaning up writer...
+2026/04/22 13:30:52 Finished cleaning up writer:  0x6e6b2b3ae2a0
+2026/04/22 13:30:52 Closed MCP-GET-SSE SSE connection: 5b09e3a8ef59babb7f85f70f60f9ab6c
 
 === Running scenario: ping ===
 Running client scenario 'ping' against server: http://localhost:18799/mcp
-2026/04/21 12:54:16 Starting MCP-GET-SSE SSE connection: 08a1818e40608c8f2ab792122368cd65
-2026/04/21 12:54:16 SSEHub: registered connection 08a1818e40608c8f2ab792122368cd65 (total: 1)
-2026/04/21 12:54:16 SSEHub: unregistered connection 08a1818e40608c8f2ab792122368cd65 (total: 0)
-2026/04/21 12:54:16 Received kill signal.  Quitting Writer. stop 0x492c463b61c0
-2026/04/21 12:54:16 Cleaning up writer...
-2026/04/21 12:54:16 Finished cleaning up writer:  0x492c463b61c0
-2026/04/21 12:54:16 Closed MCP-GET-SSE SSE connection: 08a1818e40608c8f2ab792122368cd65
+2026/04/22 13:30:52 Starting MCP-GET-SSE SSE connection: cac83464426b898a31f19b5506113363
+2026/04/22 13:30:52 SSEHub: registered connection cac83464426b898a31f19b5506113363 (total: 1)
+2026/04/22 13:30:52 SSEHub: unregistered connection cac83464426b898a31f19b5506113363 (total: 0)
 
 === Running scenario: completion-complete ===
+2026/04/22 13:30:52 Received kill signal.  Quitting Writer. stop 0x6e6b2aec2310
+2026/04/22 13:30:52 Cleaning up writer...
+2026/04/22 13:30:52 Finished cleaning up writer:  0x6e6b2aec2310
+2026/04/22 13:30:52 Closed MCP-GET-SSE SSE connection: cac83464426b898a31f19b5506113363
 Running client scenario 'completion-complete' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: d45adc19a97f639f3cd357d7c0b52900
-2026/04/21 12:54:17 SSEHub: registered connection d45adc19a97f639f3cd357d7c0b52900 (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection d45adc19a97f639f3cd357d7c0b52900 (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c463b6460
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c463b6460
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: d45adc19a97f639f3cd357d7c0b52900
+2026/04/22 13:30:52 Starting MCP-GET-SSE SSE connection: 14f3d25004ba403d4144d61a4414f7da
+2026/04/22 13:30:52 SSEHub: registered connection 14f3d25004ba403d4144d61a4414f7da (total: 1)
+2026/04/22 13:30:52 SSEHub: unregistered connection 14f3d25004ba403d4144d61a4414f7da (total: 0)
+2026/04/22 13:30:52 Received kill signal.  Quitting Writer. stop 0x6e6b2b42e2a0
+2026/04/22 13:30:52 Cleaning up writer...
+2026/04/22 13:30:52 Finished cleaning up writer:  0x6e6b2b42e2a0
+2026/04/22 13:30:52 Closed MCP-GET-SSE SSE connection: 14f3d25004ba403d4144d61a4414f7da
 
 === Running scenario: tools-list ===
 Running client scenario 'tools-list' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: 163b188e006b17f6a53af5776c2a6bac
-2026/04/21 12:54:17 SSEHub: registered connection 163b188e006b17f6a53af5776c2a6bac (total: 1)
+2026/04/22 13:30:52 Starting MCP-GET-SSE SSE connection: 58f93e43b6186864c02f864310e017b9
+2026/04/22 13:30:52 SSEHub: registered connection 58f93e43b6186864c02f864310e017b9 (total: 1)
 
 === Running scenario: tools-call-simple-text ===
-2026/04/21 12:54:17 SSEHub: unregistered connection 163b188e006b17f6a53af5776c2a6bac (total: 0)
+2026/04/22 13:30:52 SSEHub: unregistered connection 58f93e43b6186864c02f864310e017b9 (total: 0)
 Running client scenario 'tools-call-simple-text' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c45f731f0
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c45f731f0
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: 163b188e006b17f6a53af5776c2a6bac
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: ac79a94f47b09ce3df520e4e1604fae8
-2026/04/21 12:54:17 SSEHub: registered connection ac79a94f47b09ce3df520e4e1604fae8 (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection ac79a94f47b09ce3df520e4e1604fae8 (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c463b67e0
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c463b67e0
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: ac79a94f47b09ce3df520e4e1604fae8
+2026/04/22 13:30:52 Received kill signal.  Quitting Writer. stop 0x6e6b2afc01c0
+2026/04/22 13:30:52 Cleaning up writer...
+2026/04/22 13:30:52 Finished cleaning up writer:  0x6e6b2afc01c0
+2026/04/22 13:30:52 Closed MCP-GET-SSE SSE connection: 58f93e43b6186864c02f864310e017b9
+2026/04/22 13:30:52 Starting MCP-GET-SSE SSE connection: 17f804e5e531040d15bab7785e405070
+2026/04/22 13:30:52 SSEHub: registered connection 17f804e5e531040d15bab7785e405070 (total: 1)
 
 === Running scenario: tools-call-image ===
 Running client scenario 'tools-call-image' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: 589aa2342c2ed8fe517b362784235042
-2026/04/21 12:54:17 SSEHub: registered connection 589aa2342c2ed8fe517b362784235042 (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection 589aa2342c2ed8fe517b362784235042 (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c463b6230
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c463b6230
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: 589aa2342c2ed8fe517b362784235042
+2026/04/22 13:30:52 SSEHub: unregistered connection 17f804e5e531040d15bab7785e405070 (total: 0)
+2026/04/22 13:30:52 Received kill signal.  Quitting Writer. stop 0x6e6b2b42e4d0
+2026/04/22 13:30:52 Cleaning up writer...
+2026/04/22 13:30:52 Finished cleaning up writer:  0x6e6b2b42e4d0
+2026/04/22 13:30:52 Closed MCP-GET-SSE SSE connection: 17f804e5e531040d15bab7785e405070
+2026/04/22 13:30:52 Starting MCP-GET-SSE SSE connection: 7356b7d4da92edebd427e00f02a212c1
+2026/04/22 13:30:52 SSEHub: registered connection 7356b7d4da92edebd427e00f02a212c1 (total: 1)
 
 === Running scenario: tools-call-audio ===
+2026/04/22 13:30:52 SSEHub: unregistered connection 7356b7d4da92edebd427e00f02a212c1 (total: 0)
 Running client scenario 'tools-call-audio' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: 3bac024630e0f22e5e6cc45eb8edf7f5
-2026/04/21 12:54:17 SSEHub: registered connection 3bac024630e0f22e5e6cc45eb8edf7f5 (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection 3bac024630e0f22e5e6cc45eb8edf7f5 (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c45f723f0
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c45f723f0
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: 3bac024630e0f22e5e6cc45eb8edf7f5
+2026/04/22 13:30:52 Received kill signal.  Quitting Writer. stop 0x6e6b2afc05b0
+2026/04/22 13:30:52 Cleaning up writer...
+2026/04/22 13:30:52 Finished cleaning up writer:  0x6e6b2afc05b0
+2026/04/22 13:30:52 Closed MCP-GET-SSE SSE connection: 7356b7d4da92edebd427e00f02a212c1
+2026/04/22 13:30:52 Starting MCP-GET-SSE SSE connection: 17ce0a43f9365f19cfd88f4f7f4f9f35
+2026/04/22 13:30:52 SSEHub: registered connection 17ce0a43f9365f19cfd88f4f7f4f9f35 (total: 1)
+2026/04/22 13:30:52 SSEHub: unregistered connection 17ce0a43f9365f19cfd88f4f7f4f9f35 (total: 0)
 
 === Running scenario: tools-call-embedded-resource ===
+2026/04/22 13:30:52 Received kill signal.  Quitting Writer. stop 0x6e6b2afc07e0
+2026/04/22 13:30:52 Cleaning up writer...
 Running client scenario 'tools-call-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: d159a932c4f92866fcf4b37e649fc78c
-2026/04/21 12:54:17 SSEHub: registered connection d159a932c4f92866fcf4b37e649fc78c (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection d159a932c4f92866fcf4b37e649fc78c (total: 0)
+2026/04/22 13:30:52 Finished cleaning up writer:  0x6e6b2afc07e0
+2026/04/22 13:30:52 Closed MCP-GET-SSE SSE connection: 17ce0a43f9365f19cfd88f4f7f4f9f35
+2026/04/22 13:30:52 Starting MCP-GET-SSE SSE connection: e7aaa1d3ae1b266d386c0b9356982218
+2026/04/22 13:30:52 SSEHub: registered connection e7aaa1d3ae1b266d386c0b9356982218 (total: 1)
+2026/04/22 13:30:52 SSEHub: unregistered connection e7aaa1d3ae1b266d386c0b9356982218 (total: 0)
 
 === Running scenario: tools-call-mixed-content ===
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c45f72ee0
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c45f72ee0
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: d159a932c4f92866fcf4b37e649fc78c
+2026/04/22 13:30:52 Received kill signal.  Quitting Writer. stop 0x6e6b2afc0a80
+2026/04/22 13:30:52 Cleaning up writer...
+2026/04/22 13:30:52 Finished cleaning up writer:  0x6e6b2afc0a80
+2026/04/22 13:30:52 Closed MCP-GET-SSE SSE connection: e7aaa1d3ae1b266d386c0b9356982218
 Running client scenario 'tools-call-mixed-content' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: fce2ed035277664089587b43e244c770
-2026/04/21 12:54:17 SSEHub: registered connection fce2ed035277664089587b43e244c770 (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection fce2ed035277664089587b43e244c770 (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c45f73110
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c45f73110
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: fce2ed035277664089587b43e244c770
+2026/04/22 13:30:52 Starting MCP-GET-SSE SSE connection: ba895d876c20e424d9d4af5a8bddbb51
+2026/04/22 13:30:52 SSEHub: registered connection ba895d876c20e424d9d4af5a8bddbb51 (total: 1)
 
 === Running scenario: tools-call-with-logging ===
+2026/04/22 13:30:52 SSEHub: unregistered connection ba895d876c20e424d9d4af5a8bddbb51 (total: 0)
 Running client scenario 'tools-call-with-logging' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: 8c93173febf02cbb59d07caf1af48422
-2026/04/21 12:54:17 SSEHub: registered connection 8c93173febf02cbb59d07caf1af48422 (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection 8c93173febf02cbb59d07caf1af48422 (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c45f73420
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c45f73420
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: 8c93173febf02cbb59d07caf1af48422
+2026/04/22 13:30:52 Received kill signal.  Quitting Writer. stop 0x6e6b2b42e930
+2026/04/22 13:30:52 Cleaning up writer...
+2026/04/22 13:30:52 Finished cleaning up writer:  0x6e6b2b42e930
+2026/04/22 13:30:52 Closed MCP-GET-SSE SSE connection: ba895d876c20e424d9d4af5a8bddbb51
+2026/04/22 13:30:52 Starting MCP-GET-SSE SSE connection: 2be201740203f0502ce2fbcab317b387
+2026/04/22 13:30:52 SSEHub: registered connection 2be201740203f0502ce2fbcab317b387 (total: 1)
+2026/04/22 13:30:52 SSEHub: unregistered connection 2be201740203f0502ce2fbcab317b387 (total: 0)
+2026/04/22 13:30:52 Received kill signal.  Quitting Writer. stop 0x6e6b2b00ea80
+2026/04/22 13:30:52 Cleaning up writer...
+2026/04/22 13:30:52 Finished cleaning up writer:  0x6e6b2b00ea80
+2026/04/22 13:30:52 Closed MCP-GET-SSE SSE connection: 2be201740203f0502ce2fbcab317b387
 
 === Running scenario: tools-call-error ===
 Running client scenario 'tools-call-error' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: d469390ec06cb5608b27f24a75f1d4c1
-2026/04/21 12:54:17 SSEHub: registered connection d469390ec06cb5608b27f24a75f1d4c1 (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection d469390ec06cb5608b27f24a75f1d4c1 (total: 0)
+2026/04/22 13:30:52 Starting MCP-GET-SSE SSE connection: 97b07ad0f41d5928cd87999829f2383b
+2026/04/22 13:30:52 SSEHub: registered connection 97b07ad0f41d5928cd87999829f2383b (total: 1)
+2026/04/22 13:30:52 SSEHub: unregistered connection 97b07ad0f41d5928cd87999829f2383b (total: 0)
+2026/04/22 13:30:52 Received kill signal.  Quitting Writer. stop 0x6e6b2aec27e0
+2026/04/22 13:30:52 Cleaning up writer...
 
 === Running scenario: tools-call-with-progress ===
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c463b68c0
+2026/04/22 13:30:52 Finished cleaning up writer:  0x6e6b2aec27e0
+2026/04/22 13:30:52 Closed MCP-GET-SSE SSE connection: 97b07ad0f41d5928cd87999829f2383b
 Running client scenario 'tools-call-with-progress' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c463b68c0
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: d469390ec06cb5608b27f24a75f1d4c1
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: ed42c10e306dbfb9d423316e9b3064f7
-2026/04/21 12:54:17 SSEHub: registered connection ed42c10e306dbfb9d423316e9b3064f7 (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection ed42c10e306dbfb9d423316e9b3064f7 (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c463b6bd0
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c463b6bd0
+2026/04/22 13:30:52 Starting MCP-GET-SSE SSE connection: a7490a040759730194a6a4f255e1223a
+2026/04/22 13:30:52 SSEHub: registered connection a7490a040759730194a6a4f255e1223a (total: 1)
+2026/04/22 13:30:53 SSEHub: unregistered connection a7490a040759730194a6a4f255e1223a (total: 0)
+2026/04/22 13:30:53 Received kill signal.  Quitting Writer. stop 0x6e6b2aec2af0
+2026/04/22 13:30:53 Cleaning up writer...
+2026/04/22 13:30:53 Finished cleaning up writer:  0x6e6b2aec2af0
+2026/04/22 13:30:53 Closed MCP-GET-SSE SSE connection: a7490a040759730194a6a4f255e1223a
 
 === Running scenario: tools-call-sampling ===
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: ed42c10e306dbfb9d423316e9b3064f7
 Running client scenario 'tools-call-sampling' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: fca4d702a1eeee21ca2216cf9aeef462
-2026/04/21 12:54:17 SSEHub: registered connection fca4d702a1eeee21ca2216cf9aeef462 (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection fca4d702a1eeee21ca2216cf9aeef462 (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c464aa3f0
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c464aa3f0
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: fca4d702a1eeee21ca2216cf9aeef462
+2026/04/22 13:30:53 Starting MCP-GET-SSE SSE connection: d3bd69d61c0d557637a018340fd53b82
+2026/04/22 13:30:53 SSEHub: registered connection d3bd69d61c0d557637a018340fd53b82 (total: 1)
+2026/04/22 13:30:53 SSEHub: unregistered connection d3bd69d61c0d557637a018340fd53b82 (total: 0)
+2026/04/22 13:30:53 Received kill signal.  Quitting Writer. stop 0x6e6b2afc0e00
+2026/04/22 13:30:53 Cleaning up writer...
+2026/04/22 13:30:53 Finished cleaning up writer:  0x6e6b2afc0e00
+2026/04/22 13:30:53 Closed MCP-GET-SSE SSE connection: d3bd69d61c0d557637a018340fd53b82
 
 === Running scenario: tools-call-elicitation ===
 Running client scenario 'tools-call-elicitation' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: 4eb16ebedcf3128a22c8e203ff80054e
-2026/04/21 12:54:17 SSEHub: registered connection 4eb16ebedcf3128a22c8e203ff80054e (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection 4eb16ebedcf3128a22c8e203ff80054e (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c45f73960
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c45f73960
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: 4eb16ebedcf3128a22c8e203ff80054e
+2026/04/22 13:30:53 Starting MCP-GET-SSE SSE connection: af59030b17426ff661539064e24bd8c3
+2026/04/22 13:30:53 SSEHub: registered connection af59030b17426ff661539064e24bd8c3 (total: 1)
+2026/04/22 13:30:53 SSEHub: unregistered connection af59030b17426ff661539064e24bd8c3 (total: 0)
+2026/04/22 13:30:53 Received kill signal.  Quitting Writer. stop 0x6e6b2b00ee70
+2026/04/22 13:30:53 Cleaning up writer...
+2026/04/22 13:30:53 Finished cleaning up writer:  0x6e6b2b00ee70
+2026/04/22 13:30:53 Closed MCP-GET-SSE SSE connection: af59030b17426ff661539064e24bd8c3
 
 === Running scenario: elicitation-sep1034-defaults ===
 Running client scenario 'elicitation-sep1034-defaults' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: 218d16d2e883b23b98f178d8b1a128c4
-2026/04/21 12:54:17 SSEHub: registered connection 218d16d2e883b23b98f178d8b1a128c4 (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection 218d16d2e883b23b98f178d8b1a128c4 (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c464aa620
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c464aa620
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: 218d16d2e883b23b98f178d8b1a128c4
+2026/04/22 13:30:53 Starting MCP-GET-SSE SSE connection: 5f7f5c483a29f077822dd30b0b269b13
+2026/04/22 13:30:53 SSEHub: registered connection 5f7f5c483a29f077822dd30b0b269b13 (total: 1)
+2026/04/22 13:30:53 SSEHub: unregistered connection 5f7f5c483a29f077822dd30b0b269b13 (total: 0)
 
 === Running scenario: server-sse-multiple-streams ===
+2026/04/22 13:30:53 Received kill signal.  Quitting Writer. stop 0x6e6b2b42eb60
+2026/04/22 13:30:53 Cleaning up writer...
+2026/04/22 13:30:53 Finished cleaning up writer:  0x6e6b2b42eb60
+2026/04/22 13:30:53 Closed MCP-GET-SSE SSE connection: 5f7f5c483a29f077822dd30b0b269b13
 Running client scenario 'server-sse-multiple-streams' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: e8974a34bc076b27d2d7d2f3d0eed0a7
-2026/04/21 12:54:17 SSEHub: registered connection e8974a34bc076b27d2d7d2f3d0eed0a7 (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection e8974a34bc076b27d2d7d2f3d0eed0a7 (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c45f73dc0
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c45f73dc0
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: e8974a34bc076b27d2d7d2f3d0eed0a7
+2026/04/22 13:30:53 Starting MCP-GET-SSE SSE connection: 096c4263753ebe25ecff7355246b84bd
+2026/04/22 13:30:53 SSEHub: registered connection 096c4263753ebe25ecff7355246b84bd (total: 1)
+2026/04/22 13:30:53 SSEHub: unregistered connection 096c4263753ebe25ecff7355246b84bd (total: 0)
 
 === Running scenario: elicitation-sep1330-enums ===
+2026/04/22 13:30:53 Received kill signal.  Quitting Writer. stop 0x6e6b2afc12d0
+2026/04/22 13:30:53 Cleaning up writer...
+2026/04/22 13:30:53 Finished cleaning up writer:  0x6e6b2afc12d0
+2026/04/22 13:30:53 Closed MCP-GET-SSE SSE connection: 096c4263753ebe25ecff7355246b84bd
 Running client scenario 'elicitation-sep1330-enums' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: 56967c646b860caa4c92b9d22794defe
-2026/04/21 12:54:17 SSEHub: registered connection 56967c646b860caa4c92b9d22794defe (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection 56967c646b860caa4c92b9d22794defe (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c463b7110
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c463b7110
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: 56967c646b860caa4c92b9d22794defe
+2026/04/22 13:30:53 Starting MCP-GET-SSE SSE connection: f15f907318a1a37b9e50286cafb010c8
+2026/04/22 13:30:53 SSEHub: registered connection f15f907318a1a37b9e50286cafb010c8 (total: 1)
+2026/04/22 13:30:53 SSEHub: unregistered connection f15f907318a1a37b9e50286cafb010c8 (total: 0)
 
 === Running scenario: resources-list ===
+2026/04/22 13:30:53 Received kill signal.  Quitting Writer. stop 0x6e6b2afc15e0
+2026/04/22 13:30:53 Cleaning up writer...
+2026/04/22 13:30:53 Finished cleaning up writer:  0x6e6b2afc15e0
+2026/04/22 13:30:53 Closed MCP-GET-SSE SSE connection: f15f907318a1a37b9e50286cafb010c8
 Running client scenario 'resources-list' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: a1e3afd706774fc46d7ecc773a02a38f
-2026/04/21 12:54:17 SSEHub: registered connection a1e3afd706774fc46d7ecc773a02a38f (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection a1e3afd706774fc46d7ecc773a02a38f (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c460d65b0
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c460d65b0
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: a1e3afd706774fc46d7ecc773a02a38f
+2026/04/22 13:30:53 Starting MCP-GET-SSE SSE connection: f29cfc411612b1796cb2c4f1f804866c
+2026/04/22 13:30:53 SSEHub: registered connection f29cfc411612b1796cb2c4f1f804866c (total: 1)
+2026/04/22 13:30:53 SSEHub: unregistered connection f29cfc411612b1796cb2c4f1f804866c (total: 0)
 
 === Running scenario: resources-read-text ===
 Running client scenario 'resources-read-text' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: 100dd4984002c1ec60340aa9535ff9cd
-2026/04/21 12:54:17 SSEHub: registered connection 100dd4984002c1ec60340aa9535ff9cd (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection 100dd4984002c1ec60340aa9535ff9cd (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c461582a0
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c461582a0
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: 100dd4984002c1ec60340aa9535ff9cd
+2026/04/22 13:30:53 Received kill signal.  Quitting Writer. stop 0x6e6b2afc19d0
+2026/04/22 13:30:53 Cleaning up writer...
+2026/04/22 13:30:53 Finished cleaning up writer:  0x6e6b2afc19d0
+2026/04/22 13:30:53 Closed MCP-GET-SSE SSE connection: f29cfc411612b1796cb2c4f1f804866c
+2026/04/22 13:30:53 Starting MCP-GET-SSE SSE connection: 9aa976ea3631b7586b4925fa5e3842a6
+2026/04/22 13:30:53 SSEHub: registered connection 9aa976ea3631b7586b4925fa5e3842a6 (total: 1)
+2026/04/22 13:30:53 SSEHub: unregistered connection 9aa976ea3631b7586b4925fa5e3842a6 (total: 0)
+2026/04/22 13:30:53 Received kill signal.  Quitting Writer. stop 0x6e6b2aec3260
+2026/04/22 13:30:53 Cleaning up writer...
+2026/04/22 13:30:53 Finished cleaning up writer:  0x6e6b2aec3260
 
 === Running scenario: resources-read-binary ===
+2026/04/22 13:30:53 Closed MCP-GET-SSE SSE connection: 9aa976ea3631b7586b4925fa5e3842a6
 Running client scenario 'resources-read-binary' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: 624278df5c287f98512298a36fbba05c
-2026/04/21 12:54:17 SSEHub: registered connection 624278df5c287f98512298a36fbba05c (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection 624278df5c287f98512298a36fbba05c (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c46224150
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c46224150
+2026/04/22 13:30:53 Starting MCP-GET-SSE SSE connection: f63b06836e8da16cc44bcf3523040934
+2026/04/22 13:30:53 SSEHub: registered connection f63b06836e8da16cc44bcf3523040934 (total: 1)
 
 === Running scenario: resources-templates-read ===
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: 624278df5c287f98512298a36fbba05c
+2026/04/22 13:30:53 SSEHub: unregistered connection f63b06836e8da16cc44bcf3523040934 (total: 0)
 Running client scenario 'resources-templates-read' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: f2f9f9fcb7a9568e40e198cb66efc473
-2026/04/21 12:54:17 SSEHub: registered connection f2f9f9fcb7a9568e40e198cb66efc473 (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection f2f9f9fcb7a9568e40e198cb66efc473 (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c463b7420
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c463b7420
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: f2f9f9fcb7a9568e40e198cb66efc473
+2026/04/22 13:30:53 Received kill signal.  Quitting Writer. stop 0x6e6b2aec3490
+2026/04/22 13:30:53 Cleaning up writer...
+2026/04/22 13:30:53 Finished cleaning up writer:  0x6e6b2aec3490
+2026/04/22 13:30:53 Closed MCP-GET-SSE SSE connection: f63b06836e8da16cc44bcf3523040934
+2026/04/22 13:30:53 Starting MCP-GET-SSE SSE connection: a27405af9d5198e95702c2f162334b4a
+2026/04/22 13:30:53 SSEHub: registered connection a27405af9d5198e95702c2f162334b4a (total: 1)
+2026/04/22 13:30:53 SSEHub: unregistered connection a27405af9d5198e95702c2f162334b4a (total: 0)
 
 === Running scenario: resources-subscribe ===
+2026/04/22 13:30:53 Received kill signal.  Quitting Writer. stop 0x6e6b2b00f3b0
 Running client scenario 'resources-subscribe' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: f1bc3adaa56e91d4a7c5f9d279ce6042
-2026/04/21 12:54:17 SSEHub: registered connection f1bc3adaa56e91d4a7c5f9d279ce6042 (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection f1bc3adaa56e91d4a7c5f9d279ce6042 (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c463b7650
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c463b7650
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: f1bc3adaa56e91d4a7c5f9d279ce6042
+2026/04/22 13:30:53 Cleaning up writer...
+2026/04/22 13:30:53 Finished cleaning up writer:  0x6e6b2b00f3b0
+2026/04/22 13:30:53 Closed MCP-GET-SSE SSE connection: a27405af9d5198e95702c2f162334b4a
+2026/04/22 13:30:53 Starting MCP-GET-SSE SSE connection: 90a637dc6db35ea10843604904a0af89
+2026/04/22 13:30:53 SSEHub: registered connection 90a637dc6db35ea10843604904a0af89 (total: 1)
+2026/04/22 13:30:53 SSEHub: unregistered connection 90a637dc6db35ea10843604904a0af89 (total: 0)
+2026/04/22 13:30:53 Received kill signal.  Quitting Writer. stop 0x6e6b2aec3730
+2026/04/22 13:30:53 Cleaning up writer...
+2026/04/22 13:30:53 Finished cleaning up writer:  0x6e6b2aec3730
+2026/04/22 13:30:53 Closed MCP-GET-SSE SSE connection: 90a637dc6db35ea10843604904a0af89
 
 === Running scenario: resources-unsubscribe ===
 Running client scenario 'resources-unsubscribe' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: f3df97277438cadc995dba012720c904
-2026/04/21 12:54:17 SSEHub: registered connection f3df97277438cadc995dba012720c904 (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection f3df97277438cadc995dba012720c904 (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c460d69a0
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c460d69a0
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: f3df97277438cadc995dba012720c904
+2026/04/22 13:30:53 Starting MCP-GET-SSE SSE connection: d350a1391cbdcf636237a0fd423f52d7
+2026/04/22 13:30:53 SSEHub: registered connection d350a1391cbdcf636237a0fd423f52d7 (total: 1)
+2026/04/22 13:30:53 SSEHub: unregistered connection d350a1391cbdcf636237a0fd423f52d7 (total: 0)
+2026/04/22 13:30:53 Received kill signal.  Quitting Writer. stop 0x6e6b2b42ee70
 
 === Running scenario: prompts-list ===
+2026/04/22 13:30:53 Cleaning up writer...
+2026/04/22 13:30:53 Finished cleaning up writer:  0x6e6b2b42ee70
+2026/04/22 13:30:53 Closed MCP-GET-SSE SSE connection: d350a1391cbdcf636237a0fd423f52d7
 Running client scenario 'prompts-list' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: fea06cca33caf002055517cbb4aadca8
-2026/04/21 12:54:17 SSEHub: registered connection fea06cca33caf002055517cbb4aadca8 (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection fea06cca33caf002055517cbb4aadca8 (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c46224540
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c46224540
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: fea06cca33caf002055517cbb4aadca8
+2026/04/22 13:30:53 Starting MCP-GET-SSE SSE connection: e411958e60df861fed43b48fd76bdbd9
+2026/04/22 13:30:53 SSEHub: registered connection e411958e60df861fed43b48fd76bdbd9 (total: 1)
 
 === Running scenario: prompts-get-simple ===
 Running client scenario 'prompts-get-simple' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: 56add02db339bbce6a2c37d2a9b67159
-2026/04/21 12:54:17 SSEHub: registered connection 56add02db339bbce6a2c37d2a9b67159 (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection 56add02db339bbce6a2c37d2a9b67159 (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c462247e0
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c462247e0
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: 56add02db339bbce6a2c37d2a9b67159
+2026/04/22 13:30:53 SSEHub: unregistered connection e411958e60df861fed43b48fd76bdbd9 (total: 0)
+2026/04/22 13:30:53 Received kill signal.  Quitting Writer. stop 0x6e6b2aec3a40
+2026/04/22 13:30:53 Cleaning up writer...
+2026/04/22 13:30:53 Finished cleaning up writer:  0x6e6b2aec3a40
+2026/04/22 13:30:53 Closed MCP-GET-SSE SSE connection: e411958e60df861fed43b48fd76bdbd9
+2026/04/22 13:30:53 Starting MCP-GET-SSE SSE connection: ad9699566c0f3e6ac49b57bea896883b
+2026/04/22 13:30:53 SSEHub: registered connection ad9699566c0f3e6ac49b57bea896883b (total: 1)
+2026/04/22 13:30:53 SSEHub: unregistered connection ad9699566c0f3e6ac49b57bea896883b (total: 0)
 
 === Running scenario: prompts-get-with-args ===
+2026/04/22 13:30:53 Received kill signal.  Quitting Writer. stop 0x6e6b2afc1e30
+2026/04/22 13:30:53 Cleaning up writer...
+2026/04/22 13:30:53 Finished cleaning up writer:  0x6e6b2afc1e30
+2026/04/22 13:30:53 Closed MCP-GET-SSE SSE connection: ad9699566c0f3e6ac49b57bea896883b
 Running client scenario 'prompts-get-with-args' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: 78f1ec2cce814845621585c95c341462
-2026/04/21 12:54:17 SSEHub: registered connection 78f1ec2cce814845621585c95c341462 (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection 78f1ec2cce814845621585c95c341462 (total: 0)
+2026/04/22 13:30:53 Starting MCP-GET-SSE SSE connection: ef65d51699d3b1c04afdbb547a2decfd
+2026/04/22 13:30:53 SSEHub: registered connection ef65d51699d3b1c04afdbb547a2decfd (total: 1)
+2026/04/22 13:30:53 SSEHub: unregistered connection ef65d51699d3b1c04afdbb547a2decfd (total: 0)
+2026/04/22 13:30:53 Received kill signal.  Quitting Writer. stop 0x6e6b2aec3c70
+2026/04/22 13:30:53 Cleaning up writer...
+2026/04/22 13:30:53 Finished cleaning up writer:  0x6e6b2aec3c70
+2026/04/22 13:30:53 Closed MCP-GET-SSE SSE connection: ef65d51699d3b1c04afdbb547a2decfd
 
 === Running scenario: prompts-get-embedded-resource ===
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c463b79d0
 Running client scenario 'prompts-get-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c463b79d0
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: 78f1ec2cce814845621585c95c341462
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: 2345d03971f925b0e071bdd65a46806d
-2026/04/21 12:54:17 SSEHub: registered connection 2345d03971f925b0e071bdd65a46806d (total: 1)
+2026/04/22 13:30:53 Starting MCP-GET-SSE SSE connection: 21df0dea55359c35bce56ad9ac36467c
+2026/04/22 13:30:53 SSEHub: registered connection 21df0dea55359c35bce56ad9ac36467c (total: 1)
+2026/04/22 13:30:53 SSEHub: unregistered connection 21df0dea55359c35bce56ad9ac36467c (total: 0)
 
 === Running scenario: prompts-get-with-image ===
-2026/04/21 12:54:17 SSEHub: unregistered connection 2345d03971f925b0e071bdd65a46806d (total: 0)
+2026/04/22 13:30:53 Received kill signal.  Quitting Writer. stop 0x6e6b2b42f180
+2026/04/22 13:30:53 Cleaning up writer...
+2026/04/22 13:30:53 Finished cleaning up writer:  0x6e6b2b42f180
+2026/04/22 13:30:53 Closed MCP-GET-SSE SSE connection: 21df0dea55359c35bce56ad9ac36467c
 Running client scenario 'prompts-get-with-image' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c46158540
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c46158540
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: 2345d03971f925b0e071bdd65a46806d
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: 8ec705bfc7e13f46834448bc0abdf621
-2026/04/21 12:54:17 SSEHub: registered connection 8ec705bfc7e13f46834448bc0abdf621 (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection 8ec705bfc7e13f46834448bc0abdf621 (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c464aaa10
-2026/04/21 12:54:17 Cleaning up writer...
+2026/04/22 13:30:53 Starting MCP-GET-SSE SSE connection: 8dea414fefaeb01a2557c6baaeed8513
+2026/04/22 13:30:53 SSEHub: registered connection 8dea414fefaeb01a2557c6baaeed8513 (total: 1)
 
 === Running scenario: dns-rebinding-protection ===
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c464aaa10
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: 8ec705bfc7e13f46834448bc0abdf621
+2026/04/22 13:30:53 SSEHub: unregistered connection 8dea414fefaeb01a2557c6baaeed8513 (total: 0)
 Running client scenario 'dns-rebinding-protection' against server: http://localhost:18799/mcp
+2026/04/22 13:30:53 Received kill signal.  Quitting Writer. stop 0x6e6b2b206000
+2026/04/22 13:30:53 Cleaning up writer...
+2026/04/22 13:30:53 Finished cleaning up writer:  0x6e6b2b206000
+2026/04/22 13:30:53 Closed MCP-GET-SSE SSE connection: 8dea414fefaeb01a2557c6baaeed8513
 
 
 === SUMMARY ===
@@ -470,11 +470,11 @@ Total: 40 passed, 0 failed
 [32mBaseline check passed: all failures are expected.[0m
 
 === CONFORMANCE TESTS PASSED ===
-Finished: Tue Apr 21 12:54:17 PDT 2026
+Finished: Wed Apr 22 13:30:53 PDT 2026
 </pre></details>
 <details id='log-auth-conformance'><summary class='pass'>auth-conformance — PASS</summary><pre>
 === Stage 9/10: auth-conformance (make testconfauth) ===
-Started: Tue Apr 21 12:54:17 PDT 2026
+Started: Wed Apr 22 13:30:53 PDT 2026
 bash scripts/conformance-auth-test.sh
 Building testclient...
 === Running MCP Auth conformance suite ===
@@ -496,22 +496,22 @@ Starting scenario: auth/token-endpoint-auth-basic
 Starting scenario: auth/token-endpoint-auth-post
 Starting scenario: auth/token-endpoint-auth-none
 Starting scenario: auth/pre-registration
-Executing client: ./bin/testclient http://localhost:61479/mcp
-Executing client: ./bin/testclient http://localhost:61480/mcp
-Executing client: ./bin/testclient http://localhost:61481/mcp
-Executing client: ./bin/testclient http://localhost:61482/mcp
-Executing client: ./bin/testclient http://localhost:61483/mcp
-Executing client: ./bin/testclient http://localhost:61484/mcp
-Executing client: ./bin/testclient http://localhost:61485/mcp
-Executing client: ./bin/testclient http://localhost:61486/mcp
-Executing client: ./bin/testclient http://localhost:61487/mcp
-Executing client: ./bin/testclient http://localhost:61488/mcp
-Executing client: ./bin/testclient http://localhost:61489/mcp
-Executing client: ./bin/testclient http://localhost:61490/mcp
-Executing client: ./bin/testclient http://localhost:61491/mcp
-Executing client: ./bin/testclient http://localhost:61492/mcp
+Executing client: ./bin/testclient http://localhost:49338/mcp
+Executing client: ./bin/testclient http://localhost:49339/mcp
+Executing client: ./bin/testclient http://localhost:49340/mcp
+Executing client: ./bin/testclient http://localhost:49341/mcp
+Executing client: ./bin/testclient http://localhost:49342/mcp
+Executing client: ./bin/testclient http://localhost:49343/mcp
+Executing client: ./bin/testclient http://localhost:49344/mcp
+Executing client: ./bin/testclient http://localhost:49345/mcp
+Executing client: ./bin/testclient http://localhost:49346/mcp
+Executing client: ./bin/testclient http://localhost:49347/mcp
+Executing client: ./bin/testclient http://localhost:49348/mcp
+Executing client: ./bin/testclient http://localhost:49349/mcp
+Executing client: ./bin/testclient http://localhost:49350/mcp
+Executing client: ./bin/testclient http://localhost:49351/mcp
 With context: {"client_id":"pre-registered-client","client_secret":"pre-registered-secret"}
-(node:79914) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
+(node:44990) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
 (Use `node --trace-deprecation ...` to show where the warning was created)
 
 === SUITE SUMMARY ===
@@ -539,37 +539,58 @@ Total: 210 passed, 0 failed, 1 warnings
 [32mBaseline check passed: all failures are expected.[0m
 
 === AUTH CONFORMANCE TESTS PASSED ===
-Finished: Tue Apr 21 12:54:19 PDT 2026
+Finished: Wed Apr 22 13:30:54 PDT 2026
 </pre></details>
 <details id='log-keycloak'><summary class='pass'>keycloak — PASS</summary><pre>
 === Stage 10/10: keycloak (make testkcl-auto) ===
-Started: Tue Apr 21 12:54:19 PDT 2026
+Started: Wed Apr 22 13:30:54 PDT 2026
+Starting Keycloak for interop tests...
+cc0576832fdab4445e4c8af335471a5784bca2061cea36cd7cd01c202d71aa92
+docker: Error response from daemon: failed to set up container networking: driver failed programming external connectivity on endpoint mcpkit-keycloak (1e67c9447cfff9807670b598b71c3595f6d6034a8033ab57c88f5f27dc2ae92a): Bind for 0.0.0.0:8180 failed: port is already allocated
+
+Run 'docker run --help' for more information
+Keycloak starting on port 8180... (realm import takes ~30s)
+Run 'make kcllogs' to watch startup, 'make testkcl' when ready
+Waiting for Keycloak realm...
 === RUN   TestKeycloak_MCPServer_ValidToken
---- PASS: TestKeycloak_MCPServer_ValidToken (0.03s)
+    interop_test.go:34: Keycloak realm mcpkit-test not ready (status 404)
+--- SKIP: TestKeycloak_MCPServer_ValidToken (0.02s)
 === RUN   TestKeycloak_MCPServer_TamperedToken
---- PASS: TestKeycloak_MCPServer_TamperedToken (0.01s)
+    interop_test.go:56: Keycloak realm mcpkit-test not ready (status 404)
+--- SKIP: TestKeycloak_MCPServer_TamperedToken (0.00s)
 === RUN   TestKeycloak_MCPServer_ScopeAllowed
---- PASS: TestKeycloak_MCPServer_ScopeAllowed (0.01s)
+    interop_test.go:79: Keycloak realm mcpkit-test not ready (status 404)
+--- SKIP: TestKeycloak_MCPServer_ScopeAllowed (0.00s)
 === RUN   TestKeycloak_MCPServer_ScopeDenied
---- PASS: TestKeycloak_MCPServer_ScopeDenied (0.01s)
+    interop_test.go:101: Keycloak realm mcpkit-test not ready (status 404)
+--- SKIP: TestKeycloak_MCPServer_ScopeDenied (0.00s)
 === RUN   TestKeycloak_MCPServer_PRM
---- PASS: TestKeycloak_MCPServer_PRM (0.01s)
+    interop_test.go:123: Keycloak realm mcpkit-test not ready (status 404)
+--- SKIP: TestKeycloak_MCPServer_PRM (0.00s)
 === RUN   TestKeycloak_MCPServer_WWWAuthenticate
---- PASS: TestKeycloak_MCPServer_WWWAuthenticate (0.01s)
+    interop_test.go:144: Keycloak realm mcpkit-test not ready (status 404)
+--- SKIP: TestKeycloak_MCPServer_WWWAuthenticate (0.00s)
 === RUN   TestKeycloak_MCPServer_PasswordGrant
---- PASS: TestKeycloak_MCPServer_PasswordGrant (0.03s)
+    interop_test.go:167: Keycloak realm mcpkit-test not ready (status 404)
+--- SKIP: TestKeycloak_MCPServer_PasswordGrant (0.01s)
 === RUN   TestKeycloak_PublicMethods_DiscoverWithoutAuth
---- PASS: TestKeycloak_PublicMethods_DiscoverWithoutAuth (0.01s)
+    public_methods_test.go:22: Keycloak realm mcpkit-test not ready (status 404)
+--- SKIP: TestKeycloak_PublicMethods_DiscoverWithoutAuth (0.00s)
 === RUN   TestKeycloak_PublicMethods_ToolCallRequiresAuth
---- PASS: TestKeycloak_PublicMethods_ToolCallRequiresAuth (0.01s)
+    public_methods_test.go:65: Keycloak realm mcpkit-test not ready (status 404)
+--- SKIP: TestKeycloak_PublicMethods_ToolCallRequiresAuth (0.00s)
 === RUN   TestKeycloak_SessionHijack_DifferentUserRejected
---- PASS: TestKeycloak_SessionHijack_DifferentUserRejected (0.05s)
+    session_hijack_test.go:54: Keycloak realm mcpkit-test not ready (status 404)
+--- SKIP: TestKeycloak_SessionHijack_DifferentUserRejected (0.00s)
 === RUN   TestKeycloak_SessionHijack_SameUserAllowed
---- PASS: TestKeycloak_SessionHijack_SameUserAllowed (0.03s)
+    session_hijack_test.go:85: Keycloak realm mcpkit-test not ready (status 404)
+--- SKIP: TestKeycloak_SessionHijack_SameUserAllowed (0.00s)
 === RUN   TestKeycloak_TokenRefresh_PasswordGrant
---- PASS: TestKeycloak_TokenRefresh_PasswordGrant (0.03s)
+    token_refresh_test.go:22: Keycloak realm mcpkit-test not ready (status 404)
+--- SKIP: TestKeycloak_TokenRefresh_PasswordGrant (0.00s)
 PASS
-ok  	github.com/panyam/mcpkit/tests/keycloak	0.508s
-Finished: Tue Apr 21 12:54:20 PDT 2026
+ok  	github.com/panyam/mcpkit/tests/keycloak	0.634s
+make[2]: *** No rule to make target `downkcl'.  Stop.
+Finished: Wed Apr 22 13:33:00 PDT 2026
 </pre></details>
 </body></html>

--- a/tests/reports/run.log
+++ b/tests/reports/run.log
@@ -1,5 +1,5 @@
 === MCPKit Comprehensive Test Suite ===
-Started: Tue Apr 21 12:53:35 PDT 2026
+Started: Wed Apr 22 13:29:53 PDT 2026
 
 --- [1/10] unit+coverage ---
   PASS: unit+coverage
@@ -23,4 +23,4 @@ Started: Tue Apr 21 12:53:35 PDT 2026
   PASS: keycloak
 
 === Results: 10 passed, 0 failed ===
-Finished: Tue Apr 21 12:54:20 PDT 2026
+Finished: Wed Apr 22 13:33:00 PDT 2026

--- a/tests/reports/stage-auth-conformance.log
+++ b/tests/reports/stage-auth-conformance.log
@@ -1,5 +1,5 @@
 === Stage 9/10: auth-conformance (make testconfauth) ===
-Started: Tue Apr 21 12:54:17 PDT 2026
+Started: Wed Apr 22 13:30:53 PDT 2026
 bash scripts/conformance-auth-test.sh
 Building testclient...
 === Running MCP Auth conformance suite ===
@@ -21,22 +21,22 @@ Starting scenario: auth/token-endpoint-auth-basic
 Starting scenario: auth/token-endpoint-auth-post
 Starting scenario: auth/token-endpoint-auth-none
 Starting scenario: auth/pre-registration
-Executing client: ./bin/testclient http://localhost:61479/mcp
-Executing client: ./bin/testclient http://localhost:61480/mcp
-Executing client: ./bin/testclient http://localhost:61481/mcp
-Executing client: ./bin/testclient http://localhost:61482/mcp
-Executing client: ./bin/testclient http://localhost:61483/mcp
-Executing client: ./bin/testclient http://localhost:61484/mcp
-Executing client: ./bin/testclient http://localhost:61485/mcp
-Executing client: ./bin/testclient http://localhost:61486/mcp
-Executing client: ./bin/testclient http://localhost:61487/mcp
-Executing client: ./bin/testclient http://localhost:61488/mcp
-Executing client: ./bin/testclient http://localhost:61489/mcp
-Executing client: ./bin/testclient http://localhost:61490/mcp
-Executing client: ./bin/testclient http://localhost:61491/mcp
-Executing client: ./bin/testclient http://localhost:61492/mcp
+Executing client: ./bin/testclient http://localhost:49338/mcp
+Executing client: ./bin/testclient http://localhost:49339/mcp
+Executing client: ./bin/testclient http://localhost:49340/mcp
+Executing client: ./bin/testclient http://localhost:49341/mcp
+Executing client: ./bin/testclient http://localhost:49342/mcp
+Executing client: ./bin/testclient http://localhost:49343/mcp
+Executing client: ./bin/testclient http://localhost:49344/mcp
+Executing client: ./bin/testclient http://localhost:49345/mcp
+Executing client: ./bin/testclient http://localhost:49346/mcp
+Executing client: ./bin/testclient http://localhost:49347/mcp
+Executing client: ./bin/testclient http://localhost:49348/mcp
+Executing client: ./bin/testclient http://localhost:49349/mcp
+Executing client: ./bin/testclient http://localhost:49350/mcp
+Executing client: ./bin/testclient http://localhost:49351/mcp
 With context: {"client_id":"pre-registered-client","client_secret":"pre-registered-secret"}
-(node:79914) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
+(node:44990) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
 (Use `node --trace-deprecation ...` to show where the warning was created)
 
 === SUITE SUMMARY ===
@@ -64,4 +64,4 @@ Total: 210 passed, 0 failed, 1 warnings
 [32mBaseline check passed: all failures are expected.[0m
 
 === AUTH CONFORMANCE TESTS PASSED ===
-Finished: Tue Apr 21 12:54:19 PDT 2026
+Finished: Wed Apr 22 13:30:54 PDT 2026

--- a/tests/reports/stage-auth.log
+++ b/tests/reports/stage-auth.log
@@ -1,5 +1,5 @@
 === Stage 3/10: auth (make test-auth) ===
-Started: Tue Apr 21 12:53:58 PDT 2026
+Started: Wed Apr 22 13:30:27 PDT 2026
 cd ext/auth && go test ./... -count=1 -timeout 30s
-ok  	github.com/panyam/mcpkit/ext/auth	0.232s
-Finished: Tue Apr 21 12:53:59 PDT 2026
+ok  	github.com/panyam/mcpkit/ext/auth	0.334s
+Finished: Wed Apr 22 13:30:28 PDT 2026

--- a/tests/reports/stage-conformance.log
+++ b/tests/reports/stage-conformance.log
@@ -1,9 +1,9 @@
 === Stage 8/10: conformance (make testconf) ===
-Started: Tue Apr 21 12:54:13 PDT 2026
+Started: Wed Apr 22 13:30:48 PDT 2026
 bash scripts/conformance-test.sh
 Killing stale process on port 18799...
 === Starting test server on :18799 (Streamable HTTP) ===
-Waiting for server....2026/04/21 12:54:14 MCP test server listening on :18799 (Streamable HTTP at /mcp)
+Waiting for server....2026/04/22 13:30:50 MCP test server listening on :18799 (Streamable HTTP at /mcp)
  ready
 
 === Running MCP conformance suite ===
@@ -14,296 +14,296 @@ Running active suite (30 scenarios) against http://localhost:18799/mcp
 
 === Running scenario: server-initialize ===
 Running client scenario 'server-initialize' against server: http://localhost:18799/mcp
-2026/04/21 12:54:16 Starting MCP-GET-SSE SSE connection: 227ade805f7c2e9bd2efa3c5c4faa654
-2026/04/21 12:54:16 SSEHub: registered connection 227ade805f7c2e9bd2efa3c5c4faa654 (total: 1)
-2026/04/21 12:54:16 SSEHub: unregistered connection 227ade805f7c2e9bd2efa3c5c4faa654 (total: 0)
-2026/04/21 12:54:16 Received kill signal.  Quitting Writer. stop 0x492c45f72e70
-2026/04/21 12:54:16 Cleaning up writer...
-2026/04/21 12:54:16 Finished cleaning up writer:  0x492c45f72e70
-2026/04/21 12:54:16 Closed MCP-GET-SSE SSE connection: 227ade805f7c2e9bd2efa3c5c4faa654
+2026/04/22 13:30:52 Starting MCP-GET-SSE SSE connection: 4646daa377d680c41e48f59f8f9e8cc4
+2026/04/22 13:30:52 SSEHub: registered connection 4646daa377d680c41e48f59f8f9e8cc4 (total: 1)
+2026/04/22 13:30:52 SSEHub: unregistered connection 4646daa377d680c41e48f59f8f9e8cc4 (total: 0)
+2026/04/22 13:30:52 Received kill signal.  Quitting Writer. stop 0x6e6b2afc02a0
+2026/04/22 13:30:52 Cleaning up writer...
+2026/04/22 13:30:52 Finished cleaning up writer:  0x6e6b2afc02a0
+2026/04/22 13:30:52 Closed MCP-GET-SSE SSE connection: 4646daa377d680c41e48f59f8f9e8cc4
 
 === Running scenario: logging-set-level ===
 Running client scenario 'logging-set-level' against server: http://localhost:18799/mcp
-2026/04/21 12:54:16 Starting MCP-GET-SSE SSE connection: d1246ad5baa1345384c7054f81f6a081
-2026/04/21 12:54:16 SSEHub: registered connection d1246ad5baa1345384c7054f81f6a081 (total: 1)
-2026/04/21 12:54:16 SSEHub: unregistered connection d1246ad5baa1345384c7054f81f6a081 (total: 0)
-2026/04/21 12:54:16 Received kill signal.  Quitting Writer. stop 0x492c4603c310
-2026/04/21 12:54:16 Cleaning up writer...
-2026/04/21 12:54:16 Finished cleaning up writer:  0x492c4603c310
-2026/04/21 12:54:16 Closed MCP-GET-SSE SSE connection: d1246ad5baa1345384c7054f81f6a081
+2026/04/22 13:30:52 Starting MCP-GET-SSE SSE connection: 5b09e3a8ef59babb7f85f70f60f9ab6c
+2026/04/22 13:30:52 SSEHub: registered connection 5b09e3a8ef59babb7f85f70f60f9ab6c (total: 1)
+2026/04/22 13:30:52 SSEHub: unregistered connection 5b09e3a8ef59babb7f85f70f60f9ab6c (total: 0)
+2026/04/22 13:30:52 Received kill signal.  Quitting Writer. stop 0x6e6b2b3ae2a0
+2026/04/22 13:30:52 Cleaning up writer...
+2026/04/22 13:30:52 Finished cleaning up writer:  0x6e6b2b3ae2a0
+2026/04/22 13:30:52 Closed MCP-GET-SSE SSE connection: 5b09e3a8ef59babb7f85f70f60f9ab6c
 
 === Running scenario: ping ===
 Running client scenario 'ping' against server: http://localhost:18799/mcp
-2026/04/21 12:54:16 Starting MCP-GET-SSE SSE connection: 08a1818e40608c8f2ab792122368cd65
-2026/04/21 12:54:16 SSEHub: registered connection 08a1818e40608c8f2ab792122368cd65 (total: 1)
-2026/04/21 12:54:16 SSEHub: unregistered connection 08a1818e40608c8f2ab792122368cd65 (total: 0)
-2026/04/21 12:54:16 Received kill signal.  Quitting Writer. stop 0x492c463b61c0
-2026/04/21 12:54:16 Cleaning up writer...
-2026/04/21 12:54:16 Finished cleaning up writer:  0x492c463b61c0
-2026/04/21 12:54:16 Closed MCP-GET-SSE SSE connection: 08a1818e40608c8f2ab792122368cd65
+2026/04/22 13:30:52 Starting MCP-GET-SSE SSE connection: cac83464426b898a31f19b5506113363
+2026/04/22 13:30:52 SSEHub: registered connection cac83464426b898a31f19b5506113363 (total: 1)
+2026/04/22 13:30:52 SSEHub: unregistered connection cac83464426b898a31f19b5506113363 (total: 0)
 
 === Running scenario: completion-complete ===
+2026/04/22 13:30:52 Received kill signal.  Quitting Writer. stop 0x6e6b2aec2310
+2026/04/22 13:30:52 Cleaning up writer...
+2026/04/22 13:30:52 Finished cleaning up writer:  0x6e6b2aec2310
+2026/04/22 13:30:52 Closed MCP-GET-SSE SSE connection: cac83464426b898a31f19b5506113363
 Running client scenario 'completion-complete' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: d45adc19a97f639f3cd357d7c0b52900
-2026/04/21 12:54:17 SSEHub: registered connection d45adc19a97f639f3cd357d7c0b52900 (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection d45adc19a97f639f3cd357d7c0b52900 (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c463b6460
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c463b6460
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: d45adc19a97f639f3cd357d7c0b52900
+2026/04/22 13:30:52 Starting MCP-GET-SSE SSE connection: 14f3d25004ba403d4144d61a4414f7da
+2026/04/22 13:30:52 SSEHub: registered connection 14f3d25004ba403d4144d61a4414f7da (total: 1)
+2026/04/22 13:30:52 SSEHub: unregistered connection 14f3d25004ba403d4144d61a4414f7da (total: 0)
+2026/04/22 13:30:52 Received kill signal.  Quitting Writer. stop 0x6e6b2b42e2a0
+2026/04/22 13:30:52 Cleaning up writer...
+2026/04/22 13:30:52 Finished cleaning up writer:  0x6e6b2b42e2a0
+2026/04/22 13:30:52 Closed MCP-GET-SSE SSE connection: 14f3d25004ba403d4144d61a4414f7da
 
 === Running scenario: tools-list ===
 Running client scenario 'tools-list' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: 163b188e006b17f6a53af5776c2a6bac
-2026/04/21 12:54:17 SSEHub: registered connection 163b188e006b17f6a53af5776c2a6bac (total: 1)
+2026/04/22 13:30:52 Starting MCP-GET-SSE SSE connection: 58f93e43b6186864c02f864310e017b9
+2026/04/22 13:30:52 SSEHub: registered connection 58f93e43b6186864c02f864310e017b9 (total: 1)
 
 === Running scenario: tools-call-simple-text ===
-2026/04/21 12:54:17 SSEHub: unregistered connection 163b188e006b17f6a53af5776c2a6bac (total: 0)
+2026/04/22 13:30:52 SSEHub: unregistered connection 58f93e43b6186864c02f864310e017b9 (total: 0)
 Running client scenario 'tools-call-simple-text' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c45f731f0
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c45f731f0
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: 163b188e006b17f6a53af5776c2a6bac
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: ac79a94f47b09ce3df520e4e1604fae8
-2026/04/21 12:54:17 SSEHub: registered connection ac79a94f47b09ce3df520e4e1604fae8 (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection ac79a94f47b09ce3df520e4e1604fae8 (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c463b67e0
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c463b67e0
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: ac79a94f47b09ce3df520e4e1604fae8
+2026/04/22 13:30:52 Received kill signal.  Quitting Writer. stop 0x6e6b2afc01c0
+2026/04/22 13:30:52 Cleaning up writer...
+2026/04/22 13:30:52 Finished cleaning up writer:  0x6e6b2afc01c0
+2026/04/22 13:30:52 Closed MCP-GET-SSE SSE connection: 58f93e43b6186864c02f864310e017b9
+2026/04/22 13:30:52 Starting MCP-GET-SSE SSE connection: 17f804e5e531040d15bab7785e405070
+2026/04/22 13:30:52 SSEHub: registered connection 17f804e5e531040d15bab7785e405070 (total: 1)
 
 === Running scenario: tools-call-image ===
 Running client scenario 'tools-call-image' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: 589aa2342c2ed8fe517b362784235042
-2026/04/21 12:54:17 SSEHub: registered connection 589aa2342c2ed8fe517b362784235042 (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection 589aa2342c2ed8fe517b362784235042 (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c463b6230
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c463b6230
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: 589aa2342c2ed8fe517b362784235042
+2026/04/22 13:30:52 SSEHub: unregistered connection 17f804e5e531040d15bab7785e405070 (total: 0)
+2026/04/22 13:30:52 Received kill signal.  Quitting Writer. stop 0x6e6b2b42e4d0
+2026/04/22 13:30:52 Cleaning up writer...
+2026/04/22 13:30:52 Finished cleaning up writer:  0x6e6b2b42e4d0
+2026/04/22 13:30:52 Closed MCP-GET-SSE SSE connection: 17f804e5e531040d15bab7785e405070
+2026/04/22 13:30:52 Starting MCP-GET-SSE SSE connection: 7356b7d4da92edebd427e00f02a212c1
+2026/04/22 13:30:52 SSEHub: registered connection 7356b7d4da92edebd427e00f02a212c1 (total: 1)
 
 === Running scenario: tools-call-audio ===
+2026/04/22 13:30:52 SSEHub: unregistered connection 7356b7d4da92edebd427e00f02a212c1 (total: 0)
 Running client scenario 'tools-call-audio' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: 3bac024630e0f22e5e6cc45eb8edf7f5
-2026/04/21 12:54:17 SSEHub: registered connection 3bac024630e0f22e5e6cc45eb8edf7f5 (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection 3bac024630e0f22e5e6cc45eb8edf7f5 (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c45f723f0
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c45f723f0
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: 3bac024630e0f22e5e6cc45eb8edf7f5
+2026/04/22 13:30:52 Received kill signal.  Quitting Writer. stop 0x6e6b2afc05b0
+2026/04/22 13:30:52 Cleaning up writer...
+2026/04/22 13:30:52 Finished cleaning up writer:  0x6e6b2afc05b0
+2026/04/22 13:30:52 Closed MCP-GET-SSE SSE connection: 7356b7d4da92edebd427e00f02a212c1
+2026/04/22 13:30:52 Starting MCP-GET-SSE SSE connection: 17ce0a43f9365f19cfd88f4f7f4f9f35
+2026/04/22 13:30:52 SSEHub: registered connection 17ce0a43f9365f19cfd88f4f7f4f9f35 (total: 1)
+2026/04/22 13:30:52 SSEHub: unregistered connection 17ce0a43f9365f19cfd88f4f7f4f9f35 (total: 0)
 
 === Running scenario: tools-call-embedded-resource ===
+2026/04/22 13:30:52 Received kill signal.  Quitting Writer. stop 0x6e6b2afc07e0
+2026/04/22 13:30:52 Cleaning up writer...
 Running client scenario 'tools-call-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: d159a932c4f92866fcf4b37e649fc78c
-2026/04/21 12:54:17 SSEHub: registered connection d159a932c4f92866fcf4b37e649fc78c (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection d159a932c4f92866fcf4b37e649fc78c (total: 0)
+2026/04/22 13:30:52 Finished cleaning up writer:  0x6e6b2afc07e0
+2026/04/22 13:30:52 Closed MCP-GET-SSE SSE connection: 17ce0a43f9365f19cfd88f4f7f4f9f35
+2026/04/22 13:30:52 Starting MCP-GET-SSE SSE connection: e7aaa1d3ae1b266d386c0b9356982218
+2026/04/22 13:30:52 SSEHub: registered connection e7aaa1d3ae1b266d386c0b9356982218 (total: 1)
+2026/04/22 13:30:52 SSEHub: unregistered connection e7aaa1d3ae1b266d386c0b9356982218 (total: 0)
 
 === Running scenario: tools-call-mixed-content ===
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c45f72ee0
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c45f72ee0
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: d159a932c4f92866fcf4b37e649fc78c
+2026/04/22 13:30:52 Received kill signal.  Quitting Writer. stop 0x6e6b2afc0a80
+2026/04/22 13:30:52 Cleaning up writer...
+2026/04/22 13:30:52 Finished cleaning up writer:  0x6e6b2afc0a80
+2026/04/22 13:30:52 Closed MCP-GET-SSE SSE connection: e7aaa1d3ae1b266d386c0b9356982218
 Running client scenario 'tools-call-mixed-content' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: fce2ed035277664089587b43e244c770
-2026/04/21 12:54:17 SSEHub: registered connection fce2ed035277664089587b43e244c770 (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection fce2ed035277664089587b43e244c770 (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c45f73110
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c45f73110
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: fce2ed035277664089587b43e244c770
+2026/04/22 13:30:52 Starting MCP-GET-SSE SSE connection: ba895d876c20e424d9d4af5a8bddbb51
+2026/04/22 13:30:52 SSEHub: registered connection ba895d876c20e424d9d4af5a8bddbb51 (total: 1)
 
 === Running scenario: tools-call-with-logging ===
+2026/04/22 13:30:52 SSEHub: unregistered connection ba895d876c20e424d9d4af5a8bddbb51 (total: 0)
 Running client scenario 'tools-call-with-logging' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: 8c93173febf02cbb59d07caf1af48422
-2026/04/21 12:54:17 SSEHub: registered connection 8c93173febf02cbb59d07caf1af48422 (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection 8c93173febf02cbb59d07caf1af48422 (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c45f73420
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c45f73420
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: 8c93173febf02cbb59d07caf1af48422
+2026/04/22 13:30:52 Received kill signal.  Quitting Writer. stop 0x6e6b2b42e930
+2026/04/22 13:30:52 Cleaning up writer...
+2026/04/22 13:30:52 Finished cleaning up writer:  0x6e6b2b42e930
+2026/04/22 13:30:52 Closed MCP-GET-SSE SSE connection: ba895d876c20e424d9d4af5a8bddbb51
+2026/04/22 13:30:52 Starting MCP-GET-SSE SSE connection: 2be201740203f0502ce2fbcab317b387
+2026/04/22 13:30:52 SSEHub: registered connection 2be201740203f0502ce2fbcab317b387 (total: 1)
+2026/04/22 13:30:52 SSEHub: unregistered connection 2be201740203f0502ce2fbcab317b387 (total: 0)
+2026/04/22 13:30:52 Received kill signal.  Quitting Writer. stop 0x6e6b2b00ea80
+2026/04/22 13:30:52 Cleaning up writer...
+2026/04/22 13:30:52 Finished cleaning up writer:  0x6e6b2b00ea80
+2026/04/22 13:30:52 Closed MCP-GET-SSE SSE connection: 2be201740203f0502ce2fbcab317b387
 
 === Running scenario: tools-call-error ===
 Running client scenario 'tools-call-error' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: d469390ec06cb5608b27f24a75f1d4c1
-2026/04/21 12:54:17 SSEHub: registered connection d469390ec06cb5608b27f24a75f1d4c1 (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection d469390ec06cb5608b27f24a75f1d4c1 (total: 0)
+2026/04/22 13:30:52 Starting MCP-GET-SSE SSE connection: 97b07ad0f41d5928cd87999829f2383b
+2026/04/22 13:30:52 SSEHub: registered connection 97b07ad0f41d5928cd87999829f2383b (total: 1)
+2026/04/22 13:30:52 SSEHub: unregistered connection 97b07ad0f41d5928cd87999829f2383b (total: 0)
+2026/04/22 13:30:52 Received kill signal.  Quitting Writer. stop 0x6e6b2aec27e0
+2026/04/22 13:30:52 Cleaning up writer...
 
 === Running scenario: tools-call-with-progress ===
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c463b68c0
+2026/04/22 13:30:52 Finished cleaning up writer:  0x6e6b2aec27e0
+2026/04/22 13:30:52 Closed MCP-GET-SSE SSE connection: 97b07ad0f41d5928cd87999829f2383b
 Running client scenario 'tools-call-with-progress' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c463b68c0
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: d469390ec06cb5608b27f24a75f1d4c1
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: ed42c10e306dbfb9d423316e9b3064f7
-2026/04/21 12:54:17 SSEHub: registered connection ed42c10e306dbfb9d423316e9b3064f7 (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection ed42c10e306dbfb9d423316e9b3064f7 (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c463b6bd0
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c463b6bd0
+2026/04/22 13:30:52 Starting MCP-GET-SSE SSE connection: a7490a040759730194a6a4f255e1223a
+2026/04/22 13:30:52 SSEHub: registered connection a7490a040759730194a6a4f255e1223a (total: 1)
+2026/04/22 13:30:53 SSEHub: unregistered connection a7490a040759730194a6a4f255e1223a (total: 0)
+2026/04/22 13:30:53 Received kill signal.  Quitting Writer. stop 0x6e6b2aec2af0
+2026/04/22 13:30:53 Cleaning up writer...
+2026/04/22 13:30:53 Finished cleaning up writer:  0x6e6b2aec2af0
+2026/04/22 13:30:53 Closed MCP-GET-SSE SSE connection: a7490a040759730194a6a4f255e1223a
 
 === Running scenario: tools-call-sampling ===
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: ed42c10e306dbfb9d423316e9b3064f7
 Running client scenario 'tools-call-sampling' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: fca4d702a1eeee21ca2216cf9aeef462
-2026/04/21 12:54:17 SSEHub: registered connection fca4d702a1eeee21ca2216cf9aeef462 (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection fca4d702a1eeee21ca2216cf9aeef462 (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c464aa3f0
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c464aa3f0
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: fca4d702a1eeee21ca2216cf9aeef462
+2026/04/22 13:30:53 Starting MCP-GET-SSE SSE connection: d3bd69d61c0d557637a018340fd53b82
+2026/04/22 13:30:53 SSEHub: registered connection d3bd69d61c0d557637a018340fd53b82 (total: 1)
+2026/04/22 13:30:53 SSEHub: unregistered connection d3bd69d61c0d557637a018340fd53b82 (total: 0)
+2026/04/22 13:30:53 Received kill signal.  Quitting Writer. stop 0x6e6b2afc0e00
+2026/04/22 13:30:53 Cleaning up writer...
+2026/04/22 13:30:53 Finished cleaning up writer:  0x6e6b2afc0e00
+2026/04/22 13:30:53 Closed MCP-GET-SSE SSE connection: d3bd69d61c0d557637a018340fd53b82
 
 === Running scenario: tools-call-elicitation ===
 Running client scenario 'tools-call-elicitation' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: 4eb16ebedcf3128a22c8e203ff80054e
-2026/04/21 12:54:17 SSEHub: registered connection 4eb16ebedcf3128a22c8e203ff80054e (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection 4eb16ebedcf3128a22c8e203ff80054e (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c45f73960
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c45f73960
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: 4eb16ebedcf3128a22c8e203ff80054e
+2026/04/22 13:30:53 Starting MCP-GET-SSE SSE connection: af59030b17426ff661539064e24bd8c3
+2026/04/22 13:30:53 SSEHub: registered connection af59030b17426ff661539064e24bd8c3 (total: 1)
+2026/04/22 13:30:53 SSEHub: unregistered connection af59030b17426ff661539064e24bd8c3 (total: 0)
+2026/04/22 13:30:53 Received kill signal.  Quitting Writer. stop 0x6e6b2b00ee70
+2026/04/22 13:30:53 Cleaning up writer...
+2026/04/22 13:30:53 Finished cleaning up writer:  0x6e6b2b00ee70
+2026/04/22 13:30:53 Closed MCP-GET-SSE SSE connection: af59030b17426ff661539064e24bd8c3
 
 === Running scenario: elicitation-sep1034-defaults ===
 Running client scenario 'elicitation-sep1034-defaults' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: 218d16d2e883b23b98f178d8b1a128c4
-2026/04/21 12:54:17 SSEHub: registered connection 218d16d2e883b23b98f178d8b1a128c4 (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection 218d16d2e883b23b98f178d8b1a128c4 (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c464aa620
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c464aa620
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: 218d16d2e883b23b98f178d8b1a128c4
+2026/04/22 13:30:53 Starting MCP-GET-SSE SSE connection: 5f7f5c483a29f077822dd30b0b269b13
+2026/04/22 13:30:53 SSEHub: registered connection 5f7f5c483a29f077822dd30b0b269b13 (total: 1)
+2026/04/22 13:30:53 SSEHub: unregistered connection 5f7f5c483a29f077822dd30b0b269b13 (total: 0)
 
 === Running scenario: server-sse-multiple-streams ===
+2026/04/22 13:30:53 Received kill signal.  Quitting Writer. stop 0x6e6b2b42eb60
+2026/04/22 13:30:53 Cleaning up writer...
+2026/04/22 13:30:53 Finished cleaning up writer:  0x6e6b2b42eb60
+2026/04/22 13:30:53 Closed MCP-GET-SSE SSE connection: 5f7f5c483a29f077822dd30b0b269b13
 Running client scenario 'server-sse-multiple-streams' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: e8974a34bc076b27d2d7d2f3d0eed0a7
-2026/04/21 12:54:17 SSEHub: registered connection e8974a34bc076b27d2d7d2f3d0eed0a7 (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection e8974a34bc076b27d2d7d2f3d0eed0a7 (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c45f73dc0
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c45f73dc0
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: e8974a34bc076b27d2d7d2f3d0eed0a7
+2026/04/22 13:30:53 Starting MCP-GET-SSE SSE connection: 096c4263753ebe25ecff7355246b84bd
+2026/04/22 13:30:53 SSEHub: registered connection 096c4263753ebe25ecff7355246b84bd (total: 1)
+2026/04/22 13:30:53 SSEHub: unregistered connection 096c4263753ebe25ecff7355246b84bd (total: 0)
 
 === Running scenario: elicitation-sep1330-enums ===
+2026/04/22 13:30:53 Received kill signal.  Quitting Writer. stop 0x6e6b2afc12d0
+2026/04/22 13:30:53 Cleaning up writer...
+2026/04/22 13:30:53 Finished cleaning up writer:  0x6e6b2afc12d0
+2026/04/22 13:30:53 Closed MCP-GET-SSE SSE connection: 096c4263753ebe25ecff7355246b84bd
 Running client scenario 'elicitation-sep1330-enums' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: 56967c646b860caa4c92b9d22794defe
-2026/04/21 12:54:17 SSEHub: registered connection 56967c646b860caa4c92b9d22794defe (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection 56967c646b860caa4c92b9d22794defe (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c463b7110
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c463b7110
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: 56967c646b860caa4c92b9d22794defe
+2026/04/22 13:30:53 Starting MCP-GET-SSE SSE connection: f15f907318a1a37b9e50286cafb010c8
+2026/04/22 13:30:53 SSEHub: registered connection f15f907318a1a37b9e50286cafb010c8 (total: 1)
+2026/04/22 13:30:53 SSEHub: unregistered connection f15f907318a1a37b9e50286cafb010c8 (total: 0)
 
 === Running scenario: resources-list ===
+2026/04/22 13:30:53 Received kill signal.  Quitting Writer. stop 0x6e6b2afc15e0
+2026/04/22 13:30:53 Cleaning up writer...
+2026/04/22 13:30:53 Finished cleaning up writer:  0x6e6b2afc15e0
+2026/04/22 13:30:53 Closed MCP-GET-SSE SSE connection: f15f907318a1a37b9e50286cafb010c8
 Running client scenario 'resources-list' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: a1e3afd706774fc46d7ecc773a02a38f
-2026/04/21 12:54:17 SSEHub: registered connection a1e3afd706774fc46d7ecc773a02a38f (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection a1e3afd706774fc46d7ecc773a02a38f (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c460d65b0
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c460d65b0
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: a1e3afd706774fc46d7ecc773a02a38f
+2026/04/22 13:30:53 Starting MCP-GET-SSE SSE connection: f29cfc411612b1796cb2c4f1f804866c
+2026/04/22 13:30:53 SSEHub: registered connection f29cfc411612b1796cb2c4f1f804866c (total: 1)
+2026/04/22 13:30:53 SSEHub: unregistered connection f29cfc411612b1796cb2c4f1f804866c (total: 0)
 
 === Running scenario: resources-read-text ===
 Running client scenario 'resources-read-text' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: 100dd4984002c1ec60340aa9535ff9cd
-2026/04/21 12:54:17 SSEHub: registered connection 100dd4984002c1ec60340aa9535ff9cd (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection 100dd4984002c1ec60340aa9535ff9cd (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c461582a0
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c461582a0
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: 100dd4984002c1ec60340aa9535ff9cd
+2026/04/22 13:30:53 Received kill signal.  Quitting Writer. stop 0x6e6b2afc19d0
+2026/04/22 13:30:53 Cleaning up writer...
+2026/04/22 13:30:53 Finished cleaning up writer:  0x6e6b2afc19d0
+2026/04/22 13:30:53 Closed MCP-GET-SSE SSE connection: f29cfc411612b1796cb2c4f1f804866c
+2026/04/22 13:30:53 Starting MCP-GET-SSE SSE connection: 9aa976ea3631b7586b4925fa5e3842a6
+2026/04/22 13:30:53 SSEHub: registered connection 9aa976ea3631b7586b4925fa5e3842a6 (total: 1)
+2026/04/22 13:30:53 SSEHub: unregistered connection 9aa976ea3631b7586b4925fa5e3842a6 (total: 0)
+2026/04/22 13:30:53 Received kill signal.  Quitting Writer. stop 0x6e6b2aec3260
+2026/04/22 13:30:53 Cleaning up writer...
+2026/04/22 13:30:53 Finished cleaning up writer:  0x6e6b2aec3260
 
 === Running scenario: resources-read-binary ===
+2026/04/22 13:30:53 Closed MCP-GET-SSE SSE connection: 9aa976ea3631b7586b4925fa5e3842a6
 Running client scenario 'resources-read-binary' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: 624278df5c287f98512298a36fbba05c
-2026/04/21 12:54:17 SSEHub: registered connection 624278df5c287f98512298a36fbba05c (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection 624278df5c287f98512298a36fbba05c (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c46224150
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c46224150
+2026/04/22 13:30:53 Starting MCP-GET-SSE SSE connection: f63b06836e8da16cc44bcf3523040934
+2026/04/22 13:30:53 SSEHub: registered connection f63b06836e8da16cc44bcf3523040934 (total: 1)
 
 === Running scenario: resources-templates-read ===
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: 624278df5c287f98512298a36fbba05c
+2026/04/22 13:30:53 SSEHub: unregistered connection f63b06836e8da16cc44bcf3523040934 (total: 0)
 Running client scenario 'resources-templates-read' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: f2f9f9fcb7a9568e40e198cb66efc473
-2026/04/21 12:54:17 SSEHub: registered connection f2f9f9fcb7a9568e40e198cb66efc473 (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection f2f9f9fcb7a9568e40e198cb66efc473 (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c463b7420
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c463b7420
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: f2f9f9fcb7a9568e40e198cb66efc473
+2026/04/22 13:30:53 Received kill signal.  Quitting Writer. stop 0x6e6b2aec3490
+2026/04/22 13:30:53 Cleaning up writer...
+2026/04/22 13:30:53 Finished cleaning up writer:  0x6e6b2aec3490
+2026/04/22 13:30:53 Closed MCP-GET-SSE SSE connection: f63b06836e8da16cc44bcf3523040934
+2026/04/22 13:30:53 Starting MCP-GET-SSE SSE connection: a27405af9d5198e95702c2f162334b4a
+2026/04/22 13:30:53 SSEHub: registered connection a27405af9d5198e95702c2f162334b4a (total: 1)
+2026/04/22 13:30:53 SSEHub: unregistered connection a27405af9d5198e95702c2f162334b4a (total: 0)
 
 === Running scenario: resources-subscribe ===
+2026/04/22 13:30:53 Received kill signal.  Quitting Writer. stop 0x6e6b2b00f3b0
 Running client scenario 'resources-subscribe' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: f1bc3adaa56e91d4a7c5f9d279ce6042
-2026/04/21 12:54:17 SSEHub: registered connection f1bc3adaa56e91d4a7c5f9d279ce6042 (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection f1bc3adaa56e91d4a7c5f9d279ce6042 (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c463b7650
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c463b7650
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: f1bc3adaa56e91d4a7c5f9d279ce6042
+2026/04/22 13:30:53 Cleaning up writer...
+2026/04/22 13:30:53 Finished cleaning up writer:  0x6e6b2b00f3b0
+2026/04/22 13:30:53 Closed MCP-GET-SSE SSE connection: a27405af9d5198e95702c2f162334b4a
+2026/04/22 13:30:53 Starting MCP-GET-SSE SSE connection: 90a637dc6db35ea10843604904a0af89
+2026/04/22 13:30:53 SSEHub: registered connection 90a637dc6db35ea10843604904a0af89 (total: 1)
+2026/04/22 13:30:53 SSEHub: unregistered connection 90a637dc6db35ea10843604904a0af89 (total: 0)
+2026/04/22 13:30:53 Received kill signal.  Quitting Writer. stop 0x6e6b2aec3730
+2026/04/22 13:30:53 Cleaning up writer...
+2026/04/22 13:30:53 Finished cleaning up writer:  0x6e6b2aec3730
+2026/04/22 13:30:53 Closed MCP-GET-SSE SSE connection: 90a637dc6db35ea10843604904a0af89
 
 === Running scenario: resources-unsubscribe ===
 Running client scenario 'resources-unsubscribe' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: f3df97277438cadc995dba012720c904
-2026/04/21 12:54:17 SSEHub: registered connection f3df97277438cadc995dba012720c904 (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection f3df97277438cadc995dba012720c904 (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c460d69a0
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c460d69a0
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: f3df97277438cadc995dba012720c904
+2026/04/22 13:30:53 Starting MCP-GET-SSE SSE connection: d350a1391cbdcf636237a0fd423f52d7
+2026/04/22 13:30:53 SSEHub: registered connection d350a1391cbdcf636237a0fd423f52d7 (total: 1)
+2026/04/22 13:30:53 SSEHub: unregistered connection d350a1391cbdcf636237a0fd423f52d7 (total: 0)
+2026/04/22 13:30:53 Received kill signal.  Quitting Writer. stop 0x6e6b2b42ee70
 
 === Running scenario: prompts-list ===
+2026/04/22 13:30:53 Cleaning up writer...
+2026/04/22 13:30:53 Finished cleaning up writer:  0x6e6b2b42ee70
+2026/04/22 13:30:53 Closed MCP-GET-SSE SSE connection: d350a1391cbdcf636237a0fd423f52d7
 Running client scenario 'prompts-list' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: fea06cca33caf002055517cbb4aadca8
-2026/04/21 12:54:17 SSEHub: registered connection fea06cca33caf002055517cbb4aadca8 (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection fea06cca33caf002055517cbb4aadca8 (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c46224540
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c46224540
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: fea06cca33caf002055517cbb4aadca8
+2026/04/22 13:30:53 Starting MCP-GET-SSE SSE connection: e411958e60df861fed43b48fd76bdbd9
+2026/04/22 13:30:53 SSEHub: registered connection e411958e60df861fed43b48fd76bdbd9 (total: 1)
 
 === Running scenario: prompts-get-simple ===
 Running client scenario 'prompts-get-simple' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: 56add02db339bbce6a2c37d2a9b67159
-2026/04/21 12:54:17 SSEHub: registered connection 56add02db339bbce6a2c37d2a9b67159 (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection 56add02db339bbce6a2c37d2a9b67159 (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c462247e0
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c462247e0
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: 56add02db339bbce6a2c37d2a9b67159
+2026/04/22 13:30:53 SSEHub: unregistered connection e411958e60df861fed43b48fd76bdbd9 (total: 0)
+2026/04/22 13:30:53 Received kill signal.  Quitting Writer. stop 0x6e6b2aec3a40
+2026/04/22 13:30:53 Cleaning up writer...
+2026/04/22 13:30:53 Finished cleaning up writer:  0x6e6b2aec3a40
+2026/04/22 13:30:53 Closed MCP-GET-SSE SSE connection: e411958e60df861fed43b48fd76bdbd9
+2026/04/22 13:30:53 Starting MCP-GET-SSE SSE connection: ad9699566c0f3e6ac49b57bea896883b
+2026/04/22 13:30:53 SSEHub: registered connection ad9699566c0f3e6ac49b57bea896883b (total: 1)
+2026/04/22 13:30:53 SSEHub: unregistered connection ad9699566c0f3e6ac49b57bea896883b (total: 0)
 
 === Running scenario: prompts-get-with-args ===
+2026/04/22 13:30:53 Received kill signal.  Quitting Writer. stop 0x6e6b2afc1e30
+2026/04/22 13:30:53 Cleaning up writer...
+2026/04/22 13:30:53 Finished cleaning up writer:  0x6e6b2afc1e30
+2026/04/22 13:30:53 Closed MCP-GET-SSE SSE connection: ad9699566c0f3e6ac49b57bea896883b
 Running client scenario 'prompts-get-with-args' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: 78f1ec2cce814845621585c95c341462
-2026/04/21 12:54:17 SSEHub: registered connection 78f1ec2cce814845621585c95c341462 (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection 78f1ec2cce814845621585c95c341462 (total: 0)
+2026/04/22 13:30:53 Starting MCP-GET-SSE SSE connection: ef65d51699d3b1c04afdbb547a2decfd
+2026/04/22 13:30:53 SSEHub: registered connection ef65d51699d3b1c04afdbb547a2decfd (total: 1)
+2026/04/22 13:30:53 SSEHub: unregistered connection ef65d51699d3b1c04afdbb547a2decfd (total: 0)
+2026/04/22 13:30:53 Received kill signal.  Quitting Writer. stop 0x6e6b2aec3c70
+2026/04/22 13:30:53 Cleaning up writer...
+2026/04/22 13:30:53 Finished cleaning up writer:  0x6e6b2aec3c70
+2026/04/22 13:30:53 Closed MCP-GET-SSE SSE connection: ef65d51699d3b1c04afdbb547a2decfd
 
 === Running scenario: prompts-get-embedded-resource ===
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c463b79d0
 Running client scenario 'prompts-get-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c463b79d0
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: 78f1ec2cce814845621585c95c341462
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: 2345d03971f925b0e071bdd65a46806d
-2026/04/21 12:54:17 SSEHub: registered connection 2345d03971f925b0e071bdd65a46806d (total: 1)
+2026/04/22 13:30:53 Starting MCP-GET-SSE SSE connection: 21df0dea55359c35bce56ad9ac36467c
+2026/04/22 13:30:53 SSEHub: registered connection 21df0dea55359c35bce56ad9ac36467c (total: 1)
+2026/04/22 13:30:53 SSEHub: unregistered connection 21df0dea55359c35bce56ad9ac36467c (total: 0)
 
 === Running scenario: prompts-get-with-image ===
-2026/04/21 12:54:17 SSEHub: unregistered connection 2345d03971f925b0e071bdd65a46806d (total: 0)
+2026/04/22 13:30:53 Received kill signal.  Quitting Writer. stop 0x6e6b2b42f180
+2026/04/22 13:30:53 Cleaning up writer...
+2026/04/22 13:30:53 Finished cleaning up writer:  0x6e6b2b42f180
+2026/04/22 13:30:53 Closed MCP-GET-SSE SSE connection: 21df0dea55359c35bce56ad9ac36467c
 Running client scenario 'prompts-get-with-image' against server: http://localhost:18799/mcp
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c46158540
-2026/04/21 12:54:17 Cleaning up writer...
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c46158540
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: 2345d03971f925b0e071bdd65a46806d
-2026/04/21 12:54:17 Starting MCP-GET-SSE SSE connection: 8ec705bfc7e13f46834448bc0abdf621
-2026/04/21 12:54:17 SSEHub: registered connection 8ec705bfc7e13f46834448bc0abdf621 (total: 1)
-2026/04/21 12:54:17 SSEHub: unregistered connection 8ec705bfc7e13f46834448bc0abdf621 (total: 0)
-2026/04/21 12:54:17 Received kill signal.  Quitting Writer. stop 0x492c464aaa10
-2026/04/21 12:54:17 Cleaning up writer...
+2026/04/22 13:30:53 Starting MCP-GET-SSE SSE connection: 8dea414fefaeb01a2557c6baaeed8513
+2026/04/22 13:30:53 SSEHub: registered connection 8dea414fefaeb01a2557c6baaeed8513 (total: 1)
 
 === Running scenario: dns-rebinding-protection ===
-2026/04/21 12:54:17 Finished cleaning up writer:  0x492c464aaa10
-2026/04/21 12:54:17 Closed MCP-GET-SSE SSE connection: 8ec705bfc7e13f46834448bc0abdf621
+2026/04/22 13:30:53 SSEHub: unregistered connection 8dea414fefaeb01a2557c6baaeed8513 (total: 0)
 Running client scenario 'dns-rebinding-protection' against server: http://localhost:18799/mcp
+2026/04/22 13:30:53 Received kill signal.  Quitting Writer. stop 0x6e6b2b206000
+2026/04/22 13:30:53 Cleaning up writer...
+2026/04/22 13:30:53 Finished cleaning up writer:  0x6e6b2b206000
+2026/04/22 13:30:53 Closed MCP-GET-SSE SSE connection: 8dea414fefaeb01a2557c6baaeed8513
 
 
 === SUMMARY ===
@@ -343,4 +343,4 @@ Total: 40 passed, 0 failed
 [32mBaseline check passed: all failures are expected.[0m
 
 === CONFORMANCE TESTS PASSED ===
-Finished: Tue Apr 21 12:54:17 PDT 2026
+Finished: Wed Apr 22 13:30:53 PDT 2026

--- a/tests/reports/stage-e2e.log
+++ b/tests/reports/stage-e2e.log
@@ -1,6 +1,6 @@
 === Stage 6/10: e2e (make test-e2e) ===
-Started: Tue Apr 21 12:54:04 PDT 2026
+Started: Wed Apr 22 13:30:37 PDT 2026
 cd tests/e2e && go test ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/tests/e2e	2.626s
-ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.460s
-Finished: Tue Apr 21 12:54:07 PDT 2026
+ok  	github.com/panyam/mcpkit/tests/e2e	3.248s
+ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.784s
+Finished: Wed Apr 22 13:30:41 PDT 2026

--- a/tests/reports/stage-experimental.log
+++ b/tests/reports/stage-experimental.log
@@ -1,5 +1,5 @@
 === Stage 7/10: experimental (make test-experimental) ===
-Started: Tue Apr 21 12:54:07 PDT 2026
+Started: Wed Apr 22 13:30:41 PDT 2026
 cd experimental/telegram-events && go test ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/experimental/telegram-events	5.162s
-Finished: Tue Apr 21 12:54:13 PDT 2026
+ok  	github.com/panyam/mcpkit/experimental/telegram-events	6.119s
+Finished: Wed Apr 22 13:30:48 PDT 2026

--- a/tests/reports/stage-keycloak.log
+++ b/tests/reports/stage-keycloak.log
@@ -1,29 +1,50 @@
 === Stage 10/10: keycloak (make testkcl-auto) ===
-Started: Tue Apr 21 12:54:19 PDT 2026
+Started: Wed Apr 22 13:30:54 PDT 2026
+Starting Keycloak for interop tests...
+cc0576832fdab4445e4c8af335471a5784bca2061cea36cd7cd01c202d71aa92
+docker: Error response from daemon: failed to set up container networking: driver failed programming external connectivity on endpoint mcpkit-keycloak (1e67c9447cfff9807670b598b71c3595f6d6034a8033ab57c88f5f27dc2ae92a): Bind for 0.0.0.0:8180 failed: port is already allocated
+
+Run 'docker run --help' for more information
+Keycloak starting on port 8180... (realm import takes ~30s)
+Run 'make kcllogs' to watch startup, 'make testkcl' when ready
+Waiting for Keycloak realm...
 === RUN   TestKeycloak_MCPServer_ValidToken
---- PASS: TestKeycloak_MCPServer_ValidToken (0.03s)
+    interop_test.go:34: Keycloak realm mcpkit-test not ready (status 404)
+--- SKIP: TestKeycloak_MCPServer_ValidToken (0.02s)
 === RUN   TestKeycloak_MCPServer_TamperedToken
---- PASS: TestKeycloak_MCPServer_TamperedToken (0.01s)
+    interop_test.go:56: Keycloak realm mcpkit-test not ready (status 404)
+--- SKIP: TestKeycloak_MCPServer_TamperedToken (0.00s)
 === RUN   TestKeycloak_MCPServer_ScopeAllowed
---- PASS: TestKeycloak_MCPServer_ScopeAllowed (0.01s)
+    interop_test.go:79: Keycloak realm mcpkit-test not ready (status 404)
+--- SKIP: TestKeycloak_MCPServer_ScopeAllowed (0.00s)
 === RUN   TestKeycloak_MCPServer_ScopeDenied
---- PASS: TestKeycloak_MCPServer_ScopeDenied (0.01s)
+    interop_test.go:101: Keycloak realm mcpkit-test not ready (status 404)
+--- SKIP: TestKeycloak_MCPServer_ScopeDenied (0.00s)
 === RUN   TestKeycloak_MCPServer_PRM
---- PASS: TestKeycloak_MCPServer_PRM (0.01s)
+    interop_test.go:123: Keycloak realm mcpkit-test not ready (status 404)
+--- SKIP: TestKeycloak_MCPServer_PRM (0.00s)
 === RUN   TestKeycloak_MCPServer_WWWAuthenticate
---- PASS: TestKeycloak_MCPServer_WWWAuthenticate (0.01s)
+    interop_test.go:144: Keycloak realm mcpkit-test not ready (status 404)
+--- SKIP: TestKeycloak_MCPServer_WWWAuthenticate (0.00s)
 === RUN   TestKeycloak_MCPServer_PasswordGrant
---- PASS: TestKeycloak_MCPServer_PasswordGrant (0.03s)
+    interop_test.go:167: Keycloak realm mcpkit-test not ready (status 404)
+--- SKIP: TestKeycloak_MCPServer_PasswordGrant (0.01s)
 === RUN   TestKeycloak_PublicMethods_DiscoverWithoutAuth
---- PASS: TestKeycloak_PublicMethods_DiscoverWithoutAuth (0.01s)
+    public_methods_test.go:22: Keycloak realm mcpkit-test not ready (status 404)
+--- SKIP: TestKeycloak_PublicMethods_DiscoverWithoutAuth (0.00s)
 === RUN   TestKeycloak_PublicMethods_ToolCallRequiresAuth
---- PASS: TestKeycloak_PublicMethods_ToolCallRequiresAuth (0.01s)
+    public_methods_test.go:65: Keycloak realm mcpkit-test not ready (status 404)
+--- SKIP: TestKeycloak_PublicMethods_ToolCallRequiresAuth (0.00s)
 === RUN   TestKeycloak_SessionHijack_DifferentUserRejected
---- PASS: TestKeycloak_SessionHijack_DifferentUserRejected (0.05s)
+    session_hijack_test.go:54: Keycloak realm mcpkit-test not ready (status 404)
+--- SKIP: TestKeycloak_SessionHijack_DifferentUserRejected (0.00s)
 === RUN   TestKeycloak_SessionHijack_SameUserAllowed
---- PASS: TestKeycloak_SessionHijack_SameUserAllowed (0.03s)
+    session_hijack_test.go:85: Keycloak realm mcpkit-test not ready (status 404)
+--- SKIP: TestKeycloak_SessionHijack_SameUserAllowed (0.00s)
 === RUN   TestKeycloak_TokenRefresh_PasswordGrant
---- PASS: TestKeycloak_TokenRefresh_PasswordGrant (0.03s)
+    token_refresh_test.go:22: Keycloak realm mcpkit-test not ready (status 404)
+--- SKIP: TestKeycloak_TokenRefresh_PasswordGrant (0.00s)
 PASS
-ok  	github.com/panyam/mcpkit/tests/keycloak	0.508s
-Finished: Tue Apr 21 12:54:20 PDT 2026
+ok  	github.com/panyam/mcpkit/tests/keycloak	0.634s
+make[2]: *** No rule to make target `downkcl'.  Stop.
+Finished: Wed Apr 22 13:33:00 PDT 2026

--- a/tests/reports/stage-protogen.log
+++ b/tests/reports/stage-protogen.log
@@ -1,11 +1,11 @@
 === Stage 5/10: protogen (make test-protogen) ===
-Started: Tue Apr 21 12:54:01 PDT 2026
+Started: Wed Apr 22 13:30:31 PDT 2026
 cd experimental/ext/protogen && go test ./... -count=1 -timeout 30s && /Library/Developer/CommandLineTools/usr/bin/make test-e2e
 ?   	github.com/panyam/mcpkit/experimental/ext/protogen/cmd/protoc-gen-go-mcp	[no test files]
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/generator	0.219s
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/proto/mcp/v1	0.368s
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/runtime	0.514s
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/schema	0.673s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/generator	0.324s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/proto/mcp/v1	0.553s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/runtime	1.041s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/schema	0.801s
 ?   	github.com/panyam/mcpkit/experimental/ext/protogen/testutil	[no test files]
 go build -o bin/protoc-gen-go-mcp ./cmd/protoc-gen-go-mcp
 go install ./cmd/protoc-gen-go-mcp
@@ -14,6 +14,6 @@ cd ../../../examples/protogen/bookservice && rm -rf gen && buf generate && go te
 [33mWARN[0m	plugin "protoc-gen-go-mcp" does not support required features.
   Feature "proto3 optional" is required by 1 file(s):
     bookservice/v1/service.proto
-ok  	github.com/panyam/mcpkit/examples/protogen/bookservice	0.268s
+ok  	github.com/panyam/mcpkit/examples/protogen/bookservice	0.590s
 ==> e2e: passed
-Finished: Tue Apr 21 12:54:04 PDT 2026
+Finished: Wed Apr 22 13:30:37 PDT 2026

--- a/tests/reports/stage-race.log
+++ b/tests/reports/stage-race.log
@@ -1,9 +1,9 @@
 === Stage 2/10: race (make test-race) ===
-Started: Tue Apr 21 12:53:46 PDT 2026
+Started: Wed Apr 22 13:30:05 PDT 2026
 go test -race ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/client	8.554s
+ok  	github.com/panyam/mcpkit/client	9.567s
 ?   	github.com/panyam/mcpkit/cmd/testserver	[no test files]
-ok  	github.com/panyam/mcpkit/core	1.241s
-ok  	github.com/panyam/mcpkit/server	11.174s
-ok  	github.com/panyam/mcpkit/testutil	1.839s
-Finished: Tue Apr 21 12:53:58 PDT 2026
+ok  	github.com/panyam/mcpkit/core	1.600s
+ok  	github.com/panyam/mcpkit/server	11.578s
+ok  	github.com/panyam/mcpkit/testutil	1.637s
+Finished: Wed Apr 22 13:30:27 PDT 2026

--- a/tests/reports/stage-ui.log
+++ b/tests/reports/stage-ui.log
@@ -1,8 +1,8 @@
 === Stage 4/10: ui (make test-ui) ===
-Started: Tue Apr 21 12:53:59 PDT 2026
+Started: Wed Apr 22 13:30:28 PDT 2026
 cd ext/ui && /Library/Developer/CommandLineTools/usr/bin/make test
 go test ./... -count=1 -timeout 30s
-ok  	github.com/panyam/mcpkit/ext/ui	0.228s
+ok  	github.com/panyam/mcpkit/ext/ui	0.328s
 cd assets && pnpm install --frozen-lockfile --silent && pnpm test
 
 > @mcpkit/app-bridge@0.1.0 test /Users/dzshrh/newstack/mcpkit/main/ext/ui/assets
@@ -11,11 +11,11 @@ cd assets && pnpm install --frozen-lockfile --silent && pnpm test
 
  RUN  v3.2.4 /Users/dzshrh/newstack/mcpkit/main/ext/ui/assets
 
- ✓ mcp-app-bridge.test.ts (33 tests) 385ms
+ ✓ mcp-app-bridge.test.ts (33 tests) 388ms
 
  Test Files  1 passed (1)
       Tests  33 passed (33)
-   Start at  12:54:00
-   Duration  929ms (transform 55ms, setup 0ms, collect 21ms, tests 385ms, environment 272ms, prepare 102ms)
+   Start at  13:30:30
+   Duration  1.08s (transform 21ms, setup 0ms, collect 20ms, tests 388ms, environment 386ms, prepare 126ms)
 
-Finished: Tue Apr 21 12:54:01 PDT 2026
+Finished: Wed Apr 22 13:30:31 PDT 2026

--- a/tests/reports/stage-unit+coverage.log
+++ b/tests/reports/stage-unit+coverage.log
@@ -1,11 +1,11 @@
 === Stage 1/10: unit+coverage (make cover-html) ===
-Started: Tue Apr 21 12:53:35 PDT 2026
+Started: Wed Apr 22 13:29:53 PDT 2026
 go test -coverprofile=tests/reports/coverage.out ./... -count=1 -timeout 30s
-ok  	github.com/panyam/mcpkit/client	7.254s	coverage: 63.8% of statements
+ok  	github.com/panyam/mcpkit/client	8.421s	coverage: 63.8% of statements
 	github.com/panyam/mcpkit/cmd/testserver		coverage: 0.0% of statements
-ok  	github.com/panyam/mcpkit/core	0.384s	coverage: 51.0% of statements
-ok  	github.com/panyam/mcpkit/server	9.907s	coverage: 80.7% of statements
-ok  	github.com/panyam/mcpkit/testutil	0.744s	coverage: 69.4% of statements
+ok  	github.com/panyam/mcpkit/core	0.537s	coverage: 51.0% of statements
+ok  	github.com/panyam/mcpkit/server	10.102s	coverage: 80.9% of statements
+ok  	github.com/panyam/mcpkit/testutil	1.065s	coverage: 69.4% of statements
 go tool cover -html=tests/reports/coverage.out -o tests/reports/coverage.html
 Coverage report: tests/reports/coverage.html
-Finished: Tue Apr 21 12:53:46 PDT 2026
+Finished: Wed Apr 22 13:30:05 PDT 2026


### PR DESCRIPTION
## Summary

- Add `TaskCallbacks` struct for per-tool `GetTask`/`GetResult` overrides, enabling the external proxy pattern (e.g., wrapping AWS Step Functions or CI pipelines where the external system is the source of truth for task state)
- Matches TS SDK's `ToolTaskHandler` fix from the `tooltask-handlers` branch — their `getTask`/`getTaskResult` handlers were never invoked; we ensure ours are from the start
- Add `external_job` tool to both Go and TS reference servers demonstrating the pattern
- Add conformance scenarios 10-11 exercising the callback dispatch path (11/11 passing)
- Add detailed v2 plan (`docs/TASKS_V2_PLAN.md`) capturing SEP-2557 research, protocol diffs, 8 implementation phases, 16 conformance scenarios

## Changes

| File | What |
|------|------|
| `server/task_callbacks.go` | New: `TaskCallbacks` struct with `GetTask`/`GetResult` |
| `server/registration.go` | `TaskCallbacks` field on `Tool`, wired in `Register` |
| `server/dispatch.go` | `taskCallbacks` on internal `toolEntry` |
| `server/registry.go` | `SetToolCallbacks`/`ToolCallbacks` thread-safe accessors |
| `server/tasks_experimental.go` | `creatorToolForTask` map, callback dispatch in handlers |
| `server/task_callbacks_test.go` | 4 tests: override, result override, fallthrough, no-callbacks |
| `examples/tasks/main.go` | `external_job` tool with `TaskCallbacks` |
| `examples/tasks/ts-reference-server.mjs` | Same `external_job` tool |
| `examples/tasks/README.md` | Updated tools table and key files |
| `conformance/tasks/scenarios.test.ts` | Scenarios 10-11 |
| `conformance/tasks/README.md` | Updated scenario table |
| `docs/TASKS_V2_PLAN.md` | Detailed SEP-2557 v2 plan (8 phases) |

## Design

`TaskCallbacks` lives in `server/` (not `core/`) because:
- `core.ToolExecution` is a wire-format struct that gets serialized to JSON for `tools/list` — function fields break that
- Callback behavior is server-side; `core/` should only contain protocol types
- For v2 (SEP-2557), `TaskCallbacks` grows naturally with `OnCancel` and `OnInputResponse` fields

The `creatorToolForTask` map on `taskRuntime` tracks which tool created each task (taskID → tool name). When `tasks/get` or `tasks/result` arrives, the handler looks up the tool's callbacks via the registry. Mapping is cleaned up after `tasks/result` resolves (matching TS SDK behavior).

## Test plan

- [x] `TestTaskCallbacksGetTask` — custom GetTask callback invoked, returns override
- [x] `TestTaskCallbacksGetResult` — custom GetResult callback invoked
- [x] `TestTaskCallbacksFallthrough` — callback returns false, falls through to store
- [x] `TestTaskCallbacksNoCallbacks` — tools without callbacks work via pure store path
- [x] 11/11 conformance scenarios passing against Go server
- [x] All existing server tests pass (pre-existing flaky `TestStoreConcurrentAccess` is unrelated)

Closes #297