### PR TITLE
feat(events): η-1 + η-2 hook surface + poll-lease foundation

### DIFF
--- a/experimental/ext/events/events.go
+++ b/experimental/ext/events/events.go
@@ -74,6 +74,20 @@ type EventDef struct {
 	// Tool / Resource / Prompt. Sources set it once at construction
 	// and the library surfaces it on events/list.
 	Meta map[string]any `json:"_meta,omitempty"`
+
+	// Per-subscription author hooks (η-2). All four are zero-value-
+	// friendly — nil means baseline behavior (deliver to all,
+	// passthrough, no lifecycle work). Tagged json:"-" because
+	// EventDef is JSON-serialized for events/list and function
+	// fields neither serialize nor belong on the wire.
+	//
+	// Wiring is in the η-3 / η-4 sub-PRs; this PR ships the surface
+	// and panic-recovery wrappers. See docs/EVENTS_ETA_PLAN.md
+	// Q1-Q4 for the design, and hooks.go for the function types.
+	Match         MatchFunc       `json:"-"`
+	Transform     TransformFunc   `json:"-"`
+	OnSubscribe   SubscribeFunc   `json:"-"`
+	OnUnsubscribe UnsubscribeFunc `json:"-"`
 }
 
 // PollResult holds the result of a cursor-based poll from an event source.
@@ -205,6 +219,19 @@ type Config struct {
 	// the spec-recommended 30s. Override to a smaller value in tests
 	// that need to observe heartbeats quickly.
 	StreamHeartbeatInterval time.Duration
+
+	// PollLeases tracks poll-mode subscriptions as ephemeral leases
+	// so on_subscribe / on_unsubscribe can fire consistently across
+	// delivery modes (η-1 — foundation for η-3's lifecycle wiring).
+	// Spec §"Server SDK Guidance" → "Unsubscribe timing by mode"
+	// L707-715.
+	//
+	// nil leaves Register to construct a default table (5 minute
+	// TTL, no hooks) — equivalent to "infrastructure present, no
+	// authors plugged in yet". Authors that want lifecycle hooks
+	// or a different TTL construct one explicitly via
+	// NewPollLeaseTable + WithPollLease* options and pass it here.
+	PollLeases *PollLeaseTable
 }
 
 // Register hooks up events/list, events/poll, events/subscribe, and
@@ -233,8 +260,13 @@ func Register(cfg Config) {
 		}
 	}
 
+	leases := cfg.PollLeases
+	if leases == nil {
+		leases = NewPollLeaseTable()
+	}
+
 	registerList(srv, sources)
-	registerPoll(srv, sourceMap)
+	registerPoll(srv, sourceMap, cfg.UnsafeAnonymousPrincipal, leases)
 	registerStream(srv, sourceMap, cfg.UnsafeAnonymousPrincipal, cfg.StreamHeartbeatInterval)
 	if webhooks != nil {
 		registerSubscribe(srv, sourceMap, webhooks, cfg.UnsafeAnonymousPrincipal)
@@ -304,7 +336,7 @@ func registerList(srv *server.Server, sources []EventSource) {
 	})
 }
 
