### PR TITLE
feat(tasks): SEP-2663 Option-2 GoAsync sentinel + MRTR→Tasks composition (closes 347)

### DIFF
--- a/RELEASES/2026-06-30.md
+++ b/RELEASES/2026-06-30.md
@@ -1,0 +1,125 @@
+# Release 2026-06-30 — mcpkit
+
+**Status:** in flight
+**RC target:** 2026-05-15 (passed)
+**FINAL target:** 2026-06-30
+**Live tracker:** [mcpkit#431](https://github.com/panyam/mcpkit/issues/431)
+
+This doc is the version-controlled plan for the June 30 release. Live progress
+lives in mcpkit#431. After release ships, the retrospective at the bottom
+captures what worked / what slipped / what to change next cycle.
+
+## Upstream source of truth
+
+- **Release plan:** https://plan.modelcontextprotocol.io/releases/1
+- **Scope:** 25 SEPs scoped, 14/25 accepted at plan publish time
+- **Themes:** Transport Evolution (5), Agent Communication (5), Enterprise Readiness (12), Governance (2)
+
+## Locked-in scope
+
+Five mcpkit umbrellas + two conformance umbrellas. All tagged `release:2026-06-30`.
+
+| Wave | Umbrella | SEP | Stage | Status |
+|---|---|---|---|---|
+| 0 (done) | [#313](https://github.com/panyam/mcpkit/issues/313) | SEP-2356 file inputs | in-review | Phase 1+2.1 shipped; 7/7 conformance |
+| 1 | [#347](https://github.com/panyam/mcpkit/issues/347) | SEP-2322+2663 composition | accepted / in-review | Option 2 (GoAsync sentinel) locked in |
+| 2 | [#380](https://github.com/panyam/mcpkit/issues/380) | SEP-2468 RFC 9207 iss | in-review | verify-first plan; ~95% oneauth pushdown |
+| 3 | [#312](https://github.com/panyam/mcpkit/issues/312) | SEP-414 OTel (+ SEP-2028) | accepted | gold-standard body; 5 phases; lean ext/otel module |
+| 4 | [#316](https://github.com/panyam/mcpkit/issues/316) | SEP-2577 deprecate | in-review | watch-and-wait; file-by-file checklist staged |
+
+Conformance umbrellas:
+- [#382](https://github.com/panyam/mcpkit/issues/382) — auth scenarios (paired with #380, #381)
+- [#429](https://github.com/panyam/mcpkit/issues/429) — OTel scenarios (paired with #312)
+
+## Sequencing decision
+
+**Smallest-first.** Rationale:
+- #347 is a quick win (~1-2 days) that closes two long-running source-issues and validates the workflow
+- #380 next because most work is in oneauth (parallelizable across repos)
+- #312 (OTel) is the largest — start once the smaller wins prove the cycle
+- #316 is watch-and-wait; trigger-driven, no proactive schedule slot
+- #313 is already shipped for June; no further work this cycle
+
+Alternative considered: **riskiest-first** (#312 → #380 → #347). Rejected because the cycle is unproven and morale benefits from quick wins.
+
+## Cadence
+
+| Date | Milestone |
+|---|---|
+| 2026-05-19 | Plan locked; tracker filed (#431); release label applied across umbrellas |
+| 2026-05-26 | Weekly check-in 1 |
+| 2026-06-01 | Mid-point: Wave 1 + Wave 2 expected landed; Wave 3 underway |
+| 2026-06-02 | Weekly check-in 2 |
+| 2026-06-09 | Weekly check-in 3 |
+| 2026-06-16 | Weekly check-in 4 |
+| 2026-06-23 | RC freeze: all impl merged, conformance green |
+| 2026-06-30 | FINAL |
+
+Weekly check-ins are comments on mcpkit#431 capturing progress + blockers.
+
+## Per-SEP execution cycle (standard shape)
+
+Each wave follows:
+
+1. Sub-issues filed from umbrella's phase list
+2. Verify-first failing test written (proves the gap, becomes the regression)
+3. Worktree + branch: `feat/sep-NNNN-<short>` off main
+4. Implementation PR(s) per phase with tests
+5. Conformance scenarios added to paired umbrella's fork
+6. Un-skip / un-park existing local conformance if applicable
+7. Update docs (`docs/SEP_NNNN_<name>.md` if non-trivial)
+8. Close umbrella + flip gap-tracker source(s) to `done` via `gapt close`
+
+A wave is "done" when all sub-task checkboxes ticked, umbrella closed as COMPLETED, gap-tracker source(s) flipped to `done`, and conformance scenarios merged + green in the fork.
+
+## Out of scope for this release
+
+- SEP-2557 (superseded by SEP-2663)
+- SEP-2567 / SEP-2575 (stateless work, accepted-with-changes — defer)
+- SEP-2669 (steer/pause/resume — post-RC per Luca, defer-scope)
+
+## Open architecture questions (parked for future releases)
+
+- mcpkit#346 (P2/parked): notification stream routing review
+- mcpkit#342 (P2/recurring): MRTR handler restart model review
+
+## Risks
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| SEP-414 contract changes upstream before we ship | low | SEP is `accepted`; W3C Trace Context wire format is stable; ext/otel adapter is opt-in so direct dep churn doesn't affect base module |
+| SEP-2468 spec shifts iss-validation requirements | low | SEP is `in-review` but RFC 9207 itself is stable; our work is mostly oneauth |
+| #347 middleware change breaks existing tasks tests | medium | Comprehensive existing test coverage; Option 2 chosen specifically to avoid behavior change for non-MRTR tools |
+| SEP-2577 deprecation finalizes late or scope shifts | low | Watch-and-wait posture; trigger-driven work, no proactive schedule slot |
+| Conformance fork sync lag | medium | scenarios land in `panyam/mcpconformance:feat/<sep>-extension` branches; merge to upstream `modelcontextprotocol/conformance` is a separate effort |
+
+## Retrospective (fill in after FINAL)
+
+### What shipped
+
+_To be filled in after 2026-06-30._
+
+- Wave 1 (#347):
+- Wave 2 (#380, #382 scenarios):
+- Wave 3 (#312, #429 scenarios):
+- Wave 4 (#316):
+
+### What slipped
+
+_What didn't make it, and why._
+
+### What worked
+
+_Process decisions that paid off._
+
+### What was awkward
+
+_Friction we want to remove next cycle. Feeds into mcpkit#432 (release-start skill)._
+
+### Calibration for next release
+
+_Sizing accuracy, sequencing choice in hindsight, cadence pattern, conformance lag, etc._
+
+### Backlinks fired we wish we'd avoided
+
+_GH cross-references that created noise on upstream issues._

--- a/conformance/mrtr/README.md
+++ b/conformance/mrtr/README.md
@@ -1,8 +1,12 @@
 # mcpkit/conformance/mrtr — sentinel
 
-The full SEP-2322 MRTR server-conformance suite migrated upstream to
-the [`panyam/mcpconformance`](https://github.com/panyam/mcpconformance)
-fork, on the
+The full SEP-2322 MRTR server-conformance suite — 8 checks: basic
+elicitation, sampling, and roots/list round-trips; `requestState`
+validation; multi-input single round; multi-round answer accumulation;
+wrong-key tolerance; and the SEP-2663 **MRTR → Tasks composition flow**
+— lives in the
+[`panyam/mcpconformance`](https://github.com/panyam/mcpconformance)
+fork on the
 [`feat/tasks-mrtr-extension`](https://github.com/panyam/mcpconformance/tree/feat/tasks-mrtr-extension)
 branch (paired with the SEP-2663 tasks scenarios since the two surfaces
 share base types). Run from mcpkit via:
@@ -12,7 +16,8 @@ make testconf-mrtr
 ```
 
 The Makefile target invokes vitest in the fork (auto-spawning the
-`examples/mrtr` Go fixture) and then runs this folder's local sentinel
+`examples/mrtr` Go fixture — which registers `test_tool_with_task` for
+the composition scenario) and then runs this folder's local sentinel
 afterward.
 
 ## What lives here

--- a/core/tool.go
+++ b/core/tool.go
@@ -162,6 +162,33 @@ type ToolResult struct {
 	// serialized through ToolResult — dispatch reshapes the response into
 	// InputRequiredResult.
 	InputRequests InputRequests `json:"-"`
+
+	// GoAsync is the SEP-2663 in-process sentinel signalling that the handler
+	// has finished its synchronous work (e.g. gathering input via MRTR) and
+	// wants the remainder of its execution to run as a background task. When
+	// the ext/tasks middleware sees GoAsync=true on a non-InputRequired result
+	// from a tool whose Execution.TaskSupport is optional/required and the
+	// client has negotiated the io.modelcontextprotocol/tasks extension, it:
+	//
+	//  1. mints a fresh task,
+	//  2. spawns a goroutine that re-invokes the handler with a
+	//     [tasks.TaskContext] available (the handler discovers it via
+	//     [tasks.GetTaskContext] and switches to the async branch), and
+	//  3. returns CreateTaskResult to the original caller.
+	//
+	// The continuation goroutine is what runs the "real" work, so a handler
+	// that emits notifications/progress or notifications/message from the
+	// async branch gets the SEP-2663 G6 session-notify filter applied.
+	// A sync-returning handler (GoAsync=false) does NOT get that filter,
+	// because no goroutine ever runs.
+	//
+	// Ignored when:
+	//   - IsInputRequired is true (the result is an MRTR InputRequiredResult)
+	//   - the tool's Execution.TaskSupport is forbidden or absent
+	//   - the client has not negotiated the tasks extension
+	//
+	// Never serialized — this field is in-process plumbing only.
+	GoAsync bool `json:"-"`
 }
 
 // MarshalJSON ensures every ToolResult on the wire carries a ResultType.

--- a/docs/MRTR_TUTORIAL.md
+++ b/docs/MRTR_TUTORIAL.md
@@ -1,0 +1,508 @@
+# MRTR Tutorial — Multi Round-Trip Requests, end to end
+
+Everything you need to know to write tools that gather input from the client cleanly across both the legacy and stateless MCP wires, plus a clear picture of where the older "server pushes a request to the client" mechanisms fit in (and where they're going).
+
+> **Status.** Reflects the spec as of SEP-2322 (merged 2026-05-06), SEP-2575 (stateless wire), and SEP-2663 (tasks v2). mcpkit's reference fixtures live under [`examples/mrtr`](../examples/mrtr) and [`examples/tasks-v2`](../examples/tasks-v2); the conformance suite is in [panyam/mcpconformance](https://github.com/panyam/mcpconformance).
+
+---
+
+## 1. The core idea: a stateless continuation primitive
+
+When a tool needs the client to do something — pick a file, confirm an action, sample a model, list its open workspaces — the spec gives the server a single mechanism: it returns an **`InputRequiredResult`** from `tools/call` describing what it needs, and the client re-invokes the same `tools/call` carrying the answer.
+
+The mental model that breaks:
+
+> "The server pauses the handler, holds the goroutine open, resumes when the client replies."
+
+That's **not** what MRTR does. The handler returns immediately on every round. There is no goroutine waiting, no server-side pending state, no waiter channel.
+
+The mental model that works:
+
+> The server returns a **continuation token** (`requestState`). The client carries it forward. The server reconstructs context from the token on the next round, runs the same handler again with the accumulated answers, and either yields again or returns the final result.
+
+State lives **in the token**, not in server memory. The handler is the same function on every round; it just sees a richer `ToolRequest.InputResponses` each time. This is what lets MRTR work identically on legacy session-based transports and on serverless stateless ones — the server can be a different Lambda invocation each round and the conversation still resumes.
+
+If you've seen any of these elsewhere, the shape will feel familiar:
+
+- **Algebraic effects / handlers** (Koka, Eff, Unison). The handler "performs an effect"; the client handles it and returns control. The cleanest analogy.
+- **Generators / async iterators.** The handler "yields" an InputRequest and is resumed with the response. With a wrinkle: real generators preserve stack frames; MRTR replays from the top with accumulated state.
+- **OAuth authorization-code flow.** Server says "I need consent, here's an opaque state token, come back with it"; client does its part; server validates state and resumes. The structural similarity is exact — mcpkit even uses HMAC-SHA256 on the token, same posture as a signed JWT continuation.
+- **Continuation-passing style** at the protocol level. The `requestState` token IS the continuation — a serialized "where to resume" handle.
+
+---
+
+## 2. The wire shape
+
+A tool call that needs input issues an `InputRequiredResult`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "resultType": "input_required",
+    "inputRequests": {
+      "user_name": {
+        "method": "elicitation/create",
+        "params": {
+          "message": "What is your name?",
+          "requestedSchema": { "type": "object", ... }
+        }
+      }
+    },
+    "requestState": "eyJhbGciOiJIUzI1NiI...<signed token>"
+  }
+}
+```
+
+The client picks up the request, satisfies it (asks the user / samples the model / lists its roots), and re-invokes the **same** `tools/call` with `inputResponses` keyed by the same map keys:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/call",
+  "params": {
+    "name": "test_tool_with_elicitation",
+    "arguments": {},
+    "inputResponses": {
+      "user_name": { "action": "accept", "content": { "name": "Alice" } }
+    },
+    "requestState": "eyJhbGciOiJIUzI1NiI..."
+  }
+}
+```
+
+A round can carry **multiple** input requests at once (the map is plural). All of them resolve in a single client round-trip. Likewise a handler can take **multiple rounds** — each round mints a fresh `requestState`, and the server forwards prior-round answers via the token so the handler sees the full accumulated state on the final round.
+
+### Map keys are opaque
+
+`"user_name"` is server-chosen and opaque to the client. The spec says clients MUST treat them as round-trip echo strings — never parse or interpret them. mcpkit picks readable names for debuggability; that's a server-side convention, not a wire contract.
+
+### `requestState` is the continuation token
+
+The server can sign it (HMAC) or run it as plaintext. mcpkit's signed mode encodes `{tool, accumulated answers, exp}` as the state; the verifier rejects:
+
+- malformed tokens (`ErrRequestStateMalformed`),
+- signature mismatches or **tool-name mismatches** ("token issued for tool A replayed against tool B" — `ErrRequestStateInvalidSignature`),
+- expired tokens (`ErrRequestStateExpired`).
+
+Production deployments should always set a signing key via `server.WithRequestStateSigning(...)`. Plaintext mode is for tests and demos.
+
+---
+
+## 3. What server-to-client methods does MRTR cover?
+
+The `method` field on each `InputRequest` is one of the **methods the client offered** — i.e., the menu the client published in its capabilities. In practice, the three the spec scopes MRTR to are:
+
+| Method | What the server is asking for | Client capability that enables it |
+|---|---|---|
+| `elicitation/create` | A user-facing prompt; the client renders, user answers | `elicitation: {}` |
+| `sampling/createMessage` | A model completion the client routes to its LLM | `sampling: {}` |
+| `roots/list` | The client's current set of workspace roots (URIs) | `roots: {}` |
+
+The server doesn't get to invent new MRTR methods. It picks from what the client offered in `initialize` (legacy) or per-request `_meta.clientCapabilities` (stateless) — see §4.
+
+### What's `roots/list` and why does it exist?
+
+A **root** is a URI the client tells the server represents "where the user is currently working." Each root is a `{uri, name?}` pair — typically `file://`, `https://`, or some scheme-prefixed location.
+
+Examples:
+
+- An IDE host might expose `file:///Users/sri/projects/mcpkit/` when that project is open.
+- A multi-project workspace might expose two roots: `file:///work/repo-a/`, `file:///work/repo-b/`.
+- A browser-style host might expose `https://github.com/panyam/mcpkit` when the user has that repo focused.
+
+**Why servers need it.** An MCP server has no innate idea what filesystem or workspace the user is in. The host (Claude Code, Claude Desktop, Cursor, …) does. Without `roots/list`, a server would have to either:
+
+- ask the user via elicitation every time (annoying and the answer rarely changes),
+- take filesystem paths as tool arguments (verbose and error-prone),
+- or guess (broken).
+
+Roots gives the server a structured, programmatic way to ask the client *"what is the user working on right now?"* and get back a list it can scope its operations against. It's the protocol-level answer to "current working directory" in a multi-host, sandboxed world.
+
+**How it's used in practice.**
+
+- A code-search server calls `roots/list` once, gets `[file:///Users/sri/projects/mcpkit/]`, and scopes all its searches to that path. No tool argument needed.
+- A diagnostics server reads `roots/list` to know which file tree to type-check.
+- A docs server scopes its lookup index to the project root.
+
+**Why it's its own method instead of an elicitation.** Elicitation asks the user a free-form question; the answer is whatever the user types and is request-scoped. Roots are structured data the host already has — no user prompt needed — and they're stable across the session. Making it its own method lets clients return roots without user friction and lets hosts model "what's open" as first-class state.
+
+A handler that needs the current roots issues:
+
+```go
+return ctx.RequestInput(core.InputRequests{
+    "client_roots": core.InputRequest{
+        Method: "roots/list",
+        Params: json.RawMessage(`{}`),
+    },
+})
+```
+
+— see [`basicListRootsTool`](../examples/mrtr/main.go) (the A3 fixture).
+
+---
+
+## 4. Where the client publishes its capability menu — and how that changes per wire
+
+The rule the spec enforces is universal:
+
+> The server picks `InputRequest.method` from the menu of methods the client declared support for. If the client didn't declare `sampling`, the server can't legally ask for `sampling/createMessage`.
+
+What changes between wires is **when and where** the menu is published.
+
+| Wire | Menu source | Lifetime | Per-request override? |
+|---|---|---|---|
+| **Legacy** | `initialize` response | Session — cached server-side until session ends | Yes — `_meta.clientCapabilities` on a request overrides / augments the session cache (SEP-2575 also targets legacy) |
+| **Stateless** | `_meta.clientCapabilities` on **every** request | Request — declared fresh each time, no server-side cache | Same field is the only source |
+
+On stateless, the envelope is required on every request:
+
+```json
+{
+  "params": {
+    "name": "tools/call",
+    "_meta": {
+      "io.modelcontextprotocol/protocolVersion":    "DRAFT-2026-v1",
+      "io.modelcontextprotocol/clientInfo":         { ... },
+      "io.modelcontextprotocol/clientCapabilities": {
+        "elicitation": {},
+        "sampling":    {},
+        "roots":       {},
+        "extensions":  { "io.modelcontextprotocol/tasks": {} }
+      }
+    }
+  }
+}
+```
+
+A stateless request that omits `clientCapabilities` (or omits `_meta` entirely) is — from the server's perspective — a client that supports nothing. The server can't fall back to session state because there isn't any. The contract is *"if you want the server to ask you for X, declare X in `_meta` every time you might want to be asked."* This is the price stateless pays for being restart-safe.
+
+### The mcpkit helper
+
+[`core.ClientSupportsExtensionForRequest(ctx, key, perRequestCapsRaw)`](../core/stateless.go) transparently merges the session-cached caps (if any) with the per-request `_meta` override and gives you a single yes/no. Your handler or middleware doesn't need to special-case the wire. `taskV2Middleware` uses exactly this helper to gate the tasks extension; a future "MRTR capability gate" for elicitation/sampling/roots would use the same shape.
+
+---
+
+## 5. `progressToken` — who mints it and what it's for
+
+**The client mints it.** It's a single-source-of-truth correlation tag: the client picks an opaque value (any JSON scalar — string, number, even null), attaches it to the outgoing request under `_meta.progressToken`, and uses that same value to match incoming `notifications/progress` events back to the request that asked for them.
+
+```jsonc
+// client → server
+{
+  "method": "tools/call",
+  "params": {
+    "name": "summarize",
+    "arguments": { ... },
+    "_meta": {
+      "progressToken": "req-42"   // ← client's correlation tag
+    }
+  }
+}
+
+// server → client (later, on the push channel)
+{
+  "method": "notifications/progress",
+  "params": {
+    "progressToken": "req-42",    // ← server echoes the same token
+    "progress": 47,
+    "total": 100,
+    "message": "Processing batch 47/100"
+  }
+}
+```
+
+The server never invents one. There'd be no client-side correlation map to look it up in.
+
+Three layers in mcpkit:
+
+1. **Client mints + sends.** The client library accepts a `ProgressToken any` field on its call options and serializes it as `_meta.progressToken`.
+2. **Server reads + threads.** The dispatcher unmarshals the envelope, pulls `progressToken`, and constructs a `core.ToolContext` carrying it. Handlers access it via `ctx.ProgressToken()` or `req.ProgressToken`.
+3. **Server emits with the same token.** `core.EmitProgress(ctx, token, current, total, message)` wraps a `notifications/progress` carrying the original token.
+
+If the client didn't send one, the field stays `nil` and `EmitProgress` becomes a no-op (no addressee to correlate against). If you see a server-side fallback like:
+
+```go
+progressToken = tc.ProgressToken()
+if progressToken == nil {
+    progressToken = tc.TaskID()
+}
+```
+
+— that's the app synthesizing a token because the client didn't, *as a convenience*. The protocol doesn't define this fallback; it's app-level behavior.
+
+---
+
+## 6. What `notifications/progress` and `notifications/message` were for — and what replaces them inside a task
+
+Both are **server-to-client streaming notifications** on the persistent push channel:
+
+- **`notifications/progress`** — progress updates for a single in-flight request the client opted into tracking. Use case: a 30-second compute job that wants to update an IDE progress bar.
+- **`notifications/message`** — server-side log emission scoped by `logging/setLevel`. Use case: live operator logging, devtools output, audit trail.
+
+SEP-2663's **G6 rule** says: **a task's notification channel is reserved for `notifications/tasks` (the lifecycle event stream) and MUST NOT carry `notifications/progress` or `notifications/message`.**
+
+Three reasons the spec went this way:
+
+1. **Wire homogeneity.** A task is observed via `tasks/get` polling or `notifications/tasks` SSE. Mixing in progress/message events on the same stream would force every task-aware client to disambiguate between "task lifecycle event" and "tool-internal status" — and they'd need to do that in a way that's consistent across servers. Cleaner: tasks emit task events, full stop.
+2. **Stateless-wire feasibility.** Progress/message both assume a long-lived push channel. On the SEP-2575 stateless wire there isn't one. Tasks are how stateless servers expose long-running work; saying "tasks don't speak progress/message" lets stateless servers be fully spec-compliant for tasks without implementing a streaming back-channel they fundamentally can't have.
+3. **No silent loss.** A handler emitting progress on legacy lands on the GET SSE stream; the same handler under stateless silently fails to deliver. Forbidding them everywhere makes the contract uniform.
+
+### What replaces them
+
+| Old | New (inside a task) | What it gets you |
+|---|---|---|
+| `notifications/progress` | `tc.SetStatus(...)` + `statusMessage` on `TaskInfo` | Per-task progress is observed via `tasks/get` (or `notifications/tasks` if the client is listening). Status transitions and the `statusMessage` field replace progress %. |
+| `notifications/message` | Structured `result.content` when the task completes; for live observability, out-of-band server-side logging (your own log infra, OpenTelemetry, ...) | The task's `result` is where structured output goes. For live ops visibility, the spec is "use real logging" — MCP isn't the transport for that. |
+| Either, during sync handler phase | **Still works.** The G6 filter is goroutine-scoped only — a sync handler returning a `core.ToolResult` (or running an MRTR round) can still call `EmitProgress` / `EmitLog` on the request ctx | Use this for short tool calls that don't need to be tasks |
+
+### How mcpkit enforces it
+
+[`ext/tasks/tasks.go`](../ext/tasks/tasks.go) wraps the continuation goroutine's `bgCtx` with a session-notify filter:
+
+```go
+bgCtx = core.ApplySessionNotifyFilter(bgCtx,
+    "notifications/progress",
+    "notifications/message",
+)
+```
+
+So a handler written for the pre-G6 world doesn't *break* when run as a task — it just stops emitting those notifications. They no-op silently. That's what made the migration to GoAsync mechanical instead of a behavioral change.
+
+The filter is **goroutine-scoped only**. A handler that returns sync (no GoAsync, no MRTR round) runs on the unfiltered POST ctx and can still emit. That's a deliberate narrowing — sync handlers on `TaskSupport=optional/required` tools are responsible for not leaking notifications they shouldn't.
+
+---
+
+## 7. When to use what — MRTR vs push vs task input flow
+
+Three mechanisms for "server asks the client for something." Picking the right one matters.
+
+| Mechanism | Wire | Trigger | Best for |
+|---|---|---|---|
+| **MRTR** (SEP-2322) — `InputRequiredResult` | Both legacy and stateless | During a single `tools/call` execution | One-shot prompts during a tool: confirm-then-do, gather an API key before running, etc. Each round is one HTTP cycle. |
+| **Push** — server-initiated `sampling/createMessage` / `elicitation/create` / `roots/list` requests on the SSE push channel | **Legacy only** | Anytime — during a tool call, or out of band | Real-time interactions on the legacy wire. **On the stateless wire `ctx.Sample` / `ctx.Elicit` return `ErrNoRequestFunc` by construction** — there's no persistent push channel. |
+| **Tasks input flow** (SEP-2663) — `tc.TaskElicit(...)` / `tc.TaskSample(...)` | Both wires (once stateless MRTR lands — see issue 452) | Inside a running task | Long-running tasks that need input mid-execution. The task parks in `input_required`; the client observes via `tasks/get` and resumes via `tasks/update`. State is scoped to the task lifetime, not to one MRTR round. |
+
+### Decision flow
+
+```
+Is the server-to-client request happening inside a tool call?
+├── No → push (legacy only — not supported on stateless)
+└── Yes:
+    ├── Is the tool registered with TaskSupport=optional/required AND running as a task?
+    │   ├── Yes → tc.TaskElicit / tc.TaskSample (parks the task, resumes via tasks/update)
+    │   └── No → MRTR (ctx.RequestInput returns InputRequiredResult)
+    └── For the gather-then-go-async pattern (gather input fast via MRTR, then escalate to a task for the slow work), see §9.
+```
+
+### Where push is heading
+
+Once SEP-2322 is widely negotiated, the push path is reachable by deprecation:
+
+1. **Today.** `ctx.Sample` / `ctx.Elicit` work on legacy, error out on stateless. Use MRTR for new tool code that wants to work on both wires.
+2. **Next.** Document MRTR as the recommended path; keep `ctx.Sample` / `ctx.Elicit` as legacy aliases that internally route through MRTR where possible.
+3. **Eventually.** When tools' `requiredCapabilities` can opt into "MRTR-aware client only", the push path becomes dead code for sampling/elicitation/roots/list. **Notifications remain** on the push channel (lifecycle events, list-changed events) — those don't have an MRTR shape.
+
+---
+
+## 8. Writing handlers — the canonical state machine pattern
+
+MRTR handlers are state machines on `InputResponses`. The same handler runs on every round; it branches on what's been answered so far.
+
+### One-round example (basic elicitation)
+
+```go
+func basicElicitationTool(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+    resp := ctx.InputResponse("user_name")
+    if resp == nil {
+        // Round 1 — ask.
+        return ctx.RequestInput(core.InputRequests{
+            "user_name": core.InputRequest{
+                Method: "elicitation/create",
+                Params: json.RawMessage(`{"message":"What is your name?","requestedSchema":{"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}}`),
+            },
+        })
+    }
+    // Round 2 — answer in hand, do the work.
+    var er struct {
+        Action  string `json:"action"`
+        Content struct{ Name string `json:"name"` } `json:"content"`
+    }
+    if err := json.Unmarshal(resp, &er); err != nil {
+        return core.ErrorResult("malformed elicitation response: " + err.Error()), nil
+    }
+    return core.TextResult(fmt.Sprintf("Hello, %s!", er.Content.Name)), nil
+}
+```
+
+The full set of seven canonical patterns (sampling, roots, multi-input, multi-round, requestState round-trip, wrong-key tolerance) lives in [`examples/mrtr/main.go`](../examples/mrtr/main.go) and is exercised by the conformance scenarios.
+
+### Multi-round example (accumulate state across rounds)
+
+```go
+func multiRoundTool(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+    if ctx.InputResponse("step1") == nil {
+        return ctx.RequestInput(core.InputRequests{
+            "step1": core.InputRequest{Method: "elicitation/create", Params: ...},
+        })
+    }
+    if ctx.InputResponse("step2") == nil {
+        return ctx.RequestInput(core.InputRequests{
+            "step2": core.InputRequest{Method: "elicitation/create", Params: ...},
+        })
+    }
+    // Both answered — server delivered prior-round answers via requestState.
+    return core.TextResult(buildFinalAnswer(...)), nil
+}
+```
+
+The dispatcher merges prior-round answers from `requestState` into `InputResponses` before invoking the handler — so the handler always sees the full accumulated map regardless of round count.
+
+### Wrong-key tolerance
+
+If the client sends an `inputResponses` key the server didn't emit, the handler's `InputResponse("user_name")` check returns `nil` and the handler re-requests. The conformance suite asserts this is the right behavior (vs erroring) — clients can race against state, and re-requesting is more user-friendly.
+
+---
+
+## 9. Composing MRTR with tasks — the GoAsync pattern (SEP-2663)
+
+The killer composition: a single tool can run an MRTR round-trip to gather input *first*, then escalate to a background task for the slow work. This is what mcpkit issue 347 / PR 484 unblocked.
+
+The pattern:
+
+```go
+func mrtrTaskCompositionTool(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+    // Phase 3: running inside the continuation goroutine (a task was minted).
+    if tasks.GetTaskContext(ctx) != nil {
+        // Do the heavy work; TaskContext gives us TaskElicit / SetStatus / etc.
+        result := doExpensiveWork(ctx, req)
+        return result, nil
+    }
+
+    // Phase 1: sync, no inputResponses yet — MRTR round.
+    if ctx.InputResponse("user_name") == nil {
+        return ctx.RequestInput(core.InputRequests{
+            "user_name": core.InputRequest{Method: "elicitation/create", Params: ...},
+        })
+    }
+
+    // Phase 2: sync, MRTR loop is done — escalate to async.
+    return core.ToolResult{GoAsync: true}, nil
+}
+```
+
+Three phases, one handler:
+
+1. **Sync, no `user_name` yet** → return `InputRequiredResult`. `taskV2Middleware` sees an MRTR round; passes through unchanged; no task created.
+2. **Sync, `user_name` present** → return `core.ToolResult{GoAsync: true}`. `taskV2Middleware` sees the sentinel; mints a task; spawns a continuation goroutine; returns `CreateTaskResult`.
+3. **Goroutine, `TaskContext` attached** → real work runs here. The handler detects the `TaskContext` and branches into the async path. The result is stored on the task; the client retrieves via `tasks/get`.
+
+### Spec separation that you can rely on (per SEP-2663)
+
+- MRTR `requestState` does **not** carry into the task's `requestState` — the task gets its own per-task input state.
+- Task `inputRequests` keys (if the goroutine later calls `TaskElicit`) are scoped to the task lifetime — distinct from MRTR phase keys.
+- Clients don't need to deduplicate across the two flows.
+
+mcpkit's [`mrtr-08`](https://github.com/panyam/mcpconformance) conformance scenario asserts all three.
+
+### Why this needed a middleware refactor
+
+Pre-Option-2, mcpkit's `taskV2Middleware` minted the task **before** the handler ran. That made the composition impossible: round 1 always emitted `CreateTaskResult` first, because the task was already minted before the handler could ever return `InputRequiredResult`. The 2026-05-19 decision on issue 347 inverted the order — handler runs synchronously first, middleware peeks at what came back, dispatches accordingly. See PR 484's "Decision log" for the alternative shapes considered (closure-carrying sentinel, always-goroutine for sync results, etc.) and why we landed on Option A strict.
+
+---
+
+## 10. Quick reference
+
+### Tool handler shape
+
+```go
+import (
+    "github.com/panyam/mcpkit/core"
+    tasks "github.com/panyam/mcpkit/ext/tasks"
+)
+
+func handler(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+    // (Optional, when composing with tasks v2)
+    if tasks.GetTaskContext(ctx) != nil {
+        return doAsyncWork(ctx, req)
+    }
+
+    // MRTR loop — branch on what's been answered.
+    if ctx.InputResponse("foo") == nil {
+        return ctx.RequestInput(core.InputRequests{
+            "foo": core.InputRequest{Method: "elicitation/create", Params: ...},
+        })
+    }
+
+    // Everything gathered — either return sync result, or escalate to async.
+    return core.ToolResult{GoAsync: true}, nil  // or do sync work and return
+}
+```
+
+### Server setup
+
+```go
+srv := server.NewServer(info,
+    server.WithRequestStateSigning([]byte(signingKey), 24*time.Hour),  // recommended
+)
+srv.RegisterTool(toolDef, handler)
+tasks.Register(tasks.Config{Server: srv})  // if any tools opt into TaskSupport
+```
+
+### Client request shape
+
+```jsonc
+// Round 1
+{
+  "method": "tools/call",
+  "params": {
+    "name": "my_tool",
+    "arguments": { ... },
+    "_meta": {
+      // Stateless requires the full envelope on every request.
+      "io.modelcontextprotocol/protocolVersion":    "DRAFT-2026-v1",
+      "io.modelcontextprotocol/clientInfo":         { ... },
+      "io.modelcontextprotocol/clientCapabilities": {
+        "elicitation": {},
+        "extensions":  { "io.modelcontextprotocol/tasks": {} }
+      },
+      "progressToken": "req-42"  // optional, for notifications/progress correlation
+    }
+  }
+}
+
+// Round 2 (after server returned InputRequiredResult)
+{
+  "method": "tools/call",
+  "params": {
+    "name": "my_tool",
+    "arguments": { ... },
+    "_meta": { ... },                          // same envelope on every call
+    "inputResponses": { "foo": { ... } },      // keyed by the server's emitted keys
+    "requestState": "<token from round 1>"     // echo back unchanged
+  }
+}
+```
+
+### Errors to expect
+
+| Error | When | Action |
+|---|---|---|
+| `-32602 invalid params: request params missing required _meta envelope` | Stateless request without `_meta` | Add the SEP-2575 `_meta` envelope. |
+| `ErrRequestStateMalformed` / `Invalid signature` / `Expired` | `requestState` tampered, replayed across tools, or older than TTL | Restart the tool call from round 1. |
+| `-32003 missing required client capability` | Server needs a capability (e.g., `tasks` extension) the client didn't declare | Update the client's `_meta.clientCapabilities` to declare it. |
+
+---
+
+## See also
+
+- [`examples/mrtr/main.go`](../examples/mrtr/main.go) — eight canonical MRTR fixtures including the composition pattern (A8 / `test_tool_with_task`).
+- [`examples/tasks-v2/main.go`](../examples/tasks-v2/main.go) — task fixtures (slow_compute, confirm_delete, multi_input, etc.) all using the GoAsync pattern.
+- [`ext/tasks/README.md`](../ext/tasks/README.md) — task extension overview and handler-pattern reference.
+- [`docs/TASKS_V2_MIGRATION.md`](TASKS_V2_MIGRATION.md) — v1 → v2 migration guide.
+- [`docs/SEP_2663_TASKS_CONFORMANCE_PLAN.md`](SEP_2663_TASKS_CONFORMANCE_PLAN.md) — task conformance status.
+- [panyam/mcpconformance](https://github.com/panyam/mcpconformance), branch `feat/tasks-mrtr-extension` — SEP-2322 + SEP-2663 conformance scenarios.
+- Issue 452 — stateless MRTR support follow-up.
+- Issue 485 — multi-tenant isolation for stateless task store follow-up.

--- a/examples/mrtr/go.mod
+++ b/examples/mrtr/go.mod
@@ -1,15 +1,18 @@
 module github.com/panyam/mcpkit/examples/mrtr
 
-go 1.26.2
+go 1.26.3
 
 replace github.com/panyam/mcpkit => ../..
 
 replace github.com/panyam/mcpkit/examples/common => ../common
 
+replace github.com/panyam/mcpkit/ext/tasks => ../../ext/tasks
+
 require (
 	github.com/panyam/demokit v0.0.25
-	github.com/panyam/mcpkit v0.2.41
+	github.com/panyam/mcpkit v0.2.45
 	github.com/panyam/mcpkit/examples/common v0.0.0-00010101000000-000000000000
+	github.com/panyam/mcpkit/ext/tasks v0.0.0-00010101000000-000000000000
 )
 
 require (

--- a/examples/mrtr/main.go
+++ b/examples/mrtr/main.go
@@ -46,6 +46,7 @@ import (
 	"github.com/panyam/demokit"
 	"github.com/panyam/mcpkit/core"
 	"github.com/panyam/mcpkit/examples/common"
+	tasks "github.com/panyam/mcpkit/ext/tasks"
 	"github.com/panyam/mcpkit/server"
 )
 
@@ -75,6 +76,13 @@ func serve() {
 	srv := server.NewServer(core.ServerInfo{Name: "mrtr-demo", Version: "0.1.0"}, opts...)
 
 	registerMRTRTools(srv)
+
+	// SEP-2322 + SEP-2663 composition: the registry holds at least one
+	// task-eligible tool (test_tool_with_task) that gathers input via MRTR
+	// rounds and then escalates to async via the GoAsync sentinel. The
+	// taskV2Middleware is what observes the GoAsync return and spawns the
+	// continuation goroutine.
+	tasks.Register(tasks.Config{Server: srv})
 
 	log.Printf("[mrtr-demo] listening on %s", *addr)
 	if err := srv.ListenAndServe(server.WithStreamableHTTP(true)); err != nil {
@@ -146,6 +154,23 @@ func registerMRTRTools(srv *server.Server) {
 			InputSchema: map[string]any{"type": "object"},
 		},
 		basicElicitationTool, // same handler — already re-requests on missing key
+	)
+
+	// A8: SEP-2322 + SEP-2663 composition. The handler runs through an MRTR
+	// round (gathering user_name) and only then escalates to async by
+	// returning the GoAsync sentinel. taskV2Middleware observes the GoAsync
+	// return and spawns a continuation goroutine that re-invokes the handler
+	// with a TaskContext attached; the goroutine does the "expensive work"
+	// and stores the final ToolResult on the task. Conformance scenario
+	// "mrtr-08" / mrtr-tasks-composition drives this fixture.
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "test_tool_with_task",
+			Description: "A8: MRTR elicit for user_name, then escalate to async via GoAsync. The continuation goroutine does the work and returns a greeting.",
+			InputSchema: map[string]any{"type": "object"},
+			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportRequired},
+		},
+		mrtrTaskCompositionTool,
 	)
 }
 
@@ -310,4 +335,65 @@ func multiRoundTool(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult
 	json.Unmarshal(ctx.InputResponse("step1"), &s1)
 	json.Unmarshal(ctx.InputResponse("step2"), &s2)
 	return core.TextResult(fmt.Sprintf("Hi %s, your favorite color is %s.", s1.Content.Name, s2.Content.Color)), nil
+}
+
+// --- A8: MRTR → Tasks composition (SEP-2322 + SEP-2663) ---
+
+// mrtrTaskCompositionTool walks two distinct phases that meet at the GoAsync
+// sentinel:
+//
+//   Phase 1 (synchronous, no TaskContext):
+//     - If user_name hasn't been answered yet → return InputRequiredResult via
+//       ctx.RequestInput. taskV2Middleware sees IncompleteResult and lets it
+//       through; the client sees a normal MRTR InputRequiredResult.
+//     - Once user_name is present → return ToolResult{GoAsync: true}.
+//       taskV2Middleware mints a fresh task and spawns the continuation.
+//
+//   Phase 2 (in the continuation goroutine, TaskContext attached):
+//     - Detect the TaskContext, do the "expensive" work, return a normal
+//       ToolResult. taskV2Middleware stores it as the task's terminal result;
+//       the client retrieves it via tasks/get.
+//
+// Per SEP-2663 spec separation rules:
+//   - MRTR requestState is NOT carried into the task's requestState (the task
+//     gets its own per-task inputState).
+//   - Task inputRequests keys (if the goroutine called TaskElicit / TaskSample)
+//     are scoped to the task's lifetime — distinct from the MRTR phase keys.
+//   - Clients do NOT need to deduplicate across the two flows.
+func mrtrTaskCompositionTool(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+	// Phase 2: running inside the continuation goroutine. The TaskContext
+	// gates us into the async branch.
+	if tasks.GetTaskContext(ctx) != nil {
+		// "Expensive" work simulator. A real handler would call out to a
+		// downstream service, run a long computation, etc.
+		time.Sleep(50 * time.Millisecond)
+		var er struct {
+			Action  string `json:"action"`
+			Content struct {
+				Name string `json:"name"`
+			} `json:"content"`
+		}
+		if raw := ctx.InputResponse("user_name"); raw != nil {
+			_ = json.Unmarshal(raw, &er)
+		}
+		if er.Content.Name == "" {
+			return core.ErrorResult("task continuation lost user_name"), nil
+		}
+		return core.TextResult(fmt.Sprintf("Hello, %s! (computed in task)", er.Content.Name)), nil
+	}
+
+	// Phase 1: synchronous. Drive the MRTR round-trip for user_name first; do
+	// NOT mint a task until the input is in hand.
+	if ctx.InputResponse("user_name") == nil {
+		return ctx.RequestInput(core.InputRequests{
+			"user_name": core.InputRequest{
+				Method: "elicitation/create",
+				Params: json.RawMessage(`{"message":"What is your name?","requestedSchema":{"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}}`),
+			},
+		})
+	}
+
+	// MRTR loop is complete; escalate to async so the heavy work happens
+	// in the continuation goroutine (with the SEP-2663 G6 filter applied).
+	return core.ToolResult{GoAsync: true}, nil
 }

--- a/examples/tasks-v2/main.go
+++ b/examples/tasks-v2/main.go
@@ -75,9 +75,19 @@ func serve() {
 				args.Label = "default"
 			}
 
-			// Immediate result shortcut: 0 seconds means instant.
+			// Immediate result shortcut: 0 seconds means instant. The middleware
+			// will wrap this as an already-completed task (taskSupport=optional
+			// + sync return) so the wire shape stays CreateTaskResult.
 			if args.Seconds <= 0 {
 				return core.TextResult(fmt.Sprintf("Computation %q completed instantly. Result: 42.", args.Label)), nil
+			}
+
+			// SEP-2663 Option 2: the slow loop blocks and emits progress, both
+			// of which must run inside the continuation goroutine (so the
+			// G6 filter is active and the response isn't held open). On the
+			// first sync pass there's no TaskContext, so signal GoAsync.
+			if tasks.GetTaskContext(ctx) == nil {
+				return core.ToolResult{GoAsync: true}, nil
 			}
 
 			log.Printf("[slow_compute] starting %q: sleeping %ds...", args.Label, args.Seconds)
@@ -123,6 +133,9 @@ func serve() {
 	srv.Register(core.TypedTool[struct{}, core.ToolResult]("failing_job",
 		"A job that always fails after 1 second. In v2: tool error = completed + isError:true.",
 		func(ctx core.ToolContext, _ struct{}) (core.ToolResult, error) {
+			if tasks.GetTaskContext(ctx) == nil {
+				return core.ToolResult{GoAsync: true}, nil
+			}
 			log.Printf("[failing_job] starting (will fail in 1s)...")
 			time.Sleep(1 * time.Second)
 			return core.ToolResult{}, fmt.Errorf("simulated failure: job crashed")
@@ -142,7 +155,9 @@ func serve() {
 		func(ctx core.ToolContext, args confirmDeleteInput) (core.ToolResult, error) {
 			tc := tasks.GetTaskContext(ctx)
 			if tc == nil {
-				return core.ToolResult{}, fmt.Errorf("confirm_delete requires task context")
+				// SEP-2663 Option 2: TaskElicit needs the continuation
+				// goroutine's TaskContext.
+				return core.ToolResult{GoAsync: true}, nil
 			}
 			if args.Filename == "" {
 				args.Filename = "important.txt"
@@ -188,7 +203,9 @@ func serve() {
 		func(ctx core.ToolContext, _ struct{}) (core.ToolResult, error) {
 			tc := tasks.GetTaskContext(ctx)
 			if tc == nil {
-				return core.ToolResult{}, fmt.Errorf("multi_input requires task context")
+				// SEP-2663 Option 2: TaskElicit needs the continuation
+				// goroutine's TaskContext.
+				return core.ToolResult{GoAsync: true}, nil
 			}
 
 			var (
@@ -234,6 +251,11 @@ func serve() {
 	srv.Register(core.TypedTool[struct{}, core.ToolResult]("protocol_error_job",
 		"A job that triggers a protocol-level error (panic). In v2: failed + error field.",
 		func(ctx core.ToolContext, _ struct{}) (core.ToolResult, error) {
+			if tasks.GetTaskContext(ctx) == nil {
+				// Run the panic inside the goroutine so the middleware's
+				// recover() turns it into a failed task, not a sync 500.
+				return core.ToolResult{GoAsync: true}, nil
+			}
 			log.Printf("[protocol_error_job] starting (will panic in 500ms)...")
 			time.Sleep(500 * time.Millisecond)
 			panic("simulated protocol error: server internal failure")
@@ -259,6 +281,9 @@ func serve() {
 			Execution: &core.ToolExecution{TaskSupport: core.TaskSupportRequired},
 		},
 		Handler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+			if tasks.GetTaskContext(ctx) == nil {
+				return core.ToolResult{GoAsync: true}, nil
+			}
 			var args struct {
 				JobID string `json:"job_id"`
 			}

--- a/ext/tasks/README.md
+++ b/ext/tasks/README.md
@@ -71,7 +71,7 @@ func myHandler(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, err
 }
 ```
 
-The `examples/mrtr` reference fixture's `test_tool_with_task` walks this exact pattern end-to-end (drives the matching `mrtr-tasks-composition` conformance scenario).
+The `examples/mrtr` reference fixture's `test_tool_with_task` walks this exact pattern end-to-end (drives the matching `mrtr-tasks-composition` conformance scenario). For the full conceptual walk-through — MRTR as a stateless continuation primitive, capabilities across wires, progressToken, the G6 filter replacement table, MRTR vs push vs task-input-flow — see [`docs/MRTR_TUTORIAL.md`](../../docs/MRTR_TUTORIAL.md).
 
 **G6 filter scope:** the SEP-2663 G6 session-notify filter (`notifications/progress` and `notifications/message` MUST NOT be sent on tasks) is installed only on the continuation goroutine's `bgCtx`. A sync-returning handler runs on the unfiltered POST ctx — it is responsible for not leaking those notifications itself.
 

--- a/ext/tasks/README.md
+++ b/ext/tasks/README.md
@@ -23,7 +23,14 @@ srv.RegisterTool(
         Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
     },
     func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
-        // ...
+        // Handlers whose work is genuinely async opt into the continuation
+        // goroutine via the GoAsync sentinel — see "Handler pattern" below.
+        if tasks.GetTaskContext(ctx) == nil {
+            return core.ToolResult{GoAsync: true}, nil
+        }
+        // Real work runs here, with TaskContext available for TaskElicit /
+        // TaskSample / SetStatus / progress emission under the G6 filter.
+        return core.TextResult("done"), nil
     },
 )
 
@@ -31,6 +38,42 @@ tasks.Register(tasks.Config{Server: srv})
 ```
 
 `tasks.Register` installs the v2 middleware that intercepts `tools/call` for task-eligible tools, registers the `tasks/get` / `tasks/update` / `tasks/cancel` method handlers (all gated on the client declaring the extension), and advertises the extension in the `initialize` response.
+
+## Handler pattern (SEP-2663 Option 2: GoAsync)
+
+Per the 2026-05-19 design decision on issue 347, mcpkit's v2 middleware runs the handler **synchronously first** and then dispatches on what it returned. The handler chooses one of three shapes:
+
+| Handler returns | Middleware does | When to use |
+|---|---|---|
+| `core.InputRequiredResult` via `ctx.RequestInput(...)` | Passes through unchanged; no task created | SEP-2322 MRTR round — gather input before deciding whether to escalate |
+| `core.ToolResult{GoAsync: true}` | Mints a task, spawns continuation goroutine that re-invokes the handler with `TaskContext` attached, returns `CreateTaskResult` | Slow / blocking work, `TaskElicit` / `TaskSample` calls, progress emission that should be filtered |
+| `core.ToolResult{...}` (no GoAsync, no IsInputRequired) | Wraps as a born-terminal task (`status: completed`, result stored, one `notifications/tasks` event fired), returns `CreateTaskResult` | Sync work that finishes immediately on a `TaskSupport=optional/required` tool |
+
+The continuation goroutine re-invokes the same handler with a `TaskContext` accessible via `tasks.GetTaskContext(ctx)`. The handler typically branches on that:
+
+```go
+func myHandler(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+    if tasks.GetTaskContext(ctx) != nil {
+        // Continuation: do the real work. TaskElicit / TaskSample / SetStatus
+        // are all available; emissions are filtered per SEP-2663 G6.
+        return doRealWork(ctx, req)
+    }
+
+    // Optional MRTR phase: gather input via ctx.RequestInput first.
+    if ctx.InputResponse("user_name") == nil {
+        return ctx.RequestInput(core.InputRequests{
+            "user_name": core.InputRequest{Method: "elicitation/create", Params: ...},
+        })
+    }
+
+    // MRTR complete; defer the rest to the continuation goroutine.
+    return core.ToolResult{GoAsync: true}, nil
+}
+```
+
+The `examples/mrtr` reference fixture's `test_tool_with_task` walks this exact pattern end-to-end (drives the matching `mrtr-tasks-composition` conformance scenario).
+
+**G6 filter scope:** the SEP-2663 G6 session-notify filter (`notifications/progress` and `notifications/message` MUST NOT be sent on tasks) is installed only on the continuation goroutine's `bgCtx`. A sync-returning handler runs on the unfiltered POST ctx — it is responsible for not leaking those notifications itself.
 
 ## Surface
 

--- a/ext/tasks/client_integration_test.go
+++ b/ext/tasks/client_integration_test.go
@@ -55,6 +55,13 @@ func newTaskV2TestServer(t *testing.T) (string, chan struct{}) {
 			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportRequired},
 		},
 		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+			// SEP-2663 Option-2 / Go side: tools whose work is actually async
+			// MUST opt into the goroutine via GoAsync. On the first (sync) pass
+			// there is no TaskContext, so we signal "go async"; the middleware
+			// re-invokes us in the continuation goroutine with TaskContext set.
+			if tasks.GetTaskContext(ctx) == nil {
+				return core.ToolResult{GoAsync: true}, nil
+			}
 			select {
 			case <-unblock:
 			case <-ctx.Done():
@@ -73,7 +80,10 @@ func newTaskV2TestServer(t *testing.T) (string, chan struct{}) {
 		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
 			tc := tasks.GetTaskContext(ctx)
 			if tc == nil {
-				return core.ToolResult{}, errString("no task ctx")
+				// First (sync) pass — defer the elicit-driven work to the
+				// continuation goroutine where TaskContext (and TaskElicit)
+				// are available.
+				return core.ToolResult{GoAsync: true}, nil
 			}
 			res, err := tc.TaskElicit(core.ElicitationRequest{
 				Message:         "delete?",

--- a/ext/tasks/mrtr_composition_test.go
+++ b/ext/tasks/mrtr_composition_test.go
@@ -1,0 +1,185 @@
+package tasks_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/panyam/mcpkit/client"
+	"github.com/panyam/mcpkit/core"
+	. "github.com/panyam/mcpkit/server"
+	tasks "github.com/panyam/mcpkit/ext/tasks"
+)
+
+// TestMRTR_TaskComposition exercises the SEP-2322 + SEP-2663 composition that
+// the GoAsync sentinel was introduced to enable: a single tool can run an
+// MRTR round-trip (returning InputRequiredResult to gather input) and then
+// escalate to async (returning CreateTaskResult). Pre-Option-2 this was
+// impossible because taskV2Middleware created the task BEFORE the handler ran,
+// so round 1 on a task-eligible tool could never surface as InputRequiredResult.
+//
+// Mirrors the upstream conformance scenario "mrtr-tasks-composition" / mrtr-08
+// (panyam/mcpconformance, branch feat/tasks-mrtr-extension,
+// src/scenarios/server/mrtr/ephemeral-flow.ts).
+func TestMRTR_TaskComposition(t *testing.T) {
+	srv := NewServer(core.ServerInfo{Name: "mrtr-task-composition-test", Version: "0.0.1"})
+
+	// Register the composition tool. Mirrors examples/mrtr's mrtrTaskCompositionTool:
+	//   1. sync, no user_name → InputRequiredResult.
+	//   2. sync, user_name present → GoAsync sentinel.
+	//   3. goroutine (TaskContext present) → final greeting.
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "test_tool_with_task",
+			Description: "MRTR → Tasks composition fixture",
+			InputSchema: map[string]any{"type": "object"},
+			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportRequired},
+		},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+			if tasks.GetTaskContext(ctx) != nil {
+				// Continuation phase: produce the final result.
+				var er struct {
+					Action  string `json:"action"`
+					Content struct {
+						Name string `json:"name"`
+					} `json:"content"`
+				}
+				if raw := ctx.InputResponse("user_name"); raw != nil {
+					_ = json.Unmarshal(raw, &er)
+				}
+				if er.Content.Name == "" {
+					return core.ErrorResult("task continuation lost user_name"), nil
+				}
+				return core.TextResult("Hello, " + er.Content.Name + "! (computed in task)"), nil
+			}
+			if ctx.InputResponse("user_name") == nil {
+				return ctx.RequestInput(core.InputRequests{
+					"user_name": core.InputRequest{
+						Method: "elicitation/create",
+						Params: json.RawMessage(`{"message":"What is your name?","requestedSchema":{"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}}`),
+					},
+				})
+			}
+			return core.ToolResult{GoAsync: true}, nil
+		},
+	)
+
+	tasks.Register(tasks.Config{Server: srv})
+
+	handler := srv.Handler(WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "mrtr-task-comp-test", Version: "0.0.1"},
+		client.WithTasksExtension(),
+	)
+	if err := c.Connect(); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+
+	// Round 1: no inputResponses. Expect InputRequiredResult, no task.
+	r1, err := c.Call("tools/call", map[string]any{
+		"name":      "test_tool_with_task",
+		"arguments": map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("round 1: %v", err)
+	}
+	var m1 map[string]any
+	if err := json.Unmarshal(r1.Raw, &m1); err != nil {
+		t.Fatalf("round 1 unmarshal: %v (raw=%s)", err, r1.Raw)
+	}
+	if rt, _ := m1["resultType"].(string); rt != string(core.ResultTypeInputRequired) {
+		t.Fatalf("round 1 resultType = %q, want %q; raw=%s",
+			rt, core.ResultTypeInputRequired, r1.Raw)
+	}
+	if _, present := m1["taskId"]; present {
+		t.Fatalf("round 1 MUST NOT carry taskId on InputRequiredResult; raw=%s", r1.Raw)
+	}
+	ir, ok := m1["inputRequests"].(map[string]any)
+	if !ok || ir["user_name"] == nil {
+		t.Fatalf("round 1 missing inputRequests.user_name; raw=%s", r1.Raw)
+	}
+	mrtrRequestState, _ := m1["requestState"].(string)
+
+	// Round 2: echo back the elicit response (+ requestState). Expect
+	// CreateTaskResult — the handler returned GoAsync after the MRTR loop.
+	r2, err := c.Call("tools/call", map[string]any{
+		"name":      "test_tool_with_task",
+		"arguments": map[string]any{},
+		"inputResponses": map[string]any{
+			"user_name": map[string]any{
+				"action":  "accept",
+				"content": map[string]any{"name": "Alice"},
+			},
+		},
+		"requestState": mrtrRequestState,
+	})
+	if err != nil {
+		t.Fatalf("round 2: %v", err)
+	}
+	var ctr core.CreateTaskResult
+	if err := json.Unmarshal(r2.Raw, &ctr); err != nil {
+		t.Fatalf("round 2 unmarshal CreateTaskResult: %v (raw=%s)", err, r2.Raw)
+	}
+	if ctr.ResultType != core.ResultTypeTask {
+		t.Fatalf("round 2 resultType = %q, want %q; raw=%s",
+			ctr.ResultType, core.ResultTypeTask, r2.Raw)
+	}
+	if ctr.TaskID == "" {
+		t.Fatalf("round 2 CreateTaskResult missing taskId; raw=%s", r2.Raw)
+	}
+
+	// Spec separation: CreateTaskResult MUST NOT carry MRTR requestState (the
+	// merged SEP-2663 removed requestState from the v2 wire shape).
+	var raw2 map[string]any
+	json.Unmarshal(r2.Raw, &raw2)
+	if _, present := raw2["requestState"]; present {
+		t.Errorf("CreateTaskResult MUST NOT carry requestState (SEP-2663 spec separation); raw=%s", r2.Raw)
+	}
+
+	// Round 3: poll tasks/get until terminal, then assert the inlined result
+	// reflects the answer gathered during the MRTR phase.
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		gres, err := c.Call("tasks/get", map[string]any{"taskId": ctr.TaskID})
+		if err != nil {
+			t.Fatalf("tasks/get: %v", err)
+		}
+		var dt core.DetailedTask
+		if err := json.Unmarshal(gres.Raw, &dt); err != nil {
+			t.Fatalf("unmarshal DetailedTask: %v", err)
+		}
+		if dt.Status.IsTerminal() {
+			if dt.Status != core.TaskCompleted {
+				t.Fatalf("final status = %q, want %q; raw=%s",
+					dt.Status, core.TaskCompleted, gres.Raw)
+			}
+			if dt.Result == nil || len(dt.Result.Content) == 0 {
+				t.Fatalf("terminal task missing inlined result; raw=%s", gres.Raw)
+			}
+			text := dt.Result.Content[0].Text
+			if !strings.Contains(text, "Alice") {
+				t.Errorf("final task text = %q, want it to contain \"Alice\"", text)
+			}
+			if !strings.Contains(text, "computed in task") {
+				t.Errorf("final task text = %q, want it to mention task continuation", text)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("task did not reach terminal in time; last status = %q", dt.Status)
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("context expired waiting for terminal: %v", ctx.Err())
+		case <-time.After(25 * time.Millisecond):
+		}
+	}
+}

--- a/ext/tasks/stateless_wire_test.go
+++ b/ext/tasks/stateless_wire_test.go
@@ -73,7 +73,9 @@ func newStatelessTaskServer(t *testing.T) string {
 		func(ctx core.ToolContext, _ core.ToolRequest) (core.ToolResult, error) {
 			tc := tasks.GetTaskContext(ctx)
 			if tc == nil {
-				return core.ToolResult{}, errors.New("no task ctx")
+				// SEP-2663 Option 2: TaskElicit needs the continuation
+				// goroutine's TaskContext.
+				return core.ToolResult{GoAsync: true}, nil
 			}
 			res, err := tc.TaskElicit(core.ElicitationRequest{
 				Message:         "delete?",

--- a/ext/tasks/tasks.go
+++ b/ext/tasks/tasks.go
@@ -345,13 +345,30 @@ func gateOnTasksExtension(inner server.MethodHandler) server.MethodHandler {
 // --- server.Middleware ---
 
 // taskV2Middleware intercepts tools/call requests. In v2, the server decides
-// whether to create a task based on the tool's configuration — the client
-// does NOT send a `task` param.
+// whether to create a task based on the tool's configuration AND on what the
+// handler returns — the client does NOT send a `task` param.
 //
-// Behavior by taskSupport:
-//   - required: always create a task (no client hint needed)
-//   - optional: create a task (server-directed)
-//   - forbidden/absent: pass through (sync execution)
+// Flow (per the SEP-2663 + SEP-2322 composition contract):
+//
+//  1. taskSupport=forbidden/absent → pass through (sync execution).
+//  2. taskSupport=optional/required + client hasn't negotiated the tasks
+//     extension → -32003 for required, sync fallback for optional.
+//  3. Otherwise run the handler synchronously via next() FIRST, then dispatch
+//     on the returned result:
+//     - core.InputRequiredResult → MRTR round; return as-is, no task created.
+//       Lets a handler gather input via the MRTR loop and only later switch
+//       to async (SEP-2663 451f5e1).
+//     - core.ToolResult with GoAsync=true → mint a task, spawn a continuation
+//       goroutine that re-invokes the handler with a [TaskContext] attached,
+//       and return CreateTaskResult to the client. The handler's second
+//       invocation detects the TaskContext via [GetTaskContext] and runs the
+//       async branch (typically the "expensive work").
+//     - core.ToolResult (sync return, no GoAsync) → mint a task that is born
+//       terminal: StoreTerminalResult with TaskCompleted, fire one
+//       notifications/tasks event, and return CreateTaskResult. No goroutine
+//       runs. SEP-2663 G6 (no progress/log on task streams) only applies to
+//       the goroutine continuation, since that's where the session-notify
+//       filter is installed.
 func taskV2Middleware(reg *server.Registry, rt *v2TaskRuntime, cfg Config) server.Middleware {
 	return func(ctx context.Context, req *core.Request, next server.MiddlewareFunc) (*core.Response, error) {
 		if req.Method != "tools/call" {
@@ -379,8 +396,8 @@ func taskV2Middleware(reg *server.Registry, rt *v2TaskRuntime, cfg Config) serve
 		}
 
 		// Determine effective taskSupport first. Absent Execution = forbidden.
-		// In v2 this is a server-internal hint about which tools should be
-		// async — clients no longer opt in via a `task` param.
+		// In v2 this is a server-internal hint about which tools may be
+		// surfaced as tasks — clients no longer opt in via a `task` param.
 		effectiveSupport := core.TaskSupportForbidden
 		if def.Execution != nil {
 			effectiveSupport = def.Execution.TaskSupport
@@ -423,141 +440,228 @@ func taskV2Middleware(reg *server.Registry, rt *v2TaskRuntime, cfg Config) serve
 			return next(ctx, req)
 		}
 
-		// required or optional → server creates a task.
-		taskID := generateTaskID()
-		now := time.Now().UTC().Format(time.RFC3339)
-
-		// SEP-2663 wire and server.TaskStore both use milliseconds, so the config
-		// value flows through unchanged in either direction.
-		ttlMs := cfg.DefaultTTLMs
-		pollMs := cfg.DefaultPollMs
-
-		info := core.TaskInfo{
-			TaskID:        taskID,
-			Status:        core.TaskWorking,
-			CreatedAt:     now,
-			LastUpdatedAt: now,
-			TTL:           core.IntPtr(ttlMs), // store uses ms internally
-			PollInterval:  pollMs,
+		// SEP-2322 + SEP-2663 composition: run the handler synchronously so we
+		// can observe whether it wants to stay in an MRTR loop, finish sync,
+		// or escalate to a background task. This is the key inversion vs the
+		// pre-Option-2 "create task up-front, run handler in goroutine" shape
+		// — that pattern could not surface a round-1 InputRequiredResult on a
+		// task-eligible tool, because the task was already minted before the
+		// handler ran. Tracked / locked in on mcpkit#347.
+		resp, mwErr := next(ctx, req)
+		if mwErr != nil {
+			return resp, mwErr
 		}
-		store := rt.store
-		sessionID := core.GetSessionID(ctx)
-		if err := store.Create(info, sessionID); err != nil {
-			return core.NewErrorResponse(req.ID, -32603, "failed to create task: "+err.Error()), nil
+		if resp == nil || resp.Error != nil {
+			return resp, nil
 		}
 
-		var progressToken any
-		if envelope.Meta != nil {
-			progressToken = envelope.Meta.ProgressToken
+		switch r := resp.Result.(type) {
+		case core.InputRequiredResult:
+			// MRTR round — let the dispatcher's reshaped response flow back
+			// to the client unchanged. No task is created during MRTR rounds;
+			// task creation happens (if at all) on a later round when the
+			// handler returns GoAsync or a final sync result.
+			return resp, nil
+
+		case core.ToolResult:
+			var progressToken any
+			if envelope.Meta != nil {
+				progressToken = envelope.Meta.ProgressToken
+			}
+			if r.GoAsync {
+				return spawnGoAsyncTask(ctx, req, next, rt, cfg, envelope.Name, progressToken)
+			}
+			return wrapSyncAsCompletedTask(ctx, req, rt, cfg, r)
+
+		default:
+			// Some other result shape (e.g. an upstream middleware already
+			// produced a CreateTaskResult, or a non-tool response sneaks
+			// through). Pass through unchanged.
+			return resp, nil
 		}
+	}
+}
 
-		// Run the tool asynchronously.
-		go func() {
-			bgCtx := core.DetachForBackground(ctx)
-			bgCtx, cancelFunc := context.WithCancel(bgCtx)
+// spawnGoAsyncTask mints a v2 task, spawns the continuation goroutine that
+// re-invokes the handler with TaskContext attached, and returns the
+// CreateTaskResult envelope to the original caller.
+//
+// The handler is expected to be a state machine that detects the TaskContext
+// on re-invocation (via [GetTaskContext]) and runs its async branch — e.g.
+// the long-running work that was deferred after the MRTR loop completed.
+func spawnGoAsyncTask(
+	ctx context.Context,
+	req *core.Request,
+	next server.MiddlewareFunc,
+	rt *v2TaskRuntime,
+	cfg Config,
+	toolName string,
+	progressToken any,
+) (*core.Response, error) {
+	taskID := generateTaskID()
+	now := time.Now().UTC().Format(time.RFC3339)
+	ttlMs := cfg.DefaultTTLMs
+	pollMs := cfg.DefaultPollMs
 
-			// SEP-2663 input-request flow: each v2 task gets its own
-			// inputState. TaskContext.TaskElicit / TaskSample stash pending
-			// requests here; tasks/update delivers responses; tasks/get
-			// snapshots them for the DetailedTask wire shape.
-			inputState := newV2InputState()
-			tc := &TaskContext{
-				taskID:        taskID,
-				sessionID:     sessionID,
-				store:         store,
-				inputState:    inputState,
-				progressToken: progressToken,
-			}
-			bgCtx = WithTaskContext(bgCtx, tc)
-			// SEP-2663: notifications/progress and notifications/message MUST
-			// NOT be sent on tasks. Filter at the session-notify boundary so
-			// any tool handler that calls EmitProgress or EmitLog while it
-			// happens to be running as a task silently no-ops rather than
-			// leaking onto the session stream.
-			bgCtx = core.ApplySessionNotifyFilter(bgCtx,
-				"notifications/progress",
-				"notifications/message",
-			)
-			rt.register(taskID, envelope.Name, &activeTask{cancel: cancelFunc, inputState: inputState})
+	info := core.TaskInfo{
+		TaskID:        taskID,
+		Status:        core.TaskWorking,
+		CreatedAt:     now,
+		LastUpdatedAt: now,
+		TTL:           core.IntPtr(ttlMs),
+		PollInterval:  pollMs,
+	}
+	store := rt.store
+	sessionID := core.GetSessionID(ctx)
+	if err := store.Create(info, sessionID); err != nil {
+		return core.NewErrorResponse(req.ID, -32603, "failed to create task: "+err.Error()), nil
+	}
 
-			defer func() {
-				cancelFunc()
-				rt.unregister(taskID)
-				if r := recover(); r != nil {
-					// Panic = protocol-level error in v2.
-					msg := fmt.Sprintf("internal error: %v", r)
-					te := &core.TaskError{Code: -32603, Message: msg}
-					rt.setTaskError(taskID, te)
-					store.StoreTerminalResult(taskID, sessionID, core.TaskFailed, core.ErrorResult(msg), msg)
-					notifyV2TaskStatus(bgCtx, rt, store, taskID, sessionID)
-				}
-			}()
+	go func() {
+		bgCtx := core.DetachForBackground(ctx)
+		bgCtx, cancelFunc := context.WithCancel(bgCtx)
 
-			resp, mwErr := next(bgCtx, req)
+		// SEP-2663 input-request flow: each v2 task gets its own inputState.
+		// TaskContext.TaskElicit / TaskSample stash pending requests here;
+		// tasks/update delivers responses; tasks/get snapshots them for the
+		// DetailedTask wire shape. Per the spec separation rules, this
+		// inputState is scoped to the task lifetime — NOT carried over from
+		// the preceding MRTR phase's inputResponses.
+		inputState := newV2InputState()
+		tc := &TaskContext{
+			taskID:        taskID,
+			sessionID:     sessionID,
+			store:         store,
+			inputState:    inputState,
+			progressToken: progressToken,
+		}
+		bgCtx = WithTaskContext(bgCtx, tc)
+		// SEP-2663 G6: notifications/progress and notifications/message MUST
+		// NOT be sent on tasks. Filter at the session-notify boundary so any
+		// tool handler that calls EmitProgress or EmitLog while it happens to
+		// be running as the GoAsync continuation silently no-ops rather than
+		// leaking onto the session stream.
+		bgCtx = core.ApplySessionNotifyFilter(bgCtx,
+			"notifications/progress",
+			"notifications/message",
+		)
+		rt.register(taskID, toolName, &activeTask{cancel: cancelFunc, inputState: inputState})
 
-			// If middleware returned a transport-level error, treat it as a task failure.
-			if mwErr != nil {
-				te := &core.TaskError{Code: -32603, Message: mwErr.Error()}
+		defer func() {
+			cancelFunc()
+			rt.unregister(taskID)
+			if rec := recover(); rec != nil {
+				msg := fmt.Sprintf("internal error: %v", rec)
+				te := &core.TaskError{Code: -32603, Message: msg}
 				rt.setTaskError(taskID, te)
-				store.StoreTerminalResult(taskID, sessionID, core.TaskFailed, core.ErrorResult(mwErr.Error()), mwErr.Error())
+				store.StoreTerminalResult(taskID, sessionID, core.TaskFailed, core.ErrorResult(msg), msg)
 				notifyV2TaskStatus(bgCtx, rt, store, taskID, sessionID)
-				return
 			}
-
-			// Check if already cancelled — StoreTerminalResult rejects terminal→terminal.
-			if resp.Error != nil {
-				// Protocol/framework error (e.g., middleware failure, marshaling bug).
-				te := &core.TaskError{
-					Code:    resp.Error.Code,
-					Message: resp.Error.Message,
-				}
-				rt.setTaskError(taskID, te)
-				store.StoreTerminalResult(taskID, sessionID, core.TaskFailed, core.ErrorResult(resp.Error.Message), resp.Error.Message)
-				notifyV2TaskStatus(bgCtx, rt, store, taskID, sessionID)
-				return
-			}
-
-			raw, err := json.Marshal(resp.Result)
-			if err != nil {
-				te := &core.TaskError{Code: -32603, Message: "failed to marshal tool result"}
-				rt.setTaskError(taskID, te)
-				store.StoreTerminalResult(taskID, sessionID, core.TaskFailed, core.ErrorResult("failed to marshal tool result"), "")
-				notifyV2TaskStatus(bgCtx, rt, store, taskID, sessionID)
-				return
-			}
-
-			var toolResult core.ToolResult
-			if err := json.Unmarshal(raw, &toolResult); err != nil {
-				te := &core.TaskError{Code: -32603, Message: "failed to unmarshal tool result"}
-				rt.setTaskError(taskID, te)
-				store.StoreTerminalResult(taskID, sessionID, core.TaskFailed, core.ErrorResult("failed to unmarshal tool result"), "")
-				notifyV2TaskStatus(bgCtx, rt, store, taskID, sessionID)
-				return
-			}
-
-			// v2 error semantics: tool execution errors are "completed" with isError:true.
-			// Only protocol errors (resp.Error != nil) are "failed".
-			store.StoreTerminalResult(taskID, sessionID, core.TaskCompleted, toolResult, "")
-			notifyV2TaskStatus(bgCtx, rt, store, taskID, sessionID)
 		}()
 
-		// SEP-2243: stage Mcp-Name on the HTTP response so transports / proxies
-		// / observability can route or log against the task id without parsing
-		// the JSON body. No-op for non-HTTP transports (stdio, in-process).
-		core.SetResponseHeader(ctx, mcpNameHeader, taskID)
+		resp, mwErr := next(bgCtx, req)
+		if mwErr != nil {
+			te := &core.TaskError{Code: -32603, Message: mwErr.Error()}
+			rt.setTaskError(taskID, te)
+			store.StoreTerminalResult(taskID, sessionID, core.TaskFailed, core.ErrorResult(mwErr.Error()), mwErr.Error())
+			notifyV2TaskStatus(bgCtx, rt, store, taskID, sessionID)
+			return
+		}
+		if resp.Error != nil {
+			te := &core.TaskError{Code: resp.Error.Code, Message: resp.Error.Message}
+			rt.setTaskError(taskID, te)
+			store.StoreTerminalResult(taskID, sessionID, core.TaskFailed, core.ErrorResult(resp.Error.Message), resp.Error.Message)
+			notifyV2TaskStatus(bgCtx, rt, store, taskID, sessionID)
+			return
+		}
 
-		// Build the v2 wire envelope. SEP-2663 defines CreateTaskResult as
-		// `Result & Task` — a flat intersection — so the task fields are
-		// inlined alongside resultType, NOT nested under a "task" key.
-		// MUST NOT carry result/error/inputRequests/requestState (SEP-2663 —
-		// those belong on DetailedTask returned by tasks/get).
-		wireTask := toTaskInfoV2(info)
-		wireTask.TTLMs = core.IntPtr(ttlMs)
-		return core.NewResponse(req.ID, core.CreateTaskResult{
-			ResultType: core.ResultTypeTask,
-			TaskInfoV2: wireTask,
-		}), nil
+		raw, err := json.Marshal(resp.Result)
+		if err != nil {
+			te := &core.TaskError{Code: -32603, Message: "failed to marshal tool result"}
+			rt.setTaskError(taskID, te)
+			store.StoreTerminalResult(taskID, sessionID, core.TaskFailed, core.ErrorResult("failed to marshal tool result"), "")
+			notifyV2TaskStatus(bgCtx, rt, store, taskID, sessionID)
+			return
+		}
+
+		var toolResult core.ToolResult
+		if err := json.Unmarshal(raw, &toolResult); err != nil {
+			te := &core.TaskError{Code: -32603, Message: "failed to unmarshal tool result"}
+			rt.setTaskError(taskID, te)
+			store.StoreTerminalResult(taskID, sessionID, core.TaskFailed, core.ErrorResult("failed to unmarshal tool result"), "")
+			notifyV2TaskStatus(bgCtx, rt, store, taskID, sessionID)
+			return
+		}
+
+		// v2 error semantics: tool execution errors are "completed" with
+		// isError:true. Only protocol errors (resp.Error != nil) are "failed".
+		store.StoreTerminalResult(taskID, sessionID, core.TaskCompleted, toolResult, "")
+		notifyV2TaskStatus(bgCtx, rt, store, taskID, sessionID)
+	}()
+
+	core.SetResponseHeader(ctx, mcpNameHeader, taskID)
+	wireTask := toTaskInfoV2(info)
+	wireTask.TTLMs = core.IntPtr(ttlMs)
+	return core.NewResponse(req.ID, core.CreateTaskResult{
+		ResultType: core.ResultTypeTask,
+		TaskInfoV2: wireTask,
+	}), nil
+}
+
+// wrapSyncAsCompletedTask handles the case where the handler returned a sync
+// ToolResult without the GoAsync sentinel. The task is born terminal: we mint
+// it, immediately StoreTerminalResult with TaskCompleted, fire one
+// notifications/tasks event on the session-level stream, and return the
+// CreateTaskResult envelope. No goroutine ever runs; the work is already done.
+func wrapSyncAsCompletedTask(
+	ctx context.Context,
+	req *core.Request,
+	rt *v2TaskRuntime,
+	cfg Config,
+	result core.ToolResult,
+) (*core.Response, error) {
+	taskID := generateTaskID()
+	now := time.Now().UTC().Format(time.RFC3339)
+	ttlMs := cfg.DefaultTTLMs
+	pollMs := cfg.DefaultPollMs
+
+	// Create in TaskWorking so the immediately-following StoreTerminalResult
+	// can transition to completed and persist the result; the store rejects
+	// terminal→terminal transitions to guard against cancel/complete races.
+	info := core.TaskInfo{
+		TaskID:        taskID,
+		Status:        core.TaskWorking,
+		CreatedAt:     now,
+		LastUpdatedAt: now,
+		TTL:           core.IntPtr(ttlMs),
+		PollInterval:  pollMs,
 	}
+	store := rt.store
+	sessionID := core.GetSessionID(ctx)
+	if err := store.Create(info, sessionID); err != nil {
+		return core.NewErrorResponse(req.ID, -32603, "failed to create task: "+err.Error()), nil
+	}
+	if err := store.StoreTerminalResult(taskID, sessionID, core.TaskCompleted, result, ""); err != nil {
+		return core.NewErrorResponse(req.ID, -32603, "failed to store sync result: "+err.Error()), nil
+	}
+	// Reflect the just-stored terminal status in the wire envelope so the
+	// CreateTaskResult shows status="completed" instead of the transient
+	// "working" we used to bootstrap the store entry.
+	info.Status = core.TaskCompleted
+
+	// Route the lifecycle notification through the session-level GET SSE
+	// stream so clients holding a long-lived listener still see the
+	// terminal transition (matches the GoAsync path).
+	bgCtx := core.DetachForBackground(ctx)
+	notifyV2TaskStatus(bgCtx, rt, store, taskID, sessionID)
+
+	core.SetResponseHeader(ctx, mcpNameHeader, taskID)
+	wireTask := toTaskInfoV2(info)
+	wireTask.TTLMs = core.IntPtr(ttlMs)
+	return core.NewResponse(req.ID, core.CreateTaskResult{
+		ResultType: core.ResultTypeTask,
+		TaskInfoV2: wireTask,
+	}), nil
 }
 
 // mcpNameHeader is the SEP-2243 HTTP response header carrying the taskId

--- a/ext/tasks/tasks_test.go
+++ b/ext/tasks/tasks_test.go
@@ -337,6 +337,12 @@ func newTaskV2ServerWithSlow(t *testing.T) (*Server, chan struct{}) {
 			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportRequired},
 		},
 		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+			// SEP-2663 Option 2: slow / blocking work must opt into the
+			// continuation goroutine via GoAsync. The middleware re-invokes us
+			// in the goroutine with TaskContext set.
+			if tasks.GetTaskContext(ctx) == nil {
+				return core.ToolResult{GoAsync: true}, nil
+			}
 			select {
 			case <-unblock:
 			case <-ctx.Done():
@@ -726,7 +732,9 @@ func newTaskV2ServerWithElicit(t *testing.T) *Server {
 		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
 			tc := tasks.GetTaskContext(ctx)
 			if tc == nil {
-				return core.ToolResult{}, errorString("confirm-delete requires task context")
+				// SEP-2663 Option 2: TaskElicit requires the continuation
+				// goroutine's TaskContext, so signal GoAsync on the sync pass.
+				return core.ToolResult{GoAsync: true}, nil
 			}
 
 			var args struct {
@@ -1058,6 +1066,13 @@ func TestV2_NoProgressOrMessageOnTaskGoroutine(t *testing.T) {
 			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
 		},
 		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+			// SEP-2663 G6 filter is installed only on the continuation-goroutine
+			// bgCtx, so emissions only get dropped if the handler opts into
+			// GoAsync. A sync return would emit on the unfiltered POST ctx and
+			// leak — explicitly NOT what this test is asserting.
+			if tasks.GetTaskContext(ctx) == nil {
+				return core.ToolResult{GoAsync: true}, nil
+			}
 			// Both of these would normally fan out on the session stream.
 			// The v2 task filter is expected to drop both silently.
 			ctx.EmitProgress("ignored-token", 1, 2, "halfway")

--- a/server/mrtr_test.go
+++ b/server/mrtr_test.go
@@ -356,27 +356,6 @@ func TestMRTR_MultiRoundAccumulatesAnswers(t *testing.T) {
 	}
 }
 
-// TestMRTR_TaskComposition_Skipped is a tracking placeholder for MRTR↔Tasks
-// composition (gather input via MRTR rounds, then return CreateTaskResult on
-// the final round). SEP-2663 commit 451f5e1 (Apr 30) made this flow normative,
-// but our taskV2Middleware (server/tasks_v2.go) creates the task BEFORE the
-// handler runs, so the handler never gets to return InputRequiredResult on
-// round 1 — the middleware has already sent CreateTaskResult to the client.
-//
-// Resolving this is a real design choice (always-sync handler vs. handler-
-// signalled async) tracked as mcpkit issue 347. Re-enable by deleting the
-// t.Skip once that lands. A matching scenario lives skipped in the
-// conformance suite (panyam/mcpconformance, branch feat/tasks-mrtr-extension,
-// src/scenarios/server/mrtr/ephemeral-flow.ts:mrtr-tasks-composition).
-func TestMRTR_TaskComposition_Skipped(t *testing.T) {
-	t.Skip("MRTR→Tasks composition deferred — tracking: mcpkit issue 347")
-	// Implementation cross-cuts MRTR (server/) and v2 tasks (ext/tasks/);
-	// rebuild as an integration test under ext/tasks/ when mcpkit issue 347
-	// lands. A matching scenario lives skipped in the conformance suite
-	// (panyam/mcpconformance, branch feat/tasks-mrtr-extension,
-	// src/scenarios/server/mrtr/ephemeral-flow.ts:mrtr-tasks-composition).
-}
-
 // connectMRTRClient is a one-off helper for MRTR tests — most existing v2
 // fixtures register a full tasks setup we don't need here.
 func connectMRTRClient(t *testing.T, srv *Server, opts ...client.ClientOption) *client.Client {


### PR DESCRIPTION
## What changes

Three commits closing the 2026-05-19 design decision on issue 347 (Option 2 — explicit `GoAsync` sentinel) and unblocking the SEP-2322 + SEP-2663 composition flow end-to-end.

1. **`feat(tasks): SEP-2663 Option-2 GoAsync sentinel + middleware peek`**
   - New `core.ToolResult.GoAsync` bool (in-process sentinel; not serialized).
   - `taskV2Middleware` now runs the handler synchronously via `next()` first and dispatches on the result:
     - `core.InputRequiredResult` → MRTR round; pass through; no task created.
     - `core.ToolResult{GoAsync:true}` → mint a task, spawn a continuation goroutine that re-invokes the handler with `TaskContext` attached, return `CreateTaskResult`.
     - `core.ToolResult{...}` (no GoAsync) → wrap as a born-terminal task (status `completed`, result stored, one `notifications/tasks` fired), return `CreateTaskResult`.
   - The SEP-2663 G6 session-notify filter (`notifications/progress` / `notifications/message` MUST NOT be sent on tasks) is installed only on the continuation goroutine's bgCtx, so its guarantee narrows to GoAsync handlers. Sync-returning handlers are responsible for their own emissions — documented in `ext/tasks/README.md`.
   - Pre-Option-2 the middleware created the task BEFORE the handler ran, which made the MRTR→Tasks composition impossible (round 1 always emitted `CreateTaskResult` instead of `InputRequiredResult`). Reversing the order is the core inversion.

2. **`feat(mrtr): SEP-2322 + SEP-2663 composition end-to-end (mrtr-08)`**
   - New `test_tool_with_task` in `examples/mrtr` walks the three-phase pattern (MRTR elicit → GoAsync → continuation).
   - `examples/mrtr` now imports `ext/tasks` and calls `tasks.Register` so `taskV2Middleware` is wired in.
   - New `ext/tasks/mrtr_composition_test.go` integration test drives the full flow against a live httptest server (asserts: round 1 InputRequiredResult with no taskId; round 2 CreateTaskResult with taskId and no requestState; tasks/get terminal completion reflects MRTR answer).
   - Removed the long-standing `TestMRTR_TaskComposition_Skipped` placeholder in `server/mrtr_test.go` per its own "rebuild as integration test under ext/tasks" guidance.

3. **`docs(ext/tasks): document SEP-2663 Option-2 GoAsync handler pattern`**
   - Adds a "Handler pattern" table + worked example so new users see the canonical structure first.

## Fixture / example migration (in commit 1)

Every v2 task handler whose work is genuinely async (blocks on a channel, calls `TaskElicit`/`TaskSample`, emits progress mid-run, panics after a sleep, etc.) now signals `GoAsync` on the first sync pass and runs the real work in the continuation. Sync-returning tools (`fast-task`, `must-task`, `slow_compute`'s 0-second shortcut) stay as-is and get the wrap-as-completed path.

Touched fixtures and examples: `ext/tasks/tasks_test.go` (slow-task, confirm-delete, progress-emit-task); `ext/tasks/client_integration_test.go` (slow-task, confirm-delete); `ext/tasks/stateless_wire_test.go` (confirm_delete); `examples/tasks-v2/main.go` (slow_compute, failing_job, confirm_delete, multi_input, protocol_error_job, external_job).

V1 (examples/tasks, server.RegisterTasksV1) is unaffected — different middleware path.

## Decision log

Things a cold reviewer might second-guess; here's where each landed and why.

- **Option A strict (sync return → born-terminal task) vs Option C (always-goroutine).** When a `TaskSupport=optional/required` handler returns a sync `ToolResult` with no GoAsync, the middleware creates a task in `TaskWorking`, immediately transitions it to `TaskCompleted` via `StoreTerminalResult`, and fires one `notifications/tasks` event — no goroutine runs. Option C (always-goroutine, even for sync results) would have preserved the working→completed lifecycle tick for free and kept the G6 filter universal, at the cost of a goroutine hop for every fast tool. We picked the stricter Option A because (a) the spec language treats the GoAsync sentinel as explicit-opt-in, (b) sync tools shouldn't pay an async tax, and (c) conformance scenarios don't observe lifecycle event ordering on fast tools (verified — see "Conformance impact" below).

- **GoAsync as a `bool` sentinel vs an `AsyncFunc` closure on the sentinel.** The locked-in API is just `GoAsync bool` (`core/tool.go`). The continuation in the goroutine is the same handler **re-invoked** with a `TaskContext` injected on the bgCtx; handlers branch on `tasks.GetTaskContext(ctx) != nil`. A closure-carrying sentinel was considered and rejected: it would have required a function-typed field on `ToolResult` (which is otherwise pure data), and the re-invoke pattern is easier to reason about (one handler, one signature, state-machine on `TaskContext` presence). The cost is that the handler runs twice per GoAsync `tools/call` — flagged in Risks below.

- **Fixture migration in this same PR.** Under Option A, any v2 task handler that did its work synchronously (block on a channel, call `TaskElicit`, sleep-and-panic) would now hang the `tools/call` response indefinitely, because the middleware runs the handler synchronously before returning anything. Migrating those fixtures + examples to the GoAsync pattern is therefore strictly required for the PR to be green — not optional cleanup. Splitting it into a follow-up would have left main red.

- **G6 filter scope narrowed.** Pre-PR, the SEP-2663 G6 rule (`notifications/progress` and `notifications/message` MUST NOT be sent on tasks) was enforced via `core.ApplySessionNotifyFilter` on the bgCtx that every task handler ran on. Post-PR, only the GoAsync continuation gets that filter — sync-returning tools run on the unfiltered POST ctx and could leak. The `ext/tasks/README.md` Handler pattern section documents this explicitly. The alternative was Option C (universal goroutine), with its own tradeoffs.

## Risk areas / pressure-test

- **Handler runs twice per GoAsync `tools/call`.** Once sync (returns the GoAsync sentinel), once in the continuation goroutine (real work). The canonical pattern gates side-effecting code behind `tasks.GetTaskContext(ctx) != nil`, but a handler that does logging / metrics / DB writes on the wrong side of that branch will double-fire. Worth checking on downstream handlers (or `gosec`-style lint adds in a follow-up).

- **Re-routing through the full middleware chain in the goroutine.** The goroutine calls `next(bgCtx, req)` again, which re-runs every middleware between `taskV2Middleware` and the dispatcher (auth, rate-limit, audit-log, etc.). Non-idempotent middleware will fire twice. Today's middleware chain happens to be safe (audit/auth read-only on this path); flagged here because the contract is non-obvious.

- **G6 filter no longer covers sync tools.** A `TaskSupport=optional/required` tool that returns sync and calls `EmitProgress` or `EmitLog` will now leak those notifications onto the wire — pre-PR they would have been silently dropped by the filter. There is no vet/lint enforcing the new contract. The `ext/tasks/README.md` Handler pattern section documents it; a follow-up could add a runtime assert or static check.

- **Notification routing for born-terminal tasks.** The wrap-as-completed path fires one `notifications/tasks` event via `core.DetachForBackground(ctx)` so it routes to the long-lived GET SSE stream. If the SSE listener hasn't been wired up yet (race vs `initialize`), or the client is on the stateless wire (no persistent push channel), the notification silently drops. Clients should not rely on it for born-terminal tasks — `tasks/get` polling is authoritative.

## Out of scope

- **Stateless wire MRTR — still fails 7/8.** Pre-existing gap, surfaces on `main` today before this PR lands. The stateless dispatcher's `callToolForStateless` (`server/stateless_backend.go`) doesn't parse `inputResponses`/`requestState` from `tools/call` params and doesn't reshape an `IsInputRequired` sentinel into wire-shape `InputRequiredResult` — see the source comment in `server/stateless/dispatch.go:26`. Tracked at issue 452 (now unblocked since 444 closed). The matching `mrtr-tasks-composition` conformance scenario fails on the stateless wire for the same reason. Both repos will pass 8/8 on both wires once 452 lands.

- **Stateless-wire-side support for the GoAsync sentinel.** The middleware peek is wire-agnostic by construction — `next()` returns the same `core.Response.Result` types regardless of how the tool was dispatched, so once 452 wires stateless MRTR in, GoAsync composition should "just work" without further changes here. Will be verified when 452 lands.

- **Static check / vet rule for sync handlers emitting notifications.** Would catch the narrowed G6 filter case. Punt to a follow-up.

## Conformance

- **Legacy wire — 8/8** (was 7/8 + 1 SKIPPED). The new `mrtr-tasks-composition` check is activated in the matching conformance PR (panyam/mcpconformance PR 7, stacked on PR 6).
- **Stateless wire — see Out of scope.**

## Reviewer's guide

Read in this order:

1. [core/tool.go](https://github.com/panyam/mcpkit/pull/484/files#diff-0c4cfc445e145347f6ac8b4edaa2ca030b6512a3a99e6379f5122df3ca014d22) — the new `GoAsync` field + its doc block (one struct field).
2. [ext/tasks/tasks.go](https://github.com/panyam/mcpkit/pull/484/files#diff-6b15314e7b637ac95e29f77601d89c4731b2aa4943266a4013345595095df47b) — the rewritten `taskV2Middleware` + two helpers (`spawnGoAsyncTask`, `wrapSyncAsCompletedTask`). The whole point of the PR.
3. [ext/tasks/mrtr_composition_test.go](https://github.com/panyam/mcpkit/pull/484/files#diff-bb53976a20a1a30af1179e5f09bc4d9af0838b53c0f9be4abacb67adcd65341c) — new integration test; doubles as a worked example of the three-phase pattern.
4. [examples/mrtr/main.go](https://github.com/panyam/mcpkit/pull/484/files#diff-d999e8347c6d39541b70a61c0e2d2e454dd8e4ba01e9abff0f901e3958320040) — `mrtrTaskCompositionTool` shows the canonical handler shape.
5. [ext/tasks/README.md](https://github.com/panyam/mcpkit/pull/484/files#diff-b77461b568893274a40590cb3d759a76e76280129e5fdeaf865d9fe277e21332) — the "Handler pattern" section codifies the contract.
6. The remaining fixture/example handler diffs are mechanical: insert `if tasks.GetTaskContext(ctx) == nil { return core.ToolResult{GoAsync: true}, nil }` at the top.

## Closes / tracks

- Closes 347 (SEP-2322 + SEP-2663 composition middleware refactor).
- Unblocks the long-deferred 8th MRTR conformance scenario.
- Stateless MRTR follow-up tracked in issue 452.

## Test plan

- [x] `go test ./...` (root module) green.
- [x] `cd ext/tasks && go test ./...` green (including the new `TestMRTR_TaskComposition`).
- [x] `MCP_WIRE_MODES=legacy make testconf-mrtr` → 8/8 + local sentinel green.
- [x] `examples/mrtr` and `examples/tasks-v2` build clean.
- [ ] Reviewer: re-run `make testconf-mrtr` once the matching mcpconformance PR 7 lands on its base.
