### PR TITLE
deps: bump oneauth to v0.1.11 — closes Cluster B audit gap automatically

### DIFF
--- a/cmd/testclient/go.mod
+++ b/cmd/testclient/go.mod
@@ -5,7 +5,7 @@ go 1.26.3
 require (
 	github.com/panyam/mcpkit v0.2.3
 	github.com/panyam/mcpkit/ext/auth v0.0.0
-	github.com/panyam/oneauth v0.1.10
+	github.com/panyam/oneauth v0.1.11
 )
 
 require (

--- a/cmd/testclient/go.sum
+++ b/cmd/testclient/go.sum
@@ -33,8 +33,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.8 h1:5UscYTP892k54+Nyb01tKGGwZxczZ5k7BC+c0nXmcoc=
 github.com/panyam/goutils v0.1.8/go.mod h1:ntucs8GJOHQ0LmlRGRjeup3aDC2t7xPMudrRwUHrJNM=
-github.com/panyam/oneauth v0.1.10 h1:/v4x+IED7EwlMmvIyK7WvXngChBdAAC8n9in8Ld17uo=
-github.com/panyam/oneauth v0.1.10/go.mod h1:kujwUd36OsM8WyA4c++5acpK2yAgVX3Qa0iu4oI8Cp8=
+github.com/panyam/oneauth v0.1.11 h1:ltKd+Zjqp3/2iZRFzV+3q6zGS9mV75PXOTnl+j+gFv4=
+github.com/panyam/oneauth v0.1.11/go.mod h1:kujwUd36OsM8WyA4c++5acpK2yAgVX3Qa0iu4oI8Cp8=
 github.com/panyam/servicekit v0.0.25 h1:JeTRyz5ZZY3beENg0N3tLW+O39/foTuHMPAf+rpwYhM=
 github.com/panyam/servicekit v0.0.25/go.mod h1:9TkF2LRqiPC9bgu0bYVdky7rnHEuBvzGzrsoL++Ra5c=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/conformance/UPSTREAM_AUDIT.md
+++ b/conformance/UPSTREAM_AUDIT.md
@@ -14,8 +14,8 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 | Surface | Scenarios | Checks | Pass | Fail | Warn | Info | Skipped | Harness-gap |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|
 | Server | 51 | 135 | 112 | 1 | 7 | 6 | 9 | 0 |
-| Client | 40 | 1232 | 451 | 18 | 4 | 753 | 6 | 1 |
-| **Total** | **91** | **1367** | **563** | **19** | **11** | **759** | **15** | **1** |
+| Client | 40 | 1204 | 440 | 17 | 4 | 737 | 6 | 1 |
+| **Total** | **91** | **1339** | **552** | **18** | **11** | **743** | **15** | **1** |
 
 ## Harness gaps
 
@@ -33,7 +33,6 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 | `auth/iss-supported-missing` | client | partial | 14 pass / 1 fail / 24 info |  |
 | `auth/iss-unexpected` | client | partial | 14 pass / 1 fail / 24 info |  |
 | `auth/iss-wrong-issuer` | client | partial | 14 pass / 1 fail / 24 info |  |
-| `auth/metadata-issuer-mismatch` | client | partial | 14 pass / 1 fail / 24 info |  |
 | `initialize` | client | partial | 1 fail / 1 info |  |
 | `request-metadata` | client | harness-gap | — | No `checks.json` written — driver does not handle this scenario |
 | `auth/authorization-server-migration` | client | pass | 26 pass / 44 info |  |
@@ -41,6 +40,7 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 | `auth/iss-not-advertised` | client | pass | 15 pass / 24 info |  |
 | `auth/iss-supported` | client | pass | 15 pass / 24 info |  |
 | `auth/metadata-default` | client | pass | 14 pass / 24 info |  |
+| `auth/metadata-issuer-mismatch` | client | pass | 3 pass / 8 info |  |
 | `auth/metadata-var1` | client | pass | 14 pass / 26 info |  |
 | `auth/metadata-var2` | client | pass | 14 pass / 26 info |  |
 | `auth/metadata-var3` | client | pass | 14 pass / 26 info |  |

--- a/examples/auth/go.mod
+++ b/examples/auth/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/panyam/mcpkit v0.2.41
 	github.com/panyam/mcpkit/examples/common v0.0.0-00010101000000-000000000000
 	github.com/panyam/mcpkit/ext/auth v0.2.36
-	github.com/panyam/oneauth v0.1.10
+	github.com/panyam/oneauth v0.1.11
 )
 
 require (

--- a/examples/auth/go.sum
+++ b/examples/auth/go.sum
@@ -83,8 +83,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.13 h1:V819IdZTEJ3rpu33ZqohC6O9ou7KOu6cxfigoYT12OQ=
 github.com/panyam/goutils v0.1.13/go.mod h1:vd3iFcv1DjaeV6h8tslIJh9d09RLndg8UYNSGROBrM4=
-github.com/panyam/oneauth v0.1.10 h1:/v4x+IED7EwlMmvIyK7WvXngChBdAAC8n9in8Ld17uo=
-github.com/panyam/oneauth v0.1.10/go.mod h1:kujwUd36OsM8WyA4c++5acpK2yAgVX3Qa0iu4oI8Cp8=
+github.com/panyam/oneauth v0.1.11 h1:ltKd+Zjqp3/2iZRFzV+3q6zGS9mV75PXOTnl+j+gFv4=
+github.com/panyam/oneauth v0.1.11/go.mod h1:kujwUd36OsM8WyA4c++5acpK2yAgVX3Qa0iu4oI8Cp8=
 github.com/panyam/servicekit v0.1.1 h1:aIvVWjpIw2xBF5V4hpf7GY4RqinkY7u3OBbjQd8a1vU=
 github.com/panyam/servicekit v0.1.1/go.mod h1:kvuEgs3iJjwRyqGlKTkppwiFDpM69MPeihVi1m/B97o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/examples/events/discord/go.mod
+++ b/examples/events/discord/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/panyam/demokit/notebook v0.0.25 // indirect
 	github.com/panyam/gocurrent v0.1.1 // indirect
 	github.com/panyam/goutils v0.1.13 // indirect
-	github.com/panyam/oneauth v0.1.10 // indirect
+	github.com/panyam/oneauth v0.1.11 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect

--- a/examples/events/discord/go.sum
+++ b/examples/events/discord/go.sum
@@ -86,8 +86,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.13 h1:V819IdZTEJ3rpu33ZqohC6O9ou7KOu6cxfigoYT12OQ=
 github.com/panyam/goutils v0.1.13/go.mod h1:vd3iFcv1DjaeV6h8tslIJh9d09RLndg8UYNSGROBrM4=
-github.com/panyam/oneauth v0.1.10 h1:/v4x+IED7EwlMmvIyK7WvXngChBdAAC8n9in8Ld17uo=
-github.com/panyam/oneauth v0.1.10/go.mod h1:kujwUd36OsM8WyA4c++5acpK2yAgVX3Qa0iu4oI8Cp8=
+github.com/panyam/oneauth v0.1.11 h1:ltKd+Zjqp3/2iZRFzV+3q6zGS9mV75PXOTnl+j+gFv4=
+github.com/panyam/oneauth v0.1.11/go.mod h1:kujwUd36OsM8WyA4c++5acpK2yAgVX3Qa0iu4oI8Cp8=
 github.com/panyam/servicekit v0.1.1 h1:aIvVWjpIw2xBF5V4hpf7GY4RqinkY7u3OBbjQd8a1vU=
 github.com/panyam/servicekit v0.1.1/go.mod h1:kvuEgs3iJjwRyqGlKTkppwiFDpM69MPeihVi1m/B97o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/examples/events/telegram/go.mod
+++ b/examples/events/telegram/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/panyam/demokit/notebook v0.0.25 // indirect
 	github.com/panyam/gocurrent v0.1.1 // indirect
 	github.com/panyam/goutils v0.1.13 // indirect
-	github.com/panyam/oneauth v0.1.10 // indirect
+	github.com/panyam/oneauth v0.1.11 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect

--- a/examples/events/telegram/go.sum
+++ b/examples/events/telegram/go.sum
@@ -85,8 +85,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.13 h1:V819IdZTEJ3rpu33ZqohC6O9ou7KOu6cxfigoYT12OQ=
 github.com/panyam/goutils v0.1.13/go.mod h1:vd3iFcv1DjaeV6h8tslIJh9d09RLndg8UYNSGROBrM4=
-github.com/panyam/oneauth v0.1.10 h1:/v4x+IED7EwlMmvIyK7WvXngChBdAAC8n9in8Ld17uo=
-github.com/panyam/oneauth v0.1.10/go.mod h1:kujwUd36OsM8WyA4c++5acpK2yAgVX3Qa0iu4oI8Cp8=
+github.com/panyam/oneauth v0.1.11 h1:ltKd+Zjqp3/2iZRFzV+3q6zGS9mV75PXOTnl+j+gFv4=
+github.com/panyam/oneauth v0.1.11/go.mod h1:kujwUd36OsM8WyA4c++5acpK2yAgVX3Qa0iu4oI8Cp8=
 github.com/panyam/servicekit v0.1.1 h1:aIvVWjpIw2xBF5V4hpf7GY4RqinkY7u3OBbjQd8a1vU=
 github.com/panyam/servicekit v0.1.1/go.mod h1:kvuEgs3iJjwRyqGlKTkppwiFDpM69MPeihVi1m/B97o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/examples/fine-grained-auth/go.mod
+++ b/examples/fine-grained-auth/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/panyam/mcpkit v0.2.41
 	github.com/panyam/mcpkit/examples/common v0.0.0-00010101000000-000000000000
 	github.com/panyam/mcpkit/ext/auth v0.2.36
-	github.com/panyam/oneauth v0.1.10
+	github.com/panyam/oneauth v0.1.11
 	github.com/panyam/servicekit v0.1.1
 )
 

