### PR TITLE
feat(conformance): auto-generated CONFORMANCE.md with CI staleness gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,3 +67,47 @@ jobs:
 
       - name: Run ui sub-module tests
         run: cd ext/ui && go test ./... -v -count=1 -timeout 30s
+
+  conformance-report:
+    # Regenerates CONFORMANCE.md against the current testserver + upstream
+    # conformance@main and fails if the committed file is stale. See issue #498.
+    # Driver: scripts/refresh-conformance.sh → tools/conformance-report.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout mcpkit
+        uses: actions/checkout@v4
+        with:
+          path: mcpkit
+
+      - name: Checkout modelcontextprotocol/conformance@main
+        uses: actions/checkout@v4
+        with:
+          repository: modelcontextprotocol/conformance
+          path: conf-upstream-main
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: mcpkit/go.mod
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Run renderer unit tests
+        working-directory: mcpkit/tools/conformance-report
+        run: |
+          npm install --silent
+          npm test
+
+      - name: Check CONFORMANCE.md is fresh
+        working-directory: mcpkit
+        env:
+          # tier-check needs a GH token to query repo-side signals (labels,
+          # triage, etc.). The renderer drops those slices from CONFORMANCE.md
+          # so they don't affect the diff; the token only keeps tier-check
+          # from bailing during data collection.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MCPCONFORMANCE_BASE_PATH: ${{ github.workspace }}/conf-upstream-main
+        run: make check-conformance-stale

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,8 @@ make testconf-file-inputs # SEP-2356 — fork @ MCPCONFORMANCE_FILE_INPUTS_PATH 
 make testconf-auth-server # MCP authz 2025-11-25 — fork @ MCPCONFORMANCE_AUTH_PATH (6 scenarios, 23 checks: 18 active, 5 SKIPPED gaps for unsupported features)
 make testconf-stateless # SEP-2575 — upstream @ MCPCONFORMANCE_STATELESS_PATH; drives examples/stateless fixture (25 pass / 1 known upstream-test fail)
 make testconf-upstream-audit # Audit mcpkit against modelcontextprotocol/conformance@main → conformance/UPSTREAM_AUDIT.md (informational scenario-level pass/fail; runs in the conformance umbrella but exits 0 by design)
