### PR TITLE
feat(server/tasks_v2,core): SEP-2663 Phase 2 catch-up (G4-G12c)

### DIFF
--- a/core/background.go
+++ b/core/background.go
@@ -63,3 +63,31 @@ func ReplaceSessionNotifyFunc(ctx context.Context, fn NotifyFunc) context.Contex
 	newSC.notify = fn
 	return context.WithValue(ctx, sessionCtxKey, &newSC)
 }
+
+// ApplySessionNotifyFilter wraps the session's current notifyFunc with a
+// filter that silently drops notifications whose method matches any entry in
+// dropMethods, forwarding everything else to the inner notifyFunc. Used by
+// execution surfaces that need to suppress notification kinds disallowed by
+// their spec — for example, SEP-2663 forbids notifications/progress and
+// notifications/message on tasks, so the v2 task goroutine applies this filter
+// before invoking the inner tool handler.
+//
+// No-op if the context has no session, has no notifyFunc, or dropMethods is
+// empty.
+func ApplySessionNotifyFilter(ctx context.Context, dropMethods ...string) context.Context {
+	sc := sessionFromContext(ctx)
+	if sc == nil || sc.notify == nil || len(dropMethods) == 0 {
+		return ctx
+	}
+	inner := sc.notify
+	drop := make(map[string]struct{}, len(dropMethods))
+	for _, m := range dropMethods {
+		drop[m] = struct{}{}
+	}
+	return ReplaceSessionNotifyFunc(ctx, func(method string, params any) {
+		if _, blocked := drop[method]; blocked {
+			return
+		}
+		inner(method, params)
+	})
+}

--- a/core/jsonrpc.go
+++ b/core/jsonrpc.go
@@ -78,6 +78,18 @@ const (
 	// the authorization denial envelope is additive metadata in the same data
 	// object, alongside the elicitations array.
 	ErrCodeURLElicitationRequired = -32042
+
+	// ErrCodeMissingRequiredClientCapability is returned when the server
+	// cannot service a request because the client did not declare a
+	// capability the server requires for that request. The error data SHOULD
+	// carry a `requiredCapabilities` object mirroring the InitializeRequest
+	// capabilities shape so the client can self-describe what to add.
+	//
+	// Defined by SEP-2663 (Tasks Extension) for the case where a tool with
+	// TaskSupport=required is called by a client that has not declared the
+	// io.modelcontextprotocol/tasks extension. Reusable for any future
+	// extension whose required-mode path needs the same affordance.
+	ErrCodeMissingRequiredClientCapability = -32003
 )
 
 // NewResponse creates a success response for the given request ID.

--- a/docs/TASKS_V2_MIGRATION.md
+++ b/docs/TASKS_V2_MIGRATION.md
@@ -210,6 +210,34 @@ The expected flow for a deployment migrating from v1 to v2 without downtime:
 2. **Clients**: roll out the v2-aware client one cohort at a time. Each upgraded client adds `client.WithTasksExtension()` and switches to the v2 helpers.
 3. Once the v1 client population is empty, switch the server from `RegisterTasksHybrid` to `RegisterTasks` and remove the v1 sub-config.
 
