### PR TITLE
feat(conformance): auth-scope-step-up (Phase 3a) + JWT-validation flake fix

### DIFF
--- a/conformance/Makefile
+++ b/conformance/Makefile
@@ -129,12 +129,16 @@ testconf-auth-server: ## Run server-side auth conformance — fork-based scenari
 	done; \
 	BOOT=$$(curl -sf http://localhost:18098/demo/bootstrap); \
 	TOK_VALID=$$(echo "$$BOOT" | python3 -c 'import json,sys;print(json.load(sys.stdin)["tok_read"])' 2>/dev/null); \
+	TOK_RW=$$(echo "$$BOOT" | python3 -c 'import json,sys;print(json.load(sys.stdin)["tok_read_write"])' 2>/dev/null); \
+	TOK_FULL=$$(echo "$$BOOT" | python3 -c 'import json,sys;print(json.load(sys.stdin)["tok_all"])' 2>/dev/null); \
 	TOK_EXPIRED=$$(echo "$$BOOT" | python3 -c 'import json,sys;print(json.load(sys.stdin)["tok_expired"])' 2>/dev/null); \
 	TOK_WRONG_AUD=$$(echo "$$BOOT" | python3 -c 'import json,sys;print(json.load(sys.stdin)["tok_wrong_audience"])' 2>/dev/null); \
 	TOK_WRONG_ISS=$$(echo "$$BOOT" | python3 -c 'import json,sys;print(json.load(sys.stdin)["tok_wrong_issuer"])' 2>/dev/null); \
 	(cd $(MCPCONFORMANCE_AUTH_PATH) && \
 	  AUTH_SERVER_URL=http://localhost:18098/mcp \
 	  AUTH_VALID_TOKEN="$$TOK_VALID" \
+	  AUTH_READWRITE_TOKEN="$$TOK_RW" \
+	  AUTH_FULL_TOKEN="$$TOK_FULL" \
 	  AUTH_EXPIRED_TOKEN="$$TOK_EXPIRED" \
 	  AUTH_WRONG_AUDIENCE_TOKEN="$$TOK_WRONG_AUD" \
 	  AUTH_WRONG_ISSUER_TOKEN="$$TOK_WRONG_ISS" \


### PR DESCRIPTION
## Summary

**Phase 3a of the server-side auth conformance pillar** — SEP-2350 + RFC 6750 §3.1 scope enforcement. Plus a flake fix on Phase 2's tampered-token check that's been hitting `make testall` intermittently across the last several auth PRs.

The scenarios live on the `panyam/mcpconformance` fork's `pending` branch (commits a75ac98 + 671fb31 + 239e876); this PR adds 2 env vars to `testconf-auth-server` to drive Phase 3a's scope-level token variants.

## What Phase 3a covers

`AuthScopeStepUpScenario` — 5 internal checks targeting the fixture's `write-tool` (requires `write` scope) and `admin-tool` (requires `admin` scope). Each check initializes a session with the appropriate token before issuing the scope-checked `tools/call`, since scope middleware runs after session resolution.

| Check | What it tests |
|---|---|
| `auth-scope-step-up-insufficient-scope-rejected` | read-only token + write-tool → HTTP 403 (RFC 6750 §3.1) |
| `auth-scope-step-up-www-authenticate-error` | 403 carries `WWW-Authenticate: Bearer error="insufficient_scope"` |
| `auth-scope-step-up-www-authenticate-advertises-scope` | 403 carries `scope="..."` listing missing scope (SEP-2350) |
| `auth-scope-step-up-sufficient-scope-accepted` | read+write token + write-tool → HTTP not 403 |
| `auth-scope-step-up-scope-varies-by-tool` | admin-tool advertises `admin`, write-tool advertises `write` — sanity check for per-operation scope computation |

## JWT-validation flake fix (also on pending)

Phase 2's `auth-jwt-validation-tampered-token-rejected` was failing ~25% of `make testall` runs. Root cause: my tamper logic flipped the **last char** of the JWT signature. RS256 256-byte signatures end in 2 base64 chars where the last encodes only the low 2 bits of the final byte plus 4 padding bits — only chars whose binary is `XX0000` (A/Q/g/w) are valid 1-byte tails. When the original signature ended with 'A', the tamper produced 'B' which is structurally invalid base64 → strict decoders reject with HTTP 400 (malformed) before signature verification gives the expected HTTP 401.

Fix: tamper a char in the **middle** of the signature instead. Middle chars represent full 6-bit base64 groups with no padding constraints. Verified with 5 consecutive `make testconf-auth-server` runs, all 4/4 scenarios passing.

## Wiring

Two new env vars in `testconf-auth-server`:
- `AUTH_READWRITE_TOKEN` (from fixture's `tok_read_write`) — drives sufficient-scope-accepted check
- `AUTH_FULL_TOKEN` (from fixture's `tok_all`) — reserved for future Phase 3 scenarios that exercise admin-only flows

## Test plan

- [x] `make testconf-auth-server` runs all 4 scenarios (18 internal checks: 5 discovery + 5 JWT validation + 3 JWT claims + 5 scope step-up), all green
- [x] **5 consecutive runs** of `make testconf-auth-server`, all clean (flake fix verified)
- [x] `make testall` 19/19 sub-stages green — first fully clean testall in three auth PRs
- [x] Without env vars, Phase 3a's checks emit INFO not FAILURE

## Roadmap update (issue 382)

| Phase | Scenario | Status |
|---|---|---|
| 1 | `auth-oauth-discovery` | ✅ |
| 2 | `auth-jwt-validation` | ✅ |
| 2.5 | `auth-jwt-claims` | ✅ |
| **3a** | **`auth-scope-step-up`** | **shipped here** |
| 3b | `auth-iss-param` (RFC 9207) | next; needs OAuth code-flow driver |
| 3c | `auth-enterprise-managed` (RFC 8693 + RFC 7523) | needs token-exchange flow driver |

**Auth pillar coverage now: 18 internal checks across 4 ClientScenarios.** Phases 3b and 3c need OAuth flow infrastructure in the conformance scenarios — separate fixture-/runner-design call worth proposing upstream once the existing pillars stabilize.

## Note for cross-SDK adopters

The scenarios depend only on `AUTH_*_TOKEN` env vars (brand-neutral contract). Each SDK provides its own fixture exposing the required surface (PRM, scope-gated tools, mint helpers) and its own test runner that bridges its token-acquisition mechanism to those env vars. mcpkit's `examples/auth/` is one reference implementation; nothing prevents Python/Rust/Java SDKs from having theirs.