### PR TITLE
fix(events/telegram): race in TestWebhookHMACSignature_MCPHeaders

### DIFF
--- a/examples/events/telegram/handlers_test.go
+++ b/examples/events/telegram/handlers_test.go
@@ -182,13 +182,26 @@ func TestResourceMessageByCursor(t *testing.T) {
 // WithWebhookHeaderMode(MCPHeaders) for this byte-format check to apply.
 func TestWebhookHMACSignature_MCPHeaders(t *testing.T) {
 	secret := "test-secret-key"
+
+	// Captured-state mutex matches the pattern used by
+	// TestWebhookRetryOnServerError + TestWebhookNoRetryOn4xx in this
+	// file. Without it, the handler-goroutine writes race the test-
+	// goroutine reads after the time.Sleep barrier (which the race
+	// detector correctly flags — sleeps don't establish happens-before).
+	// Issue 360.
+	var mu sync.Mutex
 	var receivedBody []byte
 	var receivedSig, receivedTS string
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		receivedSig = r.Header.Get("X-MCP-Signature")
-		receivedTS = r.Header.Get("X-MCP-Timestamp")
-		receivedBody, _ = io.ReadAll(r.Body)
+		body, _ := io.ReadAll(r.Body)
+		sig := r.Header.Get("X-MCP-Signature")
+		ts := r.Header.Get("X-MCP-Timestamp")
+		mu.Lock()
+		receivedBody = body
+		receivedSig = sig
+		receivedTS = ts
+		mu.Unlock()
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
@@ -205,6 +218,8 @@ func TestWebhookHMACSignature_MCPHeaders(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond)
 
+	mu.Lock()
+	defer mu.Unlock()
 	require.NotEmpty(t, receivedBody)
 	require.NotEmpty(t, receivedSig)
 	require.NotEmpty(t, receivedTS)


### PR DESCRIPTION
Closes 360.

## What

Wrap the captured state (\`receivedBody\`, \`receivedSig\`, \`receivedTS\`) in a \`sync.Mutex\`. Read the request body / headers into locals first, then take the lock for the assignment, so I/O isn't held under the mutex.

## Why

\`go test -race\` was failing on the test — the handler-goroutine writes to the captured vars raced the test-goroutine reads after the \`time.Sleep(100ms)\` barrier. Sleeps don't establish happens-before; the race detector correctly flags it. Pre-existing latent bug; surfaced when running \`-race\` against the events ε branch.

Matches the pattern used by \`TestWebhookRetryOnServerError\` + \`TestWebhookNoRetryOn4xx\` in the same file (which already use a mutex around their captured \`attempts\` counter).

## Verify

\`\`\`
cd examples/events/telegram
go test -count=1 -race ./...
ok  	github.com/panyam/mcpkit/examples/events/telegram	8.389s
\`\`\`