### PR TITLE
fix: SEP-2322 / SEP-2663 audit gap fixes (3 gaps)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,8 +1,8 @@
 # Plan: SEP-2322 (MRTR) + SEP-2663 (Tasks Extension)
 
-**Status:** ✅ COMPLETE — all 8 phases shipped (PRs #324, #328, #329, #331, #334; Phase 8 in flight on `feat/sep-2663-phase-8`). 26/26 v2 conformance scenarios passing. v1 frozen alongside via `RegisterTasksV1`; hybrid via `RegisterTasksHybrid`. User-facing summary in [`docs/TASKS_V2_MIGRATION.md`](docs/TASKS_V2_MIGRATION.md).
+**Status:** ✅ COMPLETE — all 8 phases shipped (PRs 324, 328, 329, 331, 334, 335) + audit gap fixes (in flight on `feat/sep-2663-audit-fixes`). 27/27 v2 conformance scenarios passing. v1 frozen alongside via `RegisterTasksV1`; hybrid via `RegisterTasksHybrid`. User-facing summary in [`docs/TASKS_V2_MIGRATION.md`](docs/TASKS_V2_MIGRATION.md).
 
-**Issues:** mcpkit#320 (SEP-2663), mcpkit#321 (SEP-2322)
+**Issues:** issue 320 (SEP-2663), issue 321 (SEP-2322)
 **Branch:** `feat/tasks-extension` (from main)
 **Approach:** Evolve v2 in place (Option B). No parallel files.
 
@@ -124,7 +124,7 @@ Example server tools:
 - `failing_job` — async, transitions to `failed` (protocol error)
 - `confirm_delete` — async, transitions to `input_required`, resumes via `tasks/update`
 
-Conformance evolution (from mcpkit#320 comment):
+Conformance evolution (from issue 320 comment):
 - Keep passing scenarios, adjust shapes (ack-only cancel, etc.)
 - Rework v2-11 → extension negotiation
 - Rework v2-16/v2-17 → `tasks/update` flow (currently unimplemented)
@@ -172,14 +172,18 @@ Phase 6 (client) → Phase 7 (example + conformance) → Phase 8 (bridge)
 
 ## Open spec questions (watch before finalizing)
 
-1. `requestState` rejection: synchronous `-32602` or silent? (Luca TBD)
-2. SEP-2575 per-request capabilities shape — may change
-3. `tasks/update` / `tasks/cancel` ack for unknown taskId — may add optional validation errors
+Tracked in the living register issue titled "Tracking: SEP-2322 / SEP-2663 / SEP-2575 open spec questions" (issue 339) — code pins, test pins, and triggers for revisiting. Three entries today:
+
+1. `requestState` rejection: synchronous `-32602` or silent? — picked `-32602`.
+2. SEP-2575 per-request capabilities shape — using opaque `json.RawMessage` envelope so shape can change without consumer churn.
+3. `tasks/update` / `tasks/cancel` ack for unknown taskId — picked `-32602`.
+
+The pattern (loud failure + inline `// Open spec question` comment + named conformance scenario as the change-detector) is documented in the issue.
 
 ## Reference
 
 - SEP-2663 PR: https://github.com/modelcontextprotocol/specification/pull/2663
 - SEP-2322 PR: https://github.com/modelcontextprotocol/specification/pull/2322
-- SEP-2663 analysis: mcpkit#320
-- Existing v2 PR: mcpkit#301 (19/21 conformance)
-- Conformance test evolution: mcpkit#320 comment
+- SEP-2663 analysis: issue 320
+- Existing v2 PR: PR 301 (19/21 conformance)
+- Conformance test evolution: issue 320 comment

--- a/conformance/tasks-v2/README.md
+++ b/conformance/tasks-v2/README.md
@@ -1,133 +1,188 @@
-# MCP Tasks v2 Conformance Suite (SEP-2557)
+# MCP Tasks v2 Conformance Suite (SEP-2663)
 
-Tests any MCP server that implements the Tasks v2 protocol as proposed in [SEP-2557](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2557). Uses the official [MCP TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk) client.
+Tests any MCP server that implements the Tasks v2 surface, evolving from the original SEP-2557 draft to the current SEP-2663 (Tasks Extension) shape with SEP-2322 (MRTR base types), SEP-2575 (per-request capabilities), and SEP-2243 (Mcp-Name HTTP header).
 
-**SEP Status:** Draft, targeted for 2026-06-30-RC milestone.
+The suite drives wire-shape and behavioral assertions against any conformant server using the official [MCP TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk) client plus raw `fetch` for assertions the SDK's typed schemas would strip.
 
-These tests are written ahead of the spec being finalized — they will evolve as the SEP is refined. All scenarios are expected to **fail** until a v2 server implementation exists.
+**Current result against the in-repo server:** 27/27 scenarios passing.
 
-## What changed from v1
+## Specs covered
 
-| Aspect | v1 (spec 2025-11-25) | v2 (SEP-2557) |
+| SEP | What it adds | Where it shows up |
+|-----|--------------|-------------------|
+| SEP-2663 | Tasks Extension — `io.modelcontextprotocol/tasks` capability, `DetailedTask`, `tasks/update`, ack-only `tasks/cancel`, wire-field renames (`ttlSeconds`, `pollIntervalMilliseconds`) | v2-02, v2-04, v2-07, v2-09, v2-10, v2-11, v2-12, v2-17, v2-22, v2-23 |
+| SEP-2322 | MRTR base types — `inputRequests`/`inputResponses` maps, `requestState`, `resultType` discriminator (`task`/`complete`/`incomplete`) | v2-14, v2-15, v2-16, v2-17, v2-26 |
+| SEP-2575 | Per-request capability override via `_meta.io.modelcontextprotocol/clientCapabilities` | v2-25 |
+| SEP-2243 | `Mcp-Name` HTTP response header on task-creating responses | v2-24, v2-24b |
+
+These are deliberately kept in **one file** rather than split per-SEP. The test harness (initialize handshake, raw fetch session, extension declaration, tool fixtures) is identical for every scenario; splitting would duplicate the harness without behavioral gain. If a future non-tasks consumer of SEP-2322 appears (e.g., MRTR-style input rounds outside the tasks surface), that's the trigger to extract a separate `conformance/mrtr-base/` suite.
+
+## Wire-format diff vs v1
+
+| Aspect | v1 (spec 2025-11-25) | v2 (SEP-2663) |
 |--------|----------------------|---------------|
-| Task creation | Client sends `task` param | Server decides unilaterally |
-| `tasks/get` | Returns status only | Returns status + inlined result/error/inputRequests |
-| `tasks/result` | Separate blocking method | **Removed** |
-| `tasks/list` | Session-scoped list | **Removed** |
-| `tasks/cancel` | Optional | **Required** |
-| TTL units | Milliseconds | **Seconds** |
-| `requestState` | N/A | Opaque server state, echoed by client |
-| Input handling | Side-channel via `tasks/result` | Inline `inputRequests`/`inputResponses` in `tasks/get` |
-| Capabilities | Negotiated via `TasksCap` | **Removed** — tasks are core protocol |
-| `execution.taskSupport` | Per-tool field | **Removed** |
+| Capability slot | `capabilities.tasks` | `capabilities.extensions["io.modelcontextprotocol/tasks"]` |
+| Client opt-in | (none — anyone can send `task` hint) | MUST declare extension at session OR per-request (SEP-2575) |
+| Task creation | Client sends `task` hint param | Server decides unilaterally |
+| `resultType` discriminator | absent | `"task"` (CreateTaskResult) / `"complete"` (everything else) |
+| `tasks/get` response | flat `TaskInfo` only | `DetailedTask` with inlined `result`/`error`/`inputRequests`/`requestState` |
+| `tasks/update` | n/a | new — MRTR resume path, returns `{resultType:"complete"}` ack |
+| `tasks/cancel` response | rich task envelope | `{resultType:"complete"}` ack (no task state) |
+| `tasks/result` | separate blocking method | **removed** (result inlined on `tasks/get`) |
+| `tasks/list` | session-scoped list | **removed** |
+| TTL field | `ttl` (ms by convention) | `ttlSeconds` (units in name) |
+| Poll-interval field | `pollInterval` | `pollIntervalMilliseconds` |
+| `parentTaskId` | present | removed |
+| Tool errors | `status:failed` | `status:completed, result.isError:true` |
+| Protocol errors | `status:failed, error:...` | `status:failed, error:{code,message,data}` |
+| `Mcp-Name` HTTP header | not set | set on task-creating responses (SEP-2243) |
+| `requestState` integrity | n/a | optionally HMAC-SHA256 signed via `TasksConfig.RequestStateKey` |
 
-## Prerequisites
+## Required server fixtures
 
 The target server MUST register these tools:
 
-| Tool | Behavior |
-|------|----------|
-| `greet` | Sync-only — returns `Hello, {name}!` |
-| `slow_compute` | Async — sleeps `seconds` seconds, returns result |
-| `failing_job` | Async — always fails after 1 second |
-| `confirm_delete` | Async — elicitation via inputRequests model |
+| Tool | Behavior | Used by |
+|------|----------|---------|
+| `greet` | Sync — returns `Hello, {name}!` | v2-01, v2-26 |
+| `slow_compute` | Async — `seconds`-second sleep, returns result; `seconds:0` for immediate | v2-02 through v2-04, v2-07, v2-08, v2-12, v2-13, v2-14, v2-15, v2-21, v2-23, v2-24, v2-24b, v2-25, v2-26 |
+| `failing_job` | Async — always returns tool error after ~1s | v2-05, v2-19 |
+| `protocol_error_job` | Async — panics, surfaces as protocol error | v2-06 |
+| `confirm_delete` | Async — calls `TaskElicit` to drive the MRTR loop | v2-16, v2-17, v2-26 |
+
+The in-repo `examples/tasks-v2` server registers all of these.
 
 ## Setup
 
 ```bash
-cd conformance
-npm install
+cd conformance && npm install
 ```
 
 ## Usage
 
+Self-contained run (builds the example server, starts it, runs the suite, tears down):
+
 ```bash
-# Start a v2 server (not yet implemented)
-# SERVER_URL=http://localhost:8080/mcp npx tsx --test tasks-v2/scenarios.test.ts
+make testconf-tasks-v2
 ```
 
-## Scenarios
-
-18 scenarios covering the Tasks v2 protocol surface.
-
-### Core Lifecycle
-
-| # | Scenario | What it tests | Expected |
-|---|----------|---------------|----------|
-| 01 | Sync tool call | `greet` returns immediately, no task | Inline result, no `task` field |
-| 02 | Server-directed task creation | Server creates task without client `task` param | `task.taskId` present, non-terminal status |
-| 03 | tasks/get working status | Poll active task | `status: working` or `completed` |
-| 04 | tasks/get completed + inlined result | Poll completed task | `status: completed` + `result` with content |
-| 05 | tasks/get failed + inlined error | Poll failed task | `status: failed` + `error` field |
-| 06 | tasks/cancel (required) | Cancel working task | `status: cancelled` |
-| 07 | Cancel terminal task | Cancel completed task | JSON-RPC error |
-
-### Removed v1 Methods
-
-| # | Scenario | What it tests | Expected |
-|---|----------|---------------|----------|
-| 08 | No tasks/result | Server rejects `tasks/result` | `-32601` MethodNotFound |
-| 09 | No tasks/list | Server rejects `tasks/list` | `-32601` MethodNotFound |
-
-### TTL (seconds)
-
-| # | Scenario | What it tests | Expected |
-|---|----------|---------------|----------|
-| 10 | TTL in seconds | TTL value is reasonable for seconds (not ms) | `ttl < 10000` |
-| 11 | No early expiry | Task exists before TTL elapses | Task accessible |
-
-### requestState
-
-| # | Scenario | What it tests | Expected |
-|---|----------|---------------|----------|
-| 12 | Server returns requestState | tasks/get may include requestState | String if present |
-| 13 | Client echoes requestState | Subsequent tasks/get includes server's requestState | Server accepts |
-
-### Input Handling (MRTR)
-
-| # | Scenario | What it tests | Expected |
-|---|----------|---------------|----------|
-| 14 | inputRequests in tasks/get | `input_required` status has `inputRequests` array | Non-empty array of request objects |
-| 15 | inputResponses resumes task | Client sends responses, task completes | Task transitions to working/completed |
-
-> **Note:** There is an active debate (April 2026) about whether `inputResponses` should
-> live on `tasks/get` or a separate `tasks/continue` method. Scenarios 14-15 use `tasks/get`
-> per the current SEP text. Will update if the spec changes.
-
-### Notifications
-
-| # | Scenario | What it tests | Expected |
-|---|----------|---------------|----------|
-| 16 | DetailedTask in notifications | Terminal notification includes inlined result | Well-formed if received (optional) |
-
-### Task Creation Semantics
-
-| # | Scenario | What it tests | Expected |
-|---|----------|---------------|----------|
-| 17 | No client `task` param | tools/call without `task` still creates task | CreateTaskResult returned |
-| 18 | Immediate result shortcut | Fast operation may skip task creation | CallToolResult or CreateTaskResult (both valid) |
-
-## Design Notes
-
-### Assertions follow v1 lessons
-
-Based on spec maintainer feedback on the v1 suite:
-- Error codes use `assertJsonRpcError(e, code, label, enforce?)` with `ENFORCE_ERROR_CODES = false` by default
-- `enforce = true` only for cases where the code is mandated (e.g., `-32601` for removed methods)
-- TTL assertions check reasonable ranges, not exact values
-- Notifications are optional — well-formed if received
-- No session/auth-context isolation test (identity undefined)
-
-### Shared helpers
-
-Common utilities (`assertJsonRpcError`, `waitForTerminal`, `waitForStatus`) are in `conformance/common/helpers.ts` and shared with the v1 suite.
-
-### Not in CI
-
-This suite is **not** wired into `make testall` or pre-push hooks. No v2 server exists yet. Run manually when testing a v2 implementation:
+Manual run against a server you started yourself:
 
 ```bash
 SERVER_URL=http://localhost:8080/mcp npx tsx --test tasks-v2/scenarios.test.ts
 ```
 
-A `make testconf-tasks-v2` target will be added when a v2 server is available.
+## Scenarios
+
+### Polymorphic dispatch + lifecycle (SEP-2663 + SEP-2322)
+
+| # | Scenario | What it tests | SEPs |
+|---|----------|---------------|------|
+| 01 | Sync tool call | `greet` returns immediately, no task | 2663 |
+| 02 | Server-directed task creation | Server creates task without client `task` param | 2663 |
+| 03 | tasks/get working status | Poll an active task | 2663 |
+| 04 | tasks/get completed + inlined result | Poll completed task — `result` inlined | 2663 |
+| 05 | Tool error → completed + isError | Tool execution errors carry `isError:true` | 2663 |
+| 06 | Protocol error → failed + error | Server-side protocol errors carry `error:{code,message}` | 2663 |
+| 07 | tasks/cancel (empty ack) | Cancel response is `{resultType:"complete"}`; status settles to cancelled | 2663 |
+| 08 | Cancel terminal task | Cancel completed task → `-32602` | 2663 |
+
+### Removed v1 methods
+
+| # | Scenario | What it tests | SEPs |
+|---|----------|---------------|------|
+| 09 | No `tasks/result` | `-32601` MethodNotFound | 2663 |
+| 10 | No `tasks/list` | `-32601` MethodNotFound | 2663 |
+
+### Capability negotiation
+
+| # | Scenario | What it tests | SEPs |
+|---|----------|---------------|------|
+| 11 | Tasks under `capabilities.extensions` | Extension advertised; v1 `capabilities.tasks` slot stays absent | 2663 |
+| 22 | `tasks/*` rejected without extension | `-32601` for clients that didn't negotiate | 2663 |
+| 23 | `tools/call` without extension | Returns sync `ToolResult` (`resultType:"complete"`, no task) | 2663 + 2322 |
+| 25 | Per-request `_meta` opt-in | Produces `CreateTaskResult` even without session-level extension | 2575 |
+
+### TTL + wire fields
+
+| # | Scenario | What it tests | SEPs |
+|---|----------|---------------|------|
+| 12 | `ttlSeconds` present | Renamed from v1 `ttl`; v1 key absent | 2663 |
+| 13 | No early TTL expiry | Task accessible before TTL elapses | 2663 |
+
+### requestState (SEP-2322)
+
+| # | Scenario | What it tests | SEPs |
+|---|----------|---------------|------|
+| 14 | Server returns `requestState` | tasks/get may include it | 2322 |
+| 15 | Client echoes `requestState` | Subsequent tasks/get accepts it | 2322 |
+
+### MRTR — input flow (SEP-2322 + SEP-2663)
+
+| # | Scenario | What it tests | SEPs |
+|---|----------|---------------|------|
+| 16 | `inputRequests` map on `tasks/get` | `input_required` status surfaces pending requests | 2322 |
+| 17 | `tasks/update` resumes task | Client delivers responses via tasks/update; ack is `{resultType:"complete"}` | 2322 + 2663 |
+
+### Notifications
+
+| # | Scenario | What it tests | SEPs |
+|---|----------|---------------|------|
+| 18 | DetailedTask in notifications | Terminal notification includes inlined result | 2663 |
+
+### Misc
+
+| # | Scenario | What it tests | SEPs |
+|---|----------|---------------|------|
+| 19 | No client `task` param | tools/call without `task` still creates task | 2663 |
+| 20 | Immediate result shortcut | Fast operation may skip task creation | 2663 |
+| 21 | No `related-task` `_meta` on inlined result | tasks/get's inlined `result` doesn't carry the v1 _meta key | 2663 |
+
+### SEP-2243: Mcp-Name HTTP header
+
+| # | Scenario | What it tests | SEPs |
+|---|----------|---------------|------|
+| 24 | Mcp-Name on task creation | Task-creating tools/call response carries `Mcp-Name: <taskId>` | 2243 |
+| 24b | Mcp-Name absent on sync | Sync tools/call response does NOT carry the header | 2243 |
+
+### SEP-2322: resultType discriminator across non-task responses
+
+| # | Scenario | What it tests | SEPs |
+|---|----------|---------------|------|
+| 26 | `resultType:"complete"` on non-task responses | Sync tools/call, tasks/get, tasks/update ack, tasks/cancel ack all carry the discriminator | 2322 |
+
+## Open spec questions
+
+Where the spec is silent or ambiguous, mcpkit picks the louder/safer option (typically `-32602` over silent ack), pins the choice with an inline `// Open spec question` comment in code, and names the corresponding conformance scenario as the change-detector if the spec settles differently.
+
+The living register is tracked in the GitHub issue titled "Tracking: SEP-2322 / SEP-2663 / SEP-2575 open spec questions" (issue 339). Three entries today:
+
+1. **`requestState` rejection** — silent ack vs `-32602`. We picked `-32602`. Pinned in `server/tasks_v2.go:verifyRequestState`; covered by `TestV2_RequestState_TamperedRejected`.
+2. **SEP-2575 per-request capabilities shape** — using opaque `json.RawMessage` envelope so the shape can change without consumer churn. Covered by v2-25.
+3. **`tasks/update`/`tasks/cancel` ack for unknown taskId** — silent ack vs `-32602`. We picked `-32602`. Pinned in `server/tasks_v2.go:makeV2UpdateHandler`; covered by `TestV2_UpdateUnknownTaskRejected` (server-side; no conformance scenario yet — the upstream spec wording is too soft to assert against).
+
+## Design notes
+
+### Assertions follow v1 lessons
+
+Based on spec maintainer feedback on the v1 suite:
+- Error codes use `assertJsonRpcError(e, code, label, enforce?)` with `ENFORCE_ERROR_CODES = false` by default
+- `enforce = true` only for cases where the code is mandated (e.g., `-32601` for unknown methods)
+- TTL assertions check reasonable ranges, not exact values
+- Notifications are optional — well-formed if received
+
+### Two raw fetch sessions
+
+`before()` initializes two raw HTTP sessions:
+- `sessionId` — declares `io.modelcontextprotocol/tasks` extension; used by every happy-path scenario
+- `unsupportedSessionId` — does NOT declare the extension; used by gating tests (v2-22, v2-23)
+
+This avoids server-side state leakage between scenarios that need different capability profiles.
+
+### Bypassing SDK schema validation
+
+The MCP TypeScript SDK ships with strict Zod schemas that strip v2-only fields (`result`, `error`, `inputRequests`, `requestState`) from responses. Every scenario that needs to read those fields uses raw `fetch` via the `rawRequest` / `rawRequestFull` helpers rather than the typed SDK client. SDK-typed assertions are reserved for things the SDK already understands (e.g., the initialize negotiation in `before()`).
+
+### Shared helpers
+
+Common utilities (`assertJsonRpcError`, `waitForTerminal`, `waitForStatus`) are in `conformance/common/helpers.ts` and shared with the v1 suite.

--- a/conformance/tasks-v2/scenarios.test.ts
+++ b/conformance/tasks-v2/scenarios.test.ts
@@ -426,9 +426,10 @@ describe('MCP Tasks v2 Conformance (SEP-2663)', () => {
         const taskId = result.task.taskId;
 
         const cancelAck = await cancelTask(taskId);
-        // SEP-2663: cancel response is the empty {} ack (no task state).
-        assert.deepEqual(cancelAck, {},
-            `tasks/cancel should return empty {} ack; got ${JSON.stringify(cancelAck)}`);
+        // SEP-2663: cancel response carries no task state — only the SEP-2322
+        // resultType:"complete" discriminator (added under v2-26).
+        assert.deepEqual(cancelAck, { resultType: 'complete' },
+            `tasks/cancel should return {resultType:"complete"} ack; got ${JSON.stringify(cancelAck)}`);
 
         // Status settles to cancelled — observe via tasks/get.
         const task = await getTask(taskId);
@@ -669,8 +670,10 @@ describe('MCP Tasks v2 Conformance (SEP-2663)', () => {
         }
 
         const ack = await updateTask(taskId, responses, inputTask.requestState);
-        assert.deepEqual(ack, {},
-            `tasks/update should return empty {} ack; got ${JSON.stringify(ack)}`);
+        // SEP-2663: ack carries no task state — only the SEP-2322
+        // resultType:"complete" discriminator (covered by v2-26).
+        assert.deepEqual(ack, { resultType: 'complete' },
+            `tasks/update should return {resultType:"complete"} ack; got ${JSON.stringify(ack)}`);
 
         // Server-side goroutine resumes — status will settle to terminal
         // (or back to input_required if the tool emits another round).
@@ -805,16 +808,19 @@ describe('MCP Tasks v2 Conformance (SEP-2663)', () => {
     //
     // SEP-2663: a client that did not negotiate the extension still gets to
     // call task-eligible tools — the server falls through to synchronous
-    // execution and returns a plain ToolResult (no resultType discriminator).
-    // It MUST NOT return CreateTaskResult.
+    // execution and returns a plain ToolResult. SEP-2322: that ToolResult
+    // carries resultType:"complete" so polymorphic dispatch on the wire is
+    // uniform. The server MUST NOT return CreateTaskResult (resultType:"task")
+    // here.
     // ========================================================================
-    test('v2-23: tools/call without extension returns sync ToolResult (no CreateTaskResult)', async () => {
+    test('v2-23: tools/call without extension returns sync ToolResult (resultType:"complete", no task)', async () => {
         const result = await rawRequest('tools/call',
             { name: 'slow_compute', arguments: { seconds: 0, label: 'v2-23' } },
             { sessionId: unsupportedSessionId },
         );
-        assert.ok(!result.resultType,
-            `tools/call without extension MUST NOT carry resultType; got ${result.resultType}`);
+        // SEP-2322: sync ToolResult carries resultType:"complete" (not "task").
+        assert.equal(result.resultType, 'complete',
+            `sync ToolResult.resultType = ${result.resultType}, want "complete"`);
         assert.ok(!result.task,
             `tools/call without extension MUST NOT carry task envelope; got ${JSON.stringify(result.task)}`);
         // Sync ToolResult shape: should have content[].
@@ -874,6 +880,53 @@ describe('MCP Tasks v2 Conformance (SEP-2663)', () => {
             },
         );
         assertCreateTaskResult(result, 'v2-25 per-request opt-in');
+    });
+
+    // ========================================================================
+    // Scenario 26: SEP-2322 resultType discriminator on non-task responses
+    //
+    // SEP-2322 requires every non-task JSON-RPC response on the tools+tasks
+    // surface to carry a resultType discriminator so clients can dispatch
+    // sync vs task vs multi-round uniformly without inspecting the payload.
+    // Task-creation responses use resultType:"task" (covered by v2-02 +
+    // assertCreateTaskResult); every other response — sync tools/call,
+    // tasks/get, tasks/update, tasks/cancel — MUST carry resultType:"complete".
+    //
+    // This scenario batches the four non-task assertions in one place so a
+    // server that misses one fails loudly rather than passing the unrelated
+    // scenario it slipped through.
+    // ========================================================================
+    test('v2-26: non-task responses carry resultType:"complete" (SEP-2322)', async () => {
+        // Sync tools/call — extension declared but the tool isn't async.
+        const sync = await callTool('greet', { name: 'v2-26' });
+        assert.equal(sync.resultType, 'complete',
+            `sync tools/call resultType = ${sync.resultType}, want "complete"`);
+
+        // tasks/get — drive a fast task to completion and read the response.
+        const created = await callTool('slow_compute', { seconds: 0, label: 'v2-26' });
+        assertCreateTaskResult(created, 'v2-26 setup');
+        const taskId = created.task.taskId;
+        await waitForTerminal(taskId);
+        const got = await getTask(taskId);
+        assert.equal(got.resultType, 'complete',
+            `tasks/get resultType = ${got.resultType}, want "complete"`);
+
+        // tasks/cancel — empty ack on a (already-terminal) task should still
+        // reject with -32602; pick a fresh long-running task to cancel cleanly.
+        const longLived = await callTool('slow_compute', { seconds: 60, label: 'v2-26-cancel' });
+        const cancelAck = await cancelTask(longLived.task.taskId);
+        assert.equal(cancelAck.resultType, 'complete',
+            `tasks/cancel ack.resultType = ${cancelAck.resultType}, want "complete"`);
+
+        // tasks/update — bogus key on a non-terminal task gets a clean ack.
+        const elicit = await callTool('confirm_delete', { filename: 'v2-26.txt' });
+        const elicitTaskId = elicit.task.taskId;
+        await waitForStatus(elicitTaskId, 'input_required', 5000);
+        const updateAck = await updateTask(elicitTaskId, { 'unknown-key': { ignored: true } });
+        assert.equal(updateAck.resultType, 'complete',
+            `tasks/update ack.resultType = ${updateAck.resultType}, want "complete"`);
+        // Clean up the parked elicit task.
+        await cancelTask(elicitTaskId);
     });
 
 });

--- a/core/task_v2.go
+++ b/core/task_v2.go
@@ -2,7 +2,14 @@ package core
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
 )
 
 // TasksExtensionID is the protocol extension identifier for SEP-2663 Tasks.
@@ -104,6 +111,14 @@ type CreateTaskResult struct {
 // servers MAY include it on any status, clients MUST echo it back on the
 // next tasks/get / tasks/update / tasks/cancel for the same task. // SEP-2322
 type DetailedTask struct {
+	// ResultType is the SEP-2322 polymorphic-dispatch discriminator. For
+	// tasks/get responses it is always "complete" — the JSON-RPC request
+	// itself completes with this response, even when the underlying task
+	// is still running. (The task lifecycle is on the Status field.)
+	// MarshalJSON defaults this to ResultTypeComplete when empty so
+	// existing struct literals don't have to set it.
+	ResultType ResultType `json:"resultType"`
+
 	TaskInfoV2
 
 	// Result is inlined when Status == TaskCompleted. Includes the original
@@ -120,6 +135,17 @@ type DetailedTask struct {
 
 	// RequestState is the opaque session-continuation token. // SEP-2322
 	RequestState string `json:"requestState,omitempty"`
+}
+
+// MarshalJSON defaults ResultType to ResultTypeComplete when empty so every
+// tasks/get response carries the SEP-2322 polymorphic discriminator without
+// every call site having to set it. The task lifecycle stays on Status.
+func (d DetailedTask) MarshalJSON() ([]byte, error) {
+	type alias DetailedTask
+	if d.ResultType == "" {
+		d.ResultType = ResultTypeComplete
+	}
+	return json.Marshal(alias(d))
 }
 
 // SEP-2663 narrowed aliases — convenient names for callers that have already
@@ -153,12 +179,141 @@ type UpdateTaskRequest struct {
 	RequestState   string         `json:"requestState,omitempty"` // SEP-2322
 }
 
-// UpdateTaskResult is the (empty) ack returned by tasks/update. Servers
-// resume task execution asynchronously; clients learn the outcome via the
-// next tasks/get. // SEP-2663
-type UpdateTaskResult struct{}
+// UpdateTaskResult is the (essentially empty) ack returned by tasks/update.
+// Servers resume task execution asynchronously; clients learn the outcome
+// via the next tasks/get. The wire payload carries only the SEP-2322
+// resultType discriminator so polymorphic dispatch on tools/call vs
+// tasks/update vs tasks/get is uniform across the protocol. // SEP-2663
+type UpdateTaskResult struct {
+	// ResultType is the SEP-2322 polymorphic-dispatch discriminator. Always
+	// "complete" for the tasks/update ack (defaulted by MarshalJSON when empty).
+	ResultType ResultType `json:"resultType"`
+}
 
-// CancelTaskResult is the (empty) ack returned by tasks/cancel. Per SEP-2663,
-// cancellation does not return task state — the client should issue tasks/get
-// if it wants to observe the resulting "cancelled" status.
-type CancelTaskResult struct{}
+// MarshalJSON defaults ResultType to ResultTypeComplete so callers using
+// the zero value (UpdateTaskResult{}) emit the spec-compliant wire shape
+// without thinking about it.
+func (u UpdateTaskResult) MarshalJSON() ([]byte, error) {
+	type alias UpdateTaskResult
+	if u.ResultType == "" {
+		u.ResultType = ResultTypeComplete
+	}
+	return json.Marshal(alias(u))
+}
+
+// CancelTaskResult is the (essentially empty) ack returned by tasks/cancel.
+// Per SEP-2663, cancellation does not return task state — the client should
+// issue tasks/get if it wants to observe the resulting "cancelled" status.
+// Like UpdateTaskResult, the wire payload carries only the SEP-2322
+// resultType discriminator.
+type CancelTaskResult struct {
+	// ResultType is the SEP-2322 polymorphic-dispatch discriminator. Always
+	// "complete" for the tasks/cancel ack (defaulted by MarshalJSON when empty).
+	ResultType ResultType `json:"resultType"`
+}
+
+// MarshalJSON defaults ResultType to ResultTypeComplete so the zero value
+// (CancelTaskResult{}) emits the spec-compliant wire shape automatically.
+func (c CancelTaskResult) MarshalJSON() ([]byte, error) {
+	type alias CancelTaskResult
+	if c.ResultType == "" {
+		c.ResultType = ResultTypeComplete
+	}
+	return json.Marshal(alias(c))
+}
+
+// --- SEP-2322 requestState signing ---
+//
+// SEP-2663 says servers MUST treat requestState as attacker-controlled. The
+// helpers below implement an HMAC-SHA256-signed encoding so a server that
+// minted a token can verify the same token came back unmodified, with no
+// per-task state on the server side (stateless deployments).
+//
+// Wire format: "<base64url-signature>.<base64url-payload>" where payload is
+// the JSON encoding of requestStatePayload {taskId, exp}. base64url is
+// chosen to keep the token URL/header-safe without escaping.
+
+// ErrRequestStateMalformed indicates the encoded requestState couldn't be
+// parsed (missing separator, bad base64, bad JSON inside the payload).
+var ErrRequestStateMalformed = errors.New("requestState malformed")
+
+// ErrRequestStateInvalidSignature indicates the HMAC signature did not match
+// — either tampered payload or wrong key.
+var ErrRequestStateInvalidSignature = errors.New("requestState signature invalid")
+
+// ErrRequestStateExpired indicates the payload's expiry is in the past.
+var ErrRequestStateExpired = errors.New("requestState expired")
+
+// requestStatePayload is the JSON body wrapped inside a signed
+// requestState token. Compact (two fields) so the encoded form stays small.
+type requestStatePayload struct {
+	TaskID string `json:"taskId"`
+	Exp    int64  `json:"exp"` // unix seconds
+}
+
+// SignRequestState produces an HMAC-SHA256-signed requestState token for
+// the given taskID, valid for ttl. The encoded form is opaque to clients
+// and round-trippable via VerifyRequestState. Panics if key is empty —
+// callers MUST check before invoking (see v2TaskRuntime.makeRequestState
+// which falls back to plaintext when the key is unset).
+func SignRequestState(key []byte, taskID string, ttl time.Duration) string {
+	if len(key) == 0 {
+		// Indicates a programming error — the runtime should fall back to
+		// plain taskID in legacy mode rather than calling Sign with no key.
+		panic("core.SignRequestState: empty key")
+	}
+	payload := requestStatePayload{
+		TaskID: taskID,
+		Exp:    time.Now().Add(ttl).Unix(),
+	}
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		// json.Marshal of a tiny struct can't realistically fail.
+		panic(fmt.Sprintf("core.SignRequestState: marshal payload: %v", err))
+	}
+	mac := hmac.New(sha256.New, key)
+	mac.Write(payloadBytes)
+	sig := mac.Sum(nil)
+	return base64.RawURLEncoding.EncodeToString(sig) + "." +
+		base64.RawURLEncoding.EncodeToString(payloadBytes)
+}
+
+// VerifyRequestState checks an incoming requestState token against the
+// signing key and current time. Returns the embedded taskID on success.
+// Errors:
+//   - ErrRequestStateMalformed: structural parse failures (split, base64, JSON)
+//   - ErrRequestStateInvalidSignature: signature mismatch (tampered or wrong key)
+//   - ErrRequestStateExpired: payload exp is in the past
+//
+// Uses hmac.Equal for constant-time signature comparison.
+func VerifyRequestState(key []byte, state string) (taskID string, err error) {
+	if len(key) == 0 {
+		return "", ErrRequestStateMalformed
+	}
+	dot := strings.IndexByte(state, '.')
+	if dot < 0 {
+		return "", ErrRequestStateMalformed
+	}
+	sig, err := base64.RawURLEncoding.DecodeString(state[:dot])
+	if err != nil {
+		return "", ErrRequestStateMalformed
+	}
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(state[dot+1:])
+	if err != nil {
+		return "", ErrRequestStateMalformed
+	}
+	mac := hmac.New(sha256.New, key)
+	mac.Write(payloadBytes)
+	expected := mac.Sum(nil)
+	if !hmac.Equal(sig, expected) {
+		return "", ErrRequestStateInvalidSignature
+	}
+	var payload requestStatePayload
+	if err := json.Unmarshal(payloadBytes, &payload); err != nil {
+		return "", ErrRequestStateMalformed
+	}
+	if payload.Exp > 0 && time.Now().Unix() > payload.Exp {
+		return "", ErrRequestStateExpired
+	}
+	return payload.TaskID, nil
+}

--- a/core/task_v2_test.go
+++ b/core/task_v2_test.go
@@ -1,8 +1,13 @@
 package core
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
+	"strings"
 	"testing"
+	"time"
 )
 
 // TestResultTypeConstants verifies the wire values of the ResultType
@@ -441,9 +446,12 @@ func TestUpdateTaskRequestOmitEmpty(t *testing.T) {
 	}
 }
 
-// TestEmptyAckShapes verifies that UpdateTaskResult and CancelTaskResult
-// serialize as empty JSON objects (no task state, per SEP-2663).
-func TestEmptyAckShapes(t *testing.T) {
+// TestAckShapes verifies that UpdateTaskResult and CancelTaskResult serialize
+// to the SEP-2322 minimum: a single resultType:"complete" discriminator and
+// no other fields. SEP-2663 says the acks carry no task state — but SEP-2322
+// requires the resultType discriminator on every non-task response so
+// clients can dispatch sync/task/multi-round uniformly.
+func TestAckShapes(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		v    any
@@ -455,8 +463,142 @@ func TestEmptyAckShapes(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: %v", tc.name, err)
 		}
-		if string(data) != "{}" {
-			t.Errorf("%s = %s, want {}", tc.name, data)
+		var m map[string]any
+		if err := json.Unmarshal(data, &m); err != nil {
+			t.Fatalf("%s: unmarshal: %v", tc.name, err)
+		}
+		if got := m["resultType"]; got != "complete" {
+			t.Errorf("%s.resultType = %v, want \"complete\"", tc.name, got)
+		}
+		if len(m) != 1 {
+			t.Errorf("%s should carry only resultType (got %d keys: %v)", tc.name, len(m), m)
 		}
 	}
+}
+
+// --- SEP-2322 requestState signing (gap-3) ---
+
+// TestRequestState_RoundTrip verifies a freshly signed token verifies cleanly
+// and exposes the original taskID. The base case for the HMAC flow.
+func TestRequestState_RoundTrip(t *testing.T) {
+	key := []byte("test-key-32-bytes-min-for-hmac-shake")
+	state := SignRequestState(key, "task-abc", time.Hour)
+	if state == "" {
+		t.Fatal("SignRequestState returned empty string")
+	}
+	got, err := VerifyRequestState(key, state)
+	if err != nil {
+		t.Fatalf("VerifyRequestState: %v", err)
+	}
+	if got != "task-abc" {
+		t.Errorf("decoded taskID = %q, want %q", got, "task-abc")
+	}
+}
+
+// TestRequestState_TamperedPayload verifies that any modification to the
+// payload bytes (even a single character flip) invalidates the signature.
+// This is the core attacker scenario the HMAC defends against.
+func TestRequestState_TamperedPayload(t *testing.T) {
+	key := []byte("test-key-32-bytes-min-for-hmac-shake")
+	state := SignRequestState(key, "task-abc", time.Hour)
+	dot := strings.IndexByte(state, '.')
+	if dot < 0 {
+		t.Fatalf("expected '.' separator in signed state %q", state)
+	}
+	// Re-encode a different payload (taskId swap) but keep the original sig.
+	tampered := state[:dot+1] + base64.RawURLEncoding.EncodeToString([]byte(`{"taskId":"task-evil","exp":9999999999}`))
+	if _, err := VerifyRequestState(key, tampered); err != ErrRequestStateInvalidSignature {
+		t.Errorf("tampered payload: err = %v, want ErrRequestStateInvalidSignature", err)
+	}
+}
+
+// TestRequestState_TamperedSignature verifies that a flipped signature byte
+// (with the original payload intact) is also rejected. Symmetric with the
+// payload-tamper case.
+func TestRequestState_TamperedSignature(t *testing.T) {
+	key := []byte("test-key-32-bytes-min-for-hmac-shake")
+	state := SignRequestState(key, "task-abc", time.Hour)
+	dot := strings.IndexByte(state, '.')
+	if dot < 0 {
+		t.Fatalf("expected '.' separator")
+	}
+	// Flip a byte inside the signature (replace first char with one that
+	// decodes to different bytes).
+	sigChar := byte('A')
+	if state[0] == 'A' {
+		sigChar = 'B'
+	}
+	tampered := string(sigChar) + state[1:]
+	if _, err := VerifyRequestState(key, tampered); err != ErrRequestStateInvalidSignature {
+		t.Errorf("tampered signature: err = %v, want ErrRequestStateInvalidSignature", err)
+	}
+}
+
+// TestRequestState_Expired verifies that a token whose exp is in the past
+// is rejected even when the signature is valid.
+func TestRequestState_Expired(t *testing.T) {
+	key := []byte("test-key-32-bytes-min-for-hmac-shake")
+	// Negative TTL = exp in the past.
+	state := SignRequestState(key, "task-abc", -time.Second)
+	if _, err := VerifyRequestState(key, state); err != ErrRequestStateExpired {
+		t.Errorf("expired state: err = %v, want ErrRequestStateExpired", err)
+	}
+}
+
+// TestRequestState_Malformed batches the structural-failure cases so a
+// single test guards every parse path that should map to ErrRequestStateMalformed.
+func TestRequestState_Malformed(t *testing.T) {
+	key := []byte("test-key-32-bytes-min-for-hmac-shake")
+	cases := []struct {
+		name  string
+		state string
+	}{
+		{"missing separator", "no-dot-here-just-text"},
+		{"bad signature base64", "!!!!.eyJ0YXNrSWQiOiJ0YXNrLWFiYyIsImV4cCI6MX0"},
+		{"bad payload base64", "abc.!!!!"},
+		{"empty", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := VerifyRequestState(key, tc.state); err != ErrRequestStateMalformed {
+				t.Errorf("err = %v, want ErrRequestStateMalformed", err)
+			}
+		})
+	}
+}
+
+// TestRequestState_WrongKey verifies that a token signed with one key can't
+// be verified with a different key — covers the multi-tenant case where
+// each tenant has its own signing key.
+func TestRequestState_WrongKey(t *testing.T) {
+	keyA := []byte("tenant-a-key-32-bytes-padding-here")
+	keyB := []byte("tenant-b-key-32-bytes-padding-here")
+	state := SignRequestState(keyA, "task-abc", time.Hour)
+	if _, err := VerifyRequestState(keyB, state); err != ErrRequestStateInvalidSignature {
+		t.Errorf("wrong key: err = %v, want ErrRequestStateInvalidSignature", err)
+	}
+}
+
+// TestRequestState_BadJSONPayload verifies that a payload that survives
+// base64 + HMAC but doesn't parse as the expected JSON shape is reported
+// as malformed (not invalid-signature).
+func TestRequestState_BadJSONPayload(t *testing.T) {
+	key := []byte("test-key-32-bytes-min-for-hmac-shake")
+	rawPayload := []byte("not-json-at-all")
+	mac := hmacFromKey(t, key, rawPayload)
+	state := base64.RawURLEncoding.EncodeToString(mac) + "." +
+		base64.RawURLEncoding.EncodeToString(rawPayload)
+	if _, err := VerifyRequestState(key, state); err != ErrRequestStateMalformed {
+		t.Errorf("bad JSON payload: err = %v, want ErrRequestStateMalformed", err)
+	}
+}
+
+// hmacFromKey is a tiny test helper to compute an HMAC-SHA256 sig over an
+// arbitrary payload — used by TestRequestState_BadJSONPayload to forge a
+// signature-valid-but-payload-broken token.
+func hmacFromKey(t *testing.T, key, payload []byte) []byte {
+	t.Helper()
+	h := hmac.New(sha256.New, key)
+	h.Write(payload)
+	return h.Sum(nil)
 }

--- a/core/tool.go
+++ b/core/tool.go
@@ -77,6 +77,13 @@ type ToolRequest struct {
 
 // ToolResult is the response from a tool handler.
 type ToolResult struct {
+	// ResultType is the SEP-2322 polymorphic-dispatch discriminator. For
+	// sync tools/call responses the wire value is "complete" (defaulted by
+	// MarshalJSON when this field is empty). Task-creating responses use
+	// ResultTypeTask on CreateTaskResult instead. Multi-round tool results
+	// will use ResultTypeIncomplete once that flow is wired.
+	ResultType ResultType `json:"resultType"`
+
 	// Content is the list of content items to return.
 	Content []Content `json:"content"`
 
@@ -93,11 +100,25 @@ type ToolResult struct {
 	Meta *ToolResultMeta `json:"_meta,omitempty"`
 }
 
+// MarshalJSON ensures every ToolResult on the wire carries a ResultType.
+// Empty defaults to ResultTypeComplete so existing callers and struct
+// literals don't have to set the field explicitly. SEP-2322 requires this
+// discriminator on every non-task tools/call response so clients can
+// dispatch sync vs task vs multi-round without inspecting payload shape.
+func (r ToolResult) MarshalJSON() ([]byte, error) {
+	type alias ToolResult
+	if r.ResultType == "" {
+		r.ResultType = ResultTypeComplete
+	}
+	return json.Marshal(alias(r))
+}
+
 // UnmarshalJSON decodes a ToolResult, tolerating a single-object `content`
 // form from peers that haven't caught up to the array-form spec. Single
 // objects are wrapped into a 1-element slice. See #81.
 func (r *ToolResult) UnmarshalJSON(data []byte) error {
 	var aux struct {
+		ResultType        ResultType      `json:"resultType,omitempty"`
 		Content           json.RawMessage `json:"content"`
 		IsError           bool            `json:"isError,omitempty"`
 		StructuredContent any             `json:"structuredContent,omitempty"`
@@ -106,6 +127,7 @@ func (r *ToolResult) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
 	}
+	r.ResultType = aux.ResultType
 	r.IsError = aux.IsError
 	r.StructuredContent = aux.StructuredContent
 	r.Meta = aux.Meta

--- a/server/tasks_hybrid.go
+++ b/server/tasks_hybrid.go
@@ -68,7 +68,7 @@ func RegisterTasksHybrid(cfg TasksHybridConfig) {
 
 	reg := srv.Registry()
 	v1RT := newTaskRuntime(cfg.V1.Store, cfg.V1.MessageQueue, reg)
-	v2RT := newV2TaskRuntime(cfg.V2.Store, reg)
+	v2RT := newV2TaskRuntime(cfg.V2)
 
 	// Advertise BOTH so clients can pick. v1 SetTasksCap goes first so the
 	// v1 cap shows up under the canonical capabilities.tasks slot; the v2

--- a/server/tasks_v2.go
+++ b/server/tasks_v2.go
@@ -26,6 +26,22 @@ type TasksConfig struct {
 	// returned to clients in CreateTaskResult. Default: 1000 (1 second).
 	DefaultPollMs int
 
+	// RequestStateKey is the HMAC-SHA256 key the server uses to sign and
+	// verify SEP-2322 requestState tokens. When non-nil, requestState is
+	// returned as `<base64url-hmac>.<base64url-payload>` where the payload
+	// is JSON {"taskId":"...", "exp":<unix-seconds>} — clients echo it
+	// verbatim and the server rejects tampered or expired tokens with
+	// -32602 on tasks/get / tasks/update / tasks/cancel.
+	//
+	// SEP-2663 says servers MUST treat requestState as attacker-controlled.
+	// Production deployments SHOULD set this. nil = legacy plaintext mode
+	// (requestState == taskID), kept for backward compat with existing
+	// tests and minimal-config setups.
+	RequestStateKey []byte
+
+	// RequestStateTTL is how long a signed requestState stays valid. When
+	// 0, defaults to 24h. Has no effect when RequestStateKey is nil.
+	RequestStateTTL time.Duration
 }
 
 func (c *TasksConfig) defaults() {
@@ -38,6 +54,9 @@ func (c *TasksConfig) defaults() {
 	if c.DefaultPollMs <= 0 {
 		c.DefaultPollMs = 1000
 	}
+	if c.RequestStateTTL <= 0 {
+		c.RequestStateTTL = 24 * time.Hour
+	}
 }
 
 // v2TaskRuntime holds per-registration state for v2 tasks, shared between
@@ -45,7 +64,13 @@ func (c *TasksConfig) defaults() {
 type v2TaskRuntime struct {
 	store    TaskStore
 	registry *Registry
-	mu       sync.Mutex
+
+	// requestStateKey + requestStateTTL configure SEP-2322 requestState
+	// signing. nil key = legacy plaintext mode (requestState == taskID).
+	requestStateKey []byte
+	requestStateTTL time.Duration
+
+	mu sync.Mutex
 	active   map[string]*activeTask
 	// taskErrors stores protocol-level errors (TaskError) for failed tasks.
 	// Separate from the store's result, which holds ToolResult for completed tasks.
@@ -54,10 +79,12 @@ type v2TaskRuntime struct {
 	creatorToolForTask map[string]string
 }
 
-func newV2TaskRuntime(store TaskStore, reg *Registry) *v2TaskRuntime {
+func newV2TaskRuntime(cfg TasksConfig) *v2TaskRuntime {
 	return &v2TaskRuntime{
-		store:              store,
-		registry:           reg,
+		store:              cfg.Store,
+		registry:           cfg.Server.Registry(),
+		requestStateKey:    cfg.RequestStateKey,
+		requestStateTTL:    cfg.RequestStateTTL,
 		active:             make(map[string]*activeTask),
 		taskErrors:         make(map[string]*core.TaskError),
 		creatorToolForTask: make(map[string]string),
@@ -105,6 +132,52 @@ func (rt *v2TaskRuntime) getToolCallbacks(taskID string) *TaskCallbacks {
 		return nil
 	}
 	return rt.registry.ToolCallbacks(name)
+}
+
+// makeRequestState mints the SEP-2322 requestState string the server hands
+// to clients on tasks/get responses and notifications/tasks/status events.
+// When a signing key is configured (TasksConfig.RequestStateKey), the token
+// is HMAC-SHA256 signed with an embedded expiry; otherwise it falls back to
+// the bare taskID for backward compat with minimal-config setups and tests.
+func (rt *v2TaskRuntime) makeRequestState(taskID string) string {
+	if len(rt.requestStateKey) == 0 {
+		return taskID
+	}
+	return core.SignRequestState(rt.requestStateKey, taskID, rt.requestStateTTL)
+}
+
+// verifyRequestState validates an incoming requestState against the signing
+// key. When the key is unset we run in legacy plaintext mode: any incoming
+// requestState that matches the taskID round-trips, anything else is
+// rejected (matches the old "RequestState: p.TaskID" semantics). When the
+// key is set, the token MUST decode + HMAC-verify + not be expired; mismatch
+// returns -32602 at the handler boundary.
+//
+// expectedTaskID is the taskID the caller already pulled from the request
+// body — we cross-check the token's embedded taskID against it so a token
+// issued for task A can't be replayed against task B.
+//
+// Empty incoming requestState is allowed (legacy clients, or first call
+// before the server has minted one). Callers that want stricter behavior
+// can refuse on requestState=="" themselves.
+func (rt *v2TaskRuntime) verifyRequestState(state, expectedTaskID string) error {
+	if state == "" {
+		return nil
+	}
+	if len(rt.requestStateKey) == 0 {
+		if state != expectedTaskID {
+			return core.ErrRequestStateInvalidSignature
+		}
+		return nil
+	}
+	gotTaskID, err := core.VerifyRequestState(rt.requestStateKey, state)
+	if err != nil {
+		return err
+	}
+	if gotTaskID != expectedTaskID {
+		return core.ErrRequestStateInvalidSignature
+	}
+	return nil
 }
 
 // deliverInputResponses routes a tasks/update payload back to whichever
@@ -272,15 +345,13 @@ func (tasksExtensionProvider) Extension() core.Extension {
 func RegisterTasks(cfg TasksConfig) {
 	cfg.defaults()
 	srv := cfg.Server
-	store := cfg.Store
-	reg := srv.Registry()
-	rt := newV2TaskRuntime(store, reg)
+	rt := newV2TaskRuntime(cfg)
 
 	// Advertise the SEP-2663 Tasks extension.
 	srv.RegisterExtension(tasksExtensionProvider{})
 
 	// Install v2 middleware for tools/call interception (gated on extension).
-	srv.UseMiddleware(taskV2Middleware(reg, rt, cfg))
+	srv.UseMiddleware(taskV2Middleware(srv.Registry(), rt, cfg))
 
 	// Register tasks/* protocol methods (SEP-2663: get + update + cancel),
 	// gated on session-level extension support.
@@ -513,10 +584,20 @@ func makeV2GetHandler(rt *v2TaskRuntime) MethodHandler {
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, "task not found: "+p.TaskID)
 		}
 
+		// SEP-2322: validate any echoed requestState — tampered, expired,
+		// or cross-task tokens are rejected with -32602 so attackers can't
+		// drive the loop with forged state. Empty is allowed (first call).
+		if err := rt.verifyRequestState(p.RequestState, p.TaskID); err != nil {
+			return core.NewErrorResponse(id, core.ErrCodeInvalidParams,
+				"invalid requestState: "+err.Error())
+		}
+
 		result := core.DetailedTask{
 			TaskInfoV2: toTaskInfoV2(info),
-			// Generate requestState (opaque token for stateless deployments).
-			RequestState: p.TaskID,
+			// SEP-2322 requestState — opaque session-continuation token. The
+			// same helper feeds notifyV2TaskStatus so polling and SSE stay
+			// in sync (HMAC-signed when RequestStateKey is configured).
+			RequestState: rt.makeRequestState(p.TaskID),
 		}
 
 		// SEP-2663: when the task is awaiting MRTR input, surface the
@@ -592,6 +673,13 @@ func makeV2UpdateHandler(rt *v2TaskRuntime) MethodHandler {
 			// settles that way.
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, "task not found: "+p.TaskID)
 		}
+		// SEP-2322: validate echoed requestState before doing any work —
+		// the resume side of the MRTR loop is the most attractive target
+		// for forged state since it directly drives goroutine wake-ups.
+		if err := rt.verifyRequestState(p.RequestState, p.TaskID); err != nil {
+			return core.NewErrorResponse(id, core.ErrCodeInvalidParams,
+				"invalid requestState: "+err.Error())
+		}
 		if info.Status.IsTerminal() {
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams,
 				"task "+p.TaskID+" is in terminal state "+string(info.Status))
@@ -613,6 +701,12 @@ func makeV2CancelHandler(rt *v2TaskRuntime) MethodHandler {
 		}
 		if err := json.Unmarshal(params, &p); err != nil {
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, err.Error())
+		}
+
+		// SEP-2322: validate echoed requestState before mutating task state.
+		if err := rt.verifyRequestState(p.RequestState, p.TaskID); err != nil {
+			return core.NewErrorResponse(id, core.ErrCodeInvalidParams,
+				"invalid requestState: "+err.Error())
 		}
 
 		info, err := rt.store.Cancel(p.TaskID, ctx.SessionID())
@@ -662,13 +756,21 @@ func toTaskInfoV2(info core.TaskInfo) core.TaskInfoV2 {
 
 // notifyV2TaskStatus sends a v2-style status notification with the full
 // DetailedTask (inlined result/error) read fresh from the store. Best-effort.
+//
+// SEP-2322: the notification carries the same requestState the next
+// tasks/get would have minted. Clients update their tracked requestState
+// from notifications so a stateless deployment can pick the conversation
+// back up without an extra tasks/get round-trip.
 func notifyV2TaskStatus(ctx context.Context, rt *v2TaskRuntime, store TaskStore, taskID, sessionID string) {
 	info, ok := store.Get(taskID, sessionID)
 	if !ok {
 		return
 	}
 
-	payload := core.DetailedTask{TaskInfoV2: toTaskInfoV2(info)}
+	payload := core.DetailedTask{
+		TaskInfoV2:   toTaskInfoV2(info),
+		RequestState: rt.makeRequestState(taskID),
+	}
 
 	if info.Status == core.TaskCompleted {
 		toolResult, found := store.GetResult(taskID, sessionID)
@@ -696,8 +798,14 @@ func notifyV2TaskStatus(ctx context.Context, rt *v2TaskRuntime, store TaskStore,
 // MethodContext for callers that already have fresh TaskInfo (e.g., the
 // cancel handler, which gets info back from store.Cancel and doesn't need
 // to re-read it).
+//
+// SEP-2322: carries requestState matching what the next tasks/get would
+// return — same rationale as notifyV2TaskStatus.
 func notifyV2TaskStatusFromInfo(ctx core.MethodContext, rt *v2TaskRuntime, info core.TaskInfo) {
-	payload := core.DetailedTask{TaskInfoV2: toTaskInfoV2(info)}
+	payload := core.DetailedTask{
+		TaskInfoV2:   toTaskInfoV2(info),
+		RequestState: rt.makeRequestState(info.TaskID),
+	}
 	if info.Status == core.TaskFailed {
 		if te := rt.getTaskError(info.TaskID); te != nil {
 			payload.Error = te

--- a/server/tasks_v2_test.go
+++ b/server/tasks_v2_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -92,9 +93,10 @@ func TestV2_ExtensionAdvertised(t *testing.T) {
 }
 
 // TestV2_NoTaskCreationWithoutExtension verifies that an async-eligible tool
-// call returns a synchronous ToolResult (no resultType discriminator) when
-// the client has not negotiated the tasks extension. SEP-2663: server MUST
-// NOT return CreateTaskResult without negotiation.
+// call returns a synchronous ToolResult — resultType:"complete" per
+// SEP-2322, no task envelope — when the client has not negotiated the
+// tasks extension. SEP-2663: server MUST NOT return CreateTaskResult
+// (resultType:"task") without negotiation.
 func TestV2_NoTaskCreationWithoutExtension(t *testing.T) {
 	srv := newTaskV2Server(t)
 	c := connectV2Client(t, srv) // no WithTasksExtension
@@ -111,8 +113,9 @@ func TestV2_NoTaskCreationWithoutExtension(t *testing.T) {
 	if err := json.Unmarshal(res.Raw, &m); err != nil {
 		t.Fatalf("unmarshal result: %v", err)
 	}
-	if rt, ok := m["resultType"]; ok {
-		t.Errorf("response must NOT carry resultType when extension not negotiated; got resultType=%v", rt)
+	// SEP-2322: sync ToolResult carries resultType:"complete" (not "task").
+	if rt := m["resultType"]; rt != "complete" {
+		t.Errorf("sync ToolResult.resultType = %v, want \"complete\"", rt)
 	}
 	if _, ok := m["task"]; ok {
 		t.Errorf("response must NOT carry task envelope when extension not negotiated; got %s", res.Raw)
@@ -323,24 +326,30 @@ func TestV2_UpdateAck(t *testing.T) {
 
 	taskID := createTaskForUpdateTest(t, c, "slow-task")
 
+	// Send no RequestState — empty is allowed (legacy/first-call path).
+	// HMAC-state coverage is in TestV2_RequestState_* below.
 	res, err := c.Call("tasks/update", core.UpdateTaskRequest{
 		TaskID: taskID,
 		InputResponses: core.InputResponses{
 			"elicit-1": json.RawMessage(`{"action":"accept","content":{"ok":true}}`),
 		},
-		RequestState: "echoed-state",
 	})
 	if err != nil {
 		t.Fatalf("tasks/update: %v", err)
 	}
 
-	// Empty ack — JSON should be {} (or absent fields), no task envelope.
+	// SEP-2663 ack: no task state. SEP-2322: must carry the resultType
+	// discriminator. So the wire payload is {"resultType":"complete"} —
+	// nothing else.
 	var m map[string]any
 	if err := json.Unmarshal(res.Raw, &m); err != nil {
 		t.Fatalf("unmarshal ack: %v", err)
 	}
-	if len(m) != 0 {
-		t.Errorf("UpdateTaskResult should be empty {}, got %d keys: %v", len(m), m)
+	if rt := m["resultType"]; rt != "complete" {
+		t.Errorf("UpdateTaskResult.resultType = %v, want \"complete\"", rt)
+	}
+	if len(m) != 1 {
+		t.Errorf("UpdateTaskResult should carry only resultType (got %d keys: %v)", len(m), m)
 	}
 }
 
@@ -720,8 +729,12 @@ func TestV2_ElicitUpdateCompleteFlow(t *testing.T) {
 	}
 	var ackMap map[string]any
 	json.Unmarshal(ackRes.Raw, &ackMap)
-	if len(ackMap) != 0 {
-		t.Errorf("tasks/update ack should be empty {}, got %v", ackMap)
+	// SEP-2322: ack carries only the resultType discriminator.
+	if rt := ackMap["resultType"]; rt != "complete" {
+		t.Errorf("tasks/update ack.resultType = %v, want \"complete\"", rt)
+	}
+	if len(ackMap) != 1 {
+		t.Errorf("tasks/update ack should carry only resultType (got %d keys: %v)", len(ackMap), ackMap)
 	}
 
 	// 3. Poll until the goroutine resumes and the task completes.
@@ -836,4 +849,265 @@ func TestV2_UpdateUnknownKeyIgnored(t *testing.T) {
 	pollV2Detailed(t, ctx, c, taskID, 20*time.Millisecond, func(d core.DetailedTask) bool {
 		return d.Status.IsTerminal()
 	})
+}
+
+// TestV2_StatusNotificationCarriesRequestState verifies that
+// notifications/tasks/status events carry the SEP-2322 requestState string.
+// Clients update their tracked requestState from notifications so a
+// stateless deployment can pick the conversation back up without an extra
+// tasks/get round-trip — but only if the server actually emits it.
+//
+// The fixture wires a notification handler before creating a fast task,
+// then waits for the terminal-status notification and asserts requestState
+// is non-empty (matches the same value tasks/get would have minted).
+func TestV2_StatusNotificationCarriesRequestState(t *testing.T) {
+	srv := newTaskV2Server(t)
+
+	// Capture incoming notifications/tasks/status payloads. Use a buffered
+	// channel + select so the test isn't sensitive to delivery ordering vs
+	// the SSE stream lifecycle.
+	notifs := make(chan core.DetailedTask, 8)
+	handler := srv.Handler(WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "v2-notif-test", Version: "0.0.1"},
+		client.WithGetSSEStream(),
+		client.WithTasksExtension(),
+		client.WithNotificationCallback(func(method string, params any) {
+			if method != "notifications/tasks/status" {
+				return
+			}
+			raw, err := json.Marshal(params)
+			if err != nil {
+				return
+			}
+			var dt core.DetailedTask
+			if err := json.Unmarshal(raw, &dt); err != nil {
+				return
+			}
+			select {
+			case notifs <- dt:
+			default:
+			}
+		}),
+	)
+	if err := c.Connect(); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+
+	// Drive a fast task to terminal and watch for the status notification.
+	res, err := c.Call("tools/call", map[string]any{
+		"name":      "fast-task",
+		"arguments": map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("tools/call: %v", err)
+	}
+	var ctr core.CreateTaskResult
+	if err := json.Unmarshal(res.Raw, &ctr); err != nil {
+		t.Fatalf("unmarshal CreateTaskResult: %v", err)
+	}
+	taskID := ctr.Task.TaskID
+
+	// Wait up to 2s for a notification carrying requestState. Loop because
+	// the server may emit multiple status notifications before terminal.
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case dt := <-notifs:
+			if dt.TaskID != taskID {
+				continue
+			}
+			if dt.RequestState == "" {
+				t.Fatalf("notifications/tasks/status for %s missing requestState (full payload: %+v)", taskID, dt)
+			}
+			// SEP-2322: same body as the next tasks/get would mint —
+			// clients can drop-in update their tracked state.
+			got, err := client.GetTask(c, taskID)
+			if err != nil {
+				t.Fatalf("GetTask: %v", err)
+			}
+			if got.RequestState != dt.RequestState {
+				t.Errorf("notification requestState %q != tasks/get requestState %q",
+					dt.RequestState, got.RequestState)
+			}
+			return
+		case <-deadline:
+			t.Fatalf("timed out waiting for notifications/tasks/status with requestState for %s", taskID)
+		}
+	}
+}
+
+// --- Gap 3: HMAC-signed requestState (end-to-end) ---
+
+// newSignedTaskV2Server is a hybrid-of-newTaskV2Server-and-WithRequestStateKey
+// fixture used by the HMAC-mode tests. Wires the same fast-task tool but
+// configures TasksConfig with a fixed signing key + short TTL so each
+// request-cycle exercises the sign / verify path end-to-end.
+func newSignedTaskV2Server(t *testing.T, ttl time.Duration) (*Server, []byte) {
+	t.Helper()
+	srv := NewServer(core.ServerInfo{Name: "v2-signed-test", Version: "0.0.1"})
+
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "fast-task",
+			Description: "completes immediately",
+			InputSchema: map[string]any{"type": "object"},
+			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportRequired},
+		},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+			return core.TextResult("fast-done"), nil
+		},
+	)
+
+	key := []byte("conformance-test-32-bytes-secret-key")
+	RegisterTasks(TasksConfig{
+		Server:          srv,
+		RequestStateKey: key,
+		RequestStateTTL: ttl,
+	})
+	return srv, key
+}
+
+// TestV2_RequestState_SignedRoundTrip verifies that with a signing key
+// configured, the server emits HMAC-signed requestState on tasks/get and
+// accepts the same token echoed back on tasks/get / tasks/cancel.
+func TestV2_RequestState_SignedRoundTrip(t *testing.T) {
+	srv, _ := newSignedTaskV2Server(t, time.Hour)
+	c := connectV2Client(t, srv, client.WithTasksExtension())
+
+	// Create a task. CreateTaskResult itself doesn't carry requestState
+	// (per SEP-2663) — the first signed token comes from the next tasks/get.
+	res, err := client.ToolCall(c, "fast-task", map[string]any{})
+	if err != nil || !res.IsTask() {
+		t.Fatalf("ToolCall: %v / IsTask=%v", err, res != nil && res.IsTask())
+	}
+	taskID := res.Task.Task.TaskID
+
+	first, err := client.GetTask(c, taskID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	// Signed tokens have a "." separator and base64 segments — assert
+	// shape rather than the exact bytes (which depend on time).
+	if !strings.Contains(first.RequestState, ".") {
+		t.Fatalf("expected HMAC-signed requestState (contains '.'); got %q", first.RequestState)
+	}
+	if first.RequestState == taskID {
+		t.Errorf("HMAC mode produced plaintext requestState (= taskID); signing not applied")
+	}
+
+	// Echo the token back — server should accept and emit a fresh one
+	// (different `exp`, but verifiable).
+	second, err := client.GetTask(c, taskID, client.TaskOptions{RequestState: first.RequestState})
+	if err != nil {
+		t.Fatalf("GetTask with echoed requestState: %v", err)
+	}
+	if second.RequestState == "" {
+		t.Errorf("server should mint a fresh requestState on each tasks/get")
+	}
+}
+
+// TestV2_RequestState_TamperedRejected verifies that a token whose payload
+// is modified (after the server minted it) is rejected with -32602 on every
+// requestState-bearing handler.
+func TestV2_RequestState_TamperedRejected(t *testing.T) {
+	srv, _ := newSignedTaskV2Server(t, time.Hour)
+	c := connectV2Client(t, srv, client.WithTasksExtension())
+
+	res, _ := client.ToolCall(c, "fast-task", map[string]any{})
+	taskID := res.Task.Task.TaskID
+	first, _ := client.GetTask(c, taskID)
+
+	// Tamper the payload segment by re-encoding a different taskId.
+	dot := strings.IndexByte(first.RequestState, '.')
+	if dot < 0 {
+		t.Fatalf("expected '.' in signed requestState; got %q", first.RequestState)
+	}
+	tampered := first.RequestState[:dot+1] + "ZXZpbA" // "evil" base64
+
+	// tasks/get
+	_, err := c.Call("tasks/get", map[string]any{"taskId": taskID, "requestState": tampered})
+	rpcErr, ok := err.(*client.RPCError)
+	if !ok || rpcErr.Code != core.ErrCodeInvalidParams {
+		t.Errorf("tasks/get tampered: err=%v; want -32602", err)
+	}
+
+	// tasks/update
+	err = client.UpdateTask(c, core.UpdateTaskRequest{TaskID: taskID, RequestState: tampered})
+	rpcErr, ok = err.(*client.RPCError)
+	if !ok || rpcErr.Code != core.ErrCodeInvalidParams {
+		t.Errorf("tasks/update tampered: err=%v; want -32602", err)
+	}
+
+	// tasks/cancel
+	err = client.CancelTask(c, taskID, client.TaskOptions{RequestState: tampered})
+	rpcErr, ok = err.(*client.RPCError)
+	if !ok || rpcErr.Code != core.ErrCodeInvalidParams {
+		t.Errorf("tasks/cancel tampered: err=%v; want -32602", err)
+	}
+}
+
+// TestV2_RequestState_ExpiredRejected verifies that a token whose embedded
+// expiry has passed is rejected. Uses TTL=1s and sleep=2s — the embedded
+// `exp` is unix SECONDS, so a sub-second TTL would round to the same second
+// as `now`, making the test flake. The 1s/2s combo cleanly crosses the
+// seconds boundary regardless of when within a second the test starts.
+func TestV2_RequestState_ExpiredRejected(t *testing.T) {
+	srv, _ := newSignedTaskV2Server(t, time.Second)
+	c := connectV2Client(t, srv, client.WithTasksExtension())
+
+	res, _ := client.ToolCall(c, "fast-task", map[string]any{})
+	taskID := res.Task.Task.TaskID
+	first, _ := client.GetTask(c, taskID)
+
+	// Wait past the TTL (≥ 1s past the embedded exp, regardless of jitter).
+	time.Sleep(2 * time.Second)
+
+	_, err := c.Call("tasks/get", map[string]any{"taskId": taskID, "requestState": first.RequestState})
+	rpcErr, ok := err.(*client.RPCError)
+	if !ok {
+		t.Fatalf("expected *client.RPCError, got %T: %v", err, err)
+	}
+	if rpcErr.Code != core.ErrCodeInvalidParams {
+		t.Errorf("expired requestState: code=%d; want -32602", rpcErr.Code)
+	}
+	if !strings.Contains(rpcErr.Message, "expired") {
+		t.Errorf("expired requestState: message=%q; want it to mention \"expired\"", rpcErr.Message)
+	}
+}
+
+// TestV2_RequestState_LegacyPlaintext verifies that with no key configured
+// (the default), the server falls back to plaintext requestState (== taskID).
+// Existing tests / clients that don't echo requestState keep working.
+func TestV2_RequestState_LegacyPlaintext(t *testing.T) {
+	srv := newTaskV2Server(t) // no RequestStateKey
+	c := connectV2Client(t, srv, client.WithTasksExtension())
+
+	res, _ := client.ToolCall(c, "fast-task", map[string]any{})
+	taskID := res.Task.Task.TaskID
+	first, err := client.GetTask(c, taskID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if first.RequestState != taskID {
+		t.Errorf("legacy mode: requestState = %q, want plaintext taskID %q",
+			first.RequestState, taskID)
+	}
+
+	// Echoing the plaintext state still works (matches taskID).
+	_, err = client.GetTask(c, taskID, client.TaskOptions{RequestState: taskID})
+	if err != nil {
+		t.Errorf("legacy mode echo: %v", err)
+	}
+
+	// A non-matching string still gets rejected even in legacy mode —
+	// minimal protection against a client confusing two task IDs.
+	_, err = c.Call("tasks/get", map[string]any{"taskId": taskID, "requestState": "not-the-task-id"})
+	rpcErr, ok := err.(*client.RPCError)
+	if !ok || rpcErr.Code != core.ErrCodeInvalidParams {
+		t.Errorf("legacy mode mismatched state: err=%v; want -32602", err)
+	}
 }


### PR DESCRIPTION
Three audit gaps surfaced after the eight-phase v2 implementation landed. All three are now closed; full \`make test\` green and **27/27 v2 conformance scenarios** passing (26 prior + 1 new for SEP-2322 discriminator coverage).

> Backlink hygiene: this body and the commit message intentionally avoid \`#N\` cross-refs so we don't sprinkle backlinks across the related-but-unrelated tickets. Look up adjacent context by title or by plain number where needed.

## Gap 1 (P0): \`resultType:\"complete\"\` on non-task results

SEP-2322 requires every non-task tools/call / tasks/* response to carry the \`resultType\` discriminator so clients can dispatch sync vs task vs multi-round uniformly without inspecting payload shape.

- \`core.ToolResult\`, \`core.DetailedTask\`, \`core.UpdateTaskResult\`, \`core.CancelTaskResult\` each gain a \`ResultType\` field defaulting to \`ResultTypeComplete\` via a small \`MarshalJSON\` helper.
- Existing \"empty ack\" tests updated: \`UpdateTaskResult\` and \`CancelTaskResult\` acks are no longer empty \`{}\` — they now carry \`{resultType:\"complete\"}\`. Conformance scenarios v2-07 (cancel) and v2-17 (update) updated accordingly.
- New conformance scenario **v2-26** batches the SEP-2322 assertion across all four non-task response shapes.

> Note (no extraction yet): we deliberately did NOT extract a shared \`ResultEnvelope\` base type. With one shared field and per-type defaults, composition costs more than it saves. Cross-cutting note posted to the existing audit-log refactor-opportunities issue with the trigger condition (\"when a second cross-cutting field appears\").

## Gap 2 (P0): notifications/tasks/status carries \`requestState\`

SEP-2322 says clients SHOULD update tracked \`requestState\` from notifications. We were emitting status notifications without the field, so polling clients had to do an extra \`tasks/get\` round-trip after every notification just to refresh their token.

- \`notifyV2TaskStatus\` and \`notifyV2TaskStatusFromInfo\` now set \`RequestState\` on the DetailedTask payload using a centralized \`rt.makeRequestState\` helper.
- The same helper feeds \`tasks/get\`, so polling and SSE stay in sync — clients can drop-in update their tracked state from either source.
- New \`TestV2_StatusNotificationCarriesRequestState\` verifies the notification payload carries \`requestState\` and matches the value the next \`tasks/get\` would mint.

## Gap 3 (P1): HMAC-signed \`requestState\` integrity

SEP-2663 says servers MUST treat \`requestState\` as attacker-controlled. Pre-this-PR, \`requestState\` was the bare \`taskID\` — anyone who learned a taskID could forge any token.

- New \`TasksConfig.RequestStateKey []byte\` (nil = legacy plaintext mode for backward compat / tests) + \`RequestStateTTL\` (default 24h).
- When the key is set, requestState is encoded as \`<base64url-hmac>.<base64url-payload>\` where payload is JSON \`{taskId, exp}\`. Decoder cross-checks the embedded \`taskId\` against the request's \`taskId\` so a token issued for task A can't be replayed against task B.
- \`core.SignRequestState\` / \`core.VerifyRequestState\` exposed for symmetric verification (tests + future client-side use). Sentinel errors: \`ErrRequestStateMalformed\`, \`ErrRequestStateInvalidSignature\`, \`ErrRequestStateExpired\`.
- Verified on \`tasks/get\` / \`tasks/update\` / \`tasks/cancel\` — tampered, expired, or cross-task tokens get \`-32602\` (uniform with the existing rejection pattern; documented in the open-questions register as one of three intentional interim choices).
- **Tests:** 7 core helper tests (round-trip, tampered payload, tampered signature, expired, malformed, wrong key, bad JSON payload) + 4 server end-to-end tests (signed round-trip, tampered rejection across all three handlers, expired rejection, legacy plaintext mode preserved).

## Cross-cutting docs

- **New conformance/tasks-v2/README.md** — full rewrite from the stale SEP-2557 / 18-scenario / \"no server exists yet\" version. Now: 27 scenarios with an SEP-attribution column, current wire-format diff vs v1, required server fixtures, design notes (two raw fetch sessions for the gating tests, bypassing SDK schema validation), and an Open Spec Questions section pointing at the new tracking issue.
- **New living-register issue** titled \"Tracking: SEP-2322 / SEP-2663 / SEP-2575 open spec questions\" (issue 339) consolidates the three interim choices we made where the spec is silent or ambiguous — \`requestState\` rejection, SEP-2575 capabilities shape, unknown-taskId ack — with code pins, test pins, and triggers for revisiting. \`PLAN.md\` points at it.
- **PLAN.md scrubbed** of \`#N\`-style cross-refs that would otherwise create backlinks on every commit. Now uses plain \"issue 320\" / \"PR 301\" form so a reader can still navigate, without GitHub auto-cross-reference noise.

## Test plan

- [x] \`make test\` — core / server / client / testutil all green.
- [x] 7 new core tests (\`TestRequestState_*\`) for sign/verify primitives.
- [x] 5 new server tests: \`TestV2_StatusNotificationCarriesRequestState\` + 4× \`TestV2_RequestState_*\`.
- [x] 1 new conformance scenario (v2-26); 2 existing scenarios updated for the new ack shape.
- [x] **27/27 v2 conformance scenarios passing** (verified locally + via \`make testconf-tasks-v2\`).
- [x] v1 conformance unaffected (no shared types changed in a v1-breaking way).

## Out of scope

- Server-side conformance scenario for the unknown-taskId ack ambiguity — the upstream spec wording is too soft to assert against; covered server-side in \`TestV2_UpdateUnknownTaskRejected\`.
- ResultEnvelope base-type extraction — deferred (see audit-log refactor-opportunities issue).