### PR TITLE
docs(events): replace Greek phase labels with spec citations

### DIFF
--- a/experimental/ext/events/body_cap_test.go
+++ b/experimental/ext/events/body_cap_test.go
@@ -13,10 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// ζ-3 — body size cap + 413 non-retryable.
-//
-// Spec §"Webhook Security" → "Delivery profile (for WAF / private-cloud
-// deployments)" L487:
+// Body size cap + 413 non-retryable. Spec §"Webhook Security" →
+// "Delivery profile (for WAF / private-cloud deployments)" L487:
 //   - Servers SHOULD cap outbound delivery bodies at 256 KiB.
 //   - Servers MUST treat a 413 Payload Too Large from the receiver as
 //     non-retryable.

--- a/experimental/ext/events/control.go
+++ b/experimental/ext/events/control.go
@@ -1,10 +1,9 @@
 package events
 
-// ζ-4 — control envelopes for non-event webhook bodies.
-//
-// Spec §"Non-event webhook bodies" L415-423: the server POSTs signed
-// envelopes to webhook receivers when the event-delivery channel
-// can't carry the signal:
+// Control envelopes for non-event webhook bodies. Spec §"Non-event
+// webhook bodies" L415-423: the server POSTs signed envelopes to
+// webhook receivers when the event-delivery channel can't carry the
+// signal:
 //
 //   - {type: "gap", cursor: "<fresh>"} — a gap was detected between
 //     refreshes (e.g., a yield queue overflowed). Tells the receiver
@@ -14,8 +13,8 @@ package events
 //     the server removes the registry target.
 //
 // Both use Standard Webhooks signature headers (webhook-id /
-// webhook-timestamp / webhook-signature) plus the γ-4
-// X-MCP-Subscription-Id header. webhook-id format is
+// webhook-timestamp / webhook-signature) plus the X-MCP-Subscription-Id
+// header (spec §"Webhook Event Delivery" L390). webhook-id format is
 // msg_<type>_<random> per spec L417, distinguishing control POSTs from
 // event deliveries (which use the event's eventId so retries dedup
 // correctly).
