### PR TITLE
feat(ext/auth): SEP-1046 client_credentials TokenSource (closes #447)

### DIFF
--- a/cmd/testclient/go.mod
+++ b/cmd/testclient/go.mod
@@ -5,7 +5,7 @@ go 1.26.3
 require (
 	github.com/panyam/mcpkit v0.2.3
 	github.com/panyam/mcpkit/ext/auth v0.0.0
-	github.com/panyam/oneauth v0.1.0
+	github.com/panyam/oneauth v0.1.1
 )
 
 require (

--- a/cmd/testclient/go.mod
+++ b/cmd/testclient/go.mod
@@ -5,7 +5,7 @@ go 1.26.3
 require (
 	github.com/panyam/mcpkit v0.2.3
 	github.com/panyam/mcpkit/ext/auth v0.0.0
-	github.com/panyam/oneauth v0.1.1
+	github.com/panyam/oneauth v0.1.2
 )
 
 require (

--- a/cmd/testclient/go.sum
+++ b/cmd/testclient/go.sum
@@ -31,8 +31,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.8 h1:5UscYTP892k54+Nyb01tKGGwZxczZ5k7BC+c0nXmcoc=
 github.com/panyam/goutils v0.1.8/go.mod h1:ntucs8GJOHQ0LmlRGRjeup3aDC2t7xPMudrRwUHrJNM=
-github.com/panyam/oneauth v0.1.1 h1:8mGDH8FGetg5x0kQKVbyA59GbMufuZR7APZMokKQ8/I=
-github.com/panyam/oneauth v0.1.1/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
+github.com/panyam/oneauth v0.1.2 h1:tEH9uLTrmMbKEYw6RcPNQ2JsMGDNFP/+NmfN3xSkxB8=
+github.com/panyam/oneauth v0.1.2/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
 github.com/panyam/servicekit v0.0.25 h1:JeTRyz5ZZY3beENg0N3tLW+O39/foTuHMPAf+rpwYhM=
 github.com/panyam/servicekit v0.0.25/go.mod h1:9TkF2LRqiPC9bgu0bYVdky7rnHEuBvzGzrsoL++Ra5c=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/cmd/testclient/go.sum
+++ b/cmd/testclient/go.sum
@@ -31,8 +31,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.8 h1:5UscYTP892k54+Nyb01tKGGwZxczZ5k7BC+c0nXmcoc=
 github.com/panyam/goutils v0.1.8/go.mod h1:ntucs8GJOHQ0LmlRGRjeup3aDC2t7xPMudrRwUHrJNM=
-github.com/panyam/oneauth v0.1.0 h1:fMa6m3UGmZChhXKQssLFNarv9nM8Ka+CZQ3tFl3SKfc=
-github.com/panyam/oneauth v0.1.0/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
+github.com/panyam/oneauth v0.1.1 h1:8mGDH8FGetg5x0kQKVbyA59GbMufuZR7APZMokKQ8/I=
+github.com/panyam/oneauth v0.1.1/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
 github.com/panyam/servicekit v0.0.25 h1:JeTRyz5ZZY3beENg0N3tLW+O39/foTuHMPAf+rpwYhM=
 github.com/panyam/servicekit v0.0.25/go.mod h1:9TkF2LRqiPC9bgu0bYVdky7rnHEuBvzGzrsoL++Ra5c=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/cmd/testclient/main.go
+++ b/cmd/testclient/main.go
@@ -178,9 +178,12 @@ type toolCallSpec struct {
 }
 
 // pickTokenSource decides between OAuthTokenSource (authorization_code) and
-// ClientCredentialsTokenSource (SEP-1046) by probing the AS once for its
-// grant_types_supported. If discovery fails or the AS advertises
-// authorization_code, fall back to OAuthTokenSource — the existing behavior.
+// ClientCredentialsTokenSource (SEP-1046). PrivateKeyPEM uniquely identifies
+// private_key_jwt. For the basic variant, ctx shape (client_id + client_secret)
+// overlaps with auth-code pre-registration scenarios, so a discovery probe
+// disambiguates via AS grant_types_supported. The probe is gated on
+// `ClientID != ""` to keep DCR scenarios with no pre-registered credentials
+// on the OAuthTokenSource fast path without spurious PRM/AS round trips.
 func pickTokenSource(serverURL string, ctx conformanceContext) core.TokenSource {
 	if ctx.PrivateKeyPEM != "" {
 		log.Println("Step 2: ctx has private_key_pem → ClientCredentialsTokenSource (private_key_jwt)")
@@ -192,16 +195,18 @@ func pickTokenSource(serverURL string, ctx conformanceContext) core.TokenSource 
 			AllowInsecure:    true,
 		}
 	}
-	info, err := auth.DiscoverMCPAuth(serverURL)
-	if err == nil && info.ASMetadata != nil {
-		grants := info.ASMetadata.GrantTypesSupported
-		if slices.Contains(grants, "client_credentials") && !slices.Contains(grants, "authorization_code") {
-			log.Println("Step 2: AS advertises only client_credentials → ClientCredentialsTokenSource (basic)")
-			return &auth.ClientCredentialsTokenSource{
-				ServerURL:     serverURL,
-				ClientID:      ctx.ClientID,
-				ClientSecret:  ctx.ClientSecret,
-				AllowInsecure: true,
+	if ctx.ClientID != "" {
+		info, err := auth.DiscoverMCPAuth(serverURL)
+		if err == nil && info.ASMetadata != nil {
+			grants := info.ASMetadata.GrantTypesSupported
+			if slices.Contains(grants, "client_credentials") && !slices.Contains(grants, "authorization_code") {
+				log.Println("Step 2: AS advertises only client_credentials → ClientCredentialsTokenSource (basic)")
+				return &auth.ClientCredentialsTokenSource{
+					ServerURL:     serverURL,
+					ClientID:      ctx.ClientID,
+					ClientSecret:  ctx.ClientSecret,
+					AllowInsecure: true,
+				}
 			}
 		}
 	}

--- a/cmd/testclient/main.go
+++ b/cmd/testclient/main.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"log"
 	"os"
+	"slices"
 
 	"github.com/panyam/mcpkit/client"
 	"github.com/panyam/mcpkit/core"
@@ -95,18 +96,12 @@ func main() {
 		log.Printf("Direct connect failed: %v — proceeding with OAuth flow", err)
 	}
 
-	// Step 2: Build OAuthTokenSource with discovered credentials.
-	// OAuthTokenSource handles: PRM discovery → AS metadata → PKCE → DCR → token exchange.
-	// FollowRedirects provides headless OAuth (follows 302s instead of opening browser).
-	log.Println("Step 2: Setting up OAuthTokenSource...")
-	ts := &auth.OAuthTokenSource{
-		ServerURL:     serverURL,
-		ClientID:      ctx.ClientID,
-		ClientSecret:  ctx.ClientSecret,
-		EnableDCR:     true,  // fallback to DCR if no pre-registered client_id
-		AllowInsecure: true,  // conformance mock AS uses HTTP, not HTTPS
-		OpenBrowser:   oneauthclient.FollowRedirects(nil), // nil = default client (follows redirects)
-	}
+	// Step 2: Build a TokenSource. Pick the variant by AS grant_types_supported:
+	// SEP-1046 scenarios advertise only client_credentials (no authorization_code),
+	// so a quick discovery probe tells us which grant the AS will accept. The
+	// presence of PrivateKeyPEM additionally pins us to the private_key_jwt
+	// variant — no other scenario provides one.
+	ts := pickTokenSource(serverURL, ctx)
 
 	// Step 3: Connect with auth token.
 	log.Println("Step 3: MCP initialize with OAuth token...")
@@ -165,10 +160,12 @@ func conformanceElicitationHandler(_ context.Context, _ core.ElicitationRequest)
 
 // conformanceContext holds scenario-specific data from the conformance runner.
 type conformanceContext struct {
-	Name         string         `json:"name"`
-	ClientID     string         `json:"client_id"`
-	ClientSecret string         `json:"client_secret"`
-	ToolCalls    []toolCallSpec `json:"toolCalls"`
+	Name             string         `json:"name"`
+	ClientID         string         `json:"client_id"`
+	ClientSecret     string         `json:"client_secret"`
+	PrivateKeyPEM    string         `json:"private_key_pem"`
+	SigningAlgorithm string         `json:"signing_algorithm"`
+	ToolCalls        []toolCallSpec `json:"toolCalls"`
 }
 
 // toolCallSpec is one directed tools/call invocation requested by the scenario.
@@ -178,6 +175,45 @@ type conformanceContext struct {
 type toolCallSpec struct {
 	Name      string         `json:"name"`
 	Arguments map[string]any `json:"arguments"`
+}
+
+// pickTokenSource decides between OAuthTokenSource (authorization_code) and
+// ClientCredentialsTokenSource (SEP-1046) by probing the AS once for its
+// grant_types_supported. If discovery fails or the AS advertises
+// authorization_code, fall back to OAuthTokenSource — the existing behavior.
+func pickTokenSource(serverURL string, ctx conformanceContext) core.TokenSource {
+	if ctx.PrivateKeyPEM != "" {
+		log.Println("Step 2: ctx has private_key_pem → ClientCredentialsTokenSource (private_key_jwt)")
+		return &auth.ClientCredentialsTokenSource{
+			ServerURL:        serverURL,
+			ClientID:         ctx.ClientID,
+			PrivateKeyPEM:    ctx.PrivateKeyPEM,
+			SigningAlgorithm: ctx.SigningAlgorithm,
+			AllowInsecure:    true,
+		}
+	}
+	info, err := auth.DiscoverMCPAuth(serverURL)
+	if err == nil && info.ASMetadata != nil {
+		grants := info.ASMetadata.GrantTypesSupported
+		if slices.Contains(grants, "client_credentials") && !slices.Contains(grants, "authorization_code") {
+			log.Println("Step 2: AS advertises only client_credentials → ClientCredentialsTokenSource (basic)")
+			return &auth.ClientCredentialsTokenSource{
+				ServerURL:     serverURL,
+				ClientID:      ctx.ClientID,
+				ClientSecret:  ctx.ClientSecret,
+				AllowInsecure: true,
+			}
+		}
+	}
+	log.Println("Step 2: Setting up OAuthTokenSource...")
+	return &auth.OAuthTokenSource{
+		ServerURL:     serverURL,
+		ClientID:      ctx.ClientID,
+		ClientSecret:  ctx.ClientSecret,
+		EnableDCR:     true,
+		AllowInsecure: true,
+		OpenBrowser:   oneauthclient.FollowRedirects(nil),
+	}
 }
 
 // driveToolCalls invokes each scenario-directed tool call in sequence via the

--- a/conformance/UPSTREAM_AUDIT.md
+++ b/conformance/UPSTREAM_AUDIT.md
@@ -14,8 +14,8 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 | Surface | Scenarios | Checks | Pass | Fail | Warn | Info | Skipped | Harness-gap |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|
 | Server | 51 | 126 | 58 | 41 | 12 | 6 | 9 | 0 |
-| Client | 40 | 1206 | 442 | 31 | 4 | 723 | 6 | 1 |
-| **Total** | **91** | **1332** | **500** | **72** | **16** | **729** | **15** | **1** |
+| Client | 40 | 1452 | 496 | 27 | 4 | 919 | 6 | 1 |
+| **Total** | **91** | **1578** | **554** | **68** | **16** | **925** | **15** | **1** |
 
 ## Harness gaps
 
@@ -27,33 +27,33 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 
 | Scenario | Surface | Status | Checks | Note |
 |---|---|---|---|---|
-| `auth/2025-03-26-oauth-endpoint-fallback` | client | partial | 3 fail / 8 info |  |
-| `auth/2025-03-26-oauth-metadata-backcompat` | client | partial | 4 fail / 8 info |  |
-| `auth/authorization-server-migration` | client | partial | 15 pass / 1 fail / 32 info |  |
-| `auth/iss-normalized` | client | partial | 14 pass / 1 fail / 24 info |  |
-| `auth/iss-supported-missing` | client | partial | 14 pass / 1 fail / 24 info |  |
-| `auth/iss-unexpected` | client | partial | 14 pass / 1 fail / 24 info |  |
-| `auth/iss-wrong-issuer` | client | partial | 14 pass / 1 fail / 24 info |  |
-| `auth/metadata-issuer-mismatch` | client | partial | 14 pass / 1 fail / 24 info |  |
-| `auth/resource-mismatch` | client | partial | 14 pass / 1 fail / 24 info |  |
+| `auth/2025-03-26-oauth-endpoint-fallback` | client | partial | 3 fail / 14 info |  |
+| `auth/2025-03-26-oauth-metadata-backcompat` | client | partial | 4 fail / 14 info |  |
+| `auth/authorization-server-migration` | client | partial | 17 pass / 1 fail / 38 info |  |
+| `auth/iss-normalized` | client | partial | 16 pass / 1 fail / 30 info |  |
+| `auth/iss-supported-missing` | client | partial | 16 pass / 1 fail / 30 info |  |
+| `auth/iss-unexpected` | client | partial | 16 pass / 1 fail / 30 info |  |
+| `auth/iss-wrong-issuer` | client | partial | 16 pass / 1 fail / 30 info |  |
+| `auth/metadata-issuer-mismatch` | client | partial | 16 pass / 1 fail / 30 info |  |
+| `auth/resource-mismatch` | client | partial | 16 pass / 1 fail / 30 info |  |
 | `initialize` | client | partial | 1 fail / 1 info |  |
 | `request-metadata` | client | harness-gap | — | No `checks.json` written — driver does not handle this scenario |
-| `auth/basic-cimd` | client | pass | 14 pass / 1 warn / 24 info |  |
-| `auth/iss-not-advertised` | client | pass | 15 pass / 24 info |  |
-| `auth/iss-supported` | client | pass | 15 pass / 24 info |  |
-| `auth/metadata-default` | client | pass | 14 pass / 24 info |  |
-| `auth/metadata-var1` | client | pass | 14 pass / 26 info |  |
-| `auth/metadata-var2` | client | pass | 14 pass / 26 info |  |
-| `auth/metadata-var3` | client | pass | 14 pass / 26 info |  |
-| `auth/pre-registration` | client | pass | 13 pass / 22 info |  |
-| `auth/scope-from-scopes-supported` | client | pass | 15 pass / 24 info |  |
-| `auth/scope-from-www-authenticate` | client | pass | 15 pass / 24 info |  |
-| `auth/scope-omitted-when-undefined` | client | pass | 15 pass / 24 info |  |
-| `auth/scope-retry-limit` | client | pass | 17 pass / 36 info |  |
-| `auth/scope-step-up` | client | pass | 19 pass / 2 warn / 34 info |  |
-| `auth/token-endpoint-auth-basic` | client | pass | 19 pass / 24 info |  |
-| `auth/token-endpoint-auth-none` | client | pass | 19 pass / 24 info |  |
-| `auth/token-endpoint-auth-post` | client | pass | 19 pass / 24 info |  |
+| `auth/basic-cimd` | client | pass | 16 pass / 1 warn / 30 info |  |
+| `auth/iss-not-advertised` | client | pass | 17 pass / 30 info |  |
+| `auth/iss-supported` | client | pass | 17 pass / 30 info |  |
+| `auth/metadata-default` | client | pass | 16 pass / 30 info |  |
+| `auth/metadata-var1` | client | pass | 16 pass / 34 info |  |
+| `auth/metadata-var2` | client | pass | 16 pass / 34 info |  |
+| `auth/metadata-var3` | client | pass | 16 pass / 34 info |  |
+| `auth/pre-registration` | client | pass | 15 pass / 28 info |  |
+| `auth/scope-from-scopes-supported` | client | pass | 17 pass / 30 info |  |
+| `auth/scope-from-www-authenticate` | client | pass | 17 pass / 30 info |  |
+| `auth/scope-omitted-when-undefined` | client | pass | 17 pass / 30 info |  |
+| `auth/scope-retry-limit` | client | pass | 19 pass / 42 info |  |
+| `auth/scope-step-up` | client | pass | 21 pass / 2 warn / 40 info |  |
+| `auth/token-endpoint-auth-basic` | client | pass | 21 pass / 30 info |  |
+| `auth/token-endpoint-auth-none` | client | pass | 21 pass / 30 info |  |
+| `auth/token-endpoint-auth-post` | client | pass | 21 pass / 30 info |  |
 | `completion-complete` | server | pass | 1 pass |  |
 | `dns-rebinding-protection` | server | pass | 2 pass |  |
 | `logging-set-level` | server | pass | 1 pass |  |
@@ -92,7 +92,7 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 
 | Scenario | Surface | Status | Checks | Note |
 |---|---|---|---|---|
-| `auth/enterprise-managed-authorization` | client | partial | 8 pass / 2 fail / 12 info |  |
+| `auth/enterprise-managed-authorization` | client | partial | 10 pass / 2 fail / 18 info |  |
 
 ### [SEP-1034](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1034) (2 scenarios)
 
@@ -105,8 +105,8 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 
 | Scenario | Surface | Status | Checks | Note |
 |---|---|---|---|---|
-| `auth/client-credentials-basic` | client | partial | 8 pass / 2 fail / 12 info |  |
-| `auth/client-credentials-jwt` | client | partial | 8 pass / 2 fail / 12 info |  |
+| `auth/client-credentials-basic` | client | pass | 10 pass / 26 info |  |
+| `auth/client-credentials-jwt` | client | pass | 8 pass / 20 info |  |
 
 ### [SEP-1330](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1330) (1 scenarios)
 
@@ -144,8 +144,8 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 
 | Scenario | Surface | Status | Checks | Note |
 |---|---|---|---|---|
-| `auth/offline-access-not-supported` | client | pass | 15 pass / 24 info |  |
-| `auth/offline-access-scope` | client | pass | 14 pass / 1 warn / 25 info |  |
+| `auth/offline-access-not-supported` | client | pass | 17 pass / 30 info |  |
+| `auth/offline-access-scope` | client | pass | 16 pass / 1 warn / 31 info |  |
 
 ### [SEP-2243-CUSTOM-HEADERS](https://modelcontextprotocol.io/specification/draft/basic/transports#server-behavior-for-custom-headers) (2 scenarios)
 

--- a/conformance/UPSTREAM_AUDIT.md
+++ b/conformance/UPSTREAM_AUDIT.md
@@ -14,8 +14,8 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 | Surface | Scenarios | Checks | Pass | Fail | Warn | Info | Skipped | Harness-gap |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|
 | Server | 51 | 126 | 58 | 41 | 12 | 6 | 9 | 0 |
-| Client | 40 | 1452 | 496 | 27 | 4 | 919 | 6 | 1 |
-| **Total** | **91** | **1578** | **554** | **68** | **16** | **925** | **15** | **1** |
+| Client | 40 | 1242 | 448 | 27 | 4 | 757 | 6 | 1 |
+| **Total** | **91** | **1368** | **506** | **68** | **16** | **763** | **15** | **1** |
 
 ## Harness gaps
 
@@ -27,33 +27,33 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 
 | Scenario | Surface | Status | Checks | Note |
 |---|---|---|---|---|
-| `auth/2025-03-26-oauth-endpoint-fallback` | client | partial | 3 fail / 14 info |  |
-| `auth/2025-03-26-oauth-metadata-backcompat` | client | partial | 4 fail / 14 info |  |
-| `auth/authorization-server-migration` | client | partial | 17 pass / 1 fail / 38 info |  |
-| `auth/iss-normalized` | client | partial | 16 pass / 1 fail / 30 info |  |
-| `auth/iss-supported-missing` | client | partial | 16 pass / 1 fail / 30 info |  |
-| `auth/iss-unexpected` | client | partial | 16 pass / 1 fail / 30 info |  |
-| `auth/iss-wrong-issuer` | client | partial | 16 pass / 1 fail / 30 info |  |
-| `auth/metadata-issuer-mismatch` | client | partial | 16 pass / 1 fail / 30 info |  |
-| `auth/resource-mismatch` | client | partial | 16 pass / 1 fail / 30 info |  |
+| `auth/2025-03-26-oauth-endpoint-fallback` | client | partial | 3 fail / 8 info |  |
+| `auth/2025-03-26-oauth-metadata-backcompat` | client | partial | 4 fail / 8 info |  |
+| `auth/authorization-server-migration` | client | partial | 15 pass / 1 fail / 32 info |  |
+| `auth/iss-normalized` | client | partial | 14 pass / 1 fail / 24 info |  |
+| `auth/iss-supported-missing` | client | partial | 14 pass / 1 fail / 24 info |  |
+| `auth/iss-unexpected` | client | partial | 14 pass / 1 fail / 24 info |  |
+| `auth/iss-wrong-issuer` | client | partial | 14 pass / 1 fail / 24 info |  |
+| `auth/metadata-issuer-mismatch` | client | partial | 14 pass / 1 fail / 24 info |  |
+| `auth/resource-mismatch` | client | partial | 14 pass / 1 fail / 24 info |  |
 | `initialize` | client | partial | 1 fail / 1 info |  |
 | `request-metadata` | client | harness-gap | — | No `checks.json` written — driver does not handle this scenario |
-| `auth/basic-cimd` | client | pass | 16 pass / 1 warn / 30 info |  |
-| `auth/iss-not-advertised` | client | pass | 17 pass / 30 info |  |
-| `auth/iss-supported` | client | pass | 17 pass / 30 info |  |
-| `auth/metadata-default` | client | pass | 16 pass / 30 info |  |
-| `auth/metadata-var1` | client | pass | 16 pass / 34 info |  |
-| `auth/metadata-var2` | client | pass | 16 pass / 34 info |  |
-| `auth/metadata-var3` | client | pass | 16 pass / 34 info |  |
+| `auth/basic-cimd` | client | pass | 14 pass / 1 warn / 24 info |  |
+| `auth/iss-not-advertised` | client | pass | 15 pass / 24 info |  |
+| `auth/iss-supported` | client | pass | 15 pass / 24 info |  |
+| `auth/metadata-default` | client | pass | 14 pass / 24 info |  |
+| `auth/metadata-var1` | client | pass | 14 pass / 26 info |  |
+| `auth/metadata-var2` | client | pass | 14 pass / 26 info |  |
+| `auth/metadata-var3` | client | pass | 14 pass / 26 info |  |
 | `auth/pre-registration` | client | pass | 15 pass / 28 info |  |
-| `auth/scope-from-scopes-supported` | client | pass | 17 pass / 30 info |  |
-| `auth/scope-from-www-authenticate` | client | pass | 17 pass / 30 info |  |
-| `auth/scope-omitted-when-undefined` | client | pass | 17 pass / 30 info |  |
-| `auth/scope-retry-limit` | client | pass | 19 pass / 42 info |  |
-| `auth/scope-step-up` | client | pass | 21 pass / 2 warn / 40 info |  |
-| `auth/token-endpoint-auth-basic` | client | pass | 21 pass / 30 info |  |
-| `auth/token-endpoint-auth-none` | client | pass | 21 pass / 30 info |  |
-| `auth/token-endpoint-auth-post` | client | pass | 21 pass / 30 info |  |
+| `auth/scope-from-scopes-supported` | client | pass | 15 pass / 24 info |  |
+| `auth/scope-from-www-authenticate` | client | pass | 15 pass / 24 info |  |
+| `auth/scope-omitted-when-undefined` | client | pass | 15 pass / 24 info |  |
+| `auth/scope-retry-limit` | client | pass | 17 pass / 36 info |  |
+| `auth/scope-step-up` | client | pass | 19 pass / 2 warn / 34 info |  |
+| `auth/token-endpoint-auth-basic` | client | pass | 19 pass / 24 info |  |
+| `auth/token-endpoint-auth-none` | client | pass | 19 pass / 24 info |  |
+| `auth/token-endpoint-auth-post` | client | pass | 19 pass / 24 info |  |
 | `completion-complete` | server | pass | 1 pass |  |
 | `dns-rebinding-protection` | server | pass | 2 pass |  |
 | `logging-set-level` | server | pass | 1 pass |  |
@@ -144,8 +144,8 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 
 | Scenario | Surface | Status | Checks | Note |
 |---|---|---|---|---|
-| `auth/offline-access-not-supported` | client | pass | 17 pass / 30 info |  |
-| `auth/offline-access-scope` | client | pass | 16 pass / 1 warn / 31 info |  |
+| `auth/offline-access-not-supported` | client | pass | 15 pass / 24 info |  |
+| `auth/offline-access-scope` | client | pass | 14 pass / 1 warn / 25 info |  |
 
 ### [SEP-2243-CUSTOM-HEADERS](https://modelcontextprotocol.io/specification/draft/basic/transports#server-behavior-for-custom-headers) (2 scenarios)
 

--- a/examples/auth/go.mod
+++ b/examples/auth/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/panyam/mcpkit v0.2.41
 	github.com/panyam/mcpkit/examples/common v0.0.0-00010101000000-000000000000
 	github.com/panyam/mcpkit/ext/auth v0.2.36
-	github.com/panyam/oneauth v0.1.1
+	github.com/panyam/oneauth v0.1.2
 )
 
 require (

--- a/examples/auth/go.mod
+++ b/examples/auth/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/panyam/mcpkit v0.2.41
 	github.com/panyam/mcpkit/examples/common v0.0.0-00010101000000-000000000000
 	github.com/panyam/mcpkit/ext/auth v0.2.36
-	github.com/panyam/oneauth v0.1.0
+	github.com/panyam/oneauth v0.1.1
 )
 
 require (

--- a/examples/auth/go.sum
+++ b/examples/auth/go.sum
@@ -83,8 +83,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.13 h1:V819IdZTEJ3rpu33ZqohC6O9ou7KOu6cxfigoYT12OQ=
 github.com/panyam/goutils v0.1.13/go.mod h1:vd3iFcv1DjaeV6h8tslIJh9d09RLndg8UYNSGROBrM4=
-github.com/panyam/oneauth v0.1.1 h1:8mGDH8FGetg5x0kQKVbyA59GbMufuZR7APZMokKQ8/I=
-github.com/panyam/oneauth v0.1.1/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
+github.com/panyam/oneauth v0.1.2 h1:tEH9uLTrmMbKEYw6RcPNQ2JsMGDNFP/+NmfN3xSkxB8=
+github.com/panyam/oneauth v0.1.2/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
 github.com/panyam/servicekit v0.1.1 h1:aIvVWjpIw2xBF5V4hpf7GY4RqinkY7u3OBbjQd8a1vU=
 github.com/panyam/servicekit v0.1.1/go.mod h1:kvuEgs3iJjwRyqGlKTkppwiFDpM69MPeihVi1m/B97o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/examples/auth/go.sum
+++ b/examples/auth/go.sum
@@ -83,8 +83,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.13 h1:V819IdZTEJ3rpu33ZqohC6O9ou7KOu6cxfigoYT12OQ=
 github.com/panyam/goutils v0.1.13/go.mod h1:vd3iFcv1DjaeV6h8tslIJh9d09RLndg8UYNSGROBrM4=
-github.com/panyam/oneauth v0.1.0 h1:fMa6m3UGmZChhXKQssLFNarv9nM8Ka+CZQ3tFl3SKfc=
-github.com/panyam/oneauth v0.1.0/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
+github.com/panyam/oneauth v0.1.1 h1:8mGDH8FGetg5x0kQKVbyA59GbMufuZR7APZMokKQ8/I=
+github.com/panyam/oneauth v0.1.1/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
 github.com/panyam/servicekit v0.1.1 h1:aIvVWjpIw2xBF5V4hpf7GY4RqinkY7u3OBbjQd8a1vU=
 github.com/panyam/servicekit v0.1.1/go.mod h1:kvuEgs3iJjwRyqGlKTkppwiFDpM69MPeihVi1m/B97o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/examples/events/discord/go.mod
+++ b/examples/events/discord/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/panyam/demokit/notebook v0.0.25 // indirect
 	github.com/panyam/gocurrent v0.1.1 // indirect
 	github.com/panyam/goutils v0.1.13 // indirect
-	github.com/panyam/oneauth v0.1.1 // indirect
+	github.com/panyam/oneauth v0.1.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect

--- a/examples/events/discord/go.mod
+++ b/examples/events/discord/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/panyam/demokit/notebook v0.0.25 // indirect
 	github.com/panyam/gocurrent v0.1.1 // indirect
 	github.com/panyam/goutils v0.1.13 // indirect
-	github.com/panyam/oneauth v0.1.0 // indirect
+	github.com/panyam/oneauth v0.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect

--- a/examples/events/discord/go.sum
+++ b/examples/events/discord/go.sum
@@ -84,8 +84,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.13 h1:V819IdZTEJ3rpu33ZqohC6O9ou7KOu6cxfigoYT12OQ=
 github.com/panyam/goutils v0.1.13/go.mod h1:vd3iFcv1DjaeV6h8tslIJh9d09RLndg8UYNSGROBrM4=
-github.com/panyam/oneauth v0.1.1 h1:8mGDH8FGetg5x0kQKVbyA59GbMufuZR7APZMokKQ8/I=
-github.com/panyam/oneauth v0.1.1/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
+github.com/panyam/oneauth v0.1.2 h1:tEH9uLTrmMbKEYw6RcPNQ2JsMGDNFP/+NmfN3xSkxB8=
+github.com/panyam/oneauth v0.1.2/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
 github.com/panyam/servicekit v0.1.1 h1:aIvVWjpIw2xBF5V4hpf7GY4RqinkY7u3OBbjQd8a1vU=
 github.com/panyam/servicekit v0.1.1/go.mod h1:kvuEgs3iJjwRyqGlKTkppwiFDpM69MPeihVi1m/B97o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/examples/events/discord/go.sum
+++ b/examples/events/discord/go.sum
@@ -84,8 +84,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.13 h1:V819IdZTEJ3rpu33ZqohC6O9ou7KOu6cxfigoYT12OQ=
 github.com/panyam/goutils v0.1.13/go.mod h1:vd3iFcv1DjaeV6h8tslIJh9d09RLndg8UYNSGROBrM4=
-github.com/panyam/oneauth v0.1.0 h1:fMa6m3UGmZChhXKQssLFNarv9nM8Ka+CZQ3tFl3SKfc=
-github.com/panyam/oneauth v0.1.0/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
+github.com/panyam/oneauth v0.1.1 h1:8mGDH8FGetg5x0kQKVbyA59GbMufuZR7APZMokKQ8/I=
+github.com/panyam/oneauth v0.1.1/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
 github.com/panyam/servicekit v0.1.1 h1:aIvVWjpIw2xBF5V4hpf7GY4RqinkY7u3OBbjQd8a1vU=
 github.com/panyam/servicekit v0.1.1/go.mod h1:kvuEgs3iJjwRyqGlKTkppwiFDpM69MPeihVi1m/B97o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/examples/events/telegram/go.mod
+++ b/examples/events/telegram/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/panyam/demokit/notebook v0.0.25 // indirect
 	github.com/panyam/gocurrent v0.1.1 // indirect
 	github.com/panyam/goutils v0.1.13 // indirect
-	github.com/panyam/oneauth v0.1.1 // indirect
+	github.com/panyam/oneauth v0.1.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect

--- a/examples/events/telegram/go.mod
+++ b/examples/events/telegram/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/panyam/demokit/notebook v0.0.25 // indirect
 	github.com/panyam/gocurrent v0.1.1 // indirect
 	github.com/panyam/goutils v0.1.13 // indirect
-	github.com/panyam/oneauth v0.1.0 // indirect
+	github.com/panyam/oneauth v0.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect

--- a/examples/events/telegram/go.sum
+++ b/examples/events/telegram/go.sum
@@ -83,8 +83,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.13 h1:V819IdZTEJ3rpu33ZqohC6O9ou7KOu6cxfigoYT12OQ=
 github.com/panyam/goutils v0.1.13/go.mod h1:vd3iFcv1DjaeV6h8tslIJh9d09RLndg8UYNSGROBrM4=
-github.com/panyam/oneauth v0.1.1 h1:8mGDH8FGetg5x0kQKVbyA59GbMufuZR7APZMokKQ8/I=
-github.com/panyam/oneauth v0.1.1/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
+github.com/panyam/oneauth v0.1.2 h1:tEH9uLTrmMbKEYw6RcPNQ2JsMGDNFP/+NmfN3xSkxB8=
+github.com/panyam/oneauth v0.1.2/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
 github.com/panyam/servicekit v0.1.1 h1:aIvVWjpIw2xBF5V4hpf7GY4RqinkY7u3OBbjQd8a1vU=
 github.com/panyam/servicekit v0.1.1/go.mod h1:kvuEgs3iJjwRyqGlKTkppwiFDpM69MPeihVi1m/B97o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/examples/events/telegram/go.sum
+++ b/examples/events/telegram/go.sum
@@ -83,8 +83,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.13 h1:V819IdZTEJ3rpu33ZqohC6O9ou7KOu6cxfigoYT12OQ=
 github.com/panyam/goutils v0.1.13/go.mod h1:vd3iFcv1DjaeV6h8tslIJh9d09RLndg8UYNSGROBrM4=
-github.com/panyam/oneauth v0.1.0 h1:fMa6m3UGmZChhXKQssLFNarv9nM8Ka+CZQ3tFl3SKfc=
-github.com/panyam/oneauth v0.1.0/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
+github.com/panyam/oneauth v0.1.1 h1:8mGDH8FGetg5x0kQKVbyA59GbMufuZR7APZMokKQ8/I=
+github.com/panyam/oneauth v0.1.1/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
 github.com/panyam/servicekit v0.1.1 h1:aIvVWjpIw2xBF5V4hpf7GY4RqinkY7u3OBbjQd8a1vU=
 github.com/panyam/servicekit v0.1.1/go.mod h1:kvuEgs3iJjwRyqGlKTkppwiFDpM69MPeihVi1m/B97o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/examples/fine-grained-auth/go.mod
+++ b/examples/fine-grained-auth/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/panyam/mcpkit v0.2.41
 	github.com/panyam/mcpkit/examples/common v0.0.0-00010101000000-000000000000
 	github.com/panyam/mcpkit/ext/auth v0.2.36
-	github.com/panyam/oneauth v0.1.0
+	github.com/panyam/oneauth v0.1.1
 	github.com/panyam/servicekit v0.1.1
 )
 

--- a/examples/fine-grained-auth/go.mod
+++ b/examples/fine-grained-auth/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/panyam/mcpkit v0.2.41
 	github.com/panyam/mcpkit/examples/common v0.0.0-00010101000000-000000000000
 	github.com/panyam/mcpkit/ext/auth v0.2.36
-	github.com/panyam/oneauth v0.1.1
+	github.com/panyam/oneauth v0.1.2
 	github.com/panyam/servicekit v0.1.1
 )
 

--- a/examples/fine-grained-auth/go.sum
+++ b/examples/fine-grained-auth/go.sum
@@ -81,8 +81,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.13 h1:V819IdZTEJ3rpu33ZqohC6O9ou7KOu6cxfigoYT12OQ=
 github.com/panyam/goutils v0.1.13/go.mod h1:vd3iFcv1DjaeV6h8tslIJh9d09RLndg8UYNSGROBrM4=
-github.com/panyam/oneauth v0.1.1 h1:8mGDH8FGetg5x0kQKVbyA59GbMufuZR7APZMokKQ8/I=
-github.com/panyam/oneauth v0.1.1/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
+github.com/panyam/oneauth v0.1.2 h1:tEH9uLTrmMbKEYw6RcPNQ2JsMGDNFP/+NmfN3xSkxB8=
+github.com/panyam/oneauth v0.1.2/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
 github.com/panyam/servicekit v0.1.1 h1:aIvVWjpIw2xBF5V4hpf7GY4RqinkY7u3OBbjQd8a1vU=
 github.com/panyam/servicekit v0.1.1/go.mod h1:kvuEgs3iJjwRyqGlKTkppwiFDpM69MPeihVi1m/B97o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/examples/fine-grained-auth/go.sum
+++ b/examples/fine-grained-auth/go.sum
@@ -81,8 +81,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.13 h1:V819IdZTEJ3rpu33ZqohC6O9ou7KOu6cxfigoYT12OQ=
 github.com/panyam/goutils v0.1.13/go.mod h1:vd3iFcv1DjaeV6h8tslIJh9d09RLndg8UYNSGROBrM4=
-github.com/panyam/oneauth v0.1.0 h1:fMa6m3UGmZChhXKQssLFNarv9nM8Ka+CZQ3tFl3SKfc=
-github.com/panyam/oneauth v0.1.0/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
+github.com/panyam/oneauth v0.1.1 h1:8mGDH8FGetg5x0kQKVbyA59GbMufuZR7APZMokKQ8/I=
+github.com/panyam/oneauth v0.1.1/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
 github.com/panyam/servicekit v0.1.1 h1:aIvVWjpIw2xBF5V4hpf7GY4RqinkY7u3OBbjQd8a1vU=
 github.com/panyam/servicekit v0.1.1/go.mod h1:kvuEgs3iJjwRyqGlKTkppwiFDpM69MPeihVi1m/B97o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/ext/auth/client_credentials.go
+++ b/ext/auth/client_credentials.go
@@ -1,0 +1,173 @@
+package auth
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/panyam/oneauth/client"
+	"github.com/panyam/oneauth/utils"
+)
+
+// ClientCredentialsTokenSource implements core.TokenSource for the OAuth 2.0
+// client_credentials grant (RFC 6749 §4.4, SEP-1046). Use when the MCP client
+// is a backend service authenticating with its own identity rather than acting
+// on behalf of a human user. The flow has no browser, no consent screen, and
+// no refresh_token: tokens are minted directly by the AS in exchange for the
+// client's credentials and refetched on expiry.
+//
+// Two client-authentication variants, selected by which field the caller sets:
+//
+//   - ClientSecret  (client_secret_basic / client_secret_post per RFC 6749 §2.3.1)
+//   - PrivateKeyPEM (private_key_jwt per RFC 7523 §2.2)
+//
+// PRM discovery, AS metadata fetch, and token caching are inherited from
+// oneauth's ClientCredentialsSource; this type adds the MCP-specific glue
+// (PRM → AS resolution, scope selection, issuer-as-audience for the JWT
+// assertion per RFC 7523bis).
+type ClientCredentialsTokenSource struct {
+	// ServerURL is the MCP server URL (used for PRM discovery).
+	ServerURL string
+
+	// ClientID identifies the client at the AS. Required.
+	ClientID string
+
+	// ClientSecret authenticates the client via HTTP Basic / form POST.
+	// Mutually exclusive with PrivateKeyPEM.
+	ClientSecret string
+
+	// PrivateKeyPEM is the PKCS#8 PEM-encoded private key used to mint
+	// the client_assertion JWT. Mutually exclusive with ClientSecret.
+	// Must match the public key the AS associates with ClientID.
+	PrivateKeyPEM string
+
+	// SigningAlgorithm is the JWS alg for the assertion (e.g. "ES256", "RS256").
+	// Required when PrivateKeyPEM is set. Must match the AS's registered
+	// signing_alg for this client.
+	SigningAlgorithm string
+
+	// KeyID, when non-empty, is emitted as the JWS `kid` header so the AS
+	// can pick the right registered key. Optional.
+	KeyID string
+
+	// Scopes to request. If empty, inherits from PRM scopes_supported.
+	Scopes []string
+
+	// HTTPClient overrides the discovery and token-request HTTP client.
+	// Useful in tests with httptest.Server.
+	HTTPClient *http.Client
+
+	// AllowInsecure permits http:// AS endpoints. Required for the
+	// conformance mock AS; production deployments should leave this false
+	// so AS HTTPS is enforced.
+	AllowInsecure bool
+
+	// ASMetadataStore caches AS metadata across discovery calls when
+	// multiple sources target the same AS.
+	ASMetadataStore client.ASMetadataStore
+
+	// OnToken fires after a successful token fetch by the underlying
+	// ClientCredentialsSource. Use to persist the credential outside the
+	// in-memory cache.
+	OnToken func(*client.ServerCredential)
+
+	mu       sync.Mutex
+	authInfo *MCPAuthInfo
+	source   *client.ClientCredentialsSource
+}
+
+// Token returns a cached access token if still valid, or fetches a fresh one
+// via the configured client_credentials variant. Implements core.TokenSource.
+func (s *ClientCredentialsTokenSource) Token() (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := s.ensureSourceLocked(); err != nil {
+		return "", err
+	}
+	return s.source.Token()
+}
+
+// TokenForScopes invalidates the cached token, merges the requested scopes
+// with the existing set, and fetches a fresh token. Implements
+// core.ScopeAwareTokenSource so the mcpkit client transport can step up
+// scope on a 403 with insufficient_scope.
+func (s *ClientCredentialsTokenSource) TokenForScopes(scopes []string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := s.ensureSourceLocked(); err != nil {
+		return "", err
+	}
+	return s.source.TokenForScopes(scopes)
+}
+
+func (s *ClientCredentialsTokenSource) ensureSourceLocked() error {
+	if s.source != nil {
+		return nil
+	}
+
+	if s.ClientID == "" {
+		return fmt.Errorf("ClientCredentialsTokenSource: ClientID is required")
+	}
+	if s.ClientSecret == "" && s.PrivateKeyPEM == "" {
+		return fmt.Errorf("ClientCredentialsTokenSource: ClientSecret or PrivateKeyPEM is required")
+	}
+	if s.ClientSecret != "" && s.PrivateKeyPEM != "" {
+		return fmt.Errorf("ClientCredentialsTokenSource: ClientSecret and PrivateKeyPEM are mutually exclusive")
+	}
+	if s.PrivateKeyPEM != "" && s.SigningAlgorithm == "" {
+		return fmt.Errorf("ClientCredentialsTokenSource: SigningAlgorithm is required with PrivateKeyPEM")
+	}
+
+	var opts []DiscoverOption
+	if s.HTTPClient != nil {
+		opts = append(opts, WithHTTPClient(s.HTTPClient))
+	}
+	if s.ASMetadataStore != nil {
+		opts = append(opts, WithASMetadataStore(s.ASMetadataStore))
+	}
+	info, err := DiscoverMCPAuth(s.ServerURL, opts...)
+	if err != nil {
+		return fmt.Errorf("MCP auth discovery: %w", err)
+	}
+	s.authInfo = info
+
+	if !s.AllowInsecure {
+		if err := client.ValidateHTTPS(info.ASMetadata); err != nil {
+			return err
+		}
+	}
+
+	scopes := s.Scopes
+	if len(scopes) == 0 {
+		scopes = info.Scopes
+	}
+
+	issuer := info.AuthorizationServers[0]
+
+	cc := &client.ClientCredentialsSource{
+		TokenEndpoint: info.ASMetadata.TokenEndpoint,
+		ClientID:      s.ClientID,
+		Scopes:        scopes,
+		OnToken:       s.OnToken,
+	}
+
+	if s.PrivateKeyPEM != "" {
+		privKey, err := utils.ParsePrivateKeyPEM([]byte(s.PrivateKeyPEM))
+		if err != nil {
+			return fmt.Errorf("parse private key: %w", err)
+		}
+		cc.ClientAssertion = &client.ClientAssertionConfig{
+			PrivateKey: privKey,
+			SigningAlg: s.SigningAlgorithm,
+			KeyID:      s.KeyID,
+			Audience:   issuer,
+		}
+	} else {
+		cc.ClientSecret = s.ClientSecret
+	}
+
+	s.source = cc
+	return nil
+}

--- a/ext/auth/client_credentials_test.go
+++ b/ext/auth/client_credentials_test.go
@@ -1,0 +1,295 @@
+package auth
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// ccMockAS simulates an MCP server + AS pair for client_credentials testing.
+// /mcp returns 401, /.well-known/* serves PRM and AS metadata, /token
+// handles the client_credentials grant. The test installs an inspector
+// function to assert on each /token request.
+type ccMockAS struct {
+	*httptest.Server
+	tokenInspector func(r *http.Request, body map[string]string) tokenResponse
+	tokenCallCount atomic.Int32
+}
+
+type tokenResponse struct {
+	statusCode  int
+	accessToken string
+	expiresIn   int
+	errorCode   string
+	errorDesc   string
+}
+
+func newCCMockAS(t *testing.T, authMethods []string) *ccMockAS {
+	t.Helper()
+	mock := &ccMockAS{}
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("WWW-Authenticate",
+			`Bearer resource_metadata="`+mock.URL+`/.well-known/oauth-protected-resource/mcp"`)
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	})
+	mux.HandleFunc("/.well-known/oauth-protected-resource/mcp", func(w http.ResponseWriter, r *http.Request) {
+		prm := ProtectedResourceMetadata{
+			Resource:             mock.URL,
+			AuthorizationServers: []string{mock.URL},
+			ScopesSupported:      []string{"mcp.tools"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(prm)
+	})
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
+		meta := map[string]any{
+			"issuer":                                mock.URL,
+			"token_endpoint":                        mock.URL + "/token",
+			"grant_types_supported":                 []string{"client_credentials"},
+			"token_endpoint_auth_methods_supported": authMethods,
+			"scopes_supported":                      []string{"mcp.tools"},
+			"code_challenge_methods_supported":      []string{"S256"},
+			"response_types_supported":              []string{"code"},
+		}
+		if slices.Contains(authMethods, "private_key_jwt") {
+			meta["token_endpoint_auth_signing_alg_values_supported"] = []string{"ES256", "RS256"}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(meta)
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		mock.tokenCallCount.Add(1)
+		_ = r.ParseForm()
+		body := map[string]string{}
+		for k := range r.PostForm {
+			body[k] = r.PostForm.Get(k)
+		}
+		resp := mock.tokenInspector(r, body)
+		w.Header().Set("Content-Type", "application/json")
+		if resp.statusCode > 0 && resp.statusCode != http.StatusOK {
+			w.WriteHeader(resp.statusCode)
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"error":             resp.errorCode,
+				"error_description": resp.errorDesc,
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": resp.accessToken,
+			"token_type":   "Bearer",
+			"expires_in":   resp.expiresIn,
+		})
+	})
+
+	mock.Server = httptest.NewServer(mux)
+	t.Cleanup(mock.Close)
+	return mock
+}
+
+// TestClientCredentialsTokenSource_BasicAuth_TokenRoundtrip exercises the
+// client_secret_basic variant end-to-end: PRM discovery, AS metadata,
+// grant_type=client_credentials + Authorization: Basic header at /token,
+// then a second Token() call returns the cached value without re-hitting
+// the AS.
+func TestClientCredentialsTokenSource_BasicAuth_TokenRoundtrip(t *testing.T) {
+	mock := newCCMockAS(t, []string{"client_secret_basic"})
+	mock.tokenInspector = func(r *http.Request, body map[string]string) tokenResponse {
+		if got, want := body["grant_type"], "client_credentials"; got != want {
+			t.Errorf("grant_type = %q, want %q", got, want)
+		}
+		authHeader := r.Header.Get("Authorization")
+		if !strings.HasPrefix(authHeader, "Basic ") {
+			t.Errorf("Authorization header = %q, want Basic prefix", authHeader)
+			return tokenResponse{statusCode: 401, errorCode: "invalid_client"}
+		}
+		decoded, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(authHeader, "Basic "))
+		if err != nil {
+			t.Errorf("decode basic auth: %v", err)
+			return tokenResponse{statusCode: 401}
+		}
+		if got, want := string(decoded), "my-client:my-secret"; got != want {
+			t.Errorf("basic creds = %q, want %q", got, want)
+		}
+		return tokenResponse{accessToken: "cc-token-basic", expiresIn: 3600}
+	}
+
+	ts := &ClientCredentialsTokenSource{
+		ServerURL:     mock.URL + "/mcp",
+		ClientID:      "my-client",
+		ClientSecret:  "my-secret",
+		HTTPClient:    mock.Client(),
+		AllowInsecure: true,
+	}
+	tok, err := ts.Token()
+	if err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	if tok != "cc-token-basic" {
+		t.Errorf("Token() = %q, want cc-token-basic", tok)
+	}
+	if mock.tokenCallCount.Load() != 1 {
+		t.Errorf("/token call count = %d, want 1", mock.tokenCallCount.Load())
+	}
+
+	tok2, err := ts.Token()
+	if err != nil {
+		t.Fatalf("Token (cached): %v", err)
+	}
+	if tok2 != tok {
+		t.Errorf("cached Token() = %q, want %q", tok2, tok)
+	}
+	if mock.tokenCallCount.Load() != 1 {
+		t.Errorf("/token call count after cache hit = %d, want 1", mock.tokenCallCount.Load())
+	}
+}
+
+// TestClientCredentialsTokenSource_JWT_TokenRoundtrip exercises the
+// private_key_jwt variant: the AS verifies client_assertion_type,
+// the JWT signature, iss/sub=client_id, and that aud equals the AS
+// issuer URL (not the token endpoint) per RFC 7523bis / SEP-1046.
+func TestClientCredentialsTokenSource_JWT_TokenRoundtrip(t *testing.T) {
+	privKey, privPEM := mustGenerateES256Keypair(t)
+
+	mock := newCCMockAS(t, []string{"private_key_jwt"})
+	mock.tokenInspector = func(r *http.Request, body map[string]string) tokenResponse {
+		if got, want := body["grant_type"], "client_credentials"; got != want {
+			t.Errorf("grant_type = %q, want %q", got, want)
+		}
+		if got, want := body["client_assertion_type"], "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"; got != want {
+			t.Errorf("client_assertion_type = %q, want %q", got, want)
+		}
+		assertion := body["client_assertion"]
+		if assertion == "" {
+			t.Error("client_assertion missing")
+			return tokenResponse{statusCode: 401, errorCode: "invalid_client"}
+		}
+		tok, err := jwt.Parse(assertion, func(t *jwt.Token) (any, error) {
+			return &privKey.PublicKey, nil
+		}, jwt.WithValidMethods([]string{"ES256"}))
+		if err != nil {
+			t.Errorf("verify assertion: %v", err)
+			return tokenResponse{statusCode: 401, errorCode: "invalid_client"}
+		}
+		claims := tok.Claims.(jwt.MapClaims)
+		if got, want := claims["iss"], "my-client"; got != want {
+			t.Errorf("iss = %v, want %v", got, want)
+		}
+		if got, want := claims["sub"], "my-client"; got != want {
+			t.Errorf("sub = %v, want %v", got, want)
+		}
+		if got, want := claims["aud"], mock.URL; got != want {
+			t.Errorf("aud = %v, want %v (issuer URL, not token endpoint)", got, want)
+		}
+		return tokenResponse{accessToken: "cc-token-jwt", expiresIn: 3600}
+	}
+
+	ts := &ClientCredentialsTokenSource{
+		ServerURL:        mock.URL + "/mcp",
+		ClientID:         "my-client",
+		PrivateKeyPEM:    privPEM,
+		SigningAlgorithm: "ES256",
+		HTTPClient:       mock.Client(),
+		AllowInsecure:    true,
+	}
+	tok, err := ts.Token()
+	if err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	if tok != "cc-token-jwt" {
+		t.Errorf("Token() = %q, want cc-token-jwt", tok)
+	}
+}
+
+func TestClientCredentialsTokenSource_ValidationErrors(t *testing.T) {
+	mock := newCCMockAS(t, []string{"client_secret_basic"})
+
+	cases := []struct {
+		name    string
+		ts      ClientCredentialsTokenSource
+		wantMsg string
+	}{
+		{
+			name:    "missing ClientID",
+			ts:      ClientCredentialsTokenSource{ServerURL: mock.URL + "/mcp", ClientSecret: "x"},
+			wantMsg: "ClientID is required",
+		},
+		{
+			name:    "missing credentials",
+			ts:      ClientCredentialsTokenSource{ServerURL: mock.URL + "/mcp", ClientID: "c"},
+			wantMsg: "ClientSecret or PrivateKeyPEM is required",
+		},
+		{
+			name:    "both credentials set",
+			ts:      ClientCredentialsTokenSource{ServerURL: mock.URL + "/mcp", ClientID: "c", ClientSecret: "x", PrivateKeyPEM: "y"},
+			wantMsg: "mutually exclusive",
+		},
+		{
+			name:    "JWT missing SigningAlgorithm",
+			ts:      ClientCredentialsTokenSource{ServerURL: mock.URL + "/mcp", ClientID: "c", PrivateKeyPEM: "y"},
+			wantMsg: "SigningAlgorithm is required",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.ts.HTTPClient = mock.Client()
+			tc.ts.AllowInsecure = true
+			_, err := tc.ts.Token()
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.wantMsg) {
+				t.Errorf("error = %q, want substring %q", err, tc.wantMsg)
+			}
+		})
+	}
+}
+
+func TestClientCredentialsTokenSource_InvalidPEM(t *testing.T) {
+	mock := newCCMockAS(t, []string{"private_key_jwt"})
+	ts := &ClientCredentialsTokenSource{
+		ServerURL:        mock.URL + "/mcp",
+		ClientID:         "c",
+		PrivateKeyPEM:    "not a pem",
+		SigningAlgorithm: "ES256",
+		HTTPClient:       mock.Client(),
+		AllowInsecure:    true,
+	}
+	_, err := ts.Token()
+	if err == nil {
+		t.Fatal("expected PEM parse error")
+	}
+	if !strings.Contains(err.Error(), "parse private key") {
+		t.Errorf("error = %q, want parse private key", err)
+	}
+}
+
+func mustGenerateES256Keypair(t *testing.T) (*ecdsa.PrivateKey, string) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate ES256 key: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatalf("marshal PKCS8: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+	if pemBytes == nil {
+		t.Fatal("nil PEM bytes")
+	}
+	return priv, string(pemBytes)
+}

