### PR TITLE
feat(auth): drive end-to-end token-exchange flow check (Phase 3c)

### DIFF
--- a/conformance/Makefile
+++ b/conformance/Makefile
@@ -134,6 +134,8 @@ testconf-auth-server: ## Run server-side auth conformance — fork-based scenari
 	TOK_EXPIRED=$$(echo "$$BOOT" | python3 -c 'import json,sys;print(json.load(sys.stdin)["tok_expired"])' 2>/dev/null); \
 	TOK_WRONG_AUD=$$(echo "$$BOOT" | python3 -c 'import json,sys;print(json.load(sys.stdin)["tok_wrong_audience"])' 2>/dev/null); \
 	TOK_WRONG_ISS=$$(echo "$$BOOT" | python3 -c 'import json,sys;print(json.load(sys.stdin)["tok_wrong_issuer"])' 2>/dev/null); \
+	TOK_UPSTREAM=$$(echo "$$BOOT" | python3 -c 'import json,sys;print(json.load(sys.stdin)["tok_upstream_assertion"])' 2>/dev/null); \
+	AS_TOKEN_ENDPOINT=$$(curl -sf http://localhost:18098/.well-known/oauth-authorization-server | python3 -c 'import json,sys;print(json.load(sys.stdin)["token_endpoint"])' 2>/dev/null); \
 	(cd $(MCPCONFORMANCE_AUTH_PATH) && \
 	  AUTH_SERVER_URL=http://localhost:18098/mcp \
 	  AUTH_VALID_TOKEN="$$TOK_VALID" \
@@ -142,6 +144,8 @@ testconf-auth-server: ## Run server-side auth conformance — fork-based scenari
 	  AUTH_EXPIRED_TOKEN="$$TOK_EXPIRED" \
 	  AUTH_WRONG_AUDIENCE_TOKEN="$$TOK_WRONG_AUD" \
 	  AUTH_WRONG_ISSUER_TOKEN="$$TOK_WRONG_ISS" \
+	  AUTH_SUBJECT_ASSERTION_TOKEN="$$TOK_UPSTREAM" \
+	  AUTH_AS_TOKEN_ENDPOINT="$$AS_TOKEN_ENDPOINT" \
 	  npx vitest run src/scenarios/server/auth/auth.test.ts); \
 	RC=$$?; \
 	kill $$PID 2>/dev/null; \

--- a/examples/auth/common/setup.go
+++ b/examples/auth/common/setup.go
@@ -20,11 +20,23 @@ import (
 	"github.com/panyam/oneauth/testutil"
 )
 
+// UpstreamIdpIssuer is the iss claim value the fixture's AS will accept
+// on RFC 7523 §2.1 jwt-bearer assertions and RFC 8693 token-exchange
+// subject_tokens. Stable per-process so MintUpstreamAssertion produces
+// JWTs the AS validates.
+const UpstreamIdpIssuer = "https://test-upstream-idp.example.invalid"
+
 // Env holds the shared auth infrastructure for an example.
 type Env struct {
 	AS        *testutil.TestAuthServer
 	Validator *auth.JWTValidator
 	Scopes    []string
+
+	// upstreamKey is the RSA private key for the synthetic
+	// UpstreamIdpIssuer the fixture trusts. Used by MintUpstreamAssertion
+	// to sign assertions for the conformance suite's RFC 7523 / RFC 8693
+	// flow-layer checks. Process-local — never persisted.
+	upstreamKey *rsa.PrivateKey
 }
 
 // NewEnv creates an in-process authorization server with JWKS + token endpoint.
@@ -49,7 +61,7 @@ func NewEnv(scopes []string) *Env {
 		testutil.WithScopes(scopes),
 		testutil.WithIssParameterSupported(true),
 		testutil.WithTrustedAssertionIssuers([]apiauth.TrustedAssertionIssuer{{
-			Issuer:             "https://test-upstream-idp.example.invalid",
+			Issuer:             UpstreamIdpIssuer,
 			PublicKey:          &upstreamKey.PublicKey,
 			AcceptedAlgorithms: []string{"RS256"},
 		}}),
@@ -57,7 +69,7 @@ func NewEnv(scopes []string) *Env {
 	if err != nil {
 		log.Fatal(err)
 	}
-	return &Env{AS: as, Scopes: scopes}
+	return &Env{AS: as, Scopes: scopes, upstreamKey: upstreamKey}
 }
 
 // NewValidator creates a JWTValidator pointed at the AS's JWKS.
@@ -73,6 +85,43 @@ func (e *Env) NewValidator(audience string) *auth.JWTValidator {
 	v.Start()
 	e.Validator = v
 	return v
+}
+
+// MintUpstreamAssertion signs a JWT with the synthetic upstream IdP's
+// private key (UpstreamIdpIssuer), suitable for use as an
+// `assertion` parameter on a jwt-bearer (RFC 7523 §2.1) grant or as a
+// `subject_token` (subject_token_type=jwt) on a token-exchange
+// (RFC 8693) grant at the AS's token endpoint.
+//
+// The audience matches APIAuth.JWTAudience (the AS's configured
+// audience identifier). RFC 7523 §3 requires the assertion's `aud` to
+// identify the AS that will accept it; oneauth's validator defaults
+// the expected audience to JWTAudience when the trusted-issuer entry
+// has no Audiences pinned (which is our setup), so this matches.
+//
+// iat / exp are set to a 5-min validity window. nbf is unset (the jwt
+// library treats absent nbf as "no not-before constraint", which
+// avoids clock-skew flakes in CI).
+//
+// Used by the panyam/mcpconformance suite's flow-layer Phase 3c check
+// (auth-enterprise-managed-token-exchange-flow-shape) and is exposed
+// via /demo/bootstrap as `tok_upstream_assertion` so the conformance
+// test runner can read it without re-implementing the signing logic.
+func (e *Env) MintUpstreamAssertion(subject string) string {
+	now := time.Now()
+	claims := jwt.MapClaims{
+		"iss": UpstreamIdpIssuer,
+		"sub": subject,
+		"aud": e.AS.APIAuth.JWTAudience,
+		"iat": now.Unix(),
+		"exp": now.Add(5 * time.Minute).Unix(),
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	signed, err := tok.SignedString(e.upstreamKey)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return signed
 }
 
 // MintToken creates a valid RS256 JWT for the given subject and scopes,

--- a/examples/auth/main.go
+++ b/examples/auth/main.go
@@ -57,9 +57,18 @@ type bootstrapInfo struct {
 	// signature check passes, but each violates one specific RFC 7519
 	// claim that the server MUST reject. Demokit walkthroughs ignore
 	// these fields.
-	TokExpired        string `json:"tok_expired"`
-	TokWrongAudience  string `json:"tok_wrong_audience"`
-	TokWrongIssuer    string `json:"tok_wrong_issuer"`
+	TokExpired       string `json:"tok_expired"`
+	TokWrongAudience string `json:"tok_wrong_audience"`
+	TokWrongIssuer   string `json:"tok_wrong_issuer"`
+
+	// TokUpstreamAssertion is a JWT signed by a synthetic upstream IdP
+	// the AS trusts (UpstreamIdpIssuer in common/setup.go). The
+	// conformance suite uses this as a `subject_token` for the RFC 8693
+	// token-exchange flow check (Phase 3c
+	// auth-enterprise-managed-token-exchange-flow-shape) — POSTed to
+	// /api/token with grant_type=token-exchange + subject_token_type=jwt
+	// to verify the token-exchange response shape per RFC 8693 §2.2.
+	TokUpstreamAssertion string `json:"tok_upstream_assertion"`
 }
 
 func runDemo() {
@@ -341,6 +350,12 @@ func serve() {
 	tokWrongAud := env.MintWrongAudienceToken("alice", []string{"read"})
 	tokWrongIss := env.MintWrongIssuerToken("alice", []string{"read"})
 
+	// Pre-mint an upstream-IdP-style assertion the AS trusts. Used by
+	// the panyam/mcpconformance Phase 3c
+	// auth-enterprise-managed-token-exchange-flow-shape check as the
+	// `subject_token` parameter for the RFC 8693 token-exchange grant.
+	tokUpstreamAssertion := env.MintUpstreamAssertion("alice")
+
 	log.Printf("Auth example on %s", addr)
 	log.Printf("MCP endpoint: %s/mcp", listenURL)
 	log.Printf("Bootstrap:    %s/demo/bootstrap", listenURL)
@@ -359,14 +374,15 @@ func serve() {
 			m.HandleFunc("GET /demo/bootstrap", func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				json.NewEncoder(w).Encode(bootstrapInfo{
-					MCPURL:           listenURL + "/mcp",
-					TokRead:          tokRead,
-					TokReadWrite:     tokReadWrite,
-					TokAll:           tokAll,
-					TokBob:           tokBob,
-					TokExpired:       tokExpired,
-					TokWrongAudience: tokWrongAud,
-					TokWrongIssuer:   tokWrongIss,
+					MCPURL:               listenURL + "/mcp",
+					TokRead:              tokRead,
+					TokReadWrite:         tokReadWrite,
+					TokAll:               tokAll,
+					TokBob:               tokBob,
+					TokExpired:           tokExpired,
+					TokWrongAudience:     tokWrongAud,
+					TokWrongIssuer:       tokWrongIss,
+					TokUpstreamAssertion: tokUpstreamAssertion,
 				})
 			})
 			auth.MountAuth(m, auth.AuthConfig{


### PR DESCRIPTION
## Summary

Closes the last metadata-and-flow-layer SKIPPED for Phase 3c (RFC 8693 token-exchange) by extending the auth fixture to mint an upstream-IdP-style assertion and the conformance Makefile to plumb it through to the scenario. Closes part of #381 and contributes to #382.

After this PR + the matching scenario commit (af4ebc7 + 77bbc04 on `panyam/mcpconformance:pending`), the auth pillar runs **22 active / 1 SKIPPED** internal checks (down from 21/2). The remaining SKIPPED is `auth-iss-param-redirect-carries-iss` (Phase 3b flow-layer) — needs either oneauth's `/authorize` endpoint or a Keycloak-fronted fixture path, both deferred.

## Three coordinated changes

### 1. Fixture: mint an upstream assertion (`examples/auth/`)

`examples/auth/common/setup.go`:
- New `UpstreamIdpIssuer` const = `"https://test-upstream-idp.example.invalid"` (matches what we register as the trusted issuer)
- `Env` gains an `upstreamKey *rsa.PrivateKey` (process-local — never persisted)
- `MintUpstreamAssertion(subject) string` signs a JWT with that key, audience matching `APIAuth.JWTAudience` so the AS validator accepts it

`examples/auth/main.go`:
- `bootstrapInfo` gains `tok_upstream_assertion` field
- `serve()` pre-mints an alice assertion and exposes it via `/demo/bootstrap`

### 2. Conformance Makefile (`conformance/Makefile testconf-auth-server`)

Two new env vars passed to vitest:
- `AUTH_SUBJECT_ASSERTION_TOKEN` — extracted from `tok_upstream_assertion` in the bootstrap response
- `AUTH_AS_TOKEN_ENDPOINT` — resolved from the AS metadata's `token_endpoint` field (typically off-origin from the resource server, so we can't infer it from the MCP server URL)

### 3. Conformance scenario (panyam/mcpconformance:pending, already pushed)

`auth-enterprise-managed-token-exchange-flow-shape` now drives:

```
POST <AS token_endpoint>
  grant_type=urn:ietf:params:oauth:grant-type:token-exchange
  subject_token=<AUTH_SUBJECT_ASSERTION_TOKEN>
  subject_token_type=urn:ietf:params:oauth:token-type:jwt
```

…and verifies the RFC 8693 §2.2 response shape:
- `access_token` (REQUIRED, non-empty string)
- `issued_token_type` (REQUIRED — distinct from other grants)
- `token_type` = "Bearer" (REQUIRED for access_token issued_token_type)
- `expires_in` (RECOMMENDED — not failed when absent)

Falls back to SKIPPED when either env var is unset, with a clear "couldn't run" message rather than failing.

## Test plan

- [x] Manual round-trip via curl: assertion → token-exchange → 200 + RFC 8693 §2.2 shape
- [x] Per-check inspection: with env vars set, all 3 Phase 3c checks SUCCESS; without, the flow-layer one SKIPPED (other two SUCCESS)
- [x] `make testall`: 8h/9 auth-server-conformance green
- [ ] Unrelated stage 8e (mrtr-conformance) failure on this branch — see note below

## Unrelated mrtr regression on this branch (not introduced here)

`make testall` shows stage 8e (mrtr-conformance) failing with `resultType MUST be "input_required"; got "incomplete"`. This is a SEP-2322 spec-drift mismatch: the conformance scenarios on `panyam/mcpconformance:pending` flipped `MRTR_INPUT_REQUIRED_RESULT_TYPE` from `"incomplete"` to `"input_required"` per merged SEP-2322 commit `de6d76fb`, but mcpkit's `examples/mrtr` fixture still emits `"incomplete"`. **Separate fix in `examples/mrtr`** (and possibly `server/tasks_*` if MRTR core types ride on the same discriminator), not in scope here.

## Auth pillar status after merge

| Phase | Check | Status |
|---|---|---|
| 1 | `auth-oauth-discovery` | ✅ active |
| 2 | `auth-jwt-validation` | ✅ active |
| 2.5 | `auth-jwt-claims` | ✅ active |
| 3a | `auth-scope-step-up` | ✅ active |
| 3b | `auth-iss-param-as-metadata-advertises-support` | ✅ active |
| **3c** | **`auth-enterprise-managed-token-exchange-grant-supported`** | **✅ active** |
| **3c** | **`auth-enterprise-managed-jwt-bearer-grant-supported`** | **✅ active** |
| **3c** | **`auth-enterprise-managed-token-exchange-flow-shape`** | **✅ active (this PR)** |
| 3b | `auth-iss-param-redirect-carries-iss` | 🟡 SKIPPED (deferred — needs oneauth `/authorize` or Keycloak fixture) |

**6 ClientScenarios, 23 internal checks — 22 active / 1 SKIPPED.**