### PR TITLE
feat: SEP-2322 MRTR + SEP-2663 task types + extension negotiation (Phases 1-3)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,159 @@
+# Plan: SEP-2322 (MRTR) + SEP-2663 (Tasks Extension)
+
+**Issues:** mcpkit#320 (SEP-2663), mcpkit#321 (SEP-2322)
+**Branch:** `feat/tasks-extension` (from main)
+**Approach:** Evolve v2 in place (Option B). No parallel files.
+
+## Key decisions
+
+- **MRTR types in core/** — SEP-2322 is accepted (10/10 vote). Track with `// SEP-2322` / `// SEP-2663` comment annotations for grep-able audit when specs finalize.
+- **No `_Ext` suffix** — v2 types become THE types: `CreateTaskResult`, `DetailedTask`, `UpdateTaskRequest`, etc.
+- **Types stay in core/, handlers in server/** — tasks is too deeply woven into dispatch/middleware for ext/tasks. Wire protocol says extension; implementation is core.
+- **v1 stays frozen** — rename `tasks_experimental.go` → `tasks_v1.go`, keep `RegisterTasksV1()`. 27/27 conformance preserved.
+- **v2 evolves** — `tasks_v2.go` and `core/task_v2.go` get updated in place to match SEP-2663.
+- **Client evolves** — `client/tasks.go` updated to new shapes. No v1 client preserved (conformance tests are the safety net).
+
+## Constraints
+
+| Constraint | Status |
+|------------|--------|
+| C1 (typed contexts) | OK — `TaskContext` already typed |
+| C2 (consolidated entry structs) | OK — `taskEntry` consolidated |
+| C3 (no global mutable state) | OK — scoped to `v2TaskRuntime` |
+| server/C4 (no spec extensions without WG) | OK — implementing Agents WG spec |
+
+## Phase 1: MRTR base types
+
+**Files:** `core/task_v2.go` (modify)
+
+- [ ] Add `ResultType` constants: `ResultTypeComplete = "complete"`, `ResultTypeIncomplete = "incomplete"` (keep `ResultTypeTask = "task"`)
+- [ ] Add `InputRequest` struct: `Method string`, `Params json.RawMessage` // SEP-2322
+- [ ] Add type aliases: `InputRequests = map[string]InputRequest`, `InputResponses = map[string]json.RawMessage`
+- [ ] Ensure `RequestState` field exists on result types // SEP-2322
+
+**Test:** JSON marshal/unmarshal round-trip for all `ResultType` values, `InputRequest` shapes.
+
+## Phase 2: SEP-2663 task types
+
+**Files:** `core/task_v2.go` (evolve)
+
+- [ ] `CreateTaskResult` — remove `Result`, `Error`, `InputRequests` fields (MUST NOT carry these per SEP-2663)
+- [ ] `DetailedTask` discriminated union types: `WorkingTask`, `InputRequiredTask`, `CompletedTask`, `FailedTask`, `CancelledTask`
+- [ ] `GetTaskResult` — returns `DetailedTask`
+- [ ] `UpdateTaskRequest` (new): `TaskID`, `InputResponses`, `RequestState` // SEP-2663
+- [ ] `UpdateTaskResult` — empty ack
+- [ ] `CancelTaskResult` — empty ack (no task state)
+- [ ] Wire fields: `TTLSeconds *int`, `PollIntervalMilliseconds *int` (renamed per pja-ant feedback)
+- [ ] Remove `ParentTaskID` (not in SEP-2663)
+- [ ] Keep internal TTL storage as ms, convert at wire boundary
+
+**Test:** JSON shapes match SEP-2663 examples exactly (wire-format comparison against spec examples).
+
+## Phase 3: Extension capability negotiation
+
+**Files:** `core/session.go`, `server/dispatch.go`
+
+- [ ] Register `io.modelcontextprotocol/tasks` as extension via `caps.Extensions`
+- [ ] Remove `TasksCap`/`ServerCapabilities.Tasks` for extension path (v1 keeps its own)
+- [ ] Gate task creation on `ClientSupportsExtension(ctx, "io.modelcontextprotocol/tasks")`
+- [ ] Remove per-tool `ToolExecution.TaskSupport` gating — server decides unilaterally
+- [ ] Support per-request capabilities via `_meta.io.modelcontextprotocol/clientCapabilities` (SEP-2575 pattern)
+
+**Test:** Server returns `-32601` for `tasks/*` when extension not negotiated. Server MUST NOT return `CreateTaskResult` without extension.
+
+## Phase 4: Server handlers
+
+**Files:** `server/tasks_v2.go` (evolve)
+
+- [ ] Rename `RegisterTasksV2` → `RegisterTasks` (THE registration)
+- [ ] `tasks/get` → pure idempotent read, returns `DetailedTask`
+- [ ] `tasks/update` (new handler) → accepts `InputResponses`, returns empty ack
+- [ ] `tasks/cancel` → returns empty ack (not task state)
+- [ ] Server-directed task creation: middleware creates task for ANY tool when server decides
+- [ ] `resultType: "task"` discriminator on `CreateTaskResult`
+- [ ] Set `Mcp-Name` header to `taskId` in HTTP transport for routing // SEP-2243
+
+**Also:**
+- [ ] Rename `tasks_experimental.go` → `tasks_v1.go`
+- [ ] Rename `RegisterTasks` (old v1) → `RegisterTasksV1`
+
+**Test:** Unit tests for each handler, error cases, ack-only responses.
+
+## Phase 5: inputRequests/inputResponses flow
+
+**Files:** `server/task_session.go` (modify), `server/tasks_v2.go`
+
+Replace v1 side-channel pattern with poll-based input:
+
+- [ ] `TaskContext.TaskElicit()`:
+  1. Generate stable key (monotonic counter per task, e.g. `"elicit-1"`)
+  2. Store `ElicitationRequest` in `taskEntry.pendingInputRequests`
+  3. Transition task to `input_required`
+  4. Block on response channel keyed by request key
+- [ ] `TaskContext.TaskSample()`: same pattern for `sampling/createMessage`
+- [ ] `tasks/get` handler: read `pendingInputRequests` → populate `inputRequests` in response
+- [ ] `tasks/update` handler: match `inputResponses` keys → deliver to waiting goroutine
+- [ ] Key uniqueness: monotonic counter, never reused over task lifetime
+
+**Test:** Integration test: `confirm_delete` tool → poll → `input_required` with `inputRequests` → `tasks/update` → poll → `completed`.
+
+## Phase 6: Client
+
+**Files:** `client/tasks.go` (evolve)
+
+- [ ] Remove `ToolCallAsTask()` (no client opt-in)
+- [ ] `GetTask()` → returns `DetailedTask` with inlined result/error/inputRequests + `requestState`
+- [ ] `UpdateTask(taskId, inputResponses, requestState)` (new)
+- [ ] `CancelTask()` → returns empty (no task state)
+- [ ] Remove `GetTaskPayload()` (`tasks/result` gone)
+- [ ] Remove `ListTasks()` (`tasks/list` gone)
+- [ ] `WaitForTask()` → poll loop, respects `PollIntervalMilliseconds`, echoes `requestState`
+- [ ] Handle polymorphic `tools/call` result: check `resultType` field
+
+**Test:** Mock server returning each result shape, polymorphic dispatch.
+
+## Phase 7: Example server + conformance
+
+**Files:** `examples/tasks-v2/` (evolve), `conformance/tasks-v2/` (evolve)
+
+Example server tools:
+- `greet` — sync, always returns `CallToolResult`
+- `slow_compute` — async, returns `CreateTaskResult`, completes after delay
+- `failing_job` — async, transitions to `failed` (protocol error)
+- `confirm_delete` — async, transitions to `input_required`, resumes via `tasks/update`
+
+Conformance evolution (from mcpkit#320 comment):
+- Keep passing scenarios, adjust shapes (ack-only cancel, etc.)
+- Rework v2-11 → extension negotiation
+- Rework v2-16/v2-17 → `tasks/update` flow (currently unimplemented)
+- Add new: ext negotiation gate, polymorphic result, Mcp-Name header
+- Keep v1 suite frozen alongside
+
+## Phase 8: Backward compat bridge
+
+- [ ] `RegisterTasksV1()` stays for `2025-11-25` clients
+- [ ] `RegisterTasks()` (new) for extension-based clients
+- [ ] Both can coexist — dispatch based on negotiated capability
+- [ ] Document migration path in README
+
+## Implementation order
+
+```
+Phase 1 (MRTR types) → Phase 2 (task types) → Phase 3 (capability) →
+Phase 4 (server handlers) → Phase 5 (inputRequests flow) →
+Phase 6 (client) → Phase 7 (example + conformance) → Phase 8 (bridge)
+```
+
+## Open spec questions (watch before finalizing)
+
+1. `requestState` rejection: synchronous `-32602` or silent? (Luca TBD)
+2. SEP-2575 per-request capabilities shape — may change
+3. `tasks/update` / `tasks/cancel` ack for unknown taskId — may add optional validation errors
+
+## Reference
+
+- SEP-2663 PR: https://github.com/modelcontextprotocol/specification/pull/2663
+- SEP-2322 PR: https://github.com/modelcontextprotocol/specification/pull/2322
+- SEP-2663 analysis: mcpkit#320
+- Existing v2 PR: mcpkit#301 (19/21 conformance)
+- Conformance test evolution: mcpkit#320 comment

--- a/PLAN.md
+++ b/PLAN.md
@@ -144,6 +144,19 @@ Phase 4 (server handlers) → Phase 5 (inputRequests flow) →
 Phase 6 (client) → Phase 7 (example + conformance) → Phase 8 (bridge)
 ```
 
+## Deferred cleanup
+
+- **`TaskInfoV2` → `TaskInfo` rename** (deliberately deferred during Phase 2).
+  Rationale: the existing `TaskInfo` (in `core/task.go`) is *not* strictly a
+  v1 wire type — it's the internal `TaskStore` record (`server/task_store.go`,
+  `server/task_session.go`) that happens to also serialize as the v1 wire
+  shape. Renaming it to `TaskInfoV1` would conflate "internal storage" with
+  "v1 protocol shape" and stop being true the moment the store record needs
+  fields the wire doesn't expose. Revisit when:
+  - the v1 path is removed (then `TaskInfoV2` can simply become `TaskInfo`), or
+  - the store record needs to diverge from the v1 wire shape (then introduce
+    a dedicated `taskRecord` type and free up `TaskInfo` for the v2 wire).
+
 ## Open spec questions (watch before finalizing)
 
 1. `requestState` rejection: synchronous `-32602` or silent? (Luca TBD)

--- a/client/client.go
+++ b/client/client.go
@@ -229,6 +229,14 @@ func WithUIExtension() ClientOption {
 	})
 }
 
+// WithTasksExtension advertises SEP-2663 Tasks support
+// (io.modelcontextprotocol/tasks). v2 servers gate task creation and the
+// tasks/* methods on this declaration — clients that omit it see synchronous
+// tools/call responses and -32601 for tasks/get / tasks/cancel / tasks/update.
+func WithTasksExtension() ClientOption {
+	return WithExtension(core.TasksExtensionID, core.ClientExtensionCap{})
+}
+
 // WithTransport sets a core.Transport for the client, bypassing the default
 // HTTP transport creation. Use with server.NewInProcessTransport for testing
 // or embedded scenarios.

--- a/client/tasks.go
+++ b/client/tasks.go
@@ -76,14 +76,14 @@ func IsToolTask(tool core.ToolDef) bool {
 
 // --- Client helpers ---
 
-// GetTask polls the status of a task by ID. Non-blocking.
+// GetTask polls the status of a v1 task by ID. Non-blocking.
 // Per MCP spec 2025-11-25 §tasks/get: returns flat Result & Task.
-func GetTask(c *Client, taskID string) (*core.GetTaskResult, error) {
+func GetTask(c *Client, taskID string) (*core.GetTaskResultV1, error) {
 	result, err := c.Call("tasks/get", getTaskParams{TaskID: taskID})
 	if err != nil {
 		return nil, err
 	}
-	var r core.GetTaskResult
+	var r core.GetTaskResultV1
 	if err := json.Unmarshal(result.Raw, &r); err != nil {
 		return nil, fmt.Errorf("unmarshal tasks/get: %w", err)
 	}
@@ -110,42 +110,44 @@ func GetTaskPayload(c *Client, taskID string) (*core.ToolResult, string, error) 
 	return &r, relatedID, nil
 }
 
-// ListTasks returns all tasks with cursor-based pagination.
+// ListTasks returns all v1 tasks with cursor-based pagination.
 // Pass an empty cursor to start from the beginning.
-func ListTasks(c *Client, cursor string) (*core.ListTasksResult, error) {
+// (Removed in v2 — tasks/list is no longer part of the protocol.)
+func ListTasks(c *Client, cursor string) (*core.ListTasksResultV1, error) {
 	result, err := c.Call("tasks/list", listTasksParams{Cursor: cursor})
 	if err != nil {
 		return nil, err
 	}
-	var r core.ListTasksResult
+	var r core.ListTasksResultV1
 	if err := json.Unmarshal(result.Raw, &r); err != nil {
 		return nil, fmt.Errorf("unmarshal tasks/list: %w", err)
 	}
 	return &r, nil
 }
 
-// CancelTask cancels a running task. Returns an error if the task is
+// CancelTask cancels a running v1 task. Returns an error if the task is
 // already in a terminal state.
 // Per MCP spec 2025-11-25 §tasks/cancel: returns flat Result & Task.
-func CancelTask(c *Client, taskID string) (*core.CancelTaskResult, error) {
+func CancelTask(c *Client, taskID string) (*core.CancelTaskResultV1, error) {
 	result, err := c.Call("tasks/cancel", cancelTaskParams{TaskID: taskID})
 	if err != nil {
 		return nil, err
 	}
-	var r core.CancelTaskResult
+	var r core.CancelTaskResultV1
 	if err := json.Unmarshal(result.Raw, &r); err != nil {
 		return nil, fmt.Errorf("unmarshal tasks/cancel: %w", err)
 	}
 	return &r, nil
 }
 
-// ToolCallAsTask invokes a tool with a task hint, returning a CreateTaskResult
-// instead of the immediate tool result. The server creates a task and runs
-// the tool asynchronously.
+// ToolCallAsTask invokes a v1 tool with a task hint, returning a
+// CreateTaskResultV1 instead of the immediate tool result. The server
+// creates a task and runs the tool asynchronously.
 //
 // Pass nil for opts to use server defaults. Per MCP spec 2025-11-25:
 // task hint at params.task, progressToken at params._meta.progressToken.
-func ToolCallAsTask(c *Client, name string, args any, opts ...*TaskCallOptions) (*core.CreateTaskResult, error) {
+// (V2 removes the client task hint — the server decides unilaterally.)
+func ToolCallAsTask(c *Client, name string, args any, opts ...*TaskCallOptions) (*core.CreateTaskResultV1, error) {
 	params := toolCallAsTaskParams{
 		Name:      name,
 		Arguments: args,
@@ -161,7 +163,7 @@ func ToolCallAsTask(c *Client, name string, args any, opts ...*TaskCallOptions) 
 	if err != nil {
 		return nil, err
 	}
-	var r core.CreateTaskResult
+	var r core.CreateTaskResultV1
 	if err := json.Unmarshal(result.Raw, &r); err != nil {
 		return nil, fmt.Errorf("unmarshal task creation: %w", err)
 	}
@@ -176,7 +178,7 @@ func ToolCallAsTask(c *Client, name string, args any, opts ...*TaskCallOptions) 
 //
 // This is a convenience wrapper around GetTask for the common pattern
 // of polling until completion.
-func WaitForTask(ctx context.Context, c *Client, taskID string, pollInterval time.Duration) (*core.GetTaskResult, error) {
+func WaitForTask(ctx context.Context, c *Client, taskID string, pollInterval time.Duration) (*core.GetTaskResultV1, error) {
 	if pollInterval <= 0 {
 		pollInterval = 1 * time.Second
 	}

--- a/core/session.go
+++ b/core/session.go
@@ -103,6 +103,48 @@ func ClientSupportsExtension(ctx context.Context, extensionID string) bool {
 	return ok
 }
 
+// PerRequestClientCapsKey is the SEP-2575 _meta key under which a client may
+// declare a per-request capability override. The value is shaped like
+// ClientCapabilities and is merged additively on top of the session-level
+// capabilities for the duration of one request.
+const PerRequestClientCapsKey = "io.modelcontextprotocol/clientCapabilities"
+
+// PerRequestClientCaps decodes the SEP-2575 per-request client-capabilities
+// override from raw JSON bytes (typically the value of _meta[PerRequestClientCapsKey]
+// in the calling middleware's typed envelope). Returns nil if the bytes are
+// empty or malformed — the caller falls back to session-level caps.
+func PerRequestClientCaps(raw json.RawMessage) *ClientCapabilities {
+	if len(raw) == 0 {
+		return nil
+	}
+	var caps ClientCapabilities
+	if err := json.Unmarshal(raw, &caps); err != nil {
+		return nil
+	}
+	return &caps
+}
+
+// ClientSupportsExtensionForRequest reports whether the client supports the
+// given extension at session level (initialize handshake) OR per-request
+// level (SEP-2575 _meta override). Per-request opt-in is additive — it
+// cannot revoke a session-level declaration.
+//
+// requestCapsRaw is the raw JSON bytes from the SEP-2575 _meta override; the
+// caller extracts it from a typed envelope (e.g., a json.RawMessage field
+// tagged "io.modelcontextprotocol/clientCapabilities" inside _meta). Pass
+// an empty slice if the request had no override.
+func ClientSupportsExtensionForRequest(ctx context.Context, extensionID string, requestCapsRaw json.RawMessage) bool {
+	if ClientSupportsExtension(ctx, extensionID) {
+		return true
+	}
+	caps := PerRequestClientCaps(requestCapsRaw)
+	if caps == nil {
+		return false
+	}
+	_, ok := caps.Extensions[extensionID]
+	return ok
+}
+
 // Notify sends an arbitrary server-to-client JSON-RPC notification.
 // Returns false if no notification sender is available in the context.
 // This is the low-level API; prefer EmitLog for logging notifications.

--- a/core/task.go
+++ b/core/task.go
@@ -70,26 +70,30 @@ type TaskInfo struct {
 	PollInterval  int        `json:"pollInterval,omitempty"` // milliseconds
 }
 
-// CreateTaskResult is returned by tools/call when a task is created
-// instead of the immediate tool result. Per spec: nested under "task" key.
-type CreateTaskResult struct {
+// CreateTaskResultV1 is returned by tools/call when a v1 task is created
+// instead of the immediate tool result. Per spec 2025-11-25: nested under
+// "task" key. (V1 wire format; v2 uses CreateTaskResult with resultType.)
+type CreateTaskResultV1 struct {
 	Task TaskInfo `json:"task"`
 }
 
-// GetTaskResult is the response to tasks/get. Per spec: flat Result & Task
-// intersection — task fields at the root level, no "task" wrapper.
-type GetTaskResult struct {
+// GetTaskResultV1 is the v1 response to tasks/get. Per spec 2025-11-25:
+// flat Result & Task intersection — task fields at the root level, no "task"
+// wrapper. (V2 returns DetailedTask with inlined result/error/inputRequests.)
+type GetTaskResultV1 struct {
 	TaskInfo
 }
 
-// CancelTaskResult is the response to tasks/cancel. Per spec: flat Result & Task
-// intersection — same as GetTaskResult.
-type CancelTaskResult struct {
+// CancelTaskResultV1 is the v1 response to tasks/cancel. Per spec 2025-11-25:
+// flat Result & Task intersection — same shape as GetTaskResultV1.
+// (V2 returns an empty ack per SEP-2663.)
+type CancelTaskResultV1 struct {
 	TaskInfo
 }
 
-// ListTasksResult is the response to tasks/list with cursor pagination.
-type ListTasksResult struct {
+// ListTasksResultV1 is the v1 response to tasks/list with cursor pagination.
+// (Removed in v2 — tasks/list is no longer part of the protocol.)
+type ListTasksResultV1 struct {
 	Tasks      []TaskInfo `json:"tasks"`
 	NextCursor string     `json:"nextCursor,omitempty"`
 }

--- a/core/task_test.go
+++ b/core/task_test.go
@@ -98,10 +98,10 @@ func TestTaskInfoOmitEmpty(t *testing.T) {
 	}
 }
 
-// TestCreateTaskResultJSON verifies the CreateTaskResult envelope matches
-// the spec wire format: {"task": {...}}.
+// TestCreateTaskResultJSON verifies the v1 CreateTaskResultV1 envelope
+// matches the spec wire format: {"task": {...}}.
 func TestCreateTaskResultJSON(t *testing.T) {
-	result := CreateTaskResult{
+	result := CreateTaskResultV1{
 		Task: TaskInfo{
 			TaskID:        "task-abc",
 			Status:        TaskWorking,
@@ -240,9 +240,9 @@ func TestClientCapabilitiesWithTasks(t *testing.T) {
 	}
 }
 
-// TestListTasksResultJSON verifies pagination envelope.
+// TestListTasksResultJSON verifies the v1 pagination envelope.
 func TestListTasksResultJSON(t *testing.T) {
-	result := ListTasksResult{
+	result := ListTasksResultV1{
 		Tasks: []TaskInfo{
 			{TaskID: "t1", Status: TaskWorking, CreatedAt: "2025-01-15T10:00:00Z", LastUpdatedAt: "2025-01-15T10:00:00Z", TTL: IntPtr(30000)},
 		},
@@ -252,7 +252,7 @@ func TestListTasksResultJSON(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var decoded ListTasksResult
+	var decoded ListTasksResultV1
 	if err := json.Unmarshal(data, &decoded); err != nil {
 		t.Fatal(err)
 	}
@@ -266,11 +266,11 @@ func TestListTasksResultJSON(t *testing.T) {
 
 // --- Spec wire-format compliance tests (red-first) ---
 
-// TestGetTaskResultFlatJSON verifies that GetTaskResult serializes task fields
-// at the root level (not nested under a "task" key). Per MCP spec: tasks/get
-// returns Result & Task intersection.
+// TestGetTaskResultFlatJSON verifies that the v1 GetTaskResultV1 serializes
+// task fields at the root level (not nested under a "task" key). Per MCP
+// spec 2025-11-25: tasks/get returns Result & Task intersection.
 func TestGetTaskResultFlatJSON(t *testing.T) {
-	result := GetTaskResult{
+	result := GetTaskResultV1{
 		TaskInfo: TaskInfo{
 			TaskID:        "task-flat",
 			Status:        TaskWorking,
@@ -289,7 +289,7 @@ func TestGetTaskResultFlatJSON(t *testing.T) {
 
 	// Must NOT have a "task" wrapper key.
 	if _, ok := m["task"]; ok {
-		t.Error("GetTaskResult should serialize flat, not under a 'task' key")
+		t.Error("GetTaskResultV1 should serialize flat, not under a 'task' key")
 	}
 	// Must have taskId at root.
 	if m["taskId"] != "task-flat" {
@@ -300,10 +300,11 @@ func TestGetTaskResultFlatJSON(t *testing.T) {
 	}
 }
 
-// TestCancelTaskResultFlatJSON verifies that CancelTaskResult serializes task
-// fields at the root level. Per MCP spec: tasks/cancel returns Result & Task.
+// TestCancelTaskResultFlatJSON verifies that the v1 CancelTaskResultV1
+// serializes task fields at the root level. Per MCP spec 2025-11-25:
+// tasks/cancel returns Result & Task.
 func TestCancelTaskResultFlatJSON(t *testing.T) {
-	result := CancelTaskResult{
+	result := CancelTaskResultV1{
 		TaskInfo: TaskInfo{
 			TaskID:        "task-cancel",
 			Status:        TaskCancelled,
@@ -320,7 +321,7 @@ func TestCancelTaskResultFlatJSON(t *testing.T) {
 	json.Unmarshal(data, &m)
 
 	if _, ok := m["task"]; ok {
-		t.Error("CancelTaskResult should serialize flat, not under a 'task' key")
+		t.Error("CancelTaskResultV1 should serialize flat, not under a 'task' key")
 	}
 	if m["taskId"] != "task-cancel" {
 		t.Errorf("taskId = %v, want task-cancel", m["taskId"])

--- a/core/task_v2.go
+++ b/core/task_v2.go
@@ -1,6 +1,22 @@
 package core
 
-import "encoding/json"
+import (
+	"context"
+	"encoding/json"
+)
+
+// TasksExtensionID is the protocol extension identifier for SEP-2663 Tasks.
+// Servers advertise it under capabilities.extensions in the initialize
+// response; clients declare support under capabilities.extensions in the
+// initialize request (or per-request via SEP-2575 _meta).
+const TasksExtensionID = "io.modelcontextprotocol/tasks"
+
+// ClientSupportsTasks checks whether the connected client declared support
+// for the SEP-2663 Tasks extension during the initialize handshake.
+// Equivalent to ClientSupportsExtension(ctx, TasksExtensionID).
+func ClientSupportsTasks(ctx context.Context) bool {
+	return ClientSupportsExtension(ctx, TasksExtensionID)
+}
 
 // Tasks v2 types — SEP-2663 (Tasks Extension), SEP-2557 (resultType
 // discriminator), and MRTR base types from SEP-2322.

--- a/core/task_v2.go
+++ b/core/task_v2.go
@@ -1,48 +1,124 @@
 package core
 
-// Tasks v2 types (SEP-2557).
-//
-// Key differences from v1:
-//   - resultType: "task" discriminator on CreateTaskResult
-//   - tasks/get returns GetTaskResultV2 with inlined result/error
-//   - tasks/result and tasks/list removed
-//   - TTL in seconds (not milliseconds)
-//   - requestState for stateless deployments
-//   - Tool errors = completed + isError:true; protocol errors = failed + error field
+import "encoding/json"
 
-// ResultType is the discriminator on a CreateTaskResult response.
-// Always "task" for v2 task creation responses.
+// Tasks v2 types — SEP-2663 (Tasks Extension), SEP-2557 (resultType
+// discriminator), and MRTR base types from SEP-2322.
+//
+// Wire-format differences from v1:
+//   - tools/call carries a resultType discriminator: "task" (this file),
+//     "complete" / "incomplete" (MRTR — see ResultType constants).
+//   - tasks/get returns DetailedTask: a discriminated union by status that
+//     inlines result / error / inputRequests / requestState in one trip.
+//   - tasks/cancel and tasks/update return empty acks (no task state).
+//   - Task wire fields renamed: ttlSeconds, pollIntervalMilliseconds.
+//     Internal stores still use ms; conversion happens at the wire boundary.
+//   - parentTaskId removed (SEP-2663 does not model task parentage).
+//   - Tool errors: status "completed" with result.isError == true.
+//   - Protocol errors: status "failed" with the error inlined.
+
+// ResultType is the discriminator on a tools/call response.
+//
+// "task" indicates a task-based response (CreateTaskResult). The "complete"
+// and "incomplete" values come from MRTR (Multi-Round Tool Result, SEP-2322)
+// and signal whether a tool result is final or expects further input rounds.
 type ResultType string
 
-const ResultTypeTask ResultType = "task"
+const (
+	ResultTypeTask       ResultType = "task"
+	ResultTypeComplete   ResultType = "complete"   // SEP-2322
+	ResultTypeIncomplete ResultType = "incomplete" // SEP-2322
+)
 
-// CreateTaskResultV2 is returned by tools/call when a task is created in v2.
-// Includes the resultType discriminator per SEP-2557.
-type CreateTaskResultV2 struct {
-	ResultType ResultType `json:"resultType"`
-	Task       TaskInfo   `json:"task"`
+// InputRequest is a single MRTR input request enqueued by a server during
+// tool execution: a method (e.g., "elicitation/create", "sampling/createMessage")
+// plus opaque params encoded per that method's request schema. // SEP-2322
+type InputRequest struct {
+	Method string          `json:"method"`
+	Params json.RawMessage `json:"params,omitempty"`
 }
 
-// GetTaskResultV2 is the consolidated tasks/get response for v2.
-// Inlines result, error, or inputRequests depending on status.
-// All TaskInfo fields are at the root level (flat).
-type GetTaskResultV2 struct {
-	TaskInfo
+// InputRequests is the wire-format map from request key to InputRequest.
+// Keys are server-chosen identifiers (e.g., "elicit-1") that the client
+// echoes verbatim in the matching InputResponses entry. // SEP-2322
+type InputRequests = map[string]InputRequest
 
-	// Result is inlined when status is "completed" (including tool errors with isError:true).
+// InputResponses is the wire-format map from request key to opaque response
+// payload. Keys MUST match those previously returned in InputRequests. The
+// payload shape is defined by the original request method. // SEP-2322
+type InputResponses = map[string]json.RawMessage
+
+// TaskInfoV2 is the v2 wire shape for task metadata. Differences from
+// (v1) TaskInfo:
+//   - ttl renamed to ttlSeconds (units now part of the field name).
+//   - pollInterval renamed to pollIntervalMilliseconds.
+//   - parentTaskId removed; SEP-2663 does not expose task parentage.
+//
+// Internally, the TaskStore uses TaskInfo (ttl in milliseconds). Conversion
+// happens at the v2 wire boundary in the tasks_v2 server handlers.
+type TaskInfoV2 struct {
+	TaskID                   string     `json:"taskId"`
+	Status                   TaskStatus `json:"status"`
+	StatusMessage            string     `json:"statusMessage,omitempty"`
+	CreatedAt                string     `json:"createdAt"`
+	LastUpdatedAt            string     `json:"lastUpdatedAt"`
+	TTLSeconds               *int       `json:"ttlSeconds"`                         // required+nullable; null = unlimited
+	PollIntervalMilliseconds *int       `json:"pollIntervalMilliseconds,omitempty"` // optional
+}
+
+// CreateTaskResult is returned by tools/call when the server elects to handle
+// the call as an async task (resultType: "task"). Per SEP-2663, this envelope
+// MUST NOT carry result, error, inputRequests, or requestState — those belong
+// on tasks/get's DetailedTask response.
+type CreateTaskResult struct {
+	ResultType ResultType `json:"resultType"`
+	Task       TaskInfoV2 `json:"task"`
+}
+
+// DetailedTask is the SEP-2663 discriminated union returned by tasks/get.
+// The Status field discriminates which optional fields are populated:
+//
+//   - working          → no inlined payload
+//   - input_required   → InputRequests populated
+//   - completed        → Result populated
+//   - failed           → Error populated
+//   - cancelled        → no inlined payload
+//
+// RequestState is opaque session-continuation state for stateless deployments;
+// servers MAY include it on any status, clients MUST echo it back on the
+// next tasks/get / tasks/update / tasks/cancel for the same task. // SEP-2322
+type DetailedTask struct {
+	TaskInfoV2
+
+	// Result is inlined when Status == TaskCompleted. Includes the original
+	// ToolResult (with isError flag for tool-side errors).
 	Result *ToolResult `json:"result,omitempty"`
 
-	// Error is inlined when status is "failed" (protocol-level errors only).
+	// Error is inlined when Status == TaskFailed. Mirrors the JSON-RPC error
+	// shape and represents protocol-level failures only.
 	Error *TaskError `json:"error,omitempty"`
 
-	// InputRequests is a map of pending input requests when status is "input_required".
-	// Keys are request identifiers; values are the request payloads.
-	InputRequests map[string]any `json:"inputRequests,omitempty"`
+	// InputRequests is populated when Status == TaskInputRequired and lists
+	// the MRTR input requests the client must satisfy via tasks/update. // SEP-2322
+	InputRequests InputRequests `json:"inputRequests,omitempty"`
 
-	// RequestState is an opaque string for stateless deployments.
-	// Server generates it; client echoes in subsequent requests.
+	// RequestState is the opaque session-continuation token. // SEP-2322
 	RequestState string `json:"requestState,omitempty"`
 }
+
+// SEP-2663 narrowed aliases — convenient names for callers that have already
+// branched on status. The wire shape is identical to DetailedTask; the alias
+// just communicates which fields the caller expects to be populated.
+type (
+	WorkingTask       = DetailedTask
+	InputRequiredTask = DetailedTask
+	CompletedTask     = DetailedTask
+	FailedTask        = DetailedTask
+	CancelledTask     = DetailedTask
+)
+
+// GetTaskResult is the response shape for tasks/get. Identical to DetailedTask.
+type GetTaskResult = DetailedTask
 
 // TaskError is the error shape for protocol-level failures (status: failed).
 // Mirrors the JSON-RPC error object shape.
@@ -52,9 +128,21 @@ type TaskError struct {
 	Data    any    `json:"data,omitempty"`
 }
 
-// CancelTaskResultV2 is the response to tasks/cancel in v2.
-// Same flat shape as GetTaskResultV2.
-type CancelTaskResultV2 struct {
-	TaskInfo
-	RequestState string `json:"requestState,omitempty"`
+// UpdateTaskRequest is the params payload for tasks/update — the MRTR-driven
+// resume path. The client supplies InputResponses keyed by the same ids
+// returned in DetailedTask.InputRequests, optionally echoing RequestState. // SEP-2663
+type UpdateTaskRequest struct {
+	TaskID         string         `json:"taskId"`
+	InputResponses InputResponses `json:"inputResponses,omitempty"`
+	RequestState   string         `json:"requestState,omitempty"` // SEP-2322
 }
+
+// UpdateTaskResult is the (empty) ack returned by tasks/update. Servers
+// resume task execution asynchronously; clients learn the outcome via the
+// next tasks/get. // SEP-2663
+type UpdateTaskResult struct{}
+
+// CancelTaskResult is the (empty) ack returned by tasks/cancel. Per SEP-2663,
+// cancellation does not return task state — the client should issue tasks/get
+// if it wants to observe the resulting "cancelled" status.
+type CancelTaskResult struct{}

--- a/core/task_v2_test.go
+++ b/core/task_v2_test.go
@@ -1,0 +1,462 @@
+package core
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestResultTypeConstants verifies the wire values of the ResultType
+// discriminator. "task" is SEP-2557; "complete"/"incomplete" are SEP-2322 (MRTR).
+func TestResultTypeConstants(t *testing.T) {
+	cases := []struct {
+		rt   ResultType
+		want string
+	}{
+		{ResultTypeTask, "task"},
+		{ResultTypeComplete, "complete"},
+		{ResultTypeIncomplete, "incomplete"},
+	}
+	for _, tc := range cases {
+		if string(tc.rt) != tc.want {
+			t.Errorf("ResultType(%v) = %q, want %q", tc.rt, string(tc.rt), tc.want)
+		}
+		// JSON round-trip as a bare string.
+		data, err := json.Marshal(tc.rt)
+		if err != nil {
+			t.Fatalf("Marshal(%q): %v", tc.rt, err)
+		}
+		var got ResultType
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("Unmarshal(%s): %v", data, err)
+		}
+		if got != tc.rt {
+			t.Errorf("round-trip: got %q, want %q", got, tc.rt)
+		}
+	}
+}
+
+// TestInputRequestJSON verifies wire shape: {"method": "...", "params": {...}}
+// with params omitted when nil. Round-trip must preserve raw params bytes.
+func TestInputRequestJSON(t *testing.T) {
+	params := json.RawMessage(`{"message":"Confirm?","schema":{"type":"object"}}`)
+	req := InputRequest{
+		Method: "elicitation/create",
+		Params: params,
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatal(err)
+	}
+	if m["method"] != "elicitation/create" {
+		t.Errorf("method = %v, want elicitation/create", m["method"])
+	}
+	if _, ok := m["params"]; !ok {
+		t.Error("params missing from JSON output")
+	}
+
+	var decoded InputRequest
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Method != req.Method {
+		t.Errorf("Method = %q, want %q", decoded.Method, req.Method)
+	}
+	// json.RawMessage round-trips as raw bytes; compact equivalence is enough
+	// because the encoder may re-format whitespace.
+	var orig, got any
+	_ = json.Unmarshal(params, &orig)
+	_ = json.Unmarshal(decoded.Params, &got)
+	origBytes, _ := json.Marshal(orig)
+	gotBytes, _ := json.Marshal(got)
+	if string(origBytes) != string(gotBytes) {
+		t.Errorf("Params mismatch: got %s, want %s", gotBytes, origBytes)
+	}
+}
+
+// TestInputRequestOmitEmptyParams verifies that an InputRequest with nil
+// params omits the field entirely (not "params":null).
+func TestInputRequestOmitEmptyParams(t *testing.T) {
+	req := InputRequest{Method: "ping"}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	json.Unmarshal(data, &m)
+	if _, ok := m["params"]; ok {
+		t.Errorf("params should be omitted when nil; got %s", data)
+	}
+}
+
+// TestInputRequestsMapJSON verifies that InputRequests (alias for
+// map[string]InputRequest) marshals as a JSON object keyed by request id.
+func TestInputRequestsMapJSON(t *testing.T) {
+	reqs := InputRequests{
+		"elicit-1": InputRequest{Method: "elicitation/create", Params: json.RawMessage(`{"message":"ok?"}`)},
+		"sample-1": InputRequest{Method: "sampling/createMessage", Params: json.RawMessage(`{"maxTokens":50}`)},
+	}
+	data, err := json.Marshal(reqs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded InputRequests
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if len(decoded) != 2 {
+		t.Fatalf("len = %d, want 2", len(decoded))
+	}
+	if decoded["elicit-1"].Method != "elicitation/create" {
+		t.Errorf("elicit-1.method = %q, want elicitation/create", decoded["elicit-1"].Method)
+	}
+	if decoded["sample-1"].Method != "sampling/createMessage" {
+		t.Errorf("sample-1.method = %q, want sampling/createMessage", decoded["sample-1"].Method)
+	}
+}
+
+// TestInputResponsesMapJSON verifies that InputResponses (alias for
+// map[string]json.RawMessage) preserves opaque payload bytes per key.
+func TestInputResponsesMapJSON(t *testing.T) {
+	resps := InputResponses{
+		"elicit-1": json.RawMessage(`{"action":"accept","content":{"confirmed":true}}`),
+		"sample-1": json.RawMessage(`{"role":"assistant","content":{"type":"text","text":"hello"}}`),
+	}
+	data, err := json.Marshal(resps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded InputResponses
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if len(decoded) != 2 {
+		t.Fatalf("len = %d, want 2", len(decoded))
+	}
+	var v map[string]any
+	if err := json.Unmarshal(decoded["elicit-1"], &v); err != nil {
+		t.Fatalf("elicit-1 not valid JSON: %v", err)
+	}
+	if v["action"] != "accept" {
+		t.Errorf("elicit-1.action = %v, want accept", v["action"])
+	}
+}
+
+// TestDetailedTaskInputRequestsTyped verifies the InputRequests field on
+// DetailedTask (the SEP-2663 input_required variant) marshals to the
+// SEP-2322 wire shape and round-trips through the typed alias.
+func TestDetailedTaskInputRequestsTyped(t *testing.T) {
+	res := DetailedTask{
+		TaskInfoV2: TaskInfoV2{
+			TaskID:        "task-mrtr",
+			Status:        TaskInputRequired,
+			CreatedAt:     "2025-01-15T10:00:00Z",
+			LastUpdatedAt: "2025-01-15T10:00:01Z",
+			TTLSeconds:    IntPtr(60),
+		},
+		InputRequests: InputRequests{
+			"elicit-1": InputRequest{
+				Method: "elicitation/create",
+				Params: json.RawMessage(`{"message":"Proceed?"}`),
+			},
+		},
+		RequestState: "opaque-state-token",
+	}
+	data, err := json.Marshal(res)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wire shape: inputRequests is a JSON object keyed by request id; each
+	// entry has method + params.
+	var m map[string]any
+	json.Unmarshal(data, &m)
+	irs, ok := m["inputRequests"].(map[string]any)
+	if !ok {
+		t.Fatalf("inputRequests missing or wrong type; got %s", data)
+	}
+	entry, ok := irs["elicit-1"].(map[string]any)
+	if !ok {
+		t.Fatal("inputRequests[elicit-1] missing")
+	}
+	if entry["method"] != "elicitation/create" {
+		t.Errorf("inputRequests[elicit-1].method = %v, want elicitation/create", entry["method"])
+	}
+	if m["requestState"] != "opaque-state-token" {
+		t.Errorf("requestState = %v, want opaque-state-token", m["requestState"])
+	}
+
+	// Typed round-trip preserves InputRequest.Method through GetTaskResult,
+	// which is an alias for DetailedTask.
+	var decoded GetTaskResult
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if got := decoded.InputRequests["elicit-1"].Method; got != "elicitation/create" {
+		t.Errorf("decoded method = %q, want elicitation/create", got)
+	}
+}
+
+// TestDetailedTaskRequestStateOmitEmpty verifies that RequestState is omitted
+// when empty on DetailedTask (it's optional per SEP-2322).
+func TestDetailedTaskRequestStateOmitEmpty(t *testing.T) {
+	res := DetailedTask{
+		TaskInfoV2: TaskInfoV2{
+			TaskID: "t1", Status: TaskWorking,
+			CreatedAt: "2025-01-15T10:00:00Z", LastUpdatedAt: "2025-01-15T10:00:00Z",
+			TTLSeconds: IntPtr(30),
+		},
+	}
+	data, _ := json.Marshal(res)
+	var m map[string]any
+	json.Unmarshal(data, &m)
+	if _, ok := m["requestState"]; ok {
+		t.Errorf("DetailedTask: requestState should be omitted when empty; got %s", data)
+	}
+}
+
+// --- SEP-2663 wire-shape tests ---
+
+// TestTaskInfoV2WireFields verifies the renamed wire fields (ttlSeconds,
+// pollIntervalMilliseconds) and the absence of a parentTaskId field.
+func TestTaskInfoV2WireFields(t *testing.T) {
+	info := TaskInfoV2{
+		TaskID:                   "task-123",
+		Status:                   TaskWorking,
+		CreatedAt:                "2025-01-15T10:00:00Z",
+		LastUpdatedAt:            "2025-01-15T10:00:01Z",
+		TTLSeconds:               IntPtr(300),
+		PollIntervalMilliseconds: IntPtr(1000),
+	}
+	data, err := json.Marshal(info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	json.Unmarshal(data, &m)
+
+	for _, key := range []string{"taskId", "status", "createdAt", "lastUpdatedAt", "ttlSeconds", "pollIntervalMilliseconds"} {
+		if _, ok := m[key]; !ok {
+			t.Errorf("TaskInfoV2 missing %q; got %s", key, data)
+		}
+	}
+	// Old v1 wire keys must be absent.
+	for _, key := range []string{"ttl", "pollInterval", "parentTaskId"} {
+		if _, ok := m[key]; ok {
+			t.Errorf("TaskInfoV2 should not emit v1 key %q; got %s", key, data)
+		}
+	}
+	if m["ttlSeconds"] != float64(300) {
+		t.Errorf("ttlSeconds = %v, want 300", m["ttlSeconds"])
+	}
+	if m["pollIntervalMilliseconds"] != float64(1000) {
+		t.Errorf("pollIntervalMilliseconds = %v, want 1000", m["pollIntervalMilliseconds"])
+	}
+}
+
+// TestTaskInfoV2TTLSecondsNullable verifies that ttlSeconds is required-but-
+// nullable (present as null when nil). Mirrors v1 TaskInfo.TTL semantics.
+func TestTaskInfoV2TTLSecondsNullable(t *testing.T) {
+	info := TaskInfoV2{
+		TaskID:        "t1",
+		Status:        TaskWorking,
+		CreatedAt:     "2025-01-15T10:00:00Z",
+		LastUpdatedAt: "2025-01-15T10:00:00Z",
+		TTLSeconds:    nil,
+	}
+	data, _ := json.Marshal(info)
+	var m map[string]any
+	json.Unmarshal(data, &m)
+	val, ok := m["ttlSeconds"]
+	if !ok {
+		t.Fatalf("ttlSeconds must be present even when nil; got %s", data)
+	}
+	if val != nil {
+		t.Errorf("ttlSeconds = %v, want null", val)
+	}
+}
+
+// TestCreateTaskResultWireShape verifies the SEP-2663 wire shape:
+// {"resultType": "task", "task": {...}} with no extra fields (no result,
+// no error, no inputRequests, no requestState — all forbidden on
+// CreateTaskResult per SEP-2663).
+func TestCreateTaskResultWireShape(t *testing.T) {
+	res := CreateTaskResult{
+		ResultType: ResultTypeTask,
+		Task: TaskInfoV2{
+			TaskID:        "task-abc",
+			Status:        TaskWorking,
+			CreatedAt:     "2025-01-15T10:00:00Z",
+			LastUpdatedAt: "2025-01-15T10:00:00Z",
+			TTLSeconds:    IntPtr(60),
+		},
+	}
+	data, err := json.Marshal(res)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	json.Unmarshal(data, &m)
+
+	if m["resultType"] != "task" {
+		t.Errorf("resultType = %v, want task", m["resultType"])
+	}
+	if _, ok := m["task"]; !ok {
+		t.Fatalf("task missing; got %s", data)
+	}
+	for _, forbidden := range []string{"result", "error", "inputRequests", "requestState"} {
+		if _, ok := m[forbidden]; ok {
+			t.Errorf("CreateTaskResult must not carry %q (SEP-2663); got %s", forbidden, data)
+		}
+	}
+}
+
+// TestDetailedTaskCompletedShape verifies the wire shape for the completed
+// variant: status + result inlined, no error/inputRequests.
+func TestDetailedTaskCompletedShape(t *testing.T) {
+	res := CompletedTask{
+		TaskInfoV2: TaskInfoV2{
+			TaskID:        "t1",
+			Status:        TaskCompleted,
+			CreatedAt:     "2025-01-15T10:00:00Z",
+			LastUpdatedAt: "2025-01-15T10:00:05Z",
+			TTLSeconds:    IntPtr(60),
+		},
+		Result: &ToolResult{Content: []Content{{Type: "text", Text: "done"}}},
+	}
+	data, _ := json.Marshal(res)
+	var m map[string]any
+	json.Unmarshal(data, &m)
+
+	if m["status"] != "completed" {
+		t.Errorf("status = %v, want completed", m["status"])
+	}
+	if _, ok := m["result"]; !ok {
+		t.Errorf("result must be inlined when status=completed; got %s", data)
+	}
+	for _, absent := range []string{"error", "inputRequests"} {
+		if _, ok := m[absent]; ok {
+			t.Errorf("completed task should omit %q; got %s", absent, data)
+		}
+	}
+}
+
+// TestDetailedTaskFailedShape verifies the wire shape for the failed variant:
+// status + error inlined (JSON-RPC error shape), no result/inputRequests.
+func TestDetailedTaskFailedShape(t *testing.T) {
+	res := FailedTask{
+		TaskInfoV2: TaskInfoV2{
+			TaskID:        "t1",
+			Status:        TaskFailed,
+			CreatedAt:     "2025-01-15T10:00:00Z",
+			LastUpdatedAt: "2025-01-15T10:00:05Z",
+			TTLSeconds:    IntPtr(60),
+		},
+		Error: &TaskError{Code: -32603, Message: "internal error"},
+	}
+	data, _ := json.Marshal(res)
+	var m map[string]any
+	json.Unmarshal(data, &m)
+
+	if m["status"] != "failed" {
+		t.Errorf("status = %v, want failed", m["status"])
+	}
+	errMap, ok := m["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("error must be inlined when status=failed; got %s", data)
+	}
+	if errMap["code"] != float64(-32603) || errMap["message"] != "internal error" {
+		t.Errorf("error shape mismatch: got %v", errMap)
+	}
+	for _, absent := range []string{"result", "inputRequests"} {
+		if _, ok := m[absent]; ok {
+			t.Errorf("failed task should omit %q; got %s", absent, data)
+		}
+	}
+}
+
+// TestUpdateTaskRequestWireShape verifies the SEP-2663 tasks/update params:
+// {taskId, inputResponses, requestState}. inputResponses preserves opaque
+// per-key payloads (json.RawMessage).
+func TestUpdateTaskRequestWireShape(t *testing.T) {
+	req := UpdateTaskRequest{
+		TaskID: "task-xyz",
+		InputResponses: InputResponses{
+			"elicit-1": json.RawMessage(`{"action":"accept","content":{"ok":true}}`),
+		},
+		RequestState: "state-1",
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	json.Unmarshal(data, &m)
+
+	if m["taskId"] != "task-xyz" {
+		t.Errorf("taskId = %v, want task-xyz", m["taskId"])
+	}
+	if m["requestState"] != "state-1" {
+		t.Errorf("requestState = %v, want state-1", m["requestState"])
+	}
+	resps, ok := m["inputResponses"].(map[string]any)
+	if !ok {
+		t.Fatalf("inputResponses missing or wrong shape; got %s", data)
+	}
+	entry, ok := resps["elicit-1"].(map[string]any)
+	if !ok {
+		t.Fatalf("inputResponses[elicit-1] missing; got %s", data)
+	}
+	if entry["action"] != "accept" {
+		t.Errorf("inputResponses[elicit-1].action = %v, want accept", entry["action"])
+	}
+
+	// Round-trip preserves raw bytes per key.
+	var decoded UpdateTaskRequest
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.TaskID != req.TaskID {
+		t.Errorf("TaskID = %q, want %q", decoded.TaskID, req.TaskID)
+	}
+	if string(decoded.InputResponses["elicit-1"]) == "" {
+		t.Error("decoded InputResponses[elicit-1] is empty")
+	}
+}
+
+// TestUpdateTaskRequestOmitEmpty verifies that inputResponses and requestState
+// are omitted when empty/zero (only taskId is required).
+func TestUpdateTaskRequestOmitEmpty(t *testing.T) {
+	req := UpdateTaskRequest{TaskID: "t1"}
+	data, _ := json.Marshal(req)
+	var m map[string]any
+	json.Unmarshal(data, &m)
+	for _, absent := range []string{"inputResponses", "requestState"} {
+		if _, ok := m[absent]; ok {
+			t.Errorf("%q should be omitted when empty; got %s", absent, data)
+		}
+	}
+}
+
+// TestEmptyAckShapes verifies that UpdateTaskResult and CancelTaskResult
+// serialize as empty JSON objects (no task state, per SEP-2663).
+func TestEmptyAckShapes(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		v    any
+	}{
+		{"UpdateTaskResult", UpdateTaskResult{}},
+		{"CancelTaskResult", CancelTaskResult{}},
+	} {
+		data, err := json.Marshal(tc.v)
+		if err != nil {
+			t.Fatalf("%s: %v", tc.name, err)
+		}
+		if string(data) != "{}" {
+			t.Errorf("%s = %s, want {}", tc.name, data)
+		}
+	}
+}

--- a/examples/tasks-v2/main.go
+++ b/examples/tasks-v2/main.go
@@ -184,9 +184,9 @@ func serve() {
 			return core.TextResult(fmt.Sprintf("External job %s completed", args.JobID)), nil
 		},
 		TaskCallbacks: &server.TaskCallbacks{
-			GetTask: func(ctx core.MethodContext, taskID string) (core.GetTaskResult, bool) {
+			GetTask: func(ctx core.MethodContext, taskID string) (core.GetTaskResultV1, bool) {
 				log.Printf("[external_job] custom getTask for %s", taskID)
-				return core.GetTaskResult{}, false
+				return core.GetTaskResultV1{}, false
 			},
 			GetResult: func(ctx core.MethodContext, taskID string) (core.ToolResult, bool) {
 				log.Printf("[external_job] custom getResult for %s", taskID)

--- a/examples/tasks-v2/walkthrough.go
+++ b/examples/tasks-v2/walkthrough.go
@@ -79,13 +79,14 @@ func runDemo() {
 
 	// --- Step 1: Connect ---
 	demo.Step("Connect to the v2 tasks server").
-		Arrow("Host", "Server", "POST /mcp — initialize").
-		DashedArrow("Server", "Host", "serverInfo + tasks v2 capability").
-		Note("The mcpkit client opens a GET SSE stream so progress notifications reach us during polling. Initialize advertises the v2 tasks capability.").
+		Arrow("Host", "Server", "POST /mcp — initialize (declares io.modelcontextprotocol/tasks)").
+		DashedArrow("Server", "Host", "serverInfo + tasks extension advertised").
+		Note("The mcpkit client opens a GET SSE stream so progress notifications reach us during polling. Initialize declares support for the SEP-2663 tasks extension; without that declaration the v2 server falls through to synchronous tools/call and rejects tasks/* with -32601.").
 		Run(func() (result *demokit.StepResult) {
 			c = client.NewClient(serverURL+"/mcp",
 				core.ClientInfo{Name: "tasks-v2-host", Version: "1.0"},
 				client.WithGetSSEStream(),
+				client.WithTasksExtension(),
 				client.WithNotificationCallback(func(method string, params any) {
 					if method == "notifications/progress" {
 						fmt.Fprintf(os.Stderr, "    [notif] progress: %v\n", params)

--- a/examples/tasks-v2/walkthrough.go
+++ b/examples/tasks-v2/walkthrough.go
@@ -129,7 +129,7 @@ func runDemo() {
 				fmt.Printf("    ERROR: %v\n", err)
 				return
 			}
-			var ctr core.CreateTaskResultV2
+			var ctr core.CreateTaskResult
 			if err := json.Unmarshal(res.Raw, &ctr); err != nil {
 				fmt.Printf("    ERROR: %v\n", err)
 				return
@@ -142,8 +142,8 @@ func runDemo() {
 			fmt.Printf("    resultType:    %s\n", ctr.ResultType)
 			fmt.Printf("    taskId:        %s\n", slowTaskID)
 			fmt.Printf("    status:        %s\n", ctr.Task.Status)
-			if ctr.Task.TTL != nil {
-				fmt.Printf("    ttl:           %ds (v2 uses seconds)\n", *ctr.Task.TTL)
+			if ctr.Task.TTLSeconds != nil {
+				fmt.Printf("    ttlSeconds:    %d (SEP-2663 wire field)\n", *ctr.Task.TTLSeconds)
 			}
 			return
 		})
@@ -153,7 +153,7 @@ func runDemo() {
 		Arrow("Host", "Server", "tasks/get {taskId}  (polled)").
 		DashedArrow("Server", "Host", "notifications/progress (1/3, 2/3, 3/3) via SSE").
 		DashedArrow("Server", "Host", "{status: completed, result: {...}, ttl: ...}  (no separate tasks/result needed)").
-		Note("v2's flat shape: GetTaskResultV2 has TaskInfo fields at the top level, and inlines the actual ToolResult under `result` once status is terminal. No second roundtrip to tasks/result.").
+		Note("v2's flat shape: DetailedTask has the v2 task fields (taskId, status, ttlSeconds, ...) at the top level, and inlines the actual ToolResult under `result` once status is terminal. No second roundtrip to tasks/result.").
 		Run(func() (result *demokit.StepResult) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
@@ -185,7 +185,7 @@ func runDemo() {
 				fmt.Printf("    ERROR: %v\n", err)
 				return
 			}
-			var ctr core.CreateTaskResultV2
+			var ctr core.CreateTaskResult
 			json.Unmarshal(res.Raw, &ctr)
 			failTaskID = ctr.Task.TaskID
 
@@ -221,7 +221,7 @@ func runDemo() {
 				fmt.Printf("    ERROR: %v\n", err)
 				return
 			}
-			var ctr core.CreateTaskResultV2
+			var ctr core.CreateTaskResult
 			json.Unmarshal(res.Raw, &ctr)
 
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -256,7 +256,7 @@ func runDemo() {
 				fmt.Printf("    ERROR: %v\n", err)
 				return
 			}
-			var ctr core.CreateTaskResultV2
+			var ctr core.CreateTaskResult
 			json.Unmarshal(res.Raw, &ctr)
 			cancelID := ctr.Task.TaskID
 			fmt.Printf("    Started taskId: %s\n", cancelID)
@@ -281,7 +281,7 @@ func runDemo() {
 
 	demo.Section("Where each piece lives in mcpkit",
 		"- v2 server library: `server/tasks_v2.go`",
-		"- v2 wire types (`CreateTaskResultV2`, `GetTaskResultV2`, `ResultTypeTask`): `core/task_v2.go`",
+		"- v2 wire types (`CreateTaskResult`, `DetailedTask`, `TaskInfoV2`, `ResultTypeTask`): `core/task_v2.go` (SEP-2663)",
 		"- Conformance tests: `conformance/tasks-v2/scenarios.test.ts` (21 scenarios)",
 		"- Implementation plan: `docs/TASKS_V2_PLAN.md`",
 	)
@@ -303,13 +303,13 @@ func runDemo() {
 // pollV2 polls tasks/get until the task reaches a terminal status or the
 // context expires. There's no v2 client helper in mcpkit yet (v1 has
 // client.WaitForTask), so this is inline.
-func pollV2(ctx context.Context, c *client.Client, taskID string, interval time.Duration) (*core.GetTaskResultV2, error) {
+func pollV2(ctx context.Context, c *client.Client, taskID string, interval time.Duration) (*core.DetailedTask, error) {
 	for {
 		res, err := c.Call("tasks/get", map[string]any{"taskId": taskID})
 		if err != nil {
 			return nil, err
 		}
-		var got core.GetTaskResultV2
+		var got core.DetailedTask
 		if err := json.Unmarshal(res.Raw, &got); err != nil {
 			return nil, err
 		}

--- a/examples/tasks/main.go
+++ b/examples/tasks/main.go
@@ -277,11 +277,11 @@ func serve() {
 			return core.TextResult(fmt.Sprintf("External job %s completed", args.JobID)), nil
 		},
 		TaskCallbacks: &server.TaskCallbacks{
-			GetTask: func(ctx core.MethodContext, taskID string) (core.GetTaskResult, bool) {
+			GetTask: func(ctx core.MethodContext, taskID string) (core.GetTaskResultV1, bool) {
 				// In a real system, this would query an external API (Step Functions, etc.)
 				// For demo purposes, we augment the status message.
 				log.Printf("[external_job] custom getTask for %s", taskID)
-				return core.GetTaskResult{}, false // fall through to store
+				return core.GetTaskResultV1{}, false // fall through to store
 			},
 			GetResult: func(ctx core.MethodContext, taskID string) (core.ToolResult, bool) {
 				// In a real system, this would fetch the result from the external system.

--- a/server/server.go
+++ b/server/server.go
@@ -288,9 +288,23 @@ func (s *Server) UseMiddleware(mw ...Middleware) {
 }
 
 // SetTasksCap configures the tasks capability advertised during initialize.
-// Must be called before accepting connections.
+// Must be called before accepting connections. (V1-only: v2 advertises tasks
+// via the io.modelcontextprotocol/tasks extension instead — see RegisterTasks.)
 func (s *Server) SetTasksCap(cap *core.TasksCap) {
 	s.dispatcher.tasksCap = cap
+}
+
+// RegisterExtension declares a protocol extension at runtime, the way
+// WithExtension does at construction time. Used by RegisterTasks (and other
+// post-construction hookups like ext/auth) so the extension is advertised in
+// the initialize response without forcing callers to thread an Option through.
+// Must be called before accepting connections.
+func (s *Server) RegisterExtension(ext core.ExtensionProvider) {
+	if s.dispatcher.extensions == nil {
+		s.dispatcher.extensions = make(map[string]core.Extension)
+	}
+	e := ext.Extension()
+	s.dispatcher.extensions[e.ID] = e
 }
 
 // RegisterTool adds a tool to the server.

--- a/server/task_callbacks.go
+++ b/server/task_callbacks.go
@@ -10,8 +10,11 @@ import "github.com/panyam/mcpkit/core"
 // job system (e.g., AWS Step Functions, CI/CD pipelines) and the external
 // system is the source of truth for task state — not the in-memory store.
 //
-// Designed for extensibility: v2 (SEP-2557) will add OnCancel and
+// Designed for extensibility: v2 (SEP-2557/SEP-2663) will add OnCancel and
 // OnInputResponse fields without structural changes.
+//
+// Currently scoped to v1 — the GetTask callback returns the v1 wire shape
+// (GetTaskResultV1). The v2 task runtime does not yet consult these callbacks.
 //
 // Example:
 //
@@ -22,24 +25,24 @@ import "github.com/panyam/mcpkit/core"
 //	    },
 //	    Handler: deployHandler,
 //	    TaskCallbacks: &server.TaskCallbacks{
-//	        GetTask: func(ctx core.MethodContext, taskID string) (core.GetTaskResult, bool) {
+//	        GetTask: func(ctx core.MethodContext, taskID string) (core.GetTaskResultV1, bool) {
 //	            // Query external system for task state
 //	            state, err := stepFunctions.DescribeExecution(taskID)
 //	            if err != nil {
-//	                return core.GetTaskResult{}, false // fall through to store
+//	                return core.GetTaskResultV1{}, false // fall through to store
 //	            }
-//	            return core.GetTaskResult{TaskInfo: toTaskInfo(state)}, true
+//	            return core.GetTaskResultV1{TaskInfo: toTaskInfo(state)}, true
 //	        },
 //	    },
 //	})
 type TaskCallbacks struct {
-	// GetTask overrides the default TaskStore lookup for tasks/get.
-	// Return (result, true) to use the override response.
+	// GetTask overrides the default TaskStore lookup for the v1 tasks/get
+	// handler. Return (result, true) to use the override response.
 	// Return (_, false) to fall through to the TaskStore.
-	GetTask func(ctx core.MethodContext, taskID string) (core.GetTaskResult, bool)
+	GetTask func(ctx core.MethodContext, taskID string) (core.GetTaskResultV1, bool)
 
-	// GetResult overrides the default TaskStore lookup for tasks/result.
-	// Return (result, true) to use the override response.
+	// GetResult overrides the default TaskStore lookup for the v1 tasks/result
+	// handler. Return (result, true) to use the override response.
 	// Return (_, false) to fall through to the TaskStore.
 	GetResult func(ctx core.MethodContext, taskID string) (core.ToolResult, bool)
 }

--- a/server/task_callbacks_test.go
+++ b/server/task_callbacks_test.go
@@ -35,9 +35,9 @@ func TestTaskCallbacksGetTask(t *testing.T) {
 			return core.TextResult("done"), nil
 		},
 		TaskCallbacks: &TaskCallbacks{
-			GetTask: func(ctx core.MethodContext, taskID string) (core.GetTaskResult, bool) {
+			GetTask: func(ctx core.MethodContext, taskID string) (core.GetTaskResultV1, bool) {
 				getTaskCalled.Add(1)
-				return core.GetTaskResult{
+				return core.GetTaskResultV1{
 					TaskInfo: core.TaskInfo{
 						TaskID:        taskID,
 						Status:        core.TaskWorking,
@@ -158,9 +158,9 @@ func TestTaskCallbacksFallthrough(t *testing.T) {
 			return core.TextResult("real-result"), nil
 		},
 		TaskCallbacks: &TaskCallbacks{
-			GetTask: func(ctx core.MethodContext, taskID string) (core.GetTaskResult, bool) {
+			GetTask: func(ctx core.MethodContext, taskID string) (core.GetTaskResultV1, bool) {
 				getTaskCalled.Add(1)
-				return core.GetTaskResult{}, false // fall through to store
+				return core.GetTaskResultV1{}, false // fall through to store
 			},
 		},
 	})

--- a/server/tasks_experimental.go
+++ b/server/tasks_experimental.go
@@ -325,7 +325,7 @@ func taskMiddleware(reg *Registry, rt *taskRuntime, cfg TasksConfig) Middleware 
 			notifyTaskStatus(bgCtx, store, taskID, sessionID)
 		}()
 
-		return core.NewResponse(req.ID, core.CreateTaskResult{Task: info}), nil
+		return core.NewResponse(req.ID, core.CreateTaskResultV1{Task: info}), nil
 	}
 }
 
@@ -358,7 +358,7 @@ func makeGetHandler(rt *taskRuntime) MethodHandler {
 		if !ok {
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, "task not found: "+p.TaskID)
 		}
-		return core.NewResponse(id, core.GetTaskResult{TaskInfo: info})
+		return core.NewResponse(id, core.GetTaskResultV1{TaskInfo: info})
 	}
 }
 
@@ -450,7 +450,7 @@ func makeListHandler(store TaskStore) MethodHandler {
 		if tasks == nil {
 			tasks = []core.TaskInfo{}
 		}
-		return core.NewResponse(id, core.ListTasksResult{
+		return core.NewResponse(id, core.ListTasksResultV1{
 			Tasks:      tasks,
 			NextCursor: nextCursor,
 		})
@@ -476,7 +476,7 @@ func makeCancelHandler(rt *taskRuntime) MethodHandler {
 		// Send status notification (Phase 6).
 		ctx.Notify("notifications/tasks/status", info)
 		// Per spec: tasks/cancel returns flat Result & Task (no wrapper).
-		return core.NewResponse(id, core.CancelTaskResult{TaskInfo: info})
+		return core.NewResponse(id, core.CancelTaskResultV1{TaskInfo: info})
 	}
 }
 

--- a/server/tasks_experimental_test.go
+++ b/server/tasks_experimental_test.go
@@ -289,7 +289,7 @@ func TestTaskCapabilityAdvertised(t *testing.T) {
 	if err != nil {
 		t.Fatalf("tasks/list should succeed if capability is advertised: %v", err)
 	}
-	var list core.ListTasksResult
+	var list core.ListTasksResultV1
 	if err := json.Unmarshal(result.Raw, &list); err != nil {
 		t.Fatalf("unmarshal list: %v", err)
 	}
@@ -484,7 +484,7 @@ func TestTaskHintAtParamsRoot(t *testing.T) {
 		t.Fatalf("expected task creation, got error: %v", err)
 	}
 
-	var created core.CreateTaskResult
+	var created core.CreateTaskResultV1
 	if err := json.Unmarshal(result.Raw, &created); err != nil {
 		t.Fatal(err)
 	}
@@ -787,7 +787,7 @@ func TestTaskPollIntervalPassthrough(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var created core.CreateTaskResult
+	var created core.CreateTaskResultV1
 	json.Unmarshal(result.Raw, &created)
 
 	if created.Task.PollInterval != 2000 {
@@ -1227,7 +1227,7 @@ func TestTaskTTLExpiryE2E(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var created core.CreateTaskResult
+	var created core.CreateTaskResultV1
 	json.Unmarshal(result.Raw, &created)
 	taskID := created.Task.TaskID
 

--- a/server/tasks_v2.go
+++ b/server/tasks_v2.go
@@ -107,12 +107,36 @@ func (rt *v2TaskRuntime) getToolCallbacks(taskID string) *TaskCallbacks {
 	return rt.registry.ToolCallbacks(name)
 }
 
+// tasksExtensionProvider implements core.ExtensionProvider for the SEP-2663
+// Tasks extension. RegisterTasksV2 hands an instance to Server.RegisterExtension
+// so the extension is advertised in capabilities.extensions during initialize.
+type tasksExtensionProvider struct{}
+
+// Extension declares the SEP-2663 Tasks extension.
+//
+//nolint:unused // referenced by RegisterTasksV2 only when the v2 path is wired
+func (tasksExtensionProvider) Extension() core.Extension {
+	return core.Extension{
+		ID:          core.TasksExtensionID,
+		SpecVersion: "draft", // SEP-2663 is in draft
+		Stability:   core.Experimental,
+	}
+}
+
 // RegisterTasksV2 hooks up v2 tasks support on the given server:
+//   - Advertises the io.modelcontextprotocol/tasks extension in initialize
+//     (replacing the v1 ServerCapabilities.Tasks declaration).
 //   - Installs middleware that intercepts tools/call for task-eligible tools
-//     (server-directed, no client task param needed)
-//   - Registers tasks/get and tasks/cancel handlers
-//   - Does NOT register tasks/result or tasks/list (removed in v2)
-//   - Does NOT advertise tasks capability (tasks are core protocol in v2)
+//     (server-directed, no client task param needed). Task creation is
+//     gated on the client supporting the extension — either at session
+//     level (initialize handshake) or per-request (SEP-2575 _meta).
+//   - Registers tasks/get and tasks/cancel handlers, gated on session-level
+//     extension support; otherwise the handlers return -32601 (method not
+//     found) so unsupported clients don't see a tasks surface they didn't
+//     ask for.
+//   - Does NOT register tasks/result or tasks/list (removed in v2).
+//   - Does NOT call SetTasksCap — v2 tasks live under capabilities.extensions,
+//     not the v1 ServerCapabilities.Tasks slot.
 //
 // Must be called before accepting connections.
 func RegisterTasksV2(cfg TasksV2Config) {
@@ -122,14 +146,30 @@ func RegisterTasksV2(cfg TasksV2Config) {
 	reg := srv.Registry()
 	rt := newV2TaskRuntime(store, reg)
 
-	// Install v2 middleware for tools/call interception.
+	// Advertise the SEP-2663 Tasks extension.
+	srv.RegisterExtension(tasksExtensionProvider{})
+
+	// Install v2 middleware for tools/call interception (gated on extension).
 	srv.UseMiddleware(taskV2Middleware(reg, rt, cfg))
 
-	// Register tasks/* protocol methods (v2: only get + cancel).
-	srv.HandleMethod("tasks/get", makeV2GetHandler(rt))
-	srv.HandleMethod("tasks/cancel", makeV2CancelHandler(rt))
+	// Register tasks/* protocol methods (v2: only get + cancel),
+	// gated on session-level extension support.
+	srv.HandleMethod("tasks/get", gateOnTasksExtension(makeV2GetHandler(rt)))
+	srv.HandleMethod("tasks/cancel", gateOnTasksExtension(makeV2CancelHandler(rt)))
+}
 
-	// v2: Do NOT call SetTasksCap — tasks are core protocol, not negotiated.
+// gateOnTasksExtension wraps a tasks/* handler so unsupported clients get
+// -32601 (method not found) instead of the real handler's response. This is
+// the SEP-2663 contract: tasks/* methods MUST NOT exist for clients that did
+// not negotiate the extension during initialize.
+func gateOnTasksExtension(inner MethodHandler) MethodHandler {
+	return func(ctx core.MethodContext, id json.RawMessage, params json.RawMessage) *core.Response {
+		if !ctx.ClientSupportsExtension(core.TasksExtensionID) {
+			return core.NewErrorResponse(id, core.ErrCodeMethodNotFound,
+				"method requires extension "+core.TasksExtensionID)
+		}
+		return inner(ctx, id, params)
+	}
 }
 
 // --- Middleware ---
@@ -148,11 +188,16 @@ func taskV2Middleware(reg *Registry, rt *v2TaskRuntime, cfg TasksV2Config) Middl
 			return next(ctx, req)
 		}
 
+		// Parse the envelope. _meta carries two known keys for our purposes:
+		// progressToken (forwarded to the background goroutine) and the
+		// SEP-2575 per-request clientCapabilities override (kept as raw JSON
+		// because the typed ClientCapabilities lives in core).
 		var envelope struct {
 			Name string `json:"name"`
 			Meta *struct {
-				ProgressToken any `json:"progressToken"`
-			} `json:"_meta"`
+				ProgressToken         any             `json:"progressToken,omitempty"`
+				ClientCapabilitiesRaw json.RawMessage `json:"io.modelcontextprotocol/clientCapabilities,omitempty"`
+			} `json:"_meta,omitempty"`
 		}
 		if err := json.Unmarshal(req.Params, &envelope); err != nil {
 			return next(ctx, req)
@@ -163,7 +208,20 @@ func taskV2Middleware(reg *Registry, rt *v2TaskRuntime, cfg TasksV2Config) Middl
 			return next(ctx, req)
 		}
 
+		// SEP-2663: server MUST NOT return CreateTaskResult unless the client
+		// negotiated the io.modelcontextprotocol/tasks extension, either at
+		// session level (initialize handshake) or per-request (SEP-2575).
+		var perRequestCapsRaw json.RawMessage
+		if envelope.Meta != nil {
+			perRequestCapsRaw = envelope.Meta.ClientCapabilitiesRaw
+		}
+		if !core.ClientSupportsExtensionForRequest(ctx, core.TasksExtensionID, perRequestCapsRaw) {
+			return next(ctx, req)
+		}
+
 		// Determine effective taskSupport. Absent Execution = forbidden.
+		// In v2 this is a server-internal hint about which tools should be
+		// async — clients no longer opt in via a `task` param.
 		effectiveSupport := core.TaskSupportForbidden
 		if def.Execution != nil {
 			effectiveSupport = def.Execution.TaskSupport

--- a/server/tasks_v2.go
+++ b/server/tasks_v2.go
@@ -279,12 +279,14 @@ func taskV2Middleware(reg *Registry, rt *v2TaskRuntime, cfg TasksV2Config) Middl
 			notifyV2TaskStatus(bgCtx, rt, store, taskID, sessionID)
 		}()
 
-		// Return TTL in seconds on the wire (v2 spec).
-		wireInfo := info
-		wireInfo.TTL = core.IntPtr(ttlSec)
-		return core.NewResponse(req.ID, core.CreateTaskResultV2{
+		// Build the v2 wire envelope. CreateTaskResult MUST NOT carry result/
+		// error/inputRequests/requestState (SEP-2663 — those belong on
+		// DetailedTask returned by tasks/get).
+		wireTask := toTaskInfoV2(info)
+		wireTask.TTLSeconds = core.IntPtr(ttlSec)
+		return core.NewResponse(req.ID, core.CreateTaskResult{
 			ResultType: core.ResultTypeTask,
-			Task:       wireInfo,
+			Task:       wireTask,
 		}), nil
 	}
 }
@@ -307,15 +309,11 @@ func makeV2GetHandler(rt *v2TaskRuntime) MethodHandler {
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, "task not found: "+p.TaskID)
 		}
 
-		// Convert TTL from internal ms to seconds for v2 wire format.
-		ttlToSeconds(&info)
-
-		result := core.GetTaskResultV2{
-			TaskInfo: info,
+		result := core.DetailedTask{
+			TaskInfoV2: toTaskInfoV2(info),
+			// Generate requestState (opaque token for stateless deployments).
+			RequestState: p.TaskID,
 		}
-
-		// Generate requestState (opaque token for stateless deployments).
-		result.RequestState = p.TaskID
 
 		// Inline result or error depending on terminal status.
 		if info.Status == core.TaskCompleted {
@@ -336,7 +334,7 @@ func makeV2GetHandler(rt *v2TaskRuntime) MethodHandler {
 			if te != nil {
 				result.Error = te
 			} else {
-				// Fallback: construct from store's result.
+				// Fallback: construct from store's status message.
 				result.Error = &core.TaskError{
 					Code:    -32603,
 					Message: info.StatusMessage,
@@ -366,45 +364,52 @@ func makeV2CancelHandler(rt *v2TaskRuntime) MethodHandler {
 		// Stop the background goroutine.
 		rt.cancelTask(p.TaskID)
 
-		// Convert TTL from internal ms to seconds for v2 wire format.
-		ttlToSeconds(&info)
+		// Send status notification with the v2 wire-format task. Clients learn
+		// the new state via tasks/get; the cancel response itself is an empty
+		// ack per SEP-2663.
+		notifyV2TaskStatusFromInfo(ctx, rt, info)
 
-		// Send status notification.
-		ctx.Notify("notifications/tasks/status", info)
-
-		return core.NewResponse(id, core.CancelTaskResultV2{
-			TaskInfo:     info,
-			RequestState: p.TaskID,
-		})
+		return core.NewResponse(id, core.CancelTaskResult{})
 	}
 }
 
 // --- Helpers ---
 
-// ttlToSeconds converts a TaskInfo's TTL from internal ms to seconds (v2 wire format).
-func ttlToSeconds(info *core.TaskInfo) {
+// toTaskInfoV2 converts the internal TaskInfo (TTL stored as milliseconds) to
+// the v2 wire shape (ttlSeconds, pollIntervalMilliseconds; no parentTaskId).
+// nil TTL stays nil ("unlimited"); positive ms round down to whole seconds
+// with a 1-second floor so sub-second TTLs don't collapse to "expired".
+func toTaskInfoV2(info core.TaskInfo) core.TaskInfoV2 {
+	out := core.TaskInfoV2{
+		TaskID:        info.TaskID,
+		Status:        info.Status,
+		StatusMessage: info.StatusMessage,
+		CreatedAt:     info.CreatedAt,
+		LastUpdatedAt: info.LastUpdatedAt,
+	}
 	if info.TTL != nil && *info.TTL > 0 {
 		sec := *info.TTL / 1000
 		if sec <= 0 {
 			sec = 1
 		}
-		info.TTL = &sec
+		out.TTLSeconds = &sec
 	}
+	if info.PollInterval > 0 {
+		pi := info.PollInterval
+		out.PollIntervalMilliseconds = &pi
+	}
+	return out
 }
 
 // notifyV2TaskStatus sends a v2-style status notification with the full
-// DetailedTask (inlined result/error). Best-effort.
+// DetailedTask (inlined result/error) read fresh from the store. Best-effort.
 func notifyV2TaskStatus(ctx context.Context, rt *v2TaskRuntime, store TaskStore, taskID, sessionID string) {
 	info, ok := store.Get(taskID, sessionID)
 	if !ok {
 		return
 	}
-	ttlToSeconds(&info)
 
-	// Build a DetailedTask notification payload.
-	payload := core.GetTaskResultV2{
-		TaskInfo: info,
-	}
+	payload := core.DetailedTask{TaskInfoV2: toTaskInfoV2(info)}
 
 	if info.Status == core.TaskCompleted {
 		toolResult, found := store.GetResult(taskID, sessionID)
@@ -426,4 +431,18 @@ func notifyV2TaskStatus(ctx context.Context, rt *v2TaskRuntime, store TaskStore,
 	}
 
 	core.Notify(ctx, "notifications/tasks/status", payload)
+}
+
+// notifyV2TaskStatusFromInfo sends a status notification through the live
+// MethodContext for callers that already have fresh TaskInfo (e.g., the
+// cancel handler, which gets info back from store.Cancel and doesn't need
+// to re-read it).
+func notifyV2TaskStatusFromInfo(ctx core.MethodContext, rt *v2TaskRuntime, info core.TaskInfo) {
+	payload := core.DetailedTask{TaskInfoV2: toTaskInfoV2(info)}
+	if info.Status == core.TaskFailed {
+		if te := rt.getTaskError(info.TaskID); te != nil {
+			payload.Error = te
+		}
+	}
+	ctx.Notify("notifications/tasks/status", payload)
 }

--- a/server/tasks_v2_test.go
+++ b/server/tasks_v2_test.go
@@ -1,0 +1,264 @@
+package server_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/panyam/mcpkit/client"
+	"github.com/panyam/mcpkit/core"
+	. "github.com/panyam/mcpkit/server"
+)
+
+// newTaskV2Server registers a v2 tasks server with three tools:
+//   - "echo"      — sync (no Execution → forbidden)
+//   - "fast-task" — async-eligible (TaskSupportOptional, completes immediately)
+//   - "must-task" — async-required (TaskSupportRequired, completes immediately)
+//
+// fast-task / must-task complete on the first goroutine tick so polling tests
+// don't need to thread an unblock channel through every assertion.
+func newTaskV2Server(t *testing.T) *Server {
+	t.Helper()
+
+	srv := NewServer(core.ServerInfo{Name: "tasks-v2-test", Version: "0.0.1"})
+
+	type echoInput struct {
+		Message string `json:"message"`
+	}
+	srv.Register(core.TextTool[echoInput]("echo", "Echoes input",
+		func(ctx core.ToolContext, input echoInput) (string, error) {
+			return "echo: " + input.Message, nil
+		},
+	))
+
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "fast-task",
+			Description: "Async-eligible, completes immediately",
+			InputSchema: map[string]any{"type": "object"},
+			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
+		},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+			return core.TextResult("fast-done"), nil
+		},
+	)
+
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "must-task",
+			Description: "Async-required, completes immediately",
+			InputSchema: map[string]any{"type": "object"},
+			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportRequired},
+		},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+			return core.TextResult("must-done"), nil
+		},
+	)
+
+	RegisterTasksV2(TasksV2Config{Server: srv})
+	return srv
+}
+
+func connectV2Client(t *testing.T, srv *Server, opts ...client.ClientOption) *client.Client {
+	t.Helper()
+	handler := srv.Handler(WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "v2-test", Version: "0.0.1"}, opts...)
+	if err := c.Connect(); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+	return c
+}
+
+// --- Phase 3 gating tests ---
+
+// TestV2_ExtensionAdvertised verifies the SEP-2663 Tasks extension is
+// advertised in the initialize response under capabilities.extensions.
+func TestV2_ExtensionAdvertised(t *testing.T) {
+	srv := newTaskV2Server(t)
+	c := connectV2Client(t, srv, client.WithTasksExtension())
+
+	if !c.ServerSupportsExtension(core.TasksExtensionID) {
+		t.Errorf("server should advertise %q in capabilities.extensions", core.TasksExtensionID)
+	}
+}
+
+// TestV2_NoTaskCreationWithoutExtension verifies that an async-eligible tool
+// call returns a synchronous ToolResult (no resultType discriminator) when
+// the client has not negotiated the tasks extension. SEP-2663: server MUST
+// NOT return CreateTaskResult without negotiation.
+func TestV2_NoTaskCreationWithoutExtension(t *testing.T) {
+	srv := newTaskV2Server(t)
+	c := connectV2Client(t, srv) // no WithTasksExtension
+
+	res, err := c.Call("tools/call", map[string]any{
+		"name":      "fast-task",
+		"arguments": map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("tools/call: %v", err)
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(res.Raw, &m); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if rt, ok := m["resultType"]; ok {
+		t.Errorf("response must NOT carry resultType when extension not negotiated; got resultType=%v", rt)
+	}
+	if _, ok := m["task"]; ok {
+		t.Errorf("response must NOT carry task envelope when extension not negotiated; got %s", res.Raw)
+	}
+	// Sync ToolResult shape: should have content[].
+	if _, ok := m["content"]; !ok {
+		t.Errorf("expected sync ToolResult shape with content[]; got %s", res.Raw)
+	}
+}
+
+// TestV2_TaskCreationWithExtension verifies that the same async-eligible tool
+// returns a CreateTaskResult once the client has negotiated the extension.
+func TestV2_TaskCreationWithExtension(t *testing.T) {
+	srv := newTaskV2Server(t)
+	c := connectV2Client(t, srv, client.WithTasksExtension())
+
+	res, err := c.Call("tools/call", map[string]any{
+		"name":      "fast-task",
+		"arguments": map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("tools/call: %v", err)
+	}
+
+	var ctr core.CreateTaskResult
+	if err := json.Unmarshal(res.Raw, &ctr); err != nil {
+		t.Fatalf("unmarshal CreateTaskResult: %v", err)
+	}
+	if ctr.ResultType != core.ResultTypeTask {
+		t.Errorf("resultType = %q, want %q", ctr.ResultType, core.ResultTypeTask)
+	}
+	if ctr.Task.TaskID == "" {
+		t.Error("CreateTaskResult.task.taskId should not be empty")
+	}
+}
+
+// TestV2_TasksGetRejectedWithoutExtension verifies tasks/get returns
+// -32601 (method not found) when the client has not negotiated the extension.
+func TestV2_TasksGetRejectedWithoutExtension(t *testing.T) {
+	srv := newTaskV2Server(t)
+	c := connectV2Client(t, srv) // no WithTasksExtension
+
+	_, err := c.Call("tasks/get", map[string]any{"taskId": "any-id"})
+	if err == nil {
+		t.Fatal("tasks/get should fail without extension negotiation")
+	}
+	rpcErr, ok := err.(*client.RPCError)
+	if !ok {
+		t.Fatalf("expected *client.RPCError, got %T: %v", err, err)
+	}
+	if rpcErr.Code != core.ErrCodeMethodNotFound {
+		t.Errorf("code = %d, want %d (method not found)", rpcErr.Code, core.ErrCodeMethodNotFound)
+	}
+}
+
+// TestV2_TasksCancelRejectedWithoutExtension verifies tasks/cancel returns
+// -32601 when the client has not negotiated the extension.
+func TestV2_TasksCancelRejectedWithoutExtension(t *testing.T) {
+	srv := newTaskV2Server(t)
+	c := connectV2Client(t, srv) // no WithTasksExtension
+
+	_, err := c.Call("tasks/cancel", map[string]any{"taskId": "any-id"})
+	if err == nil {
+		t.Fatal("tasks/cancel should fail without extension negotiation")
+	}
+	rpcErr, ok := err.(*client.RPCError)
+	if !ok {
+		t.Fatalf("expected *client.RPCError, got %T: %v", err, err)
+	}
+	if rpcErr.Code != core.ErrCodeMethodNotFound {
+		t.Errorf("code = %d, want %d (method not found)", rpcErr.Code, core.ErrCodeMethodNotFound)
+	}
+}
+
+// TestV2_PerRequestExtensionOptIn verifies SEP-2575: a client that did NOT
+// negotiate the extension in initialize can still opt into task creation on
+// a single tools/call by including io.modelcontextprotocol/clientCapabilities
+// under _meta.
+func TestV2_PerRequestExtensionOptIn(t *testing.T) {
+	srv := newTaskV2Server(t)
+	c := connectV2Client(t, srv) // session-level: no extension
+
+	res, err := c.Call("tools/call", map[string]any{
+		"name":      "fast-task",
+		"arguments": map[string]any{},
+		"_meta": map[string]any{
+			core.PerRequestClientCapsKey: map[string]any{
+				"extensions": map[string]any{
+					core.TasksExtensionID: map[string]any{},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("tools/call with per-request opt-in: %v", err)
+	}
+
+	var ctr core.CreateTaskResult
+	if err := json.Unmarshal(res.Raw, &ctr); err != nil {
+		t.Fatalf("unmarshal CreateTaskResult: %v", err)
+	}
+	if ctr.ResultType != core.ResultTypeTask {
+		t.Errorf("per-request opt-in should produce CreateTaskResult; got resultType=%q, raw=%s", ctr.ResultType, res.Raw)
+	}
+}
+
+// TestV2_TasksGetWorksWithExtension is a smoke test that with the extension
+// negotiated, the full create → get cycle works end-to-end.
+func TestV2_TasksGetWorksWithExtension(t *testing.T) {
+	srv := newTaskV2Server(t)
+	c := connectV2Client(t, srv, client.WithTasksExtension())
+
+	res, err := c.Call("tools/call", map[string]any{
+		"name":      "fast-task",
+		"arguments": map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("tools/call: %v", err)
+	}
+	var ctr core.CreateTaskResult
+	if err := json.Unmarshal(res.Raw, &ctr); err != nil {
+		t.Fatalf("unmarshal CreateTaskResult: %v", err)
+	}
+
+	// Poll tasks/get until terminal — fast-task completes on first goroutine tick.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	for {
+		gres, err := c.Call("tasks/get", map[string]any{"taskId": ctr.Task.TaskID})
+		if err != nil {
+			t.Fatalf("tasks/get: %v", err)
+		}
+		var dt core.DetailedTask
+		if err := json.Unmarshal(gres.Raw, &dt); err != nil {
+			t.Fatalf("unmarshal DetailedTask: %v", err)
+		}
+		if dt.Status.IsTerminal() {
+			if dt.Status != core.TaskCompleted {
+				t.Errorf("status = %q, want %q", dt.Status, core.TaskCompleted)
+			}
+			if dt.Result == nil || len(dt.Result.Content) == 0 || dt.Result.Content[0].Text != "fast-done" {
+				t.Errorf("inlined result mismatch; got %+v", dt.Result)
+			}
+			return
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("task did not reach terminal: %v", ctx.Err())
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Phases 1, 2, and 3 of the SEP-2663 (Tasks Extension) implementation plan in `PLAN.md`. Issues: #320 (SEP-2663), #321 (SEP-2322).

This is **type & negotiation work** — no protocol behavior visible to a client that hasn't opted into the extension; the v1 path is untouched.

### Phase 1 — MRTR base types (SEP-2322) — commit 89f514c
`core/task_v2.go` gains the MRTR primitives:
- `ResultTypeComplete` / `ResultTypeIncomplete` constants alongside `ResultTypeTask`.
- `InputRequest{Method, Params}` struct.
- `InputRequests = map[string]InputRequest` and `InputResponses = map[string]json.RawMessage` typed aliases.

### Phase 2 — SEP-2663 task type evolution — commit 89f514c
- v1 result types renamed to `*V1` (`CreateTaskResultV1`, `GetTaskResultV1`, `CancelTaskResultV1`, `ListTasksResultV1`).
- v2 types drop the `V2` suffix and become canonical: `CreateTaskResult` (resultType+task only), `DetailedTask` discriminated union with `WorkingTask` / `InputRequiredTask` / `CompletedTask` / `FailedTask` / `CancelledTask` aliases, `GetTaskResult = DetailedTask`, new `UpdateTaskRequest`, empty-ack `UpdateTaskResult` and `CancelTaskResult`.
- New `TaskInfoV2` wire shape with `ttlSeconds` and `pollIntervalMilliseconds` (renamed per pja-ant feedback), no `parentTaskId`. Internal `TaskInfo` (and the `TaskStore` record) keeps milliseconds; conversion happens at the wire boundary via `toTaskInfoV2()` in `server/tasks_v2.go`.
- `tasks/cancel` returns `{}` per SEP-2663 but still notifies `DetailedTask` via SSE.

### Phase 3 — Extension capability negotiation — commit 7c84b1e
- Tasks v2 is now an **extension** (`io.modelcontextprotocol/tasks`) rather than a core capability. Server advertises it under `capabilities.extensions` in the `initialize` response.
- `core.PerRequestClientCaps(json.RawMessage)` decodes the SEP-2575 per-request capability override; `core.ClientSupportsExtensionForRequest` combines session-level + per-request declarations (additive).
- `Server.RegisterExtension(ext)` allows runtime extension declaration, mirroring `WithExtension` at construction time.
- v2 middleware gates task creation on the client supporting the extension; tools that would otherwise be async fall through to synchronous `tools/call` for unsupporting clients.
- `tasks/get` and `tasks/cancel` are wrapped in `gateOnTasksExtension`; they return `-32601` when the client did not negotiate at session level.
- `_meta` envelope is fully typed: `progressToken any` + `ClientCapabilitiesRaw json.RawMessage` (no bare `map[string]any`).
- `client.WithTasksExtension()` convenience option matching `WithUIExtension()`.
- v2 walkthrough opts into the extension and explains the new gate.

### Deferred (captured in PLAN.md / mcpkit#326)
- `TaskInfoV2` keeps its `V2` suffix for now — current `TaskInfo` is doing double duty as both v1 wire shape AND internal `TaskStore` record. Revisit when v1 is removed or the store record diverges.
- `notifyV2TaskStatus` keeps `context.Context` while `notifyV2TaskStatusFromInfo` takes `core.MethodContext` — the asymmetry is intentional (different layers); cross-cutting note logged on mcpkit#326.
- `ToolExecution.TaskSupport` remains as a server-internal hint for which tools should be async; wire-removal for v2 clients is deferred.

## What's NOT in this PR
- **Phase 4** — server handler rewrites (`tasks/update`, `Mcp-Name` header (SEP-2243), `RegisterTasks` rename so the v2 path takes the canonical name).
- **Phase 5** — input-request flow (poll-based MRTR via `TaskContext.TaskElicit`/`TaskSample` + `tasks/update`).
- **Phase 6** — client (`DetailedTask`, `UpdateTask`, polymorphic `tools/call` dispatch).
- **Phase 7** — example + conformance rework (will fix the v2 conformance regression noted below).
- **Phase 8** — backcompat bridge.

## Test plan
- [x] `make test` — core / server / client / testutil all green.
- [x] **15 new tests** in `core/task_v2_test.go` covering wire shapes for `TaskInfoV2`, `CreateTaskResult` (forbidden-field guard), `DetailedTask` completed/failed variants, `UpdateTaskRequest`, empty acks.
- [x] **7 new tests** in `server/tasks_v2_test.go` covering Phase 3 gating: extension advertised, no `CreateTaskResult` without negotiation, `tasks/get`/`tasks/cancel` return `-32601` without negotiation, SEP-2575 per-request opt-in, end-to-end smoke.
- [x] v2 walkthrough demo (`examples/tasks-v2`) exercises the new types, gates, and ack-only cancel — runs clean.
- [ ] `make testconf-tasks-v2` — **expected to regress** on v2-07/v2-08 (cancel shape change), `ttlSeconds` field rename, and now the extension-negotiation gate. Reworked in Phase 7.
- [x] `make testconf-tasks` — v1 conformance unaffected (path frozen).