### PR TITLE
docs(auth): document 2025-03-26 backcompat as wontfix per #451 policy

### DIFF
--- a/conformance/baseline.yml
+++ b/conformance/baseline.yml
@@ -34,3 +34,13 @@ client:
 
   # Required — CIMD (warning: not using Client ID Metadata Documents yet)
   - auth/basic-cimd                         # Client ID Metadata Document flow (warning)
+
+  # 2025-03-26 spec backcompat — wontfix per #451. Both scenarios test
+  # the auth flow shapes the spec removed in 2025-06-18 (rootless OAuth
+  # metadata, fallback to OAuth-standard endpoints when no metadata
+  # endpoints exist). mcpkit targets 2025-11-25 + DRAFT-2026-v1; servers
+  # stuck on 2025-03-26 hit a clear "PRM endpoint missing" error from
+  # ext/auth/discovery.go that points at the spec gap. See
+  # ext/auth/docs/DESIGN.md "Supported spec versions" for the policy.
+  - auth/2025-03-26-oauth-endpoint-fallback # legacy OAuth-endpoint root fallback (#451 wontfix)
+  - auth/2025-03-26-oauth-metadata-backcompat # legacy rootless OAuth metadata (#451 wontfix)

--- a/conformance/known-gaps.yaml
+++ b/conformance/known-gaps.yaml
@@ -21,6 +21,12 @@ scenarios:
   "server-stateless":
     issue: "upstream conformance test bug"
     note: "ServerRejectsUndeclaredCapability checks requiredCapabilities as string-array but SEP-2575 schema says object — mcpkit follows schema. Tracked in CLAUDE.md gotchas."
+  "2025-03-26-oauth-endpoint-fallback":
+    issue: "https://github.com/panyam/mcpkit/issues/451"
+    note: "Wontfix — 2025-03-26 OAuth-endpoint root fallback removed by spec in 2025-06-18. mcpkit targets 2025-11-25+; see ext/auth/docs/DESIGN.md for the policy."
+  "2025-03-26-oauth-metadata-backcompat":
+    issue: "https://github.com/panyam/mcpkit/issues/451"
+    note: "Wontfix — rootless OAuth metadata removed by spec in 2025-06-18. See ext/auth/docs/DESIGN.md."
 
 checks:
   "sep-2243-server-not-expect-null":

--- a/ext/auth/docs/DESIGN.md
+++ b/ext/auth/docs/DESIGN.md
@@ -4,6 +4,19 @@
 
 MCPKit implements the MCP Authorization specification (draft, based on OAuth 2.1 + RFC 9728) for enterprise deployment. This document covers the architecture, protocol flows, and extension/experimental marking system.
 
+## Supported spec versions
+
+mcpkit targets the **2025-11-25 MCP Authorization spec** and the in-flight **DRAFT-2026-v1** draft. The auth-flow shapes from the **2025-03-26 spec** (rootless OAuth metadata, OAuth-endpoint root fallback when no metadata endpoints exist) are intentionally **not supported** — those shapes were removed by the spec itself in 2025-06-18, and implementing them would mean carrying deprecated code paths indefinitely for a tiny pool of servers that haven't tracked the spec for more than a year.
+
+Concretely:
+
+- mcpkit's client **requires a PRM endpoint** (`/.well-known/oauth-protected-resource{path}` or `/.well-known/oauth-protected-resource`). If PRM is missing, `ext/auth/discovery.go` returns a clear `PRM endpoint returned 404` error — that error is the actionable signal that the server is on the deprecated spec.
+- The OAuth-endpoint root fallback (`/authorize`, `/token`, `/register` at server root without metadata discovery) is also unsupported. Same rationale: spec removed it; mcpkit doesn't carry it.
+
+The conformance audit's two `auth/2025-03-26-*` scenarios live in `conformance/baseline.yml` as expected-failures and in `conformance/known-gaps.yaml` with this rationale + a tracking link to #451. The upstream audit report (`conformance/UPSTREAM_AUDIT.md`) still shows them as `partial`; that's correct — we don't pass them, and that's intentional.
+
+Note: this is distinct from MCP **protocol version** negotiation. mcpkit's `server.supportedProtocolVersions` includes `2024-11-05`, `2025-03-26`, `2025-11-25`, and `DRAFT-2026-v1` — clients on the older protocol version still negotiate successfully. The thing that's unsupported is the *auth-flow shape* the 2025-03-26 spec mandated, which is independent of the protocol version field.
+
 ## Design Principles
 
 1. **Core module stays zero-auth-deps** — static bearer token validation works out of the box. JWT/OIDC/OAuth lives in `mcpkit/auth`, a separate Go sub-module that imports oneauth.


