### PR TITLE
feat(testclient): drive request-metadata + resources/prompts coverage (closes 453, advances 517)

### DIFF
--- a/cmd/testclient/main.go
+++ b/cmd/testclient/main.go
@@ -54,6 +54,20 @@ func main() {
 		return
 	}
 
+	// SEP-2575 request-metadata scenario — the upstream fixture is a bare
+	// HTTP server (not an MCP server: no initialize, but it DOES handle
+	// server/discover so a stateless-wire client connects cleanly). Drive
+	// it through driveRequestMetadata, which exercises the per-request
+	// _meta envelope + MCP-Protocol-Version header checks the scenario
+	// grades.
+	if scenario == "request-metadata" {
+		if err := driveRequestMetadata(serverURL); err != nil {
+			log.Fatalf("request-metadata: %v", err)
+		}
+		log.Println("SUCCESS: request-metadata driven")
+		return
+	}
+
 	var ctx conformanceContext
 	if contextJSON != "" {
 		json.Unmarshal([]byte(contextJSON), &ctx)
@@ -95,6 +109,7 @@ func main() {
 					log.Printf("tools/call %q: %v (may be expected)", toolName, err)
 				}
 			}
+			driveStandardHeadersCoverage(noAuthClient)
 			noAuthClient.Close()
 			log.Println("SUCCESS: connected without auth")
 			return
@@ -159,9 +174,33 @@ func main() {
 				log.Printf("tools/call %q: ok", toolName)
 			}
 		}
+		driveStandardHeadersCoverage(c)
 	}
 
 	log.Println("SUCCESS: auth flow complete")
+}
+
+// driveStandardHeadersCoverage exercises resources/* and prompts/* on a
+// connected client so the SEP-2243 http-standard-headers scenario's
+// `ClientMcp{Method,Name}Header_{resources,prompts}_*` checks observe the
+// routing headers on the wire (otherwise they stay SKIPPED). Errors are
+// non-fatal — most non-SEP-2243 scenario mocks return generic responses
+// to these methods and the test goal is header emission, not response
+// fidelity. Safe to call against any connected client; it's a few extra
+// POSTs per scenario run, which is cheap relative to the audit value.
+func driveStandardHeadersCoverage(c *client.Client) {
+	if _, err := c.Call("resources/list", map[string]any{}); err != nil {
+		log.Printf("resources/list: %v (non-fatal — coverage)", err)
+	}
+	if _, err := c.Call("resources/read", map[string]any{"uri": "test://coverage"}); err != nil {
+		log.Printf("resources/read: %v (non-fatal — coverage)", err)
+	}
+	if _, err := c.Call("prompts/list", map[string]any{}); err != nil {
+		log.Printf("prompts/list: %v (non-fatal — coverage)", err)
+	}
+	if _, err := c.Call("prompts/get", map[string]any{"name": "coverage"}); err != nil {
+		log.Printf("prompts/get: %v (non-fatal — coverage)", err)
+	}
 }
 
 // conformanceElicitationHandler returns an accept-with-empty-content

