### PR TITLE
feat(events): cursor:null / best-effort sources + drop poll batching (PR B of #323)

### DIFF
--- a/experimental/discord-events/Makefile
+++ b/experimental/discord-events/Makefile
@@ -73,6 +73,11 @@ inject:
 	  -H 'Content-Type: application/json' \
 	  -d '{"guild_id": "$(or $(GUILD),test-guild)", "channel_id": "$(or $(CHANNEL),test-channel)", "sender": "$(or $(SENDER),test-user)", "text": "$(or $(TEXT),hello from make inject)"}' | jq .
 
+inject-typing:
+	@curl -s -X POST '$(ADDR)/inject?event=discord.typing' \
+	  -H 'Content-Type: application/json' \
+	  -d '{"guild_id": "$(or $(GUILD),test-guild)", "channel_id": "$(or $(CHANNEL),test-channel)", "user": "$(or $(USER_NAME),test-user)"}' | jq .
+
 list:
 	@$(EVENTS_CLIENT) list
 
@@ -85,4 +90,4 @@ webhook:
 poll:
 	@$(EVENTS_CLIENT) poll --interval $(or $(INTERVAL),5)
 
-.PHONY: run test test-race test-ttl inject list listen webhook poll
+.PHONY: run test test-race test-ttl inject inject-typing list listen webhook poll

--- a/experimental/discord-events/README.md
+++ b/experimental/discord-events/README.md
@@ -164,7 +164,8 @@ typed accessors (for resource reads).
 | `make run` | Start server (with bot if `DISCORD_BOT_TOKEN` set) |
 | `make test` | Go tests |
 | `make test-ttl` | Drive the Python `WebhookSubscription` auto-refresh helper end-to-end (POSIX-only — see Makefile for Windows steps) |
-| `make inject TEXT="..."` | Inject a message (optional: `SENDER=`, `CHANNEL=`, `GUILD=`) |
+| `make inject TEXT="..."` | Inject a message event (optional: `SENDER=`, `CHANNEL=`, `GUILD=`) |
+| `make inject-typing` | Inject a cursorless typing event (optional: `USER_NAME=`, `CHANNEL=`, `GUILD=`) |
 | `make list` | Show server capabilities: tools, resources, events, sample poll |
 | `make listen` | SSE push listener — print events in real time |
 | `make webhook` | Webhook receiver — subscribe + auto-refresh, receive HMAC-signed POSTs |

--- a/experimental/discord-events/discord.go
+++ b/experimental/discord-events/discord.go
@@ -58,3 +58,24 @@ func newDiscordEvent(guildID, channelID, sender, content string, ts time.Time) D
 		Timestamp: ts.Format(time.RFC3339),
 	}
 }
+
+// DiscordTypingData is the typed payload for the cursorless discord.typing
+// event. Typing indicators are ephemeral state — there is no replay value,
+// so the source declares itself cursorless and the wire emits cursor:null.
+type DiscordTypingData struct {
+	GuildID   string `json:"guild_id" jsonschema:"description=Discord server (guild) ID"`
+	ChannelID string `json:"channel_id" jsonschema:"description=Channel where typing started"`
+	User      string `json:"user" jsonschema:"description=Username that started typing"`
+	StartedAt string `json:"started_at" jsonschema:"description=ISO 8601 timestamp,format=date-time"`
+}
+
+// newDiscordTypingEvent builds a DiscordTypingData payload.
+func newDiscordTypingEvent(guildID, channelID, user string, ts time.Time) DiscordTypingData {
+	log.Printf("[discord-typing] guild=%s channel=%s user=%s", guildID, channelID, user)
+	return DiscordTypingData{
+		GuildID:   guildID,
+		ChannelID: channelID,
+		User:      user,
+		StartedAt: ts.Format(time.RFC3339),
+	}
+}