### PR DESCRIPTION
## What changes

Closes #451 with **option (b)** from the issue body: document the deprecation rather than implement legacy backcompat. The 2025-03-26 auth-flow shapes (rootless OAuth metadata, OAuth-endpoint root fallback when no metadata endpoints exist) were removed by the spec itself in 2025-06-18. Implementing them now would carry deprecated code paths indefinitely for a tiny pool of servers that haven't tracked the spec for more than a year.

This is a docs + policy PR — no code change.

## Reviewer's guide

1. [ext/auth/docs/DESIGN.md](https://github.com/panyam/mcpkit/pull/516/files#diff-03a5078f128c638aca27e780bfd0c762d7a6122a8867f7df0c519ffb23c54698) — start here. New "Supported spec versions" section right after the Overview. Captures the policy + flags the (subtle but important) distinction between auth-flow-shape support and protocol-version negotiation.
2. [conformance/baseline.yml](https://github.com/panyam/mcpkit/pull/516/files#diff-0bf2c40c9b3652a5564a2ae0433f3ef2bcfe8b65280907a930c2897972b7f0a2) — both `auth/2025-03-26-*` scenarios added to the `client:` expected-failures list. Defensive: if upstream's `--suite auth` filter ever expands to include backcompat scenarios, `make testconfauth` won't surprise-fail.
3. [conformance/known-gaps.yaml](https://github.com/panyam/mcpkit/pull/516/files#diff-bcd01920bd187fabe66d67bfeb497d62d841a9e3389985aac55b32955b6d2a30) — both scenarios annotated with wontfix rationale + #451 link. Surfaces in `CONFORMANCE.md`'s Open Gaps when the renderer covers auth client scenarios.

Skim or skip: nothing — small PR.

## Decision log

- **Option (b) over (a) — document, not implement.** Spec removed these shapes in 2025-06-18; carrying deprecated paths has no long-term value. The two annotation systems (`baseline.yml` + `known-gaps.yaml`) were designed for exactly this case. Errors are already actionable — clear "PRM endpoint returned 404" tells users why connectivity failed and points at the spec gap.
- **`baseline.yml` entry is defensive, not load-bearing today.** `make testconfauth` currently doesn't run these scenarios (the upstream `--suite auth` filter scopes to current-spec scenarios only). Adding them anyway means we're safe if upstream's filter expands later.
- **`known-gaps.yaml` entries are aspirational today.** `CONFORMANCE.md`'s Open Gaps section currently only surfaces tier-check-tracked failures (server scenarios + traceability rows). When the renderer evolves to cover client auth scenarios, the rationale is already there.
- **Policy lives in `ext/auth/docs/DESIGN.md`, not CLAUDE.md.** Per the question I asked: auth concerns belong with auth docs. Cross-link from CLAUDE.md if session discoverability becomes important.

## Risk / blast radius

- **Affects:** documentation + 2 YAML files. No code path changes; no runtime behavior change.
- **Tests covering this:** `make testconfauth` still 212/212 (unchanged). `make refresh-conformance` regenerates `CONFORMANCE.md` byte-identical.
- **Reversibility:** trivial. If a user reports needing 2025-03-26 backcompat, switching to option (a) is a one-PR change with no migration cost. The DESIGN.md callout explicitly invites that path.

## Before / after

- `auth/2025-03-26-oauth-endpoint-fallback` — `partial` (still — intentional)
- `auth/2025-03-26-oauth-metadata-backcompat` — `partial` (still — intentional)
- Policy: previously implicit, now explicit in DESIGN.md
- `testconfauth` exit status: unchanged

## Out of scope

- `initialize` testclient protocolVersion bump → #514
- SEP-2243 client header on all methods → #515
- `request-metadata` harness gap → #453
