### PR TITLE
feat(client): retry on -32001/-32004 unsupported protocol version (closes 523)

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -428,6 +428,17 @@ type Client struct {
 	// via server/discover); false when this connection is on the legacy
 	// session wire. Once set it does not change for this Client's lifetime.
 	useStatelessWire bool
+
+	// negotiatedVersion is the protocol version this client emits in the
+	// SEP-2575 _meta envelope and the MCP-Protocol-Version HTTP header on
+	// every stateless-wire request. Initialized to
+	// core.DraftProtocolVersion2026V1 in NewClient and updated when a
+	// server rejects a request with -32001/-32004 + data.supported and
+	// the intersection with [core.SupportedStatelessVersions] yields a
+	// usable downgrade. Guarded by negotiatedVersionMu — reads happen on
+	// every request, writes only on retry, so RWMutex is the right shape.
+	negotiatedVersion   string
+	negotiatedVersionMu sync.RWMutex
 }
 
 // NewClient creates a new MCP client targeting the given server URL.
@@ -440,7 +451,8 @@ func NewClient(url string, info core.ClientInfo, opts ...ClientOption) *Client {
 		nextID: 1,
 		// SEP-2575 wire mode seeded from env/default; WithClientMode
 		// option (if passed) clobbers via the loop below.
-		mode: ResolveClientMode(),
+		mode:              ResolveClientMode(),
+		negotiatedVersion: core.DraftProtocolVersion2026V1,
 	}
 	for _, opt := range opts {
 		opt(c)
@@ -1429,32 +1441,45 @@ func (c *Client) rawCallWithContext(method string, params any, cc *CallContext) 
 		}
 	}
 
-	// SEP-2575 stateless wire: every outgoing call carries the _meta
-	// envelope (protocolVersion, clientInfo, clientCapabilities).
-	// No-op when c.useStatelessWire is false — legacy callers see
-	// the same params they passed in.
-	params = c.wrapParamsForStatelessWire(params)
+	resp, err := c.doRawCall(method, params, cc)
+	if err != nil && c.maxRetries > 0 && IsTransientError(err) {
+		return c.retryWithReconnect(func() (*rpcResponse, error) {
+			return c.doRawCall(method, params, cc)
+		})
+	}
+	// SEP-2575 §protocol-version-header: on -32001/-32004 + data.supported,
+	// downgrade the negotiated version (so subsequent requests stop hitting
+	// the same rejection) and retry this call once with a fresh _meta envelope
+	// + MCP-Protocol-Version header. Bounded to one attempt — if the retry
+	// also fails, return the second response as-is.
+	if retry, picked := isUnsupportedVersionError(resp); retry {
+		if c.logger != nil {
+			c.logger.Printf("[mcpkit] server rejected protocolVersion=%q; downgrading to %q and retrying",
+				c.getNegotiatedVersion(), picked)
+		}
+		c.setNegotiatedVersion(picked)
+		return c.doRawCall(method, params, cc)
+	}
+	return resp, err
+}
 
