### PR TITLE
chore(deps): bump panyam/oneauth to v0.1.0

### DIFF
--- a/examples/auth/go.mod
+++ b/examples/auth/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/panyam/mcpkit v0.2.41
 	github.com/panyam/mcpkit/examples/common v0.0.0-00010101000000-000000000000
 	github.com/panyam/mcpkit/ext/auth v0.2.36
-	github.com/panyam/oneauth v0.0.85
+	github.com/panyam/oneauth v0.1.0
 )
 
 require (

--- a/examples/auth/go.sum
+++ b/examples/auth/go.sum
@@ -83,8 +83,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.13 h1:V819IdZTEJ3rpu33ZqohC6O9ou7KOu6cxfigoYT12OQ=
 github.com/panyam/goutils v0.1.13/go.mod h1:vd3iFcv1DjaeV6h8tslIJh9d09RLndg8UYNSGROBrM4=
-github.com/panyam/oneauth v0.0.85 h1:qrfXWja/R08MyeCFR/Y4t9TD5f6nHb6TTD3kHzRU8/E=
-github.com/panyam/oneauth v0.0.85/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
+github.com/panyam/oneauth v0.1.0 h1:fMa6m3UGmZChhXKQssLFNarv9nM8Ka+CZQ3tFl3SKfc=
+github.com/panyam/oneauth v0.1.0/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
 github.com/panyam/servicekit v0.1.1 h1:aIvVWjpIw2xBF5V4hpf7GY4RqinkY7u3OBbjQd8a1vU=
 github.com/panyam/servicekit v0.1.1/go.mod h1:kvuEgs3iJjwRyqGlKTkppwiFDpM69MPeihVi1m/B97o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/examples/fine-grained-auth/go.mod
+++ b/examples/fine-grained-auth/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/panyam/mcpkit v0.2.41
 	github.com/panyam/mcpkit/examples/common v0.0.0-00010101000000-000000000000
 	github.com/panyam/mcpkit/ext/auth v0.2.36
-	github.com/panyam/oneauth v0.0.82
+	github.com/panyam/oneauth v0.1.0
 	github.com/panyam/servicekit v0.1.1
 )
 

--- a/examples/fine-grained-auth/go.sum
+++ b/examples/fine-grained-auth/go.sum
@@ -81,8 +81,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.13 h1:V819IdZTEJ3rpu33ZqohC6O9ou7KOu6cxfigoYT12OQ=
 github.com/panyam/goutils v0.1.13/go.mod h1:vd3iFcv1DjaeV6h8tslIJh9d09RLndg8UYNSGROBrM4=
-github.com/panyam/oneauth v0.0.82 h1:pbqNvNmbw1MAtJHm7frbSykJglkVSn2vg3lvt62Bqew=
-github.com/panyam/oneauth v0.0.82/go.mod h1:EXZsjH05mFz12xUX7YaWnol0NMYMzMQdXJnDR9bQ5iA=
+github.com/panyam/oneauth v0.1.0 h1:fMa6m3UGmZChhXKQssLFNarv9nM8Ka+CZQ3tFl3SKfc=
+github.com/panyam/oneauth v0.1.0/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
 github.com/panyam/servicekit v0.1.1 h1:aIvVWjpIw2xBF5V4hpf7GY4RqinkY7u3OBbjQd8a1vU=
 github.com/panyam/servicekit v0.1.1/go.mod h1:kvuEgs3iJjwRyqGlKTkppwiFDpM69MPeihVi1m/B97o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/ext/auth/go.mod
+++ b/ext/auth/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/panyam/gocurrent v0.1.1
 	github.com/panyam/mcpkit v0.2.3
-	github.com/panyam/oneauth v0.0.85
+	github.com/panyam/oneauth v0.1.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/ext/auth/go.sum
+++ b/ext/auth/go.sum
@@ -32,8 +32,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.8 h1:5UscYTP892k54+Nyb01tKGGwZxczZ5k7BC+c0nXmcoc=
 github.com/panyam/goutils v0.1.8/go.mod h1:ntucs8GJOHQ0LmlRGRjeup3aDC2t7xPMudrRwUHrJNM=
-github.com/panyam/oneauth v0.0.85 h1:qrfXWja/R08MyeCFR/Y4t9TD5f6nHb6TTD3kHzRU8/E=
-github.com/panyam/oneauth v0.0.85/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
+github.com/panyam/oneauth v0.1.0 h1:fMa6m3UGmZChhXKQssLFNarv9nM8Ka+CZQ3tFl3SKfc=
+github.com/panyam/oneauth v0.1.0/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
 github.com/panyam/servicekit v0.0.25 h1:JeTRyz5ZZY3beENg0N3tLW+O39/foTuHMPAf+rpwYhM=
 github.com/panyam/servicekit v0.0.25/go.mod h1:9TkF2LRqiPC9bgu0bYVdky7rnHEuBvzGzrsoL++Ra5c=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/panyam/mcpkit v0.2.3
 	github.com/panyam/mcpkit/ext/auth v0.0.0
 	github.com/panyam/mcpkit/ext/ui v0.0.0
