### PR TITLE
feat(conformance): auth-jwt-validation server-side scenario (Phase 2)

### DIFF
--- a/conformance/Makefile
+++ b/conformance/Makefile
@@ -107,7 +107,7 @@ testconf-file-inputs: ## Run SEP-2356 file-inputs conformance — fork-based sce
 		FILE_INPUTS_SERVER_CMD="$(REPO_ROOT)/examples/file-inputs/file-inputs-demo --serve --addr=:18097" \
 		npx vitest run src/scenarios/server/file-inputs/file-inputs.test.ts)
 
-testconf-auth-server: ## Run server-side auth conformance — fork-based scenarios (RFC 9728 PRM + RFC 8414 AS metadata; auto-spawns fixture)
+testconf-auth-server: ## Run server-side auth conformance — fork-based scenarios (RFC 9728 PRM + RFC 8414 AS metadata + RFC 6750 Bearer enforcement)
 	@if [ ! -d "$(MCPCONFORMANCE_AUTH_PATH)" ]; then \
 		echo "MCPCONFORMANCE_AUTH_PATH=$(MCPCONFORMANCE_AUTH_PATH) does not exist."; \
 		echo "Clone https://github.com/panyam/mcpconformance there or set MCPCONFORMANCE_AUTH_PATH=<path-to-clone>."; \
@@ -115,10 +115,26 @@ testconf-auth-server: ## Run server-side auth conformance — fork-based scenari
 		exit 1; \
 	fi
 	@(cd $(REPO_ROOT)/examples/auth && go build -o auth-demo .)
-	(cd $(MCPCONFORMANCE_AUTH_PATH) && npm install --silent && \
-		AUTH_SERVER_URL=http://localhost:18098/mcp \
-		AUTH_SERVER_CMD="$(REPO_ROOT)/examples/auth/auth-demo --serve --addr=:18098" \
-		npx vitest run src/scenarios/server/auth/auth.test.ts)
+	@(cd $(MCPCONFORMANCE_AUTH_PATH) && npm install --silent)
+	# Manual spawn: Phase 2's tampered/valid-token checks need a real
+	# token from the fixture's bootstrap endpoint, so we spawn here
+	# (instead of letting vitest auto-spawn) and curl /demo/bootstrap
+	# before invoking the scenarios.
+	@$(REPO_ROOT)/examples/auth/auth-demo --serve --addr=:18098 > /tmp/auth-demo.log 2>&1 & \
+	PID=$$!; \
+	for i in 1 2 3 4 5 6 7 8 9 10; do \
+	  curl -sf http://localhost:18098/.well-known/oauth-protected-resource > /dev/null 2>&1 && break; \
+	  sleep 0.5; \
+	done; \
+	TOK=$$(curl -sf http://localhost:18098/demo/bootstrap | python3 -c 'import json,sys;print(json.load(sys.stdin)["tok_read"])' 2>/dev/null); \
+	(cd $(MCPCONFORMANCE_AUTH_PATH) && \
+	  AUTH_SERVER_URL=http://localhost:18098/mcp \
+	  AUTH_VALID_TOKEN="$$TOK" \
+	  npx vitest run src/scenarios/server/auth/auth.test.ts); \
+	RC=$$?; \
+	kill $$PID 2>/dev/null; \
+	wait $$PID 2>/dev/null; \
+	exit $$RC
 
 testconf-elicitation: ## Run elicitation conformance suite (SEP-1036 URL mode + form, requires Node.js, target server must be running)
 	cd $(CONFORMANCE_DIR) && npm install --silent && \


### PR DESCRIPTION
## Summary

Phase 2 of the server-side auth conformance pillar — RFC 6750 Bearer-token enforcement on auth-gated methods. Builds on Phase 1's discovery scenario (PR 387). Updates issue 382 progress.

The scenarios live on the `panyam/mcpconformance` fork's `pending` branch under `src/scenarios/server/auth/auth.ts` (commits 363a678 + 6fd59b0); this PR wires Phase 2 into the existing `testconf-auth-server` target.

## What Phase 2 covers

`AuthJwtValidationScenario` — 5 internal checks targeting the fixture's `echo` tool (auth-gated, no specific scope):

| Check | What it tests |
|---|---|
| `auth-jwt-validation-no-token-rejected` | `tools/call` without `Authorization` → HTTP 401 |
| `auth-jwt-validation-www-authenticate-shape` | 401 carries `WWW-Authenticate: Bearer ...` (RFC 6750 §3); WARNING when `resource_metadata` parameter missing (RFC 9728 §5.1 SHOULD) |
| `auth-jwt-validation-malformed-token-rejected` | Garbage Bearer token → HTTP 401 |
| `auth-jwt-validation-tampered-token-rejected` | Valid JWT with tampered signature → HTTP 401 (INFO when `AUTH_VALID_TOKEN` unset) |
| `auth-jwt-validation-valid-token-accepted` | Valid token → HTTP not 401 (INFO when `AUTH_VALID_TOKEN` unset) |

Tampered-token check derives a forged JWT from `AUTH_VALID_TOKEN` by flipping the last byte of the signature segment — keeps the JWT structurally valid but breaks signature verification.

## Token-acquisition

`testconf-auth-server` switches from vitest-auto-spawn to manual spawn so the Makefile can curl `/demo/bootstrap` and pass `AUTH_VALID_TOKEN` to vitest. The scenario itself only depends on the env var — other-language fixtures can wire their own bootstrap-fetch.

The scope-gated `echo` tool already exists on the fixture (no fixture-side changes needed).

## Test plan

- [x] `make testconf-auth-server` runs both scenarios (10 checks total: 5 discovery + 5 JWT validation), all green
- [x] `make testall` 8h/9 sub-stage passes (separate flake on stage 1 `TestTaskElicitE2E` is unrelated — passes in 0.4s when run alone)
- [x] Without `AUTH_VALID_TOKEN`, Phase 2's tampered/valid checks emit INFO not FAILURE
- [x] With `AUTH_VALID_TOKEN`, all 5 Phase 2 checks SUCCESS

## Roadmap update (issue 382)

| Phase | Scenario | Status |
|---|---|---|
| 1 | `auth-oauth-discovery` (PRM + AS metadata) | shipped (PR 387) |
| 2 | `auth-jwt-validation` (no-token / malformed / tampered / valid-token) | **shipped here** |
| 2.5 | `auth-jwt-claims` (audience, expiry, issuer — needs fixture token-mint extension) | next |
| 3 | `auth-scope-step-up` (SEP-2350) | planned |
| 3 | `auth-iss-param` (RFC 9207, paired with issue 380) | planned |
| 3 | `auth-enterprise-managed` (RFC 8693 + RFC 7523, paired with issue 381) | planned |

Phase 2.5 needs the fixture to mint deliberately-bad tokens (expired, wrong audience, wrong issuer). That's the next fixture-design decision — likely a `--mint-test-tokens` flag on the auth-demo binary that exposes them via an extended bootstrap response.