### PR TITLE
feat(client): SEP-2243 client-side custom-header serialization (closes #461)

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -371,6 +371,13 @@ type Client struct {
 	keepaliveMaxFails int               // max consecutive failures before close/reconnect
 	keepaliveCancel   context.CancelFunc // cancels keepalive goroutine
 
+	// toolSchemas caches inputSchemas from tools/list responses, keyed by
+	// tool name. Populated by ListTools (and refreshed on each call). Used
+	// by ToolCall to extract SEP-2243 x-mcp-header annotations without an
+	// extra round-trip. Guarded by toolSchemasMu.
+	toolSchemas   map[string]core.ToolDef
+	toolSchemasMu sync.RWMutex
+
 	// Stdio transport fields (set by WithStdioTransport).
 	stdioReader io.Reader
 	stdioWriter io.Writer
@@ -823,6 +830,13 @@ func (c *Client) SetURL(url string) { c.url = url }
 type CallContext struct {
 	context.Context
 	notifyHook func(method string, params json.RawMessage)
+	// Headers are additional HTTP headers to attach to the outbound request
+	// (Streamable HTTP transport only). Used by ToolCall to inject SEP-2243
+	// Mcp-Param-* headers derived from the tool's x-mcp-header inputSchema
+	// annotations; other transports ignore. Caller-supplied keys override the
+	// transport's defaults (Content-Type, Accept, Mcp-Session-Id) only if the
+	// caller deliberately sets them — which they shouldn't.
+	Headers map[string]string
 }
 
 // NewCallContext wraps a context.Context as a CallContext for use with
@@ -992,15 +1006,80 @@ func ToolCallTyped[T any](c *Client, name string, args any) (T, error) {
 }
 
 // ToolCall invokes a tool and returns the first text content.
+//
+// If the tool's inputSchema (cached by a prior ListTools call) carries
+// SEP-2243 x-mcp-header annotations on primitive-typed properties, the
+// corresponding argument values are mirrored as Mcp-Param-{Name} HTTP
+// headers on the outbound tools/call request (in addition to the JSON
+// body). Header values are encoded plain-ASCII or =?base64?{...}?= per
+// SEP-2243 §value-encoding. Tools without cached schemas or without
+// x-mcp-header annotations send no extra headers (identical to pre-
+// SEP-2243 behavior). Caller-side note: middleware registered via
+// WithCallMiddleware does not run on the header-mirroring path.
 func (c *Client) ToolCall(name string, args any) (string, error) {
-	result, err := c.Call("tools/call", map[string]any{
-		"name":      name,
-		"arguments": args,
-	})
+	params := map[string]any{"name": name, "arguments": args}
+	headers := c.buildToolCallHeaders(name, args)
+	result, err := c.callForToolCall(params, headers)
 	if err != nil {
 		return "", err
 	}
 	return extractToolText(result.Raw)
+}
+
+// buildToolCallHeaders extracts SEP-2243 Mcp-Param-* headers for a tool
+// call, consulting the schema cache populated by ListTools. Returns nil
+// when no schema is cached or when no x-mcp-header annotations apply to
+// the provided args, so callers can use the fast (no-header) path.
+func (c *Client) buildToolCallHeaders(name string, args any) map[string]string {
+	def, ok := c.lookupToolSchema(name)
+	if !ok {
+		return nil
+	}
+	mapping := extractMcpParamHeaders(def.InputSchema)
+	if len(mapping) == 0 {
+		return nil
+	}
+	argsMap, ok := args.(map[string]any)
+	if !ok {
+		return nil
+	}
+	headers := map[string]string{}
+	for propName, headerFragment := range mapping {
+		v, present := argsMap[propName]
+		if !present {
+			continue
+		}
+		encoded, sendHeader := encodeMcpParamHeaderValue(v)
+		if !sendHeader {
+			continue
+		}
+		headers[mcpParamHeaderName(headerFragment)] = encoded
+	}
+	if len(headers) == 0 {
+		return nil
+	}
+	return headers
+}
+
+// callForToolCall dispatches a tools/call. With no headers, takes the
+// standard middleware-wrapped Call path. With headers, bypasses
+// middleware and goes directly via rawCallWithContext so the per-call
+// Headers reach the streamable transport. The middleware bypass is a
+// known trade-off; SEP-2243 tool calls are typically conformance / wire-
+// behavior paths where middleware doesn't apply.
+func (c *Client) callForToolCall(params map[string]any, headers map[string]string) (*CallResult, error) {
+	if len(headers) == 0 {
+		return c.Call("tools/call", params)
+	}
+	cc := &CallContext{Headers: headers}
+	resp, err := c.rawCallWithContext("tools/call", params, cc)
+	if err != nil {
+		return nil, err
+	}
+	if resp.Error != nil {
+		return nil, &RPCError{Code: resp.Error.Code, Message: resp.Error.Message, Data: resp.Error.Data}
+	}
+	return &CallResult{Raw: resp.Result}, nil
 }
 
 // ToolCallFull invokes a tool and returns the complete result including
@@ -1061,7 +1140,10 @@ func (c *Client) UnsubscribeResource(uri string) error {
 	return err
 }
 
-// ListTools returns all registered tool definitions.
+// ListTools returns all registered tool definitions. As a side effect it
+// caches each tool's full ToolDef (including inputSchema) keyed by name —
+// ToolCall consults this cache to detect SEP-2243 x-mcp-header annotations
+// without a second round-trip.
 func (c *Client) ListTools() ([]core.ToolDef, error) {
 	result, err := c.Call("tools/list", nil)
 	if err != nil {
@@ -1073,7 +1155,31 @@ func (c *Client) ListTools() ([]core.ToolDef, error) {
 	if err := result.Unmarshal(&resp); err != nil {
 		return nil, err
 	}
+	c.cacheToolSchemas(resp.Tools)
 	return resp.Tools, nil
+}
+
+// cacheToolSchemas replaces the tool-schema cache with the supplied tools.
+// Replace-rather-than-merge so a refreshed tools/list properly reflects
+// server-side removals (server sent a tools/listChanged notification and
+// we re-listed).
+func (c *Client) cacheToolSchemas(tools []core.ToolDef) {
+	c.toolSchemasMu.Lock()
+	defer c.toolSchemasMu.Unlock()
+	c.toolSchemas = make(map[string]core.ToolDef, len(tools))
+	for _, t := range tools {
+		c.toolSchemas[t.Name] = t
+	}
+}
+
+// lookupToolSchema returns the cached ToolDef for the given tool name, if
+// any. Callers must not retain the returned ToolDef beyond their immediate
+// use — the cache may be replaced concurrently.
+func (c *Client) lookupToolSchema(name string) (core.ToolDef, bool) {
+	c.toolSchemasMu.RLock()
+	defer c.toolSchemasMu.RUnlock()
+	t, ok := c.toolSchemas[name]
+	return t, ok
 }
 
 // ListToolsForModel returns tools visible to the LLM, filtering out tools
@@ -1450,6 +1556,15 @@ func (t *streamableClientTransport) callWithContext(data []byte, cc *CallContext
 		req.Header.Set("Accept", core.StreamableHTTPAccept)
 		if t.sessionID != "" {
 			req.Header.Set("Mcp-Session-Id", t.sessionID)
+		}
+		// Caller-supplied per-call headers (SEP-2243 Mcp-Param-* mirroring
+		// from ToolCall). Applied after the transport defaults so a caller
+		// can't accidentally clobber them — Mcp-Param-* names are reserved
+		// for the SEP-2243 mechanism.
+		if cc != nil {
+			for name, value := range cc.Headers {
+				req.Header.Set(name, value)
+			}
 		}
 		if t.modifyReq != nil {
 			t.modifyReq(req)

--- a/client/headers.go
+++ b/client/headers.go
@@ -1,0 +1,161 @@
+package client
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// SEP-2243 custom-header mirroring for tools/call.
+//
+// When a tool's inputSchema marks a primitive-typed property with the
+// `x-mcp-header` keyword, the client MUST send the corresponding argument
+// value as an `Mcp-Param-{HeaderName}` HTTP header on the tools/call
+// request — in addition to including it in the JSON body. The header name
+// is the keyword's value verbatim; the wire header is HTTP-case-insensitive.
+//
+// Values are encoded per SEP-2243 §value-encoding:
+//   - Plain ASCII (0x20-0x7E, no leading/trailing whitespace, no tab/CR/LF):
+//     sent verbatim.
+//   - Anything else (non-ASCII, control chars, tab, leading/trailing
+//     whitespace): wrapped as `=?base64?{base64-utf8}?=`.
+//   - Numbers: string representation of the value.
+//   - Booleans: "true" or "false".
+//   - Null/undefined: header omitted entirely.
+//
+// Spec: https://modelcontextprotocol.io/specification/draft/basic/transports#custom-headers-from-tool-parameters
+
+// extractMcpParamHeaders walks a tool's inputSchema and returns a map from
+// property name to header-name fragment. The HTTP header on the wire is
+// `Mcp-Param-{name fragment}`.
+//
+// Only primitive-typed properties (string/number/integer/boolean) participate
+// per the SEP-2243 spec; properties with `x-mcp-header` on object/array/null
+// types are ignored here (they're tracked as tool-validation failures, see
+// SEP-2243 invalid-tool-headers scenario — out of scope for this helper).
+//
+// Returns an empty map for nil schemas or schemas without any `x-mcp-header`
+// annotations. Never returns an error — malformed schemas just yield empty
+// maps so callers can proceed without headers (safe default).
+func extractMcpParamHeaders(inputSchema any) map[string]string {
+	out := map[string]string{}
+	schema, ok := inputSchema.(map[string]any)
+	if !ok {
+		return out
+	}
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		return out
+	}
+	for propName, raw := range props {
+		propMap, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		headerName, ok := propMap["x-mcp-header"].(string)
+		if !ok || headerName == "" {
+			continue
+		}
+		// SEP-2243: only primitive types may carry x-mcp-header. The invalid-
+		// tool-headers scenario covers rejecting non-primitive cases at
+		// tools/list time; here we just skip them so a misannotated tool
+		// doesn't generate bogus headers.
+		switch propMap["type"] {
+		case "string", "number", "integer", "boolean":
+			out[propName] = headerName
+		}
+	}
+	return out
+}
+
+// encodeMcpParamHeaderValue produces the wire form of an x-mcp-header value
+// per SEP-2243 §value-encoding. Returns the encoded string and ok=true if a
+// header should be sent for this value, or ok=false if the header should be
+// omitted entirely (nil arguments).
+//
+// String values are emitted verbatim when they're plain ASCII without
+// edge-whitespace or control chars; otherwise wrapped as
+// `=?base64?{base64-utf8}?=`. Numbers use the shortest float-round-trip
+// representation. Booleans use "true"/"false". Nil omits the header.
+func encodeMcpParamHeaderValue(v any) (string, bool) {
+	if v == nil {
+		return "", false
+	}
+	switch val := v.(type) {
+	case string:
+		return encodeMcpParamString(val), true
+	case bool:
+		if val {
+			return "true", true
+		}
+		return "false", true
+	case int:
+		return strconv.Itoa(val), true
+	case int32:
+		return strconv.FormatInt(int64(val), 10), true
+	case int64:
+		return strconv.FormatInt(val, 10), true
+	case float32:
+		return encodeMcpParamNumber(float64(val)), true
+	case float64:
+		return encodeMcpParamNumber(val), true
+	default:
+		// Last-resort: stringify via %v. Won't be base64-wrapped because we
+		// can't tell what kind of bytes it produces; if it contains unsafe
+		// chars the conformance check will catch it.
+		return fmt.Sprintf("%v", val), true
+	}
+}
+
+// encodeMcpParamString applies SEP-2243 encoding to a string value: plain
+// ASCII passes through; anything that needs encoding gets wrapped as
+// `=?base64?{...}?=`.
+func encodeMcpParamString(s string) string {
+	if needsBase64Encoding(s) {
+		return "=?base64?" + base64.StdEncoding.EncodeToString([]byte(s)) + "?="
+	}
+	return s
+}
+
+// encodeMcpParamNumber converts a float64 to the shortest accurate string
+// representation. Integers come out without a decimal point ("42"); non-
+// integer floats keep enough precision to round-trip ("3.14159").
+func encodeMcpParamNumber(f float64) string {
+	if f == float64(int64(f)) {
+		return strconv.FormatInt(int64(f), 10)
+	}
+	return strconv.FormatFloat(f, 'g', -1, 64)
+}
+
+// needsBase64Encoding reports whether a string value must be base64-wrapped
+// for SEP-2243 header transport. Triggers:
+//   - any byte outside printable ASCII range (0x20-0x7E)
+//   - any tab character (0x09)
+//   - leading or trailing whitespace (including spaces)
+//
+// Internal whitespace within the visible-ASCII range is fine (plain ASCII).
+func needsBase64Encoding(s string) bool {
+	if s == "" {
+		return false
+	}
+	if s != strings.TrimSpace(s) {
+		return true
+	}
+	for _, r := range s {
+		if r == '\t' {
+			return true
+		}
+		if r < 0x20 || r > 0x7e {
+			return true
+		}
+	}
+	return false
+}
+
+// mcpParamHeaderName returns the wire HTTP header name for a given x-mcp-header
+// fragment. The HTTP header is case-insensitive but spec-canonical form is
+// `Mcp-Param-{fragment}`.
+func mcpParamHeaderName(fragment string) string {
+	return "Mcp-Param-" + fragment
+}

--- a/client/headers_test.go
+++ b/client/headers_test.go
@@ -1,0 +1,178 @@
+package client
+
+import (
+	"reflect"
+	"testing"
+)
+
+// extractMcpParamHeaders — schema walking.
+
+func TestExtractMcpParamHeaders_NilSchema(t *testing.T) {
+	got := extractMcpParamHeaders(nil)
+	if len(got) != 0 {
+		t.Errorf("nil schema should yield empty map, got %v", got)
+	}
+}
+
+func TestExtractMcpParamHeaders_NoAnnotations(t *testing.T) {
+	schema := map[string]any{
+		"type":       "object",
+		"properties": map[string]any{"name": map[string]any{"type": "string"}},
+	}
+	got := extractMcpParamHeaders(schema)
+	if len(got) != 0 {
+		t.Errorf("schema without annotations should yield empty map, got %v", got)
+	}
+}
+
+func TestExtractMcpParamHeaders_PrimitiveTypesOnly(t *testing.T) {
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"str_field":  map[string]any{"type": "string", "x-mcp-header": "Str"},
+			"num_field":  map[string]any{"type": "number", "x-mcp-header": "Num"},
+			"int_field":  map[string]any{"type": "integer", "x-mcp-header": "Int"},
+			"bool_field": map[string]any{"type": "boolean", "x-mcp-header": "Bool"},
+			// These should be IGNORED (non-primitive types).
+			"obj_field":   map[string]any{"type": "object", "x-mcp-header": "Obj"},
+			"arr_field":   map[string]any{"type": "array", "x-mcp-header": "Arr"},
+			"null_field":  map[string]any{"type": "null", "x-mcp-header": "Null"},
+			"empty_field": map[string]any{"type": "string", "x-mcp-header": ""},
+		},
+	}
+	got := extractMcpParamHeaders(schema)
+	want := map[string]string{
+		"str_field":  "Str",
+		"num_field":  "Num",
+		"int_field":  "Int",
+		"bool_field": "Bool",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v\nwant %v", got, want)
+	}
+}
+
+// encodeMcpParamHeaderValue — value encoding.
+
+func TestEncodeMcpParamHeaderValue_NilOmitsHeader(t *testing.T) {
+	if _, ok := encodeMcpParamHeaderValue(nil); ok {
+		t.Error("nil value should report ok=false (omit header)")
+	}
+}
+
+func TestEncodeMcpParamHeaderValue_PlainASCII(t *testing.T) {
+	for _, tc := range []struct {
+		name, in, want string
+	}{
+		{"simple", "us-west1", "us-west1"},
+		{"with-internal-space", "us west 1", "us west 1"},
+		{"with-printable-ascii", "test-method", "test-method"},
+		{"empty-string", "", ""},
+		{"sql-like", "SELECT * FROM users", "SELECT * FROM users"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := encodeMcpParamHeaderValue(tc.in)
+			if !ok {
+				t.Fatal("ok=false for non-nil input")
+			}
+			if got != tc.want {
+				t.Errorf("got %q\nwant %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEncodeMcpParamHeaderValue_RequiresBase64(t *testing.T) {
+	for _, tc := range []struct {
+		name, in, want string
+	}{
+		{"non-ascii", "Hello, 世界", "=?base64?SGVsbG8sIOS4lueVjA==?="},
+		{"leading-space", " us-west1", "=?base64?IHVzLXdlc3Qx?="},
+		{"trailing-space", "us-west1 ", "=?base64?dXMtd2VzdDEg?="},
+		{"both-edges", " padded ", "=?base64?IHBhZGRlZCA=?="},
+		{"control-char-lf", "line1\nline2", "=?base64?bGluZTEKbGluZTI=?="},
+		{"crlf", "line1\r\nline2", "=?base64?bGluZTENCmxpbmUy?="},
+		{"leading-tab", "\tindented", "=?base64?CWluZGVudGVk?="},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := encodeMcpParamHeaderValue(tc.in)
+			if !ok {
+				t.Fatal("ok=false for non-nil input")
+			}
+			if got != tc.want {
+				t.Errorf("got %q\nwant %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEncodeMcpParamHeaderValue_Numbers(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   any
+		want string
+	}{
+		{"int", 42, "42"},
+		{"int64", int64(42), "42"},
+		{"float-integer-value", float64(42), "42"},
+		{"float-with-decimal", 3.14159, "3.14159"},
+		{"float-small", 0.001, "0.001"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := encodeMcpParamHeaderValue(tc.in)
+			if !ok {
+				t.Fatal("ok=false for number")
+			}
+			if got != tc.want {
+				t.Errorf("got %q\nwant %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEncodeMcpParamHeaderValue_Booleans(t *testing.T) {
+	if got, _ := encodeMcpParamHeaderValue(true); got != "true" {
+		t.Errorf("true → %q, want %q", got, "true")
+	}
+	if got, _ := encodeMcpParamHeaderValue(false); got != "false" {
+		t.Errorf("false → %q, want %q", got, "false")
+	}
+}
+
+// needsBase64Encoding — boundary tests.
+
+func TestNeedsBase64Encoding(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"empty", "", false},
+		{"plain-ascii", "us-west1", false},
+		{"sql", "SELECT * FROM users", false},
+		{"internal-spaces-only", "us west 1", false},
+		{"non-ascii", "Hello, 世界", true},
+		{"leading-space", " padded", true},
+		{"trailing-space", "padded ", true},
+		{"both-edges", " padded ", true},
+		{"tab", "\tindented", true},
+		{"newline", "line1\nline2", true},
+		{"crlf", "line1\r\nline2", true},
+		{"high-ascii", "café", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := needsBase64Encoding(tc.in); got != tc.want {
+				t.Errorf("needsBase64Encoding(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMcpParamHeaderName(t *testing.T) {
+	if got := mcpParamHeaderName("Region"); got != "Mcp-Param-Region" {
+		t.Errorf("got %q, want Mcp-Param-Region", got)
+	}
+	if got := mcpParamHeaderName("Method"); got != "Mcp-Param-Method" {
+		t.Errorf("got %q, want Mcp-Param-Method", got)
+	}
+}

--- a/conformance/UPSTREAM_AUDIT.md
+++ b/conformance/UPSTREAM_AUDIT.md
@@ -14,8 +14,8 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 | Surface | Scenarios | Checks | Pass | Fail | Warn | Info | Skipped | Harness-gap |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|
 | Server | 51 | 126 | 58 | 41 | 12 | 6 | 9 | 0 |
-| Client | 40 | 1130 | 416 | 53 | 4 | 649 | 8 | 1 |
-| **Total** | **91** | **1256** | **474** | **94** | **16** | **655** | **17** | **1** |
+| Client | 40 | 1130 | 432 | 37 | 4 | 649 | 8 | 1 |
+| **Total** | **91** | **1256** | **490** | **78** | **16** | **655** | **17** | **1** |
 
 ## Harness gaps
 
@@ -151,8 +151,8 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 
 | Scenario | Surface | Status | Checks | Note |
 |---|---|---|---|---|
-| `http-custom-headers` | client | partial | 2 pass / 16 fail |  |
 | `http-custom-header-server-validation` | server | pass | 5 skip |  |
+| `http-custom-headers` | client | pass | 18 pass |  |
 
 ### [SEP-2243-SERVER-VALIDATION](https://modelcontextprotocol.io/specification/draft/basic/transports#server-validation) (1 scenarios)
 


### PR DESCRIPTION
## What changes

Closes #461. First real impl-feature PR in the conformance audit umbrella — implements the SEP-2243 "custom headers from tool parameters" client contract. When a tool's inputSchema marks a primitive-typed property with the `x-mcp-header` keyword, mcpkit's `c.ToolCall(name, args)` now mirrors that argument as an `Mcp-Param-{Name}` HTTP header on the outbound `tools/call` request (in addition to the JSON body), encoded per SEP-2243 §value-encoding (plain ASCII or `=?base64?{...}?=` wrapping). Tools without `x-mcp-header` annotations send no extra headers — fast-path behavior is identical to before this PR.

Audit: `http-custom-headers` flips from `partial (2 pass / 16 fail)` to `pass (18 pass)`. Reverses the impl gap that PR 462 (#443) had revealed.

## Reviewer's guide

Read in this order:

1. [client/headers.go](https://github.com/panyam/mcpkit/pull/463/files#diff-1790c6c752b4269286acedff114b12c15fdd3247231744f63bebfec874352bd7) — start here. New file with the pure helpers: `extractMcpParamHeaders` walks an inputSchema for `x-mcp-header` annotations on primitive-typed properties; `encodeMcpParamHeaderValue` handles the plain-ASCII vs base64-wrap decision and value formatting; `needsBase64Encoding` is the boundary detector. All pure, no client state.
2. [client/headers_test.go](https://github.com/panyam/mcpkit/pull/463/files#diff-9b2bf2990f377f8d8d89f72ee702d57a30109c11fc701fab697b2ced14f9a2d1) — exhaustive tests for every encoding edge case from the upstream scenario (non-ASCII, leading/trailing whitespace, tabs, control chars, CRLF, numbers, booleans, empty strings) plus the schema walker. 12 tests, all green.
3. [client/client.go](https://github.com/panyam/mcpkit/pull/463/files#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09) — three integration changes:
   - `Client` gains a `toolSchemas` cache + `RWMutex` (small struct field block).
   - `ListTools` populates the cache (side effect, no API change).
   - `ToolCall` consults the cache, builds the header map, threads it through `CallContext.Headers` to the Streamable HTTP transport. `CallContext` gains a `Headers map[string]string` field.
   - Streamable transport's `callWithContext` applies caller-supplied headers after the transport defaults (Content-Type, Accept, Mcp-Session-Id) — reserved names protected from accidental clobber.
4. [conformance/UPSTREAM_AUDIT.md](https://github.com/panyam/mcpkit/pull/463/files#diff-bf63f1699e28f43c702f9450df02d9e8ec1dae36200827f929a68513bdb34197) — regenerated snapshot showing the scenario flip.

Skim or skip: the diff in client/client.go is concentrated in a small region around `ListTools` / `ToolCall` / the streamable transport's request builder; the rest of the file is unchanged.

## Diff groups

- **Pure helpers + tests:** `client/headers.go`, `client/headers_test.go` (new files).
- **Client integration:** `client/client.go` — schema cache, `ToolCall` extension, `CallContext.Headers`, streamable transport header injection.
- **Audit snapshot:** `conformance/UPSTREAM_AUDIT.md` (regenerated, same commit per snapshot discipline).

## Decision log

- **Schema-driven (Option A from the plan).** mcpkit caches `tools/list` results; `ToolCall` looks up the cached schema by name to find `x-mcp-header` annotations. Matches the SEP-2243 spec intent ("clients react to the schema"). Trade-off: callers must invoke `ListTools` before `ToolCall` for header mirroring to work — same flow conformance scenarios use anyway. Tools without cached schemas silently skip header mirroring; behavior is identical to pre-SEP-2243.
- **`CallContext.Headers` as the threading mechanism.** Less invasive than adding a new public method (`CallWithHeaders`) or changing the middleware signature. Streamable transport reads from `cc.Headers`; SSE transport ignores `cc` entirely today (its `callWithContext` discards the parameter), so SSE doesn't yet mirror headers. SSE is the older 2024-11 path; out of scope here.
- **Middleware-bypass for header-injecting calls.** When `buildToolCallHeaders` returns a non-empty map, `ToolCall` skips the middleware-wrapped `c.Call` path and invokes `rawCallWithContext` directly. Documented in the `ToolCall` doc comment. Reasoning: extending middleware to accept `CallContext` would break the public middleware signature; for SEP-2243 conformance use cases (and most server-tool use cases) middleware doesn't add value here. If a real consumer needs middleware composition with SEP-2243 headers, file a follow-up.
- **Reserved-name protection in the transport.** Caller-supplied headers from `cc.Headers` are applied AFTER `Content-Type` / `Accept` / `Mcp-Session-Id` so a deliberately-malformed `cc.Headers` map can't overwrite the transport's own headers. `Mcp-Param-*` names are the SEP-2243 namespace and won't collide.

## Risk / blast radius

- **First impl-feature PR in this umbrella.** Earlier Tier 1 PRs touched fixtures, harness, discipline helpers. This one changes the `ToolCall` hot path. Mitigation: fast-path (no header mirroring) is byte-identical to before — verified by `make test` green and the audit's existing passing scenarios staying passing.
- **`ListTools` now has a side effect.** Previously pure RPC, now also populates `c.toolSchemas`. Single-threaded callers see no change. Concurrent callers (multiple goroutines calling `ListTools` + `ToolCall`) are guarded by `toolSchemasMu` (RW lock). The cache is replace-not-merge so a refresh fully reflects server-side state.
- **Wire-format change for tools with x-mcp-header.** mcpkit clients calling such tools now send extra HTTP headers. Servers that don't recognize them ignore them (RFC 9110 §5.5 — "recipients MAY ignore unknown header fields"). No wire change for tools without the annotation.
- **No SSE coverage.** A client on SSE transport calling a tool with `x-mcp-header` annotations sends no extra headers (same as before). The conformance audit doesn't exercise SSE on this scenario, so the gap isn't visible. Documented in Out of Scope.
- **Be paranoid about:** the `extractMcpParamHeaders` walker — if upstream's `x-mcp-header` semantics evolve (e.g. nested schemas via `$ref`), the walker won't follow. Today's scenario only puts `x-mcp-header` on direct properties.

## Before / after

```
Before: | `http-custom-headers` | client | partial | 2 pass / 16 fail | (empty)
After:  | `http-custom-headers` | client | pass    | 18 pass          | (empty)
```

Sample check verdicts (all SUCCESS post-PR):
```
SUCCESS sep-2243-client-supports-custom-headers
SUCCESS sep-2243-client-mirrors-designated-params (×5)
SUCCESS sep-2243-client-encode-values (×4)
SUCCESS sep-2243-client-base64-unsafe (×7)
SUCCESS sep-2243-client-omit-null
```

Client summary delta:
```
Before: | Client | 40 | 1130 | 416 pass | 53 fail | 4 warn | 649 info | 8 skip | 1 harness-gap |
After:  | Client | 40 | 1130 | 432 pass | 37 fail | 4 warn | 649 info | 8 skip | 1 harness-gap |
```

+16 pass, -16 fail — exactly reverses the impl gap that #443's fix exposed.

## Out of scope

- **`http-invalid-tool-headers`** — client must reject tools with malformed `x-mcp-header` annotations (empty values, non-primitive types, duplicates, invalid chars in header names). Different code path (tool-list validation), tracked under SEP-2243 family in #445.
- **SSE transport header mirroring** — SSE's `callWithContext` discards the `cc` parameter today. If a real consumer needs SEP-2243 on SSE, file a follow-up.
- **Server-side tool authoring** — Go struct-tag convention for declaring `x-mcp-header` from server code (e.g. `jsonschema:"x-mcp-header=Region"`) so server authors don't have to hand-roll inputSchema map literals. Would compose naturally with `core.WithInputSchemaOverride` (PR 455) for the rare cases struct tags don't suffice.
- **Middleware composition with header-mirroring calls** — bypassed by design here. If real-world middleware use cases need to coexist with SEP-2243 headers, file a follow-up.
- **Cache invalidation on `notifications/tools/listChanged`** — current cache is replaced only on the next `ListTools` call. Server-pushed list-changed notifications don't trigger a refresh automatically. Adequate for conformance and most flows; revisit if it surfaces a real problem.

Related work:
- #460 client API audit will inspect this code path when it picks up — both for coverage (the schema-driven design exposes a coverage axis: tools-not-listed-first) and for usage hygiene (the new internal pattern of `callForToolCall` is worth documenting as a precedent).