--- a/cmd/testclient/request_metadata.go
+++ b/cmd/testclient/request_metadata.go
@@ -1,0 +1,55 @@
+package main
+
+// SEP-2575 request-metadata driver for the upstream `request-metadata`
+// scenario.
+//
+// The scenario's mock server is a bare HTTP server — no MCP initialize
+// handshake — but it DOES handle `server/discover` (returning a
+// DRAFT-2026-v1 supported version), which means a stateless-wire mcpkit
+// client connects cleanly. After connect, every subsequent POST carries
+// the SEP-2575 `_meta` envelope (protocolVersion, clientInfo,
+// clientCapabilities) and the `MCP-Protocol-Version` header — exactly
+// what the scenario grades:
+//
+//   - sep-2575-http-client-sends-version-header
+//   - sep-2575-client-populates-meta
+//   - sep-2575-http-version-header-matches-meta
+//   - sep-2575-client-declares-{roots,sampling,elicitation}-capability
+//   - sep-2575-client-retry-supported-version (WARNING — client doesn't
+//     yet retry on -32001; tracked separately)
+//
+// We use `ClientModeStateless` rather than `Adaptive` so the test
+// fails fast if the server somehow declined stateless — the scenario
+// has no meaning on the legacy wire, and falling back silently would
+// mask the audit row.
+
+import (
+	"github.com/panyam/mcpkit/client"
+	"github.com/panyam/mcpkit/core"
+)
+
+func driveRequestMetadata(serverURL string) error {
+	c := client.NewClient(serverURL,
+		core.ClientInfo{Name: "mcpkit-testclient", Version: "0.1.0"},
+		client.WithClientMode(client.ClientModeStateless),
+		client.WithElicitationHandler(conformanceElicitationHandler),
+	)
+	if err := c.Connect(); err != nil {
+		return err
+	}
+	defer c.Close()
+
+	// One follow-up POST after Connect is enough — the scenario's checks
+	// are per-request and all emit on the first non-discover call. We
+	// pick tools/list because the mock server returns a generic
+	// {tools: []} response for it; tools/call would also work.
+	if _, err := c.ListTools(); err != nil {
+		// Non-fatal — the scenario's first response is a synthetic 400
+		// with `Unsupported protocol version` to grade the retry path,
+		// which mcpkit's client doesn't yet implement (tracked as a
+		// follow-up). The first request still fires the version-header
+		// + _meta checks, which is what we care about here.
+		_ = err
+	}
+	return nil
+}

--- a/conformance/UPSTREAM_AUDIT.md
+++ b/conformance/UPSTREAM_AUDIT.md
@@ -14,45 +14,44 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 | Surface | Scenarios | Checks | Pass | Fail | Warn | Info | Skipped | Harness-gap |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|
 | Server | 51 | 135 | 112 | 1 | 7 | 6 | 9 | 0 |
-| Client | 40 | 1128 | 422 | 7 | 4 | 689 | 6 | 1 |
-| **Total** | **91** | **1263** | **534** | **8** | **11** | **695** | **15** | **1** |
+| Client | 40 | 1395 | 512 | 7 | 5 | 869 | 2 | 0 |
+| **Total** | **91** | **1530** | **624** | **8** | **12** | **875** | **11** | **0** |
 
 ## Harness gaps
 
-- `request-metadata` (client)
+_None — every scenario produced results._
 
 ## By SEP
 
-### Core / Unattributed (54 scenarios)
+### Core / Unattributed (53 scenarios)
 
 | Scenario | Surface | Status | Checks | Note |
 |---|---|---|---|---|
 | `auth/2025-03-26-oauth-endpoint-fallback` | client | partial | 3 fail / 8 info |  |
 | `auth/2025-03-26-oauth-metadata-backcompat` | client | partial | 4 fail / 8 info |  |
-| `request-metadata` | client | harness-gap | — | No `checks.json` written — driver does not handle this scenario |
-| `auth/authorization-server-migration` | client | pass | 26 pass / 44 info |  |
-| `auth/basic-cimd` | client | pass | 14 pass / 1 warn / 24 info |  |
+| `auth/authorization-server-migration` | client | pass | 30 pass / 52 info |  |
+| `auth/basic-cimd` | client | pass | 18 pass / 1 warn / 32 info |  |
 | `auth/iss-normalized` | client | pass | 8 pass / 12 info |  |
-| `auth/iss-not-advertised` | client | pass | 15 pass / 24 info |  |
-| `auth/iss-supported` | client | pass | 15 pass / 24 info |  |
+| `auth/iss-not-advertised` | client | pass | 19 pass / 32 info |  |
+| `auth/iss-supported` | client | pass | 19 pass / 32 info |  |
 | `auth/iss-supported-missing` | client | pass | 8 pass / 12 info |  |
 | `auth/iss-unexpected` | client | pass | 8 pass / 12 info |  |
 | `auth/iss-wrong-issuer` | client | pass | 8 pass / 12 info |  |
