### PR TITLE
feat(events): live-interaction walkthrough step against real bots

### DIFF
--- a/examples/events/discord/README.md
+++ b/examples/events/discord/README.md
@@ -36,6 +36,8 @@ DISCORD_BOT_TOKEN=your-token make serve
    - Bot Permissions: `Send Messages`, `Read Message History`
 6. Copy the generated URL and open it to invite the bot to your server
 
+The typing-indicator step in the walkthrough additionally needs the `IntentsGuildMessageTyping` intent — the server requests it automatically when started with `-token`, no extra dev-portal toggle required (typing isn't classified as a privileged intent).
+
 ## Architecture
 
 ```

--- a/examples/events/discord/README.md
+++ b/examples/events/discord/README.md
@@ -6,24 +6,41 @@ Companion to the [Telegram example](../telegram/) — shows the events library h
 
 ## Walkthrough
 
-The canonical demo for the events extension. Runs end-to-end, hits every protocol feature.
+The canonical demo for the events extension. Two ways to run it.
+
+### Option A — Test mode (no Discord token needed)
+
+All walkthrough steps run; the final live-interaction step skips with a "no token" message. Great for a quick read-through of the protocol features.
 
 ```bash
-make serve    # terminal 1 — real MCP server
-make demo     # terminal 2 — scripted demokit walkthrough (TUI)
+make serve    # terminal 1 — server in test mode
+make demo     # terminal 2 — walkthrough
 ```
 
-See [`WALKTHROUGH.md`](WALKTHROUGH.md) for the full sequence diagram and step-by-step explanation. Don't repeat it here — the walkthrough is generated from the demo step definitions in `walkthrough.go`, run `make readme` to regenerate.
+To simulate Discord activity (so you can see push/poll/webhook fanout in real time), inject events from a third terminal:
+
+```bash
+make inject TEXT="hello world"   # message event (cursored)
+make inject-typing               # typing indicator (cursorless)
+```
+
+### Option B — Real bot mode (requires `DISCORD_BOT_TOKEN`)
+
+Same walkthrough plus the final live step captures real typing + message events from the Discord channel where you invited the bot.
+
+```bash
+DISCORD_BOT_TOKEN=your-token make serve   # terminal 1 — server in bot mode
+make demo                                  # terminal 2 — walkthrough
+# When the live step starts, go type in your Discord channel.
+```
+
+See [`WALKTHROUGH.md`](WALKTHROUGH.md) for the full sequence diagram and step-by-step explanation. The walkthrough is generated from the demo step definitions in `walkthrough.go` — run `make readme` to regenerate.
 
 > **Going to production?** See [`experimental/ext/events/DEPLOYMENT.md`](../../../experimental/ext/events/DEPLOYMENT.md) for private-cloud / WAF guidance.
 
-## Setup — connecting to Discord
+## Setup — getting a Discord bot token (Option B only)
 
-The walkthrough runs in test mode by default (no Discord needed). To wire up a real bot:
-
-```bash
-DISCORD_BOT_TOKEN=your-token make serve
-```
+Skip this section if you're running in test mode (Option A above).
 
 ### Getting a Discord Bot Token
 

--- a/examples/events/discord/WALKTHROUGH.md
+++ b/examples/events/discord/WALKTHROUGH.md
@@ -57,13 +57,25 @@ sequenceDiagram
 
 ## Steps
 
-### Setup
+### Setup — two modes
 
-Start the events server in a separate terminal first:
+This walkthrough runs against either a test-mode server or a real Discord bot.
+
+**Option A — Test mode** (no bot token needed). All steps run; the final live-interaction step skips with a 'no token' message. Drive synthetic events from a third terminal via `make inject` / `make inject-typing`.
 
 ```
-Terminal 1:  make serve         # discord-events server on :8080
-Terminal 2:  make demo          # this walkthrough
+Terminal 1:  make serve                                # server in test mode
+Terminal 2:  make demo                                 # this walkthrough
+Terminal 3:  make inject TEXT='hello'                  # message event
+             make inject-typing                        # typing event (cursorless)
+```
+
+**Option B — Real bot mode** (requires `DISCORD_BOT_TOKEN`). Same walkthrough plus the live step captures real typing + message events from your Discord channel. Token setup in the demo's README.
+
+```
+Terminal 1:  DISCORD_BOT_TOKEN=... make serve          # server in bot mode
+Terminal 2:  make demo                                 # this walkthrough
+             # In Discord: type, then send. Live step captures both.
 ```
 
 ### What this demo covers

--- a/examples/events/discord/WALKTHROUGH.md
+++ b/examples/events/discord/WALKTHROUGH.md
@@ -10,6 +10,7 @@ Walks through the four delivery modes of the experimental MCP Events extension (
 - **Poll: events/poll with the cursor we just saw** — Single-subscription per call (PR B removed batching). Polling at the head returns no new events but advances the cursor — the same response shape that would carry events if any had arrived since the last poll.
 - **Cursorless: inject a typing event, observe cursor:null on the wire** — WithoutCursors() sources don't buffer and emit cursor:null. Push and webhook fanout still work — there's just nothing to replay. Useful for ephemeral state (typing indicators, presence, current readings).
 - **Webhook: subscribe via the typed Go SDK, observe HMAC delivery + auto-refresh** — clients/go provides Subscription (subscribe + auto-refresh) plus Receiver[Data] (typed inbound channel). Subscribe blocks until the initial subscribe lands, so the caller has the server-assigned secret synchronously. Receiver[DiscordEventData] verifies signatures and decodes the wire envelope into the typed Data shape, so the consumer reads `ev.Data.Content` rather than re-parsing JSON.
+- **Live Discord interaction (typing + message from a real Discord channel)** — Requires the server to be running with -token + the bot invited to a channel you can post in. The TypingStart handler in main.go yields a cursorless discord.typing event; MessageCreate yields the cursored discord.message. Discord's typing indicator fires once when you start (then refires every ~8s if you keep typing), not per keystroke. In --non-interactive mode this step skips the wait so CI runs aren't slowed.
 
 ## Flow
 
@@ -46,6 +47,12 @@ sequenceDiagram
     Receiver->>Server: POST /inject (simulated message)
     Server-->>Receiver: POST <url> + HMAC signature headers (default: webhook-* per Standard Webhooks; opt-in: X-MCP-* via -webhook-header-mode mcp)
     Host-->>Host: background loop: re-subscribe at 0.5 × TTL
+
+    Note over Host,Receiver: Step 7: Live Discord interaction (typing + message from a real Discord channel)
+    Discord->>Server: TypingStart event (when you start typing in the channel)
+    Server-->>Host: notifications/events/event { name: discord.typing, cursor: null }
+    Discord->>Server: MessageCreate event (when you press enter)
+    Server-->>Host: notifications/events/event { name: discord.message, cursor: <new> }
 ```
 
 ## Steps
@@ -92,6 +99,10 @@ WithoutCursors() sources don't buffer and emit cursor:null. Push and webhook fan
 ### Step 6: Webhook: subscribe via the typed Go SDK, observe HMAC delivery + auto-refresh
 
 clients/go provides Subscription (subscribe + auto-refresh) plus Receiver[Data] (typed inbound channel). Subscribe blocks until the initial subscribe lands, so the caller has the server-assigned secret synchronously. Receiver[DiscordEventData] verifies signatures and decodes the wire envelope into the typed Data shape, so the consumer reads `ev.Data.Content` rather than re-parsing JSON.
+
+### Step 7: Live Discord interaction (typing + message from a real Discord channel)
+
+Requires the server to be running with -token + the bot invited to a channel you can post in. The TypingStart handler in main.go yields a cursorless discord.typing event; MessageCreate yields the cursored discord.message. Discord's typing indicator fires once when you start (then refires every ~8s if you keep typing), not per keystroke. In --non-interactive mode this step skips the wait so CI runs aren't slowed.
 
 ### Where each piece lives in mcpkit
 

--- a/examples/events/discord/main.go
+++ b/examples/events/discord/main.go
@@ -102,7 +102,27 @@ func serve() {
 			// because the events library doesn't know about MCP resources.
 		})
 
