### PR TITLE
feat(events): ζ — webhook hardening (6/6 complete)

### DIFF
--- a/docs/EVENTS_SPEC_ALIGNMENT_PLAN.md
+++ b/docs/EVENTS_SPEC_ALIGNMENT_PLAN.md
@@ -291,6 +291,8 @@ The TS reference's heartbeat doesn't carry a cursor today; the spec now requires
 
 ### ζ — Webhook hardening (delivery-time SSRF, body cap, control envelopes, deliveryStatus)
 
+**Status:** in flight on `feat/events-zeta-webhook-hardening`. ζ-1 through ζ-4 landed (4/6 commits); ζ-5 (deliveryStatus) and ζ-6 (suspend/reactivate state machine) pending. Race-clean across all four event modules.
+
 **Goal:** close the spec-mandated security and reliability gaps in our webhook delivery path.
 
 **Spec deltas addressed:**
@@ -302,27 +304,39 @@ The TS reference's heartbeat doesn't carry a cursor today; the spec now requires
 - **`deliveryStatus`** on `events/subscribe` refresh response: `{active, lastDeliveryAt, lastError, failedSince?}`. `lastError` is a categorical string from a fixed set: `connection_refused | timeout | tls_error | http_4xx | http_5xx | challenge_failed`. **Never** raw response bodies / headers / status lines (avoids becoming a response oracle for attacker-chosen URLs). (§"Webhook Delivery Status" L425-460)
 - **Suspend / reactivate state machine**: after repeated failures the server SHOULD set `active: false`; a successful refresh reactivates it (`active: true`) and resumes retrying pending events. (§"Webhook Event Delivery" L413 + §"Webhook Delivery Status" L460)
 
-**Files touched:**
-- `experimental/ext/events/webhook.go` — new `deliveryStatus` field on `WebhookTarget`. State machine transitions documented inline. Outbound `http.Client` configured with `CheckRedirect`. SSRF check moves to a `dialContext` hook so it runs on every connect, not just at subscribe.
-- New file: `experimental/ext/events/control.go` — signing + sending for `type:gap` and `type:terminated` envelopes. Reuses the headers code from α.
-- `experimental/ext/events/events.go` — `events/subscribe` refresh response includes `deliveryStatus` when present
-- `experimental/ext/events/headers.go` — confirm `X-MCP-Subscription-Id` is added to every outbound delivery
-- Go SDK `experimental/ext/events/clients/go/receiver.go` — handles control envelopes (top-level `type` field is the discriminator); routes `gap` and `terminated` to caller-supplied callbacks
-- Python SDK — same handling
+**Files touched (as built so far):**
+- `experimental/ext/events/webhook.go` — `net.Dialer.Control` SSRF guard inspecting resolved IP at dial time (TOCTOU-safe). `CheckRedirect: ErrUseLastResponse` on outbound http.Client. Body cap (default 256 KiB) enforced REJECT-not-truncate at Deliver entry. 413 + 3xx classified as non-retryable. New `WithWebhookAllowPrivateNetworks(bool)` (default false; demos opt in) and `WithWebhookMaxBodyBytes(int)` (default 256 KiB) options. `ValidateWebhookURL` converted to a `*WebhookRegistry` method so it can read the per-instance allowPrivate setting; strict-by-default for obvious loopback hostnames at subscribe time. (ζ-1, ζ-2, ζ-3)
+- New `experimental/ext/events/control.go` — `controlEnvelope`, `ControlError`, `WebhookRegistry.PostGap(canonicalKey, freshCursor)` and `PostTerminated(canonicalKey, ControlError)`. Single-attempt delivery (best-effort signal). PostTerminated removes the target from the registry regardless of POST outcome — no zombie entries. (ζ-4)
+- `experimental/ext/events/headers.go` — `newControlMessageID(typ)` mints `msg_<typ>_<random>`, finally honoring α's reserved-form stub. (ζ-4)
+- `experimental/ext/events/events.go` — registerSubscribe calls `webhooks.ValidateWebhookURL(...)` (method form). (ζ-1)
+- Go SDK `experimental/ext/events/clients/go/receiver.go` — `OnGap(cb)` + `OnTerminated(cb)` chainable callback installers + `ControlError` type. ServeHTTP probes top-level `type` BEFORE Event unmarshal so the common case (no `type` → event) doesn't pay a double-decode tax. (ζ-4)
+- Python SDK `events_client.py` — `_make_webhook_handler` dispatches by top-level `type`; pretty-prints `── WEBHOOK GAP / TERMINATED ──` frames distinctly. (ζ-4)
+- Test fixtures across all four event modules opt into `WithWebhookAllowPrivateNetworks(true)` since httptest binds to 127.0.0.1; demo binaries do too with a comment that production deployments leave it OFF.
 
-**Acceptance:**
-- `make test-experimental` green
-- SSRF integration test: subscribe with a hostname that resolves to a public IP, then arrange (mock DNS) for it to resolve to `127.0.0.1` at delivery time — verify the delivery is rejected
-- Redirect integration test: subscribe with a URL that 302s to `127.0.0.1` — verify the outbound delivery does NOT follow
-- Body cap integration test: emit an event that would serialize to >256 KiB — verify a 413 from the receiver is treated as non-retryable
-- Control envelope test: manually trigger a gap, verify a `{type:gap}` POST arrives with valid Standard Webhooks signature + `X-MCP-Subscription-Id`
+**Files still to touch (ζ-5, ζ-6):**
+- `experimental/ext/events/webhook.go` — `DeliveryStatus{Active, LastDeliveryAt, LastError, FailedSince}` field on WebhookTarget. Suspend/reactivate state machine (counter + first-failure-time + last-success-time, configurable threshold/window).
+- `experimental/ext/events/events.go` — registerSubscribe refresh-path response includes `deliveryStatus` when target has prior delivery attempts. New `WithWebhookSuspendThreshold(n)` + `WithWebhookSuspendWindow(d)` options.
+
+**Acceptance (as verified so far):**
+- All four event modules pass `go test -count=1 -race ./...` after each commit (ζ-1 through ζ-4)
+- SSRF dial-time guard rejects 10 IP families (loopback, RFC1918, link-local, ULA, IPv4-mapped-IPv6, etc.) — pinned by table-driven `TestDelivery_DialBlocklistRanges`
+- 3xx redirect not followed — pinned by `TestDelivery_DoesNotFollowRedirects`
+- Oversized event not POSTed (REJECT not TRUNCATE) — pinned by `TestDelivery_OversizedEventNotPosted`
+- 413 from receiver = exactly 1 attempt — pinned by `TestDelivery_413NotRetried`
+- Control envelope wire shape (top-level `type`, `msg_<typ>_<random>` webhook-id, X-MCP-Subscription-Id presence) — pinned by `TestControlEnvelope_*` (server side) + `TestReceiver_RoutesGap/TerminatedToCallback` (SDK side)
+
+**Pending (ζ-5, ζ-6):**
 - `deliveryStatus` test: cause repeated 5xx failures, verify subsequent refresh response shows `active: false`; refresh again and verify reactivation behavior
+- Suspend test: N consecutive failures within W → Active=false; failures outside W don't accumulate; successful refresh reactivates
 
-**Tests:**
-- `ssrf_delivery_test.go` (new) — DNS rebinding scenario
-- `control_envelope_test.go` (new) — gap + terminated paths
-- `delivery_status_test.go` (new) — suspension / reactivation state machine
-- Extend `headers_test.go` for the `X-MCP-Subscription-Id` presence
+**Tests added so far:**
+- `ssrf_delivery_test.go` — 5 tests (loopback rejected, escape allows, blocklist table, public allows, redirects rejected)
+- `body_cap_test.go` — 4 tests (oversized rejected, oversized logged, 413 not retried, default cap pin)
+- `control_envelope_test.go` (server) — 3 tests (gap shape, terminated shape, top-level type discriminator)
+- `clients/go/control_envelope_test.go` (SDK) — 3 tests (routes gap, routes terminated, no-callback-installed safe)
+
+**Pending tests (ζ-5, ζ-6):**
+- `delivery_status_test.go` — suspension/reactivation state machine, lastError categorical (no raw response leakage)
 
 **Risk:** Low to medium. Most changes are additive (new envelope types, new header, new field on response). The SSRF + redirect changes touch the http.Client setup, easy to land safely.
 

--- a/docs/EVENTS_SPEC_ALIGNMENT_PLAN.md
+++ b/docs/EVENTS_SPEC_ALIGNMENT_PLAN.md
@@ -291,7 +291,7 @@ The TS reference's heartbeat doesn't carry a cursor today; the spec now requires
 
 ### ζ — Webhook hardening (delivery-time SSRF, body cap, control envelopes, deliveryStatus)
 
-**Status:** in flight on `feat/events-zeta-webhook-hardening`. ζ-1 through ζ-4 landed (4/6 commits); ζ-5 (deliveryStatus) and ζ-6 (suspend/reactivate state machine) pending. Race-clean across all four event modules.
+**Status:** in flight on `feat/events-zeta-webhook-hardening`. All 6 commits landed. PR 375 ready for review. ζ-7 (source-side health signals → notifications/events/error and /terminated server emissions) tracked separately as issue 376. Race-clean across all four event modules.
 
 **Goal:** close the spec-mandated security and reliability gaps in our webhook delivery path.
 
@@ -313,9 +313,9 @@ The TS reference's heartbeat doesn't carry a cursor today; the spec now requires
 - Python SDK `events_client.py` — `_make_webhook_handler` dispatches by top-level `type`; pretty-prints `── WEBHOOK GAP / TERMINATED ──` frames distinctly. (ζ-4)
 - Test fixtures across all four event modules opt into `WithWebhookAllowPrivateNetworks(true)` since httptest binds to 127.0.0.1; demo binaries do too with a comment that production deployments leave it OFF.
 
-**Files still to touch (ζ-5, ζ-6):**
-- `experimental/ext/events/webhook.go` — `DeliveryStatus{Active, LastDeliveryAt, LastError, FailedSince}` field on WebhookTarget. Suspend/reactivate state machine (counter + first-failure-time + last-success-time, configurable threshold/window).
-- `experimental/ext/events/events.go` — registerSubscribe refresh-path response includes `deliveryStatus` when target has prior delivery attempts. New `WithWebhookSuspendThreshold(n)` + `WithWebhookSuspendWindow(d)` options.
+**Files touched (ζ-5, ζ-6 — landed):**
+- `experimental/ext/events/webhook.go` — `DeliveryStatus{Active, LastDeliveryAt, LastError, FailedSince}` + `DeliveryErrorBucket` typed string (categorical: connection_refused, timeout, tls_error, http_3xx_redirect, http_4xx, http_5xx, challenge_failed). `recordDeliverySuccess` / `recordDeliveryFailure` helpers + `classifyTransportError` (type-asserted markers, no err.Error() leakage). Suspend state machine: counter + first-failure-time + last-success-time per target; sliding window. `Targets()` filter excludes suspended; `Register` refresh path reactivates suspended targets. New `WithWebhookSuspendThreshold(n)` (default 5) + `WithWebhookSuspendWindow(d)` (default 10min) options.
+- `experimental/ext/events/events.go` — `registerSubscribe` refresh response includes `deliveryStatus` via new `deliveryStatusForResponse` projector when target has prior delivery attempts. Omitted on first subscribe (nothing to report).
 
 **Acceptance (as verified so far):**
 - All four event modules pass `go test -count=1 -race ./...` after each commit (ζ-1 through ζ-4)
@@ -325,9 +325,9 @@ The TS reference's heartbeat doesn't carry a cursor today; the spec now requires
 - 413 from receiver = exactly 1 attempt — pinned by `TestDelivery_413NotRetried`
 - Control envelope wire shape (top-level `type`, `msg_<typ>_<random>` webhook-id, X-MCP-Subscription-Id presence) — pinned by `TestControlEnvelope_*` (server side) + `TestReceiver_RoutesGap/TerminatedToCallback` (SDK side)
 
-**Pending (ζ-5, ζ-6):**
-- `deliveryStatus` test: cause repeated 5xx failures, verify subsequent refresh response shows `active: false`; refresh again and verify reactivation behavior
-- Suspend test: N consecutive failures within W → Active=false; failures outside W don't accumulate; successful refresh reactivates
+**Acceptance for ζ-5, ζ-6 (landed):**
+- `deliveryStatus` round-trip: refresh after success populates `lastDeliveryAt`; refresh after 5xx shows `lastError: http_5xx`; oracle-body test confirms raw response data NEVER leaks
+- Suspend: N consecutive failures within W → Active=false; failures outside W don't accumulate (sliding-window reset); successful refresh reactivates and clears state; suspended target skipped in Deliver fan-out
 
 **Tests added so far:**
 - `ssrf_delivery_test.go` — 5 tests (loopback rejected, escape allows, blocklist table, public allows, redirects rejected)
@@ -335,8 +335,8 @@ The TS reference's heartbeat doesn't carry a cursor today; the spec now requires
 - `control_envelope_test.go` (server) — 3 tests (gap shape, terminated shape, top-level type discriminator)
 - `clients/go/control_envelope_test.go` (SDK) — 3 tests (routes gap, routes terminated, no-callback-installed safe)
 
-**Pending tests (ζ-5, ζ-6):**
-- `delivery_status_test.go` — suspension/reactivation state machine, lastError categorical (no raw response leakage)
+**Tests added (ζ-5, ζ-6 — landed):**
+- `delivery_status_test.go` — 8 tests: deliveryStatus omission on first subscribe, lastDeliveryAt after success, lastError categorical (oracle-body leak check), connection_refused bucket, suspend after threshold, sliding-window reset, refresh reactivation, suspended skipped in Deliver
 
 **Risk:** Low to medium. Most changes are additive (new envelope types, new header, new field on response). The SSRF + redirect changes touch the http.Client setup, easy to land safely.
 

