### PR TITLE
feat(events): δ — request shape alignment (flat poll, maxAge, _meta, nextCursor)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,248 @@
+# Plan: Events spec alignment δ — request shape alignment
+
+**Issue:** mcpkit 349 (umbrella) | **Group:** δ (fourth of 7)
+**Branch:** `feat/events-delta-wire-shapes` (from main, post-γ-merge)
+**Depends on:** α (#353), β (#355), γ (#356) — all merged
+**Unblocks:** ε (push delivery uses the `maxAge` plumbing δ adds; `_meta` fields δ defines surface in push notifications too)
+
+**Spec snapshot:** [`proposals/triggers-events-wg/spec-snapshots/design-sketch-2026-04-30.md`](https://github.com/panyam/mcpcontribs/blob/main/proposals/triggers-events-wg/spec-snapshots/design-sketch-2026-04-30.md). Citations below in the form `(§"Section" L<line>)`.
+
+## Summary
+
+Wire-format audit. No new methods, no new behaviors — just bring every byte of the request/response JSON onto the spec's exact shape so we can interoperate with other conformant implementations (TS SDK, etc.).
+
+Five deltas:
+1. **Flat `events/poll` request** — drop the `subscriptions[]` wrapper; lift `name`, `params`, `cursor` to top level.
+2. **`maxAge` replay floor** — optional integer-seconds cap on backfill, accepted on poll + subscribe (stream is ε territory).
+3. **`EventOccurrence._meta`** — add the optional opaque-metadata field that matches the Tool/Resource/Prompt pattern.
+4. **`EventDescriptor._meta`** — same at the event-type-definition level.
+5. **`events/list` `nextCursor`** — pagination consistency with `tools/list` / `resources/list`.
+
+Risk profile is **lower than γ**. Only one wire-breaking change (the flat poll request); no auth surgery; no identity model changes.
+
+## Spec deltas addressed
+
+| # | Delta | Spec citation |
+|---|---|---|
+| 1 | `events/poll` request: drop `subscriptions[]` wrapper. Top-level `{name, params?, cursor?, maxAge?, maxEvents?}`. | §"Poll-Based Delivery" → "Request: events/poll" L139-149 |
+| 2 | All three modes (poll, stream, subscribe) accept optional `maxAge` (integer seconds). Server begins replay from `max(cursor, now - maxAge)`. Stream lands in ε; δ wires poll + subscribe. | §"Cursor Lifecycle" → "Bounding replay with maxAge" L529 |
+| 3 | `EventOccurrence` field set audit: `eventId, name, timestamp, data, cursor` (already there post-α/β/γ). Add optional `_meta` opaque object. | §"EventOccurrence schema" L180-186; `_meta` from spec follow-on commit `d4faef9` 2026-05-01 |
+| 4 | `EventDescriptor` (per-event-type def in `events/list`): add optional `_meta` field. Matches Tool/Resource/Prompt pattern. | Spec follow-on commit `d4faef9` 2026-05-01 |
+| 5 | `events/list` response: optional `nextCursor` for pagination. Matches `tools/list` / `resources/list`. | Spec follow-on commit `d4faef9` 2026-05-01 |
+
+The May-1 follow-on items (3 `_meta`, 4 `_meta`, 5 `nextCursor`) are pre-cached in the snapshot via the "Major changes" header at the top of the snapshot file but aren't in the body line-numbered yet — line refs in code comments will say `(spec follow-on 2026-05-01)`.
+
+## Client impact
+
+Most δ changes give clients new **optional** knobs, not forcing client work. One forcing change (flat poll request) — mechanical, all call sites are ours.
+
+### Go SDK (`experimental/ext/events/clients/go/`)
+
+| Change | Site | New surface |
+|---|---|---|
+| `maxAge` on subscribe (δ-3) | `subscription.go` | `SubscribeOptions.MaxAge time.Duration` field. Sent on every refresh. Zero = no floor. |
+| `Event[Data].Meta` (δ-4) | `event.go` | Typed `Event[Data]` gains `Meta map[string]any`. `Receiver[Data]` decoder threads it through automatically. |
+| Flat poll request (δ-1) | n/a | Go SDK has no typed `Poll(...)` helper today; callers use raw `c.Call("events/poll", ...)`. So no SDK API change, but demo test call sites flatten. |
+| `nextCursor` on events/list (δ-5) | n/a | No typed `ListEvents(...)` helper either. Server-side change only. |
+
+### Python SDK (`experimental/ext/events/clients/python/events_client.py`)
+
+More affected because it has CLI subcommands that issue raw RPC calls:
+
+| Change | Site | New surface |
+|---|---|---|
+| Flat `events/poll` request (δ-1) | `cmd_poll` + `cmd_list`'s opportunistic poll | Send `{name, cursor, maxEvents}` instead of `{subscriptions: [{...}]}`. |
+| `maxAge` on subscribe (δ-3) | `WebhookSubscription.__init__` | New `max_age=0` kwarg. Optional `--max-age` CLI flag on the `webhook` subcommand. |
+| `maxAge` on poll (δ-2) | `cmd_poll` | Optional `--max-age` CLI flag, sent in the poll request. |
+| `Event._meta` (δ-4) | webhook receiver decoder | Threads `_meta` through to the printed event output. |
+| `nextCursor` on events/list (δ-5) | `cmd_list` | Loop on `nextCursor`. Today fires once since servers don't paginate. |
+
+### Application consumers (discord + telegram demos)
+
+| Change | What demos do |
+|---|---|
+| Flat poll request | `e2e_test.go` raw `c.Call("events/poll", ...)` sites flatten. ~6 sites total. |
+| `maxAge` | Optional — demos don't *need* it. Could add a small step to the walkthrough demonstrating the floor; defer unless trivially small. |
+| `_meta` | Optional — demos don't currently set metadata. Could show one source attaching `_meta` to demonstrate the pattern; defer unless useful. |
+
+### Forcing-vs-optional summary
+
+- **Optional**: `maxAge` (poll + subscribe), `_meta` (Event + EventDescriptor), `nextCursor` (events/list). Existing client code without them continues to work; the server treats absence as "default behavior".
+- **Forcing**: flat `events/poll` request shape. Old `{subscriptions: [...]}` requests get `-32602` with a spec-pointing message. We own all call sites.
+
+## Why these deltas matter (brief)
+
+- **Flat poll request**: interop. TS SDK + future implementations parse the spec's flat shape directly; our wrapper means anyone hitting our server with the spec shape gets a parse error. Wire-breaking but the spec is firm.
+- **`maxAge`**: bounds backfill on long-offline reconnects. Without it, a client offline for a week reconnects with an old cursor and the server may try to replay a week of events. With `maxAge: 300`, worst case is 5 minutes of backfill.
+- **`_meta` (Event + EventDescriptor)**: app-level metadata that doesn't fit `data`. Matches Tool/Resource/Prompt — uniform pattern across MCP. The library threads it through; spec doesn't define semantics.
+- **`nextCursor`**: pagination for servers with many event types. Most servers won't emit it, but plumbing it through keeps `events/list` consistent with `tools/list` / `resources/list` for clients that already know how to paginate.
+
+## Commits
+
+5 atomic commits, ordered to keep each green at HEAD.
+
+### δ-1 — flat `events/poll` request shape
+
+Drop the `subscriptions[]` wrapper at the JSON-RPC params level. The internal `pollResultWire` response shape is already flat (α work); δ-1 mirrors that on the request side.
+
+**Wire change:**
+
+```jsonc
+// before
+{"subscriptions": [{"name": "discord.message", "cursor": "0"}]}
+
+// after
+{"name": "discord.message", "cursor": "0"}
+```
+
+**Files**:
+- `experimental/ext/events/events.go` — `registerPoll` request struct flattens. Drops the multi-sub guard (single-sub is the only shape the spec defines now). Returns `-32602 InvalidParams` if the legacy wrapper appears (helpful error for old clients).
+- `experimental/ext/events/clients/python/events_client.py` — `cmd_poll` sends the flat shape; `cmd_list`'s opportunistic poll too.
+- `examples/events/discord/e2e_test.go` + `examples/events/telegram/e2e_test.go` + `examples/events/telegram/handlers_test.go` — every `c.Call("events/poll", {"subscriptions": [...]})` site flattens.
+
+**Tests**:
+- `TestPoll_FlatRequestShape` (NEW in `wire_shape_test.go`) — sends flat request, asserts success.
+- `TestPoll_RejectsLegacyWrapper` (NEW) — sends `{"subscriptions": [...]}`, asserts `-32602` with a message pointing at the spec change.
+
+**Spec cites for code comments**: `(§"Poll-Based Delivery" → "Request: events/poll" L139-149)`
+
+### δ-2 — `maxAge` on poll + filtering in YieldingSource
+
+Wire `maxAge` (integer seconds) through `events/poll`. `YieldingSource.Poll` filters out events with `timestamp < now - maxAge`.
+
+**Files**:
+- `experimental/ext/events/events.go` — `registerPoll` request struct adds `MaxAge int`. Pass to `source.Poll(cursor, maxEvents, maxAge)`.
+- `experimental/ext/events/yield.go` — `Poll(cursor string, limit int, maxAge time.Duration)` — new param. After buffer scan, drop events older than `now - maxAge` (when set). If filtering caused the result to start later than `cursor`, set `Truncated: true`.
+- `experimental/ext/events/clients/go/subscription.go` — already plumbs maxAge for subscribe in δ-3; poll doesn't go through the SDK so no change.
+
+**Tests**:
+- `TestYieldingSource_MaxAgeFilters` (NEW in `yield_test.go`) — yield 3 events, sleep 2s, yield 2 more, poll with `maxAge: 1s`, assert only the latest 2 returned + `Truncated: true`.
+- `TestYieldingSource_MaxAgeZeroNoFilter` — `maxAge: 0` means "no floor"; all events returned.
+- `TestPoll_MaxAgeRequest` (NEW in `wire_shape_test.go`) — request with `maxAge`, server filters correctly.
+
+**Spec cites**: `(§"Cursor Lifecycle" → "Bounding replay with maxAge" L529)`
+
+### δ-3 — `maxAge` on `events/subscribe`
+
+Subscribe accepts `maxAge`; passes through as a per-subscription replay floor for the initial subscribe and any refresh re-subscribes (server treats it the same way poll does — caps replay scope).
+
+**Files**:
+- `experimental/ext/events/events.go` — `registerSubscribe` request struct adds `MaxAge int`. Stored on `WebhookTarget` for replay decisions on (future) reconnect — for δ this is just plumbing; current webhook delivery doesn't replay (that's stream + connection-recovery territory).
+- `experimental/ext/events/webhook.go` — `WebhookTarget` gains `MaxAgeSeconds int` field. Register/Unregister signatures unchanged (canonical key is still `(principal, url, name, params)` — `maxAge` is metadata, not identity).
+- `experimental/ext/events/clients/go/subscription.go` — `SubscribeOptions.MaxAge time.Duration` (zero = no floor). Sent on every refresh.
+- `experimental/ext/events/clients/python/events_client.py` — `WebhookSubscription.__init__` gains `max_age` kwarg.
+- Demos — optional `--max-age` flag in the python helper for the `webhook` subcommand.
+
+**Tests**:
+- `TestSubscribe_AcceptsMaxAge` (NEW) — subscribe with `maxAge: 300`, no error, target stored with maxAge=300.
+- `TestSubscribe_DefaultsMaxAgeToZero` — omitted `maxAge`, target stored with maxAge=0 (no floor).
+
+**Spec cites**: `(§"Cursor Lifecycle" → "Bounding replay with maxAge" L529)`. Stream support deferred to ε.
+
+### δ-4 — `_meta` on `EventOccurrence` + `EventDescriptor`
+
+Two parallel additions of an optional opaque `_meta` field. Matches the pattern across `Tool` / `Resource` / `Prompt` in base MCP.
+
+**Files**:
+- `experimental/ext/events/events.go` — `Event` struct gains `Meta map[string]any \`json:"_meta,omitempty"\``. `EventDef` gains `Meta map[string]any \`json:"_meta,omitempty"\``.
+- `experimental/ext/events/yield.go` — `MakeEvent` doesn't need a Meta param; authors who want metadata set it post-construction or via a new variant. Keep the old `MakeEvent` signature unchanged for back-compat; consider `MakeEventWithMeta` if usability needs it (defer for now).
+- `experimental/ext/events/clients/go/event.go` — typed `Event[Data]` gains `Meta map[string]any` field.
+- `experimental/ext/events/clients/python/events_client.py` — receiver decoder threads `_meta` through.
+
+**Tests**:
+- `TestEvent_MetaSerializesWithUnderscorePrefix` (NEW in `cursorless_test.go` or new `meta_test.go`) — Event with Meta marshals to JSON containing `_meta` (not `meta`).
+- `TestEvent_MetaOmitsWhenAbsent` — Event without Meta marshals without the `_meta` key.
+- `TestEventDef_MetaInListResponse` — events/list response includes `_meta` for sources that set it.
+
+**Spec cites**: `(spec follow-on commit d4faef9 2026-05-01)`. The May-1 spec follow-on isn't body-line-numbered in the cached snapshot; cite by commit SHA.
+
+### δ-5 — `nextCursor` on `events/list` response
+
+Optional pagination cursor matching `tools/list` / `resources/list`. δ doesn't implement actual pagination logic (event lists are small in our demos) but threads the field through so future servers can.
+
+**Files**:
+- `experimental/ext/events/events.go` — `registerList` response shape gains `nextCursor string \`json:"nextCursor,omitempty"\``. Today always omitted (we return all sources in one response). Authors who need pagination subclass / wrap the handler — out of δ scope.
+- Python SDK `cmd_list` reads `nextCursor` from the response; loops if non-empty. Today the loop runs once and `nextCursor` is empty.
+
+**Tests**:
+- `TestList_ResponseShape` (NEW or updated) — events/list response includes the `events` array, omits `nextCursor` (we don't paginate today). Pin shape so future pagination doesn't accidentally break the omitted-when-empty contract.
+
+**Spec cites**: `(spec follow-on commit d4faef9 2026-05-01)`.
+
+## Files NOT touched (intentionally)
+
+- `experimental/ext/events/headers.go` — no signature/header changes in δ.
+- `experimental/ext/events/identity.go` — γ's tuple identity stays as-is. `maxAge` is metadata, not identity.
+- `experimental/ext/events/webhook.go` deliver path — δ doesn't change how deliveries go out, only what fields they may carry (`_meta` if author set it).
+
+## Tests
+
+### Red-before-green
+
+Each new test would fail against current HEAD because:
+1. Flat poll request — server expects `subscriptions[]`; sending the spec shape fails with "subscriptions[] must contain exactly one entry"
+2. `maxAge` filtering — `Poll(cursor, limit)` doesn't accept maxAge; events past the floor get returned
+3. `_meta` on Event — struct field doesn't exist; reflection-based marshal would skip; tests would fail
+4. `nextCursor` on events/list — response doesn't include the field; assertions for its presence (when set) would fail
+
+Each test added ships green AFTER the corresponding code change in the same commit.
+
+### Existing test updates
+
+- All `c.Call("events/poll", {"subscriptions": [...]})` sites in demo e2e tests — flatten in δ-1.
+- `pollResult` struct in demos — already flat (α work). No change needed.
+
+### Assertion delta tracking
+
+- Added: ~10 new tests across 5 commits
+- Updated in-place: ~6 existing demo poll-call sites (request shape only)
+- Weakened: 0
+
+## Constraints check
+
+| Constraint | Status |
+|---|---|
+| No CONSTRAINTS.md in this project | OK |
+| No globals | OK — `maxAge` is per-request / per-subscription |
+| No new abstractions for hypothetical futures | OK — `_meta` and `nextCursor` are spec-defined; not speculative |
+| No backwards-compat shims | OK — `subscriptions[]` wrapper is rejected loudly with helpful error |
+| Single-delta-per-commit | OK — 5 commits, 5 deltas |
+| Spec citation in commits + code | OK — citations inline per the convention |
+
+## Acceptance criteria
+
+- `cd experimental/ext/events && go test -count=1 ./...` green
+- `cd experimental/ext/events/clients/go && go test -count=1 ./...` green
+- `cd examples/events/discord && go test -count=1 ./...` green
+- `cd examples/events/telegram && go test -count=1 ./...` green
+- Wire test: an `events/poll` request body with `name` at top level (no `subscriptions[]`) is accepted; the legacy wrapper returns `-32602` with a spec-pointing message
+- Wire test: `events/poll` with `maxAge: 300` filters out events older than `now - 300s`
+- Wire test: `Event` struct marshaled to JSON includes `_meta` only when set; key spelled `_meta` (underscore prefix)
+- Wire test: `events/list` response shape includes `nextCursor` field with `omitempty` (not present when empty)
+- Manual: discord demo `make demo` runs end-to-end; the python `make poll` works against the new flat request shape
+
+## Out of scope for δ (explicitly)
+
+- **Push delivery (`events/stream`)** — ε. Stream's `maxAge` handling lands there.
+- **Reconnect-with-maxAge** semantics for webhook (server-side replay queue with maxAge filtering on resume) — ζ; depends on the suspend/reactivate state machine ζ adds.
+- **Actual pagination logic** for `events/list` (computing `nextCursor`, accepting it on requests) — application-layer concern; δ just threads the field through.
+- **`MakeEventWithMeta` SDK convenience constructor** — author can set `event.Meta` directly post-construction; defer the helper until a clear use case appears.
+
+## Risk
+
+**Low**. No control flow changes. The wire-breaking change (flat poll request) is mechanical; demo + SDK callers are the only consumers and they're updated in the same commits.
+
+The `maxAge` filtering in `YieldingSource` is the only meaningful new behavior — small change (filter slice after buffer scan), well-tested.
+
+## Done when
+
+- All 5 commits land
+- PR opened linking #349
+- PR merged
+- #349 updated with δ merged ✅
+- Root `PLAN.md` retired (ε writes its own)
+- Manual verify: discord demo `make demo` works; python `make poll` works against the flat shape
+
+## Spec citation in commits
+
+Same convention as γ — every commit body carries `(§"Section" L<line>)` citations. The May-1 follow-on items (#3, #4, #5) cite by upstream commit SHA `d4faef9` since they aren't body-line-numbered in the cached snapshot yet.

--- a/docs/EVENTS_SPEC_ALIGNMENT_PLAN.md
+++ b/docs/EVENTS_SPEC_ALIGNMENT_PLAN.md
@@ -211,7 +211,8 @@ The `nextCursor` and the two `_meta` fields are spec follow-ons added on 2026-05
 - `experimental/ext/events/clients/go/subscription.go` — `SubscribeOptions.MaxAge time.Duration`, sent on every subscribe + refresh.
 - `experimental/ext/events/clients/go/event.go` + `receiver.go` — `Event[Data].Meta map[string]any`, threaded through the receiver decoder.
 - `experimental/ext/events/clients/python/events_client.py` — `WebhookSubscription(max_age=0)` kwarg; `--max-age` flag on `webhook` and `poll` subcommands; receiver + cmd_poll printout surface `_meta`; `cmd_list` loops on `nextCursor`.
-- Discord + telegram demos — every `events/poll` call site flattened.
+- `experimental/ext/events/yield.go` — `YieldingSource.SetMetaFunc(func(Data) map[string]any)`. Typed setter (not a YieldingOption — option-functions don't compose with the generic `Data` type) so authors can derive per-event `_meta` without touching the yield closure signature.
+- Discord + telegram demos — every `events/poll` call site flattened. Both walkthroughs pass `MaxAge: 5*time.Minute` on subscribe (δ-3 plumbing). Discord additionally uses `SetMetaFunc` to derive `channel_type` + `mention_count` per event and `EventDef.Meta = {"category": "messaging"}` for type-level metadata.
 
 **Decision:** kept `EventSource.Poll(cursor, limit)` interface unchanged. `maxAge` filtering happens at the handler layer in `registerPoll`, after `source.Poll()` returns: drop events with `timestamp < now - maxAge`, set `truncated: true` if any were dropped, advance `cursor` to source head when filtering removed everything (so the client doesn't re-poll for the dropped events). Avoids forcing every `EventSource` implementor to learn about replay floors. Sources with non-RFC3339 timestamps are conservatively kept.
 
@@ -226,6 +227,7 @@ The `nextCursor` and the two `_meta` fields are spec follow-ons added on 2026-05
 - `TestPoll_MaxAgeFiltersOldEvents`, `TestPoll_MaxAgeZeroMeansNoFilter` (δ-2)
 - `TestSubscribe_AcceptsMaxAge`, `TestSubscribe_DefaultsMaxAgeToZero` (δ-3)
 - `TestEvent_MetaSerializesWithUnderscorePrefix` + omits-when-absent counter; same pair for `EventDef` (δ-4)
+- `TestYieldingSource_MetaFunc` + nil-omits counter in `yield_test.go` (SetMetaFunc helper)
 - `TestList_NextCursorOmitsWhenEmpty`, `TestList_NextCursorPresentWhenSet` (δ-5)
 
 **Risk:** Low. Wire-breaking but the change is mechanical and the spec is firm.

--- a/docs/EVENTS_SPEC_ALIGNMENT_PLAN.md
+++ b/docs/EVENTS_SPEC_ALIGNMENT_PLAN.md
@@ -64,6 +64,8 @@ The others (resource-template subsumption, MCP task event subsumption, event-nam
 
 ### α — Wire renames + error code remap
 
+**Status:** merged via PR #353.
+
 **Goal:** make our wire bytes use the spec's vocabulary without changing semantics.
 
 **Spec deltas addressed:**
@@ -98,6 +100,8 @@ The others (resource-template subsumption, MCP task event subsumption, event-nam
 ---
 
 ### β — Collapse webhook secret modes to client-supplied only
+
+**Status:** merged via PR #355.
 
 **Goal:** match the spec's client-supplied-only secret model. The server no longer generates secrets; the client always provides the signing key on subscribe. Net-deletion PR.
 
@@ -137,6 +141,8 @@ The others (resource-template subsumption, MCP task event subsumption, event-nam
 ---
 
 ### γ — Auth + tuple subscription identity
+
+**Status:** merged via PR #356.
 
 **Goal:** key webhook subscriptions on `(principal, delivery.url, name, params)` per the spec; reject unauthenticated webhook subscribe / unsubscribe.
 
@@ -186,6 +192,8 @@ The others (resource-template subsumption, MCP task event subsumption, event-nam
 
 ### δ — Request shape alignment (flat poll, maxAge, EventOccurrence audit)
 
+**Status:** in flight on `feat/events-delta-wire-shapes`; 5 commits landed on the branch, PR pending.
+
 **Goal:** make `events/poll` and `events/subscribe` request bodies match the spec's flat shape; add `maxAge` floor; audit EventOccurrence fields.
 
 **Spec deltas addressed:**
@@ -197,14 +205,15 @@ The others (resource-template subsumption, MCP task event subsumption, event-nam
 
 The `nextCursor` and the two `_meta` fields are spec follow-ons added on 2026-05-01 (after the in-tree plan's first draft). Folded into δ rather than spinning a micro-PR because δ is already the "wire-shape audit" PR — these three are the same kind of work.
 
-**Files touched:**
-- `experimental/ext/events/events.go` — `events/poll` handler: parse the flat shape, single subscription
-- `experimental/ext/events/yield.go` — `Poll(cursor, limit)` becomes `Poll(cursor string, maxAge time.Duration, limit int)`. Apply `maxAge` floor: drop events with `timestamp < now - maxAge` from the returned slice
-- `experimental/ext/events/clients/go/subscription.go` — Subscribe options grow `MaxAge time.Duration`; sent on every refresh
-- Python SDK — same
-- Discord + telegram demos — update their `events/poll` calls to the flat shape; offer a `--max-age` flag in the python helper
+**Files touched (as built):**
+- `experimental/ext/events/events.go` — `registerPoll` flattens the request struct; `registerSubscribe` adds `MaxAge int`; new `listResultWire` typed struct gives `events/list` a `nextCursor` field with `omitempty`. `Event` and `EventDef` gain `Meta map[string]any` with JSON tag `_meta,omitempty`.
+- `experimental/ext/events/webhook.go` — `WebhookTarget` gains `MaxAgeSeconds int`; `Register` signature grows a `maxAgeSeconds` parameter (refresh treats `0` as "don't change", non-zero replaces stored floor).
+- `experimental/ext/events/clients/go/subscription.go` — `SubscribeOptions.MaxAge time.Duration`, sent on every subscribe + refresh.
+- `experimental/ext/events/clients/go/event.go` + `receiver.go` — `Event[Data].Meta map[string]any`, threaded through the receiver decoder.
+- `experimental/ext/events/clients/python/events_client.py` — `WebhookSubscription(max_age=0)` kwarg; `--max-age` flag on `webhook` and `poll` subcommands; receiver + cmd_poll printout surface `_meta`; `cmd_list` loops on `nextCursor`.
+- Discord + telegram demos — every `events/poll` call site flattened.
 
-**Decision:** for emit-only sources (our YieldingSource ring), if `cursor` is older than `now - maxAge` AND the cursor has been evicted from the ring, the safer response is to set `truncated: true` + reset to current head — the spec explicitly permits this fallback when honouring `maxAge` literally would mean an expensive backfill scan. Implement that for `WithMaxSize` ring sources.
+**Decision:** kept `EventSource.Poll(cursor, limit)` interface unchanged. `maxAge` filtering happens at the handler layer in `registerPoll`, after `source.Poll()` returns: drop events with `timestamp < now - maxAge`, set `truncated: true` if any were dropped, advance `cursor` to source head when filtering removed everything (so the client doesn't re-poll for the dropped events). Avoids forcing every `EventSource` implementor to learn about replay floors. Sources with non-RFC3339 timestamps are conservatively kept.
 
 **Acceptance:**
 - `make test-experimental` green
@@ -212,9 +221,12 @@ The `nextCursor` and the two `_meta` fields are spec follow-ons added on 2026-05
 - `maxAge` floor test: subscribe with `maxAge: 1` after sleeping 2s past a known event, verify the event is dropped from replay
 - `EventOccurrence` field audit: every wire-format event has the five required fields with the right names
 
-**Tests:**
-- New `events_poll_shape_test.go` for the flat-request shape
-- Extend `yield_test.go` with `maxAge` filtering cases
+**Tests (as built):** added to `experimental/ext/events/wire_shape_test.go` —
+- `TestPoll_FlatRequestShape`, `TestPoll_RejectsLegacyWrapper` (δ-1)
+- `TestPoll_MaxAgeFiltersOldEvents`, `TestPoll_MaxAgeZeroMeansNoFilter` (δ-2)
+- `TestSubscribe_AcceptsMaxAge`, `TestSubscribe_DefaultsMaxAgeToZero` (δ-3)
+- `TestEvent_MetaSerializesWithUnderscorePrefix` + omits-when-absent counter; same pair for `EventDef` (δ-4)
+- `TestList_NextCursorOmitsWhenEmpty`, `TestList_NextCursorPresentWhenSet` (δ-5)
 
 **Risk:** Low. Wire-breaking but the change is mechanical and the spec is firm.
 

--- a/examples/events/discord/e2e_test.go
+++ b/examples/events/discord/e2e_test.go
@@ -99,10 +99,10 @@ func TestE2EPollDelivery(t *testing.T) {
 	require.NoError(t, yield(newDiscordEvent("guild-1", "channel-1", "alice", "hello", time.Now())))
 	require.NoError(t, yield(newDiscordEvent("guild-1", "channel-1", "bob", "world", time.Now())))
 
+	// δ-1: flat events/poll request shape per spec L139-149.
 	result, err := c.Call("events/poll", map[string]any{
-		"subscriptions": []map[string]any{
-			{"id": "poll", "name": "discord.message", "cursor": "0"},
-		},
+		"name":   "discord.message",
+		"cursor": "0",
 	})
 	require.NoError(t, err)
 
@@ -487,9 +487,8 @@ func TestE2ECursorlessPollAlwaysEmpty(t *testing.T) {
 	}
 
 	result, err := c.Call("events/poll", map[string]any{
-		"subscriptions": []map[string]any{
-			{"id": "p", "name": "discord.typing", "cursor": "0"},
-		},
+		"name":   "discord.typing",
+		"cursor": "0",
 	})
 	require.NoError(t, err)
 
@@ -533,14 +532,20 @@ func TestE2EPollMultiSubRejected(t *testing.T) {
 	srv, _, _, _ := buildTestStack()
 	c, _ := connectClient(t, srv)
 
+	// δ-1: the {subscriptions: [...]} wrapper itself is rejected with a
+	// helpful error — multi-sub vs single-sub no longer matters since the
+	// spec's flat shape doesn't have an array at all. The
+	// TestPoll_RejectsLegacyWrapper test in wire_shape_test.go covers the
+	// wrapper-level rejection at the handler level; this demo test now just
+	// confirms the user-facing error message points at the spec.
 	_, err := c.Call("events/poll", map[string]any{
 		"subscriptions": []map[string]any{
-			{"id": "a", "name": "discord.message", "cursor": "0"},
-			{"id": "b", "name": "discord.typing", "cursor": "0"},
+			{"name": "discord.message", "cursor": "0"},
 		},
 	})
-	require.Error(t, err, "multi-subscription events/poll must be rejected")
-	assert.Contains(t, err.Error(), "exactly one subscription", "error message must point at the spec change")
+	require.Error(t, err, "legacy {subscriptions: [...]} wrapper must be rejected")
+	assert.Contains(t, err.Error(), "legacy", "error message must explain the wrapper rejection")
+	assert.Contains(t, err.Error(), "L139", "error must cite the spec section")
 }
 
 // TestE2EResourceByCursor verifies the per-message resource template resolves

--- a/examples/events/discord/events.go
+++ b/examples/events/discord/events.go
@@ -8,12 +8,29 @@ import (
 // The library owns the in-memory ring buffer; the resource handlers read
 // typed payloads back via source.Recent / source.ByCursor — single source of
 // truth, no duplication, no resource-side unmarshaling.
+//
+// δ-4: the source attaches per-event `_meta` derived from the payload
+// (spec follow-on commit d4faef9 2026-05-01). channel_type and mention_count
+// are app-defined classifications that don't fit `data` — exactly what
+// `_meta` is for. Receivers see them under the spec-canonical `_meta` key.
 func newDiscordSource() (*events.YieldingSource[DiscordEventData], func(DiscordEventData) error) {
-	return events.NewYieldingSource[DiscordEventData](events.EventDef{
+	src, yield := events.NewYieldingSource[DiscordEventData](events.EventDef{
 		Name:        "discord.message",
 		Description: "Fires when a message is sent in a Discord channel the bot can see",
 		Delivery:    []string{"push", "poll", "webhook"},
+		Meta:        map[string]any{"category": "messaging"},
 	}, events.WithMaxSize(1000))
+	src.SetMetaFunc(func(d DiscordEventData) map[string]any {
+		channelType := "guild"
+		if d.GuildID == "" {
+			channelType = "dm"
+		}
+		return map[string]any{
+			"channel_type":  channelType,
+			"mention_count": len(d.Mentions),
+		}
+	})
+	return src, yield
 }
 
 // newDiscordTypingSource constructs the cursorless YieldingSource for

--- a/examples/events/discord/walkthrough.go
+++ b/examples/events/discord/walkthrough.go
@@ -274,34 +274,27 @@ func runDemo() {
 			if messageCursor != nil {
 				cursor = *messageCursor
 			}
+			// δ-1: flat top-level shape per spec §"Poll-Based Delivery"
+			// → "Request: events/poll" L139-149.
 			res, err := c.Call("events/poll", map[string]any{
-				"subscriptions": []map[string]any{
-					{"id": "demo-poll", "name": "discord.message", "cursor": cursor},
-				},
+				"name":   "discord.message",
+				"cursor": cursor,
 			})
 			if err != nil {
 				fmt.Printf("    ERROR: %v\n", err)
 				return
 			}
 			var resp struct {
-				Results []struct {
-					ID      string  `json:"id"`
-					Cursor  *string `json:"cursor"`
-					HasMore bool    `json:"hasMore"`
-					Events  []any   `json:"events"`
-				} `json:"results"`
+				Cursor  *string `json:"cursor"`
+				HasMore bool    `json:"hasMore"`
+				Events  []any   `json:"events"`
 			}
 			_ = json.Unmarshal(res.Raw, &resp)
-			if len(resp.Results) == 0 {
-				fmt.Printf("    ERROR: no result\n")
-				return
+			cur := "(none)"
+			if resp.Cursor != nil {
+				cur = *resp.Cursor
 			}
-			r := resp.Results[0]
-			c := "(none)"
-			if r.Cursor != nil {
-				c = *r.Cursor
-			}
-			fmt.Printf("    events:  %d  cursor: %s  hasMore: %v\n", len(r.Events), c, r.HasMore)
+			fmt.Printf("    events:  %d  cursor: %s  hasMore: %v\n", len(resp.Events), cur, resp.HasMore)
 			return
 		})
 

--- a/examples/events/discord/walkthrough.go
+++ b/examples/events/discord/walkthrough.go
@@ -359,6 +359,10 @@ func runDemo() {
 				CallbackURL:   hookSrv.URL,
 				RefreshFactor: 0.5,
 				OnRefresh:     func() { atomic.AddInt32(&refreshes, 1) },
+				// δ-3: bound worst-case replay on reconnect to 5 minutes
+				// (§"Cursor Lifecycle" L529). Stored on WebhookTarget
+				// for ζ's reconnect-with-replay logic.
+				MaxAge: 5 * time.Minute,
 			})
 			if err != nil {
 				fmt.Printf("    ERROR: subscribe failed: %v\n", err)
@@ -401,6 +405,10 @@ func runDemo() {
 				fmt.Printf("      eventId: %s\n", ev.EventID)
 				fmt.Printf("      cursor:  %s\n", ev.CursorStr())
 				fmt.Printf("      content: %q (from %s)\n", ev.Data.Content, ev.Data.Author.Username)
+				// δ-4: per-event _meta from the source's metaFunc.
+				if ev.Meta != nil {
+					fmt.Printf("      _meta:   %v\n", ev.Meta)
+				}
 			case <-time.After(3 * time.Second):
 				fmt.Printf("    ERROR: no webhook delivery within 3s\n")
 				return

--- a/examples/events/telegram/e2e_test.go
+++ b/examples/events/telegram/e2e_test.go
@@ -98,11 +98,11 @@ func TestE2EPollDelivery(t *testing.T) {
 	require.NoError(t, yieldText(yield, 100, "bob", "world"))
 	require.NoError(t, yieldText(yield, 100, "carol", "!"))
 
+	// δ-1: flat events/poll request shape per spec L139-149.
 	result, err := c.Call("events/poll", map[string]any{
+		"name":      "telegram.message",
+		"cursor":    "0",
 		"maxEvents": 2,
-		"subscriptions": []map[string]any{
-			{"id": "poll-1", "name": "telegram.message", "cursor": "0"},
-		},
 	})
 	require.NoError(t, err)
 
@@ -113,9 +113,8 @@ func TestE2EPollDelivery(t *testing.T) {
 	assert.Equal(t, "2", *resp.Cursor)
 
 	result2, err := c.Call("events/poll", map[string]any{
-		"subscriptions": []map[string]any{
-			{"id": "poll-2", "name": "telegram.message", "cursor": *resp.Cursor},
-		},
+		"name":   "telegram.message",
+		"cursor": *resp.Cursor,
 	})
 	require.NoError(t, err)
 
@@ -483,14 +482,15 @@ func TestE2EPollMultiSubRejected(t *testing.T) {
 	c := client.NewClient(tsrv.URL+"/mcp", core.ClientInfo{Name: "multi-sub", Version: "1.0"})
 	require.NoError(t, c.Connect())
 
+	// δ-1: the {subscriptions: [...]} wrapper is rejected with a helpful
+	// error pointing at the spec change (L139-149).
 	_, err := c.Call("events/poll", map[string]any{
 		"subscriptions": []map[string]any{
-			{"id": "a", "name": "telegram.message", "cursor": "0"},
-			{"id": "b", "name": "telegram.typing", "cursor": "0"},
+			{"name": "telegram.message", "cursor": "0"},
 		},
 	})
-	require.Error(t, err, "multi-subscription events/poll must be rejected")
-	assert.Contains(t, err.Error(), "exactly one subscription")
+	require.Error(t, err, "legacy {subscriptions: [...]} wrapper must be rejected")
+	assert.Contains(t, err.Error(), "legacy")
 }
 
 // TestE2EResourceReadViaClient verifies the recent-messages resource reads

--- a/examples/events/telegram/handlers_test.go
+++ b/examples/events/telegram/handlers_test.go
@@ -82,11 +82,11 @@ func TestEventsPollCursorPagination(t *testing.T) {
 	source, _ := preloadedSource(10)
 	c, _ := newConnectedClient(t, source, events.NewWebhookRegistry())
 
+	// δ-1: flat events/poll request shape per spec L139-149.
 	result, err := c.Call("events/poll", map[string]any{
+		"name":      "telegram.message",
+		"cursor":    "0",
 		"maxEvents": 5,
-		"subscriptions": []map[string]any{
-			{"id": "page1", "name": "telegram.message", "cursor": "0"},
-		},
 	})
 	require.NoError(t, err)
 
@@ -97,10 +97,9 @@ func TestEventsPollCursorPagination(t *testing.T) {
 	assert.Equal(t, "5", *resp.Cursor)
 
 	result2, err := c.Call("events/poll", map[string]any{
+		"name":      "telegram.message",
+		"cursor":    *resp.Cursor,
 		"maxEvents": 5,
-		"subscriptions": []map[string]any{
-			{"id": "page2", "name": "telegram.message", "cursor": *resp.Cursor},
-		},
 	})
 	require.NoError(t, err)
 
@@ -118,9 +117,8 @@ func TestEventsPollEmptyStore(t *testing.T) {
 	c, _ := newConnectedClient(t, source, events.NewWebhookRegistry())
 
 	result, err := c.Call("events/poll", map[string]any{
-		"subscriptions": []map[string]any{
-			{"id": "empty", "name": "telegram.message", "cursor": "0"},
-		},
+		"name":   "telegram.message",
+		"cursor": "0",
 	})
 	require.NoError(t, err)
 
@@ -140,9 +138,8 @@ func TestEventsPollUnknownEvent(t *testing.T) {
 	c, _ := newConnectedClient(t, source, events.NewWebhookRegistry())
 
 	_, err := c.Call("events/poll", map[string]any{
-		"subscriptions": []map[string]any{
-			{"id": "bogus", "name": "nonexistent.event", "cursor": "0"},
-		},
+		"name":   "nonexistent.event",
+		"cursor": "0",
 	})
 	require.Error(t, err, "unknown event must return a JSON-RPC error")
 	rpcErr, ok := err.(*client.RPCError)
@@ -227,10 +224,9 @@ func TestEventsPollHasMore(t *testing.T) {
 	c, _ := newConnectedClient(t, source, events.NewWebhookRegistry())
 
 	result, err := c.Call("events/poll", map[string]any{
+		"name":      "telegram.message",
+		"cursor":    "0",
 		"maxEvents": 3,
-		"subscriptions": []map[string]any{
-			{"id": "hm", "name": "telegram.message", "cursor": "0"},
-		},
 	})
 	require.NoError(t, err)
 
@@ -240,10 +236,9 @@ func TestEventsPollHasMore(t *testing.T) {
 	assert.True(t, resp.HasMore)
 
 	result2, err := c.Call("events/poll", map[string]any{
+		"name":      "telegram.message",
+		"cursor":    *resp.Cursor,
 		"maxEvents": 3,
-		"subscriptions": []map[string]any{
-			{"id": "hm2", "name": "telegram.message", "cursor": *resp.Cursor},
-		},
 	})
 	require.NoError(t, err)
 

--- a/examples/events/telegram/handlers_test.go
+++ b/examples/events/telegram/handlers_test.go
@@ -197,7 +197,7 @@ func TestWebhookHMACSignature_MCPHeaders(t *testing.T) {
 	// Direct registry poke (skip the JSON-RPC subscribe handler) — γ-2
 	// rekeyed Register on canonical-tuple bytes. Use a stub key for the
 	// HMAC delivery test; the canonical-key contents don't matter here.
-	webhooks.Register([]byte("hmac-test"), "sub_hmac_test", srv.URL, secret)
+	webhooks.Register([]byte("hmac-test"), "sub_hmac_test", srv.URL, secret, 0)
 
 	event := events.MakeEvent("telegram.message", "evt_1", "1", time.Now(),
 		map[string]string{"text": "hello"})
@@ -287,8 +287,8 @@ func TestWebhookKeyedByCanonicalTuple(t *testing.T) {
 	webhooks := events.NewWebhookRegistry()
 	keyA := []byte("alice\x1fhttp://example.com/hook\x1ftelegram.message\x1f{}")
 	keyB := []byte("bob\x1fhttp://example.com/hook\x1ftelegram.message\x1f{}")
-	webhooks.Register(keyA, "sub_alice", "http://example.com/hook", "whsec_secret-1")
-	webhooks.Register(keyB, "sub_bob", "http://example.com/hook", "whsec_secret-2")
+	webhooks.Register(keyA, "sub_alice", "http://example.com/hook", "whsec_secret-1", 0)
+	webhooks.Register(keyB, "sub_bob", "http://example.com/hook", "whsec_secret-2", 0)
 
 	targets := webhooks.Targets()
 	assert.Len(t, targets, 2)
@@ -303,7 +303,7 @@ func TestWebhookKeyedByCanonicalTuple(t *testing.T) {
 // it claims — used by other tests that exercise post-TTL behavior.
 func TestWebhookTTLExpiry(t *testing.T) {
 	webhooks := events.NewWebhookRegistry()
-	webhooks.Register([]byte("exp-test"), "sub_exp", "http://example.com/hook", "whsec_secret")
+	webhooks.Register([]byte("exp-test"), "sub_exp", "http://example.com/hook", "whsec_secret", 0)
 	assert.Len(t, webhooks.Targets(), 1)
 
 	webhooks.ExpireAll()
@@ -330,7 +330,7 @@ func TestWebhookRetryOnServerError(t *testing.T) {
 	defer srv.Close()
 
 	webhooks := events.NewWebhookRegistry()
-	webhooks.Register([]byte("retry-test"), "sub_retry", srv.URL, "whsec_secret")
+	webhooks.Register([]byte("retry-test"), "sub_retry", srv.URL, "whsec_secret", 0)
 
 	event := events.MakeEvent("telegram.message", "evt_retry", "1", time.Now(),
 		map[string]string{"text": "retry me"})
@@ -358,7 +358,7 @@ func TestWebhookNoRetryOn4xx(t *testing.T) {
 	defer srv.Close()
 
 	webhooks := events.NewWebhookRegistry()
-	webhooks.Register([]byte("no-retry"), "sub_no_retry", srv.URL, "whsec_secret")
+	webhooks.Register([]byte("no-retry"), "sub_no_retry", srv.URL, "whsec_secret", 0)
 
 	event := events.MakeEvent("telegram.message", "evt_4xx", "1", time.Now(),
 		map[string]string{"text": "no retry"})

--- a/examples/events/telegram/walkthrough.go
+++ b/examples/events/telegram/walkthrough.go
@@ -272,6 +272,10 @@ func runDemo() {
 			sub, err := eventsclient.Subscribe(ctx, c, eventsclient.SubscribeOptions{
 				EventName:   "telegram.message",
 				CallbackURL: hookSrv.URL,
+				// δ-3: bound worst-case replay on reconnect to 5 minutes
+				// (§"Cursor Lifecycle" L529). Stored on WebhookTarget
+				// for ζ's reconnect-with-replay logic.
+				MaxAge: 5 * time.Minute,
 			})
 			if err != nil {
 				fmt.Printf("    ERROR: subscribe failed: %v\n", err)

--- a/experimental/ext/events/clients/go/event.go
+++ b/experimental/ext/events/clients/go/event.go
@@ -10,6 +10,9 @@ type Event[Data any] struct {
 	Timestamp string
 	Cursor    *string
 	Data      Data
+	// Meta mirrors the wire `_meta` field on EventOccurrence (spec
+	// follow-on commit d4faef9 2026-05-01). Opaque, app-defined.
+	Meta map[string]any
 }
 
 // HasCursor reports whether the event carries a cursor.

--- a/experimental/ext/events/clients/go/receiver.go
+++ b/experimental/ext/events/clients/go/receiver.go
@@ -108,6 +108,7 @@ func (r *Receiver[Data]) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		Timestamp: wire.Timestamp,
 		Cursor:    wire.Cursor,
 		Data:      data,
+		Meta:      wire.Meta,
 	}
 
 	// Non-blocking send. A full channel signals a slow consumer; we'd

--- a/experimental/ext/events/clients/go/subscription.go
+++ b/experimental/ext/events/clients/go/subscription.go
@@ -44,6 +44,12 @@ type SubscribeOptions struct {
 	// OnRecover fires when a refresh failed (the registry had already
 	// expired the subscription) and a fresh subscribe succeeded.
 	OnRecover func()
+
+	// MaxAge is the per-subscription replay floor sent on every subscribe
+	// per spec §"Cursor Lifecycle" → "Bounding replay with maxAge" L529.
+	// Zero means no floor (server defaults to "no maxAge"). Resolution is
+	// seconds; sub-second precision is dropped on the wire.
+	MaxAge time.Duration
 }
 
 // Subscription manages an events/subscribe lifecycle with automatic TTL
@@ -171,6 +177,9 @@ func (s *Subscription) subscribe() error {
 	} else {
 		// Explicit JSON null so the server resolves to "from now".
 		params["cursor"] = nil
+	}
+	if s.opts.MaxAge > 0 {
+		params["maxAge"] = int(s.opts.MaxAge / time.Second)
 	}
 
 	resp, err := s.sess.Call("events/subscribe", params)

--- a/experimental/ext/events/clients/python/events_client.py
+++ b/experimental/ext/events/clients/python/events_client.py
@@ -182,8 +182,10 @@ def cmd_list(session: MCPSession, args):
     # events/poll
     if args.event:
         print(f"--- events/poll (cursor=0, event={args.event}) ---")
+        # δ-1: flat events/poll request shape per spec L139-149.
         resp = session.rpc("events/poll", {
-            "subscriptions": [{"id": "list", "name": args.event, "cursor": "0"}],
+            "name": args.event,
+            "cursor": "0",
         })
         result = resp.get("result", {})
         events = result.get("events", [])
@@ -530,7 +532,8 @@ def cmd_poll(session: MCPSession, args):
     try:
         while True:
             resp = session.rpc("events/poll", {
-                "subscriptions": [{"id": "poll-loop", "name": args.event, "cursor": cursor}],
+                "name": args.event,
+                "cursor": cursor,
             })
             result = resp.get("result", {})
             events = result.get("events", [])

--- a/experimental/ext/events/clients/python/events_client.py
+++ b/experimental/ext/events/clients/python/events_client.py
@@ -173,10 +173,21 @@ def cmd_list(session: MCPSession, args):
     print()
 
     # events/list
+    # δ-5: pagination via nextCursor (spec follow-on 2026-05-01).
+    # Today the library returns all sources in one response, but a server
+    # author with many event types may paginate; the loop is forward-
+    # compatible with that.
     print("--- events/list ---")
-    resp = session.rpc("events/list", {})
-    for ev in resp.get("result", {}).get("events", []):
-        print(json.dumps(ev, indent=2))
+    cursor = None
+    while True:
+        params = {"cursor": cursor} if cursor else {}
+        resp = session.rpc("events/list", params)
+        result = resp.get("result", {})
+        for ev in result.get("events", []):
+            print(json.dumps(ev, indent=2))
+        cursor = result.get("nextCursor")
+        if not cursor:
+            break
     print()
 
     # events/poll

--- a/experimental/ext/events/clients/python/events_client.py
+++ b/experimental/ext/events/clients/python/events_client.py
@@ -450,6 +450,9 @@ def _make_webhook_handler(secret_holder):
                 print(f"  name:    {event.get('name', '')}")
                 print(f"  time:    {event.get('timestamp', '')}")
                 print(f"  cursor:  {_fmt_cursor(event.get('cursor'))}")
+                meta = event.get("_meta")
+                if meta:
+                    print(f"  _meta:   {json.dumps(meta, separators=(',', ':'))}")
                 data = event.get("data")
                 if data:
                     print(json.dumps(data, indent=2))
@@ -560,6 +563,9 @@ def cmd_poll(session: MCPSession, args):
                     print(f"  name:    {ev.get('name', '')}")
                     print(f"  time:    {ev.get('timestamp', '')}")
                     print(f"  cursor:  {_fmt_cursor(ev.get('cursor'))}")
+                    meta = ev.get("_meta")
+                    if meta:
+                        print(f"  _meta:   {json.dumps(meta, separators=(',', ':'))}")
                     data = ev.get("data")
                     if data:
                         print(json.dumps(data, indent=2))

--- a/experimental/ext/events/clients/python/events_client.py
+++ b/experimental/ext/events/clients/python/events_client.py
@@ -282,6 +282,7 @@ class WebhookSubscription:
         on_event: callable = None,
         on_refresh: callable = None,
         on_recover: callable = None,
+        max_age: int = 0,
     ):
         """
         secret: client-supplied HMAC signing secret. Per spec, must be
@@ -300,6 +301,10 @@ class WebhookSubscription:
         on_recover: called when a refresh fails (subscription expired) and a
                     fresh subscribe succeeds. Receives no args. Both may fire
                     in the same cycle if the recovery succeeds.
+        max_age: per-subscription replay floor in seconds, sent on every
+                 subscribe per spec §"Cursor Lifecycle" → "Bounding replay
+                 with maxAge" L529. 0 means no floor. Bounds the worst-case
+                 replay on reconnect.
         """
         self.session = session
         self.event_name = event_name
@@ -309,6 +314,7 @@ class WebhookSubscription:
         self.on_event = on_event
         self.on_refresh = on_refresh
         self.on_recover = on_recover
+        self.max_age = max_age
 
         self._stop = threading.Event()
         self._thread = None
@@ -318,14 +324,17 @@ class WebhookSubscription:
         """Send events/subscribe and capture refreshBefore. Per spec the
         request does NOT carry id; server derives it over the canonical
         tuple (§"Subscription Identity" → "Key composition" L363)."""
-        resp = self.session.rpc("events/subscribe", {
+        params = {
             "name": self.event_name,
             "delivery": {
                 "mode": "webhook",
                 "url": self.callback_url,
                 "secret": self.secret,
             },
-        })
+        }
+        if self.max_age > 0:
+            params["maxAge"] = self.max_age
+        resp = self.session.rpc("events/subscribe", params)
         result = resp.get("result", {})
         rb_str = result.get("refreshBefore")
         if rb_str:
@@ -475,6 +484,7 @@ def cmd_webhook(session: MCPSession, args):
         callback_url=hook_url,
         secret=args.secret,  # empty → SDK auto-generates a whsec_ value
         refresh_factor=args.refresh_factor,
+        max_age=args.max_age,
     )
     secret_holder = [sub.secret]
 
@@ -531,10 +541,13 @@ def cmd_poll(session: MCPSession, args):
     cursor = "0"
     try:
         while True:
-            resp = session.rpc("events/poll", {
+            poll_params = {
                 "name": args.event,
                 "cursor": cursor,
-            })
+            }
+            if args.max_age > 0:
+                poll_params["maxAge"] = args.max_age
+            resp = session.rpc("events/poll", poll_params)
             result = resp.get("result", {})
             events = result.get("events", [])
             if result.get("truncated"):
@@ -584,9 +597,13 @@ def main():
     wp.add_argument("--secret", default="", help="HMAC signing secret (whsec_ + base64 of 24-64 bytes per spec). Empty → SDK auto-generates.")
     wp.add_argument("--refresh-factor", type=float, default=0.5,
                     help="Refresh subscription at this fraction of TTL (default 0.5)")
+    wp.add_argument("--max-age", type=int, default=0,
+                    help="Per-subscription replay floor in seconds (spec §'Cursor Lifecycle' L529). 0 = no floor.")
 
     pp = sub.add_parser("poll", help="Polling loop")
     pp.add_argument("--interval", type=int, default=5, help="Seconds between polls")
+    pp.add_argument("--max-age", type=int, default=0,
+                    help="Per-poll replay floor in seconds (spec §'Cursor Lifecycle' L529). 0 = no floor.")
 
     args = parser.parse_args()
     session = MCPSession(args.mcp)

--- a/experimental/ext/events/events.go
+++ b/experimental/ext/events/events.go
@@ -276,34 +276,39 @@ func registerList(srv *server.Server, sources []EventSource) {
 
 func registerPoll(srv *server.Server, sourceMap map[string]EventSource) {
 	srv.HandleMethod("events/poll", func(ctx core.MethodContext, id json.RawMessage, params json.RawMessage) *core.Response {
+		// Spec §"Poll-Based Delivery" → "Request: events/poll" L139-149:
+		// flat top-level shape — no subscriptions[] wrapper. Phase 1 dropped
+		// batching at the protocol level; δ-1 drops the now-vestigial
+		// wrapper at the wire level.
 		var req struct {
-			MaxEvents     int `json:"maxEvents,omitempty"`
-			Subscriptions []struct {
-				ID     string  `json:"id"`
-				Name   string  `json:"name"`
-				Cursor *string `json:"cursor"`
-			} `json:"subscriptions"`
+			Name      string         `json:"name"`
+			Params    map[string]any `json:"params,omitempty"`
+			Cursor    *string        `json:"cursor"`
+			MaxEvents int            `json:"maxEvents,omitempty"`
 		}
 		if err := json.Unmarshal(params, &req); err != nil {
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, err.Error())
 		}
-		// events/poll is single-subscription per upstream WG PR#1 line 185
-		// (comment r3140480214). Reject batched requests with a clear
-		// pointer to the spec change.
-		if len(req.Subscriptions) > 1 {
+		// Helpful diagnostic for clients still sending the legacy wrapper.
+		// A flat-shape request with name omitted is indistinguishable from
+		// a wrapper-shape request at the struct level (both leave req.Name
+		// empty); probe for the wrapper specifically.
+		if req.Name == "" {
+			var legacyProbe struct {
+				Subscriptions []json.RawMessage `json:"subscriptions"`
+			}
+			if err := json.Unmarshal(params, &legacyProbe); err == nil && legacyProbe.Subscriptions != nil {
+				return core.NewErrorResponse(id, core.ErrCodeInvalidParams,
+					`events/poll: legacy {subscriptions: [...]} wrapper rejected — send top-level {name, cursor, maxEvents} per spec §"Poll-Based Delivery" L139-149`)
+			}
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams,
-				"events/poll: pass exactly one subscription per call (multi-sub support has been removed)")
-		}
-		if len(req.Subscriptions) == 0 {
-			return core.NewErrorResponse(id, core.ErrCodeInvalidParams,
-				"events/poll: subscriptions[] must contain exactly one entry")
+				"events/poll: name is required")
 		}
 		if req.MaxEvents <= 0 {
 			req.MaxEvents = 50
 		}
 
-		sub := req.Subscriptions[0]
-		source, ok := sourceMap[sub.Name]
+		source, ok := sourceMap[req.Name]
 		if !ok {
 			return core.NewErrorResponse(id, ErrCodeEventNotFound, "EventNotFound")
 		}
@@ -314,8 +319,8 @@ func registerPoll(srv *server.Server, sourceMap map[string]EventSource) {
 		// Cursored sources return Latest(); cursorless sources return "" and
 		// the wire layer below translates that to JSON null.
 		cursor := ""
-		if sub.Cursor != nil {
-			cursor = *sub.Cursor
+		if req.Cursor != nil {
+			cursor = *req.Cursor
 		} else if !cursorless {
 			cursor = source.Latest()
 		}

--- a/experimental/ext/events/events.go
+++ b/experimental/ext/events/events.go
@@ -274,13 +274,25 @@ type pollResultWire struct {
 	NextPollSeconds int     `json:"nextPollSeconds,omitempty"`
 }
 
+// listResultWire is the events/list response shape (spec follow-on
+// commit d4faef9 2026-05-01). Optional `nextCursor` matches the
+// tools/list / resources/list pagination convention. The library does
+// not paginate today (event-type lists are small in practice); the
+// field is plumbed for forward compatibility — servers that DO have a
+// large advertised set can wrap or replace this handler and emit
+// nextCursor without changing the wire shape.
+type listResultWire struct {
+	Events     []EventDef `json:"events"`
+	NextCursor string     `json:"nextCursor,omitempty"`
+}
+
 func registerList(srv *server.Server, sources []EventSource) {
 	srv.HandleMethod("events/list", func(ctx core.MethodContext, id json.RawMessage, params json.RawMessage) *core.Response {
 		defs := make([]EventDef, 0, len(sources))
 		for _, s := range sources {
 			defs = append(defs, s.Def())
 		}
-		return core.NewResponse(id, map[string]any{"events": defs})
+		return core.NewResponse(id, listResultWire{Events: defs})
 	})
 }
 

--- a/experimental/ext/events/events.go
+++ b/experimental/ext/events/events.go
@@ -279,12 +279,13 @@ func registerPoll(srv *server.Server, sourceMap map[string]EventSource) {
 		// Spec §"Poll-Based Delivery" → "Request: events/poll" L139-149:
 		// flat top-level shape — no subscriptions[] wrapper. Phase 1 dropped
 		// batching at the protocol level; δ-1 drops the now-vestigial
-		// wrapper at the wire level.
+		// wrapper at the wire level. δ-2 added MaxAge.
 		var req struct {
 			Name      string         `json:"name"`
 			Params    map[string]any `json:"params,omitempty"`
 			Cursor    *string        `json:"cursor"`
 			MaxEvents int            `json:"maxEvents,omitempty"`
+			MaxAge    int            `json:"maxAge,omitempty"` // seconds; 0 = no floor
 		}
 		if err := json.Unmarshal(params, &req); err != nil {
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, err.Error())
@@ -332,6 +333,35 @@ func registerPoll(srv *server.Server, sourceMap map[string]EventSource) {
 		if hasMore {
 			events = events[:req.MaxEvents]
 			resultCursor = events[len(events)-1].CursorStr()
+		}
+
+		// δ-2: maxAge replay floor per spec §"Cursor Lifecycle" →
+		// "Bounding replay with maxAge" L529. Drop events whose
+		// timestamp predates now - maxAge. If filtering removes any,
+		// set Truncated=true (signals the gap to the client).
+		// When req.MaxAge is 0 (default), no filtering — preserves
+		// pre-δ-2 behavior for callers that don't pass the field.
+		if req.MaxAge > 0 && len(events) > 0 {
+			floor := time.Now().Add(-time.Duration(req.MaxAge) * time.Second)
+			kept := make([]Event, 0, len(events))
+			for _, e := range events {
+				ts, err := time.Parse(time.RFC3339, e.Timestamp)
+				if err != nil || !ts.Before(floor) {
+					kept = append(kept, e)
+				}
+			}
+			if len(kept) < len(events) {
+				pr.Truncated = true
+				// Per spec L529: when filtering removes everything,
+				// reset cursor to source head ("now") so the client
+				// doesn't re-poll for the dropped events. When some
+				// events survived, the resultCursor (last delivered)
+				// is already past the floor.
+				if len(kept) == 0 && !cursorless {
+					resultCursor = source.Latest()
+				}
+			}
+			events = kept
 		}
 
 		// For cursorless sources, the wire `cursor` is null regardless of

--- a/experimental/ext/events/events.go
+++ b/experimental/ext/events/events.go
@@ -426,6 +426,7 @@ func registerSubscribe(srv *server.Server, sourceMap map[string]EventSource, web
 				Secret string `json:"secret,omitempty"`
 			} `json:"delivery"`
 			Cursor *string `json:"cursor"`
+			MaxAge int     `json:"maxAge,omitempty"` // δ-3: spec §"Cursor Lifecycle" L529; seconds, 0 = no floor
 		}
 		if err := json.Unmarshal(params, &req); err != nil {
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, err.Error())
@@ -479,7 +480,7 @@ func registerSubscribe(srv *server.Server, sourceMap map[string]EventSource, web
 		canonical := canonicalKey(principal, req.Delivery.URL, req.Name, req.Params)
 		derivedID := deriveSubscriptionID(canonical)
 
-		expiresAt := webhooks.Register(canonical, derivedID, req.Delivery.URL, req.Delivery.Secret)
+		expiresAt := webhooks.Register(canonical, derivedID, req.Delivery.URL, req.Delivery.Secret, req.MaxAge)
 
 		// Resolve `cursor: null` to the source's current head ("from now")
 		// for cursored sources. Cursorless sources always serialize as null.

--- a/experimental/ext/events/events.go
+++ b/experimental/ext/events/events.go
@@ -34,6 +34,11 @@ type Event struct {
 	Timestamp string          `json:"timestamp"`
 	Data      json.RawMessage `json:"data"`
 	Cursor    *string         `json:"cursor"`
+	// Meta is opaque per-occurrence metadata (spec follow-on commit
+	// d4faef9 2026-05-01). Mirrors the `_meta` field on Tool / Resource
+	// / Prompt in base MCP. Library threads it through; semantics are
+	// app-defined (trace ids, source-system tags, etc.).
+	Meta map[string]any `json:"_meta,omitempty"`
 }
 
 // HasCursor reports whether the event carries a cursor (cursored source) or
@@ -64,6 +69,11 @@ type EventDef struct {
 	Delivery      []string `json:"delivery"`
 	PayloadSchema any      `json:"payloadSchema,omitempty"`
 	Cursorless    bool     `json:"cursorless,omitempty"`
+	// Meta is opaque per-event-type metadata (spec follow-on commit
+	// d4faef9 2026-05-01). Same `_meta` convention as Event /
+	// Tool / Resource / Prompt. Sources set it once at construction
+	// and the library surfaces it on events/list.
+	Meta map[string]any `json:"_meta,omitempty"`
 }
 
 // PollResult holds the result of a cursor-based poll from an event source.

--- a/experimental/ext/events/identity_handler_test.go
+++ b/experimental/ext/events/identity_handler_test.go
@@ -141,8 +141,8 @@ func TestSubscribe_TupleIsolationCrossPrincipal(t *testing.T) {
 	idBob := deriveSubscriptionID(keyBob)
 
 	// Same URL, name, params; different principal → distinct registry entries.
-	webhooks.Register(keyAlice, idAlice, "https://example.com/hook", "whsec_a")
-	webhooks.Register(keyBob, idBob, "https://example.com/hook", "whsec_b")
+	webhooks.Register(keyAlice, idAlice, "https://example.com/hook", "whsec_a", 0)
+	webhooks.Register(keyBob, idBob, "https://example.com/hook", "whsec_b", 0)
 
 	assert.Len(t, webhooks.Targets(), 2, "different principals must produce distinct registry entries")
 	assert.NotEqual(t, idAlice, idBob, "different canonical keys must derive different ids")
@@ -225,7 +225,7 @@ func TestDelivery_EmitsXMCPSubscriptionIDHeader(t *testing.T) {
 	webhooks := NewWebhookRegistry()
 	canonical := canonicalKey("test-principal", callback.URL, "fake.event", nil)
 	subID := deriveSubscriptionID(canonical)
-	webhooks.Register(canonical, subID, callback.URL, "whsec_"+strings.Repeat("a", 32))
+	webhooks.Register(canonical, subID, callback.URL, "whsec_"+strings.Repeat("a", 32), 0)
 
 	// Direct Deliver bypasses the JSON-RPC handler — what we want to
 	// inspect is the registry's outbound HTTP shape, not the subscribe

--- a/experimental/ext/events/webhook.go
+++ b/experimental/ext/events/webhook.go
@@ -48,11 +48,12 @@ func WithWebhookHeaderMode(mode WebhookHeaderMode) WebhookOption {
 // as the X-MCP-Subscription-Id header on every delivery POST per
 // §"Webhook Event Delivery" L390.
 type WebhookTarget struct {
-	CanonicalKey []byte    // canonical bytes of (principal, url, name, params)
-	ID           string    // server-derived routing handle (sub_<base64-of-16-bytes>)
-	URL          string    // delivery callback URL
-	Secret       string    // client-supplied HMAC signing secret (whsec_...)
-	ExpiresAt    time.Time // soft-state TTL expiry
+	CanonicalKey  []byte    // canonical bytes of (principal, url, name, params)
+	ID            string    // server-derived routing handle (sub_<base64-of-16-bytes>)
+	URL           string    // delivery callback URL
+	Secret        string    // client-supplied HMAC signing secret (whsec_...)
+	ExpiresAt     time.Time // soft-state TTL expiry
+	MaxAgeSeconds int       // δ-3: per-spec replay floor (§"Cursor Lifecycle" L529); 0 = no floor
 }
 
 // WebhookRegistry tracks outbound webhook subscriptions and delivers events
@@ -102,7 +103,14 @@ func NewWebhookRegistry(opts ...WebhookOption) *WebhookRegistry {
 // from identity.go. Passed in (rather than computed here) so the
 // caller can derive once and reuse for both Register and the
 // subscribe-response body.
-func (r *WebhookRegistry) Register(canonicalKey []byte, derivedID, urlStr, secret string) time.Time {
+//
+// maxAgeSeconds is the per-subscription replay floor per spec
+// §"Cursor Lifecycle" → "Bounding replay with maxAge" L529. Stored on
+// the target for use on (future) reconnect-with-replay; 0 means no
+// floor. On refresh, an explicit non-zero value replaces the prior
+// stored floor; 0 leaves the existing value untouched (treats omission
+// as "don't change").
+func (r *WebhookRegistry) Register(canonicalKey []byte, derivedID, urlStr, secret string, maxAgeSeconds int) time.Time {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.pruneExpiredLocked()
@@ -115,14 +123,18 @@ func (r *WebhookRegistry) Register(canonicalKey []byte, derivedID, urlStr, secre
 		if secret != "" {
 			existing.Secret = secret
 		}
+		if maxAgeSeconds > 0 {
+			existing.MaxAgeSeconds = maxAgeSeconds
+		}
 		r.targets[key] = existing
 	} else {
 		r.targets[key] = WebhookTarget{
-			CanonicalKey: canonicalKey,
-			ID:           derivedID,
-			URL:          urlStr,
-			Secret:       secret,
-			ExpiresAt:    expiresAt,
+			CanonicalKey:  canonicalKey,
+			ID:            derivedID,
+			URL:           urlStr,
+			Secret:        secret,
+			ExpiresAt:     expiresAt,
+			MaxAgeSeconds: maxAgeSeconds,
 		}
 	}
 	return expiresAt

--- a/experimental/ext/events/wire_shape_test.go
+++ b/experimental/ext/events/wire_shape_test.go
@@ -401,6 +401,48 @@ func TestEventDef_MetaOmitsWhenAbsent(t *testing.T) {
 		"absent Meta must omit the key entirely; got %s", string(raw))
 }
 
+// TestList_NextCursorOmitsWhenEmpty pins the events/list response shape
+// (spec follow-on commit d4faef9 2026-05-01): optional `nextCursor`
+// matches the tools/list / resources/list pagination convention.
+// Today our implementation always returns all sources in one response,
+// so nextCursor is empty — the test enforces that "empty" means the
+// key is OMITTED on the wire (omitempty), not present-as-empty-string.
+//
+// Future paginating servers can populate the field; the test catches a
+// regression where a typo or missing tag causes the field to leak as
+// `"nextCursor": ""` (which a client paginating-loop would treat as
+// "no more pages" but is still an unwanted byte tax + spec drift).
+func TestList_NextCursorOmitsWhenEmpty(t *testing.T) {
+	wire := listResultWire{
+		Events:     []EventDef{{Name: "demo", Description: "x", Delivery: []string{"poll"}}},
+		NextCursor: "",
+	}
+	raw, err := json.Marshal(wire)
+	require.NoError(t, err)
+	body := string(raw)
+
+	assert.Contains(t, body, `"events":`, "events array must be present")
+	assert.False(t, strings.Contains(body, `"nextCursor"`),
+		"empty NextCursor must omit the key entirely; got %s", body)
+}
+
+// TestList_NextCursorPresentWhenSet — counter-test: when set, the
+// response carries `nextCursor` with the populated value. Pins both
+// the field name (camelCase, matching tools/list) and the omitempty
+// behavior (only the populated field appears).
+func TestList_NextCursorPresentWhenSet(t *testing.T) {
+	wire := listResultWire{
+		Events:     []EventDef{{Name: "demo", Description: "x", Delivery: []string{"poll"}}},
+		NextCursor: "page2",
+	}
+	raw, err := json.Marshal(wire)
+	require.NoError(t, err)
+	body := string(raw)
+
+	assert.Contains(t, body, `"nextCursor":"page2"`,
+		"populated NextCursor must serialize under the camelCase key; got %s", body)
+}
+
 // TestInvalidCallbackUrl_UsesSpecCode verifies the InvalidCallbackUrl error
 // uses spec code -32015, not the legacy -32005.
 func TestInvalidCallbackUrl_UsesSpecCode(t *testing.T) {

--- a/experimental/ext/events/wire_shape_test.go
+++ b/experimental/ext/events/wire_shape_test.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -87,6 +88,50 @@ func TestEventNotFound_UsesSpecCode(t *testing.T) {
 	assert.Contains(t, body, `"message":"EventNotFound"`)
 	assert.False(t, strings.Contains(body, `"code":-32001`),
 		"legacy -32001 code must not appear (collides with base MCP ResourceNotFound)")
+}
+
+// TestPoll_FlatRequestShape pins the spec contract for events/poll
+// REQUEST shape per §"Poll-Based Delivery" → "Request: events/poll"
+// L139-149: top-level {name, cursor?, maxEvents?, params?} — no
+// subscriptions[] wrapper. δ-1 dropped the wrapper after phase 1
+// removed batching at the protocol level. Failing this test means
+// a spec-conformant client's request would not parse.
+func TestPoll_FlatRequestShape(t *testing.T) {
+	srv := buildSecretValidationStack(t)
+	rawReq, err := json.Marshal(map[string]any{
+		"name":   "fake.event",
+		"cursor": "0",
+	})
+	require.NoError(t, err)
+	resp, err := srv.Dispatch(context.Background(), &core.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "events/poll", Params: rawReq,
+	})
+	require.NoError(t, err)
+	require.Nil(t, resp.Error, "flat top-level shape must be accepted; got %+v", resp.Error)
+}
+
+// TestPoll_RejectsLegacyWrapper verifies that a request still using the
+// pre-δ {subscriptions: [...]} wrapper gets a -32602 with a message
+// pointing at the spec change. Without this helpful diagnostic, an old
+// SDK sending the legacy shape would just see "name is required" and
+// have no clue why.
+func TestPoll_RejectsLegacyWrapper(t *testing.T) {
+	srv := buildSecretValidationStack(t)
+	rawReq, err := json.Marshal(map[string]any{
+		"subscriptions": []map[string]any{
+			{"name": "fake.event", "cursor": "0"},
+		},
+	})
+	require.NoError(t, err)
+	resp, err := srv.Dispatch(context.Background(), &core.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "events/poll", Params: rawReq,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp.Error, "legacy wrapper must be rejected, not silently parsed as empty")
+	assert.Equal(t, core.ErrCodeInvalidParams, resp.Error.Code)
+	assert.Contains(t, resp.Error.Message, "legacy",
+		"error message should explain the wrapper is rejected; got %q", resp.Error.Message)
+	assert.Contains(t, resp.Error.Message, "L139", "error should cite the spec section")
 }
 
 // TestInvalidCallbackUrl_UsesSpecCode verifies the InvalidCallbackUrl error

--- a/experimental/ext/events/wire_shape_test.go
+++ b/experimental/ext/events/wire_shape_test.go
@@ -288,6 +288,46 @@ func buildPollFilterStack(t *testing.T) (*server.Server, *YieldingSource[fakeFil
 	return srv, src
 }
 
+// TestSubscribe_AcceptsMaxAge verifies the spec's maxAge floor on
+// events/subscribe per §"Cursor Lifecycle" → "Bounding replay with
+// maxAge" L529. Client supplies a per-subscription replay floor that
+// the server records on the WebhookTarget for use on (future) reconnect
+// — δ-3 plumbs the field, ζ wires the actual replay-with-floor logic.
+//
+// Without storing maxAge on the target, a long-offline subscriber's
+// reconnect would replay everything the cursor still covers; with it,
+// the server can bound replay to the requested floor.
+func TestSubscribe_AcceptsMaxAge(t *testing.T) {
+	srv, webhooks := buildAuthGateStack(t, "test-principal")
+	params := validSubscribeParams()
+	params["maxAge"] = 300
+	resp := dispatchSubscribe(t, srv, params)
+	require.Nil(t, resp.Error, "subscribe with maxAge must succeed; got %+v", resp.Error)
+
+	targets := webhooks.Targets()
+	require.Len(t, targets, 1)
+	assert.Equal(t, 300, targets[0].MaxAgeSeconds,
+		"maxAge from subscribe request must be stored on WebhookTarget for reconnect-replay bounding")
+}
+
+// TestSubscribe_DefaultsMaxAgeToZero is the counter-test: when maxAge is
+// omitted, the target stores 0 — no floor, replay is unbounded by maxAge
+// (still bounded by cursor + source retention). Catches over-eager
+// defaulting that would silently shrink replay for callers who didn't
+// opt in.
+func TestSubscribe_DefaultsMaxAgeToZero(t *testing.T) {
+	srv, webhooks := buildAuthGateStack(t, "test-principal")
+	params := validSubscribeParams()
+	// maxAge intentionally omitted
+	resp := dispatchSubscribe(t, srv, params)
+	require.Nil(t, resp.Error)
+
+	targets := webhooks.Targets()
+	require.Len(t, targets, 1)
+	assert.Equal(t, 0, targets[0].MaxAgeSeconds,
+		"omitted maxAge must default to 0 (no floor)")
+}
+
 // TestInvalidCallbackUrl_UsesSpecCode verifies the InvalidCallbackUrl error
 // uses spec code -32015, not the legacy -32005.
 func TestInvalidCallbackUrl_UsesSpecCode(t *testing.T) {

--- a/experimental/ext/events/wire_shape_test.go
+++ b/experimental/ext/events/wire_shape_test.go
@@ -328,6 +328,79 @@ func TestSubscribe_DefaultsMaxAgeToZero(t *testing.T) {
 		"omitted maxAge must default to 0 (no floor)")
 }
 
+// TestEvent_MetaSerializesWithUnderscorePrefix verifies the spec
+// follow-on (commit d4faef9 2026-05-01) added optional `_meta` to
+// EventOccurrence. Wire key MUST be `_meta` (underscore prefix), not
+// `meta` — matches the Tool/Resource/Prompt convention from base MCP.
+//
+// Without the underscore prefix, clients written to the spec wouldn't
+// find the field; the underscore is the marker that says "namespaced
+// extension metadata, distinct from app data".
+func TestEvent_MetaSerializesWithUnderscorePrefix(t *testing.T) {
+	cursor := "c1"
+	e := Event{
+		EventID:   "evt_1",
+		Name:      "demo",
+		Timestamp: "t",
+		Data:      json.RawMessage(`{}`),
+		Cursor:    &cursor,
+		Meta:      map[string]any{"trace": "abc123"},
+	}
+	raw, err := json.Marshal(e)
+	require.NoError(t, err)
+	body := string(raw)
+
+	assert.Contains(t, body, `"_meta":{"trace":"abc123"}`,
+		"Event.Meta must marshal under key `_meta` (with underscore); got %s", body)
+	assert.False(t, strings.Contains(body, `"meta":`),
+		"unprefixed `meta` key must not appear; spec uses `_meta`")
+}
+
+// TestEvent_MetaOmitsWhenAbsent verifies omitempty: events without
+// metadata produce no `_meta` key on the wire. Important so the common
+// case (no metadata) doesn't add a bytes-on-wire tax to every event.
+func TestEvent_MetaOmitsWhenAbsent(t *testing.T) {
+	cursor := "c1"
+	e := Event{
+		EventID:   "evt_1",
+		Name:      "demo",
+		Timestamp: "t",
+		Data:      json.RawMessage(`{}`),
+		Cursor:    &cursor,
+	}
+	raw, err := json.Marshal(e)
+	require.NoError(t, err)
+	assert.False(t, strings.Contains(string(raw), `"_meta"`),
+		"absent Meta must omit the key entirely; got %s", string(raw))
+}
+
+// TestEventDef_MetaSerializesWithUnderscorePrefix verifies the same
+// `_meta` convention applies to event TYPE definitions surfaced via
+// events/list (per spec follow-on commit d4faef9 2026-05-01).
+func TestEventDef_MetaSerializesWithUnderscorePrefix(t *testing.T) {
+	d := EventDef{
+		Name:        "demo",
+		Description: "test",
+		Delivery:    []string{"poll"},
+		Meta:        map[string]any{"category": "system"},
+	}
+	raw, err := json.Marshal(d)
+	require.NoError(t, err)
+	body := string(raw)
+
+	assert.Contains(t, body, `"_meta":{"category":"system"}`,
+		"EventDef.Meta must marshal under key `_meta`; got %s", body)
+}
+
+// TestEventDef_MetaOmitsWhenAbsent — counter-test for omitempty on EventDef.
+func TestEventDef_MetaOmitsWhenAbsent(t *testing.T) {
+	d := EventDef{Name: "demo", Description: "test", Delivery: []string{"poll"}}
+	raw, err := json.Marshal(d)
+	require.NoError(t, err)
+	assert.False(t, strings.Contains(string(raw), `"_meta"`),
+		"absent Meta must omit the key entirely; got %s", string(raw))
+}
+
 // TestInvalidCallbackUrl_UsesSpecCode verifies the InvalidCallbackUrl error
 // uses spec code -32015, not the legacy -32005.
 func TestInvalidCallbackUrl_UsesSpecCode(t *testing.T) {

--- a/experimental/ext/events/wire_shape_test.go
+++ b/experimental/ext/events/wire_shape_test.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/server"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -132,6 +134,158 @@ func TestPoll_RejectsLegacyWrapper(t *testing.T) {
 	assert.Contains(t, resp.Error.Message, "legacy",
 		"error message should explain the wrapper is rejected; got %q", resp.Error.Message)
 	assert.Contains(t, resp.Error.Message, "L139", "error should cite the spec section")
+}
+
+// TestPoll_MaxAgeFiltersOldEvents verifies the spec's maxAge replay
+// floor per §"Cursor Lifecycle" → "Bounding replay with maxAge" L529.
+// Server discards events whose timestamp predates `now - maxAge` and
+// signals the gap via Truncated=true. Without filtering, a long-offline
+// client reconnects with a stale cursor and triggers an unbounded
+// backfill — maxAge bounds the worst case.
+//
+// This test uses a real YieldingSource registered on a stack so the
+// timestamps come from the actual yield path (Now-based per yield call).
+func TestPoll_MaxAgeFiltersOldEvents(t *testing.T) {
+	srv, src := buildPollFilterStack(t)
+
+	// Yield 2 events that are "old" (manipulate their timestamp via
+	// the underlying source) and 2 fresh ones. Easier to backdate
+	// the events post-yield by walking the source's ring directly —
+	// but for δ-2's purposes we just yield them at different real
+	// times and use a small maxAge to filter.
+
+	// Yield "old" events with a backdated timestamp 10s in the past.
+	src.entries = append(src.entries,
+		yieldedEntry[fakeFilterPayload]{
+			data: fakeFilterPayload{Msg: "old1"},
+			event: Event{
+				EventID:   "evt_old_1",
+				Name:      "fake.event",
+				Timestamp: time.Now().Add(-10 * time.Second).Format(time.RFC3339),
+				Data:      json.RawMessage(`{"msg":"old1"}`),
+				Cursor:    cursorPtr("1"),
+			},
+		},
+		yieldedEntry[fakeFilterPayload]{
+			data: fakeFilterPayload{Msg: "old2"},
+			event: Event{
+				EventID:   "evt_old_2",
+				Name:      "fake.event",
+				Timestamp: time.Now().Add(-8 * time.Second).Format(time.RFC3339),
+				Data:      json.RawMessage(`{"msg":"old2"}`),
+				Cursor:    cursorPtr("2"),
+			},
+		},
+	)
+	// Fresh events.
+	src.entries = append(src.entries,
+		yieldedEntry[fakeFilterPayload]{
+			data: fakeFilterPayload{Msg: "fresh1"},
+			event: Event{
+				EventID:   "evt_fresh_1",
+				Name:      "fake.event",
+				Timestamp: time.Now().Format(time.RFC3339),
+				Data:      json.RawMessage(`{"msg":"fresh1"}`),
+				Cursor:    cursorPtr("3"),
+			},
+		},
+	)
+
+	// Poll with maxAge=5s — should drop both old events, keep the fresh one.
+	rawReq, _ := json.Marshal(map[string]any{
+		"name":   "fake.event",
+		"cursor": "0",
+		"maxAge": 5,
+	})
+	resp, err := srv.Dispatch(context.Background(), &core.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "events/poll", Params: rawReq,
+	})
+	require.NoError(t, err)
+	require.Nil(t, resp.Error)
+
+	body, err := json.Marshal(resp.Result)
+	require.NoError(t, err)
+	var bodyMap map[string]any
+	require.NoError(t, json.Unmarshal(body, &bodyMap))
+
+	events, _ := bodyMap["events"].([]any)
+	assert.Len(t, events, 1, "maxAge=5s must drop the 2 old events; got %d kept", len(events))
+	assert.Equal(t, true, bodyMap["truncated"], "filtering must set truncated=true to signal the gap")
+}
+
+// TestPoll_MaxAgeZeroMeansNoFilter is the counter-test: maxAge omitted
+// or set to 0 must NOT filter anything. Catches over-eager filtering
+// that would silently drop events when the client expects everything.
+func TestPoll_MaxAgeZeroMeansNoFilter(t *testing.T) {
+	srv, src := buildPollFilterStack(t)
+	// Yield one ancient event.
+	src.entries = append(src.entries,
+		yieldedEntry[fakeFilterPayload]{
+			data: fakeFilterPayload{Msg: "ancient"},
+			event: Event{
+				EventID:   "evt_ancient",
+				Name:      "fake.event",
+				Timestamp: time.Now().Add(-1 * time.Hour).Format(time.RFC3339),
+				Data:      json.RawMessage(`{"msg":"ancient"}`),
+				Cursor:    cursorPtr("1"),
+			},
+		},
+	)
+
+	rawReq, _ := json.Marshal(map[string]any{
+		"name":   "fake.event",
+		"cursor": "0",
+		// maxAge intentionally omitted
+	})
+	resp, err := srv.Dispatch(context.Background(), &core.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "events/poll", Params: rawReq,
+	})
+	require.NoError(t, err)
+	require.Nil(t, resp.Error)
+
+	body, _ := json.Marshal(resp.Result)
+	var bodyMap map[string]any
+	_ = json.Unmarshal(body, &bodyMap)
+	events, _ := bodyMap["events"].([]any)
+	assert.Len(t, events, 1, "no maxAge means no filter — ancient events must still be returned")
+	// Truncated may or may not be present depending on omitempty
+	if v, ok := bodyMap["truncated"]; ok {
+		assert.Equal(t, false, v, "no filtering happened — truncated must be false (or omitted)")
+	}
+}
+
+// --- shared helpers for δ-2 tests ---
+
+type fakeFilterPayload struct {
+	Msg string `json:"msg"`
+}
+
+func cursorPtr(s string) *string { return &s }
+
+// buildPollFilterStack builds a stack with a writable YieldingSource so
+// tests can inject events with crafted timestamps. Returns the source
+// directly (not a yield closure) so tests can manipulate the buffer.
+func buildPollFilterStack(t *testing.T) (*server.Server, *YieldingSource[fakeFilterPayload]) {
+	t.Helper()
+	src, _ := NewYieldingSource[fakeFilterPayload](EventDef{Name: "fake.event"})
+	srv := server.NewServer(core.ServerInfo{Name: "test", Version: "1.0"})
+	Register(Config{
+		Sources:                  []EventSource{src},
+		Webhooks:                 NewWebhookRegistry(),
+		Server:                   srv,
+		UnsafeAnonymousPrincipal: "test-principal",
+	})
+	initParams := json.RawMessage(`{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)
+	resp, err := srv.Dispatch(context.Background(), &core.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`0`), Method: "initialize", Params: initParams,
+	})
+	require.NoError(t, err)
+	require.Nil(t, resp.Error)
+	_, err = srv.Dispatch(context.Background(), &core.Request{
+		JSONRPC: "2.0", Method: "notifications/initialized",
+	})
+	require.NoError(t, err)
+	return srv, src
 }
 
 // TestInvalidCallbackUrl_UsesSpecCode verifies the InvalidCallbackUrl error

--- a/experimental/ext/events/yield.go
+++ b/experimental/ext/events/yield.go
@@ -128,9 +128,25 @@ type YieldingSource[Data any] struct {
 	mu       sync.RWMutex
 	entries  []yieldedEntry[Data]
 	emitHook func(Event)
+	metaFunc func(Data) map[string]any
 }
 
 func (s *YieldingSource[Data]) Def() EventDef { return s.def }
+
+// SetMetaFunc installs a per-event metadata mapper. When non-nil, the
+// source calls it during yield and assigns the result to Event.Meta
+// (spec follow-on commit d4faef9 2026-05-01: optional `_meta` on
+// EventOccurrence). Returning nil from f produces no `_meta` key on
+// the wire (omitempty). Pass nil to clear.
+//
+// Set on a separate method (not via NewYieldingSource opts) because
+// the mapper is type-parameterized over Data, which doesn't compose
+// cleanly with the option-function pattern.
+func (s *YieldingSource[Data]) SetMetaFunc(f func(Data) map[string]any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.metaFunc = f
+}
 
 // Poll implements EventSource. Returns events with cursor strictly greater
 // than the requested cursor, up to limit. The Cursor field of PollResult is
@@ -260,6 +276,11 @@ func (s *YieldingSource[Data]) yield(data Data) error {
 	}
 
 	s.mu.Lock()
+	if s.metaFunc != nil {
+		if m := s.metaFunc(data); len(m) > 0 {
+			event.Meta = m
+		}
+	}
 	if !s.cursorless {
 		// Only buffer when cursored — cursorless sources don't support
 		// poll-side replay, so retaining events would just waste memory.

--- a/experimental/ext/events/yield_test.go
+++ b/experimental/ext/events/yield_test.go
@@ -248,3 +248,39 @@ func TestYieldingSource_ConcurrentYields(t *testing.T) {
 	pr := src.Poll("", 1000)
 	assert.Len(t, pr.Events, n)
 }
+
+// TestYieldingSource_MetaFunc verifies the per-event metadata mapper:
+// when SetMetaFunc is installed, yielded events carry Event.Meta set
+// from the mapper output. Pins the spec follow-on `_meta` plumbing
+// at the source-construction layer (vs the wire layer covered by
+// wire_shape_test.go).
+func TestYieldingSource_MetaFunc(t *testing.T) {
+	src, yield := NewYieldingSource[fakePayload](EventDef{Name: "fake"})
+	src.SetMetaFunc(func(d fakePayload) map[string]any {
+		return map[string]any{"length": len(d.Msg)}
+	})
+	require.NoError(t, yield(fakePayload{Msg: "hello"}))
+
+	pr := src.Poll("", 10)
+	require.Len(t, pr.Events, 1)
+	require.NotNil(t, pr.Events[0].Meta, "metaFunc returning a non-empty map must populate Event.Meta")
+	assert.Equal(t, 5, pr.Events[0].Meta["length"])
+}
+
+// TestYieldingSource_MetaFuncReturningNilOmits verifies an empty/nil
+// map from the mapper produces no `_meta` on the wire (omitempty).
+// Catches over-eager population that would emit `_meta: {}` for every
+// event, defeating the bytes-on-wire-free common case.
+func TestYieldingSource_MetaFuncReturningNilOmits(t *testing.T) {
+	src, yield := NewYieldingSource[fakePayload](EventDef{Name: "fake"})
+	src.SetMetaFunc(func(d fakePayload) map[string]any { return nil })
+	require.NoError(t, yield(fakePayload{Msg: "x"}))
+
+	pr := src.Poll("", 10)
+	require.Len(t, pr.Events, 1)
+	assert.Nil(t, pr.Events[0].Meta, "nil/empty mapper output must leave Event.Meta unset")
+
+	raw, err := json.Marshal(pr.Events[0])
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), `"_meta"`, "omitempty must keep _meta off the wire when nil")
+}

--- a/tests/reports/report.html
+++ b/tests/reports/report.html
@@ -19,7 +19,7 @@ pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto; 
 code.cmd { background: #f0f0f0; padding: 2px 6px; border-radius: 3px; font-size: 13px; }
 </style></head><body>
 <h1>MCPKit Test Report</h1>
-<div class='meta'>Branch: <strong>feat/sep-2322-mrtr-incomplete</strong> | Commit: <code>a2f2b13</code> | Date: 2026-04-30 14:36:00</div>
+<div class='meta'>Branch: <strong>feat/events-delta-wire-shapes</strong> | Commit: <code>1a956aa</code> | Date: 2026-05-04 00:44:25</div>
 <table><tr><th>Stage</th><th>Result</th><th>Re-run</th></tr>
 <tr><td><a href='#log-unit+coverage'>unit+coverage</a></td><td class='pass'>PASS</td><td><code class='cmd'>make cover-html</code></td></tr>
 <tr><td><a href='#log-race'>race</a></td><td class='pass'>PASS</td><td><code class='cmd'>make test-race</code></td></tr>
@@ -38,48 +38,48 @@ code.cmd { background: #f0f0f0; padding: 2px 6px; border-radius: 3px; font-size:
 <h2>Stage Logs</h2>
 <details id='log-unit+coverage'><summary class='pass'>unit+coverage — PASS</summary><pre>
 === Stage 1/12: unit+coverage (make cover-html) ===
-Started: Thu Apr 30 14:34:19 PDT 2026
+Started: Mon May  4 00:42:21 PDT 2026
 go test -coverprofile=tests/reports/coverage.out ./... -count=1 -timeout 30s
-ok  	github.com/panyam/mcpkit/client	8.162s	coverage: 65.4% of statements
+ok  	github.com/panyam/mcpkit/client	8.355s	coverage: 64.2% of statements
 	github.com/panyam/mcpkit/cmd/testserver		coverage: 0.0% of statements
-ok  	github.com/panyam/mcpkit/core	0.337s	coverage: 47.3% of statements
-ok  	github.com/panyam/mcpkit/server	12.475s	coverage: 78.9% of statements
-ok  	github.com/panyam/mcpkit/testutil	1.320s	coverage: 69.4% of statements
+ok  	github.com/panyam/mcpkit/core	0.570s	coverage: 47.3% of statements
+ok  	github.com/panyam/mcpkit/server	13.784s	coverage: 79.0% of statements
+ok  	github.com/panyam/mcpkit/testutil	0.424s	coverage: 69.4% of statements
 go tool cover -html=tests/reports/coverage.out -o tests/reports/coverage.html
 Coverage report: tests/reports/coverage.html
-Finished: Thu Apr 30 14:34:33 PDT 2026
+Finished: Mon May  4 00:42:37 PDT 2026
 </pre></details>
 <details id='log-race'><summary class='pass'>race — PASS</summary><pre>
 === Stage 2/12: race (make test-race) ===
-Started: Thu Apr 30 14:34:33 PDT 2026
+Started: Mon May  4 00:42:37 PDT 2026
 go test -race ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/client	9.250s
+ok  	github.com/panyam/mcpkit/client	9.529s
 ?   	github.com/panyam/mcpkit/cmd/testserver	[no test files]
-ok  	github.com/panyam/mcpkit/core	1.374s
-ok  	github.com/panyam/mcpkit/server	13.970s
-ok  	github.com/panyam/mcpkit/testutil	2.500s
-Finished: Thu Apr 30 14:34:48 PDT 2026
+ok  	github.com/panyam/mcpkit/core	1.586s
+ok  	github.com/panyam/mcpkit/server	15.317s
+ok  	github.com/panyam/mcpkit/testutil	1.522s
+Finished: Mon May  4 00:42:56 PDT 2026
 </pre></details>
 <details id='log-auth'><summary class='pass'>auth — PASS</summary><pre>
 === Stage 3/12: auth (make test-auth) ===
-Started: Thu Apr 30 14:34:48 PDT 2026
+Started: Mon May  4 00:42:56 PDT 2026
 cd ext/auth &amp;&amp; go test ./... -count=1 -timeout 30s
-ok  	github.com/panyam/mcpkit/ext/auth	0.401s
-Finished: Thu Apr 30 14:34:49 PDT 2026
+ok  	github.com/panyam/mcpkit/ext/auth	0.718s
+Finished: Mon May  4 00:42:58 PDT 2026
 </pre></details>
 <details id='log-ui'><summary class='pass'>ui — PASS</summary><pre>
 === Stage 4/12: ui (make test-ui) ===
-Started: Thu Apr 30 14:34:49 PDT 2026
+Started: Mon May  4 00:42:58 PDT 2026
 cd ext/ui &amp;&amp; /Library/Developer/CommandLineTools/usr/bin/make test
 go test ./... -count=1 -timeout 30s
-ok  	github.com/panyam/mcpkit/ext/ui	0.417s
+ok  	github.com/panyam/mcpkit/ext/ui	0.715s
 cd assets &amp;&amp; pnpm install --frozen-lockfile --silent &amp;&amp; pnpm test
 
-&gt; @mcpkit/app-bridge@0.1.0 test /Users/dzshrh/newstack/mcpkit/mrtr/ext/ui/assets
+&gt; @mcpkit/app-bridge@0.1.0 test /Users/dzshrh/newstack/mcpkit/main/ext/ui/assets
 &gt; vitest run
 
 
- RUN  v3.2.4 /Users/dzshrh/newstack/mcpkit/mrtr/ext/ui/assets
+ RUN  v3.2.4 /Users/dzshrh/newstack/mcpkit/main/ext/ui/assets
 
 stderr | mcp-app-bridge.test.ts &gt; pre-handshake guarding &gt; sendToolListChanged is silently dropped before handshake
 [MCPApp] notify blocked before handshake: notifications/tools/list_changed
@@ -87,24 +87,24 @@ stderr | mcp-app-bridge.test.ts &gt; pre-handshake guarding &gt; sendToolListCha
 stderr | mcp-app-bridge.test.ts &gt; pre-handshake guarding &gt; log is silently dropped before handshake
 [MCPApp] notify blocked before handshake: ui/log
 
- ✓ mcp-app-bridge.test.ts (48 tests) 683ms
+ ✓ mcp-app-bridge.test.ts (48 tests) 691ms
 
  Test Files  1 passed (1)
       Tests  48 passed (48)
-   Start at  14:34:51
-   Duration  1.43s (transform 38ms, setup 0ms, collect 35ms, tests 683ms, environment 387ms, prepare 125ms)
+   Start at  00:43:01
+   Duration  1.36s (transform 31ms, setup 0ms, collect 30ms, tests 691ms, environment 339ms, prepare 68ms)
 
-Finished: Thu Apr 30 14:34:53 PDT 2026
+Finished: Mon May  4 00:43:03 PDT 2026
 </pre></details>
 <details id='log-protogen'><summary class='pass'>protogen — PASS</summary><pre>
 === Stage 5/12: protogen (make test-protogen) ===
-Started: Thu Apr 30 14:34:53 PDT 2026
+Started: Mon May  4 00:43:03 PDT 2026
 cd experimental/ext/protogen &amp;&amp; go test ./... -count=1 -timeout 30s &amp;&amp; /Library/Developer/CommandLineTools/usr/bin/make test-e2e
 ?   	github.com/panyam/mcpkit/experimental/ext/protogen/cmd/protoc-gen-go-mcp	[no test files]
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/generator	0.351s
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/proto/mcp/v1	0.635s
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/runtime	0.933s
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/schema	1.225s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/generator	1.489s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/proto/mcp/v1	0.647s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/runtime	0.670s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/schema	0.971s
 ?   	github.com/panyam/mcpkit/experimental/ext/protogen/testutil	[no test files]
 go build -o bin/protoc-gen-go-mcp ./cmd/protoc-gen-go-mcp
 go install ./cmd/protoc-gen-go-mcp
@@ -113,38 +113,37 @@ cd ../../../examples/protogen/bookservice &amp;&amp; rm -rf gen &amp;&amp; buf g
 [33mWARN[0m	plugin "protoc-gen-go-mcp" does not support required features.
   Feature "proto3 optional" is required by 1 file(s):
     bookservice/v1/service.proto
-ok  	github.com/panyam/mcpkit/examples/protogen/bookservice	0.422s
+ok  	github.com/panyam/mcpkit/examples/protogen/bookservice	0.768s
 ==&gt; e2e: passed
-Finished: Thu Apr 30 14:34:57 PDT 2026
+Finished: Mon May  4 00:43:09 PDT 2026
 </pre></details>
 <details id='log-e2e'><summary class='pass'>e2e — PASS</summary><pre>
 === Stage 6/12: e2e (make test-e2e) ===
-Started: Thu Apr 30 14:34:57 PDT 2026
+Started: Mon May  4 00:43:09 PDT 2026
 cd tests/e2e &amp;&amp; go test ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/tests/e2e	4.446s
-ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.450s
-Finished: Thu Apr 30 14:35:02 PDT 2026
+ok  	github.com/panyam/mcpkit/tests/e2e	3.625s
+ok  	github.com/panyam/mcpkit/tests/e2e/apps	1.026s
+Finished: Mon May  4 00:43:13 PDT 2026
 </pre></details>
 <details id='log-experimental'><summary class='pass'>experimental — PASS</summary><pre>
 === Stage 7/12: experimental (make test-experimental) ===
-Started: Thu Apr 30 14:35:02 PDT 2026
+Started: Mon May  4 00:43:13 PDT 2026
 cd experimental/ext/events &amp;&amp; go test ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/experimental/ext/events	0.386s
+ok  	github.com/panyam/mcpkit/experimental/ext/events	1.090s
 cd experimental/ext/events/clients/go &amp;&amp; go test ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/experimental/ext/events/clients/go	6.411s
+ok  	github.com/panyam/mcpkit/experimental/ext/events/clients/go	6.889s
 cd examples/events/discord &amp;&amp; go test ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/examples/events/discord	4.462s
+ok  	github.com/panyam/mcpkit/examples/events/discord	3.880s
 cd examples/events/telegram &amp;&amp; go test ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/examples/events/telegram	7.964s
-Finished: Thu Apr 30 14:35:24 PDT 2026
+ok  	github.com/panyam/mcpkit/examples/events/telegram	7.516s
+Finished: Mon May  4 00:43:35 PDT 2026
 </pre></details>
 <details id='log-conformance'><summary class='pass'>conformance — PASS</summary><pre>
 === Stage 8/12: conformance (make testconf) ===
-Started: Thu Apr 30 14:35:24 PDT 2026
+Started: Mon May  4 00:43:35 PDT 2026
 bash scripts/conformance-test.sh
-Killing stale process on port 18799...
 === Starting test server on :18799 (Streamable HTTP) ===
-Waiting for server....2026/04/30 14:35:26 MCP test server listening on :18799 (Streamable HTTP at /mcp)
+Waiting for server.....2026/05/04 00:43:36 MCP test server listening on :18799 (Streamable HTTP at /mcp)
  ready
 
 === Running MCP conformance suite ===
@@ -155,295 +154,295 @@ Running active suite (30 scenarios) against http://localhost:18799/mcp
 
 === Running scenario: server-initialize ===
 Running client scenario 'server-initialize' against server: http://localhost:18799/mcp
-2026/04/30 14:35:27 Starting MCP-GET-SSE SSE connection: 25aba30c70f1abbfb40eb89699a94d81
-2026/04/30 14:35:27 SSEHub: registered connection 25aba30c70f1abbfb40eb89699a94d81 (total: 1)
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: a5438f72ce48a801eeb3b7f80ad066b3
+2026/05/04 00:43:39 SSEHub: registered connection a5438f72ce48a801eeb3b7f80ad066b3 (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection a5438f72ce48a801eeb3b7f80ad066b3 (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a809b36150
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a809b36150
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: a5438f72ce48a801eeb3b7f80ad066b3
 
 === Running scenario: logging-set-level ===
-2026/04/30 14:35:27 SSEHub: unregistered connection 25aba30c70f1abbfb40eb89699a94d81 (total: 0)
 Running client scenario 'logging-set-level' against server: http://localhost:18799/mcp
-2026/04/30 14:35:27 Received kill signal.  Quitting Writer. stop 0x72c089261c0
-2026/04/30 14:35:27 Cleaning up writer...
-2026/04/30 14:35:27 Finished cleaning up writer:  0x72c089261c0
-2026/04/30 14:35:27 Closed MCP-GET-SSE SSE connection: 25aba30c70f1abbfb40eb89699a94d81
-2026/04/30 14:35:27 Starting MCP-GET-SSE SSE connection: 118de176ce8f3233ef7284338b563a86
-2026/04/30 14:35:27 SSEHub: registered connection 118de176ce8f3233ef7284338b563a86 (total: 1)
-2026/04/30 14:35:27 SSEHub: unregistered connection 118de176ce8f3233ef7284338b563a86 (total: 0)
-2026/04/30 14:35:27 Received kill signal.  Quitting Writer. stop 0x72c08926460
-2026/04/30 14:35:27 Cleaning up writer...
-2026/04/30 14:35:27 Finished cleaning up writer:  0x72c08926460
-2026/04/30 14:35:27 Closed MCP-GET-SSE SSE connection: 118de176ce8f3233ef7284338b563a86
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: 56591bca03d8770b7aa29023e2d0d75f
+2026/05/04 00:43:39 SSEHub: registered connection 56591bca03d8770b7aa29023e2d0d75f (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection 56591bca03d8770b7aa29023e2d0d75f (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a8096a6460
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a8096a6460
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: 56591bca03d8770b7aa29023e2d0d75f
 
 === Running scenario: ping ===
 Running client scenario 'ping' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: e5436ef452a1e0410533ab60bf4d182f
-2026/04/30 14:35:28 SSEHub: registered connection e5436ef452a1e0410533ab60bf4d182f (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection e5436ef452a1e0410533ab60bf4d182f (total: 0)
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c084c2380
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c084c2380
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: 1d43ce920c8e931f9c5aea6245fae6f7
+2026/05/04 00:43:39 SSEHub: registered connection 1d43ce920c8e931f9c5aea6245fae6f7 (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection 1d43ce920c8e931f9c5aea6245fae6f7 (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a809b36380
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a809b36380
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: 1d43ce920c8e931f9c5aea6245fae6f7
 
 === Running scenario: completion-complete ===
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: e5436ef452a1e0410533ab60bf4d182f
 Running client scenario 'completion-complete' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: 7086b9466dbae7fa1e6cef09f2032f48
-2026/04/30 14:35:28 SSEHub: registered connection 7086b9466dbae7fa1e6cef09f2032f48 (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection 7086b9466dbae7fa1e6cef09f2032f48 (total: 0)
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c08618af0
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c08618af0
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: 7086b9466dbae7fa1e6cef09f2032f48
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: 5f30086d5318fcdbcd945ad272980d63
+2026/05/04 00:43:39 SSEHub: registered connection 5f30086d5318fcdbcd945ad272980d63 (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection 5f30086d5318fcdbcd945ad272980d63 (total: 0)
 
 === Running scenario: tools-list ===
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a8096a6770
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a8096a6770
 Running client scenario 'tools-list' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: 14c3a93257d7ecd74b2803ce4df4f115
-2026/04/30 14:35:28 SSEHub: registered connection 14c3a93257d7ecd74b2803ce4df4f115 (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection 14c3a93257d7ecd74b2803ce4df4f115 (total: 0)
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c08926700
-2026/04/30 14:35:28 Cleaning up writer...
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: 5f30086d5318fcdbcd945ad272980d63
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: 56bee588f8b77acb1d154636bc6ffbf9
+2026/05/04 00:43:39 SSEHub: registered connection 56bee588f8b77acb1d154636bc6ffbf9 (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection 56bee588f8b77acb1d154636bc6ffbf9 (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a809c18230
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a809c18230
 
 === Running scenario: tools-call-simple-text ===
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c08926700
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: 56bee588f8b77acb1d154636bc6ffbf9
 Running client scenario 'tools-call-simple-text' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: 14c3a93257d7ecd74b2803ce4df4f115
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: 5c2b6d9c9b62a2dcfce9c0706439c105
-2026/04/30 14:35:28 SSEHub: registered connection 5c2b6d9c9b62a2dcfce9c0706439c105 (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection 5c2b6d9c9b62a2dcfce9c0706439c105 (total: 0)
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: 80b889a40df62e367771b2cae836f24b
+2026/05/04 00:43:39 SSEHub: registered connection 80b889a40df62e367771b2cae836f24b (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection 80b889a40df62e367771b2cae836f24b (total: 0)
 
 === Running scenario: tools-call-image ===
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c084c2700
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c084c2700
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: 5c2b6d9c9b62a2dcfce9c0706439c105
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a8096a6460
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a8096a6460
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: 80b889a40df62e367771b2cae836f24b
 Running client scenario 'tools-call-image' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: 574131bc2959dc64f9cb7285bda602b7
-2026/04/30 14:35:28 SSEHub: registered connection 574131bc2959dc64f9cb7285bda602b7 (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection 574131bc2959dc64f9cb7285bda602b7 (total: 0)
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: ed462fce4a6283bff83f12f80daa9f8a
+2026/05/04 00:43:39 SSEHub: registered connection ed462fce4a6283bff83f12f80daa9f8a (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection ed462fce4a6283bff83f12f80daa9f8a (total: 0)
 
 === Running scenario: tools-call-audio ===
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c084c2930
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c084c2930
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: 574131bc2959dc64f9cb7285bda602b7
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a8096a69a0
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a8096a69a0
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: ed462fce4a6283bff83f12f80daa9f8a
 Running client scenario 'tools-call-audio' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: a4a4c8170fe7ce41078b1007c29a811f
-2026/04/30 14:35:28 SSEHub: registered connection a4a4c8170fe7ce41078b1007c29a811f (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection a4a4c8170fe7ce41078b1007c29a811f (total: 0)
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: 981ac743d4b52760f6f86b7183db22a7
+2026/05/04 00:43:39 SSEHub: registered connection 981ac743d4b52760f6f86b7183db22a7 (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection 981ac743d4b52760f6f86b7183db22a7 (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a809806c40
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a809806c40
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: 981ac743d4b52760f6f86b7183db22a7
 
 === Running scenario: tools-call-embedded-resource ===
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c089269a0
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c089269a0
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: a4a4c8170fe7ce41078b1007c29a811f
 Running client scenario 'tools-call-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: 8b907438911e2c76b9f70dfe9600f216
-2026/04/30 14:35:28 SSEHub: registered connection 8b907438911e2c76b9f70dfe9600f216 (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection 8b907438911e2c76b9f70dfe9600f216 (total: 0)
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c08926cb0
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c08926cb0
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: 8b907438911e2c76b9f70dfe9600f216
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: 3d2e546cb526197983bddb7db8a98efa
+2026/05/04 00:43:39 SSEHub: registered connection 3d2e546cb526197983bddb7db8a98efa (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection 3d2e546cb526197983bddb7db8a98efa (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a8096a6cb0
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a8096a6cb0
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: 3d2e546cb526197983bddb7db8a98efa
 
 === Running scenario: tools-call-mixed-content ===
 Running client scenario 'tools-call-mixed-content' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: eb2212329eefcd6eee4c8f4efefcfd03
-2026/04/30 14:35:28 SSEHub: registered connection eb2212329eefcd6eee4c8f4efefcfd03 (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection eb2212329eefcd6eee4c8f4efefcfd03 (total: 0)
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c084c2b60
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c084c2b60
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: eb2212329eefcd6eee4c8f4efefcfd03
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: c444296948894137acacfa638de8c78a
+2026/05/04 00:43:39 SSEHub: registered connection c444296948894137acacfa638de8c78a (total: 1)
 
 === Running scenario: tools-call-with-logging ===
+2026/05/04 00:43:39 SSEHub: unregistered connection c444296948894137acacfa638de8c78a (total: 0)
 Running client scenario 'tools-call-with-logging' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: 47dc3002f088eabe4a4b49423780b4f9
-2026/04/30 14:35:28 SSEHub: registered connection 47dc3002f088eabe4a4b49423780b4f9 (total: 1)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a8096a6f50
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a8096a6f50
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: c444296948894137acacfa638de8c78a
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: d9f5912ee89b4e5ee77ef846fdb45050
+2026/05/04 00:43:39 SSEHub: registered connection d9f5912ee89b4e5ee77ef846fdb45050 (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection d9f5912ee89b4e5ee77ef846fdb45050 (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a8096a7260
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a8096a7260
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: d9f5912ee89b4e5ee77ef846fdb45050
 
 === Running scenario: tools-call-error ===
-2026/04/30 14:35:28 SSEHub: unregistered connection 47dc3002f088eabe4a4b49423780b4f9 (total: 0)
 Running client scenario 'tools-call-error' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c086191f0
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c086191f0
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: 47dc3002f088eabe4a4b49423780b4f9
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: 1e1a3d746df0b27a34949c6d6961868c
-2026/04/30 14:35:28 SSEHub: registered connection 1e1a3d746df0b27a34949c6d6961868c (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection 1e1a3d746df0b27a34949c6d6961868c (total: 0)
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: 46e6a2024c8da0e0cd335ae8f0e04432
+2026/05/04 00:43:39 SSEHub: registered connection 46e6a2024c8da0e0cd335ae8f0e04432 (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection 46e6a2024c8da0e0cd335ae8f0e04432 (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a8096a7490
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a8096a7490
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: 46e6a2024c8da0e0cd335ae8f0e04432
 
 === Running scenario: tools-call-with-progress ===
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c084c2ee0
 Running client scenario 'tools-call-with-progress' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c084c2ee0
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: 1e1a3d746df0b27a34949c6d6961868c
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: ff995e31cad0554e12487d4d28bdc698
-2026/04/30 14:35:28 SSEHub: registered connection ff995e31cad0554e12487d4d28bdc698 (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection ff995e31cad0554e12487d4d28bdc698 (total: 0)
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c08927030
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c08927030
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: ff995e31cad0554e12487d4d28bdc698
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: 8a829d086dc80b252feb2311e55b4c9f
+2026/05/04 00:43:39 SSEHub: registered connection 8a829d086dc80b252feb2311e55b4c9f (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection 8a829d086dc80b252feb2311e55b4c9f (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a809c18620
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a809c18620
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: 8a829d086dc80b252feb2311e55b4c9f
 
 === Running scenario: tools-call-sampling ===
 Running client scenario 'tools-call-sampling' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: eb0eadea11d9aae14080a23027ee5d85
-2026/04/30 14:35:28 SSEHub: registered connection eb0eadea11d9aae14080a23027ee5d85 (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection eb0eadea11d9aae14080a23027ee5d85 (total: 0)
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c084c31f0
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c084c31f0
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: eb0eadea11d9aae14080a23027ee5d85
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: 0198bd658c705fbcceb871fe36850779
+2026/05/04 00:43:39 SSEHub: registered connection 0198bd658c705fbcceb871fe36850779 (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection 0198bd658c705fbcceb871fe36850779 (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a8096a7810
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a8096a7810
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: 0198bd658c705fbcceb871fe36850779
 
 === Running scenario: tools-call-elicitation ===
 Running client scenario 'tools-call-elicitation' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: 5714e73ce9ea4dc2d65f9405a106866f
-2026/04/30 14:35:28 SSEHub: registered connection 5714e73ce9ea4dc2d65f9405a106866f (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection 5714e73ce9ea4dc2d65f9405a106866f (total: 0)
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c084c3420
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c084c3420
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: 906888231ae927601214ee97d01c0fcb
+2026/05/04 00:43:39 SSEHub: registered connection 906888231ae927601214ee97d01c0fcb (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection 906888231ae927601214ee97d01c0fcb (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a809807030
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a809807030
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: 906888231ae927601214ee97d01c0fcb
 
 === Running scenario: elicitation-sep1034-defaults ===
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: 5714e73ce9ea4dc2d65f9405a106866f
 Running client scenario 'elicitation-sep1034-defaults' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: 6f2224cebd75ec90d1fa069e927c8145
-2026/04/30 14:35:28 SSEHub: registered connection 6f2224cebd75ec90d1fa069e927c8145 (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection 6f2224cebd75ec90d1fa069e927c8145 (total: 0)
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c084c3650
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c084c3650
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: 6f2224cebd75ec90d1fa069e927c8145
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: 04651dab4d9baca67defc59a078b59ca
+2026/05/04 00:43:39 SSEHub: registered connection 04651dab4d9baca67defc59a078b59ca (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection 04651dab4d9baca67defc59a078b59ca (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a809807260
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a809807260
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: 04651dab4d9baca67defc59a078b59ca
 
 === Running scenario: server-sse-multiple-streams ===
 Running client scenario 'server-sse-multiple-streams' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: f0418ff88b08a86b0920724f281e6a0c
-2026/04/30 14:35:28 SSEHub: registered connection f0418ff88b08a86b0920724f281e6a0c (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection f0418ff88b08a86b0920724f281e6a0c (total: 0)
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: ce81dfb47bfeeda23bf5d0e232bb129d
+2026/05/04 00:43:39 SSEHub: registered connection ce81dfb47bfeeda23bf5d0e232bb129d (total: 1)
 
 === Running scenario: elicitation-sep1330-enums ===
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c08619730
-2026/04/30 14:35:28 Cleaning up writer...
+2026/05/04 00:43:39 SSEHub: unregistered connection ce81dfb47bfeeda23bf5d0e232bb129d (total: 0)
 Running client scenario 'elicitation-sep1330-enums' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c08619730
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: f0418ff88b08a86b0920724f281e6a0c
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: 1660a1e91835636b667f1dbcc91255f4
-2026/04/30 14:35:28 SSEHub: registered connection 1660a1e91835636b667f1dbcc91255f4 (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection 1660a1e91835636b667f1dbcc91255f4 (total: 0)
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c084c3960
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c084c3960
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: 1660a1e91835636b667f1dbcc91255f4
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a8096a7ce0
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a8096a7ce0
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: ce81dfb47bfeeda23bf5d0e232bb129d
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: a52647faad60ce72bc4266b0c7305512
+2026/05/04 00:43:39 SSEHub: registered connection a52647faad60ce72bc4266b0c7305512 (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection a52647faad60ce72bc4266b0c7305512 (total: 0)
 
 === Running scenario: resources-list ===
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a8097e8460
 Running client scenario 'resources-list' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: 78b42bd43dde02c3533da7df84a025d3
-2026/04/30 14:35:28 SSEHub: registered connection 78b42bd43dde02c3533da7df84a025d3 (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection 78b42bd43dde02c3533da7df84a025d3 (total: 0)
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c08619a40
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c08619a40
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: 78b42bd43dde02c3533da7df84a025d3
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a8097e8460
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: a52647faad60ce72bc4266b0c7305512
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: 03f6d88baa9def27e3aba77096429ebe
+2026/05/04 00:43:39 SSEHub: registered connection 03f6d88baa9def27e3aba77096429ebe (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection 03f6d88baa9def27e3aba77096429ebe (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a8097e8850
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a8097e8850
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: 03f6d88baa9def27e3aba77096429ebe
 
 === Running scenario: resources-read-text ===
 Running client scenario 'resources-read-text' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: 117ce28a7a80270537ebc7653d59559d
-2026/04/30 14:35:28 SSEHub: registered connection 117ce28a7a80270537ebc7653d59559d (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection 117ce28a7a80270537ebc7653d59559d (total: 0)
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c089275e0
-2026/04/30 14:35:28 Cleaning up writer...
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: 25ede364d2def077e0e27ba04f4d6809
+2026/05/04 00:43:39 SSEHub: registered connection 25ede364d2def077e0e27ba04f4d6809 (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection 25ede364d2def077e0e27ba04f4d6809 (total: 0)
 
 === Running scenario: resources-read-binary ===
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c089275e0
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: 117ce28a7a80270537ebc7653d59559d
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a80989a230
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a80989a230
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: 25ede364d2def077e0e27ba04f4d6809
 Running client scenario 'resources-read-binary' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: d86ca0b70ea141ecbbbeacdc9b7b42c8
-2026/04/30 14:35:28 SSEHub: registered connection d86ca0b70ea141ecbbbeacdc9b7b42c8 (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection d86ca0b70ea141ecbbbeacdc9b7b42c8 (total: 0)
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: 3dff1a2a24128041620596ac224be159
+2026/05/04 00:43:39 SSEHub: registered connection 3dff1a2a24128041620596ac224be159 (total: 1)
 
 === Running scenario: resources-templates-read ===
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c08619ce0
-2026/04/30 14:35:28 Cleaning up writer...
 Running client scenario 'resources-templates-read' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c08619ce0
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: d86ca0b70ea141ecbbbeacdc9b7b42c8
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: 7c99f2dc4e91ddef29d78b099be9b36d
-2026/04/30 14:35:28 SSEHub: registered connection 7c99f2dc4e91ddef29d78b099be9b36d (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection 7c99f2dc4e91ddef29d78b099be9b36d (total: 0)
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c0874e000
-2026/04/30 14:35:28 Cleaning up writer...
+2026/05/04 00:43:39 SSEHub: unregistered connection 3dff1a2a24128041620596ac224be159 (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a80989a4d0
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a80989a4d0
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: 3dff1a2a24128041620596ac224be159
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: ab9fdfb5357103f0c106a0d0b768b639
+2026/05/04 00:43:39 SSEHub: registered connection ab9fdfb5357103f0c106a0d0b768b639 (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection ab9fdfb5357103f0c106a0d0b768b639 (total: 0)
 
 === Running scenario: resources-subscribe ===
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c0874e000
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: 7c99f2dc4e91ddef29d78b099be9b36d
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a809c18bd0
 Running client scenario 'resources-subscribe' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: 5d0fda3b9de90f5e07f86a68f9e8f0c5
-2026/04/30 14:35:28 SSEHub: registered connection 5d0fda3b9de90f5e07f86a68f9e8f0c5 (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection 5d0fda3b9de90f5e07f86a68f9e8f0c5 (total: 0)
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a809c18bd0
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: ab9fdfb5357103f0c106a0d0b768b639
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: d03793fc5fb0bd2a052c6e57b079917b
+2026/05/04 00:43:39 SSEHub: registered connection d03793fc5fb0bd2a052c6e57b079917b (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection d03793fc5fb0bd2a052c6e57b079917b (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a809c18e70
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a809c18e70
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: d03793fc5fb0bd2a052c6e57b079917b
 
 === Running scenario: resources-unsubscribe ===
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c08927960
-2026/04/30 14:35:28 Cleaning up writer...
 Running client scenario 'resources-unsubscribe' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c08927960
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: 5d0fda3b9de90f5e07f86a68f9e8f0c5
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: 975d2e36f73bbe7ccb4089e6ac456c28
-2026/04/30 14:35:28 SSEHub: registered connection 975d2e36f73bbe7ccb4089e6ac456c28 (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection 975d2e36f73bbe7ccb4089e6ac456c28 (total: 0)
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: 4f99fa8ea271af38df3dfe73ae019ba7
+2026/05/04 00:43:39 SSEHub: registered connection 4f99fa8ea271af38df3dfe73ae019ba7 (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection 4f99fa8ea271af38df3dfe73ae019ba7 (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a8097e8bd0
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a8097e8bd0
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: 4f99fa8ea271af38df3dfe73ae019ba7
 
 === Running scenario: prompts-list ===
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c084c3c00
 Running client scenario 'prompts-list' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c084c3c00
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: 975d2e36f73bbe7ccb4089e6ac456c28
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: bd7509f69a8a9987ed3a23d8aafe6745
-2026/04/30 14:35:28 SSEHub: registered connection bd7509f69a8a9987ed3a23d8aafe6745 (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection bd7509f69a8a9987ed3a23d8aafe6745 (total: 0)
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c08927ce0
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c08927ce0
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: bd7509f69a8a9987ed3a23d8aafe6745
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: d85ec9a2c38f2b082ba572d409f828b1
+2026/05/04 00:43:39 SSEHub: registered connection d85ec9a2c38f2b082ba572d409f828b1 (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection d85ec9a2c38f2b082ba572d409f828b1 (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a80989a770
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a80989a770
 
 === Running scenario: prompts-get-simple ===
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: d85ec9a2c38f2b082ba572d409f828b1
 Running client scenario 'prompts-get-simple' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: 08ace7b0e437136059392061ed4f8735
-2026/04/30 14:35:28 SSEHub: registered connection 08ace7b0e437136059392061ed4f8735 (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection 08ace7b0e437136059392061ed4f8735 (total: 0)
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c085b0770
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c085b0770
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: 08ace7b0e437136059392061ed4f8735
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: a5f6878298af67d6116d9af3160861f2
+2026/05/04 00:43:39 SSEHub: registered connection a5f6878298af67d6116d9af3160861f2 (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection a5f6878298af67d6116d9af3160861f2 (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a80989a9a0
+2026/05/04 00:43:39 Cleaning up writer...
 
 === Running scenario: prompts-get-with-args ===
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a80989a9a0
 Running client scenario 'prompts-get-with-args' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: 8a292461496cacfe6adb37afcce0ee29
-2026/04/30 14:35:28 SSEHub: registered connection 8a292461496cacfe6adb37afcce0ee29 (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection 8a292461496cacfe6adb37afcce0ee29 (total: 0)
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c085b09a0
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c085b09a0
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: a5f6878298af67d6116d9af3160861f2
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: 2a677a008147a07b9fc829cad7c60af0
+2026/05/04 00:43:39 SSEHub: registered connection 2a677a008147a07b9fc829cad7c60af0 (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection 2a677a008147a07b9fc829cad7c60af0 (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a809be6070
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a809be6070
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: 2a677a008147a07b9fc829cad7c60af0
 
 === Running scenario: prompts-get-embedded-resource ===
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: 8a292461496cacfe6adb37afcce0ee29
 Running client scenario 'prompts-get-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: dd7990109675701c39006b4bd5190c0c
-2026/04/30 14:35:28 SSEHub: registered connection dd7990109675701c39006b4bd5190c0c (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection dd7990109675701c39006b4bd5190c0c (total: 0)
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c0874e310
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c0874e310
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: dd7990109675701c39006b4bd5190c0c
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: 281da2b2fd52ee904323cfa117179f9d
+2026/05/04 00:43:39 SSEHub: registered connection 281da2b2fd52ee904323cfa117179f9d (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection 281da2b2fd52ee904323cfa117179f9d (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a809be6310
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a809be6310
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: 281da2b2fd52ee904323cfa117179f9d
 
 === Running scenario: prompts-get-with-image ===
 Running client scenario 'prompts-get-with-image' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: 76f6e6391f3628a9ebcb0ce419ce3cf8
-2026/04/30 14:35:28 SSEHub: registered connection 76f6e6391f3628a9ebcb0ce419ce3cf8 (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection 76f6e6391f3628a9ebcb0ce419ce3cf8 (total: 0)
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c08b581c0
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c08b581c0
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: 1ebee1d0715987cff3e978331cbe4010
+2026/05/04 00:43:39 SSEHub: registered connection 1ebee1d0715987cff3e978331cbe4010 (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection 1ebee1d0715987cff3e978331cbe4010 (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a809c192d0
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a809c192d0
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: 1ebee1d0715987cff3e978331cbe4010
 
 === Running scenario: dns-rebinding-protection ===
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: 76f6e6391f3628a9ebcb0ce419ce3cf8
 Running client scenario 'dns-rebinding-protection' against server: http://localhost:18799/mcp
 
 
@@ -484,11 +483,11 @@ Total: 40 passed, 0 failed
 [32mBaseline check passed: all failures are expected.[0m
 
 === CONFORMANCE TESTS PASSED ===
-Finished: Thu Apr 30 14:35:28 PDT 2026
+Finished: Mon May  4 00:43:40 PDT 2026
 </pre></details>
 <details id='log-auth-conformance'><summary class='pass'>auth-conformance — PASS</summary><pre>
 === Stage 9/12: auth-conformance (make testconfauth) ===
-Started: Thu Apr 30 14:35:28 PDT 2026
+Started: Mon May  4 00:43:40 PDT 2026
 bash scripts/conformance-auth-test.sh
 Building testclient...
 === Running MCP Auth conformance suite ===
@@ -510,22 +509,22 @@ Starting scenario: auth/token-endpoint-auth-basic
 Starting scenario: auth/token-endpoint-auth-post
 Starting scenario: auth/token-endpoint-auth-none
 Starting scenario: auth/pre-registration
-Executing client: ./bin/testclient http://localhost:65307/mcp
-Executing client: ./bin/testclient http://localhost:65308/mcp
-Executing client: ./bin/testclient http://localhost:65309/mcp
-Executing client: ./bin/testclient http://localhost:65310/mcp
-Executing client: ./bin/testclient http://localhost:65311/mcp
-Executing client: ./bin/testclient http://localhost:65312/mcp
-Executing client: ./bin/testclient http://localhost:65313/mcp
-Executing client: ./bin/testclient http://localhost:65314/mcp
-Executing client: ./bin/testclient http://localhost:65315/mcp
-Executing client: ./bin/testclient http://localhost:65316/mcp
-Executing client: ./bin/testclient http://localhost:65317/mcp
-Executing client: ./bin/testclient http://localhost:65318/mcp
-Executing client: ./bin/testclient http://localhost:65319/mcp
-Executing client: ./bin/testclient http://localhost:65320/mcp
+Executing client: ./bin/testclient http://localhost:51925/mcp
+Executing client: ./bin/testclient http://localhost:51926/mcp
+Executing client: ./bin/testclient http://localhost:51927/mcp
+Executing client: ./bin/testclient http://localhost:51928/mcp
+Executing client: ./bin/testclient http://localhost:51929/mcp
+Executing client: ./bin/testclient http://localhost:51930/mcp
+Executing client: ./bin/testclient http://localhost:51931/mcp
+Executing client: ./bin/testclient http://localhost:51932/mcp
+Executing client: ./bin/testclient http://localhost:51933/mcp
+Executing client: ./bin/testclient http://localhost:51934/mcp
+Executing client: ./bin/testclient http://localhost:51935/mcp
+Executing client: ./bin/testclient http://localhost:51936/mcp
+Executing client: ./bin/testclient http://localhost:51937/mcp
+Executing client: ./bin/testclient http://localhost:51938/mcp
 With context: {"client_id":"pre-registered-client","client_secret":"pre-registered-secret"}
-(node:22698) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
+(node:9687) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
 (Use `node --trace-deprecation ...` to show where the warning was created)
 
 === SUITE SUMMARY ===
@@ -553,11 +552,11 @@ Total: 210 passed, 0 failed, 1 warnings
 [32mBaseline check passed: all failures are expected.[0m
 
 === AUTH CONFORMANCE TESTS PASSED ===
-Finished: Thu Apr 30 14:35:30 PDT 2026
+Finished: Mon May  4 00:43:42 PDT 2026
 </pre></details>
 <details id='log-tasks-conformance'><summary class='pass'>tasks-conformance — PASS</summary><pre>
 === Stage 10/12: tasks-conformance (make testconf-tasks) ===
-Started: Thu Apr 30 14:35:30 PDT 2026
+Started: Mon May  4 00:43:42 PDT 2026
 ========================================================================
   MCP Tasks — Async Tool Execution Lifecycle
   Walks through the MCP Tasks (SEP-1036) lifecycle: optional/required task support, polling, progress notifications, and cancellation.
@@ -600,10 +599,9 @@ Started: Thu Apr 30 14:35:30 PDT 2026
     (progress, status changes) reach us during polling.
 
     Press Enter to run this step...
-Connected to telegram-events 0.1.0
-
-Tools (with task support metadata):
-- send_message taskSupport=forbidden
+ERROR: initialize failed: Post "http://localhost:8080/mcp": dial tcp
+[::1]:8080: connect: connection refused
+Start the server with: make serve
 
 
   Step 2/8: Sync call: greet (taskSupport=forbidden)
@@ -616,7 +614,8 @@ Tools (with task support metadata):
     use today; tasks are opt-in per tool.
 
     Press Enter to run this step...
-ERROR: RPC error -32602: unknown tool: greet
+ERROR: Post "http://localhost:8080/mcp": dial tcp [::1]:8080: connect:
+connection refused
 
 
   Step 3/8: Optional task: slow_compute as task → CreateTaskResult
@@ -629,7 +628,8 @@ ERROR: RPC error -32602: unknown tool: greet
     immediately while the work runs in a background goroutine.
 
     Press Enter to run this step...
-ERROR: RPC error -32602: unknown tool: slow_compute
+ERROR: Post "http://localhost:8080/mcp": dial tcp [::1]:8080: connect:
+connection refused
 
 
   Step 4/8: Poll tasks/get until terminal — receive notifications/progress
@@ -644,7 +644,8 @@ ERROR: RPC error -32602: unknown tool: slow_compute
     stops.
 
     Press Enter to run this step...
-ERROR: RPC error -32601: method not found: tasks/get
+ERROR: Post "http://localhost:8080/mcp": dial tcp [::1]:8080: connect:
+connection refused
 
 
   Step 5/8: Fetch the result payload via tasks/result
@@ -657,7 +658,8 @@ ERROR: RPC error -32601: method not found: tasks/get
     tasks/result with the same taskId.
 
     Press Enter to run this step...
-ERROR: RPC error -32601: method not found: tasks/result
+ERROR: Post "http://localhost:8080/mcp": dial tcp [::1]:8080: connect:
+connection refused
 
 
   Step 6/8: Required task: failing_job — sync call returns an error
@@ -670,7 +672,8 @@ ERROR: RPC error -32601: method not found: tasks/result
     guards expensive/long tools from blocking the request thread.
 
     Press Enter to run this step...
-Server returned: RPC error -32602: unknown tool: failing_job
+Server returned: Post "http://localhost:8080/mcp": dial tcp [::1]:8080:
+connect: connection refused
 
 
   Step 7/8: Invoke failing_job as task → terminal status: failed
@@ -686,7 +689,8 @@ Server returned: RPC error -32602: unknown tool: failing_job
     polling call.
 
     Press Enter to run this step...
-ERROR: RPC error -32602: unknown tool: failing_job
+ERROR: Post "http://localhost:8080/mcp": dial tcp [::1]:8080: connect:
+connection refused
 
 
   Step 8/8: Cancel a long-running task mid-flight
@@ -705,7 +709,8 @@ ERROR: RPC error -32602: unknown tool: failing_job
     cancel doesn't overwrite the cancelled status.
 
     Press Enter to run this step...
-ERROR: RPC error -32602: unknown tool: slow_compute
+ERROR: Post "http://localhost:8080/mcp": dial tcp [::1]:8080: connect:
+connection refused
 
 
   --- Where each piece lives in mcpkit ---
@@ -725,34 +730,34 @@ ERROR: RPC error -32602: unknown tool: slow_compute
 
 === Done ===
 ▶ MCP Tasks Conformance
-  ✔ scenario 01: sync tool call returns immediately (5.534709ms)
-  ✔ scenario 02: async task creation returns CreateTaskResult (1.580584ms)
-  ✔ scenario 03: tasks/get returns flat task info (3.258792ms)
-  ✔ scenario 04: failing tool transitions to failed (1016.332292ms)
-  ✔ scenario 05: tasks/result returns ToolResult with related-task meta (1021.86425ms)
-  ✔ scenario 06: cancel returns cancelled status (3.45825ms)
-  ✔ scenario 07: tasks/list returns task array (2.1835ms)
-  ✔ scenario 08: required tool without task hint returns error (1.361125ms)
-  ✔ scenario 09: forbidden tool with task hint returns error (1.286084ms)
-  ✔ scenario 10: external proxy tool completes via task callbacks (1014.599542ms)
-  ✔ scenario 11: external proxy tool tasks/get returns task info (1.876291ms)
-  ✔ scenario 12: optional tool without hint runs synchronously (1001.395334ms)
-  ✔ scenario 13: tasks/get with bogus taskId returns error (1.267291ms)
-  ✔ scenario 14: tasks/cancel with bogus taskId returns error (0.9955ms)
-  ✔ scenario 15: cancel completed task returns error (1013.752042ms)
-  ✔ scenario 16: CreateTaskResult includes a TTL (0.958916ms)
-  ✔ scenario 17: CreateTaskResult pollInterval is valid if present (0.804834ms)
-  ✔ scenario 18: task must not expire before TTL (1516.309625ms)
-  ✔ scenario 19: concurrent task creation produces unique taskIds (1023.268042ms)
-  ✔ scenario 20: tasks/result for failed task has isError true (1014.767917ms)
-  ✔ scenario 21: tools/list includes execution.taskSupport (2.323875ms)
-  ✔ scenario 22: elicitation round-trip via tasks/result (6.73425ms)
-  ✔ scenario 23: sampling round-trip via tasks/result (7.68575ms)
-  ✔ scenario 24: progress notifications are well-formed if sent (2025.576083ms)
-  ✔ scenario 25: status notifications match task state if sent (1515.890875ms)
-  ✔ scenario 26: tasks/result includes related-task _meta (1017.0525ms)
-  ✔ scenario 27: tasks/get does not include related-task _meta (2.356ms)
-✔ MCP Tasks Conformance (13241.662084ms)
+  ✔ scenario 01: sync tool call returns immediately (4.211792ms)
+  ✔ scenario 02: async task creation returns CreateTaskResult (1.355416ms)
+  ✔ scenario 03: tasks/get returns flat task info (2.342125ms)
+  ✔ scenario 04: failing tool transitions to failed (1028.671542ms)
+  ✔ scenario 05: tasks/result returns ToolResult with related-task meta (1037.055416ms)
+  ✔ scenario 06: cancel returns cancelled status (6.420041ms)
+  ✔ scenario 07: tasks/list returns task array (2.840583ms)
+  ✔ scenario 08: required tool without task hint returns error (1.586125ms)
+  ✔ scenario 09: forbidden tool with task hint returns error (1.272041ms)
+  ✔ scenario 10: external proxy tool completes via task callbacks (1034.218417ms)
+  ✔ scenario 11: external proxy tool tasks/get returns task info (5.017209ms)
+  ✔ scenario 12: optional tool without hint runs synchronously (1003.907916ms)
+  ✔ scenario 13: tasks/get with bogus taskId returns error (4.685583ms)
+  ✔ scenario 14: tasks/cancel with bogus taskId returns error (2.225333ms)
+  ✔ scenario 15: cancel completed task returns error (1036.887916ms)
+  ✔ scenario 16: CreateTaskResult includes a TTL (2.512667ms)
+  ✔ scenario 17: CreateTaskResult pollInterval is valid if present (1.514417ms)
+  ✔ scenario 18: task must not expire before TTL (1536.077958ms)
+  ✔ scenario 19: concurrent task creation produces unique taskIds (1050.300708ms)
+  ✔ scenario 20: tasks/result for failed task has isError true (1029.944541ms)
+  ✔ scenario 21: tools/list includes execution.taskSupport (5.149125ms)
+  ✔ scenario 22: elicitation round-trip via tasks/result (14.495417ms)
+  ✔ scenario 23: sampling round-trip via tasks/result (4.780458ms)
+  ✔ scenario 24: progress notifications are well-formed if sent (2054.152708ms)
+  ✔ scenario 25: status notifications match task state if sent (1537.212292ms)
+  ✔ scenario 26: tasks/result includes related-task _meta (1039.856875ms)
+  ✔ scenario 27: tasks/get does not include related-task _meta (3.946834ms)
+✔ MCP Tasks Conformance (13470.952917ms)
 ℹ tests 27
 ℹ suites 1
 ℹ pass 27
@@ -760,242 +765,268 @@ ERROR: RPC error -32602: unknown tool: slow_compute
 ℹ cancelled 0
 ℹ skipped 0
 ℹ todo 0
-ℹ duration_ms 13580.469375
-Finished: Thu Apr 30 14:35:46 PDT 2026
+ℹ duration_ms 13828.108166
+Finished: Mon May  4 00:43:59 PDT 2026
 </pre></details>
 <details id='log-tasks-v2-conformance'><summary class='pass'>tasks-v2-conformance — PASS</summary><pre>
 === Stage 11/12: tasks-v2-conformance (make testconf-tasks-v2) ===
-Started: Thu Apr 30 14:35:46 PDT 2026
-2026/04/30 14:35:46 Tasks v2 demo server on :18092
-2026/04/30 14:35:46 Connect: http://localhost:18092/mcp
-2026/04/30 14:35:46 
-2026/04/30 14:35:46 Tools:
-2026/04/30 14:35:46   greet              — sync-only
-2026/04/30 14:35:46   slow_compute       — optional task (server-directed)
-2026/04/30 14:35:46   failing_job        — required task (tool error → completed + isError)
-2026/04/30 14:35:46   confirm_delete     — required task (input_required → tasks/update → completed)
-2026/04/30 14:35:46   protocol_error_job — required task (protocol error → failed + error)
-2026/04/30 14:35:46   external_job       — required task (TaskCallbacks proxy)
-2026/04/30 14:35:48 MCP initialize ok [320.958µs]
-2026/04/30 14:35:48 MCP notifications/initialized ok [541ns]
-2026/04/30 14:35:48 Starting MCP-GET-SSE SSE connection: baf859e600d3e9ee12c62f65f62f6cbf
-2026/04/30 14:35:48 SSEHub: registered connection baf859e600d3e9ee12c62f65f62f6cbf (total: 1)
-2026/04/30 14:35:48 MCP initialize ok [40.625µs]
-2026/04/30 14:35:48 MCP notifications/initialized ok [292ns]
-2026/04/30 14:35:48 MCP initialize ok [3.209µs]
-2026/04/30 14:35:48 MCP notifications/initialized ok [291ns]
-2026/04/30 14:35:48 MCP tools/call ok [56.334µs]
-2026/04/30 14:35:48 MCP tools/call ok [20.958µs]
+Started: Mon May  4 00:43:59 PDT 2026
+2026/05/04 00:44:01 Tasks v2 demo server on :18092
+2026/05/04 00:44:01 Connect: http://localhost:18092/mcp
+2026/05/04 00:44:01 
+2026/05/04 00:44:01 Tools:
+2026/05/04 00:44:01   greet              — sync-only
+2026/05/04 00:44:01   slow_compute       — optional task (server-directed)
+2026/05/04 00:44:01   failing_job        — required task (tool error → completed + isError)
+2026/05/04 00:44:01   confirm_delete     — required task (input_required → tasks/update → completed)
+2026/05/04 00:44:01   protocol_error_job — required task (protocol error → failed + error)
+2026/05/04 00:44:01   external_job       — required task (TaskCallbacks proxy)
+2026/05/04 00:44:02 MCP initialize ok [293.833µs]
+2026/05/04 00:44:02 MCP notifications/initialized ok [458ns]
+2026/05/04 00:44:02 Starting MCP-GET-SSE SSE connection: 437afce20a9ed8cd84e12e8f5d13f216
+2026/05/04 00:44:02 SSEHub: registered connection 437afce20a9ed8cd84e12e8f5d13f216 (total: 1)
+2026/05/04 00:44:02 MCP initialize ok [34.375µs]
+2026/05/04 00:44:02 MCP notifications/initialized ok [208ns]
+2026/05/04 00:44:02 MCP initialize ok [6.458µs]
+2026/05/04 00:44:02 MCP notifications/initialized ok [333ns]
+2026/05/04 00:44:02 MCP tools/call ok [72.834µs]
+2026/05/04 00:44:02 MCP tools/call ok [11.583µs]
+2026/05/04 00:44:02 [slow_compute] starting "v2-create": sleeping 2s...
 ▶ MCP Tasks v2 Conformance (SEP-2663)
-  ✔ v2-01: sync tool call returns immediately, no task (2.163375ms)
-2026/04/30 14:35:48 [slow_compute] starting "v2-create": sleeping 2s...
-2026/04/30 14:35:48 MCP tools/call ok [5.166µs]
-2026/04/30 14:35:48 [slow_compute] starting "v2-poll": sleeping 3s...
-  ✔ v2-02: server creates task without client task param (1.855792ms)
-2026/04/30 14:35:48 MCP tasks/get ok [8.416µs]
-2026/04/30 14:35:48 MCP tools/call ok [8.708µs]
-2026/04/30 14:35:48 [slow_compute] starting "v2-result": sleeping 1s...
-  ✔ v2-03: tasks/get returns status for active task (1.862542ms)
-2026/04/30 14:35:48 MCP tasks/get ok [3.708µs]
-2026/04/30 14:35:48 MCP tasks/get ok [8.083µs]
-2026/04/30 14:35:48 MCP tasks/get ok [10.5µs]
-2026/04/30 14:35:48 MCP tasks/get ok [23µs]
-2026/04/30 14:35:49 MCP tasks/get ok [6.958µs]
-2026/04/30 14:35:49 [slow_compute] finished "v2-result"
-2026/04/30 14:35:49 MCP tasks/get ok [17.208µs]
-2026/04/30 14:35:49 MCP tools/call ok [9.459µs]
-2026/04/30 14:35:49 [failing_job] starting (will fail in 1s)...
-2026/04/30 14:35:49 MCP tasks/get ok [3.958µs]
-  ✔ v2-04: tasks/get returns completed status with inlined result (1015.339667ms)
-2026/04/30 14:35:49 MCP tasks/get ok [9.541µs]
-2026/04/30 14:35:49 MCP tasks/get ok [26.166µs]
-2026/04/30 14:35:49 MCP tasks/get ok [11.209µs]
-2026/04/30 14:35:50 MCP tasks/get ok [6.208µs]
-2026/04/30 14:35:50 [slow_compute] finished "v2-create"
-2026/04/30 14:35:50 MCP tasks/get ok [13.792µs]
-2026/04/30 14:35:50 MCP tools/call ok [10.583µs]
-2026/04/30 14:35:50 [protocol_error_job] starting (will panic in 500ms)...
-  ✔ v2-05: tool execution error is completed with isError true (1016.758541ms)
-2026/04/30 14:35:50 MCP tasks/get ok [3.542µs]
-2026/04/30 14:35:50 MCP tasks/get ok [8.5µs]
-2026/04/30 14:35:50 MCP tasks/get ok [8.833µs]
-2026/04/30 14:35:50 MCP tasks/get ok [6.708µs]
-2026/04/30 14:35:50 MCP tools/call ok [19.375µs]
-2026/04/30 14:35:50 [slow_compute] starting "v2-cancel": sleeping 60s...
-  ✔ v2-06: protocol error is failed with error field (608.549125ms)
-2026/04/30 14:35:50 [slow_compute] cancelled "v2-cancel" at 1/60
-2026/04/30 14:35:50 MCP tasks/cancel ok [53.708µs]
-2026/04/30 14:35:50 MCP tasks/get ok [23.959µs]
-2026/04/30 14:35:50 MCP tools/call ok [9.25µs]
-2026/04/30 14:35:50 [slow_compute] starting "v2-cancel-done": sleeping 1s...
-  ✔ v2-07: tasks/cancel returns empty ack; status settles to cancelled (3.365334ms)
-2026/04/30 14:35:50 MCP tasks/get ok [3.917µs]
-2026/04/30 14:35:51 MCP tasks/get ok [6.75µs]
-2026/04/30 14:35:51 [slow_compute] finished "v2-poll"
-2026/04/30 14:35:51 MCP tasks/get ok [7.541µs]
-2026/04/30 14:35:51 MCP tasks/get ok [19.584µs]
-2026/04/30 14:35:51 MCP tasks/get ok [40.875µs]
-2026/04/30 14:35:51 [slow_compute] finished "v2-cancel-done"
-2026/04/30 14:35:51 MCP tasks/get ok [15.25µs]
-2026/04/30 14:35:51 MCP tasks/cancel error=-32602 (task is already in a terminal state) [4.75µs]
-2026/04/30 14:35:51 MCP tools/call ok [23.167µs]
-2026/04/30 14:35:51 [slow_compute] starting "v2-no-result": sleeping 1s...
-  ✔ v2-08: cancel completed task returns error (1015.996084ms)
-2026/04/30 14:35:51 MCP tasks/get ok [4.834µs]
-2026/04/30 14:35:52 MCP tasks/get ok [6.125µs]
-2026/04/30 14:35:52 MCP tasks/get ok [30.667µs]
-2026/04/30 14:35:52 MCP tasks/get ok [21.25µs]
-2026/04/30 14:35:52 MCP tasks/get ok [6.875µs]
-2026/04/30 14:35:52 [slow_compute] finished "v2-no-result"
-2026/04/30 14:35:52 MCP tasks/get ok [14.666µs]
-2026/04/30 14:35:52 MCP tasks/result error=-32601 (method not found: tasks/result) [2.459µs]
-2026/04/30 14:35:52 MCP tasks/list error=-32601 (method not found: tasks/list) [2.708µs]
-  ✔ v2-09: tasks/result is rejected (method removed in v2) (1017.306875ms)
-2026/04/30 14:35:52 MCP tools/call ok [18.292µs]
-2026/04/30 14:35:52 [slow_compute] starting "v2-ttl": sleeping 1s...
-  ✔ v2-10: tasks/list is rejected (method removed in v2) (0.824ms)
-  ✔ v2-11: tasks advertised under capabilities.extensions, not capabilities.tasks (0.108583ms)
-2026/04/30 14:35:52 MCP tools/call ok [7µs]
-2026/04/30 14:35:52 [slow_compute] starting "v2-ttl-guard": sleeping 1s...
-  ✔ v2-12: ttlSeconds present (and v1 ttl key absent) (0.839291ms)
-2026/04/30 14:35:52 MCP tasks/get ok [4.541µs]
-2026/04/30 14:35:53 MCP tasks/get ok [7.5µs]
-2026/04/30 14:35:53 MCP tasks/get ok [6.75µs]
-2026/04/30 14:35:53 MCP tasks/get ok [9.75µs]
-2026/04/30 14:35:53 MCP tasks/get ok [7.667µs]
-2026/04/30 14:35:53 [slow_compute] finished "v2-ttl"
-2026/04/30 14:35:53 [slow_compute] finished "v2-ttl-guard"
-2026/04/30 14:35:53 MCP tasks/get ok [60.125µs]
-2026/04/30 14:35:54 MCP tasks/get ok [27.209µs]
-2026/04/30 14:35:54 MCP tools/call ok [16.625µs]
-2026/04/30 14:35:54 [slow_compute] starting "v2-reqstate": sleeping 1s...
-  ✔ v2-13: task must not expire before TTL (1519.705667ms)
-2026/04/30 14:35:54 MCP tasks/get ok [6.625µs]
-2026/04/30 14:35:54 MCP tasks/get ok [23µs]
-2026/04/30 14:35:54 MCP tasks/get ok [10.166µs]
-2026/04/30 14:35:55 MCP tasks/get ok [6.209µs]
-2026/04/30 14:35:55 MCP tasks/get ok [8.666µs]
-2026/04/30 14:35:55 [slow_compute] finished "v2-reqstate"
-2026/04/30 14:35:55 MCP tasks/get ok [22.5µs]
-2026/04/30 14:35:55 MCP tasks/get ok [42.709µs]
-2026/04/30 14:35:55 MCP tools/call ok [22.042µs]
-2026/04/30 14:35:55 [slow_compute] starting "v2-reqstate-echo": sleeping 2s...
-  ✔ v2-14: tasks/get response may include requestState (1018.0765ms)
-2026/04/30 14:35:55 MCP tasks/get ok [4.333µs]
-2026/04/30 14:35:55 MCP tasks/get ok [4.042µs]
-2026/04/30 14:35:55 MCP tools/call ok [12.167µs]
-  ✔ v2-15: client echoes requestState in subsequent requests (2.778ms)
-2026/04/30 14:35:55 [confirm_delete] asking about "v2-input.txt" (parking task in input_required)...
-2026/04/30 14:35:55 MCP tasks/get ok [9.458µs]
-2026/04/30 14:35:55 MCP tools/call ok [8.167µs]
-2026/04/30 14:35:55 [confirm_delete] asking about "v2-respond.txt" (parking task in input_required)...
-  ✔ v2-16: input_required task has inputRequests map in tasks/get (1.691542ms)
-2026/04/30 14:35:55 MCP tasks/get ok [4.375µs]
-2026/04/30 14:35:55 MCP tasks/update ok [31.917µs]
-2026/04/30 14:35:55 [confirm_delete] user confirmed; deleting "v2-respond.txt"
-2026/04/30 14:35:55 MCP tasks/get ok [9.084µs]
-2026/04/30 14:35:55 MCP tools/call ok [29.792µs]
-2026/04/30 14:35:55 [slow_compute] starting "v2-notify": sleeping 1s...
-  ✔ v2-17: tasks/update inputResponses resume task (3.331ms)
-2026/04/30 14:35:55 MCP tasks/get ok [9.125µs]
-2026/04/30 14:35:55 MCP tasks/get ok [22.208µs]
-2026/04/30 14:35:55 MCP tasks/get ok [1.511708ms]
-2026/04/30 14:35:56 MCP tasks/get ok [23.25µs]
-2026/04/30 14:35:56 MCP tasks/get ok [21.833µs]
-2026/04/30 14:35:56 [slow_compute] finished "v2-notify"
-2026/04/30 14:35:56 MCP tasks/get ok [19.25µs]
-2026/04/30 14:35:57 MCP tools/call ok [26µs]
-2026/04/30 14:35:57 [failing_job] starting (will fail in 1s)...
-  ✔ v2-18: status notifications include DetailedTask if sent (1524.302125ms)
-2026/04/30 14:35:57 MCP tools/call ok [52.75µs]
-  ✔ v2-19: tools/call without task param creates task for async tools (3.091291ms)
-2026/04/30 14:35:57 MCP tools/call ok [7.833µs]
-  ✔ v2-20: server may return immediate result for fast operations (2.764042ms)
-2026/04/30 14:35:57 [slow_compute] starting "v2-no-meta": sleeping 1s...
-2026/04/30 14:35:57 MCP tasks/get ok [6.916µs]
-2026/04/30 14:35:57 MCP tasks/get ok [11.25µs]
-2026/04/30 14:35:57 MCP tasks/get ok [11.166µs]
-2026/04/30 14:35:57 [slow_compute] finished "v2-reqstate-echo"
-2026/04/30 14:35:57 MCP tasks/get ok [12.791µs]
-2026/04/30 14:35:57 MCP tasks/get ok [28.542µs]
-2026/04/30 14:35:58 [slow_compute] finished "v2-no-meta"
-2026/04/30 14:35:58 MCP tasks/get ok [33.875µs]
-2026/04/30 14:35:58 MCP tasks/get error=-32601 (method requires extension io.modelcontextprotocol/tasks) [5.083µs]
-  ✔ v2-21: tasks/get inlined result does not include related-task _meta (1019.612166ms)
-2026/04/30 14:35:58 MCP tasks/update error=-32601 (method requires extension io.modelcontextprotocol/tasks) [2.542µs]
-2026/04/30 14:35:58 MCP tasks/cancel error=-32601 (method requires extension io.modelcontextprotocol/tasks) [4.125µs]
-2026/04/30 14:35:58 MCP tools/call ok [48.583µs]
-  ✔ v2-22: tasks/* return -32601 when extension not negotiated (3.283208ms)
-2026/04/30 14:35:58 MCP tools/call ok [28.625µs]
-2026/04/30 14:35:58 [slow_compute] starting "v2-24": sleeping 1s...
-  ✔ v2-23: tools/call without extension returns sync ToolResult (result_type:"complete", no task) (1.274375ms)
-2026/04/30 14:35:58 MCP tools/call ok [17.167µs]
-  ✔ v2-24: Mcp-Name response header on task-creating tools/call (1.20125ms)
-2026/04/30 14:35:58 MCP tools/call ok [19.041µs]
-2026/04/30 14:35:58 [slow_compute] starting "v2-25": sleeping 1s...
-  ✔ v2-24b: Mcp-Name absent on sync tools/call response (1.015542ms)
-2026/04/30 14:35:58 MCP tools/call ok [17.042µs]
-  ✔ v2-25: per-request _meta opt-in produces CreateTaskResult (1.133959ms)
-2026/04/30 14:35:58 MCP tools/call ok [11.333µs]
-2026/04/30 14:35:58 MCP tasks/get ok [15.959µs]
-2026/04/30 14:35:58 MCP tasks/get ok [13.542µs]
-2026/04/30 14:35:58 MCP tools/call ok [10.125µs]
-2026/04/30 14:35:58 [slow_compute] starting "v2-26-cancel": sleeping 60s...
-2026/04/30 14:35:58 [slow_compute] cancelled "v2-26-cancel" at 1/60
-2026/04/30 14:35:58 MCP tasks/cancel ok [41.458µs]
-2026/04/30 14:35:58 MCP tools/call ok [5.917µs]
-2026/04/30 14:35:58 [confirm_delete] asking about "v2-26.txt" (parking task in input_required)...
-2026/04/30 14:35:58 MCP tasks/get ok [4.209µs]
-2026/04/30 14:35:58 MCP tasks/update ok [7µs]
-2026/04/30 14:35:58 MCP tasks/cancel ok [29.959µs]
-2026/04/30 14:35:58 SSEHub: unregistered connection baf859e600d3e9ee12c62f65f62f6cbf (total: 0)
-2026/04/30 14:35:58 Received kill signal.  Quitting Writer. stop 0x50acee58e3f0
-2026/04/30 14:35:58 Cleaning up writer...
-2026/04/30 14:35:58 Finished cleaning up writer:  0x50acee58e3f0
-2026/04/30 14:35:58 Closed MCP-GET-SSE SSE connection: baf859e600d3e9ee12c62f65f62f6cbf
-  ✔ v2-26: non-task responses carry result_type:"complete" (SEP-2322) (9.057875ms)
-✔ MCP Tasks v2 Conformance (SEP-2663) (9821.378541ms)
-ℹ tests 27
+  ✔ v2-01: sync tool call returns immediately, no task (2.582666ms)
+2026/05/04 00:44:02 MCP tools/call ok [6.625µs]
+2026/05/04 00:44:02 [slow_compute] starting "v2-poll": sleeping 3s...
+  ✔ v2-02: server creates task without client task param (1.315041ms)
+2026/05/04 00:44:02 MCP tasks/get ok [14.708µs]
+2026/05/04 00:44:02 MCP tools/call ok [6.084µs]
+2026/05/04 00:44:02 [slow_compute] starting "v2-result": sleeping 1s...
+  ✔ v2-03: tasks/get returns status for active task (2.628ms)
+2026/05/04 00:44:02 MCP tasks/get ok [4.708µs]
+2026/05/04 00:44:02 MCP tasks/get ok [22.042µs]
+2026/05/04 00:44:02 MCP tasks/get ok [18.459µs]
+2026/05/04 00:44:02 MCP tasks/get ok [15.875µs]
+2026/05/04 00:44:03 MCP tasks/get ok [25.083µs]
+2026/05/04 00:44:03 [slow_compute] finished "v2-result"
+2026/05/04 00:44:03 MCP tasks/get ok [53.75µs]
+2026/05/04 00:44:03 MCP tools/call ok [49.125µs]
+2026/05/04 00:44:03 [failing_job] starting (will fail in 1s)...
+  ✔ v2-04: tasks/get returns completed status with inlined result (1026.892541ms)
+2026/05/04 00:44:03 MCP tasks/get ok [20.75µs]
+2026/05/04 00:44:03 MCP tasks/get ok [6.667µs]
+2026/05/04 00:44:03 MCP tasks/get ok [28µs]
+2026/05/04 00:44:03 MCP tasks/get ok [37.458µs]
+2026/05/04 00:44:04 MCP tasks/get ok [29.791µs]
+2026/05/04 00:44:04 [slow_compute] finished "v2-create"
+2026/05/04 00:44:04 MCP tasks/get ok [56.209µs]
+2026/05/04 00:44:04 MCP tools/call ok [32.833µs]
+2026/05/04 00:44:04 [protocol_error_job] starting (will panic in 500ms)...
+  ✔ v2-05: tool execution error is completed with isError true (1028.27675ms)
+2026/05/04 00:44:04 MCP tasks/get ok [18.708µs]
+2026/05/04 00:44:04 MCP tasks/get ok [31.167µs]
+2026/05/04 00:44:04 MCP tasks/get ok [17.459µs]
+2026/05/04 00:44:04 MCP tasks/get ok [23.833µs]
+2026/05/04 00:44:04 MCP tools/call ok [83.042µs]
+2026/05/04 00:44:04 [slow_compute] starting "v2-cancel": sleeping 60s...
+  ✔ v2-06: protocol error is failed with error field (619.631708ms)
+2026/05/04 00:44:04 MCP tasks/cancel ok [885.5µs]
+2026/05/04 00:44:04 [slow_compute] cancelled "v2-cancel" at 1/60
+2026/05/04 00:44:04 MCP tasks/get ok [64.25µs]
+2026/05/04 00:44:04 MCP tools/call ok [44.041µs]
+2026/05/04 00:44:04 [slow_compute] starting "v2-cancel-done": sleeping 1s...
+  ✔ v2-07: tasks/cancel returns empty ack; status settles to cancelled (9.350375ms)
+2026/05/04 00:44:04 MCP tasks/get ok [10.625µs]
+2026/05/04 00:44:05 MCP tasks/get ok [13.333µs]
+2026/05/04 00:44:05 [slow_compute] finished "v2-poll"
+2026/05/04 00:44:05 MCP tasks/get ok [11.375µs]
+2026/05/04 00:44:05 MCP tasks/get ok [26.708µs]
+2026/05/04 00:44:05 MCP tasks/get ok [14.083µs]
+2026/05/04 00:44:05 [slow_compute] finished "v2-cancel-done"
+2026/05/04 00:44:05 MCP tasks/get ok [28.292µs]
+2026/05/04 00:44:05 MCP tasks/cancel error=-32602 (task is already in a terminal state) [10.291µs]
+2026/05/04 00:44:05 MCP tools/call ok [24.625µs]
+2026/05/04 00:44:05 [slow_compute] starting "v2-no-result": sleeping 1s...
+  ✔ v2-08: cancel completed task returns error (1022.157791ms)
+2026/05/04 00:44:05 MCP tasks/get ok [6.583µs]
+2026/05/04 00:44:06 MCP tasks/get ok [21.25µs]
+2026/05/04 00:44:06 MCP tasks/get ok [17.625µs]
+2026/05/04 00:44:06 MCP tasks/get ok [25.125µs]
+2026/05/04 00:44:06 MCP tasks/get ok [22.333µs]
+2026/05/04 00:44:06 [slow_compute] finished "v2-no-result"
+2026/05/04 00:44:07 MCP tasks/get ok [39.292µs]
+2026/05/04 00:44:07 MCP tasks/result error=-32601 (method not found: tasks/result) [7.916µs]
+2026/05/04 00:44:07 MCP tasks/list error=-32601 (method not found: tasks/list) [6.583µs]
+  ✔ v2-09: tasks/result is rejected (method removed in v2) (1026.445083ms)
+2026/05/04 00:44:07 MCP tools/call ok [67.917µs]
+2026/05/04 00:44:07 [slow_compute] starting "v2-ttl": sleeping 1s...
+  ✔ v2-10: tasks/list is rejected (method removed in v2) (2.697958ms)
+  ✔ v2-11: tasks advertised under capabilities.extensions, not capabilities.tasks (0.381791ms)
+2026/05/04 00:44:07 MCP tools/call ok [25.417µs]
+2026/05/04 00:44:07 [slow_compute] starting "v2-ttl-guard": sleeping 1s...
+  ✔ v2-12: ttlSeconds + pollIntervalMilliseconds present (legacy v1 keys absent) (2.750584ms)
+2026/05/04 00:44:07 MCP tasks/get ok [8.583µs]
+2026/05/04 00:44:07 MCP tasks/get ok [26.041µs]
+2026/05/04 00:44:07 MCP tasks/get ok [22.959µs]
+2026/05/04 00:44:07 MCP tasks/get ok [23.916µs]
+2026/05/04 00:44:07 MCP tasks/get ok [25.417µs]
+2026/05/04 00:44:08 [slow_compute] finished "v2-ttl"
+2026/05/04 00:44:08 [slow_compute] finished "v2-ttl-guard"
+2026/05/04 00:44:08 MCP tasks/get ok [61.25µs]
+2026/05/04 00:44:08 MCP tasks/get ok [90.041µs]
+2026/05/04 00:44:08 MCP tools/call ok [45.459µs]
+2026/05/04 00:44:08 [slow_compute] starting "v2-reqstate": sleeping 1s...
+  ✔ v2-13: task must not expire before TTL (1531.758417ms)
+2026/05/04 00:44:08 MCP tasks/get ok [18.083µs]
+2026/05/04 00:44:08 MCP tasks/get ok [23.542µs]
+2026/05/04 00:44:08 MCP tasks/get ok [25.833µs]
+2026/05/04 00:44:09 MCP tasks/get ok [25.833µs]
+2026/05/04 00:44:09 MCP tasks/get ok [26.416µs]
+2026/05/04 00:44:09 [slow_compute] finished "v2-reqstate"
+2026/05/04 00:44:09 MCP tasks/get ok [56.292µs]
+2026/05/04 00:44:09 MCP tasks/get ok [50.167µs]
+2026/05/04 00:44:09 MCP tools/call ok [62.334µs]
+2026/05/04 00:44:09 [slow_compute] starting "v2-reqstate-echo": sleeping 2s...
+  ✔ v2-14: tasks/get response may include requestState (1033.088666ms)
+2026/05/04 00:44:09 MCP tasks/get ok [14.333µs]
+2026/05/04 00:44:09 MCP tasks/get ok [14.958µs]
+2026/05/04 00:44:09 MCP tools/call ok [35.166µs]
+2026/05/04 00:44:09 [confirm_delete] asking about "v2-input.txt" (parking task in input_required)...
+  ✔ v2-15: client echoes requestState in subsequent requests (6.728834ms)
+2026/05/04 00:44:09 MCP tasks/get ok [13.167µs]
+2026/05/04 00:44:09 MCP tools/call ok [21.875µs]
+2026/05/04 00:44:09 [confirm_delete] asking about "v2-respond.txt" (parking task in input_required)...
+  ✔ v2-16: input_required task has inputRequests map in tasks/get (3.993833ms)
+2026/05/04 00:44:09 MCP tasks/get ok [13.416µs]
+2026/05/04 00:44:09 MCP tasks/update ok [39µs]
+2026/05/04 00:44:09 [confirm_delete] user confirmed; deleting "v2-respond.txt"
+2026/05/04 00:44:09 MCP tasks/get ok [25.625µs]
+2026/05/04 00:44:09 MCP tools/call ok [32.25µs]
+2026/05/04 00:44:09 [slow_compute] starting "v2-notify": sleeping 1s...
+  ✔ v2-17: tasks/update inputResponses resume task (6.354084ms)
+2026/05/04 00:44:09 MCP tasks/get ok [8.041µs]
+2026/05/04 00:44:09 MCP tasks/get ok [24.959µs]
+2026/05/04 00:44:10 MCP tasks/get ok [29.958µs]
+2026/05/04 00:44:10 MCP tasks/get ok [14.792µs]
+2026/05/04 00:44:10 MCP tasks/get ok [28.916µs]
+2026/05/04 00:44:10 [slow_compute] finished "v2-notify"
+2026/05/04 00:44:10 MCP tasks/get ok [51.5µs]
+2026/05/04 00:44:11 MCP tools/call ok [35.833µs]
+2026/05/04 00:44:11 [failing_job] starting (will fail in 1s)...
+  ✔ v2-18: status notifications include DetailedTask if sent (1529.370584ms)
+2026/05/04 00:44:11 MCP tools/call ok [30.25µs]
+  ✔ v2-19: tools/call without task param creates task for async tools (3.671625ms)
+2026/05/04 00:44:11 MCP tools/call ok [42.5µs]
+2026/05/04 00:44:11 [slow_compute] starting "v2-no-meta": sleeping 1s...
+  ✔ v2-20: server may return immediate result for fast operations (2.729625ms)
+2026/05/04 00:44:11 MCP tasks/get ok [15.583µs]
+2026/05/04 00:44:11 MCP tasks/get ok [28.292µs]
+2026/05/04 00:44:11 MCP tasks/get ok [29.625µs]
+2026/05/04 00:44:11 [slow_compute] finished "v2-reqstate-echo"
+2026/05/04 00:44:11 MCP tasks/get ok [21.25µs]
+2026/05/04 00:44:11 MCP tasks/get ok [26.959µs]
+2026/05/04 00:44:12 [slow_compute] finished "v2-no-meta"
+2026/05/04 00:44:12 MCP tasks/get ok [59.5µs]
+2026/05/04 00:44:12 MCP tasks/get error=-32601 (method requires extension io.modelcontextprotocol/tasks) [13.208µs]
+  ✔ v2-21: tasks/get inlined result does not include related-task _meta (1028.228375ms)
+2026/05/04 00:44:12 MCP tasks/update error=-32601 (method requires extension io.modelcontextprotocol/tasks) [9.416µs]
+2026/05/04 00:44:12 MCP tasks/cancel error=-32601 (method requires extension io.modelcontextprotocol/tasks) [9.167µs]
+2026/05/04 00:44:12 MCP tools/call ok [84.042µs]
+  ✔ v2-22: tasks/* return -32601 when extension not negotiated (8.154542ms)
+2026/05/04 00:44:12 MCP tools/call ok [51.5µs]
+2026/05/04 00:44:12 [slow_compute] starting "v2-24": sleeping 1s...
+  ✔ v2-23: tools/call without extension returns sync ToolResult (resultType:"complete", no task) (2.141625ms)
+2026/05/04 00:44:12 MCP tools/call ok [36.584µs]
+  ✔ v2-24: Mcp-Name + Mcp-Method response headers on task-creating tools/call (2.054959ms)
+2026/05/04 00:44:12 MCP tools/call ok [120.75µs]
+2026/05/04 00:44:12 [slow_compute] starting "v2-24c": sleeping 60s...
+  ✔ v2-24b: Mcp-Name absent on sync tools/call response (Mcp-Method still present) (1.81325ms)
+2026/05/04 00:44:12 MCP tasks/get ok [33.375µs]
+2026/05/04 00:44:12 [slow_compute] cancelled "v2-24c" at 1/60
+2026/05/04 00:44:12 MCP tasks/cancel ok [120.208µs]
+2026/05/04 00:44:12 MCP tools/call ok [35.958µs]
+2026/05/04 00:44:12 [slow_compute] starting "v2-25": sleeping 1s...
+  ✔ v2-24c: Mcp-Method on tasks/get and tasks/cancel responses (6.171291ms)
+2026/05/04 00:44:12 MCP tools/call ok [25.958µs]
+  ✔ v2-25: per-request _meta opt-in produces CreateTaskResult (1.899625ms)
+2026/05/04 00:44:12 MCP tools/call ok [15.041µs]
+2026/05/04 00:44:12 MCP tasks/get ok [20.75µs]
+2026/05/04 00:44:12 MCP tasks/get ok [11.542µs]
+2026/05/04 00:44:12 MCP tools/call ok [8.209µs]
+2026/05/04 00:44:12 [slow_compute] starting "v2-26-cancel": sleeping 60s...
+2026/05/04 00:44:12 [slow_compute] cancelled "v2-26-cancel" at 1/60
+2026/05/04 00:44:12 MCP tasks/cancel ok [65.708µs]
+2026/05/04 00:44:12 MCP tools/call ok [9.042µs]
+2026/05/04 00:44:12 [confirm_delete] asking about "v2-26.txt" (parking task in input_required)...
+2026/05/04 00:44:12 MCP tasks/get ok [11.625µs]
+2026/05/04 00:44:12 MCP tasks/update ok [9.625µs]
+2026/05/04 00:44:12 MCP tasks/cancel ok [49.75µs]
+2026/05/04 00:44:12 MCP tools/call ok [10.667µs]
+2026/05/04 00:44:12 [slow_compute] starting "v2-27": sleeping 60s...
+  ✔ v2-26: non-task responses carry resultType:"complete" (SEP-2322) (11.063333ms)
+2026/05/04 00:44:12 MCP tasks/get ok [4.542µs]
+2026/05/04 00:44:12 [slow_compute] cancelled "v2-27" at 1/60
+2026/05/04 00:44:12 MCP tasks/cancel ok [44.792µs]
+2026/05/04 00:44:12 MCP tools/call ok [7.667µs]
+2026/05/04 00:44:12 [slow_compute] starting "v2-28": sleeping 60s...
+  ✔ v2-27: tasks/get immediately after CreateTaskResult must resolve (2.447375ms)
+2026/05/04 00:44:12 MCP tasks/get ok [3.583µs]
+2026/05/04 00:44:12 MCP tasks/get ok [5.5µs]
+2026/05/04 00:44:12 MCP tasks/get ok [3.5µs]
+2026/05/04 00:44:12 [slow_compute] cancelled "v2-28" at 1/60
+2026/05/04 00:44:12 MCP tasks/cancel ok [38.917µs]
+2026/05/04 00:44:12 SSEHub: unregistered connection 437afce20a9ed8cd84e12e8f5d13f216 (total: 0)
+2026/05/04 00:44:12 Received kill signal.  Quitting Writer. stop 0x6c9cb1f42f50
+2026/05/04 00:44:12 Cleaning up writer...
+2026/05/04 00:44:12 Finished cleaning up writer:  0x6c9cb1f42f50
+2026/05/04 00:44:12 Closed MCP-GET-SSE SSE connection: 437afce20a9ed8cd84e12e8f5d13f216
+  ✔ v2-28: stale-but-valid requestState is tolerated (3.408541ms)
+✔ MCP Tasks v2 Conformance (SEP-2663) (9952.914125ms)
+ℹ tests 30
 ℹ suites 1
-ℹ pass 27
+ℹ pass 30
 ℹ fail 0
 ℹ cancelled 0
 ℹ skipped 0
 ℹ todo 0
-ℹ duration_ms 10122.0405
-Finished: Thu Apr 30 14:35:58 PDT 2026
-2026/04/30 14:35:59 [slow_compute] finished "v2-24"
-2026/04/30 14:35:59 [slow_compute] finished "v2-25"
+ℹ duration_ms 10267.112042
+Finished: Mon May  4 00:44:12 PDT 2026
+2026/05/04 00:44:13 [slow_compute] finished "v2-24"
+2026/05/04 00:44:13 [slow_compute] finished "v2-25"
 </pre></details>
 <details id='log-keycloak'><summary class='pass'>keycloak — PASS</summary><pre>
 === Stage 12/12: keycloak (make testkcl-auto) ===
-Started: Thu Apr 30 14:35:58 PDT 2026
+Started: Mon May  4 00:44:12 PDT 2026
+Starting Keycloak for interop tests...
+936a897256ba51b212a49ab4c60b4dacd45c70c638f990246826c56609707cd7
+Keycloak starting on port 8180... (realm import takes ~30s)
+Run 'make kcllogs' to watch startup, 'make testkcl' when ready
+Waiting for Keycloak realm...
 === RUN   TestKeycloak_MCPServer_ValidToken
---- PASS: TestKeycloak_MCPServer_ValidToken (0.03s)
+--- PASS: TestKeycloak_MCPServer_ValidToken (0.23s)
 === RUN   TestKeycloak_MCPServer_TamperedToken
 --- PASS: TestKeycloak_MCPServer_TamperedToken (0.02s)
 === RUN   TestKeycloak_MCPServer_ScopeAllowed
---- PASS: TestKeycloak_MCPServer_ScopeAllowed (0.01s)
+--- PASS: TestKeycloak_MCPServer_ScopeAllowed (0.02s)
 === RUN   TestKeycloak_MCPServer_ScopeDenied
---- PASS: TestKeycloak_MCPServer_ScopeDenied (0.01s)
+--- PASS: TestKeycloak_MCPServer_ScopeDenied (0.02s)
 === RUN   TestKeycloak_MCPServer_PRM
 --- PASS: TestKeycloak_MCPServer_PRM (0.01s)
 === RUN   TestKeycloak_MCPServer_WWWAuthenticate
 --- PASS: TestKeycloak_MCPServer_WWWAuthenticate (0.01s)
 === RUN   TestKeycloak_MCPServer_PasswordGrant
---- PASS: TestKeycloak_MCPServer_PasswordGrant (0.04s)
+--- PASS: TestKeycloak_MCPServer_PasswordGrant (0.11s)
 === RUN   TestKeycloak_PublicMethods_DiscoverWithoutAuth
 --- PASS: TestKeycloak_PublicMethods_DiscoverWithoutAuth (0.01s)
 === RUN   TestKeycloak_PublicMethods_ToolCallRequiresAuth
 --- PASS: TestKeycloak_PublicMethods_ToolCallRequiresAuth (0.01s)
 === RUN   TestKeycloak_SessionHijack_DifferentUserRejected
---- PASS: TestKeycloak_SessionHijack_DifferentUserRejected (0.07s)
+--- PASS: TestKeycloak_SessionHijack_DifferentUserRejected (0.08s)
 === RUN   TestKeycloak_SessionHijack_SameUserAllowed
---- PASS: TestKeycloak_SessionHijack_SameUserAllowed (0.06s)
+--- PASS: TestKeycloak_SessionHijack_SameUserAllowed (0.04s)
 === RUN   TestKeycloak_TokenRefresh_PasswordGrant
---- PASS: TestKeycloak_TokenRefresh_PasswordGrant (0.09s)
+--- PASS: TestKeycloak_TokenRefresh_PasswordGrant (0.06s)
 PASS
-ok  	github.com/panyam/mcpkit/tests/keycloak	0.870s
-Finished: Thu Apr 30 14:36:00 PDT 2026
+ok  	github.com/panyam/mcpkit/tests/keycloak	1.321s
+make[2]: *** No rule to make target `downkcl'.  Stop.
+Finished: Mon May  4 00:44:25 PDT 2026
 </pre></details>
 </body></html>

--- a/tests/reports/run.log
+++ b/tests/reports/run.log
@@ -1,5 +1,5 @@
 === MCPKit Comprehensive Test Suite ===
-Started: Thu Apr 30 14:34:19 PDT 2026
+Started: Mon May  4 00:42:21 PDT 2026
 
 --- [1/12] unit+coverage ---
   PASS: unit+coverage
@@ -27,4 +27,4 @@ Started: Thu Apr 30 14:34:19 PDT 2026
   PASS: keycloak
 
 === Results: 12 passed, 0 failed ===
-Finished: Thu Apr 30 14:36:00 PDT 2026
+Finished: Mon May  4 00:44:25 PDT 2026

--- a/tests/reports/stage-auth-conformance.log
+++ b/tests/reports/stage-auth-conformance.log
@@ -1,5 +1,5 @@
 === Stage 9/12: auth-conformance (make testconfauth) ===
-Started: Thu Apr 30 14:35:28 PDT 2026
+Started: Mon May  4 00:43:40 PDT 2026
 bash scripts/conformance-auth-test.sh
 Building testclient...
 === Running MCP Auth conformance suite ===
@@ -21,22 +21,22 @@ Starting scenario: auth/token-endpoint-auth-basic
 Starting scenario: auth/token-endpoint-auth-post
 Starting scenario: auth/token-endpoint-auth-none
 Starting scenario: auth/pre-registration
-Executing client: ./bin/testclient http://localhost:65307/mcp
-Executing client: ./bin/testclient http://localhost:65308/mcp
-Executing client: ./bin/testclient http://localhost:65309/mcp
-Executing client: ./bin/testclient http://localhost:65310/mcp
-Executing client: ./bin/testclient http://localhost:65311/mcp
-Executing client: ./bin/testclient http://localhost:65312/mcp
-Executing client: ./bin/testclient http://localhost:65313/mcp
-Executing client: ./bin/testclient http://localhost:65314/mcp
-Executing client: ./bin/testclient http://localhost:65315/mcp
-Executing client: ./bin/testclient http://localhost:65316/mcp
-Executing client: ./bin/testclient http://localhost:65317/mcp
-Executing client: ./bin/testclient http://localhost:65318/mcp
-Executing client: ./bin/testclient http://localhost:65319/mcp
-Executing client: ./bin/testclient http://localhost:65320/mcp
+Executing client: ./bin/testclient http://localhost:51925/mcp
+Executing client: ./bin/testclient http://localhost:51926/mcp
+Executing client: ./bin/testclient http://localhost:51927/mcp
+Executing client: ./bin/testclient http://localhost:51928/mcp
+Executing client: ./bin/testclient http://localhost:51929/mcp
+Executing client: ./bin/testclient http://localhost:51930/mcp
+Executing client: ./bin/testclient http://localhost:51931/mcp
+Executing client: ./bin/testclient http://localhost:51932/mcp
+Executing client: ./bin/testclient http://localhost:51933/mcp
+Executing client: ./bin/testclient http://localhost:51934/mcp
+Executing client: ./bin/testclient http://localhost:51935/mcp
+Executing client: ./bin/testclient http://localhost:51936/mcp
+Executing client: ./bin/testclient http://localhost:51937/mcp
+Executing client: ./bin/testclient http://localhost:51938/mcp
 With context: {"client_id":"pre-registered-client","client_secret":"pre-registered-secret"}
-(node:22698) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
+(node:9687) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
 (Use `node --trace-deprecation ...` to show where the warning was created)
 
 === SUITE SUMMARY ===
@@ -64,4 +64,4 @@ Total: 210 passed, 0 failed, 1 warnings
 [32mBaseline check passed: all failures are expected.[0m
 
 === AUTH CONFORMANCE TESTS PASSED ===
-Finished: Thu Apr 30 14:35:30 PDT 2026
+Finished: Mon May  4 00:43:42 PDT 2026

--- a/tests/reports/stage-auth.log
+++ b/tests/reports/stage-auth.log
@@ -1,5 +1,5 @@
 === Stage 3/12: auth (make test-auth) ===
-Started: Thu Apr 30 14:34:48 PDT 2026
+Started: Mon May  4 00:42:56 PDT 2026
 cd ext/auth && go test ./... -count=1 -timeout 30s
-ok  	github.com/panyam/mcpkit/ext/auth	0.401s
-Finished: Thu Apr 30 14:34:49 PDT 2026
+ok  	github.com/panyam/mcpkit/ext/auth	0.718s
+Finished: Mon May  4 00:42:58 PDT 2026

--- a/tests/reports/stage-conformance.log
+++ b/tests/reports/stage-conformance.log
@@ -1,9 +1,8 @@
 === Stage 8/12: conformance (make testconf) ===
-Started: Thu Apr 30 14:35:24 PDT 2026
+Started: Mon May  4 00:43:35 PDT 2026
 bash scripts/conformance-test.sh
-Killing stale process on port 18799...
 === Starting test server on :18799 (Streamable HTTP) ===
-Waiting for server....2026/04/30 14:35:26 MCP test server listening on :18799 (Streamable HTTP at /mcp)
+Waiting for server.....2026/05/04 00:43:36 MCP test server listening on :18799 (Streamable HTTP at /mcp)
  ready
 
 === Running MCP conformance suite ===
@@ -14,295 +13,295 @@ Running active suite (30 scenarios) against http://localhost:18799/mcp
 
 === Running scenario: server-initialize ===
 Running client scenario 'server-initialize' against server: http://localhost:18799/mcp
-2026/04/30 14:35:27 Starting MCP-GET-SSE SSE connection: 25aba30c70f1abbfb40eb89699a94d81
-2026/04/30 14:35:27 SSEHub: registered connection 25aba30c70f1abbfb40eb89699a94d81 (total: 1)
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: a5438f72ce48a801eeb3b7f80ad066b3
+2026/05/04 00:43:39 SSEHub: registered connection a5438f72ce48a801eeb3b7f80ad066b3 (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection a5438f72ce48a801eeb3b7f80ad066b3 (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a809b36150
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a809b36150
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: a5438f72ce48a801eeb3b7f80ad066b3
 
 === Running scenario: logging-set-level ===
-2026/04/30 14:35:27 SSEHub: unregistered connection 25aba30c70f1abbfb40eb89699a94d81 (total: 0)
 Running client scenario 'logging-set-level' against server: http://localhost:18799/mcp
-2026/04/30 14:35:27 Received kill signal.  Quitting Writer. stop 0x72c089261c0
-2026/04/30 14:35:27 Cleaning up writer...
-2026/04/30 14:35:27 Finished cleaning up writer:  0x72c089261c0
-2026/04/30 14:35:27 Closed MCP-GET-SSE SSE connection: 25aba30c70f1abbfb40eb89699a94d81
-2026/04/30 14:35:27 Starting MCP-GET-SSE SSE connection: 118de176ce8f3233ef7284338b563a86
-2026/04/30 14:35:27 SSEHub: registered connection 118de176ce8f3233ef7284338b563a86 (total: 1)
-2026/04/30 14:35:27 SSEHub: unregistered connection 118de176ce8f3233ef7284338b563a86 (total: 0)
-2026/04/30 14:35:27 Received kill signal.  Quitting Writer. stop 0x72c08926460
-2026/04/30 14:35:27 Cleaning up writer...
-2026/04/30 14:35:27 Finished cleaning up writer:  0x72c08926460
-2026/04/30 14:35:27 Closed MCP-GET-SSE SSE connection: 118de176ce8f3233ef7284338b563a86
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: 56591bca03d8770b7aa29023e2d0d75f
+2026/05/04 00:43:39 SSEHub: registered connection 56591bca03d8770b7aa29023e2d0d75f (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection 56591bca03d8770b7aa29023e2d0d75f (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a8096a6460
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a8096a6460
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: 56591bca03d8770b7aa29023e2d0d75f
 
 === Running scenario: ping ===
 Running client scenario 'ping' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: e5436ef452a1e0410533ab60bf4d182f
-2026/04/30 14:35:28 SSEHub: registered connection e5436ef452a1e0410533ab60bf4d182f (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection e5436ef452a1e0410533ab60bf4d182f (total: 0)
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c084c2380
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c084c2380
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: 1d43ce920c8e931f9c5aea6245fae6f7
+2026/05/04 00:43:39 SSEHub: registered connection 1d43ce920c8e931f9c5aea6245fae6f7 (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection 1d43ce920c8e931f9c5aea6245fae6f7 (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a809b36380
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a809b36380
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: 1d43ce920c8e931f9c5aea6245fae6f7
 
 === Running scenario: completion-complete ===
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: e5436ef452a1e0410533ab60bf4d182f
 Running client scenario 'completion-complete' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: 7086b9466dbae7fa1e6cef09f2032f48
-2026/04/30 14:35:28 SSEHub: registered connection 7086b9466dbae7fa1e6cef09f2032f48 (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection 7086b9466dbae7fa1e6cef09f2032f48 (total: 0)
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c08618af0
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c08618af0
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: 7086b9466dbae7fa1e6cef09f2032f48
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: 5f30086d5318fcdbcd945ad272980d63
+2026/05/04 00:43:39 SSEHub: registered connection 5f30086d5318fcdbcd945ad272980d63 (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection 5f30086d5318fcdbcd945ad272980d63 (total: 0)
 
 === Running scenario: tools-list ===
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a8096a6770
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a8096a6770
 Running client scenario 'tools-list' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: 14c3a93257d7ecd74b2803ce4df4f115
-2026/04/30 14:35:28 SSEHub: registered connection 14c3a93257d7ecd74b2803ce4df4f115 (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection 14c3a93257d7ecd74b2803ce4df4f115 (total: 0)
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c08926700
-2026/04/30 14:35:28 Cleaning up writer...
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: 5f30086d5318fcdbcd945ad272980d63
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: 56bee588f8b77acb1d154636bc6ffbf9
+2026/05/04 00:43:39 SSEHub: registered connection 56bee588f8b77acb1d154636bc6ffbf9 (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection 56bee588f8b77acb1d154636bc6ffbf9 (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a809c18230
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a809c18230
 
 === Running scenario: tools-call-simple-text ===
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c08926700
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: 56bee588f8b77acb1d154636bc6ffbf9
 Running client scenario 'tools-call-simple-text' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: 14c3a93257d7ecd74b2803ce4df4f115
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: 5c2b6d9c9b62a2dcfce9c0706439c105
-2026/04/30 14:35:28 SSEHub: registered connection 5c2b6d9c9b62a2dcfce9c0706439c105 (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection 5c2b6d9c9b62a2dcfce9c0706439c105 (total: 0)
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: 80b889a40df62e367771b2cae836f24b
+2026/05/04 00:43:39 SSEHub: registered connection 80b889a40df62e367771b2cae836f24b (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection 80b889a40df62e367771b2cae836f24b (total: 0)
 
 === Running scenario: tools-call-image ===
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c084c2700
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c084c2700
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: 5c2b6d9c9b62a2dcfce9c0706439c105
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a8096a6460
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a8096a6460
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: 80b889a40df62e367771b2cae836f24b
 Running client scenario 'tools-call-image' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: 574131bc2959dc64f9cb7285bda602b7
-2026/04/30 14:35:28 SSEHub: registered connection 574131bc2959dc64f9cb7285bda602b7 (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection 574131bc2959dc64f9cb7285bda602b7 (total: 0)
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: ed462fce4a6283bff83f12f80daa9f8a
+2026/05/04 00:43:39 SSEHub: registered connection ed462fce4a6283bff83f12f80daa9f8a (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection ed462fce4a6283bff83f12f80daa9f8a (total: 0)
 
 === Running scenario: tools-call-audio ===
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c084c2930
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c084c2930
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: 574131bc2959dc64f9cb7285bda602b7
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a8096a69a0
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a8096a69a0
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: ed462fce4a6283bff83f12f80daa9f8a
 Running client scenario 'tools-call-audio' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: a4a4c8170fe7ce41078b1007c29a811f
-2026/04/30 14:35:28 SSEHub: registered connection a4a4c8170fe7ce41078b1007c29a811f (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection a4a4c8170fe7ce41078b1007c29a811f (total: 0)
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: 981ac743d4b52760f6f86b7183db22a7
+2026/05/04 00:43:39 SSEHub: registered connection 981ac743d4b52760f6f86b7183db22a7 (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection 981ac743d4b52760f6f86b7183db22a7 (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a809806c40
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a809806c40
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: 981ac743d4b52760f6f86b7183db22a7
 
 === Running scenario: tools-call-embedded-resource ===
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c089269a0
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c089269a0
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: a4a4c8170fe7ce41078b1007c29a811f
 Running client scenario 'tools-call-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: 8b907438911e2c76b9f70dfe9600f216
-2026/04/30 14:35:28 SSEHub: registered connection 8b907438911e2c76b9f70dfe9600f216 (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection 8b907438911e2c76b9f70dfe9600f216 (total: 0)
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c08926cb0
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c08926cb0
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: 8b907438911e2c76b9f70dfe9600f216
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: 3d2e546cb526197983bddb7db8a98efa
+2026/05/04 00:43:39 SSEHub: registered connection 3d2e546cb526197983bddb7db8a98efa (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection 3d2e546cb526197983bddb7db8a98efa (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a8096a6cb0
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a8096a6cb0
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: 3d2e546cb526197983bddb7db8a98efa
 
 === Running scenario: tools-call-mixed-content ===
 Running client scenario 'tools-call-mixed-content' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: eb2212329eefcd6eee4c8f4efefcfd03
-2026/04/30 14:35:28 SSEHub: registered connection eb2212329eefcd6eee4c8f4efefcfd03 (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection eb2212329eefcd6eee4c8f4efefcfd03 (total: 0)
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c084c2b60
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c084c2b60
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: eb2212329eefcd6eee4c8f4efefcfd03
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: c444296948894137acacfa638de8c78a
+2026/05/04 00:43:39 SSEHub: registered connection c444296948894137acacfa638de8c78a (total: 1)
 
 === Running scenario: tools-call-with-logging ===
+2026/05/04 00:43:39 SSEHub: unregistered connection c444296948894137acacfa638de8c78a (total: 0)
 Running client scenario 'tools-call-with-logging' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: 47dc3002f088eabe4a4b49423780b4f9
-2026/04/30 14:35:28 SSEHub: registered connection 47dc3002f088eabe4a4b49423780b4f9 (total: 1)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a8096a6f50
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a8096a6f50
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: c444296948894137acacfa638de8c78a
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: d9f5912ee89b4e5ee77ef846fdb45050
+2026/05/04 00:43:39 SSEHub: registered connection d9f5912ee89b4e5ee77ef846fdb45050 (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection d9f5912ee89b4e5ee77ef846fdb45050 (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a8096a7260
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a8096a7260
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: d9f5912ee89b4e5ee77ef846fdb45050
 
 === Running scenario: tools-call-error ===
-2026/04/30 14:35:28 SSEHub: unregistered connection 47dc3002f088eabe4a4b49423780b4f9 (total: 0)
 Running client scenario 'tools-call-error' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c086191f0
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c086191f0
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: 47dc3002f088eabe4a4b49423780b4f9
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: 1e1a3d746df0b27a34949c6d6961868c
-2026/04/30 14:35:28 SSEHub: registered connection 1e1a3d746df0b27a34949c6d6961868c (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection 1e1a3d746df0b27a34949c6d6961868c (total: 0)
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: 46e6a2024c8da0e0cd335ae8f0e04432
+2026/05/04 00:43:39 SSEHub: registered connection 46e6a2024c8da0e0cd335ae8f0e04432 (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection 46e6a2024c8da0e0cd335ae8f0e04432 (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a8096a7490
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a8096a7490
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: 46e6a2024c8da0e0cd335ae8f0e04432
 
 === Running scenario: tools-call-with-progress ===
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c084c2ee0
 Running client scenario 'tools-call-with-progress' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c084c2ee0
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: 1e1a3d746df0b27a34949c6d6961868c
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: ff995e31cad0554e12487d4d28bdc698
-2026/04/30 14:35:28 SSEHub: registered connection ff995e31cad0554e12487d4d28bdc698 (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection ff995e31cad0554e12487d4d28bdc698 (total: 0)
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c08927030
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c08927030
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: ff995e31cad0554e12487d4d28bdc698
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: 8a829d086dc80b252feb2311e55b4c9f
+2026/05/04 00:43:39 SSEHub: registered connection 8a829d086dc80b252feb2311e55b4c9f (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection 8a829d086dc80b252feb2311e55b4c9f (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a809c18620
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a809c18620
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: 8a829d086dc80b252feb2311e55b4c9f
 
 === Running scenario: tools-call-sampling ===
 Running client scenario 'tools-call-sampling' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: eb0eadea11d9aae14080a23027ee5d85
-2026/04/30 14:35:28 SSEHub: registered connection eb0eadea11d9aae14080a23027ee5d85 (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection eb0eadea11d9aae14080a23027ee5d85 (total: 0)
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c084c31f0
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c084c31f0
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: eb0eadea11d9aae14080a23027ee5d85
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: 0198bd658c705fbcceb871fe36850779
+2026/05/04 00:43:39 SSEHub: registered connection 0198bd658c705fbcceb871fe36850779 (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection 0198bd658c705fbcceb871fe36850779 (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a8096a7810
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a8096a7810
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: 0198bd658c705fbcceb871fe36850779
 
 === Running scenario: tools-call-elicitation ===
 Running client scenario 'tools-call-elicitation' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: 5714e73ce9ea4dc2d65f9405a106866f
-2026/04/30 14:35:28 SSEHub: registered connection 5714e73ce9ea4dc2d65f9405a106866f (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection 5714e73ce9ea4dc2d65f9405a106866f (total: 0)
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c084c3420
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c084c3420
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: 906888231ae927601214ee97d01c0fcb
+2026/05/04 00:43:39 SSEHub: registered connection 906888231ae927601214ee97d01c0fcb (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection 906888231ae927601214ee97d01c0fcb (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a809807030
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a809807030
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: 906888231ae927601214ee97d01c0fcb
 
 === Running scenario: elicitation-sep1034-defaults ===
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: 5714e73ce9ea4dc2d65f9405a106866f
 Running client scenario 'elicitation-sep1034-defaults' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: 6f2224cebd75ec90d1fa069e927c8145
-2026/04/30 14:35:28 SSEHub: registered connection 6f2224cebd75ec90d1fa069e927c8145 (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection 6f2224cebd75ec90d1fa069e927c8145 (total: 0)
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c084c3650
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c084c3650
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: 6f2224cebd75ec90d1fa069e927c8145
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: 04651dab4d9baca67defc59a078b59ca
+2026/05/04 00:43:39 SSEHub: registered connection 04651dab4d9baca67defc59a078b59ca (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection 04651dab4d9baca67defc59a078b59ca (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a809807260
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a809807260
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: 04651dab4d9baca67defc59a078b59ca
 
 === Running scenario: server-sse-multiple-streams ===
 Running client scenario 'server-sse-multiple-streams' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: f0418ff88b08a86b0920724f281e6a0c
-2026/04/30 14:35:28 SSEHub: registered connection f0418ff88b08a86b0920724f281e6a0c (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection f0418ff88b08a86b0920724f281e6a0c (total: 0)
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: ce81dfb47bfeeda23bf5d0e232bb129d
+2026/05/04 00:43:39 SSEHub: registered connection ce81dfb47bfeeda23bf5d0e232bb129d (total: 1)
 
 === Running scenario: elicitation-sep1330-enums ===
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c08619730
-2026/04/30 14:35:28 Cleaning up writer...
+2026/05/04 00:43:39 SSEHub: unregistered connection ce81dfb47bfeeda23bf5d0e232bb129d (total: 0)
 Running client scenario 'elicitation-sep1330-enums' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c08619730
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: f0418ff88b08a86b0920724f281e6a0c
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: 1660a1e91835636b667f1dbcc91255f4
-2026/04/30 14:35:28 SSEHub: registered connection 1660a1e91835636b667f1dbcc91255f4 (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection 1660a1e91835636b667f1dbcc91255f4 (total: 0)
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c084c3960
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c084c3960
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: 1660a1e91835636b667f1dbcc91255f4
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a8096a7ce0
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a8096a7ce0
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: ce81dfb47bfeeda23bf5d0e232bb129d
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: a52647faad60ce72bc4266b0c7305512
+2026/05/04 00:43:39 SSEHub: registered connection a52647faad60ce72bc4266b0c7305512 (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection a52647faad60ce72bc4266b0c7305512 (total: 0)
 
 === Running scenario: resources-list ===
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a8097e8460
 Running client scenario 'resources-list' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: 78b42bd43dde02c3533da7df84a025d3
-2026/04/30 14:35:28 SSEHub: registered connection 78b42bd43dde02c3533da7df84a025d3 (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection 78b42bd43dde02c3533da7df84a025d3 (total: 0)
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c08619a40
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c08619a40
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: 78b42bd43dde02c3533da7df84a025d3
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a8097e8460
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: a52647faad60ce72bc4266b0c7305512
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: 03f6d88baa9def27e3aba77096429ebe
+2026/05/04 00:43:39 SSEHub: registered connection 03f6d88baa9def27e3aba77096429ebe (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection 03f6d88baa9def27e3aba77096429ebe (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a8097e8850
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a8097e8850
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: 03f6d88baa9def27e3aba77096429ebe
 
 === Running scenario: resources-read-text ===
 Running client scenario 'resources-read-text' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: 117ce28a7a80270537ebc7653d59559d
-2026/04/30 14:35:28 SSEHub: registered connection 117ce28a7a80270537ebc7653d59559d (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection 117ce28a7a80270537ebc7653d59559d (total: 0)
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c089275e0
-2026/04/30 14:35:28 Cleaning up writer...
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: 25ede364d2def077e0e27ba04f4d6809
+2026/05/04 00:43:39 SSEHub: registered connection 25ede364d2def077e0e27ba04f4d6809 (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection 25ede364d2def077e0e27ba04f4d6809 (total: 0)
 
 === Running scenario: resources-read-binary ===
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c089275e0
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: 117ce28a7a80270537ebc7653d59559d
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a80989a230
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a80989a230
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: 25ede364d2def077e0e27ba04f4d6809
 Running client scenario 'resources-read-binary' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: d86ca0b70ea141ecbbbeacdc9b7b42c8
-2026/04/30 14:35:28 SSEHub: registered connection d86ca0b70ea141ecbbbeacdc9b7b42c8 (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection d86ca0b70ea141ecbbbeacdc9b7b42c8 (total: 0)
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: 3dff1a2a24128041620596ac224be159
+2026/05/04 00:43:39 SSEHub: registered connection 3dff1a2a24128041620596ac224be159 (total: 1)
 
 === Running scenario: resources-templates-read ===
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c08619ce0
-2026/04/30 14:35:28 Cleaning up writer...
 Running client scenario 'resources-templates-read' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c08619ce0
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: d86ca0b70ea141ecbbbeacdc9b7b42c8
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: 7c99f2dc4e91ddef29d78b099be9b36d
-2026/04/30 14:35:28 SSEHub: registered connection 7c99f2dc4e91ddef29d78b099be9b36d (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection 7c99f2dc4e91ddef29d78b099be9b36d (total: 0)
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c0874e000
-2026/04/30 14:35:28 Cleaning up writer...
+2026/05/04 00:43:39 SSEHub: unregistered connection 3dff1a2a24128041620596ac224be159 (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a80989a4d0
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a80989a4d0
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: 3dff1a2a24128041620596ac224be159
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: ab9fdfb5357103f0c106a0d0b768b639
+2026/05/04 00:43:39 SSEHub: registered connection ab9fdfb5357103f0c106a0d0b768b639 (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection ab9fdfb5357103f0c106a0d0b768b639 (total: 0)
 
 === Running scenario: resources-subscribe ===
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c0874e000
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: 7c99f2dc4e91ddef29d78b099be9b36d
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a809c18bd0
 Running client scenario 'resources-subscribe' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: 5d0fda3b9de90f5e07f86a68f9e8f0c5
-2026/04/30 14:35:28 SSEHub: registered connection 5d0fda3b9de90f5e07f86a68f9e8f0c5 (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection 5d0fda3b9de90f5e07f86a68f9e8f0c5 (total: 0)
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a809c18bd0
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: ab9fdfb5357103f0c106a0d0b768b639
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: d03793fc5fb0bd2a052c6e57b079917b
+2026/05/04 00:43:39 SSEHub: registered connection d03793fc5fb0bd2a052c6e57b079917b (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection d03793fc5fb0bd2a052c6e57b079917b (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a809c18e70
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a809c18e70
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: d03793fc5fb0bd2a052c6e57b079917b
 
 === Running scenario: resources-unsubscribe ===
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c08927960
-2026/04/30 14:35:28 Cleaning up writer...
 Running client scenario 'resources-unsubscribe' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c08927960
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: 5d0fda3b9de90f5e07f86a68f9e8f0c5
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: 975d2e36f73bbe7ccb4089e6ac456c28
-2026/04/30 14:35:28 SSEHub: registered connection 975d2e36f73bbe7ccb4089e6ac456c28 (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection 975d2e36f73bbe7ccb4089e6ac456c28 (total: 0)
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: 4f99fa8ea271af38df3dfe73ae019ba7
+2026/05/04 00:43:39 SSEHub: registered connection 4f99fa8ea271af38df3dfe73ae019ba7 (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection 4f99fa8ea271af38df3dfe73ae019ba7 (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a8097e8bd0
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a8097e8bd0
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: 4f99fa8ea271af38df3dfe73ae019ba7
 
 === Running scenario: prompts-list ===
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c084c3c00
 Running client scenario 'prompts-list' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c084c3c00
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: 975d2e36f73bbe7ccb4089e6ac456c28
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: bd7509f69a8a9987ed3a23d8aafe6745
-2026/04/30 14:35:28 SSEHub: registered connection bd7509f69a8a9987ed3a23d8aafe6745 (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection bd7509f69a8a9987ed3a23d8aafe6745 (total: 0)
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c08927ce0
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c08927ce0
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: bd7509f69a8a9987ed3a23d8aafe6745
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: d85ec9a2c38f2b082ba572d409f828b1
+2026/05/04 00:43:39 SSEHub: registered connection d85ec9a2c38f2b082ba572d409f828b1 (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection d85ec9a2c38f2b082ba572d409f828b1 (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a80989a770
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a80989a770
 
 === Running scenario: prompts-get-simple ===
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: d85ec9a2c38f2b082ba572d409f828b1
 Running client scenario 'prompts-get-simple' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: 08ace7b0e437136059392061ed4f8735
-2026/04/30 14:35:28 SSEHub: registered connection 08ace7b0e437136059392061ed4f8735 (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection 08ace7b0e437136059392061ed4f8735 (total: 0)
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c085b0770
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c085b0770
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: 08ace7b0e437136059392061ed4f8735
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: a5f6878298af67d6116d9af3160861f2
+2026/05/04 00:43:39 SSEHub: registered connection a5f6878298af67d6116d9af3160861f2 (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection a5f6878298af67d6116d9af3160861f2 (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a80989a9a0
+2026/05/04 00:43:39 Cleaning up writer...
 
 === Running scenario: prompts-get-with-args ===
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a80989a9a0
 Running client scenario 'prompts-get-with-args' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: 8a292461496cacfe6adb37afcce0ee29
-2026/04/30 14:35:28 SSEHub: registered connection 8a292461496cacfe6adb37afcce0ee29 (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection 8a292461496cacfe6adb37afcce0ee29 (total: 0)
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c085b09a0
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c085b09a0
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: a5f6878298af67d6116d9af3160861f2
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: 2a677a008147a07b9fc829cad7c60af0
+2026/05/04 00:43:39 SSEHub: registered connection 2a677a008147a07b9fc829cad7c60af0 (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection 2a677a008147a07b9fc829cad7c60af0 (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a809be6070
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a809be6070
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: 2a677a008147a07b9fc829cad7c60af0
 
 === Running scenario: prompts-get-embedded-resource ===
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: 8a292461496cacfe6adb37afcce0ee29
 Running client scenario 'prompts-get-embedded-resource' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: dd7990109675701c39006b4bd5190c0c
-2026/04/30 14:35:28 SSEHub: registered connection dd7990109675701c39006b4bd5190c0c (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection dd7990109675701c39006b4bd5190c0c (total: 0)
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c0874e310
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c0874e310
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: dd7990109675701c39006b4bd5190c0c
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: 281da2b2fd52ee904323cfa117179f9d
+2026/05/04 00:43:39 SSEHub: registered connection 281da2b2fd52ee904323cfa117179f9d (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection 281da2b2fd52ee904323cfa117179f9d (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a809be6310
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a809be6310
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: 281da2b2fd52ee904323cfa117179f9d
 
 === Running scenario: prompts-get-with-image ===
 Running client scenario 'prompts-get-with-image' against server: http://localhost:18799/mcp
-2026/04/30 14:35:28 Starting MCP-GET-SSE SSE connection: 76f6e6391f3628a9ebcb0ce419ce3cf8
-2026/04/30 14:35:28 SSEHub: registered connection 76f6e6391f3628a9ebcb0ce419ce3cf8 (total: 1)
-2026/04/30 14:35:28 SSEHub: unregistered connection 76f6e6391f3628a9ebcb0ce419ce3cf8 (total: 0)
-2026/04/30 14:35:28 Received kill signal.  Quitting Writer. stop 0x72c08b581c0
-2026/04/30 14:35:28 Cleaning up writer...
-2026/04/30 14:35:28 Finished cleaning up writer:  0x72c08b581c0
+2026/05/04 00:43:39 Starting MCP-GET-SSE SSE connection: 1ebee1d0715987cff3e978331cbe4010
+2026/05/04 00:43:39 SSEHub: registered connection 1ebee1d0715987cff3e978331cbe4010 (total: 1)
+2026/05/04 00:43:39 SSEHub: unregistered connection 1ebee1d0715987cff3e978331cbe4010 (total: 0)
+2026/05/04 00:43:39 Received kill signal.  Quitting Writer. stop 0x63a809c192d0
+2026/05/04 00:43:39 Cleaning up writer...
+2026/05/04 00:43:39 Finished cleaning up writer:  0x63a809c192d0
+2026/05/04 00:43:39 Closed MCP-GET-SSE SSE connection: 1ebee1d0715987cff3e978331cbe4010
 
 === Running scenario: dns-rebinding-protection ===
-2026/04/30 14:35:28 Closed MCP-GET-SSE SSE connection: 76f6e6391f3628a9ebcb0ce419ce3cf8
 Running client scenario 'dns-rebinding-protection' against server: http://localhost:18799/mcp
 
 
@@ -343,4 +342,4 @@ Total: 40 passed, 0 failed
 [32mBaseline check passed: all failures are expected.[0m
 
 === CONFORMANCE TESTS PASSED ===
-Finished: Thu Apr 30 14:35:28 PDT 2026
+Finished: Mon May  4 00:43:40 PDT 2026

--- a/tests/reports/stage-e2e.log
+++ b/tests/reports/stage-e2e.log
@@ -1,6 +1,6 @@
 === Stage 6/12: e2e (make test-e2e) ===
-Started: Thu Apr 30 14:34:57 PDT 2026
+Started: Mon May  4 00:43:09 PDT 2026
 cd tests/e2e && go test ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/tests/e2e	4.446s
-ok  	github.com/panyam/mcpkit/tests/e2e/apps	0.450s
-Finished: Thu Apr 30 14:35:02 PDT 2026
+ok  	github.com/panyam/mcpkit/tests/e2e	3.625s
+ok  	github.com/panyam/mcpkit/tests/e2e/apps	1.026s
+Finished: Mon May  4 00:43:13 PDT 2026

--- a/tests/reports/stage-experimental.log
+++ b/tests/reports/stage-experimental.log
@@ -1,11 +1,11 @@
 === Stage 7/12: experimental (make test-experimental) ===
-Started: Thu Apr 30 14:35:02 PDT 2026
+Started: Mon May  4 00:43:13 PDT 2026
 cd experimental/ext/events && go test ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/experimental/ext/events	0.386s
+ok  	github.com/panyam/mcpkit/experimental/ext/events	1.090s
 cd experimental/ext/events/clients/go && go test ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/experimental/ext/events/clients/go	6.411s
+ok  	github.com/panyam/mcpkit/experimental/ext/events/clients/go	6.889s
 cd examples/events/discord && go test ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/examples/events/discord	4.462s
+ok  	github.com/panyam/mcpkit/examples/events/discord	3.880s
 cd examples/events/telegram && go test ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/examples/events/telegram	7.964s
-Finished: Thu Apr 30 14:35:24 PDT 2026
+ok  	github.com/panyam/mcpkit/examples/events/telegram	7.516s
+Finished: Mon May  4 00:43:35 PDT 2026

--- a/tests/reports/stage-keycloak.log
+++ b/tests/reports/stage-keycloak.log
@@ -1,29 +1,35 @@
 === Stage 12/12: keycloak (make testkcl-auto) ===
-Started: Thu Apr 30 14:35:58 PDT 2026
+Started: Mon May  4 00:44:12 PDT 2026
+Starting Keycloak for interop tests...
+936a897256ba51b212a49ab4c60b4dacd45c70c638f990246826c56609707cd7
+Keycloak starting on port 8180... (realm import takes ~30s)
+Run 'make kcllogs' to watch startup, 'make testkcl' when ready
+Waiting for Keycloak realm...
 === RUN   TestKeycloak_MCPServer_ValidToken
---- PASS: TestKeycloak_MCPServer_ValidToken (0.03s)
+--- PASS: TestKeycloak_MCPServer_ValidToken (0.23s)
 === RUN   TestKeycloak_MCPServer_TamperedToken
 --- PASS: TestKeycloak_MCPServer_TamperedToken (0.02s)
 === RUN   TestKeycloak_MCPServer_ScopeAllowed
---- PASS: TestKeycloak_MCPServer_ScopeAllowed (0.01s)
+--- PASS: TestKeycloak_MCPServer_ScopeAllowed (0.02s)
 === RUN   TestKeycloak_MCPServer_ScopeDenied
---- PASS: TestKeycloak_MCPServer_ScopeDenied (0.01s)
+--- PASS: TestKeycloak_MCPServer_ScopeDenied (0.02s)
 === RUN   TestKeycloak_MCPServer_PRM
 --- PASS: TestKeycloak_MCPServer_PRM (0.01s)
 === RUN   TestKeycloak_MCPServer_WWWAuthenticate
 --- PASS: TestKeycloak_MCPServer_WWWAuthenticate (0.01s)
 === RUN   TestKeycloak_MCPServer_PasswordGrant
---- PASS: TestKeycloak_MCPServer_PasswordGrant (0.04s)
+--- PASS: TestKeycloak_MCPServer_PasswordGrant (0.11s)
 === RUN   TestKeycloak_PublicMethods_DiscoverWithoutAuth
 --- PASS: TestKeycloak_PublicMethods_DiscoverWithoutAuth (0.01s)
 === RUN   TestKeycloak_PublicMethods_ToolCallRequiresAuth
 --- PASS: TestKeycloak_PublicMethods_ToolCallRequiresAuth (0.01s)
 === RUN   TestKeycloak_SessionHijack_DifferentUserRejected
---- PASS: TestKeycloak_SessionHijack_DifferentUserRejected (0.07s)
+--- PASS: TestKeycloak_SessionHijack_DifferentUserRejected (0.08s)
 === RUN   TestKeycloak_SessionHijack_SameUserAllowed
---- PASS: TestKeycloak_SessionHijack_SameUserAllowed (0.06s)
+--- PASS: TestKeycloak_SessionHijack_SameUserAllowed (0.04s)
 === RUN   TestKeycloak_TokenRefresh_PasswordGrant
---- PASS: TestKeycloak_TokenRefresh_PasswordGrant (0.09s)
+--- PASS: TestKeycloak_TokenRefresh_PasswordGrant (0.06s)
 PASS
-ok  	github.com/panyam/mcpkit/tests/keycloak	0.870s
-Finished: Thu Apr 30 14:36:00 PDT 2026
+ok  	github.com/panyam/mcpkit/tests/keycloak	1.321s
+make[2]: *** No rule to make target `downkcl'.  Stop.
+Finished: Mon May  4 00:44:25 PDT 2026

--- a/tests/reports/stage-protogen.log
+++ b/tests/reports/stage-protogen.log
@@ -1,11 +1,11 @@
 === Stage 5/12: protogen (make test-protogen) ===
-Started: Thu Apr 30 14:34:53 PDT 2026
+Started: Mon May  4 00:43:03 PDT 2026
 cd experimental/ext/protogen && go test ./... -count=1 -timeout 30s && /Library/Developer/CommandLineTools/usr/bin/make test-e2e
 ?   	github.com/panyam/mcpkit/experimental/ext/protogen/cmd/protoc-gen-go-mcp	[no test files]
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/generator	0.351s
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/proto/mcp/v1	0.635s
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/runtime	0.933s
-ok  	github.com/panyam/mcpkit/experimental/ext/protogen/schema	1.225s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/generator	1.489s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/proto/mcp/v1	0.647s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/runtime	0.670s
+ok  	github.com/panyam/mcpkit/experimental/ext/protogen/schema	0.971s
 ?   	github.com/panyam/mcpkit/experimental/ext/protogen/testutil	[no test files]
 go build -o bin/protoc-gen-go-mcp ./cmd/protoc-gen-go-mcp
 go install ./cmd/protoc-gen-go-mcp
@@ -14,6 +14,6 @@ cd ../../../examples/protogen/bookservice && rm -rf gen && buf generate && go te
 [33mWARN[0m	plugin "protoc-gen-go-mcp" does not support required features.
   Feature "proto3 optional" is required by 1 file(s):
     bookservice/v1/service.proto
-ok  	github.com/panyam/mcpkit/examples/protogen/bookservice	0.422s
+ok  	github.com/panyam/mcpkit/examples/protogen/bookservice	0.768s
 ==> e2e: passed
-Finished: Thu Apr 30 14:34:57 PDT 2026
+Finished: Mon May  4 00:43:09 PDT 2026

--- a/tests/reports/stage-race.log
+++ b/tests/reports/stage-race.log
@@ -1,9 +1,9 @@
 === Stage 2/12: race (make test-race) ===
-Started: Thu Apr 30 14:34:33 PDT 2026
+Started: Mon May  4 00:42:37 PDT 2026
 go test -race ./... -count=1 -timeout 60s
-ok  	github.com/panyam/mcpkit/client	9.250s
+ok  	github.com/panyam/mcpkit/client	9.529s
 ?   	github.com/panyam/mcpkit/cmd/testserver	[no test files]
-ok  	github.com/panyam/mcpkit/core	1.374s
-ok  	github.com/panyam/mcpkit/server	13.970s
-ok  	github.com/panyam/mcpkit/testutil	2.500s
-Finished: Thu Apr 30 14:34:48 PDT 2026
+ok  	github.com/panyam/mcpkit/core	1.586s
+ok  	github.com/panyam/mcpkit/server	15.317s
+ok  	github.com/panyam/mcpkit/testutil	1.522s
+Finished: Mon May  4 00:42:56 PDT 2026

--- a/tests/reports/stage-tasks-conformance.log
+++ b/tests/reports/stage-tasks-conformance.log
@@ -1,5 +1,5 @@
 === Stage 10/12: tasks-conformance (make testconf-tasks) ===
-Started: Thu Apr 30 14:35:30 PDT 2026
+Started: Mon May  4 00:43:42 PDT 2026
 ========================================================================
   MCP Tasks — Async Tool Execution Lifecycle
   Walks through the MCP Tasks (SEP-1036) lifecycle: optional/required task support, polling, progress notifications, and cancellation.
@@ -42,10 +42,9 @@ Started: Thu Apr 30 14:35:30 PDT 2026
     (progress, status changes) reach us during polling.
 
     Press Enter to run this step...
-Connected to telegram-events 0.1.0
-
-Tools (with task support metadata):
-- send_message taskSupport=forbidden
+ERROR: initialize failed: Post "http://localhost:8080/mcp": dial tcp
+[::1]:8080: connect: connection refused
+Start the server with: make serve
 
 
   Step 2/8: Sync call: greet (taskSupport=forbidden)
@@ -58,7 +57,8 @@ Tools (with task support metadata):
     use today; tasks are opt-in per tool.
 
     Press Enter to run this step...
-ERROR: RPC error -32602: unknown tool: greet
+ERROR: Post "http://localhost:8080/mcp": dial tcp [::1]:8080: connect:
+connection refused
 
 
   Step 3/8: Optional task: slow_compute as task → CreateTaskResult
@@ -71,7 +71,8 @@ ERROR: RPC error -32602: unknown tool: greet
     immediately while the work runs in a background goroutine.
 
     Press Enter to run this step...
-ERROR: RPC error -32602: unknown tool: slow_compute
+ERROR: Post "http://localhost:8080/mcp": dial tcp [::1]:8080: connect:
+connection refused
 
 
   Step 4/8: Poll tasks/get until terminal — receive notifications/progress
@@ -86,7 +87,8 @@ ERROR: RPC error -32602: unknown tool: slow_compute
     stops.
 
     Press Enter to run this step...
-ERROR: RPC error -32601: method not found: tasks/get
+ERROR: Post "http://localhost:8080/mcp": dial tcp [::1]:8080: connect:
+connection refused
 
 
   Step 5/8: Fetch the result payload via tasks/result
@@ -99,7 +101,8 @@ ERROR: RPC error -32601: method not found: tasks/get
     tasks/result with the same taskId.
 
     Press Enter to run this step...
-ERROR: RPC error -32601: method not found: tasks/result
+ERROR: Post "http://localhost:8080/mcp": dial tcp [::1]:8080: connect:
+connection refused
 
 
   Step 6/8: Required task: failing_job — sync call returns an error
@@ -112,7 +115,8 @@ ERROR: RPC error -32601: method not found: tasks/result
     guards expensive/long tools from blocking the request thread.
 
     Press Enter to run this step...
-Server returned: RPC error -32602: unknown tool: failing_job
+Server returned: Post "http://localhost:8080/mcp": dial tcp [::1]:8080:
+connect: connection refused
 
 
   Step 7/8: Invoke failing_job as task → terminal status: failed
@@ -128,7 +132,8 @@ Server returned: RPC error -32602: unknown tool: failing_job
     polling call.
 
     Press Enter to run this step...
-ERROR: RPC error -32602: unknown tool: failing_job
+ERROR: Post "http://localhost:8080/mcp": dial tcp [::1]:8080: connect:
+connection refused
 
 
   Step 8/8: Cancel a long-running task mid-flight
@@ -147,7 +152,8 @@ ERROR: RPC error -32602: unknown tool: failing_job
     cancel doesn't overwrite the cancelled status.
 
     Press Enter to run this step...
-ERROR: RPC error -32602: unknown tool: slow_compute
+ERROR: Post "http://localhost:8080/mcp": dial tcp [::1]:8080: connect:
+connection refused
 
 
   --- Where each piece lives in mcpkit ---
@@ -167,34 +173,34 @@ ERROR: RPC error -32602: unknown tool: slow_compute
 
 === Done ===
 ▶ MCP Tasks Conformance
-  ✔ scenario 01: sync tool call returns immediately (5.534709ms)
-  ✔ scenario 02: async task creation returns CreateTaskResult (1.580584ms)
-  ✔ scenario 03: tasks/get returns flat task info (3.258792ms)
-  ✔ scenario 04: failing tool transitions to failed (1016.332292ms)
-  ✔ scenario 05: tasks/result returns ToolResult with related-task meta (1021.86425ms)
-  ✔ scenario 06: cancel returns cancelled status (3.45825ms)
-  ✔ scenario 07: tasks/list returns task array (2.1835ms)
-  ✔ scenario 08: required tool without task hint returns error (1.361125ms)
-  ✔ scenario 09: forbidden tool with task hint returns error (1.286084ms)
-  ✔ scenario 10: external proxy tool completes via task callbacks (1014.599542ms)
-  ✔ scenario 11: external proxy tool tasks/get returns task info (1.876291ms)
-  ✔ scenario 12: optional tool without hint runs synchronously (1001.395334ms)
-  ✔ scenario 13: tasks/get with bogus taskId returns error (1.267291ms)
-  ✔ scenario 14: tasks/cancel with bogus taskId returns error (0.9955ms)
-  ✔ scenario 15: cancel completed task returns error (1013.752042ms)
-  ✔ scenario 16: CreateTaskResult includes a TTL (0.958916ms)
-  ✔ scenario 17: CreateTaskResult pollInterval is valid if present (0.804834ms)
-  ✔ scenario 18: task must not expire before TTL (1516.309625ms)
-  ✔ scenario 19: concurrent task creation produces unique taskIds (1023.268042ms)
-  ✔ scenario 20: tasks/result for failed task has isError true (1014.767917ms)
-  ✔ scenario 21: tools/list includes execution.taskSupport (2.323875ms)
-  ✔ scenario 22: elicitation round-trip via tasks/result (6.73425ms)
-  ✔ scenario 23: sampling round-trip via tasks/result (7.68575ms)
-  ✔ scenario 24: progress notifications are well-formed if sent (2025.576083ms)
-  ✔ scenario 25: status notifications match task state if sent (1515.890875ms)
-  ✔ scenario 26: tasks/result includes related-task _meta (1017.0525ms)
-  ✔ scenario 27: tasks/get does not include related-task _meta (2.356ms)
-✔ MCP Tasks Conformance (13241.662084ms)
+  ✔ scenario 01: sync tool call returns immediately (4.211792ms)
+  ✔ scenario 02: async task creation returns CreateTaskResult (1.355416ms)
+  ✔ scenario 03: tasks/get returns flat task info (2.342125ms)
+  ✔ scenario 04: failing tool transitions to failed (1028.671542ms)
+  ✔ scenario 05: tasks/result returns ToolResult with related-task meta (1037.055416ms)
+  ✔ scenario 06: cancel returns cancelled status (6.420041ms)
+  ✔ scenario 07: tasks/list returns task array (2.840583ms)
+  ✔ scenario 08: required tool without task hint returns error (1.586125ms)
+  ✔ scenario 09: forbidden tool with task hint returns error (1.272041ms)
+  ✔ scenario 10: external proxy tool completes via task callbacks (1034.218417ms)
+  ✔ scenario 11: external proxy tool tasks/get returns task info (5.017209ms)
+  ✔ scenario 12: optional tool without hint runs synchronously (1003.907916ms)
+  ✔ scenario 13: tasks/get with bogus taskId returns error (4.685583ms)
+  ✔ scenario 14: tasks/cancel with bogus taskId returns error (2.225333ms)
+  ✔ scenario 15: cancel completed task returns error (1036.887916ms)
+  ✔ scenario 16: CreateTaskResult includes a TTL (2.512667ms)
+  ✔ scenario 17: CreateTaskResult pollInterval is valid if present (1.514417ms)
+  ✔ scenario 18: task must not expire before TTL (1536.077958ms)
+  ✔ scenario 19: concurrent task creation produces unique taskIds (1050.300708ms)
+  ✔ scenario 20: tasks/result for failed task has isError true (1029.944541ms)
+  ✔ scenario 21: tools/list includes execution.taskSupport (5.149125ms)
+  ✔ scenario 22: elicitation round-trip via tasks/result (14.495417ms)
+  ✔ scenario 23: sampling round-trip via tasks/result (4.780458ms)
+  ✔ scenario 24: progress notifications are well-formed if sent (2054.152708ms)
+  ✔ scenario 25: status notifications match task state if sent (1537.212292ms)
+  ✔ scenario 26: tasks/result includes related-task _meta (1039.856875ms)
+  ✔ scenario 27: tasks/get does not include related-task _meta (3.946834ms)
+✔ MCP Tasks Conformance (13470.952917ms)
 ℹ tests 27
 ℹ suites 1
 ℹ pass 27
@@ -202,5 +208,5 @@ ERROR: RPC error -32602: unknown tool: slow_compute
 ℹ cancelled 0
 ℹ skipped 0
 ℹ todo 0
-ℹ duration_ms 13580.469375
-Finished: Thu Apr 30 14:35:46 PDT 2026
+ℹ duration_ms 13828.108166
+Finished: Mon May  4 00:43:59 PDT 2026

--- a/tests/reports/stage-tasks-v2-conformance.log
+++ b/tests/reports/stage-tasks-v2-conformance.log
@@ -1,202 +1,222 @@
 === Stage 11/12: tasks-v2-conformance (make testconf-tasks-v2) ===
-Started: Thu Apr 30 14:35:46 PDT 2026
-2026/04/30 14:35:46 Tasks v2 demo server on :18092
-2026/04/30 14:35:46 Connect: http://localhost:18092/mcp
-2026/04/30 14:35:46 
-2026/04/30 14:35:46 Tools:
-2026/04/30 14:35:46   greet              — sync-only
-2026/04/30 14:35:46   slow_compute       — optional task (server-directed)
-2026/04/30 14:35:46   failing_job        — required task (tool error → completed + isError)
-2026/04/30 14:35:46   confirm_delete     — required task (input_required → tasks/update → completed)
-2026/04/30 14:35:46   protocol_error_job — required task (protocol error → failed + error)
-2026/04/30 14:35:46   external_job       — required task (TaskCallbacks proxy)
-2026/04/30 14:35:48 MCP initialize ok [320.958µs]
-2026/04/30 14:35:48 MCP notifications/initialized ok [541ns]
-2026/04/30 14:35:48 Starting MCP-GET-SSE SSE connection: baf859e600d3e9ee12c62f65f62f6cbf
-2026/04/30 14:35:48 SSEHub: registered connection baf859e600d3e9ee12c62f65f62f6cbf (total: 1)
-2026/04/30 14:35:48 MCP initialize ok [40.625µs]
-2026/04/30 14:35:48 MCP notifications/initialized ok [292ns]
-2026/04/30 14:35:48 MCP initialize ok [3.209µs]
-2026/04/30 14:35:48 MCP notifications/initialized ok [291ns]
-2026/04/30 14:35:48 MCP tools/call ok [56.334µs]
-2026/04/30 14:35:48 MCP tools/call ok [20.958µs]
+Started: Mon May  4 00:43:59 PDT 2026
+2026/05/04 00:44:01 Tasks v2 demo server on :18092
+2026/05/04 00:44:01 Connect: http://localhost:18092/mcp
+2026/05/04 00:44:01 
+2026/05/04 00:44:01 Tools:
+2026/05/04 00:44:01   greet              — sync-only
+2026/05/04 00:44:01   slow_compute       — optional task (server-directed)
+2026/05/04 00:44:01   failing_job        — required task (tool error → completed + isError)
+2026/05/04 00:44:01   confirm_delete     — required task (input_required → tasks/update → completed)
+2026/05/04 00:44:01   protocol_error_job — required task (protocol error → failed + error)
+2026/05/04 00:44:01   external_job       — required task (TaskCallbacks proxy)
+2026/05/04 00:44:02 MCP initialize ok [293.833µs]
+2026/05/04 00:44:02 MCP notifications/initialized ok [458ns]
+2026/05/04 00:44:02 Starting MCP-GET-SSE SSE connection: 437afce20a9ed8cd84e12e8f5d13f216
+2026/05/04 00:44:02 SSEHub: registered connection 437afce20a9ed8cd84e12e8f5d13f216 (total: 1)
+2026/05/04 00:44:02 MCP initialize ok [34.375µs]
+2026/05/04 00:44:02 MCP notifications/initialized ok [208ns]
+2026/05/04 00:44:02 MCP initialize ok [6.458µs]
+2026/05/04 00:44:02 MCP notifications/initialized ok [333ns]
+2026/05/04 00:44:02 MCP tools/call ok [72.834µs]
+2026/05/04 00:44:02 MCP tools/call ok [11.583µs]
+2026/05/04 00:44:02 [slow_compute] starting "v2-create": sleeping 2s...
 ▶ MCP Tasks v2 Conformance (SEP-2663)
-  ✔ v2-01: sync tool call returns immediately, no task (2.163375ms)
-2026/04/30 14:35:48 [slow_compute] starting "v2-create": sleeping 2s...
-2026/04/30 14:35:48 MCP tools/call ok [5.166µs]
-2026/04/30 14:35:48 [slow_compute] starting "v2-poll": sleeping 3s...
-  ✔ v2-02: server creates task without client task param (1.855792ms)
-2026/04/30 14:35:48 MCP tasks/get ok [8.416µs]
-2026/04/30 14:35:48 MCP tools/call ok [8.708µs]
-2026/04/30 14:35:48 [slow_compute] starting "v2-result": sleeping 1s...
-  ✔ v2-03: tasks/get returns status for active task (1.862542ms)
-2026/04/30 14:35:48 MCP tasks/get ok [3.708µs]
-2026/04/30 14:35:48 MCP tasks/get ok [8.083µs]
-2026/04/30 14:35:48 MCP tasks/get ok [10.5µs]
-2026/04/30 14:35:48 MCP tasks/get ok [23µs]
-2026/04/30 14:35:49 MCP tasks/get ok [6.958µs]
-2026/04/30 14:35:49 [slow_compute] finished "v2-result"
-2026/04/30 14:35:49 MCP tasks/get ok [17.208µs]
-2026/04/30 14:35:49 MCP tools/call ok [9.459µs]
-2026/04/30 14:35:49 [failing_job] starting (will fail in 1s)...
-2026/04/30 14:35:49 MCP tasks/get ok [3.958µs]
-  ✔ v2-04: tasks/get returns completed status with inlined result (1015.339667ms)
-2026/04/30 14:35:49 MCP tasks/get ok [9.541µs]
-2026/04/30 14:35:49 MCP tasks/get ok [26.166µs]
-2026/04/30 14:35:49 MCP tasks/get ok [11.209µs]
-2026/04/30 14:35:50 MCP tasks/get ok [6.208µs]
-2026/04/30 14:35:50 [slow_compute] finished "v2-create"
-2026/04/30 14:35:50 MCP tasks/get ok [13.792µs]
-2026/04/30 14:35:50 MCP tools/call ok [10.583µs]
-2026/04/30 14:35:50 [protocol_error_job] starting (will panic in 500ms)...
-  ✔ v2-05: tool execution error is completed with isError true (1016.758541ms)
-2026/04/30 14:35:50 MCP tasks/get ok [3.542µs]
-2026/04/30 14:35:50 MCP tasks/get ok [8.5µs]
-2026/04/30 14:35:50 MCP tasks/get ok [8.833µs]
-2026/04/30 14:35:50 MCP tasks/get ok [6.708µs]
-2026/04/30 14:35:50 MCP tools/call ok [19.375µs]
-2026/04/30 14:35:50 [slow_compute] starting "v2-cancel": sleeping 60s...
-  ✔ v2-06: protocol error is failed with error field (608.549125ms)
-2026/04/30 14:35:50 [slow_compute] cancelled "v2-cancel" at 1/60
-2026/04/30 14:35:50 MCP tasks/cancel ok [53.708µs]
-2026/04/30 14:35:50 MCP tasks/get ok [23.959µs]
-2026/04/30 14:35:50 MCP tools/call ok [9.25µs]
-2026/04/30 14:35:50 [slow_compute] starting "v2-cancel-done": sleeping 1s...
-  ✔ v2-07: tasks/cancel returns empty ack; status settles to cancelled (3.365334ms)
-2026/04/30 14:35:50 MCP tasks/get ok [3.917µs]
-2026/04/30 14:35:51 MCP tasks/get ok [6.75µs]
-2026/04/30 14:35:51 [slow_compute] finished "v2-poll"
-2026/04/30 14:35:51 MCP tasks/get ok [7.541µs]
-2026/04/30 14:35:51 MCP tasks/get ok [19.584µs]
-2026/04/30 14:35:51 MCP tasks/get ok [40.875µs]
-2026/04/30 14:35:51 [slow_compute] finished "v2-cancel-done"
-2026/04/30 14:35:51 MCP tasks/get ok [15.25µs]
-2026/04/30 14:35:51 MCP tasks/cancel error=-32602 (task is already in a terminal state) [4.75µs]
-2026/04/30 14:35:51 MCP tools/call ok [23.167µs]
-2026/04/30 14:35:51 [slow_compute] starting "v2-no-result": sleeping 1s...
-  ✔ v2-08: cancel completed task returns error (1015.996084ms)
-2026/04/30 14:35:51 MCP tasks/get ok [4.834µs]
-2026/04/30 14:35:52 MCP tasks/get ok [6.125µs]
-2026/04/30 14:35:52 MCP tasks/get ok [30.667µs]
-2026/04/30 14:35:52 MCP tasks/get ok [21.25µs]
-2026/04/30 14:35:52 MCP tasks/get ok [6.875µs]
-2026/04/30 14:35:52 [slow_compute] finished "v2-no-result"
-2026/04/30 14:35:52 MCP tasks/get ok [14.666µs]
-2026/04/30 14:35:52 MCP tasks/result error=-32601 (method not found: tasks/result) [2.459µs]
-2026/04/30 14:35:52 MCP tasks/list error=-32601 (method not found: tasks/list) [2.708µs]
-  ✔ v2-09: tasks/result is rejected (method removed in v2) (1017.306875ms)
-2026/04/30 14:35:52 MCP tools/call ok [18.292µs]
-2026/04/30 14:35:52 [slow_compute] starting "v2-ttl": sleeping 1s...
-  ✔ v2-10: tasks/list is rejected (method removed in v2) (0.824ms)
-  ✔ v2-11: tasks advertised under capabilities.extensions, not capabilities.tasks (0.108583ms)
-2026/04/30 14:35:52 MCP tools/call ok [7µs]
-2026/04/30 14:35:52 [slow_compute] starting "v2-ttl-guard": sleeping 1s...
-  ✔ v2-12: ttlSeconds present (and v1 ttl key absent) (0.839291ms)
-2026/04/30 14:35:52 MCP tasks/get ok [4.541µs]
-2026/04/30 14:35:53 MCP tasks/get ok [7.5µs]
-2026/04/30 14:35:53 MCP tasks/get ok [6.75µs]
-2026/04/30 14:35:53 MCP tasks/get ok [9.75µs]
-2026/04/30 14:35:53 MCP tasks/get ok [7.667µs]
-2026/04/30 14:35:53 [slow_compute] finished "v2-ttl"
-2026/04/30 14:35:53 [slow_compute] finished "v2-ttl-guard"
-2026/04/30 14:35:53 MCP tasks/get ok [60.125µs]
-2026/04/30 14:35:54 MCP tasks/get ok [27.209µs]
-2026/04/30 14:35:54 MCP tools/call ok [16.625µs]
-2026/04/30 14:35:54 [slow_compute] starting "v2-reqstate": sleeping 1s...
-  ✔ v2-13: task must not expire before TTL (1519.705667ms)
-2026/04/30 14:35:54 MCP tasks/get ok [6.625µs]
-2026/04/30 14:35:54 MCP tasks/get ok [23µs]
-2026/04/30 14:35:54 MCP tasks/get ok [10.166µs]
-2026/04/30 14:35:55 MCP tasks/get ok [6.209µs]
-2026/04/30 14:35:55 MCP tasks/get ok [8.666µs]
-2026/04/30 14:35:55 [slow_compute] finished "v2-reqstate"
-2026/04/30 14:35:55 MCP tasks/get ok [22.5µs]
-2026/04/30 14:35:55 MCP tasks/get ok [42.709µs]
-2026/04/30 14:35:55 MCP tools/call ok [22.042µs]
-2026/04/30 14:35:55 [slow_compute] starting "v2-reqstate-echo": sleeping 2s...
-  ✔ v2-14: tasks/get response may include requestState (1018.0765ms)
-2026/04/30 14:35:55 MCP tasks/get ok [4.333µs]
-2026/04/30 14:35:55 MCP tasks/get ok [4.042µs]
-2026/04/30 14:35:55 MCP tools/call ok [12.167µs]
-  ✔ v2-15: client echoes requestState in subsequent requests (2.778ms)
-2026/04/30 14:35:55 [confirm_delete] asking about "v2-input.txt" (parking task in input_required)...
-2026/04/30 14:35:55 MCP tasks/get ok [9.458µs]
-2026/04/30 14:35:55 MCP tools/call ok [8.167µs]
-2026/04/30 14:35:55 [confirm_delete] asking about "v2-respond.txt" (parking task in input_required)...
-  ✔ v2-16: input_required task has inputRequests map in tasks/get (1.691542ms)
-2026/04/30 14:35:55 MCP tasks/get ok [4.375µs]
-2026/04/30 14:35:55 MCP tasks/update ok [31.917µs]
-2026/04/30 14:35:55 [confirm_delete] user confirmed; deleting "v2-respond.txt"
-2026/04/30 14:35:55 MCP tasks/get ok [9.084µs]
-2026/04/30 14:35:55 MCP tools/call ok [29.792µs]
-2026/04/30 14:35:55 [slow_compute] starting "v2-notify": sleeping 1s...
-  ✔ v2-17: tasks/update inputResponses resume task (3.331ms)
-2026/04/30 14:35:55 MCP tasks/get ok [9.125µs]
-2026/04/30 14:35:55 MCP tasks/get ok [22.208µs]
-2026/04/30 14:35:55 MCP tasks/get ok [1.511708ms]
-2026/04/30 14:35:56 MCP tasks/get ok [23.25µs]
-2026/04/30 14:35:56 MCP tasks/get ok [21.833µs]
-2026/04/30 14:35:56 [slow_compute] finished "v2-notify"
-2026/04/30 14:35:56 MCP tasks/get ok [19.25µs]
-2026/04/30 14:35:57 MCP tools/call ok [26µs]
-2026/04/30 14:35:57 [failing_job] starting (will fail in 1s)...
-  ✔ v2-18: status notifications include DetailedTask if sent (1524.302125ms)
-2026/04/30 14:35:57 MCP tools/call ok [52.75µs]
-  ✔ v2-19: tools/call without task param creates task for async tools (3.091291ms)
-2026/04/30 14:35:57 MCP tools/call ok [7.833µs]
-  ✔ v2-20: server may return immediate result for fast operations (2.764042ms)
-2026/04/30 14:35:57 [slow_compute] starting "v2-no-meta": sleeping 1s...
-2026/04/30 14:35:57 MCP tasks/get ok [6.916µs]
-2026/04/30 14:35:57 MCP tasks/get ok [11.25µs]
-2026/04/30 14:35:57 MCP tasks/get ok [11.166µs]
-2026/04/30 14:35:57 [slow_compute] finished "v2-reqstate-echo"
-2026/04/30 14:35:57 MCP tasks/get ok [12.791µs]
-2026/04/30 14:35:57 MCP tasks/get ok [28.542µs]
-2026/04/30 14:35:58 [slow_compute] finished "v2-no-meta"
-2026/04/30 14:35:58 MCP tasks/get ok [33.875µs]
-2026/04/30 14:35:58 MCP tasks/get error=-32601 (method requires extension io.modelcontextprotocol/tasks) [5.083µs]
-  ✔ v2-21: tasks/get inlined result does not include related-task _meta (1019.612166ms)
-2026/04/30 14:35:58 MCP tasks/update error=-32601 (method requires extension io.modelcontextprotocol/tasks) [2.542µs]
-2026/04/30 14:35:58 MCP tasks/cancel error=-32601 (method requires extension io.modelcontextprotocol/tasks) [4.125µs]
-2026/04/30 14:35:58 MCP tools/call ok [48.583µs]
-  ✔ v2-22: tasks/* return -32601 when extension not negotiated (3.283208ms)
-2026/04/30 14:35:58 MCP tools/call ok [28.625µs]
-2026/04/30 14:35:58 [slow_compute] starting "v2-24": sleeping 1s...
-  ✔ v2-23: tools/call without extension returns sync ToolResult (result_type:"complete", no task) (1.274375ms)
-2026/04/30 14:35:58 MCP tools/call ok [17.167µs]
-  ✔ v2-24: Mcp-Name response header on task-creating tools/call (1.20125ms)
-2026/04/30 14:35:58 MCP tools/call ok [19.041µs]
-2026/04/30 14:35:58 [slow_compute] starting "v2-25": sleeping 1s...
-  ✔ v2-24b: Mcp-Name absent on sync tools/call response (1.015542ms)
-2026/04/30 14:35:58 MCP tools/call ok [17.042µs]
-  ✔ v2-25: per-request _meta opt-in produces CreateTaskResult (1.133959ms)
-2026/04/30 14:35:58 MCP tools/call ok [11.333µs]
-2026/04/30 14:35:58 MCP tasks/get ok [15.959µs]
-2026/04/30 14:35:58 MCP tasks/get ok [13.542µs]
-2026/04/30 14:35:58 MCP tools/call ok [10.125µs]
-2026/04/30 14:35:58 [slow_compute] starting "v2-26-cancel": sleeping 60s...
-2026/04/30 14:35:58 [slow_compute] cancelled "v2-26-cancel" at 1/60
-2026/04/30 14:35:58 MCP tasks/cancel ok [41.458µs]
-2026/04/30 14:35:58 MCP tools/call ok [5.917µs]
-2026/04/30 14:35:58 [confirm_delete] asking about "v2-26.txt" (parking task in input_required)...
-2026/04/30 14:35:58 MCP tasks/get ok [4.209µs]
-2026/04/30 14:35:58 MCP tasks/update ok [7µs]
-2026/04/30 14:35:58 MCP tasks/cancel ok [29.959µs]
-2026/04/30 14:35:58 SSEHub: unregistered connection baf859e600d3e9ee12c62f65f62f6cbf (total: 0)
-2026/04/30 14:35:58 Received kill signal.  Quitting Writer. stop 0x50acee58e3f0
-2026/04/30 14:35:58 Cleaning up writer...
-2026/04/30 14:35:58 Finished cleaning up writer:  0x50acee58e3f0
-2026/04/30 14:35:58 Closed MCP-GET-SSE SSE connection: baf859e600d3e9ee12c62f65f62f6cbf
-  ✔ v2-26: non-task responses carry result_type:"complete" (SEP-2322) (9.057875ms)
-✔ MCP Tasks v2 Conformance (SEP-2663) (9821.378541ms)
-ℹ tests 27
+  ✔ v2-01: sync tool call returns immediately, no task (2.582666ms)
+2026/05/04 00:44:02 MCP tools/call ok [6.625µs]
+2026/05/04 00:44:02 [slow_compute] starting "v2-poll": sleeping 3s...
+  ✔ v2-02: server creates task without client task param (1.315041ms)
+2026/05/04 00:44:02 MCP tasks/get ok [14.708µs]
+2026/05/04 00:44:02 MCP tools/call ok [6.084µs]
+2026/05/04 00:44:02 [slow_compute] starting "v2-result": sleeping 1s...
+  ✔ v2-03: tasks/get returns status for active task (2.628ms)
+2026/05/04 00:44:02 MCP tasks/get ok [4.708µs]
+2026/05/04 00:44:02 MCP tasks/get ok [22.042µs]
+2026/05/04 00:44:02 MCP tasks/get ok [18.459µs]
+2026/05/04 00:44:02 MCP tasks/get ok [15.875µs]
+2026/05/04 00:44:03 MCP tasks/get ok [25.083µs]
+2026/05/04 00:44:03 [slow_compute] finished "v2-result"
+2026/05/04 00:44:03 MCP tasks/get ok [53.75µs]
+2026/05/04 00:44:03 MCP tools/call ok [49.125µs]
+2026/05/04 00:44:03 [failing_job] starting (will fail in 1s)...
+  ✔ v2-04: tasks/get returns completed status with inlined result (1026.892541ms)
+2026/05/04 00:44:03 MCP tasks/get ok [20.75µs]
+2026/05/04 00:44:03 MCP tasks/get ok [6.667µs]
+2026/05/04 00:44:03 MCP tasks/get ok [28µs]
+2026/05/04 00:44:03 MCP tasks/get ok [37.458µs]
+2026/05/04 00:44:04 MCP tasks/get ok [29.791µs]
+2026/05/04 00:44:04 [slow_compute] finished "v2-create"
+2026/05/04 00:44:04 MCP tasks/get ok [56.209µs]
+2026/05/04 00:44:04 MCP tools/call ok [32.833µs]
+2026/05/04 00:44:04 [protocol_error_job] starting (will panic in 500ms)...
+  ✔ v2-05: tool execution error is completed with isError true (1028.27675ms)
+2026/05/04 00:44:04 MCP tasks/get ok [18.708µs]
+2026/05/04 00:44:04 MCP tasks/get ok [31.167µs]
+2026/05/04 00:44:04 MCP tasks/get ok [17.459µs]
+2026/05/04 00:44:04 MCP tasks/get ok [23.833µs]
+2026/05/04 00:44:04 MCP tools/call ok [83.042µs]
+2026/05/04 00:44:04 [slow_compute] starting "v2-cancel": sleeping 60s...
+  ✔ v2-06: protocol error is failed with error field (619.631708ms)
+2026/05/04 00:44:04 MCP tasks/cancel ok [885.5µs]
+2026/05/04 00:44:04 [slow_compute] cancelled "v2-cancel" at 1/60
+2026/05/04 00:44:04 MCP tasks/get ok [64.25µs]
+2026/05/04 00:44:04 MCP tools/call ok [44.041µs]
+2026/05/04 00:44:04 [slow_compute] starting "v2-cancel-done": sleeping 1s...
+  ✔ v2-07: tasks/cancel returns empty ack; status settles to cancelled (9.350375ms)
+2026/05/04 00:44:04 MCP tasks/get ok [10.625µs]
+2026/05/04 00:44:05 MCP tasks/get ok [13.333µs]
+2026/05/04 00:44:05 [slow_compute] finished "v2-poll"
+2026/05/04 00:44:05 MCP tasks/get ok [11.375µs]
+2026/05/04 00:44:05 MCP tasks/get ok [26.708µs]
+2026/05/04 00:44:05 MCP tasks/get ok [14.083µs]
+2026/05/04 00:44:05 [slow_compute] finished "v2-cancel-done"
+2026/05/04 00:44:05 MCP tasks/get ok [28.292µs]
+2026/05/04 00:44:05 MCP tasks/cancel error=-32602 (task is already in a terminal state) [10.291µs]
+2026/05/04 00:44:05 MCP tools/call ok [24.625µs]
+2026/05/04 00:44:05 [slow_compute] starting "v2-no-result": sleeping 1s...
+  ✔ v2-08: cancel completed task returns error (1022.157791ms)
+2026/05/04 00:44:05 MCP tasks/get ok [6.583µs]
+2026/05/04 00:44:06 MCP tasks/get ok [21.25µs]
+2026/05/04 00:44:06 MCP tasks/get ok [17.625µs]
+2026/05/04 00:44:06 MCP tasks/get ok [25.125µs]
+2026/05/04 00:44:06 MCP tasks/get ok [22.333µs]
+2026/05/04 00:44:06 [slow_compute] finished "v2-no-result"
+2026/05/04 00:44:07 MCP tasks/get ok [39.292µs]
+2026/05/04 00:44:07 MCP tasks/result error=-32601 (method not found: tasks/result) [7.916µs]
+2026/05/04 00:44:07 MCP tasks/list error=-32601 (method not found: tasks/list) [6.583µs]
+  ✔ v2-09: tasks/result is rejected (method removed in v2) (1026.445083ms)
+2026/05/04 00:44:07 MCP tools/call ok [67.917µs]
+2026/05/04 00:44:07 [slow_compute] starting "v2-ttl": sleeping 1s...
+  ✔ v2-10: tasks/list is rejected (method removed in v2) (2.697958ms)
+  ✔ v2-11: tasks advertised under capabilities.extensions, not capabilities.tasks (0.381791ms)
+2026/05/04 00:44:07 MCP tools/call ok [25.417µs]
+2026/05/04 00:44:07 [slow_compute] starting "v2-ttl-guard": sleeping 1s...
+  ✔ v2-12: ttlSeconds + pollIntervalMilliseconds present (legacy v1 keys absent) (2.750584ms)
+2026/05/04 00:44:07 MCP tasks/get ok [8.583µs]
+2026/05/04 00:44:07 MCP tasks/get ok [26.041µs]
+2026/05/04 00:44:07 MCP tasks/get ok [22.959µs]
+2026/05/04 00:44:07 MCP tasks/get ok [23.916µs]
+2026/05/04 00:44:07 MCP tasks/get ok [25.417µs]
+2026/05/04 00:44:08 [slow_compute] finished "v2-ttl"
+2026/05/04 00:44:08 [slow_compute] finished "v2-ttl-guard"
+2026/05/04 00:44:08 MCP tasks/get ok [61.25µs]
+2026/05/04 00:44:08 MCP tasks/get ok [90.041µs]
+2026/05/04 00:44:08 MCP tools/call ok [45.459µs]
+2026/05/04 00:44:08 [slow_compute] starting "v2-reqstate": sleeping 1s...
+  ✔ v2-13: task must not expire before TTL (1531.758417ms)
+2026/05/04 00:44:08 MCP tasks/get ok [18.083µs]
+2026/05/04 00:44:08 MCP tasks/get ok [23.542µs]
+2026/05/04 00:44:08 MCP tasks/get ok [25.833µs]
+2026/05/04 00:44:09 MCP tasks/get ok [25.833µs]
+2026/05/04 00:44:09 MCP tasks/get ok [26.416µs]
+2026/05/04 00:44:09 [slow_compute] finished "v2-reqstate"
+2026/05/04 00:44:09 MCP tasks/get ok [56.292µs]
+2026/05/04 00:44:09 MCP tasks/get ok [50.167µs]
+2026/05/04 00:44:09 MCP tools/call ok [62.334µs]
+2026/05/04 00:44:09 [slow_compute] starting "v2-reqstate-echo": sleeping 2s...
+  ✔ v2-14: tasks/get response may include requestState (1033.088666ms)
+2026/05/04 00:44:09 MCP tasks/get ok [14.333µs]
+2026/05/04 00:44:09 MCP tasks/get ok [14.958µs]
+2026/05/04 00:44:09 MCP tools/call ok [35.166µs]
+2026/05/04 00:44:09 [confirm_delete] asking about "v2-input.txt" (parking task in input_required)...
+  ✔ v2-15: client echoes requestState in subsequent requests (6.728834ms)
+2026/05/04 00:44:09 MCP tasks/get ok [13.167µs]
+2026/05/04 00:44:09 MCP tools/call ok [21.875µs]
+2026/05/04 00:44:09 [confirm_delete] asking about "v2-respond.txt" (parking task in input_required)...
+  ✔ v2-16: input_required task has inputRequests map in tasks/get (3.993833ms)
+2026/05/04 00:44:09 MCP tasks/get ok [13.416µs]
+2026/05/04 00:44:09 MCP tasks/update ok [39µs]
+2026/05/04 00:44:09 [confirm_delete] user confirmed; deleting "v2-respond.txt"
+2026/05/04 00:44:09 MCP tasks/get ok [25.625µs]
+2026/05/04 00:44:09 MCP tools/call ok [32.25µs]
+2026/05/04 00:44:09 [slow_compute] starting "v2-notify": sleeping 1s...
+  ✔ v2-17: tasks/update inputResponses resume task (6.354084ms)
+2026/05/04 00:44:09 MCP tasks/get ok [8.041µs]
+2026/05/04 00:44:09 MCP tasks/get ok [24.959µs]
+2026/05/04 00:44:10 MCP tasks/get ok [29.958µs]
+2026/05/04 00:44:10 MCP tasks/get ok [14.792µs]
+2026/05/04 00:44:10 MCP tasks/get ok [28.916µs]
+2026/05/04 00:44:10 [slow_compute] finished "v2-notify"
+2026/05/04 00:44:10 MCP tasks/get ok [51.5µs]
+2026/05/04 00:44:11 MCP tools/call ok [35.833µs]
+2026/05/04 00:44:11 [failing_job] starting (will fail in 1s)...
+  ✔ v2-18: status notifications include DetailedTask if sent (1529.370584ms)
+2026/05/04 00:44:11 MCP tools/call ok [30.25µs]
+  ✔ v2-19: tools/call without task param creates task for async tools (3.671625ms)
+2026/05/04 00:44:11 MCP tools/call ok [42.5µs]
+2026/05/04 00:44:11 [slow_compute] starting "v2-no-meta": sleeping 1s...
+  ✔ v2-20: server may return immediate result for fast operations (2.729625ms)
+2026/05/04 00:44:11 MCP tasks/get ok [15.583µs]
+2026/05/04 00:44:11 MCP tasks/get ok [28.292µs]
+2026/05/04 00:44:11 MCP tasks/get ok [29.625µs]
+2026/05/04 00:44:11 [slow_compute] finished "v2-reqstate-echo"
+2026/05/04 00:44:11 MCP tasks/get ok [21.25µs]
+2026/05/04 00:44:11 MCP tasks/get ok [26.959µs]
+2026/05/04 00:44:12 [slow_compute] finished "v2-no-meta"
+2026/05/04 00:44:12 MCP tasks/get ok [59.5µs]
+2026/05/04 00:44:12 MCP tasks/get error=-32601 (method requires extension io.modelcontextprotocol/tasks) [13.208µs]
+  ✔ v2-21: tasks/get inlined result does not include related-task _meta (1028.228375ms)
+2026/05/04 00:44:12 MCP tasks/update error=-32601 (method requires extension io.modelcontextprotocol/tasks) [9.416µs]
+2026/05/04 00:44:12 MCP tasks/cancel error=-32601 (method requires extension io.modelcontextprotocol/tasks) [9.167µs]
+2026/05/04 00:44:12 MCP tools/call ok [84.042µs]
+  ✔ v2-22: tasks/* return -32601 when extension not negotiated (8.154542ms)
+2026/05/04 00:44:12 MCP tools/call ok [51.5µs]
+2026/05/04 00:44:12 [slow_compute] starting "v2-24": sleeping 1s...
+  ✔ v2-23: tools/call without extension returns sync ToolResult (resultType:"complete", no task) (2.141625ms)
+2026/05/04 00:44:12 MCP tools/call ok [36.584µs]
+  ✔ v2-24: Mcp-Name + Mcp-Method response headers on task-creating tools/call (2.054959ms)
+2026/05/04 00:44:12 MCP tools/call ok [120.75µs]
+2026/05/04 00:44:12 [slow_compute] starting "v2-24c": sleeping 60s...
+  ✔ v2-24b: Mcp-Name absent on sync tools/call response (Mcp-Method still present) (1.81325ms)
+2026/05/04 00:44:12 MCP tasks/get ok [33.375µs]
+2026/05/04 00:44:12 [slow_compute] cancelled "v2-24c" at 1/60
+2026/05/04 00:44:12 MCP tasks/cancel ok [120.208µs]
+2026/05/04 00:44:12 MCP tools/call ok [35.958µs]
+2026/05/04 00:44:12 [slow_compute] starting "v2-25": sleeping 1s...
+  ✔ v2-24c: Mcp-Method on tasks/get and tasks/cancel responses (6.171291ms)
+2026/05/04 00:44:12 MCP tools/call ok [25.958µs]
+  ✔ v2-25: per-request _meta opt-in produces CreateTaskResult (1.899625ms)
+2026/05/04 00:44:12 MCP tools/call ok [15.041µs]
+2026/05/04 00:44:12 MCP tasks/get ok [20.75µs]
+2026/05/04 00:44:12 MCP tasks/get ok [11.542µs]
+2026/05/04 00:44:12 MCP tools/call ok [8.209µs]
+2026/05/04 00:44:12 [slow_compute] starting "v2-26-cancel": sleeping 60s...
+2026/05/04 00:44:12 [slow_compute] cancelled "v2-26-cancel" at 1/60
+2026/05/04 00:44:12 MCP tasks/cancel ok [65.708µs]
+2026/05/04 00:44:12 MCP tools/call ok [9.042µs]
+2026/05/04 00:44:12 [confirm_delete] asking about "v2-26.txt" (parking task in input_required)...
+2026/05/04 00:44:12 MCP tasks/get ok [11.625µs]
+2026/05/04 00:44:12 MCP tasks/update ok [9.625µs]
+2026/05/04 00:44:12 MCP tasks/cancel ok [49.75µs]
+2026/05/04 00:44:12 MCP tools/call ok [10.667µs]
+2026/05/04 00:44:12 [slow_compute] starting "v2-27": sleeping 60s...
+  ✔ v2-26: non-task responses carry resultType:"complete" (SEP-2322) (11.063333ms)
+2026/05/04 00:44:12 MCP tasks/get ok [4.542µs]
+2026/05/04 00:44:12 [slow_compute] cancelled "v2-27" at 1/60
+2026/05/04 00:44:12 MCP tasks/cancel ok [44.792µs]
+2026/05/04 00:44:12 MCP tools/call ok [7.667µs]
+2026/05/04 00:44:12 [slow_compute] starting "v2-28": sleeping 60s...
+  ✔ v2-27: tasks/get immediately after CreateTaskResult must resolve (2.447375ms)
+2026/05/04 00:44:12 MCP tasks/get ok [3.583µs]
+2026/05/04 00:44:12 MCP tasks/get ok [5.5µs]
+2026/05/04 00:44:12 MCP tasks/get ok [3.5µs]
+2026/05/04 00:44:12 [slow_compute] cancelled "v2-28" at 1/60
+2026/05/04 00:44:12 MCP tasks/cancel ok [38.917µs]
+2026/05/04 00:44:12 SSEHub: unregistered connection 437afce20a9ed8cd84e12e8f5d13f216 (total: 0)
+2026/05/04 00:44:12 Received kill signal.  Quitting Writer. stop 0x6c9cb1f42f50
+2026/05/04 00:44:12 Cleaning up writer...
+2026/05/04 00:44:12 Finished cleaning up writer:  0x6c9cb1f42f50
+2026/05/04 00:44:12 Closed MCP-GET-SSE SSE connection: 437afce20a9ed8cd84e12e8f5d13f216
+  ✔ v2-28: stale-but-valid requestState is tolerated (3.408541ms)
+✔ MCP Tasks v2 Conformance (SEP-2663) (9952.914125ms)
+ℹ tests 30
 ℹ suites 1
-ℹ pass 27
+ℹ pass 30
 ℹ fail 0
 ℹ cancelled 0
 ℹ skipped 0
 ℹ todo 0
-ℹ duration_ms 10122.0405
-Finished: Thu Apr 30 14:35:58 PDT 2026
-2026/04/30 14:35:59 [slow_compute] finished "v2-24"
-2026/04/30 14:35:59 [slow_compute] finished "v2-25"
+ℹ duration_ms 10267.112042
+Finished: Mon May  4 00:44:12 PDT 2026
+2026/05/04 00:44:13 [slow_compute] finished "v2-24"
+2026/05/04 00:44:13 [slow_compute] finished "v2-25"

--- a/tests/reports/stage-ui.log
+++ b/tests/reports/stage-ui.log
@@ -1,15 +1,15 @@
 === Stage 4/12: ui (make test-ui) ===
-Started: Thu Apr 30 14:34:49 PDT 2026
+Started: Mon May  4 00:42:58 PDT 2026
 cd ext/ui && /Library/Developer/CommandLineTools/usr/bin/make test
 go test ./... -count=1 -timeout 30s
-ok  	github.com/panyam/mcpkit/ext/ui	0.417s
+ok  	github.com/panyam/mcpkit/ext/ui	0.715s
 cd assets && pnpm install --frozen-lockfile --silent && pnpm test
 
-> @mcpkit/app-bridge@0.1.0 test /Users/dzshrh/newstack/mcpkit/mrtr/ext/ui/assets
+> @mcpkit/app-bridge@0.1.0 test /Users/dzshrh/newstack/mcpkit/main/ext/ui/assets
 > vitest run
 
 
- RUN  v3.2.4 /Users/dzshrh/newstack/mcpkit/mrtr/ext/ui/assets
+ RUN  v3.2.4 /Users/dzshrh/newstack/mcpkit/main/ext/ui/assets
 
 stderr | mcp-app-bridge.test.ts > pre-handshake guarding > sendToolListChanged is silently dropped before handshake
 [MCPApp] notify blocked before handshake: notifications/tools/list_changed
@@ -17,11 +17,11 @@ stderr | mcp-app-bridge.test.ts > pre-handshake guarding > sendToolListChanged i
 stderr | mcp-app-bridge.test.ts > pre-handshake guarding > log is silently dropped before handshake
 [MCPApp] notify blocked before handshake: ui/log
 
- ✓ mcp-app-bridge.test.ts (48 tests) 683ms
+ ✓ mcp-app-bridge.test.ts (48 tests) 691ms
 
  Test Files  1 passed (1)
       Tests  48 passed (48)
-   Start at  14:34:51
-   Duration  1.43s (transform 38ms, setup 0ms, collect 35ms, tests 683ms, environment 387ms, prepare 125ms)
+   Start at  00:43:01
+   Duration  1.36s (transform 31ms, setup 0ms, collect 30ms, tests 691ms, environment 339ms, prepare 68ms)
 
-Finished: Thu Apr 30 14:34:53 PDT 2026
+Finished: Mon May  4 00:43:03 PDT 2026

--- a/tests/reports/stage-unit+coverage.log
+++ b/tests/reports/stage-unit+coverage.log
@@ -1,11 +1,11 @@
 === Stage 1/12: unit+coverage (make cover-html) ===
-Started: Thu Apr 30 14:34:19 PDT 2026
+Started: Mon May  4 00:42:21 PDT 2026
 go test -coverprofile=tests/reports/coverage.out ./... -count=1 -timeout 30s
-ok  	github.com/panyam/mcpkit/client	8.162s	coverage: 65.4% of statements
+ok  	github.com/panyam/mcpkit/client	8.355s	coverage: 64.2% of statements
 	github.com/panyam/mcpkit/cmd/testserver		coverage: 0.0% of statements
-ok  	github.com/panyam/mcpkit/core	0.337s	coverage: 47.3% of statements
-ok  	github.com/panyam/mcpkit/server	12.475s	coverage: 78.9% of statements
-ok  	github.com/panyam/mcpkit/testutil	1.320s	coverage: 69.4% of statements
+ok  	github.com/panyam/mcpkit/core	0.570s	coverage: 47.3% of statements
+ok  	github.com/panyam/mcpkit/server	13.784s	coverage: 79.0% of statements
+ok  	github.com/panyam/mcpkit/testutil	0.424s	coverage: 69.4% of statements
 go tool cover -html=tests/reports/coverage.out -o tests/reports/coverage.html
 Coverage report: tests/reports/coverage.html
-Finished: Thu Apr 30 14:34:33 PDT 2026
+Finished: Mon May  4 00:42:37 PDT 2026


### PR DESCRIPTION
Spec alignment, fourth of seven (α #353, β #355, γ #356 merged). Five wire-format deltas, each in its own commit with spec citations, plus two demo follow-ups. Tracking: mcpkit#349.

Spec snapshot: \`proposals/triggers-events-wg/spec-snapshots/design-sketch-2026-04-30.md\` (cached in mcpcontribs).

## Deltas

| # | Change | Spec |
|---|---|---|
| δ-1 | Flat \`events/poll\` request — drop \`subscriptions[]\` wrapper | §"Poll-Based Delivery" L139-149 |
| δ-2 | \`maxAge\` replay floor on poll (handler-layer filter) | §"Cursor Lifecycle" L529 |
| δ-3 | \`maxAge\` on subscribe (stored on \`WebhookTarget\`) | §"Cursor Lifecycle" L529 |
| δ-4 | \`_meta\` on \`EventOccurrence\` + \`EventDescriptor\` | spec follow-on commit d4faef9 (2026-05-01) |
| δ-5 | \`nextCursor\` on \`events/list\` | spec follow-on commit d4faef9 (2026-05-01) |

## Risk profile

Lower than γ. Only one wire-breaking change (flat poll request); no auth surgery; no identity changes. The four other deltas are additive optional fields.

Forcing for clients: flat \`events/poll\` request shape only. Old \`{subscriptions: [...]}\` requests now return \`-32602\` with a spec-pointing message; we own all call sites and they're updated in δ-1.

## Design notes

**δ-2 / δ-3 maxAge**: implemented at the handler layer in \`registerPoll\`/\`registerSubscribe\` rather than threading a parameter through \`EventSource.Poll(cursor, limit)\`. Keeps the source interface stable; existing implementors don't have to learn about replay floors. Server filters out events with \`timestamp < now - maxAge\` and sets \`truncated: true\` to signal the gap.

**WebhookTarget.MaxAgeSeconds**: stored on the target for ζ's reconnect-with-replay logic. Refresh treats \`0\` as "don't change" (so a refresh that omits maxAge doesn't accidentally drop the stored floor).

**listResultWire**: typed response struct introduced for \`events/list\` so the \`omitempty\` contract on \`nextCursor\` is enforced by the type system (instead of \`map[string]any\`). Pinned by \`TestList_NextCursorOmitsWhenEmpty\`.

## Demo follow-ups (after the 5 spec commits)

- **\`YieldingSource.SetMetaFunc(func(Data) map[string]any)\`** — typed setter so authors can derive per-event \`_meta\` without touching the yield closure signature. Lives as a setter rather than a YieldingOption because option-functions don't compose with the generic \`Data\` type.
- **Discord walkthrough** now lights up \`_meta\` end-to-end: \`channel_type\` ("dm" vs "guild") and \`mention_count\` per event from the metaFunc, plus \`EventDef.Meta = {"category": "messaging"}\` for type-level metadata. The receiver step prints \`ev.Meta\` when present.
- **Both walkthroughs** pass \`MaxAge: 5*time.Minute\` on subscribe so the δ-3 plumbing flows end-to-end (no observable effect today; ζ wires the actual replay-with-floor logic).

## Test sweep

All four affected modules pass \`go test -count=1 ./...\`:
- \`experimental/ext/events/\`
- \`experimental/ext/events/clients/go/\`
- \`examples/events/discord/\`
- \`examples/events/telegram/\`

12 new tests added (red-before-green for each delta + SetMetaFunc), 0 assertions weakened, ~6 demo poll-call sites flattened in place.

## Out of scope

- **Push delivery** (\`events/stream\`) — ε. Stream's \`maxAge\` handling lands there.
- **Reconnect-with-maxAge** semantics for webhook (server-side replay queue) — ζ; depends on the suspend/reactivate state machine.
- **Actual pagination logic** for \`events/list\` (computing/accepting \`nextCursor\` requests) — application-layer concern; δ just threads the field through the wire.