### PR TITLE
feat(core)!: sealed-interface ToolResponse / PromptResponse returns (closes 486)

### DIFF
--- a/client/client_ext_test.go
+++ b/client/client_ext_test.go
@@ -35,7 +35,7 @@ func newUITestServer() *server.Server {
 			Description: "Visible to everyone",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("public"), nil
 		},
 	)
@@ -52,7 +52,7 @@ func newUITestServer() *server.Server {
 				},
 			},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("model"), nil
 		},
 	)
@@ -70,7 +70,7 @@ func newUITestServer() *server.Server {
 				},
 			},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("both"), nil
 		},
 	)
@@ -87,7 +87,7 @@ func newUITestServer() *server.Server {
 				},
 			},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("app-only"), nil
 		},
 	)
@@ -99,7 +99,7 @@ func newUITestServer() *server.Server {
 			Description: "Reports client UI support",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			if core.ClientSupportsUI(ctx) {
 				return core.TextResult("ui: yes"), nil
 			}
@@ -180,7 +180,7 @@ func TestClientServerSupportsUI(t *testing.T) {
 		srv := server.NewServer(core.ServerInfo{Name: "plain", Version: "1.0"})
 		srv.RegisterTool(
 			core.ToolDef{Name: "noop", Description: "noop", InputSchema: map[string]any{"type": "object"}},
-			func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+			func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 				return core.TextResult("ok"), nil
 			},
 		)

--- a/client/client_get_sse_test.go
+++ b/client/client_get_sse_test.go
@@ -31,7 +31,7 @@ func newGetSSETestServer() *server.Server {
 				"required":   []string{"msg"},
 			},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			var p struct {
 				Msg string `json:"msg"`
 			}

--- a/client/client_per_call_notify_test.go
+++ b/client/client_per_call_notify_test.go
@@ -37,7 +37,7 @@ func TestCallContext_NotifyHookFiresOnCallStreamNotifications(t *testing.T) {
 			Description: "Emits a custom notification, then returns success",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(ctx core.ToolContext, _ core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, _ core.ToolRequest) (core.ToolResponse, error) {
 			// Use a custom method via ctx.Notify so the test doesn't depend
 			// on logging/setLevel having been called (log notifications are
 			// gated by the per-session log level).
@@ -96,7 +96,7 @@ func TestCallContext_NoHook_GlobalStillFires(t *testing.T) {
 			Description: "Emits + returns",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(ctx core.ToolContext, _ core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, _ core.ToolRequest) (core.ToolResponse, error) {
 			ctx.Notify("notifications/test/ping", map[string]any{"from": "handler"})
 			return core.TextResult("ok"), nil
 		},

--- a/client/client_reconnect_test.go
+++ b/client/client_reconnect_test.go
@@ -140,7 +140,7 @@ func TestReconnect_WithLogging(t *testing.T) {
 	srv := server.NewServer(core.ServerInfo{Name: "reconnect-test", Version: "1.0"})
 	srv.RegisterTool(
 		core.ToolDef{Name: "count", Description: "counts calls"},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			n := callCount.Add(1)
 			return core.TextResult(fmt.Sprintf("call-%d", n)), nil
 		},

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -35,7 +35,7 @@ func newTestMCPServer() *server.Server {
 				},
 			},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("ui ok"), nil
 		},
 	)
@@ -585,7 +585,7 @@ func newExtraSchemaServer() *server.Server {
 				},
 			},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("ok"), nil
 		},
 	)
@@ -713,7 +713,7 @@ func newNotifyTestServer() *server.Server {
 				"properties": map[string]any{"tag": map[string]any{"type": "string"}},
 			},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			var p struct {
 				Tag string `json:"tag"`
 			}
@@ -737,7 +737,7 @@ func newNotifyTestServer() *server.Server {
 				"properties": map[string]any{"message": map[string]any{"type": "string"}},
 				"required":   []string{"message"},
 			}},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			var p struct {
 				Message string `json:"message"`
 			}

--- a/client/iterators_test.go
+++ b/client/iterators_test.go
@@ -70,7 +70,7 @@ func TestPrompts_IteratesAll(t *testing.T) {
 		n := name
 		srv.RegisterPrompt(
 			core.PromptDef{Name: n, Description: "prompt " + n},
-			func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResult, error) {
+			func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResponse, error) {
 				return core.PromptResult{}, nil
 			},
 		)