+## Known behaviours after SEP-2663 merge
+
+SEP-2663 was merged Final at spec commit `c47bd846` on 2026-05-15. The merge picked up several normative clarifications that mcpkit had partially anticipated. The notes below capture how mcpkit lands against each.
+
+### G4: schema categories removed
+
+The spec dropped a set of MDX `@category` markers (`notifications/tasks/status`, `tasks`, `tasks/get`, `tasks/result`, `tasks/list`, `tasks/cancel`, `tasks/input_response`) in spec commit `304aa7bf`. These were documentation-site-only constructs and never appeared as runtime constants in mcpkit. No-op for the implementation; `tasks/input_response` in particular was a never-shipped method name.
+
+### G5: notifications/cancelled does not cancel tasks
+
+The spec clarified (commits `3f33c7d1` and `46394d21`) that `notifications/cancelled` applies to in-flight `tools/call` cancellation, not to task lifecycle. v2 task cancellation goes through `tasks/cancel` (`server/tasks_v2.go` `makeV2CancelHandler`); the existing `notifications/cancelled` handler in `server/dispatch.go` does not mutate task state. No code change required.
+
+### G6: notifications/progress and notifications/message disallowed on tasks
+
+The spec hardened (commit `2dba297b`) to: "`notifications/progress` and `notifications/message` notifications MUST NOT be sent on the `subscriptions/listen` stream for a task, and are not supported on tasks in general." mcpkit enforces this at the session-notify boundary: the v2 task goroutine wraps its background context with `core.ApplySessionNotifyFilter` (defined in `core/background.go`) so a tool that calls `ToolContext.EmitProgress` or `BaseContext.EmitLog` while running as a task silently no-ops on those two methods. Tool authors do not need to know the rule; the framework drops the emissions.
+
+### G12a: tasks/get response shapes per status
+
+The spec added (commit `b15331ef`) five status-specific MUST rules for the `tasks/get` response shape: `working` returns the Task, `input_required` includes `inputRequests`, `completed` includes `result`, `cancelled` returns the Task, `failed` includes the error. mcpkit's `makeV2GetHandler` complies for the in-process execution path. External-backed tools (the planned `TaskCallbacks.OnInputResponse` extension point) are not yet wired and will need to surface the same fields once that path lands; tracked alongside the existing v2 callbacks work.
+
+### G12b: Auth binding on every task-related request
+
+The spec added (commit `527e5c5b`) the requirement that servers MUST authenticate and authorize each task-related request. mcpkit binds at two layers: the streamable transport's session-hijack protection binds `Claims.Subject` at session creation and re-verifies on each POST/GET/DELETE; the task handlers then scope every store lookup to the requesting session via `store.Get(taskID, sessionID)` / `store.Cancel(taskID, sessionID)`. Cross-session attempts surface as "task not found" rather than leaking task existence.
+
+### G12c: required-tasks return -32003 instead of silently downgrading to sync
+
+The spec added (commit `6e4fd57c`) the requirement that a server which cannot service a request without returning `CreateTaskResult` (i.e. a tool with `TaskSupport=required`) MUST return error `-32003` (Missing Required Client Capability) with a `data.requiredCapabilities` payload, rather than silently downgrading. mcpkit's `taskV2Middleware` now evaluates `TaskSupport` before checking extension declaration; required tools called by clients that have not declared `io.modelcontextprotocol/tasks` get `-32003` with a structured payload. `TaskSupport=optional` retains the sync-fallback behaviour because the server can still service those without a task. The new error code is exported as `core.ErrCodeMissingRequiredClientCapability`.
+
 ## Reference
 
 - SEP-2663 (Tasks Extension): https://github.com/modelcontextprotocol/specification/pull/2663

--- a/server/tasks_v2.go
+++ b/server/tasks_v2.go
@@ -430,6 +430,19 @@ func taskV2Middleware(reg *Registry, rt *v2TaskRuntime, cfg TasksConfig) Middlew
 			return next(ctx, req)
 		}
 
+		// Determine effective taskSupport first. Absent Execution = forbidden.
+		// In v2 this is a server-internal hint about which tools should be
+		// async — clients no longer opt in via a `task` param.
+		effectiveSupport := core.TaskSupportForbidden
+		if def.Execution != nil {
+			effectiveSupport = def.Execution.TaskSupport
+		}
+
+		// forbidden/absent: pass through (sync), regardless of extension state.
+		if effectiveSupport == core.TaskSupportForbidden {
+			return next(ctx, req)
+		}
+
 		// SEP-2663: server MUST NOT return CreateTaskResult unless the client
 		// negotiated the io.modelcontextprotocol/tasks extension, either at
 		// session level (initialize handshake) or per-request (SEP-2575).
@@ -438,19 +451,27 @@ func taskV2Middleware(reg *Registry, rt *v2TaskRuntime, cfg TasksConfig) Middlew
 			perRequestCapsRaw = envelope.Meta.ClientCapabilitiesRaw
 		}
 		if !core.ClientSupportsExtensionForRequest(ctx, core.TasksExtensionID, perRequestCapsRaw) {
-			return next(ctx, req)
-		}
-
-		// Determine effective taskSupport. Absent Execution = forbidden.
-		// In v2 this is a server-internal hint about which tools should be
-		// async — clients no longer opt in via a `task` param.
-		effectiveSupport := core.TaskSupportForbidden
-		if def.Execution != nil {
-			effectiveSupport = def.Execution.TaskSupport
-		}
-
-		// In v2, forbidden/absent → pass through (sync).
-		if effectiveSupport == core.TaskSupportForbidden {
+			// SEP-2663 (spec commit 6e4fd57c in PR 2663): if the server cannot
+			// service the request without returning CreateTaskResult — i.e. the
+			// tool's TaskSupport is `required` — it MUST return -32003 with a
+			// machine-readable `requiredCapabilities` payload so the client can
+			// self-describe what to add. For `optional`, the server still CAN
+			// service the request without a task, so falling through to sync
+			// remains correct.
+			if effectiveSupport == core.TaskSupportRequired {
+				return core.NewErrorResponseWithData(
+					req.ID,
+					core.ErrCodeMissingRequiredClientCapability,
+					"client must declare extension "+core.TasksExtensionID,
+					map[string]any{
+						"requiredCapabilities": map[string]any{
+							"extensions": map[string]any{
+								core.TasksExtensionID: map[string]any{},
+							},
+						},
+					},
+				), nil
+			}
 			return next(ctx, req)
 		}
 