--- a/examples/events/discord/e2e_test.go
+++ b/examples/events/discord/e2e_test.go
@@ -28,6 +28,9 @@ import (
 // The cursorless typing source is registered alongside discord.message so
 // cursor-shape tests can exercise both modes against the same server.
 func buildTestStack(whOpts ...events.WebhookOption) (*server.Server, *events.YieldingSource[DiscordEventData], func(DiscordEventData) error, *events.WebhookRegistry) {
+	// ζ-1: tests subscribe to httptest URLs (127.0.0.1:N); bypass the
+	// production-default SSRF dial guard.
+	whOpts = append([]events.WebhookOption{events.WithWebhookAllowPrivateNetworks(true)}, whOpts...)
 	webhooks := events.NewWebhookRegistry(whOpts...)
 	source, yield := newDiscordSource()
 	typingSource, _ := newDiscordTypingSource()
@@ -51,6 +54,9 @@ func buildTestStack(whOpts ...events.WebhookOption) (*server.Server, *events.Yie
 // buildTestStackWithTyping returns the same wired server but exposes the
 // cursorless typing yield function too. Used by the cursorless e2e tests.
 func buildTestStackWithTyping(whOpts ...events.WebhookOption) (*server.Server, func(DiscordEventData) error, func(DiscordTypingData) error, *events.WebhookRegistry) {
+	// ζ-1: tests subscribe to httptest URLs (127.0.0.1:N); bypass the
+	// production-default SSRF dial guard.
+	whOpts = append([]events.WebhookOption{events.WithWebhookAllowPrivateNetworks(true)}, whOpts...)
 	webhooks := events.NewWebhookRegistry(whOpts...)
 	source, yield := newDiscordSource()
 	typingSource, yieldTyping := newDiscordTypingSource()

--- a/examples/events/discord/main.go
+++ b/examples/events/discord/main.go
@@ -56,6 +56,12 @@ func serve() {
 
 	whOpts := []events.WebhookOption{
 		events.WithWebhookHeaderMode(headerMode),
+		// ζ-1 demo escape: the demo's webhook step subscribes to local
+		// httptest receivers (127.0.0.1:N), which the production-default
+		// dial-time SSRF guard would block. Production deployments leave
+		// this OFF so loopback/private-IP webhook URLs are rejected at
+		// dial per spec §"Webhook Security" L464.
+		events.WithWebhookAllowPrivateNetworks(true),
 	}
 	if *whTTL > 0 {
 		whOpts = append(whOpts, events.WithWebhookTTL(*whTTL))

--- a/examples/events/telegram/e2e_test.go
+++ b/examples/events/telegram/e2e_test.go
@@ -29,6 +29,9 @@ import (
 // The cursorless typing source is registered alongside telegram.message so
 // cursor-shape tests can exercise both modes against the same server.
 func buildTestStack(whOpts ...events.WebhookOption) (*server.Server, *events.YieldingSource[TelegramEventData], func(TelegramEventData) error, *events.WebhookRegistry) {
+	// ζ-1: tests subscribe to httptest URLs (127.0.0.1:N); bypass the
+	// production-default SSRF dial guard.
+	whOpts = append([]events.WebhookOption{events.WithWebhookAllowPrivateNetworks(true)}, whOpts...)
 	webhooks := events.NewWebhookRegistry(whOpts...)
 	source, yield := newTelegramSource()
 	typingSource, _ := newTelegramTypingSource()
@@ -54,7 +57,7 @@ func buildTestStack(whOpts ...events.WebhookOption) (*server.Server, *events.Yie
 // tests so they can publish typing events without spinning up a Telegram
 // session.
 func buildTestStackWithTyping() (*server.Server, func(TelegramEventData) error, func(TelegramTypingData) error) {
-	webhooks := events.NewWebhookRegistry()
+	webhooks := events.NewWebhookRegistry(events.WithWebhookAllowPrivateNetworks(true))
 	source, yield := newTelegramSource()
 	typingSource, yieldTyping := newTelegramTypingSource()
 

--- a/examples/events/telegram/handlers_test.go
+++ b/examples/events/telegram/handlers_test.go
@@ -80,7 +80,7 @@ type pollResult struct {
 // end-to-end against the YieldingSource path. Two pages of 5 cover all 10.
 func TestEventsPollCursorPagination(t *testing.T) {
 	source, _ := preloadedSource(10)
-	c, _ := newConnectedClient(t, source, events.NewWebhookRegistry())
+	c, _ := newConnectedClient(t, source, events.NewWebhookRegistry(events.WithWebhookAllowPrivateNetworks(true)))
 
 	// δ-1: flat events/poll request shape per spec L139-149.
 	result, err := c.Call("events/poll", map[string]any{
@@ -114,7 +114,7 @@ func TestEventsPollCursorPagination(t *testing.T) {
 // and a stable cursor — sanity check for the no-data case.
 func TestEventsPollEmptyStore(t *testing.T) {
 	source, _ := newTelegramSource()
-	c, _ := newConnectedClient(t, source, events.NewWebhookRegistry())
+	c, _ := newConnectedClient(t, source, events.NewWebhookRegistry(events.WithWebhookAllowPrivateNetworks(true)))
 
 	result, err := c.Call("events/poll", map[string]any{
 		"name":   "telegram.message",
@@ -135,7 +135,7 @@ func TestEventsPollEmptyStore(t *testing.T) {
 // Single-sub call, single-sub response, single-sub error path.
 func TestEventsPollUnknownEvent(t *testing.T) {
 	source, _ := newTelegramSource()
-	c, _ := newConnectedClient(t, source, events.NewWebhookRegistry())
+	c, _ := newConnectedClient(t, source, events.NewWebhookRegistry(events.WithWebhookAllowPrivateNetworks(true)))
 
 	_, err := c.Call("events/poll", map[string]any{
 		"name":   "nonexistent.event",
@@ -151,7 +151,7 @@ func TestEventsPollUnknownEvent(t *testing.T) {
 // typed payloads from the YieldingSource — no separate buffer involved.
 func TestResourceRecentMessages(t *testing.T) {
 	source, _ := preloadedSource(3)
-	c, _ := newConnectedClient(t, source, events.NewWebhookRegistry())
+	c, _ := newConnectedClient(t, source, events.NewWebhookRegistry(events.WithWebhookAllowPrivateNetworks(true)))
 
 	text, err := c.ReadResource("telegram://messages/recent")
 	require.NoError(t, err)
@@ -166,7 +166,7 @@ func TestResourceRecentMessages(t *testing.T) {
 // {cursor} to the matching event payload. Cursor is the addressing scheme.
 func TestResourceMessageByCursor(t *testing.T) {
 	source, _ := preloadedSource(3)
-	c, _ := newConnectedClient(t, source, events.NewWebhookRegistry())
+	c, _ := newConnectedClient(t, source, events.NewWebhookRegistry(events.WithWebhookAllowPrivateNetworks(true)))
 
 	text, err := c.ReadResource("telegram://message/2")
 	require.NoError(t, err)
@@ -206,7 +206,10 @@ func TestWebhookHMACSignature_MCPHeaders(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	webhooks := events.NewWebhookRegistry(events.WithWebhookHeaderMode(events.MCPHeaders))
+	webhooks := events.NewWebhookRegistry(
+		events.WithWebhookHeaderMode(events.MCPHeaders),
+		events.WithWebhookAllowPrivateNetworks(true), // ζ-1: httptest is loopback
+	)
 	// Direct registry poke (skip the JSON-RPC subscribe handler) — γ-2
 	// rekeyed Register on canonical-tuple bytes. Use a stub key for the
 	// HMAC delivery test; the canonical-key contents don't matter here.
@@ -236,7 +239,7 @@ func TestWebhookHMACSignature_MCPHeaders(t *testing.T) {
 // result. Critical for clients deciding whether to poll again immediately.
 func TestEventsPollHasMore(t *testing.T) {
 	source, _ := preloadedSource(5)
-	c, _ := newConnectedClient(t, source, events.NewWebhookRegistry())
+	c, _ := newConnectedClient(t, source, events.NewWebhookRegistry(events.WithWebhookAllowPrivateNetworks(true)))
 
 	result, err := c.Call("events/poll", map[string]any{
 		"name":      "telegram.message",
@@ -268,7 +271,7 @@ func TestEventsPollHasMore(t *testing.T) {
 // refresh.
 func TestSubscribeReturnsRefreshBefore(t *testing.T) {
 	source, _ := newTelegramSource()
-	webhooks := events.NewWebhookRegistry()
+	webhooks := events.NewWebhookRegistry(events.WithWebhookAllowPrivateNetworks(true))
 	c, _ := newConnectedClient(t, source, webhooks)
 
 	result, err := c.Call("events/subscribe", map[string]any{
@@ -299,7 +302,7 @@ func TestSubscribeReturnsRefreshBefore(t *testing.T) {
 // property (§"Subscription Identity" → "Cross-tenant isolation" L378)
 // at the registry level.
 func TestWebhookKeyedByCanonicalTuple(t *testing.T) {
-	webhooks := events.NewWebhookRegistry()
+	webhooks := events.NewWebhookRegistry(events.WithWebhookAllowPrivateNetworks(true))
 	keyA := []byte("alice\x1fhttp://example.com/hook\x1ftelegram.message\x1f{}")
 	keyB := []byte("bob\x1fhttp://example.com/hook\x1ftelegram.message\x1f{}")
 	webhooks.Register(keyA, "sub_alice", "http://example.com/hook", "whsec_secret-1", 0)
@@ -317,7 +320,7 @@ func TestWebhookKeyedByCanonicalTuple(t *testing.T) {
 // TestWebhookTTLExpiry verifies the test-helper ExpireAll path does what
 // it claims — used by other tests that exercise post-TTL behavior.
 func TestWebhookTTLExpiry(t *testing.T) {
-	webhooks := events.NewWebhookRegistry()
+	webhooks := events.NewWebhookRegistry(events.WithWebhookAllowPrivateNetworks(true))
 	webhooks.Register([]byte("exp-test"), "sub_exp", "http://example.com/hook", "whsec_secret", 0)
 	assert.Len(t, webhooks.Targets(), 1)
 
@@ -344,7 +347,7 @@ func TestWebhookRetryOnServerError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	webhooks := events.NewWebhookRegistry()
+	webhooks := events.NewWebhookRegistry(events.WithWebhookAllowPrivateNetworks(true))
 	webhooks.Register([]byte("retry-test"), "sub_retry", srv.URL, "whsec_secret", 0)
 
 	event := events.MakeEvent("telegram.message", "evt_retry", "1", time.Now(),
@@ -372,7 +375,7 @@ func TestWebhookNoRetryOn4xx(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	webhooks := events.NewWebhookRegistry()
+	webhooks := events.NewWebhookRegistry(events.WithWebhookAllowPrivateNetworks(true))
 	webhooks.Register([]byte("no-retry"), "sub_no_retry", srv.URL, "whsec_secret", 0)
 
 	event := events.MakeEvent("telegram.message", "evt_4xx", "1", time.Now(),

--- a/examples/events/telegram/main.go
+++ b/examples/events/telegram/main.go
@@ -54,6 +54,12 @@ func serve() {
 
 	whOpts := []events.WebhookOption{
 		events.WithWebhookHeaderMode(headerMode),
+		// ζ-1 demo escape: the demo's webhook step subscribes to local
+		// httptest receivers (127.0.0.1:N). Production-default dial-time
+		// SSRF guard would block these. Production deployments leave
+		// this OFF so loopback/private-IP webhook URLs are rejected at
+		// dial per spec §"Webhook Security" L464.
+		events.WithWebhookAllowPrivateNetworks(true),
 	}
 	log.Printf("[server] webhook headers=%s; client-supplied secrets only", headerMode)
 

--- a/experimental/ext/events/body_cap_test.go
+++ b/experimental/ext/events/body_cap_test.go
@@ -1,0 +1,134 @@
+package events
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ζ-3 — body size cap + 413 non-retryable.
+//
+// Spec §"Webhook Security" → "Delivery profile (for WAF / private-cloud
+// deployments)" L487:
+//   - Servers SHOULD cap outbound delivery bodies at 256 KiB.
+//   - Servers MUST treat a 413 Payload Too Large from the receiver as
+//     non-retryable.
+//
+// Cap mode is REJECT, not TRUNCATE — truncation would corrupt the
+// HMAC signature and silently drop event content, both bad. The
+// rejected event is logged and skipped (it will never get smaller on
+// retry).
+
+// TestDelivery_OversizedEventNotPosted verifies a body that exceeds the
+// configured cap is NOT POSTed to the receiver. The cap defaults to 256
+// KiB (spec); we set it lower for the test so we can build an oversized
+// payload without ballooning test memory.
+func TestDelivery_OversizedEventNotPosted(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// 1 KiB cap so we don't allocate a 256 KiB+ blob in the test process.
+	r := NewWebhookRegistry(
+		WithWebhookAllowPrivateNetworks(true),
+		WithWebhookMaxBodyBytes(1024),
+	)
+	r.Register([]byte("k"), "sub_test", srv.URL, "whsec_secret", 0)
+
+	// Build a payload that, when JSON-marshaled with the envelope,
+	// exceeds 1 KiB. 2 KiB of "A" inside Data is enough.
+	bigData, _ := json.Marshal(map[string]string{"text": strings.Repeat("A", 2048)})
+	r.Deliver(Event{
+		EventID:   "evt_oversize",
+		Name:      "fake.event",
+		Timestamp: time.Now().Format(time.RFC3339),
+		Data:      bigData,
+	})
+
+	time.Sleep(200 * time.Millisecond)
+	assert.Equal(t, int32(0), hits.Load(),
+		"oversized payload MUST NOT be POSTed; spec L487 cap is reject-not-truncate (truncation would corrupt HMAC)")
+}
+
+// TestDelivery_OversizedEventLogged is a counter-assertion: the rejection
+// must be observable in the log so operators know events are being
+// dropped (silent drop would be worse than retrying).
+func TestDelivery_OversizedEventLogged(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	logCap := &captureLog{}
+	r := NewWebhookRegistry(
+		WithWebhookAllowPrivateNetworks(true),
+		WithWebhookMaxBodyBytes(1024),
+	)
+	logCap.attach(r)
+	r.Register([]byte("k"), "sub_test", srv.URL, "whsec_secret", 0)
+
+	bigData, _ := json.Marshal(map[string]string{"text": strings.Repeat("B", 2048)})
+	r.Deliver(Event{
+		EventID:   "evt_oversize_logged",
+		Name:      "fake.event",
+		Timestamp: time.Now().Format(time.RFC3339),
+		Data:      bigData,
+	})
+
+	time.Sleep(100 * time.Millisecond)
+	logged := false
+	for _, line := range logCap.snapshot() {
+		if strings.Contains(line, "oversize") || strings.Contains(line, "exceeds") || strings.Contains(line, "too large") {
+			logged = true
+			break
+		}
+	}
+	assert.True(t, logged,
+		"oversized payload rejection MUST be logged; got:\n%s",
+		strings.Join(logCap.snapshot(), "\n"))
+}
+
+// TestDelivery_413NotRetried verifies that a 413 Payload Too Large
+// response from the receiver is classified as non-retryable per spec
+// L487. Without this, a receiver permanently configured to reject our
+// payloads would accumulate retry traffic indefinitely (effectively a
+// self-DoS).
+func TestDelivery_413NotRetried(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusRequestEntityTooLarge) // 413
+	}))
+	defer srv.Close()
+
+	r := NewWebhookRegistry(WithWebhookAllowPrivateNetworks(true))
+	r.Register([]byte("k"), "sub_test", srv.URL, "whsec_secret", 0)
+
+	r.Deliver(MakeEvent("fake.event", "evt_413", "1", time.Now(),
+		map[string]string{"text": "tiny"}))
+
+	// Generous wait — if 413 were retried with backoff, we'd see 4 attempts
+	// over ~3.5 seconds. 1 second covers a single attempt + safety margin.
+	time.Sleep(1 * time.Second)
+
+	assert.Equal(t, int32(1), hits.Load(),
+		"413 MUST be treated as non-retryable per spec L487; got %d attempts", hits.Load())
+}
+
+// TestDelivery_DefaultCapIs256KiB pins the default cap value to 256 KiB
+// per spec. Catches an accidental config drift.
+func TestDelivery_DefaultCapIs256KiB(t *testing.T) {
+	r := NewWebhookRegistry()
+	require.Equal(t, 256*1024, r.maxBodyBytes,
+		"default body cap MUST be 256 KiB per spec L487")
+}

--- a/experimental/ext/events/clients/go/control_envelope_test.go
+++ b/experimental/ext/events/clients/go/control_envelope_test.go
@@ -1,0 +1,122 @@
+package eventsclient_test
+
+import (
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/panyam/mcpkit/experimental/ext/events"
+	eventsclient "github.com/panyam/mcpkit/experimental/ext/events/clients/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ζ-4 receiver-side dispatch — these tests stand up an httptest receiver
+// (the eventsclient.Receiver), point a server-side WebhookRegistry at
+// it, and trigger PostGap / PostTerminated. They verify the receiver's
+// top-level `type` discriminator routes the body to the right typed
+// callback (OnGap / OnTerminated) instead of falling through to the
+// Event[Data] channel.
+//
+// The HTTP path / signature / headers are the same as event deliveries
+// (covered by other tests); these focus on the dispatch.
+
+// TestReceiver_RoutesGapToCallback verifies a {type:"gap"} envelope
+// fires OnGap with the carried cursor — and does NOT also leak an
+// empty/zero Event[Data] onto the Events() channel.
+func TestReceiver_RoutesGapToCallback(t *testing.T) {
+	const secret = "whsec_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	recv := eventsclient.NewReceiver[map[string]any](secret)
+	defer recv.Close()
+
+	gotCursor := make(chan string, 1)
+	recv.OnGap(func(c string) { gotCursor <- c })
+
+	srv := httptest.NewServer(recv)
+	defer srv.Close()
+
+	r := events.NewWebhookRegistry(events.WithWebhookAllowPrivateNetworks(true))
+	canonical := []byte("gap-test-key")
+	r.Register(canonical, "sub_gap_test", srv.URL, secret, 0)
+
+	r.PostGap(canonical, "fresh-c-77")
+
+	select {
+	case got := <-gotCursor:
+		assert.Equal(t, "fresh-c-77", got, "OnGap cursor must match the value the server sent")
+	case <-time.After(2 * time.Second):
+		t.Fatal("OnGap callback never fired")
+	}
+
+	// Receiver's Events channel must NOT have received anything — gap
+	// envelopes route to OnGap, not Events().
+	select {
+	case ev := <-recv.Events():
+		t.Fatalf("gap envelope leaked onto Events() as Event=%+v", ev)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+// TestReceiver_RoutesTerminatedToCallback verifies a {type:"terminated"}
+// envelope fires OnTerminated with the carried error code+message.
+func TestReceiver_RoutesTerminatedToCallback(t *testing.T) {
+	const secret = "whsec_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	recv := eventsclient.NewReceiver[map[string]any](secret)
+	defer recv.Close()
+
+	gotErr := make(chan eventsclient.ControlError, 1)
+	recv.OnTerminated(func(e eventsclient.ControlError) { gotErr <- e })
+
+	srv := httptest.NewServer(recv)
+	defer srv.Close()
+
+	r := events.NewWebhookRegistry(events.WithWebhookAllowPrivateNetworks(true))
+	canonical := []byte("terminated-test-key")
+	r.Register(canonical, "sub_term_test", srv.URL, secret, 0)
+
+	r.PostTerminated(canonical, events.ControlError{Code: -32012, Message: "Unauthorized"})
+
+	select {
+	case got := <-gotErr:
+		assert.Equal(t, -32012, got.Code)
+		assert.Equal(t, "Unauthorized", got.Message)
+	case <-time.After(2 * time.Second):
+		t.Fatal("OnTerminated callback never fired")
+	}
+}
+
+// TestReceiver_NoCallbacksRegistered verifies a control envelope with
+// no callback installed is silently dropped (with HTTP 200 — the server
+// shouldn't infer the receiver doesn't care). Catches a regression
+// where a missing callback would crash with nil deref or 500-error
+// the server's POST.
+func TestReceiver_NoCallbacksRegistered(t *testing.T) {
+	const secret = "whsec_cccccccccccccccccccccccccccccccc"
+	recv := eventsclient.NewReceiver[map[string]any](secret)
+	defer recv.Close()
+	// No OnGap / OnTerminated installed.
+
+	srv := httptest.NewServer(recv)
+	defer srv.Close()
+
+	var serverPostFailed atomic.Bool
+	r := events.NewWebhookRegistry(events.WithWebhookAllowPrivateNetworks(true))
+	canonical := []byte("no-cb-key")
+	r.Register(canonical, "sub_no_cb", srv.URL, secret, 0)
+
+	r.PostGap(canonical, "c1")
+	require.Eventually(t, func() bool {
+		// give it time to land
+		return true
+	}, 100*time.Millisecond, 20*time.Millisecond)
+
+	// We can't easily observe the 200 from this side, but we can verify
+	// the receiver's Events channel didn't get a spurious event.
+	select {
+	case ev := <-recv.Events():
+		t.Fatalf("envelope leaked to Events() despite no callback: %+v", ev)
+	case <-time.After(100 * time.Millisecond):
+	}
+	assert.False(t, serverPostFailed.Load(), "server-side POST shouldn't have logged a failure")
+}

--- a/experimental/ext/events/clients/go/eventsclient_test.go
+++ b/experimental/ext/events/clients/go/eventsclient_test.go
@@ -30,6 +30,10 @@ type fakePayload struct {
 func stack(t *testing.T, whOpts ...events.WebhookOption) (*client.Client, func(fakePayload) error, *events.WebhookRegistry) {
 	t.Helper()
 
+	// ζ-1: SDK tests subscribe to httptest URLs (127.0.0.1:N). Prepend
+	// the loopback escape so the dial-time SSRF guard doesn't block
+	// the test deliveries. Per-test whOpts can still override.
+	whOpts = append([]events.WebhookOption{events.WithWebhookAllowPrivateNetworks(true)}, whOpts...)
 	webhooks := events.NewWebhookRegistry(whOpts...)
 	src, yield := events.NewYieldingSource[fakePayload](events.EventDef{
 		Name:        "fake.event",

--- a/experimental/ext/events/clients/go/receiver.go
+++ b/experimental/ext/events/clients/go/receiver.go
@@ -24,6 +24,19 @@ type Receiver[Data any] struct {
 	out      chan Event[Data]
 	closed   bool
 	rejected uint64
+
+	// ζ-4 control envelope callbacks. Both are optional. The discriminator
+	// is the top-level `type` field per spec §"Non-event webhook bodies"
+	// L415: "gap" carries a fresh cursor; "terminated" carries an error.
+	onGap        func(cursor string)
+	onTerminated func(err ControlError)
+}
+
+// ControlError mirrors the JSON-RPC error object carried in a
+// type:terminated control envelope per spec L420.
+type ControlError struct {
+	Code    int
+	Message string
 }
 
 // NewReceiver constructs a typed receiver with the given verification
@@ -52,6 +65,30 @@ func (r *Receiver[Data]) SetSecret(secret string) {
 
 // Events returns the typed delivery channel. Closes when Close is called.
 func (r *Receiver[Data]) Events() <-chan Event[Data] { return r.out }
+
+// OnGap installs a callback invoked when the receiver gets a
+// {type:"gap", cursor:<fresh>} control envelope (spec L415). Caller
+// SHOULD reset its persisted cursor to the carried value and re-fetch
+// authoritative state if the gap matters for correctness.
+//
+// Receiver-callback semantics: invoked from the inbound HTTP handler
+// goroutine — must NOT block. Heavy work belongs in a separate
+// goroutine inside the callback.
+func (r *Receiver[Data]) OnGap(fn func(cursor string)) {
+	r.mu.Lock()
+	r.onGap = fn
+	r.mu.Unlock()
+}
+
+// OnTerminated installs a callback invoked when the receiver gets a
+// {type:"terminated", error:{...}} control envelope (spec L420). Caller
+// SHOULD remove its local subscription state — the server has already
+// stopped delivering. Same goroutine constraints as OnGap.
+func (r *Receiver[Data]) OnTerminated(fn func(err ControlError)) {
+	r.mu.Lock()
+	r.onTerminated = fn
+	r.mu.Unlock()
+}
 
 // Close stops accepting deliveries and closes the Events channel. Safe
 // to call multiple times.
@@ -85,6 +122,51 @@ func (r *Receiver[Data]) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	if !verifySignature(req.Header, body, secret) {
 		http.Error(w, "signature verification failed", http.StatusUnauthorized)
+		return
+	}
+
+	// ζ-4: top-level `type` field discriminates control envelopes from
+	// event deliveries (spec §"Non-event webhook bodies" L415-423).
+	// Probe with a minimal struct before unmarshaling as Event so we
+	// don't double-decode the common case (no `type` → event).
+	var probe struct {
+		Type string `json:"type"`
+	}
+	_ = json.Unmarshal(body, &probe)
+	switch probe.Type {
+	case "gap":
+		var env struct {
+			Cursor string `json:"cursor"`
+		}
+		_ = json.Unmarshal(body, &env)
+		r.mu.RLock()
+		cb := r.onGap
+		r.mu.RUnlock()
+		if cb != nil {
+			cb(env.Cursor)
+		}
+		w.WriteHeader(http.StatusOK)
+		return
+	case "terminated":
+		var env struct {
+			Error *struct {
+				Code    int    `json:"code"`
+				Message string `json:"message"`
+			} `json:"error"`
+		}
+		_ = json.Unmarshal(body, &env)
+		r.mu.RLock()
+		cb := r.onTerminated
+		r.mu.RUnlock()
+		if cb != nil {
+			ce := ControlError{}
+			if env.Error != nil {
+				ce.Code = env.Error.Code
+				ce.Message = env.Error.Message
+			}
+			cb(ce)
+		}
+		w.WriteHeader(http.StatusOK)
 		return
 	}
 

--- a/experimental/ext/events/clients/python/events_client.py
+++ b/experimental/ext/events/clients/python/events_client.py
@@ -580,22 +580,59 @@ def _make_webhook_handler(secret_holder):
             mode = "standard" if self.headers.get("webhook-signature") else "mcp"
 
             label = f"{mode} sig OK" if sig_ok else f"{mode} sig FAIL"
+
+            # ζ-4: top-level `type` discriminator distinguishes control
+            # envelopes (gap, terminated) from event deliveries.
+            # Spec §"Non-event webhook bodies" L415-423.
+            try:
+                payload = json.loads(body)
+            except Exception:
+                print()
+                print(f"── WEBHOOK RAW ({label}) " + "─" * 30)
+                print(f"  raw: {body.decode(errors='replace')}")
+                print()
+                sys.stdout.flush()
+                self.send_response(200)
+                self.end_headers()
+                return
+
+            envelope_type = payload.get("type")
+            if envelope_type == "gap":
+                print()
+                print(f"── WEBHOOK GAP ({label}) " + "─" * 32)
+                print(f"  cursor:  {_fmt_cursor(payload.get('cursor'))}")
+                print(f"  → reset persisted cursor and re-fetch authoritative state if it matters")
+                print()
+                sys.stdout.flush()
+                self.send_response(200)
+                self.end_headers()
+                return
+            if envelope_type == "terminated":
+                err = payload.get("error") or {}
+                print()
+                print(f"── WEBHOOK TERMINATED ({label}) " + "─" * 26)
+                print(f"  code:    {err.get('code')}")
+                print(f"  message: {err.get('message')!r}")
+                print(f"  → server has stopped delivering; remove local subscription state")
+                print()
+                sys.stdout.flush()
+                self.send_response(200)
+                self.end_headers()
+                return
+
+            # Event delivery (default).
             print()
             print(f"── WEBHOOK EVENT ({label}) " + "─" * 30)
-            try:
-                event = json.loads(body)
-                print(f"  id:      {event.get('eventId', '')}")
-                print(f"  name:    {event.get('name', '')}")
-                print(f"  time:    {event.get('timestamp', '')}")
-                print(f"  cursor:  {_fmt_cursor(event.get('cursor'))}")
-                meta = event.get("_meta")
-                if meta:
-                    print(f"  _meta:   {json.dumps(meta, separators=(',', ':'))}")
-                data = event.get("data")
-                if data:
-                    print(json.dumps(data, indent=2))
-            except Exception:
-                print(f"  raw: {body.decode()}")
+            print(f"  id:      {payload.get('eventId', '')}")
+            print(f"  name:    {payload.get('name', '')}")
+            print(f"  time:    {payload.get('timestamp', '')}")
+            print(f"  cursor:  {_fmt_cursor(payload.get('cursor'))}")
+            meta = payload.get("_meta")
+            if meta:
+                print(f"  _meta:   {json.dumps(meta, separators=(',', ':'))}")
+            data = payload.get("data")
+            if data:
+                print(json.dumps(data, indent=2))
             print()
             sys.stdout.flush()
             self.send_response(200)

--- a/experimental/ext/events/control.go
+++ b/experimental/ext/events/control.go
@@ -1,0 +1,135 @@
+package events
+
+// ζ-4 — control envelopes for non-event webhook bodies.
+//
+// Spec §"Non-event webhook bodies" L415-423: the server POSTs signed
+// envelopes to webhook receivers when the event-delivery channel
+// can't carry the signal:
+//
+//   - {type: "gap", cursor: "<fresh>"} — a gap was detected between
+//     refreshes (e.g., a yield queue overflowed). Tells the receiver
+//     to reset its cursor to the carried value.
+//   - {type: "terminated", error: {code, message}} — the subscription
+//     has ended (e.g., auth revoked). Receiver removes the subscription;
+//     the server removes the registry target.
+//
+// Both use Standard Webhooks signature headers (webhook-id /
+// webhook-timestamp / webhook-signature) plus the γ-4
+// X-MCP-Subscription-Id header. webhook-id format is
+// msg_<type>_<random> per spec L417, distinguishing control POSTs from
+// event deliveries (which use the event's eventId so retries dedup
+// correctly).
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+// ControlError is the error payload carried in a type:terminated
+// envelope. Mirrors a JSON-RPC error object (code + message) so
+// receivers can map the categorical reason consistently with how they
+// already handle JSON-RPC failures elsewhere.
+type ControlError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// controlEnvelope is the wire shape of a non-event webhook body per
+// spec L415-423. The top-level `type` field is the discriminator;
+// payload-specific fields (cursor for gap, error for terminated) are
+// optional and use omitempty so envelopes only carry the field they
+// need.
+type controlEnvelope struct {
+	Type   string        `json:"type"`
+	Cursor string        `json:"cursor,omitempty"`
+	Error  *ControlError `json:"error,omitempty"`
+}
+
+// PostGap delivers a {type:gap, cursor:<fresh>} envelope to the
+// webhook target identified by canonicalKey. The receiver should reset
+// its persisted cursor to the provided fresh value and resume from
+// there. Per spec §"Non-event webhook bodies" L415.
+//
+// No-op if no target matches canonicalKey (e.g., the subscription has
+// already expired or been unregistered). Logged via the registry's
+// logf hook on best-effort failure; this method does not retry beyond
+// the deliver-loop's existing exponential backoff.
+func (r *WebhookRegistry) PostGap(canonicalKey []byte, freshCursor string) {
+	r.mu.RLock()
+	target, ok := r.targets[string(canonicalKey)]
+	r.mu.RUnlock()
+	if !ok {
+		return
+	}
+	body, err := json.Marshal(controlEnvelope{Type: "gap", Cursor: freshCursor})
+	if err != nil {
+		r.logf("[webhook] PostGap: marshal failed: %v", err)
+		return
+	}
+	go r.deliverControl(target, "gap", body)
+}
+
+// PostTerminated delivers a {type:terminated, error:...} envelope to
+// the webhook target and then removes the target from the registry —
+// the receiver is being told the subscription is dead, so subsequent
+// event yields shouldn't try to deliver to it anyway. Per spec
+// §"Non-event webhook bodies" L420 + §"Authorization" L783-795.
+//
+// No-op if no target matches canonicalKey. The target removal happens
+// regardless of whether the POST succeeded; if the receiver was
+// unreachable when we tried to notify it, we still don't want a zombie
+// entry in the registry.
+func (r *WebhookRegistry) PostTerminated(canonicalKey []byte, controlErr ControlError) {
+	r.mu.Lock()
+	target, ok := r.targets[string(canonicalKey)]
+	if ok {
+		delete(r.targets, string(canonicalKey))
+	}
+	r.mu.Unlock()
+	if !ok {
+		return
+	}
+	body, err := json.Marshal(controlEnvelope{Type: "terminated", Error: &controlErr})
+	if err != nil {
+		r.logf("[webhook] PostTerminated: marshal failed: %v", err)
+		return
+	}
+	go r.deliverControl(target, "terminated", body)
+}
+
+// deliverControl POSTs a control envelope synchronously (caller starts
+// the goroutine). Uses newControlMessageID for the webhook-id so the
+// type prefix appears in the header. Reuses the per-mode signing
+// machinery from headers.go so the wire signature matches what event
+// deliveries use; receivers verify with the same code path.
+//
+// Single-attempt delivery: control envelopes are best-effort signals.
+// Retrying a `terminated` envelope after the target was removed would
+// race the next subscribe; retrying a `gap` envelope would compound a
+// racing condition the receiver is already being told to recover from.
+func (r *WebhookRegistry) deliverControl(target WebhookTarget, typ string, body []byte) {
+	msgID := newControlMessageID(typ)
+	signed := signFor(r.headerMode, msgID, body, target.Secret, time.Now()).
+		withSubscriptionID(target.ID)
+
+	req, err := http.NewRequestWithContext(context.Background(), "POST", target.URL, bytes.NewReader(signed.body))
+	if err != nil {
+		r.logf("[webhook] deliverControl(%s) build-request failed for %s: %v", typ, target.URL, err)
+		return
+	}
+	signed.applyHeaders(req)
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		r.logf("[webhook] deliverControl(%s) to %s failed: %v", typ, target.URL, err)
+		return
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		r.logf("[webhook] deliverControl(%s) to %s returned %d", typ, target.URL, resp.StatusCode)
+	}
+}

--- a/experimental/ext/events/control_envelope_test.go
+++ b/experimental/ext/events/control_envelope_test.go
@@ -1,0 +1,190 @@
+package events
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ζ-4 — control envelopes (type:gap, type:terminated).
+//
+// Spec §"Non-event webhook bodies" L415-423: the server POSTs signed
+// envelopes to webhook receivers when (a) a gap is detected between
+// refreshes (type:gap, carries fresh cursor) or (b) the subscription
+// has ended (type:terminated, carries error). Both use Standard
+// Webhooks headers + X-MCP-Subscription-Id, distinguished from event
+// deliveries by the top-level `type` field discriminator AND by the
+// webhook-id pattern: msg_<type>_<random> vs eventId for events
+// (see α's newMessageID; ζ-4 finally uses the typed form).
+
+// captureControlPost records what the receiver saw — body, headers —
+// for the test to inspect after PostGap / PostTerminated returns.
+type captureControlPost struct {
+	mu      sync.Mutex
+	body    []byte
+	headers http.Header
+	hits    int
+}
+
+func (c *captureControlPost) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		body, _ := readAll(r.Body)
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		c.body = body
+		c.headers = r.Header.Clone()
+		c.hits++
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+func readAll(r interface {
+	Read(p []byte) (n int, err error)
+}) ([]byte, error) {
+	const max = 64 * 1024
+	buf := make([]byte, 0, 1024)
+	tmp := make([]byte, 1024)
+	for {
+		n, err := r.Read(tmp)
+		if n > 0 {
+			buf = append(buf, tmp[:n]...)
+			if len(buf) > max {
+				return buf, nil
+			}
+		}
+		if err != nil {
+			return buf, nil
+		}
+	}
+}
+
+// TestControlEnvelope_GapShape verifies PostGap POSTs a body matching
+// {type:"gap", cursor:"<fresh>"} per spec L415, with Standard Webhooks
+// headers (webhook-id, webhook-timestamp, webhook-signature) and the
+// γ-4 X-MCP-Subscription-Id header. webhook-id format is
+// msg_gap_<random> per spec, distinguishing control POSTs from event
+// deliveries (which use eventId).
+func TestControlEnvelope_GapShape(t *testing.T) {
+	cap := &captureControlPost{}
+	srv := httptest.NewServer(cap.handler())
+	defer srv.Close()
+
+	r := NewWebhookRegistry(WithWebhookAllowPrivateNetworks(true))
+	canonical := canonicalKey("alice", srv.URL, "fake.event", nil)
+	subID := deriveSubscriptionID(canonical)
+	r.Register(canonical, subID, srv.URL, "whsec_"+strings.Repeat("a", 32), 0)
+
+	r.PostGap(canonical, "fresh-cursor-123")
+
+	require.Eventually(t, func() bool {
+		cap.mu.Lock()
+		defer cap.mu.Unlock()
+		return cap.hits == 1
+	}, 2*time.Second, 20*time.Millisecond, "expected exactly one gap POST")
+
+	cap.mu.Lock()
+	defer cap.mu.Unlock()
+
+	// Body shape.
+	var env map[string]any
+	require.NoError(t, json.Unmarshal(cap.body, &env))
+	assert.Equal(t, "gap", env["type"], "envelope type MUST be 'gap'; got %v", env["type"])
+	assert.Equal(t, "fresh-cursor-123", env["cursor"],
+		"gap envelope MUST carry the fresh cursor for the receiver to resume from")
+
+	// Headers — Standard Webhooks.
+	wid := cap.headers.Get("webhook-id")
+	assert.True(t, strings.HasPrefix(wid, "msg_gap_"),
+		"webhook-id MUST be msg_<type>_<random> per spec L417; got %q", wid)
+	assert.NotEmpty(t, cap.headers.Get("webhook-timestamp"))
+	assert.NotEmpty(t, cap.headers.Get("webhook-signature"))
+
+	// γ-4 X-MCP-Subscription-Id MUST appear on every webhook delivery,
+	// including control envelopes.
+	assert.Equal(t, subID, cap.headers.Get("X-MCP-Subscription-Id"),
+		"control envelopes MUST carry X-MCP-Subscription-Id (γ-4 + spec L390/L472)")
+}
+
+// TestControlEnvelope_TerminatedShape verifies PostTerminated POSTs
+// {type:"terminated", error:{code, message}} per spec L420. webhook-id
+// is msg_terminated_<random>. After a successful POST the registry
+// removes the target so subsequent event yields don't try to deliver
+// to a subscription the receiver already knows is dead.
+func TestControlEnvelope_TerminatedShape(t *testing.T) {
+	cap := &captureControlPost{}
+	srv := httptest.NewServer(cap.handler())
+	defer srv.Close()
+
+	r := NewWebhookRegistry(WithWebhookAllowPrivateNetworks(true))
+	canonical := canonicalKey("alice", srv.URL, "fake.event", nil)
+	subID := deriveSubscriptionID(canonical)
+	r.Register(canonical, subID, srv.URL, "whsec_"+strings.Repeat("a", 32), 0)
+
+	r.PostTerminated(canonical, ControlError{Code: -32012, Message: "Unauthorized"})
+
+	require.Eventually(t, func() bool {
+		cap.mu.Lock()
+		defer cap.mu.Unlock()
+		return cap.hits == 1
+	}, 2*time.Second, 20*time.Millisecond)
+
+	cap.mu.Lock()
+	defer cap.mu.Unlock()
+
+	var env map[string]any
+	require.NoError(t, json.Unmarshal(cap.body, &env))
+	assert.Equal(t, "terminated", env["type"])
+	errMap, ok := env["error"].(map[string]any)
+	require.True(t, ok, "terminated envelope MUST include an error object; got %v", env["error"])
+	assert.EqualValues(t, -32012, errMap["code"])
+	assert.Equal(t, "Unauthorized", errMap["message"])
+
+	wid := cap.headers.Get("webhook-id")
+	assert.True(t, strings.HasPrefix(wid, "msg_terminated_"),
+		"webhook-id MUST be msg_terminated_<random>; got %q", wid)
+	assert.Equal(t, subID, cap.headers.Get("X-MCP-Subscription-Id"))
+
+	// After PostTerminated, the registry MUST drop the target so the
+	// next yield doesn't try to deliver to it.
+	assert.Empty(t, r.Targets(),
+		"PostTerminated MUST remove the target from the registry")
+}
+
+// TestControlEnvelope_TypeDiscriminatorIsTopLevel verifies the spec
+// contract that lets receivers route by inspecting the body without
+// per-payload heuristics: the discriminator is a top-level `type`
+// field, not nested inside `data` or anywhere else. Receivers
+// implementing the spec wire shape can branch once on this field.
+func TestControlEnvelope_TypeDiscriminatorIsTopLevel(t *testing.T) {
+	cap := &captureControlPost{}
+	srv := httptest.NewServer(cap.handler())
+	defer srv.Close()
+
+	r := NewWebhookRegistry(WithWebhookAllowPrivateNetworks(true))
+	canonical := canonicalKey("alice", srv.URL, "fake.event", nil)
+	subID := deriveSubscriptionID(canonical)
+	r.Register(canonical, subID, srv.URL, "whsec_"+strings.Repeat("a", 32), 0)
+
+	r.PostGap(canonical, "c1")
+
+	require.Eventually(t, func() bool {
+		cap.mu.Lock()
+		defer cap.mu.Unlock()
+		return cap.hits == 1
+	}, time.Second, 20*time.Millisecond)
+
+	cap.mu.Lock()
+	defer cap.mu.Unlock()
+	body := string(cap.body)
+	// Sanity: `type` appears at the JSON-object root, not inside another
+	// object. Cheap textual check sufficient since marshaling is stable.
+	assert.True(t, strings.HasPrefix(body, `{"type":`),
+		"top-level field MUST be `type`; got body: %s", body)
+}

--- a/experimental/ext/events/delivery_status_test.go
+++ b/experimental/ext/events/delivery_status_test.go
@@ -183,6 +183,154 @@ func TestDeliveryStatus_LastErrorIsCategorical(t *testing.T) {
 	assert.NotEmpty(t, status["failedSince"], "failedSince MUST be set during a current failure run")
 }
 
+// TestSuspend_AfterThresholdConsecutiveFailures verifies the spec
+// suspend rule (§"Webhook Event Delivery" L413 + §"Webhook Delivery
+// Status" L460): after N consecutive delivery failures within a sliding
+// window W, the registry sets Active=false on the target. Subsequent
+// yields don't attempt delivery (covered by separate test below).
+//
+// Without this state machine, a permanently-down receiver would
+// accumulate retry traffic indefinitely — effectively a self-DoS for
+// every subscription pointing at a dead URL.
+func TestSuspend_AfterThresholdConsecutiveFailures(t *testing.T) {
+	// Receiver always returns 500 — every deliver() ends in failure.
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer receiver.Close()
+
+	const threshold = 3
+	r := NewWebhookRegistry(
+		WithWebhookAllowPrivateNetworks(true),
+		WithWebhookSuspendThreshold(threshold),
+		WithWebhookSuspendWindow(10*time.Second),
+	)
+	canonical := []byte("suspend-threshold-test")
+	r.Register(canonical, "sub_st", receiver.URL, "whsec_secret", 0)
+
+	// Drive `threshold` consecutive failed deliveries (each deliver()
+	// internally retries; we count whole-call outcomes, not retries).
+	for i := 0; i < threshold; i++ {
+		r.deliver(r.Targets()[0], "evt_"+string(rune('a'+i)), []byte(`{}`))
+	}
+
+	st := r.DeliveryStatus(canonical)
+	assert.False(t, st.Active,
+		"after %d consecutive failures, target MUST be suspended (Active=false); got %+v", threshold, st)
+}
+
+// TestSuspend_FailuresOutsideWindowDontAccumulate verifies the sliding-
+// window semantic: failures separated by more than W don't count
+// toward the same run. A receiver that has one failure per hour for
+// weeks shouldn't get suspended; only a *current* run of failures
+// does.
+//
+// Implementation strategy here: use a deliberately tiny window so
+// the test runs fast.
+func TestSuspend_FailuresOutsideWindowDontAccumulate(t *testing.T) {
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer receiver.Close()
+
+	const threshold = 3
+	r := NewWebhookRegistry(
+		WithWebhookAllowPrivateNetworks(true),
+		WithWebhookSuspendThreshold(threshold),
+		WithWebhookSuspendWindow(200*time.Millisecond),
+	)
+	canonical := []byte("suspend-window-test")
+	r.Register(canonical, "sub_sw", receiver.URL, "whsec_secret", 0)
+
+	// 2 failures, then sleep past the window, then 2 more.
+	// First-failure-time should reset on the post-sleep failures, so
+	// total counted-toward-current-run = 2 < threshold = 3 → still Active.
+	r.deliver(r.Targets()[0], "evt_1", []byte(`{}`))
+	r.deliver(r.Targets()[0], "evt_2", []byte(`{}`))
+
+	time.Sleep(300 * time.Millisecond) // > 200ms window
+
+	r.deliver(r.Targets()[0], "evt_3", []byte(`{}`))
+	r.deliver(r.Targets()[0], "evt_4", []byte(`{}`))
+
+	st := r.DeliveryStatus(canonical)
+	assert.True(t, st.Active,
+		"failures separated by more than the suspend window MUST NOT accumulate; got %+v", st)
+}
+
+// TestSuspend_SuccessfulRefreshReactivates verifies that re-subscribing
+// (idempotent refresh — same canonical tuple) flips a suspended target
+// back to Active=true, clearing the failure run. Per spec L460: "a
+// successful refresh reactivates."
+//
+// The reactivation path is: client retries subscribe → matches existing
+// canonical key → registry refresh path runs → sees Status.Active=false,
+// resets to true + clears failure state.
+func TestSuspend_SuccessfulRefreshReactivates(t *testing.T) {
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer receiver.Close()
+
+	r := NewWebhookRegistry(
+		WithWebhookAllowPrivateNetworks(true),
+		WithWebhookSuspendThreshold(2),
+		WithWebhookSuspendWindow(10*time.Second),
+	)
+	canonical := []byte("reactivate-test")
+	r.Register(canonical, "sub_react", receiver.URL, "whsec_secret", 0)
+
+	// Drive 2 consecutive failures → suspended.
+	r.deliver(r.Targets()[0], "evt_a", []byte(`{}`))
+	r.deliver(r.Targets()[0], "evt_b", []byte(`{}`))
+	require.False(t, r.DeliveryStatus(canonical).Active, "precondition: target should be suspended")
+
+	// Refresh — same canonical tuple, idempotent re-Register.
+	r.Register(canonical, "sub_react", receiver.URL, "whsec_secret", 0)
+
+	st := r.DeliveryStatus(canonical)
+	assert.True(t, st.Active, "successful refresh MUST reactivate; got %+v", st)
+	assert.Equal(t, DeliveryErrorNone, st.LastError, "refresh MUST clear lastError")
+	assert.Nil(t, st.FailedSince, "refresh MUST clear failedSince")
+}
+
+// TestSuspend_SuspendedTargetSkippedInDeliver verifies that a suspended
+// target is omitted from the broadcast list — yielded events no longer
+// attempt delivery to it. Without this skip, the suspend state would
+// be cosmetic (just a status flag) and the dead receiver would still
+// see retry traffic on every yield.
+func TestSuspend_SuspendedTargetSkippedInDeliver(t *testing.T) {
+	var hits atomic.Int32
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer receiver.Close()
+
+	r := NewWebhookRegistry(
+		WithWebhookAllowPrivateNetworks(true),
+		WithWebhookSuspendThreshold(2),
+		WithWebhookSuspendWindow(10*time.Second),
+	)
+	canonical := []byte("skip-deliver-test")
+	r.Register(canonical, "sub_skip", receiver.URL, "whsec_secret", 0)
+
+	// Drive 2 failures → suspended.
+	r.deliver(r.Targets()[0], "evt_a", []byte(`{}`))
+	r.deliver(r.Targets()[0], "evt_b", []byte(`{}`))
+	require.False(t, r.DeliveryStatus(canonical).Active)
+
+	// Note hits up to here so we measure only what happens AFTER suspension.
+	hitsBeforeSuspendYield := hits.Load()
+
+	// Yield via Deliver — suspended target should be skipped.
+	r.Deliver(MakeEvent("fake.event", "evt_post_suspend", "1", time.Now(), map[string]string{"k": "v"}))
+	time.Sleep(200 * time.Millisecond)
+
+	assert.Equal(t, hitsBeforeSuspendYield, hits.Load(),
+		"suspended target MUST NOT receive new delivery attempts; got %d new hits", hits.Load()-hitsBeforeSuspendYield)
+}
+
 // TestDeliveryStatus_LastErrorBucketsForConnectionRefused verifies the
 // connection_refused bucket — a receiver that's down (refused TCP).
 // Use a known-closed port.

--- a/experimental/ext/events/delivery_status_test.go
+++ b/experimental/ext/events/delivery_status_test.go
@@ -1,0 +1,212 @@
+package events
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ζ-5 — deliveryStatus on events/subscribe refresh response.
+//
+// Spec §"Webhook Delivery Status" L425-460: the registry tracks per-
+// target delivery health. Subscribe refresh response includes:
+//
+//   deliveryStatus: {
+//     active:         bool,
+//     lastDeliveryAt: ISO-8601 string (omitted when never delivered),
+//     lastError:      categorical string (omitted when no failure),
+//     failedSince:    ISO-8601 string (omitted when last attempt OK)
+//   }
+//
+// lastError is from a FIXED CATEGORICAL SET — never raw response bodies,
+// headers, or status lines. The reason: the subscribe response is
+// visible to the subscriber. A receiver returning internal information
+// in its response body would otherwise leak to whoever subscribed.
+// Spec L460: "Servers MUST NOT include raw response data in
+// deliveryStatus.lastError."
+//
+// Allowed categorical values:
+//   connection_refused | timeout | tls_error
+//   http_3xx_redirect  | http_4xx | http_5xx
+//   challenge_failed   | (empty when no failure)
+//
+// First subscribe (no prior attempts) MUST omit deliveryStatus entirely
+// — there's nothing to report and emitting an empty one would just
+// add bytes to every initial subscribe response.
+
+// dispatchSubscribeForStatus is a small helper that drives an
+// events/subscribe call from a test, returning the parsed response
+// result. The caller has already registered + driven deliveries
+// against the target so the refresh path has something to report.
+func dispatchSubscribeForStatus(t *testing.T, srv *server.Server, callbackURL, secret string) map[string]any {
+	t.Helper()
+	params := map[string]any{
+		"name": "fake.event",
+		"delivery": map[string]any{
+			"mode":   "webhook",
+			"url":    callbackURL,
+			"secret": secret,
+		},
+	}
+	raw, err := json.Marshal(params)
+	require.NoError(t, err)
+	resp, err := srv.Dispatch(context.Background(), &core.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "events/subscribe", Params: raw,
+	})
+	require.NoError(t, err)
+	require.Nil(t, resp.Error, "expected success; got %+v", resp.Error)
+
+	body, err := json.Marshal(resp.Result)
+	require.NoError(t, err)
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(body, &m))
+	return m
+}
+
+// TestDeliveryStatus_OmittedOnFirstSubscribe verifies the contract that
+// the subscribe response carries NO deliveryStatus on the initial
+// subscribe — no attempts have happened, nothing to report. Adding an
+// empty status object would just be wire bloat.
+func TestDeliveryStatus_OmittedOnFirstSubscribe(t *testing.T) {
+	srv, _ := buildAuthGateStack(t, "test-principal")
+	resp := dispatchSubscribe(t, srv, validSubscribeParams())
+	require.Nil(t, resp.Error)
+
+	body, _ := json.Marshal(resp.Result)
+	var m map[string]any
+	_ = json.Unmarshal(body, &m)
+	_, has := m["deliveryStatus"]
+	assert.False(t, has,
+		"first subscribe MUST omit deliveryStatus (no prior attempts to report); got %s", string(body))
+}
+
+// TestDeliveryStatus_AfterSuccessPopulatesLastDeliveryAt verifies that
+// after a successful delivery, the next subscribe refresh response
+// includes deliveryStatus.lastDeliveryAt (ISO-8601). active=true,
+// lastError empty/absent, failedSince absent.
+func TestDeliveryStatus_AfterSuccessPopulatesLastDeliveryAt(t *testing.T) {
+	var hits atomic.Int32
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer receiver.Close()
+
+	srv, webhooks := buildAuthGateStack(t, "test-principal")
+
+	// Initial subscribe (won't have status; that's the prior test).
+	params := map[string]any{
+		"name": "fake.event",
+		"delivery": map[string]any{
+			"mode":   "webhook",
+			"url":    receiver.URL,
+			"secret": generateSecret(),
+		},
+	}
+	require.Nil(t, dispatchSubscribe(t, srv, params).Error)
+
+	// Drive one successful delivery.
+	webhooks.Deliver(MakeEvent("fake.event", "evt_1", "1", time.Now(), map[string]string{"k": "v"}))
+	require.Eventually(t, func() bool { return hits.Load() >= 1 },
+		2*time.Second, 20*time.Millisecond, "delivery should have landed")
+
+	// Refresh subscribe — same tuple, idempotent. Response should now
+	// include deliveryStatus.
+	result := dispatchSubscribeForStatus(t, srv, receiver.URL, params["delivery"].(map[string]any)["secret"].(string))
+	status, ok := result["deliveryStatus"].(map[string]any)
+	require.True(t, ok, "refresh response MUST include deliveryStatus after a delivery; got %+v", result)
+	assert.Equal(t, true, status["active"])
+	assert.NotEmpty(t, status["lastDeliveryAt"], "lastDeliveryAt MUST be populated after a delivery")
+	_, hasErr := status["lastError"]
+	assert.False(t, hasErr, "lastError MUST be omitted after a clean delivery; got %v", status["lastError"])
+}
+
+// TestDeliveryStatus_LastErrorIsCategorical verifies that a delivery
+// failure populates lastError with a CATEGORICAL value, not a raw
+// substring of the receiver's response body. Spec L460 mandates this
+// to avoid the subscribe response becoming a response oracle for
+// attacker-chosen URLs.
+func TestDeliveryStatus_LastErrorIsCategorical(t *testing.T) {
+	// Receiver returns 500 with a body that, if leaked, would tell us.
+	const oracleBody = "INTERNAL_SERVER_ORACLE_LEAK"
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(oracleBody))
+	}))
+	defer receiver.Close()
+
+	srv, webhooks := buildAuthGateStack(t, "test-principal")
+	params := map[string]any{
+		"name": "fake.event",
+		"delivery": map[string]any{
+			"mode":   "webhook",
+			"url":    receiver.URL,
+			"secret": generateSecret(),
+		},
+	}
+	require.Nil(t, dispatchSubscribe(t, srv, params).Error)
+
+	webhooks.Deliver(MakeEvent("fake.event", "evt_fail", "1", time.Now(), map[string]string{"k": "v"}))
+	// Wait long enough for the deliver loop to retry-and-fail (3 retries
+	// with backoff 0.5s + 1s + 2s = ~3.5s total).
+	time.Sleep(4 * time.Second)
+
+	result := dispatchSubscribeForStatus(t, srv, receiver.URL, params["delivery"].(map[string]any)["secret"].(string))
+	status, ok := result["deliveryStatus"].(map[string]any)
+	require.True(t, ok, "refresh after failure MUST report deliveryStatus")
+
+	lastErr, _ := status["lastError"].(string)
+	assert.Equal(t, "http_5xx", lastErr,
+		"lastError MUST be the categorical bucket; got %q", lastErr)
+
+	// Stronger assertion: the oracle body must NOT appear ANYWHERE in
+	// the response. Catches future regressions where someone might
+	// accidentally include err.Error() (which Go's http.Client may
+	// include parts of).
+	body, _ := json.Marshal(result)
+	assert.False(t, strings.Contains(string(body), oracleBody),
+		"raw receiver response body MUST NOT leak into deliveryStatus; got %s", string(body))
+	assert.False(t, strings.Contains(string(body), "INTERNAL_SERVER"),
+		"any substring of the receiver body must not leak; got %s", string(body))
+
+	// failedSince should be populated (we have a current run of failures).
+	assert.NotEmpty(t, status["failedSince"], "failedSince MUST be set during a current failure run")
+}
+
+// TestDeliveryStatus_LastErrorBucketsForConnectionRefused verifies the
+// connection_refused bucket — a receiver that's down (refused TCP).
+// Use a known-closed port.
+func TestDeliveryStatus_LastErrorBucketsForConnectionRefused(t *testing.T) {
+	srv, webhooks := buildAuthGateStack(t, "test-principal")
+	// Port 1 is reserved and reliably refuses.
+	deadURL := "http://127.0.0.1:1/sink"
+	params := map[string]any{
+		"name": "fake.event",
+		"delivery": map[string]any{
+			"mode":   "webhook",
+			"url":    deadURL,
+			"secret": generateSecret(),
+		},
+	}
+	require.Nil(t, dispatchSubscribe(t, srv, params).Error)
+
+	webhooks.Deliver(MakeEvent("fake.event", "evt_refused", "1", time.Now(), map[string]string{"k": "v"}))
+	time.Sleep(4 * time.Second) // 3 retries with backoff
+
+	result := dispatchSubscribeForStatus(t, srv, deadURL, params["delivery"].(map[string]any)["secret"].(string))
+	status, ok := result["deliveryStatus"].(map[string]any)
+	require.True(t, ok)
+	lastErr, _ := status["lastError"].(string)
+	assert.Equal(t, "connection_refused", lastErr,
+		"refused TCP MUST classify as connection_refused; got %q", lastErr)
+}

--- a/experimental/ext/events/events.go
+++ b/experimental/ext/events/events.go
@@ -474,7 +474,7 @@ func registerSubscribe(srv *server.Server, sourceMap map[string]EventSource, web
 		if req.Delivery.URL == "" {
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, "delivery.url is required")
 		}
-		if err := ValidateWebhookURL(req.Delivery.URL); err != nil {
+		if err := webhooks.ValidateWebhookURL(req.Delivery.URL); err != nil {
 			return core.NewErrorResponse(id, ErrCodeInvalidCallbackUrl, err.Error())
 		}
 

--- a/experimental/ext/events/events.go
+++ b/experimental/ext/events/events.go
@@ -536,12 +536,52 @@ func registerSubscribe(srv *server.Server, sourceMap map[string]EventSource, web
 		// for security, used only as the X-MCP-Subscription-Id header
 		// value on delivery POSTs (γ-4 wires the header). Knowing the
 		// id grants no operations on the subscription (L378).
-		return core.NewResponse(id, map[string]any{
+		respBody := map[string]any{
 			"id":            derivedID,
 			"cursor":        wireCursor,
 			"refreshBefore": expiresAt.Format(time.RFC3339),
-		})
+		}
+		// ζ-5: include deliveryStatus on refresh response when the target
+		// has prior delivery attempts. Spec §"Webhook Delivery Status"
+		// L425-460. Omitted on first subscribe — there's nothing to
+		// report and an empty object would just be wire bloat.
+		if status, ok := deliveryStatusForResponse(webhooks.DeliveryStatus(canonical)); ok {
+			respBody["deliveryStatus"] = status
+		}
+		return core.NewResponse(id, respBody)
 	})
+}
+
+// deliveryStatusForResponse projects an internal DeliveryStatus into
+// the spec wire shape (§"Webhook Delivery Status" L425-460). Returns
+// (nil, false) when there's nothing to report (no prior attempts).
+//
+// Wire shape:
+//
+//	{
+//	  "active":         bool,
+//	  "lastDeliveryAt": "RFC3339" (omitted if nil),
+//	  "lastError":      "categorical" (omitted if empty),
+//	  "failedSince":    "RFC3339" (omitted if nil)
+//	}
+func deliveryStatusForResponse(s DeliveryStatus) (map[string]any, bool) {
+	// "Nothing to report" = no successes AND no failures.
+	if s.LastDeliveryAt == nil && s.LastError == DeliveryErrorNone && s.FailedSince == nil {
+		return nil, false
+	}
+	out := map[string]any{
+		"active": s.Active,
+	}
+	if s.LastDeliveryAt != nil {
+		out["lastDeliveryAt"] = s.LastDeliveryAt.Format(time.RFC3339)
+	}
+	if s.LastError != DeliveryErrorNone {
+		out["lastError"] = string(s.LastError)
+	}
+	if s.FailedSince != nil {
+		out["failedSince"] = s.FailedSince.Format(time.RFC3339)
+	}
+	return out, true
 }
 
 func registerUnsubscribe(srv *server.Server, webhooks *WebhookRegistry, unsafeAnon string) {

--- a/experimental/ext/events/headers.go
+++ b/experimental/ext/events/headers.go
@@ -171,7 +171,7 @@ func signFor(mode WebhookHeaderMode, msgID string, body []byte, secret string, n
 // "msg_" prefix Stripe / Standard Webhooks examples use, with 16 random
 // bytes as URL-safe base64. Reserved for non-event POSTs (control
 // envelopes) — event deliveries use the event's own eventId so that
-// retries dedup correctly at the receiver. See ζ for control envelopes.
+// retries dedup correctly at the receiver. See ζ-4 for control envelopes.
 func newMessageID() string {
 	var buf [16]byte
 	if _, err := rand.Read(buf[:]); err != nil {
@@ -180,6 +180,23 @@ func newMessageID() string {
 		return "msg_" + strconv.FormatInt(time.Now().UnixNano(), 36)
 	}
 	return "msg_" + base64.RawURLEncoding.EncodeToString(buf[:])
+}
+
+// newControlMessageID mints a Standard-Webhooks-shaped message ID with
+// the type-tagged form msg_<typ>_<random>, used for non-event control
+// envelope POSTs (ζ-4 — type:gap, type:terminated). The type tag lets
+// receivers and operators distinguish control deliveries from event
+// deliveries (which use the event's eventId as webhook-id) without
+// parsing the body.
+//
+// Per spec §"Non-event webhook bodies" L417: control envelopes use the
+// pattern msg_<type>_<random> for webhook-id.
+func newControlMessageID(typ string) string {
+	var buf [12]byte // shorter random suffix; the type prefix carries info
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "msg_" + typ + "_" + strconv.FormatInt(time.Now().UnixNano(), 36)
+	}
+	return "msg_" + typ + "_" + base64.RawURLEncoding.EncodeToString(buf[:])
 }
 
 // VerifyMCPSignature checks an X-MCP-Signature header against body+timestamp.

--- a/experimental/ext/events/identity_handler_test.go
+++ b/experimental/ext/events/identity_handler_test.go
@@ -30,7 +30,9 @@ import (
 func buildAuthGateStack(t *testing.T, unsafeAnon string) (*server.Server, *WebhookRegistry) {
 	t.Helper()
 	srv := server.NewServer(core.ServerInfo{Name: "test", Version: "1.0"})
-	webhooks := NewWebhookRegistry()
+	// ζ-1: tests subscribe to httptest URLs (127.0.0.1:N) — bypass
+	// the production-default SSRF dial guard.
+	webhooks := NewWebhookRegistry(WithWebhookAllowPrivateNetworks(true))
 	Register(Config{
 		Sources:                  []EventSource{fakeSecretValidationSource{}},
 		Webhooks:                 webhooks,
@@ -222,7 +224,10 @@ func TestDelivery_EmitsXMCPSubscriptionIDHeader(t *testing.T) {
 	}))
 	defer callback.Close()
 
-	webhooks := NewWebhookRegistry()
+	// ζ-1: httptest binds to 127.0.0.1; tests that drive an actual
+	// delivery need WithWebhookAllowPrivateNetworks(true) to bypass
+	// the dial-time SSRF guard.
+	webhooks := NewWebhookRegistry(WithWebhookAllowPrivateNetworks(true))
 	canonical := canonicalKey("test-principal", callback.URL, "fake.event", nil)
 	subID := deriveSubscriptionID(canonical)
 	webhooks.Register(canonical, subID, callback.URL, "whsec_"+strings.Repeat("a", 32), 0)

--- a/experimental/ext/events/ssrf_delivery_test.go
+++ b/experimental/ext/events/ssrf_delivery_test.go
@@ -46,10 +46,9 @@ func ssrfTestRegistry(allowPrivate bool, captureLog *captureLog) *WebhookRegistr
 		opts = append(opts, WithWebhookAllowPrivateNetworks(true))
 	}
 	r := NewWebhookRegistry(opts...)
-	r.client = &http.Client{
-		Timeout:   2 * time.Second,
-		Transport: &http.Transport{DialContext: r.dialContextForTest()},
-	}
+	// Shorten the timeout so test failures are fast; preserve the
+	// SSRF Dialer.Control + CheckRedirect from NewWebhookRegistry.
+	r.client.Timeout = 2 * time.Second
 	if captureLog != nil {
 		captureLog.attach(r)
 	}
@@ -199,6 +198,49 @@ func TestDelivery_DialAllowsPublicIPs(t *testing.T) {
 // MakeEvent + the dial test helpers below reference the delivery-failure
 // log channel — confirm a failed dial classifies correctly.
 var _ = io.EOF // keep io import alive for potential future error checks
+
+// TestDelivery_DoesNotFollowRedirects verifies that the webhook
+// http.Client refuses to follow 3xx responses (ζ-2). Without this, a
+// receiver could 302 to an internal address (127.0.0.1, 10.x, etc.)
+// and bypass the dial-time SSRF guard via Go's default 10-redirect
+// follow behavior.
+//
+// Per spec §"Webhook Security" → "SSRF prevention" L464: redirects
+// MUST be explicitly disabled for outbound delivery POSTs.
+func TestDelivery_DoesNotFollowRedirects(t *testing.T) {
+	var hits, redirectHits atomic.Int32
+
+	// Final destination — should NEVER be hit if redirects are disabled.
+	finalSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		redirectHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer finalSrv.Close()
+
+	// Initial receiver — returns a 302 to finalSrv.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Location", finalSrv.URL)
+		w.WriteHeader(http.StatusFound) // 302
+	}))
+	defer srv.Close()
+
+	// Use the loopback escape so we can test the redirect specifically,
+	// not the SSRF dial guard.
+	r := ssrfTestRegistry(true, nil)
+	r.Register([]byte("k"), "sub_test", srv.URL, "whsec_secret", 0)
+	r.Deliver(MakeEvent("fake.event", "evt_1", "1", time.Now(),
+		map[string]string{"text": "hi"}))
+
+	// Wait long enough for the deliver loop to retry-and-fail (3xx
+	// classified as non-retryable per ζ-2 + retry semantics).
+	time.Sleep(300 * time.Millisecond)
+
+	assert.Equal(t, int32(1), hits.Load(),
+		"initial receiver should be POSTed exactly once — 3xx is non-retryable per ζ-2; got %d", hits.Load())
+	assert.Equal(t, int32(0), redirectHits.Load(),
+		"redirect target MUST NOT be followed; got %d follow-up POSTs", redirectHits.Load())
+}
 
 // errIsContextOrConn returns true if the error is the kind of network
 // failure we expect when a dial is allowed-by-SSRF but fails for other

--- a/experimental/ext/events/ssrf_delivery_test.go
+++ b/experimental/ext/events/ssrf_delivery_test.go
@@ -1,0 +1,215 @@
+package events
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ζ-1 — delivery-time SSRF guard.
+//
+// The pre-ζ webhook registry only checked the URL hostname at subscribe
+// time, with a "WARNING: allowed in POC mode" log that allowed loopback
+// through. This is unsafe under DNS rebinding: an attacker registers a
+// public hostname, then changes its DNS to resolve to an internal IP at
+// delivery time. The pre-ζ check has nothing to say about that.
+//
+// ζ-1 moves the check into the http.Client's Dialer.Control callback so
+// it runs on EVERY connect attempt against the resolved IP — TOCTOU-free
+// because the IP we inspect is the same one about to be used for the
+// connect syscall. Per spec §"Webhook Security" → "SSRF prevention" L464.
+
+// captureDeliveryFailure returns a webhook registry configured with a
+// captured-failure log so tests can observe whether a delivery attempt
+// was blocked at the dial layer (vs reaching the server). The blocked-by-
+// SSRF log lines carry a recognizable substring tests can grep.
+//
+// allowPrivate controls WithWebhookAllowPrivateNetworks: false (default
+// for production) means loopback / private ranges are rejected at dial
+// time; true (demos and tests that want to actually deliver to httptest)
+// permits them.
+func ssrfTestRegistry(allowPrivate bool, captureLog *captureLog) *WebhookRegistry {
+	opts := []WebhookOption{}
+	if allowPrivate {
+		opts = append(opts, WithWebhookAllowPrivateNetworks(true))
+	}
+	r := NewWebhookRegistry(opts...)
+	r.client = &http.Client{
+		Timeout:   2 * time.Second,
+		Transport: &http.Transport{DialContext: r.dialContextForTest()},
+	}
+	if captureLog != nil {
+		captureLog.attach(r)
+	}
+	return r
+}
+
+// captureLog is a tiny goroutine-safe log capture used by SSRF tests to
+// observe whether the dial-time check fired. Hooks the registry's deliver
+// loop via the test-only setLogf hook.
+type captureLog struct {
+	mu    sync.Mutex
+	lines []string
+}
+
+func (c *captureLog) attach(r *WebhookRegistry) {
+	r.setLogfForTest(func(format string, args ...any) {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		c.lines = append(c.lines, fmt.Sprintf(format, args...))
+	})
+}
+
+func (c *captureLog) snapshot() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]string, len(c.lines))
+	copy(out, c.lines)
+	return out
+}
+
+func (c *captureLog) containsSSRFBlock() bool {
+	for _, l := range c.snapshot() {
+		if strings.Contains(l, "SSRF") || strings.Contains(l, "blocked") {
+			return true
+		}
+	}
+	return false
+}
+
+// TestDelivery_RejectsLoopbackAtDialTime verifies the dial-time guard
+// rejects 127.0.0.1 — the canonical SSRF target — when the demo escape
+// hatch (WithWebhookAllowPrivateNetworks) is OFF. Pre-ζ this would have
+// connected silently with only a "WARNING" log; the spec requires hard
+// rejection in production.
+func TestDelivery_RejectsLoopbackAtDialTime(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	logCap := &captureLog{}
+	r := ssrfTestRegistry(false, logCap) // allowPrivate=false → loopback BLOCKED
+
+	r.Register([]byte("k"), "sub_test", srv.URL, "whsec_secret", 0)
+	r.Deliver(MakeEvent("fake.event", "evt_1", "1", time.Now(),
+		map[string]string{"text": "hi"}))
+
+	// Give the deliver goroutine a moment to fail.
+	time.Sleep(200 * time.Millisecond)
+
+	assert.True(t, logCap.containsSSRFBlock(),
+		"loopback delivery should have been blocked at dial time; logs were:\n%s",
+		strings.Join(logCap.snapshot(), "\n"))
+}
+
+// TestDelivery_AllowsLoopbackWithEscape verifies the demo escape hatch:
+// WithWebhookAllowPrivateNetworks(true) permits loopback dials so demos
+// can deliver to local httptest servers without standing up public DNS.
+// Counter-test for TestDelivery_RejectsLoopbackAtDialTime.
+func TestDelivery_AllowsLoopbackWithEscape(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	r := ssrfTestRegistry(true, nil) // allowPrivate=true → demo mode
+	r.Register([]byte("k"), "sub_test", srv.URL, "whsec_secret", 0)
+	r.Deliver(MakeEvent("fake.event", "evt_1", "1", time.Now(),
+		map[string]string{"text": "hi"}))
+
+	require.Eventually(t, func() bool { return hits.Load() == 1 },
+		2*time.Second, 20*time.Millisecond,
+		"with the escape hatch, loopback delivery must succeed")
+}
+
+// TestDelivery_DialBlocklistRanges verifies the per-range blocking. We
+// can't bind a server to every range, so we ask the registry's
+// dialContext callback directly with synthetic addresses and verify the
+// classification — what would the Dialer have done? The actual dial
+// path is exercised by the loopback test above; this one pins the
+// per-range CIDR membership.
+func TestDelivery_DialBlocklistRanges(t *testing.T) {
+	r := NewWebhookRegistry() // strict default
+	dial := r.dialContextForTest()
+
+	cases := []struct {
+		name string
+		addr string
+	}{
+		{"IPv4 loopback", "127.0.0.1:80"},
+		{"IPv6 loopback", "[::1]:80"},
+		{"IPv4 link-local", "169.254.169.254:80"}, // AWS metadata service
+		{"IPv4 private 10/8", "10.0.0.1:80"},
+		{"IPv4 private 172.16/12", "172.16.0.1:80"},
+		{"IPv4 private 192.168/16", "192.168.0.1:80"},
+		{"IPv6 link-local", "[fe80::1]:80"},
+		{"IPv6 ULA fc00::/7", "[fc00::1]:80"},
+		{"IPv4-mapped-IPv6 loopback", "[::ffff:127.0.0.1]:80"},
+		{"unspecified IPv4", "0.0.0.0:80"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+			defer cancel()
+			_, err := dial(ctx, "tcp", tc.addr)
+			require.Error(t, err, "%s should be blocked at dial", tc.addr)
+			assert.True(t,
+				strings.Contains(err.Error(), "SSRF") || strings.Contains(err.Error(), "blocked"),
+				"error should mention SSRF/blocked for %s; got: %v", tc.addr, err)
+		})
+	}
+}
+
+// TestDelivery_DialAllowsPublicIPs verifies the counter-test: a
+// recognizably-public IP (8.8.8.8 in this case — Google DNS, won't be
+// dialled to completion because we cancel the ctx, but should NOT be
+// rejected by the SSRF guard).
+func TestDelivery_DialAllowsPublicIPs(t *testing.T) {
+	r := NewWebhookRegistry()
+	dial := r.dialContextForTest()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	_, err := dial(ctx, "tcp", "8.8.8.8:443")
+	// We expect either a context-deadline-exceeded or a connection error,
+	// NOT an SSRF rejection.
+	if err == nil {
+		t.Skip("unexpectedly connected to 8.8.8.8 within 50ms; environment is too fast/cached")
+	}
+	assert.False(t,
+		strings.Contains(err.Error(), "SSRF") || strings.Contains(err.Error(), "blocked"),
+		"public IP must not be SSRF-rejected; got: %v", err)
+}
+
+// MakeEvent + the dial test helpers below reference the delivery-failure
+// log channel — confirm a failed dial classifies correctly.
+var _ = io.EOF // keep io import alive for potential future error checks
+
+// errIsContextOrConn returns true if the error is the kind of network
+// failure we expect when a dial is allowed-by-SSRF but fails for other
+// reasons (timeout, refused, etc.).
+func errIsContextOrConn(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var ne net.Error
+	return errors.As(err, &ne)
+}

--- a/experimental/ext/events/webhook.go
+++ b/experimental/ext/events/webhook.go
@@ -129,10 +129,18 @@ func NewWebhookRegistry(opts ...WebhookOption) *WebhookRegistry {
 	// http.Client wired AFTER options apply so the Dialer.Control callback
 	// can read the resolved allowPrivateNetworks setting. ζ-1 spec
 	// §"Webhook Security" → "SSRF prevention" L464.
+	//
+	// CheckRedirect (ζ-2): explicitly disable the default 10-redirect
+	// follow. A receiver returning 3xx to an internal address would
+	// otherwise bypass the dial-time SSRF guard via Go's redirect chain.
+	// Per spec same paragraph L464.
 	r.client = &http.Client{
 		Timeout: 5 * time.Second,
 		Transport: &http.Transport{
 			DialContext: r.dialContext(),
+		},
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
 		},
 	}
 	return r
@@ -393,6 +401,13 @@ func (r *WebhookRegistry) deliver(target WebhookTarget, eventID string, body []b
 		}
 
 		r.logf("[webhook] delivery to %s returned %d", target.URL, resp.StatusCode)
+		if resp.StatusCode >= 300 && resp.StatusCode < 400 {
+			// ζ-2: 3xx is non-retryable. We disabled redirect-following
+			// via CheckRedirect; a receiver returning 3xx is signalling
+			// "go elsewhere" but we're not allowed to. Re-trying won't
+			// change the response; treat as terminal.
+			return
+		}
 		if resp.StatusCode >= 400 && resp.StatusCode < 500 {
 			return // 4xx = client error, not retryable
 		}

--- a/experimental/ext/events/webhook.go
+++ b/experimental/ext/events/webhook.go
@@ -16,8 +16,10 @@ import (
 )
 
 const (
-	defaultWebhookTTL          = 60 * time.Second // 1 minute for POC (production: longer)
-	defaultWebhookMaxBodyBytes = 256 * 1024       // ζ-3 spec L487
+	defaultWebhookTTL              = 60 * time.Second // 1 minute for POC (production: longer)
+	defaultWebhookMaxBodyBytes     = 256 * 1024       // ζ-3 spec L487
+	defaultWebhookSuspendThreshold = 5                // ζ-6: N consecutive failures
+	defaultWebhookSuspendWindow    = 10 * time.Minute // ζ-6: sliding window W
 )
 
 // WebhookOption configures a WebhookRegistry at construction time.
@@ -42,6 +44,37 @@ func WithWebhookTTL(ttl time.Duration) WebhookOption {
 func WithWebhookHeaderMode(mode WebhookHeaderMode) WebhookOption {
 	return func(r *WebhookRegistry) {
 		r.headerMode = mode
+	}
+}
+
+// WithWebhookSuspendThreshold overrides the count of consecutive
+// delivery failures (within the suspend window) that trips a target
+// into Active=false. Default 5. Pass <=0 to keep the default.
+//
+// Per spec §"Webhook Event Delivery" L413 + §"Webhook Delivery Status"
+// L460: "after repeated failures the server SHOULD set active: false."
+// The spec doesn't fix a number; this option lets deployments tune
+// hysteresis. ζ-6.
+func WithWebhookSuspendThreshold(n int) WebhookOption {
+	return func(r *WebhookRegistry) {
+		if n > 0 {
+			r.suspendThreshold = n
+		}
+	}
+}
+
+// WithWebhookSuspendWindow overrides the sliding window over which
+// consecutive failures count toward suspension. Default 10 minutes.
+// Pass <=0 to keep the default.
+//
+// Failures separated by more than W don't accumulate — a receiver
+// with one failure per hour for weeks shouldn't get suspended; only
+// a current run of failures does. ζ-6.
+func WithWebhookSuspendWindow(d time.Duration) WebhookOption {
+	return func(r *WebhookRegistry) {
+		if d > 0 {
+			r.suspendWindow = d
+		}
 	}
 }
 
@@ -108,6 +141,11 @@ type WebhookTarget struct {
 	// Mutated only via *WebhookRegistry methods under r.mu so the
 	// snapshot returned by Targets()/DeliveryStatus() is consistent.
 	Status DeliveryStatus
+
+	// ζ-6: internal counter for the suspend state machine. Tracks
+	// consecutive failures within the current sliding-window run.
+	// Not surfaced on the wire; the wire-visible signal is Status.Active.
+	failureCount int
 }
 
 // DeliveryStatus is the per-target delivery-health summary surfaced on
@@ -167,8 +205,10 @@ type WebhookRegistry struct {
 	client               *http.Client
 	ttl                  time.Duration
 	headerMode           WebhookHeaderMode
-	allowPrivateNetworks bool // ζ-1: when false (default), Dialer.Control rejects private/loopback IPs
-	maxBodyBytes         int  // ζ-3: outbound POST body cap in bytes; default 256 KiB
+	allowPrivateNetworks bool          // ζ-1: when false (default), Dialer.Control rejects private/loopback IPs
+	maxBodyBytes         int           // ζ-3: outbound POST body cap in bytes; default 256 KiB
+	suspendThreshold     int           // ζ-6: consecutive failures → Active=false; default 5
+	suspendWindow        time.Duration // ζ-6: sliding window over which failures accumulate; default 10min
 
 	// logf is the logging hook used by deliver paths. Defaults to log.Printf;
 	// tests override via setLogfForTest to capture failures (including SSRF
@@ -182,11 +222,13 @@ type WebhookRegistry struct {
 // Override via the With* options.
 func NewWebhookRegistry(opts ...WebhookOption) *WebhookRegistry {
 	r := &WebhookRegistry{
-		targets:      make(map[string]WebhookTarget),
-		ttl:          defaultWebhookTTL,
-		headerMode:   StandardWebhooks,
-		maxBodyBytes: defaultWebhookMaxBodyBytes,
-		logf:         log.Printf,
+		targets:          make(map[string]WebhookTarget),
+		ttl:              defaultWebhookTTL,
+		headerMode:       StandardWebhooks,
+		maxBodyBytes:     defaultWebhookMaxBodyBytes,
+		suspendThreshold: defaultWebhookSuspendThreshold,
+		suspendWindow:    defaultWebhookSuspendWindow,
+		logf:             log.Printf,
 	}
 	for _, o := range opts {
 		o(r)
@@ -331,6 +373,17 @@ func (r *WebhookRegistry) Register(canonicalKey []byte, derivedID, urlStr, secre
 		if maxAgeSeconds > 0 {
 			existing.MaxAgeSeconds = maxAgeSeconds
 		}
+		// ζ-6: a successful refresh reactivates a suspended target per
+		// spec L460. Clear the failure run so deliveries can resume.
+		// Pending events do NOT replay automatically (would re-flood a
+		// recovering receiver); the client signals replay intent via
+		// the next events/poll or by waiting for live events.
+		if !existing.Status.Active {
+			existing.Status.Active = true
+			existing.Status.LastError = DeliveryErrorNone
+			existing.Status.FailedSince = nil
+			existing.failureCount = 0
+		}
 		r.targets[key] = existing
 	} else {
 		r.targets[key] = WebhookTarget{
@@ -359,14 +412,21 @@ func (r *WebhookRegistry) Unregister(canonicalKey []byte) {
 	delete(r.targets, string(canonicalKey))
 }
 
-// Targets returns a snapshot of all non-expired webhook targets.
+// Targets returns a snapshot of all non-expired AND non-suspended
+// webhook targets. Used by Deliver to fan out an event; suspended
+// targets (ζ-6: Active=false after N consecutive failures) are
+// excluded so dead receivers don't keep getting retry traffic.
+//
+// Lookup-by-canonical-key paths (PostGap, PostTerminated) bypass this
+// filter — control envelopes for terminated/gap should still POST to
+// suspended targets if anything (last-gasp signals).
 func (r *WebhookRegistry) Targets() []WebhookTarget {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	now := time.Now()
 	out := make([]WebhookTarget, 0, len(r.targets))
 	for _, t := range r.targets {
-		if t.ExpiresAt.After(now) {
+		if t.ExpiresAt.After(now) && t.Status.Active {
 			out = append(out, t)
 		}
 	}
@@ -432,9 +492,10 @@ const (
 )
 
 // recordDeliverySuccess updates the target's DeliveryStatus after a
-// successful delivery attempt. Active stays true; LastDeliveryAt
-// advances; LastError + FailedSince clear (the current failure run,
-// if any, is over).
+// successful delivery attempt. Active stays/becomes true (clears any
+// prior suspension — ζ-6); LastDeliveryAt advances; LastError +
+// FailedSince clear (the current failure run, if any, is over);
+// failure counter resets to 0.
 func (r *WebhookRegistry) recordDeliverySuccess(canonicalKey []byte, at time.Time) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -447,17 +508,21 @@ func (r *WebhookRegistry) recordDeliverySuccess(canonicalKey []byte, at time.Tim
 	t.Status.LastDeliveryAt = &atCopy
 	t.Status.LastError = DeliveryErrorNone
 	t.Status.FailedSince = nil
+	t.failureCount = 0
 	r.targets[string(canonicalKey)] = t
 }
 
 // recordDeliveryFailure updates the target's DeliveryStatus after the
 // FINAL failed attempt (all retries exhausted). LastError gets the
 // categorical bucket; FailedSince is set on the FIRST failure of a
-// run and preserved across subsequent failures so subscribers can
-// see how long the receiver has been unreachable.
+// CURRENT run (sliding-window resets see ζ-6 suspendWindow) and
+// preserved across subsequent failures so subscribers can see how long
+// the receiver has been unreachable.
 //
-// Active stays as-is here; ζ-6's suspend/reactivate state machine
-// flips Active=false when the failure run hits the configured threshold.
+// Suspend rule (ζ-6): if FailedSince is older than suspendWindow,
+// reset the run (this failure starts a new run). Otherwise, count
+// consecutive failures within the run; on hitting suspendThreshold,
+// flip Active=false.
 func (r *WebhookRegistry) recordDeliveryFailure(canonicalKey []byte, bucket DeliveryErrorBucket) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -465,10 +530,22 @@ func (r *WebhookRegistry) recordDeliveryFailure(canonicalKey []byte, bucket Deli
 	if !ok {
 		return
 	}
+	now := time.Now()
 	t.Status.LastError = bucket
-	if t.Status.FailedSince == nil {
-		now := time.Now()
-		t.Status.FailedSince = &now
+
+	// ζ-6: sliding-window failure counting. If the current run is
+	// older than the window, reset — this failure starts a fresh run.
+	// failureCount is per-target; tracked alongside the wire-visible
+	// DeliveryStatus fields.
+	if t.Status.FailedSince == nil || now.Sub(*t.Status.FailedSince) > r.suspendWindow {
+		startCopy := now
+		t.Status.FailedSince = &startCopy
+		t.failureCount = 1
+	} else {
+		t.failureCount++
+	}
+	if t.failureCount >= r.suspendThreshold {
+		t.Status.Active = false
 	}
 	r.targets[string(canonicalKey)] = t
 }

--- a/experimental/ext/events/webhook.go
+++ b/experimental/ext/events/webhook.go
@@ -15,7 +15,10 @@ import (
 	"time"
 )
 
-const defaultWebhookTTL = 60 * time.Second // 1 minute for POC (production: longer)
+const (
+	defaultWebhookTTL          = 60 * time.Second // 1 minute for POC (production: longer)
+	defaultWebhookMaxBodyBytes = 256 * 1024       // ζ-3 spec L487
+)
 
 // WebhookOption configures a WebhookRegistry at construction time.
 type WebhookOption func(*WebhookRegistry)
@@ -39,6 +42,22 @@ func WithWebhookTTL(ttl time.Duration) WebhookOption {
 func WithWebhookHeaderMode(mode WebhookHeaderMode) WebhookOption {
 	return func(r *WebhookRegistry) {
 		r.headerMode = mode
+	}
+}
+
+// WithWebhookMaxBodyBytes overrides the outbound delivery body cap.
+// Default is 256 KiB per spec §"Webhook Security" → "Delivery profile"
+// L487. Pass <=0 to keep the default.
+//
+// Cap mode is REJECT, not TRUNCATE — truncation would corrupt the
+// HMAC signature and silently drop event content. Events whose
+// serialized envelope exceeds the cap are logged and skipped (will
+// never get smaller on retry).
+func WithWebhookMaxBodyBytes(n int) WebhookOption {
+	return func(r *WebhookRegistry) {
+		if n > 0 {
+			r.maxBodyBytes = n
+		}
 	}
 }
 
@@ -105,6 +124,7 @@ type WebhookRegistry struct {
 	ttl                  time.Duration
 	headerMode           WebhookHeaderMode
 	allowPrivateNetworks bool // ζ-1: when false (default), Dialer.Control rejects private/loopback IPs
+	maxBodyBytes         int  // ζ-3: outbound POST body cap in bytes; default 256 KiB
 
 	// logf is the logging hook used by deliver paths. Defaults to log.Printf;
 	// tests override via setLogfForTest to capture failures (including SSRF
@@ -118,10 +138,11 @@ type WebhookRegistry struct {
 // Override via the With* options.
 func NewWebhookRegistry(opts ...WebhookOption) *WebhookRegistry {
 	r := &WebhookRegistry{
-		targets:    make(map[string]WebhookTarget),
-		ttl:        defaultWebhookTTL,
-		headerMode: StandardWebhooks,
-		logf:       log.Printf,
+		targets:      make(map[string]WebhookTarget),
+		ttl:          defaultWebhookTTL,
+		headerMode:   StandardWebhooks,
+		maxBodyBytes: defaultWebhookMaxBodyBytes,
+		logf:         log.Printf,
 	}
 	for _, o := range opts {
 		o(r)
@@ -341,6 +362,16 @@ func (r *WebhookRegistry) Deliver(event Event) {
 		return
 	}
 
+	// ζ-3: spec L487 caps outbound delivery bodies at 256 KiB (configurable
+	// via WithWebhookMaxBodyBytes). Reject oversized — truncation would
+	// corrupt the HMAC signature and silently drop event content.
+	// Re-trying won't shrink the body, so this is terminal for the event.
+	if len(body) > r.maxBodyBytes {
+		r.logf("[webhook] event %s body %d bytes exceeds cap %d; dropping (will not retry)",
+			event.EventID, len(body), r.maxBodyBytes)
+		return
+	}
+
 	for _, t := range targets {
 		go r.deliver(t, event.EventID, body)
 	}
@@ -406,6 +437,11 @@ func (r *WebhookRegistry) deliver(target WebhookTarget, eventID string, body []b
 			// via CheckRedirect; a receiver returning 3xx is signalling
 			// "go elsewhere" but we're not allowed to. Re-trying won't
 			// change the response; treat as terminal.
+			return
+		}
+		if resp.StatusCode == http.StatusRequestEntityTooLarge {
+			// ζ-3 spec L487: 413 MUST be non-retryable. Receiver
+			// rejects our payload size; retrying won't change that.
 			return
 		}
 		if resp.StatusCode >= 400 && resp.StatusCode < 500 {

--- a/experimental/ext/events/webhook.go
+++ b/experimental/ext/events/webhook.go
@@ -2,13 +2,16 @@ package events
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 )
 
@@ -36,6 +39,32 @@ func WithWebhookTTL(ttl time.Duration) WebhookOption {
 func WithWebhookHeaderMode(mode WebhookHeaderMode) WebhookOption {
 	return func(r *WebhookRegistry) {
 		r.headerMode = mode
+	}
+}
+
+// WithWebhookAllowPrivateNetworks permits outbound webhook deliveries to
+// loopback / private / link-local IP ranges. The default is FALSE (strict);
+// turn this ON for demo and test setups that deliver to local httptest
+// servers, NEVER in production.
+//
+// Per spec §"Webhook Security" → "SSRF prevention" L464, deployments MUST
+// guard against DNS rebinding by checking the resolved IP at dial time.
+// ζ-1's net.Dialer.Control callback rejects:
+//   - 127.0.0.0/8, ::1 (loopback)
+//   - 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 (RFC1918 private IPv4)
+//   - 169.254.0.0/16, fe80::/10 (link-local — includes AWS metadata service)
+//   - fc00::/7 (IPv6 ULA)
+//   - 0.0.0.0, :: (unspecified)
+//   - 224.0.0.0/4, ff00::/8 (multicast)
+//   - 255.255.255.255 (broadcast)
+//   - IPv4-mapped IPv6 forms of any of the above
+//
+// When this option is enabled (allow=true), the guard is bypassed —
+// all of those ranges become dialable. The discord/telegram demos enable
+// this so `make demo` works against local httptest servers.
+func WithWebhookAllowPrivateNetworks(allow bool) WebhookOption {
+	return func(r *WebhookRegistry) {
+		r.allowPrivateNetworks = allow
 	}
 }
 
@@ -70,28 +99,131 @@ type WebhookTarget struct {
 // subscription. Cross-tenant isolation is by construction since
 // principal is part of the key.
 type WebhookRegistry struct {
-	mu         sync.RWMutex
-	targets    map[string]WebhookTarget // keyed by string(canonicalKey)
-	client     *http.Client
-	ttl        time.Duration
-	headerMode WebhookHeaderMode
+	mu                   sync.RWMutex
+	targets              map[string]WebhookTarget // keyed by string(canonicalKey)
+	client               *http.Client
+	ttl                  time.Duration
+	headerMode           WebhookHeaderMode
+	allowPrivateNetworks bool // ζ-1: when false (default), Dialer.Control rejects private/loopback IPs
+
+	// logf is the logging hook used by deliver paths. Defaults to log.Printf;
+	// tests override via setLogfForTest to capture failures (including SSRF
+	// dial-time rejections) for assertions.
+	logf func(format string, args ...any)
 }
 
 // NewWebhookRegistry creates an empty registry with the documented defaults:
-// 5-second HTTP timeout, 60-second TTL, StandardWebhooks signing. Override
-// via the With* options.
+// 5-second HTTP timeout, 60-second TTL, StandardWebhooks signing,
+// SSRF-strict outbound dialing (loopback / private / link-local rejected).
+// Override via the With* options.
 func NewWebhookRegistry(opts ...WebhookOption) *WebhookRegistry {
 	r := &WebhookRegistry{
 		targets:    make(map[string]WebhookTarget),
-		client:     &http.Client{Timeout: 5 * time.Second},
 		ttl:        defaultWebhookTTL,
 		headerMode: StandardWebhooks,
+		logf:       log.Printf,
 	}
 	for _, o := range opts {
 		o(r)
 	}
+	// http.Client wired AFTER options apply so the Dialer.Control callback
+	// can read the resolved allowPrivateNetworks setting. ζ-1 spec
+	// §"Webhook Security" → "SSRF prevention" L464.
+	r.client = &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: &http.Transport{
+			DialContext: r.dialContext(),
+		},
+	}
 	return r
 }
+
+// dialContext returns the net.Dialer.DialContext used by the outbound
+// http.Client. The Dialer's Control callback inspects the resolved
+// IP:port AFTER DNS resolution but BEFORE the connect syscall, rejecting
+// any address that falls in the SSRF blocklist (unless
+// allowPrivateNetworks is set). Per spec §"Webhook Security" → "SSRF
+// prevention" L464.
+//
+// Inspecting at Control rather than resolving manually avoids a TOCTOU
+// where the resolver and the dialer could see different addresses (DNS
+// rebinding); the address passed to Control is the exact one the
+// connect syscall will use.
+func (r *WebhookRegistry) dialContext() func(ctx context.Context, network, addr string) (net.Conn, error) {
+	dialer := &net.Dialer{
+		Timeout: 5 * time.Second,
+		Control: func(network, address string, _ syscall.RawConn) error {
+			if r.allowPrivateNetworks {
+				return nil
+			}
+			host, _, err := net.SplitHostPort(address)
+			if err != nil {
+				return fmt.Errorf("SSRF guard: invalid dial address %q: %w", address, err)
+			}
+			ip := net.ParseIP(host)
+			if ip == nil {
+				return fmt.Errorf("SSRF guard: unresolved dial address %q", address)
+			}
+			if reason := isBlockedIP(ip); reason != "" {
+				return fmt.Errorf("SSRF guard: blocked dial to %s (%s)", ip, reason)
+			}
+			return nil
+		},
+	}
+	return dialer.DialContext
+}
+
+// isBlockedIP returns a non-empty reason string when ip falls in any of
+// the SSRF-blocked ranges. Returns "" for public addresses. Handles
+// IPv4-mapped IPv6 by re-checking the unmapped form.
+//
+// Ranges blocked (must match the WithWebhookAllowPrivateNetworks doc):
+//   - loopback (127.0.0.0/8, ::1)
+//   - RFC1918 private IPv4 (10/8, 172.16/12, 192.168/16)
+//   - link-local (169.254.0.0/16, fe80::/10)
+//   - IPv6 ULA (fc00::/7)
+//   - unspecified (0.0.0.0, ::)
+//   - multicast (224.0.0.0/4, ff00::/8)
+//   - broadcast (255.255.255.255)
+func isBlockedIP(ip net.IP) string {
+	// Normalize IPv4-mapped-IPv6 to IPv4 form so "::ffff:127.0.0.1" is
+	// classified the same as "127.0.0.1".
+	if v4 := ip.To4(); v4 != nil {
+		ip = v4
+	}
+	switch {
+	case ip.IsLoopback():
+		return "loopback"
+	case ip.IsLinkLocalUnicast():
+		return "link-local"
+	case ip.IsLinkLocalMulticast(), ip.IsInterfaceLocalMulticast(), ip.IsMulticast():
+		return "multicast"
+	case ip.IsUnspecified():
+		return "unspecified"
+	case ip.IsPrivate():
+		// Covers RFC1918 (10/8, 172.16/12, 192.168/16) AND IPv6 ULA (fc00::/7).
+		return "private"
+	}
+	// Broadcast — net.IP.IsGlobalUnicast() returns false for it but we
+	// want a clear message.
+	if ip.Equal(net.IPv4bcast) {
+		return "broadcast"
+	}
+	return ""
+}
+
+// dialContextForTest exposes the dialer for unit tests that exercise
+// per-CIDR rejection without spinning up a server in every range.
+func (r *WebhookRegistry) dialContextForTest() func(ctx context.Context, network, addr string) (net.Conn, error) {
+	return r.dialContext()
+}
+
+// setLogfForTest swaps the registry's log hook so tests can capture
+// delivery failures (including SSRF dial-time rejections) for assertions.
+func (r *WebhookRegistry) setLogfForTest(f func(format string, args ...any)) {
+	r.logf = f
+}
+
 
 // Register adds or refreshes a webhook subscription keyed on the spec's
 // canonical tuple (§"Subscription Identity" → "Key composition" L363).
@@ -197,7 +329,7 @@ func (r *WebhookRegistry) Deliver(event Event) {
 
 	body, err := json.Marshal(event)
 	if err != nil {
-		log.Printf("[webhook] failed to marshal event: %v", err)
+		r.logf("[webhook] failed to marshal event: %v", err)
 		return
 	}
 
@@ -221,7 +353,7 @@ func (r *WebhookRegistry) deliver(target WebhookTarget, eventID string, body []b
 
 	for attempt := 0; attempt <= maxRetries; attempt++ {
 		if attempt > 0 {
-			log.Printf("[webhook] retry %d/%d for %s (backoff %v)", attempt, maxRetries, target.URL, backoff)
+			r.logf("[webhook] retry %d/%d for %s (backoff %v)", attempt, maxRetries, target.URL, backoff)
 			time.Sleep(backoff)
 			backoff *= 2
 			if backoff > maxBackoff {
@@ -244,14 +376,14 @@ func (r *WebhookRegistry) deliver(target WebhookTarget, eventID string, body []b
 
 		req, err := http.NewRequest("POST", target.URL, bytes.NewReader(signed.body))
 		if err != nil {
-			log.Printf("[webhook] failed to create request for %s: %v", target.URL, err)
+			r.logf("[webhook] failed to create request for %s: %v", target.URL, err)
 			return // not retryable
 		}
 		signed.applyHeaders(req)
 
 		resp, err := r.client.Do(req)
 		if err != nil {
-			log.Printf("[webhook] delivery to %s failed: %v", target.URL, err)
+			r.logf("[webhook] delivery to %s failed: %v", target.URL, err)
 			continue // retry
 		}
 		resp.Body.Close()
@@ -260,21 +392,26 @@ func (r *WebhookRegistry) deliver(target WebhookTarget, eventID string, body []b
 			return // success
 		}
 
-		log.Printf("[webhook] delivery to %s returned %d", target.URL, resp.StatusCode)
+		r.logf("[webhook] delivery to %s returned %d", target.URL, resp.StatusCode)
 		if resp.StatusCode >= 400 && resp.StatusCode < 500 {
 			return // 4xx = client error, not retryable
 		}
 		// 5xx = server error, retry
 	}
-	log.Printf("[webhook] delivery to %s failed after %d retries, giving up", target.URL, maxRetries)
+	r.logf("[webhook] delivery to %s failed after %d retries, giving up", target.URL, maxRetries)
 }
 
-// ValidateWebhookURL performs basic SSRF validation on a webhook callback URL.
-// Spec: "MUST validate callback URLs at subscribe time" and "SHOULD reject
-// URLs pointing to private/loopback ranges."
-// For this POC we reject obvious loopback and private schemes. Production
-// implementations should also resolve DNS and check the resulting IP.
-func ValidateWebhookURL(rawURL string) error {
+// ValidateWebhookURL is a fail-fast subscribe-time check on a webhook
+// callback URL. Rejects non-http(s) schemes and obvious loopback hostnames
+// unless the registry has WithWebhookAllowPrivateNetworks(true).
+//
+// This is the SUBSCRIBE-time check, not the load-bearing one. The
+// authoritative SSRF guard is the dial-time check in dialContext, which
+// is TOCTOU-safe under DNS rebinding (per spec §"Webhook Security" →
+// "SSRF prevention" L464). ValidateWebhookURL is a UX aid: catches
+// obvious mistakes at subscribe so the client gets -32015 InvalidCallbackUrl
+// immediately rather than a delayed delivery failure.
+func (r *WebhookRegistry) ValidateWebhookURL(rawURL string) error {
 	u, err := url.Parse(rawURL)
 	if err != nil {
 		return fmt.Errorf("invalid URL: %w", err)
@@ -282,11 +419,16 @@ func ValidateWebhookURL(rawURL string) error {
 	if u.Scheme != "http" && u.Scheme != "https" {
 		return fmt.Errorf("unsupported scheme %q (must be http or https)", u.Scheme)
 	}
-	host := strings.ToLower(u.Hostname())
-	if host == "localhost" || host == "127.0.0.1" || host == "::1" || host == "0.0.0.0" {
-		// Allow in test/dev — production should reject these.
-		log.Printf("[webhook] WARNING: loopback webhook URL %s (allowed in POC mode)", rawURL)
+	if r.allowPrivateNetworks {
+		return nil
 	}
+	host := strings.ToLower(u.Hostname())
+	switch host {
+	case "localhost", "127.0.0.1", "::1", "0.0.0.0":
+		return fmt.Errorf("loopback hostnames are not permitted; set WithWebhookAllowPrivateNetworks(true) for demos")
+	}
+	// Hostnames that aren't bare loopback strings get a free pass at
+	// subscribe time — DNS resolution is the dial-time guard's job.
 	return nil
 }
 

--- a/experimental/ext/events/webhook.go
+++ b/experimental/ext/events/webhook.go
@@ -102,7 +102,51 @@ type WebhookTarget struct {
 	Secret        string    // client-supplied HMAC signing secret (whsec_...)
 	ExpiresAt     time.Time // soft-state TTL expiry
 	MaxAgeSeconds int       // δ-3: per-spec replay floor (§"Cursor Lifecycle" L529); 0 = no floor
+
+	// ζ-5: per-target delivery health, surfaced on subscribe refresh
+	// response per spec §"Webhook Delivery Status" L425-460.
+	// Mutated only via *WebhookRegistry methods under r.mu so the
+	// snapshot returned by Targets()/DeliveryStatus() is consistent.
+	Status DeliveryStatus
 }
+
+// DeliveryStatus is the per-target delivery-health summary surfaced on
+// the events/subscribe refresh response per spec §"Webhook Delivery
+// Status" L425-460. Subscribers use it to decide whether to back off,
+// re-create the subscription with a fresh secret, or alert.
+//
+// LastError is a CATEGORICAL string from a fixed set; the spec
+// explicitly forbids raw response bodies / headers / status lines
+// because the subscribe response is visible to the subscriber and
+// arbitrary receiver responses must not become a data oracle. Empty
+// when no failure has happened on the current run.
+//
+// LastDeliveryAt is set to the most recent successful delivery time;
+// nil when never successfully delivered. FailedSince is set on the
+// first failure of a current failure run; nil when the last attempt
+// succeeded. Both timestamps serialize to ISO-8601 (RFC3339).
+type DeliveryStatus struct {
+	Active         bool
+	LastDeliveryAt *time.Time
+	LastError      DeliveryErrorBucket
+	FailedSince    *time.Time
+}
+
+// DeliveryErrorBucket is the spec's categorical lastError set per
+// L460. Values that don't appear in this list MUST NOT leak into the
+// subscribe response.
+type DeliveryErrorBucket string
+
+const (
+	DeliveryErrorNone              DeliveryErrorBucket = ""
+	DeliveryErrorConnectionRefused DeliveryErrorBucket = "connection_refused"
+	DeliveryErrorTimeout           DeliveryErrorBucket = "timeout"
+	DeliveryErrorTLS               DeliveryErrorBucket = "tls_error"
+	DeliveryError3xxRedirect       DeliveryErrorBucket = "http_3xx_redirect"
+	DeliveryError4xx               DeliveryErrorBucket = "http_4xx"
+	DeliveryError5xx               DeliveryErrorBucket = "http_5xx"
+	DeliveryErrorChallengeFailed   DeliveryErrorBucket = "challenge_failed"
+)
 
 // WebhookRegistry tracks outbound webhook subscriptions and delivers events
 // with HMAC-SHA256 signed payloads. Subscriptions have TTL-based soft state
@@ -296,6 +340,10 @@ func (r *WebhookRegistry) Register(canonicalKey []byte, derivedID, urlStr, secre
 			Secret:        secret,
 			ExpiresAt:     expiresAt,
 			MaxAgeSeconds: maxAgeSeconds,
+			// ζ-5: Active defaults to true on first registration. The
+			// suspend state machine in ζ-6 flips this to false after
+			// repeated failures; a successful refresh resets it.
+			Status: DeliveryStatus{Active: true},
 		}
 	}
 	return expiresAt
@@ -383,12 +431,105 @@ const (
 	maxBackoff     = 5 * time.Second
 )
 
+// recordDeliverySuccess updates the target's DeliveryStatus after a
+// successful delivery attempt. Active stays true; LastDeliveryAt
+// advances; LastError + FailedSince clear (the current failure run,
+// if any, is over).
+func (r *WebhookRegistry) recordDeliverySuccess(canonicalKey []byte, at time.Time) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	t, ok := r.targets[string(canonicalKey)]
+	if !ok {
+		return
+	}
+	atCopy := at
+	t.Status.Active = true
+	t.Status.LastDeliveryAt = &atCopy
+	t.Status.LastError = DeliveryErrorNone
+	t.Status.FailedSince = nil
+	r.targets[string(canonicalKey)] = t
+}
+
+// recordDeliveryFailure updates the target's DeliveryStatus after the
+// FINAL failed attempt (all retries exhausted). LastError gets the
+// categorical bucket; FailedSince is set on the FIRST failure of a
+// run and preserved across subsequent failures so subscribers can
+// see how long the receiver has been unreachable.
+//
+// Active stays as-is here; ζ-6's suspend/reactivate state machine
+// flips Active=false when the failure run hits the configured threshold.
+func (r *WebhookRegistry) recordDeliveryFailure(canonicalKey []byte, bucket DeliveryErrorBucket) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	t, ok := r.targets[string(canonicalKey)]
+	if !ok {
+		return
+	}
+	t.Status.LastError = bucket
+	if t.Status.FailedSince == nil {
+		now := time.Now()
+		t.Status.FailedSince = &now
+	}
+	r.targets[string(canonicalKey)] = t
+}
+
+// DeliveryStatus returns a snapshot of the target's delivery health.
+// Returns the zero value when no target matches canonicalKey.
+func (r *WebhookRegistry) DeliveryStatus(canonicalKey []byte) DeliveryStatus {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if t, ok := r.targets[string(canonicalKey)]; ok {
+		return t.Status
+	}
+	return DeliveryStatus{}
+}
+
+// classifyTransportError maps a Go net/http transport-layer error
+// (returned from http.Client.Do when no HTTP response was received) to
+// the categorical bucket spec L460 mandates. NEVER inspects err.Error()
+// substrings beyond the standard library's own type-asserted markers
+// (net.Error, *url.Error wrappers) — keeps the bucket boundaries
+// stable across Go versions and avoids accidentally surfacing receiver-
+// chosen content into the subscribe response.
+func classifyTransportError(err error) DeliveryErrorBucket {
+	if err == nil {
+		return DeliveryErrorNone
+	}
+	// net.Error.Timeout() is the type-safe way to detect deadline
+	// exceeded / i/o timeout without parsing strings.
+	if ne, ok := err.(interface{ Timeout() bool }); ok && ne.Timeout() {
+		return DeliveryErrorTimeout
+	}
+	// Substring match for the OS-level errno text Go wraps. These
+	// strings are stable across Go versions per the standard library
+	// docs but kept as a fallback — the type-safe net.OpError + syscall
+	// inspection would be more robust if we ever needed to distinguish
+	// further.
+	s := err.Error()
+	switch {
+	case strings.Contains(s, "connection refused"):
+		return DeliveryErrorConnectionRefused
+	case strings.Contains(s, "tls:") || strings.Contains(s, "x509:") || strings.Contains(s, "certificate"):
+		return DeliveryErrorTLS
+	}
+	// Default: unclassified network failure. Surface as connection_refused
+	// since it's the most common transport failure and the alternatives
+	// (timeout, tls_error) are already handled above.
+	return DeliveryErrorConnectionRefused
+}
+
 // deliver attempts to POST the event with exponential backoff on failure.
 // eventID is the event's identifier; used as webhook-id (stable across
 // retries so the receiver's dedup works). Spec: SHOULD retry with
 // exponential backoff.
 func (r *WebhookRegistry) deliver(target WebhookTarget, eventID string, body []byte) {
 	backoff := initialBackoff
+	// ζ-5: tracks the last per-attempt failure bucket. Recorded onto
+	// deliveryStatus only after all retries are exhausted (i.e., this
+	// is the FINAL outcome). A transient blip during a successful
+	// retry-cycle would otherwise falsely appear as "current failure"
+	// on the next subscribe refresh.
+	lastErrBucket := DeliveryErrorNone
 
 	for attempt := 0; attempt <= maxRetries; attempt++ {
 		if attempt > 0 {
@@ -423,33 +564,45 @@ func (r *WebhookRegistry) deliver(target WebhookTarget, eventID string, body []b
 		resp, err := r.client.Do(req)
 		if err != nil {
 			r.logf("[webhook] delivery to %s failed: %v", target.URL, err)
+			// Don't record the per-attempt failure on the target yet —
+			// only the FINAL outcome (after all retries exhausted) gets
+			// stored on deliveryStatus. Otherwise transient blips
+			// during a successful retry would falsely show up as
+			// "current failure" on the next subscribe refresh.
+			lastErrBucket = classifyTransportError(err)
 			continue // retry
 		}
 		resp.Body.Close()
 
 		if resp.StatusCode < 300 {
+			r.recordDeliverySuccess(target.CanonicalKey, time.Now())
 			return // success
 		}
 
 		r.logf("[webhook] delivery to %s returned %d", target.URL, resp.StatusCode)
-		if resp.StatusCode >= 300 && resp.StatusCode < 400 {
+		switch {
+		case resp.StatusCode >= 300 && resp.StatusCode < 400:
 			// ζ-2: 3xx is non-retryable. We disabled redirect-following
 			// via CheckRedirect; a receiver returning 3xx is signalling
 			// "go elsewhere" but we're not allowed to. Re-trying won't
 			// change the response; treat as terminal.
+			r.recordDeliveryFailure(target.CanonicalKey, DeliveryError3xxRedirect)
 			return
-		}
-		if resp.StatusCode == http.StatusRequestEntityTooLarge {
+		case resp.StatusCode == http.StatusRequestEntityTooLarge:
 			// ζ-3 spec L487: 413 MUST be non-retryable. Receiver
 			// rejects our payload size; retrying won't change that.
+			r.recordDeliveryFailure(target.CanonicalKey, DeliveryError4xx)
 			return
-		}
-		if resp.StatusCode >= 400 && resp.StatusCode < 500 {
+		case resp.StatusCode >= 400 && resp.StatusCode < 500:
+			r.recordDeliveryFailure(target.CanonicalKey, DeliveryError4xx)
 			return // 4xx = client error, not retryable
 		}
-		// 5xx = server error, retry
+		// 5xx = server error, retry. Bucket so the final-outcome record
+		// (below the retry loop) knows which bucket to record.
+		lastErrBucket = DeliveryError5xx
 	}
 	r.logf("[webhook] delivery to %s failed after %d retries, giving up", target.URL, maxRetries)
+	r.recordDeliveryFailure(target.CanonicalKey, lastErrBucket)
 }
 
 // ValidateWebhookURL is a fail-fast subscribe-time check on a webhook


### PR DESCRIPTION
**All 6 commits landed.** Ready for review (currently still draft — toggle in the GitHub UI when ready to merge). Spec alignment, sixth of seven (α #353, β #355, γ #356, δ #357, ε #368 merged). Tracking: mcpkit#349.

ζ-7 (source-side health signals → \`notifications/events/error\` and \`/terminated\` server emissions) is the deferred follow-up, tracked as issue 376.

## What's in this PR

| # | Change | Spec |
|---|---|---|
| ζ-1 | SSRF revalidation at delivery time via \`net.Dialer.Control\`. Rejects 10 IP families (loopback, RFC1918, link-local, ULA, IPv4-mapped-IPv6, etc.) at the resolved-IP layer — TOCTOU-safe under DNS rebinding. \`WithWebhookAllowPrivateNetworks(bool)\` opt-in for demos. | §"Webhook Security" → "SSRF prevention" L464 |
| ζ-2 | Disable HTTP redirects on outbound deliveries (\`CheckRedirect: ErrUseLastResponse\`). 3xx classified as non-retryable. | Same paragraph L464 |
| ζ-3 | Body size cap (default 256 KiB) — REJECT not TRUNCATE (truncation would corrupt HMAC). 413 from receiver = non-retryable. \`WithWebhookMaxBodyBytes(int)\` option. | §"Webhook Security" → "Delivery profile" L487 |
| ζ-4 | Control envelopes \`{type:"gap", cursor}\` and \`{type:"terminated", error}\` with Standard Webhooks signature + γ-4 \`X-MCP-Subscription-Id\` + \`webhook-id: msg_<typ>_<random>\`. Receiver-side \`OnGap\`/\`OnTerminated\` callbacks in Go SDK; pretty-printed in Python receiver. | §"Non-event webhook bodies" L415-423 |
| ζ-5 | \`deliveryStatus\` field on \`events/subscribe\` refresh response: \`{active, lastDeliveryAt, lastError, failedSince?}\`. \`lastError\` from a categorical fixed set; oracle-body test confirms raw response data NEVER leaks. | §"Webhook Delivery Status" L425-460 |
| ζ-6 | Suspend/reactivate state machine: N consecutive failures within sliding window W → \`active: false\`; successful refresh reactivates and clears state; suspended targets skipped in Deliver fan-out. \`WithWebhookSuspendThreshold(n)\` (default 5) + \`WithWebhookSuspendWindow(d)\` (default 10min). | §"Webhook Event Delivery" L413 + §"Webhook Delivery Status" L460 |

## Design notes

**SSRF check at \`Dialer.Control\` layer.** Inspects resolved IP:port AFTER DNS resolution but BEFORE the connect syscall — TOCTOU-free because the IP we inspect is the same one the syscall will use. Beats resolve-then-dial-manually for the same reason.

**Categorical \`lastError\` is load-bearing for security.** The subscribe response is visible to the subscriber. If a receiver returned internal information in its response body (e.g., Kubernetes internal hostnames in a 5xx error), and we surfaced raw error strings, we'd become a response oracle for any URL the subscriber chooses. \`classifyTransportError\` uses type-asserted markers (\`net.Error.Timeout()\`) and a small substring fallback; never inspects err.Error() in a way that could leak receiver content.

**Suspend uses sliding window + counter.** Spec doesn't fix a number; the threshold/window options let deployments tune hysteresis. The window matters: a receiver with one failure per hour for weeks shouldn't get suspended; only a *current* run does.

**Reactivation does NOT auto-replay pending events.** Successful refresh flips Active=true and clears failure state, but does not re-flood the recovering receiver. The client signals replay intent via the next \`events/poll\` or by waiting for live events. Spec is permissive here; this is the safer default.

## Test sweep

All four event modules pass \`go test -count=1 -race ./...\`:
- \`experimental/ext/events/\`
- \`experimental/ext/events/clients/go/\`
- \`examples/events/discord/\`
- \`examples/events/telegram/\`

23 new tests added across:
- \`ssrf_delivery_test.go\` — 5
- \`body_cap_test.go\` — 4
- \`control_envelope_test.go\` (server) — 3
- \`clients/go/control_envelope_test.go\` (SDK) — 3
- \`delivery_status_test.go\` — 8

0 assertions weakened. Test fixtures across the four modules updated with \`WithWebhookAllowPrivateNetworks(true)\` since httptest binds to 127.0.0.1.

## Out of scope for ζ

- **ζ-7** (\`notifications/events/error\` and \`/terminated\` server emissions wired to the new deliveryStatus + suspend transitions) — tracked as issue 376. Source-side health signaling is a different architectural concern; deferred to a small follow-up PR.
- **\`events/getDeliveryStatus\`** RPC — spec doesn't define one; refresh response is the channel.
- **Per-deployment SSRF allow-list** for hostnames — operator concern; not in spec.