### PR TITLE
chore(server): accept DRAFT-2026-v1 in initialize negotiation

### DIFF
--- a/server/dispatch.go
+++ b/server/dispatch.go
@@ -17,7 +17,13 @@ import (
 // supportedProtocolVersions lists the MCP protocol versions this server supports,
 // ordered newest-first. During initialization the server picks the client's requested
 // version if it appears in this list; otherwise it rejects with the full list.
-var supportedProtocolVersions = []string{"2025-11-25", "2025-03-26", "2024-11-05"}
+//
+// "DRAFT-2026-v1" is the in-flight 2026 protocol revision that carries the SEP-2663
+// tasks extension, SEP-2575 stateless capability override, and SEP-2322 MRTR base
+// types. Accepting it lets draft-aware conformance suites (panyam/mcpconformance
+// feat/tasks-mrtr-extension, upstream PR 262) complete the initialize handshake
+// without forcing them to lie about which version they speak.
+var supportedProtocolVersions = []string{"DRAFT-2026-v1", "2025-11-25", "2025-03-26", "2024-11-05"}
 
 // ErrCodeCancelled is the JSON-RPC error code for a cancelled request.
 const ErrCodeCancelled = -32800


### PR DESCRIPTION
## What changes

Adds `"DRAFT-2026-v1"` to mcpkit's `supportedProtocolVersions` list so the server accepts the in-flight 2026 protocol revision in the `initialize` handshake. One-line addition (newest-first) plus a doc comment explaining why the draft string lives next to the dated releases.

## Why

The tasks-v2 / MRTR conformance fork at [panyam/mcpconformance feat/tasks-mrtr-extension](https://github.com/panyam/mcpconformance/tree/feat/tasks-mrtr-extension) (upstream PR 262) is moving off the SDK Client for draft-tagged scenarios. The SDK pins `protocolVersion: "2025-11-25"` in the initialize body, which prevents strict draft-only servers (e.g. Randgalt's at modelcontextprotocol/conformance#262) from handshaking. The conformance fix introduces an `initRawSession` helper that sends `DRAFT-2026-v1` directly.

Without this PR mcpkit's tasks-v2 fixture (`examples/tasks-v2`) is the next strict-draft server — every tasks scenario fails on bootstrap with `MCP error -32602: unsupported protocol version: DRAFT-2026-v1`.

## Reviewer's guide

Read in this order:

1. `server/dispatch.go` lines 17-26 — the one-line list addition plus the rationale comment.

Skim or skip: nothing else touched.

## Risk

- Additive. Servers that previously rejected `DRAFT-2026-v1` now accept it. No version that previously worked is rejected.
- No client-side change. Existing mcpkit clients keep sending `2025-11-25` until/unless they're updated.
- Verified via the tasks-v2 conformance suite (against the migrated fork): 9/9 scenarios pass. With this change reverted, 8/9 fail on bootstrap (only `tasks-status-notifications`, which doesn't open a session, survives).

## Out of scope

- No client-side protocol-version bump. mcpkit's `client/` still negotiates released versions only.
- No additions to the spec-version literals in tests/examples. The 4-element `supportedProtocolVersions` list is the single source of truth.