### PR TITLE
feat(events): spec alignment γ — auth gate + tuple subscription identity

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,240 @@
+# Plan: Events spec alignment γ — auth + tuple subscription identity
+
+**Issue:** mcpkit 349 (umbrella) | **Group:** γ (third of 7)
+**Branch:** `feat/events-gamma-auth-tuple` (from main, post-β-merge)
+**Depends on:** α (#353 merged dc0f8aa) and β (#355 merged 96b41d1)
+**Unblocks:** ζ (control envelopes use the derived id from γ; `X-MCP-Subscription-Id` header lives in ζ but γ provides the value)
+
+**Spec snapshot:** [`proposals/triggers-events-wg/spec-snapshots/design-sketch-2026-04-30.md`](https://github.com/panyam/mcpcontribs/blob/main/proposals/triggers-events-wg/spec-snapshots/design-sketch-2026-04-30.md). Citations below in the form `(§"Section" L<line>)`.
+
+## Summary
+
+Move webhook subscription identity onto the spec's `(principal, delivery.url, name, params)` tuple, drop the client-supplied `id`, derive a deterministic server-side `id` for receiver routing, gate webhook subscribe/unsubscribe on auth (with a demo-only escape hatch), and emit the routing handle as `X-MCP-Subscription-Id` on every delivery POST.
+
+This is the largest behavioral change in the alignment plan. Mitigations: hybrid auth (auto-detects real OAuth/Keycloak via env var, falls back to a demo principal otherwise), feature-gated rollout per commit, atomic commits each green at HEAD.
+
+## Spec deltas addressed
+
+| # | Delta | Spec citation |
+|---|---|---|
+| 1 | `events/subscribe` and `events/unsubscribe` MUST require an authenticated principal; reject unauth with `-32012 Unauthorized` | §"Subscription Identity" → "Authentication required" L361; error code table L110 |
+| 2 | Subscription key is `(principal, delivery.url, name, params)`, `params` compared by canonical-JSON equality, all four immutable for the sub's lifetime | §"Subscription Identity" → "Key composition" L363 |
+| 3 | No client-generated `id`. Server derives a deterministic SHA-256 over the canonical key serialization | §"Subscription Identity" → "Derived `id`" L367 |
+| 4 | The derived `id` is a routing handle, not a capability — knowing it does not authorize anything | §"Subscription Identity" → "Derived `id`" L367 + "Cross-tenant isolation" L378 |
+| 5 | `events/unsubscribe` resolves by tuple — `(name, params, delivery.url)` from the request, `principal` from auth context, derived `id` not accepted as input | §"Unsubscribing: events/unsubscribe" L509 |
+| 6 | `X-MCP-Subscription-Id` header on every webhook delivery POST | §"Webhook Event Delivery" L390 + §"Webhook Security" → "Signature scheme" L472 |
+
+## Hybrid auth design (the demo escape hatch)
+
+The spec mandates "MUST reject unauthenticated calls with `-32012`" (L361). Our discord/telegram demos run anonymous today (no `WithAuth(...)` on the server). Enforcing the spec strictly would require every demo to stand up an OAuth provider just to run `make demo`.
+
+**Solution: detect at runtime.** If real auth is wired, follow spec strictly. If not, fall back to a demo-only "anonymous principal" knob with explicit `Unsafe` naming and startup warning logs.
+
+```go
+// New field on events.Config
+type Config struct {
+    Sources                  []EventSource
+    Webhooks                 *WebhookRegistry
+    Server                   *server.Server
+    UnsafeAnonymousPrincipal string  // demo-only; empty = strict spec
+}
+```
+
+**Handler logic** (in `registerSubscribe` and `registerUnsubscribe`):
+
+```go
+principal := ""
+if claims := ctx.AuthClaims(); claims != nil {
+    principal = claims.Subject                 // path 1: real auth (spec-correct)
+} else if cfg.UnsafeAnonymousPrincipal != "" {
+    principal = cfg.UnsafeAnonymousPrincipal   // path 2: demo escape hatch
+} else {
+    return core.NewErrorResponse(id, ErrCodeUnauthorized, "Unauthorized")  // path 3: spec strict
+}
+```
+
+**Demo wiring** (`examples/events/discord/main.go`, telegram parallel):
+
+```go
+cfg := events.Config{Sources: ..., Webhooks: webhooks, Server: srv}
+if issuer := os.Getenv("OAUTH_ISSUER"); issuer != "" {
+    // KCL / any OIDC provider detected — wire real auth
+    srv.UseAuth(buildValidator(issuer))
+    log.Printf("[server] auth: real OIDC provider at %s — webhook subscribe requires authenticated principal", issuer)
+} else {
+    cfg.UnsafeAnonymousPrincipal = "demo-user"
+    log.Printf("[server] auth: demo mode — webhook subscribe accepts anonymous (DEVIATES from spec). Set OAUTH_ISSUER to enable real auth.")
+}
+events.Register(cfg)
+```
+
+**What this buys**:
+- `make demo` works out of the box (anonymous, demo principal stands in for `claims.Subject`)
+- `make kcl && OAUTH_ISSUER=http://localhost:8081/realms/demo make demo` runs against Keycloak with real auth, full spec behavior
+- Production deployments that wire `WithAuth(...)` and don't set `UnsafeAnonymousPrincipal` get spec-mandated `-32012` for anonymous subscribe attempts
+- Misconfigured deployments (no auth, no anonymous fallback) also get `-32012` — fail-loud is good
+
+**Deviation cost is contained**: only one named knob (`UnsafeAnonymousPrincipal`), `Unsafe` prefix, startup log warning, defaults to off. Tests can set it to keep working without standing up auth.
+
+## Commits
+
+5 atomic commits. Each builds and tests green at HEAD.
+
+### γ-1 — tuple identity helpers (no behavior change)
+
+Add `canonicalKey(principal, url, name, params) []byte` and `deriveSubscriptionID(canonicalKey) string` as pure-functional helpers in a new file `experimental/ext/events/identity.go`. Unit tests cover canonical-JSON equality of params, sort-stability, principal isolation, derivation determinism, and id collision-resistance for typical inputs.
+
+No callers yet — registry + handlers continue using `(url, id)` keys. Lets γ-2 reach for proven helpers.
+
+**Files**: `experimental/ext/events/identity.go` (NEW, ~60 LOC), `experimental/ext/events/identity_test.go` (NEW, ~80 LOC).
+
+**Spec cite for code comments**: `(§"Subscription Identity" → "Key composition" L363, "Derived `id`" L367)`
+
+### γ-2 — auth gate + tuple-keyed registry + UnsafeAnonymousPrincipal escape
+
+The behavioral change. Subscribe handler reads principal via the path-1/2/3 logic; registry rekeys on the tuple via canonicalKey from γ-1; deriveSubscriptionID becomes the routing id.
+
+**Files**:
+- `experimental/ext/events/events.go` — Subscribe handler reads principal, derives id from canonicalKey(principal, url, name, params), passes to Register. Drops the `id` request field. Same for Unsubscribe. Returns `-32012 Unauthorized` on path-3.
+- `experimental/ext/events/webhook.go` — `Register(canonicalKey []byte, derivedID, url, secret string)`. Internal `targets` map keyed on canonicalKey hex (or string-encoded bytes) instead of `(url, id)`. `Unregister(canonicalKey []byte)`.
+- `experimental/ext/events/errors.go` — Add `ErrCodeUnauthorized = -32012` (we left this out of α; γ needs it).
+- `experimental/ext/events/secret_validation_test.go` — Tests already use `srv.Dispatch` with the dispatcher in init state. Add `UnsafeAnonymousPrincipal: "test"` to the Register call in `buildSecretValidationStack` so existing tests keep working. Add NEW tests for the strict-spec path-3 rejection.
+
+**Tests** (red-before-green):
+- `TestSubscribe_RejectsAnonymousWhenStrict` — Register with no `UnsafeAnonymousPrincipal`, no auth wired → subscribe returns `-32012 Unauthorized`.
+- `TestSubscribe_AcceptsAnonymousWithEscape` — Register with `UnsafeAnonymousPrincipal: "demo"` → subscribe succeeds; the stored target's principal is "demo".
+- `TestSubscribe_AcceptsRealAuth` — Register with no escape, but supply claims via test plumbing → subscribe succeeds; stored target's principal is `claims.Subject`.
+- `TestSubscribe_TupleIsolation` — Two subscribes from different principals with same `(url, name, params)` → two distinct registry entries (cross-tenant isolation per L378).
+- `TestSubscribe_TupleIdempotence` — Two subscribes from same principal with same `(url, name, params)` → one registry entry; second call refreshes TTL.
+- `TestUnsubscribe_RejectsIDInput` (already exists in β; verify it still rejects).
+- `TestUnsubscribe_ByTuple` — Unsubscribe with `(name, params, delivery.url)` removes the registered subscription.
+
+**Spec cites for code comments**:
+- Auth gate: `(§"Subscription Identity" → "Authentication required" L361)`
+- Tuple key: `(§"Subscription Identity" → "Key composition" L363)`
+- Cross-tenant isolation property: `(§"Subscription Identity" → "Cross-tenant isolation" L378)`
+
+### γ-3 — drop client-supplied `id` from the wire; return server-derived only
+
+Subscribe request no longer accepts `id`. Subscribe response continues to return `id` (the server-derived value). Unsubscribe request stops accepting `id` — only the tuple form per γ-2.
+
+This is a wire-shape change separate from γ-2's auth+tuple logic so the diff stays narrow per delta.
+
+**Files**:
+- `experimental/ext/events/events.go` — Subscribe handler request struct loses the `ID string` field. Drops the line that uses it.
+- `experimental/ext/events/clients/go/subscription.go` — `SubscribeOptions.SubID` field deleted. `subscribe()` no longer sends `id` in the request body. `Subscription.ID()` returns the server-derived value (this was already true post-β; just remove the SDK-side `SubID` plumbing).
+- Python SDK — same shape change: `WebhookSubscription.__init__` loses `sub_id` kwarg.
+- Discord + telegram demos — drop the `SubID:` arg in their `eventsclient.Subscribe(...)` calls.
+
+**Tests**:
+- `TestSubscribe_RejectsClientSuppliedID` (NEW) — request with `id` field returns `-32602 InvalidParams: client-supplied id is not accepted; server derives id over (principal, name, params, url)`.
+- Update existing tests that pass `SubID` to drop the field.
+
+**Spec cites**:
+- `(§"Subscription Identity" → "Key composition" L363: "There is no client-generated id ... fully determined by what it listens for, where it delivers, and who asked")`
+
+### γ-4 — `X-MCP-Subscription-Id` header on every webhook delivery
+
+The header lives in delivery (a ζ-flavored concern), but γ produces the id value, so wiring the header here keeps the change atomic with the change that introduces the value. The webhook delivery code in `webhook.go::deliver` and the headers package both grow this.
+
+**Files**:
+- `experimental/ext/events/headers.go` — `signedDelivery` carries the subscription id; `applyHeaders` adds `X-MCP-Subscription-Id: <id>`.
+- `experimental/ext/events/webhook.go` — `deliver(target, eventID, body)` becomes `deliver(target, eventID, subID, body)`. `Deliver(event)` looks up the target's derived id (from γ-2's tuple keying) and threads it through.
+- `experimental/ext/events/clients/go/receiver.go` — already reads webhook headers via `r.Header.Get(...)`; no change needed for receiving the new header (consuming it lands in ζ along with `match`/`transform` per-sub routing). For γ, just emit the header.
+
+**Tests**:
+- `TestStandardWebhooks_EmitsSubscriptionIDHeader` (NEW) — make a delivery, assert `X-MCP-Subscription-Id` header is present and equals the subscription's derived id.
+- `TestStandardWebhooks_SubscriptionIDStableAcrossRetries` (NEW) — pair with the existing `TestStandardWebhooks_WebhookIDIsStableAcrossRetries`. The subscription id MUST also be stable across retries (same sub, same id).
+
+**Spec cites**:
+- `(§"Webhook Event Delivery" L390: "X-MCP-Subscription-Id is an MCP-specific header... carrying the subscription id so the receiver can select the correct secret before parsing the body")`
+- `(§"Webhook Security" → "Signature scheme" L472)`
+
+### γ-5 — demo wiring + WALKTHROUGH regen + docs
+
+Demos auto-detect: if `OAUTH_ISSUER` env var is set, wire real auth via `server.WithAuth(...)`. Otherwise set `events.Config.UnsafeAnonymousPrincipal: "demo-user"` and log a warning at server start.
+
+Discord walkthrough's webhook step + new spec-validation steps (added in β-4-followup-2) work in both modes. Add a brand-new walkthrough step demonstrating the cross-tenant isolation property (two subscribes with different principals → distinct subscriptions).
+
+**Files**:
+- `examples/events/discord/main.go` — env-var detection, `WithAuth(...)` wiring or `UnsafeAnonymousPrincipal` fallback. ~30 LOC of demo code.
+- `examples/events/telegram/main.go` — same pattern.
+- `examples/events/discord/walkthrough.go` — NEW step demonstrating tuple identity / cross-tenant isolation if running in real-auth mode; gracefully no-ops in anonymous demo mode with a one-line note.
+- `examples/events/discord/WALKTHROUGH.md` — regenerated via `make readme`.
+- `examples/events/discord/README.md` + `telegram/README.md` — document the env-var detection (`OAUTH_ISSUER` to enable real auth; otherwise demo mode).
+- `experimental/ext/events/README.md` — document the `UnsafeAnonymousPrincipal` option and its `Unsafe` prefix rationale.
+- `experimental/ext/events/DEPLOYMENT.md` — note that production deployments should never set `UnsafeAnonymousPrincipal`; auth misconfiguration is detectable via the startup log.
+
+**Tests**: end-to-end tests (`examples/events/discord/e2e_test.go`) need an init-time config decision. Tests can either:
+1. Default to `UnsafeAnonymousPrincipal: "test"` (matches existing test behavior pre-γ).
+2. Have a small subset that wires fake claims to exercise real-auth path-1.
+
+I lean (1) for the bulk + (2) for ~3 new tests covering the auth-strict + auth-success paths. Existing assertions stay valid.
+
+## Auth integration plumbing
+
+The investigation in [task #60] mapped the surface:
+
+| What | Where |
+|---|---|
+| Handler reads claims | `core.MethodContext.AuthClaims() *core.Claims` (`core/handler_context.go:183`) |
+| Claims struct | `core/auth.go:8-25` — `Claims{Subject, Issuer, Audience, Scopes, Extra}` |
+| Server wires auth | `server.WithAuth(validator)` (`examples/auth/main.go:302-332`) |
+| When no auth: `claims == nil` | `server/server.go:1016-1027` `CheckAuth` returns `(nil, nil)` |
+| Test plumbing for fake claims | `core.ContextWithSession(ctx, ..., &core.Claims{Subject: "test"})` (`ext/auth/scope_middleware_test.go:28-32`) |
+
+For real-auth demo path, `OAUTH_ISSUER` env var triggers `examples/auth/common/setup.go::NewValidator(issuer)` (or equivalent) — same code path the existing auth examples use.
+
+## Test impact summary
+
+| Bucket | Count | Notes |
+|---|---|---|
+| New red-before-green tests | ~10 | Auth gate (3), tuple identity (3), webhook header (2), client-id rejection (1), tuple-form unsubscribe (1) |
+| Existing tests updated | ~5 | secret_validation_test.go: add `UnsafeAnonymousPrincipal: "test"` to fixture. Demo e2e tests: same. |
+| Tests deleted | 0 | γ adds capability, doesn't remove any |
+| Strict-strengthening on assertions | ✅ | No weakened checks |
+
+## Acceptance criteria
+
+- `cd experimental/ext/events && go test -count=1 ./...` green
+- `cd examples/events/discord && go test -count=1 ./...` green (demo defaults work)
+- `cd examples/events/telegram && go test -count=1 ./...` green
+- `grep -rn "SubID\|sub_id" experimental/ext/events/` returns 0 matches outside test fixtures (`SubID` field deleted from Go SDK)
+- Manual: `make serve` (anonymous) + `make demo` works end-to-end including the webhook step (uses anonymous escape)
+- Manual (if Keycloak available): `make kcl && OAUTH_ISSUER=... make serve` + `make demo` works end-to-end with real auth
+- Wire bytes for an anonymous subscribe with no escape configured: `{"error":{"code":-32012,"message":"Unauthorized"}}`
+- Wire bytes for any successful webhook delivery contain `X-MCP-Subscription-Id: <derived id>` header
+
+## Out of scope for γ (explicitly)
+
+- **Push delivery (`events/stream`)** — ε. Push has its own per-stream identity via `requestId`; γ's tuple identity is webhook-only.
+- **Control envelopes (`type:gap`, `type:terminated`)** — ζ. They will use the `id` value γ produces but the envelope-emission code lives in ζ.
+- **`deliveryStatus` on refresh response** — ζ.
+- **`maxAge`** — δ.
+- **Asymmetric server signing (ed25519, JWKS)** — Open Question 6 in the spec; not in any planned PR group yet.
+
+## Risk
+
+**Medium**. Touches the webhook critical path:
+- registry rekey (γ-2) is the most invasive single change
+- new fail-loud rejection path (`-32012` for anon when no escape) — could surprise an existing deployment that relies on anonymous webhook subscribes
+- `OAUTH_ISSUER` auto-detect in demos changes behavior under env-var presence — needs to be visible in the startup log so reviewers know which mode is active
+
+**Mitigations**:
+- Each commit independently revertable
+- The `Unsafe` prefix on the escape hatch + startup warning log surface the deviation
+- Test coverage explicitly exercises path-1/2/3 transitions
+- Demo defaults stay green without OAUTH_ISSUER set (we don't break `make demo`)
+
+## Done when
+
+- All 5 commits land
+- PR opened linking #349
+- PR merged
+- #349 updated with γ merged ✅
+- Root `PLAN.md` retired (δ writes its own)
+- Manual verify: discord demo `make demo` works; if Keycloak is set up locally, the Keycloak flow works too
+
+## Spec citation in commits
+
+Every commit message body carries at least one spec citation in the form `(§"Section name" L<line>)` so the commit log itself is correlatable to the spec snapshot. Pattern was established in the umbrella plan citation pass (commit `844522a` on this branch).

--- a/docs/EVENTS_SPEC_ALIGNMENT_PLAN.md
+++ b/docs/EVENTS_SPEC_ALIGNMENT_PLAN.md
@@ -1,8 +1,10 @@
 # Events Spec Alignment — Phase 2 Plan
 
-**Status:** Drafted 2026-05-01. Not yet started. Replaces the spec-tracking work that landed in mcpkit#323 (phase 1).
+**Status:** Drafted 2026-05-01. α + β shipped as of 2026-05-02. Replaces the spec-tracking work that landed in mcpkit#323 (phase 1).
 **Scope:** `experimental/ext/events/` library, `experimental/ext/events/clients/go/` SDK, the discord + telegram demos under `examples/events/`.
-**Spec target:** the in-progress MCP Events extension spec sketch as of 2026-04-30. Substantial revisions landed in the spec in late April that broke from the direction phase 1 implemented; this plan re-aligns.
+**Spec target:** the MCP Events extension spec sketch cached at [`proposals/triggers-events-wg/spec-snapshots/design-sketch-2026-04-30.md`](https://github.com/panyam/mcpcontribs/blob/main/proposals/triggers-events-wg/spec-snapshots/design-sketch-2026-04-30.md) (in mcpcontribs, not this repo). Substantial revisions landed in the upstream sketch in late April that broke from the direction phase 1 implemented; this plan re-aligns.
+
+**Citation convention:** every delta in the per-PR sections below carries a citation in the form `(§"Section name" L<line>)` referencing the cached snapshot. Line numbers are stable against that snapshot file; if a future spec revision lands, we add a new dated snapshot rather than rewriting old citations. PR descriptions and commit messages following this plan should carry the same form so reviewers can correlate code → spec text directly.
 
 ## TL;DR
 
@@ -139,11 +141,12 @@ The others (resource-template subsumption, MCP task event subsumption, event-nam
 **Goal:** key webhook subscriptions on `(principal, delivery.url, name, params)` per the spec; reject unauthenticated webhook subscribe / unsubscribe.
 
 **Spec deltas addressed:**
-- `events/subscribe` and `events/unsubscribe` MUST require an authenticated principal (`-32012 Unauthorized` if missing)
-- Subscription key is `(principal, delivery.url, name, params)`. `params` compared by canonical-JSON equality. All four components are immutable for the subscription lifetime.
-- No client-generated `id`. Server derives a deterministic SHA-256 over the canonical key serialization.
-- The derived `id` is a routing handle, not a capability. Appears in `X-MCP-Subscription-Id` on every webhook delivery POST (header was added in ζ — see note).
-- `events/unsubscribe` accepts only `(name, params, delivery.url)` from the client; `principal` is taken from the auth context. Rejects an `id`-keyed unsubscribe.
+- `events/subscribe` and `events/unsubscribe` MUST require an authenticated principal (`-32012 Unauthorized` if missing) (§"Subscription Identity" → "Authentication required" L361, error code table L110)
+- Subscription key is `(principal, delivery.url, name, params)`. `params` compared by canonical-JSON equality. All four components are immutable for the subscription lifetime. (§"Subscription Identity" → "Key composition" L363)
+- No client-generated `id`. Server derives a deterministic SHA-256 over the canonical key serialization. (§"Subscription Identity" → "Derived `id`" L367)
+- The derived `id` is a routing handle, not a capability. Appears in `X-MCP-Subscription-Id` on every webhook delivery POST (header lives in §"Webhook Event Delivery" L390 — γ produces the value, ζ wires the header).
+- `events/unsubscribe` accepts only `(name, params, delivery.url)` from the client; `principal` is taken from the auth context. Rejects an `id`-keyed unsubscribe. (§"Unsubscribing: events/unsubscribe" L509)
+- Cross-tenant isolation property: two distinct tenants subscribing to the same `(name, params)` get distinct subscriptions; learning another tenant's derived `id` gains nothing. (§"Subscription Identity" → "Cross-tenant isolation" L378)
 
 **Cross-PR note:** `X-MCP-Subscription-Id` header emission technically belongs in ζ (it's a delivery-time concern), but γ produces the `id` value. ζ wires the header onto the outbound POST.
 
@@ -184,11 +187,11 @@ The others (resource-template subsumption, MCP task event subsumption, event-nam
 **Goal:** make `events/poll` and `events/subscribe` request bodies match the spec's flat shape; add `maxAge` floor; audit EventOccurrence fields.
 
 **Spec deltas addressed:**
-- `events/poll` request: drop `subscriptions[]` array (already single-entry-enforced after phase 1). Lift `name`, `params`, `cursor` to top level. Add optional `maxAge` (integer seconds), `maxEvents` (integer).
-- All three modes (poll, stream, subscribe) accept optional `maxAge`. Server begins replay from `max(cursor, now - maxAge)`.
-- `EventOccurrence` field set: `eventId` (string, required), `name` (string, required), `timestamp` (ISO 8601, required), `data` (object, required), `cursor` (string | null, optional), `_meta` (object, optional). Confirm we emit the required five with the right names; fix any drift.
-- `events/list` response: add optional `nextCursor` for pagination consistency with base MCP list endpoints (`tools/list`, `resources/list`). Today the events list is small enough that we'd always omit it; thread the field through and emit only when set.
-- `EventDescriptor` (per event-type definition in `events/list`): add optional `_meta` field, matching the metadata pattern on `Tool` / `Resource` / `Prompt`. Authors can attach arbitrary metadata; the SDK threads it through.
+- `events/poll` request: drop `subscriptions[]` array (already single-entry-enforced after phase 1). Lift `name`, `params`, `cursor` to top level. Add optional `maxAge` (integer seconds), `maxEvents` (integer). (§"Poll-Based Delivery" → "Request: events/poll" L139-149)
+- All three modes (poll, stream, subscribe) accept optional `maxAge`. Server begins replay from `max(cursor, now - maxAge)`. (§"Cursor Lifecycle" → "Bounding replay with maxAge" L529)
+- `EventOccurrence` field set: `eventId` (string, required), `name` (string, required), `timestamp` (ISO 8601, required), `data` (object, required), `cursor` (string | null, optional), `_meta` (object, optional). Confirm we emit the required five with the right names; fix any drift. (§"EventOccurrence schema" L180-186; `_meta` added in spec follow-on commit `d4faef9` 2026-05-01)
+- `events/list` response: add optional `nextCursor` for pagination consistency with base MCP list endpoints (`tools/list`, `resources/list`). Today the events list is small enough that we'd always omit it; thread the field through and emit only when set. (Spec follow-on commit `d4faef9` 2026-05-01 — pre-cached snapshot doesn't show this section yet; future snapshot will.)
+- `EventDescriptor` (per event-type definition in `events/list`): add optional `_meta` field, matching the metadata pattern on `Tool` / `Resource` / `Prompt`. Authors can attach arbitrary metadata; the SDK threads it through. (Spec follow-on commit `d4faef9` 2026-05-01)
 
 The `nextCursor` and the two `_meta` fields are spec follow-ons added on 2026-05-01 (after the in-tree plan's first draft). Folded into δ rather than spinning a micro-PR because δ is already the "wire-shape audit" PR — these three are the same kind of work.
 
@@ -222,16 +225,16 @@ The `nextCursor` and the two `_meta` fields are spec follow-ons added on 2026-05
 **Goal:** real per-subscription push delivery, replacing today's broadcast-to-all-SSE-listeners model.
 
 **Spec deltas addressed:**
-- `events/stream` is a long-lived JSON-RPC request (one per subscription). Streamable HTTP: POST returns SSE response. stdio: notifications on stdout demuxed via `requestId`.
-- Server emits five new notifications, all carrying `requestId` (the JSON-RPC `id` of the parent stream):
-  - `notifications/events/active {requestId, cursor, truncated}` — confirmation, sent on subscribe and again on mid-stream gap recovery
-  - `notifications/events/event {requestId, eventId, name, timestamp, data, cursor}` — payload
-  - `notifications/events/heartbeat {requestId, cursor}` — keepalive ≥30s; carries cursor so client's persisted cursor advances during quiet periods. SSE `data:` frame, NOT comment form
-  - `notifications/events/error {requestId, error}` — transient per-event upstream failure; stream stays open
-  - `notifications/events/terminated {requestId, error}` — subscription has ended (auth revoked, etc.); SDK removes the subscription
-- `StreamEventsResult {_meta: {}}` — empty typed final frame, sent only when server initiates the close
-- Client cancellation: HTTP abort or `notifications/cancelled` (stdio)
-- `events/stream` requests are exempt from any general request-concurrency cap
+- `events/stream` is a long-lived JSON-RPC request (one per subscription). Streamable HTTP: POST returns SSE response. stdio: notifications on stdout demuxed via `requestId`. (§"Push-Based Delivery" L199-206 + "Request: events/stream" L225-241)
+- Server emits five new notifications, all carrying `requestId` (the JSON-RPC `id` of the parent stream): (§"Push-Based Delivery" → "Event Delivery" L243-271)
+  - `notifications/events/active {requestId, cursor, truncated}` — confirmation, sent on subscribe and again on mid-stream gap recovery (L249)
+  - `notifications/events/event {requestId, eventId, name, timestamp, data, cursor}` — payload (L252)
+  - `notifications/events/heartbeat {requestId, cursor}` — keepalive ≥30s; carries cursor so client's persisted cursor advances during quiet periods. SSE `data:` frame, NOT comment form. (§"Push-Based Delivery" → "Lifecycle" → "Heartbeat" L270)
+  - `notifications/events/error {requestId, error}` — transient per-event upstream failure; stream stays open (L255 + L261)
+  - `notifications/events/terminated {requestId, error}` — subscription has ended (auth revoked, etc.); SDK removes the subscription (§"Authorization" L783-795)
+- `StreamEventsResult {_meta: {}}` — empty typed final frame, sent only when server initiates the close (§"Push-Based Delivery" → "Lifecycle" → "Stream termination" L269)
+- Client cancellation: HTTP abort or `notifications/cancelled` (stdio) (§"Push-Based Delivery" → "Lifecycle" → "Cancellation" L271)
+- `events/stream` requests are exempt from any general request-concurrency cap (§"Push-Based Delivery" → "Lifecycle" → "Concurrent streams" L272)
 
 **This is the largest single PR. Worth a focused design doc commit before code.** Suggested approach: open a feature branch, write `PLAN.md` at root with the wire-level design (notification routing, heartbeat goroutine lifecycle, demux on stdio), then implement.
 
@@ -274,13 +277,13 @@ The TS reference's heartbeat doesn't carry a cursor today; the spec now requires
 **Goal:** close the spec-mandated security and reliability gaps in our webhook delivery path.
 
 **Spec deltas addressed:**
-- **SSRF revalidation at delivery time** (sketch line 464): hostname-based subscribe-time check is insufficient under DNS rebinding. Resolve hostname, check resolved IP against the blocklist, connect directly to that IP (sending the original hostname in `Host` header / TLS SNI).
-- **No HTTP redirects on webhook deliveries** — explicitly disable via `http.Client.CheckRedirect: ErrUseLastResponse`. Redirects can target an internal address that bypasses the blocklist.
-- **Body size cap**: SHOULD ≤ 256 KiB; servers MUST treat 413 from the receiver as non-retryable.
-- **Control envelopes** (sketch line 419-423): server POSTs signed `{type:gap, cursor:<fresh>}` when a gap is detected between refreshes; signed `{type:terminated, error:{...}}` when the subscription ends. Both use Standard Webhooks headers + `X-MCP-Subscription-Id`. `webhook-id` is `msg_<type>_<random>` (vs `eventId` for event deliveries — set up in α).
-- **`X-MCP-Subscription-Id` header** on every webhook delivery POST (the routing handle from γ; surfaced in the body-less header so receivers pick the right secret without parsing).
-- **`deliveryStatus`** on `events/subscribe` refresh response: `{active, lastDeliveryAt, lastError, failedSince?}`. `lastError` is a categorical string from a fixed set: `connection_refused | timeout | tls_error | http_4xx | http_5xx | challenge_failed`. **Never** raw response bodies / headers / status lines (avoids becoming a response oracle for attacker-chosen URLs).
-- **Suspend / reactivate state machine**: after repeated failures the server SHOULD set `active: false`; a successful refresh reactivates it (`active: true`) and resumes retrying pending events.
+- **SSRF revalidation at delivery time**: hostname-based subscribe-time check is insufficient under DNS rebinding. Resolve hostname, check resolved IP against the blocklist, connect directly to that IP (sending the original hostname in `Host` header / TLS SNI). (§"Webhook Security" → "SSRF prevention" L464)
+- **No HTTP redirects on webhook deliveries** — explicitly disable via `http.Client.CheckRedirect: ErrUseLastResponse`. Redirects can target an internal address that bypasses the blocklist. (§"Webhook Security" → "SSRF prevention" L464 — same paragraph)
+- **Body size cap**: SHOULD ≤ 256 KiB; servers MUST treat 413 from the receiver as non-retryable. (§"Webhook Security" → "Delivery profile (for WAF / private-cloud deployments)" L487)
+- **Control envelopes**: server POSTs signed `{type:gap, cursor:<fresh>}` when a gap is detected between refreshes; signed `{type:terminated, error:{...}}` when the subscription ends. Both use Standard Webhooks headers + `X-MCP-Subscription-Id`. `webhook-id` is `msg_<type>_<random>` (vs `eventId` for event deliveries — set up in α). (§"Non-event webhook bodies" L415-423)
+- **`X-MCP-Subscription-Id` header** on every webhook delivery POST (the routing handle from γ; surfaced in the body-less header so receivers pick the right secret without parsing). (§"Webhook Event Delivery" L390 + §"Webhook Security" → "Signature scheme" L472)
+- **`deliveryStatus`** on `events/subscribe` refresh response: `{active, lastDeliveryAt, lastError, failedSince?}`. `lastError` is a categorical string from a fixed set: `connection_refused | timeout | tls_error | http_4xx | http_5xx | challenge_failed`. **Never** raw response bodies / headers / status lines (avoids becoming a response oracle for attacker-chosen URLs). (§"Webhook Delivery Status" L425-460)
+- **Suspend / reactivate state machine**: after repeated failures the server SHOULD set `active: false`; a successful refresh reactivates it (`active: true`) and resumes retrying pending events. (§"Webhook Event Delivery" L413 + §"Webhook Delivery Status" L460)
 
 **Files touched:**
 - `experimental/ext/events/webhook.go` — new `deliveryStatus` field on `WebhookTarget`. State machine transitions documented inline. Outbound `http.Client` configured with `CheckRedirect`. SSRF check moves to a `dialContext` hook so it runs on every connect, not just at subscribe.
@@ -314,7 +317,7 @@ The TS reference's heartbeat doesn't carry a cursor today; the spec now requires
 
 **Goal:** add the per-subscription `match`/`transform` async hooks, `on_subscribe`/`on_unsubscribe` lifecycle hooks, and poll-lease tracking.
 
-**Why deferred:** the design needs more thought than the others. The spec's hook surface (sketch lines 599-635, 667-691) is described in Python-flavored prose; mapping it to Go's type system + concurrency model is its own design exercise. Worth doing *after* ε proves out the per-subscription event flow, since these hooks gate per-subscription delivery decisions.
+**Why deferred:** the design needs more thought than the others. The spec's hook surface — `match`/`transform` per-subscription (§"Server SDK Guidance" L599-635) and `on_subscribe`/`on_unsubscribe` lifecycle (§"Server SDK Guidance" → "Subscription lifecycle hooks" L667-691) — is described in Python-flavored prose; mapping it to Go's type system + concurrency model is its own design exercise. Worth doing *after* ε proves out the per-subscription event flow, since these hooks gate per-subscription delivery decisions.
 
 **When to revisit:** after ε merges and the discord/telegram demos run on real `events/stream`. By that point we'll have load-bearing per-subscription state to hang the hooks off, instead of bolting them onto the broadcast path.
 

--- a/docs/EVENTS_SPEC_ALIGNMENT_PLAN.md
+++ b/docs/EVENTS_SPEC_ALIGNMENT_PLAN.md
@@ -159,9 +159,11 @@ The others (resource-template subsumption, MCP task event subsumption, event-nam
 - New file: `experimental/ext/events/identity.go` — pure-functional helpers `canonicalKey`, `deriveSubscriptionID`. Easy to unit-test.
 
 **Auth integration:**
-- mcpkit has an `ext/auth` package with `AuthContext` extraction. The events handler gets the principal via `auth.PrincipalFrom(ctx)` (or equivalent — verify exact API at impl time).
+- The events handler reads the principal via `core.MethodContext.AuthClaims()` returning `*core.Claims` (mcpkit core, not `ext/auth`). `claims.Subject` is the principal in the canonical tuple.
 - For unauthenticated mcpkit servers: webhook subscribe MUST return `-32012`. Poll and push are unaffected (they don't require auth per the spec).
-- For the discord + telegram demos: today they're anonymous. After γ, the webhook step in their walkthrough will fail unless we either (a) add a minimal auth shim to the demo server or (b) skip the webhook step in anonymous mode with an explanatory note. **Decision deferred to PR start time** — likely (b) for the demo, with a note pointing at how to enable auth.
+- For the discord + telegram demos: hybrid auto-detect via `OAUTH_ISSUER` env var. When set, wire `server.WithAuth(JWTValidator)` and follow spec strictly. When not set, fall back to `events.Config.UnsafeAnonymousPrincipal: "demo-user"` so `make demo` runs end-to-end without an OIDC provider. Server logs which posture is active at startup.
+
+**Composition note (WG-relevant):** `ext/events` has zero compile-time dependency on `ext/auth`. It depends on `core.Claims` (the abstract auth contract). Any auth provider that populates `core.Claims` works — JWT/OIDC via `ext/auth`, mTLS-derived principals, session cookies, custom validators. Auth and Events are independent extensions composed at the wiring layer (`server.WithAuth(...)` in `main.go`), not at the protocol-implementation layer. This is the right shape for MCP extensions: extensions depend on stable core abstractions, not on each other.
 
 **Acceptance:**
 - `make test-experimental` green

--- a/examples/events/discord/README.md
+++ b/examples/events/discord/README.md
@@ -114,6 +114,36 @@ go run . --serve -webhook-ttl 5s
 
 Per spec, the webhook signing secret is **client-supplied only** (`whsec_` + base64 of 24-64 random bytes). The python `make webhook` and the Go SDK both auto-generate when the application doesn't supply one. See [`experimental/ext/events/README.md`](../../../experimental/ext/events/README.md) for the full configuration reference.
 
+## Auth posture (γ): demo escape vs real OIDC
+
+Per spec §"Subscription Identity" L361 webhook subscribe MUST require an authenticated principal. The demo auto-detects which posture to run in based on environment variables:
+
+```bash
+# Demo posture (default): no env vars set.
+# Server runs anonymous; events.Config.UnsafeAnonymousPrincipal="demo-user"
+# is the escape hatch so make demo works end-to-end without an OIDC provider.
+# Server logs:  [server] auth: demo (anonymous → UnsafeAnonymousPrincipal)
+make serve
+
+# Real-OIDC posture: set OAUTH_ISSUER (and optionally OAUTH_AUDIENCE / OAUTH_JWKS_URL).
+# Server wires server.WithAuth(JWTValidator) and follows the spec strictly —
+# anonymous webhook subscribes are rejected with -32012 Unauthorized.
+# Server logs:  [server] auth: real OIDC (...) — anonymous webhook subscribes rejected per spec
+OAUTH_ISSUER=http://localhost:8081/realms/demo \
+OAUTH_AUDIENCE=mcp-events \
+make serve
+```
+
+Recognized env vars:
+
+| Env var | Default | Notes |
+|---|---|---|
+| `OAUTH_ISSUER` | (unset → demo posture) | OIDC issuer URL. For Keycloak: `http://localhost:8081/realms/<realm>`. Setting this enables real auth. |
+| `OAUTH_JWKS_URL` | `<issuer>/protocol/openid-connect/certs` | Override for non-Keycloak providers. |
+| `OAUTH_AUDIENCE` | `mcp-events` | Tokens MUST have this audience claim. |
+
+The events package itself depends only on `core.Claims` (the abstract auth contract), not on any specific auth implementation — see [`experimental/ext/events/README.md`](../../../experimental/ext/events/README.md) "Auth + extension composition" for the design rationale.
+
 ## Make targets
 
 | Target | Description |

--- a/examples/events/discord/WALKTHROUGH.md
+++ b/examples/events/discord/WALKTHROUGH.md
@@ -12,7 +12,8 @@ Walks through the four delivery modes of the experimental MCP Events extension (
 - **Webhook: subscribe via the typed Go SDK, observe HMAC delivery + auto-refresh** — clients/go provides Subscription (subscribe + auto-refresh) plus Receiver[Data] (typed inbound channel). Per spec, the HMAC signing secret is client-supplied — the SDK auto-generates a whsec_ value via events.GenerateSecret() when SubscribeOptions.Secret is empty, and exposes it via Subscription.Secret() so the receiver can verify with the same value. Receiver[DiscordEventData] verifies signatures and decodes the wire envelope into the typed Data shape, so the consumer reads `ev.Data.Content` rather than re-parsing JSON.
 - **Spec validation: empty delivery.secret is rejected** — Per spec, delivery.secret is REQUIRED on every events/subscribe — there is no server-side fallback. The server rejects at subscribe time so a subscription never exists that produces unverifiable deliveries. The Go SDK auto-generates a conforming whsec_ value via events.GenerateSecret() when SubscribeOptions.Secret is empty; this step makes a raw client.Call to bypass that and demonstrate the validator.
 - **Spec validation: malformed delivery.secret is rejected** — The validator enforces the full Standard Webhooks format: whsec_ followed by base64 of 24-64 random bytes. A non-prefixed value, a too-short value, or non-base64 garbage all fail with -32602 InvalidParams. This is what catches IaC-pinned secrets that don't match the spec format before they create a broken subscription.
-- **Spec validation: valid whsec_ accepted; response does NOT echo secret** — Counter-test for the validator: a freshly-generated whsec_ value is accepted. Note the response carries id + cursor + refreshBefore but no secret — the spec dropped it because the client supplied it (server doesn't need to echo) and echoing risks leaks via proxies, logs, or IDE network panes. The receiver verifies signatures with the value the client already knows.
+- **Spec validation: client-supplied id is rejected** — Per spec §"Subscription Identity" → "Key composition" L363: "There is no client-generated id — a subscription is fully determined by what it listens for, where it delivers, and who asked." The server derives the id from (principal, name, params, url) and returns it; old SDKs sending an id field get a loud -32602 instead of a silent mis-keying.
+- **Spec validation: valid whsec_ accepted; response carries server-derived id, no secret** — Counter-test: a freshly-generated whsec_ value is accepted. The response carries the server-derived id (sub_<base64>) per spec §"Subscription Identity" → "Derived id" L367 — non-load-bearing for security, surfaced as X-MCP-Subscription-Id on delivery POSTs (γ-4 wires the header). The response does NOT echo the secret because the client already supplied it; echoing would risk leaks via proxies / logs / IDE network panes.
 - **Live Discord interaction (typing + message from a real Discord channel)** — Requires the server to be running with -token + the bot invited to a channel you can post in. The TypingStart handler in main.go yields a cursorless discord.typing event; MessageCreate yields the cursored discord.message. Discord's typing indicator fires once when you start (then refires every ~8s if you keep typing), not per keystroke. In --non-interactive mode this step skips the wait so CI runs aren't slowed.
 
 ## Flow
@@ -59,12 +60,16 @@ sequenceDiagram
     Host->>Server: events/subscribe { delivery: { secret: 'wrong' } }
     Server-->>Host: -32602 InvalidParams: delivery.secret invalid: must start with the whsec_ prefix
 
-    Note over Host,Receiver: Step 9: Spec validation: valid whsec_ accepted; response does NOT echo secret
+    Note over Host,Receiver: Step 9: Spec validation: client-supplied id is rejected
+    Host->>Server: events/subscribe { id: 'mine', ... }
+    Server-->>Host: -32602 InvalidParams: client-supplied id is not accepted
+
+    Note over Host,Receiver: Step 10: Spec validation: valid whsec_ accepted; response carries server-derived id, no secret
     Host->>Host: events.GenerateSecret() → whsec_<base64 of 32 bytes>
     Host->>Server: events/subscribe { delivery: { secret: whsec_<valid> } }
-    Server-->>Host: { id, cursor, refreshBefore }   (NO secret field per spec)
+    Server-->>Host: { id: sub_<base64-of-16-bytes>, cursor, refreshBefore }   (no secret per spec)
 
-    Note over Host,Receiver: Step 10: Live Discord interaction (typing + message from a real Discord channel)
+    Note over Host,Receiver: Step 11: Live Discord interaction (typing + message from a real Discord channel)
     Discord->>Server: TypingStart event (when you start typing in the channel)
     Server-->>Host: notifications/events/event { name: discord.typing, cursor: null }
     Discord->>Server: MessageCreate event (when you press enter)
@@ -136,11 +141,15 @@ Per spec, delivery.secret is REQUIRED on every events/subscribe — there is no 
 
 The validator enforces the full Standard Webhooks format: whsec_ followed by base64 of 24-64 random bytes. A non-prefixed value, a too-short value, or non-base64 garbage all fail with -32602 InvalidParams. This is what catches IaC-pinned secrets that don't match the spec format before they create a broken subscription.
 
-### Step 9: Spec validation: valid whsec_ accepted; response does NOT echo secret
+### Step 9: Spec validation: client-supplied id is rejected
 
-Counter-test for the validator: a freshly-generated whsec_ value is accepted. Note the response carries id + cursor + refreshBefore but no secret — the spec dropped it because the client supplied it (server doesn't need to echo) and echoing risks leaks via proxies, logs, or IDE network panes. The receiver verifies signatures with the value the client already knows.
+Per spec §"Subscription Identity" → "Key composition" L363: "There is no client-generated id — a subscription is fully determined by what it listens for, where it delivers, and who asked." The server derives the id from (principal, name, params, url) and returns it; old SDKs sending an id field get a loud -32602 instead of a silent mis-keying.
 
-### Step 10: Live Discord interaction (typing + message from a real Discord channel)
+### Step 10: Spec validation: valid whsec_ accepted; response carries server-derived id, no secret
+
+Counter-test: a freshly-generated whsec_ value is accepted. The response carries the server-derived id (sub_<base64>) per spec §"Subscription Identity" → "Derived id" L367 — non-load-bearing for security, surfaced as X-MCP-Subscription-Id on delivery POSTs (γ-4 wires the header). The response does NOT echo the secret because the client already supplied it; echoing would risk leaks via proxies / logs / IDE network panes.
+
+### Step 11: Live Discord interaction (typing + message from a real Discord channel)
 
 Requires the server to be running with -token + the bot invited to a channel you can post in. The TypingStart handler in main.go yields a cursorless discord.typing event; MessageCreate yields the cursored discord.message. Discord's typing indicator fires once when you start (then refires every ~8s if you keep typing), not per keystroke. In --non-interactive mode this step skips the wait so CI runs aren't slowed.
 

--- a/examples/events/discord/e2e_test.go
+++ b/examples/events/discord/e2e_test.go
@@ -37,9 +37,10 @@ func buildTestStack(whOpts ...events.WebhookOption) (*server.Server, *events.Yie
 	registerResources(srv, source)
 	registerTools(srv, nil) // nil session = test mode
 	events.Register(events.Config{
-		Sources:  []events.EventSource{source, typingSource},
-		Webhooks: webhooks,
-		Server:   srv,
+		Sources:                  []events.EventSource{source, typingSource},
+		Webhooks:                 webhooks,
+		Server:                   srv,
+		UnsafeAnonymousPrincipal: "test-principal", // tests don't wire auth; γ-2 spec gate would reject otherwise
 	})
 
 	return srv, source, yield, webhooks
@@ -59,9 +60,10 @@ func buildTestStackWithTyping(whOpts ...events.WebhookOption) (*server.Server, f
 	registerResources(srv, source)
 	registerTools(srv, nil)
 	events.Register(events.Config{
-		Sources:  []events.EventSource{source, typingSource},
-		Webhooks: webhooks,
-		Server:   srv,
+		Sources:                  []events.EventSource{source, typingSource},
+		Webhooks:                 webhooks,
+		Server:                   srv,
+		UnsafeAnonymousPrincipal: "test-principal",
 	})
 	return srv, yield, yieldTyping, webhooks
 }

--- a/examples/events/discord/e2e_test.go
+++ b/examples/events/discord/e2e_test.go
@@ -186,7 +186,6 @@ func TestE2EWebhookDelivery(t *testing.T) {
 
 	clientSecret := events.GenerateSecret()
 	subResult, err := c.Call("events/subscribe", map[string]any{
-		"id":       "wh",
 		"name":     "discord.message",
 		"delivery": map[string]any{"mode": "webhook", "url": callbackSrv.URL, "secret": clientSecret},
 	})
@@ -312,7 +311,6 @@ func TestE2EWebhookDelivery_StandardHeaders(t *testing.T) {
 	c, _ := connectClient(t, srv)
 	clientSecret := events.GenerateSecret()
 	_, err := c.Call("events/subscribe", map[string]any{
-		"id":       "wh-std",
 		"name":     "discord.message",
 		"delivery": map[string]any{"mode": "webhook", "url": callbackSrv.URL, "secret": clientSecret},
 	})
@@ -366,7 +364,6 @@ func TestE2EWebhookDelivery_MCPHeadersOptIn(t *testing.T) {
 	c, _ := connectClient(t, srv)
 	clientSecret := events.GenerateSecret()
 	_, err := c.Call("events/subscribe", map[string]any{
-		"id":       "wh-mcp",
 		"name":     "discord.message",
 		"delivery": map[string]any{"mode": "webhook", "url": callbackSrv.URL, "secret": clientSecret},
 	})
@@ -453,7 +450,6 @@ func TestE2ECursorlessWebhookDelivery(t *testing.T) {
 
 	clientSecret := events.GenerateSecret()
 	raw, err := c.Call("events/subscribe", map[string]any{
-		"id":       "wh-typing",
 		"name":     "discord.typing",
 		"delivery": map[string]any{"mode": "webhook", "url": callbackSrv.URL, "secret": clientSecret},
 	})
@@ -517,7 +513,6 @@ func TestE2ESubscribeCursorNullOnCursoredSourceReturnsLatest(t *testing.T) {
 	require.NotEmpty(t, expected, "precondition: source has a head cursor")
 
 	raw, err := c.Call("events/subscribe", map[string]any{
-		"id":       "wh-fromnow",
 		"name":     "discord.message",
 		"delivery": map[string]any{"mode": "webhook", "url": "http://localhost:1/sink", "secret": events.GenerateSecret()},
 		// cursor field intentionally omitted → JSON null on parse

--- a/examples/events/discord/go.mod
+++ b/examples/events/discord/go.mod
@@ -6,6 +6,7 @@ replace (
 	github.com/panyam/mcpkit => ../../..
 	github.com/panyam/mcpkit/experimental/ext/events => ../../../experimental/ext/events
 	github.com/panyam/mcpkit/experimental/ext/events/clients/go => ../../../experimental/ext/events/clients/go
+	github.com/panyam/mcpkit/ext/auth => ../../../ext/auth
 )
 
 require (
@@ -14,6 +15,7 @@ require (
 	github.com/panyam/mcpkit v0.2.40
 	github.com/panyam/mcpkit/experimental/ext/events v0.0.0
 	github.com/panyam/mcpkit/experimental/ext/events/clients/go v0.0.0-00010101000000-000000000000
+	github.com/panyam/mcpkit/ext/auth v0.2.42
 	github.com/panyam/servicekit v0.0.25
 	github.com/stretchr/testify v1.11.1
 )
@@ -31,6 +33,8 @@ require (
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/fernet/fernet-go v0.0.0-20240119011108-303da6aec611 // indirect
+	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/invopop/jsonschema v0.13.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.4.0 // indirect
@@ -39,6 +43,7 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/panyam/gocurrent v0.1.0 // indirect
 	github.com/panyam/goutils v0.1.8 // indirect
+	github.com/panyam/oneauth v0.0.79 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
@@ -46,7 +51,8 @@ require (
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	github.com/yuin/goldmark v1.8.2 // indirect
-	golang.org/x/crypto v0.22.0 // indirect
+	golang.org/x/crypto v0.46.0 // indirect
+	golang.org/x/oauth2 v0.34.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.33.0 // indirect

--- a/examples/events/discord/go.sum
+++ b/examples/events/discord/go.sum
@@ -26,6 +26,10 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/fernet/fernet-go v0.0.0-20240119011108-303da6aec611 h1:JwYtKJ/DVEoIA5dH45OEU7uoryZY/gjd/BQiwwAOImM=
+github.com/fernet/fernet-go v0.0.0-20240119011108-303da6aec611/go.mod h1:zHMNeYgqrTpKyjawjitDg0Osd1P/FmeA0SZLYK3RfLQ=
+github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
+github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
@@ -56,6 +60,8 @@ github.com/panyam/gocurrent v0.1.0 h1:AW8ctsSQHtoj8QXN55e9n+TYxtq+noF/ikPsRLiihi
 github.com/panyam/gocurrent v0.1.0/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.8 h1:5UscYTP892k54+Nyb01tKGGwZxczZ5k7BC+c0nXmcoc=
 github.com/panyam/goutils v0.1.8/go.mod h1:ntucs8GJOHQ0LmlRGRjeup3aDC2t7xPMudrRwUHrJNM=
+github.com/panyam/oneauth v0.0.79 h1:oDFdjsNqzv6OZSh4F1qm8REhRSGZLsCpTQRj1GznQVA=
+github.com/panyam/oneauth v0.0.79/go.mod h1:07eoijxxnj1mCxIIDo71FNGVyl4ru1Aw+G9x7qoSnnk=
 github.com/panyam/servicekit v0.0.25 h1:JeTRyz5ZZY3beENg0N3tLW+O39/foTuHMPAf+rpwYhM=
 github.com/panyam/servicekit v0.0.25/go.mod h1:9TkF2LRqiPC9bgu0bYVdky7rnHEuBvzGzrsoL++Ra5c=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -77,13 +83,15 @@ github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT0
 github.com/yuin/goldmark v1.8.2 h1:kEGpgqJXdgbkhcOgBxkC0X0PmoPG1ZyoZ117rDVp4zE=
 github.com/yuin/goldmark v1.8.2/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
-golang.org/x/crypto v0.22.0 h1:g1v0xeRhjcugydODzvb3mEM9SQ0HGp9s/nh3COQ/C30=
-golang.org/x/crypto v0.22.0/go.mod h1:vr6Su+7cTlO45qkww3VDJlzDn0ctJvRgYbC2NvXHt+M=
+golang.org/x/crypto v0.46.0 h1:cKRW/pmt1pKAfetfu+RCEvjvZkA9RimPbh7bhFjGVBU=
+golang.org/x/crypto v0.46.0/go.mod h1:Evb/oLKmMraqjZ2iQTwDwvCtJkczlDuTmdJXoZVzqU0=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.49.0 h1:eeHFmOGUTtaaPSGNmjBKpbng9MulQsJURQUAfUwY++o=
 golang.org/x/net v0.49.0/go.mod h1:/ysNB2EvaqvesRkuLAyjI1ycPZlQHM3q01F02UY/MV8=
+golang.org/x/oauth2 v0.34.0 h1:hqK/t4AKgbqWkdkcAeI8XLmbK+4m4G5YeQRrmiotGlw=
+golang.org/x/oauth2 v0.34.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
 golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
 golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/examples/events/discord/main.go
+++ b/examples/events/discord/main.go
@@ -129,6 +129,14 @@ func serve() {
 		Sources:  []events.EventSource{source, typingSource},
 		Webhooks: webhooks,
 		Server:   srv,
+		// γ-2 spec gate (§"Subscription Identity" L361) requires an
+		// authenticated principal for webhook subscribe. Demo runs
+		// anonymously by default — use the escape hatch with a fixed
+		// principal so make demo continues to work end-to-end.
+		// γ-5 will replace this with auto-detection: if OAUTH_ISSUER
+		// is set, wire real auth via server.WithAuth(...) and drop
+		// the UnsafeAnonymousPrincipal fallback.
+		UnsafeAnonymousPrincipal: "demo-user",
 	})
 
 	mux := http.NewServeMux()

--- a/examples/events/discord/main.go
+++ b/examples/events/discord/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/bwmarrin/discordgo"
 	"github.com/panyam/mcpkit/core"
 	"github.com/panyam/mcpkit/experimental/ext/events"
+	"github.com/panyam/mcpkit/ext/auth"
 	"github.com/panyam/mcpkit/server"
 	gohttp "github.com/panyam/servicekit/http"
 )
@@ -115,29 +116,45 @@ func serve() {
 		log.Println("[discord] no token provided — running in test mode")
 	}
 
-	srv := server.NewServer(
-		core.ServerInfo{Name: "discord-events", Version: "0.1.0"},
+	// γ-5: auto-detect auth posture.
+	//
+	// If OAUTH_ISSUER is set, wire real OIDC auth via server.WithAuth(...)
+	// and follow the spec strictly — anonymous webhook subscribes are
+	// rejected with -32012 per §"Subscription Identity" → "Authentication
+	// required" L361. Otherwise fall back to the demo escape hatch so
+	// `make demo` works end-to-end without an auth provider.
+	srvOpts := []server.Option{
 		server.WithSubscriptions(),
 		server.WithMiddleware(server.LoggingMiddleware(log.Default())),
 		server.WithRequestLogging(log.Default()),
+	}
+	authPosture := "demo (anonymous → UnsafeAnonymousPrincipal)"
+	if validator := tryEnableAuth(); validator != nil {
+		srvOpts = append(srvOpts, server.WithAuth(validator))
+		authPosture = "real OIDC (" + os.Getenv("OAUTH_ISSUER") + ") — anonymous webhook subscribes rejected per spec"
+	}
+
+	srv := server.NewServer(
+		core.ServerInfo{Name: "discord-events", Version: "0.1.0"},
+		srvOpts...,
 	)
+	log.Printf("[server] auth: %s", authPosture)
 
 	registerResources(srv, source)
 	registerTools(srv, dg)
 
-	events.Register(events.Config{
+	cfg := events.Config{
 		Sources:  []events.EventSource{source, typingSource},
 		Webhooks: webhooks,
 		Server:   srv,
-		// γ-2 spec gate (§"Subscription Identity" L361) requires an
-		// authenticated principal for webhook subscribe. Demo runs
-		// anonymously by default — use the escape hatch with a fixed
-		// principal so make demo continues to work end-to-end.
-		// γ-5 will replace this with auto-detection: if OAUTH_ISSUER
-		// is set, wire real auth via server.WithAuth(...) and drop
-		// the UnsafeAnonymousPrincipal fallback.
-		UnsafeAnonymousPrincipal: "demo-user",
-	})
+	}
+	// Demo escape hatch — only when no real auth is wired. Production
+	// deployments leave UnsafeAnonymousPrincipal empty AND configure
+	// real auth via server.WithAuth(...).
+	if !hasOAuthEnv() {
+		cfg.UnsafeAnonymousPrincipal = "demo-user"
+	}
+	events.Register(cfg)
 
 	mux := http.NewServeMux()
 	mux.Handle("/mcp", srv.Handler(
@@ -209,4 +226,45 @@ func serve() {
 	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
 	<-stop
 	log.Println("[server] shutting down")
+}
+
+// hasOAuthEnv reports whether OAUTH_ISSUER is set (real-auth posture).
+// Used by the events.Config wiring to decide whether to set the
+// UnsafeAnonymousPrincipal demo escape.
+func hasOAuthEnv() bool {
+	return os.Getenv("OAUTH_ISSUER") != ""
+}
+
+// tryEnableAuth builds a JWTValidator from environment variables and
+// returns it (so the caller can pass server.WithAuth(validator)).
+// Returns nil if OAUTH_ISSUER is not set — caller falls back to the
+// UnsafeAnonymousPrincipal demo escape.
+//
+// Recognized env vars:
+//   OAUTH_ISSUER    REQUIRED. The OIDC issuer URL.
+//                   For Keycloak: http://localhost:8081/realms/<realm>
+//   OAUTH_JWKS_URL  Optional. Defaults to <issuer>/protocol/openid-connect/certs
+//                   (Keycloak convention). Override for non-Keycloak providers.
+//   OAUTH_AUDIENCE  Optional. Defaults to "mcp-events". Tokens MUST have
+//                   this audience claim to be accepted.
+func tryEnableAuth() *auth.JWTValidator {
+	issuer := os.Getenv("OAUTH_ISSUER")
+	if issuer == "" {
+		return nil
+	}
+	jwksURL := os.Getenv("OAUTH_JWKS_URL")
+	if jwksURL == "" {
+		jwksURL = issuer + "/protocol/openid-connect/certs"
+	}
+	audience := os.Getenv("OAUTH_AUDIENCE")
+	if audience == "" {
+		audience = "mcp-events"
+	}
+	v := auth.NewJWTValidator(auth.JWTConfig{
+		JWKSURL:  jwksURL,
+		Issuer:   issuer,
+		Audience: audience,
+	})
+	v.Start()
+	return v
 }

--- a/examples/events/discord/test_ttl.py
+++ b/examples/events/discord/test_ttl.py
@@ -85,7 +85,6 @@ def main() -> int:
         event_name="discord.message",
         callback_url=f"http://localhost:{args.port}",
         secret=args.secret,
-        sub_id="ttl-test",
         refresh_factor=0.5,  # refresh at 0.5*TTL (half a TTL window)
         on_refresh=on_refresh,
     )

--- a/examples/events/discord/walkthrough.go
+++ b/examples/events/discord/walkthrough.go
@@ -364,7 +364,6 @@ func runDemo() {
 			sub, err := eventsclient.Subscribe(ctx, c, eventsclient.SubscribeOptions{
 				EventName:     "discord.message",
 				CallbackURL:   hookSrv.URL,
-				SubID:         "demo-webhook",
 				RefreshFactor: 0.5,
 				OnRefresh:     func() { atomic.AddInt32(&refreshes, 1) },
 			})
@@ -379,8 +378,11 @@ func runDemo() {
 			// refused" retry log on the server side after the demo ends.
 			defer func() {
 				sub.Stop()
+				// γ-2: unsubscribe by tuple (§"Unsubscribing" L509) —
+				// (name, params, delivery.url). The derived id is not
+				// accepted as input.
 				_, _ = c.Call("events/unsubscribe", map[string]any{
-					"id":       sub.ID(),
+					"name":     "discord.message",
 					"delivery": map[string]any{"url": hookSrv.URL},
 				})
 			}()
@@ -423,7 +425,6 @@ func runDemo() {
 		Note("Per spec, delivery.secret is REQUIRED on every events/subscribe — there is no server-side fallback. The server rejects at subscribe time so a subscription never exists that produces unverifiable deliveries. The Go SDK auto-generates a conforming whsec_ value via events.GenerateSecret() when SubscribeOptions.Secret is empty; this step makes a raw client.Call to bypass that and demonstrate the validator.").
 		Run(func(_ demokit.StepContext) (result *demokit.StepResult) {
 			_, err := c.Call("events/subscribe", map[string]any{
-				"id":   "validation-empty",
 				"name": "discord.message",
 				"delivery": map[string]any{
 					"mode": "webhook",
@@ -449,7 +450,6 @@ func runDemo() {
 		Note("The validator enforces the full Standard Webhooks format: whsec_ followed by base64 of 24-64 random bytes. A non-prefixed value, a too-short value, or non-base64 garbage all fail with -32602 InvalidParams. This is what catches IaC-pinned secrets that don't match the spec format before they create a broken subscription.").
 		Run(func(_ demokit.StepContext) (result *demokit.StepResult) {
 			_, err := c.Call("events/subscribe", map[string]any{
-				"id":   "validation-bad",
 				"name": "discord.message",
 				"delivery": map[string]any{
 					"mode":   "webhook",
@@ -469,18 +469,44 @@ func runDemo() {
 			return
 		})
 
-	// --- Step 9: Spec validation — valid secret accepted, response omits secret ---
-	demo.Step("Spec validation: valid whsec_ accepted; response does NOT echo secret").
+	// --- Step 9: Spec validation — client-supplied id is rejected (γ-3) ---
+	demo.Step("Spec validation: client-supplied id is rejected").
+		Arrow("Host", "Server", "events/subscribe { id: 'mine', ... }").
+		DashedArrow("Server", "Host", "-32602 InvalidParams: client-supplied id is not accepted").
+		Note("Per spec §\"Subscription Identity\" → \"Key composition\" L363: \"There is no client-generated id — a subscription is fully determined by what it listens for, where it delivers, and who asked.\" The server derives the id from (principal, name, params, url) and returns it; old SDKs sending an id field get a loud -32602 instead of a silent mis-keying.").
+		Run(func(_ demokit.StepContext) (result *demokit.StepResult) {
+			_, err := c.Call("events/subscribe", map[string]any{
+				"id":   "client-picked-id",
+				"name": "discord.message",
+				"delivery": map[string]any{
+					"mode":   "webhook",
+					"url":    "http://localhost:1/sink",
+					"secret": events.GenerateSecret(),
+				},
+			})
+			rpcErr, ok := err.(*client.RPCError)
+			if !ok {
+				fmt.Printf("    UNEXPECTED: want *client.RPCError, got %v\n", err)
+				return
+			}
+			fmt.Printf("    code=%d  message=%q\n", rpcErr.Code, rpcErr.Message)
+			if rpcErr.Code != -32602 {
+				fmt.Printf("    UNEXPECTED: want code=-32602\n")
+			}
+			return
+		})
+
+	// --- Step 10: Spec validation — valid secret accepted, response omits secret ---
+	demo.Step("Spec validation: valid whsec_ accepted; response carries server-derived id, no secret").
 		Arrow("Host", "Host", "events.GenerateSecret() → whsec_<base64 of 32 bytes>").
 		Arrow("Host", "Server", "events/subscribe { delivery: { secret: whsec_<valid> } }").
-		DashedArrow("Server", "Host", "{ id, cursor, refreshBefore }   (NO secret field per spec)").
-		Note("Counter-test for the validator: a freshly-generated whsec_ value is accepted. Note the response carries id + cursor + refreshBefore but no secret — the spec dropped it because the client supplied it (server doesn't need to echo) and echoing risks leaks via proxies, logs, or IDE network panes. The receiver verifies signatures with the value the client already knows.").
+		DashedArrow("Server", "Host", "{ id: sub_<base64-of-16-bytes>, cursor, refreshBefore }   (no secret per spec)").
+		Note("Counter-test: a freshly-generated whsec_ value is accepted. The response carries the server-derived id (sub_<base64>) per spec §\"Subscription Identity\" → \"Derived id\" L367 — non-load-bearing for security, surfaced as X-MCP-Subscription-Id on delivery POSTs (γ-4 wires the header). The response does NOT echo the secret because the client already supplied it; echoing would risk leaks via proxies / logs / IDE network panes.").
 		Run(func(_ demokit.StepContext) (result *demokit.StepResult) {
 			supplied := events.GenerateSecret()
 			fmt.Printf("    supplied secret:  %s...\n", truncate(supplied, 16))
 
 			res, err := c.Call("events/subscribe", map[string]any{
-				"id":   "validation-good",
 				"name": "discord.message",
 				"delivery": map[string]any{
 					"mode":   "webhook",
@@ -498,20 +524,21 @@ func runDemo() {
 				RefreshBefore string `json:"refreshBefore"`
 			}
 			_ = json.Unmarshal(res.Raw, &resp)
-			fmt.Printf("    response.id:            %q\n", resp.ID)
+			fmt.Printf("    response.id:            %q  (server-derived sub_<base64>)\n", resp.ID)
 			fmt.Printf("    response.refreshBefore: %q\n", resp.RefreshBefore)
 			fmt.Printf("    response.secret:        %q  (empty per spec)\n", resp.Secret)
 
-			// Eagerly unsubscribe so the validation-good subscription doesn't
-			// tie up a delivery target for a TTL window after the demo ends.
+			// Eagerly unsubscribe (γ-2: tuple form, no id) so the
+			// subscription doesn't tie up a delivery target for a TTL
+			// window after the demo ends.
 			_, _ = c.Call("events/unsubscribe", map[string]any{
-				"id":       "validation-good",
+				"name":     "discord.message",
 				"delivery": map[string]any{"url": "http://localhost:1/sink"},
 			})
 			return
 		})
 
-	// --- Step 10: Live Discord interaction ---
+	// --- Step 11: Live Discord interaction ---
 	// Uses demokit's Timeout (safety upper bound) + Cancellable (press-enter
 	// to end early in interactive non-TUI mode). Output streams live as
 	// events arrive — demokit v0.0.8+ tees step stdout to the renderer in

--- a/examples/events/telegram/README.md
+++ b/examples/events/telegram/README.md
@@ -81,6 +81,17 @@ go run . --serve -webhook-header-mode mcp
 
 Per spec, the webhook signing secret is **client-supplied only** (`whsec_` + base64 of 24-64 random bytes). See [`experimental/ext/events/README.md`](../../../experimental/ext/events/README.md) for the full configuration reference.
 
+## Auth posture (γ)
+
+Same auto-detect pattern as the discord demo — see [`../discord/README.md`](../discord/README.md#auth-posture-γ-demo-escape-vs-real-oidc) for the full env-var contract. TL;DR:
+
+```bash
+make serve                                                      # demo posture (anonymous escape)
+OAUTH_ISSUER=http://localhost:8081/realms/demo make serve       # real OIDC, spec-strict
+```
+
+Server logs which posture is active at startup.
+
 ## Make targets
 
 | Target | Description |

--- a/examples/events/telegram/e2e_test.go
+++ b/examples/events/telegram/e2e_test.go
@@ -197,7 +197,6 @@ func TestE2EWebhookDelivery(t *testing.T) {
 
 	clientSecret := events.GenerateSecret()
 	subResult, err := c.Call("events/subscribe", map[string]any{
-		"id":       "wh-e2e",
 		"name":     "telegram.message",
 		"delivery": map[string]any{"mode": "webhook", "url": callbackSrv.URL, "secret": clientSecret},
 	})
@@ -270,7 +269,6 @@ func TestE2EWebhookDelivery_StandardHeaders(t *testing.T) {
 
 	clientSecret := events.GenerateSecret()
 	_, err := c.Call("events/subscribe", map[string]any{
-		"id":       "wh-std",
 		"name":     "telegram.message",
 		"delivery": map[string]any{"mode": "webhook", "url": callbackSrv.URL, "secret": clientSecret},
 	})
@@ -329,7 +327,6 @@ func TestE2EWebhookDelivery_MCPHeadersOptIn(t *testing.T) {
 
 	clientSecret := events.GenerateSecret()
 	_, err := c.Call("events/subscribe", map[string]any{
-		"id":       "wh-mcp",
 		"name":     "telegram.message",
 		"delivery": map[string]any{"mode": "webhook", "url": callbackSrv.URL, "secret": clientSecret},
 	})
@@ -453,7 +450,6 @@ func TestE2ECursorlessWebhookDelivery(t *testing.T) {
 	require.NoError(t, c.Connect())
 
 	raw, err := c.Call("events/subscribe", map[string]any{
-		"id":       "wh-typing",
 		"name":     "telegram.typing",
 		"delivery": map[string]any{"mode": "webhook", "url": callbackSrv.URL, "secret": events.GenerateSecret()},
 	})

--- a/examples/events/telegram/e2e_test.go
+++ b/examples/events/telegram/e2e_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -37,9 +38,10 @@ func buildTestStack(whOpts ...events.WebhookOption) (*server.Server, *events.Yie
 	registerResources(srv, source)
 	(&ToolDelivery{Bot: nil}).Register(srv)
 	events.Register(events.Config{
-		Sources:  []events.EventSource{source, typingSource},
-		Webhooks: webhooks,
-		Server:   srv,
+		Sources:                  []events.EventSource{source, typingSource},
+		Webhooks:                 webhooks,
+		Server:                   srv,
+		UnsafeAnonymousPrincipal: "test-principal",
 	})
 
 	return srv, source, yield, webhooks
@@ -61,9 +63,10 @@ func buildTestStackWithTyping() (*server.Server, func(TelegramEventData) error, 
 	registerResources(srv, source)
 	(&ToolDelivery{Bot: nil}).Register(srv)
 	events.Register(events.Config{
-		Sources:  []events.EventSource{source, typingSource},
-		Webhooks: webhooks,
-		Server:   srv,
+		Sources:                  []events.EventSource{source, typingSource},
+		Webhooks:                 webhooks,
+		Server:                   srv,
+		UnsafeAnonymousPrincipal: "test-principal",
 	})
 	return srv, yield, yieldTyping
 }
@@ -200,14 +203,17 @@ func TestE2EWebhookDelivery(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Spec: subscribe response carries id but does NOT echo the secret.
-	// The client already supplied it; receiver verifies with that value.
+	// Spec: subscribe response carries id (server-derived per
+	// §"Subscription Identity" → "Derived id" L367) but does NOT echo
+	// the secret. The client already supplied the secret; receiver
+	// verifies with that value. The id is the X-MCP-Subscription-Id
+	// routing handle (γ-4 wires the header).
 	var subResp struct {
 		ID     string `json:"id"`
 		Secret string `json:"secret"`
 	}
 	require.NoError(t, json.Unmarshal(subResult.Raw, &subResp))
-	assert.Equal(t, "wh-e2e", subResp.ID)
+	assert.True(t, strings.HasPrefix(subResp.ID, "sub_"), "id must be the server-derived sub_<base64> per spec; got %q", subResp.ID)
 	require.Empty(t, subResp.Secret, "subscribe response must NOT carry a secret field per spec")
 	mu.Lock()
 	assignedSecret = clientSecret

--- a/examples/events/telegram/go.mod
+++ b/examples/events/telegram/go.mod
@@ -6,6 +6,7 @@ replace (
 	github.com/panyam/mcpkit => ../../..
 	github.com/panyam/mcpkit/experimental/ext/events => ../../../experimental/ext/events
 	github.com/panyam/mcpkit/experimental/ext/events/clients/go => ../../../experimental/ext/events/clients/go
+	github.com/panyam/mcpkit/ext/auth => ../../../ext/auth
 )
 
 require (
@@ -14,6 +15,7 @@ require (
 	github.com/panyam/mcpkit v0.2.40
 	github.com/panyam/mcpkit/experimental/ext/events v0.0.0
 	github.com/panyam/mcpkit/experimental/ext/events/clients/go v0.0.0-00010101000000-000000000000
+	github.com/panyam/mcpkit/ext/auth v0.0.0-00010101000000-000000000000
 	github.com/panyam/servicekit v0.0.25
 	github.com/stretchr/testify v1.11.1
 )
@@ -31,6 +33,8 @@ require (
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/fernet/fernet-go v0.0.0-20240119011108-303da6aec611 // indirect
+	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/invopop/jsonschema v0.13.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.4.0 // indirect
@@ -39,6 +43,7 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/panyam/gocurrent v0.1.0 // indirect
 	github.com/panyam/goutils v0.1.8 // indirect
+	github.com/panyam/oneauth v0.0.79 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
@@ -46,6 +51,8 @@ require (
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	github.com/yuin/goldmark v1.8.2 // indirect
+	golang.org/x/crypto v0.46.0 // indirect
+	golang.org/x/oauth2 v0.34.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.33.0 // indirect

--- a/examples/events/telegram/go.sum
+++ b/examples/events/telegram/go.sum
@@ -24,8 +24,12 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/fernet/fernet-go v0.0.0-20240119011108-303da6aec611 h1:JwYtKJ/DVEoIA5dH45OEU7uoryZY/gjd/BQiwwAOImM=
+github.com/fernet/fernet-go v0.0.0-20240119011108-303da6aec611/go.mod h1:zHMNeYgqrTpKyjawjitDg0Osd1P/FmeA0SZLYK3RfLQ=
 github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1 h1:wG8n/XJQ07TmjbITcGiUaOtXxdrINDz1b0J1w0SzqDc=
 github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1/go.mod h1:A2S0CWkNylc2phvKXWBBdD3K0iGnDBGbzRpISP2zBl8=
+github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
+github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
@@ -55,6 +59,8 @@ github.com/panyam/gocurrent v0.1.0 h1:AW8ctsSQHtoj8QXN55e9n+TYxtq+noF/ikPsRLiihi
 github.com/panyam/gocurrent v0.1.0/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.8 h1:5UscYTP892k54+Nyb01tKGGwZxczZ5k7BC+c0nXmcoc=
 github.com/panyam/goutils v0.1.8/go.mod h1:ntucs8GJOHQ0LmlRGRjeup3aDC2t7xPMudrRwUHrJNM=
+github.com/panyam/oneauth v0.0.79 h1:oDFdjsNqzv6OZSh4F1qm8REhRSGZLsCpTQRj1GznQVA=
+github.com/panyam/oneauth v0.0.79/go.mod h1:07eoijxxnj1mCxIIDo71FNGVyl4ru1Aw+G9x7qoSnnk=
 github.com/panyam/servicekit v0.0.25 h1:JeTRyz5ZZY3beENg0N3tLW+O39/foTuHMPAf+rpwYhM=
 github.com/panyam/servicekit v0.0.25/go.mod h1:9TkF2LRqiPC9bgu0bYVdky7rnHEuBvzGzrsoL++Ra5c=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -75,10 +81,14 @@ github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zI
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/goldmark v1.8.2 h1:kEGpgqJXdgbkhcOgBxkC0X0PmoPG1ZyoZ117rDVp4zE=
 github.com/yuin/goldmark v1.8.2/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
+golang.org/x/crypto v0.46.0 h1:cKRW/pmt1pKAfetfu+RCEvjvZkA9RimPbh7bhFjGVBU=
+golang.org/x/crypto v0.46.0/go.mod h1:Evb/oLKmMraqjZ2iQTwDwvCtJkczlDuTmdJXoZVzqU0=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
 golang.org/x/net v0.49.0 h1:eeHFmOGUTtaaPSGNmjBKpbng9MulQsJURQUAfUwY++o=
 golang.org/x/net v0.49.0/go.mod h1:/ysNB2EvaqvesRkuLAyjI1ycPZlQHM3q01F02UY/MV8=
+golang.org/x/oauth2 v0.34.0 h1:hqK/t4AKgbqWkdkcAeI8XLmbK+4m4G5YeQRrmiotGlw=
+golang.org/x/oauth2 v0.34.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
 golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
 golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=

--- a/examples/events/telegram/handlers_test.go
+++ b/examples/events/telegram/handlers_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -49,9 +50,10 @@ func newConnectedClient(t *testing.T, source *events.YieldingSource[TelegramEven
 	registerResources(srv, source)
 	(&ToolDelivery{Bot: nil}).Register(srv)
 	events.Register(events.Config{
-		Sources:  []events.EventSource{source},
-		Webhooks: webhooks,
-		Server:   srv,
+		Sources:                  []events.EventSource{source},
+		Webhooks:                 webhooks,
+		Server:                   srv,
+		UnsafeAnonymousPrincipal: "test-principal",
 	})
 
 	handler := srv.Handler(server.WithStreamableHTTP(true))
@@ -195,7 +197,10 @@ func TestWebhookHMACSignature_MCPHeaders(t *testing.T) {
 	defer srv.Close()
 
 	webhooks := events.NewWebhookRegistry(events.WithWebhookHeaderMode(events.MCPHeaders))
-	webhooks.Register("hmac-test", srv.URL, secret)
+	// Direct registry poke (skip the JSON-RPC subscribe handler) — γ-2
+	// rekeyed Register on canonical-tuple bytes. Use a stub key for the
+	// HMAC delivery test; the canonical-key contents don't matter here.
+	webhooks.Register([]byte("hmac-test"), "sub_hmac_test", srv.URL, secret)
 
 	event := events.MakeEvent("telegram.message", "evt_1", "1", time.Now(),
 		map[string]string{"text": "hello"})
@@ -268,7 +273,9 @@ func TestSubscribeReturnsRefreshBefore(t *testing.T) {
 		RefreshBefore string `json:"refreshBefore"`
 	}
 	require.NoError(t, json.Unmarshal(result.Raw, &resp))
-	assert.Equal(t, "rb-test", resp.ID)
+	// γ-2: server-derived id replaces client-supplied id per spec
+	// §"Subscription Identity" → "Derived id" L367.
+	assert.True(t, strings.HasPrefix(resp.ID, "sub_"), "id must be server-derived sub_<base64>; got %q", resp.ID)
 	assert.NotEmpty(t, resp.RefreshBefore)
 
 	rb, err := time.Parse(time.RFC3339, resp.RefreshBefore)
@@ -276,27 +283,33 @@ func TestSubscribeReturnsRefreshBefore(t *testing.T) {
 	assert.True(t, rb.After(time.Now()))
 }
 
-// TestWebhookKeyedByURLAndID verifies (url, id) composite keying — two
-// distinct subscriptions to the same URL coexist.
-func TestWebhookKeyedByURLAndID(t *testing.T) {
+// TestWebhookKeyedByCanonicalTuple verifies γ-2 registry keying: two
+// distinct canonical keys (different principals subscribing to the same
+// URL) coexist as distinct entries; Unregister by canonical key removes
+// only the matching entry. This is the spec's cross-tenant isolation
+// property (§"Subscription Identity" → "Cross-tenant isolation" L378)
+// at the registry level.
+func TestWebhookKeyedByCanonicalTuple(t *testing.T) {
 	webhooks := events.NewWebhookRegistry()
-	webhooks.Register("sub-1", "http://example.com/hook", "secret-1")
-	webhooks.Register("sub-2", "http://example.com/hook", "secret-2")
+	keyA := []byte("alice\x1fhttp://example.com/hook\x1ftelegram.message\x1f{}")
+	keyB := []byte("bob\x1fhttp://example.com/hook\x1ftelegram.message\x1f{}")
+	webhooks.Register(keyA, "sub_alice", "http://example.com/hook", "whsec_secret-1")
+	webhooks.Register(keyB, "sub_bob", "http://example.com/hook", "whsec_secret-2")
 
 	targets := webhooks.Targets()
 	assert.Len(t, targets, 2)
 
-	webhooks.Unregister("http://example.com/hook", "sub-1")
+	webhooks.Unregister(keyA)
 	targets = webhooks.Targets()
 	assert.Len(t, targets, 1)
-	assert.Equal(t, "sub-2", targets[0].ID)
+	assert.Equal(t, "sub_bob", targets[0].ID, "unregister(keyA) must leave keyB intact")
 }
 
 // TestWebhookTTLExpiry verifies the test-helper ExpireAll path does what
 // it claims — used by other tests that exercise post-TTL behavior.
 func TestWebhookTTLExpiry(t *testing.T) {
 	webhooks := events.NewWebhookRegistry()
-	webhooks.Register("exp-test", "http://example.com/hook", "secret")
+	webhooks.Register([]byte("exp-test"), "sub_exp", "http://example.com/hook", "whsec_secret")
 	assert.Len(t, webhooks.Targets(), 1)
 
 	webhooks.ExpireAll()
@@ -323,7 +336,7 @@ func TestWebhookRetryOnServerError(t *testing.T) {
 	defer srv.Close()
 
 	webhooks := events.NewWebhookRegistry()
-	webhooks.Register("retry-test", srv.URL, "secret")
+	webhooks.Register([]byte("retry-test"), "sub_retry", srv.URL, "whsec_secret")
 
 	event := events.MakeEvent("telegram.message", "evt_retry", "1", time.Now(),
 		map[string]string{"text": "retry me"})
@@ -351,7 +364,7 @@ func TestWebhookNoRetryOn4xx(t *testing.T) {
 	defer srv.Close()
 
 	webhooks := events.NewWebhookRegistry()
-	webhooks.Register("no-retry", srv.URL, "secret")
+	webhooks.Register([]byte("no-retry"), "sub_no_retry", srv.URL, "whsec_secret")
 
 	event := events.MakeEvent("telegram.message", "evt_4xx", "1", time.Now(),
 		map[string]string{"text": "no retry"})

--- a/examples/events/telegram/handlers_test.go
+++ b/examples/events/telegram/handlers_test.go
@@ -262,7 +262,6 @@ func TestSubscribeReturnsRefreshBefore(t *testing.T) {
 	c, _ := newConnectedClient(t, source, webhooks)
 
 	result, err := c.Call("events/subscribe", map[string]any{
-		"id":       "rb-test",
 		"name":     "telegram.message",
 		"delivery": map[string]any{"mode": "webhook", "url": "http://example.com/hook", "secret": events.GenerateSecret()},
 	})

--- a/examples/events/telegram/main.go
+++ b/examples/events/telegram/main.go
@@ -24,6 +24,7 @@ import (
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
 	"github.com/panyam/mcpkit/core"
 	"github.com/panyam/mcpkit/experimental/ext/events"
+	"github.com/panyam/mcpkit/ext/auth"
 	"github.com/panyam/mcpkit/server"
 	gohttp "github.com/panyam/servicekit/http"
 )
@@ -72,27 +73,40 @@ func serve() {
 		log.Println("[telegram] no token provided — running in test mode")
 	}
 
-	srv := server.NewServer(
-		core.ServerInfo{Name: "telegram-events", Version: "0.1.0"},
+	// γ-5: auto-detect auth posture. Identical pattern to discord's main.go
+	// — if OAUTH_ISSUER is set, wire real OIDC auth and follow the spec
+	// strictly (anonymous webhook subscribes rejected with -32012 per
+	// §"Subscription Identity" L361). Otherwise fall back to the demo
+	// escape hatch so `make demo` works without an auth provider.
+	srvOpts := []server.Option{
 		server.WithSubscriptions(),
 		server.WithMiddleware(server.LoggingMiddleware(log.Default())),
 		server.WithRequestLogging(log.Default()),
+	}
+	authPosture := "demo (anonymous → UnsafeAnonymousPrincipal)"
+	if validator := tryEnableAuth(); validator != nil {
+		srvOpts = append(srvOpts, server.WithAuth(validator))
+		authPosture = "real OIDC (" + os.Getenv("OAUTH_ISSUER") + ") — anonymous webhook subscribes rejected per spec"
+	}
+
+	srv := server.NewServer(
+		core.ServerInfo{Name: "telegram-events", Version: "0.1.0"},
+		srvOpts...,
 	)
+	log.Printf("[server] auth: %s", authPosture)
 
 	registerResources(srv, source)
 	(&ToolDelivery{Bot: bot}).Register(srv)
 
-	events.Register(events.Config{
+	cfg := events.Config{
 		Sources:  []events.EventSource{source, typingSource},
 		Webhooks: webhooks,
 		Server:   srv,
-		// γ-2 spec gate (§"Subscription Identity" L361) requires an
-		// authenticated principal for webhook subscribe. Demo runs
-		// anonymously by default — use the escape hatch with a fixed
-		// principal so make demo continues to work end-to-end.
-		// γ-5 will replace this with auto-detection (OAUTH_ISSUER env var).
-		UnsafeAnonymousPrincipal: "demo-user",
-	})
+	}
+	if !hasOAuthEnv() {
+		cfg.UnsafeAnonymousPrincipal = "demo-user"
+	}
+	events.Register(cfg)
 
 	mux := http.NewServeMux()
 	mux.Handle("/mcp", srv.Handler(
@@ -193,4 +207,45 @@ func startTelegramPolling(bot *tgbotapi.BotAPI, yield func(TelegramEventData) er
 		log.Printf("[telegram] chat=%s sender=%s text=%q", ev.ChatID, ev.User, ev.Text)
 	}
 	log.Println("[telegram] poll loop ended")
+}
+
+// hasOAuthEnv reports whether OAUTH_ISSUER is set (real-auth posture).
+// Used by the events.Config wiring to decide whether to set the
+// UnsafeAnonymousPrincipal demo escape.
+func hasOAuthEnv() bool {
+	return os.Getenv("OAUTH_ISSUER") != ""
+}
+
+// tryEnableAuth builds a JWTValidator from environment variables and
+// returns it (so the caller can pass server.WithAuth(validator)).
+// Returns nil if OAUTH_ISSUER is not set — caller falls back to the
+// UnsafeAnonymousPrincipal demo escape.
+//
+// Recognized env vars:
+//   OAUTH_ISSUER    REQUIRED. The OIDC issuer URL.
+//                   For Keycloak: http://localhost:8081/realms/<realm>
+//   OAUTH_JWKS_URL  Optional. Defaults to <issuer>/protocol/openid-connect/certs
+//                   (Keycloak convention). Override for non-Keycloak providers.
+//   OAUTH_AUDIENCE  Optional. Defaults to "mcp-events". Tokens MUST have
+//                   this audience claim to be accepted.
+func tryEnableAuth() *auth.JWTValidator {
+	issuer := os.Getenv("OAUTH_ISSUER")
+	if issuer == "" {
+		return nil
+	}
+	jwksURL := os.Getenv("OAUTH_JWKS_URL")
+	if jwksURL == "" {
+		jwksURL = issuer + "/protocol/openid-connect/certs"
+	}
+	audience := os.Getenv("OAUTH_AUDIENCE")
+	if audience == "" {
+		audience = "mcp-events"
+	}
+	v := auth.NewJWTValidator(auth.JWTConfig{
+		JWKSURL:  jwksURL,
+		Issuer:   issuer,
+		Audience: audience,
+	})
+	v.Start()
+	return v
 }

--- a/examples/events/telegram/main.go
+++ b/examples/events/telegram/main.go
@@ -86,6 +86,12 @@ func serve() {
 		Sources:  []events.EventSource{source, typingSource},
 		Webhooks: webhooks,
 		Server:   srv,
+		// γ-2 spec gate (§"Subscription Identity" L361) requires an
+		// authenticated principal for webhook subscribe. Demo runs
+		// anonymously by default — use the escape hatch with a fixed
+		// principal so make demo continues to work end-to-end.
+		// γ-5 will replace this with auto-detection (OAUTH_ISSUER env var).
+		UnsafeAnonymousPrincipal: "demo-user",
 	})
 
 	mux := http.NewServeMux()

--- a/examples/events/telegram/walkthrough.go
+++ b/examples/events/telegram/walkthrough.go
@@ -272,7 +272,6 @@ func runDemo() {
 			sub, err := eventsclient.Subscribe(ctx, c, eventsclient.SubscribeOptions{
 				EventName:   "telegram.message",
 				CallbackURL: hookSrv.URL,
-				SubID:       "demo-telegram-webhook",
 			})
 			if err != nil {
 				fmt.Printf("    ERROR: subscribe failed: %v\n", err)
@@ -285,8 +284,9 @@ func runDemo() {
 			// refused" retry log on the server side after the demo ends.
 			defer func() {
 				sub.Stop()
+				// γ-2: unsubscribe by tuple (§"Unsubscribing" L509).
 				_, _ = c.Call("events/unsubscribe", map[string]any{
-					"id":       sub.ID(),
+					"name":     "telegram.message",
 					"delivery": map[string]any{"url": hookSrv.URL},
 				})
 			}()

--- a/experimental/ext/events/DEPLOYMENT.md
+++ b/experimental/ext/events/DEPLOYMENT.md
@@ -121,6 +121,44 @@ Operational notes:
 - **Rotation is client-initiated.** Supply a new `whsec_` value on a refresh `events/subscribe` call. The server replaces the stored value; in-flight deliveries signed with the old secret will fail verification at the receiver. Spec describes a Standard-Webhooks dual-sign grace window for this case (not yet implemented in mcpkit; tracked under PR group ζ).
 - **Treat each `whsec_` value as a credential.** Provision via secrets manager (Vault, AWS Secrets Manager, GCP Secret Manager, K8s secret with appropriate restrictions) when subscribing programmatically. Compromise of one secret only compromises that subscription's deliveries — there's no master root.
 
+## Auth + tuple subscription identity (γ)
+
+Per spec §"Subscription Identity" → "Authentication required" L361, webhook `events/subscribe` and `events/unsubscribe` MUST require an authenticated principal — servers reject unauthenticated calls with `-32012 Unauthorized`. The registry keys subscriptions on the canonical tuple `(principal, delivery.url, name, params)`; cross-tenant isolation is by construction since the principal is part of the key.
+
+Production wiring (the spec-strict path):
+
+```go
+validator := auth.NewJWTValidator(auth.JWTConfig{
+    JWKSURL:  "<your-OIDC-issuer>/.well-known/jwks.json",
+    Issuer:   "<your-OIDC-issuer>",
+    Audience: "mcp-events",
+})
+validator.Start()
+
+srv := server.NewServer(
+    core.ServerInfo{...},
+    server.WithSubscriptions(),
+    server.WithAuth(validator),  // ← anonymous webhook subscribes → -32012
+)
+events.Register(events.Config{
+    Sources:  ...,
+    Webhooks: webhooks,
+    Server:   srv,
+    // UnsafeAnonymousPrincipal intentionally NOT set — production
+    // deployments rely on the spec-strict auth gate.
+})
+```
+
+The `events` package only depends on `core.Claims` (the abstract auth contract), not on `ext/auth` or any specific auth implementation. You can swap in mTLS-derived principals, session-cookie validators, or custom JWKS — Events keeps working as long as `ctx.AuthClaims().Subject` returns the principal.
+
+### `UnsafeAnonymousPrincipal` is for demos only
+
+The `events.Config.UnsafeAnonymousPrincipal` field deliberately deviates from the spec — when set, anonymous calls are accepted under the configured principal. **Production deployments MUST leave this field empty.** The startup log line emitted by `events.Register` explicitly warns when it's non-empty so misconfiguration is loud rather than silent.
+
+If a production deployment sets it: the spec's `-32012` rejection is bypassed; webhook subscribe accepts anonymous calls under a single shared principal; cross-tenant isolation breaks (everyone is "the demo user"); the audit trail loses its principal field. None of these are acceptable production properties.
+
+The demos use it as an escape hatch so `make demo` works without standing up an auth provider. Each demo also auto-detects `OAUTH_ISSUER` and switches to real auth when present — see `examples/events/discord/README.md` for the env-var contract.
+
 ## Connecting an MCP host
 
 Once the server is running, point any MCP host at it:
@@ -153,5 +191,7 @@ Before going live with a webhook-enabled events server in a private-cloud deploy
 - [ ] Receiver is idempotent on `event.eventId`.
 - [ ] Receiver returns 2xx for accept, 4xx for reject-permanently, 5xx for retry.
 - [ ] Webhook secrets (each subscription's `whsec_` value) reach the receiver via your secrets-management path; rotation procedure documented.
+- [ ] **`events.Config.UnsafeAnonymousPrincipal` is EMPTY** in production code paths. Auth is wired via `server.WithAuth(...)`. Anonymous webhook subscribes return `-32012 Unauthorized`.
+- [ ] Server startup log shows `[events] WARNING: UnsafeAnonymousPrincipal=...` is **NOT** present. (Its presence indicates the demo escape hatch is on.)
 - [ ] If using Standard Webhooks header mode, WAF allowlist has the `webhook-*` headers (not `X-MCP-*`).
 - [ ] Subscribers run an SDK that auto-refreshes (or have explicit refresh logic that fires before `refreshBefore`).

--- a/experimental/ext/events/README.md
+++ b/experimental/ext/events/README.md
@@ -165,6 +165,46 @@ from events_client import generate_webhook_secret
 secret = generate_webhook_secret()
 ```
 
+### Subscription identity + auth gate (γ)
+
+Per spec §"Subscription Identity" L361-378, webhook subscribe and unsubscribe MUST require an authenticated principal; the registry keys subscriptions on the canonical tuple `(principal, delivery.url, name, params)` and derives a routing handle (`X-MCP-Subscription-Id`) over the same canonical bytes. Two distinct tenants subscribing to the same `(name, params, url)` get distinct subscriptions — cross-tenant isolation by construction.
+
+The handler reads the principal via mcpkit's core auth abstraction (`core.MethodContext.AuthClaims().Subject`), so **any** auth provider that populates `core.Claims` works — JWT/OIDC via mcpkit's `ext/auth`, mTLS-derived principals, session cookies, custom validators, etc. Events depends on the `core.Claims` interface, **not** on `ext/auth` or any specific implementation. See "Auth + extension composition" below.
+
+For demos and unauthenticated mcpkit servers that want to exercise webhook delivery without standing up an auth provider, `events.Config.UnsafeAnonymousPrincipal` is a deliberate spec-deviating escape hatch:
+
+```go
+events.Register(events.Config{
+    Sources:                  sources,
+    Webhooks:                 webhooks,
+    Server:                   srv,
+    UnsafeAnonymousPrincipal: "demo-user", // ONLY for demos — see DEPLOYMENT.md
+})
+```
+
+When set, anonymous webhook subscribes are accepted under the configured principal. The server logs a startup warning so deployments using it know they're off-spec. **Production deployments leave this empty AND wire `server.WithAuth(validator)` so unauthenticated subscribe attempts hit the spec-mandated `-32012 Unauthorized` rejection.**
+
+### Auth + extension composition
+
+Events depends only on the `core.Claims` interface, not on any specific auth implementation. The wiring layer (a server's `main.go`) chooses the auth provider:
+
+```
+ext/events  ──→  core.Claims (the abstract contract)
+                       ↑
+ext/auth    ──→  populates Claims via JWT/OIDC validation
+                       ↑
+your code   ──→  server.WithAuth(your favorite validator)
+```
+
+The Events implementation has zero compile-time dependency on `ext/auth`. You can:
+
+- Use mcpkit's `ext/auth` for JWT/OIDC (what the demos do)
+- Use mTLS — populate Claims from the cert subject
+- Use session cookies — populate Claims from your session store
+- Use no auth at all — set `UnsafeAnonymousPrincipal` for demos
+
+This is the right composition shape for MCP extensions — extensions depend on stable core abstractions, not on each other.
+
 ### Header mode (`WebhookHeaderMode`)
 
 Two on-the-wire signature formats. Default is `MCPHeaders`. Only the headers and signature scheme are configurable; the body shape (the `events.Event` envelope) is unchanged.

--- a/experimental/ext/events/clients/go/eventsclient_test.go
+++ b/experimental/ext/events/clients/go/eventsclient_test.go
@@ -73,7 +73,6 @@ func TestSubscribe_AutoGeneratesSecretWhenEmpty(t *testing.T) {
 	sub, err := eventsclient.Subscribe(ctx, c, eventsclient.SubscribeOptions{
 		EventName:   "fake.event",
 		CallbackURL: "http://localhost:1/sink",
-		SubID:       "auto-gen-test",
 		// Secret intentionally omitted → SDK auto-generates
 	})
 	require.NoError(t, err)
@@ -98,7 +97,6 @@ func TestSubscribe_PreservesCallerSuppliedSecret(t *testing.T) {
 	sub, err := eventsclient.Subscribe(ctx, c, eventsclient.SubscribeOptions{
 		EventName:   "fake.event",
 		CallbackURL: "http://localhost:1/sink",
-		SubID:       "preserve-test",
 		Secret:      supplied,
 	})
 	require.NoError(t, err)
@@ -122,7 +120,6 @@ func TestSubscribe_AutoRefreshFiresWithinShortTTL(t *testing.T) {
 	sub, err := eventsclient.Subscribe(ctx, c, eventsclient.SubscribeOptions{
 		EventName:     "fake.event",
 		CallbackURL:   "http://localhost:1/sink",
-		SubID:         "refresh-test",
 		RefreshFactor: 0.4,
 		OnRefresh:     func() { atomic.AddInt32(&refreshes, 1) },
 	})
@@ -166,7 +163,6 @@ func TestReceiver_DeliversTypedEvents(t *testing.T) {
 	sub, err := eventsclient.Subscribe(ctx, c, eventsclient.SubscribeOptions{
 		EventName:   "fake.event",
 		CallbackURL: hookSrv.URL,
-		SubID:       "recv-test",
 	})
 	require.NoError(t, err)
 	defer sub.Stop()
@@ -203,7 +199,6 @@ func TestReceiver_RejectsBadSignature(t *testing.T) {
 	sub, err := eventsclient.Subscribe(ctx, c, eventsclient.SubscribeOptions{
 		EventName:   "fake.event",
 		CallbackURL: hookSrv.URL,
-		SubID:       "badsig-test",
 	})
 	require.NoError(t, err)
 	defer sub.Stop()
@@ -237,7 +232,6 @@ func TestReceiver_AcceptsStandardWebhooksHeaders(t *testing.T) {
 	sub, err := eventsclient.Subscribe(ctx, c, eventsclient.SubscribeOptions{
 		EventName:   "fake.event",
 		CallbackURL: hookSrv.URL,
-		SubID:       "stdwh-test",
 	})
 	require.NoError(t, err)
 	defer sub.Stop()
@@ -290,7 +284,6 @@ func TestReceiver_DropsOnFullChannel(t *testing.T) {
 	sub, err := eventsclient.Subscribe(ctx, c, eventsclient.SubscribeOptions{
 		EventName:   "fake.event",
 		CallbackURL: hookSrv.URL,
-		SubID:       "drop-test",
 	})
 	require.NoError(t, err)
 	defer sub.Stop()
@@ -318,7 +311,6 @@ func TestSubscribe_StopsOnContextCancel(t *testing.T) {
 	sub, err := eventsclient.Subscribe(ctx, c, eventsclient.SubscribeOptions{
 		EventName:     "fake.event",
 		CallbackURL:   "http://localhost:1/sink",
-		SubID:         "ctx-cancel-test",
 		RefreshFactor: 0.4,
 		OnRefresh:     func() { atomic.AddInt32(&refreshes, 1) },
 	})
@@ -342,7 +334,6 @@ func TestSubscribe_StopIsIdempotent(t *testing.T) {
 	sub, err := eventsclient.Subscribe(context.Background(), c, eventsclient.SubscribeOptions{
 		EventName:   "fake.event",
 		CallbackURL: "http://localhost:1/sink",
-		SubID:       "stop-twice-test",
 	})
 	require.NoError(t, err)
 	sub.Stop()

--- a/experimental/ext/events/clients/go/eventsclient_test.go
+++ b/experimental/ext/events/clients/go/eventsclient_test.go
@@ -42,9 +42,10 @@ func stack(t *testing.T, whOpts ...events.WebhookOption) (*client.Client, func(f
 		server.WithSubscriptions(),
 	)
 	events.Register(events.Config{
-		Sources:  []events.EventSource{src},
-		Webhooks: webhooks,
-		Server:   srv,
+		Sources:                  []events.EventSource{src},
+		Webhooks:                 webhooks,
+		Server:                   srv,
+		UnsafeAnonymousPrincipal: "test-principal", // SDK tests don't wire auth; γ-2 spec gate would reject otherwise
 	})
 
 	handler := srv.Handler(server.WithStreamableHTTP(true))

--- a/experimental/ext/events/clients/go/subscription.go
+++ b/experimental/ext/events/clients/go/subscription.go
@@ -27,11 +27,6 @@ type SubscribeOptions struct {
 	// against this same value.
 	Secret string
 
-	// SubID is the client-side subscription id (for now; γ replaces
-	// id-keyed subscription identity with the (principal, name, params,
-	// url) tuple per spec).
-	SubID string
-
 	// Cursor controls the resume point. nil = "from now" (server returns
 	// its current head). Non-nil = explicit resume cursor.
 	Cursor *string
@@ -157,9 +152,13 @@ func (s *Subscription) Stop() {
 // subscribe performs one events/subscribe round-trip and updates state.
 // Caller is responsible for firing OnRefresh / OnRecover; this method
 // only handles the network call and state update.
+//
+// Per spec §"Subscription Identity" → "Derived id" L367, the server
+// derives the subscription id from (principal, name, params, url) — the
+// SDK does not send an id; it reads the derived id back from the
+// response (Subscription.ID()).
 func (s *Subscription) subscribe() error {
 	params := map[string]any{
-		"id":   s.opts.SubID,
 		"name": s.opts.EventName,
 		"delivery": map[string]any{
 			"mode":   "webhook",

--- a/experimental/ext/events/clients/python/events_client.py
+++ b/experimental/ext/events/clients/python/events_client.py
@@ -276,7 +276,6 @@ class WebhookSubscription:
         event_name: str,
         callback_url: str,
         secret: str = "",
-        sub_id: str = "wh-sub",
         refresh_factor: float = 0.5,
         on_event: callable = None,
         on_refresh: callable = None,
@@ -287,6 +286,13 @@ class WebhookSubscription:
                 whsec_ + base64 of 24-64 random bytes. If empty, the SDK
                 auto-generates a spec-conformant value via
                 generate_webhook_secret().
+
+        Note: there is no sub_id parameter. Per spec §"Subscription
+        Identity" → "Key composition" L363, the server derives the
+        subscription id from (principal, name, params, url); clients
+        do not supply one. The derived id is read back from the
+        subscribe response (self.id after start()).
+
         on_refresh: called after each successful refresh (including the initial
                     subscribe and any post-recovery re-subscribe). Receives no args.
         on_recover: called when a refresh fails (subscription expired) and a
@@ -297,7 +303,6 @@ class WebhookSubscription:
         self.event_name = event_name
         self.callback_url = callback_url
         self.secret = secret if secret else generate_webhook_secret()
-        self.sub_id = sub_id
         self.refresh_factor = refresh_factor
         self.on_event = on_event
         self.on_refresh = on_refresh
@@ -308,9 +313,10 @@ class WebhookSubscription:
         self._refresh_before = None  # parsed from server response
 
     def _subscribe(self):
-        """Send events/subscribe and capture refreshBefore."""
+        """Send events/subscribe and capture refreshBefore. Per spec the
+        request does NOT carry id; server derives it over the canonical
+        tuple (§"Subscription Identity" → "Key composition" L363)."""
         resp = self.session.rpc("events/subscribe", {
-            "id": self.sub_id,
             "name": self.event_name,
             "delivery": {
                 "mode": "webhook",
@@ -466,7 +472,6 @@ def cmd_webhook(session: MCPSession, args):
         event_name=args.event,
         callback_url=hook_url,
         secret=args.secret,  # empty → SDK auto-generates a whsec_ value
-        sub_id="wh-demo",
         refresh_factor=args.refresh_factor,
     )
     secret_holder = [sub.secret]

--- a/experimental/ext/events/errors.go
+++ b/experimental/ext/events/errors.go
@@ -18,12 +18,13 @@ package events
 //   -32016 SubscriptionNotFound    — Unsubscribe target doesn't exist
 //   -32017 DeliveryModeUnsupported — Event type doesn't support requested mode
 //
-// Only the two codes the events handlers currently emit are declared
-// below. Subsequent spec-alignment PRs (γ for auth, ζ for delivery
-// status / unsubscribe lookup, etc.) add the remaining constants in
-// the commit that introduces the behavior using them — keeps each
-// new code visible alongside its first use.
+// Only codes the events handlers currently emit are declared below.
+// Subsequent spec-alignment PRs (ζ for delivery status / unsubscribe
+// lookup, etc.) add the remaining constants in the commit that
+// introduces the behavior using them — keeps each new code visible
+// alongside its first use.
 const (
 	ErrCodeEventNotFound      = -32011 // Unknown event name
+	ErrCodeUnauthorized       = -32012 // Caller lacks permission for this event/params
 	ErrCodeInvalidCallbackUrl = -32015 // Webhook URL unreachable / rejected
 )

--- a/experimental/ext/events/events.go
+++ b/experimental/ext/events/events.go
@@ -14,6 +14,7 @@ package events
 
 import (
 	"encoding/json"
+	"log"
 	"time"
 
 	"github.com/panyam/mcpkit/core"
@@ -168,6 +169,25 @@ type Config struct {
 	Sources  []EventSource
 	Webhooks *WebhookRegistry // nil disables webhook delivery
 	Server   *server.Server
+
+	// UnsafeAnonymousPrincipal stands in for claims.Subject when the
+	// request has no authenticated principal — i.e. the server has no
+	// auth middleware wired and ctx.AuthClaims() returns nil.
+	//
+	// This is a deliberate spec deviation. Per spec §"Subscription
+	// Identity" → "Authentication required" L361, servers MUST reject
+	// unauthenticated webhook subscribes with -32012 Unauthorized. The
+	// escape hatch exists so demos and unauthenticated mcpkit servers
+	// can exercise webhook delivery end-to-end without standing up an
+	// OAuth provider; it is named with the "Unsafe" prefix and produces
+	// a startup warning log so deployments using it know they're
+	// off-spec.
+	//
+	// Empty (default) keeps the spec-strict behavior. Production
+	// deployments wire auth via server.WithAuth(...) and leave this
+	// empty; ctx.AuthClaims().Subject becomes the principal in the
+	// canonical tuple. See γ PLAN.md for the design rationale.
+	UnsafeAnonymousPrincipal string
 }
 
 // Register hooks up events/list, events/poll, events/subscribe, and
@@ -199,8 +219,14 @@ func Register(cfg Config) {
 	registerList(srv, sources)
 	registerPoll(srv, sourceMap)
 	if webhooks != nil {
-		registerSubscribe(srv, sourceMap, webhooks)
-		registerUnsubscribe(srv, webhooks)
+		registerSubscribe(srv, sourceMap, webhooks, cfg.UnsafeAnonymousPrincipal)
+		registerUnsubscribe(srv, webhooks, cfg.UnsafeAnonymousPrincipal)
+	}
+	if cfg.UnsafeAnonymousPrincipal != "" {
+		log.Printf("[events] WARNING: UnsafeAnonymousPrincipal=%q — unauthenticated webhook subscribes "+
+			"will be accepted under this principal. DEVIATES from spec §\"Subscription Identity\" L361 "+
+			"(MUST reject unauthenticated). Use only for demos / development.",
+			cfg.UnsafeAnonymousPrincipal)
 	}
 }
 
@@ -322,11 +348,36 @@ func registerPoll(srv *server.Server, sourceMap map[string]EventSource) {
 	})
 }
 
-func registerSubscribe(srv *server.Server, sourceMap map[string]EventSource, webhooks *WebhookRegistry) {
+// resolvePrincipal returns the principal to use for the canonical
+// subscription key, applying the spec's auth-required rule
+// (§"Subscription Identity" → "Authentication required" L361) with the
+// UnsafeAnonymousPrincipal escape hatch (events.Config field).
+//
+// Returns: (principal, ok). When ok is false, the handler MUST reject
+// the request with -32012 Unauthorized — there is neither real auth
+// nor a configured anonymous fallback.
+//
+// Path-1 (real auth): claims != nil → claims.Subject. Spec-correct.
+// Path-2 (demo escape): claims == nil and unsafeAnon != "" → unsafeAnon.
+//   Deliberately deviates from the spec; gated by Unsafe-prefix + startup
+//   warning in Register.
+// Path-3 (strict): claims == nil and unsafeAnon == "" → reject. Spec-correct.
+func resolvePrincipal(ctx core.MethodContext, unsafeAnon string) (string, bool) {
+	if claims := ctx.AuthClaims(); claims != nil {
+		return claims.Subject, true
+	}
+	if unsafeAnon != "" {
+		return unsafeAnon, true
+	}
+	return "", false
+}
+
+func registerSubscribe(srv *server.Server, sourceMap map[string]EventSource, webhooks *WebhookRegistry, unsafeAnon string) {
 	srv.HandleMethod("events/subscribe", func(ctx core.MethodContext, id json.RawMessage, params json.RawMessage) *core.Response {
 		var req struct {
-			ID       string `json:"id"`
-			Name     string `json:"name"`
+			ID       string         `json:"id"`
+			Name     string         `json:"name"`
+			Params   map[string]any `json:"params,omitempty"`
 			Delivery struct {
 				Mode   string `json:"mode"`
 				URL    string `json:"url"`
@@ -363,7 +414,26 @@ func registerSubscribe(srv *server.Server, sourceMap map[string]EventSource, web
 				"delivery.secret invalid: "+err.Error())
 		}
 
-		expiresAt := webhooks.Register(req.ID, req.Delivery.URL, req.Delivery.Secret)
+		// Spec §"Subscription Identity" → "Authentication required" L361:
+		// events/subscribe MUST be called with an authenticated principal;
+		// servers MUST reject unauthenticated calls with -32012. The
+		// UnsafeAnonymousPrincipal escape hatch (Config field) lets demos
+		// run anonymously — see resolvePrincipal docs.
+		principal, ok := resolvePrincipal(ctx, unsafeAnon)
+		if !ok {
+			return core.NewErrorResponse(id, ErrCodeUnauthorized, "Unauthorized")
+		}
+
+		// Spec §"Subscription Identity" → "Key composition" L363: the
+		// subscription is identified by (principal, delivery.url, name,
+		// params). Two subscribes producing identical canonical bytes
+		// refer to the same subscription (idempotent refresh). Different
+		// principals → distinct subscriptions (cross-tenant isolation
+		// L378).
+		canonical := canonicalKey(principal, req.Delivery.URL, req.Name, req.Params)
+		derivedID := deriveSubscriptionID(canonical)
+
+		expiresAt := webhooks.Register(canonical, derivedID, req.Delivery.URL, req.Delivery.Secret)
 
 		// Resolve `cursor: null` to the source's current head ("from now")
 		// for cursored sources. Cursorless sources always serialize as null.
@@ -382,22 +452,29 @@ func registerSubscribe(srv *server.Server, sourceMap map[string]EventSource, web
 		}
 
 		// Per spec, the response does NOT echo back the secret. The
-		// client supplied it, so the client already knows it. Echoing
-		// would also risk leaking the secret to anyone who can observe
-		// the response (proxies, logs, IDE network panes during
-		// development).
+		// client supplied it, so the client already knows it.
+		//
+		// The id field is the SERVER-DERIVED routing handle per spec
+		// §"Subscription Identity" → "Derived id" L367 — non-load-bearing
+		// for security, used only as the X-MCP-Subscription-Id header
+		// value on delivery POSTs (γ-4 wires the header). Knowing the
+		// id grants no operations on the subscription (L378).
 		return core.NewResponse(id, map[string]any{
-			"id":            req.ID,
+			"id":            derivedID,
 			"cursor":        wireCursor,
 			"refreshBefore": expiresAt.Format(time.RFC3339),
 		})
 	})
 }
 
-func registerUnsubscribe(srv *server.Server, webhooks *WebhookRegistry) {
+func registerUnsubscribe(srv *server.Server, webhooks *WebhookRegistry, unsafeAnon string) {
 	srv.HandleMethod("events/unsubscribe", func(ctx core.MethodContext, id json.RawMessage, params json.RawMessage) *core.Response {
+		// Spec §"Unsubscribing: events/unsubscribe" L509: resolves on the
+		// same canonical tuple as subscribe — (principal, name, params,
+		// delivery.url). The derived id is NOT accepted as input.
 		var req struct {
-			ID       string `json:"id"`
+			Name     string         `json:"name"`
+			Params   map[string]any `json:"params,omitempty"`
 			Delivery *struct {
 				URL string `json:"url"`
 			} `json:"delivery,omitempty"`
@@ -405,14 +482,20 @@ func registerUnsubscribe(srv *server.Server, webhooks *WebhookRegistry) {
 		if err := json.Unmarshal(params, &req); err != nil {
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, err.Error())
 		}
+		if req.Name == "" {
+			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, "name is required")
+		}
 		if req.Delivery == nil || req.Delivery.URL == "" {
-			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, "delivery.url required")
+			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, "delivery.url is required")
 		}
-		if req.ID == "" {
-			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, "id is required")
+
+		principal, ok := resolvePrincipal(ctx, unsafeAnon)
+		if !ok {
+			return core.NewErrorResponse(id, ErrCodeUnauthorized, "Unauthorized")
 		}
-		// γ will replace id with the (principal, name, params, url) tuple per spec.
-		webhooks.Unregister(req.Delivery.URL, req.ID)
+
+		canonical := canonicalKey(principal, req.Delivery.URL, req.Name, req.Params)
+		webhooks.Unregister(canonical)
 		return core.NewResponse(id, map[string]any{})
 	})
 }

--- a/experimental/ext/events/events.go
+++ b/experimental/ext/events/events.go
@@ -375,6 +375,13 @@ func resolvePrincipal(ctx core.MethodContext, unsafeAnon string) (string, bool) 
 func registerSubscribe(srv *server.Server, sourceMap map[string]EventSource, webhooks *WebhookRegistry, unsafeAnon string) {
 	srv.HandleMethod("events/subscribe", func(ctx core.MethodContext, id json.RawMessage, params json.RawMessage) *core.Response {
 		var req struct {
+			// ID is parsed only to surface a helpful error if a client
+			// sends the legacy field. Per spec §"Subscription Identity"
+			// → "Key composition" L363: "There is no client-generated id
+			// — a subscription is fully determined by what it listens
+			// for, where it delivers, and who asked." γ-3 rejects
+			// client-supplied id at the wire level so old SDKs fail
+			// loudly instead of silently mis-keying.
 			ID       string         `json:"id"`
 			Name     string         `json:"name"`
 			Params   map[string]any `json:"params,omitempty"`
@@ -387,6 +394,10 @@ func registerSubscribe(srv *server.Server, sourceMap map[string]EventSource, web
 		}
 		if err := json.Unmarshal(params, &req); err != nil {
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, err.Error())
+		}
+		if req.ID != "" {
+			return core.NewErrorResponse(id, core.ErrCodeInvalidParams,
+				"client-supplied id is not accepted; server derives id over (principal, name, params, url) per spec — drop the id field from your subscribe request")
 		}
 		if _, ok := sourceMap[req.Name]; !ok {
 			return core.NewErrorResponse(id, ErrCodeEventNotFound, "EventNotFound")

--- a/experimental/ext/events/headers.go
+++ b/experimental/ext/events/headers.go
@@ -60,9 +60,37 @@ func ParseHeaderMode(s string) (WebhookHeaderMode, error) {
 
 // signedDelivery holds the headers and the request body for one webhook POST.
 // applyHeaders writes them onto an outbound *http.Request.
+//
+// Per spec §"Webhook Event Delivery" L390 + §"Webhook Security" →
+// "Signature scheme" L472: every delivery MUST include
+// X-MCP-Subscription-Id (the subscription's derived id from
+// γ-2's tuple identity) so the receiver can select the correct
+// secret without parsing the body. This is the only MCP-specific
+// header on a Standard Webhooks delivery; everything else conforms
+// to the Standard Webhooks profile.
+//
+// withSubscriptionID returns a copy with the X-MCP-Subscription-Id
+// header layered on. Kept as a separate method so the signing
+// functions stay focused on signature math; the registry's deliver
+// path layers the routing header after signing.
 type signedDelivery struct {
 	headers map[string]string
 	body    []byte
+}
+
+// withSubscriptionID adds the X-MCP-Subscription-Id header carrying
+// the spec's derived subscription id (sub_<base64>). Receivers use
+// the header to pick the correct secret without parsing the body.
+func (d signedDelivery) withSubscriptionID(subID string) signedDelivery {
+	if subID == "" {
+		return d
+	}
+	hdrs := make(map[string]string, len(d.headers)+1)
+	for k, v := range d.headers {
+		hdrs[k] = v
+	}
+	hdrs["X-MCP-Subscription-Id"] = subID
+	return signedDelivery{headers: hdrs, body: d.body}
 }
 
 func (d signedDelivery) applyHeaders(req *http.Request) {

--- a/experimental/ext/events/headers_test.go
+++ b/experimental/ext/events/headers_test.go
@@ -131,6 +131,61 @@ func TestStandardWebhooks_WebhookIDIsStableAcrossRetries(t *testing.T) {
 		"signature regenerates per retry because timestamp is part of the signed input")
 }
 
+// TestStandardWebhooks_EmitsSubscriptionIDHeader verifies γ-4's spec
+// contract (§"Webhook Event Delivery" L390 + §"Webhook Security" →
+// "Signature scheme" L472): every delivery MUST include
+// X-MCP-Subscription-Id carrying the spec's derived subscription id
+// so the receiver can select the correct secret without parsing the
+// body.
+//
+// Without this header, a receiver hosting multiple subscriptions on a
+// single endpoint would have no way to pick the correct verification
+// secret — the body has eventId + name but not the subscription id.
+func TestStandardWebhooks_EmitsSubscriptionIDHeader(t *testing.T) {
+	body := []byte(`{"eventId":"evt_1","data":{}}`)
+	signed := signStandardWebhooks("evt_1", body, "whsec_test", time.Unix(1700000000, 0)).
+		withSubscriptionID("sub_abc123")
+
+	got, ok := signed.headers["X-MCP-Subscription-Id"]
+	require.True(t, ok, "X-MCP-Subscription-Id header MUST be present on every delivery")
+	assert.Equal(t, "sub_abc123", got)
+}
+
+// TestStandardWebhooks_SubscriptionIDStableAcrossRetries pairs with
+// TestStandardWebhooks_WebhookIDIsStableAcrossRetries (which verifies
+// webhook-id stability for receiver dedup). The X-MCP-Subscription-Id
+// must ALSO be stable across retries — same subscription, same routing
+// handle. If it changed per retry, a receiver tracking deliveries by
+// subscription would log spurious churn or worse, mis-route to a
+// non-existent subscription.
+func TestStandardWebhooks_SubscriptionIDStableAcrossRetries(t *testing.T) {
+	body := []byte(`{"eventId":"evt_42","data":{}}`)
+	subID := "sub_stable_test"
+
+	first := signStandardWebhooks("evt_42", body, "whsec_test", time.Unix(1700000000, 0)).
+		withSubscriptionID(subID)
+	second := signStandardWebhooks("evt_42", body, "whsec_test", time.Unix(1700000005, 0)).
+		withSubscriptionID(subID)
+
+	assert.Equal(t, first.headers["X-MCP-Subscription-Id"], second.headers["X-MCP-Subscription-Id"],
+		"X-MCP-Subscription-Id must be stable across retries of the same event")
+	assert.Equal(t, subID, first.headers["X-MCP-Subscription-Id"])
+}
+
+// TestStandardWebhooks_WithEmptySubscriptionIDIsNoOp verifies that
+// withSubscriptionID("") leaves the headers untouched. Defensive — the
+// registry's deliver path always passes target.ID (always set post-γ-2),
+// but the empty-string case shouldn't crash or add a misleading
+// "X-MCP-Subscription-Id: " header.
+func TestStandardWebhooks_WithEmptySubscriptionIDIsNoOp(t *testing.T) {
+	body := []byte(`{}`)
+	signed := signStandardWebhooks("evt_1", body, "whsec_test", time.Unix(1700000000, 0)).
+		withSubscriptionID("")
+
+	_, present := signed.headers["X-MCP-Subscription-Id"]
+	assert.False(t, present, "empty subscription id must not add the header at all")
+}
+
 // TestNewMessageID_Uniqueness verifies the helper produces distinct ids
 // across calls. Without this, replay-detection logic on receivers that
 // dedupe by webhook-id would silently break.

--- a/experimental/ext/events/identity.go
+++ b/experimental/ext/events/identity.go
@@ -1,0 +1,114 @@
+package events
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"sort"
+	"strings"
+)
+
+// canonicalKey returns the canonical-bytes encoding of a webhook subscription
+// identity tuple per spec §"Subscription Identity" → "Key composition" L363:
+//
+//	(principal, delivery.url, name, params)
+//
+// The four components are joined by 0x1f (US, unit separator); params is
+// canonicalized by lexicographically sorting keys and JSON-encoding the
+// resulting object so map iteration order doesn't affect the bytes.
+//
+// Two subscribe calls produce identical canonical bytes if and only if all
+// four components match — which is the spec's idempotency rule (§"Subscription
+// Identity" → "Key composition" L363: "There is no client-generated id —
+// a subscription is fully determined by what it listens for, where it
+// delivers, and who asked").
+//
+// principal is read from the authenticated session's claims.Subject by the
+// subscribe handler. For unauthenticated demos, the events.Config field
+// UnsafeAnonymousPrincipal stands in for the missing claims.Subject; this
+// is an explicit deviation from the spec's "MUST reject unauthenticated"
+// rule (L361) and is gated by the Unsafe-prefixed name + a startup warning
+// log on the server.
+func canonicalKey(principal, deliveryURL, name string, params map[string]any) []byte {
+	var paramBytes []byte
+	if len(params) == 0 {
+		paramBytes = []byte("{}")
+	} else {
+		paramBytes = canonicalJSON(params)
+	}
+	// 0x1f (Unit Separator) is non-printable and won't collide with any
+	// reasonable principal/url/name/params content. Joining with a
+	// printable character (e.g. ":") would let a crafted principal
+	// containing the separator merge into the next field.
+	const sep = "\x1f"
+	var b strings.Builder
+	b.Grow(len(principal) + len(deliveryURL) + len(name) + len(paramBytes) + 3)
+	b.WriteString(principal)
+	b.WriteString(sep)
+	b.WriteString(deliveryURL)
+	b.WriteString(sep)
+	b.WriteString(name)
+	b.WriteString(sep)
+	b.Write(paramBytes)
+	return []byte(b.String())
+}
+
+// canonicalJSON serializes a map[string]any with sorted top-level keys so
+// the byte output is stable regardless of map iteration order. Nested
+// maps and slices are JSON-marshaled with their natural ordering — this
+// is sufficient for the spec's "params is compared by canonical-JSON
+// equality" requirement (§"Subscription Identity" → "Key composition"
+// L363) because subscription params are flat key-value by convention;
+// servers that accept nested params should document the canonicalization
+// they apply.
+func canonicalJSON(m map[string]any) []byte {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	b.WriteByte('{')
+	for i, k := range keys {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		kJSON, _ := json.Marshal(k)
+		vJSON, _ := json.Marshal(m[k])
+		b.Write(kJSON)
+		b.WriteByte(':')
+		b.Write(vJSON)
+	}
+	b.WriteByte('}')
+	return []byte(b.String())
+}
+
+// deriveSubscriptionID returns a routing handle of the form
+// "sub_<base64-of-16-bytes>" derived from the canonical tuple bytes via
+// SHA-256 truncated to 128 bits. Surfaced on the wire as the
+// X-MCP-Subscription-Id header on every webhook delivery POST per
+// spec §"Webhook Event Delivery" L390 and §"Webhook Security" → "Signature
+// scheme" L472.
+//
+// Collision analysis:
+//
+//   - Birthday bound: ~2^64 subscriptions before 50% accidental collision.
+//     At 1T subs forever, P(collision) ≈ 5.4e-15 — effectively zero.
+//   - Engineered collision (find any colliding pair): ~2^64 hash evals,
+//     marginally feasible for a nation-state attacker over weeks/months.
+//   - Targeted preimage (collide with a specific victim tuple): ~2^128 work,
+//     infeasible for anyone.
+//
+// The id is intentionally non-load-bearing for security per spec
+// §"Subscription Identity" → "Cross-tenant isolation" L378: "A caller who
+// learns another tenant's derived id gains nothing — id is not accepted
+// as input to any method." Even a successful collision lets an attacker
+// only cause routing weirdness on the receiver side, where HMAC
+// verification with the wrong secret fails by construction.
+//
+// Truncation can be widened to 24 or 32 bytes if a deployment wants
+// extra headroom — change the slice bound below; no API change required.
+func deriveSubscriptionID(canonical []byte) string {
+	sum := sha256.Sum256(canonical)
+	return "sub_" + base64.RawURLEncoding.EncodeToString(sum[:16])
+}

--- a/experimental/ext/events/identity_handler_test.go
+++ b/experimental/ext/events/identity_handler_test.go
@@ -150,6 +150,25 @@ func TestSubscribe_TupleIsolationCrossPrincipal(t *testing.T) {
 	assert.Equal(t, idBob, targets[0].ID, "unregister(alice's tuple) must not affect bob's subscription")
 }
 
+// TestSubscribe_RejectsClientSuppliedID verifies γ-3's wire-strict
+// rejection of legacy id-bearing subscribe requests. Per spec
+// §"Subscription Identity" → "Key composition" L363: "There is no
+// client-generated id — a subscription is fully determined by what it
+// listens for, where it delivers, and who asked." Old SDKs sending an
+// id field get a loud -32602 instead of a silent mis-keying that
+// would route deliveries under the wrong subscription.
+func TestSubscribe_RejectsClientSuppliedID(t *testing.T) {
+	srv, _ := buildAuthGateStack(t, "test-principal")
+	params := validSubscribeParams()
+	params["id"] = "client-picked-id" // pre-γ wire shape
+
+	resp := dispatchSubscribe(t, srv, params)
+	require.NotNil(t, resp.Error, "client-supplied id must be rejected")
+	assert.Equal(t, core.ErrCodeInvalidParams, resp.Error.Code, "expected -32602 InvalidParams")
+	assert.Contains(t, resp.Error.Message, "id is not accepted",
+		"error message should explain why; got %q", resp.Error.Message)
+}
+
 // TestUnsubscribe_ByTuple verifies the spec's unsubscribe-by-tuple
 // behavior (§"Unsubscribing: events/unsubscribe" L509): client supplies
 // (name, params, delivery.url); server resolves via canonical key,

--- a/experimental/ext/events/identity_handler_test.go
+++ b/experimental/ext/events/identity_handler_test.go
@@ -1,0 +1,190 @@
+package events
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Handler-level tests for γ-2's auth gate + tuple-keyed registry. Tests
+// here build a server WITHOUT UnsafeAnonymousPrincipal so they exercise
+// the spec-strict path-3 rejection. The shared fixture in
+// secret_validation_test.go uses UnsafeAnonymousPrincipal: "test-principal"
+// for tests that aren't concerned with the auth gate; this file's tests
+// build their own minimal stack so they can vary the auth posture.
+
+// buildAuthGateStack returns a server with the events handlers registered
+// + a reference to the registry so tests can inspect target state.
+// unsafeAnon controls whether the strict spec auth gate fires:
+//   - "" → strict (§"Subscription Identity" → "Authentication required" L361)
+//   - non-empty → escape hatch (events.Config.UnsafeAnonymousPrincipal docs)
+func buildAuthGateStack(t *testing.T, unsafeAnon string) (*server.Server, *WebhookRegistry) {
+	t.Helper()
+	srv := server.NewServer(core.ServerInfo{Name: "test", Version: "1.0"})
+	webhooks := NewWebhookRegistry()
+	Register(Config{
+		Sources:                  []EventSource{fakeSecretValidationSource{}},
+		Webhooks:                 webhooks,
+		Server:                   srv,
+		UnsafeAnonymousPrincipal: unsafeAnon,
+	})
+	initParams := json.RawMessage(`{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)
+	resp, err := srv.Dispatch(context.Background(), &core.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`0`), Method: "initialize", Params: initParams,
+	})
+	require.NoError(t, err)
+	require.Nil(t, resp.Error)
+	_, err = srv.Dispatch(context.Background(), &core.Request{
+		JSONRPC: "2.0", Method: "notifications/initialized",
+	})
+	require.NoError(t, err)
+	return srv, webhooks
+}
+
+func dispatchSubscribe(t *testing.T, srv *server.Server, params map[string]any) *core.Response {
+	t.Helper()
+	raw, err := json.Marshal(params)
+	require.NoError(t, err)
+	resp, err := srv.Dispatch(context.Background(), &core.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "events/subscribe", Params: raw,
+	})
+	require.NoError(t, err)
+	return resp
+}
+
+// validSubscribeParams returns a well-formed subscribe request body that
+// will pass all validation EXCEPT the auth gate. Use to factor out the
+// boilerplate from auth-focused tests.
+func validSubscribeParams() map[string]any {
+	return map[string]any{
+		"name": "fake.event",
+		"delivery": map[string]any{
+			"mode":   "webhook",
+			"url":    "https://example.com/hook",
+			"secret": generateSecret(),
+		},
+	}
+}
+
+// TestSubscribe_RejectsAnonymousUnderStrictSpec verifies the spec-strict
+// path: when the server has no auth wired AND no UnsafeAnonymousPrincipal
+// configured, anonymous webhook subscribes are rejected with -32012
+// per §"Subscription Identity" → "Authentication required" L361.
+//
+// Without this rejection, a misconfigured deployment would silently
+// accept anonymous subscribes — the failure mode the spec is preventing.
+func TestSubscribe_RejectsAnonymousUnderStrictSpec(t *testing.T) {
+	srv, _ := buildAuthGateStack(t, "")
+	resp := dispatchSubscribe(t, srv, validSubscribeParams())
+
+	require.NotNil(t, resp.Error, "expected -32012; got success result")
+	assert.Equal(t, ErrCodeUnauthorized, resp.Error.Code,
+		"spec-mandated -32012 Unauthorized for anonymous webhook subscribe")
+}
+
+// TestSubscribe_AcceptsAnonymousWithEscape verifies the demo escape
+// hatch: when UnsafeAnonymousPrincipal is set, anonymous calls succeed
+// using the configured principal as claims.Subject's stand-in.
+func TestSubscribe_AcceptsAnonymousWithEscape(t *testing.T) {
+	srv, _ := buildAuthGateStack(t, "test-principal")
+	resp := dispatchSubscribe(t, srv, validSubscribeParams())
+
+	require.Nil(t, resp.Error,
+		"with UnsafeAnonymousPrincipal set, anonymous subscribes must succeed; got %+v", resp.Error)
+	require.NotNil(t, resp.Result)
+}
+
+// TestSubscribe_TupleIdempotence verifies the spec's idempotent-subscribe
+// rule (§"Subscription Identity" → "Key composition" L363): two subscribe
+// calls with identical (name, params, delivery.url) AND same principal
+// are the SAME subscription — the second is a TTL refresh, not a new
+// registry entry.
+func TestSubscribe_TupleIdempotence(t *testing.T) {
+	srv, webhooks := buildAuthGateStack(t, "test-principal")
+
+	params := validSubscribeParams()
+	resp1 := dispatchSubscribe(t, srv, params)
+	require.Nil(t, resp1.Error)
+	resp2 := dispatchSubscribe(t, srv, params)
+	require.Nil(t, resp2.Error)
+
+	// Same canonical key → same registry entry → exactly one target.
+	assert.Len(t, webhooks.Targets(), 1, "two subscribes with same tuple must produce ONE registry entry (idempotent refresh)")
+
+	// Both responses carry the SAME server-derived id.
+	id1 := extractIDField(t, resp1)
+	id2 := extractIDField(t, resp2)
+	assert.Equal(t, id1, id2, "both subscribes must derive the same id (deterministic over canonical key)")
+}
+
+// TestSubscribe_TupleIsolationCrossPrincipal verifies the spec's
+// cross-tenant isolation property (§"Subscription Identity" L378): two
+// subscribes with same (name, params, delivery.url) but DIFFERENT
+// principals are DIFFERENT subscriptions. We can't easily set different
+// principals on Dispatch (no auth middleware in test fixture), so this
+// test exercises the property at the canonical-key level instead —
+// which is what the registry compares.
+func TestSubscribe_TupleIsolationCrossPrincipal(t *testing.T) {
+	webhooks := NewWebhookRegistry()
+	keyAlice := canonicalKey("alice", "https://example.com/hook", "fake.event", nil)
+	keyBob := canonicalKey("bob", "https://example.com/hook", "fake.event", nil)
+	idAlice := deriveSubscriptionID(keyAlice)
+	idBob := deriveSubscriptionID(keyBob)
+
+	// Same URL, name, params; different principal → distinct registry entries.
+	webhooks.Register(keyAlice, idAlice, "https://example.com/hook", "whsec_a")
+	webhooks.Register(keyBob, idBob, "https://example.com/hook", "whsec_b")
+
+	assert.Len(t, webhooks.Targets(), 2, "different principals must produce distinct registry entries")
+	assert.NotEqual(t, idAlice, idBob, "different canonical keys must derive different ids")
+
+	// Unregistering alice's tuple leaves bob's intact (no cross-tenant collateral).
+	webhooks.Unregister(keyAlice)
+	targets := webhooks.Targets()
+	require.Len(t, targets, 1)
+	assert.Equal(t, idBob, targets[0].ID, "unregister(alice's tuple) must not affect bob's subscription")
+}
+
+// TestUnsubscribe_ByTuple verifies the spec's unsubscribe-by-tuple
+// behavior (§"Unsubscribing: events/unsubscribe" L509): client supplies
+// (name, params, delivery.url); server resolves via canonical key,
+// removes the entry. No id required in the request.
+func TestUnsubscribe_ByTuple(t *testing.T) {
+	srv, webhooks := buildAuthGateStack(t, "test-principal")
+
+	subParams := validSubscribeParams()
+	subResp := dispatchSubscribe(t, srv, subParams)
+	require.Nil(t, subResp.Error)
+	require.Len(t, webhooks.Targets(), 1)
+
+	// Unsubscribe with the same (name, delivery.url) — no id field.
+	unsubParams := map[string]any{
+		"name":     subParams["name"],
+		"delivery": map[string]any{"url": subParams["delivery"].(map[string]any)["url"]},
+	}
+	rawUnsub, err := json.Marshal(unsubParams)
+	require.NoError(t, err)
+	unsubResp, err := srv.Dispatch(context.Background(), &core.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`2`), Method: "events/unsubscribe", Params: rawUnsub,
+	})
+	require.NoError(t, err)
+	require.Nil(t, unsubResp.Error)
+	assert.Empty(t, webhooks.Targets(), "tuple-form unsubscribe must remove the matching entry")
+}
+
+// --- helpers ---
+
+// extractIDField reads the "id" field from a Response.Result map.
+func extractIDField(t *testing.T, resp *core.Response) string {
+	t.Helper()
+	m, ok := resp.Result.(map[string]any)
+	require.True(t, ok, "response.Result must be map[string]any; got %T", resp.Result)
+	id, ok := m["id"].(string)
+	require.True(t, ok, "response.Result[\"id\"] must be string; got %T", m["id"])
+	return id
+}

--- a/experimental/ext/events/identity_handler_test.go
+++ b/experimental/ext/events/identity_handler_test.go
@@ -3,7 +3,11 @@ package events
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/panyam/mcpkit/core"
 	"github.com/panyam/mcpkit/server"
@@ -194,6 +198,47 @@ func TestUnsubscribe_ByTuple(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, unsubResp.Error)
 	assert.Empty(t, webhooks.Targets(), "tuple-form unsubscribe must remove the matching entry")
+}
+
+// TestDelivery_EmitsXMCPSubscriptionIDHeader verifies γ-4's end-to-end
+// header wiring: a real subscribe → yield → POST round-trip carries
+// the X-MCP-Subscription-Id header on the outbound delivery, and the
+// header value matches the server-derived id returned in the subscribe
+// response. Per spec §"Webhook Event Delivery" L390 + §"Webhook
+// Security" L472.
+//
+// Without this test, a regression in the deliver path could drop the
+// header silently — receivers on shared callback URLs would still
+// process the body but would have no way to pick the right secret.
+func TestDelivery_EmitsXMCPSubscriptionIDHeader(t *testing.T) {
+	// Spin up a callback server that captures inbound headers, then
+	// build an events stack pointing at it. Use the public Register
+	// + canonicalKey path (not srv.Dispatch) since we need a real
+	// HTTP delivery to inspect the on-wire headers.
+	gotHeader := make(chan string, 1)
+	callback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeader <- r.Header.Get("X-MCP-Subscription-Id")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer callback.Close()
+
+	webhooks := NewWebhookRegistry()
+	canonical := canonicalKey("test-principal", callback.URL, "fake.event", nil)
+	subID := deriveSubscriptionID(canonical)
+	webhooks.Register(canonical, subID, callback.URL, "whsec_"+strings.Repeat("a", 32))
+
+	// Direct Deliver bypasses the JSON-RPC handler — what we want to
+	// inspect is the registry's outbound HTTP shape, not the subscribe
+	// flow (covered by other tests).
+	webhooks.Deliver(Event{EventID: "evt_1", Name: "fake.event", Data: json.RawMessage(`{}`)})
+
+	select {
+	case got := <-gotHeader:
+		assert.Equal(t, subID, got, "X-MCP-Subscription-Id MUST equal the derived subscription id")
+		assert.True(t, strings.HasPrefix(got, "sub_"), "header value must be the spec-shaped sub_<base64>; got %q", got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for delivery POST — was the header dropped?")
+	}
 }
 
 // --- helpers ---

--- a/experimental/ext/events/identity_test.go
+++ b/experimental/ext/events/identity_test.go
@@ -1,0 +1,161 @@
+package events
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCanonicalKey_DeterministicForSameInputs pins the foundational
+// idempotency property: two subscribe calls with identical
+// (principal, url, name, params) MUST produce identical canonical bytes
+// — that's how the registry knows "this is the same subscription, refresh
+// it" instead of creating a duplicate. (§"Subscription Identity" →
+// "Key composition" L363).
+func TestCanonicalKey_DeterministicForSameInputs(t *testing.T) {
+	a := canonicalKey("alice", "https://example.com/hook", "incident.created",
+		map[string]any{"severity": "P1", "service": "api"})
+	b := canonicalKey("alice", "https://example.com/hook", "incident.created",
+		map[string]any{"severity": "P1", "service": "api"})
+	assert.Equal(t, a, b, "same inputs MUST produce identical canonical bytes — idempotency depends on it")
+}
+
+// TestCanonicalKey_ParamMapOrderInvariant verifies the canonical-JSON
+// requirement (L363 "params is compared by canonical-JSON equality"):
+// param map iteration order must NOT affect the bytes. Without this,
+// the same subscribe call could non-deterministically derive different
+// ids across runs.
+func TestCanonicalKey_ParamMapOrderInvariant(t *testing.T) {
+	// Two maps with same content but Go's map randomization could
+	// iterate them differently on each call. The canonical encoder
+	// must sort the keys.
+	a := canonicalKey("alice", "u", "n", map[string]any{
+		"a": "1", "b": "2", "c": "3", "d": "4", "e": "5",
+	})
+	b := canonicalKey("alice", "u", "n", map[string]any{
+		"e": "5", "d": "4", "c": "3", "b": "2", "a": "1",
+	})
+	assert.Equal(t, a, b, "param map order must not affect canonical bytes")
+}
+
+// TestCanonicalKey_DifferentPrincipalDifferentKey is the spec's
+// cross-tenant isolation property in test form (§"Subscription Identity" →
+// "Cross-tenant isolation" L378): two distinct tenants subscribing to the
+// same (name, params, url) MUST get distinct subscriptions. Without
+// principal in the key the tuple would be guessable across tenants.
+func TestCanonicalKey_DifferentPrincipalDifferentKey(t *testing.T) {
+	alice := canonicalKey("alice", "u", "n", map[string]any{"x": "1"})
+	bob := canonicalKey("bob", "u", "n", map[string]any{"x": "1"})
+	assert.NotEqual(t, alice, bob, "different principals must canonicalize to different keys (cross-tenant isolation)")
+}
+
+// TestCanonicalKey_DifferentURLDifferentKey verifies subs to different
+// callback URLs (e.g., one tenant's proxy vs another's) get distinct
+// canonical bytes even with same (principal, name, params).
+func TestCanonicalKey_DifferentURLDifferentKey(t *testing.T) {
+	a := canonicalKey("alice", "https://a.example.com/hook", "n", nil)
+	b := canonicalKey("alice", "https://b.example.com/hook", "n", nil)
+	assert.NotEqual(t, a, b)
+}
+
+// TestCanonicalKey_DifferentNameDifferentKey — pretty obvious but
+// pinning prevents accidental loss in any future refactor.
+func TestCanonicalKey_DifferentNameDifferentKey(t *testing.T) {
+	a := canonicalKey("alice", "u", "incident.created", nil)
+	b := canonicalKey("alice", "u", "incident.resolved", nil)
+	assert.NotEqual(t, a, b)
+}
+
+// TestCanonicalKey_DifferentParamsDifferentKey verifies any change in
+// params changes the canonical bytes — even one field flip.
+func TestCanonicalKey_DifferentParamsDifferentKey(t *testing.T) {
+	a := canonicalKey("alice", "u", "n", map[string]any{"region": "us"})
+	b := canonicalKey("alice", "u", "n", map[string]any{"region": "eu"})
+	assert.NotEqual(t, a, b)
+}
+
+// TestCanonicalKey_NilAndEmptyParamsEquivalent verifies the corner case
+// that callers passing nil and callers passing an empty map get the
+// same canonical bytes. Otherwise some clients would derive different
+// ids based on whether they sent `params: {}` vs omitted the field.
+func TestCanonicalKey_NilAndEmptyParamsEquivalent(t *testing.T) {
+	withNil := canonicalKey("alice", "u", "n", nil)
+	withEmpty := canonicalKey("alice", "u", "n", map[string]any{})
+	assert.Equal(t, withNil, withEmpty, "nil and empty params must canonicalize identically")
+}
+
+// TestCanonicalKey_FieldsAreSeparated checks that a crafted principal
+// containing a value that LOOKS like a URL doesn't merge into the URL
+// field via concatenation. This is why we use 0x1f (Unit Separator) as
+// the joiner — it's non-printable and won't appear in any reasonable
+// principal/url/name/params content.
+func TestCanonicalKey_FieldsAreSeparated(t *testing.T) {
+	// "alice" + sep + "u" + sep + "n" + sep + "{}"  vs
+	// "alice" + sep + "u" + sep + "n" + sep + "{}"  with a crafted
+	// principal that tries to inject a separator-like character.
+	// If the joiner were ":" then principal="alice:https://evil.com"
+	// could collide with principal="alice", url="https://evil.com".
+	// Using 0x1f makes that impossible because 0x1f doesn't render
+	// or get accepted in OAuth subject claims.
+	normal := canonicalKey("alice", "https://victim.example/hook", "n", nil)
+	crafted := canonicalKey("alice:https://victim.example/hook", "alt-url", "n", nil)
+	assert.NotEqual(t, normal, crafted, "field separator must prevent injection of canonical-key fields via principal content")
+}
+
+// TestDeriveSubscriptionID_DeterministicAndFormatted pins the routing-id
+// derivation: stable for fixed canonical bytes, "sub_" prefix for
+// recognizability in logs / headers.
+func TestDeriveSubscriptionID_DeterministicAndFormatted(t *testing.T) {
+	canonical := canonicalKey("alice", "u", "n", map[string]any{"x": "1"})
+	id1 := deriveSubscriptionID(canonical)
+	id2 := deriveSubscriptionID(canonical)
+	assert.Equal(t, id1, id2, "derivation must be stable for the same canonical bytes")
+	assert.True(t, strings.HasPrefix(id1, "sub_"), "id must start with sub_ prefix; got %q", id1)
+}
+
+// TestDeriveSubscriptionID_DifferentInputsDifferentID checks that the
+// hash function actually differentiates different canonical-byte inputs.
+// Sanity check that we're not using a constant.
+func TestDeriveSubscriptionID_DifferentInputsDifferentID(t *testing.T) {
+	a := deriveSubscriptionID(canonicalKey("alice", "u", "n", nil))
+	b := deriveSubscriptionID(canonicalKey("bob", "u", "n", nil))
+	assert.NotEqual(t, a, b)
+}
+
+// TestDeriveSubscriptionID_ReasonableLength checks the routing handle
+// stays in a reasonable size range for a header value. 16 bytes
+// base64-encoded with raw-url encoding is 22 chars; with the "sub_"
+// prefix the total is 26.
+func TestDeriveSubscriptionID_ReasonableLength(t *testing.T) {
+	id := deriveSubscriptionID(canonicalKey("alice", "u", "n", nil))
+	assert.Equal(t, 26, len(id), "expected sub_ + 22-char base64 of 16 bytes; got %d-char id %q", len(id), id)
+}
+
+// TestCanonicalKey_NoCollisionForKnownInputs is a smoke test against
+// accidental collisions among a small set of plausible inputs. With
+// 128-bit truncation the birthday bound is ~2^64 — at this small scale
+// no collisions are expected, and any collision here would be a coding
+// regression in canonicalKey or deriveSubscriptionID.
+func TestCanonicalKey_NoCollisionForKnownInputs(t *testing.T) {
+	inputs := []struct {
+		principal, url, name string
+		params               map[string]any
+	}{
+		{"alice", "https://a.com/hook", "incident.created", map[string]any{"severity": "P1"}},
+		{"alice", "https://a.com/hook", "incident.created", map[string]any{"severity": "P2"}},
+		{"alice", "https://a.com/hook", "incident.resolved", map[string]any{"severity": "P1"}},
+		{"alice", "https://b.com/hook", "incident.created", map[string]any{"severity": "P1"}},
+		{"bob", "https://a.com/hook", "incident.created", map[string]any{"severity": "P1"}},
+		{"alice", "https://a.com/hook", "incident.created", nil},
+	}
+	seen := make(map[string]int, len(inputs))
+	for i, in := range inputs {
+		id := deriveSubscriptionID(canonicalKey(in.principal, in.url, in.name, in.params))
+		if prev, dup := seen[id]; dup {
+			t.Errorf("collision: input %d (%+v) and input %d (%+v) both derive %s",
+				prev, inputs[prev], i, in, id)
+		}
+		seen[id] = i
+	}
+}

--- a/experimental/ext/events/secret_validation_test.go
+++ b/experimental/ext/events/secret_validation_test.go
@@ -107,7 +107,6 @@ func TestValidateClientSecret_AcceptsBothBase64Variants(t *testing.T) {
 // is REQUIRED — there is no server-side fallback.
 func TestSubscribe_RejectsMissingSecret(t *testing.T) {
 	resp := callSubscribeHandler(t, map[string]any{
-		"id":   "test",
 		"name": "fake.event",
 		"delivery": map[string]any{
 			"mode": "webhook",
@@ -132,7 +131,6 @@ func TestSubscribe_RejectsMalformedSecret(t *testing.T) {
 	for _, s := range bad {
 		t.Run(s, func(t *testing.T) {
 			resp := callSubscribeHandler(t, map[string]any{
-				"id":   "test",
 				"name": "fake.event",
 				"delivery": map[string]any{
 					"mode":   "webhook",
@@ -151,7 +149,6 @@ func TestSubscribe_RejectsMalformedSecret(t *testing.T) {
 // reject conformant inputs.
 func TestSubscribe_AcceptsValidWhsecSecret(t *testing.T) {
 	resp := callSubscribeHandler(t, map[string]any{
-		"id":   "test",
 		"name": "fake.event",
 		"delivery": map[string]any{
 			"mode":   "webhook",
@@ -171,7 +168,6 @@ func TestSubscribe_AcceptsValidWhsecSecret(t *testing.T) {
 func TestSubscribe_ResponseDoesNotEchoSecret(t *testing.T) {
 	supplied := generateSecret()
 	resp := callSubscribeHandler(t, map[string]any{
-		"id":   "test",
 		"name": "fake.event",
 		"delivery": map[string]any{
 			"mode":   "webhook",

--- a/experimental/ext/events/secret_validation_test.go
+++ b/experimental/ext/events/secret_validation_test.go
@@ -190,19 +190,22 @@ func TestSubscribe_ResponseDoesNotEchoSecret(t *testing.T) {
 	assert.NotContains(t, body, supplied, "subscribe response must not echo the client-supplied secret value")
 }
 
-// TestUnsubscribe_RejectsSecretForm verifies the handler no longer
-// accepts the legacy "unsubscribe by presenting the secret" path that
-// existed before β. Spec keys unsubscribe on the (principal, name,
-// params, url) tuple (γ implements full tuple); β narrows to id-only.
-func TestUnsubscribe_RejectsSecretForm(t *testing.T) {
+// TestUnsubscribe_RequiresTupleNotSecret verifies the handler ignores
+// the legacy proof-of-possession secret-form unsubscribe — γ keys
+// unsubscribe on the (principal, name, params, delivery.url) tuple
+// per spec §"Unsubscribing: events/unsubscribe" L509. A request that
+// supplies only delivery.url + delivery.secret (no name) is rejected
+// with name-required because the secret field is no longer part of the
+// unsubscribe surface.
+func TestUnsubscribe_RequiresTupleNotSecret(t *testing.T) {
 	resp := callUnsubscribeHandler(t, map[string]any{
-		// id intentionally omitted
+		// name intentionally omitted; secret would have worked pre-β
 		"delivery": map[string]any{
 			"url":    "https://example.com/hook",
 			"secret": "whsec_should-not-be-accepted-here",
 		},
 	})
-	requireRPCError(t, resp, core.ErrCodeInvalidParams, "id")
+	requireRPCError(t, resp, core.ErrCodeInvalidParams, "name")
 }
 
 // --- handler-invocation helpers (private to test file) ---
@@ -219,15 +222,21 @@ func (fakeSecretValidationSource) Poll(_ string, _ int) PollResult { return Poll
 func (fakeSecretValidationSource) Latest() string                  { return "" }
 
 // buildSecretValidationStack returns a server with the events handlers
-// registered AND an initialize handshake completed so subsequent
+// registered (with UnsafeAnonymousPrincipal: "test-principal" so the
+// handlers don't reject every test request with -32012 Unauthorized —
+// γ adds spec-mandated auth gating, but the secret-validation tests
+// here are concerned with the validator and unsubscribe shape, not
+// the auth gate. Auth-specific tests live in identity_handler_test.go
+// (γ-2 follow-on).) The initialize handshake is completed so subsequent
 // Dispatch calls accept arbitrary methods.
 func buildSecretValidationStack(t *testing.T) *server.Server {
 	t.Helper()
 	srv := server.NewServer(core.ServerInfo{Name: "test", Version: "1.0"})
 	Register(Config{
-		Sources:  []EventSource{fakeSecretValidationSource{}},
-		Webhooks: NewWebhookRegistry(),
-		Server:   srv,
+		Sources:                  []EventSource{fakeSecretValidationSource{}},
+		Webhooks:                 NewWebhookRegistry(),
+		Server:                   srv,
+		UnsafeAnonymousPrincipal: "test-principal",
 	})
 	// Two-step init handshake — the dispatcher rejects non-init methods
 	// until BOTH (a) the initialize request returns and (b) the client

--- a/experimental/ext/events/webhook.go
+++ b/experimental/ext/events/webhook.go
@@ -221,7 +221,14 @@ func (r *WebhookRegistry) deliver(target WebhookTarget, eventID string, body []b
 		// (so receiver dedup works) and consistent across delivery paths
 		// (webhook emit + poll backfill of the same upstream event collapse
 		// under the receiver's eventId-keyed dedup).
-		signed := signFor(r.headerMode, eventID, body, target.Secret, time.Now())
+		//
+		// X-MCP-Subscription-Id carries target.ID (γ-2's derived id over
+		// the canonical tuple) so the receiver can select the correct
+		// secret without parsing the body. Per spec §"Webhook Event
+		// Delivery" L390 + §"Webhook Security" L472: this is the only
+		// MCP-specific header on a Standard Webhooks delivery.
+		signed := signFor(r.headerMode, eventID, body, target.Secret, time.Now()).
+			withSubscriptionID(target.ID)
 
 		req, err := http.NewRequest("POST", target.URL, bytes.NewReader(signed.body))
 		if err != nil {

--- a/experimental/ext/events/webhook.go
+++ b/experimental/ext/events/webhook.go
@@ -40,17 +40,19 @@ func WithWebhookHeaderMode(mode WebhookHeaderMode) WebhookOption {
 }
 
 // WebhookTarget is a registered outbound webhook callback with TTL-based expiry.
+//
+// The CanonicalKey is the spec's identity tuple bytes
+// (§"Subscription Identity" → "Key composition" L363) and serves as the
+// registry's primary key. The ID is the spec's derived routing handle
+// (§"Subscription Identity" → "Derived id" L367), surfaced on the wire
+// as the X-MCP-Subscription-Id header on every delivery POST per
+// §"Webhook Event Delivery" L390.
 type WebhookTarget struct {
-	ID        string // client-provided subscription ID
-	URL       string
-	Secret    string
-	ExpiresAt time.Time
-}
-
-// webhookKey returns the composite key for a webhook subscription per spec:
-// (delivery.url, id) for unauthenticated servers.
-func webhookKey(urlStr, id string) string {
-	return urlStr + "\x00" + id
+	CanonicalKey []byte    // canonical bytes of (principal, url, name, params)
+	ID           string    // server-derived routing handle (sub_<base64-of-16-bytes>)
+	URL          string    // delivery callback URL
+	Secret       string    // client-supplied HMAC signing secret (whsec_...)
+	ExpiresAt    time.Time // soft-state TTL expiry
 }
 
 // WebhookRegistry tracks outbound webhook subscriptions and delivers events
@@ -60,9 +62,15 @@ func webhookKey(urlStr, id string) string {
 // The HMAC signing secret is always client-supplied per the spec; the
 // registry stores it as-is on Register and uses it directly when signing
 // outbound deliveries.
+//
+// The registry is keyed on the spec's canonical-tuple bytes
+// (§"Subscription Identity" L363) — two subscribes with the same
+// canonical key (same principal, url, name, params) refer to the same
+// subscription. Cross-tenant isolation is by construction since
+// principal is part of the key.
 type WebhookRegistry struct {
 	mu         sync.RWMutex
-	targets    map[string]WebhookTarget // keyed by webhookKey(url, id)
+	targets    map[string]WebhookTarget // keyed by string(canonicalKey)
 	client     *http.Client
 	ttl        time.Duration
 	headerMode WebhookHeaderMode
@@ -84,31 +92,50 @@ func NewWebhookRegistry(opts ...WebhookOption) *WebhookRegistry {
 	return r
 }
 
-// Register adds or refreshes a webhook subscription. Returns the expiry time.
-func (r *WebhookRegistry) Register(id, urlStr, secret string) time.Time {
+// Register adds or refreshes a webhook subscription keyed on the spec's
+// canonical tuple (§"Subscription Identity" → "Key composition" L363).
+// Two calls with the same canonicalKey refer to the same subscription
+// — second call refreshes TTL + replaces secret. Returns the expiry time.
+//
+// The derivedID is the X-MCP-Subscription-Id value the registry emits
+// on every delivery POST; it MUST be deriveSubscriptionID(canonicalKey)
+// from identity.go. Passed in (rather than computed here) so the
+// caller can derive once and reuse for both Register and the
+// subscribe-response body.
+func (r *WebhookRegistry) Register(canonicalKey []byte, derivedID, urlStr, secret string) time.Time {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.pruneExpiredLocked()
 	expiresAt := time.Now().Add(r.ttl)
-	key := webhookKey(urlStr, id)
+	key := string(canonicalKey)
 	if existing, ok := r.targets[key]; ok {
-		// Refresh: update expiry and secret if provided
+		// Refresh: update expiry and secret if provided. Secret rotation
+		// per spec is allowed by supplying a new value on refresh.
 		existing.ExpiresAt = expiresAt
 		if secret != "" {
 			existing.Secret = secret
 		}
 		r.targets[key] = existing
 	} else {
-		r.targets[key] = WebhookTarget{ID: id, URL: urlStr, Secret: secret, ExpiresAt: expiresAt}
+		r.targets[key] = WebhookTarget{
+			CanonicalKey: canonicalKey,
+			ID:           derivedID,
+			URL:          urlStr,
+			Secret:       secret,
+			ExpiresAt:    expiresAt,
+		}
 	}
 	return expiresAt
 }
 
-// Unregister removes a webhook subscription by (url, id).
-func (r *WebhookRegistry) Unregister(urlStr, id string) {
+// Unregister removes a webhook subscription by canonical-tuple key.
+// No-op if no entry matches. Per spec §"Unsubscribing: events/unsubscribe"
+// L509, the derived id is not accepted as input — callers resolve via
+// the same canonical tuple they would for a subscribe.
+func (r *WebhookRegistry) Unregister(canonicalKey []byte) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	delete(r.targets, webhookKey(urlStr, id))
+	delete(r.targets, string(canonicalKey))
 }
 
 // Targets returns a snapshot of all non-expired webhook targets.


### PR DESCRIPTION
## Summary

PR group **γ** of the events spec alignment phase 2 plan (#349) — auth gate + tuple subscription identity per spec §"Subscription Identity" L357-378.

The largest behavioral change in the alignment plan. Webhook subscribe and unsubscribe are now keyed on the spec's canonical tuple `(principal, delivery.url, name, params)`; client-supplied `id` is rejected; server derives `id` deterministically over the tuple via SHA-256 truncated to 128 bits; `X-MCP-Subscription-Id` header on every delivery POST.

Six commits (the planned 5 + a small upfront umbrella-doc citation pass), each green at HEAD.

## Wire-shape changes

### `events/subscribe` request

- **`id` field rejected** with `-32602 InvalidParams: client-supplied id is not accepted; server derives id over (principal, name, params, url) per spec`. Per spec §"Subscription Identity" → "Key composition" L363: "There is no client-generated id."
- **`name`, `params`, `delivery.{mode,url,secret}`, `cursor`** — same as before.
- **Auth required**: missing `claims` returns `-32012 Unauthorized` per L361.

### `events/subscribe` response

- **`id` is now the server-derived `sub_<base64-of-16-bytes>`** per L367, not the client-supplied value.
- `cursor`, `refreshBefore` — same as before.

### `events/unsubscribe` request

- **Tuple form only**: `(name, params, delivery.url)` + auth → server resolves via canonical key. Per L509: "The derived id is not accepted as input."
- The id-form (`{id, delivery.url}`) and the secret-form (proof-of-possession) are gone.

### Webhook delivery

- **`X-MCP-Subscription-Id` header** on every POST per L390 + L472. Routing handle for receivers — local to whoever holds the matching secret, not a global registry. Like an HTTP cookie, not a URL path.

## Hybrid auth design (the demo escape hatch)

The spec mandates "MUST reject unauthenticated calls with -32012" (L361). Demos run anonymous today; enforcing the spec strictly would require every demo to stand up an OAuth provider just to run `make demo`.

**Solution: auto-detect at runtime.** If real auth is wired (`OAUTH_ISSUER` env var → `server.WithAuth(JWTValidator)`), follow spec strictly. If not, fall back to a demo-only `events.Config.UnsafeAnonymousPrincipal` knob with explicit `Unsafe` naming and a startup warning log.

```go
// New field on events.Config
type Config struct {
    Sources                  []EventSource
    Webhooks                 *WebhookRegistry
    Server                   *server.Server
    UnsafeAnonymousPrincipal string  // demo-only; empty = strict spec
}
```

3-path principal resolution in the handler:

```go
// Path 1 — claims != nil → claims.Subject       (spec-correct, real auth)
// Path 2 — claims == nil but unsafeAnon != ""   (demo escape hatch)
// Path 3 — claims == nil and unsafeAnon == ""   → -32012 Unauthorized (spec strict)
```

Production deployments wire `server.WithAuth(...)` and leave `UnsafeAnonymousPrincipal` empty. Demos auto-detect via env var. Server logs which posture is active at startup.

## Composition note (the WG-relevant takeaway)

**`ext/events` has zero compile-time dependency on `ext/auth`.** It depends on `core.Claims` (the abstract auth contract). Any auth provider populating Claims works:

```
ext/events  ──→  core.Claims (the abstract contract)
                       ↑
ext/auth    ──→  populates Claims via JWT/OIDC validation
                       ↑
your code   ──→  server.WithAuth(your favorite validator)
```

`grep "ext/auth" experimental/ext/events/` returns 0 matches in non-test code. The Go compiler enforces it.

This is the right shape for MCP extensions — extensions depend on stable core abstractions, not on each other. Spec correctly defers auth to MCP's general auth surface; our impl follows that.

## Commits

| # | Commit | Theme |
|---|---|---|
| 0 | `844522a` | umbrella plan citation pass — adds inline spec citations `(§"Section" L<line>)` to all γ-η delta lists |
| 1 | `d4f7ba8` | γ-1 — `canonicalKey` + `deriveSubscriptionID` helpers + 12 unit tests |
| 2 | `1540536` | γ-2 — auth gate + tuple-keyed registry + `UnsafeAnonymousPrincipal` escape hatch + 5 handler-level tests |
| 3 | `8fd18de` | γ-3 — drop client-supplied `id` from subscribe wire (server + Go SDK + Python SDK + demos) + 1 new validation step |
| 4 | `2ccd5d3` | γ-4 — `X-MCP-Subscription-Id` header on every delivery POST + 4 tests |
| 5 | `7906f7a` | γ-5 — demo `OAUTH_ISSUER` auto-detect + READMEs + DEPLOYMENT updates + composition docs |

## Tests

**+22 new tests** across the package:
- 12 in `identity_test.go` — canonicalKey + deriveSubscriptionID property tests (idempotency, isolation, separator-injection guard, hash determinism, length, smoke-no-collision)
- 5 in `identity_handler_test.go` — auth gate path-1/2/3, tuple isolation, tuple-form unsubscribe, client-id rejection, X-MCP-Subscription-Id header end-to-end
- 4 in `headers_test.go` — header presence, retry stability, empty-id no-op
- 1 cross-cutting end-to-end via real HTTP callback

**0 weakened assertions.** Test fixtures gain `UnsafeAnonymousPrincipal: "test-principal"` so existing tests don't hit the new auth gate; new tests building stricter stacks exercise the spec-strict rejection path.

## Spec citations

Every commit body and PLAN.md section carries inline citations in the form `(§"Section" L<line>)` referencing the cached spec snapshot at `proposals/triggers-events-wg/spec-snapshots/design-sketch-2026-04-30.md`. Reviewers can correlate code → spec text directly.

Pattern was established in commit `844522a` (umbrella plan citation pass) and applies forward to all PRs (δ–η).

## Verification

- `experimental/ext/events`: ✅
- `experimental/ext/events/clients/go`: ✅
- `examples/events/discord`: ✅
- `examples/events/telegram`: ✅

Manual smoke (in PR description so reviewer can repro):
- `make serve` → demo posture, anonymous works, server logs "demo (anonymous → UnsafeAnonymousPrincipal)"
- `OAUTH_ISSUER=http://localhost:8081/realms/demo make serve` → real OIDC posture, anonymous webhook subscribes get -32012, server logs "real OIDC (...) — anonymous webhook subscribes rejected per spec"
- Hit subscribe with `id` field → -32602 with helpful message
- Hit unsubscribe with id-form → "name is required" (γ-2 changed unsubscribe to tuple form)

## Test plan

- [x] All 4 modules green
- [x] Composition property verified — `grep "ext/auth" experimental/ext/events/*.go` returns 0 matches in non-test code
- [ ] Reviewer can run `make demo` end-to-end (works in demo posture without env vars)
- [ ] Reviewer can paste a bad-id subscribe via curl and see `-32602` with the message that points at the spec change

## Tracking

Closes a portion of #349 (PR group γ). Umbrella stays open for δ–η. PLAN.md at the repo root carries this PR's focused design — to be retired after merge per the layered planning approach.

Phase 1 reference: #323 (closed). Group α: #353 (merged `dc0f8aa`). Group β: #355 (merged `96b41d1`).
