### PR TITLE
feat(ext/auth): SEP-990 enterprise-managed authorization (closes #448)

### DIFF
--- a/cmd/testclient/go.mod
+++ b/cmd/testclient/go.mod
@@ -5,7 +5,7 @@ go 1.26.3
 require (
 	github.com/panyam/mcpkit v0.2.3
 	github.com/panyam/mcpkit/ext/auth v0.0.0
-	github.com/panyam/oneauth v0.1.4
+	github.com/panyam/oneauth v0.1.5
 )
 
 require (

--- a/cmd/testclient/go.sum
+++ b/cmd/testclient/go.sum
@@ -1,3 +1,5 @@
+github.com/alexedwards/scs/v2 v2.8.0 h1:h31yUYoycPuL0zt14c0gd+oqxfRwIj6SOjHdKRZxhEw=
+github.com/alexedwards/scs/v2 v2.8.0/go.mod h1:ToaROZxyKukJKT/xLcVQAChi5k6+Pn1Gvmdl7h3RRj8=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
@@ -31,8 +33,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.8 h1:5UscYTP892k54+Nyb01tKGGwZxczZ5k7BC+c0nXmcoc=
 github.com/panyam/goutils v0.1.8/go.mod h1:ntucs8GJOHQ0LmlRGRjeup3aDC2t7xPMudrRwUHrJNM=
-github.com/panyam/oneauth v0.1.4 h1:ypHq1SkdXSHWQFlyl8gZCDUub0TWL/EPqR8IlAlJjLQ=
-github.com/panyam/oneauth v0.1.4/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
+github.com/panyam/oneauth v0.1.5 h1:YQMy4V54tLSwyZd/NS7KwS5Q3Is/mu0UZWXd7csEb3M=
+github.com/panyam/oneauth v0.1.5/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
 github.com/panyam/servicekit v0.0.25 h1:JeTRyz5ZZY3beENg0N3tLW+O39/foTuHMPAf+rpwYhM=
 github.com/panyam/servicekit v0.0.25/go.mod h1:9TkF2LRqiPC9bgu0bYVdky7rnHEuBvzGzrsoL++Ra5c=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/cmd/testclient/main.go
+++ b/cmd/testclient/main.go
@@ -165,6 +165,10 @@ type conformanceContext struct {
 	ClientSecret     string         `json:"client_secret"`
 	PrivateKeyPEM    string         `json:"private_key_pem"`
 	SigningAlgorithm string         `json:"signing_algorithm"`
+	IdpClientID      string         `json:"idp_client_id"`
+	IdpIDToken       string         `json:"idp_id_token"`
+	IdpIssuer        string         `json:"idp_issuer"`
+	IdpTokenEndpoint string         `json:"idp_token_endpoint"`
 	ToolCalls        []toolCallSpec `json:"toolCalls"`
 }
 
@@ -177,14 +181,25 @@ type toolCallSpec struct {
 	Arguments map[string]any `json:"arguments"`
 }
 
-// pickTokenSource decides between OAuthTokenSource (authorization_code) and
-// ClientCredentialsTokenSource (SEP-1046). PrivateKeyPEM uniquely identifies
-// private_key_jwt. For the basic variant, ctx shape (client_id + client_secret)
-// overlaps with auth-code pre-registration scenarios, so a discovery probe
-// disambiguates via AS grant_types_supported. The probe is gated on
-// `ClientID != ""` to keep DCR scenarios with no pre-registered credentials
-// on the OAuthTokenSource fast path without spurious PRM/AS round trips.
+// pickTokenSource decides which TokenSource to use based on context shape:
+// SEP-990 (idp_id_token), SEP-1046 private_key_jwt (private_key_pem),
+// SEP-1046 basic (AS advertises only client_credentials), or the default
+// authorization_code flow. The AS-discovery probe is gated on ClientID != ""
+// to keep DCR scenarios with no pre-registered credentials on the
+// OAuthTokenSource fast path without spurious PRM/AS round trips.
 func pickTokenSource(serverURL string, ctx conformanceContext) core.TokenSource {
+	if ctx.IdpIDToken != "" && ctx.IdpTokenEndpoint != "" {
+		log.Println("Step 2: ctx has idp_id_token + idp_token_endpoint → EnterpriseManagedTokenSource (SEP-990)")
+		return &auth.EnterpriseManagedTokenSource{
+			ServerURL:        serverURL,
+			ClientID:         ctx.ClientID,
+			ClientSecret:     ctx.ClientSecret,
+			IdpClientID:      ctx.IdpClientID,
+			IdpIDToken:       ctx.IdpIDToken,
+			IdpTokenEndpoint: ctx.IdpTokenEndpoint,
+			AllowInsecure:    true,
+		}
+	}
 	if ctx.PrivateKeyPEM != "" {
 		log.Println("Step 2: ctx has private_key_pem → ClientCredentialsTokenSource (private_key_jwt)")
 		return &auth.ClientCredentialsTokenSource{

--- a/conformance/UPSTREAM_AUDIT.md
+++ b/conformance/UPSTREAM_AUDIT.md
@@ -14,8 +14,8 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 | Surface | Scenarios | Checks | Pass | Fail | Warn | Info | Skipped | Harness-gap |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|
 | Server | 51 | 126 | 58 | 41 | 12 | 6 | 9 | 0 |
-| Client | 40 | 1242 | 448 | 27 | 4 | 757 | 6 | 1 |
-| **Total** | **91** | **1368** | **506** | **68** | **16** | **763** | **15** | **1** |
+| Client | 40 | 1241 | 447 | 25 | 4 | 759 | 6 | 1 |
+| **Total** | **91** | **1367** | **505** | **66** | **16** | **765** | **15** | **1** |
 
 ## Harness gaps
 
@@ -92,7 +92,7 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 
 | Scenario | Surface | Status | Checks | Note |
 |---|---|---|---|---|
-| `auth/enterprise-managed-authorization` | client | partial | 10 pass / 2 fail / 18 info |  |
+| `auth/enterprise-managed-authorization` | client | pass | 9 pass / 20 info |  |
 
 ### [SEP-1034](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1034) (2 scenarios)
 

--- a/examples/auth/go.mod
+++ b/examples/auth/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/panyam/mcpkit v0.2.41
 	github.com/panyam/mcpkit/examples/common v0.0.0-00010101000000-000000000000
 	github.com/panyam/mcpkit/ext/auth v0.2.36
-	github.com/panyam/oneauth v0.1.4
+	github.com/panyam/oneauth v0.1.5
 )
 
 require (

--- a/examples/auth/go.sum
+++ b/examples/auth/go.sum
@@ -83,8 +83,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.13 h1:V819IdZTEJ3rpu33ZqohC6O9ou7KOu6cxfigoYT12OQ=
 github.com/panyam/goutils v0.1.13/go.mod h1:vd3iFcv1DjaeV6h8tslIJh9d09RLndg8UYNSGROBrM4=
-github.com/panyam/oneauth v0.1.4 h1:ypHq1SkdXSHWQFlyl8gZCDUub0TWL/EPqR8IlAlJjLQ=
-github.com/panyam/oneauth v0.1.4/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
+github.com/panyam/oneauth v0.1.5 h1:YQMy4V54tLSwyZd/NS7KwS5Q3Is/mu0UZWXd7csEb3M=
+github.com/panyam/oneauth v0.1.5/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
 github.com/panyam/servicekit v0.1.1 h1:aIvVWjpIw2xBF5V4hpf7GY4RqinkY7u3OBbjQd8a1vU=
 github.com/panyam/servicekit v0.1.1/go.mod h1:kvuEgs3iJjwRyqGlKTkppwiFDpM69MPeihVi1m/B97o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/examples/events/discord/go.mod
+++ b/examples/events/discord/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/panyam/demokit/notebook v0.0.25 // indirect
 	github.com/panyam/gocurrent v0.1.1 // indirect
 	github.com/panyam/goutils v0.1.13 // indirect
-	github.com/panyam/oneauth v0.1.4 // indirect
+	github.com/panyam/oneauth v0.1.5 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect

--- a/examples/events/discord/go.sum
+++ b/examples/events/discord/go.sum
@@ -1,5 +1,7 @@
 charm.land/lipgloss/v2 v2.0.3 h1:yM2zJ4Cf5Y51b7RHIwioil4ApI/aypFXXVHSwlM6RzU=
 charm.land/lipgloss/v2 v2.0.3/go.mod h1:7myLU9iG/3xluAWzpY/fSxYYHCgoKTie7laxk6ATwXA=
+github.com/alexedwards/scs/v2 v2.8.0 h1:h31yUYoycPuL0zt14c0gd+oqxfRwIj6SOjHdKRZxhEw=
+github.com/alexedwards/scs/v2 v2.8.0/go.mod h1:ToaROZxyKukJKT/xLcVQAChi5k6+Pn1Gvmdl7h3RRj8=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
@@ -84,8 +86,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.13 h1:V819IdZTEJ3rpu33ZqohC6O9ou7KOu6cxfigoYT12OQ=
 github.com/panyam/goutils v0.1.13/go.mod h1:vd3iFcv1DjaeV6h8tslIJh9d09RLndg8UYNSGROBrM4=
-github.com/panyam/oneauth v0.1.4 h1:ypHq1SkdXSHWQFlyl8gZCDUub0TWL/EPqR8IlAlJjLQ=
-github.com/panyam/oneauth v0.1.4/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
+github.com/panyam/oneauth v0.1.5 h1:YQMy4V54tLSwyZd/NS7KwS5Q3Is/mu0UZWXd7csEb3M=
+github.com/panyam/oneauth v0.1.5/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
 github.com/panyam/servicekit v0.1.1 h1:aIvVWjpIw2xBF5V4hpf7GY4RqinkY7u3OBbjQd8a1vU=
 github.com/panyam/servicekit v0.1.1/go.mod h1:kvuEgs3iJjwRyqGlKTkppwiFDpM69MPeihVi1m/B97o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/examples/events/telegram/go.mod
+++ b/examples/events/telegram/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/panyam/demokit/notebook v0.0.25 // indirect
 	github.com/panyam/gocurrent v0.1.1 // indirect
 	github.com/panyam/goutils v0.1.13 // indirect
-	github.com/panyam/oneauth v0.1.4 // indirect
+	github.com/panyam/oneauth v0.1.5 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect

--- a/examples/events/telegram/go.sum
+++ b/examples/events/telegram/go.sum
@@ -1,5 +1,7 @@
 charm.land/lipgloss/v2 v2.0.3 h1:yM2zJ4Cf5Y51b7RHIwioil4ApI/aypFXXVHSwlM6RzU=
 charm.land/lipgloss/v2 v2.0.3/go.mod h1:7myLU9iG/3xluAWzpY/fSxYYHCgoKTie7laxk6ATwXA=
+github.com/alexedwards/scs/v2 v2.8.0 h1:h31yUYoycPuL0zt14c0gd+oqxfRwIj6SOjHdKRZxhEw=
+github.com/alexedwards/scs/v2 v2.8.0/go.mod h1:ToaROZxyKukJKT/xLcVQAChi5k6+Pn1Gvmdl7h3RRj8=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
@@ -83,8 +85,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.13 h1:V819IdZTEJ3rpu33ZqohC6O9ou7KOu6cxfigoYT12OQ=
 github.com/panyam/goutils v0.1.13/go.mod h1:vd3iFcv1DjaeV6h8tslIJh9d09RLndg8UYNSGROBrM4=
-github.com/panyam/oneauth v0.1.4 h1:ypHq1SkdXSHWQFlyl8gZCDUub0TWL/EPqR8IlAlJjLQ=
-github.com/panyam/oneauth v0.1.4/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
+github.com/panyam/oneauth v0.1.5 h1:YQMy4V54tLSwyZd/NS7KwS5Q3Is/mu0UZWXd7csEb3M=
+github.com/panyam/oneauth v0.1.5/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
 github.com/panyam/servicekit v0.1.1 h1:aIvVWjpIw2xBF5V4hpf7GY4RqinkY7u3OBbjQd8a1vU=
 github.com/panyam/servicekit v0.1.1/go.mod h1:kvuEgs3iJjwRyqGlKTkppwiFDpM69MPeihVi1m/B97o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/examples/fine-grained-auth/go.mod
+++ b/examples/fine-grained-auth/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/panyam/mcpkit v0.2.41
 	github.com/panyam/mcpkit/examples/common v0.0.0-00010101000000-000000000000
 	github.com/panyam/mcpkit/ext/auth v0.2.36
-	github.com/panyam/oneauth v0.1.4
+	github.com/panyam/oneauth v0.1.5
 	github.com/panyam/servicekit v0.1.1
 )
 

--- a/examples/fine-grained-auth/go.sum
+++ b/examples/fine-grained-auth/go.sum
@@ -1,5 +1,7 @@
 charm.land/lipgloss/v2 v2.0.3 h1:yM2zJ4Cf5Y51b7RHIwioil4ApI/aypFXXVHSwlM6RzU=
 charm.land/lipgloss/v2 v2.0.3/go.mod h1:7myLU9iG/3xluAWzpY/fSxYYHCgoKTie7laxk6ATwXA=
+github.com/alexedwards/scs/v2 v2.8.0 h1:h31yUYoycPuL0zt14c0gd+oqxfRwIj6SOjHdKRZxhEw=
+github.com/alexedwards/scs/v2 v2.8.0/go.mod h1:ToaROZxyKukJKT/xLcVQAChi5k6+Pn1Gvmdl7h3RRj8=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
@@ -81,8 +83,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.13 h1:V819IdZTEJ3rpu33ZqohC6O9ou7KOu6cxfigoYT12OQ=
 github.com/panyam/goutils v0.1.13/go.mod h1:vd3iFcv1DjaeV6h8tslIJh9d09RLndg8UYNSGROBrM4=
-github.com/panyam/oneauth v0.1.4 h1:ypHq1SkdXSHWQFlyl8gZCDUub0TWL/EPqR8IlAlJjLQ=
-github.com/panyam/oneauth v0.1.4/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
+github.com/panyam/oneauth v0.1.5 h1:YQMy4V54tLSwyZd/NS7KwS5Q3Is/mu0UZWXd7csEb3M=
+github.com/panyam/oneauth v0.1.5/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
 github.com/panyam/servicekit v0.1.1 h1:aIvVWjpIw2xBF5V4hpf7GY4RqinkY7u3OBbjQd8a1vU=
 github.com/panyam/servicekit v0.1.1/go.mod h1:kvuEgs3iJjwRyqGlKTkppwiFDpM69MPeihVi1m/B97o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/ext/auth/docs/DESIGN.md
+++ b/ext/auth/docs/DESIGN.md
@@ -289,6 +289,7 @@ type AuthError struct {
 | `JWTValidator` | `AuthValidator` + `ClaimsProvider` | `jwt.Parse` with JWKS keyfunc (`JWKSKeyStore.GetKeyByKid`) |
 | `OAuthTokenSource` | `TokenSource` | `client.LoginWithBrowser` + `client.DiscoverAS` |
 | `ClientCredentialsTokenSource` | `TokenSource` + `ScopeAwareTokenSource` | `client.ClientCredentialsSource` (basic and `private_key_jwt` per SEP-1046) |
+| `EnterpriseManagedTokenSource` | `TokenSource` + `ScopeAwareTokenSource` | `client.TokenExchange` (RFC 8693) → `client.JwtBearerGrant` (RFC 7523 §2.1), two-stage chain per SEP-990 |
 | `AuthExtension` | `ExtensionProvider` | (none — declares MCP auth extension metadata) |
 
 ## Server Usage

--- a/ext/auth/enterprise_managed.go
+++ b/ext/auth/enterprise_managed.go
@@ -1,0 +1,195 @@
+package auth
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/panyam/oneauth/client"
+)
+
+// EnterpriseManagedTokenSource implements core.TokenSource for the SEP-990
+// enterprise-managed authorization flow. The MCP client presents an upstream
+// IdP-issued ID token, exchanges it for an ID-JAG via RFC 8693 at the IdP,
+// then redeems the ID-JAG at the MCP authorization server via RFC 7523 §2.1
+// (jwt-bearer grant) using `client_secret_basic` for client authentication.
+//
+// This is the two-stage chain in plain terms:
+//
+//	IdP /token   (RFC 8693)   id_token → id-jag
+//	AS  /token   (RFC 7523)   id-jag   → MCP access token
+//
+// The first stage is "the IdP vouches for the user". The second stage is
+// "the AS vouches for the MCP client acting on the user's behalf at the
+// MCP server." See:
+//
+//	https://github.com/modelcontextprotocol/ext-auth/blob/main/specification/draft/enterprise-managed-authorization.mdx
+//
+// Token caching is keyed on the MCP access token's expiry. When the access
+// token expires the source re-runs the full two-stage chain — the ID-JAG
+// is single-use so we never cache it across calls.
+type EnterpriseManagedTokenSource struct {
+	// ServerURL is the MCP server URL. Used for PRM discovery and as the
+	// `resource` form value on the IdP token exchange.
+	ServerURL string
+
+	// ClientID identifies this MCP client at the MCP authorization server.
+	// Required.
+	ClientID string
+
+	// ClientSecret authenticates the MCP client at the AS via
+	// `client_secret_basic` (RFC 6749 §2.3.1) on the jwt-bearer grant
+	// request. Required.
+	ClientSecret string
+
+	// IdpClientID is the client identity sent on the IdP token exchange.
+	// SEP-990 §6.1 notes the IdP "needs to be aware of the MCP Client's
+	// client_id that it normally uses with the MCP Server"; this field
+	// names the client at the IdP, which may differ from ClientID above.
+	// Optional — empty falls back to the unauthenticated token-exchange
+	// path (AuthMethodNone), which the conformance fixture accepts.
+	IdpClientID string
+
+	// IdpIDToken is the signed ID token issued by the IdP for the user.
+	// Required. Sent as the RFC 8693 `subject_token`.
+	IdpIDToken string
+
+	// IdpTokenEndpoint is the URL of the IdP token endpoint that performs
+	// the RFC 8693 token exchange. Required. The conformance scenario
+	// provides this directly in MCP_CONFORMANCE_CONTEXT rather than
+	// requiring a separate IdP discovery step.
+	IdpTokenEndpoint string
+
+	// AllowInsecure permits http:// AS endpoints. The conformance mock AS
+	// uses HTTP; production deployments leave this false.
+	AllowInsecure bool
+
+	// HTTPClient overrides the discovery and token-request HTTP client.
+	HTTPClient *http.Client
+
+	// ASMetadataStore caches AS metadata across discovery calls.
+	ASMetadataStore client.ASMetadataStore
+
+	mu          sync.Mutex
+	authInfo    *MCPAuthInfo
+	accessToken string
+	expiry      time.Time
+}
+
+// Token returns a cached access token if still valid, or runs the full
+// two-stage chain (token exchange at IdP → jwt-bearer grant at AS).
+// Implements core.TokenSource.
+func (s *EnterpriseManagedTokenSource) Token() (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.accessToken != "" && time.Now().Add(tokenExpiryBuffer).Before(s.expiry) {
+		return s.accessToken, nil
+	}
+	if err := s.ensureDiscoveredLocked(); err != nil {
+		return "", err
+	}
+	return s.refetchLocked()
+}
+
+// TokenForScopes invalidates the cached access token and re-runs the
+// chain. SEP-990 doesn't have a scope step-up story today; the implementation
+// re-runs the same flow because the AS may issue a token with different
+// scope based on the (already-issued) ID-JAG.
+func (s *EnterpriseManagedTokenSource) TokenForScopes(_ []string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.accessToken = ""
+	s.expiry = time.Time{}
+	if err := s.ensureDiscoveredLocked(); err != nil {
+		return "", err
+	}
+	return s.refetchLocked()
+}
+
+func (s *EnterpriseManagedTokenSource) ensureDiscoveredLocked() error {
+	if s.authInfo != nil {
+		return nil
+	}
+	if s.ClientID == "" {
+		return fmt.Errorf("EnterpriseManagedTokenSource: ClientID is required")
+	}
+	if s.ClientSecret == "" {
+		return fmt.Errorf("EnterpriseManagedTokenSource: ClientSecret is required")
+	}
+	if s.IdpIDToken == "" {
+		return fmt.Errorf("EnterpriseManagedTokenSource: IdpIDToken is required")
+	}
+	if s.IdpTokenEndpoint == "" {
+		return fmt.Errorf("EnterpriseManagedTokenSource: IdpTokenEndpoint is required")
+	}
+
+	var opts []DiscoverOption
+	if s.HTTPClient != nil {
+		opts = append(opts, WithHTTPClient(s.HTTPClient))
+	}
+	if s.ASMetadataStore != nil {
+		opts = append(opts, WithASMetadataStore(s.ASMetadataStore))
+	}
+	info, err := DiscoverMCPAuth(s.ServerURL, opts...)
+	if err != nil {
+		return fmt.Errorf("MCP auth discovery: %w", err)
+	}
+	if !s.AllowInsecure {
+		if err := client.ValidateHTTPS(info.ASMetadata); err != nil {
+			return err
+		}
+	}
+	s.authInfo = info
+	return nil
+}
+
+func (s *EnterpriseManagedTokenSource) refetchLocked() (string, error) {
+	asIssuer := s.authInfo.AuthorizationServers[0]
+	asTokenEndpoint := s.authInfo.ASMetadata.TokenEndpoint
+
+	// Stage 1 — IdP RFC 8693 token exchange. ClientSecret/ClientAssertion
+	// are intentionally left empty: SEP-990 has the IdP authorize on the
+	// strength of the subject_token's signature + claims, not via an
+	// additional client credential at the exchange endpoint.
+	idp := client.NewAuthClient(s.IdpTokenEndpoint, nil,
+		client.WithASMetadata(&client.ASMetadata{TokenEndpoint: s.IdpTokenEndpoint}))
+
+	exch, err := idp.TokenExchange(&client.TokenExchangeRequest{
+		ClientID:           s.IdpClientID,
+		SubjectToken:       s.IdpIDToken,
+		SubjectTokenType:   "urn:ietf:params:oauth:token-type:id_token",
+		RequestedTokenType: "urn:ietf:params:oauth:token-type:id-jag",
+		Audience:           []string{asIssuer},
+		Resource:           []string{s.ServerURL},
+	})
+	if err != nil {
+		return "", fmt.Errorf("idp token exchange: %w", err)
+	}
+	if exch.AccessToken == "" {
+		return "", fmt.Errorf("idp token exchange returned no access_token")
+	}
+
+	// Stage 2 — AS RFC 7523 §2.1 jwt-bearer grant. ClientSecret travels via
+	// client_secret_basic per the AS's advertised auth methods.
+	as := client.NewAuthClient(asTokenEndpoint, nil,
+		client.WithASMetadata(&client.ASMetadata{
+			TokenEndpoint:            asTokenEndpoint,
+			TokenEndpointAuthMethods: s.authInfo.ASMetadata.TokenEndpointAuthMethods,
+		}))
+
+	cred, err := as.JwtBearerGrant(&client.JwtBearerGrantRequest{
+		ClientID:     s.ClientID,
+		ClientSecret: s.ClientSecret,
+		Assertion:    exch.AccessToken,
+	})
+	if err != nil {
+		return "", fmt.Errorf("as jwt-bearer grant: %w", err)
+	}
+
+	s.accessToken = cred.AccessToken
+	s.expiry = cred.ExpiresAt
+	return s.accessToken, nil
+}

--- a/ext/auth/enterprise_managed_test.go
+++ b/ext/auth/enterprise_managed_test.go
@@ -1,0 +1,282 @@
+package auth
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+type idpRequest struct {
+	grantType          string
+	subjectToken       string
+	subjectTokenType   string
+	requestedTokenType string
+	audience           []string
+	resource           []string
+	clientID           string
+}
+
+type asRequest struct {
+	grantType     string
+	assertion     string
+	authorization string
+}
+
+// enterpriseMockServers stands up two httptest.Servers — one for the IdP
+// (RFC 8693 token-exchange) and one combining the MCP server + AS
+// (RFC 7523 jwt-bearer grant) — and exposes the most recent request to
+// each token endpoint for assertion.
+type enterpriseMockServers struct {
+	mcpAndAS *httptest.Server
+	idp      *httptest.Server
+
+	idpCalls    atomic.Int32
+	asCalls     atomic.Int32
+	lastIdp     idpRequest
+	lastAS      asRequest
+	asResponder func(asRequest) (statusCode int, body any)
+}
+
+func newEnterpriseMockServers(t *testing.T) *enterpriseMockServers {
+	t.Helper()
+	m := &enterpriseMockServers{}
+
+	idpMux := http.NewServeMux()
+	idpMux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		m.idpCalls.Add(1)
+		_ = r.ParseForm()
+		m.lastIdp = idpRequest{
+			grantType:          r.PostForm.Get("grant_type"),
+			subjectToken:       r.PostForm.Get("subject_token"),
+			subjectTokenType:   r.PostForm.Get("subject_token_type"),
+			requestedTokenType: r.PostForm.Get("requested_token_type"),
+			audience:           r.PostForm["audience"],
+			resource:           r.PostForm["resource"],
+			clientID:           r.PostForm.Get("client_id"),
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":      "idjag-" + m.lastIdp.subjectToken[:8],
+			"issued_token_type": "urn:ietf:params:oauth:token-type:id-jag",
+			"token_type":        "N_A",
+		})
+	})
+	m.idp = httptest.NewServer(idpMux)
+	t.Cleanup(m.idp.Close)
+
+	mcpMux := http.NewServeMux()
+	mcpMux.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("WWW-Authenticate",
+			`Bearer resource_metadata="`+m.mcpAndAS.URL+`/.well-known/oauth-protected-resource/mcp"`)
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	})
+	mcpMux.HandleFunc("/.well-known/oauth-protected-resource/mcp", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(ProtectedResourceMetadata{
+			Resource:             m.mcpAndAS.URL,
+			AuthorizationServers: []string{m.mcpAndAS.URL},
+		})
+	})
+	mcpMux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                                m.mcpAndAS.URL,
+			"token_endpoint":                        m.mcpAndAS.URL + "/token",
+			"grant_types_supported":                 []string{"urn:ietf:params:oauth:grant-type:jwt-bearer"},
+			"token_endpoint_auth_methods_supported": []string{"client_secret_basic"},
+			"code_challenge_methods_supported":      []string{"S256"},
+			"response_types_supported":              []string{"code"},
+			"scopes_supported":                      []string{"mcp.tools"},
+		})
+	})
+	mcpMux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		m.asCalls.Add(1)
+		_ = r.ParseForm()
+		m.lastAS = asRequest{
+			grantType:     r.PostForm.Get("grant_type"),
+			assertion:     r.PostForm.Get("assertion"),
+			authorization: r.Header.Get("Authorization"),
+		}
+		if m.asResponder != nil {
+			status, body := m.asResponder(m.lastAS)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(status)
+			_ = json.NewEncoder(w).Encode(body)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "mcp-access-token",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	})
+	m.mcpAndAS = httptest.NewServer(mcpMux)
+	t.Cleanup(m.mcpAndAS.Close)
+
+	return m
+}
+
+func TestEnterpriseManagedTokenSource_TwoStageRoundtrip(t *testing.T) {
+	mock := newEnterpriseMockServers(t)
+	ts := &EnterpriseManagedTokenSource{
+		ServerURL:        mock.mcpAndAS.URL + "/mcp",
+		ClientID:         "mcp-client",
+		ClientSecret:     "mcp-secret",
+		IdpClientID:      "idp-client",
+		IdpIDToken:       "idtoken12345abcdef",
+		IdpTokenEndpoint: mock.idp.URL + "/token",
+		HTTPClient:       mock.mcpAndAS.Client(),
+		AllowInsecure:    true,
+	}
+
+	tok, err := ts.Token()
+	if err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	if tok != "mcp-access-token" {
+		t.Errorf("Token() = %q, want mcp-access-token", tok)
+	}
+
+	if got, want := mock.lastIdp.grantType, "urn:ietf:params:oauth:grant-type:token-exchange"; got != want {
+		t.Errorf("idp grant_type = %q, want %q", got, want)
+	}
+	if got, want := mock.lastIdp.subjectToken, "idtoken12345abcdef"; got != want {
+		t.Errorf("idp subject_token = %q, want %q", got, want)
+	}
+	if got, want := mock.lastIdp.subjectTokenType, "urn:ietf:params:oauth:token-type:id_token"; got != want {
+		t.Errorf("idp subject_token_type = %q, want %q", got, want)
+	}
+	if got, want := mock.lastIdp.requestedTokenType, "urn:ietf:params:oauth:token-type:id-jag"; got != want {
+		t.Errorf("idp requested_token_type = %q, want %q", got, want)
+	}
+	if len(mock.lastIdp.audience) != 1 || mock.lastIdp.audience[0] != mock.mcpAndAS.URL {
+		t.Errorf("idp audience = %v, want [%q]", mock.lastIdp.audience, mock.mcpAndAS.URL)
+	}
+	wantResource := mock.mcpAndAS.URL + "/mcp"
+	if len(mock.lastIdp.resource) != 1 || mock.lastIdp.resource[0] != wantResource {
+		t.Errorf("idp resource = %v, want [%q]", mock.lastIdp.resource, wantResource)
+	}
+
+	if got, want := mock.lastAS.grantType, "urn:ietf:params:oauth:grant-type:jwt-bearer"; got != want {
+		t.Errorf("as grant_type = %q, want %q", got, want)
+	}
+	if !strings.HasPrefix(mock.lastAS.assertion, "idjag-") {
+		t.Errorf("as assertion = %q, want id-jag from stage 1", mock.lastAS.assertion)
+	}
+	if !strings.HasPrefix(mock.lastAS.authorization, "Basic ") {
+		t.Fatalf("as Authorization = %q, want Basic prefix", mock.lastAS.authorization)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(mock.lastAS.authorization, "Basic "))
+	if err != nil {
+		t.Fatalf("decode basic auth: %v", err)
+	}
+	if got, want := string(decoded), "mcp-client:mcp-secret"; got != want {
+		t.Errorf("as basic creds = %q, want %q", got, want)
+	}
+
+	tok2, err := ts.Token()
+	if err != nil {
+		t.Fatalf("Token (cached): %v", err)
+	}
+	if tok2 != tok {
+		t.Errorf("cached Token() = %q, want %q", tok2, tok)
+	}
+	if mock.idpCalls.Load() != 1 {
+		t.Errorf("idp call count = %d after cache hit, want 1", mock.idpCalls.Load())
+	}
+	if mock.asCalls.Load() != 1 {
+		t.Errorf("as call count = %d after cache hit, want 1", mock.asCalls.Load())
+	}
+}
+
+func TestEnterpriseManagedTokenSource_IdpClientIDFlowsThrough(t *testing.T) {
+	mock := newEnterpriseMockServers(t)
+	ts := &EnterpriseManagedTokenSource{
+		ServerURL:        mock.mcpAndAS.URL + "/mcp",
+		ClientID:         "mcp-client",
+		ClientSecret:     "mcp-secret",
+		IdpClientID:      "enterprise-idp-client",
+		IdpIDToken:       "idtokenABCDEFGHIJ",
+		IdpTokenEndpoint: mock.idp.URL + "/token",
+		HTTPClient:       mock.mcpAndAS.Client(),
+		AllowInsecure:    true,
+	}
+	if _, err := ts.Token(); err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	if got, want := mock.lastIdp.clientID, "enterprise-idp-client"; got != want {
+		t.Errorf("idp client_id = %q, want %q", got, want)
+	}
+}
+
+func TestEnterpriseManagedTokenSource_ValidationErrors(t *testing.T) {
+	mock := newEnterpriseMockServers(t)
+	base := EnterpriseManagedTokenSource{
+		ServerURL:        mock.mcpAndAS.URL + "/mcp",
+		ClientID:         "mcp-client",
+		ClientSecret:     "mcp-secret",
+		IdpIDToken:       "idtoken12345abcdef",
+		IdpTokenEndpoint: mock.idp.URL + "/token",
+		HTTPClient:       mock.mcpAndAS.Client(),
+		AllowInsecure:    true,
+	}
+	cases := []struct {
+		name    string
+		mut     func(*EnterpriseManagedTokenSource)
+		wantMsg string
+	}{
+		{"missing ClientID", func(s *EnterpriseManagedTokenSource) { s.ClientID = "" }, "ClientID is required"},
+		{"missing ClientSecret", func(s *EnterpriseManagedTokenSource) { s.ClientSecret = "" }, "ClientSecret is required"},
+		{"missing IdpIDToken", func(s *EnterpriseManagedTokenSource) { s.IdpIDToken = "" }, "IdpIDToken is required"},
+		{"missing IdpTokenEndpoint", func(s *EnterpriseManagedTokenSource) { s.IdpTokenEndpoint = "" }, "IdpTokenEndpoint is required"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := base
+			tc.mut(&ts)
+			_, err := ts.Token()
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tc.wantMsg) {
+				t.Errorf("error = %q, want substring %q", err, tc.wantMsg)
+			}
+		})
+	}
+}
+
+func TestEnterpriseManagedTokenSource_IdpRejects(t *testing.T) {
+	mock := newEnterpriseMockServers(t)
+	// Override IdP /token to reject with invalid_grant
+	mock.idp.Close()
+	idpMux := http.NewServeMux()
+	idpMux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "invalid_grant", "error_description": "bad subject_token"})
+	})
+	mock.idp = httptest.NewServer(idpMux)
+	t.Cleanup(mock.idp.Close)
+
+	ts := &EnterpriseManagedTokenSource{
+		ServerURL:        mock.mcpAndAS.URL + "/mcp",
+		ClientID:         "mcp-client",
+		ClientSecret:     "mcp-secret",
+		IdpIDToken:       "idtoken12345abcdef",
+		IdpTokenEndpoint: mock.idp.URL + "/token",
+		HTTPClient:       mock.mcpAndAS.Client(),
+		AllowInsecure:    true,
+	}
+	_, err := ts.Token()
+	if err == nil {
+		t.Fatal("expected idp rejection error")
+	}
+	if !strings.Contains(err.Error(), "idp token exchange") {
+		t.Errorf("error = %q, want substring 'idp token exchange'", err)
+	}
+}