--- a/ext/auth/docs/DESIGN.md
+++ b/ext/auth/docs/DESIGN.md
@@ -288,7 +288,7 @@ type AuthError struct {
 |------|-----------|----------------|
 | `JWTValidator` | `AuthValidator` + `ClaimsProvider` | `jwt.Parse` with JWKS keyfunc (`JWKSKeyStore.GetKeyByKid`) |
 | `OAuthTokenSource` | `TokenSource` | `client.LoginWithBrowser` + `client.DiscoverAS` |
-| `ClientCredentialsSource` | `TokenSource` | `client.ClientCredentialsToken` |
+| `ClientCredentialsTokenSource` | `TokenSource` + `ScopeAwareTokenSource` | `client.ClientCredentialsSource` (basic and `private_key_jwt` per SEP-1046) |
 | `AuthExtension` | `ExtensionProvider` | (none — declares MCP auth extension metadata) |
 
 ## Server Usage

--- a/ext/auth/go.mod
+++ b/ext/auth/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/panyam/gocurrent v0.1.1
 	github.com/panyam/mcpkit v0.2.3
-	github.com/panyam/oneauth v0.1.1
+	github.com/panyam/oneauth v0.1.2
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/ext/auth/go.mod
+++ b/ext/auth/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/panyam/gocurrent v0.1.1
 	github.com/panyam/mcpkit v0.2.3
-	github.com/panyam/oneauth v0.1.0
+	github.com/panyam/oneauth v0.1.1
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/ext/auth/go.sum
+++ b/ext/auth/go.sum
@@ -32,8 +32,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.8 h1:5UscYTP892k54+Nyb01tKGGwZxczZ5k7BC+c0nXmcoc=
 github.com/panyam/goutils v0.1.8/go.mod h1:ntucs8GJOHQ0LmlRGRjeup3aDC2t7xPMudrRwUHrJNM=
-github.com/panyam/oneauth v0.1.1 h1:8mGDH8FGetg5x0kQKVbyA59GbMufuZR7APZMokKQ8/I=
-github.com/panyam/oneauth v0.1.1/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
+github.com/panyam/oneauth v0.1.2 h1:tEH9uLTrmMbKEYw6RcPNQ2JsMGDNFP/+NmfN3xSkxB8=
+github.com/panyam/oneauth v0.1.2/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
 github.com/panyam/servicekit v0.0.25 h1:JeTRyz5ZZY3beENg0N3tLW+O39/foTuHMPAf+rpwYhM=
 github.com/panyam/servicekit v0.0.25/go.mod h1:9TkF2LRqiPC9bgu0bYVdky7rnHEuBvzGzrsoL++Ra5c=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/ext/auth/go.sum
+++ b/ext/auth/go.sum
@@ -32,8 +32,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.8 h1:5UscYTP892k54+Nyb01tKGGwZxczZ5k7BC+c0nXmcoc=
 github.com/panyam/goutils v0.1.8/go.mod h1:ntucs8GJOHQ0LmlRGRjeup3aDC2t7xPMudrRwUHrJNM=
-github.com/panyam/oneauth v0.1.0 h1:fMa6m3UGmZChhXKQssLFNarv9nM8Ka+CZQ3tFl3SKfc=
-github.com/panyam/oneauth v0.1.0/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
+github.com/panyam/oneauth v0.1.1 h1:8mGDH8FGetg5x0kQKVbyA59GbMufuZR7APZMokKQ8/I=
+github.com/panyam/oneauth v0.1.1/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
 github.com/panyam/servicekit v0.0.25 h1:JeTRyz5ZZY3beENg0N3tLW+O39/foTuHMPAf+rpwYhM=
 github.com/panyam/servicekit v0.0.25/go.mod h1:9TkF2LRqiPC9bgu0bYVdky7rnHEuBvzGzrsoL++Ra5c=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/panyam/mcpkit v0.2.3
 	github.com/panyam/mcpkit/ext/auth v0.0.0
 	github.com/panyam/mcpkit/ext/ui v0.0.0
-	github.com/panyam/oneauth v0.1.1
+	github.com/panyam/oneauth v0.1.2
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/panyam/mcpkit v0.2.3
 	github.com/panyam/mcpkit/ext/auth v0.0.0
 	github.com/panyam/mcpkit/ext/ui v0.0.0
-	github.com/panyam/oneauth v0.1.0
+	github.com/panyam/oneauth v0.1.1
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/tests/e2e/go.sum
+++ b/tests/e2e/go.sum
@@ -33,8 +33,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.8 h1:5UscYTP892k54+Nyb01tKGGwZxczZ5k7BC+c0nXmcoc=
 github.com/panyam/goutils v0.1.8/go.mod h1:ntucs8GJOHQ0LmlRGRjeup3aDC2t7xPMudrRwUHrJNM=
-github.com/panyam/oneauth v0.1.0 h1:fMa6m3UGmZChhXKQssLFNarv9nM8Ka+CZQ3tFl3SKfc=
-github.com/panyam/oneauth v0.1.0/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
+github.com/panyam/oneauth v0.1.1 h1:8mGDH8FGetg5x0kQKVbyA59GbMufuZR7APZMokKQ8/I=
+github.com/panyam/oneauth v0.1.1/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
 github.com/panyam/servicekit v0.0.25 h1:JeTRyz5ZZY3beENg0N3tLW+O39/foTuHMPAf+rpwYhM=
 github.com/panyam/servicekit v0.0.25/go.mod h1:9TkF2LRqiPC9bgu0bYVdky7rnHEuBvzGzrsoL++Ra5c=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/tests/e2e/go.sum
+++ b/tests/e2e/go.sum
@@ -33,8 +33,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.8 h1:5UscYTP892k54+Nyb01tKGGwZxczZ5k7BC+c0nXmcoc=
 github.com/panyam/goutils v0.1.8/go.mod h1:ntucs8GJOHQ0LmlRGRjeup3aDC2t7xPMudrRwUHrJNM=
-github.com/panyam/oneauth v0.1.1 h1:8mGDH8FGetg5x0kQKVbyA59GbMufuZR7APZMokKQ8/I=
-github.com/panyam/oneauth v0.1.1/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
+github.com/panyam/oneauth v0.1.2 h1:tEH9uLTrmMbKEYw6RcPNQ2JsMGDNFP/+NmfN3xSkxB8=
+github.com/panyam/oneauth v0.1.2/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
 github.com/panyam/servicekit v0.0.25 h1:JeTRyz5ZZY3beENg0N3tLW+O39/foTuHMPAf+rpwYhM=
 github.com/panyam/servicekit v0.0.25/go.mod h1:9TkF2LRqiPC9bgu0bYVdky7rnHEuBvzGzrsoL++Ra5c=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/tests/keycloak/go.mod
+++ b/tests/keycloak/go.mod
@@ -5,7 +5,7 @@ go 1.26.3
 require (
 	github.com/panyam/mcpkit v0.2.3
 	github.com/panyam/mcpkit/ext/auth v0.0.0
-	github.com/panyam/oneauth v0.1.1
+	github.com/panyam/oneauth v0.1.2
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/tests/keycloak/go.mod
+++ b/tests/keycloak/go.mod
@@ -5,7 +5,7 @@ go 1.26.3
 require (
 	github.com/panyam/mcpkit v0.2.3
 	github.com/panyam/mcpkit/ext/auth v0.0.0
-	github.com/panyam/oneauth v0.1.0
+	github.com/panyam/oneauth v0.1.1
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/tests/keycloak/go.sum
+++ b/tests/keycloak/go.sum
@@ -33,8 +33,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.8 h1:5UscYTP892k54+Nyb01tKGGwZxczZ5k7BC+c0nXmcoc=
 github.com/panyam/goutils v0.1.8/go.mod h1:ntucs8GJOHQ0LmlRGRjeup3aDC2t7xPMudrRwUHrJNM=
-github.com/panyam/oneauth v0.1.0 h1:fMa6m3UGmZChhXKQssLFNarv9nM8Ka+CZQ3tFl3SKfc=
-github.com/panyam/oneauth v0.1.0/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
+github.com/panyam/oneauth v0.1.1 h1:8mGDH8FGetg5x0kQKVbyA59GbMufuZR7APZMokKQ8/I=
+github.com/panyam/oneauth v0.1.1/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
 github.com/panyam/servicekit v0.0.25 h1:JeTRyz5ZZY3beENg0N3tLW+O39/foTuHMPAf+rpwYhM=
 github.com/panyam/servicekit v0.0.25/go.mod h1:9TkF2LRqiPC9bgu0bYVdky7rnHEuBvzGzrsoL++Ra5c=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/tests/keycloak/go.sum
+++ b/tests/keycloak/go.sum
@@ -33,8 +33,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.8 h1:5UscYTP892k54+Nyb01tKGGwZxczZ5k7BC+c0nXmcoc=
 github.com/panyam/goutils v0.1.8/go.mod h1:ntucs8GJOHQ0LmlRGRjeup3aDC2t7xPMudrRwUHrJNM=
-github.com/panyam/oneauth v0.1.1 h1:8mGDH8FGetg5x0kQKVbyA59GbMufuZR7APZMokKQ8/I=
-github.com/panyam/oneauth v0.1.1/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
+github.com/panyam/oneauth v0.1.2 h1:tEH9uLTrmMbKEYw6RcPNQ2JsMGDNFP/+NmfN3xSkxB8=
+github.com/panyam/oneauth v0.1.2/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
 github.com/panyam/servicekit v0.0.25 h1:JeTRyz5ZZY3beENg0N3tLW+O39/foTuHMPAf+rpwYhM=
 github.com/panyam/servicekit v0.0.25/go.mod h1:9TkF2LRqiPC9bgu0bYVdky7rnHEuBvzGzrsoL++Ra5c=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
## What changes

Adds `ext/auth.ClientCredentialsTokenSource` as a `core.TokenSource` implementation for OAuth 2.0 machine-to-machine flows (SEP-1046). Two client-authentication variants are exposed: `ClientSecret` (HTTP Basic, RFC 6749 §4.4) and `PrivateKeyPEM` + `SigningAlgorithm` (`private_key_jwt`, RFC 7523 §2.2). The underlying token caching, `OnToken` hook, and proactive refresher come from oneauth's `ClientCredentialsSource` via the v0.1.1 `ClientAssertion` field — this PR is the consumer half of [panyam/oneauth#211](https://github.com/panyam/oneauth/issues/211). Bumps oneauth to v0.1.2 in lock-step (RFC 8707 / RFC 9396 plumbing added there is not exercised here yet).

The JWT assertion's `aud` claim is set to the AS issuer URL (not the token endpoint) per RFC 7523bis, using oneauth's `ClientAssertionConfig.Audience` field. The upstream conformance fixture verifies `aud` against `authBaseUrl`, and oneauth was previously hardcoded to the token endpoint URL — that mismatch is what made this PR a two-step pushdown.

`cmd/testclient` grows a discovery probe to pick between `OAuthTokenSource` and the new `ClientCredentialsTokenSource`. AS metadata `grant_types_supported` drives the decision; `PrivateKeyPEM` in `MCP_CONFORMANCE_CONTEXT` additionally pins to the JWT variant. The probe is gated on `ctx.ClientID != ""` so DCR scenarios stay on the OAuthTokenSource fast path. All other auth scenarios continue through the `authorization_code` path unchanged.

Both upstream SEP-1046 client conformance scenarios flip from `partial (8p/2f/12i)` to `pass (10p/26i)` (basic) and `pass (8p/20i)` (jwt). Server surface unchanged; client surface gains +6 pass / -4 fail in `conformance/UPSTREAM_AUDIT.md`. Harness-gap count unchanged at 1 (the same `request-metadata` scenario lacking a driver).

## Reviewer's guide

Read in this order:

1. [ext/auth/client_credentials.go](https://github.com/panyam/mcpkit/pull/469/files#diff-c24f6edc66944bad16c70b808c05bf9652eeafe7d0a07490610fefa0f02d2777) — start here. New file. `ClientCredentialsTokenSource` struct (basic + JWT branches), `ensureSourceLocked` does validation + MCP discovery + builds the underlying oneauth source with the right audience. ~170 lines.
2. [ext/auth/client_credentials_test.go](https://github.com/panyam/mcpkit/pull/469/files#diff-4ed44f1994c58c7bc7fbbf0c78af584987db87c5360479e246fcd79ec1dd175b) — acceptance for the above. Mock AS at httptest.Server, exercises basic + JWT round trips end-to-end, asserts wire shape (grant_type, Basic header, client_assertion_type, JWT iss/sub/aud claims), plus caching and validation errors. Reference-impl behavior matches upstream `client-credentials.ts` fixture.
3. [cmd/testclient/main.go](https://github.com/panyam/mcpkit/pull/469/files#diff-bc7a02b2751e1c671ee37f491a72c42030bf2566f6d0496f30ae2a0ab19ffaae) — `pickTokenSource` helper does the gated discovery probe. `conformanceContext` gains `PrivateKeyPEM` and `SigningAlgorithm` fields. Existing OAuthTokenSource path preserved verbatim for non-SEP-1046 scenarios.
4. [ext/auth/docs/DESIGN.md](https://github.com/panyam/mcpkit/pull/469/files#diff-03a5078f128c638aca27e780bfd0c762d7a6122a8867f7df0c519ffb23c54698) — one-line update to the implementations table.
5. [conformance/UPSTREAM_AUDIT.md](https://github.com/panyam/mcpkit/pull/469/files#diff-bf63f1699e28f43c702f9450df02d9e8ec1dae36200827f929a68513bdb34197) — regenerated snapshot. Both `client-credentials-*` rows flip to `pass`.

Skim or skip: the `go.mod`/`go.sum` churn across submodules is mechanical (oneauth `v0.1.0` → `v0.1.2` bump in lock-step). No code consumes the v0.1.2 additions yet.

## Decision log

- **Pushdown to oneauth first.** Initial plan was to build the form-POST and JWT minting inside mcpkit. Pushed back to oneauth as panyam/oneauth#211: caller-controllable assertion audience (RFC 7523bis) and JWT support inside `ClientCredentialsSource` (so caching parity with the secret-based path). Consumer here is now thin glue (PRM/AS discovery, MCP-specific scope selection, basic-or-JWT branch) rather than reimplementing RFC 6749 §4.4 mechanics.
- **AS issuer URL as JWT `aud`, not token endpoint.** Conformance fixture verifies `audience: [authBaseUrl, authBaseUrl + '/']` (the AS origin), per RFC 7523bis. oneauth's `ClientAssertionConfig.Audience` field overrides the default token-endpoint audience.
- **Discovery-driven TokenSource selection in testclient.** Auth-code pre-registration scenarios also set `{client_id, client_secret}` in their context, so client-credentials-basic can't be distinguished by context shape alone. The AS's `grant_types_supported` is the deciding signal. Gated on `ctx.ClientID != ""` so DCR scenarios skip the probe entirely.
- **`AllowInsecure: true` on the testclient TokenSource.** Conformance mock AS uses HTTP. Production users leave the default `false` so HTTPS is enforced.
- **PKCS#8 PEM only.** `utils.ParsePrivateKeyPEM` accepts PKCS#8; PKCS#1 and SEC1 would need a defensive parser. Upstream scenario generates PKCS#8 (jose `exportPKCS8`), and PKCS#8 is the modern recommendation. PKCS#1 callers can convert with `openssl pkcs8 -topk8`. Worth a follow-up if real users complain.
- **No `Resources` (RFC 8707) wired through yet.** oneauth v0.1.2 grew the field back, but the conformance scenarios don't verify it. Add later if a real consumer needs it.

## Risk / blast radius

- **No regression on existing flows.** `OAuthTokenSource` unchanged. testclient's auth-code path preserved verbatim for all scenarios that don't trigger client_credentials detection.
- **Behavior change for testclient under client_credentials scenarios.** Previously: testclient ran auth_code, mock AS rejected with `unsupported_grant_type`. Now: testclient runs client_credentials, mock AS accepts. With the gated probe, the discovery cost is paid only for scenarios with a pre-registered client_id — no extra HTTP for DCR scenarios.
- **PEM parse errors surface at first `Token()` call, not source construction.** Validation runs lazily inside `ensureSourceLocked`. Acceptable since `Token()` is the first thing the client calls; the error reaches the caller before any MCP request goes out.
- **Be paranoid about:** the `client.ClientCredentialsSource` cache contract. We rely on it returning the same access token until `expires_in` elapses. Verified by `TestClientCredentialsTokenSource_BasicAuth_TokenRoundtrip` (second `Token()` does not increment the AS call count).

## Before / after

```
Before: | `auth/client-credentials-basic` | client | partial | 8 pass / 2 fail / 12 info | (empty)
        | `auth/client-credentials-jwt`   | client | partial | 8 pass / 2 fail / 12 info | (empty)
After:  | `auth/client-credentials-basic` | client | pass    | 10 pass / 26 info         | (empty)
        | `auth/client-credentials-jwt`   | client | pass    | 8 pass / 20 info          | (empty)
```

Specific SEP-1046 checks that flip from FAILURE to SUCCESS:
- `client-credentials-grant-type` (both scenarios)
- `client-credentials-basic-auth` (basic): "Client successfully authenticated with client_secret_basic"
- `client-credentials-jwt-verified` (jwt): "Client successfully authenticated with signed JWT assertion"

Client surface delta:
```
Before: | Client | 40 | 1206 | 442 pass | 31 fail | 4 partial | 723 info | 6 skipped | 1 harness-gap |
After:  | Client | 40 | 1242 | 448 pass | 27 fail | 4 partial | 757 info | 6 skipped | 1 harness-gap |
```

(The +34 info checks are the two client_credentials scenarios now firing wire-level INFO events end-to-end. Harness-gap is unchanged.)

## Out of scope (deferred)

- **PKCS#1 / SEC1 PEM support** — wait for a user complaint. `openssl pkcs8 -topk8` is a one-line workaround.
- **RFC 8707 `Resources` and RFC 9396 `AuthorizationDetails` on the new TokenSource** — supported by oneauth v0.1.2, not surfaced here. Add when a real consumer needs them.
- **Client-credentials token refresh via ProactiveRefresher** — supported by oneauth but not exposed on `ClientCredentialsTokenSource` yet (no real user need; conformance grades a single fetch).

## Related work

- panyam/oneauth#211 / oneauth PR 212 — pushdown work this PR consumes. Tagged as v0.1.1, then v0.1.2 added RFC 8707 / RFC 9396 plumbing.
- Umbrella issue 439 — Tier 2 queue (item 5, last).
