### PR TITLE
fix(scripts): build testserver before launch so $! is the actual fixture PID

### DIFF
--- a/scripts/apps-playwright-test.sh
+++ b/scripts/apps-playwright-test.sh
@@ -59,9 +59,15 @@ if lsof -ti:$PORT >/dev/null 2>&1; then
     sleep 1
 fi
 
-# Start mcpkit test server
+# Build the testserver binary, then run it directly. `go run` spawns the
+# compiled binary as a separate macOS child process; killing the wrapper
+# leaves the child orphaned, which hangs make after a successful test.
+# See scripts/conformance-test.sh for the same fix.
+echo "Building mcpkit test server..."
+go build -o cmd/testserver/testserver ./cmd/testserver
+
 echo "Starting mcpkit test server on port $PORT..."
-STREAMABLE=1 PORT=$PORT go run ./cmd/testserver &
+STREAMABLE=1 PORT=$PORT ./cmd/testserver/testserver &
 SERVER_PID=$!
 
 # Wait for server readiness

--- a/scripts/conformance-test.sh
+++ b/scripts/conformance-test.sh
@@ -37,8 +37,18 @@ if lsof -i ":$PORT" -t >/dev/null 2>&1; then
     sleep 1
 fi
 
+echo "=== Building test server ==="
+# Build first, then run the binary directly. Previously this script used
+# `go run ./cmd/testserver &` and captured $! — but on macOS `go run` spawns
+# the compiled binary as a separate child, so killing $SERVER_PID at cleanup
+# leaves the child as an orphan that hangs `make testconf` after a
+# successful run (the npm conformance harness exits clean, but make waits
+# on the lingering testserver). Building to a binary makes $! unambiguously
+# the fixture PID, matching the pattern testconf-tasks already uses.
+go build -o cmd/testserver/testserver ./cmd/testserver
+
 echo "=== Starting test server on :$PORT (Streamable HTTP) ==="
-STREAMABLE=1 PORT=$PORT go run ./cmd/testserver &
+STREAMABLE=1 PORT=$PORT ./cmd/testserver/testserver &
 SERVER_PID=$!
 
 # Wait for server to be ready

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -26,8 +26,14 @@ echo "==============================="
 echo "=== SSE TRANSPORT TESTS     ==="
 echo "==============================="
 
+# Build once, reuse for both SSE and Streamable HTTP launches below.
+# Avoids the `go run` orphan-child pattern described in
+# scripts/conformance-test.sh.
+echo "=== Building test server ==="
+go build -o cmd/testserver/testserver ./cmd/testserver
+
 echo "=== Starting SSE test server on :$SSE_PORT ==="
-PORT=$SSE_PORT go run ./cmd/testserver &
+PORT=$SSE_PORT ./cmd/testserver/testserver &
 PIDS+=($!)
 sleep 2
 
@@ -76,7 +82,7 @@ echo "=== STREAMABLE HTTP TESTS   ==="
 echo "==============================="
 
 echo "=== Starting Streamable HTTP test server on :$STREAMABLE_PORT ==="
-STREAMABLE=1 PORT=$STREAMABLE_PORT go run ./cmd/testserver &
+STREAMABLE=1 PORT=$STREAMABLE_PORT ./cmd/testserver/testserver &
 PIDS+=($!)
 sleep 2
 


### PR DESCRIPTION
## Summary

`make testconf` was reliably hanging for tens of minutes after printing `=== CONFORMANCE TESTS PASSED ===`. The npm conformance harness exited cleanly, but make sat waiting on an orphaned testserver child process. Killing the orphan unblocked make every time. This PR fixes the launch pattern in the three scripts that were susceptible to it.

## Reviewer's guide

1. [scripts/conformance-test.sh](https://github.com/panyam/mcpkit/pull/497/files#diff-530d263b9262685a3ca410499eb5f50f3ec82bc09802c470fb389bfeef99d9b7) — start here. Adds a `go build -o cmd/testserver/testserver ./cmd/testserver` step before the background launch, then runs the binary directly (`./cmd/testserver/testserver &`) instead of `go run ./cmd/testserver &`. The new comment explains *why* — link bait for future-me when grep shows the unusual idiom.
2. [scripts/apps-playwright-test.sh](https://github.com/panyam/mcpkit/pull/497/files#diff-cf9f5d63ce556d2e70d89507d6cd8c44b110f80d606ce4a1ea698d2f528db7aa) — same shape, same fix; references the conformance-test.sh comment so the explanation lives in one place.
3. [scripts/smoke-test.sh](https://github.com/panyam/mcpkit/pull/497/files#diff-885c10d33923b48e6e7205bf336fa032fb220a3b241c01cb37a3bdf21228f7eb) — same fix in two places (one for SSE, one for Streamable HTTP). Both launches reuse the single build.

Skim or skip: just those three files.

## Decision log

- **Why `go build` then run the binary, not `go run`?** On macOS, `go run` compiles the binary and spawns it as a separate child rather than exec'ing in place. `$!` captures the `go run` wrapper PID. At cleanup, `kill "$SERVER_PID"` terminates the wrapper — which has often already exited or moved on — leaving the testserver binary as an orphan owned by init (ppid 1), holding the port and keeping make alive. Building first means `$!` is unambiguously the fixture PID. The same idiom already works in `conformance/Makefile`'s `testconf-tasks` target.
- **Why build into `cmd/testserver/testserver` rather than a tmpdir?** That path is already in `.gitignore` (added in PR #494). It also matches what `go build .` inside `cmd/testserver/` would produce, so the binary lives where a developer would expect to find it. Re-running the script overwrites the binary cleanly.
- **Why not switch to process-group kill?** Considered `kill -- -$SERVER_PID` to nuke the whole process group. Doesn't help here because the orphaned testserver gets reparented to init *before* cleanup runs — by then it's no longer in the group. Building the binary is simpler and addresses the root cause.

## Risk / blast radius

- **Affects:** the three conformance/smoke scripts only. No production code touched.
- **Tests covering this:** verified by re-running `make -C conformance testconf` after the fix. Suite exits 0, "Server shut down gracefully" appears, no orphan testserver remains, port 18799 is freed. Previously this same command hung 25+ minutes.
- **Be paranoid about:** the `cmd/testserver/testserver` binary now gets built on every `make testconf` run. Build is fast (a few seconds) and idempotent; downside is one extra file in the working tree (already gitignored).

## Before / after

| | Before | After |
|---|---|---|
| `make -C conformance testconf` exit time after `PASSED` | 25+ minutes (hung on orphan), needed manual `kill` | <1s, "Server shut down gracefully" then exit 0 |
| Orphaned testserver after run | Yes (owned by init, holding port) | No |
| Tests pass count | 40/40 | 40/40 (unchanged) |

## Out of scope

- The deeper question of "why does mcpkit's testserver need conformance-specific options at all" is filed as #496. This PR just fixes the script bug.