--- a/ext/auth/go.mod
+++ b/ext/auth/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/panyam/gocurrent v0.1.1
 	github.com/panyam/mcpkit v0.2.3
-	github.com/panyam/oneauth v0.1.4
+	github.com/panyam/oneauth v0.1.5
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/ext/auth/go.sum
+++ b/ext/auth/go.sum
@@ -1,3 +1,5 @@
+github.com/alexedwards/scs/v2 v2.8.0 h1:h31yUYoycPuL0zt14c0gd+oqxfRwIj6SOjHdKRZxhEw=
+github.com/alexedwards/scs/v2 v2.8.0/go.mod h1:ToaROZxyKukJKT/xLcVQAChi5k6+Pn1Gvmdl7h3RRj8=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
@@ -32,8 +34,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.8 h1:5UscYTP892k54+Nyb01tKGGwZxczZ5k7BC+c0nXmcoc=
 github.com/panyam/goutils v0.1.8/go.mod h1:ntucs8GJOHQ0LmlRGRjeup3aDC2t7xPMudrRwUHrJNM=
-github.com/panyam/oneauth v0.1.4 h1:ypHq1SkdXSHWQFlyl8gZCDUub0TWL/EPqR8IlAlJjLQ=
-github.com/panyam/oneauth v0.1.4/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
+github.com/panyam/oneauth v0.1.5 h1:YQMy4V54tLSwyZd/NS7KwS5Q3Is/mu0UZWXd7csEb3M=
+github.com/panyam/oneauth v0.1.5/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
 github.com/panyam/servicekit v0.0.25 h1:JeTRyz5ZZY3beENg0N3tLW+O39/foTuHMPAf+rpwYhM=
 github.com/panyam/servicekit v0.0.25/go.mod h1:9TkF2LRqiPC9bgu0bYVdky7rnHEuBvzGzrsoL++Ra5c=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/panyam/mcpkit v0.2.3
 	github.com/panyam/mcpkit/ext/auth v0.0.0
 	github.com/panyam/mcpkit/ext/ui v0.0.0
