### PR TITLE
feat(server): SEP-2243 routing-header validation (closes #476)

### DIFF
--- a/conformance/UPSTREAM_AUDIT.md
+++ b/conformance/UPSTREAM_AUDIT.md
@@ -13,9 +13,9 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 
 | Surface | Scenarios | Checks | Pass | Fail | Warn | Info | Skipped | Harness-gap |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|
-| Server | 51 | 126 | 56 | 43 | 12 | 6 | 9 | 0 |
+| Server | 51 | 126 | 66 | 38 | 7 | 6 | 9 | 0 |
 | Client | 40 | 1241 | 447 | 25 | 4 | 759 | 6 | 1 |
-| **Total** | **91** | **1367** | **503** | **68** | **16** | **765** | **15** | **1** |
+| **Total** | **91** | **1367** | **513** | **63** | **11** | **765** | **15** | **1** |
 
 ## Harness gaps
 
@@ -158,7 +158,7 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 
 | Scenario | Surface | Status | Checks | Note |
 |---|---|---|---|---|
-| `http-header-validation` | server | partial | 3 pass / 5 fail / 5 warn |  |
+| `http-header-validation` | server | pass | 13 pass |  |
 
 ### [SEP-2243-X-MCP-HEADER](https://modelcontextprotocol.io/specification/draft/server/tools#x-mcp-header) (1 scenarios)
 

--- a/core/jsonrpc.go
+++ b/core/jsonrpc.go
@@ -91,6 +91,12 @@ const (
 	// io.modelcontextprotocol/tasks). Reusable for any future extension
 	// whose required-mode path needs the same affordance.
 	ErrCodeMissingRequiredClientCapability = -32003
+
+	// ErrCodeHeaderMismatch indicates the request's SEP-2243 routing
+	// headers (Mcp-Method, Mcp-Name) disagree with the JSON-RPC body,
+	// or that a required routing header is missing. Paired with HTTP
+	// 400 Bad Request. Defined by SEP-2243 §Server Validation.
+	ErrCodeHeaderMismatch = -32001
 )
 
 // NewResponse creates a success response for the given request ID.

--- a/server/header_validation.go
+++ b/server/header_validation.go
@@ -1,0 +1,126 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+// SEP-2243 routing header names. Lookups via http.Header.Get are
+// case-insensitive on the name side; values are case-sensitive per
+// SEP-2243 (e.g. `tools/list` and `TOOLS/LIST` are distinct).
+const (
+	mcpMethodHeader = "Mcp-Method"
+	mcpNameHeader   = "Mcp-Name"
+)
+
+// sep2243EnforcedVersions enumerates the negotiated MCP protocol
+// versions that mandate SEP-2243 routing-header validation server-side.
+// SEP-2243 is currently draft-only; widen this list when a dated
+// release picks up the requirement (and the official SDKs ship clients
+// that emit Mcp-Method / Mcp-Name).
+var sep2243EnforcedVersions = map[string]bool{
+	"DRAFT-2026-v1": true,
+}
+
+// isSEP2243EnforcedVersion reports whether the session's negotiated
+// protocol version requires Mcp-Method / Mcp-Name validation.
+func isSEP2243EnforcedVersion(negotiated string) bool {
+	return sep2243EnforcedVersions[negotiated]
+}
+
+// validateRoutingHeaders enforces SEP-2243 §Server Validation: the
+// `Mcp-Method` header MUST be present and exactly match the JSON-RPC
+// body method, and for methods that carry a body-side identifier
+// (currently `tools/call` → `params.name`, `resources/read` →
+// `params.uri`) the `Mcp-Name` header MUST be present and match.
+// Header values are trimmed for RFC 9110 OWS before comparison.
+//
+// Returns a JSON-RPC error frame on mismatch (caller writes HTTP 400 +
+// the frame as the body). Returns nil when the request passes.
+func validateRoutingHeaders(req *core.Request, headers http.Header) *core.Response {
+	hdrMethod := strings.TrimSpace(headers.Get(mcpMethodHeader))
+	if hdrMethod != req.Method {
+		return headerMismatchResponse(req.ID, mcpMethodHeader, hdrMethod, req.Method)
+	}
+	field, bodyValue, requiresName := extractRoutingName(req)
+	if !requiresName {
+		return nil
+	}
+	hdrName := strings.TrimSpace(headers.Get(mcpNameHeader))
+	if hdrName != bodyValue {
+		return headerMismatchResponse(req.ID, mcpNameHeader, hdrName, bodyValue,
+			"bodyField", field)
+	}
+	return nil
+}
+
+// extractRoutingName reports whether the request's method carries a
+// body-side identifier that `Mcp-Name` must mirror, and returns the
+// expected value. Methods without a name-shaped param leave Mcp-Name
+// validation off — the spec only mandates Mcp-Name for calls with a
+// resource-routable name in the body.
+func extractRoutingName(req *core.Request) (field, value string, ok bool) {
+	switch req.Method {
+	case "tools/call":
+		var p struct {
+			Name string `json:"name"`
+		}
+		if err := json.Unmarshal(req.Params, &p); err != nil {
+			return "name", "", true
+		}
+		return "name", p.Name, true
+	case "resources/read":
+		var p struct {
+			URI string `json:"uri"`
+		}
+		if err := json.Unmarshal(req.Params, &p); err != nil {
+			return "uri", "", true
+		}
+		return "uri", p.URI, true
+	default:
+		return "", "", false
+	}
+}
+
+// writeHeaderMismatch writes an HTTP 400 response carrying the
+// JSON-RPC error frame from validateRoutingHeaders. Per SEP-2243 the
+// status code is MUST (400) and the JSON-RPC error code is SHOULD
+// (-32001); we emit both so the conformance warning checks also flip
+// to SUCCESS.
+func writeHeaderMismatch(w http.ResponseWriter, errResp *core.Response) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadRequest)
+	raw, err := json.Marshal(errResp)
+	if err != nil {
+		// Fall back to a plain JSON shape; should never happen for our
+		// own well-formed Response value, but don't drop the status code.
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":null,"error":{"code":-32001,"message":"header mismatch"}}`))
+		return
+	}
+	_, _ = w.Write(raw)
+}
+
+// headerMismatchResponse builds the JSON-RPC error frame for a SEP-2243
+// routing-header validation failure. The `data` object carries
+// `reason` / `header` / `expected` / `received` so client transports
+// (and humans) can see exactly which header disagreed with what value.
+func headerMismatchResponse(id json.RawMessage, header, received, expected string, extra ...string) *core.Response {
+	reason := fmt.Sprintf("%s header value does not match request body", header)
+	if received == "" {
+		reason = fmt.Sprintf("%s header is required but missing", header)
+	}
+	data := map[string]any{
+		"reason":   reason,
+		"header":   header,
+		"expected": expected,
+		"received": received,
+	}
+	for i := 0; i+1 < len(extra); i += 2 {
+		data[extra[i]] = extra[i+1]
+	}
+	return core.NewErrorResponseWithData(id, core.ErrCodeHeaderMismatch, reason, data)
+}

