### PR TITLE
feat(client): bump protocolVersion + emit SEP-2243 Mcp-Method/Mcp-Name headers (closes 514, 515)

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -23,16 +23,24 @@ import (
 type clientTransport interface {
 	// connect establishes the transport connection.
 	connect() error
-	// call sends a JSON-RPC request and returns the response.
-	call(data []byte) (*rpcResponse, error)
+	// call sends a JSON-RPC request and returns the response. The method
+	// argument is the JSON-RPC method name carried in data; the streamable
+	// HTTP transport mirrors it onto the SEP-2243 Mcp-Method routing
+	// header. Other transports may ignore it.
+	call(method string, data []byte) (*rpcResponse, error)
 	// callWithContext is like call but accepts a typed CallContext carrying
-	// per-call cancellation and an optional notification hook. Transports
-	// that can't honor cc (no per-call notification scoping) MUST still
-	// issue the call — the hook is a best-effort enhancement, not a
-	// requirement. Pass nil cc to behave identically to call().
-	callWithContext(data []byte, cc *CallContext) (*rpcResponse, error)
-	// notify sends a JSON-RPC notification (no response expected).
-	notify(data []byte) error
+	// per-call cancellation, an optional notification hook, and (on the
+	// streamable HTTP transport) the SEP-2243 Mcp-Name header value via
+	// cc.mcpName. Transports that can't honor cc (no per-call notification
+	// scoping) MUST still issue the call — the hook is a best-effort
+	// enhancement, not a requirement. Pass nil cc to behave identically
+	// to call().
+	callWithContext(method string, data []byte, cc *CallContext) (*rpcResponse, error)
+	// notify sends a JSON-RPC notification (no response expected). The
+	// method argument is the JSON-RPC method name carried in data; the
+	// streamable HTTP transport mirrors it onto the SEP-2243 Mcp-Method
+	// routing header. Other transports may ignore it.
+	notify(method string, data []byte) error
 	// close shuts down the transport.
 	close() error
 	// getSessionID returns the current session ID (empty if none).
@@ -276,14 +284,16 @@ func (a *coreTransportAdapter) connect() error {
 	return a.inner.Connect(context.Background())
 }
 
-func (a *coreTransportAdapter) call(data []byte) (*rpcResponse, error) {
-	return a.callWithContext(data, nil)
+func (a *coreTransportAdapter) call(method string, data []byte) (*rpcResponse, error) {
+	return a.callWithContext(method, data, nil)
 }
 
-// callWithContext on the core.Transport adapter ignores cc — core.Transport
-// has no notion of per-call notification scoping. Notifications still flow
-// through whatever notify path the underlying transport provides.
-func (a *coreTransportAdapter) callWithContext(data []byte, _ *CallContext) (*rpcResponse, error) {
+// callWithContext on the core.Transport adapter ignores method and cc —
+// core.Transport has no notion of per-call notification scoping, and the
+// underlying transport carries its own method routing inside the JSON-RPC
+// envelope. Notifications still flow through whatever notify path the
+// underlying transport provides.
+func (a *coreTransportAdapter) callWithContext(_ string, data []byte, _ *CallContext) (*rpcResponse, error) {
 	var req core.Request
 	if err := json.Unmarshal(data, &req); err != nil {
 		return nil, fmt.Errorf("invalid request: %w", err)
@@ -312,7 +322,7 @@ func (a *coreTransportAdapter) callWithContext(data []byte, _ *CallContext) (*rp
 	}, nil
 }
 
-func (a *coreTransportAdapter) notify(data []byte) error {
+func (a *coreTransportAdapter) notify(_ string, data []byte) error {
 	var req core.Request
 	if err := json.Unmarshal(data, &req); err != nil {
 		return fmt.Errorf("invalid notification: %w", err)
@@ -612,7 +622,7 @@ func (c *Client) doConnect() error {
 
 	// Initialize handshake
 	resp, err := c.rawCall("initialize", initializeParams{
-		ProtocolVersion: "2024-11-05",
+		ProtocolVersion: "2025-11-25",
 		Capabilities:    caps,
 		ClientInfo:      c.info,
 	})
@@ -910,6 +920,13 @@ type CallContext struct {
 	// transport's defaults (Content-Type, Accept, Mcp-Session-Id) only if the
 	// caller deliberately sets them — which they shouldn't.
 	Headers map[string]string
+	// mcpName carries the SEP-2243 Mcp-Name routing header value for the
+	// methods that have one (tools/call → params.name, prompts/get →
+	// params.name, resources/read → params.uri). Set by the wrapper that
+	// builds the call (ToolCall / PromptGet / ResourceRead); the streamable
+	// HTTP transport mirrors it onto the wire header. Unexported because
+	// callers shouldn't override the wrapper's value.
+	mcpName string
 }
 
 // NewCallContext wraps a context.Context as a CallContext for use with
@@ -1399,6 +1416,19 @@ func (c *Client) rawCall(method string, params any) (*rpcResponse, error) {
 // rawCallWithContext is the underlying call path used by both Call and
 // CallContext. cc may be nil for a no-context call (legacy Call path).
 func (c *Client) rawCallWithContext(method string, params any, cc *CallContext) (*rpcResponse, error) {
+	// SEP-2243 routing-header derivation runs against the caller's original
+	// params (pre-stateless-wrap) so the name/uri stays unwrapped. Allocates
+	// a CallContext only when needed so legacy callers without per-call
+	// state still see nil cc downstream where it matters.
+	if name := deriveMcpName(method, params); name != "" {
+		if cc == nil {
+			cc = &CallContext{}
+		}
+		if cc.mcpName == "" {
+			cc.mcpName = name
+		}
+	}
+
 	// SEP-2575 stateless wire: every outgoing call carries the _meta
 	// envelope (protocolVersion, clientInfo, clientCapabilities).
 	// No-op when c.useStatelessWire is false — legacy callers see
@@ -1415,13 +1445,13 @@ func (c *Client) rawCallWithContext(method string, params any, cc *CallContext) 
 	}
 	data, _ := json.Marshal(req)
 
-	resp, err := c.transport.callWithContext(data, cc)
+	resp, err := c.transport.callWithContext(method, data, cc)
 	if err != nil && c.maxRetries > 0 && IsTransientError(err) {
 		return c.retryWithReconnect(func() (*rpcResponse, error) {
 			// Re-build with new ID (old may have been consumed)
 			req.ID = marshalID(c.nextRequestID())
 			data, _ = json.Marshal(req)
-			return c.transport.callWithContext(data, cc)
+			return c.transport.callWithContext(method, data, cc)
 		})
 	}
 	return resp, err
@@ -1443,11 +1473,11 @@ func (c *Client) notifyMethod(method string, params any) error {
 	}
 	data, _ := json.Marshal(req)
 
-	err := c.transport.notify(data)
+	err := c.transport.notify(method, data)
 	if err != nil && c.maxRetries > 0 && IsTransientError(err) {
 		return c.retryNotifyWithReconnect(func() error {
 			data, _ = json.Marshal(req)
-			return c.transport.notify(data)
+			return c.transport.notify(method, data)
 		})
 	}
 	return err
@@ -1621,8 +1651,8 @@ func (t *streamableClientTransport) dispatchSSEEventWithHook(data string, hook f
 	return nil
 }
 
-func (t *streamableClientTransport) call(data []byte) (*rpcResponse, error) {
-	return t.callWithContext(data, nil)
+func (t *streamableClientTransport) call(method string, data []byte) (*rpcResponse, error) {
+	return t.callWithContext(method, data, nil)
 }
 
 // callWithContext issues the POST and, if the response is SSE, threads the
@@ -1634,7 +1664,7 @@ func (t *streamableClientTransport) call(data []byte) (*rpcResponse, error) {
 // When cc carries a context, the underlying http.Request is built with it
 // so cancelling cancels the in-flight POST — required for events/stream's
 // Stop() to actually close the connection.
-func (t *streamableClientTransport) callWithContext(data []byte, cc *CallContext) (*rpcResponse, error) {
+func (t *streamableClientTransport) callWithContext(method string, data []byte, cc *CallContext) (*rpcResponse, error) {
 	reqCtx := context.Background()
 	if cc != nil && cc.Context != nil {
 		reqCtx = cc.Context
@@ -1655,6 +1685,11 @@ func (t *streamableClientTransport) callWithContext(data []byte, cc *CallContext
 		if t.client != nil && t.client.useStatelessWire {
 			req.Header.Set(core.HTTPProtocolVersionHeader, core.DraftProtocolVersion2026V1)
 		}
+		// SEP-2243 standard routing headers: mirror the JSON-RPC method
+		// and (when set by callers like ToolCall / ResourceRead /
+		// PromptGet) the per-method name onto Mcp-Method / Mcp-Name so
+		// proxies and middleware can route without parsing the body.
+		setSEP2243RoutingHeaders(req, method, cc)
 		// Caller-supplied per-call headers (SEP-2243 Mcp-Param-* mirroring
 		// from ToolCall). Applied after the transport defaults so a caller
 		// can't accidentally clobber them — Mcp-Param-* names are reserved
@@ -1885,7 +1920,7 @@ func (t *streamableClientTransport) postResponse(resp *core.Response) {
 	httpResp.Body.Close()
 }
 
-func (t *streamableClientTransport) notify(data []byte) error {
+func (t *streamableClientTransport) notify(method string, data []byte) error {
 	buildReq := func() (*http.Request, error) {
 		req, err := http.NewRequest("POST", t.url, bytes.NewReader(data))
 		if err != nil {
@@ -1896,6 +1931,9 @@ func (t *streamableClientTransport) notify(data []byte) error {
 		if t.sessionID != "" {
 			req.Header.Set("Mcp-Session-Id", t.sessionID)
 		}
+		// SEP-2243 routing headers — notifications never carry an Mcp-Name
+		// (no params.name/uri), so cc is nil here on purpose.
+		setSEP2243RoutingHeaders(req, method, nil)
 		if t.modifyReq != nil {
 			t.modifyReq(req)
 		}
@@ -2137,15 +2175,17 @@ func (t *sseClientTransport) close() error {
 
 func (t *sseClientTransport) getSessionID() string { return t.sessionID }
 
-// callWithContext on the legacy SSE transport ignores cc — notifications
-// arrive on the GET stream (background reader), not on a per-call response,
-// so per-call scoping is not meaningful here. Notifications still reach
-// the session-global callback via the existing path.
-func (t *sseClientTransport) callWithContext(data []byte, _ *CallContext) (*rpcResponse, error) {
-	return t.call(data)
+// callWithContext on the legacy SSE transport ignores method and cc —
+// notifications arrive on the GET stream (background reader), not on a
+// per-call response, so per-call scoping is not meaningful here. The SEP-2243
+// routing headers are also a no-op on this transport (legacy SSE predates
+// the SEP). Notifications still reach the session-global callback via the
+// existing path.
+func (t *sseClientTransport) callWithContext(method string, data []byte, _ *CallContext) (*rpcResponse, error) {
+	return t.call(method, data)
 }
 
-func (t *sseClientTransport) call(data []byte) (*rpcResponse, error) {
+func (t *sseClientTransport) call(_ string, data []byte) (*rpcResponse, error) {
 	// Check if the background reader is already dead before doing any work.
 	select {
 	case <-t.done:
@@ -2209,7 +2249,7 @@ func (t *sseClientTransport) call(data []byte) (*rpcResponse, error) {
 	}
 }
 
-func (t *sseClientTransport) notify(data []byte) error {
+func (t *sseClientTransport) notify(_ string, data []byte) error {
 	// Check if the background reader is already dead before POSTing.
 	select {
 	case <-t.done:

--- a/client/client_logging.go
+++ b/client/client_logging.go
@@ -53,17 +53,16 @@ func (t *loggingTransport) connect() error {
 }
 
 // call logs the JSON-RPC method name, latency, and result status.
-func (t *loggingTransport) call(data []byte) (*rpcResponse, error) {
-	return t.callWithContext(data, nil)
+func (t *loggingTransport) call(method string, data []byte) (*rpcResponse, error) {
+	return t.callWithContext(method, data, nil)
 }
 
 // callWithContext delegates to the wrapped transport's per-call context
 // path so events/stream's notify hook reaches Streamable HTTP through
 // the logging wrapper.
-func (t *loggingTransport) callWithContext(data []byte, cc *CallContext) (*rpcResponse, error) {
-	method := ExtractMethodFromJSON(data)
+func (t *loggingTransport) callWithContext(method string, data []byte, cc *CallContext) (*rpcResponse, error) {
 	start := time.Now()
-	resp, err := t.inner.callWithContext(data, cc)
+	resp, err := t.inner.callWithContext(method, data, cc)
 	elapsed := time.Since(start)
 	if err != nil {
 		t.logger.Printf("[mcpkit] → %s error=%v [%s]", method, err, elapsed)
@@ -77,10 +76,9 @@ func (t *loggingTransport) callWithContext(data []byte, cc *CallContext) (*rpcRe
 }
 
 // notify logs the JSON-RPC notification method and any error.
-func (t *loggingTransport) notify(data []byte) error {
-	method := ExtractMethodFromJSON(data)
+func (t *loggingTransport) notify(method string, data []byte) error {
 	start := time.Now()
-	err := t.inner.notify(data)
+	err := t.inner.notify(method, data)
 	elapsed := time.Since(start)
 	if err != nil {
 		t.logger.Printf("[mcpkit] → %s (notify) error=%v [%s]", method, err, elapsed)

--- a/client/client_reconnect.go
+++ b/client/client_reconnect.go
@@ -105,12 +105,12 @@ func (c *Client) reconnect() error {
 		Method:  "initialize",
 	}
 	initReq.Params, _ = json.Marshal(initializeParams{
-		ProtocolVersion: "2024-11-05",
+		ProtocolVersion: "2025-11-25",
 		Capabilities:    core.ClientCapabilities{},
 		ClientInfo:      c.info,
 	})
 	data, _ := json.Marshal(initReq)
-	resp, err := c.transport.call(data)
+	resp, err := c.transport.call("initialize", data)
 	if err != nil {
 		return err
 	}
@@ -127,7 +127,7 @@ func (c *Client) reconnect() error {
 		Method:  "notifications/initialized",
 	}
 	data, _ = json.Marshal(notifReq)
-	if err := c.transport.notify(data); err != nil {
+	if err := c.transport.notify("notifications/initialized", data); err != nil {
 		return err
 	}
 

--- a/client/headers.go
+++ b/client/headers.go
@@ -3,9 +3,74 @@ package client
 import (
 	"encoding/base64"
 	"fmt"
+	"net/http"
 	"strconv"
 	"strings"
 )
+
+// SEP-2243 standard routing headers. Mirrors the JSON-RPC method (and, for
+// tools/call / prompts/get / resources/read, the params.name or params.uri)
+// onto HTTP headers so proxies and middleware can route requests without
+// parsing the JSON body. See server/header_validation.go for the matching
+// server-side check.
+const (
+	mcpMethodHeader = "Mcp-Method"
+	mcpNameHeader   = "Mcp-Name"
+)
+
+// setSEP2243RoutingHeaders attaches the SEP-2243 standard routing headers to a
+// streamable HTTP request. method is the JSON-RPC method carried in the body
+// and is always mirrored onto Mcp-Method; cc may carry a per-call mcpName
+// (derived centrally in rawCallWithContext for tools/call / prompts/get /
+// resources/read) that is mirrored onto Mcp-Name. Passing nil cc, or a cc
+// without mcpName set, simply skips Mcp-Name — Mcp-Method is unconditional.
+func setSEP2243RoutingHeaders(req *http.Request, method string, cc *CallContext) {
+	if method != "" {
+		req.Header.Set(mcpMethodHeader, method)
+	}
+	if cc != nil && cc.mcpName != "" {
+		req.Header.Set(mcpNameHeader, cc.mcpName)
+	}
+}
+
+// deriveMcpName extracts the SEP-2243 Mcp-Name value from a JSON-RPC params
+// payload for the three methods that carry a routable name/URI in their
+// params: tools/call (params.name), prompts/get (params.name), and
+// resources/read (params.uri). Returns "" for any other method or when the
+// field is missing / non-string — callers should skip emitting Mcp-Name
+// in that case (server-side fail-closed will reject mismatches).
+//
+// params is the Go value the caller passed to Call / rawCallWithContext —
+// typically map[string]any or a concrete struct. Supports both shapes so
+// no caller has to flatten ahead of time.
+func deriveMcpName(method string, params any) string {
+	if params == nil {
+		return ""
+	}
+	switch method {
+	case "tools/call", "prompts/get":
+		return stringField(params, "name")
+	case "resources/read":
+		return stringField(params, "uri")
+	}
+	return ""
+}
+
+// stringField reads a string-typed field from a params value by name. Handles
+// the common map[string]any and map[string]string shapes; struct-typed params
+// are out of scope here (the routing-header helpers only fire for the three
+// SEP-2243 methods, and mcpkit's call sites for those use map shapes).
+func stringField(params any, field string) string {
+	switch p := params.(type) {
+	case map[string]any:
+		if v, ok := p[field].(string); ok {
+			return v
+		}
+	case map[string]string:
+		return p[field]
+	}
+	return ""
+}
 
 
 // SEP-2243 custom-header mirroring for tools/call.

--- a/client/headers_test.go
+++ b/client/headers_test.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"testing"
 )
@@ -292,4 +294,108 @@ func TestValidateMcpParamHeaders_InvalidCases(t *testing.T) {
 			}
 		})
 	}
+}
+
+// SEP-2243 standard routing headers — Mcp-Method / Mcp-Name.
+
+func TestDeriveMcpName(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		method string
+		params any
+		want   string
+	}{
+		{"tools-call-map-any", "tools/call", map[string]any{"name": "echo", "arguments": map[string]any{}}, "echo"},
+		{"prompts-get-map-any", "prompts/get", map[string]any{"name": "summary"}, "summary"},
+		{"resources-read-map-string", "resources/read", map[string]string{"uri": "file:///a.txt"}, "file:///a.txt"},
+		{"resources-read-map-any", "resources/read", map[string]any{"uri": "file:///b.txt"}, "file:///b.txt"},
+		{"tools-list-no-name", "tools/list", map[string]any{}, ""},
+		{"unknown-method", "ping", map[string]any{"name": "ignored"}, ""},
+		{"nil-params", "tools/call", nil, ""},
+		{"name-not-string", "tools/call", map[string]any{"name": 42}, ""},
+		{"empty-name", "tools/call", map[string]any{"name": ""}, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := deriveMcpName(tc.method, tc.params)
+			if got != tc.want {
+				t.Errorf("deriveMcpName(%q, %v) = %q, want %q", tc.method, tc.params, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSetSEP2243RoutingHeaders(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		method     string
+		cc         *CallContext
+		wantMethod string
+		wantName   string
+	}{
+		{"method-only-nil-cc", "tools/list", nil, "tools/list", ""},
+		{"method-and-name", "tools/call", &CallContext{mcpName: "echo"}, "tools/call", "echo"},
+		{"empty-method-skipped", "", &CallContext{mcpName: "echo"}, "", "echo"},
+		{"cc-without-name", "ping", &CallContext{}, "ping", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("POST", "/", nil)
+			setSEP2243RoutingHeaders(req, tc.method, tc.cc)
+			if got := req.Header.Get("Mcp-Method"); got != tc.wantMethod {
+				t.Errorf("Mcp-Method = %q, want %q", got, tc.wantMethod)
+			}
+			if got := req.Header.Get("Mcp-Name"); got != tc.wantName {
+				t.Errorf("Mcp-Name = %q, want %q", got, tc.wantName)
+			}
+		})
+	}
+}
+
+// End-to-end: a streamable POST through the client should land at the server
+// with Mcp-Method (always) and Mcp-Name (when applicable) set. This guards
+// the wire-level contract that SEP-2243 routing middleware depends on.
+func TestStreamableTransportEmitsSEP2243Headers(t *testing.T) {
+	type captured struct {
+		method, mcpMethod, mcpName string
+	}
+	var got captured
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got.method = r.Method
+		got.mcpMethod = r.Header.Get("Mcp-Method")
+		got.mcpName = r.Header.Get("Mcp-Name")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+	}))
+	defer srv.Close()
+
+	t.Run("notify-without-name", func(t *testing.T) {
+		got = captured{}
+		tr := newStreamableClientTransport(srv.URL, nil)
+		data := []byte(`{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}`)
+		if err := tr.notify("notifications/initialized", data); err != nil {
+			t.Fatalf("notify: %v", err)
+		}
+		if got.mcpMethod != "notifications/initialized" {
+			t.Errorf("Mcp-Method = %q, want %q", got.mcpMethod, "notifications/initialized")
+		}
+		if got.mcpName != "" {
+			t.Errorf("Mcp-Name = %q, want empty (notify path never sets Mcp-Name)", got.mcpName)
+		}
+	})
+
+	t.Run("call-with-name-via-cc", func(t *testing.T) {
+		got = captured{}
+		tr := newStreamableClientTransport(srv.URL, nil)
+		data := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo"}}`)
+		cc := &CallContext{mcpName: "echo"}
+		if _, err := tr.callWithContext("tools/call", data, cc); err != nil {
+			t.Fatalf("callWithContext: %v", err)
+		}
+		if got.mcpMethod != "tools/call" {
+			t.Errorf("Mcp-Method = %q, want %q", got.mcpMethod, "tools/call")
+		}
+		if got.mcpName != "echo" {
+			t.Errorf("Mcp-Name = %q, want %q", got.mcpName, "echo")
+		}
+	})
 }

--- a/conformance/UPSTREAM_AUDIT.md
+++ b/conformance/UPSTREAM_AUDIT.md
@@ -14,8 +14,8 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 | Surface | Scenarios | Checks | Pass | Fail | Warn | Info | Skipped | Harness-gap |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|
 | Server | 51 | 135 | 112 | 1 | 7 | 6 | 9 | 0 |
-| Client | 40 | 1128 | 416 | 13 | 4 | 689 | 6 | 1 |
-| **Total** | **91** | **1263** | **528** | **14** | **11** | **695** | **15** | **1** |
+| Client | 40 | 1128 | 422 | 7 | 4 | 689 | 6 | 1 |
+| **Total** | **91** | **1263** | **534** | **8** | **11** | **695** | **15** | **1** |
 
 ## Harness gaps
 
@@ -29,7 +29,6 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 |---|---|---|---|---|
 | `auth/2025-03-26-oauth-endpoint-fallback` | client | partial | 3 fail / 8 info |  |
 | `auth/2025-03-26-oauth-metadata-backcompat` | client | partial | 4 fail / 8 info |  |
-| `initialize` | client | partial | 1 fail / 1 info |  |
 | `request-metadata` | client | harness-gap | — | No `checks.json` written — driver does not handle this scenario |
 | `auth/authorization-server-migration` | client | pass | 26 pass / 44 info |  |
 | `auth/basic-cimd` | client | pass | 14 pass / 1 warn / 24 info |  |
@@ -56,6 +55,7 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 | `auth/token-endpoint-auth-post` | client | pass | 19 pass / 24 info |  |
 | `completion-complete` | server | pass | 1 pass |  |
 | `dns-rebinding-protection` | server | pass | 2 pass |  |
+| `initialize` | client | pass | 1 pass / 1 info |  |
 | `logging-set-level` | server | pass | 1 pass |  |
 | `ping` | server | pass | 1 pass |  |
 | `prompts-get-embedded-resource` | server | pass | 1 pass |  |
@@ -170,7 +170,7 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 
 | Scenario | Surface | Status | Checks | Note |
 |---|---|---|---|---|
-| `http-standard-headers` | client | partial | 5 fail / 6 skip |  |
+| `http-standard-headers` | client | pass | 5 pass / 6 skip |  |
 
 ### [SEP-2322](https://modelcontextprotocol.io/specification/draft/basic/utilities/mrtr) (14 scenarios)
 


### PR DESCRIPTION
## What changes

Two conformance-audit gaps in `make testconf-upstream-audit`, bundled because they overlap on the same files (`client/client.go`, `client/client_reconnect.go`):

- The mcpkit client's `initialize` handshake sent `protocolVersion: 2024-11-05` — older than the latest spec it actually supports. The upstream grader checks the client offers its newest version. Bumped to `2025-11-25` in both `Connect()` and the reconnect path.
- The streamable HTTP transport never emitted the SEP-2243 standard routing headers (`Mcp-Method` always, `Mcp-Name` for `tools/call` / `prompts/get` / `resources/read`). Proxies and middleware that want to route MCP requests without parsing the JSON body had nothing to read.

## Reviewer's guide

Read in this order:

1. [client/client.go](https://github.com/panyam/mcpkit/pull/518/files#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09) — interface signature change (`call` / `callWithContext` / `notify` gain `method string` as first param) + the `mcpName` field on `CallContext` + central derivation in `rawCallWithContext`. The four implementations (coreTransportAdapter, streamableClientTransport, sseClientTransport, loggingTransport) update in lock-step. ProtocolVersion bump is at line 615.
2. [client/headers.go](https://github.com/panyam/mcpkit/pull/518/files#diff-1790c6c752b4269286acedff114b12c15fdd3247231744f63bebfec874352bd7) — `setSEP2243RoutingHeaders` helper + `deriveMcpName` (with a typed `stringField` shim for both `map[string]any` and `map[string]string` params shapes).
3. [client/headers_test.go](https://github.com/panyam/mcpkit/pull/518/files#diff-9b2bf2990f377f8d8d89f72ee702d57a30109c11fc701fab697b2ced14f9a2d1) — table-driven tests for the helper + an end-to-end check that the streamable transport actually emits the headers on a real `httptest.NewServer` round-trip.
4. [client/client_reconnect.go](https://github.com/panyam/mcpkit/pull/518/files#diff-2590812b49336b09a28623c91f155d259cd9ee07dd189e4d723fff83e8974c0c) — version bump + interface-cascade updates.
5. [client/client_logging.go](https://github.com/panyam/mcpkit/pull/518/files#diff-16d0ee16effb6f493eca4b4d009a7b5905f03f797a0806dc9aced3dac709bfb8) — interface-cascade only (drops `ExtractMethodFromJSON` usage in favor of the explicit param).
6. [conformance/UPSTREAM_AUDIT.md](https://github.com/panyam/mcpkit/pull/518/files#diff-bf63f1699e28f43c702f9450df02d9e8ec1dae36200827f929a68513bdb34197) — regenerated audit shows both rows flipped: `initialize` client now passes; `http-standard-headers` client goes from 5 fails to `5 pass / 6 skip`.

## Decision log

- **Pass `method` as an explicit param, not parse JSON inside a helper.** Considered grepping the method out of the serialized body inside the transport (`ExtractMethodFromJSON` already does this for logging). Rejected because the streamable transport then has to know JSON-RPC envelope shape, and the param is already a typed `string` two frames up the stack. Cleaner typing across the interface in exchange for a one-line touch on each caller.
- **Derive `mcpName` centrally in `rawCallWithContext`, not at each caller.** Considered passing `name` as a second interface param or threading it through every `ToolCall` / `Get` wrapper. Rejected because all paths funnel through `rawCallWithContext` already — deriving once there covers `Call`, `CallContext`, MRTR, tasks v1/v2, and tasks v2-handles for free. The cost is a tiny `deriveMcpName(method, params)` switch on three method names.
- **Skip `postResponse` + legacy SSE for now.** Both edge surfaces. Tracked in 517 with the rationale (and the 6 SKIPPED conformance checks that stay SKIPPED until testclient drives resources/* + prompts/*).
- **Hardcode `Mcp-Method` / `Mcp-Name` strings in client package, don't lift to `core/`.** Server already hardcodes them as unexported constants in `server/header_validation.go`. Lifting to `core/` is a separate cleanup; doing it here would expand scope without changing wire behavior.

## Risk / blast radius

- **Affects:** every Streamable HTTP client call (now carries Mcp-Method); every reconnect cycle (now claims 2025-11-25); the `clientTransport` interface (internal, no public-API break — `Client` is the public surface).
- **Tests covering this:** `client/headers_test.go` (table-driven + end-to-end), full `make test` clean, `make test-auth`, `make testconfauth` (all 14 scenarios + baseline still pass).
- **Be paranoid about:** the `rawCallWithContext` cc-allocation logic. The function now lazily allocates a CallContext when it doesn't have one and a SEP-2243 method is detected. Anywhere downstream that assumed `cc == nil` for unparameterized calls now sees a `*CallContext{mcpName: \"...\"}` instead. I audited the three transports — coreTransportAdapter and sseClientTransport both ignore cc; streamableClientTransport only reads `cc.Context` (defaulting to background), `cc.Headers`, and now `cc.mcpName`. No regressions.

## Before / after

`make testconf-upstream-audit` diff (snippet):

```
- | `initialize` | client | fail | ... |
+ | `initialize` | client | pass | 1 pass / 1 info |  |
- | `http-standard-headers` | client | fail | 5 fail / 6 skip |
+ | `http-standard-headers` | client | pass | 5 pass / 6 skip |  |
```

## Out of scope (deliberately deferred)

- Extend SEP-2243 coverage to `postResponse` + legacy SSE + testclient resources/prompts driver → 517 (P2, transport, conformance).
