### PR TITLE
fix(server): enforce SEP-2575 per-request _meta on DRAFT-2026-v1 legacy wire

### DIFF
--- a/server/dispatch.go
+++ b/server/dispatch.go
@@ -132,6 +132,16 @@ type Dispatcher struct {
 	listCacheScope string
 	readTTLMs      *int
 	readCacheScope string
+
+	// allowLegacyOnDraft is an opt-in back-compat escape hatch: when true,
+	// the legacy initialize+session wire is accepted on DRAFT-2026-v1 without
+	// per-request _meta enforcement. Default false — SEP-2575 (Accepted)
+	// removes the initialize handshake on draft and mandates per-request
+	// `params._meta.io.modelcontextprotocol/{protocolVersion,clientInfo,
+	// clientCapabilities}` on every follow-up; missing _meta MUST be
+	// rejected with -32602. Set via WithAllowLegacyOnDraft() for servers
+	// that prefer leniency over strict spec conformance.
+	allowLegacyOnDraft bool
 }
 
 // applyReadCacheControl fills the SEP-2549 ttlMs / cacheScope hints on a
@@ -269,6 +279,7 @@ func (d *Dispatcher) newSession() *Dispatcher {
 		listCacheScope:       d.listCacheScope,
 		readTTLMs:            d.readTTLMs,
 		readCacheScope:       d.readCacheScope,
+		allowLegacyOnDraft:   d.allowLegacyOnDraft,
 	}
 }
 
@@ -343,6 +354,26 @@ func (d *Dispatcher) Dispatch(ctx context.Context, req *core.Request) *core.Resp
 	default:
 		if !d.initialized {
 			return core.NewErrorResponse(id, core.ErrCodeInvalidRequest, "server not initialized")
+		}
+
+		// SEP-2575 (Accepted): on DRAFT-2026-v1, the initialize handshake is
+		// removed; every request MUST carry the per-request _meta envelope
+		// (params._meta.io.modelcontextprotocol/{protocolVersion, clientInfo,
+		// clientCapabilities}). We retain initialize+session as a back-compat
+		// entry point so clients pinned to older versions still negotiate, but
+		// once the negotiated version is DRAFT-2026-v1 every follow-up request
+		// must carry _meta or the server MUST reject with -32602 InvalidParams.
+		// allowLegacyOnDraft (WithAllowLegacyOnDraft) is an opt-in escape
+		// hatch for server authors who want to be forgiving — off by default.
+		if d.negotiatedVersion == core.DraftProtocolVersion2026V1 && !d.allowLegacyOnDraft {
+			if _, err := core.DecodeRequestMeta(req.Params); err != nil {
+				field := "io.modelcontextprotocol/protocolVersion"
+				if mve, ok := err.(*core.MetaValidationError); ok && mve.Field != "_meta" {
+					field = "io.modelcontextprotocol/" + mve.Field
+				}
+				return core.NewErrorResponse(id, core.ErrCodeInvalidParams,
+					"Missing required metadata: "+field)
+			}
 		}
 
 		// Track in-flight request for cancellation support.

--- a/server/header_validation_integration_test.go
+++ b/server/header_validation_integration_test.go
@@ -5,10 +5,44 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	core "github.com/panyam/mcpkit/core"
 )
+
+// testStreamableServerAllowLegacyOnDraft builds a streamable server
+// configured with WithAllowLegacyOnDraft so the SEP-2243 routing-header
+// integration tests can drive the legacy initialize+session wire on
+// DRAFT-2026-v1 without tripping the strict SEP-2575 _meta enforcement.
+// These tests precisely cover the back-compat path the new option
+// preserves; everywhere else the default (strict, off) applies.
+func testStreamableServerAllowLegacyOnDraft() *httptest.Server {
+	srv := NewServer(
+		core.ServerInfo{Name: "test-streamable", Version: "0.1.0"},
+		WithAllowLegacyOnDraft(),
+	)
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "echo",
+			Description: "Echoes the input",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"message": map[string]any{"type": "string"},
+				},
+			},
+		},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+			var args struct {
+				Message string `json:"message"`
+			}
+			req.Bind(&args)
+			return core.TextResult("echo: " + args.Message), nil
+		},
+	)
+	return httptest.NewServer(srv.Handler(WithStreamableHTTP(true), WithSSE(false)))
+}
 
 // initDraftSession bootstraps a Streamable HTTP session that negotiated
 // the DRAFT-2026-v1 protocol version, so subsequent POSTs go through