--- a/client/mrtr_test.go
+++ b/client/mrtr_test.go
@@ -63,7 +63,7 @@ func TestCallToolWithInputs_MaxRounds(t *testing.T) {
 			Description: "Always asks for more input",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return ctx.RequestInput(core.InputRequests{
 				"loop": core.InputRequest{Method: "elicitation/create", Params: json.RawMessage(`{}`)},
 			})
@@ -140,7 +140,7 @@ func mrtrTestServer(t *testing.T) *server.Server {
 			Description: "Asks for user name then greets them",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			if !ctx.HasInputResponses() {
 				return ctx.RequestInput(core.InputRequests{
 					"user_name": core.InputRequest{

--- a/client/typed_call_test.go
+++ b/client/typed_call_test.go
@@ -29,7 +29,7 @@ func TestToolCallTyped(t *testing.T) {
 			InputSchema:  map[string]any{"type": "object"},
 			OutputSchema: map[string]any{"type": "object"},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.StructuredResult("found 2 items", SearchResult{
 				Items: []string{"a", "b"},
 				Total: 2,
@@ -62,7 +62,7 @@ func TestToolCallTypedNoStructuredContent(t *testing.T) {
 			Description: "Returns text only",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("just text"), nil
 		},
 	)
@@ -91,7 +91,7 @@ func TestToolCallTypedToolError(t *testing.T) {
 			Description: "Always fails",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.ErrorResult("something went wrong"), nil
 		},
 	)
@@ -120,7 +120,7 @@ func TestToolCallFullSuccess(t *testing.T) {
 			Description: "Returns a greeting",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("hello world"), nil
 		},
 	)
@@ -151,7 +151,7 @@ func TestToolCallFullError(t *testing.T) {
 			Description: "Returns a structured error",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.StructuredError("version conflict", map[string]any{
 				"error":           "version_conflict",
 				"current_version": 5,
@@ -205,7 +205,7 @@ func TestToolCallFullStructuredSuccess(t *testing.T) {
 			InputSchema:  map[string]any{"type": "object"},
 			OutputSchema: map[string]any{"type": "object"},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.StructuredResult("found 2 items", SearchResult{
 				Items: []string{"a", "b"},
 				Total: 2,

--- a/cmd/testserver/conformance_apps.go
+++ b/cmd/testserver/conformance_apps.go
@@ -109,8 +109,8 @@ func registerConformanceApps(srv *server.Server) {
 	))
 
 	// elicit-with-ui: demonstrates app-backed elicitation with _meta.ui
-	srv.Register(core.TypedTool[struct{}, core.ToolResult]("elicit-with-ui", "Elicits input using an MCP App UI",
-		func(ctx core.ToolContext, _ struct{}) (core.ToolResult, error) {
+	srv.Register(core.TypedTool[struct{}, core.ToolResponse]("elicit-with-ui", "Elicits input using an MCP App UI",
+		func(ctx core.ToolContext, _ struct{}) (core.ToolResponse, error) {
 			result, err := ctx.Elicit(core.ElicitationRequest{
 				Message: "Choose a dashboard widget",
 				Meta: &core.ElicitationMeta{

--- a/cmd/testserver/conformance_prompts.go
+++ b/cmd/testserver/conformance_prompts.go
@@ -20,7 +20,7 @@ func registerConformancePrompts(srv *server.Server) {
 			Name:        "test_simple_prompt",
 			Description: "A simple prompt for conformance testing",
 		},
-		func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResult, error) {
+		func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResponse, error) {
 			return core.PromptResult{
 				Description: "A simple test prompt",
 				Messages: []core.PromptMessage{{
@@ -41,7 +41,7 @@ func registerConformancePrompts(srv *server.Server) {
 				{Name: "arg2", Description: "Second test argument", Required: true},
 			},
 		},
-		func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResult, error) {
+		func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResponse, error) {
 			arg1 := req.Arguments["arg1"]
 			arg2 := req.Arguments["arg2"]
 			return core.PromptResult{
@@ -63,7 +63,7 @@ func registerConformancePrompts(srv *server.Server) {
 				{Name: "resourceUri", Description: "URI of the resource to embed", Required: true},
 			},
 		},
-		func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResult, error) {
+		func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResponse, error) {
 			uri, _ := req.Arguments["resourceUri"].(string)
 			return core.PromptResult{
 				Description: "A prompt with an embedded resource",
@@ -88,7 +88,7 @@ func registerConformancePrompts(srv *server.Server) {
 			Name:        "test_prompt_with_image",
 			Description: "A prompt that includes an image",
 		},
-		func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResult, error) {
+		func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResponse, error) {
 			pngBytes := minimalPNG() // reuse from conformance_tools.go
 			return core.PromptResult{
 				Description: "A prompt with image content",

--- a/cmd/testserver/conformance_tools.go
+++ b/cmd/testserver/conformance_tools.go
@@ -34,8 +34,8 @@ func registerConformanceTools(srv *server.Server) {
 	))
 
 	// test_image_content: returns base64 PNG image content
-	srv.Register(core.TypedTool[emptyInput, core.ToolResult]("test_image_content", "Returns image content for conformance testing",
-		func(ctx core.ToolContext, _ emptyInput) (core.ToolResult, error) {
+	srv.Register(core.TypedTool[emptyInput, core.ToolResponse]("test_image_content", "Returns image content for conformance testing",
+		func(ctx core.ToolContext, _ emptyInput) (core.ToolResponse, error) {
 			pngBytes := minimalPNG()
 			return core.ToolResult{
 				Content: []core.Content{{
@@ -48,8 +48,8 @@ func registerConformanceTools(srv *server.Server) {
 	))
 
 	// test_audio_content: returns base64 audio content
-	srv.Register(core.TypedTool[emptyInput, core.ToolResult]("test_audio_content", "Returns audio content for conformance testing",
-		func(ctx core.ToolContext, _ emptyInput) (core.ToolResult, error) {
+	srv.Register(core.TypedTool[emptyInput, core.ToolResponse]("test_audio_content", "Returns audio content for conformance testing",
+		func(ctx core.ToolContext, _ emptyInput) (core.ToolResponse, error) {
 			wavBytes := minimalWAV()
 			return core.ToolResult{
 				Content: []core.Content{{
@@ -62,8 +62,8 @@ func registerConformanceTools(srv *server.Server) {
 	))
 
 	// test_multiple_content_types: returns text + image + embedded resource content
-	srv.Register(core.TypedTool[emptyInput, core.ToolResult]("test_multiple_content_types", "Returns mixed text, image, and resource content for conformance testing",
-		func(ctx core.ToolContext, _ emptyInput) (core.ToolResult, error) {
+	srv.Register(core.TypedTool[emptyInput, core.ToolResponse]("test_multiple_content_types", "Returns mixed text, image, and resource content for conformance testing",
+		func(ctx core.ToolContext, _ emptyInput) (core.ToolResponse, error) {
 			pngBytes := minimalPNG()
 			return core.ToolResult{
 				Content: []core.Content{
@@ -111,8 +111,8 @@ func registerConformanceTools(srv *server.Server) {
 	))
 
 	// test_embedded_resource: returns a resource content item
-	srv.Register(core.TypedTool[emptyInput, core.ToolResult]("test_embedded_resource", "Returns embedded resource content for conformance testing",
-		func(ctx core.ToolContext, _ emptyInput) (core.ToolResult, error) {
+	srv.Register(core.TypedTool[emptyInput, core.ToolResponse]("test_embedded_resource", "Returns embedded resource content for conformance testing",
+		func(ctx core.ToolContext, _ emptyInput) (core.ToolResponse, error) {
 			return core.ToolResult{
 				Content: []core.Content{{
 					Type: "resource",
@@ -129,8 +129,8 @@ func registerConformanceTools(srv *server.Server) {
 	// test_sampling: calls sampling/createMessage during tool execution.
 	// The conformance suite's client must respond to the server-to-client request
 	// with an LLM inference result. The tool returns the model's response text.
-	srv.Register(core.TypedTool[emptyInput, core.ToolResult]("test_sampling", "Calls sampling/createMessage and returns the LLM response for conformance testing",
-		func(ctx core.ToolContext, _ emptyInput) (core.ToolResult, error) {
+	srv.Register(core.TypedTool[emptyInput, core.ToolResponse]("test_sampling", "Calls sampling/createMessage and returns the LLM response for conformance testing",
+		func(ctx core.ToolContext, _ emptyInput) (core.ToolResponse, error) {
 			result, err := ctx.Sample(core.CreateMessageRequest{
 				Messages: []core.SamplingMessage{{
 					Role:    "user",
@@ -148,8 +148,8 @@ func registerConformanceTools(srv *server.Server) {
 	// test_elicitation: calls elicitation/create during tool execution.
 	// The conformance suite's client must respond to the server-to-client request
 	// with user input. The tool returns the user's action and content.
-	srv.Register(core.TypedTool[emptyInput, core.ToolResult]("test_elicitation", "Calls elicitation/create and returns user input for conformance testing",
-		func(ctx core.ToolContext, _ emptyInput) (core.ToolResult, error) {
+	srv.Register(core.TypedTool[emptyInput, core.ToolResponse]("test_elicitation", "Calls elicitation/create and returns user input for conformance testing",
+		func(ctx core.ToolContext, _ emptyInput) (core.ToolResponse, error) {
 			result, err := ctx.Elicit(core.ElicitationRequest{
 				Message:         "Please provide your name",
 				RequestedSchema: json.RawMessage(`{"type":"object","properties":{"name":{"type":"string","description":"Your name"}}}`),
@@ -169,8 +169,8 @@ func registerConformanceTools(srv *server.Server) {
 	// containing default values for all primitive types (SEP-1034 conformance).
 	// Schema includes: string, integer, number, enum with default, and boolean,
 	// each with a default value set.
-	srv.Register(core.TypedTool[emptyInput, core.ToolResult]("test_elicitation_sep1034_defaults", "Calls elicitation/create with default values for all primitive types (SEP-1034)",
-		func(ctx core.ToolContext, _ emptyInput) (core.ToolResult, error) {
+	srv.Register(core.TypedTool[emptyInput, core.ToolResponse]("test_elicitation_sep1034_defaults", "Calls elicitation/create with default values for all primitive types (SEP-1034)",
+		func(ctx core.ToolContext, _ emptyInput) (core.ToolResponse, error) {
 			schema := json.RawMessage(`{
 				"type": "object",
 				"properties": {
@@ -197,8 +197,8 @@ func registerConformanceTools(srv *server.Server) {
 	// variants defined in SEP-1330 conformance: untitled single-select, titled
 	// single-select (oneOf), legacy titled (enumNames), untitled multi-select,
 	// and titled multi-select (anyOf).
-	srv.Register(core.TypedTool[emptyInput, core.ToolResult]("test_elicitation_sep1330_enums", "Calls elicitation/create with all 5 enum variants (SEP-1330)",
-		func(ctx core.ToolContext, _ emptyInput) (core.ToolResult, error) {
+	srv.Register(core.TypedTool[emptyInput, core.ToolResponse]("test_elicitation_sep1330_enums", "Calls elicitation/create with all 5 enum variants (SEP-1330)",
+		func(ctx core.ToolContext, _ emptyInput) (core.ToolResponse, error) {
 			schema := json.RawMessage(`{
 				"type": "object",
 				"properties": {
@@ -252,8 +252,8 @@ func registerConformanceTools(srv *server.Server) {
 
 	// test_elicitation_url_mode: calls elicitation/create in URL mode (SEP-1036).
 	// The server sends a URL for out-of-band interaction and returns the client's response.
-	srv.Register(core.TypedTool[emptyInput, core.ToolResult]("test_elicitation_url_mode", "Calls elicitation/create in URL mode (SEP-1036)",
-		func(ctx core.ToolContext, _ emptyInput) (core.ToolResult, error) {
+	srv.Register(core.TypedTool[emptyInput, core.ToolResponse]("test_elicitation_url_mode", "Calls elicitation/create in URL mode (SEP-1036)",
+		func(ctx core.ToolContext, _ emptyInput) (core.ToolResponse, error) {
 			result, err := core.ElicitURL(ctx, core.ElicitationRequest{
 				Message:       "Please approve access by visiting this URL",
 				URL:           "https://example.com/approve?session=test123",
@@ -268,8 +268,8 @@ func registerConformanceTools(srv *server.Server) {
 
 	// test_elicitation_url_required_error: returns a -32042 URLElicitationRequiredError
 	// to test client handling of the error code and embedded elicitation list.
-	srv.Register(core.TypedTool[emptyInput, core.ToolResult]("test_elicitation_url_required_error", "Returns -32042 URLElicitationRequiredError for conformance testing",
-		func(ctx core.ToolContext, _ emptyInput) (core.ToolResult, error) {
+	srv.Register(core.TypedTool[emptyInput, core.ToolResponse]("test_elicitation_url_required_error", "Returns -32042 URLElicitationRequiredError for conformance testing",
+		func(ctx core.ToolContext, _ emptyInput) (core.ToolResponse, error) {
 			// This tool always returns an error to test the -32042 code path.
 			// In practice, this would be returned by middleware or auth checks.
 			return core.ErrorResult("requires URL elicitation"), fmt.Errorf("url_elicitation_required")
@@ -278,8 +278,8 @@ func registerConformanceTools(srv *server.Server) {
 
 	// test_elicitation_complete_notification: triggers a URL elicitation, then
 	// sends notifications/elicitation/complete after a short delay.
-	srv.Register(core.TypedTool[emptyInput, core.ToolResult]("test_elicitation_complete_notification", "URL elicitation with completion notification (SEP-1036)",
-		func(ctx core.ToolContext, _ emptyInput) (core.ToolResult, error) {
+	srv.Register(core.TypedTool[emptyInput, core.ToolResponse]("test_elicitation_complete_notification", "URL elicitation with completion notification (SEP-1036)",
+		func(ctx core.ToolContext, _ emptyInput) (core.ToolResponse, error) {
 			elicitID := "elicit-complete-test-001"
 
 			// Send the URL elicitation.
@@ -301,8 +301,8 @@ func registerConformanceTools(srv *server.Server) {
 
 	// test_elicitation_mode_default_form: calls elicitation/create with no mode
 	// set (should default to form). Verifies backwards compatibility.
-	srv.Register(core.TypedTool[emptyInput, core.ToolResult]("test_elicitation_mode_default_form", "Calls elicitation/create with no mode (defaults to form, backwards compat)",
-		func(ctx core.ToolContext, _ emptyInput) (core.ToolResult, error) {
+	srv.Register(core.TypedTool[emptyInput, core.ToolResponse]("test_elicitation_mode_default_form", "Calls elicitation/create with no mode (defaults to form, backwards compat)",
+		func(ctx core.ToolContext, _ emptyInput) (core.ToolResponse, error) {
 			result, err := ctx.Elicit(core.ElicitationRequest{
 				Message:         "Pick a color (no mode set)",
 				RequestedSchema: json.RawMessage(`{"type":"object","properties":{"color":{"type":"string"}}}`),
@@ -327,10 +327,10 @@ func registerConformanceTools(srv *server.Server) {
 	// a real mcpkit user with an advanced schema would write — keep the typed
 	// In struct for unmarshalling, supply the schema by hand for the 2020-12
 	// features struct tags cannot express.
-	srv.Register(core.TypedTool[contact2020Input, core.ToolResult](
+	srv.Register(core.TypedTool[contact2020Input, core.ToolResponse](
 		"json_schema_2020_12_tool",
 		"Tool with JSON Schema 2020-12 features (SEP-1613, SEP-2106)",
-		func(ctx core.ToolContext, _ contact2020Input) (core.ToolResult, error) {
+		func(ctx core.ToolContext, _ contact2020Input) (core.ToolResponse, error) {
 			return core.TextResult("json_schema_2020_12_tool invoked"), nil
 		},
 		core.WithInputSchemaOverride(map[string]any{

--- a/core/detach.go
+++ b/core/detach.go
@@ -37,7 +37,7 @@ import "context"
 //
 // Example:
 //
-//	func longRunningTool(ctx context.Context, req core.ToolRequest) (core.ToolResult, error) {
+//	func longRunningTool(ctx context.Context, req core.ToolRequest) (core.ToolResponse, error) {
 //	    // Hint the client to reconnect in 5 minutes
 //	    core.EmitSSERetry(ctx, 5*time.Minute)
 //

--- a/core/handler_context.go
+++ b/core/handler_context.go
@@ -417,14 +417,14 @@ func (tc ToolContext) RequestState() string {
 }
 
 // RequestInput is the SEP-2322 ephemeral retry primitive. Handlers return
-// the value as their ToolResult to signal "I need more input from the
-// client before I can produce a final result"; the dispatch layer
-// reshapes the response on the wire as an InputRequiredResult and mints a
-// fresh requestState for the next round.
+// the value as their ToolResponse to signal "I need more input from the
+// client before I can produce a final result"; the dispatch layer mints a
+// fresh requestState onto the returned InputRequiredResult before emitting
+// it on the wire.
 //
 // Usage in a tool handler:
 //
-//	func myTool(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+//	func myTool(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 //	    if !ctx.HasInputResponses() {
 //	        return ctx.RequestInput(core.InputRequests{
 //	            "user_name": {
@@ -438,9 +438,10 @@ func (tc ToolContext) RequestState() string {
 //
 // The error return is always nil — the helper exists so the call site
 // reads as a single return statement matching the ToolHandler signature.
-func (tc ToolContext) RequestInput(reqs InputRequests) (ToolResult, error) {
-	return ToolResult{
-		IsInputRequired: true,
-		InputRequests:   reqs,
+// The concrete return type is InputRequiredResult (not ToolResponse) so
+// callers can use the typed value directly when they need to.
+func (tc ToolContext) RequestInput(reqs InputRequests) (InputRequiredResult, error) {
+	return InputRequiredResult{
+		InputRequests: reqs,
 	}, nil
 }

--- a/core/mrtr.go
+++ b/core/mrtr.go
@@ -96,6 +96,9 @@ type InputRequiredResult struct {
 	RequestState string `json:"requestState,omitempty"`
 }
 
+// toolResponse marks InputRequiredResult as a [ToolResponse] variant.
+func (InputRequiredResult) toolResponse() {}
+
 // MarshalJSON defaults ResultType to ResultTypeInputRequired so handlers
 // that build an InputRequiredResult{} literal don't have to set the
 // discriminator.

--- a/core/prompt.go
+++ b/core/prompt.go
@@ -97,11 +97,28 @@ type PromptRequest struct {
 	Arguments map[string]any
 }
 
+// PromptResponse is the sealed interface returned by PromptHandler
+// implementations. Today only [PromptResult] (the sync wire envelope)
+// implements it; a future [InputRequiredResult] PromptResponse impl plugs in
+// by adding a one-line promptResponse() method (see issue #452 / SEP-2322
+// prompt scenarios).
+//
+// The interface is sealed via the unexported promptResponse() marker so
+// external types cannot impersonate a core response variant.
+type PromptResponse interface {
+	promptResponse()
+}
+
 // PromptResult is the response from a prompt handler.
 type PromptResult struct {
 	Description string          `json:"description,omitempty"`
 	Messages    []PromptMessage `json:"messages"`
 }
 
+func (PromptResult) promptResponse() {}
+
 // PromptHandler generates prompt messages, optionally using arguments.
-type PromptHandler func(ctx PromptContext, req PromptRequest) (PromptResult, error)
+//
+// Returns the sealed [PromptResponse] interface — handlers typically return
+// a [PromptResult] literal which satisfies the interface.
+type PromptHandler func(ctx PromptContext, req PromptRequest) (PromptResponse, error)

--- a/core/resource_notify.go
+++ b/core/resource_notify.go
@@ -14,7 +14,7 @@ import "context"
 //
 // Usage in a tool handler:
 //
-//	func updateWidget(ctx context.Context, req core.ToolRequest) (core.ToolResult, error) {
+//	func updateWidget(ctx context.Context, req core.ToolRequest) (core.ToolResponse, error) {
 //	    db.UpdateWidget(args.ID, args.Name)
 //	    core.NotifyResourceUpdated(ctx, "widgets/" + args.ID)
 //	    return core.TextResult("updated"), nil

--- a/core/response_types_test.go
+++ b/core/response_types_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 )
@@ -211,5 +212,48 @@ func TestEmptyResultJSON(t *testing.T) {
 	}
 	if string(raw) != "{}" {
 		t.Errorf("struct{}{} JSON = %q, want {}", string(raw))
+	}
+}
+
+// TestToolResponseSealedInterface verifies that the four core ToolResponse
+// variants — ToolResult, InputRequiredResult, CreateTaskResult, GoAsyncResult —
+// satisfy the ToolResponse interface, and that PromptResult satisfies
+// PromptResponse. Sealing is enforced at compile time via the unexported
+// toolResponse()/promptResponse() marker methods.
+func TestToolResponseSealedInterface(t *testing.T) {
+	var _ ToolResponse = ToolResult{}
+	var _ ToolResponse = InputRequiredResult{}
+	var _ ToolResponse = CreateTaskResult{}
+	var _ ToolResponse = GoAsyncResult{}
+	var _ PromptResponse = PromptResult{}
+}
+
+// TestGoAsyncResultZeroValue verifies that the GoAsyncResult sentinel carries
+// no fields: it is an in-process discriminator, never serialized on the wire.
+// Marshalling it produces "{}" — which the dispatch path passes through to a
+// tasks middleware that intercepts on the type.
+func TestGoAsyncResultZeroValue(t *testing.T) {
+	raw, err := json.Marshal(GoAsyncResult{})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(raw) != "{}" {
+		t.Errorf("GoAsyncResult JSON = %q, want {}", string(raw))
+	}
+}
+
+// TestRequestInputReturnsInputRequiredResult verifies that ctx.RequestInput
+// returns a typed core.InputRequiredResult value (not a generic ToolResponse)
+// so callers that want the concrete type don't need a type assertion.
+func TestRequestInputReturnsInputRequiredResult(t *testing.T) {
+	tc := NewToolContext(context.Background())
+	got, err := tc.RequestInput(InputRequests{
+		"k": {Method: "elicitation/create"},
+	})
+	if err != nil {
+		t.Fatalf("RequestInput err: %v", err)
+	}
+	if _, ok := got.InputRequests["k"]; !ok {
+		t.Errorf("RequestInput dropped key k: %+v", got)
 	}
 }

--- a/core/slog_handler.go
+++ b/core/slog_handler.go
@@ -15,7 +15,7 @@ import (
 //
 // Create via NewMCPLogHandler inside a tool/resource/prompt handler:
 //
-//	func myTool(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+//	func myTool(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 //	    logger := slog.New(core.NewMCPLogHandler(ctx, nil))
 //	    logger.Info("processing", "key", "value")  // → notifications/message
 //	    ...

--- a/core/streaming.go
+++ b/core/streaming.go
@@ -53,7 +53,7 @@ func ContentChunkMethodFromContext(ctx context.Context) string {
 //
 // Example:
 //
-//	func myTool(ctx context.Context, req core.ToolRequest) (core.ToolResult, error) {
+//	func myTool(ctx context.Context, req core.ToolRequest) (core.ToolResponse, error) {
 //	    core.EmitContent(ctx, req.RequestID, core.Content{Type: "text", Text: "Step 1..."})
 //	    // ... work ...
 //	    core.EmitContent(ctx, req.RequestID, core.Content{Type: "text", Text: "Step 2..."})

--- a/core/task_v2.go
+++ b/core/task_v2.go
@@ -79,6 +79,13 @@ type CreateTaskResult struct {
 	TaskInfoV2
 }
 
+// toolResponse marks CreateTaskResult as a [ToolResponse] variant. A handler
+// can return this directly when it has already minted a task identifier and
+// wants to hand the response off to the client without going through the
+// middleware-driven goroutine spawn path (rare — most handlers return
+// [GoAsyncResult] and let the tasks middleware do the work).
+func (CreateTaskResult) toolResponse() {}
+
 // DetailedTask is the SEP-2663 discriminated union returned by tasks/get.
 // The Status field discriminates which optional fields are populated:
 //

--- a/core/tool.go
+++ b/core/tool.go
@@ -122,7 +122,26 @@ type ToolRequest struct {
 	RequestState string
 }
 
-// ToolResult is the response from a tool handler.
+// ToolResponse is the sealed interface returned by ToolHandler implementations.
+//
+// Four core variants implement it:
+//
+//   - [ToolResult]          — the sync "complete" wire envelope.
+//   - [InputRequiredResult] — the SEP-2322 multi-round "input_required" envelope.
+//   - [CreateTaskResult]    — the SEP-2663 "task" envelope (handler-emitted; rare).
+//   - [GoAsyncResult]       — in-process signal that the ext/tasks middleware
+//     should mint a task and run the handler again on a background goroutine.
+//     Never serialized.
+//
+// The interface is sealed via the unexported toolResponse() marker so external
+// types cannot impersonate a core response variant. Dispatch type-switches on
+// the concrete value; the previous IsInputRequired/InputRequests/GoAsync
+// sentinel fields on ToolResult are gone.
+type ToolResponse interface {
+	toolResponse()
+}
+
+// ToolResult is the sync "complete" response from a tool handler.
 type ToolResult struct {
 	// ResultType is the SEP-2322 polymorphic-dispatch discriminator. For
 	// sync tools/call responses the wire value is "complete" (defaulted by
@@ -145,51 +164,39 @@ type ToolResult struct {
 
 	// Meta holds optional result metadata (e.g., pagination cursor).
 	Meta *ToolResultMeta `json:"_meta,omitempty"`
-
-	// IsInputRequired is the in-process sentinel signalling that the handler
-	// is returning an MRTR InputRequiredResult rather than a final tool result.
-	// Set by ctx.RequestInput; the dispatch layer detects it, mints / refreshes
-	// the requestState, and reshapes the wire payload as InputRequiredResult.
-	// Never serialized — this field is in-process plumbing only.
-	//
-	// Renamed from IsIncomplete in lockstep with the SEP-2322 wire-variant
-	// rename (commit de6d76fb merged 2026-05-06).
-	IsInputRequired bool `json:"-"`
-
-	// InputRequests is the SEP-2322 inputRequests map staged by ctx.RequestInput
-	// when IsInputRequired is true. Dispatch reads it to build the
-	// InputRequiredResult envelope. Nil for normal complete results. Never
-	// serialized through ToolResult — dispatch reshapes the response into
-	// InputRequiredResult.
-	InputRequests InputRequests `json:"-"`
-
-	// GoAsync is the SEP-2663 in-process sentinel signalling that the handler
-	// has finished its synchronous work (e.g. gathering input via MRTR) and
-	// wants the remainder of its execution to run as a background task. When
-	// the ext/tasks middleware sees GoAsync=true on a non-InputRequired result
-	// from a tool whose Execution.TaskSupport is optional/required and the
-	// client has negotiated the io.modelcontextprotocol/tasks extension, it:
-	//
-	//  1. mints a fresh task,
-	//  2. spawns a goroutine that re-invokes the handler with a
-	//     [tasks.TaskContext] available (the handler discovers it via
-	//     [tasks.GetTaskContext] and switches to the async branch), and
-	//  3. returns CreateTaskResult to the original caller.
-	//
-	// The continuation goroutine is what runs the "real" work, so a handler
-	// that emits notifications/progress or notifications/message from the
-	// async branch gets the SEP-2663 G6 session-notify filter applied.
-	// A sync-returning handler (GoAsync=false) does NOT get that filter,
-	// because no goroutine ever runs.
-	//
-	// Ignored when:
-	//   - IsInputRequired is true (the result is an MRTR InputRequiredResult)
-	//   - the tool's Execution.TaskSupport is forbidden or absent
-	//   - the client has not negotiated the tasks extension
-	//
-	// Never serialized — this field is in-process plumbing only.
-	GoAsync bool `json:"-"`
 }
+
+func (ToolResult) toolResponse() {}
+
+// GoAsyncResult is an in-process signal returned by a tool handler when it
+// has finished its synchronous work (e.g. gathering input via MRTR) and wants
+// the remainder of its execution to run as a background task.
+//
+// The ext/tasks middleware observes a GoAsyncResult on a tool whose
+// Execution.TaskSupport is optional/required when the client has negotiated
+// the io.modelcontextprotocol/tasks extension. On observation it:
+//
+//  1. mints a fresh task,
+//  2. spawns a goroutine that re-invokes the handler with a
+//     [tasks.TaskContext] attached (the handler discovers it via
+//     [tasks.GetTaskContext] and switches to the async branch), and
+//  3. returns CreateTaskResult to the original caller.
+//
+// The continuation goroutine is what runs the "real" work, so a handler
+// that emits notifications/progress or notifications/message from the
+// async branch gets the SEP-2663 G6 session-notify filter applied.
+// A handler that returns ToolResult sync (no GoAsyncResult) does NOT get
+// that filter, because no goroutine ever runs.
+//
+// Ignored when:
+//   - the tool's Execution.TaskSupport is forbidden or absent
+//   - the client has not negotiated the tasks extension
+//
+// GoAsyncResult has no wire envelope of its own — it never escapes the
+// in-process boundary.
+type GoAsyncResult struct{}
+
+func (GoAsyncResult) toolResponse() {}
 
 // MarshalJSON ensures every ToolResult on the wire carries a ResultType.
 // Empty defaults to ResultTypeComplete so existing callers and struct
@@ -330,4 +337,13 @@ func (r *ToolRequest) Bind(v any) error {
 // ToolHandler is the function signature for tool implementations.
 // The ToolContext provides typed access to session capabilities (EmitLog,
 // EmitProgress, EmitContent, Sample, Elicit, etc.) with IDE discoverability.
-type ToolHandler func(ctx ToolContext, req ToolRequest) (ToolResult, error)
+//
+// The return type is the sealed [ToolResponse] interface — handlers may
+// return any of [ToolResult], [InputRequiredResult], [CreateTaskResult],
+// or [GoAsyncResult]. The most common form is a [ToolResult] literal:
+//
+//	return core.ToolResult{Content: []core.Content{{Type: "text", Text: "ok"}}}, nil
+//
+// Or the convenience helpers — TextResult, ErrorResult, StructuredResult —
+// which return concrete ToolResult values that satisfy ToolResponse.
+type ToolHandler func(ctx ToolContext, req ToolRequest) (ToolResponse, error)

--- a/core/typed_tool.go
+++ b/core/typed_tool.go
@@ -22,6 +22,9 @@ type TypedToolResult struct {
 // The Out type parameter controls output behavior:
 //   - string: handler returns text, wrapped via TextResult. No OutputSchema.
 //   - ToolResult: handler returns a ToolResult directly. No OutputSchema.
+//   - ToolResponse: handler returns any ToolResponse variant (ToolResult,
+//     InputRequiredResult, CreateTaskResult, GoAsyncResult). No OutputSchema.
+//     Use this for MRTR / SEP-2663 tools.
 //   - any struct: handler returns typed data. OutputSchema auto-derived from Out.
 //     Result uses StructuredResult with JSON text fallback.
 //
@@ -65,7 +68,8 @@ func TypedTool[In, Out any](name, desc string,
 	outType := reflect.TypeOf((*Out)(nil)).Elem()
 	isStringOut := outType.Kind() == reflect.String
 	isToolResultOut := outType == reflect.TypeOf(ToolResult{})
-	if !isStringOut && !isToolResultOut {
+	isToolResponseOut := outType == reflect.TypeOf((*ToolResponse)(nil)).Elem()
+	if !isStringOut && !isToolResultOut && !isToolResponseOut {
 		outputSchema = GenerateSchema[Out]()
 	}
 
@@ -81,7 +85,7 @@ func TypedTool[In, Out any](name, desc string,
 		Execution:      cfg.toolExecution,
 	}
 
-	wrappedHandler := func(ctx ToolContext, req ToolRequest) (ToolResult, error) {
+	wrappedHandler := func(ctx ToolContext, req ToolRequest) (ToolResponse, error) {
 		var input In
 		if err := json.Unmarshal(req.Arguments, &input); err != nil {
 			return ErrorResult(fmt.Sprintf("invalid arguments: %v", err)), nil
@@ -90,7 +94,7 @@ func TypedTool[In, Out any](name, desc string,
 		if err != nil {
 			return ToolResult{}, err
 		}
-		return wrapOutput(out, isStringOut, isToolResultOut)
+		return wrapOutput(out, isStringOut, isToolResultOut, isToolResponseOut)
 	}
 
 	return TypedToolResult{ToolDef: def, Handler: wrappedHandler}
@@ -189,8 +193,8 @@ func WithInputSchemaOverride(schema any) TypedToolOption {
 //	type SlowComputeInput struct {
 //	    Seconds int `json:"seconds"`
 //	}
-//	r := core.TypedTool[SlowComputeInput, core.ToolResult]("slow_compute", "...",
-//	    func(ctx core.ToolContext, in SlowComputeInput) (core.ToolResult, error) { ... },
+//	r := core.TypedTool[SlowComputeInput, core.ToolResponse]("slow_compute", "...",
+//	    func(ctx core.ToolContext, in SlowComputeInput) (core.ToolResponse, error) { ... },
 //	    core.WithToolExecution(&core.ToolExecution{TaskSupport: core.TaskSupportOptional}),
 //	)
 //
@@ -203,13 +207,16 @@ func WithToolExecution(execution *ToolExecution) TypedToolOption {
 	return func(c *typedToolConfig) { c.toolExecution = execution }
 }
 
-// wrapOutput converts a typed handler output into a ToolResult.
-func wrapOutput[Out any](out Out, isString, isToolResult bool) (ToolResult, error) {
+// wrapOutput converts a typed handler output into a ToolResponse.
+func wrapOutput[Out any](out Out, isString, isToolResult, isToolResponse bool) (ToolResponse, error) {
 	if isString {
 		return TextResult(any(out).(string)), nil
 	}
 	if isToolResult {
 		return any(out).(ToolResult), nil
+	}
+	if isToolResponse {
+		return any(out).(ToolResponse), nil
 	}
 	data, err := json.Marshal(out)
 	if err != nil {

--- a/docs/HANDLER_RETURNS_MIGRATION.md
+++ b/docs/HANDLER_RETURNS_MIGRATION.md
@@ -1,0 +1,65 @@
+## Handler Returns Migration (`ToolResponse` / `PromptResponse`)
+
+`ToolHandler` and `PromptHandler` now return sealed-interface response types instead of concrete result structs. This is a **breaking signature change** that landed pre-customer to remove three in-process sentinel fields from `core.ToolResult` (`IsInputRequired`, `InputRequests`, `GoAsync`). New response variants now plug in by adding a method on the sealed interface, not a new flag.
+
+> Tracking: [issue #486](https://github.com/panyam/mcpkit/issues/486).
+
+## TL;DR
+
+```go
+// Before
+func myTool(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error)
+func myPrompt(ctx core.PromptContext, req core.PromptRequest) (core.PromptResult, error)
+
+// After
+func myTool(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error)
+func myPrompt(ctx core.PromptContext, req core.PromptRequest) (core.PromptResponse, error)
+```
+
+Handler bodies usually don't change — `core.ToolResult{...}` / `core.PromptResult{...}` literals satisfy the sealed interface. Two body-level patterns need a small touch-up:
+
+| Before | After |
+|---|---|
+| `return core.ToolResult{GoAsync: true}, nil` | `return core.GoAsyncResult{}, nil` |
+| `result.IsInputRequired` / `result.InputRequests` field access on the return value | Type-assert the response: `if ir, ok := resp.(core.InputRequiredResult); ok { ... }` |
+
+`ctx.RequestInput(...)` continues to work — it now returns a typed `(core.InputRequiredResult, error)` so its return satisfies `ToolResponse` directly.
+
+## What ships in `core`
+
+```go
+type ToolResponse interface { toolResponse() }
+
+func (ToolResult)          toolResponse() {}  // wire "complete"
+func (InputRequiredResult) toolResponse() {}  // wire "input_required"  — SEP-2322
+func (CreateTaskResult)    toolResponse() {}  // wire "task"            — SEP-2663
+func (GoAsyncResult)       toolResponse() {}  // in-process discriminator; never serialized
+
+type PromptResponse interface { promptResponse() }
+func (PromptResult) promptResponse() {}
+```
+
+The interfaces are sealed via unexported marker methods, so external packages can't impersonate a core variant. Dispatch type-switches on the concrete value and emits the matching wire envelope. `ext/tasks` intercepts `GoAsyncResult` to spawn the SEP-2663 continuation goroutine; the legacy dispatcher reshapes `InputRequiredResult` with a freshly-minted `requestState`.
+
+## Why now
+
+- Three sentinel fields on a wire struct is a sum type masquerading as a record. New result variants (a future `InputRequiredResult` on `PromptResponse` for SEP-2322 prompt support, etc.) would have meant a new flag and another `json:"-"` field.
+- `ToolResult` is now a pure wire shape — every field on it appears on the JSON envelope.
+- Pre-customer is the cheapest time to flip the signature. Downstream consumers are limited.
+
+## Mechanical migration recipe
+
+1. Change every handler signature: `(core.ToolResult, error)` → `(core.ToolResponse, error)`; same for prompts.
+2. Replace `core.ToolResult{GoAsync: true}` literals with `core.GoAsyncResult{}`.
+3. Where you previously read `IsInputRequired` / `InputRequests` off a handler's `core.ToolResult` return value, type-assert against `core.InputRequiredResult` instead.
+4. If you used `core.TypedTool[X, core.ToolResult]` with a handler that wants to return `InputRequiredResult` / `GoAsyncResult` / `CreateTaskResult`, switch the type parameter to `core.ToolResponse`:
+
+   ```go
+   core.TypedTool[MyInput, core.ToolResponse]("my_tool", "...",
+       func(ctx core.ToolContext, in MyInput) (core.ToolResponse, error) { ... },
+   )
+   ```
+
+   `core.TypedTool[X, core.ToolResult]` keeps working for handlers that only return a sync `ToolResult`.
+
+5. Run `make tidy-all` (each sub-module pins its own `core` version).

--- a/examples/apps/react/server/main.go
+++ b/examples/apps/react/server/main.go
@@ -63,7 +63,7 @@ func main() {
 	ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[struct{}, core.ToolResult]{
 		Name:        "get-time",
 		Description: "Returns the current server time as an ISO 8601 string.",
-		Handler: func(ctx core.ToolContext, _ struct{}) (core.ToolResult, error) {
+		Handler: func(ctx core.ToolContext, _ struct{}) (core.ToolResponse, error) {
 			t := time.Now().UTC().Format(time.RFC3339)
 			return core.StructuredResult(t, map[string]string{"time": t}), nil
 		},
@@ -145,7 +145,7 @@ func main() {
 				{Name: "timezone", Description: "Timezone (e.g., UTC, US/Eastern)", Required: false},
 			},
 		},
-		func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResult, error) {
+		func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResponse, error) {
 			tz := "UTC"
 			if v, ok := req.Arguments["timezone"]; ok && v != "" {
 				tz, _ = v.(string)

--- a/examples/apps/todolist/main.go
+++ b/examples/apps/todolist/main.go
@@ -89,7 +89,7 @@ func main() {
 	ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[addTaskInput, core.ToolResult]{
 		Name:        "add_task",
 		Description: "Add a task to the board",
-		Handler: func(ctx core.ToolContext, input addTaskInput) (core.ToolResult, error) {
+		Handler: func(ctx core.ToolContext, input addTaskInput) (core.ToolResponse, error) {
 			if input.Priority == "" {
 				input.Priority = "medium"
 			}
@@ -140,8 +140,8 @@ func main() {
 		},
 	))
 
-	srv.Register(core.TypedTool[struct{}, core.ToolResult]("list_tasks", "List all tasks on the board",
-		func(ctx core.ToolContext, _ struct{}) (core.ToolResult, error) {
+	srv.Register(core.TypedTool[struct{}, core.ToolResponse]("list_tasks", "List all tasks on the board",
+		func(ctx core.ToolContext, _ struct{}) (core.ToolResponse, error) {
 			tasksMu.Lock()
 			data, _ := json.Marshal(tasks)
 			tasksMu.Unlock()
@@ -233,7 +233,7 @@ func main() {
 			Name:        "task_summary",
 			Description: "Returns a formatted summary of all tasks on the board",
 		},
-		func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResult, error) {
+		func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResponse, error) {
 			tasksMu.Lock()
 			snapshot := make([]Task, len(tasks))
 			copy(snapshot, tasks)

--- a/examples/elicitation/main.go
+++ b/examples/elicitation/main.go
@@ -344,7 +344,7 @@ func serve() {
 				}
 			}`),
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			var args struct {
 				ResourceID string `json:"resourceId"`
 			}

--- a/examples/file-inputs/apps.go
+++ b/examples/file-inputs/apps.go
@@ -52,7 +52,7 @@ func registerAppsTools(srv *server.Server, uploadDir string) {
 		},
 		ResourceURI: "ui://file-inputs/upload-image",
 		Visibility:  []core.UIVisibility{core.UIVisibilityModel, core.UIVisibilityApp},
-		ToolHandler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		ToolHandler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			// When invoked by the model with `image` already populated, fall
 			// through to the regular handler. When invoked by the user
 			// clicking the in-app button (which round-trips back as
@@ -83,7 +83,7 @@ func registerAppsTools(srv *server.Server, uploadDir string) {
 		},
 		ResourceURI: "ui://file-inputs/analyze-documents",
 		Visibility:  []core.UIVisibility{core.UIVisibilityModel, core.UIVisibilityApp},
-		ToolHandler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		ToolHandler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return analyzeDocumentsHandler(ctx, req, uploadDir)
 		},
 		ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {

--- a/examples/file-inputs/main.go
+++ b/examples/file-inputs/main.go
@@ -111,7 +111,7 @@ func registerTools(srv *server.Server, uploadDir string) {
 				"required": []string{"image"},
 			},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return uploadImageHandler(ctx, req, uploadDir)
 		},
 	)
@@ -131,7 +131,7 @@ func registerTools(srv *server.Server, uploadDir string) {
 				"required": []string{"documents"},
 			},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return analyzeDocumentsHandler(ctx, req, uploadDir)
 		},
 	)
@@ -148,13 +148,13 @@ func registerTools(srv *server.Server, uploadDir string) {
 				"required": []string{"file"},
 			},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return processAnyFileHandler(ctx, req, uploadDir)
 		},
 	)
 }
 
-func uploadImageHandler(ctx core.ToolContext, req core.ToolRequest, uploadDir string) (core.ToolResult, error) {
+func uploadImageHandler(ctx core.ToolContext, req core.ToolRequest, uploadDir string) (core.ToolResponse, error) {
 	args, err := parseArgs(req.Arguments)
 	if err != nil {
 		return core.ErrorResult("invalid arguments: " + err.Error()), nil
@@ -191,7 +191,7 @@ func uploadImageHandler(ctx core.ToolContext, req core.ToolRequest, uploadDir st
 	return core.TextResult(b.String()), nil
 }
 
-func analyzeDocumentsHandler(ctx core.ToolContext, req core.ToolRequest, uploadDir string) (core.ToolResult, error) {
+func analyzeDocumentsHandler(ctx core.ToolContext, req core.ToolRequest, uploadDir string) (core.ToolResponse, error) {
 	args, err := parseArgs(req.Arguments)
 	if err != nil {
 		return core.ErrorResult("invalid arguments: " + err.Error()), nil
@@ -229,7 +229,7 @@ func analyzeDocumentsHandler(ctx core.ToolContext, req core.ToolRequest, uploadD
 	return core.TextResult(b.String()), nil
 }
 
-func processAnyFileHandler(ctx core.ToolContext, req core.ToolRequest, uploadDir string) (core.ToolResult, error) {
+func processAnyFileHandler(ctx core.ToolContext, req core.ToolRequest, uploadDir string) (core.ToolResponse, error) {
 	args, err := parseArgs(req.Arguments)
 	if err != nil {
 		return core.ErrorResult("invalid arguments: " + err.Error()), nil

--- a/examples/fine-grained-auth/main.go
+++ b/examples/fine-grained-auth/main.go
@@ -927,7 +927,7 @@ func registerTools(srv *server.Server) {
 				}
 			}`),
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			var args struct {
 				DocID string `json:"docId"`
 			}
@@ -961,7 +961,7 @@ func registerTools(srv *server.Server) {
 				"required": ["docId", "content"]
 			}`),
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			var args struct {
 				DocID   string `json:"docId"`
 				Content string `json:"content"`
@@ -993,7 +993,7 @@ func registerTools(srv *server.Server) {
 				"required": ["amount", "currency", "payee"]
 			}`),
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			var args struct {
 				Amount   string `json:"amount"`
 				Currency string `json:"currency"`

--- a/examples/host/01-apphost/main.go
+++ b/examples/host/01-apphost/main.go
@@ -56,7 +56,7 @@ func main() {
 				core.ToolDef{Name: "server_echo", Description: "Echo back the input", InputSchema: map[string]any{
 					"type": "object", "properties": map[string]any{"msg": map[string]any{"type": "string"}},
 				}},
-				func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+				func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 					var args struct{ Msg string `json:"msg"` }
 					req.Bind(&args)
 					return core.TextResult("echo: " + args.Msg), nil
@@ -64,7 +64,7 @@ func main() {
 			)
 			srv.RegisterTool(
 				core.ToolDef{Name: "server_time", Description: "Get current time", InputSchema: map[string]any{"type": "object"}},
-				func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+				func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 					return core.TextResult(time.Now().Format(time.RFC3339)), nil
 				},
 			)

--- a/examples/host/02-multi-server/main.go
+++ b/examples/host/02-multi-server/main.go
@@ -47,7 +47,7 @@ func main() {
 			n := tName
 			srv.RegisterTool(
 				core.ToolDef{Name: n, Description: desc, InputSchema: map[string]any{"type": "object"}},
-				func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+				func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 					return core.TextResult(fmt.Sprintf("[%s] %s: ok", name, n)), nil
 				},
 			)

--- a/examples/list-ttl/main.go
+++ b/examples/list-ttl/main.go
@@ -69,7 +69,7 @@ func serve() {
 			Description: "Returns 'pong'",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("pong"), nil
 		},
 	)
@@ -106,7 +106,7 @@ func serve() {
 
 	srv.RegisterPrompt(
 		core.PromptDef{Name: "hello", Description: "Sample prompt"},
-		func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResult, error) {
+		func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResponse, error) {
 			return core.PromptResult{}, nil
 		},
 	)

--- a/examples/mrtr/main.go
+++ b/examples/mrtr/main.go
@@ -176,7 +176,7 @@ func registerMRTRTools(srv *server.Server) {
 
 // --- A1: basic elicitation ---
 
-func basicElicitationTool(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+func basicElicitationTool(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 	resp := ctx.InputResponse("user_name")
 	if resp == nil {
 		return ctx.RequestInput(core.InputRequests{
@@ -203,7 +203,7 @@ func basicElicitationTool(ctx core.ToolContext, req core.ToolRequest) (core.Tool
 
 // --- A2: basic sampling ---
 
-func basicSamplingTool(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+func basicSamplingTool(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 	resp := ctx.InputResponse("capital_question")
 	if resp == nil {
 		return ctx.RequestInput(core.InputRequests{
@@ -227,7 +227,7 @@ func basicSamplingTool(ctx core.ToolContext, req core.ToolRequest) (core.ToolRes
 
 // --- A3: basic list roots ---
 
-func basicListRootsTool(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+func basicListRootsTool(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 	resp := ctx.InputResponse("client_roots")
 	if resp == nil {
 		return ctx.RequestInput(core.InputRequests{
@@ -255,7 +255,7 @@ func basicListRootsTool(ctx core.ToolContext, req core.ToolRequest) (core.ToolRe
 
 // --- A4: requestState round-trip ---
 
-func requestStateTool(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+func requestStateTool(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 	resp := ctx.InputResponse("confirm")
 	if resp == nil {
 		return ctx.RequestInput(core.InputRequests{
@@ -273,7 +273,7 @@ func requestStateTool(ctx core.ToolContext, req core.ToolRequest) (core.ToolResu
 
 // --- A5: multiple inputs in one round ---
 
-func multipleInputsTool(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+func multipleInputsTool(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 	if !ctx.HasInputResponses() {
 		return ctx.RequestInput(core.InputRequests{
 			"user_name": core.InputRequest{
@@ -305,7 +305,7 @@ func multipleInputsTool(ctx core.ToolContext, req core.ToolRequest) (core.ToolRe
 
 // --- A6: multi-round (step1 → step2 → complete) ---
 
-func multiRoundTool(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+func multiRoundTool(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 	if ctx.InputResponse("step1") == nil {
 		return ctx.RequestInput(core.InputRequests{
 			"step1": core.InputRequest{
@@ -360,7 +360,7 @@ func multiRoundTool(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult
 //   - Task inputRequests keys (if the goroutine called TaskElicit / TaskSample)
 //     are scoped to the task's lifetime — distinct from the MRTR phase keys.
 //   - Clients do NOT need to deduplicate across the two flows.
-func mrtrTaskCompositionTool(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+func mrtrTaskCompositionTool(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 	// Phase 2: running inside the continuation goroutine. The TaskContext
 	// gates us into the async branch.
 	if tasks.GetTaskContext(ctx) != nil {
@@ -395,5 +395,5 @@ func mrtrTaskCompositionTool(ctx core.ToolContext, req core.ToolRequest) (core.T
 
 	// MRTR loop is complete; escalate to async so the heavy work happens
 	// in the continuation goroutine (with the SEP-2663 G6 filter applied).
-	return core.ToolResult{GoAsync: true}, nil
+	return core.GoAsyncResult{}, nil
 }

--- a/examples/stateless/main.go
+++ b/examples/stateless/main.go
@@ -147,7 +147,7 @@ func registerCartTools(srv *server.Server, carts server.HandleStore[Cart]) {
 				"SEP-2567: subsequent tools thread cart_id as a parameter.",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(_ core.ToolContext, _ core.ToolRequest) (core.ToolResult, error) {
+		func(_ core.ToolContext, _ core.ToolRequest) (core.ToolResponse, error) {
 			id := carts.Mint(Cart{}, 0)
 			out := map[string]any{"cart_id": id}
 			raw, _ := json.Marshal(out)
@@ -172,7 +172,7 @@ func registerCartTools(srv *server.Server, carts server.HandleStore[Cart]) {
 				"required": []string{"cart_id", "sku", "quantity"},
 			},
 		},
-		func(_ core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(_ core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			var args struct {
 				CartID   string `json:"cart_id"`
 				SKU      string `json:"sku"`
@@ -222,7 +222,7 @@ func registerCartTools(srv *server.Server, carts server.HandleStore[Cart]) {
 				"required":   []string{"cart_id"},
 			},
 		},
-		func(_ core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(_ core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			var args struct {
 				CartID string `json:"cart_id"`
 			}
@@ -258,7 +258,7 @@ func registerDiagnosticTools(srv *server.Server) {
 			Description: "SEP-2575 conformance hook: rejects with -32003 when the per-request _meta.clientCapabilities lacks 'sampling'.",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(ctx core.ToolContext, _ core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, _ core.ToolRequest) (core.ToolResponse, error) {
 			meta := stateless.RequestMetaFromContext(ctx)
 			if meta == nil || meta.ClientCapabilities == nil || meta.ClientCapabilities.Sampling == nil {
 				return core.ToolResult{}, &core.MissingCapabilityError{
@@ -276,7 +276,7 @@ func registerDiagnosticTools(srv *server.Server) {
 			Description: "SEP-2575 conformance hook: emits an InputRequiredResult (MRTR) instead of a server-initiated request on the response stream.",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(ctx core.ToolContext, _ core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, _ core.ToolRequest) (core.ToolResponse, error) {
 			if !ctx.HasInputResponses() {
 				return ctx.RequestInput(core.InputRequests{
 					"name": core.NewElicitationInputRequest(core.ElicitationRequest{
@@ -299,7 +299,7 @@ func registerDiagnosticTools(srv *server.Server) {
 			Description: "SEP-2575 conformance hook: emits notifications/message ONLY if the per-request _meta.logLevel is set.",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(ctx core.ToolContext, _ core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, _ core.ToolRequest) (core.ToolResponse, error) {
 			meta := stateless.RequestMetaFromContext(ctx)
 			if meta != nil && meta.LogLevel != "" {
 				if lvl, ok := core.ParseLogLevel(meta.LogLevel); ok {
@@ -317,11 +317,11 @@ func registerDiagnosticTools(srv *server.Server) {
 			Description: "SEP-2575 conformance hook: mutates the tool registry to broadcast notifications/tools/list_changed.",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(_ core.ToolContext, _ core.ToolRequest) (core.ToolResult, error) {
+		func(_ core.ToolContext, _ core.ToolRequest) (core.ToolResponse, error) {
 			name := fmt.Sprintf("_synthetic_%d", time.Now().UnixNano())
 			_ = srv.Registry().AddTool(
 				core.ToolDef{Name: name, Description: "synthetic"},
-				func(_ core.ToolContext, _ core.ToolRequest) (core.ToolResult, error) {
+				func(_ core.ToolContext, _ core.ToolRequest) (core.ToolResponse, error) {
 					return core.TextResult("synthetic"), nil
 				},
 			)
@@ -336,11 +336,11 @@ func registerDiagnosticTools(srv *server.Server) {
 			Description: "SEP-2575 conformance hook: mutates the prompt registry to broadcast notifications/prompts/list_changed.",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(_ core.ToolContext, _ core.ToolRequest) (core.ToolResult, error) {
+		func(_ core.ToolContext, _ core.ToolRequest) (core.ToolResponse, error) {
 			name := fmt.Sprintf("_synthetic_prompt_%d", time.Now().UnixNano())
 			_ = srv.Registry().AddPrompt(
 				core.PromptDef{Name: name, Description: "synthetic"},
-				func(_ core.PromptContext, _ core.PromptRequest) (core.PromptResult, error) {
+				func(_ core.PromptContext, _ core.PromptRequest) (core.PromptResponse, error) {
 					return core.PromptResult{}, nil
 				},
 			)
@@ -359,7 +359,7 @@ func registerSeedPrompt(srv *server.Server) {
 			Name:        "greeting",
 			Description: "Demo prompt so prompts/list and prompts cap are non-empty.",
 		},
-		func(_ core.PromptContext, _ core.PromptRequest) (core.PromptResult, error) {
+		func(_ core.PromptContext, _ core.PromptRequest) (core.PromptResponse, error) {
 			return core.PromptResult{
 				Messages: []core.PromptMessage{{
 					Role:    "user",

--- a/examples/tasks-v2/main.go
+++ b/examples/tasks-v2/main.go
@@ -68,9 +68,9 @@ func serve() {
 		Seconds int    `json:"seconds,omitempty"`
 		Label   string `json:"label,omitempty"`
 	}
-	srv.Register(core.TypedTool[slowComputeInput, core.ToolResult]("slow_compute",
+	srv.Register(core.TypedTool[slowComputeInput, core.ToolResponse]("slow_compute",
 		"Simulate a slow computation. In v2, always runs as a task unless instant (0 seconds).",
-		func(ctx core.ToolContext, args slowComputeInput) (core.ToolResult, error) {
+		func(ctx core.ToolContext, args slowComputeInput) (core.ToolResponse, error) {
 			if args.Label == "" {
 				args.Label = "default"
 			}
@@ -87,7 +87,7 @@ func serve() {
 			// G6 filter is active and the response isn't held open). On the
 			// first sync pass there's no TaskContext, so signal GoAsync.
 			if tasks.GetTaskContext(ctx) == nil {
-				return core.ToolResult{GoAsync: true}, nil
+				return core.GoAsyncResult{}, nil
 			}
 
 			log.Printf("[slow_compute] starting %q: sleeping %ds...", args.Label, args.Seconds)
@@ -130,11 +130,11 @@ func serve() {
 
 	// failing_job: required task support. Always fails with a tool execution error.
 	// In v2, tool errors → completed + isError:true (NOT failed).
-	srv.Register(core.TypedTool[struct{}, core.ToolResult]("failing_job",
+	srv.Register(core.TypedTool[struct{}, core.ToolResponse]("failing_job",
 		"A job that always fails after 1 second. In v2: tool error = completed + isError:true.",
-		func(ctx core.ToolContext, _ struct{}) (core.ToolResult, error) {
+		func(ctx core.ToolContext, _ struct{}) (core.ToolResponse, error) {
 			if tasks.GetTaskContext(ctx) == nil {
-				return core.ToolResult{GoAsync: true}, nil
+				return core.GoAsyncResult{}, nil
 			}
 			log.Printf("[failing_job] starting (will fail in 1s)...")
 			time.Sleep(1 * time.Second)
@@ -150,14 +150,14 @@ func serve() {
 	type confirmDeleteInput struct {
 		Filename string `json:"filename,omitempty"`
 	}
-	srv.Register(core.TypedTool[confirmDeleteInput, core.ToolResult]("confirm_delete",
+	srv.Register(core.TypedTool[confirmDeleteInput, core.ToolResponse]("confirm_delete",
 		"Asks the client to confirm before deleting (demonstrates SEP-2663 inputRequests/inputResponses).",
-		func(ctx core.ToolContext, args confirmDeleteInput) (core.ToolResult, error) {
+		func(ctx core.ToolContext, args confirmDeleteInput) (core.ToolResponse, error) {
 			tc := tasks.GetTaskContext(ctx)
 			if tc == nil {
 				// SEP-2663 Option 2: TaskElicit needs the continuation
 				// goroutine's TaskContext.
-				return core.ToolResult{GoAsync: true}, nil
+				return core.GoAsyncResult{}, nil
 			}
 			if args.Filename == "" {
 				args.Filename = "important.txt"
@@ -198,14 +198,14 @@ func serve() {
 	// the SEP-2663 partial-fulfillment path: a client may answer one key on
 	// tasks/update, observe the task is still input_required with the other
 	// key remaining, and answer the second on a follow-up tasks/update.
-	srv.Register(core.TypedTool[struct{}, core.ToolResult]("multi_input",
+	srv.Register(core.TypedTool[struct{}, core.ToolResponse]("multi_input",
 		"Asks for two simultaneous inputs (name + confirm) so partial inputResponses can be exercised.",
-		func(ctx core.ToolContext, _ struct{}) (core.ToolResult, error) {
+		func(ctx core.ToolContext, _ struct{}) (core.ToolResponse, error) {
 			tc := tasks.GetTaskContext(ctx)
 			if tc == nil {
 				// SEP-2663 Option 2: TaskElicit needs the continuation
 				// goroutine's TaskContext.
-				return core.ToolResult{GoAsync: true}, nil
+				return core.GoAsyncResult{}, nil
 			}
 
 			var (
@@ -248,13 +248,13 @@ func serve() {
 
 	// protocol_error_job: required task support. Triggers a protocol-level failure
 	// by panicking. In v2, protocol errors → failed + error field.
-	srv.Register(core.TypedTool[struct{}, core.ToolResult]("protocol_error_job",
+	srv.Register(core.TypedTool[struct{}, core.ToolResponse]("protocol_error_job",
 		"A job that triggers a protocol-level error (panic). In v2: failed + error field.",
-		func(ctx core.ToolContext, _ struct{}) (core.ToolResult, error) {
+		func(ctx core.ToolContext, _ struct{}) (core.ToolResponse, error) {
 			if tasks.GetTaskContext(ctx) == nil {
 				// Run the panic inside the goroutine so the middleware's
 				// recover() turns it into a failed task, not a sync 500.
-				return core.ToolResult{GoAsync: true}, nil
+				return core.GoAsyncResult{}, nil
 			}
 			log.Printf("[protocol_error_job] starting (will panic in 500ms)...")
 			time.Sleep(500 * time.Millisecond)
@@ -280,9 +280,9 @@ func serve() {
 			},
 			Execution: &core.ToolExecution{TaskSupport: core.TaskSupportRequired},
 		},
-		Handler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		Handler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			if tasks.GetTaskContext(ctx) == nil {
-				return core.ToolResult{GoAsync: true}, nil
+				return core.GoAsyncResult{}, nil
 			}
 			var args struct {
 				JobID string `json:"job_id"`

--- a/examples/tasks/main.go
+++ b/examples/tasks/main.go
@@ -68,9 +68,9 @@ func serve() {
 		Seconds int    `json:"seconds,omitempty"`
 		Label   string `json:"label,omitempty"`
 	}
-	srv.Register(core.TypedTool[slowComputeInput, core.ToolResult]("slow_compute",
+	srv.Register(core.TypedTool[slowComputeInput, core.ToolResponse]("slow_compute",
 		"Simulate a slow computation (sleeps for the given duration). Supports optional async task execution.",
-		func(ctx core.ToolContext, args slowComputeInput) (core.ToolResult, error) {
+		func(ctx core.ToolContext, args slowComputeInput) (core.ToolResponse, error) {
 			if args.Seconds <= 0 {
 				args.Seconds = 3
 			}
@@ -125,9 +125,9 @@ func serve() {
 
 	// failing_job: required task support. Must be invoked as a task.
 	// Calling without a task hint returns an error. Always fails after a delay.
-	srv.Register(core.TypedTool[struct{}, core.ToolResult]("failing_job",
+	srv.Register(core.TypedTool[struct{}, core.ToolResponse]("failing_job",
 		"A job that always fails after 1 second. Requires task invocation — calling without 'task' hint returns an error.",
-		func(ctx core.ToolContext, _ struct{}) (core.ToolResult, error) {
+		func(ctx core.ToolContext, _ struct{}) (core.ToolResponse, error) {
 			log.Printf("[failing_job] starting (will fail in 1s)...")
 			time.Sleep(1 * time.Second)
 			return core.ToolResult{}, fmt.Errorf("simulated failure: job crashed")
@@ -141,9 +141,9 @@ func serve() {
 	type confirmDeleteInput struct {
 		Filename string `json:"filename,omitempty"`
 	}
-	srv.Register(core.TypedTool[confirmDeleteInput, core.ToolResult]("confirm_delete",
+	srv.Register(core.TypedTool[confirmDeleteInput, core.ToolResponse]("confirm_delete",
 		"Asks for confirmation before deleting a file. Demonstrates task-based elicitation.",
-		func(ctx core.ToolContext, args confirmDeleteInput) (core.ToolResult, error) {
+		func(ctx core.ToolContext, args confirmDeleteInput) (core.ToolResponse, error) {
 			tc := server.GetTaskContext(ctx)
 			if tc == nil {
 				return core.ToolResult{}, fmt.Errorf("confirm_delete requires task context")
@@ -189,9 +189,9 @@ func serve() {
 	type writeHaikuInput struct {
 		Topic string `json:"topic,omitempty"`
 	}
-	srv.Register(core.TypedTool[writeHaikuInput, core.ToolResult]("write_haiku",
+	srv.Register(core.TypedTool[writeHaikuInput, core.ToolResponse]("write_haiku",
 		"Asks the LLM to write a haiku on a topic. Demonstrates task-based sampling.",
-		func(ctx core.ToolContext, args writeHaikuInput) (core.ToolResult, error) {
+		func(ctx core.ToolContext, args writeHaikuInput) (core.ToolResponse, error) {
 			tc := server.GetTaskContext(ctx)
 			if tc == nil {
 				return core.ToolResult{}, fmt.Errorf("write_haiku requires task context")
@@ -247,7 +247,7 @@ func serve() {
 			},
 			Execution: &core.ToolExecution{TaskSupport: core.TaskSupportRequired},
 		},
-		Handler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		Handler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			var args struct {
 				JobID string `json:"job_id"`
 			}

--- a/ext/auth/scopes.go
+++ b/ext/auth/scopes.go
@@ -16,7 +16,7 @@ import (
 //
 // Usage in a tool handler:
 //
-//	func adminTool(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+//	func adminTool(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 //	    if err := auth.RequireScope(ctx, "admin:write"); err != nil {
 //	        return core.ErrorResult(err.Error()), nil
 //	    }

--- a/ext/tasks/client_integration_test.go
+++ b/ext/tasks/client_integration_test.go
@@ -41,7 +41,7 @@ func newTaskV2TestServer(t *testing.T) (string, chan struct{}) {
 			InputSchema: map[string]any{"type": "object"},
 			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportRequired},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("fast-done"), nil
 		},
 	)
@@ -54,13 +54,13 @@ func newTaskV2TestServer(t *testing.T) (string, chan struct{}) {
 			InputSchema: map[string]any{"type": "object"},
 			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportRequired},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			// SEP-2663 Option-2 / Go side: tools whose work is actually async
 			// MUST opt into the goroutine via GoAsync. On the first (sync) pass
 			// there is no TaskContext, so we signal "go async"; the middleware
 			// re-invokes us in the continuation goroutine with TaskContext set.
 			if tasks.GetTaskContext(ctx) == nil {
-				return core.ToolResult{GoAsync: true}, nil
+				return core.GoAsyncResult{}, nil
 			}
 			select {
 			case <-unblock:
@@ -77,13 +77,13 @@ func newTaskV2TestServer(t *testing.T) (string, chan struct{}) {
 			InputSchema: map[string]any{"type": "object"},
 			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportRequired},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			tc := tasks.GetTaskContext(ctx)
 			if tc == nil {
 				// First (sync) pass — defer the elicit-driven work to the
 				// continuation goroutine where TaskContext (and TaskElicit)
 				// are available.
-				return core.ToolResult{GoAsync: true}, nil
+				return core.GoAsyncResult{}, nil
 			}
 			res, err := tc.TaskElicit(core.ElicitationRequest{
 				Message:         "delete?",

--- a/ext/tasks/mrtr_composition_test.go
+++ b/ext/tasks/mrtr_composition_test.go
@@ -38,7 +38,7 @@ func TestMRTR_TaskComposition(t *testing.T) {
 			InputSchema: map[string]any{"type": "object"},
 			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportRequired},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			if tasks.GetTaskContext(ctx) != nil {
 				// Continuation phase: produce the final result.
 				var er struct {
@@ -63,7 +63,7 @@ func TestMRTR_TaskComposition(t *testing.T) {
 					},
 				})
 			}
-			return core.ToolResult{GoAsync: true}, nil
+			return core.GoAsyncResult{}, nil
 		},
 	)
 

--- a/ext/tasks/stateless_wire_test.go
+++ b/ext/tasks/stateless_wire_test.go
@@ -46,7 +46,7 @@ func newStatelessTaskServer(t *testing.T) string {
 			InputSchema: map[string]any{"type": "object"},
 			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
 		},
-		func(ctx core.ToolContext, _ core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, _ core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("done"), nil
 		},
 	)
@@ -58,7 +58,7 @@ func newStatelessTaskServer(t *testing.T) string {
 			InputSchema: map[string]any{"type": "object"},
 			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportRequired},
 		},
-		func(ctx core.ToolContext, _ core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, _ core.ToolRequest) (core.ToolResponse, error) {
 			return core.ToolResult{}, errors.New("planned failure")
 		},
 	)
@@ -70,12 +70,12 @@ func newStatelessTaskServer(t *testing.T) string {
 			InputSchema: map[string]any{"type": "object"},
 			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportRequired},
 		},
-		func(ctx core.ToolContext, _ core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, _ core.ToolRequest) (core.ToolResponse, error) {
 			tc := tasks.GetTaskContext(ctx)
 			if tc == nil {
 				// SEP-2663 Option 2: TaskElicit needs the continuation
 				// goroutine's TaskContext.
-				return core.ToolResult{GoAsync: true}, nil
+				return core.GoAsyncResult{}, nil
 			}
 			res, err := tc.TaskElicit(core.ElicitationRequest{
 				Message:         "delete?",

--- a/ext/tasks/tasks.go
+++ b/ext/tasks/tasks.go
@@ -460,23 +460,24 @@ func taskV2Middleware(reg *server.Registry, rt *v2TaskRuntime, cfg Config) serve
 			// MRTR round — let the dispatcher's reshaped response flow back
 			// to the client unchanged. No task is created during MRTR rounds;
 			// task creation happens (if at all) on a later round when the
-			// handler returns GoAsync or a final sync result.
+			// handler returns GoAsyncResult or a final sync result.
 			return resp, nil
 
-		case core.ToolResult:
+		case core.GoAsyncResult:
 			var progressToken any
 			if envelope.Meta != nil {
 				progressToken = envelope.Meta.ProgressToken
 			}
-			if r.GoAsync {
-				return spawnGoAsyncTask(ctx, req, next, rt, cfg, envelope.Name, progressToken)
-			}
+			return spawnGoAsyncTask(ctx, req, next, rt, cfg, envelope.Name, progressToken)
+
+		case core.ToolResult:
 			return wrapSyncAsCompletedTask(ctx, req, rt, cfg, r)
 
 		default:
 			// Some other result shape (e.g. an upstream middleware already
 			// produced a CreateTaskResult, or a non-tool response sneaks
 			// through). Pass through unchanged.
+			_ = r
 			return resp, nil
 		}
 	}
@@ -575,20 +576,17 @@ func spawnGoAsyncTask(
 			return
 		}
 
-		raw, err := json.Marshal(resp.Result)
-		if err != nil {
-			te := &core.TaskError{Code: -32603, Message: "failed to marshal tool result"}
+		// The continuation handler is expected to return a sync ToolResult on
+		// its final invocation. Other ToolResponse variants are programmer
+		// errors at this point — they'd indicate the handler is trying to
+		// re-enter the MRTR loop or re-spawn from inside an async task, which
+		// SEP-2663 does not allow. We surface them as protocol failures.
+		toolResult, ok := resp.Result.(core.ToolResult)
+		if !ok {
+			msg := fmt.Sprintf("tool returned unexpected %T inside async continuation; expected core.ToolResult", resp.Result)
+			te := &core.TaskError{Code: -32603, Message: msg}
 			rt.setTaskError(taskID, te)
-			store.StoreTerminalResult(taskID, sessionID, core.TaskFailed, core.ErrorResult("failed to marshal tool result"), "")
-			notifyV2TaskStatus(bgCtx, rt, store, taskID, sessionID)
-			return
-		}
-
-		var toolResult core.ToolResult
-		if err := json.Unmarshal(raw, &toolResult); err != nil {
-			te := &core.TaskError{Code: -32603, Message: "failed to unmarshal tool result"}
-			rt.setTaskError(taskID, te)
-			store.StoreTerminalResult(taskID, sessionID, core.TaskFailed, core.ErrorResult("failed to unmarshal tool result"), "")
+			store.StoreTerminalResult(taskID, sessionID, core.TaskFailed, core.ErrorResult(msg), msg)
 			notifyV2TaskStatus(bgCtx, rt, store, taskID, sessionID)
 			return
 		}

--- a/ext/tasks/tasks_test.go
+++ b/ext/tasks/tasks_test.go
@@ -45,7 +45,7 @@ func newTaskV2Server(t *testing.T) *Server {
 			InputSchema: map[string]any{"type": "object"},
 			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("fast-done"), nil
 		},
 	)
@@ -57,7 +57,7 @@ func newTaskV2Server(t *testing.T) *Server {
 			InputSchema: map[string]any{"type": "object"},
 			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportRequired},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("must-done"), nil
 		},
 	)
@@ -336,12 +336,12 @@ func newTaskV2ServerWithSlow(t *testing.T) (*Server, chan struct{}) {
 			InputSchema: map[string]any{"type": "object"},
 			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportRequired},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			// SEP-2663 Option 2: slow / blocking work must opt into the
 			// continuation goroutine via GoAsync. The middleware re-invokes us
 			// in the goroutine with TaskContext set.
 			if tasks.GetTaskContext(ctx) == nil {
-				return core.ToolResult{GoAsync: true}, nil
+				return core.GoAsyncResult{}, nil
 			}
 			select {
 			case <-unblock:
@@ -729,12 +729,12 @@ func newTaskV2ServerWithElicit(t *testing.T) *Server {
 			},
 			Execution: &core.ToolExecution{TaskSupport: core.TaskSupportRequired},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			tc := tasks.GetTaskContext(ctx)
 			if tc == nil {
 				// SEP-2663 Option 2: TaskElicit requires the continuation
 				// goroutine's TaskContext, so signal GoAsync on the sync pass.
-				return core.ToolResult{GoAsync: true}, nil
+				return core.GoAsyncResult{}, nil
 			}
 
 			var args struct {
@@ -1065,13 +1065,13 @@ func TestV2_NoProgressOrMessageOnTaskGoroutine(t *testing.T) {
 			InputSchema: map[string]any{"type": "object"},
 			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			// SEP-2663 G6 filter is installed only on the continuation-goroutine
 			// bgCtx, so emissions only get dropped if the handler opts into
 			// GoAsync. A sync return would emit on the unfiltered POST ctx and
 			// leak — explicitly NOT what this test is asserting.
 			if tasks.GetTaskContext(ctx) == nil {
-				return core.ToolResult{GoAsync: true}, nil
+				return core.GoAsyncResult{}, nil
 			}
 			// Both of these would normally fan out on the session stream.
 			// The v2 task filter is expected to drop both silently.

--- a/ext/ui/app_helpers_test.go
+++ b/ext/ui/app_helpers_test.go
@@ -19,7 +19,7 @@ func TestRegisterAppTool(t *testing.T) {
 		Description: "Build a slide deck",
 		InputSchema: map[string]any{"type": "object"},
 		ResourceURI: "ui://decks/view",
-		ToolHandler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		ToolHandler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("ok"), nil
 		},
 		ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
@@ -159,7 +159,7 @@ func TestRegisterAppToolTemplate(t *testing.T) {
 		Description: "Show a pizza",
 		InputSchema: map[string]any{"type": "object"},
 		ResourceURI: "ui://pizzas/{pizzaId}/details",
-		ToolHandler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		ToolHandler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("ok"), nil
 		},
 		TemplateHandler: func(ctx core.ResourceContext, uri string, params map[string]string) (core.ResourceResult, error) {
@@ -215,7 +215,7 @@ func TestRegisterAppToolTemplateNilHandlerPanics(t *testing.T) {
 	RegisterAppTool(reg, AppToolConfig{
 		Name:        "bad_template",
 		ResourceURI: "ui://items/{id}/view",
-		ToolHandler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		ToolHandler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("ok"), nil
 		},
 		// TemplateHandler intentionally nil
@@ -237,7 +237,7 @@ func TestRegisterAppToolConcreteNilHandlerPanics(t *testing.T) {
 	RegisterAppTool(reg, AppToolConfig{
 		Name:        "bad_concrete",
 		ResourceURI: "ui://items/view",
-		ToolHandler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		ToolHandler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("ok"), nil
 		},
 		// ResourceHandler intentionally nil
@@ -252,7 +252,7 @@ func TestRegisterAppToolSupportedDisplayModes(t *testing.T) {
 	RegisterAppTool(reg, AppToolConfig{
 		Name:        "dashboard",
 		ResourceURI: "ui://dashboard/view",
-		ToolHandler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		ToolHandler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("ok"), nil
 		},
 		ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
@@ -287,7 +287,7 @@ func TestTemplateManualHybrid(t *testing.T) {
 		Description: "Manual hybrid",
 		InputSchema: map[string]any{"type": "object"},
 		ResourceURI: "ui://app/{id}/view",
-		ToolHandler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		ToolHandler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("ok"), nil
 		},
 		ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
@@ -347,7 +347,7 @@ func TestTemplateToolNotifiesResourceUpdated(t *testing.T) {
 			"widget_id": map[string]any{"type": "string"},
 		}},
 		ResourceURI: "ui://widgets/{widget_id}/preview",
-		ToolHandler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		ToolHandler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("previewed"), nil
 		},
 		TemplateHandler: func(ctx core.ResourceContext, uri string, params map[string]string) (core.ResourceResult, error) {
@@ -375,9 +375,13 @@ func TestTemplateToolNotifiesResourceUpdated(t *testing.T) {
 	toolCtx := core.NewToolContext(ctx)
 
 	args, _ := json.Marshal(map[string]string{"widget_id": "w42"})
-	result, err := reg.toolHandlers[0](toolCtx, core.ToolRequest{Arguments: args})
+	resp, err := reg.toolHandlers[0](toolCtx, core.ToolRequest{Arguments: args})
 	if err != nil {
 		t.Fatalf("tool handler error: %v", err)
+	}
+	result, ok := resp.(core.ToolResult)
+	if !ok {
+		t.Fatalf("unexpected response type %T", resp)
 	}
 	if result.IsError {
 		t.Fatalf("tool returned error: %s", result.Content[0].Text)

--- a/ext/ui/app_host_integration_test.go
+++ b/ext/ui/app_host_integration_test.go
@@ -22,7 +22,7 @@ func TestAppHost_EndToEnd(t *testing.T) {
 	srv := server.NewServer(core.ServerInfo{Name: "test-server", Version: "1.0"})
 	srv.RegisterTool(
 		core.ToolDef{Name: "server_echo", Description: "Server-side echo"},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			var args map[string]string
 			json.Unmarshal(req.Arguments, &args)
 			return core.TextResult("server:" + args["msg"]), nil

--- a/ext/ui/extension.go
+++ b/ext/ui/extension.go
@@ -180,7 +180,7 @@ func RegisterAppTool(reg ToolResourceRegistrar, cfg AppToolConfig) {
 		// from tool arguments after each successful call, then notify
 		// the host that the concrete fallback resource has new content.
 		origHandler := cfg.ToolHandler
-		wrappedHandler := func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		wrappedHandler := func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			result, err := origHandler(ctx, req)
 			if err == nil {
 				params := extractTemplateParams(templateVars, req.Arguments)

--- a/ext/ui/server_registry_integration_test.go
+++ b/ext/ui/server_registry_integration_test.go
@@ -23,7 +23,7 @@ func newTestServer(tools map[string]string) *server.Server {
 		n, d := name, desc // capture
 		srv.RegisterTool(
 			core.ToolDef{Name: n, Description: d, InputSchema: map[string]any{"type": "object"}},
-			func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+			func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 				return core.TextResult(n + ":ok"), nil
 			},
 		)

--- a/server/auth_integration_test.go
+++ b/server/auth_integration_test.go
@@ -243,7 +243,7 @@ func TestAnnotationsOnToolDef(t *testing.T) {
 	srv := NewServer(core.ServerInfo{Name: "test", Version: "0.1.0"})
 	srv.RegisterExperimentalTool(
 		core.ToolDef{Name: "beta-tool", Description: "experimental"},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("ok"), nil
 		},
 	)

--- a/server/auth_retry_integration_test.go
+++ b/server/auth_retry_integration_test.go
@@ -34,7 +34,7 @@ func TestClient_Streamable_401Integration(t *testing.T) {
 		server.WithBearerToken("valid-token"))
 	srv.RegisterTool(
 		core.ToolDef{Name: "echo", Description: "echo", InputSchema: map[string]any{"type": "object", "properties": map[string]any{"message": map[string]any{"type": "string"}}}},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			var p struct{ Message string `json:"message"` }
 			req.Bind(&p)
 			return core.TextResult("echo: "+p.Message), nil
@@ -65,7 +65,7 @@ func TestClient_Streamable_AuthErrorType(t *testing.T) {
 		server.WithBearerToken("valid-token"))
 	srv.RegisterTool(
 		core.ToolDef{Name: "echo", Description: "echo"},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("ok"), nil
 		},
 	)

--- a/server/concurrency_test.go
+++ b/server/concurrency_test.go
@@ -27,7 +27,7 @@ func TestConcurrentRequestsGetCorrectResponses(t *testing.T) {
 			Description: "Returns the request argument as-is for identification",
 			InputSchema: map[string]any{"type": "object", "properties": map[string]any{"tag": map[string]any{"type": "string"}}},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			var p struct{ Tag string `json:"tag"` }
 			req.Bind(&p)
 			time.Sleep(10 * time.Millisecond) // simulate work
@@ -76,7 +76,7 @@ func TestDuplicateRequestIDRejected(t *testing.T) {
 			Description: "Takes 100ms to complete",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			time.Sleep(100 * time.Millisecond)
 			return core.TextResult("done"), nil
 		},

--- a/server/detach_integration_test.go
+++ b/server/detach_integration_test.go
@@ -34,7 +34,7 @@ func TestDetach_ToolSurvivesPerToolTimeout(t *testing.T) {
 			InputSchema: map[string]any{"type": "object"},
 			Timeout:     50 * time.Millisecond, // short timeout
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			// Detach — strips the per-tool timeout.
 			ctx = ctx.DetachFromClient()
 
@@ -101,7 +101,7 @@ func TestDetach_NonDetachedToolCancelledByTimeout(t *testing.T) {
 			InputSchema: map[string]any{"type": "object"},
 			Timeout:     50 * time.Millisecond,
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			// NO DetachFromClient.
 			for i := 0; i < 10; i++ {
 				select {
@@ -165,7 +165,7 @@ func TestStreamableHTTP_DetachedToolPreservesRetryHint(t *testing.T) {
 			Description: "Emits retry then detaches",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			_ = core.EmitSSERetry(ctx, 10*time.Second)
 			ctx = ctx.DetachFromClient()
 			time.Sleep(50 * time.Millisecond)

--- a/server/devex_test.go
+++ b/server/devex_test.go
@@ -118,7 +118,7 @@ func TestStructuredContentInDispatch(t *testing.T) {
 			InputSchema:  map[string]any{"type": "object"},
 			OutputSchema: map[string]any{"type": "object", "properties": map[string]any{"count": map[string]any{"type": "integer"}}},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.StructuredResult("3 items", map[string]any{"count": 3}), nil
 		},
 	)
@@ -222,7 +222,7 @@ func TestStatelessMode_NoSession(t *testing.T) {
 	srv := server.NewServer(core.ServerInfo{Name: "stateless", Version: "1.0"})
 	srv.RegisterTool(
 		core.ToolDef{Name: "ping", Description: "ping", InputSchema: map[string]any{"type": "object"}},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("pong"), nil
 		},
 	)
@@ -252,7 +252,7 @@ func TestStatelessMode_IndependentRequests(t *testing.T) {
 	srv := server.NewServer(core.ServerInfo{Name: "stateless", Version: "1.0"})
 	srv.RegisterTool(
 		core.ToolDef{Name: "count", Description: "count", InputSchema: map[string]any{"type": "object"}},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			callCount++
 			return core.TextResult(fmt.Sprintf("call-%d", callCount)), nil
 		},

--- a/server/dispatch.go
+++ b/server/dispatch.go
@@ -567,23 +567,29 @@ func (d *Dispatcher) handleToolsCall(ctx context.Context, id json.RawMessage, pa
 	}
 
 	tc := core.NewToolContextWithMRTR(ctx, progressToken, mergedResponses, envelope.RequestState)
-	result, hErr := entry.handler(tc, req)
+	resp, hErr := entry.handler(tc, req)
 	if hErr != nil {
-		result = core.ErrorResult(fmt.Sprintf("tool %q: %v", envelope.Name, hErr))
+		resp = core.ErrorResult(fmt.Sprintf("tool %q: %v", envelope.Name, hErr))
 	}
 
-	// SEP-2322: handler signalled "I need more input" — reshape the
-	// response on the wire as InputRequiredResult and mint a fresh
-	// requestState carrying the merged accumulated answers so the next
-	// round sees them too.
-	if result.IsInputRequired {
+	// Type-switch on the sealed ToolResponse interface. SEP-2322
+	// InputRequiredResult gets a freshly-minted requestState that carries the
+	// merged accumulated answers so the next round sees them too. Every other
+	// variant — ToolResult, CreateTaskResult, GoAsyncResult — flows through
+	// to the response as-is. GoAsyncResult is in-process plumbing the
+	// ext/tasks middleware intercepts before the response reaches the wire;
+	// if no middleware is installed and a handler still emits GoAsyncResult,
+	// it marshals to "{}" which is a programmer error to be diagnosed at
+	// registration time, not silently absorbed here.
+	switch r := resp.(type) {
+	case core.InputRequiredResult:
 		return core.NewResponse(id, core.InputRequiredResult{
-			InputRequests: result.InputRequests,
+			InputRequests: r.InputRequests,
 			RequestState:  d.mrtr.mintRequestState(envelope.Name, mergedResponses),
 		})
+	default:
+		return core.NewResponse(id, resp)
 	}
-
-	return core.NewResponse(id, result)
 }
 
 // --- Resources ---

--- a/server/dispatch_test.go
+++ b/server/dispatch_test.go
@@ -40,7 +40,7 @@ func testDispatcher() *Dispatcher {
 				"required": []string{"message"},
 			},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			var args struct {
 				Message string `json:"message"`
 			}
@@ -187,6 +187,83 @@ func TestDispatchToolsCall(t *testing.T) {
 	}
 }
 
+// TestDispatchToolsCall_HandlerReturnsTypedVariants verifies that a tool
+// handler can return any of the sealed ToolResponse variants directly —
+// without going through ctx.RequestInput or relying on a sentinel field
+// flip on ToolResult — and that dispatch emits the matching wire envelope.
+// Red-before-green for the SEP-486 sealed-interface refactor: under the
+// old field-on-struct dispatch, only ctx.RequestInput()'s flag-set path
+// produced an input_required envelope; a handler that returned an
+// InputRequiredResult literal would have been marshaled as a malformed
+// ToolResult ({"resultType":"input_required","content":null,...}).
+func TestDispatchToolsCall_HandlerReturnsTypedVariants(t *testing.T) {
+	cases := []struct {
+		name           string
+		handler        func(core.ToolContext, core.ToolRequest) (core.ToolResponse, error)
+		wantResultType core.ResultType
+	}{
+		{
+			name: "input_required",
+			handler: func(core.ToolContext, core.ToolRequest) (core.ToolResponse, error) {
+				return core.InputRequiredResult{
+					InputRequests: core.InputRequests{
+						"k": {Method: "elicitation/create", Params: json.RawMessage(`{}`)},
+					},
+				}, nil
+			},
+			wantResultType: core.ResultTypeInputRequired,
+		},
+		{
+			name: "task_envelope",
+			handler: func(core.ToolContext, core.ToolRequest) (core.ToolResponse, error) {
+				return core.CreateTaskResult{
+					ResultType: core.ResultTypeTask,
+					TaskInfoV2: core.TaskInfoV2{
+						TaskID:        "t-abc",
+						Status:        core.TaskWorking,
+						CreatedAt:     "2026-05-28T00:00:00Z",
+						LastUpdatedAt: "2026-05-28T00:00:00Z",
+					},
+				}, nil
+			},
+			wantResultType: core.ResultTypeTask,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := NewDispatcher(core.ServerInfo{Name: "test-server", Version: "1.0.0"})
+			d.RegisterTool(
+				core.ToolDef{
+					Name:        "typed_variant",
+					Description: "returns a typed ToolResponse variant",
+					InputSchema: map[string]any{"type": "object"},
+				},
+				tc.handler,
+			)
+			initDispatcher(d)
+			resp := d.Dispatch(context.Background(), &core.Request{
+				JSONRPC: "2.0",
+				ID:      json.RawMessage(`9`),
+				Method:  "tools/call",
+				Params:  json.RawMessage(`{"name":"typed_variant","arguments":{}}`),
+			})
+			if resp == nil || resp.Error != nil {
+				t.Fatalf("unexpected error: %+v", resp)
+			}
+			raw, _ := core.MarshalJSON(resp.Result)
+			var probe struct {
+				ResultType core.ResultType `json:"resultType"`
+			}
+			if err := json.Unmarshal(raw, &probe); err != nil {
+				t.Fatalf("decode resultType from %s: %v", raw, err)
+			}
+			if probe.ResultType != tc.wantResultType {
+				t.Errorf("resultType = %q, want %q (raw=%s)", probe.ResultType, tc.wantResultType, raw)
+			}
+		})
+	}
+}
+
 func TestDispatchToolsCallUnknown(t *testing.T) {
 	d := testDispatcher()
 	resp := d.Dispatch(context.Background(), &core.Request{
@@ -270,7 +347,7 @@ func TestDispatchToolsCallHandlerError(t *testing.T) {
 	// Register a tool that always returns a Go error
 	d.RegisterTool(
 		core.ToolDef{Name: "failing", Description: "always fails"},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.ToolResult{}, fmt.Errorf("something broke")
 		},
 	)
@@ -309,7 +386,7 @@ func TestDispatchToolsCallHandlerError(t *testing.T) {
 func TestDispatchToolOrder(t *testing.T) {
 	d := NewDispatcher(core.ServerInfo{Name: "test", Version: "1.0"})
 	for _, name := range []string{"charlie", "alpha", "bravo"} {
-		d.RegisterTool(core.ToolDef{Name: name, Description: name}, func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		d.RegisterTool(core.ToolDef{Name: name, Description: name}, func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult(name), nil
 		})
 	}
@@ -456,7 +533,7 @@ func TestDispatchBeforeInitialized(t *testing.T) {
 	d := NewDispatcher(core.ServerInfo{Name: "test", Version: "1.0"})
 	d.RegisterTool(
 		core.ToolDef{Name: "echo", Description: "echoes"},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("hi"), nil
 		},
 	)
@@ -491,7 +568,7 @@ func TestDispatchToolsCallBeforeAnyInit(t *testing.T) {
 	d := NewDispatcher(core.ServerInfo{Name: "test", Version: "1.0"})
 	d.RegisterTool(
 		core.ToolDef{Name: "echo", Description: "echoes"},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("hi"), nil
 		},
 	)
@@ -663,7 +740,7 @@ func TestDispatchToolsCallWithProgressToken(t *testing.T) {
 	var gotToken any
 	d.RegisterTool(
 		core.ToolDef{Name: "progress_tool", Description: "captures progress token"},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			gotToken = req.ProgressToken
 			return core.TextResult("ok"), nil
 		},
@@ -689,7 +766,7 @@ func TestDispatchToolsCallWithoutProgressToken(t *testing.T) {
 	var gotToken any = "sentinel"
 	d.RegisterTool(
 		core.ToolDef{Name: "no_progress", Description: "no progress token"},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			gotToken = req.ProgressToken
 			return core.TextResult("ok"), nil
 		},
@@ -737,7 +814,7 @@ func TestDispatchToolsListExtraSchemaFields(t *testing.T) {
 				},
 			},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("ok"), nil
 		},
 	)
@@ -813,7 +890,7 @@ func TestToolsListMeta(t *testing.T) {
 				},
 			},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("ok"), nil
 		},
 	)
@@ -823,7 +900,7 @@ func TestToolsListMeta(t *testing.T) {
 			Description: "Tool without UI metadata",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("ok"), nil
 		},
 	)

--- a/server/dynamic_test.go
+++ b/server/dynamic_test.go
@@ -69,7 +69,7 @@ func TestAddToolAfterServing(t *testing.T) {
 	// Add a tool at runtime
 	d.Reg.AddTool(
 		core.ToolDef{Name: "dynamic", Description: "Added at runtime"},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("dynamic"), nil
 		},
 	)
@@ -88,7 +88,7 @@ func TestRemoveTool(t *testing.T) {
 
 	d.Reg.AddTool(
 		core.ToolDef{Name: "ephemeral", Description: "Will be removed"},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("here"), nil
 		},
 	)
@@ -140,7 +140,7 @@ func TestAddToolBroadcastsListChanged(t *testing.T) {
 
 	srv.Registry().AddTool(
 		core.ToolDef{Name: "notified", Description: "triggers broadcast"},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("ok"), nil
 		},
 	)
@@ -159,7 +159,7 @@ func TestRemoveToolBroadcastsListChanged(t *testing.T) {
 
 	srv.Registry().AddTool(
 		core.ToolDef{Name: "temp", Description: "temp"},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("ok"), nil
 		},
 	)
@@ -265,7 +265,7 @@ func TestAddPromptAfterServing(t *testing.T) {
 
 	d.Reg.AddPrompt(
 		core.PromptDef{Name: "dynamic-prompt", Description: "Added at runtime"},
-		func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResult, error) {
+		func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResponse, error) {
 			return core.PromptResult{Messages: []core.PromptMessage{
 				{Role: "assistant", Content: core.Content{Type: "text", Text: "dynamic"}},
 			}}, nil
@@ -292,7 +292,7 @@ func TestRemovePrompt(t *testing.T) {
 
 	d.Reg.AddPrompt(
 		core.PromptDef{Name: "temp-prompt", Description: "Temp"},
-		func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResult, error) {
+		func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResponse, error) {
 			return core.PromptResult{}, nil
 		},
 	)
@@ -317,7 +317,7 @@ func TestAddPromptBroadcastsListChanged(t *testing.T) {
 
 	srv.Registry().AddPrompt(
 		core.PromptDef{Name: "p", Description: "P"},
-		func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResult, error) {
+		func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResponse, error) {
 			return core.PromptResult{}, nil
 		},
 	)
@@ -345,7 +345,7 @@ func TestConcurrentAddAndList(t *testing.T) {
 			defer wg.Done()
 			d.Reg.AddTool(
 				core.ToolDef{Name: json.Number(json.Number(string(rune('a'+i)))).String(), Description: "concurrent"},
-				func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+				func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 					return core.TextResult("ok"), nil
 				},
 			)

--- a/server/elicitation_integration_test.go
+++ b/server/elicitation_integration_test.go
@@ -185,7 +185,7 @@ func TestElicitModeValidation(t *testing.T) {
 			Description: "Sends raw URL-mode elicitation/create",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			// Use ElicitURL which checks capabilities.
 			result, err := core.ElicitURL(ctx, core.ElicitationRequest{
 				Message:       "Visit URL",
@@ -234,7 +234,7 @@ func newURLElicitationTestServer() *server.Server {
 			Description: "Calls ElicitURL and returns the user's response",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			result, err := core.ElicitURL(ctx, core.ElicitationRequest{
 				Message:       "Please approve access",
 				URL:           "https://example.com/approve?session=test",
@@ -253,7 +253,7 @@ func newURLElicitationTestServer() *server.Server {
 			Description: "URL elicitation with completion notification",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			elicitID := "elicit-complete-001"
 			result, err := core.ElicitURL(ctx, core.ElicitationRequest{
 				Message:       "Visit URL to approve",
@@ -355,7 +355,7 @@ func newElicitationTestServer() *server.Server {
 			Description: "Calls elicitation/create and returns the user's response",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			result, err := core.Elicit(ctx, core.ElicitationRequest{
 				Message:         "Pick a color",
 				RequestedSchema: json.RawMessage(`{"type":"object","properties":{"color":{"type":"string","enum":["red","green","blue"]}}}`),

--- a/server/exec.go
+++ b/server/exec.go
@@ -80,7 +80,7 @@ func ToolExec(cfg ExecConfig) Tool {
 			InputSchema: schema,
 			Timeout:     cfg.Timeout,
 		},
-		Handler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		Handler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			// Build the full argument list: static args + dynamic args.
 			args := make([]string, len(cfg.Args))
 			copy(args, cfg.Args)

--- a/server/exec_test.go
+++ b/server/exec_test.go
@@ -9,6 +9,23 @@ import (
 	core "github.com/panyam/mcpkit/core"
 )
 
+// callToolExec runs a ToolExec handler and unwraps the response to the
+// concrete ToolResult. Bound to ToolExec's contract (it always returns a
+// terminal sync ToolResult), so this helper does not need to handle the
+// other ToolResponse variants.
+func callToolExec(t *testing.T, tool Tool, req core.ToolRequest) (core.ToolResult, error) {
+	t.Helper()
+	resp, err := tool.Handler(core.NewToolContext(context.Background()), req)
+	if err != nil {
+		return core.ToolResult{}, err
+	}
+	tr, ok := resp.(core.ToolResult)
+	if !ok {
+		t.Fatalf("ToolExec returned unexpected response type %T", resp)
+	}
+	return tr, nil
+}
+
 // TestToolExec_Echo wraps the "echo" command as an MCP tool and verifies that
 // the subprocess stdout is returned as a TextResult. This is the simplest
 // ToolExec scenario: static args, no dynamic BuildArgs, no timeout.
@@ -19,9 +36,7 @@ func TestToolExec_Echo(t *testing.T) {
 		Args:    []string{"hello"},
 	})
 
-	result, err := tool.Handler(core.NewToolContext(context.Background()), core.ToolRequest{
-		Name: "echo-test",
-	})
+	result, err := callToolExec(t, tool, core.ToolRequest{Name: "echo-test"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -52,7 +67,7 @@ func TestToolExec_BuildArgs(t *testing.T) {
 		},
 	})
 
-	result, err := tool.Handler(core.NewToolContext(context.Background()), core.ToolRequest{
+	result, err := callToolExec(t, tool, core.ToolRequest{
 		Name:      "echo-dynamic",
 		Arguments: json.RawMessage(`{"message":"world"}`),
 	})
@@ -77,9 +92,7 @@ func TestToolExec_NonZeroExit(t *testing.T) {
 		Args:    []string{"-c", "echo fail >&2; exit 1"},
 	})
 
-	result, err := tool.Handler(core.NewToolContext(context.Background()), core.ToolRequest{
-		Name: "fail-test",
-	})
+	result, err := callToolExec(t, tool, core.ToolRequest{Name: "fail-test"})
 	if err != nil {
 		t.Fatalf("unexpected transport error: %v", err)
 	}
@@ -107,9 +120,7 @@ func TestToolExec_Timeout(t *testing.T) {
 	})
 
 	start := time.Now()
-	result, err := tool.Handler(core.NewToolContext(context.Background()), core.ToolRequest{
-		Name: "timeout-test",
-	})
+	result, err := callToolExec(t, tool, core.ToolRequest{Name: "timeout-test"})
 	elapsed := time.Since(start)
 
 	if err != nil {

--- a/server/file_validation_test.go
+++ b/server/file_validation_test.go
@@ -33,7 +33,7 @@ func newFileInputTestServer(t *testing.T) *server.Server {
 				"required": []string{"image"},
 			},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			// Should never be reached on rejection paths.
 			return core.TextResult("handler reached"), nil
 		},
@@ -119,7 +119,7 @@ func TestFileInputValidation_ArrayItems(t *testing.T) {
 				"required": []string{"documents"},
 			},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("ok"), nil
 		},
 	)
@@ -173,7 +173,7 @@ func TestFileInputCapGating_StripsKeywordWithoutCap(t *testing.T) {
 				"required": []string{"image"},
 			},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("ok"), nil
 		},
 	)
@@ -224,7 +224,7 @@ func TestFileInputCapGating_PreservesKeywordWithCap(t *testing.T) {
 				},
 			},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("ok"), nil
 		},
 	)
@@ -263,7 +263,7 @@ func TestFileInputValidation_DisabledByDefault(t *testing.T) {
 				"required": []string{"image"},
 			},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("handler reached"), nil
 		},
 	)

--- a/server/list_ttl_test.go
+++ b/server/list_ttl_test.go
@@ -209,7 +209,7 @@ func newListTTLClient(t *testing.T, opts ...Option) *client.Client {
 
 	srv.RegisterTool(
 		core.ToolDef{Name: "echo", Description: "echo", InputSchema: map[string]any{"type": "object"}},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("ok"), nil
 		},
 	)
@@ -231,7 +231,7 @@ func newListTTLClient(t *testing.T, opts ...Option) *client.Client {
 	)
 	srv.RegisterPrompt(
 		core.PromptDef{Name: "hello", Description: "hello"},
-		func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResult, error) {
+		func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResponse, error) {
 			return core.PromptResult{}, nil
 		},
 	)

--- a/server/middleware_test.go
+++ b/server/middleware_test.go
@@ -32,7 +32,7 @@ func TestMiddleware_SeesAllRequests(t *testing.T) {
 		WithMiddleware(mw))
 	srv.RegisterTool(
 		core.ToolDef{Name: "echo", Description: "echo"},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("ok"), nil
 		},
 	)
@@ -102,7 +102,7 @@ func TestMiddleware_ShortCircuit(t *testing.T) {
 		WithMiddleware(blockingMW))
 	srv.RegisterTool(
 		core.ToolDef{Name: "echo", Description: "echo"},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			dispatched.Store(true)
 			return core.TextResult("should not reach"), nil
 		},
@@ -166,7 +166,7 @@ func TestMiddleware_ToolTimeoutPreserved(t *testing.T) {
 		WithMiddleware(mw))
 	srv.RegisterTool(
 		core.ToolDef{Name: "slow", Description: "slow"},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			select {
 			case <-time.After(200 * time.Millisecond):
 				return core.TextResult("too slow"), nil

--- a/server/mrtr_test.go
+++ b/server/mrtr_test.go
@@ -25,7 +25,7 @@ func TestMRTR_BasicElicitationRoundTrip(t *testing.T) {
 			Description: "Asks for user name then greets them",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			if !ctx.HasInputResponses() {
 				return ctx.RequestInput(core.InputRequests{
 					"user_name": core.InputRequest{
@@ -131,7 +131,7 @@ func TestMRTR_RequestStateSigned(t *testing.T) {
 			Description: "Confirms requestState validation",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			if ctx.RequestState() == "" {
 				return ctx.RequestInput(core.InputRequests{
 					"confirm": core.InputRequest{
@@ -208,7 +208,7 @@ func TestMRTR_TamperedRequestStateRejected(t *testing.T) {
 			Description: "",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("ok"), nil
 		},
 	)
@@ -255,7 +255,7 @@ func TestMRTR_MultiRoundAccumulatesAnswers(t *testing.T) {
 			Description: "Two-step elicitation",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			if ctx.InputResponse("step1") == nil {
 				return ctx.RequestInput(core.InputRequests{
 					"step1": core.InputRequest{

--- a/server/prompt_integration_test.go
+++ b/server/prompt_integration_test.go
@@ -18,7 +18,7 @@ func testPromptDispatcher() *Dispatcher {
 				{Name: "name", Description: "Name to greet", Required: true},
 			},
 		},
-		func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResult, error) {
+		func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResponse, error) {
 			name, _ := req.Arguments["name"].(string)
 			return core.PromptResult{
 				Description: "Greeting",
@@ -31,7 +31,7 @@ func testPromptDispatcher() *Dispatcher {
 	)
 	d.RegisterPrompt(
 		core.PromptDef{Name: "simple", Description: "No-args prompt"},
-		func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResult, error) {
+		func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResponse, error) {
 			return core.PromptResult{
 				Messages: []core.PromptMessage{{
 					Role:    "user",

--- a/server/prompt_schema_test.go
+++ b/server/prompt_schema_test.go
@@ -28,7 +28,7 @@ func TestPromptsListAdvertisesSchema(t *testing.T) {
 				},
 			},
 		},
-		func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResult, error) {
+		func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResponse, error) {
 			return core.PromptResult{}, nil
 		},
 	)
@@ -75,7 +75,7 @@ func TestPromptsGetPassesTypedArguments(t *testing.T) {
 				{Name: "verbose", Schema: map[string]any{"type": "boolean"}},
 			},
 		},
-		func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResult, error) {
+		func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResponse, error) {
 			captured = req.Arguments
 			return core.PromptResult{
 				Messages: []core.PromptMessage{{

--- a/server/registration.go
+++ b/server/registration.go
@@ -12,7 +12,7 @@ import core "github.com/panyam/mcpkit/core"
 //
 //	srv.Register(server.Tool{
 //	    ToolDef: core.ToolDef{Name: "echo", Description: "Echo input", InputSchema: schema},
-//	    Handler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+//	    Handler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 //	        return core.TextResult("echoed"), nil
 //	    },
 //	})

--- a/server/registration_test.go
+++ b/server/registration_test.go
@@ -22,7 +22,7 @@ func TestRegisterToolSingleStruct(t *testing.T) {
 			Description: "Greets the user",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		Handler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		Handler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("hello"), nil
 		},
 	})
@@ -69,7 +69,7 @@ func TestRegisterPromptSingleStruct(t *testing.T) {
 			Name:        "greeting",
 			Description: "A greeting prompt",
 		},
-		Handler: func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResult, error) {
+		Handler: func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResponse, error) {
 			return core.PromptResult{
 				Messages: []core.PromptMessage{{
 					Role:    "assistant",
@@ -93,7 +93,7 @@ func TestRegisterMixed(t *testing.T) {
 	srv.Register(
 		server.Tool{
 			ToolDef: core.ToolDef{Name: "t1", Description: "tool", InputSchema: map[string]any{"type": "object"}},
-			Handler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+			Handler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 				return core.TextResult("t1"), nil
 			},
 		},
@@ -105,7 +105,7 @@ func TestRegisterMixed(t *testing.T) {
 		},
 		server.Prompt{
 			PromptDef: core.PromptDef{Name: "p1", Description: "prompt"},
-			Handler: func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResult, error) {
+			Handler: func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResponse, error) {
 				return core.PromptResult{}, nil
 			},
 		},
@@ -132,14 +132,14 @@ func TestExistingTwoArgAPIStillWorks(t *testing.T) {
 	// Old API
 	srv.RegisterTool(
 		core.ToolDef{Name: "old-style", Description: "two-arg", InputSchema: map[string]any{"type": "object"}},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("old"), nil
 		},
 	)
 	// New API
 	srv.Register(server.Tool{
 		ToolDef: core.ToolDef{Name: "new-style", Description: "single-struct", InputSchema: map[string]any{"type": "object"}},
-		Handler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		Handler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("new"), nil
 		},
 	})

--- a/server/registry_overwrite_test.go
+++ b/server/registry_overwrite_test.go
@@ -22,7 +22,7 @@ import (
 func TestAddTool_OverwriteDoesNotDuplicateOrder(t *testing.T) {
 	d := testDynamicDispatcher()
 
-	handler := func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+	handler := func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 		return core.TextResult("v1"), nil
 	}
 	d.Reg.AddTool(core.ToolDef{Name: "dup", Description: "first"}, handler)
@@ -95,7 +95,7 @@ func TestAddResourceTemplate_OverwriteDoesNotDuplicateOrder(t *testing.T) {
 func TestAddPrompt_OverwriteDoesNotDuplicateOrder(t *testing.T) {
 	d := testDynamicDispatcher()
 
-	handler := func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResult, error) {
+	handler := func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResponse, error) {
 		return core.PromptResult{}, nil
 	}
 	d.Reg.AddPrompt(core.PromptDef{Name: "dup", Description: "first"}, handler)

--- a/server/resource_notify_test.go
+++ b/server/resource_notify_test.go
@@ -29,7 +29,7 @@ func TestNotifyResourceUpdatedFromHandler(t *testing.T) {
 	var handlerCalled bool
 	srv.RegisterTool(
 		core.ToolDef{Name: "mutate", InputSchema: map[string]any{"type": "object"}},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			handlerCalled = true
 			core.NotifyResourceUpdated(ctx, "test://res")
 			return core.TextResult("ok"), nil

--- a/server/roots_integration_test.go
+++ b/server/roots_integration_test.go
@@ -105,7 +105,7 @@ func newRootsTestServer(callbackCh chan []core.Root) *server.Server {
 	)
 	srv.RegisterTool(
 		core.ToolDef{Name: "noop", Description: "noop", InputSchema: map[string]any{"type": "object"}},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("ok"), nil
 		},
 	)

--- a/server/roots_test.go
+++ b/server/roots_test.go
@@ -112,7 +112,7 @@ func newRootsHarness(t *testing.T, clientRootsCap bool) *rootsHarness {
 	// A no-op tool so InitHandshake-style initialize requests succeed.
 	h.srv.RegisterTool(
 		core.ToolDef{Name: "noop", Description: "noop", InputSchema: map[string]any{"type": "object"}},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("ok"), nil
 		},
 	)

--- a/server/roots_timeout_test.go
+++ b/server/roots_timeout_test.go
@@ -39,7 +39,7 @@ func TestRoots_CustomFetchTimeout(t *testing.T) {
 	)
 	srv.RegisterTool(
 		core.ToolDef{Name: "noop", InputSchema: map[string]any{"type": "object"}},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("ok"), nil
 		},
 	)

--- a/server/sampling_integration_test.go
+++ b/server/sampling_integration_test.go
@@ -138,7 +138,7 @@ func newSamplingTestServer(toolTimeout *time.Duration) *server.Server {
 			Description: "Calls sampling/createMessage and returns the result",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			result, err := core.Sample(ctx, core.CreateMessageRequest{
 				Messages:  []core.SamplingMessage{{Role: "user", Content: core.Content{Type: "text", Text: "Say hello"}}},
 				MaxTokens: 100,
@@ -157,7 +157,7 @@ func newSamplingTestServer(toolTimeout *time.Duration) *server.Server {
 			Description: "Calls Sample() with a short deadline to test timeout",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			tctx, cancel := context.WithTimeout(ctx, 200*time.Millisecond)
 			defer cancel()
 			result, err := core.Sample(tctx, core.CreateMessageRequest{

--- a/server/schema_validation_test.go
+++ b/server/schema_validation_test.go
@@ -82,12 +82,12 @@ func getPrompt(t *testing.T, srv *server.Server, name string, args map[string]an
 
 // okHandler is a trivial tool handler that returns "ok". Used whenever the
 // test only cares about whether the call reached the handler.
-func okHandler(_ core.ToolContext, _ core.ToolRequest) (core.ToolResult, error) {
+func okHandler(_ core.ToolContext, _ core.ToolRequest) (core.ToolResponse, error) {
 	return core.TextResult("ok"), nil
 }
 
 // okPromptHandler is the prompt-side analogue of okHandler.
-func okPromptHandler(_ core.PromptContext, _ core.PromptRequest) (core.PromptResult, error) {
+func okPromptHandler(_ core.PromptContext, _ core.PromptRequest) (core.PromptResponse, error) {
 	return core.PromptResult{Description: "ok"}, nil
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -32,7 +32,7 @@ func TestServerDispatch(t *testing.T) {
 	srv := NewServer(core.ServerInfo{Name: "test", Version: "0.1.0"})
 	srv.RegisterTool(
 		core.ToolDef{Name: "greet", Description: "say hi"},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("hi"), nil
 		},
 	)
@@ -65,7 +65,7 @@ func TestServerToolTimeout(t *testing.T) {
 	)
 	srv.RegisterTool(
 		core.ToolDef{Name: "slow", Description: "blocks"},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			select {
 			case <-ctx.Done():
 				return core.ErrorResult("timeout: " + ctx.Err().Error()), nil

--- a/server/session_timeout_test.go
+++ b/server/session_timeout_test.go
@@ -20,7 +20,7 @@ func testStreamableServerWithTimeout(timeout time.Duration, opts ...TransportOpt
 		core.ToolDef{Name: "echo", Description: "Echoes input", InputSchema: map[string]any{
 			"type": "object", "properties": map[string]any{"message": map[string]any{"type": "string"}},
 		}},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			var p struct{ Message string `json:"message"` }
 			req.Bind(&p)
 			return core.TextResult("echo: " + p.Message), nil
@@ -96,7 +96,7 @@ func TestSessionTimeoutPausesDuringActiveRequest(t *testing.T) {
 	var called atomic.Bool
 	srv.RegisterTool(
 		core.ToolDef{Name: "slow", Description: "Takes a while"},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			called.Store(true)
 			time.Sleep(150 * time.Millisecond)
 			return core.TextResult("done"), nil

--- a/server/sse_retry_test.go
+++ b/server/sse_retry_test.go
@@ -65,7 +65,7 @@ func TestSSE_EmitRetryHintReachesClient(t *testing.T) {
 			Description: "Emits a retry hint, then returns",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			if err := core.EmitSSERetry(ctx, 30*time.Second); err != nil {
 				return core.ErrorResult("emit: " + err.Error()), nil
 			}
@@ -131,7 +131,7 @@ func TestSSE_EmitRetryHintNoOpOnNonSSEPath(t *testing.T) {
 	var called bool
 	d.RegisterTool(
 		core.ToolDef{Name: "t", InputSchema: map[string]any{"type": "object"}},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			called = true
 			if err := core.EmitSSERetry(ctx, 5*time.Second); err != nil {
 				t.Errorf("EmitSSERetry on no-sse-hint ctx: %v", err)

--- a/server/stateless/dispatch_test.go
+++ b/server/stateless/dispatch_test.go
@@ -204,7 +204,7 @@ func TestDispatch_ToolsCallMissingCapReturns32003(t *testing.T) {
 	// required-cap payload shape. Locked here so future refactors of
 	// translateToolError surface in this test, not the conformance audit.
 	required := core.ClientCapabilities{Sampling: &struct{}{}}
-	h := func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+	h := func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 		return core.ToolResult{}, &core.MissingCapabilityError{
 			Required: required,
 			Message:  "this tool requires sampling",

--- a/server/stateless/loglevel_gate_test.go
+++ b/server/stateless/loglevel_gate_test.go
@@ -78,7 +78,7 @@ func TestRequestMeta_LogLevelThreadingExposedToHandlers(t *testing.T) {
 				tool: func(name string) (core.ToolDef, core.ToolHandler, bool) {
 					if name == "spy_log_level" {
 						return core.ToolDef{Name: name},
-							func(ctx core.ToolContext, _ core.ToolRequest) (core.ToolResult, error) {
+							func(ctx core.ToolContext, _ core.ToolRequest) (core.ToolResponse, error) {
 								captured = RequestMetaFromContext(ctx)
 								return core.TextResult("ok"), nil
 							}, true

--- a/server/stdio_transport_test.go
+++ b/server/stdio_transport_test.go
@@ -286,7 +286,7 @@ func TestStdioNotificationDelivery(t *testing.T) {
 	// Register a tool that emits a log notification.
 	srv.RegisterTool(
 		core.ToolDef{Name: "log-test", Description: "emits a log", InputSchema: json.RawMessage(`{"type":"object"}`)},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			core.EmitLog(ctx, core.LogInfo, "test-logger", "hello from stdio")
 			return core.ToolResult{Content: []core.Content{{Type: "text", Text: "ok"}}}, nil
 		},
@@ -388,7 +388,7 @@ func newTestServer() *Server {
 			Description: "echoes input",
 			InputSchema: json.RawMessage(`{"type":"object","properties":{"message":{"type":"string"}}}`),
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			var args struct{ Message string }
 			json.Unmarshal(req.Arguments, &args)
 			return core.ToolResult{

--- a/server/streamable_retry_test.go
+++ b/server/streamable_retry_test.go
@@ -35,7 +35,7 @@ func TestStreamableHTTP_EmitRetryHintReachesGetSSEStream(t *testing.T) {
 			Description: "Emits a retry hint, then returns",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			if err := core.EmitSSERetry(ctx, 30*time.Second); err != nil {
 				return core.ErrorResult("emit: " + err.Error()), nil
 			}
@@ -138,7 +138,7 @@ func TestStreamableHTTP_EmitRetryHintNoOpWithoutGetStream(t *testing.T) {
 			Description: "Emits a retry hint with no GET stream",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			handlerCalled = true
 			if err := core.EmitSSERetry(ctx, 5*time.Second); err != nil {
 				t.Errorf("EmitSSERetry error: %v (expected nil for no-op)", err)

--- a/server/streamable_stateless_test.go
+++ b/server/streamable_stateless_test.go
@@ -23,7 +23,7 @@ func newStatelessTestServer(t *testing.T, mode stateless.Mode) (*Server, string,
 	// Register a trivial tool so tools/list returns something.
 	if err := s.Registry().AddTool(
 		core.ToolDef{Name: "echo", Description: "echoes back"},
-		func(_ core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(_ core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.ToolResult{Content: []core.Content{{Type: "text", Text: string(req.Arguments)}}}, nil
 		},
 	); err != nil {
@@ -33,7 +33,7 @@ func newStatelessTestServer(t *testing.T, mode stateless.Mode) (*Server, string,
 	// translateToolError end-to-end.
 	if err := s.Registry().AddTool(
 		core.ToolDef{Name: "test_missing_capability"},
-		func(_ core.ToolContext, _ core.ToolRequest) (core.ToolResult, error) {
+		func(_ core.ToolContext, _ core.ToolRequest) (core.ToolResponse, error) {
 			return core.ToolResult{}, &core.MissingCapabilityError{
 				Required: core.ClientCapabilities{Sampling: &struct{}{}},
 				Message:  "this tool requires sampling",

--- a/server/streamable_transport_test.go
+++ b/server/streamable_transport_test.go
@@ -29,7 +29,7 @@ func testStreamableServer(opts ...TransportOption) *httptest.Server {
 				},
 			},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			var args struct {
 				Message string `json:"message"`
 			}
@@ -378,7 +378,7 @@ func TestStreamableAuthRequired(t *testing.T) {
 	)
 	srv.RegisterTool(
 		core.ToolDef{Name: "echo", Description: "echo"},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("ok"), nil
 		},
 	)
@@ -507,13 +507,13 @@ func testStreamableServerWithLogging(opts ...TransportOption) *httptest.Server {
 	srv := NewServer(core.ServerInfo{Name: "test-streamable-sse", Version: "0.1.0"})
 	srv.RegisterTool(
 		core.ToolDef{Name: "echo", Description: "Echoes input", InputSchema: map[string]any{"type": "object"}},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("ok"), nil
 		},
 	)
 	srv.RegisterTool(
 		core.ToolDef{Name: "log_tool", Description: "Emits logs", InputSchema: map[string]any{"type": "object"}},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			core.EmitLog(ctx, core.LogInfo, "test", "step one")
 			core.EmitLog(ctx, core.LogInfo, "test", "step two")
 			return core.TextResult("done"), nil

--- a/server/streaming_test.go
+++ b/server/streaming_test.go
@@ -27,7 +27,7 @@ func TestStreamingToolResultsOverSSE(t *testing.T) {
 			Description: "Emits 3 content chunks then returns final result",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		Handler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		Handler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			for i := 1; i <= 3; i++ {
 				core.EmitContent(ctx, req.RequestID, core.Content{
 					Type: "text",
@@ -86,7 +86,7 @@ func TestStreamingToolErrorMidStream(t *testing.T) {
 			Description: "Emits chunks then fails",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		Handler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		Handler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			core.EmitContent(ctx, req.RequestID, core.Content{Type: "text", Text: "partial-1"})
 			core.EmitContent(ctx, req.RequestID, core.Content{Type: "text", Text: "partial-2"})
 			return core.ErrorResult("failed mid-stream"), nil
@@ -127,7 +127,7 @@ func TestStreamingToolNoHandler(t *testing.T) {
 			Description: "Emits chunks but client ignores them",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		Handler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		Handler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			core.EmitContent(ctx, req.RequestID, core.Content{Type: "text", Text: "ignored"})
 			return core.TextResult("final only"), nil
 		},
@@ -160,7 +160,7 @@ func TestStreamingToolCustomMethod(t *testing.T) {
 			Description: "Uses custom chunk method",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		Handler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		Handler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			core.EmitContent(ctx, req.RequestID, core.Content{Type: "text", Text: "custom chunk"})
 			return core.TextResult("done"), nil
 		},

--- a/server/task_callbacks_test.go
+++ b/server/task_callbacks_test.go
@@ -27,7 +27,7 @@ func TestTaskCallbacksGetTask(t *testing.T) {
 			InputSchema: map[string]any{"type": "object"},
 			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
 		},
-		Handler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		Handler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			select {
 			case <-unblock:
 			case <-ctx.Done():
@@ -89,7 +89,7 @@ func TestTaskCallbacksGetResult(t *testing.T) {
 			InputSchema: map[string]any{"type": "object"},
 			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
 		},
-		Handler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		Handler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("store-result"), nil
 		},
 		TaskCallbacks: &TaskCallbacks{
@@ -154,7 +154,7 @@ func TestTaskCallbacksFallthrough(t *testing.T) {
 			InputSchema: map[string]any{"type": "object"},
 			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
 		},
-		Handler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		Handler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("real-result"), nil
 		},
 		TaskCallbacks: &TaskCallbacks{

--- a/server/tasks_v1_test.go
+++ b/server/tasks_v1_test.go
@@ -43,7 +43,7 @@ func newTaskServer(t *testing.T) (*Server, chan struct{}) {
 			}},
 			Execution: &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			// Wait for unblock signal OR context cancellation (Phase 5).
 			select {
 			case <-unblock:
@@ -66,7 +66,7 @@ func newTaskServer(t *testing.T) (*Server, chan struct{}) {
 			InputSchema: map[string]any{"type": "object"},
 			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.ToolResult{}, fmt.Errorf("boom")
 		},
 	)
@@ -79,7 +79,7 @@ func newTaskServer(t *testing.T) (*Server, chan struct{}) {
 			InputSchema: map[string]any{"type": "object"},
 			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportRequired},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("ok"), nil
 		},
 	)
@@ -92,7 +92,7 @@ func newTaskServer(t *testing.T) (*Server, chan struct{}) {
 			InputSchema: map[string]any{"type": "object"},
 			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportForbidden},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("sync-only"), nil
 		},
 	)
@@ -673,7 +673,7 @@ func TestTaskPanicRecovery(t *testing.T) {
 			InputSchema: map[string]any{"type": "object"},
 			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			panic("test panic")
 		},
 	)
@@ -808,7 +808,7 @@ func TestGetTaskContextNilForSync(t *testing.T) {
 			InputSchema: map[string]any{"type": "object"},
 			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			tc := GetTaskContext(ctx)
 			gotTC = tc != nil
 			return core.TextResult("ok"), nil
@@ -840,7 +840,7 @@ func TestGetTaskContextAvailableForAsync(t *testing.T) {
 			InputSchema: map[string]any{"type": "object"},
 			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			tc := GetTaskContext(ctx)
 			if tc != nil {
 				gotTaskID <- tc.TaskID()
@@ -890,7 +890,7 @@ func TestTaskInputRequiredTransition(t *testing.T) {
 			InputSchema: map[string]any{"type": "object"},
 			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			tc := GetTaskContext(ctx)
 			if tc == nil {
 				return core.TextResult("no task context"), nil
@@ -1008,7 +1008,7 @@ func TestQueueCleanupOnCancel(t *testing.T) {
 			InputSchema: map[string]any{"type": "object"},
 			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			select {} // block forever
 		},
 	)
@@ -1063,7 +1063,7 @@ func TestTaskElicitE2E(t *testing.T) {
 			},
 			Execution: &core.ToolExecution{TaskSupport: core.TaskSupportRequired},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			tc := GetTaskContext(ctx)
 			if tc == nil {
 				return core.ToolResult{}, fmt.Errorf("expected TaskContext")
@@ -1145,7 +1145,7 @@ func TestTaskSampleE2E(t *testing.T) {
 			},
 			Execution: &core.ToolExecution{TaskSupport: core.TaskSupportRequired},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			tc := GetTaskContext(ctx)
 			if tc == nil {
 				return core.ToolResult{}, fmt.Errorf("expected TaskContext")
@@ -1270,7 +1270,7 @@ func TestTaskProgressFromBackgroundNoPanic(t *testing.T) {
 			InputSchema: map[string]any{"type": "object"},
 			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			// Emit progress — this should not panic even without GET SSE.
 			ctx.EmitProgress("token", 1, 2, "halfway")
 			ctx.EmitProgress("token", 2, 2, "done")
@@ -1319,7 +1319,7 @@ func TestTaskCancelStopsGoroutine(t *testing.T) {
 			InputSchema: map[string]any{"type": "object"},
 			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			// Wait for cancellation or timeout.
 			select {
 			case <-ctx.Done():
@@ -1366,7 +1366,7 @@ func TestTaskStatusNotificationOnComplete(t *testing.T) {
 			InputSchema: map[string]any{"type": "object"},
 			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("done"), nil
 		},
 	)
@@ -1416,7 +1416,7 @@ func TestTaskStatusNotificationOnCancel(t *testing.T) {
 			InputSchema: map[string]any{"type": "object"},
 			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			<-ctx.Done()
 			return core.TextResult("cancelled"), nil
 		},
@@ -1476,7 +1476,7 @@ func TestTaskProgressTokenPreserved(t *testing.T) {
 			InputSchema: map[string]any{"type": "object"},
 			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			tc := GetTaskContext(ctx)
 			gotToken <- tc.ProgressToken()
 			return core.TextResult("ok"), nil
@@ -1518,7 +1518,7 @@ func TestTaskDoubleCompletionRejected(t *testing.T) {
 			InputSchema: map[string]any{"type": "object"},
 			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("done"), nil
 		},
 	)
@@ -1625,7 +1625,7 @@ func TestToolCallAsTaskWithProgressToken(t *testing.T) {
 			InputSchema: map[string]any{"type": "object"},
 			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			tc := GetTaskContext(ctx)
 			gotToken <- tc.ProgressToken()
 			return core.TextResult("ok"), nil

--- a/server/timeout_test.go
+++ b/server/timeout_test.go
@@ -27,7 +27,7 @@ func TestPerToolTimeout(t *testing.T) {
 			InputSchema: map[string]any{"type": "object"},
 			Timeout:     50 * time.Millisecond,
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			select {
 			case <-ctx.Done():
 				return core.ErrorResult("timed out"), ctx.Err()
@@ -44,7 +44,7 @@ func TestPerToolTimeout(t *testing.T) {
 			Description: "Returns immediately",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("fast result"), nil
 		},
 	)
@@ -111,7 +111,7 @@ func TestPerPromptTimeout(t *testing.T) {
 			Description: "Takes too long",
 			Timeout:     50 * time.Millisecond,
 		},
-		func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResult, error) {
+		func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResponse, error) {
 			select {
 			case <-ctx.Done():
 				return core.PromptResult{}, ctx.Err()
@@ -147,7 +147,7 @@ func TestServerWideTimeoutIsFallback(t *testing.T) {
 			InputSchema: map[string]any{"type": "object"},
 			// No Timeout set — uses server-wide
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			select {
 			case <-ctx.Done():
 				return core.ErrorResult("timed out"), ctx.Err()

--- a/server/transport_test.go
+++ b/server/transport_test.go
@@ -51,7 +51,7 @@ func testMCPServer(opts ...TransportOption) (*httptest.Server, *Server) {
 				},
 			},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			var args struct {
 				Message string `json:"message"`
 			}
@@ -303,7 +303,7 @@ func TestSSEAuthRequired(t *testing.T) {
 	)
 	srv.RegisterTool(
 		core.ToolDef{Name: "echo", Description: "echo"},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("ok"), nil
 		},
 	)
@@ -495,7 +495,7 @@ func TestSSELoggingNotification(t *testing.T) {
 			Description: "Emits a log notification then returns a result",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			core.EmitLog(ctx, core.LogInfo, "test-logger", "hello from tool")
 			return core.TextResult("done"), nil
 		},
@@ -637,7 +637,7 @@ func TestSSELoggingFilteredByLevel(t *testing.T) {
 			Description: "Emits a debug log",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			core.EmitLog(ctx, core.LogDebug, "test", "debug msg")
 			return core.TextResult("ok"), nil
 		},
@@ -712,7 +712,7 @@ func TestSSEProgressNotification(t *testing.T) {
 			Description: "Emits progress notifications then returns a result",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			core.EmitProgress(ctx, req.ProgressToken, 0, 100, "start")
 			core.EmitProgress(ctx, req.ProgressToken, 50, 100, "mid")
 			core.EmitProgress(ctx, req.ProgressToken, 100, 100, "done")

--- a/server/typed_tool_test.go
+++ b/server/typed_tool_test.go
@@ -132,8 +132,8 @@ func TestTypedTool_OutputSchemaGeneration(t *testing.T) {
 	assert.Nil(t, stringTool.OutputSchema, "string Out should not generate OutputSchema")
 
 	// core.ToolResult Out → no OutputSchema
-	resultTool := core.TypedTool[greetInput, core.ToolResult]("c", "desc",
-		func(ctx core.ToolContext, input greetInput) (core.ToolResult, error) {
+	resultTool := core.TypedTool[greetInput, core.ToolResponse]("c", "desc",
+		func(ctx core.ToolContext, input greetInput) (core.ToolResponse, error) {
 			return core.TextResult("raw"), nil
 		},
 	)
@@ -259,8 +259,8 @@ func TestTypedTool_StructuredOutput(t *testing.T) {
 // Out type passes the handler's result through without modification.
 func TestTypedTool_ToolResultPassthrough(t *testing.T) {
 	srv := server.NewServer(core.ServerInfo{Name: "test", Version: "1.0"})
-	srv.Register(core.TypedTool[greetInput, core.ToolResult]("multi", "Multi-content",
-		func(ctx core.ToolContext, input greetInput) (core.ToolResult, error) {
+	srv.Register(core.TypedTool[greetInput, core.ToolResponse]("multi", "Multi-content",
+		func(ctx core.ToolContext, input greetInput) (core.ToolResponse, error) {
 			return core.ToolResult{
 				Content: []core.Content{
 					{Type: "text", Text: "line 1"},

--- a/tests/e2e/apps/app_helpers_test.go
+++ b/tests/e2e/apps/app_helpers_test.go
@@ -25,7 +25,7 @@ func TestRegisterAppToolE2E(t *testing.T) {
 		Description: "Build a slide deck",
 		InputSchema: map[string]any{"type": "object"},
 		ResourceURI: "ui://decks/view",
-		ToolHandler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		ToolHandler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("deck built"), nil
 		},
 		ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
@@ -109,7 +109,7 @@ func TestNotifyResourcesChangedE2E(t *testing.T) {
 			Description: "Mutates state and notifies",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			core.NotifyResourcesChanged(ctx)
 			return core.TextResult("mutated"), nil
 		},

--- a/tests/e2e/apps/extension_test.go
+++ b/tests/e2e/apps/extension_test.go
@@ -33,7 +33,7 @@ func TestUIExtensionNegotiationE2E(t *testing.T) {
 			Description: "Reports whether client supports UI",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			mu.Lock()
 			uiSupported = core.ClientSupportsUI(ctx)
 			mu.Unlock()

--- a/tests/e2e/apps/meta_test.go
+++ b/tests/e2e/apps/meta_test.go
@@ -40,7 +40,7 @@ func newAppTestServer() *server.Server {
 				},
 			},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			var p struct{ Title string `json:"title"` }
 			req.Bind(&p)
 			return core.TextResult(fmt.Sprintf("built: %s", p.Title)), nil
@@ -54,7 +54,7 @@ func newAppTestServer() *server.Server {
 			Description: "Echo input",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("echo"), nil
 		},
 	)

--- a/tests/e2e/apps/server_registry_test.go
+++ b/tests/e2e/apps/server_registry_test.go
@@ -25,7 +25,7 @@ func newSimpleServer(t *testing.T, tools map[string]string) *client.Client {
 		n, d := name, desc
 		srv.RegisterTool(
 			core.ToolDef{Name: n, Description: d, InputSchema: map[string]any{"type": "object"}},
-			func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+			func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 				return core.TextResult(n + ":result"), nil
 			},
 		)

--- a/tests/e2e/apps/testenv_test.go
+++ b/tests/e2e/apps/testenv_test.go
@@ -46,7 +46,7 @@ func newConformanceServer() *server.Server {
 				},
 			},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("Dashboard displayed"), nil
 		},
 	)
@@ -66,7 +66,7 @@ func newConformanceServer() *server.Server {
 				},
 			},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			var args struct{ Page string `json:"page"` }
 			req.Bind(&args)
 			return core.TextResult("Navigated to " + args.Page), nil
@@ -86,7 +86,7 @@ func newConformanceServer() *server.Server {
 				},
 			},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult(`Dashboard data: {"widgets": 5}`), nil
 		},
 	)
@@ -104,7 +104,7 @@ func newConformanceServer() *server.Server {
 				},
 			},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			core.NotifyResourcesChanged(ctx)
 			return core.TextResult("Dashboard mutated"), nil
 		},
@@ -117,7 +117,7 @@ func newConformanceServer() *server.Server {
 			Description: "Tool without UI metadata",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			return core.TextResult("plain result"), nil
 		},
 	)

--- a/tests/e2e/detach_test.go
+++ b/tests/e2e/detach_test.go
@@ -39,7 +39,7 @@ func TestE2E_DetachFromClient_SurvivesPerToolTimeout(t *testing.T) {
 			}},
 			Timeout: 100 * time.Millisecond, // short timeout
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			var args struct {
 				Tag string `json:"tag"`
 			}
@@ -94,7 +94,7 @@ func TestE2E_DetachFromClient_NonDetachedToolCancelledByTimeout(t *testing.T) {
 			InputSchema: map[string]any{"type": "object"},
 			Timeout:     100 * time.Millisecond,
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			// NO DetachFromClient — tool uses the request context.
 			for i := 0; i < 6; i++ {
 				select {
@@ -142,7 +142,7 @@ func TestE2E_DetachFromClient_WithRetryHint(t *testing.T) {
 			InputSchema: map[string]any{"type": "object"},
 			Timeout:     50 * time.Millisecond,
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			// Emit retry hint while still attached.
 			_ = core.EmitSSERetry(ctx, 30*time.Second)
 

--- a/tests/e2e/mcpserver_test.go
+++ b/tests/e2e/mcpserver_test.go
@@ -70,7 +70,7 @@ func (e *TestEnv) buildMCPServerWithOpts(t *testing.T, extraOpts ...server.Optio
 			Description: "Echoes input and reports authenticated claims. No scope required.",
 			InputSchema: json.RawMessage(`{"type":"object","properties":{"msg":{"type":"string"}}}`),
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			claims := core.AuthClaims(ctx)
 			var args map[string]any
 			json.Unmarshal(req.Arguments, &args)
@@ -93,7 +93,7 @@ func (e *TestEnv) buildMCPServerWithOpts(t *testing.T, extraOpts ...server.Optio
 			Description: "Requires tools:call scope. Returns 'ok' on success.",
 			InputSchema: json.RawMessage(`{"type":"object"}`),
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			if err := auth.RequireScope(ctx, "tools:call"); err != nil {
 				return core.TextResult("error: " + err.Error()), nil
 			}
@@ -108,7 +108,7 @@ func (e *TestEnv) buildMCPServerWithOpts(t *testing.T, extraOpts ...server.Optio
 			Description: "Requires admin:write scope. Returns 'admin ok' on success.",
 			InputSchema: json.RawMessage(`{"type":"object"}`),
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			if err := auth.RequireScope(ctx, "admin:write"); err != nil {
 				return core.TextResult("error: " + err.Error()), nil
 			}

--- a/tests/e2e/schema_validation_test.go
+++ b/tests/e2e/schema_validation_test.go
@@ -37,7 +37,7 @@ func TestE2E_SchemaValidationErrorOverWire(t *testing.T) {
 				},
 			},
 		},
-	}, func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+	}, func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 		return core.TextResult("ok"), nil
 	})
 

--- a/tests/e2e/streaming_test.go
+++ b/tests/e2e/streaming_test.go
@@ -34,7 +34,7 @@ func TestE2E_StreamingToolResults(t *testing.T) {
 			Description: "Simulates a long analysis emitting incremental results",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		Handler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		Handler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			steps := []string{"Fetching data...", "Processing rows...", "Generating report..."}
 			for _, step := range steps {
 				core.EmitContent(ctx, req.RequestID, core.Content{
@@ -100,7 +100,7 @@ func TestE2E_StreamingWithoutHandler(t *testing.T) {
 			Description: "Emits chunks but client has no handler",
 			InputSchema: map[string]any{"type": "object"},
 		},
-		Handler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		Handler: func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			core.EmitContent(ctx, req.RequestID, core.Content{Type: "text", Text: "ignored chunk"})
 			return core.TextResult("final only"), nil
 		},

--- a/tests/keycloak/testutil_test.go
+++ b/tests/keycloak/testutil_test.go
@@ -147,7 +147,7 @@ func NewMCPTestEnv(t *testing.T, extraOpts ...server.Option) *MCPTestEnv {
 			Description: "Echoes input and reports claims. No scope required.",
 			InputSchema: json.RawMessage(`{"type":"object","properties":{"msg":{"type":"string"}}}`),
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			claims := core.AuthClaims(ctx)
 			var args map[string]any
 			json.Unmarshal(req.Arguments, &args)
@@ -168,7 +168,7 @@ func NewMCPTestEnv(t *testing.T, extraOpts ...server.Option) *MCPTestEnv {
 			Description: "Requires tools-call scope.",
 			InputSchema: json.RawMessage(`{"type":"object"}`),
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			if err := auth.RequireScope(ctx, scopeToolsCall); err != nil {
 				return core.TextResult("error: " + err.Error()), nil
 			}

--- a/testutil/testclient_test.go
+++ b/testutil/testclient_test.go
@@ -25,7 +25,7 @@ func newTestServer(t *testing.T) *server.Server {
 				"properties": map[string]any{"name": map[string]any{"type": "string"}},
 			},
 		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error) {
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
 			var p struct {
 				Name string `json:"name"`
 			}


### PR DESCRIPTION
## What changes

`ToolHandler` and `PromptHandler` now return sealed-interface response types instead of concrete result structs. `core.ToolResult` sheds three in-process sentinel fields (`IsInputRequired`, `InputRequests`, `GoAsync`) and becomes a pure wire shape. New response variants now plug in by adding a method on the sealed interface, not a new flag.

Closes issue 486. Sequenced BEFORE 452 — its `PromptResult InputRequiredResult` support becomes a one-line `func (InputRequiredResult) promptResponse() {}` follow-up.

Breaking — every in-tree `ToolHandler` / `PromptHandler` signature flips:

```go
// Before
func myTool(ctx core.ToolContext, req core.ToolRequest) (core.ToolResult, error)
// After
func myTool(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error)
```

Bodies usually don't change — `core.ToolResult{...}` / `core.PromptResult{...}` literals satisfy the sealed interface. Only two body-level patterns need a touch-up; see `docs/HANDLER_RETURNS_MIGRATION.md`.

## Reviewer's guide

Read in this order:

1. [core/tool.go](https://github.com/panyam/mcpkit/pull/487/files#diff-0c4cfc445e145347f6ac8b4edaa2ca030b6512a3a99e6379f5122df3ca014d22) — start here. New `ToolResponse` sealed interface, new `GoAsyncResult` variant, three sentinel fields removed from `ToolResult`.
2. [core/prompt.go](https://github.com/panyam/mcpkit/pull/487/files#diff-9cf2ccebf5ec053fceb3ee1248d0d09c1f3be1891c1abf9ea833323e7966c866) — same shape applied to `PromptResponse` / `PromptResult`.
3. [core/mrtr.go](https://github.com/panyam/mcpkit/pull/487/files#diff-e35e8e196366177f5fbc1038f83e79bb201533c23472c8df64ad47e213d9becf) + [core/task_v2.go](https://github.com/panyam/mcpkit/pull/487/files#diff-3538d827f8d2f0385530a0112d8defa64f901a0827609fe5f730db43ff24049a) — one-line `toolResponse()` markers on `InputRequiredResult` and `CreateTaskResult`.
4. [core/handler_context.go](https://github.com/panyam/mcpkit/pull/487/files#diff-b3a3b2b8bf11bb86d8a8e1e60213e581011ae6a264a9923034d1db6a1d6d39e2) — `ctx.RequestInput` now returns typed `(InputRequiredResult, error)` directly.
5. [core/typed_tool.go](https://github.com/panyam/mcpkit/pull/487/files#diff-2a38d67d5979f975464d4ad38d21b6a6a1e9d22f1e4e78a2ccae5651b8f77f32) — `TypedTool[X, core.ToolResponse]` is a first-class shape alongside the existing `core.ToolResult` and `string` Out types.
6. [server/dispatch.go](https://github.com/panyam/mcpkit/pull/487/files#diff-7640bcbef23148a16e477c63c7092f0ba89780f5278a9d6ba6ed513d62f68a92) — type-switch on the response variant. Only `InputRequiredResult` still gets a reshape (fresh requestState mint); everything else flows through.
7. [ext/tasks/tasks.go](https://github.com/panyam/mcpkit/pull/487/files#diff-6b15314e7b637ac95e29f77601d89c4731b2aa4943266a4013345595095df47b) — middleware switch now uses `core.GoAsyncResult` for the spawn trigger, with a typed `core.ToolResult` assertion at the goroutine join.
8. [server/dispatch_test.go](https://github.com/panyam/mcpkit/pull/487/files#diff-6d494ca6d994aaa7ac3d1fa3e8dc200297e6c6e1d639176a92968198b8bfcabe) — new `TestDispatchToolsCall_HandlerReturnsTypedVariants` is the red-before-green for the dispatch flip.
9. [core/response_types_test.go](https://github.com/panyam/mcpkit/pull/487/files#diff-7411f608458478539a8454d1ddfcd71e1eeaa1d8890a16946b038d68574989f2) — interface-compliance + zero-value + `RequestInput` round-trip assertions.
10. [docs/HANDLER_RETURNS_MIGRATION.md](https://github.com/panyam/mcpkit/pull/487/files#diff-b4a35c3683d4bf32ef5b7a63ca842f2dd4cbcf1bb6c399ae93a67de21162d3ce) — migration recipe for downstream consumers.

Skim or skip: the ~80 mechanical handler-signature flips across `examples/`, `tests/e2e/`, `cmd/testserver/`, every `*_test.go`. They're 1–10 line type changes.

## Diff groups

- Production: `core/tool.go`, `core/prompt.go`, `core/mrtr.go`, `core/task_v2.go`, `core/handler_context.go`, `core/typed_tool.go`, `server/dispatch.go`, `server/exec.go`, `server/registration.go`, `ext/tasks/tasks.go`, `ext/ui/extension.go`, `ext/auth/scopes.go`, `core/detach.go`, `core/resource_notify.go`, `core/slog_handler.go`, `core/streaming.go`
- Tests: new + flipped — `core/response_types_test.go`, `server/dispatch_test.go`, plus every `*_test.go` whose handlers now return `core.ToolResponse`
- Mechanical: all `examples/` `main.go`, `cmd/testserver/conformance_*.go`, `tests/e2e/`, `tests/keycloak/`, `testutil/`

## Decision log

- **`GoAsyncResult` lives in `core/`, not `ext/tasks/`.** A type defined outside `core/` can't implement the sealed `toolResponse()` method. Per-package SEP-2663 placement was considered but `core/` already owns sibling SEP-2663 wire types (`CreateTaskResult`, `TaskInfoV2`) so the new variant is consistent.
- **`InputRequiredResult` implements `toolResponse()` only.** `promptResponse()` is deliberately deferred to 452 / SEP-2322-on-prompts; the type is wire-method-agnostic, so adding the second marker later is a one-line change.
- **`TypedTool` gained `Out=core.ToolResponse` rather than auto-flipping all existing `Out=core.ToolResult` call sites.** Both work side-by-side: `Out=core.ToolResult` for pure sync tools, `Out=core.ToolResponse` for MRTR / SEP-2663 handlers that need polymorphic returns.
- **Dispatch only reshapes `InputRequiredResult`.** `CreateTaskResult` and `GoAsyncResult` flow through to the tasks middleware. If no tasks middleware is installed and a handler emits `GoAsyncResult` anyway, it marshals as `{}` — a programmer error to be caught at registration time, not silently absorbed in dispatch.

## Risk / blast radius

- Affects every downstream consumer with a registered `ToolHandler` or `PromptHandler`. By design — this is a breaking signature change. Pre-customer, low.
- Sub-modules `ext/auth/`, `ext/tasks/`, `ext/ui/`, `experimental/ext/protogen/` consume `core/` via the workspace replace; `make tidy-all` covers them in-tree.
- Pressure-test: the type-switch `default:` branch in `server/dispatch.go` — make sure an unknown variant returns a sensible error rather than nil-panicking.

## Test results

- `make test` — all root packages green
- `make test-auth` — green
- `make test-ui` — green
- `make test-e2e` — green
- `cd ext/tasks && go test ./...` — green
- `cd experimental/ext/protogen && go test ./...` — green
- `make testconf` — 40/40 baseline
- `make testconf-tasks` — 27/27
- `make testconf-tasks-v2` — 18/18
- `make testconf-mrtr` (legacy wire, `MCP_WIRE_MODES=legacy`) — 1/1
- `make testconf-file-inputs` — 1/1
- `make testconf-stateless` — 25/1 (matches the documented "Stateless 25/26" baseline)

The fork's stateless-wire MRTR scenarios fail on this branch the same way they fail on main — `server/stateless_backend.go`'s `callToolForStateless` does not decode `inputResponses` / `requestState`. Pre-existing gap, out of scope. Filed for follow-up.

## Out of scope

- Wiring `InputRequiredResult.promptResponse()` for SEP-2322 prompt support → tracked as issue 452.
- Stateless-wire MRTR (`callToolForStateless` round-2 decoding) → pre-existing; follow-up needed.
- Bumping example sub-modules to tagged `core` releases → workspace `replace` keeps everything in lockstep in-tree.
