### PR TITLE
fix(conformance): pin upstream SHA in CI gate so it's reproducible

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,9 +69,16 @@ jobs:
         run: cd ext/ui && go test ./... -v -count=1 -timeout 30s
 
   conformance-report:
-    # Regenerates CONFORMANCE.md against the current testserver + upstream
-    # conformance@main and fails if the committed file is stale. See issue #498.
-    # Driver: scripts/refresh-conformance.sh → tools/conformance-report.
+    # Regenerates CONFORMANCE.md against the current testserver + the upstream
+    # conformance SHA pinned in the committed file's stamp line, and fails if
+    # the result is stale. See issue 498.
+    #
+    # Why pin instead of tracking upstream/main: upstream advances daily, so
+    # tracking main would make this gate fail on every PR until a maintainer
+    # ran `make refresh-conformance` locally. Pinning to the stamp lets the
+    # gate verify "the committed file is reproducible from its declared
+    # inputs" — bumping upstream becomes an explicit, reviewable change
+    # (run `make refresh-conformance` + commit the diff).
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -81,10 +88,27 @@ jobs:
         with:
           path: mcpkit
 
-      - name: Checkout modelcontextprotocol/conformance@main
+      - name: Extract pinned upstream-conformance SHA from CONFORMANCE.md
+        id: pin
+        working-directory: mcpkit
+        run: |
+          # Stamp line shape: "<!-- generated against upstream-conformance@<sha> · protocol <ver> · ... -->"
+          # The regex restricts capture to hex chars, so a maliciously crafted
+          # body cannot inject anything into the `ref:` parameter below.
+          SHA="$(sed -n 's/.*upstream-conformance@\([a-f0-9]\{4,\}\).*/\1/p' CONFORMANCE.md | head -1)"
+          if [ -z "$SHA" ]; then
+            echo "::error::Could not extract upstream-conformance SHA from CONFORMANCE.md stamp line."
+            echo "::error::Run 'make refresh-conformance' locally to regenerate the file."
+            exit 1
+          fi
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "Pinned upstream-conformance@$SHA"
+
+      - name: Checkout modelcontextprotocol/conformance at pinned SHA
         uses: actions/checkout@v4
         with:
           repository: modelcontextprotocol/conformance
+          ref: ${{ steps.pin.outputs.sha }}
           path: conf-upstream-main
 
       - uses: actions/setup-go@v5

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -62,7 +62,7 @@ _Status reflects upstream-declared requirements only. Scenario→SEP attribution
 
 | Scenario | Surface | Checks fail/pass | Tracking |
 |---|---|---:|---|
-| `server-stateless` | server | 1/19 | — |
+| `server-stateless` | server | 1/19 | upstream conformance test bug — ServerRejectsUndeclaredCapability checks requiredCapabilities as string-array but SEP-2575 schema says object — mcpkit follows schema. Tracked in CLAUDE.md gotchas. |
 
 ### Declared requirements with no emitted check
 

--- a/conformance/Makefile
+++ b/conformance/Makefile
@@ -217,12 +217,12 @@ refresh-conformance: ## Regenerate CONFORMANCE.md from upstream tier-check + tra
 	fi
 	cd $(REPO_ROOT) && MCPCONFORMANCE_BASE_PATH="$(MCPCONFORMANCE_BASE_PATH)" bash scripts/refresh-conformance.sh
 
