### PR TITLE
chore: bump oneauth to v0.1.4 across all sub-modules

### DIFF
--- a/cmd/testclient/go.mod
+++ b/cmd/testclient/go.mod
@@ -5,7 +5,7 @@ go 1.26.3
 require (
 	github.com/panyam/mcpkit v0.2.3
 	github.com/panyam/mcpkit/ext/auth v0.0.0
-	github.com/panyam/oneauth v0.1.2
+	github.com/panyam/oneauth v0.1.4
 )
 
 require (

--- a/cmd/testclient/go.sum
+++ b/cmd/testclient/go.sum
@@ -31,8 +31,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.8 h1:5UscYTP892k54+Nyb01tKGGwZxczZ5k7BC+c0nXmcoc=
 github.com/panyam/goutils v0.1.8/go.mod h1:ntucs8GJOHQ0LmlRGRjeup3aDC2t7xPMudrRwUHrJNM=
-github.com/panyam/oneauth v0.1.2 h1:tEH9uLTrmMbKEYw6RcPNQ2JsMGDNFP/+NmfN3xSkxB8=
-github.com/panyam/oneauth v0.1.2/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
+github.com/panyam/oneauth v0.1.4 h1:ypHq1SkdXSHWQFlyl8gZCDUub0TWL/EPqR8IlAlJjLQ=
+github.com/panyam/oneauth v0.1.4/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
 github.com/panyam/servicekit v0.0.25 h1:JeTRyz5ZZY3beENg0N3tLW+O39/foTuHMPAf+rpwYhM=
 github.com/panyam/servicekit v0.0.25/go.mod h1:9TkF2LRqiPC9bgu0bYVdky7rnHEuBvzGzrsoL++Ra5c=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/examples/auth/go.mod
+++ b/examples/auth/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/panyam/mcpkit v0.2.41
 	github.com/panyam/mcpkit/examples/common v0.0.0-00010101000000-000000000000
 	github.com/panyam/mcpkit/ext/auth v0.2.36
-	github.com/panyam/oneauth v0.1.2
+	github.com/panyam/oneauth v0.1.4
 )
 
 require (

--- a/examples/auth/go.sum
+++ b/examples/auth/go.sum
@@ -83,8 +83,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.13 h1:V819IdZTEJ3rpu33ZqohC6O9ou7KOu6cxfigoYT12OQ=
 github.com/panyam/goutils v0.1.13/go.mod h1:vd3iFcv1DjaeV6h8tslIJh9d09RLndg8UYNSGROBrM4=
-github.com/panyam/oneauth v0.1.2 h1:tEH9uLTrmMbKEYw6RcPNQ2JsMGDNFP/+NmfN3xSkxB8=
-github.com/panyam/oneauth v0.1.2/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
+github.com/panyam/oneauth v0.1.4 h1:ypHq1SkdXSHWQFlyl8gZCDUub0TWL/EPqR8IlAlJjLQ=
+github.com/panyam/oneauth v0.1.4/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
 github.com/panyam/servicekit v0.1.1 h1:aIvVWjpIw2xBF5V4hpf7GY4RqinkY7u3OBbjQd8a1vU=
 github.com/panyam/servicekit v0.1.1/go.mod h1:kvuEgs3iJjwRyqGlKTkppwiFDpM69MPeihVi1m/B97o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/examples/events/discord/go.mod
+++ b/examples/events/discord/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/panyam/demokit/notebook v0.0.25 // indirect
 	github.com/panyam/gocurrent v0.1.1 // indirect
 	github.com/panyam/goutils v0.1.13 // indirect
-	github.com/panyam/oneauth v0.1.2 // indirect
+	github.com/panyam/oneauth v0.1.4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect

--- a/examples/events/discord/go.sum
+++ b/examples/events/discord/go.sum
@@ -84,8 +84,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.13 h1:V819IdZTEJ3rpu33ZqohC6O9ou7KOu6cxfigoYT12OQ=
 github.com/panyam/goutils v0.1.13/go.mod h1:vd3iFcv1DjaeV6h8tslIJh9d09RLndg8UYNSGROBrM4=
-github.com/panyam/oneauth v0.1.2 h1:tEH9uLTrmMbKEYw6RcPNQ2JsMGDNFP/+NmfN3xSkxB8=
-github.com/panyam/oneauth v0.1.2/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
+github.com/panyam/oneauth v0.1.4 h1:ypHq1SkdXSHWQFlyl8gZCDUub0TWL/EPqR8IlAlJjLQ=
+github.com/panyam/oneauth v0.1.4/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
 github.com/panyam/servicekit v0.1.1 h1:aIvVWjpIw2xBF5V4hpf7GY4RqinkY7u3OBbjQd8a1vU=
 github.com/panyam/servicekit v0.1.1/go.mod h1:kvuEgs3iJjwRyqGlKTkppwiFDpM69MPeihVi1m/B97o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/examples/events/telegram/go.mod
+++ b/examples/events/telegram/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/panyam/demokit/notebook v0.0.25 // indirect
 	github.com/panyam/gocurrent v0.1.1 // indirect
 	github.com/panyam/goutils v0.1.13 // indirect
-	github.com/panyam/oneauth v0.1.2 // indirect
+	github.com/panyam/oneauth v0.1.4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect

--- a/examples/events/telegram/go.sum
+++ b/examples/events/telegram/go.sum
@@ -83,8 +83,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.13 h1:V819IdZTEJ3rpu33ZqohC6O9ou7KOu6cxfigoYT12OQ=
 github.com/panyam/goutils v0.1.13/go.mod h1:vd3iFcv1DjaeV6h8tslIJh9d09RLndg8UYNSGROBrM4=
-github.com/panyam/oneauth v0.1.2 h1:tEH9uLTrmMbKEYw6RcPNQ2JsMGDNFP/+NmfN3xSkxB8=
-github.com/panyam/oneauth v0.1.2/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
+github.com/panyam/oneauth v0.1.4 h1:ypHq1SkdXSHWQFlyl8gZCDUub0TWL/EPqR8IlAlJjLQ=
+github.com/panyam/oneauth v0.1.4/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
 github.com/panyam/servicekit v0.1.1 h1:aIvVWjpIw2xBF5V4hpf7GY4RqinkY7u3OBbjQd8a1vU=
 github.com/panyam/servicekit v0.1.1/go.mod h1:kvuEgs3iJjwRyqGlKTkppwiFDpM69MPeihVi1m/B97o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/examples/fine-grained-auth/go.mod
+++ b/examples/fine-grained-auth/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/panyam/mcpkit v0.2.41
 	github.com/panyam/mcpkit/examples/common v0.0.0-00010101000000-000000000000
 	github.com/panyam/mcpkit/ext/auth v0.2.36
-	github.com/panyam/oneauth v0.1.2
+	github.com/panyam/oneauth v0.1.4
 	github.com/panyam/servicekit v0.1.1
 )
 

