### PR TITLE
feat(server): SEP-2356 file-input validation + conformance suite (A3 + acceptance bar) — 6/7 green

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ make testconf-tasks    # Tasks v1 conformance (27 scenarios, self-contained)
 make testconf-tasks-v2 # Tasks v2 conformance (33 scenarios, self-contained, SEP-2663)
 make testconf-mrtr     # MRTR conformance (7 scenarios + 1 deferred skip, SEP-2322)
 make testconf-list-ttl # List-TTL conformance (5 scenarios, SEP-2549)
+make testconf-file-inputs # File-inputs conformance (7 scenarios, SEP-2356; 4 green / 3 red awaiting #361 + #362)
 make testall           # Everything (12 stages) + Keycloak + HTML report
 make audit             # govulncheck + gosec + gitleaks + race
 make tag-push V=vX.Y.Z # Tag root + all sub-modules and push
@@ -59,7 +60,7 @@ Module-specific gotchas live in their READMEs.
 
 ## Conformance
 
-Server: 30/30, Auth: 14/14, Apps: 21, Tasks v1: 27/27, Tasks v2: 33/33 (SEP-2663), MRTR: 7/7 (SEP-2322, ephemeral; 1 task-composition scenario skipped pending follow-up), List-TTL: 5/5 (SEP-2549), Keycloak: 12/12, testall: 12/12 stages.
+Server: 30/30, Auth: 14/14, Apps: 21, Tasks v1: 27/27, Tasks v2: 33/33 (SEP-2663), MRTR: 7/7 (SEP-2322, ephemeral; 1 task-composition scenario skipped pending follow-up), List-TTL: 5/5 (SEP-2549), File-Inputs: 4/7 (SEP-2356; 3 awaiting #361 server validation + #362 capability gating), Keycloak: 12/12, testall: 12/12 stages.
 
 ## Tasks v1 vs v2
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ make testconf-tasks    # Tasks v1 conformance (27 scenarios, self-contained)
 make testconf-tasks-v2 # Tasks v2 conformance (33 scenarios, self-contained, SEP-2663)
 make testconf-mrtr     # MRTR conformance (7 scenarios + 1 deferred skip, SEP-2322)
 make testconf-list-ttl # List-TTL conformance (5 scenarios, SEP-2549)
-make testconf-file-inputs # File-inputs conformance (7 scenarios, SEP-2356; 4 green / 3 red awaiting #361 + #362)
+make testconf-file-inputs # File-inputs conformance (7 scenarios, SEP-2356; 6 green / 1 red awaiting #362)
 make testall           # Everything (12 stages) + Keycloak + HTML report
 make audit             # govulncheck + gosec + gitleaks + race
 make tag-push V=vX.Y.Z # Tag root + all sub-modules and push
@@ -60,7 +60,7 @@ Module-specific gotchas live in their READMEs.
 
 ## Conformance
 
-Server: 30/30, Auth: 14/14, Apps: 21, Tasks v1: 27/27, Tasks v2: 33/33 (SEP-2663), MRTR: 7/7 (SEP-2322, ephemeral; 1 task-composition scenario skipped pending follow-up), List-TTL: 5/5 (SEP-2549), File-Inputs: 4/7 (SEP-2356; 3 awaiting #361 server validation + #362 capability gating), Keycloak: 12/12, testall: 12/12 stages.
+Server: 30/30, Auth: 14/14, Apps: 21, Tasks v1: 27/27, Tasks v2: 33/33 (SEP-2663), MRTR: 7/7 (SEP-2322, ephemeral; 1 task-composition scenario skipped pending follow-up), List-TTL: 5/5 (SEP-2549), File-Inputs: 6/7 (SEP-2356; 1 awaiting #362 capability gating), Keycloak: 12/12, testall: 12/12 stages.
 
 ## Tasks v1 vs v2
 

--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,18 @@ testconf-list-ttl: ## Run MCP SEP-2549 list-TTL conformance (builds + starts 3 s
 	wait $$PID1 $$PID2 $$PID3 2>/dev/null; \
 	exit $$RC
 
+testconf-file-inputs: ## Run MCP SEP-2356 file-inputs conformance (builds + starts server, runs tests, tears down)
+	@(cd examples/file-inputs && go build -o file-inputs-demo .) && \
+	examples/file-inputs/file-inputs-demo --serve --addr=:18097 & PID=$$!; \
+	sleep 1; \
+	(cd conformance && npm install --silent && \
+	SERVER_URL=http://localhost:18097/mcp \
+	npx tsx --test file-inputs/scenarios.test.ts); \
+	RC=$$?; \
+	kill $$PID 2>/dev/null; \
+	wait $$PID 2>/dev/null; \
+	exit $$RC
+
 testconf-elicitation: ## Run elicitation conformance suite (SEP-1036 URL mode + form, requires Node.js, target server must be running)
 	cd conformance && npm install --silent && SERVER_URL=$${SERVER_URL:-http://localhost:8080/mcp} npx tsx --test elicitation/scenarios.test.ts
 

--- a/conformance/file-inputs/README.md
+++ b/conformance/file-inputs/README.md
@@ -45,15 +45,14 @@ are not exercised here — they're bridge UX, not wire format.
 | `file-inputs-01` | client WITH `fileInputs` cap sees `x-mcp-file` on every file property | ✅ green | — |
 | `file-inputs-02` | client WITHOUT cap does NOT see `x-mcp-file` (but tools stay visible) | ❌ red | [#362 — A4 capability gating](https://github.com/panyam/mcpkit/issues/362) |
 | `file-inputs-03` | valid file upload round-trips bytes / media type / filename | ✅ green | — |
-| `file-inputs-04` | oversized file → `-32602` + `data.reason: "file_too_large"` | ❌ red | [#361 — A3 server validation](https://github.com/panyam/mcpkit/issues/361) |
-| `file-inputs-05` | wrong MIME → `-32602` + `data.reason: "file_type_not_accepted"` | ❌ red | [#361 — A3 server validation](https://github.com/panyam/mcpkit/issues/361) |
+| `file-inputs-04` | oversized file → `-32602` + `data.reason: "file_too_large"` | ✅ green (A3 shipped) | — |
+| `file-inputs-05` | wrong MIME → `-32602` + `data.reason: "file_type_not_accepted"` | ✅ green (A3 shipped) | — |
 | `file-inputs-06` | array-of-files input (`analyze_documents`) handles multiple URIs | ✅ green | — |
 | `file-inputs-07` | filename with special chars (parens, spaces, quotes) round-trips through percent-encoding | ✅ green | — |
 
-The 4 green scenarios are the contract A1 (#358, shipped) already
-satisfies. The 3 red scenarios are the done-bar for A3 (#361) and A4
-(#362). When all 7 are green, SEP-2356 Phase 1.4 + 1.5 are complete and
-this suite becomes the WG-facing acceptance bar.
+6 green, 1 red. The remaining red (cap-gating) is the done-bar for A4
+(#362). When `file-inputs-02` flips green, SEP-2356 Phase 1.4 + 1.5 are
+complete and this suite becomes the WG-facing acceptance bar.
 
 ## Running
 

--- a/conformance/file-inputs/README.md
+++ b/conformance/file-inputs/README.md
@@ -1,0 +1,97 @@
+# SEP-2356 File Inputs — Conformance
+
+Verifies that an MCP server correctly implements the SEP-2356 file-input
+wire contract: `x-mcp-file` schema marker visibility gated on the client's
+`fileInputs` capability, RFC 2397 base64 data URI round-trip, and
+structured `-32602` error responses for oversized / wrong-MIME payloads.
+
+[sep-2356]: https://github.com/modelcontextprotocol/specification/pull/2356
+
+## Wire contract
+
+| Concern | Expected wire shape |
+|---|---|
+| Schema marker (cap declared) | `x-mcp-file: <FileInputDescriptor>` on `{type: "string", format: "uri"}` properties (and on `items` for arrays) |
+| Schema marker (no cap) | keyword stripped; underlying `string`/`uri` property remains so the tool stays callable |
+| File payload | `data:<mediaType>;name=<pct-encoded-filename>;base64,<payload>` |
+| Filename encoding | `url.PathEscape`-equivalent — encodes `( ) ! * '` (broader than `encodeURIComponent`) |
+| Oversized payload | `-32602` + `data: {reason: "file_too_large", actualSize, maxSize}` |
+| Wrong MIME | `-32602` + `data: {reason: "file_type_not_accepted", mediaType, accept}` |
+
+The cap-gating interpretation locked here is **strip the keyword, keep the
+property**. Spec text says "MUST NOT include file input fields" — this
+suite reads that as the keyword, not the whole property, so legacy clients
+without the SEP-2356 cap can still call the tools and render a text input
+as a fallback.
+
+## Server fixture
+
+[`examples/file-inputs/`](../../examples/file-inputs/) registers three
+demo tools that exercise every SEP-2356 shape:
+
+| Tool | Descriptor | Shape |
+|------|-----------|-------|
+| `upload_image` | `accept: ["image/*"]`, `maxSize: 5 MiB` | single-file (`properties.image.x-mcp-file`) |
+| `analyze_documents` | `accept: ["application/pdf", ".pdf"]` | array (`properties.documents.items.x-mcp-file`) |
+| `process_any_file` | `{}` (no constraints) | single-file, no filter |
+
+The Apps-mode wrappers (`apps_upload_image`, `apps_analyze_documents`)
+are not exercised here — they're bridge UX, not wire format.
+
+## Scenarios
+
+| ID | What it tests | Status today | Unblocked by |
+|----|---------------|--------------|--------------|
+| `file-inputs-01` | client WITH `fileInputs` cap sees `x-mcp-file` on every file property | ✅ green | — |
+| `file-inputs-02` | client WITHOUT cap does NOT see `x-mcp-file` (but tools stay visible) | ❌ red | [#362 — A4 capability gating](https://github.com/panyam/mcpkit/issues/362) |
+| `file-inputs-03` | valid file upload round-trips bytes / media type / filename | ✅ green | — |
+| `file-inputs-04` | oversized file → `-32602` + `data.reason: "file_too_large"` | ❌ red | [#361 — A3 server validation](https://github.com/panyam/mcpkit/issues/361) |
+| `file-inputs-05` | wrong MIME → `-32602` + `data.reason: "file_type_not_accepted"` | ❌ red | [#361 — A3 server validation](https://github.com/panyam/mcpkit/issues/361) |
+| `file-inputs-06` | array-of-files input (`analyze_documents`) handles multiple URIs | ✅ green | — |
+| `file-inputs-07` | filename with special chars (parens, spaces, quotes) round-trips through percent-encoding | ✅ green | — |
+
+The 4 green scenarios are the contract A1 (#358, shipped) already
+satisfies. The 3 red scenarios are the done-bar for A3 (#361) and A4
+(#362). When all 7 are green, SEP-2356 Phase 1.4 + 1.5 are complete and
+this suite becomes the WG-facing acceptance bar.
+
+## Running
+
+```bash
+# from repo root — handles build + spawn + tear-down
+make testconf-file-inputs
+
+# or manually against an already-running server
+cd conformance && npm install
+SERVER_URL=http://localhost:18097/mcp \
+  npx tsx --test file-inputs/scenarios.test.ts
+```
+
+## Why locked-in error data shape
+
+Scenarios 4 and 5 assert structured error data:
+
+```json
+{
+  "code": -32602,
+  "message": "...",
+  "data": {
+    "reason": "file_too_large",
+    "actualSize": 5243904,
+    "maxSize": 5242880
+  }
+}
+```
+
+Locked here so:
+
+- Multiple language SDKs converge on the same shape (this suite is the
+  cross-impl contract).
+- Clients can render rich error UX (showing the actual vs maximum size,
+  not just a stringified message).
+- The `reason` field doubles as a stable machine-readable identifier;
+  bridge sentinel error names (`MCPFileTooLarge`, `MCPFileTypeNotAccepted`)
+  align with the same constants on the JS side.
+
+If the SEP-2356 / SEP-2631 reconciliation later reshapes the error
+contract, this suite is the single point that needs updating.

--- a/conformance/file-inputs/scenarios.test.ts
+++ b/conformance/file-inputs/scenarios.test.ts
@@ -1,0 +1,402 @@
+/**
+ * SEP-2356 — File Inputs — Conformance Scenarios
+ *
+ * Verifies the wire-format contract for declarative file inputs:
+ *
+ *   - Tool input properties of `{type: "string", format: "uri"}` carrying
+ *     the `x-mcp-file` JSON Schema extension keyword are advertised to
+ *     clients that declare the `fileInputs` capability.
+ *   - Servers MUST NOT include `x-mcp-file` in tool schemas (or
+ *     elicitation `requestedSchema`) for clients without the capability.
+ *     Per spec interpretation locked here: STRIP the keyword, KEEP the
+ *     property visible as a plain `string`/`uri` so the tool stays
+ *     callable on clients that haven't adopted SEP-2356.
+ *   - Files travel as RFC 2397 base64 data URIs with an optional
+ *     percent-encoded `name=` parameter:
+ *         data:<mediatype>;name=<pct-encoded>;base64,<payload>
+ *   - Servers reject oversized payloads with JSON-RPC `-32602` and
+ *     structured `data: {reason: "file_too_large", actualSize, maxSize}`.
+ *   - Servers reject MIME mismatches with `-32602` and
+ *     `data: {reason: "file_type_not_accepted", mediaType, accept}`.
+ *   - Both single-file and array-of-files inputs work; filenames with
+ *     special characters round-trip through percent-encoding.
+ *
+ * Server fixture (one process):
+ *   examples/file-inputs/file-inputs-demo --serve --addr=:18097
+ *
+ * The fixture registers three tools whose handlers exercise the SEP-2356
+ * surface:
+ *   upload_image       (image/* , maxSize 5 MiB)  — single-file picker
+ *   analyze_documents  (.pdf / application/pdf)   — array picker
+ *   process_any_file   (no constraints)           — unrestricted
+ *
+ * Apps-mode wrappers (`apps_upload_image`, `apps_analyze_documents`) are
+ * not exercised here — they're bridge-mediated UX, not wire-format
+ * concerns.
+ *
+ * Server URL comes from env (set by the Makefile target
+ * `testconf-file-inputs`):
+ *
+ *   SERVER_URL — default http://localhost:18097/mcp
+ *
+ * Usage (manual — usually invoked via `make testconf-file-inputs`):
+ *
+ *   SERVER_URL=http://localhost:18097/mcp \
+ *     npx tsx --test file-inputs/scenarios.test.ts
+ */
+
+import { describe, test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+const SERVER_URL = process.env.SERVER_URL || 'http://localhost:18097/mcp';
+
+// =============================================================================
+// Raw JSON-RPC plumbing — bypasses the SDK so we can inspect (and craft)
+// wire shapes the SDK might validate-and-strip.
+// =============================================================================
+
+let nextId = 1;
+
+interface InitOptions {
+    /** Whether to declare the `fileInputs` capability in initialize. */
+    fileInputs?: boolean;
+}
+
+async function initSession(opts: InitOptions = {}): Promise<string> {
+    const capabilities: Record<string, unknown> = {};
+    if (opts.fileInputs) capabilities.fileInputs = {};
+
+    const resp = await fetch(SERVER_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+        body: JSON.stringify({
+            jsonrpc: '2.0', id: 'init', method: 'initialize',
+            params: {
+                protocolVersion: '2025-11-25',
+                clientInfo: { name: 'file-inputs-conformance', version: '1.0' },
+                capabilities,
+            },
+        }),
+    });
+    const sid = resp.headers.get('mcp-session-id') || '';
+    if (!sid) throw new Error(`initialize at ${SERVER_URL} missing Mcp-Session-Id`);
+    await fetch(SERVER_URL, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+            'Mcp-Session-Id': sid,
+        },
+        body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }),
+    });
+    return sid;
+}
+
+interface RawCallResult {
+    /** Set when the server returned a JSON-RPC `result`. */
+    result?: any;
+    /** Set when the server returned a JSON-RPC `error`. */
+    error?: { code: number; message: string; data?: any };
+}
+
+async function rawCall(sid: string, method: string, params: any = null): Promise<RawCallResult> {
+    const id = nextId++;
+    const resp = await fetch(SERVER_URL, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'text/event-stream, application/json',
+            'Mcp-Session-Id': sid,
+        },
+        body: JSON.stringify({ jsonrpc: '2.0', id, method, params }),
+    });
+    const ct = resp.headers.get('content-type') || '';
+    let body: any;
+    if (ct.includes('text/event-stream')) {
+        const text = await resp.text();
+        for (const line of text.split('\n')) {
+            const trimmed = line.trim();
+            if (trimmed.startsWith('data:')) {
+                const payload = trimmed.slice(5).trimStart();
+                if (payload.startsWith('{')) {
+                    const parsed = JSON.parse(payload);
+                    if (parsed.id === id) { body = parsed; break; }
+                }
+            }
+        }
+    } else {
+        body = await resp.json();
+    }
+    if (!body) throw new Error(`No response for ${method}`);
+    return { result: body.result, error: body.error };
+}
+
+// =============================================================================
+// Helpers — data URI synthesis and schema walking
+// =============================================================================
+
+/** Match Go's `url.PathEscape` — encodes `( ) ! * '` which encodeURIComponent leaves alone. */
+function pctEncodePathLike(s: string): string {
+    return encodeURIComponent(s).replace(
+        /[!'()*]/g,
+        (ch) => '%' + ch.charCodeAt(0).toString(16).toUpperCase(),
+    );
+}
+
+/** Build a base64 data URI matching `core.EncodeDataURI` byte-for-byte. */
+function makeDataURI(mediaType: string, filename: string, bytes: Buffer | string): string {
+    const buf = typeof bytes === 'string' ? Buffer.from(bytes, 'utf8') : bytes;
+    const namePart = filename ? `;name=${pctEncodePathLike(filename)}` : '';
+    return `data:${mediaType}${namePart};base64,${buf.toString('base64')}`;
+}
+
+/** Walk a tool's inputSchema and return the set of property paths that
+ * carry the `x-mcp-file` keyword. Used to assert presence/absence of the
+ * keyword across single, array, and nested cases. */
+function findFileInputPaths(inputSchema: any): string[] {
+    const found: string[] = [];
+    function walk(node: any, path: string): void {
+        if (node == null || typeof node !== 'object') return;
+        if (Object.prototype.hasOwnProperty.call(node, 'x-mcp-file')) {
+            found.push(path);
+        }
+        if (node.properties && typeof node.properties === 'object') {
+            for (const [k, v] of Object.entries(node.properties)) {
+                walk(v, path ? `${path}.${k}` : k);
+            }
+        }
+        if (node.items) {
+            walk(node.items, `${path}[]`);
+        }
+    }
+    walk(inputSchema, '');
+    return found;
+}
+
+/** Pull a tool definition from a `tools/list` result by name. */
+function findTool(toolsListResult: any, name: string): any {
+    const tool = (toolsListResult.tools || []).find((t: any) => t.name === name);
+    if (!tool) throw new Error(`tool ${name} not found in tools/list result`);
+    return tool;
+}
+
+/** Pull the first text content block from a `tools/call` result. */
+function extractText(callResult: any): string {
+    const content = (callResult.content || []) as Array<{ type?: string; text?: string }>;
+    return content.map((c) => (c.type === 'text' ? c.text || '' : '')).join('\n');
+}
+
+// =============================================================================
+// Scenarios
+// =============================================================================
+
+describe('SEP-2356 File Inputs', () => {
+
+    // -------------------------------------------------------------------------
+    // Capability-gated schema visibility
+    // -------------------------------------------------------------------------
+
+    // verifies: when the client declares `fileInputs`, the server advertises
+    // `x-mcp-file` on every file-input property in tools/list — including the
+    // array-items shape used by `analyze_documents`.
+    test('file-inputs-01: client with fileInputs cap sees x-mcp-file', async () => {
+        const sid = await initSession({ fileInputs: true });
+        const list = (await rawCall(sid, 'tools/list')).result;
+
+        const upload = findTool(list, 'upload_image');
+        const uploadPaths = findFileInputPaths(upload.inputSchema);
+        assert.deepEqual(uploadPaths, ['image'],
+            `upload_image: expected x-mcp-file on .image, found at ${JSON.stringify(uploadPaths)}`);
+
+        const analyze = findTool(list, 'analyze_documents');
+        const analyzePaths = findFileInputPaths(analyze.inputSchema);
+        assert.deepEqual(analyzePaths, ['documents[]'],
+            `analyze_documents: expected x-mcp-file on .documents[], found at ${JSON.stringify(analyzePaths)}`);
+
+        const proc = findTool(list, 'process_any_file');
+        const procPaths = findFileInputPaths(proc.inputSchema);
+        assert.deepEqual(procPaths, ['file'],
+            `process_any_file: expected x-mcp-file on .file, found at ${JSON.stringify(procPaths)}`);
+    });
+
+    // verifies: when the client does NOT declare `fileInputs`, the server
+    // strips the `x-mcp-file` keyword from every tool schema BUT keeps the
+    // properties themselves visible as plain string/uri so legacy clients
+    // can still call the tools (rendering a text input as fallback).
+    // Awaiting #362 (SEP-2356 A4 — capability gating).
+    test('file-inputs-02: client without cap does NOT see x-mcp-file (but tools stay visible)', async () => {
+        const sid = await initSession({ fileInputs: false });
+        const list = (await rawCall(sid, 'tools/list')).result;
+
+        for (const toolName of ['upload_image', 'analyze_documents', 'process_any_file']) {
+            const tool = findTool(list, toolName);
+            const paths = findFileInputPaths(tool.inputSchema);
+            assert.deepEqual(paths, [],
+                `${toolName}: x-mcp-file MUST be stripped for clients without fileInputs cap; found at ${JSON.stringify(paths)}`);
+
+            // Property still visible — interpretation locked: strip keyword,
+            // not the whole property. Verify the underlying string/uri schema
+            // remains so the tool stays callable.
+            const props = tool.inputSchema.properties || {};
+            const required = tool.inputSchema.required || [];
+            for (const name of required) {
+                assert.ok(props[name] != null,
+                    `${toolName}: required property "${name}" was hidden along with x-mcp-file (interpretation: keyword strip only)`);
+            }
+        }
+    });
+
+    // -------------------------------------------------------------------------
+    // Wire-format round-trip
+    // -------------------------------------------------------------------------
+
+    // verifies: a valid file upload round-trips end-to-end. Server must
+    // decode the data URI, recover the bytes / media type / filename, and
+    // include them in the tool result. Uses the smallest valid PNG so the
+    // test runs fast even on slow CI.
+    test('file-inputs-03: valid file upload succeeds with metadata round-trip', async () => {
+        const sid = await initSession({ fileInputs: true });
+
+        // 1×1 transparent PNG (67 bytes) — same fixture shape used by
+        // examples/file-inputs/testdata/.
+        const png = Buffer.from([
+            0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+            0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+            0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+            0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+            0x89, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x44, 0x41,
+            0x54, 0x78, 0x9c, 0x63, 0x00, 0x01, 0x00, 0x00,
+            0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00,
+            0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae,
+            0x42, 0x60, 0x82,
+        ]);
+        const uri = makeDataURI('image/png', 'pixel.png', png);
+
+        const out = (await rawCall(sid, 'tools/call', {
+            name: 'upload_image',
+            arguments: { image: uri, caption: 'conformance fixture' },
+        })).result;
+
+        assert.equal(out.isError, undefined,
+            `tool returned isError; result=${JSON.stringify(out)}`);
+        const text = extractText(out);
+        assert.match(text, /pixel\.png/, 'response must echo the decoded filename');
+        assert.match(text, /image\/png/, 'response must echo the decoded media type');
+        assert.match(text, /\b67\b/, 'response must echo the decoded byte count (67 bytes)');
+    });
+
+    // verifies: when the descriptor declares maxSize=5 MiB and the client
+    // sends a payload above that, the server returns JSON-RPC -32602 with
+    // structured data: {reason, actualSize, maxSize}. Spec contract locked
+    // here so error data shape stays consistent across reference impls.
+    // Awaiting #361 (SEP-2356 A3 — server validation).
+    test('file-inputs-04: oversized file rejects with -32602 + reason file_too_large', async () => {
+        const sid = await initSession({ fileInputs: true });
+
+        const maxSize = 5 * 1024 * 1024; // upload_image's declared maxSize
+        const oversized = Buffer.alloc(maxSize + 1024); // 5 MiB + 1 KiB
+        const uri = makeDataURI('image/png', 'too-big.png', oversized);
+
+        const out = await rawCall(sid, 'tools/call', {
+            name: 'upload_image',
+            arguments: { image: uri },
+        });
+
+        assert.ok(out.error,
+            `expected JSON-RPC error; got result=${JSON.stringify(out.result)}`);
+        assert.equal(out.error!.code, -32602,
+            `error.code = ${out.error!.code}, want -32602`);
+        const data = out.error!.data || {};
+        assert.equal(data.reason, 'file_too_large',
+            `error.data.reason = ${JSON.stringify(data.reason)}, want "file_too_large"`);
+        assert.equal(typeof data.actualSize, 'number',
+            'error.data.actualSize MUST be a number');
+        assert.ok(data.actualSize > maxSize,
+            `actualSize ${data.actualSize} should exceed maxSize ${maxSize}`);
+        assert.equal(data.maxSize, maxSize,
+            `error.data.maxSize = ${data.maxSize}, want ${maxSize}`);
+    });
+
+    // verifies: when the descriptor declares accept=["image/*"] and the
+    // client sends a text/plain payload, the server returns -32602 with
+    // data: {reason: "file_type_not_accepted", mediaType, accept}.
+    // Awaiting #361 (SEP-2356 A3 — server validation).
+    test('file-inputs-05: wrong MIME rejects with -32602 + reason file_type_not_accepted', async () => {
+        const sid = await initSession({ fileInputs: true });
+
+        const uri = makeDataURI('text/plain', 'not-an-image.txt', 'hello world');
+        const out = await rawCall(sid, 'tools/call', {
+            name: 'upload_image',
+            arguments: { image: uri },
+        });
+
+        assert.ok(out.error,
+            `expected JSON-RPC error; got result=${JSON.stringify(out.result)}`);
+        assert.equal(out.error!.code, -32602,
+            `error.code = ${out.error!.code}, want -32602`);
+        const data = out.error!.data || {};
+        assert.equal(data.reason, 'file_type_not_accepted',
+            `error.data.reason = ${JSON.stringify(data.reason)}, want "file_type_not_accepted"`);
+        assert.equal(data.mediaType, 'text/plain',
+            `error.data.mediaType = ${JSON.stringify(data.mediaType)}, want "text/plain"`);
+        assert.ok(Array.isArray(data.accept),
+            'error.data.accept MUST be an array of patterns the server accepts');
+        assert.ok(data.accept.includes('image/*'),
+            `error.data.accept = ${JSON.stringify(data.accept)} should include "image/*"`);
+    });
+
+    // verifies: array-of-files input (analyze_documents.documents) accepts
+    // multiple data URIs in one call and the server decodes each. Confirms
+    // FileInputArrayProperty's `items.x-mcp-file` shape isn't a special case
+    // that gets dropped on the wire.
+    test('file-inputs-06: multi-file array input handles multiple data URIs', async () => {
+        const sid = await initSession({ fileInputs: true });
+
+        const pdf = (label: string) => Buffer.from(`%PDF-1.4\n% ${label}\n%%EOF\n`, 'utf8');
+        const docs = [
+            makeDataURI('application/pdf', 'contract.pdf', pdf('contract')),
+            makeDataURI('application/pdf', 'appendix.pdf', pdf('appendix')),
+        ];
+
+        const out = (await rawCall(sid, 'tools/call', {
+            name: 'analyze_documents',
+            arguments: { documents: docs },
+        })).result;
+
+        assert.equal(out.isError, undefined,
+            `tool returned isError; result=${JSON.stringify(out)}`);
+        const text = extractText(out);
+        assert.match(text, /contract\.pdf/, 'response must echo first document filename');
+        assert.match(text, /appendix\.pdf/, 'response must echo second document filename');
+        assert.match(text, /application\/pdf/, 'response must echo PDF media type');
+    });
+
+    // verifies: filenames with characters outside the unreserved set
+    // (parens, spaces, quotes) round-trip end-to-end. Catches encoders that
+    // diverge from `url.PathEscape` (e.g., a JS implementation using only
+    // `encodeURIComponent`, which leaves parens unescaped).
+    test('file-inputs-07: filename with special chars round-trips via percent-encoding', async () => {
+        const sid = await initSession({ fileInputs: true });
+
+        const filename = "my photo (1) ' .png";
+        // Confirm our local encoder produced the expected wire form before
+        // we send it — protects the test itself against a regression in
+        // pctEncodePathLike.
+        const uri = makeDataURI('image/png', filename, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+        assert.match(uri, /;name=my%20photo%20%281%29%20%27%20\.png;/,
+            `local encoder output not in expected shape: ${uri}`);
+
+        const out = (await rawCall(sid, 'tools/call', {
+            name: 'process_any_file',
+            arguments: { file: uri },
+        })).result;
+
+        assert.equal(out.isError, undefined,
+            `tool returned isError; result=${JSON.stringify(out)}`);
+        const text = extractText(out);
+        // Server-side `core.DecodeDataURI` reverses the percent-encoding,
+        // so the human-readable filename must reappear verbatim.
+        assert.ok(text.includes(filename),
+            `response must contain decoded filename ${JSON.stringify(filename)}; got: ${JSON.stringify(text)}`);
+    });
+});

--- a/core/file_validation.go
+++ b/core/file_validation.go
@@ -1,0 +1,185 @@
+package core
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// SEP-2356 file-input validation — runs against a data URI argument and the
+// server-declared FileInputDescriptor. Returns one of the typed errors
+// below on failure; nil on success or when desc is nil (no constraint).
+//
+// The error types carry structured fields the dispatcher packs into the
+// JSON-RPC `data` object on the wire — the on-wire shape is frozen by
+// `conformance/file-inputs/scenarios.test.ts` (the cross-impl contract).
+
+// Sentinel errors for callers that just want to test category. The typed
+// errors below carry structured fields; these constants are useful for
+// `errors.Is` checks.
+var (
+	ErrFileTooLarge        = errors.New("file too large")
+	ErrFileTypeNotAccepted = errors.New("file type not accepted")
+)
+
+// File-input error reason strings. Pinned by the conformance suite as
+// stable machine-readable identifiers — clients can branch on these
+// without parsing the human-readable message. JS-side bridge errors
+// (ext/ui/assets/file-picker.ts) use the same constants.
+const (
+	FileInputReasonTooLarge       = "file_too_large"
+	FileInputReasonTypeNotAccepted = "file_type_not_accepted"
+)
+
+// FileTooLargeError reports that a decoded payload exceeds the
+// descriptor's MaxSize. The dispatcher serializes Data() as the JSON-RPC
+// `error.data` object on the wire.
+type FileTooLargeError struct {
+	// Field is the JSON-Schema property path of the offending arg (e.g.
+	// "image" or "documents[0]"). Optional — empty when the validator
+	// doesn't have path context.
+	Field      string
+	ActualSize int
+	MaxSize    int
+}
+
+func (e *FileTooLargeError) Error() string {
+	return fmt.Sprintf("file size %d exceeds maxSize %d", e.ActualSize, e.MaxSize)
+}
+
+// Unwrap lets errors.Is(err, ErrFileTooLarge) succeed.
+func (e *FileTooLargeError) Unwrap() error { return ErrFileTooLarge }
+
+// FileTooLargeData is the wire-shape of FileTooLargeError. Frozen by the
+// conformance suite: `{reason, actualSize, maxSize}`.
+type FileTooLargeData struct {
+	Reason     string `json:"reason"`     // always "file_too_large"
+	Field      string `json:"field,omitempty"`
+	ActualSize int    `json:"actualSize"`
+	MaxSize    int    `json:"maxSize"`
+}
+
+// Data returns the structured wire payload for this error.
+func (e *FileTooLargeError) Data() FileTooLargeData {
+	return FileTooLargeData{
+		Reason:     FileInputReasonTooLarge,
+		Field:      e.Field,
+		ActualSize: e.ActualSize,
+		MaxSize:    e.MaxSize,
+	}
+}
+
+// FileTypeNotAcceptedError reports that a decoded payload's media type or
+// filename does not match any pattern in the descriptor's Accept list.
+type FileTypeNotAcceptedError struct {
+	Field     string
+	MediaType string
+	Filename  string
+	Accept    []string
+}
+
+func (e *FileTypeNotAcceptedError) Error() string {
+	return fmt.Sprintf("file type %q not in accept list %v", e.MediaType, e.Accept)
+}
+
+// Unwrap lets errors.Is(err, ErrFileTypeNotAccepted) succeed.
+func (e *FileTypeNotAcceptedError) Unwrap() error { return ErrFileTypeNotAccepted }
+
+// FileTypeNotAcceptedData is the wire-shape of FileTypeNotAcceptedError.
+// Frozen by the conformance suite: `{reason, mediaType, accept}`.
+type FileTypeNotAcceptedData struct {
+	Reason    string   `json:"reason"`     // always "file_type_not_accepted"
+	Field     string   `json:"field,omitempty"`
+	MediaType string   `json:"mediaType"`
+	Filename  string   `json:"filename,omitempty"`
+	Accept    []string `json:"accept"`
+}
+
+// Data returns the structured wire payload for this error.
+func (e *FileTypeNotAcceptedError) Data() FileTypeNotAcceptedData {
+	accept := e.Accept
+	if accept == nil {
+		// JSON-marshal nil to [] not null — the conformance suite asserts
+		// `data.accept` is an array.
+		accept = []string{}
+	}
+	return FileTypeNotAcceptedData{
+		Reason:    FileInputReasonTypeNotAccepted,
+		Field:     e.Field,
+		MediaType: e.MediaType,
+		Filename:  e.Filename,
+		Accept:    accept,
+	}
+}
+
+// FileMatchesAccept implements the SEP-2356 accept-pattern matcher.
+// Pattern rules — same set as the JS-side bridge matcher in
+// ext/ui/assets/file-picker.ts so both sides agree on what passes:
+//
+//   - "image/png"  — exact MIME match (case-sensitive on type, as RFC 6838)
+//   - "image/*"    — wildcard subtype match (prefix on `type/`)
+//   - ".pdf"       — extension match against filename suffix (case-insensitive)
+//
+// Empty / nil accept means anything matches.
+func FileMatchesAccept(mediaType, filename string, accept []string) bool {
+	if len(accept) == 0 {
+		return true
+	}
+	lowerName := strings.ToLower(filename)
+	for _, pattern := range accept {
+		if strings.HasPrefix(pattern, ".") {
+			if strings.HasSuffix(lowerName, strings.ToLower(pattern)) {
+				return true
+			}
+			continue
+		}
+		slash := strings.Index(pattern, "/")
+		if slash < 0 {
+			continue
+		}
+		subtype := pattern[slash+1:]
+		if subtype == "*" {
+			if strings.HasPrefix(mediaType, pattern[:slash+1]) {
+				return true
+			}
+		} else if mediaType == pattern {
+			return true
+		}
+	}
+	return false
+}
+
+// ValidateFileInput decodes a data URI argument and verifies it against
+// a server-declared FileInputDescriptor.
+//
+//   - Returns nil on success, or when desc is nil (no constraint).
+//   - Returns *FileTooLargeError when MaxSize is set and exceeded.
+//   - Returns *FileTypeNotAcceptedError when Accept is set and unmet.
+//   - Returns the underlying decoder error when uri is malformed.
+//
+// The returned typed errors carry structured fields that the dispatcher
+// packs into the JSON-RPC `data` object — see the conformance suite for
+// the frozen wire shape.
+func ValidateFileInput(uri string, desc *FileInputDescriptor) error {
+	if desc == nil {
+		return nil
+	}
+	data, mediaType, filename, err := DecodeDataURI(uri)
+	if err != nil {
+		return err
+	}
+	if desc.MaxSize != nil && len(data) > *desc.MaxSize {
+		return &FileTooLargeError{
+			ActualSize: len(data),
+			MaxSize:    *desc.MaxSize,
+		}
+	}
+	if !FileMatchesAccept(mediaType, filename, desc.Accept) {
+		return &FileTypeNotAcceptedError{
+			MediaType: mediaType,
+			Filename:  filename,
+			Accept:    desc.Accept,
+		}
+	}
+	return nil
+}

--- a/core/file_validation_test.go
+++ b/core/file_validation_test.go
@@ -1,0 +1,198 @@
+package core
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+// verifies: empty / nil accept matches anything (the unconstrained
+// `process_any_file`-style descriptor).
+func TestFileMatchesAccept_EmptyAccepts(t *testing.T) {
+	if !FileMatchesAccept("image/png", "x.png", nil) {
+		t.Error("nil accept should match")
+	}
+	if !FileMatchesAccept("image/png", "x.png", []string{}) {
+		t.Error("empty accept should match")
+	}
+}
+
+// verifies: exact MIME pattern matches identical type/subtype, rejects
+// anything else.
+func TestFileMatchesAccept_ExactMIME(t *testing.T) {
+	accept := []string{"image/png"}
+	if !FileMatchesAccept("image/png", "x.png", accept) {
+		t.Error("exact match should succeed")
+	}
+	if FileMatchesAccept("image/jpeg", "x.jpg", accept) {
+		t.Error("non-matching MIME should be rejected")
+	}
+}
+
+// verifies: wildcard subtype ("image/*") matches every image/... and
+// rejects everything outside that prefix.
+func TestFileMatchesAccept_WildcardSubtype(t *testing.T) {
+	accept := []string{"image/*"}
+	if !FileMatchesAccept("image/png", "x.png", accept) {
+		t.Error("image/png should match image/*")
+	}
+	if !FileMatchesAccept("image/jpeg", "x.jpg", accept) {
+		t.Error("image/jpeg should match image/*")
+	}
+	if FileMatchesAccept("application/pdf", "x.pdf", accept) {
+		t.Error("application/pdf must not match image/*")
+	}
+}
+
+// verifies: extension hint matches by filename suffix, case-insensitive.
+// Server-side matcher must agree with the JS-side bridge matcher.
+func TestFileMatchesAccept_ExtensionHint(t *testing.T) {
+	accept := []string{".pdf"}
+	if !FileMatchesAccept("application/pdf", "report.pdf", accept) {
+		t.Error("lowercase extension should match")
+	}
+	if !FileMatchesAccept("application/pdf", "REPORT.PDF", accept) {
+		t.Error("uppercase filename should match (case-insensitive)")
+	}
+	if FileMatchesAccept("application/pdf", "report.txt", accept) {
+		t.Error("non-matching extension should be rejected")
+	}
+}
+
+// verifies: when accept includes both extension and MIME forms, either
+// shape matches (the analyze_documents demo tool uses both).
+func TestFileMatchesAccept_MixedPatterns(t *testing.T) {
+	accept := []string{"application/pdf", ".pdf"}
+	if !FileMatchesAccept("application/pdf", "x.pdf", accept) {
+		t.Error("MIME form should match")
+	}
+	// File without proper MIME but with .pdf extension still matches via the
+	// extension fallback.
+	if !FileMatchesAccept("application/octet-stream", "report.pdf", accept) {
+		t.Error("extension fallback should match when MIME is generic")
+	}
+}
+
+// verifies: nil descriptor short-circuits — unconstrained tools accept
+// every file without decoding.
+func TestValidateFileInput_NilDescriptor(t *testing.T) {
+	if err := ValidateFileInput("data:text/plain;base64,aGVsbG8=", nil); err != nil {
+		t.Errorf("nil descriptor must not error: %v", err)
+	}
+}
+
+// verifies: a valid file passes both size and MIME checks.
+func TestValidateFileInput_HappyPath(t *testing.T) {
+	max := 1024
+	desc := &FileInputDescriptor{
+		Accept:  []string{"text/plain"},
+		MaxSize: &max,
+	}
+	uri := EncodeDataURI([]byte("hello"), "text/plain", "greeting.txt")
+	if err := ValidateFileInput(uri, desc); err != nil {
+		t.Errorf("happy-path validation failed: %v", err)
+	}
+}
+
+// verifies: oversized payload returns *FileTooLargeError with the actual
+// size + declared limit, and that errors.Is(err, ErrFileTooLarge) holds
+// so callers can branch on the sentinel.
+func TestValidateFileInput_OversizedReturnsTypedError(t *testing.T) {
+	max := 4
+	desc := &FileInputDescriptor{MaxSize: &max}
+	uri := EncodeDataURI([]byte("hello world"), "text/plain", "x.txt")
+	err := ValidateFileInput(uri, desc)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, ErrFileTooLarge) {
+		t.Errorf("errors.Is(err, ErrFileTooLarge) = false; err = %T %v", err, err)
+	}
+	tooBig, ok := err.(*FileTooLargeError)
+	if !ok {
+		t.Fatalf("err type = %T, want *FileTooLargeError", err)
+	}
+	if tooBig.ActualSize != 11 || tooBig.MaxSize != 4 {
+		t.Errorf("actual = %d / max = %d, want 11 / 4", tooBig.ActualSize, tooBig.MaxSize)
+	}
+}
+
+// verifies: wrong MIME returns *FileTypeNotAcceptedError carrying the
+// observed media type + the accept list (so clients can render a useful
+// error message).
+func TestValidateFileInput_WrongMIMEReturnsTypedError(t *testing.T) {
+	desc := &FileInputDescriptor{Accept: []string{"image/*"}}
+	uri := EncodeDataURI([]byte("hello"), "text/plain", "x.txt")
+	err := ValidateFileInput(uri, desc)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, ErrFileTypeNotAccepted) {
+		t.Errorf("errors.Is(err, ErrFileTypeNotAccepted) = false; err = %T %v", err, err)
+	}
+	mismatch, ok := err.(*FileTypeNotAcceptedError)
+	if !ok {
+		t.Fatalf("err type = %T, want *FileTypeNotAcceptedError", err)
+	}
+	if mismatch.MediaType != "text/plain" {
+		t.Errorf("MediaType = %q, want text/plain", mismatch.MediaType)
+	}
+	if len(mismatch.Accept) != 1 || mismatch.Accept[0] != "image/*" {
+		t.Errorf("Accept = %v, want [image/*]", mismatch.Accept)
+	}
+}
+
+// verifies: extension-fallback works through ValidateFileInput, not just
+// FileMatchesAccept directly. Sends a generic-MIME PDF (matches via
+// .pdf extension) — guards against a regression where the orchestrator
+// only checks MIME and ignores the filename.
+func TestValidateFileInput_ExtensionFallback(t *testing.T) {
+	desc := &FileInputDescriptor{Accept: []string{"application/pdf", ".pdf"}}
+	uri := EncodeDataURI([]byte("%PDF-1.4\n"), "application/octet-stream", "doc.pdf")
+	if err := ValidateFileInput(uri, desc); err != nil {
+		t.Errorf("extension fallback should accept: %v", err)
+	}
+}
+
+// verifies: malformed data URIs surface the underlying decoder error
+// rather than a generic validation error. The dispatcher will report
+// these as -32602 too, but with the decoder's reason string so debug
+// signal stays high.
+func TestValidateFileInput_MalformedURI(t *testing.T) {
+	desc := &FileInputDescriptor{}
+	if err := ValidateFileInput("not-a-data-uri", desc); err == nil {
+		t.Error("malformed URI should error")
+	}
+	if err := ValidateFileInput("data:text/plain,not-base64-form", desc); err == nil {
+		t.Error("non-base64 data URI should error")
+	}
+}
+
+// verifies: typed-error Data() methods produce JSON matching the wire
+// shape locked by the conformance suite (`{reason, actualSize, maxSize}`
+// and `{reason, mediaType, accept}`). If this test fails, the
+// `conformance/file-inputs/` scenarios will too — they assert the same
+// keys on the JSON-RPC error.data object.
+func TestFileInputErrorData_WireShape(t *testing.T) {
+	tooBig := (&FileTooLargeError{ActualSize: 100, MaxSize: 64}).Data()
+	raw, _ := json.Marshal(tooBig)
+	if string(raw) != `{"reason":"file_too_large","actualSize":100,"maxSize":64}` {
+		t.Errorf("FileTooLargeData JSON = %s", raw)
+	}
+
+	wrongType := (&FileTypeNotAcceptedError{
+		MediaType: "text/plain",
+		Accept:    []string{"image/*"},
+	}).Data()
+	raw, _ = json.Marshal(wrongType)
+	if string(raw) != `{"reason":"file_type_not_accepted","mediaType":"text/plain","accept":["image/*"]}` {
+		t.Errorf("FileTypeNotAcceptedData JSON = %s", raw)
+	}
+
+	// nil Accept marshals to [] (not null) so JS-side type checks pass.
+	emptyAccept := (&FileTypeNotAcceptedError{MediaType: "x/y"}).Data()
+	raw, _ = json.Marshal(emptyAccept)
+	if string(raw) != `{"reason":"file_type_not_accepted","mediaType":"x/y","accept":[]}` {
+		t.Errorf("nil Accept JSON = %s, want [] not null", raw)
+	}
+}

--- a/docs/SEP_2356_FILE_INPUTS_PLAN.md
+++ b/docs/SEP_2356_FILE_INPUTS_PLAN.md
@@ -63,22 +63,18 @@ Two phases: core protocol support (Phase 1), then MCP Apps bridge integration
 - [x] `FileInputArrayProperty(desc) map[string]any` — array of file-input items.
 - [x] `ExtractFileInputDescriptor(prop) *FileInputDescriptor` — handles both typed-value (`FileInputDescriptor` struct) and JSON-unmarshalled (`map[string]any`) shapes; the JSON path is needed when round-tripping schemas through `tools/list`.
 
-### 1.4: Server-side validation
+### 1.4: Server-side validation ✅ shipped
 
-**Files:** `server/file_validation.go` (new)
+**Files:** `core/file_validation.go` (new), `core/file_validation_test.go` (new), `server/file_validation.go` (new), `server/file_validation_test.go` (new), `server/dispatch.go`, `server/server.go`, `examples/file-inputs/main.go`
 
-- [ ] `ValidateFileInput(value string, desc *FileInputDescriptor) error`
-  — parse as data URI, check MIME against `accept` patterns, check decoded
-  size against `maxSize`
-- [ ] MIME matching: exact match (`image/png`), wildcard subtype (`image/*`),
-  extension hint (`.pdf` — match against known MIME types)
-- [ ] Return `-32602` with reason `"file_too_large"` for oversized files
-- [ ] Return `-32602` with reason `"file_type_not_accepted"` for MIME mismatch
-- [ ] Optional: middleware that auto-validates file inputs before handler runs
-  (inspect inputSchema for `x-mcp-file` properties, validate matching args)
-
-**Test:** `server/file_validation_test.go` — valid file passes, oversized rejected,
-wrong MIME rejected, wildcard matching, extension matching.
+- [x] `core.ValidateFileInput(uri, desc)` — decode data URI, check size + MIME.
+- [x] `core.FileMatchesAccept` — exact / wildcard subtype / extension hint matcher (mirrors JS-side `fileMatchesAccept` in `ext/ui/assets/file-picker.ts` so both sides agree).
+- [x] Typed errors `core.FileTooLargeError` + `core.FileTypeNotAcceptedError` carrying structured `Data()` payloads. Sentinels `core.ErrFileTooLarge` + `core.ErrFileTypeNotAccepted` for `errors.Is`.
+- [x] Reason constants `core.FileInputReasonTooLarge` ("file_too_large") and `core.FileInputReasonTypeNotAccepted` ("file_type_not_accepted") align with bridge JS sentinel error names.
+- [x] `server.WithFileInputValidation()` Option enables the dispatcher hook. Disabled by default — handlers can opt in.
+- [x] Dispatcher walks the tool's InputSchema for `x-mcp-file` properties (single + array `items` shape), runs `core.ValidateFileInput` on every matching arg, returns `-32602` with structured `data: {reason, field, actualSize, maxSize}` (too-large) or `data: {reason, field, mediaType, accept}` (wrong MIME) on failure. Wire shape frozen by `conformance/file-inputs/scenarios.test.ts`.
+- [x] `examples/file-inputs/` opts into the validator — manual hand-rolled checks dropped.
+- [x] 11 new core unit tests + 5 new server unit tests + 2 conformance scenarios (`file-inputs-04` + `file-inputs-05`) flipped from red to green.
 
 ### 1.5: Server capability gating
 

--- a/examples/file-inputs/WALKTHROUGH.md
+++ b/examples/file-inputs/WALKTHROUGH.md
@@ -110,17 +110,77 @@ The server is started with `server.WithFileInputValidation()` (see `examples/fil
 
 The next three steps exercise all three failure modes the validator covers. They drive the server through the Go MCP client (`*client.Client`); the `client.RPCError` returned on rejection carries the same structured `data` field the wire emits. Each step prints `error.code`, `error.message`, and `error.data` so the rejection contract is visible in the demo output.
 
+Each step also attaches a copy-pasteable `bash` block (rendered via demokit `VerbatimLang` so the lines survive any terminal width) reproducing the same call on the wire — useful for validating from a non-Go SDK or sanity-checking the JSON shape directly.
+
 ### Step 7: upload_image rejects wrong MIME (text/plain into image/* slot)
 
 The descriptor declares `accept: ["image/*"]`. Sending a text/plain data URI hits the dispatcher's accept-pattern matcher (`core.FileMatchesAccept`), which fails before the handler runs. The error data carries `mediaType` (what we sent) and `accept` (what the server requires) so a client can render a useful message.
+
+#### Reproduce on the wire
+
+```bash
+# Mint a session
+SID=$(curl -s -X POST http://localhost:8080/mcp \
+  -H 'Content-Type: application/json' -H 'Accept: application/json' \
+  -d '{"jsonrpc":"2.0","id":"i","method":"initialize","params":{"protocolVersion":"2025-11-25","clientInfo":{"name":"x","version":"1"},"capabilities":{"fileInputs":{}}}}' \
+  -D - -o /dev/null | grep -i 'mcp-session-id' | awk '{print $2}' | tr -d '\r\n')
+curl -s -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" -H "Accept: application/json" -H "Mcp-Session-Id: $SID" \
+  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null
+
+# Send a text/plain payload into upload_image's image/* slot
+URI='data:text/plain;name=x.txt;base64,aGVsbG8='
+curl -s -X POST http://localhost:8080/mcp \
+  -H 'Content-Type: application/json' -H 'Accept: text/event-stream, application/json' -H "Mcp-Session-Id: $SID" \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"upload_image\",\"arguments\":{\"image\":\"$URI\"}}}"
+```
 
 ### Step 8: upload_image rejects oversized payload (6 MiB into 5 MiB cap)
 
 Same descriptor declares `maxSize: 5_242_880` (5 MiB). We synthesize a 6 MiB null-byte buffer, encode as `image/png`, and send it. The validator decodes the data URI, sees the size cap is exceeded, and short-circuits with structured size info.
 
+#### Reproduce on the wire
+
+```bash
+# Mint a session
+SID=$(curl -s -X POST http://localhost:8080/mcp \
+  -H 'Content-Type: application/json' -H 'Accept: application/json' \
+  -d '{"jsonrpc":"2.0","id":"i","method":"initialize","params":{"protocolVersion":"2025-11-25","clientInfo":{"name":"x","version":"1"},"capabilities":{"fileInputs":{}}}}' \
+  -D - -o /dev/null | grep -i 'mcp-session-id' | awk '{print $2}' | tr -d '\r\n')
+curl -s -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" -H "Accept: application/json" -H "Mcp-Session-Id: $SID" \
+  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null
+
+# Generate a 6 MiB image/png payload (Python keeps the curl short)
+BIG=$(python3 -c 'import base64; print("data:image/png;name=big.png;base64," + base64.b64encode(b"\x00" * (6*1024*1024)).decode())')
+curl -s -X POST http://localhost:8080/mcp \
+  -H 'Content-Type: application/json' -H 'Accept: text/event-stream, application/json' -H "Mcp-Session-Id: $SID" \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"upload_image\",\"arguments\":{\"image\":\"$BIG\"}}}"
+```
+
 ### Step 9: analyze_documents rejects per-element with field path tracking
 
 Send a 2-element array where element 0 is a valid PDF and element 1 is a text/plain payload. The dispatcher's array-items walker validates each element against `items.x-mcp-file` and surfaces the path of the offender — `data.field == "documents[1]"`. Useful so a client rendering rich error UX can highlight the specific input that failed instead of asking the user to re-pick everything.
+
+#### Reproduce on the wire
+
+```bash
+# Mint a session
+SID=$(curl -s -X POST http://localhost:8080/mcp \
+  -H 'Content-Type: application/json' -H 'Accept: application/json' \
+  -d '{"jsonrpc":"2.0","id":"i","method":"initialize","params":{"protocolVersion":"2025-11-25","clientInfo":{"name":"x","version":"1"},"capabilities":{"fileInputs":{}}}}' \
+  -D - -o /dev/null | grep -i 'mcp-session-id' | awk '{print $2}' | tr -d '\r\n')
+curl -s -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" -H "Accept: application/json" -H "Mcp-Session-Id: $SID" \
+  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null
+
+# Send 2 documents — index 0 valid PDF, index 1 wrong MIME
+GOOD='data:application/pdf;name=ok.pdf;base64,JVBERi0xLjQKJSVFT0YK'
+BAD='data:text/plain;name=bad.txt;base64,aGVsbG8='
+curl -s -X POST http://localhost:8080/mcp \
+  -H 'Content-Type: application/json' -H 'Accept: text/event-stream, application/json' -H "Mcp-Session-Id: $SID" \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"analyze_documents\",\"arguments\":{\"documents\":[\"$GOOD\",\"$BAD\"]}}}"
+```
 
 ### MCP Apps mode (Phase 2.1)
 

--- a/examples/file-inputs/WALKTHROUGH.md
+++ b/examples/file-inputs/WALKTHROUGH.md
@@ -10,6 +10,37 @@ Walks through SEP-2356, which lets servers declare file-input properties on tool
 - **analyze_documents — array-of-files input** — Demonstrates `core.FileInputArrayProperty` — the schema marks the `documents` array's *items* with `x-mcp-file`, so a host renders one picker per row. The walkthrough loads two embedded PDFs (`testdata/contract.pdf`, `testdata/appendix.pdf`) and sends both in one call.
 - **process_any_file — no accept/maxSize filter** — Empty `FileInputDescriptor{}` means "any file, any size." Useful for ad-hoc inspection. The handler still decodes via `core.DecodeDataURI`, which rejects malformed or non-base64 URIs. The walkthrough reads `testdata/README.txt` so the payload is a real on-disk file.
 - **Optional: send a file from disk** — Pass `--file <path>` on the demo command line to read an image from disk and upload it. Skipped silently when the flag isn't set so the walkthrough stays hermetic; demonstrates the on-disk → data URI path you'd use in a real client integration. Phase 1.6 will fold this into `client.PrepareFileArg(path, descriptor)`.
+- **upload_image rejects wrong MIME (text/plain into image/* slot)** — The descriptor declares `accept: ["image/*"]`. Sending a text/plain data URI hits the dispatcher's accept-pattern matcher (`core.FileMatchesAccept`), which fails before the handler runs. The error data carries `mediaType` (what we sent) and `accept` (what the server requires) so a client can render a useful message.
+
+Equivalent curl:
+
+```bash
+URI='data:text/plain;name=x.txt;base64,aGVsbG8='
+curl -s -X POST http://localhost:8080/mcp \
+  -H 'Content-Type: application/json' -H 'Accept: text/event-stream, application/json' -H "Mcp-Session-Id: $SID" \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"upload_image\",\"arguments\":{\"image\":\"$URI\"}}}"
+```
+- **upload_image rejects oversized payload (6 MiB into 5 MiB cap)** — Same descriptor declares `maxSize: 5_242_880` (5 MiB). We synthesize a 6 MiB null-byte buffer, encode as `image/png`, and send it. The validator decodes the data URI, sees the size cap is exceeded, and short-circuits with structured size info.
+
+Equivalent curl (generates the 6 MiB payload via Python):
+
+```bash
+BIG=$(python3 -c 'import base64; print("data:image/png;name=big.png;base64," + base64.b64encode(b"\x00" * (6*1024*1024)).decode())')
+curl -s -X POST http://localhost:8080/mcp \
+  -H 'Content-Type: application/json' -H 'Accept: text/event-stream, application/json' -H "Mcp-Session-Id: $SID" \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"upload_image\",\"arguments\":{\"image\":\"$BIG\"}}}"
+```
+- **analyze_documents rejects per-element with field path tracking** — Send a 2-element array where element 0 is a valid PDF and element 1 is a text/plain payload. The dispatcher's array-items walker validates each element against `items.x-mcp-file` and surfaces the path of the offender — `data.field == "documents[1]"`. Useful so a client rendering rich error UX can highlight the specific input that failed instead of asking the user to re-pick everything.
+
+Equivalent curl (note the array form in `arguments.documents`):
+
+```bash
+GOOD='data:application/pdf;name=ok.pdf;base64,JVBERi0xLjQKJSVFT0YK'
+BAD='data:text/plain;name=bad.txt;base64,aGVsbG8='
+curl -s -X POST http://localhost:8080/mcp \
+  -H 'Content-Type: application/json' -H 'Accept: text/event-stream, application/json' -H "Mcp-Session-Id: $SID" \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"analyze_documents\",\"arguments\":{\"documents\":[\"$GOOD\",\"$BAD\"]}}}"
+```
 
 ## Flow
 
@@ -41,6 +72,18 @@ sequenceDiagram
     Note over Host,Server: Step 6: Optional: send a file from disk
     Host->>Server: tools/call upload_image (from --file <path>)
     Server-->>Host: decoded metadata of the on-disk file
+
+    Note over Host,Server: Step 7: upload_image rejects wrong MIME (text/plain into image/* slot)
+    Host->>Server: tools/call upload_image { image: data:text/plain;… }
+    Server-->>Host: -32602 + data: {reason: file_type_not_accepted, mediaType, accept, field}
+
+    Note over Host,Server: Step 8: upload_image rejects oversized payload (6 MiB into 5 MiB cap)
+    Host->>Server: tools/call upload_image { image: data:image/png;… 6 MiB }
+    Server-->>Host: -32602 + data: {reason: file_too_large, actualSize, maxSize, field}
+
+    Note over Host,Server: Step 9: analyze_documents rejects per-element with field path tracking
+    Host->>Server: tools/call analyze_documents { documents: [valid pdf, text/plain] }
+    Server-->>Host: -32602 + data.field = "documents[1]"
 ```
 
 ## Steps
@@ -88,6 +131,67 @@ Empty `FileInputDescriptor{}` means "any file, any size." Useful for ad-hoc insp
 ### Step 6: Optional: send a file from disk
 
 Pass `--file <path>` on the demo command line to read an image from disk and upload it. Skipped silently when the flag isn't set so the walkthrough stays hermetic; demonstrates the on-disk → data URI path you'd use in a real client integration. Phase 1.6 will fold this into `client.PrepareFileArg(path, descriptor)`.
+
+### Validation — server rejects non-conforming uploads (Phase 1.4)
+
+The server is started with `server.WithFileInputValidation()` (see `examples/file-inputs/main.go`), so the dispatcher walks each tool's `inputSchema` for `x-mcp-file` properties and runs `core.ValidateFileInput` on every matching arg BEFORE the handler runs. Failures surface as JSON-RPC `-32602` with a structured `data` payload — that exact shape is the contract pinned by `conformance/file-inputs/scenarios.test.ts`.
+
+The next three steps exercise all three failure modes the validator covers. Each step also includes the equivalent raw `curl` so you can repro on the wire — the demo's helpers (`c.Call`, `client.RPCError`) are just convenience wrappers over the same JSON-RPC traffic.
+
+To repro any of these manually:
+
+```bash
+# Init a session first
+SID=$(curl -s -X POST http://localhost:8080/mcp \
+  -H 'Content-Type: application/json' -H 'Accept: application/json' \
+  -d '{"jsonrpc":"2.0","id":"i","method":"initialize","params":{"protocolVersion":"2025-11-25","clientInfo":{"name":"x","version":"1"},"capabilities":{"fileInputs":{}}}}' \
+  -D - -o /dev/null | grep -i 'mcp-session-id' | awk '{print $2}' | tr -d '\r\n')
+curl -s -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" -H "Accept: application/json" -H "Mcp-Session-Id: $SID" \
+  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null
+```
+
+With `$SID` exported, the per-test curls below land cleanly on the running server.
+
+### Step 7: upload_image rejects wrong MIME (text/plain into image/* slot)
+
+The descriptor declares `accept: ["image/*"]`. Sending a text/plain data URI hits the dispatcher's accept-pattern matcher (`core.FileMatchesAccept`), which fails before the handler runs. The error data carries `mediaType` (what we sent) and `accept` (what the server requires) so a client can render a useful message.
+
+Equivalent curl:
+
+```bash
+URI='data:text/plain;name=x.txt;base64,aGVsbG8='
+curl -s -X POST http://localhost:8080/mcp \
+  -H 'Content-Type: application/json' -H 'Accept: text/event-stream, application/json' -H "Mcp-Session-Id: $SID" \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"upload_image\",\"arguments\":{\"image\":\"$URI\"}}}"
+```
+
+### Step 8: upload_image rejects oversized payload (6 MiB into 5 MiB cap)
+
+Same descriptor declares `maxSize: 5_242_880` (5 MiB). We synthesize a 6 MiB null-byte buffer, encode as `image/png`, and send it. The validator decodes the data URI, sees the size cap is exceeded, and short-circuits with structured size info.
+
+Equivalent curl (generates the 6 MiB payload via Python):
+
+```bash
+BIG=$(python3 -c 'import base64; print("data:image/png;name=big.png;base64," + base64.b64encode(b"\x00" * (6*1024*1024)).decode())')
+curl -s -X POST http://localhost:8080/mcp \
+  -H 'Content-Type: application/json' -H 'Accept: text/event-stream, application/json' -H "Mcp-Session-Id: $SID" \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"upload_image\",\"arguments\":{\"image\":\"$BIG\"}}}"
+```
+
+### Step 9: analyze_documents rejects per-element with field path tracking
+
+Send a 2-element array where element 0 is a valid PDF and element 1 is a text/plain payload. The dispatcher's array-items walker validates each element against `items.x-mcp-file` and surfaces the path of the offender — `data.field == "documents[1]"`. Useful so a client rendering rich error UX can highlight the specific input that failed instead of asking the user to re-pick everything.
+
+Equivalent curl (note the array form in `arguments.documents`):
+
+```bash
+GOOD='data:application/pdf;name=ok.pdf;base64,JVBERi0xLjQKJSVFT0YK'
+BAD='data:text/plain;name=bad.txt;base64,aGVsbG8='
+curl -s -X POST http://localhost:8080/mcp \
+  -H 'Content-Type: application/json' -H 'Accept: text/event-stream, application/json' -H "Mcp-Session-Id: $SID" \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"analyze_documents\",\"arguments\":{\"documents\":[\"$GOOD\",\"$BAD\"]}}}"
+```
 
 ### MCP Apps mode (Phase 2.1)
 

--- a/examples/file-inputs/WALKTHROUGH.md
+++ b/examples/file-inputs/WALKTHROUGH.md
@@ -11,36 +11,8 @@ Walks through SEP-2356, which lets servers declare file-input properties on tool
 - **process_any_file — no accept/maxSize filter** — Empty `FileInputDescriptor{}` means "any file, any size." Useful for ad-hoc inspection. The handler still decodes via `core.DecodeDataURI`, which rejects malformed or non-base64 URIs. The walkthrough reads `testdata/README.txt` so the payload is a real on-disk file.
 - **Optional: send a file from disk** — Pass `--file <path>` on the demo command line to read an image from disk and upload it. Skipped silently when the flag isn't set so the walkthrough stays hermetic; demonstrates the on-disk → data URI path you'd use in a real client integration. Phase 1.6 will fold this into `client.PrepareFileArg(path, descriptor)`.
 - **upload_image rejects wrong MIME (text/plain into image/* slot)** — The descriptor declares `accept: ["image/*"]`. Sending a text/plain data URI hits the dispatcher's accept-pattern matcher (`core.FileMatchesAccept`), which fails before the handler runs. The error data carries `mediaType` (what we sent) and `accept` (what the server requires) so a client can render a useful message.
-
-Equivalent curl:
-
-```bash
-URI='data:text/plain;name=x.txt;base64,aGVsbG8='
-curl -s -X POST http://localhost:8080/mcp \
-  -H 'Content-Type: application/json' -H 'Accept: text/event-stream, application/json' -H "Mcp-Session-Id: $SID" \
-  -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"upload_image\",\"arguments\":{\"image\":\"$URI\"}}}"
-```
 - **upload_image rejects oversized payload (6 MiB into 5 MiB cap)** — Same descriptor declares `maxSize: 5_242_880` (5 MiB). We synthesize a 6 MiB null-byte buffer, encode as `image/png`, and send it. The validator decodes the data URI, sees the size cap is exceeded, and short-circuits with structured size info.
-
-Equivalent curl (generates the 6 MiB payload via Python):
-
-```bash
-BIG=$(python3 -c 'import base64; print("data:image/png;name=big.png;base64," + base64.b64encode(b"\x00" * (6*1024*1024)).decode())')
-curl -s -X POST http://localhost:8080/mcp \
-  -H 'Content-Type: application/json' -H 'Accept: text/event-stream, application/json' -H "Mcp-Session-Id: $SID" \
-  -d "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"upload_image\",\"arguments\":{\"image\":\"$BIG\"}}}"
-```
 - **analyze_documents rejects per-element with field path tracking** — Send a 2-element array where element 0 is a valid PDF and element 1 is a text/plain payload. The dispatcher's array-items walker validates each element against `items.x-mcp-file` and surfaces the path of the offender — `data.field == "documents[1]"`. Useful so a client rendering rich error UX can highlight the specific input that failed instead of asking the user to re-pick everything.
-
-Equivalent curl (note the array form in `arguments.documents`):
-
-```bash
-GOOD='data:application/pdf;name=ok.pdf;base64,JVBERi0xLjQKJSVFT0YK'
-BAD='data:text/plain;name=bad.txt;base64,aGVsbG8='
-curl -s -X POST http://localhost:8080/mcp \
-  -H 'Content-Type: application/json' -H 'Accept: text/event-stream, application/json' -H "Mcp-Session-Id: $SID" \
-  -d "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"analyze_documents\",\"arguments\":{\"documents\":[\"$GOOD\",\"$BAD\"]}}}"
-```
 
 ## Flow
 
@@ -136,62 +108,19 @@ Pass `--file <path>` on the demo command line to read an image from disk and upl
 
 The server is started with `server.WithFileInputValidation()` (see `examples/file-inputs/main.go`), so the dispatcher walks each tool's `inputSchema` for `x-mcp-file` properties and runs `core.ValidateFileInput` on every matching arg BEFORE the handler runs. Failures surface as JSON-RPC `-32602` with a structured `data` payload — that exact shape is the contract pinned by `conformance/file-inputs/scenarios.test.ts`.
 
-The next three steps exercise all three failure modes the validator covers. Each step also includes the equivalent raw `curl` so you can repro on the wire — the demo's helpers (`c.Call`, `client.RPCError`) are just convenience wrappers over the same JSON-RPC traffic.
-
-To repro any of these manually:
-
-```bash
-# Init a session first
-SID=$(curl -s -X POST http://localhost:8080/mcp \
-  -H 'Content-Type: application/json' -H 'Accept: application/json' \
-  -d '{"jsonrpc":"2.0","id":"i","method":"initialize","params":{"protocolVersion":"2025-11-25","clientInfo":{"name":"x","version":"1"},"capabilities":{"fileInputs":{}}}}' \
-  -D - -o /dev/null | grep -i 'mcp-session-id' | awk '{print $2}' | tr -d '\r\n')
-curl -s -X POST http://localhost:8080/mcp \
-  -H "Content-Type: application/json" -H "Accept: application/json" -H "Mcp-Session-Id: $SID" \
-  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null
-```
-
-With `$SID` exported, the per-test curls below land cleanly on the running server.
+The next three steps exercise all three failure modes the validator covers. They drive the server through the Go MCP client (`*client.Client`); the `client.RPCError` returned on rejection carries the same structured `data` field the wire emits. Each step prints `error.code`, `error.message`, and `error.data` so the rejection contract is visible in the demo output.
 
 ### Step 7: upload_image rejects wrong MIME (text/plain into image/* slot)
 
 The descriptor declares `accept: ["image/*"]`. Sending a text/plain data URI hits the dispatcher's accept-pattern matcher (`core.FileMatchesAccept`), which fails before the handler runs. The error data carries `mediaType` (what we sent) and `accept` (what the server requires) so a client can render a useful message.
 
-Equivalent curl:
-
-```bash
-URI='data:text/plain;name=x.txt;base64,aGVsbG8='
-curl -s -X POST http://localhost:8080/mcp \
-  -H 'Content-Type: application/json' -H 'Accept: text/event-stream, application/json' -H "Mcp-Session-Id: $SID" \
-  -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"upload_image\",\"arguments\":{\"image\":\"$URI\"}}}"
-```
-
 ### Step 8: upload_image rejects oversized payload (6 MiB into 5 MiB cap)
 
 Same descriptor declares `maxSize: 5_242_880` (5 MiB). We synthesize a 6 MiB null-byte buffer, encode as `image/png`, and send it. The validator decodes the data URI, sees the size cap is exceeded, and short-circuits with structured size info.
 
-Equivalent curl (generates the 6 MiB payload via Python):
-
-```bash
-BIG=$(python3 -c 'import base64; print("data:image/png;name=big.png;base64," + base64.b64encode(b"\x00" * (6*1024*1024)).decode())')
-curl -s -X POST http://localhost:8080/mcp \
-  -H 'Content-Type: application/json' -H 'Accept: text/event-stream, application/json' -H "Mcp-Session-Id: $SID" \
-  -d "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"upload_image\",\"arguments\":{\"image\":\"$BIG\"}}}"
-```
-
 ### Step 9: analyze_documents rejects per-element with field path tracking
 
 Send a 2-element array where element 0 is a valid PDF and element 1 is a text/plain payload. The dispatcher's array-items walker validates each element against `items.x-mcp-file` and surfaces the path of the offender — `data.field == "documents[1]"`. Useful so a client rendering rich error UX can highlight the specific input that failed instead of asking the user to re-pick everything.
-
-Equivalent curl (note the array form in `arguments.documents`):
-
-```bash
-GOOD='data:application/pdf;name=ok.pdf;base64,JVBERi0xLjQKJSVFT0YK'
-BAD='data:text/plain;name=bad.txt;base64,aGVsbG8='
-curl -s -X POST http://localhost:8080/mcp \
-  -H 'Content-Type: application/json' -H 'Accept: text/event-stream, application/json' -H "Mcp-Session-Id: $SID" \
-  -d "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"analyze_documents\",\"arguments\":{\"documents\":[\"$GOOD\",\"$BAD\"]}}}"
-```
 
 ### MCP Apps mode (Phase 2.1)
 

--- a/examples/file-inputs/go.mod
+++ b/examples/file-inputs/go.mod
@@ -8,7 +8,7 @@ replace (
 )
 
 require (
-	github.com/panyam/demokit v0.0.13
+	github.com/panyam/demokit v0.0.16
 	github.com/panyam/mcpkit v0.2.41
 	github.com/panyam/mcpkit/ext/ui v0.0.0
 )

--- a/examples/file-inputs/go.sum
+++ b/examples/file-inputs/go.sum
@@ -47,8 +47,10 @@ github.com/mattn/go-runewidth v0.0.23 h1:7ykA0T0jkPpzSvMS5i9uoNn2Xy3R383f9HDx3Ry
 github.com/mattn/go-runewidth v0.0.23/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
-github.com/panyam/demokit v0.0.13 h1:Auic7Xp7ODER8N3xDqKZByOovoB2UEX2RhtV8ZqNlc8=
-github.com/panyam/demokit v0.0.13/go.mod h1:JCOqPCWUBMrA95pTCyTIXrgN+X1xlSKR+QcG7Ve8AqY=
+github.com/panyam/demokit v0.0.15 h1:LMoiYtQCeZqqMtwVkX/4zLHWxFsuZxr1ZJPv3vtgJZg=
+github.com/panyam/demokit v0.0.15/go.mod h1:JCOqPCWUBMrA95pTCyTIXrgN+X1xlSKR+QcG7Ve8AqY=
+github.com/panyam/demokit v0.0.16 h1:BkD6h0/RTgxuWHQkDc6K3wHFLq9yB3VUnHr3mHx2xvE=
+github.com/panyam/demokit v0.0.16/go.mod h1:JCOqPCWUBMrA95pTCyTIXrgN+X1xlSKR+QcG7Ve8AqY=
 github.com/panyam/gocurrent v0.1.0 h1:AW8ctsSQHtoj8QXN55e9n+TYxtq+noF/ikPsRLiihiM=
 github.com/panyam/gocurrent v0.1.0/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.13 h1:V819IdZTEJ3rpu33ZqohC6O9ou7KOu6cxfigoYT12OQ=

--- a/examples/file-inputs/main.go
+++ b/examples/file-inputs/main.go
@@ -73,6 +73,10 @@ func serve() {
 		// MCP Apps extension powers the in-iframe file picker apps
 		// registered in apps.go (SEP-2356 Phase 2.1).
 		server.WithExtension(&ui.UIExtension{}),
+		// SEP-2356 Phase 1.4 — auto-validate file-typed args (size +
+		// MIME) against the descriptor declared in each tool's
+		// InputSchema. Failures surface as -32602 with structured data.
+		server.WithFileInputValidation(),
 	)
 
 	registerTools(srv, uploadDir)

--- a/examples/file-inputs/main.go
+++ b/examples/file-inputs/main.go
@@ -41,7 +41,11 @@ func main() {
 
 func serve() {
 	addr := flag.String("addr", ":8080", "listen address")
-	flag.CommandLine.Parse(filterFlags(os.Args[1:]))
+	flag.CommandLine.Parse(demokit.FilterArgs(os.Args[1:],
+		demokit.BoolFlag("--serve"),
+		demokit.ValueFlag("--url"),
+		demokit.ValueFlag("--file"),
+	))
 
 	// Same logger shape as examples/elicitation/main.go — tints request
 	// flow so a side-by-side `make serve` + `make demo` shows what the

--- a/examples/file-inputs/walkthrough.go
+++ b/examples/file-inputs/walkthrough.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -240,6 +241,76 @@ func runDemo() {
 			return nil
 		})
 
+	// -- SEP-2356 Phase 1.4 — server-side validation rejection demos --
+
+	demo.Section("Validation — server rejects non-conforming uploads (Phase 1.4)",
+		"The server is started with `server.WithFileInputValidation()` (see `examples/file-inputs/main.go`), so the dispatcher walks each tool's `inputSchema` for `x-mcp-file` properties and runs `core.ValidateFileInput` on every matching arg BEFORE the handler runs. Failures surface as JSON-RPC `-32602` with a structured `data` payload — that exact shape is the contract pinned by `conformance/file-inputs/scenarios.test.ts`.",
+		"",
+		"The next three steps exercise all three failure modes the validator covers. Each step also includes the equivalent raw `curl` so you can repro on the wire — the demo's helpers (`c.Call`, `client.RPCError`) are just convenience wrappers over the same JSON-RPC traffic.",
+		"",
+		"To repro any of these manually:",
+		"",
+		"```bash",
+		"# Init a session first",
+		"SID=$(curl -s -X POST http://localhost:8080/mcp \\",
+		"  -H 'Content-Type: application/json' -H 'Accept: application/json' \\",
+		"  -d '{\"jsonrpc\":\"2.0\",\"id\":\"i\",\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-11-25\",\"clientInfo\":{\"name\":\"x\",\"version\":\"1\"},\"capabilities\":{\"fileInputs\":{}}}}' \\",
+		"  -D - -o /dev/null | grep -i 'mcp-session-id' | awk '{print $2}' | tr -d '\\r\\n')",
+		"curl -s -X POST http://localhost:8080/mcp \\",
+		"  -H \"Content-Type: application/json\" -H \"Accept: application/json\" -H \"Mcp-Session-Id: $SID\" \\",
+		"  -d '{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}' >/dev/null",
+		"```",
+		"",
+		"With `$SID` exported, the per-test curls below land cleanly on the running server.",
+	)
+
+	demo.Step("upload_image rejects wrong MIME (text/plain into image/* slot)").
+		Arrow("Host", "Server", "tools/call upload_image { image: data:text/plain;… }").
+		DashedArrow("Server", "Host", "-32602 + data: {reason: file_type_not_accepted, mediaType, accept, field}").
+		Note("The descriptor declares `accept: [\"image/*\"]`. Sending a text/plain data URI hits the dispatcher's accept-pattern matcher (`core.FileMatchesAccept`), which fails before the handler runs. The error data carries `mediaType` (what we sent) and `accept` (what the server requires) so a client can render a useful message.\n\nEquivalent curl:\n\n```bash\nURI='data:text/plain;name=x.txt;base64,aGVsbG8='\ncurl -s -X POST http://localhost:8080/mcp \\\n  -H 'Content-Type: application/json' -H 'Accept: text/event-stream, application/json' -H \"Mcp-Session-Id: $SID\" \\\n  -d \"{\\\"jsonrpc\\\":\\\"2.0\\\",\\\"id\\\":1,\\\"method\\\":\\\"tools/call\\\",\\\"params\\\":{\\\"name\\\":\\\"upload_image\\\",\\\"arguments\\\":{\\\"image\\\":\\\"$URI\\\"}}}\"\n```").
+		Run(func(ctx demokit.StepContext) *demokit.StepResult {
+			uri := core.EncodeDataURI([]byte("hello"), "text/plain", "x.txt")
+			fmt.Printf("    sending: data URI with mediaType=text/plain (%d bytes total)\n", len(uri))
+			_, err := c.Call("tools/call", map[string]any{
+				"name":      "upload_image",
+				"arguments": map[string]any{"image": uri},
+			})
+			printRPCError(err, "file_type_not_accepted")
+			return nil
+		})
+
+	demo.Step("upload_image rejects oversized payload (6 MiB into 5 MiB cap)").
+		Arrow("Host", "Server", "tools/call upload_image { image: data:image/png;… 6 MiB }").
+		DashedArrow("Server", "Host", "-32602 + data: {reason: file_too_large, actualSize, maxSize, field}").
+		Note("Same descriptor declares `maxSize: 5_242_880` (5 MiB). We synthesize a 6 MiB null-byte buffer, encode as `image/png`, and send it. The validator decodes the data URI, sees the size cap is exceeded, and short-circuits with structured size info.\n\nEquivalent curl (generates the 6 MiB payload via Python):\n\n```bash\nBIG=$(python3 -c 'import base64; print(\"data:image/png;name=big.png;base64,\" + base64.b64encode(b\"\\x00\" * (6*1024*1024)).decode())')\ncurl -s -X POST http://localhost:8080/mcp \\\n  -H 'Content-Type: application/json' -H 'Accept: text/event-stream, application/json' -H \"Mcp-Session-Id: $SID\" \\\n  -d \"{\\\"jsonrpc\\\":\\\"2.0\\\",\\\"id\\\":2,\\\"method\\\":\\\"tools/call\\\",\\\"params\\\":{\\\"name\\\":\\\"upload_image\\\",\\\"arguments\\\":{\\\"image\\\":\\\"$BIG\\\"}}}\"\n```").
+		Run(func(ctx demokit.StepContext) *demokit.StepResult {
+			big := make([]byte, 6*1024*1024) // 6 MiB of zeros
+			uri := core.EncodeDataURI(big, "image/png", "big.png")
+			fmt.Printf("    sending: 6 MiB image/png payload (server cap is 5 MiB)\n")
+			_, err := c.Call("tools/call", map[string]any{
+				"name":      "upload_image",
+				"arguments": map[string]any{"image": uri},
+			})
+			printRPCError(err, "file_too_large")
+			return nil
+		})
+
+	demo.Step("analyze_documents rejects per-element with field path tracking").
+		Arrow("Host", "Server", "tools/call analyze_documents { documents: [valid pdf, text/plain] }").
+		DashedArrow("Server", "Host", "-32602 + data.field = \"documents[1]\"").
+		Note("Send a 2-element array where element 0 is a valid PDF and element 1 is a text/plain payload. The dispatcher's array-items walker validates each element against `items.x-mcp-file` and surfaces the path of the offender — `data.field == \"documents[1]\"`. Useful so a client rendering rich error UX can highlight the specific input that failed instead of asking the user to re-pick everything.\n\nEquivalent curl (note the array form in `arguments.documents`):\n\n```bash\nGOOD='data:application/pdf;name=ok.pdf;base64,JVBERi0xLjQKJSVFT0YK'\nBAD='data:text/plain;name=bad.txt;base64,aGVsbG8='\ncurl -s -X POST http://localhost:8080/mcp \\\n  -H 'Content-Type: application/json' -H 'Accept: text/event-stream, application/json' -H \"Mcp-Session-Id: $SID\" \\\n  -d \"{\\\"jsonrpc\\\":\\\"2.0\\\",\\\"id\\\":3,\\\"method\\\":\\\"tools/call\\\",\\\"params\\\":{\\\"name\\\":\\\"analyze_documents\\\",\\\"arguments\\\":{\\\"documents\\\":[\\\"$GOOD\\\",\\\"$BAD\\\"]}}}\"\n```").
+		Run(func(ctx demokit.StepContext) *demokit.StepResult {
+			good := core.EncodeDataURI([]byte("%PDF-1.4\n%%EOF\n"), "application/pdf", "ok.pdf")
+			bad := core.EncodeDataURI([]byte("hello"), "text/plain", "bad.txt")
+			fmt.Printf("    sending: 2 documents (index 0: valid PDF, index 1: text/plain)\n")
+			_, err := c.Call("tools/call", map[string]any{
+				"name":      "analyze_documents",
+				"arguments": map[string]any{"documents": []string{good, bad}},
+			})
+			printRPCError(err, "file_type_not_accepted")
+			return nil
+		})
+
 	demo.Section("MCP Apps mode (Phase 2.1)",
 		"This same server also registers two MCP App tools that drive the same handlers via in-iframe file pickers — the human-in-the-loop case file-uploads-wg flagged as a gap:",
 		"",
@@ -388,6 +459,37 @@ func previewHex(data []byte, n int) {
 	fmt.Printf("      │ %s\n", strings.TrimRight(b.String(), " "))
 	if len(data) > n {
 		fmt.Printf("      │ … (+%d bytes)\n", len(data)-n)
+	}
+}
+
+// printRPCError formats a `*client.RPCError` for the validation rejection
+// demo steps. wantReason is the SEP-2356 reason the demo expects to see —
+// printed alongside the actual reason so a regression in the wire shape
+// is visible in the demo output (and not just in the conformance suite).
+func printRPCError(err error, wantReason string) {
+	if err == nil {
+		fmt.Printf("    UNEXPECTED: server accepted the call; no validation triggered\n")
+		return
+	}
+	var rpc *client.RPCError
+	if !errors.As(err, &rpc) {
+		fmt.Printf("    transport error: %v\n", err)
+		return
+	}
+	fmt.Printf("    error.code:    %d\n", rpc.Code)
+	fmt.Printf("    error.message: %s\n", rpc.Message)
+	if rpc.Data == nil {
+		fmt.Printf("    error.data:    <none>\n")
+		return
+	}
+	pretty, _ := json.MarshalIndent(rpc.Data, "      ", "  ")
+	fmt.Printf("    error.data:    %s\n", string(pretty))
+	gotReason := ""
+	if m, ok := rpc.Data.(map[string]any); ok {
+		gotReason, _ = m["reason"].(string)
+	}
+	if wantReason != "" && gotReason != wantReason {
+		fmt.Printf("    WARN: data.reason = %q, expected %q\n", gotReason, wantReason)
 	}
 }
 

--- a/examples/file-inputs/walkthrough.go
+++ b/examples/file-inputs/walkthrough.go
@@ -243,31 +243,25 @@ func runDemo() {
 
 	// -- SEP-2356 Phase 1.4 — server-side validation rejection demos --
 
+	// TODO: once demokit ships the .Verbatim() / .Shell() block primitive
+	// (tracked separately in the demokit project), inline the equivalent
+	// curl recipes for each rejection step here so users can copy-paste
+	// them straight from the live TUI render. Today the lipgloss box wraps
+	// long lines and injects border characters mid-content, so the curl
+	// recipes were stripped to keep the demo's TUI render copy-paste-safe.
+	// The `Run` callbacks below already exercise every rejection path via
+	// the Go MCP client (`*client.Client` + `client.RPCError`) — no
+	// behavior loss, only the wire-level reproduction docs are deferred.
 	demo.Section("Validation — server rejects non-conforming uploads (Phase 1.4)",
 		"The server is started with `server.WithFileInputValidation()` (see `examples/file-inputs/main.go`), so the dispatcher walks each tool's `inputSchema` for `x-mcp-file` properties and runs `core.ValidateFileInput` on every matching arg BEFORE the handler runs. Failures surface as JSON-RPC `-32602` with a structured `data` payload — that exact shape is the contract pinned by `conformance/file-inputs/scenarios.test.ts`.",
 		"",
-		"The next three steps exercise all three failure modes the validator covers. Each step also includes the equivalent raw `curl` so you can repro on the wire — the demo's helpers (`c.Call`, `client.RPCError`) are just convenience wrappers over the same JSON-RPC traffic.",
-		"",
-		"To repro any of these manually:",
-		"",
-		"```bash",
-		"# Init a session first",
-		"SID=$(curl -s -X POST http://localhost:8080/mcp \\",
-		"  -H 'Content-Type: application/json' -H 'Accept: application/json' \\",
-		"  -d '{\"jsonrpc\":\"2.0\",\"id\":\"i\",\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-11-25\",\"clientInfo\":{\"name\":\"x\",\"version\":\"1\"},\"capabilities\":{\"fileInputs\":{}}}}' \\",
-		"  -D - -o /dev/null | grep -i 'mcp-session-id' | awk '{print $2}' | tr -d '\\r\\n')",
-		"curl -s -X POST http://localhost:8080/mcp \\",
-		"  -H \"Content-Type: application/json\" -H \"Accept: application/json\" -H \"Mcp-Session-Id: $SID\" \\",
-		"  -d '{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}' >/dev/null",
-		"```",
-		"",
-		"With `$SID` exported, the per-test curls below land cleanly on the running server.",
+		"The next three steps exercise all three failure modes the validator covers. They drive the server through the Go MCP client (`*client.Client`); the `client.RPCError` returned on rejection carries the same structured `data` field the wire emits. Each step prints `error.code`, `error.message`, and `error.data` so the rejection contract is visible in the demo output.",
 	)
 
 	demo.Step("upload_image rejects wrong MIME (text/plain into image/* slot)").
 		Arrow("Host", "Server", "tools/call upload_image { image: data:text/plain;… }").
 		DashedArrow("Server", "Host", "-32602 + data: {reason: file_type_not_accepted, mediaType, accept, field}").
-		Note("The descriptor declares `accept: [\"image/*\"]`. Sending a text/plain data URI hits the dispatcher's accept-pattern matcher (`core.FileMatchesAccept`), which fails before the handler runs. The error data carries `mediaType` (what we sent) and `accept` (what the server requires) so a client can render a useful message.\n\nEquivalent curl:\n\n```bash\nURI='data:text/plain;name=x.txt;base64,aGVsbG8='\ncurl -s -X POST http://localhost:8080/mcp \\\n  -H 'Content-Type: application/json' -H 'Accept: text/event-stream, application/json' -H \"Mcp-Session-Id: $SID\" \\\n  -d \"{\\\"jsonrpc\\\":\\\"2.0\\\",\\\"id\\\":1,\\\"method\\\":\\\"tools/call\\\",\\\"params\\\":{\\\"name\\\":\\\"upload_image\\\",\\\"arguments\\\":{\\\"image\\\":\\\"$URI\\\"}}}\"\n```").
+		Note("The descriptor declares `accept: [\"image/*\"]`. Sending a text/plain data URI hits the dispatcher's accept-pattern matcher (`core.FileMatchesAccept`), which fails before the handler runs. The error data carries `mediaType` (what we sent) and `accept` (what the server requires) so a client can render a useful message.").
 		Run(func(ctx demokit.StepContext) *demokit.StepResult {
 			uri := core.EncodeDataURI([]byte("hello"), "text/plain", "x.txt")
 			fmt.Printf("    sending: data URI with mediaType=text/plain (%d bytes total)\n", len(uri))
@@ -282,7 +276,7 @@ func runDemo() {
 	demo.Step("upload_image rejects oversized payload (6 MiB into 5 MiB cap)").
 		Arrow("Host", "Server", "tools/call upload_image { image: data:image/png;… 6 MiB }").
 		DashedArrow("Server", "Host", "-32602 + data: {reason: file_too_large, actualSize, maxSize, field}").
-		Note("Same descriptor declares `maxSize: 5_242_880` (5 MiB). We synthesize a 6 MiB null-byte buffer, encode as `image/png`, and send it. The validator decodes the data URI, sees the size cap is exceeded, and short-circuits with structured size info.\n\nEquivalent curl (generates the 6 MiB payload via Python):\n\n```bash\nBIG=$(python3 -c 'import base64; print(\"data:image/png;name=big.png;base64,\" + base64.b64encode(b\"\\x00\" * (6*1024*1024)).decode())')\ncurl -s -X POST http://localhost:8080/mcp \\\n  -H 'Content-Type: application/json' -H 'Accept: text/event-stream, application/json' -H \"Mcp-Session-Id: $SID\" \\\n  -d \"{\\\"jsonrpc\\\":\\\"2.0\\\",\\\"id\\\":2,\\\"method\\\":\\\"tools/call\\\",\\\"params\\\":{\\\"name\\\":\\\"upload_image\\\",\\\"arguments\\\":{\\\"image\\\":\\\"$BIG\\\"}}}\"\n```").
+		Note("Same descriptor declares `maxSize: 5_242_880` (5 MiB). We synthesize a 6 MiB null-byte buffer, encode as `image/png`, and send it. The validator decodes the data URI, sees the size cap is exceeded, and short-circuits with structured size info.").
 		Run(func(ctx demokit.StepContext) *demokit.StepResult {
 			big := make([]byte, 6*1024*1024) // 6 MiB of zeros
 			uri := core.EncodeDataURI(big, "image/png", "big.png")
@@ -298,7 +292,7 @@ func runDemo() {
 	demo.Step("analyze_documents rejects per-element with field path tracking").
 		Arrow("Host", "Server", "tools/call analyze_documents { documents: [valid pdf, text/plain] }").
 		DashedArrow("Server", "Host", "-32602 + data.field = \"documents[1]\"").
-		Note("Send a 2-element array where element 0 is a valid PDF and element 1 is a text/plain payload. The dispatcher's array-items walker validates each element against `items.x-mcp-file` and surfaces the path of the offender — `data.field == \"documents[1]\"`. Useful so a client rendering rich error UX can highlight the specific input that failed instead of asking the user to re-pick everything.\n\nEquivalent curl (note the array form in `arguments.documents`):\n\n```bash\nGOOD='data:application/pdf;name=ok.pdf;base64,JVBERi0xLjQKJSVFT0YK'\nBAD='data:text/plain;name=bad.txt;base64,aGVsbG8='\ncurl -s -X POST http://localhost:8080/mcp \\\n  -H 'Content-Type: application/json' -H 'Accept: text/event-stream, application/json' -H \"Mcp-Session-Id: $SID\" \\\n  -d \"{\\\"jsonrpc\\\":\\\"2.0\\\",\\\"id\\\":3,\\\"method\\\":\\\"tools/call\\\",\\\"params\\\":{\\\"name\\\":\\\"analyze_documents\\\",\\\"arguments\\\":{\\\"documents\\\":[\\\"$GOOD\\\",\\\"$BAD\\\"]}}}\"\n```").
+		Note("Send a 2-element array where element 0 is a valid PDF and element 1 is a text/plain payload. The dispatcher's array-items walker validates each element against `items.x-mcp-file` and surfaces the path of the offender — `data.field == \"documents[1]\"`. Useful so a client rendering rich error UX can highlight the specific input that failed instead of asking the user to re-pick everything.").
 		Run(func(ctx demokit.StepContext) *demokit.StepResult {
 			good := core.EncodeDataURI([]byte("%PDF-1.4\n%%EOF\n"), "application/pdf", "ok.pdf")
 			bad := core.EncodeDataURI([]byte("hello"), "text/plain", "bad.txt")

--- a/examples/file-inputs/walkthrough.go
+++ b/examples/file-inputs/walkthrough.go
@@ -33,32 +33,6 @@ var fixtureAppendixPDF []byte
 //go:embed testdata/README.txt
 var fixtureREADME []byte
 
-// filterFlags strips top-level flags so the inner flag.Parse on -addr is
-// happy when invoked from `make serve`. Same shape as list-ttl/walkthrough.go,
-// updated for demokit v0.0.13's `--doc <format>` (replaces the removed
-// `--readme` flag) and `--from <trace>` companion.
-func filterFlags(args []string) []string {
-	out := make([]string, 0, len(args))
-	skip := false
-	for _, a := range args {
-		if skip {
-			skip = false
-			continue
-		}
-		switch {
-		case a == "--serve", a == "--tui", a == "--non-interactive":
-			continue
-		case a == "--url", a == "--file", a == "--doc", a == "--from":
-			skip = true
-			continue
-		case strings.HasPrefix(a, "--doc="), strings.HasPrefix(a, "--from="),
-			strings.HasPrefix(a, "--url="), strings.HasPrefix(a, "--file="):
-			continue
-		}
-		out = append(out, a)
-	}
-	return out
-}
 
 func runDemo() {
 	serverURL := "http://localhost:8080"
@@ -243,25 +217,33 @@ func runDemo() {
 
 	// -- SEP-2356 Phase 1.4 — server-side validation rejection demos --
 
-	// TODO: once demokit ships the .Verbatim() / .Shell() block primitive
-	// (tracked separately in the demokit project), inline the equivalent
-	// curl recipes for each rejection step here so users can copy-paste
-	// them straight from the live TUI render. Today the lipgloss box wraps
-	// long lines and injects border characters mid-content, so the curl
-	// recipes were stripped to keep the demo's TUI render copy-paste-safe.
-	// The `Run` callbacks below already exercise every rejection path via
-	// the Go MCP client (`*client.Client` + `client.RPCError`) — no
-	// behavior loss, only the wire-level reproduction docs are deferred.
 	demo.Section("Validation — server rejects non-conforming uploads (Phase 1.4)",
 		"The server is started with `server.WithFileInputValidation()` (see `examples/file-inputs/main.go`), so the dispatcher walks each tool's `inputSchema` for `x-mcp-file` properties and runs `core.ValidateFileInput` on every matching arg BEFORE the handler runs. Failures surface as JSON-RPC `-32602` with a structured `data` payload — that exact shape is the contract pinned by `conformance/file-inputs/scenarios.test.ts`.",
 		"",
 		"The next three steps exercise all three failure modes the validator covers. They drive the server through the Go MCP client (`*client.Client`); the `client.RPCError` returned on rejection carries the same structured `data` field the wire emits. Each step prints `error.code`, `error.message`, and `error.data` so the rejection contract is visible in the demo output.",
+		"",
+		"Each step also attaches a copy-pasteable `bash` block (rendered via demokit `VerbatimLang` so the lines survive any terminal width) reproducing the same call on the wire — useful for validating from a non-Go SDK or sanity-checking the JSON shape directly.",
 	)
 
 	demo.Step("upload_image rejects wrong MIME (text/plain into image/* slot)").
 		Arrow("Host", "Server", "tools/call upload_image { image: data:text/plain;… }").
 		DashedArrow("Server", "Host", "-32602 + data: {reason: file_type_not_accepted, mediaType, accept, field}").
 		Note("The descriptor declares `accept: [\"image/*\"]`. Sending a text/plain data URI hits the dispatcher's accept-pattern matcher (`core.FileMatchesAccept`), which fails before the handler runs. The error data carries `mediaType` (what we sent) and `accept` (what the server requires) so a client can render a useful message.").
+		VerbatimLang("Reproduce on the wire", "bash", `# Mint a session
+SID=$(curl -s -X POST http://localhost:8080/mcp \
+  -H 'Content-Type: application/json' -H 'Accept: application/json' \
+  -d '{"jsonrpc":"2.0","id":"i","method":"initialize","params":{"protocolVersion":"2025-11-25","clientInfo":{"name":"x","version":"1"},"capabilities":{"fileInputs":{}}}}' \
+  -D - -o /dev/null | grep -i 'mcp-session-id' | awk '{print $2}' | tr -d '\r\n')
+curl -s -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" -H "Accept: application/json" -H "Mcp-Session-Id: $SID" \
+  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null
+
+# Send a text/plain payload into upload_image's image/* slot
+URI='data:text/plain;name=x.txt;base64,aGVsbG8='
+curl -s -X POST http://localhost:8080/mcp \
+  -H 'Content-Type: application/json' -H 'Accept: text/event-stream, application/json' -H "Mcp-Session-Id: $SID" \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"upload_image\",\"arguments\":{\"image\":\"$URI\"}}}"
+`).
 		Run(func(ctx demokit.StepContext) *demokit.StepResult {
 			uri := core.EncodeDataURI([]byte("hello"), "text/plain", "x.txt")
 			fmt.Printf("    sending: data URI with mediaType=text/plain (%d bytes total)\n", len(uri))
@@ -277,6 +259,21 @@ func runDemo() {
 		Arrow("Host", "Server", "tools/call upload_image { image: data:image/png;… 6 MiB }").
 		DashedArrow("Server", "Host", "-32602 + data: {reason: file_too_large, actualSize, maxSize, field}").
 		Note("Same descriptor declares `maxSize: 5_242_880` (5 MiB). We synthesize a 6 MiB null-byte buffer, encode as `image/png`, and send it. The validator decodes the data URI, sees the size cap is exceeded, and short-circuits with structured size info.").
+		VerbatimLang("Reproduce on the wire", "bash", `# Mint a session
+SID=$(curl -s -X POST http://localhost:8080/mcp \
+  -H 'Content-Type: application/json' -H 'Accept: application/json' \
+  -d '{"jsonrpc":"2.0","id":"i","method":"initialize","params":{"protocolVersion":"2025-11-25","clientInfo":{"name":"x","version":"1"},"capabilities":{"fileInputs":{}}}}' \
+  -D - -o /dev/null | grep -i 'mcp-session-id' | awk '{print $2}' | tr -d '\r\n')
+curl -s -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" -H "Accept: application/json" -H "Mcp-Session-Id: $SID" \
+  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null
+
+# Generate a 6 MiB image/png payload (Python keeps the curl short)
+BIG=$(python3 -c 'import base64; print("data:image/png;name=big.png;base64," + base64.b64encode(b"\x00" * (6*1024*1024)).decode())')
+curl -s -X POST http://localhost:8080/mcp \
+  -H 'Content-Type: application/json' -H 'Accept: text/event-stream, application/json' -H "Mcp-Session-Id: $SID" \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"upload_image\",\"arguments\":{\"image\":\"$BIG\"}}}"
+`).
 		Run(func(ctx demokit.StepContext) *demokit.StepResult {
 			big := make([]byte, 6*1024*1024) // 6 MiB of zeros
 			uri := core.EncodeDataURI(big, "image/png", "big.png")
@@ -293,6 +290,22 @@ func runDemo() {
 		Arrow("Host", "Server", "tools/call analyze_documents { documents: [valid pdf, text/plain] }").
 		DashedArrow("Server", "Host", "-32602 + data.field = \"documents[1]\"").
 		Note("Send a 2-element array where element 0 is a valid PDF and element 1 is a text/plain payload. The dispatcher's array-items walker validates each element against `items.x-mcp-file` and surfaces the path of the offender — `data.field == \"documents[1]\"`. Useful so a client rendering rich error UX can highlight the specific input that failed instead of asking the user to re-pick everything.").
+		VerbatimLang("Reproduce on the wire", "bash", `# Mint a session
+SID=$(curl -s -X POST http://localhost:8080/mcp \
+  -H 'Content-Type: application/json' -H 'Accept: application/json' \
+  -d '{"jsonrpc":"2.0","id":"i","method":"initialize","params":{"protocolVersion":"2025-11-25","clientInfo":{"name":"x","version":"1"},"capabilities":{"fileInputs":{}}}}' \
+  -D - -o /dev/null | grep -i 'mcp-session-id' | awk '{print $2}' | tr -d '\r\n')
+curl -s -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" -H "Accept: application/json" -H "Mcp-Session-Id: $SID" \
+  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null
+
+# Send 2 documents — index 0 valid PDF, index 1 wrong MIME
+GOOD='data:application/pdf;name=ok.pdf;base64,JVBERi0xLjQKJSVFT0YK'
+BAD='data:text/plain;name=bad.txt;base64,aGVsbG8='
+curl -s -X POST http://localhost:8080/mcp \
+  -H 'Content-Type: application/json' -H 'Accept: text/event-stream, application/json' -H "Mcp-Session-Id: $SID" \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"analyze_documents\",\"arguments\":{\"documents\":[\"$GOOD\",\"$BAD\"]}}}"
+`).
 		Run(func(ctx demokit.StepContext) *demokit.StepResult {
 			good := core.EncodeDataURI([]byte("%PDF-1.4\n%%EOF\n"), "application/pdf", "ok.pdf")
 			bad := core.EncodeDataURI([]byte("hello"), "text/plain", "bad.txt")
@@ -326,11 +339,8 @@ func runDemo() {
 		"- SEP-2356 spec: modelcontextprotocol/specification PR 2356",
 	)
 
-	for _, arg := range os.Args[1:] {
-		if strings.TrimSpace(arg) == "--tui" {
-			demo.WithRenderer(tui.New())
-			break
-		}
+	if demokit.IsTUI() {
+		demo.WithRenderer(tui.New())
 	}
 
 	demo.Execute()

--- a/server/dispatch.go
+++ b/server/dispatch.go
@@ -96,6 +96,16 @@ type Dispatcher struct {
 	// validation themselves. Default: validation enabled.
 	skipSchemaValidation bool
 
+	// validateFileInputs enables SEP-2356 file-input validation in the
+	// tools/call path. When true, the dispatcher walks the tool's
+	// inputSchema for `x-mcp-file` properties (single + array-items) and
+	// runs `core.ValidateFileInput` on every matching argument BEFORE the
+	// handler runs. Failures surface as -32602 with structured `data`
+	// (`{reason, actualSize, maxSize}` for oversized; `{reason, mediaType,
+	// accept, ...}` for MIME mismatches) — the wire shape is frozen by
+	// `conformance/file-inputs/`. Set via WithFileInputValidation().
+	validateFileInputs bool
+
 	// tasksCap is the tasks capability to advertise during initialize.
 	// nil means tasks are not enabled. Set via Server.SetTasksCap().
 	tasksCap *core.TasksCap
@@ -228,6 +238,7 @@ func (d *Dispatcher) newSession() *Dispatcher {
 		eventIDs:             newEventIDGen(),
 		requestIDs:           newEventIDGen(),
 		skipSchemaValidation: d.skipSchemaValidation,
+		validateFileInputs:   d.validateFileInputs,
 		tasksCap:             d.tasksCap,
 		customHandlers:       d.customHandlers,
 		mrtr:                 d.mrtr,
@@ -456,6 +467,18 @@ func (d *Dispatcher) handleToolsCall(ctx context.Context, id json.RawMessage, pa
 		if ve := entry.schema.validate(envelope.Arguments); ve != nil {
 			return core.NewErrorResponseWithData(id, core.ErrCodeInvalidParams,
 				"argument validation failed", ve)
+		}
+	}
+
+	// SEP-2356 file-input validation. Walk the tool's inputSchema for
+	// `x-mcp-file` properties (single string/uri AND array-items shapes)
+	// and run `core.ValidateFileInput` on each matching argument. Failures
+	// surface as -32602 with the structured `data` payload locked by the
+	// `conformance/file-inputs/` suite. Skipped unless
+	// WithFileInputValidation() is enabled.
+	if d.validateFileInputs {
+		if resp := d.validateFileInputArgs(id, entry.def.InputSchema, envelope.Arguments); resp != nil {
+			return resp
 		}
 	}
 

--- a/server/file_validation.go
+++ b/server/file_validation.go
@@ -1,0 +1,127 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+// validateFileInputArgs walks a tool's inputSchema for SEP-2356
+// `x-mcp-file` properties and runs `core.ValidateFileInput` on every
+// matching argument. Returns a `-32602` response with structured error
+// data on the first failure, nil otherwise.
+//
+// Supports both shapes the schema helpers emit:
+//
+//   - single file:  `properties.<name>.x-mcp-file = <descriptor>`
+//   - array of files: `properties.<name>.items.x-mcp-file = <descriptor>`
+//
+// The error data payload is the typed `Data()` method on the matching
+// `core.FileTooLargeError` / `core.FileTypeNotAcceptedError` — frozen by
+// `conformance/file-inputs/scenarios.test.ts` as the cross-impl contract.
+func (d *Dispatcher) validateFileInputArgs(id json.RawMessage, inputSchema any, args json.RawMessage) *core.Response {
+	schemaMap, ok := inputSchema.(map[string]any)
+	if !ok {
+		// Tools registered with typed schemas (jsonschema.Schema or other
+		// non-map shapes) skip this hook — they're free to validate
+		// themselves. Future enhancement: walk typed schemas via reflection.
+		return nil
+	}
+	props, ok := schemaMap["properties"].(map[string]any)
+	if !ok || len(props) == 0 {
+		return nil
+	}
+
+	var argMap map[string]any
+	if len(args) > 0 {
+		_ = json.Unmarshal(args, &argMap)
+	}
+	if argMap == nil {
+		return nil
+	}
+
+	for propName, propAny := range props {
+		prop, ok := propAny.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		// Single-file property.
+		if desc := core.ExtractFileInputDescriptor(prop); desc != nil {
+			uri, ok := argMap[propName].(string)
+			if !ok {
+				// Missing arg or wrong type — schema validation already
+				// surfaced this; skip silently here.
+				continue
+			}
+			if err := core.ValidateFileInput(uri, desc); err != nil {
+				return d.fileInputErrorResponse(id, propName, err)
+			}
+			continue
+		}
+
+		// Array of files: items carries the descriptor.
+		items, ok := prop["items"].(map[string]any)
+		if !ok {
+			continue
+		}
+		desc := core.ExtractFileInputDescriptor(items)
+		if desc == nil {
+			continue
+		}
+		arr, ok := argMap[propName].([]any)
+		if !ok {
+			continue
+		}
+		for i, item := range arr {
+			uri, ok := item.(string)
+			if !ok {
+				continue
+			}
+			if err := core.ValidateFileInput(uri, desc); err != nil {
+				return d.fileInputErrorResponse(id, fmt.Sprintf("%s[%d]", propName, i), err)
+			}
+		}
+	}
+	return nil
+}
+
+// fileInputErrorResponse builds the JSON-RPC -32602 envelope for a
+// file-input validation failure. The `data` field carries the typed
+// payload from `core.FileTooLargeError.Data()` /
+// `core.FileTypeNotAcceptedError.Data()` — the exact shape asserted by
+// the conformance suite.
+//
+// `field` is the JSON-Schema property path of the offending arg (e.g.
+// "image" or "documents[2]"); attached to the error data so clients
+// rendering rich error UX can highlight the specific input that failed.
+func (d *Dispatcher) fileInputErrorResponse(id json.RawMessage, field string, err error) *core.Response {
+	switch typed := err.(type) {
+	case *core.FileTooLargeError:
+		typed.Field = field
+		return core.NewErrorResponseWithData(
+			id,
+			core.ErrCodeInvalidParams,
+			fmt.Sprintf("file input %q exceeds size limit", field),
+			typed.Data(),
+		)
+	case *core.FileTypeNotAcceptedError:
+		typed.Field = field
+		return core.NewErrorResponseWithData(
+			id,
+			core.ErrCodeInvalidParams,
+			fmt.Sprintf("file input %q rejected: type not in accept list", field),
+			typed.Data(),
+		)
+	default:
+		// Decoder-level failures (malformed data URI, non-base64) — surface
+		// as -32602 too, but without structured data since these aren't
+		// part of the conformance contract.
+		return core.NewErrorResponse(
+			id,
+			core.ErrCodeInvalidParams,
+			fmt.Sprintf("file input %q invalid: %s", field, err.Error()),
+		)
+	}
+}

--- a/server/file_validation_test.go
+++ b/server/file_validation_test.go
@@ -1,0 +1,175 @@
+package server_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/server"
+	"github.com/stretchr/testify/require"
+)
+
+// newFileInputTestServer returns a server with WithFileInputValidation
+// enabled and a single image-only tool registered. Reuses the
+// newSchemaTestServer pattern from schema_validation_test.go (Dispatch
+// bypass after initialize).
+func newFileInputTestServer(t *testing.T) *server.Server {
+	t.Helper()
+	srv := newSchemaTestServer(t, server.WithFileInputValidation())
+
+	maxSize := 1024
+	srv.RegisterTool(
+		core.ToolDef{
+			Name: "upload_image",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"image": core.FileInputProperty(core.FileInputDescriptor{
+						Accept:  []string{"image/*"},
+						MaxSize: &maxSize,
+					}),
+				},
+				"required": []string{"image"},
+			},
+		},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+			// Should never be reached on rejection paths.
+			return core.TextResult("handler reached"), nil
+		},
+	)
+	return srv
+}
+
+// verifies: WithFileInputValidation enabled + a 2 KiB payload against a
+// 1 KiB cap returns -32602 with the wire shape pinned by
+// `conformance/file-inputs/scenarios.test.ts`:
+// `data: {reason: "file_too_large", field, actualSize, maxSize}`.
+func TestFileInputValidation_OversizedReturns32602(t *testing.T) {
+	srv := newFileInputTestServer(t)
+
+	big := make([]byte, 2048)
+	uri := core.EncodeDataURI(big, "image/png", "big.png")
+	resp := callTool(t, srv, "upload_image", map[string]any{"image": uri})
+
+	require.NotNil(t, resp.Error, "expected JSON-RPC error, got result")
+	require.Equal(t, core.ErrCodeInvalidParams, resp.Error.Code)
+
+	dataRaw, err := json.Marshal(resp.Error.Data)
+	require.NoError(t, err)
+	var data core.FileTooLargeData
+	require.NoError(t, json.Unmarshal(dataRaw, &data))
+	require.Equal(t, core.FileInputReasonTooLarge, data.Reason)
+	require.Equal(t, "image", data.Field)
+	require.Equal(t, 2048, data.ActualSize)
+	require.Equal(t, 1024, data.MaxSize)
+}
+
+// verifies: a payload whose decoded media type is outside the
+// descriptor's accept list returns -32602 with reason
+// `file_type_not_accepted` plus the offending mediaType + the
+// declared accept list.
+func TestFileInputValidation_WrongMIMEReturns32602(t *testing.T) {
+	srv := newFileInputTestServer(t)
+
+	uri := core.EncodeDataURI([]byte("hello"), "text/plain", "x.txt")
+	resp := callTool(t, srv, "upload_image", map[string]any{"image": uri})
+
+	require.NotNil(t, resp.Error)
+	require.Equal(t, core.ErrCodeInvalidParams, resp.Error.Code)
+
+	dataRaw, err := json.Marshal(resp.Error.Data)
+	require.NoError(t, err)
+	var data core.FileTypeNotAcceptedData
+	require.NoError(t, json.Unmarshal(dataRaw, &data))
+	require.Equal(t, core.FileInputReasonTypeNotAccepted, data.Reason)
+	require.Equal(t, "image", data.Field)
+	require.Equal(t, "text/plain", data.MediaType)
+	require.Equal(t, []string{"image/*"}, data.Accept)
+}
+
+// verifies: an in-budget image payload reaches the handler. Smoke check
+// that the validator isn't over-rejecting compliant inputs.
+func TestFileInputValidation_ValidPasses(t *testing.T) {
+	srv := newFileInputTestServer(t)
+
+	uri := core.EncodeDataURI([]byte{0x89, 0x50, 0x4E, 0x47}, "image/png", "tiny.png")
+	resp := callTool(t, srv, "upload_image", map[string]any{"image": uri})
+
+	require.Nil(t, resp.Error, "valid input should not be rejected")
+	require.NotNil(t, resp.Result)
+}
+
+// verifies: the same descriptor with an array shape (file inputs as
+// `documents[]` rather than a single property) routes through the
+// items-walker correctly. Catches a regression where the dispatcher
+// only inspects top-level properties and skips array items.
+func TestFileInputValidation_ArrayItems(t *testing.T) {
+	srv := newSchemaTestServer(t, server.WithFileInputValidation())
+	srv.RegisterTool(
+		core.ToolDef{
+			Name: "analyze_documents",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"documents": core.FileInputArrayProperty(core.FileInputDescriptor{
+						Accept: []string{"application/pdf"},
+					}),
+				},
+				"required": []string{"documents"},
+			},
+		},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+			return core.TextResult("ok"), nil
+		},
+	)
+
+	good := core.EncodeDataURI([]byte("%PDF-1.4\n"), "application/pdf", "a.pdf")
+	bad := core.EncodeDataURI([]byte("hello"), "text/plain", "b.txt")
+
+	resp := callTool(t, srv, "analyze_documents", map[string]any{
+		"documents": []string{good, bad},
+	})
+	require.NotNil(t, resp.Error, "second item should fail validation")
+	require.Equal(t, core.ErrCodeInvalidParams, resp.Error.Code)
+
+	dataRaw, _ := json.Marshal(resp.Error.Data)
+	var data core.FileTypeNotAcceptedData
+	require.NoError(t, json.Unmarshal(dataRaw, &data))
+	require.Equal(t, "documents[1]", data.Field,
+		"field path must reflect the offending array index")
+}
+
+// verifies: the option-disabled path leaves arguments untouched and
+// reaches the handler even with a non-conforming payload (so consumers
+// who prefer to validate themselves keep their existing behavior).
+func TestFileInputValidation_DisabledByDefault(t *testing.T) {
+	// No WithFileInputValidation() option here.
+	srv := newSchemaTestServer(t)
+
+	maxSize := 16
+	srv.RegisterTool(
+		core.ToolDef{
+			Name: "upload_image",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"image": core.FileInputProperty(core.FileInputDescriptor{
+						Accept:  []string{"image/*"},
+						MaxSize: &maxSize,
+					}),
+				},
+				"required": []string{"image"},
+			},
+		},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+			return core.TextResult("handler reached"), nil
+		},
+	)
+
+	// Wrong MIME + oversized — would be rejected with validation enabled.
+	uri := core.EncodeDataURI(make([]byte, 1024), "text/plain", "x.txt")
+	resp := callTool(t, srv, "upload_image", map[string]any{"image": uri})
+
+	require.Nil(t, resp.Error, "default behavior must NOT auto-validate file inputs")
+	require.NotNil(t, resp.Result)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -43,6 +43,7 @@ type serverOptions struct {
 	onRootsChanged       func([]core.Root) // optional callback when client sends roots/list_changed
 	rootsFetchTimeout    time.Duration     // timeout for server-to-client roots/list requests (0 = default 30s)
 	skipSchemaValidation bool              // WithSchemaValidation(false) disables call-time validation
+	validateFileInputs   bool              // WithFileInputValidation enables SEP-2356 size + MIME enforcement
 	publicMethods        map[string]bool   // methods that bypass auth (pre-auth discovery)
 	customHandlers       map[string]MethodHandler // custom JSON-RPC method handlers
 	httpHandlers         []httpHandlerEntry       // custom HTTP endpoint handlers
@@ -250,6 +251,38 @@ func WithSchemaValidation(enabled bool) Option {
 	return func(o *serverOptions) { o.skipSchemaValidation = !enabled }
 }
 
+// WithFileInputValidation enables SEP-2356 server-side validation of
+// file-typed tool arguments. When enabled, the dispatcher walks each
+// tool's inputSchema for `x-mcp-file` properties (single string/uri or
+// array-items shape) and runs `core.ValidateFileInput` on every matching
+// argument BEFORE the handler is invoked.
+//
+// Failures surface as JSON-RPC -32602 with structured `data`:
+//
+//	{
+//	  "code": -32602,
+//	  "message": "file input \"image\" exceeds size limit",
+//	  "data": {
+//	    "reason": "file_too_large",
+//	    "field": "image",
+//	    "actualSize": 5243904,
+//	    "maxSize": 5242880
+//	  }
+//	}
+//
+// The wire shape is frozen by `conformance/file-inputs/scenarios.test.ts`
+// (the cross-impl contract). Disabled by default — handlers that prefer
+// to validate themselves can leave it off.
+//
+// Usage:
+//
+//	srv := server.NewServer(info,
+//	    server.WithFileInputValidation(),
+//	)
+func WithFileInputValidation() Option {
+	return func(o *serverOptions) { o.validateFileInputs = true }
+}
+
 // WithAllowedRoots restricts tool cwd to the given directory prefixes.
 func WithAllowedRoots(roots ...string) Option {
 	return func(o *serverOptions) { o.allowedRoots = roots }
@@ -279,6 +312,7 @@ func NewServer(info core.ServerInfo, opts ...Option) *Server {
 	// Propagate schema validation opt-out to the dispatcher so per-session
 	// clones inherit it via newSession().
 	s.dispatcher.skipSchemaValidation = s.options.skipSchemaValidation
+	s.dispatcher.validateFileInputs = s.options.validateFileInputs
 	s.dispatcher.customHandlers = s.options.customHandlers
 	// Wire registry change notifications to Server.Broadcast so that
 	// dynamic adds/removes automatically notify all connected sessions.


### PR DESCRIPTION
This PR ships **two intertwined pieces** for SEP-2356:

1. The **conformance suite** (`conformance/file-inputs/`, 7 scenarios) — the cross-impl wire-format contract; mergeable as a standalone artifact.
2. **Server-side validation** (#361, A3) — the implementation that flips two of the suite's red scenarios green.

Closes #361. Live state: **6/7 green**. The remaining red (`file-inputs-02`, capability gating) is the done-bar for #362.

## Why both in one PR

The user wanted to watch the reds flip live. Stacking A3 onto the same branch as the conformance suite demonstrates the test-first acceptance-bar approach end-to-end: scaffolding → red → impl → green. PR diff shows the test-first commit (`383d5f7`) and the validation commit (`a6ee57a`) as separate history points.

## Conformance scenarios

| ID | Test | Status | Unblocked by |
|---|---|---|---|
| `file-inputs-01` | client WITH `fileInputs` cap sees `x-mcp-file` everywhere | ✅ green | — |
| `file-inputs-02` | client WITHOUT cap does NOT see `x-mcp-file` (but tools stay visible) | ❌ red | #362 |
| `file-inputs-03` | valid file upload round-trips bytes / media type / filename | ✅ green | — |
| `file-inputs-04` | oversized → `-32602` + `data: {reason, actualSize, maxSize, field}` | ✅ green (this PR) | — |
| `file-inputs-05` | wrong MIME → `-32602` + `data: {reason, mediaType, accept, field}` | ✅ green (this PR) | — |
| `file-inputs-06` | array-of-files (`analyze_documents`) handles multiple URIs | ✅ green | — |
| `file-inputs-07` | filename special chars round-trip via percent-encoding | ✅ green | — |

## Server surface added (A3)

| Surface | Where | Notes |
|---|---|---|
| `core.ValidateFileInput(uri, desc)` | `core/file_validation.go` | Decode data URI + run accept + maxSize checks. Returns typed errors. |
| `core.FileMatchesAccept(mediaType, filename, accept)` | same | Mirrors JS-side `fileMatchesAccept` in `ext/ui/assets/file-picker.ts` so both sides agree. |
| `core.FileTooLargeError` + `core.FileTypeNotAcceptedError` | same | Structured `Data()` payloads matching the conformance contract. Sentinels via `core.ErrFileTooLarge` / `ErrFileTypeNotAccepted` for `errors.Is`. |
| `core.FileInputReasonTooLarge` / `core.FileInputReasonTypeNotAccepted` | same | Reason string constants — bridge sentinel error names align (`MCPFileTooLarge` ↔ `file_too_large`). |
| `server.WithFileInputValidation()` | `server/server.go` | Option. Disabled by default. |
| Dispatcher hook | `server/dispatch.go` | Walks `InputSchema` for `x-mcp-file` (single + array items), validates each matching arg, surfaces `-32602` with structured `data` (with `field` path tracking, e.g. `documents[2]`). |
| `examples/file-inputs/main.go` | example | Now opts in via `WithFileInputValidation()` — handlers no longer need their own checks. |

## Locked design decisions

Spelled out in `conformance/file-inputs/README.md`:

1. **Error data shape** — structured: `{reason, field, actualSize, maxSize}` for too-large; `{reason, field, mediaType, accept}` for wrong MIME. Mirrors how SEP-2549 / SEP-2322 carry data; lets clients render rich error UX.
2. **Cap-gating interpretation** — strip the `x-mcp-file` keyword, keep the underlying string/uri property visible. Asserted by `file-inputs-02`; locked-in here so #362 inherits the spec contract.
3. **Filename percent-encoding ruleset** — matches Go's `url.PathEscape` byte-for-byte. The most likely cross-impl divergence point — flagged in the README.

## Test plan

- [x] `make testconf-file-inputs` — 6/7 green (was 4/7 in the baseline commit). The 1 remaining red is `file-inputs-02` (capability gating, awaiting #362).
- [x] `make test` — core / server / client / testutil all green; +11 new core tests, +5 new server tests.
- [x] `make test-ui` — bridge JS unaffected (61/61 still green).
- [x] `examples/file-inputs/` demokit walkthrough still completes end-to-end.
- [x] Server tests follow the schema_validation_test.go pattern (direct `Dispatch` after handshake bypass); avoids the SSE-parsing complexity of httptest.
- [x] No relaxed assertions on existing tests (added: 16, removed/weakened: 0).

## Cross-spec note

Validation logic survives a hypothetical SEP-2631 migration intact — the front-end decoder swaps from "decode data URI" to "dispatch on `FileValue` payload variant," but the `accept` matcher and `maxSize` check don't change. The error data shape stays the same since `FileValue.inlineBase64` would carry the same media-type info.

Casey-facing draft response (with the suite linked as drafting fodder for SEP-2631) staged in `mcpcontrib/proposals/file-uploads-wg/draft-responses.md` — postable once #362 lands and the suite hits 7/7.