### PR TITLE
fix(stateless): honor SEP-2663 tasks extension on the stateless wire (480)

### DIFF
--- a/ext/tasks/stateless_wire_test.go
+++ b/ext/tasks/stateless_wire_test.go
@@ -1,0 +1,446 @@
+package tasks_test
+
+// SEP-2575 stateless-wire end-to-end tests for the SEP-2663 tasks extension.
+// Each test POSTs a raw stateless-shaped request to a Dual-mode Streamable
+// HTTP server with tasks.Register installed, and asserts the response shape
+// matches what the v2-on-stateless conformance scenarios expect.
+//
+// Issue: panyam/mcpkit#480.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	core "github.com/panyam/mcpkit/core"
+	tasks "github.com/panyam/mcpkit/ext/tasks"
+	server "github.com/panyam/mcpkit/server"
+)
+
+const statelessDraftVersion = "DRAFT-2026-v1"
+
+// newStatelessTaskServer registers a server that intentionally covers the
+// scenarios the conformance fork's stateless-mode run exercises:
+//
+//   - slow_compute    — TaskSupport=optional
+//   - failing_job     — TaskSupport=required (returns a tool error after a beat)
+//   - confirm_delete  — TaskSupport=required, calls TaskElicit → input_required
+//
+// Wraps in an httptest server with the default ModeDual; stateless-shaped
+// POSTs route through the SEP-2575 dispatcher.
+func newStatelessTaskServer(t *testing.T) string {
+	t.Helper()
+
+	srv := server.NewServer(core.ServerInfo{Name: "stateless-tasks-test", Version: "0.0.1"})
+
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "slow_compute",
+			Description: "optional task support",
+			InputSchema: map[string]any{"type": "object"},
+			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
+		},
+		func(ctx core.ToolContext, _ core.ToolRequest) (core.ToolResult, error) {
+			return core.TextResult("done"), nil
+		},
+	)
+
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "failing_job",
+			Description: "required task support",
+			InputSchema: map[string]any{"type": "object"},
+			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportRequired},
+		},
+		func(ctx core.ToolContext, _ core.ToolRequest) (core.ToolResult, error) {
+			return core.ToolResult{}, errors.New("planned failure")
+		},
+	)
+
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "confirm_delete",
+			Description: "required task with elicitation",
+			InputSchema: map[string]any{"type": "object"},
+			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportRequired},
+		},
+		func(ctx core.ToolContext, _ core.ToolRequest) (core.ToolResult, error) {
+			tc := tasks.GetTaskContext(ctx)
+			if tc == nil {
+				return core.ToolResult{}, errors.New("no task ctx")
+			}
+			res, err := tc.TaskElicit(core.ElicitationRequest{
+				Message:         "delete?",
+				RequestedSchema: json.RawMessage(`{"type":"object","properties":{"confirm":{"type":"boolean"}}}`),
+			})
+			if err != nil {
+				return core.ToolResult{}, err
+			}
+			if res.Action == "accept" {
+				if ok, _ := res.Content["confirm"].(bool); ok {
+					return core.TextResult("deleted"), nil
+				}
+			}
+			return core.TextResult("kept"), nil
+		},
+	)
+
+	tasks.Register(tasks.Config{Server: srv, DefaultPollMs: 50})
+
+	ts := httptest.NewServer(srv.Handler(server.WithStreamableHTTP(true)))
+	t.Cleanup(ts.Close)
+	return ts.URL + "/mcp"
+}
+
+// metaWithCaps builds an _meta envelope optionally declaring the tasks
+// extension via per-request clientCapabilities (SEP-2575).
+func metaWithCaps(withTasks bool) map[string]any {
+	caps := map[string]any{}
+	if withTasks {
+		caps["extensions"] = map[string]any{
+			core.TasksExtensionID: map[string]any{},
+		}
+	}
+	return map[string]any{
+		"io.modelcontextprotocol/protocolVersion":    statelessDraftVersion,
+		"io.modelcontextprotocol/clientInfo":         map[string]any{"name": "stateless-task-test", "version": "1"},
+		"io.modelcontextprotocol/clientCapabilities": caps,
+	}
+}
+
+// postStatelessRPC sends one JSON-RPC request over the stateless wire and
+// returns the decoded *core.Response.
+func postStatelessRPC(t *testing.T, url string, id int, method string, params map[string]any) *core.Response {
+	t.Helper()
+
+	body, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"method":  method,
+		"params":  params,
+	})
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), "POST", url, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", core.StreamableHTTPAccept)
+	req.Header.Set("MCP-Protocol-Version", statelessDraftVersion)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("http do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	payload := bytes.TrimSpace(raw)
+	if idx := bytes.Index(payload, []byte("data:")); idx >= 0 {
+		payload = bytes.TrimSpace(payload[idx+len("data:"):])
+	}
+
+	var out core.Response
+	if err := json.Unmarshal(payload, &out); err != nil {
+		t.Fatalf("decode response (%d bytes, status %d): %v\n%s", len(raw), resp.StatusCode, err, string(raw))
+	}
+	return &out
+}
+
+// TestStateless_ToolsCall_OptionalTask_WithExtension covers
+// `tasks-capability-negotiation::tasks-per-request-meta-opt-in` from the fork:
+// a client that declares the tasks extension only via per-request _meta must
+// receive `resultType: "task"` for a TaskSupport=optional tool.
+func TestStateless_ToolsCall_OptionalTask_WithExtension(t *testing.T) {
+	url := newStatelessTaskServer(t)
+
+	resp := postStatelessRPC(t, url, 1, "tools/call", map[string]any{
+		"name":      "slow_compute",
+		"arguments": map[string]any{},
+		"_meta":     metaWithCaps(true),
+	})
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %+v", resp.Error)
+	}
+
+	raw, _ := json.Marshal(resp.Result)
+	var got core.CreateTaskResult
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("decode CreateTaskResult: %v\n%s", err, string(raw))
+	}
+	if got.ResultType != core.ResultTypeTask {
+		t.Fatalf("resultType = %q, want %q (sync fall-through happened; per-request caps not honored)", got.ResultType, core.ResultTypeTask)
+	}
+	if got.TaskID == "" {
+		t.Errorf("CreateTaskResult.taskId is empty")
+	}
+	if got.TTLMs == nil {
+		t.Errorf("CreateTaskResult.ttlMs is nil; spec requires the renamed field")
+	}
+}
+
+// TestStateless_ToolsCall_OptionalTask_NoExtension verifies the SEP-2663
+// fall-through: a TaskSupport=optional tool called without the tasks
+// extension declared returns a synchronous ToolResult, not -32003.
+func TestStateless_ToolsCall_OptionalTask_NoExtension(t *testing.T) {
+	url := newStatelessTaskServer(t)
+
+	resp := postStatelessRPC(t, url, 1, "tools/call", map[string]any{
+		"name":      "slow_compute",
+		"arguments": map[string]any{},
+		"_meta":     metaWithCaps(false),
+	})
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %+v", resp.Error)
+	}
+	raw, _ := json.Marshal(resp.Result)
+	var got core.ToolResult
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("decode sync ToolResult: %v\n%s", err, string(raw))
+	}
+	if len(got.Content) == 0 || got.Content[0].Text != "done" {
+		t.Errorf("sync content mismatch: %+v", got)
+	}
+}
+
+// TestStateless_ToolsCall_RequiredTask_NoExtension covers
+// `tasks-required-task-error`: TaskSupport=required without the extension
+// declared MUST return -32003 with structured requiredCapabilities.
+func TestStateless_ToolsCall_RequiredTask_NoExtension(t *testing.T) {
+	url := newStatelessTaskServer(t)
+
+	resp := postStatelessRPC(t, url, 1, "tools/call", map[string]any{
+		"name":      "failing_job",
+		"arguments": map[string]any{},
+		"_meta":     metaWithCaps(false),
+	})
+	if resp.Error == nil {
+		t.Fatalf("expected -32003, got success: %+v", resp.Result)
+	}
+	if resp.Error.Code != core.ErrCodeMissingRequiredClientCapability {
+		t.Fatalf("error code = %d, want %d (-32003); body=%+v",
+			resp.Error.Code, core.ErrCodeMissingRequiredClientCapability, resp.Error)
+	}
+
+	dataRaw, _ := json.Marshal(resp.Error.Data)
+	var data struct {
+		RequiredCapabilities struct {
+			Extensions map[string]any `json:"extensions"`
+		} `json:"requiredCapabilities"`
+	}
+	if err := json.Unmarshal(dataRaw, &data); err != nil {
+		t.Fatalf("decode error.data: %v", err)
+	}
+	if _, ok := data.RequiredCapabilities.Extensions[core.TasksExtensionID]; !ok {
+		t.Errorf("requiredCapabilities.extensions missing %q; got %+v",
+			core.TasksExtensionID, data.RequiredCapabilities.Extensions)
+	}
+}
+
+// TestStateless_TasksGet_NoExtension covers
+// `tasks-methods-gated-without-extension`: tasks/get on the stateless wire
+// without the per-request extension declaration MUST return -32003 (not
+// -32601 "method not found", which is what an unrouted method emits).
+func TestStateless_TasksGet_NoExtension(t *testing.T) {
+	url := newStatelessTaskServer(t)
+
+	resp := postStatelessRPC(t, url, 1, "tasks/get", map[string]any{
+		"taskId": "nonexistent",
+		"_meta":  metaWithCaps(false),
+	})
+	if resp.Error == nil {
+		t.Fatalf("expected -32003, got success: %+v", resp.Result)
+	}
+	if resp.Error.Code != core.ErrCodeMissingRequiredClientCapability {
+		t.Fatalf("error code = %d, want %d (-32003); body=%+v",
+			resp.Error.Code, core.ErrCodeMissingRequiredClientCapability, resp.Error)
+	}
+}
+
+// TestStateless_TasksUpdate_NoExtension is the tasks/update sibling of the
+// gating check.
+func TestStateless_TasksUpdate_NoExtension(t *testing.T) {
+	url := newStatelessTaskServer(t)
+
+	resp := postStatelessRPC(t, url, 1, "tasks/update", map[string]any{
+		"taskId":         "nonexistent",
+		"inputResponses": map[string]any{},
+		"_meta":          metaWithCaps(false),
+	})
+	if resp.Error == nil {
+		t.Fatalf("expected -32003, got success: %+v", resp.Result)
+	}
+	if resp.Error.Code != core.ErrCodeMissingRequiredClientCapability {
+		t.Fatalf("error code = %d, want %d (-32003); body=%+v",
+			resp.Error.Code, core.ErrCodeMissingRequiredClientCapability, resp.Error)
+	}
+}
+
+// TestStateless_TasksCancel_NoExtension is the tasks/cancel sibling.
+func TestStateless_TasksCancel_NoExtension(t *testing.T) {
+	url := newStatelessTaskServer(t)
+
+	resp := postStatelessRPC(t, url, 1, "tasks/cancel", map[string]any{
+		"taskId": "nonexistent",
+		"_meta":  metaWithCaps(false),
+	})
+	if resp.Error == nil {
+		t.Fatalf("expected -32003, got success: %+v", resp.Result)
+	}
+	if resp.Error.Code != core.ErrCodeMissingRequiredClientCapability {
+		t.Fatalf("error code = %d, want %d (-32003); body=%+v",
+			resp.Error.Code, core.ErrCodeMissingRequiredClientCapability, resp.Error)
+	}
+}
+
+// TestStateless_TasksLifecycle covers `tasks-lifecycle`,
+// `tasks-dispatch-and-envelope`, and `tasks-wire-field-renames` together:
+// create a task, poll tasks/get with the extension declared until terminal,
+// confirm the inlined result + ttlMs wire field.
+func TestStateless_TasksLifecycle(t *testing.T) {
+	url := newStatelessTaskServer(t)
+
+	created := postStatelessRPC(t, url, 1, "tools/call", map[string]any{
+		"name":      "slow_compute",
+		"arguments": map[string]any{},
+		"_meta":     metaWithCaps(true),
+	})
+	if created.Error != nil {
+		t.Fatalf("create task: %+v", created.Error)
+	}
+	raw, _ := json.Marshal(created.Result)
+	var ct core.CreateTaskResult
+	if err := json.Unmarshal(raw, &ct); err != nil {
+		t.Fatalf("decode CreateTaskResult: %v", err)
+	}
+	if ct.TaskID == "" {
+		t.Fatalf("no taskId on CreateTaskResult: %+v", ct)
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	var final core.DetailedTask
+	for time.Now().Before(deadline) {
+		resp := postStatelessRPC(t, url, 2, "tasks/get", map[string]any{
+			"taskId": ct.TaskID,
+			"_meta":  metaWithCaps(true),
+		})
+		if resp.Error != nil {
+			t.Fatalf("tasks/get: %+v", resp.Error)
+		}
+		raw, _ := json.Marshal(resp.Result)
+		var dt core.DetailedTask
+		if err := json.Unmarshal(raw, &dt); err != nil {
+			t.Fatalf("decode DetailedTask: %v\n%s", err, string(raw))
+		}
+		if dt.Status == core.TaskCompleted || dt.Status == core.TaskFailed || dt.Status == core.TaskCancelled {
+			final = dt
+			break
+		}
+		time.Sleep(40 * time.Millisecond)
+	}
+
+	if final.Status != core.TaskCompleted {
+		t.Fatalf("status = %q, want completed (lifecycle never terminated)", final.Status)
+	}
+	if final.Result == nil || len(final.Result.Content) == 0 || final.Result.Content[0].Text != "done" {
+		t.Errorf("inlined result mismatch: %+v", final.Result)
+	}
+}
+
+// TestStateless_TasksMRTR covers `tasks-mrtr-input`: a TaskElicit call parks
+// the task in input_required, tasks/update delivers the response, and the
+// task transitions to completed. All over the stateless wire.
+func TestStateless_TasksMRTR(t *testing.T) {
+	url := newStatelessTaskServer(t)
+
+	created := postStatelessRPC(t, url, 1, "tools/call", map[string]any{
+		"name":      "confirm_delete",
+		"arguments": map[string]any{},
+		"_meta":     metaWithCaps(true),
+	})
+	if created.Error != nil {
+		t.Fatalf("create task: %+v", created.Error)
+	}
+	raw, _ := json.Marshal(created.Result)
+	var ct core.CreateTaskResult
+	if err := json.Unmarshal(raw, &ct); err != nil {
+		t.Fatalf("decode CreateTaskResult: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	var inputKey string
+	for time.Now().Before(deadline) {
+		resp := postStatelessRPC(t, url, 2, "tasks/get", map[string]any{
+			"taskId": ct.TaskID,
+			"_meta":  metaWithCaps(true),
+		})
+		if resp.Error != nil {
+			t.Fatalf("tasks/get: %+v", resp.Error)
+		}
+		raw, _ := json.Marshal(resp.Result)
+		var dt core.DetailedTask
+		if err := json.Unmarshal(raw, &dt); err != nil {
+			t.Fatalf("decode DetailedTask: %v", err)
+		}
+		if dt.Status == core.TaskInputRequired && len(dt.InputRequests) > 0 {
+			for k := range dt.InputRequests {
+				inputKey = k
+				break
+			}
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if inputKey == "" {
+		t.Fatal("task never surfaced input_required with an inputRequest key")
+	}
+
+	updateResp := postStatelessRPC(t, url, 3, "tasks/update", map[string]any{
+		"taskId": ct.TaskID,
+		"inputResponses": map[string]any{
+			inputKey: map[string]any{
+				"action":  "accept",
+				"content": map[string]any{"confirm": true},
+			},
+		},
+		"_meta": metaWithCaps(true),
+	})
+	if updateResp.Error != nil {
+		t.Fatalf("tasks/update: %+v", updateResp.Error)
+	}
+
+	deadline = time.Now().Add(2 * time.Second)
+	var final core.DetailedTask
+	for time.Now().Before(deadline) {
+		resp := postStatelessRPC(t, url, 4, "tasks/get", map[string]any{
+			"taskId": ct.TaskID,
+			"_meta":  metaWithCaps(true),
+		})
+		raw, _ := json.Marshal(resp.Result)
+		var dt core.DetailedTask
+		_ = json.Unmarshal(raw, &dt)
+		if dt.Status == core.TaskCompleted || dt.Status == core.TaskFailed {
+			final = dt
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if final.Status != core.TaskCompleted {
+		t.Fatalf("after tasks/update, status = %q, want completed", final.Status)
+	}
+	if final.Result == nil || len(final.Result.Content) == 0 || final.Result.Content[0].Text != "deleted" {
+		t.Errorf("expected deleted result, got %+v", final.Result)
+	}
+}

--- a/ext/tasks/tasks.go
+++ b/ext/tasks/tasks.go
@@ -304,9 +304,27 @@ func Register(cfg Config) {
 // handler's response. The error data carries the same `requiredCapabilities`
 // shape the required-task middleware emits, so a client that hits the
 // gate can self-describe what to add and retry.
+//
+// Capability sourcing is two-layered: session-level declaration (legacy
+// initialize handshake) OR per-request _meta.io.modelcontextprotocol/
+// clientCapabilities override (SEP-2575 stateless wire). The latter is the
+// only path available on the stateless wire — there is no initialize
+// handshake to seed session caps from — so without it tasks/* would always
+// emit -32003 on the stateless wire even when the client did declare the
+// extension per-request.
 func gateOnTasksExtension(inner server.MethodHandler) server.MethodHandler {
 	return func(ctx core.MethodContext, id json.RawMessage, params json.RawMessage) *core.Response {
-		if !ctx.ClientSupportsExtension(core.TasksExtensionID) {
+		var envelope struct {
+			Meta *struct {
+				ClientCapabilitiesRaw json.RawMessage `json:"io.modelcontextprotocol/clientCapabilities,omitempty"`
+			} `json:"_meta,omitempty"`
+		}
+		var perRequestCapsRaw json.RawMessage
+		if err := json.Unmarshal(params, &envelope); err == nil && envelope.Meta != nil {
+			perRequestCapsRaw = envelope.Meta.ClientCapabilitiesRaw
+		}
+
+		if !core.ClientSupportsExtensionForRequest(ctx, core.TasksExtensionID, perRequestCapsRaw) {
 			return core.NewErrorResponseWithData(
 				id,
 				core.ErrCodeMissingRequiredClientCapability,

--- a/server/stateless/backend.go
+++ b/server/stateless/backend.go
@@ -1,6 +1,8 @@
 package stateless
 
 import (
+	"context"
+
 	core "github.com/panyam/mcpkit/core"
 )
 
@@ -60,4 +62,21 @@ type Backend interface {
 	// to every list response. A nil *int / empty string omits the field.
 	ListTTLMs() *int
 	ListCacheScope() string
+
+	// InvokeWithMiddleware runs the server's middleware chain around
+	// invoking the given request, returning the JSON-RPC response.
+	//
+	// Used by the stateless dispatcher for methods that must traverse
+	// server-level middleware on the stateless wire — SEP-2663 tools/call
+	// (so taskV2Middleware fires) and tasks/get|update|cancel (registered
+	// via Server.HandleMethod). Without this seam, extensions installed
+	// via Server.UseMiddleware / HandleMethod would be invisible to the
+	// stateless dispatcher.
+	//
+	// Returns (response, true) when the backend handled the request; the
+	// dispatcher uses that response verbatim. Returns (nil, false) to let
+	// the dispatcher fall back to its built-in per-method handler — used
+	// by minimal test fakes that don't carry middleware or custom-method
+	// registrations.
+	InvokeWithMiddleware(ctx context.Context, req *core.Request) (*core.Response, bool)
 }

--- a/server/stateless/dispatch.go
+++ b/server/stateless/dispatch.go
@@ -123,6 +123,29 @@ func (d *Dispatcher) Dispatch(ctx context.Context, req *core.Request) *core.Resp
 		return d.handlePromptsGet(ctx, id, req.Params)
 	case "completion/complete":
 		return d.handleCompletionComplete(ctx, id, req.Params)
+	case "tasks/get", "tasks/update", "tasks/cancel":
+		// SEP-2663 tasks extension methods. Routing goes through the
+		// backend's middleware-aware path so:
+		//   - extension capability gating (handler emits -32003 if the
+		//     per-request _meta.io.modelcontextprotocol/clientCapabilities
+		//     omits the extension declaration), and
+		//   - any server-level middleware (auth, logging, future extensions)
+		//     applies on the stateless wire too.
+		//
+		// Backends without middleware support (test fakes) fall through
+		// to -32601 below — which mirrors the legacy "method not found"
+		// for the same scenario.
+		out := &core.Request{
+			JSONRPC: "2.0",
+			ID:      id,
+			Method:  req.Method,
+			Params:  req.Params,
+		}
+		if resp, ok := d.Backend.InvokeWithMiddleware(ctx, out); ok {
+			return resp
+		}
+		return core.NewErrorResponse(id, core.ErrCodeMethodNotFound,
+			"method not found: "+req.Method)
 	default:
 		return core.NewErrorResponse(id, core.ErrCodeMethodNotFound,
 			"method not found: "+req.Method)

--- a/server/stateless/dispatch_test.go
+++ b/server/stateless/dispatch_test.go
@@ -51,6 +51,14 @@ func (f *fakeBackend) Completion(string, string) (core.CompletionHandler, bool) 
 func (f *fakeBackend) ListTTLMs() *int                                          { return f.ttlMs }
 func (f *fakeBackend) ListCacheScope() string                                   { return f.scope }
 
+// InvokeWithMiddleware returns (nil, false) so the dispatcher falls back
+// to its built-in per-method handler. The fake doesn't model server-level
+// middleware or custom-method registrations — both belong to production
+// statelessBackend (server package).
+func (f *fakeBackend) InvokeWithMiddleware(context.Context, *core.Request) (*core.Response, bool) {
+	return nil, false
+}
+
 // validMetaParams is a params blob with the minimum valid _meta envelope.
 func validMetaParams(t *testing.T) json.RawMessage {
 	t.Helper()

--- a/server/stateless/handlers.go
+++ b/server/stateless/handlers.go
@@ -43,6 +43,22 @@ type toolsCallEnvelope struct {
 }
 
 func (d *Dispatcher) handleToolsCall(ctx context.Context, id json.RawMessage, params json.RawMessage) *core.Response {
+	// Prefer the middleware-aware path so server-level middleware (notably
+	// the v2 task middleware from ext/tasks) fires on the stateless wire
+	// just like it does on the legacy wire. Backends that don't carry
+	// middleware (test fakes) return ok=false and we fall back to direct
+	// invocation below.
+	req := &core.Request{
+		JSONRPC: "2.0",
+		ID:      id,
+		Method:  "tools/call",
+		Params:  params,
+	}
+	if resp, ok := d.Backend.InvokeWithMiddleware(ctx, req); ok {
+		return resp
+	}
+
+	// Fallback path: no middleware support on this backend.
 	var env toolsCallEnvelope
 	if err := json.Unmarshal(params, &env); err != nil {
 		return core.NewErrorResponse(id, core.ErrCodeInvalidParams,

--- a/server/stateless_backend.go
+++ b/server/stateless_backend.go
@@ -1,6 +1,11 @@
 package server
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
 	core "github.com/panyam/mcpkit/core"
 	"github.com/panyam/mcpkit/server/stateless"
 )
@@ -207,4 +212,102 @@ func (b *statelessBackend) ListTTLMs() *int {
 // ListCacheScope returns the SEP-2549 cacheScope hint applied to list responses.
 func (b *statelessBackend) ListCacheScope() string {
 	return b.s.options.listCacheScope
+}
+
+// InvokeWithMiddleware runs the server's middleware chain (s.options.middleware)
+// around a terminal handler that dispatches by method:
+//
+//   - "tools/call" → look up the registered tool, invoke it, translate
+//     *core.MissingCapabilityError into a SEP-2575 -32003 response.
+//   - any other method → consult s.dispatcher.customHandlers (the map populated
+//     by Server.HandleMethod, used by tasks.Register for tasks/get|update|cancel).
+//     Returns -32601 when no handler is registered for the method.
+//
+// The middleware chain matters because the v2 tasks extension installs
+// taskV2Middleware via Server.UseMiddleware; without traversing that chain
+// the stateless wire's tools/call would never produce a CreateTaskResult.
+//
+// Background goroutines spawned from middleware (e.g., the v2 task runner)
+// have no session-level notify path on the stateless wire — there's no
+// persistent GET SSE stream to push notifications onto. notifications/tasks
+// emissions silently drop, which matches the SEP-2575 design (no server-
+// initiated push); clients observe state via tasks/get polling.
+//
+// All stateless task store entries currently key under sessionID=""
+// (no session). This means stateless tasks share one bucket per process,
+// which is acceptable for the single-tenant fixtures the conformance
+// suite covers; multi-tenant deployments should layer an auth-subject-
+// keyed store wrapper. Tracked for a follow-up.
+func (b *statelessBackend) InvokeWithMiddleware(ctx context.Context, req *core.Request) (*core.Response, bool) {
+	terminal := MiddlewareFunc(func(ctx context.Context, req *core.Request) (*core.Response, error) {
+		switch req.Method {
+		case "tools/call":
+			return b.callToolForStateless(ctx, req), nil
+		default:
+			if h, ok := b.s.dispatcher.customHandlers[req.Method]; ok {
+				return h(core.NewMethodContext(ctx), req.ID, req.Params), nil
+			}
+			return core.NewErrorResponse(req.ID, core.ErrCodeMethodNotFound,
+				"method not found: "+req.Method), nil
+		}
+	})
+
+	handler := terminal
+	for i := len(b.s.options.middleware) - 1; i >= 0; i-- {
+		next := handler
+		mw := b.s.options.middleware[i]
+		handler = func(ctx context.Context, req *core.Request) (*core.Response, error) {
+			return mw(ctx, req, next)
+		}
+	}
+
+	resp, err := handler(ctx, req)
+	if err != nil {
+		return core.NewErrorResponse(req.ID, core.ErrCodeInternal, err.Error()), true
+	}
+	return resp, true
+}
+
+// callToolForStateless replicates the decode → look-up → invoke → translate
+// flow that stateless.handleToolsCall used to do directly. Kept here so the
+// stateless dispatcher's per-method file stays thin and the middleware-aware
+// path lives next to the rest of the Backend impl.
+func (b *statelessBackend) callToolForStateless(ctx context.Context, req *core.Request) *core.Response {
+	var env struct {
+		Name      string          `json:"name"`
+		Arguments json.RawMessage `json:"arguments,omitempty"`
+	}
+	if err := json.Unmarshal(req.Params, &env); err != nil {
+		return core.NewErrorResponse(req.ID, core.ErrCodeInvalidParams,
+			"invalid tools/call params: "+err.Error())
+	}
+	_, handler, ok := b.Tool(env.Name)
+	if !ok {
+		return core.NewErrorResponse(req.ID, core.ErrCodeInvalidParams,
+			"unknown tool: "+env.Name)
+	}
+	result, err := handler(core.NewToolContext(ctx), core.ToolRequest{
+		Name:      env.Name,
+		Arguments: env.Arguments,
+	})
+	if err != nil {
+		var missing *core.MissingCapabilityError
+		if errors.As(err, &missing) {
+			return core.NewErrorResponseWithData(
+				req.ID,
+				core.ErrCodeMissingRequiredClientCapability,
+				missing.Error(),
+				core.MissingRequiredClientCapabilityData{
+					RequiredCapabilities: missing.Required,
+				},
+			)
+		}
+		// Plain handler error becomes isError content in a SUCCESS JSON-RPC
+		// response, matching the legacy dispatch path (server/dispatch.go
+		// handleToolsCall). For SEP-2663 task-creating calls this is load-
+		// bearing: the v2 task middleware sees resp.Error == nil and stores
+		// the task as `completed` with isError, per spec — not as `failed`.
+		result = core.ErrorResult(fmt.Sprintf("tool %q: %v", env.Name, err))
+	}
+	return core.NewResponse(req.ID, result)
 }

--- a/server/stateless_detect.go
+++ b/server/stateless_detect.go
@@ -40,11 +40,17 @@ func (k wireKind) String() string {
 //	1. Method == initialize / notifications/initialized → legacy
 //	   (these methods don't exist on stateless)
 //	2. Method == server/discover → stateless (doesn't exist on legacy)
-//	3. MCP-Protocol-Version HTTP header present with value in
-//	   core.SupportedStatelessVersions → stateless
-//	4. params._meta protocolVersion present → stateless
-//	5. Mcp-Session-Id HTTP header present → legacy (mid-session call)
-//	6. Otherwise → legacy under Dual mode (backward compat)
+//	3. params._meta protocolVersion present → stateless
+//	4. Mcp-Session-Id HTTP header present → legacy (mid-session call)
+//	5. Otherwise → legacy under Dual mode (backward compat)
+//
+// The HTTP MCP-Protocol-Version header is intentionally NOT a wire
+// signal: per the MCP 2025-11-25 transport spec it's a universal
+// post-initialize requirement on every HTTP request regardless of
+// wire, so its presence discriminates nothing. The header is still
+// cross-checked against _meta.protocolVersion on requests already
+// routed to stateless (see statelessVersionMismatch) — that's a
+// value check, not a routing decision.
 //
 // Pure-Stateless and Pure-Legacy modes short-circuit: an incoming
 // shape that doesn't match the configured mode still routes to that
@@ -72,29 +78,20 @@ func detectWireKind(r *http.Request, body []byte, req *core.Request, mode statel
 		return wireStateless
 	}
 
-	// Signal 3: MCP-Protocol-Version HTTP header naming a stateless version.
-	if hdr := r.Header.Get(mcpProtocolVersionHeader); hdr != "" {
-		for _, sv := range core.SupportedStatelessVersions {
-			if hdr == sv {
-				return wireStateless
-			}
-		}
-	}
-
-	// Signal 4: params._meta carries a protocolVersion (stateless envelope).
+	// Signal 3: params._meta carries a protocolVersion (stateless envelope).
 	if hasStatelessMetaProtocolVersion(req.Params) {
 		return wireStateless
 	}
 
-	// Signal 5: legacy session id present.
+	// Signal 4: legacy session id present.
 	if r.Header.Get(mcpSessionIDHeader) != "" {
 		return wireLegacy
 	}
 
-	// Signal 6: Dual default — fall back to legacy for backward compat.
-	// A stateless client that forgot all of MCP-Protocol-Version,
-	// _meta, and server/discover will surface as a legacy-shaped
-	// missing-session error, which is the right "wake up" signal.
+	// Signal 5: Dual default — fall back to legacy for backward compat.
+	// A stateless client that forgot both _meta and server/discover
+	// will surface as a legacy-shaped missing-session error, which is
+	// the right "wake up" signal.
 	return wireLegacy
 }
 

--- a/server/streamable_stateless.go
+++ b/server/streamable_stateless.go
@@ -44,6 +44,21 @@ func (t *streamableTransport) handleStatelessPost(w http.ResponseWriter, r *http
 		}
 	}
 
+	// (1b) SEP-2243 routing-header validation. The stateless wire only
+	// speaks DRAFT-2026-v1 (the version that adopted SEP-2243), so any
+	// Mcp-Method / Mcp-Name a client does send MUST agree with the body.
+	// Lenient on absent headers — keeps clients that haven't adopted
+	// SEP-2243 yet working — strict on mismatched values, which is what
+	// the conformance suite locks. Header *presence* without a match
+	// surfaces -32001 via headerMismatchResponse with the diagnostic
+	// `data` payload (header, expected, received).
+	if r.Header.Get(mcpMethodHeader) != "" {
+		if errResp := validateRoutingHeaders(req, r.Header); errResp != nil {
+			writeHeaderMismatch(w, errResp)
+			return
+		}
+	}
+
 	// (2) Dispatch. ResponseHeaderCollector lets handlers stage
 	// transport-level headers (SEP-2243 Mcp-Name etc.) the same way
 	// the legacy path does.

--- a/server/streamable_stateless_test.go
+++ b/server/streamable_stateless_test.go
@@ -150,8 +150,10 @@ func TestStatelessRouting_DualMode_RemovedMethodReturns404(t *testing.T) {
 	_, url, teardown := newStatelessTestServer(t, stateless.ModeDual)
 	defer teardown()
 
-	// Force the stateless path via the header even though the method
-	// itself is "ping" (which is legacy-only). Detection rule 3 wins.
+	// Force the stateless path via the body _meta envelope even though
+	// the method itself is "ping" (which is legacy-only). Signal 3
+	// (_meta.protocolVersion present) routes to stateless; the
+	// dispatcher then -32601s because "ping" isn't a stateless method.
 	resp := postStatelessJSON(t, url, map[string]any{
 		"jsonrpc": "2.0", "id": 1, "method": "ping",
 		"params": validMetaParams(),
@@ -318,11 +320,16 @@ func TestStatelessRouting_DetectionPriorities(t *testing.T) {
 		{"initialize → legacy regardless of stateless header",
 			"initialize", map[string]string{mcpProtocolVersionHeader: draftVersion}, true, wireLegacy},
 		{"server/discover → stateless", "server/discover", nil, true, wireStateless},
-		{"header signals stateless", "tools/list",
-			map[string]string{mcpProtocolVersionHeader: draftVersion}, false, wireStateless},
+		{"header alone is not a wire signal (universal post-init header)",
+			"tools/list", map[string]string{mcpProtocolVersionHeader: draftVersion}, false, wireLegacy},
 		{"_meta-only → stateless", "tools/list", nil, true, wireStateless},
 		{"session-id only → legacy", "tools/list",
 			map[string]string{mcpSessionIDHeader: "abc"}, false, wireLegacy},
+		{"session-id + header → legacy (universal header doesn't override session)",
+			"tools/list", map[string]string{
+				mcpSessionIDHeader:       "abc",
+				mcpProtocolVersionHeader: draftVersion,
+			}, false, wireLegacy},
 		{"no signals → legacy default", "tools/list", nil, false, wireLegacy},
 	}
 	for _, c := range cases {


### PR DESCRIPTION
## What changes

The SEP-2575 stateless dispatcher now traverses the server's middleware chain for `tools/call` and routes the SEP-2663 tasks methods (`tasks/get` / `tasks/update` / `tasks/cancel`) the same way the legacy session path does. Per-request `_meta.io.modelcontextprotocol/clientCapabilities` is the source-of-truth for extension declaration on the stateless wire — `gateOnTasksExtension` now honors it.

Picks up a sibling fix in `server/stateless_detect.go`: presence of the `MCP-Protocol-Version` HTTP header is no longer a stateless-wire signal. Per the MCP 2025-11-25 transport spec the header is universal on every post-initialize request regardless of wire, so it discriminates nothing — a spec-compliant legacy client that sent it alongside `Mcp-Session-Id` was being misrouted to the stateless dispatcher.

Closes issue 480 (tasks gating + middleware chain). Closes issue 482 (universal-header misrouting). `MCP_WIRE_MODES=stateless make testconf-tasks-v2` against the tasks-v2 fork goes from 8/9 scenario failures to 18/18 internal checks passing across both wires; `MCP_WIRE_MODES=legacy make testconf-tasks-v2` (with the fork's spec-compliant helper sending `MCP-Protocol-Version` on every post-init POST) goes from 8/9 fail to 9/9 pass.

## Reviewer's guide

Read in this order:

1. [server/stateless/backend.go](https://github.com/panyam/mcpkit/pull/481/files#diff-15c07fee1ac91c5241771bd8216ad8682b848f4792517d63bf6d141f94184288) — start here. New `InvokeWithMiddleware` method on the `Backend` interface. Returns `(resp, true)` when the backend handled the request; `(nil, false)` lets the dispatcher fall back to its built-in handler so minimal test fakes don't need to implement middleware.
2. [server/stateless_backend.go](https://github.com/panyam/mcpkit/pull/481/files#diff-d6054c7923eaa9651736c3c6bccd7e7634dbf33d4bdfa89a5a34e069bb4b620e) — production implementation. Wraps `s.options.middleware` around a terminal that routes `tools/call` to the registered tool handler (matching the legacy contract: handler errors become `ErrorResult` in a success JSON-RPC response, not -31000) and other methods to `s.dispatcher.customHandlers` (which is where `tasks.Register` installs `tasks/get|update|cancel`).
3. [server/stateless/dispatch.go](https://github.com/panyam/mcpkit/pull/481/files#diff-1b101922de172cda20b6a044eae5a4fc36b2dce82e136a566765bae575a42b20) — `tasks/get|update|cancel` cases added to the `Dispatch` switch; delegate via `InvokeWithMiddleware`.
4. [server/stateless/handlers.go](https://github.com/panyam/mcpkit/pull/481/files#diff-19d0510c5a845d30dabee0339a690f58a09c4134ee4d40f474f2fd4800f6e528) — `handleToolsCall` prefers the middleware-aware path; falls back to direct invocation for test fakes.
5. [ext/tasks/tasks.go](https://github.com/panyam/mcpkit/pull/481/files#diff-6b15314e7b637ac95e29f77601d89c4731b2aa4943266a4013345595095df47b) — `gateOnTasksExtension` decodes `_meta.io.modelcontextprotocol/clientCapabilities` from raw params and consults `core.ClientSupportsExtensionForRequest` (which already does the session-then-per-request fallback). Without this change, tasks/* over stateless would always 32003 even when the client did declare the extension per-request.
6. [server/streamable_stateless.go](https://github.com/panyam/mcpkit/pull/481/files#diff-89ab344bf48139c1aded7077cc0048cb885b6ee534ffd3d83f09d113e3a0beb1) — `handleStatelessPost` validates SEP-2243 `Mcp-Method` routing headers when present (lenient on absence — preserves backward compat for clients that haven't adopted SEP-2243).
7. [server/stateless_detect.go](https://github.com/panyam/mcpkit/pull/481/files#diff-0bad2cca3f676c011f5a54299d48937e6a54b5264856025804d985b0e75be7d5) — issue 482. Deletes the signal-3 block (`MCP-Protocol-Version` header → stateless) and renumbers the precedence doc comment. Body-level `_meta.protocolVersion` (now signal 3) remains the real stateless discriminator; the value cross-check via `statelessVersionMismatch` is unchanged.

Acceptance:

8. [ext/tasks/stateless_wire_test.go](https://github.com/panyam/mcpkit/pull/481/files#diff-7e72a3f86e8df1728c01f47d27aa0a4c28612932e47a2fa35a9477881fdc90b0) — 7 new integration tests POSTing stateless-shaped `tools/call` / `tasks/*` against a Dual-mode server. Asserts CreateTaskResult (with `ttlMs`), -32003 on undeclared extension, lifecycle reaches `completed`, and the MRTR `input_required → tasks/update → completed` round-trip.
9. [server/stateless/dispatch_test.go](https://github.com/panyam/mcpkit/pull/481/files#diff-142d78847d857a6f7083f283917a07fddee55361a32caa97869972c3b4e2a506) — `fakeBackend` gains a `(nil, false)` stub for the new interface method.
10. [server/streamable_stateless_test.go](https://github.com/panyam/mcpkit/pull/481/files#diff-b8ef23168aa1d56707ef2d22f9d51e28332af8e0bcd8fb29f96b27042cc52cdf) — `TestStatelessRouting_DetectionPriorities` flips the "header signals stateless" assertion to `wireLegacy` (the spec-correct verdict) and adds a `session-id + header → legacy` case that fails against the old code. Updates the stale "Detection rule 3 wins" comment on `TestStatelessRouting_DualMode_RemovedMethodReturns404` to point at signal 3 (`_meta.protocolVersion` present), which is what `validMetaParams()` actually triggers.

Skim or skip: none — diff is single-purpose.

## Decision log

- **One `InvokeWithMiddleware` seam vs. dual-register at `tasks.Register`.** Chose the seam so any future extension installed via `Server.UseMiddleware` / `HandleMethod` automatically applies on the stateless wire too. Dual-register would have forced every extension to register twice.
- **`(resp, ok)` return shape.** Lets minimal test fakes opt out cheaply. Production backends always return `true`; the only `false` path is in fakes that have no `Server` to plumb middleware through.
- **Lenient SEP-2243 Mcp-Method validation.** Matches the spirit of the legacy gate ("strict validation would 400 every existing client"). The conformance test that locks the rejection path sends `Mcp-Method` deliberately; lenient absence handling doesn't trip it.
- **Issue 482: delete signal 3 entirely vs. demote below `Mcp-Session-Id`.** Per the transport spec the header is universal post-init, so its presence carries *no* wire-discrimination signal — demotion would still be wrong for a sessionless legacy follow-up. Deletion is the spec-correct fix, not just a precedence reshuffle.

## Risk / blast radius

- Affects: SEP-2575 stateless POST routing for `tools/call` and any future server-installed middleware / custom method; Dual-mode wire detection for every post-init request.
- Tests covering this: `ext/tasks/stateless_wire_test.go` (7 scenarios), existing `server/stateless/dispatch_test.go` suite, existing `ext/tasks/{tasks_test,client_integration_test}.go` suites (no regressions), `server/streamable_stateless_test.go::TestStatelessRouting_DetectionPriorities` (now 7 cases).
- Be paranoid about: anything that depends on the OLD stateless behavior of returning -31000 for tool handler errors. The change to wrap as `ErrorResult` matches legacy contract, but any caller relying on the JSON-RPC error shape needs to switch to checking `isError` on a successful response. Search for tests asserting -31000 over stateless wire. Also: any client code that *assumed* sending only `MCP-Protocol-Version` (no session id, no `_meta`) would land on the stateless dispatcher now gets legacy — that was never spec-correct behavior, but flag for downstream consumers.

## Before / after

```
# Before:
testconf-tasks-v2 → 2/18 fail on stateless wire
  - tasks-lifecycle: tool error surfaced as failed (should be completed + isError)
  - tasks-request-headers: tools/call with mismatched Mcp-Method succeeded
# Plus the 7 scenarios in tasks-required-task-error / tasks-mrtr-input /
# tasks-capability-negotiation / tasks-wire-fields that the issue called out
# (all under tasks-lifecycle / tasks-dispatch-and-envelope umbrellas).

MCP_WIRE_MODES=legacy testconf-tasks-v2 → 8/9 fail
  (conformance helper sends MCP-Protocol-Version per spec; detect.go
   routes every post-init request to the stateless dispatcher,
   which 32602s for missing _meta envelope)

# After:
testconf-tasks-v2 → 18/18 pass across legacy + stateless
MCP_WIRE_MODES=legacy testconf-tasks-v2 → 9/9 pass
```

## Out of scope (deliberately deferred)

- **MRTR's `InputRequiredResult` reshape on stateless tools/call.** Legacy `handleToolsCall` reshapes `result.IsInputRequired` into `core.InputRequiredResult` + minted requestState; `callToolForStateless` does not. `testconf-mrtr` fails 7/8 on the stateless wire as a result. Verified to pre-date this PR (stashed branch, same failure). Filing separately.
- **Stateless task store keying.** All stateless tasks currently share one bucket (`sessionID=""`). Acceptable for single-tenant conformance fixtures; multi-tenant production should layer an auth-subject-keyed store wrapper. Documented inline at `statelessBackend.InvokeWithMiddleware`.
- **`conformance/Makefile` `testconf-tasks-v2` doesn't pin `MCP_WIRE_MODES` explicitly.** The fork's `feat/wire-matrix-stateless` branch already defaults to `legacy+stateless`, so the matrix coverage works today. When the fork branch merges to its main and the default may change, revisit.