--- a/examples/fine-grained-auth/go.sum
+++ b/examples/fine-grained-auth/go.sum
@@ -81,8 +81,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.13 h1:V819IdZTEJ3rpu33ZqohC6O9ou7KOu6cxfigoYT12OQ=
 github.com/panyam/goutils v0.1.13/go.mod h1:vd3iFcv1DjaeV6h8tslIJh9d09RLndg8UYNSGROBrM4=
-github.com/panyam/oneauth v0.1.2 h1:tEH9uLTrmMbKEYw6RcPNQ2JsMGDNFP/+NmfN3xSkxB8=
-github.com/panyam/oneauth v0.1.2/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
+github.com/panyam/oneauth v0.1.4 h1:ypHq1SkdXSHWQFlyl8gZCDUub0TWL/EPqR8IlAlJjLQ=
+github.com/panyam/oneauth v0.1.4/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
 github.com/panyam/servicekit v0.1.1 h1:aIvVWjpIw2xBF5V4hpf7GY4RqinkY7u3OBbjQd8a1vU=
 github.com/panyam/servicekit v0.1.1/go.mod h1:kvuEgs3iJjwRyqGlKTkppwiFDpM69MPeihVi1m/B97o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/ext/auth/go.mod
+++ b/ext/auth/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/panyam/gocurrent v0.1.1
 	github.com/panyam/mcpkit v0.2.3
-	github.com/panyam/oneauth v0.1.2
+	github.com/panyam/oneauth v0.1.4
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/ext/auth/go.sum
+++ b/ext/auth/go.sum
@@ -32,8 +32,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.8 h1:5UscYTP892k54+Nyb01tKGGwZxczZ5k7BC+c0nXmcoc=
 github.com/panyam/goutils v0.1.8/go.mod h1:ntucs8GJOHQ0LmlRGRjeup3aDC2t7xPMudrRwUHrJNM=
-github.com/panyam/oneauth v0.1.2 h1:tEH9uLTrmMbKEYw6RcPNQ2JsMGDNFP/+NmfN3xSkxB8=
-github.com/panyam/oneauth v0.1.2/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
+github.com/panyam/oneauth v0.1.4 h1:ypHq1SkdXSHWQFlyl8gZCDUub0TWL/EPqR8IlAlJjLQ=
+github.com/panyam/oneauth v0.1.4/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
 github.com/panyam/servicekit v0.0.25 h1:JeTRyz5ZZY3beENg0N3tLW+O39/foTuHMPAf+rpwYhM=
 github.com/panyam/servicekit v0.0.25/go.mod h1:9TkF2LRqiPC9bgu0bYVdky7rnHEuBvzGzrsoL++Ra5c=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/panyam/mcpkit v0.2.3
 	github.com/panyam/mcpkit/ext/auth v0.0.0
 	github.com/panyam/mcpkit/ext/ui v0.0.0
-	github.com/panyam/oneauth v0.1.2
+	github.com/panyam/oneauth v0.1.4
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/tests/e2e/go.sum
+++ b/tests/e2e/go.sum
@@ -33,8 +33,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.8 h1:5UscYTP892k54+Nyb01tKGGwZxczZ5k7BC+c0nXmcoc=
 github.com/panyam/goutils v0.1.8/go.mod h1:ntucs8GJOHQ0LmlRGRjeup3aDC2t7xPMudrRwUHrJNM=
