### PR TITLE
fix(ci): pin upstream-conformance with full 40-char SHA so actions/checkout can resolve it

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,9 +93,11 @@ jobs:
         working-directory: mcpkit
         run: |
           # Stamp line shape: "<!-- generated against upstream-conformance@<sha> · protocol <ver> · ... -->"
+          # Requires the full 40-char SHA — actions/checkout@v4 cannot resolve
+          # short SHAs as refs (it tries to fetch them as branch/tag names).
           # The regex restricts capture to hex chars, so a maliciously crafted
           # body cannot inject anything into the `ref:` parameter below.
-          SHA="$(sed -n 's/.*upstream-conformance@\([a-f0-9]\{4,\}\).*/\1/p' CONFORMANCE.md | head -1)"
+          SHA="$(sed -n 's/.*upstream-conformance@\([a-f0-9]\{40\}\).*/\1/p' CONFORMANCE.md | head -1)"
           if [ -z "$SHA" ]; then
             echo "::error::Could not extract upstream-conformance SHA from CONFORMANCE.md stamp line."
             echo "::error::Run 'make refresh-conformance' locally to regenerate the file."

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -28,7 +28,7 @@ Needs Node.js 22+ and a clone of `modelcontextprotocol/conformance` at `../conf-
 ---
 
 <!-- begin:generated -->
-<!-- generated against upstream-conformance@bcfd400 · protocol 2025-11-25 · regenerate via scripts/refresh-conformance.sh -->
+<!-- generated against upstream-conformance@bcfd400c9a53dd133f315c3afafc7961e488a005 · protocol 2025-11-25 · regenerate via scripts/refresh-conformance.sh -->
 
 ## Conformance Summary
 

--- a/scripts/refresh-conformance.sh
+++ b/scripts/refresh-conformance.sh
@@ -92,7 +92,9 @@ echo ""
 echo "=== Installing upstream conformance deps (builds dist/ via prepare) ==="
 (cd "$CONF_DIR" && npm install --silent)
 
-UPSTREAM_SHA="$(cd "$CONF_DIR" && git rev-parse --short HEAD)"
+# Full 40-char SHA — actions/checkout@v4 in the CI freshness gate cannot
+# resolve short SHAs as refs (it tries to fetch them as branch/tag names).
+UPSTREAM_SHA="$(cd "$CONF_DIR" && git rev-parse HEAD)"
 PROTOCOL_VERSION="${REFRESH_PROTOCOL:-2025-11-25}"
 
 echo ""

--- a/tools/conformance-report/test/fixtures/expected.md
+++ b/tools/conformance-report/test/fixtures/expected.md
@@ -1,5 +1,5 @@
 <!-- begin:generated -->
-<!-- generated against upstream-conformance@abc1234 · protocol 2025-11-25 · regenerate via scripts/refresh-conformance.sh -->
+<!-- generated against upstream-conformance@abc1234567890abcdef1234567890abcdef123456 · protocol 2025-11-25 · regenerate via scripts/refresh-conformance.sh -->
 
 ## Conformance Summary
 

--- a/tools/conformance-report/test/render.test.ts
+++ b/tools/conformance-report/test/render.test.ts
@@ -17,7 +17,7 @@ function loadFixtures() {
     scorecard: loadScorecard(join(here, 'scorecard.json')),
     traceability: loadTraceability(join(here, 'traceability.json')),
     knownGaps: loadKnownGaps(join(here, 'known-gaps.yaml')),
-    upstreamSha: 'abc1234',
+    upstreamSha: 'abc1234567890abcdef1234567890abcdef123456',
     protocolVersion: '2025-11-25'
   };
 }


### PR DESCRIPTION
## What changes

The `conformance-report` CI gate has been red for a while. Root cause: `scripts/refresh-conformance.sh` stamps the upstream SHA into `CONFORMANCE.md` via `git rev-parse --short HEAD` (7 chars). The workflow extracts that SHA back out and feeds it to `actions/checkout@v4`'s `ref:`, which cannot resolve short SHAs — it tries to fetch them as branch/tag names (`+refs/heads/bcfd400*:...`) and fails.

Three coordinated changes that ship together so the gate flips green:

1. `scripts/refresh-conformance.sh` — drop `--short` so the stamp gets the full 40-char SHA.
2. `.github/workflows/test.yml` — tighten the SHA-extract regex from `[a-f0-9]{4,}` to `[a-f0-9]{40}` (defense in depth — if someone hand-edits a short SHA back in, the gate fails extraction with the standard "run `make refresh-conformance`" message instead of the cryptic git-fetch failure).
3. `CONFORMANCE.md` — regenerated. Only the stamp line changes (`bcfd400` → `bcfd400c9a53dd133f315c3afafc7961e488a005`).

Plus a fixture update so the renderer test reflects production format.

## Reviewer's guide

Read in this order:

1. [scripts/refresh-conformance.sh](https://github.com/panyam/mcpkit/pull/521/files#diff-3775227d6d2846bfa2da31ff1ede031280bd0cfd0dcd9e74828cc013993aed1c) — one-line fix + comment explaining the constraint. Start here.
2. [.github/workflows/test.yml](https://github.com/panyam/mcpkit/pull/521/files#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88) — regex tighten + updated comment block on the `Extract pinned upstream-conformance SHA` step.
3. [CONFORMANCE.md](https://github.com/panyam/mcpkit/pull/521/files#diff-d647b61d5d64e4801ec167193f4f207eb71d12b4ec92d5f08b2867673481b9de) — single-line diff in the stamp.
4. `tools/conformance-report/test/{render.test.ts,fixtures/expected.md}` — placeholder `abc1234` → `abc1234567890abcdef1234567890abcdef123456` so the unit test exercises a production-shaped SHA.

Skim or skip: nothing — single-purpose infra fix.

## Decision log

- **Fix the producer (script) AND tighten the consumer (workflow regex).** Fixing only the script would leave the workflow accepting short SHAs as valid extractions and then failing with the same cryptic error on the next regression. The regex tighten makes the failure mode loud at the right step.
- **Update the test fixture too.** The renderer accepts any string for `upstreamSha`, so the fixture isn't enforcing the contract — but using a production-shaped placeholder makes the test self-documenting and would catch a future renderer refactor that started validating length.

## Risk / blast radius

- **Affects:** the `conformance-report` CI gate only. No production code, no protocol behavior, no audit-grade changes.
- **Tests covering this:** `tools/conformance-report` unit tests pass; `make check-conformance-stale` locally compares against the committed CONFORMANCE.md (will pass once this PR merges, because the regenerated file then has the full SHA).
- **Be paranoid about:** the CI gate is what will actually verify this fix end-to-end — the workflow re-runs on this PR, and a green check on `conformance-report` is the acceptance signal.