-| `auth/metadata-default` | client | pass | 14 pass / 24 info |  |
+| `auth/metadata-default` | client | pass | 18 pass / 32 info |  |
 | `auth/metadata-issuer-mismatch` | client | pass | 3 pass / 8 info |  |
-| `auth/metadata-var1` | client | pass | 14 pass / 26 info |  |
-| `auth/metadata-var2` | client | pass | 14 pass / 26 info |  |
-| `auth/metadata-var3` | client | pass | 14 pass / 26 info |  |
-| `auth/pre-registration` | client | pass | 15 pass / 28 info |  |
+| `auth/metadata-var1` | client | pass | 18 pass / 34 info |  |
+| `auth/metadata-var2` | client | pass | 18 pass / 34 info |  |
+| `auth/metadata-var3` | client | pass | 18 pass / 34 info |  |
+| `auth/pre-registration` | client | pass | 19 pass / 36 info |  |
 | `auth/resource-mismatch` | client | pass | 2 pass / 6 info |  |
-| `auth/scope-from-scopes-supported` | client | pass | 15 pass / 24 info |  |
-| `auth/scope-from-www-authenticate` | client | pass | 15 pass / 24 info |  |
-| `auth/scope-omitted-when-undefined` | client | pass | 15 pass / 24 info |  |
+| `auth/scope-from-scopes-supported` | client | pass | 19 pass / 32 info |  |
+| `auth/scope-from-www-authenticate` | client | pass | 19 pass / 32 info |  |
+| `auth/scope-omitted-when-undefined` | client | pass | 19 pass / 32 info |  |
 | `auth/scope-retry-limit` | client | pass | 17 pass / 36 info |  |
 | `auth/scope-step-up` | client | pass | 19 pass / 2 warn / 34 info |  |
-| `auth/token-endpoint-auth-basic` | client | pass | 19 pass / 24 info |  |
-| `auth/token-endpoint-auth-none` | client | pass | 19 pass / 24 info |  |
-| `auth/token-endpoint-auth-post` | client | pass | 19 pass / 24 info |  |
+| `auth/token-endpoint-auth-basic` | client | pass | 23 pass / 32 info |  |
+| `auth/token-endpoint-auth-none` | client | pass | 23 pass / 32 info |  |
+| `auth/token-endpoint-auth-post` | client | pass | 23 pass / 32 info |  |
 | `completion-complete` | server | pass | 1 pass |  |
 | `dns-rebinding-protection` | server | pass | 2 pass |  |
 | `initialize` | client | pass | 1 pass / 1 info |  |
@@ -70,7 +69,7 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 | `resources-templates-read` | server | pass | 1 pass |  |
 | `resources-unsubscribe` | server | pass | 1 pass |  |
 | `server-initialize` | server | pass | 2 pass |  |
-| `tools_call` | client | pass | 1 pass / 10 info |  |
+| `tools_call` | client | pass | 1 pass / 18 info |  |
 | `tools-call-audio` | server | pass | 1 pass |  |
 | `tools-call-elicitation` | server | pass | 1 pass |  |
 | `tools-call-embedded-resource` | server | pass | 1 pass |  |
@@ -92,21 +91,21 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 
 | Scenario | Surface | Status | Checks | Note |
 |---|---|---|---|---|
-| `auth/enterprise-managed-authorization` | client | pass | 9 pass / 20 info |  |
+| `auth/enterprise-managed-authorization` | client | pass | 13 pass / 28 info |  |
 
 ### [SEP-1034](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1034) (2 scenarios)
 
 | Scenario | Surface | Status | Checks | Note |
 |---|---|---|---|---|
-| `elicitation-sep1034-client-defaults` | client | pass | 5 pass / 12 info |  |
+| `elicitation-sep1034-client-defaults` | client | pass | 5 pass / 20 info |  |
 | `elicitation-sep1034-defaults` | server | pass | 5 pass |  |
 
 ### [SEP-1046-CLIENT-CREDENTIALS](https://github.com/modelcontextprotocol/ext-auth/blob/main/specification/draft/oauth-client-credentials.mdx) (2 scenarios)
 
 | Scenario | Surface | Status | Checks | Note |
 |---|---|---|---|---|