-github.com/panyam/oneauth v0.1.2 h1:tEH9uLTrmMbKEYw6RcPNQ2JsMGDNFP/+NmfN3xSkxB8=
-github.com/panyam/oneauth v0.1.2/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
+github.com/panyam/oneauth v0.1.4 h1:ypHq1SkdXSHWQFlyl8gZCDUub0TWL/EPqR8IlAlJjLQ=
+github.com/panyam/oneauth v0.1.4/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
 github.com/panyam/servicekit v0.0.25 h1:JeTRyz5ZZY3beENg0N3tLW+O39/foTuHMPAf+rpwYhM=
 github.com/panyam/servicekit v0.0.25/go.mod h1:9TkF2LRqiPC9bgu0bYVdky7rnHEuBvzGzrsoL++Ra5c=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/tests/keycloak/go.mod
+++ b/tests/keycloak/go.mod
@@ -5,7 +5,7 @@ go 1.26.3
 require (
 	github.com/panyam/mcpkit v0.2.3
 	github.com/panyam/mcpkit/ext/auth v0.0.0
-	github.com/panyam/oneauth v0.1.2
+	github.com/panyam/oneauth v0.1.4
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/tests/keycloak/go.sum
+++ b/tests/keycloak/go.sum
@@ -33,8 +33,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.8 h1:5UscYTP892k54+Nyb01tKGGwZxczZ5k7BC+c0nXmcoc=
 github.com/panyam/goutils v0.1.8/go.mod h1:ntucs8GJOHQ0LmlRGRjeup3aDC2t7xPMudrRwUHrJNM=
-github.com/panyam/oneauth v0.1.2 h1:tEH9uLTrmMbKEYw6RcPNQ2JsMGDNFP/+NmfN3xSkxB8=
-github.com/panyam/oneauth v0.1.2/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
+github.com/panyam/oneauth v0.1.4 h1:ypHq1SkdXSHWQFlyl8gZCDUub0TWL/EPqR8IlAlJjLQ=
+github.com/panyam/oneauth v0.1.4/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
 github.com/panyam/servicekit v0.0.25 h1:JeTRyz5ZZY3beENg0N3tLW+O39/foTuHMPAf+rpwYhM=
 github.com/panyam/servicekit v0.0.25/go.mod h1:9TkF2LRqiPC9bgu0bYVdky7rnHEuBvzGzrsoL++Ra5c=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
Pulls in the completed **Subject vocab rename** from oneauth PRs 214 + 215.

## What's in v0.1.4

The principal-of-a-token concept across oneauth now uses `Subject` (RFC 7519 \`sub\`):

- v0.1.3 (PR 214): `core.RefreshToken.Subject`, `core.APIKey.Subject`, `localauth.VerificationToken.Subject`, storage interface methods (`GetSubjectTokens`, `RevokeSubjectTokens`, `ListSubjectAPIKeys`, `DeleteSubjectTokens`).
- v0.1.4 (PR 215): `core.GetSubjectFromContext` / `SetSubjectInContext` / `DefaultSubjectParamName=\"loggedInSubject\"`, `apiauth.GetSubjectFromAPIContext`, `PasswordGrantResponse.Subject`, `TokenInfo.Subject`, `httpauth.{GetLoggedInSubject, SetLoggedInSubject}`, `grpc.SubjectFromContext` + metadata header `x-subject`.

Application user-account types (`accounts.User`, `Identity.UserID`, `Username.UserID`) remain `UserID` — only token-bearing principals flipped.

## What changes in mcpkit

**Nothing in the source.** Audit confirmed `ext/auth` only re-exports `client.ClientRegistrationRequest`, `client.ClientRegistrationResponse`, and `client.RegisterClient` via type aliases — none touched by the rename. Other consumers (Discord/Telegram example `.UserID` accesses) are on Discord SDK types, not oneauth.

Pure dep bump.

## Reviewer's guide

`go.mod` / `go.sum` updates across 8 sub-modules:

- `ext/auth/go.mod` — start here, the main consumer
- `tests/keycloak/go.mod`, `tests/e2e/go.mod` — interop suites
- `examples/auth/go.mod`, `examples/fine-grained-auth/go.mod` — auth example servers
- `cmd/testclient/go.mod` — was on 0.0.85, leapfrogs to 0.1.4
- `examples/events/{discord,telegram}/go.mod` — indirect deps only, also leapfrog from 0.0.85

## Verification

- `GOWORK=off go build ./...` — green across all 8 sub-modules.
- `GOWORK=off go test ./...` — green for `ext/auth`, `tests/e2e`, `examples/events/{discord,telegram}`. `tests/keycloak` skipped (requires container; not run pre-merge).
- One pre-existing failure surfaced — `examples/auth/main.go:495` has `log.Printf(\"%s\", addr)` where `addr` is `*string` from `flag.String`. Same failure exists on `main` without this bump — **not introduced by this PR**. Separate cleanup if you want it.

## Risk

Minimal. No source changes anywhere; only dep version + checksums shift. Worst case is rolling back the `go get` is one-line per sub-module.