### PR TITLE
tasks-v2: SEP-2663 + SEP-2243 coverage (Fixes 3-7)

### DIFF
--- a/conformance/tasks-v2/README.md
+++ b/conformance/tasks-v2/README.md
@@ -4,7 +4,17 @@ Tests any MCP server that implements the Tasks v2 surface, evolving from the ori
 
 The suite drives wire-shape and behavioral assertions against any conformant server using the official [MCP TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk) client plus raw `fetch` for assertions the SDK's typed schemas would strip.
 
-**Current result against the in-repo server:** 27/27 scenarios passing.
+**Current result against the in-repo server:** 30/30 scenarios passing (v2-01..v2-26 plus v2-24c, v2-27, v2-28).
+
+> **A note on wire shapes vs. published SEP TypeScript declarations.** The
+> assertions in this suite track what SEP-2663 / SEP-2322 / SEP-2575 / SEP-2243
+> *say* in their normative text and what mcpkit implements end-to-end against
+> a real client. The published SEP TypeScript schemas in
+> `modelcontextprotocol/specification` may lag the spec text (the most recent
+> example: the upstream conformance PR briefly used a snake_case `result_type`
+> discriminator, but Luca confirmed camelCase `resultType` is the standard —
+> we've aligned to camelCase here). When the TS declarations and the spec
+> text disagree, this suite follows the spec text.
 
 ## Specs covered
 
@@ -13,7 +23,7 @@ The suite drives wire-shape and behavioral assertions against any conformant ser
 | SEP-2663 | Tasks Extension — `io.modelcontextprotocol/tasks` capability, `DetailedTask`, `tasks/update`, ack-only `tasks/cancel`, wire-field renames (`ttlSeconds`, `pollIntervalMilliseconds`) | v2-02, v2-04, v2-07, v2-09, v2-10, v2-11, v2-12, v2-17, v2-22, v2-23 |
 | SEP-2322 | MRTR base types — `inputRequests`/`inputResponses` maps, `requestState`, `resultType` discriminator (`task`/`complete`/`incomplete`) | v2-14, v2-15, v2-16, v2-17, v2-26 |
 | SEP-2575 | Per-request capability override via `_meta.io.modelcontextprotocol/clientCapabilities` | v2-25 |
-| SEP-2243 | `Mcp-Name` HTTP response header on task-creating responses | v2-24, v2-24b |
+| SEP-2243 | `Mcp-Name` (task id) on task-creating responses + `Mcp-Method` (JSON-RPC method) on every response | v2-24, v2-24b, v2-24c |
 
 These are deliberately kept in **one file** rather than split per-SEP. The test harness (initialize handshake, raw fetch session, extension declaration, tool fixtures) is identical for every scenario; splitting would duplicate the harness without behavioral gain. If a future non-tasks consumer of SEP-2322 appears (e.g., MRTR-style input rounds outside the tasks surface), that's the trigger to extract a separate `conformance/mrtr-base/` suite.
 
@@ -108,8 +118,14 @@ SERVER_URL=http://localhost:8080/mcp npx tsx --test tasks-v2/scenarios.test.ts
 
 | # | Scenario | What it tests | SEPs |
 |---|----------|---------------|------|
-| 12 | `ttlSeconds` present | Renamed from v1 `ttl`; v1 key absent | 2663 |
+| 12 | `ttlSeconds` + `pollIntervalMilliseconds` present | Renamed from v1 `ttl` / `pollInterval`; legacy keys absent | 2663 |
 | 13 | No early TTL expiry | Task accessible before TTL elapses | 2663 |
+
+### Strong-consistency / durable create
+
+| # | Scenario | What it tests | SEPs |
+|---|----------|---------------|------|
+| 27 | Immediate `tasks/get` after `CreateTaskResult` | Server MUST NOT return `CreateTaskResult` until `tasks/get` resolves | 2663 |
 
 ### requestState (SEP-2322)
 
@@ -117,6 +133,7 @@ SERVER_URL=http://localhost:8080/mcp npx tsx --test tasks-v2/scenarios.test.ts
 |---|----------|---------------|------|
 | 14 | Server returns `requestState` | tasks/get may include it | 2322 |
 | 15 | Client echoes `requestState` | Subsequent tasks/get accepts it | 2322 |
+| 28 | Stale `requestState` tolerated | Echoing a previously-valid (now-superseded) token MUST succeed | 2663 + 2322 |
 
 ### MRTR — input flow (SEP-2322 + SEP-2663)
 
@@ -139,12 +156,13 @@ SERVER_URL=http://localhost:8080/mcp npx tsx --test tasks-v2/scenarios.test.ts
 | 20 | Immediate result shortcut | Fast operation may skip task creation | 2663 |
 | 21 | No `related-task` `_meta` on inlined result | tasks/get's inlined `result` doesn't carry the v1 _meta key | 2663 |
 
-### SEP-2243: Mcp-Name HTTP header
+### SEP-2243: Mcp-Name + Mcp-Method HTTP headers
 
 | # | Scenario | What it tests | SEPs |
 |---|----------|---------------|------|
-| 24 | Mcp-Name on task creation | Task-creating tools/call response carries `Mcp-Name: <taskId>` | 2243 |
-| 24b | Mcp-Name absent on sync | Sync tools/call response does NOT carry the header | 2243 |
+| 24 | Mcp-Name + Mcp-Method on task creation | Task-creating tools/call response carries `Mcp-Name: <taskId>` AND `Mcp-Method: tools/call` | 2243 |
+| 24b | Mcp-Name absent on sync (Mcp-Method still set) | Sync tools/call: no Mcp-Name; Mcp-Method present | 2243 |
+| 24c | Mcp-Method on tasks/* responses | `tasks/get`, `tasks/cancel` responses carry `Mcp-Method: <method>` | 2243 |
 
 ### SEP-2322: resultType discriminator across non-task responses
 

--- a/conformance/tasks-v2/scenarios.test.ts
+++ b/conformance/tasks-v2/scenarios.test.ts
@@ -530,24 +530,40 @@ describe('MCP Tasks v2 Conformance (SEP-2663)', () => {
     });
 
     // ========================================================================
-    // Scenario 12: ttlSeconds field present and in seconds
+    // Scenario 12: ttlSeconds + pollIntervalMilliseconds wire-field renames
     //
-    // SEP-2663 renamed the wire field from `ttl` to `ttlSeconds` (units are
-    // now part of the field name, no convention required). The legacy `ttl`
-    // key MUST NOT appear on the v2 wire — clients that key off it on a v2
-    // server would silently see an unbounded TTL.
+    // SEP-2663 renamed two wire fields with units in the name (no convention
+    // required):
+    //   - `ttl` (milliseconds, by convention) → `ttlSeconds`
+    //   - `pollInterval` (milliseconds, by convention) → `pollIntervalMilliseconds`
+    //
+    // The legacy keys MUST NOT appear on the v2 wire — clients that key off
+    // them on a v2 server would silently see an unbounded TTL or a missing
+    // poll hint.
     // ========================================================================
-    test('v2-12: ttlSeconds present (and v1 ttl key absent)', async () => {
+    test('v2-12: ttlSeconds + pollIntervalMilliseconds present (legacy v1 keys absent)', async () => {
         const result = await callTool('slow_compute', { seconds: 1, label: 'v2-ttl' });
-        // SEP-2663 flat CreateTaskResult: ttlSeconds is at the top level
-        // alongside resultType, not nested under a "task" wrapper.
+        // SEP-2663 flat CreateTaskResult: the renamed wire fields are at the
+        // top level alongside resultType, not nested under a "task" wrapper.
+
+        // ttlSeconds — required, positive, no legacy `ttl` key.
         assert.ok(result.ttlSeconds !== undefined,
             'CreateTaskResult should have ttlSeconds (SEP-2663 wire-field rename)');
         assert.ok(typeof result.ttlSeconds === 'number' && result.ttlSeconds > 0,
             'ttlSeconds should be a positive number');
-        // The v1 `ttl` (milliseconds) key MUST NOT appear in v2 responses.
         assert.ok(!('ttl' in result),
             'v2 CreateTaskResult MUST NOT carry the v1 `ttl` key (use ttlSeconds)');
+
+        // pollIntervalMilliseconds — optional, but the in-tree fixture sets
+        // DefaultPollMs so we expect it to be populated. When present it must
+        // be a positive number and the legacy `pollInterval` key must NOT
+        // appear on the v2 wire.
+        if (result.pollIntervalMilliseconds !== undefined) {
+            assert.ok(typeof result.pollIntervalMilliseconds === 'number' && result.pollIntervalMilliseconds > 0,
+                'pollIntervalMilliseconds should be a positive number when present');
+        }
+        assert.ok(!('pollInterval' in result),
+            'v2 CreateTaskResult MUST NOT carry the v1 `pollInterval` key (use pollIntervalMilliseconds)');
     });
 
     // ========================================================================
@@ -843,15 +859,21 @@ describe('MCP Tasks v2 Conformance (SEP-2663)', () => {
     });
 
     // ========================================================================
-    // Scenario 24: SEP-2243 Mcp-Name HTTP response header on task creation
+    // Scenario 24: SEP-2243 Mcp-Name + Mcp-Method HTTP response headers
     //
-    // The streamable-HTTP transport MUST set Mcp-Name: <taskId> on the
-    // response to a task-creating tools/call so HTTP-level routing /
-    // observability can key off the task id without parsing the JSON body.
-    // The header MUST NOT appear when the call did not create a task (sync
-    // tool, or extension not negotiated).
+    // The streamable-HTTP transport MUST set both:
+    //   - Mcp-Name: <taskId> — only on task-creating responses; carries the
+    //     new task id so HTTP-level routing / observability can key off it
+    //     without parsing the JSON body.
+    //   - Mcp-Method: <jsonrpc-method> — on every JSON-RPC response; carries
+    //     the originating method (tools/call, tasks/get, …) so the same
+    //     infrastructure can shape requests by route.
+    //
+    // Mcp-Name MUST NOT appear when the call did not create a task (sync
+    // tool, or extension not negotiated). Mcp-Method MUST appear on every
+    // RPC response regardless of method.
     // ========================================================================
-    test('v2-24: Mcp-Name response header on task-creating tools/call', async () => {
+    test('v2-24: Mcp-Name + Mcp-Method response headers on task-creating tools/call', async () => {
         const { result, response } = await rawRequestFull('tools/call', {
             name: 'slow_compute', arguments: { seconds: 1, label: 'v2-24' },
         });
@@ -861,15 +883,38 @@ describe('MCP Tasks v2 Conformance (SEP-2663)', () => {
             'Mcp-Name header MUST be set on task-creating tools/call response');
         assert.equal(mcpName, result.taskId,
             'Mcp-Name header value MUST equal the taskId in the response body');
+        // SEP-2243 Mcp-Method: the JSON-RPC method that produced this response.
+        const mcpMethod = response.headers.get('mcp-method');
+        assert.equal(mcpMethod, 'tools/call',
+            `Mcp-Method header MUST equal the originating JSON-RPC method; got ${mcpMethod}`);
     });
 
-    test('v2-24b: Mcp-Name absent on sync tools/call response', async () => {
+    test('v2-24b: Mcp-Name absent on sync tools/call response (Mcp-Method still present)', async () => {
         const { response } = await rawRequestFull('tools/call', {
             name: 'greet', arguments: { name: 'world' },
         });
         const mcpName = response.headers.get('mcp-name');
         assert.ok(!mcpName,
             `sync tools/call MUST NOT emit Mcp-Name; got ${mcpName}`);
+        // Mcp-Method is method-keyed, not task-keyed — it MUST appear on
+        // every RPC response, including this sync one.
+        assert.equal(response.headers.get('mcp-method'), 'tools/call',
+            'Mcp-Method MUST be set on every tools/call response (sync or task)');
+    });
+
+    test('v2-24c: Mcp-Method on tasks/get and tasks/cancel responses', async () => {
+        // Drive a task we can then read + cancel.
+        const created = await callTool('slow_compute', { seconds: 60, label: 'v2-24c' });
+        assertCreateTaskResult(created, 'v2-24c setup');
+        const taskId = created.taskId;
+
+        const getResp = await rawRequestFull('tasks/get', { taskId });
+        assert.equal(getResp.response.headers.get('mcp-method'), 'tasks/get',
+            'Mcp-Method MUST equal "tasks/get" on the tasks/get response');
+
+        const cancelResp = await rawRequestFull('tasks/cancel', { taskId });
+        assert.equal(cancelResp.response.headers.get('mcp-method'), 'tasks/cancel',
+            'Mcp-Method MUST equal "tasks/cancel" on the tasks/cancel response');
     });
 
     // ========================================================================
@@ -941,6 +986,72 @@ describe('MCP Tasks v2 Conformance (SEP-2663)', () => {
             `tasks/update ack.resultType = ${updateAck.resultType}, want "complete"`);
         // Clean up the parked elicit task.
         await cancelTask(elicitTaskId);
+    });
+
+    // ========================================================================
+    // Scenario 27: SEP-2663 strong-consistency / durable-create
+    //
+    // "A server MUST NOT return CreateTaskResult until the task is durably
+    // created — that is, until a tasks/get for the returned taskId would
+    // resolve."
+    //
+    // Issue tools/call → take the returned taskId → immediately issue
+    // tasks/get with no sleep / poll. The server MUST resolve, not -32602.
+    // A naive implementation that creates the task in the background goroutine
+    // (after returning CreateTaskResult to the client) would fail this test.
+    // ========================================================================
+    test('v2-27: tasks/get immediately after CreateTaskResult must resolve', async () => {
+        const created = await callTool('slow_compute', { seconds: 60, label: 'v2-27' });
+        assertCreateTaskResult(created, 'v2-27 create');
+
+        // No await/sleep between the create and the get — codifies the
+        // strong-consistency ordering.
+        const got = await getTask(created.taskId);
+        assert.equal(got.taskId, created.taskId,
+            'immediate tasks/get after CreateTaskResult must resolve (SEP-2663 durable-create)');
+
+        // Cleanup so we don't leak a 60-second task.
+        await cancelTask(created.taskId);
+    });
+
+    // ========================================================================
+    // Scenario 28: SEP-2663 stale requestState tolerance
+    //
+    // "Servers MUST tolerate receiving a stale or outdated value gracefully."
+    //
+    // Each tasks/get mints a fresh requestState (different exp). After two
+    // tasks/get calls, the first token is "stale" (a newer one exists) but
+    // still within its TTL — echoing it MUST succeed, not -32602.
+    //
+    // No-op for servers running in legacy plaintext mode (requestState ==
+    // taskID, every echo is identical) — the assertion still holds because
+    // the same plaintext token round-trips both times.
+    // ========================================================================
+    test('v2-28: stale-but-valid requestState is tolerated', async () => {
+        const created = await callTool('slow_compute', { seconds: 60, label: 'v2-28' });
+        assertCreateTaskResult(created, 'v2-28 create');
+        const taskId = created.taskId;
+
+        const first = await getTask(taskId);
+        const tokenA = first.requestState;
+        if (!tokenA) {
+            // Server didn't issue requestState at all — nothing to test.
+            // (Conformance allows requestState to be absent per SEP-2322.)
+            await cancelTask(taskId);
+            return;
+        }
+
+        // Second call mints a fresh token (potentially with a newer exp),
+        // making tokenA stale on a server that signs with embedded expiry.
+        const second = await getTask(taskId, { requestState: tokenA });
+        assert.ok(second.taskId, 'second tasks/get should succeed when echoing tokenA');
+
+        // Now echo the older tokenA again — server MUST accept stale-but-valid.
+        const stale = await getTask(taskId, { requestState: tokenA });
+        assert.equal(stale.taskId, taskId,
+            'stale-but-valid requestState MUST be tolerated (SEP-2663)');
+
+        await cancelTask(taskId);
     });
 
 });

--- a/docs/TASKS_CONFORMANCE_PLAN.md
+++ b/docs/TASKS_CONFORMANCE_PLAN.md
@@ -94,10 +94,11 @@ Files to change:
 
 ### Fix 2: Protocol version
 
-- [ ] `conformance/tasks-v2/scenarios.test.ts` — Change `protocolVersion: '2025-11-25'`
-  to `'2026-06-30'` in the `before()` block / `initRawSession` calls.
-
-**Test:** Suite still passes with new version string.
+- [ ] **Deferred — pending the actual `2026-06-30` spec release.** The
+  conformance harness currently negotiates `'2025-11-25'`. Bumping requires
+  a paired change to `server/dispatch.go:supportedProtocolVersions`, which
+  would amount to declaring "mcpkit supports the not-yet-released
+  2026-06-30 spec." Revisit when that version actually lands upstream.
 
 ## Should fix (coverage gaps — spec requirements without test assertions)
 
@@ -107,49 +108,66 @@ Parallel to the existing `ttlSeconds` test in v2-12. Assert:
 - `pollIntervalMilliseconds` key present on CreateTaskResult when server sets it
 - Legacy `pollInterval` key absent
 
-- [ ] `conformance/tasks-v2/scenarios.test.ts` — Add assertion to v2-12 or new v2-XX
-- [ ] `core/task_v2_test.go` — Add wire-format test for `pollIntervalMilliseconds`
+- [x] `conformance/tasks-v2/scenarios.test.ts` v2-12 extended to also assert
+  `pollIntervalMilliseconds` (when present, must be a positive number) and
+  the absence of the legacy `pollInterval` key. Title updated accordingly.
+- [x] `core/task_v2_test.go` — already covered by `TestTaskInfoV2WireFields`
+  (asserts both renamed keys are present and both legacy keys are absent)
+  and by the rewritten `TestCreateTaskResultWireShape` (which now exercises
+  `PollIntervalMilliseconds` round-trip on the flat envelope too). No new
+  test needed.
 
 ### Fix 4: requestState stale-value tolerance
 
 SEP-2663: "Servers MUST tolerate receiving a stale or outdated value gracefully."
 
-- [ ] `server/tasks_v2_test.go` — New test: create task, get requestState A, get again
-  (requestState B), send tasks/get with stale requestState A → should succeed (not -32602).
-- [ ] `conformance/tasks-v2/scenarios.test.ts` — New scenario v2-XX: echo a previously-valid
-  but no-longer-latest requestState → server must accept.
+- [x] `server/tasks_v2_test.go` — `TestV2_RequestState_StaleTolerance`: create
+  task, mint tokenA, sleep ≥1s (unix-seconds expiry granularity), tasks/get
+  with tokenA mints tokenB, then echo the older tokenA — server MUST accept.
+- [x] `conformance/tasks-v2/scenarios.test.ts` — `v2-28` mirrors the same
+  flow against any conformant server.
 
-Note: Our HMAC implementation currently verifies the signature is valid, not that it's the
-latest value. So stale-but-valid tokens should already work. This test confirms it.
+Confirmed: our HMAC verifier checks signature + expiry only, never "latest
+version" — stale-but-valid tokens already work. The new tests lock in that
+behavior so a "track latest only" refactor would fail loudly.
 
 ### Fix 5: Strong consistency (immediate tasks/get after create)
 
 SEP-2663: "A server MUST NOT return CreateTaskResult until the task is durably created —
 that is, until a tasks/get for the returned taskId would resolve."
 
-- [ ] `server/tasks_v2_test.go` — New test: call tools/call → get CreateTaskResult →
-  immediately call tasks/get with returned taskId → must succeed (not -32602).
-- [ ] `conformance/tasks-v2/scenarios.test.ts` — New scenario v2-XX: immediate tasks/get
-  after CreateTaskResult must resolve.
+- [x] `server/tasks_v2_test.go` — `TestV2_StrongConsistency_ImmediateGet`:
+  tools/call → CreateTaskResult → immediate tasks/get (no sleep, no goroutine
+  yield) — must resolve, not -32602.
+- [x] `conformance/tasks-v2/scenarios.test.ts` — `v2-27` mirrors the same flow.
 
-Note: Our implementation already does this (store.Create is synchronous before response).
-This test codifies it.
+Confirmed: middleware calls `store.Create` synchronously before building
+the response, so the task is queryable the instant the client sees the
+CreateTaskResult. The new tests codify that ordering.
 
 ### Fix 6: Mcp-Method header assertion
 
 SEP-2243 requires both `Mcp-Name` AND `Mcp-Method` headers. v2-24 covers Mcp-Name only.
 
-- [ ] `server/tasks_v2_test.go` — Extend Mcp-Name test to also verify `Mcp-Method` header
-  is set to the JSON-RPC method name (e.g., `tasks/get`, `tasks/cancel`, `tasks/update`).
-- [ ] `conformance/tasks-v2/scenarios.test.ts` — Extend v2-24 or new scenario to assert
-  `Mcp-Method` header.
+- [x] `server/server.go:dispatchWithOpts` now stages `Mcp-Method: <req.Method>`
+  for every JSON-RPC response via the existing `core.WithResponseHeaderCollector`
+  plumbing. Pairs with the v2 task middleware's existing `Mcp-Name: <taskId>`.
+- [x] `server/tasks_v2_test.go` — `TestV2_McpNameHeaderOnTaskCreation` extended
+  to also assert `Mcp-Method == "tools/call"`. New `TestV2_McpMethodHeaderOnTasksMethods`
+  verifies tasks/get and tasks/update responses carry the right method.
+- [x] `conformance/tasks-v2/scenarios.test.ts` — v2-24 extended (Mcp-Method on
+  task-creating tools/call), v2-24b extended (Mcp-Method present on sync
+  tools/call too), v2-24c new (Mcp-Method on tasks/get and tasks/cancel).
 
 ### Fix 7: Cleanup stale comments and v2-16
 
 - [x] `conformance/tasks-v2/scenarios.test.ts` v2-16 — PROVISIONAL comment
   removed; replaced with a pointer to v2-17 (which exercises tasks/update).
-- [ ] `conformance/tasks-v2/README.md` — Note that wire shapes match the implementation,
-  not necessarily the published SEP TS declarations (which may lag behind).
+- [x] `conformance/tasks-v2/README.md` — Added a paragraph at the top noting
+  this suite tracks spec text + mcpkit's end-to-end behavior, not the
+  published SEP TypeScript declarations (which may lag — most recent
+  example: the upstream conformance PR briefly used snake_case
+  `result_type`, but Luca confirmed camelCase is the standard).
 
 ## Implementation order
 

--- a/server/server.go
+++ b/server/server.go
@@ -506,6 +506,17 @@ func (s *Server) dispatchWithOpts(d *Dispatcher, ctx context.Context, claims *co
 	// Set the session ID so middleware and handlers can access it via ctx.SessionID().
 	core.SetSessionID(ctx, d.sessionID)
 
+	// SEP-2243: stage the Mcp-Method response header carrying the JSON-RPC
+	// method name (e.g. "tools/call", "tasks/get"). Pairs with Mcp-Name
+	// (taskId, set by the v2 task middleware on task-creating tools/call) so
+	// HTTP infrastructure can route / log against the request shape without
+	// parsing the JSON body. Notifications go nowhere (dispatch returns nil),
+	// so the header is harmlessly dropped for those — only RPC responses
+	// carry it through to the wire.
+	if req.Method != "" {
+		core.SetResponseHeader(ctx, "Mcp-Method", req.Method)
+	}
+
 	// Register a detach strategy for background goroutines (e.g., async tasks).
 	// The strategy replaces the POST-scoped requestFunc and notifyFunc (which
 	// write to the now-closed response stream) with session-level equivalents

--- a/server/tasks_v2_test.go
+++ b/server/tasks_v2_test.go
@@ -536,6 +536,13 @@ func TestV2_McpNameHeaderOnTaskCreation(t *testing.T) {
 		t.Fatalf("missing Mcp-Name header on task-creating tools/call; got body: %s", body)
 	}
 
+	// SEP-2243 also requires Mcp-Method — the JSON-RPC method that produced
+	// this response. Pairs with Mcp-Name so HTTP infrastructure can route /
+	// log against (method, taskId) without parsing the JSON body.
+	if got := resp.Header.Get("Mcp-Method"); got != "tools/call" {
+		t.Errorf("Mcp-Method = %q, want \"tools/call\"", got)
+	}
+
 	// Sanity: the header value should match the taskId in the response body.
 	var rpcResp struct {
 		Result core.CreateTaskResult `json:"result"`
@@ -545,6 +552,62 @@ func TestV2_McpNameHeaderOnTaskCreation(t *testing.T) {
 	}
 	if mcpName != rpcResp.Result.TaskID {
 		t.Errorf("Mcp-Name = %q, want match for taskId %q", mcpName, rpcResp.Result.TaskID)
+	}
+}
+
+// TestV2_McpMethodHeaderOnTasksMethods verifies the SEP-2243 Mcp-Method
+// header carries the JSON-RPC method name on every tasks/* response, not
+// just task-creating tools/call. Mcp-Name is task-creation-specific and
+// stays empty for these reads.
+func TestV2_McpMethodHeaderOnTasksMethods(t *testing.T) {
+	srv := newTaskV2Server(t)
+	handler := srv.Handler(WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	sid := initializeSession(t, ts.URL, true /* declare tasks ext */)
+
+	// Create a task so we have an id to query.
+	createResp := rawHTTPCall(t, ts.URL, sid, true /* jsonOnly */, "tools/call", "fast-task")
+	createBody, _ := io.ReadAll(createResp.Body)
+	createResp.Body.Close()
+	var createWrap struct {
+		Result core.CreateTaskResult `json:"result"`
+	}
+	if err := json.Unmarshal(createBody, &createWrap); err != nil {
+		t.Fatalf("unmarshal create response: %v", err)
+	}
+	taskID := createWrap.Result.TaskID
+	if taskID == "" {
+		t.Fatal("missing taskId in CreateTaskResult")
+	}
+
+	cases := []struct {
+		method string
+		body   string
+	}{
+		{"tasks/get", `{"jsonrpc":"2.0","id":1,"method":"tasks/get","params":{"taskId":"` + taskID + `"}}`},
+		{"tasks/update", `{"jsonrpc":"2.0","id":2,"method":"tasks/update","params":{"taskId":"` + taskID + `"}}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.method, func(t *testing.T) {
+			req, _ := http.NewRequest("POST", ts.URL+"/mcp", strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Accept", "application/json")
+			req.Header.Set("Mcp-Session-Id", sid)
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("%s: %v", tc.method, err)
+			}
+			io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if got := resp.Header.Get("Mcp-Method"); got != tc.method {
+				t.Errorf("%s: Mcp-Method = %q, want %q", tc.method, got, tc.method)
+			}
+			if got := resp.Header.Get("Mcp-Name"); got != "" {
+				t.Errorf("%s: Mcp-Name should be empty for non-task-creating responses; got %q", tc.method, got)
+			}
+		})
 	}
 }
 
@@ -1076,6 +1139,108 @@ func TestV2_RequestState_ExpiredRejected(t *testing.T) {
 	}
 	if !strings.Contains(rpcErr.Message, "expired") {
 		t.Errorf("expired requestState: message=%q; want it to mention \"expired\"", rpcErr.Message)
+	}
+}
+
+// TestV2_StrongConsistency_ImmediateGet verifies SEP-2663's durable-create
+// guarantee: "A server MUST NOT return CreateTaskResult until the task is
+// durably created — that is, until a tasks/get for the returned taskId would
+// resolve."
+//
+// Our middleware calls store.Create synchronously before building the
+// response, so the task is queryable the instant the client sees the
+// CreateTaskResult. This test codifies that ordering — if a future refactor
+// pushed store.Create into the background goroutine, this would catch it.
+func TestV2_StrongConsistency_ImmediateGet(t *testing.T) {
+	srv, _ := newTaskV2ServerWithSlow(t)
+	c := connectV2Client(t, srv, client.WithTasksExtension())
+
+	res, err := c.Call("tools/call", map[string]any{
+		"name":      "slow-task",
+		"arguments": map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("tools/call: %v", err)
+	}
+	var ctr core.CreateTaskResult
+	if err := json.Unmarshal(res.Raw, &ctr); err != nil {
+		t.Fatalf("unmarshal CreateTaskResult: %v", err)
+	}
+	if ctr.TaskID == "" {
+		t.Fatal("missing taskId in CreateTaskResult")
+	}
+
+	// Immediately query — no sleep, no poll, no goroutine yield. SEP-2663
+	// says this MUST resolve, even if the tool's background goroutine hasn't
+	// been scheduled yet.
+	got, err := c.Call("tasks/get", map[string]any{"taskId": ctr.TaskID})
+	if err != nil {
+		t.Fatalf("immediate tasks/get after CreateTaskResult must resolve (SEP-2663): %v", err)
+	}
+	var dt core.DetailedTask
+	if err := json.Unmarshal(got.Raw, &dt); err != nil {
+		t.Fatalf("unmarshal DetailedTask: %v", err)
+	}
+	if dt.TaskID != ctr.TaskID {
+		t.Errorf("tasks/get returned wrong taskId: got %q, want %q", dt.TaskID, ctr.TaskID)
+	}
+	// Status should be non-terminal (slow-task blocks until unblocked); the
+	// exact value doesn't matter — what matters is that the task exists.
+	if dt.Status.IsTerminal() {
+		t.Errorf("expected non-terminal status (task is blocked), got %q", dt.Status)
+	}
+}
+
+// TestV2_RequestState_StaleTolerance verifies SEP-2663's "Servers MUST tolerate
+// receiving a stale or outdated value gracefully" requirement. Each tasks/get
+// mints a fresh signed requestState (different `exp`), so an earlier token
+// becomes "stale" the moment the next one is minted — but stale-but-not-expired
+// tokens MUST still verify and the request MUST succeed (not -32602).
+//
+// Our HMAC verifier only checks signature validity + expiry, never "latest
+// version," so this test codifies the existing behavior. Servers that decide
+// to track a "latest only" notion would fail here, which is the point.
+func TestV2_RequestState_StaleTolerance(t *testing.T) {
+	srv, _ := newSignedTaskV2Server(t, time.Hour)
+	c := connectV2Client(t, srv, client.WithTasksExtension())
+
+	res, err := client.ToolCall(c, "fast-task", map[string]any{})
+	if err != nil || !res.IsTask() {
+		t.Fatalf("ToolCall: %v / IsTask=%v", err, res != nil && res.IsTask())
+	}
+	taskID := res.Task.TaskID
+
+	// Mint tokenA via the first tasks/get.
+	first, err := client.GetTask(c, taskID)
+	if err != nil {
+		t.Fatalf("first GetTask: %v", err)
+	}
+	tokenA := first.RequestState
+	if tokenA == "" {
+		t.Fatal("expected non-empty requestState from signed-mode server")
+	}
+
+	// Sleep ≥1s so the next mint embeds a different `exp` (unix seconds
+	// granularity) — that's what makes tokenA "stale."
+	time.Sleep(1100 * time.Millisecond)
+
+	second, err := client.GetTask(c, taskID, client.TaskOptions{RequestState: tokenA})
+	if err != nil {
+		t.Fatalf("second GetTask (echoing tokenA): %v", err)
+	}
+	tokenB := second.RequestState
+	if tokenB == "" || tokenB == tokenA {
+		t.Fatalf("expected fresh token on second tasks/get; got %q (vs A=%q)", tokenB, tokenA)
+	}
+
+	// Now echo the older tokenA — it's stale (a newer token has been minted)
+	// but still within its TTL, so the server MUST accept it.
+	stale, err := client.GetTask(c, taskID, client.TaskOptions{RequestState: tokenA})
+	if err != nil {
+		t.Fatalf("stale-token GetTask: %v — server must tolerate stale-but-valid tokens (SEP-2663)", err)
+	}
+	if stale.TaskID != taskID {
+		t.Errorf("stale-token GetTask returned wrong taskId: got %q, want %q", stale.TaskID, taskID)
 	}
 }
 


### PR DESCRIPTION
## Summary

Three SEP-2663 spec requirements that lacked test coverage and one missing SEP-2243 header on every JSON-RPC response. The underlying implementation already complies with each — these tests + the Mcp-Method change lock in the existing behavior so a future refactor would catch a regression.

- **Fix 3 — `pollIntervalMilliseconds` rename assertion (v2-12).** Parallel to the existing `ttlSeconds` rename test: assert the renamed key is present and the legacy `pollInterval` is absent. Core wire-format already covered by `TestTaskInfoV2WireFields` + the rewritten `TestCreateTaskResultWireShape`.
- **Fix 4 — stale `requestState` tolerance (v2-28 + `TestV2_RequestState_StaleTolerance`).** SEP-2663: "Servers MUST tolerate receiving a stale or outdated value gracefully." Mint tokenA, mint tokenB, then echo tokenA again — server MUST accept. Our HMAC verifier only checks signature + expiry (never "is this the latest token"), so the test passes today and guards against a "track latest only" regression.
- **Fix 5 — strong-consistency / durable create (v2-27 + `TestV2_StrongConsistency_ImmediateGet`).** SEP-2663: servers MUST NOT return `CreateTaskResult` until `tasks/get` for the returned taskId would resolve. tools/call → CreateTaskResult → immediate tasks/get with no sleep — passes because the v2 middleware calls `store.Create` synchronously before building the response.
- **Fix 6 — `Mcp-Method` header (server + v2-24 / v2-24b / v2-24c + `TestV2_McpMethodHeaderOnTasksMethods`).** SEP-2243 requires both `Mcp-Name` AND `Mcp-Method`; the existing v2-24 only covered Mcp-Name. Server now stages `Mcp-Method: <req.Method>` on every JSON-RPC response in `dispatchWithOpts` (using the same staged-header plumbing the v2 task middleware already uses for Mcp-Name). v2-24 extended; v2-24b extended (Mcp-Method present on sync tools/call too); v2-24c new (Mcp-Method on tasks/get + tasks/cancel responses).
- **Fix 7 — README pointer.** `conformance/tasks-v2/README.md` gained a paragraph noting the suite tracks SEP normative text + mcpkit's end-to-end behavior, not the published TS declarations (which can lag — most recent example: the upstream conformance PR briefly used snake_case `result_type`, reverted to camelCase per Luca).
- **Fix 2 deferred.** Bumping the conformance harness from `protocolVersion: '2025-11-25'` to `'2026-06-30'` would require declaring server-side support for a not-yet-released spec version. Plan annotated; revisit when the version actually lands.

## Conformance plan mapping

Closes Fixes 3, 4, 5, 6, and the README pointer of Fix 7 from `docs/TASKS_CONFORMANCE_PLAN.md`. Fix 2 explicitly deferred. Combined with PRs 350 + 351 already merged, this drains the must-fix + should-fix buckets of the plan.

## Test plan

- [x] `go vet ./...`
- [x] `make test`
- [x] `make testconf-tasks-v2` — 30/30 (was 27/27; v2-24c, v2-27, v2-28 added)
- [x] `make testconf-mrtr` — 7/7 + 1 deferred skip
- [x] `TestV2_RequestState_StaleTolerance`, `TestV2_StrongConsistency_ImmediateGet`, `TestV2_McpMethodHeaderOnTasksMethods` all pass alongside the existing requestState / Mcp-Name suite