-	github.com/panyam/oneauth v0.1.4
+	github.com/panyam/oneauth v0.1.5
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/tests/e2e/go.sum
+++ b/tests/e2e/go.sum
@@ -33,8 +33,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.8 h1:5UscYTP892k54+Nyb01tKGGwZxczZ5k7BC+c0nXmcoc=
 github.com/panyam/goutils v0.1.8/go.mod h1:ntucs8GJOHQ0LmlRGRjeup3aDC2t7xPMudrRwUHrJNM=
-github.com/panyam/oneauth v0.1.4 h1:ypHq1SkdXSHWQFlyl8gZCDUub0TWL/EPqR8IlAlJjLQ=
-github.com/panyam/oneauth v0.1.4/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
+github.com/panyam/oneauth v0.1.5 h1:YQMy4V54tLSwyZd/NS7KwS5Q3Is/mu0UZWXd7csEb3M=
+github.com/panyam/oneauth v0.1.5/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
 github.com/panyam/servicekit v0.0.25 h1:JeTRyz5ZZY3beENg0N3tLW+O39/foTuHMPAf+rpwYhM=
 github.com/panyam/servicekit v0.0.25/go.mod h1:9TkF2LRqiPC9bgu0bYVdky7rnHEuBvzGzrsoL++Ra5c=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/tests/keycloak/go.mod
