### PR TITLE
feat(events): η-3 lifecycle hook wiring across all three delivery modes

### DIFF
--- a/examples/events/discord/e2e_test.go
+++ b/examples/events/discord/e2e_test.go
@@ -217,8 +217,7 @@ func TestE2EHealthSignalsEndToEnd(t *testing.T) {
 	defer webhookReceiver.Close()
 
 	canonical := []byte("health-test-canonical")
-	webhooks.Register(canonical, "sub_health", webhookReceiver.URL,
-		"whsec_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 0)
+	webhooks.Register(events.RegisterParams{CanonicalKey: canonical, DerivedID: "sub_health", URL: webhookReceiver.URL, Secret: "whsec_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", MaxAgeSeconds: 0})
 
 	// Step 1: transient error → stream OnError fires; webhook unaffected.
 	require.NoError(t, source.YieldError(events.EventDeliveryError{

--- a/examples/events/telegram/handlers_test.go
+++ b/examples/events/telegram/handlers_test.go
@@ -213,7 +213,7 @@ func TestWebhookHMACSignature_MCPHeaders(t *testing.T) {
 	// Direct registry poke (skip the JSON-RPC subscribe handler) — γ-2
 	// rekeyed Register on canonical-tuple bytes. Use a stub key for the
 	// HMAC delivery test; the canonical-key contents don't matter here.
-	webhooks.Register([]byte("hmac-test"), "sub_hmac_test", srv.URL, secret, 0)
+	webhooks.Register(events.RegisterParams{CanonicalKey: []byte("hmac-test"), DerivedID: "sub_hmac_test", URL: srv.URL, Secret: secret, MaxAgeSeconds: 0})
 
 	event := events.MakeEvent("telegram.message", "evt_1", "1", time.Now(),
 		map[string]string{"text": "hello"})
@@ -305,8 +305,8 @@ func TestWebhookKeyedByCanonicalTuple(t *testing.T) {
 	webhooks := events.NewWebhookRegistry(events.WithWebhookAllowPrivateNetworks(true))
 	keyA := []byte("alice\x1fhttp://example.com/hook\x1ftelegram.message\x1f{}")
 	keyB := []byte("bob\x1fhttp://example.com/hook\x1ftelegram.message\x1f{}")
-	webhooks.Register(keyA, "sub_alice", "http://example.com/hook", "whsec_secret-1", 0)
-	webhooks.Register(keyB, "sub_bob", "http://example.com/hook", "whsec_secret-2", 0)
+	webhooks.Register(events.RegisterParams{CanonicalKey: keyA, DerivedID: "sub_alice", URL: "http://example.com/hook", Secret: "whsec_secret-1", MaxAgeSeconds: 0})
+	webhooks.Register(events.RegisterParams{CanonicalKey: keyB, DerivedID: "sub_bob", URL: "http://example.com/hook", Secret: "whsec_secret-2", MaxAgeSeconds: 0})
 
 	targets := webhooks.Targets()
 	assert.Len(t, targets, 2)
@@ -321,7 +321,7 @@ func TestWebhookKeyedByCanonicalTuple(t *testing.T) {
 // it claims — used by other tests that exercise post-TTL behavior.
 func TestWebhookTTLExpiry(t *testing.T) {
 	webhooks := events.NewWebhookRegistry(events.WithWebhookAllowPrivateNetworks(true))
-	webhooks.Register([]byte("exp-test"), "sub_exp", "http://example.com/hook", "whsec_secret", 0)
+	webhooks.Register(events.RegisterParams{CanonicalKey: []byte("exp-test"), DerivedID: "sub_exp", URL: "http://example.com/hook", Secret: "whsec_secret", MaxAgeSeconds: 0})
 	assert.Len(t, webhooks.Targets(), 1)
 
 	webhooks.ExpireAll()
@@ -348,7 +348,7 @@ func TestWebhookRetryOnServerError(t *testing.T) {
 	defer srv.Close()
 
 	webhooks := events.NewWebhookRegistry(events.WithWebhookAllowPrivateNetworks(true))
-	webhooks.Register([]byte("retry-test"), "sub_retry", srv.URL, "whsec_secret", 0)
+	webhooks.Register(events.RegisterParams{CanonicalKey: []byte("retry-test"), DerivedID: "sub_retry", URL: srv.URL, Secret: "whsec_secret", MaxAgeSeconds: 0})
 
 	event := events.MakeEvent("telegram.message", "evt_retry", "1", time.Now(),
 		map[string]string{"text": "retry me"})
@@ -376,7 +376,7 @@ func TestWebhookNoRetryOn4xx(t *testing.T) {
 	defer srv.Close()
 
 	webhooks := events.NewWebhookRegistry(events.WithWebhookAllowPrivateNetworks(true))
-	webhooks.Register([]byte("no-retry"), "sub_no_retry", srv.URL, "whsec_secret", 0)
+	webhooks.Register(events.RegisterParams{CanonicalKey: []byte("no-retry"), DerivedID: "sub_no_retry", URL: srv.URL, Secret: "whsec_secret", MaxAgeSeconds: 0})
 
 	event := events.MakeEvent("telegram.message", "evt_4xx", "1", time.Now(),
 		map[string]string{"text": "no retry"})

--- a/experimental/ext/events/body_cap_test.go
+++ b/experimental/ext/events/body_cap_test.go
@@ -43,7 +43,7 @@ func TestDelivery_OversizedEventNotPosted(t *testing.T) {
 		WithWebhookAllowPrivateNetworks(true),
 		WithWebhookMaxBodyBytes(1024),
 	)
-	r.Register([]byte("k"), "sub_test", srv.URL, "whsec_secret", 0)
+	r.Register(RegisterParams{CanonicalKey: []byte("k"), DerivedID: "sub_test", URL: srv.URL, Secret: "whsec_secret", MaxAgeSeconds: 0})
 
 	// Build a payload that, when JSON-marshaled with the envelope,
 	// exceeds 1 KiB. 2 KiB of "A" inside Data is enough.
@@ -75,7 +75,7 @@ func TestDelivery_OversizedEventLogged(t *testing.T) {
 		WithWebhookMaxBodyBytes(1024),
 	)
 	logCap.attach(r)
-	r.Register([]byte("k"), "sub_test", srv.URL, "whsec_secret", 0)
+	r.Register(RegisterParams{CanonicalKey: []byte("k"), DerivedID: "sub_test", URL: srv.URL, Secret: "whsec_secret", MaxAgeSeconds: 0})
 
 	bigData, _ := json.Marshal(map[string]string{"text": strings.Repeat("B", 2048)})
 	r.Deliver(Event{
@@ -112,7 +112,7 @@ func TestDelivery_413NotRetried(t *testing.T) {
 	defer srv.Close()
 
 	r := NewWebhookRegistry(WithWebhookAllowPrivateNetworks(true))
-	r.Register([]byte("k"), "sub_test", srv.URL, "whsec_secret", 0)
+	r.Register(RegisterParams{CanonicalKey: []byte("k"), DerivedID: "sub_test", URL: srv.URL, Secret: "whsec_secret", MaxAgeSeconds: 0})
 
 	r.Deliver(MakeEvent("fake.event", "evt_413", "1", time.Now(),
 		map[string]string{"text": "tiny"}))

--- a/experimental/ext/events/clients/go/control_envelope_test.go
+++ b/experimental/ext/events/clients/go/control_envelope_test.go
@@ -38,7 +38,7 @@ func TestReceiver_RoutesGapToCallback(t *testing.T) {
 
 	r := events.NewWebhookRegistry(events.WithWebhookAllowPrivateNetworks(true))
 	canonical := []byte("gap-test-key")
-	r.Register(canonical, "sub_gap_test", srv.URL, secret, 0)
+	r.Register(events.RegisterParams{CanonicalKey: canonical, DerivedID: "sub_gap_test", URL: srv.URL, Secret: secret, MaxAgeSeconds: 0})
 
 	r.PostGap(canonical, "fresh-c-77")
 
@@ -73,7 +73,7 @@ func TestReceiver_RoutesTerminatedToCallback(t *testing.T) {
 
 	r := events.NewWebhookRegistry(events.WithWebhookAllowPrivateNetworks(true))
 	canonical := []byte("terminated-test-key")
-	r.Register(canonical, "sub_term_test", srv.URL, secret, 0)
+	r.Register(events.RegisterParams{CanonicalKey: canonical, DerivedID: "sub_term_test", URL: srv.URL, Secret: secret, MaxAgeSeconds: 0})
 
 	r.PostTerminated(canonical, events.ControlError{Code: -32012, Message: "Unauthorized"})
 
@@ -103,7 +103,7 @@ func TestReceiver_NoCallbacksRegistered(t *testing.T) {
 	var serverPostFailed atomic.Bool
 	r := events.NewWebhookRegistry(events.WithWebhookAllowPrivateNetworks(true))
 	canonical := []byte("no-cb-key")
-	r.Register(canonical, "sub_no_cb", srv.URL, secret, 0)
+	r.Register(events.RegisterParams{CanonicalKey: canonical, DerivedID: "sub_no_cb", URL: srv.URL, Secret: secret, MaxAgeSeconds: 0})
 
 	r.PostGap(canonical, "c1")
 	require.Eventually(t, func() bool {

--- a/experimental/ext/events/control.go
+++ b/experimental/ext/events/control.go
@@ -92,6 +92,11 @@ func (r *WebhookRegistry) PostTerminated(canonicalKey []byte, controlErr Control
 	if !ok {
 		return
 	}
+	// η-3: PostTerminated is server-initiated subscription death;
+	// onRemove fires on actual registry deletion. Suspend (handled
+	// via postTerminatedSilent) deliberately does NOT fire — the
+	// target stays in the registry as paused.
+	r.fireOnRemove(target)
 	body, err := json.Marshal(controlEnvelope{Type: "terminated", Error: &controlErr})
 	if err != nil {
 		r.logf("[webhook] PostTerminated: marshal failed: %v", err)

--- a/experimental/ext/events/control_envelope_test.go
+++ b/experimental/ext/events/control_envelope_test.go
@@ -79,7 +79,7 @@ func TestControlEnvelope_GapShape(t *testing.T) {
 	r := NewWebhookRegistry(WithWebhookAllowPrivateNetworks(true))
 	canonical := canonicalKey("alice", srv.URL, "fake.event", nil)
 	subID := deriveSubscriptionID(canonical)
-	r.Register(canonical, subID, srv.URL, "whsec_"+strings.Repeat("a", 32), 0)
+	r.Register(RegisterParams{CanonicalKey: canonical, DerivedID: subID, URL: srv.URL, Secret: "whsec_"+strings.Repeat("a", 32), MaxAgeSeconds: 0})
 
 	r.PostGap(canonical, "fresh-cursor-123")
 
@@ -125,7 +125,7 @@ func TestControlEnvelope_TerminatedShape(t *testing.T) {
 	r := NewWebhookRegistry(WithWebhookAllowPrivateNetworks(true))
 	canonical := canonicalKey("alice", srv.URL, "fake.event", nil)
 	subID := deriveSubscriptionID(canonical)
-	r.Register(canonical, subID, srv.URL, "whsec_"+strings.Repeat("a", 32), 0)
+	r.Register(RegisterParams{CanonicalKey: canonical, DerivedID: subID, URL: srv.URL, Secret: "whsec_"+strings.Repeat("a", 32), MaxAgeSeconds: 0})
 
 	r.PostTerminated(canonical, ControlError{Code: -32012, Message: "Unauthorized"})
 
@@ -170,7 +170,7 @@ func TestControlEnvelope_TypeDiscriminatorIsTopLevel(t *testing.T) {
 	r := NewWebhookRegistry(WithWebhookAllowPrivateNetworks(true))
 	canonical := canonicalKey("alice", srv.URL, "fake.event", nil)
 	subID := deriveSubscriptionID(canonical)
-	r.Register(canonical, subID, srv.URL, "whsec_"+strings.Repeat("a", 32), 0)
+	r.Register(RegisterParams{CanonicalKey: canonical, DerivedID: subID, URL: srv.URL, Secret: "whsec_"+strings.Repeat("a", 32), MaxAgeSeconds: 0})
 
 	r.PostGap(canonical, "c1")
 

--- a/experimental/ext/events/delivery_status_test.go
+++ b/experimental/ext/events/delivery_status_test.go
@@ -207,7 +207,7 @@ func TestSuspend_AfterThresholdConsecutiveFailures(t *testing.T) {
 		WithWebhookSuspendWindow(10*time.Second),
 	)
 	canonical := []byte("suspend-threshold-test")
-	r.Register(canonical, "sub_st", receiver.URL, "whsec_secret", 0)
+	r.Register(RegisterParams{CanonicalKey: canonical, DerivedID: "sub_st", URL: receiver.URL, Secret: "whsec_secret", MaxAgeSeconds: 0})
 
 	// Drive `threshold` consecutive failed deliveries (each deliver()
 	// internally retries; we count whole-call outcomes, not retries).
@@ -241,7 +241,7 @@ func TestSuspend_FailuresOutsideWindowDontAccumulate(t *testing.T) {
 		WithWebhookSuspendWindow(200*time.Millisecond),
 	)
 	canonical := []byte("suspend-window-test")
-	r.Register(canonical, "sub_sw", receiver.URL, "whsec_secret", 0)
+	r.Register(RegisterParams{CanonicalKey: canonical, DerivedID: "sub_sw", URL: receiver.URL, Secret: "whsec_secret", MaxAgeSeconds: 0})
 
 	// 2 failures, then sleep past the window, then 2 more.
 	// First-failure-time should reset on the post-sleep failures, so
@@ -279,7 +279,7 @@ func TestSuspend_SuccessfulRefreshReactivates(t *testing.T) {
 		WithWebhookSuspendWindow(10*time.Second),
 	)
 	canonical := []byte("reactivate-test")
-	r.Register(canonical, "sub_react", receiver.URL, "whsec_secret", 0)
+	r.Register(RegisterParams{CanonicalKey: canonical, DerivedID: "sub_react", URL: receiver.URL, Secret: "whsec_secret", MaxAgeSeconds: 0})
 
 	// Drive 2 consecutive failures → suspended.
 	r.deliver(r.Targets()[0], "evt_a", []byte(`{}`))
@@ -287,7 +287,7 @@ func TestSuspend_SuccessfulRefreshReactivates(t *testing.T) {
 	require.False(t, r.DeliveryStatus(canonical).Active, "precondition: target should be suspended")
 
 	// Refresh — same canonical tuple, idempotent re-Register.
-	r.Register(canonical, "sub_react", receiver.URL, "whsec_secret", 0)
+	r.Register(RegisterParams{CanonicalKey: canonical, DerivedID: "sub_react", URL: receiver.URL, Secret: "whsec_secret", MaxAgeSeconds: 0})
 
 	st := r.DeliveryStatus(canonical)
 	assert.True(t, st.Active, "successful refresh MUST reactivate; got %+v", st)
@@ -329,7 +329,7 @@ func TestSuspend_SuspendedTargetSkippedInDeliver(t *testing.T) {
 		WithWebhookSuspendWindow(10*time.Second),
 	)
 	canonical := []byte("skip-deliver-test")
-	r.Register(canonical, "sub_skip", receiver.URL, "whsec_secret", 0)
+	r.Register(RegisterParams{CanonicalKey: canonical, DerivedID: "sub_skip", URL: receiver.URL, Secret: "whsec_secret", MaxAgeSeconds: 0})
 
 	// Drive 2 failures → suspended.
 	r.deliver(r.Targets()[0], "evt_a", []byte(`{}`))
@@ -386,7 +386,7 @@ func TestSuspend_AutoPostsTerminatedEnvelopeOnSuspension(t *testing.T) {
 		WithWebhookSuspendWindow(10*time.Second),
 	)
 	canonical := []byte("auto-terminated-test")
-	r.Register(canonical, "sub_at", receiver.URL, "whsec_secret", 0)
+	r.Register(RegisterParams{CanonicalKey: canonical, DerivedID: "sub_at", URL: receiver.URL, Secret: "whsec_secret", MaxAgeSeconds: 0})
 
 	// Drive 2 failures → suspend transition fires.
 	r.deliver(r.Targets()[0], "evt_a", []byte(`{}`))
@@ -432,7 +432,7 @@ func TestSuspend_DoesNotAutoPostTerminatedTwice(t *testing.T) {
 		WithWebhookSuspendWindow(10*time.Second),
 	)
 	canonical := []byte("idempotent-terminated-test")
-	r.Register(canonical, "sub_idem", receiver.URL, "whsec_secret", 0)
+	r.Register(RegisterParams{CanonicalKey: canonical, DerivedID: "sub_idem", URL: receiver.URL, Secret: "whsec_secret", MaxAgeSeconds: 0})
 
 	// Suspend.
 	r.deliver(r.Targets()[0], "evt_a", []byte(`{}`))

--- a/experimental/ext/events/errors.go
+++ b/experimental/ext/events/errors.go
@@ -26,6 +26,7 @@ package events
 const (
 	ErrCodeEventNotFound           = -32011 // Unknown event name
 	ErrCodeUnauthorized            = -32012 // Caller lacks permission for this event/params
+	ErrCodeTooManySubscriptions    = -32013 // Server-imposed subscription limit reached / on_subscribe refused
 	ErrCodeInvalidCallbackUrl      = -32015 // Webhook URL unreachable / rejected
 	ErrCodeDeliveryModeUnsupported = -32017 // Event type doesn't support requested mode
 )

--- a/experimental/ext/events/events.go
+++ b/experimental/ext/events/events.go
@@ -13,6 +13,7 @@
 package events
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 	"time"
@@ -265,6 +266,35 @@ func Register(cfg Config) {
 		leases = NewPollLeaseTable()
 	}
 
+	// η-3: lifecycle hook wiring. The SDK installs onRemove on the
+	// webhook registry (fires safeOnUnsubscribe for explicit
+	// Unregister, TTL prune, PostTerminated) and chains an onExpire
+	// hook on the poll-lease table (fires safeOnUnsubscribe when a
+	// poll lease ages out). on_subscribe firing happens inline at
+	// the per-mode call sites (registerSubscribe for webhook,
+	// registerStream for push, registerPoll for poll) — those have
+	// the live HookContext / params at hand.
+	if webhooks != nil {
+		webhooks.AddOnRemoveHook(func(t WebhookTarget) {
+			source, ok := sourceMap[t.EventName]
+			if !ok {
+				return
+			}
+			hc := newHookContext(context.Background(), t.Principal, t.ID, DeliveryModeWebhook)
+			safeOnUnsubscribe(source.Def().OnUnsubscribe, hc, t.Params)
+		})
+	}
+	leases.chainOnExpire(func(principal, eventName string, params map[string]any) {
+		source, ok := sourceMap[eventName]
+		if !ok {
+			return
+		}
+		// Poll has no subscription id — the lease tuple IS the
+		// identity. SubscriptionID() returns empty per Q4.
+		hc := newHookContext(context.Background(), principal, "", DeliveryModePoll)
+		safeOnUnsubscribe(source.Def().OnUnsubscribe, hc, params)
+	})
+
 	registerList(srv, sources)
 	registerPoll(srv, sourceMap, cfg.UnsafeAnonymousPrincipal, leases)
 	registerStream(srv, sourceMap, cfg.UnsafeAnonymousPrincipal, cfg.StreamHeartbeatInterval)
@@ -387,11 +417,25 @@ func registerPoll(srv *server.Server, sourceMap map[string]EventSource, unsafeAn
 		//
 		// Touch fires OnCreate the first time a (principal, name,
 		// params) tuple is seen and renews the lease on subsequent
-		// polls. η-3 wires OnCreate/OnExpire to safeOnSubscribe /
-		// safeOnUnsubscribe so author hooks fire consistently with
-		// webhook + push lifecycle.
+		// polls. η-3 fires safeOnSubscribe inline when Touch reports
+		// "newly created" — the lease's onExpire (chained by
+		// Register) handles the unsubscribe side from the background
+		// sweep goroutine.
 		principal, _ := resolvePrincipal(ctx, unsafeAnon)
-		leases.Touch(principal, req.Name, req.Params)
+		if leases.Touch(principal, req.Name, req.Params) {
+			hc := newHookContext(ctx, principal, "", DeliveryModePoll)
+			if err := safeOnSubscribe(source.Def().OnSubscribe, hc, req.Params); err != nil {
+				// on_subscribe rejected the lease — surface the
+				// failure to the caller. The lease is already in
+				// the table; rather than racing to remove it, we
+				// rely on its TTL to clean up. The sub will not
+				// have provisioned upstream resources (the author's
+				// hook returned error before that), so the empty
+				// lease is harmless.
+				return core.NewErrorResponse(id, ErrCodeTooManySubscriptions,
+					"on_subscribe rejected: "+err.Error())
+			}
+		}
 
 		cursorless := source.Def().Cursorless
 
@@ -559,7 +603,37 @@ func registerSubscribe(srv *server.Server, sourceMap map[string]EventSource, web
 		canonical := canonicalKey(principal, req.Delivery.URL, req.Name, req.Params)
 		derivedID := deriveSubscriptionID(canonical)
 
-		expiresAt := webhooks.Register(canonical, derivedID, req.Delivery.URL, req.Delivery.Secret, req.MaxAge)
+		expiresAt, isNew := webhooks.Register(RegisterParams{
+			CanonicalKey:  canonical,
+			DerivedID:     derivedID,
+			URL:           req.Delivery.URL,
+			Secret:        req.Delivery.Secret,
+			MaxAgeSeconds: req.MaxAge,
+			EventName:     req.Name,
+			Principal:     principal,
+			Params:        req.Params,
+		})
+
+		// η-3: fire safeOnSubscribe ONLY on first registration. Refresh
+		// of an existing subscription is renewal, not subscribe (Q4); we
+		// do not re-fire so authors don't churn upstream listeners on
+		// every TTL refresh. The webhook on_unsubscribe path runs from
+		// the registry's onRemove hook (installed in Register above).
+		if isNew {
+			source := sourceMap[req.Name]
+			def := source.Def()
+			hc := newHookContext(ctx, principal, derivedID, DeliveryModeWebhook)
+			if err := safeOnSubscribe(def.OnSubscribe, hc, req.Params); err != nil {
+				// on_subscribe rejected: roll back the registration
+				// (otherwise an unprovisioned subscription would still
+				// receive deliveries) and surface the error. η-6 will
+				// add a dedicated SubscribeFailed code; for now use
+				// TooManySubscriptions per the plan's Q3 mapping.
+				webhooks.Unregister(canonical)
+				return core.NewErrorResponse(id, ErrCodeTooManySubscriptions,
+					"on_subscribe rejected: "+err.Error())
+			}
+		}
 
 		// Resolve `cursor: null` to the source's current head ("from now")
 		// for cursored sources. Cursorless sources always serialize as null.

--- a/experimental/ext/events/identity_handler_test.go
+++ b/experimental/ext/events/identity_handler_test.go
@@ -143,8 +143,8 @@ func TestSubscribe_TupleIsolationCrossPrincipal(t *testing.T) {
 	idBob := deriveSubscriptionID(keyBob)
 
 	// Same URL, name, params; different principal → distinct registry entries.
-	webhooks.Register(keyAlice, idAlice, "https://example.com/hook", "whsec_a", 0)
-	webhooks.Register(keyBob, idBob, "https://example.com/hook", "whsec_b", 0)
+	webhooks.Register(RegisterParams{CanonicalKey: keyAlice, DerivedID: idAlice, URL: "https://example.com/hook", Secret: "whsec_a", MaxAgeSeconds: 0})
+	webhooks.Register(RegisterParams{CanonicalKey: keyBob, DerivedID: idBob, URL: "https://example.com/hook", Secret: "whsec_b", MaxAgeSeconds: 0})
 
 	assert.Len(t, webhooks.Targets(), 2, "different principals must produce distinct registry entries")
 	assert.NotEqual(t, idAlice, idBob, "different canonical keys must derive different ids")
@@ -230,7 +230,7 @@ func TestDelivery_EmitsXMCPSubscriptionIDHeader(t *testing.T) {
 	webhooks := NewWebhookRegistry(WithWebhookAllowPrivateNetworks(true))
 	canonical := canonicalKey("test-principal", callback.URL, "fake.event", nil)
 	subID := deriveSubscriptionID(canonical)
-	webhooks.Register(canonical, subID, callback.URL, "whsec_"+strings.Repeat("a", 32), 0)
+	webhooks.Register(RegisterParams{CanonicalKey: canonical, DerivedID: subID, URL: callback.URL, Secret: "whsec_"+strings.Repeat("a", 32), MaxAgeSeconds: 0})
 
 	// Direct Deliver bypasses the JSON-RPC handler — what we want to
 	// inspect is the registry's outbound HTTP shape, not the subscribe

--- a/experimental/ext/events/lifecycle_test.go
+++ b/experimental/ext/events/lifecycle_test.go
@@ -1,0 +1,655 @@
+package events
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/server"
+	"github.com/stretchr/testify/require"
+)
+
+// Lifecycle hook firings across all three delivery modes (η-3).
+//
+// Acceptance per docs/EVENTS_ETA_PLAN.md:
+//   - Hooks fire exactly once per subscription lifecycle in each mode.
+//   - Refresh of an existing webhook subscription does NOT re-fire
+//     on_subscribe.
+//   - TTL expiry of a webhook subscription fires on_unsubscribe.
+//   - Suspend transition does NOT fire on_unsubscribe.
+//   - Subsequent reactivating-refresh does NOT re-fire on_subscribe.
+//   - Poll-lease expiry fires on_unsubscribe.
+//   - on_subscribe error rolls back / rejects across all modes.
+
+// hookCounter records on_subscribe / on_unsubscribe firings with the
+// HookContext snapshot at fire time so tests can assert mode and
+// principal as well as count. Concurrent-safe.
+type hookCounter struct {
+	mu             sync.Mutex
+	subscribes     []hookCall
+	unsubscribes   []hookCall
+	subscribeErr   error // returned from on_subscribe; nil = succeed
+}
+
+type hookCall struct {
+	Principal      string
+	SubscriptionID string
+	Mode           DeliveryMode
+	Params         map[string]any
+}
+
+func (h *hookCounter) onSubscribe(ctx HookContext, params map[string]any) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.subscribes = append(h.subscribes, hookCall{
+		Principal:      ctx.Principal(),
+		SubscriptionID: ctx.SubscriptionID(),
+		Mode:           ctx.Mode(),
+		Params:         params,
+	})
+	return h.subscribeErr
+}
+
+func (h *hookCounter) onUnsubscribe(ctx HookContext, params map[string]any) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.unsubscribes = append(h.unsubscribes, hookCall{
+		Principal:      ctx.Principal(),
+		SubscriptionID: ctx.SubscriptionID(),
+		Mode:           ctx.Mode(),
+		Params:         params,
+	})
+}
+
+func (h *hookCounter) subCount() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.subscribes)
+}
+
+func (h *hookCounter) unsubCount() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.unsubscribes)
+}
+
+func (h *hookCounter) lastSub() (hookCall, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if len(h.subscribes) == 0 {
+		return hookCall{}, false
+	}
+	return h.subscribes[len(h.subscribes)-1], true
+}
+
+// lifecycleFixture wraps the boilerplate of registering a single
+// YieldingSource with hook fields and standing up an mcp Server with
+// init handshake done.
+type lifecycleFixture struct {
+	t        *testing.T
+	srv      *server.Server
+	source   *YieldingSource[map[string]any]
+	yield    func(map[string]any) error
+	def      EventDef
+	webhooks *WebhookRegistry
+	leases   *PollLeaseTable
+	hooks    *hookCounter
+}
+
+func newLifecycleFixture(t *testing.T, hooks *hookCounter, webhookOpts ...WebhookOption) *lifecycleFixture {
+	t.Helper()
+	def := EventDef{
+		Name:        "lifecycle.test",
+		Description: "lifecycle hook firing tests",
+		Delivery:    []string{"poll", "push", "webhook"},
+		OnSubscribe: hooks.onSubscribe,
+		OnUnsubscribe: hooks.onUnsubscribe,
+	}
+	src, yield := NewYieldingSource[map[string]any](def)
+	wh := NewWebhookRegistry(append([]WebhookOption{
+		WithWebhookAllowPrivateNetworks(true),
+	}, webhookOpts...)...)
+	leases := NewPollLeaseTable(
+		WithPollLeaseTTL(40*time.Millisecond),
+		WithPollLeaseSweepInterval(time.Hour), // we drive sweeps manually
+	)
+	srv := server.NewServer(core.ServerInfo{Name: "test", Version: "1.0"})
+	Register(Config{
+		Sources:                  []EventSource{src},
+		Webhooks:                 wh,
+		Server:                   srv,
+		PollLeases:               leases,
+		UnsafeAnonymousPrincipal: "alice",
+		StreamHeartbeatInterval:  500 * time.Millisecond,
+	})
+	finishInitHandshake(t, srv)
+	return &lifecycleFixture{
+		t:        t,
+		srv:      srv,
+		source:   src,
+		yield:    yield,
+		def:      def,
+		webhooks: wh,
+		leases:   leases,
+		hooks:    hooks,
+	}
+}
+
+func (f *lifecycleFixture) close() {
+	f.leases.Close()
+}
+
+// dispatch shells out to the server.Server's Dispatch path with a
+// JSON-RPC envelope. Used for events/subscribe / events/unsubscribe.
+func (f *lifecycleFixture) dispatch(method string, params map[string]any) *core.Response {
+	f.t.Helper()
+	raw, err := json.Marshal(params)
+	require.NoError(f.t, err)
+	resp, err := f.srv.Dispatch(context.Background(), &core.Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  method,
+		Params:  raw,
+	})
+	require.NoError(f.t, err)
+	return resp
+}
+
+// --- Webhook lifecycle ---
+
+func TestLifecycle_Webhook_SubscribeUnsubscribe_FiresHooksOnce(t *testing.T) {
+	hooks := &hookCounter{}
+	f := newLifecycleFixture(t, hooks)
+	defer f.close()
+
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer receiver.Close()
+
+	subParams := map[string]any{
+		"name":   "lifecycle.test",
+		"params": map[string]any{"sev": "high"},
+		"delivery": map[string]any{
+			"mode":   "webhook",
+			"url":    receiver.URL,
+			"secret": "whsec_" + strings.Repeat("a", 32),
+		},
+	}
+	resp := f.dispatch("events/subscribe", subParams)
+	require.Nil(t, resp.Error, "subscribe failed: %+v", resp.Error)
+	if hooks.subCount() != 1 {
+		t.Fatalf("after subscribe: subscribes=%d, want 1", hooks.subCount())
+	}
+	if hooks.unsubCount() != 0 {
+		t.Fatalf("after subscribe: unsubscribes=%d, want 0", hooks.unsubCount())
+	}
+	last, _ := hooks.lastSub()
+	if last.Mode != DeliveryModeWebhook {
+		t.Errorf("on_subscribe Mode = %v, want DeliveryModeWebhook", last.Mode)
+	}
+	if last.Principal != "alice" {
+		t.Errorf("on_subscribe Principal = %q, want \"alice\"", last.Principal)
+	}
+	if last.SubscriptionID == "" || !strings.HasPrefix(last.SubscriptionID, "sub_") {
+		t.Errorf("on_subscribe SubscriptionID = %q, want non-empty sub_ prefixed", last.SubscriptionID)
+	}
+
+	unsubParams := map[string]any{
+		"name":     "lifecycle.test",
+		"params":   map[string]any{"sev": "high"},
+		"delivery": map[string]any{"url": receiver.URL},
+	}
+	resp = f.dispatch("events/unsubscribe", unsubParams)
+	require.Nil(t, resp.Error, "unsubscribe failed: %+v", resp.Error)
+	if hooks.unsubCount() != 1 {
+		t.Fatalf("after unsubscribe: unsubscribes=%d, want 1", hooks.unsubCount())
+	}
+	if hooks.subCount() != 1 {
+		t.Fatalf("after unsubscribe: subscribes=%d (would have re-fired); want 1", hooks.subCount())
+	}
+}
+
+func TestLifecycle_Webhook_RefreshDoesNotReFireOnSubscribe(t *testing.T) {
+	hooks := &hookCounter{}
+	f := newLifecycleFixture(t, hooks)
+	defer f.close()
+
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer receiver.Close()
+
+	subParams := map[string]any{
+		"name":   "lifecycle.test",
+		"params": map[string]any{"sev": "high"},
+		"delivery": map[string]any{
+			"mode":   "webhook",
+			"url":    receiver.URL,
+			"secret": "whsec_" + strings.Repeat("a", 32),
+		},
+	}
+	for i := 0; i < 3; i++ {
+		resp := f.dispatch("events/subscribe", subParams)
+		require.Nil(t, resp.Error, "subscribe %d failed: %+v", i, resp.Error)
+	}
+	if hooks.subCount() != 1 {
+		t.Fatalf("after 3 subscribes (1 new + 2 refresh): subscribes=%d, want 1", hooks.subCount())
+	}
+	if hooks.unsubCount() != 0 {
+		t.Fatalf("refresh fired unsubscribe: %d, want 0", hooks.unsubCount())
+	}
+}
+
+func TestLifecycle_Webhook_TTLPruneFiresOnUnsubscribe(t *testing.T) {
+	hooks := &hookCounter{}
+	// Set a long TTL on the registry but use ExpireAll to force the
+	// next Register to prune. (The pruning side effect is what fires
+	// the unsubscribe hook.)
+	f := newLifecycleFixture(t, hooks, WithWebhookTTL(time.Hour))
+	defer f.close()
+
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer receiver.Close()
+
+	subParams := map[string]any{
+		"name":   "lifecycle.test",
+		"params": map[string]any{"sev": "high"},
+		"delivery": map[string]any{
+			"mode":   "webhook",
+			"url":    receiver.URL,
+			"secret": "whsec_" + strings.Repeat("a", 32),
+		},
+	}
+	resp := f.dispatch("events/subscribe", subParams)
+	require.Nil(t, resp.Error)
+
+	// Force expiry, then a Register call to trigger pruneExpiredLocked.
+	f.webhooks.ExpireAll()
+	resp = f.dispatch("events/subscribe", map[string]any{
+		"name": "lifecycle.test",
+		"params": map[string]any{"sev": "low"}, // distinct → new sub, triggers prune
+		"delivery": map[string]any{
+			"mode":   "webhook",
+			"url":    receiver.URL,
+			"secret": "whsec_" + strings.Repeat("b", 32),
+		},
+	})
+	require.Nil(t, resp.Error)
+
+	if hooks.unsubCount() != 1 {
+		t.Fatalf("after TTL prune: unsubscribes=%d, want 1 (the expired sub)", hooks.unsubCount())
+	}
+}
+
+func TestLifecycle_Webhook_PostTerminatedFiresOnUnsubscribe(t *testing.T) {
+	hooks := &hookCounter{}
+	f := newLifecycleFixture(t, hooks)
+	defer f.close()
+
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer receiver.Close()
+
+	subParams := map[string]any{
+		"name":   "lifecycle.test",
+		"params": map[string]any{"sev": "high"},
+		"delivery": map[string]any{
+			"mode":   "webhook",
+			"url":    receiver.URL,
+			"secret": "whsec_" + strings.Repeat("a", 32),
+		},
+	}
+	resp := f.dispatch("events/subscribe", subParams)
+	require.Nil(t, resp.Error)
+
+	// PostTerminated drives the server-initiated death path. Look up
+	// the canonical key the registry stored.
+	targets := f.webhooks.Targets()
+	require.Len(t, targets, 1, "expected exactly one registered target")
+	f.webhooks.PostTerminated(targets[0].CanonicalKey, ControlError{Code: -32603, Message: "test"})
+
+	if hooks.unsubCount() != 1 {
+		t.Fatalf("PostTerminated: unsubscribes=%d, want 1", hooks.unsubCount())
+	}
+}
+
+// TestLifecycle_Webhook_SuspendDoesNotFireOnUnsubscribe verifies that
+// the suspend transition (Active=true→false from repeated delivery
+// failures, ζ-6) does NOT fire on_unsubscribe — the subscription is
+// paused, not removed; refresh reactivates without re-firing
+// on_subscribe (Q4).
+func TestLifecycle_Webhook_SuspendDoesNotFireOnUnsubscribe(t *testing.T) {
+	hooks := &hookCounter{}
+	const threshold = 2
+	failingReceiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer failingReceiver.Close()
+
+	f := newLifecycleFixture(t, hooks,
+		WithWebhookSuspendThreshold(threshold),
+		WithWebhookSuspendWindow(10*time.Second),
+	)
+	defer f.close()
+
+	subParams := map[string]any{
+		"name":   "lifecycle.test",
+		"params": map[string]any{"sev": "high"},
+		"delivery": map[string]any{
+			"mode":   "webhook",
+			"url":    failingReceiver.URL,
+			"secret": "whsec_" + strings.Repeat("a", 32),
+		},
+	}
+	resp := f.dispatch("events/subscribe", subParams)
+	require.Nil(t, resp.Error)
+	require.Equal(t, 1, hooks.subCount())
+
+	// Drive `threshold` consecutive failed deliveries to trigger
+	// suspend. recordDeliveryFailure flips Active=false and calls
+	// postTerminatedSilent (not PostTerminated) — no registry
+	// deletion → onRemove must not fire.
+	target := f.webhooks.Targets()[0]
+	for i := 0; i < threshold; i++ {
+		f.webhooks.deliver(target, "evt_"+string(rune('a'+i)), []byte(`{}`))
+	}
+
+	st := f.webhooks.DeliveryStatus(target.CanonicalKey)
+	require.False(t, st.Active, "target should be suspended; got %+v", st)
+	if hooks.unsubCount() != 0 {
+		t.Errorf("suspend transition fired %d on_unsubscribe; want 0 (suspend ≠ unsubscribe)",
+			hooks.unsubCount())
+	}
+
+	// Reactivating refresh: same canonical tuple. Active flips back
+	// to true; on_subscribe MUST NOT re-fire.
+	resp = f.dispatch("events/subscribe", subParams)
+	require.Nil(t, resp.Error)
+	st = f.webhooks.DeliveryStatus(target.CanonicalKey)
+	require.True(t, st.Active, "refresh should reactivate suspended target")
+	if hooks.subCount() != 1 {
+		t.Errorf("reactivating refresh re-fired on_subscribe (now %d); want 1", hooks.subCount())
+	}
+}
+
+// TestLifecycle_Webhook_OnSubscribeError_RollsBack verifies that an
+// author returning error from on_subscribe rolls the registration
+// back so a rejected subscription doesn't sit in the registry as
+// half-provisioned.
+func TestLifecycle_Webhook_OnSubscribeError_RollsBack(t *testing.T) {
+	hooks := &hookCounter{subscribeErr: errStub("upstream quota exceeded")}
+	f := newLifecycleFixture(t, hooks)
+	defer f.close()
+
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer receiver.Close()
+
+	resp := f.dispatch("events/subscribe", map[string]any{
+		"name":   "lifecycle.test",
+		"params": map[string]any{"sev": "high"},
+		"delivery": map[string]any{
+			"mode":   "webhook",
+			"url":    receiver.URL,
+			"secret": "whsec_" + strings.Repeat("a", 32),
+		},
+	})
+	require.NotNil(t, resp.Error, "on_subscribe error should produce a JSON-RPC error response")
+	require.Equal(t, ErrCodeTooManySubscriptions, resp.Error.Code)
+
+	// Rollback assertion: registry should not retain the rejected sub.
+	if got := len(f.webhooks.Targets()); got != 0 {
+		t.Errorf("rollback failed: registry contains %d targets after on_subscribe error; want 0", got)
+	}
+	// Rollback fires onRemove (Unregister), which would call
+	// on_unsubscribe — that's fine; the author's hook is allowed to
+	// see the teardown of the subscription it just rejected.
+	if hooks.subCount() != 1 {
+		t.Errorf("on_subscribe call count = %d; want 1", hooks.subCount())
+	}
+}
+
+// --- Push (events/stream) lifecycle ---
+
+func TestLifecycle_Push_OpenCloseFiresHooksOnce(t *testing.T) {
+	hooks := &hookCounter{}
+	f := newLifecycleFixture(t, hooks)
+	defer f.close()
+
+	// events/stream blocks until ctx cancels. Run it in a goroutine
+	// with a short cancel so we can observe both subscribe (after
+	// the channel is acquired) and unsubscribe (on return).
+	ctx, cancel := context.WithCancel(context.Background())
+	rawReq, err := json.Marshal(map[string]any{
+		"name":   "lifecycle.test",
+		"params": map[string]any{"sev": "high"},
+	})
+	require.NoError(t, err)
+
+	streamDone := make(chan struct{})
+	go func() {
+		defer close(streamDone)
+		_, _ = f.srv.Dispatch(ctx, &core.Request{
+			JSONRPC: "2.0",
+			ID:      json.RawMessage(`2`),
+			Method:  "events/stream",
+			Params:  rawReq,
+		})
+	}()
+
+	// Wait for on_subscribe to fire (stream opened).
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && hooks.subCount() == 0 {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if hooks.subCount() != 1 {
+		t.Fatalf("after stream open: subscribes=%d, want 1", hooks.subCount())
+	}
+	last, _ := hooks.lastSub()
+	if last.Mode != DeliveryModePush {
+		t.Errorf("push on_subscribe Mode = %v, want DeliveryModePush", last.Mode)
+	}
+	if !strings.HasPrefix(last.SubscriptionID, "sub_") {
+		t.Errorf("push on_subscribe SubscriptionID = %q, want sub_-prefixed", last.SubscriptionID)
+	}
+
+	cancel()
+	select {
+	case <-streamDone:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("stream did not return after ctx cancel")
+	}
+
+	if hooks.unsubCount() != 1 {
+		t.Fatalf("after stream close: unsubscribes=%d, want 1", hooks.unsubCount())
+	}
+}
+
+func TestLifecycle_Push_OnSubscribeError_RejectsStream(t *testing.T) {
+	hooks := &hookCounter{subscribeErr: errStub("upstream busy")}
+	f := newLifecycleFixture(t, hooks)
+	defer f.close()
+
+	rawReq, err := json.Marshal(map[string]any{
+		"name":   "lifecycle.test",
+		"params": map[string]any{"sev": "high"},
+	})
+	require.NoError(t, err)
+	resp, err := f.srv.Dispatch(context.Background(), &core.Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`3`),
+		Method:  "events/stream",
+		Params:  rawReq,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp.Error)
+	require.Equal(t, ErrCodeTooManySubscriptions, resp.Error.Code)
+	// on_unsubscribe deliberately does NOT fire — we never crossed
+	// the live-subscription line. (defer is set up after the
+	// safeOnSubscribe error check.)
+	if hooks.unsubCount() != 0 {
+		t.Errorf("rejected stream fired %d on_unsubscribe; want 0", hooks.unsubCount())
+	}
+}
+
+// --- Poll lifecycle ---
+
+func TestLifecycle_Poll_FirstPollFiresOnSubscribe(t *testing.T) {
+	hooks := &hookCounter{}
+	f := newLifecycleFixture(t, hooks)
+	defer f.close()
+
+	dispatchPoll(t, f.srv, "lifecycle.test", map[string]any{"sev": "high"})
+	if hooks.subCount() != 1 {
+		t.Fatalf("first poll: subscribes=%d, want 1", hooks.subCount())
+	}
+	last, _ := hooks.lastSub()
+	if last.Mode != DeliveryModePoll {
+		t.Errorf("poll on_subscribe Mode = %v, want DeliveryModePoll", last.Mode)
+	}
+	// Poll has no sub id per Q4.
+	if last.SubscriptionID != "" {
+		t.Errorf("poll on_subscribe SubscriptionID = %q, want \"\" (Q4: poll has no sub id)", last.SubscriptionID)
+	}
+}
+
+func TestLifecycle_Poll_RepeatedPollDoesNotReFire(t *testing.T) {
+	hooks := &hookCounter{}
+	f := newLifecycleFixture(t, hooks)
+	defer f.close()
+
+	for i := 0; i < 5; i++ {
+		dispatchPoll(t, f.srv, "lifecycle.test", map[string]any{"sev": "high"})
+	}
+	if hooks.subCount() != 1 {
+		t.Fatalf("after 5 polls: subscribes=%d, want 1", hooks.subCount())
+	}
+}
+
+func TestLifecycle_Poll_TTLExpiryFiresOnUnsubscribe(t *testing.T) {
+	hooks := &hookCounter{}
+	f := newLifecycleFixture(t, hooks)
+	defer f.close()
+
+	dispatchPoll(t, f.srv, "lifecycle.test", map[string]any{"sev": "high"})
+	require.Equal(t, 1, hooks.subCount())
+
+	// Wait past TTL (40ms in fixture), then drive the sweep.
+	time.Sleep(60 * time.Millisecond)
+	f.leases.sweepExpiredForTest()
+
+	// Sweep fires asynchronously through chainOnExpire; give it a
+	// moment to deliver. (sweepExpiredForTest fires hooks
+	// synchronously in the calling goroutine, but the chained hook
+	// invokes safeOnUnsubscribe which is also sync; just be safe.)
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) && hooks.unsubCount() == 0 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if hooks.unsubCount() != 1 {
+		t.Fatalf("poll TTL expiry: unsubscribes=%d, want 1", hooks.unsubCount())
+	}
+}
+
+func TestLifecycle_Poll_OnSubscribeError_Rejects(t *testing.T) {
+	hooks := &hookCounter{subscribeErr: errStub("poll quota")}
+	f := newLifecycleFixture(t, hooks)
+	defer f.close()
+
+	body := map[string]any{
+		"name":   "lifecycle.test",
+		"params": map[string]any{"sev": "high"},
+	}
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+	resp, err := f.srv.Dispatch(context.Background(), &core.Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`4`),
+		Method:  "events/poll",
+		Params:  raw,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp.Error, "poll on_subscribe error should surface via JSON-RPC error")
+	require.Equal(t, ErrCodeTooManySubscriptions, resp.Error.Code)
+}
+
+// --- Concurrency safety ---
+
+// Concurrent subscribes for the same canonical tuple should fire
+// on_subscribe exactly once (the second call is a refresh — the
+// registry's isNew flag determines this atomically under the lock).
+func TestLifecycle_Webhook_ConcurrentSubscribe_FiresOnce(t *testing.T) {
+	hooks := &hookCounter{}
+	f := newLifecycleFixture(t, hooks)
+	defer f.close()
+
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer receiver.Close()
+
+	subParams := map[string]any{
+		"name":   "lifecycle.test",
+		"params": map[string]any{"sev": "high"},
+		"delivery": map[string]any{
+			"mode":   "webhook",
+			"url":    receiver.URL,
+			"secret": "whsec_" + strings.Repeat("a", 32),
+		},
+	}
+
+	raw, err := json.Marshal(subParams)
+	require.NoError(t, err)
+
+	const goroutines = 8
+	var wg sync.WaitGroup
+	var fails atomic.Int32
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			// Distinct IDs so the dispatcher doesn't dedup
+			// concurrent identical envelopes.
+			idRaw := json.RawMessage([]byte{'"', 'r', byte('0' + i), '"'})
+			resp, derr := f.srv.Dispatch(context.Background(), &core.Request{
+				JSONRPC: "2.0",
+				ID:      idRaw,
+				Method:  "events/subscribe",
+				Params:  raw,
+			})
+			if derr != nil || (resp != nil && resp.Error != nil) {
+				fails.Add(1)
+				if resp != nil && resp.Error != nil {
+					t.Logf("subscribe goroutine %d error: %+v", i, resp.Error)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	if fails.Load() != 0 {
+		t.Fatalf("concurrent subscribes had %d failures; want 0", fails.Load())
+	}
+	if hooks.subCount() != 1 {
+		t.Errorf("concurrent subscribes for same canonical tuple fired on_subscribe %d times; want 1", hooks.subCount())
+	}
+}
+
+// errStub returns a sentinel error for the on_subscribe rejection
+// tests. Inline so the lifecycle tests don't import a heavy errors
+// package for one-off sentinels.
+type errStub string
+
+func (e errStub) Error() string { return string(e) }

--- a/experimental/ext/events/poll_lease.go
+++ b/experimental/ext/events/poll_lease.go
@@ -268,6 +268,32 @@ func (t *PollLeaseTable) sweepExpired() {
 // deterministically without waiting for the ticker.
 func (t *PollLeaseTable) sweepExpiredForTest() { t.sweepExpired() }
 
+// chainOnExpire appends an additional OnExpire hook that fires after
+// any user-supplied one. Used by events.Register to install the
+// SDK's safeOnUnsubscribe wiring on a table the user may have
+// constructed with their own OnExpire diagnostic hook. Chaining
+// (rather than overwriting) keeps both observable.
+//
+// Package-internal: the public surface is WithPollLeaseOnExpire
+// (single hook at construction). η-3 is the only caller — adding
+// the SDK's lifecycle wiring on a per-Register basis.
+func (t *PollLeaseTable) chainOnExpire(h PollLeaseHook) {
+	if h == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	prev := t.onExpire
+	if prev == nil {
+		t.onExpire = h
+		return
+	}
+	t.onExpire = func(principal, eventName string, params map[string]any) {
+		prev(principal, eventName, params)
+		h(principal, eventName, params)
+	}
+}
+
 // invokeLeaseHook invokes a PollLeaseHook with panic recovery. A
 // hook that panics shouldn't take down the sweep goroutine or the
 // poll handler; log + swallow.

--- a/experimental/ext/events/ssrf_delivery_test.go
+++ b/experimental/ext/events/ssrf_delivery_test.go
@@ -102,7 +102,7 @@ func TestDelivery_RejectsLoopbackAtDialTime(t *testing.T) {
 	logCap := &captureLog{}
 	r := ssrfTestRegistry(false, logCap) // allowPrivate=false → loopback BLOCKED
 
-	r.Register([]byte("k"), "sub_test", srv.URL, "whsec_secret", 0)
+	r.Register(RegisterParams{CanonicalKey: []byte("k"), DerivedID: "sub_test", URL: srv.URL, Secret: "whsec_secret", MaxAgeSeconds: 0})
 	r.Deliver(MakeEvent("fake.event", "evt_1", "1", time.Now(),
 		map[string]string{"text": "hi"}))
 
@@ -127,7 +127,7 @@ func TestDelivery_AllowsLoopbackWithEscape(t *testing.T) {
 	defer srv.Close()
 
 	r := ssrfTestRegistry(true, nil) // allowPrivate=true → demo mode
-	r.Register([]byte("k"), "sub_test", srv.URL, "whsec_secret", 0)
+	r.Register(RegisterParams{CanonicalKey: []byte("k"), DerivedID: "sub_test", URL: srv.URL, Secret: "whsec_secret", MaxAgeSeconds: 0})
 	r.Deliver(MakeEvent("fake.event", "evt_1", "1", time.Now(),
 		map[string]string{"text": "hi"}))
 
@@ -228,7 +228,7 @@ func TestDelivery_DoesNotFollowRedirects(t *testing.T) {
 	// Use the loopback escape so we can test the redirect specifically,
 	// not the SSRF dial guard.
 	r := ssrfTestRegistry(true, nil)
-	r.Register([]byte("k"), "sub_test", srv.URL, "whsec_secret", 0)
+	r.Register(RegisterParams{CanonicalKey: []byte("k"), DerivedID: "sub_test", URL: srv.URL, Secret: "whsec_secret", MaxAgeSeconds: 0})
 	r.Deliver(MakeEvent("fake.event", "evt_1", "1", time.Now(),
 		map[string]string{"text": "hi"}))
 

--- a/experimental/ext/events/stream.go
+++ b/experimental/ext/events/stream.go
@@ -21,12 +21,32 @@ package events
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"encoding/json"
 	"time"
 
 	"github.com/panyam/mcpkit/core"
 	"github.com/panyam/mcpkit/server"
 )
+
+// newStreamSubscriptionID generates the server-derived sub_<base64>
+// handle for a push stream (η-3). Streams have no canonical-tuple
+// identity (no delivery URL), and the same (principal, name, params)
+// can be open across multiple concurrent streams — each is its own
+// runtime subscription. A random 16-byte sub id keeps SubscriptionID()
+// usable on HookContext for push without conflating concurrent
+// streams.
+//
+// Webhook uses deriveSubscriptionID over the canonical tuple so two
+// subscribes with identical inputs collapse onto one id; that property
+// is correct for webhook (refresh ≠ new sub) but wrong for push (each
+// stream open IS a new sub). Hence the different generation strategy.
+func newStreamSubscriptionID() string {
+	var buf [16]byte
+	_, _ = rand.Read(buf[:])
+	return "sub_" + base64.RawURLEncoding.EncodeToString(buf[:])
+}
 
 const defaultStreamHeartbeatInterval = 30 * time.Second
 
@@ -124,7 +144,8 @@ func registerStream(srv *server.Server, sourceMap map[string]EventSource, unsafe
 		// events/stream MUST be called with an authenticated principal —
 		// the spec lists Unauthorized among events/stream's immediate
 		// errors at L267. Same auth gate as events/subscribe (γ-2).
-		if _, ok := resolvePrincipal(ctx, unsafeAnon); !ok {
+		principal, ok := resolvePrincipal(ctx, unsafeAnon)
+		if !ok {
 			return core.NewErrorResponse(id, ErrCodeUnauthorized, "Unauthorized")
 		}
 
@@ -163,6 +184,23 @@ func registerStream(srv *server.Server, sourceMap map[string]EventSource, unsafe
 		})
 
 		evCh := sub.Subscribe(ctx)
+
+		// η-3: lifecycle hooks for push. on_subscribe fires after the
+		// channel is acquired (the subscription is now live and would
+		// receive events); on_unsubscribe fires on every return path
+		// via defer. The fresh sub id is unique per stream so concurrent
+		// streams from the same principal/name/params don't conflate.
+		streamSubID := newStreamSubscriptionID()
+		hc := newHookContext(ctx, principal, streamSubID, DeliveryModePush)
+		if err := safeOnSubscribe(def.OnSubscribe, hc, req.Params); err != nil {
+			// Author rejected provisioning; close out the stream
+			// before any delivery happens. Returning an error here
+			// produces a JSON-RPC error response per the spec's
+			// "events/stream's immediate errors" at L267.
+			return core.NewErrorResponse(id, ErrCodeTooManySubscriptions,
+				"on_subscribe rejected: "+err.Error())
+		}
+		defer safeOnUnsubscribe(def.OnUnsubscribe, hc, req.Params)
 
 		ticker := time.NewTicker(heartbeat)
 		defer ticker.Stop()

--- a/experimental/ext/events/webhook.go
+++ b/experimental/ext/events/webhook.go
@@ -25,6 +25,30 @@ const (
 // WebhookOption configures a WebhookRegistry at construction time.
 type WebhookOption func(*WebhookRegistry)
 
+// WebhookOnRemoveHook fires whenever a target is actually removed from
+// the registry — explicit Unregister, TTL prune, or PostTerminated.
+// Does NOT fire on the suspend transition (Active=true→false), which
+// keeps the target in the registry as paused (η-3 / Q4: suspend ≠
+// unsubscribe; refresh reactivates without re-firing on_subscribe).
+//
+// Hooks fire OUTSIDE the registry's lock so a slow listener can't
+// serialize Register/Unregister/PostTerminated.
+type WebhookOnRemoveHook func(t WebhookTarget)
+
+// WithWebhookOnRemove registers a callback that fires when a target is
+// actually removed from the registry. Multiple calls accumulate — all
+// hooks fire in registration order. events.Register installs an SDK-
+// internal hook here to fire safeOnUnsubscribe on the EventDef's
+// OnUnsubscribe field; deployments wanting their own diagnostic
+// listener can pass an additional hook via this option.
+func WithWebhookOnRemove(h WebhookOnRemoveHook) WebhookOption {
+	return func(r *WebhookRegistry) {
+		if h != nil {
+			r.onRemoveHooks = append(r.onRemoveHooks, h)
+		}
+	}
+}
+
 // WithWebhookTTL overrides the registry's subscription TTL. Useful for tests
 // (drive the SDK's TTL refresh behavior in seconds rather than minutes) and
 // for deployments that want longer-lived subscriptions. Pass <=0 to keep
@@ -128,6 +152,12 @@ func WithWebhookAllowPrivateNetworks(allow bool) WebhookOption {
 // (§"Subscription Identity" → "Derived id" L367), surfaced on the wire
 // as the X-MCP-Subscription-Id header on every delivery POST per
 // §"Webhook Event Delivery" L390.
+//
+// EventName, Principal, Params (η-3): copies of the identity components
+// stored separately so OnRemove hooks (and η-4 match/transform on
+// fanout) can construct a HookContext + params payload without
+// re-parsing canonical bytes. Redundant with CanonicalKey; cheap to
+// store, and the registry already owns the only writer.
 type WebhookTarget struct {
 	CanonicalKey  []byte    // canonical bytes of (principal, url, name, params)
 	ID            string    // server-derived routing handle (sub_<base64-of-16-bytes>)
@@ -135,6 +165,10 @@ type WebhookTarget struct {
 	Secret        string    // client-supplied HMAC signing secret (whsec_...)
 	ExpiresAt     time.Time // soft-state TTL expiry
 	MaxAgeSeconds int       // δ-3: per-spec replay floor (§"Cursor Lifecycle" L529); 0 = no floor
+
+	EventName string         // event-type name (η-3 hook lookup)
+	Principal string         // resolved subscription principal (η-3 HookContext)
+	Params    map[string]any // canonicalized subscription params (η-3 hook payload)
 
 	// ζ-5: per-target delivery health, surfaced on subscribe refresh
 	// response per spec §"Webhook Delivery Status" L425-460.
@@ -210,10 +244,52 @@ type WebhookRegistry struct {
 	suspendThreshold     int           // ζ-6: consecutive failures → Active=false; default 5
 	suspendWindow        time.Duration // ζ-6: sliding window over which failures accumulate; default 10min
 
+	// onRemoveHooks fire when a target is actually removed from the
+	// registry (Unregister, TTL prune, PostTerminated). η-3.
+	// Mutated only at construction (WithWebhookOnRemove) and via
+	// AddOnRemoveHook; reads under mu.RLock. Hooks fire OUTSIDE the
+	// lock to keep a slow listener from serializing the registry.
+	onRemoveHooks []WebhookOnRemoveHook
+
 	// logf is the logging hook used by deliver paths. Defaults to log.Printf;
 	// tests override via setLogfForTest to capture failures (including SSRF
 	// dial-time rejections) for assertions.
 	logf func(format string, args ...any)
+}
+
+// AddOnRemoveHook registers a callback that fires when a target is
+// actually removed from the registry. Equivalent to WithWebhookOnRemove
+// but callable after construction — used by events.Register to install
+// the SDK's safeOnUnsubscribe wiring on a registry the user
+// constructed.
+func (r *WebhookRegistry) AddOnRemoveHook(h WebhookOnRemoveHook) {
+	if h == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.onRemoveHooks = append(r.onRemoveHooks, h)
+}
+
+// fireOnRemove invokes every registered onRemove hook with the given
+// target. MUST be called outside r.mu so a slow listener doesn't
+// serialize the registry. Each hook runs with panic recovery — a
+// buggy listener can't take down the caller (Unregister / Register's
+// prune path / PostTerminated).
+func (r *WebhookRegistry) fireOnRemove(t WebhookTarget) {
+	r.mu.RLock()
+	hooks := append([]WebhookOnRemoveHook(nil), r.onRemoveHooks...)
+	r.mu.RUnlock()
+	for _, h := range hooks {
+		func() {
+			defer func() {
+				if rec := recover(); rec != nil {
+					r.logf("[webhook] OnRemove hook panic for target %s: %v", t.ID, rec)
+				}
+			}()
+			h(t)
+		}()
+	}
 }
 
 // NewWebhookRegistry creates an empty registry with the documented defaults:
@@ -340,38 +416,67 @@ func (r *WebhookRegistry) setLogfForTest(f func(format string, args ...any)) {
 }
 
 
+// RegisterParams bundles the inputs for Register. Promoted to a struct
+// over a long positional list because η-3 added EventName / Principal
+// / Params to the identity-side state — six positional args was
+// already at the readability ceiling.
+type RegisterParams struct {
+	CanonicalKey  []byte
+	DerivedID     string
+	URL           string
+	Secret        string
+	MaxAgeSeconds int
+
+	// EventName / Principal / Params (η-3): copies of the identity
+	// components the registry stores so OnRemove hooks have full
+	// HookContext + payload available without re-parsing canonical
+	// bytes. Fed by the same canonical-tuple inputs the caller
+	// already used to compute CanonicalKey.
+	EventName string
+	Principal string
+	Params    map[string]any
+}
+
 // Register adds or refreshes a webhook subscription keyed on the spec's
 // canonical tuple (§"Subscription Identity" → "Key composition" L363).
-// Two calls with the same canonicalKey refer to the same subscription
-// — second call refreshes TTL + replaces secret. Returns the expiry time.
+// Two calls with the same CanonicalKey refer to the same subscription
+// — second call refreshes TTL + replaces secret.
 //
-// The derivedID is the X-MCP-Subscription-Id value the registry emits
-// on every delivery POST; it MUST be deriveSubscriptionID(canonicalKey)
+// Returns (expiresAt, isNew). isNew is true on first registration
+// (caller fires safeOnSubscribe) and false on refresh (η-3 / Q4:
+// refresh ≠ subscribe). Caller resolves the distinction; the registry
+// just reports it.
+//
+// DerivedID is the X-MCP-Subscription-Id value the registry emits on
+// every delivery POST; it MUST be deriveSubscriptionID(CanonicalKey)
 // from identity.go. Passed in (rather than computed here) so the
 // caller can derive once and reuse for both Register and the
 // subscribe-response body.
 //
-// maxAgeSeconds is the per-subscription replay floor per spec
+// MaxAgeSeconds is the per-subscription replay floor per spec
 // §"Cursor Lifecycle" → "Bounding replay with maxAge" L529. Stored on
 // the target for use on (future) reconnect-with-replay; 0 means no
 // floor. On refresh, an explicit non-zero value replaces the prior
 // stored floor; 0 leaves the existing value untouched (treats omission
 // as "don't change").
-func (r *WebhookRegistry) Register(canonicalKey []byte, derivedID, urlStr, secret string, maxAgeSeconds int) time.Time {
+//
+// Side effect: prunes expired targets before registering. Each pruned
+// target fires the onRemove hooks (η-3: lifecycle parity — TTL expiry
+// is an unsubscribe).
+func (r *WebhookRegistry) Register(p RegisterParams) (expiresAt time.Time, isNew bool) {
 	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.pruneExpiredLocked()
-	expiresAt := time.Now().Add(r.ttl)
-	key := string(canonicalKey)
+	pruned := r.pruneExpiredLocked()
+	expiresAt = time.Now().Add(r.ttl)
+	key := string(p.CanonicalKey)
 	if existing, ok := r.targets[key]; ok {
 		// Refresh: update expiry and secret if provided. Secret rotation
 		// per spec is allowed by supplying a new value on refresh.
 		existing.ExpiresAt = expiresAt
-		if secret != "" {
-			existing.Secret = secret
+		if p.Secret != "" {
+			existing.Secret = p.Secret
 		}
-		if maxAgeSeconds > 0 {
-			existing.MaxAgeSeconds = maxAgeSeconds
+		if p.MaxAgeSeconds > 0 {
+			existing.MaxAgeSeconds = p.MaxAgeSeconds
 		}
 		// ζ-6: a successful refresh reactivates a suspended target per
 		// spec L460. Clear the failure run so deliveries can resume.
@@ -385,31 +490,55 @@ func (r *WebhookRegistry) Register(canonicalKey []byte, derivedID, urlStr, secre
 			existing.failureCount = 0
 		}
 		r.targets[key] = existing
+		isNew = false
 	} else {
 		r.targets[key] = WebhookTarget{
-			CanonicalKey:  canonicalKey,
-			ID:            derivedID,
-			URL:           urlStr,
-			Secret:        secret,
+			CanonicalKey:  p.CanonicalKey,
+			ID:            p.DerivedID,
+			URL:           p.URL,
+			Secret:        p.Secret,
 			ExpiresAt:     expiresAt,
-			MaxAgeSeconds: maxAgeSeconds,
+			MaxAgeSeconds: p.MaxAgeSeconds,
+			EventName:     p.EventName,
+			Principal:     p.Principal,
+			Params:        p.Params,
 			// ζ-5: Active defaults to true on first registration. The
 			// suspend state machine in ζ-6 flips this to false after
 			// repeated failures; a successful refresh resets it.
 			Status: DeliveryStatus{Active: true},
 		}
+		isNew = true
 	}
-	return expiresAt
+	r.mu.Unlock()
+
+	// Fire onRemove for any pruned targets OUTSIDE the lock — a slow
+	// listener (e.g., one that releases an upstream resource via
+	// blocking I/O inside on_unsubscribe) shouldn't serialize the
+	// registry's hot path.
+	for _, t := range pruned {
+		r.fireOnRemove(t)
+	}
+	return expiresAt, isNew
 }
 
 // Unregister removes a webhook subscription by canonical-tuple key.
 // No-op if no entry matches. Per spec §"Unsubscribing: events/unsubscribe"
 // L509, the derived id is not accepted as input — callers resolve via
 // the same canonical tuple they would for a subscribe.
+//
+// Fires onRemove hooks for the deleted target — η-3's lifecycle
+// parity. Callers that explicitly Unregister get the same on_unsubscribe
+// behavior as TTL prune and PostTerminated.
 func (r *WebhookRegistry) Unregister(canonicalKey []byte) {
 	r.mu.Lock()
-	defer r.mu.Unlock()
-	delete(r.targets, string(canonicalKey))
+	target, ok := r.targets[string(canonicalKey)]
+	if ok {
+		delete(r.targets, string(canonicalKey))
+	}
+	r.mu.Unlock()
+	if ok {
+		r.fireOnRemove(target)
+	}
 }
 
 // Targets returns a snapshot of all non-expired AND non-suspended
@@ -433,15 +562,21 @@ func (r *WebhookRegistry) Targets() []WebhookTarget {
 	return out
 }
 
-// pruneExpiredLocked removes expired subscriptions. Must hold r.mu write lock.
-func (r *WebhookRegistry) pruneExpiredLocked() {
+// pruneExpiredLocked removes expired subscriptions and returns the
+// removed targets so the caller can fire onRemove hooks OUTSIDE the
+// lock (η-3: lifecycle parity — TTL prune is an unsubscribe). Must
+// hold r.mu write lock.
+func (r *WebhookRegistry) pruneExpiredLocked() []WebhookTarget {
 	now := time.Now()
+	var removed []WebhookTarget
 	for key, t := range r.targets {
 		if t.ExpiresAt.Before(now) {
 			log.Printf("[webhook] subscription %s expired, removing", t.ID)
 			delete(r.targets, key)
+			removed = append(removed, t)
 		}
 	}
+	return removed
 }
 
 // ExpireAll forcibly expires all subscriptions (test helper).


### PR DESCRIPTION
## Summary
- Wires safeOnSubscribe / safeOnUnsubscribe (η-2's surface) at the per-mode call sites — webhook subscribe/unsubscribe/prune/PostTerminated, push stream open/close, poll first-touch/lease-expiry. Authors set OnSubscribe / OnUnsubscribe once on EventDef; the SDK fires consistently across modes.
- Q4 contract is enforced and tested: refresh ≠ subscribe (no re-fire on TTL refresh), suspend ≠ unsubscribe (Active=false leaves the target in the registry; reactivating refresh does not re-fire on_subscribe).
- on_subscribe returning error rolls back webhook registration and rejects push/poll subscriptions before the live-subscription line. Surfaces as -32013 TooManySubscriptions; η-6 may differentiate to a SubscribeFailed code if needed.

Built on top of #399 (foundation). Plan: \`docs/EVENTS_ETA_PLAN.md\`.

## Notable changes worth attention during review

### WebhookRegistry.Register signature change
- Was: \`Register(canonicalKey, derivedID, url, secret, maxAge) time.Time\`
- Now: \`Register(RegisterParams) (time.Time, bool)\` — bool is \`isNew\` so the caller fires on_subscribe ONLY on first registration.
- Struct over positional because adding EventName / Principal / Params (needed for hook payloads) brought the arg count past readability. Six call sites in tests + two in examples were updated.
- Experimental package — breaking changes are expected per CLAUDE.md. Flagging in case you want a thin positional shim retained.

### WebhookRegistry.OnRemove hooks
- \`WithWebhookOnRemove(h)\` at construction + \`AddOnRemoveHook(h)\` post-construction (the SDK uses the latter from \`Register()\` since the user constructs the WebhookRegistry first).
- Multiple hooks accumulate; all fire in registration order with panic recovery so a buggy listener can't take down the registry.
- Fires from Unregister, prune-on-Register, PostTerminated. Does NOT fire from postTerminatedSilent (suspend) — that path keeps the target in the registry as paused.

### Push subscription IDs
- Fresh \`sub_<base64-of-16-bytes>\` per stream open via \`newStreamSubscriptionID\` (crypto/rand). Deliberately different from webhook (which derives deterministically from the canonical tuple) because concurrent push streams from the same principal/name/params are each a separate runtime subscription.

### Poll lease OnExpire chaining
- New package-internal helper \`PollLeaseTable.chainOnExpire\` composes the SDK's safeOnUnsubscribe wiring with any user-supplied OnExpire (set via \`WithPollLeaseOnExpire\`) — both fire. registerPoll fires on_subscribe inline (uses Touch's bool return) so we don't need to chain OnCreate.

## What this PR does NOT do
- Match / transform on broadcast emit (η-4)
- Targeted emit by subscription id (η-5)
- TooManySubscriptions enforcement counts (η-6 — this PR uses the code for on_subscribe rejection only)

## Test plan
- [x] make test-experimental-events
- [x] make test-experimental-events-discord
- [x] make test-experimental-events-telegram
- [x] make test-experimental-events-clients-go
- [x] new lifecycle_test.go: 13 cases covering webhook subscribe/unsubscribe/refresh/TTL/PostTerminated/suspend/concurrent + push open/close + poll first/repeat/expiry + on_subscribe error rejection in all three modes