### PR TITLE
feat: SEP-2663 server handlers, tasks/update, Mcp-Name (Phase 4)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -157,6 +157,17 @@ Phase 6 (client) → Phase 7 (example + conformance) → Phase 8 (bridge)
   - the store record needs to diverge from the v1 wire shape (then introduce
     a dedicated `taskRecord` type and free up `TaskInfo` for the v2 wire).
 
+- **Internal v2 symbols keep `V2`/`v2` infix** (deferred during Phase 4).
+  After promoting `RegisterTasksV2` → `RegisterTasks` and `TasksV2Config` →
+  `TasksConfig`, the canonical-named v2 file still has internal symbols like
+  `taskV2Middleware`, `v2TaskRuntime`, `newV2TaskRuntime`, `makeV2GetHandler`,
+  `notifyV2TaskStatus`, `notifyV2TaskStatusFromInfo`, `toTaskInfoV2`. They
+  collide with v1 internals in the same package (`taskMiddleware`,
+  `taskRuntime`, `makeGetHandler`, `notifyTaskStatus`), so dropping the V2
+  prefix requires renaming v1 internals to `*V1` first. Pure stylistic
+  cleanup with no user-visible impact — sweep when v1 is removed or when a
+  refactor already touches these files.
+
 ## Open spec questions (watch before finalizing)
 
 1. `requestState` rejection: synchronous `-32602` or silent? (Luca TBD)

--- a/core/session.go
+++ b/core/session.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"encoding/json"
+	"sync"
 	"sync/atomic"
 )
 
@@ -42,6 +43,40 @@ type sessionCtx struct {
 	notifyResourceUpdated func(uri string)
 }
 
+// responseHeaderCollector buffers per-request HTTP response headers set by
+// middleware or handlers. Mutex-guarded because background-goroutine middleware
+// can race with the transport's read after dispatch returns.
+type responseHeaderCollector struct {
+	mu      sync.Mutex
+	headers map[string]string
+}
+
+func (c *responseHeaderCollector) set(k, v string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.headers == nil {
+		c.headers = make(map[string]string)
+	}
+	c.headers[k] = v
+}
+
+func (c *responseHeaderCollector) snapshot() map[string]string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.headers) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(c.headers))
+	for k, v := range c.headers {
+		out[k] = v
+	}
+	return out
+}
+
+type responseHeadersCtxKey int
+
+const responseHeadersKey responseHeadersCtxKey = 0
+
 type ctxKey int
 
 const sessionCtxKey ctxKey = iota
@@ -58,6 +93,41 @@ func ContextWithSession(ctx context.Context, notify NotifyFunc, request RequestF
 		clientCaps: clientCaps,
 		claims:     claims,
 	})
+}
+
+// WithResponseHeaderCollector attaches a fresh per-request HTTP response
+// header collector to ctx. Transports call this on the inbound request
+// context BEFORE dispatching so middleware/handlers can stage headers via
+// SetResponseHeader, and the transport reads them via CollectResponseHeaders
+// before writing the response. Non-HTTP transports skip this and the
+// staging functions become silent no-ops.
+func WithResponseHeaderCollector(ctx context.Context) context.Context {
+	return context.WithValue(ctx, responseHeadersKey, &responseHeaderCollector{})
+}
+
+// SetResponseHeader stages an HTTP response header that the transport applies
+// before writing the response body. Used by middleware and handlers that need
+// to surface protocol metadata at the HTTP layer (e.g., the v2 task middleware
+// emits Mcp-Name: <taskId> per SEP-2243). Silent no-op when the request was
+// not wrapped with WithResponseHeaderCollector (e.g., non-HTTP transports).
+func SetResponseHeader(ctx context.Context, key, value string) {
+	c, _ := ctx.Value(responseHeadersKey).(*responseHeaderCollector)
+	if c == nil {
+		return
+	}
+	c.set(key, value)
+}
+
+// CollectResponseHeaders returns a snapshot of the response headers staged on
+// the current request via SetResponseHeader. HTTP transports call this after
+// dispatch returns, before writing response headers. Returns nil when no
+// collector was attached or no headers were staged.
+func CollectResponseHeaders(ctx context.Context) map[string]string {
+	c, _ := ctx.Value(responseHeadersKey).(*responseHeaderCollector)
+	if c == nil {
+		return nil
+	}
+	return c.snapshot()
 }
 
 // SetSessionID sets the transport-assigned session ID on the session context.

--- a/examples/tasks-v2/main.go
+++ b/examples/tasks-v2/main.go
@@ -195,8 +195,9 @@ func serve() {
 		},
 	})
 
-	// Register v2 tasks on the server.
-	server.RegisterTasksV2(server.TasksV2Config{Server: srv})
+	// Register v2 tasks on the server (canonical RegisterTasks since SEP-2663
+	// — v2 takes the canonical name; v1 lives at RegisterTasksV1).
+	server.RegisterTasks(server.TasksConfig{Server: srv})
 
 	log.Printf("Tasks v2 demo server on %s", *addr)
 	log.Printf("Connect: http://localhost%s/mcp", *addr)

--- a/examples/tasks/main.go
+++ b/examples/tasks/main.go
@@ -291,8 +291,8 @@ func serve() {
 		},
 	})
 
-	// Register tasks capability on the server.
-	server.RegisterTasks(server.TasksConfig{Server: srv})
+	// Register v1 tasks capability on the server.
+	server.RegisterTasksV1(server.TasksConfigV1{Server: srv})
 
 	log.Printf("Tasks demo server on %s", *addr)
 	log.Printf("Connect MCPJam or VS Code: http://localhost%s/mcp", *addr)

--- a/server/streamable_transport.go
+++ b/server/streamable_transport.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -238,7 +239,8 @@ func (t *streamableTransport) handlePost(w http.ResponseWriter, r *http.Request)
 		dispatcher := t.server.newSession()
 		// Auto-initialize the dispatcher so it accepts any method
 		dispatcher.initialized = true
