### PR TITLE
feat(events): default WebhookHeaderMode to StandardWebhooks

### DIFF
--- a/examples/events/discord/e2e_test.go
+++ b/examples/events/discord/e2e_test.go
@@ -147,11 +147,10 @@ func TestE2EPushDelivery(t *testing.T) {
 	assert.Contains(t, received, "notifications/events/event")
 }
 
-// TestE2EWebhookDelivery verifies webhook fanout via the default secret mode
-// (Server). Demonstrates the post-PR-C contract: the server generates the
-// secret regardless of what the client supplied, returns it in the subscribe
-// response, and signs deliveries with the generated secret. The receiver
-// uses the returned secret to verify.
+// TestE2EWebhookDelivery verifies webhook fanout via the default modes:
+// Server-generated secret + StandardWebhooks header naming. The latter is
+// the post-r3167245184 default (upstream WG PR#1 line 434, author aligned
+// on Standard Webhooks).
 func TestE2EWebhookDelivery(t *testing.T) {
 	srv, _, yield, webhooks := buildTestStack()
 
@@ -161,12 +160,14 @@ func TestE2EWebhookDelivery(t *testing.T) {
 
 	callbackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
-		sig := r.Header.Get("X-MCP-Signature")
-		ts := r.Header.Get("X-MCP-Timestamp")
+		msgID := r.Header.Get("webhook-id")
+		ts := r.Header.Get("webhook-timestamp")
+		sig := r.Header.Get("webhook-signature")
 		mu.Lock()
 		secret := assignedSecret
 		mu.Unlock()
-		assert.True(t, events.VerifyMCPSignature(body, secret, ts, sig), "signature should verify against the server-assigned secret")
+		assert.True(t, events.VerifyStandardWebhooksSignature(body, secret, msgID, ts, sig), "signature should verify against the server-assigned secret")
+		assert.Empty(t, r.Header.Get("X-MCP-Signature"), "default header mode must NOT emit X-MCP-* headers")
 
 		var event events.Event
 		json.Unmarshal(body, &event)
@@ -280,12 +281,13 @@ func TestE2EWebhookDelivery_IdentityMode(t *testing.T) {
 
 	callbackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
-		sig := r.Header.Get("X-MCP-Signature")
-		ts := r.Header.Get("X-MCP-Timestamp")
+		msgID := r.Header.Get("webhook-id")
+		ts := r.Header.Get("webhook-timestamp")
+		sig := r.Header.Get("webhook-signature")
 		mu.Lock()
 		secret := assignedSecret
 		mu.Unlock()
-		assert.True(t, events.VerifyMCPSignature(body, secret, ts, sig), "delivery should sign with the derived secret")
+		assert.True(t, events.VerifyStandardWebhooksSignature(body, secret, msgID, ts, sig), "delivery should sign with the derived secret (Standard Webhooks default)")
 
 		var event events.Event
 		json.Unmarshal(body, &event)
@@ -336,10 +338,10 @@ func TestE2EWebhookDelivery_IdentityMode(t *testing.T) {
 	require.Len(t, deliveries, 1, "delivery must reach the receiver under the derived secret")
 }
 
-// TestE2EWebhookDelivery_StandardHeaders verifies that switching the header
-// mode to StandardWebhooks emits webhook-id / webhook-timestamp /
-// webhook-signature on the wire and that the signature verifies via the
-// Standard Webhooks verifier (not the X-MCP-* one).
+// TestE2EWebhookDelivery_StandardHeaders pins the StandardWebhooks header
+// path explicitly. Today this is also the default (covered by
+// TestE2EWebhookDelivery), but the explicit opt-in test stays so the wire
+// format remains pinned regardless of any future default flip.
 func TestE2EWebhookDelivery_StandardHeaders(t *testing.T) {
 	srv, _, yield, _ := buildTestStack(
 		events.WithWebhookHeaderMode(events.StandardWebhooks),
@@ -387,6 +389,63 @@ func TestE2EWebhookDelivery_StandardHeaders(t *testing.T) {
 	mu.Unlock()
 
 	require.NoError(t, yield(newDiscordEvent("g", "c", "alice", "standard-headers test", time.Now())))
+	time.Sleep(500 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 1, deliveries)
+}
+
+// TestE2EWebhookDelivery_MCPHeadersOptIn pins the MCPHeaders header path
+// explicitly. Symmetric to TestE2EWebhookDelivery_StandardHeaders — the
+// non-default mode is opted into via WithWebhookHeaderMode and verified
+// for byte-format on the wire.
+func TestE2EWebhookDelivery_MCPHeadersOptIn(t *testing.T) {
+	srv, _, yield, _ := buildTestStack(
+		events.WithWebhookHeaderMode(events.MCPHeaders),
+	)
+
+	var mu sync.Mutex
+	var deliveries int
+	var assignedSecret string
+
+	callbackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		sig := r.Header.Get("X-MCP-Signature")
+		ts := r.Header.Get("X-MCP-Timestamp")
+		assert.NotEmpty(t, sig, "must emit X-MCP-Signature")
+		assert.NotEmpty(t, ts, "must emit X-MCP-Timestamp")
+		assert.True(t, len(sig) > 7 && sig[:7] == "sha256=", "signature must be sha256=<hex>")
+		assert.Empty(t, r.Header.Get("webhook-signature"), "must NOT emit webhook-* headers in MCP mode")
+
+		mu.Lock()
+		secret := assignedSecret
+		mu.Unlock()
+		assert.True(t, events.VerifyMCPSignature(body, secret, ts, sig))
+
+		mu.Lock()
+		deliveries++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer callbackSrv.Close()
+
+	c, _ := connectClient(t, srv)
+	raw, err := c.Call("events/subscribe", map[string]any{
+		"id":       "wh-mcp",
+		"name":     "discord.message",
+		"delivery": map[string]any{"mode": "webhook", "url": callbackSrv.URL},
+	})
+	require.NoError(t, err)
+	var resp struct {
+		Secret string `json:"secret"`
+	}
+	require.NoError(t, json.Unmarshal(raw.Raw, &resp))
+	mu.Lock()
+	assignedSecret = resp.Secret
+	mu.Unlock()
+
+	require.NoError(t, yield(newDiscordEvent("g", "c", "alice", "mcp-headers test", time.Now())))
 	time.Sleep(500 * time.Millisecond)
 
 	mu.Lock()

--- a/examples/events/discord/main.go
+++ b/examples/events/discord/main.go
@@ -47,7 +47,7 @@ func serve() {
 	token := flag.String("token", "", "Discord bot token (omit for test mode)")
 	whTTL := flag.Duration("webhook-ttl", 0, "override webhook subscription TTL (default 60s; useful for driving the SDK refresh path in tests)")
 	whSecretMode := flag.String("webhook-secret-mode", "server", "webhook secret mode: server | client | identity")
-	whHeaderMode := flag.String("webhook-header-mode", "mcp", "webhook header style: mcp | standard")
+	whHeaderMode := flag.String("webhook-header-mode", "standard", "webhook header style: standard | mcp")
 	whRootHex := flag.String("webhook-root", "", "hex-encoded master secret for identity mode (required when -webhook-secret-mode=identity)")
 	flag.CommandLine.Parse(filterFlags(os.Args[1:]))
 

--- a/examples/events/telegram/e2e_test.go
+++ b/examples/events/telegram/e2e_test.go
@@ -154,10 +154,10 @@ func TestE2EPushDelivery(t *testing.T) {
 	assert.Contains(t, received, "notifications/events/event")
 }
 
-// TestE2EWebhookDelivery verifies webhook fanout via the default secret
-// mode (Server). Per the post-PR-C contract: server generates the secret
-// regardless of what the client supplies, returns it on subscribe, and
-// signs deliveries with the generated secret.
+// TestE2EWebhookDelivery verifies webhook fanout via the default modes:
+// Server-generated secret + StandardWebhooks header naming. The latter is
+// the post-r3167245184 default (upstream WG PR#1 line 434, author aligned
+// on Standard Webhooks).
 func TestE2EWebhookDelivery(t *testing.T) {
 	srv, _, yield, webhooks := buildTestStack()
 
@@ -167,12 +167,14 @@ func TestE2EWebhookDelivery(t *testing.T) {
 
 	callbackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
-		sig := r.Header.Get("X-MCP-Signature")
-		ts := r.Header.Get("X-MCP-Timestamp")
+		msgID := r.Header.Get("webhook-id")
+		ts := r.Header.Get("webhook-timestamp")
+		sig := r.Header.Get("webhook-signature")
 		mu.Lock()
 		secret := assignedSecret
 		mu.Unlock()
-		assert.True(t, events.VerifyMCPSignature(body, secret, ts, sig), "signature should verify against the server-assigned secret")
+		assert.True(t, events.VerifyStandardWebhooksSignature(body, secret, msgID, ts, sig), "signature should verify against the server-assigned secret")
+		assert.Empty(t, r.Header.Get("X-MCP-Signature"), "default header mode must NOT emit X-MCP-* headers")
 
 		var event events.Event
 		json.Unmarshal(body, &event)
@@ -235,12 +237,13 @@ func TestE2EWebhookDelivery_IdentityMode(t *testing.T) {
 
 	callbackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
-		sig := r.Header.Get("X-MCP-Signature")
-		ts := r.Header.Get("X-MCP-Timestamp")
+		msgID := r.Header.Get("webhook-id")
+		ts := r.Header.Get("webhook-timestamp")
+		sig := r.Header.Get("webhook-signature")
 		mu.Lock()
 		secret := assignedSecret
 		mu.Unlock()
-		assert.True(t, events.VerifyMCPSignature(body, secret, ts, sig))
+		assert.True(t, events.VerifyStandardWebhooksSignature(body, secret, msgID, ts, sig))
 		mu.Lock()
 		deliveries++
 		mu.Unlock()
@@ -344,6 +347,68 @@ func TestE2EWebhookDelivery_StandardHeaders(t *testing.T) {
 	mu.Unlock()
 
 	require.NoError(t, yieldText(yield, 100, "alice", "standard-headers test"))
+	time.Sleep(500 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 1, deliveries)
+}
+
+// TestE2EWebhookDelivery_MCPHeadersOptIn pins the MCPHeaders header path
+// explicitly. Symmetric to TestE2EWebhookDelivery_StandardHeaders — the
+// non-default mode is opted into via WithWebhookHeaderMode and verified
+// for byte-format on the wire.
+func TestE2EWebhookDelivery_MCPHeadersOptIn(t *testing.T) {
+	srv, _, yield, _ := buildTestStack(
+		events.WithWebhookHeaderMode(events.MCPHeaders),
+	)
+
+	var mu sync.Mutex
+	var deliveries int
+	var assignedSecret string
+
+	callbackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		sig := r.Header.Get("X-MCP-Signature")
+		ts := r.Header.Get("X-MCP-Timestamp")
+		assert.NotEmpty(t, sig, "must emit X-MCP-Signature")
+		assert.NotEmpty(t, ts, "must emit X-MCP-Timestamp")
+		assert.True(t, len(sig) > 7 && sig[:7] == "sha256=", "signature must be sha256=<hex>")
+		assert.Empty(t, r.Header.Get("webhook-signature"), "must NOT emit webhook-* headers in MCP mode")
+
+		mu.Lock()
+		secret := assignedSecret
+		mu.Unlock()
+		assert.True(t, events.VerifyMCPSignature(body, secret, ts, sig))
+
+		mu.Lock()
+		deliveries++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer callbackSrv.Close()
+
+	handler := srv.Handler(server.WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "mcphdr-test", Version: "1.0"})
+	require.NoError(t, c.Connect())
+
+	raw, err := c.Call("events/subscribe", map[string]any{
+		"id":       "wh-mcp",
+		"name":     "telegram.message",
+		"delivery": map[string]any{"mode": "webhook", "url": callbackSrv.URL},
+	})
+	require.NoError(t, err)
+	var resp struct {
+		Secret string `json:"secret"`
+	}
+	require.NoError(t, json.Unmarshal(raw.Raw, &resp))
+	mu.Lock()
+	assignedSecret = resp.Secret
+	mu.Unlock()
+
+	require.NoError(t, yieldText(yield, 100, "alice", "mcp-headers test"))
 	time.Sleep(500 * time.Millisecond)
 
 	mu.Lock()

--- a/examples/events/telegram/handlers_test.go
+++ b/examples/events/telegram/handlers_test.go
@@ -183,9 +183,11 @@ func TestResourceMessageByCursor(t *testing.T) {
 	assert.Equal(t, "message 2", payload.Text)
 }
 
-// TestWebhookHMACSignature verifies HMAC-SHA256(secret, ts + "." + body)
-// signing matches what receivers expect — protocol-level webhook contract.
-func TestWebhookHMACSignature(t *testing.T) {
+// TestWebhookHMACSignature_MCPHeaders pins the X-MCP-* wire shape under the
+// MCPHeaders opt-in. After the default flip to Standard Webhooks
+// (r3167245184), the registry must be explicitly configured with
+// WithWebhookHeaderMode(MCPHeaders) for this byte-format check to apply.
+func TestWebhookHMACSignature_MCPHeaders(t *testing.T) {
 	secret := "test-secret-key"
 	var receivedBody []byte
 	var receivedSig, receivedTS string
@@ -198,7 +200,7 @@ func TestWebhookHMACSignature(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	webhooks := events.NewWebhookRegistry()
+	webhooks := events.NewWebhookRegistry(events.WithWebhookHeaderMode(events.MCPHeaders))
 	webhooks.Register("hmac-test", srv.URL, secret)
 
 	event := events.MakeEvent("telegram.message", "evt_1", "1", time.Now(),

--- a/examples/events/telegram/main.go
+++ b/examples/events/telegram/main.go
@@ -45,7 +45,7 @@ func serve() {
 	addr := flag.String("addr", ":8080", "listen address")
 	token := flag.String("token", "", "Telegram bot token (omit for test mode)")
 	whSecretMode := flag.String("webhook-secret-mode", "server", "webhook secret mode: server | client | identity")
-	whHeaderMode := flag.String("webhook-header-mode", "mcp", "webhook header style: mcp | standard")
+	whHeaderMode := flag.String("webhook-header-mode", "standard", "webhook header style: standard | mcp")
 	whRootHex := flag.String("webhook-root", "", "hex-encoded master secret for identity mode (required when -webhook-secret-mode=identity)")
 	flag.CommandLine.Parse(filterFlags(os.Args[1:]))
 

--- a/experimental/ext/events/DEPLOYMENT.md
+++ b/experimental/ext/events/DEPLOYMENT.md
@@ -50,8 +50,8 @@ For deployments where the receiver sits behind a WAF, the rules need to allow we
 | **Path** | Whatever the subscriber registered (`callback_url`) | The MCP server POSTs to exactly this URL |
 | **Source IP** | The MCP server's egress IPs | Restrict to known issuers |
 | **Headers required** | `Content-Type: application/json` + the signature pair (see below) | Reject unsigned requests at the edge |
-| **Headers (MCPHeaders mode, default)** | `X-MCP-Signature` (`sha256=<hex>`) + `X-MCP-Timestamp` (unix seconds) | The two-field signature pair |
-| **Headers (StandardWebhooks mode)** | `webhook-id` + `webhook-timestamp` + `webhook-signature` (`v1,<base64>`) | Per [standardwebhooks.com](https://www.standardwebhooks.com/) |
+| **Headers (StandardWebhooks mode, default)** | `webhook-id` + `webhook-timestamp` + `webhook-signature` (`v1,<base64>`) | Per [standardwebhooks.com](https://www.standardwebhooks.com/) |
+| **Headers (MCPHeaders mode, opt-in)** | `X-MCP-Signature` (`sha256=<hex>`) + `X-MCP-Timestamp` (unix seconds) | The pre-r3167245184 default; opt-in for callers that already wired against this shape |
 | **Body size** | Reasonable cap (1 MB is plenty for almost any event payload) | Limit DoS surface |
 | **Rate limit** | Per source IP, generous (≥ 100 r/s) | Bursts happen during reconnects + identity-mode rebroadcasts |
 

--- a/experimental/ext/events/README.md
+++ b/experimental/ext/events/README.md
@@ -164,8 +164,8 @@ Two on-the-wire signature formats. Default is `MCPHeaders`. Only the headers and
 
 | Mode | Headers | HMAC base |
 |---|---|---|
-| `MCPHeaders` (default) | `X-MCP-Signature: sha256=<hex>` + `X-MCP-Timestamp: <unix>` | `HMAC(secret, ts + "." + body)` |
-| `StandardWebhooks` | `webhook-id`, `webhook-timestamp`, `webhook-signature: v1,<base64>` per [standardwebhooks.com](https://www.standardwebhooks.com/) | `HMAC(secret, msg_id + "." + ts + "." + body)` |
+| `StandardWebhooks` (default) | `webhook-id`, `webhook-timestamp`, `webhook-signature: v1,<base64>` per [standardwebhooks.com](https://www.standardwebhooks.com/) | `HMAC(secret, msg_id + "." + ts + "." + body)` |
+| `MCPHeaders` (opt-in) | `X-MCP-Signature: sha256=<hex>` + `X-MCP-Timestamp: <unix>` | `HMAC(secret, ts + "." + body)` |
 
 Verification helpers ship for both:
 

--- a/experimental/ext/events/headers.go
+++ b/experimental/ext/events/headers.go
@@ -14,42 +14,47 @@ import (
 )
 
 // WebhookHeaderMode selects the header / signature wire format for outbound
-// webhook deliveries. Defaults to MCPHeaders.
+// webhook deliveries. Defaults to StandardWebhooks per upstream WG PR#1
+// line 434 (comment r3167245184) — author signaled alignment on Standard
+// Webhooks naming. MCPHeaders is retained as an opt-in mode for clients
+// that already standardized on the X-MCP-* shape.
 type WebhookHeaderMode int
 
 const (
-	// MCPHeaders emits X-MCP-Signature and X-MCP-Timestamp with the
-	// signature computed as HMAC(secret, ts + "." + body).
-	MCPHeaders WebhookHeaderMode = iota
-
-	// StandardWebhooks emits webhook-id, webhook-timestamp, and
+	// StandardWebhooks (default) emits webhook-id, webhook-timestamp, and
 	// webhook-signature ("v1,<base64>") per https://standardwebhooks.com/.
 	// HMAC base is webhook_id + "." + webhook_timestamp + "." + body.
 	// Note: only the headers/signature scheme is adopted — the Standard
 	// Webhooks payload envelope is intentionally out of scope here.
-	StandardWebhooks
+	StandardWebhooks WebhookHeaderMode = iota
+
+	// MCPHeaders emits X-MCP-Signature and X-MCP-Timestamp with the
+	// signature computed as HMAC(secret, ts + "." + body). Was the
+	// pre-r3167245184 default; kept as an opt-in for callers that
+	// already wired against this shape.
+	MCPHeaders
 )
 
 // String renders the mode as a config-flag-friendly token.
 func (m WebhookHeaderMode) String() string {
 	switch m {
-	case StandardWebhooks:
-		return "standard"
-	default:
+	case MCPHeaders:
 		return "mcp"
+	default:
+		return "standard"
 	}
 }
 
 // ParseHeaderMode converts a flag-style token ("mcp" or "standard") to a
-// WebhookHeaderMode. Empty string returns the default (MCPHeaders).
+// WebhookHeaderMode. Empty string returns the default (StandardWebhooks).
 func ParseHeaderMode(s string) (WebhookHeaderMode, error) {
 	switch strings.ToLower(strings.TrimSpace(s)) {
-	case "", "mcp":
-		return MCPHeaders, nil
-	case "standard", "standardwebhooks", "standard-webhooks":
+	case "", "standard", "standardwebhooks", "standard-webhooks":
 		return StandardWebhooks, nil
+	case "mcp":
+		return MCPHeaders, nil
 	default:
-		return MCPHeaders, fmt.Errorf("unknown header mode %q (want mcp|standard)", s)
+		return StandardWebhooks, fmt.Errorf("unknown header mode %q (want standard|mcp)", s)
 	}
 }
 
@@ -113,10 +118,10 @@ func signStandardWebhooks(body []byte, secret string, now time.Time) signedDeliv
 // signFor selects the right signer for the registry's mode.
 func signFor(mode WebhookHeaderMode, body []byte, secret string, now time.Time) signedDelivery {
 	switch mode {
-	case StandardWebhooks:
-		return signStandardWebhooks(body, secret, now)
-	default:
+	case MCPHeaders:
 		return signMCP(body, secret, now)
+	default:
+		return signStandardWebhooks(body, secret, now)
 	}
 }
 

--- a/experimental/ext/events/headers_test.go
+++ b/experimental/ext/events/headers_test.go
@@ -15,18 +15,19 @@ import (
 
 // TestParseHeaderMode_Aliases verifies the flag parser accepts the friendly
 // alias forms ("mcp", "standard", "standardwebhooks", "standard-webhooks")
-// case-insensitively, and that empty string falls back to the default. The
-// CLI flag plumbing depends on this — keeping it loose lets users not memorize
-// the exact spelling.
+// case-insensitively, and that empty string falls back to the default
+// (StandardWebhooks per upstream WG PR#1 line 434, comment r3167245184).
+// The CLI flag plumbing depends on this — keeping it loose lets users not
+// memorize the exact spelling.
 func TestParseHeaderMode_Aliases(t *testing.T) {
 	cases := map[string]WebhookHeaderMode{
-		"":                  MCPHeaders,
-		"mcp":               MCPHeaders,
-		"MCP":               MCPHeaders,
+		"":                  StandardWebhooks,
 		"standard":          StandardWebhooks,
 		"Standard":          StandardWebhooks,
 		"standardwebhooks":  StandardWebhooks,
 		"standard-webhooks": StandardWebhooks,
+		"mcp":               MCPHeaders,
+		"MCP":               MCPHeaders,
 	}
 	for in, want := range cases {
 		got, err := ParseHeaderMode(in)

--- a/experimental/ext/events/webhook.go
+++ b/experimental/ext/events/webhook.go
@@ -31,8 +31,9 @@ func WithWebhookTTL(ttl time.Duration) WebhookOption {
 }
 
 // WithWebhookHeaderMode selects the header / signature wire format used for
-// outbound deliveries. Defaults to MCPHeaders. See WebhookHeaderMode for the
-// available modes (MCPHeaders, StandardWebhooks).
+// outbound deliveries. Defaults to StandardWebhooks (per upstream WG PR#1
+// line 434, comment r3167245184). See WebhookHeaderMode for the available
+// modes (StandardWebhooks, MCPHeaders).
 func WithWebhookHeaderMode(mode WebhookHeaderMode) WebhookOption {
 	return func(r *WebhookRegistry) {
 		r.headerMode = mode
@@ -86,8 +87,9 @@ type WebhookRegistry struct {
 }
 
 // NewWebhookRegistry creates an empty registry with the documented defaults:
-// 5-second HTTP timeout, 60-second TTL, MCPHeaders signing, WebhookSecretServer
-// (server always generates secrets). Override via the With* options.
+// 5-second HTTP timeout, 60-second TTL, StandardWebhooks signing,
+// WebhookSecretServer (server always generates secrets). Override via the
+// With* options.
 //
 // Identity mode requires WithWebhookRoot. If the caller selects identity
 // mode without providing a root, NewWebhookRegistry panics — surfacing the
@@ -97,7 +99,7 @@ func NewWebhookRegistry(opts ...WebhookOption) *WebhookRegistry {
 		targets:    make(map[string]WebhookTarget),
 		client:     &http.Client{Timeout: 5 * time.Second},
 		ttl:        defaultWebhookTTL,
-		headerMode: MCPHeaders,
+		headerMode: StandardWebhooks,
 		secretMode: WebhookSecretServer,
 	}
 	for _, o := range opts {


### PR DESCRIPTION
## Summary

Flips the default `WebhookHeaderMode` from `MCPHeaders` to `StandardWebhooks`.

PR C (#327) deliberately kept the default at `MCPHeaders` to avoid pre-empting a WG decision. Upstream author has now signaled alignment on Standard Webhooks naming, so the pre-emption window closed and the conservative default no longer matches the spec direction.

## Changes

### Library (`experimental/ext/events`)
- `WebhookHeaderMode` iota order swapped: `StandardWebhooks` is now value 0 (zero default), `MCPHeaders` becomes opt-in.
- `ParseHeaderMode` empty-string falls through to `StandardWebhooks`.
- `NewWebhookRegistry` default `headerMode` flipped.
- `signFor` switch defaults to Standard Webhooks signing.
- Doc comments updated; README + DEPLOYMENT.md tables reordered (Standard Webhooks first, marked default).

### Demos
- `-webhook-header-mode` flag default flipped from `"mcp"` to `"standard"` in both demos.
- `TestE2EWebhookDelivery` in both demos: assertions updated to verify `webhook-*` headers and assert `X-MCP-Signature` is absent.
- `TestE2EWebhookDelivery_IdentityMode`: same — Identity mode now signs via Standard Webhooks (the default header mode).
- New `TestE2EWebhookDelivery_MCPHeadersOptIn` in both demos pins the `MCPHeaders` byte format under explicit opt-in. Symmetric to the existing `_StandardHeaders` test so **both wire formats stay pinned regardless of any future default flip**.
- `telegram-events/handlers_test.go`: `TestWebhookHMACSignature` renamed to `TestWebhookHMACSignature_MCPHeaders` and constructed with `WithWebhookHeaderMode(MCPHeaders)` explicitly.

## Tests

`make test-experimental` green across all four modules:
- `experimental/ext/events/` — 36 tests + parse-aliases test updated for new default
- `experimental/ext/events/clients/go/` — 12 tests (no change; auto-detect handles both header modes)
- `examples/events/discord/` — 11 tests (TestE2EWebhookDelivery + IdentityMode updated; new MCPHeadersOptIn added)
- `examples/events/telegram/` — 13 tests (same update + handlers_test rename)

`make test-ttl` still passes.

### Assertion-count audit

Existing tests' assertions were updated, not weakened — they now verify the **new** default's wire shape. Two new tests (`TestE2EWebhookDelivery_MCPHeadersOptIn` in each demo) add coverage for the opt-in path; net assertion count goes up.

## References (non-linking)

```
panyam/mcpkit#323 (umbrella)
panyam/mcpkit#327 (PR C — secret + header modes; this PR flips C's default)

Upstream alignment that triggered the flip:
  https://github.com/modelcontextprotocol/experimental-ext-triggers-events/pull/1#discussion_r3167245184
```
