### PR TITLE
feat(server/tasks_v2): rename notifications/tasks/status to notifications/tasks

### DIFF
--- a/docs/TASKS_V2_MIGRATION.md
+++ b/docs/TASKS_V2_MIGRATION.md
@@ -109,6 +109,14 @@ Map keys are server-minted opaque strings. Clients MUST treat them as round-trip
 
 After `tasks/cancel`, observe the resulting `cancelled` status via the next `tasks/get`.
 
+### 6. Status notification method renamed
+
+| | v1 | v2 |
+|---|---|---|
+| Status notification method | `notifications/tasks/status` | `notifications/tasks` |
+
+Payload shape is unchanged on the v2 path (still a `DetailedTask` carrying the SEP-2322 `requestState`). Only the JSON-RPC method name moved. The v1 method name is preserved, so hybrid servers emit both names — v2 clients subscribe to `notifications/tasks`, v1 clients keep their existing `notifications/tasks/status` subscription. (Spec commit `1d3813ab` in PR 2663.)
+
 ## Server migration paths
 
 ### Pure v1 server (no change required)

--- a/server/tasks_v2.go
+++ b/server/tasks_v2.go
@@ -136,7 +136,7 @@ func (rt *v2TaskRuntime) getToolCallbacks(taskID string) *TaskCallbacks {
 }
 
 // makeRequestState mints the SEP-2322 requestState string the server hands
-// to clients on tasks/get responses and notifications/tasks/status events.
+// to clients on tasks/get responses and notifications/tasks events.
 // When a signing key is configured (TasksConfig.RequestStateKey), the token
 // is HMAC-SHA256 signed with an embedded expiry; otherwise it falls back to
 // the bare taskID for backward compat with minimal-config setups and tests.
@@ -827,7 +827,7 @@ func notifyV2TaskStatus(ctx context.Context, rt *v2TaskRuntime, store TaskStore,
 		}
 	}
 
-	core.Notify(ctx, "notifications/tasks/status", payload)
+	core.Notify(ctx, "notifications/tasks", payload)
 }
 
 // notifyV2TaskStatusFromInfo sends a status notification through the live
@@ -847,5 +847,5 @@ func notifyV2TaskStatusFromInfo(ctx core.MethodContext, rt *v2TaskRuntime, info 
 			payload.Error = te
 		}
 	}
-	ctx.Notify("notifications/tasks/status", payload)
+	ctx.Notify("notifications/tasks", payload)
 }

--- a/server/tasks_v2_test.go
+++ b/server/tasks_v2_test.go
@@ -915,7 +915,7 @@ func TestV2_UpdateUnknownKeyIgnored(t *testing.T) {
 }
 
 // TestV2_StatusNotificationCarriesRequestState verifies that
-// notifications/tasks/status events carry the SEP-2322 requestState string.
+// notifications/tasks events carry the SEP-2322 requestState string.
 // Clients update their tracked requestState from notifications so a
 // stateless deployment can pick the conversation back up without an extra
 // tasks/get round-trip — but only if the server actually emits it.
@@ -926,7 +926,7 @@ func TestV2_UpdateUnknownKeyIgnored(t *testing.T) {
 func TestV2_StatusNotificationCarriesRequestState(t *testing.T) {
 	srv := newTaskV2Server(t)
 
-	// Capture incoming notifications/tasks/status payloads. Use a buffered
+	// Capture incoming notifications/tasks payloads. Use a buffered
 	// channel + select so the test isn't sensitive to delivery ordering vs
 	// the SSE stream lifecycle.
 	notifs := make(chan core.DetailedTask, 8)
@@ -938,7 +938,7 @@ func TestV2_StatusNotificationCarriesRequestState(t *testing.T) {
 		client.WithGetSSEStream(),
 		client.WithTasksExtension(),
 		client.WithNotificationCallback(func(method string, params any) {
-			if method != "notifications/tasks/status" {
+			if method != "notifications/tasks" {
 				return
 			}
 			raw, err := json.Marshal(params)
@@ -984,7 +984,7 @@ func TestV2_StatusNotificationCarriesRequestState(t *testing.T) {
 				continue
 			}
 			if dt.RequestState == "" {
-				t.Fatalf("notifications/tasks/status for %s missing requestState (full payload: %+v)", taskID, dt)
+				t.Fatalf("notifications/tasks for %s missing requestState (full payload: %+v)", taskID, dt)
 			}
 			// SEP-2322: same body as the next tasks/get would mint —
 			// clients can drop-in update their tracked state.
@@ -998,7 +998,7 @@ func TestV2_StatusNotificationCarriesRequestState(t *testing.T) {
 			}
 			return
 		case <-deadline:
-			t.Fatalf("timed out waiting for notifications/tasks/status with requestState for %s", taskID)
+			t.Fatalf("timed out waiting for notifications/tasks with requestState for %s", taskID)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- SEP-2663 (Tasks Extension) merged Final at `c47bd846` on 2026-05-15. The merged spec renamed the v2 status notification wire method from `notifications/tasks/status` to `notifications/tasks` (spec commit `1d3813ab` in PR 2663).
- This PR renames the v2 path only. v1 (`server/tasks_v1.go`, `server/tasks_v1_test.go`) keeps the original method name, so hybrid servers emit both names — consistent with the dual capability advertisement.
- One subsection added to `docs/TASKS_V2_MIGRATION.md` covering the rename.

## Sites changed

- `server/tasks_v2.go:139` — doc comment on `makeRequestState`
- `server/tasks_v2.go:830` — `notifyV2TaskStatus` emission
- `server/tasks_v2.go:850` — `notifyV2TaskStatusFromInfo` emission
- `server/tasks_v2_test.go:918, 929, 941, 987, 1001` — comments, handler assertion, error messages
- `docs/TASKS_V2_MIGRATION.md` — new section 6 "Status notification method renamed"

## Test plan

- [x] `go test ./server/...` green locally (13.5s)
- [ ] CI green