--- a/server/header_validation_integration_test.go
+++ b/server/header_validation_integration_test.go
@@ -1,0 +1,154 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	core "github.com/panyam/mcpkit/core"
+)
+
+// initDraftSession bootstraps a Streamable HTTP session that negotiated
+// the DRAFT-2026-v1 protocol version, so subsequent POSTs go through
+// the SEP-2243 routing-header gate.
+func initDraftSession(t *testing.T, url string) string {
+	t.Helper()
+	resp, err := streamablePost(url+"/mcp", "", &core.Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  "initialize",
+		Params:  json.RawMessage(`{"protocolVersion":"DRAFT-2026-v1","capabilities":{},"clientInfo":{"name":"draft-test","version":"1.0"}}`),
+	})
+	if err != nil {
+		t.Fatalf("initialize POST failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("initialize status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+	sessionID := resp.Header.Get(mcpSessionIDHeader)
+	if sessionID == "" {
+		t.Fatal("no Mcp-Session-Id header on initialize response")
+	}
+	// Notify initialized with matching Mcp-Method (gate is active on this session)
+	req, _ := http.NewRequest(http.MethodPost, url+"/mcp", bytes.NewReader([]byte(`{"jsonrpc":"2.0","method":"notifications/initialized"}`)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set(mcpSessionIDHeader, sessionID)
+	req.Header.Set("Mcp-Method", "notifications/initialized")
+	r2, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("initialized notification failed: %v", err)
+	}
+	r2.Body.Close()
+	if r2.StatusCode != http.StatusAccepted {
+		t.Fatalf("initialized notification status = %d, want 202", r2.StatusCode)
+	}
+	return sessionID
+}
+
+func postWithHeaders(url, sessionID string, body any, extra map[string]string) (*http.Response, error) {
+	raw, _ := json.Marshal(body)
+	req, _ := http.NewRequest(http.MethodPost, url, bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	if sessionID != "" {
+		req.Header.Set(mcpSessionIDHeader, sessionID)
+	}
+	for k, v := range extra {
+		req.Header.Set(k, v)
+	}
+	return http.DefaultClient.Do(req)
+}
+
+func decodeJSONRPCError(t *testing.T, resp *http.Response) *core.Error {
+	t.Helper()
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	var parsed core.Response
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("decode response body %q: %v", string(body), err)
+	}
+	return parsed.Error
+}
+
+func TestHeaderValidation_DraftSession_RejectsMismatchedMethod(t *testing.T) {
+	ts := testStreamableServer()
+	defer ts.Close()
+	sessionID := initDraftSession(t, ts.URL)
+
+	resp, err := postWithHeaders(ts.URL+"/mcp", sessionID,
+		&core.Request{JSONRPC: "2.0", ID: json.RawMessage(`2`), Method: "tools/list"},
+		map[string]string{"Mcp-Method": "prompts/list"})
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+	if e := decodeJSONRPCError(t, resp); e == nil || e.Code != core.ErrCodeHeaderMismatch {
+		t.Errorf("error code = %+v, want -32001", e)
+	}
+}
+
+func TestHeaderValidation_DraftSession_AcceptsMatchedHeaders(t *testing.T) {
+	ts := testStreamableServer()
+	defer ts.Close()
+	sessionID := initDraftSession(t, ts.URL)
+
+	resp, err := postWithHeaders(ts.URL+"/mcp", sessionID,
+		&core.Request{JSONRPC: "2.0", ID: json.RawMessage(`2`), Method: "tools/list"},
+		map[string]string{"Mcp-Method": "tools/list"})
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+}
+
+func TestHeaderValidation_DatedSession_SkipsValidation(t *testing.T) {
+	ts := testStreamableServer()
+	defer ts.Close()
+	// streamableInit negotiates 2024-11-05 — outside the SEP-2243 enforced set.
+	sessionID := streamableInit(t, ts.URL)
+
+	// Missing Mcp-Method header on a tools/list call. Should NOT trigger
+	// SEP-2243 validation because the negotiated version is dated. The
+	// dispatcher returns a normal tools/list response.
+	resp, err := streamablePost(ts.URL+"/mcp", sessionID,
+		&core.Request{JSONRPC: "2.0", ID: json.RawMessage(`2`), Method: "tools/list"})
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200 (gate should skip dated-version sessions); body: %s", resp.StatusCode, body)
+	}
+}
+
+func TestHeaderValidation_DraftSession_MismatchedToolName(t *testing.T) {
+	ts := testStreamableServer()
+	defer ts.Close()
+	sessionID := initDraftSession(t, ts.URL)
+
+	resp, err := postWithHeaders(ts.URL+"/mcp", sessionID,
+		&core.Request{JSONRPC: "2.0", ID: json.RawMessage(`2`), Method: "tools/call",
+			Params: json.RawMessage(`{"name":"echo","arguments":{"message":"hi"}}`)},
+		map[string]string{"Mcp-Method": "tools/call", "Mcp-Name": "wrong_tool"})
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+	if e := decodeJSONRPCError(t, resp); e == nil || e.Code != core.ErrCodeHeaderMismatch {
+		t.Errorf("error code = %+v, want -32001", e)
+	}
+}

--- a/server/header_validation_test.go
+++ b/server/header_validation_test.go
@@ -1,0 +1,123 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+func makeReq(t *testing.T, method string, params any) *core.Request {
+	t.Helper()
+	r := &core.Request{JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: method}
+	if params != nil {
+		raw, err := json.Marshal(params)
+		if err != nil {
+			t.Fatalf("marshal params: %v", err)
+		}
+		r.Params = raw
+	}
+	return r
+}
+
+func TestValidateRoutingHeaders_MismatchedMethod(t *testing.T) {
+	req := makeReq(t, "tools/list", nil)
+	h := http.Header{}
+	h.Set("Mcp-Method", "prompts/list")
+	resp := validateRoutingHeaders(req, h)
+	if resp == nil || resp.Error == nil || resp.Error.Code != core.ErrCodeHeaderMismatch {
+		t.Fatalf("expected -32001 HeaderMismatch, got %+v", resp)
+	}
+}
+
+func TestValidateRoutingHeaders_MissingMethod(t *testing.T) {
+	req := makeReq(t, "tools/list", nil)
+	h := http.Header{}
+	resp := validateRoutingHeaders(req, h)
+	if resp == nil || resp.Error == nil || resp.Error.Code != core.ErrCodeHeaderMismatch {
+		t.Fatalf("expected -32001 HeaderMismatch, got %+v", resp)
+	}
+}
+
+func TestValidateRoutingHeaders_MismatchedName(t *testing.T) {
+	req := makeReq(t, "tools/call", map[string]any{"name": "greet", "arguments": map[string]any{}})
+	h := http.Header{}
+	h.Set("Mcp-Method", "tools/call")
+	h.Set("Mcp-Name", "wrong_tool")
+	resp := validateRoutingHeaders(req, h)
+	if resp == nil || resp.Error == nil || resp.Error.Code != core.ErrCodeHeaderMismatch {
+		t.Fatalf("expected -32001 HeaderMismatch for name mismatch, got %+v", resp)
+	}
+}
+
+func TestValidateRoutingHeaders_MissingNameWhenBodyHasName(t *testing.T) {
+	req := makeReq(t, "tools/call", map[string]any{"name": "greet", "arguments": map[string]any{}})
+	h := http.Header{}
+	h.Set("Mcp-Method", "tools/call")
+	resp := validateRoutingHeaders(req, h)
+	if resp == nil || resp.Error == nil || resp.Error.Code != core.ErrCodeHeaderMismatch {
+		t.Fatalf("expected -32001 HeaderMismatch for missing Mcp-Name, got %+v", resp)
+	}
+}
+
+func TestValidateRoutingHeaders_CaseSensitiveValue(t *testing.T) {
+	req := makeReq(t, "tools/list", nil)
+	h := http.Header{}
+	h.Set("Mcp-Method", "TOOLS/LIST")
+	resp := validateRoutingHeaders(req, h)
+	if resp == nil || resp.Error == nil || resp.Error.Code != core.ErrCodeHeaderMismatch {
+		t.Fatalf("expected -32001 HeaderMismatch for case-mismatched header value, got %+v", resp)
+	}
+}
+
+func TestValidateRoutingHeaders_OWSStrippedFromName(t *testing.T) {
+	req := makeReq(t, "tools/call", map[string]any{"name": "greet", "arguments": map[string]any{}})
+	h := http.Header{}
+	h.Set("Mcp-Method", "tools/call")
+	h.Set("Mcp-Name", "  greet  ")
+	if resp := validateRoutingHeaders(req, h); resp != nil {
+		t.Fatalf("OWS-trimmed Mcp-Name should validate, got %+v", resp)
+	}
+}
+
+func TestValidateRoutingHeaders_HeaderNameCaseInsensitive(t *testing.T) {
+	req := makeReq(t, "tools/list", nil)
+	for _, name := range []string{"mcp-method", "MCP-METHOD", "Mcp-Method", "mCp-MeThOd"} {
+		h := http.Header{}
+		h.Set(name, "tools/list")
+		if resp := validateRoutingHeaders(req, h); resp != nil {
+			t.Errorf("header name %q should match case-insensitively, got %+v", name, resp)
+		}
+	}
+}
+
+func TestValidateRoutingHeaders_MatchingMethodOnly(t *testing.T) {
+	req := makeReq(t, "tools/list", nil)
+	h := http.Header{}
+	h.Set("Mcp-Method", "tools/list")
+	if resp := validateRoutingHeaders(req, h); resp != nil {
+		t.Fatalf("matching Mcp-Method on no-name method should pass, got %+v", resp)
+	}
+}
+
+func TestValidateRoutingHeaders_MatchingResourcesReadURI(t *testing.T) {
+	req := makeReq(t, "resources/read", map[string]any{"uri": "file:///tmp/foo.txt"})
+	h := http.Header{}
+	h.Set("Mcp-Method", "resources/read")
+	h.Set("Mcp-Name", "file:///tmp/foo.txt")
+	if resp := validateRoutingHeaders(req, h); resp != nil {
+		t.Fatalf("matching Mcp-Name=uri on resources/read should pass, got %+v", resp)
+	}
+}
+
+func TestValidateRoutingHeaders_MismatchedResourcesReadURI(t *testing.T) {
+	req := makeReq(t, "resources/read", map[string]any{"uri": "file:///tmp/foo.txt"})
+	h := http.Header{}
+	h.Set("Mcp-Method", "resources/read")
+	h.Set("Mcp-Name", "file:///tmp/other.txt")
+	resp := validateRoutingHeaders(req, h)
+	if resp == nil || resp.Error == nil || resp.Error.Code != core.ErrCodeHeaderMismatch {
+		t.Fatalf("expected -32001 HeaderMismatch for URI mismatch, got %+v", resp)
+	}
+}

--- a/server/streamable_transport.go
+++ b/server/streamable_transport.go
@@ -281,6 +281,24 @@ func (t *streamableTransport) handlePost(w http.ResponseWriter, r *http.Request)
 	defer entry.idleTimer.Release()
 	dispatcher := entry.dispatcher
 
+	// SEP-2243 §Server Validation: Mcp-Method (always) and Mcp-Name
+	// (when body carries a name-shaped param) MUST match the body, or
+	// the server rejects with HTTP 400 + JSON-RPC -32001.
+	//
+	// Gated on the session's negotiated protocol version because
+	// SEP-2243 lives in DRAFT-2026-v1 only — no dated release imposes
+	// the routing-header contract today, and the SDKs every MCP client
+	// uses (official TS/Python, mcpjam, VS Code, Cursor, ...) do not
+	// emit these headers yet. Validating unconditionally would 400
+	// every existing client. Once SEP-2243 ships in a dated release
+	// the gate can widen to include that version.
+	if isSEP2243EnforcedVersion(dispatcher.negotiatedVersion) {
+		if errResp := validateRoutingHeaders(&req, r.Header); errResp != nil {
+			writeHeaderMismatch(w, errResp)
+			return
+		}
+	}
+
 	// Validate MCP-Protocol-Version if present.
 	// Per spec: "If the server receives a request with an invalid or unsupported
 	// MCP-Protocol-Version, it MUST respond with 400 Bad core.Request."


### PR DESCRIPTION
## What changes

Streamable HTTP POST now validates `Mcp-Method` (and `Mcp-Name` for methods that carry a name-shaped param: `tools/call` → `params.name`, `resources/read` → `params.uri`) against the JSON-RPC body. On mismatch or absence-when-required the server responds with HTTP 400 + JSON-RPC error code `-32001` (`HeaderMismatch`) and bails before dispatch. Per SEP-2243 §Server Validation.

**Gated on the session's negotiated protocol version**: today only `DRAFT-2026-v1` mandates the routing-header contract; no dated release imposes it, and no shipping MCP SDK emits these headers (`@modelcontextprotocol/sdk@1.29.0` doesn't, neither does any client built on it — mcpjam, VS Code Copilot Chat, Cursor, Claude Desktop, etc.). The gate keeps mcpkit servers interop-compatible with the existing ecosystem while making the audit row green for draft-aware clients.

