### PR TITLE
feat(core): WithToolExecution option for TypedTool (closes #457)

### DIFF
--- a/conformance/FIXTURE_AUDIT.md
+++ b/conformance/FIXTURE_AUDIT.md
@@ -17,10 +17,10 @@ Driven by [issue 456](https://github.com/panyam/mcpkit/issues/456). The audit wa
 |---|---:|
 | PASS | 13 |
 | JUSTIFIED | 3 |
-| PROMOTE (follow-up filed) | 1 (issue [#457](https://github.com/panyam/mcpkit/issues/457)) |
+| PROMOTE (resolved) | 1 — [#457](https://github.com/panyam/mcpkit/issues/457) landed `core.WithToolExecution`; affected examples migrated |
 | MIGRATE | 0 |
 
-No surface uses an undocumented path. All deviations from the typed-helper happy path are either canonical (RegisterTool / RegisterResource / RegisterPrompt are documented public methods), justified (TaskCallbacks needs `server.Tool{}` for architectural reasons), or filed for follow-up (`WithToolExecution`).
+No surface uses an undocumented path. All deviations from the typed-helper happy path are either canonical (`RegisterTool` / `RegisterResource` / `RegisterPrompt` are documented public methods), justified (TaskCallbacks needs `server.Tool{}` for architectural reasons), or resolved by a follow-up.
 
 ## Per-surface verdicts
 
@@ -57,15 +57,15 @@ OAuth driver uses `client.NewClient(...)`, `client.WithClientLogging`, `client.W
 
 Uses `server.NewServer` with documented option helpers. Tools registered via canonical paths (no raw `server.Tool{}` found in grep). Documentation block at `main.go:1-14` explicitly covers the two-process architecture from `examples/CONVENTIONS.md`.
 
-### `examples/tasks-v2/` — JUSTIFIED + PROMOTE filed (#457)
+### `examples/tasks-v2/` — JUSTIFIED
 
-One raw `server.Tool{}` usage at `main.go:275` for `external_job` — needed because the tool registers `TaskCallbacks: &server.TaskCallbacks{GetTask: ..., GetResult: ...}` for the external-proxy pattern. `TaskCallbacks` is a `server.Tool` field that `core.TypedTool` cannot expose without creating a `core → server` import (wrong direction). **JUSTIFIED with no in-scope migration.**
+One raw `server.Tool{}` usage at `main.go` for `external_job` — needed because the tool registers `TaskCallbacks: &server.TaskCallbacks{GetTask: ..., GetResult: ...}` for the external-proxy pattern. `TaskCallbacks` is a `server.Tool` field that `core.TypedTool` cannot expose without creating a `core → server` import (wrong direction). **JUSTIFIED with no in-scope migration.**
 
-Multiple `srv.RegisterTool(core.ToolDef{...}, handler)` direct calls for tools that set `Execution: &core.ToolExecution{TaskSupport: ...}`. `RegisterTool` is public + documented, but `TypedTool` doesn't expose `Execution` via a `With*` option, so users with task-support tools drop out of the typed-helper ergonomics. **PROMOTE** — issue [#457](https://github.com/panyam/mcpkit/issues/457) tracks adding `core.WithToolExecution`.
+All other tools (`slow_compute`, `failing_job`, `confirm_delete`, `multi_input`, `protocol_error_job`) migrated to `srv.Register(core.TypedTool[...](..., core.WithInputSchemaOverride(...), core.WithToolExecution(...)))` per [#457](https://github.com/panyam/mcpkit/issues/457) resolution. The typed-helper path now covers every tool with `Execution` set.
 
-### `examples/mrtr/` — PASS (with PROMOTE overlap)
+### `examples/mrtr/` — JUSTIFIED
 
-All registrations via `srv.RegisterTool(core.ToolDef{...}, handler)` — canonical, but each tool sets `Execution.TaskSupport`. Will benefit from #457's `WithToolExecution` migration. No raw `server.Tool{}` usage.
+All 7 MRTR tools register via `srv.RegisterTool(def, handler)` with the named-handler `func(ctx, req) (ToolResult, error)` shape. The handlers need raw `req.Arguments` access to inspect `inputResponses` and `requestState` for the SEP-2322 MRTR round-trip protocol — `TypedTool`'s typed handler signature (`func(ctx, In) (Out, error)`) does not expose the raw `ToolRequest`, so migration is not feasible without a new typed-helper API for MRTR-style stateful tools. **JUSTIFIED** — rationale is the handler-signature requirement, not `Execution`. None of the MRTR tools set `Execution`; they're driven by the MRTR helpers, not the v2 tasks protocol.
 
 ### `examples/list-ttl/` — PASS
 
@@ -75,9 +75,9 @@ All registrations via `srv.RegisterTool(core.ToolDef{...}, handler)` — canonic
 
 Imports `ext/ui` and uses `ui.RequestDisplayMode` / `ui.FileInputAnnotation` helpers (the documented `ext/ui` surface). `srv.RegisterTool` for SEP-2356 file-input tools. No raw struct usage.
 
-### `examples/tasks/` — JUSTIFIED + PROMOTE filed (#457)
+### `examples/tasks/` — JUSTIFIED
 
-Same shape as `examples/tasks-v2/`: one raw `server.Tool{TaskCallbacks: ...}` at `main.go:255` for the same `external_job` proxy pattern (JUSTIFIED, same reason), and multiple `RegisterTool` calls for `Execution.TaskSupport`-setting tools (PROMOTE, tracked in [#457](https://github.com/panyam/mcpkit/issues/457)).
+Same shape as `examples/tasks-v2/`: one raw `server.Tool{TaskCallbacks: ...}` for the `external_job` proxy pattern (JUSTIFIED, same reason). All other tools (`slow_compute`, `failing_job`, `confirm_delete`, `write_haiku`) migrated to `core.TypedTool` + `WithInputSchemaOverride` + `WithToolExecution` per [#457](https://github.com/panyam/mcpkit/issues/457) resolution.
 
 ### `scripts/conformance-audit.sh` — PASS
 
@@ -116,7 +116,8 @@ Canonical paths used as reference:
 |---|---|
 | Tool registration | `srv.Register(core.TextTool[In](...))` / `srv.Register(core.TypedTool[In, Out](..., opts...))` |
 | Tool with raw 2020-12 schema | `core.TypedTool[In, Out](..., core.WithInputSchemaOverride(schema))` (post PR 455) |
-| Tool with `Execution`/`TaskCallbacks` | `srv.RegisterTool(def, handler)` / `srv.Register(server.Tool{ToolDef, Handler, TaskCallbacks})` (until [#457](https://github.com/panyam/mcpkit/issues/457) lands `WithToolExecution`) |
+| Tool with `Execution` | `srv.Register(core.TypedTool[In, Out](..., core.WithToolExecution(...)))` (post [#457](https://github.com/panyam/mcpkit/issues/457)) |
+| Tool with `TaskCallbacks` | `srv.Register(server.Tool{ToolDef, Handler, TaskCallbacks})` (no typed helper — server-level concept) |
 | Resource registration | `srv.RegisterResource(core.ResourceDef{...}, handler)` |
 | Resource template | `srv.RegisterResourceTemplate(core.ResourceTemplate{...}, handler)` |
 | Prompt registration | `srv.RegisterPrompt(core.PromptDef{...}, handler)` |

--- a/core/typed_tool.go
+++ b/core/typed_tool.go
@@ -78,6 +78,7 @@ func TypedTool[In, Out any](name, desc string,
 		Meta:           cfg.meta,
 		Timeout:        cfg.timeout,
 		RequiredScopes: cfg.requiredScopes,
+		Execution:      cfg.toolExecution,
 	}
 
 	wrappedHandler := func(ctx ToolContext, req ToolRequest) (ToolResult, error) {
@@ -121,6 +122,7 @@ type typedToolConfig struct {
 	timeout             time.Duration
 	requiredScopes      []string
 	inputSchemaOverride any
+	toolExecution       *ToolExecution
 }
 
 // WithToolAnnotations sets the Annotations field on the generated ToolDef.
@@ -173,6 +175,32 @@ func WithToolRequiredScopes(scopes ...string) TypedToolOption {
 //	)
 func WithInputSchemaOverride(schema any) TypedToolOption {
 	return func(c *typedToolConfig) { c.inputSchemaOverride = schema }
+}
+
+// WithToolExecution sets the Execution field on the generated ToolDef. Use this
+// for tools that participate in the v2 tasks protocol (SEP-2557) and need to
+// declare task-support semantics (TaskSupportRequired, TaskSupportOptional, or
+// the default TaskSupportForbidden). Without this option the generated ToolDef
+// has no Execution field, which is equivalent to TaskSupportForbidden per the
+// spec (sync-only tool).
+//
+// Example:
+//
+//	type SlowComputeInput struct {
+//	    Seconds int `json:"seconds"`
+//	}
+//	r := core.TypedTool[SlowComputeInput, core.ToolResult]("slow_compute", "...",
+//	    func(ctx core.ToolContext, in SlowComputeInput) (core.ToolResult, error) { ... },
+//	    core.WithToolExecution(&core.ToolExecution{TaskSupport: core.TaskSupportOptional}),
+//	)
+//
+// For tools that also need server-side per-tool task callbacks
+// (TaskCallbacks for GetTask/GetResult overrides), use the lower-level
+// server.Tool{ToolDef, Handler, TaskCallbacks} struct path instead —
+// TaskCallbacks is a server-level concept that cannot be exposed via this
+// core-only helper without crossing module boundaries.
+func WithToolExecution(execution *ToolExecution) TypedToolOption {
+	return func(c *typedToolConfig) { c.toolExecution = execution }
 }
 
 // wrapOutput converts a typed handler output into a ToolResult.

--- a/core/typed_tool_test.go
+++ b/core/typed_tool_test.go
@@ -60,3 +60,40 @@ func TestTypedTool_WithInputSchemaOverride(t *testing.T) {
 		t.Errorf("InputSchema was not preserved verbatim;\n got %#v\nwant %#v", tt.InputSchema, override)
 	}
 }
+
+// TestTypedTool_DefaultExecutionUnset confirms the baseline: without
+// WithToolExecution, the generated ToolDef.Execution is nil (sync-only,
+// equivalent to TaskSupportForbidden). Anchor test so the option test below
+// means something.
+func TestTypedTool_DefaultExecutionUnset(t *testing.T) {
+	tt := TypedTool[overrideTestInput, string]("greet", "say hi",
+		func(ctx ToolContext, in overrideTestInput) (string, error) { return "", nil },
+	)
+	if tt.Execution != nil {
+		t.Errorf("Execution should be nil by default; got %#v", tt.Execution)
+	}
+}
+
+// TestTypedTool_WithToolExecution confirms the option threads the
+// ToolExecution through to the generated ToolDef. Load-bearing for the
+// PROMOTE of v2-tasks tools from raw RegisterTool to the typed helper path
+// (issue #457).
+func TestTypedTool_WithToolExecution(t *testing.T) {
+	exec := &ToolExecution{TaskSupport: TaskSupportRequired}
+
+	tt := TypedTool[overrideTestInput, string]("greet", "say hi",
+		func(ctx ToolContext, in overrideTestInput) (string, error) { return "", nil },
+		WithToolExecution(exec),
+	)
+
+	if tt.Execution == nil {
+		t.Fatal("Execution is nil after WithToolExecution; expected non-nil")
+	}
+	if tt.Execution.TaskSupport != TaskSupportRequired {
+		t.Errorf("TaskSupport = %q, want %q", tt.Execution.TaskSupport, TaskSupportRequired)
+	}
+	// Pointer should be preserved exactly (we threaded it through, not copied).
+	if tt.Execution != exec {
+		t.Errorf("Execution pointer was copied; expected the same pointer threaded through")
+	}
+}

--- a/examples/tasks-v2/main.go
+++ b/examples/tasks-v2/main.go
@@ -64,33 +64,13 @@ func serve() {
 
 	// slow_compute: optional task support. In v2, server always creates a task
 	// for this tool (no client hint needed). Immediate result shortcut for 0s.
-	srv.RegisterTool(
-		core.ToolDef{
-			Name:        "slow_compute",
-			Description: "Simulate a slow computation. In v2, always runs as a task unless instant (0 seconds).",
-			InputSchema: map[string]any{
-				"type": "object",
-				"properties": map[string]any{
-					"seconds": map[string]any{
-						"type":        "integer",
-						"description": "How many seconds to compute (sleep)",
-						"default":     3,
-					},
-					"label": map[string]any{
-						"type":        "string",
-						"description": "A label for the computation",
-						"default":     "default",
-					},
-				},
-			},
-			Execution: &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
-		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
-			var args struct {
-				Seconds int    `json:"seconds"`
-				Label   string `json:"label"`
-			}
-			json.Unmarshal(req.Arguments, &args)
+	type slowComputeInput struct {
+		Seconds int    `json:"seconds,omitempty"`
+		Label   string `json:"label,omitempty"`
+	}
+	srv.Register(core.TypedTool[slowComputeInput, core.ToolResult]("slow_compute",
+		"Simulate a slow computation. In v2, always runs as a task unless instant (0 seconds).",
+		func(ctx core.ToolContext, args slowComputeInput) (core.ToolResult, error) {
 			if args.Label == "" {
 				args.Label = "default"
 			}
@@ -120,57 +100,50 @@ func serve() {
 			log.Printf("[slow_compute] finished %q", args.Label)
 			return core.TextResult(fmt.Sprintf("Computation %q completed after %d seconds. Result: 42.", args.Label, args.Seconds)), nil
 		},
-	)
+		core.WithInputSchemaOverride(map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"seconds": map[string]any{
+					"type":        "integer",
+					"description": "How many seconds to compute (sleep)",
+					"default":     3,
+				},
+				"label": map[string]any{
+					"type":        "string",
+					"description": "A label for the computation",
+					"default":     "default",
+				},
+			},
+		}),
+		core.WithToolExecution(&core.ToolExecution{TaskSupport: core.TaskSupportOptional}),
+	))
 
 	// failing_job: required task support. Always fails with a tool execution error.
 	// In v2, tool errors → completed + isError:true (NOT failed).
-	srv.RegisterTool(
-		core.ToolDef{
-			Name:        "failing_job",
-			Description: "A job that always fails after 1 second. In v2: tool error = completed + isError:true.",
-			InputSchema: map[string]any{
-				"type":       "object",
-				"properties": map[string]any{},
-			},
-			Execution: &core.ToolExecution{TaskSupport: core.TaskSupportRequired},
-		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+	srv.Register(core.TypedTool[struct{}, core.ToolResult]("failing_job",
+		"A job that always fails after 1 second. In v2: tool error = completed + isError:true.",
+		func(ctx core.ToolContext, _ struct{}) (core.ToolResult, error) {
 			log.Printf("[failing_job] starting (will fail in 1s)...")
 			time.Sleep(1 * time.Second)
 			return core.ToolResult{}, fmt.Errorf("simulated failure: job crashed")
 		},
-	)
+		core.WithToolExecution(&core.ToolExecution{TaskSupport: core.TaskSupportRequired}),
+	))
 
 	// confirm_delete: required task support, demonstrates the SEP-2663 MRTR
 	// elicit → tasks/update → complete loop. The tool calls TaskElicit, parks
 	// the task in input_required (which surfaces inputRequests on tasks/get),
 	// and resumes when the client sends the matching response via tasks/update.
-	srv.RegisterTool(
-		core.ToolDef{
-			Name:        "confirm_delete",
-			Description: "Asks the client to confirm before deleting (demonstrates SEP-2663 inputRequests/inputResponses).",
-			InputSchema: map[string]any{
-				"type": "object",
-				"properties": map[string]any{
-					"filename": map[string]any{
-						"type":        "string",
-						"description": "File the user is being asked to confirm deletion of",
-						"default":     "important.txt",
-					},
-				},
-			},
-			Execution: &core.ToolExecution{TaskSupport: core.TaskSupportRequired},
-		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+	type confirmDeleteInput struct {
+		Filename string `json:"filename,omitempty"`
+	}
+	srv.Register(core.TypedTool[confirmDeleteInput, core.ToolResult]("confirm_delete",
+		"Asks the client to confirm before deleting (demonstrates SEP-2663 inputRequests/inputResponses).",
+		func(ctx core.ToolContext, args confirmDeleteInput) (core.ToolResult, error) {
 			tc := tasks.GetTaskContext(ctx)
 			if tc == nil {
 				return core.ToolResult{}, fmt.Errorf("confirm_delete requires task context")
 			}
-
-			var args struct {
-				Filename string `json:"filename"`
-			}
-			json.Unmarshal(req.Arguments, &args)
 			if args.Filename == "" {
 				args.Filename = "important.txt"
 			}
@@ -192,24 +165,27 @@ func serve() {
 			log.Printf("[confirm_delete] user declined; keeping %q", args.Filename)
 			return core.TextResult(fmt.Sprintf("kept '%s'", args.Filename)), nil
 		},
-	)
+		core.WithInputSchemaOverride(map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"filename": map[string]any{
+					"type":        "string",
+					"description": "File the user is being asked to confirm deletion of",
+					"default":     "important.txt",
+				},
+			},
+		}),
+		core.WithToolExecution(&core.ToolExecution{TaskSupport: core.TaskSupportRequired}),
+	))
 
 	// multi_input: required task support. Fans out two TaskElicit calls in
 	// parallel so the task surfaces TWO simultaneous inputRequests, exercising
 	// the SEP-2663 partial-fulfillment path: a client may answer one key on
 	// tasks/update, observe the task is still input_required with the other
 	// key remaining, and answer the second on a follow-up tasks/update.
-	srv.RegisterTool(
-		core.ToolDef{
-			Name:        "multi_input",
-			Description: "Asks for two simultaneous inputs (name + confirm) so partial inputResponses can be exercised.",
-			InputSchema: map[string]any{
-				"type":       "object",
-				"properties": map[string]any{},
-			},
-			Execution: &core.ToolExecution{TaskSupport: core.TaskSupportRequired},
-		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+	srv.Register(core.TypedTool[struct{}, core.ToolResult]("multi_input",
+		"Asks for two simultaneous inputs (name + confirm) so partial inputResponses can be exercised.",
+		func(ctx core.ToolContext, _ struct{}) (core.ToolResult, error) {
 			tc := tasks.GetTaskContext(ctx)
 			if tc == nil {
 				return core.ToolResult{}, fmt.Errorf("multi_input requires task context")
@@ -250,26 +226,20 @@ func serve() {
 			confirmed, _ := confirmRes.Content["confirm"].(bool)
 			return core.TextResult(fmt.Sprintf("name=%q confirmed=%t", name, confirmed)), nil
 		},
-	)
+		core.WithToolExecution(&core.ToolExecution{TaskSupport: core.TaskSupportRequired}),
+	))
 
 	// protocol_error_job: required task support. Triggers a protocol-level failure
 	// by panicking. In v2, protocol errors → failed + error field.
-	srv.RegisterTool(
-		core.ToolDef{
-			Name:        "protocol_error_job",
-			Description: "A job that triggers a protocol-level error (panic). In v2: failed + error field.",
-			InputSchema: map[string]any{
-				"type":       "object",
-				"properties": map[string]any{},
-			},
-			Execution: &core.ToolExecution{TaskSupport: core.TaskSupportRequired},
-		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+	srv.Register(core.TypedTool[struct{}, core.ToolResult]("protocol_error_job",
+		"A job that triggers a protocol-level error (panic). In v2: failed + error field.",
+		func(ctx core.ToolContext, _ struct{}) (core.ToolResult, error) {
 			log.Printf("[protocol_error_job] starting (will panic in 500ms)...")
 			time.Sleep(500 * time.Millisecond)
 			panic("simulated protocol error: server internal failure")
 		},
-	)
+		core.WithToolExecution(&core.ToolExecution{TaskSupport: core.TaskSupportRequired}),
+	))
 
 	// external_job: required task support with TaskCallbacks (proxy pattern).
 	srv.Register(server.Tool{

--- a/examples/tasks/main.go
+++ b/examples/tasks/main.go
@@ -64,33 +64,13 @@ func serve() {
 
 	// slow_compute: optional task support. Can be called sync (blocks) or
 	// async (returns task immediately, poll for result).
-	srv.RegisterTool(
-		core.ToolDef{
-			Name:        "slow_compute",
-			Description: "Simulate a slow computation (sleeps for the given duration). Supports optional async task execution.",
-			InputSchema: map[string]any{
-				"type": "object",
-				"properties": map[string]any{
-					"seconds": map[string]any{
-						"type":        "integer",
-						"description": "How many seconds to compute (sleep)",
-						"default":     3,
-					},
-					"label": map[string]any{
-						"type":        "string",
-						"description": "A label for the computation",
-						"default":     "default",
-					},
-				},
-			},
-			Execution: &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
-		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
-			var args struct {
-				Seconds int    `json:"seconds"`
-				Label   string `json:"label"`
-			}
-			json.Unmarshal(req.Arguments, &args)
+	type slowComputeInput struct {
+		Seconds int    `json:"seconds,omitempty"`
+		Label   string `json:"label,omitempty"`
+	}
+	srv.Register(core.TypedTool[slowComputeInput, core.ToolResult]("slow_compute",
+		"Simulate a slow computation (sleeps for the given duration). Supports optional async task execution.",
+		func(ctx core.ToolContext, args slowComputeInput) (core.ToolResult, error) {
 			if args.Seconds <= 0 {
 				args.Seconds = 3
 			}
@@ -125,56 +105,49 @@ func serve() {
 
 			return core.TextResult(fmt.Sprintf("Computation %q completed after %d seconds. Result: 42.", args.Label, args.Seconds)), nil
 		},
-	)
+		core.WithInputSchemaOverride(map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"seconds": map[string]any{
+					"type":        "integer",
+					"description": "How many seconds to compute (sleep)",
+					"default":     3,
+				},
+				"label": map[string]any{
+					"type":        "string",
+					"description": "A label for the computation",
+					"default":     "default",
+				},
+			},
+		}),
+		core.WithToolExecution(&core.ToolExecution{TaskSupport: core.TaskSupportOptional}),
+	))
 
 	// failing_job: required task support. Must be invoked as a task.
 	// Calling without a task hint returns an error. Always fails after a delay.
-	srv.RegisterTool(
-		core.ToolDef{
-			Name:        "failing_job",
-			Description: "A job that always fails after 1 second. Requires task invocation — calling without 'task' hint returns an error.",
-			InputSchema: map[string]any{
-				"type":       "object",
-				"properties": map[string]any{},
-			},
-			Execution: &core.ToolExecution{TaskSupport: core.TaskSupportRequired},
-		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+	srv.Register(core.TypedTool[struct{}, core.ToolResult]("failing_job",
+		"A job that always fails after 1 second. Requires task invocation — calling without 'task' hint returns an error.",
+		func(ctx core.ToolContext, _ struct{}) (core.ToolResult, error) {
 			log.Printf("[failing_job] starting (will fail in 1s)...")
 			time.Sleep(1 * time.Second)
 			return core.ToolResult{}, fmt.Errorf("simulated failure: job crashed")
 		},
-	)
+		core.WithToolExecution(&core.ToolExecution{TaskSupport: core.TaskSupportRequired}),
+	))
 
 	// confirm_delete: demonstrates elicitation from a background task.
 	// Requires task invocation. Uses TaskElicit to ask the user for confirmation
 	// before "deleting" a file.
-	srv.RegisterTool(
-		core.ToolDef{
-			Name:        "confirm_delete",
-			Description: "Asks for confirmation before deleting a file. Demonstrates task-based elicitation.",
-			InputSchema: map[string]any{
-				"type": "object",
-				"properties": map[string]any{
-					"filename": map[string]any{
-						"type":        "string",
-						"description": "File to delete",
-						"default":     "important.txt",
-					},
-				},
-			},
-			Execution: &core.ToolExecution{TaskSupport: core.TaskSupportRequired},
-		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+	type confirmDeleteInput struct {
+		Filename string `json:"filename,omitempty"`
+	}
+	srv.Register(core.TypedTool[confirmDeleteInput, core.ToolResult]("confirm_delete",
+		"Asks for confirmation before deleting a file. Demonstrates task-based elicitation.",
+		func(ctx core.ToolContext, args confirmDeleteInput) (core.ToolResult, error) {
 			tc := server.GetTaskContext(ctx)
 			if tc == nil {
 				return core.ToolResult{}, fmt.Errorf("confirm_delete requires task context")
 			}
-
-			var args struct {
-				Filename string `json:"filename"`
-			}
-			json.Unmarshal(req.Arguments, &args)
 			if args.Filename == "" {
 				args.Filename = "important.txt"
 			}
@@ -198,36 +171,31 @@ func serve() {
 			log.Printf("[confirm_delete] user declined deletion of %q", args.Filename)
 			return core.TextResult("Deletion cancelled"), nil
 		},
-	)
+		core.WithInputSchemaOverride(map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"filename": map[string]any{
+					"type":        "string",
+					"description": "File to delete",
+					"default":     "important.txt",
+				},
+			},
+		}),
+		core.WithToolExecution(&core.ToolExecution{TaskSupport: core.TaskSupportRequired}),
+	))
 
 	// write_haiku: demonstrates sampling from a background task.
 	// Requires task invocation. Uses TaskSample to ask the LLM to generate a haiku.
-	srv.RegisterTool(
-		core.ToolDef{
-			Name:        "write_haiku",
-			Description: "Asks the LLM to write a haiku on a topic. Demonstrates task-based sampling.",
-			InputSchema: map[string]any{
-				"type": "object",
-				"properties": map[string]any{
-					"topic": map[string]any{
-						"type":        "string",
-						"description": "Topic for the haiku",
-						"default":     "nature",
-					},
-				},
-			},
-			Execution: &core.ToolExecution{TaskSupport: core.TaskSupportRequired},
-		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+	type writeHaikuInput struct {
+		Topic string `json:"topic,omitempty"`
+	}
+	srv.Register(core.TypedTool[writeHaikuInput, core.ToolResult]("write_haiku",
+		"Asks the LLM to write a haiku on a topic. Demonstrates task-based sampling.",
+		func(ctx core.ToolContext, args writeHaikuInput) (core.ToolResult, error) {
 			tc := server.GetTaskContext(ctx)
 			if tc == nil {
 				return core.ToolResult{}, fmt.Errorf("write_haiku requires task context")
 			}
-
-			var args struct {
-				Topic string `json:"topic"`
-			}
-			json.Unmarshal(req.Arguments, &args)
 			if args.Topic == "" {
 				args.Topic = "nature"
 			}
@@ -247,7 +215,18 @@ func serve() {
 			log.Printf("[write_haiku] received haiku from %s", result.Model)
 			return core.TextResult(fmt.Sprintf("Haiku about %s:\n%s", args.Topic, result.Content.Text)), nil
 		},
-	)
+		core.WithInputSchemaOverride(map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"topic": map[string]any{
+					"type":        "string",
+					"description": "Topic for the haiku",
+					"default":     "nature",
+				},
+			},
+		}),
+		core.WithToolExecution(&core.ToolExecution{TaskSupport: core.TaskSupportRequired}),
+	))
 
 	// external_job: demonstrates TaskCallbacks (per-tool getTask/getResult overrides).
 	// Simulates proxying an external job system where the tool provides custom


### PR DESCRIPTION
## What changes

Closes issue 457. Adds `core.WithToolExecution(*core.ToolExecution)` — a `TypedToolOption` that lets tools needing v2 task-support (`TaskSupportRequired` / `TaskSupportOptional` per SEP-2557) keep using `core.TypedTool` instead of dropping to `srv.RegisterTool(def, handler)` with manual `req.Arguments` unmarshalling. Mirrors `core.WithInputSchemaOverride` (PR 455) in shape and discipline.

Migrates the affected example fixtures (`examples/tasks/`, `examples/tasks-v2/`) to the new path. `examples/mrtr/` stays on `RegisterTool` for a different reason (handler-signature, not `Execution`); this PR also clarifies that in the audit doc.

Resolves the one PROMOTE finding from fixture audit PR 458.

## Reviewer's guide

Read in this order:

1. [core/typed_tool.go](https://github.com/panyam/mcpkit/pull/459/files#diff-2a38d67d5979f975464d4ad38d21b6a6a1e9d22f1e4e78a2ccae5651b8f77f32) — start here. New `WithToolExecution` option + one-line wiring (`def.Execution = cfg.toolExecution`) in `TypedTool`. Doc comment includes the canonical example and points to `server.Tool{TaskCallbacks: ...}` for the case where TaskCallbacks is needed too.
2. [core/typed_tool_test.go](https://github.com/panyam/mcpkit/pull/459/files#diff-44f39e4c7bf5b8af29bed62d2c411de1083742bbf57924e5f9a63ee0993e9348) — two new tests: `TestTypedTool_DefaultExecutionUnset` (anchor) and `TestTypedTool_WithToolExecution` (load-bearing).
3. [examples/tasks-v2/main.go](https://github.com/panyam/mcpkit/pull/459/files#diff-072aac4bbcff96610a88cdebff776b325764aae392f71ad9c85bee454810f997) — 5 tools migrated from `RegisterTool` to `TypedTool + WithToolExecution`. `external_job` stays raw (TaskCallbacks).
4. [examples/tasks/main.go](https://github.com/panyam/mcpkit/pull/459/files#diff-afb90cb7ac0e1de0166e72d0c4945dda9b993efd078f5a8e8dcc598aa00a1b00) — 4 tools migrated same way. `external_job` stays raw.
5. [conformance/FIXTURE_AUDIT.md](https://github.com/panyam/mcpkit/pull/459/files#diff-5249bb2e6c3d5bb050eb7e6181508d653e4f81bb297a6a09193d2c31abdd8c08) — verdicts updated: PROMOTE resolved, mrtr's JUSTIFIED rationale clarified.

Skim or skip: nothing.

## Diff groups

- **Core API:** `core/typed_tool.go`, `core/typed_tool_test.go`.
- **Example migrations (mechanical):** `examples/tasks/main.go`, `examples/tasks-v2/main.go`. Each tool: lift inline anonymous arg struct to a named type, drop `json.Unmarshal`, switch `RegisterTool` to `Register(TypedTool[...](..., WithToolExecution(...)))`.
- **Audit doc update:** `conformance/FIXTURE_AUDIT.md`. JUSTIFIED+PROMOTE entries become JUSTIFIED-only; reference table updated.

## Decision log

- **Option-on-TypedTool, not new sibling helper.** Same reasoning as PR 455's `WithInputSchemaOverride` discussion. Adding a `RawTool` would create an "escape hatch" developers would reach for too eagerly; an option keeps the typed-helper path as the default and the advanced field as the exception.
- **`WithInputSchemaOverride` retained for tools with `default`-carrying schemas.** Three migrated tools (`slow_compute` in both, `confirm_delete` in both, `write_haiku` in tasks) keep verbatim schemas via `WithInputSchemaOverride` because Go struct tag reflection doesn't cleanly produce JSON Schema `default` keywords. Pairing both options demonstrates they compose. For empty-input tools (`failing_job`, `multi_input`, `protocol_error_job`), `struct{}` is used directly — reflection-derived schema is correct.
- **`examples/mrtr/` deliberately NOT migrated.** Its 7 tools use `RegisterTool` because their handlers need raw `req.Arguments` to inspect `inputResponses` and `requestState` for the SEP-2322 MRTR round-trip protocol. `TypedTool`'s handler signature (`func(ctx, In) (Out, error)`) doesn't expose the raw `ToolRequest`. None of those tools set `Execution`. Issue #457's body listed mrtr incorrectly; the audit doc now spells out the handler-signature reason as the actual JUSTIFIED rationale.
- **`external_job` in both tasks examples stays as raw `server.Tool{TaskCallbacks: ...}`.** TaskCallbacks is a `server`-level concept; exposing it via core would require `core → server` (wrong direction). JUSTIFIED already documented in `FIXTURE_AUDIT.md`.

## Risk / blast radius

- **No wire change.** Each migrated tool keeps an identical input schema (verbatim via `WithInputSchemaOverride` for the default-carrying ones, structurally equivalent for empty schemas). `make test` green; both example binaries build clean.
- **Behavior preserved.** Handler logic is identical post-migration; only the unmarshalling boilerplate moves from the handler body into `TypedTool`'s generated wrapper.
- **No production code paths touched outside `core/typed_tool.go`.** `core.ToolDef.Execution` already existed; the option just lets `TypedTool` thread it through.
- **Be paranoid about:** schema preservation for the three default-carrying tools (`slow_compute`, `confirm_delete`, `write_haiku`). The override path keeps them verbatim, but reviewers should eyeball the schema literals before/after the migration — should be byte-identical.

## Before / after sample (slow_compute, tasks-v2)

Before (raw `RegisterTool` + manual unmarshal):

```go
srv.RegisterTool(
    core.ToolDef{
        Name: "slow_compute",
        Description: "...",
        InputSchema: map[string]any{ /* hand-rolled with defaults */ },
        Execution: &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
    },
    func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
        var args struct{ Seconds int; Label string }
        json.Unmarshal(req.Arguments, &args)
        // ... compute
    },
)
```

After (typed handler + helper-bundled options):

```go
type slowComputeInput struct {
    Seconds int    `json:"seconds,omitempty"`
    Label   string `json:"label,omitempty"`
}
srv.Register(core.TypedTool[slowComputeInput, core.ToolResult]("slow_compute", "...",
    func(ctx core.ToolContext, args slowComputeInput) (core.ToolResult, error) {
        // ... compute (no unmarshal boilerplate)
    },
    core.WithInputSchemaOverride(map[string]any{ /* same schema as before */ }),
    core.WithToolExecution(&core.ToolExecution{TaskSupport: core.TaskSupportOptional}),
))
```

Net per tool: fewer lines, typed handler signature, schema preserved verbatim. Wire behavior identical.

## Out of scope

- A typed-helper for MRTR-style stateful tools (raw `req.Arguments` inspection) — would be a different shape, separate issue if ever needed.
- Documenting `server.Tool{TaskCallbacks: ...}` discoverability — noted in audit, not filed (API is correct, only docs gap is minor).
- Remaining umbrella sub-tickets (#443 testclient http-custom-headers, #444 SEP-2575 stateless, Tier 2, #452 SEP-2322 impl, #453 non-auth client driver).

