### PR TITLE
chore(conformance): wire refresh-conformance into the conformance umbrella

### DIFF
--- a/conformance/Makefile
+++ b/conformance/Makefile
@@ -44,7 +44,7 @@ MCPCONFORMANCE_BASE_PATH        ?= $(abspath $(REPO_ROOT)/../conf-upstream-main)
 # exist (each target fail-fasts with a remediation message if missing). Fair
 # game: contributors should have all conf-* sibling clones before pushing
 # anything that touches conformance surfaces.
-test: testconf testconfauth testconf-tasks testconf-tasks-v2 testconf-mrtr testconf-file-inputs testconf-auth-server testconf-stateless testconf-upstream-audit ## Run all conformance suites (needs fork worktrees + conf-upstream-main)
+test: testconf testconfauth testconf-tasks testconf-tasks-v2 testconf-mrtr testconf-file-inputs testconf-auth-server testconf-stateless testconf-upstream-audit refresh-conformance ## Run all conformance suites (needs fork worktrees + conf-upstream-main)
 
 testconfall: testconf testconfauth ## Run base + auth conformance only
 


### PR DESCRIPTION
## What changes

One-line addition: `refresh-conformance` now runs as part of `make -C conformance test`, alongside the existing `testconf-upstream-audit`.

## Why

PR 507 introduced `make refresh-conformance` (and `make check-conformance-stale`) but left them as standalone targets. With this change, maintainers running the full conformance umbrella before a release regenerate `CONFORMANCE.md` as part of the run.

Deliberately **not** added to `make testall`. Same precedent as `testconf-upstream-audit`: it imposes the upstream-clone + GH-token prereqs that the conformance umbrella already requires per its header comment (*"Fair game: contributors should have all conf-* sibling clones before pushing anything that touches conformance surfaces"*), but `testall` users with just Go + Node shouldn't need to clone upstream conformance just to run tests.

## Decision log

- **Picked `refresh-conformance` (regenerate) over `check-conformance-stale` (regenerate + fail-if-dirty) inside the umbrella.** Matches `testconf-upstream-audit`'s "produce the artifact" semantics. Failing the umbrella on a stale `CONFORMANCE.md` would be surprising — the maintainer probably wants the file fresh, not a build failure. The CI staleness gate (`check-conformance-stale`, wired in `.github/workflows/test.yml`) remains the actual contract on every PR.

## Risk / blast radius

- Affects only `make -C conformance test`. `make test`, `make testall`, and individual `testconf-*` targets unchanged.
- Local runs of the conformance umbrella now produce a working-tree change to `CONFORMANCE.md` if upstream has advanced since the last commit. `git status` will surface it; CI will reject a stale commit via the existing gate.