### PR TITLE
docs: extend Greek-to-spec sweep to clients/go + examples

### DIFF
--- a/client/client_per_call_notify_test.go
+++ b/client/client_per_call_notify_test.go
@@ -19,12 +19,12 @@ import (
 // per-call notification hook on the typed CallContext (CallContext.WithNotifyHook)
 // receives notifications arriving on the call's POST SSE response stream.
 //
-// Foundation for events/stream's Stream() helper (ε-4): without per-call
+// Foundation for the events/stream client helper: without per-call
 // routing, notifications/events/* would only reach the session-global
-// callback, forcing every consumer to demux globally. With this hook, each
-// long-lived call (events/stream today, future tasks/progress streams,
-// sampling/elicitation flows) gets a private notification channel scoped
-// to its own response stream.
+// callback, forcing every consumer to demux globally. With this hook,
+// each long-lived call (events/stream today, future tasks/progress
+// streams, sampling/elicitation flows) gets a private notification
+// channel scoped to its own response stream.
 //
 // Setup: a tool that emits a custom notification mid-execution then returns.
 // Both the global callback and the per-call hook should fire — the hook is

--- a/examples/events/discord/e2e_test.go
+++ b/examples/events/discord/e2e_test.go
@@ -28,8 +28,9 @@ import (
 // The cursorless typing source is registered alongside discord.message so
 // cursor-shape tests can exercise both modes against the same server.
 func buildTestStack(whOpts ...events.WebhookOption) (*server.Server, *events.YieldingSource[DiscordEventData], func(DiscordEventData) error, *events.WebhookRegistry) {
-	// ζ-1: tests subscribe to httptest URLs (127.0.0.1:N); bypass the
-	// production-default SSRF dial guard.
+	// Tests subscribe to httptest URLs (127.0.0.1:N); bypass the
+	// production-default SSRF dial guard (spec §"Webhook Security"
+	// → "SSRF prevention" L464).
 	whOpts = append([]events.WebhookOption{events.WithWebhookAllowPrivateNetworks(true)}, whOpts...)
 	webhooks := events.NewWebhookRegistry(whOpts...)
 	source, yield := newDiscordSource()
@@ -45,7 +46,7 @@ func buildTestStack(whOpts ...events.WebhookOption) (*server.Server, *events.Yie
 		Sources:                  []events.EventSource{source, typingSource},
 		Webhooks:                 webhooks,
 		Server:                   srv,
-		UnsafeAnonymousPrincipal: "test-principal", // tests don't wire auth; γ-2 spec gate would reject otherwise
+		UnsafeAnonymousPrincipal: "test-principal", // tests don't wire auth; spec gate at §"Subscription Identity" L361 would reject otherwise
 	})
 
 	return srv, source, yield, webhooks
@@ -54,8 +55,9 @@ func buildTestStack(whOpts ...events.WebhookOption) (*server.Server, *events.Yie
 // buildTestStackWithTyping returns the same wired server but exposes the
 // cursorless typing yield function too. Used by the cursorless e2e tests.
 func buildTestStackWithTyping(whOpts ...events.WebhookOption) (*server.Server, func(DiscordEventData) error, func(DiscordTypingData) error, *events.WebhookRegistry) {
-	// ζ-1: tests subscribe to httptest URLs (127.0.0.1:N); bypass the
-	// production-default SSRF dial guard.
+	// Tests subscribe to httptest URLs (127.0.0.1:N); bypass the
+	// production-default SSRF dial guard (spec §"Webhook Security"
+	// → "SSRF prevention" L464).
 	whOpts = append([]events.WebhookOption{events.WithWebhookAllowPrivateNetworks(true)}, whOpts...)
 	webhooks := events.NewWebhookRegistry(whOpts...)
 	source, yield := newDiscordSource()
@@ -107,7 +109,8 @@ func TestE2EPollDelivery(t *testing.T) {
 	require.NoError(t, yield(newDiscordEvent("guild-1", "channel-1", "alice", "hello", time.Now())))
 	require.NoError(t, yield(newDiscordEvent("guild-1", "channel-1", "bob", "world", time.Now())))
 
-	// δ-1: flat events/poll request shape per spec L139-149.
+	// Flat events/poll request shape per spec §"Poll-Based Delivery"
+	// → "Request: events/poll" L139-149.
 	result, err := c.Call("events/poll", map[string]any{
 		"name":   "discord.message",
 		"cursor": "0",
@@ -135,9 +138,9 @@ func TestE2EPollDelivery(t *testing.T) {
 //   - Verify OnEvent callback fires with the spec EventOccurrence shape
 //   - Stop() the stream and confirm clean shutdown via Done()
 //
-// This is the E2E coverage for the new push delivery model. The legacy
-// broadcast path is still exercised by TestE2EPushDelivery below; both
-// stay until ε-6's deprecation lands in η.
+// This is the E2E coverage for the per-stream push delivery model.
+// The legacy broadcast path is still exercised by TestE2EPushDelivery
+// below; both stay while the legacy path is in transition.
 func TestE2EStreamDelivery(t *testing.T) {
 	srv, _, yield, _ := buildTestStack()
 	c, _ := connectClient(t, srv)
@@ -174,11 +177,13 @@ func TestE2EStreamDelivery(t *testing.T) {
 	}
 }
 
-// TestE2EHealthSignalsEndToEnd is the end-to-end ζ-7 verification:
-// source-side YieldError / YieldTerminated bubble through to BOTH
-// stream subscribers (notifications/events/error and /terminated)
-// AND webhook subscribers (auto-PostTerminated control envelope on
-// the suspend / source-terminate path).
+// TestE2EHealthSignalsEndToEnd is the end-to-end source-health
+// verification: source-side YieldError / YieldTerminated bubble
+// through to BOTH stream subscribers (notifications/events/error
+// and /terminated per spec §"Push-Based Delivery" L255+L261 and
+// §"Authorization" L783-795) AND webhook subscribers
+// (auto-PostTerminated control envelope on the suspend /
+// source-terminate path).
 //
 // The walkthrough Step 5.5 only exercises the transient path because
 // YieldTerminated is one-shot — it would break subsequent walkthrough
@@ -234,12 +239,11 @@ func TestE2EHealthSignalsEndToEnd(t *testing.T) {
 	// Step 2: terminate → stream OnTerminated fires + Stream's
 	// internal goroutine returns (Done unblocks). Webhook subscriber
 	// is unaffected by source termination directly — it gets a
-	// type:terminated envelope only when ζ-6's suspend state machine
-	// flips Active=false (separate path covered by ζ-7.3 unit tests).
-	// This test exercises the source-side terminate flow on the
-	// stream side; webhook auto-PostTerminated is verified by
-	// TestSuspend_AutoPostsTerminatedEnvelopeOnSuspension in the
-	// events module.
+	// type:terminated envelope only when the suspend state machine
+	// flips Active=false (spec §"Webhook Delivery Status" L460;
+	// covered by TestSuspend_AutoPostsTerminatedEnvelopeOnSuspension
+	// in the events module). This test exercises the source-side
+	// terminate flow on the stream side.
 	require.NoError(t, source.YieldTerminated(events.EventDeliveryError{
 		Code: -32012, Message: "demo terminated",
 	}))
@@ -715,10 +719,12 @@ func TestE2EPollMultiSubRejected(t *testing.T) {
 	srv, _, _, _ := buildTestStack()
 	c, _ := connectClient(t, srv)
 
-	// δ-1: the {subscriptions: [...]} wrapper itself is rejected with a
-	// helpful error — multi-sub vs single-sub no longer matters since the
-	// spec's flat shape doesn't have an array at all. The
-	// TestPoll_RejectsLegacyWrapper test in wire_shape_test.go covers the
+	// The legacy {subscriptions: [...]} wrapper itself is rejected
+	// with a helpful error — multi-sub vs single-sub no longer
+	// matters since the spec's flat shape (§"Poll-Based Delivery" →
+	// "Request: events/poll" L139-149) doesn't have an array at all.
+	// The TestPoll_RejectsLegacyWrapper test in wire_shape_test.go
+	// covers the
 	// wrapper-level rejection at the handler level; this demo test now just
 	// confirms the user-facing error message points at the spec.
 	_, err := c.Call("events/poll", map[string]any{

--- a/examples/events/discord/events.go
+++ b/examples/events/discord/events.go
@@ -9,10 +9,11 @@ import (
 // typed payloads back via source.Recent / source.ByCursor — single source of
 // truth, no duplication, no resource-side unmarshaling.
 //
-// δ-4: the source attaches per-event `_meta` derived from the payload
-// (spec follow-on commit d4faef9 2026-05-01). channel_type and mention_count
-// are app-defined classifications that don't fit `data` — exactly what
-// `_meta` is for. Receivers see them under the spec-canonical `_meta` key.
+// The source attaches per-event `_meta` derived from the payload
+// (spec follow-on commit d4faef9 2026-05-01). channel_type and
+// mention_count are app-defined classifications that don't fit
+// `data` — exactly what `_meta` is for. Receivers see them under the
+// spec-canonical `_meta` key.
 func newDiscordSource() (*events.YieldingSource[DiscordEventData], func(DiscordEventData) error) {
 	src, yield := events.NewYieldingSource[DiscordEventData](events.EventDef{
 		Name:        "discord.message",

--- a/examples/events/discord/main.go
+++ b/examples/events/discord/main.go
@@ -48,7 +48,7 @@ func serve() {
 	token := flag.String("token", "", "Discord bot token (omit for test mode)")
 	whTTL := flag.Duration("webhook-ttl", 0, "override webhook subscription TTL (default 60s; useful for driving the SDK refresh path in tests)")
 	whHeaderMode := flag.String("webhook-header-mode", "standard", "webhook header style: standard | mcp")
-	whSuspendThreshold := flag.Int("webhook-suspend-threshold", 0, "override consecutive-failures count that flips a webhook target to Active=false (default 5; lower to 1 for demoing the ζ-6 suspend transition without waiting 5×retry-cycles)")
+	whSuspendThreshold := flag.Int("webhook-suspend-threshold", 0, "override consecutive-failures count that flips a webhook target to Active=false (default 5; lower to 1 for demoing the suspend transition without waiting 5×retry-cycles)")
 	flag.CommandLine.Parse(demokit.FilterArgs(os.Args[1:],
 		demokit.BoolFlag("--serve"),
 		demokit.ValueFlag("--url"),
@@ -66,11 +66,11 @@ func serve() {
 
 	whOpts := []events.WebhookOption{
 		events.WithWebhookHeaderMode(headerMode),
-		// ζ-1 demo escape: the demo's webhook step subscribes to local
+		// Demo escape: the demo's webhook step subscribes to local
 		// httptest receivers (127.0.0.1:N), which the production-default
 		// dial-time SSRF guard would block. Production deployments leave
 		// this OFF so loopback/private-IP webhook URLs are rejected at
-		// dial per spec §"Webhook Security" L464.
+		// dial per spec §"Webhook Security" → "SSRF prevention" L464.
 		events.WithWebhookAllowPrivateNetworks(true),
 	}
 	if *whTTL > 0 {
@@ -136,7 +136,7 @@ func serve() {
 		log.Println("[discord] no token provided — running in test mode")
 	}
 
-	// γ-5: auto-detect auth posture.
+	// Auto-detect auth posture.
 	//
 	// If OAUTH_ISSUER is set, wire real OIDC auth via server.WithAuth(...)
 	// and follow the spec strictly — anonymous webhook subscribes are
@@ -179,10 +179,11 @@ func serve() {
 			eventName = "discord.message"
 		}
 
-		// ζ-7.4: source-side health-signal injection. Demo's stand-in
-		// for a real source bubbling upstream errors. Triggers
-		// notifications/events/error or /terminated on push subscribers,
-		// per spec §"Push-Based Delivery" → "Event Delivery" L255-271.
+		// Source-side health-signal injection. Demo's stand-in for a
+		// real source bubbling upstream errors. Triggers
+		// notifications/events/error or /terminated on push
+		// subscribers per spec §"Push-Based Delivery" → "Event
+		// Delivery" L255-271.
 		// `?action=error` is transient (stream stays); `?action=terminate`
 		// is one-shot terminal (stream closes; webhook subscribers get a
 		// type:terminated control envelope).

--- a/examples/events/discord/walkthrough.go
+++ b/examples/events/discord/walkthrough.go
@@ -193,7 +193,7 @@ func runDemo() {
 			if messageCursor != nil {
 				cursor = *messageCursor
 			}
-			// δ-1: flat top-level shape per spec §"Poll-Based Delivery"
+			// Flat top-level shape per spec §"Poll-Based Delivery"
 			// → "Request: events/poll" L139-149.
 			res, err := c.Call("events/poll", map[string]any{
 				"name":   "discord.message",
@@ -264,7 +264,7 @@ func runDemo() {
 			return
 		})
 
-	// --- Step 5.5: Source-side health signals (ζ-7) ---
+	// --- Step 5.5: Source-side health signals ---
 	demo.Step("What happens when the upstream source has a hiccup?").
 		Arrow("Host", "Server", "events/stream { name: discord.message }").
 		DashedArrow("Server", "Host", "notifications/events/active").
@@ -352,9 +352,10 @@ func runDemo() {
 				CallbackURL:   hookSrv.URL,
 				RefreshFactor: 0.5,
 				OnRefresh:     func() { atomic.AddInt32(&refreshes, 1) },
-				// δ-3: bound worst-case replay on reconnect to 5 minutes
-				// (§"Cursor Lifecycle" L529). Stored on WebhookTarget
-				// for ζ's reconnect-with-replay logic.
+				// Bound worst-case replay on reconnect to 5 minutes
+				// per spec §"Cursor Lifecycle" → "Bounding replay
+				// with maxAge" L529. Stored on WebhookTarget for
+				// future reconnect-with-replay logic.
 				MaxAge: 5 * time.Minute,
 			})
 			if err != nil {
@@ -368,9 +369,10 @@ func runDemo() {
 			// refused" retry log on the server side after the demo ends.
 			defer func() {
 				sub.Stop()
-				// γ-2: unsubscribe by tuple (§"Unsubscribing" L509) —
-				// (name, params, delivery.url). The derived id is not
-				// accepted as input.
+				// Unsubscribe by tuple (spec §"Unsubscribing:
+				// events/unsubscribe" L509) — (name, params,
+				// delivery.url). The derived id is not accepted
+				// as input.
 				_, _ = c.Call("events/unsubscribe", map[string]any{
 					"name":     "discord.message",
 					"delivery": map[string]any{"url": hookSrv.URL},
@@ -405,7 +407,7 @@ func runDemo() {
 			return
 		})
 
-	// --- Step 6.5: Multi-subscription routing (γ-4 + ε requestId echo) ---
+	// --- Step 6.5: Multi-subscription routing (X-MCP-Subscription-Id + requestId echo) ---
 	demo.Step("Two subs to the same event with different params — how do I tell deliveries apart?").
 		Arrow("Host", "Server", "events/subscribe { name: discord.message, params: {channel_id: 'alpha'}, ... }").
 		DashedArrow("Server", "Host", "{ id: sub_<A>, ... }").
@@ -525,7 +527,7 @@ func runDemo() {
 			return
 		})
 
-	// --- Step 6.7: Webhook delivery health (ζ-5 deliveryStatus + ζ-6 suspend) ---
+	// --- Step 6.7: Webhook delivery health (deliveryStatus + suspend) ---
 	demo.Step("My webhook receiver just died. How does the server let me know?").
 		Arrow("Receiver", "Receiver", "spin up failing receiver (returns 500 on event POSTs)").
 		Arrow("Host", "Server", "events/subscribe { name: discord.message, ... }").
@@ -715,7 +717,7 @@ func runDemo() {
 			return
 		})
 
-	// --- Step 9: Spec validation — client-supplied id is rejected (γ-3) ---
+	// --- Step 9: Spec validation — client-supplied id is rejected ---
 	demo.Step("What if I try to pick my own subscription id?").
 		Arrow("Host", "Server", "events/subscribe { id: 'mine', ... }").
 		DashedArrow("Server", "Host", "-32602 InvalidParams: client-supplied id is not accepted").
@@ -775,9 +777,10 @@ func runDemo() {
 			pretty, _ := json.MarshalIndent(v, "    ", "  ")
 			fmt.Printf("    events/subscribe response (server-derived id, no secret echo per spec):\n%s\n", string(pretty))
 
-			// Eagerly unsubscribe (γ-2: tuple form, no id) so the
-			// subscription doesn't tie up a delivery target for a TTL
-			// window after the demo ends.
+			// Eagerly unsubscribe (tuple form per spec
+			// §"Unsubscribing: events/unsubscribe" L509, no id) so
+			// the subscription doesn't tie up a delivery target
+			// for a TTL window after the demo ends.
 			_, _ = c.Call("events/unsubscribe", map[string]any{
 				"name":     "discord.message",
 				"delivery": map[string]any{"url": "http://localhost:1/sink"},

--- a/examples/events/telegram/e2e_test.go
+++ b/examples/events/telegram/e2e_test.go
@@ -29,8 +29,9 @@ import (
 // The cursorless typing source is registered alongside telegram.message so
 // cursor-shape tests can exercise both modes against the same server.
 func buildTestStack(whOpts ...events.WebhookOption) (*server.Server, *events.YieldingSource[TelegramEventData], func(TelegramEventData) error, *events.WebhookRegistry) {
-	// ζ-1: tests subscribe to httptest URLs (127.0.0.1:N); bypass the
-	// production-default SSRF dial guard.
+	// Tests subscribe to httptest URLs (127.0.0.1:N); bypass the
+	// production-default SSRF dial guard (spec §"Webhook Security"
+	// → "SSRF prevention" L464).
 	whOpts = append([]events.WebhookOption{events.WithWebhookAllowPrivateNetworks(true)}, whOpts...)
 	webhooks := events.NewWebhookRegistry(whOpts...)
 	source, yield := newTelegramSource()
@@ -103,7 +104,8 @@ func TestE2EPollDelivery(t *testing.T) {
 	require.NoError(t, yieldText(yield, 100, "bob", "world"))
 	require.NoError(t, yieldText(yield, 100, "carol", "!"))
 
-	// δ-1: flat events/poll request shape per spec L139-149.
+	// Flat events/poll request shape per spec §"Poll-Based Delivery"
+	// → "Request: events/poll" L139-149.
 	result, err := c.Call("events/poll", map[string]any{
 		"name":      "telegram.message",
 		"cursor":    "0",
@@ -292,10 +294,11 @@ func TestE2EWebhookDelivery(t *testing.T) {
 	require.NoError(t, err)
 
 	// Spec: subscribe response carries id (server-derived per
-	// §"Subscription Identity" → "Derived id" L367) but does NOT echo
-	// the secret. The client already supplied the secret; receiver
-	// verifies with that value. The id is the X-MCP-Subscription-Id
-	// routing handle (γ-4 wires the header).
+	// §"Subscription Identity" → "Derived id" L367) but does NOT
+	// echo the secret. The client already supplied the secret;
+	// receiver verifies with that value. The id is the
+	// X-MCP-Subscription-Id routing handle (spec §"Webhook Event
+	// Delivery" L390 + §"Webhook Security" L472).
 	var subResp struct {
 		ID     string `json:"id"`
 		Secret string `json:"secret"`
@@ -572,8 +575,9 @@ func TestE2EPollMultiSubRejected(t *testing.T) {
 	c := client.NewClient(tsrv.URL+"/mcp", core.ClientInfo{Name: "multi-sub", Version: "1.0"})
 	require.NoError(t, c.Connect())
 
-	// δ-1: the {subscriptions: [...]} wrapper is rejected with a helpful
-	// error pointing at the spec change (L139-149).
+	// The legacy {subscriptions: [...]} wrapper is rejected with a
+	// helpful error pointing at the spec change (§"Poll-Based
+	// Delivery" → "Request: events/poll" L139-149).
 	_, err := c.Call("events/poll", map[string]any{
 		"subscriptions": []map[string]any{
 			{"name": "telegram.message", "cursor": "0"},

--- a/examples/events/telegram/handlers_test.go
+++ b/examples/events/telegram/handlers_test.go
@@ -82,7 +82,8 @@ func TestEventsPollCursorPagination(t *testing.T) {
 	source, _ := preloadedSource(10)
 	c, _ := newConnectedClient(t, source, events.NewWebhookRegistry(events.WithWebhookAllowPrivateNetworks(true)))
 
-	// δ-1: flat events/poll request shape per spec L139-149.
+	// Flat events/poll request shape per spec §"Poll-Based Delivery"
+	// → "Request: events/poll" L139-149.
 	result, err := c.Call("events/poll", map[string]any{
 		"name":      "telegram.message",
 		"cursor":    "0",
@@ -208,11 +209,12 @@ func TestWebhookHMACSignature_MCPHeaders(t *testing.T) {
 
 	webhooks := events.NewWebhookRegistry(
 		events.WithWebhookHeaderMode(events.MCPHeaders),
-		events.WithWebhookAllowPrivateNetworks(true), // ζ-1: httptest is loopback
+		events.WithWebhookAllowPrivateNetworks(true), // httptest is loopback; bypass SSRF dial guard
 	)
-	// Direct registry poke (skip the JSON-RPC subscribe handler) — γ-2
-	// rekeyed Register on canonical-tuple bytes. Use a stub key for the
-	// HMAC delivery test; the canonical-key contents don't matter here.
+	// Direct registry poke (skip the JSON-RPC subscribe handler).
+	// Register is keyed on canonical-tuple bytes (spec §"Subscription
+	// Identity" → "Key composition" L363); the contents don't matter
+	// for this HMAC delivery test, so we use a stub key.
 	webhooks.Register(events.RegisterParams{CanonicalKey: []byte("hmac-test"), DerivedID: "sub_hmac_test", URL: srv.URL, Secret: secret, MaxAgeSeconds: 0})
 
 	event := events.MakeEvent("telegram.message", "evt_1", "1", time.Now(),
@@ -285,7 +287,7 @@ func TestSubscribeReturnsRefreshBefore(t *testing.T) {
 		RefreshBefore string `json:"refreshBefore"`
 	}
 	require.NoError(t, json.Unmarshal(result.Raw, &resp))
-	// γ-2: server-derived id replaces client-supplied id per spec
+	// Server-derived id replaces client-supplied id per spec
 	// §"Subscription Identity" → "Derived id" L367.
 	assert.True(t, strings.HasPrefix(resp.ID, "sub_"), "id must be server-derived sub_<base64>; got %q", resp.ID)
 	assert.NotEmpty(t, resp.RefreshBefore)
@@ -295,12 +297,14 @@ func TestSubscribeReturnsRefreshBefore(t *testing.T) {
 	assert.True(t, rb.After(time.Now()))
 }
 
-// TestWebhookKeyedByCanonicalTuple verifies γ-2 registry keying: two
-// distinct canonical keys (different principals subscribing to the same
-// URL) coexist as distinct entries; Unregister by canonical key removes
-// only the matching entry. This is the spec's cross-tenant isolation
-// property (§"Subscription Identity" → "Cross-tenant isolation" L378)
-// at the registry level.
+// TestWebhookKeyedByCanonicalTuple verifies the registry's
+// canonical-tuple keying (spec §"Subscription Identity" → "Key
+// composition" L363): two distinct canonical keys (different
+// principals subscribing to the same URL) coexist as distinct
+// entries; Unregister by canonical key removes only the matching
+// entry. This is the spec's cross-tenant isolation property
+// (§"Subscription Identity" → "Cross-tenant isolation" L378) at
+// the registry level.
 func TestWebhookKeyedByCanonicalTuple(t *testing.T) {
 	webhooks := events.NewWebhookRegistry(events.WithWebhookAllowPrivateNetworks(true))
 	keyA := []byte("alice\x1fhttp://example.com/hook\x1ftelegram.message\x1f{}")

--- a/examples/events/telegram/main.go
+++ b/examples/events/telegram/main.go
@@ -59,11 +59,12 @@ func serve() {
 
 	whOpts := []events.WebhookOption{
 		events.WithWebhookHeaderMode(headerMode),
-		// ζ-1 demo escape: the demo's webhook step subscribes to local
-		// httptest receivers (127.0.0.1:N). Production-default dial-time
-		// SSRF guard would block these. Production deployments leave
-		// this OFF so loopback/private-IP webhook URLs are rejected at
-		// dial per spec §"Webhook Security" L464.
+		// Demo escape: the demo's webhook step subscribes to local
+		// httptest receivers (127.0.0.1:N). Production-default
+		// dial-time SSRF guard would block these. Production
+		// deployments leave this OFF so loopback/private-IP webhook
+		// URLs are rejected at dial per spec §"Webhook Security" →
+		// "SSRF prevention" L464.
 		events.WithWebhookAllowPrivateNetworks(true),
 	}
 	log.Printf("[server] webhook headers=%s; client-supplied secrets only", headerMode)
@@ -84,11 +85,12 @@ func serve() {
 		log.Println("[telegram] no token provided — running in test mode")
 	}
 
-	// γ-5: auto-detect auth posture. Identical pattern to discord's main.go
-	// — if OAUTH_ISSUER is set, wire real OIDC auth and follow the spec
-	// strictly (anonymous webhook subscribes rejected with -32012 per
-	// §"Subscription Identity" L361). Otherwise fall back to the demo
-	// escape hatch so `make demo` works without an auth provider.
+	// Auto-detect auth posture. Identical pattern to discord's
+	// main.go — if OAUTH_ISSUER is set, wire real OIDC auth and
+	// follow the spec strictly (anonymous webhook subscribes
+	// rejected with -32012 per §"Subscription Identity" L361).
+	// Otherwise fall back to the demo escape hatch so `make demo`
+	// works without an auth provider.
 	srvOpts := common.MCPServerOptions(*addr, "[mcp] ")
 	srvOpts = append(srvOpts, server.WithSubscriptions())
 	authPosture := "demo (anonymous → UnsafeAnonymousPrincipal)"

--- a/examples/events/telegram/walkthrough.go
+++ b/examples/events/telegram/walkthrough.go
@@ -198,9 +198,10 @@ func runDemo() {
 			sub, err := eventsclient.Subscribe(ctx, c, eventsclient.SubscribeOptions{
 				EventName:   "telegram.message",
 				CallbackURL: hookSrv.URL,
-				// δ-3: bound worst-case replay on reconnect to 5 minutes
-				// (§"Cursor Lifecycle" L529). Stored on WebhookTarget
-				// for ζ's reconnect-with-replay logic.
+				// Bound worst-case replay on reconnect to 5 minutes
+				// per spec §"Cursor Lifecycle" → "Bounding replay
+				// with maxAge" L529. Stored on WebhookTarget for
+				// future reconnect-with-replay logic.
 				MaxAge: 5 * time.Minute,
 			})
 			if err != nil {
@@ -214,7 +215,8 @@ func runDemo() {
 			// refused" retry log on the server side after the demo ends.
 			defer func() {
 				sub.Stop()
-				// γ-2: unsubscribe by tuple (§"Unsubscribing" L509).
+				// Unsubscribe by tuple per spec §"Unsubscribing:
+				// events/unsubscribe" L509.
 				_, _ = c.Call("events/unsubscribe", map[string]any{
 					"name":     "telegram.message",
 					"delivery": map[string]any{"url": hookSrv.URL},

--- a/experimental/ext/events/clients/go/control_envelope_test.go
+++ b/experimental/ext/events/clients/go/control_envelope_test.go
@@ -12,12 +12,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// ζ-4 receiver-side dispatch — these tests stand up an httptest receiver
-// (the eventsclient.Receiver), point a server-side WebhookRegistry at
-// it, and trigger PostGap / PostTerminated. They verify the receiver's
-// top-level `type` discriminator routes the body to the right typed
-// callback (OnGap / OnTerminated) instead of falling through to the
-// Event[Data] channel.
+// Receiver-side control-envelope dispatch — these tests stand up an
+// httptest receiver (the eventsclient.Receiver), point a server-side
+// WebhookRegistry at it, and trigger PostGap / PostTerminated. They
+// verify the receiver's top-level `type` discriminator (spec
+// §"Non-event webhook bodies" L415-423) routes the body to the right
+// typed callback (OnGap / OnTerminated) instead of falling through
+// to the Event[Data] channel.
 //
 // The HTTP path / signature / headers are the same as event deliveries
 // (covered by other tests); these focus on the dispatch.

--- a/experimental/ext/events/clients/go/eventsclient_test.go
+++ b/experimental/ext/events/clients/go/eventsclient_test.go
@@ -30,8 +30,9 @@ type fakePayload struct {
 func stack(t *testing.T, whOpts ...events.WebhookOption) (*client.Client, func(fakePayload) error, *events.WebhookRegistry) {
 	t.Helper()
 
-	// ζ-1: SDK tests subscribe to httptest URLs (127.0.0.1:N). Prepend
-	// the loopback escape so the dial-time SSRF guard doesn't block
+	// SDK tests subscribe to httptest URLs (127.0.0.1:N). Prepend
+	// the loopback escape so the dial-time SSRF guard (spec
+	// §"Webhook Security" → "SSRF prevention" L464) doesn't block
 	// the test deliveries. Per-test whOpts can still override.
 	whOpts = append([]events.WebhookOption{events.WithWebhookAllowPrivateNetworks(true)}, whOpts...)
 	webhooks := events.NewWebhookRegistry(whOpts...)
@@ -49,7 +50,7 @@ func stack(t *testing.T, whOpts ...events.WebhookOption) (*client.Client, func(f
 		Sources:                  []events.EventSource{src},
 		Webhooks:                 webhooks,
 		Server:                   srv,
-		UnsafeAnonymousPrincipal: "test-principal", // SDK tests don't wire auth; γ-2 spec gate would reject otherwise
+		UnsafeAnonymousPrincipal: "test-principal", // SDK tests don't wire auth; spec gate at §"Subscription Identity" L361 would reject otherwise
 	})
 
 	handler := srv.Handler(server.WithStreamableHTTP(true))

--- a/experimental/ext/events/clients/go/receiver.go
+++ b/experimental/ext/events/clients/go/receiver.go
@@ -25,9 +25,10 @@ type Receiver[Data any] struct {
 	closed   bool
 	rejected uint64
 
-	// ζ-4 control envelope callbacks. Both are optional. The discriminator
-	// is the top-level `type` field per spec §"Non-event webhook bodies"
-	// L415: "gap" carries a fresh cursor; "terminated" carries an error.
+	// Control envelope callbacks per spec §"Non-event webhook bodies"
+	// L415-423. Both are optional. The discriminator is the top-level
+	// `type` field: "gap" carries a fresh cursor; "terminated"
+	// carries an error.
 	onGap        func(cursor string)
 	onTerminated func(err ControlError)
 }
@@ -125,7 +126,7 @@ func (r *Receiver[Data]) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	// ζ-4: top-level `type` field discriminates control envelopes from
+	// Top-level `type` field discriminates control envelopes from
 	// event deliveries (spec §"Non-event webhook bodies" L415-423).
 	// Probe with a minimal struct before unmarshaling as Event so we
 	// don't double-decode the common case (no `type` → event).

--- a/experimental/ext/events/clients/go/stream.go
+++ b/experimental/ext/events/clients/go/stream.go
@@ -1,12 +1,14 @@
 package eventsclient
 
-// Stream — events/stream client helper (ε-4b).
+// Stream — events/stream client helper. Spec §"Push-Based Delivery"
+// L223+.
 //
 // One Stream holds one open events/stream call. The helper:
 //
-//  1. Issues an events/stream POST via client.CallWithOptions, threading
-//     a per-call notification hook (ε-4a) so notifications/events/* land
-//     here rather than only on the session-global callback.
+//  1. Issues an events/stream POST via client.CallWithOptions,
+//     threading a per-call notification hook (CallContext.WithNotifyHook)
+//     so notifications/events/* land here rather than only on the
+//     session-global callback.
 //  2. Routes each notification by method to the matching typed callback
 //     (OnEvent, OnHeartbeat, OnTruncated, OnError, OnTerminated).
 //  3. Returns from the constructor once the initial

--- a/experimental/ext/events/clients/go/stream_test.go
+++ b/experimental/ext/events/clients/go/stream_test.go
@@ -49,7 +49,7 @@ func streamStack(t *testing.T, heartbeat time.Duration) (*client.Client, func(fa
 // TestStream_DeliversEventsViaCallback verifies the typed callback path:
 // open a Stream, yield events server-side, OnEvent fires per event with
 // the spec-shape EventOccurrence in the wire payload. This is the
-// happy-path that the discord/telegram demos will rely on after ε-6.
+// happy-path that the discord/telegram demos rely on.
 //
 // Failing this means the SDK's per-call notify hook plumbing is broken
 // or the Stream goroutine isn't dispatching to OnEvent.

--- a/experimental/ext/events/clients/go/subscription.go
+++ b/experimental/ext/events/clients/go/subscription.go
@@ -104,8 +104,10 @@ func Subscribe(parent context.Context, sess *client.Client, opts SubscribeOption
 }
 
 // ID returns the subscription id the SDK supplied (echoed by the
-// server). γ replaces id-keyed subscription identity with the
-// (principal, name, params, url) tuple per spec.
+// server). The spec replaces id-keyed subscription identity with the
+// (principal, name, params, url) tuple per §"Subscription Identity"
+// → "Key composition" L363; this id is the server-derived routing
+// handle, not the canonical key.
 func (s *Subscription) ID() string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()


### PR DESCRIPTION
## Summary
Round 2 of the Greek-phase-label sweep. Round 1 (PR #404) covered \`experimental/ext/events/\` itself; this one extends the same approach to:

- \`experimental/ext/events/clients/go/\` (the Go events SDK client) — 6 files, 7 refs
- \`examples/events/discord/\` (handlers, tests, walkthrough, main) — 4 files, 23 refs
- \`examples/events/telegram/\` (same shape as discord) — 4 files, 14 refs
- \`client/client_per_call_notify_test.go\` — 1 ref to "ε-4" reframed as "events/stream client helper foundation"

## Sweep rules (unchanged from round 1)
- Drop pure phase markers (e.g., \`// ζ-6.\`).
- Replace phase-prefixed spec citations with the citation alone (e.g., \`"δ-1: flat events/poll request shape per spec L139-149"\` → \`"Flat events/poll request shape per spec §"Poll-Based Delivery" → "Request: events/poll" L139-149"\`).
- Reword cross-phase references like \`"γ-2's auth gate"\` to cite the spec section that motivates the work (\`§"Subscription Identity" → "Authentication required" L361\`).

## Counts
Across the additional scope (clients/go + examples + the one core test):
- before: 45 refs across 13 files
- after:  0

Combined with round 1 (186 refs), the events-related code is now Greek-free across all functional code: 231 → 0.

## What stayed
Same as round 1: planning docs (\`docs/EVENTS_*_PLAN.md\`), commit messages, and PR descriptions remain untouched.

## Test plan
- [x] make test-experimental-events
- [x] make test-experimental-events-discord
- [x] make test-experimental-events-telegram
- [x] make test-experimental-events-clients-go