### PR TITLE
feat: SEP-2663 example + 26/26 v2 conformance (Phase 7)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,10 +65,10 @@ testconf-tasks: ## Run MCP Tasks v1 conformance (builds + starts server, runs te
 
 testconf-tasks-v2: ## Run MCP Tasks v2 conformance (builds + starts server, runs tests, tears down)
 	@(cd examples/tasks-v2 && go build -o tasks-v2 .) && \
-	examples/tasks-v2/tasks-v2 -addr :18092 & PID=$$!; \
+	examples/tasks-v2/tasks-v2 --serve -addr :18092 & PID=$$!; \
 	sleep 1; \
 	(cd conformance && npm install --silent && \
-	SERVER_URL=http://localhost:18092/mcp npx tsx --test --test-name-pattern 'v2-(?!1[67])' tasks-v2/scenarios.test.ts); \
+	SERVER_URL=http://localhost:18092/mcp npx tsx --test tasks-v2/scenarios.test.ts); \
 	RC=$$?; kill $$PID 2>/dev/null; wait $$PID 2>/dev/null; exit $$RC
 
 testconf-elicitation: ## Run elicitation conformance suite (SEP-1036 URL mode + form, requires Node.js, target server must be running)

--- a/conformance/tasks-v2/scenarios.test.ts
+++ b/conformance/tasks-v2/scenarios.test.ts
@@ -1,32 +1,36 @@
 /**
- * MCP Tasks v2 Conformance Scenarios (SEP-2557)
+ * MCP Tasks v2 Conformance Scenarios (SEP-2663 / SEP-2322 / SEP-2575 / SEP-2243)
  *
- * Tests any MCP server that implements the Tasks v2 protocol as proposed
- * in SEP-2557 (https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2557).
- *
- * SEP STATUS: Draft, targeted for 2026-06-30-RC milestone.
- * These tests are written ahead of the spec being finalized. They will
- * evolve as the SEP is refined. All scenarios should FAIL today — no
- * v2 server implementation exists yet (red-before-green).
+ * Tests any MCP server that implements the Tasks v2 surface, evolving from
+ * the original SEP-2557 draft to the current shape:
+ *   - SEP-2663 — Tasks Extension (https://github.com/modelcontextprotocol/specification/pull/2663)
+ *   - SEP-2322 — MRTR base types (inputRequests/inputResponses, requestState)
+ *   - SEP-2575 — per-request capabilities via _meta.io.modelcontextprotocol/clientCapabilities
+ *   - SEP-2243 — Mcp-Name HTTP response header
  *
  * UPSTREAM PORTING NOTE: When porting to the conformance repo, these
  * individual test() calls should be consolidated into ~4 scenarios with
  * multiple ConformanceCheck entries each, per AGENTS.md: "one scenario
  * with many checks beats 10 scenarios with one check each." The current
  * structure is for readability during spec review. Each check will need
- * specReferences pointing to the relevant SEP-2557 sections.
+ * specReferences pointing to the relevant SEP-2663 sections.
  *
- * Key differences from v1 (spec 2025-11-25):
- *   - tasks/result REMOVED — result inlined into tasks/get
- *   - tasks/list REMOVED — sessions going away
- *   - No client `task` param — server decides unilaterally
- *   - TTL in seconds (not milliseconds)
- *   - requestState for stateless deployments
- *   - inputRequests/inputResponses inline in tasks/get (MRTR model)
- *   - tasks/cancel required (not optional)
- *   - No capability advertisement — tasks are core protocol
- *   - resultType: "task" discriminator on CreateTaskResult
- *   - "failed" status = JSON-RPC protocol error only; tool errors = "completed" + isError
+ * Key wire-format differences from v1 (MCP spec 2025-11-25):
+ *   - Tasks is an EXTENSION (io.modelcontextprotocol/tasks) advertised under
+ *     capabilities.extensions — clients MUST declare support during initialize
+ *     (or per-request via SEP-2575 _meta) for the server to accept the surface.
+ *   - tasks/result REMOVED — result inlined into tasks/get's DetailedTask.
+ *   - tasks/list REMOVED.
+ *   - tasks/update is the new MRTR resume path (delivers inputResponses).
+ *   - tasks/cancel returns an EMPTY {} ack (no task state).
+ *   - No client `task` param — server decides unilaterally.
+ *   - Wire fields renamed: ttlSeconds, pollIntervalMilliseconds. parentTaskId removed.
+ *   - inputRequests is a MAP keyed by server-minted opaque ids; inputResponses
+ *     mirrors the same keys via tasks/update.
+ *   - resultType: "task" discriminator on CreateTaskResult; absence => sync ToolResult.
+ *   - "failed" status = JSON-RPC protocol error only; tool errors = "completed" + isError.
+ *   - Mcp-Name HTTP response header carries the new taskId on task-creating
+ *     responses (SEP-2243).
  *
  * Usage:
  *   cd conformance && npm install
@@ -37,7 +41,7 @@
  *   - slow_compute — async, sleeps N seconds, returns result
  *   - failing_job — async, always fails after 1s (tool-level error, not protocol error)
  *   - protocol_error_job — async, fails with a JSON-RPC protocol error
- *   - confirm_delete — async, elicitation via inputRequests model
+ *   - confirm_delete — async, elicitation via the SEP-2663 inputRequests / tasks/update flow
  */
 
 import { describe, test, before, after } from 'node:test';
@@ -46,42 +50,72 @@ import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/cli
 import { assertJsonRpcError } from '../common/helpers.js';
 
 const SERVER_URL = process.env.SERVER_URL || 'http://localhost:8080/mcp';
+const TASKS_EXTENSION_ID = 'io.modelcontextprotocol/tasks';
 
 let client: Client;
-let sessionId: string;
+let sessionId: string;          // raw session that DECLARES the tasks extension
+let unsupportedSessionId: string; // raw session that does NOT declare the extension (for gating tests)
 let nextId = 1;
 
-before(async () => {
-    const transport = new StreamableHTTPClientTransport(new URL(SERVER_URL));
-    // v2: No tasks capability negotiation — tasks are core protocol.
-    // Client still declares elicitation/sampling for inputRequests handling.
-    client = new Client(
-        { name: 'mcp-tasks-v2-conformance', version: '1.0.0' },
-        { capabilities: { elicitation: {}, sampling: {} } }
-    );
-    await client.connect(transport);
-
-    // Extract session ID for raw requests (the SDK stores it internally).
-    // We use raw fetch for tasks/get and tools/call because the SDK's
-    // built-in Zod schemas strip v2-only fields like `result` and `error`.
+// initRawSession runs the raw initialize handshake against SERVER_URL with the
+// supplied capabilities and returns the session id from Mcp-Session-Id, after
+// firing the notifications/initialized to make the session usable. We bypass
+// the SDK because its built-in Zod schemas strip v2-only fields (result,
+// error, inputRequests, etc.) from responses.
+async function initRawSession(capabilities: Record<string, unknown>): Promise<string> {
     const initResp = await fetch(SERVER_URL, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
         body: JSON.stringify({
             jsonrpc: '2.0', id: 'init-raw', method: 'initialize',
-            params: { protocolVersion: '2025-11-25',
-                      clientInfo: { name: 'raw-init', version: '1.0' },
-                      capabilities: {} }
-        })
+            params: {
+                protocolVersion: '2025-11-25',
+                clientInfo: { name: 'raw-init', version: '1.0' },
+                capabilities,
+            },
+        }),
     });
-    sessionId = initResp.headers.get('mcp-session-id') || '';
-    // Send initialized notification
+    const sid = initResp.headers.get('mcp-session-id') || '';
+    if (!sid) throw new Error('initialize response missing Mcp-Session-Id');
+
     await fetch(SERVER_URL, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'Accept': 'application/json',
-                   'Mcp-Session-Id': sessionId },
-        body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' })
+        headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+            'Mcp-Session-Id': sid,
+        },
+        body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }),
     });