`http-header-validation` (server) flips from `partial (3p/5f/5w)` to `pass (13p)`: all 5 reject sub-cases SUCCESS plus all 5 `sep-2243-server-reject-error-code` warnings SUCCESS (we emit `-32001`, which the warning checks were grading for). Server surface gains +10 pass / -5 fail / -5 warn in `conformance/UPSTREAM_AUDIT.md`.

## Reviewer's guide

Read in this order:

1. [server/header_validation.go](https://github.com/panyam/mcpkit/pull/477/files#diff-5a541595ad85736d66e51215dee6a6479e47188446e5bc9ece9b5a7c5e8a8551) — start here. New file. `validateRoutingHeaders` (pure function returning a `*core.Response` on mismatch or nil on pass) + `writeHeaderMismatch` (HTTP 400 writer) + `isSEP2243EnforcedVersion` (the gate). RFC 9110 OWS trim on header values. ~90 lines.
2. [server/header_validation_test.go](https://github.com/panyam/mcpkit/pull/477/files#diff-3785e69e2a5d588010a4b60a3b02dfaccb248d70e2e78ab89b8f9f6d9e9f61f7) — acceptance for the pure function. 10 unit cases: each of the 5 reject sub-cases, the 3 acceptance-tolerance cases (OWS whitespace, lowercase header name, uppercase header name), plus `resources/read` URI match + mismatch.
3. [server/header_validation_integration_test.go](https://github.com/panyam/mcpkit/pull/477/files#diff-f27d86c33d46bdd403c6598ac85aa22d0704570858e56855b2b44c61bfbefa19) — httptest-driven end-to-end. 4 cases: mismatched method on draft session rejected; matched headers on draft session accepted; dated session (`2024-11-05`) skips the gate entirely; mismatched tool name rejected. The dated-session test is the one that proves we don't break existing MCP clients.
4. [core/jsonrpc.go](https://github.com/panyam/mcpkit/pull/477/files#diff-f9f4f09be0f88717867046128a5e4338f60aaea6764fda9b9a6c95c4089797f4) — adds `ErrCodeHeaderMismatch = -32001` next to the other SEP-defined error codes (`-32003` for SEP-2575 missing-capability, etc.). 4-line addition.
5. [server/streamable_transport.go](https://github.com/panyam/mcpkit/pull/477/files#diff-6d7a7857fa287633c986304e06b224dc7e95a8a8d770430f684717bb7d1543b4) — wire-in in `handlePost` after session lookup, gated on `isSEP2243EnforcedVersion(dispatcher.negotiatedVersion)`. 7 lines including comment.
6. [conformance/UPSTREAM_AUDIT.md](https://github.com/panyam/mcpkit/pull/477/files#diff-bf63f1699e28f43c702f9450df02d9e8ec1dae36200827f929a68513bdb34197) — regenerated snapshot. The `http-header-validation` row flips to `pass`; totals shift accordingly.

Skim or skip: nothing else touched.

## Decision log

- **Draft-gated, not strict-always.** Initial plan considered enforcing unconditionally given mcpkit has no Go-library consumers yet. But mcpkit serves HTTP to **any** MCP client on the network — and no shipping SDK emits these headers today. Strict enforcement would 400 every existing client (mcpjam, VS Code, Cursor, Claude Desktop, official SDKs). The gate matches how the upstream conformance scenario itself is tagged (`source.introducedIn: DRAFT_PROTOCOL_VERSION`).
- **Validator is a pure function.** Takes `*core.Request` + `http.Header`, returns `*core.Response` (nil on pass). Easy to test, no transport coupling.
- **`-32001` is named `ErrCodeHeaderMismatch` in core.** SEP-2243 reserves the code; placing the constant in `core/jsonrpc.go` keeps it next to the other SEP-defined codes and avoids "is -32001 used anywhere?" cross-package searches.
- **`Mcp-Name` only required for `tools/call` and `resources/read`.** Those are the methods the upstream scenario exercises. Other methods that may carry name-shaped params (`prompts/get`, etc.) aren't in the scenario; I left a method-switch in the validator so adding them is a one-liner if a future SEP-2243 sub-case lands.
- **Header VALUES case-sensitive; NAMES case-insensitive.** Go's `http.Header.Get` already normalizes header NAMES via `textproto.CanonicalMIMEHeaderKey`, so the lowercase/uppercase header-name acceptance checks pass for free.
- **RFC 9110 OWS trimming.** The validator calls `strings.TrimSpace` on header values before comparison. This is what the spec mandates and matches the conformance scenario's whitespace acceptance check.

## Risk / blast radius

- **Backcompat protected by the version gate.** Existing clients on `2025-11-25` and earlier are unaffected; their sessions never enter the validation block. Confirmed by `TestHeaderValidation_DatedSession_SkipsValidation` which negotiates `2024-11-05` and verifies a header-less `tools/list` succeeds.
- **Initialize requests are not validated.** `handlePost` routes `initialize` to `handleInitialize` before the session lookup, so the validation block (which runs after session lookup) never sees the initialize body. This is intentional — the negotiated version doesn't exist yet at initialize time.
- **Stateless mode not validated.** The stateless code path doesn't go through session lookup either; no scenario currently exercises SEP-2243 in stateless mode. Easy to add when SEP-2575 work surfaces a need.
- **When SEP-2243 ships in a dated release.** `sep2243EnforcedVersions` in `header_validation.go` is the single point to widen. One-line addition; matches the audit's grading once the SEPs land.
- **Be paranoid about:** the body re-parse cost. The validator extracts `params.name` / `params.uri` via a typed `json.Unmarshal` against a one-field struct, so it's one allocation per request on draft sessions. Measurable but negligible at any realistic call rate.

## Before / after

```
Before: | `http-header-validation` | server | partial | 3 pass / 5 fail / 5 warn |
After:  | `http-header-validation` | server | pass    | 13 pass                  |

Server: 51 | 126 | 56 → 66 pass | 43 → 38 fail | 12 → 7 warn | 6 info | 9 skipped | 0 harness-gap
Total:  91 | 1367 | 503 → 513 pass | 68 → 63 fail | 16 → 11 warn | ...
```

Specific sub-checks that flip from FAILURE / WARNING to SUCCESS:
- `sep-2243-server-reject-invalid-headers` × 5 (mismatch method / missing method / mismatch name / missing name / case-mismatch value)
- `sep-2243-server-reject-error-code` × 5 (same 5 cases — we emit `-32001`, so the warning checks pass)

## Out of scope (deliberately deferred)

- **Strict enforcement on dated-version sessions.** Wait until SEP-2243 lands in a dated MCP spec release and the major client SDKs ship with header emission. At that point widen `sep2243EnforcedVersions` and the test matrix.
- **Stateless-mode validation.** No conformance scenario exercises it; add when SEP-2575 work makes stateless a first-class path.
- **`prompts/get`, other name-shaped methods.** Not in the current SEP-2243 conformance scenario. Trivial to add to the validator's method-switch when upstream extends coverage.
- **Client-side header emission.** mcpkit's own Go client doesn't emit Mcp-Method / Mcp-Name today; it'll need to once it starts negotiating `DRAFT-2026-v1`. Tracked separately if/when that becomes necessary; today the Go client doesn't negotiate draft.

## Related work

- Umbrella issue 439 — Tier 1/2 conformance audit gaps.
- PR 463 — SEP-2243 client-side custom-header serialization (the response-side mirror of this PR's request-side validation).