@@ -500,6 +521,15 @@ func taskV2Middleware(reg *Registry, rt *v2TaskRuntime, cfg TasksConfig) Middlew
 				progressToken: progressToken,
 			}
 			bgCtx = WithTaskContext(bgCtx, tc)
+			// SEP-2663: notifications/progress and notifications/message MUST
+			// NOT be sent on tasks. Filter at the session-notify boundary so
+			// any tool handler that calls EmitProgress or EmitLog while it
+			// happens to be running as a task silently no-ops rather than
+			// leaking onto the session stream. Spec commit 2dba297b in PR 2663.
+			bgCtx = core.ApplySessionNotifyFilter(bgCtx,
+				"notifications/progress",
+				"notifications/message",
+			)
 			rt.register(taskID, envelope.Name, &activeTask{cancel: cancelFunc, inputState: inputState})
 
 			defer func() {

--- a/server/tasks_v2_test.go
+++ b/server/tasks_v2_test.go
@@ -152,6 +152,54 @@ func TestV2_TaskCreationWithExtension(t *testing.T) {
 	}
 }
 
+// TestV2_RequiredTaskRejectsClientWithoutExtension verifies SEP-2663's
+// required-tasks error spec (spec commit 6e4fd57c in PR 2663). When a tool
+// declared with TaskSupport=required is invoked by a client that has not
+// negotiated the io.modelcontextprotocol/tasks extension, the server MUST
+// return -32003 (Missing Required Client Capability) with a structured
+// `requiredCapabilities` payload — NOT silently fall through to synchronous
+// execution. TaskSupport=optional retains the sync-fallback behaviour
+// because the server can still service those requests without a task.
+func TestV2_RequiredTaskRejectsClientWithoutExtension(t *testing.T) {
+	srv := newTaskV2Server(t)
+	c := connectV2Client(t, srv) // no WithTasksExtension
+
+	_, err := c.Call("tools/call", map[string]any{
+		"name":      "must-task",
+		"arguments": map[string]any{},
+	})
+	if err == nil {
+		t.Fatal("must-task without extension should reject with -32003, got nil error")
+	}
+	rpcErr, ok := err.(*client.RPCError)
+	if !ok {
+		t.Fatalf("expected *client.RPCError, got %T: %v", err, err)
+	}
+	if rpcErr.Code != core.ErrCodeMissingRequiredClientCapability {
+		t.Errorf("code = %d, want %d (-32003 Missing Required Client Capability)",
+			rpcErr.Code, core.ErrCodeMissingRequiredClientCapability)
+	}
+
+	// Validate the data shape: requiredCapabilities.extensions.<tasksExtensionID>.
+	// Use round-trip JSON to normalize map types regardless of decoder path.
+	raw, err := json.Marshal(rpcErr.Data)
+	if err != nil {
+		t.Fatalf("marshal error data: %v", err)
+	}
+	var data struct {
+		RequiredCapabilities struct {
+			Extensions map[string]json.RawMessage `json:"extensions"`
+		} `json:"requiredCapabilities"`
+	}
+	if err := json.Unmarshal(raw, &data); err != nil {
+		t.Fatalf("unmarshal error data: %v (raw=%s)", err, raw)
+	}
+	if _, present := data.RequiredCapabilities.Extensions[core.TasksExtensionID]; !present {
+		t.Errorf("required extension %q missing from error data; got %s",
+			core.TasksExtensionID, raw)
+	}
+}
+
 // TestV2_TasksGetRejectedWithoutExtension verifies tasks/get returns
 // -32601 (method not found) when the client has not negotiated the extension.
 func TestV2_TasksGetRejectedWithoutExtension(t *testing.T) {
@@ -999,6 +1047,93 @@ func TestV2_StatusNotificationCarriesRequestState(t *testing.T) {
 			return
 		case <-deadline:
 			t.Fatalf("timed out waiting for notifications/tasks with requestState for %s", taskID)
+		}
+	}
+}
+
+// TestV2_NoProgressOrMessageOnTaskGoroutine verifies that a tool which calls
+// EmitProgress or EmitLog while running as a task does not leak
+// notifications/progress or notifications/message onto the session stream.
+// SEP-2663 (spec commit 2dba297b in PR 2663) tightened the rule to a MUST
+// NOT, and mcpkit enforces it at the session-notify boundary by wrapping the
+// bgCtx with core.ApplySessionNotifyFilter so neither emission path reaches
+// the wire — regardless of whether the tool author remembers the rule.
+func TestV2_NoProgressOrMessageOnTaskGoroutine(t *testing.T) {
+	srv := newTaskV2Server(t)
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "progress-emit-task",
+			Description: "Emits progress + log notifications while running as a task; tests SEP-2663 G6 filter",
+			InputSchema: map[string]any{"type": "object"},
+			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
+		},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+			// Both of these would normally fan out on the session stream.
+			// The v2 task filter is expected to drop both silently.
+			ctx.EmitProgress("ignored-token", 1, 2, "halfway")
+			ctx.EmitLog(core.LogInfo, "test-logger", map[string]any{"msg": "from-task"})
+			return core.TextResult("progress-done"), nil
+		},
+	)
+
+	handler := srv.Handler(WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	// Capture every notification the client sees so we can assert the filter
+	// is comprehensive (no leakage of either method).
+	type seen struct {
+		method string
+	}
+	notifs := make(chan seen, 16)
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "v2-g6-test", Version: "0.0.1"},
+		client.WithGetSSEStream(),
+		client.WithTasksExtension(),
+		client.WithNotificationCallback(func(method string, _ any) {
+			select {
+			case notifs <- seen{method}:
+			default:
+			}
+		}),
+	)
+	if err := c.Connect(); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+
+	res, err := c.Call("tools/call", map[string]any{
+		"name":      "progress-emit-task",
+		"arguments": map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("tools/call: %v", err)
+	}
+	var ctr core.CreateTaskResult
+	if err := json.Unmarshal(res.Raw, &ctr); err != nil {
+		t.Fatalf("unmarshal CreateTaskResult: %v", err)
+	}
+
+	// Poll until terminal so the goroutine has run + emitted (and we know the
+	// filter has had its chance to drop).
+	pollV2Detailed(t, context.Background(), c, ctr.TaskID, 10*time.Millisecond, func(d core.DetailedTask) bool {
+		return d.Status.IsTerminal()
+	})
+
+	// Drain notifications with a short tail wait so any leaked emission has
+	// time to land on the SSE stream before we judge.
+	deadline := time.After(200 * time.Millisecond)
+drain:
+	for {
+		select {
+		case n := <-notifs:
+			switch n.method {
+			case "notifications/progress":
+				t.Fatalf("SEP-2663 G6 violation: notifications/progress leaked onto task stream")
+			case "notifications/message":
+				t.Fatalf("SEP-2663 G6 violation: notifications/message leaked onto task stream")
+			}
+		case <-deadline:
+			break drain
 		}
 	}
 }


