### PR TITLE
feat: SEP-2663 v2 client (Phase 6)

### DIFF
--- a/client/tasks.go
+++ b/client/tasks.go
@@ -1,0 +1,249 @@
+package client
+
+// V2 task client helpers — SEP-2663 (Tasks Extension), SEP-2557 (resultType
+// discriminator), SEP-2322 (MRTR).
+//
+// Differences from the v1 helpers in tasks_v1.go:
+//   - No client-side task hint: the server decides whether tools/call returns
+//     a sync ToolResult or a CreateTaskResult. ToolCall returns a polymorphic
+//     ToolCallResult so callers can branch on which shape arrived.
+//   - tasks/get returns DetailedTask with inlined result/error/inputRequests.
+//   - tasks/update is the new resume path for MRTR input rounds.
+//   - tasks/cancel returns an empty ack.
+//   - WaitForTask polls tasks/get and honors the server's
+//     PollIntervalMilliseconds hint, automatically echoing requestState.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+// --- Public option types ---
+
+// TaskOptions configures a single tasks/get or tasks/cancel call.
+// The zero value sends no requestState; pass an explicit value to echo a
+// requestState the server returned on a previous response (SEP-2322 stateless
+// deployments). Polling helpers (WaitForTask) thread requestState
+// automatically and don't require callers to pass it manually.
+type TaskOptions struct {
+	// RequestState is the opaque session-continuation token the server
+	// returned on the most recent DetailedTask. Echoed verbatim — clients
+	// MUST treat it as opaque.
+	RequestState string
+}
+
+// WaitOptions configures WaitForTask.
+type WaitOptions struct {
+	// PollInterval overrides the server's PollIntervalMilliseconds hint.
+	// 0 (the default) means: respect whatever the server returned, with a
+	// 1-second floor and a 30-second cap if the server didn't say.
+	PollInterval time.Duration
+
+	// RequestState seeds the echo loop. When the server returns an updated
+	// requestState in a poll response, WaitForTask switches to using it on
+	// the next call.
+	RequestState string
+}
+
+// ToolCallResult is the discriminated union returned by ToolCall when the
+// server may have elected to handle a tools/call as an async task. Exactly
+// one of Sync or Task is non-nil — branch on which is set.
+type ToolCallResult struct {
+	// Sync is populated when the server ran the tool to completion in the
+	// same request and returned a ToolResult directly (sync tool, or the
+	// SEP-2663 immediate-result shortcut).
+	Sync *core.ToolResult
+
+	// Task is populated when the server elected to create a task (the
+	// resultType: "task" discriminator was present on the response).
+	Task *core.CreateTaskResult
+}
+
+// IsTask reports whether the result is the task-creation variant.
+func (r *ToolCallResult) IsTask() bool { return r != nil && r.Task != nil }
+
+// --- Wire-format params ---
+
+type tasksGetParams struct {
+	TaskID       string `json:"taskId"`
+	RequestState string `json:"requestState,omitempty"`
+}
+
+type tasksCancelParams struct {
+	TaskID       string `json:"taskId"`
+	RequestState string `json:"requestState,omitempty"`
+}
+
+// --- Polymorphic tools/call ---
+
+// ToolCall invokes a tool, transparently handling both the sync ToolResult
+// and the SEP-2663 CreateTaskResult shapes. Branch on result.IsTask() (or
+// the Sync / Task fields directly) to know which arrived.
+//
+// Servers gate task creation on the io.modelcontextprotocol/tasks extension,
+// so this only ever returns a Task result if the client declared the
+// extension during initialize (or per-request via SEP-2575 _meta).
+func ToolCall(c *Client, name string, args any) (*ToolCallResult, error) {
+	resp, err := c.Call("tools/call", map[string]any{
+		"name":      name,
+		"arguments": args,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return parseToolCallResult(resp.Raw)
+}
+
+// parseToolCallResult inspects the resultType discriminator on a tools/call
+// response and decodes into the matching typed shape. Exposed as a top-level
+// helper so other callers (e.g. typed wrappers) can reuse the dispatch.
+func parseToolCallResult(raw json.RawMessage) (*ToolCallResult, error) {
+	var probe struct {
+		ResultType core.ResultType `json:"resultType"`
+	}
+	// Probe failure is harmless — fall through to the sync shape, which
+	// will surface its own decode error if the response is genuinely malformed.
+	_ = json.Unmarshal(raw, &probe)
+
+	if probe.ResultType == core.ResultTypeTask {
+		var r core.CreateTaskResult
+		if err := json.Unmarshal(raw, &r); err != nil {
+			return nil, fmt.Errorf("unmarshal CreateTaskResult: %w", err)
+		}
+		return &ToolCallResult{Task: &r}, nil
+	}
+
+	var r core.ToolResult
+	if err := json.Unmarshal(raw, &r); err != nil {
+		return nil, fmt.Errorf("unmarshal ToolResult: %w", err)
+	}
+	return &ToolCallResult{Sync: &r}, nil
+}
+
+// --- tasks/get / tasks/update / tasks/cancel ---
+
+// GetTask fetches the current state of a v2 task as a DetailedTask, with
+// inlined result / error / inputRequests / requestState depending on status.
+// Idempotent — safe to call as often as needed; servers gate this method on
+// the io.modelcontextprotocol/tasks extension being negotiated.
+func GetTask(c *Client, taskID string, opts ...TaskOptions) (*core.DetailedTask, error) {
+	params := tasksGetParams{TaskID: taskID}
+	if len(opts) > 0 {
+		params.RequestState = opts[0].RequestState
+	}
+	resp, err := c.Call("tasks/get", params)
+	if err != nil {
+		return nil, err
+	}
+	var dt core.DetailedTask
+	if err := json.Unmarshal(resp.Raw, &dt); err != nil {
+		return nil, fmt.Errorf("unmarshal DetailedTask: %w", err)
+	}
+	return &dt, nil
+}
+
+// UpdateTask resumes a task parked in input_required by delivering the
+// inputResponses the server's pending inputRequests are waiting on. The
+// server matches keys, hands the payloads to the waiting goroutine, and
+// the task transitions back to working (or directly to a terminal state
+// if the tool finishes immediately after).
+//
+// Returns nil on success — the server response is an empty ack per
+// SEP-2663. Observe the resulting state via the next GetTask poll.
+func UpdateTask(c *Client, req core.UpdateTaskRequest) error {
+	if req.TaskID == "" {
+		return fmt.Errorf("UpdateTask: missing TaskID")
+	}
+	if _, err := c.Call("tasks/update", req); err != nil {
+		return err
+	}
+	return nil
+}
+
+// CancelTask cancels a running task. Returns nil on success — the server
+// response is an empty ack per SEP-2663 (no task state). Issue GetTask if
+// you need to observe the resulting "cancelled" status.
+func CancelTask(c *Client, taskID string, opts ...TaskOptions) error {
+	params := tasksCancelParams{TaskID: taskID}
+	if len(opts) > 0 {
+		params.RequestState = opts[0].RequestState
+	}
+	if _, err := c.Call("tasks/cancel", params); err != nil {
+		return err
+	}
+	return nil
+}
+
+// --- Polling helpers ---
+
+const (
+	// defaultPollInterval is the floor used when neither the caller nor the
+	// server suggests one. Tuned for "feels responsive in tests, doesn't
+	// hammer in production."
+	defaultPollInterval = 1 * time.Second
+	// maxPollInterval caps server-suggested intervals so a misconfigured
+	// server can't park a poll loop indefinitely.
+	maxPollInterval = 30 * time.Second
+)
+
+// WaitForTask polls tasks/get until the task reaches a terminal state or
+// ctx fires. Each iteration honors:
+//
+//   - opts[0].PollInterval if non-zero (caller override),
+//   - else the server's PollIntervalMilliseconds on the most recent response,
+//   - else the 1-second default.
+//
+// requestState is threaded automatically: each poll echoes the requestState
+// the server returned on the previous response. Returns the final
+// DetailedTask snapshot (which inlines the result / error / inputRequests
+// per SEP-2663). Note that input_required is NOT terminal — callers wanting
+// to handle the MRTR resume should poll until terminal or use a tighter
+// loop that checks for input_required and calls UpdateTask in between.
+func WaitForTask(ctx context.Context, c *Client, taskID string, opts ...WaitOptions) (*core.DetailedTask, error) {
+	var override time.Duration
+	state := ""
+	if len(opts) > 0 {
+		override = opts[0].PollInterval
+		state = opts[0].RequestState
+	}
+
+	for {
+		dt, err := GetTask(c, taskID, TaskOptions{RequestState: state})
+		if err != nil {
+			return nil, err
+		}
+		if dt.Status.IsTerminal() {
+			return dt, nil
+		}
+		if dt.RequestState != "" {
+			state = dt.RequestState
+		}
+
+		wait := nextPollWait(override, dt.PollIntervalMilliseconds)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(wait):
+		}
+	}
+}
+
+// nextPollWait picks the next poll interval, applying the caller override,
+// the server hint, and the floor/ceiling.
+func nextPollWait(override time.Duration, serverHintMs *int) time.Duration {
+	if override > 0 {
+		return override
+	}
+	if serverHintMs != nil && *serverHintMs > 0 {
+		hint := time.Duration(*serverHintMs) * time.Millisecond
+		if hint > maxPollInterval {
+			return maxPollInterval
+		}
+		return hint
+	}
+	return defaultPollInterval
+}

--- a/client/tasks_test.go
+++ b/client/tasks_test.go
@@ -1,0 +1,388 @@
+package client_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	client "github.com/panyam/mcpkit/client"
+	core "github.com/panyam/mcpkit/core"
+	server "github.com/panyam/mcpkit/server"
+)
+
+// --- v2 task client fixtures ---
+
+// newTaskV2TestServer registers a small v2 task server: "echo" runs sync,
+// "fast-task" creates a task that completes immediately, "slow-task" blocks
+// until unblock is closed, and "confirm-delete" exercises TaskElicit so the
+// MRTR loop can be driven end-to-end. Returns the server, the unblock chan
+// for slow-task (close to release), and the URL of the httptest server.
+func newTaskV2TestServer(t *testing.T) (string, chan struct{}) {
+	t.Helper()
+
+	srv := server.NewServer(core.ServerInfo{Name: "v2-client-test", Version: "0.0.1"})
+
+	type echoInput struct {
+		Message string `json:"message"`
+	}
+	srv.Register(core.TextTool[echoInput]("echo", "echoes",
+		func(ctx core.ToolContext, in echoInput) (string, error) {
+			return "echo: " + in.Message, nil
+		},
+	))
+
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "fast-task",
+			Description: "completes immediately",
+			InputSchema: map[string]any{"type": "object"},
+			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportRequired},
+		},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+			return core.TextResult("fast-done"), nil
+		},
+	)
+
+	unblock := make(chan struct{})
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "slow-task",
+			Description: "blocks until unblocked",
+			InputSchema: map[string]any{"type": "object"},
+			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportRequired},
+		},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+			select {
+			case <-unblock:
+			case <-ctx.Done():
+			}
+			return core.TextResult("slow-done"), nil
+		},
+	)
+
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "confirm-delete",
+			Description: "asks via TaskElicit",
+			InputSchema: map[string]any{"type": "object"},
+			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportRequired},
+		},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+			tc := server.GetTaskContext(ctx)
+			if tc == nil {
+				return core.ToolResult{}, errString("no task ctx")
+			}
+			res, err := tc.TaskElicit(core.ElicitationRequest{
+				Message:         "delete?",
+				RequestedSchema: json.RawMessage(`{"type":"object","properties":{"confirm":{"type":"boolean"}}}`),
+			})
+			if err != nil {
+				return core.ToolResult{}, err
+			}
+			if res.Action == "accept" {
+				if ok, _ := res.Content["confirm"].(bool); ok {
+					return core.TextResult("deleted"), nil
+				}
+			}
+			return core.TextResult("kept"), nil
+		},
+	)
+
+	server.RegisterTasks(server.TasksConfig{Server: srv, DefaultPollMs: 50})
+
+	handler := srv.Handler(server.WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+	t.Cleanup(func() { close(unblock) })
+
+	return ts.URL, unblock
+}
+
+// errString lets the inline tool handler raise an error without dragging in
+// fmt.Errorf for one literal.
+type errString string
+
+func (e errString) Error() string { return string(e) }
+
+func connectV2TaskClient(t *testing.T, url string, opts ...client.ClientOption) *client.Client {
+	t.Helper()
+	opts = append(opts, client.WithTasksExtension())
+	c := client.NewClient(url+"/mcp", core.ClientInfo{Name: "v2-task-client-test", Version: "0.0.1"}, opts...)
+	if err := c.Connect(); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+	return c
+}
+
+// --- Polymorphic ToolCall ---
+
+// TestToolCall_SyncResult verifies ToolCall returns the Sync variant for a
+// tool the server runs synchronously (no Execution / TaskSupport=forbidden).
+func TestToolCall_SyncResult(t *testing.T) {
+	url, _ := newTaskV2TestServer(t)
+	c := connectV2TaskClient(t, url)
+
+	res, err := client.ToolCall(c, "echo", map[string]any{"message": "hi"})
+	if err != nil {
+		t.Fatalf("ToolCall: %v", err)
+	}
+	if res.IsTask() {
+		t.Fatalf("expected Sync variant for sync tool; got Task=%+v", res.Task)
+	}
+	if res.Sync == nil || len(res.Sync.Content) == 0 || res.Sync.Content[0].Text != "echo: hi" {
+		t.Errorf("Sync result mismatch: %+v", res.Sync)
+	}
+}
+
+// TestToolCall_TaskResult verifies ToolCall returns the Task variant when the
+// server elects to create a task (TaskSupport=required + extension negotiated).
+func TestToolCall_TaskResult(t *testing.T) {
+	url, _ := newTaskV2TestServer(t)
+	c := connectV2TaskClient(t, url)
+
+	res, err := client.ToolCall(c, "fast-task", map[string]any{})
+	if err != nil {
+		t.Fatalf("ToolCall: %v", err)
+	}
+	if !res.IsTask() {
+		t.Fatalf("expected Task variant; got Sync=%+v", res.Sync)
+	}
+	if res.Task.ResultType != core.ResultTypeTask {
+		t.Errorf("resultType = %q, want %q", res.Task.ResultType, core.ResultTypeTask)
+	}
+	if res.Task.Task.TaskID == "" {
+		t.Error("missing taskId in CreateTaskResult")
+	}
+}
+
+// --- GetTask ---
+
+// TestGetTask returns DetailedTask with the v2 wire shape (TaskInfoV2 fields,
+// requestState present). Status may be working or already terminal — both
+// are valid as long as the shape decodes.
+func TestGetTask(t *testing.T) {
+	url, _ := newTaskV2TestServer(t)
+	c := connectV2TaskClient(t, url)
+
+	res, err := client.ToolCall(c, "fast-task", map[string]any{})
+	if err != nil || !res.IsTask() {
+		t.Fatalf("setup: ToolCall(fast-task) = %v, %+v", err, res)
+	}
+	taskID := res.Task.Task.TaskID
+
+	dt, err := client.GetTask(c, taskID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if dt.TaskID != taskID {
+		t.Errorf("TaskID = %q, want %q", dt.TaskID, taskID)
+	}
+	if dt.RequestState == "" {
+		t.Errorf("expected non-empty requestState (server should emit one)")
+	}
+}
+
+// --- WaitForTask ---
+
+// TestWaitForTask polls until terminal and verifies the inlined result is
+// surfaced on DetailedTask.Result.
+func TestWaitForTask(t *testing.T) {
+	url, _ := newTaskV2TestServer(t)
+	c := connectV2TaskClient(t, url)
+
+	res, _ := client.ToolCall(c, "fast-task", map[string]any{})
+	taskID := res.Task.Task.TaskID
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	dt, err := client.WaitForTask(ctx, c, taskID)
+	if err != nil {
+		t.Fatalf("WaitForTask: %v", err)
+	}
+	if dt.Status != core.TaskCompleted {
+		t.Fatalf("status = %q, want completed", dt.Status)
+	}
+	if dt.Result == nil || len(dt.Result.Content) == 0 || dt.Result.Content[0].Text != "fast-done" {
+		t.Errorf("inlined result mismatch: %+v", dt.Result)
+	}
+}
+
+// TestWaitForTask_HonorsServerPollHint verifies the loop respects the
+// server's PollIntervalMilliseconds. We set DefaultPollMs=50 in the fixture,
+// kick off a task that takes ~150ms, and assert the wait stretches at least
+// across one server-suggested interval (i.e., we don't poll the server in a
+// tight loop).
+func TestWaitForTask_HonorsServerPollHint(t *testing.T) {
+	url, unblock := newTaskV2TestServer(t)
+	c := connectV2TaskClient(t, url)
+
+	res, _ := client.ToolCall(c, "slow-task", map[string]any{})
+	taskID := res.Task.Task.TaskID
+
+	// Release after 150ms so the wait spans at least 2-3 server-hinted polls.
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		select {
+		case unblock <- struct{}{}:
+		default:
+		}
+	}()
+
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	dt, err := client.WaitForTask(ctx, c, taskID)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("WaitForTask: %v", err)
+	}
+	if dt.Status != core.TaskCompleted {
+		t.Fatalf("status = %q, want completed", dt.Status)
+	}
+	// We're not asserting an upper bound (CI noise) — just that we waited at
+	// least one server poll interval. If the helper ignored the hint and
+	// busy-looped, elapsed would be ~equal to the work duration (150ms).
+	// With a 50ms hint we expect elapsed ≥ ~200ms (work + at least one poll).
+	if elapsed < 100*time.Millisecond {
+		t.Errorf("elapsed %s suspiciously short — likely busy-looped instead of honoring server's PollIntervalMilliseconds", elapsed)
+	}
+}
+
+// TestWaitForTask_RespectsCallerOverride verifies the WaitOptions.PollInterval
+// override beats the server hint.
+func TestWaitForTask_RespectsCallerOverride(t *testing.T) {
+	url, unblock := newTaskV2TestServer(t)
+	c := connectV2TaskClient(t, url)
+
+	res, _ := client.ToolCall(c, "slow-task", map[string]any{})
+	taskID := res.Task.Task.TaskID
+
+	// Release right away so the test doesn't depend on timing precision.
+	close := make(chan struct{})
+	go func() {
+		<-close
+		select {
+		case unblock <- struct{}{}:
+		default:
+		}
+	}()
+	go func() { time.Sleep(20 * time.Millisecond); close <- struct{}{} }()
+
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, err := client.WaitForTask(ctx, c, taskID, client.WaitOptions{PollInterval: 10 * time.Millisecond})
+	if err != nil {
+		t.Fatalf("WaitForTask: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		// With a 10ms override + ~20ms work we should finish quickly.
+		// The server's 50ms hint should NOT have applied.
+		t.Errorf("elapsed %s — caller's 10ms override doesn't seem to have taken effect over the server's 50ms hint", elapsed)
+	}
+}
+
+// --- UpdateTask (MRTR loop) ---
+
+// TestUpdateTask_FullElicitLoop drives the SEP-2663 elicit→update→complete
+// cycle through the v2 client helpers end-to-end.
+func TestUpdateTask_FullElicitLoop(t *testing.T) {
+	url, _ := newTaskV2TestServer(t)
+	c := connectV2TaskClient(t, url)
+
+	res, err := client.ToolCall(c, "confirm-delete", map[string]any{})
+	if err != nil || !res.IsTask() {
+		t.Fatalf("ToolCall(confirm-delete): err=%v res=%+v", err, res)
+	}
+	taskID := res.Task.Task.TaskID
+
+	// Poll until input_required surfaces a pending request.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var pending *core.DetailedTask
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		dt, err := client.GetTask(c, taskID)
+		if err != nil {
+			t.Fatalf("GetTask: %v", err)
+		}
+		if dt.Status == core.TaskInputRequired && len(dt.InputRequests) > 0 {
+			pending = dt
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if pending == nil {
+		t.Fatal("task never reached input_required with InputRequests populated")
+	}
+
+	var key string
+	for k := range pending.InputRequests {
+		key = k
+		break
+	}
+
+	// Reply via UpdateTask.
+	if err := client.UpdateTask(c, core.UpdateTaskRequest{
+		TaskID: taskID,
+		InputResponses: core.InputResponses{
+			key: json.RawMessage(`{"action":"accept","content":{"confirm":true}}`),
+		},
+		RequestState: pending.RequestState,
+	}); err != nil {
+		t.Fatalf("UpdateTask: %v", err)
+	}
+
+	// Wait for completion via WaitForTask.
+	final, err := client.WaitForTask(ctx, c, taskID)
+	if err != nil {
+		t.Fatalf("WaitForTask: %v", err)
+	}
+	if final.Status != core.TaskCompleted {
+		t.Errorf("status = %q, want completed", final.Status)
+	}
+	if final.Result == nil || len(final.Result.Content) == 0 || final.Result.Content[0].Text != "deleted" {
+		t.Errorf("inlined result mismatch: %+v", final.Result)
+	}
+}
+
+// TestUpdateTask_MissingTaskID surfaces the client-side guard before issuing
+// the RPC (no point round-tripping a request that's structurally invalid).
+func TestUpdateTask_MissingTaskID(t *testing.T) {
+	url, _ := newTaskV2TestServer(t)
+	c := connectV2TaskClient(t, url)
+	if err := client.UpdateTask(c, core.UpdateTaskRequest{}); err == nil {
+		t.Error("expected error for empty TaskID")
+	}
+}
+
+// --- CancelTask ---
+
+// TestCancelTask returns nil on success (empty ack) and the task transitions
+// to cancelled when polled.
+func TestCancelTask(t *testing.T) {
+	url, unblock := newTaskV2TestServer(t)
+	c := connectV2TaskClient(t, url)
+	_ = unblock // intentional: leave slow-task blocked so cancel has work to do
+
+	res, _ := client.ToolCall(c, "slow-task", map[string]any{})
+	taskID := res.Task.Task.TaskID
+
+	if err := client.CancelTask(c, taskID); err != nil {
+		t.Fatalf("CancelTask: %v", err)
+	}
+
+	// Status should settle to cancelled on the next poll.
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	dt, err := client.WaitForTask(ctx, c, taskID)
+	if err != nil {
+		t.Fatalf("WaitForTask after cancel: %v", err)
+	}
+	if dt.Status != core.TaskCancelled {
+		t.Errorf("status = %q, want cancelled", dt.Status)
+	}
+}

--- a/client/tasks_v1.go
+++ b/client/tasks_v1.go
@@ -1,5 +1,9 @@
 package client
 
+// V1 task client (MCP spec 2025-11-25, pre-SEP-2663). Frozen alongside the
+// server-side v1 path so existing v1 conformance / unit tests stay green.
+// New code should target the v2 helpers in client/tasks.go.
+
 import (
 	"context"
 	"encoding/json"
@@ -9,41 +13,42 @@ import (
 	"github.com/panyam/mcpkit/core"
 )
 
-// --- Typed request params ---
+// --- Typed request params (v1 wire) ---
 
-type getTaskParams struct {
+type getTaskParamsV1 struct {
 	TaskID string `json:"taskId"`
 }
 
-type resultParams struct {
+type resultParamsV1 struct {
 	TaskID string `json:"taskId"`
 }
 
-type listTasksParams struct {
+type listTasksParamsV1 struct {
 	Cursor string `json:"cursor,omitempty"`
 }
 
-type cancelTaskParams struct {
+type cancelTaskParamsV1 struct {
 	TaskID string `json:"taskId"`
 }
 
-// toolCallAsTaskParams is the wire-format params for tools/call with a task hint.
-// Per MCP spec 2025-11-25: task hint is at params.task (sibling of name/arguments).
-type toolCallAsTaskParams struct {
+// toolCallAsTaskParamsV1 is the wire-format params for tools/call with a v1
+// task hint. Per MCP spec 2025-11-25: task hint is at params.task (sibling of
+// name/arguments).
+type toolCallAsTaskParamsV1 struct {
 	Name      string         `json:"name"`
 	Arguments any            `json:"arguments"`
-	Task      taskParam      `json:"task"`
+	Task      taskParamV1    `json:"task"`
 	Meta      map[string]any `json:"_meta,omitempty"`
 }
 
-type taskParam struct {
+type taskParamV1 struct {
 	TTL          int `json:"ttl,omitempty"`          // milliseconds
 	PollInterval int `json:"pollInterval,omitempty"` // milliseconds
 }
 
-// TaskCallOptions configures a ToolCallAsTask invocation.
+// TaskCallOptionsV1 configures a ToolCallAsTaskV1 invocation.
 // Nil means use server defaults for everything.
-type TaskCallOptions struct {
+type TaskCallOptionsV1 struct {
 	// TTL in milliseconds. 0 = server default.
 	TTL int
 
@@ -55,31 +60,32 @@ type TaskCallOptions struct {
 	ProgressToken any
 }
 
-// IsToolTask checks whether a tool supports task invocation based on its
+// IsToolTaskV1 checks whether a tool supports task invocation based on its
 // Execution.TaskSupport field. Returns true for "required" or "optional".
-// Per MCP spec 2025-11-25: absent Execution = forbidden.
+// Per MCP spec 2025-11-25: absent Execution = forbidden. (V2 servers decide
+// task creation unilaterally — there is no equivalent client-side check.)
 //
-// Use with ListTools to decide whether to call ToolCallAsTask or ToolCall:
+// Use with ListTools to decide whether to call ToolCallAsTaskV1 or ToolCall:
 //
 //	tools, _ := c.ListTools()
 //	for _, t := range tools {
-//	    if client.IsToolTask(t) {
-//	        client.ToolCallAsTask(c, t.Name, args)
+//	    if client.IsToolTaskV1(t) {
+//	        client.ToolCallAsTaskV1(c, t.Name, args)
 //	    } else {
 //	        c.ToolCall(t.Name, args)
 //	    }
 //	}
-func IsToolTask(tool core.ToolDef) bool {
+func IsToolTaskV1(tool core.ToolDef) bool {
 	return tool.Execution != nil &&
 		tool.Execution.TaskSupport != core.TaskSupportForbidden
 }
 
-// --- Client helpers ---
+// --- v1 client helpers ---
 
-// GetTask polls the status of a v1 task by ID. Non-blocking.
+// GetTaskV1 polls the status of a v1 task by ID. Non-blocking.
 // Per MCP spec 2025-11-25 §tasks/get: returns flat Result & Task.
-func GetTask(c *Client, taskID string) (*core.GetTaskResultV1, error) {
-	result, err := c.Call("tasks/get", getTaskParams{TaskID: taskID})
+func GetTaskV1(c *Client, taskID string) (*core.GetTaskResultV1, error) {
+	result, err := c.Call("tasks/get", getTaskParamsV1{TaskID: taskID})
 	if err != nil {
 		return nil, err
 	}
@@ -90,12 +96,13 @@ func GetTask(c *Client, taskID string) (*core.GetTaskResultV1, error) {
 	return &r, nil
 }
 
-// GetTaskPayload fetches the result payload for a task. Blocks until the
-// task reaches a terminal state via the tasks/result long-poll.
+// GetTaskPayloadV1 fetches the result payload for a v1 task. Blocks until
+// the task reaches a terminal state via the tasks/result long-poll.
 // Per MCP spec 2025-11-25 §tasks/result: returns the original ToolResult
-// with _meta["io.modelcontextprotocol/related-task"].
-func GetTaskPayload(c *Client, taskID string) (*core.ToolResult, string, error) {
-	result, err := c.Call("tasks/result", resultParams{TaskID: taskID})
+// with _meta["io.modelcontextprotocol/related-task"]. (V2 removed
+// tasks/result — DetailedTask inlines the result instead.)
+func GetTaskPayloadV1(c *Client, taskID string) (*core.ToolResult, string, error) {
+	result, err := c.Call("tasks/result", resultParamsV1{TaskID: taskID})
 	if err != nil {
 		return nil, "", err
 	}
@@ -110,11 +117,11 @@ func GetTaskPayload(c *Client, taskID string) (*core.ToolResult, string, error) 
 	return &r, relatedID, nil
 }
 
-// ListTasks returns all v1 tasks with cursor-based pagination.
+// ListTasksV1 returns all v1 tasks with cursor-based pagination.
 // Pass an empty cursor to start from the beginning.
 // (Removed in v2 — tasks/list is no longer part of the protocol.)
-func ListTasks(c *Client, cursor string) (*core.ListTasksResultV1, error) {
-	result, err := c.Call("tasks/list", listTasksParams{Cursor: cursor})
+func ListTasksV1(c *Client, cursor string) (*core.ListTasksResultV1, error) {
+	result, err := c.Call("tasks/list", listTasksParamsV1{Cursor: cursor})
 	if err != nil {
 		return nil, err
 	}
@@ -125,11 +132,12 @@ func ListTasks(c *Client, cursor string) (*core.ListTasksResultV1, error) {
 	return &r, nil
 }
 
-// CancelTask cancels a running v1 task. Returns an error if the task is
+// CancelTaskV1 cancels a running v1 task. Returns an error if the task is
 // already in a terminal state.
 // Per MCP spec 2025-11-25 §tasks/cancel: returns flat Result & Task.
-func CancelTask(c *Client, taskID string) (*core.CancelTaskResultV1, error) {
-	result, err := c.Call("tasks/cancel", cancelTaskParams{TaskID: taskID})
+// (V2 returns an empty ack; the v2 helper signature reflects that.)
+func CancelTaskV1(c *Client, taskID string) (*core.CancelTaskResultV1, error) {
+	result, err := c.Call("tasks/cancel", cancelTaskParamsV1{TaskID: taskID})
 	if err != nil {
 		return nil, err
 	}
@@ -140,21 +148,22 @@ func CancelTask(c *Client, taskID string) (*core.CancelTaskResultV1, error) {
 	return &r, nil
 }
 
-// ToolCallAsTask invokes a v1 tool with a task hint, returning a
+// ToolCallAsTaskV1 invokes a v1 tool with a task hint, returning a
 // CreateTaskResultV1 instead of the immediate tool result. The server
 // creates a task and runs the tool asynchronously.
 //
 // Pass nil for opts to use server defaults. Per MCP spec 2025-11-25:
 // task hint at params.task, progressToken at params._meta.progressToken.
-// (V2 removes the client task hint — the server decides unilaterally.)
-func ToolCallAsTask(c *Client, name string, args any, opts ...*TaskCallOptions) (*core.CreateTaskResultV1, error) {
-	params := toolCallAsTaskParams{
+// (V2 removes the client task hint — the server decides unilaterally —
+// so there is no V2 equivalent to this helper.)
+func ToolCallAsTaskV1(c *Client, name string, args any, opts ...*TaskCallOptionsV1) (*core.CreateTaskResultV1, error) {
+	params := toolCallAsTaskParamsV1{
 		Name:      name,
 		Arguments: args,
 	}
 	if len(opts) > 0 && opts[0] != nil {
 		o := opts[0]
-		params.Task = taskParam{TTL: o.TTL, PollInterval: o.PollInterval}
+		params.Task = taskParamV1{TTL: o.TTL, PollInterval: o.PollInterval}
 		if o.ProgressToken != nil {
 			params.Meta = map[string]any{"progressToken": o.ProgressToken}
 		}
@@ -170,20 +179,17 @@ func ToolCallAsTask(c *Client, name string, args any, opts ...*TaskCallOptions) 
 	return &r, nil
 }
 
-// WaitForTask polls tasks/get until the task reaches a terminal state or
-// the context is cancelled. Returns the final task info.
+// WaitForTaskV1 polls tasks/get until the v1 task reaches a terminal state
+// or the context is cancelled. Returns the final task info.
 //
 // Use pollInterval of 0 for a 1-second default. The context controls
 // the overall timeout — use context.WithTimeout for deadline-based waiting.
-//
-// This is a convenience wrapper around GetTask for the common pattern
-// of polling until completion.
-func WaitForTask(ctx context.Context, c *Client, taskID string, pollInterval time.Duration) (*core.GetTaskResultV1, error) {
+func WaitForTaskV1(ctx context.Context, c *Client, taskID string, pollInterval time.Duration) (*core.GetTaskResultV1, error) {
 	if pollInterval <= 0 {
 		pollInterval = 1 * time.Second
 	}
 	for {
-		got, err := GetTask(c, taskID)
+		got, err := GetTaskV1(c, taskID)
 		if err != nil {
 			return nil, err
 		}

--- a/examples/tasks/walkthrough.go
+++ b/examples/tasks/walkthrough.go
@@ -131,7 +131,7 @@ func runDemo() {
 		DashedArrow("Server", "Host", "{taskId, status: working, ttl, pollInterval}").
 		Note("slow_compute has taskSupport=optional. Sending the `task` hint tells the server to run it asynchronously. We get a taskId back immediately while the work runs in a background goroutine.").
 		Run(func() (result *demokit.StepResult) {
-			res, err := client.ToolCallAsTask(c, "slow_compute", map[string]any{
+			res, err := client.ToolCallAsTaskV1(c, "slow_compute", map[string]any{
 				"seconds": 3, "label": "demo",
 			})
 			if err != nil {
@@ -154,7 +154,7 @@ func runDemo() {
 		Run(func() (result *demokit.StepResult) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			final, err := client.WaitForTask(ctx, c, slowTaskID, 500*time.Millisecond)
+			final, err := client.WaitForTaskV1(ctx, c, slowTaskID, 500*time.Millisecond)
 			if err != nil {
 				fmt.Printf("    ERROR: %v\n", err)
 				return
@@ -169,7 +169,7 @@ func runDemo() {
 		DashedArrow("Server", "Host", "ToolResult").
 		Note("tasks/get returns task status only. To get the actual tool result (content blocks, isError flag, structured content), the host calls tasks/result with the same taskId.").
 		Run(func() (result *demokit.StepResult) {
-			tr, _, err := client.GetTaskPayload(c, slowTaskID)
+			tr, _, err := client.GetTaskPayloadV1(c, slowTaskID)
 			if err != nil {
 				fmt.Printf("    ERROR: %v\n", err)
 				return
@@ -203,14 +203,14 @@ func runDemo() {
 		DashedArrow("Server", "Host", "{status: failed, error: \"simulated failure\"}").
 		Note("Errors from required-task tools surface as a terminal status of `failed`. The host gets the taskId immediately, polls, and learns the task failed via the status field — no exception thrown on the polling call.").
 		Run(func() (result *demokit.StepResult) {
-			res, err := client.ToolCallAsTask(c, "failing_job", map[string]any{})
+			res, err := client.ToolCallAsTaskV1(c, "failing_job", map[string]any{})
 			if err != nil {
 				fmt.Printf("    ERROR: %v\n", err)
 				return
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
-			final, err := client.WaitForTask(ctx, c, res.Task.TaskID, 500*time.Millisecond)
+			final, err := client.WaitForTaskV1(ctx, c, res.Task.TaskID, 500*time.Millisecond)
 			if err != nil {
 				fmt.Printf("    ERROR: %v\n", err)
 				return
@@ -229,7 +229,7 @@ func runDemo() {
 		DashedArrow("Server", "Host", "{status: cancelled}").
 		Note("Tasks support cooperative cancellation. The server cancels the goroutine's context; tools that select on ctx.Done() exit cleanly. Status transitions to `cancelled`. mcpkit guards against terminal-to-terminal transitions so a tool finishing normally after cancel doesn't overwrite the cancelled status.").
 		Run(func() (result *demokit.StepResult) {
-			res, err := client.ToolCallAsTask(c, "slow_compute", map[string]any{
+			res, err := client.ToolCallAsTaskV1(c, "slow_compute", map[string]any{
 				"seconds": 10, "label": "to-cancel",
 			})
 			if err != nil {
@@ -241,14 +241,14 @@ func runDemo() {
 
 			time.Sleep(500 * time.Millisecond)
 			fmt.Printf("    Cancelling ...\n")
-			if _, err := client.CancelTask(c, cancelTaskID); err != nil {
+			if _, err := client.CancelTaskV1(c, cancelTaskID); err != nil {
 				fmt.Printf("    ERROR: %v\n", err)
 				return
 			}
 
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
-			final, err := client.WaitForTask(ctx, c, cancelTaskID, 200*time.Millisecond)
+			final, err := client.WaitForTaskV1(ctx, c, cancelTaskID, 200*time.Millisecond)
 			if err != nil {
 				fmt.Printf("    ERROR: %v\n", err)
 				return

--- a/server/task_callbacks_test.go
+++ b/server/task_callbacks_test.go
@@ -53,13 +53,13 @@ func TestTaskCallbacksGetTask(t *testing.T) {
 	c := connectClient(t, srv)
 
 	// Create a task.
-	created, err := client.ToolCallAsTask(c, "proxy-job", map[string]any{})
+	created, err := client.ToolCallAsTaskV1(c, "proxy-job", map[string]any{})
 	if err != nil {
 		t.Fatalf("ToolCallAsTask: %v", err)
 	}
 
 	// Poll via tasks/get — should hit the custom callback.
-	got, err := client.GetTask(c, created.Task.TaskID)
+	got, err := client.GetTaskV1(c, created.Task.TaskID)
 	if err != nil {
 		t.Fatalf("GetTask: %v", err)
 	}
@@ -107,7 +107,7 @@ func TestTaskCallbacksGetResult(t *testing.T) {
 	c := connectClient(t, srv)
 
 	// Create task — tool returns immediately, task completes fast.
-	created, err := client.ToolCallAsTask(c, "proxy-result", map[string]any{})
+	created, err := client.ToolCallAsTaskV1(c, "proxy-result", map[string]any{})
 	if err != nil {
 		t.Fatalf("ToolCallAsTask: %v", err)
 	}
@@ -115,13 +115,13 @@ func TestTaskCallbacksGetResult(t *testing.T) {
 	// Wait for terminal state via tasks/get polling.
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	_, err = client.WaitForTask(ctx, c, created.Task.TaskID, 50*time.Millisecond)
+	_, err = client.WaitForTaskV1(ctx, c, created.Task.TaskID, 50*time.Millisecond)
 	if err != nil {
 		t.Fatalf("WaitForTask: %v", err)
 	}
 
 	// Now call tasks/result — should hit the custom GetResult callback.
-	result, _, err := client.GetTaskPayload(c, created.Task.TaskID)
+	result, _, err := client.GetTaskPayloadV1(c, created.Task.TaskID)
 	if err != nil {
 		t.Fatalf("GetTaskPayload: %v", err)
 	}
@@ -169,7 +169,7 @@ func TestTaskCallbacksFallthrough(t *testing.T) {
 
 	c := connectClient(t, srv)
 
-	created, err := client.ToolCallAsTask(c, "fallthrough-job", map[string]any{})
+	created, err := client.ToolCallAsTaskV1(c, "fallthrough-job", map[string]any{})
 	if err != nil {
 		t.Fatalf("ToolCallAsTask: %v", err)
 	}
@@ -177,10 +177,10 @@ func TestTaskCallbacksFallthrough(t *testing.T) {
 	// Wait for completion so the store has the task.
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	client.WaitForTask(ctx, c, created.Task.TaskID, 50*time.Millisecond)
+	client.WaitForTaskV1(ctx, c, created.Task.TaskID, 50*time.Millisecond)
 
 	// Poll via tasks/get — callback returns false, so store handles it.
-	got, err := client.GetTask(c, created.Task.TaskID)
+	got, err := client.GetTaskV1(c, created.Task.TaskID)
 	if err != nil {
 		t.Fatalf("GetTask: %v", err)
 	}
@@ -200,13 +200,13 @@ func TestTaskCallbacksNoCallbacks(t *testing.T) {
 	srv, unblock := newTaskServer(t) // uses default tools, no callbacks
 	c := connectClient(t, srv)
 
-	created, err := client.ToolCallAsTask(c, "slow", map[string]any{"data": "x"})
+	created, err := client.ToolCallAsTaskV1(c, "slow", map[string]any{"data": "x"})
 	if err != nil {
 		t.Fatalf("ToolCallAsTask: %v", err)
 	}
 
 	// Should still work via TaskStore.
-	got, err := client.GetTask(c, created.Task.TaskID)
+	got, err := client.GetTaskV1(c, created.Task.TaskID)
 	if err != nil {
 		t.Fatalf("GetTask: %v", err)
 	}

--- a/server/tasks_v1_test.go
+++ b/server/tasks_v1_test.go
@@ -124,7 +124,7 @@ func TestTaskFullLifecycle(t *testing.T) {
 	c := connectClient(t, srv)
 
 	// 1. Create task via tools/call with task hint.
-	created, err := client.ToolCallAsTask(c, "slow", map[string]any{"data": "hello"})
+	created, err := client.ToolCallAsTaskV1(c, "slow", map[string]any{"data": "hello"})
 	if err != nil {
 		t.Fatalf("ToolCallAsTask: %v", err)
 	}
@@ -136,7 +136,7 @@ func TestTaskFullLifecycle(t *testing.T) {
 	}
 
 	// 2. Poll — should still be working.
-	got, err := client.GetTask(c, created.Task.TaskID)
+	got, err := client.GetTaskV1(c, created.Task.TaskID)
 	if err != nil {
 		t.Fatalf("GetTask: %v", err)
 	}
@@ -145,7 +145,7 @@ func TestTaskFullLifecycle(t *testing.T) {
 	}
 
 	// 3. List — should include our task.
-	list, err := client.ListTasks(c, "")
+	list, err := client.ListTasksV1(c, "")
 	if err != nil {
 		t.Fatalf("ListTasks: %v", err)
 	}
@@ -162,7 +162,7 @@ func TestTaskFullLifecycle(t *testing.T) {
 	// 4. Unblock the tool and fetch the result.
 	unblock <- struct{}{}
 
-	result, taskID, err := client.GetTaskPayload(c, created.Task.TaskID)
+	result, taskID, err := client.GetTaskPayloadV1(c, created.Task.TaskID)
 	if err != nil {
 		t.Fatalf("GetTaskPayload: %v", err)
 	}
@@ -179,12 +179,12 @@ func TestTaskCancel(t *testing.T) {
 	srv, _ := newTaskServer(t) // don't unblock — tool stays blocked
 	c := connectClient(t, srv)
 
-	created, err := client.ToolCallAsTask(c, "slow", map[string]any{"data": "cancel-me"})
+	created, err := client.ToolCallAsTaskV1(c, "slow", map[string]any{"data": "cancel-me"})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	cancelled, err := client.CancelTask(c, created.Task.TaskID)
+	cancelled, err := client.CancelTaskV1(c, created.Task.TaskID)
 	if err != nil {
 		t.Fatalf("CancelTask: %v", err)
 	}
@@ -193,7 +193,7 @@ func TestTaskCancel(t *testing.T) {
 	}
 
 	// Poll after cancel — should still be cancelled.
-	got, err := client.GetTask(c, created.Task.TaskID)
+	got, err := client.GetTaskV1(c, created.Task.TaskID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -207,7 +207,7 @@ func TestTaskFailedTool(t *testing.T) {
 	srv, _ := newTaskServer(t)
 	c := connectClient(t, srv)
 
-	created, err := client.ToolCallAsTask(c, "fail-async", nil)
+	created, err := client.ToolCallAsTaskV1(c, "fail-async", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -215,7 +215,7 @@ func TestTaskFailedTool(t *testing.T) {
 	// The tool fails immediately, so poll until terminal.
 	var info core.TaskInfo
 	for i := 0; i < 20; i++ {
-		got, err := client.GetTask(c, created.Task.TaskID)
+		got, err := client.GetTaskV1(c, created.Task.TaskID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -303,14 +303,14 @@ func TestTaskMultipleConcurrent(t *testing.T) {
 	const n = 5
 	var taskIDs []string
 	for i := 0; i < n; i++ {
-		created, err := client.ToolCallAsTask(c, "slow", map[string]any{"data": fmt.Sprintf("t%d", i)})
+		created, err := client.ToolCallAsTaskV1(c, "slow", map[string]any{"data": fmt.Sprintf("t%d", i)})
 		if err != nil {
 			t.Fatal(err)
 		}
 		taskIDs = append(taskIDs, created.Task.TaskID)
 	}
 
-	list, err := client.ListTasks(c, "")
+	list, err := client.ListTasksV1(c, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -319,7 +319,7 @@ func TestTaskMultipleConcurrent(t *testing.T) {
 	}
 
 	for _, id := range taskIDs {
-		_, err := client.CancelTask(c, id)
+		_, err := client.CancelTaskV1(c, id)
 		if err != nil {
 			t.Errorf("cancel %s: %v", id, err)
 		}
@@ -332,7 +332,7 @@ func TestTaskCustomTTL(t *testing.T) {
 	defer close(unblock)
 	c := connectClient(t, srv)
 
-	created, err := client.ToolCallAsTask(c, "slow", map[string]any{"data": "x"}, &client.TaskCallOptions{TTL: 60000})
+	created, err := client.ToolCallAsTaskV1(c, "slow", map[string]any{"data": "x"}, &client.TaskCallOptionsV1{TTL: 60000})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -347,7 +347,7 @@ func TestTaskGetNotFound(t *testing.T) {
 	defer close(unblock)
 	c := connectClient(t, srv)
 
-	_, err := client.GetTask(c, "nonexistent-id")
+	_, err := client.GetTaskV1(c, "nonexistent-id")
 	if err == nil {
 		t.Fatal("expected error for nonexistent task")
 	}
@@ -358,10 +358,10 @@ func TestTaskCancelAlreadyTerminal(t *testing.T) {
 	srv, _ := newTaskServer(t)
 	c := connectClient(t, srv)
 
-	created, _ := client.ToolCallAsTask(c, "slow", map[string]any{"data": "x"})
-	client.CancelTask(c, created.Task.TaskID)
+	created, _ := client.ToolCallAsTaskV1(c, "slow", map[string]any{"data": "x"})
+	client.CancelTaskV1(c, created.Task.TaskID)
 
-	_, err := client.CancelTask(c, created.Task.TaskID)
+	_, err := client.CancelTaskV1(c, created.Task.TaskID)
 	if err == nil {
 		t.Fatal("expected error cancelling already-terminal task")
 	}
@@ -410,13 +410,13 @@ func TestTaskResultAfterCompletion(t *testing.T) {
 	srv, unblock := newTaskServer(t)
 	c := connectClient(t, srv)
 
-	created, _ := client.ToolCallAsTask(c, "slow", map[string]any{"data": "done"})
+	created, _ := client.ToolCallAsTaskV1(c, "slow", map[string]any{"data": "done"})
 
 	unblock <- struct{}{}
 
 	var completed bool
 	for i := 0; i < 20; i++ {
-		got, _ := client.GetTask(c, created.Task.TaskID)
+		got, _ := client.GetTaskV1(c, created.Task.TaskID)
 		if got.Status == core.TaskCompleted {
 			completed = true
 			break
@@ -427,7 +427,7 @@ func TestTaskResultAfterCompletion(t *testing.T) {
 		t.Fatal("task did not complete in time")
 	}
 
-	result, _, err := client.GetTaskPayload(c, created.Task.TaskID)
+	result, _, err := client.GetTaskPayloadV1(c, created.Task.TaskID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -448,7 +448,7 @@ func TestTaskProgressCounter(t *testing.T) {
 	done := make(chan struct{})
 	for i := 0; i < n; i++ {
 		go func() {
-			created, err := client.ToolCallAsTask(c, "slow", map[string]any{"data": "x"})
+			created, err := client.ToolCallAsTaskV1(c, "slow", map[string]any{"data": "x"})
 			if err == nil {
 				if ids[created.Task.TaskID] {
 					collisions.Add(1)
@@ -567,7 +567,7 @@ func TestTasksGetFlatWireFormat(t *testing.T) {
 	defer close(unblock)
 	c := connectClient(t, srv)
 
-	created, err := client.ToolCallAsTask(c, "slow", map[string]any{"data": "flat"})
+	created, err := client.ToolCallAsTaskV1(c, "slow", map[string]any{"data": "flat"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -595,7 +595,7 @@ func TestTasksCancelFlatWireFormat(t *testing.T) {
 	srv, _ := newTaskServer(t)
 	c := connectClient(t, srv)
 
-	created, _ := client.ToolCallAsTask(c, "slow", map[string]any{"data": "x"})
+	created, _ := client.ToolCallAsTaskV1(c, "slow", map[string]any{"data": "x"})
 
 	result, err := c.Call("tasks/cancel", map[string]any{"taskId": created.Task.TaskID})
 	if err != nil {
@@ -619,12 +619,12 @@ func TestTasksResultRelatedTask(t *testing.T) {
 	srv, unblock := newTaskServer(t)
 	c := connectClient(t, srv)
 
-	created, _ := client.ToolCallAsTask(c, "slow", map[string]any{"data": "meta"})
+	created, _ := client.ToolCallAsTaskV1(c, "slow", map[string]any{"data": "meta"})
 	unblock <- struct{}{}
 
 	// Wait for completion.
 	for i := 0; i < 20; i++ {
-		got, _ := client.GetTask(c, created.Task.TaskID)
+		got, _ := client.GetTaskV1(c, created.Task.TaskID)
 		if got.Status.IsTerminal() {
 			break
 		}
@@ -680,7 +680,7 @@ func TestTaskPanicRecovery(t *testing.T) {
 	RegisterTasksV1(TasksConfigV1{Server: srv})
 	c := connectClient(t, srv)
 
-	created, err := client.ToolCallAsTask(c, "panic-tool", nil)
+	created, err := client.ToolCallAsTaskV1(c, "panic-tool", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -688,7 +688,7 @@ func TestTaskPanicRecovery(t *testing.T) {
 	// Poll until terminal.
 	var info core.TaskInfo
 	for i := 0; i < 20; i++ {
-		got, err := client.GetTask(c, created.Task.TaskID)
+		got, err := client.GetTaskV1(c, created.Task.TaskID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -713,14 +713,14 @@ func TestTaskResultForFailedTask(t *testing.T) {
 	srv, _ := newTaskServer(t)
 	c := connectClient(t, srv)
 
-	created, err := client.ToolCallAsTask(c, "fail-async", nil)
+	created, err := client.ToolCallAsTaskV1(c, "fail-async", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Wait for task to fail.
 	for i := 0; i < 20; i++ {
-		got, _ := client.GetTask(c, created.Task.TaskID)
+		got, _ := client.GetTaskV1(c, created.Task.TaskID)
 		if got.Status.IsTerminal() {
 			break
 		}
@@ -728,7 +728,7 @@ func TestTaskResultForFailedTask(t *testing.T) {
 	}
 
 	// tasks/result should return a ToolResult, not an error.
-	result, relatedID, err := client.GetTaskPayload(c, created.Task.TaskID)
+	result, relatedID, err := client.GetTaskPayloadV1(c, created.Task.TaskID)
 	if err != nil {
 		t.Fatalf("tasks/result should not return error for failed task, got: %v", err)
 	}
@@ -746,19 +746,19 @@ func TestTaskResultForCancelledTask(t *testing.T) {
 	srv, _ := newTaskServer(t)
 	c := connectClient(t, srv)
 
-	created, err := client.ToolCallAsTask(c, "slow", map[string]any{"data": "cancel-me"})
+	created, err := client.ToolCallAsTaskV1(c, "slow", map[string]any{"data": "cancel-me"})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Cancel immediately.
-	_, err = client.CancelTask(c, created.Task.TaskID)
+	_, err = client.CancelTaskV1(c, created.Task.TaskID)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// tasks/result should return a ToolResult, not an error.
-	result, relatedID, err := client.GetTaskPayload(c, created.Task.TaskID)
+	result, relatedID, err := client.GetTaskPayloadV1(c, created.Task.TaskID)
 	if err != nil {
 		t.Fatalf("tasks/result should not return error for cancelled task, got: %v", err)
 	}
@@ -853,7 +853,7 @@ func TestGetTaskContextAvailableForAsync(t *testing.T) {
 	RegisterTasksV1(TasksConfigV1{Server: srv})
 	c := connectClient(t, srv)
 
-	created, err := client.ToolCallAsTask(c, "check-ctx", nil)
+	created, err := client.ToolCallAsTaskV1(c, "check-ctx", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -909,7 +909,7 @@ func TestTaskInputRequiredTransition(t *testing.T) {
 	RegisterTasksV1(TasksConfigV1{Server: srv})
 	c := connectClient(t, srv)
 
-	created, err := client.ToolCallAsTask(c, "needs-input", nil)
+	created, err := client.ToolCallAsTaskV1(c, "needs-input", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -922,7 +922,7 @@ func TestTaskInputRequiredTransition(t *testing.T) {
 	}
 
 	// Poll tasks/get — should see input_required.
-	got, err := client.GetTask(c, created.Task.TaskID)
+	got, err := client.GetTaskV1(c, created.Task.TaskID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -935,7 +935,7 @@ func TestTaskInputRequiredTransition(t *testing.T) {
 
 	// Wait for completion.
 	for i := 0; i < 20; i++ {
-		got, _ = client.GetTask(c, created.Task.TaskID)
+		got, _ = client.GetTaskV1(c, created.Task.TaskID)
 		if got.Status.IsTerminal() {
 			break
 		}
@@ -952,7 +952,7 @@ func TestTaskResultConcurrentCancel(t *testing.T) {
 	srv, _ := newTaskServer(t) // slow tool blocks on channel
 	c := connectClient(t, srv)
 
-	created, err := client.ToolCallAsTask(c, "slow", map[string]any{"data": "x"})
+	created, err := client.ToolCallAsTaskV1(c, "slow", map[string]any{"data": "x"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -965,7 +965,7 @@ func TestTaskResultConcurrentCancel(t *testing.T) {
 	}
 	ch := make(chan resultOut, 1)
 	go func() {
-		r, tid, err := client.GetTaskPayload(c, created.Task.TaskID)
+		r, tid, err := client.GetTaskPayloadV1(c, created.Task.TaskID)
 		ch <- resultOut{r, tid, err}
 	}()
 
@@ -973,7 +973,7 @@ func TestTaskResultConcurrentCancel(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	// Cancel the task — should unblock tasks/result.
-	_, err = client.CancelTask(c, created.Task.TaskID)
+	_, err = client.CancelTaskV1(c, created.Task.TaskID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1015,7 +1015,7 @@ func TestQueueCleanupOnCancel(t *testing.T) {
 	RegisterTasksV1(TasksConfigV1{Server: srv, Store: store, MessageQueue: queue})
 	c := connectClient(t, srv)
 
-	created, err := client.ToolCallAsTask(c, "slow", nil)
+	created, err := client.ToolCallAsTaskV1(c, "slow", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1029,7 +1029,7 @@ func TestQueueCleanupOnCancel(t *testing.T) {
 	}, 0)
 
 	// Cancel via client — handler should drain the queue.
-	_, err = client.CancelTask(c, created.Task.TaskID)
+	_, err = client.CancelTaskV1(c, created.Task.TaskID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1107,7 +1107,7 @@ func TestTaskElicitE2E(t *testing.T) {
 	))
 
 	// Create the task.
-	created, err := client.ToolCallAsTask(c, "confirm-action", map[string]any{"action": "deploy"})
+	created, err := client.ToolCallAsTaskV1(c, "confirm-action", map[string]any{"action": "deploy"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1115,7 +1115,7 @@ func TestTaskElicitE2E(t *testing.T) {
 	// GetTaskPayload blocks on tasks/result. During the long-poll, the handler
 	// proxies the elicitation to the client, the client responds, the tool
 	// completes, and we get the result.
-	result, relatedID, err := client.GetTaskPayload(c, created.Task.TaskID)
+	result, relatedID, err := client.GetTaskPayloadV1(c, created.Task.TaskID)
 	if err != nil {
 		t.Fatalf("GetTaskPayload: %v", err)
 	}
@@ -1187,12 +1187,12 @@ func TestTaskSampleE2E(t *testing.T) {
 		},
 	))
 
-	created, err := client.ToolCallAsTask(c, "write-haiku", map[string]any{"topic": "nature"})
+	created, err := client.ToolCallAsTaskV1(c, "write-haiku", map[string]any{"topic": "nature"})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	result, _, err := client.GetTaskPayload(c, created.Task.TaskID)
+	result, _, err := client.GetTaskPayloadV1(c, created.Task.TaskID)
 	if err != nil {
 		t.Fatalf("GetTaskPayload: %v", err)
 	}
@@ -1236,7 +1236,7 @@ func TestTaskTTLExpiryE2E(t *testing.T) {
 
 	// Wait for task to complete.
 	for i := 0; i < 20; i++ {
-		got, err := client.GetTask(c, taskID)
+		got, err := client.GetTaskV1(c, taskID)
 		if err != nil {
 			break // task might have been cleaned up already
 		}
@@ -1250,7 +1250,7 @@ func TestTaskTTLExpiryE2E(t *testing.T) {
 	time.Sleep(300 * time.Millisecond)
 
 	// Task should be gone.
-	_, err = client.GetTask(c, taskID)
+	_, err = client.GetTaskV1(c, taskID)
 	if err == nil {
 		t.Error("expected error — task should have been cleaned up after TTL expired")
 	}
@@ -1281,14 +1281,14 @@ func TestTaskProgressFromBackgroundNoPanic(t *testing.T) {
 	c := connectClient(t, srv)
 
 	// Create task (no GET SSE stream — just POST).
-	created, err := client.ToolCallAsTask(c, "progress-tool", nil)
+	created, err := client.ToolCallAsTaskV1(c, "progress-tool", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Wait for completion — should succeed, not fail with panic.
 	for i := 0; i < 20; i++ {
-		got, err := client.GetTask(c, created.Task.TaskID)
+		got, err := client.GetTaskV1(c, created.Task.TaskID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1333,13 +1333,13 @@ func TestTaskCancelStopsGoroutine(t *testing.T) {
 	RegisterTasksV1(TasksConfigV1{Server: srv})
 	c := connectClient(t, srv)
 
-	created, err := client.ToolCallAsTask(c, "long-task", nil)
+	created, err := client.ToolCallAsTaskV1(c, "long-task", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Cancel the task.
-	_, err = client.CancelTask(c, created.Task.TaskID)
+	_, err = client.CancelTaskV1(c, created.Task.TaskID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1382,13 +1382,13 @@ func TestTaskStatusNotificationOnComplete(t *testing.T) {
 		}
 	}))
 
-	created, err := client.ToolCallAsTask(c, "fast", nil)
+	created, err := client.ToolCallAsTaskV1(c, "fast", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Call tasks/result — this triggers the notification (Option 1).
-	client.GetTaskPayload(c, created.Task.TaskID)
+	client.GetTaskPayloadV1(c, created.Task.TaskID)
 
 	// Wait for the completion notification.
 	select {
@@ -1433,12 +1433,12 @@ func TestTaskStatusNotificationOnCancel(t *testing.T) {
 		}
 	}))
 
-	created, err := client.ToolCallAsTask(c, "blocking", nil)
+	created, err := client.ToolCallAsTaskV1(c, "blocking", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = client.CancelTask(c, created.Task.TaskID)
+	_, err = client.CancelTaskV1(c, created.Task.TaskID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1525,14 +1525,14 @@ func TestTaskDoubleCompletionRejected(t *testing.T) {
 	RegisterTasksV1(TasksConfigV1{Server: srv})
 	c := connectClient(t, srv)
 
-	created, err := client.ToolCallAsTask(c, "fast", nil)
+	created, err := client.ToolCallAsTaskV1(c, "fast", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Wait for completion.
 	for i := 0; i < 20; i++ {
-		got, _ := client.GetTask(c, created.Task.TaskID)
+		got, _ := client.GetTaskV1(c, created.Task.TaskID)
 		if got.Status.IsTerminal() {
 			break
 		}
@@ -1540,7 +1540,7 @@ func TestTaskDoubleCompletionRejected(t *testing.T) {
 	}
 
 	// First tasks/result succeeds.
-	result1, _, err := client.GetTaskPayload(c, created.Task.TaskID)
+	result1, _, err := client.GetTaskPayloadV1(c, created.Task.TaskID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1549,7 +1549,7 @@ func TestTaskDoubleCompletionRejected(t *testing.T) {
 	}
 
 	// Second tasks/result also succeeds (idempotent read — result is stored).
-	result2, _, err := client.GetTaskPayload(c, created.Task.TaskID)
+	result2, _, err := client.GetTaskPayloadV1(c, created.Task.TaskID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1566,7 +1566,7 @@ func TestWaitForTaskCompletes(t *testing.T) {
 	srv, unblock := newTaskServer(t)
 	c := connectClient(t, srv)
 
-	created, err := client.ToolCallAsTask(c, "slow", map[string]any{"data": "wait"})
+	created, err := client.ToolCallAsTaskV1(c, "slow", map[string]any{"data": "wait"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1577,7 +1577,7 @@ func TestWaitForTaskCompletes(t *testing.T) {
 		unblock <- struct{}{}
 	}()
 
-	got, err := client.WaitForTask(context.Background(), c, created.Task.TaskID, 50*time.Millisecond)
+	got, err := client.WaitForTaskV1(context.Background(), c, created.Task.TaskID, 50*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1592,7 +1592,7 @@ func TestWaitForTaskCancelled(t *testing.T) {
 	srv, _ := newTaskServer(t)
 	c := connectClient(t, srv)
 
-	created, err := client.ToolCallAsTask(c, "slow", map[string]any{"data": "wait-cancel"})
+	created, err := client.ToolCallAsTaskV1(c, "slow", map[string]any{"data": "wait-cancel"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1600,10 +1600,10 @@ func TestWaitForTaskCancelled(t *testing.T) {
 	// Cancel after a short delay.
 	go func() {
 		time.Sleep(100 * time.Millisecond)
-		client.CancelTask(c, created.Task.TaskID)
+		client.CancelTaskV1(c, created.Task.TaskID)
 	}()
 
-	got, err := client.WaitForTask(context.Background(), c, created.Task.TaskID, 50*time.Millisecond)
+	got, err := client.WaitForTaskV1(context.Background(), c, created.Task.TaskID, 50*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1634,7 +1634,7 @@ func TestToolCallAsTaskWithProgressToken(t *testing.T) {
 	RegisterTasksV1(TasksConfigV1{Server: srv})
 	c := connectClient(t, srv)
 
-	_, err := client.ToolCallAsTask(c, "token-check", nil, &client.TaskCallOptions{
+	_, err := client.ToolCallAsTaskV1(c, "token-check", nil, &client.TaskCallOptionsV1{
 		ProgressToken: "client-token-123",
 	})
 	if err != nil {
@@ -1658,7 +1658,7 @@ func TestToolCallAsTaskWithPollInterval(t *testing.T) {
 	defer close(unblock)
 	c := connectClient(t, srv)
 
-	created, err := client.ToolCallAsTask(c, "slow", map[string]any{"data": "x"}, &client.TaskCallOptions{
+	created, err := client.ToolCallAsTaskV1(c, "slow", map[string]any{"data": "x"}, &client.TaskCallOptionsV1{
 		PollInterval: 2000,
 	})
 	if err != nil {
@@ -1676,7 +1676,7 @@ func TestWaitForTaskTimeout(t *testing.T) {
 	srv, _ := newTaskServer(t) // never unblock — task stays working forever
 	c := connectClient(t, srv)
 
-	created, err := client.ToolCallAsTask(c, "slow", map[string]any{"data": "stuck"})
+	created, err := client.ToolCallAsTaskV1(c, "slow", map[string]any{"data": "stuck"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1685,7 +1685,7 @@ func TestWaitForTaskTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 
-	_, err = client.WaitForTask(ctx, c, created.Task.TaskID, 50*time.Millisecond)
+	_, err = client.WaitForTaskV1(ctx, c, created.Task.TaskID, 50*time.Millisecond)
 	if err == nil {
 		t.Fatal("expected timeout error")
 	}
@@ -1709,7 +1709,7 @@ func TestIsToolTask(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := client.IsToolTask(tt.tool)
+			got := client.IsToolTaskV1(tt.tool)
 			if got != tt.expected {
 				t.Errorf("IsToolTask(%q) = %v, want %v", tt.tool.Name, got, tt.expected)
 			}


### PR DESCRIPTION
## Summary

Phase 6 of the SEP-2663 (Tasks Extension) plan in `PLAN.md`. Issues: #320 (SEP-2663), #321 (SEP-2322).

This PR adds the **v2 client helpers** companion to the server-side work in PRs #324 / #328 / #329. Two commits, intentionally split so `git log --follow` traces v1's lineage cleanly:

1. **72c8ad2** — `refactor: rename v1 client helpers to *V1` (git-tracked rename + V1 suffix)
2. **edf06e7** — `feat: SEP-2663 v2 task client helpers`

## Commit 1 — v1 split

- `git mv client/tasks.go → client/tasks_v1.go` (rename preserved).
- Public symbols suffixed `*V1`: `GetTaskV1`, `GetTaskPayloadV1`, `ListTasksV1`, `CancelTaskV1`, `ToolCallAsTaskV1`, `WaitForTaskV1`, `IsToolTaskV1`, `TaskCallOptionsV1`.
- Internal v1 wire-param types follow the same suffix convention (`getTaskParamsV1`, `taskParamV1`, ...) so commit 2's v2 client can reuse the unsuffixed names.
- All **91 v1 client call sites** updated across `server/tasks_v1_test.go`, `server/task_callbacks_test.go`, `examples/tasks/walkthrough.go`.
- No behavior change.

## Commit 2 — v2 client (new `client/tasks.go`)

Public API:
- **`ToolCall(c, name, args) → *ToolCallResult`** — polymorphic dispatch over the `tools/call` response. `ToolCallResult.Sync` is set for sync tools / immediate-result shortcuts; `ToolCallResult.Task` is set when the server elects to create a task (`resultType: "task"` discriminator). `IsTask()` helper for branch readability.
- **`GetTask(c, taskID, opts...) → *core.DetailedTask`** — idempotent read of the v2 task surface. Inlined `result` / `error` / `inputRequests` / `requestState` per status. Optional `TaskOptions{RequestState}` for SEP-2322 echo.
- **`UpdateTask(c, req) error`** — SEP-2663 resume path. Takes the typed `core.UpdateTaskRequest` (TaskID + InputResponses + RequestState). Client-side guard for missing TaskID. Returns nil on the empty ack.
- **`CancelTask(c, taskID, opts...) error`** — SEP-2663 ack-only cancel.
- **`WaitForTask(ctx, c, taskID, opts...) → *core.DetailedTask`** — poll loop with three-tier interval selection (caller override, server's `PollIntervalMilliseconds` hint, 1s default), 30s ceiling so a misconfigured server can't park us indefinitely. Threads `requestState` echo automatically across iterations.

Removed (vs v1):
- `ToolCallAsTask` — v2 has no client-side task hint (server decides unilaterally).
- `GetTaskPayload` — `tasks/result` is gone in v2; `DetailedTask` inlines the result.
- `ListTasks` — `tasks/list` is gone in v2.

Notes:
- `input_required` is intentionally **not** terminal in `WaitForTask`. Callers driving the MRTR loop should poll explicitly and call `UpdateTask` between iterations (the `FullElicitLoop` test models this exact shape).

## Tests — `client/tasks_test.go` (+9)

Drive everything against an in-process v2 server with `WithTasksExtension()`:
- `TestToolCall_SyncResult` / `_TaskResult` — polymorphic dispatch covers both branches.
- `TestGetTask` — DetailedTask shape + requestState present.
- `TestWaitForTask` — terminal + inlined result.
- `TestWaitForTask_HonorsServerPollHint` — doesn't busy-loop when the server suggests an interval.
- `TestWaitForTask_RespectsCallerOverride` — caller's `PollInterval` beats the server hint.
- `TestUpdateTask_FullElicitLoop` — end-to-end SEP-2663 elicit → update → complete via the v2 helpers (drives the `confirm-delete` fixture through `TaskElicit`).
- `TestUpdateTask_MissingTaskID` — client-side guard.
- `TestCancelTask` — ack + status transitions to cancelled.

## What's NOT in this PR
- **Phase 7** — example + conformance rework. The v1 walkthrough was updated mechanically (renames only); the v2 walkthrough hasn't been switched to the new `client.ToolCall` polymorphic helper yet, and the conformance suite still asserts pre-SEP-2663 shapes.
- **Phase 8** — backcompat bridge.

## Test plan
- [x] `make test` — core / server / client / testutil all green.
- [x] 9 new client tests covering the v2 helpers + polymorphic dispatch.
- [x] `make testconf-tasks` — v1 conformance unaffected (path frozen, just renamed).
- [ ] `make testconf-tasks-v2` — still expected to regress (extension gating + shape changes from Phases 2-3-4-5); reworked in Phase 7.