--- a/examples/fine-grained-auth/go.sum
+++ b/examples/fine-grained-auth/go.sum
@@ -83,8 +83,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.13 h1:V819IdZTEJ3rpu33ZqohC6O9ou7KOu6cxfigoYT12OQ=
 github.com/panyam/goutils v0.1.13/go.mod h1:vd3iFcv1DjaeV6h8tslIJh9d09RLndg8UYNSGROBrM4=
-github.com/panyam/oneauth v0.1.10 h1:/v4x+IED7EwlMmvIyK7WvXngChBdAAC8n9in8Ld17uo=
-github.com/panyam/oneauth v0.1.10/go.mod h1:kujwUd36OsM8WyA4c++5acpK2yAgVX3Qa0iu4oI8Cp8=
+github.com/panyam/oneauth v0.1.11 h1:ltKd+Zjqp3/2iZRFzV+3q6zGS9mV75PXOTnl+j+gFv4=
+github.com/panyam/oneauth v0.1.11/go.mod h1:kujwUd36OsM8WyA4c++5acpK2yAgVX3Qa0iu4oI8Cp8=
 github.com/panyam/servicekit v0.1.1 h1:aIvVWjpIw2xBF5V4hpf7GY4RqinkY7u3OBbjQd8a1vU=
 github.com/panyam/servicekit v0.1.1/go.mod h1:kvuEgs3iJjwRyqGlKTkppwiFDpM69MPeihVi1m/B97o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/ext/auth/go.mod
