### PR TITLE
feat(tasks): -32003 for gated tasks/* + idempotent terminal cancel

### DIFF
--- a/core/jsonrpc.go
+++ b/core/jsonrpc.go
@@ -85,10 +85,11 @@ const (
 	// carry a `requiredCapabilities` object mirroring the InitializeRequest
 	// capabilities shape so the client can self-describe what to add.
 	//
-	// Defined by SEP-2663 (Tasks Extension) for the case where a tool with
-	// TaskSupport=required is called by a client that has not declared the
-	// io.modelcontextprotocol/tasks extension. Reusable for any future
-	// extension whose required-mode path needs the same affordance.
+	// Defined by SEP-2575 §"Missing Required Capabilities". SEP-2663
+	// applies the rule to the tasks extension (TaskSupport=required tools
+	// reject with this code when the client did not declare
+	// io.modelcontextprotocol/tasks). Reusable for any future extension
+	// whose required-mode path needs the same affordance.
 	ErrCodeMissingRequiredClientCapability = -32003
 )
 

--- a/ext/tasks/tasks.go
+++ b/ext/tasks/tasks.go
@@ -271,10 +271,11 @@ func (tasksExtensionProvider) Extension() core.Extension {
 //     (server-directed, no client task param needed). Task creation is
 //     gated on the client supporting the extension — either at session
 //     level (initialize handshake) or per-request (SEP-2575 _meta).
-//   - Registers tasks/get and tasks/cancel handlers, gated on session-level
-//     extension support; otherwise the handlers return -32601 (method not
-//     found) so unsupported clients don't see a tasks surface they didn't
-//     ask for.
+//   - Registers tasks/get, tasks/update, and tasks/cancel handlers, gated
+//     on session-level extension support; otherwise the handlers return
+//     -32003 (Missing Required Client Capability, SEP-2575) with a
+//     machine-readable `requiredCapabilities` payload so unsupported
+//     clients can self-describe what to add.
 //   - Does NOT register tasks/result or tasks/list (removed in v2).
 //   - Does NOT call SetTasksCap — v2 tasks live under capabilities.extensions,
 //     not the v1 ServerCapabilities.Tasks slot.
@@ -299,14 +300,25 @@ func Register(cfg Config) {
 }
 
 // gateOnTasksExtension wraps a tasks/* handler so unsupported clients get
-// -32601 (method not found) instead of the real handler's response. This is
-// the SEP-2663 contract: tasks/* methods MUST NOT exist for clients that did
-// not negotiate the extension during initialize.
+// -32003 (Missing Required Client Capability, SEP-2575) instead of the real
+// handler's response. The error data carries the same `requiredCapabilities`
+// shape the required-task middleware emits, so a client that hits the
+// gate can self-describe what to add and retry.
 func gateOnTasksExtension(inner server.MethodHandler) server.MethodHandler {
 	return func(ctx core.MethodContext, id json.RawMessage, params json.RawMessage) *core.Response {
 		if !ctx.ClientSupportsExtension(core.TasksExtensionID) {
-			return core.NewErrorResponse(id, core.ErrCodeMethodNotFound,
-				"method requires extension "+core.TasksExtensionID)
+			return core.NewErrorResponseWithData(
+				id,
+				core.ErrCodeMissingRequiredClientCapability,
+				"method requires extension "+core.TasksExtensionID,
+				map[string]any{
+					"requiredCapabilities": map[string]any{
+						"extensions": map[string]any{
+							core.TasksExtensionID: map[string]any{},
+						},
+					},
+				},
+			)
 		}
 		return inner(ctx, id, params)
 	}
@@ -649,6 +661,14 @@ func makeV2CancelHandler(rt *v2TaskRuntime) server.MethodHandler {
 		}
 		if err := json.Unmarshal(params, &p); err != nil {
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, err.Error())
+		}
+
+		// SEP-2663 cancel is idempotent — if the task is already terminal,
+		// return the same empty ack as on an active task so clients don't
+		// have to race observation vs cancel. Skip the store mutation in
+		// that case.
+		if info, ok := rt.store.Get(p.TaskID, ctx.SessionID()); ok && info.Status.IsTerminal() {
+			return core.NewResponse(id, core.CancelTaskResult{})
 		}
 
 		info, err := rt.store.Cancel(p.TaskID, ctx.SessionID())

--- a/ext/tasks/tasks_test.go
+++ b/ext/tasks/tasks_test.go
@@ -202,7 +202,8 @@ func TestV2_RequiredTaskRejectsClientWithoutExtension(t *testing.T) {
 }
 
 // TestV2_TasksGetRejectedWithoutExtension verifies tasks/get returns
-// -32601 (method not found) when the client has not negotiated the extension.
+// -32003 (Missing Required Client Capability, SEP-2575) when the client has
+// not negotiated the tasks extension.
 func TestV2_TasksGetRejectedWithoutExtension(t *testing.T) {
 	srv := newTaskV2Server(t)
 	c := connectV2Client(t, srv) // no WithTasksExtension
@@ -215,13 +216,13 @@ func TestV2_TasksGetRejectedWithoutExtension(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected *client.RPCError, got %T: %v", err, err)
 	}
-	if rpcErr.Code != core.ErrCodeMethodNotFound {
-		t.Errorf("code = %d, want %d (method not found)", rpcErr.Code, core.ErrCodeMethodNotFound)
+	if rpcErr.Code != core.ErrCodeMissingRequiredClientCapability {
+		t.Errorf("code = %d, want %d (missing required client capability)", rpcErr.Code, core.ErrCodeMissingRequiredClientCapability)
 	}
 }
 
 // TestV2_TasksCancelRejectedWithoutExtension verifies tasks/cancel returns
-// -32601 when the client has not negotiated the extension.
+// -32003 when the client has not negotiated the tasks extension.
 func TestV2_TasksCancelRejectedWithoutExtension(t *testing.T) {
 	srv := newTaskV2Server(t)
 	c := connectV2Client(t, srv) // no WithTasksExtension
@@ -234,8 +235,8 @@ func TestV2_TasksCancelRejectedWithoutExtension(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected *client.RPCError, got %T: %v", err, err)
 	}
-	if rpcErr.Code != core.ErrCodeMethodNotFound {
-		t.Errorf("code = %d, want %d (method not found)", rpcErr.Code, core.ErrCodeMethodNotFound)
+	if rpcErr.Code != core.ErrCodeMissingRequiredClientCapability {
+		t.Errorf("code = %d, want %d (missing required client capability)", rpcErr.Code, core.ErrCodeMissingRequiredClientCapability)
 	}
 }
 
@@ -459,8 +460,9 @@ func TestV2_UpdateTerminalRejected(t *testing.T) {
 	}
 }
 
-// TestV2_UpdateRejectedWithoutExtension verifies tasks/update returns -32601
-// when the client did not negotiate the tasks extension at session level.
+// TestV2_UpdateRejectedWithoutExtension verifies tasks/update returns -32003
+// (Missing Required Client Capability, SEP-2575) when the client did not
+// negotiate the tasks extension at session level.
 func TestV2_UpdateRejectedWithoutExtension(t *testing.T) {
 	srv := newTaskV2Server(t)
 	c := connectV2Client(t, srv) // no WithTasksExtension
@@ -473,8 +475,8 @@ func TestV2_UpdateRejectedWithoutExtension(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected *client.RPCError, got %T: %v", err, err)
 	}
-	if rpcErr.Code != core.ErrCodeMethodNotFound {
-		t.Errorf("code = %d, want %d (method not found)", rpcErr.Code, core.ErrCodeMethodNotFound)
+	if rpcErr.Code != core.ErrCodeMissingRequiredClientCapability {
+		t.Errorf("code = %d, want %d (missing required client capability)", rpcErr.Code, core.ErrCodeMissingRequiredClientCapability)
 	}
 }
 


### PR DESCRIPTION
## What changes

Two behavioral fixes to the SEP-2663 tasks-v2 surface, surfaced in review of the conformance-fork PR (panyam/mcpconformance PR 262):

1. **`gateOnTasksExtension` returns `-32003` (not `-32601`) with `requiredCapabilities` data.** When a client calls `tasks/get` / `tasks/update` / `tasks/cancel` without negotiating the `io.modelcontextprotocol/tasks` extension, the gate now follows the SEP-2575 §"Missing Required Capabilities" pattern that already governs `TaskSupport=required` tools — the error data carries the same `requiredCapabilities` shape so the client can self-describe what to add and retry.
2. **`tasks/cancel` is idempotent on terminal tasks.** Previously returned `-32602` ("task is already in a terminal state"); now short-circuits to the same empty ack as on an active task. SEP-2663 cancel is meant to be idempotent so clients don't have to race observation vs cancel.

Plus a doc-comment fix on `core.ErrCodeMissingRequiredClientCapability` — SEP-2575 is the canonical home of `-32003`; SEP-2663 just applies the rule to the tasks extension.

## Reviewer's guide

Read in this order:

1. [ext/tasks/tasks.go](https://github.com/panyam/mcpkit/pull/430/files#diff-6b15314e7b637ac95e29f77601d89c4731b2aa4943266a4013345595095df47b) — start here. Two handler-level changes: `gateOnTasksExtension` (was `-32601`, now `-32003` with `requiredCapabilities`) and `makeV2CancelHandler` (terminal short-circuit).
2. [ext/tasks/tasks_test.go](https://github.com/panyam/mcpkit/pull/430/files#diff-bf917765e81561f93979c22bfaae3e346516d0c28ba4ee9d322d1d63bb08867c) — acceptance for the gate flip. Three `*RejectedWithoutExtension` tests now assert `ErrCodeMissingRequiredClientCapability` instead of `ErrCodeMethodNotFound`.
3. [core/jsonrpc.go](https://github.com/panyam/mcpkit/pull/430/files#diff-f9f4f09be0f88717867046128a5e4338f60aaea6764fda9b9a6c95c4089797f4) — doc-only. Clarifies that `-32003` is defined by SEP-2575 and applied to tasks by SEP-2663.

Skim: nothing else.

## Decision log

- **Idempotent cancel implemented in the handler, not the store.** `InMemoryTaskStore.Cancel` still rejects terminal→terminal with `errTaskTerminal`; the handler does a `store.Get` first and short-circuits if terminal. Keeps the store invariant intact (Cancel is a state transition, terminal→terminal would be a lie) while making the wire surface idempotent. Other store callers see no behavior change.
- **`-32003` is forward-looking.** The merged SEPs don't currently mandate this code for the gated-method path — Luca's review note recommended it as the right code to follow the SEP-2575 pattern. The conformance assertion has a matching open-spec-questions flag in its README. If the spec lands on something different, we flip in lockstep.
- **No new test for terminal-cancel idempotency on the Go side.** The conformance suite `tasks-cancel-terminal-idempotent-ack` exercises this end-to-end against the fixture — that's the canonical assertion. Adding a duplicate Go-level test would just be a second source of truth.

## Risk / blast radius

- **Affects:** any client of `ext/tasks` that depends on the specific error code returned by the gated tasks/* paths or by terminal `tasks/cancel`. No public API change; behavior change only.
- **Tests covering this:** the three `*RejectedWithoutExtension` tests in `ext/tasks/tasks_test.go` (Go side) and the `tasks-methods-gated-without-extension` + `tasks-cancel-terminal-idempotent-ack` checks in `panyam/mcpconformance` PR 262 (conformance side).
- **Be paranoid about:** other callers of `InMemoryTaskStore.Cancel` that might rely on the `errTaskTerminal` return value. Grep confirms only the v2 cancel handler is the call site; v1's `tasks/cancel` uses a different store API path.

## Out of scope (deliberately deferred)

- Filing a conformance follow-up issue covering (a) rewriting the `notifications/tasks` scenario against `subscriptions/listen` now that PR 271 has landed and (b) the MRTR↔Tasks composition test for the `requestState` asymmetry. Will file once panyam/mcpconformance PR 262 merges.

## Test plan

- [x] `go build ./...` from repo root
- [x] `go test ./...` in `ext/tasks/` — all green
- [x] `make test` from repo root — all green (core, server, client, testutil)
- [x] `make testconf-tasks-v2` — 9/9 scenarios pass against the in-lockstep `panyam/mcpconformance` branch (`feat/tasks-mrtr-extension`)