--- a/experimental/discord-events/e2e_test.go
+++ b/experimental/discord-events/e2e_test.go
@@ -22,9 +22,13 @@ import (
 // events without spinning up a Discord session. Optional WebhookOptions
 // configure the registry — defaults match the production demo (Server +
 // MCPHeaders).
+//
+// The cursorless typing source is registered alongside discord.message so
+// cursor-shape tests can exercise both modes against the same server.
 func buildTestStack(whOpts ...events.WebhookOption) (*server.Server, *events.YieldingSource[DiscordEventData], func(DiscordEventData) error, *events.WebhookRegistry) {
 	webhooks := events.NewWebhookRegistry(whOpts...)
 	source, yield := newDiscordSource()
+	typingSource, _ := newDiscordTypingSource()
 
 	srv := server.NewServer(
 		core.ServerInfo{Name: "discord-events-test", Version: "0.1.0"},
@@ -33,12 +37,33 @@ func buildTestStack(whOpts ...events.WebhookOption) (*server.Server, *events.Yie
 	registerResources(srv, source)
 	registerTools(srv, nil) // nil session = test mode
 	events.Register(events.Config{
-		Sources:  []events.EventSource{source},
+		Sources:  []events.EventSource{source, typingSource},
 		Webhooks: webhooks,
 		Server:   srv,
 	})
 
 	return srv, source, yield, webhooks
+}
+
+// buildTestStackWithTyping returns the same wired server but exposes the
+// cursorless typing yield function too. Used by the cursorless e2e tests.
+func buildTestStackWithTyping(whOpts ...events.WebhookOption) (*server.Server, func(DiscordEventData) error, func(DiscordTypingData) error, *events.WebhookRegistry) {
+	webhooks := events.NewWebhookRegistry(whOpts...)
+	source, yield := newDiscordSource()
+	typingSource, yieldTyping := newDiscordTypingSource()
+
+	srv := server.NewServer(
+		core.ServerInfo{Name: "discord-events-test", Version: "0.1.0"},
+		server.WithSubscriptions(),
+	)
+	registerResources(srv, source)
+	registerTools(srv, nil)
+	events.Register(events.Config{
+		Sources:  []events.EventSource{source, typingSource},
+		Webhooks: webhooks,
+		Server:   srv,
+	})
+	return srv, yield, yieldTyping, webhooks
 }
 
 func connectClient(t *testing.T, srv *server.Server) (*client.Client, *httptest.Server) {
@@ -197,13 +222,25 @@ func TestE2EEventsList(t *testing.T) {
 			Name          string   `json:"name"`
 			Delivery      []string `json:"delivery"`
 			PayloadSchema any      `json:"payloadSchema"`
+			Cursorless    bool     `json:"cursorless"`
 		} `json:"events"`
 	}
 	require.NoError(t, json.Unmarshal(result.Raw, &resp))
-	require.Len(t, resp.Events, 1)
-	assert.Equal(t, "discord.message", resp.Events[0].Name)
-	assert.ElementsMatch(t, []string{"push", "poll", "webhook"}, resp.Events[0].Delivery)
-	assert.NotNil(t, resp.Events[0].PayloadSchema, "payloadSchema should be auto-derived")
+	byName := map[string]int{}
+	for i, e := range resp.Events {
+		byName[e.Name] = i
+	}
+	require.Contains(t, byName, "discord.message")
+	require.Contains(t, byName, "discord.typing")
+
+	msg := resp.Events[byName["discord.message"]]
+	assert.ElementsMatch(t, []string{"push", "poll", "webhook"}, msg.Delivery)
+	assert.NotNil(t, msg.PayloadSchema, "payloadSchema should be auto-derived")
+	assert.False(t, msg.Cursorless, "discord.message is cursored")
+
+	typing := resp.Events[byName["discord.typing"]]
+	assert.ElementsMatch(t, []string{"push", "webhook"}, typing.Delivery)
+	assert.True(t, typing.Cursorless, "discord.typing is cursorless")
 }
 
 // TestE2EResourceRead verifies the recent-messages resource reads from the
@@ -384,6 +421,177 @@ func TestE2EUnsubscribeBySecret(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Len(t, webhooks.Targets(), 0, "unsubscribe by secret must remove the matching subscription")
+}
+
+// TestE2ECursorlessPushDelivery verifies the cursorless typing source: yield
+// triggers a push notification whose Event.cursor is JSON null on the wire.
+// Confirms the `*string` cursor field round-trips correctly through the
+// notification fanout path.
+func TestE2ECursorlessPushDelivery(t *testing.T) {
+	srv, _, yieldTyping, _ := buildTestStackWithTyping()
+
+	var mu sync.Mutex
+	var receivedRaw []map[string]any
+
+	handler := srv.Handler(server.WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "cursorless-push", Version: "1.0"},
+		client.WithGetSSEStream(),
+		client.WithNotificationCallback(func(method string, params any) {
+			if method != "notifications/events/event" {
+				return
+			}
+			b, _ := json.Marshal(params)
+			var p map[string]any
+			_ = json.Unmarshal(b, &p)
+			mu.Lock()
+			receivedRaw = append(receivedRaw, p)
+			mu.Unlock()
+		}),
+	)
+	require.NoError(t, c.Connect())
+	defer c.Close()
+
+	time.Sleep(200 * time.Millisecond)
+	require.NoError(t, yieldTyping(newDiscordTypingEvent("g", "c", "alice", time.Now())))
+	time.Sleep(500 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, receivedRaw, 1, "push must deliver the typing event")
+	cursorVal, present := receivedRaw[0]["cursor"]
+	require.True(t, present, "cursor field must be present on the wire (not omitted)")
+	assert.Nil(t, cursorVal, "cursorless event must wire as cursor:null")
+}
+
+// TestE2ECursorlessWebhookDelivery verifies the cursorless typing source's
+// webhook delivery: the POSTed Event JSON has cursor:null. Mirrors the push
+// test but through the webhook fanout path.
+func TestE2ECursorlessWebhookDelivery(t *testing.T) {
+	srv, _, yieldTyping, _ := buildTestStackWithTyping()
+
+	var mu sync.Mutex
+	var deliveryBody map[string]any
+	var assignedSecret string
+
+	callbackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		_ = json.Unmarshal(body, &deliveryBody)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer callbackSrv.Close()
+
+	handler := srv.Handler(server.WithStreamableHTTP(true))
+	tsrv := httptest.NewServer(handler)
+	defer tsrv.Close()
+	c := client.NewClient(tsrv.URL+"/mcp", core.ClientInfo{Name: "cursorless-wh", Version: "1.0"})
+	require.NoError(t, c.Connect())
+
+	raw, err := c.Call("events/subscribe", map[string]any{
+		"id":       "wh-typing",
+		"name":     "discord.typing",
+		"delivery": map[string]any{"mode": "webhook", "url": callbackSrv.URL},
+	})
+	require.NoError(t, err)
+	var resp struct {
+		Cursor *string `json:"cursor"`
+		Secret string  `json:"secret"`
+	}
+	require.NoError(t, json.Unmarshal(raw.Raw, &resp))
+	assert.Nil(t, resp.Cursor, "subscribe response cursor must be null for cursorless source")
+	mu.Lock()
+	assignedSecret = resp.Secret
+	mu.Unlock()
+	_ = assignedSecret
+
+	require.NoError(t, yieldTyping(newDiscordTypingEvent("g", "c", "alice", time.Now())))
+	time.Sleep(500 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.NotNil(t, deliveryBody, "webhook must deliver the typing event")
+	cursorVal, present := deliveryBody["cursor"]
+	require.True(t, present, "cursor field must be present on the wire")
+	assert.Nil(t, cursorVal, "cursorless event must wire as cursor:null")
+}
+
+// TestE2ECursorlessPollAlwaysEmpty verifies events/poll on a cursorless
+// source returns no events and a null cursor regardless of how the client
+// addressed it. Subscribers can't replay missed indicators by design.
+func TestE2ECursorlessPollAlwaysEmpty(t *testing.T) {
+	srv, _, yieldTyping, _ := buildTestStackWithTyping()
+	c, _ := connectClient(t, srv)
+
+	for i := 0; i < 3; i++ {
+		require.NoError(t, yieldTyping(newDiscordTypingEvent("g", "c", "alice", time.Now())))
+	}
+
+	result, err := c.Call("events/poll", map[string]any{
+		"subscriptions": []map[string]any{
+			{"id": "p", "name": "discord.typing", "cursor": "0"},
+		},
+	})
+	require.NoError(t, err)
+
+	var resp struct {
+		Results []struct {
+			Events []events.Event `json:"events"`
+			Cursor *string        `json:"cursor"`
+		} `json:"results"`
+	}
+	require.NoError(t, json.Unmarshal(result.Raw, &resp))
+	require.Len(t, resp.Results, 1)
+	assert.Empty(t, resp.Results[0].Events)
+	assert.Nil(t, resp.Results[0].Cursor, "poll on cursorless source must return cursor:null")
+}
+
+// TestE2ESubscribeCursorNullOnCursoredSourceReturnsLatest verifies the
+// "from now" subscribe semantic on a cursored source: passing cursor:null
+// makes the server stamp the response with the source's current head, so
+// the client polls forward without replaying historical events.
+func TestE2ESubscribeCursorNullOnCursoredSourceReturnsLatest(t *testing.T) {
+	srv, source, yield, _ := buildTestStack()
+	c, _ := connectClient(t, srv)
+
+	require.NoError(t, yield(newDiscordEvent("g", "c", "a", "first", time.Now())))
+	require.NoError(t, yield(newDiscordEvent("g", "c", "b", "second", time.Now())))
+	expected := source.Latest()
+	require.NotEmpty(t, expected, "precondition: source has a head cursor")
+
+	raw, err := c.Call("events/subscribe", map[string]any{
+		"id":       "wh-fromnow",
+		"name":     "discord.message",
+		"delivery": map[string]any{"mode": "webhook", "url": "http://localhost:1/sink"},
+		// cursor field intentionally omitted → JSON null on parse
+	})
+	require.NoError(t, err)
+	var resp struct {
+		Cursor *string `json:"cursor"`
+	}
+	require.NoError(t, json.Unmarshal(raw.Raw, &resp))
+	require.NotNil(t, resp.Cursor, "cursored source must return a real cursor for cursor:null subscribe")
+	assert.Equal(t, expected, *resp.Cursor, "subscribe response cursor must equal source.Latest()")
+}
+
+// TestE2EPollMultiSubRejected verifies the wire-level guarantee that
+// events/poll no longer accepts multiple subscriptions in one request.
+// Single-sub callers still work; multi-sub callers get a clear error.
+func TestE2EPollMultiSubRejected(t *testing.T) {
+	srv, _, _, _ := buildTestStack()
+	c, _ := connectClient(t, srv)
+
+	_, err := c.Call("events/poll", map[string]any{
+		"subscriptions": []map[string]any{
+			{"id": "a", "name": "discord.message", "cursor": "0"},
+			{"id": "b", "name": "discord.typing", "cursor": "0"},
+		},
+	})
+	require.Error(t, err, "multi-subscription events/poll must be rejected")
+	assert.Contains(t, err.Error(), "exactly one subscription", "error message must point at the spec change")
 }
 
 // TestE2EResourceByCursor verifies the per-message resource template resolves

--- a/experimental/discord-events/events.go
+++ b/experimental/discord-events/events.go
@@ -15,3 +15,16 @@ func newDiscordSource() (*events.YieldingSource[DiscordEventData], func(DiscordE
 		Delivery:    []string{"push", "poll", "webhook"},
 	}, events.WithMaxSize(1000))
 }
+
+// newDiscordTypingSource constructs the cursorless YieldingSource for
+// discord.typing events. Typing indicators are ephemeral — the source skips
+// buffering and events emit with `cursor: null` on the wire. Push and webhook
+// delivery still work; poll always returns empty (subscribers can't replay
+// missed indicators, which matches the semantics of the underlying state).
+func newDiscordTypingSource() (*events.YieldingSource[DiscordTypingData], func(DiscordTypingData) error) {
+	return events.NewYieldingSource[DiscordTypingData](events.EventDef{
+		Name:        "discord.typing",
+		Description: "Fires when a user starts typing in a Discord channel",
+		Delivery:    []string{"push", "webhook"},
+	}, events.WithoutCursors())
+}

--- a/experimental/discord-events/main.go
+++ b/experimental/discord-events/main.go
@@ -13,6 +13,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"flag"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -69,6 +70,7 @@ func main() {
 
 	webhooks := events.NewWebhookRegistry(whOpts...)
 	source, yield := newDiscordSource()
+	typingSource, yieldTyping := newDiscordTypingSource()
 
 	var dg *discordgo.Session
 	if *token != "" {
@@ -110,7 +112,7 @@ func main() {
 	registerTools(srv, dg)
 
 	events.Register(events.Config{
-		Sources:  []events.EventSource{source},
+		Sources:  []events.EventSource{source, typingSource},
 		Webhooks: webhooks,
 		Server:   srv,
 	})
@@ -122,24 +124,55 @@ func main() {
 		server.WithEventStore(gohttp.NewMemoryEventStore(eventStoreCap)),
 	))
 
+	// One endpoint, dispatch on ?event=<name>. Default is discord.message
+	// for backwards compatibility with the older inject script. Body shape
+	// varies per event — see the per-event branches below.
 	mux.HandleFunc("POST /inject", func(w http.ResponseWriter, r *http.Request) {
-		var msg struct {
-			GuildID   string `json:"guild_id"`
-			ChannelID string `json:"channel_id"`
-			Sender    string `json:"sender"`
-			Text      string `json:"text"`
+		eventName := r.URL.Query().Get("event")
+		if eventName == "" {
+			eventName = "discord.message"
 		}
-		if err := json.NewDecoder(r.Body).Decode(&msg); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
+
+		switch eventName {
+		case "discord.message":
+			var msg struct {
+				GuildID   string `json:"guild_id"`
+				ChannelID string `json:"channel_id"`
+				Sender    string `json:"sender"`
+				Text      string `json:"text"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&msg); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			if msg.Sender == "" {
+				msg.Sender = "injected"
+			}
+			_ = yield(newDiscordEvent(msg.GuildID, msg.ChannelID, msg.Sender, msg.Text, time.Now()))
+			srv.NotifyResourceUpdated("discord://messages/recent")
+
+		case "discord.typing":
+			var msg struct {
+				GuildID   string `json:"guild_id"`
+				ChannelID string `json:"channel_id"`
+				User      string `json:"user"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&msg); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			if msg.User == "" {
+				msg.User = "injected-typing"
+			}
+			_ = yieldTyping(newDiscordTypingEvent(msg.GuildID, msg.ChannelID, msg.User, time.Now()))
+
+		default:
+			http.Error(w, fmt.Sprintf("unknown event %q (want discord.message or discord.typing)", eventName), http.StatusBadRequest)
 			return
 		}
-		if msg.Sender == "" {
-			msg.Sender = "injected"
-		}
-		_ = yield(newDiscordEvent(msg.GuildID, msg.ChannelID, msg.Sender, msg.Text, time.Now()))
-		srv.NotifyResourceUpdated("discord://messages/recent")
+
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{"status": "ok"})
+		json.NewEncoder(w).Encode(map[string]any{"status": "ok", "event": eventName})
 	})
 
 	log.Printf("[server] discord-events listening on %s (MCP at /mcp)", *addr)

--- a/experimental/ext/events/README.md
+++ b/experimental/ext/events/README.md
@@ -11,6 +11,21 @@ Two source styles, pick whichever matches who owns storage:
 | **`YieldingSource`** (recommended) | The source pushes events at you (bot callback, HTTP handler, channel reader) | Library — bounded ring, typed `Recent(n)` / `ByCursor(c)` accessors | Library wires it (`SetEmitHook` via `Register`) |
 | **`TypedSource`** | The source already owns its storage (DB, event log, external queue) | You — implement `Poll(cursor, limit)` | You — call `events.Emit` and `events.EmitToWebhooks` yourself |
 
+## Cursored vs cursorless sources
+
+Sources come in two flavors:
+
+| | Cursored (default) | Cursorless |
+|---|---|---|
+| Construction | `events.NewYieldingSource[Data](def)` | `events.NewYieldingSource[Data](def, events.WithoutCursors())` |
+| `Event.cursor` on the wire | string | `null` |
+| Internal buffer | yes (events retained for replay) | no (events emitted and forgotten) |
+| `events/poll` | returns events since the supplied cursor | always returns empty + `cursor: null` |
+| `events/subscribe` with `cursor: null` | resolves to source's current head ("from now") | stays null |
+| `EventDef.cursorless` advertised in `events/list` | `false` | `true` |
+
+Use cursorless for ephemeral state where replay carries no value (typing indicators, presence, current readings). Use cursored for messages, alerts, audit logs, etc.
+
 ## Quickstart — `YieldingSource`
 
 ```go
@@ -79,22 +94,27 @@ myDB.OnInsert = func(row Row) {
 
 | Method | Description |
 |--------|-------------|
-| `events/list` | Returns event definitions with auto-derived `payloadSchema` |
-| `events/poll` | Cursor-based polling, `hasMore` + `cursorGap` signals |
-| `events/subscribe` | Webhook registration with HMAC secret + TTL + `refreshBefore` |
-| `events/unsubscribe` | Webhook removal by `(url, id)` |
+| `events/list` | Returns event definitions with auto-derived `payloadSchema` and `cursorless` flag |
+| `events/poll` | Single-subscription polling (multi-subscription is rejected per upstream WG PR#1 line 185, comment `r3140480214`); `hasMore` + `cursorGap` signals |
+| `events/subscribe` | Webhook registration with HMAC secret + TTL + `refreshBefore`. `cursor: null` means "from now" — server resolves to source's current head |
+| `events/unsubscribe` | Webhook removal by `(url, id)` or `(url, secret)` |
 
 ## Key types
 
 ```go
-// Event is the wire-format envelope.
+// Event is the wire-format envelope. Cursor is a pointer so cursorless
+// sources serialize as `cursor: null`; HasCursor / CursorStr hide the
+// pointer at call sites that don't care.
 type Event struct {
     EventID   string          `json:"eventId"`
     Name      string          `json:"name"`
     Timestamp string          `json:"timestamp"`
     Data      json.RawMessage `json:"data"`
-    Cursor    string          `json:"cursor"`
+    Cursor    *string         `json:"cursor"`
 }
+
+func (e Event) HasCursor() bool   // true for cursored events
+func (e Event) CursorStr() string // "" for cursorless
 
 // EventSource — what TypedSource implements; YieldingSource also satisfies it.
 type EventSource interface {

--- a/experimental/ext/events/cursorless_test.go
+++ b/experimental/ext/events/cursorless_test.go
@@ -1,0 +1,140 @@
+package events
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEvent_NilCursorSerializesAsNull pins the wire shape: an Event with
+// nil Cursor must marshal to JSON with `"cursor": null`, NOT omitted.
+// Receivers that key on cursor presence depend on this distinction.
+func TestEvent_NilCursorSerializesAsNull(t *testing.T) {
+	e := Event{EventID: "evt_1", Name: "x", Timestamp: "t", Data: json.RawMessage(`{}`)}
+	raw, err := json.Marshal(e)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), `"cursor":null`,
+		"cursorless events must wire as cursor:null, not omit the field")
+}
+
+// TestEvent_NonNilCursorSerializesAsString pins the cursored wire shape.
+func TestEvent_NonNilCursorSerializesAsString(t *testing.T) {
+	c := "abc123"
+	e := Event{EventID: "evt_1", Name: "x", Timestamp: "t", Data: json.RawMessage(`{}`), Cursor: &c}
+	raw, err := json.Marshal(e)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), `"cursor":"abc123"`)
+}
+
+// TestEvent_HasCursorAndCursorStr exercises the helper accessors so internal
+// callers don't have to do `*event.Cursor` themselves and risk a nil deref.
+func TestEvent_HasCursorAndCursorStr(t *testing.T) {
+	none := Event{}
+	assert.False(t, none.HasCursor())
+	assert.Equal(t, "", none.CursorStr())
+
+	c := "abc"
+	with := Event{Cursor: &c}
+	assert.True(t, with.HasCursor())
+	assert.Equal(t, "abc", with.CursorStr())
+}
+
+// TestMakeEvent_EmptyCursorYieldsNil verifies the constructor's empty-string
+// → nil pointer convention. Source authors use empty string for "no cursor"
+// and the wire layer translates to null without a separate API.
+func TestMakeEvent_EmptyCursorYieldsNil(t *testing.T) {
+	e := MakeEvent[map[string]string]("name", "evt_1", "", testTime(), map[string]string{"k": "v"})
+	assert.False(t, e.HasCursor(), "empty cursor must produce nil pointer")
+	assert.Nil(t, e.Cursor)
+}
+
+// TestMakeEvent_NonEmptyCursorYieldsPointer verifies the cursored case.
+func TestMakeEvent_NonEmptyCursorYieldsPointer(t *testing.T) {
+	e := MakeEvent[map[string]string]("name", "evt_1", "abc", testTime(), map[string]string{"k": "v"})
+	require.True(t, e.HasCursor())
+	assert.Equal(t, "abc", e.CursorStr())
+}
+
+// TestYieldingSource_WithoutCursorsEmitsNilCursor verifies that yielded
+// events from a cursorless source carry a nil Cursor. This is the source
+// author-side API for ephemeral-state sources (typing, presence, etc.).
+func TestYieldingSource_WithoutCursorsEmitsNilCursor(t *testing.T) {
+	src, yield := NewYieldingSource[fakePayload](EventDef{Name: "fake"}, WithoutCursors())
+
+	var captured Event
+	src.SetEmitHook(func(e Event) { captured = e })
+
+	require.NoError(t, yield(fakePayload{Msg: "x"}))
+	assert.False(t, captured.HasCursor(),
+		"cursorless source must emit events with nil cursor")
+}
+
+// TestYieldingSource_WithoutCursorsDoesNotBuffer verifies the source skips
+// buffering — Len, Recent, ByCursor all show no retained state. Saves
+// memory and signals to operators that replay isn't supported.
+func TestYieldingSource_WithoutCursorsDoesNotBuffer(t *testing.T) {
+	src, yield := NewYieldingSource[fakePayload](EventDef{Name: "fake"}, WithoutCursors())
+	require.NoError(t, yield(fakePayload{Msg: "a"}))
+	require.NoError(t, yield(fakePayload{Msg: "b"}))
+
+	assert.Equal(t, 0, src.Len(), "cursorless source must not buffer")
+	assert.Empty(t, src.Recent(50), "Recent on cursorless source must be empty")
+	_, ok := src.ByCursor("anything")
+	assert.False(t, ok)
+}
+
+// TestYieldingSource_WithoutCursorsPollIsAlwaysEmpty verifies Poll on a
+// cursorless source returns no events regardless of the requested cursor —
+// caller knows there's nothing to replay.
+func TestYieldingSource_WithoutCursorsPollIsAlwaysEmpty(t *testing.T) {
+	src, yield := NewYieldingSource[fakePayload](EventDef{Name: "fake"}, WithoutCursors())
+	for i := 0; i < 3; i++ {
+		require.NoError(t, yield(fakePayload{Msg: "x"}))
+	}
+
+	pr := src.Poll("", 100)
+	assert.Empty(t, pr.Events)
+	assert.Equal(t, "", pr.Cursor)
+}
+
+// TestYieldingSource_WithoutCursorsLatestIsEmpty verifies Latest returns ""
+// for cursorless sources. The poll handler keys on this to decide whether
+// `cursor: null` should resolve to a real value or stay null.
+func TestYieldingSource_WithoutCursorsLatestIsEmpty(t *testing.T) {
+	src, yield := NewYieldingSource[fakePayload](EventDef{Name: "fake"}, WithoutCursors())
+	require.NoError(t, yield(fakePayload{Msg: "x"}))
+	assert.Equal(t, "", src.Latest())
+}
+
+// TestYieldingSource_DefIsCursorless verifies the cursorless flag flows
+// onto the EventDef advertised via events/list. Clients use this to decide
+// whether to bother passing a real cursor on subscribe / poll.
+func TestYieldingSource_DefIsCursorless(t *testing.T) {
+	cursored, _ := NewYieldingSource[fakePayload](EventDef{Name: "a"})
+	cursorless, _ := NewYieldingSource[fakePayload](EventDef{Name: "b"}, WithoutCursors())
+
+	assert.False(t, cursored.Def().Cursorless)
+	assert.True(t, cursorless.Def().Cursorless)
+}
+
+// TestYieldingSource_LatestReturnsHeadCursor verifies cursored sources
+// expose the head cursor for `cursor: null` subscribe resolution. The
+// subscribe handler stamps this onto the response so the client polls
+// from the right point onward.
+func TestYieldingSource_LatestReturnsHeadCursor(t *testing.T) {
+	src, yield := NewYieldingSource[fakePayload](EventDef{Name: "fake"})
+	assert.Equal(t, "", src.Latest(), "empty source has no head")
+	require.NoError(t, yield(fakePayload{Msg: "a"}))
+	require.NoError(t, yield(fakePayload{Msg: "b"}))
+	assert.NotEmpty(t, src.Latest())
+	assert.Equal(t, "2", src.Latest(), "memory store assigns monotonic int cursors starting at 1")
+}
+
+// testTime returns a fixed timestamp for deterministic tests.
+func testTime() (t time.Time) {
+	t, _ = time.Parse(time.RFC3339, "2026-04-30T00:00:00Z")
+	return
+}

