### PR TITLE
fix(examples/host): port Run closures to demokit.StepContext signature

### DIFF
--- a/examples/host/01-apphost/main.go
+++ b/examples/host/01-apphost/main.go
@@ -47,7 +47,7 @@ func main() {
 		Arrow("Srv", "Srv", "RegisterTool(\"server_echo\")").
 		Arrow("Srv", "Srv", "RegisterTool(\"server_time\")").
 		Note("The server provides two tools: echo (returns input) and time (returns current time).").
-		Run(func() {
+		Run(func(_ demokit.StepContext) *demokit.StepResult {
 			srv = server.NewServer(core.ServerInfo{Name: "demo-server", Version: "1.0"})
 
 			srv.RegisterTool(
@@ -67,6 +67,7 @@ func main() {
 				},
 			)
 			fmt.Println("  Server created with 2 tools: server_echo, server_time")
+			return nil
 		})
 
 	// --- Step 2: Connect client ---
@@ -74,7 +75,7 @@ func main() {
 		Arrow("Client", "Srv", "initialize").
 		DashedArrow("Srv", "Client", "capabilities, serverInfo").
 		Note("The client connects without HTTP — using InProcessTransport for direct dispatch.").
-		Run(func() {
+		Run(func(_ demokit.StepContext) *demokit.StepResult {
 			xport := server.NewInProcessTransport(srv)
 			c = client.NewClient("memory://", core.ClientInfo{Name: "demo-host", Version: "1.0"},
 				client.WithTransport(xport),
@@ -82,7 +83,7 @@ func main() {
 			)
 			if err := c.Connect(); err != nil {
 				fmt.Printf("  ERROR: %v\n", err)
-				return
+				return nil
 			}
 			fmt.Printf("  Connected to %s %s\n", c.ServerInfo.Name, c.ServerInfo.Version)
 
@@ -95,6 +96,7 @@ func main() {
 				fmt.Print(t.Name)
 			}
 			fmt.Println()
+			return nil
 		})
 
 	// --- Step 3: Create app bridge with tools ---
@@ -103,7 +105,7 @@ func main() {
 		Arrow("Bridge", "Bridge", "RegisterTool(\"app_greet\")").
 		Arrow("Bridge", "Bridge", "RegisterTool(\"app_counter\")").
 		Note("The bridge simulates an MCP App (iframe). It registers two tools that the host/model can call directly.").
-		Run(func() {
+		Run(func(_ demokit.StepContext) *demokit.StepResult {
 			bridge = ui.NewInProcessAppBridge()
 
 			bridge.RegisterTool("app_greet", core.ToolDef{
@@ -129,6 +131,7 @@ func main() {
 			})
 
 			fmt.Println("  Bridge created with 2 app tools: app_greet, app_counter")
+			return nil
 		})
 
 	// --- Step 4: Create and start AppHost ---
@@ -139,13 +142,14 @@ func main() {
 		Arrow("Host", "Bridge", "Send(tools/list) — initial fetch").
 		DashedArrow("Bridge", "Host", "{tools: [app_greet, app_counter]}").
 		Note("AppHost wires up bidirectional routing and fetches the initial app tool list.").
-		Run(func() {
+		Run(func(_ demokit.StepContext) *demokit.StepResult {
 			host = ui.NewAppHost(c, bridge)
 			if err := host.Start(ctx); err != nil {
 				fmt.Printf("  ERROR: %v\n", err)
-				return
+				return nil
 			}
 			fmt.Println("  AppHost started — bridge handlers wired, initial tool list fetched")
+			return nil
 		})
 
 	// --- Step 5: List all tools ---
@@ -155,16 +159,17 @@ func main() {
 		Arrow("Host", "Bridge", "cached app tools").
 		DashedArrow("Bridge", "Host", "[app_greet, app_counter]").
 		Note("ListAllTools merges tools from the MCP server and the app bridge into a single list.").
-		Run(func() {
+		Run(func(_ demokit.StepContext) *demokit.StepResult {
 			tools, err := host.ListAllTools(ctx)
 			if err != nil {
 				fmt.Printf("  ERROR: %v\n", err)
-				return
+				return nil
 			}
 			fmt.Printf("  All tools (%d total):\n", len(tools))
 			for _, t := range tools {
 				fmt.Printf("    - %s (%s)\n", t.Name, t.Description)
 			}
+			return nil
 		})
 
 	// --- Step 6: Call app tool ---
@@ -172,11 +177,11 @@ func main() {
 		Arrow("Host", "Bridge", "Send(tools/call, {name: \"app_greet\", args: {name: \"World\"}})").
 		DashedArrow("Bridge", "Host", "ToolResult {text: \"Hello, World!\"}").
 		Note("The host calls a tool registered by the app. The bridge dispatches to the Go handler.").
-		Run(func() {
+		Run(func(_ demokit.StepContext) *demokit.StepResult {
 			result, err := host.CallAppTool(ctx, "app_greet", map[string]any{"name": "World"})
 			if err != nil {
 				fmt.Printf("  ERROR: %v\n", err)
-				return
+				return nil
 			}
 			fmt.Printf("  Result: %s\n", result.Content[0].Text)
 
@@ -184,6 +189,7 @@ func main() {
 			host.CallAppTool(ctx, "app_counter", nil)
 			result2, _ := host.CallAppTool(ctx, "app_counter", nil)
 			fmt.Printf("  Counter after 2 calls: %s\n", result2.Content[0].Text)
+			return nil
 		})
 
 	// --- Step 7: App calls server tool ---
@@ -195,19 +201,20 @@ func main() {
 		DashedArrow("Client", "Host", "CallResult").
 		DashedArrow("Host", "Bridge", "Response").
 		Note("The app calls a server-side tool through the bridge. AppHost forwards to the MCP server via the Client.").
-		Run(func() {
+		Run(func(_ demokit.StepContext) *demokit.StepResult {
 			resp, err := bridge.SendToHost(ctx, "tools/call", map[string]any{
 				"name":      "server_echo",
 				"arguments": map[string]any{"msg": "from the app"},
 			})
 			if err != nil {
 				fmt.Printf("  ERROR: %v\n", err)
-				return
+				return nil
 			}
 			raw, _ := ui.ToBytes(resp.Result)
 			var result core.ToolResult
 			json.Unmarshal(raw, &result)
 			fmt.Printf("  App called server_echo → %s\n", result.Content[0].Text)
+			return nil
 		})
 
 	// --- Step 8: Dynamic tool registration ---
@@ -217,7 +224,7 @@ func main() {
 		Arrow("Host", "Bridge", "Send(tools/list) — refresh").
 		DashedArrow("Bridge", "Host", "{tools: [app_greet, app_counter, app_dice]}").
 		Note("The app registers a new tool after startup. AppHost detects the change and refreshes its cache.").
-		Run(func() {
+		Run(func(_ demokit.StepContext) *demokit.StepResult {
 			bridge.RegisterTool("app_dice", core.ToolDef{
 				Description: "Roll a random die",
 			}, func(args map[string]any) (any, error) {
@@ -237,6 +244,7 @@ func main() {
 
 			result, _ := host.CallAppTool(ctx, "app_dice", nil)
 			fmt.Printf("  Called app_dice → %s\n", result.Content[0].Text)
+			return nil
 		})
 
 	demo.Section("Cleanup",

--- a/examples/host/02-multi-server/main.go
+++ b/examples/host/02-multi-server/main.go
@@ -65,7 +65,7 @@ func main() {
 		Arrow("C", "C", "list_events, create_event, get_info").
 		Arrow("K", "K", "get_time").
 		Note("Weather and Calendar both have a 'get_info' tool — this will cause a collision in the registry.").
-		Run(func() {
+		Run(func(_ demokit.StepContext) *demokit.StepResult {
 			weatherClient = newServer("weather", map[string]string{
 				"get_forecast": "Get weather forecast",
 				"get_alerts":   "Get weather alerts",
@@ -81,6 +81,7 @@ func main() {
 			})
 			fmt.Println("  Created 3 servers: weather (3 tools), calendar (3 tools), clock (1 tool)")
 			fmt.Println("  Note: 'get_info' exists in both weather and calendar")
+			return nil
 		})
 
 	// --- Step 2: Create registry with resolver ---
@@ -89,7 +90,7 @@ func main() {
 		Arrow("Reg", "Reg", "WithToolResolver(arg-based routing)").
 		Arrow("Reg", "Reg", "WithCollisionHandler(log collisions)").
 		Note("The resolver picks a server based on args. The collision handler logs when ambiguity is detected.").
-		Run(func() {
+		Run(func(_ demokit.StepContext) *demokit.StepResult {
 			reg = ui.NewServerRegistry(
 				ui.WithToolResolver(func(ctx context.Context, name string, candidates []ui.RegisteredTool, args map[string]any) (string, error) {
 					// Route based on a "source" hint in the args.
@@ -109,6 +110,7 @@ func main() {
 				}),
 			)
 			fmt.Println("  Registry created with arg-based resolver and collision logger")
+			return nil
 		})
 
 	// --- Step 3: Add servers ---
@@ -117,7 +119,7 @@ func main() {
 		Arrow("Reg", "C", "Add(\"calendar\", calendarClient)").
 		Arrow("Reg", "K", "Add(\"clock\", clockClient)").
 		Note("When calendar is added, the registry detects that 'get_info' now exists in both weather and calendar.").
-		Run(func() {
+		Run(func(_ demokit.StepContext) *demokit.StepResult {
 			reg.Add(ctx, "weather", weatherClient)
 			fmt.Println("  Added weather")
 			reg.Add(ctx, "calendar", calendarClient)
@@ -125,18 +127,20 @@ func main() {
 			reg.Add(ctx, "clock", clockClient)
 			fmt.Println("  Added clock")
 			fmt.Printf("  Servers: %v\n", reg.Servers())
+			return nil
 		})
 
 	// --- Step 4: AllTools ---
 	demo.Step("AllTools — aggregated tool list with routing metadata").
 		Arrow("Reg", "Reg", "AllTools()").
 		Note("Returns all tools from all servers. Each tool has clean name + ServerID metadata.").
-		Run(func() {
+		Run(func(_ demokit.StepContext) *demokit.StepResult {
 			tools, _ := reg.AllTools(ctx)
 			fmt.Printf("  %d tools across 3 servers:\n", len(tools))
 			for _, t := range tools {
 				fmt.Printf("    %-15s  server=%-10s  %s\n", t.Name, t.ServerID, t.Description)
 			}
+			return nil
 		})
 
 	// --- Step 5: Unambiguous call ---
@@ -144,13 +148,14 @@ func main() {
 		Arrow("Reg", "W", "CallTool(\"get_forecast\")").
 		DashedArrow("W", "Reg", "ToolResult").
 		Note("get_forecast exists only in weather — no resolver needed, routes directly.").
-		Run(func() {
+		Run(func(_ demokit.StepContext) *demokit.StepResult {
 			result, err := reg.CallTool(ctx, "get_forecast", nil)
 			if err != nil {
 				fmt.Printf("  ERROR: %v\n", err)
-				return
+				return nil
 			}
 			fmt.Printf("  Result: %s\n", result.Content[0].Text)
+			return nil
 		})
 
 	// --- Step 6: Ambiguous call ---
@@ -160,13 +165,14 @@ func main() {
 		Arrow("Reg", "C", "tools/call").
 		DashedArrow("C", "Reg", "ToolResult").
 		Note("get_info is ambiguous (weather + calendar). The resolver sees {source: \"calendar\"} and picks calendar.").
-		Run(func() {
+		Run(func(_ demokit.StepContext) *demokit.StepResult {
 			result, err := reg.CallTool(ctx, "get_info", map[string]any{"source": "calendar"})
 			if err != nil {
 				fmt.Printf("  ERROR: %v\n", err)
-				return
+				return nil
 			}
 			fmt.Printf("  Result: %s\n", result.Content[0].Text)
+			return nil
 		})
 
 	// --- Step 7: Explicit routing ---
@@ -174,20 +180,21 @@ func main() {
 		Arrow("Reg", "W", "CallToolOn(\"weather\", \"get_info\")").
 		DashedArrow("W", "Reg", "ToolResult").
 		Note("CallToolOn routes directly to the specified server. No resolver involved.").
-		Run(func() {
+		Run(func(_ demokit.StepContext) *demokit.StepResult {
 			result, err := reg.CallToolOn(ctx, "weather", "get_info", nil)
 			if err != nil {
 				fmt.Printf("  ERROR: %v\n", err)
-				return
+				return nil
 			}
 			fmt.Printf("  Result: %s\n", result.Content[0].Text)
+			return nil
 		})
 
 	// --- Step 8: Remove server ---
 	demo.Step("Remove server — tools disappear from index").
 		Arrow("Reg", "K", "Remove(\"clock\")").
 		Note("After removing clock, get_time is no longer available.").
-		Run(func() {
+		Run(func(_ demokit.StepContext) *demokit.StepResult {
 			reg.Remove("clock")
 			fmt.Printf("  Remaining servers: %v\n", reg.Servers())
 
@@ -195,6 +202,7 @@ func main() {
 			if err != nil {
 				fmt.Printf("  CallTool(\"get_time\"): %v ✓\n", err)
 			}
+			return nil
 		})
 
 	// --- Step 9: Add with app bridge ---
@@ -203,7 +211,7 @@ func main() {
 		Arrow("Reg", "K", "AddWithBridge(\"clock-v2\", client, bridge)").
 		Arrow("Br", "Br", "RegisterTool(\"app_stopwatch\")").
 		Note("Re-adds clock with an app bridge that provides an extra tool. Both server and app tools appear in AllTools.").
-		Run(func() {
+		Run(func(_ demokit.StepContext) *demokit.StepResult {
 			// Recreate clock server.
 			clockClient = newServer("clock-v2", map[string]string{
 				"get_time": "Get current time (v2)",
@@ -231,9 +239,10 @@ func main() {
 			result, err := reg.CallTool(ctx, "app_stopwatch", nil)
 			if err != nil {
 				fmt.Printf("  ERROR: %v\n", err)
-				return
+				return nil
 			}
 			fmt.Printf("  Called app_stopwatch → %s\n", result.Content[0].Text)
+			return nil
 		})
 
 	demo.Execute()


### PR DESCRIPTION
Pre-existing API drift surfaced when bumping to demokit v0.0.21 (PR 435). The host examples (`01-apphost`, `02-multi-server`) still used the retired `Run(func() {})` shape; demokit's `StepDef.Run` has required `func(demokit.StepContext) *demokit.StepResult` for several versions.

## What changes

17 `Run(func() { … })` closures across the two examples become:

```go
Run(func(_ demokit.StepContext) *demokit.StepResult {
    // … original body …
    return nil
})
```

Parameter is `_` because the demos share state via outer-scope variables (e.g. `srv`, `c`, `bridge`, `ctx = context.Background()`) — naming the parameter `ctx` would have shadowed the outer `ctx`. Bare `return` statements in error-paths inside the closures became `return nil`.

## Reviewer's guide

1. `examples/host/01-apphost/main.go` — 8 Run blocks converted (and 5 bare returns → return nil).
2. `examples/host/02-multi-server/main.go` — 9 Run blocks converted.

The transformation is mechanical and uniform across both files. The bodies of the closures are unchanged.

## Verification

`go build ./...` clean in both host example dirs. Full sweep over every mcpkit example module (apps/, auth/, common/, elicitation/, events/, file-inputs/, fine-grained-auth/, host/, list-ttl/, mrtr/, protogen/bookservice, tasks/, tasks-v2/) passes too — including the apps/react/server/ + events/{discord,telegram} that I hadn't verified in PR 435.

## Risk

- No runtime behavior change — the closures' bodies are byte-identical apart from the signature wrapper and trailing `return nil`. Each demo runs the same steps it did before drift broke the build.