-func registerPoll(srv *server.Server, sourceMap map[string]EventSource) {
+func registerPoll(srv *server.Server, sourceMap map[string]EventSource, unsafeAnon string, leases *PollLeaseTable) {
 	srv.HandleMethod("events/poll", func(ctx core.MethodContext, id json.RawMessage, params json.RawMessage) *core.Response {
 		// Spec §"Poll-Based Delivery" → "Request: events/poll" L139-149:
 		// flat top-level shape — no subscriptions[] wrapper. Phase 1 dropped
@@ -343,6 +375,23 @@ func registerPoll(srv *server.Server, sourceMap map[string]EventSource) {
 		if !ok {
 			return core.NewErrorResponse(id, ErrCodeEventNotFound, "EventNotFound")
 		}
+
+		// η-1: poll-lease bookkeeping. The lease keys on
+		// (principal-or-anon, name, paramsHash) per spec L707.
+		// resolvePrincipal returns "" when there's no auth claim AND
+		// no UnsafeAnonymousPrincipal fallback — that empty string
+		// IS the shared-anon slot the spec describes for
+		// unauthenticated servers. We deliberately ignore the ok
+		// flag here: poll has no spec-mandated reject rule, unlike
+		// subscribe / stream.
+		//
+		// Touch fires OnCreate the first time a (principal, name,
+		// params) tuple is seen and renews the lease on subsequent
+		// polls. η-3 wires OnCreate/OnExpire to safeOnSubscribe /
+		// safeOnUnsubscribe so author hooks fire consistently with
+		// webhook + push lifecycle.
+		principal, _ := resolvePrincipal(ctx, unsafeAnon)
+		leases.Touch(principal, req.Name, req.Params)
 
 		cursorless := source.Def().Cursorless
 

--- a/experimental/ext/events/hooks.go
+++ b/experimental/ext/events/hooks.go
@@ -1,0 +1,305 @@
+package events
+
+// Hook surface for per-event-type author behavior — match / transform on
+// broadcast emit and on_subscribe / on_unsubscribe on lifecycle (η-2).
+//
+// Design context:
+//
+//   - Spec §"Server SDK Guidance" L565+ describes hooks in Python prose.
+//     Idioms 3 and 5 (class-bundled match/transform; separate
+//     @on_subscribe decorator) collapse onto a single Go answer: fields
+//     on EventDef. See docs/EVENTS_ETA_PLAN.md Q1.
+//
+//   - Hooks are sync per Q3 — goroutines that call yield/Subscribe/
+//     Register already exist; no new concurrency primitive needed.
+//
+//   - Hooks are zero-value-friendly: nil = "not set" = baseline behavior
+//     (all subscribers receive, payload unchanged, no lifecycle work).
+//
+// This file defines the type aliases, the HookContext, and the panic-
+// recovery wrappers. Wiring into the four call sites (events/poll,
+// events/stream, events/subscribe, the emit fanout) is η-3 / η-4 / η-5.
+
+import (
+	"context"
+	"log"
+)
+
+// DeliveryMode identifies which delivery path is invoking a hook so
+// authors can implement mode-aware behavior (e.g., a noisy push channel
+// they want to filter, but allow webhook through unchanged).
+//
+// The zero value is intentionally unset — a hook firing without a mode
+// would indicate a wiring bug, not a third "default" mode.
+type DeliveryMode int
+
+const (
+	deliveryModeUnset DeliveryMode = iota
+	DeliveryModePoll
+	DeliveryModePush
+	DeliveryModeWebhook
+)
+
+// String returns a human-readable name for the delivery mode.
+func (m DeliveryMode) String() string {
+	switch m {
+	case DeliveryModePoll:
+		return "poll"
+	case DeliveryModePush:
+		return "push"
+	case DeliveryModeWebhook:
+		return "webhook"
+	default:
+		return "unset"
+	}
+}
+
+// HookContext carries per-invocation state into the author's hook
+// callbacks: stdlib context for cancellation, plus the pieces of
+// subscription identity the author would otherwise have to thread by
+// hand (principal, subscription id, delivery mode).
+//
+// Why an interface instead of a struct: the SDK is the only producer
+// — authors only consume HookContext — so an interface keeps the
+// surface narrow (4 read-only methods, no zero-value footguns from
+// uninitialized exported fields) and lets us add fields on the impl
+// without breaking source compatibility for callers that already
+// type-asserted on a stable method set.
+//
+// Why not reuse core.MethodContext: that type is shaped around handler
+// invocation (carries id, request method, send-side Notify) — none of
+// which makes sense per-emit-fanout-iteration. See
+// docs/EVENTS_ETA_PLAN.md Q2.
+type HookContext interface {
+	// Context returns the underlying stdlib context. Authors honor
+	// cancellation / deadlines through this when doing blocking I/O
+	// inside a hook.
+	Context() context.Context
+
+	// Principal returns the resolved subscription principal (post-
+	// UnsafeAnonymousPrincipal fallback). For poll, this matches the
+	// principal slot of the lease key.
+	Principal() string
+
+	// SubscriptionID returns the server-derived sub_<base64> handle
+	// for webhook and push subscriptions. Empty string for poll —
+	// poll subscriptions are identified by lease tuple, not by id.
+	SubscriptionID() string
+
+	// Mode reports which delivery path is invoking the hook.
+	Mode() DeliveryMode
+}
+
+// hookContext is the package-internal HookContext implementation. The
+// type is unexported so authors can't accidentally construct one out
+// of context — they receive HookContext from the SDK and pass it
+// around as a value.
+type hookContext struct {
+	ctx            context.Context
+	principal      string
+	subscriptionID string
+	mode           DeliveryMode
+}
+
+func (h *hookContext) Context() context.Context {
+	if h == nil || h.ctx == nil {
+		return context.Background()
+	}
+	return h.ctx
+}
+
+func (h *hookContext) Principal() string {
+	if h == nil {
+		return ""
+	}
+	return h.principal
+}
+
+func (h *hookContext) SubscriptionID() string {
+	if h == nil {
+		return ""
+	}
+	return h.subscriptionID
+}
+
+func (h *hookContext) Mode() DeliveryMode {
+	if h == nil {
+		return deliveryModeUnset
+	}
+	return h.mode
+}
+
+// newHookContext is the package-internal constructor used by the
+// wiring sub-PRs (η-3 / η-4) when invoking the safe* wrappers.
+func newHookContext(ctx context.Context, principal, subID string, mode DeliveryMode) HookContext {
+	return &hookContext{ctx: ctx, principal: principal, subscriptionID: subID, mode: mode}
+}
+
+// MatchFunc decides whether an emitted event should reach the
+// subscriber identified by ctx + params. Return true to deliver, false
+// to skip. nil MatchFunc on EventDef means "deliver to all".
+//
+// Python original (Idiom 3, spec L633-644):
+//
+//	@staticmethod
+//	def match(ctx: Context, event: Event, params: dict) -> bool:
+//	    sev = params.get("severity")
+//	    return sev is None or event.data["severity"] == sev
+//
+// Go translation: sync function (spec's `async` collapses to plain
+// Go funcs per Idiom 2 / Q3); per-subscription parameters move from
+// the static-method receiver onto a HookContext argument (Q2). Stored
+// as a field on EventDef rather than a separate registration call —
+// hooks are per-event-type, EventDef is per-event-type, so they live
+// together (Q1).
+//
+// Spec §"Server SDK Guidance" L623-629. Hot path: invoked once per
+// (event, subscriber) pair on broadcast emit; authors should avoid
+// I/O. Use HookContext.Context() for cancellation if a downstream
+// lookup needs it.
+type MatchFunc func(ctx HookContext, event Event, params map[string]any) bool
+
+// TransformFunc shapes the event for one subscriber.
+//
+// Python original (Idiom 3, spec L633-644):
+//
+//	@staticmethod
+//	def transform(ctx: Context, event: Event, params: dict) -> Event:
+//	    if params.get("redact_pii"):
+//	        return event.replace(data={**event.data, "reporter": None})
+//	    return event
+//
+// Go translation: sync function with a (Event, bool) return instead
+// of plain Event. The `bool` says "I modified the event; re-marshal
+// the body for this subscriber." Returning `(orig, false)` is the
+// passthrough path — wiring code skips the re-marshal / re-sign work.
+// This is the cost Python authors don't see (immutable-update via
+// `event.replace(...)` looks free at the syntax level but allocates a
+// new dict every time); Go forces it visible, and the bool gives
+// authors a way to opt out per-subscriber. See Idiom 4 + Q8.
+//
+// nil TransformFunc on EventDef means "passthrough; no per-subscriber
+// re-marshal".
+type TransformFunc func(ctx HookContext, event Event, params map[string]any) (Event, bool)
+
+// SubscribeFunc fires once per subscription lifecycle on initial
+// subscribe / first poll.
+//
+// Python original (Idiom 5, spec L694-697):
+//
+//	@server.on_subscribe("slack.message")
+//	async def on_subscribe(context, params, subscription_id):
+//	    """Set up upstream listener for this subscription's params."""
+//	    await slack.join_channel(params["channel"])
+//
+// Go translation: sync function returning error so the author can
+// refuse provisioning (e.g., upstream API quota exceeded) — the
+// closest analog to a Python coroutine raising. The Python signature
+// has `subscription_id` as a third positional argument; Go folds it
+// onto HookContext.SubscriptionID() so the call site stays uniform
+// across delivery modes (poll has no sub id and the field is empty
+// — see Q4). Stored as a field on EventDef rather than a separate
+// `@server.on_subscribe(name)` decorator (Q1 — same answer as match/
+// transform, since it's still per-event-type state).
+//
+// Returning a non-nil error fails the subscribe call: the SDK
+// surfaces it as -32013 TooManySubscriptions today (η-6 may add a
+// dedicated SubscribeFailed code if a real use case appears). The
+// SDK does NOT roll back webhook registration / push stream open on
+// hook failure; authors that need rollback should arrange it inside
+// the hook before returning the error.
+type SubscribeFunc func(ctx HookContext, params map[string]any) error
+
+// UnsubscribeFunc fires once per subscription lifecycle on actual
+// removal — webhook Unregister / TTL prune / PostTerminated, stream
+// close, poll-lease expiry.
+//
+// Python original (Idiom 5, spec L699-702):
+//
+//	@server.on_unsubscribe("slack.message")
+//	async def on_unsubscribe(context, params, subscription_id):
+//	    """Tear down upstream listener."""
+//	    await slack.leave_channel(params["channel"])
+//
+// Go translation: sync function with no return — teardown is
+// notification-style. Same subscription_id-onto-HookContext folding
+// as SubscribeFunc. Does NOT fire on the suspend transition (Active
+// true→false): the subscription is paused, not removed; a subsequent
+// refresh reactivates it without re-firing on_subscribe (Q4).
+//
+// Failures inside the hook are logged + swallowed. Authors that need
+// failure visibility should surface it through their own logging /
+// metrics from inside the hook.
+type UnsubscribeFunc func(ctx HookContext, params map[string]any)
+
+// safeMatch invokes a MatchFunc with panic recovery. A nil match means
+// "deliver to all" (returns true). A panicking match logs and returns
+// false — a buggy filter shouldn't accidentally fan out everything.
+func safeMatch(fn MatchFunc, ctx HookContext, event Event, params map[string]any) (matched bool) {
+	if fn == nil {
+		return true
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("[events] match hook panic for event %q (sub=%q mode=%s): %v",
+				event.Name, ctx.SubscriptionID(), ctx.Mode(), r)
+			matched = false
+		}
+	}()
+	return fn(ctx, event, params)
+}
+
+// safeTransform invokes a TransformFunc with panic recovery. A nil
+// transform is passthrough (returns the original event, modified=false).
+// A panicking transform logs and returns the original event with
+// modified=false — fall back to passthrough rather than dropping the
+// event entirely.
+func safeTransform(fn TransformFunc, ctx HookContext, event Event, params map[string]any) (out Event, modified bool) {
+	if fn == nil {
+		return event, false
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("[events] transform hook panic for event %q (sub=%q mode=%s): %v",
+				event.Name, ctx.SubscriptionID(), ctx.Mode(), r)
+			out = event
+			modified = false
+		}
+	}()
+	return fn(ctx, event, params)
+}
+
+// safeOnSubscribe invokes a SubscribeFunc with panic recovery. A nil
+// hook is a no-op (returns nil). A panicking hook logs and returns nil
+// — the subscription proceeds; the spec is non-normative here and a
+// crash inside the author's lifecycle hook shouldn't take down the
+// caller's subscribe attempt.
+func safeOnSubscribe(fn SubscribeFunc, ctx HookContext, params map[string]any) (err error) {
+	if fn == nil {
+		return nil
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("[events] on_subscribe hook panic (sub=%q mode=%s): %v",
+				ctx.SubscriptionID(), ctx.Mode(), r)
+			err = nil
+		}
+	}()
+	return fn(ctx, params)
+}
+
+// safeOnUnsubscribe invokes an UnsubscribeFunc with panic recovery. A
+// nil hook is a no-op. A panicking hook logs and is swallowed —
+// teardown is best-effort.
+func safeOnUnsubscribe(fn UnsubscribeFunc, ctx HookContext, params map[string]any) {
+	if fn == nil {
+		return
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("[events] on_unsubscribe hook panic (sub=%q mode=%s): %v",
+				ctx.SubscriptionID(), ctx.Mode(), r)
+		}
+	}()
+	fn(ctx, params)
+}

--- a/experimental/ext/events/hooks_test.go
+++ b/experimental/ext/events/hooks_test.go
@@ -1,0 +1,232 @@
+package events
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// testHC returns an empty HookContext for tests that don't care about
+// its fields (panic recovery, nil-vs-not). Wiring tests that DO care
+// (η-3 / η-4) construct via newHookContext directly.
+func testHC() HookContext {
+	return newHookContext(nil, "", "", deliveryModeUnset)
+}
+
+func TestHookContext_Defaults(t *testing.T) {
+	// Empty constructor — covers the wiring sub-PRs' fallback path
+	// (no auth claims, no sub id) plus the nil-receiver guards on
+	// the impl methods (which keep tests/zero values from panicking).
+	zero := newHookContext(nil, "", "", deliveryModeUnset)
+	if zero.Context() != context.Background() {
+		t.Errorf("HookContext.Context() should fall back to context.Background() when ctx is nil, got %v", zero.Context())
+	}
+	if zero.Principal() != "" {
+		t.Errorf("empty HookContext.Principal() = %q, want empty", zero.Principal())
+	}
+	if zero.SubscriptionID() != "" {
+		t.Errorf("empty HookContext.SubscriptionID() = %q, want empty", zero.SubscriptionID())
+	}
+	if zero.Mode() != deliveryModeUnset {
+		t.Errorf("empty HookContext.Mode() = %v, want deliveryModeUnset", zero.Mode())
+	}
+}
+
+func TestHookContext_NilReceiverSafe(t *testing.T) {
+	// A nil *hookContext satisfies HookContext (Go interface trap)
+	// — the impl methods must guard against it so authors that
+	// somehow obtained a typed-nil don't crash.
+	var nilImpl *hookContext
+	var hc HookContext = nilImpl
+	if hc.Context() != context.Background() {
+		t.Errorf("nil-receiver Context() did not fall back to Background()")
+	}
+	if hc.Principal() != "" {
+		t.Errorf("nil-receiver Principal() = %q, want empty", hc.Principal())
+	}
+	if hc.SubscriptionID() != "" {
+		t.Errorf("nil-receiver SubscriptionID() = %q, want empty", hc.SubscriptionID())
+	}
+	if hc.Mode() != deliveryModeUnset {
+		t.Errorf("nil-receiver Mode() = %v, want deliveryModeUnset", hc.Mode())
+	}
+}
+
+func TestHookContext_Populated(t *testing.T) {
+	type ctxKey string
+	parent := context.WithValue(context.Background(), ctxKey("k"), "v")
+	hc := newHookContext(parent, "alice", "sub_abc", DeliveryModeWebhook)
+	if hc.Principal() != "alice" {
+		t.Errorf("Principal() = %q, want %q", hc.Principal(), "alice")
+	}
+	if hc.SubscriptionID() != "sub_abc" {
+		t.Errorf("SubscriptionID() = %q, want %q", hc.SubscriptionID(), "sub_abc")
+	}
+	if hc.Mode() != DeliveryModeWebhook {
+		t.Errorf("Mode() = %v, want DeliveryModeWebhook", hc.Mode())
+	}
+	if got := hc.Context().Value(ctxKey("k")); got != "v" {
+		t.Errorf("Context().Value(k) = %v, want \"v\" (context not preserved)", got)
+	}
+}
+
+func TestDeliveryMode_String(t *testing.T) {
+	cases := []struct {
+		mode DeliveryMode
+		want string
+	}{
+		{DeliveryModePoll, "poll"},
+		{DeliveryModePush, "push"},
+		{DeliveryModeWebhook, "webhook"},
+		{deliveryModeUnset, "unset"},
+	}
+	for _, c := range cases {
+		if got := c.mode.String(); got != c.want {
+			t.Errorf("DeliveryMode(%d).String() = %q, want %q", c.mode, got, c.want)
+		}
+	}
+}
+
+func TestSafeMatch_NilIsDeliverAll(t *testing.T) {
+	if !safeMatch(nil, testHC(), Event{}, nil) {
+		t.Errorf("safeMatch(nil) = false, want true (nil match = deliver to all)")
+	}
+}
+
+func TestSafeMatch_PassthroughResults(t *testing.T) {
+	yes := func(HookContext, Event, map[string]any) bool { return true }
+	no := func(HookContext, Event, map[string]any) bool { return false }
+	if !safeMatch(yes, testHC(), Event{}, nil) {
+		t.Errorf("safeMatch(yes) returned false")
+	}
+	if safeMatch(no, testHC(), Event{}, nil) {
+		t.Errorf("safeMatch(no) returned true")
+	}
+}
+
+func TestSafeMatch_PanicReturnsFalse(t *testing.T) {
+	panicky := func(HookContext, Event, map[string]any) bool { panic("oops") }
+	if safeMatch(panicky, testHC(), Event{Name: "panic-evt"}, nil) {
+		t.Errorf("safeMatch(panicky) returned true; want false on panic")
+	}
+}
+
+func TestSafeTransform_NilIsPassthrough(t *testing.T) {
+	in := Event{Name: "x", EventID: "evt_1"}
+	out, modified := safeTransform(nil, testHC(), in, nil)
+	if modified {
+		t.Errorf("safeTransform(nil) modified=true; want false")
+	}
+	if out.EventID != in.EventID || out.Name != in.Name {
+		t.Errorf("safeTransform(nil) returned %+v; want passthrough of %+v", out, in)
+	}
+}
+
+func TestSafeTransform_PassthroughResults(t *testing.T) {
+	in := Event{Name: "x", Data: json.RawMessage(`{"a":1}`)}
+	redact := func(_ HookContext, e Event, _ map[string]any) (Event, bool) {
+		e.Data = json.RawMessage(`{"a":null}`)
+		return e, true
+	}
+	out, modified := safeTransform(redact, testHC(), in, nil)
+	if !modified {
+		t.Errorf("safeTransform(redact) modified=false; want true")
+	}
+	if string(out.Data) != `{"a":null}` {
+		t.Errorf("safeTransform(redact) data = %s, want {\"a\":null}", out.Data)
+	}
+	// Original event must not have been mutated under us.
+	if string(in.Data) != `{"a":1}` {
+		t.Errorf("safeTransform mutated input event: %s", in.Data)
+	}
+}
+
+func TestSafeTransform_PanicReturnsOriginal(t *testing.T) {
+	in := Event{Name: "x", EventID: "evt_1", Data: json.RawMessage(`{"keep":true}`)}
+	panicky := func(HookContext, Event, map[string]any) (Event, bool) { panic("nope") }
+	out, modified := safeTransform(panicky, testHC(), in, nil)
+	if modified {
+		t.Errorf("safeTransform(panic) modified=true; want false")
+	}
+	if out.EventID != in.EventID || string(out.Data) != string(in.Data) {
+		t.Errorf("safeTransform(panic) = %+v; want original %+v", out, in)
+	}
+}
+
+func TestSafeOnSubscribe_NilIsNoop(t *testing.T) {
+	if err := safeOnSubscribe(nil, testHC(), nil); err != nil {
+		t.Errorf("safeOnSubscribe(nil) = %v; want nil", err)
+	}
+}
+
+func TestSafeOnSubscribe_ErrorIsReturned(t *testing.T) {
+	want := errors.New("upstream quota")
+	fn := func(HookContext, map[string]any) error { return want }
+	if got := safeOnSubscribe(fn, testHC(), nil); !errors.Is(got, want) {
+		t.Errorf("safeOnSubscribe returned %v; want %v", got, want)
+	}
+}
+
+func TestSafeOnSubscribe_PanicSwallowed(t *testing.T) {
+	fn := func(HookContext, map[string]any) error { panic("boom") }
+	if err := safeOnSubscribe(fn, testHC(), nil); err != nil {
+		t.Errorf("safeOnSubscribe(panic) = %v; want nil (panic swallowed)", err)
+	}
+}
+
+func TestSafeOnUnsubscribe_NilIsNoop(t *testing.T) {
+	// Just must not panic.
+	safeOnUnsubscribe(nil, testHC(), nil)
+}
+
+func TestSafeOnUnsubscribe_PanicSwallowed(t *testing.T) {
+	fn := func(HookContext, map[string]any) { panic("teardown failed") }
+	// Must not propagate.
+	safeOnUnsubscribe(fn, testHC(), nil)
+}
+
+func TestSafeOnUnsubscribe_FunctionRuns(t *testing.T) {
+	called := false
+	fn := func(HookContext, map[string]any) { called = true }
+	safeOnUnsubscribe(fn, testHC(), nil)
+	if !called {
+		t.Errorf("safeOnUnsubscribe did not invoke the function")
+	}
+}
+
+// Hook fields on EventDef must be tagged json:"-" so they don't leak
+// onto the wire when events/list serializes the EventDef. Verifies the
+// struct tag rather than just round-tripping JSON because the function
+// fields would fail to marshal at all (functions have no JSON form);
+// the test exists to lock the tag in place against future edits.
+func TestEventDef_HooksOmittedFromJSON(t *testing.T) {
+	def := EventDef{
+		Name:        "test.event",
+		Description: "ensures hooks don't leak",
+		Delivery:    []string{"poll"},
+		Match: func(HookContext, Event, map[string]any) bool {
+			return true
+		},
+		Transform: func(_ HookContext, e Event, _ map[string]any) (Event, bool) {
+			return e, false
+		},
+		OnSubscribe:   func(HookContext, map[string]any) error { return nil },
+		OnUnsubscribe: func(HookContext, map[string]any) {},
+	}
+	out, err := json.Marshal(def)
+	if err != nil {
+		t.Fatalf("json.Marshal(EventDef) returned error: %v", err)
+	}
+	s := string(out)
+	for _, banned := range []string{`"Match"`, `"Transform"`, `"OnSubscribe"`, `"OnUnsubscribe"`,
+		`"match"`, `"transform"`, `"onSubscribe"`, `"onUnsubscribe"`} {
+		if strings.Contains(s, banned) {
+			t.Errorf("EventDef JSON contains hook field %s; output: %s", banned, s)
+		}
+	}
+	if !strings.Contains(s, `"name":"test.event"`) {
+		t.Errorf("EventDef JSON missing name; output: %s", s)
+	}
+}

--- a/experimental/ext/events/poll_lease.go
+++ b/experimental/ext/events/poll_lease.go
@@ -1,0 +1,310 @@
+package events
+
+// Poll-lease table — in-memory soft state tracking which (principal,
+// eventName, params) tuples have recent poll activity, with TTL-based
+// expiry and lifecycle callbacks. Foundation for η-3's poll-mode
+// on_subscribe / on_unsubscribe wiring (η-1).
+//
+// Spec §"Server SDK Guidance" → "Unsubscribe timing by mode" L707-715:
+// "the SDK treats poll subscriptions as leased. The lease is keyed on
+// `(principal-or-null, eventName, canonicalHash(params))`... The lease
+// window is SDK-configurable and SHOULD default to a small multiple of
+// the server's typical nextPollSeconds."
+//
+// Why a separate table rather than reusing WebhookRegistry's TTL state:
+// the registry is keyed on (principal, url, name, params) — webhook has
+// a delivery URL, poll does not. Different identity tuple → different
+// store. Both use the same canonical-JSON-of-params building block from
+// identity.go.
+
+import (
+	"log"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	defaultPollLeaseTTL           = 5 * time.Minute // spec L711 example
+	defaultPollLeaseSweepInterval = 30 * time.Second
+)
+
+// PollLeaseHook is the callback signature for OnCreate / OnExpire. The
+// SDK invokes it with the lease's identity tuple so authors (typically
+// via the η-3 wiring that turns these into on_subscribe / on_unsubscribe
+// calls) can provision and tear down upstream resources.
+//
+// Hooks fire from the goroutine that called Touch (OnCreate) or the
+// background sweep goroutine (OnExpire). Authors that need to do
+// blocking work should not be afraid to — the calling sites are
+// already async.
+type PollLeaseHook func(principal, eventName string, params map[string]any)
+
+// PollLeaseOption configures a PollLeaseTable at construction time.
+type PollLeaseOption func(*PollLeaseTable)
+
+// WithPollLeaseTTL overrides the lease TTL. Default is 5 minutes
+// (spec L711 example). A new poll within the TTL window renews the
+// lease (no OnCreate fires); a lease whose ExpiresAt has passed is
+// reaped on the next sweep (OnExpire fires).
+func WithPollLeaseTTL(d time.Duration) PollLeaseOption {
+	return func(t *PollLeaseTable) {
+		if d > 0 {
+			t.ttl = d
+		}
+	}
+}
+
+// WithPollLeaseSweepInterval overrides how often the background
+// goroutine scans for expired leases. Default 30s. Tests that want
+// faster expiry observation should set both this and
+// WithPollLeaseTTL to small values.
+func WithPollLeaseSweepInterval(d time.Duration) PollLeaseOption {
+	return func(t *PollLeaseTable) {
+		if d > 0 {
+			t.sweepInterval = d
+		}
+	}
+}
+
+// WithPollLeaseOnCreate registers a callback that fires once when a
+// (principal, name, params) tuple is observed for the first time
+// (lease is newly created). Subsequent polls within the TTL window
+// renew the lease without re-firing.
+func WithPollLeaseOnCreate(hook PollLeaseHook) PollLeaseOption {
+	return func(t *PollLeaseTable) { t.onCreate = hook }
+}
+
+// WithPollLeaseOnExpire registers a callback that fires when a lease
+// is reaped because its TTL elapsed without a renewing Touch.
+func WithPollLeaseOnExpire(hook PollLeaseHook) PollLeaseOption {
+	return func(t *PollLeaseTable) { t.onExpire = hook }
+}
+
+// pollLease is one entry in the table.
+type pollLease struct {
+	principal string
+	eventName string
+	params    map[string]any
+	expiresAt time.Time
+}
+
+// PollLeaseTable tracks poll-mode subscriptions as ephemeral leases.
+// Construct via NewPollLeaseTable. Callers (registerPoll, in events.go)
+// invoke Touch on every poll; OnCreate / OnExpire fire from the
+// lifecycle of each lease.
+//
+// All state is in-process — leases do not persist across restart per
+// the spec's explicit ephemerality rule (L715). After restart,
+// on_subscribe re-fires on the first poll for any active subscription;
+// authors should make their on_subscribe idempotent.
+type PollLeaseTable struct {
+	mu            sync.Mutex
+	leases        map[string]*pollLease
+	ttl           time.Duration
+	sweepInterval time.Duration
+	onCreate      PollLeaseHook
+	onExpire      PollLeaseHook
+
+	// Lifecycle for the background sweep goroutine. The goroutine is
+	// started lazily on the first Touch (so unused tables don't leak)
+	// and stopped via Close (test teardown / graceful shutdown).
+	// `started` and `closed` are guarded by mu.
+	started bool
+	closed  bool
+	stopCh  chan struct{}
+	doneCh  chan struct{}
+
+	// nowFn is overridable for deterministic tests.
+	nowFn func() time.Time
+}
+
+// NewPollLeaseTable constructs a lease table with sensible defaults
+// (5 minute TTL, 30 second sweep interval, no hooks). Override via
+// the With* options.
+func NewPollLeaseTable(opts ...PollLeaseOption) *PollLeaseTable {
+	t := &PollLeaseTable{
+		leases:        make(map[string]*pollLease),
+		ttl:           defaultPollLeaseTTL,
+		sweepInterval: defaultPollLeaseSweepInterval,
+		stopCh:        make(chan struct{}),
+		doneCh:        make(chan struct{}),
+		nowFn:         time.Now,
+	}
+	for _, o := range opts {
+		o(t)
+	}
+	return t
+}
+
+// Touch registers a poll for (principal, eventName, params). Returns
+// true when the call newly created the lease (and OnCreate fired for
+// it), false when an existing lease was renewed (or the table is
+// closed — Close-after-Touch is a no-op).
+//
+// principal may be empty — anonymous polling on a server without auth
+// shares a single lease per (name, params) per spec L707 ("on
+// unauthenticated servers all callers share one lease").
+func (t *PollLeaseTable) Touch(principal, eventName string, params map[string]any) bool {
+	key := pollLeaseKey(principal, eventName, params)
+	now := t.nowFn()
+	expiresAt := now.Add(t.ttl)
+
+	t.mu.Lock()
+	if t.closed {
+		t.mu.Unlock()
+		return false
+	}
+	// Lazy-start the sweep goroutine on first use so unused tables
+	// (e.g., a freshly registered server nobody polls) don't burn a
+	// goroutine. `started` is guarded by mu — we may hold it for
+	// strictly longer than the lookup, but the goroutine spawn is
+	// cheap and avoids a separate atomic.
+	if !t.started {
+		t.started = true
+		go t.runSweeper()
+	}
+
+	existing, ok := t.leases[key]
+	if ok {
+		existing.expiresAt = expiresAt
+		t.mu.Unlock()
+		return false
+	}
+	lease := &pollLease{
+		principal: principal,
+		eventName: eventName,
+		params:    params,
+		expiresAt: expiresAt,
+	}
+	t.leases[key] = lease
+	hook := t.onCreate
+	t.mu.Unlock()
+
+	if hook != nil {
+		invokeLeaseHook("OnCreate", hook, lease)
+	}
+	return true
+}
+
+// Len reports the current number of live leases. Snapshot — callers
+// must not race on it for correctness.
+func (t *PollLeaseTable) Len() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.leases)
+}
+
+// Close stops the background sweep goroutine. Safe to call multiple
+// times. After Close, Touch is a no-op (returns false; doesn't track
+// new leases or fire OnCreate). Intended for graceful shutdown / test
+// teardown.
+//
+// Channel-safety: stopCh is *closed* (not sent to), so any number of
+// readers wake up in lock-step — no risk of a goroutine missing the
+// signal. doneCh is closed by the sweeper itself on exit; Close waits
+// on it only when started==true, so a never-started table doesn't
+// hang at the receive.
+func (t *PollLeaseTable) Close() {
+	t.mu.Lock()
+	if t.closed {
+		t.mu.Unlock()
+		return
+	}
+	t.closed = true
+	started := t.started
+	t.mu.Unlock()
+
+	close(t.stopCh)
+	if !started {
+		// Sweeper never ran — nothing to wait for.
+		return
+	}
+	<-t.doneCh
+}
+
+// runSweeper is the body of the background sweep goroutine. Started
+// from Touch on first use (under mu, via the started flag) so unused
+// tables don't leak a goroutine.
+func (t *PollLeaseTable) runSweeper() {
+	ticker := time.NewTicker(t.sweepInterval)
+	defer ticker.Stop()
+	defer close(t.doneCh)
+	for {
+		select {
+		case <-t.stopCh:
+			return
+		case <-ticker.C:
+			t.sweepExpired()
+		}
+	}
+}
+
+// sweepExpired removes leases past their ExpiresAt and fires OnExpire
+// for each. Exported-for-test via sweepExpiredForTest. The hook fires
+// outside the lock so a long-running OnExpire doesn't serialize Touch.
+func (t *PollLeaseTable) sweepExpired() {
+	now := t.nowFn()
+	t.mu.Lock()
+	hook := t.onExpire
+	var expired []*pollLease
+	for k, l := range t.leases {
+		if !l.expiresAt.After(now) {
+			expired = append(expired, l)
+			delete(t.leases, k)
+		}
+	}
+	t.mu.Unlock()
+
+	if hook == nil {
+		return
+	}
+	for _, l := range expired {
+		invokeLeaseHook("OnExpire", hook, l)
+	}
+}
+
+// sweepExpiredForTest exposes the sweep so tests can drive expiry
+// deterministically without waiting for the ticker.
+func (t *PollLeaseTable) sweepExpiredForTest() { t.sweepExpired() }
+
+// invokeLeaseHook invokes a PollLeaseHook with panic recovery. A
+// hook that panics shouldn't take down the sweep goroutine or the
+// poll handler; log + swallow.
+func invokeLeaseHook(label string, hook PollLeaseHook, l *pollLease) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("[events] poll-lease %s hook panic for (%q,%q): %v",
+				label, l.principal, l.eventName, r)
+		}
+	}()
+	hook(l.principal, l.eventName, l.params)
+}
+
+// pollLeaseKey returns the canonical-bytes encoding of a
+// (principal, eventName, params) tuple — the spec's poll-lease
+// identity (L707).
+//
+// Different shape from identity.go's canonicalKey (which adds
+// delivery URL for webhook subscriptions). Same canonical-JSON-of-
+// params building block (canonicalJSON) so two polls with map-
+// iteration-order-different params hash identically.
+//
+// Returned as a string for direct use as the lease-table map key.
+func pollLeaseKey(principal, eventName string, params map[string]any) string {
+	var paramBytes []byte
+	if len(params) == 0 {
+		paramBytes = []byte("{}")
+	} else {
+		paramBytes = canonicalJSON(params)
+	}
+	const sep = "\x1f"
+	var b strings.Builder
+	b.Grow(len(principal) + len(eventName) + len(paramBytes) + 2)
+	b.WriteString(principal)
+	b.WriteString(sep)
+	b.WriteString(eventName)
+	b.WriteString(sep)
+	b.Write(paramBytes)
+	return b.String()
+}

