### PR TITLE
docs(conformance): bump check count for auth Phase 3b/3c (fork-side)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ make testconf-tasks-v2 # SEP-2663 — fork @ MCPCONFORMANCE_TASKS_V2_PATH + mcpk
 make testconf-mrtr     # SEP-2322 — fork @ MCPCONFORMANCE_MRTR_PATH + mcpkit-local stricter sentinel
 make testconf-list-ttl # SEP-2549 — fork @ MCPCONFORMANCE_LIST_TTL_PATH (5 checks, 3 fixtures)
 make testconf-file-inputs # SEP-2356 — fork @ MCPCONFORMANCE_FILE_INPUTS_PATH (7 checks)
-make testconf-auth-server # MCP authz 2025-11-25 — fork @ MCPCONFORMANCE_AUTH_PATH (5 checks: PRM + AS metadata, Phase 1)
+make testconf-auth-server # MCP authz 2025-11-25 — fork @ MCPCONFORMANCE_AUTH_PATH (6 scenarios, 23 checks: 18 active, 5 SKIPPED gaps for unsupported features)
 make testall           # Everything (9 stages, 18 sub-stages) + Keycloak + HTML report
 make audit             # govulncheck + gosec + gitleaks + race
 make tag-push V=vX.Y.Z # Tag root + all sub-modules and push


### PR DESCRIPTION
## Summary

Companion to fork-side commits e15a208 + 12a43cb on `panyam/mcpconformance:pending`, which add **Phase 3b (`auth-iss-param`)** and **Phase 3c (`auth-enterprise-managed`)** scenarios.

mcpkit-side change is doc-only: bump CLAUDE.md's `testconf-auth-server` summary line. No Makefile/fixture changes needed because Phase 3b/3c are pure AS-metadata fetches — they pick up automatically via the existing test runner.

## What just landed (fork side)

- **`AuthIssParamScenario`** (Phase 3b — RFC 9207 / SEP-2468) — 2 checks: AS-metadata advertisement + redirect-iss flow.
- **`AuthEnterpriseManagedScenario`** (Phase 3c — RFC 8693 + RFC 7523) — 3 checks: token-exchange grant advertised, jwt-bearer grant advertised, end-to-end token-exchange flow.

Each gap-emission uses **`SKIPPED`** with a tracking message linking to the relevant mcpkit issue (#380 for 3b, #381 for 3c). When the AS adds the advertisements those checks flip to `SUCCESS` automatically — no scenario-side changes needed. The flow-layer checks flip when an OAuth flow-driver lands in the conformance suite (separate decision).

## Why this is the right pattern

> "Build the tests, mark them as known gaps until the implementation is done."

This documents the conformance surface up-front — anyone reading the scenarios sees what conformance _looks like_ before the implementation lands. As issues #380 / #381 progress, the SKIPPED messages grow stale ("we still see this") which prompts action. testall stays green throughout (SKIPPED isn't FAILURE).

Analogous to mcpkit's existing `conformance/baseline.yml` for the upstream client suite — the same idea, just inline per-check rather than in a separate baseline file.

## Auth pillar status

| Phase | Scenario | Checks | Status |
|---|---|---|---|
| 1 | `auth-oauth-discovery` | 5 | ✅ active |
| 2 | `auth-jwt-validation` | 5 | ✅ active |
| 2.5 | `auth-jwt-claims` | 3 | ✅ active |
| 3a | `auth-scope-step-up` | 5 | ✅ active |
| 3b | `auth-iss-param` | 2 | 🟡 1 SKIPPED (paired with #380) + 1 SKIPPED (flow driver) |
| 3c | `auth-enterprise-managed` | 3 | 🟡 2 SKIPPED (paired with #381) + 1 SKIPPED (flow driver) |

**Totals: 6 ClientScenarios, 23 internal checks — 18 active, 5 SKIPPED (gaps tracked).**

## Test plan

- [x] `make testall` 19/19 sub-stages green (SKIPPED treated as pass per `auth.test.ts`'s failure-filter)
- [x] Per-check inspection confirms 18 SUCCESS / 5 SKIPPED / 0 FAILURE / 0 WARNING
- [x] Each SKIPPED message includes the tracking issue link (#380 / #381) and the trigger condition that would flip it to active

## Closes part of issue 382

Phase 3 trio fully shipped. Remaining work is in the **implementations** (not the conformance suite):
- mcpkit issue 380 — RFC 9207 iss support → flips 1 SKIPPED to SUCCESS in 3b
- mcpkit issue 381 — RFC 8693 + RFC 7523 grants → flips 2 SKIPPED to SUCCESS in 3c
- An OAuth flow-driver in the conformance suite → flips the 2 flow-layer SKIPPEDs to active checks