### PR TITLE
feat(events): η-4 match / transform on broadcast emit

### DIFF
--- a/experimental/ext/events/events.go
+++ b/experimental/ext/events/events.go
@@ -283,8 +283,23 @@ func Register(cfg Config) {
 			hc := newHookContext(context.Background(), t.Principal, t.ID, DeliveryModeWebhook)
 			safeOnUnsubscribe(source.Def().OnUnsubscribe, hc, t.Params)
 		})
+		// η-4: let Deliver look up Match / Transform per event name
+		// without leaking sourceMap onto WebhookRegistry.
+		webhooks.SetDefResolver(func(eventName string) EventDef {
+			source, ok := sourceMap[eventName]
+			if !ok {
+				return EventDef{}
+			}
+			return source.Def()
+		})
 	}
-	leases.chainOnExpire(func(principal, eventName string, params map[string]any) {
+	// Chain the SDK's onExpire onto whatever the user already
+	// configured (via WithPollLeaseOnExpire on the table they passed).
+	// Both fire — user diagnostic stays observable while the SDK
+	// dispatches to safeOnUnsubscribe. Mutating onExpire under
+	// PollLeaseTable.mu so it's safe even if the sweeper has already
+	// started reading it.
+	sdkOnExpire := func(principal, eventName string, params map[string]any) {
 		source, ok := sourceMap[eventName]
 		if !ok {
 			return
@@ -293,7 +308,17 @@ func Register(cfg Config) {
 		// identity. SubscriptionID() returns empty per Q4.
 		hc := newHookContext(context.Background(), principal, "", DeliveryModePoll)
 		safeOnUnsubscribe(source.Def().OnUnsubscribe, hc, params)
-	})
+	}
+	leases.mu.Lock()
+	if prev := leases.onExpire; prev != nil {
+		leases.onExpire = func(p, n string, params map[string]any) {
+			prev(p, n, params)
+			sdkOnExpire(p, n, params)
+		}
+	} else {
+		leases.onExpire = sdkOnExpire
+	}
+	leases.mu.Unlock()
 
 	registerList(srv, sources)
 	registerPoll(srv, sourceMap, cfg.UnsafeAnonymousPrincipal, leases)
@@ -456,6 +481,27 @@ func registerPoll(srv *server.Server, sourceMap map[string]EventSource, unsafeAn
 		if hasMore {
 			events = events[:req.MaxEvents]
 			resultCursor = events[len(events)-1].CursorStr()
+		}
+
+		// η-4: per-call match/transform on the events the source
+		// returned. Match drops events the caller's params don't
+		// want; Transform shapes the event for this caller. Spec
+		// L629: "Poll subscribers see the same filtering and shaping
+		// as push/webhook subscribers." We apply BEFORE the maxAge
+		// floor so authors who use Transform to backdate timestamps
+		// (or whatever) still get a consistent floor.
+		def := source.Def()
+		if def.Match != nil || def.Transform != nil {
+			hc := newHookContext(ctx, principal, "", DeliveryModePoll)
+			kept := make([]Event, 0, len(events))
+			for _, e := range events {
+				if !safeMatch(def.Match, hc, e, req.Params) {
+					continue
+				}
+				delivered, _ := safeTransform(def.Transform, hc, e, req.Params)
+				kept = append(kept, delivered)
+			}
+			events = kept
 		}
 
 		// δ-2: maxAge replay floor per spec §"Cursor Lifecycle" →

--- a/experimental/ext/events/match_transform_test.go
+++ b/experimental/ext/events/match_transform_test.go
@@ -1,0 +1,561 @@
+package events
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/server"
+	"github.com/stretchr/testify/require"
+)
+
+// Per-subscription Match / Transform on broadcast emit (η-4).
+//
+// Coverage targets per docs/EVENTS_ETA_PLAN.md η-4 acceptance:
+//   - Match returning false filters that subscriber out.
+//   - Transform changes the delivered event per subscriber.
+//   - nil hooks are no-op (passthrough; baseline).
+//   - Panicking hooks recover safely (match=false, transform=identity).
+//   - Webhook bodies re-marshal + re-sign per target ONLY when
+//     transform actually returned (_, true).
+//   - Cross-mode parity: same EventDef, same emit → push / webhook /
+//     poll all agree on which subscribers see the event and what
+//     shape it arrives in.
+
+type sevPayload struct {
+	Severity string `json:"severity"`
+	Reporter string `json:"reporter"`
+}
+
+// matchOnSeverity returns a MatchFunc that delivers the event only
+// when the subscriber's params.severity equals the event's severity
+// (or when params.severity is unset → deliver-all). Mirrors the
+// canonical spec example at L633-644.
+func matchOnSeverity() MatchFunc {
+	return func(_ HookContext, event Event, params map[string]any) bool {
+		want, ok := params["severity"].(string)
+		if !ok || want == "" {
+			return true
+		}
+		var p sevPayload
+		if err := json.Unmarshal(event.Data, &p); err != nil {
+			return true // unparseable → don't filter (fail open)
+		}
+		return p.Severity == want
+	}
+}
+
+// transformRedactReporter blanks the Reporter field when the
+// subscriber's params.redact_pii is truthy. Returns (modified, true)
+// only when it actually redacted, so the wiring's Q8 short-circuit
+// can skip re-marshal on the passthrough path.
+func transformRedactReporter() TransformFunc {
+	return func(_ HookContext, event Event, params map[string]any) (Event, bool) {
+		v, _ := params["redact_pii"].(bool)
+		if !v {
+			return event, false
+		}
+		var p sevPayload
+		if err := json.Unmarshal(event.Data, &p); err != nil {
+			return event, false
+		}
+		p.Reporter = ""
+		raw, err := json.Marshal(p)
+		if err != nil {
+			return event, false
+		}
+		out := event
+		out.Data = raw
+		return out, true
+	}
+}
+
+// --- Push fanout (yield → Subscribe channel) ---
+
+func TestMatchTransform_Push_MatchFiltersSubscribers(t *testing.T) {
+	def := EventDef{
+		Name:        "alert.fired",
+		Description: "match-only push test",
+		Delivery:    []string{"push"},
+		Match:       matchOnSeverity(),
+	}
+	src, yield := NewYieldingSource[sevPayload](def)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	chHigh := src.Subscribe(ctx, SubscribeOpts{Principal: "alice", Params: map[string]any{"severity": "high"}})
+	chLow := src.Subscribe(ctx, SubscribeOpts{Principal: "bob", Params: map[string]any{"severity": "low"}})
+	chAll := src.Subscribe(ctx, SubscribeOpts{Principal: "carol", Params: nil})
+
+	require.NoError(t, yield(sevPayload{Severity: "high", Reporter: "alice@x"}))
+
+	// chHigh + chAll should see it; chLow should not.
+	expectEvent := func(label string, ch <-chan SubscriberEvent, want bool) {
+		t.Helper()
+		select {
+		case se := <-ch:
+			if !want {
+				t.Fatalf("%s: received event but Match should have filtered it: %+v", label, se.Event)
+			}
+		case <-time.After(100 * time.Millisecond):
+			if want {
+				t.Fatalf("%s: did not receive event within deadline", label)
+			}
+		}
+	}
+	expectEvent("chHigh", chHigh, true)
+	expectEvent("chLow", chLow, false)
+	expectEvent("chAll", chAll, true)
+}
+
+func TestMatchTransform_Push_TransformShapesPerSubscriber(t *testing.T) {
+	def := EventDef{
+		Name:        "alert.fired",
+		Description: "transform-only push test",
+		Delivery:    []string{"push"},
+		Transform:   transformRedactReporter(),
+	}
+	src, yield := NewYieldingSource[sevPayload](def)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	chRedact := src.Subscribe(ctx, SubscribeOpts{Params: map[string]any{"redact_pii": true}})
+	chRaw := src.Subscribe(ctx, SubscribeOpts{Params: map[string]any{"redact_pii": false}})
+
+	require.NoError(t, yield(sevPayload{Severity: "high", Reporter: "alice@x"}))
+
+	pickPayload := func(ch <-chan SubscriberEvent) sevPayload {
+		t.Helper()
+		select {
+		case se := <-ch:
+			var p sevPayload
+			require.NoError(t, json.Unmarshal(se.Event.Data, &p))
+			return p
+		case <-time.After(200 * time.Millisecond):
+			t.Fatalf("no event")
+			return sevPayload{}
+		}
+	}
+	got := pickPayload(chRedact)
+	if got.Reporter != "" {
+		t.Errorf("redacted subscriber: Reporter = %q, want \"\"", got.Reporter)
+	}
+	got = pickPayload(chRaw)
+	if got.Reporter != "alice@x" {
+		t.Errorf("raw subscriber: Reporter = %q, want \"alice@x\"", got.Reporter)
+	}
+}
+
+func TestMatchTransform_Push_NilHooksAreNoop(t *testing.T) {
+	src, yield := NewYieldingSource[sevPayload](EventDef{
+		Name:        "alert.fired",
+		Description: "nil hooks",
+		Delivery:    []string{"push"},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch := src.Subscribe(ctx, SubscribeOpts{Params: map[string]any{"severity": "low"}})
+
+	require.NoError(t, yield(sevPayload{Severity: "high", Reporter: "alice@x"}))
+
+	select {
+	case se := <-ch:
+		var p sevPayload
+		require.NoError(t, json.Unmarshal(se.Event.Data, &p))
+		if p.Severity != "high" || p.Reporter != "alice@x" {
+			t.Errorf("nil-hooks delivered modified event: %+v", p)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatalf("nil-hooks subscriber did not receive event")
+	}
+}
+
+func TestMatchTransform_Push_PanicSafe(t *testing.T) {
+	def := EventDef{
+		Name:        "alert.fired",
+		Description: "panic-safe push",
+		Delivery:    []string{"push"},
+		Match: func(HookContext, Event, map[string]any) bool {
+			panic("match boom")
+		},
+		Transform: func(HookContext, Event, map[string]any) (Event, bool) {
+			panic("transform boom")
+		},
+	}
+	src, yield := NewYieldingSource[sevPayload](def)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch := src.Subscribe(ctx, SubscribeOpts{Params: map[string]any{"severity": "high"}})
+
+	require.NoError(t, yield(sevPayload{Severity: "high", Reporter: "alice@x"}))
+
+	// Match panic → safeMatch returns false → subscriber does not
+	// receive. The fanout itself MUST NOT crash.
+	select {
+	case <-ch:
+		t.Fatalf("panicking match delivered the event; safeMatch should have returned false")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+// --- Webhook fanout (Deliver) ---
+
+func TestMatchTransform_Webhook_MatchAndTransformPerTarget(t *testing.T) {
+	def := EventDef{
+		Name:        "alert.fired",
+		Description: "match+transform webhook",
+		Delivery:    []string{"webhook"},
+		Match:       matchOnSeverity(),
+		Transform:   transformRedactReporter(),
+	}
+	src, yield := NewYieldingSource[sevPayload](def)
+
+	type received struct {
+		body []byte
+		sub  string
+	}
+	var bodiesA, bodiesB, bodiesC []received
+	var mu sync.Mutex
+	mkReceiver := func(sink *[]received) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			b := make([]byte, r.ContentLength)
+			_, _ = r.Body.Read(b)
+			mu.Lock()
+			*sink = append(*sink, received{body: b, sub: r.Header.Get("X-MCP-Subscription-Id")})
+			mu.Unlock()
+			w.WriteHeader(200)
+		}))
+	}
+	rA := mkReceiver(&bodiesA)
+	rB := mkReceiver(&bodiesB)
+	rC := mkReceiver(&bodiesC)
+	defer rA.Close()
+	defer rB.Close()
+	defer rC.Close()
+
+	srv := server.NewServer(core.ServerInfo{Name: "test", Version: "1.0"})
+	wh := NewWebhookRegistry(WithWebhookAllowPrivateNetworks(true))
+	Register(Config{
+		Sources:                  []EventSource{src},
+		Webhooks:                 wh,
+		Server:                   srv,
+		UnsafeAnonymousPrincipal: "alice",
+	})
+	finishInitHandshake(t, srv)
+
+	subscribe := func(url string, params map[string]any, secretLetter byte) {
+		t.Helper()
+		body := map[string]any{
+			"name":   "alert.fired",
+			"params": params,
+			"delivery": map[string]any{
+				"mode":   "webhook",
+				"url":    url,
+				"secret": "whsec_" + strings.Repeat(string(secretLetter), 32),
+			},
+		}
+		raw, _ := json.Marshal(body)
+		resp, err := srv.Dispatch(context.Background(), &core.Request{
+			JSONRPC: "2.0", ID: json.RawMessage(`1`),
+			Method: "events/subscribe", Params: raw,
+		})
+		require.NoError(t, err)
+		require.Nil(t, resp.Error, "subscribe failed: %+v", resp.Error)
+	}
+	// A: match high, no redact → receives raw body
+	subscribe(rA.URL, map[string]any{"severity": "high"}, 'a')
+	// B: match low → filtered out (won't receive)
+	subscribe(rB.URL, map[string]any{"severity": "low"}, 'b')
+	// C: match high, redact → receives body with empty Reporter
+	subscribe(rC.URL, map[string]any{"severity": "high", "redact_pii": true}, 'c')
+
+	require.NoError(t, yield(sevPayload{Severity: "high", Reporter: "alice@x"}))
+
+	// Async deliver — wait briefly for all three (or just the
+	// expected two) to land.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		nA, nB, nC := len(bodiesA), len(bodiesB), len(bodiesC)
+		mu.Unlock()
+		if nA > 0 && nC > 0 && nB == 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(bodiesA) != 1 {
+		t.Fatalf("A (match=high) got %d deliveries, want 1", len(bodiesA))
+	}
+	if len(bodiesB) != 0 {
+		t.Fatalf("B (match=low) got %d deliveries, want 0 (Match should filter)", len(bodiesB))
+	}
+	if len(bodiesC) != 1 {
+		t.Fatalf("C (match=high+redact) got %d deliveries, want 1", len(bodiesC))
+	}
+
+	parseReporter := func(b []byte) string {
+		var env struct {
+			Data sevPayload `json:"data"`
+		}
+		require.NoError(t, json.Unmarshal(b, &env))
+		return env.Data.Reporter
+	}
+	if got := parseReporter(bodiesA[0].body); got != "alice@x" {
+		t.Errorf("A: Reporter = %q, want \"alice@x\" (no redact)", got)
+	}
+	if got := parseReporter(bodiesC[0].body); got != "" {
+		t.Errorf("C: Reporter = %q, want \"\" (redacted)", got)
+	}
+
+	// Sanity: the redacted body MUST be a different byte string from
+	// the raw body — otherwise the HMAC signatures would collide and
+	// the per-target re-sign code path is dead.
+	if string(bodiesA[0].body) == string(bodiesC[0].body) {
+		t.Errorf("redacted target body identical to raw target body — re-marshal-on-modified path didn't run")
+	}
+}
+
+func TestMatchTransform_Webhook_FiltersByEventName(t *testing.T) {
+	// Two sources sharing one registry: a yield from source A must
+	// NOT deliver to source B's webhook subscribers. (Pre-η-4 the
+	// registry didn't filter by name; η-4's per-target processing
+	// adds the filter.)
+	srcA, yieldA := NewYieldingSource[sevPayload](EventDef{
+		Name:        "src.a",
+		Description: "source A",
+		Delivery:    []string{"webhook"},
+	})
+	srcB, _ := NewYieldingSource[sevPayload](EventDef{
+		Name:        "src.b",
+		Description: "source B",
+		Delivery:    []string{"webhook"},
+	})
+
+	var hits atomic.Int32
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(200)
+	}))
+	defer receiver.Close()
+
+	srv := server.NewServer(core.ServerInfo{Name: "test", Version: "1.0"})
+	wh := NewWebhookRegistry(WithWebhookAllowPrivateNetworks(true))
+	Register(Config{
+		Sources:                  []EventSource{srcA, srcB},
+		Webhooks:                 wh,
+		Server:                   srv,
+		UnsafeAnonymousPrincipal: "alice",
+	})
+	finishInitHandshake(t, srv)
+
+	// Subscribe ONLY to src.b
+	body := map[string]any{
+		"name": "src.b",
+		"delivery": map[string]any{
+			"mode":   "webhook",
+			"url":    receiver.URL,
+			"secret": "whsec_" + strings.Repeat("a", 32),
+		},
+	}
+	raw, _ := json.Marshal(body)
+	resp, err := srv.Dispatch(context.Background(), &core.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`),
+		Method: "events/subscribe", Params: raw,
+	})
+	require.NoError(t, err)
+	require.Nil(t, resp.Error)
+
+	// Yield from src.a — should NOT deliver to src.b's webhook.
+	require.NoError(t, yieldA(sevPayload{Severity: "high"}))
+
+	time.Sleep(150 * time.Millisecond)
+	if got := hits.Load(); got != 0 {
+		t.Errorf("src.a yield delivered to src.b's webhook %d times; want 0 (event-name filter)", got)
+	}
+}
+
+// --- Poll path ---
+
+func TestMatchTransform_Poll_AppliesPerCall(t *testing.T) {
+	def := EventDef{
+		Name:        "alert.fired",
+		Description: "poll match+transform",
+		Delivery:    []string{"poll"},
+		Match:       matchOnSeverity(),
+		Transform:   transformRedactReporter(),
+	}
+	src, yield := NewYieldingSource[sevPayload](def)
+
+	srv := server.NewServer(core.ServerInfo{Name: "test", Version: "1.0"})
+	Register(Config{
+		Sources:                  []EventSource{src},
+		Server:                   srv,
+		UnsafeAnonymousPrincipal: "alice",
+	})
+	finishInitHandshake(t, srv)
+
+	// Pre-populate two events of differing severity.
+	require.NoError(t, yield(sevPayload{Severity: "high", Reporter: "h@x"}))
+	require.NoError(t, yield(sevPayload{Severity: "low", Reporter: "l@x"}))
+
+	pollAndDecode := func(params map[string]any) []sevPayload {
+		t.Helper()
+		body := map[string]any{"name": "alert.fired", "params": params, "cursor": "0"}
+		raw, _ := json.Marshal(body)
+		resp, err := srv.Dispatch(context.Background(), &core.Request{
+			JSONRPC: "2.0", ID: json.RawMessage(`1`),
+			Method: "events/poll", Params: raw,
+		})
+		require.NoError(t, err)
+		require.Nil(t, resp.Error, "poll failed: %+v", resp.Error)
+		w, ok := resp.Result.(pollResultWire)
+		require.True(t, ok, "events/poll Result should be pollResultWire, got %T", resp.Result)
+		out := make([]sevPayload, 0, len(w.Events))
+		for _, e := range w.Events {
+			var p sevPayload
+			require.NoError(t, json.Unmarshal(e.Data, &p))
+			out = append(out, p)
+		}
+		return out
+	}
+
+	// Caller asking for severity=high gets only the high-severity
+	// event, with redact applied.
+	got := pollAndDecode(map[string]any{"severity": "high", "redact_pii": true})
+	if len(got) != 1 {
+		t.Fatalf("severity=high: got %d events, want 1", len(got))
+	}
+	if got[0].Severity != "high" {
+		t.Errorf("severity=high: got severity %q, want \"high\"", got[0].Severity)
+	}
+	if got[0].Reporter != "" {
+		t.Errorf("severity=high+redact: Reporter = %q, want \"\"", got[0].Reporter)
+	}
+
+	// Caller without severity filter gets both.
+	got = pollAndDecode(nil)
+	if len(got) != 2 {
+		t.Fatalf("no filter: got %d events, want 2", len(got))
+	}
+}
+
+// --- Cross-mode parity ---
+
+// TestMatchTransform_CrossModeParity verifies that the same EventDef
+// with the same hooks gives consistent filtering and shaping across
+// push, webhook, and poll for the same emitted event.
+func TestMatchTransform_CrossModeParity(t *testing.T) {
+	def := EventDef{
+		Name:        "alert.fired",
+		Description: "cross-mode parity",
+		Delivery:    []string{"poll", "push", "webhook"},
+		Match:       matchOnSeverity(),
+		Transform:   transformRedactReporter(),
+	}
+	src, yield := NewYieldingSource[sevPayload](def)
+
+	srv := server.NewServer(core.ServerInfo{Name: "test", Version: "1.0"})
+	wh := NewWebhookRegistry(WithWebhookAllowPrivateNetworks(true))
+	Register(Config{
+		Sources:                  []EventSource{src},
+		Webhooks:                 wh,
+		Server:                   srv,
+		UnsafeAnonymousPrincipal: "alice",
+		StreamHeartbeatInterval:  500 * time.Millisecond,
+	})
+	finishInitHandshake(t, srv)
+
+	matchParams := map[string]any{"severity": "high", "redact_pii": true}
+
+	// Push: subscribe to source directly so we don't have to drive
+	// the full events/stream flow.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pushCh := src.Subscribe(ctx, SubscribeOpts{Principal: "alice", Params: matchParams})
+
+	// Webhook
+	var whBody []byte
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(buf)
+		whBody = buf
+		w.WriteHeader(200)
+	}))
+	defer receiver.Close()
+	subBody, _ := json.Marshal(map[string]any{
+		"name":   "alert.fired",
+		"params": matchParams,
+		"delivery": map[string]any{
+			"mode":   "webhook",
+			"url":    receiver.URL,
+			"secret": "whsec_" + strings.Repeat("a", 32),
+		},
+	})
+	resp, err := srv.Dispatch(context.Background(), &core.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`),
+		Method: "events/subscribe", Params: subBody,
+	})
+	require.NoError(t, err)
+	require.Nil(t, resp.Error)
+
+	// Yield matches.
+	require.NoError(t, yield(sevPayload{Severity: "high", Reporter: "h@x"}))
+
+	// Push delivery
+	var pushPayload sevPayload
+	select {
+	case se := <-pushCh:
+		require.NoError(t, json.Unmarshal(se.Event.Data, &pushPayload))
+	case <-time.After(300 * time.Millisecond):
+		t.Fatalf("push subscriber did not receive event")
+	}
+
+	// Webhook delivery — async; wait
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) && len(whBody) == 0 {
+		time.Sleep(10 * time.Millisecond)
+	}
+	require.NotEmpty(t, whBody, "webhook receiver got no body")
+	var whEnv struct {
+		Data sevPayload `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(whBody, &whEnv))
+
+	// Poll delivery
+	pollBody, _ := json.Marshal(map[string]any{
+		"name": "alert.fired", "params": matchParams, "cursor": "0",
+	})
+	resp, err = srv.Dispatch(context.Background(), &core.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`2`),
+		Method: "events/poll", Params: pollBody,
+	})
+	require.NoError(t, err)
+	w, ok := resp.Result.(pollResultWire)
+	require.True(t, ok, "events/poll Result should be pollResultWire, got %T", resp.Result)
+	require.Len(t, w.Events, 1)
+	var pollPayload sevPayload
+	require.NoError(t, json.Unmarshal(w.Events[0].Data, &pollPayload))
+
+	// All three modes saw the same redacted shape.
+	if pushPayload.Reporter != "" || whEnv.Data.Reporter != "" || pollPayload.Reporter != "" {
+		t.Errorf("cross-mode parity broken: push=%q webhook=%q poll=%q (want all empty)",
+			pushPayload.Reporter, whEnv.Data.Reporter, pollPayload.Reporter)
+	}
+	if pushPayload.Severity != "high" || whEnv.Data.Severity != "high" || pollPayload.Severity != "high" {
+		t.Errorf("cross-mode parity broken: severity push=%q webhook=%q poll=%q",
+			pushPayload.Severity, whEnv.Data.Severity, pollPayload.Severity)
+	}
+}

--- a/experimental/ext/events/poll_lease.go
+++ b/experimental/ext/events/poll_lease.go
@@ -268,32 +268,6 @@ func (t *PollLeaseTable) sweepExpired() {
 // deterministically without waiting for the ticker.
 func (t *PollLeaseTable) sweepExpiredForTest() { t.sweepExpired() }
 
-// chainOnExpire appends an additional OnExpire hook that fires after
-// any user-supplied one. Used by events.Register to install the
-// SDK's safeOnUnsubscribe wiring on a table the user may have
-// constructed with their own OnExpire diagnostic hook. Chaining
-// (rather than overwriting) keeps both observable.
-//
-// Package-internal: the public surface is WithPollLeaseOnExpire
-// (single hook at construction). η-3 is the only caller — adding
-// the SDK's lifecycle wiring on a per-Register basis.
-func (t *PollLeaseTable) chainOnExpire(h PollLeaseHook) {
-	if h == nil {
-		return
-	}
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	prev := t.onExpire
-	if prev == nil {
-		t.onExpire = h
-		return
-	}
-	t.onExpire = func(principal, eventName string, params map[string]any) {
-		prev(principal, eventName, params)
-		h(principal, eventName, params)
-	}
-}
-
 // invokeLeaseHook invokes a PollLeaseHook with panic recovery. A
 // hook that panics shouldn't take down the sweep goroutine or the
 // poll handler; log + swallow.

--- a/experimental/ext/events/stream.go
+++ b/experimental/ext/events/stream.go
@@ -30,24 +30,6 @@ import (
 	"github.com/panyam/mcpkit/server"
 )
 
-// newStreamSubscriptionID generates the server-derived sub_<base64>
-// handle for a push stream (η-3). Streams have no canonical-tuple
-// identity (no delivery URL), and the same (principal, name, params)
-// can be open across multiple concurrent streams — each is its own
-// runtime subscription. A random 16-byte sub id keeps SubscriptionID()
-// usable on HookContext for push without conflating concurrent
-// streams.
-//
-// Webhook uses deriveSubscriptionID over the canonical tuple so two
-// subscribes with identical inputs collapse onto one id; that property
-// is correct for webhook (refresh ≠ new sub) but wrong for push (each
-// stream open IS a new sub). Hence the different generation strategy.
-func newStreamSubscriptionID() string {
-	var buf [16]byte
-	_, _ = rand.Read(buf[:])
-	return "sub_" + base64.RawURLEncoding.EncodeToString(buf[:])
-}
-
 const defaultStreamHeartbeatInterval = 30 * time.Second
 
 // StreamEventsResult is the typed final frame of an events/stream call per
@@ -67,8 +49,14 @@ type StreamEventsResult struct {
 // does not (it has no internal buffer to fan out from). registerStream
 // rejects events/stream for sources lacking this capability with -32017
 // DeliveryModeUnsupported per spec.
+//
+// SubscribeOpts (η-4): the SDK passes the resolved subscriber identity
+// (Principal / SubscriptionID / Params) at Subscribe time so the
+// source can stash it on its subscriberSlot and apply the EventDef's
+// Match / Transform on fanout. Implementations that don't care can
+// ignore the opts.
 type streamSubscribable interface {
-	Subscribe(ctx context.Context) <-chan SubscriberEvent
+	Subscribe(ctx context.Context, opts SubscribeOpts) <-chan SubscriberEvent
 }
 
 // activeNotifParams is the wire shape of notifications/events/active per
@@ -176,21 +164,44 @@ func registerStream(srv *server.Server, sourceMap map[string]EventSource, unsafe
 			}
 		}
 
-		// Send the confirmation notification. Per spec L240, this MUST
-		// arrive before any event delivery.
+		// η-3 / η-4: derive the per-stream sub id BEFORE subscribing
+		// so it can ride on the subscriberSlot for fanout-time
+		// HookContext construction. Each stream open gets a fresh
+		// random sub id — push doesn't share canonical-tuple identity
+		// across concurrent streams from the same principal/name/params,
+		// so unlike webhook (where deriveSubscriptionID collapses
+		// duplicate subscribes), every open IS a new subscription.
+		var subIDBuf [16]byte
+		_, _ = rand.Read(subIDBuf[:])
+		streamSubID := "sub_" + base64.RawURLEncoding.EncodeToString(subIDBuf[:])
+
+		// Subscribe BEFORE sending the active notification. Per spec
+		// L240 active MUST arrive before any event delivery, but
+		// "delivery" here means the handler's select loop reading
+		// from evCh — that loop doesn't start until below. Doing
+		// Subscribe first eliminates a race where a client that
+		// observes active and immediately triggers a yield could see
+		// the yield miss this stream because the slot wasn't yet
+		// registered.
+		evCh := sub.Subscribe(ctx, SubscribeOpts{
+			Principal:      principal,
+			SubscriptionID: streamSubID,
+			Params:         req.Params,
+		})
+
+		// Send the confirmation notification. The loop below reads
+		// from evCh; active goes out via ctx.Notify before the loop
+		// starts, so any events queued on evCh between Subscribe and
+		// Notify still arrive AFTER the active frame on the wire.
 		ctx.Notify("notifications/events/active", activeNotifParams{
 			RequestID: id,
 			Cursor:    initialCursor,
 		})
 
-		evCh := sub.Subscribe(ctx)
-
 		// η-3: lifecycle hooks for push. on_subscribe fires after the
 		// channel is acquired (the subscription is now live and would
 		// receive events); on_unsubscribe fires on every return path
-		// via defer. The fresh sub id is unique per stream so concurrent
-		// streams from the same principal/name/params don't conflate.
-		streamSubID := newStreamSubscriptionID()
+		// via defer.
 		hc := newHookContext(ctx, principal, streamSubID, DeliveryModePush)
 		if err := safeOnSubscribe(def.OnSubscribe, hc, req.Params); err != nil {
 			// Author rejected provisioning; close out the stream

--- a/experimental/ext/events/stream_routing_test.go
+++ b/experimental/ext/events/stream_routing_test.go
@@ -201,7 +201,7 @@ type fakeSubscribableSource struct {
 func (f *fakeSubscribableSource) Def() EventDef                  { return f.def }
 func (f *fakeSubscribableSource) Poll(string, int) PollResult    { return PollResult{} }
 func (f *fakeSubscribableSource) Latest() string                 { return f.latest }
-func (f *fakeSubscribableSource) Subscribe(context.Context) <-chan SubscriberEvent {
+func (f *fakeSubscribableSource) Subscribe(context.Context, SubscribeOpts) <-chan SubscriberEvent {
 	return f.ch
 }
 

--- a/experimental/ext/events/webhook.go
+++ b/experimental/ext/events/webhook.go
@@ -251,10 +251,30 @@ type WebhookRegistry struct {
 	// lock to keep a slow listener from serializing the registry.
 	onRemoveHooks []WebhookOnRemoveHook
 
+	// defResolver lets Deliver look up an event-type's Match /
+	// Transform hooks at fanout time without WebhookRegistry needing
+	// to know about EventDef directly. events.Register installs this;
+	// callers that hand-deliver events (e.g., TypedSource authors
+	// reaching for EmitToWebhooks themselves) get a no-op resolver
+	// and the per-target match/transform path is a passthrough.
+	// η-4. Set under mu, read under mu.RLock.
+	defResolver func(eventName string) EventDef
+
 	// logf is the logging hook used by deliver paths. Defaults to log.Printf;
 	// tests override via setLogfForTest to capture failures (including SSRF
 	// dial-time rejections) for assertions.
 	logf func(format string, args ...any)
+}
+
+// SetDefResolver installs the resolver Deliver uses to look up an
+// event-type's Match / Transform hooks at fanout time. events.Register
+// is the only caller — it points the resolver at the source map so the
+// registry stays decoupled from EventDef. Safe to call after the
+// registry has been handed out; the field is mu-guarded.
+func (r *WebhookRegistry) SetDefResolver(fn func(eventName string) EventDef) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.defResolver = fn
 }
 
 // AddOnRemoveHook registers a callback that fires when a target is
@@ -590,33 +610,89 @@ func (r *WebhookRegistry) ExpireAll() {
 	}
 }
 
-// Deliver sends an event to all non-expired webhooks. Each POST includes an
-// HMAC-SHA256 signature in X-MCP-Signature and a timestamp in X-MCP-Timestamp.
-// Delivery failures are retried with exponential backoff per spec.
+// Deliver sends an event to webhook subscribers of that event name.
+//
+// Per-target processing (η-4):
+//  1. Filter by event name — only targets whose EventName matches the
+//     event are considered.
+//  2. safeMatch with the EventDef's Match — skip target if false.
+//  3. safeTransform with the EventDef's Transform — use the returned
+//     event's body when the bool says modified, otherwise reuse the
+//     original marshal.
+//
+// Each POST carries an HMAC-SHA256 signature; failures retry with
+// exponential backoff. When transform modifies the event, the per-
+// target body is re-marshaled and re-signed (the receiver's HMAC
+// check would fail otherwise) and re-checked against the body cap.
+//
+// Match / Transform are looked up via SetDefResolver. Callers that
+// haven't installed a resolver (TypedSource authors hand-emitting)
+// get a passthrough — Match=nil delivers to all matching-name targets,
+// Transform=nil reuses the original body.
 func (r *WebhookRegistry) Deliver(event Event) {
 	targets := r.Targets()
 	if len(targets) == 0 {
 		return
 	}
 
-	body, err := json.Marshal(event)
+	// One marshal upfront for the unmodified path; per-target
+	// re-marshal only when transform actually changes the event
+	// (Q8 short-circuit).
+	originalBody, err := json.Marshal(event)
 	if err != nil {
 		r.logf("[webhook] failed to marshal event: %v", err)
 		return
 	}
-
-	// ζ-3: spec L487 caps outbound delivery bodies at 256 KiB (configurable
-	// via WithWebhookMaxBodyBytes). Reject oversized — truncation would
-	// corrupt the HMAC signature and silently drop event content.
-	// Re-trying won't shrink the body, so this is terminal for the event.
-	if len(body) > r.maxBodyBytes {
+	if len(originalBody) > r.maxBodyBytes {
+		// ζ-3: spec L487 caps outbound delivery bodies at 256 KiB
+		// (configurable via WithWebhookMaxBodyBytes). Reject
+		// oversized — truncation would corrupt the HMAC signature
+		// and silently drop event content. Re-trying won't shrink
+		// the body, so this is terminal for the event.
 		r.logf("[webhook] event %s body %d bytes exceeds cap %d; dropping (will not retry)",
-			event.EventID, len(body), r.maxBodyBytes)
+			event.EventID, len(originalBody), r.maxBodyBytes)
 		return
 	}
 
+	r.mu.RLock()
+	resolver := r.defResolver
+	r.mu.RUnlock()
+	var def EventDef
+	if resolver != nil {
+		def = resolver(event.Name)
+	}
+
 	for _, t := range targets {
-		go r.deliver(t, event.EventID, body)
+		if t.EventName != "" && t.EventName != event.Name {
+			// Pre-η-3 targets had no EventName recorded — skip the
+			// filter for those (zero string) so legacy fixtures
+			// keep working. Real targets registered via the
+			// subscribe handler always carry the name.
+			continue
+		}
+
+		hc := newHookContext(context.Background(), t.Principal, t.ID, DeliveryModeWebhook)
+		if !safeMatch(def.Match, hc, event, t.Params) {
+			continue
+		}
+		delivered, modified := safeTransform(def.Transform, hc, event, t.Params)
+
+		body := originalBody
+		if modified {
+			b, err := json.Marshal(delivered)
+			if err != nil {
+				r.logf("[webhook] transform-modified event %s: marshal failed for target %s: %v",
+					event.EventID, t.ID, err)
+				continue
+			}
+			if len(b) > r.maxBodyBytes {
+				r.logf("[webhook] transform-modified event %s: body %d bytes exceeds cap %d for target %s; dropping",
+					event.EventID, len(b), r.maxBodyBytes, t.ID)
+				continue
+			}
+			body = b
+		}
+		go r.deliver(t, delivered.EventID, body)
 	}
 }
 

--- a/experimental/ext/events/yield.go
+++ b/experimental/ext/events/yield.go
@@ -71,13 +71,42 @@ type EventDeliveryError struct {
 // subscriberSlot is one registered Subscribe channel. pendingTruncated is
 // set when a yield is dropped because the chan is full; the next successful
 // send delivers a Truncated marker before the event itself.
+//
+// principal / subscriptionID / params (η-4): per-subscriber identity
+// captured at Subscribe time so the per-yield fanout can build a
+// HookContext + apply the EventDef's Match / Transform per subscriber.
+// Spec §"Server SDK Guidance" L623-629.
 type subscriberSlot struct {
 	ch               chan SubscriberEvent
+	principal        string
+	subscriptionID   string
+	params           map[string]any
 	pendingTruncated atomic.Bool
 	// closeOnce gates the chan close so YieldTerminated and the
 	// Subscribe cleanup goroutine can both attempt close without
 	// racing into "close of closed channel". ζ-7.
 	closeOnce sync.Once
+}
+
+// SubscribeOpts bundles the per-subscriber metadata Subscribe needs.
+// Promoted to a struct over a positional list because η-4 added two
+// fields to the existing (ctx) signature; future additions (MaxAge,
+// per-subscriber backpressure tuning) extend the struct without
+// rippling through every caller.
+type SubscribeOpts struct {
+	// Principal is the resolved subscription principal. Surfaced on
+	// HookContext.Principal() during fanout so author Match /
+	// Transform can do principal-aware filtering.
+	Principal string
+	// SubscriptionID is the server-derived sub_<base64> handle
+	// (per-stream for push). Surfaced on HookContext.SubscriptionID()
+	// during fanout. Empty for callers that don't have one.
+	SubscriptionID string
+	// Params is the subscribe-time parameter map. Surfaced as the
+	// `params` argument to Match / Transform so authors can implement
+	// "deliver only when params.severity matches event.data.severity"
+	// per spec L633-644.
+	Params map[string]any
 }
 
 // closeChan idempotently closes the slot's channel. Safe to call from
@@ -314,6 +343,12 @@ func (s *YieldingSource[Data]) fanoutLocked(se SubscriberEvent) {
 // the slot is removed from the source and the channel is closed (range
 // loops exit cleanly, select-on-closed returns the zero value).
 //
+// SubscribeOpts (η-4) carries per-subscriber identity (Principal,
+// SubscriptionID, Params) onto the slot so fanout can build a
+// HookContext and apply the EventDef's Match / Transform per
+// subscriber. Pass the zero value for hook-less callers; the safe
+// wrappers tolerate empty fields.
+//
 // On a slow consumer (channel full), yield does NOT block — the event
 // is dropped for that subscriber and a Truncated marker is sent on the
 // next successful send. Stream handlers map Truncated=true onto a fresh
@@ -322,8 +357,13 @@ func (s *YieldingSource[Data]) fanoutLocked(se SubscriberEvent) {
 //
 // Cursorless sources still buffer-and-fanout to subscribers (push delivery
 // works fine without replay); only Poll returns empty on cursorless.
-func (s *YieldingSource[Data]) Subscribe(ctx context.Context) <-chan SubscriberEvent {
-	slot := &subscriberSlot{ch: make(chan SubscriberEvent, s.subscriberBuf)}
+func (s *YieldingSource[Data]) Subscribe(ctx context.Context, opts SubscribeOpts) <-chan SubscriberEvent {
+	slot := &subscriberSlot{
+		ch:             make(chan SubscriberEvent, s.subscriberBuf),
+		principal:      opts.Principal,
+		subscriptionID: opts.SubscriptionID,
+		params:         opts.Params,
+	}
 	s.mu.Lock()
 	s.subscribers = append(s.subscribers, slot)
 	s.mu.Unlock()
@@ -517,27 +557,68 @@ func (s *YieldingSource[Data]) yield(data Data) error {
 			s.entries = s.entries[len(s.entries)-s.maxSize:]
 		}
 	}
-	// Fanout to live Subscribe channels under the same lock that gates
-	// close() in the cleanup goroutine — guarantees we never send to a
-	// closed channel. Sends are non-blocking; on a full subscriber buffer
-	// the event is dropped for that subscriber and pendingTruncated flips
-	// so the next successful send carries Truncated=true.
-	for _, sub := range s.subscribers {
-		truncated := sub.pendingTruncated.Load()
-		select {
-		case sub.ch <- SubscriberEvent{Event: event, Truncated: truncated}:
-			if truncated {
-				sub.pendingTruncated.Store(false)
-			}
-		default:
-			sub.pendingTruncated.Store(true)
-		}
-	}
+	// η-4: snapshot subscribers under the lock, then drop the lock
+	// before invoking author hooks. Match / Transform fire on the hot
+	// path — running them while holding s.mu would serialize the
+	// whole source on a slow author callback. The cleanup goroutine
+	// in Subscribe also takes s.mu before close()-ing the chan, so
+	// snapshotting + sending later means a closed-chan send is
+	// possible during a close-vs-send race; we tolerate that with a
+	// non-blocking send + recover (see deliverEventToSlot below).
+	subs := append([]*subscriberSlot(nil), s.subscribers...)
 	hook := s.emitHook
+	matchFn := s.def.Match
+	transformFn := s.def.Transform
 	s.mu.Unlock()
+
+	for _, sub := range subs {
+		s.deliverEventToSlot(sub, event, matchFn, transformFn)
+	}
 
 	if hook != nil {
 		hook(event)
 	}
 	return nil
+}
+
+// deliverEventToSlot applies the EventDef's Match / Transform for one
+// subscriber and sends the resulting event onto its channel. Extracted
+// from yield() to keep the per-subscriber logic readable.
+//
+// Hot-path discipline (Q8):
+//   - safeMatch / safeTransform are nil-tolerant + panic-recovering;
+//     a buggy author hook can't take down the fanout.
+//   - Match=false skips the subscriber outright (and skips Transform).
+//   - Transform returning (event, false) is the passthrough fast
+//     path — we send the unmodified event reference, no per-subscriber
+//     allocation cost.
+//   - The send is still non-blocking + drop-with-Truncated; pinning a
+//     slow consumer with backpressure would serialize the source.
+//   - close-vs-send race: defer/recover catches the rare case where
+//     the cleanup goroutine closed the chan between our snapshot and
+//     send. Treated as a normal drop (the subscriber is gone).
+func (s *YieldingSource[Data]) deliverEventToSlot(sub *subscriberSlot, event Event, matchFn MatchFunc, transformFn TransformFunc) {
+	defer func() {
+		if r := recover(); r != nil {
+			// Most likely a "send on closed channel" because Subscribe's
+			// cleanup goroutine raced ahead. The slot is being torn
+			// down anyway; treat as a normal drop.
+		}
+	}()
+
+	hc := newHookContext(context.Background(), sub.principal, sub.subscriptionID, DeliveryModePush)
+	if !safeMatch(matchFn, hc, event, sub.params) {
+		return
+	}
+	delivered, _ := safeTransform(transformFn, hc, event, sub.params)
+
+	truncated := sub.pendingTruncated.Load()
+	select {
+	case sub.ch <- SubscriberEvent{Event: delivered, Truncated: truncated}:
+		if truncated {
+			sub.pendingTruncated.Store(false)
+		}
+	default:
+		sub.pendingTruncated.Store(true)
+	}
 }

--- a/experimental/ext/events/yield_test.go
+++ b/experimental/ext/events/yield_test.go
@@ -300,7 +300,7 @@ func TestYieldingSource_SubscribeReceivesYieldedEvents(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ch := src.Subscribe(ctx)
+	ch := src.Subscribe(ctx, SubscribeOpts{})
 	require.NotNil(t, ch, "Subscribe must return a non-nil channel")
 
 	require.NoError(t, yield(fakePayload{Msg: "alpha"}))
@@ -329,9 +329,9 @@ func TestYieldingSource_MultipleSubscribersAllReceive(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	subA := src.Subscribe(ctx)
-	subB := src.Subscribe(ctx)
-	subC := src.Subscribe(ctx)
+	subA := src.Subscribe(ctx, SubscribeOpts{})
+	subB := src.Subscribe(ctx, SubscribeOpts{})
+	subC := src.Subscribe(ctx, SubscribeOpts{})
 
 	require.NoError(t, yield(fakePayload{Msg: "x"}))
 
@@ -350,7 +350,7 @@ func TestYieldingSource_SubscribeCleanupOnContextCancel(t *testing.T) {
 	src, yield := NewYieldingSource[fakePayload](EventDef{Name: "fake"})
 
 	ctx, cancel := context.WithCancel(context.Background())
-	_ = src.Subscribe(ctx)
+	_ = src.Subscribe(ctx, SubscribeOpts{})
 	assert.Equal(t, 1, src.SubscriberCount(), "subscribe should register one slot")
 
 	cancel()
@@ -377,7 +377,7 @@ func TestYieldingSource_SubscribeDropsOnSlowConsumer(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ch := src.Subscribe(ctx)
+	ch := src.Subscribe(ctx, SubscribeOpts{})
 
 	// Fill the buffer (cap=1) and then keep yielding without draining.
 	require.NoError(t, yield(fakePayload{Msg: "a"}))
@@ -431,7 +431,7 @@ func TestYieldingSource_YieldError_DeliversErrorVariant(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ch := src.Subscribe(ctx)
+	ch := src.Subscribe(ctx, SubscribeOpts{})
 	require.NoError(t, src.YieldError(EventDeliveryError{Code: -32603, Message: "upstream 503"}))
 
 	se := readSubscriberEvent(t, ch, time.Second)
@@ -458,7 +458,7 @@ func TestYieldingSource_YieldTerminated_DeliversTerminatedAndClosesChan(t *testi
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ch := src.Subscribe(ctx)
+	ch := src.Subscribe(ctx, SubscribeOpts{})
 	require.NoError(t, src.YieldTerminated(EventDeliveryError{Code: -32012, Message: "Unauthorized"}))
 
 	se := readSubscriberEvent(t, ch, time.Second)
@@ -489,7 +489,7 @@ func TestYieldingSource_YieldsAfterTerminatedAreNoOp(t *testing.T) {
 	// subscriber chan is closed and out of the picture.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ch := src.Subscribe(ctx)
+	ch := src.Subscribe(ctx, SubscribeOpts{})
 	require.NoError(t, src.YieldTerminated(EventDeliveryError{Code: 0, Message: "done"}))
 	_ = readSubscriberEvent(t, ch, time.Second) // drain terminated
 	// chan should be closed; drain once more to confirm.


### PR DESCRIPTION
## Summary
- Wires safeMatch / safeTransform from η-2 into the per-event fanout for all three delivery modes (push, webhook, poll). Authors set Match / Transform on EventDef once; the SDK applies them per subscriber so one emit fans out into per-recipient filtering and shaping.
- Push: subscriberSlot now carries (Principal, SubscriptionID, Params) captured at Subscribe time. yield() snapshots subscribers under the source lock, releases it, and applies hooks per slot — running them under the lock would serialize the source on a slow author callback.
- Webhook: Deliver filters by event name first (real bug: pre-η-4 every webhook target received every event regardless of name), then per-target Match → Transform → re-marshal + re-sign body only when transform actually returned (_, true). Q8 short-circuit keeps the passthrough path zero-allocation.
- Poll: registerPoll applies Match / Transform per-event using the polling caller's principal+params, before the maxAge floor.

Plan: \`docs/EVENTS_ETA_PLAN.md\`. Built on top of #399 (η-1 + η-2) and #400 (η-3).

## Notable changes worth attention during review

### SubscribeOpts struct
\`YieldingSource.Subscribe(ctx, principal, params)\` would have been the next signature breakage after η-3. Promoted to \`Subscribe(ctx, SubscribeOpts)\` so future additions extend the struct without rippling through every caller. The streamSubscribable interface and the test helper \`fakeSubscribableSource\` were updated.

### WebhookRegistry.SetDefResolver (decoupling)
Deliver needs Match / Transform but \`WebhookRegistry\` shouldn't know about \`EventDef\`. Resolved with an injected resolver: \`SetDefResolver(func(eventName string) EventDef)\`. \`events.Register\` installs it pointing at sourceMap. Callers that hand-deliver (TypedSource users) get a passthrough resolver and the per-target hook calls become no-ops.

### Race fix uncovered by η-4
\`registerStream\` previously sent the \`active\` notification BEFORE Subscribe registered the slot. A client that observed active and immediately triggered a yield could see the yield miss the stream — flaky pre-η-4, more frequent after the wider fanout window in this PR. Reordering to Subscribe-then-active eliminates the race; spec L240's "active before any event delivery" still holds because the handler's read loop doesn't start until both have run.

Reproduced \`TestStream_TwoConcurrentStreamsSameSourceBothReceive\` failing ~1 in 5 runs before the fix; 10 consecutive runs green after.

### Cleanups in this branch (per the new "avoid private-helper proliferation" rule)
- Inlined \`newStreamSubscriptionID\` (4-line wrapper around crypto/rand) into registerStream.
- Inlined \`PollLeaseTable.chainOnExpire\` (5-line method, called once) into events.Register.
- Kept \`YieldingSource.deliverEventToSlot\` as a private method — 20-line block tightly coupled to subscriberSlot internals and yield's lock discipline; inlining would push yield() past 90 lines.

## What this PR does NOT do
- Targeted emit by subscription id (η-5)
- TooManySubscriptions enforcement counts (η-6)
- Per-subscription rate limiting (out of scope per plan, belongs in middleware)

## Test plan
- [x] make test-experimental-events
- [x] make test-experimental-events-discord
- [x] make test-experimental-events-telegram
- [x] make test-experimental-events-clients-go
- [x] new match_transform_test.go (8 cases): push match-filters / transform-shapes / nil-passthrough / panic-safe; webhook match+transform per target with re-sign verification; webhook event-name filter (cross-source); poll per-call match+transform; cross-mode parity (same EventDef + same yield → push/webhook/poll all agree)
- [x] race fix verified: TestStream_TwoConcurrentStreamsSameSourceBothReceive 10x consecutive green