### PR DESCRIPTION
## What changes

Closes the six audit gaps (G4, G5, G6, G12a, G12b, G12c) opened by the Final-merged SEP-2663 (spec commit `c47bd846`, 2026-05-15) against mcpkit's v0.2.44 baseline. Four gaps were doc-only (mcpkit already aligned); two needed small framework changes — a notification-method drop filter applied in the v2 task goroutine (G6), and a middleware reorder that returns `-32003` instead of silently downgrading required tasks to sync (G12c). v1 path is untouched.

## Reviewer's guide

Read in this order:

1. [core/background.go](https://github.com/panyam/mcpkit/pull/414/files#diff-a140d50aedc8a501fb80e6f96a6d14138fb8fccd993931552cf99b9f59a04131) — start here. New `ApplySessionNotifyFilter(ctx, dropMethods...)` helper next to the existing `ReplaceSessionNotifyFunc`. Wraps the session's notifyFunc with a method-set drop list. Generic; not tasks-specific.
2. [server/tasks_v2.go](https://github.com/panyam/mcpkit/pull/414/files#diff-95eaa1c90d414ad57bbc73e270734b6e953fce04637f0da44f31491f2386f097) — two changes in one file. (a) `taskV2Middleware` reordered so `TaskSupport` is determined before the extension declaration check, with required-tools returning `-32003` (Missing Required Client Capability) + structured `requiredCapabilities` data. (b) Inside the task goroutine, `ApplySessionNotifyFilter(bgCtx, "notifications/progress", "notifications/message")` is applied right after `WithTaskContext`.
3. [core/jsonrpc.go](https://github.com/panyam/mcpkit/pull/414/files#diff-f9f4f09be0f88717867046128a5e4338f60aaea6764fda9b9a6c95c4089797f4) — new exported constant `ErrCodeMissingRequiredClientCapability = -32003`, sibling to `ErrCodeMethodNotFound`. Reusable by any future required-capability check, not tasks-specific.
4. [server/tasks_v2_test.go](https://github.com/panyam/mcpkit/pull/414/files#diff-1e7423fe3036784ee36159dfc5ddaf1edd5850d314f27f06d20926481aa20e09) — acceptance for both code changes. `TestV2_RequiredTaskRejectsClientWithoutExtension` covers G12c (asserts code + structured data shape); `TestV2_NoProgressOrMessageOnTaskGoroutine` covers G6 (registers a tool that calls EmitProgress + EmitLog while running as a task and asserts neither notification kind reaches the client).
5. [docs/TASKS_V2_MIGRATION.md](https://github.com/panyam/mcpkit/pull/414/files#diff-240b4fc6190d28f1d6941b11fbfd87cff7b9f4ac7c8188a0f656f9a09458ba88) — new "Known behaviours after SEP-2663 merge" section with a paragraph per gap (G4/G5/G6/G12a/G12b/G12c).

Skim or skip: nothing. The PR is small enough that every file is load-bearing.

## Decision log

- Chose framework-level filter (the brief's option a) over docs-only divergence (option b) for G6 because the spec is MUST-NOT and the helper turned out to be ~15 LoC by reusing the existing `ReplaceSessionNotifyFunc` plumbing. The alternative would have pushed the rule onto tool authors.
- Reordered `taskV2Middleware` rather than adding a second pass for G12c because the existing "look up tool, then create task" structure already had a natural insertion point for the support-check, and pulling support evaluation up eliminates a now-dead branch in the forbidden path.
- Kept all v1 sites (`server/tasks_v1.go`, `server/tasks_v1_test.go`) untouched. Per CLAUDE.md, v1 is frozen and on a decommissioning path; the SEP-2663 catch-up scope is v2-only.

## Risk / blast radius

- Affects clients calling a `TaskSupport=required` tool without declaring the `io.modelcontextprotocol/tasks` extension: was silent sync execution, is now a `-32003` error. This is the intended SEP-2663 behaviour. `TaskSupport=optional` clients retain their existing sync fallback.
- Affects tools that emit `notifications/progress` or `notifications/message` while running as a v2 task: those notifications are silently dropped at the session-notify boundary. The example's `slow_compute` tool (`examples/tasks-v2/main.go`) calls `EmitProgress` and will now no-op when invoked as a task — `walkthrough.go`'s progress listener will print fewer lines, no test breakage.
- Tests covering: the two new tests above plus the unchanged `TestV2_NoTaskCreationWithoutExtension` and `TestV2_TaskCreationWithExtension` (still pass; sync/optional behaviour unchanged).
- Be paranoid about: tools that spawn their own goroutines and re-derive a notify path that bypasses the bgCtx filter. The current code path is robust against well-behaved tools (those using `ctx.EmitProgress` / `BaseContext.EmitLog`); a determined tool can still defeat it.

## Stacking

Was originally stacked on PR 412 (Phase 1 — `notifications/tasks/status` rename). Since 412 has merged into `main`, GitHub auto-retargeted this PR's base to `main`. The diff is now Phase 2 work only (single commit).

## Out of scope (deferred)

- Phase 3 — remove `RequestState` from the tasks-v2 wire while preserving MRTR's signing infra. Tracked in the SEP-2663 catch-up plan, follows once this PR merges.
- Phase 4 — `docs/TASKS_V2_MIGRATION.md` top-of-file "Status: draft" callout rewrite for Final-merged framing. Rides along with the Phase 3 PR.
- External-backed `TaskCallbacks.OnInputResponse` path (relevant to G12a's `input_required` response shape for non-in-process tools). Deferred until that callback lands.
- Move v2 tasks implementation from `server/` to a new `ext/tasks/` sub-module. Tracked in `panyam/mcpkit` issue 413 — follows the SEP-2663 catch-up.

## Test plan

- [x] `go test ./server/...` green locally (13.2s)
- [x] `go test ./core/...` green locally (0.6s)
- [x] `go build ./...` clean
- [ ] CI green
