### PR TITLE
feat(conformance): auth-oauth-discovery server-side scenario (Phase 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ make testconf-tasks-v2 # SEP-2663 — fork @ MCPCONFORMANCE_TASKS_V2_PATH + mcpk
 make testconf-mrtr     # SEP-2322 — fork @ MCPCONFORMANCE_MRTR_PATH + mcpkit-local stricter sentinel
 make testconf-list-ttl # SEP-2549 — fork @ MCPCONFORMANCE_LIST_TTL_PATH (5 checks, 3 fixtures)
 make testconf-file-inputs # SEP-2356 — fork @ MCPCONFORMANCE_FILE_INPUTS_PATH (7 checks)
+make testconf-auth-server # MCP authz 2025-11-25 — fork @ MCPCONFORMANCE_AUTH_PATH (5 checks: PRM + AS metadata, Phase 1)
 make testall           # Everything (9 stages, 18 sub-stages) + Keycloak + HTML report
 make audit             # govulncheck + gosec + gitleaks + race
 make tag-push V=vX.Y.Z # Tag root + all sub-modules and push
@@ -55,7 +56,7 @@ Project-wide: `CONSTRAINTS.md`. Per-package: `core/CONSTRAINTS.md`, `server/CONS
 - **Demokit non-interactive + browser steps**: Steps that open a browser and expect user action will fail in `--non-interactive` mode. Interactive mode is the primary path.
 - **Three-state TTL needs `*int` + omitempty**: SEP-2549 distinguishes `nil` (no guidance), `&0` (do not cache), `&N>0` (fresh for N seconds). Plain `int` with omitempty would conflate `nil` with `&0`. Same pattern fits any spec field with explicit-zero semantics.
 - **Conformance suites are brand-neutral**: `conformance/*/` assert what the spec says, not what mcpkit does. mcpkit-specific behavior (e.g., echoing SEP-2243 routing headers on responses) belongs in `server/*_test.go`, not in conformance scenarios. The conformance suites are the marketing — keep them framed as "what any server must do."
-- **`MCPCONFORMANCE_*_PATH` (per-suite, defined in `conformance/Makefile`)**: each `testconf-*` target points at its own worktree of the [`panyam/mcpconformance`](https://github.com/panyam/mcpconformance) fork because different SEPs live on different branches while their upstream PRs are still draft. Defaults (resolved relative to `conformance/Makefile`): `MCPCONFORMANCE_TASKS_V2_PATH` and `MCPCONFORMANCE_MRTR_PATH` → `../conf-template` (`feat/tasks-mrtr-extension`); `MCPCONFORMANCE_FILE_INPUTS_PATH` and `MCPCONFORMANCE_LIST_TTL_PATH` → `../conf-pending` (`pending`). Override per-invocation when a SEP splits to its own branch waiting upstream approval. Each target fail-fasts with a remediation message if its path is missing.
+- **`MCPCONFORMANCE_*_PATH` (per-suite, defined in `conformance/Makefile`)**: each `testconf-*` target points at its own worktree of the [`panyam/mcpconformance`](https://github.com/panyam/mcpconformance) fork because different SEPs live on different branches while their upstream PRs are still draft. Defaults (resolved relative to `conformance/Makefile`): `MCPCONFORMANCE_TASKS_V2_PATH` and `MCPCONFORMANCE_MRTR_PATH` → `../conf-template` (`feat/tasks-mrtr-extension`); `MCPCONFORMANCE_FILE_INPUTS_PATH`, `MCPCONFORMANCE_LIST_TTL_PATH`, and `MCPCONFORMANCE_AUTH_PATH` → `../conf-pending` (`pending`). Override per-invocation when a SEP splits to its own branch waiting upstream approval. Each target fail-fasts with a remediation message if its path is missing.
 
 Module-specific gotchas live in their READMEs.
 

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,9 @@ testconf-list-ttl: ## Run SEP-2549 list-TTL conformance — fork-based, 3 fixtur
 testconf-file-inputs: ## Run SEP-2356 file-inputs conformance — fork-based (delegates to conformance/Makefile)
 	$(MAKE) -C conformance testconf-file-inputs
 
+testconf-auth-server: ## Run server-side auth conformance — fork-based, RFC 9728 + RFC 8414 (delegates to conformance/Makefile)
+	$(MAKE) -C conformance testconf-auth-server
+
 testconf-elicitation: ## Run SEP-1036 elicitation conformance (delegates to conformance/Makefile)
 	$(MAKE) -C conformance testconf-elicitation
 
@@ -168,6 +171,7 @@ testall: ## Run ALL tests (starts Keycloak if needed) + per-stage HTML reports
 	$(call run_stage,8e,9,mrtr-conformance,testconf-mrtr) \
 	$(call run_stage,8f,9,list-ttl-conformance,testconf-list-ttl) \
 	$(call run_stage,8g,9,file-inputs-conformance,testconf-file-inputs) \
+	$(call run_stage,8h,9,auth-server-conformance,testconf-auth-server) \
 	$(call run_stage,9,9,keycloak,testkcl-auto) \
 	echo "" | tee -a $(REPORT_DIR)/run.log; \
 	echo "=== Results: $$PASS passed, $$FAIL failed ===" | tee -a $(REPORT_DIR)/run.log; \
@@ -421,5 +425,5 @@ setup: setup-tools setup-hooks ## Full development setup
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-18s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: build test test-race test-v cover cover-html cover-func cover-all test-auth test-ui test-protogen test-e2e test-experimental test-apps-playwright testkcl testkcl-auto testall test-report smoke testconfall testconf testconfauth testconf-tasks testconf-tasks-v2 testconf-mrtr testconf-list-ttl testconf-file-inputs testconf-elicitation vet lint vulncheck seccheck secrets verify-submodule-deps audit ci ci-full serve serve-streamable serve-both tidy tidy-all bump-root tag tag-push setup-tools setup-hooks setup upkcl downkcl kcllogs build-bridge help
+.PHONY: build test test-race test-v cover cover-html cover-func cover-all test-auth test-ui test-protogen test-e2e test-experimental test-apps-playwright testkcl testkcl-auto testall test-report smoke testconfall testconf testconfauth testconf-tasks testconf-tasks-v2 testconf-mrtr testconf-list-ttl testconf-file-inputs testconf-auth-server testconf-elicitation vet lint vulncheck seccheck secrets verify-submodule-deps audit ci ci-full serve serve-streamable serve-both tidy tidy-all bump-root tag tag-push setup-tools setup-hooks setup upkcl downkcl kcllogs build-bridge help
 .DEFAULT_GOAL := help

--- a/conformance/Makefile
+++ b/conformance/Makefile
@@ -23,15 +23,17 @@ MCPCONFORMANCE_TASKS_V2_PATH    ?= $(abspath $(REPO_ROOT)/../conf-template)
 MCPCONFORMANCE_MRTR_PATH        ?= $(abspath $(REPO_ROOT)/../conf-template)
 MCPCONFORMANCE_FILE_INPUTS_PATH ?= $(abspath $(REPO_ROOT)/../conf-pending)
 MCPCONFORMANCE_LIST_TTL_PATH    ?= $(abspath $(REPO_ROOT)/../conf-pending)
+MCPCONFORMANCE_AUTH_PATH        ?= $(abspath $(REPO_ROOT)/../conf-pending)
 
 .PHONY: test testconfall testconf testconfauth \
         testconf-tasks testconf-tasks-v2 testconf-mrtr \
-        testconf-list-ttl testconf-file-inputs testconf-elicitation help
+        testconf-list-ttl testconf-file-inputs testconf-auth-server \
+        testconf-elicitation help
 
 # Default umbrella — runs every conformance suite. Fork-based suites
 # require their MCPCONFORMANCE_*_PATH worktree to exist (each target
 # fail-fasts with a remediation message if missing).
-test: testconf testconfauth testconf-tasks testconf-tasks-v2 testconf-mrtr testconf-list-ttl testconf-file-inputs ## Run all conformance suites (needs fork worktrees for SEP scenarios)
+test: testconf testconfauth testconf-tasks testconf-tasks-v2 testconf-mrtr testconf-list-ttl testconf-file-inputs testconf-auth-server ## Run all conformance suites (needs fork worktrees for SEP scenarios)
 
 testconfall: testconf testconfauth ## Run base + auth conformance only
 
@@ -104,6 +106,19 @@ testconf-file-inputs: ## Run SEP-2356 file-inputs conformance — fork-based sce
 		FILE_INPUTS_SERVER_URL=http://localhost:18097/mcp \
 		FILE_INPUTS_SERVER_CMD="$(REPO_ROOT)/examples/file-inputs/file-inputs-demo --serve --addr=:18097" \
 		npx vitest run src/scenarios/server/file-inputs/file-inputs.test.ts)
+
+testconf-auth-server: ## Run server-side auth conformance — fork-based scenarios (RFC 9728 PRM + RFC 8414 AS metadata; auto-spawns fixture)
+	@if [ ! -d "$(MCPCONFORMANCE_AUTH_PATH)" ]; then \
+		echo "MCPCONFORMANCE_AUTH_PATH=$(MCPCONFORMANCE_AUTH_PATH) does not exist."; \
+		echo "Clone https://github.com/panyam/mcpconformance there or set MCPCONFORMANCE_AUTH_PATH=<path-to-clone>."; \
+		echo "Default expects the 'pending' branch checked out at ../conf-pending."; \
+		exit 1; \
+	fi
+	@(cd $(REPO_ROOT)/examples/auth && go build -o auth-demo .)
+	(cd $(MCPCONFORMANCE_AUTH_PATH) && npm install --silent && \
+		AUTH_SERVER_URL=http://localhost:18098/mcp \
+		AUTH_SERVER_CMD="$(REPO_ROOT)/examples/auth/auth-demo --serve --addr=:18098" \
+		npx vitest run src/scenarios/server/auth/auth.test.ts)
 
 testconf-elicitation: ## Run elicitation conformance suite (SEP-1036 URL mode + form, requires Node.js, target server must be running)
 	cd $(CONFORMANCE_DIR) && npm install --silent && \


### PR DESCRIPTION
## Summary

Phase 1 of the server-side auth conformance pillar — sibling to tasks-v2 / MRTR / file-inputs / list-ttl. The scenario itself lives on the `panyam/mcpconformance` fork's `pending` branch under `src/scenarios/server/auth/` (commit pushed); this PR adds the mcpkit Makefile target, shim, env var, and testall sub-stage that drive it.

Closes part of mcpkit issue 382 (Phase 1 only; Phase 2/3 follow-ups tracked in the same issue).

## What this covers (Phase 1)

`auth-oauth-discovery` ClientScenario — **read-only OAuth 2.0 discovery, no token flows**. 5 internal checks:

| Check | What it tests |
|---|---|
| `auth-oauth-discovery-prm-root` | GET `/.well-known/oauth-protected-resource` returns 200 + RFC 9728 JSON (`resource`, `authorization_servers`) |
| `auth-oauth-discovery-prm-path-based` | When MCP endpoint is non-root, `/.well-known/oauth-protected-resource{mcpPath}` is also reachable (RFC 9728 §3.1) |
| `auth-oauth-discovery-prm-content-type` | PRM Content-Type: `application/json` |
| `auth-oauth-discovery-as-metadata` | AS metadata reachable + RFC 8414 shape (`issuer`, `token_endpoint`, conditional `authorization_endpoint`) |
| `auth-oauth-discovery-as-metadata-content-type` | AS metadata Content-Type: `application/json` (or INFO when same-origin proxy is absent) |

The `authorization_endpoint` requirement is conditional on `grant_types_supported` per RFC 8414 §2 — a `client_credentials`-only AS (like our `examples/auth/` fixture) doesn't need it.

## Wiring

| | |
|---|---|
| New target | `testconf-auth-server` (delegates to `conformance/Makefile`) |
| New env var | `MCPCONFORMANCE_AUTH_PATH` (default `../conf-pending`, mirrors the other per-suite vars) |
| Fixture | `examples/auth/auth-demo --serve --addr=:18098` (existing) — mounts both well-known endpoints via `auth.MountAuth` |
| testall slot | Sub-stage `8h/9` (group 8 — conformance) |

## Where the scenarios live

Pushed to `panyam/mcpconformance` `pending` branch — commits `a4bb4de` (scenarios) + `39b7892` (style). When the auth pillar stabilizes upstream, we'll cherry-pick into a `feat/auth-extension` branch for a Draft PR alongside PR 262 (tasks/MRTR).

## Test plan

- [x] `make testconf-auth-server` green (5/5 checks against the `examples/auth` fixture)
- [x] `make testall` 19/19 sub-stages green, including the new `8h/9 auth-server-conformance`
- [x] Each existing testconf-* target continues to default to its correct fork worktree

## Roadmap (in `src/scenarios/server/auth/README.md` on `pending`)

| Phase | Scenario | Status |
|---|---|---|
| 1 | `auth-oauth-discovery` (PRM + AS metadata) | shipped here |
| 2 | `auth-jwt-validation` (claim allowlist, audience, expiry, signature) | planned |
| 3 | `auth-scope-step-up` (SEP-2350) | planned |
| 3 | `auth-iss-param` (RFC 9207, paired with mcpkit issue 380) | planned |
| 3 | `auth-enterprise-managed` (RFC 8693 + RFC 7523, paired with mcpkit issue 381) | planned |

Each later phase needs more from the fixture (real AS issuing tokens of specific shapes); Phase 1 sets the floor with read-only discovery so the heavier-fixture decision can be deferred.