+++ b/ext/auth/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/panyam/gocurrent v0.1.1
 	github.com/panyam/mcpkit v0.2.3
-	github.com/panyam/oneauth v0.1.10
+	github.com/panyam/oneauth v0.1.11
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/ext/auth/go.sum
+++ b/ext/auth/go.sum
@@ -34,8 +34,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.8 h1:5UscYTP892k54+Nyb01tKGGwZxczZ5k7BC+c0nXmcoc=
 github.com/panyam/goutils v0.1.8/go.mod h1:ntucs8GJOHQ0LmlRGRjeup3aDC2t7xPMudrRwUHrJNM=
-github.com/panyam/oneauth v0.1.10 h1:/v4x+IED7EwlMmvIyK7WvXngChBdAAC8n9in8Ld17uo=
-github.com/panyam/oneauth v0.1.10/go.mod h1:kujwUd36OsM8WyA4c++5acpK2yAgVX3Qa0iu4oI8Cp8=
+github.com/panyam/oneauth v0.1.11 h1:ltKd+Zjqp3/2iZRFzV+3q6zGS9mV75PXOTnl+j+gFv4=
+github.com/panyam/oneauth v0.1.11/go.mod h1:kujwUd36OsM8WyA4c++5acpK2yAgVX3Qa0iu4oI8Cp8=
 github.com/panyam/servicekit v0.0.25 h1:JeTRyz5ZZY3beENg0N3tLW+O39/foTuHMPAf+rpwYhM=
 github.com/panyam/servicekit v0.0.25/go.mod h1:9TkF2LRqiPC9bgu0bYVdky7rnHEuBvzGzrsoL++Ra5c=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/panyam/mcpkit v0.2.3
 	github.com/panyam/mcpkit/ext/auth v0.0.0
 	github.com/panyam/mcpkit/ext/ui v0.0.0
