### PR TITLE
server: enforce Mcp-Name on tasks/{get,update,cancel} (SEP-2663)

### DIFF
--- a/server/header_validation.go
+++ b/server/header_validation.go
@@ -81,6 +81,16 @@ func extractRoutingName(req *core.Request) (field, value string, ok bool) {
 			return "uri", "", true
 		}
 		return "uri", p.URI, true
+	case "tasks/get", "tasks/update", "tasks/cancel":
+		// SEP-2663 elevates Mcp-Name: <taskId> to a required client
+		// header on these methods, so SEP-2243's universal MUST applies.
+		var p struct {
+			TaskID string `json:"taskId"`
+		}
+		if err := json.Unmarshal(req.Params, &p); err != nil {
+			return "taskId", "", true
+		}
+		return "taskId", p.TaskID, true
 	default:
 		return "", "", false
 	}

--- a/server/header_validation_test.go
+++ b/server/header_validation_test.go
@@ -121,3 +121,41 @@ func TestValidateRoutingHeaders_MismatchedResourcesReadURI(t *testing.T) {
 		t.Fatalf("expected -32001 HeaderMismatch for URI mismatch, got %+v", resp)
 	}
 }
+
+// SEP-2663 elevates Mcp-Name: <taskId> to a required client header on
+// tasks/get, tasks/update, and tasks/cancel. The SEP-2243 universal
+// MUST therefore applies — server rejects mismatched or missing
+// Mcp-Name with -32001 HeaderMismatch.
+func TestValidateRoutingHeaders_TasksMethodsCarryTaskID(t *testing.T) {
+	for _, method := range []string{"tasks/get", "tasks/update", "tasks/cancel"} {
+		method := method
+		t.Run(method+"/matched", func(t *testing.T) {
+			req := makeReq(t, method, map[string]any{"taskId": "task-abc"})
+			h := http.Header{}
+			h.Set("Mcp-Method", method)
+			h.Set("Mcp-Name", "task-abc")
+			if resp := validateRoutingHeaders(req, h); resp != nil {
+				t.Fatalf("matched Mcp-Name should pass, got %+v", resp)
+			}
+		})
+		t.Run(method+"/mismatched", func(t *testing.T) {
+			req := makeReq(t, method, map[string]any{"taskId": "task-abc"})
+			h := http.Header{}
+			h.Set("Mcp-Method", method)
+			h.Set("Mcp-Name", "task-xyz")
+			resp := validateRoutingHeaders(req, h)
+			if resp == nil || resp.Error == nil || resp.Error.Code != core.ErrCodeHeaderMismatch {
+				t.Fatalf("expected -32001 HeaderMismatch for taskId mismatch, got %+v", resp)
+			}
+		})
+		t.Run(method+"/missing", func(t *testing.T) {
+			req := makeReq(t, method, map[string]any{"taskId": "task-abc"})
+			h := http.Header{}
+			h.Set("Mcp-Method", method)
+			resp := validateRoutingHeaders(req, h)
+			if resp == nil || resp.Error == nil || resp.Error.Code != core.ErrCodeHeaderMismatch {
+				t.Fatalf("expected -32001 HeaderMismatch for missing Mcp-Name, got %+v", resp)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What changes

Server now rejects requests where the SEP-2243 `Mcp-Name` routing header
disagrees with (or is missing on) `tasks/get`, `tasks/update`, or
`tasks/cancel`, returning the standard `-32001 HeaderMismatch` JSON-RPC
error. Previously these three methods fell through `extractRoutingName`'s
default branch and the `Mcp-Name` check was silently skipped.

SEP-2663 elevates `Mcp-Name: <taskId>` to a required client header on those
three methods, so SEP-2243's universal MUST applies. This change brings the
server into compliance and flips the conformance check
`sep-2663-server-rejects-mismatched-mcp-name-on-tasks-get` from FAILURE to
SUCCESS on both the legacy and stateless wires of the tasks-v2 fixture.

Closes #499.

## Reviewer's guide

Read in this order:

1. [server/header_validation.go](https://github.com/panyam/mcpkit/pull/501/files#diff-5a541595ad85736d66e51215dee6a6479e47188446e5bc9ece9b5a7c5e8a8551) — the only production change. One new
   switch case mirrors the existing `tools/call` / `resources/read`
   pattern, unmarshalling `params.taskId` and returning it as the
   expected `Mcp-Name` value.
2. [server/header_validation_test.go](https://github.com/panyam/mcpkit/pull/501/files#diff-3785e69e2a5d588010a4b60a3b02dfaccb248d70e2e78ab89b8f9f6d9e9f61f7) — a single table-driven test
   covers matched / mismatched / missing `Mcp-Name` for each of the
   three methods (9 subtests total). The 3 "matched" subtests were
   passing by accident pre-fix (validation skipped); after the fix they
   pass on purpose.

Skim or skip: none — diff is 48 lines.

## Decision log

- **One combined switch case for all three methods** rather than three
  separate cases. They share the exact same `params.taskId` shape per
  SEP-2663 §"Streamable HTTP: Routing Headers", so the per-method
  duplication would be noise.
- **Table-driven test rather than 9 separate functions.** The three
  methods share one shape; the table makes adding a fourth method (if
  the SEP ever covers more) a one-line edit.
- **No raw-session "missing Mcp-Name" suppression on the conformance
  side.** Issue 499 calls this out as out of scope — the current
  `extraHeaders` mechanism overrides but doesn't suppress a header.
  Tracked separately on the conformance side.

## Risk / blast radius

- **Affects:** any client that calls `tasks/get`, `tasks/update`, or
  `tasks/cancel` with `Mcp-Method` set (i.e., a SEP-2243-aware client)
  but a wrong or missing `Mcp-Name` value. Such a client is already
  non-conformant per SEP-2663; the previous behavior was silent
  acceptance, so this is strictly a validation tightening on three
  methods that had no `Mcp-Name` check before.
- **Tests covering this:** `TestValidateRoutingHeaders_TasksMethodsCarryTaskID`
  in `server/header_validation_test.go` (9 subtests); the upstream-portable
  fork-side scenario `tasks-request-headers` in the `mcpconformance`
  fork (legacy + stateless wires).
- **Be paranoid about:** the lower-cased `taskId` JSON tag — SEP-2663
  uses `taskId` (lowercase `Id`), matching `core.TaskInfo`'s existing
  serialization. Double-checked against `tasks_v1_test.go` call sites.

## Before / after

Pre-fix, against the same fixture:

```
× src/scenarios/server/tasks/all-scenarios.test.ts > ... legacy wire >
    'tasks-request-headers' ... 1/4 checks failed:
  - sep-2663-server-rejects-mismatched-mcp-name-on-tasks-get:
    tasks/get with mismatched Mcp-Name returned a result;
    SEP-2243 requires -32001 rejection
× ... stateless wire > 'tasks-request-headers' ... same failure
```

Post-fix:

```
✓ ... legacy wire > 'tasks-request-headers' — all checks succeed
✓ ... stateless wire > 'tasks-request-headers' — all checks succeed
```

Counts: 9 assertions added, 0 existing assertions removed or weakened.

## Out of scope (deliberately deferred)

- Conformance-side raw-session "missing `Mcp-Name` → -32001" check —
  needs an `extraHeaders` suppression mechanism on the fork; per the
  issue body, tracked separately on the conformance side.

## Test plan

- [x] `cd server && go test -run TestValidateRoutingHeaders -count=1` — passes
- [x] `make test` — all core packages pass (client, core, server, server/stateless, testutil)
- [x] `make testconf-tasks-v2` — 18/18 fork scenarios pass on both wires (was 16/18)
- [x] `make testconf-mrtr` — 2/2 MRTR scenarios pass
- [x] `make testconf-upstream-audit` — regenerated; no diff (upstream-main doesn't ship the SEP-2663 headers scenario yet)
- [ ] CI green (auth, ui, e2e, conformance suites)
