### PR TITLE
fix(conformance): add --serve to testconf-tasks Makefile target

### DIFF
--- a/conformance/Makefile
+++ b/conformance/Makefile
@@ -45,7 +45,7 @@ testconfauth: ## Run MCP Auth conformance suite (client-side, requires mcpkit/au
 
 testconf-tasks: ## Run MCP Tasks v1 conformance (builds + starts server, runs tests, tears down)
 	@(cd $(REPO_ROOT)/examples/tasks && go build -o tasks .) && \
-	$(REPO_ROOT)/examples/tasks/tasks -addr :18091 & PID=$$!; \
+	$(REPO_ROOT)/examples/tasks/tasks --serve -addr :18091 & PID=$$!; \
 	sleep 1; \
 	(cd $(CONFORMANCE_DIR) && npm install --silent && \
 	SERVER_URL=http://localhost:18091/mcp npx tsx --test tasks/scenarios.test.ts); \


### PR DESCRIPTION
## What changes

Restores `make testconf-tasks` (v1 conformance, 27 scenarios). It has been silently failing with `ECONNREFUSED ::1:18091` since commit df63906 migrated `examples/tasks/` to the demokit walkthrough+serve pattern. Without `--serve`, the example binary prints the walkthrough and exits before binding any port; the conformance test client connects 1s later and gets no listener. Adding `--serve` matches the pattern the sibling target `testconf-tasks-v2` already uses.

## Reviewer's guide

Only one file:

1. [conformance/Makefile](https://github.com/panyam/mcpkit/pull/416/files#diff-53e691e18159f1d2d88ea4a327f2f87d567e5b2365d94006d152c4de9ad4f084) — adds `--serve` to the v1 example launch line. Compare against `testconf-tasks-v2` (immediately below) which already does this for the v2 example.

## Decision log

- Kept the `-addr :18091` flag verbatim. The example accepts both standard Go flags and demokit-filtered flags; the test addr stays where it was.
- Did not touch sibling targets — `testconf-tasks-v2`, `testconf-mrtr`, `testconf-list-ttl`, `testconf-file-inputs`, `testconf-auth-server` already pass `--serve` (or use a fork-side `SERVER_CMD` that includes it).

## Risk / blast radius

- Affects only `make testconf-tasks` and any aggregate target that runs it (`make testall` stage 8c, `make testconfall`).
- Verified locally: 27/27 v1 conformance scenarios pass with this change.
- Reverts behaviour to what we had pre-df63906; no new code paths.

## Out of scope

- The intermittent 2m timeout in stage 1 (unit+coverage) of `make testall` is a separate issue, filed as `panyam/mcpkit` issue 415. Not reproducible in isolation; this PR does not address it.

## Test plan

- [x] `make testconf-tasks` green locally (27/27 scenarios pass)
- [ ] CI green