-		resp, dErr := t.server.dispatchWith(dispatcher, r.Context(), claims, &req)
+		ctx := core.WithResponseHeaderCollector(r.Context())
+		resp, dErr := t.server.dispatchWith(dispatcher, ctx, claims, &req)
 		if dErr != nil {
 			writeAuthError(w, dErr)
 			return
@@ -247,6 +249,7 @@ func (t *streamableTransport) handlePost(w http.ResponseWriter, r *http.Request)
 			w.WriteHeader(http.StatusAccepted)
 			return
 		}
+		applyStagedResponseHeaders(w, ctx)
 		w.Header().Set("Content-Type", "application/json")
 		raw, _ := marshalJSON(resp)
 		w.Write(raw)
@@ -303,7 +306,8 @@ func (t *streamableTransport) handlePost(w http.ResponseWriter, r *http.Request)
 	}
 
 	// Synchronous JSON path (no mid-request notifications)
-	resp, dErr := t.server.dispatchWith(dispatcher, r.Context(), claims, &req)
+	ctx := core.WithResponseHeaderCollector(r.Context())
+	resp, dErr := t.server.dispatchWith(dispatcher, ctx, claims, &req)
 	if dErr != nil {
 		writeAuthError(w, dErr)
 		return
@@ -314,6 +318,7 @@ func (t *streamableTransport) handlePost(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	applyStagedResponseHeaders(w, ctx)
 	w.Header().Set("Content-Type", "application/json")
 	raw, err := marshalJSON(resp)
 	if err != nil {
@@ -321,6 +326,16 @@ func (t *streamableTransport) handlePost(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	w.Write(raw)
+}
+
+// applyStagedResponseHeaders writes any HTTP response headers staged by
+// middleware/handlers during dispatch (via core.SetResponseHeader) onto w
+// before the response body is written. Caller must invoke before any Write
+// or WriteHeader, otherwise the headers are dropped by net/http.
+func applyStagedResponseHeaders(w http.ResponseWriter, ctx context.Context) {
+	for k, v := range core.CollectResponseHeaders(ctx) {
+		w.Header().Set(k, v)
+	}
 }
 
 // handlePostSSE handles a POST request using SSE streaming, allowing the server
@@ -332,7 +347,8 @@ func (t *streamableTransport) handlePostSSE(w http.ResponseWriter, r *http.Reque
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		// Fall back to synchronous JSON if flushing not supported
-		resp, dErr := t.server.dispatchWith(d, r.Context(), claims, req)
+		ctx := core.WithResponseHeaderCollector(r.Context())
+		resp, dErr := t.server.dispatchWith(d, ctx, claims, req)
 		if dErr != nil {
 			writeAuthError(w, dErr)
 			return
@@ -341,11 +357,17 @@ func (t *streamableTransport) handlePostSSE(w http.ResponseWriter, r *http.Reque
 			w.WriteHeader(http.StatusAccepted)
 			return
 		}
+		applyStagedResponseHeaders(w, ctx)
 		w.Header().Set("Content-Type", "application/json")
 		raw, _ := marshalJSON(resp)
 		w.Write(raw)
 		return
 	}
+
+	// Attach a response-header collector so middleware/handlers can stage
+	// HTTP response headers (e.g., Mcp-Name from the v2 task middleware per
+	// SEP-2243) that we apply on the first SSE flush below.
+	dispatchCtx := core.WithResponseHeaderCollector(r.Context())
 
 	// SSE headers are set lazily on first write so we can still surface
 	// transport-level auth errors via writeAuthError (HTTP 403/401 +
@@ -361,6 +383,9 @@ func (t *streamableTransport) handlePostSSE(w http.ResponseWriter, r *http.Reque
 			return // POST response already sent — background goroutine writing to dead writer
 		}
 		if !sseStarted {
+			// Apply any headers staged by middleware/handlers (e.g., Mcp-Name)
+			// before we commit response headers via Content-Type.
+			applyStagedResponseHeaders(w, dispatchCtx)
 			w.Header().Set("Content-Type", "text/event-stream")
 			w.Header().Set("Cache-Control", "no-cache")
 			w.Header().Set("Connection", "keep-alive")
@@ -404,7 +429,7 @@ func (t *streamableTransport) handlePostSSE(w http.ResponseWriter, r *http.Reque
 	}
 
 	// Dispatch with request-scoped notify, request, and retry funcs.
-	resp, dErr := t.server.dispatchWithOpts(d, r.Context(), claims, requestNotify, requestFunc, sseRetry, req)
+	resp, dErr := t.server.dispatchWithOpts(d, dispatchCtx, claims, requestNotify, requestFunc, sseRetry, req)
 
 	// Transport-level error from middleware (e.g., scope step-up): if the SSE
 	// stream hasn't started yet, we can still send an HTTP-level auth response

--- a/server/task_callbacks_test.go
+++ b/server/task_callbacks_test.go
@@ -48,7 +48,7 @@ func TestTaskCallbacksGetTask(t *testing.T) {
 		},
 	})
 
-	RegisterTasks(TasksConfig{Server: srv})
+	RegisterTasksV1(TasksConfigV1{Server: srv})
 
 	c := connectClient(t, srv)
 
@@ -102,7 +102,7 @@ func TestTaskCallbacksGetResult(t *testing.T) {
 		},
 	})
 
-	RegisterTasks(TasksConfig{Server: srv})
+	RegisterTasksV1(TasksConfigV1{Server: srv})
 
 	c := connectClient(t, srv)
 
@@ -165,7 +165,7 @@ func TestTaskCallbacksFallthrough(t *testing.T) {
 		},
 	})
 
