### PR TITLE
feat(events): webhook secret modes + Standard Webhooks header variant (PR C of #323)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Binaries
+__pycache__
 bin
 *.exe
 *.exe~

--- a/experimental/discord-events/README.md
+++ b/experimental/discord-events/README.md
@@ -171,3 +171,24 @@ typed accessors (for resource reads).
 | `make poll` | Polling loop (default 5s interval, override: `INTERVAL=10`) |
 
 All client commands use the shared [`events_client.py`](../ext/events/events_client.py).
+
+## Webhook secret + header modes
+
+The server flags select per-registry secret and header modes (see
+[`experimental/ext/events/README.md`](../ext/events/) for the full matrix).
+
+```bash
+# Default: server-generated secrets, X-MCP-* headers
+go run . -addr :8080
+
+# Client-supplied secrets (echoed back if non-empty)
+go run . -addr :8080 -webhook-secret-mode client
+
+# Identity mode: secret = HMAC(root, tuple); subscribe is idempotent on tuple
+go run . -addr :8080 -webhook-secret-mode identity -webhook-root deadbeefcafef00d
+
+# Standard Webhooks header naming (webhook-id / webhook-timestamp / webhook-signature)
+go run . -addr :8080 -webhook-header-mode standard
+```
+
+The Python `make webhook` receiver auto-detects the header set on the wire and verifies accordingly — no extra client-side flag.

--- a/experimental/discord-events/e2e_test.go
+++ b/experimental/discord-events/e2e_test.go
@@ -19,9 +19,11 @@ import (
 
 // buildTestStack constructs a server + source + yield closure used by all
 // e2e tests. The source and yield are returned so tests can directly publish
-// events without spinning up a Discord session.
-func buildTestStack() (*server.Server, *events.YieldingSource[DiscordEventData], func(DiscordEventData) error, *events.WebhookRegistry) {
-	webhooks := events.NewWebhookRegistry()
+// events without spinning up a Discord session. Optional WebhookOptions
+// configure the registry — defaults match the production demo (Server +
+// MCPHeaders).
+func buildTestStack(whOpts ...events.WebhookOption) (*server.Server, *events.YieldingSource[DiscordEventData], func(DiscordEventData) error, *events.WebhookRegistry) {
+	webhooks := events.NewWebhookRegistry(whOpts...)
 	source, yield := newDiscordSource()
 
 	srv := server.NewServer(
@@ -120,20 +122,26 @@ func TestE2EPushDelivery(t *testing.T) {
 	assert.Contains(t, received, "notifications/events/event")
 }
 
-// TestE2EWebhookDelivery verifies webhook fanout — same library hook also
-// routes events to registered webhook subscribers with HMAC signing. Tests
-// the full subscribe → yield → POST → verify-signature path.
+// TestE2EWebhookDelivery verifies webhook fanout via the default secret mode
+// (Server). Demonstrates the post-PR-C contract: the server generates the
+// secret regardless of what the client supplied, returns it in the subscribe
+// response, and signs deliveries with the generated secret. The receiver
+// uses the returned secret to verify.
 func TestE2EWebhookDelivery(t *testing.T) {
 	srv, _, yield, webhooks := buildTestStack()
 
 	var mu sync.Mutex
 	var deliveries []events.Event
+	var assignedSecret string
 
 	callbackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
 		sig := r.Header.Get("X-MCP-Signature")
 		ts := r.Header.Get("X-MCP-Timestamp")
-		assert.True(t, events.VerifySignature(body, "secret", ts, sig))
+		mu.Lock()
+		secret := assignedSecret
+		mu.Unlock()
+		assert.True(t, events.VerifyMCPSignature(body, secret, ts, sig), "signature should verify against the server-assigned secret")
 
 		var event events.Event
 		json.Unmarshal(body, &event)
@@ -146,13 +154,23 @@ func TestE2EWebhookDelivery(t *testing.T) {
 
 	c, _ := connectClient(t, srv)
 
-	_, err := c.Call("events/subscribe", map[string]any{
+	subResult, err := c.Call("events/subscribe", map[string]any{
 		"id":       "wh",
 		"name":     "discord.message",
-		"delivery": map[string]any{"mode": "webhook", "url": callbackSrv.URL, "secret": "secret"},
+		"delivery": map[string]any{"mode": "webhook", "url": callbackSrv.URL, "secret": "ignored-in-server-mode"},
 	})
 	require.NoError(t, err)
 	require.Len(t, webhooks.Targets(), 1)
+
+	var subResp struct {
+		Secret string `json:"secret"`
+	}
+	require.NoError(t, json.Unmarshal(subResult.Raw, &subResp))
+	require.NotEmpty(t, subResp.Secret, "server mode must return its generated secret")
+	require.NotEqual(t, "ignored-in-server-mode", subResp.Secret, "server mode must NOT echo the client-supplied secret")
+	mu.Lock()
+	assignedSecret = subResp.Secret
+	mu.Unlock()
 
 	require.NoError(t, yield(newDiscordEvent("g", "c", "bob", "webhook test", time.Now())))
 	time.Sleep(500 * time.Millisecond)
@@ -206,6 +224,166 @@ func TestE2EResourceRead(t *testing.T) {
 	require.Len(t, payloads, 1)
 	assert.Equal(t, "alice", payloads[0].Author.Username)
 	assert.Equal(t, "resource test", payloads[0].Content)
+}
+
+// TestE2EWebhookDelivery_IdentityMode verifies the identity-mode contract
+// end-to-end: subscribe is idempotent on the (name, url, params) tuple, the
+// server returns derived id and secret, and webhook delivery signs with
+// the derived secret. Two subscribes with the same tuple must collapse to
+// one registry entry.
+func TestE2EWebhookDelivery_IdentityMode(t *testing.T) {
+	srv, _, yield, webhooks := buildTestStack(
+		events.WithWebhookSecretMode(events.WebhookSecretIdentity),
+		events.WithWebhookRoot([]byte("test-root-master")),
+	)
+
+	var mu sync.Mutex
+	var deliveries []events.Event
+	var assignedSecret string
+
+	callbackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		sig := r.Header.Get("X-MCP-Signature")
+		ts := r.Header.Get("X-MCP-Timestamp")
+		mu.Lock()
+		secret := assignedSecret
+		mu.Unlock()
+		assert.True(t, events.VerifyMCPSignature(body, secret, ts, sig), "delivery should sign with the derived secret")
+
+		var event events.Event
+		json.Unmarshal(body, &event)
+		mu.Lock()
+		deliveries = append(deliveries, event)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer callbackSrv.Close()
+
+	c, _ := connectClient(t, srv)
+
+	subscribe := func(clientID string) (string, string) {
+		t.Helper()
+		raw, err := c.Call("events/subscribe", map[string]any{
+			"id":   clientID,
+			"name": "discord.message",
+			"delivery": map[string]any{
+				"mode":   "webhook",
+				"url":    callbackSrv.URL,
+				"params": map[string]string{"region": "us"},
+			},
+		})
+		require.NoError(t, err)
+		var resp struct {
+			ID     string `json:"id"`
+			Secret string `json:"secret"`
+		}
+		require.NoError(t, json.Unmarshal(raw.Raw, &resp))
+		return resp.ID, resp.Secret
+	}
+
+	id1, sec1 := subscribe("client-id-A")
+	id2, sec2 := subscribe("client-id-B") // different client id, same tuple
+	assert.Equal(t, id1, id2, "identity mode must derive the same id regardless of client-supplied id")
+	assert.Equal(t, sec1, sec2, "identity mode must derive the same secret for the same tuple")
+	assert.Len(t, webhooks.Targets(), 1, "two subscribes against the same tuple must collapse to one entry")
+
+	mu.Lock()
+	assignedSecret = sec1
+	mu.Unlock()
+
+	require.NoError(t, yield(newDiscordEvent("g", "c", "alice", "identity-mode test", time.Now())))
+	time.Sleep(500 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, deliveries, 1, "delivery must reach the receiver under the derived secret")
+}
+
+// TestE2EWebhookDelivery_StandardHeaders verifies that switching the header
+// mode to StandardWebhooks emits webhook-id / webhook-timestamp /
+// webhook-signature on the wire and that the signature verifies via the
+// Standard Webhooks verifier (not the X-MCP-* one).
+func TestE2EWebhookDelivery_StandardHeaders(t *testing.T) {
+	srv, _, yield, _ := buildTestStack(
+		events.WithWebhookHeaderMode(events.StandardWebhooks),
+	)
+
+	var mu sync.Mutex
+	var deliveries int
+	var assignedSecret string
+
+	callbackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		msgID := r.Header.Get("webhook-id")
+		ts := r.Header.Get("webhook-timestamp")
+		sig := r.Header.Get("webhook-signature")
+		assert.NotEmpty(t, msgID, "must emit webhook-id")
+		assert.NotEmpty(t, ts, "must emit webhook-timestamp")
+		assert.True(t, len(sig) > 3 && sig[:3] == "v1,", "signature must be v1,<base64>")
+		assert.Empty(t, r.Header.Get("X-MCP-Signature"), "must NOT emit X-MCP-* headers in standard mode")
+
+		mu.Lock()
+		secret := assignedSecret
+		mu.Unlock()
+		assert.True(t, events.VerifyStandardWebhooksSignature(body, secret, msgID, ts, sig))
+
+		mu.Lock()
+		deliveries++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer callbackSrv.Close()
+
+	c, _ := connectClient(t, srv)
+	raw, err := c.Call("events/subscribe", map[string]any{
+		"id":       "wh-std",
+		"name":     "discord.message",
+		"delivery": map[string]any{"mode": "webhook", "url": callbackSrv.URL},
+	})
+	require.NoError(t, err)
+	var resp struct {
+		Secret string `json:"secret"`
+	}
+	require.NoError(t, json.Unmarshal(raw.Raw, &resp))
+	mu.Lock()
+	assignedSecret = resp.Secret
+	mu.Unlock()
+
+	require.NoError(t, yield(newDiscordEvent("g", "c", "alice", "standard-headers test", time.Now())))
+	time.Sleep(500 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 1, deliveries)
+}
+
+// TestE2EUnsubscribeBySecret verifies the proof-of-possession unsubscribe
+// path works through the JSON-RPC handler — clients can unsubscribe by
+// presenting the secret without remembering the server-assigned id.
+func TestE2EUnsubscribeBySecret(t *testing.T) {
+	srv, _, _, webhooks := buildTestStack()
+	c, _ := connectClient(t, srv)
+
+	raw, err := c.Call("events/subscribe", map[string]any{
+		"id":       "wh-unsub",
+		"name":     "discord.message",
+		"delivery": map[string]any{"mode": "webhook", "url": "http://localhost:1/sink"},
+	})
+	require.NoError(t, err)
+	var resp struct {
+		Secret string `json:"secret"`
+	}
+	require.NoError(t, json.Unmarshal(raw.Raw, &resp))
+	require.Len(t, webhooks.Targets(), 1)
+
+	_, err = c.Call("events/unsubscribe", map[string]any{
+		"delivery": map[string]any{
+			"url":    "http://localhost:1/sink",
+			"secret": resp.Secret,
+		},
+	})
+	require.NoError(t, err)
+	assert.Len(t, webhooks.Targets(), 0, "unsubscribe by secret must remove the matching subscription")
 }
 
 // TestE2EResourceByCursor verifies the per-message resource template resolves

--- a/experimental/discord-events/main.go
+++ b/experimental/discord-events/main.go
@@ -10,6 +10,7 @@
 package main
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"flag"
 	"log"
@@ -32,13 +33,40 @@ func main() {
 	addr := flag.String("addr", ":8080", "listen address")
 	token := flag.String("token", "", "Discord bot token (omit for test mode)")
 	whTTL := flag.Duration("webhook-ttl", 0, "override webhook subscription TTL (default 60s; useful for driving the SDK refresh path in tests)")
+	whSecretMode := flag.String("webhook-secret-mode", "server", "webhook secret mode: server | client | identity")
+	whHeaderMode := flag.String("webhook-header-mode", "mcp", "webhook header style: mcp | standard")
+	whRootHex := flag.String("webhook-root", "", "hex-encoded master secret for identity mode (required when -webhook-secret-mode=identity)")
 	flag.Parse()
 
-	var whOpts []events.WebhookOption
+	secretMode, err := events.ParseSecretMode(*whSecretMode)
+	if err != nil {
+		log.Fatalf("invalid -webhook-secret-mode: %v", err)
+	}
+	headerMode, err := events.ParseHeaderMode(*whHeaderMode)
+	if err != nil {
+		log.Fatalf("invalid -webhook-header-mode: %v", err)
+	}
+
+	whOpts := []events.WebhookOption{
+		events.WithWebhookSecretMode(secretMode),
+		events.WithWebhookHeaderMode(headerMode),
+	}
 	if *whTTL > 0 {
 		whOpts = append(whOpts, events.WithWebhookTTL(*whTTL))
 		log.Printf("[server] webhook TTL overridden to %s", *whTTL)
 	}
+	if secretMode == events.WebhookSecretIdentity {
+		if *whRootHex == "" {
+			log.Fatalf("-webhook-root is required when -webhook-secret-mode=identity")
+		}
+		root, err := hex.DecodeString(*whRootHex)
+		if err != nil {
+			log.Fatalf("invalid -webhook-root: %v", err)
+		}
+		whOpts = append(whOpts, events.WithWebhookRoot(root))
+	}
+	log.Printf("[server] webhook modes: secret=%s headers=%s", secretMode, headerMode)
+
 	webhooks := events.NewWebhookRegistry(whOpts...)
 	source, yield := newDiscordSource()
 

--- a/experimental/ext/events/README.md
+++ b/experimental/ext/events/README.md
@@ -114,16 +114,61 @@ type PollResult struct {
 
 ## Webhook delivery
 
-- HMAC-SHA256 signing: `HMAC(secret, timestamp + "." + body)`
-- Headers: `X-MCP-Signature`, `X-MCP-Timestamp`
 - TTL-based soft state with automatic expiry (default 60s, override via `WithWebhookTTL`)
-- Keyed by `(url, id)` per spec (unauthenticated servers)
 - Retry with exponential backoff on 5xx (no retry on 4xx)
 - Basic SSRF validation on callback URLs
+- Pluggable signature format and secret model (see below)
 
 ```go
-webhooks := events.NewWebhookRegistry(events.WithWebhookTTL(5 * time.Second))
+webhooks := events.NewWebhookRegistry(
+    events.WithWebhookTTL(5 * time.Second),
+    events.WithWebhookSecretMode(events.WebhookSecretIdentity),
+    events.WithWebhookRoot([]byte("master")),
+    events.WithWebhookHeaderMode(events.StandardWebhooks),
+)
 ```
+
+### Secret mode (`WebhookSecretMode`)
+
+Three options for who decides on the per-subscription HMAC secret. Default is `WebhookSecretServer`.
+
+| Mode | Behavior | When to use |
+|---|---|---|
+| `WebhookSecretServer` (default) | Server always generates a fresh high-entropy secret; client-supplied `delivery.secret` is ignored. Returned in subscribe response. | Most cases. Avoids trusting client entropy. |
+| `WebhookSecretClient` | Client supplies `delivery.secret`; if empty, server generates one. | Pre-provisioned secrets (IaC, gateways with the secret in config). |
+| `WebhookSecretIdentity` | Secret is `HMAC(root, canonical(name, url, params))`. Subscribe is **idempotent** on the tuple — same inputs return the same `id` and `secret`, no duplicate registry entry. Requires `WithWebhookRoot`. | When subscriptions are agent-generated and you want deterministic, deduplicating identity. |
+
+### Header mode (`WebhookHeaderMode`)
+
+Two on-the-wire signature formats. Default is `MCPHeaders`. Only the headers and signature scheme are configurable; the body shape (the `events.Event` envelope) is unchanged.
+
+| Mode | Headers | HMAC base |
+|---|---|---|
+| `MCPHeaders` (default) | `X-MCP-Signature: sha256=<hex>` + `X-MCP-Timestamp: <unix>` | `HMAC(secret, ts + "." + body)` |
+| `StandardWebhooks` | `webhook-id`, `webhook-timestamp`, `webhook-signature: v1,<base64>` per [standardwebhooks.com](https://www.standardwebhooks.com/) | `HMAC(secret, msg_id + "." + ts + "." + body)` |
+
+Verification helpers ship for both:
+
+```go
+events.VerifyMCPSignature(body, secret, ts, sig)
+events.VerifyStandardWebhooksSignature(body, secret, msgID, ts, sig)
+```
+
+The Python `events_client.py` receiver auto-detects which header set is on the inbound request and verifies accordingly — no client-side mode flag needed.
+
+### Unsubscribe
+
+Two equivalent forms — pick whichever is convenient. In Identity mode the secret form is preferred because the `id` is server-derived.
+
+```jsonc
+// By id (any mode):
+{"delivery": {"url": "https://...", "id": "sub-1"}}
+
+// By proof-of-possession of the secret (any mode):
+{"delivery": {"url": "https://...", "secret": "whsec_..."}}
+```
+
+The registry method is `WebhookRegistry.Unregister(url, id)` or `WebhookRegistry.UnregisterBySecret(url, secret)`. The unsubscribe handler accepts either form.
 
 ## Python client SDK — auto-refresh
 

--- a/experimental/ext/events/events.go
+++ b/experimental/ext/events/events.go
@@ -14,7 +14,6 @@ package events
 
 import (
 	"encoding/json"
-	"fmt"
 	"time"
 
 	"github.com/panyam/mcpkit/core"
@@ -254,12 +253,13 @@ func registerPoll(srv *server.Server, sourceMap map[string]EventSource) {
 func registerSubscribe(srv *server.Server, sourceMap map[string]EventSource, webhooks *WebhookRegistry) {
 	srv.HandleMethod("events/subscribe", func(ctx core.MethodContext, id json.RawMessage, params json.RawMessage) *core.Response {
 		var req struct {
-			ID       string  `json:"id"`
-			Name     string  `json:"name"`
+			ID       string `json:"id"`
+			Name     string `json:"name"`
 			Delivery struct {
-				Mode   string `json:"mode"`
-				URL    string `json:"url"`
-				Secret string `json:"secret,omitempty"`
+				Mode   string            `json:"mode"`
+				URL    string            `json:"url"`
+				Secret string            `json:"secret,omitempty"`
+				Params map[string]string `json:"params,omitempty"` // identity-mode tuple input
 			} `json:"delivery"`
 			Cursor *string `json:"cursor"`
 		}
@@ -279,12 +279,13 @@ func registerSubscribe(srv *server.Server, sourceMap map[string]EventSource, web
 			return core.NewErrorResponse(id, -32005, err.Error())
 		}
 
-		secret := req.Delivery.Secret
-		if secret == "" {
-			secret = fmt.Sprintf("whsec_%d", time.Now().UnixNano())
-		}
+		// Per-mode behavior is documented on WebhookSecretMode.
+		resolvedID, secret := webhooks.resolveSecret(
+			req.ID, req.Delivery.Secret,
+			req.Name, req.Delivery.URL, req.Delivery.Params,
+		)
 
-		expiresAt := webhooks.Register(req.ID, req.Delivery.URL, secret)
+		expiresAt := webhooks.Register(resolvedID, req.Delivery.URL, secret)
 
 		cursorStr := "0"
 		if req.Cursor != nil {
@@ -292,7 +293,7 @@ func registerSubscribe(srv *server.Server, sourceMap map[string]EventSource, web
 		}
 
 		return core.NewResponse(id, map[string]any{
-			"id":            req.ID,
+			"id":            resolvedID,
 			"secret":        secret,
 			"cursor":        cursorStr,
 			"refreshBefore": expiresAt.Format(time.RFC3339),
@@ -305,7 +306,8 @@ func registerUnsubscribe(srv *server.Server, webhooks *WebhookRegistry) {
 		var req struct {
 			ID       string `json:"id"`
 			Delivery *struct {
-				URL string `json:"url"`
+				URL    string `json:"url"`
+				Secret string `json:"secret,omitempty"` // proof-of-possession path (any mode)
 			} `json:"delivery,omitempty"`
 		}
 		if err := json.Unmarshal(params, &req); err != nil {
@@ -314,7 +316,18 @@ func registerUnsubscribe(srv *server.Server, webhooks *WebhookRegistry) {
 		if req.Delivery == nil || req.Delivery.URL == "" {
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, "delivery.url required")
 		}
-		webhooks.Unregister(req.Delivery.URL, req.ID)
+		if req.ID == "" && req.Delivery.Secret == "" {
+			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, "either id or delivery.secret is required")
+		}
+		// Either form is accepted in any mode. Identity mode docs steer
+		// clients toward the secret form (proof-of-possession); other modes
+		// typically use the id form. Internally the registry resolves both
+		// to the same subscription.
+		if req.ID != "" {
+			webhooks.Unregister(req.Delivery.URL, req.ID)
+		} else {
+			webhooks.UnregisterBySecret(req.Delivery.URL, req.Delivery.Secret)
+		}
 		return core.NewResponse(id, map[string]any{})
 	})
 }

--- a/experimental/ext/events/events_client.py
+++ b/experimental/ext/events/events_client.py
@@ -360,20 +360,48 @@ class WebhookSubscription:
 # Subcommand: webhook
 # ═══════════════════════════════════════════════════════════════════
 
-def _make_webhook_handler(secret: str):
+def _verify_signature(headers, body: bytes, secret: str) -> bool:
+    """Verify either X-MCP-* or webhook-* signature on an inbound delivery.
+    Detects which header set is present rather than requiring the caller to
+    know the server's mode — handy for ad-hoc receivers and tests.
+    """
+    mcp_sig = headers.get("X-MCP-Signature", "")
+    if mcp_sig:
+        ts = headers.get("X-MCP-Timestamp", "")
+        expected = "sha256=" + hmac.new(
+            secret.encode(), (ts + ".").encode() + body, hashlib.sha256
+        ).hexdigest()
+        return hmac.compare_digest(mcp_sig, expected)
+
+    std_sig = headers.get("webhook-signature", "")
+    if std_sig:
+        msg_id = headers.get("webhook-id", "")
+        ts = headers.get("webhook-timestamp", "")
+        import base64
+        expected = "v1," + base64.b64encode(
+            hmac.new(secret.encode(), (msg_id + "." + ts + ".").encode() + body, hashlib.sha256).digest()
+        ).decode()
+        # Standard Webhooks allows multiple space-separated v1 sigs; any match wins.
+        for cand in std_sig.split():
+            if hmac.compare_digest(cand, expected):
+                return True
+        return False
+    return False
+
+
+def _make_webhook_handler(secret_holder):
+    """secret_holder is a list with one element — `secret_holder[0]` — so the
+    handler reads the live secret on every request. cmd_webhook updates the
+    holder after subscribe returns the server-assigned secret (which may
+    differ from anything the client supplied, depending on secret mode)."""
     class Handler(BaseHTTPRequestHandler):
         def do_POST(self):
             length = int(self.headers.get("Content-Length", 0))
             body = self.rfile.read(length)
-            sig = self.headers.get("X-MCP-Signature", "")
-            ts = self.headers.get("X-MCP-Timestamp", "")
+            sig_ok = _verify_signature(self.headers, body, secret_holder[0])
+            mode = "standard" if self.headers.get("webhook-signature") else "mcp"
 
-            expected = "sha256=" + hmac.new(
-                secret.encode(), (ts + ".").encode() + body, hashlib.sha256
-            ).hexdigest()
-            sig_ok = hmac.compare_digest(sig, expected)
-
-            label = "sig OK" if sig_ok else "sig FAIL"
+            label = f"{mode} sig OK" if sig_ok else f"{mode} sig FAIL"
             print()
             print(f"── WEBHOOK EVENT ({label}) " + "─" * 30)
             try:
@@ -402,14 +430,17 @@ def cmd_webhook(session: MCPSession, args):
     if not args.event:
         sys.exit("ERROR: --event is required for webhook mode")
 
-    secret = args.secret
     hook_url = f"http://localhost:{args.port}"
 
     print("=== MCP Events — Webhook Receiver ===\n")
 
-    # Start local receiver first
+    # Start local receiver first. The verification secret lives in a
+    # one-element list so we can swap in the server-assigned secret after
+    # subscribe returns (Server / Identity modes generate or derive the
+    # secret server-side; Client mode echoes the supplied one).
+    secret_holder = [args.secret]
     print(f"Starting webhook receiver on port {args.port}...")
-    server = HTTPServer(("", args.port), _make_webhook_handler(secret))
+    server = HTTPServer(("", args.port), _make_webhook_handler(secret_holder))
     threading.Thread(target=server.serve_forever, daemon=True).start()
 
     # Initialize MCP, then subscribe with auto-refresh.
@@ -426,12 +457,18 @@ def cmd_webhook(session: MCPSession, args):
         session,
         event_name=args.event,
         callback_url=hook_url,
-        secret=secret,
+        secret=args.secret,
         sub_id="wh-demo",
         refresh_factor=args.refresh_factor,
         on_refresh=on_refresh,
     )
     result = sub.start()
+    # Adopt whatever secret the server returned — handles Server / Identity
+    # modes where the client-supplied secret is ignored.
+    if result.get("secret"):
+        secret_holder[0] = result["secret"]
+        if result["secret"] != args.secret:
+            print(f"  using server-assigned secret (mode is not 'client'): {result['secret'][:16]}...")
     if result.get("id"):
         print(f"  subscription: {result['id']}")
     if result.get("refreshBefore"):

--- a/experimental/ext/events/headers.go
+++ b/experimental/ext/events/headers.go
@@ -1,0 +1,165 @@
+package events
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// WebhookHeaderMode selects the header / signature wire format for outbound
+// webhook deliveries. Defaults to MCPHeaders.
+type WebhookHeaderMode int
+
+const (
+	// MCPHeaders emits X-MCP-Signature and X-MCP-Timestamp with the
+	// signature computed as HMAC(secret, ts + "." + body).
+	MCPHeaders WebhookHeaderMode = iota
+
+	// StandardWebhooks emits webhook-id, webhook-timestamp, and
+	// webhook-signature ("v1,<base64>") per https://standardwebhooks.com/.
+	// HMAC base is webhook_id + "." + webhook_timestamp + "." + body.
+	// Note: only the headers/signature scheme is adopted — the Standard
+	// Webhooks payload envelope is intentionally out of scope here.
+	StandardWebhooks
+)
+
+// String renders the mode as a config-flag-friendly token.
+func (m WebhookHeaderMode) String() string {
+	switch m {
+	case StandardWebhooks:
+		return "standard"
+	default:
+		return "mcp"
+	}
+}
+
+// ParseHeaderMode converts a flag-style token ("mcp" or "standard") to a
+// WebhookHeaderMode. Empty string returns the default (MCPHeaders).
+func ParseHeaderMode(s string) (WebhookHeaderMode, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "mcp":
+		return MCPHeaders, nil
+	case "standard", "standardwebhooks", "standard-webhooks":
+		return StandardWebhooks, nil
+	default:
+		return MCPHeaders, fmt.Errorf("unknown header mode %q (want mcp|standard)", s)
+	}
+}
+
+// signedDelivery holds the headers and the request body for one webhook POST.
+// applyHeaders writes them onto an outbound *http.Request.
+type signedDelivery struct {
+	headers map[string]string
+	body    []byte
+}
+
+func (d signedDelivery) applyHeaders(req *http.Request) {
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range d.headers {
+		req.Header.Set(k, v)
+	}
+}
+
+// signMCP produces the today's-default signed delivery.
+//   X-MCP-Signature:  sha256=<hex(HMAC(secret, ts + "." + body))>
+//   X-MCP-Timestamp:  <unix>
+func signMCP(body []byte, secret string, now time.Time) signedDelivery {
+	ts := strconv.FormatInt(now.Unix(), 10)
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(ts))
+	mac.Write([]byte("."))
+	mac.Write(body)
+	sig := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+	return signedDelivery{
+		headers: map[string]string{
+			"X-MCP-Signature": sig,
+			"X-MCP-Timestamp": ts,
+		},
+		body: body,
+	}
+}
+
+// signStandardWebhooks produces a Standard Webhooks v1 signed delivery.
+//   webhook-id:        <random message id>
+//   webhook-timestamp: <unix>
+//   webhook-signature: v1,<base64(HMAC(secret, msgId + "." + ts + "." + body))>
+func signStandardWebhooks(body []byte, secret string, now time.Time) signedDelivery {
+	msgID := newMessageID()
+	ts := strconv.FormatInt(now.Unix(), 10)
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(msgID))
+	mac.Write([]byte("."))
+	mac.Write([]byte(ts))
+	mac.Write([]byte("."))
+	mac.Write(body)
+	sig := "v1," + base64.StdEncoding.EncodeToString(mac.Sum(nil))
+	return signedDelivery{
+		headers: map[string]string{
+			"webhook-id":        msgID,
+			"webhook-timestamp": ts,
+			"webhook-signature": sig,
+		},
+		body: body,
+	}
+}
+
+// signFor selects the right signer for the registry's mode.
+func signFor(mode WebhookHeaderMode, body []byte, secret string, now time.Time) signedDelivery {
+	switch mode {
+	case StandardWebhooks:
+		return signStandardWebhooks(body, secret, now)
+	default:
+		return signMCP(body, secret, now)
+	}
+}
+
+// newMessageID returns a Standard-Webhooks-shaped message ID. Uses the
+// "msg_" prefix Stripe / Standard Webhooks examples use, with 16 random
+// bytes as URL-safe base64. Independent of the event's own EventID.
+func newMessageID() string {
+	var buf [16]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		// Should never happen on supported platforms; degrade with a
+		// timestamp-based fallback rather than panicking the delivery loop.
+		return "msg_" + strconv.FormatInt(time.Now().UnixNano(), 36)
+	}
+	return "msg_" + base64.RawURLEncoding.EncodeToString(buf[:])
+}
+
+// VerifyMCPSignature checks an X-MCP-Signature header against body+timestamp.
+// Equivalent to (and kept as) the existing VerifySignature helper.
+func VerifyMCPSignature(body []byte, secret, timestamp, signature string) bool {
+	expected := signMCP(body, secret, time.Unix(parseUnix(timestamp), 0)).headers["X-MCP-Signature"]
+	return hmac.Equal([]byte(expected), []byte(signature))
+}
+
+// VerifyStandardWebhooksSignature checks a webhook-signature header. Standard
+// Webhooks allows multiple space-separated versioned signatures
+// (e.g. "v1,abc v1,def"); we accept any matching v1.
+func VerifyStandardWebhooksSignature(body []byte, secret, msgID, timestamp, signature string) bool {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(msgID))
+	mac.Write([]byte("."))
+	mac.Write([]byte(timestamp))
+	mac.Write([]byte("."))
+	mac.Write(body)
+	expected := "v1," + base64.StdEncoding.EncodeToString(mac.Sum(nil))
+	for _, candidate := range strings.Fields(signature) {
+		if hmac.Equal([]byte(candidate), []byte(expected)) {
+			return true
+		}
+	}
+	return false
+}
+
+func parseUnix(s string) int64 {
+	n, _ := strconv.ParseInt(strings.TrimSpace(s), 10, 64)
+	return n
+}

--- a/experimental/ext/events/headers_test.go
+++ b/experimental/ext/events/headers_test.go
@@ -1,0 +1,178 @@
+package events
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseHeaderMode_Aliases verifies the flag parser accepts the friendly
+// alias forms ("mcp", "standard", "standardwebhooks", "standard-webhooks")
+// case-insensitively, and that empty string falls back to the default. The
+// CLI flag plumbing depends on this — keeping it loose lets users not memorize
+// the exact spelling.
+func TestParseHeaderMode_Aliases(t *testing.T) {
+	cases := map[string]WebhookHeaderMode{
+		"":                  MCPHeaders,
+		"mcp":               MCPHeaders,
+		"MCP":               MCPHeaders,
+		"standard":          StandardWebhooks,
+		"Standard":          StandardWebhooks,
+		"standardwebhooks":  StandardWebhooks,
+		"standard-webhooks": StandardWebhooks,
+	}
+	for in, want := range cases {
+		got, err := ParseHeaderMode(in)
+		require.NoError(t, err, "input=%q", in)
+		assert.Equal(t, want, got, "input=%q", in)
+	}
+}
+
+// TestParseHeaderMode_Unknown verifies unknown tokens are rejected so a
+// typo in a CLI flag fails loudly instead of silently picking the default.
+func TestParseHeaderMode_Unknown(t *testing.T) {
+	_, err := ParseHeaderMode("bogus")
+	assert.Error(t, err)
+}
+
+// TestSignMCP_ByteFormat pins the exact wire format of the MCP header path:
+// X-MCP-Signature is "sha256=<hex>" computed over (ts + "." + body).
+// Receivers (including non-Go ones) depend on this exact shape.
+func TestSignMCP_ByteFormat(t *testing.T) {
+	body := []byte(`{"hello":"world"}`)
+	secret := "topsecret"
+	now := time.Unix(1700000000, 0)
+
+	d := signMCP(body, secret, now)
+
+	assert.Equal(t, "1700000000", d.headers["X-MCP-Timestamp"])
+	assert.True(t, strings.HasPrefix(d.headers["X-MCP-Signature"], "sha256="), "sig must start with sha256=")
+
+	// Recompute by hand and compare.
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte("1700000000"))
+	mac.Write([]byte("."))
+	mac.Write(body)
+	want := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+	assert.Equal(t, want, d.headers["X-MCP-Signature"])
+	assert.Equal(t, body, d.body, "body passes through unmodified")
+}
+
+// TestSignStandardWebhooks_ByteFormat pins the Standard Webhooks v1 wire
+// format: signature is "v1,<base64>" computed over (msgId + "." + ts + "." + body)
+// and a webhook-id is generated per delivery. Pinning the byte format protects
+// against accidental drift when refactoring.
+func TestSignStandardWebhooks_ByteFormat(t *testing.T) {
+	body := []byte(`{"hello":"world"}`)
+	secret := "topsecret"
+	now := time.Unix(1700000000, 0)
+
+	d := signStandardWebhooks(body, secret, now)
+
+	assert.Equal(t, "1700000000", d.headers["webhook-timestamp"])
+	require.NotEmpty(t, d.headers["webhook-id"], "webhook-id must be populated")
+	require.True(t, strings.HasPrefix(d.headers["webhook-id"], "msg_"))
+
+	sig := d.headers["webhook-signature"]
+	require.True(t, strings.HasPrefix(sig, "v1,"), "sig must start with v1,: got %q", sig)
+
+	// Recompute using the generated webhook-id and compare.
+	msgID := d.headers["webhook-id"]
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(msgID))
+	mac.Write([]byte("."))
+	mac.Write([]byte("1700000000"))
+	mac.Write([]byte("."))
+	mac.Write(body)
+	want := "v1," + base64.StdEncoding.EncodeToString(mac.Sum(nil))
+	assert.Equal(t, want, sig)
+	assert.Equal(t, body, d.body, "body passes through unmodified")
+}
+
+// TestNewMessageID_Uniqueness verifies the helper produces distinct ids
+// across calls. Without this, replay-detection logic on receivers that
+// dedupe by webhook-id would silently break.
+func TestNewMessageID_Uniqueness(t *testing.T) {
+	seen := make(map[string]struct{}, 100)
+	for i := 0; i < 100; i++ {
+		id := newMessageID()
+		_, dup := seen[id]
+		require.False(t, dup, "duplicate message id at iteration %d: %s", i, id)
+		seen[id] = struct{}{}
+	}
+}
+
+// TestVerifyMCPSignature_RoundTrip verifies the verifier accepts a freshly
+// signed payload (positive case) and rejects a tampered body, swapped
+// timestamp, or wrong secret (negative cases).
+func TestVerifyMCPSignature_RoundTrip(t *testing.T) {
+	body := []byte(`{"x":1}`)
+	secret := "k"
+	now := time.Unix(1700000000, 0)
+
+	d := signMCP(body, secret, now)
+	ts := d.headers["X-MCP-Timestamp"]
+	sig := d.headers["X-MCP-Signature"]
+
+	assert.True(t, VerifyMCPSignature(body, secret, ts, sig), "valid signature should verify")
+	assert.False(t, VerifyMCPSignature([]byte(`{"x":2}`), secret, ts, sig), "tampered body must fail")
+	assert.False(t, VerifyMCPSignature(body, "wrong", ts, sig), "wrong secret must fail")
+	assert.False(t, VerifyMCPSignature(body, secret, "1700000001", sig), "wrong timestamp must fail")
+}
+
+// TestVerifyStandardWebhooksSignature_RoundTrip verifies the Standard
+// Webhooks verifier accepts freshly signed deliveries and rejects mutations.
+// Also verifies the multi-signature tolerance — the spec allows space-
+// separated versioned signatures, and we must accept any matching v1.
+func TestVerifyStandardWebhooksSignature_RoundTrip(t *testing.T) {
+	body := []byte(`{"x":1}`)
+	secret := "k"
+	now := time.Unix(1700000000, 0)
+
+	d := signStandardWebhooks(body, secret, now)
+	msgID := d.headers["webhook-id"]
+	ts := d.headers["webhook-timestamp"]
+	sig := d.headers["webhook-signature"]
+
+	assert.True(t, VerifyStandardWebhooksSignature(body, secret, msgID, ts, sig))
+	assert.False(t, VerifyStandardWebhooksSignature([]byte(`{"x":2}`), secret, msgID, ts, sig), "tampered body must fail")
+	assert.False(t, VerifyStandardWebhooksSignature(body, "wrong", msgID, ts, sig), "wrong secret must fail")
+	assert.False(t, VerifyStandardWebhooksSignature(body, secret, "msg_other", ts, sig), "wrong message id must fail")
+
+	// Multi-signature header (spec-allowed): rotation case where a sender
+	// emits old + new signatures simultaneously.
+	mac := hmac.New(sha256.New, []byte("rotated"))
+	mac.Write([]byte(msgID))
+	mac.Write([]byte("."))
+	mac.Write([]byte(ts))
+	mac.Write([]byte("."))
+	mac.Write(body)
+	rotated := "v1," + base64.StdEncoding.EncodeToString(mac.Sum(nil))
+
+	combined := sig + " " + rotated
+	assert.True(t, VerifyStandardWebhooksSignature(body, secret, msgID, ts, combined), "any matching v1 should verify")
+	assert.True(t, VerifyStandardWebhooksSignature(body, "rotated", msgID, ts, combined), "rotated key matches the second v1")
+}
+
+// TestSignFor_DispatchesByMode verifies the dispatcher picks the right
+// signer per mode — guarantees the registry's mode field actually controls
+// which header set goes on the wire.
+func TestSignFor_DispatchesByMode(t *testing.T) {
+	body := []byte(`{}`)
+	now := time.Unix(1700000000, 0)
+
+	mcp := signFor(MCPHeaders, body, "k", now)
+	assert.Contains(t, mcp.headers, "X-MCP-Signature")
+	assert.NotContains(t, mcp.headers, "webhook-signature")
+
+	std := signFor(StandardWebhooks, body, "k", now)
+	assert.Contains(t, std.headers, "webhook-signature")
+	assert.NotContains(t, std.headers, "X-MCP-Signature")
+}

--- a/experimental/ext/events/registry_modes_test.go
+++ b/experimental/ext/events/registry_modes_test.go
@@ -1,0 +1,169 @@
+package events
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewWebhookRegistry_IdentityRequiresRoot verifies the registry refuses
+// to construct in Identity mode without a root — the config bug is caught
+// at process start instead of at first subscribe (where a derivation against
+// a nil root would silently produce a degenerate secret).
+func TestNewWebhookRegistry_IdentityRequiresRoot(t *testing.T) {
+	defer func() {
+		r := recover()
+		require.NotNil(t, r, "constructing identity mode without root must panic")
+		assert.Contains(t, r.(string), "WithWebhookRoot")
+	}()
+	_ = NewWebhookRegistry(WithWebhookSecretMode(WebhookSecretIdentity))
+}
+
+// TestNewWebhookRegistry_DefaultsToServerMode pins the default mode so that a
+// future change to the default is a deliberate, visible edit (and triggers
+// downstream test updates) rather than a silent shift.
+func TestNewWebhookRegistry_DefaultsToServerMode(t *testing.T) {
+	r := NewWebhookRegistry()
+	assert.Equal(t, WebhookSecretServer, r.SecretMode())
+}
+
+// TestResolveSecret_ServerModeIgnoresClient verifies that in Server mode the
+// supplied secret is dropped on the floor and a fresh one is generated.
+// This is the entropy-QA argument from Casey on PR#1 line 391: the server
+// shouldn't trust client entropy.
+func TestResolveSecret_ServerModeIgnoresClient(t *testing.T) {
+	r := NewWebhookRegistry() // Server is default
+	_, secret := r.resolveSecret("client-id", "client-supplied", "alert.fired", "https://x", nil)
+	assert.NotEqual(t, "client-supplied", secret, "server mode must not honour client secret")
+	assert.True(t, strings.HasPrefix(secret, "whsec_"), "server-generated secret must use the whsec_ prefix")
+}
+
+// TestResolveSecret_ClientModeHonoursSupplied verifies that in Client mode
+// the client-supplied secret round-trips unchanged. This is the IaC use
+// case (Aman Singh on line 391): the gateway has the secret pre-provisioned
+// before subscribe is called.
+func TestResolveSecret_ClientModeHonoursSupplied(t *testing.T) {
+	r := NewWebhookRegistry(WithWebhookSecretMode(WebhookSecretClient))
+	id, secret := r.resolveSecret("client-id", "client-supplied", "alert.fired", "https://x", nil)
+	assert.Equal(t, "client-id", id)
+	assert.Equal(t, "client-supplied", secret)
+}
+
+// TestResolveSecret_ClientModeFallsBackWhenEmpty verifies that Client mode
+// generates a secret when the client supplies none — preserves usability
+// for clients that don't bring their own.
+func TestResolveSecret_ClientModeFallsBackWhenEmpty(t *testing.T) {
+	r := NewWebhookRegistry(WithWebhookSecretMode(WebhookSecretClient))
+	_, secret := r.resolveSecret("client-id", "", "alert.fired", "https://x", nil)
+	assert.True(t, strings.HasPrefix(secret, "whsec_"))
+}
+
+// TestResolveSecret_IdentityModeIsDeterministic verifies Identity mode's
+// core property: same tuple → same id and secret. This is what makes the
+// subscribe operation idempotent at the HTTP layer.
+func TestResolveSecret_IdentityModeIsDeterministic(t *testing.T) {
+	r := NewWebhookRegistry(
+		WithWebhookSecretMode(WebhookSecretIdentity),
+		WithWebhookRoot([]byte("root")),
+	)
+	id1, sec1 := r.resolveSecret("ignored", "ignored", "alert.fired", "https://x", map[string]string{"region": "us"})
+	id2, sec2 := r.resolveSecret("also-ignored", "also-ignored", "alert.fired", "https://x", map[string]string{"region": "us"})
+	assert.Equal(t, id1, id2, "identity mode must derive the same id for the same tuple")
+	assert.Equal(t, sec1, sec2, "identity mode must derive the same secret for the same tuple")
+}
+
+// TestResolveSecret_IdentityModeIgnoresClientInputs verifies that the
+// client-supplied id and secret are NOT what the registry stores in
+// Identity mode. Together with the determinism test above, this proves
+// the only inputs that affect identity-mode output are (name, url, params).
+func TestResolveSecret_IdentityModeIgnoresClientInputs(t *testing.T) {
+	r := NewWebhookRegistry(
+		WithWebhookSecretMode(WebhookSecretIdentity),
+		WithWebhookRoot([]byte("root")),
+	)
+	id, secret := r.resolveSecret("client-id", "client-secret", "alert.fired", "https://x", nil)
+	assert.NotEqual(t, "client-id", id)
+	assert.NotEqual(t, "client-secret", secret)
+	assert.True(t, strings.HasPrefix(id, "sub_"))
+	assert.True(t, strings.HasPrefix(secret, "whsec_"))
+}
+
+// TestRegister_IdentityModeIsIdempotent verifies that two registrations
+// against the same tuple produce a single registry entry, not two. This is
+// the user-visible consequence of identity-mode determinism: a re-subscribe
+// is effectively a refresh, not a new subscription.
+func TestRegister_IdentityModeIsIdempotent(t *testing.T) {
+	r := NewWebhookRegistry(
+		WithWebhookSecretMode(WebhookSecretIdentity),
+		WithWebhookRoot([]byte("root")),
+	)
+	id1, sec1 := r.resolveSecret("", "", "alert.fired", "https://x", nil)
+	id2, sec2 := r.resolveSecret("", "", "alert.fired", "https://x", nil)
+	require.Equal(t, id1, id2)
+	require.Equal(t, sec1, sec2)
+
+	r.Register(id1, "https://x", sec1)
+	r.Register(id2, "https://x", sec2)
+
+	assert.Len(t, r.Targets(), 1, "two identity-mode subscribes against the same tuple must collapse to one entry")
+}
+
+// TestUnregisterBySecret_RemovesMatching verifies the proof-of-possession
+// unsubscribe path removes only the subscription matching the supplied
+// (url, secret) — leaves other URLs and other secrets at the same URL alone.
+func TestUnregisterBySecret_RemovesMatching(t *testing.T) {
+	r := NewWebhookRegistry()
+	r.Register("a", "https://x", "secret-a")
+	r.Register("b", "https://x", "secret-b")
+	r.Register("c", "https://y", "secret-a") // same secret string, different URL
+
+	r.UnregisterBySecret("https://x", "secret-a")
+
+	urls := map[string]string{}
+	for _, t := range r.Targets() {
+		urls[t.ID] = t.URL
+	}
+	assert.NotContains(t, urls, "a", "matching (url, secret) entry must be removed")
+	assert.Contains(t, urls, "b", "different secret at same URL must remain")
+	assert.Contains(t, urls, "c", "same secret at different URL must remain")
+}
+
+// TestUnregisterBySecret_NoMatchIsNoOp verifies passing a secret no
+// subscription has is a silent no-op rather than an error. Mirrors
+// Unregister(id) behaviour and avoids leaking via error vs no-op timing.
+func TestUnregisterBySecret_NoMatchIsNoOp(t *testing.T) {
+	r := NewWebhookRegistry()
+	r.Register("a", "https://x", "secret-a")
+	r.UnregisterBySecret("https://x", "wrong-secret")
+	assert.Len(t, r.Targets(), 1)
+}
+
+// TestUnregisterBySecret_EmptySecretIsNoOp verifies that an empty secret
+// can never match — protects against a callsite that didn't supply a
+// secret accidentally wiping everything that has empty Secret in storage.
+func TestUnregisterBySecret_EmptySecretIsNoOp(t *testing.T) {
+	r := NewWebhookRegistry()
+	r.Register("a", "https://x", "")
+	r.UnregisterBySecret("https://x", "")
+	assert.Len(t, r.Targets(), 1, "empty secret must never match")
+}
+
+// TestRegister_TTLAppliesPerMode verifies the TTL configuration interacts
+// cleanly with the identity-mode dedupe path — a re-subscribe refreshes
+// the existing entry's expiry rather than creating a parallel one.
+func TestRegister_TTLAppliesPerMode(t *testing.T) {
+	r := NewWebhookRegistry(
+		WithWebhookSecretMode(WebhookSecretIdentity),
+		WithWebhookRoot([]byte("root")),
+		WithWebhookTTL(50*time.Millisecond),
+	)
+	id, secret := r.resolveSecret("", "", "x", "https://x", nil)
+	first := r.Register(id, "https://x", secret)
+	time.Sleep(10 * time.Millisecond)
+	second := r.Register(id, "https://x", secret)
+	assert.True(t, second.After(first), "re-register on the same identity must extend the expiry")
+	assert.Len(t, r.Targets(), 1, "still one entry — refresh, not parallel")
+}

--- a/experimental/ext/events/secret.go
+++ b/experimental/ext/events/secret.go
@@ -1,0 +1,128 @@
+package events
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// WebhookSecretMode selects how the registry decides on the per-subscription
+// HMAC secret at events/subscribe time. Defaults to WebhookSecretServer:
+// the server always generates a fresh high-entropy secret regardless of
+// what the client supplies.
+type WebhookSecretMode int
+
+const (
+	// WebhookSecretServer (default): server always generates a fresh
+	// high-entropy secret and returns it. Client-supplied delivery.secret
+	// is ignored. Casey's preferred default — entropy quality assurance,
+	// avoids the server having to validate client-side entropy.
+	WebhookSecretServer WebhookSecretMode = iota
+
+	// WebhookSecretClient: client provides delivery.secret. If empty, the
+	// server falls back to generating one. Useful for deployments that
+	// pre-provision secrets (e.g., via IaC) where the gateway has the
+	// secret before the subscribe call.
+	WebhookSecretClient
+
+	// WebhookSecretIdentity: secret is derived deterministically from a
+	// canonical tuple of (url, name, params) using HMAC-SHA256 against a
+	// server-side root. Subscribe is idempotent on the tuple — same
+	// inputs produce the same secret and the same id, so a re-subscribe
+	// with identical params returns the existing subscription rather
+	// than creating a duplicate. id is also derived (hash of tuple).
+	// Requires WithWebhookRoot at construction; otherwise registration
+	// errors. Per Peter Alexander's writeup on PR#1 line 391 (~30%
+	// confidence at time of writing).
+	WebhookSecretIdentity
+)
+
+// String renders the mode as a config-flag-friendly token.
+func (m WebhookSecretMode) String() string {
+	switch m {
+	case WebhookSecretClient:
+		return "client"
+	case WebhookSecretIdentity:
+		return "identity"
+	default:
+		return "server"
+	}
+}
+
+// ParseSecretMode converts a flag-style token to a WebhookSecretMode.
+// Empty string returns the default (WebhookSecretServer).
+func ParseSecretMode(s string) (WebhookSecretMode, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "server":
+		return WebhookSecretServer, nil
+	case "client":
+		return WebhookSecretClient, nil
+	case "identity":
+		return WebhookSecretIdentity, nil
+	default:
+		return WebhookSecretServer, fmt.Errorf("unknown secret mode %q (want server|client|identity)", s)
+	}
+}
+
+// generateSecret returns a high-entropy "whsec_<base64>" string suitable
+// for use as a webhook signing secret. 32 random bytes → 256 bits.
+func generateSecret() string {
+	var buf [32]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		// Should never fail on supported platforms; fall back to a
+		// recognizably weak placeholder so the failure is visible
+		// rather than silent.
+		return "whsec_INSECURE_FALLBACK"
+	}
+	return "whsec_" + base64.RawURLEncoding.EncodeToString(buf[:])
+}
+
+// canonicalTuple produces the input bytes for identity-mode HMAC derivation.
+// The wire-stable shape is: name + 0x1f + url + 0x1f + canonical(params).
+// 0x1f (US, unit separator) avoids collisions from any printable character.
+//
+// params is canonicalized by sorting keys lexicographically and serializing
+// as key=value pairs joined by 0x1e (RS, record separator). Nil/empty
+// params is permitted and serializes to the empty string.
+func canonicalTuple(name, url string, params map[string]string) []byte {
+	const (
+		us = "\x1f" // unit separator between fields
+		rs = "\x1e" // record separator between params
+	)
+	var paramStr string
+	if len(params) > 0 {
+		keys := make([]string, 0, len(params))
+		for k := range params {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		parts := make([]string, len(keys))
+		for i, k := range keys {
+			parts[i] = k + "=" + params[k]
+		}
+		paramStr = strings.Join(parts, rs)
+	}
+	return []byte(name + us + url + us + paramStr)
+}
+
+// deriveIdentitySecret computes the HMAC-SHA256(root, canonicalTuple) and
+// returns it as a recognizable "whsec_<hex>" string. Stable across calls
+// for the same inputs.
+func deriveIdentitySecret(root []byte, name, url string, params map[string]string) string {
+	mac := hmac.New(sha256.New, root)
+	mac.Write(canonicalTuple(name, url, params))
+	return "whsec_" + hex.EncodeToString(mac.Sum(nil))
+}
+
+// deriveIdentityID computes a stable subscription id from the same tuple,
+// suitable as a routing key for receivers. Returned as "sub_<base64>" using
+// raw URL-safe base64 with no padding.
+func deriveIdentityID(name, url string, params map[string]string) string {
+	sum := sha256.Sum256(canonicalTuple(name, url, params))
+	return "sub_" + base64.RawURLEncoding.EncodeToString(sum[:16])
+}

--- a/experimental/ext/events/secret_test.go
+++ b/experimental/ext/events/secret_test.go
@@ -1,0 +1,117 @@
+package events
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseSecretMode_Aliases verifies the flag parser accepts the friendly
+// alias forms case-insensitively, and that empty string falls back to the
+// default (WebhookSecretServer).
+func TestParseSecretMode_Aliases(t *testing.T) {
+	cases := map[string]WebhookSecretMode{
+		"":         WebhookSecretServer,
+		"server":   WebhookSecretServer,
+		"SERVER":   WebhookSecretServer,
+		"client":   WebhookSecretClient,
+		"Client":   WebhookSecretClient,
+		"identity": WebhookSecretIdentity,
+		"Identity": WebhookSecretIdentity,
+	}
+	for in, want := range cases {
+		got, err := ParseSecretMode(in)
+		require.NoError(t, err, "input=%q", in)
+		assert.Equal(t, want, got, "input=%q", in)
+	}
+}
+
+// TestParseSecretMode_Unknown verifies typos error rather than silently
+// defaulting — protects users from picking an unintended mode.
+func TestParseSecretMode_Unknown(t *testing.T) {
+	_, err := ParseSecretMode("identityy")
+	assert.Error(t, err)
+}
+
+// TestGenerateSecret_PrefixAndEntropy verifies generated secrets have the
+// expected wire-recognizable prefix and meaningful entropy (distinct on
+// repeated calls).
+func TestGenerateSecret_PrefixAndEntropy(t *testing.T) {
+	a := generateSecret()
+	b := generateSecret()
+	assert.True(t, strings.HasPrefix(a, "whsec_"), "must start with whsec_")
+	assert.True(t, strings.HasPrefix(b, "whsec_"))
+	assert.NotEqual(t, a, b, "two generated secrets must differ")
+	assert.Greater(t, len(a), 30, "secret should carry meaningful entropy")
+}
+
+// TestCanonicalTuple_Stable verifies the canonical-tuple helper produces
+// identical bytes for identical inputs and diverges on any field change.
+// This is the foundation of identity-mode determinism: if canonicalization
+// drifts, the same subscription request would derive different secrets
+// across calls and break idempotency.
+func TestCanonicalTuple_Stable(t *testing.T) {
+	a := canonicalTuple("alert.fired", "https://example.com/hook", map[string]string{"region": "us"})
+	b := canonicalTuple("alert.fired", "https://example.com/hook", map[string]string{"region": "us"})
+	assert.Equal(t, a, b, "same inputs must produce same canonical bytes")
+
+	c := canonicalTuple("alert.fired", "https://example.com/hook", map[string]string{"region": "eu"})
+	assert.NotEqual(t, a, c, "different params must produce different canonical bytes")
+
+	d := canonicalTuple("alert.fired", "https://other.example.com/hook", map[string]string{"region": "us"})
+	assert.NotEqual(t, a, d, "different url must produce different canonical bytes")
+
+	e := canonicalTuple("incident.fired", "https://example.com/hook", map[string]string{"region": "us"})
+	assert.NotEqual(t, a, e, "different name must produce different canonical bytes")
+}
+
+// TestCanonicalTuple_ParamOrderInvariant verifies that param map iteration
+// order does not affect the canonical bytes — keys are sorted internally.
+// Without this, identity mode would non-deterministically derive different
+// secrets for the same logical subscription.
+func TestCanonicalTuple_ParamOrderInvariant(t *testing.T) {
+	a := canonicalTuple("x", "u", map[string]string{"a": "1", "b": "2", "c": "3"})
+	b := canonicalTuple("x", "u", map[string]string{"c": "3", "a": "1", "b": "2"})
+	assert.Equal(t, a, b)
+}
+
+// TestCanonicalTuple_EmptyParams verifies nil and empty maps are treated
+// equivalently and produce the same canonical bytes.
+func TestCanonicalTuple_EmptyParams(t *testing.T) {
+	a := canonicalTuple("x", "u", nil)
+	b := canonicalTuple("x", "u", map[string]string{})
+	assert.Equal(t, a, b)
+}
+
+// TestDeriveIdentitySecret_Deterministic verifies the secret derivation is
+// stable for fixed (root, tuple) — which is the whole point of identity
+// mode: subscribing twice with the same tuple yields the same secret.
+func TestDeriveIdentitySecret_Deterministic(t *testing.T) {
+	root := []byte("master-root")
+	a := deriveIdentitySecret(root, "x", "u", map[string]string{"k": "v"})
+	b := deriveIdentitySecret(root, "x", "u", map[string]string{"k": "v"})
+	assert.Equal(t, a, b)
+	assert.True(t, strings.HasPrefix(a, "whsec_"))
+}
+
+// TestDeriveIdentitySecret_DiffersByRoot verifies rotating the root produces
+// a different secret for the same tuple. Operationally this is the rotation
+// path: change the root → all derived secrets change → effectively rotates
+// every subscription at once.
+func TestDeriveIdentitySecret_DiffersByRoot(t *testing.T) {
+	a := deriveIdentitySecret([]byte("root-a"), "x", "u", nil)
+	b := deriveIdentitySecret([]byte("root-b"), "x", "u", nil)
+	assert.NotEqual(t, a, b)
+}
+
+// TestDeriveIdentityID_Deterministic verifies the derived id is stable for
+// fixed inputs. Receivers route by id, so non-determinism would cause
+// route lookups to fail across subscribe calls.
+func TestDeriveIdentityID_Deterministic(t *testing.T) {
+	a := deriveIdentityID("x", "u", map[string]string{"k": "v"})
+	b := deriveIdentityID("x", "u", map[string]string{"k": "v"})
+	assert.Equal(t, a, b)
+	assert.True(t, strings.HasPrefix(a, "sub_"))
+}

--- a/experimental/ext/events/webhook.go
+++ b/experimental/ext/events/webhook.go
@@ -2,9 +2,7 @@ package events
 
 import (
 	"bytes"
-	"crypto/hmac"
-	"crypto/sha256"
-	"encoding/hex"
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -32,6 +30,34 @@ func WithWebhookTTL(ttl time.Duration) WebhookOption {
 	}
 }
 
+// WithWebhookHeaderMode selects the header / signature wire format used for
+// outbound deliveries. Defaults to MCPHeaders. See WebhookHeaderMode for the
+// available modes (MCPHeaders, StandardWebhooks).
+func WithWebhookHeaderMode(mode WebhookHeaderMode) WebhookOption {
+	return func(r *WebhookRegistry) {
+		r.headerMode = mode
+	}
+}
+
+// WithWebhookSecretMode selects how the registry decides on the
+// per-subscription HMAC secret. See WebhookSecretMode (Server / Client /
+// Identity). Defaults to WebhookSecretServer.
+func WithWebhookSecretMode(mode WebhookSecretMode) WebhookOption {
+	return func(r *WebhookRegistry) {
+		r.secretMode = mode
+	}
+}
+
+// WithWebhookRoot supplies the master secret used by Identity mode to derive
+// per-subscription secrets via HMAC(root, canonicalTuple). Required when
+// using WebhookSecretIdentity; ignored otherwise (kept for forward use).
+// The bytes are not copied — pass a slice the caller doesn't mutate.
+func WithWebhookRoot(root []byte) WebhookOption {
+	return func(r *WebhookRegistry) {
+		r.root = root
+	}
+}
+
 // WebhookTarget is a registered outbound webhook callback with TTL-based expiry.
 type WebhookTarget struct {
 	ID        string // client-provided subscription ID
@@ -50,25 +76,72 @@ func webhookKey(urlStr, id string) string {
 // with HMAC-SHA256 signed payloads. Subscriptions have TTL-based soft state
 // per Peter's spec — they expire if the client stops refreshing.
 type WebhookRegistry struct {
-	mu      sync.RWMutex
-	targets map[string]WebhookTarget // keyed by webhookKey(url, id)
-	client  *http.Client
-	ttl     time.Duration
+	mu         sync.RWMutex
+	targets    map[string]WebhookTarget // keyed by webhookKey(url, id)
+	client     *http.Client
+	ttl        time.Duration
+	headerMode WebhookHeaderMode
+	secretMode WebhookSecretMode
+	root       []byte
 }
 
-// NewWebhookRegistry creates an empty registry with a 5-second HTTP timeout
-// and the default 60-second subscription TTL (override via WithWebhookTTL).
+// NewWebhookRegistry creates an empty registry with the documented defaults:
+// 5-second HTTP timeout, 60-second TTL, MCPHeaders signing, WebhookSecretServer
+// (server always generates secrets). Override via the With* options.
+//
+// Identity mode requires WithWebhookRoot. If the caller selects identity
+// mode without providing a root, NewWebhookRegistry panics — surfacing the
+// config bug at process start rather than at first subscribe.
 func NewWebhookRegistry(opts ...WebhookOption) *WebhookRegistry {
 	r := &WebhookRegistry{
-		targets: make(map[string]WebhookTarget),
-		client:  &http.Client{Timeout: 5 * time.Second},
-		ttl:     defaultWebhookTTL,
+		targets:    make(map[string]WebhookTarget),
+		client:     &http.Client{Timeout: 5 * time.Second},
+		ttl:        defaultWebhookTTL,
+		headerMode: MCPHeaders,
+		secretMode: WebhookSecretServer,
 	}
 	for _, o := range opts {
 		o(r)
 	}
+	if r.secretMode == WebhookSecretIdentity && len(r.root) == 0 {
+		panic("events: WebhookSecretIdentity requires WithWebhookRoot to be set")
+	}
 	return r
 }
+
+// resolveSecret applies the registry's secret mode to a subscribe request.
+// Returns the secret to store and use for signing, plus the id to record
+// against the subscription (which may differ from the client-supplied id
+// when identity mode derives its own).
+//
+// Inputs:
+//   clientID, clientSecret — what the client supplied (may be empty)
+//   name, url, params      — the canonical tuple inputs for identity mode
+//
+// Behaviour by mode:
+//   Server   — always generate a fresh secret; ignore clientSecret. id is
+//              passed through (clientID).
+//   Client   — honour clientSecret; if empty, fall back to generating one.
+//              id is clientID.
+//   Identity — derive both secret and id from (name, url, params) via the
+//              configured root. Ignore clientSecret AND clientID.
+func (r *WebhookRegistry) resolveSecret(clientID, clientSecret, name, url string, params map[string]string) (id, secret string) {
+	switch r.secretMode {
+	case WebhookSecretIdentity:
+		return deriveIdentityID(name, url, params), deriveIdentitySecret(r.root, name, url, params)
+	case WebhookSecretClient:
+		if clientSecret == "" {
+			return clientID, generateSecret()
+		}
+		return clientID, clientSecret
+	default: // WebhookSecretServer
+		return clientID, generateSecret()
+	}
+}
+
+// SecretMode returns the registry's configured secret mode (read-only).
+// Subscribe handlers consult this when shaping their response.
+func (r *WebhookRegistry) SecretMode() WebhookSecretMode { return r.secretMode }
 
 // Register adds or refreshes a webhook subscription. Returns the expiry time.
 func (r *WebhookRegistry) Register(id, urlStr, secret string) time.Time {
@@ -95,6 +168,26 @@ func (r *WebhookRegistry) Unregister(urlStr, id string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	delete(r.targets, webhookKey(urlStr, id))
+}
+
+// UnregisterBySecret removes a webhook subscription identified by
+// (url, secret). Used as the proof-of-possession unsubscribe path —
+// clients that hold the secret can drop the subscription without knowing
+// or remembering the server-assigned id. No-op if no match found.
+//
+// Constant-time secret comparison guards against timing-leak side channels.
+func (r *WebhookRegistry) UnregisterBySecret(urlStr, secret string) {
+	if secret == "" {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	want := []byte(secret)
+	for key, t := range r.targets {
+		if t.URL == urlStr && subtle.ConstantTimeCompare([]byte(t.Secret), want) == 1 {
+			delete(r.targets, key)
+		}
+	}
 }
 
 // Targets returns a snapshot of all non-expired webhook targets.
@@ -174,17 +267,14 @@ func (r *WebhookRegistry) deliver(target WebhookTarget, body []byte) {
 			}
 		}
 
-		ts := fmt.Sprintf("%d", time.Now().Unix())
-		sig := sign(body, ts, target.Secret)
+		signed := signFor(r.headerMode, body, target.Secret, time.Now())
 
-		req, err := http.NewRequest("POST", target.URL, bytes.NewReader(body))
+		req, err := http.NewRequest("POST", target.URL, bytes.NewReader(signed.body))
 		if err != nil {
 			log.Printf("[webhook] failed to create request for %s: %v", target.URL, err)
 			return // not retryable
 		}
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("X-MCP-Signature", sig)
-		req.Header.Set("X-MCP-Timestamp", ts)
+		signed.applyHeaders(req)
 
 		resp, err := r.client.Do(req)
 		if err != nil {
@@ -227,19 +317,8 @@ func ValidateWebhookURL(rawURL string) error {
 	return nil
 }
 
-// sign computes HMAC-SHA256(secret, timestamp + "." + body) per Peter's spec
-// and returns "sha256=<hex>".
-func sign(body []byte, timestamp, secret string) string {
-	mac := hmac.New(sha256.New, []byte(secret))
-	mac.Write([]byte(timestamp))
-	mac.Write([]byte("."))
-	mac.Write(body)
-	return fmt.Sprintf("sha256=%s", hex.EncodeToString(mac.Sum(nil)))
-}
-
-// VerifySignature checks that a webhook signature matches the expected HMAC
-// using the timestamp + "." + body format.
+// VerifySignature checks an X-MCP-Signature header. Convenience alias for
+// VerifyMCPSignature kept for callers that pre-date the header-mode split.
 func VerifySignature(body []byte, secret, timestamp, signature string) bool {
-	expected := sign(body, timestamp, secret)
-	return hmac.Equal([]byte(expected), []byte(signature))
+	return VerifyMCPSignature(body, secret, timestamp, signature)
 }

--- a/experimental/telegram-events/README.md
+++ b/experimental/telegram-events/README.md
@@ -135,3 +135,20 @@ Telegram Bot (long-poll)  ──or──  POST /inject
 | `make poll` | Polling loop (default 5s interval, override: `INTERVAL=10`) |
 
 All client commands use the shared [`events_client.py`](../ext/events/events_client.py).
+
+## Webhook secret + header modes
+
+The server takes the same `-webhook-secret-mode` / `-webhook-header-mode` /
+`-webhook-root` flags as discord-events. See
+[`experimental/ext/events/README.md`](../ext/events/) for the full matrix.
+
+```bash
+# Default
+go run . -addr :8080
+
+# Identity mode (idempotent subscribe, derived secrets)
+go run . -addr :8080 -webhook-secret-mode identity -webhook-root deadbeefcafef00d
+
+# Standard Webhooks header naming
+go run . -addr :8080 -webhook-header-mode standard
+```

--- a/experimental/telegram-events/e2e_test.go
+++ b/experimental/telegram-events/e2e_test.go
@@ -20,8 +20,10 @@ import (
 
 // buildTestStack returns a fully wired test server plus the source/yield
 // pair so tests can publish events directly without a Telegram session.
-func buildTestStack() (*server.Server, *events.YieldingSource[TelegramEventData], func(TelegramEventData) error, *events.WebhookRegistry) {
-	webhooks := events.NewWebhookRegistry()
+// Optional WebhookOptions configure the registry; defaults match the
+// production demo (Server + MCPHeaders).
+func buildTestStack(whOpts ...events.WebhookOption) (*server.Server, *events.YieldingSource[TelegramEventData], func(TelegramEventData) error, *events.WebhookRegistry) {
+	webhooks := events.NewWebhookRegistry(whOpts...)
 	source, yield := newTelegramSource()
 
 	srv := server.NewServer(
@@ -125,19 +127,25 @@ func TestE2EPushDelivery(t *testing.T) {
 	assert.Contains(t, received, "notifications/events/event")
 }
 
-// TestE2EWebhookDelivery verifies webhook fanout — same library hook also
-// routes events to registered webhook subscribers with HMAC signing.
+// TestE2EWebhookDelivery verifies webhook fanout via the default secret
+// mode (Server). Per the post-PR-C contract: server generates the secret
+// regardless of what the client supplies, returns it on subscribe, and
+// signs deliveries with the generated secret.
 func TestE2EWebhookDelivery(t *testing.T) {
 	srv, _, yield, webhooks := buildTestStack()
 
 	var mu sync.Mutex
 	var deliveries []events.Event
+	var assignedSecret string
 
 	callbackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
 		sig := r.Header.Get("X-MCP-Signature")
 		ts := r.Header.Get("X-MCP-Timestamp")
-		assert.True(t, events.VerifySignature(body, "wh-secret", ts, sig))
+		mu.Lock()
+		secret := assignedSecret
+		mu.Unlock()
+		assert.True(t, events.VerifyMCPSignature(body, secret, ts, sig), "signature should verify against the server-assigned secret")
 
 		var event events.Event
 		json.Unmarshal(body, &event)
@@ -158,15 +166,21 @@ func TestE2EWebhookDelivery(t *testing.T) {
 	subResult, err := c.Call("events/subscribe", map[string]any{
 		"id":       "wh-e2e",
 		"name":     "telegram.message",
-		"delivery": map[string]any{"mode": "webhook", "url": callbackSrv.URL, "secret": "wh-secret"},
+		"delivery": map[string]any{"mode": "webhook", "url": callbackSrv.URL, "secret": "ignored-in-server-mode"},
 	})
 	require.NoError(t, err)
 
 	var subResp struct {
-		ID string `json:"id"`
+		ID     string `json:"id"`
+		Secret string `json:"secret"`
 	}
 	require.NoError(t, json.Unmarshal(subResult.Raw, &subResp))
 	assert.Equal(t, "wh-e2e", subResp.ID)
+	require.NotEmpty(t, subResp.Secret)
+	require.NotEqual(t, "ignored-in-server-mode", subResp.Secret, "server mode must NOT echo the client-supplied secret")
+	mu.Lock()
+	assignedSecret = subResp.Secret
+	mu.Unlock()
 	require.Len(t, webhooks.Targets(), 1)
 
 	require.NoError(t, yieldText(yield, 200, "bob", "webhook test"))
@@ -176,6 +190,138 @@ func TestE2EWebhookDelivery(t *testing.T) {
 	defer mu.Unlock()
 	require.Len(t, deliveries, 1)
 	assert.Equal(t, "telegram.message", deliveries[0].Name)
+}
+
+// TestE2EWebhookDelivery_IdentityMode verifies the identity-mode contract
+// end-to-end on telegram-events: subscribe is idempotent on the
+// (name, url, params) tuple, server returns derived id and secret, and
+// webhook delivery signs with the derived secret.
+func TestE2EWebhookDelivery_IdentityMode(t *testing.T) {
+	srv, _, yield, webhooks := buildTestStack(
+		events.WithWebhookSecretMode(events.WebhookSecretIdentity),
+		events.WithWebhookRoot([]byte("test-root-master")),
+	)
+
+	var mu sync.Mutex
+	var deliveries int
+	var assignedSecret string
+
+	callbackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		sig := r.Header.Get("X-MCP-Signature")
+		ts := r.Header.Get("X-MCP-Timestamp")
+		mu.Lock()
+		secret := assignedSecret
+		mu.Unlock()
+		assert.True(t, events.VerifyMCPSignature(body, secret, ts, sig))
+		mu.Lock()
+		deliveries++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer callbackSrv.Close()
+
+	handler := srv.Handler(server.WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "identity-test", Version: "1.0"})
+	require.NoError(t, c.Connect())
+
+	subscribe := func(clientID string) (string, string) {
+		t.Helper()
+		raw, err := c.Call("events/subscribe", map[string]any{
+			"id":   clientID,
+			"name": "telegram.message",
+			"delivery": map[string]any{
+				"mode":   "webhook",
+				"url":    callbackSrv.URL,
+				"params": map[string]string{"chat": "100"},
+			},
+		})
+		require.NoError(t, err)
+		var resp struct {
+			ID     string `json:"id"`
+			Secret string `json:"secret"`
+		}
+		require.NoError(t, json.Unmarshal(raw.Raw, &resp))
+		return resp.ID, resp.Secret
+	}
+	id1, sec1 := subscribe("client-A")
+	id2, sec2 := subscribe("client-B")
+	assert.Equal(t, id1, id2, "identity mode derives same id regardless of client-supplied id")
+	assert.Equal(t, sec1, sec2, "identity mode derives same secret for same tuple")
+	assert.Len(t, webhooks.Targets(), 1, "two subscribes against same tuple collapse to one entry")
+
+	mu.Lock()
+	assignedSecret = sec1
+	mu.Unlock()
+	require.NoError(t, yieldText(yield, 100, "alice", "identity-mode test"))
+	time.Sleep(500 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 1, deliveries)
+}
+
+// TestE2EWebhookDelivery_StandardHeaders verifies StandardWebhooks header
+// emission on telegram-events.
+func TestE2EWebhookDelivery_StandardHeaders(t *testing.T) {
+	srv, _, yield, _ := buildTestStack(
+		events.WithWebhookHeaderMode(events.StandardWebhooks),
+	)
+
+	var mu sync.Mutex
+	var deliveries int
+	var assignedSecret string
+
+	callbackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		msgID := r.Header.Get("webhook-id")
+		ts := r.Header.Get("webhook-timestamp")
+		sig := r.Header.Get("webhook-signature")
+		assert.NotEmpty(t, msgID)
+		assert.NotEmpty(t, ts)
+		assert.True(t, len(sig) > 3 && sig[:3] == "v1,")
+		assert.Empty(t, r.Header.Get("X-MCP-Signature"))
+
+		mu.Lock()
+		secret := assignedSecret
+		mu.Unlock()
+		assert.True(t, events.VerifyStandardWebhooksSignature(body, secret, msgID, ts, sig))
+
+		mu.Lock()
+		deliveries++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer callbackSrv.Close()
+
+	handler := srv.Handler(server.WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "stdhdr-test", Version: "1.0"})
+	require.NoError(t, c.Connect())
+
+	raw, err := c.Call("events/subscribe", map[string]any{
+		"id":       "wh-std",
+		"name":     "telegram.message",
+		"delivery": map[string]any{"mode": "webhook", "url": callbackSrv.URL},
+	})
+	require.NoError(t, err)
+	var resp struct {
+		Secret string `json:"secret"`
+	}
+	require.NoError(t, json.Unmarshal(raw.Raw, &resp))
+	mu.Lock()
+	assignedSecret = resp.Secret
+	mu.Unlock()
+
+	require.NoError(t, yieldText(yield, 100, "alice", "standard-headers test"))
+	time.Sleep(500 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 1, deliveries)
 }
 
 // TestE2EEventsList verifies events/list returns the telegram.message

--- a/experimental/telegram-events/main.go
+++ b/experimental/telegram-events/main.go
@@ -10,6 +10,7 @@
 package main
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"flag"
 	"log"
@@ -29,9 +30,37 @@ const eventStoreCap = 1000
 func main() {
 	addr := flag.String("addr", ":8080", "listen address")
 	token := flag.String("token", "", "Telegram bot token (omit for test mode)")
+	whSecretMode := flag.String("webhook-secret-mode", "server", "webhook secret mode: server | client | identity")
+	whHeaderMode := flag.String("webhook-header-mode", "mcp", "webhook header style: mcp | standard")
+	whRootHex := flag.String("webhook-root", "", "hex-encoded master secret for identity mode (required when -webhook-secret-mode=identity)")
 	flag.Parse()
 
-	webhooks := events.NewWebhookRegistry()
+	secretMode, err := events.ParseSecretMode(*whSecretMode)
+	if err != nil {
+		log.Fatalf("invalid -webhook-secret-mode: %v", err)
+	}
+	headerMode, err := events.ParseHeaderMode(*whHeaderMode)
+	if err != nil {
+		log.Fatalf("invalid -webhook-header-mode: %v", err)
+	}
+
+	whOpts := []events.WebhookOption{
+		events.WithWebhookSecretMode(secretMode),
+		events.WithWebhookHeaderMode(headerMode),
+	}
+	if secretMode == events.WebhookSecretIdentity {
+		if *whRootHex == "" {
+			log.Fatalf("-webhook-root is required when -webhook-secret-mode=identity")
+		}
+		root, err := hex.DecodeString(*whRootHex)
+		if err != nil {
+			log.Fatalf("invalid -webhook-root: %v", err)
+		}
+		whOpts = append(whOpts, events.WithWebhookRoot(root))
+	}
+	log.Printf("[server] webhook modes: secret=%s headers=%s", secretMode, headerMode)
+
+	webhooks := events.NewWebhookRegistry(whOpts...)
 	source, yield := newTelegramSource()
 
 	var bot *tgbotapi.BotAPI


### PR DESCRIPTION
## Summary

PR C from #323. Three webhook secret modes + two webhook header modes, all selectable via options on `NewWebhookRegistry`. Both demos take new flags exposing them.

The defaults change:
- **Secret mode default flips from "Client-with-fallback" → `WebhookSecretServer`.** The server always generates the secret and returns it; client-supplied `delivery.secret` is ignored. This matches the entropy-QA argument from the upstream review (line 391, comment `r3139411312`).
- **Header mode default stays at `MCPHeaders`.** Standard Webhooks naming is fully supported, but defaulting to it would pre-empt a WG decision. Easy to flip later if/when the WG aligns.

## What's new

### Secret modes (`WebhookSecretMode`)

| Mode | Behavior |
|---|---|
| `WebhookSecretServer` (default) | Always server-generated. `delivery.secret` ignored. |
| `WebhookSecretClient` | Honors `delivery.secret`; generates one when empty. |
| `WebhookSecretIdentity` | `secret = HMAC(root, canonical(name, url, params))`. **Idempotent on the tuple** — same inputs → same `id` and `secret`, no duplicate registry entry. Requires `WithWebhookRoot` or `NewWebhookRegistry` panics. |

### Header modes (`WebhookHeaderMode`)

| Mode | Headers | HMAC base |
|---|---|---|
| `MCPHeaders` (default) | `X-MCP-Signature: sha256=<hex>` + `X-MCP-Timestamp` | `HMAC(secret, ts + "." + body)` |
| `StandardWebhooks` | `webhook-id`, `webhook-timestamp`, `webhook-signature: v1,<base64>` | `HMAC(secret, msg_id + "." + ts + "." + body)` |

Standard Webhooks payload envelope is intentionally out of scope — headers only.

### Unsubscribe

Two equivalent forms accepted in any mode:

```jsonc
{"delivery": {"url": "https://...", "id":     "sub-1"     }}
{"delivery": {"url": "https://...", "secret": "whsec_..." }}
```

The secret form (`UnregisterBySecret`, proof-of-possession) uses `crypto/subtle.ConstantTimeCompare` to avoid timing leaks.

## Demo wiring

Both `discord-events` and `telegram-events` take new server flags:

```bash
go run . -addr :8080
go run . -addr :8080 -webhook-secret-mode client
go run . -addr :8080 -webhook-secret-mode identity -webhook-root deadbeefcafef00d
go run . -addr :8080 -webhook-header-mode standard
```

The Python receiver (`events_client.py` / `cmd_webhook`) auto-detects which header set is on the inbound request and verifies accordingly. It also adopts whatever secret the server returns from `events/subscribe` so it works under all three secret modes without configuration.

## Tests

Added test files (all green, ~30 new tests):

- `headers_test.go` (8) — flag-token parsing, byte-format pinning of both header schemes, multi-signature tolerance for Standard Webhooks rotation case, dispatch-by-mode.
- `secret_test.go` (10) — flag-token parsing, secret-prefix entropy, canonical tuple stability + key-order invariance + nil/empty equivalence, derivation determinism, root-rotation distinguishes secrets, identity id determinism.
- `registry_modes_test.go` (12) — Identity-without-root panics, default mode pinning, per-mode `resolveSecret` behavior, idempotent registration in identity mode, `UnregisterBySecret` matches scope, no-op on empty/missing, TTL refresh under identity dedupe.
- Both demos: `TestE2EWebhookDelivery_IdentityMode`, `TestE2EWebhookDelivery_StandardHeaders`. discord-events also adds `TestE2EUnsubscribeBySecret`.

### Assertion-count audit

| Bucket | Δ |
|---|---|
| `experimental/ext/events/headers_test.go` | +8 tests, ~25 assertions (new file) |
| `experimental/ext/events/secret_test.go` | +10 tests, ~25 assertions (new file) |
| `experimental/ext/events/registry_modes_test.go` | +12 tests, ~30 assertions (new file) |
| `experimental/discord-events/e2e_test.go` | +3 tests (`_IdentityMode`, `_StandardHeaders`, `UnsubscribeBySecret`); existing `TestE2EWebhookDelivery` updated to verify against the **server-assigned** secret rather than the supplied one — same number of assertions, semantics now match Server-mode default |
| `experimental/telegram-events/e2e_test.go` | +2 tests (`_IdentityMode`, `_StandardHeaders`); same `TestE2EWebhookDelivery` update |

Net coverage increased substantially. The two `TestE2EWebhookDelivery` updates are the visible breakage from the default-mode flip (called out in the plan); they're the only existing assertions that needed adjustment.

## Constraint check

- C1 (typed contexts): all new options are construction-time `func(*WebhookRegistry)` — no handler signatures touched.
- C2 (consolidated structs): no new parallel maps.
- C3 (no globals): all new state lives on the `WebhookRegistry` instance.

## Out of scope (tracked in #323 / #326)

- PR B: cursor:null / best-effort + deprecate poll batching.
- PR D: DEPLOYMENT.md (WAF / private cloud notes).
- Promote `WebhookRegistry` outbox + crypto primitives to a shared package when a second consumer arrives — tracked in audit log #326 (added during this PR's implementation).

## References (non-linking — code block to suppress backlinks)

```
panyam/mcpkit#323 (umbrella)
panyam/mcpkit#326 (audit log)
panyam/mcpkit#324 (SEP-2663 merged into main during this PR; clean three-way)

Upstream review threads referenced in this PR (open in browser):
  https://github.com/modelcontextprotocol/experimental-ext-triggers-events/pull/1#discussion_r3139411312  (Casey: server-defined secrets)
  https://github.com/modelcontextprotocol/experimental-ext-triggers-events/pull/1#discussion_r3140468225  (Peter: secret-as-identity writeup)
  https://github.com/modelcontextprotocol/experimental-ext-triggers-events/pull/1#discussion_r3139431337  (Casey: Standard Webhooks naming)
```