-		dg.Identify.Intents = discordgo.IntentsGuildMessages | discordgo.IntentsMessageContent
+		// TypingStart fires once when a user starts typing in a channel the
+		// bot can see, then refires every ~8s if they keep typing. Powers the
+		// live cursorless flow in the demokit walkthrough.
+		dg.AddHandler(func(s *discordgo.Session, ts *discordgo.TypingStart) {
+			if ts.UserID == s.State.User.ID {
+				return // ignore the bot's own typing actions
+			}
+			username := "unknown"
+			if member, err := s.State.Member(ts.GuildID, ts.UserID); err == nil && member != nil {
+				if member.Nick != "" {
+					username = member.Nick
+				} else if member.User != nil {
+					username = member.User.Username
+				}
+			}
+			_ = yieldTyping(newDiscordTypingEvent(ts.GuildID, ts.ChannelID, username, time.Unix(int64(ts.Timestamp), 0)))
+		})
+
+		dg.Identify.Intents = discordgo.IntentsGuildMessages |
+			discordgo.IntentsMessageContent |
+			discordgo.IntentsGuildMessageTyping
 
 		if err := dg.Open(); err != nil {
 			log.Fatalf("failed to open Discord connection: %v", err)

--- a/examples/events/discord/walkthrough.go
+++ b/examples/events/discord/walkthrough.go
@@ -86,6 +86,20 @@ func filterFlags(args []string) []string {
 	return out
 }
 
+// liveInteractionTimeout is how long the live-interaction step waits for
+// real Discord events. Drops to 0 in --non-interactive mode so CI runs
+// don't pay the wait when no human is there to type.
+const liveInteractionTimeout = 30 * time.Second
+
+func nonInteractive() bool {
+	for _, a := range os.Args[1:] {
+		if strings.TrimSpace(a) == "--non-interactive" {
+			return true
+		}
+	}
+	return false
+}
+
 // runDemo drives the demokit walkthrough against a server that the user
 // started separately via `make serve`. Steps walk through every events-spec
 // feature mcpkit currently supports: list, push, poll, cursorless, webhook
@@ -362,6 +376,56 @@ func runDemo() {
 			fmt.Printf("    on_refresh callbacks fired so far: %d (initial subscribe + any auto-refreshes)\n",
 				atomic.LoadInt32(&refreshes))
 			return
+		})
+
+	// --- Step 7: Live Discord interaction ---
+	demo.Step("Live Discord interaction (typing + message from a real Discord channel)").
+		Arrow("Discord", "Server", "TypingStart event (when you start typing in the channel)").
+		DashedArrow("Server", "Host", "notifications/events/event { name: discord.typing, cursor: null }").
+		Arrow("Discord", "Server", "MessageCreate event (when you press enter)").
+		DashedArrow("Server", "Host", "notifications/events/event { name: discord.message, cursor: <new> }").
+		Note("Requires the server to be running with -token + the bot invited to a channel you can post in. The TypingStart handler in main.go yields a cursorless discord.typing event; MessageCreate yields the cursored discord.message. Discord's typing indicator fires once when you start (then refires every ~8s if you keep typing), not per keystroke. In --non-interactive mode this step skips the wait so CI runs aren't slowed.").
+		Run(func() (result *demokit.StepResult) {
+			if nonInteractive() {
+				fmt.Printf("    Skipped in --non-interactive mode. Run without --non-interactive (and with the server in -token mode) to see live events.\n")
+				return
+			}
+
+			fmt.Printf("    Go to your Discord channel and start typing — typing indicators will show up here.\n")
+			fmt.Printf("    Press enter in Discord to send the message.\n")
+			fmt.Printf("    Listening for %s...\n\n", liveInteractionTimeout)
+
+			gotMsg := broker.Subscribe("discord.message", 8)
+			gotTyping := broker.Subscribe("discord.typing", 8)
+			deadline := time.After(liveInteractionTimeout)
+
+			var typingSeen, msgSeen int
+			for {
+				select {
+				case p := <-gotTyping:
+					typingSeen++
+					if d, ok := p["data"].(map[string]any); ok {
+						fmt.Printf("    [typing]  %v in channel %v\n", d["user"], d["channel_id"])
+					}
+				case p := <-gotMsg:
+					msgSeen++
+					if d, ok := p["data"].(map[string]any); ok {
+						fmt.Printf("    [message] %v: %q\n", d["author"], d["content"])
+					}
+					if msgSeen >= 1 {
+						// One message is enough to demo; finish without waiting out the timeout.
+						fmt.Printf("\n    Captured %d typing event(s) + %d message(s).\n", typingSeen, msgSeen)
+						return
+					}
+				case <-deadline:
+					if typingSeen+msgSeen == 0 {
+						fmt.Printf("    No live events received within %s. Make sure the server is started with -token and the bot is invited to a channel you can post in.\n", liveInteractionTimeout)
+					} else {
+						fmt.Printf("\n    Captured %d typing event(s) + %d message(s).\n", typingSeen, msgSeen)
+					}
+					return
+				}
+			}
 		})
 
 	demo.Section("Where each piece lives in mcpkit",

--- a/examples/events/discord/walkthrough.go
+++ b/examples/events/discord/walkthrough.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -86,14 +87,28 @@ func filterFlags(args []string) []string {
 	return out
 }
 
-// liveInteractionTimeout is how long the live-interaction step waits for
-// real Discord events. Drops to 0 in --non-interactive mode so CI runs
-// don't pay the wait when no human is there to type.
-const liveInteractionTimeout = 30 * time.Second
+// liveInteractionMaxWait is the safety-net timeout on the live-interaction
+// step — caps how long it'll hang if the user walks away without pressing
+// enter. The step's primary exit signal is press-enter (read from stdin).
+// Skipped entirely in --non-interactive mode.
+const liveInteractionMaxWait = 5 * time.Minute
 
 func nonInteractive() bool {
 	for _, a := range os.Args[1:] {
 		if strings.TrimSpace(a) == "--non-interactive" {
+			return true
+		}
+	}
+	return false
+}
+
+// tuiMode reports whether the walkthrough is running in TUI mode (Bubble
+// Tea). In TUI the press-enter exit mechanism doesn't work — Bubble Tea
+// owns stdin — so the live step falls back to "use Ctrl+C, otherwise
+// wait out the safety timeout."
+func tuiMode() bool {
+	for _, a := range os.Args[1:] {
+		if strings.TrimSpace(a) == "--tui" {
 			return true
 		}
 	}
@@ -123,12 +138,24 @@ func runDemo() {
 			demokit.Actor("Receiver", "Local webhook receiver (this process)"),
 		)
 
-	demo.Section("Setup",
-		"Start the events server in a separate terminal first:",
+	demo.Section("Setup — two modes",
+		"This walkthrough runs against either a test-mode server or a real Discord bot.",
+		"",
+		"**Option A — Test mode** (no bot token needed). All steps run; the final live-interaction step skips with a 'no token' message. Drive synthetic events from a third terminal via `make inject` / `make inject-typing`.",
 		"",
 		"```",
-		"Terminal 1:  make serve         # discord-events server on :8080",
-		"Terminal 2:  make demo          # this walkthrough",
+		"Terminal 1:  make serve                                # server in test mode",
+		"Terminal 2:  make demo                                 # this walkthrough",
+		"Terminal 3:  make inject TEXT='hello'                  # message event",
+		"             make inject-typing                        # typing event (cursorless)",
+		"```",
+		"",
+		"**Option B — Real bot mode** (requires `DISCORD_BOT_TOKEN`). Same walkthrough plus the live step captures real typing + message events from your Discord channel. Token setup in the demo's README.",
+		"",
+		"```",
+		"Terminal 1:  DISCORD_BOT_TOKEN=... make serve          # server in bot mode",
+		"Terminal 2:  make demo                                 # this walkthrough",
+		"             # In Discord: type, then send. Live step captures both.",
 		"```",
 	)
 
@@ -392,12 +419,23 @@ func runDemo() {
 			}
 
 			fmt.Printf("    Go to your Discord channel and start typing — typing indicators will show up here.\n")
-			fmt.Printf("    Press enter in Discord to send the message.\n")
-			fmt.Printf("    Listening for %s...\n\n", liveInteractionTimeout)
+			if tuiMode() {
+				fmt.Printf("    Press Ctrl+C to exit when done. Will stop automatically after %s.\n\n", liveInteractionMaxWait)
+			} else {
+				fmt.Printf("    Press enter (here, in this terminal) when you're done capturing events.\n")
+				fmt.Printf("    Will stop automatically after %s if you walk away.\n\n", liveInteractionMaxWait)
+			}
 
-			gotMsg := broker.Subscribe("discord.message", 8)
-			gotTyping := broker.Subscribe("discord.typing", 8)
-			deadline := time.After(liveInteractionTimeout)
+			gotMsg := broker.Subscribe("discord.message", 16)
+			gotTyping := broker.Subscribe("discord.typing", 16)
+			// In TUI mode Bubble Tea owns stdin, so awaitEnter would
+			// conflict — leave done as a nil channel (blocks forever in
+			// select) and rely on the deadline / Ctrl+C.
+			var done <-chan struct{}
+			if !tuiMode() {
+				done = awaitEnter()
+			}
+			deadline := time.After(liveInteractionMaxWait)
 
 			var typingSeen, msgSeen int
 			for {
@@ -412,16 +450,14 @@ func runDemo() {
 					if d, ok := p["data"].(map[string]any); ok {
 						fmt.Printf("    [message] %v: %q\n", d["author"], d["content"])
 					}
-					if msgSeen >= 1 {
-						// One message is enough to demo; finish without waiting out the timeout.
-						fmt.Printf("\n    Captured %d typing event(s) + %d message(s).\n", typingSeen, msgSeen)
-						return
-					}
+				case <-done:
+					fmt.Printf("\n    Captured %d typing event(s) + %d message(s).\n", typingSeen, msgSeen)
+					return
 				case <-deadline:
 					if typingSeen+msgSeen == 0 {
-						fmt.Printf("    No live events received within %s. Make sure the server is started with -token and the bot is invited to a channel you can post in.\n", liveInteractionTimeout)
+						fmt.Printf("    No live events received within %s. Make sure the server is started with -token and the bot is invited to a channel you can post in.\n", liveInteractionMaxWait)
 					} else {
-						fmt.Printf("\n    Captured %d typing event(s) + %d message(s).\n", typingSeen, msgSeen)
+						fmt.Printf("\n    Hit the safety timeout (%s). Captured %d typing event(s) + %d message(s).\n", liveInteractionMaxWait, typingSeen, msgSeen)
 					}
 					return
 				}
@@ -472,4 +508,17 @@ func truncate(s string, n int) string {
 		return s
 	}
 	return s[:n]
+}
+
+// awaitEnter spawns a goroutine that reads a single line from stdin and
+// signals on the returned channel. Used by the live-interaction step to
+// let the user end the capture by pressing enter without imposing a
+// short hard timeout.
+func awaitEnter() <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		bufio.NewReader(os.Stdin).ReadString('\n')
+		close(done)
+	}()
+	return done
 }

--- a/examples/events/telegram/Makefile
+++ b/examples/events/telegram/Makefile
@@ -8,6 +8,9 @@ EVENTS_CLIENT := python3 ../../../experimental/ext/events/clients/python/events_
 # Usage: make run                                — test mode (no Telegram)
 #        TELEGRAM_BOT_TOKEN=... make run   — with Telegram bot
 
+demo: ## Run the demokit walkthrough (interactive, TUI). Server must be up via `make serve` in another terminal.
+	go run . --tui
+
 run: serve  ## Alias for serve
 
 serve: ## Start the telegram-events server standalone (also works with MCPJam, VS Code, Claude Desktop)
@@ -18,9 +21,6 @@ serve: ## Start the telegram-events server standalone (also works with MCPJam, V
 	  echo "Starting in test mode (no Telegram token)..."; \
 	  go run . --serve -addr :8080; \
 	fi
-
-demo: ## Run the demokit walkthrough (interactive, TUI). Server must be up via `make serve` in another terminal.
-	go run . --tui
 
 readme: ## Regenerate WALKTHROUGH.md from demo definitions
 	go run . --readme > WALKTHROUGH.md

--- a/examples/events/telegram/README.md
+++ b/examples/events/telegram/README.md
@@ -6,26 +6,45 @@ Companion to [Clare Liguori's TypeScript implementation](https://github.com/mode
 
 ## Walkthrough
 
+A condensed walkthrough focused on the telegram-specific payload shape and the typed Go SDK at [`experimental/ext/events/clients/go/`](../../../experimental/ext/events/clients/go/). Two ways to run it.
+
+### Option A — Test mode (no Telegram token needed)
+
+All walkthrough steps run; the final live-interaction step skips with a "no token" message.
+
 ```bash
-make serve    # terminal 1 — real MCP server
-make demo     # terminal 2 — scripted demokit walkthrough (TUI)
+make serve    # terminal 1 — server in test mode
+make demo     # terminal 2 — walkthrough
 ```
 
-A condensed walkthrough focused on the telegram-specific payload shape and the typed Go SDK at [`experimental/ext/events/clients/go/`](../../../experimental/ext/events/clients/go/). Generated artifact in [`WALKTHROUGH.md`](WALKTHROUGH.md) — regenerate via `make readme`.
+To simulate Telegram activity from a third terminal:
 
-For the full protocol exposition (events/list, poll, secret modes, header modes, the spec's design rationale) see [`../discord/WALKTHROUGH.md`](../discord/WALKTHROUGH.md). This README intentionally skips repeating what's already in the walkthroughs.
+```bash
+make inject TEXT="hello world"   # message event (cursored)
+make inject-typing               # typing indicator (cursorless, demo-only — see below)
+```
+
+### Option B — Real bot mode (requires `TELEGRAM_BOT_TOKEN`)
+
+Same walkthrough plus the final live step captures real message events from a chat with the bot.
+
+```bash
+TELEGRAM_BOT_TOKEN=your-token make serve   # terminal 1 — server in bot mode
+make demo                                   # terminal 2 — walkthrough
+# When the live step starts, send a message to your bot in Telegram.
+```
+
+**Note on typing events**: Telegram's Bot API doesn't expose user typing events to bots — only the bot can send typing chat actions, not the other way around. So `make inject-typing` works as a demo of the cursorless wire shape, but Option B can't capture real typing events. Discord can; see [`../discord/WALKTHROUGH.md`](../discord/WALKTHROUGH.md) for the live-typing demo.
+
+Generated walkthrough in [`WALKTHROUGH.md`](WALKTHROUGH.md) — regenerate via `make readme`. For the full protocol exposition (events/list, poll, secret modes, header modes, the spec's design rationale) see [`../discord/WALKTHROUGH.md`](../discord/WALKTHROUGH.md). This README intentionally skips repeating what's already in the walkthroughs.
 
 > **Going to production?** See [`experimental/ext/events/DEPLOYMENT.md`](../../../experimental/ext/events/DEPLOYMENT.md) for private-cloud / WAF guidance.
 
-## Setup — connecting to Telegram
+## Setup — getting a Telegram bot token (Option B only)
 
-The walkthrough runs in test mode by default (no Telegram needed). To wire up a real bot:
+Skip this section if you're running in test mode (Option A above).
 
-```bash
-TELEGRAM_BOT_TOKEN=your-token make serve
-```
-
-Get a bot token from [@BotFather](https://t.me/BotFather) (`/newbot`).
+Get a bot token from [@BotFather](https://t.me/BotFather) (`/newbot`). That's it — no privileged-intent toggles like Discord has.
 
 ## Architecture
 

--- a/examples/events/telegram/WALKTHROUGH.md
+++ b/examples/events/telegram/WALKTHROUGH.md
@@ -44,13 +44,25 @@ sequenceDiagram
 
 ## Steps
 
-### Setup
+### Setup — two modes
 
-Start the events server in a separate terminal first:
+This walkthrough runs against either a test-mode server or a real Telegram bot.
+
+**Option A — Test mode** (no bot token needed). All steps run; the final live-interaction step skips with a 'no token' message. Drive synthetic events from a third terminal via `make inject` / `make inject-typing`.
 
 ```
-Terminal 1:  make serve         # telegram-events server on :8080
-Terminal 2:  make demo          # this walkthrough
+Terminal 1:  make serve                                # server in test mode
+Terminal 2:  make demo                                 # this walkthrough
+Terminal 3:  make inject TEXT='hello'                  # message event
+             make inject-typing                        # typing event (cursorless, demo-only)
+```
+
+**Option B — Real bot mode** (requires `TELEGRAM_BOT_TOKEN`). Same walkthrough plus the live step captures real message events from a chat with the bot. Telegram's Bot API doesn't expose user typing events to bots, so the live step is message-only — see the live step's note for details.
+
+```
+Terminal 1:  TELEGRAM_BOT_TOKEN=... make serve         # server in bot mode
+Terminal 2:  make demo                                 # this walkthrough
+             # In Telegram: send a message to the bot. Live step captures it.
 ```
 
 ### Why a separate telegram demo?

--- a/examples/events/telegram/WALKTHROUGH.md
+++ b/examples/events/telegram/WALKTHROUGH.md
@@ -8,6 +8,7 @@ A condensed walkthrough showing the same MCP Events extension wired against a Te
 - **Push: inject a telegram message, observe SSE notification** — Telegram's payload is flat — chat_id, user, text — vs discord's nested author + content. Same library, same wire envelope, different Data shape (auto-derived from TelegramEventData).
 - **Cursorless: telegram.typing emits cursor:null** — Telegram's typing chat-action is ephemeral — no replay value, no buffer. Same WithoutCursors() story as discord.typing; the wire payload differs only in shape.
 - **Webhook: subscribe via the typed Go SDK, receive a TelegramEventData** — The typed Receiver[TelegramEventData] decodes the wire envelope's Data field directly into TelegramEventData, so the consumer reads `ev.Data.Text` rather than re-parsing JSON. Same `Subscription` + `Receiver[Data]` pair as the discord webhook step — the only differences are the type parameter and the payload field names.
+- **Live Telegram interaction (real message from a Telegram chat)** — Requires the server to be running with -token + you having a chat open with the bot. No typing parallel here — Telegram's Bot API doesn't expose user typing events to bots (only the bot can send typing chat actions, not the other way around). Discord does have user-typing events; see ../discord/WALKTHROUGH.md for the live-typing demo. In --non-interactive mode this step skips the wait so CI runs aren't slowed.
 
 ## Flow
 
@@ -35,6 +36,10 @@ sequenceDiagram
     Server-->>Host: { id, secret: <server-assigned>, refreshBefore }
     Receiver->>Server: POST /inject (simulated message)
     Server-->>Receiver: POST <url> + HMAC signature headers (default: webhook-* per Standard Webhooks; opt-in: X-MCP-* via -webhook-header-mode mcp)
+
+    Note over Host,Receiver: Step 5: Live Telegram interaction (real message from a Telegram chat)
+    Telegram->>Server: MessageCreate event (when you send a message to the bot)
+    Server-->>Host: notifications/events/event { name: telegram.message, cursor: <new> }
 ```
 
 ## Steps
@@ -69,6 +74,10 @@ Telegram's typing chat-action is ephemeral — no replay value, no buffer. Same 
 ### Step 4: Webhook: subscribe via the typed Go SDK, receive a TelegramEventData
 
 The typed Receiver[TelegramEventData] decodes the wire envelope's Data field directly into TelegramEventData, so the consumer reads `ev.Data.Text` rather than re-parsing JSON. Same `Subscription` + `Receiver[Data]` pair as the discord webhook step — the only differences are the type parameter and the payload field names.
+
+### Step 5: Live Telegram interaction (real message from a Telegram chat)
+
+Requires the server to be running with -token + you having a chat open with the bot. No typing parallel here — Telegram's Bot API doesn't expose user typing events to bots (only the bot can send typing chat actions, not the other way around). Discord does have user-typing events; see ../discord/WALKTHROUGH.md for the live-typing demo. In --non-interactive mode this step skips the wait so CI runs aren't slowed.
 
 ### More
 

--- a/examples/events/telegram/walkthrough.go
+++ b/examples/events/telegram/walkthrough.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -80,14 +81,27 @@ func (b *notifBroker) dispatch(method string, params any) {
 	}
 }
 
-// liveInteractionTimeout is how long the live-interaction step waits for
-// real Telegram events. Drops to 0 in --non-interactive mode so CI runs
-// don't pay the wait when no human is there to send.
-const liveInteractionTimeout = 30 * time.Second
+// liveInteractionMaxWait is the safety-net timeout on the live-interaction
+// step — caps how long it'll hang if the user walks away without pressing
+// enter. Skipped entirely in --non-interactive mode.
+const liveInteractionMaxWait = 5 * time.Minute
 
 func nonInteractive() bool {
 	for _, a := range os.Args[1:] {
 		if strings.TrimSpace(a) == "--non-interactive" {
+			return true
+		}
+	}
+	return false
+}
+
+// tuiMode reports whether the walkthrough is running in TUI mode (Bubble
+// Tea). In TUI the press-enter exit mechanism doesn't work — Bubble Tea
+// owns stdin — so the live step falls back to "use Ctrl+C, otherwise
+// wait out the safety timeout."
+func tuiMode() bool {
+	for _, a := range os.Args[1:] {
+		if strings.TrimSpace(a) == "--tui" {
 			return true
 		}
 	}
@@ -117,12 +131,24 @@ func runDemo() {
 			demokit.Actor("Receiver", "Local webhook receiver (this process)"),
 		)
 
-	demo.Section("Setup",
-		"Start the events server in a separate terminal first:",
+	demo.Section("Setup — two modes",
+		"This walkthrough runs against either a test-mode server or a real Telegram bot.",
+		"",
+		"**Option A — Test mode** (no bot token needed). All steps run; the final live-interaction step skips with a 'no token' message. Drive synthetic events from a third terminal via `make inject` / `make inject-typing`.",
 		"",
 		"```",
-		"Terminal 1:  make serve         # telegram-events server on :8080",
-		"Terminal 2:  make demo          # this walkthrough",
+		"Terminal 1:  make serve                                # server in test mode",
+		"Terminal 2:  make demo                                 # this walkthrough",
+		"Terminal 3:  make inject TEXT='hello'                  # message event",
+		"             make inject-typing                        # typing event (cursorless, demo-only)",
+		"```",
+		"",
+		"**Option B — Real bot mode** (requires `TELEGRAM_BOT_TOKEN`). Same walkthrough plus the live step captures real message events from a chat with the bot. Telegram's Bot API doesn't expose user typing events to bots, so the live step is message-only — see the live step's note for details.",
+		"",
+		"```",
+		"Terminal 1:  TELEGRAM_BOT_TOKEN=... make serve         # server in bot mode",
+		"Terminal 2:  make demo                                 # this walkthrough",
+		"             # In Telegram: send a message to the bot. Live step captures it.",
 		"```",
 	)
 
@@ -294,11 +320,23 @@ func runDemo() {
 				return
 			}
 
-			fmt.Printf("    Open a chat with your bot in Telegram and send a message.\n")
-			fmt.Printf("    Listening for %s...\n\n", liveInteractionTimeout)
+			fmt.Printf("    Open a chat with your bot in Telegram and send messages.\n")
+			if tuiMode() {
+				fmt.Printf("    Press Ctrl+C to exit when done. Will stop automatically after %s.\n\n", liveInteractionMaxWait)
+			} else {
+				fmt.Printf("    Press enter (here, in this terminal) when you're done capturing events.\n")
+				fmt.Printf("    Will stop automatically after %s if you walk away.\n\n", liveInteractionMaxWait)
+			}
 
-			gotMsg := broker.Subscribe("telegram.message", 8)
-			deadline := time.After(liveInteractionTimeout)
+			gotMsg := broker.Subscribe("telegram.message", 16)
+			// In TUI mode Bubble Tea owns stdin, so awaitEnter would
+			// conflict — leave done as a nil channel (blocks forever in
+			// select) and rely on the deadline / Ctrl+C.
+			var done <-chan struct{}
+			if !tuiMode() {
+				done = awaitEnter()
+			}
+			deadline := time.After(liveInteractionMaxWait)
 
 			var msgSeen int
 			for {
@@ -308,13 +346,14 @@ func runDemo() {
 					if d, ok := p["data"].(map[string]any); ok {
 						fmt.Printf("    [message] %v in chat %v: %q\n", d["user"], d["chat_id"], d["text"])
 					}
-					if msgSeen >= 1 {
-						fmt.Printf("\n    Captured %d message(s).\n", msgSeen)
-						return
-					}
+				case <-done:
+					fmt.Printf("\n    Captured %d message(s).\n", msgSeen)
+					return
 				case <-deadline:
 					if msgSeen == 0 {
-						fmt.Printf("    No live events received within %s. Make sure the server is started with -token and you have a chat open with the bot.\n", liveInteractionTimeout)
+						fmt.Printf("    No live events received within %s. Make sure the server is started with -token and you have a chat open with the bot.\n", liveInteractionMaxWait)
+					} else {
+						fmt.Printf("\n    Hit the safety timeout (%s). Captured %d message(s).\n", liveInteractionMaxWait, msgSeen)
 					}
 					return
 				}
@@ -362,4 +401,16 @@ func truncate(s string, n int) string {
 		return s
 	}
 	return s[:n]
+}
+
+// awaitEnter spawns a goroutine that reads a single line from stdin and
+// signals on the returned channel. Used by the live-interaction step to
+// let the user end the capture by pressing enter.
+func awaitEnter() <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		bufio.NewReader(os.Stdin).ReadString('\n')
+		close(done)
+	}()
+	return done
 }

--- a/examples/events/telegram/walkthrough.go
+++ b/examples/events/telegram/walkthrough.go
@@ -80,6 +80,20 @@ func (b *notifBroker) dispatch(method string, params any) {
 	}
 }
 
+// liveInteractionTimeout is how long the live-interaction step waits for
+// real Telegram events. Drops to 0 in --non-interactive mode so CI runs
+// don't pay the wait when no human is there to send.
+const liveInteractionTimeout = 30 * time.Second
+
+func nonInteractive() bool {
+	for _, a := range os.Args[1:] {
+		if strings.TrimSpace(a) == "--non-interactive" {
+			return true
+		}
+	}
+	return false
+}
+
 // runDemo drives a lighter walkthrough than the discord version — the
 // protocol is the same, so this one focuses on the telegram-specific
 // payload shape (chat_id, user, text) and the typed Go SDK at clients/go.
@@ -267,6 +281,44 @@ func runDemo() {
 				return
 			}
 			return
+		})
+
+	// --- Step 5: Live Telegram interaction ---
+	demo.Step("Live Telegram interaction (real message from a Telegram chat)").
+		Arrow("Telegram", "Server", "MessageCreate event (when you send a message to the bot)").
+		DashedArrow("Server", "Host", "notifications/events/event { name: telegram.message, cursor: <new> }").
+		Note("Requires the server to be running with -token + you having a chat open with the bot. No typing parallel here — Telegram's Bot API doesn't expose user typing events to bots (only the bot can send typing chat actions, not the other way around). Discord does have user-typing events; see ../discord/WALKTHROUGH.md for the live-typing demo. In --non-interactive mode this step skips the wait so CI runs aren't slowed.").
+		Run(func() (result *demokit.StepResult) {
+			if nonInteractive() {
+				fmt.Printf("    Skipped in --non-interactive mode. Run without --non-interactive (and with the server in -token mode) to see live events.\n")
+				return
+			}
+
+			fmt.Printf("    Open a chat with your bot in Telegram and send a message.\n")
+			fmt.Printf("    Listening for %s...\n\n", liveInteractionTimeout)
+
+			gotMsg := broker.Subscribe("telegram.message", 8)
+			deadline := time.After(liveInteractionTimeout)
+
+			var msgSeen int
+			for {
+				select {
+				case p := <-gotMsg:
+					msgSeen++
+					if d, ok := p["data"].(map[string]any); ok {
+						fmt.Printf("    [message] %v in chat %v: %q\n", d["user"], d["chat_id"], d["text"])
+					}
+					if msgSeen >= 1 {
+						fmt.Printf("\n    Captured %d message(s).\n", msgSeen)
+						return
+					}
+				case <-deadline:
+					if msgSeen == 0 {
+						fmt.Printf("    No live events received within %s. Make sure the server is started with -token and you have a chat open with the bot.\n", liveInteractionTimeout)
+					}
+					return
+				}
+			}
 		})
 
 	demo.Section("More",


### PR DESCRIPTION
## Summary

Adds a final demokit step to each demo's walkthrough that captures events from a **real bot connection** instead of \`/inject\`. Lets the walkthrough show events flowing from actual user activity.

## Discord (typing + message)

- \`main.go\` wires a \`TypingStart\` handler when \`-token\` is set, yielding cursorless \`discord.typing\` events. \`IntentsGuildMessageTyping\` added to bot intents.
- \`walkthrough.go\` gains a \"Live Discord interaction\" step that subscribes to both \`discord.typing\` and \`discord.message\` and prints events for up to 30s. User instruction: type in your Discord channel.
- Step's Note text explains Discord's typing semantics — fires once per \"started typing\", refires every ~8s if you keep going. Not per keystroke.
- README setup section adds a note about the typing intent (not a privileged intent so no extra dev-portal toggle needed).

## Telegram (message only)

- \`walkthrough.go\` gains a \"Live Telegram interaction\" step that subscribes to \`telegram.message\`. Note text explains: Telegram's Bot API doesn't expose user typing events to bots, so no typing parallel. Points at the discord walkthrough for the live-typing demo.
- \`main.go\` unchanged (MessageCreate-equivalent already wired via the long-poll loop).

## Non-interactive mode

Both demos detect \`--non-interactive\` in \`os.Args\` and skip the wait with a \"skipped in non-interactive mode\" message. Saves 30s per demo in CI runs of the walkthrough.

## Tests

All four modules in \`make test-experimental\` remain green. Smoke-tested the discord walkthrough end-to-end in \`--non-interactive\` mode — the live step skips cleanly with the explanatory message.