### PR TITLE
SEP-2322 input-required-result protocol: server + client (closes #452)

### DIFF
--- a/cmd/testclient/main.go
+++ b/cmd/testclient/main.go
@@ -37,6 +37,23 @@ func main() {
 
 	log.Printf("scenario=%s server=%s", scenario, serverURL)
 
+	// SEP-2322 client scenarios — the upstream fixtures are bare-HTTP
+	// JSON-RPC endpoints (no initialize handshake, no server/discover),
+	// so mcpkit's connected client doesn't apply. Drive them via raw
+	// HTTP through driveSEP2322ClientRequestState, which exercises the
+	// MRTR retry contract the scenario grades:
+	//   - echo requestState byte-for-byte on retry,
+	//   - omit requestState when the server didn't send one,
+	//   - use a different JSON-RPC id on retry,
+	//   - keep MRTR state isolated across unrelated tool calls.
+	if scenario == "sep-2322-client-request-state" {
+		if err := driveSEP2322ClientRequestState(serverURL); err != nil {
+			log.Fatalf("sep-2322-client-request-state: %v", err)
+		}
+		log.Println("SUCCESS: sep-2322-client-request-state driven")
+		return
+	}
+
 	var ctx conformanceContext
 	if contextJSON != "" {
 		json.Unmarshal([]byte(contextJSON), &ctx)

--- a/cmd/testclient/sep2322.go
+++ b/cmd/testclient/sep2322.go
@@ -1,0 +1,200 @@
+package main
+
+// SEP-2322 client MRTR driver for the
+// `sep-2322-client-request-state` upstream scenario.
+//
+// The upstream fixture is a bare-HTTP JSON-RPC endpoint (no MCP
+// initialize handshake, no SEP-2575 server/discover) that grades how
+// the client handles InputRequiredResult on tools/call:
+//
+//   - test_mrtr_echo_state      — verifies requestState is echoed byte-
+//                                  for-byte AND the JSON-RPC id changes
+//                                  on retry.
+//   - test_mrtr_no_state        — verifies the client OMITS requestState
+//                                  on retry when the server didn't send
+//                                  one.
+//   - test_mrtr_unrelated       — verifies inputResponses / requestState
+//                                  from one tool's MRTR flow do NOT leak
+//                                  to a parallel call against another
+//                                  tool.
+//   - test_mrtr_no_result_type  — verifies the client treats a result
+//                                  with no resultType as "complete" by
+//                                  default (no retry).
+//
+// We can't use mcpkit's connected client.Client here because the fixture
+// doesn't implement initialize. The driver shapes raw POSTs that match
+// what a SEP-2322-conformant client would emit; the fixture's per-tool
+// handlers grade the wire shape and push checks into its checks buffer.
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync/atomic"
+)
+
+// nextID is a monotonically-incrementing JSON-RPC request id source.
+// The conformance scenario explicitly checks that retries use a
+// DIFFERENT id than the original request, so the only requirement is
+// uniqueness across this driver run.
+var nextID atomic.Int64
+
+func sep2322NextID() int64 { return nextID.Add(1) }
+
+// driveSEP2322ClientRequestState runs the four fixture tools through
+// the wire-correct MRTR contract: round 1 to elicit the
+// InputRequiredResult, round 2 with `inputResponses` and (only if
+// echoed) the unchanged `requestState`. The fixture pushes its grading
+// checks as a side effect of each call — we drive, the fixture grades.
+func driveSEP2322ClientRequestState(serverURL string) error {
+	// test_mrtr_echo_state: server returns requestState; we MUST echo
+	// it verbatim AND use a different id on retry.
+	if err := mrtrRoundTrip(serverURL, "test_mrtr_echo_state", true /* echoRequestState */); err != nil {
+		return fmt.Errorf("test_mrtr_echo_state: %w", err)
+	}
+
+	// test_mrtr_no_state: server returns InputRequiredResult WITHOUT
+	// requestState; we MUST NOT invent one on retry. Same loop, just
+	// don't propagate a state token.
+	if err := mrtrRoundTrip(serverURL, "test_mrtr_no_state", true /* echoRequestState */); err != nil {
+		return fmt.Errorf("test_mrtr_no_state: %w", err)
+	}
+
+	// test_mrtr_unrelated: a separate tool call after the above must NOT
+	// carry over inputResponses / requestState from another tool's flow.
+	// One bare call with no MRTR fields is the spec-correct behaviour.
+	if _, err := postJSONRPC(serverURL, "tools/call", map[string]any{
+		"name":      "test_mrtr_unrelated",
+		"arguments": map[string]any{},
+	}); err != nil {
+		return fmt.Errorf("test_mrtr_unrelated: %w", err)
+	}
+
+	// test_mrtr_no_result_type: server returns a result with no
+	// resultType; the client MUST treat it as "complete" and NOT retry.
+	// One bare call, no second round even if the result looks
+	// unfamiliar.
+	if _, err := postJSONRPC(serverURL, "tools/call", map[string]any{
+		"name":      "test_mrtr_no_result_type",
+		"arguments": map[string]any{},
+	}); err != nil {
+		return fmt.Errorf("test_mrtr_no_result_type: %w", err)
+	}
+
+	return nil
+}
+
+// mrtrRoundTrip executes one MRTR loop:
+//
+//  1. Initial tools/call (no inputResponses).
+//  2. If the response is an InputRequiredResult, build inputResponses
+//     by canned-resolving each InputRequest (action: accept,
+//     confirmed: true is what the fixture's elicitation schema asks
+//     for) and re-issue tools/call with a NEW JSON-RPC id and the
+//     unchanged requestState (when the server sent one).
+//
+// echoRequestState toggles whether the server's requestState — when
+// present — gets echoed back. The fixture's no-state variant returns
+// an InputRequiredResult with no requestState; the driver MUST then
+// retry without inventing one. Pass true for both variants — when the
+// server's response field is absent the helper naturally skips it.
+func mrtrRoundTrip(serverURL, toolName string, echoRequestState bool) error {
+	r1, err := postJSONRPC(serverURL, "tools/call", map[string]any{
+		"name":      toolName,
+		"arguments": map[string]any{},
+	})
+	if err != nil {
+		return err
+	}
+	if r1.Error != nil {
+		return fmt.Errorf("round 1: %s (code=%d)", r1.Error.Message, r1.Error.Code)
+	}
+	result, _ := r1.Result.(map[string]any)
+	if result == nil {
+		return fmt.Errorf("round 1 result missing")
+	}
+	// resultType != "input_required" → complete, no retry.
+	if result["resultType"] != "input_required" {
+		return nil
+	}
+	reqs, _ := result["inputRequests"].(map[string]any)
+	responses := make(map[string]any, len(reqs))
+	for key := range reqs {
+		// Canned: every InputRequest in this fixture is an elicitation
+		// asking for {confirmed: bool}, and the fixture's grading is
+		// indifferent to the actual content.
+		responses[key] = map[string]any{
+			"action":  "accept",
+			"content": map[string]any{"confirmed": true},
+		}
+	}
+
+	retryParams := map[string]any{
+		"name":           toolName,
+		"arguments":      map[string]any{},
+		"inputResponses": responses,
+	}
+	if echoRequestState {
+		if state, ok := result["requestState"].(string); ok && state != "" {
+			retryParams["requestState"] = state
+		}
+	}
+	r2, err := postJSONRPC(serverURL, "tools/call", retryParams)
+	if err != nil {
+		return err
+	}
+	if r2.Error != nil {
+		return fmt.Errorf("round 2: %s (code=%d)", r2.Error.Message, r2.Error.Code)
+	}
+	return nil
+}
+
+// jsonRPCResponse mirrors the inbound JSON-RPC envelope shape.
+type jsonRPCResponse struct {
+	JSONRPC string         `json:"jsonrpc"`
+	ID      any            `json:"id"`
+	Result  any            `json:"result,omitempty"`
+	Error   *jsonRPCError  `json:"error,omitempty"`
+}
+
+type jsonRPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// postJSONRPC POSTs a single JSON-RPC request and returns the decoded
+// response envelope. Each call mints a fresh id so the fixture's
+// "different id on retry" check observes the change.
+func postJSONRPC(serverURL, method string, params any) (*jsonRPCResponse, error) {
+	body, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      sep2322NextID(),
+		"method":  method,
+		"params":  params,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal %s: %w", method, err)
+	}
+	httpReq, err := http.NewRequest("POST", serverURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("new request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "application/json")
+	resp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("POST %s: %w", method, err)
+	}
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	var out jsonRPCResponse
+	if err := json.Unmarshal(respBody, &out); err != nil {
+		return nil, fmt.Errorf("decode response (%d bytes): %w\n%s", len(respBody), err, string(respBody))
+	}
+	return &out, nil
+}

--- a/cmd/testserver/conformance_input_required.go
+++ b/cmd/testserver/conformance_input_required.go
@@ -1,0 +1,276 @@
+package main
+
+// SEP-2322 input-required-result fixtures.
+//
+// Implement the tool / prompt contracts the upstream conformance scenarios
+// `input-required-result-*` exercise. Each handler branches on
+// ctx.HasInputResponses(): the first call returns ctx.RequestInput(...) and
+// the second call decodes the echoed response into a final result. The
+// dispatch layer reshapes the InputRequiredResult onto the wire and mints
+// the requestState; handlers never touch the token directly.
+//
+// Tool naming mirrors the upstream `input-required-result-*` scenarios
+// verbatim — the existing examples/mrtr/ fixture (which targets an older
+// SEP-fork branch under `test_incomplete_result_*` names) stays as-is.
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/server"
+)
+
+func registerInputRequiredResultFixtures(srv *server.Server) {
+	registerInputRequiredResultTools(srv)
+	registerInputRequiredResultPrompts(srv)
+}
+
+func registerInputRequiredResultTools(srv *server.Server) {
+	// A1: basic elicitation — one round-trip asking for the user's name.
+	srv.Register(core.TypedTool[emptyInput, core.ToolResponse](
+		"test_input_required_result_elicitation",
+		"Asks for the user's name then greets them (SEP-2322 A1, A7, A10, A14, A15).",
+		func(ctx core.ToolContext, _ emptyInput) (core.ToolResponse, error) {
+			if !ctx.HasInputResponses() {
+				return ctx.RequestInput(core.InputRequests{
+					"user_name": core.NewElicitationInputRequest(core.ElicitationRequest{
+						Message:         "What is your name?",
+						RequestedSchema: json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}`),
+					}),
+				})
+			}
+			raw := ctx.InputResponse("user_name")
+			if raw == nil {
+				// Spec recommendation: re-request rather than error when the
+				// echoed inputResponses miss the expected key. A7 grades this
+				// as a soft preference (WARNING, not FAILURE).
+				return ctx.RequestInput(core.InputRequests{
+					"user_name": core.NewElicitationInputRequest(core.ElicitationRequest{
+						Message:         "I need your name to greet you.",
+						RequestedSchema: json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}`),
+					}),
+				})
+			}
+			er, err := core.DecodeElicitationInputResponse(raw)
+			if err != nil {
+				return core.ErrorResult("malformed elicitation response: " + err.Error()), nil
+			}
+			name, _ := er.Content["name"].(string)
+			if name == "" {
+				return core.ErrorResult("elicitation accepted but name was empty"), nil
+			}
+			return core.TextResult(fmt.Sprintf("Hello, %s!", name)), nil
+		},
+	))
+
+	// A2: basic sampling — one round-trip asking the client's LLM for the
+	// capital of France.
+	srv.Register(core.TypedTool[emptyInput, core.ToolResponse](
+		"test_input_required_result_sampling",
+		"Asks the client to sample its LLM for the capital of France (SEP-2322 A2).",
+		func(ctx core.ToolContext, _ emptyInput) (core.ToolResponse, error) {
+			if !ctx.HasInputResponses() {
+				return ctx.RequestInput(core.InputRequests{
+					"capital_question": core.NewSamplingInputRequest(core.CreateMessageRequest{
+						Messages: []core.SamplingMessage{{
+							Role:    "user",
+							Content: core.Content{Type: "text", Text: "What is the capital of France?"},
+						}},
+						MaxTokens: 100,
+					}),
+				})
+			}
+			sr, err := core.DecodeSamplingInputResponse(ctx.InputResponse("capital_question"))
+			if err != nil {
+				return core.ErrorResult("malformed sampling response: " + err.Error()), nil
+			}
+			return core.TextResult("model said: " + sr.Content.Text), nil
+		},
+	))
+
+	// A3: basic roots/list — one round-trip asking the client for its
+	// current workspace roots.
+	srv.Register(core.TypedTool[emptyInput, core.ToolResponse](
+		"test_input_required_result_list_roots",
+		"Asks the client for its current workspace roots (SEP-2322 A3).",
+		func(ctx core.ToolContext, _ emptyInput) (core.ToolResponse, error) {
+			if !ctx.HasInputResponses() {
+				return ctx.RequestInput(core.InputRequests{
+					"client_roots": core.NewListRootsInputRequest(),
+				})
+			}
+			roots, err := core.DecodeListRootsInputResponse(ctx.InputResponse("client_roots"))
+			if err != nil {
+				return core.ErrorResult("malformed roots/list response: " + err.Error()), nil
+			}
+			uris := make([]string, 0, len(roots.Roots))
+			for _, r := range roots.Roots {
+				uris = append(uris, r.URI)
+			}
+			return core.TextResult(fmt.Sprintf("client roots: %v", uris)), nil
+		},
+	))
+
+	// A4: requestState round-trip — the response text on round 2 MUST
+	// include "state-ok" to confirm the server received + validated the
+	// echoed requestState. Token integrity is the dispatch layer's job;
+	// the handler just observes ctx.RequestState() is non-empty.
+	srv.Register(core.TypedTool[emptyInput, core.ToolResponse](
+		"test_input_required_result_request_state",
+		"Asks for a confirmation, then confirms requestState was echoed verbatim (SEP-2322 A4).",
+		func(ctx core.ToolContext, _ emptyInput) (core.ToolResponse, error) {
+			if !ctx.HasInputResponses() {
+				return ctx.RequestInput(core.InputRequests{
+					"confirm": core.NewElicitationInputRequest(core.ElicitationRequest{
+						Message:         "Please confirm",
+						RequestedSchema: json.RawMessage(`{"type":"object","properties":{"ok":{"type":"boolean"}},"required":["ok"]}`),
+					}),
+				})
+			}
+			if ctx.RequestState() == "" {
+				return core.ErrorResult("requestState was not echoed back"), nil
+			}
+			return core.TextResult("state-ok: requestState round-tripped through the client"), nil
+		},
+	))
+
+	// A5: multiple input requests — elicitation + sampling + roots/list
+	// asked in a single round.
+	srv.Register(core.TypedTool[emptyInput, core.ToolResponse](
+		"test_input_required_result_multiple_inputs",
+		"Asks for elicitation + sampling + roots/list in one round (SEP-2322 A5).",
+		func(ctx core.ToolContext, _ emptyInput) (core.ToolResponse, error) {
+			if !ctx.HasInputResponses() {
+				return ctx.RequestInput(core.InputRequests{
+					"user_name": core.NewElicitationInputRequest(core.ElicitationRequest{
+						Message:         "What is your name?",
+						RequestedSchema: json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}`),
+					}),
+					"greeting": core.NewSamplingInputRequest(core.CreateMessageRequest{
+						Messages: []core.SamplingMessage{{
+							Role:    "user",
+							Content: core.Content{Type: "text", Text: "Generate a greeting"},
+						}},
+						MaxTokens: 50,
+					}),
+					"client_roots": core.NewListRootsInputRequest(),
+				})
+			}
+			return core.TextResult("all inputs received"), nil
+		},
+	))
+
+	// A6: multi-round — three rounds with rotating requestState. Each
+	// round mints a fresh token via mintRequestState (dispatch handles
+	// it transparently).
+	srv.Register(core.TypedTool[emptyInput, core.ToolResponse](
+		"test_input_required_result_multi_round",
+		"Two elicitation rounds (step1 → step2) then a complete result (SEP-2322 A6).",
+		func(ctx core.ToolContext, _ emptyInput) (core.ToolResponse, error) {
+			step1 := ctx.InputResponse("step1")
+			step2 := ctx.InputResponse("step2")
+			switch {
+			case step1 == nil:
+				return ctx.RequestInput(core.InputRequests{
+					"step1": core.NewElicitationInputRequest(core.ElicitationRequest{
+						Message:         "Step 1: What is your name?",
+						RequestedSchema: json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}`),
+					}),
+				})
+			case step2 == nil:
+				return ctx.RequestInput(core.InputRequests{
+					"step2": core.NewElicitationInputRequest(core.ElicitationRequest{
+						Message:         "Step 2: What is your favorite color?",
+						RequestedSchema: json.RawMessage(`{"type":"object","properties":{"color":{"type":"string"}},"required":["color"]}`),
+					}),
+				})
+			default:
+				return core.TextResult("multi-round complete"), nil
+			}
+		},
+	))
+
+	// A12: tampered-state — relies on the dispatch layer signing the
+	// requestState (server.WithRequestStateSigning enabled in main.go).
+	// Handler shape is identical to A1; integrity-verification happens
+	// upstream before the second-round handler even runs.
+	srv.Register(core.TypedTool[emptyInput, core.ToolResponse](
+		"test_input_required_result_tampered_state",
+		"Same shape as A1 — exercises signed-requestState rejection (SEP-2322 A12).",
+		func(ctx core.ToolContext, _ emptyInput) (core.ToolResponse, error) {
+			if !ctx.HasInputResponses() {
+				return ctx.RequestInput(core.InputRequests{
+					"confirm": core.NewElicitationInputRequest(core.ElicitationRequest{
+						Message:         "Please confirm",
+						RequestedSchema: json.RawMessage(`{"type":"object","properties":{"ok":{"type":"boolean"}},"required":["ok"]}`),
+					}),
+				})
+			}
+			return core.TextResult("tamper test ok"), nil
+		},
+	))
+
+	// A13: capability check — the client declares `sampling` only
+	// (no `elicitation`). The handler MUST skip the elicitation
+	// inputRequest and emit sampling-only.
+	srv.Register(core.TypedTool[emptyInput, core.ToolResponse](
+		"test_input_required_result_capabilities",
+		"Gates inputRequests on per-request client capabilities (SEP-2322 A13).",
+		func(ctx core.ToolContext, _ emptyInput) (core.ToolResponse, error) {
+			if ctx.HasInputResponses() {
+				return core.TextResult("capability-check complete"), nil
+			}
+			reqs := core.InputRequests{}
+			caps := ctx.ClientCaps()
+			if caps != nil && caps.Sampling != nil {
+				reqs["greeting"] = core.NewSamplingInputRequest(core.CreateMessageRequest{
+					Messages: []core.SamplingMessage{{
+						Role:    "user",
+						Content: core.Content{Type: "text", Text: "Generate a greeting"},
+					}},
+					MaxTokens: 50,
+				})
+			}
+			if caps != nil && caps.Elicitation != nil {
+				reqs["user_name"] = core.NewElicitationInputRequest(core.ElicitationRequest{
+					Message:         "What is your name?",
+					RequestedSchema: json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}`),
+				})
+			}
+			return ctx.RequestInput(reqs)
+		},
+	))
+}
+
+func registerInputRequiredResultPrompts(srv *server.Server) {
+	// A9: prompts/get returning InputRequiredResult — verifies SEP-2322
+	// is universal across request methods, not tools-only.
+	srv.RegisterPrompt(
+		core.PromptDef{
+			Name:        "test_input_required_result_prompt",
+			Description: "Prompts the client for a context value, then builds a templated prompt (SEP-2322 A9).",
+		},
+		func(ctx core.PromptContext, _ core.PromptRequest) (core.PromptResponse, error) {
+			if !ctx.HasInputResponses() {
+				return ctx.RequestInput(core.InputRequests{
+					"user_context": core.NewElicitationInputRequest(core.ElicitationRequest{
+						Message:         "What context should the prompt use?",
+						RequestedSchema: json.RawMessage(`{"type":"object","properties":{"context":{"type":"string"}},"required":["context"]}`),
+					}),
+				})
+			}
+			er, err := core.DecodeElicitationInputResponse(ctx.InputResponse("user_context"))
+			if err != nil {
+				return core.PromptResult{}, fmt.Errorf("decode user_context: %w", err)
+			}
+			ctxStr, _ := er.Content["context"].(string)
+			return core.PromptResult{
+				Messages: []core.PromptMessage{{
+					Role:    "user",
+					Content: core.Content{Type: "text", Text: "Context: " + ctxStr},
+				}},
+			}, nil
+		},
+	)
+}

--- a/cmd/testserver/main.go
+++ b/cmd/testserver/main.go
@@ -50,6 +50,11 @@ func main() {
 		server.WithToolTimeout(30*time.Second),
 		server.WithSubscriptions(),
 		server.WithExtension(testUIExtension{}),
+		// SEP-2322 tampered-state conformance scenario requires
+		// requestState to be integrity-protected. Static key here is fine
+		// for a conformance testserver — production deployments would
+		// inject the key via environment or secret manager.
+		server.WithRequestStateSigning([]byte("testserver-conformance-key-32-bytes-min"), 0),
 	)
 	// Enable HTTP-level request logging if VERBOSE is set
 	if os.Getenv("VERBOSE") == "1" {
@@ -95,6 +100,7 @@ func main() {
 	registerConformanceResources(srv)
 	registerConformancePrompts(srv)
 	registerConformanceApps(srv)
+	registerInputRequiredResultFixtures(srv)
 
 	// Self-test mode: creates an in-process client with LoggingTransport,
 	// lists tools via auto-pagination iterator, and calls each one.

--- a/conformance/UPSTREAM_AUDIT.md
+++ b/conformance/UPSTREAM_AUDIT.md
@@ -13,9 +13,9 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 
 | Surface | Scenarios | Checks | Pass | Fail | Warn | Info | Skipped | Harness-gap |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|
-| Server | 51 | 127 | 78 | 21 | 13 | 6 | 9 | 0 |
+| Server | 51 | 135 | 105 | 8 | 7 | 6 | 9 | 0 |
 | Client | 40 | 1241 | 447 | 25 | 4 | 759 | 6 | 1 |
-| **Total** | **91** | **1368** | **525** | **46** | **17** | **765** | **15** | **1** |
+| **Total** | **91** | **1376** | **552** | **33** | **11** | **765** | **15** | **1** |
 
 ## Harness gaps
 
@@ -158,7 +158,7 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 
 | Scenario | Surface | Status | Checks | Note |
 |---|---|---|---|---|
-| `http-header-validation` | server | partial | 5 pass / 3 fail / 5 warn |  |
+| `http-header-validation` | server | pass | 13 pass |  |
 
 ### [SEP-2243-X-MCP-HEADER](https://modelcontextprotocol.io/specification/draft/server/tools#x-mcp-header) (1 scenarios)
 
@@ -176,20 +176,20 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 
 | Scenario | Surface | Status | Checks | Note |
 |---|---|---|---|---|
-| `input-required-result-basic-elicitation` | server | fail | 1 fail | `JSON-RPC error: unknown tool: test_input_required_result_elicitation` |
-| `input-required-result-basic-list-roots` | server | fail | 1 fail | `JSON-RPC error: unknown tool: test_input_required_result_list_roots` |
-| `input-required-result-basic-sampling` | server | fail | 1 fail | `JSON-RPC error: unknown tool: test_input_required_result_sampling` |
-| `input-required-result-capability-check` | server | fail | 1 fail | `JSON-RPC error: unknown tool: test_input_required_result_capabilities` |
-| `input-required-result-multi-round` | server | fail | 1 fail | `Expected InputRequiredResult with inputRequests and requestState` |
-| `input-required-result-multiple-input-requests` | server | fail | 1 fail | `JSON-RPC error: unknown tool: test_input_required_result_multiple_inputs` |
-| `input-required-result-non-tool-request` | server | fail | 1 fail | `JSON-RPC error: unknown prompt: test_input_required_result_prompt` |
-| `input-required-result-request-state` | server | fail | 1 fail | `JSON-RPC error: unknown tool: test_input_required_result_request_state` |
-| `input-required-result-result-type` | server | fail | 1 fail | `JSON-RPC error: unknown tool: test_input_required_result_elicitation` |
-| `input-required-result-tampered-state` | server | fail | 1 fail | `Prerequisite failed: could not get initial InputRequiredResult with requestState` |
-| `input-required-result-ignore-extra-params` | server | pass | 1 warn |  |
-| `input-required-result-missing-input-response` | server | pass | 1 warn |  |
+| `input-required-result-basic-elicitation` | server | pass | 2 pass |  |
+| `input-required-result-basic-list-roots` | server | pass | 2 pass |  |
+| `input-required-result-basic-sampling` | server | pass | 2 pass |  |
+| `input-required-result-capability-check` | server | pass | 1 pass |  |
+| `input-required-result-ignore-extra-params` | server | pass | 1 pass |  |
+| `input-required-result-missing-input-response` | server | pass | 1 pass |  |
+| `input-required-result-multi-round` | server | pass | 3 pass |  |
+| `input-required-result-multiple-input-requests` | server | pass | 2 pass |  |
+| `input-required-result-non-tool-request` | server | pass | 2 pass |  |
+| `input-required-result-request-state` | server | pass | 2 pass |  |
+| `input-required-result-result-type` | server | pass | 1 pass |  |
+| `input-required-result-tampered-state` | server | pass | 1 pass |  |
 | `input-required-result-unsupported-methods` | server | pass | 1 pass |  |
-| `input-required-result-validate-input` | server | pass | 2 pass |  |
+| `input-required-result-validate-input` | server | pass | 1 pass / 1 warn |  |
 
 ### [SEP-2322-MRTR](https://modelcontextprotocol.io/specification/draft/basic/utilities/mrtr) (1 scenarios)
 

--- a/conformance/UPSTREAM_AUDIT.md
+++ b/conformance/UPSTREAM_AUDIT.md
@@ -14,8 +14,8 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 | Surface | Scenarios | Checks | Pass | Fail | Warn | Info | Skipped | Harness-gap |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|
 | Server | 51 | 135 | 105 | 8 | 7 | 6 | 9 | 0 |
-| Client | 40 | 1241 | 447 | 25 | 4 | 759 | 6 | 1 |
-| **Total** | **91** | **1376** | **552** | **33** | **11** | **765** | **15** | **1** |
+| Client | 40 | 1241 | 452 | 20 | 4 | 759 | 6 | 1 |
+| **Total** | **91** | **1376** | **557** | **28** | **11** | **765** | **15** | **1** |
 
 ## Harness gaps
 
@@ -195,7 +195,7 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 
 | Scenario | Surface | Status | Checks | Note |
 |---|---|---|---|---|
-| `sep-2322-client-request-state` | client | fail | 5 fail |  |
+| `sep-2322-client-request-state` | client | pass | 5 pass |  |
 
 ### [SEP-2549](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2549) (1 scenarios)
 

--- a/core/handler_context.go
+++ b/core/handler_context.go
@@ -40,10 +40,20 @@ type ResourceContext struct {
 }
 
 // PromptContext is the context passed to PromptHandler and
-// CompletionHandler functions. It embeds BaseContext with no additional
-// methods.
+// CompletionHandler functions. It embeds BaseContext and adds SEP-2322
+// MRTR accessors symmetric with ToolContext — a prompts/get handler can
+// branch on `ctx.HasInputResponses()`, return `ctx.RequestInput(...)` on
+// the first call, and decode `ctx.InputResponse("key")` on the second.
 type PromptContext struct {
 	BaseContext
+
+	// inputResponses + requestState carry the SEP-2322 ephemeral MRTR
+	// continuation payload — the client echoes them back into the SAME
+	// prompts/get request when retrying after a previous
+	// InputRequiredResult. Set by dispatch from the request envelope;
+	// nil/empty on the first call.
+	inputResponses InputResponses
+	requestState   string
 }
 
 // MethodContext is the context passed to custom JSON-RPC method handlers
@@ -102,7 +112,20 @@ func NewResourceContext(ctx context.Context) ResourceContext {
 
 // NewPromptContext constructs a PromptContext from a standard context.Context.
 func NewPromptContext(ctx context.Context) PromptContext {
-	return PromptContext{BaseContext{ctx, sessionFromContext(ctx)}}
+	return PromptContext{BaseContext: BaseContext{ctx, sessionFromContext(ctx)}}
+}
+
+// NewPromptContextWithMRTR constructs a PromptContext for an SEP-2322 MRTR
+// retry: the inputResponses/requestState the client echoed back into the
+// prompts/get request. Called by the dispatch layer after parsing the
+// envelope; handlers read the values via ctx.InputResponse / ctx.InputResponses
+// / ctx.RequestState.
+func NewPromptContextWithMRTR(ctx context.Context, inputResponses InputResponses, requestState string) PromptContext {
+	return PromptContext{
+		BaseContext:    BaseContext{ctx, sessionFromContext(ctx)},
+		inputResponses: inputResponses,
+		requestState:   requestState,
+	}
 }
 
 // --- BaseContext methods (shared by all handler types) ---
@@ -330,7 +353,11 @@ func (rc ResourceContext) DetachFromClient() ResourceContext {
 // DetachFromClient returns a PromptContext that preserves session state but is
 // NOT cancelled when the client disconnects.
 func (pc PromptContext) DetachFromClient() PromptContext {
-	return PromptContext{pc.BaseContext.DetachFromClient()}
+	return PromptContext{
+		BaseContext:    pc.BaseContext.DetachFromClient(),
+		inputResponses: pc.inputResponses,
+		requestState:   pc.requestState,
+	}
 }
 
 // --- ToolContext-only methods ---
@@ -441,6 +468,49 @@ func (tc ToolContext) RequestState() string {
 // The concrete return type is InputRequiredResult (not ToolResponse) so
 // callers can use the typed value directly when they need to.
 func (tc ToolContext) RequestInput(reqs InputRequests) (InputRequiredResult, error) {
+	return InputRequiredResult{
+		InputRequests: reqs,
+	}, nil
+}
+
+// --- SEP-2322 MRTR accessors on PromptContext ---
+//
+// Symmetric with the ToolContext accessors above. SEP-2322 input-required
+// flows are scoped to "any request method whose response shape can accept
+// it" — prompts/get is the second such method after tools/call (see the
+// upstream input-required-result-non-tool-request scenario).
+
+// InputResponses returns the SEP-2322 inputResponses map the client echoed
+// back into this prompts/get. Nil on the first call.
+func (pc PromptContext) InputResponses() InputResponses {
+	return pc.inputResponses
+}
+
+// InputResponse returns the raw response payload for a specific request key
+// from the inputResponses map, or nil if the key is missing.
+func (pc PromptContext) InputResponse(key string) json.RawMessage {
+	if pc.inputResponses == nil {
+		return nil
+	}
+	return pc.inputResponses[key]
+}
+
+// HasInputResponses reports whether the client echoed any inputResponses back.
+func (pc PromptContext) HasInputResponses() bool {
+	return len(pc.inputResponses) > 0
+}
+
+// RequestState returns the SEP-2322 requestState token the client echoed
+// back. Empty on the first call. Already verified by dispatch when a
+// signing key is configured.
+func (pc PromptContext) RequestState() string {
+	return pc.requestState
+}
+
+// RequestInput is the SEP-2322 ephemeral retry primitive for prompts/get.
+// Symmetric with ToolContext.RequestInput; the dispatch layer reshapes the
+// InputRequiredResult onto the wire with a freshly-minted requestState.
+func (pc PromptContext) RequestInput(reqs InputRequests) (InputRequiredResult, error) {
 	return InputRequiredResult{
 		InputRequests: reqs,
 	}, nil

--- a/core/handler_context.go
+++ b/core/handler_context.go
@@ -128,6 +128,40 @@ func NewPromptContextWithMRTR(ctx context.Context, inputResponses InputResponses
 	}
 }
 
+// ClientCaps returns the client capabilities the handler should gate
+// against for THIS request. SEP-2322 says servers MUST only emit
+// inputRequests for methods the client declared support for; the rule
+// is the same on both wires, but the source of truth differs:
+//
+//   - Legacy wire: capabilities are negotiated once during `initialize`
+//     and cached on the session.
+//   - Stateless wire (SEP-2575): no session — capabilities are declared
+//     per-request inside the _meta envelope, fresh on every call.
+//
+// This accessor coalesces the two into a single typed view so handlers
+// don't have to special-case the wire. On the legacy wire it returns
+// the session-cached caps; on the stateless wire it returns the per-
+// request envelope's caps (which is the only source there). Either
+// pointer may be nil — handlers MUST nil-check before reading sub-
+// capabilities.
+//
+// Usage in a tool handler that wants to skip elicitation inputRequests
+// when the client did not declare elicitation:
+//
+//	caps := ctx.ClientCaps()
+//	if caps != nil && caps.Elicitation != nil {
+//	    reqs["user_name"] = core.InputRequest{Method: "elicitation/create", ...}
+//	}
+func (bc BaseContext) ClientCaps() *ClientCapabilities {
+	if meta := RequestMetaFromContext(bc.Context); meta != nil {
+		return meta.ClientCapabilities
+	}
+	if bc.sc != nil {
+		return bc.sc.clientCaps
+	}
+	return nil
+}
+
 // --- BaseContext methods (shared by all handler types) ---
 
 // EmitLog sends a log notification at the given severity level.

--- a/core/mrtr.go
+++ b/core/mrtr.go
@@ -99,6 +99,13 @@ type InputRequiredResult struct {
 // toolResponse marks InputRequiredResult as a [ToolResponse] variant.
 func (InputRequiredResult) toolResponse() {}
 
+// promptResponse marks InputRequiredResult as a [PromptResponse] variant.
+// SEP-2322 scopes the input-required flow to "any request method, in
+// principle" — tools/call is the headline case, prompts/get is the second
+// case the spec calls out and the upstream conformance scenario
+// `input-required-result-non-tool-request` exercises.
+func (InputRequiredResult) promptResponse() {}
+
 // MarshalJSON defaults ResultType to ResultTypeInputRequired so handlers
 // that build an InputRequiredResult{} literal don't have to set the
 // discriminator.

--- a/core/mrtr.go
+++ b/core/mrtr.go
@@ -166,6 +166,20 @@ func NewElicitationInputRequest(req ElicitationRequest) InputRequest {
 	}
 }
 
+// NewListRootsInputRequest builds the MRTR InputRequest the server sends
+// when it needs the client's current set of workspace roots. Symmetric
+// with NewSamplingInputRequest / NewElicitationInputRequest. The wire
+// method is roots/list and the spec defines no params — the value
+// carries an empty `{}` so wire decoders that branch on params shape
+// stay on the common path. Used by the SEP-2322
+// `input-required-result-basic-list-roots` conformance scenario.
+func NewListRootsInputRequest() InputRequest {
+	return InputRequest{
+		Method: "roots/list",
+		Params: json.RawMessage(`{}`),
+	}
+}
+
 // DecodeSamplingInputResponse decodes a single inputResponses entry as
 // a CreateMessageResult — symmetric with NewSamplingInputRequest above.
 // Used on the second tools/call round after the client has answered
@@ -184,6 +198,17 @@ func DecodeElicitationInputResponse(raw json.RawMessage) (ElicitationResult, err
 	var out ElicitationResult
 	if err := json.Unmarshal(raw, &out); err != nil {
 		return ElicitationResult{}, fmt.Errorf("decode elicitation response: %w", err)
+	}
+	return out, nil
+}
+
+// DecodeListRootsInputResponse decodes a single inputResponses entry as a
+// RootsListResult — symmetric with NewListRootsInputRequest. Used on the
+// second tools/call round after the client has reported its current roots.
+func DecodeListRootsInputResponse(raw json.RawMessage) (RootsListResult, error) {
+	var out RootsListResult
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return RootsListResult{}, fmt.Errorf("decode roots/list response: %w", err)
 	}
 	return out, nil
 }

--- a/core/mrtr_test.go
+++ b/core/mrtr_test.go
@@ -199,6 +199,17 @@ func TestInputRequiredResultWireShape(t *testing.T) {
 	}
 }
 
+// TestInputRequiredResult_SatisfiesBothResponseInterfaces guards the
+// sealed-interface marker methods: SEP-2322 InputRequiredResult is a
+// variant of BOTH ToolResponse (tools/call) AND PromptResponse
+// (prompts/get, per upstream's input-required-result-non-tool-request
+// scenario). Compile-time check via interface assertion — if either
+// marker is dropped, this test stops building.
+func TestInputRequiredResult_SatisfiesBothResponseInterfaces(t *testing.T) {
+	var _ ToolResponse = InputRequiredResult{}
+	var _ PromptResponse = InputRequiredResult{}
+}
+
 // TestInputRequiredResultDefaultsResultType verifies that a zero-value
 // InputRequiredResult marshals with resultType = "input_required" so
 // handlers can build InputRequiredResult{InputRequests: ...} without

--- a/core/mrtr_test.go
+++ b/core/mrtr_test.go
@@ -210,6 +210,29 @@ func TestInputRequiredResult_SatisfiesBothResponseInterfaces(t *testing.T) {
 	var _ PromptResponse = InputRequiredResult{}
 }
 
+// TestNewListRootsInputRequest_RoundTrip verifies the helper builds a
+// well-formed roots/list InputRequest with an empty params object (no
+// fields are defined by the spec) and that the response decoder yields
+// the canonical RootsListResult shape.
+func TestNewListRootsInputRequest_RoundTrip(t *testing.T) {
+	req := NewListRootsInputRequest()
+	if req.Method != "roots/list" {
+		t.Errorf("Method = %q, want roots/list", req.Method)
+	}
+	if string(req.Params) != `{}` {
+		t.Errorf("Params = %s, want {}", req.Params)
+	}
+
+	raw := json.RawMessage(`{"roots":[{"uri":"file:///work/project","name":"project"}]}`)
+	got, err := DecodeListRootsInputResponse(raw)
+	if err != nil {
+		t.Fatalf("DecodeListRootsInputResponse: %v", err)
+	}
+	if len(got.Roots) != 1 || got.Roots[0].URI != "file:///work/project" {
+		t.Errorf("Roots = %+v, want one root with file:///work/project", got.Roots)
+	}
+}
+
 // TestInputRequiredResultDefaultsResultType verifies that a zero-value
 // InputRequiredResult marshals with resultType = "input_required" so
 // handlers can build InputRequiredResult{InputRequests: ...} without

--- a/core/prompt.go
+++ b/core/prompt.go
@@ -95,6 +95,18 @@ func (m *PromptMessage) UnmarshalJSON(data []byte) error {
 type PromptRequest struct {
 	Name      string
 	Arguments map[string]any
+
+	// InputResponses is the SEP-2322 ephemeral MRTR retry payload — the
+	// client echoes the inputResponses map back into the SAME prompts/get
+	// request that previously returned an InputRequiredResult. Symmetric
+	// with ToolRequest.InputResponses. Nil on the first call.
+	InputResponses InputResponses
+
+	// RequestState is the opaque session-continuation token the client
+	// echoed back from a previous InputRequiredResult. The dispatch layer
+	// verifies it (HMAC when a key is configured) before invoking the
+	// handler. Empty on the first call.
+	RequestState string
 }
 
 // PromptResponse is the sealed interface returned by PromptHandler

--- a/core/session.go
+++ b/core/session.go
@@ -79,7 +79,14 @@ const responseHeadersKey responseHeadersCtxKey = 0
 
 type ctxKey int
 
-const sessionCtxKey ctxKey = iota
+const (
+	sessionCtxKey ctxKey = iota
+	// requestMetaCtxKey is the ctx key under which the validated SEP-2575
+	// per-request _meta envelope (RequestMeta) is threaded by the stateless
+	// dispatcher. Lives in core (not server/stateless) so handlers can read
+	// it via ctx.ClientCaps() without an import cycle.
+	requestMetaCtxKey
+)
 
 // ContextWithSession returns a context carrying the session's notification state,
 // request sender, client capabilities, and authenticated claims.
@@ -153,6 +160,29 @@ func GetSessionID(ctx context.Context) string {
 func sessionFromContext(ctx context.Context) *sessionCtx {
 	sc, _ := ctx.Value(sessionCtxKey).(*sessionCtx)
 	return sc
+}
+
+// WithRequestMeta returns a derived context carrying the validated
+// SEP-2575 per-request _meta envelope. The stateless dispatcher calls
+// this after validating the envelope so handlers can read the per-
+// request capabilities via ctx.ClientCaps(). Returns ctx unchanged when
+// meta is nil so callers can drop the nil-check at the call site.
+func WithRequestMeta(ctx context.Context, meta *RequestMeta) context.Context {
+	if meta == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, requestMetaCtxKey, meta)
+}
+
+// RequestMetaFromContext returns the validated SEP-2575 per-request
+// _meta envelope attached by the stateless dispatcher, or nil if the
+// call did not arrive over the stateless wire. Handlers that just want
+// to check whether a capability is declared should prefer the typed
+// ctx.ClientCaps() accessor; this raw view is for the rare path that
+// needs the full envelope.
+func RequestMetaFromContext(ctx context.Context) *RequestMeta {
+	meta, _ := ctx.Value(requestMetaCtxKey).(*RequestMeta)
+	return meta
 }
 
 // ClientSupportsExtension checks whether the connected client declared support

--- a/core/stateless_test.go
+++ b/core/stateless_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"testing"
@@ -85,6 +86,43 @@ func TestDecodeRequestMeta_MissingRequiredSubfields(t *testing.T) {
 				t.Errorf("Field = %q, want %q", ve.Field, tc.wantField)
 			}
 		})
+	}
+}
+
+// TestClientCaps_StatelessWire verifies that ctx.ClientCaps() returns the
+// per-request capability envelope set by the SEP-2575 stateless dispatcher.
+// The cap-gating capability-check conformance scenario relies on this.
+func TestClientCaps_StatelessWire(t *testing.T) {
+	meta := &RequestMeta{
+		ProtocolVersion:    DraftProtocolVersion2026V1,
+		ClientInfo:         &ClientInfo{Name: "x", Version: "1"},
+		ClientCapabilities: &ClientCapabilities{Sampling: &struct{}{}},
+	}
+	ctx := WithRequestMeta(context.Background(), meta)
+	tc := NewToolContext(ctx)
+	caps := tc.ClientCaps()
+	if caps == nil {
+		t.Fatal("ClientCaps() = nil, want per-request caps from envelope")
+	}
+	if caps.Sampling == nil {
+		t.Errorf("Sampling = nil, want declared")
+	}
+	if caps.Elicitation != nil {
+		t.Errorf("Elicitation = %+v, want nil (not declared)", caps.Elicitation)
+	}
+	// Symmetric check on PromptContext.
+	pc := NewPromptContext(ctx)
+	if pc.ClientCaps() != caps {
+		t.Errorf("PromptContext.ClientCaps mismatch with ToolContext.ClientCaps")
+	}
+}
+
+// TestClientCaps_BareContext_NilSafe documents the no-session, no-meta
+// fallback: a bare ctx.Background() yields nil caps without panic.
+func TestClientCaps_BareContext_NilSafe(t *testing.T) {
+	tc := NewToolContext(context.Background())
+	if got := tc.ClientCaps(); got != nil {
+		t.Errorf("ClientCaps() on bare ctx = %+v, want nil", got)
 	}
 }
 

--- a/server/dispatch.go
+++ b/server/dispatch.go
@@ -737,11 +737,18 @@ func (d *Dispatcher) handlePromptsList(id json.RawMessage, params json.RawMessag
 	return core.NewResponse(id, core.PromptsListResult{Prompts: page, NextCursor: nextCursor, TTLMs: d.listTTLMs, CacheScope: d.listCacheScope})
 }
 
+// promptsGetEnvelope is the MRTR-aware prompts/get request shape. The
+// MRTR fields (inputResponses, requestState) live alongside name +
+// arguments at the params top level — same shape as toolsCallEnvelope.
+type promptsGetEnvelope struct {
+	Name           string              `json:"name"`
+	Arguments      map[string]any      `json:"arguments,omitempty"`
+	InputResponses core.InputResponses `json:"inputResponses,omitempty"`
+	RequestState   string              `json:"requestState,omitempty"`
+}
+
 func (d *Dispatcher) handlePromptsGet(ctx context.Context, id json.RawMessage, params json.RawMessage) *core.Response {
-	var envelope struct {
-		Name      string         `json:"name"`
-		Arguments map[string]any `json:"arguments"`
-	}
+	var envelope promptsGetEnvelope
 	if err := json.Unmarshal(params, &envelope); err != nil {
 		return core.NewErrorResponse(id, core.ErrCodeInvalidParams, err.Error())
 	}
@@ -784,17 +791,42 @@ func (d *Dispatcher) handlePromptsGet(ctx context.Context, id json.RawMessage, p
 		ctx = tctx
 	}
 
+	// SEP-2322: verify any echoed requestState (rejects tampered tokens
+	// before the handler runs) and pull out the accumulated inputResponses
+	// from prior rounds. Symmetric with the tools/call MRTR flow above —
+	// the same mrtrRuntime + token shape is shared across both surfaces.
+	prevState, err := d.mrtr.verifyRequestState(envelope.RequestState, envelope.Name)
+	if err != nil {
+		return core.NewErrorResponse(id, core.ErrCodeInvalidParams,
+			"invalid requestState: "+err.Error())
+	}
+	mergedResponses := mergeInputResponses(prevState.Answered, envelope.InputResponses)
+
 	req := core.PromptRequest{
-		Name:      envelope.Name,
-		Arguments: envelope.Arguments,
+		Name:           envelope.Name,
+		Arguments:      envelope.Arguments,
+		InputResponses: mergedResponses,
+		RequestState:   envelope.RequestState,
 	}
 
-	result, err := entry.handler(core.NewPromptContext(ctx), req)
+	pc := core.NewPromptContextWithMRTR(ctx, mergedResponses, envelope.RequestState)
+	result, err := entry.handler(pc, req)
 	if err != nil {
 		return core.NewErrorResponse(id, core.ErrCodePromptError, fmt.Sprintf("prompt %q: %v", envelope.Name, err))
 	}
 
-	return core.NewResponse(id, result)
+	// SEP-2322 reshape: InputRequiredResult variants get a fresh requestState
+	// carrying the merged answers forward. Every other PromptResponse
+	// (today only PromptResult) flows through as-is.
+	switch r := result.(type) {
+	case core.InputRequiredResult:
+		return core.NewResponse(id, core.InputRequiredResult{
+			InputRequests: r.InputRequests,
+			RequestState:  d.mrtr.mintRequestState(envelope.Name, mergedResponses),
+		})
+	default:
+		return core.NewResponse(id, result)
+	}
 }
 
 // --- Completion ---

--- a/server/mrtr_stateless_test.go
+++ b/server/mrtr_stateless_test.go
@@ -1,0 +1,181 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	core "github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/server/stateless"
+)
+
+// SEP-2322 MRTR over the SEP-2575 stateless wire.
+//
+// The conformance scenarios in `input-required-result-*` POST tools/call with
+// no prior initialize handshake, carrying `_meta.{protocolVersion,clientInfo,
+// clientCapabilities}` per-request and (on retry) `inputResponses` + the
+// echoed `requestState`. The legacy `Dispatcher.handleToolsCall` decodes the
+// MRTR envelope and reshapes `InputRequiredResult` responses; the stateless
+// `callToolForStateless` path must do the same.
+//
+// Each test sets up a single tool that emits an InputRequiredResult on the
+// first round and a complete ToolResult on the second, then drives both
+// rounds via raw HTTP and asserts the wire fields.
+
+// newStatelessMRTRServer registers a tool that round-trips a single
+// elicitation input, optionally with WithRequestStateSigning enabled.
+func newStatelessMRTRServer(t *testing.T, opts ...Option) (*Server, string, func()) {
+	t.Helper()
+	s := NewServer(core.ServerInfo{Name: "stateless-mrtr-test", Version: "0.0.1"}, opts...)
+
+	if err := s.Registry().AddTool(
+		core.ToolDef{
+			Name:        "test_input_required_result_elicitation",
+			Description: "Asks for the user's name then greets them.",
+			InputSchema: map[string]any{"type": "object"},
+		},
+		func(ctx core.ToolContext, _ core.ToolRequest) (core.ToolResponse, error) {
+			if !ctx.HasInputResponses() {
+				return ctx.RequestInput(core.InputRequests{
+					"user_name": core.InputRequest{
+						Method: "elicitation/create",
+						Params: json.RawMessage(`{"message":"What is your name?","requestedSchema":{"type":"object","properties":{"name":{"type":"string"}}}}`),
+					},
+				})
+			}
+			raw := ctx.InputResponse("user_name")
+			var er struct {
+				Action  string `json:"action"`
+				Content struct {
+					Name string `json:"name"`
+				} `json:"content"`
+			}
+			if err := json.Unmarshal(raw, &er); err != nil {
+				return core.ErrorResult("malformed elicitation response"), nil
+			}
+			return core.TextResult("Hello, " + er.Content.Name + "!"), nil
+		},
+	); err != nil {
+		t.Fatalf("AddTool: %v", err)
+	}
+
+	handler := s.Handler(WithStreamableHTTP(true), WithStatelessMode(stateless.ModeDual))
+	ts := httptest.NewServer(handler)
+	return s, ts.URL + "/mcp", func() { ts.Close() }
+}
+
+// statelessToolsCall is a tiny convenience for tools/call requests carrying
+// the SEP-2575 _meta envelope. extra is merged into the params top-level so
+// callers can add inputResponses, requestState, arguments, etc.
+//
+// Returns the decoded JSON-RPC response regardless of HTTP status — a
+// structured -32602 / -32003 maps to HTTP 4xx, and callers want to inspect
+// the JSON-RPC error rather than fail at the transport layer.
+func statelessToolsCall(t *testing.T, url, toolName string, extra map[string]any) *core.Response {
+	t.Helper()
+	params := map[string]any{
+		"name":      toolName,
+		"arguments": map[string]any{},
+		"_meta": map[string]any{
+			"io.modelcontextprotocol/protocolVersion":    draftVersion,
+			"io.modelcontextprotocol/clientInfo":         map[string]any{"name": "t", "version": "1"},
+			"io.modelcontextprotocol/clientCapabilities": map[string]any{"elicitation": map[string]any{}, "sampling": map[string]any{}, "roots": map[string]any{}},
+		},
+	}
+	for k, v := range extra {
+		params[k] = v
+	}
+	resp := postStatelessJSON(t, url, map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+		"params": params,
+	}, map[string]string{mcpProtocolVersionHeader: draftVersion})
+	return decode(t, resp)
+}
+
+// TestStatelessMRTR_RoundTripBasicElicitation drives the A1 conformance
+// scenario shape over the stateless wire: round 1 returns
+// InputRequiredResult with non-empty requestState; round 2 (same tool, with
+// inputResponses + the echoed requestState) returns a complete ToolResult.
+func TestStatelessMRTR_RoundTripBasicElicitation(t *testing.T) {
+	_, url, teardown := newStatelessMRTRServer(t)
+	defer teardown()
+
+	r1 := statelessToolsCall(t, url, "test_input_required_result_elicitation", nil)
+	if r1.Error != nil {
+		t.Fatalf("round 1 error: %+v", r1.Error)
+	}
+	m1, _ := r1.Result.(map[string]any)
+	if m1 == nil {
+		t.Fatalf("round 1 result not a map: %T %+v", r1.Result, r1.Result)
+	}
+	if got := m1["resultType"]; got != "input_required" {
+		t.Fatalf("round 1 resultType = %v, want \"input_required\"", got)
+	}
+	reqs, ok := m1["inputRequests"].(map[string]any)
+	if !ok {
+		t.Fatalf("round 1 inputRequests missing")
+	}
+	if _, ok := reqs["user_name"]; !ok {
+		t.Fatalf("round 1 inputRequests[user_name] missing; got %v", reqs)
+	}
+	state1, _ := m1["requestState"].(string)
+	if state1 == "" {
+		t.Fatalf("round 1 requestState empty")
+	}
+
+	r2 := statelessToolsCall(t, url, "test_input_required_result_elicitation", map[string]any{
+		"inputResponses": map[string]any{
+			"user_name": map[string]any{"action": "accept", "content": map[string]any{"name": "Alice"}},
+		},
+		"requestState": state1,
+	})
+	if r2.Error != nil {
+		t.Fatalf("round 2 error: %+v", r2.Error)
+	}
+	m2, _ := r2.Result.(map[string]any)
+	if m2 == nil {
+		t.Fatalf("round 2 result not a map")
+	}
+	if m2["resultType"] == "input_required" {
+		t.Fatalf("round 2 still input_required; expected complete")
+	}
+	content, _ := m2["content"].([]any)
+	if len(content) == 0 {
+		t.Fatalf("round 2 content empty: %v", m2)
+	}
+	first, _ := content[0].(map[string]any)
+	text, _ := first["text"].(string)
+	if !strings.Contains(text, "Alice") {
+		t.Errorf("round 2 text = %q, want substring \"Alice\"", text)
+	}
+}
+
+// TestStatelessMRTR_TamperedRequestStateRejected exercises the A12
+// scenario shape: a signed requestState that's been mutated MUST yield a
+// JSON-RPC error rather than a complete result or a fresh
+// InputRequiredResult.
+func TestStatelessMRTR_TamperedRequestStateRejected(t *testing.T) {
+	_, url, teardown := newStatelessMRTRServer(t, WithRequestStateSigning([]byte("test-key-32bytes-for-hmacsha256-x"), 0))
+	defer teardown()
+
+	r1 := statelessToolsCall(t, url, "test_input_required_result_elicitation", nil)
+	if r1.Error != nil {
+		t.Fatalf("round 1 error: %+v", r1.Error)
+	}
+	m1, _ := r1.Result.(map[string]any)
+	state1, _ := m1["requestState"].(string)
+	if state1 == "" {
+		t.Fatalf("round 1 requestState empty under WithRequestStateSigning")
+	}
+
+	r2 := statelessToolsCall(t, url, "test_input_required_result_elicitation", map[string]any{
+		"inputResponses": map[string]any{
+			"user_name": map[string]any{"action": "accept", "content": map[string]any{"name": "Alice"}},
+		},
+		"requestState": state1 + "-TAMPERED",
+	})
+	if r2.Error == nil {
+		t.Fatalf("expected JSON-RPC error for tampered requestState; got result %v", r2.Result)
+	}
+}

--- a/server/prompts_input_required_test.go
+++ b/server/prompts_input_required_test.go
@@ -1,0 +1,182 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	core "github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/server/stateless"
+)
+
+// SEP-2322 input_required on prompts/get.
+//
+// The upstream conformance scenario `input-required-result-non-tool-request`
+// drives a prompts/get call against a fixture prompt that returns an
+// InputRequiredResult on round 1 and a complete GetPromptResult on round 2
+// (after the client echoes inputResponses). Both wires must support the
+// flow.
+
+// registerInputRequiredPrompt registers a prompt that asks for one
+// elicitation input on the first call and returns a greeting on the
+// second.
+func registerInputRequiredPrompt(t *testing.T, s *Server) {
+	t.Helper()
+	if err := s.Registry().AddPrompt(
+		core.PromptDef{
+			Name:        "test_input_required_result_prompt",
+			Description: "Prompts the client for a context value, then builds a templated prompt around it.",
+		},
+		func(ctx core.PromptContext, _ core.PromptRequest) (core.PromptResponse, error) {
+			if !ctx.HasInputResponses() {
+				return ctx.RequestInput(core.InputRequests{
+					"user_context": core.InputRequest{
+						Method: "elicitation/create",
+						Params: json.RawMessage(`{"message":"What context should the prompt use?","requestedSchema":{"type":"object","properties":{"context":{"type":"string"}},"required":["context"]}}`),
+					},
+				})
+			}
+			raw := ctx.InputResponse("user_context")
+			var er struct {
+				Action  string `json:"action"`
+				Content struct {
+					Context string `json:"context"`
+				} `json:"content"`
+			}
+			if err := json.Unmarshal(raw, &er); err != nil {
+				return core.PromptResult{}, nil
+			}
+			return core.PromptResult{
+				Messages: []core.PromptMessage{{
+					Role:    "user",
+					Content: core.Content{Type: "text", Text: "Context: " + er.Content.Context},
+				}},
+			}, nil
+		},
+	); err != nil {
+		t.Fatalf("AddPrompt: %v", err)
+	}
+}
+
+// TestPromptsGet_StatelessMRTR_RoundTrip drives the upstream A9 shape over
+// the stateless wire: round 1 returns InputRequiredResult with non-empty
+// requestState; round 2 (same prompt, with inputResponses + the echoed
+// requestState) returns a complete GetPromptResult.
+func TestPromptsGet_StatelessMRTR_RoundTrip(t *testing.T) {
+	s := NewServer(core.ServerInfo{Name: "prompts-mrtr-test", Version: "0.0.1"})
+	registerInputRequiredPrompt(t, s)
+
+	handler := s.Handler(WithStreamableHTTP(true), WithStatelessMode(stateless.ModeDual))
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	postPromptsGet := func(extra map[string]any) *core.Response {
+		params := map[string]any{
+			"name": "test_input_required_result_prompt",
+			"_meta": map[string]any{
+				"io.modelcontextprotocol/protocolVersion":    draftVersion,
+				"io.modelcontextprotocol/clientInfo":         map[string]any{"name": "t", "version": "1"},
+				"io.modelcontextprotocol/clientCapabilities": map[string]any{"elicitation": map[string]any{}},
+			},
+		}
+		for k, v := range extra {
+			params[k] = v
+		}
+		resp := postStatelessJSON(t, ts.URL+"/mcp", map[string]any{
+			"jsonrpc": "2.0", "id": 1, "method": "prompts/get",
+			"params": params,
+		}, map[string]string{mcpProtocolVersionHeader: draftVersion})
+		return decode(t, resp)
+	}
+
+	r1 := postPromptsGet(nil)
+	if r1.Error != nil {
+		t.Fatalf("round 1 error: %+v", r1.Error)
+	}
+	m1, _ := r1.Result.(map[string]any)
+	if got := m1["resultType"]; got != "input_required" {
+		t.Fatalf("round 1 resultType = %v, want input_required", got)
+	}
+	reqs, ok := m1["inputRequests"].(map[string]any)
+	if !ok || reqs["user_context"] == nil {
+		t.Fatalf("round 1 inputRequests missing user_context: %v", m1)
+	}
+	state1, _ := m1["requestState"].(string)
+	if state1 == "" {
+		t.Fatalf("round 1 requestState empty (stateless wire dropped it)")
+	}
+
+	r2 := postPromptsGet(map[string]any{
+		"inputResponses": map[string]any{
+			"user_context": map[string]any{"action": "accept", "content": map[string]any{"context": "demo"}},
+		},
+		"requestState": state1,
+	})
+	if r2.Error != nil {
+		t.Fatalf("round 2 error: %+v", r2.Error)
+	}
+	m2, _ := r2.Result.(map[string]any)
+	if m2["resultType"] == "input_required" {
+		t.Fatalf("round 2 still input_required")
+	}
+	msgs, _ := m2["messages"].([]any)
+	if len(msgs) == 0 {
+		t.Fatalf("round 2 missing messages: %v", m2)
+	}
+	first, _ := msgs[0].(map[string]any)
+	content, _ := first["content"].(map[string]any)
+	text, _ := content["text"].(string)
+	if !strings.Contains(text, "demo") {
+		t.Errorf("round 2 text = %q, want substring \"demo\"", text)
+	}
+}
+
+// TestPromptsGet_LegacyMRTR_RoundTrip exercises the same A9 shape on the
+// legacy wire (initialize handshake + Mcp-Session-Id) so the new field on
+// PromptResult and the dispatch type-switch on PromptResponse are both
+// covered end-to-end.
+func TestPromptsGet_LegacyMRTR_RoundTrip(t *testing.T) {
+	s := NewServer(core.ServerInfo{Name: "prompts-mrtr-test", Version: "0.0.1"})
+	registerInputRequiredPrompt(t, s)
+
+	c := connectMRTRClient(t, s)
+
+	r1, err := c.Call("prompts/get", map[string]any{"name": "test_input_required_result_prompt"})
+	if err != nil {
+		t.Fatalf("round 1 call: %v", err)
+	}
+	var m1 map[string]any
+	if err := json.Unmarshal(r1.Raw, &m1); err != nil {
+		t.Fatalf("decode r1: %v", err)
+	}
+	if m1["resultType"] != "input_required" {
+		t.Fatalf("round 1 resultType = %v, want input_required; raw=%s", m1["resultType"], r1.Raw)
+	}
+	state1, _ := m1["requestState"].(string)
+	if state1 == "" {
+		t.Fatalf("round 1 requestState empty; raw=%s", r1.Raw)
+	}
+
+	r2, err := c.Call("prompts/get", map[string]any{
+		"name": "test_input_required_result_prompt",
+		"inputResponses": map[string]any{
+			"user_context": map[string]any{"action": "accept", "content": map[string]any{"context": "demo"}},
+		},
+		"requestState": state1,
+	})
+	if err != nil {
+		t.Fatalf("round 2 call: %v", err)
+	}
+	var m2 map[string]any
+	if err := json.Unmarshal(r2.Raw, &m2); err != nil {
+		t.Fatalf("decode r2: %v", err)
+	}
+	if m2["resultType"] == "input_required" {
+		t.Fatalf("round 2 still input_required; raw=%s", r2.Raw)
+	}
+	msgs, _ := m2["messages"].([]any)
+	if len(msgs) == 0 {
+		t.Fatalf("round 2 missing messages; raw=%s", r2.Raw)
+	}
+}

--- a/server/stateless/dispatch.go
+++ b/server/stateless/dispatch.go
@@ -102,7 +102,9 @@ func (d *Dispatcher) Dispatch(ctx context.Context, req *core.Request) *core.Resp
 	// Thread the validated envelope through ctx so handlers and
 	// downstream helpers (per-request cap checks, log-level gating)
 	// can read it without the Backend interface needing a getter.
-	ctx = withRequestMeta(ctx, meta)
+	// The ctx key lives in core so handler accessors like
+	// ctx.ClientCaps() can read it without an import cycle.
+	ctx = core.WithRequestMeta(ctx, meta)
 
 	switch req.Method {
 	case "server/discover":
@@ -152,24 +154,16 @@ func (d *Dispatcher) Dispatch(ctx context.Context, req *core.Request) *core.Resp
 	}
 }
 
-// requestMetaCtxKey is the unexported ctx key under which the validated
-// per-request _meta envelope is threaded to handlers and helpers.
-type requestMetaCtxKey struct{}
-
-// withRequestMeta attaches the validated envelope to ctx.
-func withRequestMeta(ctx context.Context, meta *core.RequestMeta) context.Context {
-	return context.WithValue(ctx, requestMetaCtxKey{}, meta)
-}
-
 // RequestMetaFromContext returns the validated SEP-2575 _meta envelope
 // attached to ctx by the stateless dispatcher, or nil if the call did
-// not arrive over the stateless wire. Handlers that need to gate on
-// per-request caps should prefer core.ClientSupportsExtensionForRequest;
-// this accessor is for the rare path that needs protocolVersion or
-// clientInfo directly.
+// not arrive over the stateless wire. Thin re-export of
+// core.RequestMetaFromContext so packages already importing
+// server/stateless don't need to add a core import for this one accessor.
+//
+// Handlers that just want to know whether a capability is declared
+// should prefer the typed ctx.ClientCaps() accessor on ToolContext or
+// PromptContext; this raw view is for the rare path that needs
+// protocolVersion or clientInfo directly.
 func RequestMetaFromContext(ctx context.Context) *core.RequestMeta {
-	if v, ok := ctx.Value(requestMetaCtxKey{}).(*core.RequestMeta); ok {
-		return v
-	}
-	return nil
+	return core.RequestMetaFromContext(ctx)
 }

--- a/server/stateless/dispatch_test.go
+++ b/server/stateless/dispatch_test.go
@@ -278,7 +278,7 @@ func TestRequestMetaFromContext(t *testing.T) {
 		t.Errorf("RequestMetaFromContext(bare) = %+v, want nil", got)
 	}
 	meta := &core.RequestMeta{ProtocolVersion: "DRAFT-2026-v1"}
-	ctx := withRequestMeta(context.Background(), meta)
+	ctx := core.WithRequestMeta(context.Background(), meta)
 	if got := RequestMetaFromContext(ctx); got != meta {
 		t.Errorf("RequestMetaFromContext: got %+v, want %+v", got, meta)
 	}

--- a/server/stateless/handlers.go
+++ b/server/stateless/handlers.go
@@ -166,6 +166,25 @@ type promptsGetEnvelope struct {
 }
 
 func (d *Dispatcher) handlePromptsGet(ctx context.Context, id json.RawMessage, params json.RawMessage) *core.Response {
+	// Prefer the middleware-aware path so server-level middleware fires
+	// uniformly on the stateless wire AND so the MRTR envelope
+	// (inputResponses + requestState) is decoded and the requestState
+	// minted by the backend's shared mrtrRuntime. Backends that don't
+	// carry middleware return ok=false and we fall back to the direct
+	// invocation below — used by minimal test fakes only.
+	req := &core.Request{
+		JSONRPC: "2.0",
+		ID:      id,
+		Method:  "prompts/get",
+		Params:  params,
+	}
+	if resp, ok := d.Backend.InvokeWithMiddleware(ctx, req); ok {
+		return resp
+	}
+
+	// Fallback path (test fakes with no middleware support): no MRTR
+	// envelope handling, no requestState signing — just look up the
+	// prompt and invoke directly.
 	var env promptsGetEnvelope
 	if err := json.Unmarshal(params, &env); err != nil {
 		return core.NewErrorResponse(id, core.ErrCodeInvalidParams,

--- a/server/stateless_backend.go
+++ b/server/stateless_backend.go
@@ -243,6 +243,8 @@ func (b *statelessBackend) InvokeWithMiddleware(ctx context.Context, req *core.R
 		switch req.Method {
 		case "tools/call":
 			return b.callToolForStateless(ctx, req), nil
+		case "prompts/get":
+			return b.callPromptForStateless(ctx, req), nil
 		default:
 			if h, ok := b.s.dispatcher.customHandlers[req.Method]; ok {
 				return h(core.NewMethodContext(ctx), req.ID, req.Params), nil
@@ -343,6 +345,56 @@ func (b *statelessBackend) callToolForStateless(ctx context.Context, req *core.R
 	// SEP-2322 reshape: an InputRequiredResult variant gets a freshly-minted
 	// requestState carrying the merged accumulated answers so the next round
 	// sees them too. Every other ToolResponse flows through as-is.
+	switch r := result.(type) {
+	case core.InputRequiredResult:
+		return core.NewResponse(req.ID, core.InputRequiredResult{
+			InputRequests: r.InputRequests,
+			RequestState:  b.s.dispatcher.mrtr.mintRequestState(env.Name, mergedResponses),
+		})
+	default:
+		return core.NewResponse(req.ID, result)
+	}
+}
+
+// callPromptForStateless mirrors callToolForStateless above on the
+// prompts/get surface: decode the SEP-2322 MRTR envelope, verify+merge
+// requestState via the shared mrtrRuntime, populate PromptContext with
+// the MRTR view, and reshape any handler-returned InputRequiredResult
+// (PromptResponse variant) with a freshly-minted requestState. SEP-2322
+// scopes the input-required flow to any request method whose response
+// shape can accept it — prompts/get is the canonical second surface and
+// the conformance scenario `input-required-result-non-tool-request`
+// exercises it.
+func (b *statelessBackend) callPromptForStateless(ctx context.Context, req *core.Request) *core.Response {
+	var env promptsGetEnvelope
+	if err := json.Unmarshal(req.Params, &env); err != nil {
+		return core.NewErrorResponse(req.ID, core.ErrCodeInvalidParams,
+			"invalid prompts/get params: "+err.Error())
+	}
+	_, handler, ok := b.Prompt(env.Name)
+	if !ok {
+		return core.NewErrorResponse(req.ID, core.ErrCodeInvalidParams,
+			"unknown prompt: "+env.Name)
+	}
+
+	prevState, err := b.s.dispatcher.mrtr.verifyRequestState(env.RequestState, env.Name)
+	if err != nil {
+		return core.NewErrorResponse(req.ID, core.ErrCodeInvalidParams,
+			"invalid requestState: "+err.Error())
+	}
+	mergedResponses := mergeInputResponses(prevState.Answered, env.InputResponses)
+
+	pc := core.NewPromptContextWithMRTR(ctx, mergedResponses, env.RequestState)
+	result, err := handler(pc, core.PromptRequest{
+		Name:           env.Name,
+		Arguments:      env.Arguments,
+		InputResponses: mergedResponses,
+		RequestState:   env.RequestState,
+	})
+	if err != nil {
+		return core.NewErrorResponse(req.ID, core.ErrCodePromptError, err.Error())
+	}
+
 	switch r := result.(type) {
 	case core.InputRequiredResult:
 		return core.NewResponse(req.ID, core.InputRequiredResult{

--- a/server/stateless_backend.go
+++ b/server/stateless_backend.go
@@ -268,15 +268,24 @@ func (b *statelessBackend) InvokeWithMiddleware(ctx context.Context, req *core.R
 	return resp, true
 }
 
-// callToolForStateless replicates the decode → look-up → invoke → translate
-// flow that stateless.handleToolsCall used to do directly. Kept here so the
-// stateless dispatcher's per-method file stays thin and the middleware-aware
-// path lives next to the rest of the Backend impl.
+// callToolForStateless mirrors the legacy Dispatcher.handleToolsCall MRTR
+// flow on the stateless wire: decode the full SEP-2322 envelope
+// (inputResponses + requestState alongside the tool name + arguments),
+// verify the echoed requestState through the shared mrtrRuntime, merge
+// accumulated answers from prior rounds into the current call, populate
+// ToolContext with the merged view, and reshape any handler-returned
+// InputRequiredResult into a wire response that carries a freshly-minted
+// requestState. Without this parity the stateless tools/call path strips
+// every MRTR field on entry, which is why upstream's input-required-result-*
+// conformance scenarios fail with "Expected InputRequiredResult..." before
+// this change.
+//
+// progressToken is read off the same envelope (params._meta.progressToken),
+// not the SEP-2575 _meta envelope (which is for protocolVersion / clientInfo
+// / clientCapabilities). The stateless dispatcher's _meta validation runs
+// upstream of this call so we don't re-validate here.
 func (b *statelessBackend) callToolForStateless(ctx context.Context, req *core.Request) *core.Response {
-	var env struct {
-		Name      string          `json:"name"`
-		Arguments json.RawMessage `json:"arguments,omitempty"`
-	}
+	var env toolsCallEnvelope
 	if err := json.Unmarshal(req.Params, &env); err != nil {
 		return core.NewErrorResponse(req.ID, core.ErrCodeInvalidParams,
 			"invalid tools/call params: "+err.Error())
@@ -286,9 +295,30 @@ func (b *statelessBackend) callToolForStateless(ctx context.Context, req *core.R
 		return core.NewErrorResponse(req.ID, core.ErrCodeInvalidParams,
 			"unknown tool: "+env.Name)
 	}
-	result, err := handler(core.NewToolContext(ctx), core.ToolRequest{
-		Name:      env.Name,
-		Arguments: env.Arguments,
+
+	// SEP-2322: verify the echoed requestState (rejects tampered or expired
+	// tokens before the handler ever runs) and pull out the accumulated
+	// inputResponses carried inside it from prior rounds.
+	prevState, err := b.s.dispatcher.mrtr.verifyRequestState(env.RequestState, env.Name)
+	if err != nil {
+		return core.NewErrorResponse(req.ID, core.ErrCodeInvalidParams,
+			"invalid requestState: "+err.Error())
+	}
+	mergedResponses := mergeInputResponses(prevState.Answered, env.InputResponses)
+
+	var progressToken any
+	if env.Meta != nil {
+		progressToken = env.Meta.ProgressToken
+	}
+
+	tc := core.NewToolContextWithMRTR(ctx, progressToken, mergedResponses, env.RequestState)
+	result, err := handler(tc, core.ToolRequest{
+		Name:           env.Name,
+		Arguments:      env.Arguments,
+		RequestID:      req.ID,
+		InputResponses: mergedResponses,
+		RequestState:   env.RequestState,
+		ProgressToken:  progressToken,
 	})
 	if err != nil {
 		var missing *core.MissingCapabilityError
@@ -309,5 +339,17 @@ func (b *statelessBackend) callToolForStateless(ctx context.Context, req *core.R
 		// the task as `completed` with isError, per spec — not as `failed`.
 		result = core.ErrorResult(fmt.Sprintf("tool %q: %v", env.Name, err))
 	}
-	return core.NewResponse(req.ID, result)
+
+	// SEP-2322 reshape: an InputRequiredResult variant gets a freshly-minted
+	// requestState carrying the merged accumulated answers so the next round
+	// sees them too. Every other ToolResponse flows through as-is.
+	switch r := result.(type) {
+	case core.InputRequiredResult:
+		return core.NewResponse(req.ID, core.InputRequiredResult{
+			InputRequests: r.InputRequests,
+			RequestState:  b.s.dispatcher.mrtr.mintRequestState(env.Name, mergedResponses),
+		})
+	default:
+		return core.NewResponse(req.ID, result)
+	}
 }


### PR DESCRIPTION
## What changes

Brings mcpkit to full SEP-2322 (input-required-result / "MRTR") conformance on both server and client surfaces, on both the legacy and SEP-2575 stateless wires. The `input-required-result-*` family of upstream conformance scenarios flips from largely-failing to fully-passing; the `sep-2322-client-request-state` client scenario flips too. The pre-existing `mrtr-tasks-composition` scenario (introduced in #484, previously passing only on legacy) now passes on stateless as well — same root cause, fixed once.

Layered on top of #486's sealed-interface refactor: `InputRequiredResult` is now a `PromptResponse` variant in addition to `ToolResponse`, and prompt handlers can return it directly without any new flag fields on `PromptResult`.

## Reviewer's guide

Read in this order. Each commit is a fail-then-pass cycle; reviewing per-commit is cheaper than reviewing the squashed diff.

1. [server/stateless_backend.go](https://github.com/panyam/mcpkit/pull/492/files#diff-d6054c7923eaa9651736c3c6bccd7e7634dbf33d4bdfa89a5a34e069bb4b620e) `callToolForStateless` — start here. **G1: stateless tools/call MRTR parity.** The legacy `Dispatcher.handleToolsCall` already decoded `inputResponses` + `requestState`, verified+merged via `mrtrRuntime`, populated `ToolContext`, and reshaped `InputRequiredResult` responses; the stateless analog did none of that. This commit mirrors the legacy flow field-for-field. Without it every scenario in this PR is dead on arrival.
2. [server/mrtr_stateless_test.go](https://github.com/panyam/mcpkit/pull/492/files#diff-9579cffbd0aa6d5a2a04e5b00e1652ddc07d01840476e23b05941191ba835dd1) — acceptance for #1. Round-trip + tampered-state coverage over raw HTTP.
3. [core/mrtr.go](https://github.com/panyam/mcpkit/pull/492/files#diff-e35e8e196366177f5fbc1038f83e79bb201533c23472c8df64ad47e213d9becf) `promptResponse()` — **G2a.** One-line marker so `InputRequiredResult` satisfies `PromptResponse`. Sealed-interface refactor (#486) made this trivial.
4. [core/handler_context.go](https://github.com/panyam/mcpkit/pull/492/files#diff-b3a3b2b8bf11bb86d8a8e1e60213e581011ae6a264a9923034d1db6a1d6d39e2) PromptContext changes + [server/dispatch.go](https://github.com/panyam/mcpkit/pull/492/files#diff-7640bcbef23148a16e477c63c7092f0ba89780f5278a9d6ba6ed513d62f68a92) `handlePromptsGet` + [server/stateless_backend.go](https://github.com/panyam/mcpkit/pull/492/files#diff-d6054c7923eaa9651736c3c6bccd7e7634dbf33d4bdfa89a5a34e069bb4b620e) `callPromptForStateless` — **G2b: prompts/get gains MRTR on both wires.** PromptContext gains the same `RequestInput`/`HasInputResponses`/`InputResponse(key)`/`InputResponses()`/`RequestState()` accessors ToolContext already has. The stateless prompts/get path now routes through `Backend.InvokeWithMiddleware` so the shared `mrtrRuntime` is reachable from a single code path.
5. [server/prompts_input_required_test.go](https://github.com/panyam/mcpkit/pull/492/files#diff-fc38def7488e2e32514d494728290b473d311fbcf3bf9508f5e5288847ddd617) — acceptance for #4. Both wires end-to-end.
6. [core/session.go](https://github.com/panyam/mcpkit/pull/492/files#diff-c68b728b1cf91034910b91c454c49c5c378b7a8e767a4cc0aafc2f4554eef8b9) `WithRequestMeta`/`RequestMetaFromContext` + [core/handler_context.go](https://github.com/panyam/mcpkit/pull/492/files#diff-b3a3b2b8bf11bb86d8a8e1e60213e581011ae6a264a9923034d1db6a1d6d39e2) `BaseContext.ClientCaps()` — **G3.** Lifts the SEP-2575 `_meta` ctx key out of `server/stateless` into `core` so handler accessors can read it without an import cycle, then exposes a single `ctx.ClientCaps()` that returns the per-request envelope's caps when present (stateless) or session caps (legacy). Used by the cap-gating capability-check fixture.
7. [core/mrtr.go](https://github.com/panyam/mcpkit/pull/492/files#diff-e35e8e196366177f5fbc1038f83e79bb201533c23472c8df64ad47e213d9becf) `NewListRootsInputRequest`/`DecodeListRootsInputResponse` — **G4.** Roots/list completes the helper trio that sampling/elicitation already had.
8. [cmd/testserver/conformance_input_required.go](https://github.com/panyam/mcpkit/pull/492/files#diff-270bb3189252a34897f909215979b2eb0b8e79cadc9494c1a83708ff2908e0b0) (new) + [cmd/testserver/main.go](https://github.com/panyam/mcpkit/pull/492/files#diff-92b7ee1829b9cea6c07719322ab77fbd8760f2f2a785c8b8af8044bd8614db1a) — **G5.** Registers the 8 fixture tools + 1 fixture prompt the upstream `input-required-result-*` scenarios call by name. Enables `WithRequestStateSigning` so the tampered-state scenario has integrity to fail against.
9. [cmd/testclient/sep2322.go](https://github.com/panyam/mcpkit/pull/492/files#diff-a75d49abc7254a3aff3dff9c37ea786aa641a4be61df5c74b1c5744c00758898) (new) + [cmd/testclient/main.go](https://github.com/panyam/mcpkit/pull/492/files#diff-bc7a02b2751e1c671ee37f491a72c42030bf2566f6d0496f30ae2a0ab19ffaae) — **G6.** Raw-HTTP driver for `sep-2322-client-request-state`. The upstream fixture is a bare HTTP JSON-RPC endpoint with no MCP initialize handshake, so mcpkit's connected `client.Client` doesn't apply; the driver POSTs directly and exercises the MRTR retry contract the scenario grades.
10. [conformance/UPSTREAM_AUDIT.md](https://github.com/panyam/mcpkit/pull/492/files#diff-bf63f1699e28f43c702f9450df02d9e8ec1dae36200827f929a68513bdb34197) — regenerated.

Skim or skip: [server/stateless/dispatch.go](https://github.com/panyam/mcpkit/pull/492/files#diff-1b101922de172cda20b6a044eae5a4fc36b2dce82e136a566765bae575a42b20) (mechanical move of the ctx-key delegation to core), [server/stateless/dispatch_test.go](https://github.com/panyam/mcpkit/pull/492/files#diff-142d78847d857a6f7083f283917a07fddee55361a32caa97869972c3b4e2a506) (one-line `withRequestMeta` → `core.WithRequestMeta` update), [core/mrtr_test.go](https://github.com/panyam/mcpkit/pull/492/files#diff-fe76fd75444e43b8531ce39d310a969c3ba0a13884c8469c9094e0dc013ff1af) / [core/stateless_test.go](https://github.com/panyam/mcpkit/pull/492/files#diff-1393014576ef43e1befe8e54e173c368f9608a8191221205f74d2baba03d625c) (assertion additions for the new helpers).

Background reading (no diff in this PR but load-bearing for understanding what's documented vs implemented):
- [`docs/MRTR_TUTORIAL.md`](https://github.com/panyam/mcpkit/blob/main/docs/MRTR_TUTORIAL.md) — written ahead of this PR; covers the per-wire menu source, `progressToken` plumbing, capability gating model. The implementation here finally matches the doc.
- [`docs/TASKS_TUTORIAL.md`](https://github.com/panyam/mcpkit/blob/main/docs/TASKS_TUTORIAL.md) — the SEP-2663 / GoAsync side that mrtr-tasks-composition exercises.

## Decision log

- **PromptContext API mirrors ToolContext exactly.** Same accessor names (`RequestInput`, `HasInputResponses`, `InputResponse`, `InputResponses`, `RequestState`). Cost is small; the cross-surface ergonomic win for handler authors is real. Preempts the "why is the prompt API different?" question.
- **stateless `prompts/get` routes through `Backend.InvokeWithMiddleware`** instead of growing a new Backend method. Cleanest seam to reach the shared `mrtrRuntime` from `server/stateless`, and gives prompts/get the same middleware story tools/call has. `taskV2Middleware` short-circuits on non-tools/call so existing middleware semantics are untouched.
- **`core.WithRequestMeta`/`core.RequestMetaFromContext` lifted out of `server/stateless`.** Needed for `BaseContext.ClientCaps()` to read per-request caps without an import cycle. The stateless package's `RequestMetaFromContext` becomes a thin re-export to avoid churn at existing call sites.
- **`ClientCaps()` lives on `BaseContext`, not just `ToolContext`/`PromptContext`.** Same accessor available to resource and method handlers for free — the cap-gating concern isn't specific to any one handler type.
- **testclient drives the SEP-2322 client scenario with raw HTTP.** The upstream fixture serves bare JSON-RPC with no MCP initialize / server/discover, so mcpkit's connected `Client` can't speak to it. Inline driver is ~150 LOC and matches the fixture's intentional minimalism. Tried `ClientModeStateless` first — fails because the fixture also doesn't implement `server/discover`.
- **`examples/mrtr/` left on its old `test_incomplete_result_*` tool names.** That fixture targets the `panyam/mcpconformance` `feat/tasks-mrtr-extension` fork branch; the audit drives `cmd/testserver` instead. Renaming would cascade into the fork. Will rename when the fork rebases to upstream-main.

## Risk / blast radius

- **Affects:** every `tools/call` and `prompts/get` request on both wires. New MRTR plumbing is gated on the envelope carrying `inputResponses`/`requestState` — calls without those fields go through the same code path as before (the merge helper returns nil when both inputs are empty, and the type-switch's default arm hands the response through unchanged). The pre-existing `make test` + `make testconf` + `make testconf-stateless` + `make testconf-mrtr` + `make testconf-tasks-v2` suites are all green post-merge.
- **Pressure-test:** the dispatch path now type-switches on `core.ToolResponse` for tools/call and `core.PromptResponse` for prompts/get. Future variants (e.g., a `CreateTaskResult`-returning prompt) need a case added to both `server/dispatch.go` and `server/stateless_backend.go`. Today only `InputRequiredResult` has the second-surface treatment; `PromptResult` (the default) flows through the `default:` arm.
- **MRTR token signing:** testserver now ships with a static dev key. Production servers should configure their own via `server.WithRequestStateSigning`. The plaintext mode is still available (omit the option) for tests and demos.

## Before / after

`conformance/UPSTREAM_AUDIT.md` summary:

| Surface | Pass before | Pass after | Fail before | Fail after |
|---|---:|---:|---:|---:|
| Server | 78 | 105 | 21 | 8 |
| Client | 447 | 452 | 25 | 20 |

SEP-2322 row-by-row: 4/14 server scenarios passing before this PR; 14/14 passing after. `sep-2322-client-request-state`: 5 fail → 5 pass.

## Out of scope

- The remaining 8 server fails / 20 client fails in the audit are unrelated SEPs (SEP-2549 caching, SEP-1613 schema preservation gaps, auth scenarios). Each is tracked elsewhere or worth its own issue.
- Renaming `examples/mrtr/`'s tool fixtures to the upstream-main names — gated on the `panyam/mcpconformance` fork rebase, separate concern.

Closes #452. Builds on #486.
