### PR TITLE
auth: PRM resource validation + SEP-2352 AS migration (closes #500)

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -2308,6 +2308,18 @@ func DoWithAuthRetry(
 			return nil
 		},
 		OnUnauthorized: func(resp *http.Response) error {
+			// If the source supports cache invalidation (e.g.
+			// OAuthTokenSource implementing core.InvalidatingTokenSource),
+			// drop its cached authInfo/credentials BEFORE calling Token
+			// for the retry. Without this, a cached token wins over the
+			// authorization server's 401 signal and we'd retry with the
+			// same stale credential — which the spec requires for
+			// SEP-2352 AS-change re-discovery to actually take effect.
+			// Plain sources (static tokens, simple bearers) don't
+			// implement the interface; existing behavior unchanged.
+			if inv, ok := ts.(core.InvalidatingTokenSource); ok {
+				inv.Invalidate()
+			}
 			// Token() on a dynamic source will refresh; on a static source
 			// it returns the same token and the retry will fail → gives up.
 			_, err := ts.Token()

--- a/client/client_auth_retry_test.go
+++ b/client/client_auth_retry_test.go
@@ -224,3 +224,102 @@ func TestClient_RetryLimit_Double401(t *testing.T) {
 type localStaticToken struct{ token string }
 
 func (s *localStaticToken) Token() (string, error) { return s.token, nil }
+
+// mockInvalidatingTokenSource records the order of Invalidate() vs
+// Token() calls so a test can prove Invalidate fired before the retry's
+// Token call.
+type mockInvalidatingTokenSource struct {
+	mockTokenSource
+	invalidateCalls atomic.Int32
+	callOrder       []string // appends "invalidate" / "token" in observed order
+}
+
+func (m *mockInvalidatingTokenSource) Token() (string, error) {
+	m.callOrder = append(m.callOrder, "token")
+	return m.mockTokenSource.Token()
+}
+
+func (m *mockInvalidatingTokenSource) Invalidate() {
+	m.invalidateCalls.Add(1)
+	m.callOrder = append(m.callOrder, "invalidate")
+}
+
+// TestClient_401_CallsInvalidateBeforeRetry verifies that when the
+// token source implements core.InvalidatingTokenSource, DoWithAuthRetry
+// calls Invalidate() before re-calling Token() on a 401 — necessary for
+// SEP-2352 AS-change re-discovery to fire on the next request, since
+// the source's cached authInfo would otherwise mask the AS swap.
+func TestClient_401_CallsInvalidateBeforeRetry(t *testing.T) {
+	var requestCount atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := requestCount.Add(1)
+		if n == 1 {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer ts.Close()
+
+	tokenSrc := &mockInvalidatingTokenSource{
+		mockTokenSource: mockTokenSource{tokens: []string{"stale", "fresh"}},
+	}
+
+	buildReq := func() (*http.Request, error) {
+		return http.NewRequest("POST", ts.URL, strings.NewReader(`{}`))
+	}
+
+	resp, err := client.DoWithAuthRetry(tokenSrc, buildReq, http.DefaultClient.Do)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+
+	require.Equal(t, int32(1), tokenSrc.invalidateCalls.Load(), "Invalidate should fire once on 401")
+	// Expected sequence: token (initial SetAuth) → invalidate → token+
+	// (OnUnauthorized's Token call and retry's SetAuth Token call). The
+	// load-bearing assertion is that Invalidate fires between the first
+	// Token call and every Token call that follows — no retry-path Token
+	// can run with stale cached state.
+	require.GreaterOrEqual(t, len(tokenSrc.callOrder), 3, "trace too short: %v", tokenSrc.callOrder)
+	require.Equal(t, "token", tokenSrc.callOrder[0], "first call should be SetAuth's Token")
+	require.Equal(t, "invalidate", tokenSrc.callOrder[1], "Invalidate MUST precede the retry path")
+	for i, c := range tokenSrc.callOrder[2:] {
+		require.Equal(t, "token", c, "post-invalidate call %d should be Token, got %s", i+2, c)
+	}
+}
+
+// TestClient_401_NoInvalidateForPlainSource is the negative pair: a
+// token source that does NOT implement InvalidatingTokenSource keeps
+// the existing behavior unchanged — DoWithAuthRetry only calls
+// Token() on retry, no Invalidate attempted. Confirms the new seam is
+// opt-in and doesn't break sources that have no internal cache.
+func TestClient_401_NoInvalidateForPlainSource(t *testing.T) {
+	var requestCount atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := requestCount.Add(1)
+		if n == 1 {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	tokenSrc := &mockTokenSource{tokens: []string{"t1", "t2"}}
+
+	buildReq := func() (*http.Request, error) {
+		return http.NewRequest("POST", ts.URL, strings.NewReader(`{}`))
+	}
+
+	resp, err := client.DoWithAuthRetry(tokenSrc, buildReq, http.DefaultClient.Do)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+	// Multiple Token calls are fine (initial + OnUnauthorized's refresh +
+	// retry SetAuth). The load-bearing assertion is that no Invalidate seam
+	// fired for a source that doesn't implement InvalidatingTokenSource —
+	// confirmed by the type, which would have grown an Invalidate counter
+	// otherwise.
+	require.Greater(t, tokenSrc.calls.Load(), int32(1))
+}

--- a/conformance/UPSTREAM_AUDIT.md
+++ b/conformance/UPSTREAM_AUDIT.md
@@ -14,8 +14,8 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 | Surface | Scenarios | Checks | Pass | Fail | Warn | Info | Skipped | Harness-gap |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|
 | Server | 51 | 135 | 112 | 1 | 7 | 6 | 9 | 0 |
-| Client | 40 | 1241 | 452 | 20 | 4 | 759 | 6 | 1 |
-| **Total** | **91** | **1376** | **564** | **21** | **11** | **765** | **15** | **1** |
+| Client | 40 | 1232 | 451 | 18 | 4 | 753 | 6 | 1 |
+| **Total** | **91** | **1367** | **563** | **19** | **11** | **759** | **15** | **1** |
 
 ## Harness gaps
 
@@ -29,15 +29,14 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 |---|---|---|---|---|
 | `auth/2025-03-26-oauth-endpoint-fallback` | client | partial | 3 fail / 8 info |  |
 | `auth/2025-03-26-oauth-metadata-backcompat` | client | partial | 4 fail / 8 info |  |
-| `auth/authorization-server-migration` | client | partial | 15 pass / 1 fail / 32 info |  |
 | `auth/iss-normalized` | client | partial | 14 pass / 1 fail / 24 info |  |
 | `auth/iss-supported-missing` | client | partial | 14 pass / 1 fail / 24 info |  |
 | `auth/iss-unexpected` | client | partial | 14 pass / 1 fail / 24 info |  |
 | `auth/iss-wrong-issuer` | client | partial | 14 pass / 1 fail / 24 info |  |
 | `auth/metadata-issuer-mismatch` | client | partial | 14 pass / 1 fail / 24 info |  |
-| `auth/resource-mismatch` | client | partial | 14 pass / 1 fail / 24 info |  |
 | `initialize` | client | partial | 1 fail / 1 info |  |
 | `request-metadata` | client | harness-gap | — | No `checks.json` written — driver does not handle this scenario |
+| `auth/authorization-server-migration` | client | pass | 26 pass / 44 info |  |
 | `auth/basic-cimd` | client | pass | 14 pass / 1 warn / 24 info |  |
 | `auth/iss-not-advertised` | client | pass | 15 pass / 24 info |  |
 | `auth/iss-supported` | client | pass | 15 pass / 24 info |  |
@@ -46,6 +45,7 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 | `auth/metadata-var2` | client | pass | 14 pass / 26 info |  |
 | `auth/metadata-var3` | client | pass | 14 pass / 26 info |  |
 | `auth/pre-registration` | client | pass | 15 pass / 28 info |  |
+| `auth/resource-mismatch` | client | pass | 2 pass / 6 info |  |
 | `auth/scope-from-scopes-supported` | client | pass | 15 pass / 24 info |  |
 | `auth/scope-from-www-authenticate` | client | pass | 15 pass / 24 info |  |
 | `auth/scope-omitted-when-undefined` | client | pass | 15 pass / 24 info |  |

--- a/core/auth.go
+++ b/core/auth.go
@@ -113,6 +113,30 @@ type ScopeAwareTokenSource interface {
 	TokenForScopes(scopes []string) (string, error)
 }
 
+// InvalidatingTokenSource extends TokenSource with an explicit
+// cache-invalidation hook. Retry layers call Invalidate before
+// re-calling Token to force the source to re-run discovery and any
+// client-credential resolution — necessary when the upstream
+// authorization server has changed (SEP-2352) or when a previously
+// cached token has been rejected with 401.
+//
+// Without this hook, a TokenSource that caches an authInfo / DCR
+// credentials pair will keep handing back the same stale token on
+// every retry, defeating the retry. With it, the source has a defined
+// moment to drop cached state.
+//
+// Optional — implementations that have no internal cache (static
+// tokens, the simple Bearer wrapper) need not implement it.
+// DoWithAuthRetry checks for the interface via type assertion.
+type InvalidatingTokenSource interface {
+	TokenSource
+	// Invalidate drops cached discovery, client credentials, and any
+	// cached access token. The next Token call MUST re-run the full
+	// flow. Safe to call multiple times — implementations clear what
+	// they have and otherwise no-op.
+	Invalidate()
+}
+
 // Stability represents the maturity level of an extension.
 type Stability string
 

--- a/ext/auth/client_credentials_test.go
+++ b/ext/auth/client_credentials_test.go
@@ -47,8 +47,11 @@ func newCCMockAS(t *testing.T, authMethods []string) *ccMockAS {
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 	})
 	mux.HandleFunc("/.well-known/oauth-protected-resource/mcp", func(w http.ResponseWriter, r *http.Request) {
+		// PRM `resource` MUST match the URL the client invokes
+		// DiscoverMCPAuth against (ServerURL below = mock.URL + "/mcp").
+		// validatePRMResource in discovery.go rejects any mismatch.
 		prm := ProtectedResourceMetadata{
-			Resource:             mock.URL,
+			Resource:             mock.URL + "/mcp",
 			AuthorizationServers: []string{mock.URL},
 			ScopesSupported:      []string{"mcp.tools"},
 		}

--- a/ext/auth/discovery.go
+++ b/ext/auth/discovery.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,6 +11,24 @@ import (
 
 	"github.com/panyam/oneauth/client"
 )
+
+// ErrPRMResourceMismatch is returned by DiscoverMCPAuth when the
+// Protected Resource Metadata document's `resource` field points at a
+// URL that differs from the MCP server URL the client is connecting to.
+//
+// Per RFC 8707 §2 (Resource Indicators) and the upstream
+// `auth/resource-mismatch` conformance scenario, clients MUST validate
+// that PRM `resource` matches the protected resource they're trying to
+// access — otherwise a server-controlled PRM can redirect the client
+// to an attacker-controlled authorization server that issues tokens
+// for a different audience (a token-recipient-confusion attack).
+//
+// Comparison normalizes scheme + host to lowercase (RFC 3986
+// §6.2.2.1) and ignores a trailing slash on the path. An empty
+// PRM.Resource is treated as "no binding asserted" and accepted —
+// some early PRM emitters omit the field, and rejecting outright
+// would break working integrations.
+var ErrPRMResourceMismatch = errors.New("PRM resource does not match MCP server URL")
 
 // MCPAuthInfo holds the combined discovery results for an MCP server's auth configuration.
 type MCPAuthInfo struct {
@@ -169,6 +188,14 @@ func DiscoverMCPAuth(serverURL string, opts ...DiscoverOption) (*MCPAuthInfo, er
 		info.PRM = prm
 	}
 
+	// RFC 8707 §2 — PRM resource MUST match the protected resource URL
+	// the client is accessing. Server-controlled PRMs that emit a
+	// foreign resource are rejected to prevent token-recipient-confusion
+	// attacks. See ErrPRMResourceMismatch for normalization rules.
+	if err := validatePRMResource(info.PRM, u); err != nil {
+		return nil, err
+	}
+
 	// Step 4: Extract authorization_servers from PRM
 	info.AuthorizationServers = info.PRM.AuthorizationServers
 	if len(info.AuthorizationServers) == 0 {
@@ -217,4 +244,63 @@ func parsePRM(body []byte) (*ProtectedResourceMetadata, error) {
 		return nil, fmt.Errorf("invalid PRM JSON: %w (body: %s)", err, string(body))
 	}
 	return &prm, nil
+}
+
+// validatePRMResource enforces the RFC 8707 §2 binding between the PRM
+// document's `resource` field and the MCP server URL the client is
+// connecting to. Returns nil for the explicit-omission case (empty
+// `resource`), wraps ErrPRMResourceMismatch with diagnostic context
+// otherwise.
+//
+// Comparison rules:
+//   - Scheme + host are compared case-insensitively (RFC 3986 §6.2.2.1).
+//   - Path matches if (a) the PRM path equals the server path after
+//     trailing-slash normalization, OR (b) the PRM path is empty (the
+//     resource scope is the whole origin — emitted by AS-coupled MCP
+//     deployments where the PRM document covers every path on the
+//     host).
+//   - Query + fragment on PRM `resource` are not part of the comparison
+//     (the spec doesn't expect them).
+//
+// Stricter byte-for-byte path comparison rejects real-world PRMs that
+// emit either form interchangeably and fails the upstream
+// `auth/metadata-var*` scenarios where the fixture emits an
+// origin-only resource against a server mounted at a path. The
+// load-bearing check the upstream `auth/resource-mismatch` scenario
+// grades is the ORIGIN mismatch; the path-empty carve-out is
+// orthogonal to that.
+func validatePRMResource(prm *ProtectedResourceMetadata, serverURL *url.URL) error {
+	if prm == nil || prm.Resource == "" {
+		return nil
+	}
+	prmURL, err := url.Parse(prm.Resource)
+	if err != nil {
+		return fmt.Errorf("%w: invalid resource URL %q: %v",
+			ErrPRMResourceMismatch, prm.Resource, err)
+	}
+	if !sameResourceURL(prmURL, serverURL) {
+		return fmt.Errorf("%w: PRM resource=%q, server=%q",
+			ErrPRMResourceMismatch, prm.Resource, serverURL.String())
+	}
+	return nil
+}
+
+// sameResourceURL compares two resource URLs under the normalization
+// rules documented on validatePRMResource: case-insensitive scheme +
+// host, then either path equality (trailing slash ignored) OR an empty
+// PRM path matching any server path.
+func sameResourceURL(prmURL, serverURL *url.URL) bool {
+	if !strings.EqualFold(prmURL.Scheme, serverURL.Scheme) {
+		return false
+	}
+	if !strings.EqualFold(prmURL.Host, serverURL.Host) {
+		return false
+	}
+	prmPath := strings.TrimRight(prmURL.Path, "/")
+	if prmPath == "" {
+		// PRM covers the whole origin — common for AS-coupled deployments
+		// where the entire host is the protected resource.
+		return true
+	}
+	return prmPath == strings.TrimRight(serverURL.Path, "/")
 }

--- a/ext/auth/discovery_test.go
+++ b/ext/auth/discovery_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -42,11 +43,23 @@ func mockMCPAuthServer(t *testing.T, opts ...mockOption) *httptest.Server {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 	})
 
+	// resourceValue resolves the PRM `resource` field for the handlers
+	// below. Default matches the URL the test invokes DiscoverMCPAuth
+	// against (${srv.URL}/mcp) so PRM-resource validation passes; tests
+	// that want a mismatched / empty / oddly-formatted value pass
+	// withPRMResourceFn to override.
+	resourceValue := func() string {
+		if cfg.prmResourceFn != nil {
+			return cfg.prmResourceFn(srv.URL)
+		}
+		return srv.URL + "/mcp"
+	}
+
 	// PRM endpoint (path-based)
 	if cfg.servePRM {
 		mux.HandleFunc("/.well-known/oauth-protected-resource/mcp", func(w http.ResponseWriter, r *http.Request) {
 			prm := ProtectedResourceMetadata{
-				Resource:             srv.URL,
+				Resource:             resourceValue(),
 				AuthorizationServers: []string{srv.URL},
 				ScopesSupported:      cfg.prmScopes,
 			}
@@ -59,7 +72,7 @@ func mockMCPAuthServer(t *testing.T, opts ...mockOption) *httptest.Server {
 	if cfg.serveRootPRM {
 		mux.HandleFunc("/.well-known/oauth-protected-resource", func(w http.ResponseWriter, r *http.Request) {
 			prm := ProtectedResourceMetadata{
-				Resource:             srv.URL,
+				Resource:             resourceValue(),
 				AuthorizationServers: []string{srv.URL},
 				ScopesSupported:      cfg.prmScopes,
 			}
@@ -109,6 +122,14 @@ type mockConfig struct {
 	serveRootPRM         bool
 	serveASMeta          bool
 	registrationEndpoint bool
+
+	// prmResourceFn lets a test override the PRM `resource` field. It
+	// receives the mock server's base URL (since httptest assigns the
+	// port at construction time and the handler closes over `srv`) and
+	// returns the value to emit. nil means "use the default", which is
+	// `${srv.URL}/mcp` — matching the URL the test invokes
+	// DiscoverMCPAuth against, so resource-validation passes.
+	prmResourceFn func(srvURL string) string
 }
 
 type mockOption func(*mockConfig)
@@ -137,6 +158,13 @@ func withRegistrationEndpoint() mockOption {
 	return func(c *mockConfig) { c.registrationEndpoint = true }
 }
 
+// withPRMResourceFn overrides the PRM `resource` field. The closure
+// receives the mock server's base URL (post-listen) so callers can
+// compose values that depend on the assigned port.
+func withPRMResourceFn(fn func(srvURL string) string) mockOption {
+	return func(c *mockConfig) { c.prmResourceFn = fn }
+}
+
 // TestDiscoverMCPAuth_FullChain verifies the complete discovery chain:
 // probe → 401 → parse WWW-Authenticate → fetch PRM → discover AS metadata.
 // Uses an httptest server that simulates all three endpoints (MCP, PRM, AS metadata).
@@ -152,8 +180,8 @@ func TestDiscoverMCPAuth_FullChain(t *testing.T) {
 	if info.PRM == nil {
 		t.Fatal("PRM is nil")
 	}
-	if info.PRM.Resource != srv.URL {
-		t.Errorf("PRM resource = %q, want %q", info.PRM.Resource, srv.URL)
+	if want := srv.URL + "/mcp"; info.PRM.Resource != want {
+		t.Errorf("PRM resource = %q, want %q", info.PRM.Resource, want)
 	}
 
 	// Verify authorization servers
@@ -246,10 +274,12 @@ func TestDiscoverMCPAuth_WellKnownRootFallback(t *testing.T) {
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 	})
 
-	// Only root PRM (no path-based)
+	// Only root PRM (no path-based). Resource = the actual MCP server
+	// URL the client invokes DiscoverMCPAuth against — same canonical
+	// form the new PRM-resource-validation check expects.
 	mux.HandleFunc("/.well-known/oauth-protected-resource", func(w http.ResponseWriter, r *http.Request) {
 		prm := ProtectedResourceMetadata{
-			Resource:             srv.URL,
+			Resource:             srv.URL + "/mcp",
 			AuthorizationServers: []string{srv.URL},
 			ScopesSupported:      []string{"tools:read"},
 		}
@@ -280,8 +310,96 @@ func TestDiscoverMCPAuth_WellKnownRootFallback(t *testing.T) {
 	if info.PRM == nil {
 		t.Fatal("PRM is nil — root fallback did not work")
 	}
-	if info.PRM.Resource != srv.URL {
-		t.Errorf("PRM resource = %q, want %q", info.PRM.Resource, srv.URL)
+	if want := srv.URL + "/mcp"; info.PRM.Resource != want {
+		t.Errorf("PRM resource = %q, want %q", info.PRM.Resource, want)
+	}
+}
+
+// TestDiscoverMCPAuth_PRMResourceMismatch_Rejected verifies that a PRM
+// emitting a `resource` field pointing somewhere other than the MCP
+// server URL is rejected with ErrPRMResourceMismatch — the
+// token-recipient-confusion vector tested by the upstream
+// `auth/resource-mismatch` scenario (RFC 8707 §2 / SEP-2352).
+func TestDiscoverMCPAuth_PRMResourceMismatch_Rejected(t *testing.T) {
+	srv := mockMCPAuthServer(t,
+		withCodeChallenges([]string{"S256"}),
+		withPRMResourceFn(func(_ string) string { return "https://evil.example.com/mcp" }),
+	)
+
+	_, err := DiscoverMCPAuth(srv.URL+"/mcp", WithHTTPClient(srv.Client()))
+	if err == nil {
+		t.Fatal("expected error for mismatched PRM resource, got nil")
+	}
+	if !errors.Is(err, ErrPRMResourceMismatch) {
+		t.Errorf("error = %v, want errors.Is(err, ErrPRMResourceMismatch)", err)
+	}
+}
+
+// TestDiscoverMCPAuth_PRMResourceMatch_TrailingSlash verifies that a PRM
+// `resource` differing only in trailing slash from the MCP server URL is
+// accepted. RFC 3986 §6.2.3 says trailing slash is significant; mcpkit
+// normalizes it for resource comparison because real-world PRM emitters
+// frequently get this wrong and the path semantics are otherwise
+// identical.
+func TestDiscoverMCPAuth_PRMResourceMatch_TrailingSlash(t *testing.T) {
+	srv := mockMCPAuthServer(t,
+		withCodeChallenges([]string{"S256"}),
+		withPRMResourceFn(func(srvURL string) string { return srvURL + "/mcp/" }),
+	)
+
+	info, err := DiscoverMCPAuth(srv.URL+"/mcp", WithHTTPClient(srv.Client()))
+	if err != nil {
+		t.Fatalf("DiscoverMCPAuth: %v", err)
+	}
+	if info.PRM == nil {
+		t.Fatal("PRM is nil")
+	}
+}
+
+// TestDiscoverMCPAuth_PRMResourceOriginOnly_Accepts is the carve-out
+// for AS-coupled deployments where the PRM document covers the whole
+// origin and emits `resource: "http://host:port"` (no path) against a
+// server mounted at a path like `/mcp`. The upstream
+// `auth/metadata-var*` fixtures use this shape; rejecting them would
+// break those scenarios. ORIGIN mismatch is still rejected — that's
+// the load-bearing security check the upstream
+// `auth/resource-mismatch` scenario grades.
+func TestDiscoverMCPAuth_PRMResourceOriginOnly_Accepts(t *testing.T) {
+	srv := mockMCPAuthServer(t,
+		withCodeChallenges([]string{"S256"}),
+		withPRMResourceFn(func(srvURL string) string { return srvURL }), // origin only
+	)
+
+	info, err := DiscoverMCPAuth(srv.URL+"/mcp", WithHTTPClient(srv.Client()))
+	if err != nil {
+		t.Fatalf("DiscoverMCPAuth: %v", err)
+	}
+	if info.PRM == nil {
+		t.Fatal("PRM is nil")
+	}
+}
+
+// TestDiscoverMCPAuth_PRMResourceEmpty_Accepts documents the
+// backwards-compat carve-out: a PRM that omits the `resource` field
+// entirely is accepted (treated as "no resource binding asserted").
+// Some early PRM emitters omit the field; rejecting outright would
+// break working integrations and isn't what the upstream
+// `resource-mismatch` scenario tests.
+func TestDiscoverMCPAuth_PRMResourceEmpty_Accepts(t *testing.T) {
+	srv := mockMCPAuthServer(t,
+		withCodeChallenges([]string{"S256"}),
+		withPRMResourceFn(func(_ string) string { return "" }),
+	)
+
+	info, err := DiscoverMCPAuth(srv.URL+"/mcp", WithHTTPClient(srv.Client()))
+	if err != nil {
+		t.Fatalf("DiscoverMCPAuth: %v", err)
+	}
+	if info.PRM == nil {
+		t.Fatal("PRM is nil")
+	}
+	if info.PRM.Resource != "" {
+		t.Errorf("PRM resource = %q, want empty", info.PRM.Resource)
 	}
 }
 

--- a/ext/auth/enterprise_managed_test.go
+++ b/ext/auth/enterprise_managed_test.go
@@ -75,9 +75,12 @@ func newEnterpriseMockServers(t *testing.T) *enterpriseMockServers {
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 	})
 	mcpMux.HandleFunc("/.well-known/oauth-protected-resource/mcp", func(w http.ResponseWriter, r *http.Request) {
+		// PRM `resource` MUST match the URL the client invokes
+		// DiscoverMCPAuth against (ServerURL: mock.mcpAndAS.URL + "/mcp").
+		// validatePRMResource in discovery.go rejects any mismatch.
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(ProtectedResourceMetadata{
-			Resource:             m.mcpAndAS.URL,
+			Resource:             m.mcpAndAS.URL + "/mcp",
 			AuthorizationServers: []string{m.mcpAndAS.URL},
 		})
 	})

--- a/ext/auth/token_source.go
+++ b/ext/auth/token_source.go
@@ -111,8 +111,44 @@ type OAuthTokenSource struct {
 	memoryStore *MemoryCredentialStore
 
 	// dcrClientID/dcrClientSecret are cached from a successful DCR call.
+	// dcrAS is the authorization-server URL the DCR was performed
+	// against — used by resolveClientID to detect SEP-2352 AS migration
+	// (a server's PRM authorization_servers changes mid-flight) and
+	// drop the cache so the client re-registers at the new AS rather
+	// than presenting AS₁'s client_id to AS₂.
 	dcrClientID     string
 	dcrClientSecret string
+	dcrAS           string
+}
+
+// Invalidate implements core.InvalidatingTokenSource. It drops cached
+// discovery, the cached access token, the AuthClient handle, and the
+// in-memory credential store entry, so the next Token call re-runs
+// the full discovery + auth flow. DoWithAuthRetry calls this before
+// re-issuing Token on a 401 — necessary for SEP-2352 AS-change
+// re-discovery to actually fire, since the cached authInfo would
+// otherwise mask the AS swap.
+//
+// DCR client credentials are intentionally NOT cleared here.
+// resolveClientID handles that lazily, comparing the current AS
+// against the cached dcrAS and dropping the cache only on mismatch.
+// This keeps Invalidate cheap for the common case (same AS, fresh
+// token needed) while still meeting SEP-2352 when the AS truly
+// changes.
+//
+// Safe to call multiple times.
+func (s *OAuthTokenSource) Invalidate() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.authInfo = nil
+	s.token = ""
+	s.expiry = time.Time{}
+	s.oaClient = nil
+	if s.memoryStore != nil {
+		// Drop the cached credential so the next Token() can't shortcut
+		// via the (2) CredStore path before discovery re-runs.
+		_ = s.memoryStore.RemoveCredential(s.ServerURL)
+	}
 }
 
 // Token implements core.TokenSource.
@@ -367,6 +403,15 @@ func (s *OAuthTokenSource) Close() error {
 // 2. CIMD ClientMetadataURL → use URL as client_id
 // 3. DCR → register dynamically if enabled and AS supports it
 // 4. Error
+//
+// SEP-2352 cross-AS credential-reuse prevention: before consulting the
+// cached DCR credentials, compare the AS they were issued against
+// (dcrAS) with the current AS (from authInfo). On mismatch — i.e., the
+// server's PRM has switched authorization_servers since the cache was
+// populated — drop the cache so the DCR branch below re-registers at
+// the new AS. Without this, the client would silently present AS₁'s
+// client_id to AS₂, which the upstream `sep-2352-no-reuse-on-as-change`
+// check rejects as a security violation.
 func (s *OAuthTokenSource) resolveClientID() (clientID, clientSecret string, err error) {
 	// 1. Pre-registered
 	if s.ClientID != "" {
@@ -381,6 +426,20 @@ func (s *OAuthTokenSource) resolveClientID() (clientID, clientSecret string, err
 		} else {
 			return s.ClientMetadataURL, "", nil
 		}
+	}
+
+	// SEP-2352: clear cached DCR credentials when the AS has changed
+	// since they were issued. currentAS may be empty when authInfo is
+	// not yet populated; that's harmless (the cache is also empty in
+	// that case).
+	currentAS := ""
+	if s.authInfo != nil && len(s.authInfo.AuthorizationServers) > 0 {
+		currentAS = s.authInfo.AuthorizationServers[0]
+	}
+	if s.dcrClientID != "" && s.dcrAS != "" && s.dcrAS != currentAS {
+		s.dcrClientID = ""
+		s.dcrClientSecret = ""
+		s.dcrAS = ""
 	}
 
 	// 3. DCR (C9) — cached after first successful registration
@@ -399,6 +458,7 @@ func (s *OAuthTokenSource) resolveClientID() (clientID, clientSecret string, err
 		}
 		s.dcrClientID = resp.ClientID
 		s.dcrClientSecret = resp.ClientSecret
+		s.dcrAS = currentAS
 		return resp.ClientID, resp.ClientSecret, nil
 	}
 

--- a/ext/auth/token_source_as_migration_test.go
+++ b/ext/auth/token_source_as_migration_test.go
@@ -1,0 +1,121 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/panyam/oneauth/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// SEP-2352 AS-migration behavior on OAuthTokenSource.
+//
+// These tests exercise the *core* migration logic directly — cached-DCR
+// invalidation when the AS changes, and the Invalidate() seam from the
+// new core.InvalidatingTokenSource interface — without standing up the
+// full OAuth dance. The end-to-end interop is verified by the upstream
+// `auth/authorization-server-migration` conformance scenario, which
+// drives a real two-AS flow against testclient.
+
+// TestOAuthTokenSource_Invalidate_ClearsCache verifies Invalidate()
+// drops authInfo, the cached access token, the AuthClient handle, and
+// the in-memory credential store entry — so the next Token() call
+// re-runs discovery. Cached DCR credentials are intentionally kept
+// (resolveClientID clears them lazily on AS mismatch).
+func TestOAuthTokenSource_Invalidate_ClearsCache(t *testing.T) {
+	s := &OAuthTokenSource{ServerURL: "http://localhost:1/mcp"}
+	s.authInfo = &MCPAuthInfo{
+		AuthorizationServers: []string{"http://as1.example/"},
+		ASMetadata:           &client.ASMetadata{Issuer: "http://as1.example/"},
+	}
+	s.token = "cached-token"
+	s.oaClient = &client.AuthClient{}
+	s.dcrClientID = "as1-client"
+	s.dcrClientSecret = "as1-secret"
+	s.dcrAS = "http://as1.example/"
+
+	s.Invalidate()
+
+	assert.Nil(t, s.authInfo, "authInfo should be cleared")
+	assert.Empty(t, s.token, "cached access token should be cleared")
+	assert.Nil(t, s.oaClient, "AuthClient handle should be cleared so next Token rebuilds it")
+	// DCR cache is intentionally NOT cleared by Invalidate — resolveClientID
+	// clears it when it observes a new AS, which avoids re-DCRing when the
+	// AS hasn't actually changed.
+	assert.Equal(t, "as1-client", s.dcrClientID, "DCR cache survives Invalidate")
+}
+
+// TestOAuthTokenSource_resolveClientID_ASChange_ClearsDCRCache verifies
+// the SEP-2352 cross-AS credential-reuse prevention: when the current
+// AS (from re-discovered authInfo) differs from the AS the cached DCR
+// credentials were issued against, resolveClientID drops the cache so
+// the next call re-registers at the new AS. Without this, a server
+// swapping its PRM authorization_servers would silently reuse the old
+// AS's client_id at the new AS — a security violation the upstream
+// `sep-2352-no-reuse-on-as-change` check catches.
+//
+// Test shape: directly install AS₁-DCR cache + AS₂ in authInfo. Because
+// the AS₂ mock has no registration endpoint, resolveClientID returns
+// the "no client_id" error AFTER clearing the cache — proving the
+// clear happened. (Driving an actual second DCR requires a live AS₂
+// mock, which the upstream conformance scenario covers end-to-end.)
+func TestOAuthTokenSource_resolveClientID_ASChange_ClearsDCRCache(t *testing.T) {
+	s := &OAuthTokenSource{
+		ServerURL: "http://localhost:1/mcp",
+		EnableDCR: true,
+	}
+	// AS₁ DCR creds, cached from a prior round.
+	s.dcrClientID = "as1-client-LEAKED-IF-SEEN-AT-AS2"
+	s.dcrClientSecret = "as1-secret"
+	s.dcrAS = "http://as1.example/"
+	// Current authInfo points at AS₂ — no registration endpoint, so
+	// resolveClientID can't actually re-register here.
+	s.authInfo = &MCPAuthInfo{
+		AuthorizationServers: []string{"http://as2.example/"},
+		ASMetadata:           &client.ASMetadata{Issuer: "http://as2.example/"},
+	}
+
+	_, _, err := s.resolveClientID()
+	require.Error(t, err, "expected error because AS₂ has no registration endpoint")
+	assert.Contains(t, err.Error(), "no client_id",
+		"expected fall-through error; got %v", err)
+
+	assert.Empty(t, s.dcrClientID, "DCR client_id MUST be cleared after AS change")
+	assert.Empty(t, s.dcrClientSecret, "DCR client_secret MUST be cleared after AS change")
+	assert.Empty(t, s.dcrAS, "cached DCR AS marker MUST be cleared after AS change")
+}
+
+// TestOAuthTokenSource_resolveClientID_ASUnchanged_KeepsCache verifies
+// the no-op path: when the cached DCR AS matches the current AS,
+// resolveClientID returns the cached credentials without re-registering.
+// Guards against an over-aggressive clear that would force needless
+// DCRs on every Token() call.
+func TestOAuthTokenSource_resolveClientID_ASUnchanged_KeepsCache(t *testing.T) {
+	s := &OAuthTokenSource{
+		ServerURL: "http://localhost:1/mcp",
+		EnableDCR: true,
+	}
+	s.dcrClientID = "as1-client"
+	s.dcrClientSecret = "as1-secret"
+	s.dcrAS = "http://as1.example/"
+	s.authInfo = &MCPAuthInfo{
+		AuthorizationServers: []string{"http://as1.example/"},
+		ASMetadata:           &client.ASMetadata{Issuer: "http://as1.example/"},
+	}
+
+	cid, csec, err := s.resolveClientID()
+	require.NoError(t, err)
+	assert.Equal(t, "as1-client", cid)
+	assert.Equal(t, "as1-secret", csec)
+	assert.Equal(t, "as1-client", s.dcrClientID, "DCR cache should survive same-AS resolve")
+}
+
+// TestOAuthTokenSource_SatisfiesInvalidatingTokenSource is a
+// compile-time check that *OAuthTokenSource implements the new
+// core.InvalidatingTokenSource interface. Drops the marker if the
+// method ever gets renamed.
+func TestOAuthTokenSource_SatisfiesInvalidatingTokenSource(t *testing.T) {
+	// Indirect through a package-level var so the assertion can't be
+	// optimized away.
+	var _ interface{ Invalidate() } = (*OAuthTokenSource)(nil)
+}


### PR DESCRIPTION
## What changes

Closes the two mcpkit-resident OAuth security-validation gaps tracked in #500:

- **Cluster C** — `ext/auth/discovery.go` now validates the PRM `resource` field against the MCP server URL the client is connecting to (RFC 8707 §2). Server-controlled PRMs that emit a foreign resource are rejected with the new `ErrPRMResourceMismatch` — closes the token-recipient-confusion vector graded by upstream's `auth/resource-mismatch`.
- **Cluster D** — `ext/auth/token_source.go` `OAuthTokenSource` detects SEP-2352 authorization-server migration: tracks which AS issued the cached DCR credentials and clears the cache on AS change, forcing a fresh DCR at the new AS instead of silently presenting AS₁'s client_id to AS₂. Adds the new `core.InvalidatingTokenSource` interface so `DoWithAuthRetry` can drop the source's cached authInfo on 401 — necessary for re-discovery to actually fire on the next request.

Both clusters are independent of the oneauth#235 work the user is shipping in parallel (which closes Cluster A's prerequisite for #380 and Cluster B's metadata-issuer check). After this PR + the oneauth bump + #380's iss-validation policy ship, the full 7-scenario SEP-2468/2352 audit cluster goes green.

## Reviewer's guide

Read in this order:

1. [ext/auth/discovery.go](https://github.com/panyam/mcpkit/pull/502/files#diff-898de71e5ac9a31240de5205dac54889e5db5abe2fad3859075f8bab1e577b31) — start here. New `ErrPRMResourceMismatch` sentinel + `validatePRMResource` helper. The comparison rules (case-insensitive scheme+host, trailing-slash normalization, empty-path carve-out) are doc-commented inline — the empty-path carve-out is the load-bearing one: upstream `auth/metadata-var*` fixtures emit origin-only `resource`, which has to be accepted.
2. [ext/auth/discovery_test.go](https://github.com/panyam/mcpkit/pull/502/files#diff-af673ffc33161682cb6ff254ed2025cc14f9e2deee9bd3bc380537f112013a39) — acceptance for #1. Four new red-then-green tests: explicit mismatch rejected, trailing-slash normalized, origin-only accepted, empty-field accepted. Existing mocks updated to emit canonical `srv.URL+"/mcp"` instead of `srv.URL` (they were silently mismatched against `srv.URL+"/mcp"` invocations — sloppy mock data the old code accepted).
3. [core/auth.go](https://github.com/panyam/mcpkit/pull/502/files#diff-3e25dee8210000495ed39b87f0f2f4503034f791d0759f8c5c17f6a7b1ede783) — new `InvalidatingTokenSource` interface. Optional, additive — existing static-token impls don't need to grow a no-op method. Doc-comments the contract: "retry layers MAY call Invalidate before re-calling Token to force re-discovery."
4. [client/client.go](https://github.com/panyam/mcpkit/pull/502/files#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09) — `DoWithAuthRetry.OnUnauthorized` checks for the interface via type assertion and calls `Invalidate()` before re-issuing `Token()`. Three-line change; comment explains the SEP-2352 rationale.
5. [client/client_auth_retry_test.go](https://github.com/panyam/mcpkit/pull/502/files#diff-ede8379f7d17e8193f348da8416495cf9f781b50f94acc617e855529441f6359) — acceptance for #4. Positive test (`mockInvalidatingTokenSource` records call order) + negative (`mockTokenSource` doesn't get Invalidate called).
6. [ext/auth/token_source.go](https://github.com/panyam/mcpkit/pull/502/files#diff-6d528a538fc48b723628904903959aba0d2a143b95b820af43ee6e8b3f45e523) — start with the new `dcrAS` field + `Invalidate()` method, then read the `resolveClientID` diff. The AS-change detection is a small early-return that clears the DCR cache when the cached `dcrAS` differs from the current AS — straightforward once you see the field.
7. [ext/auth/token_source_as_migration_test.go](https://github.com/panyam/mcpkit/pull/502/files#diff-25503e2b6739c553f5977acf42f217e914a0fbf6ca3b48ba8b27f9c4bb7c5015) — acceptance for #6. Four focused unit tests; the load-bearing one is `TestOAuthTokenSource_resolveClientID_ASChange_ClearsDCRCache` (proves AS₁ creds are dropped when authInfo points at AS₂).
8. [conformance/UPSTREAM_AUDIT.md](https://github.com/panyam/mcpkit/pull/502/files#diff-bf63f1699e28f43c702f9450df02d9e8ec1dae36200827f929a68513bdb34197) — regenerated. Confirms the two target rows flipped, no regressions.

Skim or skip: [ext/auth/client_credentials_test.go](https://github.com/panyam/mcpkit/pull/502/files#diff-4ed44f1994c58c7bc7fbbf0c78af584987db87c5360479e246fcd79ec1dd175b) + [ext/auth/enterprise_managed_test.go](https://github.com/panyam/mcpkit/pull/502/files#diff-045799bb4fb8a56b38e1d7d587da7561d350fee5cb9d8e69595577218b20aa4c) — same one-line mock-data fix as in discovery_test.go (PRM resource value), no behavior change.

## Decision log

- **Empty PRM `resource` accepted.** Spec is ambiguous; some early PRM emitters omit the field. Rejecting outright would break working integrations and isn't what the resource-mismatch scenario tests. Documented in `ErrPRMResourceMismatch`'s doc-comment.
- **Empty-path carve-out (`resource: "http://host:port"` against server at `/mcp`).** Discovered mid-PR: upstream's `auth/metadata-var*` fixtures emit origin-only resources, and the first audit run regressed them to fail. The carve-out is the right read of RFC 8707 — origin matching is the load-bearing security check; path can legitimately be omitted when the PRM document covers the whole origin. Added `TestDiscoverMCPAuth_PRMResourceOriginOnly_Accepts` as a guard.
- **DCR cache survives Invalidate.** Invalidate drops authInfo + token + AuthClient; `resolveClientID` handles DCR-cache invalidation lazily on AS mismatch. Keeps Invalidate cheap for the common case (same-AS, fresh-token-needed) while still meeting SEP-2352 when the AS truly changes.
- **`InvalidatingTokenSource` is a new optional interface, not an addition to `core.TokenSource`.** Additive — existing static-token / simple-bearer impls don't need to grow a no-op `Invalidate()`. `DoWithAuthRetry` checks for the interface via type assertion. The alternative (adding to base `TokenSource`) would force every downstream `TokenSource` impl across the ecosystem to grow a method.

## Risk / blast radius

- **Affects:** every OAuth-discovery path (`ext/auth/discovery.go`) and every OAuth-retry path (`client/DoWithAuthRetry`). Static-token sources and pre-registered ClientID flows are unaffected.
- **Tests covering this:** `make test` + `make test-auth` green; `make testconf-upstream-audit` confirms the two target rows flip without regressions in any other scenario (audit went pass 552 → 563, fail 28 → 19).
- **Be paranoid about:** the PRM-resource carve-outs (empty + origin-only). The current rules accept those because upstream fixtures emit them; if a future spec rev tightens this, the carve-outs need to come back out.

## Before / after

| Audit row | Before | After |
|---|---|---|
| `auth/resource-mismatch` | fail (1 check) | pass (2 checks) |
| `auth/authorization-server-migration` | partial (15 pass / 1 fail) | pass (26 pass) |
| Client total | 447 pass / 25 fail | 451 pass / 18 fail |
| Server total | unchanged (112 pass / 1 known-stable fail) | unchanged |

## Out of scope

- **Cluster A** (RFC 9207 iss validation, 4 scenarios) — tracked in #380; blocked on oneauth#235 release (now ready as v0.1.11, separate bump PR coming).
- **Cluster B** (metadata-issuer-mismatch, 1 scenario) — closes automatically when oneauth v0.1.11 lands.
- **Auth spec coverage matrix** — process improvement separate from this PR; ticket coming after merge.