+    return sid;
+}
+
+before(async () => {
+    const transport = new StreamableHTTPClientTransport(new URL(SERVER_URL));
+    // v2: declare the io.modelcontextprotocol/tasks extension so the server
+    // gates the task surface ON for this client. Also declare elicitation /
+    // sampling so v1-style notifications round-trip.
+    client = new Client(
+        { name: 'mcp-tasks-v2-conformance', version: '1.0.0' },
+        {
+            capabilities: {
+                elicitation: {},
+                sampling: {},
+                extensions: { [TASKS_EXTENSION_ID]: {} },
+            },
+        },
+    );
+    await client.connect(transport);
+
+    // Two raw sessions: one that declares the tasks extension (used by every
+    // happy-path scenario) and one that doesn't (used by the negative-gate
+    // scenarios v2-23 / v2-25-no-meta).
+    sessionId = await initRawSession({
+        elicitation: {},
+        sampling: {},
+        extensions: { [TASKS_EXTENSION_ID]: {} },
+    });
+    unsupportedSessionId = await initRawSession({});
 });
 
 after(async () => {
@@ -97,16 +131,33 @@ after(async () => {
  * Parses SSE `data:` lines if the response is text/event-stream, or
  * plain JSON otherwise.
  */
-async function rawRequest(method: string, params: any): Promise<any> {
+async function rawRequest(method: string, params: any, opts: { sessionId?: string; meta?: any } = {}): Promise<any> {
+    const result = await rawRequestFull(method, params, opts);
+    return result.result;
+}
+
+/**
+ * Like rawRequest, but also returns the raw fetch Response so callers can
+ * inspect transport-level headers (e.g., SEP-2243 Mcp-Name). Most scenarios
+ * only need the JSON-RPC body; the Mcp-Name scenario is the outlier that
+ * needs the headers.
+ */
+async function rawRequestFull(
+    method: string,
+    params: any,
+    opts: { sessionId?: string; meta?: any } = {},
+): Promise<{ result: any; response: Response }> {
     const id = nextId++;
+    const sid = opts.sessionId ?? sessionId;
+    const requestParams = opts.meta ? { ...params, _meta: opts.meta } : params;
     const resp = await fetch(SERVER_URL, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
             'Accept': 'text/event-stream, application/json',
-            'Mcp-Session-Id': sessionId,
+            'Mcp-Session-Id': sid,
         },
-        body: JSON.stringify({ jsonrpc: '2.0', id, method, params }),
+        body: JSON.stringify({ jsonrpc: '2.0', id, method, params: requestParams }),
     });
     const ct = resp.headers.get('content-type') || '';
     let body: any;
@@ -119,7 +170,6 @@ async function rawRequest(method: string, params: any): Promise<any> {
                 const payload = trimmed.slice(5).trimStart();
                 if (payload.startsWith('{')) {
                     const parsed = JSON.parse(payload);
-                    // Find the response matching our request ID.
                     if (parsed.id === id) {
                         body = parsed;
                         break;
@@ -137,7 +187,7 @@ async function rawRequest(method: string, params: any): Promise<any> {
         err.data = body.error.data;
         throw err;
     }
-    return body.result;
+    return { result: body.result, response: resp };
 }
 
 /**
@@ -151,18 +201,30 @@ async function callTool(toolName: string, args: Record<string, unknown>): Promis
 }
 
 /**
- * Call tasks/get with optional requestState and inputResponses.
- * This is the v2 consolidated polling endpoint.
+ * Call tasks/get. Idempotent read of the v2 task surface — returns DetailedTask
+ * with inlined result / error / inputRequests / requestState per status.
+ * SEP-2663 moved input-response delivery off this method onto tasks/update;
+ * see updateTask below.
  */
-async function getTask(taskId: string, opts: { requestState?: string; inputResponses?: Record<string, any> } = {}): Promise<any> {
+async function getTask(taskId: string, opts: { requestState?: string } = {}): Promise<any> {
     const params: any = { taskId };
     if (opts.requestState !== undefined) {
         params.requestState = opts.requestState;
     }
-    if (opts.inputResponses !== undefined) {
-        params.inputResponses = opts.inputResponses;
-    }
     return rawRequest('tasks/get', params);
+}
+
+/**
+ * Call tasks/update — SEP-2663 MRTR resume path. Delivers inputResponses
+ * keyed to whatever inputRequests the server emitted. Returns the empty
+ * {} ack.
+ */
+async function updateTask(taskId: string, inputResponses: Record<string, any>, requestState?: string): Promise<any> {
+    const params: any = { taskId, inputResponses };
+    if (requestState !== undefined) {
+        params.requestState = requestState;
+    }
+    return rawRequest('tasks/update', params);
 }
 
 /** Poll tasks/get until a terminal state via raw requests. */
@@ -228,7 +290,7 @@ function assertCompletedResult(task: any, label: string) {
 // Scenarios
 // ============================================================================
 
-describe('MCP Tasks v2 Conformance (SEP-2557)', () => {
+describe('MCP Tasks v2 Conformance (SEP-2663)', () => {
 
     // ========================================================================
     // Scenario 01: Sync tool call — no task created
@@ -350,19 +412,25 @@ describe('MCP Tasks v2 Conformance (SEP-2557)', () => {
     });
 
     // ========================================================================
-    // Scenario 07: tasks/cancel (cooperative, required)
+    // Scenario 07: tasks/cancel returns empty ack; status settles to cancelled
     //
-    // In v2, tasks/cancel is REQUIRED (not optional like v1).
+    // SEP-2663 changed the cancel response from a rich task envelope to an
+    // empty {} ack — the client observes the resulting "cancelled" status
+    // via the next tasks/get. This is more honest about the cooperative
+    // nature of cancellation: the response only acknowledges the request,
+    // not that the goroutine has stopped yet.
     // ========================================================================
-    test('v2-07: tasks/cancel returns cancelled status', async () => {
+    test('v2-07: tasks/cancel returns empty ack; status settles to cancelled', async () => {
         const result = await callTool('slow_compute', { seconds: 60, label: 'v2-cancel' });
         assertCreateTaskResult(result, 'v2-07 create');
         const taskId = result.task.taskId;
 
-        const cancelled = await cancelTask(taskId);
-        assert.equal(cancelled.status, 'cancelled', 'should be cancelled');
+        const cancelAck = await cancelTask(taskId);
+        // SEP-2663: cancel response is the empty {} ack (no task state).
+        assert.deepEqual(cancelAck, {},
+            `tasks/cancel should return empty {} ack; got ${JSON.stringify(cancelAck)}`);
 
-        // Confirm via tasks/get.
+        // Status settles to cancelled — observe via tasks/get.
         const task = await getTask(taskId);
         assert.equal(task.status, 'cancelled', 'poll after cancel should show cancelled');
     });
@@ -424,49 +492,51 @@ describe('MCP Tasks v2 Conformance (SEP-2557)', () => {
     });
 
     // ========================================================================
-    // Scenario 11: No tasks in initialize capabilities
+    // Scenario 11: tasks live under capabilities.extensions, not the v1
+    // capabilities.tasks slot
     //
-    // In v2, tasks are core protocol — not negotiated via capabilities.
-    // The server SHOULD NOT advertise tasks in initialize.capabilities.
+    // SEP-2663: tasks is an extension, NOT a top-level capability. The server
+    // MUST advertise it under capabilities.extensions[io.modelcontextprotocol/tasks]
+    // and MUST NOT use the v1 capabilities.tasks slot.
     //
-    // NOTE: Accessing server capabilities via private fields is fragile.
-    // The conformance repo may have a better mechanism for this check.
+    // NOTE: Accessing server capabilities via private fields is fragile —
+    // the mechanism varies by SDK version.
     // ========================================================================
-    test('v2-11: tasks not advertised in initialize capabilities', async () => {
-        // Access server capabilities — the mechanism varies by SDK version.
+    test('v2-11: tasks advertised under capabilities.extensions, not capabilities.tasks', async () => {
         const caps = (client as any)._serverCapabilities
             ?? (client as any).serverCapabilities
             ?? (client as any)._capabilities;
-        if (caps) {
-            assert.ok(!caps.tasks,
-                'v2 server should not advertise tasks in capabilities (tasks are core protocol)');
+        if (!caps) {
+            // SDK didn't expose capabilities — the conformance repo may have a
+            // better mechanism. Skip rather than failing on missing access.
+            return;
         }
-        // If we can't access capabilities, this check is a no-op.
-        // The conformance repo may have a better mechanism.
+        assert.ok(!caps.tasks,
+            'v2 server must NOT use the v1 capabilities.tasks slot (use capabilities.extensions instead)');
+        assert.ok(caps.extensions,
+            'v2 server must advertise capabilities.extensions');
+        assert.ok(caps.extensions[TASKS_EXTENSION_ID],
+            `v2 server must advertise the ${TASKS_EXTENSION_ID} extension under capabilities.extensions`);
     });
 
     // ========================================================================
-    // Scenario 12: TTL field present and in seconds
+    // Scenario 12: ttlSeconds field present and in seconds
     //
-    // v2 aligns TTL with SEP-2549: seconds, not milliseconds.
-    //
-    // NOTE: TTL units are purely convention — the schema alone can't
-    // distinguish seconds from milliseconds. The field may be renamed to
-    // `ttlSeconds` (pending SEP-2549 resolution). This test checks the
-    // value is reasonable for seconds but can't programmatically enforce
-    // the unit. Servers with very long TTLs (e.g., 24h = 86400s) will
-    // pass regardless of unit.
+    // SEP-2663 renamed the wire field from `ttl` to `ttlSeconds` (units are
+    // now part of the field name, no convention required). The legacy `ttl`
+    // key MUST NOT appear on the v2 wire — clients that key off it on a v2
+    // server would silently see an unbounded TTL.
     // ========================================================================
-    test('v2-12: TTL is present and reasonable for seconds', async () => {
+    test('v2-12: ttlSeconds present (and v1 ttl key absent)', async () => {
         const result = await callTool('slow_compute', { seconds: 1, label: 'v2-ttl' });
         const task = result.task;
-        assert.ok(task.ttl !== undefined, 'task should have ttl');
-        assert.ok(typeof task.ttl === 'number' && task.ttl > 0, 'ttl should be a positive number');
-        // Best-effort heuristic: typical server defaults are 60-600 seconds.
-        // If TTL > 10000, it's likely still using milliseconds (the most common
-        // migration bug). This is convention, not schema-enforceable.
-        assert.ok(task.ttl < 10000,
-            `ttl should be in seconds (got ${task.ttl} — if >10000, likely milliseconds)`);
+        assert.ok(task.ttlSeconds !== undefined,
+            'task should have ttlSeconds (SEP-2663 wire-field rename)');
+        assert.ok(typeof task.ttlSeconds === 'number' && task.ttlSeconds > 0,
+            'ttlSeconds should be a positive number');
+        // The v1 `ttl` (milliseconds) key MUST NOT appear in v2 responses.
+        assert.ok(!('ttl' in task),
+            'v2 task object MUST NOT carry the v1 `ttl` key (use ttlSeconds)');
     });
 
     // ========================================================================
@@ -569,56 +639,44 @@ describe('MCP Tasks v2 Conformance (SEP-2557)', () => {
     });
 
     // ========================================================================
-    // Scenario 17: inputResponses resumes task
+    // Scenario 17: tasks/update delivers inputResponses; task resumes
     //
-    // Client sends inputResponses as a MAP in a subsequent request to
-    // provide the requested input. Keys must correspond to the inputRequests
-    // keys. The task should resume.
-    //
-    // PROVISIONAL: inputResponses will likely move to a separate method
-    // (name TBD). Currently using tasks/get per the SEP text, but this
-    // scenario WILL NEED UPDATING when the delivery method is finalized.
-    //
-    // NOTE: The task can also return input_required again (e.g., if the
-    // server sent multiple requests and the client only responded to one).
-    // This scenario responds to all requests so the task should complete.
+    // SEP-2663 finalized the MRTR resume path: the client sends inputResponses
+    // via the new tasks/update method (NOT on tasks/get). The server matches
+    // keys to the previously-emitted inputRequests, hands the payloads to the
+    // waiting goroutine, and the task transitions back to working (or
+    // directly to terminal if the tool finishes immediately after).
+    // tasks/update returns an empty {} ack — observe the resulting status
+    // via the next tasks/get.
     // ========================================================================
-    test('v2-17: inputResponses map resumes task', async () => {
+    test('v2-17: tasks/update inputResponses resume task', async () => {
         const result = await callTool('confirm_delete', { filename: 'v2-respond.txt' });
         assertCreateTaskResult(result, 'v2-17 create');
         const taskId = result.task.taskId;
 
-        // Wait for input_required.
+        // Wait for input_required + populated inputRequests.
         const inputTask = await waitForStatus(taskId, 'input_required', 5000);
         assert.equal(inputTask.status, 'input_required', 'should be input_required');
+        assert.ok(inputTask.inputRequests && Object.keys(inputTask.inputRequests).length > 0,
+            'input_required task must surface inputRequests via tasks/get');
 
-        // Build inputResponses map — keys must match inputRequests keys.
-        const requestKeys = Object.keys(inputTask.inputRequests || {});
+        // Build inputResponses keyed by the server-minted opaque ids. Echo
+        // the requestState the server returned so stateless deployments
+        // can pick the request back up.
         const responses: Record<string, any> = {};
-        for (const key of requestKeys) {
-            responses[key] = {
-                action: 'accept',
-                content: { confirm: true }
-            };
+        for (const key of Object.keys(inputTask.inputRequests)) {
+            responses[key] = { action: 'accept', content: { confirm: true } };
         }
 
-        const state = inputTask.requestState;
-        const resumed = await getTask(taskId, {
-            requestState: state,
-            inputResponses: responses
-        });
+        const ack = await updateTask(taskId, responses, inputTask.requestState);
+        assert.deepEqual(ack, {},
+            `tasks/update should return empty {} ack; got ${JSON.stringify(ack)}`);
 
-        // Task should have resumed — working, completed, or input_required again.
-        assert.ok(
-            ['working', 'completed', 'input_required'].includes(resumed.status),
-            `task should have resumed, got ${resumed.status}`
-        );
-
-        // If not yet completed, wait for completion.
-        if (resumed.status !== 'completed') {
-            const terminal = await waitForTerminal(taskId);
-            assert.equal(terminal.status, 'completed', 'task should complete after input');
-        }
+        // Server-side goroutine resumes — status will settle to terminal
+        // (or back to input_required if the tool emits another round).
+        const terminal = await waitForTerminal(taskId);
+        assert.equal(terminal.status, 'completed',
+            `task should complete after tasks/update; got ${terminal.status}`);
     });
 
     // ========================================================================
@@ -713,6 +771,109 @@ describe('MCP Tasks v2 Conformance (SEP-2557)', () => {
         const related = meta?.['io.modelcontextprotocol/related-task'];
         assert.ok(!related,
             'tasks/get inlined result MUST NOT include related-task _meta');
+    });
+
+    // ========================================================================
+    // Scenario 22: tasks/* rejected when extension not negotiated
+    //
+    // SEP-2663: tasks/get / tasks/update / tasks/cancel MUST NOT exist for
+    // a session that did not declare the io.modelcontextprotocol/tasks
+    // extension during initialize. Servers return -32601 (MethodNotFound)
+    // so unsupported clients don't see a tasks surface they didn't ask for.
+    //
+    // This scenario uses a SECOND session (unsupportedSessionId, set up in
+    // before()) that omitted the extension declaration.
+    // ========================================================================
+    test('v2-22: tasks/* return -32601 when extension not negotiated', async () => {
+        const cases: Array<{ method: string; params: any }> = [
+            { method: 'tasks/get', params: { taskId: 'any-id' } },
+            { method: 'tasks/update', params: { taskId: 'any-id', inputResponses: {} } },
+            { method: 'tasks/cancel', params: { taskId: 'any-id' } },
+        ];
+        for (const tc of cases) {
+            try {
+                await rawRequest(tc.method, tc.params, { sessionId: unsupportedSessionId });
+                assert.fail(`${tc.method} should fail without extension negotiation`);
+            } catch (e: any) {
+                assertJsonRpcError(e, -32601, `${tc.method} without ext`, true);
+            }
+        }
+    });
+
+    // ========================================================================
+    // Scenario 23: tools/call without extension does NOT create a task
+    //
+    // SEP-2663: a client that did not negotiate the extension still gets to
+    // call task-eligible tools — the server falls through to synchronous
+    // execution and returns a plain ToolResult (no resultType discriminator).
+    // It MUST NOT return CreateTaskResult.
+    // ========================================================================
+    test('v2-23: tools/call without extension returns sync ToolResult (no CreateTaskResult)', async () => {
+        const result = await rawRequest('tools/call',
+            { name: 'slow_compute', arguments: { seconds: 0, label: 'v2-23' } },
+            { sessionId: unsupportedSessionId },
+        );
+        assert.ok(!result.resultType,
+            `tools/call without extension MUST NOT carry resultType; got ${result.resultType}`);
+        assert.ok(!result.task,
+            `tools/call without extension MUST NOT carry task envelope; got ${JSON.stringify(result.task)}`);
+        // Sync ToolResult shape: should have content[].
+        assert.ok(result.content,
+            `expected sync ToolResult with content[]; got ${JSON.stringify(result)}`);
+    });
+
+    // ========================================================================
+    // Scenario 24: SEP-2243 Mcp-Name HTTP response header on task creation
+    //
+    // The streamable-HTTP transport MUST set Mcp-Name: <taskId> on the
+    // response to a task-creating tools/call so HTTP-level routing /
+    // observability can key off the task id without parsing the JSON body.
+    // The header MUST NOT appear when the call did not create a task (sync
+    // tool, or extension not negotiated).
+    // ========================================================================
+    test('v2-24: Mcp-Name response header on task-creating tools/call', async () => {
+        const { result, response } = await rawRequestFull('tools/call', {
+            name: 'slow_compute', arguments: { seconds: 1, label: 'v2-24' },
+        });
+        assertCreateTaskResult(result, 'v2-24');
+        const mcpName = response.headers.get('mcp-name');
+        assert.ok(mcpName,
+            'Mcp-Name header MUST be set on task-creating tools/call response');
+        assert.equal(mcpName, result.task.taskId,
+            'Mcp-Name header value MUST equal the taskId in the response body');
+    });
+
+    test('v2-24b: Mcp-Name absent on sync tools/call response', async () => {
+        const { response } = await rawRequestFull('tools/call', {
+            name: 'greet', arguments: { name: 'world' },
+        });
+        const mcpName = response.headers.get('mcp-name');
+        assert.ok(!mcpName,
+            `sync tools/call MUST NOT emit Mcp-Name; got ${mcpName}`);
+    });
+
+    // ========================================================================
+    // Scenario 25: SEP-2575 per-request capability override
+    //
+    // A client that did NOT declare the extension at session level can opt
+    // into task creation for a single tools/call by including the extension
+    // under _meta.io.modelcontextprotocol/clientCapabilities.extensions.
+    // Per-request opt-in is additive — it cannot revoke a session-level
+    // declaration and only applies to the current request.
+    // ========================================================================
+    test('v2-25: per-request _meta opt-in produces CreateTaskResult', async () => {
+        const result = await rawRequest('tools/call',
+            { name: 'slow_compute', arguments: { seconds: 1, label: 'v2-25' } },
+            {
+                sessionId: unsupportedSessionId, // session-level: no extension
+                meta: {
+                    'io.modelcontextprotocol/clientCapabilities': {
+                        extensions: { [TASKS_EXTENSION_ID]: {} },
+                    },
+                },
+            },
+        );
+        assertCreateTaskResult(result, 'v2-25 per-request opt-in');
     });
 
 });

--- a/examples/tasks-v2/WALKTHROUGH.md
+++ b/examples/tasks-v2/WALKTHROUGH.md
@@ -1,16 +1,16 @@
-# MCP Tasks v2 (SEP-2557) — Server-Directed Async
+# MCP Tasks v2 (SEP-2663) — Server-Directed Async + MRTR
 
-Walks through the v2 Tasks protocol where the *server* decides whether to create a task — clients no longer send a task hint. Inlined results, flat shape, and tool-error vs protocol-error semantics.
+Walks through the v2 Tasks extension where the *server* decides whether to create a task — clients no longer send a task hint. Polymorphic tools/call, inlined results, ack-only cancel, and the new tasks/update flow that closes the elicit/sample (MRTR) loop.
 
 ## What you'll learn
 
-- **Connect to the v2 tasks server** — The mcpkit client opens a GET SSE stream so progress notifications reach us during polling. Initialize advertises the v2 tasks capability.
-- **Sync call: greet — no task created** — greet is taskSupport=forbidden. The server runs it inline and returns the standard ToolResult shape. No task created. The host can detect sync vs task by checking for the `resultType: "task"` discriminator on the response.
-- **slow_compute (no task hint!) — server creates a task** — Critical v2 semantics: client doesn't include a `task` param — calls slow_compute like any sync tool. Because slow_compute has Execution.TaskSupport=optional, the server elects to create a task. The discriminator `resultType: "task"` tells the host to switch to polling mode.
-- **Poll tasks/get — final response inlines the result** — v2's flat shape: GetTaskResultV2 has TaskInfo fields at the top level, and inlines the actual ToolResult under `result` once status is terminal. No second roundtrip to tasks/result.
-- **failing_job → status: completed, result.isError: true (TOOL error semantics)** — In v2, a tool that returns an error result lands in status `completed` with `result.isError: true`. The task itself ran to completion — the *operation* failed but the *infrastructure* didn't. This is distinct from protocol failures (next step).
-- **protocol_error_job → status: failed, error: {...} (PROTOCOL error semantics)** — Protocol errors (panics, framework bugs, things that aren't the tool's fault) land in status `failed` with the error inlined as `error: {code, message, data}` mirroring JSON-RPC error shape. The host should treat this as 'something is broken', not 'the tool said no'.
-- **Cancel a long-running task → status: cancelled** — Same cooperative cancellation as v1. Server cancels the goroutine context; tools that select on ctx.Done() exit cleanly. v2 cancel response also includes the flat TaskInfo so the host doesn't need an extra round-trip.
+- **Connect to the v2 tasks server (declare extension)** — `client.WithTasksExtension()` adds `io.modelcontextprotocol/tasks` to ClientCapabilities.Extensions during initialize. Without that declaration, the v2 server falls through to synchronous tools/call and rejects tasks/* with -32601.
+- **Sync call: greet — ToolCall returns Sync variant** — `client.ToolCall(c, name, args)` returns a polymorphic `*ToolCallResult`. For sync tools (no Execution / TaskSupport=forbidden) the server returns a plain `ToolResult` and the helper sets `Sync` (not `Task`). Callers branch on `result.IsTask()`.
+- **slow_compute (no task hint!) — server creates a task → ToolCall returns Task variant** — Critical v2 semantics: no `task` param in the request — the server elects to create a task because slow_compute has TaskSupport=optional. The discriminator `resultType: "task"` lights up `result.IsTask()` on the helper. The Mcp-Name HTTP header carries the same taskId so HTTP routing/observability can key off it without parsing the body.
+- **failing_job → status: completed, result.isError: true (TOOL error semantics)** — In v2, a tool that returns an error result lands in status `completed` with `result.isError: true`. The task itself ran to completion — the *operation* failed but the *infrastructure* didn't. Distinct from protocol failures (next step).
+- **protocol_error_job → status: failed, error: {...} (PROTOCOL error semantics)** — Protocol errors (panics, framework bugs, things that aren't the tool's fault) land in status `failed` with the error inlined as `error: {code, message, data}` mirroring the JSON-RPC error shape. The host should treat this as 'something is broken', not 'the tool said no'.
+- **confirm_delete → input_required → tasks/update → completed (SEP-2663 MRTR)** — This is the new SEP-2663 MRTR loop: the tool blocks on `TaskElicit`, the task parks in `input_required`, `tasks/get` surfaces the pending request under `inputRequests` (server-minted opaque keys), and `client.UpdateTask` delivers the matching response so the goroutine resumes. Cancellation during input_required propagates via ctx.Done() — see `TestV2_ElicitCancelUnblocks` in server tests.
+- **Cancel a long-running task → empty ack, status settles to cancelled** — Same cooperative cancellation as v1 (server cancels the goroutine context; tools that select on ctx.Done() exit cleanly), but the response shape changed: SEP-2663 cancel returns an empty `{}` ack. Observe the `cancelled` status via the next `tasks/get` (or `WaitForTask` which does it for you).
 
 ## Flow
 
@@ -19,39 +19,45 @@ sequenceDiagram
     participant Host as MCP Host (this client)
     participant Server as MCP Server (make serve)
 
-    Note over Host,Server: Step 1: Connect to the v2 tasks server
-    Host->>Server: POST /mcp — initialize
-    Server-->>Host: serverInfo + tasks v2 capability
+    Note over Host,Server: Step 1: Connect to the v2 tasks server (declare extension)
+    Host->>Server: POST /mcp — initialize (declares io.modelcontextprotocol/tasks)
+    Server-->>Host: serverInfo + tasks extension advertised under capabilities.extensions
 
-    Note over Host,Server: Step 2: Sync call: greet — no task created
+    Note over Host,Server: Step 2: Sync call: greet — ToolCall returns Sync variant
     Host->>Server: tools/call: greet {name: "world"}
-    Server-->>Host: ToolResult (no resultType discriminator → sync)
+    Server-->>Host: ToolResult (no resultType discriminator → ToolCallResult.Sync)
 
-    Note over Host,Server: Step 3: slow_compute (no task hint!) — server creates a task
+    Note over Host,Server: Step 3: slow_compute (no task hint!) — server creates a task → ToolCall returns Task variant
     Host->>Server: tools/call: slow_compute {seconds: 3}
-    Server-->>Host: {resultType: "task", task: {taskId, status: working, ttl}}
+    Server-->>Host: {resultType: "task", task: {taskId, status: working, ttlSeconds, ...}}
++ Mcp-Name: <taskId> response header (SEP-2243)
 
-    Note over Host,Server: Step 4: Poll tasks/get — final response inlines the result
-    Host->>Server: tasks/get {taskId}  (polled)
-    Server-->>Host: notifications/progress (1/3, 2/3, 3/3) via SSE
-    Server-->>Host: {status: completed, result: {...}, ttl: ...}  (no separate tasks/result needed)
-
-    Note over Host,Server: Step 5: failing_job → status: completed, result.isError: true (TOOL error semantics)
-    Host->>Server: tools/call: failing_job
-    Server-->>Host: {resultType: task, task: ...}
-    Host->>Server: tasks/get (polled)
+    Note over Host,Server: Step 4: failing_job → status: completed, result.isError: true (TOOL error semantics)
+    Host->>Server: tools/call: failing_job → CreateTaskResult
+    Host->>Server: WaitForTask polls tasks/get until terminal
     Server-->>Host: {status: completed, result: {isError: true, content: [...]}}
 
-    Note over Host,Server: Step 6: protocol_error_job → status: failed, error: {...} (PROTOCOL error semantics)
-    Host->>Server: tools/call: protocol_error_job
-    Host->>Server: tasks/get (polled)
+    Note over Host,Server: Step 5: protocol_error_job → status: failed, error: {...} (PROTOCOL error semantics)
+    Host->>Server: tools/call: protocol_error_job → CreateTaskResult
+    Host->>Server: WaitForTask polls tasks/get until terminal
     Server-->>Host: {status: failed, error: {code, message}}
 
-    Note over Host,Server: Step 7: Cancel a long-running task → status: cancelled
+    Note over Host,Server: Step 6: confirm_delete → input_required → tasks/update → completed (SEP-2663 MRTR)
+    Host->>Server: tools/call: confirm_delete {filename: "important.txt"}
+    Server-->>Host: {resultType: task, task: {status: working, ...}}
+    Host->>Server: GetTask (polled until status = input_required)
+    Server-->>Host: DetailedTask {status: input_required, inputRequests: { "elicit-N": {method, params} }}
+    Host->>Server: tasks/update {taskId, inputResponses: { "elicit-N": {action: accept, content: {confirm: true}} }}
+    Server-->>Host: {} (empty ack)
+    Host->>Server: WaitForTask until terminal
+    Server-->>Host: {status: completed, result: {content: ["deleted 'important.txt'"]}}
+
+    Note over Host,Server: Step 7: Cancel a long-running task → empty ack, status settles to cancelled
     Host->>Server: tools/call: slow_compute {seconds: 10}
     Server-->>Host: {resultType: task, task: ...}
-    Host->>Server: tasks/cancel {taskId}
-    Host->>Server: tasks/get (final)
+    Host->>Server: client.CancelTask
+    Server-->>Host: {} (empty ack — SEP-2663 cancel returns no task state)
+    Host->>Server: WaitForTask polls tasks/get
     Server-->>Host: {status: cancelled}
 ```
 
@@ -63,54 +69,59 @@ Start the MCP server in a separate terminal first:
 
 ```
 Terminal 1:  make serve        # tasks-v2 server on :8080
-Terminal 2:  make run          # this demo
+Terminal 2:  make demo         # this demo
 ```
 
 ### v1 vs v2 — what changed
 
-In v1 (SEP-1036) the *client* hints at task vs sync via a `task` param. v2 (SEP-2557) flips this:
+v1 (SEP-1036, MCP spec 2025-11-25) had the *client* hint at task vs sync via a `task` param. v2 (SEP-2663, in-flight) flips the contract:
 
-- **No client task hint.** Just call `tools/call` normally — the *server* decides.
-- **`resultType` discriminator** on `tools/call` response: `"task"` means a task was created (poll); absent means sync result.
-- **Inlined `result` / `error` / `inputRequests`** on `tasks/get` — no separate `tasks/result` call.
-- **TTL in seconds** (was milliseconds in v1).
-- **Error semantics**: tool errors (logic failures) → `status: completed, isError: true`. Protocol errors (framework crashes) → `status: failed` + `error` object.
+- **Tasks is an extension** (`io.modelcontextprotocol/tasks`). Clients declare support during `initialize`; servers gate every task-creating `tools/call` and every `tasks/*` method on the negotiation.
+- **No client task hint.** Just call `tools/call` normally — the *server* decides whether to run sync or create a task. The client `client.ToolCall` helper returns a polymorphic `ToolCallResult` with either `Sync` or `Task` populated.
+- **`resultType` discriminator** on `tools/call` response: `"task"` means a task was created; absent means sync.
+- **`tasks/get` returns `DetailedTask`** with inlined `result` / `error` / `inputRequests` / `requestState` per status. No separate `tasks/result` round-trip.
+- **`tasks/cancel` returns an empty ack**. Observe the resulting `cancelled` status with the next `tasks/get`.
+- **`tasks/update` is the SEP-2663 resume path** for MRTR input rounds — the client delivers `inputResponses` keyed to whatever `inputRequests` the server emitted.
+- **Wire fields renamed**: `ttlSeconds`, `pollIntervalMilliseconds`. `parentTaskId` removed.
+- **Mcp-Name HTTP header** (SEP-2243) carries the new taskId on task-creating responses.
+- **Error semantics**: tool errors → `status: completed, isError: true`. Protocol errors → `status: failed` + `error` object.
 - **`tasks/result` and `tasks/list` removed** — `tasks/get` is the single read endpoint.
 
-### Step 1: Connect to the v2 tasks server
+### Step 1: Connect to the v2 tasks server (declare extension)
 
-The mcpkit client opens a GET SSE stream so progress notifications reach us during polling. Initialize advertises the v2 tasks capability.
+`client.WithTasksExtension()` adds `io.modelcontextprotocol/tasks` to ClientCapabilities.Extensions during initialize. Without that declaration, the v2 server falls through to synchronous tools/call and rejects tasks/* with -32601.
 
-### Step 2: Sync call: greet — no task created
+### Step 2: Sync call: greet — ToolCall returns Sync variant
 
-greet is taskSupport=forbidden. The server runs it inline and returns the standard ToolResult shape. No task created. The host can detect sync vs task by checking for the `resultType: "task"` discriminator on the response.
+`client.ToolCall(c, name, args)` returns a polymorphic `*ToolCallResult`. For sync tools (no Execution / TaskSupport=forbidden) the server returns a plain `ToolResult` and the helper sets `Sync` (not `Task`). Callers branch on `result.IsTask()`.
 
-### Step 3: slow_compute (no task hint!) — server creates a task
+### Step 3: slow_compute (no task hint!) — server creates a task → ToolCall returns Task variant
 
-Critical v2 semantics: client doesn't include a `task` param — calls slow_compute like any sync tool. Because slow_compute has Execution.TaskSupport=optional, the server elects to create a task. The discriminator `resultType: "task"` tells the host to switch to polling mode.
+Critical v2 semantics: no `task` param in the request — the server elects to create a task because slow_compute has TaskSupport=optional. The discriminator `resultType: "task"` lights up `result.IsTask()` on the helper. The Mcp-Name HTTP header carries the same taskId so HTTP routing/observability can key off it without parsing the body.
 
-### Step 4: Poll tasks/get — final response inlines the result
+### Step 4: failing_job → status: completed, result.isError: true (TOOL error semantics)
 
-v2's flat shape: GetTaskResultV2 has TaskInfo fields at the top level, and inlines the actual ToolResult under `result` once status is terminal. No second roundtrip to tasks/result.
+In v2, a tool that returns an error result lands in status `completed` with `result.isError: true`. The task itself ran to completion — the *operation* failed but the *infrastructure* didn't. Distinct from protocol failures (next step).
 
-### Step 5: failing_job → status: completed, result.isError: true (TOOL error semantics)
+### Step 5: protocol_error_job → status: failed, error: {...} (PROTOCOL error semantics)
 
-In v2, a tool that returns an error result lands in status `completed` with `result.isError: true`. The task itself ran to completion — the *operation* failed but the *infrastructure* didn't. This is distinct from protocol failures (next step).
+Protocol errors (panics, framework bugs, things that aren't the tool's fault) land in status `failed` with the error inlined as `error: {code, message, data}` mirroring the JSON-RPC error shape. The host should treat this as 'something is broken', not 'the tool said no'.
 
-### Step 6: protocol_error_job → status: failed, error: {...} (PROTOCOL error semantics)
+### Step 6: confirm_delete → input_required → tasks/update → completed (SEP-2663 MRTR)
 
-Protocol errors (panics, framework bugs, things that aren't the tool's fault) land in status `failed` with the error inlined as `error: {code, message, data}` mirroring JSON-RPC error shape. The host should treat this as 'something is broken', not 'the tool said no'.
+This is the new SEP-2663 MRTR loop: the tool blocks on `TaskElicit`, the task parks in `input_required`, `tasks/get` surfaces the pending request under `inputRequests` (server-minted opaque keys), and `client.UpdateTask` delivers the matching response so the goroutine resumes. Cancellation during input_required propagates via ctx.Done() — see `TestV2_ElicitCancelUnblocks` in server tests.
 
-### Step 7: Cancel a long-running task → status: cancelled
+### Step 7: Cancel a long-running task → empty ack, status settles to cancelled
 
-Same cooperative cancellation as v1. Server cancels the goroutine context; tools that select on ctx.Done() exit cleanly. v2 cancel response also includes the flat TaskInfo so the host doesn't need an extra round-trip.
+Same cooperative cancellation as v1 (server cancels the goroutine context; tools that select on ctx.Done() exit cleanly), but the response shape changed: SEP-2663 cancel returns an empty `{}` ack. Observe the `cancelled` status via the next `tasks/get` (or `WaitForTask` which does it for you).
 
 ### Where each piece lives in mcpkit
 
-- v2 server library: `server/tasks_v2.go`
-- v2 wire types (`CreateTaskResultV2`, `GetTaskResultV2`, `ResultTypeTask`): `core/task_v2.go`
-- Conformance tests: `conformance/tasks-v2/scenarios.test.ts` (21 scenarios)
-- Implementation plan: `docs/TASKS_V2_PLAN.md`
+- v2 server library: `server/tasks_v2.go` (RegisterTasks, gating, MRTR runtime)
+- v2 wire types (`CreateTaskResult`, `DetailedTask`, `TaskInfoV2`, `UpdateTaskRequest`, `ResultTypeTask`): `core/task_v2.go` (SEP-2663)
+- v2 client helpers (`ToolCall`, `GetTask`, `UpdateTask`, `WaitForTask`, `CancelTask`): `client/tasks.go`
+- Conformance tests: `conformance/tasks-v2/scenarios.test.ts`
+- Implementation plan + open questions: `PLAN.md`
 
 ## Run it
 

--- a/examples/tasks-v2/main.go
+++ b/examples/tasks-v2/main.go
@@ -134,6 +134,59 @@ func serve() {
 		},
 	)
 
+	// confirm_delete: required task support, demonstrates the SEP-2663 MRTR
+	// elicit → tasks/update → complete loop. The tool calls TaskElicit, parks
+	// the task in input_required (which surfaces inputRequests on tasks/get),
+	// and resumes when the client sends the matching response via tasks/update.
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "confirm_delete",
+			Description: "Asks the client to confirm before deleting (demonstrates SEP-2663 inputRequests/inputResponses).",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"filename": map[string]any{
+						"type":        "string",
+						"description": "File the user is being asked to confirm deletion of",
+						"default":     "important.txt",
+					},
+				},
+			},
+			Execution: &core.ToolExecution{TaskSupport: core.TaskSupportRequired},
+		},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+			tc := server.GetTaskContext(ctx)
+			if tc == nil {
+				return core.ToolResult{}, fmt.Errorf("confirm_delete requires task context")
+			}
+
+			var args struct {
+				Filename string `json:"filename"`
+			}
+			json.Unmarshal(req.Arguments, &args)
+			if args.Filename == "" {
+				args.Filename = "important.txt"
+			}
+
+			log.Printf("[confirm_delete] asking about %q (parking task in input_required)...", args.Filename)
+			result, err := tc.TaskElicit(core.ElicitationRequest{
+				Message:         fmt.Sprintf("Delete '%s'?", args.Filename),
+				RequestedSchema: json.RawMessage(`{"type":"object","properties":{"confirm":{"type":"boolean"}},"required":["confirm"]}`),
+			})
+			if err != nil {
+				return core.TextResult(fmt.Sprintf("elicitation failed: %v", err)), nil
+			}
+			if result.Action == "accept" {
+				if confirmed, _ := result.Content["confirm"].(bool); confirmed {
+					log.Printf("[confirm_delete] user confirmed; deleting %q", args.Filename)
+					return core.TextResult(fmt.Sprintf("deleted '%s'", args.Filename)), nil
+				}
+			}
+			log.Printf("[confirm_delete] user declined; keeping %q", args.Filename)
+			return core.TextResult(fmt.Sprintf("kept '%s'", args.Filename)), nil
+		},
+	)
+
 	// protocol_error_job: required task support. Triggers a protocol-level failure
 	// by panicking. In v2, protocol errors → failed + error field.
 	srv.RegisterTool(
@@ -206,8 +259,9 @@ func serve() {
 	log.Printf("  greet              — sync-only")
 	log.Printf("  slow_compute       — optional task (server-directed)")
 	log.Printf("  failing_job        — required task (tool error → completed + isError)")
+	log.Printf("  confirm_delete     — required task (input_required → tasks/update → completed)")
 	log.Printf("  protocol_error_job — required task (protocol error → failed + error)")
-	log.Printf("  external_job       �� required task (TaskCallbacks proxy)")
+	log.Printf("  external_job       — required task (TaskCallbacks proxy)")
 	if err := srv.Run(*addr); err != nil {
 		log.Fatal(err)
 	}

--- a/examples/tasks-v2/walkthrough.go
+++ b/examples/tasks-v2/walkthrough.go
@@ -43,9 +43,9 @@ func runDemo() {
 		}
 	}
 
-	demo := demokit.New("MCP Tasks v2 (SEP-2557) — Server-Directed Async").
+	demo := demokit.New("MCP Tasks v2 (SEP-2663) — Server-Directed Async + MRTR").
 		Dir("tasks-v2").
-		Description("Walks through the v2 Tasks protocol where the *server* decides whether to create a task — clients no longer send a task hint. Inlined results, flat shape, and tool-error vs protocol-error semantics.").
+		Description("Walks through the v2 Tasks extension where the *server* decides whether to create a task — clients no longer send a task hint. Polymorphic tools/call, inlined results, ack-only cancel, and the new tasks/update flow that closes the elicit/sample (MRTR) loop.").
 		Actors(
 			demokit.Actor("Host", "MCP Host (this client)"),
 			demokit.Actor("Server", "MCP Server (make serve)"),
@@ -56,32 +56,32 @@ func runDemo() {
 		"",
 		"```",
 		"Terminal 1:  make serve        # tasks-v2 server on :8080",
-		"Terminal 2:  make run          # this demo",
+		"Terminal 2:  make demo         # this demo",
 		"```",
 	)
 
 	demo.Section("v1 vs v2 — what changed",
-		"In v1 (SEP-1036) the *client* hints at task vs sync via a `task` param. v2 (SEP-2557) flips this:",
+		"v1 (SEP-1036, MCP spec 2025-11-25) had the *client* hint at task vs sync via a `task` param. v2 (SEP-2663, in-flight) flips the contract:",
 		"",
-		"- **No client task hint.** Just call `tools/call` normally — the *server* decides.",
-		"- **`resultType` discriminator** on `tools/call` response: `\"task\"` means a task was created (poll); absent means sync result.",
-		"- **Inlined `result` / `error` / `inputRequests`** on `tasks/get` — no separate `tasks/result` call.",
-		"- **TTL in seconds** (was milliseconds in v1).",
-		"- **Error semantics**: tool errors (logic failures) → `status: completed, isError: true`. Protocol errors (framework crashes) → `status: failed` + `error` object.",
+		"- **Tasks is an extension** (`io.modelcontextprotocol/tasks`). Clients declare support during `initialize`; servers gate every task-creating `tools/call` and every `tasks/*` method on the negotiation.",
+		"- **No client task hint.** Just call `tools/call` normally — the *server* decides whether to run sync or create a task. The client `client.ToolCall` helper returns a polymorphic `ToolCallResult` with either `Sync` or `Task` populated.",
+		"- **`resultType` discriminator** on `tools/call` response: `\"task\"` means a task was created; absent means sync.",
+		"- **`tasks/get` returns `DetailedTask`** with inlined `result` / `error` / `inputRequests` / `requestState` per status. No separate `tasks/result` round-trip.",
+		"- **`tasks/cancel` returns an empty ack**. Observe the resulting `cancelled` status with the next `tasks/get`.",
+		"- **`tasks/update` is the SEP-2663 resume path** for MRTR input rounds — the client delivers `inputResponses` keyed to whatever `inputRequests` the server emitted.",
+		"- **Wire fields renamed**: `ttlSeconds`, `pollIntervalMilliseconds`. `parentTaskId` removed.",
+		"- **Mcp-Name HTTP header** (SEP-2243) carries the new taskId on task-creating responses.",
+		"- **Error semantics**: tool errors → `status: completed, isError: true`. Protocol errors → `status: failed` + `error` object.",
 		"- **`tasks/result` and `tasks/list` removed** — `tasks/get` is the single read endpoint.",
 	)
 
-	var (
-		c          *client.Client
-		slowTaskID string
-		failTaskID string
-	)
+	var c *client.Client
 
 	// --- Step 1: Connect ---
-	demo.Step("Connect to the v2 tasks server").
+	demo.Step("Connect to the v2 tasks server (declare extension)").
 		Arrow("Host", "Server", "POST /mcp — initialize (declares io.modelcontextprotocol/tasks)").
-		DashedArrow("Server", "Host", "serverInfo + tasks extension advertised").
-		Note("The mcpkit client opens a GET SSE stream so progress notifications reach us during polling. Initialize declares support for the SEP-2663 tasks extension; without that declaration the v2 server falls through to synchronous tools/call and rejects tasks/* with -32601.").
+		DashedArrow("Server", "Host", "serverInfo + tasks extension advertised under capabilities.extensions").
+		Note("`client.WithTasksExtension()` adds `io.modelcontextprotocol/tasks` to ClientCapabilities.Extensions during initialize. Without that declaration, the v2 server falls through to synchronous tools/call and rejects tasks/* with -32601.").
 		Run(func() (result *demokit.StepResult) {
 			c = client.NewClient(serverURL+"/mcp",
 				core.ClientInfo{Name: "tasks-v2-host", Version: "1.0"},
@@ -98,67 +98,63 @@ func runDemo() {
 				return
 			}
 			fmt.Printf("    Connected to %s %s\n", c.ServerInfo.Name, c.ServerInfo.Version)
+			fmt.Printf("    Extension advertised: %v\n", c.ServerSupportsExtension(core.TasksExtensionID))
 			return
 		})
 
-	// --- Step 2: Sync call (resultType absent) ---
-	demo.Step("Sync call: greet — no task created").
+	// --- Step 2: Polymorphic tools/call — sync branch ---
+	demo.Step("Sync call: greet — ToolCall returns Sync variant").
 		Arrow("Host", "Server", "tools/call: greet {name: \"world\"}").
-		DashedArrow("Server", "Host", "ToolResult (no resultType discriminator → sync)").
-		Note("greet is taskSupport=forbidden. The server runs it inline and returns the standard ToolResult shape. No task created. The host can detect sync vs task by checking for the `resultType: \"task\"` discriminator on the response.").
+		DashedArrow("Server", "Host", "ToolResult (no resultType discriminator → ToolCallResult.Sync)").
+		Note("`client.ToolCall(c, name, args)` returns a polymorphic `*ToolCallResult`. For sync tools (no Execution / TaskSupport=forbidden) the server returns a plain `ToolResult` and the helper sets `Sync` (not `Task`). Callers branch on `result.IsTask()`.").
 		Run(func() (result *demokit.StepResult) {
-			text, err := c.ToolCall("greet", map[string]any{"name": "world"})
+			res, err := client.ToolCall(c, "greet", map[string]any{"name": "world"})
 			if err != nil {
 				fmt.Printf("    ERROR: %v\n", err)
 				return
 			}
-			fmt.Printf("    Result: %s\n", text)
+			if res.IsTask() {
+				fmt.Printf("    UNEXPECTED: greet returned a task (%s)\n", res.Task.Task.TaskID)
+				return
+			}
+			if len(res.Sync.Content) > 0 {
+				fmt.Printf("    Sync result: %s\n", res.Sync.Content[0].Text)
+			}
 			return
 		})
 
-	// --- Step 3: Server-decided task (slow_compute, no client hint) ---
-	demo.Step("slow_compute (no task hint!) — server creates a task").
+	// --- Step 3: Polymorphic tools/call — task branch ---
+	demo.Step("slow_compute (no task hint!) — server creates a task → ToolCall returns Task variant").
 		Arrow("Host", "Server", "tools/call: slow_compute {seconds: 3}").
-		DashedArrow("Server", "Host", "{resultType: \"task\", task: {taskId, status: working, ttl}}").
-		Note("Critical v2 semantics: client doesn't include a `task` param — calls slow_compute like any sync tool. Because slow_compute has Execution.TaskSupport=optional, the server elects to create a task. The discriminator `resultType: \"task\"` tells the host to switch to polling mode.").
+		DashedArrow("Server", "Host", "{resultType: \"task\", task: {taskId, status: working, ttlSeconds, ...}}\n+ Mcp-Name: <taskId> response header (SEP-2243)").
+		Note("Critical v2 semantics: no `task` param in the request — the server elects to create a task because slow_compute has TaskSupport=optional. The discriminator `resultType: \"task\"` lights up `result.IsTask()` on the helper. The Mcp-Name HTTP header carries the same taskId so HTTP routing/observability can key off it without parsing the body.").
 		Run(func() (result *demokit.StepResult) {
-			res, err := c.Call("tools/call", map[string]any{
-				"name":      "slow_compute",
-				"arguments": map[string]any{"seconds": 3, "label": "demo"},
-			})
+			var slowTaskID string
+			res, err := client.ToolCall(c, "slow_compute", map[string]any{"seconds": 3, "label": "demo"})
 			if err != nil {
 				fmt.Printf("    ERROR: %v\n", err)
 				return
 			}
-			var ctr core.CreateTaskResult
-			if err := json.Unmarshal(res.Raw, &ctr); err != nil {
-				fmt.Printf("    ERROR: %v\n", err)
+			if !res.IsTask() {
+				fmt.Printf("    UNEXPECTED: slow_compute returned sync\n")
 				return
 			}
-			if ctr.ResultType != core.ResultTypeTask {
-				fmt.Printf("    UNEXPECTED: missing resultType=\"task\" discriminator\n")
-				return
-			}
-			slowTaskID = ctr.Task.TaskID
-			fmt.Printf("    resultType:    %s\n", ctr.ResultType)
+			slowTaskID = res.Task.Task.TaskID
+			fmt.Printf("    resultType:    %s\n", res.Task.ResultType)
 			fmt.Printf("    taskId:        %s\n", slowTaskID)
-			fmt.Printf("    status:        %s\n", ctr.Task.Status)
-			if ctr.Task.TTLSeconds != nil {
-				fmt.Printf("    ttlSeconds:    %d (SEP-2663 wire field)\n", *ctr.Task.TTLSeconds)
+			fmt.Printf("    status:        %s\n", res.Task.Task.Status)
+			if res.Task.Task.TTLSeconds != nil {
+				fmt.Printf("    ttlSeconds:    %d\n", *res.Task.Task.TTLSeconds)
 			}
-			return
-		})
+			if res.Task.Task.PollIntervalMilliseconds != nil {
+				fmt.Printf("    pollIntervalMilliseconds: %d\n", *res.Task.Task.PollIntervalMilliseconds)
+			}
 
-	// --- Step 4: tasks/get with inlined result on completion ---
-	demo.Step("Poll tasks/get — final response inlines the result").
-		Arrow("Host", "Server", "tasks/get {taskId}  (polled)").
-		DashedArrow("Server", "Host", "notifications/progress (1/3, 2/3, 3/3) via SSE").
-		DashedArrow("Server", "Host", "{status: completed, result: {...}, ttl: ...}  (no separate tasks/result needed)").
-		Note("v2's flat shape: DetailedTask has the v2 task fields (taskId, status, ttlSeconds, ...) at the top level, and inlines the actual ToolResult under `result` once status is terminal. No second roundtrip to tasks/result.").
-		Run(func() (result *demokit.StepResult) {
+			// --- Step 4 (chained): WaitForTask honors PollIntervalMilliseconds ---
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			final, err := pollV2(ctx, c, slowTaskID, 500*time.Millisecond)
+			fmt.Printf("    waiting for terminal via client.WaitForTask ...\n")
+			final, err := client.WaitForTask(ctx, c, slowTaskID)
 			if err != nil {
 				fmt.Printf("    ERROR: %v\n", err)
 				return
@@ -172,27 +168,19 @@ func runDemo() {
 
 	// --- Step 5: Tool error → completed + isError:true ---
 	demo.Step("failing_job → status: completed, result.isError: true (TOOL error semantics)").
-		Arrow("Host", "Server", "tools/call: failing_job").
-		DashedArrow("Server", "Host", "{resultType: task, task: ...}").
-		Arrow("Host", "Server", "tasks/get (polled)").
+		Arrow("Host", "Server", "tools/call: failing_job → CreateTaskResult").
+		Arrow("Host", "Server", "WaitForTask polls tasks/get until terminal").
 		DashedArrow("Server", "Host", "{status: completed, result: {isError: true, content: [...]}}").
-		Note("In v2, a tool that returns an error result lands in status `completed` with `result.isError: true`. The task itself ran to completion — the *operation* failed but the *infrastructure* didn't. This is distinct from protocol failures (next step).").
+		Note("In v2, a tool that returns an error result lands in status `completed` with `result.isError: true`. The task itself ran to completion — the *operation* failed but the *infrastructure* didn't. Distinct from protocol failures (next step).").
 		Run(func() (result *demokit.StepResult) {
-			res, err := c.Call("tools/call", map[string]any{
-				"name":      "failing_job",
-				"arguments": map[string]any{},
-			})
-			if err != nil {
-				fmt.Printf("    ERROR: %v\n", err)
+			res, err := client.ToolCall(c, "failing_job", map[string]any{})
+			if err != nil || !res.IsTask() {
+				fmt.Printf("    ERROR: %v / IsTask=%v\n", err, res != nil && res.IsTask())
 				return
 			}
-			var ctr core.CreateTaskResult
-			json.Unmarshal(res.Raw, &ctr)
-			failTaskID = ctr.Task.TaskID
-
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
-			final, err := pollV2(ctx, c, failTaskID, 200*time.Millisecond)
+			final, err := client.WaitForTask(ctx, c, res.Task.Task.TaskID)
 			if err != nil {
 				fmt.Printf("    ERROR: %v\n", err)
 				return
@@ -209,25 +197,19 @@ func runDemo() {
 
 	// --- Step 6: Protocol error → failed + error ---
 	demo.Step("protocol_error_job → status: failed, error: {...} (PROTOCOL error semantics)").
-		Arrow("Host", "Server", "tools/call: protocol_error_job").
-		Arrow("Host", "Server", "tasks/get (polled)").
+		Arrow("Host", "Server", "tools/call: protocol_error_job → CreateTaskResult").
+		Arrow("Host", "Server", "WaitForTask polls tasks/get until terminal").
 		DashedArrow("Server", "Host", "{status: failed, error: {code, message}}").
-		Note("Protocol errors (panics, framework bugs, things that aren't the tool's fault) land in status `failed` with the error inlined as `error: {code, message, data}` mirroring JSON-RPC error shape. The host should treat this as 'something is broken', not 'the tool said no'.").
+		Note("Protocol errors (panics, framework bugs, things that aren't the tool's fault) land in status `failed` with the error inlined as `error: {code, message, data}` mirroring the JSON-RPC error shape. The host should treat this as 'something is broken', not 'the tool said no'.").
 		Run(func() (result *demokit.StepResult) {
-			res, err := c.Call("tools/call", map[string]any{
-				"name":      "protocol_error_job",
-				"arguments": map[string]any{},
-			})
-			if err != nil {
-				fmt.Printf("    ERROR: %v\n", err)
+			res, err := client.ToolCall(c, "protocol_error_job", map[string]any{})
+			if err != nil || !res.IsTask() {
+				fmt.Printf("    ERROR: %v / IsTask=%v\n", err, res != nil && res.IsTask())
 				return
 			}
-			var ctr core.CreateTaskResult
-			json.Unmarshal(res.Raw, &ctr)
-
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
-			final, err := pollV2(ctx, c, ctr.Task.TaskID, 200*time.Millisecond)
+			final, err := client.WaitForTask(ctx, c, res.Task.Task.TaskID)
 			if err != nil {
 				fmt.Printf("    ERROR: %v\n", err)
 				return
@@ -240,38 +222,112 @@ func runDemo() {
 			return
 		})
 
-	// --- Step 7: Cancellation ---
-	demo.Step("Cancel a long-running task → status: cancelled").
+	// --- Step 7: MRTR — confirm_delete drives the elicit/update loop ---
+	demo.Step("confirm_delete → input_required → tasks/update → completed (SEP-2663 MRTR)").
+		Arrow("Host", "Server", "tools/call: confirm_delete {filename: \"important.txt\"}").
+		DashedArrow("Server", "Host", "{resultType: task, task: {status: working, ...}}").
+		Arrow("Host", "Server", "GetTask (polled until status = input_required)").
+		DashedArrow("Server", "Host", "DetailedTask {status: input_required, inputRequests: { \"elicit-N\": {method, params} }}").
+		Arrow("Host", "Server", "tasks/update {taskId, inputResponses: { \"elicit-N\": {action: accept, content: {confirm: true}} }}").
+		DashedArrow("Server", "Host", "{} (empty ack)").
+		Arrow("Host", "Server", "WaitForTask until terminal").
+		DashedArrow("Server", "Host", "{status: completed, result: {content: [\"deleted 'important.txt'\"]}}").
+		Note("This is the new SEP-2663 MRTR loop: the tool blocks on `TaskElicit`, the task parks in `input_required`, `tasks/get` surfaces the pending request under `inputRequests` (server-minted opaque keys), and `client.UpdateTask` delivers the matching response so the goroutine resumes. Cancellation during input_required propagates via ctx.Done() — see `TestV2_ElicitCancelUnblocks` in server tests.").
+		Run(func() (result *demokit.StepResult) {
+			res, err := client.ToolCall(c, "confirm_delete", map[string]any{"filename": "important.txt"})
+			if err != nil || !res.IsTask() {
+				fmt.Printf("    ERROR: %v / IsTask=%v\n", err, res != nil && res.IsTask())
+				return
+			}
+			taskID := res.Task.Task.TaskID
+			fmt.Printf("    taskId: %s\n", taskID)
+
+			// Poll until the task parks in input_required with a populated InputRequests map.
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			deadline := time.Now().Add(5 * time.Second)
+			var pending *core.DetailedTask
+			for time.Now().Before(deadline) {
+				dt, err := client.GetTask(c, taskID)
+				if err != nil {
+					fmt.Printf("    ERROR: %v\n", err)
+					return
+				}
+				if dt.Status == core.TaskInputRequired && len(dt.InputRequests) > 0 {
+					pending = dt
+					break
+				}
+				time.Sleep(100 * time.Millisecond)
+			}
+			if pending == nil {
+				fmt.Printf("    ERROR: task did not reach input_required\n")
+				return
+			}
+
+			// Server picks the key — clients MUST treat it as opaque echo.
+			var key string
+			for k := range pending.InputRequests {
+				key = k
+				break
+			}
+			fmt.Printf("    pending status:   %s\n", pending.Status)
+			fmt.Printf("    pending key:      %s (server-minted, opaque)\n", key)
+			fmt.Printf("    pending method:   %s\n", pending.InputRequests[key].Method)
+
+			// Resume via tasks/update.
+			fmt.Printf("    delivering tasks/update {action: accept, confirm: true} ...\n")
+			if err := client.UpdateTask(c, core.UpdateTaskRequest{
+				TaskID: taskID,
+				InputResponses: core.InputResponses{
+					key: json.RawMessage(`{"action":"accept","content":{"confirm":true}}`),
+				},
+				RequestState: pending.RequestState,
+			}); err != nil {
+				fmt.Printf("    ERROR tasks/update: %v\n", err)
+				return
+			}
+
+			// Wait for completion.
+			final, err := client.WaitForTask(ctx, c, taskID)
+			if err != nil {
+				fmt.Printf("    ERROR WaitForTask: %v\n", err)
+				return
+			}
+			fmt.Printf("    Terminal status:  %s\n", final.Status)
+			if final.Result != nil && len(final.Result.Content) > 0 {
+				fmt.Printf("    Inlined result:   %s\n", final.Result.Content[0].Text)
+			}
+			return
+		})
+
+	// --- Step 8: Cancellation — ack-only ---
+	demo.Step("Cancel a long-running task → empty ack, status settles to cancelled").
 		Arrow("Host", "Server", "tools/call: slow_compute {seconds: 10}").
 		DashedArrow("Server", "Host", "{resultType: task, task: ...}").
-		Arrow("Host", "Server", "tasks/cancel {taskId}").
-		Arrow("Host", "Server", "tasks/get (final)").
+		Arrow("Host", "Server", "client.CancelTask").
+		DashedArrow("Server", "Host", "{} (empty ack — SEP-2663 cancel returns no task state)").
+		Arrow("Host", "Server", "WaitForTask polls tasks/get").
 		DashedArrow("Server", "Host", "{status: cancelled}").
-		Note("Same cooperative cancellation as v1. Server cancels the goroutine context; tools that select on ctx.Done() exit cleanly. v2 cancel response also includes the flat TaskInfo so the host doesn't need an extra round-trip.").
+		Note("Same cooperative cancellation as v1 (server cancels the goroutine context; tools that select on ctx.Done() exit cleanly), but the response shape changed: SEP-2663 cancel returns an empty `{}` ack. Observe the `cancelled` status via the next `tasks/get` (or `WaitForTask` which does it for you).").
 		Run(func() (result *demokit.StepResult) {
-			res, err := c.Call("tools/call", map[string]any{
-				"name":      "slow_compute",
-				"arguments": map[string]any{"seconds": 10, "label": "to-cancel"},
-			})
-			if err != nil {
+			res, err := client.ToolCall(c, "slow_compute", map[string]any{"seconds": 10, "label": "to-cancel"})
+			if err != nil || !res.IsTask() {
 				fmt.Printf("    ERROR: %v\n", err)
 				return
 			}
-			var ctr core.CreateTaskResult
-			json.Unmarshal(res.Raw, &ctr)
-			cancelID := ctr.Task.TaskID
+			cancelID := res.Task.Task.TaskID
 			fmt.Printf("    Started taskId: %s\n", cancelID)
 
 			time.Sleep(500 * time.Millisecond)
 			fmt.Printf("    Cancelling ...\n")
-			if _, err := c.Call("tasks/cancel", map[string]any{"taskId": cancelID}); err != nil {
+			if err := client.CancelTask(c, cancelID); err != nil {
 				fmt.Printf("    ERROR: %v\n", err)
 				return
 			}
 
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
-			final, err := pollV2(ctx, c, cancelID, 200*time.Millisecond)
+			final, err := client.WaitForTask(ctx, c, cancelID)
 			if err != nil {
 				fmt.Printf("    ERROR: %v\n", err)
 				return
@@ -281,10 +337,11 @@ func runDemo() {
 		})
 
 	demo.Section("Where each piece lives in mcpkit",
-		"- v2 server library: `server/tasks_v2.go`",
-		"- v2 wire types (`CreateTaskResult`, `DetailedTask`, `TaskInfoV2`, `ResultTypeTask`): `core/task_v2.go` (SEP-2663)",
-		"- Conformance tests: `conformance/tasks-v2/scenarios.test.ts` (21 scenarios)",
-		"- Implementation plan: `docs/TASKS_V2_PLAN.md`",
+		"- v2 server library: `server/tasks_v2.go` (RegisterTasks, gating, MRTR runtime)",
+		"- v2 wire types (`CreateTaskResult`, `DetailedTask`, `TaskInfoV2`, `UpdateTaskRequest`, `ResultTypeTask`): `core/task_v2.go` (SEP-2663)",
+		"- v2 client helpers (`ToolCall`, `GetTask`, `UpdateTask`, `WaitForTask`, `CancelTask`): `client/tasks.go`",
+		"- Conformance tests: `conformance/tasks-v2/scenarios.test.ts`",
+		"- Implementation plan + open questions: `PLAN.md`",
 	)
 
 	for _, arg := range os.Args[1:] {
@@ -298,29 +355,5 @@ func runDemo() {
 
 	if c != nil {
 		c.Close()
-	}
-}
-
-// pollV2 polls tasks/get until the task reaches a terminal status or the
-// context expires. There's no v2 client helper in mcpkit yet (v1 has
-// client.WaitForTask), so this is inline.
-func pollV2(ctx context.Context, c *client.Client, taskID string, interval time.Duration) (*core.DetailedTask, error) {
-	for {
-		res, err := c.Call("tasks/get", map[string]any{"taskId": taskID})
-		if err != nil {
-			return nil, err
-		}
-		var got core.DetailedTask
-		if err := json.Unmarshal(res.Raw, &got); err != nil {
-			return nil, err
-		}
-		if got.Status.IsTerminal() {
-			return &got, nil
-		}
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-time.After(interval):
-		}
 	}
 }


### PR DESCRIPTION
## Summary

Phase 7 of the SEP-2663 (Tasks Extension) plan in `PLAN.md`. Issues: #320 (SEP-2663), #321 (SEP-2322).

This is the user-visible payoff PR: the v2 example, walkthrough, and conformance suite all move onto the canonical SEP-2663 surface, and the **conformance suite drives every wire-shape and behavioral change introduced across Phases 1–6 end-to-end**. Result: **26/26 v2 scenarios pass**, verified via both inline runs and `make testconf-tasks-v2`.

## Example server (`examples/tasks-v2`)
- New `confirm_delete` tool exercises the SEP-2663 MRTR loop: calls `TaskElicit`, parks the task in `input_required`, resumes via `tasks/update`. Stand-in for the Phase 7 plan's named tool.
- Server log lists the new tool in the startup banner.

## v2 walkthrough (`examples/tasks-v2/walkthrough.go` + `WALKTHROUGH.md`)
- Title bumped: SEP-2557 → SEP-2663.
- Replaces raw `c.Call("tools/call", ...)` + manual `CreateTaskResult` parsing with **`client.ToolCall`** (polymorphic `ToolCallResult` with `.Sync` / `.Task`).
- Replaces the inline `pollV2` helper with **`client.WaitForTask`** (which honors the server's `PollIntervalMilliseconds` hint and threads `requestState` automatically).
- Replaces raw `tasks/cancel` with **`client.CancelTask`** (now an empty ack).
- New step 7 walks the **elicit → tasks/update → complete** loop using `client.UpdateTask`, surfacing the server-minted opaque key.
- Updated section pointer points at `PLAN.md` and the new `client/tasks.go`.
- `WALKTHROUGH.md` regenerated via `make readme`.

## Conformance suite (`conformance/tasks-v2/scenarios.test.ts`)

### Infrastructure
- Header docstring + `describe()` name updated to SEP-2663 with references to SEP-2322 / SEP-2575 / SEP-2243.
- `before()` declares the `io.modelcontextprotocol/tasks` extension on both the SDK Client and the raw fetch session. A SECOND raw session is initialized **without** the extension for the negative-gate scenarios.
- New `initRawSession` helper consolidates the raw initialize + `notifications/initialized` dance.
- `getTask` simplified (drops `inputResponses` param — that's `tasks/update` now). New `updateTask` helper. `rawRequestFull` returns the raw `Response` so header-inspecting scenarios can read transport-level headers.

### Updated scenarios
- **v2-07 cancel**: now asserts the empty `{}` ack (per SEP-2663) instead of a rich task envelope. Status-settles-to-cancelled assertion preserved via the follow-up `tasks/get`.
- **v2-11 capabilities**: asserts the extension IS advertised under `capabilities.extensions[io.modelcontextprotocol/tasks]` AND that the v1 `capabilities.tasks` slot stays absent.
- **v2-12 TTL**: renamed to `ttlSeconds`; also asserts the old `ttl` key is absent (catching servers that left the v1 wire field in by mistake).
- **v2-17 inputResponses**: switched from `getTask({inputResponses})` to the SEP-2663 `tasks/update` method. Asserts the empty `{}` ack and that the task settles to `completed` after delivery.

### New scenarios (5)
- **v2-22**: `tasks/get` / `tasks/update` / `tasks/cancel` return `-32601` when the session did not negotiate the extension.
- **v2-23**: `tools/call` from a session without the extension returns a sync `ToolResult` (no `resultType`, no `task` envelope).
- **v2-24** / **v2-24b**: SEP-2243 `Mcp-Name` response header is set on task-creating `tools/call` (and absent on sync).
- **v2-25**: SEP-2575 per-request `_meta` opt-in produces `CreateTaskResult` even when session-level extension was not declared.

## Makefile (`testconf-tasks-v2`)
- Pass `--serve` to the example binary (post-Phase-4 the binary defaults to demo mode and was silently failing to start).
- Drop the `--test-name-pattern 'v2-(?!1[67])'` exclusion: Phase 5 closed the MRTR loop, so v2-16 + v2-17 are no longer deferred.

## Test plan
- [x] `make test` — core / server / client / testutil all green.
- [x] **`make testconf-tasks-v2` — 26/26 scenarios pass.**
- [x] Inline conformance run (post-build) — 26/26 pass.
- [x] `make testconf-tasks` — v1 conformance unaffected.
- [x] Manual smoke: `cd examples/tasks-v2 && make demo` walks through all 8 steps including the new MRTR step, against a `make serve` server.

## What's NOT in this PR
- **Phase 8** — backcompat bridge: documenting that v1 (`RegisterTasksV1`) and v2 (`RegisterTasks`) can coexist on the same server, and writing the migration guide. Last phase.