-	github.com/panyam/oneauth v0.1.10
+	github.com/panyam/oneauth v0.1.11
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/tests/e2e/go.sum
+++ b/tests/e2e/go.sum
@@ -33,8 +33,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.8 h1:5UscYTP892k54+Nyb01tKGGwZxczZ5k7BC+c0nXmcoc=
 github.com/panyam/goutils v0.1.8/go.mod h1:ntucs8GJOHQ0LmlRGRjeup3aDC2t7xPMudrRwUHrJNM=
-github.com/panyam/oneauth v0.1.10 h1:/v4x+IED7EwlMmvIyK7WvXngChBdAAC8n9in8Ld17uo=
-github.com/panyam/oneauth v0.1.10/go.mod h1:kujwUd36OsM8WyA4c++5acpK2yAgVX3Qa0iu4oI8Cp8=
+github.com/panyam/oneauth v0.1.11 h1:ltKd+Zjqp3/2iZRFzV+3q6zGS9mV75PXOTnl+j+gFv4=
+github.com/panyam/oneauth v0.1.11/go.mod h1:kujwUd36OsM8WyA4c++5acpK2yAgVX3Qa0iu4oI8Cp8=
 github.com/panyam/servicekit v0.0.25 h1:JeTRyz5ZZY3beENg0N3tLW+O39/foTuHMPAf+rpwYhM=
 github.com/panyam/servicekit v0.0.25/go.mod h1:9TkF2LRqiPC9bgu0bYVdky7rnHEuBvzGzrsoL++Ra5c=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/tests/keycloak/go.mod