-	github.com/panyam/oneauth v0.0.85
+	github.com/panyam/oneauth v0.1.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/tests/e2e/go.sum
+++ b/tests/e2e/go.sum
@@ -33,8 +33,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.8 h1:5UscYTP892k54+Nyb01tKGGwZxczZ5k7BC+c0nXmcoc=
 github.com/panyam/goutils v0.1.8/go.mod h1:ntucs8GJOHQ0LmlRGRjeup3aDC2t7xPMudrRwUHrJNM=
-github.com/panyam/oneauth v0.0.85 h1:qrfXWja/R08MyeCFR/Y4t9TD5f6nHb6TTD3kHzRU8/E=
-github.com/panyam/oneauth v0.0.85/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
+github.com/panyam/oneauth v0.1.0 h1:fMa6m3UGmZChhXKQssLFNarv9nM8Ka+CZQ3tFl3SKfc=
+github.com/panyam/oneauth v0.1.0/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
 github.com/panyam/servicekit v0.0.25 h1:JeTRyz5ZZY3beENg0N3tLW+O39/foTuHMPAf+rpwYhM=
 github.com/panyam/servicekit v0.0.25/go.mod h1:9TkF2LRqiPC9bgu0bYVdky7rnHEuBvzGzrsoL++Ra5c=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/tests/keycloak/go.mod
+++ b/tests/keycloak/go.mod
@@ -5,7 +5,7 @@ go 1.26.3
 require (
 	github.com/panyam/mcpkit v0.2.3
 	github.com/panyam/mcpkit/ext/auth v0.0.0
-	github.com/panyam/oneauth v0.0.85
+	github.com/panyam/oneauth v0.1.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/tests/keycloak/go.sum
+++ b/tests/keycloak/go.sum
@@ -33,8 +33,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.8 h1:5UscYTP892k54+Nyb01tKGGwZxczZ5k7BC+c0nXmcoc=
 github.com/panyam/goutils v0.1.8/go.mod h1:ntucs8GJOHQ0LmlRGRjeup3aDC2t7xPMudrRwUHrJNM=
-github.com/panyam/oneauth v0.0.85 h1:qrfXWja/R08MyeCFR/Y4t9TD5f6nHb6TTD3kHzRU8/E=
-github.com/panyam/oneauth v0.0.85/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
+github.com/panyam/oneauth v0.1.0 h1:fMa6m3UGmZChhXKQssLFNarv9nM8Ka+CZQ3tFl3SKfc=
+github.com/panyam/oneauth v0.1.0/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
 github.com/panyam/servicekit v0.0.25 h1:JeTRyz5ZZY3beENg0N3tLW+O39/foTuHMPAf+rpwYhM=
 github.com/panyam/servicekit v0.0.25/go.mod h1:9TkF2LRqiPC9bgu0bYVdky7rnHEuBvzGzrsoL++Ra5c=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
## What changes

Bumps `panyam/oneauth` to `v0.1.0` across all 5 sub-modules that consume it.

oneauth `v0.1.0` is the first `0.1.x` release and lands a breaking package reshape:
- `User` / `Identity` / `Channel` and their stores moved to a new `accounts/` package
- OAuth callback handlers moved to a new `federatedauth/` package
- `core.AuthToken` / `TokenStore` renamed to `localauth.VerificationToken` / `VerificationTokenStore`
- `httpauth.setLoggedInUser(user core.User, ...)` renamed to `httpauth.SetLoggedInUserID(userID string, ...)`

See oneauth PR 210 for the full details.

## Why this is a clean dep bump

mcpkit consumes oneauth as an **OAuth client / JWT validator / PRM metadata** stack. It does not implement user/identity/channel stores or wire OAuth callback handlers. Verified by grep across the 21 oneauth-using files: only `oneauth/core.ContainsAllScopes` and `oneauth/core.AuthorizationDetail` are referenced, and both stay in `core/` after the reshape.

Zero source changes required.

## Reviewer's guide

Each sub-module just had `go.mod` + `go.sum` updated. Inspect any one as a representative:

1. [ext/auth/go.mod](https://github.com/panyam/mcpkit/pull/467/files#diff-3c7eea7bae0c98e4121ff2f0c27d6b3612e863db7c0863d7ea006b9184d57ed7) — primary integration; `v0.0.85` → `v0.1.0`
2. [examples/fine-grained-auth/go.mod](https://github.com/panyam/mcpkit/pull/467/files#diff-2736cf2bc74f35978090404c893ba28d5fa87825b3fca4dd8d0953595720d460) — leapfrog from `v0.0.82` (had lagged behind the others)
3. The other three (`examples/auth`, `tests/e2e`, `tests/keycloak`) — straight `v0.0.85` → `v0.1.0`

## Verification

- `ext/auth`: `go build ./...` + `go test ./...` pass
- `tests/e2e`: `go build ./...` + `go test ./...` pass (e2e + e2e/apps)
- `examples/*`: `go build ./...` pass
- `tests/keycloak`: `go build ./...` pass (live Keycloak tests not run locally — requires Docker)

All builds run with `GOWORK=off` to confirm the pin works without workspace help.

## Test plan

- [x] `cd ext/auth && go test ./...`
- [x] `cd tests/e2e && go test ./...`
- [ ] CI runs the full matrix (including Keycloak via Docker)