-| `auth/client-credentials-basic` | client | pass | 10 pass / 26 info |  |
-| `auth/client-credentials-jwt` | client | pass | 8 pass / 20 info |  |
+| `auth/client-credentials-basic` | client | pass | 14 pass / 34 info |  |
+| `auth/client-credentials-jwt` | client | pass | 12 pass / 28 info |  |
 
 ### [SEP-1330](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1330) (1 scenarios)
 
@@ -126,7 +125,7 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 |---|---|---|---|---|
 | `server-sse-multiple-streams` | server | pass | 2 pass |  |
 | `server-sse-polling` | server | pass | 3 warn / 6 info |  |
-| `sse-retry` | client | pass | 3 pass / 13 info |  |
+| `sse-retry` | client | pass | 3 pass / 17 info |  |
 
 ### [SEP-2106](https://modelcontextprotocol.io/seps/2106-json-schema-2020-12#security-implications) (1 scenarios)
 
@@ -144,8 +143,8 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 
 | Scenario | Surface | Status | Checks | Note |
 |---|---|---|---|---|
-| `auth/offline-access-not-supported` | client | pass | 15 pass / 24 info |  |
-| `auth/offline-access-scope` | client | pass | 14 pass / 1 warn / 25 info |  |
+| `auth/offline-access-not-supported` | client | pass | 19 pass / 32 info |  |
+| `auth/offline-access-scope` | client | pass | 18 pass / 1 warn / 33 info |  |
 
 ### [SEP-2243-CUSTOM-HEADERS](https://modelcontextprotocol.io/specification/draft/basic/transports#server-behavior-for-custom-headers) (2 scenarios)
 
@@ -170,7 +169,7 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 
 | Scenario | Surface | Status | Checks | Note |
 |---|---|---|---|---|
-| `http-standard-headers` | client | pass | 5 pass / 6 skip |  |
+| `http-standard-headers` | client | pass | 11 pass |  |
 
 ### [SEP-2322](https://modelcontextprotocol.io/specification/draft/basic/utilities/mrtr) (14 scenarios)
 
@@ -203,11 +202,12 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 |---|---|---|---|---|
 | `caching` | server | pass | 7 pass |  |
 
-### [SEP-2575](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2575) (1 scenarios)
+### [SEP-2575](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2575) (2 scenarios)
 
 | Scenario | Surface | Status | Checks | Note |
 |---|---|---|---|---|
 | `server-stateless` | server | fork-covered | 19 pass / 1 fail / 2 warn / 4 skip | Also graded by `testconf-stateless` |
+| `request-metadata` | client | pass | 4 pass / 1 warn / 2 skip |  |
 
 
 ## Methodology


### PR DESCRIPTION
## What changes

Extends `cmd/testclient` to drive two non-OAuth conformance scenarios that were previously SKIPPED or harness-gap'd, completing the testclient audit-row coverage. Bundled because the two issues share testclient's scenario-dispatch surface (cross-referenced explicitly on issue 453 from the earlier comment thread).

| Audit row | Before | After |
|---|---|---|
| `request-metadata` (client) | `harness-gap` (no checks observed) | `pass — 4 pass / 1 warn / 2 skip` |
| `http-standard-headers` (client) | `pass — 5 pass / 6 skip` | `pass — 11 pass` |

## Reviewer's guide

Read in this order:

1. [cmd/testclient/request_metadata.go](https://github.com/panyam/mcpkit/pull/524/files#diff-9597fe798f935d559061a993334192e720a65c2f28a18df766a4d02d358e7297) — new scenario driver. Start here. Uses `client.WithClientMode(client.ClientModeStateless)` so the mcpkit client skips initialize and uses the SEP-2575 stateless wire from the first request, which is exactly what the upstream scenario grades. The mock server handles `server/discover` (verified in `request-metadata.ts:292-306` upstream) so `Connect()` succeeds; one follow-up `ListTools()` is enough to fire every per-request check.
2. [cmd/testclient/main.go](https://github.com/panyam/mcpkit/pull/524/files#diff-bc7a02b2751e1c671ee37f491a72c42030bf2566f6d0496f30ae2a0ab19ffaae) — two surgical additions:
   - New `case "request-metadata"` dispatch in `main()` after the existing SEP-2322 case (mirrors the same pattern).
   - New `driveStandardHeadersCoverage(c)` helper called in both the no-auth and OAuth success branches. Issues `resources/list`, `resources/read`, `prompts/list`, `prompts/get` against any connected client — purely for header emission, errors non-fatal.
3. [conformance/UPSTREAM_AUDIT.md](https://github.com/panyam/mcpkit/pull/524/files#diff-bf63f1699e28f43c702f9450df02d9e8ec1dae36200827f929a68513bdb34197) — regenerated. Check count goes from 1263 to 1530 because previously-SKIPPED / never-emitted checks now fire and get recorded. Skim the `request-metadata` and `http-standard-headers` rows.

Skim or skip: nothing — single-purpose driver extension.

## Decision log

- **Stateless wire mode for request-metadata, not adaptive.** The scenario tests SEP-2575 per-request `_meta`, which only applies on the stateless wire. Adaptive mode would silently fall back to legacy on the scenario's first 400 response, masking the audit row. Stateless fast-fails if the server somehow declines — correct behavior for a test driver.
- **Unconditional resources/prompts calls in the standard branch, not gated on scenario name.** Cleaner: one helper, no scenario-specific branching. Most mock servers stub these methods with generic responses; non-stubbed servers error and the call is logged non-fatal (same pattern as existing `tools/call` fallback). Costs 4 extra POSTs per scenario run; buys the audit row + serendipitous coverage in future scenarios.
- **Use `c.Call(method, params)` for resources/prompts, not typed wrappers.** `c.ReadResource` / `c.ListPrompts` parse responses and may error on empty/malformed mock returns. The test goal is request emission (header presence on the wire), not response fidelity, so the lower-level `Call` is the right primitive.
- **One bundled PR, not two.** Issues 453 and 517 share `cmd/testclient` as the implementation surface; bundling avoids two diffs touching `main.go` in slightly different ways. The cross-reference comment thread on issue 453 / issue 517 documented this rationale at filing time.

## Risk / blast radius

- **Affects:** `cmd/testclient` only. Not shipped to users, not imported by anything else. Conformance suite is the consumer.
- **Tests covering this:** `make -C conformance testconf-upstream-audit` shows both rows flipped (regenerated `UPSTREAM_AUDIT.md` is committed). `make -C conformance testconfauth` still passes (212 pass, 1 expected baseline failure). `make test` clean.
- **Be paranoid about:** the new resources/prompts calls in the OAuth branch hit every auth scenario's mock server. Most scenarios stub these methods; one that doesn't would error each call but `log.Printf(...non-fatal — coverage)` keeps the scenario alive. Verified: all 14 auth scenarios still pass.

## Before / after

```diff
- | `request-metadata` | client | harness-gap | — | No `checks.json` written — driver does not handle this scenario |
+ | `request-metadata` | client | pass | 4 pass / 1 warn / 2 skip |  |

- | `http-standard-headers` | client | pass | 5 pass / 6 skip |  |
+ | `http-standard-headers` | client | pass | 11 pass |  |
```

## Out of scope (deliberately deferred)

- **Client retry on -32001 unsupported protocol version** → filed as issue 523 (P2). The request-metadata WARNING row depends on this; mcpkit's client doesn't yet downgrade-and-retry on -32001. Per SEP-2575 it's a client SHOULD, not MUST — gap documented, fix tracked separately.
- **`postResponse` + legacy SSE Mcp-Method coverage** (also tracked in issue 517) — same issue, separate scope. This PR closes the testclient-coverage portion of 517; the transport-side bits remain open.