+++ b/tests/keycloak/go.mod
@@ -5,7 +5,7 @@ go 1.26.3
 require (
 	github.com/panyam/mcpkit v0.2.3
 	github.com/panyam/mcpkit/ext/auth v0.0.0
-	github.com/panyam/oneauth v0.1.10
+	github.com/panyam/oneauth v0.1.11
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/tests/keycloak/go.sum
+++ b/tests/keycloak/go.sum
@@ -33,8 +33,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.8 h1:5UscYTP892k54+Nyb01tKGGwZxczZ5k7BC+c0nXmcoc=
 github.com/panyam/goutils v0.1.8/go.mod h1:ntucs8GJOHQ0LmlRGRjeup3aDC2t7xPMudrRwUHrJNM=
-github.com/panyam/oneauth v0.1.10 h1:/v4x+IED7EwlMmvIyK7WvXngChBdAAC8n9in8Ld17uo=
-github.com/panyam/oneauth v0.1.10/go.mod h1:kujwUd36OsM8WyA4c++5acpK2yAgVX3Qa0iu4oI8Cp8=
+github.com/panyam/oneauth v0.1.11 h1:ltKd+Zjqp3/2iZRFzV+3q6zGS9mV75PXOTnl+j+gFv4=
+github.com/panyam/oneauth v0.1.11/go.mod h1:kujwUd36OsM8WyA4c++5acpK2yAgVX3Qa0iu4oI8Cp8=
 github.com/panyam/servicekit v0.0.25 h1:JeTRyz5ZZY3beENg0N3tLW+O39/foTuHMPAf+rpwYhM=
 github.com/panyam/servicekit v0.0.25/go.mod h1:9TkF2LRqiPC9bgu0bYVdky7rnHEuBvzGzrsoL++Ra5c=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
## Summary

panyam/oneauth#235 (merged, released as v0.1.11) added RFC 8414 §3.3 metadata-issuer validation in `client.DiscoverAS` and surfaces the RFC 9207 `iss` query parameter on OAuth callback results. Consuming the release flips one audit scenario green automatically and **unblocks #380's mcpkit-side iss-validation policy work** which couldn't proceed without the new oneauth surface.

## Reviewer's guide

1. `go.mod` — start here. Just the version pin bump (v0.1.10 → v0.1.11).
2. [conformance/UPSTREAM_AUDIT.md](https://github.com/panyam/mcpkit/pull/505/files#diff-bf63f1699e28f43c702f9450df02d9e8ec1dae36200827f929a68513bdb34197) — regenerated. Confirms `auth/metadata-issuer-mismatch` flipped from fail to pass purely from the bump.
3. The other 15 touched files are mechanical `go.mod`/`go.sum` updates from `make tidy-all` across the 8 other modules carrying the pin.

Skim or skip: every non-root `go.mod` / `go.sum` — pure version-pin propagation.

## Decision log

- **No mcpkit-side code change in this PR.** oneauth#235's two features (Iss exposure + metadata-issuer validation) are surgical: the metadata-issuer check fires inside `client.DiscoverAS` and the Iss field is now populated on callback-result structs. The iss validation policy itself (read the field, compare against advertised AS, accept/reject per RFC 9207 §2.4) is mcpkit's concern and lives in #380.
- **Why this is a separate PR from #380 (Cluster A).** #380 is a non-trivial mcpkit code change (policy logic, RFC 3986 normalization, AS-advertisement gating). Bundling the bump with #380 would make the dep-bump diff impossible to spot among the policy work. Separate PRs preserve the "boring dep bump that flips one scenario" framing for this one and the "non-trivial security policy" framing for #380.

## Risk / blast radius

- **Affects:** every module pinning oneauth. No mcpkit API surface changed.
- **Tests covering this:** `make test` + `make test-auth` + `go test ./tests/e2e/...` all green post-bump. Audit confirms the one flip without any other regressions.
- **Be paranoid about:** other downstream behavior changes in oneauth v0.1.11. I reviewed oneauth#235's diff scope — it's narrow and additive (Iss exposure + DiscoverAS validation). If anything else changed, the build / test sweep would have surfaced it.

## Before / after

| Audit row | Before this PR | After this PR |
|---|---|---|
| `auth/metadata-issuer-mismatch` (Cluster B) | fail (1 check) | pass (3 checks) |
| `auth/iss-*` (Cluster A, 4 scenarios) | partial (1 fail each) | unchanged — needs #380 |
| Server | 112 pass / 1 fail | unchanged |
| Client | 451 pass / 18 fail | 440 pass / 17 fail (−1 fail; passing-check count dipped because the now-rejected metadata scenario emits fewer follow-on checks) |

## Out of scope

- **Cluster A** (RFC 9207 iss validation, 4 scenarios) — tracked in #380. This bump unblocks it; implementation lands in a follow-up PR that reads `callbackResult.Iss` and applies the RFC 9207 §2.4 comparison rules.