+make refresh-conformance # Regenerate CONFORMANCE.md from upstream tier-check + traceability (issue #498). Driver: scripts/refresh-conformance.sh, renderer: tools/conformance-report.
+make check-conformance-stale # CI gate — refresh + git diff --exit-code CONFORMANCE.md (issue #498). Wired into .github/workflows/test.yml on every PR.
 make testall           # Everything (9 stages, 18 sub-stages) + Keycloak + HTML report
 make audit             # govulncheck + gosec + gitleaks + race
 make tag-push V=vX.Y.Z # Tag root + all sub-modules and push

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -1,0 +1,73 @@
+# MCP Conformance
+
+mcpkit's posture against the [MCP conformance suite](https://github.com/modelcontextprotocol/conformance) and the per-SEP traceability manifest, regenerated on every PR and gated for staleness by CI.
+
+This file has two parts:
+
+- **Overview** (hand-edited, preserved across regenerations) — what the report covers, what it does *not* cover, and how to read it.
+- **Generated block** below the begin-marker — rebuilt from `npx @modelcontextprotocol/conformance tier-check --output json` + `src/seps/traceability.json`. Do not hand-edit; changes are overwritten by `scripts/refresh-conformance.sh`.
+
+## How to read this
+
+- **Conformance Summary** counts wire-level scenarios from the upstream conformance suite running against `cmd/testserver`. Aggregate pass/total at the scenario level + check-level pass/fail totals.
+- **SEP Coverage** is sourced from upstream's traceability manifest, which maps each SEP to its declared requirements. A row's `Status` says whether upstream has emitted a check ID for every declared requirement — *not* whether mcpkit passes them. Scenario-level pass/fail per SEP lives in [`conformance/UPSTREAM_AUDIT.md`](conformance/UPSTREAM_AUDIT.md), which grades mcpkit against every scenario upstream currently ships.
+- **Open Gaps** lists failing scenarios + traceability rows with no emitted check. Tracking links and one-line context come from [`conformance/known-gaps.yaml`](conformance/known-gaps.yaml).
+
+## What this report is *not*
+
+The renderer drops the tier-check checks that depend on live GitHub state (labels, triage SLA, P0 resolution, stable release, policy signals, spec tracking). Those are useful tier-1 signals but they change daily independent of code, which would break the CI staleness gate. To see the full `tier-check` scorecard for a point-in-time tier judgement, run `npx @modelcontextprotocol/conformance tier-check --repo panyam/mcpkit --output markdown` directly.
+
+## Regenerate locally
+
+```
+bash scripts/refresh-conformance.sh
+```
+
+Needs Node.js 22+ and a clone of `modelcontextprotocol/conformance` at `../conf-upstream-main` (override with `MCPCONFORMANCE_BASE_PATH=...`). Output is deterministic — re-running on unchanged input produces a byte-identical file.
+
+---
+
+<!-- begin:generated -->
+<!-- generated against upstream-conformance@bcfd400 · protocol 2025-11-25 · regenerate via scripts/refresh-conformance.sh -->
+
+## Conformance Summary
+
+| Surface | Scenarios pass/total | Checks pass/fail |
+|---|---:|---:|
+| Server | 46/47 | 92/1 |
+| Client | 0/0 | 0/0 |
+
+## SEP Coverage
+
+| SEP | Tested reqs | Excluded | Untested | Status |
+|---|---:|---:|---:|---|
+| [SEP-837](https://modelcontextprotocol.io/specification/draft/basic/authorization#application-type-and-redirect-uri-constraints) | 1 | 4 | 0 | **pass** |
+| [SEP-2106](https://modelcontextprotocol.io/seps/2106-json-schema-2020-12#security-implications) | 1 | 4 | 0 | **pass** |
+| [SEP-2164](https://modelcontextprotocol.io/specification/draft/server/resources#error-handling) | 2 | 1 | 0 | **pass** |
+| [SEP-2207](https://modelcontextprotocol.io/specification/draft/basic/authorization#refresh-tokens) | 1 | 3 | 0 | **pass** |
+| [SEP-2243](https://modelcontextprotocol.io/specification/draft/basic/transports#standard-mcp-request-headers) | 18 | 4 | 2 | partial |
+| [SEP-2260](https://modelcontextprotocol.io/specification/draft/basic/transports#streamable-http) | 0 | 12 | 0 | _untested_ |
+| [SEP-2322](https://modelcontextprotocol.io/specification/draft/basic/utilities/mrtr) | 17 | 16 | 0 | **pass** |
+| [SEP-2350](https://modelcontextprotocol.io/specification/draft/basic/authorization#runtime-insufficient-scope-errors) | 1 | 2 | 0 | **pass** |
+| [SEP-2352](https://modelcontextprotocol.io/specification/draft/basic/authorization#authorization-server-binding) | 3 | 3 | 0 | **pass** |
+| [SEP-2468](https://modelcontextprotocol.io/specification/draft/basic/authorization#authorization-response-validation) | 6 | 3 | 0 | **pass** |
+| [SEP-2549](https://modelcontextprotocol.io/specification/draft/server/utilities/caching) | 7 | 13 | 0 | **pass** |
+| [SEP-2575](https://modelcontextprotocol.io/specification/draft/basic/lifecycle) | 22 | 13 | 0 | **pass** |
+
+_Status reflects upstream-declared requirements only. Scenario→SEP attribution is not exposed in tier-check JSON today; this column tracks "does upstream have a check ID for this SEP requirement", not "does mcpkit pass it". Per-SEP scenario pass/fail lives in `conformance/UPSTREAM_AUDIT.md`._
+
+## Open Gaps
+
+### Failing scenarios
+
+| Scenario | Surface | Checks fail/pass | Tracking |
+|---|---|---:|---|
+| `server-stateless` | server | 1/19 | — |
+
+### Declared requirements with no emitted check
+
+| SEP | Check ID | Tracking |
+|---|---|---|
+| SEP-2243 | `sep-2243-server-not-expect-null` | MCP-Name fail-closed semantics on tasks/* — covered locally by server/middleware test |
+| SEP-2243 | `sep-2243-server-reject-missing-required` | MCP-Name fail-closed semantics on tasks/* — covered locally by server/middleware test |
+<!-- end:generated -->

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,12 @@ testconf-auth-server: ## Run server-side auth conformance — fork-based, RFC 97
 testconf-elicitation: ## Run SEP-1036 elicitation conformance (delegates to conformance/Makefile)
 	$(MAKE) -C conformance testconf-elicitation
 
+refresh-conformance: ## Regenerate CONFORMANCE.md from upstream tier-check + traceability (delegates to conformance/Makefile)
+	$(MAKE) -C conformance refresh-conformance
+
+check-conformance-stale: ## Fail if CONFORMANCE.md is stale relative to current testserver + upstream (CI gate)
+	$(MAKE) -C conformance check-conformance-stale
+
 test-auth: ## Run auth sub-module tests
 	cd ext/auth && go test ./... -count=1 -timeout 30s
 
@@ -423,5 +429,5 @@ setup: setup-tools setup-hooks ## Full development setup
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-18s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: build test test-race test-v cover cover-html cover-func cover-all test-auth test-ui test-protogen test-e2e test-experimental test-apps-playwright testkcl testkcl-auto testall test-report smoke testconfall testconf testconfauth testconf-tasks testconf-tasks-v2 testconf-mrtr testconf-file-inputs testconf-auth-server testconf-elicitation vet lint vulncheck seccheck secrets verify-submodule-deps audit ci ci-full serve serve-streamable serve-both tidy tidy-all bump-root tag tag-push setup-tools setup-hooks setup upkcl downkcl kcllogs build-bridge help
+.PHONY: build test test-race test-v cover cover-html cover-func cover-all test-auth test-ui test-protogen test-e2e test-experimental test-apps-playwright testkcl testkcl-auto testall test-report smoke testconfall testconf testconfauth testconf-tasks testconf-tasks-v2 testconf-mrtr testconf-file-inputs testconf-auth-server testconf-elicitation refresh-conformance check-conformance-stale vet lint vulncheck seccheck secrets verify-submodule-deps audit ci ci-full serve serve-streamable serve-both tidy tidy-all bump-root tag tag-push setup-tools setup-hooks setup upkcl downkcl kcllogs build-bridge help
 .DEFAULT_GOAL := help

--- a/conformance/Makefile
+++ b/conformance/Makefile
@@ -36,7 +36,8 @@ MCPCONFORMANCE_BASE_PATH        ?= $(abspath $(REPO_ROOT)/../conf-upstream-main)
         testconf-tasks testconf-tasks-v2 testconf-mrtr \
         testconf-file-inputs testconf-auth-server \
         testconf-stateless \
-        testconf-elicitation testconf-upstream-audit help
+        testconf-elicitation testconf-upstream-audit \
+        refresh-conformance check-conformance-stale help
 
 # Default umbrella — runs every conformance suite. Fork-based suites and the
 # upstream-main audit each require their MCPCONFORMANCE_*_PATH worktree to
@@ -205,6 +206,26 @@ testconf-elicitation: ## Run elicitation conformance suite (SEP-1036 URL mode + 
 	cd $(CONFORMANCE_DIR) && npm install --silent && \
 	SERVER_URL=$${SERVER_URL:-http://localhost:8080/mcp} \
 	npx tsx --test elicitation/scenarios.test.ts
+
+refresh-conformance: ## Regenerate CONFORMANCE.md from upstream tier-check + traceability (issue #498). Output: CONFORMANCE.md at repo root.
+	@if [ ! -d "$(MCPCONFORMANCE_BASE_PATH)" ]; then \
+		echo "MCPCONFORMANCE_BASE_PATH=$(MCPCONFORMANCE_BASE_PATH) does not exist."; \
+		echo "Clone https://github.com/modelcontextprotocol/conformance there:"; \
+		echo "  git clone https://github.com/modelcontextprotocol/conformance.git $(MCPCONFORMANCE_BASE_PATH)"; \
+		echo "Or set MCPCONFORMANCE_BASE_PATH=<path-to-clone>."; \
+		exit 1; \
+	fi
+	cd $(REPO_ROOT) && MCPCONFORMANCE_BASE_PATH="$(MCPCONFORMANCE_BASE_PATH)" bash scripts/refresh-conformance.sh
+
+check-conformance-stale: refresh-conformance ## CI gate — fail if CONFORMANCE.md is stale (issue #498). Run after refresh-conformance; diff must be empty.
+	@cd $(REPO_ROOT) && git diff --exit-code CONFORMANCE.md > /dev/null 2>&1 || { \
+		echo "CONFORMANCE.md is stale relative to current testserver + upstream conformance."; \
+		echo "Run 'make refresh-conformance' locally and commit the regenerated file."; \
+		echo ""; \
+		git diff CONFORMANCE.md | head -60; \
+		exit 1; \
+	}
+	@echo "CONFORMANCE.md is up to date."
 
 testconf-upstream-audit: ## Audit mcpkit against modelcontextprotocol/conformance@main (informational — exit 0 regardless of scenario pass/fail). Output: conformance/UPSTREAM_AUDIT.md.
 	@if [ ! -d "$(MCPCONFORMANCE_BASE_PATH)" ]; then \

--- a/conformance/known-gaps.yaml
+++ b/conformance/known-gaps.yaml
@@ -1,0 +1,29 @@
+# Hand-annotated overlay for CONFORMANCE.md "Open Gaps" section.
+#
+# Joined by tools/conformance-report at render time with the raw FAILURE /
+# untested rows from upstream tier-check + traceability. Adding an entry here
+# does NOT mark a gap as resolved — it just attaches a tracking link + one-line
+# context so reviewers know we're aware of it.
+#
+# Schema:
+#   scenarios:
+#     <scenario-id>:           # exact upstream scenario name after timestamp
+#       issue: <link>          #   normalization (e.g. "tools-dynamic")
+#       note: <one line>
+#   checks:
+#     <check-id>:              # check ID from src/seps/*.yaml
+#       issue: <link>          #   (e.g. "sep-2243-server-not-expect-null")
+#       note: <one line>
+#
+# Keep entries terse; the renderer puts them straight into a table cell.
+
+scenarios:
+  "stateless":
+    issue: "upstream conformance test bug"
+    note: "ServerRejectsUndeclaredCapability checks requiredCapabilities as string-array but SEP-2575 schema says object — mcpkit follows schema. Tracked in CLAUDE.md gotchas."
+
+checks:
+  "sep-2243-server-not-expect-null":
+    note: "MCP-Name fail-closed semantics on tasks/* — covered locally by server/middleware test"
+  "sep-2243-server-reject-missing-required":
+    note: "MCP-Name fail-closed semantics on tasks/* — covered locally by server/middleware test"

--- a/scripts/refresh-conformance.sh
+++ b/scripts/refresh-conformance.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# Regenerates CONFORMANCE.md at the repo root by:
+#   1. spawning cmd/testserver on a free port
+#   2. running upstream tier-check --output json against it
+#   3. driving tools/conformance-report to splice the result into CONFORMANCE.md
+#
+# Requires:
+#   - Node.js 22+ (npx)
+#   - A clone of modelcontextprotocol/conformance at $MCPCONFORMANCE_BASE_PATH
+#     (defaults to ../conf-upstream-main relative to repo root)
+#   - GH_TOKEN or `gh auth login` — upstream tier-check still queries GitHub
+#     for tier-1 signals; the renderer drops those slices on the way out, but
+#     the CLI itself fails closed without a token.
+#
+# Output: writes CONFORMANCE.md at the repo root in-place. Re-running on
+# unchanged input must produce a byte-identical file — this is the contract
+# the CI staleness gate relies on.
+#
+# Env overrides:
+#   MCPCONFORMANCE_BASE_PATH — path to upstream conformance clone
+#   REFRESH_PORT             — testserver port (default 18799)
+#   REFRESH_OUT              — output path (default CONFORMANCE.md at repo root)
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CONF_DIR="${MCPCONFORMANCE_BASE_PATH:-$REPO_ROOT/../conf-upstream-main}"
+PORT="${REFRESH_PORT:-18799}"
+OUT="${REFRESH_OUT:-$REPO_ROOT/CONFORMANCE.md}"
+WORK_DIR="$(mktemp -d -t conformance-report.XXXXXX)"
+SERVER_PID=""
+
+cleanup() {
+    if [ -n "$SERVER_PID" ]; then
+        kill "$SERVER_PID" 2>/dev/null || true
+        wait "$SERVER_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+if [ ! -d "$CONF_DIR" ]; then
+    echo "refresh-conformance: \$MCPCONFORMANCE_BASE_PATH=$CONF_DIR does not exist." >&2
+    echo "  Clone https://github.com/modelcontextprotocol/conformance there, or" >&2
+    echo "  re-run with MCPCONFORMANCE_BASE_PATH=<path-to-clone>." >&2
+    exit 1
+fi
+
+if ! command -v npx >/dev/null 2>&1; then
+    echo "refresh-conformance: npx not found. Install Node.js 22+." >&2
+    exit 1
+fi
+
+# --- 1. Build mcpkit fixture -----------------------------------------------
+
+echo "=== Building cmd/testserver ==="
+(cd "$REPO_ROOT" && go build -o "$WORK_DIR/testserver" ./cmd/testserver)
+
+# Kill any stale process on the port to avoid connecting to old code.
+if lsof -i ":$PORT" -t >/dev/null 2>&1; then
+    echo "Killing stale process on port $PORT..."
+    lsof -i ":$PORT" -t | xargs kill 2>/dev/null || true
+    sleep 1
+fi
+
+echo "=== Spawning testserver on :$PORT ==="
+STREAMABLE=1 PORT=$PORT "$WORK_DIR/testserver" > "$WORK_DIR/testserver.log" 2>&1 &
+SERVER_PID=$!
+
+# Wait for readiness via initialize handshake.
+echo -n "Waiting for testserver..."
+for i in $(seq 1 30); do
+    if curl -s -o /dev/null -w "%{http_code}" -X POST "http://localhost:$PORT/mcp" \
+        -H "Content-Type: application/json" \
+        -H "Accept: application/json, text/event-stream" \
+        -d '{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"refresh","version":"0.0"}}}' \
+        2>/dev/null | grep -q "200"; then
+        echo " ready"
+        break
+    fi
+    echo -n "."
+    sleep 1
+done
+
+if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    echo " FAIL: testserver exited"
+    cat "$WORK_DIR/testserver.log"
+    exit 1
+fi
+
+# --- 2. Run upstream tier-check --------------------------------------------
+
+echo ""
+echo "=== Installing upstream conformance deps (builds dist/ via prepare) ==="
+(cd "$CONF_DIR" && npm install --silent)
+
+UPSTREAM_SHA="$(cd "$CONF_DIR" && git rev-parse --short HEAD)"
+PROTOCOL_VERSION="${REFRESH_PROTOCOL:-2025-11-25}"
+
+echo ""
+echo "=== Running upstream tier-check --output json ==="
+# tier-check needs a GH token for repo-side signals (labels/triage/etc.). The
+# renderer drops those from CONFORMANCE.md, but the CLI itself bails without
+# one. We pass --skip-conformance off so the scorecard carries scenario
+# results; the only reason we run tier-check (vs running `server` directly)
+# is that its JSON shape is already what the renderer parses.
+(cd "$CONF_DIR" && node dist/index.js tier-check \
+    --repo panyam/mcpkit \
+    --conformance-server-url "http://localhost:$PORT/mcp" \
+    --output json \
+    > "$WORK_DIR/scorecard.json")
+
+# --- 3. Render -------------------------------------------------------------
+
+echo ""
+echo "=== Rendering CONFORMANCE.md ==="
+# Install renderer deps once; idempotent on rerun.
+(cd "$REPO_ROOT/tools/conformance-report" && npm install --silent)
+(cd "$REPO_ROOT/tools/conformance-report" && npx tsx src/index.ts \
+    --scorecard "$WORK_DIR/scorecard.json" \
+    --traceability "$CONF_DIR/src/seps/traceability.json" \
+    --known-gaps "$REPO_ROOT/conformance/known-gaps.yaml" \
+    --out "$OUT" \
+    --upstream-sha "$UPSTREAM_SHA" \
+    --protocol "$PROTOCOL_VERSION")
+
+echo ""
+echo "=== CONFORMANCE.md refreshed ==="
+echo "  upstream-conformance@$UPSTREAM_SHA"
+echo "  protocol $PROTOCOL_VERSION"
+echo "  output:  $OUT"

--- a/tools/conformance-report/.gitignore
+++ b/tools/conformance-report/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+package-lock.json

--- a/tools/conformance-report/README.md
+++ b/tools/conformance-report/README.md
@@ -1,0 +1,42 @@
+# @mcpkit/conformance-report
+
+Renders [`CONFORMANCE.md`](../../CONFORMANCE.md) at the repo root from two upstream artifacts:
+
+- `tier-check --output json` (upstream `modelcontextprotocol/conformance` CLI) — per-scenario pass/fail
+- `src/seps/traceability.json` (committed in the upstream conformance clone) — maps SEP → declared requirements → check IDs
+
+Output: one Markdown file with a hand-edited `## Overview` block (preserved across regenerations) + a generated per-SEP coverage matrix + generated open-gaps section.
+
+## CLI
+
+```
+conformance-report \
+  --scorecard <path/to/tier-check.json> \
+  --traceability <path/to/traceability.json> \
+  --known-gaps <path/to/known-gaps.yaml> \
+  --out <path/to/CONFORMANCE.md>
+```
+
+All flags are required. The tool re-reads the existing `--out` file (if present) to preserve hand-edited content between the file header and the `<!-- begin:generated -->` marker.
+
+## Why a separate package
+
+The renderer is small (~200 lines) but ports cleanly into upstream `tier-check --format markdown` once interest exists (issue #498 Phase 3). Living in-tree under `tools/` while we iterate matches the issue's Phase 1 decision; the cost of moving it later is a `git mv` + bin pointer update.
+
+## Determinism
+
+The output is intentionally free of wall-clock timestamps. The header stamps:
+
+- Upstream conformance commit SHA (so an upstream-driven check-ID change diffs)
+- MCP protocol version
+
+The mcpkit commit SHA is **not** stamped — including it would diff the file on every commit even when no scenarios changed, defeating the CI staleness gate. `git blame CONFORMANCE.md` gives the same provenance.
+
+## Tests
+
+```
+npm install
+npm test
+```
+
+Tests are fixture-driven: golden `expected.md` + recorded scorecard/traceability inputs in `test/fixtures/`.

--- a/tools/conformance-report/package.json
+++ b/tools/conformance-report/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@mcpkit/conformance-report",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "description": "Renders CONFORMANCE.md from upstream tier-check JSON + traceability manifest. In-tree for now; intended to upstream as `tier-check --format markdown` (issue #498 Phase 3).",
+  "bin": {
+    "conformance-report": "src/index.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "yaml": "^2.5.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.0.0",
+    "typescript": "^5.4.0",
+    "vitest": "^2.0.0",
+    "@types/node": "^22.0.0"
+  }
+}

--- a/tools/conformance-report/src/index.ts
+++ b/tools/conformance-report/src/index.ts
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+// CLI entry. Parses flags, loads inputs via parse.ts, splices the renderer
+// output into the existing CONFORMANCE.md (preserving the hand-edited region
+// above <!-- begin:generated -->), writes the file.
+//
+// Invocation (see scripts/refresh-conformance.sh):
+//   conformance-report \
+//     --scorecard <tier-check.json> \
+//     --traceability <upstream/src/seps/traceability.json> \
+//     --known-gaps <conformance/known-gaps.yaml> \
+//     --out CONFORMANCE.md \
+//     --upstream-sha <sha> \
+//     --protocol <ver>
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { loadScorecard, loadTraceability, loadKnownGaps } from './parse.js';
+import { renderGeneratedBlock, spliceGeneratedRegion } from './render.js';
+
+interface CliArgs {
+  scorecard: string;
+  traceability: string;
+  knownGaps: string;
+  out: string;
+  upstreamSha: string;
+  protocol: string;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const out: Partial<CliArgs> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const consume = () => {
+      const v = argv[++i];
+      if (!v) throw new Error(`flag ${arg} requires a value`);
+      return v;
+    };
+    switch (arg) {
+      case '--scorecard':
+        out.scorecard = consume();
+        break;
+      case '--traceability':
+        out.traceability = consume();
+        break;
+      case '--known-gaps':
+        out.knownGaps = consume();
+        break;
+      case '--out':
+        out.out = consume();
+        break;
+      case '--upstream-sha':
+        out.upstreamSha = consume();
+        break;
+      case '--protocol':
+        out.protocol = consume();
+        break;
+      case '--help':
+      case '-h':
+        usage();
+        process.exit(0);
+      default:
+        throw new Error(`unknown flag: ${arg}`);
+    }
+  }
+  for (const k of ['scorecard', 'traceability', 'knownGaps', 'out', 'upstreamSha', 'protocol'] as const) {
+    if (!out[k]) throw new Error(`missing required flag: --${k.replace(/([A-Z])/g, '-$1').toLowerCase()}`);
+  }
+  return out as CliArgs;
+}
+
+function usage(): void {
+  process.stderr.write(
+    `conformance-report --scorecard <path> --traceability <path> --known-gaps <path> --out <path> --upstream-sha <sha> --protocol <ver>\n`
+  );
+}
+
+function main(): void {
+  const args = parseArgs(process.argv.slice(2));
+  const scorecard = loadScorecard(args.scorecard);
+  const traceability = loadTraceability(args.traceability);
+  const knownGaps = loadKnownGaps(args.knownGaps);
+  const block = renderGeneratedBlock({
+    scorecard,
+    traceability,
+    knownGaps,
+    upstreamSha: args.upstreamSha,
+    protocolVersion: args.protocol
+  });
+  const existing = existsSync(args.out) ? readFileSync(args.out, 'utf-8') : null;
+  const merged = spliceGeneratedRegion(existing, block);
+  writeFileSync(args.out, merged);
+}
+
+try {
+  main();
+} catch (err) {
+  process.stderr.write(`conformance-report: ${(err as Error).message}\n`);
+  process.exit(1);
+}

--- a/tools/conformance-report/src/parse.ts
+++ b/tools/conformance-report/src/parse.ts
@@ -1,0 +1,38 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { parse as parseYaml } from 'yaml';
+import type {
+  KnownGaps,
+  TierScorecard,
+  TraceabilityManifest
+} from './types.js';
+
+// loadScorecard reads a tier-check `--output json` artifact and returns the
+// typed scorecard. Throws on missing or malformed input — callers are
+// expected to surface the failure to the user, not silently render an
+// empty report.
+export function loadScorecard(path: string): TierScorecard {
+  const raw = readFileSync(path, 'utf-8');
+  return JSON.parse(raw) as TierScorecard;
+}
+
+// loadTraceability reads `src/seps/traceability.json` from an upstream
+// conformance clone. Throws on missing or malformed input.
+export function loadTraceability(path: string): TraceabilityManifest {
+  const raw = readFileSync(path, 'utf-8');
+  return JSON.parse(raw) as TraceabilityManifest;
+}
+
+// loadKnownGaps reads the local hand-annotated gap overlay. Returns an empty
+// object (no annotations) if the file is missing — the overlay is optional,
+// not required for rendering.
+export function loadKnownGaps(path: string): KnownGaps {
+  if (!existsSync(path)) {
+    return {};
+  }
+  const raw = readFileSync(path, 'utf-8');
+  const parsed = parseYaml(raw);
+  if (!parsed || typeof parsed !== 'object') {
+    return {};
+  }
+  return parsed as KnownGaps;
+}

--- a/tools/conformance-report/src/render.ts
+++ b/tools/conformance-report/src/render.ts
@@ -1,0 +1,285 @@
+import type {
+  ConformanceResult,
+  ConformanceScenarioResult,
+  KnownGapEntry,
+  RenderInput,
+  TraceabilityManifest
+} from './types.js';
+
+// BEGIN_GENERATED / END_GENERATED bracket the renderer-owned region of
+// CONFORMANCE.md. Hand-edited content above BEGIN is preserved across
+// regenerations; everything between the markers is replaced.
+export const BEGIN_GENERATED = '<!-- begin:generated -->';
+export const END_GENERATED = '<!-- end:generated -->';
+
+// renderGeneratedBlock produces the renderer-owned region (stamp + summary +
+// per-SEP requirements + gaps). The caller is responsible for splicing it
+// into the surrounding hand-edited document via spliceGeneratedRegion.
+//
+// Two-table design intentionally avoids claiming a scenario→SEP join the
+// upstream JSON does not support. Per the traceability manifest's own scope
+// note ("tier-check reports at scenario granularity and does not currently
+// expose per-check IDs, while this manifest carries check IDs but not
+// scenario names"), the join cannot be done today. The summary table grades
+// the suite at the wire level; the SEP table grades requirement coverage at
+// the spec level. Together they give a faithful picture without inventing
+// data.
+export function renderGeneratedBlock(input: RenderInput): string {
+  const lines: string[] = [];
+  lines.push(BEGIN_GENERATED);
+  lines.push(renderStamp(input));
+  lines.push('');
+  lines.push('## Conformance Summary');
+  lines.push('');
+  lines.push(...renderSummary(input));
+  lines.push('');
+  lines.push('## SEP Coverage');
+  lines.push('');
+  lines.push(...renderSepTable(input));
+  lines.push('');
+  lines.push('## Open Gaps');
+  lines.push('');
+  lines.push(...renderGaps(input));
+  lines.push(END_GENERATED);
+  return lines.join('\n');
+}
+
+// spliceGeneratedRegion replaces the BEGIN/END region in `existing` with
+// `block`. If no region is present, appends `block` after the existing
+// content (with a separating blank line). This preserves hand-edited
+// content above the generated region across regenerations.
+//
+// Markers are matched as whole lines (preceded by newline or start-of-file,
+// followed by newline or end-of-file). This is intentional: a maintainer
+// writing the literal marker text inside the hand-edited Overview prose
+// (e.g. documenting the marker convention) must not collide with the splice
+// anchor. The whole-line constraint makes prose embeddings unambiguously
+// safe.
+export function spliceGeneratedRegion(
+  existing: string | null,
+  block: string
+): string {
+  const trailing = block.endsWith('\n') ? block : block + '\n';
+  if (existing === null || existing === '') {
+    return trailing;
+  }
+  const beginIdx = findStandaloneMarker(existing, BEGIN_GENERATED);
+  const endIdx = findStandaloneMarker(existing, END_GENERATED);
+  if (beginIdx === -1 || endIdx === -1 || endIdx < beginIdx) {
+    const sep = existing.endsWith('\n') ? '\n' : '\n\n';
+    return existing + sep + trailing;
+  }
+  const before = existing.slice(0, beginIdx);
+  const after = existing.slice(endIdx + END_GENERATED.length);
+  const tail = after.startsWith('\n') ? after : '\n' + after;
+  return before + block + tail;
+}
+
+// findStandaloneMarker returns the byte offset of `marker` only when it sits
+// on its own line (start-of-file or newline before; newline or end-of-file
+// after). Returns -1 otherwise. Prevents prose collisions with the splice
+// anchor.
+function findStandaloneMarker(text: string, marker: string): number {
+  let from = 0;
+  while (from <= text.length) {
+    const idx = text.indexOf(marker, from);
+    if (idx === -1) return -1;
+    const okBefore = idx === 0 || text[idx - 1] === '\n';
+    const endOfMarker = idx + marker.length;
+    const okAfter = endOfMarker === text.length || text[endOfMarker] === '\n';
+    if (okBefore && okAfter) return idx;
+    from = idx + 1;
+  }
+  return -1;
+}
+
+function renderStamp(input: RenderInput): string {
+  return `<!-- generated against upstream-conformance@${input.upstreamSha} · protocol ${input.protocolVersion} · regenerate via scripts/refresh-conformance.sh -->`;
+}
+
+// --- Conformance summary ----------------------------------------------------
+//
+// Aggregates server and client scenario results at the wire level. This is
+// the slice tier-check JSON does support; per-SEP attribution lives in the
+// next section, sourced from traceability.
+
+function renderSummary(input: RenderInput): string[] {
+  const s = input.scorecard.checks.conformance;
+  const c = input.scorecard.checks.client_conformance;
+  const lines: string[] = [];
+  lines.push('| Surface | Scenarios pass/total | Checks pass/fail |');
+  lines.push('|---|---:|---:|');
+  lines.push(
+    `| Server | ${s.passed}/${s.total} | ${sumChecks(s, 'passed')}/${sumChecks(s, 'failed')} |`
+  );
+  lines.push(
+    `| Client | ${c.passed}/${c.total} | ${sumChecks(c, 'passed')}/${sumChecks(c, 'failed')} |`
+  );
+  return lines;
+}
+
+function sumChecks(r: ConformanceResult, side: 'passed' | 'failed'): number {
+  let total = 0;
+  for (const d of r.details) {
+    total += side === 'passed' ? d.checks_passed : d.checks_failed;
+  }
+  return total;
+}
+
+// --- SEP coverage -----------------------------------------------------------
+
+function renderSepTable(input: RenderInput): string[] {
+  const sepIds = Object.keys(input.traceability.seps).sort((a, b) => Number(a) - Number(b));
+  if (sepIds.length === 0) {
+    return ['_No SEPs declared in upstream traceability manifest._'];
+  }
+  const lines: string[] = [];
+  lines.push('| SEP | Tested reqs | Excluded | Untested | Status |');
+  lines.push('|---|---:|---:|---:|---|');
+  for (const sep of sepIds) {
+    const s = input.traceability.seps[sep];
+    const label = s.specUrl ? `[SEP-${sep}](${s.specUrl})` : `SEP-${sep}`;
+    const status =
+      s.summary.untested === 0 && s.summary.tested > 0
+        ? '**pass**'
+        : s.summary.tested === 0
+          ? '_untested_'
+          : 'partial';
+    lines.push(
+      `| ${label} | ${s.summary.tested} | ${s.summary.excluded} | ${s.summary.untested} | ${status} |`
+    );
+  }
+  lines.push('');
+  lines.push(
+    '_Status reflects upstream-declared requirements only. Scenario→SEP attribution is not exposed in tier-check JSON today; this column tracks "does upstream have a check ID for this SEP requirement", not "does mcpkit pass it". Per-SEP scenario pass/fail lives in `conformance/UPSTREAM_AUDIT.md`._'
+  );
+  return lines;
+}
+
+// --- Open gaps --------------------------------------------------------------
+
+interface GapRow {
+  scenario: string;
+  surface: 'server' | 'client';
+  checksFailed: number;
+  checksPassed: number;
+  annotation: KnownGapEntry | null;
+}
+
+function renderGaps(input: RenderInput): string[] {
+  const fails: GapRow[] = [];
+  for (const d of input.scorecard.checks.conformance.details) {
+    if (!d.passed) {
+      const normalized = normalizeScenarioId(d.scenario, 'server');
+      fails.push({
+        scenario: normalized,
+        surface: 'server',
+        checksFailed: d.checks_failed,
+        checksPassed: d.checks_passed,
+        annotation: lookupAnnotation(normalized, input.knownGaps)
+      });
+    }
+  }
+  for (const d of input.scorecard.checks.client_conformance.details) {
+    if (!d.passed) {
+      const normalized = normalizeScenarioId(d.scenario, 'client');
+      fails.push({
+        scenario: normalized,
+        surface: 'client',
+        checksFailed: d.checks_failed,
+        checksPassed: d.checks_passed,
+        annotation: lookupAnnotation(normalized, input.knownGaps)
+      });
+    }
+  }
+  fails.sort((a, b) => a.scenario.localeCompare(b.scenario));
+
+  const untestedRequirements = collectUntestedRequirements(
+    input.traceability,
+    input.knownGaps
+  );
+
+  if (fails.length === 0 && untestedRequirements.length === 0) {
+    return ['_No open conformance gaps._ \\o/'];
+  }
+
+  const lines: string[] = [];
+  if (fails.length > 0) {
+    lines.push('### Failing scenarios');
+    lines.push('');
+    lines.push('| Scenario | Surface | Checks fail/pass | Tracking |');
+    lines.push('|---|---|---:|---|');
+    for (const f of fails) {
+      lines.push(
+        `| \`${f.scenario}\` | ${f.surface} | ${f.checksFailed}/${f.checksPassed} | ${formatAnnotation(f.annotation)} |`
+      );
+    }
+    lines.push('');
+  }
+  if (untestedRequirements.length > 0) {
+    lines.push('### Declared requirements with no emitted check');
+    lines.push('');
+    lines.push('| SEP | Check ID | Tracking |');
+    lines.push('|---|---|---|');
+    for (const r of untestedRequirements) {
+      lines.push(`| SEP-${r.sep} | \`${r.check}\` | ${formatAnnotation(r.annotation)} |`);
+    }
+  }
+  return lines;
+}
+
+// normalizeScenarioId strips the timestamp suffix and (for server scenarios)
+// the leading "server-" prefix that upstream tier-check pulls from output
+// directory names. Mirrors the same fix-up scripts/conformance-audit-report.ts
+// applies to its harness output. Example:
+//   "server-tools-list-2026-05-31T00-07-40-860Z" → "tools-list".
+const TIMESTAMP_RE = /-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z$/;
+function normalizeScenarioId(raw: string, surface: 'server' | 'client'): string {
+  let id = raw.replace(TIMESTAMP_RE, '');
+  if (surface === 'server' && id.startsWith('server-')) {
+    id = id.slice('server-'.length);
+  }
+  return id;
+}
+
+function lookupAnnotation(
+  scenario: string,
+  knownGaps: { scenarios?: Record<string, KnownGapEntry> }
+): KnownGapEntry | null {
+  return knownGaps.scenarios?.[scenario] ?? null;
+}
+
+function lookupCheckAnnotation(
+  checkId: string,
+  knownGaps: { checks?: Record<string, KnownGapEntry> }
+): KnownGapEntry | null {
+  return knownGaps.checks?.[checkId] ?? null;
+}
+
+function formatAnnotation(a: KnownGapEntry | null): string {
+  if (!a) return '—';
+  const parts: string[] = [];
+  if (a.issue) parts.push(a.issue);
+  if (a.note) parts.push(a.note);
+  return parts.length === 0 ? '—' : parts.join(' — ');
+}
+
+function collectUntestedRequirements(
+  trace: TraceabilityManifest,
+  knownGaps: { checks?: Record<string, KnownGapEntry> }
+): Array<{ sep: string; check: string; annotation: KnownGapEntry | null }> {
+  const out: Array<{ sep: string; check: string; annotation: KnownGapEntry | null }> = [];
+  for (const sep of Object.keys(trace.seps).sort((a, b) => Number(a) - Number(b))) {
+    const s = trace.seps[sep];
+    for (const r of s.requirements) {
+      if (r.status === 'untested') {
+        out.push({
+          sep,
+          check: r.check,
+          annotation: lookupCheckAnnotation(r.check, knownGaps)
+        });
+      }
+    }
+  }
+  return out;
+}

--- a/tools/conformance-report/src/types.ts
+++ b/tools/conformance-report/src/types.ts
@@ -1,0 +1,110 @@
+// Mirrors the subset of upstream tier-check output we consume. Kept narrow on
+// purpose — only the fields the renderer reads. If upstream renames or removes
+// one of these we get a TS error at parse time, which is the signal to update
+// fixtures and the recorded golden output.
+//
+// Upstream source of truth: modelcontextprotocol/conformance, src/tier-check/types.ts.
+
+export type CheckStatus = 'pass' | 'fail' | 'partial' | 'skipped';
+
+export interface ConformanceScenarioResult {
+  scenario: string;
+  passed: boolean;
+  checks_passed: number;
+  checks_failed: number;
+  specVersions?: string[];
+}
+
+export interface ConformanceResult {
+  status: CheckStatus;
+  pass_rate: number;
+  passed: number;
+  failed: number;
+  total: number;
+  details: ConformanceScenarioResult[];
+}
+
+export interface TierScorecard {
+  repo: string;
+  branch: string | null;
+  timestamp: string;
+  version: string | null;
+  checks: {
+    conformance: ConformanceResult;
+    client_conformance: ConformanceResult;
+    // Other tier-check checks (labels, triage, p0_resolution, stable_release,
+    // policy_signals, spec_tracking) are intentionally NOT typed here — the
+    // renderer drops them so they cannot influence CONFORMANCE.md, which
+    // would break the CI staleness gate (they depend on live GH state).
+  };
+  implied_tier: {
+    tier: 1 | 2 | 3;
+    tier1_blockers: string[];
+    tier2_met: boolean;
+    note: string;
+  };
+}
+
+// --- Upstream traceability manifest (src/seps/traceability.json) ------------
+
+export interface TraceabilityRequirement {
+  check: string;
+  status: 'tested' | 'untested';
+  text?: string;
+  url?: string;
+  issue?: string;
+}
+
+export interface TraceabilityExclusion {
+  text: string;
+  reason: string;
+  issue?: string;
+}
+
+export interface SepTraceability {
+  yaml: string | null;
+  specUrl: string | null;
+  requirements: TraceabilityRequirement[];
+  excluded: TraceabilityExclusion[];
+  unkeyed: Array<{ text: string }>;
+  untracked: string[];
+  summary: {
+    tested: number;
+    untested: number;
+    excluded: number;
+    untracked: number;
+    unkeyed: number;
+  };
+}
+
+export interface TraceabilityManifest {
+  schemaVersion: number;
+  docs: string;
+  source: string | null;
+  seps: Record<string, SepTraceability>;
+}
+
+// --- Local hand-annotated gap overlay ---------------------------------------
+
+export interface KnownGapEntry {
+  issue?: string;
+  note?: string;
+}
+
+export interface KnownGaps {
+  // Keys are scenario IDs (e.g. "tools/dynamic") or check IDs
+  // (e.g. "sep-2322-input-required-on-allowed-method"). First match wins.
+  scenarios?: Record<string, KnownGapEntry>;
+  checks?: Record<string, KnownGapEntry>;
+}
+
+// --- Render input -----------------------------------------------------------
+
+export interface RenderInput {
+  scorecard: TierScorecard;
+  traceability: TraceabilityManifest;
+  knownGaps: KnownGaps;
+  // Provenance — used for the stamp comment at the top of the generated block.
+  upstreamSha: string;
+  protocolVersion: string;
+}

--- a/tools/conformance-report/test/fixtures/expected.md
+++ b/tools/conformance-report/test/fixtures/expected.md
@@ -1,0 +1,33 @@
+<!-- begin:generated -->
+<!-- generated against upstream-conformance@abc1234 · protocol 2025-11-25 · regenerate via scripts/refresh-conformance.sh -->
+
+## Conformance Summary
+
+| Surface | Scenarios pass/total | Checks pass/fail |
+|---|---:|---:|
+| Server | 3/4 | 14/2 |
+| Client | 1/1 | 14/0 |
+
+## SEP Coverage
+
+| SEP | Tested reqs | Excluded | Untested | Status |
+|---|---:|---:|---:|---|
+| [SEP-2322](https://modelcontextprotocol.io/specification/draft/basic/utilities/mrtr) | 1 | 0 | 1 | partial |
+| [SEP-2549](https://modelcontextprotocol.io/seps/2549-list-ttl) | 1 | 0 | 0 | **pass** |
+
+_Status reflects upstream-declared requirements only. Scenario→SEP attribution is not exposed in tier-check JSON today; this column tracks "does upstream have a check ID for this SEP requirement", not "does mcpkit pass it". Per-SEP scenario pass/fail lives in `conformance/UPSTREAM_AUDIT.md`._
+
+## Open Gaps
+
+### Failing scenarios
+
+| Scenario | Surface | Checks fail/pass | Tracking |
+|---|---|---:|---|
+| `mrtr-basic` | server | 2/3 | mcpkit#487 — stateless wire drops inputResponses (gotcha tracked in CLAUDE.md) |
+
+### Declared requirements with no emitted check
+
+| SEP | Check ID | Tracking |
+|---|---|---|
+| SEP-2322 | `sep-2322-input-required-on-allowed-method` | conformance#262 — scenario coverage pending upstream merge |
+<!-- end:generated -->

--- a/tools/conformance-report/test/fixtures/known-gaps.yaml
+++ b/tools/conformance-report/test/fixtures/known-gaps.yaml
@@ -1,0 +1,10 @@
+# Hand-annotated overlay for test fixtures.
+# Production overlay lives at conformance/known-gaps.yaml.
+scenarios:
+  "mrtr-basic":
+    issue: "mcpkit#487"
+    note: "stateless wire drops inputResponses (gotcha tracked in CLAUDE.md)"
+checks:
+  "sep-2322-input-required-on-allowed-method":
+    issue: "conformance#262"
+    note: "scenario coverage pending upstream merge"

--- a/tools/conformance-report/test/fixtures/scorecard.json
+++ b/tools/conformance-report/test/fixtures/scorecard.json
@@ -1,0 +1,67 @@
+{
+  "repo": "panyam/mcpkit",
+  "branch": "main",
+  "timestamp": "2026-05-30T00:00:00.000Z",
+  "version": "v0.2.43",
+  "checks": {
+    "conformance": {
+      "status": "partial",
+      "pass_rate": 0.75,
+      "passed": 3,
+      "failed": 1,
+      "total": 4,
+      "details": [
+        {
+          "scenario": "server-ping-2026-05-31T00-07-40-860Z",
+          "passed": true,
+          "checks_passed": 2,
+          "checks_failed": 0,
+          "specVersions": ["2025-11-25"]
+        },
+        {
+          "scenario": "server-tools-dynamic-2026-05-31T00-07-41-198Z",
+          "passed": true,
+          "checks_passed": 5,
+          "checks_failed": 0,
+          "specVersions": ["2025-11-25", "DRAFT-2026-v1"]
+        },
+        {
+          "scenario": "server-mrtr-basic-2026-05-31T00-07-41-512Z",
+          "passed": false,
+          "checks_passed": 3,
+          "checks_failed": 2,
+          "specVersions": ["DRAFT-2026-v1"]
+        },
+        {
+          "scenario": "server-tools-structured-output-2026-05-31T00-07-42-001Z",
+          "passed": true,
+          "checks_passed": 4,
+          "checks_failed": 0,
+          "specVersions": ["2025-11-25"]
+        }
+      ]
+    },
+    "client_conformance": {
+      "status": "pass",
+      "pass_rate": 1,
+      "passed": 1,
+      "failed": 0,
+      "total": 1,
+      "details": [
+        {
+          "scenario": "auth-basic-2026-05-31T00-07-43-001Z",
+          "passed": true,
+          "checks_passed": 14,
+          "checks_failed": 0,
+          "specVersions": ["2025-11-25"]
+        }
+      ]
+    }
+  },
+  "implied_tier": {
+    "tier": 2,
+    "tier1_blockers": ["server_conformance"],
+    "tier2_met": true,
+    "note": "Server conformance has 1 failing scenario; tier 2 thresholds met."
+  }
+}

--- a/tools/conformance-report/test/fixtures/traceability.json
+++ b/tools/conformance-report/test/fixtures/traceability.json
@@ -1,0 +1,54 @@
+{
+  "schemaVersion": 1,
+  "docs": "https://github.com/modelcontextprotocol/conformance/blob/main/AGENTS.md#traceability-manifest",
+  "source": "mcpkit-test-fixture",
+  "seps": {
+    "2322": {
+      "yaml": "src/seps/sep-2322.yaml",
+      "specUrl": "https://modelcontextprotocol.io/specification/draft/basic/utilities/mrtr",
+      "requirements": [
+        {
+          "check": "sep-2322-result-type-included",
+          "status": "tested",
+          "text": "The resultType field MUST be included to indicate the type of the result."
+        },
+        {
+          "check": "sep-2322-input-required-on-allowed-method",
+          "status": "untested",
+          "text": "Servers MUST only send InputRequiredResult for tools/call, prompts/get, or completion/complete."
+        }
+      ],
+      "excluded": [],
+      "unkeyed": [],
+      "untracked": [],
+      "summary": {
+        "tested": 1,
+        "untested": 1,
+        "excluded": 0,
+        "untracked": 0,
+        "unkeyed": 0
+      }
+    },
+    "2549": {
+      "yaml": "src/seps/sep-2549.yaml",
+      "specUrl": "https://modelcontextprotocol.io/seps/2549-list-ttl",
+      "requirements": [
+        {
+          "check": "sep-2549-ttl-ms-respected",
+          "status": "tested",
+          "text": "Clients MUST treat absent ttlMs the same as ttlMs: 0."
+        }
+      ],
+      "excluded": [],
+      "unkeyed": [],
+      "untracked": [],
+      "summary": {
+        "tested": 1,
+        "untested": 0,
+        "excluded": 0,
+        "untracked": 0,
+        "unkeyed": 0
+      }
+    }
+  }
+}

--- a/tools/conformance-report/test/render.test.ts
+++ b/tools/conformance-report/test/render.test.ts
@@ -1,0 +1,134 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { loadKnownGaps, loadScorecard, loadTraceability } from '../src/parse.js';
+import {
+  BEGIN_GENERATED,
+  END_GENERATED,
+  renderGeneratedBlock,
+  spliceGeneratedRegion
+} from '../src/render.js';
+
+const here = fileURLToPath(new URL('./fixtures/', import.meta.url));
+
+function loadFixtures() {
+  return {
+    scorecard: loadScorecard(join(here, 'scorecard.json')),
+    traceability: loadTraceability(join(here, 'traceability.json')),
+    knownGaps: loadKnownGaps(join(here, 'known-gaps.yaml')),
+    upstreamSha: 'abc1234',
+    protocolVersion: '2025-11-25'
+  };
+}
+
+function trimTrailing(s: string): string {
+  return s.replace(/\n+$/, '');
+}
+
+describe('renderGeneratedBlock', () => {
+  it('matches the golden output for the canonical fixture', () => {
+    const input = loadFixtures();
+    const expected = readFileSync(join(here, 'expected.md'), 'utf-8');
+    const got = renderGeneratedBlock(input);
+    expect(trimTrailing(got)).toBe(trimTrailing(expected));
+  });
+
+  it('is deterministic across runs (no wall-clock, no random ordering)', () => {
+    const input = loadFixtures();
+    const a = renderGeneratedBlock(input);
+    const b = renderGeneratedBlock(input);
+    expect(a).toBe(b);
+  });
+
+  it('does not include any wall-clock date in the stamp', () => {
+    const input = loadFixtures();
+    const got = renderGeneratedBlock(input);
+    // Wall-clock dates (e.g. ISO 2026-05-30 or year tokens) anywhere in the
+    // generated block would break the staleness gate; only the upstream SHA
+    // and protocol version are allowed in the stamp.
+    expect(got).not.toMatch(/202\d-\d{2}-\d{2}T/);
+    expect(got).not.toMatch(/generated YYYY-MM-DD/);
+  });
+
+  it('drops tier-check checks that depend on live GitHub state', () => {
+    const input = loadFixtures();
+    const got = renderGeneratedBlock(input);
+    // None of these slices should leak into CONFORMANCE.md — they change
+    // daily independent of code and would break the diff gate.
+    expect(got).not.toMatch(/Labels/i);
+    expect(got).not.toMatch(/Triage/i);
+    expect(got).not.toMatch(/P0/);
+    expect(got).not.toMatch(/Stable Release/i);
+    expect(got).not.toMatch(/Policy Signals/i);
+    expect(got).not.toMatch(/Spec Tracking/i);
+  });
+
+  it('shows "no open gaps" when scorecard is clean and traceability fully tested', () => {
+    const input = loadFixtures();
+    input.scorecard.checks.conformance.details = input.scorecard.checks.conformance.details.map((d) => ({
+      ...d,
+      passed: true,
+      checks_failed: 0
+    }));
+    input.scorecard.checks.client_conformance.details = input.scorecard.checks.client_conformance.details.map((d) => ({
+      ...d,
+      passed: true,
+      checks_failed: 0
+    }));
+    for (const sep of Object.values(input.traceability.seps)) {
+      for (const r of sep.requirements) r.status = 'tested';
+      sep.summary.untested = 0;
+    }
+    const got = renderGeneratedBlock(input);
+    expect(got).toMatch(/No open conformance gaps/);
+  });
+});
+
+describe('spliceGeneratedRegion', () => {
+  it('preserves hand-edited content above the begin marker', () => {
+    const preserved =
+      '# CONFORMANCE\n\nThis is the overview, hand-edited by maintainers.\n\n';
+    const existing = preserved + BEGIN_GENERATED + '\nOLD BLOCK\n' + END_GENERATED + '\n';
+    const newBlock = BEGIN_GENERATED + '\nNEW BLOCK\n' + END_GENERATED;
+    const merged = spliceGeneratedRegion(existing, newBlock);
+    expect(merged.startsWith(preserved)).toBe(true);
+    expect(merged).toContain('NEW BLOCK');
+    expect(merged).not.toContain('OLD BLOCK');
+  });
+
+  it('appends the block when no markers exist (bootstrap case)', () => {
+    const newBlock = BEGIN_GENERATED + '\nFIRST RUN\n' + END_GENERATED;
+    const merged = spliceGeneratedRegion(null, newBlock);
+    expect(merged).toContain('FIRST RUN');
+    expect(merged.endsWith('\n')).toBe(true);
+  });
+
+  it('appends to existing content with no markers (in-flight migration)', () => {
+    const existing = '# CONFORMANCE\n\nLegacy hand-written file.\n';
+    const newBlock = BEGIN_GENERATED + '\nNEW\n' + END_GENERATED;
+    const merged = spliceGeneratedRegion(existing, newBlock);
+    expect(merged.startsWith(existing)).toBe(true);
+    expect(merged).toContain('NEW');
+  });
+
+  it('ignores marker text embedded in prose (only whole-line markers anchor the splice)', () => {
+    // Overview text legitimately mentions the marker convention. The first
+    // textual occurrence below sits on the same line as other prose; the
+    // real splice anchor is the standalone marker further down.
+    const preserved =
+      '# CONFORMANCE\n\nOverview mentioning the <!-- begin:generated --> marker convention inline.\n\n';
+    const existing =
+      preserved +
+      BEGIN_GENERATED +
+      '\nOLD BLOCK\n' +
+      END_GENERATED +
+      '\n';
+    const newBlock = BEGIN_GENERATED + '\nNEW BLOCK\n' + END_GENERATED;
+    const merged = spliceGeneratedRegion(existing, newBlock);
+    expect(merged.startsWith(preserved)).toBe(true);
+    expect(merged).toContain('marker convention inline');
+    expect(merged).toContain('NEW BLOCK');
+    expect(merged).not.toContain('OLD BLOCK');
+  });
+});

--- a/tools/conformance-report/tsconfig.json
+++ b/tools/conformance-report/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
## What changes

Adds `tools/conformance-report` — an in-tree TS renderer that drives upstream `tier-check --output json`, joins it with the SEP traceability manifest from `modelcontextprotocol/conformance@main`, and produces `CONFORMANCE.md` at the repo root. CI regenerates on every PR and fails on diff.

Closes issue 498 (Phase 1). Phases 2–5 (upstream offer, GH Pages, etc.) are deferred.

## Reviewer's guide

Read in this order:

1. [CONFORMANCE.md](https://github.com/panyam/mcpkit/pull/507/files#diff-d647b61d5d64e4801ec167193f4f207eb71d12b4ec92d5f08b2867673481b9de) — start here. The artifact this PR exists to produce. The hand-edited Overview block above `<!-- begin:generated -->` explains scope and the deliberate omissions; the generated block below it is what the renderer wrote.
2. [tools/conformance-report/src/render.ts](https://github.com/panyam/mcpkit/pull/507/files#diff-6bb2e05fa1f26aafff697dbeaebb958d4e1614720f307ffa950b0f788660a3b3) — the renderer. Two-table design (Conformance Summary + SEP Coverage) intentionally avoids claiming a scenario→SEP join the upstream JSON does not support (see in-file comment citing the traceability manifest's own scope note). `spliceGeneratedRegion` uses whole-line marker matching so prose mentioning the marker text inline does not collide.
3. [tools/conformance-report/test/render.test.ts](https://github.com/panyam/mcpkit/pull/507/files#diff-b40940fc3456a81861d60c3b5655a5b18f8445e86401a47b7fbbc5db112ed612) — golden + regression tests. Nine cases including determinism, GH-volatile-slice exclusion, the no-gaps state, and the prose-collision regression.
4. `tools/conformance-report/test/fixtures/` — `scorecard.json` + `traceability.json` + `known-gaps.yaml` + `expected.md`. The fixture mirrors real upstream JSON shape (timestamp-suffixed scenario IDs, protocol-version-only `specVersions`) so the test catches drift if upstream's output schema moves.
5. [scripts/refresh-conformance.sh](https://github.com/panyam/mcpkit/pull/507/files#diff-3775227d6d2846bfa2da31ff1ede031280bd0cfd0dcd9e74828cc013993aed1c) — driver. Builds `cmd/testserver`, spawns it, runs `tier-check`, invokes the renderer, writes [CONFORMANCE.md](https://github.com/panyam/mcpkit/pull/507/files#diff-d647b61d5d64e4801ec167193f4f207eb71d12b4ec92d5f08b2867673481b9de) in place.
6. [conformance/known-gaps.yaml](https://github.com/panyam/mcpkit/pull/507/files#diff-bcd01920bd187fabe66d67bfeb497d62d841a9e3389985aac55b32955b6d2a30) — hand-annotated overlay the renderer joins with raw failure rows. Schema documented in the file header.
7. [conformance/Makefile](https://github.com/panyam/mcpkit/pull/507/files#diff-53e691e18159f1d2d88ea4a327f2f87d567e5b2365d94006d152c4de9ad4f084) — `refresh-conformance` and `check-conformance-stale` targets (the latter is the CI gate).
8. [.github/workflows/test.yml](https://github.com/panyam/mcpkit/pull/507/files#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88) — new `conformance-report` job. Checks out both `mcpkit` and `modelcontextprotocol/conformance` at `main`, runs renderer unit tests, then `make check-conformance-stale`.

Skim or skip: [tools/conformance-report/package.json](https://github.com/panyam/mcpkit/pull/507/files#diff-b05901240c7924802b81971f1d4699f9e09999d0dfc109de5f12ddabf1ffc2c1), `tsconfig.json`, `.gitignore`, `README.md` — standard scaffolding; root [Makefile](https://github.com/panyam/mcpkit/pull/507/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52) + [CLAUDE.md](https://github.com/panyam/mcpkit/pull/507/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7) — one-line delegates and pointer.

## Diff groups

- Production: `tools/conformance-report/src/`, `scripts/refresh-conformance.sh`, `conformance/known-gaps.yaml`, `CONFORMANCE.md`
- Tests: `tools/conformance-report/test/`
- Wiring: `.github/workflows/test.yml`, `Makefile`, `conformance/Makefile`, `CLAUDE.md`, `tools/conformance-report/{package.json,tsconfig.json,.gitignore,README.md}`

## Decision log

- **Why a two-table layout instead of the issue's `| SEP | Title | Tier | Passing | Total | Status |`?** The issue's design assumed scenario→SEP attribution could be joined from `tier-check` + `traceability.json`. The upstream traceability manifest's own scope note (`src/traceability/types.ts`) says otherwise: *"tier-check reports at scenario granularity and does not currently expose per-check IDs, while this manifest carries check IDs but not scenario names. Wiring plan.mcp.io's two feeds together needs one side to add the missing column first."* I confirmed this empirically by inspecting real tier-check JSON — `specVersions` carries protocol versions (`"2025-11-25"`, `"DRAFT-2026-v1"`), never `SEP-NNNN` tags. So the renderer splits the question into what each feed *can* answer honestly: wire-level pass/fail per surface, and requirement-coverage per SEP. The doc explicitly tells the reader to consult `conformance/UPSTREAM_AUDIT.md` for the scenario-level per-SEP grading we already have.

- **Why drop tier-check's GH-side checks (labels, triage, P0s, release, policy signals, spec tracking)?** They depend on live GitHub state and change daily independent of code, which would break the CI staleness gate (every PR would see a diff). The renderer drops them on the way out; the full `tier-check --output markdown` still works for point-in-time tier judgements, called out in the Overview.

- **Why no wall-clock date or mcpkit SHA in the stamp?** UPSTREAM_AUDIT.md precedent: both would mutate on every commit regardless of content change, defeating the diff gate. Stamp carries only the upstream conformance SHA + protocol version. `git blame CONFORMANCE.md` gives identical provenance for the mcpkit side.

- **Why a hand-annotated `known-gaps.yaml` overlay instead of raw failure rows only?** Same human-overlay pattern as `FORK_OVERLAP` in `scripts/conformance-audit-report.ts`. Lets a reviewer skim Open Gaps and see "yes, this fail is the SEP-2575 upstream-test bug we already document in CLAUDE.md gotchas" instead of treating every row as fresh news.

- **Why whole-line marker matching in `spliceGeneratedRegion`?** Caught during local idempotency testing: my own Overview prose mentioned `<!-- begin:generated -->` literally to describe the convention, which collided with the splice anchor and ate the Overview on regen. Hardened to require markers on their own line; regression test added.

## Risk / blast radius

- **Affects:** new CI job (`conformance-report`) added to `.github/workflows/test.yml`. New `make` targets on root + `conformance/`. New committed file `CONFORMANCE.md`. No code in `core/`, `server/`, `client/`, `ext/*`.
- **Tests covering this:** `tools/conformance-report/test/render.test.ts` (9 cases). Idempotency verified locally end-to-end.
- **Be paranoid about:**
  - CI flake potential — the new job clones upstream `modelcontextprotocol/conformance@main`, so an upstream breaking change to `tier-check`'s JSON shape will surface here as a failed CI run on every PR until either the renderer or fixtures catch up. That's the intended signal (we want to know when upstream moves), but it can block unrelated work. The mitigation if it bites: pin upstream to a tag instead of `main` via `actions/checkout@v4 ref:`, or land the renderer update as a follow-up.
  - The renderer needs `GITHUB_TOKEN` to keep tier-check from bailing on its GH queries, even though we discard the results. Workflow uses the default `secrets.GITHUB_TOKEN`. Rate-limit on a busy repo is theoretically possible.

## Out of scope (deliberately deferred)

- Phase 2: cross-reference from conformance#262, MCP conformance Discord post.
- Phase 3: upstream-offer the renderer as `tier-check --format markdown` in `modelcontextprotocol/conformance`.
- Phase 4: filed upstream PR.
- Phase 5: GH Pages docs site.
- Registering mcpkit on `plan.modelcontextprotocol.io` (governance question, separate ask).
