### PR TITLE
refactor(core): dedupe MarshalJSON ResultType defaulting (closes 488)

### DIFF
--- a/core/mrtr.go
+++ b/core/mrtr.go
@@ -42,6 +42,16 @@ const (
 	ResultTypeInputRequired ResultType = "input_required" // SEP-2322
 )
 
+// defaultResultType assigns want when r points at the zero value. Used by
+// MarshalJSON impls of response types whose ResultType discriminator is
+// mandatory on the wire — callers and struct literals shouldn't have to
+// set the obvious value.
+func defaultResultType(r *ResultType, want ResultType) {
+	if *r == "" {
+		*r = want
+	}
+}
+
 // InputRequest is a single MRTR input request enqueued by a server during
 // tool execution: a method (e.g., "elicitation/create", "sampling/createMessage")
 // plus opaque params encoded per that method's request schema. // SEP-2322
@@ -111,9 +121,7 @@ func (InputRequiredResult) promptResponse() {}
 // discriminator.
 func (r InputRequiredResult) MarshalJSON() ([]byte, error) {
 	type alias InputRequiredResult
-	if r.ResultType == "" {
-		r.ResultType = ResultTypeInputRequired
-	}
+	defaultResultType(&r.ResultType, ResultTypeInputRequired)
 	return json.Marshal(alias(r))
 }
 

--- a/core/mrtr_test.go
+++ b/core/mrtr_test.go
@@ -42,6 +42,23 @@ func TestResultTypeConstants(t *testing.T) {
 	}
 }
 