+// doRawCall is the inner stateless-wrap + marshal + transport-call slice
+// shared between rawCallWithContext's first attempt, its transient-error
+// retry loop, and its SEP-2575 version-downgrade retry. Each call rebuilds
+// params (so the _meta envelope picks up any negotiated-version update)
+// and mints a fresh JSON-RPC id (servers reject reused ids).
+func (c *Client) doRawCall(method string, params any, cc *CallContext) (*rpcResponse, error) {
+	wrapped := c.wrapParamsForStatelessWire(params)
 	req := core.Request{
 		JSONRPC: "2.0",
 		ID:      marshalID(c.nextRequestID()),
 		Method:  method,
 	}
-	if params != nil {
-		req.Params, _ = json.Marshal(params)
+	if wrapped != nil {
+		req.Params, _ = json.Marshal(wrapped)
 	}
 	data, _ := json.Marshal(req)
-
-	resp, err := c.transport.callWithContext(method, data, cc)
-	if err != nil && c.maxRetries > 0 && IsTransientError(err) {
-		return c.retryWithReconnect(func() (*rpcResponse, error) {
-			// Re-build with new ID (old may have been consumed)
-			req.ID = marshalID(c.nextRequestID())
-			data, _ = json.Marshal(req)
-			return c.transport.callWithContext(method, data, cc)
-		})
-	}
-	return resp, err
+	return c.transport.callWithContext(method, data, cc)
 }
 
 // marshalID converts an integer request ID to json.RawMessage.
@@ -1681,9 +1706,11 @@ func (t *streamableClientTransport) callWithContext(method string, data []byte, 
 		}
 		// SEP-2575: clients on the stateless wire MUST send the
 		// protocol version on every request so the server can
-		// cross-check it against the _meta envelope.
+		// cross-check it against the _meta envelope. The version
+		// tracks Client.negotiatedVersion so retry-with-downgrade
+		// flows through here automatically.
 		if t.client != nil && t.client.useStatelessWire {
-			req.Header.Set(core.HTTPProtocolVersionHeader, core.DraftProtocolVersion2026V1)
+			req.Header.Set(core.HTTPProtocolVersionHeader, t.client.getNegotiatedVersion())
 		}
 		// SEP-2243 standard routing headers: mirror the JSON-RPC method
 		// and (when set by callers like ToolCall / ResourceRead /

--- a/client/stateless.go
+++ b/client/stateless.go
@@ -98,13 +98,33 @@ type discoverResult struct {
 // across both wires.
 func (c *Client) buildRequestMeta() map[string]any {
 	return map[string]any{
-		core.MetaKeyProtocolVersion: core.DraftProtocolVersion2026V1,
+		core.MetaKeyProtocolVersion: c.getNegotiatedVersion(),
 		core.MetaKeyClientInfo: map[string]any{
 			"name":    c.info.Name,
 			"version": c.info.Version,
 		},
 		core.MetaKeyClientCapabilities: c.computeClientCapabilities(),
 	}
+}
+
+// getNegotiatedVersion returns the protocol version the client emits on
+// the SEP-2575 stateless wire. Initialized to DraftProtocolVersion2026V1
+// in NewClient; mutated by setNegotiatedVersion when a server -32001/-32004
+// response triggers a retry-with-downgrade.
+func (c *Client) getNegotiatedVersion() string {
+	c.negotiatedVersionMu.RLock()
+	defer c.negotiatedVersionMu.RUnlock()
+	return c.negotiatedVersion
+}
+
+// setNegotiatedVersion records a new negotiated protocol version. Called
+// from the rawCallWithContext retry path when isUnsupportedVersionError
+// yields a usable downgrade. Subsequent requests on this client emit the
+// new version automatically.
+func (c *Client) setNegotiatedVersion(v string) {
+	c.negotiatedVersionMu.Lock()
+	defer c.negotiatedVersionMu.Unlock()
+	c.negotiatedVersion = v
 }
 
 // computeClientCapabilities returns the ClientCapabilities object the

--- a/client/stateless_test.go
+++ b/client/stateless_test.go
@@ -86,8 +86,9 @@ func TestWrapParamsForStatelessWire_NoOpUnlessStateless(t *testing.T) {
 
 func TestWrapParamsForStatelessWire_AddsEnvelope(t *testing.T) {
 	c := &Client{
-		info:             core.ClientInfo{Name: "t", Version: "1"},
-		useStatelessWire: true,
+		info:              core.ClientInfo{Name: "t", Version: "1"},
+		useStatelessWire:  true,
+		negotiatedVersion: core.DraftProtocolVersion2026V1,
 	}
 	got := c.wrapParamsForStatelessWire(map[string]any{"name": "echo"})
 	m, ok := got.(map[string]any)
@@ -109,8 +110,9 @@ func TestWrapParamsForStatelessWire_AddsEnvelope(t *testing.T) {
 
 func TestWrapParamsForStatelessWire_PreservesCallerMeta(t *testing.T) {
 	c := &Client{
-		info:             core.ClientInfo{Name: "t", Version: "1"},
-		useStatelessWire: true,
+		info:              core.ClientInfo{Name: "t", Version: "1"},
+		useStatelessWire:  true,
+		negotiatedVersion: core.DraftProtocolVersion2026V1,
 	}
 	in := map[string]any{
 		"_meta": map[string]any{

--- a/client/version_negotiate.go
+++ b/client/version_negotiate.go
@@ -1,0 +1,92 @@
+package client
+
+import (
+	"github.com/panyam/mcpkit/core"
+)
+
+// SEP-2575 §protocol-version-header: when a server rejects a request with
+// JSON-RPC error code -32001 / -32004 and returns `data.supported: [...]`,
+// the client SHOULD pick a mutually supported version and retry. This file
+// holds the pure decision helpers; the retry orchestration lives in
+// client.go::rawCallWithContext.
+
+// isUnsupportedVersionError reports whether resp is a server rejection
+// that should trigger version-retry. The signal is the presence of a
+// non-empty `data.supported` string array on a -32001 or -32004 error —
+// both codes appear in the wild (mcpkit's own server uses -32004, the
+// upstream conformance scenario emits -32001), and the semantic
+// discriminator is the supported-list payload, not the code itself.
+// HeaderMismatchData's -32001 responses don't carry `supported`, so
+// the predicate naturally distinguishes them.
+//
+// Returns (true, picked) when the supported list intersects mcpkit's
+// stateless-wire support set and a usable downgrade exists; otherwise
+// (false, "").
+func isUnsupportedVersionError(resp *rpcResponse) (retry bool, picked string) {
+	if resp == nil || resp.Error == nil {
+		return false, ""
+	}
+	if resp.Error.Code != core.ErrCodeHeaderMismatch &&
+		resp.Error.Code != core.ErrCodeUnsupportedProtocolVersion {
+		return false, ""
+	}
+	supported, ok := extractSupportedList(resp.Error.Data)
+	if !ok || len(supported) == 0 {
+		return false, ""
+	}
+	picked = pickSupportedVersion(supported, core.SupportedStatelessVersions)
+	return picked != "", picked
+}
+
+// pickSupportedVersion returns the first version in clientSupported that
+// also appears in serverSupported, or "" if the intersection is empty.
+// Ordered by clientSupported so callers control preference (newest-first
+// in mcpkit's case — see core.SupportedStatelessVersions).
+func pickSupportedVersion(serverSupported, clientSupported []string) string {
+	server := make(map[string]struct{}, len(serverSupported))
+	for _, v := range serverSupported {
+		server[v] = struct{}{}
+	}
+	for _, v := range clientSupported {
+		if _, ok := server[v]; ok {
+			return v
+		}
+	}
+	return ""
+}
+
+// extractSupportedList pulls the `supported` field out of an error's
+// structured data payload. Tolerates the two on-wire shapes the field
+// arrives in: map[string]any (raw JSON decode) and []string (typed
+// helpers that pre-parsed). Returns (nil, false) on any other shape.
+func extractSupportedList(data any) ([]string, bool) {
+	switch d := data.(type) {
+	case map[string]any:
+		raw, ok := d["supported"]
+		if !ok {
+			return nil, false
+		}
+		return toStringSlice(raw)
+	case []string:
+		return d, true
+	}
+	return nil, false
+}
+
+func toStringSlice(v any) ([]string, bool) {
+	switch s := v.(type) {
+	case []string:
+		return s, true
+	case []any:
+		out := make([]string, 0, len(s))
+		for _, item := range s {
+			str, ok := item.(string)
+			if !ok {
+				return nil, false
+			}
+			out = append(out, str)
+		}
+		return out, true
+	}
+	return nil, false
+}

--- a/client/version_negotiate_test.go
+++ b/client/version_negotiate_test.go
@@ -1,0 +1,164 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+func TestPickSupportedVersion(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		server           []string
+		client           []string
+		want             string
+	}{
+		{"single-match", []string{"DRAFT-2026-v1"}, []string{"DRAFT-2026-v1"}, "DRAFT-2026-v1"},
+		{"client-preference-newest-first", []string{"2024-11-05", "DRAFT-2026-v1"}, []string{"DRAFT-2026-v1", "2024-11-05"}, "DRAFT-2026-v1"},
+		{"server-only-old", []string{"2024-11-05"}, []string{"DRAFT-2026-v1"}, ""},
+		{"empty-server", []string{}, []string{"DRAFT-2026-v1"}, ""},
+		{"empty-client", []string{"DRAFT-2026-v1"}, []string{}, ""},
+		{"no-overlap", []string{"2025-03-26"}, []string{"DRAFT-2026-v1"}, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := pickSupportedVersion(tc.server, tc.client); got != tc.want {
+				t.Errorf("pick(server=%v, client=%v) = %q, want %q", tc.server, tc.client, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsUnsupportedVersionError(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		resp      *rpcResponse
+		wantRetry bool
+		wantPick  string
+	}{
+		{"nil-resp", nil, false, ""},
+		{"no-error", &rpcResponse{}, false, ""},
+		{
+			"32001-with-supported-draft",
+			&rpcResponse{Error: &core.Error{
+				Code: -32001, Message: "Unsupported protocol version",
+				Data: map[string]any{"supported": []any{"DRAFT-2026-v1"}},
+			}},
+			true, "DRAFT-2026-v1",
+		},
+		{
+			"32004-with-supported-draft",
+			&rpcResponse{Error: &core.Error{
+				Code: -32004, Message: "UnsupportedVersion",
+				Data: map[string]any{"supported": []any{"DRAFT-2026-v1"}},
+			}},
+			true, "DRAFT-2026-v1",
+		},
+		{
+			"32001-header-mismatch-no-supported",
+			&rpcResponse{Error: &core.Error{
+				Code: -32001, Message: "header mismatch",
+				Data: map[string]any{"header": "Mcp-Method", "expected": "tools/list", "received": "tools/call"},
+			}},
+			false, "",
+		},
+		{
+			"32004-supported-no-overlap",
+			&rpcResponse{Error: &core.Error{
+				Code: -32004, Message: "UnsupportedVersion",
+				Data: map[string]any{"supported": []any{"2024-11-05"}},
+			}},
+			false, "",
+		},
+		{
+			"other-error-code-with-supported",
+			&rpcResponse{Error: &core.Error{
+				Code: -32603, Message: "internal error",
+				Data: map[string]any{"supported": []any{"DRAFT-2026-v1"}},
+			}},
+			false, "",
+		},
+		{
+			"typed-string-slice-supported",
+			&rpcResponse{Error: &core.Error{
+				Code: -32004,
+				Data: map[string]any{"supported": []string{"DRAFT-2026-v1"}},
+			}},
+			true, "DRAFT-2026-v1",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gotRetry, gotPick := isUnsupportedVersionError(tc.resp)
+			if gotRetry != tc.wantRetry || gotPick != tc.wantPick {
+				t.Errorf("got (retry=%v, pick=%q), want (retry=%v, pick=%q)",
+					gotRetry, gotPick, tc.wantRetry, tc.wantPick)
+			}
+		})
+	}
+}
+
+// End-to-end retry: a stateless-wire client should retry exactly once
+// when the server returns -32001 + data.supported on the first POST, and
+// observe a SUCCESS on the second. Mirrors the upstream request-metadata
+// conformance scenario's retry probe (closes #523's WARNING).
+func TestRawCallRetryOnUnsupportedVersion(t *testing.T) {
+	var postCount atomic.Int32
+	var firstVersionHeader, secondVersionHeader atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req core.Request
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		count := postCount.Add(1)
+
+		// First request: respond server/discover so Connect() succeeds,
+		// then on the first follow-up call return -32001 + supported list.
+		if req.Method == "server/discover" {
+			firstVersionHeader.Store(r.Header.Get(core.HTTPProtocolVersionHeader))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(fmt.Sprintf(
+				`{"jsonrpc":"2.0","id":%s,"result":{"supportedVersions":["%s"],"capabilities":{},"serverInfo":{"name":"t","version":"1"}}}`,
+				string(req.ID), core.DraftProtocolVersion2026V1)))
+			return
+		}
+
+		if count == 2 {
+			// First non-discover POST: reject with -32001 + supported.
+			firstVersionHeader.Store(r.Header.Get(core.HTTPProtocolVersionHeader))
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(fmt.Sprintf(
+				`{"jsonrpc":"2.0","id":%s,"error":{"code":-32001,"message":"Unsupported protocol version","data":{"supported":["%s"]}}}`,
+				string(req.ID), core.DraftProtocolVersion2026V1)))
+			return
+		}
+
+		// Retry attempt — should succeed.
+		secondVersionHeader.Store(r.Header.Get(core.HTTPProtocolVersionHeader))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(fmt.Sprintf(
+			`{"jsonrpc":"2.0","id":%s,"result":{"tools":[]}}`, string(req.ID))))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, core.ClientInfo{Name: "retry-test", Version: "1"},
+		WithClientMode(ClientModeStateless))
+	if err := c.Connect(); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer c.Close()
+
+	if _, err := c.ListTools(); err != nil {
+		t.Fatalf("ListTools after retry: %v", err)
+	}
+
+	// Discover + first attempt + retry = 3 POSTs.
+	if got := postCount.Load(); got != 3 {
+		t.Errorf("POST count = %d, want 3 (discover + first + retry)", got)
+	}
+	if v, _ := secondVersionHeader.Load().(string); v != core.DraftProtocolVersion2026V1 {
+		t.Errorf("retry MCP-Protocol-Version = %q, want %q", v, core.DraftProtocolVersion2026V1)
+	}
+}

--- a/conformance/UPSTREAM_AUDIT.md
+++ b/conformance/UPSTREAM_AUDIT.md
@@ -14,8 +14,8 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 | Surface | Scenarios | Checks | Pass | Fail | Warn | Info | Skipped | Harness-gap |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|
 | Server | 51 | 135 | 112 | 1 | 7 | 6 | 9 | 0 |
-| Client | 40 | 1395 | 512 | 7 | 5 | 869 | 2 | 0 |
-| **Total** | **91** | **1530** | **624** | **8** | **12** | **875** | **11** | **0** |
+| Client | 40 | 1395 | 513 | 7 | 4 | 869 | 2 | 0 |
+| **Total** | **91** | **1530** | **625** | **8** | **11** | **875** | **11** | **0** |
 
 ## Harness gaps
 
@@ -207,7 +207,7 @@ _None — every scenario produced results._
 | Scenario | Surface | Status | Checks | Note |
 |---|---|---|---|---|
 | `server-stateless` | server | fork-covered | 19 pass / 1 fail / 2 warn / 4 skip | Also graded by `testconf-stateless` |
-| `request-metadata` | client | pass | 4 pass / 1 warn / 2 skip |  |
+| `request-metadata` | client | pass | 5 pass / 2 skip |  |
 
 
 ## Methodology


### PR DESCRIPTION
## What changes

Per SEP-2575 §protocol-version-header: when a stateless-wire server rejects a request with JSON-RPC `-32001` or `-32004` + `data.supported: [<version>, ...]`, the client SHOULD pick a mutually supported version and retry. mcpkit's client now does. Closes the lone WARNING in the `request-metadata` upstream conformance row; legacy wire is unaffected (it negotiates the version once during initialize and isn't subject to per-request rejection).

| Audit row | Before | After |
|---|---|---|
| `request-metadata` (client) | `4 pass / 1 warn / 2 skip` | `5 pass / 2 skip` |

The 2 SKIPPED remain — they're correct (the spec only fires the roots/sampling capability checks if the client declares them; mcpkit's testclient only declares elicitation).

## Reviewer's guide

Read in this order:

1. [client/version_negotiate.go](https://github.com/panyam/mcpkit/pull/525/files#diff-7fc88a6d52c5072f05c684c90ba0bc868ee84b9ebd920a019a7c9bc1ebd52938) — start here. New file. Two helpers: `isUnsupportedVersionError(*rpcResponse) (retry bool, picked string)` (predicate + version pick in one call) and `pickSupportedVersion(server, client []string) string` (ordered intersection, client controls preference order). The predicate accepts either error code (`-32001` or `-32004`) because the upstream scenario emits `-32001` while mcpkit's own server emits `-32004`; the semantic signal is the `data.supported` payload, not the code.
2. [client/version_negotiate_test.go](https://github.com/panyam/mcpkit/pull/525/files#diff-2ebccd27e3ba85d08afce6e2d104df0292f8a2044e1233e3580ff305138624d6) — table-driven for both helpers + an end-to-end `TestRawCallRetryOnUnsupportedVersion` that drives a real `httptest` server through the discover + reject + retry-success round-trip.
3. [client/client.go](https://github.com/panyam/mcpkit/pull/525/files#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09) — `Client.negotiatedVersion` field added (initialized to `DraftProtocolVersion2026V1` in `NewClient`, guarded by `RWMutex`). `rawCallWithContext` extracts a new `doRawCall` helper so the retry path can rebuild the request cleanly (fresh `_meta` with the downgraded version, fresh JSON-RPC id). Retry is bounded to one attempt.
4. [client/stateless.go](https://github.com/panyam/mcpkit/pull/525/files#diff-c095a06bc0f1fa5239aedc79840fd85cdd3dfc10886bcee46b7e6d35eaa978c6) — `buildRequestMeta` reads `c.getNegotiatedVersion()`; new `setNegotiatedVersion` writer. The streamable HTTP transport already reads `c.client.useStatelessWire` to decide whether to emit `MCP-Protocol-Version`; now it also reads `getNegotiatedVersion()` for the value, so a successful retry flows through to every subsequent request.
5. [client/stateless_test.go](https://github.com/panyam/mcpkit/pull/525/files#diff-e38d77a970a17c0ec5721a78e295be3d9fd6e4bf0020a4d45feb8a075f53ce4f) — two pre-existing tests updated to set `negotiatedVersion` on `Client{}` literals (the field is required for `buildRequestMeta` to emit a non-empty protocolVersion; `NewClient` does this automatically, the literal-construction path didn't).
6. [conformance/UPSTREAM_AUDIT.md](https://github.com/panyam/mcpkit/pull/525/files#diff-bf63f1699e28f43c702f9450df02d9e8ec1dae36200827f929a68513bdb34197) — regenerated. Single-line change on the `request-metadata` row.

Skim or skip: nothing — single-purpose feature.

## Decision log

- **Match both `-32001` and `-32004`, gated on `data.supported` shape.** The upstream `request-metadata` conformance scenario emits `-32001` for unsupported version; mcpkit's own server uses `-32004`. Either is in the wild. The presence of `data.supported` as a string array is the actual semantic signal — `HeaderMismatchData` (the other `-32001` user) carries `{reason, header, expected, received, ...}` and won't have a `supported` field, so the predicate naturally distinguishes them. Less brittle than picking one code.
- **Session-wide version mutation, not per-call.** When the retry succeeds, `c.negotiatedVersion` is updated so subsequent requests emit the downgraded version directly. Per-call mutation would cycle the discover-reject-retry on every request, which is wasteful and surprises observers reading the wire.
- **`RWMutex` over `atomic.Value[string]`.** Reads happen on every request (cheap with `RLock`); writes only fire on the rare retry. Reader-heavy workload is exactly what RWMutex is built for. `atomic.Value` would work but `Load/Store` of strings via interface is uglier and trades one cost for another with no real win.
- **Extract `doRawCall` rather than retry-in-place.** The retry path needs `wrapParamsForStatelessWire` to re-run so the rebuilt `_meta` picks up the new version. Inlining that re-wrap in `rawCallWithContext` would duplicate the marshal sequence three times (initial, transient-error retry, version-downgrade retry). Extraction keeps each call site short.
- **Bounded to one retry.** Per-call boolean isn't needed because `doRawCall` itself doesn't retry — the retry orchestration lives in `rawCallWithContext`, which only attempts the version-downgrade path once. A pathologically-misbehaving server that keeps rejecting after the downgrade gets the second response surfaced as-is to the caller.

## Risk / blast radius

- **Affects:** every SEP-2575 stateless-wire client (the `rawCallWithContext` path runs the version-retry check on every response). Legacy wire callers are unaffected — `wrapParamsForStatelessWire` is a no-op there, and the version-retry predicate only fires when a server returns `data.supported` (legacy servers don't).
- **Tests covering this:** `make test` clean (client + core + server + sub-modules), `make test-auth` + `ext/tasks` + `ext/ui` clean, `make -C conformance testconfauth` clean (14 scenarios + baseline), upstream audit regenerated.
- **Be paranoid about:** the `negotiatedVersion` field's concurrent-write semantics. The `RWMutex` protects against torn reads, but two concurrent retries (e.g., two POSTs racing into `rawCallWithContext`) could both see the rejection, both call `setNegotiatedVersion`, and both retry. Both retries land with the same downgraded version, so the duplicate write is idempotent. The retry attempts themselves are independent calls with different JSON-RPC ids — no risk of duplicate-id confusion server-side. No mitigation needed beyond the existing RWMutex.

## Before / after

```
# Before:
SUCCESS  sep-2575-http-client-sends-version-header
SUCCESS  sep-2575-client-populates-meta
SUCCESS  sep-2575-http-version-header-matches-meta
SKIPPED  sep-2575-client-declares-roots-capability
SKIPPED  sep-2575-client-declares-sampling-capability
SUCCESS  sep-2575-client-declares-elicitation-capability
WARNING  sep-2575-client-retry-supported-version

# After:
SUCCESS  sep-2575-client-retry-supported-version
(others unchanged)
```
