### PR TITLE
auth: RFC 9207 iss validation — closes all 4 SEP-2468 scenarios (#380, full)

### DIFF
--- a/cmd/testclient/go.mod
+++ b/cmd/testclient/go.mod
@@ -5,7 +5,7 @@ go 1.26.3
 require (
 	github.com/panyam/mcpkit v0.2.3
 	github.com/panyam/mcpkit/ext/auth v0.0.0
-	github.com/panyam/oneauth v0.1.11
+	github.com/panyam/oneauth v0.1.12
 )
 
 require (

--- a/cmd/testclient/go.sum
+++ b/cmd/testclient/go.sum
@@ -33,8 +33,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.8 h1:5UscYTP892k54+Nyb01tKGGwZxczZ5k7BC+c0nXmcoc=
 github.com/panyam/goutils v0.1.8/go.mod h1:ntucs8GJOHQ0LmlRGRjeup3aDC2t7xPMudrRwUHrJNM=
-github.com/panyam/oneauth v0.1.11 h1:ltKd+Zjqp3/2iZRFzV+3q6zGS9mV75PXOTnl+j+gFv4=
-github.com/panyam/oneauth v0.1.11/go.mod h1:kujwUd36OsM8WyA4c++5acpK2yAgVX3Qa0iu4oI8Cp8=
+github.com/panyam/oneauth v0.1.12 h1:QP4cBhpGdaGAJRXaBqDBV8r+Qn8pMD6rpsQpfLijoaQ=
+github.com/panyam/oneauth v0.1.12/go.mod h1:kujwUd36OsM8WyA4c++5acpK2yAgVX3Qa0iu4oI8Cp8=
 github.com/panyam/servicekit v0.0.25 h1:JeTRyz5ZZY3beENg0N3tLW+O39/foTuHMPAf+rpwYhM=
 github.com/panyam/servicekit v0.0.25/go.mod h1:9TkF2LRqiPC9bgu0bYVdky7rnHEuBvzGzrsoL++Ra5c=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/conformance/UPSTREAM_AUDIT.md
+++ b/conformance/UPSTREAM_AUDIT.md
@@ -14,8 +14,8 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 | Surface | Scenarios | Checks | Pass | Fail | Warn | Info | Skipped | Harness-gap |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|
 | Server | 51 | 135 | 112 | 1 | 7 | 6 | 9 | 0 |
-| Client | 40 | 1204 | 440 | 17 | 4 | 737 | 6 | 1 |
-| **Total** | **91** | **1339** | **552** | **18** | **11** | **743** | **15** | **1** |
+| Client | 40 | 1147 | 422 | 14 | 4 | 701 | 6 | 1 |
+| **Total** | **91** | **1282** | **534** | **15** | **11** | **707** | **15** | **1** |
 
 ## Harness gaps
 
@@ -29,16 +29,16 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 |---|---|---|---|---|
 | `auth/2025-03-26-oauth-endpoint-fallback` | client | partial | 3 fail / 8 info |  |
 | `auth/2025-03-26-oauth-metadata-backcompat` | client | partial | 4 fail / 8 info |  |
-| `auth/iss-normalized` | client | partial | 14 pass / 1 fail / 24 info |  |
 | `auth/iss-supported-missing` | client | partial | 14 pass / 1 fail / 24 info |  |
-| `auth/iss-unexpected` | client | partial | 14 pass / 1 fail / 24 info |  |
-| `auth/iss-wrong-issuer` | client | partial | 14 pass / 1 fail / 24 info |  |
 | `initialize` | client | partial | 1 fail / 1 info |  |
 | `request-metadata` | client | harness-gap | — | No `checks.json` written — driver does not handle this scenario |
 | `auth/authorization-server-migration` | client | pass | 26 pass / 44 info |  |
 | `auth/basic-cimd` | client | pass | 14 pass / 1 warn / 24 info |  |
+| `auth/iss-normalized` | client | pass | 8 pass / 12 info |  |
 | `auth/iss-not-advertised` | client | pass | 15 pass / 24 info |  |
 | `auth/iss-supported` | client | pass | 15 pass / 24 info |  |
+| `auth/iss-unexpected` | client | pass | 8 pass / 12 info |  |
+| `auth/iss-wrong-issuer` | client | pass | 8 pass / 12 info |  |
 | `auth/metadata-default` | client | pass | 14 pass / 24 info |  |
 | `auth/metadata-issuer-mismatch` | client | pass | 3 pass / 8 info |  |
 | `auth/metadata-var1` | client | pass | 14 pass / 26 info |  |

--- a/conformance/UPSTREAM_AUDIT.md
+++ b/conformance/UPSTREAM_AUDIT.md
@@ -14,8 +14,8 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 | Surface | Scenarios | Checks | Pass | Fail | Warn | Info | Skipped | Harness-gap |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|
 | Server | 51 | 135 | 112 | 1 | 7 | 6 | 9 | 0 |
-| Client | 40 | 1147 | 422 | 14 | 4 | 701 | 6 | 1 |
-| **Total** | **91** | **1282** | **534** | **15** | **11** | **707** | **15** | **1** |
+| Client | 40 | 1128 | 416 | 13 | 4 | 689 | 6 | 1 |
+| **Total** | **91** | **1263** | **528** | **14** | **11** | **695** | **15** | **1** |
 
 ## Harness gaps
 
@@ -29,7 +29,6 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 |---|---|---|---|---|
 | `auth/2025-03-26-oauth-endpoint-fallback` | client | partial | 3 fail / 8 info |  |
 | `auth/2025-03-26-oauth-metadata-backcompat` | client | partial | 4 fail / 8 info |  |
-| `auth/iss-supported-missing` | client | partial | 14 pass / 1 fail / 24 info |  |
 | `initialize` | client | partial | 1 fail / 1 info |  |
 | `request-metadata` | client | harness-gap | — | No `checks.json` written — driver does not handle this scenario |
 | `auth/authorization-server-migration` | client | pass | 26 pass / 44 info |  |
@@ -37,6 +36,7 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 | `auth/iss-normalized` | client | pass | 8 pass / 12 info |  |
 | `auth/iss-not-advertised` | client | pass | 15 pass / 24 info |  |
 | `auth/iss-supported` | client | pass | 15 pass / 24 info |  |
+| `auth/iss-supported-missing` | client | pass | 8 pass / 12 info |  |
 | `auth/iss-unexpected` | client | pass | 8 pass / 12 info |  |
 | `auth/iss-wrong-issuer` | client | pass | 8 pass / 12 info |  |
 | `auth/metadata-default` | client | pass | 14 pass / 24 info |  |

--- a/examples/auth/go.mod
+++ b/examples/auth/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/panyam/mcpkit v0.2.41
 	github.com/panyam/mcpkit/examples/common v0.0.0-00010101000000-000000000000
 	github.com/panyam/mcpkit/ext/auth v0.2.36
-	github.com/panyam/oneauth v0.1.11
+	github.com/panyam/oneauth v0.1.12
 )
 
 require (

--- a/examples/auth/go.sum
+++ b/examples/auth/go.sum
@@ -83,8 +83,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.13 h1:V819IdZTEJ3rpu33ZqohC6O9ou7KOu6cxfigoYT12OQ=
 github.com/panyam/goutils v0.1.13/go.mod h1:vd3iFcv1DjaeV6h8tslIJh9d09RLndg8UYNSGROBrM4=
-github.com/panyam/oneauth v0.1.11 h1:ltKd+Zjqp3/2iZRFzV+3q6zGS9mV75PXOTnl+j+gFv4=
-github.com/panyam/oneauth v0.1.11/go.mod h1:kujwUd36OsM8WyA4c++5acpK2yAgVX3Qa0iu4oI8Cp8=
+github.com/panyam/oneauth v0.1.12 h1:QP4cBhpGdaGAJRXaBqDBV8r+Qn8pMD6rpsQpfLijoaQ=
+github.com/panyam/oneauth v0.1.12/go.mod h1:kujwUd36OsM8WyA4c++5acpK2yAgVX3Qa0iu4oI8Cp8=
 github.com/panyam/servicekit v0.1.1 h1:aIvVWjpIw2xBF5V4hpf7GY4RqinkY7u3OBbjQd8a1vU=
 github.com/panyam/servicekit v0.1.1/go.mod h1:kvuEgs3iJjwRyqGlKTkppwiFDpM69MPeihVi1m/B97o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/examples/events/discord/go.mod
+++ b/examples/events/discord/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/panyam/demokit/notebook v0.0.25 // indirect
 	github.com/panyam/gocurrent v0.1.1 // indirect
 	github.com/panyam/goutils v0.1.13 // indirect
-	github.com/panyam/oneauth v0.1.11 // indirect
+	github.com/panyam/oneauth v0.1.12 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect

--- a/examples/events/discord/go.sum
+++ b/examples/events/discord/go.sum
@@ -86,8 +86,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.13 h1:V819IdZTEJ3rpu33ZqohC6O9ou7KOu6cxfigoYT12OQ=
 github.com/panyam/goutils v0.1.13/go.mod h1:vd3iFcv1DjaeV6h8tslIJh9d09RLndg8UYNSGROBrM4=
-github.com/panyam/oneauth v0.1.11 h1:ltKd+Zjqp3/2iZRFzV+3q6zGS9mV75PXOTnl+j+gFv4=
-github.com/panyam/oneauth v0.1.11/go.mod h1:kujwUd36OsM8WyA4c++5acpK2yAgVX3Qa0iu4oI8Cp8=
+github.com/panyam/oneauth v0.1.12 h1:QP4cBhpGdaGAJRXaBqDBV8r+Qn8pMD6rpsQpfLijoaQ=
+github.com/panyam/oneauth v0.1.12/go.mod h1:kujwUd36OsM8WyA4c++5acpK2yAgVX3Qa0iu4oI8Cp8=
 github.com/panyam/servicekit v0.1.1 h1:aIvVWjpIw2xBF5V4hpf7GY4RqinkY7u3OBbjQd8a1vU=
 github.com/panyam/servicekit v0.1.1/go.mod h1:kvuEgs3iJjwRyqGlKTkppwiFDpM69MPeihVi1m/B97o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/examples/events/telegram/go.mod
+++ b/examples/events/telegram/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/panyam/demokit/notebook v0.0.25 // indirect
 	github.com/panyam/gocurrent v0.1.1 // indirect
 	github.com/panyam/goutils v0.1.13 // indirect
-	github.com/panyam/oneauth v0.1.11 // indirect
+	github.com/panyam/oneauth v0.1.12 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect

--- a/examples/events/telegram/go.sum
+++ b/examples/events/telegram/go.sum
@@ -85,8 +85,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.13 h1:V819IdZTEJ3rpu33ZqohC6O9ou7KOu6cxfigoYT12OQ=
 github.com/panyam/goutils v0.1.13/go.mod h1:vd3iFcv1DjaeV6h8tslIJh9d09RLndg8UYNSGROBrM4=
-github.com/panyam/oneauth v0.1.11 h1:ltKd+Zjqp3/2iZRFzV+3q6zGS9mV75PXOTnl+j+gFv4=
-github.com/panyam/oneauth v0.1.11/go.mod h1:kujwUd36OsM8WyA4c++5acpK2yAgVX3Qa0iu4oI8Cp8=
+github.com/panyam/oneauth v0.1.12 h1:QP4cBhpGdaGAJRXaBqDBV8r+Qn8pMD6rpsQpfLijoaQ=
+github.com/panyam/oneauth v0.1.12/go.mod h1:kujwUd36OsM8WyA4c++5acpK2yAgVX3Qa0iu4oI8Cp8=
 github.com/panyam/servicekit v0.1.1 h1:aIvVWjpIw2xBF5V4hpf7GY4RqinkY7u3OBbjQd8a1vU=
 github.com/panyam/servicekit v0.1.1/go.mod h1:kvuEgs3iJjwRyqGlKTkppwiFDpM69MPeihVi1m/B97o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/examples/fine-grained-auth/go.mod
+++ b/examples/fine-grained-auth/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/panyam/mcpkit v0.2.41
 	github.com/panyam/mcpkit/examples/common v0.0.0-00010101000000-000000000000
 	github.com/panyam/mcpkit/ext/auth v0.2.36
-	github.com/panyam/oneauth v0.1.11
+	github.com/panyam/oneauth v0.1.12
 	github.com/panyam/servicekit v0.1.1
 )
 

--- a/examples/fine-grained-auth/go.sum
+++ b/examples/fine-grained-auth/go.sum
@@ -83,8 +83,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.13 h1:V819IdZTEJ3rpu33ZqohC6O9ou7KOu6cxfigoYT12OQ=
 github.com/panyam/goutils v0.1.13/go.mod h1:vd3iFcv1DjaeV6h8tslIJh9d09RLndg8UYNSGROBrM4=
-github.com/panyam/oneauth v0.1.11 h1:ltKd+Zjqp3/2iZRFzV+3q6zGS9mV75PXOTnl+j+gFv4=
-github.com/panyam/oneauth v0.1.11/go.mod h1:kujwUd36OsM8WyA4c++5acpK2yAgVX3Qa0iu4oI8Cp8=
+github.com/panyam/oneauth v0.1.12 h1:QP4cBhpGdaGAJRXaBqDBV8r+Qn8pMD6rpsQpfLijoaQ=
+github.com/panyam/oneauth v0.1.12/go.mod h1:kujwUd36OsM8WyA4c++5acpK2yAgVX3Qa0iu4oI8Cp8=
 github.com/panyam/servicekit v0.1.1 h1:aIvVWjpIw2xBF5V4hpf7GY4RqinkY7u3OBbjQd8a1vU=
 github.com/panyam/servicekit v0.1.1/go.mod h1:kvuEgs3iJjwRyqGlKTkppwiFDpM69MPeihVi1m/B97o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/ext/auth/go.mod
+++ b/ext/auth/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/panyam/gocurrent v0.1.1
 	github.com/panyam/mcpkit v0.2.3
-	github.com/panyam/oneauth v0.1.11
+	github.com/panyam/oneauth v0.1.12
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/ext/auth/go.sum
+++ b/ext/auth/go.sum
@@ -34,8 +34,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.8 h1:5UscYTP892k54+Nyb01tKGGwZxczZ5k7BC+c0nXmcoc=
 github.com/panyam/goutils v0.1.8/go.mod h1:ntucs8GJOHQ0LmlRGRjeup3aDC2t7xPMudrRwUHrJNM=
-github.com/panyam/oneauth v0.1.11 h1:ltKd+Zjqp3/2iZRFzV+3q6zGS9mV75PXOTnl+j+gFv4=
-github.com/panyam/oneauth v0.1.11/go.mod h1:kujwUd36OsM8WyA4c++5acpK2yAgVX3Qa0iu4oI8Cp8=
+github.com/panyam/oneauth v0.1.12 h1:QP4cBhpGdaGAJRXaBqDBV8r+Qn8pMD6rpsQpfLijoaQ=
+github.com/panyam/oneauth v0.1.12/go.mod h1:kujwUd36OsM8WyA4c++5acpK2yAgVX3Qa0iu4oI8Cp8=
 github.com/panyam/servicekit v0.0.25 h1:JeTRyz5ZZY3beENg0N3tLW+O39/foTuHMPAf+rpwYhM=
 github.com/panyam/servicekit v0.0.25/go.mod h1:9TkF2LRqiPC9bgu0bYVdky7rnHEuBvzGzrsoL++Ra5c=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/ext/auth/iss_validator.go
+++ b/ext/auth/iss_validator.go
@@ -1,0 +1,71 @@
+package auth
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrIssMismatch is returned by the OAuth callback when the RFC 9207
+// `iss` query parameter is present in the authorization response but
+// does not match the issuer identifier of the authorization server the
+// client sent the user to.
+//
+// This is the OAuth-callback analogue of an issuer-mismatch attack
+// (RFC 9207 Mix-Up Protection): an attacker substitutes a different
+// AS's redirect with a code that LOOKS valid (matching state, correct
+// shape) but `iss` carries the attacker's AS identifier. Without this
+// check the client would proceed to token exchange against the wrong
+// AS and accept a token minted by an unintended issuer.
+//
+// Wrapped with diagnostic context (PRM issuer, observed iss) so
+// callers logging the error can see what was rejected; consumers
+// branching on the failure mode should use errors.Is.
+var ErrIssMismatch = errors.New("RFC 9207 iss does not match authorization server issuer")
+
+// ErrIssMissing is returned when the authorization server advertised
+// `authorization_response_iss_parameter_supported: true` in its AS
+// metadata but the authorization response omitted the `iss` query
+// parameter. RFC 9207 §2.4 says clients MUST treat the parameter as
+// REQUIRED when the AS advertises support — silently accepting the
+// omission would degrade the mix-up protection the advertisement
+// promised.
+//
+// Distinct from ErrIssMismatch so audit / log consumers can tell
+// "advertised but absent" apart from "present but wrong" — different
+// failure modes, different remediation.
+var ErrIssMissing = errors.New("RFC 9207 iss missing despite authorization server advertising support")
+
+// validateIss applies the RFC 9207 §2.4 client-side validation rule
+// against an `iss` query parameter received on an OAuth callback.
+// Wired into OAuthTokenSource via the oneauth BrowserLoginRequest
+// OnCallback hook (since oneauth#235 surfaces but does not enforce);
+// kept package-private because the only consumer today is the token
+// source's callback closure.
+//
+// Rules (RFC 9207 §2.4 default mode, strict-mode tracked separately
+// via panyam/oneauth#238):
+//
+//	iss present + matches expected  → nil
+//	iss present + mismatches        → ErrIssMismatch
+//	iss absent + AS advertised      → ErrIssMissing
+//	iss absent + AS did not advertise → nil (legacy AS, pre-9207)
+//
+// Comparison is byte-for-byte. RFC 9207 §2.4 explicitly forbids
+// normalization (case folding, default-port elision, trailing-slash,
+// percent-encoding) — the upstream `sep-2468-client-no-normalization`
+// check enforces this. Distinct from PRM resource validation
+// (discovery.go), which DOES normalize because RFC 8707 has different
+// semantics; conflating the two rules would defeat the mix-up
+// protection the byte-strict comparison is designed to provide.
+func validateIss(iss, expectedIssuer string, asAdvertisedSupport bool) error {
+	if iss == "" {
+		if asAdvertisedSupport {
+			return fmt.Errorf("%w: expected=%q", ErrIssMissing, expectedIssuer)
+		}
+		return nil
+	}
+	if iss != expectedIssuer {
+		return fmt.Errorf("%w: got=%q expected=%q", ErrIssMismatch, iss, expectedIssuer)
+	}
+	return nil
+}

--- a/ext/auth/iss_validator_test.go
+++ b/ext/auth/iss_validator_test.go
@@ -1,0 +1,129 @@
+package auth
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestValidateIss covers the SEP-2468 / RFC 9207 §2.4 comparison
+// rules across the four upstream conformance scenarios + the
+// normalization edge cases mcpkit chose to accept.
+//
+// Rule recap (default mode, strict=false):
+//
+//	iss empty + !advertised → accept (legacy AS pre-9207)
+//	iss empty + advertised  → ErrIssMissing
+//	iss present             → must equal expected after RFC 3986
+//	                          §6.2 normalization, else ErrIssMismatch
+func TestValidateIss(t *testing.T) {
+	cases := []struct {
+		name        string
+		iss         string
+		expected    string
+		advertised  bool
+		wantErr     error
+	}{
+		{
+			name:       "happy: matches when AS advertised support (iss-supported scenario shape)",
+			iss:        "http://localhost:18099",
+			expected:   "http://localhost:18099",
+			advertised: true,
+			wantErr:    nil,
+		},
+		{
+			name:       "happy: matches when AS did not advertise but sent iss anyway",
+			iss:        "http://localhost:18099",
+			expected:   "http://localhost:18099",
+			advertised: false,
+			wantErr:    nil,
+		},
+		{
+			name:       "iss-supported-missing: AS advertised, iss omitted → reject",
+			iss:        "",
+			expected:   "http://localhost:18099",
+			advertised: true,
+			wantErr:    ErrIssMissing,
+		},
+		{
+			name:       "legacy: AS did not advertise, iss omitted → accept (pre-9207 AS)",
+			iss:        "",
+			expected:   "http://localhost:18099",
+			advertised: false,
+			wantErr:    nil,
+		},
+		{
+			name:       "iss-wrong-issuer: AS advertised, iss mismatches → reject",
+			iss:        "https://evil.example.com",
+			expected:   "http://localhost:18099",
+			advertised: true,
+			wantErr:    ErrIssMismatch,
+		},
+		{
+			name:       "iss-unexpected: AS did NOT advertise but sent wrong iss → reject (presence implies validation)",
+			iss:        "https://evil.example.com",
+			expected:   "http://localhost:18099",
+			advertised: false,
+			wantErr:    ErrIssMismatch,
+		},
+		{
+			// RFC 9207 §2.4 + upstream `sep-2468-client-no-normalization`
+			// scenario: byte-for-byte comparison only. A trailing-slash
+			// variant of the issuer MUST be treated as a mismatch — the
+			// client doesn't get to normalize, since normalization would
+			// defeat the mix-up protection the strict comparison provides.
+			name:       "iss-normalized: trailing-slash variant rejects (strict per RFC 9207)",
+			iss:        "http://localhost:18099/",
+			expected:   "http://localhost:18099",
+			advertised: true,
+			wantErr:    ErrIssMismatch,
+		},
+		{
+			name:       "iss-normalized: trailing-slash variant rejects in both directions",
+			iss:        "http://localhost:18099",
+			expected:   "http://localhost:18099/",
+			advertised: true,
+			wantErr:    ErrIssMismatch,
+		},
+		{
+			name:       "case difference rejects (strict per RFC 9207, no scheme/host folding)",
+			iss:        "HTTP://LocalHost:18099",
+			expected:   "http://localhost:18099",
+			advertised: true,
+			wantErr:    ErrIssMismatch,
+		},
+		{
+			name:       "path mismatch within same origin rejects",
+			iss:        "http://localhost:18099/realm/A",
+			expected:   "http://localhost:18099/realm/B",
+			advertised: true,
+			wantErr:    ErrIssMismatch,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := validateIss(tc.iss, tc.expected, tc.advertised)
+			if tc.wantErr == nil {
+				if got != nil {
+					t.Fatalf("got error %v, want nil", got)
+				}
+				return
+			}
+			if !errors.Is(got, tc.wantErr) {
+				t.Fatalf("got error %v, want errors.Is %v", got, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestValidateIss_StringSurfaceRejected covers a malformed iss value
+// (no URL semantics). Byte comparison can't accidentally match the
+// expected issuer, so the case still rejects — but for a different
+// reason than a parse failure would: the comparison is purely
+// string-equality, never URL-aware.
+func TestValidateIss_StringSurfaceRejected(t *testing.T) {
+	err := validateIss("::not a url::", "http://localhost:18099", true)
+	if !errors.Is(err, ErrIssMismatch) {
+		t.Fatalf("got %v, want errors.Is ErrIssMismatch", err)
+	}
+}

--- a/ext/auth/token_source.go
+++ b/ext/auth/token_source.go
@@ -265,6 +265,23 @@ func (s *OAuthTokenSource) Token() (string, error) {
 	// oneauth 0.1.9 (#217): BrowserLoginConfig renamed to BrowserLoginRequest;
 	// LoginWithBrowser now takes (ctx, *BrowserLoginRequest).
 	expectedIssuer := s.authInfo.AuthorizationServers[0]
+	// SEP-2468 / RFC 9207 §2.4: validate the iss query parameter on the
+	// OAuth callback before token exchange. oneauth surfaces the value
+	// via OnCallback (#235) but explicitly leaves enforcement policy to
+	// the consumer. mcpkit's policy:
+	//   iss present → MUST match expected issuer (byte-for-byte; §2.4
+	//                 forbids normalization)
+	//   iss absent + AS advertised → MUST reject (the advertisement
+	//                                 promise binds the AS)
+	//   iss absent + AS did not advertise → accept (legacy AS pre-9207)
+	//
+	// asAdvertisedSupport is read from the AS metadata field surfaced
+	// by oneauth v0.1.12 (oneauth#239). nil means the AS metadata didn't
+	// include the field at all → treat as legacy.
+	asAdvertisedSupport := false
+	if flag := s.authInfo.ASMetadata.AuthorizationResponseIssParameterSupported; flag != nil && *flag {
+		asAdvertisedSupport = true
+	}
 	loginReq := &client.BrowserLoginRequest{
 		AuthorizationEndpoint:    s.authInfo.ASMetadata.AuthorizationEndpoint,
 		TokenEndpoint:            s.authInfo.ASMetadata.TokenEndpoint,
@@ -274,21 +291,8 @@ func (s *OAuthTokenSource) Token() (string, error) {
 		Scopes:                   scopes,
 		Resource:                 s.ServerURL, // RFC 8707: bind token to this MCP server
 		OpenBrowser:              s.OpenBrowser,
-		// SEP-2468 / RFC 9207 §2.4: validate the iss query parameter on
-		// the OAuth callback before token exchange. oneauth surfaces the
-		// value via OnCallback (#235) but explicitly leaves enforcement
-		// policy to the consumer. mcpkit's policy:
-		//   iss present → MUST match expected issuer
-		//   iss absent  → accept (treated as legacy AS pre-9207)
-		//
-		// The full RFC 9207 §2.4 rule also rejects "iss absent + AS
-		// advertised support" — but that branch needs the
-		// authorization_response_iss_parameter_supported flag which
-		// client.ASMetadata in oneauth v0.1.11 does not yet expose
-		// (tracked at panyam/oneauth#239). Once that lands and we bump,
-		// this closure passes the advertised flag instead of false.
 		OnCallback: func(_ context.Context, p client.CallbackParams) error {
-			return validateIss(p.Iss, expectedIssuer, false /* asAdvertisedSupport */)
+			return validateIss(p.Iss, expectedIssuer, asAdvertisedSupport)
 		},
 	}
 	if s.HTTPClient != nil {

--- a/ext/auth/token_source.go
+++ b/ext/auth/token_source.go
@@ -264,6 +264,7 @@ func (s *OAuthTokenSource) Token() (string, error) {
 	// works correctly even with explicit endpoints (oneauth#74).
 	// oneauth 0.1.9 (#217): BrowserLoginConfig renamed to BrowserLoginRequest;
 	// LoginWithBrowser now takes (ctx, *BrowserLoginRequest).
+	expectedIssuer := s.authInfo.AuthorizationServers[0]
 	loginReq := &client.BrowserLoginRequest{
 		AuthorizationEndpoint:    s.authInfo.ASMetadata.AuthorizationEndpoint,
 		TokenEndpoint:            s.authInfo.ASMetadata.TokenEndpoint,
@@ -273,6 +274,22 @@ func (s *OAuthTokenSource) Token() (string, error) {
 		Scopes:                   scopes,
 		Resource:                 s.ServerURL, // RFC 8707: bind token to this MCP server
 		OpenBrowser:              s.OpenBrowser,
+		// SEP-2468 / RFC 9207 §2.4: validate the iss query parameter on
+		// the OAuth callback before token exchange. oneauth surfaces the
+		// value via OnCallback (#235) but explicitly leaves enforcement
+		// policy to the consumer. mcpkit's policy:
+		//   iss present → MUST match expected issuer
+		//   iss absent  → accept (treated as legacy AS pre-9207)
+		//
+		// The full RFC 9207 §2.4 rule also rejects "iss absent + AS
+		// advertised support" — but that branch needs the
+		// authorization_response_iss_parameter_supported flag which
+		// client.ASMetadata in oneauth v0.1.11 does not yet expose
+		// (tracked at panyam/oneauth#239). Once that lands and we bump,
+		// this closure passes the advertised flag instead of false.
+		OnCallback: func(_ context.Context, p client.CallbackParams) error {
+			return validateIss(p.Iss, expectedIssuer, false /* asAdvertisedSupport */)
+		},
 	}
 	if s.HTTPClient != nil {
 		loginReq.HTTPClient = s.HTTPClient

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/panyam/mcpkit v0.2.3
 	github.com/panyam/mcpkit/ext/auth v0.0.0
 	github.com/panyam/mcpkit/ext/ui v0.0.0
-	github.com/panyam/oneauth v0.1.11
+	github.com/panyam/oneauth v0.1.12
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/tests/e2e/go.sum
+++ b/tests/e2e/go.sum
@@ -33,8 +33,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.8 h1:5UscYTP892k54+Nyb01tKGGwZxczZ5k7BC+c0nXmcoc=
 github.com/panyam/goutils v0.1.8/go.mod h1:ntucs8GJOHQ0LmlRGRjeup3aDC2t7xPMudrRwUHrJNM=
-github.com/panyam/oneauth v0.1.11 h1:ltKd+Zjqp3/2iZRFzV+3q6zGS9mV75PXOTnl+j+gFv4=
-github.com/panyam/oneauth v0.1.11/go.mod h1:kujwUd36OsM8WyA4c++5acpK2yAgVX3Qa0iu4oI8Cp8=
+github.com/panyam/oneauth v0.1.12 h1:QP4cBhpGdaGAJRXaBqDBV8r+Qn8pMD6rpsQpfLijoaQ=
+github.com/panyam/oneauth v0.1.12/go.mod h1:kujwUd36OsM8WyA4c++5acpK2yAgVX3Qa0iu4oI8Cp8=
 github.com/panyam/servicekit v0.0.25 h1:JeTRyz5ZZY3beENg0N3tLW+O39/foTuHMPAf+rpwYhM=
 github.com/panyam/servicekit v0.0.25/go.mod h1:9TkF2LRqiPC9bgu0bYVdky7rnHEuBvzGzrsoL++Ra5c=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/tests/keycloak/go.mod
+++ b/tests/keycloak/go.mod
@@ -5,7 +5,7 @@ go 1.26.3
 require (
 	github.com/panyam/mcpkit v0.2.3
 	github.com/panyam/mcpkit/ext/auth v0.0.0
-	github.com/panyam/oneauth v0.1.11
+	github.com/panyam/oneauth v0.1.12
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/tests/keycloak/go.sum
+++ b/tests/keycloak/go.sum
@@ -33,8 +33,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.8 h1:5UscYTP892k54+Nyb01tKGGwZxczZ5k7BC+c0nXmcoc=
 github.com/panyam/goutils v0.1.8/go.mod h1:ntucs8GJOHQ0LmlRGRjeup3aDC2t7xPMudrRwUHrJNM=
-github.com/panyam/oneauth v0.1.11 h1:ltKd+Zjqp3/2iZRFzV+3q6zGS9mV75PXOTnl+j+gFv4=
-github.com/panyam/oneauth v0.1.11/go.mod h1:kujwUd36OsM8WyA4c++5acpK2yAgVX3Qa0iu4oI8Cp8=
+github.com/panyam/oneauth v0.1.12 h1:QP4cBhpGdaGAJRXaBqDBV8r+Qn8pMD6rpsQpfLijoaQ=
+github.com/panyam/oneauth v0.1.12/go.mod h1:kujwUd36OsM8WyA4c++5acpK2yAgVX3Qa0iu4oI8Cp8=
 github.com/panyam/servicekit v0.0.25 h1:JeTRyz5ZZY3beENg0N3tLW+O39/foTuHMPAf+rpwYhM=
 github.com/panyam/servicekit v0.0.25/go.mod h1:9TkF2LRqiPC9bgu0bYVdky7rnHEuBvzGzrsoL++Ra5c=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
## What changes

Closes #380 fully — all 4 SEP-2468 audit scenarios flip to pass. mcpkit's `OAuthTokenSource` validates the RFC 9207 `iss` query parameter on the OAuth callback (via oneauth's `BrowserLoginRequest.OnCallback` hook) and rejects mismatched / missing / forged iss values before token exchange.

Two commits on the branch:

1. **Initial implementation** — `iss_validator.go` + wiring in `token_source.go`. Closes 3 of 4 scenarios. The 4th (`auth/iss-supported-missing`) was held back because oneauth v0.1.11's `client.ASMetadata` didn't surface the AS's advertised `authorization_response_iss_parameter_supported` flag.
2. **oneauth v0.1.12 bump** — oneauth#239 shipped the field; the closure now reads the real value instead of the hardcoded `false`. Closes the 4th scenario, completes #380.

## Reviewer's guide

1. [ext/auth/iss_validator.go](https://github.com/panyam/mcpkit/pull/506/files#diff-93ce6cb901b74f24988d5c10b19fc87fcaac1d4ff6eea7bbfa211294becb96b4) (new) — start here. `ErrIssMismatch` + `ErrIssMissing` sentinels and the package-private `validateIss` helper. The doc-comments capture the spec rule and the (counter-intuitive) **byte-strict** comparison — see "Spec subtlety" below.
2. [ext/auth/iss_validator_test.go](https://github.com/panyam/mcpkit/pull/506/files#diff-81c692aea6008ba5cc723255bff9d199b9d313ab8c75076b6b9d60a6f84442ad) (new) — acceptance for #1. 11-case table-driven test covering all 4 audit-scenario shapes plus the byte-strict edge cases (trailing-slash variants must reject, case differences must reject, path mismatch within same origin must reject).
3. [ext/auth/token_source.go](https://github.com/panyam/mcpkit/pull/506/files#diff-6d528a538fc48b723628904903959aba0d2a143b95b820af43ee6e8b3f45e523) — wires the validator into the OAuth callback. The closure now reads `s.authInfo.ASMetadata.AuthorizationResponseIssParameterSupported` (exposed in oneauth v0.1.12) to decide whether to enforce the "iss absent + AS advertised → reject" branch.
4. `go.mod` + 16 other `go.mod` / `go.sum` files — `oneauth` bumped v0.1.11 → v0.1.12 across all 9 modules carrying the pin. Mechanical; `make tidy-all` propagates.
5. [conformance/UPSTREAM_AUDIT.md](https://github.com/panyam/mcpkit/pull/506/files#diff-bf63f1699e28f43c702f9450df02d9e8ec1dae36200827f929a68513bdb34197) — regenerated. All 4 iss-* scenarios pass; no regressions.

Skim or skip: the non-root `go.mod` / `go.sum` files (mechanical version bump).

## Spec subtlety worth pressure-testing

The conformance scenario naming `auth/iss-normalized` is misleading — that scenario tests that the client does **NOT** normalize. RFC 9207 §2.4 inherits its comparison semantics from RFC 9068 §2.1.1 (JWT `iss` claim) which is **byte-equal**.

This is the opposite of RFC 8707 PRM resource validation (in `discovery.go`), which DOES normalize. The two surfaces look the same on the surface (both URLs) but are governed by different RFCs with different rules. The first push of this PR had the validator with the same normalization rules as the PRM helper; the upstream audit caught it and the byte-strict version replaced it before review.

## Decision log

- **Byte-for-byte comparison, not normalized.** RFC 9207 §2.4 explicitly forbids normalization. Don't change this without re-reading the spec text and the `sep-2468-client-no-normalization` check.
- **Distinct sentinels for "missing" vs "mismatch".** Different remediations — keeping them separate lets audit/log consumers tell them apart.
- **`validateIss` is package-private.** Only consumer today is the token source's OnCallback closure; export later if a real external consumer appears.
- **Two commits, not squashed.** The first commit ("3 of 4 closes") is a coherent partial that some consumers may want to cherry-pick if they can't bump oneauth yet. The second commit ("bump + 4th close") is a separable dep bump. Keeping them separate preserves both stories.

## Risk / blast radius

- **Affects:** `OAuthTokenSource` browser-login path only. Static-token sources and pre-registered ClientID flows are unaffected. Client-credentials / enterprise-managed flows don't have a callback redirect — iss only applies to authorization-code.
- **Tests covering this:** `make test-auth` green (validator unit tests + token source unchanged baseline). `make testconf-upstream-audit` confirms all 4 target rows flip with no regressions.
- **Be paranoid about:** the byte-strict comparison decision. If a real AS in the wild emits `https://as.example.com/` and the configured issuer is `https://as.example.com`, this PR will reject — which is what RFC 9207 §2.4 says, but it may surprise downstream users who expect URL normalization. Document the strictness clearly in any user-facing OAuth docs.

## Before / after

| Audit row | Before this PR | After this PR |
|---|---|---|
| `auth/iss-normalized` | partial (1 fail) | pass |
| `auth/iss-unexpected` | partial (1 fail) | pass |
| `auth/iss-wrong-issuer` | partial (1 fail) | pass |
| `auth/iss-supported-missing` | partial (1 fail) | pass |
| Server | unchanged | unchanged |
| Client total fails | 18 | 14 |

## Cluster status

With this PR + #492 (Clusters C+D) + #505 (Cluster B via oneauth v0.1.11 bump), the entire SEP-2468/2352 audit cluster #380 was tracking is now closed.

## Out of scope

- **Strict-mode flag** (require iss even when AS didn't advertise) — tracked at oneauth#238 as the library-level helper. mcpkit will wrap it when the helper ships.
- **RFC 3986 URL-normalization pushdown to oneauth** — tracked as a separate follow-up; reviewer's guide for that lands in a different PR.

## Refs

- #380 (this issue, fully closes)
- oneauth#235 (closed prereq — surfaced iss on callback)
- oneauth#238 (companion — ValidateIss helper, will replace validateIss here when shipped)
- oneauth#239 (closed prereq — surfaced advertised-flag on ASMetadata; this PR's second commit consumes it)