-check-conformance-stale: refresh-conformance ## CI gate — fail if CONFORMANCE.md is stale (issue #498). Run after refresh-conformance; diff must be empty.
-	@cd $(REPO_ROOT) && git diff --exit-code CONFORMANCE.md > /dev/null 2>&1 || { \
+check-conformance-stale: refresh-conformance ## CI gate — fail if CONFORMANCE.md is stale (issue 498). Compares working tree to HEAD so the gate is robust to staging order.
+	@cd $(REPO_ROOT) && git diff --exit-code HEAD -- CONFORMANCE.md > /dev/null 2>&1 || { \
 		echo "CONFORMANCE.md is stale relative to current testserver + upstream conformance."; \
 		echo "Run 'make refresh-conformance' locally and commit the regenerated file."; \
 		echo ""; \
-		git diff CONFORMANCE.md | head -60; \
+		git diff HEAD -- CONFORMANCE.md | head -60; \
 		exit 1; \
 	}
 	@echo "CONFORMANCE.md is up to date."

--- a/conformance/known-gaps.yaml
+++ b/conformance/known-gaps.yaml
@@ -18,7 +18,7 @@
 # Keep entries terse; the renderer puts them straight into a table cell.
 
 scenarios:
-  "stateless":
+  "server-stateless":
     issue: "upstream conformance test bug"
     note: "ServerRejectsUndeclaredCapability checks requiredCapabilities as string-array but SEP-2575 schema says object — mcpkit follows schema. Tracked in CLAUDE.md gotchas."
 


### PR DESCRIPTION
## What changes

Fixes the `conformance-report` CI job that failed on PR 507's first post-merge run. Three small fixes:

1. **Pin upstream checkout to the SHA in `CONFORMANCE.md`** (workflow). Was tracking `modelcontextprotocol/conformance@main`, which advances daily — by the time CI ran, upstream had moved from `bcfd400` (the SHA stamped in the committed file) to `7d3b897`, so the regen produced a different scorecard than what was committed. PR 507's decision log called this risk out as "intended signal"; the actual experience after one day is that it's just flake. Pin the workflow's `actions/checkout` `ref:` to the SHA grepped out of the committed file's stamp line. Bumping upstream becomes an explicit, reviewable change — `make refresh-conformance` updates both the report and (transitively) the pin in one diff.
2. **Diff against `HEAD`, not the index** (`conformance/Makefile`). `git diff --exit-code CONFORMANCE.md` compares working tree to index. A maintainer who stages a broken file before running the gate would see a false pass. Compare to `HEAD` instead; robust regardless of staging order. (CI is unaffected — nothing is staged in CI.)
3. **Fix the `known-gaps.yaml` scenario key from `stateless` to `server-stateless`** (`conformance/known-gaps.yaml`). The renderer normalizes upstream's raw `server-server-stateless-<timestamp>` by stripping the timestamp + a single `server-` prefix, leaving `server-stateless`. My original annotation key was one prefix-strip too aggressive, so the annotation never attached. The Tracking cell now surfaces the SEP-2575 upstream-test-bug context we already document in CLAUDE.md gotchas.

## Reviewer's guide

1. [.github/workflows/test.yml](https://github.com/panyam/mcpkit/pull/510/files#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88) — start here. New "Extract pinned upstream-conformance SHA" step + `ref:` interpolation. The regex `s/.*upstream-conformance@\([a-f0-9]\{4,\}\).*/\1/p` restricts capture to hex chars so a crafted file body cannot inject into the `ref:` parameter.
2. [conformance/Makefile](https://github.com/panyam/mcpkit/pull/510/files#diff-53e691e18159f1d2d88ea4a327f2f87d567e5b2365d94006d152c4de9ad4f084) — `check-conformance-stale` target switched from `git diff --exit-code CONFORMANCE.md` to `git diff --exit-code HEAD -- CONFORMANCE.md`.
3. [conformance/known-gaps.yaml](https://github.com/panyam/mcpkit/pull/510/files#diff-bcd01920bd187fabe66d67bfeb497d62d841a9e3389985aac55b32955b6d2a30) — single key rename: `stateless` → `server-stateless`.
4. [CONFORMANCE.md](https://github.com/panyam/mcpkit/pull/510/files#diff-d647b61d5d64e4801ec167193f4f207eb71d12b4ec92d5f08b2867673481b9de) — one-line regenerated diff: the failing-scenario row's Tracking column now carries the upstream-test-bug note.

## Decision log

- **Why grep the SHA out of `CONFORMANCE.md` instead of a separate `UPSTREAM_SHA` file?** Single source of truth. The stamp is already the canonical declaration of "this report was generated against upstream@X"; introducing a parallel pin file would let them drift.
- **Why fail-loud on a missing SHA in the stamp?** A missing SHA means the file was hand-edited in a way that broke the contract, or never regenerated since a renderer rewrite. Either way silent fallback would be worse — better to surface "run `make refresh-conformance` locally".
- **Why not just pin to a tag?** Upstream `modelcontextprotocol/conformance` doesn't cut tags on a predictable cadence — pinning to a SHA + tracking it in the artifact is more honest about what the report actually grades.

## Risk / blast radius

- Workflow change only affects the new `conformance-report` job (introduced in PR 507). No other CI jobs touched.
- Local `make` targets behave the same modulo the HEAD-vs-index nuance, which only matters in the rare "stage broken file then run gate" case.

## Verification

- `make check-conformance-stale` clean locally (regen is byte-identical to committed file when upstream is at the pinned SHA).
- `npm test` in `tools/conformance-report/` — 9/9 unchanged.