--- a/experimental/ext/events/poll_lease_test.go
+++ b/experimental/ext/events/poll_lease_test.go
@@ -1,0 +1,392 @@
+package events
+
+import (
+	"context"
+	"encoding/json"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/server"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Touch / OnCreate / OnExpire semantics ---
+
+func TestPollLeaseTable_Touch_NewVsRenew(t *testing.T) {
+	var creates atomic.Int32
+	t1 := NewPollLeaseTable(
+		WithPollLeaseTTL(50*time.Millisecond),
+		WithPollLeaseSweepInterval(time.Hour), // disable background sweeps for this test
+		WithPollLeaseOnCreate(func(string, string, map[string]any) { creates.Add(1) }),
+	)
+	defer t1.Close()
+
+	if !t1.Touch("alice", "alert.fired", map[string]any{"sev": "high"}) {
+		t.Fatalf("first Touch returned false; want true (newly created)")
+	}
+	if t1.Touch("alice", "alert.fired", map[string]any{"sev": "high"}) {
+		t.Fatalf("second Touch returned true; want false (renewal)")
+	}
+	if t1.Touch("alice", "alert.fired", map[string]any{"sev": "high"}) {
+		t.Fatalf("third Touch returned true; want false (renewal)")
+	}
+	if creates.Load() != 1 {
+		t.Fatalf("OnCreate fired %d times; want 1 across renewals", creates.Load())
+	}
+}
+
+func TestPollLeaseTable_DistinctParamsCreateDistinctLeases(t *testing.T) {
+	var creates atomic.Int32
+	tt := NewPollLeaseTable(
+		WithPollLeaseSweepInterval(time.Hour),
+		WithPollLeaseOnCreate(func(string, string, map[string]any) { creates.Add(1) }),
+	)
+	defer tt.Close()
+
+	tt.Touch("alice", "alert.fired", map[string]any{"sev": "high"})
+	tt.Touch("alice", "alert.fired", map[string]any{"sev": "low"})
+	if got := creates.Load(); got != 2 {
+		t.Fatalf("OnCreate fired %d times; want 2 (distinct param sets)", got)
+	}
+	if tt.Len() != 2 {
+		t.Fatalf("Len() = %d; want 2", tt.Len())
+	}
+}
+
+func TestPollLeaseTable_AnonymousPrincipalSharesLease(t *testing.T) {
+	var creates atomic.Int32
+	tt := NewPollLeaseTable(
+		WithPollLeaseSweepInterval(time.Hour),
+		WithPollLeaseOnCreate(func(string, string, map[string]any) { creates.Add(1) }),
+	)
+	defer tt.Close()
+
+	if !tt.Touch("", "alert.fired", map[string]any{"sev": "high"}) {
+		t.Fatalf("first anon Touch returned false; want true")
+	}
+	if tt.Touch("", "alert.fired", map[string]any{"sev": "high"}) {
+		t.Fatalf("second anon Touch returned true; want false (shared lease per spec L707)")
+	}
+	if got := creates.Load(); got != 1 {
+		t.Fatalf("OnCreate fired %d times; want 1 (anon callers share)", got)
+	}
+}
+
+func TestPollLeaseTable_MapIterationOrderInvariant(t *testing.T) {
+	// Two params maps with identical entries but built in different
+	// orders MUST hash to the same lease (canonicalJSON sorts keys).
+	tt := NewPollLeaseTable(WithPollLeaseSweepInterval(time.Hour))
+	defer tt.Close()
+
+	tt.Touch("alice", "alert.fired", map[string]any{"a": 1, "b": 2})
+	if tt.Touch("alice", "alert.fired", map[string]any{"b": 2, "a": 1}) {
+		t.Fatalf("Touch with reordered params returned true; want false (same canonical key)")
+	}
+	if tt.Len() != 1 {
+		t.Fatalf("Len() = %d; want 1 after reordered-params renewal", tt.Len())
+	}
+}
+
+func TestPollLeaseTable_ExpiryFiresOnExpire(t *testing.T) {
+	var creates, expires atomic.Int32
+	tt := NewPollLeaseTable(
+		WithPollLeaseTTL(20*time.Millisecond),
+		WithPollLeaseSweepInterval(time.Hour), // drive sweep manually
+		WithPollLeaseOnCreate(func(string, string, map[string]any) { creates.Add(1) }),
+		WithPollLeaseOnExpire(func(string, string, map[string]any) { expires.Add(1) }),
+	)
+	defer tt.Close()
+
+	tt.Touch("alice", "alert.fired", map[string]any{"sev": "high"})
+	if creates.Load() != 1 || expires.Load() != 0 {
+		t.Fatalf("after Touch: creates=%d expires=%d; want 1, 0", creates.Load(), expires.Load())
+	}
+
+	// Within TTL — sweep should NOT expire.
+	tt.sweepExpiredForTest()
+	if expires.Load() != 0 {
+		t.Fatalf("sweep within TTL fired %d expires; want 0", expires.Load())
+	}
+
+	// Past TTL — sweep should expire exactly once.
+	time.Sleep(40 * time.Millisecond)
+	tt.sweepExpiredForTest()
+	if expires.Load() != 1 {
+		t.Fatalf("sweep past TTL fired %d expires; want 1", expires.Load())
+	}
+	if tt.Len() != 0 {
+		t.Fatalf("Len() = %d after expiry; want 0", tt.Len())
+	}
+	// A second sweep with no live leases is a no-op.
+	tt.sweepExpiredForTest()
+	if expires.Load() != 1 {
+		t.Fatalf("second sweep over empty table fired more expires (now %d); want 1", expires.Load())
+	}
+}
+
+func TestPollLeaseTable_RenewalPreventsExpiry(t *testing.T) {
+	var expires atomic.Int32
+	tt := NewPollLeaseTable(
+		WithPollLeaseTTL(40*time.Millisecond),
+		WithPollLeaseSweepInterval(time.Hour),
+		WithPollLeaseOnExpire(func(string, string, map[string]any) { expires.Add(1) }),
+	)
+	defer tt.Close()
+
+	for i := 0; i < 4; i++ {
+		tt.Touch("alice", "alert.fired", nil)
+		time.Sleep(15 * time.Millisecond)
+		tt.sweepExpiredForTest()
+	}
+	if expires.Load() != 0 {
+		t.Fatalf("expires fired %d times under continuous renewal; want 0", expires.Load())
+	}
+	if tt.Len() != 1 {
+		t.Fatalf("Len() = %d under continuous renewal; want 1", tt.Len())
+	}
+}
+
+func TestPollLeaseTable_HookPanicSwallowed(t *testing.T) {
+	tt := NewPollLeaseTable(
+		WithPollLeaseTTL(10*time.Millisecond),
+		WithPollLeaseSweepInterval(time.Hour),
+		WithPollLeaseOnCreate(func(string, string, map[string]any) { panic("oncreate boom") }),
+		WithPollLeaseOnExpire(func(string, string, map[string]any) { panic("onexpire boom") }),
+	)
+	defer tt.Close()
+
+	// Must not propagate panic.
+	tt.Touch("alice", "alert.fired", nil)
+	time.Sleep(20 * time.Millisecond)
+	tt.sweepExpiredForTest()
+}
+
+// --- Concurrency ---
+
+func TestPollLeaseTable_ConcurrentTouchSafe(t *testing.T) {
+	var creates atomic.Int32
+	tt := NewPollLeaseTable(
+		WithPollLeaseSweepInterval(time.Hour),
+		WithPollLeaseOnCreate(func(string, string, map[string]any) { creates.Add(1) }),
+	)
+	defer tt.Close()
+
+	const goroutines, perGoroutine = 16, 200
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perGoroutine; i++ {
+				tt.Touch("alice", "alert.fired", map[string]any{"sev": "high"})
+			}
+		}()
+	}
+	wg.Wait()
+
+	if creates.Load() != 1 {
+		t.Fatalf("OnCreate fired %d times under concurrent Touch; want exactly 1", creates.Load())
+	}
+	if tt.Len() != 1 {
+		t.Fatalf("Len() = %d after concurrent Touch on one tuple; want 1", tt.Len())
+	}
+}
+
+// --- Channel lifecycle (the no-hang claim) ---
+
+func TestPollLeaseTable_CloseBeforeTouch_DoesNotHang(t *testing.T) {
+	tt := NewPollLeaseTable(WithPollLeaseSweepInterval(time.Hour))
+	done := make(chan struct{})
+	go func() {
+		tt.Close()
+		close(done)
+	}()
+	select {
+	case <-done:
+		// good — Close returned without waiting on doneCh because
+		// the sweeper never started.
+	case <-time.After(2 * time.Second):
+		t.Fatalf("Close() before any Touch hung — sweeper never started, but Close awaited doneCh")
+	}
+}
+
+func TestPollLeaseTable_CloseAfterTouch_StopsSweeper(t *testing.T) {
+	tt := NewPollLeaseTable(
+		WithPollLeaseTTL(time.Hour),
+		WithPollLeaseSweepInterval(5*time.Millisecond),
+	)
+	tt.Touch("alice", "alert.fired", nil)
+
+	// Let the sweeper tick at least once so we know it's running.
+	time.Sleep(15 * time.Millisecond)
+
+	before := runtime.NumGoroutine()
+	tt.Close()
+	// Close must wait for the sweeper to exit before returning, so a
+	// sample taken immediately after MUST NOT contain it.
+	after := runtime.NumGoroutine()
+	if after >= before {
+		// runtime.NumGoroutine fluctuates with the scheduler; ride
+		// 50ms then re-sample. If still >= before, fail.
+		time.Sleep(50 * time.Millisecond)
+		after = runtime.NumGoroutine()
+		if after >= before {
+			t.Fatalf("Close did not reap the sweeper goroutine: before=%d after=%d", before, after)
+		}
+	}
+}
+
+func TestPollLeaseTable_TouchAfterClose_IsNoop(t *testing.T) {
+	var creates atomic.Int32
+	tt := NewPollLeaseTable(
+		WithPollLeaseSweepInterval(time.Hour),
+		WithPollLeaseOnCreate(func(string, string, map[string]any) { creates.Add(1) }),
+	)
+	tt.Close()
+
+	if got := tt.Touch("alice", "alert.fired", nil); got {
+		t.Fatalf("Touch after Close returned true; want false (table is closed)")
+	}
+	if creates.Load() != 0 {
+		t.Fatalf("OnCreate fired %d times after Close; want 0", creates.Load())
+	}
+	if tt.Len() != 0 {
+		t.Fatalf("Len() = %d after Close+Touch; want 0", tt.Len())
+	}
+}
+
+func TestPollLeaseTable_DoubleClose_IsNoop(t *testing.T) {
+	tt := NewPollLeaseTable(
+		WithPollLeaseTTL(time.Hour),
+		WithPollLeaseSweepInterval(5*time.Millisecond),
+	)
+	tt.Touch("alice", "alert.fired", nil)
+	time.Sleep(15 * time.Millisecond)
+
+	tt.Close()
+	// Second close MUST NOT block, panic on double close(stopCh), or
+	// receive from a doneCh that's already been drained.
+	done := make(chan struct{})
+	go func() {
+		tt.Close()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("second Close() hung")
+	}
+}
+
+// --- Wire helper ---
+
+func TestPollLeaseKey_StableAcrossEqualMaps(t *testing.T) {
+	a := pollLeaseKey("alice", "alert.fired", map[string]any{"a": 1, "b": 2})
+	b := pollLeaseKey("alice", "alert.fired", map[string]any{"b": 2, "a": 1})
+	if a != b {
+		t.Errorf("pollLeaseKey not stable across map iteration order: %q vs %q", a, b)
+	}
+}
+
+func TestPollLeaseKey_DistinctOnPrincipal(t *testing.T) {
+	a := pollLeaseKey("alice", "alert.fired", nil)
+	b := pollLeaseKey("bob", "alert.fired", nil)
+	if a == b {
+		t.Errorf("pollLeaseKey collided across principals: %q", a)
+	}
+}
+
+func TestPollLeaseKey_DistinctOnEventName(t *testing.T) {
+	a := pollLeaseKey("alice", "alert.fired", nil)
+	b := pollLeaseKey("alice", "alert.cleared", nil)
+	if a == b {
+		t.Errorf("pollLeaseKey collided across event names: %q", a)
+	}
+}
+
+// TestRegisterPoll_TouchesLeaseTable verifies the integration: a real
+// events/poll dispatch goes through Touch on the configured lease
+// table. Uses the OnCreate hook as a sentinel — if Touch isn't called
+// from registerPoll, we never observe the create.
+func TestRegisterPoll_TouchesLeaseTable(t *testing.T) {
+	var creates atomic.Int32
+	leases := NewPollLeaseTable(
+		WithPollLeaseSweepInterval(time.Hour),
+		WithPollLeaseOnCreate(func(_, _ string, _ map[string]any) { creates.Add(1) }),
+	)
+	defer leases.Close()
+
+	src, _ := NewYieldingSource[map[string]any](EventDef{
+		Name:        "poll.lease.touch.test",
+		Description: "verifies registerPoll → Touch wiring",
+		Delivery:    []string{"poll"},
+	})
+	srv := server.NewServer(core.ServerInfo{Name: "test", Version: "1.0"})
+	Register(Config{
+		Sources:                  []EventSource{src},
+		Server:                   srv,
+		PollLeases:               leases,
+		UnsafeAnonymousPrincipal: "test-anon",
+	})
+	finishInitHandshake(t, srv)
+
+	// Two polls for the same tuple → one create; a different params
+	// tuple → second create. This proves both that Touch ran (we'd
+	// see zero otherwise) and that the same canonical key is being
+	// computed (we'd see two creates for the first pair otherwise).
+	for i := 0; i < 2; i++ {
+		dispatchPoll(t, srv, "poll.lease.touch.test", map[string]any{"sev": "high"})
+	}
+	if got := creates.Load(); got != 1 {
+		t.Fatalf("after two identical polls: creates=%d, want 1", got)
+	}
+	dispatchPoll(t, srv, "poll.lease.touch.test", map[string]any{"sev": "low"})
+	if got := creates.Load(); got != 2 {
+		t.Fatalf("after distinct-params poll: creates=%d, want 2", got)
+	}
+}
+
+// finishInitHandshake runs the two-step initialize / initialized
+// handshake so the server's dispatcher will accept non-init methods.
+// Existing tests inline this; pulled here for readability.
+func finishInitHandshake(t *testing.T, srv *server.Server) {
+	t.Helper()
+	initParams := json.RawMessage(`{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)
+	resp, err := srv.Dispatch(context.Background(), &core.Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`0`),
+		Method:  "initialize",
+		Params:  initParams,
+	})
+	require.NoError(t, err)
+	require.Nil(t, resp.Error, "initialize should succeed; got %+v", resp.Error)
+	_, err = srv.Dispatch(context.Background(), &core.Request{
+		JSONRPC: "2.0",
+		Method:  "notifications/initialized",
+	})
+	require.NoError(t, err)
+}
+
+// dispatchPoll invokes events/poll with the given event name and
+// params via the server's normal dispatch path.
+func dispatchPoll(t *testing.T, srv *server.Server, name string, params map[string]any) {
+	t.Helper()
+	body := map[string]any{"name": name}
+	if params != nil {
+		body["params"] = params
+	}
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+	resp, err := srv.Dispatch(context.Background(), &core.Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  "events/poll",
+		Params:  raw,
+	})
+	require.NoError(t, err)
+	require.Nil(t, resp.Error, "events/poll returned error: %+v", resp.Error)
+}


### PR DESCRIPTION
## Summary
- Adds the per-event-type hook surface (Match / Transform / OnSubscribe / OnUnsubscribe) as nil-friendly fields on EventDef, plus a typed HookContext interface, panic-recovery wrappers, and Python-original docblocks on each hook type so the Go ↔ Python translation is visible at the call site.
- Adds PollLeaseTable infrastructure for poll-mode lifecycle parity, wired into Config and registerPoll's Touch path. Channel lifecycle is verified by tests so the background sweeper can't hang Close (Close-before-Touch, Close-after, Touch-after-Close, double-Close).
- Both halves are purely additive — no behavior change until η-3 / η-4 wire safe-wrappers and OnCreate / OnExpire to subscriber lifecycle. Foundation lands first so η-3 / η-4 / η-5 / η-6 can land in parallel.

Plan: `docs/EVENTS_ETA_PLAN.md`
Spec: design-sketch-2026-04-30 Server SDK Guidance L565-715

## What this PR does NOT do
- Calls to safeOnSubscribe / safeOnUnsubscribe from events/subscribe, events/unsubscribe, events/stream, or the poll-lease OnCreate/OnExpire callbacks (η-3)
- Match / transform on broadcast emit (η-4)
- EmitToSubscription targeted emit (η-5)
- TooManySubscriptions enforcement (η-6)

## Decisions worth a second look during review
- **HookContext as interface vs struct.** The plan's η-2 section says "HookContext interface + hookContext impl"; current code matches that. A struct with exported methods would be functionally identical and simpler. Flagging in case you want to flip before η-3 lands.
- **Touch placement.** Touch fires after the EventNotFound check so unknown event names don't pollute the lease table. The alternative (touch-then-validate) would surface lease creates for typos. Current order seems right but worth a glance.
- **TransformFunc returns (Event, bool).** Q3 in the plan sketches Event-only; Q8 spells out the (Event, bool) optimization — the bool says "I modified it; re-marshal." Went with Q8 because Q3's signature was illustrative and the allocation cost is real for fanout sources. Documented inline.
- **Anonymous principal handling on poll.** registerPoll calls resolvePrincipal(ctx, unsafeAnon) the same way subscribe and stream do, so a deployment running with UnsafeAnonymousPrincipal=\"demo\" sees a coherent principal across all three modes. Spec L707 ("on unauthenticated servers all callers share one lease") is matched verbatim when no fallback is set — the empty-string principal slot is shared.

## Test plan
- [x] make test-experimental-events
- [x] make test-experimental-events-discord
- [x] make test-experimental-events-telegram
- [x] poll-lease channel-lifecycle tests (CloseBeforeTouch, CloseAfterTouch, TouchAfterClose, DoubleClose)
- [x] hook panic-recovery tests (match returns false on panic, transform returns original, lifecycle hooks log + swallow)
- [x] EventDef hook fields verified absent from events/list JSON output