### PR TITLE
fix: keepalive tolerates method-not-found + initialize returns SSE

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ Sub-module commands: see `ext/ui/Makefile`, `experimental/ext/protogen/Makefile`
 - **Tasks side-channel**: `TaskElicit`/`TaskSample` send via the `tasks/result` handler's live connection, not the background goroutine's dead one. The handler proxies requests from a channel.
 - **POST SSE writer closure**: After `handlePostSSE` returns, the SSE writer is marked `closed`. Background goroutines that try to notify via the dead writer get silent no-ops instead of panics.
 - **Task cancel race**: After cancel, the background goroutine checks if the task is already terminal before setting status. `StoreTerminalResult` also guards against terminal→terminal transitions.
-- **Initialize returns JSON, not SSE**: Go server returns initialize as plain JSON; TS SDK returns SSE. Both spec-compliant. Curl helpers must handle both formats (#284).
+- **Initialize returns SSE or JSON**: Go server returns initialize as SSE when the client sends `Accept: text/event-stream` (matching TS SDK), or plain JSON otherwise. Curl helpers should send the appropriate Accept header.
 - **Conformance assertions — spec MUST vs MAY**: Don't assert specific error codes unless the spec mandates them. TTL is a client hint (server may ignore). `pollInterval` is server-only (not a client request param — TS SDK bug). Notifications are optional. Auth-context binding ≠ session isolation. Use `ENFORCE_ERROR_CODES` flag pattern for future-proofing.
 - **Flaky TestStoreConcurrentAccess**: Was caused by timestamp-based task IDs colliding when goroutines ran within the same nanosecond. Fixed with deterministic IDs (`fmt.Sprintf`).
 

--- a/client/client.go
+++ b/client/client.go
@@ -589,7 +589,7 @@ func (c *Client) startKeepalive() {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				_, err := c.rawCall("ping", nil)
+				resp, err := c.rawCall("ping", nil)
 				if err != nil {
 					failures++
 					if failures >= maxFails {
@@ -599,6 +599,10 @@ func (c *Client) startKeepalive() {
 						}
 						return
 					}
+				} else if resp != nil && resp.Error != nil && resp.Error.Code == core.ErrCodeMethodNotFound {
+					// Method-not-found proves the connection is alive — the server
+					// received the ping and responded. Per MCP spec, ping is optional.
+					failures = 0
 				} else {
 					failures = 0
 				}

--- a/server/content_type_test.go
+++ b/server/content_type_test.go
@@ -1,6 +1,7 @@
 package server_test
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -91,4 +92,67 @@ func TestGETRequestsNotAffectedByContentTypeCheck(t *testing.T) {
 	resp.Body.Close()
 	// Should not be 415 — GET doesn't require Content-Type
 	assert.NotEqual(t, 415, resp.StatusCode)
+}
+
+// TestInitializeReturnsSSEWhenAccepted verifies that when the client sends
+// Accept: text/event-stream, the initialize response is returned as an SSE
+// event (Content-Type: text/event-stream) matching TS SDK behavior (#284).
+func TestInitializeReturnsSSEWhenAccepted(t *testing.T) {
+	srv := testutil.NewTestServer()
+	handler := srv.Handler(server.WithStreamableHTTP(true), server.WithSSE(false))
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}`
+	req, _ := http.NewRequest("POST", ts.URL+"/mcp", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "text/event-stream, application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, "text/event-stream", resp.Header.Get("Content-Type"))
+	assert.NotEmpty(t, resp.Header.Get("Mcp-Session-Id"), "should have session ID header")
+
+	// Read the body — should be SSE format: "id: ...\nevent: message\ndata: {...}\n\n"
+	data, _ := io.ReadAll(resp.Body)
+	bodyStr := string(data)
+	assert.Contains(t, bodyStr, "event: message")
+	assert.Contains(t, bodyStr, "data: ")
+	assert.Contains(t, bodyStr, `"protocolVersion"`)
+}
+
+// TestInitializeReturnsJSONWhenNotAccepted verifies that when the client
+// sends Accept: application/json (no SSE), the initialize response is
+// returned as plain JSON (backwards compatible behavior).
+func TestInitializeReturnsJSONWhenNotAccepted(t *testing.T) {
+	srv := testutil.NewTestServer()
+	handler := srv.Handler(server.WithStreamableHTTP(true), server.WithSSE(false))
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}`
+	req, _ := http.NewRequest("POST", ts.URL+"/mcp", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+	assert.NotEmpty(t, resp.Header.Get("Mcp-Session-Id"))
+
+	// Body should be raw JSON, not SSE
+	data, _ := io.ReadAll(resp.Body)
+	bodyStr := string(data)
+	assert.NotContains(t, bodyStr, "event: message", "should not be SSE format")
+	assert.Contains(t, bodyStr, `"protocolVersion"`)
 }

--- a/server/keepalive.go
+++ b/server/keepalive.go
@@ -52,6 +52,13 @@ func (k *sessionKeepalive) run(ctx context.Context) {
 			cancel()
 
 			if err != nil {
+				// A method-not-found response proves the connection is alive —
+				// the client received the ping and responded. Per MCP spec,
+				// ping is optional; not implementing it is not a failure.
+				if IsMethodNotFound(err) {
+					failures = 0
+					continue
+				}
 				failures++
 				log.Printf("mcpkit: keepalive ping failed (%d/%d): %v", failures, k.maxFailures, err)
 				if k.onPingFail != nil {

--- a/server/keepalive_test.go
+++ b/server/keepalive_test.go
@@ -6,6 +6,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/panyam/mcpkit/core"
 )
 
 // TestSessionKeepaliveDetectsDeadClient verifies that the server-side
@@ -97,4 +99,60 @@ func TestSessionKeepaliveStopPreventsDeathCallback(t *testing.T) {
 	if deathCalled.Load() {
 		t.Error("onDeath should NOT be called after stop()")
 	}
+}
+
+// TestKeepaliveMethodNotFoundDoesNotKillSession verifies that a client
+// responding with method-not-found (-32601) to a ping request does NOT
+// count as a keepalive failure. Per MCP spec, ping is optional — a
+// method-not-found response proves the connection is alive.
+func TestKeepaliveMethodNotFoundDoesNotKillSession(t *testing.T) {
+	var deathCalled atomic.Bool
+
+	// requestFunc that always returns method-not-found (simulates client
+	// that doesn't implement ping).
+	methodNotFoundRequest := func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+		return nil, &ServerRequestError{
+			Code:    core.ErrCodeMethodNotFound,
+			Message: "Method not found",
+		}
+	}
+
+	ka := &sessionKeepalive{
+		interval:    30 * time.Millisecond,
+		maxFailures: 2, // low threshold — would trigger quickly with real failures
+		requestFunc: methodNotFoundRequest,
+		onDeath:     func() { deathCalled.Store(true) },
+	}
+	ka.start()
+	defer ka.stop()
+
+	// Run long enough for many ping cycles. None should count as failures.
+	time.Sleep(150 * time.Millisecond)
+
+	if deathCalled.Load() {
+		t.Error("onDeath should NOT be called when client returns method-not-found")
+	}
+}
+
+// TestIsMethodNotFound verifies the IsMethodNotFound helper correctly
+// identifies ServerRequestError with code -32601.
+func TestIsMethodNotFound(t *testing.T) {
+	t.Run("method not found", func(t *testing.T) {
+		err := &ServerRequestError{Code: core.ErrCodeMethodNotFound, Message: "not found"}
+		if !IsMethodNotFound(err) {
+			t.Error("expected IsMethodNotFound to return true")
+		}
+	})
+	t.Run("other error code", func(t *testing.T) {
+		err := &ServerRequestError{Code: core.ErrCodeInternal, Message: "internal"}
+		if IsMethodNotFound(err) {
+			t.Error("expected IsMethodNotFound to return false for non-method-not-found")
+		}
+	})
+	t.Run("non-ServerRequestError", func(t *testing.T) {
+		err := context.DeadlineExceeded
+		if IsMethodNotFound(err) {
+			t.Error("expected IsMethodNotFound to return false for non-ServerRequestError")
+		}
+	})
 }

--- a/server/request.go
+++ b/server/request.go
@@ -13,6 +13,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	core "github.com/panyam/mcpkit/core"
@@ -32,6 +33,28 @@ type pendingServerRequest struct {
 type serverResponse struct {
 	Result any
 	Error  *core.Error
+}
+
+// ServerRequestError is a typed error returned by sendServerRequest when the
+// client responds with a JSON-RPC error. It wraps the error code and message
+// so callers can inspect the code (e.g., to distinguish method-not-found from
+// transport failures).
+type ServerRequestError struct {
+	Code    int
+	Message string
+}
+
+func (e *ServerRequestError) Error() string {
+	return fmt.Sprintf("client error: [%d] %s", e.Code, e.Message)
+}
+
+// IsMethodNotFound reports whether the error is a JSON-RPC method-not-found (-32601).
+func IsMethodNotFound(err error) bool {
+	var sre *ServerRequestError
+	if errors.As(err, &sre) {
+		return sre.Code == core.ErrCodeMethodNotFound
+	}
+	return false
 }
 
 // marshalRequest builds a JSON-RPC 2.0 request with a string ID.
@@ -80,7 +103,7 @@ func sendServerRequest(
 		return nil, ctx.Err()
 	case resp := <-pr.ch:
 		if resp.Error != nil {
-			return nil, fmt.Errorf("client error: [%d] %s", resp.Error.Code, resp.Error.Message)
+			return nil, &ServerRequestError{Code: resp.Error.Code, Message: resp.Error.Message}
 		}
 		// Result may be typed (from NewResponse) or json.RawMessage (from client).
 		if raw, ok := resp.Result.(json.RawMessage); ok {

--- a/server/streamable_transport.go
+++ b/server/streamable_transport.go
@@ -446,6 +446,25 @@ func (t *streamableTransport) handleInitialize(w http.ResponseWriter, r *http.Re
 	t.sessions.Store(sessionID, entry)
 
 	w.Header().Set(mcpSessionIDHeader, sessionID)
+
+	// Return SSE when the client accepts it (matching TS SDK behavior).
+	// Fall back to JSON when the client only accepts JSON.
+	_, acceptsSSE := gohttp.ParseAcceptTypes(r.Header.Get("Accept"))
+	if acceptsSSE {
+		if flusher, ok := w.(http.Flusher); ok {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.Header().Set("Cache-Control", "no-cache")
+			w.Header().Set("Connection", "keep-alive")
+			w.Header().Set("X-Accel-Buffering", "no")
+			raw, _ := marshalJSON(resp)
+			emitSSEEvent(dispatcher.eventIDs, t.config.eventStore, sessionID, raw, func(id string, data json.RawMessage) {
+				fmt.Fprintf(w, "id: %s\nevent: message\ndata: %s\n\n", id, data)
+				flusher.Flush()
+			})
+			return
+		}
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	raw, _ := marshalJSON(resp)
 	w.Write(raw)
@@ -814,12 +833,6 @@ func shouldStreamSSE(accept string, req *core.Request) bool {
 
 	_, acceptsSSE := gohttp.ParseAcceptTypes(accept)
 	if !acceptsSSE {
-		return false
-	}
-
-	// Never stream SSE for initialize — the handshake must return JSON
-	// so the client can parse the session ID and server capabilities.
-	if req.Method == "initialize" {
 		return false
 	}
 

--- a/tests/reports/report.html
+++ b/tests/reports/report.html
@@ -19,7 +19,7 @@ pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto; 
 code.cmd { background: #f0f0f0; padding: 2px 6px; border-radius: 3px; font-size: 13px; }
 </style></head><body>
 <h1>MCPKit Test Report</h1>
-<div class='meta'>Branch: <strong>feat/elicitation-url-mode-sep1036</strong> | Commit: <code>6fbfef2</code> | Date: 2026-04-22 20:36:54</div>
+<div class='meta'>Branch: <strong>fix/keepalive-method-not-found-and-init-sse</strong> | Commit: <code>7ddf16d</code> | Date: 2026-04-22 22:29:09</div>
 <table><tr><th>Stage</th><th>Result</th><th>Re-run</th></tr>
 <tr><td><a href='#log-unit+coverage'>unit+coverage</a></td><td class='pass'>PASS</td><td><code class='cmd'>make cover-html</code></td></tr>
 <tr><td><a href='#log-race'>race</a></td><td class='pass'>PASS</td><td><code class='cmd'>make test-race</code></td></tr>
@@ -36,41 +36,41 @@ code.cmd { background: #f0f0f0; padding: 2px 6px; border-radius: 3px; font-size:
 <h2>Stage Logs</h2>
 <details id='log-unit+coverage'><summary class='pass'>unit+coverage — PASS</summary><pre>
 === Stage 1/10: unit+coverage (make cover-html) ===
-Started: Wed Apr 22 20:33:51 PDT 2026
+Started: Wed Apr 22 22:26:07 PDT 2026
 go test -coverprofile=tests/reports/coverage.out ./... -count=1 -timeout 30s
-ok  	github.com/panyam/mcpkit/client	9.169s	coverage: 63.4% of statements
+ok  	github.com/panyam/mcpkit/client	8.073s	coverage: 62.9% of statements
 	github.com/panyam/mcpkit/cmd/testserver		coverage: 0.0% of statements
-ok  	github.com/panyam/mcpkit/core	0.558s	coverage: 50.0% of statements
-ok  	github.com/panyam/mcpkit/server	10.543s	coverage: 80.9% of statements
-ok  	github.com/panyam/mcpkit/testutil	0.753s	coverage: 69.4% of statements
+ok  	github.com/panyam/mcpkit/core	0.398s	coverage: 50.0% of statements
+ok  	github.com/panyam/mcpkit/server	10.537s	coverage: 81.1% of statements
+ok  	github.com/panyam/mcpkit/testutil	0.502s	coverage: 69.4% of statements
 go tool cover -html=tests/reports/coverage.out -o tests/reports/coverage.html
 Coverage report: tests/reports/coverage.html
-Finished: Wed Apr 22 20:34:04 PDT 2026
+Finished: Wed Apr 22 22:26:20 PDT 2026
 </pre></details>
 <details id='log-race'><summary class='pass'>race — PASS</summary><pre>
 === Stage 2/10: race (make test-race) ===
-Started: Wed Apr 22 20:34:04 PDT 2026
+Started: Wed Apr 22 22:26:20 PDT 2026
 go test -race ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/client	9.005s
+ok  	github.com/panyam/mcpkit/client	10.278s
 ?   	github.com/panyam/mcpkit/cmd/testserver	[no test files]
-ok  	github.com/panyam/mcpkit/core	1.930s
-ok  	github.com/panyam/mcpkit/server	12.043s
-ok  	github.com/panyam/mcpkit/testutil	1.542s
-Finished: Wed Apr 22 20:34:20 PDT 2026
+ok  	github.com/panyam/mcpkit/core	1.373s
+ok  	github.com/panyam/mcpkit/server	11.474s
+ok  	github.com/panyam/mcpkit/testutil	1.859s
+Finished: Wed Apr 22 22:26:35 PDT 2026
 </pre></details>
 <details id='log-auth'><summary class='pass'>auth — PASS</summary><pre>
 === Stage 3/10: auth (make test-auth) ===
-Started: Wed Apr 22 20:34:20 PDT 2026
+Started: Wed Apr 22 22:26:35 PDT 2026
 cd ext/auth &amp;&amp; go test ./... -count=1 -timeout 30s
-ok  	github.com/panyam/mcpkit/ext/auth	0.659s
-Finished: Wed Apr 22 20:34:21 PDT 2026
+ok  	github.com/panyam/mcpkit/ext/auth	0.359s
+Finished: Wed Apr 22 22:26:36 PDT 2026
 </pre></details>
 <details id='log-ui'><summary class='pass'>ui — PASS</summary><pre>
 === Stage 4/10: ui (make test-ui) ===
-Started: Wed Apr 22 20:34:21 PDT 2026
+Started: Wed Apr 22 22:26:36 PDT 2026
 cd ext/ui &amp;&amp; /Library/Developer/CommandLineTools/usr/bin/make test
 go test ./... -count=1 -timeout 30s
-ok  	github.com/panyam/mcpkit/ext/ui	0.586s
+ok  	github.com/panyam/mcpkit/ext/ui	0.347s
 cd assets &amp;&amp; pnpm install --frozen-lockfile --silent &amp;&amp; pnpm test
 
 &gt; @mcpkit/app-bridge@0.1.0 test /Users/dzshrh/newstack/mcpkit/pocs/ext/ui/assets
@@ -79,24 +79,24 @@ cd assets &amp;&amp; pnpm install --frozen-lockfile --silent &amp;&amp; pnpm tes
 
  RUN  v3.2.4 /Users/dzshrh/newstack/mcpkit/pocs/ext/ui/assets
 
- ✓ mcp-app-bridge.test.ts (33 tests) 403ms
+ ✓ mcp-app-bridge.test.ts (33 tests) 383ms
 
  Test Files  1 passed (1)
       Tests  33 passed (33)
-   Start at  20:34:24
-   Duration  1.22s (transform 31ms, setup 0ms, collect 28ms, tests 403ms, environment 476ms, prepare 129ms)
+   Start at  22:26:38
+   Duration  1.11s (transform 31ms, setup 0ms, collect 28ms, tests 383ms, environment 384ms, prepare 134ms)
 
-Finished: Wed Apr 22 20:34:25 PDT 2026
+Finished: Wed Apr 22 22:26:39 PDT 2026
 </pre></details>
 <details id='log-protogen'><summary class='pass'>protogen — PASS</summary><pre>
 === Stage 5/10: protogen (make test-protogen) ===
-Started: Wed Apr 22 20:34:25 PDT 2026
+Started: Wed Apr 22 22:26:39 PDT 2026
 cd experimental/ext/protogen &amp;&amp; go test ./... -count=1 -timeout 30s &amp;&amp; /Library/Developer/CommandLineTools/usr/bin/make test-e2e
 ?   	github.com/panyam/mcpkit/experimental/ext/protogen/cmd/protoc-gen-go-mcp	[no test files]
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/generator	0.898s
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/proto/mcp/v1	1.159s
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/runtime	0.661s
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/schema	1.470s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/generator	0.966s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/proto/mcp/v1	0.357s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/runtime	1.255s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/schema	0.665s
 ?   	github.com/panyam/mcpkit/experimental/ext/protogen/testutil	[no test files]
 go build -o bin/protoc-gen-go-mcp ./cmd/protoc-gen-go-mcp
 go install ./cmd/protoc-gen-go-mcp
@@ -105,32 +105,32 @@ cd ../../../examples/protogen/bookservice &amp;&amp; rm -rf gen &amp;&amp; buf g
 [33mWARN[0m	plugin "protoc-gen-go-mcp" does not support required features.
   Feature "proto3 optional" is required by 1 file(s):
     bookservice/v1/service.proto
-ok  	github.com/panyam/mcpkit/examples/protogen/bookservice	0.708s
+ok  	github.com/panyam/mcpkit/examples/protogen/bookservice	0.808s
 ==&gt; e2e: passed
-Finished: Wed Apr 22 20:34:31 PDT 2026
+Finished: Wed Apr 22 22:26:44 PDT 2026
 </pre></details>
 <details id='log-e2e'><summary class='pass'>e2e — PASS</summary><pre>
 === Stage 6/10: e2e (make test-e2e) ===
-Started: Wed Apr 22 20:34:31 PDT 2026
+Started: Wed Apr 22 22:26:44 PDT 2026
 cd tests/e2e &amp;&amp; go test ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/tests/e2e	3.918s
-ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.965s
-Finished: Wed Apr 22 20:34:36 PDT 2026
+ok  	github.com/panyam/mcpkit/tests/e2e	4.771s
+ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.682s
+Finished: Wed Apr 22 22:26:50 PDT 2026
 </pre></details>
 <details id='log-experimental'><summary class='pass'>experimental — PASS</summary><pre>
 === Stage 7/10: experimental (make test-experimental) ===
-Started: Wed Apr 22 20:34:36 PDT 2026
+Started: Wed Apr 22 22:26:50 PDT 2026
 cd experimental/telegram-events &amp;&amp; go test ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/experimental/telegram-events	5.528s
-Finished: Wed Apr 22 20:34:42 PDT 2026
+ok  	github.com/panyam/mcpkit/experimental/telegram-events	5.562s
+Finished: Wed Apr 22 22:26:56 PDT 2026
 </pre></details>
 <details id='log-conformance'><summary class='pass'>conformance — PASS</summary><pre>
 === Stage 8/10: conformance (make testconf) ===
-Started: Wed Apr 22 20:34:42 PDT 2026
+Started: Wed Apr 22 22:26:56 PDT 2026
 bash scripts/conformance-test.sh
 Killing stale process on port 18799...
 === Starting test server on :18799 (Streamable HTTP) ===
-Waiting for server....2026/04/22 20:34:44 MCP test server listening on :18799 (Streamable HTTP at /mcp)
+Waiting for server.....2026/04/22 22:26:59 MCP test server listening on :18799 (Streamable HTTP at /mcp)
  ready
 
 === Running MCP conformance suite ===
@@ -141,295 +141,295 @@ Running active suite (30 scenarios) against http://localhost:18799/mcp
 
 === Running scenario: server-initialize ===
 Running client scenario 'server-initialize' against server: http://localhost:18799/mcp
-2026/04/22 20:34:46 Starting MCP-GET-SSE SSE connection: cd73f46a3a098825ecb00cee65306e60
-2026/04/22 20:34:46 SSEHub: registered connection cd73f46a3a098825ecb00cee65306e60 (total: 1)
-2026/04/22 20:34:46 SSEHub: unregistered connection cd73f46a3a098825ecb00cee65306e60 (total: 0)
-2026/04/22 20:34:46 Received kill signal.  Quitting Writer. stop 0x1b2ab39ca150
-2026/04/22 20:34:46 Cleaning up writer...
-2026/04/22 20:34:46 Finished cleaning up writer:  0x1b2ab39ca150
-2026/04/22 20:34:46 Closed MCP-GET-SSE SSE connection: cd73f46a3a098825ecb00cee65306e60
+2026/04/22 22:27:01 Starting MCP-GET-SSE SSE connection: f16538d4b15aa5fa75a8c28960a52f8c
+2026/04/22 22:27:01 SSEHub: registered connection f16538d4b15aa5fa75a8c28960a52f8c (total: 1)
+2026/04/22 22:27:01 SSEHub: unregistered connection f16538d4b15aa5fa75a8c28960a52f8c (total: 0)
+2026/04/22 22:27:01 Received kill signal.  Quitting Writer. stop 0x4fcda634310
+2026/04/22 22:27:01 Cleaning up writer...
+2026/04/22 22:27:01 Finished cleaning up writer:  0x4fcda634310
+2026/04/22 22:27:01 Closed MCP-GET-SSE SSE connection: f16538d4b15aa5fa75a8c28960a52f8c
 
 === Running scenario: logging-set-level ===
 Running client scenario 'logging-set-level' against server: http://localhost:18799/mcp
-2026/04/22 20:34:46 Starting MCP-GET-SSE SSE connection: 21c3dcdf315049d8058fc543bc0c7583
-2026/04/22 20:34:46 SSEHub: registered connection 21c3dcdf315049d8058fc543bc0c7583 (total: 1)
-2026/04/22 20:34:46 SSEHub: unregistered connection 21c3dcdf315049d8058fc543bc0c7583 (total: 0)
-2026/04/22 20:34:46 Received kill signal.  Quitting Writer. stop 0x1b2ab39ca380
-2026/04/22 20:34:46 Cleaning up writer...
-2026/04/22 20:34:46 Finished cleaning up writer:  0x1b2ab39ca380
-2026/04/22 20:34:46 Closed MCP-GET-SSE SSE connection: 21c3dcdf315049d8058fc543bc0c7583
+2026/04/22 22:27:01 Starting MCP-GET-SSE SSE connection: 0cff83f51f69f191fd917156430e8b21
+2026/04/22 22:27:01 SSEHub: registered connection 0cff83f51f69f191fd917156430e8b21 (total: 1)
+2026/04/22 22:27:01 SSEHub: unregistered connection 0cff83f51f69f191fd917156430e8b21 (total: 0)
+2026/04/22 22:27:01 Received kill signal.  Quitting Writer. stop 0x4fcda5b01c0
+2026/04/22 22:27:01 Cleaning up writer...
+2026/04/22 22:27:01 Finished cleaning up writer:  0x4fcda5b01c0
+2026/04/22 22:27:01 Closed MCP-GET-SSE SSE connection: 0cff83f51f69f191fd917156430e8b21
 
 === Running scenario: ping ===
 Running client scenario 'ping' against server: http://localhost:18799/mcp
-2026/04/22 20:34:46 Starting MCP-GET-SSE SSE connection: 29586e6ac9b05564b00b9554b0268e1b
-2026/04/22 20:34:46 SSEHub: registered connection 29586e6ac9b05564b00b9554b0268e1b (total: 1)
-2026/04/22 20:34:46 SSEHub: unregistered connection 29586e6ac9b05564b00b9554b0268e1b (total: 0)
-2026/04/22 20:34:46 Received kill signal.  Quitting Writer. stop 0x1b2ab3d32310
-2026/04/22 20:34:46 Cleaning up writer...
-2026/04/22 20:34:46 Finished cleaning up writer:  0x1b2ab3d32310
-2026/04/22 20:34:46 Closed MCP-GET-SSE SSE connection: 29586e6ac9b05564b00b9554b0268e1b
+2026/04/22 22:27:01 Starting MCP-GET-SSE SSE connection: c10c4d47d8f6ba70aadb87014c038b5a
+2026/04/22 22:27:01 SSEHub: registered connection c10c4d47d8f6ba70aadb87014c038b5a (total: 1)
+2026/04/22 22:27:01 SSEHub: unregistered connection c10c4d47d8f6ba70aadb87014c038b5a (total: 0)
+2026/04/22 22:27:01 Received kill signal.  Quitting Writer. stop 0x4fcda6341c0
+2026/04/22 22:27:01 Cleaning up writer...
+2026/04/22 22:27:01 Finished cleaning up writer:  0x4fcda6341c0
+2026/04/22 22:27:01 Closed MCP-GET-SSE SSE connection: c10c4d47d8f6ba70aadb87014c038b5a
 
 === Running scenario: completion-complete ===
 Running client scenario 'completion-complete' against server: http://localhost:18799/mcp
-2026/04/22 20:34:46 Starting MCP-GET-SSE SSE connection: 07fc923040a39f91e49ae5487499c995
-2026/04/22 20:34:46 SSEHub: registered connection 07fc923040a39f91e49ae5487499c995 (total: 1)
-2026/04/22 20:34:46 SSEHub: unregistered connection 07fc923040a39f91e49ae5487499c995 (total: 0)
-2026/04/22 20:34:46 Received kill signal.  Quitting Writer. stop 0x1b2ab39ca5b0
-2026/04/22 20:34:46 Cleaning up writer...
-2026/04/22 20:34:46 Finished cleaning up writer:  0x1b2ab39ca5b0
-2026/04/22 20:34:46 Closed MCP-GET-SSE SSE connection: 07fc923040a39f91e49ae5487499c995
+2026/04/22 22:27:01 Starting MCP-GET-SSE SSE connection: e517b3eab5b262856eaf80eb81c2070e
+2026/04/22 22:27:01 SSEHub: registered connection e517b3eab5b262856eaf80eb81c2070e (total: 1)
+2026/04/22 22:27:01 SSEHub: unregistered connection e517b3eab5b262856eaf80eb81c2070e (total: 0)
+2026/04/22 22:27:01 Received kill signal.  Quitting Writer. stop 0x4fcda6343f0
+2026/04/22 22:27:01 Cleaning up writer...
+2026/04/22 22:27:01 Finished cleaning up writer:  0x4fcda6343f0
+2026/04/22 22:27:01 Closed MCP-GET-SSE SSE connection: e517b3eab5b262856eaf80eb81c2070e
 
 === Running scenario: tools-list ===
 Running client scenario 'tools-list' against server: http://localhost:18799/mcp
-2026/04/22 20:34:46 Starting MCP-GET-SSE SSE connection: 77801cb67c3da2d8b080495374266f14
-2026/04/22 20:34:46 SSEHub: registered connection 77801cb67c3da2d8b080495374266f14 (total: 1)
-2026/04/22 20:34:46 SSEHub: unregistered connection 77801cb67c3da2d8b080495374266f14 (total: 0)
+2026/04/22 22:27:01 Starting MCP-GET-SSE SSE connection: 067266fd4bed596ac4f8018415992c2a
+2026/04/22 22:27:01 SSEHub: registered connection 067266fd4bed596ac4f8018415992c2a (total: 1)
+2026/04/22 22:27:01 SSEHub: unregistered connection 067266fd4bed596ac4f8018415992c2a (total: 0)
+2026/04/22 22:27:01 Received kill signal.  Quitting Writer. stop 0x4fcda6a0460
+2026/04/22 22:27:01 Cleaning up writer...
 
 === Running scenario: tools-call-simple-text ===
-2026/04/22 20:34:46 Received kill signal.  Quitting Writer. stop 0x1b2ab3d321c0
-2026/04/22 20:34:46 Cleaning up writer...
+2026/04/22 22:27:01 Finished cleaning up writer:  0x4fcda6a0460
 Running client scenario 'tools-call-simple-text' against server: http://localhost:18799/mcp
-2026/04/22 20:34:46 Finished cleaning up writer:  0x1b2ab3d321c0
-2026/04/22 20:34:46 Closed MCP-GET-SSE SSE connection: 77801cb67c3da2d8b080495374266f14
-2026/04/22 20:34:46 Starting MCP-GET-SSE SSE connection: baff50b946d4eeaa92ae32988b1c8c97
-2026/04/22 20:34:46 SSEHub: registered connection baff50b946d4eeaa92ae32988b1c8c97 (total: 1)
-2026/04/22 20:34:46 SSEHub: unregistered connection baff50b946d4eeaa92ae32988b1c8c97 (total: 0)
-2026/04/22 20:34:46 Received kill signal.  Quitting Writer. stop 0x1b2ab39ca1c0
-2026/04/22 20:34:46 Cleaning up writer...
-2026/04/22 20:34:46 Finished cleaning up writer:  0x1b2ab39ca1c0
-2026/04/22 20:34:46 Closed MCP-GET-SSE SSE connection: baff50b946d4eeaa92ae32988b1c8c97
+2026/04/22 22:27:01 Closed MCP-GET-SSE SSE connection: 067266fd4bed596ac4f8018415992c2a
+2026/04/22 22:27:01 Starting MCP-GET-SSE SSE connection: f6a4f0ab160623d41a4766d7775365c3
+2026/04/22 22:27:01 SSEHub: registered connection f6a4f0ab160623d41a4766d7775365c3 (total: 1)
+2026/04/22 22:27:01 SSEHub: unregistered connection f6a4f0ab160623d41a4766d7775365c3 (total: 0)
+2026/04/22 22:27:01 Received kill signal.  Quitting Writer. stop 0x4fcda5b03f0
+2026/04/22 22:27:01 Cleaning up writer...
+2026/04/22 22:27:01 Finished cleaning up writer:  0x4fcda5b03f0
+2026/04/22 22:27:01 Closed MCP-GET-SSE SSE connection: f6a4f0ab160623d41a4766d7775365c3
 
 === Running scenario: tools-call-image ===
 Running client scenario 'tools-call-image' against server: http://localhost:18799/mcp
-2026/04/22 20:34:46 Starting MCP-GET-SSE SSE connection: 864999cd67d910e44df29ed6f1819b89
-2026/04/22 20:34:46 SSEHub: registered connection 864999cd67d910e44df29ed6f1819b89 (total: 1)
-2026/04/22 20:34:46 SSEHub: unregistered connection 864999cd67d910e44df29ed6f1819b89 (total: 0)
-2026/04/22 20:34:46 Received kill signal.  Quitting Writer. stop 0x1b2ab3d32540
-2026/04/22 20:34:46 Cleaning up writer...
-2026/04/22 20:34:46 Finished cleaning up writer:  0x1b2ab3d32540
-2026/04/22 20:34:46 Closed MCP-GET-SSE SSE connection: 864999cd67d910e44df29ed6f1819b89
+2026/04/22 22:27:01 Starting MCP-GET-SSE SSE connection: 0f183d5b45ade31fc8c088bf030f0868
+2026/04/22 22:27:01 SSEHub: registered connection 0f183d5b45ade31fc8c088bf030f0868 (total: 1)
 
 === Running scenario: tools-call-audio ===
+2026/04/22 22:27:01 SSEHub: unregistered connection 0f183d5b45ade31fc8c088bf030f0868 (total: 0)
 Running client scenario 'tools-call-audio' against server: http://localhost:18799/mcp
-2026/04/22 20:34:46 Starting MCP-GET-SSE SSE connection: 11827d7450c5699736ee30bd4be9afdc
-2026/04/22 20:34:46 SSEHub: registered connection 11827d7450c5699736ee30bd4be9afdc (total: 1)
-2026/04/22 20:34:46 SSEHub: unregistered connection 11827d7450c5699736ee30bd4be9afdc (total: 0)
-2026/04/22 20:34:46 Received kill signal.  Quitting Writer. stop 0x1b2ab3d9c540
-2026/04/22 20:34:46 Cleaning up writer...
-2026/04/22 20:34:46 Finished cleaning up writer:  0x1b2ab3d9c540
-2026/04/22 20:34:46 Closed MCP-GET-SSE SSE connection: 11827d7450c5699736ee30bd4be9afdc
+2026/04/22 22:27:01 Received kill signal.  Quitting Writer. stop 0x4fcda634770
+2026/04/22 22:27:01 Cleaning up writer...
+2026/04/22 22:27:01 Finished cleaning up writer:  0x4fcda634770
+2026/04/22 22:27:01 Closed MCP-GET-SSE SSE connection: 0f183d5b45ade31fc8c088bf030f0868
+2026/04/22 22:27:01 Starting MCP-GET-SSE SSE connection: 28d9d3431f16e5aaed478bbc4e492b73
+2026/04/22 22:27:01 SSEHub: registered connection 28d9d3431f16e5aaed478bbc4e492b73 (total: 1)
+2026/04/22 22:27:01 SSEHub: unregistered connection 28d9d3431f16e5aaed478bbc4e492b73 (total: 0)
+2026/04/22 22:27:01 Received kill signal.  Quitting Writer. stop 0x4fcda6349a0
+2026/04/22 22:27:01 Cleaning up writer...
+2026/04/22 22:27:01 Finished cleaning up writer:  0x4fcda6349a0
+2026/04/22 22:27:01 Closed MCP-GET-SSE SSE connection: 28d9d3431f16e5aaed478bbc4e492b73
 
 === Running scenario: tools-call-embedded-resource ===
 Running client scenario 'tools-call-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/22 20:34:46 Starting MCP-GET-SSE SSE connection: 847a27d45c25a85ece98daa423ac5588
-2026/04/22 20:34:46 SSEHub: registered connection 847a27d45c25a85ece98daa423ac5588 (total: 1)
-2026/04/22 20:34:46 SSEHub: unregistered connection 847a27d45c25a85ece98daa423ac5588 (total: 0)
-2026/04/22 20:34:46 Received kill signal.  Quitting Writer. stop 0x1b2ab39ca690
-2026/04/22 20:34:46 Cleaning up writer...
-2026/04/22 20:34:46 Finished cleaning up writer:  0x1b2ab39ca690
-2026/04/22 20:34:46 Closed MCP-GET-SSE SSE connection: 847a27d45c25a85ece98daa423ac5588
+2026/04/22 22:27:01 Starting MCP-GET-SSE SSE connection: c83dba23ec0e9afb0c8a9b98bc75e3a2
+2026/04/22 22:27:01 SSEHub: registered connection c83dba23ec0e9afb0c8a9b98bc75e3a2 (total: 1)
 
 === Running scenario: tools-call-mixed-content ===
+2026/04/22 22:27:01 SSEHub: unregistered connection c83dba23ec0e9afb0c8a9b98bc75e3a2 (total: 0)
+2026/04/22 22:27:01 Received kill signal.  Quitting Writer. stop 0x4fcda6a0850
 Running client scenario 'tools-call-mixed-content' against server: http://localhost:18799/mcp
-2026/04/22 20:34:46 Starting MCP-GET-SSE SSE connection: d8f7944a26d314a3d48b3a78e7999613
-2026/04/22 20:34:46 SSEHub: registered connection d8f7944a26d314a3d48b3a78e7999613 (total: 1)
-2026/04/22 20:34:46 SSEHub: unregistered connection d8f7944a26d314a3d48b3a78e7999613 (total: 0)
+2026/04/22 22:27:01 Cleaning up writer...
+2026/04/22 22:27:01 Finished cleaning up writer:  0x4fcda6a0850
+2026/04/22 22:27:01 Closed MCP-GET-SSE SSE connection: c83dba23ec0e9afb0c8a9b98bc75e3a2
+2026/04/22 22:27:01 Starting MCP-GET-SSE SSE connection: ba679e591c4b8f8fd2a7874839482c4a
+2026/04/22 22:27:01 SSEHub: registered connection ba679e591c4b8f8fd2a7874839482c4a (total: 1)
 
 === Running scenario: tools-call-with-logging ===
-2026/04/22 20:34:46 Received kill signal.  Quitting Writer. stop 0x1b2ab38e6c40
-2026/04/22 20:34:46 Cleaning up writer...
 Running client scenario 'tools-call-with-logging' against server: http://localhost:18799/mcp
-2026/04/22 20:34:46 Finished cleaning up writer:  0x1b2ab38e6c40
-2026/04/22 20:34:46 Closed MCP-GET-SSE SSE connection: d8f7944a26d314a3d48b3a78e7999613
-2026/04/22 20:34:46 Starting MCP-GET-SSE SSE connection: 64b570c7c1fb316f8026ab25824eb082
-2026/04/22 20:34:46 SSEHub: registered connection 64b570c7c1fb316f8026ab25824eb082 (total: 1)
+2026/04/22 22:27:01 SSEHub: unregistered connection ba679e591c4b8f8fd2a7874839482c4a (total: 0)
+2026/04/22 22:27:01 Received kill signal.  Quitting Writer. stop 0x4fcda6a0af0
+2026/04/22 22:27:01 Cleaning up writer...
+2026/04/22 22:27:01 Finished cleaning up writer:  0x4fcda6a0af0
+2026/04/22 22:27:01 Closed MCP-GET-SSE SSE connection: ba679e591c4b8f8fd2a7874839482c4a
+2026/04/22 22:27:01 Starting MCP-GET-SSE SSE connection: 6b2d802fa5d2a716cc5070734ec6a0a7
+2026/04/22 22:27:01 SSEHub: registered connection 6b2d802fa5d2a716cc5070734ec6a0a7 (total: 1)
+2026/04/22 22:27:02 SSEHub: unregistered connection 6b2d802fa5d2a716cc5070734ec6a0a7 (total: 0)
 
 === Running scenario: tools-call-error ===
-2026/04/22 20:34:47 SSEHub: unregistered connection 64b570c7c1fb316f8026ab25824eb082 (total: 0)
+2026/04/22 22:27:02 Received kill signal.  Quitting Writer. stop 0x4fcda6a0d90
+2026/04/22 22:27:02 Cleaning up writer...
+2026/04/22 22:27:02 Finished cleaning up writer:  0x4fcda6a0d90
+2026/04/22 22:27:02 Closed MCP-GET-SSE SSE connection: 6b2d802fa5d2a716cc5070734ec6a0a7
 Running client scenario 'tools-call-error' against server: http://localhost:18799/mcp
-2026/04/22 20:34:47 Received kill signal.  Quitting Writer. stop 0x1b2ab39ca8c0
-2026/04/22 20:34:47 Cleaning up writer...
-2026/04/22 20:34:47 Finished cleaning up writer:  0x1b2ab39ca8c0
-2026/04/22 20:34:47 Closed MCP-GET-SSE SSE connection: 64b570c7c1fb316f8026ab25824eb082
-2026/04/22 20:34:47 Starting MCP-GET-SSE SSE connection: fdffc79d69b51814d9834d7942df27f5
-2026/04/22 20:34:47 SSEHub: registered connection fdffc79d69b51814d9834d7942df27f5 (total: 1)
-2026/04/22 20:34:47 SSEHub: unregistered connection fdffc79d69b51814d9834d7942df27f5 (total: 0)
-2026/04/22 20:34:47 Received kill signal.  Quitting Writer. stop 0x1b2ab38e7030
-2026/04/22 20:34:47 Cleaning up writer...
-2026/04/22 20:34:47 Finished cleaning up writer:  0x1b2ab38e7030
-2026/04/22 20:34:47 Closed MCP-GET-SSE SSE connection: fdffc79d69b51814d9834d7942df27f5
+2026/04/22 22:27:02 Starting MCP-GET-SSE SSE connection: fc4d9eefbae045824b77d3a44735cdc0
+2026/04/22 22:27:02 SSEHub: registered connection fc4d9eefbae045824b77d3a44735cdc0 (total: 1)
+2026/04/22 22:27:02 SSEHub: unregistered connection fc4d9eefbae045824b77d3a44735cdc0 (total: 0)
+2026/04/22 22:27:02 Received kill signal.  Quitting Writer. stop 0x4fcda634d90
+2026/04/22 22:27:02 Cleaning up writer...
 
 === Running scenario: tools-call-with-progress ===
+2026/04/22 22:27:02 Finished cleaning up writer:  0x4fcda634d90
+2026/04/22 22:27:02 Closed MCP-GET-SSE SSE connection: fc4d9eefbae045824b77d3a44735cdc0
 Running client scenario 'tools-call-with-progress' against server: http://localhost:18799/mcp
-2026/04/22 20:34:47 Starting MCP-GET-SSE SSE connection: cca1791e2c7d9cc70923f9fa09496693
-2026/04/22 20:34:47 SSEHub: registered connection cca1791e2c7d9cc70923f9fa09496693 (total: 1)
-2026/04/22 20:34:47 SSEHub: unregistered connection cca1791e2c7d9cc70923f9fa09496693 (total: 0)
-2026/04/22 20:34:47 Received kill signal.  Quitting Writer. stop 0x1b2ab39cab60
-2026/04/22 20:34:47 Cleaning up writer...
-2026/04/22 20:34:47 Finished cleaning up writer:  0x1b2ab39cab60
-2026/04/22 20:34:47 Closed MCP-GET-SSE SSE connection: cca1791e2c7d9cc70923f9fa09496693
+2026/04/22 22:27:02 Starting MCP-GET-SSE SSE connection: ea55463172e2e9c87e41cb77c12f280c
+2026/04/22 22:27:02 SSEHub: registered connection ea55463172e2e9c87e41cb77c12f280c (total: 1)
+2026/04/22 22:27:02 SSEHub: unregistered connection ea55463172e2e9c87e41cb77c12f280c (total: 0)
 
 === Running scenario: tools-call-sampling ===
+2026/04/22 22:27:02 Received kill signal.  Quitting Writer. stop 0x4fcda6a1110
+2026/04/22 22:27:02 Cleaning up writer...
 Running client scenario 'tools-call-sampling' against server: http://localhost:18799/mcp
-2026/04/22 20:34:47 Starting MCP-GET-SSE SSE connection: 5a83acc9d7bf4a2cb9d1bccb28d5cc57
-2026/04/22 20:34:47 SSEHub: registered connection 5a83acc9d7bf4a2cb9d1bccb28d5cc57 (total: 1)
-2026/04/22 20:34:47 SSEHub: unregistered connection 5a83acc9d7bf4a2cb9d1bccb28d5cc57 (total: 0)
-2026/04/22 20:34:47 Received kill signal.  Quitting Writer. stop 0x1b2ab3d32850
-2026/04/22 20:34:47 Cleaning up writer...
-2026/04/22 20:34:47 Finished cleaning up writer:  0x1b2ab3d32850
-2026/04/22 20:34:47 Closed MCP-GET-SSE SSE connection: 5a83acc9d7bf4a2cb9d1bccb28d5cc57
+2026/04/22 22:27:02 Finished cleaning up writer:  0x4fcda6a1110
+2026/04/22 22:27:02 Closed MCP-GET-SSE SSE connection: ea55463172e2e9c87e41cb77c12f280c
+2026/04/22 22:27:02 Starting MCP-GET-SSE SSE connection: 1410f6f24ab20930727d3664848b2cce
+2026/04/22 22:27:02 SSEHub: registered connection 1410f6f24ab20930727d3664848b2cce (total: 1)
+2026/04/22 22:27:02 SSEHub: unregistered connection 1410f6f24ab20930727d3664848b2cce (total: 0)
+2026/04/22 22:27:02 Received kill signal.  Quitting Writer. stop 0x4fcda6a1490
+2026/04/22 22:27:02 Cleaning up writer...
 
 === Running scenario: tools-call-elicitation ===
+2026/04/22 22:27:02 Finished cleaning up writer:  0x4fcda6a1490
+2026/04/22 22:27:02 Closed MCP-GET-SSE SSE connection: 1410f6f24ab20930727d3664848b2cce
 Running client scenario 'tools-call-elicitation' against server: http://localhost:18799/mcp
-2026/04/22 20:34:47 Starting MCP-GET-SSE SSE connection: b992b0a5f562241486cc6c7dd273821f
-2026/04/22 20:34:47 SSEHub: registered connection b992b0a5f562241486cc6c7dd273821f (total: 1)
+2026/04/22 22:27:02 Starting MCP-GET-SSE SSE connection: 4c962b1cf9045b6bdcffd79a4e07f8af
+2026/04/22 22:27:02 SSEHub: registered connection 4c962b1cf9045b6bdcffd79a4e07f8af (total: 1)
+2026/04/22 22:27:02 SSEHub: unregistered connection 4c962b1cf9045b6bdcffd79a4e07f8af (total: 0)
+2026/04/22 22:27:02 Received kill signal.  Quitting Writer. stop 0x4fcda6a1880
+2026/04/22 22:27:02 Cleaning up writer...
+2026/04/22 22:27:02 Finished cleaning up writer:  0x4fcda6a1880
+2026/04/22 22:27:02 Closed MCP-GET-SSE SSE connection: 4c962b1cf9045b6bdcffd79a4e07f8af
 
 === Running scenario: elicitation-sep1034-defaults ===
-2026/04/22 20:34:47 SSEHub: unregistered connection b992b0a5f562241486cc6c7dd273821f (total: 0)
-2026/04/22 20:34:47 Received kill signal.  Quitting Writer. stop 0x1b2ab39cb030
-2026/04/22 20:34:47 Cleaning up writer...
-2026/04/22 20:34:47 Finished cleaning up writer:  0x1b2ab39cb030
-2026/04/22 20:34:47 Closed MCP-GET-SSE SSE connection: b992b0a5f562241486cc6c7dd273821f
 Running client scenario 'elicitation-sep1034-defaults' against server: http://localhost:18799/mcp
-2026/04/22 20:34:47 Starting MCP-GET-SSE SSE connection: e46c5494206fd307e5876e100221cc0d
-2026/04/22 20:34:47 SSEHub: registered connection e46c5494206fd307e5876e100221cc0d (total: 1)
-2026/04/22 20:34:47 SSEHub: unregistered connection e46c5494206fd307e5876e100221cc0d (total: 0)
+2026/04/22 22:27:02 Starting MCP-GET-SSE SSE connection: ea6b074d9dc20d6fed2af966d2c2bf73
+2026/04/22 22:27:02 SSEHub: registered connection ea6b074d9dc20d6fed2af966d2c2bf73 (total: 1)
+2026/04/22 22:27:02 SSEHub: unregistered connection ea6b074d9dc20d6fed2af966d2c2bf73 (total: 0)
+2026/04/22 22:27:02 Received kill signal.  Quitting Writer. stop 0x4fcda5b0850
+2026/04/22 22:27:02 Cleaning up writer...
+2026/04/22 22:27:02 Finished cleaning up writer:  0x4fcda5b0850
+2026/04/22 22:27:02 Closed MCP-GET-SSE SSE connection: ea6b074d9dc20d6fed2af966d2c2bf73
 
 === Running scenario: server-sse-multiple-streams ===
-2026/04/22 20:34:47 Received kill signal.  Quitting Writer. stop 0x1b2ab38e7340
-2026/04/22 20:34:47 Cleaning up writer...
 Running client scenario 'server-sse-multiple-streams' against server: http://localhost:18799/mcp
-2026/04/22 20:34:47 Finished cleaning up writer:  0x1b2ab38e7340
-2026/04/22 20:34:47 Closed MCP-GET-SSE SSE connection: e46c5494206fd307e5876e100221cc0d
-2026/04/22 20:34:47 Starting MCP-GET-SSE SSE connection: a3742c8470c8acc93e24d75c51d8e8f4
-2026/04/22 20:34:47 SSEHub: registered connection a3742c8470c8acc93e24d75c51d8e8f4 (total: 1)
+2026/04/22 22:27:02 Starting MCP-GET-SSE SSE connection: ea1635f60fa7286031ff08139fc2cd9d
+2026/04/22 22:27:02 SSEHub: registered connection ea1635f60fa7286031ff08139fc2cd9d (total: 1)
+2026/04/22 22:27:02 SSEHub: unregistered connection ea1635f60fa7286031ff08139fc2cd9d (total: 0)
 
 === Running scenario: elicitation-sep1330-enums ===
+2026/04/22 22:27:02 Received kill signal.  Quitting Writer. stop 0x4fcda5b0af0
 Running client scenario 'elicitation-sep1330-enums' against server: http://localhost:18799/mcp
-2026/04/22 20:34:47 SSEHub: unregistered connection a3742c8470c8acc93e24d75c51d8e8f4 (total: 0)
-2026/04/22 20:34:47 Received kill signal.  Quitting Writer. stop 0x1b2ab3d9cb60
-2026/04/22 20:34:47 Cleaning up writer...
-2026/04/22 20:34:47 Finished cleaning up writer:  0x1b2ab3d9cb60
-2026/04/22 20:34:47 Closed MCP-GET-SSE SSE connection: a3742c8470c8acc93e24d75c51d8e8f4
-2026/04/22 20:34:47 Starting MCP-GET-SSE SSE connection: e1914f5149abd701d22d0ee84449a774
-2026/04/22 20:34:47 SSEHub: registered connection e1914f5149abd701d22d0ee84449a774 (total: 1)
-2026/04/22 20:34:47 SSEHub: unregistered connection e1914f5149abd701d22d0ee84449a774 (total: 0)
-2026/04/22 20:34:47 Received kill signal.  Quitting Writer. stop 0x1b2ab38e7810
-2026/04/22 20:34:47 Cleaning up writer...
-2026/04/22 20:34:47 Finished cleaning up writer:  0x1b2ab38e7810
-2026/04/22 20:34:47 Closed MCP-GET-SSE SSE connection: e1914f5149abd701d22d0ee84449a774
+2026/04/22 22:27:02 Cleaning up writer...
+2026/04/22 22:27:02 Finished cleaning up writer:  0x4fcda5b0af0
+2026/04/22 22:27:02 Closed MCP-GET-SSE SSE connection: ea1635f60fa7286031ff08139fc2cd9d
+2026/04/22 22:27:02 Starting MCP-GET-SSE SSE connection: 5de549592e3c0662342e869bc7880935
+2026/04/22 22:27:02 SSEHub: registered connection 5de549592e3c0662342e869bc7880935 (total: 1)
+2026/04/22 22:27:02 SSEHub: unregistered connection 5de549592e3c0662342e869bc7880935 (total: 0)
+2026/04/22 22:27:02 Received kill signal.  Quitting Writer. stop 0x4fcda70e230
+2026/04/22 22:27:02 Cleaning up writer...
+2026/04/22 22:27:02 Finished cleaning up writer:  0x4fcda70e230
+2026/04/22 22:27:02 Closed MCP-GET-SSE SSE connection: 5de549592e3c0662342e869bc7880935
 
 === Running scenario: resources-list ===
 Running client scenario 'resources-list' against server: http://localhost:18799/mcp
-2026/04/22 20:34:47 Starting MCP-GET-SSE SSE connection: ac1da82df1541b95bd6cb8ed12768540
-2026/04/22 20:34:47 SSEHub: registered connection ac1da82df1541b95bd6cb8ed12768540 (total: 1)
-2026/04/22 20:34:47 SSEHub: unregistered connection ac1da82df1541b95bd6cb8ed12768540 (total: 0)
-2026/04/22 20:34:47 Received kill signal.  Quitting Writer. stop 0x1b2ab3d9ce00
-2026/04/22 20:34:47 Cleaning up writer...
-2026/04/22 20:34:47 Finished cleaning up writer:  0x1b2ab3d9ce00
-2026/04/22 20:34:47 Closed MCP-GET-SSE SSE connection: ac1da82df1541b95bd6cb8ed12768540
+2026/04/22 22:27:02 Starting MCP-GET-SSE SSE connection: ba44d1b6a87c23b196e5ebba1f337c12
+2026/04/22 22:27:02 SSEHub: registered connection ba44d1b6a87c23b196e5ebba1f337c12 (total: 1)
 
 === Running scenario: resources-read-text ===
+2026/04/22 22:27:02 SSEHub: unregistered connection ba44d1b6a87c23b196e5ebba1f337c12 (total: 0)
 Running client scenario 'resources-read-text' against server: http://localhost:18799/mcp
-2026/04/22 20:34:47 Starting MCP-GET-SSE SSE connection: 4f58d4f9ed36487037f42b5f1534b93c
-2026/04/22 20:34:47 SSEHub: registered connection 4f58d4f9ed36487037f42b5f1534b93c (total: 1)
+2026/04/22 22:27:02 Received kill signal.  Quitting Writer. stop 0x4fcda70e460
+2026/04/22 22:27:02 Cleaning up writer...
+2026/04/22 22:27:02 Finished cleaning up writer:  0x4fcda70e460
+2026/04/22 22:27:02 Closed MCP-GET-SSE SSE connection: ba44d1b6a87c23b196e5ebba1f337c12
+2026/04/22 22:27:02 Starting MCP-GET-SSE SSE connection: 6bf895baf08af0598ea3b1f8a67b3709
+2026/04/22 22:27:02 SSEHub: registered connection 6bf895baf08af0598ea3b1f8a67b3709 (total: 1)
+2026/04/22 22:27:02 SSEHub: unregistered connection 6bf895baf08af0598ea3b1f8a67b3709 (total: 0)
+2026/04/22 22:27:02 Received kill signal.  Quitting Writer. stop 0x4fcda5b0e00
+2026/04/22 22:27:02 Cleaning up writer...
+2026/04/22 22:27:02 Finished cleaning up writer:  0x4fcda5b0e00
+2026/04/22 22:27:02 Closed MCP-GET-SSE SSE connection: 6bf895baf08af0598ea3b1f8a67b3709
 
 === Running scenario: resources-read-binary ===
 Running client scenario 'resources-read-binary' against server: http://localhost:18799/mcp
-2026/04/22 20:34:47 SSEHub: unregistered connection 4f58d4f9ed36487037f42b5f1534b93c (total: 0)
-2026/04/22 20:34:47 Received kill signal.  Quitting Writer. stop 0x1b2ab38e7ab0
-2026/04/22 20:34:47 Cleaning up writer...
-2026/04/22 20:34:47 Finished cleaning up writer:  0x1b2ab38e7ab0
-2026/04/22 20:34:47 Closed MCP-GET-SSE SSE connection: 4f58d4f9ed36487037f42b5f1534b93c
-2026/04/22 20:34:47 Starting MCP-GET-SSE SSE connection: e55d3478aa3238c808e827533d1c6b59
-2026/04/22 20:34:47 SSEHub: registered connection e55d3478aa3238c808e827533d1c6b59 (total: 1)
-2026/04/22 20:34:47 SSEHub: unregistered connection e55d3478aa3238c808e827533d1c6b59 (total: 0)
-2026/04/22 20:34:47 Received kill signal.  Quitting Writer. stop 0x1b2ab3d32f50
-2026/04/22 20:34:47 Cleaning up writer...
-2026/04/22 20:34:47 Finished cleaning up writer:  0x1b2ab3d32f50
-2026/04/22 20:34:47 Closed MCP-GET-SSE SSE connection: e55d3478aa3238c808e827533d1c6b59
+2026/04/22 22:27:02 Starting MCP-GET-SSE SSE connection: ef61aef36a9b797478e092ba7fdd2a00
+2026/04/22 22:27:02 SSEHub: registered connection ef61aef36a9b797478e092ba7fdd2a00 (total: 1)
+2026/04/22 22:27:02 SSEHub: unregistered connection ef61aef36a9b797478e092ba7fdd2a00 (total: 0)
 
 === Running scenario: resources-templates-read ===
+2026/04/22 22:27:02 Received kill signal.  Quitting Writer. stop 0x4fcda70e770
+2026/04/22 22:27:02 Cleaning up writer...
 Running client scenario 'resources-templates-read' against server: http://localhost:18799/mcp
-2026/04/22 20:34:47 Starting MCP-GET-SSE SSE connection: d6eab4bc209982adba5299fb652a36ae
-2026/04/22 20:34:47 SSEHub: registered connection d6eab4bc209982adba5299fb652a36ae (total: 1)
-2026/04/22 20:34:47 SSEHub: unregistered connection d6eab4bc209982adba5299fb652a36ae (total: 0)
-2026/04/22 20:34:47 Received kill signal.  Quitting Writer. stop 0x1b2ab39cb2d0
-2026/04/22 20:34:47 Cleaning up writer...
-2026/04/22 20:34:47 Finished cleaning up writer:  0x1b2ab39cb2d0
-2026/04/22 20:34:47 Closed MCP-GET-SSE SSE connection: d6eab4bc209982adba5299fb652a36ae
+2026/04/22 22:27:02 Finished cleaning up writer:  0x4fcda70e770
+2026/04/22 22:27:02 Closed MCP-GET-SSE SSE connection: ef61aef36a9b797478e092ba7fdd2a00
+2026/04/22 22:27:02 Starting MCP-GET-SSE SSE connection: d9e1f1b2c1c88ed953178c59295fb70d
+2026/04/22 22:27:02 SSEHub: registered connection d9e1f1b2c1c88ed953178c59295fb70d (total: 1)
+2026/04/22 22:27:02 SSEHub: unregistered connection d9e1f1b2c1c88ed953178c59295fb70d (total: 0)
+2026/04/22 22:27:02 Received kill signal.  Quitting Writer. stop 0x4fcda5b1030
+2026/04/22 22:27:02 Cleaning up writer...
+2026/04/22 22:27:02 Finished cleaning up writer:  0x4fcda5b1030
+2026/04/22 22:27:02 Closed MCP-GET-SSE SSE connection: d9e1f1b2c1c88ed953178c59295fb70d
 
 === Running scenario: resources-subscribe ===
 Running client scenario 'resources-subscribe' against server: http://localhost:18799/mcp
-2026/04/22 20:34:47 Starting MCP-GET-SSE SSE connection: d80512738699879ae9d5894131a904b3
-2026/04/22 20:34:47 SSEHub: registered connection d80512738699879ae9d5894131a904b3 (total: 1)
-2026/04/22 20:34:47 SSEHub: unregistered connection d80512738699879ae9d5894131a904b3 (total: 0)
-2026/04/22 20:34:47 Received kill signal.  Quitting Writer. stop 0x1b2ab3d33260
-2026/04/22 20:34:47 Cleaning up writer...
-2026/04/22 20:34:47 Finished cleaning up writer:  0x1b2ab3d33260
-2026/04/22 20:34:47 Closed MCP-GET-SSE SSE connection: d80512738699879ae9d5894131a904b3
+2026/04/22 22:27:02 Starting MCP-GET-SSE SSE connection: 2a05bd481a9f69da179a1b5fb0efd5d9
+2026/04/22 22:27:02 SSEHub: registered connection 2a05bd481a9f69da179a1b5fb0efd5d9 (total: 1)
 
 === Running scenario: resources-unsubscribe ===
+2026/04/22 22:27:02 SSEHub: unregistered connection 2a05bd481a9f69da179a1b5fb0efd5d9 (total: 0)
 Running client scenario 'resources-unsubscribe' against server: http://localhost:18799/mcp
-2026/04/22 20:34:47 Starting MCP-GET-SSE SSE connection: 9817d0ca4d07a03cf3e45c61912465b2
-2026/04/22 20:34:47 SSEHub: registered connection 9817d0ca4d07a03cf3e45c61912465b2 (total: 1)
-2026/04/22 20:34:47 SSEHub: unregistered connection 9817d0ca4d07a03cf3e45c61912465b2 (total: 0)
-2026/04/22 20:34:47 Received kill signal.  Quitting Writer. stop 0x1b2ab3d33500
-2026/04/22 20:34:47 Cleaning up writer...
-2026/04/22 20:34:47 Finished cleaning up writer:  0x1b2ab3d33500
-2026/04/22 20:34:47 Closed MCP-GET-SSE SSE connection: 9817d0ca4d07a03cf3e45c61912465b2
+2026/04/22 22:27:02 Received kill signal.  Quitting Writer. stop 0x4fcda70eaf0
+2026/04/22 22:27:02 Cleaning up writer...
+2026/04/22 22:27:02 Finished cleaning up writer:  0x4fcda70eaf0
+2026/04/22 22:27:02 Closed MCP-GET-SSE SSE connection: 2a05bd481a9f69da179a1b5fb0efd5d9
+2026/04/22 22:27:02 Starting MCP-GET-SSE SSE connection: 0cb9a9d809156b7c34b7a3aebe4195c2
+2026/04/22 22:27:02 SSEHub: registered connection 0cb9a9d809156b7c34b7a3aebe4195c2 (total: 1)
 
 === Running scenario: prompts-list ===
+2026/04/22 22:27:02 SSEHub: unregistered connection 0cb9a9d809156b7c34b7a3aebe4195c2 (total: 0)
 Running client scenario 'prompts-list' against server: http://localhost:18799/mcp
-2026/04/22 20:34:47 Starting MCP-GET-SSE SSE connection: b5bf6b0035b92f9c2577d3718d8ba5fa
-2026/04/22 20:34:47 SSEHub: registered connection b5bf6b0035b92f9c2577d3718d8ba5fa (total: 1)
-2026/04/22 20:34:47 SSEHub: unregistered connection b5bf6b0035b92f9c2577d3718d8ba5fa (total: 0)
-2026/04/22 20:34:47 Received kill signal.  Quitting Writer. stop 0x1b2ab3d9d180
-2026/04/22 20:34:47 Cleaning up writer...
-2026/04/22 20:34:47 Finished cleaning up writer:  0x1b2ab3d9d180
-2026/04/22 20:34:47 Closed MCP-GET-SSE SSE connection: b5bf6b0035b92f9c2577d3718d8ba5fa
+2026/04/22 22:27:02 Received kill signal.  Quitting Writer. stop 0x4fcda635880
+2026/04/22 22:27:02 Cleaning up writer...
+2026/04/22 22:27:02 Finished cleaning up writer:  0x4fcda635880
+2026/04/22 22:27:02 Closed MCP-GET-SSE SSE connection: 0cb9a9d809156b7c34b7a3aebe4195c2
+2026/04/22 22:27:02 Starting MCP-GET-SSE SSE connection: b05282fabc1b8ee945a9a91541bcf64f
+2026/04/22 22:27:02 SSEHub: registered connection b05282fabc1b8ee945a9a91541bcf64f (total: 1)
+2026/04/22 22:27:02 SSEHub: unregistered connection b05282fabc1b8ee945a9a91541bcf64f (total: 0)
+2026/04/22 22:27:02 Received kill signal.  Quitting Writer. stop 0x4fcda70ed20
+2026/04/22 22:27:02 Cleaning up writer...
+2026/04/22 22:27:02 Finished cleaning up writer:  0x4fcda70ed20
+2026/04/22 22:27:02 Closed MCP-GET-SSE SSE connection: b05282fabc1b8ee945a9a91541bcf64f
 
 === Running scenario: prompts-get-simple ===
 Running client scenario 'prompts-get-simple' against server: http://localhost:18799/mcp
-2026/04/22 20:34:47 Starting MCP-GET-SSE SSE connection: 889fcb61bfbf9eb28c4ed3cef6446f55
-2026/04/22 20:34:47 SSEHub: registered connection 889fcb61bfbf9eb28c4ed3cef6446f55 (total: 1)
-2026/04/22 20:34:47 SSEHub: unregistered connection 889fcb61bfbf9eb28c4ed3cef6446f55 (total: 0)
-2026/04/22 20:34:47 Received kill signal.  Quitting Writer. stop 0x1b2ab3d33810
-2026/04/22 20:34:47 Cleaning up writer...
+2026/04/22 22:27:02 Starting MCP-GET-SSE SSE connection: 4f6979bd70d3caa1ad9c92f6a9ad2696
+2026/04/22 22:27:02 SSEHub: registered connection 4f6979bd70d3caa1ad9c92f6a9ad2696 (total: 1)
+2026/04/22 22:27:02 SSEHub: unregistered connection 4f6979bd70d3caa1ad9c92f6a9ad2696 (total: 0)
+2026/04/22 22:27:02 Received kill signal.  Quitting Writer. stop 0x4fcda635c00
+2026/04/22 22:27:02 Cleaning up writer...
+2026/04/22 22:27:02 Finished cleaning up writer:  0x4fcda635c00
 
 === Running scenario: prompts-get-with-args ===
-2026/04/22 20:34:47 Finished cleaning up writer:  0x1b2ab3d33810
-2026/04/22 20:34:47 Closed MCP-GET-SSE SSE connection: 889fcb61bfbf9eb28c4ed3cef6446f55
+2026/04/22 22:27:02 Closed MCP-GET-SSE SSE connection: 4f6979bd70d3caa1ad9c92f6a9ad2696
 Running client scenario 'prompts-get-with-args' against server: http://localhost:18799/mcp
-2026/04/22 20:34:47 Starting MCP-GET-SSE SSE connection: ccaa5189ccdab1658465649c4ae0816f
-2026/04/22 20:34:47 SSEHub: registered connection ccaa5189ccdab1658465649c4ae0816f (total: 1)
-2026/04/22 20:34:47 SSEHub: unregistered connection ccaa5189ccdab1658465649c4ae0816f (total: 0)
-2026/04/22 20:34:47 Received kill signal.  Quitting Writer. stop 0x1b2ab3d33ab0
-2026/04/22 20:34:47 Cleaning up writer...
-2026/04/22 20:34:47 Finished cleaning up writer:  0x1b2ab3d33ab0
+2026/04/22 22:27:02 Starting MCP-GET-SSE SSE connection: ef46bd4892acf60d8e6e97df0e5580bd
+2026/04/22 22:27:02 SSEHub: registered connection ef46bd4892acf60d8e6e97df0e5580bd (total: 1)
+2026/04/22 22:27:02 SSEHub: unregistered connection ef46bd4892acf60d8e6e97df0e5580bd (total: 0)
+2026/04/22 22:27:02 Received kill signal.  Quitting Writer. stop 0x4fcda5b1340
+2026/04/22 22:27:02 Cleaning up writer...
 
 === Running scenario: prompts-get-embedded-resource ===
-2026/04/22 20:34:47 Closed MCP-GET-SSE SSE connection: ccaa5189ccdab1658465649c4ae0816f
+2026/04/22 22:27:02 Finished cleaning up writer:  0x4fcda5b1340
+2026/04/22 22:27:02 Closed MCP-GET-SSE SSE connection: ef46bd4892acf60d8e6e97df0e5580bd
 Running client scenario 'prompts-get-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/22 20:34:47 Starting MCP-GET-SSE SSE connection: 3fe5c3318c9cf118644d0d5a21fe629b
-2026/04/22 20:34:47 SSEHub: registered connection 3fe5c3318c9cf118644d0d5a21fe629b (total: 1)
-2026/04/22 20:34:47 SSEHub: unregistered connection 3fe5c3318c9cf118644d0d5a21fe629b (total: 0)
-2026/04/22 20:34:47 Received kill signal.  Quitting Writer. stop 0x1b2ab39cb650
-2026/04/22 20:34:47 Cleaning up writer...
-2026/04/22 20:34:47 Finished cleaning up writer:  0x1b2ab39cb650
-2026/04/22 20:34:47 Closed MCP-GET-SSE SSE connection: 3fe5c3318c9cf118644d0d5a21fe629b
+2026/04/22 22:27:02 Starting MCP-GET-SSE SSE connection: 5582c80e07e4a0f421b22863b41dbef4
+2026/04/22 22:27:02 SSEHub: registered connection 5582c80e07e4a0f421b22863b41dbef4 (total: 1)
+2026/04/22 22:27:02 SSEHub: unregistered connection 5582c80e07e4a0f421b22863b41dbef4 (total: 0)
 
 === Running scenario: prompts-get-with-image ===
+2026/04/22 22:27:02 Received kill signal.  Quitting Writer. stop 0x4fcda6a1ce0
 Running client scenario 'prompts-get-with-image' against server: http://localhost:18799/mcp
-2026/04/22 20:34:47 Starting MCP-GET-SSE SSE connection: 6b1014062b926dea5d3241ef9e9dbff2
-2026/04/22 20:34:47 SSEHub: registered connection 6b1014062b926dea5d3241ef9e9dbff2 (total: 1)
-2026/04/22 20:34:47 SSEHub: unregistered connection 6b1014062b926dea5d3241ef9e9dbff2 (total: 0)
-2026/04/22 20:34:47 Received kill signal.  Quitting Writer. stop 0x1b2ab3d9d490
-2026/04/22 20:34:47 Cleaning up writer...
-2026/04/22 20:34:47 Finished cleaning up writer:  0x1b2ab3d9d490
+2026/04/22 22:27:02 Cleaning up writer...
+2026/04/22 22:27:02 Finished cleaning up writer:  0x4fcda6a1ce0
+2026/04/22 22:27:02 Closed MCP-GET-SSE SSE connection: 5582c80e07e4a0f421b22863b41dbef4
+2026/04/22 22:27:02 Starting MCP-GET-SSE SSE connection: 0cfa1834a837f76cd8c4525858269cd6
+2026/04/22 22:27:02 SSEHub: registered connection 0cfa1834a837f76cd8c4525858269cd6 (total: 1)
+2026/04/22 22:27:02 SSEHub: unregistered connection 0cfa1834a837f76cd8c4525858269cd6 (total: 0)
+2026/04/22 22:27:02 Received kill signal.  Quitting Writer. stop 0x4fcda6a1f10
+2026/04/22 22:27:02 Cleaning up writer...
 
 === Running scenario: dns-rebinding-protection ===
-2026/04/22 20:34:47 Closed MCP-GET-SSE SSE connection: 6b1014062b926dea5d3241ef9e9dbff2
+2026/04/22 22:27:02 Finished cleaning up writer:  0x4fcda6a1f10
+2026/04/22 22:27:02 Closed MCP-GET-SSE SSE connection: 0cfa1834a837f76cd8c4525858269cd6
 Running client scenario 'dns-rebinding-protection' against server: http://localhost:18799/mcp
 
 
@@ -470,11 +470,11 @@ Total: 40 passed, 0 failed
 [32mBaseline check passed: all failures are expected.[0m
 
 === CONFORMANCE TESTS PASSED ===
-Finished: Wed Apr 22 20:34:47 PDT 2026
+Finished: Wed Apr 22 22:27:02 PDT 2026
 </pre></details>
 <details id='log-auth-conformance'><summary class='pass'>auth-conformance — PASS</summary><pre>
 === Stage 9/10: auth-conformance (make testconfauth) ===
-Started: Wed Apr 22 20:34:47 PDT 2026
+Started: Wed Apr 22 22:27:02 PDT 2026
 bash scripts/conformance-auth-test.sh
 Building testclient...
 === Running MCP Auth conformance suite ===
@@ -496,22 +496,22 @@ Starting scenario: auth/token-endpoint-auth-basic
 Starting scenario: auth/token-endpoint-auth-post
 Starting scenario: auth/token-endpoint-auth-none
 Starting scenario: auth/pre-registration
-Executing client: ./bin/testclient http://localhost:62980/mcp
-Executing client: ./bin/testclient http://localhost:62981/mcp
-Executing client: ./bin/testclient http://localhost:62982/mcp
-Executing client: ./bin/testclient http://localhost:62983/mcp
-Executing client: ./bin/testclient http://localhost:62984/mcp
-Executing client: ./bin/testclient http://localhost:62985/mcp
-Executing client: ./bin/testclient http://localhost:62986/mcp
-Executing client: ./bin/testclient http://localhost:62987/mcp
-Executing client: ./bin/testclient http://localhost:62988/mcp
-Executing client: ./bin/testclient http://localhost:62989/mcp
-Executing client: ./bin/testclient http://localhost:62990/mcp
-Executing client: ./bin/testclient http://localhost:62991/mcp
-Executing client: ./bin/testclient http://localhost:62992/mcp
-Executing client: ./bin/testclient http://localhost:62993/mcp
+Executing client: ./bin/testclient http://localhost:50727/mcp
+Executing client: ./bin/testclient http://localhost:50728/mcp
+Executing client: ./bin/testclient http://localhost:50729/mcp
+Executing client: ./bin/testclient http://localhost:50730/mcp
+Executing client: ./bin/testclient http://localhost:50731/mcp
+Executing client: ./bin/testclient http://localhost:50732/mcp
+Executing client: ./bin/testclient http://localhost:50733/mcp
+Executing client: ./bin/testclient http://localhost:50734/mcp
+Executing client: ./bin/testclient http://localhost:50735/mcp
+Executing client: ./bin/testclient http://localhost:50736/mcp
+Executing client: ./bin/testclient http://localhost:50737/mcp
+Executing client: ./bin/testclient http://localhost:50738/mcp
+Executing client: ./bin/testclient http://localhost:50739/mcp
+Executing client: ./bin/testclient http://localhost:50740/mcp
 With context: {"client_id":"pre-registered-client","client_secret":"pre-registered-secret"}
-(node:79336) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
+(node:93015) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
 (Use `node --trace-deprecation ...` to show where the warning was created)
 
 === SUITE SUMMARY ===
@@ -539,15 +539,15 @@ Total: 210 passed, 0 failed, 1 warnings
 [32mBaseline check passed: all failures are expected.[0m
 
 === AUTH CONFORMANCE TESTS PASSED ===
-Finished: Wed Apr 22 20:34:49 PDT 2026
+Finished: Wed Apr 22 22:27:04 PDT 2026
 </pre></details>
 <details id='log-keycloak'><summary class='pass'>keycloak — PASS</summary><pre>
 === Stage 10/10: keycloak (make testkcl-auto) ===
-Started: Wed Apr 22 20:34:49 PDT 2026
+Started: Wed Apr 22 22:27:04 PDT 2026
 Starting Keycloak for interop tests...
 mcpkit-keycloak
-e6e04e923b1bf88b8072ccc5031379c3961a60c33e29a938420093986acc9472
-docker: Error response from daemon: failed to set up container networking: driver failed programming external connectivity on endpoint mcpkit-keycloak (dff84c05d3de2e1a87ea32b8914c18341cb2799ab9d25ba1e528069a524f2f2b): Bind for 0.0.0.0:8180 failed: port is already allocated
+13297f6bbd0b64128a80157e95cab8b93a77e362c4a2e93f21f85364fbd4d376
+docker: Error response from daemon: failed to set up container networking: driver failed programming external connectivity on endpoint mcpkit-keycloak (2b9ee3a6845386c41b2e9af234eea18c276be905bba15bd834752dd7d06086a4): Bind for 0.0.0.0:8180 failed: port is already allocated
 
 Run 'docker run --help' for more information
 Keycloak starting on port 8180... (realm import takes ~30s)
@@ -590,8 +590,8 @@ Waiting for Keycloak realm...
     token_refresh_test.go:22: Keycloak realm mcpkit-test not ready (status 404)
 --- SKIP: TestKeycloak_TokenRefresh_PasswordGrant (0.00s)
 PASS
-ok  	github.com/panyam/mcpkit/tests/keycloak	0.747s
+ok  	github.com/panyam/mcpkit/tests/keycloak	0.672s
 make[2]: *** No rule to make target `downkcl'.  Stop.
-Finished: Wed Apr 22 20:36:54 PDT 2026
+Finished: Wed Apr 22 22:29:09 PDT 2026
 </pre></details>
 </body></html>

--- a/tests/reports/run.log
+++ b/tests/reports/run.log
@@ -1,5 +1,5 @@
 === MCPKit Comprehensive Test Suite ===
-Started: Wed Apr 22 20:33:51 PDT 2026
+Started: Wed Apr 22 22:26:07 PDT 2026
 
 --- [1/10] unit+coverage ---
   PASS: unit+coverage
@@ -23,4 +23,4 @@ Started: Wed Apr 22 20:33:51 PDT 2026
   PASS: keycloak
 
 === Results: 10 passed, 0 failed ===
-Finished: Wed Apr 22 20:36:54 PDT 2026
+Finished: Wed Apr 22 22:29:09 PDT 2026

--- a/tests/reports/stage-auth-conformance.log
+++ b/tests/reports/stage-auth-conformance.log
@@ -1,5 +1,5 @@
 === Stage 9/10: auth-conformance (make testconfauth) ===
-Started: Wed Apr 22 20:34:47 PDT 2026
+Started: Wed Apr 22 22:27:02 PDT 2026
 bash scripts/conformance-auth-test.sh
 Building testclient...
 === Running MCP Auth conformance suite ===
@@ -21,22 +21,22 @@ Starting scenario: auth/token-endpoint-auth-basic
 Starting scenario: auth/token-endpoint-auth-post
 Starting scenario: auth/token-endpoint-auth-none
 Starting scenario: auth/pre-registration
-Executing client: ./bin/testclient http://localhost:62980/mcp
-Executing client: ./bin/testclient http://localhost:62981/mcp
-Executing client: ./bin/testclient http://localhost:62982/mcp
-Executing client: ./bin/testclient http://localhost:62983/mcp
-Executing client: ./bin/testclient http://localhost:62984/mcp
-Executing client: ./bin/testclient http://localhost:62985/mcp
-Executing client: ./bin/testclient http://localhost:62986/mcp
-Executing client: ./bin/testclient http://localhost:62987/mcp
-Executing client: ./bin/testclient http://localhost:62988/mcp
-Executing client: ./bin/testclient http://localhost:62989/mcp
-Executing client: ./bin/testclient http://localhost:62990/mcp
-Executing client: ./bin/testclient http://localhost:62991/mcp
-Executing client: ./bin/testclient http://localhost:62992/mcp
-Executing client: ./bin/testclient http://localhost:62993/mcp
+Executing client: ./bin/testclient http://localhost:50727/mcp
+Executing client: ./bin/testclient http://localhost:50728/mcp
+Executing client: ./bin/testclient http://localhost:50729/mcp
+Executing client: ./bin/testclient http://localhost:50730/mcp
+Executing client: ./bin/testclient http://localhost:50731/mcp
+Executing client: ./bin/testclient http://localhost:50732/mcp
+Executing client: ./bin/testclient http://localhost:50733/mcp
+Executing client: ./bin/testclient http://localhost:50734/mcp
+Executing client: ./bin/testclient http://localhost:50735/mcp
+Executing client: ./bin/testclient http://localhost:50736/mcp
+Executing client: ./bin/testclient http://localhost:50737/mcp
+Executing client: ./bin/testclient http://localhost:50738/mcp
+Executing client: ./bin/testclient http://localhost:50739/mcp
+Executing client: ./bin/testclient http://localhost:50740/mcp
 With context: {"client_id":"pre-registered-client","client_secret":"pre-registered-secret"}
-(node:79336) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
+(node:93015) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
 (Use `node --trace-deprecation ...` to show where the warning was created)
 
 === SUITE SUMMARY ===
@@ -64,4 +64,4 @@ Total: 210 passed, 0 failed, 1 warnings
 [32mBaseline check passed: all failures are expected.[0m
 
 === AUTH CONFORMANCE TESTS PASSED ===
-Finished: Wed Apr 22 20:34:49 PDT 2026
+Finished: Wed Apr 22 22:27:04 PDT 2026

--- a/tests/reports/stage-auth.log
+++ b/tests/reports/stage-auth.log
@@ -1,5 +1,5 @@
 === Stage 3/10: auth (make test-auth) ===
-Started: Wed Apr 22 20:34:20 PDT 2026
+Started: Wed Apr 22 22:26:35 PDT 2026
 cd ext/auth && go test ./... -count=1 -timeout 30s
-ok  	github.com/panyam/mcpkit/ext/auth	0.659s
-Finished: Wed Apr 22 20:34:21 PDT 2026
+ok  	github.com/panyam/mcpkit/ext/auth	0.359s
+Finished: Wed Apr 22 22:26:36 PDT 2026

--- a/tests/reports/stage-conformance.log
+++ b/tests/reports/stage-conformance.log
@@ -1,9 +1,9 @@
 === Stage 8/10: conformance (make testconf) ===
-Started: Wed Apr 22 20:34:42 PDT 2026
+Started: Wed Apr 22 22:26:56 PDT 2026
 bash scripts/conformance-test.sh
 Killing stale process on port 18799...
 === Starting test server on :18799 (Streamable HTTP) ===
-Waiting for server....2026/04/22 20:34:44 MCP test server listening on :18799 (Streamable HTTP at /mcp)
+Waiting for server.....2026/04/22 22:26:59 MCP test server listening on :18799 (Streamable HTTP at /mcp)
  ready
 
 === Running MCP conformance suite ===
@@ -14,295 +14,295 @@ Running active suite (30 scenarios) against http://localhost:18799/mcp
 
 === Running scenario: server-initialize ===
 Running client scenario 'server-initialize' against server: http://localhost:18799/mcp
-2026/04/22 20:34:46 Starting MCP-GET-SSE SSE connection: cd73f46a3a098825ecb00cee65306e60
-2026/04/22 20:34:46 SSEHub: registered connection cd73f46a3a098825ecb00cee65306e60 (total: 1)
-2026/04/22 20:34:46 SSEHub: unregistered connection cd73f46a3a098825ecb00cee65306e60 (total: 0)
-2026/04/22 20:34:46 Received kill signal.  Quitting Writer. stop 0x1b2ab39ca150
-2026/04/22 20:34:46 Cleaning up writer...
-2026/04/22 20:34:46 Finished cleaning up writer:  0x1b2ab39ca150
-2026/04/22 20:34:46 Closed MCP-GET-SSE SSE connection: cd73f46a3a098825ecb00cee65306e60
+2026/04/22 22:27:01 Starting MCP-GET-SSE SSE connection: f16538d4b15aa5fa75a8c28960a52f8c
+2026/04/22 22:27:01 SSEHub: registered connection f16538d4b15aa5fa75a8c28960a52f8c (total: 1)
+2026/04/22 22:27:01 SSEHub: unregistered connection f16538d4b15aa5fa75a8c28960a52f8c (total: 0)
+2026/04/22 22:27:01 Received kill signal.  Quitting Writer. stop 0x4fcda634310
+2026/04/22 22:27:01 Cleaning up writer...
+2026/04/22 22:27:01 Finished cleaning up writer:  0x4fcda634310
+2026/04/22 22:27:01 Closed MCP-GET-SSE SSE connection: f16538d4b15aa5fa75a8c28960a52f8c
 
 === Running scenario: logging-set-level ===
 Running client scenario 'logging-set-level' against server: http://localhost:18799/mcp
-2026/04/22 20:34:46 Starting MCP-GET-SSE SSE connection: 21c3dcdf315049d8058fc543bc0c7583
-2026/04/22 20:34:46 SSEHub: registered connection 21c3dcdf315049d8058fc543bc0c7583 (total: 1)
-2026/04/22 20:34:46 SSEHub: unregistered connection 21c3dcdf315049d8058fc543bc0c7583 (total: 0)
-2026/04/22 20:34:46 Received kill signal.  Quitting Writer. stop 0x1b2ab39ca380
-2026/04/22 20:34:46 Cleaning up writer...
-2026/04/22 20:34:46 Finished cleaning up writer:  0x1b2ab39ca380
-2026/04/22 20:34:46 Closed MCP-GET-SSE SSE connection: 21c3dcdf315049d8058fc543bc0c7583
+2026/04/22 22:27:01 Starting MCP-GET-SSE SSE connection: 0cff83f51f69f191fd917156430e8b21
+2026/04/22 22:27:01 SSEHub: registered connection 0cff83f51f69f191fd917156430e8b21 (total: 1)
+2026/04/22 22:27:01 SSEHub: unregistered connection 0cff83f51f69f191fd917156430e8b21 (total: 0)
+2026/04/22 22:27:01 Received kill signal.  Quitting Writer. stop 0x4fcda5b01c0
+2026/04/22 22:27:01 Cleaning up writer...
+2026/04/22 22:27:01 Finished cleaning up writer:  0x4fcda5b01c0
+2026/04/22 22:27:01 Closed MCP-GET-SSE SSE connection: 0cff83f51f69f191fd917156430e8b21
 
 === Running scenario: ping ===
 Running client scenario 'ping' against server: http://localhost:18799/mcp
-2026/04/22 20:34:46 Starting MCP-GET-SSE SSE connection: 29586e6ac9b05564b00b9554b0268e1b
-2026/04/22 20:34:46 SSEHub: registered connection 29586e6ac9b05564b00b9554b0268e1b (total: 1)
-2026/04/22 20:34:46 SSEHub: unregistered connection 29586e6ac9b05564b00b9554b0268e1b (total: 0)
-2026/04/22 20:34:46 Received kill signal.  Quitting Writer. stop 0x1b2ab3d32310
-2026/04/22 20:34:46 Cleaning up writer...
-2026/04/22 20:34:46 Finished cleaning up writer:  0x1b2ab3d32310
-2026/04/22 20:34:46 Closed MCP-GET-SSE SSE connection: 29586e6ac9b05564b00b9554b0268e1b
+2026/04/22 22:27:01 Starting MCP-GET-SSE SSE connection: c10c4d47d8f6ba70aadb87014c038b5a
+2026/04/22 22:27:01 SSEHub: registered connection c10c4d47d8f6ba70aadb87014c038b5a (total: 1)
+2026/04/22 22:27:01 SSEHub: unregistered connection c10c4d47d8f6ba70aadb87014c038b5a (total: 0)
+2026/04/22 22:27:01 Received kill signal.  Quitting Writer. stop 0x4fcda6341c0
+2026/04/22 22:27:01 Cleaning up writer...
+2026/04/22 22:27:01 Finished cleaning up writer:  0x4fcda6341c0
+2026/04/22 22:27:01 Closed MCP-GET-SSE SSE connection: c10c4d47d8f6ba70aadb87014c038b5a
 
 === Running scenario: completion-complete ===
 Running client scenario 'completion-complete' against server: http://localhost:18799/mcp
-2026/04/22 20:34:46 Starting MCP-GET-SSE SSE connection: 07fc923040a39f91e49ae5487499c995
-2026/04/22 20:34:46 SSEHub: registered connection 07fc923040a39f91e49ae5487499c995 (total: 1)
-2026/04/22 20:34:46 SSEHub: unregistered connection 07fc923040a39f91e49ae5487499c995 (total: 0)
-2026/04/22 20:34:46 Received kill signal.  Quitting Writer. stop 0x1b2ab39ca5b0
-2026/04/22 20:34:46 Cleaning up writer...
-2026/04/22 20:34:46 Finished cleaning up writer:  0x1b2ab39ca5b0
-2026/04/22 20:34:46 Closed MCP-GET-SSE SSE connection: 07fc923040a39f91e49ae5487499c995
+2026/04/22 22:27:01 Starting MCP-GET-SSE SSE connection: e517b3eab5b262856eaf80eb81c2070e
+2026/04/22 22:27:01 SSEHub: registered connection e517b3eab5b262856eaf80eb81c2070e (total: 1)
+2026/04/22 22:27:01 SSEHub: unregistered connection e517b3eab5b262856eaf80eb81c2070e (total: 0)
+2026/04/22 22:27:01 Received kill signal.  Quitting Writer. stop 0x4fcda6343f0
+2026/04/22 22:27:01 Cleaning up writer...
+2026/04/22 22:27:01 Finished cleaning up writer:  0x4fcda6343f0
+2026/04/22 22:27:01 Closed MCP-GET-SSE SSE connection: e517b3eab5b262856eaf80eb81c2070e
 
 === Running scenario: tools-list ===
 Running client scenario 'tools-list' against server: http://localhost:18799/mcp
-2026/04/22 20:34:46 Starting MCP-GET-SSE SSE connection: 77801cb67c3da2d8b080495374266f14
-2026/04/22 20:34:46 SSEHub: registered connection 77801cb67c3da2d8b080495374266f14 (total: 1)
-2026/04/22 20:34:46 SSEHub: unregistered connection 77801cb67c3da2d8b080495374266f14 (total: 0)
+2026/04/22 22:27:01 Starting MCP-GET-SSE SSE connection: 067266fd4bed596ac4f8018415992c2a
+2026/04/22 22:27:01 SSEHub: registered connection 067266fd4bed596ac4f8018415992c2a (total: 1)
+2026/04/22 22:27:01 SSEHub: unregistered connection 067266fd4bed596ac4f8018415992c2a (total: 0)
+2026/04/22 22:27:01 Received kill signal.  Quitting Writer. stop 0x4fcda6a0460
+2026/04/22 22:27:01 Cleaning up writer...
 
 === Running scenario: tools-call-simple-text ===
-2026/04/22 20:34:46 Received kill signal.  Quitting Writer. stop 0x1b2ab3d321c0
-2026/04/22 20:34:46 Cleaning up writer...
+2026/04/22 22:27:01 Finished cleaning up writer:  0x4fcda6a0460
 Running client scenario 'tools-call-simple-text' against server: http://localhost:18799/mcp
-2026/04/22 20:34:46 Finished cleaning up writer:  0x1b2ab3d321c0
-2026/04/22 20:34:46 Closed MCP-GET-SSE SSE connection: 77801cb67c3da2d8b080495374266f14
-2026/04/22 20:34:46 Starting MCP-GET-SSE SSE connection: baff50b946d4eeaa92ae32988b1c8c97
-2026/04/22 20:34:46 SSEHub: registered connection baff50b946d4eeaa92ae32988b1c8c97 (total: 1)
-2026/04/22 20:34:46 SSEHub: unregistered connection baff50b946d4eeaa92ae32988b1c8c97 (total: 0)
-2026/04/22 20:34:46 Received kill signal.  Quitting Writer. stop 0x1b2ab39ca1c0
-2026/04/22 20:34:46 Cleaning up writer...
-2026/04/22 20:34:46 Finished cleaning up writer:  0x1b2ab39ca1c0
-2026/04/22 20:34:46 Closed MCP-GET-SSE SSE connection: baff50b946d4eeaa92ae32988b1c8c97
+2026/04/22 22:27:01 Closed MCP-GET-SSE SSE connection: 067266fd4bed596ac4f8018415992c2a
+2026/04/22 22:27:01 Starting MCP-GET-SSE SSE connection: f6a4f0ab160623d41a4766d7775365c3
+2026/04/22 22:27:01 SSEHub: registered connection f6a4f0ab160623d41a4766d7775365c3 (total: 1)
+2026/04/22 22:27:01 SSEHub: unregistered connection f6a4f0ab160623d41a4766d7775365c3 (total: 0)
+2026/04/22 22:27:01 Received kill signal.  Quitting Writer. stop 0x4fcda5b03f0
+2026/04/22 22:27:01 Cleaning up writer...
+2026/04/22 22:27:01 Finished cleaning up writer:  0x4fcda5b03f0
+2026/04/22 22:27:01 Closed MCP-GET-SSE SSE connection: f6a4f0ab160623d41a4766d7775365c3
 
 === Running scenario: tools-call-image ===
 Running client scenario 'tools-call-image' against server: http://localhost:18799/mcp
-2026/04/22 20:34:46 Starting MCP-GET-SSE SSE connection: 864999cd67d910e44df29ed6f1819b89
-2026/04/22 20:34:46 SSEHub: registered connection 864999cd67d910e44df29ed6f1819b89 (total: 1)
-2026/04/22 20:34:46 SSEHub: unregistered connection 864999cd67d910e44df29ed6f1819b89 (total: 0)
-2026/04/22 20:34:46 Received kill signal.  Quitting Writer. stop 0x1b2ab3d32540
-2026/04/22 20:34:46 Cleaning up writer...
-2026/04/22 20:34:46 Finished cleaning up writer:  0x1b2ab3d32540
-2026/04/22 20:34:46 Closed MCP-GET-SSE SSE connection: 864999cd67d910e44df29ed6f1819b89
+2026/04/22 22:27:01 Starting MCP-GET-SSE SSE connection: 0f183d5b45ade31fc8c088bf030f0868
+2026/04/22 22:27:01 SSEHub: registered connection 0f183d5b45ade31fc8c088bf030f0868 (total: 1)
 
 === Running scenario: tools-call-audio ===
+2026/04/22 22:27:01 SSEHub: unregistered connection 0f183d5b45ade31fc8c088bf030f0868 (total: 0)
 Running client scenario 'tools-call-audio' against server: http://localhost:18799/mcp
-2026/04/22 20:34:46 Starting MCP-GET-SSE SSE connection: 11827d7450c5699736ee30bd4be9afdc
-2026/04/22 20:34:46 SSEHub: registered connection 11827d7450c5699736ee30bd4be9afdc (total: 1)
-2026/04/22 20:34:46 SSEHub: unregistered connection 11827d7450c5699736ee30bd4be9afdc (total: 0)
-2026/04/22 20:34:46 Received kill signal.  Quitting Writer. stop 0x1b2ab3d9c540
-2026/04/22 20:34:46 Cleaning up writer...
-2026/04/22 20:34:46 Finished cleaning up writer:  0x1b2ab3d9c540
-2026/04/22 20:34:46 Closed MCP-GET-SSE SSE connection: 11827d7450c5699736ee30bd4be9afdc
+2026/04/22 22:27:01 Received kill signal.  Quitting Writer. stop 0x4fcda634770
+2026/04/22 22:27:01 Cleaning up writer...
+2026/04/22 22:27:01 Finished cleaning up writer:  0x4fcda634770
+2026/04/22 22:27:01 Closed MCP-GET-SSE SSE connection: 0f183d5b45ade31fc8c088bf030f0868
+2026/04/22 22:27:01 Starting MCP-GET-SSE SSE connection: 28d9d3431f16e5aaed478bbc4e492b73
+2026/04/22 22:27:01 SSEHub: registered connection 28d9d3431f16e5aaed478bbc4e492b73 (total: 1)
+2026/04/22 22:27:01 SSEHub: unregistered connection 28d9d3431f16e5aaed478bbc4e492b73 (total: 0)
+2026/04/22 22:27:01 Received kill signal.  Quitting Writer. stop 0x4fcda6349a0
+2026/04/22 22:27:01 Cleaning up writer...
+2026/04/22 22:27:01 Finished cleaning up writer:  0x4fcda6349a0
+2026/04/22 22:27:01 Closed MCP-GET-SSE SSE connection: 28d9d3431f16e5aaed478bbc4e492b73
 
 === Running scenario: tools-call-embedded-resource ===
 Running client scenario 'tools-call-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/22 20:34:46 Starting MCP-GET-SSE SSE connection: 847a27d45c25a85ece98daa423ac5588
-2026/04/22 20:34:46 SSEHub: registered connection 847a27d45c25a85ece98daa423ac5588 (total: 1)
-2026/04/22 20:34:46 SSEHub: unregistered connection 847a27d45c25a85ece98daa423ac5588 (total: 0)
-2026/04/22 20:34:46 Received kill signal.  Quitting Writer. stop 0x1b2ab39ca690
-2026/04/22 20:34:46 Cleaning up writer...
-2026/04/22 20:34:46 Finished cleaning up writer:  0x1b2ab39ca690
-2026/04/22 20:34:46 Closed MCP-GET-SSE SSE connection: 847a27d45c25a85ece98daa423ac5588
+2026/04/22 22:27:01 Starting MCP-GET-SSE SSE connection: c83dba23ec0e9afb0c8a9b98bc75e3a2
+2026/04/22 22:27:01 SSEHub: registered connection c83dba23ec0e9afb0c8a9b98bc75e3a2 (total: 1)
 
 === Running scenario: tools-call-mixed-content ===
+2026/04/22 22:27:01 SSEHub: unregistered connection c83dba23ec0e9afb0c8a9b98bc75e3a2 (total: 0)
+2026/04/22 22:27:01 Received kill signal.  Quitting Writer. stop 0x4fcda6a0850
 Running client scenario 'tools-call-mixed-content' against server: http://localhost:18799/mcp
-2026/04/22 20:34:46 Starting MCP-GET-SSE SSE connection: d8f7944a26d314a3d48b3a78e7999613
-2026/04/22 20:34:46 SSEHub: registered connection d8f7944a26d314a3d48b3a78e7999613 (total: 1)
-2026/04/22 20:34:46 SSEHub: unregistered connection d8f7944a26d314a3d48b3a78e7999613 (total: 0)
+2026/04/22 22:27:01 Cleaning up writer...
+2026/04/22 22:27:01 Finished cleaning up writer:  0x4fcda6a0850
+2026/04/22 22:27:01 Closed MCP-GET-SSE SSE connection: c83dba23ec0e9afb0c8a9b98bc75e3a2
+2026/04/22 22:27:01 Starting MCP-GET-SSE SSE connection: ba679e591c4b8f8fd2a7874839482c4a
+2026/04/22 22:27:01 SSEHub: registered connection ba679e591c4b8f8fd2a7874839482c4a (total: 1)
 
 === Running scenario: tools-call-with-logging ===
-2026/04/22 20:34:46 Received kill signal.  Quitting Writer. stop 0x1b2ab38e6c40
-2026/04/22 20:34:46 Cleaning up writer...
 Running client scenario 'tools-call-with-logging' against server: http://localhost:18799/mcp
-2026/04/22 20:34:46 Finished cleaning up writer:  0x1b2ab38e6c40
-2026/04/22 20:34:46 Closed MCP-GET-SSE SSE connection: d8f7944a26d314a3d48b3a78e7999613
-2026/04/22 20:34:46 Starting MCP-GET-SSE SSE connection: 64b570c7c1fb316f8026ab25824eb082
-2026/04/22 20:34:46 SSEHub: registered connection 64b570c7c1fb316f8026ab25824eb082 (total: 1)
+2026/04/22 22:27:01 SSEHub: unregistered connection ba679e591c4b8f8fd2a7874839482c4a (total: 0)
+2026/04/22 22:27:01 Received kill signal.  Quitting Writer. stop 0x4fcda6a0af0
+2026/04/22 22:27:01 Cleaning up writer...
+2026/04/22 22:27:01 Finished cleaning up writer:  0x4fcda6a0af0
+2026/04/22 22:27:01 Closed MCP-GET-SSE SSE connection: ba679e591c4b8f8fd2a7874839482c4a
+2026/04/22 22:27:01 Starting MCP-GET-SSE SSE connection: 6b2d802fa5d2a716cc5070734ec6a0a7
+2026/04/22 22:27:01 SSEHub: registered connection 6b2d802fa5d2a716cc5070734ec6a0a7 (total: 1)
+2026/04/22 22:27:02 SSEHub: unregistered connection 6b2d802fa5d2a716cc5070734ec6a0a7 (total: 0)
 
 === Running scenario: tools-call-error ===
-2026/04/22 20:34:47 SSEHub: unregistered connection 64b570c7c1fb316f8026ab25824eb082 (total: 0)
+2026/04/22 22:27:02 Received kill signal.  Quitting Writer. stop 0x4fcda6a0d90
+2026/04/22 22:27:02 Cleaning up writer...
+2026/04/22 22:27:02 Finished cleaning up writer:  0x4fcda6a0d90
+2026/04/22 22:27:02 Closed MCP-GET-SSE SSE connection: 6b2d802fa5d2a716cc5070734ec6a0a7
 Running client scenario 'tools-call-error' against server: http://localhost:18799/mcp
-2026/04/22 20:34:47 Received kill signal.  Quitting Writer. stop 0x1b2ab39ca8c0
-2026/04/22 20:34:47 Cleaning up writer...
-2026/04/22 20:34:47 Finished cleaning up writer:  0x1b2ab39ca8c0
-2026/04/22 20:34:47 Closed MCP-GET-SSE SSE connection: 64b570c7c1fb316f8026ab25824eb082
-2026/04/22 20:34:47 Starting MCP-GET-SSE SSE connection: fdffc79d69b51814d9834d7942df27f5
-2026/04/22 20:34:47 SSEHub: registered connection fdffc79d69b51814d9834d7942df27f5 (total: 1)
-2026/04/22 20:34:47 SSEHub: unregistered connection fdffc79d69b51814d9834d7942df27f5 (total: 0)
-2026/04/22 20:34:47 Received kill signal.  Quitting Writer. stop 0x1b2ab38e7030
-2026/04/22 20:34:47 Cleaning up writer...
-2026/04/22 20:34:47 Finished cleaning up writer:  0x1b2ab38e7030
-2026/04/22 20:34:47 Closed MCP-GET-SSE SSE connection: fdffc79d69b51814d9834d7942df27f5
+2026/04/22 22:27:02 Starting MCP-GET-SSE SSE connection: fc4d9eefbae045824b77d3a44735cdc0
+2026/04/22 22:27:02 SSEHub: registered connection fc4d9eefbae045824b77d3a44735cdc0 (total: 1)
+2026/04/22 22:27:02 SSEHub: unregistered connection fc4d9eefbae045824b77d3a44735cdc0 (total: 0)
+2026/04/22 22:27:02 Received kill signal.  Quitting Writer. stop 0x4fcda634d90
+2026/04/22 22:27:02 Cleaning up writer...
 
 === Running scenario: tools-call-with-progress ===
+2026/04/22 22:27:02 Finished cleaning up writer:  0x4fcda634d90
+2026/04/22 22:27:02 Closed MCP-GET-SSE SSE connection: fc4d9eefbae045824b77d3a44735cdc0
 Running client scenario 'tools-call-with-progress' against server: http://localhost:18799/mcp
-2026/04/22 20:34:47 Starting MCP-GET-SSE SSE connection: cca1791e2c7d9cc70923f9fa09496693
-2026/04/22 20:34:47 SSEHub: registered connection cca1791e2c7d9cc70923f9fa09496693 (total: 1)
-2026/04/22 20:34:47 SSEHub: unregistered connection cca1791e2c7d9cc70923f9fa09496693 (total: 0)
-2026/04/22 20:34:47 Received kill signal.  Quitting Writer. stop 0x1b2ab39cab60
-2026/04/22 20:34:47 Cleaning up writer...
-2026/04/22 20:34:47 Finished cleaning up writer:  0x1b2ab39cab60
-2026/04/22 20:34:47 Closed MCP-GET-SSE SSE connection: cca1791e2c7d9cc70923f9fa09496693
+2026/04/22 22:27:02 Starting MCP-GET-SSE SSE connection: ea55463172e2e9c87e41cb77c12f280c
+2026/04/22 22:27:02 SSEHub: registered connection ea55463172e2e9c87e41cb77c12f280c (total: 1)
+2026/04/22 22:27:02 SSEHub: unregistered connection ea55463172e2e9c87e41cb77c12f280c (total: 0)
 
 === Running scenario: tools-call-sampling ===
+2026/04/22 22:27:02 Received kill signal.  Quitting Writer. stop 0x4fcda6a1110
+2026/04/22 22:27:02 Cleaning up writer...
 Running client scenario 'tools-call-sampling' against server: http://localhost:18799/mcp
-2026/04/22 20:34:47 Starting MCP-GET-SSE SSE connection: 5a83acc9d7bf4a2cb9d1bccb28d5cc57
-2026/04/22 20:34:47 SSEHub: registered connection 5a83acc9d7bf4a2cb9d1bccb28d5cc57 (total: 1)
-2026/04/22 20:34:47 SSEHub: unregistered connection 5a83acc9d7bf4a2cb9d1bccb28d5cc57 (total: 0)
-2026/04/22 20:34:47 Received kill signal.  Quitting Writer. stop 0x1b2ab3d32850
-2026/04/22 20:34:47 Cleaning up writer...
-2026/04/22 20:34:47 Finished cleaning up writer:  0x1b2ab3d32850
-2026/04/22 20:34:47 Closed MCP-GET-SSE SSE connection: 5a83acc9d7bf4a2cb9d1bccb28d5cc57
+2026/04/22 22:27:02 Finished cleaning up writer:  0x4fcda6a1110
+2026/04/22 22:27:02 Closed MCP-GET-SSE SSE connection: ea55463172e2e9c87e41cb77c12f280c
+2026/04/22 22:27:02 Starting MCP-GET-SSE SSE connection: 1410f6f24ab20930727d3664848b2cce
+2026/04/22 22:27:02 SSEHub: registered connection 1410f6f24ab20930727d3664848b2cce (total: 1)
+2026/04/22 22:27:02 SSEHub: unregistered connection 1410f6f24ab20930727d3664848b2cce (total: 0)
+2026/04/22 22:27:02 Received kill signal.  Quitting Writer. stop 0x4fcda6a1490
+2026/04/22 22:27:02 Cleaning up writer...
 
 === Running scenario: tools-call-elicitation ===
+2026/04/22 22:27:02 Finished cleaning up writer:  0x4fcda6a1490
+2026/04/22 22:27:02 Closed MCP-GET-SSE SSE connection: 1410f6f24ab20930727d3664848b2cce
 Running client scenario 'tools-call-elicitation' against server: http://localhost:18799/mcp
-2026/04/22 20:34:47 Starting MCP-GET-SSE SSE connection: b992b0a5f562241486cc6c7dd273821f
-2026/04/22 20:34:47 SSEHub: registered connection b992b0a5f562241486cc6c7dd273821f (total: 1)
+2026/04/22 22:27:02 Starting MCP-GET-SSE SSE connection: 4c962b1cf9045b6bdcffd79a4e07f8af
+2026/04/22 22:27:02 SSEHub: registered connection 4c962b1cf9045b6bdcffd79a4e07f8af (total: 1)
+2026/04/22 22:27:02 SSEHub: unregistered connection 4c962b1cf9045b6bdcffd79a4e07f8af (total: 0)
+2026/04/22 22:27:02 Received kill signal.  Quitting Writer. stop 0x4fcda6a1880
+2026/04/22 22:27:02 Cleaning up writer...
+2026/04/22 22:27:02 Finished cleaning up writer:  0x4fcda6a1880
+2026/04/22 22:27:02 Closed MCP-GET-SSE SSE connection: 4c962b1cf9045b6bdcffd79a4e07f8af
 
 === Running scenario: elicitation-sep1034-defaults ===
-2026/04/22 20:34:47 SSEHub: unregistered connection b992b0a5f562241486cc6c7dd273821f (total: 0)
-2026/04/22 20:34:47 Received kill signal.  Quitting Writer. stop 0x1b2ab39cb030
-2026/04/22 20:34:47 Cleaning up writer...
-2026/04/22 20:34:47 Finished cleaning up writer:  0x1b2ab39cb030
-2026/04/22 20:34:47 Closed MCP-GET-SSE SSE connection: b992b0a5f562241486cc6c7dd273821f
 Running client scenario 'elicitation-sep1034-defaults' against server: http://localhost:18799/mcp
-2026/04/22 20:34:47 Starting MCP-GET-SSE SSE connection: e46c5494206fd307e5876e100221cc0d
-2026/04/22 20:34:47 SSEHub: registered connection e46c5494206fd307e5876e100221cc0d (total: 1)
-2026/04/22 20:34:47 SSEHub: unregistered connection e46c5494206fd307e5876e100221cc0d (total: 0)
+2026/04/22 22:27:02 Starting MCP-GET-SSE SSE connection: ea6b074d9dc20d6fed2af966d2c2bf73
+2026/04/22 22:27:02 SSEHub: registered connection ea6b074d9dc20d6fed2af966d2c2bf73 (total: 1)
+2026/04/22 22:27:02 SSEHub: unregistered connection ea6b074d9dc20d6fed2af966d2c2bf73 (total: 0)
+2026/04/22 22:27:02 Received kill signal.  Quitting Writer. stop 0x4fcda5b0850
+2026/04/22 22:27:02 Cleaning up writer...
+2026/04/22 22:27:02 Finished cleaning up writer:  0x4fcda5b0850
+2026/04/22 22:27:02 Closed MCP-GET-SSE SSE connection: ea6b074d9dc20d6fed2af966d2c2bf73
 
 === Running scenario: server-sse-multiple-streams ===
-2026/04/22 20:34:47 Received kill signal.  Quitting Writer. stop 0x1b2ab38e7340
-2026/04/22 20:34:47 Cleaning up writer...
 Running client scenario 'server-sse-multiple-streams' against server: http://localhost:18799/mcp
-2026/04/22 20:34:47 Finished cleaning up writer:  0x1b2ab38e7340
-2026/04/22 20:34:47 Closed MCP-GET-SSE SSE connection: e46c5494206fd307e5876e100221cc0d
-2026/04/22 20:34:47 Starting MCP-GET-SSE SSE connection: a3742c8470c8acc93e24d75c51d8e8f4
-2026/04/22 20:34:47 SSEHub: registered connection a3742c8470c8acc93e24d75c51d8e8f4 (total: 1)
+2026/04/22 22:27:02 Starting MCP-GET-SSE SSE connection: ea1635f60fa7286031ff08139fc2cd9d
+2026/04/22 22:27:02 SSEHub: registered connection ea1635f60fa7286031ff08139fc2cd9d (total: 1)
+2026/04/22 22:27:02 SSEHub: unregistered connection ea1635f60fa7286031ff08139fc2cd9d (total: 0)
 
 === Running scenario: elicitation-sep1330-enums ===
+2026/04/22 22:27:02 Received kill signal.  Quitting Writer. stop 0x4fcda5b0af0
 Running client scenario 'elicitation-sep1330-enums' against server: http://localhost:18799/mcp
-2026/04/22 20:34:47 SSEHub: unregistered connection a3742c8470c8acc93e24d75c51d8e8f4 (total: 0)
-2026/04/22 20:34:47 Received kill signal.  Quitting Writer. stop 0x1b2ab3d9cb60
-2026/04/22 20:34:47 Cleaning up writer...
-2026/04/22 20:34:47 Finished cleaning up writer:  0x1b2ab3d9cb60
-2026/04/22 20:34:47 Closed MCP-GET-SSE SSE connection: a3742c8470c8acc93e24d75c51d8e8f4
-2026/04/22 20:34:47 Starting MCP-GET-SSE SSE connection: e1914f5149abd701d22d0ee84449a774
-2026/04/22 20:34:47 SSEHub: registered connection e1914f5149abd701d22d0ee84449a774 (total: 1)
-2026/04/22 20:34:47 SSEHub: unregistered connection e1914f5149abd701d22d0ee84449a774 (total: 0)
-2026/04/22 20:34:47 Received kill signal.  Quitting Writer. stop 0x1b2ab38e7810
-2026/04/22 20:34:47 Cleaning up writer...
-2026/04/22 20:34:47 Finished cleaning up writer:  0x1b2ab38e7810
-2026/04/22 20:34:47 Closed MCP-GET-SSE SSE connection: e1914f5149abd701d22d0ee84449a774
+2026/04/22 22:27:02 Cleaning up writer...
+2026/04/22 22:27:02 Finished cleaning up writer:  0x4fcda5b0af0
+2026/04/22 22:27:02 Closed MCP-GET-SSE SSE connection: ea1635f60fa7286031ff08139fc2cd9d
+2026/04/22 22:27:02 Starting MCP-GET-SSE SSE connection: 5de549592e3c0662342e869bc7880935
+2026/04/22 22:27:02 SSEHub: registered connection 5de549592e3c0662342e869bc7880935 (total: 1)
+2026/04/22 22:27:02 SSEHub: unregistered connection 5de549592e3c0662342e869bc7880935 (total: 0)
+2026/04/22 22:27:02 Received kill signal.  Quitting Writer. stop 0x4fcda70e230
+2026/04/22 22:27:02 Cleaning up writer...
+2026/04/22 22:27:02 Finished cleaning up writer:  0x4fcda70e230
+2026/04/22 22:27:02 Closed MCP-GET-SSE SSE connection: 5de549592e3c0662342e869bc7880935
 
 === Running scenario: resources-list ===
 Running client scenario 'resources-list' against server: http://localhost:18799/mcp
-2026/04/22 20:34:47 Starting MCP-GET-SSE SSE connection: ac1da82df1541b95bd6cb8ed12768540
-2026/04/22 20:34:47 SSEHub: registered connection ac1da82df1541b95bd6cb8ed12768540 (total: 1)
-2026/04/22 20:34:47 SSEHub: unregistered connection ac1da82df1541b95bd6cb8ed12768540 (total: 0)
-2026/04/22 20:34:47 Received kill signal.  Quitting Writer. stop 0x1b2ab3d9ce00
-2026/04/22 20:34:47 Cleaning up writer...
-2026/04/22 20:34:47 Finished cleaning up writer:  0x1b2ab3d9ce00
-2026/04/22 20:34:47 Closed MCP-GET-SSE SSE connection: ac1da82df1541b95bd6cb8ed12768540
+2026/04/22 22:27:02 Starting MCP-GET-SSE SSE connection: ba44d1b6a87c23b196e5ebba1f337c12
+2026/04/22 22:27:02 SSEHub: registered connection ba44d1b6a87c23b196e5ebba1f337c12 (total: 1)
 
 === Running scenario: resources-read-text ===
+2026/04/22 22:27:02 SSEHub: unregistered connection ba44d1b6a87c23b196e5ebba1f337c12 (total: 0)
 Running client scenario 'resources-read-text' against server: http://localhost:18799/mcp
-2026/04/22 20:34:47 Starting MCP-GET-SSE SSE connection: 4f58d4f9ed36487037f42b5f1534b93c
-2026/04/22 20:34:47 SSEHub: registered connection 4f58d4f9ed36487037f42b5f1534b93c (total: 1)
+2026/04/22 22:27:02 Received kill signal.  Quitting Writer. stop 0x4fcda70e460
+2026/04/22 22:27:02 Cleaning up writer...
+2026/04/22 22:27:02 Finished cleaning up writer:  0x4fcda70e460
+2026/04/22 22:27:02 Closed MCP-GET-SSE SSE connection: ba44d1b6a87c23b196e5ebba1f337c12
+2026/04/22 22:27:02 Starting MCP-GET-SSE SSE connection: 6bf895baf08af0598ea3b1f8a67b3709
+2026/04/22 22:27:02 SSEHub: registered connection 6bf895baf08af0598ea3b1f8a67b3709 (total: 1)
+2026/04/22 22:27:02 SSEHub: unregistered connection 6bf895baf08af0598ea3b1f8a67b3709 (total: 0)
+2026/04/22 22:27:02 Received kill signal.  Quitting Writer. stop 0x4fcda5b0e00
+2026/04/22 22:27:02 Cleaning up writer...
+2026/04/22 22:27:02 Finished cleaning up writer:  0x4fcda5b0e00
+2026/04/22 22:27:02 Closed MCP-GET-SSE SSE connection: 6bf895baf08af0598ea3b1f8a67b3709
 
 === Running scenario: resources-read-binary ===
 Running client scenario 'resources-read-binary' against server: http://localhost:18799/mcp
-2026/04/22 20:34:47 SSEHub: unregistered connection 4f58d4f9ed36487037f42b5f1534b93c (total: 0)
-2026/04/22 20:34:47 Received kill signal.  Quitting Writer. stop 0x1b2ab38e7ab0
-2026/04/22 20:34:47 Cleaning up writer...
-2026/04/22 20:34:47 Finished cleaning up writer:  0x1b2ab38e7ab0
-2026/04/22 20:34:47 Closed MCP-GET-SSE SSE connection: 4f58d4f9ed36487037f42b5f1534b93c
-2026/04/22 20:34:47 Starting MCP-GET-SSE SSE connection: e55d3478aa3238c808e827533d1c6b59
-2026/04/22 20:34:47 SSEHub: registered connection e55d3478aa3238c808e827533d1c6b59 (total: 1)
-2026/04/22 20:34:47 SSEHub: unregistered connection e55d3478aa3238c808e827533d1c6b59 (total: 0)
-2026/04/22 20:34:47 Received kill signal.  Quitting Writer. stop 0x1b2ab3d32f50
-2026/04/22 20:34:47 Cleaning up writer...
-2026/04/22 20:34:47 Finished cleaning up writer:  0x1b2ab3d32f50
-2026/04/22 20:34:47 Closed MCP-GET-SSE SSE connection: e55d3478aa3238c808e827533d1c6b59
+2026/04/22 22:27:02 Starting MCP-GET-SSE SSE connection: ef61aef36a9b797478e092ba7fdd2a00
+2026/04/22 22:27:02 SSEHub: registered connection ef61aef36a9b797478e092ba7fdd2a00 (total: 1)
+2026/04/22 22:27:02 SSEHub: unregistered connection ef61aef36a9b797478e092ba7fdd2a00 (total: 0)
 
 === Running scenario: resources-templates-read ===
+2026/04/22 22:27:02 Received kill signal.  Quitting Writer. stop 0x4fcda70e770
+2026/04/22 22:27:02 Cleaning up writer...
 Running client scenario 'resources-templates-read' against server: http://localhost:18799/mcp
-2026/04/22 20:34:47 Starting MCP-GET-SSE SSE connection: d6eab4bc209982adba5299fb652a36ae
-2026/04/22 20:34:47 SSEHub: registered connection d6eab4bc209982adba5299fb652a36ae (total: 1)
-2026/04/22 20:34:47 SSEHub: unregistered connection d6eab4bc209982adba5299fb652a36ae (total: 0)
-2026/04/22 20:34:47 Received kill signal.  Quitting Writer. stop 0x1b2ab39cb2d0
-2026/04/22 20:34:47 Cleaning up writer...
-2026/04/22 20:34:47 Finished cleaning up writer:  0x1b2ab39cb2d0
-2026/04/22 20:34:47 Closed MCP-GET-SSE SSE connection: d6eab4bc209982adba5299fb652a36ae
+2026/04/22 22:27:02 Finished cleaning up writer:  0x4fcda70e770
+2026/04/22 22:27:02 Closed MCP-GET-SSE SSE connection: ef61aef36a9b797478e092ba7fdd2a00
+2026/04/22 22:27:02 Starting MCP-GET-SSE SSE connection: d9e1f1b2c1c88ed953178c59295fb70d
+2026/04/22 22:27:02 SSEHub: registered connection d9e1f1b2c1c88ed953178c59295fb70d (total: 1)
+2026/04/22 22:27:02 SSEHub: unregistered connection d9e1f1b2c1c88ed953178c59295fb70d (total: 0)
+2026/04/22 22:27:02 Received kill signal.  Quitting Writer. stop 0x4fcda5b1030
+2026/04/22 22:27:02 Cleaning up writer...
+2026/04/22 22:27:02 Finished cleaning up writer:  0x4fcda5b1030
+2026/04/22 22:27:02 Closed MCP-GET-SSE SSE connection: d9e1f1b2c1c88ed953178c59295fb70d
 
 === Running scenario: resources-subscribe ===
 Running client scenario 'resources-subscribe' against server: http://localhost:18799/mcp
-2026/04/22 20:34:47 Starting MCP-GET-SSE SSE connection: d80512738699879ae9d5894131a904b3
-2026/04/22 20:34:47 SSEHub: registered connection d80512738699879ae9d5894131a904b3 (total: 1)
-2026/04/22 20:34:47 SSEHub: unregistered connection d80512738699879ae9d5894131a904b3 (total: 0)
-2026/04/22 20:34:47 Received kill signal.  Quitting Writer. stop 0x1b2ab3d33260
-2026/04/22 20:34:47 Cleaning up writer...
-2026/04/22 20:34:47 Finished cleaning up writer:  0x1b2ab3d33260
-2026/04/22 20:34:47 Closed MCP-GET-SSE SSE connection: d80512738699879ae9d5894131a904b3
+2026/04/22 22:27:02 Starting MCP-GET-SSE SSE connection: 2a05bd481a9f69da179a1b5fb0efd5d9
+2026/04/22 22:27:02 SSEHub: registered connection 2a05bd481a9f69da179a1b5fb0efd5d9 (total: 1)
 
 === Running scenario: resources-unsubscribe ===
+2026/04/22 22:27:02 SSEHub: unregistered connection 2a05bd481a9f69da179a1b5fb0efd5d9 (total: 0)
 Running client scenario 'resources-unsubscribe' against server: http://localhost:18799/mcp
-2026/04/22 20:34:47 Starting MCP-GET-SSE SSE connection: 9817d0ca4d07a03cf3e45c61912465b2
-2026/04/22 20:34:47 SSEHub: registered connection 9817d0ca4d07a03cf3e45c61912465b2 (total: 1)
-2026/04/22 20:34:47 SSEHub: unregistered connection 9817d0ca4d07a03cf3e45c61912465b2 (total: 0)
-2026/04/22 20:34:47 Received kill signal.  Quitting Writer. stop 0x1b2ab3d33500
-2026/04/22 20:34:47 Cleaning up writer...
-2026/04/22 20:34:47 Finished cleaning up writer:  0x1b2ab3d33500
-2026/04/22 20:34:47 Closed MCP-GET-SSE SSE connection: 9817d0ca4d07a03cf3e45c61912465b2
+2026/04/22 22:27:02 Received kill signal.  Quitting Writer. stop 0x4fcda70eaf0
+2026/04/22 22:27:02 Cleaning up writer...
+2026/04/22 22:27:02 Finished cleaning up writer:  0x4fcda70eaf0
+2026/04/22 22:27:02 Closed MCP-GET-SSE SSE connection: 2a05bd481a9f69da179a1b5fb0efd5d9
+2026/04/22 22:27:02 Starting MCP-GET-SSE SSE connection: 0cb9a9d809156b7c34b7a3aebe4195c2
+2026/04/22 22:27:02 SSEHub: registered connection 0cb9a9d809156b7c34b7a3aebe4195c2 (total: 1)
 
 === Running scenario: prompts-list ===
+2026/04/22 22:27:02 SSEHub: unregistered connection 0cb9a9d809156b7c34b7a3aebe4195c2 (total: 0)
 Running client scenario 'prompts-list' against server: http://localhost:18799/mcp
-2026/04/22 20:34:47 Starting MCP-GET-SSE SSE connection: b5bf6b0035b92f9c2577d3718d8ba5fa
-2026/04/22 20:34:47 SSEHub: registered connection b5bf6b0035b92f9c2577d3718d8ba5fa (total: 1)
-2026/04/22 20:34:47 SSEHub: unregistered connection b5bf6b0035b92f9c2577d3718d8ba5fa (total: 0)
-2026/04/22 20:34:47 Received kill signal.  Quitting Writer. stop 0x1b2ab3d9d180
-2026/04/22 20:34:47 Cleaning up writer...
-2026/04/22 20:34:47 Finished cleaning up writer:  0x1b2ab3d9d180
-2026/04/22 20:34:47 Closed MCP-GET-SSE SSE connection: b5bf6b0035b92f9c2577d3718d8ba5fa
+2026/04/22 22:27:02 Received kill signal.  Quitting Writer. stop 0x4fcda635880
+2026/04/22 22:27:02 Cleaning up writer...
+2026/04/22 22:27:02 Finished cleaning up writer:  0x4fcda635880
+2026/04/22 22:27:02 Closed MCP-GET-SSE SSE connection: 0cb9a9d809156b7c34b7a3aebe4195c2
+2026/04/22 22:27:02 Starting MCP-GET-SSE SSE connection: b05282fabc1b8ee945a9a91541bcf64f
+2026/04/22 22:27:02 SSEHub: registered connection b05282fabc1b8ee945a9a91541bcf64f (total: 1)
+2026/04/22 22:27:02 SSEHub: unregistered connection b05282fabc1b8ee945a9a91541bcf64f (total: 0)
+2026/04/22 22:27:02 Received kill signal.  Quitting Writer. stop 0x4fcda70ed20
+2026/04/22 22:27:02 Cleaning up writer...
+2026/04/22 22:27:02 Finished cleaning up writer:  0x4fcda70ed20
+2026/04/22 22:27:02 Closed MCP-GET-SSE SSE connection: b05282fabc1b8ee945a9a91541bcf64f
 
 === Running scenario: prompts-get-simple ===
 Running client scenario 'prompts-get-simple' against server: http://localhost:18799/mcp
-2026/04/22 20:34:47 Starting MCP-GET-SSE SSE connection: 889fcb61bfbf9eb28c4ed3cef6446f55
-2026/04/22 20:34:47 SSEHub: registered connection 889fcb61bfbf9eb28c4ed3cef6446f55 (total: 1)
-2026/04/22 20:34:47 SSEHub: unregistered connection 889fcb61bfbf9eb28c4ed3cef6446f55 (total: 0)
-2026/04/22 20:34:47 Received kill signal.  Quitting Writer. stop 0x1b2ab3d33810
-2026/04/22 20:34:47 Cleaning up writer...
+2026/04/22 22:27:02 Starting MCP-GET-SSE SSE connection: 4f6979bd70d3caa1ad9c92f6a9ad2696
+2026/04/22 22:27:02 SSEHub: registered connection 4f6979bd70d3caa1ad9c92f6a9ad2696 (total: 1)
+2026/04/22 22:27:02 SSEHub: unregistered connection 4f6979bd70d3caa1ad9c92f6a9ad2696 (total: 0)
+2026/04/22 22:27:02 Received kill signal.  Quitting Writer. stop 0x4fcda635c00
+2026/04/22 22:27:02 Cleaning up writer...
+2026/04/22 22:27:02 Finished cleaning up writer:  0x4fcda635c00
 
 === Running scenario: prompts-get-with-args ===
-2026/04/22 20:34:47 Finished cleaning up writer:  0x1b2ab3d33810
-2026/04/22 20:34:47 Closed MCP-GET-SSE SSE connection: 889fcb61bfbf9eb28c4ed3cef6446f55
+2026/04/22 22:27:02 Closed MCP-GET-SSE SSE connection: 4f6979bd70d3caa1ad9c92f6a9ad2696
 Running client scenario 'prompts-get-with-args' against server: http://localhost:18799/mcp
-2026/04/22 20:34:47 Starting MCP-GET-SSE SSE connection: ccaa5189ccdab1658465649c4ae0816f
-2026/04/22 20:34:47 SSEHub: registered connection ccaa5189ccdab1658465649c4ae0816f (total: 1)
-2026/04/22 20:34:47 SSEHub: unregistered connection ccaa5189ccdab1658465649c4ae0816f (total: 0)
-2026/04/22 20:34:47 Received kill signal.  Quitting Writer. stop 0x1b2ab3d33ab0
-2026/04/22 20:34:47 Cleaning up writer...
-2026/04/22 20:34:47 Finished cleaning up writer:  0x1b2ab3d33ab0
+2026/04/22 22:27:02 Starting MCP-GET-SSE SSE connection: ef46bd4892acf60d8e6e97df0e5580bd
+2026/04/22 22:27:02 SSEHub: registered connection ef46bd4892acf60d8e6e97df0e5580bd (total: 1)
+2026/04/22 22:27:02 SSEHub: unregistered connection ef46bd4892acf60d8e6e97df0e5580bd (total: 0)
+2026/04/22 22:27:02 Received kill signal.  Quitting Writer. stop 0x4fcda5b1340
+2026/04/22 22:27:02 Cleaning up writer...
 
 === Running scenario: prompts-get-embedded-resource ===
-2026/04/22 20:34:47 Closed MCP-GET-SSE SSE connection: ccaa5189ccdab1658465649c4ae0816f
+2026/04/22 22:27:02 Finished cleaning up writer:  0x4fcda5b1340
+2026/04/22 22:27:02 Closed MCP-GET-SSE SSE connection: ef46bd4892acf60d8e6e97df0e5580bd
 Running client scenario 'prompts-get-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/22 20:34:47 Starting MCP-GET-SSE SSE connection: 3fe5c3318c9cf118644d0d5a21fe629b
-2026/04/22 20:34:47 SSEHub: registered connection 3fe5c3318c9cf118644d0d5a21fe629b (total: 1)
-2026/04/22 20:34:47 SSEHub: unregistered connection 3fe5c3318c9cf118644d0d5a21fe629b (total: 0)
-2026/04/22 20:34:47 Received kill signal.  Quitting Writer. stop 0x1b2ab39cb650
-2026/04/22 20:34:47 Cleaning up writer...
-2026/04/22 20:34:47 Finished cleaning up writer:  0x1b2ab39cb650
-2026/04/22 20:34:47 Closed MCP-GET-SSE SSE connection: 3fe5c3318c9cf118644d0d5a21fe629b
+2026/04/22 22:27:02 Starting MCP-GET-SSE SSE connection: 5582c80e07e4a0f421b22863b41dbef4
+2026/04/22 22:27:02 SSEHub: registered connection 5582c80e07e4a0f421b22863b41dbef4 (total: 1)
+2026/04/22 22:27:02 SSEHub: unregistered connection 5582c80e07e4a0f421b22863b41dbef4 (total: 0)
 
 === Running scenario: prompts-get-with-image ===
+2026/04/22 22:27:02 Received kill signal.  Quitting Writer. stop 0x4fcda6a1ce0
 Running client scenario 'prompts-get-with-image' against server: http://localhost:18799/mcp
-2026/04/22 20:34:47 Starting MCP-GET-SSE SSE connection: 6b1014062b926dea5d3241ef9e9dbff2
-2026/04/22 20:34:47 SSEHub: registered connection 6b1014062b926dea5d3241ef9e9dbff2 (total: 1)
-2026/04/22 20:34:47 SSEHub: unregistered connection 6b1014062b926dea5d3241ef9e9dbff2 (total: 0)
-2026/04/22 20:34:47 Received kill signal.  Quitting Writer. stop 0x1b2ab3d9d490
-2026/04/22 20:34:47 Cleaning up writer...
-2026/04/22 20:34:47 Finished cleaning up writer:  0x1b2ab3d9d490
+2026/04/22 22:27:02 Cleaning up writer...
+2026/04/22 22:27:02 Finished cleaning up writer:  0x4fcda6a1ce0
+2026/04/22 22:27:02 Closed MCP-GET-SSE SSE connection: 5582c80e07e4a0f421b22863b41dbef4
+2026/04/22 22:27:02 Starting MCP-GET-SSE SSE connection: 0cfa1834a837f76cd8c4525858269cd6
+2026/04/22 22:27:02 SSEHub: registered connection 0cfa1834a837f76cd8c4525858269cd6 (total: 1)
+2026/04/22 22:27:02 SSEHub: unregistered connection 0cfa1834a837f76cd8c4525858269cd6 (total: 0)
+2026/04/22 22:27:02 Received kill signal.  Quitting Writer. stop 0x4fcda6a1f10
+2026/04/22 22:27:02 Cleaning up writer...
 
 === Running scenario: dns-rebinding-protection ===
-2026/04/22 20:34:47 Closed MCP-GET-SSE SSE connection: 6b1014062b926dea5d3241ef9e9dbff2
+2026/04/22 22:27:02 Finished cleaning up writer:  0x4fcda6a1f10
+2026/04/22 22:27:02 Closed MCP-GET-SSE SSE connection: 0cfa1834a837f76cd8c4525858269cd6
 Running client scenario 'dns-rebinding-protection' against server: http://localhost:18799/mcp
 
 
@@ -343,4 +343,4 @@ Total: 40 passed, 0 failed
 [32mBaseline check passed: all failures are expected.[0m
 
 === CONFORMANCE TESTS PASSED ===
-Finished: Wed Apr 22 20:34:47 PDT 2026
+Finished: Wed Apr 22 22:27:02 PDT 2026

--- a/tests/reports/stage-e2e.log
+++ b/tests/reports/stage-e2e.log
@@ -1,6 +1,6 @@
 === Stage 6/10: e2e (make test-e2e) ===
-Started: Wed Apr 22 20:34:31 PDT 2026
+Started: Wed Apr 22 22:26:44 PDT 2026
 cd tests/e2e && go test ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/tests/e2e	3.918s
-ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.965s
-Finished: Wed Apr 22 20:34:36 PDT 2026
+ok  	github.com/panyam/mcpkit/tests/e2e	4.771s
+ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.682s
+Finished: Wed Apr 22 22:26:50 PDT 2026

--- a/tests/reports/stage-experimental.log
+++ b/tests/reports/stage-experimental.log
@@ -1,5 +1,5 @@
 === Stage 7/10: experimental (make test-experimental) ===
-Started: Wed Apr 22 20:34:36 PDT 2026
+Started: Wed Apr 22 22:26:50 PDT 2026
 cd experimental/telegram-events && go test ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/experimental/telegram-events	5.528s
-Finished: Wed Apr 22 20:34:42 PDT 2026
+ok  	github.com/panyam/mcpkit/experimental/telegram-events	5.562s
+Finished: Wed Apr 22 22:26:56 PDT 2026

--- a/tests/reports/stage-keycloak.log
+++ b/tests/reports/stage-keycloak.log
@@ -1,9 +1,9 @@
 === Stage 10/10: keycloak (make testkcl-auto) ===
-Started: Wed Apr 22 20:34:49 PDT 2026
+Started: Wed Apr 22 22:27:04 PDT 2026
 Starting Keycloak for interop tests...
 mcpkit-keycloak
-e6e04e923b1bf88b8072ccc5031379c3961a60c33e29a938420093986acc9472
-docker: Error response from daemon: failed to set up container networking: driver failed programming external connectivity on endpoint mcpkit-keycloak (dff84c05d3de2e1a87ea32b8914c18341cb2799ab9d25ba1e528069a524f2f2b): Bind for 0.0.0.0:8180 failed: port is already allocated
+13297f6bbd0b64128a80157e95cab8b93a77e362c4a2e93f21f85364fbd4d376
+docker: Error response from daemon: failed to set up container networking: driver failed programming external connectivity on endpoint mcpkit-keycloak (2b9ee3a6845386c41b2e9af234eea18c276be905bba15bd834752dd7d06086a4): Bind for 0.0.0.0:8180 failed: port is already allocated
 
 Run 'docker run --help' for more information
 Keycloak starting on port 8180... (realm import takes ~30s)
@@ -46,6 +46,6 @@ Waiting for Keycloak realm...
     token_refresh_test.go:22: Keycloak realm mcpkit-test not ready (status 404)
 --- SKIP: TestKeycloak_TokenRefresh_PasswordGrant (0.00s)
 PASS
-ok  	github.com/panyam/mcpkit/tests/keycloak	0.747s
+ok  	github.com/panyam/mcpkit/tests/keycloak	0.672s
 make[2]: *** No rule to make target `downkcl'.  Stop.
-Finished: Wed Apr 22 20:36:54 PDT 2026
+Finished: Wed Apr 22 22:29:09 PDT 2026

--- a/tests/reports/stage-protogen.log
+++ b/tests/reports/stage-protogen.log
@@ -1,11 +1,11 @@
 === Stage 5/10: protogen (make test-protogen) ===
-Started: Wed Apr 22 20:34:25 PDT 2026
+Started: Wed Apr 22 22:26:39 PDT 2026
 cd experimental/ext/protogen && go test ./... -count=1 -timeout 30s && /Library/Developer/CommandLineTools/usr/bin/make test-e2e
 ?   	github.com/panyam/mcpkit/experimental/ext/protogen/cmd/protoc-gen-go-mcp	[no test files]
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/generator	0.898s
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/proto/mcp/v1	1.159s
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/runtime	0.661s
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/schema	1.470s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/generator	0.966s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/proto/mcp/v1	0.357s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/runtime	1.255s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/schema	0.665s
 ?   	github.com/panyam/mcpkit/experimental/ext/protogen/testutil	[no test files]
 go build -o bin/protoc-gen-go-mcp ./cmd/protoc-gen-go-mcp
 go install ./cmd/protoc-gen-go-mcp
@@ -14,6 +14,6 @@ cd ../../../examples/protogen/bookservice && rm -rf gen && buf generate && go te
 [33mWARN[0m	plugin "protoc-gen-go-mcp" does not support required features.
   Feature "proto3 optional" is required by 1 file(s):
     bookservice/v1/service.proto
-ok  	github.com/panyam/mcpkit/examples/protogen/bookservice	0.708s
+ok  	github.com/panyam/mcpkit/examples/protogen/bookservice	0.808s
 ==> e2e: passed
-Finished: Wed Apr 22 20:34:31 PDT 2026
+Finished: Wed Apr 22 22:26:44 PDT 2026

--- a/tests/reports/stage-race.log
+++ b/tests/reports/stage-race.log
@@ -1,9 +1,9 @@
 === Stage 2/10: race (make test-race) ===
-Started: Wed Apr 22 20:34:04 PDT 2026
+Started: Wed Apr 22 22:26:20 PDT 2026
 go test -race ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/client	9.005s
+ok  	github.com/panyam/mcpkit/client	10.278s
 ?   	github.com/panyam/mcpkit/cmd/testserver	[no test files]
-ok  	github.com/panyam/mcpkit/core	1.930s
-ok  	github.com/panyam/mcpkit/server	12.043s
-ok  	github.com/panyam/mcpkit/testutil	1.542s
-Finished: Wed Apr 22 20:34:20 PDT 2026
+ok  	github.com/panyam/mcpkit/core	1.373s
+ok  	github.com/panyam/mcpkit/server	11.474s
+ok  	github.com/panyam/mcpkit/testutil	1.859s
+Finished: Wed Apr 22 22:26:35 PDT 2026

--- a/tests/reports/stage-ui.log
+++ b/tests/reports/stage-ui.log
@@ -1,8 +1,8 @@
 === Stage 4/10: ui (make test-ui) ===
-Started: Wed Apr 22 20:34:21 PDT 2026
+Started: Wed Apr 22 22:26:36 PDT 2026
 cd ext/ui && /Library/Developer/CommandLineTools/usr/bin/make test
 go test ./... -count=1 -timeout 30s
-ok  	github.com/panyam/mcpkit/ext/ui	0.586s
+ok  	github.com/panyam/mcpkit/ext/ui	0.347s
 cd assets && pnpm install --frozen-lockfile --silent && pnpm test
 
 > @mcpkit/app-bridge@0.1.0 test /Users/dzshrh/newstack/mcpkit/pocs/ext/ui/assets
@@ -11,11 +11,11 @@ cd assets && pnpm install --frozen-lockfile --silent && pnpm test
 
  RUN  v3.2.4 /Users/dzshrh/newstack/mcpkit/pocs/ext/ui/assets
 
- ✓ mcp-app-bridge.test.ts (33 tests) 403ms
+ ✓ mcp-app-bridge.test.ts (33 tests) 383ms
 
  Test Files  1 passed (1)
       Tests  33 passed (33)
-   Start at  20:34:24
-   Duration  1.22s (transform 31ms, setup 0ms, collect 28ms, tests 403ms, environment 476ms, prepare 129ms)
+   Start at  22:26:38
+   Duration  1.11s (transform 31ms, setup 0ms, collect 28ms, tests 383ms, environment 384ms, prepare 134ms)
 
-Finished: Wed Apr 22 20:34:25 PDT 2026
+Finished: Wed Apr 22 22:26:39 PDT 2026

--- a/tests/reports/stage-unit+coverage.log
+++ b/tests/reports/stage-unit+coverage.log
@@ -1,11 +1,11 @@
 === Stage 1/10: unit+coverage (make cover-html) ===
-Started: Wed Apr 22 20:33:51 PDT 2026
+Started: Wed Apr 22 22:26:07 PDT 2026
 go test -coverprofile=tests/reports/coverage.out ./... -count=1 -timeout 30s
-ok  	github.com/panyam/mcpkit/client	9.169s	coverage: 63.4% of statements
+ok  	github.com/panyam/mcpkit/client	8.073s	coverage: 62.9% of statements
 	github.com/panyam/mcpkit/cmd/testserver		coverage: 0.0% of statements
-ok  	github.com/panyam/mcpkit/core	0.558s	coverage: 50.0% of statements
-ok  	github.com/panyam/mcpkit/server	10.543s	coverage: 80.9% of statements
-ok  	github.com/panyam/mcpkit/testutil	0.753s	coverage: 69.4% of statements
+ok  	github.com/panyam/mcpkit/core	0.398s	coverage: 50.0% of statements
+ok  	github.com/panyam/mcpkit/server	10.537s	coverage: 81.1% of statements
+ok  	github.com/panyam/mcpkit/testutil	0.502s	coverage: 69.4% of statements
 go tool cover -html=tests/reports/coverage.out -o tests/reports/coverage.html
 Coverage report: tests/reports/coverage.html
-Finished: Wed Apr 22 20:34:04 PDT 2026
+Finished: Wed Apr 22 22:26:20 PDT 2026


### PR DESCRIPTION
## Summary

Two independent fixes bundled:

- **#294**: Keepalive ping returning method-not-found (-32601) no longer kills the session. A method-not-found response proves the connection is alive.
- **#284**: Initialize returns SSE when client sends `Accept: text/event-stream`, matching TS SDK behavior. Falls back to JSON otherwise.

## Changes

| File | What |
|------|------|
| `server/request.go` | `ServerRequestError` typed error (replaces `fmt.Errorf`), `IsMethodNotFound()` helper |
| `server/keepalive.go` | Check `IsMethodNotFound` before counting failure — reset counter instead |
| `client/client.go` | Check `resp.Error.Code` for -32601 in client keepalive (hardens fragile path) |
| `server/streamable_transport.go` | Remove initialize block from `shouldStreamSSE`, add SSE path in `handleInitialize` |
| `server/keepalive_test.go` | `TestKeepaliveMethodNotFoundDoesNotKillSession`, `TestIsMethodNotFound` (3 cases) |
| `server/content_type_test.go` | `TestInitializeReturnsSSEWhenAccepted`, `TestInitializeReturnsJSONWhenNotAccepted` |
| `CLAUDE.md` | Update gotcha: initialize now returns SSE or JSON |

## Test plan

- [x] `TestKeepaliveMethodNotFoundDoesNotKillSession` — method-not-found doesn't trigger session death
- [x] `TestIsMethodNotFound` — typed error detection (3 sub-cases)
- [x] `TestInitializeReturnsSSEWhenAccepted` — SSE format with correct headers
- [x] `TestInitializeReturnsJSONWhenNotAccepted` — JSON format preserved
- [x] All existing tests pass (core, client, server)

Closes #284, closes #294