### PR TITLE
docs(readme): shields, prominent docs/conformance links, star history

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
-# MCPKit
+# mcpkit
 
 Production-grade MCP (Model Context Protocol) server and client library for Go.
+
+[![Go Reference](https://pkg.go.dev/badge/github.com/panyam/mcpkit.svg)](https://pkg.go.dev/github.com/panyam/mcpkit)
+[![Go Report Card](https://goreportcard.com/badge/github.com/panyam/mcpkit)](https://goreportcard.com/report/github.com/panyam/mcpkit)
+[![CI](https://github.com/panyam/mcpkit/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/panyam/mcpkit/actions/workflows/test.yml)
+[![Conformance](https://img.shields.io/badge/MCP%20conformance-passing-success)](https://panyam.github.io/mcpkit/conformance/)
+[![Docs](https://img.shields.io/badge/docs-panyam.github.io%2Fmcpkit-blue)](https://panyam.github.io/mcpkit/)
+[![License](https://img.shields.io/github/license/panyam/mcpkit)](LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/panyam/mcpkit?style=social)](https://github.com/panyam/mcpkit/stargazers)
+
+**[Docs site](https://panyam.github.io/mcpkit/)** · **[Conformance report](https://panyam.github.io/mcpkit/conformance/)** · **[Capabilities](https://panyam.github.io/mcpkit/capabilities/)** · **[Quick Start](#quick-start)**
 
 ## Quick Start
 
@@ -41,12 +51,12 @@ srv.Run(":8787") // Streamable HTTP
 
 ## Conformance
 
-**30/30** server scenarios, **14/14** auth scenarios, **21** MCP Apps conformance tests passing against the [official MCP conformance suite](https://github.com/modelcontextprotocol/conformance) and internal test suites.
+**30/30** server scenarios, **14/14** auth scenarios, **21** MCP Apps conformance tests passing against the [official MCP conformance suite](https://github.com/modelcontextprotocol/conformance) and internal test suites. The full per-SEP rollup is published at [panyam.github.io/mcpkit/conformance](https://panyam.github.io/mcpkit/conformance/).
 
 Three artifacts describe mcpkit's conformance posture at increasing granularity:
 
-- [`CONFORMANCE.md`](CONFORMANCE.md) — auto-generated per-SEP rollup (regenerated on every PR; CI-gated for staleness).
-- [`conformance/UPSTREAM_AUDIT.md`](conformance/UPSTREAM_AUDIT.md) — per-scenario pass/fail against upstream's full test set (`make testconf-upstream-audit`).
+- [`CONFORMANCE.md`](CONFORMANCE.md) — auto-generated per-SEP rollup (regenerated on every PR; CI-gated for staleness). [Live site](https://panyam.github.io/mcpkit/conformance/).
+- [`conformance/UPSTREAM_AUDIT.md`](conformance/UPSTREAM_AUDIT.md) — per-scenario pass/fail against upstream's full test set (`make testconf-upstream-audit`). [Live site](https://panyam.github.io/mcpkit/conformance/upstream-audit/).
 - [`conformance/AUTH_SPEC_COVERAGE.md`](conformance/AUTH_SPEC_COVERAGE.md) — hand-curated per-clause traceability for the auth surface: every MUST/SHOULD → mcpkit impl file:line → test that proves it.
 
 ## Testing
@@ -109,3 +119,9 @@ For best performance, configure your authorization server to use **ES256 (ECDSA 
 
 - `servicekit` v0.0.22 — SSE hub, graceful shutdown, HTTP error types
 - `oneauth` v0.0.64 — JWT/OIDC (only via `ext/auth` sub-module)
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=panyam/mcpkit&type=Date)](https://star-history.com/#panyam/mcpkit&Date)
+
+If mcpkit is useful to you, starring the repo is the cheapest way to help — it's the main signal we use to prioritize what to ship next.


### PR DESCRIPTION
## What changes

Top-of-README shields (Go reference, Go report card, CI status, conformance, docs, license, stars) plus a one-line nav row pointing at the docs site, conformance report, capabilities page, and the existing Quick Start anchor. The goal is passive discovery — the badges fire the moment someone lands on the repo, so visitors learn what mcpkit is and how thoroughly it conforms without needing a separate announcement.

Bottom of the README gains a Star History section sourced from star-history.com. The Conformance section's three artifacts now also link to their `panyam.github.io/mcpkit` equivalents (issue 508 deployment landed in PR 526).

## Reviewer's guide

1. [README.md](https://github.com/panyam/mcpkit/pull/528/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) — three contiguous edits: header (badges + nav), Conformance section (live-site links added), bottom (Star History block).

## Decision log

- **No emojis in the nav row.** Matches the repo's existing tone.
- **`?style=social` on the stars badge.** Highlights it as the social-proof element vs the technical badges above.
- **`star-history.com` over a custom solution.** Free, no JS, hot-linked image, used by hundreds of OSS projects — same well-trodden path the audience expects.
- **`mcp-conformance=passing` badge text.** Conservative — links to the live conformance page where the actual numbers live, so the badge doesn't drift when the count moves.

## Repo metadata — needs your one-time gh action

I tried to set these via `gh api` but the personal token lacks the `repo` admin scope. These are the biggest passive-discovery lever (topics drive GitHub's search ranking, description appears in the repo card everywhere). Paste either via the repo Settings UI, or with a `gh` token that has `repo` scope:

\`\`\`bash
# Description + homepage
gh api -X PATCH /repos/panyam/mcpkit \\
  -f description='Production-grade Model Context Protocol (MCP) server and client library for Go. OAuth/PRM authentication, MCP Apps, Tasks v2, SEP-2575 stateless wire, full upstream conformance.' \\
  -f homepage='https://panyam.github.io/mcpkit/'

# Topics (drives GitHub search relevance)
gh api -X PUT /repos/panyam/mcpkit/topics \\
  -F 'names[]=mcp' \\
  -F 'names[]=model-context-protocol' \\
  -F 'names[]=mcp-server' \\
  -F 'names[]=mcp-client' \\
  -F 'names[]=mcp-conformance' \\
  -F 'names[]=golang' \\
  -F 'names[]=go' \\
  -F 'names[]=llm' \\
  -F 'names[]=ai-agents' \\
  -F 'names[]=oauth' \\
  -F 'names[]=anthropic' \\
  -F 'names[]=claude'
\`\`\`

Adjust the topic list to taste — GitHub allows up to 20 per repo.

## Risk

Minimal. Image hot-links go through shields.io / star-history.com / pkg.go.dev — all well-established services that GitHub renders by default. If any one of them goes down the rendered README degrades gracefully (broken-image icons) but no functional impact.

## Out of scope (passive-discovery follow-ups worth filing separately)

- Submit to community lists: [awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers), [awesome-go](https://github.com/avelino/awesome-go).
- A GitHub social preview image (Settings → Social preview) — also a passive-discovery lever; needs a designed PNG.
- An OpenGraph card on the docs site itself so link previews on Discord/Twitter render with a title + description (currently they render as bare URLs).
