### PR TITLE
feat(tasks_v2): remove requestState from the tasks-v2 wire

### DIFF
--- a/client/tasks.go
+++ b/client/tasks.go
@@ -11,10 +11,9 @@ package client
 //   - tasks/update is the new resume path for MRTR input rounds.
 //   - tasks/cancel returns an empty ack.
 //   - WaitForTask polls tasks/get and honors the server's PollIntervalMs
-//     hint, automatically echoing requestState. Per SEP-2663 (commit a1ed0703)
-//     a caller that has issued tasks/cancel may abort the poll loop without
-//     waiting for "cancelled" status to surface; cancel the ctx passed to
-//     WaitForTask and it returns context.Canceled.
+//     hint. Per SEP-2663 a caller that has issued tasks/cancel may abort
+//     the poll loop without waiting for "cancelled" status to surface;
+//     cancel the ctx passed to WaitForTask and it returns context.Canceled.
 
 import (
 	"context"
@@ -27,29 +26,12 @@ import (
 
 // --- Public option types ---
 
-// TaskOptions configures a single tasks/get or tasks/cancel call.
-// The zero value sends no requestState; pass an explicit value to echo a
-// requestState the server returned on a previous response (SEP-2322 stateless
-// deployments). Polling helpers (WaitForTask) thread requestState
-// automatically and don't require callers to pass it manually.
-type TaskOptions struct {
-	// RequestState is the opaque session-continuation token the server
-	// returned on the most recent DetailedTask. Echoed verbatim — clients
-	// MUST treat it as opaque.
-	RequestState string
-}
-
 // WaitOptions configures WaitForTask.
 type WaitOptions struct {
 	// PollInterval overrides the server's PollIntervalMs hint.
 	// 0 (the default) means: respect whatever the server returned, with a
 	// 1-second floor and a 30-second cap if the server didn't say.
 	PollInterval time.Duration
-
-	// RequestState seeds the echo loop. When the server returns an updated
-	// requestState in a poll response, WaitForTask switches to using it on
-	// the next call.
-	RequestState string
 }
 
 // ToolCallResult is the discriminated union returned by ToolCall. Exactly
@@ -71,7 +53,8 @@ type ToolCallResult struct {
 	// themselves (resolve inputRequests, retry tools/call with
 	// inputResponses + requestState); CallToolWithInputs handles the
 	// loop automatically. Renamed from Incomplete in lockstep with
-	// SEP-2322 commit de6d76fb (merged 2026-05-06).
+	// SEP-2322. The `requestState` echo on retry remains valid for the
+	// MRTR surface even though the tasks-v2 wire no longer carries it.
 	InputRequired *core.InputRequiredResult
 }
 
@@ -89,13 +72,11 @@ func (r *ToolCallResult) IsInputRequired() bool {
 // --- Wire-format params ---
 
 type tasksGetParams struct {
-	TaskID       string `json:"taskId"`
-	RequestState string `json:"requestState,omitempty"`
+	TaskID string `json:"taskId"`
 }
 
 type tasksCancelParams struct {
-	TaskID       string `json:"taskId"`
-	RequestState string `json:"requestState,omitempty"`
+	TaskID string `json:"taskId"`
 }
 
 // --- Polymorphic tools/call ---
@@ -154,15 +135,11 @@ func parseToolCallResult(raw json.RawMessage) (*ToolCallResult, error) {
 // --- tasks/get / tasks/update / tasks/cancel ---
 
 // GetTask fetches the current state of a v2 task as a DetailedTask, with
-// inlined result / error / inputRequests / requestState depending on status.
-// Idempotent — safe to call as often as needed; servers gate this method on
-// the io.modelcontextprotocol/tasks extension being negotiated.
-func GetTask(c *Client, taskID string, opts ...TaskOptions) (*core.DetailedTask, error) {
-	params := tasksGetParams{TaskID: taskID}
-	if len(opts) > 0 {
-		params.RequestState = opts[0].RequestState
-	}
-	resp, err := c.Call("tasks/get", params)
+// inlined result / error / inputRequests depending on status. Idempotent —
+// safe to call as often as needed; servers gate this method on the
+// io.modelcontextprotocol/tasks extension being negotiated.
+func GetTask(c *Client, taskID string) (*core.DetailedTask, error) {
+	resp, err := c.Call("tasks/get", tasksGetParams{TaskID: taskID})
 	if err != nil {
 		return nil, err
 	}
@@ -194,12 +171,8 @@ func UpdateTask(c *Client, req core.UpdateTaskRequest) error {
 // CancelTask cancels a running task. Returns nil on success — the server
 // response is an empty ack per SEP-2663 (no task state). Issue GetTask if
 // you need to observe the resulting "cancelled" status.
-func CancelTask(c *Client, taskID string, opts ...TaskOptions) error {
-	params := tasksCancelParams{TaskID: taskID}
-	if len(opts) > 0 {
-		params.RequestState = opts[0].RequestState
-	}
-	if _, err := c.Call("tasks/cancel", params); err != nil {
+func CancelTask(c *Client, taskID string) error {
+	if _, err := c.Call("tasks/cancel", tasksCancelParams{TaskID: taskID}); err != nil {
 		return err
 	}
 	return nil
@@ -224,32 +197,29 @@ const (
 //   - else the server's PollIntervalMs on the most recent response,
 //   - else the 1-second default.
 //
-// requestState is threaded automatically: each poll echoes the requestState
-// the server returned on the previous response. Returns the final
-// DetailedTask snapshot (which inlines the result / error / inputRequests
-// per SEP-2663). Note that input_required is NOT terminal — callers wanting
-// to handle the MRTR resume should poll until terminal or use a tighter
-// loop that checks for input_required and calls UpdateTask in between.
+// Returns the final DetailedTask snapshot (which inlines the result / error
+// / inputRequests per SEP-2663). Note that input_required is NOT terminal —
+// callers wanting to handle the MRTR resume should poll until terminal or
+// use a tighter loop that checks for input_required and calls UpdateTask in
+// between.
 //
-// Cancel-poll abort (SEP-2663 commit a1ed0703): a caller that issues
-// tasks/cancel may stop polling immediately without waiting for the server
-// to surface "cancelled" status. The recommended pattern is to derive a
-// child context for the wait and cancel it after CancelTask returns:
+// Cancel-poll abort (SEP-2663): a caller that issues tasks/cancel may stop
+// polling immediately without waiting for the server to surface "cancelled"
+// status. The recommended pattern is to derive a child context for the wait
+// and cancel it after CancelTask returns:
 //
 //	pollCtx, stopPoll := context.WithCancel(ctx)
 //	defer stopPoll()
 //	go func() {
 //	    <-userCancelSignal
-//	    client.CancelTask(ctx, taskID, nil)
+//	    client.CancelTask(c, taskID)
 //	    stopPoll()
 //	}()
 //	dt, err := client.WaitForTask(pollCtx, taskID)  // err == context.Canceled on abort
 func WaitForTask(ctx context.Context, c *Client, taskID string, opts ...WaitOptions) (*core.DetailedTask, error) {
 	var override time.Duration
-	state := ""
 	if len(opts) > 0 {
 		override = opts[0].PollInterval
-		state = opts[0].RequestState
 	}
 
 	for {
@@ -262,15 +232,12 @@ func WaitForTask(ctx context.Context, c *Client, taskID string, opts ...WaitOpti
 		default:
 		}
 
-		dt, err := GetTask(c, taskID, TaskOptions{RequestState: state})
+		dt, err := GetTask(c, taskID)
 		if err != nil {
 			return nil, err
 		}
 		if dt.Status.IsTerminal() {
 			return dt, nil
-		}
-		if dt.RequestState != "" {
-			state = dt.RequestState
 		}
 
 		wait := nextPollWait(override, dt.PollIntervalMs)

--- a/client/tasks_test.go
+++ b/client/tasks_test.go
@@ -160,9 +160,9 @@ func TestToolCall_TaskResult(t *testing.T) {
 
 // --- GetTask ---
 
-// TestGetTask returns DetailedTask with the v2 wire shape (TaskInfoV2 fields,
-// requestState present). Status may be working or already terminal — both
-// are valid as long as the shape decodes.
+// TestGetTask returns DetailedTask with the v2 wire shape (TaskInfoV2 fields).
+// Status may be working or already terminal — both are valid as long as the
+// shape decodes.
 func TestGetTask(t *testing.T) {
 	url, _ := newTaskV2TestServer(t)
 	c := connectV2TaskClient(t, url)
@@ -179,9 +179,6 @@ func TestGetTask(t *testing.T) {
 	}
 	if dt.TaskID != taskID {
 		t.Errorf("TaskID = %q, want %q", dt.TaskID, taskID)
-	}
-	if dt.RequestState == "" {
-		t.Errorf("expected non-empty requestState (server should emit one)")
 	}
 }
 
@@ -378,7 +375,6 @@ func TestUpdateTask_FullElicitLoop(t *testing.T) {
 		InputResponses: core.InputResponses{
 			key: json.RawMessage(`{"action":"accept","content":{"confirm":true}}`),
 		},
-		RequestState: pending.RequestState,
 	}); err != nil {
 		t.Fatalf("UpdateTask: %v", err)
 	}

--- a/core/task_v2.go
+++ b/core/task_v2.go
@@ -127,10 +127,6 @@ type CreateTaskResult struct {
 //   - completed        → Result populated
 //   - failed           → Error populated
 //   - cancelled        → no inlined payload
-//
-// RequestState is opaque session-continuation state for stateless deployments;
-// servers MAY include it on any status, clients MUST echo it back on the
-// next tasks/get / tasks/update / tasks/cancel for the same task. // SEP-2322
 type DetailedTask struct {
 	// ResultType is the SEP-2322 polymorphic-dispatch discriminator. For
 	// tasks/get responses it is always "complete" — the JSON-RPC request
@@ -153,9 +149,6 @@ type DetailedTask struct {
 	// InputRequests is populated when Status == TaskInputRequired and lists
 	// the MRTR input requests the client must satisfy via tasks/update. // SEP-2322
 	InputRequests InputRequests `json:"inputRequests,omitempty"`
-
-	// RequestState is the opaque session-continuation token. // SEP-2322
-	RequestState string `json:"requestState,omitempty"`
 }
 
 // MarshalJSON defaults ResultType to ResultTypeComplete when empty so every
@@ -193,11 +186,10 @@ type TaskError struct {
 
 // UpdateTaskRequest is the params payload for tasks/update — the MRTR-driven
 // resume path. The client supplies InputResponses keyed by the same ids
-// returned in DetailedTask.InputRequests, optionally echoing RequestState. // SEP-2663
+// returned in DetailedTask.InputRequests. // SEP-2663
 type UpdateTaskRequest struct {
 	TaskID         string         `json:"taskId"`
 	InputResponses InputResponses `json:"inputResponses,omitempty"`
-	RequestState   string         `json:"requestState,omitempty"` // SEP-2322
 }
 
 // UpdateTaskResult is the (essentially empty) ack returned by tasks/update.
@@ -290,16 +282,24 @@ func (r InputRequiredResult) MarshalJSON() ([]byte, error) {
 	return json.Marshal(alias(r))
 }
 
-// --- SEP-2322 requestState signing ---
+// --- MRTR requestState signing ---
 //
-// SEP-2663 says servers MUST treat requestState as attacker-controlled. The
-// helpers below implement an HMAC-SHA256-signed encoding so a server that
-// minted a token can verify the same token came back unmodified, with no
-// per-task state on the server side (stateless deployments).
+// SEP-2322's InputRequiredResult.RequestState carries an opaque token from
+// server to client which the client MUST echo on subsequent requests. The
+// helpers below implement an HMAC-SHA256-signed encoding so a stateless
+// server can verify the token came back unmodified, plus a plaintext mode
+// for deployments without a signing key.
 //
-// Wire format: "<base64url-signature>.<base64url-payload>" where payload is
-// the JSON encoding of requestStatePayload {taskId, exp}. base64url is
-// chosen to keep the token URL/header-safe without escaping.
+// Wire format (signed): "<base64url-signature>.<base64url-payload>" where
+// payload is the JSON encoding of MRTRRoundState {tool, answered, exp}.
+// base64url is chosen to keep the token URL/header-safe without escaping.
+//
+// SignRequestState / VerifyRequestState use the older requestStatePayload
+// {taskId, exp} shape. SEP-2663 removed `requestState` from the tasks-v2
+// wire, so the tasks-v2 paths no longer call them. They are retained
+// because server/mrtr.go reads legacy single-round tokens with this shape
+// for backward compatibility; that shim is removable once all in-flight
+// rounds have rotated past.
 
 // ErrRequestStateMalformed indicates the encoded requestState couldn't be
 // parsed (missing separator, bad base64, bad JSON inside the payload).
@@ -313,7 +313,8 @@ var ErrRequestStateInvalidSignature = errors.New("requestState signature invalid
 var ErrRequestStateExpired = errors.New("requestState expired")
 
 // requestStatePayload is the JSON body wrapped inside a signed
-// requestState token. Compact (two fields) so the encoded form stays small.
+// requestState token (legacy single-round MRTR shape). Compact (two
+// fields) so the encoded form stays small.
 type requestStatePayload struct {
 	TaskID string `json:"taskId"`
 	Exp    int64  `json:"exp"` // unix seconds
@@ -321,13 +322,12 @@ type requestStatePayload struct {
 
 // SignRequestState produces an HMAC-SHA256-signed requestState token for
 // the given taskID, valid for ttl. The encoded form is opaque to clients
-// and round-trippable via VerifyRequestState. Panics if key is empty —
-// callers MUST check before invoking (see v2TaskRuntime.makeRequestState
-// which falls back to plaintext when the key is unset).
+// and round-trippable via VerifyRequestState. Panics if key is empty.
+//
+// Retained for backward-compat with legacy MRTR tokens; see the section
+// banner above.
 func SignRequestState(key []byte, taskID string, ttl time.Duration) string {
 	if len(key) == 0 {
-		// Indicates a programming error — the runtime should fall back to
-		// plain taskID in legacy mode rather than calling Sign with no key.
 		panic("core.SignRequestState: empty key")
 	}
 	payload := requestStatePayload{
@@ -336,7 +336,6 @@ func SignRequestState(key []byte, taskID string, ttl time.Duration) string {
 	}
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
-		// json.Marshal of a tiny struct can't realistically fail.
 		panic(fmt.Sprintf("core.SignRequestState: marshal payload: %v", err))
 	}
 	mac := hmac.New(sha256.New, key)
@@ -344,6 +343,47 @@ func SignRequestState(key []byte, taskID string, ttl time.Duration) string {
 	sig := mac.Sum(nil)
 	return base64.RawURLEncoding.EncodeToString(sig) + "." +
 		base64.RawURLEncoding.EncodeToString(payloadBytes)
+}
+
+// VerifyRequestState checks an incoming requestState token against the
+// signing key and current time. Returns the embedded taskID on success.
+// Errors:
+//   - ErrRequestStateMalformed: structural parse failures (split, base64, JSON)
+//   - ErrRequestStateInvalidSignature: signature mismatch (tampered or wrong key)
+//   - ErrRequestStateExpired: payload exp is in the past
+//
+// Uses hmac.Equal for constant-time signature comparison. Retained for
+// backward-compat with legacy MRTR tokens; see the section banner above.
+func VerifyRequestState(key []byte, state string) (taskID string, err error) {
+	if len(key) == 0 {
+		return "", ErrRequestStateMalformed
+	}
+	dot := strings.IndexByte(state, '.')
+	if dot < 0 {
+		return "", ErrRequestStateMalformed
+	}
+	sig, err := base64.RawURLEncoding.DecodeString(state[:dot])
+	if err != nil {
+		return "", ErrRequestStateMalformed
+	}
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(state[dot+1:])
+	if err != nil {
+		return "", ErrRequestStateMalformed
+	}
+	mac := hmac.New(sha256.New, key)
+	mac.Write(payloadBytes)
+	expected := mac.Sum(nil)
+	if !hmac.Equal(sig, expected) {
+		return "", ErrRequestStateInvalidSignature
+	}
+	var payload requestStatePayload
+	if err := json.Unmarshal(payloadBytes, &payload); err != nil {
+		return "", ErrRequestStateMalformed
+	}
+	if payload.Exp > 0 && time.Now().Unix() > payload.Exp {
+		return "", ErrRequestStateExpired
+	}
+	return payload.TaskID, nil
 }
 
 // MRTRRoundState is the payload encoded inside an SEP-2322 ephemeral
@@ -460,42 +500,3 @@ func DecodeMRTRStatePlaintext(token string) (MRTRRoundState, error) {
 	return state, nil
 }
 
-// VerifyRequestState checks an incoming requestState token against the
-// signing key and current time. Returns the embedded taskID on success.
-// Errors:
-//   - ErrRequestStateMalformed: structural parse failures (split, base64, JSON)
-//   - ErrRequestStateInvalidSignature: signature mismatch (tampered or wrong key)
-//   - ErrRequestStateExpired: payload exp is in the past
-//
-// Uses hmac.Equal for constant-time signature comparison.
-func VerifyRequestState(key []byte, state string) (taskID string, err error) {
-	if len(key) == 0 {
-		return "", ErrRequestStateMalformed
-	}
-	dot := strings.IndexByte(state, '.')
-	if dot < 0 {
-		return "", ErrRequestStateMalformed
-	}
-	sig, err := base64.RawURLEncoding.DecodeString(state[:dot])
-	if err != nil {
-		return "", ErrRequestStateMalformed
-	}
-	payloadBytes, err := base64.RawURLEncoding.DecodeString(state[dot+1:])
-	if err != nil {
-		return "", ErrRequestStateMalformed
-	}
-	mac := hmac.New(sha256.New, key)
-	mac.Write(payloadBytes)
-	expected := mac.Sum(nil)
-	if !hmac.Equal(sig, expected) {
-		return "", ErrRequestStateInvalidSignature
-	}
-	var payload requestStatePayload
-	if err := json.Unmarshal(payloadBytes, &payload); err != nil {
-		return "", ErrRequestStateMalformed
-	}
-	if payload.Exp > 0 && time.Now().Unix() > payload.Exp {
-		return "", ErrRequestStateExpired
-	}
-	return payload.TaskID, nil
-}

--- a/core/task_v2_test.go
+++ b/core/task_v2_test.go
@@ -170,7 +170,6 @@ func TestDetailedTaskInputRequestsTyped(t *testing.T) {
 				Params: json.RawMessage(`{"message":"Proceed?"}`),
 			},
 		},
-		RequestState: "opaque-state-token",
 	}
 	data, err := json.Marshal(res)
 	if err != nil {
@@ -192,9 +191,6 @@ func TestDetailedTaskInputRequestsTyped(t *testing.T) {
 	if entry["method"] != "elicitation/create" {
 		t.Errorf("inputRequests[elicit-1].method = %v, want elicitation/create", entry["method"])
 	}
-	if m["requestState"] != "opaque-state-token" {
-		t.Errorf("requestState = %v, want opaque-state-token", m["requestState"])
-	}
 
 	// Typed round-trip preserves InputRequest.Method through GetTaskResult,
 	// which is an alias for DetailedTask.
@@ -207,9 +203,11 @@ func TestDetailedTaskInputRequestsTyped(t *testing.T) {
 	}
 }
 
-// TestDetailedTaskRequestStateOmitEmpty verifies that RequestState is omitted
-// when empty on DetailedTask (it's optional per SEP-2322).
-func TestDetailedTaskRequestStateOmitEmpty(t *testing.T) {
+// TestDetailedTaskNoRequestState verifies that DetailedTask never emits a
+// `requestState` JSON field — the merged SEP-2663 removed the field from
+// the tasks-v2 wire entirely. (MRTR's InputRequiredResult.RequestState
+// remains on a different surface; see TestInputRequiredResult below.)
+func TestDetailedTaskNoRequestState(t *testing.T) {
 	res := DetailedTask{
 		TaskInfoV2: TaskInfoV2{
 			TaskID: "t1", Status: TaskWorking,
@@ -221,7 +219,7 @@ func TestDetailedTaskRequestStateOmitEmpty(t *testing.T) {
 	var m map[string]any
 	json.Unmarshal(data, &m)
 	if _, ok := m["requestState"]; ok {
-		t.Errorf("DetailedTask: requestState should be omitted when empty; got %s", data)
+		t.Errorf("DetailedTask: requestState MUST NOT appear on the tasks-v2 wire; got %s", data)
 	}
 }
 
@@ -416,15 +414,14 @@ func TestDetailedTaskFailedShape(t *testing.T) {
 }
 
 // TestUpdateTaskRequestWireShape verifies the SEP-2663 tasks/update params:
-// {taskId, inputResponses, requestState}. inputResponses preserves opaque
-// per-key payloads (json.RawMessage).
+// {taskId, inputResponses}. inputResponses preserves opaque per-key payloads
+// (json.RawMessage). The merged spec removed requestState from this shape.
 func TestUpdateTaskRequestWireShape(t *testing.T) {
 	req := UpdateTaskRequest{
 		TaskID: "task-xyz",
 		InputResponses: InputResponses{
 			"elicit-1": json.RawMessage(`{"action":"accept","content":{"ok":true}}`),
 		},
-		RequestState: "state-1",
 	}
 	data, err := json.Marshal(req)
 	if err != nil {
@@ -436,8 +433,8 @@ func TestUpdateTaskRequestWireShape(t *testing.T) {
 	if m["taskId"] != "task-xyz" {
 		t.Errorf("taskId = %v, want task-xyz", m["taskId"])
 	}
-	if m["requestState"] != "state-1" {
-		t.Errorf("requestState = %v, want state-1", m["requestState"])
+	if _, ok := m["requestState"]; ok {
+		t.Errorf("requestState MUST NOT appear on UpdateTaskRequest (removed by merged SEP-2663); got %s", data)
 	}
 	resps, ok := m["inputResponses"].(map[string]any)
 	if !ok {
@@ -464,17 +461,15 @@ func TestUpdateTaskRequestWireShape(t *testing.T) {
 	}
 }
 
-// TestUpdateTaskRequestOmitEmpty verifies that inputResponses and requestState
-// are omitted when empty/zero (only taskId is required).
+// TestUpdateTaskRequestOmitEmpty verifies that inputResponses is omitted
+// when empty (only taskId is required).
 func TestUpdateTaskRequestOmitEmpty(t *testing.T) {
 	req := UpdateTaskRequest{TaskID: "t1"}
 	data, _ := json.Marshal(req)
 	var m map[string]any
 	json.Unmarshal(data, &m)
-	for _, absent := range []string{"inputResponses", "requestState"} {
-		if _, ok := m[absent]; ok {
-			t.Errorf("%q should be omitted when empty; got %s", absent, data)
-		}
+	if _, ok := m["inputResponses"]; ok {
+		t.Errorf("inputResponses should be omitted when empty; got %s", data)
 	}
 }
 

--- a/docs/TASKS_V2_MIGRATION.md
+++ b/docs/TASKS_V2_MIGRATION.md
@@ -214,29 +214,35 @@ The expected flow for a deployment migrating from v1 to v2 without downtime:
 
 SEP-2663 was merged Final at spec commit `c47bd846` on 2026-05-15. The merge picked up several normative clarifications that mcpkit had partially anticipated. The notes below capture how mcpkit lands against each.
 
-### G4: schema categories removed
+### Schema categories removed (doc-site only)
 
 The spec dropped a set of MDX `@category` markers (`notifications/tasks/status`, `tasks`, `tasks/get`, `tasks/result`, `tasks/list`, `tasks/cancel`, `tasks/input_response`) in spec commit `304aa7bf`. These were documentation-site-only constructs and never appeared as runtime constants in mcpkit. No-op for the implementation; `tasks/input_response` in particular was a never-shipped method name.
 
-### G5: notifications/cancelled does not cancel tasks
+### notifications/cancelled does not cancel tasks
 
 The spec clarified (commits `3f33c7d1` and `46394d21`) that `notifications/cancelled` applies to in-flight `tools/call` cancellation, not to task lifecycle. v2 task cancellation goes through `tasks/cancel` (`server/tasks_v2.go` `makeV2CancelHandler`); the existing `notifications/cancelled` handler in `server/dispatch.go` does not mutate task state. No code change required.
 
-### G6: notifications/progress and notifications/message disallowed on tasks
+### notifications/progress and notifications/message disallowed on tasks
 
 The spec hardened (commit `2dba297b`) to: "`notifications/progress` and `notifications/message` notifications MUST NOT be sent on the `subscriptions/listen` stream for a task, and are not supported on tasks in general." mcpkit enforces this at the session-notify boundary: the v2 task goroutine wraps its background context with `core.ApplySessionNotifyFilter` (defined in `core/background.go`) so a tool that calls `ToolContext.EmitProgress` or `BaseContext.EmitLog` while running as a task silently no-ops on those two methods. Tool authors do not need to know the rule; the framework drops the emissions.
 
-### G12a: tasks/get response shapes per status
+### tasks/get response shapes per status
 
 The spec added (commit `b15331ef`) five status-specific MUST rules for the `tasks/get` response shape: `working` returns the Task, `input_required` includes `inputRequests`, `completed` includes `result`, `cancelled` returns the Task, `failed` includes the error. mcpkit's `makeV2GetHandler` complies for the in-process execution path. External-backed tools (the planned `TaskCallbacks.OnInputResponse` extension point) are not yet wired and will need to surface the same fields once that path lands; tracked alongside the existing v2 callbacks work.
 
-### G12b: Auth binding on every task-related request
+### Auth binding on every task-related request
 
 The spec added (commit `527e5c5b`) the requirement that servers MUST authenticate and authorize each task-related request. mcpkit binds at two layers: the streamable transport's session-hijack protection binds `Claims.Subject` at session creation and re-verifies on each POST/GET/DELETE; the task handlers then scope every store lookup to the requesting session via `store.Get(taskID, sessionID)` / `store.Cancel(taskID, sessionID)`. Cross-session attempts surface as "task not found" rather than leaking task existence.
 
-### G12c: required-tasks return -32003 instead of silently downgrading to sync
+### Required-tasks return -32003 instead of silently downgrading to sync
 
-The spec added (commit `6e4fd57c`) the requirement that a server which cannot service a request without returning `CreateTaskResult` (i.e. a tool with `TaskSupport=required`) MUST return error `-32003` (Missing Required Client Capability) with a `data.requiredCapabilities` payload, rather than silently downgrading. mcpkit's `taskV2Middleware` now evaluates `TaskSupport` before checking extension declaration; required tools called by clients that have not declared `io.modelcontextprotocol/tasks` get `-32003` with a structured payload. `TaskSupport=optional` retains the sync-fallback behaviour because the server can still service those without a task. The new error code is exported as `core.ErrCodeMissingRequiredClientCapability`.
+The spec added the requirement that a server which cannot service a request without returning `CreateTaskResult` (i.e. a tool with `TaskSupport=required`) MUST return error `-32003` (Missing Required Client Capability) with a `data.requiredCapabilities` payload, rather than silently downgrading. mcpkit's `taskV2Middleware` now evaluates `TaskSupport` before checking extension declaration; required tools called by clients that have not declared `io.modelcontextprotocol/tasks` get `-32003` with a structured payload. `TaskSupport=optional` retains the sync-fallback behaviour because the server can still service those without a task. The new error code is exported as `core.ErrCodeMissingRequiredClientCapability`.
+
+### requestState removed from the tasks-v2 wire
+
+The merged SEP-2663 dropped the `requestState?: string` field from the `Task` base interface and removed the entire "Request State Management" section. mcpkit's `core.DetailedTask`, `core.UpdateTaskRequest`, `tasks/get` inline param struct, and `tasks/cancel` inline param struct no longer carry the field; the runtime helpers (`v2TaskRuntime.makeRequestState` / `verifyRequestState`) and per-registration signing config (`TasksConfig.RequestStateKey` / `RequestStateTTL`) are removed. The client surface drops `TaskOptions.RequestState`; `client.GetTask` and `client.CancelTask` simplify to `(c, taskID)` signatures, and `WaitForTask` no longer threads requestState through its poll loop.
+
+SEP-2322's `core.InputRequiredResult.RequestState` (the MRTR multi-round-trip surface) is unchanged. The server-wide `WithRequestStateSigning` option stays — MRTR's dispatcher still uses it via `s.dispatcher.mrtr` for signing the MRTR round state. The `core.SignRequestState` / `core.VerifyRequestState` helpers are retained because `server/mrtr.go` reads legacy single-round MRTR tokens with the older payload shape for backward compatibility; that shim is removable once in-flight rounds rotate past.
 
 ## Reference
 

--- a/examples/tasks-v2/walkthrough.go
+++ b/examples/tasks-v2/walkthrough.go
@@ -254,7 +254,6 @@ func runDemo() {
 				InputResponses: core.InputResponses{
 					key: json.RawMessage(`{"action":"accept","content":{"confirm":true}}`),
 				},
-				RequestState: pending.RequestState,
 			}); err != nil {
 				fmt.Printf("    ERROR tasks/update: %v\n", err)
 				return

--- a/server/mrtr_test.go
+++ b/server/mrtr_test.go
@@ -432,67 +432,6 @@ func TestMRTR_TaskComposition_Skipped(t *testing.T) {
 	}
 }
 
-// TestRequestStateSigning_SharedByMRTRAndTasks verifies that a server-wide
-// WithRequestStateSigning is inherited by RegisterTasks when
-// TasksConfig.RequestStateKey is left unset — production deployments
-// should configure the HMAC key once and have BOTH ephemeral MRTR and
-// SEP-2663 task requestStates signed with the same secret.
-func TestRequestStateSigning_SharedByMRTRAndTasks(t *testing.T) {
-	signingKey := []byte("shared-signing-key")
-
-	srv := NewServer(
-		core.ServerInfo{Name: "mrtr-shared-key", Version: "0.0.1"},
-		WithRequestStateSigning(signingKey, time.Hour),
-	)
-	srv.RegisterTool(
-		core.ToolDef{
-			Name:        "fast-task",
-			Description: "Async-eligible, completes immediately",
-			InputSchema: map[string]any{"type": "object"},
-			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
-		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
-			return core.TextResult("done"), nil
-		},
-	)
-	// No RequestStateKey on the TasksConfig — should inherit from server-wide.
-	RegisterTasks(TasksConfig{Server: srv})
-
-	c := connectMRTRClient(t, srv, client.WithTasksExtension())
-
-	// Drive task creation and pull tasks/get to inspect the requestState
-	// the server minted; if inheritance worked, it's HMAC-signed (sig.payload),
-	// otherwise it's the legacy plaintext taskID.
-	res, err := c.Call("tools/call", map[string]any{
-		"name":      "fast-task",
-		"arguments": map[string]any{},
-	})
-	if err != nil {
-		t.Fatalf("tools/call: %v", err)
-	}
-	var ctr core.CreateTaskResult
-	if err := json.Unmarshal(res.Raw, &ctr); err != nil {
-		t.Fatalf("unmarshal CreateTaskResult: %v", err)
-	}
-	getRes, err := c.Call("tasks/get", map[string]any{"taskId": ctr.TaskID})
-	if err != nil {
-		t.Fatalf("tasks/get: %v", err)
-	}
-	var dt core.DetailedTask
-	json.Unmarshal(getRes.Raw, &dt)
-	if dt.RequestState == "" {
-		t.Fatal("DetailedTask.requestState empty; expected signed token")
-	}
-	if !strings.Contains(dt.RequestState, ".") {
-		t.Errorf("DetailedTask.requestState = %q, want sig.payload form (server-wide signing didn't reach tasks)", dt.RequestState)
-	}
-
-	// And the same key must verify the token end-to-end via the public helper.
-	if _, err := core.VerifyRequestState(signingKey, dt.RequestState); err != nil {
-		t.Errorf("VerifyRequestState: %v (token=%q)", err, dt.RequestState)
-	}
-}
-
 // connectMRTRClient is a one-off helper for MRTR tests — most existing v2
 // fixtures register a full tasks setup we don't need here.
 func connectMRTRClient(t *testing.T, srv *Server, opts ...client.ClientOption) *client.Client {

--- a/server/tasks_v2.go
+++ b/server/tasks_v2.go
@@ -26,23 +26,6 @@ type TasksConfig struct {
 	// DefaultPollMs is the suggested poll interval in milliseconds,
 	// returned to clients in CreateTaskResult as pollIntervalMs. Default: 1000 (1 second).
 	DefaultPollMs int
-
-	// RequestStateKey is the HMAC-SHA256 key the server uses to sign and
-	// verify SEP-2322 requestState tokens. When non-nil, requestState is
-	// returned as `<base64url-hmac>.<base64url-payload>` where the payload
-	// is JSON {"taskId":"...", "exp":<unix-seconds>} — clients echo it
-	// verbatim and the server rejects tampered or expired tokens with
-	// -32602 on tasks/get / tasks/update / tasks/cancel.
-	//
-	// SEP-2663 says servers MUST treat requestState as attacker-controlled.
-	// Production deployments SHOULD set this. nil = legacy plaintext mode
-	// (requestState == taskID), kept for backward compat with existing
-	// tests and minimal-config setups.
-	RequestStateKey []byte
-
-	// RequestStateTTL is how long a signed requestState stays valid. When
-	// 0, defaults to 24h. Has no effect when RequestStateKey is nil.
-	RequestStateTTL time.Duration
 }
 
 func (c *TasksConfig) defaults() {
@@ -55,9 +38,6 @@ func (c *TasksConfig) defaults() {
 	if c.DefaultPollMs <= 0 {
 		c.DefaultPollMs = 1000
 	}
-	if c.RequestStateTTL <= 0 {
-		c.RequestStateTTL = 24 * time.Hour
-	}
 }
 
 // v2TaskRuntime holds per-registration state for v2 tasks, shared between
@@ -65,11 +45,6 @@ func (c *TasksConfig) defaults() {
 type v2TaskRuntime struct {
 	store    TaskStore
 	registry *Registry
-
-	// requestStateKey + requestStateTTL configure SEP-2322 requestState
-	// signing. nil key = legacy plaintext mode (requestState == taskID).
-	requestStateKey []byte
-	requestStateTTL time.Duration
 
 	mu sync.Mutex
 	active   map[string]*activeTask
@@ -84,8 +59,6 @@ func newV2TaskRuntime(cfg TasksConfig) *v2TaskRuntime {
 	return &v2TaskRuntime{
 		store:              cfg.Store,
 		registry:           cfg.Server.Registry(),
-		requestStateKey:    cfg.RequestStateKey,
-		requestStateTTL:    cfg.RequestStateTTL,
 		active:             make(map[string]*activeTask),
 		taskErrors:         make(map[string]*core.TaskError),
 		creatorToolForTask: make(map[string]string),
@@ -133,52 +106,6 @@ func (rt *v2TaskRuntime) getToolCallbacks(taskID string) *TaskCallbacks {
 		return nil
 	}
 	return rt.registry.ToolCallbacks(name)
-}
-
-// makeRequestState mints the SEP-2322 requestState string the server hands
-// to clients on tasks/get responses and notifications/tasks events.
-// When a signing key is configured (TasksConfig.RequestStateKey), the token
-// is HMAC-SHA256 signed with an embedded expiry; otherwise it falls back to
-// the bare taskID for backward compat with minimal-config setups and tests.
-func (rt *v2TaskRuntime) makeRequestState(taskID string) string {
-	if len(rt.requestStateKey) == 0 {
-		return taskID
-	}
-	return core.SignRequestState(rt.requestStateKey, taskID, rt.requestStateTTL)
-}
-
-// verifyRequestState validates an incoming requestState against the signing
-// key. When the key is unset we run in legacy plaintext mode: any incoming
-// requestState that matches the taskID round-trips, anything else is
-// rejected (matches the old "RequestState: p.TaskID" semantics). When the
-// key is set, the token MUST decode + HMAC-verify + not be expired; mismatch
-// returns -32602 at the handler boundary.
-//
-// expectedTaskID is the taskID the caller already pulled from the request
-// body — we cross-check the token's embedded taskID against it so a token
-// issued for task A can't be replayed against task B.
-//
-// Empty incoming requestState is allowed (legacy clients, or first call
-// before the server has minted one). Callers that want stricter behavior
-// can refuse on requestState=="" themselves.
-func (rt *v2TaskRuntime) verifyRequestState(state, expectedTaskID string) error {
-	if state == "" {
-		return nil
-	}
-	if len(rt.requestStateKey) == 0 {
-		if state != expectedTaskID {
-			return core.ErrRequestStateInvalidSignature
-		}
-		return nil
-	}
-	gotTaskID, err := core.VerifyRequestState(rt.requestStateKey, state)
-	if err != nil {
-		return err
-	}
-	if gotTaskID != expectedTaskID {
-		return core.ErrRequestStateInvalidSignature
-	}
-	return nil
 }
 
 // deliverInputResponses routes a tasks/update payload back to whichever
@@ -354,16 +281,6 @@ func (tasksExtensionProvider) Extension() core.Extension {
 // Must be called before accepting connections.
 func RegisterTasks(cfg TasksConfig) {
 	srv := cfg.Server
-	// Inherit server-wide WithRequestStateSigning unless this RegisterTasks
-	// call overrides explicitly. Sharing the key means production deployments
-	// configure HMAC once and both MRTR (Dispatcher.mrtr) + Tasks (this
-	// runtime) sign with the same secret.
-	if len(cfg.RequestStateKey) == 0 && srv != nil && len(srv.options.requestStateKey) > 0 {
-		cfg.RequestStateKey = srv.options.requestStateKey
-	}
-	if cfg.RequestStateTTL == 0 && srv != nil && srv.options.requestStateTTL > 0 {
-		cfg.RequestStateTTL = srv.options.requestStateTTL
-	}
 	cfg.defaults()
 	rt := newV2TaskRuntime(cfg)
 
@@ -451,13 +368,13 @@ func taskV2Middleware(reg *Registry, rt *v2TaskRuntime, cfg TasksConfig) Middlew
 			perRequestCapsRaw = envelope.Meta.ClientCapabilitiesRaw
 		}
 		if !core.ClientSupportsExtensionForRequest(ctx, core.TasksExtensionID, perRequestCapsRaw) {
-			// SEP-2663 (spec commit 6e4fd57c in PR 2663): if the server cannot
-			// service the request without returning CreateTaskResult — i.e. the
-			// tool's TaskSupport is `required` — it MUST return -32003 with a
-			// machine-readable `requiredCapabilities` payload so the client can
-			// self-describe what to add. For `optional`, the server still CAN
-			// service the request without a task, so falling through to sync
-			// remains correct.
+			// Per the merged SEP-2663: if the server cannot service the
+			// request without returning CreateTaskResult — i.e. the tool's
+			// TaskSupport is `required` — it MUST return -32003 with a
+			// machine-readable `requiredCapabilities` payload so the client
+			// can self-describe what to add. For `optional`, the server still
+			// CAN service the request without a task, so falling through to
+			// sync remains correct.
 			if effectiveSupport == core.TaskSupportRequired {
 				return core.NewErrorResponseWithData(
 					req.ID,
@@ -525,7 +442,7 @@ func taskV2Middleware(reg *Registry, rt *v2TaskRuntime, cfg TasksConfig) Middlew
 			// NOT be sent on tasks. Filter at the session-notify boundary so
 			// any tool handler that calls EmitProgress or EmitLog while it
 			// happens to be running as a task silently no-ops rather than
-			// leaking onto the session stream. Spec commit 2dba297b in PR 2663.
+			// leaking onto the session stream.
 			bgCtx = core.ApplySessionNotifyFilter(bgCtx,
 				"notifications/progress",
 				"notifications/message",
@@ -623,8 +540,7 @@ const mcpNameHeader = "Mcp-Name"
 func makeV2GetHandler(rt *v2TaskRuntime) MethodHandler {
 	return func(ctx core.MethodContext, id json.RawMessage, params json.RawMessage) *core.Response {
 		var p struct {
-			TaskID       string `json:"taskId"`
-			RequestState string `json:"requestState,omitempty"`
+			TaskID string `json:"taskId"`
 		}
 		if err := json.Unmarshal(params, &p); err != nil {
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, err.Error())
@@ -636,20 +552,8 @@ func makeV2GetHandler(rt *v2TaskRuntime) MethodHandler {
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, "task not found: "+p.TaskID)
 		}
 
-		// SEP-2322: validate any echoed requestState — tampered, expired,
-		// or cross-task tokens are rejected with -32602 so attackers can't
-		// drive the loop with forged state. Empty is allowed (first call).
-		if err := rt.verifyRequestState(p.RequestState, p.TaskID); err != nil {
-			return core.NewErrorResponse(id, core.ErrCodeInvalidParams,
-				"invalid requestState: "+err.Error())
-		}
-
 		result := core.DetailedTask{
 			TaskInfoV2: toTaskInfoV2(info),
-			// SEP-2322 requestState — opaque session-continuation token. The
-			// same helper feeds notifyV2TaskStatus so polling and SSE stay
-			// in sync (HMAC-signed when RequestStateKey is configured).
-			RequestState: rt.makeRequestState(p.TaskID),
 		}
 
 		// SEP-2663: when the task is awaiting MRTR input, surface the
@@ -694,8 +598,7 @@ func makeV2GetHandler(rt *v2TaskRuntime) MethodHandler {
 
 // makeV2UpdateHandler implements SEP-2663 tasks/update — the resume path for
 // MRTR input rounds. The client supplies inputResponses keyed to the
-// inputRequests previously surfaced via tasks/get's DetailedTask, optionally
-// echoing requestState (SEP-2322) for stateless deployments.
+// inputRequests previously surfaced via tasks/get's DetailedTask.
 //
 // This Phase 4 implementation is a validating shell: it parses the request,
 // confirms the task exists and is non-terminal, hands the responses to the
@@ -725,13 +628,6 @@ func makeV2UpdateHandler(rt *v2TaskRuntime) MethodHandler {
 			// settles that way.
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, "task not found: "+p.TaskID)
 		}
-		// SEP-2322: validate echoed requestState before doing any work —
-		// the resume side of the MRTR loop is the most attractive target
-		// for forged state since it directly drives goroutine wake-ups.
-		if err := rt.verifyRequestState(p.RequestState, p.TaskID); err != nil {
-			return core.NewErrorResponse(id, core.ErrCodeInvalidParams,
-				"invalid requestState: "+err.Error())
-		}
 		if info.Status.IsTerminal() {
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams,
 				"task "+p.TaskID+" is in terminal state "+string(info.Status))
@@ -748,17 +644,10 @@ func makeV2UpdateHandler(rt *v2TaskRuntime) MethodHandler {
 func makeV2CancelHandler(rt *v2TaskRuntime) MethodHandler {
 	return func(ctx core.MethodContext, id json.RawMessage, params json.RawMessage) *core.Response {
 		var p struct {
-			TaskID       string `json:"taskId"`
-			RequestState string `json:"requestState,omitempty"`
+			TaskID string `json:"taskId"`
 		}
 		if err := json.Unmarshal(params, &p); err != nil {
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, err.Error())
-		}
-
-		// SEP-2322: validate echoed requestState before mutating task state.
-		if err := rt.verifyRequestState(p.RequestState, p.TaskID); err != nil {
-			return core.NewErrorResponse(id, core.ErrCodeInvalidParams,
-				"invalid requestState: "+err.Error())
 		}
 
 		info, err := rt.store.Cancel(p.TaskID, ctx.SessionID())
@@ -806,14 +695,8 @@ func toTaskInfoV2(info core.TaskInfo) core.TaskInfoV2 {
 // notifyV2TaskStatus sends a v2-style status notification with the full
 // DetailedTask (inlined result/error) read fresh from the store. Best-effort.
 //
-// SEP-2322: the notification carries the same requestState the next
-// tasks/get would have minted. Clients update their tracked requestState
-// from notifications so a stateless deployment can pick the conversation
-// back up without an extra tasks/get round-trip.
-//
 // Wire fields: payload embeds TaskInfoV2, so the JSON keys are `ttlMs` and
-// `pollIntervalMs` per the 2026-05-07 SEP-2663 commit (62758914) that aligned
-// all duration fields on the Ms suffix and integer milliseconds.
+// `pollIntervalMs`. All duration fields are integer milliseconds (SEP-2663).
 //
 // Stream routing (Streamable HTTP): the bgCtx passed in here was produced
 // by core.DetachForBackground in taskV2Middleware, which swaps the dead
@@ -834,8 +717,7 @@ func notifyV2TaskStatus(ctx context.Context, rt *v2TaskRuntime, store TaskStore,
 	}
 
 	payload := core.DetailedTask{
-		TaskInfoV2:   toTaskInfoV2(info),
-		RequestState: rt.makeRequestState(taskID),
+		TaskInfoV2: toTaskInfoV2(info),
 	}
 
 	if info.Status == core.TaskCompleted {
@@ -864,13 +746,9 @@ func notifyV2TaskStatus(ctx context.Context, rt *v2TaskRuntime, store TaskStore,
 // MethodContext for callers that already have fresh TaskInfo (e.g., the
 // cancel handler, which gets info back from store.Cancel and doesn't need
 // to re-read it).
-//
-// SEP-2322: carries requestState matching what the next tasks/get would
-// return — same rationale as notifyV2TaskStatus.
 func notifyV2TaskStatusFromInfo(ctx core.MethodContext, rt *v2TaskRuntime, info core.TaskInfo) {
 	payload := core.DetailedTask{
-		TaskInfoV2:   toTaskInfoV2(info),
-		RequestState: rt.makeRequestState(info.TaskID),
+		TaskInfoV2: toTaskInfoV2(info),
 	}
 	if info.Status == core.TaskFailed {
 		if te := rt.getTaskError(info.TaskID); te != nil {

--- a/server/tasks_v2_test.go
+++ b/server/tasks_v2_test.go
@@ -152,14 +152,14 @@ func TestV2_TaskCreationWithExtension(t *testing.T) {
 	}
 }
 
-// TestV2_RequiredTaskRejectsClientWithoutExtension verifies SEP-2663's
-// required-tasks error spec (spec commit 6e4fd57c in PR 2663). When a tool
-// declared with TaskSupport=required is invoked by a client that has not
-// negotiated the io.modelcontextprotocol/tasks extension, the server MUST
-// return -32003 (Missing Required Client Capability) with a structured
-// `requiredCapabilities` payload — NOT silently fall through to synchronous
-// execution. TaskSupport=optional retains the sync-fallback behaviour
-// because the server can still service those requests without a task.
+// TestV2_RequiredTaskRejectsClientWithoutExtension verifies the merged
+// SEP-2663 required-tasks error spec. When a tool declared with
+// TaskSupport=required is invoked by a client that has not negotiated the
+// io.modelcontextprotocol/tasks extension, the server MUST return -32003
+// (Missing Required Client Capability) with a structured `requiredCapabilities`
+// payload — NOT silently fall through to synchronous execution.
+// TaskSupport=optional retains the sync-fallback behaviour because the
+// server can still service those requests without a task.
 func TestV2_RequiredTaskRejectsClientWithoutExtension(t *testing.T) {
 	srv := newTaskV2Server(t)
 	c := connectV2Client(t, srv) // no WithTasksExtension
@@ -962,22 +962,19 @@ func TestV2_UpdateUnknownKeyIgnored(t *testing.T) {
 	})
 }
 
-// TestV2_StatusNotificationCarriesRequestState verifies that
-// notifications/tasks events carry the SEP-2322 requestState string.
-// Clients update their tracked requestState from notifications so a
-// stateless deployment can pick the conversation back up without an extra
-// tasks/get round-trip — but only if the server actually emits it.
-//
-// The fixture wires a notification handler before creating a fast task,
-// then waits for the terminal-status notification and asserts requestState
-// is non-empty (matches the same value tasks/get would have minted).
-func TestV2_StatusNotificationCarriesRequestState(t *testing.T) {
+// TestV2_StatusNotificationOmitsRequestState verifies that notifications/tasks
+// payloads MUST NOT carry `requestState`. The merged SEP-2663 removed the
+// field from the Task base interface, so the DetailedTask shape on every
+// task-bearing message — CreateTaskResult, tasks/get, and these
+// notifications — omits it. The test inspects the raw JSON payload (rather
+// than the typed DetailedTask, which would lose the field at the struct
+// boundary) so a server that re-introduces the field would be caught.
+func TestV2_StatusNotificationOmitsRequestState(t *testing.T) {
 	srv := newTaskV2Server(t)
 
-	// Capture incoming notifications/tasks payloads. Use a buffered
-	// channel + select so the test isn't sensitive to delivery ordering vs
-	// the SSE stream lifecycle.
-	notifs := make(chan core.DetailedTask, 8)
+	// Capture incoming notifications/tasks payloads as raw JSON so we can
+	// assert on the actual wire field set.
+	notifs := make(chan map[string]any, 8)
 	handler := srv.Handler(WithStreamableHTTP(true))
 	ts := httptest.NewServer(handler)
 	t.Cleanup(ts.Close)
@@ -993,12 +990,12 @@ func TestV2_StatusNotificationCarriesRequestState(t *testing.T) {
 			if err != nil {
 				return
 			}
-			var dt core.DetailedTask
-			if err := json.Unmarshal(raw, &dt); err != nil {
+			var m map[string]any
+			if err := json.Unmarshal(raw, &m); err != nil {
 				return
 			}
 			select {
-			case notifs <- dt:
+			case notifs <- m:
 			default:
 			}
 		}),
@@ -1022,31 +1019,21 @@ func TestV2_StatusNotificationCarriesRequestState(t *testing.T) {
 	}
 	taskID := ctr.TaskID
 
-	// Wait up to 2s for a notification carrying requestState. Loop because
-	// the server may emit multiple status notifications before terminal.
+	// Wait up to 2s for any notification matching our task and assert the
+	// raw payload omits `requestState`.
 	deadline := time.After(2 * time.Second)
 	for {
 		select {
-		case dt := <-notifs:
-			if dt.TaskID != taskID {
+		case m := <-notifs:
+			if m["taskId"] != taskID {
 				continue
 			}
-			if dt.RequestState == "" {
-				t.Fatalf("notifications/tasks for %s missing requestState (full payload: %+v)", taskID, dt)
-			}
-			// SEP-2322: same body as the next tasks/get would mint —
-			// clients can drop-in update their tracked state.
-			got, err := client.GetTask(c, taskID)
-			if err != nil {
-				t.Fatalf("GetTask: %v", err)
-			}
-			if got.RequestState != dt.RequestState {
-				t.Errorf("notification requestState %q != tasks/get requestState %q",
-					dt.RequestState, got.RequestState)
+			if _, present := m["requestState"]; present {
+				t.Fatalf("notifications/tasks for %s carries requestState; merged SEP-2663 removed it from the v2 wire (payload: %+v)", taskID, m)
 			}
 			return
 		case <-deadline:
-			t.Fatalf("timed out waiting for notifications/tasks with requestState for %s", taskID)
+			t.Fatalf("timed out waiting for notifications/tasks for %s", taskID)
 		}
 	}
 }
@@ -1054,10 +1041,10 @@ func TestV2_StatusNotificationCarriesRequestState(t *testing.T) {
 // TestV2_NoProgressOrMessageOnTaskGoroutine verifies that a tool which calls
 // EmitProgress or EmitLog while running as a task does not leak
 // notifications/progress or notifications/message onto the session stream.
-// SEP-2663 (spec commit 2dba297b in PR 2663) tightened the rule to a MUST
-// NOT, and mcpkit enforces it at the session-notify boundary by wrapping the
-// bgCtx with core.ApplySessionNotifyFilter so neither emission path reaches
-// the wire — regardless of whether the tool author remembers the rule.
+// The merged SEP-2663 made this a MUST NOT; mcpkit enforces it at the
+// session-notify boundary by wrapping the bgCtx with
+// core.ApplySessionNotifyFilter so neither emission path reaches the wire
+// — regardless of whether the tool author remembers the rule.
 func TestV2_NoProgressOrMessageOnTaskGoroutine(t *testing.T) {
 	srv := newTaskV2Server(t)
 	srv.RegisterTool(
@@ -1135,279 +1122,5 @@ drain:
 		case <-deadline:
 			break drain
 		}
-	}
-}
-
-// --- Gap 3: HMAC-signed requestState (end-to-end) ---
-
-// newSignedTaskV2Server is a hybrid-of-newTaskV2Server-and-WithRequestStateKey
-// fixture used by the HMAC-mode tests. Wires the same fast-task tool but
-// configures TasksConfig with a fixed signing key + short TTL so each
-// request-cycle exercises the sign / verify path end-to-end.
-func newSignedTaskV2Server(t *testing.T, ttl time.Duration) (*Server, []byte) {
-	t.Helper()
-	srv := NewServer(core.ServerInfo{Name: "v2-signed-test", Version: "0.0.1"})
-
-	srv.RegisterTool(
-		core.ToolDef{
-			Name:        "fast-task",
-			Description: "completes immediately",
-			InputSchema: map[string]any{"type": "object"},
-			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportRequired},
-		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
-			return core.TextResult("fast-done"), nil
-		},
-	)
-
-	key := []byte("conformance-test-32-bytes-secret-key")
-	RegisterTasks(TasksConfig{
-		Server:          srv,
-		RequestStateKey: key,
-		RequestStateTTL: ttl,
-	})
-	return srv, key
-}
-
-// TestV2_RequestState_SignedRoundTrip verifies that with a signing key
-// configured, the server emits HMAC-signed requestState on tasks/get and
-// accepts the same token echoed back on tasks/get / tasks/cancel.
-func TestV2_RequestState_SignedRoundTrip(t *testing.T) {
-	srv, _ := newSignedTaskV2Server(t, time.Hour)
-	c := connectV2Client(t, srv, client.WithTasksExtension())
-
-	// Create a task. CreateTaskResult itself doesn't carry requestState
-	// (per SEP-2663) — the first signed token comes from the next tasks/get.
-	res, err := client.ToolCall(c, "fast-task", map[string]any{})
-	if err != nil || !res.IsTask() {
-		t.Fatalf("ToolCall: %v / IsTask=%v", err, res != nil && res.IsTask())
-	}
-	taskID := res.Task.TaskID
-
-	first, err := client.GetTask(c, taskID)
-	if err != nil {
-		t.Fatalf("GetTask: %v", err)
-	}
-	// Signed tokens have a "." separator and base64 segments — assert
-	// shape rather than the exact bytes (which depend on time).
-	if !strings.Contains(first.RequestState, ".") {
-		t.Fatalf("expected HMAC-signed requestState (contains '.'); got %q", first.RequestState)
-	}
-	if first.RequestState == taskID {
-		t.Errorf("HMAC mode produced plaintext requestState (= taskID); signing not applied")
-	}
-
-	// Echo the token back — server should accept and emit a fresh one
-	// (different `exp`, but verifiable).
-	second, err := client.GetTask(c, taskID, client.TaskOptions{RequestState: first.RequestState})
-	if err != nil {
-		t.Fatalf("GetTask with echoed requestState: %v", err)
-	}
-	if second.RequestState == "" {
-		t.Errorf("server should mint a fresh requestState on each tasks/get")
-	}
-}
-
-// TestV2_RequestState_TamperedRejected verifies that a token whose payload
-// is modified (after the server minted it) is rejected with -32602 on every
-// requestState-bearing handler.
-func TestV2_RequestState_TamperedRejected(t *testing.T) {
-	srv, _ := newSignedTaskV2Server(t, time.Hour)
-	c := connectV2Client(t, srv, client.WithTasksExtension())
-
-	res, _ := client.ToolCall(c, "fast-task", map[string]any{})
-	taskID := res.Task.TaskID
-	first, _ := client.GetTask(c, taskID)
-
-	// Tamper the payload segment by re-encoding a different taskId.
-	dot := strings.IndexByte(first.RequestState, '.')
-	if dot < 0 {
-		t.Fatalf("expected '.' in signed requestState; got %q", first.RequestState)
-	}
-	tampered := first.RequestState[:dot+1] + "ZXZpbA" // "evil" base64
-
-	// tasks/get
-	_, err := c.Call("tasks/get", map[string]any{"taskId": taskID, "requestState": tampered})
-	rpcErr, ok := err.(*client.RPCError)
-	if !ok || rpcErr.Code != core.ErrCodeInvalidParams {
-		t.Errorf("tasks/get tampered: err=%v; want -32602", err)
-	}
-
-	// tasks/update
-	err = client.UpdateTask(c, core.UpdateTaskRequest{TaskID: taskID, RequestState: tampered})
-	rpcErr, ok = err.(*client.RPCError)
-	if !ok || rpcErr.Code != core.ErrCodeInvalidParams {
-		t.Errorf("tasks/update tampered: err=%v; want -32602", err)
-	}
-
-	// tasks/cancel
-	err = client.CancelTask(c, taskID, client.TaskOptions{RequestState: tampered})
-	rpcErr, ok = err.(*client.RPCError)
-	if !ok || rpcErr.Code != core.ErrCodeInvalidParams {
-		t.Errorf("tasks/cancel tampered: err=%v; want -32602", err)
-	}
-}
-
-// TestV2_RequestState_ExpiredRejected verifies that a token whose embedded
-// expiry has passed is rejected. Uses TTL=1s and sleep=2s — the embedded
-// `exp` is unix SECONDS, so a sub-second TTL would round to the same second
-// as `now`, making the test flake. The 1s/2s combo cleanly crosses the
-// seconds boundary regardless of when within a second the test starts.
-func TestV2_RequestState_ExpiredRejected(t *testing.T) {
-	srv, _ := newSignedTaskV2Server(t, time.Second)
-	c := connectV2Client(t, srv, client.WithTasksExtension())
-
-	res, _ := client.ToolCall(c, "fast-task", map[string]any{})
-	taskID := res.Task.TaskID
-	first, _ := client.GetTask(c, taskID)
-
-	// Wait past the TTL (≥ 1s past the embedded exp, regardless of jitter).
-	time.Sleep(2 * time.Second)
-
-	_, err := c.Call("tasks/get", map[string]any{"taskId": taskID, "requestState": first.RequestState})
-	rpcErr, ok := err.(*client.RPCError)
-	if !ok {
-		t.Fatalf("expected *client.RPCError, got %T: %v", err, err)
-	}
-	if rpcErr.Code != core.ErrCodeInvalidParams {
-		t.Errorf("expired requestState: code=%d; want -32602", rpcErr.Code)
-	}
-	if !strings.Contains(rpcErr.Message, "expired") {
-		t.Errorf("expired requestState: message=%q; want it to mention \"expired\"", rpcErr.Message)
-	}
-}
-
-// TestV2_StrongConsistency_ImmediateGet verifies SEP-2663's durable-create
-// guarantee: "A server MUST NOT return CreateTaskResult until the task is
-// durably created — that is, until a tasks/get for the returned taskId would
-// resolve."
-//
-// Our middleware calls store.Create synchronously before building the
-// response, so the task is queryable the instant the client sees the
-// CreateTaskResult. This test codifies that ordering — if a future refactor
-// pushed store.Create into the background goroutine, this would catch it.
-func TestV2_StrongConsistency_ImmediateGet(t *testing.T) {
-	srv, _ := newTaskV2ServerWithSlow(t)
-	c := connectV2Client(t, srv, client.WithTasksExtension())
-
-	res, err := c.Call("tools/call", map[string]any{
-		"name":      "slow-task",
-		"arguments": map[string]any{},
-	})
-	if err != nil {
-		t.Fatalf("tools/call: %v", err)
-	}
-	var ctr core.CreateTaskResult
-	if err := json.Unmarshal(res.Raw, &ctr); err != nil {
-		t.Fatalf("unmarshal CreateTaskResult: %v", err)
-	}
-	if ctr.TaskID == "" {
-		t.Fatal("missing taskId in CreateTaskResult")
-	}
-
-	// Immediately query — no sleep, no poll, no goroutine yield. SEP-2663
-	// says this MUST resolve, even if the tool's background goroutine hasn't
-	// been scheduled yet.
-	got, err := c.Call("tasks/get", map[string]any{"taskId": ctr.TaskID})
-	if err != nil {
-		t.Fatalf("immediate tasks/get after CreateTaskResult must resolve (SEP-2663): %v", err)
-	}
-	var dt core.DetailedTask
-	if err := json.Unmarshal(got.Raw, &dt); err != nil {
-		t.Fatalf("unmarshal DetailedTask: %v", err)
-	}
-	if dt.TaskID != ctr.TaskID {
-		t.Errorf("tasks/get returned wrong taskId: got %q, want %q", dt.TaskID, ctr.TaskID)
-	}
-	// Status should be non-terminal (slow-task blocks until unblocked); the
-	// exact value doesn't matter — what matters is that the task exists.
-	if dt.Status.IsTerminal() {
-		t.Errorf("expected non-terminal status (task is blocked), got %q", dt.Status)
-	}
-}
-
-// TestV2_RequestState_StaleTolerance verifies SEP-2663's "Servers MUST tolerate
-// receiving a stale or outdated value gracefully" requirement. Each tasks/get
-// mints a fresh signed requestState (different `exp`), so an earlier token
-// becomes "stale" the moment the next one is minted — but stale-but-not-expired
-// tokens MUST still verify and the request MUST succeed (not -32602).
-//
-// Our HMAC verifier only checks signature validity + expiry, never "latest
-// version," so this test codifies the existing behavior. Servers that decide
-// to track a "latest only" notion would fail here, which is the point.
-func TestV2_RequestState_StaleTolerance(t *testing.T) {
-	srv, _ := newSignedTaskV2Server(t, time.Hour)
-	c := connectV2Client(t, srv, client.WithTasksExtension())
-
-	res, err := client.ToolCall(c, "fast-task", map[string]any{})
-	if err != nil || !res.IsTask() {
-		t.Fatalf("ToolCall: %v / IsTask=%v", err, res != nil && res.IsTask())
-	}
-	taskID := res.Task.TaskID
-
-	// Mint tokenA via the first tasks/get.
-	first, err := client.GetTask(c, taskID)
-	if err != nil {
-		t.Fatalf("first GetTask: %v", err)
-	}
-	tokenA := first.RequestState
-	if tokenA == "" {
-		t.Fatal("expected non-empty requestState from signed-mode server")
-	}
-
-	// Sleep ≥1s so the next mint embeds a different `exp` (unix seconds
-	// granularity) — that's what makes tokenA "stale."
-	time.Sleep(1100 * time.Millisecond)
-
-	second, err := client.GetTask(c, taskID, client.TaskOptions{RequestState: tokenA})
-	if err != nil {
-		t.Fatalf("second GetTask (echoing tokenA): %v", err)
-	}
-	tokenB := second.RequestState
-	if tokenB == "" || tokenB == tokenA {
-		t.Fatalf("expected fresh token on second tasks/get; got %q (vs A=%q)", tokenB, tokenA)
-	}
-
-	// Now echo the older tokenA — it's stale (a newer token has been minted)
-	// but still within its TTL, so the server MUST accept it.
-	stale, err := client.GetTask(c, taskID, client.TaskOptions{RequestState: tokenA})
-	if err != nil {
-		t.Fatalf("stale-token GetTask: %v — server must tolerate stale-but-valid tokens (SEP-2663)", err)
-	}
-	if stale.TaskID != taskID {
-		t.Errorf("stale-token GetTask returned wrong taskId: got %q, want %q", stale.TaskID, taskID)
-	}
-}
-
-// TestV2_RequestState_LegacyPlaintext verifies that with no key configured
-// (the default), the server falls back to plaintext requestState (== taskID).
-// Existing tests / clients that don't echo requestState keep working.
-func TestV2_RequestState_LegacyPlaintext(t *testing.T) {
-	srv := newTaskV2Server(t) // no RequestStateKey
-	c := connectV2Client(t, srv, client.WithTasksExtension())
-
-	res, _ := client.ToolCall(c, "fast-task", map[string]any{})
-	taskID := res.Task.TaskID
-	first, err := client.GetTask(c, taskID)
-	if err != nil {
-		t.Fatalf("GetTask: %v", err)
-	}
-	if first.RequestState != taskID {
-		t.Errorf("legacy mode: requestState = %q, want plaintext taskID %q",
-			first.RequestState, taskID)
-	}
-
-	// Echoing the plaintext state still works (matches taskID).
-	_, err = client.GetTask(c, taskID, client.TaskOptions{RequestState: taskID})
-	if err != nil {
-		t.Errorf("legacy mode echo: %v", err)
-	}
-
-	// A non-matching string still gets rejected even in legacy mode —
-	// minimal protection against a client confusing two task IDs.
-	_, err = c.Call("tasks/get", map[string]any{"taskId": taskID, "requestState": "not-the-task-id"})
-	rpcErr, ok := err.(*client.RPCError)
-	if !ok || rpcErr.Code != core.ErrCodeInvalidParams {
-		t.Errorf("legacy mode mismatched state: err=%v; want -32602", err)
 	}
 }


### PR DESCRIPTION
## What changes

The merged SEP-2663 dropped the `requestState?: string` field from the `Task` base interface and deleted the entire "Request State Management" section. This PR brings mcpkit's tasks-v2 wire in line: `DetailedTask`, `UpdateTaskRequest`, and the `tasks/get` / `tasks/cancel` inline param structs no longer carry the field; the runtime helpers and per-registration signing config that minted/verified it are gone; the client surface drops `TaskOptions.RequestState` and the polling-loop echo. SEP-2322's MRTR `InputRequiredResult.RequestState` is unchanged. The `panyam/mcpconformance` `tasks-request-state-removal` scenario flips from FAIL to PASS — the deliberate failing window that the prior conformance-fork PR opened is now closed.

## Reviewer's guide

Read in this order:

1. [core/task_v2.go](https://github.com/panyam/mcpkit/pull/417/files#diff-3538d827f8d2f0385530a0112d8defa64f901a0827609fe5f730db43ff24049a) — start here. Drops `RequestState` from `DetailedTask` and `UpdateTaskRequest`, rescopes the "requestState signing" section banner to MRTR, and adds inline notes that `SignRequestState` / `VerifyRequestState` are retained for the legacy MRTR-token shim in `server/mrtr.go`.
2. [server/tasks_v2.go](https://github.com/panyam/mcpkit/pull/417/files#diff-95eaa1c90d414ad57bbc73e270734b6e953fce04637f0da44f31491f2386f097) — the bulk of the production-code diff. Removes `TasksConfig.RequestStateKey` / `RequestStateTTL`, the `v2TaskRuntime.requestStateKey/TTL` fields, the `makeRequestState` / `verifyRequestState` methods, the per-registration inheritance from `WithRequestStateSigning` in `RegisterTasks`, and every population/echo/validation site across `makeV2GetHandler`, `makeV2UpdateHandler`, `makeV2CancelHandler`, `notifyV2TaskStatus`, and `notifyV2TaskStatusFromInfo`.
3. [client/tasks.go](https://github.com/panyam/mcpkit/pull/417/files#diff-d0b57c8858ad0192278d3050dbcdd6e4e6891f72eb9d4e8d0f076efdcacc7265) — client surface change. `TaskOptions` is removed (no remaining fields); `GetTask(c, taskID)` and `CancelTask(c, taskID)` lose the `opts ...TaskOptions` variadic; `WaitOptions.RequestState` is gone and the `WaitForTask` polling loop no longer threads `state` through iterations.
4. [server/tasks_v2_test.go](https://github.com/panyam/mcpkit/pull/417/files#diff-1e7423fe3036784ee36159dfc5ddaf1edd5850d314f27f06d20926481aa20e09) — the largest test diff. `TestV2_StatusNotificationCarriesRequestState` is inverted to `TestV2_StatusNotificationOmitsRequestState` (asserts the raw notification payload omits `requestState`). The five `TestV2_RequestState_*` HMAC-mode tests and the `newSignedTaskV2Server` fixture are removed — they exercise a now-removed feature, and the underlying signing primitives stay covered by [core/task_v2_test.go](https://github.com/panyam/mcpkit/pull/417/files#diff-6901b5c43348f336ead3c8fd405986c20a4dd6249af891c63d10cb58da06905c). Some Phase-2 inline spec-commit attributions on adjacent tests are scrubbed in passing.
5. [core/task_v2_test.go](https://github.com/panyam/mcpkit/pull/417/files#diff-6901b5c43348f336ead3c8fd405986c20a4dd6249af891c63d10cb58da06905c) — `TestDetailedTaskRequestStateOmitEmpty` inverted to `TestDetailedTaskNoRequestState`; `TestUpdateTaskRequestWireShape`'s positive `requestState` assertion flipped to absence; the unused omit-empty case on `UpdateTaskRequest` updated to check only `inputResponses`.
6. [client/tasks_test.go](https://github.com/panyam/mcpkit/pull/417/files#diff-c7563622279baa6fb976a1341f662e3170cfb22c14f9563816310cd217f9861c) — drops two assertions on `dt.RequestState` / `pending.RequestState` that referenced the removed field.
7. [server/mrtr_test.go](https://github.com/panyam/mcpkit/pull/417/files#diff-f5a3e6e5f5ac2bd8ac2d757d2cb0819fdd0162179f3686b1b6859628dfa46329) — removes `TestRequestStateSigning_SharedByMRTRAndTasks`. That test verified inheritance of the server-wide signing key into the v2-wire requestState path; with v2 no longer signing anything, the test exercises a feature that no longer exists. The MRTR-specific tests (`TestMRTR_RequestStateSigned`, `TestMRTR_TamperedRequestStateRejected`, ...) are untouched.
8. [examples/tasks-v2/walkthrough.go](https://github.com/panyam/mcpkit/pull/417/files#diff-84203486551480d08bf5dad4f513c032154ade216bc4cd2e9e5ea43ba9f5e90d) — one site removed: the `RequestState: pending.RequestState` argument on the `UpdateTask` call.
9. [docs/TASKS_V2_MIGRATION.md](https://github.com/panyam/mcpkit/pull/417/files#diff-240b4fc6190d28f1d6941b11fbfd87cff7b9f4ac7c8188a0f656f9a09458ba88) — new "requestState removed from the tasks-v2 wire" subsection at the bottom of Known Behaviours. While in the file, six adjacent section headers had their internal-tracking-code prefixes (`G4:`, `G5:`, `G6:`, ...) stripped — the body text was already descriptive.

Skim or skip: nothing. Every file is load-bearing for the wire-shape change.

## Decision log

- **Kept `core.SignRequestState` and `core.VerifyRequestState`.** Initial plan was to remove them as orphaned helpers. Caller-tracing surfaced a real MRTR use: `server/mrtr.go`'s `verifyRequestState` calls `core.VerifyRequestState` as a backward-compat fallback for legacy single-round MRTR tokens minted before the MRTR struct schema landed. The TODO comment in that helper says the shim is removable once in-flight rounds rotate past — that cleanup belongs in a separate, MRTR-focused pass, not blended with this wire-shape change. The 5 unit tests in `core/task_v2_test.go` that cover these helpers remain meaningful.
- **Removed `TaskOptions` entirely** rather than keeping it as a zero-field struct. No remaining fields, no foreseeable additions; preserving it as a placeholder invites confusion. Per project policy "no backwards-compatibility concerns" the signature break on `GetTask` / `CancelTask` is acceptable.
- **`TestRequestStateSigning_SharedByMRTRAndTasks` removed, not converted.** The test specifically asserted that server-wide `WithRequestStateSigning` was inherited by `RegisterTasks` and applied to the v2-wire `requestState`. With v2 no longer signing anything, there is no "sharing" relationship to verify; the MRTR signing path has its own dedicated tests (`TestMRTR_RequestStateSigned`, `TestMRTR_TamperedRequestStateRejected`).
- **In-place rewrite of `TestV2_StatusNotificationCarriesRequestState`** (rename + body inversion) rather than delete + add. Preserves blame continuity for the notification-observation harness; the test name and body change tell the inversion story together.

## Risk

- Wire-shape break on the tasks-v2 surface. Any external consumer that read `DetailedTask.RequestState` or set `UpdateTaskRequest.RequestState` will not compile against this commit; per project policy there are none yet.
- Client signature break: `GetTask(c, taskID, opts...)` → `GetTask(c, taskID)`; same for `CancelTask`. `WaitForTask` retains its variadic but `WaitOptions.RequestState` is gone.
- The MRTR backward-compat shim in `server/mrtr.go` continues to call `core.VerifyRequestState`. Removing those helpers later requires either retiring the shim or rebuilding equivalents in MRTR-only form.
- Tests covering this change: `TestV2_StatusNotificationOmitsRequestState`, `TestDetailedTaskNoRequestState`, `TestUpdateTaskRequestWireShape` (flipped to absence), plus the conformance suite's `tasks-request-state-removal` scenario going green.
- Be paranoid about: any handler/test fixture that synthesized a fake `DetailedTask` literal with `RequestState` set (compiler catches all of these — verified). And the `WaitForTask` polling helper — the loop simplification is small but it's the hot path for v2 clients; e2e tests cover it.

## Verification

- `go test ./core/... ./server/... ./client/...` green locally
- `go build ./...` clean
- `make tidy-all` clean across all sub-modules
- `make testconf-tasks-v2` — **9 of 9 scenarios pass** (was 8 of 9 before this commit, with `tasks-request-state-removal` failing on `tasks-get-detailed-no-request-state`)

## Out of scope (deferred)

- v2 → `ext/tasks/` sub-module move, tracked in `panyam/mcpkit` issue 413.
- The legacy MRTR-token backward-compat shim in `server/mrtr.go:100-113` (and the corresponding `core.SignRequestState` / `VerifyRequestState` helpers). Removable once all in-flight MRTR rounds have rotated past the older payload shape.
- v1 path (`server/tasks_v1*.go`) — frozen, decommissioning is its own initiative.
- `docs/TASKS_V2_MIGRATION.md` top-of-file "Status: in spec draft" callout rewrite — a separate doc-sweep PR.

## Test plan

- [x] `go test ./core/... ./server/... ./client/...` green (`core` 0.5s, `server` 10.5s, `client` 9s)
- [x] `make testconf-tasks-v2` shows 9 of 9 scenarios pass against the panyam/mcpconformance Final-aligned suite
- [x] `make tidy-all` clean
- [ ] CI green
- [ ] `make testall` green (next user step)