+++ b/tests/keycloak/go.mod
@@ -5,7 +5,7 @@ go 1.26.3
 require (
 	github.com/panyam/mcpkit v0.2.3
 	github.com/panyam/mcpkit/ext/auth v0.0.0
-	github.com/panyam/oneauth v0.1.4
+	github.com/panyam/oneauth v0.1.5
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/tests/keycloak/go.sum
+++ b/tests/keycloak/go.sum
@@ -33,8 +33,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.8 h1:5UscYTP892k54+Nyb01tKGGwZxczZ5k7BC+c0nXmcoc=
 github.com/panyam/goutils v0.1.8/go.mod h1:ntucs8GJOHQ0LmlRGRjeup3aDC2t7xPMudrRwUHrJNM=
-github.com/panyam/oneauth v0.1.4 h1:ypHq1SkdXSHWQFlyl8gZCDUub0TWL/EPqR8IlAlJjLQ=
-github.com/panyam/oneauth v0.1.4/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
+github.com/panyam/oneauth v0.1.5 h1:YQMy4V54tLSwyZd/NS7KwS5Q3Is/mu0UZWXd7csEb3M=
+github.com/panyam/oneauth v0.1.5/go.mod h1:EAmer8OH3x4QRM5VueLANJgfAyzivhGwaSfJZ3rUrbM=
 github.com/panyam/servicekit v0.0.25 h1:JeTRyz5ZZY3beENg0N3tLW+O39/foTuHMPAf+rpwYhM=
 github.com/panyam/servicekit v0.0.25/go.mod h1:9TkF2LRqiPC9bgu0bYVdky7rnHEuBvzGzrsoL++Ra5c=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
## What changes

Adds `ext/auth.EnterpriseManagedTokenSource` implementing the SEP-990 two-stage flow for enterprise-managed OAuth. The MCP client presents an upstream IdP-issued ID token; the source exchanges it for an ID-JAG via RFC 8693 at the IdP, then redeems the ID-JAG at the MCP authorization server via RFC 7523 §2.1 (`urn:ietf:params:oauth:grant-type:jwt-bearer`) authenticated with `client_secret_basic`. Both stages use new primitives from oneauth v0.1.5 (`AuthClient.TokenExchange` and `AuthClient.JwtBearerGrant`) — this PR is the consumer half of [panyam/oneauth#213](https://github.com/panyam/oneauth/issues/213).

`cmd/testclient` grows a new branch in `pickTokenSource`: when `MCP_CONFORMANCE_CONTEXT` provides `idp_id_token` + `idp_token_endpoint`, route through `EnterpriseManagedTokenSource`. SEP-1046 and authorization_code paths are unchanged.

`auth/enterprise-managed-authorization` flips from `partial (10p/2f/18i)` to `pass (9p/20i)`. Both SEP-990 checks (`complete-flow-token-exchange` and `complete-flow-jwt-bearer`) flip from `FAILURE` to `SUCCESS`. Server surface unchanged.

## Reviewer's guide

Read in this order:

1. [ext/auth/enterprise_managed.go](https://github.com/panyam/mcpkit/pull/475/files#diff-6634b8e08a5db7dcc2c2b3031cbfb3d9338a20df245773c9a42435a11f8e898d) — start here. New file. `EnterpriseManagedTokenSource` struct + `Token()` runs PRM/AS discovery once, then `refetchLocked` chains stage 1 (TokenExchange at the IdP) and stage 2 (JwtBearerGrant at the AS). Access-token expiry drives the cache; the ID-JAG is re-minted every refetch (single-use).
2. [ext/auth/enterprise_managed_test.go](https://github.com/panyam/mcpkit/pull/475/files#diff-045799bb4fb8a56b38e1d7d587da7561d350fee5cb9d8e69595577218b20aa4c) — acceptance. Mock IdP + MCP/AS pair via two `httptest.Server`s. Asserts wire shape on both stages (RFC 8693 form params on IdP, RFC 7523 `assertion` + `Authorization: Basic` on AS), plus caching, validation errors, and IdP-rejection propagation.
3. [cmd/testclient/main.go](https://github.com/panyam/mcpkit/pull/475/files#diff-bc7a02b2751e1c671ee37f491a72c42030bf2566f6d0496f30ae2a0ab19ffaae) — `pickTokenSource` gains the SEP-990 branch (highest priority since `idp_id_token` is uniquely identifying). `conformanceContext` gains `IdpClientID`, `IdpIDToken`, `IdpIssuer`, `IdpTokenEndpoint`.
4. [ext/auth/docs/DESIGN.md](https://github.com/panyam/mcpkit/pull/475/files#diff-03a5078f128c638aca27e780bfd0c762d7a6122a8867f7df0c519ffb23c54698) — one-line addition to the implementations table.
5. [conformance/UPSTREAM_AUDIT.md](https://github.com/panyam/mcpkit/pull/475/files#diff-bf63f1699e28f43c702f9450df02d9e8ec1dae36200827f929a68513bdb34197) — regenerated snapshot. The `enterprise-managed-authorization` row flips to `pass`.

Skim or skip: the `go.mod`/`go.sum` churn across sub-modules is mechanical (`oneauth v0.1.4 → v0.1.5` in lock-step). No code consumes the bump outside [ext/auth/enterprise_managed.go](https://github.com/panyam/mcpkit/pull/475/files#diff-6634b8e08a5db7dcc2c2b3031cbfb3d9338a20df245773c9a42435a11f8e898d).

## Decision log

- **Pushdown to oneauth first.** TokenExchange and JwtBearerGrant are general OAuth primitives that don't belong in mcpkit. They landed in oneauth v0.1.5 via panyam/oneauth#213; the consumer here is thin glue.
- **IdP authentication is `AuthMethodNone`.** SEP-990's IdP token exchange authorizes on the subject_token signature, not via a separate client credential at the exchange endpoint. `EnterpriseManagedTokenSource` passes `IdpClientID` (informational) and no client secret — oneauth's `SelectAuthMethod` returns `AuthMethodNone`, which emits `client_id` in the body but no Authorization header. Matches the conformance fixture exactly.
- **`IdpClientID` is optional.** Empty is fine (still works with the conformance mock). Real IdPs that gate the exchange endpoint on a registered client_id can set it.
- **Cache the access token; re-mint the ID-JAG on every refetch.** The ID-JAG is single-use by spec (5-minute TTL in the fixture, fresh `jti` per exchange). Caching across refetches would risk a stale `jti` being rejected.
- **PRM/AS discovery reused.** No duplication with `OAuthTokenSource` / `ClientCredentialsTokenSource` — `DiscoverMCPAuth` does the heavy lifting once per source instance.

## Risk / blast radius

- **No regression on existing flows.** `OAuthTokenSource` and `ClientCredentialsTokenSource` unchanged. testclient routes scenarios that don't provide `idp_id_token` through the previous branches verbatim.
- **Behavior change for testclient under the SEP-990 scenario.** Previously: ran authorization_code, mock AS rejected with `unsupported_grant_type: Auth server only supports jwt-bearer grant`. Now: two-stage chain completes, mock AS issues access token, MCP requests authenticated.
- **`AllowInsecure: true` on the testclient TokenSource.** Conformance mock IdP + AS use HTTP. Production users leave the default `false`.
- **Be paranoid about:** the access-token caching contract. Verified by `TestEnterpriseManagedTokenSource_TwoStageRoundtrip` — second `Token()` returns the cached value, neither IdP nor AS counter increments past 1.

## Before / after

```
Before: | `auth/enterprise-managed-authorization` | client | partial | 10 pass / 2 fail / 18 info | (empty)
After:  | `auth/enterprise-managed-authorization` | client | pass    | 9 pass / 20 info          | (empty)
```

Specific SEP-990 checks that flip from FAILURE to SUCCESS:
- `complete-flow-token-exchange`: "Successfully exchanged IDP ID token for ID-JAG at IdP with all required parameters"
- `complete-flow-jwt-bearer`: "Successfully verified client auth, ID-JAG claims, and exchanged for access token"

## Out of scope (deferred)

- **`private_key_jwt` client auth on stage 2.** The conformance scenario uses `client_secret_basic`. Real enterprise deployments often prefer `private_key_jwt`; oneauth's `JwtBearerGrantRequest.ClientAssertion` field is wired but not exposed on `EnterpriseManagedTokenSource` yet. Add when a real consumer asks.
- **IdP discovery via `.well-known/openid-configuration`.** Conformance gives us `idp_token_endpoint` directly. A future helper could populate it from an issuer URL via discovery.
- **Scope step-up via `TokenForScopes`.** Re-runs the full chain since SEP-990 has no defined scope-step-up story. Could be more efficient if the AS lets us request additional scopes on the same ID-JAG.

## Related work

- panyam/oneauth#213 / oneauth PR 216 — pushdown work this PR consumes. Tagged as v0.1.5.
- Umbrella issue 439 — Tier 2 conformance audit work.