@@ -92,10 +91,11 @@ func (r *WebhookRegistry) PostTerminated(canonicalKey []byte, controlErr Control
 	if !ok {
 		return
 	}
-	// η-3: PostTerminated is server-initiated subscription death;
-	// onRemove fires on actual registry deletion. Suspend (handled
-	// via postTerminatedSilent) deliberately does NOT fire — the
-	// target stays in the registry as paused.
+	// PostTerminated is server-initiated subscription death;
+	// onRemove fires on actual registry deletion (per spec §"Server
+	// SDK Guidance" → "Unsubscribe timing by mode" L707). Suspend
+	// (handled via postTerminatedSilent) deliberately does NOT fire
+	// — the target stays in the registry as paused.
 	r.fireOnRemove(target)
 	body, err := json.Marshal(controlEnvelope{Type: "terminated", Error: &controlErr})
 	if err != nil {
@@ -107,9 +107,10 @@ func (r *WebhookRegistry) PostTerminated(canonicalKey []byte, controlErr Control
 
 // postTerminatedSilent POSTs a {type:terminated} envelope to a target
 // WITHOUT removing it from the registry. Distinct from the public
-// PostTerminated which removes — the suspend transition (ζ-6 →
-// ζ-7.3) needs the target to remain observable as Active=false so the
-// spec's "successful refresh reactivates" path stays available.
+// PostTerminated which removes — the suspend transition (per spec
+// §"Webhook Delivery Status" L460) needs the target to remain
+// observable as Active=false so the spec's "successful refresh
+// reactivates" path stays available.
 //
 // Caller (recordDeliveryFailure on the suspend transition) passes the
 // target snapshot so this method doesn't need to re-acquire the lock.

--- a/experimental/ext/events/control_envelope_test.go
+++ b/experimental/ext/events/control_envelope_test.go
@@ -13,16 +13,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// ζ-4 — control envelopes (type:gap, type:terminated).
-//
-// Spec §"Non-event webhook bodies" L415-423: the server POSTs signed
-// envelopes to webhook receivers when (a) a gap is detected between
-// refreshes (type:gap, carries fresh cursor) or (b) the subscription
-// has ended (type:terminated, carries error). Both use Standard
-// Webhooks headers + X-MCP-Subscription-Id, distinguished from event
+// Control envelopes (type:gap, type:terminated). Spec §"Non-event
+// webhook bodies" L415-423: the server POSTs signed envelopes to
+// webhook receivers when (a) a gap is detected between refreshes
+// (type:gap, carries fresh cursor) or (b) the subscription has ended
+// (type:terminated, carries error). Both use Standard Webhooks
+// headers + X-MCP-Subscription-Id, distinguished from event
 // deliveries by the top-level `type` field discriminator AND by the
-// webhook-id pattern: msg_<type>_<random> vs eventId for events
-// (see α's newMessageID; ζ-4 finally uses the typed form).
+// webhook-id pattern: msg_<type>_<random> vs eventId for events.
 
 // captureControlPost records what the receiver saw — body, headers —
 // for the test to inspect after PostGap / PostTerminated returns.
@@ -68,9 +66,9 @@ func readAll(r interface {
 // TestControlEnvelope_GapShape verifies PostGap POSTs a body matching
 // {type:"gap", cursor:"<fresh>"} per spec L415, with Standard Webhooks
 // headers (webhook-id, webhook-timestamp, webhook-signature) and the
-// γ-4 X-MCP-Subscription-Id header. webhook-id format is
-// msg_gap_<random> per spec, distinguishing control POSTs from event
-// deliveries (which use eventId).
+// X-MCP-Subscription-Id header (spec §"Webhook Event Delivery" L390).
+// webhook-id format is msg_gap_<random> per spec, distinguishing
+// control POSTs from event deliveries (which use eventId).
 func TestControlEnvelope_GapShape(t *testing.T) {
 	cap := &captureControlPost{}
 	srv := httptest.NewServer(cap.handler())
@@ -106,10 +104,11 @@ func TestControlEnvelope_GapShape(t *testing.T) {
 	assert.NotEmpty(t, cap.headers.Get("webhook-timestamp"))
 	assert.NotEmpty(t, cap.headers.Get("webhook-signature"))
 
-	// γ-4 X-MCP-Subscription-Id MUST appear on every webhook delivery,
-	// including control envelopes.
+	// X-MCP-Subscription-Id MUST appear on every webhook delivery,
+	// including control envelopes (spec §"Webhook Event Delivery"
+	// L390 + §"Webhook Security" → "Signature scheme" L472).
 	assert.Equal(t, subID, cap.headers.Get("X-MCP-Subscription-Id"),
-		"control envelopes MUST carry X-MCP-Subscription-Id (γ-4 + spec L390/L472)")
+		"control envelopes MUST carry X-MCP-Subscription-Id (spec L390/L472)")
 }
 
 // TestControlEnvelope_TerminatedShape verifies PostTerminated POSTs

--- a/experimental/ext/events/delivery_status_test.go
+++ b/experimental/ext/events/delivery_status_test.go
@@ -17,10 +17,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// ζ-5 — deliveryStatus on events/subscribe refresh response.
-//
-// Spec §"Webhook Delivery Status" L425-460: the registry tracks per-
-// target delivery health. Subscribe refresh response includes:
+// deliveryStatus on events/subscribe refresh response. Spec
+// §"Webhook Delivery Status" L425-460: the registry tracks per-target
+// delivery health. Subscribe refresh response includes:
 //
 //   deliveryStatus: {
 //     active:         bool,
@@ -301,19 +300,21 @@ func TestSuspend_SuccessfulRefreshReactivates(t *testing.T) {
 // be cosmetic (just a status flag) and the dead receiver would still
 // see event-retry traffic on every yield.
 //
-// Note: the receiver counts EVENT deliveries only — ζ-7.3 added an
-// auto-PostTerminated control envelope on the suspend transition,
-// which also hits the receiver but is a control body, not an event.
-// The discriminator is the body's top-level `type` field.
+// Note: the receiver counts EVENT deliveries only — the suspend
+// transition auto-POSTs a {type:terminated} control envelope (spec
+// §"Non-event webhook bodies" L420), which also hits the receiver
+// but is a control body, not an event. The discriminator is the
+// body's top-level `type` field.
 func TestSuspend_SuspendedTargetSkippedInDeliver(t *testing.T) {
 	var eventHits atomic.Int32
 	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
 		var env map[string]any
 		_ = json.Unmarshal(body, &env)
-		// ζ-7.3: distinguish event deliveries from the auto-Post
-		// terminated control envelope. Only count events for this
-		// test's "suspended target gets no new event deliveries" claim.
+		// Distinguish event deliveries from the auto-Post terminated
+		// control envelope (spec §"Non-event webhook bodies" L420).
+		// Only count events for this test's "suspended target gets
+		// no new event deliveries" claim.
 		if env["type"] == "terminated" {
 			w.WriteHeader(http.StatusOK)
 			return
@@ -347,16 +348,17 @@ func TestSuspend_SuspendedTargetSkippedInDeliver(t *testing.T) {
 		"suspended target MUST NOT receive new event delivery attempts; got %d new event hits", eventHits.Load()-hitsBeforeSuspendYield)
 }
 
-// TestSuspend_AutoPostsTerminatedEnvelopeOnSuspension verifies the
-// ζ-7.3 wiring: when ζ-6's suspend transition flips Active=true→false,
-// the registry automatically POSTs a {type:"terminated", error:{...}}
-// control envelope to the receiver as a courtesy notification.
+// TestSuspend_AutoPostsTerminatedEnvelopeOnSuspension verifies that
+// when the suspend transition flips Active=true→false (spec §"Webhook
+// Delivery Status" L460), the registry automatically POSTs a
+// {type:"terminated", error:{...}} control envelope to the receiver
+// as a courtesy notification (spec §"Non-event webhook bodies" L420).
 //
 // Important behavior: the target is NOT removed from the registry
-// (distinct from explicit PostTerminated which removes). The auto-Post
-// uses postTerminatedSilent so deliveryStatus stays observable
-// (Active=false) for the spec-defined "successful refresh reactivates"
-// path (ζ-6).
+// (distinct from explicit PostTerminated which removes). The
+// auto-Post uses postTerminatedSilent so deliveryStatus stays
+// observable (Active=false) for the spec-defined "successful refresh
+// reactivates" path.
 //
 // Without this auto-Post, the receiver would have no signal that its
 // subscription got suspended — it would just stop seeing events with

--- a/experimental/ext/events/emit_targeted.go
+++ b/experimental/ext/events/emit_targeted.go
@@ -3,7 +3,7 @@ package events
 import "log"
 
 // EmitToSubscription delivers an event to exactly one subscription
-// identified by sub id, bypassing the broadcast fanout (η-5).
+// identified by sub id, bypassing the broadcast fanout.
 //
 // Spec §"Server SDK Guidance" L630: targeted emit is appropriate when
 // the server has set up a per-subscription upstream listener and

--- a/experimental/ext/events/emit_targeted_test.go
+++ b/experimental/ext/events/emit_targeted_test.go
@@ -16,10 +16,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// EmitToSubscription targeted delivery (η-5). Spec §"Server SDK
-// Guidance" L630.
+// EmitToSubscription targeted delivery. Spec §"Server SDK Guidance"
+// L630.
 //
-// Coverage targets per docs/EVENTS_ETA_PLAN.md η-5 acceptance:
+// Coverage targets:
 //   - EmitToSubscription delivers to exactly the named subscription
 //     regardless of Match.
 //   - Unknown subID drops with a debug log (no panic, no error).

--- a/experimental/ext/events/errors.go
+++ b/experimental/ext/events/errors.go
@@ -19,10 +19,9 @@ package events
 //   -32017 DeliveryModeUnsupported — Event type doesn't support requested mode
 //
 // Only codes the events handlers currently emit are declared below.
-// Subsequent spec-alignment PRs (ζ for delivery status / unsubscribe
-// lookup, etc.) add the remaining constants in the commit that
-// introduces the behavior using them — keeps each new code visible
-// alongside its first use.
+// New constants get added in the same commit that introduces the
+// behavior using them — keeps each new code visible alongside its
+// first use.
 const (
 	ErrCodeEventNotFound           = -32011 // Unknown event name
 	ErrCodeUnauthorized            = -32012 // Caller lacks permission for this event/params

--- a/experimental/ext/events/events.go
+++ b/experimental/ext/events/events.go
@@ -76,15 +76,12 @@ type EventDef struct {
 	// and the library surfaces it on events/list.
 	Meta map[string]any `json:"_meta,omitempty"`
 
-	// Per-subscription author hooks (η-2). All four are zero-value-
-	// friendly — nil means baseline behavior (deliver to all,
-	// passthrough, no lifecycle work). Tagged json:"-" because
-	// EventDef is JSON-serialized for events/list and function
-	// fields neither serialize nor belong on the wire.
-	//
-	// Wiring is in the η-3 / η-4 sub-PRs; this PR ships the surface
-	// and panic-recovery wrappers. See docs/EVENTS_ETA_PLAN.md
-	// Q1-Q4 for the design, and hooks.go for the function types.
+	// Per-subscription author hooks per spec §"Server SDK Guidance"
+	// L623-705. All four are zero-value-friendly — nil means baseline
+	// behavior (deliver to all, passthrough, no lifecycle work).
+	// Tagged json:"-" because EventDef is JSON-serialized for
+	// events/list and function fields neither serialize nor belong
+	// on the wire. See hooks.go for the function types.
 	Match         MatchFunc       `json:"-"`
 	Transform     TransformFunc   `json:"-"`
 	OnSubscribe   SubscribeFunc   `json:"-"`
@@ -211,7 +208,7 @@ type Config struct {
 	// Empty (default) keeps the spec-strict behavior. Production
 	// deployments wire auth via server.WithAuth(...) and leave this
 	// empty; ctx.AuthClaims().Subject becomes the principal in the
-	// canonical tuple. See γ PLAN.md for the design rationale.
+	// canonical tuple per spec §"Subscription Identity" L361.
 	UnsafeAnonymousPrincipal string
 
 	// StreamHeartbeatInterval is how often events/stream emits
@@ -223,9 +220,8 @@ type Config struct {
 
 	// PollLeases tracks poll-mode subscriptions as ephemeral leases
 	// so on_subscribe / on_unsubscribe can fire consistently across
-	// delivery modes (η-1 — foundation for η-3's lifecycle wiring).
-	// Spec §"Server SDK Guidance" → "Unsubscribe timing by mode"
-	// L707-715.
+	// delivery modes per spec §"Server SDK Guidance" → "Unsubscribe
+	// timing by mode" L707-715.
 	//
 	// nil leaves Register to construct a default table (5 minute
 	// TTL, no hooks) — equivalent to "infrastructure present, no
@@ -235,12 +231,13 @@ type Config struct {
 	PollLeases *PollLeaseTable
 
 	// SubscriptionIndex maps server-derived sub ids to per-
-	// subscription deliver closures so EmitToSubscription can
-	// route by id without scanning every source / target (η-5).
-	// Populated by the lifecycle wiring inside Register
-	// (registerStream Add/Remove on stream open/close, webhook
-	// subscribe Add + onRemove Remove). Poll subscriptions are not
-	// indexed (no sub id; lease tuple is the routing identity).
+	// subscription deliver closures so EmitToSubscription (spec
+	// §"Server SDK Guidance" L630) can route by id without scanning
+	// every source / target. Populated by the lifecycle wiring
+	// inside Register (registerStream Add/Remove on stream
+	// open/close, webhook subscribe Add + onRemove Remove). Poll
+	// subscriptions are not indexed (no sub id; lease tuple is the
+	// routing identity).
 	//
 	// Authors that want to call EmitToSubscription should construct
 	// one via NewSubscriptionIndex and pass it here so they hold a
@@ -250,10 +247,12 @@ type Config struct {
 	SubscriptionIndex *SubscriptionIndex
 
 	// Quota enforces per-principal-per-event-type subscription caps
-	// per spec L705 (η-6). Reserve fires BEFORE on_subscribe; if the
-	// principal is at cap, the request is rejected with -32013
-	// TooManySubscriptions and on_subscribe never runs (no upstream
-	// resource provisioning for a rejected sub).
+	// per spec §"Server SDK Guidance" → "Subscription lifecycle
+	// hooks" L705 ("Servers SHOULD enforce TooManySubscriptions
+	// before invoking on_subscribe"). If the principal is at cap,
+	// the request is rejected with -32013 TooManySubscriptions and
+	// on_subscribe never runs (no upstream resource provisioning
+	// for a rejected sub).
 	//
 	// Authors configure caps via NewQuota(WithMaxSubscriptionsPerPrincipal(name, n)...)
 	// and pass the result here. nil leaves Register to construct an
@@ -301,26 +300,30 @@ func Register(cfg Config) {
 		quota = NewQuota() // no caps configured → every Reserve succeeds
 	}
 
-	// η-3: lifecycle hook wiring. The SDK installs onRemove on the
-	// webhook registry (fires safeOnUnsubscribe for explicit
-	// Unregister, TTL prune, PostTerminated) and chains an onExpire
-	// hook on the poll-lease table (fires safeOnUnsubscribe when a
-	// poll lease ages out). on_subscribe firing happens inline at
-	// the per-mode call sites (registerSubscribe for webhook,
-	// registerStream for push, registerPoll for poll) — those have
-	// the live HookContext / params at hand.
+	// Lifecycle hook wiring per spec §"Server SDK Guidance" →
+	// "Subscription lifecycle hooks" L691-705. The SDK installs
+	// onRemove on the webhook registry (fires safeOnUnsubscribe
+	// for explicit Unregister, TTL prune, PostTerminated) and
+	// chains an onExpire hook on the poll-lease table (fires
+	// safeOnUnsubscribe when a poll lease ages out). on_subscribe
+	// firing happens inline at the per-mode call sites
+	// (registerSubscribe for webhook, registerStream for push,
+	// registerPoll for poll) — those have the live HookContext /
+	// params at hand.
 	if webhooks != nil {
 		webhooks.AddOnRemoveHook(func(t WebhookTarget) {
-			// η-5: drop the index entry first so a racing
+			// Drop the index entry first so a racing
 			// EmitToSubscription that hasn't yet reached its
 			// Lookup will get the unknown-id branch (clean drop)
 			// rather than calling DeliverToTarget on a registry
 			// the target was just removed from.
 			idx.Remove(t.ID)
-			// η-6: release the quota slot. Pairs with the Reserve
-			// in registerSubscribe — fires once per actual removal
-			// (Unregister, prune, PostTerminated; NOT suspend per
-			// Q4). Safe for uncapped event-types (no-op).
+			// Release the quota slot. Pairs with the Reserve in
+			// registerSubscribe — fires once per actual removal
+			// (Unregister, prune, PostTerminated; NOT suspend —
+			// suspend ≠ unsubscribe per spec §"Webhook Delivery
+			// Status" L460). Safe for uncapped event-types
+			// (no-op).
 			quota.Release(t.Principal, t.EventName)
 			source, ok := sourceMap[t.EventName]
 			if !ok {
@@ -329,8 +332,9 @@ func Register(cfg Config) {
 			hc := newHookContext(context.Background(), t.Principal, t.ID, DeliveryModeWebhook)
 			safeOnUnsubscribe(source.Def().OnUnsubscribe, hc, t.Params)
 		})
-		// η-4: let Deliver look up Match / Transform per event name
-		// without leaking sourceMap onto WebhookRegistry.
+		// Let Deliver look up Match / Transform per event name
+		// (spec §"Server SDK Guidance" L623-629) without leaking
+		// sourceMap onto WebhookRegistry.
 		webhooks.SetDefResolver(func(eventName string) EventDef {
 			source, ok := sourceMap[eventName]
 			if !ok {
@@ -346,7 +350,7 @@ func Register(cfg Config) {
 	// PollLeaseTable.mu so it's safe even if the sweeper has already
 	// started reading it.
 	sdkOnExpire := func(principal, eventName string, params map[string]any) {
-		// η-6: release the quota slot. Pairs with the Reserve in
+		// Release the quota slot. Pairs with the Reserve in
 		// registerPoll on isNew. Fires once per actual lease
 		// expiry (the sweeper drives this).
 		quota.Release(principal, eventName)
@@ -355,7 +359,9 @@ func Register(cfg Config) {
 			return
 		}
 		// Poll has no subscription id — the lease tuple IS the
-		// identity. SubscriptionID() returns empty per Q4.
+		// routing identity per spec §"Server SDK Guidance" →
+		// "Unsubscribe timing by mode" L707. SubscriptionID()
+		// returns empty.
 		hc := newHookContext(context.Background(), principal, "", DeliveryModePoll)
 		safeOnUnsubscribe(source.Def().OnUnsubscribe, hc, params)
 	}
@@ -443,10 +449,10 @@ func registerList(srv *server.Server, sources []EventSource) {
 
 func registerPoll(srv *server.Server, sourceMap map[string]EventSource, unsafeAnon string, leases *PollLeaseTable, quota *Quota) {
 	srv.HandleMethod("events/poll", func(ctx core.MethodContext, id json.RawMessage, params json.RawMessage) *core.Response {
-		// Spec §"Poll-Based Delivery" → "Request: events/poll" L139-149:
-		// flat top-level shape — no subscriptions[] wrapper. Phase 1 dropped
-		// batching at the protocol level; δ-1 drops the now-vestigial
-		// wrapper at the wire level. δ-2 added MaxAge.
+		// Spec §"Poll-Based Delivery" → "Request: events/poll"
+		// L139-149: flat top-level shape — no subscriptions[]
+		// wrapper. MaxAge per spec §"Cursor Lifecycle" →
+		// "Bounding replay with maxAge" L529.
 		var req struct {
 			Name      string         `json:"name"`
 			Params    map[string]any `json:"params,omitempty"`
@@ -481,24 +487,27 @@ func registerPoll(srv *server.Server, sourceMap map[string]EventSource, unsafeAn
 			return core.NewErrorResponse(id, ErrCodeEventNotFound, "EventNotFound")
 		}
 
-		// η-1: poll-lease bookkeeping. The lease keys on
-		// (principal-or-anon, name, paramsHash) per spec L707.
-		// resolvePrincipal returns "" when there's no auth claim AND
-		// no UnsafeAnonymousPrincipal fallback — that empty string
-		// IS the shared-anon slot the spec describes for
-		// unauthenticated servers. We deliberately ignore the ok
-		// flag here: poll has no spec-mandated reject rule, unlike
+		// Poll-lease bookkeeping per spec §"Server SDK Guidance" →
+		// "Unsubscribe timing by mode" L707. The lease keys on
+		// (principal-or-anon, name, paramsHash). resolvePrincipal
+		// returns "" when there's no auth claim AND no
+		// UnsafeAnonymousPrincipal fallback — that empty string IS
+		// the shared-anon slot the spec describes for unauthenticated
+		// servers ("on unauthenticated servers all callers share one
+		// lease per (name, params)"). The ok flag is intentionally
+		// ignored here: poll has no spec-mandated reject rule, unlike
 		// subscribe / stream.
 		//
 		// Touch fires OnCreate the first time a (principal, name,
 		// params) tuple is seen and renews the lease on subsequent
-		// polls. η-3 fires safeOnSubscribe inline when Touch reports
+		// polls. We fire safeOnSubscribe inline when Touch reports
 		// "newly created" — the lease's onExpire (chained by
 		// Register) handles the unsubscribe side from the background
 		// sweep goroutine.
 		principal, _ := resolvePrincipal(ctx, unsafeAnon)
 		if leases.Touch(principal, req.Name, req.Params) {
-			// η-6: enforce quota BEFORE on_subscribe per spec L705.
+			// Enforce quota BEFORE on_subscribe per spec §"Server
+			// SDK Guidance" → "Subscription lifecycle hooks" L705.
 			// Touch already created the lease; if Reserve fails,
 			// roll back the lease so a rejected subscription
 			// doesn't sit in the table holding a slot it never
@@ -543,13 +552,13 @@ func registerPoll(srv *server.Server, sourceMap map[string]EventSource, unsafeAn
 			resultCursor = events[len(events)-1].CursorStr()
 		}
 
-		// η-4: per-call match/transform on the events the source
-		// returned. Match drops events the caller's params don't
-		// want; Transform shapes the event for this caller. Spec
-		// L629: "Poll subscribers see the same filtering and shaping
-		// as push/webhook subscribers." We apply BEFORE the maxAge
-		// floor so authors who use Transform to backdate timestamps
-		// (or whatever) still get a consistent floor.
+		// Per-call match/transform on the events the source returned.
+		// Match drops events the caller's params don't want; Transform
+		// shapes the event for this caller. Spec §"Server SDK
+		// Guidance" L629: "Poll subscribers see the same filtering and
+		// shaping as push/webhook subscribers." Applied BEFORE the
+		// maxAge floor so authors who use Transform to backdate
+		// timestamps still get a consistent floor.
 		def := source.Def()
 		if def.Match != nil || def.Transform != nil {
 			hc := newHookContext(ctx, principal, "", DeliveryModePoll)
@@ -564,12 +573,11 @@ func registerPoll(srv *server.Server, sourceMap map[string]EventSource, unsafeAn
 			events = kept
 		}
 
-		// δ-2: maxAge replay floor per spec §"Cursor Lifecycle" →
+		// maxAge replay floor per spec §"Cursor Lifecycle" →
 		// "Bounding replay with maxAge" L529. Drop events whose
 		// timestamp predates now - maxAge. If filtering removes any,
-		// set Truncated=true (signals the gap to the client).
-		// When req.MaxAge is 0 (default), no filtering — preserves
-		// pre-δ-2 behavior for callers that don't pass the field.
+		// set Truncated=true (signals the gap to the client). When
+		// req.MaxAge is 0 (default), no filtering applies.
 		if req.MaxAge > 0 && len(events) > 0 {
 			floor := time.Now().Add(-time.Duration(req.MaxAge) * time.Second)
 			kept := make([]Event, 0, len(events))
@@ -643,9 +651,9 @@ func registerSubscribe(srv *server.Server, sourceMap map[string]EventSource, web
 			// sends the legacy field. Per spec §"Subscription Identity"
 			// → "Key composition" L363: "There is no client-generated id
 			// — a subscription is fully determined by what it listens
-			// for, where it delivers, and who asked." γ-3 rejects
-			// client-supplied id at the wire level so old SDKs fail
-			// loudly instead of silently mis-keying.
+			// for, where it delivers, and who asked." Rejecting a
+			// client-supplied id at the wire level makes old SDKs
+			// fail loudly instead of silently mis-keying.
 			ID       string         `json:"id"`
 			Name     string         `json:"name"`
 			Params   map[string]any `json:"params,omitempty"`
@@ -655,7 +663,7 @@ func registerSubscribe(srv *server.Server, sourceMap map[string]EventSource, web
 				Secret string `json:"secret,omitempty"`
 			} `json:"delivery"`
 			Cursor *string `json:"cursor"`
-			MaxAge int     `json:"maxAge,omitempty"` // δ-3: spec §"Cursor Lifecycle" L529; seconds, 0 = no floor
+			MaxAge int     `json:"maxAge,omitempty"` // spec §"Cursor Lifecycle" L529; seconds, 0 = no floor
 		}
 		if err := json.Unmarshal(params, &req); err != nil {
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, err.Error())
@@ -720,14 +728,17 @@ func registerSubscribe(srv *server.Server, sourceMap map[string]EventSource, web
 			Params:        req.Params,
 		})
 
-		// η-3 / η-6: on first registration, enforce the quota then
-		// fire on_subscribe. Refresh of an existing subscription is
-		// renewal, not subscribe (Q4); skip both. The webhook
-		// on_unsubscribe path + the quota Release run from the
-		// registry's onRemove hook (installed in Register above).
+		// On first registration only, enforce the quota then fire
+		// on_subscribe. Refresh of an existing subscription is
+		// renewal, not subscribe — neither hook re-fires (per spec
+		// §"Webhook Delivery Status" L460 + §"Server SDK Guidance"
+		// L691). The webhook on_unsubscribe path + the quota Release
+		// run from the registry's onRemove hook (installed in
+		// Register above).
 		if isNew {
-			// η-6: enforce cap BEFORE on_subscribe per spec L705.
-			// If Reserve fails, roll back the registration so a
+			// Enforce cap BEFORE on_subscribe per spec §"Server SDK
+			// Guidance" → "Subscription lifecycle hooks" L705. If
+			// Reserve fails, roll back the registration so a
 			// rejected sub doesn't sit in the registry holding a
 			// slot it never got. Unregister fires onRemove →
 			// quota.Release (a no-op here because we never
@@ -747,7 +758,7 @@ func registerSubscribe(srv *server.Server, sourceMap map[string]EventSource, web
 				return core.NewErrorResponse(id, ErrCodeTooManySubscriptions,
 					"on_subscribe rejected: "+err.Error())
 			}
-			// η-5: register this webhook target in the SubscriptionIndex
+			// Register this webhook target in the SubscriptionIndex
 			// AFTER on_subscribe succeeded — no half-provisioned
 			// entries. Refresh-of-existing skips the Add entirely
 			// (entry from the original subscribe still routes
@@ -778,19 +789,21 @@ func registerSubscribe(srv *server.Server, sourceMap map[string]EventSource, web
 		// client supplied it, so the client already knows it.
 		//
 		// The id field is the SERVER-DERIVED routing handle per spec
-		// §"Subscription Identity" → "Derived id" L367 — non-load-bearing
-		// for security, used only as the X-MCP-Subscription-Id header
-		// value on delivery POSTs (γ-4 wires the header). Knowing the
-		// id grants no operations on the subscription (L378).
+		// §"Subscription Identity" → "Derived id" L367 —
+		// non-load-bearing for security, used only as the
+		// X-MCP-Subscription-Id header value on delivery POSTs (per
+		// §"Webhook Event Delivery" L390). Knowing the id grants no
+		// operations on the subscription (L378).
 		respBody := map[string]any{
 			"id":            derivedID,
 			"cursor":        wireCursor,
 			"refreshBefore": expiresAt.Format(time.RFC3339),
 		}
-		// ζ-5: include deliveryStatus on refresh response when the target
-		// has prior delivery attempts. Spec §"Webhook Delivery Status"
-		// L425-460. Omitted on first subscribe — there's nothing to
-		// report and an empty object would just be wire bloat.
+		// Include deliveryStatus on refresh response when the target
+		// has prior delivery attempts (spec §"Webhook Delivery
+		// Status" L425-460). Omitted on first subscribe — there's
+		// nothing to report and an empty object would just be wire
+		// bloat.
 		if status, ok := deliveryStatusForResponse(webhooks.DeliveryStatus(canonical)); ok {
 			respBody["deliveryStatus"] = status
 		}

--- a/experimental/ext/events/headers.go
+++ b/experimental/ext/events/headers.go
@@ -63,11 +63,12 @@ func ParseHeaderMode(s string) (WebhookHeaderMode, error) {
 //
 // Per spec §"Webhook Event Delivery" L390 + §"Webhook Security" →
 // "Signature scheme" L472: every delivery MUST include
-// X-MCP-Subscription-Id (the subscription's derived id from
-// γ-2's tuple identity) so the receiver can select the correct
-// secret without parsing the body. This is the only MCP-specific
-// header on a Standard Webhooks delivery; everything else conforms
-// to the Standard Webhooks profile.
+// X-MCP-Subscription-Id (the subscription's derived id from the
+// canonical-tuple identity at §"Subscription Identity" → "Derived
+// id" L367) so the receiver can select the correct secret without
+// parsing the body. This is the only MCP-specific header on a
+// Standard Webhooks delivery; everything else conforms to the
+// Standard Webhooks profile.
 //
 // withSubscriptionID returns a copy with the X-MCP-Subscription-Id
 // header layered on. Kept as a separate method so the signing
@@ -135,8 +136,9 @@ func signMCP(_ string, body []byte, secret string, now time.Time) signedDelivery
 // under client-side dedup. Crucially, the msgID is also stable across retries
 // of the same event — if it weren't, a Standard-Webhooks-conformant receiver
 // would treat each retry as a distinct delivery and dedup would silently
-// break. Control envelopes (added in PR group ζ) supply their own msgID of
-// the form msg_<type>_<random>; see newMessageID.
+// break. Control envelopes (per spec §"Non-event webhook bodies"
+// L415-423) supply their own msgID of the form msg_<type>_<random>;
+// see newMessageID.
 func signStandardWebhooks(msgID string, body []byte, secret string, now time.Time) signedDelivery {
 	ts := strconv.FormatInt(now.Unix(), 10)
 	mac := hmac.New(sha256.New, []byte(secret))
@@ -170,8 +172,9 @@ func signFor(mode WebhookHeaderMode, msgID string, body []byte, secret string, n
 // newMessageID returns a Standard-Webhooks-shaped message ID. Uses the
 // "msg_" prefix Stripe / Standard Webhooks examples use, with 16 random
 // bytes as URL-safe base64. Reserved for non-event POSTs (control
-// envelopes) — event deliveries use the event's own eventId so that
-// retries dedup correctly at the receiver. See ζ-4 for control envelopes.
+// envelopes per spec §"Non-event webhook bodies" L415-423) — event
+// deliveries use the event's own eventId so that retries dedup
+// correctly at the receiver.
 func newMessageID() string {
 	var buf [16]byte
 	if _, err := rand.Read(buf[:]); err != nil {
@@ -184,10 +187,11 @@ func newMessageID() string {
 
 // newControlMessageID mints a Standard-Webhooks-shaped message ID with
 // the type-tagged form msg_<typ>_<random>, used for non-event control
-// envelope POSTs (ζ-4 — type:gap, type:terminated). The type tag lets
-// receivers and operators distinguish control deliveries from event
-// deliveries (which use the event's eventId as webhook-id) without
-// parsing the body.
+// envelope POSTs (type:gap, type:terminated per spec §"Non-event
+// webhook bodies" L415-423). The type tag lets receivers and
+// operators distinguish control deliveries from event deliveries
+// (which use the event's eventId as webhook-id) without parsing the
+// body.
 //
 // Per spec §"Non-event webhook bodies" L417: control envelopes use the
 // pattern msg_<type>_<random> for webhook-id.

--- a/experimental/ext/events/headers_test.go
+++ b/experimental/ext/events/headers_test.go
@@ -131,9 +131,9 @@ func TestStandardWebhooks_WebhookIDIsStableAcrossRetries(t *testing.T) {
 		"signature regenerates per retry because timestamp is part of the signed input")
 }
 
-// TestStandardWebhooks_EmitsSubscriptionIDHeader verifies γ-4's spec
-// contract (§"Webhook Event Delivery" L390 + §"Webhook Security" →
-// "Signature scheme" L472): every delivery MUST include
+// TestStandardWebhooks_EmitsSubscriptionIDHeader verifies the spec
+// contract at §"Webhook Event Delivery" L390 + §"Webhook Security" →
+// "Signature scheme" L472: every delivery MUST include
 // X-MCP-Subscription-Id carrying the spec's derived subscription id
 // so the receiver can select the correct secret without parsing the
 // body.
@@ -173,10 +173,10 @@ func TestStandardWebhooks_SubscriptionIDStableAcrossRetries(t *testing.T) {
 }
 
 // TestStandardWebhooks_WithEmptySubscriptionIDIsNoOp verifies that
-// withSubscriptionID("") leaves the headers untouched. Defensive — the
-// registry's deliver path always passes target.ID (always set post-γ-2),
-// but the empty-string case shouldn't crash or add a misleading
-// "X-MCP-Subscription-Id: " header.
+// withSubscriptionID("") leaves the headers untouched. Defensive —
+// the registry's deliver path always passes target.ID (always set on
+// real registrations), but the empty-string case shouldn't crash or
+// add a misleading "X-MCP-Subscription-Id: " header.
 func TestStandardWebhooks_WithEmptySubscriptionIDIsNoOp(t *testing.T) {
 	body := []byte(`{}`)
 	signed := signStandardWebhooks("evt_1", body, "whsec_test", time.Unix(1700000000, 0)).

--- a/experimental/ext/events/hooks.go
+++ b/experimental/ext/events/hooks.go
@@ -1,24 +1,28 @@
 package events
 
 // Hook surface for per-event-type author behavior — match / transform on
-// broadcast emit and on_subscribe / on_unsubscribe on lifecycle (η-2).
+// broadcast emit (spec §"Server SDK Guidance" L623-629) and
+// on_subscribe / on_unsubscribe on lifecycle (spec §"Server SDK
+// Guidance" → "Subscription lifecycle hooks" L691-705).
 //
 // Design context:
 //
-//   - Spec §"Server SDK Guidance" L565+ describes hooks in Python prose.
-//     Idioms 3 and 5 (class-bundled match/transform; separate
-//     @on_subscribe decorator) collapse onto a single Go answer: fields
-//     on EventDef. See docs/EVENTS_ETA_PLAN.md Q1.
+//   - The spec describes hooks in Python prose. The class-bundled
+//     match/transform pattern and the separate @on_subscribe decorator
+//     collapse onto a single Go answer: fields on EventDef. Storing
+//     all four hooks in one place mirrors how the spec ties them to
+//     an event type.
 //
-//   - Hooks are sync per Q3 — goroutines that call yield/Subscribe/
+//   - Hooks are sync — goroutines that call yield / Subscribe /
 //     Register already exist; no new concurrency primitive needed.
 //
-//   - Hooks are zero-value-friendly: nil = "not set" = baseline behavior
-//     (all subscribers receive, payload unchanged, no lifecycle work).
+//   - Hooks are zero-value-friendly: nil = "not set" = baseline
+//     behavior (all subscribers receive, payload unchanged, no
+//     lifecycle work).
 //
-// This file defines the type aliases, the HookContext, and the panic-
-// recovery wrappers. Wiring into the four call sites (events/poll,
-// events/stream, events/subscribe, the emit fanout) is η-3 / η-4 / η-5.
+// This file defines the type aliases, the HookContext, and the
+// panic-recovery wrappers. Wiring lives in the four call sites
+// (events/poll, events/stream, events/subscribe, the emit fanout).
 
 import (
 	"context"
@@ -130,7 +134,7 @@ func (h *hookContext) Mode() DeliveryMode {
 }
 
 // newHookContext is the package-internal constructor used by the
-// wiring sub-PRs (η-3 / η-4) when invoking the safe* wrappers.
+// per-mode handlers when invoking the safe* wrappers.
 func newHookContext(ctx context.Context, principal, subID string, mode DeliveryMode) HookContext {
 	return &hookContext{ctx: ctx, principal: principal, subscriptionID: subID, mode: mode}
 }
@@ -197,14 +201,16 @@ type TransformFunc func(ctx HookContext, event Event, params map[string]any) (Ev
 // closest analog to a Python coroutine raising. The Python signature
 // has `subscription_id` as a third positional argument; Go folds it
 // onto HookContext.SubscriptionID() so the call site stays uniform
-// across delivery modes (poll has no sub id and the field is empty
-// — see Q4). Stored as a field on EventDef rather than a separate
-// `@server.on_subscribe(name)` decorator (Q1 — same answer as match/
-// transform, since it's still per-event-type state).
+// across delivery modes (poll has no sub id and the field is empty —
+// the lease tuple is the routing identity per spec §"Server SDK
+// Guidance" → "Unsubscribe timing by mode" L707). Stored as a field
+// on EventDef rather than a separate `@server.on_subscribe(name)`
+// decorator — same answer as match/transform, since it's still
+// per-event-type state.
 //
 // Returning a non-nil error fails the subscribe call: the SDK
-// surfaces it as -32013 TooManySubscriptions today (η-6 may add a
-// dedicated SubscribeFailed code if a real use case appears). The
+// surfaces it as -32013 TooManySubscriptions today (a dedicated
+// SubscribeFailed code may follow if a real use case appears). The
 // SDK does NOT roll back webhook registration / push stream open on
 // hook failure; authors that need rollback should arrange it inside
 // the hook before returning the error.

--- a/experimental/ext/events/hooks_test.go
+++ b/experimental/ext/events/hooks_test.go
@@ -10,7 +10,7 @@ import (
 
 // testHC returns an empty HookContext for tests that don't care about
 // its fields (panic recovery, nil-vs-not). Wiring tests that DO care
-// (η-3 / η-4) construct via newHookContext directly.
+// per-mode wiring tests construct via newHookContext directly.
 func testHC() HookContext {
 	return newHookContext(nil, "", "", deliveryModeUnset)
 }

--- a/experimental/ext/events/identity_handler_test.go
+++ b/experimental/ext/events/identity_handler_test.go
@@ -15,12 +15,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Handler-level tests for γ-2's auth gate + tuple-keyed registry. Tests
-// here build a server WITHOUT UnsafeAnonymousPrincipal so they exercise
-// the spec-strict path-3 rejection. The shared fixture in
-// secret_validation_test.go uses UnsafeAnonymousPrincipal: "test-principal"
-// for tests that aren't concerned with the auth gate; this file's tests
-// build their own minimal stack so they can vary the auth posture.
+// Handler-level tests for the spec auth gate (§"Subscription
+// Identity" → "Authentication required" L361) + tuple-keyed
+// registry. Tests here build a server WITHOUT
+// UnsafeAnonymousPrincipal so they exercise the strict rejection
+// path. The shared fixture in secret_validation_test.go uses
+// UnsafeAnonymousPrincipal: "test-principal" for tests that aren't
+// concerned with the auth gate; this file's tests build their own
+// minimal stack so they can vary the auth posture.
 
 // buildAuthGateStack returns a server with the events handlers registered
 // + a reference to the registry so tests can inspect target state.
@@ -30,8 +32,9 @@ import (
 func buildAuthGateStack(t *testing.T, unsafeAnon string) (*server.Server, *WebhookRegistry) {
 	t.Helper()
 	srv := server.NewServer(core.ServerInfo{Name: "test", Version: "1.0"})
-	// ζ-1: tests subscribe to httptest URLs (127.0.0.1:N) — bypass
-	// the production-default SSRF dial guard.
+	// Tests subscribe to httptest URLs (127.0.0.1:N) — bypass the
+	// production-default SSRF dial guard (spec §"Webhook Security"
+	// → "SSRF prevention" L464).
 	webhooks := NewWebhookRegistry(WithWebhookAllowPrivateNetworks(true))
 	Register(Config{
 		Sources:                  []EventSource{fakeSecretValidationSource{}},
@@ -156,7 +159,7 @@ func TestSubscribe_TupleIsolationCrossPrincipal(t *testing.T) {
 	assert.Equal(t, idBob, targets[0].ID, "unregister(alice's tuple) must not affect bob's subscription")
 }
 
-// TestSubscribe_RejectsClientSuppliedID verifies γ-3's wire-strict
+// TestSubscribe_RejectsClientSuppliedID verifies the wire-strict
 // rejection of legacy id-bearing subscribe requests. Per spec
 // §"Subscription Identity" → "Key composition" L363: "There is no
 // client-generated id — a subscription is fully determined by what it
@@ -166,7 +169,7 @@ func TestSubscribe_TupleIsolationCrossPrincipal(t *testing.T) {
 func TestSubscribe_RejectsClientSuppliedID(t *testing.T) {
 	srv, _ := buildAuthGateStack(t, "test-principal")
 	params := validSubscribeParams()
-	params["id"] = "client-picked-id" // pre-γ wire shape
+	params["id"] = "client-picked-id" // legacy wire shape
 
 	resp := dispatchSubscribe(t, srv, params)
 	require.NotNil(t, resp.Error, "client-supplied id must be rejected")
@@ -202,12 +205,12 @@ func TestUnsubscribe_ByTuple(t *testing.T) {
 	assert.Empty(t, webhooks.Targets(), "tuple-form unsubscribe must remove the matching entry")
 }
 
-// TestDelivery_EmitsXMCPSubscriptionIDHeader verifies γ-4's end-to-end
-// header wiring: a real subscribe → yield → POST round-trip carries
+// TestDelivery_EmitsXMCPSubscriptionIDHeader verifies the end-to-end
+// header wiring per spec §"Webhook Event Delivery" L390 + §"Webhook
+// Security" L472: a real subscribe → yield → POST round-trip carries
 // the X-MCP-Subscription-Id header on the outbound delivery, and the
-// header value matches the server-derived id returned in the subscribe
-// response. Per spec §"Webhook Event Delivery" L390 + §"Webhook
-// Security" L472.
+// header value matches the server-derived id returned in the
+// subscribe response.
 //
 // Without this test, a regression in the deliver path could drop the
 // header silently — receivers on shared callback URLs would still
@@ -224,9 +227,10 @@ func TestDelivery_EmitsXMCPSubscriptionIDHeader(t *testing.T) {
 	}))
 	defer callback.Close()
 
-	// ζ-1: httptest binds to 127.0.0.1; tests that drive an actual
+	// httptest binds to 127.0.0.1; tests that drive an actual
 	// delivery need WithWebhookAllowPrivateNetworks(true) to bypass
-	// the dial-time SSRF guard.
+	// the dial-time SSRF guard (spec §"Webhook Security" → "SSRF
+	// prevention" L464).
 	webhooks := NewWebhookRegistry(WithWebhookAllowPrivateNetworks(true))
 	canonical := canonicalKey("test-principal", callback.URL, "fake.event", nil)
 	subID := deriveSubscriptionID(canonical)

--- a/experimental/ext/events/lifecycle_test.go
+++ b/experimental/ext/events/lifecycle_test.go
@@ -16,7 +16,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Lifecycle hook firings across all three delivery modes (η-3).
+// Lifecycle hook firings across all three delivery modes. Spec
+// §"Server SDK Guidance" → "Subscription lifecycle hooks" L691-715.
 //
 // Acceptance per docs/EVENTS_ETA_PLAN.md:
 //   - Hooks fire exactly once per subscription lifecycle in each mode.
@@ -326,9 +327,9 @@ func TestLifecycle_Webhook_PostTerminatedFiresOnUnsubscribe(t *testing.T) {
 
 // TestLifecycle_Webhook_SuspendDoesNotFireOnUnsubscribe verifies that
 // the suspend transition (Active=true→false from repeated delivery
-// failures, ζ-6) does NOT fire on_unsubscribe — the subscription is
-// paused, not removed; refresh reactivates without re-firing
-// on_subscribe (Q4).
+// failures, spec §"Webhook Delivery Status" L460) does NOT fire
+// on_unsubscribe — the subscription is paused, not removed; refresh
+// reactivates without re-firing on_subscribe.
 func TestLifecycle_Webhook_SuspendDoesNotFireOnUnsubscribe(t *testing.T) {
 	hooks := &hookCounter{}
 	const threshold = 2

--- a/experimental/ext/events/match_transform_test.go
+++ b/experimental/ext/events/match_transform_test.go
@@ -16,9 +16,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Per-subscription Match / Transform on broadcast emit (η-4).
+// Per-subscription Match / Transform on broadcast emit. Spec
+// §"Server SDK Guidance" L623-629.
 //
-// Coverage targets per docs/EVENTS_ETA_PLAN.md η-4 acceptance:
+// Coverage targets:
 //   - Match returning false filters that subscriber out.
 //   - Transform changes the delivered event per subscriber.
 //   - nil hooks are no-op (passthrough; baseline).
@@ -330,9 +331,8 @@ func TestMatchTransform_Webhook_MatchAndTransformPerTarget(t *testing.T) {
 
 func TestMatchTransform_Webhook_FiltersByEventName(t *testing.T) {
 	// Two sources sharing one registry: a yield from source A must
-	// NOT deliver to source B's webhook subscribers. (Pre-η-4 the
-	// registry didn't filter by name; η-4's per-target processing
-	// adds the filter.)
+	// NOT deliver to source B's webhook subscribers. The per-target
+	// processing in Deliver enforces the event-name filter.
 	srcA, yieldA := NewYieldingSource[sevPayload](EventDef{
 		Name:        "src.a",
 		Description: "source A",

--- a/experimental/ext/events/poll_lease.go
+++ b/experimental/ext/events/poll_lease.go
@@ -2,8 +2,9 @@ package events
 
 // Poll-lease table — in-memory soft state tracking which (principal,
 // eventName, params) tuples have recent poll activity, with TTL-based
-// expiry and lifecycle callbacks. Foundation for η-3's poll-mode
-// on_subscribe / on_unsubscribe wiring (η-1).
+// expiry and lifecycle callbacks. Provides the per-subscription
+// identity poll otherwise lacks, so on_subscribe / on_unsubscribe
+// can fire consistently with webhook + push.
 //
 // Spec §"Server SDK Guidance" → "Unsubscribe timing by mode" L707-715:
 // "the SDK treats poll subscriptions as leased. The lease is keyed on
@@ -30,9 +31,10 @@ const (
 )
 
 // PollLeaseHook is the callback signature for OnCreate / OnExpire. The
-// SDK invokes it with the lease's identity tuple so authors (typically
-// via the η-3 wiring that turns these into on_subscribe / on_unsubscribe
-// calls) can provision and tear down upstream resources.
+// SDK invokes it with the lease's identity tuple; events.Register
+// chains an internal hook that turns these into on_subscribe /
+// on_unsubscribe calls per spec §"Server SDK Guidance" →
+// "Subscription lifecycle hooks" L691.
 //
 // Hooks fire from the goroutine that called Touch (OnCreate) or the
 // background sweep goroutine (OnExpire). Authors that need to do
@@ -189,7 +191,8 @@ func (t *PollLeaseTable) Touch(principal, eventName string, params map[string]an
 
 // Remove drops a lease for (principal, eventName, params) immediately,
 // without firing OnExpire. Returns true when an entry actually went
-// away. Used by the η-6 quota wiring to roll back a Touch when
+// away. Used by the quota wiring (spec §"Server SDK Guidance" →
+// "Subscription lifecycle hooks" L705) to roll back a Touch when
 // Reserve fails — the lease was just created but the principal is
 // over their cap, so the lease should never have been there.
 //

--- a/experimental/ext/events/quota.go
+++ b/experimental/ext/events/quota.go
@@ -1,9 +1,8 @@
 package events
 
-// Per-principal-per-event-type subscription quota (η-6). Spec
-// §"Server SDK Guidance" → "Subscription lifecycle hooks" L705:
-// "Servers SHOULD enforce TooManySubscriptions before invoking
-// on_subscribe."
+// Per-principal-per-event-type subscription quota. Spec §"Server SDK
+// Guidance" → "Subscription lifecycle hooks" L705: "Servers SHOULD
+// enforce TooManySubscriptions before invoking on_subscribe."
 //
 // Why per-principal-per-event-type:
 //
@@ -18,9 +17,8 @@ package events
 //     "one client spawning 10000 subs to one event" pattern without
 //     getting in the way of normal cross-event-type usage.
 //
-// docs/EVENTS_ETA_PLAN.md Q7 picks (per-principal, per-event-type)
-// as the default; the other axes can be added behind options later
-// if a deployment needs them.
+// (per-principal, per-event-type) is the default; the other axes
+// can be added behind options later if a deployment needs them.
 //
 // Implementation note: built on golang.org/x/sync/semaphore.Weighted,
 // which is the canonical Go primitive for "at most N concurrent

--- a/experimental/ext/events/quota_test.go
+++ b/experimental/ext/events/quota_test.go
@@ -16,8 +16,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TooManySubscriptions enforcement per spec L705 (η-6). Acceptance
-// per docs/EVENTS_ETA_PLAN.md:
+// TooManySubscriptions enforcement per spec §"Server SDK Guidance" →
+// "Subscription lifecycle hooks" L705. Acceptance:
 //   - Cap of N per-event-type per-principal: (N+1)th subscribe
 //     returns -32013.
 //   - Same cap applies to push and poll modes consistently.

--- a/experimental/ext/events/secret_validation_test.go
+++ b/experimental/ext/events/secret_validation_test.go
@@ -187,15 +187,16 @@ func TestSubscribe_ResponseDoesNotEchoSecret(t *testing.T) {
 }
 
 // TestUnsubscribe_RequiresTupleNotSecret verifies the handler ignores
-// the legacy proof-of-possession secret-form unsubscribe — γ keys
-// unsubscribe on the (principal, name, params, delivery.url) tuple
-// per spec §"Unsubscribing: events/unsubscribe" L509. A request that
+// the legacy proof-of-possession secret-form unsubscribe — the spec
+// keys unsubscribe on the (principal, name, params, delivery.url)
+// tuple per §"Unsubscribing: events/unsubscribe" L509. A request that
 // supplies only delivery.url + delivery.secret (no name) is rejected
 // with name-required because the secret field is no longer part of the
 // unsubscribe surface.
 func TestUnsubscribe_RequiresTupleNotSecret(t *testing.T) {
 	resp := callUnsubscribeHandler(t, map[string]any{
-		// name intentionally omitted; secret would have worked pre-β
+		// name intentionally omitted; the legacy secret-form would
+		// have worked here, but the spec now requires the tuple.
 		"delivery": map[string]any{
 			"url":    "https://example.com/hook",
 			"secret": "whsec_should-not-be-accepted-here",
@@ -219,12 +220,12 @@ func (fakeSecretValidationSource) Latest() string                  { return "" }
 
 // buildSecretValidationStack returns a server with the events handlers
 // registered (with UnsafeAnonymousPrincipal: "test-principal" so the
-// handlers don't reject every test request with -32012 Unauthorized —
-// γ adds spec-mandated auth gating, but the secret-validation tests
-// here are concerned with the validator and unsubscribe shape, not
-// the auth gate. Auth-specific tests live in identity_handler_test.go
-// (γ-2 follow-on).) The initialize handshake is completed so subsequent
-// Dispatch calls accept arbitrary methods.
+// handlers don't reject every test request with -32012 Unauthorized
+// per spec §"Subscription Identity" → "Authentication required" L361.
+// The secret-validation tests here are concerned with the validator
+// and unsubscribe shape, not the auth gate; auth-specific tests live
+// in identity_handler_test.go.) The initialize handshake is completed
+// so subsequent Dispatch calls accept arbitrary methods.
 func buildSecretValidationStack(t *testing.T) *server.Server {
 	t.Helper()
 	srv := server.NewServer(core.ServerInfo{Name: "test", Version: "1.0"})

--- a/experimental/ext/events/ssrf_delivery_test.go
+++ b/experimental/ext/events/ssrf_delivery_test.go
@@ -18,18 +18,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// ζ-1 — delivery-time SSRF guard.
+// Delivery-time SSRF guard. Spec §"Webhook Security" → "SSRF
+// prevention" L464.
 //
-// The pre-ζ webhook registry only checked the URL hostname at subscribe
-// time, with a "WARNING: allowed in POC mode" log that allowed loopback
-// through. This is unsafe under DNS rebinding: an attacker registers a
-// public hostname, then changes its DNS to resolve to an internal IP at
-// delivery time. The pre-ζ check has nothing to say about that.
-//
-// ζ-1 moves the check into the http.Client's Dialer.Control callback so
-// it runs on EVERY connect attempt against the resolved IP — TOCTOU-free
-// because the IP we inspect is the same one about to be used for the
-// connect syscall. Per spec §"Webhook Security" → "SSRF prevention" L464.
+// A subscribe-time hostname check would be unsafe under DNS rebinding:
+// an attacker registers a public hostname, then changes its DNS to
+// resolve to an internal IP at delivery time. The check moved into
+// the http.Client's Dialer.Control callback runs on EVERY connect
+// attempt against the resolved IP — TOCTOU-free because the IP we
+// inspect is the same one about to be used for the connect syscall.
 
 // captureDeliveryFailure returns a webhook registry configured with a
 // captured-failure log so tests can observe whether a delivery attempt
@@ -90,8 +87,8 @@ func (c *captureLog) containsSSRFBlock() bool {
 
 // TestDelivery_RejectsLoopbackAtDialTime verifies the dial-time guard
 // rejects 127.0.0.1 — the canonical SSRF target — when the demo escape
-// hatch (WithWebhookAllowPrivateNetworks) is OFF. Pre-ζ this would have
-// connected silently with only a "WARNING" log; the spec requires hard
+// hatch (WithWebhookAllowPrivateNetworks) is OFF. The spec
+// (§"Webhook Security" → "SSRF prevention" L464) requires hard
 // rejection in production.
 func TestDelivery_RejectsLoopbackAtDialTime(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -200,7 +197,7 @@ func TestDelivery_DialAllowsPublicIPs(t *testing.T) {
 var _ = io.EOF // keep io import alive for potential future error checks
 
 // TestDelivery_DoesNotFollowRedirects verifies that the webhook
-// http.Client refuses to follow 3xx responses (ζ-2). Without this, a
+// http.Client refuses to follow 3xx responses. Without this, a
 // receiver could 302 to an internal address (127.0.0.1, 10.x, etc.)
 // and bypass the dial-time SSRF guard via Go's default 10-redirect
 // follow behavior.
@@ -233,11 +230,12 @@ func TestDelivery_DoesNotFollowRedirects(t *testing.T) {
 		map[string]string{"text": "hi"}))
 
 	// Wait long enough for the deliver loop to retry-and-fail (3xx
-	// classified as non-retryable per ζ-2 + retry semantics).
+	// is classified as non-retryable per the registry's retry
+	// semantics).
 	time.Sleep(300 * time.Millisecond)
 
 	assert.Equal(t, int32(1), hits.Load(),
-		"initial receiver should be POSTed exactly once — 3xx is non-retryable per ζ-2; got %d", hits.Load())
+		"initial receiver should be POSTed exactly once — 3xx is non-retryable; got %d", hits.Load())
 	assert.Equal(t, int32(0), redirectHits.Load(),
 		"redirect target MUST NOT be followed; got %d follow-up POSTs", redirectHits.Load())
 }

--- a/experimental/ext/events/stream.go
+++ b/experimental/ext/events/stream.go
@@ -1,6 +1,7 @@
 package events
 
-// events/stream — push delivery for the MCP Events extension (ε-2).
+// events/stream — push delivery for the MCP Events extension. Spec
+// §"Push-Based Delivery" → "Request: events/stream" L240-294.
 //
 // One open events/stream call holds a single subscription's per-stream
 // goroutine. The handler:
@@ -9,7 +10,7 @@ package events
 //     source supports push).
 //  2. Sends notifications/events/active with the resolved cursor (§"Push-
 //     Based Delivery" → "Request: events/stream" L240).
-//  3. Subscribes to the source's live channel (ε-1's Subscribe API).
+//  3. Subscribes to the source's live channel.
 //  4. Loops on (event arrival, heartbeat tick, ctx.Done):
 //     - Event arrival → notifications/events/event (L243-271). If the source
 //       signals Truncated=true, prepends a fresh notifications/events/active
@@ -50,16 +51,17 @@ type StreamEventsResult struct {
 // rejects events/stream for sources lacking this capability with -32017
 // DeliveryModeUnsupported per spec.
 //
-// SubscribeOpts (η-4): the SDK passes the resolved subscriber identity
+// SubscribeOpts: the SDK passes the resolved subscriber identity
 // (Principal / SubscriptionID / Params) at Subscribe time so the
 // source can stash it on its subscriberSlot and apply the EventDef's
-// Match / Transform on fanout. Implementations that don't care can
-// ignore the opts.
+// Match / Transform (spec §"Server SDK Guidance" L623-629) on fanout.
+// Implementations that don't care can ignore the opts.
 //
-// Returns (chan, sender). The sender (η-5) delivers a single event to
-// THIS specific subscription, bypassing Match / Transform — used by
-// EmitToSubscription to route by sub id. Sources that don't support
-// targeted delivery can return a no-op sender.
+// Returns (chan, sender). The sender delivers a single event to THIS
+// specific subscription, bypassing Match / Transform — used by
+// EmitToSubscription (spec §"Server SDK Guidance" L630) to route by
+// sub id. Sources that don't support targeted delivery can return a
+// no-op sender.
 type streamSubscribable interface {
 	Subscribe(ctx context.Context, opts SubscribeOpts) (<-chan SubscriberEvent, func(Event))
 }
@@ -98,7 +100,7 @@ type heartbeatNotifParams struct {
 // (spec L255+L261, transient — stream stays open) and
 // notifications/events/terminated (spec L783-795, terminal — stream
 // closes). Both carry the same {requestId, error{code,message}} envelope
-// per the spec's JSON-RPC-error-shaped error payload. ζ-7.
+// per the spec's JSON-RPC-error-shaped error payload.
 type errorNotifParams struct {
 	RequestID json.RawMessage `json:"requestId"`
 	Error     errPayload      `json:"error"`
@@ -136,7 +138,7 @@ func registerStream(srv *server.Server, sourceMap map[string]EventSource, unsafe
 		// Spec §"Subscription Identity" → "Authentication required" L361:
 		// events/stream MUST be called with an authenticated principal —
 		// the spec lists Unauthorized among events/stream's immediate
-		// errors at L267. Same auth gate as events/subscribe (γ-2).
+		// errors at L267. Same auth gate as events/subscribe.
 		principal, ok := resolvePrincipal(ctx, unsafeAnon)
 		if !ok {
 			return core.NewErrorResponse(id, ErrCodeUnauthorized, "Unauthorized")
@@ -151,7 +153,8 @@ func registerStream(srv *server.Server, sourceMap map[string]EventSource, unsafe
 				"DeliveryModeUnsupported: source does not support push delivery")
 		}
 
-		// η-6: enforce quota BEFORE Subscribe + on_subscribe per spec
+		// Enforce quota BEFORE Subscribe + on_subscribe per spec
+		// §"Server SDK Guidance" → "Subscription lifecycle hooks"
 		// L705. Done early so a rejected stream never registers a
 		// slot or fires any author hooks. Defer the Release on every
 		// return path below — pairs 1:1 with this Reserve regardless
@@ -180,12 +183,12 @@ func registerStream(srv *server.Server, sourceMap map[string]EventSource, unsafe
 			}
 		}
 
-		// η-3 / η-4: derive the per-stream sub id BEFORE subscribing
-		// so it can ride on the subscriberSlot for fanout-time
-		// HookContext construction. Each stream open gets a fresh
-		// random sub id — push doesn't share canonical-tuple identity
-		// across concurrent streams from the same principal/name/params,
-		// so unlike webhook (where deriveSubscriptionID collapses
+		// Derive the per-stream sub id BEFORE subscribing so it can
+		// ride on the subscriberSlot for fanout-time HookContext
+		// construction. Each stream open gets a fresh random sub id —
+		// push doesn't share canonical-tuple identity across
+		// concurrent streams from the same principal/name/params, so
+		// unlike webhook (where deriveSubscriptionID collapses
 		// duplicate subscribes), every open IS a new subscription.
 		var subIDBuf [16]byte
 		_, _ = rand.Read(subIDBuf[:])
@@ -205,10 +208,11 @@ func registerStream(srv *server.Server, sourceMap map[string]EventSource, unsafe
 			Params:         req.Params,
 		})
 
-		// η-5: register this stream's sender in the SubscriptionIndex
-		// so EmitToSubscription(idx, event, streamSubID) routes here.
-		// Removed on every return path so a closed stream's id can't
-		// match a stale entry.
+		// Register this stream's sender in the SubscriptionIndex so
+		// EmitToSubscription(idx, event, streamSubID) routes here
+		// (spec §"Server SDK Guidance" L630). Removed on every
+		// return path so a closed stream's id can't match a stale
+		// entry.
 		idx.Add(streamSubID, DeliveryModePush, sender)
 		defer idx.Remove(streamSubID)
 
@@ -221,10 +225,11 @@ func registerStream(srv *server.Server, sourceMap map[string]EventSource, unsafe
 			Cursor:    initialCursor,
 		})
 
-		// η-3: lifecycle hooks for push. on_subscribe fires after the
-		// channel is acquired (the subscription is now live and would
-		// receive events); on_unsubscribe fires on every return path
-		// via defer.
+		// Lifecycle hooks for push (spec §"Server SDK Guidance" →
+		// "Subscription lifecycle hooks" L691). on_subscribe fires
+		// after the channel is acquired (the subscription is now
+		// live and would receive events); on_unsubscribe fires on
+		// every return path via defer.
 		hc := newHookContext(ctx, principal, streamSubID, DeliveryModePush)
 		if err := safeOnSubscribe(def.OnSubscribe, hc, req.Params); err != nil {
 			// Author rejected provisioning; close out the stream
@@ -254,9 +259,10 @@ func registerStream(srv *server.Server, sourceMap map[string]EventSource, unsafe
 					return core.NewResponse(id, StreamEventsResult{Meta: map[string]any{}})
 				}
 
-				// ζ-7: terminal source signal. Emit notifications/events/
-				// terminated per spec L783-795 and return — subscription
-				// has ended; SDK callback fires + stream closes.
+				// Terminal source signal. Emit notifications/events/
+				// terminated per spec L783-795 and return —
+				// subscription has ended; SDK callback fires + stream
+				// closes.
 				if se.Terminated != nil {
 					ctx.Notify("notifications/events/terminated", errorNotifParams{
 						RequestID: id,
@@ -265,9 +271,10 @@ func registerStream(srv *server.Server, sourceMap map[string]EventSource, unsafe
 					return core.NewResponse(id, StreamEventsResult{Meta: map[string]any{}})
 				}
 
-				// ζ-7: transient source signal. Emit notifications/events/
-				// error per spec L255+L261 and stay open — subscription
-				// remains active; the next event continues normally.
+				// Transient source signal. Emit notifications/events/
+				// error per spec L255+L261 and stay open —
+				// subscription remains active; the next event
+				// continues normally.
 				if se.Error != nil {
 					ctx.Notify("notifications/events/error", errorNotifParams{
 						RequestID: id,

--- a/experimental/ext/events/stream_routing_test.go
+++ b/experimental/ext/events/stream_routing_test.go
@@ -96,9 +96,10 @@ func requestIDOf(t *testing.T, n capturedNotif) string {
 // source A must surface only on the stream subscribed to A, never on the
 // stream subscribed to B.
 //
-// Without isolation, the broadcast model from before ε would resurface:
+// Without isolation, the legacy broadcast model would resurface:
 // every open stream would see every event from every source. The
-// requestId echo + per-source Subscribe channel are what make this work.
+// requestId echo + per-source Subscribe channel are what make this
+// work.
 func TestStream_TwoConcurrentStreamsIsolated(t *testing.T) {
 	srcA, yieldA := NewYieldingSource[fakePayload](EventDef{Name: "fake.A", Description: "A", Delivery: []string{"push"}})
 	srcB, _ := NewYieldingSource[fakePayload](EventDef{Name: "fake.B", Description: "B", Delivery: []string{"push"}})
@@ -148,8 +149,8 @@ func TestStream_TwoConcurrentStreamsIsolated(t *testing.T) {
 
 // TestStream_TwoConcurrentStreamsSameSourceBothReceive verifies the
 // fanout-of-fanout case: two streams against the SAME source both
-// receive every yielded event. ε-1's Subscribe slice + the handler
-// re-subscribing per call is what makes this work.
+// receive every yielded event. The source's Subscribe slice + the
+// handler re-subscribing per call is what makes this work.
 //
 // Without fanout, only one stream would hear each event (or worse,
 // they'd race for the single Subscribe channel).
@@ -263,10 +264,11 @@ func TestStream_GapRecoveryEmitsFreshActive(t *testing.T) {
 	assert.Equal(t, "evt_recovery", evP["eventId"])
 }
 
-// TestStream_EmitsNotificationsEventsError verifies the ζ-7.2 dispatch:
-// when a SubscriberEvent.Error arrives on the stream's source channel,
-// the handler emits notifications/events/error{requestId, error}
-// (spec L255+L261). Stream stays open — the error variant is transient.
+// TestStream_EmitsNotificationsEventsError verifies that when a
+// SubscriberEvent.Error arrives on the stream's source channel, the
+// handler emits notifications/events/error{requestId, error} per
+// spec §"Push-Based Delivery" L255+L261. Stream stays open — the
+// error variant is transient.
 //
 // The fake source lets us inject the Error variant directly without
 // having to wire a real upstream-failure scenario.
@@ -304,12 +306,12 @@ func TestStream_EmitsNotificationsEventsError(t *testing.T) {
 	expectNotif(t, st.notifs, "notifications/events/event", time.Second)
 }
 
-// TestStream_EmitsNotificationsEventsTerminated verifies the ζ-7.2
-// terminal dispatch: SubscriberEvent.Terminated → notifications/events/
-// terminated{requestId, error} (spec L783-795) AND the stream returns
-// (closes). The handler returns the empty StreamEventsResult after
-// emitting the notification, so the SDK call's Done channel closes
-// shortly after.
+// TestStream_EmitsNotificationsEventsTerminated verifies the
+// terminal dispatch: SubscriberEvent.Terminated →
+// notifications/events/terminated{requestId, error} per spec
+// §"Authorization" L783-795, AND the stream returns (closes). The
+// handler returns the empty StreamEventsResult after emitting the
+// notification, so the SDK call's Done channel closes shortly after.
 func TestStream_EmitsNotificationsEventsTerminated(t *testing.T) {
 	fake := &fakeSubscribableSource{
 		def: EventDef{Name: "fake.event", Description: "test", Delivery: []string{"push"}},

--- a/experimental/ext/events/stream_test.go
+++ b/experimental/ext/events/stream_test.go
@@ -14,9 +14,10 @@ import (
 
 // streamTestStack wires a server with a YieldingSource backing a fake event
 // + an InProcessTransport that captures every notification onto a channel.
-// All ε-2 tests share this fixture — events/stream is a long-lived call so
-// every test follows the same pattern: start the call in a goroutine, read
-// notifications, cancel ctx, verify the final response.
+// All events/stream tests share this fixture — events/stream is a
+// long-lived call so every test follows the same pattern: start the
+// call in a goroutine, read notifications, cancel ctx, verify the
+// final response.
 //
 // unsafeAnon "" → spec-strict auth (anonymous calls fail -32012);
 // non-empty   → demo escape hatch.

--- a/experimental/ext/events/subscription_index.go
+++ b/experimental/ext/events/subscription_index.go
@@ -4,8 +4,9 @@ import "sync"
 
 // SubscriptionIndex maps a server-derived subscription id to the
 // callback that delivers an event to that specific subscription. It
-// is the routing table consulted by EmitToSubscription (η-5) so an
-// author who knows the target sub id can bypass broadcast fanout.
+// is the routing table consulted by EmitToSubscription (spec §"Server
+// SDK Guidance" L630) so an author who knows the target sub id can
+// bypass broadcast fanout.
 //
 // The index is maintained by the lifecycle wiring in Register:
 // per-mode registration sites call Add when a subscription becomes
@@ -14,12 +15,14 @@ import "sync"
 // can do so without scanning the deliver closure.
 //
 // Push subscriptions: each open events/stream gets its own random
-// sub id (η-3) — concurrent streams from the same principal/name/
-// params are distinct entries in the index. Webhook subscriptions:
-// the spec's derived id (deriveSubscriptionID over the canonical
-// tuple) is reused — refresh keeps the same id, so the index entry
-// also stays put. Poll subscriptions are NOT indexed (no sub id;
-// the lease tuple is the routing identity per Q4).
+// sub id — concurrent streams from the same principal/name/params
+// are distinct entries in the index. Webhook subscriptions: the
+// spec's derived id (deriveSubscriptionID over the canonical tuple,
+// §"Subscription Identity" → "Derived id" L367) is reused — refresh
+// keeps the same id, so the index entry also stays put. Poll
+// subscriptions are NOT indexed (no sub id; the lease tuple is the
+// routing identity per spec §"Server SDK Guidance" → "Unsubscribe
+// timing by mode" L707).
 type SubscriptionIndex struct {
 	mu      sync.RWMutex
 	entries map[string]subscriptionEntry

--- a/experimental/ext/events/webhook.go
+++ b/experimental/ext/events/webhook.go
@@ -17,9 +17,9 @@ import (
 
 const (
 	defaultWebhookTTL              = 60 * time.Second // 1 minute for POC (production: longer)
-	defaultWebhookMaxBodyBytes     = 256 * 1024       // ζ-3 spec L487
-	defaultWebhookSuspendThreshold = 5                // ζ-6: N consecutive failures
-	defaultWebhookSuspendWindow    = 10 * time.Minute // ζ-6: sliding window W
+	defaultWebhookMaxBodyBytes     = 256 * 1024       // spec §"Webhook Security" → "Delivery profile" L487
+	defaultWebhookSuspendThreshold = 5                // N consecutive failures before Active=false
+	defaultWebhookSuspendWindow    = 10 * time.Minute // sliding window over which failures accumulate
 )
 
 // WebhookOption configures a WebhookRegistry at construction time.
@@ -28,8 +28,9 @@ type WebhookOption func(*WebhookRegistry)
 // WebhookOnRemoveHook fires whenever a target is actually removed from
 // the registry — explicit Unregister, TTL prune, or PostTerminated.
 // Does NOT fire on the suspend transition (Active=true→false), which
-// keeps the target in the registry as paused (η-3 / Q4: suspend ≠
-// unsubscribe; refresh reactivates without re-firing on_subscribe).
+// keeps the target in the registry as paused — suspend ≠ unsubscribe;
+// refresh reactivates without re-firing on_subscribe per spec
+// §"Webhook Delivery Status" L460.
 //
 // Hooks fire OUTSIDE the registry's lock so a slow listener can't
 // serialize Register/Unregister/PostTerminated.
@@ -78,7 +79,7 @@ func WithWebhookHeaderMode(mode WebhookHeaderMode) WebhookOption {
 // Per spec §"Webhook Event Delivery" L413 + §"Webhook Delivery Status"
 // L460: "after repeated failures the server SHOULD set active: false."
 // The spec doesn't fix a number; this option lets deployments tune
-// hysteresis. ζ-6.
+// hysteresis.
 func WithWebhookSuspendThreshold(n int) WebhookOption {
 	return func(r *WebhookRegistry) {
 		if n > 0 {
@@ -93,7 +94,7 @@ func WithWebhookSuspendThreshold(n int) WebhookOption {
 //
 // Failures separated by more than W don't accumulate — a receiver
 // with one failure per hour for weeks shouldn't get suspended; only
-// a current run of failures does. ζ-6.
+// a current run of failures does.
 func WithWebhookSuspendWindow(d time.Duration) WebhookOption {
 	return func(r *WebhookRegistry) {
 		if d > 0 {
@@ -125,7 +126,7 @@ func WithWebhookMaxBodyBytes(n int) WebhookOption {
 //
 // Per spec §"Webhook Security" → "SSRF prevention" L464, deployments MUST
 // guard against DNS rebinding by checking the resolved IP at dial time.
-// ζ-1's net.Dialer.Control callback rejects:
+// The net.Dialer.Control callback installed by NewWebhookRegistry rejects:
 //   - 127.0.0.0/8, ::1 (loopback)
 //   - 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 (RFC1918 private IPv4)
 //   - 169.254.0.0/16, fe80::/10 (link-local — includes AWS metadata service)
@@ -153,31 +154,32 @@ func WithWebhookAllowPrivateNetworks(allow bool) WebhookOption {
 // as the X-MCP-Subscription-Id header on every delivery POST per
 // §"Webhook Event Delivery" L390.
 //
-// EventName, Principal, Params (η-3): copies of the identity components
-// stored separately so OnRemove hooks (and η-4 match/transform on
-// fanout) can construct a HookContext + params payload without
-// re-parsing canonical bytes. Redundant with CanonicalKey; cheap to
-// store, and the registry already owns the only writer.
+// EventName, Principal, Params: copies of the identity components
+// stored separately so OnRemove hooks (and Match / Transform on
+// fanout) can construct a HookContext + params payload per spec
+// §"Server SDK Guidance" L623-629 without re-parsing canonical
+// bytes. Redundant with CanonicalKey; cheap to store, and the
+// registry already owns the only writer.
 type WebhookTarget struct {
 	CanonicalKey  []byte    // canonical bytes of (principal, url, name, params)
 	ID            string    // server-derived routing handle (sub_<base64-of-16-bytes>)
 	URL           string    // delivery callback URL
 	Secret        string    // client-supplied HMAC signing secret (whsec_...)
 	ExpiresAt     time.Time // soft-state TTL expiry
-	MaxAgeSeconds int       // δ-3: per-spec replay floor (§"Cursor Lifecycle" L529); 0 = no floor
+	MaxAgeSeconds int       // per-spec replay floor (§"Cursor Lifecycle" L529); 0 = no floor
 
-	EventName string         // event-type name (η-3 hook lookup)
-	Principal string         // resolved subscription principal (η-3 HookContext)
-	Params    map[string]any // canonicalized subscription params (η-3 hook payload)
+	EventName string         // event-type name (used by Match / Transform / OnRemove lookup)
+	Principal string         // resolved subscription principal (used by HookContext)
+	Params    map[string]any // canonicalized subscription params (passed to hooks)
 
-	// ζ-5: per-target delivery health, surfaced on subscribe refresh
+	// Status is per-target delivery health, surfaced on subscribe refresh
 	// response per spec §"Webhook Delivery Status" L425-460.
 	// Mutated only via *WebhookRegistry methods under r.mu so the
 	// snapshot returned by Targets()/DeliveryStatus() is consistent.
 	Status DeliveryStatus
 
-	// ζ-6: internal counter for the suspend state machine. Tracks
-	// consecutive failures within the current sliding-window run.
+	// failureCount is the internal counter for the suspend state machine.
+	// Tracks consecutive failures within the current sliding-window run.
 	// Not surfaced on the wire; the wire-visible signal is Status.Active.
 	failureCount int
 }
@@ -239,25 +241,28 @@ type WebhookRegistry struct {
 	client               *http.Client
 	ttl                  time.Duration
 	headerMode           WebhookHeaderMode
-	allowPrivateNetworks bool          // ζ-1: when false (default), Dialer.Control rejects private/loopback IPs
-	maxBodyBytes         int           // ζ-3: outbound POST body cap in bytes; default 256 KiB
-	suspendThreshold     int           // ζ-6: consecutive failures → Active=false; default 5
-	suspendWindow        time.Duration // ζ-6: sliding window over which failures accumulate; default 10min
+	allowPrivateNetworks bool          // when false (default), Dialer.Control rejects private/loopback IPs (spec §"Webhook Security" → "SSRF prevention" L464)
+	maxBodyBytes         int           // outbound POST body cap (spec §"Webhook Security" → "Delivery profile" L487); default 256 KiB
+	suspendThreshold     int           // consecutive failures → Active=false (spec §"Webhook Delivery Status" L460); default 5
+	suspendWindow        time.Duration // sliding window over which failures accumulate; default 10min
 
 	// onRemoveHooks fire when a target is actually removed from the
-	// registry (Unregister, TTL prune, PostTerminated). η-3.
+	// registry (Unregister, TTL prune, PostTerminated). The SDK uses
+	// these to drive on_unsubscribe and quota release per spec
+	// §"Server SDK Guidance" → "Subscription lifecycle hooks" L691.
 	// Mutated only at construction (WithWebhookOnRemove) and via
 	// AddOnRemoveHook; reads under mu.RLock. Hooks fire OUTSIDE the
 	// lock to keep a slow listener from serializing the registry.
 	onRemoveHooks []WebhookOnRemoveHook
 
 	// defResolver lets Deliver look up an event-type's Match /
-	// Transform hooks at fanout time without WebhookRegistry needing
-	// to know about EventDef directly. events.Register installs this;
-	// callers that hand-deliver events (e.g., TypedSource authors
-	// reaching for EmitToWebhooks themselves) get a no-op resolver
-	// and the per-target match/transform path is a passthrough.
-	// η-4. Set under mu, read under mu.RLock.
+	// Transform hooks (spec §"Server SDK Guidance" L623-629) at
+	// fanout time without WebhookRegistry needing to know about
+	// EventDef directly. events.Register installs this; callers that
+	// hand-deliver events (e.g., TypedSource authors reaching for
+	// EmitToWebhooks themselves) get a no-op resolver and the
+	// per-target match/transform path is a passthrough.
+	// Set under mu, read under mu.RLock.
 	defResolver func(eventName string) EventDef
 
 	// logf is the logging hook used by deliver paths. Defaults to log.Printf;
@@ -330,13 +335,13 @@ func NewWebhookRegistry(opts ...WebhookOption) *WebhookRegistry {
 		o(r)
 	}
 	// http.Client wired AFTER options apply so the Dialer.Control callback
-	// can read the resolved allowPrivateNetworks setting. ζ-1 spec
+	// can read the resolved allowPrivateNetworks setting. Spec
 	// §"Webhook Security" → "SSRF prevention" L464.
 	//
-	// CheckRedirect (ζ-2): explicitly disable the default 10-redirect
-	// follow. A receiver returning 3xx to an internal address would
-	// otherwise bypass the dial-time SSRF guard via Go's redirect chain.
-	// Per spec same paragraph L464.
+	// CheckRedirect: explicitly disable the default 10-redirect follow.
+	// A receiver returning 3xx to an internal address would otherwise
+	// bypass the dial-time SSRF guard via Go's redirect chain. Per
+	// spec same paragraph L464.
 	r.client = &http.Client{
 		Timeout: 5 * time.Second,
 		Transport: &http.Transport{
@@ -436,10 +441,9 @@ func (r *WebhookRegistry) setLogfForTest(f func(format string, args ...any)) {
 }
 
 
-// RegisterParams bundles the inputs for Register. Promoted to a struct
-// over a long positional list because η-3 added EventName / Principal
-// / Params to the identity-side state — six positional args was
-// already at the readability ceiling.
+// RegisterParams bundles the inputs for Register. A struct rather than
+// a positional list because EventName / Principal / Params took the
+// arg count past the readability ceiling.
 type RegisterParams struct {
 	CanonicalKey  []byte
 	DerivedID     string
@@ -447,11 +451,12 @@ type RegisterParams struct {
 	Secret        string
 	MaxAgeSeconds int
 
-	// EventName / Principal / Params (η-3): copies of the identity
+	// EventName / Principal / Params: copies of the identity
 	// components the registry stores so OnRemove hooks have full
-	// HookContext + payload available without re-parsing canonical
-	// bytes. Fed by the same canonical-tuple inputs the caller
-	// already used to compute CanonicalKey.
+	// HookContext + payload available (per spec §"Server SDK
+	// Guidance" → "Subscription lifecycle hooks" L691) without
+	// re-parsing canonical bytes. Fed by the same canonical-tuple
+	// inputs the caller already used to compute CanonicalKey.
 	EventName string
 	Principal string
 	Params    map[string]any
@@ -463,9 +468,10 @@ type RegisterParams struct {
 // — second call refreshes TTL + replaces secret.
 //
 // Returns (expiresAt, isNew). isNew is true on first registration
-// (caller fires safeOnSubscribe) and false on refresh (η-3 / Q4:
-// refresh ≠ subscribe). Caller resolves the distinction; the registry
-// just reports it.
+// (caller fires safeOnSubscribe per spec §"Server SDK Guidance" L691)
+// and false on refresh — refresh ≠ subscribe, so on_subscribe MUST
+// NOT re-fire. Caller resolves the distinction; the registry just
+// reports it.
 //
 // DerivedID is the X-MCP-Subscription-Id value the registry emits on
 // every delivery POST; it MUST be deriveSubscriptionID(CanonicalKey)
@@ -481,8 +487,9 @@ type RegisterParams struct {
 // as "don't change").
 //
 // Side effect: prunes expired targets before registering. Each pruned
-// target fires the onRemove hooks (η-3: lifecycle parity — TTL expiry
-// is an unsubscribe).
+// target fires the onRemove hooks — TTL expiry counts as an
+// unsubscribe (spec §"Server SDK Guidance" → "Unsubscribe timing by
+// mode" L707).
 func (r *WebhookRegistry) Register(p RegisterParams) (expiresAt time.Time, isNew bool) {
 	r.mu.Lock()
 	pruned := r.pruneExpiredLocked()
@@ -498,11 +505,12 @@ func (r *WebhookRegistry) Register(p RegisterParams) (expiresAt time.Time, isNew
 		if p.MaxAgeSeconds > 0 {
 			existing.MaxAgeSeconds = p.MaxAgeSeconds
 		}
-		// ζ-6: a successful refresh reactivates a suspended target per
-		// spec L460. Clear the failure run so deliveries can resume.
-		// Pending events do NOT replay automatically (would re-flood a
-		// recovering receiver); the client signals replay intent via
-		// the next events/poll or by waiting for live events.
+		// A successful refresh reactivates a suspended target per spec
+		// §"Webhook Delivery Status" L460. Clear the failure run so
+		// deliveries can resume. Pending events do NOT replay
+		// automatically (would re-flood a recovering receiver); the
+		// client signals replay intent via the next events/poll or by
+		// waiting for live events.
 		if !existing.Status.Active {
 			existing.Status.Active = true
 			existing.Status.LastError = DeliveryErrorNone
@@ -522,9 +530,10 @@ func (r *WebhookRegistry) Register(p RegisterParams) (expiresAt time.Time, isNew
 			EventName:     p.EventName,
 			Principal:     p.Principal,
 			Params:        p.Params,
-			// ζ-5: Active defaults to true on first registration. The
-			// suspend state machine in ζ-6 flips this to false after
-			// repeated failures; a successful refresh resets it.
+			// Active defaults to true on first registration. The
+			// suspend state machine flips this to false after
+			// repeated failures (spec §"Webhook Delivery Status"
+			// L460); a successful refresh resets it.
 			Status: DeliveryStatus{Active: true},
 		}
 		isNew = true
@@ -546,9 +555,10 @@ func (r *WebhookRegistry) Register(p RegisterParams) (expiresAt time.Time, isNew
 // L509, the derived id is not accepted as input — callers resolve via
 // the same canonical tuple they would for a subscribe.
 //
-// Fires onRemove hooks for the deleted target — η-3's lifecycle
-// parity. Callers that explicitly Unregister get the same on_unsubscribe
-// behavior as TTL prune and PostTerminated.
+// Fires onRemove hooks for the deleted target — explicit Unregister
+// gets the same on_unsubscribe lifecycle (spec §"Server SDK
+// Guidance" → "Unsubscribe timing by mode" L707) as TTL prune and
+// PostTerminated.
 func (r *WebhookRegistry) Unregister(canonicalKey []byte) {
 	r.mu.Lock()
 	target, ok := r.targets[string(canonicalKey)]
@@ -563,8 +573,9 @@ func (r *WebhookRegistry) Unregister(canonicalKey []byte) {
 
 // Targets returns a snapshot of all non-expired AND non-suspended
 // webhook targets. Used by Deliver to fan out an event; suspended
-// targets (ζ-6: Active=false after N consecutive failures) are
-// excluded so dead receivers don't keep getting retry traffic.
+// targets (Active=false after N consecutive failures, per spec
+// §"Webhook Delivery Status" L460) are excluded so dead receivers
+// don't keep getting retry traffic.
 //
 // Lookup-by-canonical-key paths (PostGap, PostTerminated) bypass this
 // filter — control envelopes for terminated/gap should still POST to
@@ -584,8 +595,8 @@ func (r *WebhookRegistry) Targets() []WebhookTarget {
 
 // pruneExpiredLocked removes expired subscriptions and returns the
 // removed targets so the caller can fire onRemove hooks OUTSIDE the
-// lock (η-3: lifecycle parity — TTL prune is an unsubscribe). Must
-// hold r.mu write lock.
+// lock — TTL prune is an unsubscribe per spec §"Server SDK Guidance"
+// → "Unsubscribe timing by mode" L707. Must hold r.mu write lock.
 func (r *WebhookRegistry) pruneExpiredLocked() []WebhookTarget {
 	now := time.Now()
 	var removed []WebhookTarget
@@ -602,9 +613,9 @@ func (r *WebhookRegistry) pruneExpiredLocked() []WebhookTarget {
 // DeliverToTarget POSTs an event to a single target identified by
 // canonical key, bypassing the broadcast fanout (and thus skipping
 // Match / Transform). Used by EmitToSubscription for targeted delivery
-// (η-5) — the spec's "the author has already shaped this event for
-// this specific subscription" model means hooks are deliberately not
-// applied here.
+// per spec §"Server SDK Guidance" L630 — the "the author has already
+// shaped this event for this specific subscription" model means
+// hooks are deliberately not applied here.
 //
 // Returns false when there is no live target for the canonical key
 // (unregistered between the index lookup and this call, suspended,
@@ -648,7 +659,7 @@ func (r *WebhookRegistry) ExpireAll() {
 
 // Deliver sends an event to webhook subscribers of that event name.
 //
-// Per-target processing (η-4):
+// Per-target processing (spec §"Server SDK Guidance" L623-629):
 //  1. Filter by event name — only targets whose EventName matches the
 //     event are considered.
 //  2. safeMatch with the EventDef's Match — skip target if false.
@@ -673,18 +684,19 @@ func (r *WebhookRegistry) Deliver(event Event) {
 
 	// One marshal upfront for the unmodified path; per-target
 	// re-marshal only when transform actually changes the event
-	// (Q8 short-circuit).
+	// (passthrough short-circuit avoids the alloc).
 	originalBody, err := json.Marshal(event)
 	if err != nil {
 		r.logf("[webhook] failed to marshal event: %v", err)
 		return
 	}
 	if len(originalBody) > r.maxBodyBytes {
-		// ζ-3: spec L487 caps outbound delivery bodies at 256 KiB
-		// (configurable via WithWebhookMaxBodyBytes). Reject
-		// oversized — truncation would corrupt the HMAC signature
-		// and silently drop event content. Re-trying won't shrink
-		// the body, so this is terminal for the event.
+		// Spec §"Webhook Security" → "Delivery profile" L487 caps
+		// outbound delivery bodies at 256 KiB (configurable via
+		// WithWebhookMaxBodyBytes). Reject oversized — truncation
+		// would corrupt the HMAC signature and silently drop event
+		// content. Re-trying won't shrink the body, so this is
+		// terminal for the event.
 		r.logf("[webhook] event %s body %d bytes exceeds cap %d; dropping (will not retry)",
 			event.EventID, len(originalBody), r.maxBodyBytes)
 		return
@@ -700,10 +712,10 @@ func (r *WebhookRegistry) Deliver(event Event) {
 
 	for _, t := range targets {
 		if t.EventName != "" && t.EventName != event.Name {
-			// Pre-η-3 targets had no EventName recorded — skip the
-			// filter for those (zero string) so legacy fixtures
-			// keep working. Real targets registered via the
-			// subscribe handler always carry the name.
+			// Targets whose EventName is unset are pre-identity-
+			// tracking fixtures — skip the name filter for them so
+			// legacy tests keep working. Real targets registered
+			// via the subscribe handler always carry the name.
 			continue
 		}
 
@@ -740,9 +752,9 @@ const (
 
 // recordDeliverySuccess updates the target's DeliveryStatus after a
 // successful delivery attempt. Active stays/becomes true (clears any
-// prior suspension — ζ-6); LastDeliveryAt advances; LastError +
-// FailedSince clear (the current failure run, if any, is over);
-// failure counter resets to 0.
+// prior suspension per spec §"Webhook Delivery Status" L460);
+// LastDeliveryAt advances; LastError + FailedSince clear (the current
+// failure run, if any, is over); failure counter resets to 0.
 func (r *WebhookRegistry) recordDeliverySuccess(canonicalKey []byte, at time.Time) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -762,14 +774,14 @@ func (r *WebhookRegistry) recordDeliverySuccess(canonicalKey []byte, at time.Tim
 // recordDeliveryFailure updates the target's DeliveryStatus after the
 // FINAL failed attempt (all retries exhausted). LastError gets the
 // categorical bucket; FailedSince is set on the FIRST failure of a
-// CURRENT run (sliding-window resets see ζ-6 suspendWindow) and
-// preserved across subsequent failures so subscribers can see how long
-// the receiver has been unreachable.
+// CURRENT run (sliding-window resets via suspendWindow) and preserved
+// across subsequent failures so subscribers can see how long the
+// receiver has been unreachable.
 //
-// Suspend rule (ζ-6): if FailedSince is older than suspendWindow,
-// reset the run (this failure starts a new run). Otherwise, count
-// consecutive failures within the run; on hitting suspendThreshold,
-// flip Active=false.
+// Suspend rule (spec §"Webhook Delivery Status" L460): if FailedSince
+// is older than suspendWindow, reset the run (this failure starts a
+// new run). Otherwise, count consecutive failures within the run; on
+// hitting suspendThreshold, flip Active=false.
 func (r *WebhookRegistry) recordDeliveryFailure(canonicalKey []byte, bucket DeliveryErrorBucket) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -780,8 +792,8 @@ func (r *WebhookRegistry) recordDeliveryFailure(canonicalKey []byte, bucket Deli
 	now := time.Now()
 	t.Status.LastError = bucket
 
-	// ζ-6: sliding-window failure counting. If the current run is
-	// older than the window, reset — this failure starts a fresh run.
+	// Sliding-window failure counting. If the current run is older
+	// than the window, reset — this failure starts a fresh run.
 	// failureCount is per-target; tracked alongside the wire-visible
 	// DeliveryStatus fields.
 	if t.Status.FailedSince == nil || now.Sub(*t.Status.FailedSince) > r.suspendWindow {
@@ -796,12 +808,14 @@ func (r *WebhookRegistry) recordDeliveryFailure(canonicalKey []byte, bucket Deli
 		t.Status.Active = false
 	}
 	r.targets[string(canonicalKey)] = t
-	// ζ-7.3: on the Active true→false transition, auto-Post a
+	// On the Active true→false transition, auto-Post a
 	// {type:terminated} envelope to the receiver as a courtesy
-	// notification. Uses postTerminatedSilent so the target stays
-	// in the registry (Active=false observable; reactivate via refresh).
-	// Snapshot the target struct before releasing the lock — the
-	// async deliverControl needs URL/Secret/ID outside the lock.
+	// notification (spec §"Non-event webhook bodies" L420). Uses
+	// postTerminatedSilent so the target stays in the registry
+	// (Active=false observable; reactivate via refresh per
+	// §"Webhook Delivery Status" L460). Snapshot the target struct
+	// before releasing the lock — the async deliverControl needs
+	// URL/Secret/ID outside the lock.
 	if wasActive && !t.Status.Active {
 		r.postTerminatedSilent(t, ControlError{
 			Code:    -32603,
@@ -861,7 +875,7 @@ func classifyTransportError(err error) DeliveryErrorBucket {
 // exponential backoff.
 func (r *WebhookRegistry) deliver(target WebhookTarget, eventID string, body []byte) {
 	backoff := initialBackoff
-	// ζ-5: tracks the last per-attempt failure bucket. Recorded onto
+	// Tracks the last per-attempt failure bucket. Recorded onto
 	// deliveryStatus only after all retries are exhausted (i.e., this
 	// is the FINAL outcome). A transient blip during a successful
 	// retry-cycle would otherwise falsely appear as "current failure"
@@ -883,8 +897,9 @@ func (r *WebhookRegistry) deliver(target WebhookTarget, eventID string, body []b
 		// (webhook emit + poll backfill of the same upstream event collapse
 		// under the receiver's eventId-keyed dedup).
 		//
-		// X-MCP-Subscription-Id carries target.ID (γ-2's derived id over
-		// the canonical tuple) so the receiver can select the correct
+		// X-MCP-Subscription-Id carries target.ID (the spec's derived
+		// id over the canonical tuple, §"Subscription Identity" →
+		// "Derived id" L367) so the receiver can select the correct
 		// secret without parsing the body. Per spec §"Webhook Event
 		// Delivery" L390 + §"Webhook Security" L472: this is the only
 		// MCP-specific header on a Standard Webhooks delivery.
@@ -919,15 +934,17 @@ func (r *WebhookRegistry) deliver(target WebhookTarget, eventID string, body []b
 		r.logf("[webhook] delivery to %s returned %d", target.URL, resp.StatusCode)
 		switch {
 		case resp.StatusCode >= 300 && resp.StatusCode < 400:
-			// ζ-2: 3xx is non-retryable. We disabled redirect-following
+			// 3xx is non-retryable. We disabled redirect-following
 			// via CheckRedirect; a receiver returning 3xx is signalling
-			// "go elsewhere" but we're not allowed to. Re-trying won't
+			// "go elsewhere" but we're not allowed to (spec §"Webhook
+			// Security" → "SSRF prevention" L464). Re-trying won't
 			// change the response; treat as terminal.
 			r.recordDeliveryFailure(target.CanonicalKey, DeliveryError3xxRedirect)
 			return
 		case resp.StatusCode == http.StatusRequestEntityTooLarge:
-			// ζ-3 spec L487: 413 MUST be non-retryable. Receiver
-			// rejects our payload size; retrying won't change that.
+			// Spec §"Webhook Security" → "Delivery profile" L487:
+			// 413 MUST be non-retryable. Receiver rejects our
+			// payload size; retrying won't change that.
 			r.recordDeliveryFailure(target.CanonicalKey, DeliveryError4xx)
 			return
 		case resp.StatusCode >= 400 && resp.StatusCode < 500:

--- a/experimental/ext/events/wire_shape_test.go
+++ b/experimental/ext/events/wire_shape_test.go
@@ -19,10 +19,11 @@ import (
 // test means a client decoding the spec shape would not find its data — or
 // would find it under the legacy nested key path.
 //
-// The legacy results[] wrapper was a partial-success container from the
-// batching era (one entry per subscription, each with its own error field).
-// Phase 1 dropped batching at the protocol level; α drops the now-vestigial
-// wrapper at the wire level too.
+// The legacy results[] wrapper was a partial-success container from
+// the batching era (one entry per subscription, each with its own
+// error field). Batching went away at the protocol level when the
+// spec moved to single-subscription requests; the wire layer
+// followed.
 func TestPollResponse_FlatShape(t *testing.T) {
 	cursor := "cursor_xyz"
 	wire := pollResultWire{
@@ -95,9 +96,8 @@ func TestEventNotFound_UsesSpecCode(t *testing.T) {
 // TestPoll_FlatRequestShape pins the spec contract for events/poll
 // REQUEST shape per §"Poll-Based Delivery" → "Request: events/poll"
 // L139-149: top-level {name, cursor?, maxEvents?, params?} — no
-// subscriptions[] wrapper. δ-1 dropped the wrapper after phase 1
-// removed batching at the protocol level. Failing this test means
-// a spec-conformant client's request would not parse.
+// subscriptions[] wrapper. Failing this test means a spec-conformant
+// client's request would not parse.
 func TestPoll_FlatRequestShape(t *testing.T) {
 	srv := buildSecretValidationStack(t)
 	rawReq, err := json.Marshal(map[string]any{
@@ -112,11 +112,11 @@ func TestPoll_FlatRequestShape(t *testing.T) {
 	require.Nil(t, resp.Error, "flat top-level shape must be accepted; got %+v", resp.Error)
 }
 
-// TestPoll_RejectsLegacyWrapper verifies that a request still using the
-// pre-δ {subscriptions: [...]} wrapper gets a -32602 with a message
-// pointing at the spec change. Without this helpful diagnostic, an old
-// SDK sending the legacy shape would just see "name is required" and
-// have no clue why.
+// TestPoll_RejectsLegacyWrapper verifies that a request still using
+// the legacy {subscriptions: [...]} wrapper gets a -32602 with a
+// message pointing at the spec change. Without this helpful
+// diagnostic, an old SDK sending the legacy shape would just see
+// "name is required" and have no clue why.
 func TestPoll_RejectsLegacyWrapper(t *testing.T) {
 	srv := buildSecretValidationStack(t)
 	rawReq, err := json.Marshal(map[string]any{
@@ -151,8 +151,8 @@ func TestPoll_MaxAgeFiltersOldEvents(t *testing.T) {
 	// Yield 2 events that are "old" (manipulate their timestamp via
 	// the underlying source) and 2 fresh ones. Easier to backdate
 	// the events post-yield by walking the source's ring directly —
-	// but for δ-2's purposes we just yield them at different real
-	// times and use a small maxAge to filter.
+	// but for these maxAge tests we just yield them at different
+	// real times and use a small maxAge to filter.
 
 	// Yield "old" events with a backdated timestamp 10s in the past.
 	src.entries = append(src.entries,
@@ -254,7 +254,7 @@ func TestPoll_MaxAgeZeroMeansNoFilter(t *testing.T) {
 	}
 }
 
-// --- shared helpers for δ-2 tests ---
+// --- shared helpers for poll maxAge tests ---
 
 type fakeFilterPayload struct {
 	Msg string `json:"msg"`
@@ -291,12 +291,12 @@ func buildPollFilterStack(t *testing.T) (*server.Server, *YieldingSource[fakeFil
 // TestSubscribe_AcceptsMaxAge verifies the spec's maxAge floor on
 // events/subscribe per §"Cursor Lifecycle" → "Bounding replay with
 // maxAge" L529. Client supplies a per-subscription replay floor that
-// the server records on the WebhookTarget for use on (future) reconnect
-// — δ-3 plumbs the field, ζ wires the actual replay-with-floor logic.
+// the server records on the WebhookTarget for use on (future)
+// reconnect-with-replay.
 //
 // Without storing maxAge on the target, a long-offline subscriber's
-// reconnect would replay everything the cursor still covers; with it,
-// the server can bound replay to the requested floor.
+// reconnect would replay everything the cursor still covers; with
+// it, the server can bound replay to the requested floor.
 func TestSubscribe_AcceptsMaxAge(t *testing.T) {
 	srv, webhooks := buildAuthGateStack(t, "test-principal")
 	params := validSubscribeParams()

--- a/experimental/ext/events/yield.go
+++ b/experimental/ext/events/yield.go
@@ -33,19 +33,19 @@ type yieldingConfig struct {
 //     Truncated=true signals "one or more events were dropped before this
 //     one" — consumers SHOULD treat as a possible state gap and re-fetch
 //     authoritative state if it matters. Per spec §"Push-Based Delivery"
-//     → "Event Delivery" L285, ε-2's stream handler maps Truncated=true
+//     → "Event Delivery" L285, the stream handler maps Truncated=true
 //     onto a fresh notifications/events/active{truncated:true} that
 //     precedes the event.
 //
 //   - Transient error: Error populated; Event/Terminated nil. Stream
 //     subscribers map onto notifications/events/error per spec L255+L261;
 //     stream stays open. Webhook delivery is unaffected (errors are
-//     upstream, not delivery-side). ζ-7.
+//     upstream, not delivery-side).
 //
 //   - Terminal: Terminated populated; Event/Error nil. Stream subscribers
 //     map onto notifications/events/terminated per spec L783-795 and the
 //     stream closes. Subscriber chans close after the terminal event.
-//     One-shot — subsequent yields are no-ops. ζ-7.
+//     One-shot — subsequent yields are no-ops.
 //
 // Riding Truncated on the next successful event (rather than a separate
 // marker frame) keeps the channel order trivially correct under any
@@ -72,10 +72,10 @@ type EventDeliveryError struct {
 // set when a yield is dropped because the chan is full; the next successful
 // send delivers a Truncated marker before the event itself.
 //
-// principal / subscriptionID / params (η-4): per-subscriber identity
+// principal / subscriptionID / params: per-subscriber identity
 // captured at Subscribe time so the per-yield fanout can build a
-// HookContext + apply the EventDef's Match / Transform per subscriber.
-// Spec §"Server SDK Guidance" L623-629.
+// HookContext + apply the EventDef's Match / Transform per subscriber
+// per spec §"Server SDK Guidance" L623-629.
 type subscriberSlot struct {
 	ch               chan SubscriberEvent
 	principal        string
@@ -84,15 +84,14 @@ type subscriberSlot struct {
 	pendingTruncated atomic.Bool
 	// closeOnce gates the chan close so YieldTerminated and the
 	// Subscribe cleanup goroutine can both attempt close without
-	// racing into "close of closed channel". ζ-7.
+	// racing into "close of closed channel".
 	closeOnce sync.Once
 }
 
 // SubscribeOpts bundles the per-subscriber metadata Subscribe needs.
-// Promoted to a struct over a positional list because η-4 added two
-// fields to the existing (ctx) signature; future additions (MaxAge,
-// per-subscriber backpressure tuning) extend the struct without
-// rippling through every caller.
+// A struct rather than a positional list so future additions (MaxAge,
+// per-subscriber backpressure tuning) extend without rippling through
+// every caller.
 type SubscribeOpts struct {
 	// Principal is the resolved subscription principal. Surfaced on
 	// HookContext.Principal() during fanout so author Match /
@@ -118,8 +117,9 @@ func (s *subscriberSlot) closeChan() {
 
 // deliverEvent sends one event to the slot's channel non-blocking,
 // honoring the existing pendingTruncated bookkeeping. Used by both
-// the per-yield fanout (after match/transform) and the η-5 targeted
-// deliver path (which bypasses match/transform).
+// the per-yield fanout (after match/transform) and the targeted-
+// deliver path used by EmitToSubscription (spec §"Server SDK
+// Guidance" L630), which bypasses match/transform.
 //
 // Tolerates a closed-channel race: if Subscribe's cleanup goroutine
 // has raced ahead and close()-d the channel between our read of
@@ -265,7 +265,7 @@ type YieldingSource[Data any] struct {
 	emitHook    func(Event)
 	metaFunc    func(Data) map[string]any
 	subscribers []*subscriberSlot
-	terminated  bool // ζ-7: one-shot YieldTerminated has fired; subsequent yields are no-ops
+	terminated  bool // one-shot YieldTerminated has fired; subsequent yields are no-ops
 }
 
 func (s *YieldingSource[Data]) Def() EventDef { return s.def }
@@ -285,10 +285,11 @@ func (s *YieldingSource[Data]) SetMetaFunc(f func(Data) map[string]any) {
 	s.metaFunc = f
 }
 
-// YieldError emits a transient-failure signal to all live subscribers
-// (ζ-7). Stream subscribers map this onto a notifications/events/error
-// frame per spec L255+L261; the subscription stays open. Webhook
-// delivery is unaffected (errors are upstream-side, not delivery-side).
+// YieldError emits a transient-failure signal to all live subscribers.
+// Stream subscribers map this onto a notifications/events/error frame
+// per spec §"Push-Based Delivery" L255+L261; the subscription stays
+// open. Webhook delivery is unaffected (errors are upstream-side, not
+// delivery-side).
 //
 // No-op after YieldTerminated has fired (one-shot terminal semantic).
 // Returns nil; the signature mirrors yield/YieldTerminated for consistency
@@ -306,11 +307,11 @@ func (s *YieldingSource[Data]) YieldError(err EventDeliveryError) error {
 }
 
 // YieldTerminated emits a terminal signal to all live subscribers and
-// closes their channels (ζ-7). Stream subscribers map this onto a
-// notifications/events/terminated frame per spec L783-795 and the
-// stream returns. After this call, the source is terminated: subsequent
-// yield / YieldError / YieldTerminated calls are silently dropped, and
-// Poll returns empty.
+// closes their channels. Stream subscribers map this onto a
+// notifications/events/terminated frame per spec §"Authorization"
+// L783-795 and the stream returns. After this call, the source is
+// terminated: subsequent yield / YieldError / YieldTerminated calls
+// are silently dropped, and Poll returns empty.
 //
 // One-shot. Receivers seeing the terminal signal SHOULD remove their
 // local subscription state — there's no recovery path for the source
@@ -360,16 +361,18 @@ func (s *YieldingSource[Data]) fanoutLocked(se SubscriberEvent) {
 }
 
 // Subscribe registers a per-call live-event channel for push delivery
-// (ε-1 — foundation for events/stream). The returned channel receives a
-// SubscriberEvent for every yield() until ctx is Done; on cancellation
-// the slot is removed from the source and the channel is closed (range
-// loops exit cleanly, select-on-closed returns the zero value).
+// (the foundation for events/stream, spec §"Push-Based Delivery"
+// L223+). The returned channel receives a SubscriberEvent for every
+// yield() until ctx is Done; on cancellation the slot is removed from
+// the source and the channel is closed (range loops exit cleanly,
+// select-on-closed returns the zero value).
 //
-// SubscribeOpts (η-4) carries per-subscriber identity (Principal,
+// SubscribeOpts carries per-subscriber identity (Principal,
 // SubscriptionID, Params) onto the slot so fanout can build a
-// HookContext and apply the EventDef's Match / Transform per
-// subscriber. Pass the zero value for hook-less callers; the safe
-// wrappers tolerate empty fields.
+// HookContext and apply the EventDef's Match / Transform (spec
+// §"Server SDK Guidance" L623-629) per subscriber. Pass the zero
+// value for hook-less callers; the safe wrappers tolerate empty
+// fields.
 //
 // On a slow consumer (channel full), yield does NOT block — the event
 // is dropped for that subscriber and a Truncated marker is sent on the
@@ -377,13 +380,14 @@ func (s *YieldingSource[Data]) fanoutLocked(se SubscriberEvent) {
 // notifications/events/active{truncated:true, cursor:source.Latest()}
 // per spec §"Push-Based Delivery" → "Event Delivery" L285.
 //
-// Cursorless sources still buffer-and-fanout to subscribers (push delivery
-// works fine without replay); only Poll returns empty on cursorless.
-// Returns (chan, sender). The sender closure delivers a single event
-// to THIS specific slot, bypassing the per-yield fanout's Match /
-// Transform — used by η-5's EmitToSubscription so an author who has
-// the sub id can route directly to one subscriber. Callers that only
-// want broadcast delivery can ignore the second return.
+// Cursorless sources still buffer-and-fanout to subscribers (push
+// delivery works fine without replay); only Poll returns empty on
+// cursorless. Returns (chan, sender). The sender closure delivers a
+// single event to THIS specific slot, bypassing the per-yield
+// fanout's Match / Transform — used by EmitToSubscription (spec
+// §"Server SDK Guidance" L630) so an author who has the sub id can
+// route directly to one subscriber. Callers that only want broadcast
+// delivery can ignore the second return.
 func (s *YieldingSource[Data]) Subscribe(ctx context.Context, opts SubscribeOpts) (<-chan SubscriberEvent, func(Event)) {
 	slot := &subscriberSlot{
 		ch:             make(chan SubscriberEvent, s.subscriberBuf),
@@ -440,9 +444,9 @@ func (s *YieldingSource[Data]) Poll(cursor string, limit int) PollResult {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	// ζ-7: terminated source returns empty. Poll callers — including
-	// the events/poll handler — should observe nothing-to-deliver
-	// rather than the residual entries from before termination.
+	// Terminated source returns empty. Poll callers — including the
+	// events/poll handler — should observe nothing-to-deliver rather
+	// than the residual entries from before termination.
 	if s.terminated {
 		return PollResult{}
 	}
@@ -541,11 +545,11 @@ func (s *YieldingSource[Data]) SetEmitHook(hook func(Event)) {
 }
 
 func (s *YieldingSource[Data]) yield(data Data) error {
-	// ζ-7 one-shot terminated check. Sources that have signaled
-	// terminal can't deliver new events to subscribers (chans are
-	// closed). Returning nil rather than error so callers wrapping
-	// yield in event-driven code paths don't have to special-case
-	// the post-terminated lifetime.
+	// One-shot terminated check. Sources that have signaled terminal
+	// can't deliver new events to subscribers (chans are closed).
+	// Returning nil rather than error so callers wrapping yield in
+	// event-driven code paths don't have to special-case the
+	// post-terminated lifetime.
 	s.mu.RLock()
 	terminated := s.terminated
 	s.mu.RUnlock()
@@ -585,14 +589,14 @@ func (s *YieldingSource[Data]) yield(data Data) error {
 			s.entries = s.entries[len(s.entries)-s.maxSize:]
 		}
 	}
-	// η-4: snapshot subscribers under the lock, then drop the lock
-	// before invoking author hooks. Match / Transform fire on the hot
-	// path — running them while holding s.mu would serialize the
-	// whole source on a slow author callback. The cleanup goroutine
-	// in Subscribe also takes s.mu before close()-ing the chan, so
-	// snapshotting + sending later means a closed-chan send is
-	// possible during a close-vs-send race; subscriberSlot.deliverEvent
-	// owns the recover for that.
+	// Snapshot subscribers under the lock, then drop the lock before
+	// invoking author hooks. Match / Transform (spec §"Server SDK
+	// Guidance" L623-629) fire on the hot path — running them while
+	// holding s.mu would serialize the whole source on a slow author
+	// callback. The cleanup goroutine in Subscribe also takes s.mu
+	// before close()-ing the chan, so snapshotting + sending later
+	// means a closed-chan send is possible during a close-vs-send
+	// race; subscriberSlot.deliverEvent owns the recover for that.
 	subs := append([]*subscriberSlot(nil), s.subscribers...)
 	hook := s.emitHook
 	matchFn := s.def.Match
@@ -615,7 +619,7 @@ func (s *YieldingSource[Data]) yield(data Data) error {
 // private subscriberSlot internals + yield's lock discipline so it's
 // not reusable outside this file.
 //
-// Hot-path discipline (Q8):
+// Hot-path discipline:
 //   - safeMatch / safeTransform are nil-tolerant + panic-recovering;
 //     a buggy author hook can't take down the fanout.
 //   - Match=false skips the subscriber outright (and skips Transform).
@@ -624,7 +628,8 @@ func (s *YieldingSource[Data]) yield(data Data) error {
 //     allocation cost.
 //   - subscriberSlot.deliverEvent owns the close-vs-send race recovery
 //     and the non-blocking + drop-with-Truncated semantics; same
-//     codepath as the η-5 targeted-deliver closure.
+//     codepath as the targeted-deliver closure used by
+//     EmitToSubscription (spec §"Server SDK Guidance" L630).
 func (s *YieldingSource[Data]) deliverEventToSlot(sub *subscriberSlot, event Event, matchFn MatchFunc, transformFn TransformFunc) {
 	hc := newHookContext(context.Background(), sub.principal, sub.subscriptionID, DeliveryModePush)
 	if !safeMatch(matchFn, hc, event, sub.params) {

--- a/experimental/ext/events/yield_test.go
+++ b/experimental/ext/events/yield_test.go
@@ -287,11 +287,12 @@ func TestYieldingSource_MetaFuncReturningNilOmits(t *testing.T) {
 	assert.NotContains(t, string(raw), `"_meta"`, "omitempty must keep _meta off the wire when nil")
 }
 
-// TestYieldingSource_SubscribeReceivesYieldedEvents verifies the ε-1
+// TestYieldingSource_SubscribeReceivesYieldedEvents verifies the
 // per-call subscription channel: Subscribe(ctx) returns a chan that
 // receives a SubscriberEvent for every subsequent yield. The push
-// delivery model (events/stream, ε-2) sits on top of this primitive —
-// each open stream handler holds one subscription chan.
+// delivery model (events/stream, spec §"Push-Based Delivery" L223+)
+// sits on top of this primitive — each open stream handler holds
+// one subscription chan.
 //
 // Failing this test means events/stream cannot deliver anything: the
 // stream handler would have no source-level channel to select on.
@@ -418,14 +419,14 @@ func readSubscriberEvent(t *testing.T, ch <-chan SubscriberEvent, d time.Duratio
 }
 
 // TestYieldingSource_YieldError_DeliversErrorVariant verifies the
-// ζ-7 source-side health signal: YieldError emits a SubscriberEvent
-// with Error set (no Event payload, not Truncated). Stream subscribers
+// source-side health signal: YieldError emits a SubscriberEvent with
+// Error set (no Event payload, not Truncated). Stream subscribers
 // map this onto a notifications/events/error frame; the subscription
-// stays open per spec L255+L261 (transient upstream failure).
+// stays open per spec §"Push-Based Delivery" L255+L261 (transient
+// upstream failure).
 //
-// Without this primitive, sources have no way to signal "I tried to
-// fetch upstream and got a 503" — the pre-ζ-7 yield API only supports
-// successful events.
+// Without this primitive, sources would have no way to signal "I
+// tried to fetch upstream and got a 503" — only successful events.
 func TestYieldingSource_YieldError_DeliversErrorVariant(t *testing.T) {
 	src, _ := NewYieldingSource[fakePayload](EventDef{Name: "fake"})
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
## Summary
Sweeps the \`experimental/ext/events\` package for mcpkit-internal phase labels (alpha/beta/gamma/delta/epsilon/zeta/eta and the corresponding Greek symbols) in code comments and replaces them with spec citations where the rationale is spec-driven.

**Why:** the Greek labels were internal scaffolding to plan the spec-alignment work — readable for the team, opaque for outside contributors trying to understand "why does this code exist?". Spec citations explain the why in a form that survives mcpkit's milestone naming.

This is a docs/comments-only sweep — zero functional changes.

## Sweep rules
- \`"ζ-3 spec L487"\` → \`"spec §"Webhook Security" → "Delivery profile" L487"\` (drop the phase prefix; keep the citation that already carried the meaning).
- \`"ζ-6: N consecutive failures"\` → \`"N consecutive failures before Active=false"\` (drop the prefix; the description was already enough, sometimes with a spec ref appended).
- \`"η-3 — foundation for η-4's lifecycle wiring"\` → spec §"Server SDK Guidance" → "Subscription lifecycle hooks" L691 (replace cross-phase reference with the spec section that motivates it).
- \`"γ adds spec-mandated auth gating"\` → reword in passive without the phase, citing §"Subscription Identity" L361.
- \`"ζ-6."\` appended to a paragraph as just a phase marker → delete.
- Stale doc reference \`"See γ PLAN.md"\` → cite the spec section the rationale came from.
- \`"Q1-Q8"\` references to the η plan's design questions → either spec section reference or drop entirely.

## What stayed
- Spec citations themselves (§"…" L###) — those are the point of this sweep, not the target.
- All behavioral code: zero functional changes.
- Planning docs (\`docs/EVENTS_*_PLAN.md\`) — those legitimately document mcpkit phasing history and remain useful as planning artifacts. Sweep targets code comments, not planning prose.
- Commit messages, PR descriptions, git history — historical record, untouched.

## Counts
Greek refs in \`*.go\` under \`experimental/ext/events/\`:
- before: 186 across ~20 files
- after:  0

## Test plan
- [x] make test-experimental-events
- [x] make test-experimental-events-discord
- [x] make test-experimental-events-telegram
- [x] make test-experimental-events-clients-go

This was tracked as a follow-up after the η plan closed; see the post-η Greek-to-SEP reference sweep noted across earlier PR reviews.