### PR TITLE
feat(conformance): auth-jwt-claims server-side scenario (Phase 2.5)

### DIFF
--- a/conformance/Makefile
+++ b/conformance/Makefile
@@ -116,20 +116,28 @@ testconf-auth-server: ## Run server-side auth conformance — fork-based scenari
 	fi
 	@(cd $(REPO_ROOT)/examples/auth && go build -o auth-demo .)
 	@(cd $(MCPCONFORMANCE_AUTH_PATH) && npm install --silent)
-	# Manual spawn: Phase 2's tampered/valid-token checks need a real
-	# token from the fixture's bootstrap endpoint, so we spawn here
-	# (instead of letting vitest auto-spawn) and curl /demo/bootstrap
-	# before invoking the scenarios.
+	# Manual spawn: Phase 2 + 2.5's token-needing checks pull four pre-
+	# minted tokens from the fixture's bootstrap (one valid, three
+	# deliberately-bad-claim variants), so we spawn here (instead of
+	# letting vitest auto-spawn) and curl /demo/bootstrap before
+	# invoking the scenarios.
 	@$(REPO_ROOT)/examples/auth/auth-demo --serve --addr=:18098 > /tmp/auth-demo.log 2>&1 & \
 	PID=$$!; \
 	for i in 1 2 3 4 5 6 7 8 9 10; do \
 	  curl -sf http://localhost:18098/.well-known/oauth-protected-resource > /dev/null 2>&1 && break; \
 	  sleep 0.5; \
 	done; \
