### PR TITLE
cleanup(core): split MRTR types out of task_v2.go into mrtr.go

### DIFF
--- a/core/mrtr.go
+++ b/core/mrtr.go
@@ -1,0 +1,327 @@
+package core
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// SEP-2322 (Multi-Round Tool Result, "MRTR") base types.
+//
+// MRTR is the ephemeral input-required flow on top of any request method
+// (typically tools/call): when a server needs additional input before it
+// can produce a final result, it returns InputRequiredResult; the client
+// retries the same request method with `inputResponses` keyed against the
+// previously-emitted ids (plus the echoed `requestState`). Rounds continue
+// until the server returns a complete result, a CreateTaskResult (handing
+// off to tasks-v2 in core/task_v2.go), or an error.
+//
+// The discriminator (ResultType) and the round-token signing helpers
+// (Sign/VerifyRequestState, Sign/VerifyMRTRState) live here because
+// SEP-2322 defines them. SEP-2663 tasks-v2 consumes the same discriminator
+// and the same input-key/request shape, but those types stay owned by
+// SEP-2322.
+
+// ResultType is the discriminator on a tools/call response.
+//
+// "task" indicates a task-based response (CreateTaskResult). The "complete"
+// and "input_required" values come from MRTR (Multi-Round Tool Result,
+// SEP-2322) and signal whether a tool result is final or expects further
+// input rounds. The "input_required" variant was renamed from "incomplete"
+// in SEP-2322 commit de6d76fb, merged 2026-05-06.
+type ResultType string
+
+const (
+	ResultTypeTask          ResultType = "task"
+	ResultTypeComplete      ResultType = "complete"       // SEP-2322
+	ResultTypeInputRequired ResultType = "input_required" // SEP-2322
+)
+
+// InputRequest is a single MRTR input request enqueued by a server during
+// tool execution: a method (e.g., "elicitation/create", "sampling/createMessage")
+// plus opaque params encoded per that method's request schema. // SEP-2322
+type InputRequest struct {
+	Method string          `json:"method"`
+	Params json.RawMessage `json:"params,omitempty"`
+}
+
+// InputRequests is the wire-format map from request key to InputRequest.
+// Keys are server-chosen identifiers (e.g., "elicit-1") that the client
+// echoes verbatim in the matching InputResponses entry. // SEP-2322
+type InputRequests = map[string]InputRequest
+
+// InputResponses is the wire-format map from request key to opaque response
+// payload. Keys MUST match those previously returned in InputRequests. The
+// payload shape is defined by the original request method. // SEP-2322
+type InputResponses = map[string]json.RawMessage
+
+// InputRequiredResult is the SEP-2322 wire envelope returned by tools/call
+// (and other request methods, in principle) when the server needs additional
+// input from the client before it can produce a final result. Clients retry
+// the same request with `inputResponses` (and the echoed `requestState`)
+// until the server returns a complete result, a CreateTaskResult, or an
+// error.
+//
+// Renamed from IncompleteResult in SEP-2322 commit de6d76fb (merged
+// 2026-05-06) per dsp-ant request. The wire `resultType` value flipped
+// from "incomplete" to "input_required" at the same time. SEP-2663 had
+// not yet adopted the rename as of 2026-05-07 PM, but Caitie committed
+// to a coherent Draft Spec + Schema at the 5/15 RC (issue comment
+// 4384052694), so the alignment direction is "input_required" both
+// places.
+//
+// Wire-format note: the `resultType` discriminator is camelCase like every
+// other MCP wire field — Luca confirmed camelCase is the SEP-2322 spec
+// standard. (The upstream conformance suite briefly used snake_case but
+// that's being corrected on their side.)
+type InputRequiredResult struct {
+	// ResultType is always "input_required". Defaulted by MarshalJSON when
+	// empty so server handlers can build the struct without thinking about
+	// it.
+	ResultType ResultType `json:"resultType"`
+
+	// InputRequests is the map of server-chosen request keys → InputRequest
+	// describing what the server needs from the client. Keys are echoed back
+	// verbatim by the client in the matching InputResponses entry.
+	InputRequests InputRequests `json:"inputRequests,omitempty"`
+
+	// RequestState is the opaque session-continuation token. SEP-2322 says
+	// servers MUST treat any echoed value as attacker-controlled; the helper
+	// API in dispatch HMAC-signs it when a key is configured.
+	RequestState string `json:"requestState,omitempty"`
+}
+
+// MarshalJSON defaults ResultType to ResultTypeInputRequired so handlers
+// that build an InputRequiredResult{} literal don't have to set the
+// discriminator.
+func (r InputRequiredResult) MarshalJSON() ([]byte, error) {
+	type alias InputRequiredResult
+	if r.ResultType == "" {
+		r.ResultType = ResultTypeInputRequired
+	}
+	return json.Marshal(alias(r))
+}
+
+// --- MRTR requestState signing ---
+//
+// SEP-2322's InputRequiredResult.RequestState carries an opaque token from
+// server to client which the client MUST echo on subsequent requests. The
+// helpers below implement an HMAC-SHA256-signed encoding so a stateless
+// server can verify the token came back unmodified, plus a plaintext mode
+// for deployments without a signing key.
+//
+// Wire format (signed): "<base64url-signature>.<base64url-payload>" where
+// payload is the JSON encoding of MRTRRoundState {tool, answered, exp}.
+// base64url is chosen to keep the token URL/header-safe without escaping.
+//
+// SignRequestState / VerifyRequestState use the older requestStatePayload
+// {taskId, exp} shape. SEP-2663 removed `requestState` from the tasks-v2
+// wire, so the tasks-v2 paths no longer call them. They are retained
+// because server/mrtr.go reads legacy single-round tokens with this shape
+// for backward compatibility; that shim is removable once all in-flight
+// rounds have rotated past.
+
+// ErrRequestStateMalformed indicates the encoded requestState couldn't be
+// parsed (missing separator, bad base64, bad JSON inside the payload).
+var ErrRequestStateMalformed = errors.New("requestState malformed")
+
+// ErrRequestStateInvalidSignature indicates the HMAC signature did not match
+// — either tampered payload or wrong key.
+var ErrRequestStateInvalidSignature = errors.New("requestState signature invalid")
+
+// ErrRequestStateExpired indicates the payload's expiry is in the past.
+var ErrRequestStateExpired = errors.New("requestState expired")
+
+// requestStatePayload is the JSON body wrapped inside a signed
+// requestState token (legacy single-round MRTR shape). Compact (two
+// fields) so the encoded form stays small.
+type requestStatePayload struct {
+	TaskID string `json:"taskId"`
+	Exp    int64  `json:"exp"` // unix seconds
+}
+
+// SignRequestState produces an HMAC-SHA256-signed requestState token for
+// the given taskID, valid for ttl. The encoded form is opaque to clients
+// and round-trippable via VerifyRequestState. Panics if key is empty.
+//
+// Retained for backward-compat with legacy MRTR tokens; see the section
+// banner above.
+func SignRequestState(key []byte, taskID string, ttl time.Duration) string {
+	if len(key) == 0 {
+		panic("core.SignRequestState: empty key")
+	}
+	payload := requestStatePayload{
+		TaskID: taskID,
+		Exp:    time.Now().Add(ttl).Unix(),
+	}
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		panic(fmt.Sprintf("core.SignRequestState: marshal payload: %v", err))
+	}
+	mac := hmac.New(sha256.New, key)
+	mac.Write(payloadBytes)
+	sig := mac.Sum(nil)
+	return base64.RawURLEncoding.EncodeToString(sig) + "." +
+		base64.RawURLEncoding.EncodeToString(payloadBytes)
+}
+
+// VerifyRequestState checks an incoming requestState token against the
+// signing key and current time. Returns the embedded taskID on success.
+// Errors:
+//   - ErrRequestStateMalformed: structural parse failures (split, base64, JSON)
+//   - ErrRequestStateInvalidSignature: signature mismatch (tampered or wrong key)
+//   - ErrRequestStateExpired: payload exp is in the past
+//
+// Uses hmac.Equal for constant-time signature comparison. Retained for
+// backward-compat with legacy MRTR tokens; see the section banner above.
+func VerifyRequestState(key []byte, state string) (taskID string, err error) {
+	if len(key) == 0 {
+		return "", ErrRequestStateMalformed
+	}
+	dot := strings.IndexByte(state, '.')
+	if dot < 0 {
+		return "", ErrRequestStateMalformed
+	}
+	sig, err := base64.RawURLEncoding.DecodeString(state[:dot])
+	if err != nil {
+		return "", ErrRequestStateMalformed
+	}
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(state[dot+1:])
+	if err != nil {
+		return "", ErrRequestStateMalformed
+	}
+	mac := hmac.New(sha256.New, key)
+	mac.Write(payloadBytes)
+	expected := mac.Sum(nil)
+	if !hmac.Equal(sig, expected) {
+		return "", ErrRequestStateInvalidSignature
+	}
+	var payload requestStatePayload
+	if err := json.Unmarshal(payloadBytes, &payload); err != nil {
+		return "", ErrRequestStateMalformed
+	}
+	if payload.Exp > 0 && time.Now().Unix() > payload.Exp {
+		return "", ErrRequestStateExpired
+	}
+	return payload.TaskID, nil
+}
+
+// MRTRRoundState is the payload encoded inside an SEP-2322 ephemeral
+// requestState token across multi-round flows. The dispatcher uses it to
+// carry accumulated InputResponses from previous rounds back to the
+// handler — the wire protocol only ships the current round's responses,
+// so without this carry-over a stateless handler couldn't see history.
+//
+// Tool is the tool name the token was issued for; replays against a
+// different tool fail with ErrRequestStateInvalidSignature. Answered is
+// the merged inputResponses map (raw, opaque per-key payloads). Exp is
+// the unix-seconds expiry, mirroring the requestStatePayload semantics.
+type MRTRRoundState struct {
+	Tool     string                     `json:"tool"`
+	Answered map[string]json.RawMessage `json:"answered,omitempty"`
+	Exp      int64                      `json:"exp"`
+}
+
+// SignMRTRState produces an HMAC-SHA256-signed requestState token wrapping
+// state. ttl bounds the token's validity. Same wire format as
+// SignRequestState ("<base64url-sig>.<base64url-payload>") so the same
+// helpers in transports/middleware that already strip / re-add the prefix
+// work uniformly. Panics if key is empty — callers should fall back to
+// the plaintext encoder when no signing key is configured.
+func SignMRTRState(key []byte, state MRTRRoundState, ttl time.Duration) (string, error) {
+	if len(key) == 0 {
+		return "", errors.New("core.SignMRTRState: empty key")
+	}
+	if state.Exp == 0 {
+		state.Exp = time.Now().Add(ttl).Unix()
+	}
+	payloadBytes, err := json.Marshal(state)
+	if err != nil {
+		return "", fmt.Errorf("marshal MRTR state: %w", err)
+	}
+	mac := hmac.New(sha256.New, key)
+	mac.Write(payloadBytes)
+	sig := mac.Sum(nil)
+	return base64.RawURLEncoding.EncodeToString(sig) + "." +
+		base64.RawURLEncoding.EncodeToString(payloadBytes), nil
+}
+
+// VerifyMRTRState validates an incoming MRTR requestState token against the
+// signing key + current time and returns the embedded round state. Errors:
+//   - ErrRequestStateMalformed: structural parse failures (split, base64, JSON)
+//   - ErrRequestStateInvalidSignature: signature mismatch (tampered or wrong key)
+//   - ErrRequestStateExpired: payload exp is in the past
+//
+// Uses hmac.Equal for constant-time signature comparison.
+func VerifyMRTRState(key []byte, token string) (MRTRRoundState, error) {
+	if len(key) == 0 {
+		return MRTRRoundState{}, ErrRequestStateMalformed
+	}
+	dot := strings.IndexByte(token, '.')
+	if dot < 0 {
+		return MRTRRoundState{}, ErrRequestStateMalformed
+	}
+	sig, err := base64.RawURLEncoding.DecodeString(token[:dot])
+	if err != nil {
+		return MRTRRoundState{}, ErrRequestStateMalformed
+	}
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(token[dot+1:])
+	if err != nil {
+		return MRTRRoundState{}, ErrRequestStateMalformed
+	}
+	mac := hmac.New(sha256.New, key)
+	mac.Write(payloadBytes)
+	expected := mac.Sum(nil)
+	if !hmac.Equal(sig, expected) {
+		return MRTRRoundState{}, ErrRequestStateInvalidSignature
+	}
+	var state MRTRRoundState
+	if err := json.Unmarshal(payloadBytes, &state); err != nil {
+		return MRTRRoundState{}, ErrRequestStateMalformed
+	}
+	if state.Exp > 0 && time.Now().Unix() > state.Exp {
+		return MRTRRoundState{}, ErrRequestStateExpired
+	}
+	return state, nil
+}
+
+// EncodeMRTRStatePlaintext returns a base64url-encoded JSON of state with no
+// integrity guarantee — used by the dispatcher in plaintext mode when no
+// signing key is configured. The encoded form is parseable but trivially
+// forgeable; SEP-2322 servers without a signing key must treat it as
+// untrusted regardless.
+func EncodeMRTRStatePlaintext(state MRTRRoundState) (string, error) {
+	if state.Exp == 0 {
+		state.Exp = time.Now().Add(24 * time.Hour).Unix()
+	}
+	payloadBytes, err := json.Marshal(state)
+	if err != nil {
+		return "", fmt.Errorf("marshal MRTR state: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(payloadBytes), nil
+}
+
+// DecodeMRTRStatePlaintext parses a token produced by EncodeMRTRStatePlaintext.
+// Returns ErrRequestStateMalformed for unparseable tokens and
+// ErrRequestStateExpired when the embedded exp is in the past. No signature
+// check (plaintext mode has none).
+func DecodeMRTRStatePlaintext(token string) (MRTRRoundState, error) {
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		return MRTRRoundState{}, ErrRequestStateMalformed
+	}
+	var state MRTRRoundState
+	if err := json.Unmarshal(payloadBytes, &state); err != nil {
+		return MRTRRoundState{}, ErrRequestStateMalformed
+	}
+	if state.Exp > 0 && time.Now().Unix() > state.Exp {
+		return MRTRRoundState{}, ErrRequestStateExpired
+	}
+	return state, nil
+}
+

--- a/core/mrtr_test.go
+++ b/core/mrtr_test.go
@@ -1,0 +1,344 @@
+package core
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestResultTypeConstants verifies the wire values of the ResultType
+// discriminator. "task" is SEP-2557; "complete" / "input_required" are
+// SEP-2322 (MRTR), with "input_required" renamed from the earlier
+// "incomplete" in commit de6d76fb (merged 2026-05-06).
+func TestResultTypeConstants(t *testing.T) {
+	cases := []struct {
+		rt   ResultType
+		want string
+	}{
+		{ResultTypeTask, "task"},
+		{ResultTypeComplete, "complete"},
+		{ResultTypeInputRequired, "input_required"},
+	}
+	for _, tc := range cases {
+		if string(tc.rt) != tc.want {
+			t.Errorf("ResultType(%v) = %q, want %q", tc.rt, string(tc.rt), tc.want)
+		}
+		// JSON round-trip as a bare string.
+		data, err := json.Marshal(tc.rt)
+		if err != nil {
+			t.Fatalf("Marshal(%q): %v", tc.rt, err)
+		}
+		var got ResultType
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("Unmarshal(%s): %v", data, err)
+		}
+		if got != tc.rt {
+			t.Errorf("round-trip: got %q, want %q", got, tc.rt)
+		}
+	}
+}
+
+// TestInputRequestJSON verifies wire shape: {"method": "...", "params": {...}}
+// with params omitted when nil. Round-trip must preserve raw params bytes.
+func TestInputRequestJSON(t *testing.T) {
+	params := json.RawMessage(`{"message":"Confirm?","schema":{"type":"object"}}`)
+	req := InputRequest{
+		Method: "elicitation/create",
+		Params: params,
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatal(err)
+	}
+	if m["method"] != "elicitation/create" {
+		t.Errorf("method = %v, want elicitation/create", m["method"])
+	}
+	if _, ok := m["params"]; !ok {
+		t.Error("params missing from JSON output")
+	}
+
+	var decoded InputRequest
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Method != req.Method {
+		t.Errorf("Method = %q, want %q", decoded.Method, req.Method)
+	}
+	// json.RawMessage round-trips as raw bytes; compact equivalence is enough
+	// because the encoder may re-format whitespace.
+	var orig, got any
+	_ = json.Unmarshal(params, &orig)
+	_ = json.Unmarshal(decoded.Params, &got)
+	origBytes, _ := json.Marshal(orig)
+	gotBytes, _ := json.Marshal(got)
+	if string(origBytes) != string(gotBytes) {
+		t.Errorf("Params mismatch: got %s, want %s", gotBytes, origBytes)
+	}
+}
+
+// TestInputRequestOmitEmptyParams verifies that an InputRequest with nil
+// params omits the field entirely (not "params":null).
+func TestInputRequestOmitEmptyParams(t *testing.T) {
+	req := InputRequest{Method: "ping"}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	json.Unmarshal(data, &m)
+	if _, ok := m["params"]; ok {
+		t.Errorf("params should be omitted when nil; got %s", data)
+	}
+}
+
+// TestInputRequestsMapJSON verifies that InputRequests (alias for
+// map[string]InputRequest) marshals as a JSON object keyed by request id.
+func TestInputRequestsMapJSON(t *testing.T) {
+	reqs := InputRequests{
+		"elicit-1": InputRequest{Method: "elicitation/create", Params: json.RawMessage(`{"message":"ok?"}`)},
+		"sample-1": InputRequest{Method: "sampling/createMessage", Params: json.RawMessage(`{"maxTokens":50}`)},
+	}
+	data, err := json.Marshal(reqs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded InputRequests
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if len(decoded) != 2 {
+		t.Fatalf("len = %d, want 2", len(decoded))
+	}
+	if decoded["elicit-1"].Method != "elicitation/create" {
+		t.Errorf("elicit-1.method = %q, want elicitation/create", decoded["elicit-1"].Method)
+	}
+	if decoded["sample-1"].Method != "sampling/createMessage" {
+		t.Errorf("sample-1.method = %q, want sampling/createMessage", decoded["sample-1"].Method)
+	}
+}
+
+// TestInputResponsesMapJSON verifies that InputResponses (alias for
+// map[string]json.RawMessage) preserves opaque payload bytes per key.
+func TestInputResponsesMapJSON(t *testing.T) {
+	resps := InputResponses{
+		"elicit-1": json.RawMessage(`{"action":"accept","content":{"confirmed":true}}`),
+		"sample-1": json.RawMessage(`{"role":"assistant","content":{"type":"text","text":"hello"}}`),
+	}
+	data, err := json.Marshal(resps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded InputResponses
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if len(decoded) != 2 {
+		t.Fatalf("len = %d, want 2", len(decoded))
+	}
+	var v map[string]any
+	if err := json.Unmarshal(decoded["elicit-1"], &v); err != nil {
+		t.Fatalf("elicit-1 not valid JSON: %v", err)
+	}
+	if v["action"] != "accept" {
+		t.Errorf("elicit-1.action = %v, want accept", v["action"])
+	}
+}
+
+// TestInputRequiredResultWireShape verifies the SEP-2322 ephemeral wire
+// shape: {"resultType": "input_required", "inputRequests": {...},
+// "requestState": "..."}. resultType is camelCase like every other MCP
+// wire field — Luca confirmed camelCase is the SEP-2322 spec standard.
+// "input_required" is the SEP-2322 wire variant value, renamed from
+// "incomplete" in commit de6d76fb (merged 2026-05-06).
+func TestInputRequiredResultWireShape(t *testing.T) {
+	res := InputRequiredResult{
+		InputRequests: InputRequests{
+			"user_name": InputRequest{
+				Method: "elicitation/create",
+				Params: json.RawMessage(`{"message":"What is your name?"}`),
+			},
+		},
+		RequestState: "opaque-state",
+	}
+	data, err := json.Marshal(res)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatal(err)
+	}
+
+	if m["resultType"] != "input_required" {
+		t.Errorf("resultType = %v, want \"input_required\"; got %s", m["resultType"], data)
+	}
+	if _, ok := m["result_type"]; ok {
+		t.Errorf("snake_case result_type must NOT appear (camelCase is the wire field); got %s", data)
+	}
+	if m["requestState"] != "opaque-state" {
+		t.Errorf("requestState = %v, want opaque-state", m["requestState"])
+	}
+	reqs, ok := m["inputRequests"].(map[string]any)
+	if !ok {
+		t.Fatalf("inputRequests missing or wrong shape; got %s", data)
+	}
+	entry, ok := reqs["user_name"].(map[string]any)
+	if !ok {
+		t.Fatalf("inputRequests[user_name] missing; got %s", data)
+	}
+	if entry["method"] != "elicitation/create" {
+		t.Errorf("inputRequests[user_name].method = %v, want elicitation/create", entry["method"])
+	}
+}
+
+// TestInputRequiredResultDefaultsResultType verifies that a zero-value
+// InputRequiredResult marshals with resultType = "input_required" so
+// handlers can build InputRequiredResult{InputRequests: ...} without
+// setting the discriminator manually.
+func TestInputRequiredResultDefaultsResultType(t *testing.T) {
+	data, err := json.Marshal(InputRequiredResult{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	json.Unmarshal(data, &m)
+	if m["resultType"] != "input_required" {
+		t.Errorf("zero-value InputRequiredResult.resultType = %v, want \"input_required\"; got %s",
+			m["resultType"], data)
+	}
+}
+
+// --- SEP-2322 requestState signing ---
+
+// TestRequestState_RoundTrip verifies a freshly signed token verifies cleanly
+// and exposes the original taskID. The base case for the HMAC flow.
+func TestRequestState_RoundTrip(t *testing.T) {
+	key := []byte("test-key-32-bytes-min-for-hmac-shake")
+	state := SignRequestState(key, "task-abc", time.Hour)
+	if state == "" {
+		t.Fatal("SignRequestState returned empty string")
+	}
+	got, err := VerifyRequestState(key, state)
+	if err != nil {
+		t.Fatalf("VerifyRequestState: %v", err)
+	}
+	if got != "task-abc" {
+		t.Errorf("decoded taskID = %q, want %q", got, "task-abc")
+	}
+}
+
+// TestRequestState_TamperedPayload verifies that any modification to the
+// payload bytes (even a single character flip) invalidates the signature.
+// This is the core attacker scenario the HMAC defends against.
+func TestRequestState_TamperedPayload(t *testing.T) {
+	key := []byte("test-key-32-bytes-min-for-hmac-shake")
+	state := SignRequestState(key, "task-abc", time.Hour)
+	dot := strings.IndexByte(state, '.')
+	if dot < 0 {
+		t.Fatalf("expected '.' separator in signed state %q", state)
+	}
+	// Re-encode a different payload (taskId swap) but keep the original sig.
+	tampered := state[:dot+1] + base64.RawURLEncoding.EncodeToString([]byte(`{"taskId":"task-evil","exp":9999999999}`))
+	if _, err := VerifyRequestState(key, tampered); err != ErrRequestStateInvalidSignature {
+		t.Errorf("tampered payload: err = %v, want ErrRequestStateInvalidSignature", err)
+	}
+}
+
+// TestRequestState_TamperedSignature verifies that a flipped signature byte
+// (with the original payload intact) is also rejected. Symmetric with the
+// payload-tamper case.
+func TestRequestState_TamperedSignature(t *testing.T) {
+	key := []byte("test-key-32-bytes-min-for-hmac-shake")
+	state := SignRequestState(key, "task-abc", time.Hour)
+	dot := strings.IndexByte(state, '.')
+	if dot < 0 {
+		t.Fatalf("expected '.' separator")
+	}
+	// Flip a byte inside the signature (replace first char with one that
+	// decodes to different bytes).
+	sigChar := byte('A')
+	if state[0] == 'A' {
+		sigChar = 'B'
+	}
+	tampered := string(sigChar) + state[1:]
+	if _, err := VerifyRequestState(key, tampered); err != ErrRequestStateInvalidSignature {
+		t.Errorf("tampered signature: err = %v, want ErrRequestStateInvalidSignature", err)
+	}
+}
+
+// TestRequestState_Expired verifies that a token whose exp is in the past
+// is rejected even when the signature is valid.
+func TestRequestState_Expired(t *testing.T) {
+	key := []byte("test-key-32-bytes-min-for-hmac-shake")
+	// Negative TTL = exp in the past.
+	state := SignRequestState(key, "task-abc", -time.Second)
+	if _, err := VerifyRequestState(key, state); err != ErrRequestStateExpired {
+		t.Errorf("expired state: err = %v, want ErrRequestStateExpired", err)
+	}
+}
+
+// TestRequestState_Malformed batches the structural-failure cases so a
+// single test guards every parse path that should map to ErrRequestStateMalformed.
+func TestRequestState_Malformed(t *testing.T) {
+	key := []byte("test-key-32-bytes-min-for-hmac-shake")
+	cases := []struct {
+		name  string
+		state string
+	}{
+		{"missing separator", "no-dot-here-just-text"},
+		{"bad signature base64", "!!!!.eyJ0YXNrSWQiOiJ0YXNrLWFiYyIsImV4cCI6MX0"},
+		{"bad payload base64", "abc.!!!!"},
+		{"empty", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := VerifyRequestState(key, tc.state); err != ErrRequestStateMalformed {
+				t.Errorf("err = %v, want ErrRequestStateMalformed", err)
+			}
+		})
+	}
+}
+
+// TestRequestState_WrongKey verifies that a token signed with one key can't
+// be verified with a different key — covers the multi-tenant case where
+// each tenant has its own signing key.
+func TestRequestState_WrongKey(t *testing.T) {
+	keyA := []byte("tenant-a-key-32-bytes-padding-here")
+	keyB := []byte("tenant-b-key-32-bytes-padding-here")
+	state := SignRequestState(keyA, "task-abc", time.Hour)
+	if _, err := VerifyRequestState(keyB, state); err != ErrRequestStateInvalidSignature {
+		t.Errorf("wrong key: err = %v, want ErrRequestStateInvalidSignature", err)
+	}
+}
+
+// TestRequestState_BadJSONPayload verifies that a payload that survives
+// base64 + HMAC but doesn't parse as the expected JSON shape is reported
+// as malformed (not invalid-signature).
+func TestRequestState_BadJSONPayload(t *testing.T) {
+	key := []byte("test-key-32-bytes-min-for-hmac-shake")
+	rawPayload := []byte("not-json-at-all")
+	mac := hmacFromKey(t, key, rawPayload)
+	state := base64.RawURLEncoding.EncodeToString(mac) + "." +
+		base64.RawURLEncoding.EncodeToString(rawPayload)
+	if _, err := VerifyRequestState(key, state); err != ErrRequestStateMalformed {
+		t.Errorf("bad JSON payload: err = %v, want ErrRequestStateMalformed", err)
+	}
+}
+
+// hmacFromKey is a tiny test helper to compute an HMAC-SHA256 sig over an
+// arbitrary payload — used by TestRequestState_BadJSONPayload to forge a
+// signature-valid-but-payload-broken token.
+func hmacFromKey(t *testing.T, key, payload []byte) []byte {
+	t.Helper()
+	h := hmac.New(sha256.New, key)
+	h.Write(payload)
+	return h.Sum(nil)
+}

--- a/core/task_v2.go
+++ b/core/task_v2.go
@@ -2,14 +2,7 @@ package core
 
 import (
 	"context"
-	"crypto/hmac"
-	"crypto/sha256"
-	"encoding/base64"
 	"encoding/json"
-	"errors"
-	"fmt"
-	"strings"
-	"time"
 )
 
 // TasksExtensionID is the protocol extension identifier for SEP-2663 Tasks.
@@ -25,18 +18,18 @@ func ClientSupportsTasks(ctx context.Context) bool {
 	return ClientSupportsExtension(ctx, TasksExtensionID)
 }
 
-// Tasks v2 types — SEP-2663 (Tasks Extension), SEP-2557 (resultType
-// discriminator), and MRTR base types from SEP-2322.
+// SEP-2663 (Tasks Extension) wire types.
+//
+// Tasks-v2 builds on the SEP-2322 MRTR base types in core/mrtr.go — the
+// ResultType discriminator, InputRequest / InputRequests / InputResponses
+// shapes, and the requestState signing helpers all live there because
+// SEP-2322 owns them.
 //
 // Wire-format differences from v1:
-//   - tools/call carries a resultType discriminator: "task" (this file),
-//     "complete" / "input_required" (MRTR — see ResultType constants).
-//     The "input_required" variant was renamed from "incomplete" in
-//     SEP-2322 commit de6d76fb (merged 2026-05-06) per dsp-ant request,
-//     to avoid the semantic collision with task-creating tools/call
-//     responses (which are also "incomplete" in some sense).
+//   - tools/call carries a ResultType discriminator: "task" (this file),
+//     "complete" / "input_required" (MRTR — see core/mrtr.go).
 //   - tasks/get returns DetailedTask: a discriminated union by status that
-//     inlines result / error / inputRequests / requestState in one trip.
+//     inlines result / error / inputRequests in one trip.
 //   - tasks/cancel and tasks/update return empty acks (no task state).
 //   - Task wire fields use the Ms suffix: ttlMs, pollIntervalMs (both
 //     integer milliseconds). Internal stores already use ms, so the v2
@@ -44,39 +37,6 @@ func ClientSupportsTasks(ctx context.Context) bool {
 //   - parentTaskId removed (SEP-2663 does not model task parentage).
 //   - Tool errors: status "completed" with result.isError == true.
 //   - Protocol errors: status "failed" with the error inlined.
-
-// ResultType is the discriminator on a tools/call response.
-//
-// "task" indicates a task-based response (CreateTaskResult). The "complete"
-// and "input_required" values come from MRTR (Multi-Round Tool Result,
-// SEP-2322) and signal whether a tool result is final or expects further
-// input rounds. The "input_required" variant was renamed from "incomplete"
-// in SEP-2322 commit de6d76fb, merged 2026-05-06.
-type ResultType string
-
-const (
-	ResultTypeTask          ResultType = "task"
-	ResultTypeComplete      ResultType = "complete"       // SEP-2322
-	ResultTypeInputRequired ResultType = "input_required" // SEP-2322
-)
-
-// InputRequest is a single MRTR input request enqueued by a server during
-// tool execution: a method (e.g., "elicitation/create", "sampling/createMessage")
-// plus opaque params encoded per that method's request schema. // SEP-2322
-type InputRequest struct {
-	Method string          `json:"method"`
-	Params json.RawMessage `json:"params,omitempty"`
-}
-
-// InputRequests is the wire-format map from request key to InputRequest.
-// Keys are server-chosen identifiers (e.g., "elicit-1") that the client
-// echoes verbatim in the matching InputResponses entry. // SEP-2322
-type InputRequests = map[string]InputRequest
-
-// InputResponses is the wire-format map from request key to opaque response
-// payload. Keys MUST match those previously returned in InputRequests. The
-// payload shape is defined by the original request method. // SEP-2322
-type InputResponses = map[string]json.RawMessage
 
 // TaskInfoV2 is the v2 wire shape for task metadata. Differences from
 // (v1) TaskInfo:
@@ -234,269 +194,3 @@ func (c CancelTaskResult) MarshalJSON() ([]byte, error) {
 	}
 	return json.Marshal(alias(c))
 }
-
-// InputRequiredResult is the SEP-2322 wire envelope returned by tools/call
-// (and other request methods, in principle) when the server needs additional
-// input from the client before it can produce a final result. Clients retry
-// the same request with `inputResponses` (and the echoed `requestState`)
-// until the server returns a complete result, a CreateTaskResult, or an
-// error.
-//
-// Renamed from IncompleteResult in SEP-2322 commit de6d76fb (merged
-// 2026-05-06) per dsp-ant request. The wire `resultType` value flipped
-// from "incomplete" to "input_required" at the same time. SEP-2663 had
-// not yet adopted the rename as of 2026-05-07 PM, but Caitie committed
-// to a coherent Draft Spec + Schema at the 5/15 RC (issue comment
-// 4384052694), so the alignment direction is "input_required" both
-// places.
-//
-// Wire-format note: the `resultType` discriminator is camelCase like every
-// other MCP wire field — Luca confirmed camelCase is the SEP-2322 spec
-// standard. (The upstream conformance suite briefly used snake_case but
-// that's being corrected on their side.)
-type InputRequiredResult struct {
-	// ResultType is always "input_required". Defaulted by MarshalJSON when
-	// empty so server handlers can build the struct without thinking about
-	// it.
-	ResultType ResultType `json:"resultType"`
-
-	// InputRequests is the map of server-chosen request keys → InputRequest
-	// describing what the server needs from the client. Keys are echoed back
-	// verbatim by the client in the matching InputResponses entry.
-	InputRequests InputRequests `json:"inputRequests,omitempty"`
-
-	// RequestState is the opaque session-continuation token. SEP-2322 says
-	// servers MUST treat any echoed value as attacker-controlled; the helper
-	// API in dispatch HMAC-signs it when a key is configured.
-	RequestState string `json:"requestState,omitempty"`
-}
-
-// MarshalJSON defaults ResultType to ResultTypeInputRequired so handlers
-// that build an InputRequiredResult{} literal don't have to set the
-// discriminator.
-func (r InputRequiredResult) MarshalJSON() ([]byte, error) {
-	type alias InputRequiredResult
-	if r.ResultType == "" {
-		r.ResultType = ResultTypeInputRequired
-	}
-	return json.Marshal(alias(r))
-}
-
-// --- MRTR requestState signing ---
-//
-// SEP-2322's InputRequiredResult.RequestState carries an opaque token from
-// server to client which the client MUST echo on subsequent requests. The
-// helpers below implement an HMAC-SHA256-signed encoding so a stateless
-// server can verify the token came back unmodified, plus a plaintext mode
-// for deployments without a signing key.
-//
-// Wire format (signed): "<base64url-signature>.<base64url-payload>" where
-// payload is the JSON encoding of MRTRRoundState {tool, answered, exp}.
-// base64url is chosen to keep the token URL/header-safe without escaping.
-//
-// SignRequestState / VerifyRequestState use the older requestStatePayload
-// {taskId, exp} shape. SEP-2663 removed `requestState` from the tasks-v2
-// wire, so the tasks-v2 paths no longer call them. They are retained
-// because server/mrtr.go reads legacy single-round tokens with this shape
-// for backward compatibility; that shim is removable once all in-flight
-// rounds have rotated past.
-
-// ErrRequestStateMalformed indicates the encoded requestState couldn't be
-// parsed (missing separator, bad base64, bad JSON inside the payload).
-var ErrRequestStateMalformed = errors.New("requestState malformed")
-
-// ErrRequestStateInvalidSignature indicates the HMAC signature did not match
-// — either tampered payload or wrong key.
-var ErrRequestStateInvalidSignature = errors.New("requestState signature invalid")
-
-// ErrRequestStateExpired indicates the payload's expiry is in the past.
-var ErrRequestStateExpired = errors.New("requestState expired")
-
-// requestStatePayload is the JSON body wrapped inside a signed
-// requestState token (legacy single-round MRTR shape). Compact (two
-// fields) so the encoded form stays small.
-type requestStatePayload struct {
-	TaskID string `json:"taskId"`
-	Exp    int64  `json:"exp"` // unix seconds
-}
-
-// SignRequestState produces an HMAC-SHA256-signed requestState token for
-// the given taskID, valid for ttl. The encoded form is opaque to clients
-// and round-trippable via VerifyRequestState. Panics if key is empty.
-//
-// Retained for backward-compat with legacy MRTR tokens; see the section
-// banner above.
-func SignRequestState(key []byte, taskID string, ttl time.Duration) string {
-	if len(key) == 0 {
-		panic("core.SignRequestState: empty key")
-	}
-	payload := requestStatePayload{
-		TaskID: taskID,
-		Exp:    time.Now().Add(ttl).Unix(),
-	}
-	payloadBytes, err := json.Marshal(payload)
-	if err != nil {
-		panic(fmt.Sprintf("core.SignRequestState: marshal payload: %v", err))
-	}
-	mac := hmac.New(sha256.New, key)
-	mac.Write(payloadBytes)
-	sig := mac.Sum(nil)
-	return base64.RawURLEncoding.EncodeToString(sig) + "." +
-		base64.RawURLEncoding.EncodeToString(payloadBytes)
-}
-
-// VerifyRequestState checks an incoming requestState token against the
-// signing key and current time. Returns the embedded taskID on success.
-// Errors:
-//   - ErrRequestStateMalformed: structural parse failures (split, base64, JSON)
-//   - ErrRequestStateInvalidSignature: signature mismatch (tampered or wrong key)
-//   - ErrRequestStateExpired: payload exp is in the past
-//
-// Uses hmac.Equal for constant-time signature comparison. Retained for
-// backward-compat with legacy MRTR tokens; see the section banner above.
-func VerifyRequestState(key []byte, state string) (taskID string, err error) {
-	if len(key) == 0 {
-		return "", ErrRequestStateMalformed
-	}
-	dot := strings.IndexByte(state, '.')
-	if dot < 0 {
-		return "", ErrRequestStateMalformed
-	}
-	sig, err := base64.RawURLEncoding.DecodeString(state[:dot])
-	if err != nil {
-		return "", ErrRequestStateMalformed
-	}
-	payloadBytes, err := base64.RawURLEncoding.DecodeString(state[dot+1:])
-	if err != nil {
-		return "", ErrRequestStateMalformed
-	}
-	mac := hmac.New(sha256.New, key)
-	mac.Write(payloadBytes)
-	expected := mac.Sum(nil)
-	if !hmac.Equal(sig, expected) {
-		return "", ErrRequestStateInvalidSignature
-	}
-	var payload requestStatePayload
-	if err := json.Unmarshal(payloadBytes, &payload); err != nil {
-		return "", ErrRequestStateMalformed
-	}
-	if payload.Exp > 0 && time.Now().Unix() > payload.Exp {
-		return "", ErrRequestStateExpired
-	}
-	return payload.TaskID, nil
-}
-
-// MRTRRoundState is the payload encoded inside an SEP-2322 ephemeral
-// requestState token across multi-round flows. The dispatcher uses it to
-// carry accumulated InputResponses from previous rounds back to the
-// handler — the wire protocol only ships the current round's responses,
-// so without this carry-over a stateless handler couldn't see history.
-//
-// Tool is the tool name the token was issued for; replays against a
-// different tool fail with ErrRequestStateInvalidSignature. Answered is
-// the merged inputResponses map (raw, opaque per-key payloads). Exp is
-// the unix-seconds expiry, mirroring the requestStatePayload semantics.
-type MRTRRoundState struct {
-	Tool     string                     `json:"tool"`
-	Answered map[string]json.RawMessage `json:"answered,omitempty"`
-	Exp      int64                      `json:"exp"`
-}
-
-// SignMRTRState produces an HMAC-SHA256-signed requestState token wrapping
-// state. ttl bounds the token's validity. Same wire format as
-// SignRequestState ("<base64url-sig>.<base64url-payload>") so the same
-// helpers in transports/middleware that already strip / re-add the prefix
-// work uniformly. Panics if key is empty — callers should fall back to
-// the plaintext encoder when no signing key is configured.
-func SignMRTRState(key []byte, state MRTRRoundState, ttl time.Duration) (string, error) {
-	if len(key) == 0 {
-		return "", errors.New("core.SignMRTRState: empty key")
-	}
-	if state.Exp == 0 {
-		state.Exp = time.Now().Add(ttl).Unix()
-	}
-	payloadBytes, err := json.Marshal(state)
-	if err != nil {
-		return "", fmt.Errorf("marshal MRTR state: %w", err)
-	}
-	mac := hmac.New(sha256.New, key)
-	mac.Write(payloadBytes)
-	sig := mac.Sum(nil)
-	return base64.RawURLEncoding.EncodeToString(sig) + "." +
-		base64.RawURLEncoding.EncodeToString(payloadBytes), nil
-}
-
-// VerifyMRTRState validates an incoming MRTR requestState token against the
-// signing key + current time and returns the embedded round state. Errors:
-//   - ErrRequestStateMalformed: structural parse failures (split, base64, JSON)
-//   - ErrRequestStateInvalidSignature: signature mismatch (tampered or wrong key)
-//   - ErrRequestStateExpired: payload exp is in the past
-//
-// Uses hmac.Equal for constant-time signature comparison.
-func VerifyMRTRState(key []byte, token string) (MRTRRoundState, error) {
-	if len(key) == 0 {
-		return MRTRRoundState{}, ErrRequestStateMalformed
-	}
-	dot := strings.IndexByte(token, '.')
-	if dot < 0 {
-		return MRTRRoundState{}, ErrRequestStateMalformed
-	}
-	sig, err := base64.RawURLEncoding.DecodeString(token[:dot])
-	if err != nil {
-		return MRTRRoundState{}, ErrRequestStateMalformed
-	}
-	payloadBytes, err := base64.RawURLEncoding.DecodeString(token[dot+1:])
-	if err != nil {
-		return MRTRRoundState{}, ErrRequestStateMalformed
-	}
-	mac := hmac.New(sha256.New, key)
-	mac.Write(payloadBytes)
-	expected := mac.Sum(nil)
-	if !hmac.Equal(sig, expected) {
-		return MRTRRoundState{}, ErrRequestStateInvalidSignature
-	}
-	var state MRTRRoundState
-	if err := json.Unmarshal(payloadBytes, &state); err != nil {
-		return MRTRRoundState{}, ErrRequestStateMalformed
-	}
-	if state.Exp > 0 && time.Now().Unix() > state.Exp {
-		return MRTRRoundState{}, ErrRequestStateExpired
-	}
-	return state, nil
-}
-
-// EncodeMRTRStatePlaintext returns a base64url-encoded JSON of state with no
-// integrity guarantee — used by the dispatcher in plaintext mode when no
-// signing key is configured. The encoded form is parseable but trivially
-// forgeable; SEP-2322 servers without a signing key must treat it as
-// untrusted regardless.
-func EncodeMRTRStatePlaintext(state MRTRRoundState) (string, error) {
-	if state.Exp == 0 {
-		state.Exp = time.Now().Add(24 * time.Hour).Unix()
-	}
-	payloadBytes, err := json.Marshal(state)
-	if err != nil {
-		return "", fmt.Errorf("marshal MRTR state: %w", err)
-	}
-	return base64.RawURLEncoding.EncodeToString(payloadBytes), nil
-}
-
-// DecodeMRTRStatePlaintext parses a token produced by EncodeMRTRStatePlaintext.
-// Returns ErrRequestStateMalformed for unparseable tokens and
-// ErrRequestStateExpired when the embedded exp is in the past. No signature
-// check (plaintext mode has none).
-func DecodeMRTRStatePlaintext(token string) (MRTRRoundState, error) {
-	payloadBytes, err := base64.RawURLEncoding.DecodeString(token)
-	if err != nil {
-		return MRTRRoundState{}, ErrRequestStateMalformed
-	}
-	var state MRTRRoundState
-	if err := json.Unmarshal(payloadBytes, &state); err != nil {
-		return MRTRRoundState{}, ErrRequestStateMalformed
-	}
-	if state.Exp > 0 && time.Now().Unix() > state.Exp {
-		return MRTRRoundState{}, ErrRequestStateExpired
-	}
-	return state, nil
-}
-

--- a/core/task_v2_test.go
+++ b/core/task_v2_test.go
@@ -1,156 +1,9 @@
 package core
 
 import (
-	"crypto/hmac"
-	"crypto/sha256"
-	"encoding/base64"
 	"encoding/json"
-	"strings"
 	"testing"
-	"time"
 )
-
-// TestResultTypeConstants verifies the wire values of the ResultType
-// discriminator. "task" is SEP-2557; "complete" / "input_required" are
-// SEP-2322 (MRTR), with "input_required" renamed from the earlier
-// "incomplete" in commit de6d76fb (merged 2026-05-06).
-func TestResultTypeConstants(t *testing.T) {
-	cases := []struct {
-		rt   ResultType
-		want string
-	}{
-		{ResultTypeTask, "task"},
-		{ResultTypeComplete, "complete"},
-		{ResultTypeInputRequired, "input_required"},
-	}
-	for _, tc := range cases {
-		if string(tc.rt) != tc.want {
-			t.Errorf("ResultType(%v) = %q, want %q", tc.rt, string(tc.rt), tc.want)
-		}
-		// JSON round-trip as a bare string.
-		data, err := json.Marshal(tc.rt)
-		if err != nil {
-			t.Fatalf("Marshal(%q): %v", tc.rt, err)
-		}
-		var got ResultType
-		if err := json.Unmarshal(data, &got); err != nil {
-			t.Fatalf("Unmarshal(%s): %v", data, err)
-		}
-		if got != tc.rt {
-			t.Errorf("round-trip: got %q, want %q", got, tc.rt)
-		}
-	}
-}
-
-// TestInputRequestJSON verifies wire shape: {"method": "...", "params": {...}}
-// with params omitted when nil. Round-trip must preserve raw params bytes.
-func TestInputRequestJSON(t *testing.T) {
-	params := json.RawMessage(`{"message":"Confirm?","schema":{"type":"object"}}`)
-	req := InputRequest{
-		Method: "elicitation/create",
-		Params: params,
-	}
-	data, err := json.Marshal(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var m map[string]any
-	if err := json.Unmarshal(data, &m); err != nil {
-		t.Fatal(err)
-	}
-	if m["method"] != "elicitation/create" {
-		t.Errorf("method = %v, want elicitation/create", m["method"])
-	}
-	if _, ok := m["params"]; !ok {
-		t.Error("params missing from JSON output")
-	}
-
-	var decoded InputRequest
-	if err := json.Unmarshal(data, &decoded); err != nil {
-		t.Fatal(err)
-	}
-	if decoded.Method != req.Method {
-		t.Errorf("Method = %q, want %q", decoded.Method, req.Method)
-	}
-	// json.RawMessage round-trips as raw bytes; compact equivalence is enough
-	// because the encoder may re-format whitespace.
-	var orig, got any
-	_ = json.Unmarshal(params, &orig)
-	_ = json.Unmarshal(decoded.Params, &got)
-	origBytes, _ := json.Marshal(orig)
-	gotBytes, _ := json.Marshal(got)
-	if string(origBytes) != string(gotBytes) {
-		t.Errorf("Params mismatch: got %s, want %s", gotBytes, origBytes)
-	}
-}
-
-// TestInputRequestOmitEmptyParams verifies that an InputRequest with nil
-// params omits the field entirely (not "params":null).
-func TestInputRequestOmitEmptyParams(t *testing.T) {
-	req := InputRequest{Method: "ping"}
-	data, err := json.Marshal(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var m map[string]any
-	json.Unmarshal(data, &m)
-	if _, ok := m["params"]; ok {
-		t.Errorf("params should be omitted when nil; got %s", data)
-	}
-}
-
-// TestInputRequestsMapJSON verifies that InputRequests (alias for
-// map[string]InputRequest) marshals as a JSON object keyed by request id.
-func TestInputRequestsMapJSON(t *testing.T) {
-	reqs := InputRequests{
-		"elicit-1": InputRequest{Method: "elicitation/create", Params: json.RawMessage(`{"message":"ok?"}`)},
-		"sample-1": InputRequest{Method: "sampling/createMessage", Params: json.RawMessage(`{"maxTokens":50}`)},
-	}
-	data, err := json.Marshal(reqs)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var decoded InputRequests
-	if err := json.Unmarshal(data, &decoded); err != nil {
-		t.Fatal(err)
-	}
-	if len(decoded) != 2 {
-		t.Fatalf("len = %d, want 2", len(decoded))
-	}
-	if decoded["elicit-1"].Method != "elicitation/create" {
-		t.Errorf("elicit-1.method = %q, want elicitation/create", decoded["elicit-1"].Method)
-	}
-	if decoded["sample-1"].Method != "sampling/createMessage" {
-		t.Errorf("sample-1.method = %q, want sampling/createMessage", decoded["sample-1"].Method)
-	}
-}
-
-// TestInputResponsesMapJSON verifies that InputResponses (alias for
-// map[string]json.RawMessage) preserves opaque payload bytes per key.
-func TestInputResponsesMapJSON(t *testing.T) {
-	resps := InputResponses{
-		"elicit-1": json.RawMessage(`{"action":"accept","content":{"confirmed":true}}`),
-		"sample-1": json.RawMessage(`{"role":"assistant","content":{"type":"text","text":"hello"}}`),
-	}
-	data, err := json.Marshal(resps)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var decoded InputResponses
-	if err := json.Unmarshal(data, &decoded); err != nil {
-		t.Fatal(err)
-	}
-	if len(decoded) != 2 {
-		t.Fatalf("len = %d, want 2", len(decoded))
-	}
-	var v map[string]any
-	if err := json.Unmarshal(decoded["elicit-1"], &v); err != nil {
-		t.Fatalf("elicit-1 not valid JSON: %v", err)
-	}
-	if v["action"] != "accept" {
-		t.Errorf("elicit-1.action = %v, want accept", v["action"])
-	}
-}
 
 // TestDetailedTaskInputRequestsTyped verifies the InputRequests field on
 // DetailedTask (the SEP-2663 input_required variant) marshals to the
@@ -162,7 +15,7 @@ func TestDetailedTaskInputRequestsTyped(t *testing.T) {
 			Status:        TaskInputRequired,
 			CreatedAt:     "2025-01-15T10:00:00Z",
 			LastUpdatedAt: "2025-01-15T10:00:01Z",
-			TTLMs:    IntPtr(60),
+			TTLMs:         IntPtr(60),
 		},
 		InputRequests: InputRequests{
 			"elicit-1": InputRequest{
@@ -206,7 +59,7 @@ func TestDetailedTaskInputRequestsTyped(t *testing.T) {
 // TestDetailedTaskNoRequestState verifies that DetailedTask never emits a
 // `requestState` JSON field — the merged SEP-2663 removed the field from
 // the tasks-v2 wire entirely. (MRTR's InputRequiredResult.RequestState
-// remains on a different surface; see TestInputRequiredResult below.)
+// remains on a different surface; see TestInputRequiredResult in mrtr_test.go.)
 func TestDetailedTaskNoRequestState(t *testing.T) {
 	res := DetailedTask{
 		TaskInfoV2: TaskInfoV2{
@@ -229,11 +82,11 @@ func TestDetailedTaskNoRequestState(t *testing.T) {
 // pollIntervalMs) and the absence of a parentTaskId field.
 func TestTaskInfoV2WireFields(t *testing.T) {
 	info := TaskInfoV2{
-		TaskID:                   "task-123",
-		Status:                   TaskWorking,
-		CreatedAt:                "2025-01-15T10:00:00Z",
-		LastUpdatedAt:            "2025-01-15T10:00:01Z",
-		TTLMs:               IntPtr(300),
+		TaskID:         "task-123",
+		Status:         TaskWorking,
+		CreatedAt:      "2025-01-15T10:00:00Z",
+		LastUpdatedAt:  "2025-01-15T10:00:01Z",
+		TTLMs:          IntPtr(300),
 		PollIntervalMs: IntPtr(1000),
 	}
 	data, err := json.Marshal(info)
@@ -270,7 +123,7 @@ func TestTaskInfoV2TTLMsNullable(t *testing.T) {
 		Status:        TaskWorking,
 		CreatedAt:     "2025-01-15T10:00:00Z",
 		LastUpdatedAt: "2025-01-15T10:00:00Z",
-		TTLMs:    nil,
+		TTLMs:         nil,
 	}
 	data, _ := json.Marshal(info)
 	var m map[string]any
@@ -293,11 +146,11 @@ func TestCreateTaskResultWireShape(t *testing.T) {
 	res := CreateTaskResult{
 		ResultType: ResultTypeTask,
 		TaskInfoV2: TaskInfoV2{
-			TaskID:                   "task-abc",
-			Status:                   TaskWorking,
-			CreatedAt:                "2025-01-15T10:00:00Z",
-			LastUpdatedAt:            "2025-01-15T10:00:00Z",
-			TTLMs:               IntPtr(60),
+			TaskID:         "task-abc",
+			Status:         TaskWorking,
+			CreatedAt:      "2025-01-15T10:00:00Z",
+			LastUpdatedAt:  "2025-01-15T10:00:00Z",
+			TTLMs:          IntPtr(60),
 			PollIntervalMs: IntPtr(1000),
 		},
 	}
@@ -358,7 +211,7 @@ func TestDetailedTaskCompletedShape(t *testing.T) {
 			Status:        TaskCompleted,
 			CreatedAt:     "2025-01-15T10:00:00Z",
 			LastUpdatedAt: "2025-01-15T10:00:05Z",
-			TTLMs:    IntPtr(60),
+			TTLMs:         IntPtr(60),
 		},
 		Result: &ToolResult{Content: []Content{{Type: "text", Text: "done"}}},
 	}
@@ -388,7 +241,7 @@ func TestDetailedTaskFailedShape(t *testing.T) {
 			Status:        TaskFailed,
 			CreatedAt:     "2025-01-15T10:00:00Z",
 			LastUpdatedAt: "2025-01-15T10:00:05Z",
-			TTLMs:    IntPtr(60),
+			TTLMs:         IntPtr(60),
 		},
 		Error: &TaskError{Code: -32603, Message: "internal error"},
 	}
@@ -473,70 +326,6 @@ func TestUpdateTaskRequestOmitEmpty(t *testing.T) {
 	}
 }
 
-// TestInputRequiredResultWireShape verifies the SEP-2322 ephemeral wire
-// shape: {"resultType": "input_required", "inputRequests": {...},
-// "requestState": "..."}. resultType is camelCase like every other MCP
-// wire field — Luca confirmed camelCase is the SEP-2322 spec standard.
-// "input_required" is the SEP-2322 wire variant value, renamed from
-// "incomplete" in commit de6d76fb (merged 2026-05-06).
-func TestInputRequiredResultWireShape(t *testing.T) {
-	res := InputRequiredResult{
-		InputRequests: InputRequests{
-			"user_name": InputRequest{
-				Method: "elicitation/create",
-				Params: json.RawMessage(`{"message":"What is your name?"}`),
-			},
-		},
-		RequestState: "opaque-state",
-	}
-	data, err := json.Marshal(res)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var m map[string]any
-	if err := json.Unmarshal(data, &m); err != nil {
-		t.Fatal(err)
-	}
-
-	if m["resultType"] != "input_required" {
-		t.Errorf("resultType = %v, want \"input_required\"; got %s", m["resultType"], data)
-	}
-	if _, ok := m["result_type"]; ok {
-		t.Errorf("snake_case result_type must NOT appear (camelCase is the wire field); got %s", data)
-	}
-	if m["requestState"] != "opaque-state" {
-		t.Errorf("requestState = %v, want opaque-state", m["requestState"])
-	}
-	reqs, ok := m["inputRequests"].(map[string]any)
-	if !ok {
-		t.Fatalf("inputRequests missing or wrong shape; got %s", data)
-	}
-	entry, ok := reqs["user_name"].(map[string]any)
-	if !ok {
-		t.Fatalf("inputRequests[user_name] missing; got %s", data)
-	}
-	if entry["method"] != "elicitation/create" {
-		t.Errorf("inputRequests[user_name].method = %v, want elicitation/create", entry["method"])
-	}
-}
-
-// TestInputRequiredResultDefaultsResultType verifies that a zero-value
-// InputRequiredResult marshals with resultType = "input_required" so
-// handlers can build InputRequiredResult{InputRequests: ...} without
-// setting the discriminator manually.
-func TestInputRequiredResultDefaultsResultType(t *testing.T) {
-	data, err := json.Marshal(InputRequiredResult{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	var m map[string]any
-	json.Unmarshal(data, &m)
-	if m["resultType"] != "input_required" {
-		t.Errorf("zero-value InputRequiredResult.resultType = %v, want \"input_required\"; got %s",
-			m["resultType"], data)
-	}
-}
-
 // TestAckShapes verifies that UpdateTaskResult and CancelTaskResult serialize
 // to the SEP-2322 minimum: a single resultType:"complete" discriminator and
 // no other fields. SEP-2663 says the acks carry no task state — but SEP-2322
@@ -565,131 +354,4 @@ func TestAckShapes(t *testing.T) {
 			t.Errorf("%s should carry only resultType (got %d keys: %v)", tc.name, len(m), m)
 		}
 	}
-}
-
-// --- SEP-2322 requestState signing (gap-3) ---
-
-// TestRequestState_RoundTrip verifies a freshly signed token verifies cleanly
-// and exposes the original taskID. The base case for the HMAC flow.
-func TestRequestState_RoundTrip(t *testing.T) {
-	key := []byte("test-key-32-bytes-min-for-hmac-shake")
-	state := SignRequestState(key, "task-abc", time.Hour)
-	if state == "" {
-		t.Fatal("SignRequestState returned empty string")
-	}
-	got, err := VerifyRequestState(key, state)
-	if err != nil {
-		t.Fatalf("VerifyRequestState: %v", err)
-	}
-	if got != "task-abc" {
-		t.Errorf("decoded taskID = %q, want %q", got, "task-abc")
-	}
-}
-
-// TestRequestState_TamperedPayload verifies that any modification to the
-// payload bytes (even a single character flip) invalidates the signature.
-// This is the core attacker scenario the HMAC defends against.
-func TestRequestState_TamperedPayload(t *testing.T) {
-	key := []byte("test-key-32-bytes-min-for-hmac-shake")
-	state := SignRequestState(key, "task-abc", time.Hour)
-	dot := strings.IndexByte(state, '.')
-	if dot < 0 {
-		t.Fatalf("expected '.' separator in signed state %q", state)
-	}
-	// Re-encode a different payload (taskId swap) but keep the original sig.
-	tampered := state[:dot+1] + base64.RawURLEncoding.EncodeToString([]byte(`{"taskId":"task-evil","exp":9999999999}`))
-	if _, err := VerifyRequestState(key, tampered); err != ErrRequestStateInvalidSignature {
-		t.Errorf("tampered payload: err = %v, want ErrRequestStateInvalidSignature", err)
-	}
-}
-
-// TestRequestState_TamperedSignature verifies that a flipped signature byte
-// (with the original payload intact) is also rejected. Symmetric with the
-// payload-tamper case.
-func TestRequestState_TamperedSignature(t *testing.T) {
-	key := []byte("test-key-32-bytes-min-for-hmac-shake")
-	state := SignRequestState(key, "task-abc", time.Hour)
-	dot := strings.IndexByte(state, '.')
-	if dot < 0 {
-		t.Fatalf("expected '.' separator")
-	}
-	// Flip a byte inside the signature (replace first char with one that
-	// decodes to different bytes).
-	sigChar := byte('A')
-	if state[0] == 'A' {
-		sigChar = 'B'
-	}
-	tampered := string(sigChar) + state[1:]
-	if _, err := VerifyRequestState(key, tampered); err != ErrRequestStateInvalidSignature {
-		t.Errorf("tampered signature: err = %v, want ErrRequestStateInvalidSignature", err)
-	}
-}
-
-// TestRequestState_Expired verifies that a token whose exp is in the past
-// is rejected even when the signature is valid.
-func TestRequestState_Expired(t *testing.T) {
-	key := []byte("test-key-32-bytes-min-for-hmac-shake")
-	// Negative TTL = exp in the past.
-	state := SignRequestState(key, "task-abc", -time.Second)
-	if _, err := VerifyRequestState(key, state); err != ErrRequestStateExpired {
-		t.Errorf("expired state: err = %v, want ErrRequestStateExpired", err)
-	}
-}
-
-// TestRequestState_Malformed batches the structural-failure cases so a
-// single test guards every parse path that should map to ErrRequestStateMalformed.
-func TestRequestState_Malformed(t *testing.T) {
-	key := []byte("test-key-32-bytes-min-for-hmac-shake")
-	cases := []struct {
-		name  string
-		state string
-	}{
-		{"missing separator", "no-dot-here-just-text"},
-		{"bad signature base64", "!!!!.eyJ0YXNrSWQiOiJ0YXNrLWFiYyIsImV4cCI6MX0"},
-		{"bad payload base64", "abc.!!!!"},
-		{"empty", ""},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if _, err := VerifyRequestState(key, tc.state); err != ErrRequestStateMalformed {
-				t.Errorf("err = %v, want ErrRequestStateMalformed", err)
-			}
-		})
-	}
-}
-
-// TestRequestState_WrongKey verifies that a token signed with one key can't
-// be verified with a different key — covers the multi-tenant case where
-// each tenant has its own signing key.
-func TestRequestState_WrongKey(t *testing.T) {
-	keyA := []byte("tenant-a-key-32-bytes-padding-here")
-	keyB := []byte("tenant-b-key-32-bytes-padding-here")
-	state := SignRequestState(keyA, "task-abc", time.Hour)
-	if _, err := VerifyRequestState(keyB, state); err != ErrRequestStateInvalidSignature {
-		t.Errorf("wrong key: err = %v, want ErrRequestStateInvalidSignature", err)
-	}
-}
-
-// TestRequestState_BadJSONPayload verifies that a payload that survives
-// base64 + HMAC but doesn't parse as the expected JSON shape is reported
-// as malformed (not invalid-signature).
-func TestRequestState_BadJSONPayload(t *testing.T) {
-	key := []byte("test-key-32-bytes-min-for-hmac-shake")
-	rawPayload := []byte("not-json-at-all")
-	mac := hmacFromKey(t, key, rawPayload)
-	state := base64.RawURLEncoding.EncodeToString(mac) + "." +
-		base64.RawURLEncoding.EncodeToString(rawPayload)
-	if _, err := VerifyRequestState(key, state); err != ErrRequestStateMalformed {
-		t.Errorf("bad JSON payload: err = %v, want ErrRequestStateMalformed", err)
-	}
-}
-
-// hmacFromKey is a tiny test helper to compute an HMAC-SHA256 sig over an
-// arbitrary payload — used by TestRequestState_BadJSONPayload to forge a
-// signature-valid-but-payload-broken token.
-func hmacFromKey(t *testing.T, key, payload []byte) []byte {
-	t.Helper()
-	h := hmac.New(sha256.New, key)
-	h.Write(payload)
-	return h.Sum(nil)
 }


### PR DESCRIPTION
## What changes

Splits `core/task_v2.go` into two files along the SEP boundary so the file name matches what's inside. The original held both SEP-2663 tasks-v2 wire types (`TaskInfoV2`, `CreateTaskResult`, `DetailedTask`, etc.) and SEP-2322 MRTR types (`InputRequiredResult`, `requestState` signing helpers, `MRTRRoundState`) under the misleading `task_v2.go` name. After the split, `core/mrtr.go` holds the SEP-2322 types and `core/task_v2.go` holds only the SEP-2663 tasks-v2 wire types. Pure mechanical move — no behavior change, no public-API rename, no external import changes.

Closes one of four items on issue 433. The other three (subscriptions/listen rewrite, MRTR↔Tasks composition test, `-32003` spec confirmation) each have hard blockers and stay open.

## Reviewer's guide

Read in this order:

1. [core/mrtr.go](https://github.com/panyam/mcpkit/pull/434/files#diff-e35e8e196366177f5fbc1038f83e79bb201533c23472c8df64ad47e213d9becf) — start here. New file (was the MRTR half of `task_v2.go`). Should be a clean SEP-2322 surface: `ResultType` discriminator, `InputRequest` / `InputRequests` / `InputResponses`, `InputRequiredResult`, error sentinels, `Sign/VerifyRequestState`, `MRTRRoundState`, `Sign/VerifyMRTRState`, `Encode/DecodeMRTRStatePlaintext`.
2. [core/task_v2.go](https://github.com/panyam/mcpkit/pull/434/files#diff-3538d827f8d2f0385530a0112d8defa64f901a0827609fe5f730db43ff24049a) — the slimmed-down tasks-v2 file. Should now hold only `TasksExtensionID` + `ClientSupportsTasks`, `TaskInfoV2`, `CreateTaskResult`, `DetailedTask` + narrowed aliases + `GetTaskResult`, `TaskError`, `UpdateTaskRequest` / `UpdateTaskResult`, `CancelTaskResult`.
3. [core/mrtr_test.go](https://github.com/panyam/mcpkit/pull/434/files#diff-fe76fd75444e43b8531ce39d310a969c3ba0a13884c8469c9094e0dc013ff1af) + [core/task_v2_test.go](https://github.com/panyam/mcpkit/pull/434/files#diff-6901b5c43348f336ead3c8fd405986c20a4dd6249af891c63d10cb58da06905c) — tests split by the same SEP boundary. `mrtr_test.go` carries `TestResultTypeConstants`, the `TestInputRequest*` / `TestInputResponses*` / `TestInputRequiredResult*` cases, and the seven `TestRequestState_*` HMAC tests. `task_v2_test.go` carries the SEP-2663 wire-shape tests and `TestAckShapes`.

Skim or skip: nothing. Diff is tight.

## Decision log

- **`ResultType` enum moves to `mrtr.go`.** SEP-2322 owns the discriminator; tasks-v2 just consumes the same enum. Same logic for `InputRequest` / `InputRequests` / `InputResponses`.
- **`mrtr.go` is the rename target, not `task_v2.go`.** The git mechanic was `git mv core/task_v2.go core/mrtr.go` (plus the test analog), then surgical edits to drop the tasks-v2 blocks. `mrtr.go` inherited the majority of the original content (~59% similarity), so `git log --follow core/mrtr.go` traces back through all the prior history of the original file. The new `core/task_v2.go` is a fresh file from this commit.
- **Test files split too**, mirroring the source split. Considered keeping all tests in one file but the rename-target rule applies symmetrically — keeping MRTR tests with MRTR types makes both the read-path and `git log --follow` cleaner.

## Risk / blast radius

- **Affects:** `core` package internals. No public API change.
- **Tests covering this:** every existing test in `core/` (TestResultTypeConstants through TestAckShapes) — they're the same tests, just moved file. Acceptance is "nothing new fails."
- **Be paranoid about:** missed cross-references in doc comments. I rewrote the file-header doc comments in both files; verify they don't claim something that no longer lives in that file.

## Before / after

- Lines in `core/task_v2.go`: 502 → 196 (only tasks-v2 wire types now)
- Lines in `core/mrtr.go`: 0 → 327 (all SEP-2322 types now)
- Lines in `core/task_v2_test.go`: 695 → 295
- Lines in `core/mrtr_test.go`: 0 → 344

Verified:

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` (root module) — all green
- [x] `go test ./...` (ext/tasks sub-module) — all green
- [x] `make testconf-tasks-v2` — 9/9 scenarios pass

## Out of scope (deliberately deferred)

- Rewrite `tasks-status-notifications` scenario against `subscriptions/listen` — issue 433 item 1, blocked on PR 262 merging upstream.
- MRTR↔Tasks composition test for `requestState` asymmetry — issue 433 item 2, blocked on PR 262 merging upstream.
- `-32003` for gated tasks methods spec confirmation — issue 433 item 4, blocked on upstream maintainer response.
