### PR TITLE
fix(testserver): enable SEP-2549 caching hints — closes upstream caching scenario

### DIFF
--- a/cmd/testserver/main.go
+++ b/cmd/testserver/main.go
@@ -55,6 +55,17 @@ func main() {
 		// for a conformance testserver — production deployments would
 		// inject the key via environment or secret manager.
 		server.WithRequestStateSigning([]byte("testserver-conformance-key-32-bytes-min"), 0),
+		// SEP-2549 caching hints. The upstream `caching` conformance
+		// scenario verifies that tools/list, prompts/list, resources/list,
+		// resources/templates/list, AND resources/read responses ALL carry
+		// `ttlMs` (non-negative int) + `cacheScope` ("public" | "private").
+		// 60s is the same default the existing examples/list-ttl fixture
+		// uses; public scope is correct for tools/prompts/resources lists
+		// because the catalog doesn't vary per caller. resources/read
+		// content frequently does, so its default is private — handlers
+		// can still override per-read via ResourceResult.CacheScope.
+		server.WithListCacheControl(60_000, core.CacheScopePublic),
+		server.WithReadResourceCacheControl(60_000, core.CacheScopePrivate),
 	)
 	// Enable HTTP-level request logging if VERBOSE is set
 	if os.Getenv("VERBOSE") == "1" {

--- a/conformance/UPSTREAM_AUDIT.md
+++ b/conformance/UPSTREAM_AUDIT.md
@@ -13,9 +13,9 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 
 | Surface | Scenarios | Checks | Pass | Fail | Warn | Info | Skipped | Harness-gap |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|
-| Server | 51 | 135 | 105 | 8 | 7 | 6 | 9 | 0 |
+| Server | 51 | 135 | 112 | 1 | 7 | 6 | 9 | 0 |
 | Client | 40 | 1241 | 452 | 20 | 4 | 759 | 6 | 1 |
-| **Total** | **91** | **1376** | **557** | **28** | **11** | **765** | **15** | **1** |
+| **Total** | **91** | **1376** | **564** | **21** | **11** | **765** | **15** | **1** |
 
 ## Harness gaps
 
@@ -201,7 +201,7 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 
 | Scenario | Surface | Status | Checks | Note |
 |---|---|---|---|---|
-| `caching` | server | fail | 7 fail | `tools/list response missing ttlMs; tools/list response missing cacheScope` |
+| `caching` | server | pass | 7 pass |  |
 
 ### [SEP-2575](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2575) (1 scenarios)
 


### PR DESCRIPTION
## Summary

The upstream `caching` server conformance scenario was failing 7/7 checks with `tools/list response missing ttlMs; tools/list response missing cacheScope`. mcpkit **ships** SEP-2549 (the library exposes `WithListCacheControl` and `WithReadResourceCacheControl`, the fork's `make testconf-list-ttl` passes 5/5) — but `cmd/testserver`, the binary the upstream audit drives, was never configured to enable the hints. Pure fixture-config gap; no library change.

## Reviewer's guide

1. [cmd/testserver/main.go](https://github.com/panyam/mcpkit/pull/495/files#diff-92b7ee1829b9cea6c07719322ab77fbd8760f2f2a785c8b8af8044bd8614db1a) — start here. Two new server option lines under the existing `WithRequestStateSigning` block:
   - `WithListCacheControl(60_000, core.CacheScopePublic)` — applies `ttlMs` + `cacheScope` to `tools/list`, `prompts/list`, `resources/list`, `resources/templates/list`. Public scope because catalogs don't vary per caller.
   - `WithReadResourceCacheControl(60_000, core.CacheScopePrivate)` — applies the same fields to `resources/read`. Private scope because read content frequently varies per caller; handlers can still override per-read via `ResourceResult.CacheScope`.
2. [conformance/UPSTREAM_AUDIT.md](https://github.com/panyam/mcpkit/pull/495/files#diff-bf63f1699e28f43c702f9450df02d9e8ec1dae36200827f929a68513bdb34197) — regenerated. Caching row flips `fail` → `pass`; server passing-checks total goes 105 → 112.

Skim or skip: just those two files.

## Decision log

- **60s TTL chosen to match `examples/list-ttl`.** The fork-based `make testconf-list-ttl` fixture already uses 60s as its default and passes upstream's stricter sentinel checks; keeping `cmd/testserver` consistent means one less number to remember.
- **No library change.** The conformance audit's `make testconf-list-ttl` was already green against `examples/list-ttl` — the library's caching plumbing works. The gap was purely that `cmd/testserver` (the binary the upstream audit drives) wasn't wiring the options. Confirmed by POSTing `tools/list` against an unmodified `cmd/testserver` pre-fix and observing the response lacked both fields.
- **`scope=public` on lists, `scope=private` on reads.** Lists return server-wide catalogs (same for every caller). Reads frequently return content scoped to the authenticated user. The split matches the security guidance in `docs/LIST_TTL_MIGRATION.md`.

## Risk / blast radius

- **Affects:** `cmd/testserver` only (the conformance audit driver). No production code touched; library behavior is unchanged.
- **Tests covering this:** `make testconf-upstream-audit` regenerates the report — caching flips 7 fail → 7 pass; every other scenario stays where it was. `make test` is green post-change (core/server/client/stateless).
- **Be paranoid about:** the one remaining server fail in the audit is `server-stateless` (fork-covered, known upstream-test bug per `CLAUDE.md` — the array-vs-object `requiredCapabilities` check). Not a regression from this PR; pre-existing.

## Before / after

| | Before | After |
|---|---|---|
| `caching` server scenario | fail 7/7 | pass 7/7 |
| Server passing checks (audit) | 105 | 112 |
| Server failing checks (audit) | 8 | 1 (`server-stateless`, pre-existing known) |

## Out of scope

- Remaining audit gaps (auth client issuer-normalization 7 scenarios × 1 fail, `http-standard-headers` 5 fails tracked in #461, `request-metadata` harness-gap tracked in #453, `initialize` client 1 fail). All separate.