+func TestDefaultResultType(t *testing.T) {
+	t.Run("empty-gets-default", func(t *testing.T) {
+		var rt ResultType
+		defaultResultType(&rt, ResultTypeComplete)
+		if rt != ResultTypeComplete {
+			t.Errorf("empty → %q, want %q", rt, ResultTypeComplete)
+		}
+	})
+	t.Run("non-empty-preserved", func(t *testing.T) {
+		rt := ResultTypeTask
+		defaultResultType(&rt, ResultTypeComplete)
+		if rt != ResultTypeTask {
+			t.Errorf("preset %q clobbered to %q", ResultTypeTask, rt)
+		}
+	})
+}
+
 // TestInputRequestJSON verifies wire shape: {"method": "...", "params": {...}}
 // with params omitted when nil. Round-trip must preserve raw params bytes.
 func TestInputRequestJSON(t *testing.T) {

--- a/core/task_v2.go
+++ b/core/task_v2.go
@@ -123,9 +123,7 @@ type DetailedTask struct {
 // every call site having to set it. The task lifecycle stays on Status.
 func (d DetailedTask) MarshalJSON() ([]byte, error) {
 	type alias DetailedTask
-	if d.ResultType == "" {
-		d.ResultType = ResultTypeComplete
-	}
+	defaultResultType(&d.ResultType, ResultTypeComplete)
 	return json.Marshal(alias(d))
 }
 
@@ -175,9 +173,7 @@ type UpdateTaskResult struct {
 // without thinking about it.
 func (u UpdateTaskResult) MarshalJSON() ([]byte, error) {
 	type alias UpdateTaskResult
-	if u.ResultType == "" {
-		u.ResultType = ResultTypeComplete
-	}
+	defaultResultType(&u.ResultType, ResultTypeComplete)
 	return json.Marshal(alias(u))
 }
 
@@ -196,8 +192,6 @@ type CancelTaskResult struct {
 // (CancelTaskResult{}) emits the spec-compliant wire shape automatically.
 func (c CancelTaskResult) MarshalJSON() ([]byte, error) {
 	type alias CancelTaskResult
-	if c.ResultType == "" {
-		c.ResultType = ResultTypeComplete
-	}
+	defaultResultType(&c.ResultType, ResultTypeComplete)
 	return json.Marshal(alias(c))
 }

--- a/core/tool.go
+++ b/core/tool.go
@@ -205,9 +205,7 @@ func (GoAsyncResult) toolResponse() {}
 // dispatch sync vs task vs multi-round without inspecting payload shape.
 func (r ToolResult) MarshalJSON() ([]byte, error) {
 	type alias ToolResult
-	if r.ResultType == "" {
-		r.ResultType = ResultTypeComplete
-	}
+	defaultResultType(&r.ResultType, ResultTypeComplete)
 	return json.Marshal(alias(r))
 }
 


### PR DESCRIPTION
## What changes

Five response envelopes in `core/` share an identical `MarshalJSON` shape that differs only in which `ResultType*` constant they default to. Extract a one-line helper next to the `ResultType` constants; each `MarshalJSON` shrinks from a 3-line if-block to a one-line call that expresses intent. Pure refactor — `make test` clean, `make check-conformance-stale` reports `CONFORMANCE.md` is up to date.

Affected impls:

| Type | Default |
|---|---|
| `core.ToolResult` | `ResultTypeComplete` |
| `core.InputRequiredResult` | `ResultTypeInputRequired` |
| `core.DetailedTask` | `ResultTypeComplete` |
| `core.UpdateTaskResult` | `ResultTypeComplete` |
| `core.CancelTaskResult` | `ResultTypeComplete` |

## Reviewer's guide

Read in this order:

1. [core/mrtr.go](https://github.com/panyam/mcpkit/pull/522/files#diff-e35e8e196366177f5fbc1038f83e79bb201533c23472c8df64ad47e213d9becf) — start here. New `defaultResultType` helper next to the `ResultType` constants block, plus the refactored `InputRequiredResult.MarshalJSON`. The doc comment explains why the helper exists (5 callers share the pattern, the field is mandatory on the wire, callers shouldn't have to set the obvious value).
2. [core/tool.go](https://github.com/panyam/mcpkit/pull/522/files#diff-0c4cfc445e145347f6ac8b4edaa2ca030b6512a3a99e6379f5122df3ca014d22) — `ToolResult.MarshalJSON` refactor.
3. [core/task_v2.go](https://github.com/panyam/mcpkit/pull/522/files#diff-3538d827f8d2f0385530a0112d8defa64f901a0827609fe5f730db43ff24049a) — three refactors: `DetailedTask`, `UpdateTaskResult`, `CancelTaskResult`. All identical pattern, all default to `ResultTypeComplete`.
4. [core/mrtr_test.go](https://github.com/panyam/mcpkit/pull/522/files#diff-fe76fd75444e43b8531ce39d310a969c3ba0a13884c8469c9094e0dc013ff1af) — `TestDefaultResultType` (2 sub-tests, ~10 lines) locks the helper's empty-vs-set contract.

Skim or skip: nothing — single-purpose refactor.

## Decision log

- **Helper, not struct embedding.** Per issue 488: a shared base struct would leak on day one because `GoAsyncResult` has no `ResultType` field, and the sealed `toolResponse()` marker already serves as "what unites these." The `type alias` trick in each `MarshalJSON` is per-impl by design — you can't lift the call into a helper without dragging the alias along, so 3 lines is the floor.
- **Place the helper in `mrtr.go` next to the `ResultType` constants** (not in `tool.go` or a new file). Readers learn what `ResultType` is in that block; the defaulting helper belongs with the type it operates on.
- **Add a tiny test for the helper** even though existing marshal tests are the acceptance for the wire shape. The helper now serves 5 callers; a dedicated test locks the contract (empty → defaulted; non-empty → preserved) so a future caller can grep for "what does this do" and find the answer in 10 lines.

## Risk / blast radius

- **Affects:** wire encoding of 5 response types. Behavior is byte-equivalent — same conditional, same defaults, same final marshal call.
- **Tests covering this:** `TestToolResultMarshalAlwaysEmitsArray` (content_cardinality_test.go), `TestInputRequiredResultWireShape` (mrtr_test.go), task v2 marshal tests (task_v2_test.go), `ext/tasks` integration tests for `UpdateTaskResult` / `CancelTaskResult`. All pass.
- **Be paranoid about:** nothing — the diff is mechanical. Each impl swaps `if r.ResultType == "" { r.ResultType = X }` for `defaultResultType(&r.ResultType, X)`. No behavior change is possible without breaking the helper's contract, which is tested.