-	TOK=$$(curl -sf http://localhost:18098/demo/bootstrap | python3 -c 'import json,sys;print(json.load(sys.stdin)["tok_read"])' 2>/dev/null); \
+	BOOT=$$(curl -sf http://localhost:18098/demo/bootstrap); \
+	TOK_VALID=$$(echo "$$BOOT" | python3 -c 'import json,sys;print(json.load(sys.stdin)["tok_read"])' 2>/dev/null); \
+	TOK_EXPIRED=$$(echo "$$BOOT" | python3 -c 'import json,sys;print(json.load(sys.stdin)["tok_expired"])' 2>/dev/null); \
+	TOK_WRONG_AUD=$$(echo "$$BOOT" | python3 -c 'import json,sys;print(json.load(sys.stdin)["tok_wrong_audience"])' 2>/dev/null); \
+	TOK_WRONG_ISS=$$(echo "$$BOOT" | python3 -c 'import json,sys;print(json.load(sys.stdin)["tok_wrong_issuer"])' 2>/dev/null); \
 	(cd $(MCPCONFORMANCE_AUTH_PATH) && \
 	  AUTH_SERVER_URL=http://localhost:18098/mcp \
-	  AUTH_VALID_TOKEN="$$TOK" \
+	  AUTH_VALID_TOKEN="$$TOK_VALID" \
+	  AUTH_EXPIRED_TOKEN="$$TOK_EXPIRED" \
+	  AUTH_WRONG_AUDIENCE_TOKEN="$$TOK_WRONG_AUD" \
+	  AUTH_WRONG_ISSUER_TOKEN="$$TOK_WRONG_ISS" \
 	  npx vitest run src/scenarios/server/auth/auth.test.ts); \
 	RC=$$?; \
 	kill $$PID 2>/dev/null; \

--- a/examples/auth/common/setup.go
+++ b/examples/auth/common/setup.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/panyam/mcpkit/core"
@@ -53,6 +54,71 @@ func (e *Env) NewValidator(audience string) *auth.JWTValidator {
 func (e *Env) MintToken(subject string, scopes []string) string {
 	claims := jwt.MapClaims{
 		"sub": subject,
+	}
+	if e.AS.APIAuth.JWTAudience != "" {
+		claims["aud"] = e.AS.APIAuth.JWTAudience
+	}
+	if len(scopes) > 0 {
+		claims["scope"] = strings.Join(scopes, " ")
+	}
+	tok, err := e.AS.MintTokenWithClaims(claims)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return tok
+}
+
+// MintExpiredToken creates a properly signed RS256 JWT whose `exp` claim is
+// 1 hour in the past. Conformance fixtures use this to verify that servers
+// reject expired tokens — the signature still verifies (same AS key), but
+// the standard JWT exp validation MUST reject it.
+func (e *Env) MintExpiredToken(subject string, scopes []string) string {
+	now := time.Now()
+	claims := jwt.MapClaims{
+		"sub": subject,
+		"iat": now.Add(-2 * time.Hour).Unix(),
+		"exp": now.Add(-1 * time.Hour).Unix(),
+	}
+	if e.AS.APIAuth.JWTAudience != "" {
+		claims["aud"] = e.AS.APIAuth.JWTAudience
+	}
+	if len(scopes) > 0 {
+		claims["scope"] = strings.Join(scopes, " ")
+	}
+	tok, err := e.AS.MintTokenWithClaims(claims)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return tok
+}
+
+// MintWrongAudienceToken creates a properly signed token whose `aud` claim
+// points at a different resource. Conformance fixtures use this to verify
+// audience enforcement — RFC 7519 requires servers to reject tokens whose
+// aud doesn't match.
+func (e *Env) MintWrongAudienceToken(subject string, scopes []string) string {
+	claims := jwt.MapClaims{
+		"sub": subject,
+		"aud": "https://wrong-audience.example.invalid",
+	}
+	if len(scopes) > 0 {
+		claims["scope"] = strings.Join(scopes, " ")
+	}
+	tok, err := e.AS.MintTokenWithClaims(claims)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return tok
+}
+
+// MintWrongIssuerToken creates a token signed by THIS AS (so the signature
+// verifies against the JWKS at the configured issuer) but whose `iss` claim
+// claims a DIFFERENT issuer. RFC 7519 + standard JWT validation requires
+// servers to reject when iss doesn't match the configured Issuer.
+func (e *Env) MintWrongIssuerToken(subject string, scopes []string) string {
+	claims := jwt.MapClaims{
+		"sub": subject,
+		"iss": "https://wrong-issuer.example.invalid",
 	}
 	if e.AS.APIAuth.JWTAudience != "" {
 		claims["aud"] = e.AS.APIAuth.JWTAudience

--- a/examples/auth/main.go
+++ b/examples/auth/main.go
@@ -50,6 +50,16 @@ type bootstrapInfo struct {
 	TokReadWrite string `json:"tok_read_write"`
 	TokAll       string `json:"tok_all"`
 	TokBob       string `json:"tok_bob"`
+
+	// Deliberately-bad tokens for conformance testing — used by the
+	// SEP-2356 file-inputs / MCP-auth conformance suites in
+	// panyam/mcpconformance. Properly signed by this AS so the JWKS
+	// signature check passes, but each violates one specific RFC 7519
+	// claim that the server MUST reject. Demokit walkthroughs ignore
+	// these fields.
+	TokExpired        string `json:"tok_expired"`
+	TokWrongAudience  string `json:"tok_wrong_audience"`
+	TokWrongIssuer    string `json:"tok_wrong_issuer"`
 }
 
 func runDemo() {
@@ -324,6 +334,13 @@ func serve() {
 	tokAll := env.MintToken("alice", []string{"read", "write", "admin"})
 	tokBob := env.MintToken("bob", []string{"read", "write", "admin"})
 
+	// Pre-mint deliberately-bad tokens for the SEP-2356 / MCP-auth
+	// conformance suites. Each is properly signed (signature passes
+	// JWKS verification) but violates one specific RFC 7519 claim.
+	tokExpired := env.MintExpiredToken("alice", []string{"read"})
+	tokWrongAud := env.MintWrongAudienceToken("alice", []string{"read"})
+	tokWrongIss := env.MintWrongIssuerToken("alice", []string{"read"})
+
 	log.Printf("Auth example on %s", addr)
 	log.Printf("MCP endpoint: %s/mcp", listenURL)
 	log.Printf("Bootstrap:    %s/demo/bootstrap", listenURL)
@@ -342,11 +359,14 @@ func serve() {
 			m.HandleFunc("GET /demo/bootstrap", func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				json.NewEncoder(w).Encode(bootstrapInfo{
-					MCPURL:       listenURL + "/mcp",
-					TokRead:      tokRead,
-					TokReadWrite: tokReadWrite,
-					TokAll:       tokAll,
-					TokBob:       tokBob,
+					MCPURL:           listenURL + "/mcp",
+					TokRead:          tokRead,
+					TokReadWrite:     tokReadWrite,
+					TokAll:           tokAll,
+					TokBob:           tokBob,
+					TokExpired:       tokExpired,
+					TokWrongAudience: tokWrongAud,
+					TokWrongIssuer:   tokWrongIss,
 				})
 			})
 			auth.MountAuth(m, auth.AuthConfig{


### PR DESCRIPTION
## Summary

Phase 2.5 of the server-side auth conformance pillar — RFC 7519 standard claim validation (audience, expiry, issuer). Closes the JWT-validation pillar for issue 382 (Phases 1 + 2 + 2.5 done; Phase 3 starts a new pillar with real OAuth token flows).

The scenarios live on the `panyam/mcpconformance` fork's `pending` branch (commits 4d10872 + db6afdd); this PR extends the auth fixture to mint deliberately-bad-claim tokens and wires them into `testconf-auth-server`.

## What Phase 2.5 covers

`AuthJwtClaimsScenario` — 3 internal checks. Each sends a properly-signed JWT (signature verifies against AS's JWKS) whose claims violate one specific RFC 7519 requirement:

| Check | What it tests |
|---|---|
| `auth-jwt-claims-expired-rejected` | `exp` in the past → HTTP 401 (RFC 7519 §4.1.4) |
| `auth-jwt-claims-wrong-audience-rejected` | `aud` ≠ resource URI → HTTP 401 (RFC 7519 §4.1.3 + MCP authorization spec; mitigates confused-deputy) |
| `auth-jwt-claims-wrong-issuer-rejected` | Token signed by trusted AS but `iss` claim claims different issuer → HTTP 401 (RFC 7519 §4.1.1) |

Each emits INFO when its `AUTH_{EXPIRED,WRONG_AUDIENCE,WRONG_ISSUER}_TOKEN` env var is unset.

## Fixture extension

`examples/auth/`:
- `common/setup.go`: three new mint helpers (`MintExpiredToken`, `MintWrongAudienceToken`, `MintWrongIssuerToken`) using oneauth's `MintTokenWithClaims` to override RFC 7519 defaults (exp/aud/iss).
- `main.go`: `bootstrapInfo` gains three fields; `serve()` pre-mints all four shapes; `/demo/bootstrap` exposes them alongside the existing valid tokens.

The bad tokens don't affect the demokit walkthrough — it still uses `tok_read` / `tok_read_write` / `tok_all` / `tok_bob` and ignores the new fields.

## Wiring

`testconf-auth-server` extracts all four tokens from `/demo/bootstrap` and exports them as `AUTH_VALID_TOKEN` + `AUTH_EXPIRED_TOKEN` + `AUTH_WRONG_AUDIENCE_TOKEN` + `AUTH_WRONG_ISSUER_TOKEN` for vitest.

## Test plan

- [x] `make testconf-auth-server` runs all 3 scenarios (13 checks total: 5 discovery + 5 JWT validation + 3 JWT claims), all green
- [x] Each bad-token shape verified against the fixture: expired → 401 "token is expired", wrong-aud → 401 "invalid audience", wrong-iss → 401 "invalid issuer"
- [x] Without env vars, Phase 2.5's checks emit INFO (not FAILURE)
- [x] `make testall` 8h/9 green (separate flake on stage 1 `TestTaskSampleE2E` is unrelated — same hang-pattern as `TestTaskElicitE2E` from PR 387; both pass in <1s when run alone — pre-existing E2E test flakiness)
- [x] `examples/auth/` demokit walkthrough still works (unchanged behavior; new fields ignored by walkthrough)

## Roadmap update (issue 382)

| Phase | Scenario | Status |
|---|---|---|
| 1 | `auth-oauth-discovery` (PRM + AS metadata) | shipped (PR 387) |
| 2 | `auth-jwt-validation` (no-token / malformed / tampered / valid) | shipped (PR 388) |
| 2.5 | `auth-jwt-claims` (expired / wrong-aud / wrong-iss) | **shipped here** |
| 3 | `auth-scope-step-up` (SEP-2350) | next pillar |
| 3 | `auth-iss-param` (RFC 9207, paired with issue 380) | planned |
| 3 | `auth-enterprise-managed` (RFC 8693 + RFC 7523, paired with issue 381) | planned |

JWT-validation pillar fully closed: 13 checks across signature, structural, and claim validation.

## Note on flaky E2E tests

`TestTaskSampleE2E` and `TestTaskElicitE2E` in `server/` both hang for ~2m and time out under `make testall`'s `unit+coverage` stage but pass in <1s when run alone. Same hang pattern across two PRs now; worth a separate issue/fix that's out of scope here.