@@ -76,7 +110,7 @@ func decodeJSONRPCError(t *testing.T, resp *http.Response) *core.Error {
 }
 
 func TestHeaderValidation_DraftSession_RejectsMismatchedMethod(t *testing.T) {
-	ts := testStreamableServer()
+	ts := testStreamableServerAllowLegacyOnDraft()
 	defer ts.Close()
 	sessionID := initDraftSession(t, ts.URL)
 
@@ -95,7 +129,7 @@ func TestHeaderValidation_DraftSession_RejectsMismatchedMethod(t *testing.T) {
 }
 
 func TestHeaderValidation_DraftSession_AcceptsMatchedHeaders(t *testing.T) {
-	ts := testStreamableServer()
+	ts := testStreamableServerAllowLegacyOnDraft()
 	defer ts.Close()
 	sessionID := initDraftSession(t, ts.URL)
 
@@ -134,7 +168,7 @@ func TestHeaderValidation_DatedSession_SkipsValidation(t *testing.T) {
 }
 
 func TestHeaderValidation_DraftSession_MismatchedToolName(t *testing.T) {
-	ts := testStreamableServer()
+	ts := testStreamableServerAllowLegacyOnDraft()
 	defer ts.Close()
 	sessionID := initDraftSession(t, ts.URL)
 

--- a/server/server.go
+++ b/server/server.go
@@ -54,6 +54,7 @@ type serverOptions struct {
 	listCacheScope       string                   // SEP-2549 cacheScope attached to every list response ("" = omit)
 	readTTLMs            *int                     // SEP-2549 resources/read default cache-freshness hint (ms); handler may override per-read
 	readCacheScope       string                   // SEP-2549 resources/read default cacheScope; handler may override per-read
+	allowLegacyOnDraft   bool                     // WithAllowLegacyOnDraft — opt-in SEP-2575 leniency on the legacy wire (off by default; strict per spec)
 }
 
 type httpHandlerEntry struct {
@@ -335,6 +336,24 @@ func WithAllowedRoots(roots ...string) Option {
 	return func(o *serverOptions) { o.allowedRoots = roots }
 }
 
+// WithAllowLegacyOnDraft is an opt-in back-compat escape hatch for the
+// SEP-2575 enforcement on DRAFT-2026-v1. When set, the legacy session
+// wire (initialize + Mcp-Session-Id) is accepted on the draft protocol
+// version without enforcing the per-request _meta envelope on follow-up
+// requests.
+//
+// Default (option NOT set): the dispatcher enforces SEP-2575 strictly —
+// on DRAFT-2026-v1, every post-initialize request MUST carry
+// `params._meta.io.modelcontextprotocol/{protocolVersion, clientInfo,
+// clientCapabilities}`; missing _meta is rejected with -32602.
+//
+// Use this only if you have legacy clients pinned to DRAFT-2026-v1 that
+// haven't migrated to per-request metadata yet. New servers should leave
+// this off so non-conformant clients fail loudly.
+func WithAllowLegacyOnDraft() Option {
+	return func(o *serverOptions) { o.allowLegacyOnDraft = true }
+}
+
 // WithRootsFetchTimeout sets the deadline for server-to-client roots/list
 // requests issued after notifications/roots/list_changed. Default is 30s.
 // Decrease for aggressive fail-fast; increase for slow clients with large
@@ -362,6 +381,7 @@ func NewServer(info core.ServerInfo, opts ...Option) *Server {
 	// clones inherit it via newSession().
 	s.dispatcher.skipSchemaValidation = s.options.skipSchemaValidation
 	s.dispatcher.validateFileInputs = s.options.validateFileInputs
+	s.dispatcher.allowLegacyOnDraft = s.options.allowLegacyOnDraft
 	s.dispatcher.customHandlers = s.options.customHandlers
 	// Wire registry change notifications to Server.Broadcast so that
 	// dynamic adds/removes automatically notify all connected sessions.


### PR DESCRIPTION
## Summary

- On `DRAFT-2026-v1`, every request body MUST carry `params._meta.io.modelcontextprotocol/{protocolVersion, clientInfo, clientCapabilities}` (SEP-2575, status Accepted). Missing _meta MUST be rejected with `-32602`.
- The stateless dispatcher already enforces this via `core.DecodeRequestMeta`. The legacy `server.Dispatcher` did not — it silently accepted legacy `initialize`+`Mcp-Session-Id` traffic against draft, masking the spec gap for clients that hadn't migrated to per-request _meta.
- This PR adds the same `_meta` enforcement on the legacy path when `negotiatedVersion == DRAFT-2026-v1`, plus an opt-in `WithAllowLegacyOnDraft()` escape hatch (default off) for server authors who deliberately want to keep accepting un-migrated legacy clients on the draft version.

## How the gap was reproduced

Driven via the panyam/mcpconformance fork branch `feat/tasks-mrtr-extension` against the mcpkit `examples/tasks-v2` fixture built from this branch:

| Run | Result |
|---|---|
| Lenient mcpkit (main today) | 16/18 tasks-suite checks pass — gap masked |
| Strict mcpkit (this PR, default off) | **7/18 legacy-wire checks fail** with the exact spec error: `MCP error -32602: Missing required metadata: io.modelcontextprotocol/protocolVersion` |
| Strict mcpkit + conformance fix (drop legacy wire on draft) | 9/9 stateless-wire checks pass |

The same -32602 shape is what Randgalt reported on upstream conformance PR 262 on 2026-05-31; this PR makes mcpkit's reference fixture exhibit the same spec-correct behavior.

## Change shape

- `server/dispatch.go` — `Dispatcher.allowLegacyOnDraft bool` (default false), threaded through `newSession()`. Post-initialize dispatch loop now calls `core.DecodeRequestMeta` on every request when `negotiatedVersion == core.DraftProtocolVersion2026V1 && !allowLegacyOnDraft`; on `*core.MetaValidationError` returns `-32602` with message `"Missing required metadata: io.modelcontextprotocol/<field>"`.
- `server/server.go` — new `WithAllowLegacyOnDraft()` `Option`, wired through `serverOptions.allowLegacyOnDraft → dispatcher.allowLegacyOnDraft` at server-construction time.
- `server/header_validation_integration_test.go` — three `TestHeaderValidation_DraftSession_*` tests now use a local `testStreamableServerAllowLegacyOnDraft()` helper. These tests deliberately exercise the legacy-wire-on-draft surface (SEP-2243 routing-header validation is currently draft-only) so they sit on the back-compat path the new option preserves. The dated-session test is unchanged.

## Test plan

- [x] `go test ./...` — clean across `client`, `core`, `server`, `server/stateless`, `testutil`
- [x] Conformance harness (panyam/mcpconformance `feat/tasks-mrtr-extension`) pre-fix run reproduces randgalt's exact `-32602 Missing required metadata: io.modelcontextprotocol/protocolVersion` on 7 tasks-suite checks
- [x] Conformance harness post-fix (with the matching wire-mode change on the fork branch) passes 9/9 stateless-wire scenarios against the strict fixture
- [ ] Reviewer: confirm `WithAllowLegacyOnDraft()` naming / placement vs. existing `WithSchemaValidation(false)` / `WithFileInputValidation()` Option ergonomics