--- a/experimental/ext/events/events.go
+++ b/experimental/ext/events/events.go
@@ -23,23 +23,54 @@ import (
 // Event is the wire-format event envelope delivered via all three modes.
 // The Data field is typed per-source via generics at construction time
 // (see MakeEvent), but serialized as json.RawMessage on the wire.
+//
+// Cursor is a pointer so cursorless sources can emit `cursor: null` per
+// upstream WG PR#1 line 392. Use HasCursor / CursorStr to access it without
+// dealing with the pointer directly.
 type Event struct {
 	EventID   string          `json:"eventId"`
 	Name      string          `json:"name"`
 	Timestamp string          `json:"timestamp"`
 	Data      json.RawMessage `json:"data"`
-	Cursor    string          `json:"cursor"`
+	Cursor    *string         `json:"cursor"`
+}
+
+// HasCursor reports whether the event carries a cursor (cursored source) or
+// is cursor-less (best-effort source). Wire shape is `cursor: <string>` vs
+// `cursor: null`.
+func (e Event) HasCursor() bool { return e.Cursor != nil }
+
+// CursorStr returns the cursor string for cursored events, or "" when the
+// event is cursorless. Convenience wrapper to avoid `*event.Cursor` at call
+// sites that don't care about the cursored / cursorless distinction.
+func (e Event) CursorStr() string {
+	if e.Cursor == nil {
+		return ""
+	}
+	return *e.Cursor
 }
 
 // EventDef describes an event type advertised via events/list.
+//
+// Cursorless declares a source that does not support cursor-based replay.
+// The library still serves events/poll for it (always returning empty +
+// `cursor: null`), and push/webhook delivery still works — events arrive
+// with `cursor: null`. Use this for ephemeral-state sources (typing
+// indicators, presence, current-readings) where replay carries no value.
 type EventDef struct {
 	Name          string   `json:"name"`
 	Description   string   `json:"description"`
 	Delivery      []string `json:"delivery"`
 	PayloadSchema any      `json:"payloadSchema,omitempty"`
+	Cursorless    bool     `json:"cursorless,omitempty"`
 }
 
 // PollResult holds the result of a cursor-based poll from an event source.
+//
+// Cursor is the string a client should pass on its next poll. For cursored
+// sources this is typically the cursor of the last delivered event (or
+// Latest() when nothing was delivered). For cursorless sources Cursor is
+// always "" and the wire layer translates it to `cursor: null`.
 type PollResult struct {
 	Events []Event
 	Cursor string
@@ -59,8 +90,9 @@ type PollResult struct {
 // calls these methods to serve events/list and events/poll requests.
 //
 // Cursors are opaque strings per the spec — the source defines their format.
-// The spec says null cursor means "start from now" — the source should return
-// no events and a fresh cursor for subsequent polls.
+// Latest() supports the `cursor: null` subscribe / poll semantic ("from now"):
+// the library asks the source for its current head and returns it as the
+// resume cursor. Cursorless sources should return "".
 type EventSource interface {
 	// Def returns the event definition for events/list.
 	Def() EventDef
@@ -68,10 +100,17 @@ type EventSource interface {
 	// Poll returns events since the given cursor, up to limit.
 	// An empty cursor means "start from now" (return empty + fresh cursor).
 	Poll(cursor string, limit int) PollResult
+
+	// Latest returns the cursor of the most recent event the source knows
+	// about. Used to resolve `cursor: null` subscribe requests to a concrete
+	// resume point. Cursorless sources should return "".
+	Latest() string
 }
 
 // TypedSource creates an EventSource with auto-derived payloadSchema from the
-// Data type parameter, matching the TypedTool ergonomic pattern.
+// Data type parameter, matching the TypedTool ergonomic pattern. Pass `latest`
+// returning the head cursor of your store; return "" if your source does not
+// support cursor-based replay.
 //
 // Example:
 //
@@ -79,35 +118,46 @@ type EventSource interface {
 //	    Name:        "telegram.message",
 //	    Description: "Fires when a message is received",
 //	    Delivery:    []string{"push", "poll", "webhook"},
-//	}, func(cursor string, limit int) events.PollResult {
-//	    // ... cursor-based retrieval from your store
-//	})
-func TypedSource[Data any](def EventDef, poll func(cursor string, limit int) PollResult) EventSource {
+//	},
+//	    func(cursor string, limit int) events.PollResult { /* read store */ },
+//	    func() string { return store.HeadCursor() },
+//	)
+func TypedSource[Data any](def EventDef, poll func(cursor string, limit int) PollResult, latest func() string) EventSource {
 	if def.PayloadSchema == nil {
 		def.PayloadSchema = core.GenerateSchema[Data]()
 	}
-	return &typedSource{def: def, poll: poll}
+	if latest == nil {
+		latest = func() string { return "" }
+	}
+	return &typedSource{def: def, poll: poll, latest: latest}
 }
 
 type typedSource struct {
-	def  EventDef
-	poll func(cursor string, limit int) PollResult
+	def    EventDef
+	poll   func(cursor string, limit int) PollResult
+	latest func() string
 }
 
 func (s *typedSource) Def() EventDef                            { return s.def }
 func (s *typedSource) Poll(cursor string, limit int) PollResult { return s.poll(cursor, limit) }
+func (s *typedSource) Latest() string                           { return s.latest() }
 
 // MakeEvent creates an Event envelope with typed data. The data is serialized
-// to JSON for the wire format.
+// to JSON for the wire format. An empty cursor maps to nil (wire `cursor: null`)
+// — convenient for cursorless sources without forcing every caller to deal
+// with `*string`.
 func MakeEvent[Data any](name string, eventID string, cursor string, ts time.Time, data Data) Event {
 	raw, _ := json.Marshal(data)
-	return Event{
+	e := Event{
 		EventID:   eventID,
 		Name:      name,
 		Timestamp: ts.Format(time.RFC3339),
 		Data:      raw,
-		Cursor:    cursor,
 	}
+	if cursor != "" {
+		e.Cursor = &cursor
+	}
+	return e
 }
 
 // Config holds the options for registering event sources on an MCP server.
@@ -168,10 +218,14 @@ func EmitToWebhooks(webhooks *WebhookRegistry, event Event) {
 // nextPollSeconds is per-subscription per Peter's spec — the server can
 // recommend different poll intervals for different event types. Client SDKs
 // should coalesce by taking the minimum across subscriptions.
+//
+// Cursor is a pointer so cursorless sources serialize as `cursor: null`.
+// Note: there is intentionally no `omitempty` — cursored sources with empty
+// cursor still emit `cursor: ""`, only nil maps to JSON null.
 type pollResultWire struct {
 	ID              string  `json:"id"`
 	Events          []Event `json:"events,omitempty"`
-	Cursor          string  `json:"cursor"`
+	Cursor          *string `json:"cursor"`
 	HasMore         bool    `json:"hasMore"`
 	CursorGap       bool    `json:"cursorGap,omitempty"`
 	NextPollSeconds int     `json:"nextPollSeconds,omitempty"`
@@ -204,49 +258,71 @@ func registerPoll(srv *server.Server, sourceMap map[string]EventSource) {
 		if err := json.Unmarshal(params, &req); err != nil {
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, err.Error())
 		}
+		// events/poll is single-subscription per upstream WG PR#1 line 185
+		// (comment r3140480214). Reject batched requests with a clear
+		// pointer to the spec change.
+		if len(req.Subscriptions) > 1 {
+			return core.NewErrorResponse(id, core.ErrCodeInvalidParams,
+				"events/poll: pass exactly one subscription per call (multi-sub support has been removed)")
+		}
+		if len(req.Subscriptions) == 0 {
+			return core.NewErrorResponse(id, core.ErrCodeInvalidParams,
+				"events/poll: subscriptions[] must contain exactly one entry")
+		}
 		if req.MaxEvents <= 0 {
 			req.MaxEvents = 50
 		}
 
-		results := make([]pollResultWire, 0, len(req.Subscriptions))
-		for _, sub := range req.Subscriptions {
-			source, ok := sourceMap[sub.Name]
-			if !ok {
-				results = append(results, pollResultWire{
-					ID: sub.ID,
-					Error: &struct {
-						Code    int    `json:"code"`
-						Message string `json:"message"`
-					}{Code: -32001, Message: "EventNotFound"},
-				})
-				continue
-			}
-
-			cursor := ""
-			if sub.Cursor != nil {
-				cursor = *sub.Cursor
-			}
-
-			pr := source.Poll(cursor, req.MaxEvents+1)
-			hasMore := len(pr.Events) > req.MaxEvents
-			events := pr.Events
-			resultCursor := pr.Cursor
-			if hasMore {
-				events = events[:req.MaxEvents]
-				resultCursor = events[len(events)-1].Cursor
-			}
-
-			results = append(results, pollResultWire{
-				ID:              sub.ID,
-				Events:          events,
-				Cursor:          resultCursor,
-				HasMore:         hasMore,
-				CursorGap:       pr.CursorGap,
-				NextPollSeconds: 5,
-			})
+		sub := req.Subscriptions[0]
+		source, ok := sourceMap[sub.Name]
+		if !ok {
+			return core.NewResponse(id, map[string]any{"results": []pollResultWire{{
+				ID: sub.ID,
+				Error: &struct {
+					Code    int    `json:"code"`
+					Message string `json:"message"`
+				}{Code: -32001, Message: "EventNotFound"},
+			}}})
 		}
 
-		return core.NewResponse(id, map[string]any{"results": results})
+		cursorless := source.Def().Cursorless
+
+		// Resolve `cursor: null` to the source's current head ("from now").
+		// Cursored sources return Latest(); cursorless sources return "" and
+		// the wire layer below translates that to JSON null.
+		cursor := ""
+		if sub.Cursor != nil {
+			cursor = *sub.Cursor
+		} else if !cursorless {
+			cursor = source.Latest()
+		}
+
+		pr := source.Poll(cursor, req.MaxEvents+1)
+		hasMore := len(pr.Events) > req.MaxEvents
+		events := pr.Events
+		resultCursor := pr.Cursor
+		if hasMore {
+			events = events[:req.MaxEvents]
+			resultCursor = events[len(events)-1].CursorStr()
+		}
+
+		// For cursorless sources, the wire `cursor` is null regardless of
+		// what the source returned. For cursored sources, marshal the
+		// resolved string into a *string so it serializes as a JSON string.
+		var wireCursor *string
+		if !cursorless {
+			c := resultCursor
+			wireCursor = &c
+		}
+
+		return core.NewResponse(id, map[string]any{"results": []pollResultWire{{
+			ID:              sub.ID,
+			Events:          events,
+			Cursor:          wireCursor,
+			HasMore:         hasMore,
+			CursorGap:       pr.CursorGap,
+			NextPollSeconds: 5,
+		}}})
 	})
 }
 
@@ -287,15 +363,26 @@ func registerSubscribe(srv *server.Server, sourceMap map[string]EventSource, web
 
 		expiresAt := webhooks.Register(resolvedID, req.Delivery.URL, secret)
 
-		cursorStr := "0"
-		if req.Cursor != nil {
-			cursorStr = *req.Cursor
+		// Resolve `cursor: null` to the source's current head ("from now")
+		// for cursored sources. Cursorless sources always serialize as null.
+		// An explicit non-null client cursor passes through unchanged.
+		source := sourceMap[req.Name] // already validated above
+		cursorless := source.Def().Cursorless
+		var wireCursor *string
+		if cursorless {
+			wireCursor = nil
+		} else if req.Cursor != nil {
+			c := *req.Cursor
+			wireCursor = &c
+		} else {
+			c := source.Latest()
+			wireCursor = &c
 		}
 
 		return core.NewResponse(id, map[string]any{
 			"id":            resolvedID,
 			"secret":        secret,
-			"cursor":        cursorStr,
+			"cursor":        wireCursor,
 			"refreshBefore": expiresAt.Format(time.RFC3339),
 		})
 	})

--- a/experimental/ext/events/events_client.py
+++ b/experimental/ext/events/events_client.py
@@ -37,6 +37,15 @@ from urllib.request import Request, urlopen
 # MCP session helpers
 # ═══════════════════════════════════════════════════════════════════
 
+def _fmt_cursor(c) -> str:
+    """Render a cursor for human-readable logging. Cursored sources emit a
+    string; cursorless sources emit JSON null which deserializes to Python
+    None — render that as a visible token rather than the literal "None"."""
+    if c is None:
+        return "(none)"
+    return c
+
+
 class MCPSession:
     """Thin wrapper around an MCP Streamable HTTP session."""
 
@@ -170,7 +179,7 @@ def cmd_list(session: MCPSession, args):
         if results:
             r = results[0]
             n = len(r.get("events", []))
-            print(f"  {n} event(s), cursor={r.get('cursor')}, hasMore={r.get('hasMore')}")
+            print(f"  {n} event(s), cursor={_fmt_cursor(r.get('cursor'))}, hasMore={r.get('hasMore')}")
             for ev in r.get("events", [])[:3]:
                 print(f"    {ev.get('eventId')}: {json.dumps(ev.get('data', {}), separators=(',', ':'))[:120]}")
         print()
@@ -215,7 +224,7 @@ def cmd_listen(session: MCPSession, args):
             print(f"  id:      {p.get('eventId', '')}")
             print(f"  name:    {p.get('name', '')}")
             print(f"  time:    {p.get('timestamp', '')}")
-            print(f"  cursor:  {p.get('cursor', '')}")
+            print(f"  cursor:  {_fmt_cursor(p.get('cursor'))}")
             data = p.get("data")
             if data:
                 print(json.dumps(data, indent=2))
@@ -409,7 +418,7 @@ def _make_webhook_handler(secret_holder):
                 print(f"  id:      {event.get('eventId', '')}")
                 print(f"  name:    {event.get('name', '')}")
                 print(f"  time:    {event.get('timestamp', '')}")
-                print(f"  cursor:  {event.get('cursor', '')}")
+                print(f"  cursor:  {_fmt_cursor(event.get('cursor'))}")
                 data = event.get("data")
                 if data:
                     print(json.dumps(data, indent=2))
@@ -520,7 +529,7 @@ def cmd_poll(session: MCPSession, args):
                         print(f"  id:      {ev.get('eventId', '')}")
                         print(f"  name:    {ev.get('name', '')}")
                         print(f"  time:    {ev.get('timestamp', '')}")
-                        print(f"  cursor:  {ev.get('cursor', '')}")
+                        print(f"  cursor:  {_fmt_cursor(ev.get('cursor'))}")
                         data = ev.get("data")
                         if data:
                             print(json.dumps(data, indent=2))

--- a/experimental/ext/events/yield.go
+++ b/experimental/ext/events/yield.go
@@ -17,17 +17,33 @@ const defaultYieldingMaxSize = 1000
 type YieldingOption func(*yieldingConfig)
 
 type yieldingConfig struct {
-	maxSize int
+	maxSize    int
+	cursorless bool
 }
 
 // WithMaxSize caps the YieldingSource's internal ring buffer. Older events
 // are evicted FIFO once the cap is reached. Default is 1000. Pass <=0 to
-// keep the default.
+// keep the default. Has no effect when WithoutCursors is set (cursorless
+// sources do not buffer events).
 func WithMaxSize(n int) YieldingOption {
 	return func(c *yieldingConfig) {
 		if n > 0 {
 			c.maxSize = n
 		}
+	}
+}
+
+// WithoutCursors marks the source as cursorless: events are emitted with
+// `cursor: null` on the wire, the source does not buffer events, and
+// events/poll always returns empty. Use for ephemeral-state sources where
+// replay carries no value (typing indicators, presence, current readings).
+//
+// Push and webhook fanout still work exactly the same — the difference is
+// that subscribers can't replay missed events. The EventDef advertised by
+// events/list carries `cursorless: true` so clients can plan accordingly.
+func WithoutCursors() YieldingOption {
+	return func(c *yieldingConfig) {
+		c.cursorless = true
 	}
 }
 
@@ -68,8 +84,12 @@ func NewYieldingSource[Data any](def EventDef, opts ...YieldingOption) (*Yieldin
 	if def.PayloadSchema == nil {
 		def.PayloadSchema = core.GenerateSchema[Data]()
 	}
+	// Reflect cursorlessness onto the EventDef so events/list advertises it.
+	if cfg.cursorless {
+		def.Cursorless = true
+	}
 
-	s := &YieldingSource[Data]{def: def, maxSize: cfg.maxSize}
+	s := &YieldingSource[Data]{def: def, maxSize: cfg.maxSize, cursorless: cfg.cursorless}
 	yield := func(data Data) error {
 		return s.yield(data)
 	}
@@ -95,10 +115,15 @@ type yieldedEntry[Data any] struct {
 // YieldingSource is a push-style EventSource. It owns an in-memory ring
 // buffer of typed payloads + wire Events; events/poll reads through the same
 // buffer. Construct via NewYieldingSource.
+//
+// When constructed with WithoutCursors, the source skips buffering entirely.
+// Push and webhook fanout still fire (events emitted with `cursor: null`),
+// but Poll always returns empty and Recent / ByCursor return zero results.
 type YieldingSource[Data any] struct {
-	def     EventDef
-	maxSize int
-	seq     atomic.Int64
+	def        EventDef
+	maxSize    int
+	cursorless bool
+	seq        atomic.Int64
 
 	mu       sync.RWMutex
 	entries  []yieldedEntry[Data]
@@ -111,7 +136,14 @@ func (s *YieldingSource[Data]) Def() EventDef { return s.def }
 // than the requested cursor, up to limit. The Cursor field of PollResult is
 // the cursor of the last delivered event (or the head if none) so the
 // client's cursor advances even on empty polls.
+//
+// Cursorless sources always return empty events + empty cursor; the wire
+// layer translates the empty cursor to JSON null.
 func (s *YieldingSource[Data]) Poll(cursor string, limit int) PollResult {
+	if s.cursorless {
+		return PollResult{}
+	}
+
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -119,7 +151,7 @@ func (s *YieldingSource[Data]) Poll(cursor string, limit int) PollResult {
 
 	gap := false
 	if c > 0 && len(s.entries) > 0 {
-		oldest, _ := strconv.ParseInt(s.entries[0].event.Cursor, 10, 64)
+		oldest, _ := strconv.ParseInt(s.entries[0].event.CursorStr(), 10, 64)
 		if c < oldest {
 			gap = true
 		}
@@ -127,7 +159,7 @@ func (s *YieldingSource[Data]) Poll(cursor string, limit int) PollResult {
 
 	out := make([]Event, 0, limit)
 	for _, e := range s.entries {
-		ec, _ := strconv.ParseInt(e.event.Cursor, 10, 64)
+		ec, _ := strconv.ParseInt(e.event.CursorStr(), 10, 64)
 		if ec > c {
 			out = append(out, e.event)
 			if len(out) >= limit {
@@ -138,11 +170,25 @@ func (s *YieldingSource[Data]) Poll(cursor string, limit int) PollResult {
 
 	next := cursor
 	if len(out) > 0 {
-		next = out[len(out)-1].Cursor
+		next = out[len(out)-1].CursorStr()
 	} else if len(s.entries) > 0 {
-		next = s.entries[len(s.entries)-1].event.Cursor
+		next = s.entries[len(s.entries)-1].event.CursorStr()
 	}
 	return PollResult{Events: out, Cursor: next, CursorGap: gap}
+}
+
+// Latest implements EventSource. Returns the cursor of the most recently
+// yielded event, or "" when the source is empty or cursorless.
+func (s *YieldingSource[Data]) Latest() string {
+	if s.cursorless {
+		return ""
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if len(s.entries) == 0 {
+		return ""
+	}
+	return s.entries[len(s.entries)-1].event.CursorStr()
 }
 
 // Recent returns up to n most-recently-yielded payloads, oldest-first within
@@ -166,12 +212,12 @@ func (s *YieldingSource[Data]) Recent(n int) []Data {
 
 // ByCursor returns the typed payload for the event with the given cursor.
 // Returns (zero, false) if the cursor is not present in the buffer (either
-// never existed or was evicted).
+// never existed, was evicted, or the source is cursorless).
 func (s *YieldingSource[Data]) ByCursor(cursor string) (Data, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	for _, e := range s.entries {
-		if e.event.Cursor == cursor {
+		if e.event.CursorStr() == cursor {
 			return e.data, true
 		}
 	}
@@ -202,19 +248,25 @@ func (s *YieldingSource[Data]) yield(data Data) error {
 	}
 
 	seq := s.seq.Add(1)
-	cursor := strconv.FormatInt(seq, 10)
 	event := Event{
 		EventID:   fmt.Sprintf("evt_%d", seq),
 		Name:      s.def.Name,
 		Timestamp: now.Format(time.RFC3339),
 		Data:      raw,
-		Cursor:    cursor,
+	}
+	if !s.cursorless {
+		cursor := strconv.FormatInt(seq, 10)
+		event.Cursor = &cursor
 	}
 
 	s.mu.Lock()
-	s.entries = append(s.entries, yieldedEntry[Data]{data: data, event: event})
-	if len(s.entries) > s.maxSize {
-		s.entries = s.entries[len(s.entries)-s.maxSize:]
+	if !s.cursorless {
+		// Only buffer when cursored — cursorless sources don't support
+		// poll-side replay, so retaining events would just waste memory.
+		s.entries = append(s.entries, yieldedEntry[Data]{data: data, event: event})
+		if len(s.entries) > s.maxSize {
+			s.entries = s.entries[len(s.entries)-s.maxSize:]
+		}
 	}
 	hook := s.emitHook
 	s.mu.Unlock()

--- a/experimental/ext/events/yield_test.go
+++ b/experimental/ext/events/yield_test.go
@@ -57,7 +57,7 @@ func TestYieldingSource_YieldAppearsOnPoll(t *testing.T) {
 func TestYieldingSource_PollHonorsCursor(t *testing.T) {
 	src, yield := NewYieldingSource[fakePayload](EventDef{Name: "fake"})
 	require.NoError(t, yield(fakePayload{Msg: "a"}))
-	c1 := src.Poll("", 10).Events[0].Cursor
+	c1 := src.Poll("", 10).Events[0].CursorStr()
 
 	require.NoError(t, yield(fakePayload{Msg: "b"}))
 	require.NoError(t, yield(fakePayload{Msg: "c"}))
@@ -85,7 +85,7 @@ func TestYieldingSource_PollRespectsLimit(t *testing.T) {
 func TestYieldingSource_EvictionAndCursorGap(t *testing.T) {
 	src, yield := NewYieldingSource[fakePayload](EventDef{Name: "fake"}, WithMaxSize(3))
 	require.NoError(t, yield(fakePayload{Msg: "1"}))
-	c1 := src.Poll("", 10).Events[0].Cursor
+	c1 := src.Poll("", 10).Events[0].CursorStr()
 	require.NoError(t, yield(fakePayload{Msg: "2"}))
 	require.NoError(t, yield(fakePayload{Msg: "3"}))
 	require.NoError(t, yield(fakePayload{Msg: "4"})) // evicts c1
@@ -197,7 +197,7 @@ func TestYieldingSource_ByCursorFindsTypedPayload(t *testing.T) {
 	require.NoError(t, yield(fakePayload{Msg: "second"}))
 
 	first := src.Poll("", 10).Events[0]
-	got, ok := src.ByCursor(first.Cursor)
+	got, ok := src.ByCursor(first.CursorStr())
 	assert.True(t, ok)
 	assert.Equal(t, "first", got.Msg)
 }

--- a/experimental/telegram-events/Makefile
+++ b/experimental/telegram-events/Makefile
@@ -32,6 +32,11 @@ inject:
 	  -H 'Content-Type: application/json' \
 	  -d '{"chat_id": $(or $(CHAT_ID),100), "sender": "$(or $(SENDER),test-user)", "text": "$(or $(TEXT),hello from make inject)"}' | jq .
 
+inject-typing:
+	@curl -s -X POST '$(ADDR)/inject?event=telegram.typing' \
+	  -H 'Content-Type: application/json' \
+	  -d '{"chat_id": $(or $(CHAT_ID),100), "user": "$(or $(USER_NAME),test-user)"}' | jq .
+
 list:
 	@$(EVENTS_CLIENT) list
 
@@ -44,4 +49,4 @@ webhook:
 poll:
 	@$(EVENTS_CLIENT) poll --interval $(or $(INTERVAL),5)
 
-.PHONY: run test test-race inject list listen webhook poll
+.PHONY: run test test-race inject inject-typing list listen webhook poll

--- a/experimental/telegram-events/README.md
+++ b/experimental/telegram-events/README.md
@@ -128,7 +128,8 @@ Telegram Bot (long-poll)  ──or──  POST /inject
 |--------|-------------|
 | `make run` | Start server (with bot if `TELEGRAM_BOT_TOKEN` set) |
 | `make test` | Go tests |
-| `make inject TEXT="..."` | Inject a message (optional: `SENDER=`, `CHAT_ID=`) |
+| `make inject TEXT="..."` | Inject a message event (optional: `SENDER=`, `CHAT_ID=`) |
+| `make inject-typing` | Inject a cursorless typing event (optional: `USER_NAME=`, `CHAT_ID=`) |
 | `make list` | Show server capabilities: tools, resources, events, sample poll |
 | `make listen` | SSE push listener — print events in real time |
 | `make webhook` | Webhook receiver — subscribe + auto-refresh, receive HMAC-signed POSTs |

--- a/experimental/telegram-events/e2e_test.go
+++ b/experimental/telegram-events/e2e_test.go
@@ -22,9 +22,13 @@ import (
 // pair so tests can publish events directly without a Telegram session.
 // Optional WebhookOptions configure the registry; defaults match the
 // production demo (Server + MCPHeaders).
+//
+// The cursorless typing source is registered alongside telegram.message so
+// cursor-shape tests can exercise both modes against the same server.
 func buildTestStack(whOpts ...events.WebhookOption) (*server.Server, *events.YieldingSource[TelegramEventData], func(TelegramEventData) error, *events.WebhookRegistry) {
 	webhooks := events.NewWebhookRegistry(whOpts...)
 	source, yield := newTelegramSource()
+	typingSource, _ := newTelegramTypingSource()
 
 	srv := server.NewServer(
 		core.ServerInfo{Name: "telegram-events-e2e", Version: "0.1.0"},
@@ -33,12 +37,35 @@ func buildTestStack(whOpts ...events.WebhookOption) (*server.Server, *events.Yie
 	registerResources(srv, source)
 	(&ToolDelivery{Bot: nil}).Register(srv)
 	events.Register(events.Config{
-		Sources:  []events.EventSource{source},
+		Sources:  []events.EventSource{source, typingSource},
 		Webhooks: webhooks,
 		Server:   srv,
 	})
 
 	return srv, source, yield, webhooks
+}
+
+// buildTestStackWithTyping is a parallel constructor that returns the typing
+// yield closure alongside the message yield. Used by the cursorless e2e
+// tests so they can publish typing events without spinning up a Telegram
+// session.
+func buildTestStackWithTyping() (*server.Server, func(TelegramEventData) error, func(TelegramTypingData) error) {
+	webhooks := events.NewWebhookRegistry()
+	source, yield := newTelegramSource()
+	typingSource, yieldTyping := newTelegramTypingSource()
+
+	srv := server.NewServer(
+		core.ServerInfo{Name: "telegram-events-e2e", Version: "0.1.0"},
+		server.WithSubscriptions(),
+	)
+	registerResources(srv, source)
+	(&ToolDelivery{Bot: nil}).Register(srv)
+	events.Register(events.Config{
+		Sources:  []events.EventSource{source, typingSource},
+		Webhooks: webhooks,
+		Server:   srv,
+	})
+	return srv, yield, yieldTyping
 }
 
 // yieldText is a small helper for tests that just need to publish a message.
@@ -344,13 +371,135 @@ func TestE2EEventsList(t *testing.T) {
 			Name          string   `json:"name"`
 			Delivery      []string `json:"delivery"`
 			PayloadSchema any      `json:"payloadSchema"`
+			Cursorless    bool     `json:"cursorless"`
 		} `json:"events"`
 	}
 	require.NoError(t, json.Unmarshal(result.Raw, &resp))
-	require.Len(t, resp.Events, 1)
-	assert.Equal(t, "telegram.message", resp.Events[0].Name)
-	assert.ElementsMatch(t, []string{"push", "poll", "webhook"}, resp.Events[0].Delivery)
-	assert.NotNil(t, resp.Events[0].PayloadSchema, "payloadSchema should be auto-derived")
+	byName := map[string]int{}
+	for i, e := range resp.Events {
+		byName[e.Name] = i
+	}
+	require.Contains(t, byName, "telegram.message")
+	require.Contains(t, byName, "telegram.typing")
+
+	msg := resp.Events[byName["telegram.message"]]
+	assert.ElementsMatch(t, []string{"push", "poll", "webhook"}, msg.Delivery)
+	assert.NotNil(t, msg.PayloadSchema, "payloadSchema should be auto-derived")
+	assert.False(t, msg.Cursorless, "telegram.message is cursored")
+
+	typing := resp.Events[byName["telegram.typing"]]
+	assert.ElementsMatch(t, []string{"push", "webhook"}, typing.Delivery)
+	assert.True(t, typing.Cursorless, "telegram.typing is cursorless")
+}
+
+// TestE2ECursorlessPushDelivery verifies the cursorless typing source on
+// telegram-events: yield triggers a push notification whose Event.cursor
+// is JSON null on the wire.
+func TestE2ECursorlessPushDelivery(t *testing.T) {
+	srv, _, yieldTyping := buildTestStackWithTyping()
+
+	var mu sync.Mutex
+	var receivedRaw []map[string]any
+
+	handler := srv.Handler(server.WithStreamableHTTP(true))
+	tsrv := httptest.NewServer(handler)
+	defer tsrv.Close()
+
+	c := client.NewClient(tsrv.URL+"/mcp", core.ClientInfo{Name: "cursorless-push", Version: "1.0"},
+		client.WithGetSSEStream(),
+		client.WithNotificationCallback(func(method string, params any) {
+			if method != "notifications/events/event" {
+				return
+			}
+			b, _ := json.Marshal(params)
+			var p map[string]any
+			_ = json.Unmarshal(b, &p)
+			mu.Lock()
+			receivedRaw = append(receivedRaw, p)
+			mu.Unlock()
+		}),
+	)
+	require.NoError(t, c.Connect())
+	defer c.Close()
+
+	time.Sleep(200 * time.Millisecond)
+	require.NoError(t, yieldTyping(newTelegramTypingEvent(100, "alice", time.Now())))
+	time.Sleep(500 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, receivedRaw, 1, "push must deliver the typing event")
+	cursorVal, present := receivedRaw[0]["cursor"]
+	require.True(t, present, "cursor field must be present on the wire")
+	assert.Nil(t, cursorVal, "cursorless event must wire as cursor:null")
+}
+
+// TestE2ECursorlessWebhookDelivery verifies the cursorless typing source's
+// webhook delivery on telegram-events: the POSTed Event JSON has cursor:null.
+func TestE2ECursorlessWebhookDelivery(t *testing.T) {
+	srv, _, yieldTyping := buildTestStackWithTyping()
+
+	var mu sync.Mutex
+	var deliveryBody map[string]any
+
+	callbackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		_ = json.Unmarshal(body, &deliveryBody)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer callbackSrv.Close()
+
+	handler := srv.Handler(server.WithStreamableHTTP(true))
+	tsrv := httptest.NewServer(handler)
+	defer tsrv.Close()
+	c := client.NewClient(tsrv.URL+"/mcp", core.ClientInfo{Name: "cursorless-wh", Version: "1.0"})
+	require.NoError(t, c.Connect())
+
+	raw, err := c.Call("events/subscribe", map[string]any{
+		"id":       "wh-typing",
+		"name":     "telegram.typing",
+		"delivery": map[string]any{"mode": "webhook", "url": callbackSrv.URL},
+	})
+	require.NoError(t, err)
+	var resp struct {
+		Cursor *string `json:"cursor"`
+	}
+	require.NoError(t, json.Unmarshal(raw.Raw, &resp))
+	assert.Nil(t, resp.Cursor, "subscribe response cursor must be null for cursorless source")
+
+	require.NoError(t, yieldTyping(newTelegramTypingEvent(100, "alice", time.Now())))
+	time.Sleep(500 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.NotNil(t, deliveryBody)
+	cursorVal, present := deliveryBody["cursor"]
+	require.True(t, present)
+	assert.Nil(t, cursorVal, "cursorless event must wire as cursor:null")
+}
+
+// TestE2EPollMultiSubRejected verifies the wire-level guarantee that
+// events/poll no longer accepts multiple subscriptions in one request.
+// Mirrors the discord-events test for telegram parity.
+func TestE2EPollMultiSubRejected(t *testing.T) {
+	srv, _, _, _ := buildTestStack()
+
+	handler := srv.Handler(server.WithStreamableHTTP(true))
+	tsrv := httptest.NewServer(handler)
+	defer tsrv.Close()
+	c := client.NewClient(tsrv.URL+"/mcp", core.ClientInfo{Name: "multi-sub", Version: "1.0"})
+	require.NoError(t, c.Connect())
+
+	_, err := c.Call("events/poll", map[string]any{
+		"subscriptions": []map[string]any{
+			{"id": "a", "name": "telegram.message", "cursor": "0"},
+			{"id": "b", "name": "telegram.typing", "cursor": "0"},
+		},
+	})
+	require.Error(t, err, "multi-subscription events/poll must be rejected")
+	assert.Contains(t, err.Error(), "exactly one subscription")
 }
 
 // TestE2EResourceReadViaClient verifies the recent-messages resource reads

--- a/experimental/telegram-events/events.go
+++ b/experimental/telegram-events/events.go
@@ -15,3 +15,15 @@ func newTelegramSource() (*events.YieldingSource[TelegramEventData], func(Telegr
 		Delivery:    []string{"push", "poll", "webhook"},
 	}, events.WithMaxSize(1000))
 }
+
+// newTelegramTypingSource constructs the cursorless YieldingSource for
+// telegram.typing events. Typing indicators are ephemeral — the source skips
+// buffering and events emit with `cursor: null` on the wire. Push and webhook
+// delivery still work; poll always returns empty.
+func newTelegramTypingSource() (*events.YieldingSource[TelegramTypingData], func(TelegramTypingData) error) {
+	return events.NewYieldingSource[TelegramTypingData](events.EventDef{
+		Name:        "telegram.typing",
+		Description: "Fires when a user starts typing in a Telegram chat",
+		Delivery:    []string{"push", "webhook"},
+	}, events.WithoutCursors())
+}

--- a/experimental/telegram-events/main.go
+++ b/experimental/telegram-events/main.go
@@ -13,6 +13,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"flag"
+	"fmt"
 	"log"
 	"net/http"
 	"strconv"
@@ -62,6 +63,7 @@ func main() {
 
 	webhooks := events.NewWebhookRegistry(whOpts...)
 	source, yield := newTelegramSource()
+	typingSource, yieldTyping := newTelegramTypingSource()
 
 	var bot *tgbotapi.BotAPI
 	if *token != "" {
@@ -86,7 +88,7 @@ func main() {
 	(&ToolDelivery{Bot: bot}).Register(srv)
 
 	events.Register(events.Config{
-		Sources:  []events.EventSource{source},
+		Sources:  []events.EventSource{source, typingSource},
 		Webhooks: webhooks,
 		Server:   srv,
 	})
@@ -104,30 +106,60 @@ func main() {
 		w.WriteHeader(http.StatusOK)
 	})
 
+	// One endpoint, dispatch on ?event=<name>. Default is telegram.message
+	// for backwards compatibility with the older inject script. Body shape
+	// varies per event — see the per-event branches below.
 	mux.HandleFunc("POST /inject", func(w http.ResponseWriter, r *http.Request) {
-		var msg struct {
-			ChatID int64  `json:"chat_id"`
-			Sender string `json:"sender"`
-			Text   string `json:"text"`
+		eventName := r.URL.Query().Get("event")
+		if eventName == "" {
+			eventName = "telegram.message"
 		}
-		if err := json.NewDecoder(r.Body).Decode(&msg); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
+
+		switch eventName {
+		case "telegram.message":
+			var msg struct {
+				ChatID int64  `json:"chat_id"`
+				Sender string `json:"sender"`
+				Text   string `json:"text"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&msg); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			if msg.Sender == "" {
+				msg.Sender = "injected"
+			}
+			now := time.Now()
+			_ = yield(TelegramEventData{
+				ChatID:    strconv.FormatInt(msg.ChatID, 10),
+				User:      msg.Sender,
+				Text:      msg.Text,
+				Timestamp: now.Format(time.RFC3339),
+			})
+			srv.NotifyResourceUpdated("telegram://messages/recent")
+			log.Printf("[inject] sender=%s text=%q", msg.Sender, msg.Text)
+
+		case "telegram.typing":
+			var msg struct {
+				ChatID int64  `json:"chat_id"`
+				User   string `json:"user"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&msg); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			if msg.User == "" {
+				msg.User = "injected-typing"
+			}
+			_ = yieldTyping(newTelegramTypingEvent(msg.ChatID, msg.User, time.Now()))
+
+		default:
+			http.Error(w, fmt.Sprintf("unknown event %q (want telegram.message or telegram.typing)", eventName), http.StatusBadRequest)
 			return
 		}
-		if msg.Sender == "" {
-			msg.Sender = "injected"
-		}
-		now := time.Now()
-		_ = yield(TelegramEventData{
-			ChatID:    strconv.FormatInt(msg.ChatID, 10),
-			User:      msg.Sender,
-			Text:      msg.Text,
-			Timestamp: now.Format(time.RFC3339),
-		})
-		srv.NotifyResourceUpdated("telegram://messages/recent")
-		log.Printf("[inject] sender=%s text=%q", msg.Sender, msg.Text)
+
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{"status": "ok"})
+		json.NewEncoder(w).Encode(map[string]any{"status": "ok", "event": eventName})
 	})
 
 	log.Printf("[server] telegram-events listening on %s (MCP at /mcp)", *addr)

--- a/experimental/telegram-events/telegram.go
+++ b/experimental/telegram-events/telegram.go
@@ -48,6 +48,25 @@ func makeTelegramEvent(msg *tgbotapi.Message) TelegramEventData {
 	}
 }
 
+// TelegramTypingData is the typed payload for the cursorless telegram.typing
+// event. Telegram's bot API exposes typing as a chat-action update; the
+// indicator is ephemeral so the source declares itself cursorless and the
+// wire emits cursor:null.
+type TelegramTypingData struct {
+	ChatID    string `json:"chat_id"`
+	User      string `json:"user" jsonschema:"description=Username that started typing"`
+	StartedAt string `json:"started_at" jsonschema:"description=ISO 8601 timestamp,format=date-time"`
+}
+
+// newTelegramTypingEvent builds a TelegramTypingData payload.
+func newTelegramTypingEvent(chatID int64, user string, ts time.Time) TelegramTypingData {
+	return TelegramTypingData{
+		ChatID:    strconv.FormatInt(chatID, 10),
+		User:      user,
+		StartedAt: ts.Format(time.RFC3339),
+	}
+}
+
 // handleTelegramWebhook processes a Telegram Bot API webhook POST and yields
 // the resulting event. Returns true if an event was published.
 func handleTelegramWebhook(yield func(TelegramEventData) error, r *http.Request) bool {


### PR DESCRIPTION
## Summary

PR B from #323. Three things, designed to ship together because they all touch the cursor field on the wire.

1. **Source-level cursorless mode** — `events.WithoutCursors()` option. The source skips buffering, emits events with `cursor: null`, and `events/poll` always returns empty. Push and webhook fanout still work.
2. **Subscriber-level "from now"** — `cursor: null` on subscribe / poll resolves to `source.Latest()` for cursored sources (server returns the head; subsequent events get real cursors). For cursorless sources it stays null.
3. **Poll batching removed** — `events/poll` rejects multi-subscription requests with InvalidParams. No deprecation flag; the upstream WG alignment on this is firm enough that the rollback path isn't worth carrying.

## Wire shape changes

| Field | Before | After |
|---|---|---|
| `Event.cursor` | `string` (always present, often `""` for "from beginning" subscribers) | `string \| null` — cursorless events serialize as `null` |
| `pollResultWire.cursor` | `string` | `string \| null` |
| `EventDef.cursorless` | — | new optional `bool`, advertised via `events/list` |
| `events/poll` request | `subscriptions: [...]` (any length) | array, `len > 1` rejected |

The empty-string-as-from-beginning convention is gone. `cursor: null` = from now; real cursor = resume from there. Existing tests that used `cursor: "0"` continue to work via the int-cursor coincidence (memory store starts at 1, so "0" naturally selects everything) — no functional break for them.

## Library API

```go
// New option:
source, yield := events.NewYieldingSource[TypingData](
    events.EventDef{Name: "discord.typing", ...},
    events.WithoutCursors(),  // <-- here
)

// New helpers on Event:
event.HasCursor()  // bool — true for cursored
event.CursorStr()  // string — "" for cursorless

// New method on EventSource interface:
type EventSource interface {
    Def() EventDef
    Poll(cursor string, limit int) PollResult
    Latest() string  // <-- new; "" for cursorless or empty source
}
```

`MakeEvent` keeps its `string` cursor parameter — empty string maps to nil pointer internally so source authors don't deal with `*string` directly.

`TypedSource` now takes a `latest func() string` alongside `poll`. No third-party callers (the demos were ported to `YieldingSource` in PR A) so no breakage in practice.

## Demos

Both `discord-events` and `telegram-events` now register a cursorless typing event (`discord.typing` / `telegram.typing`) alongside the cursored message event. The `/inject` HTTP endpoint dispatches on a `?event=<name>` query param (default `*.message` for back-compat). New `make inject-typing` targets in both Makefiles.

The Python client (`events_client.py`) prints `(none)` for null cursors instead of the bare Python `None`. Functional behavior unchanged.

## Tests

| File | New | Purpose |
|---|---|---|
| `experimental/ext/events/cursorless_test.go` | 8 tests | Wire-shape pinning (`cursor: null` vs `cursor: "abc"`), `MakeEvent`'s empty-string → nil convention, cursorless source's no-buffer behavior, cursored source's `Latest()` head, `EventDef.Cursorless` flag flow |
| `experimental/discord-events/e2e_test.go` | 5 tests | `TestE2ECursorlessPushDelivery`, `TestE2ECursorlessWebhookDelivery`, `TestE2ECursorlessPollAlwaysEmpty`, `TestE2ESubscribeCursorNullOnCursoredSourceReturnsLatest`, `TestE2EPollMultiSubRejected` |
| `experimental/telegram-events/e2e_test.go` | 3 tests | Parallel typing push + webhook + multi-sub-rejection |

Plus `TestE2EEventsList` updated in both demos to assert by event name (now two events per server) and to verify the new `Cursorless` flag on the `events/list` response.

### Assertion-count audit

- 16 new tests across the three modules (~50+ new assertions).
- `TestE2EEventsList` in both demos changed shape — was `len == 1` + name string equality; now is `Contains` on a name map plus per-event delivery + cursorless verification. Same assertion count, **stronger** semantics (verifies both events and the cursorless flag).
- No existing assertions weakened or removed.

`make test-experimental` passes all three modules. `make test-ttl` still passes against the Server-mode default.

## Constraint check

- C1 (typed contexts): no handler signature changes. ✅
- C2 (consolidated structs): no new parallel maps. ✅
- C3 (no globals): all new state lives on the `YieldingSource` instance. ✅

## Out of scope (still tracked)

- PR D: `DEPLOYMENT.md` (WAF / private cloud notes).
- PR A's three feature follow-ups (move demos to `examples/events/`, `eventsclient` Go package, optional zero-marshal Recent).
- Audit log #326 (cross-cutting refactor opportunities — crypto primitives + webhook outbox extraction).

## References (non-linking — code block to suppress backlinks)

```
panyam/mcpkit#323 (umbrella)
panyam/mcpkit#326 (audit log)

Upstream review threads referenced in this PR (open in browser):
  https://github.com/modelcontextprotocol/experimental-ext-triggers-events/pull/1#discussion_r3139388811  (Casey: best-effort updates)
  https://github.com/modelcontextprotocol/experimental-ext-triggers-events/pull/1#discussion_r3140484970  (author response: cursor:null)
  https://github.com/modelcontextprotocol/experimental-ext-triggers-events/pull/1#discussion_r3139417032  (Casey: cursor required?)
  https://github.com/modelcontextprotocol/experimental-ext-triggers-events/pull/1#discussion_r3140488267  (author response: servers without cursors return null)
  https://github.com/modelcontextprotocol/experimental-ext-triggers-events/pull/1#discussion_r3139231068  (Casey: drop poll batching)
  https://github.com/modelcontextprotocol/experimental-ext-triggers-events/pull/1#discussion_r3140480214  (author confirms)
```
