### PR TITLE
feat: SEP-2663 inputRequests/inputResponses flow (Phase 5)

### DIFF
--- a/server/task_session.go
+++ b/server/task_session.go
@@ -45,8 +45,9 @@ type TaskContext struct {
 	taskID        string
 	sessionID     string
 	store         TaskStore
-	requests      chan sideChannelRequest // read by tasks/result handler
-	progressToken any                    // original _meta.progressToken from client (Phase 7c)
+	requests      chan sideChannelRequest // v1 only: read by tasks/result handler
+	inputState    *v2InputState           // v2 only: SEP-2663 input request flow
+	progressToken any                     // original _meta.progressToken from client
 }
 
 type taskContextKey struct{}
@@ -92,44 +93,36 @@ func (tc *TaskContext) SetStatus(status core.TaskStatus) error {
 	return err
 }
 
-// TaskElicit sends an elicitation request to the client via the tasks/result
-// side-channel. The request is proxied by the tasks/result long-poll handler
-// through its live connection.
+// TaskElicit asks the client for elicitation input from inside a running task.
 //
-// Status transitions: working → input_required → (wait for client) → working
+// Behavior depends on which task runtime owns this TaskContext:
+//
+//   - v2 (SEP-2663): the request is stashed on the task's inputState under a
+//     monotonic key, the task transitions to input_required, and the goroutine
+//     blocks on a per-key waiter channel. The client observes the pending
+//     request via tasks/get's DetailedTask.InputRequests and resumes the task
+//     by sending the matching response via tasks/update. ctx cancellation
+//     unblocks the wait with the corresponding context error.
+//   - v1 (legacy): the request is enqueued on a side-channel proxied by the
+//     tasks/result long-poll handler.
+//
+// Status transitions for both paths: working → input_required → working.
 func (tc *TaskContext) TaskElicit(req core.ElicitationRequest) (core.ElicitationResult, error) {
-	// Transition to input_required.
-	if err := tc.store.Update(tc.taskID, tc.sessionID, func(t *core.TaskInfo) {
-		t.Status = core.TaskInputRequired
-	}); err != nil {
-		return core.ElicitationResult{}, fmt.Errorf("task %s: failed to set input_required: %w", tc.taskID, err)
-	}
-
-	// Inject related-task metadata.
+	// Inject related-task metadata so out-of-band consumers can correlate.
 	if req.Meta == nil {
 		req.Meta = &core.ElicitationMeta{}
 	}
 	req.Meta.RelatedTask = &core.RelatedTaskMeta{TaskID: tc.taskID}
 
-	// Serialize params.
 	params, err := core.MarshalJSON(req)
 	if err != nil {
-		tc.store.Update(tc.taskID, tc.sessionID, func(t *core.TaskInfo) { t.Status = core.TaskWorking })
 		return core.ElicitationResult{}, fmt.Errorf("marshal elicitation request: %w", err)
 	}
 
-	// Send to the tasks/result handler and wait for response.
-	resp, err := tc.sendSideChannel("elicitation/create", params)
-
-	// Transition back to working.
-	tc.store.Update(tc.taskID, tc.sessionID, func(t *core.TaskInfo) {
-		t.Status = core.TaskWorking
-	})
-
+	resp, err := tc.requestInput("elicit", "elicitation/create", params)
 	if err != nil {
 		return core.ElicitationResult{}, err
 	}
-
 	var result core.ElicitationResult
 	if err := json.Unmarshal(resp, &result); err != nil {
 		return core.ElicitationResult{}, fmt.Errorf("unmarshal elicitation result: %w", err)
@@ -137,43 +130,25 @@ func (tc *TaskContext) TaskElicit(req core.ElicitationRequest) (core.Elicitation
 	return result, nil
 }
 
-// TaskSample sends a sampling request to the client via the tasks/result
-// side-channel.
+// TaskSample asks the client for a sampling/createMessage response from
+// inside a running task. See TaskElicit for the v1 vs v2 routing.
 //
-// Status transitions: working → input_required → (wait for client) → working
+// Status transitions: working → input_required → working.
 func (tc *TaskContext) TaskSample(req core.CreateMessageRequest) (core.CreateMessageResult, error) {
-	// Transition to input_required.
-	if err := tc.store.Update(tc.taskID, tc.sessionID, func(t *core.TaskInfo) {
-		t.Status = core.TaskInputRequired
-	}); err != nil {
-		return core.CreateMessageResult{}, fmt.Errorf("task %s: failed to set input_required: %w", tc.taskID, err)
-	}
-
-	// Inject related-task metadata.
 	if req.Meta == nil {
 		req.Meta = &core.SamplingMeta{}
 	}
 	req.Meta.RelatedTask = &core.RelatedTaskMeta{TaskID: tc.taskID}
 
-	// Serialize params.
 	params, err := core.MarshalJSON(req)
 	if err != nil {
-		tc.store.Update(tc.taskID, tc.sessionID, func(t *core.TaskInfo) { t.Status = core.TaskWorking })
 		return core.CreateMessageResult{}, fmt.Errorf("marshal sampling request: %w", err)
 	}
 
-	// Send to the tasks/result handler and wait for response.
-	resp, err := tc.sendSideChannel("sampling/createMessage", params)
-
-	// Transition back to working.
-	tc.store.Update(tc.taskID, tc.sessionID, func(t *core.TaskInfo) {
-		t.Status = core.TaskWorking
-	})
-
+	resp, err := tc.requestInput("sample", "sampling/createMessage", params)
 	if err != nil {
 		return core.CreateMessageResult{}, err
 	}
-
 	var result core.CreateMessageResult
 	if err := json.Unmarshal(resp, &result); err != nil {
 		return core.CreateMessageResult{}, fmt.Errorf("unmarshal sampling result: %w", err)
@@ -181,8 +156,75 @@ func (tc *TaskContext) TaskSample(req core.CreateMessageRequest) (core.CreateMes
 	return result, nil
 }
 
-// sendSideChannel enqueues a request for the tasks/result handler to proxy,
-// then blocks until the response arrives.
+// requestInput is the routing layer behind TaskElicit / TaskSample. It picks
+// the v2 SEP-2663 path when an inputState is attached and falls back to the
+// v1 side-channel otherwise. methodPrefix is a short readable tag used to
+// mint stable keys ("elicit-1", "sample-2") on the v2 path; jsonRpcMethod
+// is the actual JSON-RPC method name routed to the client.
+func (tc *TaskContext) requestInput(methodPrefix, jsonRpcMethod string, params json.RawMessage) (json.RawMessage, error) {
+	if tc.inputState != nil {
+		return tc.requestInputV2(methodPrefix, jsonRpcMethod, params)
+	}
+	return tc.requestInputV1(jsonRpcMethod, params)
+}
+
+// requestInputV2 implements the SEP-2663 input-request flow.
+func (tc *TaskContext) requestInputV2(methodPrefix, jsonRpcMethod string, params json.RawMessage) (json.RawMessage, error) {
+	_, waiter := tc.inputState.enqueue(methodPrefix, core.InputRequest{
+		Method: jsonRpcMethod,
+		Params: params,
+	})
+
+	// Transition to input_required and notify status so polling clients
+	// pick up the new pending request on the next tasks/get.
+	if err := tc.store.Update(tc.taskID, tc.sessionID, func(t *core.TaskInfo) {
+		t.Status = core.TaskInputRequired
+	}); err != nil {
+		return nil, fmt.Errorf("task %s: set input_required: %w", tc.taskID, err)
+	}
+	notifyTaskStatus(tc.Context, tc.store, tc.taskID, tc.sessionID)
+
+	// Wait for either tasks/update delivery or context cancellation.
+	var payload json.RawMessage
+	select {
+	case payload = <-waiter:
+		// Closed-channel receive yields nil payload + ok=false; treat as cancel.
+		if payload == nil {
+			return nil, fmt.Errorf("task %s: input wait cancelled", tc.taskID)
+		}
+	case <-tc.Context.Done():
+		return nil, tc.Context.Err()
+	}
+
+	// Transition back to working before returning. Best-effort: if the task
+	// has already gone terminal, the store's terminal guard rejects this.
+	tc.store.Update(tc.taskID, tc.sessionID, func(t *core.TaskInfo) {
+		t.Status = core.TaskWorking
+	})
+	notifyTaskStatus(tc.Context, tc.store, tc.taskID, tc.sessionID)
+
+	return payload, nil
+}
+
+// requestInputV1 implements the legacy v1 side-channel flow (tasks/result
+// long-poll proxies the request through its live connection).
+func (tc *TaskContext) requestInputV1(jsonRpcMethod string, params json.RawMessage) (json.RawMessage, error) {
+	if err := tc.store.Update(tc.taskID, tc.sessionID, func(t *core.TaskInfo) {
+		t.Status = core.TaskInputRequired
+	}); err != nil {
+		return nil, fmt.Errorf("task %s: set input_required: %w", tc.taskID, err)
+	}
+
+	resp, err := tc.sendSideChannel(jsonRpcMethod, params)
+
+	tc.store.Update(tc.taskID, tc.sessionID, func(t *core.TaskInfo) {
+		t.Status = core.TaskWorking
+	})
+	return resp, err
+}
+
+// sendSideChannel enqueues a request for the v1 tasks/result handler to
+// proxy, then blocks until the response arrives.
 func (tc *TaskContext) sendSideChannel(method string, params json.RawMessage) (json.RawMessage, error) {
 	respCh := make(chan sideChannelResponse, 1)
 	tc.requests <- sideChannelRequest{

--- a/server/tasks_v1.go
+++ b/server/tasks_v1.go
@@ -53,10 +53,18 @@ func (c *TasksConfigV1) defaults() {
 	}
 }
 
-// activeTask holds per-task runtime state for a running async task (C2: consolidated struct).
+// activeTask holds per-task runtime state for a running async task (C2:
+// consolidated struct). Used by both the v1 and v2 task runtimes; some fields
+// are path-specific and stay nil when not used.
 type activeTask struct {
-	requests chan sideChannelRequest // read by tasks/result handler for side-channel proxying
-	cancel   context.CancelFunc     // cancels the background goroutine's context (Phase 5)
+	requests chan sideChannelRequest // v1 only: read by tasks/result handler for side-channel proxying
+	cancel   context.CancelFunc      // both: cancels the background goroutine's context
+
+	// inputState tracks pending SEP-2663 input requests for v2 tasks. nil for
+	// v1-driven tasks (which use the legacy `requests` side-channel above).
+	// Populated by v2 middleware at task creation; consulted by tasks/get
+	// (snapshot of pending) and tasks/update (delivery to waiters).
+	inputState *v2InputState
 }
 
 // taskRuntime holds the per-registration state shared between the middleware

--- a/server/tasks_v2.go
+++ b/server/tasks_v2.go
@@ -107,25 +107,134 @@ func (rt *v2TaskRuntime) getToolCallbacks(taskID string) *TaskCallbacks {
 	return rt.registry.ToolCallbacks(name)
 }
 
-// deliverInputResponses routes a tasks/update payload back to whatever was
-// waiting on the corresponding input requests. Phase 4 ships an intentional
-// no-op so the handler can ack without blocking; Phase 5 wires the two real
-// delivery paths:
+// deliverInputResponses routes a tasks/update payload back to whichever
+// goroutine is waiting on the corresponding SEP-2663 input request. For
+// each response key that matches a pending request on the task's
+// inputState, the payload is sent on the per-key waiter channel so
+// TaskContext.TaskElicit / TaskSample can return. Unknown keys are
+// silently dropped — clients may legitimately race tasks/update against
+// status changes.
 //
-//   - In-process tools (the goroutine path used by RegisterTasks today):
-//     match each response key to a per-key channel on the taskEntry and send
-//     so TaskContext.TaskElicit / TaskSample can return.
-//   - External-backed tools (Temporal, Step Functions, SQS, ...): dispatch
-//     through TaskCallbacks.OnInputResponse so the proxy hands the payload
-//     to the orchestrator. This callback field doesn't exist yet — it lands
-//     when a real external-backed example drives the contract.
-//
-// Until Phase 5 lands, the handler still returns ack so clients that drive
-// the Phase 5 protocol shape early get plausible behavior at the wire level.
+// External-backed tools (Temporal, Step Functions, SQS, ...) will also
+// route through here once a planned TaskCallbacks.OnInputResponse field
+// exists; until that lands, they won't have an inputState attached and
+// this method is a no-op for them.
 func (rt *v2TaskRuntime) deliverInputResponses(taskID string, responses core.InputResponses) {
-	_ = taskID
-	_ = responses
-	// TODO(phase 5): in-process channel dispatch + TaskCallbacks.OnInputResponse.
+	state := rt.inputStateFor(taskID)
+	if state == nil {
+		return
+	}
+	for key, payload := range responses {
+		state.deliver(key, payload)
+	}
+}
+
+// inputStateFor returns the per-task SEP-2663 input-state, or nil if the
+// task has no active entry (already terminal, never created, or the
+// underlying tool is external-backed without an inputState attached).
+func (rt *v2TaskRuntime) inputStateFor(taskID string) *v2InputState {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	if at := rt.active[taskID]; at != nil {
+		return at.inputState
+	}
+	return nil
+}
+
+// v2InputState tracks SEP-2663 input requests in flight for one v2 task.
+// Each enqueue mints a stable monotonic key ("elicit-1", "sample-2", ...)
+// and returns a waiter channel; the matching tasks/update key delivers the
+// raw response payload through that channel. Concurrency-safe.
+type v2InputState struct {
+	mu      sync.Mutex
+	counter uint64
+	pending map[string]*v2InputWait
+}
+
+func newV2InputState() *v2InputState {
+	return &v2InputState{pending: make(map[string]*v2InputWait)}
+}
+
+// v2InputWait pairs a pending input request with the channel its caller
+// (TaskContext.TaskElicit / TaskSample) is blocked on.
+type v2InputWait struct {
+	request core.InputRequest
+	waiter  chan json.RawMessage
+}
+
+// enqueue mints a new monotonic key, stashes the request on pending, and
+// returns the key plus the waiter channel the caller should block on.
+// methodPrefix is a short tag ("elicit", "sample") used to make the keys
+// readable when surfaced in tasks/get responses; uniqueness comes from
+// the global counter, not the prefix.
+//
+// IMPORTANT: the key format ("<prefix>-<n>") is a server-internal readability
+// choice, not a wire contract. Per SEP-2322 / SEP-2663 the InputRequests /
+// InputResponses map keys are server-chosen and opaque to the client —
+// clients MUST treat them as round-trip echo strings and MUST NOT parse them.
+// We are free to change the generator (e.g., to UUIDs) without breaking any
+// conformant client.
+func (s *v2InputState) enqueue(methodPrefix string, req core.InputRequest) (key string, waiter chan json.RawMessage) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.counter++
+	key = fmt.Sprintf("%s-%d", methodPrefix, s.counter)
+	waiter = make(chan json.RawMessage, 1)
+	s.pending[key] = &v2InputWait{request: req, waiter: waiter}
+	return key, waiter
+}
+
+// deliver routes a tasks/update payload to the waiter for key, returning
+// true if a waiter was found. The pending entry is removed regardless of
+// whether the send succeeds (the caller's select on ctx.Done() may have
+// already drained the slot). Buffered waiter chans guarantee deliver
+// never blocks.
+func (s *v2InputState) deliver(key string, payload json.RawMessage) bool {
+	s.mu.Lock()
+	wait, ok := s.pending[key]
+	if ok {
+		delete(s.pending, key)
+	}
+	s.mu.Unlock()
+	if !ok {
+		return false
+	}
+	select {
+	case wait.waiter <- payload:
+	default:
+		// Waiter already abandoned the slot (cancelled / context done).
+	}
+	return true
+}
+
+// snapshot copies the current pending requests into the SEP-2663 wire
+// shape for tasks/get DetailedTask responses. Returns nil when nothing
+// is pending so the handler omits the field entirely.
+func (s *v2InputState) snapshot() core.InputRequests {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.pending) == 0 {
+		return nil
+	}
+	out := make(core.InputRequests, len(s.pending))
+	for k, w := range s.pending {
+		out[k] = w.request
+	}
+	return out
+}
+
+// cancelAll drops every pending request and closes the waiter channels so
+// blocked goroutines unblock with a zero-value payload (callers detect
+// this via the closed-channel receive). Called when a task transitions to
+// a terminal state without delivering responses (cancel, panic, etc.).
+func (s *v2InputState) cancelAll() {
+	s.mu.Lock()
+	pending := s.pending
+	s.pending = make(map[string]*v2InputWait)
+	s.mu.Unlock()
+	for _, w := range pending {
+		close(w.waiter)
+	}
 }
 
 // tasksExtensionProvider implements core.ExtensionProvider for the SEP-2663
@@ -287,16 +396,20 @@ func taskV2Middleware(reg *Registry, rt *v2TaskRuntime, cfg TasksConfig) Middlew
 			bgCtx := core.DetachForBackground(ctx)
 			bgCtx, cancelFunc := context.WithCancel(bgCtx)
 
-			reqCh := make(chan sideChannelRequest, 1)
+			// SEP-2663 input-request flow: each v2 task gets its own
+			// inputState. TaskContext.TaskElicit / TaskSample stash pending
+			// requests here; tasks/update delivers responses; tasks/get
+			// snapshots them for the DetailedTask wire shape.
+			inputState := newV2InputState()
 			tc := &TaskContext{
 				taskID:        taskID,
 				sessionID:     sessionID,
 				store:         store,
-				requests:      reqCh,
+				inputState:    inputState,
 				progressToken: progressToken,
 			}
 			bgCtx = WithTaskContext(bgCtx, tc)
-			rt.register(taskID, envelope.Name, &activeTask{requests: reqCh, cancel: cancelFunc})
+			rt.register(taskID, envelope.Name, &activeTask{cancel: cancelFunc, inputState: inputState})
 
 			defer func() {
 				cancelFunc()
@@ -404,6 +517,15 @@ func makeV2GetHandler(rt *v2TaskRuntime) MethodHandler {
 			TaskInfoV2: toTaskInfoV2(info),
 			// Generate requestState (opaque token for stateless deployments).
 			RequestState: p.TaskID,
+		}
+
+		// SEP-2663: when the task is awaiting MRTR input, surface the
+		// pending requests on DetailedTask.InputRequests so the client
+		// knows which keys to satisfy via tasks/update.
+		if info.Status == core.TaskInputRequired {
+			if state := rt.inputStateFor(p.TaskID); state != nil {
+				result.InputRequests = state.snapshot()
+			}
 		}
 
 		// Inline result or error depending on terminal status.

--- a/server/tasks_v2_test.go
+++ b/server/tasks_v2_test.go
@@ -578,3 +578,262 @@ func TestV2_McpNameHeaderAbsentWithoutExtension(t *testing.T) {
 		t.Errorf("tools/call without extension should not emit Mcp-Name; got %q", got)
 	}
 }
+
+// --- Phase 5: SEP-2663 inputRequests / inputResponses flow ---
+
+// newTaskV2ServerWithElicit registers a "confirm-delete" tool that calls
+// TaskElicit and returns a result derived from the user's response. The
+// Phase 5 integration test drives the full SEP-2663 elicit → update →
+// complete cycle against this fixture.
+func newTaskV2ServerWithElicit(t *testing.T) *Server {
+	t.Helper()
+	srv := newTaskV2Server(t)
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "confirm-delete",
+			Description: "Asks the client to confirm before deleting",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"filename": map[string]any{"type": "string"},
+				},
+			},
+			Execution: &core.ToolExecution{TaskSupport: core.TaskSupportRequired},
+		},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+			tc := GetTaskContext(ctx)
+			if tc == nil {
+				return core.ToolResult{}, errorString("confirm-delete requires task context")
+			}
+
+			var args struct {
+				Filename string `json:"filename"`
+			}
+			json.Unmarshal(req.Arguments, &args)
+			if args.Filename == "" {
+				args.Filename = "untitled"
+			}
+
+			res, err := tc.TaskElicit(core.ElicitationRequest{
+				Message:         "Delete " + args.Filename + "?",
+				RequestedSchema: json.RawMessage(`{"type":"object","properties":{"confirm":{"type":"boolean"}}}`),
+			})
+			if err != nil {
+				return core.ToolResult{}, err
+			}
+			if res.Action == "accept" {
+				if confirmed, _ := res.Content["confirm"].(bool); confirmed {
+					return core.TextResult("deleted " + args.Filename), nil
+				}
+			}
+			return core.TextResult("kept " + args.Filename), nil
+		},
+	)
+	return srv
+}
+
+// errorString is a tiny adapter so the inline tool handler doesn't have to
+// import "errors" / "fmt" just for one literal.
+type errorString string
+
+func (e errorString) Error() string { return string(e) }
+
+// pollV2Detailed polls tasks/get every interval until pred returns true or
+// the context expires. Returns the last DetailedTask seen.
+func pollV2Detailed(t *testing.T, ctx context.Context, c *client.Client, taskID string, interval time.Duration, pred func(core.DetailedTask) bool) core.DetailedTask {
+	t.Helper()
+	var last core.DetailedTask
+	for {
+		gres, err := c.Call("tasks/get", map[string]any{"taskId": taskID})
+		if err != nil {
+			t.Fatalf("tasks/get: %v", err)
+		}
+		if err := json.Unmarshal(gres.Raw, &last); err != nil {
+			t.Fatalf("unmarshal DetailedTask: %v", err)
+		}
+		if pred(last) {
+			return last
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("tasks/get poll timed out; last status %q, raw %s", last.Status, gres.Raw)
+		case <-time.After(interval):
+		}
+	}
+}
+
+// TestV2_ElicitUpdateCompleteFlow drives the full SEP-2663 input-request
+// loop end-to-end:
+//
+//	tools/call confirm-delete  →  CreateTaskResult
+//	poll tasks/get             →  status: input_required, inputRequests populated
+//	tasks/update               →  empty ack, server-side goroutine unblocks
+//	poll tasks/get             →  status: completed, result inlined
+func TestV2_ElicitUpdateCompleteFlow(t *testing.T) {
+	srv := newTaskV2ServerWithElicit(t)
+	c := connectV2Client(t, srv, client.WithTasksExtension())
+
+	res, err := c.Call("tools/call", map[string]any{
+		"name":      "confirm-delete",
+		"arguments": map[string]any{"filename": "important.txt"},
+	})
+	if err != nil {
+		t.Fatalf("tools/call: %v", err)
+	}
+	var ctr core.CreateTaskResult
+	if err := json.Unmarshal(res.Raw, &ctr); err != nil {
+		t.Fatalf("unmarshal CreateTaskResult: %v", err)
+	}
+	taskID := ctr.Task.TaskID
+
+	// 1. Wait for input_required + a populated inputRequests map.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	pending := pollV2Detailed(t, ctx, c, taskID, 20*time.Millisecond, func(d core.DetailedTask) bool {
+		return d.Status == core.TaskInputRequired && len(d.InputRequests) > 0
+	})
+	if got := len(pending.InputRequests); got != 1 {
+		t.Fatalf("expected 1 pending input request, got %d (raw: %+v)", got, pending.InputRequests)
+	}
+
+	// Pick whatever key the server minted — clients MUST treat it as opaque.
+	var key string
+	var inputReq core.InputRequest
+	for k, v := range pending.InputRequests {
+		key = k
+		inputReq = v
+		break
+	}
+	if inputReq.Method != "elicitation/create" {
+		t.Errorf("inputRequests[%q].method = %q, want elicitation/create", key, inputReq.Method)
+	}
+
+	// 2. Reply via tasks/update — empty ack confirms the server accepted it.
+	ackRes, err := c.Call("tasks/update", core.UpdateTaskRequest{
+		TaskID: taskID,
+		InputResponses: core.InputResponses{
+			key: json.RawMessage(`{"action":"accept","content":{"confirm":true}}`),
+		},
+	})
+	if err != nil {
+		t.Fatalf("tasks/update: %v", err)
+	}
+	var ackMap map[string]any
+	json.Unmarshal(ackRes.Raw, &ackMap)
+	if len(ackMap) != 0 {
+		t.Errorf("tasks/update ack should be empty {}, got %v", ackMap)
+	}
+
+	// 3. Poll until the goroutine resumes and the task completes.
+	final := pollV2Detailed(t, ctx, c, taskID, 20*time.Millisecond, func(d core.DetailedTask) bool {
+		return d.Status.IsTerminal()
+	})
+	if final.Status != core.TaskCompleted {
+		t.Fatalf("status = %q, want completed", final.Status)
+	}
+	if final.Result == nil || len(final.Result.Content) == 0 {
+		t.Fatalf("expected inlined result with content, got %+v", final.Result)
+	}
+	if got := final.Result.Content[0].Text; got != "deleted important.txt" {
+		t.Errorf("result text = %q, want %q", got, "deleted important.txt")
+	}
+}
+
+// TestV2_ElicitCancelUnblocks verifies that a tasks/cancel issued while a
+// task is parked in input_required cancels the background goroutine — the
+// pending TaskElicit returns via ctx.Done() instead of waiting forever for
+// a tasks/update that will never come. The task transitions to cancelled.
+func TestV2_ElicitCancelUnblocks(t *testing.T) {
+	srv := newTaskV2ServerWithElicit(t)
+	c := connectV2Client(t, srv, client.WithTasksExtension())
+
+	res, err := c.Call("tools/call", map[string]any{
+		"name":      "confirm-delete",
+		"arguments": map[string]any{"filename": "doc.txt"},
+	})
+	if err != nil {
+		t.Fatalf("tools/call: %v", err)
+	}
+	var ctr core.CreateTaskResult
+	json.Unmarshal(res.Raw, &ctr)
+	taskID := ctr.Task.TaskID
+
+	// Wait for input_required, then cancel.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	pollV2Detailed(t, ctx, c, taskID, 20*time.Millisecond, func(d core.DetailedTask) bool {
+		return d.Status == core.TaskInputRequired
+	})
+
+	if _, err := c.Call("tasks/cancel", map[string]any{"taskId": taskID}); err != nil {
+		t.Fatalf("tasks/cancel: %v", err)
+	}
+
+	final := pollV2Detailed(t, ctx, c, taskID, 20*time.Millisecond, func(d core.DetailedTask) bool {
+		return d.Status.IsTerminal()
+	})
+	if final.Status != core.TaskCancelled {
+		t.Errorf("status = %q, want cancelled", final.Status)
+	}
+}
+
+// TestV2_UpdateUnknownKeyIgnored verifies that delivering a tasks/update
+// payload for a key that doesn't match any pending request is silently
+// dropped — the still-blocked TaskElicit keeps waiting. Important because
+// the wait-then-deliver dance can race; an in-flight tasks/update with a
+// stale or made-up key MUST NOT crash the server.
+func TestV2_UpdateUnknownKeyIgnored(t *testing.T) {
+	srv := newTaskV2ServerWithElicit(t)
+	c := connectV2Client(t, srv, client.WithTasksExtension())
+
+	res, err := c.Call("tools/call", map[string]any{
+		"name":      "confirm-delete",
+		"arguments": map[string]any{"filename": "x.txt"},
+	})
+	if err != nil {
+		t.Fatalf("tools/call: %v", err)
+	}
+	var ctr core.CreateTaskResult
+	json.Unmarshal(res.Raw, &ctr)
+	taskID := ctr.Task.TaskID
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	pending := pollV2Detailed(t, ctx, c, taskID, 20*time.Millisecond, func(d core.DetailedTask) bool {
+		return d.Status == core.TaskInputRequired && len(d.InputRequests) > 0
+	})
+
+	// Send an update for a bogus key — should ack but NOT unblock.
+	if _, err := c.Call("tasks/update", core.UpdateTaskRequest{
+		TaskID: taskID,
+		InputResponses: core.InputResponses{
+			"bogus-key": json.RawMessage(`{"action":"reject"}`),
+		},
+	}); err != nil {
+		t.Fatalf("tasks/update with unknown key: %v", err)
+	}
+
+	// Confirm the task is still parked — the real key is still pending.
+	gres, _ := c.Call("tasks/get", map[string]any{"taskId": taskID})
+	var still core.DetailedTask
+	json.Unmarshal(gres.Raw, &still)
+	if still.Status != core.TaskInputRequired {
+		t.Errorf("status = %q, want still input_required", still.Status)
+	}
+
+	// Now satisfy the real key so the test cleanly completes the goroutine.
+	var realKey string
+	for k := range pending.InputRequests {
+		realKey = k
+		break
+	}
+	c.Call("tasks/update", core.UpdateTaskRequest{
+		TaskID: taskID,
+		InputResponses: core.InputResponses{
+			realKey: json.RawMessage(`{"action":"accept","content":{"confirm":false}}`),
+		},
+	})
+	pollV2Detailed(t, ctx, c, taskID, 20*time.Millisecond, func(d core.DetailedTask) bool {
+		return d.Status.IsTerminal()
+	})
+}