-	RegisterTasks(TasksConfig{Server: srv})
+	RegisterTasksV1(TasksConfigV1{Server: srv})
 
 	c := connectClient(t, srv)
 

--- a/server/tasks_v1.go
+++ b/server/tasks_v1.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Config holds the options for registering tasks support on an MCP server.
-type TasksConfig struct {
+type TasksConfigV1 struct {
 	// Store is the task state backend. If nil, an InMemoryTaskStore is used.
 	Store TaskStore
 
@@ -38,7 +38,7 @@ type TasksConfig struct {
 	MaxQueueSize int
 }
 
-func (c *TasksConfig) defaults() {
+func (c *TasksConfigV1) defaults() {
 	if c.Store == nil {
 		c.Store = NewInMemoryStore()
 	}
@@ -144,7 +144,7 @@ func (rt *taskRuntime) cancelTask(taskID string) {
 //   - Advertises the tasks capability in the initialize response
 //
 // Must be called before accepting connections.
-func RegisterTasks(cfg TasksConfig) {
+func RegisterTasksV1(cfg TasksConfigV1) {
 	cfg.defaults()
 	srv := cfg.Server
 	store := cfg.Store
@@ -178,7 +178,7 @@ func RegisterTasks(cfg TasksConfig) {
 // hint at params.task (per MCP spec 2025-11-25) and the tool supports tasks,
 // the middleware creates a task, runs the tool asynchronously, and returns
 // CreateTaskResult immediately.
-func taskMiddleware(reg *Registry, rt *taskRuntime, cfg TasksConfig) Middleware {
+func taskMiddleware(reg *Registry, rt *taskRuntime, cfg TasksConfigV1) Middleware {
 	return func(ctx context.Context, req *core.Request, next MiddlewareFunc) (*core.Response, error) {
 		if req.Method != "tools/call" {
 			return next(ctx, req)

--- a/server/tasks_v1_test.go
+++ b/server/tasks_v1_test.go
@@ -97,7 +97,7 @@ func newTaskServer(t *testing.T) (*Server, chan struct{}) {
 		},
 	)
 
-	RegisterTasks(TasksConfig{Server: srv})
+	RegisterTasksV1(TasksConfigV1{Server: srv})
 
 	return srv, unblock
 }
@@ -677,7 +677,7 @@ func TestTaskPanicRecovery(t *testing.T) {
 			panic("test panic")
 		},
 	)
-	RegisterTasks(TasksConfig{Server: srv})
+	RegisterTasksV1(TasksConfigV1{Server: srv})
 	c := connectClient(t, srv)
 
 	created, err := client.ToolCallAsTask(c, "panic-tool", nil)
@@ -814,7 +814,7 @@ func TestGetTaskContextNilForSync(t *testing.T) {
 			return core.TextResult("ok"), nil
 		},
 	)
-	RegisterTasks(TasksConfig{Server: srv})
+	RegisterTasksV1(TasksConfigV1{Server: srv})
 	c := connectClient(t, srv)
 
 	// Call without task hint — sync mode.
@@ -850,7 +850,7 @@ func TestGetTaskContextAvailableForAsync(t *testing.T) {
 			return core.TextResult("ok"), nil
 		},
 	)
-	RegisterTasks(TasksConfig{Server: srv})
+	RegisterTasksV1(TasksConfigV1{Server: srv})
 	c := connectClient(t, srv)
 
 	created, err := client.ToolCallAsTask(c, "check-ctx", nil)
@@ -906,7 +906,7 @@ func TestTaskInputRequiredTransition(t *testing.T) {
 			return core.TextResult("done"), nil
 		},
 	)
-	RegisterTasks(TasksConfig{Server: srv})
+	RegisterTasksV1(TasksConfigV1{Server: srv})
 	c := connectClient(t, srv)
 
 	created, err := client.ToolCallAsTask(c, "needs-input", nil)
@@ -1012,7 +1012,7 @@ func TestQueueCleanupOnCancel(t *testing.T) {
 			select {} // block forever
 		},
 	)
-	RegisterTasks(TasksConfig{Server: srv, Store: store, MessageQueue: queue})
+	RegisterTasksV1(TasksConfigV1{Server: srv, Store: store, MessageQueue: queue})
 	c := connectClient(t, srv)
 
 	created, err := client.ToolCallAsTask(c, "slow", nil)
@@ -1094,7 +1094,7 @@ func TestTaskElicitE2E(t *testing.T) {
 		},
 	)
 
-	RegisterTasks(TasksConfig{Server: srv})
+	RegisterTasksV1(TasksConfigV1{Server: srv})
 
 	// Client with an elicitation handler that auto-accepts.
 	c := connectClient(t, srv, client.WithElicitationHandler(
@@ -1171,7 +1171,7 @@ func TestTaskSampleE2E(t *testing.T) {
 		},
 	)
 
-	RegisterTasks(TasksConfig{Server: srv})
+	RegisterTasksV1(TasksConfigV1{Server: srv})
 
 	// Client with a sampling handler that returns a mock haiku.
 	c := connectClient(t, srv, client.WithSamplingHandler(
@@ -1277,7 +1277,7 @@ func TestTaskProgressFromBackgroundNoPanic(t *testing.T) {
 			return core.TextResult("ok"), nil
 		},
 	)
-	RegisterTasks(TasksConfig{Server: srv})
+	RegisterTasksV1(TasksConfigV1{Server: srv})
 	c := connectClient(t, srv)
 
 	// Create task (no GET SSE stream — just POST).
@@ -1330,7 +1330,7 @@ func TestTaskCancelStopsGoroutine(t *testing.T) {
 			}
 		},
 	)
-	RegisterTasks(TasksConfig{Server: srv})
+	RegisterTasksV1(TasksConfigV1{Server: srv})
 	c := connectClient(t, srv)
 
 	created, err := client.ToolCallAsTask(c, "long-task", nil)
@@ -1370,7 +1370,7 @@ func TestTaskStatusNotificationOnComplete(t *testing.T) {
 			return core.TextResult("done"), nil
 		},
 	)
-	RegisterTasks(TasksConfig{Server: srv})
+	RegisterTasksV1(TasksConfigV1{Server: srv})
 
 	notifications := make(chan core.TaskInfo, 10)
 	c := connectClient(t, srv, client.WithNotificationCallback(func(method string, params any) {
@@ -1421,7 +1421,7 @@ func TestTaskStatusNotificationOnCancel(t *testing.T) {
 			return core.TextResult("cancelled"), nil
 		},
 	)
-	RegisterTasks(TasksConfig{Server: srv})
+	RegisterTasksV1(TasksConfigV1{Server: srv})
 
 	notifications := make(chan core.TaskInfo, 10)
 	c := connectClient(t, srv, client.WithNotificationCallback(func(method string, params any) {
@@ -1482,7 +1482,7 @@ func TestTaskProgressTokenPreserved(t *testing.T) {
 			return core.TextResult("ok"), nil
 		},
 	)
-	RegisterTasks(TasksConfig{Server: srv})
+	RegisterTasksV1(TasksConfigV1{Server: srv})
 	c := connectClient(t, srv)
 
 	_, err := c.Call("tools/call", map[string]any{
@@ -1522,7 +1522,7 @@ func TestTaskDoubleCompletionRejected(t *testing.T) {
 			return core.TextResult("done"), nil
 		},
 	)
-	RegisterTasks(TasksConfig{Server: srv})
+	RegisterTasksV1(TasksConfigV1{Server: srv})
 	c := connectClient(t, srv)
 
 	created, err := client.ToolCallAsTask(c, "fast", nil)
@@ -1631,7 +1631,7 @@ func TestToolCallAsTaskWithProgressToken(t *testing.T) {
 			return core.TextResult("ok"), nil
 		},
 	)
-	RegisterTasks(TasksConfig{Server: srv})
+	RegisterTasksV1(TasksConfigV1{Server: srv})
 	c := connectClient(t, srv)
 
 	_, err := client.ToolCallAsTask(c, "token-check", nil, &client.TaskCallOptions{

--- a/server/tasks_v2.go
+++ b/server/tasks_v2.go
@@ -10,8 +10,8 @@ import (
 	"github.com/panyam/mcpkit/core"
 )
 
-// TasksV2Config holds the options for registering v2 tasks support on an MCP server.
-type TasksV2Config struct {
+// TasksConfig holds the options for registering v2 tasks support on an MCP server.
+type TasksConfig struct {
 	// Store is the task state backend. If nil, an InMemoryTaskStore is used.
 	Store TaskStore
 
@@ -28,7 +28,7 @@ type TasksV2Config struct {
 
 }
 
-func (c *TasksV2Config) defaults() {
+func (c *TasksConfig) defaults() {
 	if c.Store == nil {
 		c.Store = NewInMemoryStore()
 	}
@@ -41,7 +41,7 @@ func (c *TasksV2Config) defaults() {
 }
 
 // v2TaskRuntime holds per-registration state for v2 tasks, shared between
-// middleware and handlers. Scoped to a single RegisterTasksV2 call (C3).
+// middleware and handlers. Scoped to a single RegisterTasks call (C3).
 type v2TaskRuntime struct {
 	store    TaskStore
 	registry *Registry
@@ -107,14 +107,35 @@ func (rt *v2TaskRuntime) getToolCallbacks(taskID string) *TaskCallbacks {
 	return rt.registry.ToolCallbacks(name)
 }
 
+// deliverInputResponses routes a tasks/update payload back to whatever was
+// waiting on the corresponding input requests. Phase 4 ships an intentional
+// no-op so the handler can ack without blocking; Phase 5 wires the two real
+// delivery paths:
+//
+//   - In-process tools (the goroutine path used by RegisterTasks today):
+//     match each response key to a per-key channel on the taskEntry and send
+//     so TaskContext.TaskElicit / TaskSample can return.
+//   - External-backed tools (Temporal, Step Functions, SQS, ...): dispatch
+//     through TaskCallbacks.OnInputResponse so the proxy hands the payload
+//     to the orchestrator. This callback field doesn't exist yet — it lands
+//     when a real external-backed example drives the contract.
+//
+// Until Phase 5 lands, the handler still returns ack so clients that drive
+// the Phase 5 protocol shape early get plausible behavior at the wire level.
+func (rt *v2TaskRuntime) deliverInputResponses(taskID string, responses core.InputResponses) {
+	_ = taskID
+	_ = responses
+	// TODO(phase 5): in-process channel dispatch + TaskCallbacks.OnInputResponse.
+}
+
 // tasksExtensionProvider implements core.ExtensionProvider for the SEP-2663
-// Tasks extension. RegisterTasksV2 hands an instance to Server.RegisterExtension
+// Tasks extension. RegisterTasks hands an instance to Server.RegisterExtension
 // so the extension is advertised in capabilities.extensions during initialize.
 type tasksExtensionProvider struct{}
 
 // Extension declares the SEP-2663 Tasks extension.
 //
-//nolint:unused // referenced by RegisterTasksV2 only when the v2 path is wired
+//nolint:unused // referenced by RegisterTasks only when the v2 path is wired
 func (tasksExtensionProvider) Extension() core.Extension {
 	return core.Extension{
 		ID:          core.TasksExtensionID,
@@ -123,7 +144,7 @@ func (tasksExtensionProvider) Extension() core.Extension {
 	}
 }
 
-// RegisterTasksV2 hooks up v2 tasks support on the given server:
+// RegisterTasks hooks up v2 tasks support on the given server:
 //   - Advertises the io.modelcontextprotocol/tasks extension in initialize
 //     (replacing the v1 ServerCapabilities.Tasks declaration).
 //   - Installs middleware that intercepts tools/call for task-eligible tools
@@ -139,7 +160,7 @@ func (tasksExtensionProvider) Extension() core.Extension {
 //     not the v1 ServerCapabilities.Tasks slot.
 //
 // Must be called before accepting connections.
-func RegisterTasksV2(cfg TasksV2Config) {
+func RegisterTasks(cfg TasksConfig) {
 	cfg.defaults()
 	srv := cfg.Server
 	store := cfg.Store
@@ -152,9 +173,10 @@ func RegisterTasksV2(cfg TasksV2Config) {
 	// Install v2 middleware for tools/call interception (gated on extension).
 	srv.UseMiddleware(taskV2Middleware(reg, rt, cfg))
 
-	// Register tasks/* protocol methods (v2: only get + cancel),
+	// Register tasks/* protocol methods (SEP-2663: get + update + cancel),
 	// gated on session-level extension support.
 	srv.HandleMethod("tasks/get", gateOnTasksExtension(makeV2GetHandler(rt)))
+	srv.HandleMethod("tasks/update", gateOnTasksExtension(makeV2UpdateHandler(rt)))
 	srv.HandleMethod("tasks/cancel", gateOnTasksExtension(makeV2CancelHandler(rt)))
 }
 
@@ -182,7 +204,7 @@ func gateOnTasksExtension(inner MethodHandler) MethodHandler {
 //   - required: always create a task (no client hint needed)
 //   - optional: create a task (server-directed)
 //   - forbidden/absent: pass through (sync execution)
-func taskV2Middleware(reg *Registry, rt *v2TaskRuntime, cfg TasksV2Config) Middleware {
+func taskV2Middleware(reg *Registry, rt *v2TaskRuntime, cfg TasksConfig) Middleware {
 	return func(ctx context.Context, req *core.Request, next MiddlewareFunc) (*core.Response, error) {
 		if req.Method != "tools/call" {
 			return next(ctx, req)
@@ -337,6 +359,11 @@ func taskV2Middleware(reg *Registry, rt *v2TaskRuntime, cfg TasksV2Config) Middl
 			notifyV2TaskStatus(bgCtx, rt, store, taskID, sessionID)
 		}()
 
+		// SEP-2243: stage Mcp-Name on the HTTP response so transports / proxies
+		// / observability can route or log against the task id without parsing
+		// the JSON body. No-op for non-HTTP transports (stdio, in-process).
+		core.SetResponseHeader(ctx, mcpNameHeader, taskID)
+
 		// Build the v2 wire envelope. CreateTaskResult MUST NOT carry result/
 		// error/inputRequests/requestState (SEP-2663 — those belong on
 		// DetailedTask returned by tasks/get).
@@ -348,6 +375,12 @@ func taskV2Middleware(reg *Registry, rt *v2TaskRuntime, cfg TasksV2Config) Middl
 		}), nil
 	}
 }
+
+// mcpNameHeader is the SEP-2243 HTTP response header carrying the taskId
+// when a task-creating tools/call response is returned. Transports surface
+// it so downstream HTTP infrastructure (proxies, observability) can route
+// or log against the task identifier without parsing the JSON body.
+const mcpNameHeader = "Mcp-Name"
 
 // --- Method Handlers ---
 
@@ -401,6 +434,52 @@ func makeV2GetHandler(rt *v2TaskRuntime) MethodHandler {
 		}
 
 		return core.NewResponse(id, result)
+	}
+}
+
+// makeV2UpdateHandler implements SEP-2663 tasks/update — the resume path for
+// MRTR input rounds. The client supplies inputResponses keyed to the
+// inputRequests previously surfaced via tasks/get's DetailedTask, optionally
+// echoing requestState (SEP-2322) for stateless deployments.
+//
+// This Phase 4 implementation is a validating shell: it parses the request,
+// confirms the task exists and is non-terminal, hands the responses to the
+// runtime's deliveryInputResponses helper, and returns an empty ack
+// (UpdateTaskResult{}) per SEP-2663. Phase 5 wires the actual delivery — for
+// in-process tasks, that means matching keys to per-key channels on the
+// taskEntry and unblocking the waiting goroutine; for external-backed tools
+// (Temporal, Step Functions, SQS, ...), Phase 5 routes through a planned
+// TaskCallbacks.OnInputResponse extension point so the proxy can forward the
+// payload to the orchestrator. Either way, the handler shape stays the same.
+func makeV2UpdateHandler(rt *v2TaskRuntime) MethodHandler {
+	return func(ctx core.MethodContext, id json.RawMessage, params json.RawMessage) *core.Response {
+		var p core.UpdateTaskRequest
+		if err := json.Unmarshal(params, &p); err != nil {
+			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, err.Error())
+		}
+		if p.TaskID == "" {
+			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, "missing taskId")
+		}
+
+		sid := ctx.SessionID()
+		info, ok := rt.store.Get(p.TaskID, sid)
+		if !ok {
+			// Open spec question (PLAN.md): tasks/update for unknown taskId
+			// may end up as a silent ack. For now treat it as -32602 so
+			// callers find out immediately; flip to silent if the spec
+			// settles that way.
+			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, "task not found: "+p.TaskID)
+		}
+		if info.Status.IsTerminal() {
+			return core.NewErrorResponse(id, core.ErrCodeInvalidParams,
+				"task "+p.TaskID+" is in terminal state "+string(info.Status))
+		}
+
+		// Hand off to the runtime. Phase 4 only logs/queues; Phase 5 wires
+		// the actual per-key delivery and goroutine unblock.
+		rt.deliverInputResponses(p.TaskID, p.InputResponses)
+
+		return core.NewResponse(id, core.UpdateTaskResult{})
 	}
 }
 

--- a/server/tasks_v2_test.go
+++ b/server/tasks_v2_test.go
@@ -1,8 +1,11 @@
 package server_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"io"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -57,7 +60,7 @@ func newTaskV2Server(t *testing.T) *Server {
 		},
 	)
 
-	RegisterTasksV2(TasksV2Config{Server: srv})
+	RegisterTasks(TasksConfig{Server: srv})
 	return srv
 }
 
@@ -260,5 +263,318 @@ func TestV2_TasksGetWorksWithExtension(t *testing.T) {
 			t.Fatalf("task did not reach terminal: %v", ctx.Err())
 		case <-time.After(20 * time.Millisecond):
 		}
+	}
+}
+
+// --- Phase 4: tasks/update handler ---
+
+// newTaskV2ServerWithSlow extends the standard v2 fixture with a "slow-task"
+// tool that blocks until the returned channel is closed. Phase 4 update tests
+// use it to land an update while the task is still in the working state.
+// Phase 5 will add a real input_required tool; this is the pre-Phase-5 stand-in.
+func newTaskV2ServerWithSlow(t *testing.T) (*Server, chan struct{}) {
+	t.Helper()
+	srv := newTaskV2Server(t)
+	unblock := make(chan struct{})
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "slow-task",
+			Description: "Blocks until unblocked — used to update during working",
+			InputSchema: map[string]any{"type": "object"},
+			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportRequired},
+		},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+			select {
+			case <-unblock:
+			case <-ctx.Done():
+			}
+			return core.TextResult("slow-done"), nil
+		},
+	)
+	return srv, unblock
+}
+
+func createTaskForUpdateTest(t *testing.T, c *client.Client, tool string) string {
+	t.Helper()
+	res, err := c.Call("tools/call", map[string]any{
+		"name":      tool,
+		"arguments": map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("tools/call %q: %v", tool, err)
+	}
+	var ctr core.CreateTaskResult
+	if err := json.Unmarshal(res.Raw, &ctr); err != nil {
+		t.Fatalf("unmarshal CreateTaskResult: %v", err)
+	}
+	if ctr.Task.TaskID == "" {
+		t.Fatal("missing taskId in CreateTaskResult")
+	}
+	return ctr.Task.TaskID
+}
+
+// TestV2_UpdateAck verifies tasks/update returns an empty {} ack when the
+// supplied taskId matches a non-terminal task. Phase 4 only validates the
+// shell — Phase 5 adds the actual input-response delivery.
+func TestV2_UpdateAck(t *testing.T) {
+	srv, unblock := newTaskV2ServerWithSlow(t)
+	defer close(unblock)
+	c := connectV2Client(t, srv, client.WithTasksExtension())
+
+	taskID := createTaskForUpdateTest(t, c, "slow-task")
+
+	res, err := c.Call("tasks/update", core.UpdateTaskRequest{
+		TaskID: taskID,
+		InputResponses: core.InputResponses{
+			"elicit-1": json.RawMessage(`{"action":"accept","content":{"ok":true}}`),
+		},
+		RequestState: "echoed-state",
+	})
+	if err != nil {
+		t.Fatalf("tasks/update: %v", err)
+	}
+
+	// Empty ack — JSON should be {} (or absent fields), no task envelope.
+	var m map[string]any
+	if err := json.Unmarshal(res.Raw, &m); err != nil {
+		t.Fatalf("unmarshal ack: %v", err)
+	}
+	if len(m) != 0 {
+		t.Errorf("UpdateTaskResult should be empty {}, got %d keys: %v", len(m), m)
+	}
+}
+
+// TestV2_UpdateUnknownTaskRejected verifies tasks/update on an unknown taskId
+// surfaces -32602 (invalid params). The PLAN open question allows this to
+// flip to a silent ack later if the spec settles that way.
+func TestV2_UpdateUnknownTaskRejected(t *testing.T) {
+	srv := newTaskV2Server(t)
+	c := connectV2Client(t, srv, client.WithTasksExtension())
+
+	_, err := c.Call("tasks/update", core.UpdateTaskRequest{TaskID: "no-such-task"})
+	if err == nil {
+		t.Fatal("tasks/update with unknown taskId should fail")
+	}
+	rpcErr, ok := err.(*client.RPCError)
+	if !ok {
+		t.Fatalf("expected *client.RPCError, got %T: %v", err, err)
+	}
+	if rpcErr.Code != core.ErrCodeInvalidParams {
+		t.Errorf("code = %d, want %d (invalid params)", rpcErr.Code, core.ErrCodeInvalidParams)
+	}
+}
+
+// TestV2_UpdateTerminalRejected verifies tasks/update on a terminal task
+// surfaces -32602 — once a task is completed/failed/cancelled there's no
+// goroutine to deliver responses to.
+func TestV2_UpdateTerminalRejected(t *testing.T) {
+	srv := newTaskV2Server(t)
+	c := connectV2Client(t, srv, client.WithTasksExtension())
+
+	taskID := createTaskForUpdateTest(t, c, "fast-task")
+
+	// Wait for fast-task to complete (it returns immediately on goroutine tick).
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		gres, err := c.Call("tasks/get", map[string]any{"taskId": taskID})
+		if err != nil {
+			t.Fatalf("tasks/get: %v", err)
+		}
+		var dt core.DetailedTask
+		json.Unmarshal(gres.Raw, &dt)
+		if dt.Status.IsTerminal() {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	_, err := c.Call("tasks/update", core.UpdateTaskRequest{TaskID: taskID})
+	if err == nil {
+		t.Fatal("tasks/update on terminal task should fail")
+	}
+	rpcErr, ok := err.(*client.RPCError)
+	if !ok {
+		t.Fatalf("expected *client.RPCError, got %T: %v", err, err)
+	}
+	if rpcErr.Code != core.ErrCodeInvalidParams {
+		t.Errorf("code = %d, want %d (invalid params)", rpcErr.Code, core.ErrCodeInvalidParams)
+	}
+}
+
+// TestV2_UpdateRejectedWithoutExtension verifies tasks/update returns -32601
+// when the client did not negotiate the tasks extension at session level.
+func TestV2_UpdateRejectedWithoutExtension(t *testing.T) {
+	srv := newTaskV2Server(t)
+	c := connectV2Client(t, srv) // no WithTasksExtension
+
+	_, err := c.Call("tasks/update", core.UpdateTaskRequest{TaskID: "any-id"})
+	if err == nil {
+		t.Fatal("tasks/update without extension should fail")
+	}
+	rpcErr, ok := err.(*client.RPCError)
+	if !ok {
+		t.Fatalf("expected *client.RPCError, got %T: %v", err, err)
+	}
+	if rpcErr.Code != core.ErrCodeMethodNotFound {
+		t.Errorf("code = %d, want %d (method not found)", rpcErr.Code, core.ErrCodeMethodNotFound)
+	}
+}
+
+// --- Phase 4: SEP-2243 Mcp-Name response header ---
+
+// rawHTTPCall is a helper that POSTs a JSON-RPC request and returns the raw
+// http.Response so tests can inspect transport-level headers (e.g., Mcp-Name).
+// Hits the streamable-HTTP endpoint directly, bypassing the mcpkit client.
+//
+// jsonOnly forces the Accept header to "application/json" so the server picks
+// the synchronous JSON path (vs the SSE path that wraps the response in an
+// "id:/event:/data:" frame). Set true for tests that need to parse the JSON
+// body directly; leave false to exercise the default streamable-HTTP path.
+func rawHTTPCall(t *testing.T, baseURL, sessionID string, jsonOnly bool, method, name string) *http.Response {
+	t.Helper()
+	params := map[string]any{
+		"name":      name,
+		"arguments": map[string]any{},
+	}
+	body, _ := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  method,
+		"params":  params,
+	})
+	req, _ := http.NewRequest(http.MethodPost, baseURL+"/mcp", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	if jsonOnly {
+		req.Header.Set("Accept", "application/json")
+	} else {
+		req.Header.Set("Accept", core.StreamableHTTPAccept)
+	}
+	if sessionID != "" {
+		req.Header.Set("Mcp-Session-Id", sessionID)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("HTTP POST: %v", err)
+	}
+	return resp
+}
+
+// initializeSession runs initialize against the test server and returns the
+// session id from the Mcp-Session-Id response header. Needed because the v2
+// gating tests run header assertions against post-initialize requests.
+func initializeSession(t *testing.T, baseURL string, declareTasksExt bool) string {
+	t.Helper()
+	caps := map[string]any{}
+	if declareTasksExt {
+		caps["extensions"] = map[string]any{core.TasksExtensionID: map[string]any{}}
+	}
+	body, _ := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": "2025-11-25",
+			"capabilities":    caps,
+			"clientInfo":      map[string]any{"name": "raw-test", "version": "0.0.1"},
+		},
+	})
+	req, _ := http.NewRequest(http.MethodPost, baseURL+"/mcp", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", core.StreamableHTTPAccept)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+	defer resp.Body.Close()
+	io.ReadAll(resp.Body)
+	sid := resp.Header.Get("Mcp-Session-Id")
+	if sid == "" {
+		t.Fatal("initialize response missing Mcp-Session-Id")
+	}
+
+	// Send notifications/initialized so subsequent calls are accepted.
+	notifBody, _ := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"method":  "notifications/initialized",
+	})
+	notif, _ := http.NewRequest(http.MethodPost, baseURL+"/mcp", bytes.NewReader(notifBody))
+	notif.Header.Set("Content-Type", "application/json")
+	notif.Header.Set("Accept", core.StreamableHTTPAccept)
+	notif.Header.Set("Mcp-Session-Id", sid)
+	if r, err := http.DefaultClient.Do(notif); err == nil {
+		r.Body.Close()
+	}
+	return sid
+}
+
+// TestV2_McpNameHeaderOnTaskCreation verifies the streamable HTTP transport
+// emits the SEP-2243 Mcp-Name header carrying the new taskId on the response
+// to a task-creating tools/call.
+func TestV2_McpNameHeaderOnTaskCreation(t *testing.T) {
+	srv := newTaskV2Server(t)
+	handler := srv.Handler(WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	sid := initializeSession(t, ts.URL, true /* declare tasks ext */)
+
+	resp := rawHTTPCall(t, ts.URL, sid, true /* jsonOnly */, "tools/call", "fast-task")
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	mcpName := resp.Header.Get("Mcp-Name")
+	if mcpName == "" {
+		t.Fatalf("missing Mcp-Name header on task-creating tools/call; got body: %s", body)
+	}
+
+	// Sanity: the header value should match the taskId in the response body.
+	var rpcResp struct {
+		Result core.CreateTaskResult `json:"result"`
+	}
+	if err := json.Unmarshal(body, &rpcResp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if mcpName != rpcResp.Result.Task.TaskID {
+		t.Errorf("Mcp-Name = %q, want match for taskId %q", mcpName, rpcResp.Result.Task.TaskID)
+	}
+}
+
+// TestV2_McpNameHeaderAbsentOnSyncCall verifies the Mcp-Name header is NOT
+// set when the tools/call is handled synchronously (no task created).
+func TestV2_McpNameHeaderAbsentOnSyncCall(t *testing.T) {
+	srv := newTaskV2Server(t)
+	handler := srv.Handler(WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	sid := initializeSession(t, ts.URL, true)
+
+	// "echo" has no Execution field → forbidden → never becomes a task.
+	resp := rawHTTPCall(t, ts.URL, sid, true /* jsonOnly */, "tools/call", "echo")
+	defer resp.Body.Close()
+	io.ReadAll(resp.Body)
+
+	if got := resp.Header.Get("Mcp-Name"); got != "" {
+		t.Errorf("sync tools/call should not emit Mcp-Name; got %q", got)
+	}
+}
+
+// TestV2_McpNameHeaderAbsentWithoutExtension verifies the header is NOT set
+// when the client did not negotiate the tasks extension — middleware never
+// reaches the task-creation branch and so never stages the header.
+func TestV2_McpNameHeaderAbsentWithoutExtension(t *testing.T) {
+	srv := newTaskV2Server(t)
+	handler := srv.Handler(WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	sid := initializeSession(t, ts.URL, false /* no extension */)
+
+	resp := rawHTTPCall(t, ts.URL, sid, true /* jsonOnly */, "tools/call", "fast-task")
+	defer resp.Body.Close()
+	io.ReadAll(resp.Body)
+
+	if got := resp.Header.Get("Mcp-Name"); got != "" {
+		t.Errorf("tools/call without extension should not emit Mcp-Name; got %q", got)
 	}
 }


### PR DESCRIPTION
## Summary

Phase 4 of the SEP-2663 (Tasks Extension) implementation plan in `PLAN.md`. Issue: #320.

This PR promotes the v2 task implementation to the **canonical** name, adds the **`tasks/update`** method (handler shell — actual delivery wires up in Phase 5), and threads the **SEP-2243 `Mcp-Name`** HTTP response header through a new generic header-staging plumbing.

### File + symbol renames
- `server/tasks_experimental.go` → `server/tasks_v1.go` (git-tracked rename)
- `server/tasks_experimental_test.go` → `server/tasks_v1_test.go` (git-tracked rename)
- v1: `RegisterTasks` → `RegisterTasksV1`, `TasksConfig` → `TasksConfigV1`
- v2: `RegisterTasksV2` → `RegisterTasks`, `TasksV2Config` → `TasksConfig` (canonical)
- All callers updated (examples, tests, `task_callbacks_test`).

Internal v2 symbol prefixes (`taskV2Middleware`, `v2TaskRuntime`, `makeV2*Handler`, `notifyV2TaskStatus`, `toTaskInfoV2`) intentionally keep the `V2` infix to avoid colliding with v1 internals in the same package. PLAN.md has the rationale and the deferred-sweep condition.

### `tasks/update` (SEP-2663) — handler shell
- `core.UpdateTaskRequest` / `core.UpdateTaskResult` (added in Phase 2) are now wired in via `RegisterTasks(...)` under `gateOnTasksExtension`, so unsupported clients see `-32601` (extension not negotiated).
- The handler validates `taskId` + non-terminal state and returns the empty `UpdateTaskResult{}` ack.
- Actual input-response delivery — matching responses to per-key channels on the in-process `taskEntry`, plus a planned `TaskCallbacks.OnInputResponse` for **external-backed orchestrators** (Temporal / Step Functions / SQS) — lands in Phase 5. For now `v2TaskRuntime.deliverInputResponses` is an intentional no-op with the contract documented inline.

### Mcp-Name HTTP response header (SEP-2243)
Generic plumbing in `core/session.go`:
- `WithResponseHeaderCollector(ctx)` attaches a fresh per-request collector.
- `SetResponseHeader(ctx, k, v)` stages a header from middleware/handlers.
- `CollectResponseHeaders(ctx)` snapshots the staged map for the transport.
- No-op on non-HTTP transports (stdio, in-process).

Streamable HTTP transport applies staged headers in **both** paths:
- `handlePost` (stateless + sync JSON): `applyStagedResponseHeaders` runs before `Content-Type` is set on `w`.
- `handlePostSSE`: `applyStagedResponseHeaders` runs **inside `writeSSE`**, before the first `sseStarted=true` flip — so headers land whether the first SSE write is a notification or the final response.

The v2 task middleware stages `Mcp-Name: <taskId>` right after task creation, before returning `CreateTaskResult`.

### Tests (`server/tasks_v2_test.go`, +7 cases for Phase 4)
- `TestV2_UpdateAck` — empty `{}` ack on a non-terminal task.
- `TestV2_UpdateUnknownTaskRejected` — `-32602` for unknown `taskId`.
- `TestV2_UpdateTerminalRejected` — `-32602` once a task is terminal.
- `TestV2_UpdateRejectedWithoutExtension` — `-32601` without negotiation.
- `TestV2_McpNameHeaderOnTaskCreation` — header set + value matches the `taskId` in the response body (JSON path).
- `TestV2_McpNameHeaderAbsentOnSyncCall` — no header on sync `tools/call`.
- `TestV2_McpNameHeaderAbsentWithoutExtension` — no header when middleware never reaches the task-creation branch.

Total v2 test count: **14** (7 Phase 3 + 7 Phase 4).

## What's NOT in this PR
- **Phase 5** — `inputRequests` / `inputResponses` flow: `TaskContext.TaskElicit` / `TaskSample` switch from side-channel to "stash an `InputRequest` keyed by a monotonic id, transition to `input_required`, block on a per-key channel"; `tasks/update` runtime helper actually delivers responses to those channels. This is where the planned `TaskCallbacks.OnInputResponse` extension point lands for external-backed tools.
- **Phase 6** — client (`UpdateTask` helper, `DetailedTask` shape, polymorphic `tools/call` dispatch).
- **Phase 7** — example + conformance rework.
- **Phase 8** — backcompat bridge.

## Test plan
- [x] `make test` — core / server / client / testutil all green.
- [x] 7 new tests in `server/tasks_v2_test.go` for Phase 4 (`tasks/update` + Mcp-Name).
- [x] Full v2 test suite (14 cases) green.
- [ ] `make testconf-tasks-v2` — still expected to regress (gating + shape changes from Phases 2-3-4); reworked in Phase 7.
- [x] `make testconf-tasks` — v1 conformance unaffected (path frozen, just renamed).