### PR DESCRIPTION
## Summary

Phase 5 of the SEP-2663 (Tasks Extension) plan in `PLAN.md`. Issues: #320 (SEP-2663), #321 (SEP-2322).

This PR **closes the MRTR loop end-to-end**. A v2 tool can now call `TaskElicit` / `TaskSample`, the goroutine actually parks until the client replies via `tasks/update`, and `tasks/get` surfaces the pending requests under `DetailedTask.InputRequests`. Phase 4's `tasks/update` handler (which until now ack'd into a no-op `deliverInputResponses` stub) is wired through to real waiter delivery.

## Primitives — `server/tasks_v2.go`

`v2InputState` per task (mu, monotonic counter, pending map of `key → {InputRequest, waiter chan}`).
- `enqueue(prefix, req) → (key, waiter)` — mints a stable key (`"<prefix>-<n>"`), stashes the request, returns a buffered waiter chan.
  > **Important:** the key format is a server-internal readability choice, **not** a wire contract. Per SEP-2322 / SEP-2663 the `InputRequests` / `InputResponses` map keys are server-chosen and opaque to the client — clients MUST treat them as round-trip echo strings. We're free to swap to UUIDs without breaking conformant clients. Documented inline.
- `deliver(key, payload) → bool` — routes a tasks/update payload to the waiter and removes the entry. Unknown keys are silent no-ops (clients may legitimately race tasks/update against status changes).
- `snapshot() → InputRequests` — copies pending into the SEP-2663 wire shape for tasks/get.
- `cancelAll()` — closes all waiters; available for explicit cleanup paths (today `ctx.Done()` propagation handles unblock naturally, so this isn't called yet).

`activeTask` (in `server/tasks_v1.go`) gains an `inputState *v2InputState` field per CONSTRAINTS C2 — kept on the existing per-task entry instead of introducing a parallel map. Field stays nil for v1-driven tasks.

## Wiring — `server/tasks_v2.go`

- v2 middleware mints a fresh `inputState` per task and threads it onto **both** `activeTask` (so handlers can find it via `inputStateFor(taskID)`) and `TaskContext` (so the tool can use it).
- `v2TaskRuntime.deliverInputResponses` (a Phase 4 stub) now forwards each `(key, payload)` to `inputStateFor(taskID).deliver(...)`.
- `makeV2GetHandler` populates `DetailedTask.InputRequests` when `status == TaskInputRequired` by calling `state.snapshot()`.

## TaskContext — `server/task_session.go`

- New field `inputState *v2InputState` (nil on the v1 path).
- `TaskElicit` / `TaskSample` factor through a new `requestInput` router: `inputState != nil` → SEP-2663 path (enqueue + park on waiter, `select` on `ctx.Done()`); else → legacy v1 `sendSideChannel`.
- v2 path: `working → input_required` (notify status) → block on waiter or `ctx.Done()` → `working` (notify status) → return parsed result. Cancellation propagates via the `bgCtx` the middleware already cancels in its defer, so the goroutine never leaks.

## Tests — `server/tasks_v2_test.go` (+3)

- **`TestV2_ElicitUpdateCompleteFlow`** — `tools/call confirm-delete` → poll until `input_required` + `InputRequests` populated → `tasks/update` with the server-minted key → poll until `completed` with inlined result. Verifies the wire shape, the round-trip, and the inlined `ToolResult`.
- **`TestV2_ElicitCancelUnblocks`** — `tasks/cancel` issued during `input_required` propagates via `ctx.Done()`; task transitions to `cancelled` cleanly with no goroutine leak.
- **`TestV2_UpdateUnknownKeyIgnored`** — bogus `tasks/update` keys are silently dropped; the real pending request stays resolvable. Important because the wait-then-deliver dance can race; an in-flight stale or made-up key MUST NOT crash the server.

Total v2 test count: **17** (Phase 3: 7, Phase 4: 7, Phase 5: 3). `make test` green.

## External-backed tools

Temporal / Step Functions / SQS-style proxies still no-op cleanly because they have no `inputState` attached (`deliverInputResponses` returns early when `inputStateFor(taskID)` is nil). The planned `TaskCallbacks.OnInputResponse` extension point will hook into `deliverInputResponses` when a real external-backed example drives the contract — out of scope for this PR.

## What's NOT in this PR

- **Phase 6** — client (`UpdateTask` helper, `WaitForTask` for v2, polymorphic `tools/call` dispatch).
- **Phase 7** — example + conformance rework (the v2 walkthrough's `confirm_delete` story still uses the v1 elicit path).
- **Phase 8** — backcompat bridge.

## Test plan

- [x] `make test` — core / server / client / testutil all green.
- [x] 3 new integration tests in `server/tasks_v2_test.go` covering the elicit/update/complete loop, cancellation while parked, and unknown-key resilience.
- [x] Full v2 test suite (17 cases) green.
- [ ] `make testconf-tasks-v2` — still expected to regress (extension gating + shape changes from earlier phases); reworked in Phase 7.
- [x] `make testconf-tasks` — v1 conformance unaffected (path frozen, just renamed).