### PR TITLE
feat(conformance-report): hover tooltips + per-SEP exclusion detail

### DIFF
--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -41,20 +41,424 @@ Needs Node.js 22+ and a clone of `modelcontextprotocol/conformance` at `../conf-
 
 | SEP | Tested reqs | Excluded | Untested | Status |
 |---|---:|---:|---:|---|
-| [SEP-837](https://modelcontextprotocol.io/specification/draft/basic/authorization#application-type-and-redirect-uri-constraints) | 1 | 4 | 0 | **pass** |
-| [SEP-2106](https://modelcontextprotocol.io/seps/2106-json-schema-2020-12#security-implications) | 1 | 4 | 0 | **pass** |
-| [SEP-2164](https://modelcontextprotocol.io/specification/draft/server/resources#error-handling) | 2 | 1 | 0 | **pass** |
-| [SEP-2207](https://modelcontextprotocol.io/specification/draft/basic/authorization#refresh-tokens) | 1 | 3 | 0 | **pass** |
-| [SEP-2243](https://modelcontextprotocol.io/specification/draft/basic/transports#standard-mcp-request-headers) | 18 | 4 | 2 | partial |
-| [SEP-2260](https://modelcontextprotocol.io/specification/draft/basic/transports#streamable-http) | 0 | 12 | 0 | _untested_ |
-| [SEP-2322](https://modelcontextprotocol.io/specification/draft/basic/utilities/mrtr) | 17 | 16 | 0 | **pass** |
-| [SEP-2350](https://modelcontextprotocol.io/specification/draft/basic/authorization#runtime-insufficient-scope-errors) | 1 | 2 | 0 | **pass** |
-| [SEP-2352](https://modelcontextprotocol.io/specification/draft/basic/authorization#authorization-server-binding) | 3 | 3 | 0 | **pass** |
-| [SEP-2468](https://modelcontextprotocol.io/specification/draft/basic/authorization#authorization-response-validation) | 6 | 3 | 0 | **pass** |
-| [SEP-2549](https://modelcontextprotocol.io/specification/draft/server/utilities/caching) | 7 | 13 | 0 | **pass** |
-| [SEP-2575](https://modelcontextprotocol.io/specification/draft/basic/lifecycle) | 22 | 13 | 0 | **pass** |
+| [SEP-837](https://modelcontextprotocol.io/specification/draft/basic/authorization#application-type-and-redirect-uri-constraints) | [1](#sep-837-tested "Tested: sep-837-application-type-present.") | [4](#sep-837-excluded "2x harness cannot determine the client-under-test application c; 1x robustness requirement with no defined wire-level success cr; 1x UI/DX behavior, not protocol-observable") | 0 | **pass** |
+| [SEP-2106](https://modelcontextprotocol.io/seps/2106-json-schema-2020-12#security-implications) | [1](#sep-2106-tested "Tested: sep-2106-no-network-ref-deref.") | [4](#sep-2106-excluded "1x Migration/deprecation guidance for SDK maintainers; about SD; 1x Restates pre-existing schema-validation behavior and is too ; 1x Applies only when the non-default opt-in network-$ref fetch ; 1x Internal validator resource limits (max schema depth, subsch") | 0 | **pass** |
+| [SEP-2164](https://modelcontextprotocol.io/specification/draft/server/resources#error-handling) | [2](#sep-2164-tested "Tested: sep-2164-no-empty-contents, sep-2164-error-code.") | [1](#sep-2164-excluded "1x Client-side error handling is implementation-defined; not pr") | 0 | **pass** |
+| [SEP-2207](https://modelcontextprotocol.io/specification/draft/basic/authorization#refresh-tokens) | [1](#sep-2207-tested "Tested: sep-2207-client-metadata-grant-types.") | [3](#sep-2207-excluded "1x The server suite does not yet exercise the SDK server as an ; 1x Confidentiality of refresh tokens in storage is client-inter; 1x A client assuming refresh tokens will be issued is mental-") | 0 | **pass** |
+| [SEP-2243](https://modelcontextprotocol.io/specification/draft/basic/transports#standard-mcp-request-headers) | [18](#sep-2243-tested "Tested: sep-2243-client-includes-standard-headers, sep-2243-header-name-case-insensitive, sep-2243-server-reject-invalid-headers, +15 more.") | [4](#sep-2243-excluded "2x Intermediary requirement; conformance harness tests clients ; 1x Log output is not wire-observable.; 1x Design guidance to humans; not protocol-observable.") | [2](#sep-2243-untested "Untested: sep-2243-server-not-expect-null, sep-2243-server-reject-missing-required.") | partial |
+| [SEP-2260](https://modelcontextprotocol.io/specification/draft/basic/transports#streamable-http) | 0 | [12](#sep-2260-excluded "10x No longer needed this behavior is enabled by default SEP-232; 1x Semantic association (relate to) is not protocol-observabl; 1x Implementation preference for keepalive mechanism choice; no") | 0 | _untested_ |
+| [SEP-2322](https://modelcontextprotocol.io/specification/draft/basic/utilities/mrtr) | [17](#sep-2322-tested "Tested: sep-2322-result-type-included, sep-2322-default-result-type-complete, sep-2322-not-on-unsupported-requests, +14 more.") | [16](#sep-2322-excluded "8x Tasks moved to an extension as of SEP-2663; no longer part o; 1x inputRequests is a JSON object; duplicate keys are collapsed; 1x Architectural migration statement; tested indirectly through; 1x Internal security posture; not observable at protocol level; 1x Internal implementation choice about encryption/signing; not; 1x Internal requestState format; not observable at protocol lev; 1x Internal enforcement policy; conformance harness cannot dete; 1x Server-internal robustness assumption; not observable at pro; 1x Duplicates integrity-protection requirements above; internal") | 0 | **pass** |
+| [SEP-2350](https://modelcontextprotocol.io/specification/draft/basic/authorization#runtime-insufficient-scope-errors) | [1](#sep-2350-tested "Tested: sep-2350-scope-union-on-reauth.") | [2](#sep-2350-excluded "1x All scopes required for the current operation has no harne; 1x reword of pre-existing requirement (request->operation, +RFC") | 0 | **pass** |
+| [SEP-2352](https://modelcontextprotocol.io/specification/draft/basic/authorization#authorization-server-binding) | [3](#sep-2352-tested "Tested: sep-2352-no-cross-as-credential-reuse, sep-2352-no-reuse-on-as-change, sep-2352-reregister-on-as-change.") | [3](#sep-2352-excluded "1x internal storage requirement; not directly observable on the; 1x internal state-keying requirement; not protocol-observable; 1x UI behavior; the negative half (do not send mismatched crede") | 0 | **pass** |
+| [SEP-2468](https://modelcontextprotocol.io/specification/draft/basic/authorization#authorization-response-validation) | [6](#sep-2468-tested "Tested: sep-2468-client-validate-metadata-issuer, sep-2468-client-compare-iss-supported, sep-2468-client-reject-missing-iss, +3 more.") | [3](#sep-2468-excluded "1x Targets the authorization server under test; observing iss i; 1x Conditional on the AS actually including iss in an authoriza; 1x display is UI-facing; act-on has no protocol-observable sign") | 0 | **pass** |
+| [SEP-2549](https://modelcontextprotocol.io/specification/draft/server/utilities/caching) | [7](#sep-2549-tested "Tested: sep-2549-tools-list-caching-hints, sep-2549-prompts-list-caching-hints, sep-2549-resources-list-caching-hints, +4 more.") | [13](#sep-2549-excluded "9x Client-side caching behavior; not observable at the protocol; 1x Client-side polling behavior; not observable at the protocol; 1x Client/cache-side behavior; not observable at the protocol l; 1x Server-side awareness requirement; implementation guidance n; 1x Server-side access control; implementation guidance not test") | 0 | **pass** |
+| [SEP-2575](https://modelcontextprotocol.io/specification/draft/basic/lifecycle) | [22](#sep-2575-tested "Tested: sep-2575-client-populates-meta, sep-2575-server-rejects-undeclared-capability, sep-2575-missing-capability-http-400, +19 more.") | [13](#sep-2575-excluded "6x stdio client harness not implemented — see https://github.co; 1x internal server state, not directly wire-observable; the obs; 1x not observable from a black-box harness; every harness reque; 1x treated as cancellation is internal server state; once the; 1x stop work as soon as practical is unobservable from a blac; 1x architectural guidance, observable only via subscriptionId/t; 1x client-internal demux; not observable on the wire from the h; 1x internal comparison; gracefully has no wire-observable def") | 0 | **pass** |
 
-_Status reflects upstream-declared requirements only. Scenario→SEP attribution is not exposed in tier-check JSON today; this column tracks "does upstream have a check ID for this SEP requirement", not "does mcpkit pass it". Per-SEP scenario pass/fail lives in `conformance/UPSTREAM_AUDIT.md`._
+_Numeric cells link to per-SEP detail below; hover/long-press surfaces a one-line summary. Status reflects upstream-declared requirements only — Scenario→SEP attribution is not exposed in tier-check JSON today; this column tracks "does upstream have a check ID for this SEP requirement", not "does mcpkit pass it". Per-SEP scenario pass/fail lives in `conformance/UPSTREAM_AUDIT.md`._
+
+## SEP Detail
+
+Per-SEP breakdown of upstream traceability — what is exercised, what is intentionally excluded, and what is declared but not yet exercised. Useful for auditing whether each exclusion still makes sense as upstream evolves. Check IDs link to their definition in the upstream SEP YAML.
+
+### SEP-837
+
+<a id="sep-837-tested"></a>
+
+**Tested (1)**
+
+- [`sep-837-application-type-present`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-837.yaml)
+
+<a id="sep-837-excluded"></a>
+
+**Excluded (4)**
+
+| Requirement | Upstream reason |
+|---|---|
+| Native applications (desktop applications, mobile apps, CLI tools, and locally-hosted web applications accessed via localhost) SHOULD use application_type: "native". | harness cannot determine the client-under-test application class (native vs web) out-of-band; only presence and value validity are wire-observable |
+| Web applications (remote browser-based applications served from a non-local host) SHOULD use application_type: "web". | harness cannot determine the client-under-test application class (native vs web) out-of-band; only presence and value validity are wire-observable |
+| MCP clients MUST be prepared to handle registration failures due to redirect URI constraints when authorization servers implement OIDC. | robustness requirement with no defined wire-level success criterion |
+| When a registration request is rejected, clients SHOULD surface a meaningful error to the user or developer. | UI/DX behavior, not protocol-observable |
+
+<a id="sep-837-untested"></a>
+
+**Untested (0)**
+
+_None._
+
+### SEP-2106
+
+<a id="sep-2106-tested"></a>
+
+**Tested (1)**
+
+- [`sep-2106-no-network-ref-deref`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2106.yaml)
+
+<a id="sep-2106-excluded"></a>
+
+**Excluded (4)**
+
+| Requirement | Upstream reason |
+|---|---|
+| SDK maintainers SHOULD: Document the migration in SDK release notes; Where ergonomic, provide typed helpers (e.g. generics over a tool's `outputSchema`) so consumers do not need to write narrowing guards by hand | Migration/deprecation guidance for SDK maintainers; about SDK source code, not protocol-observable wire behavior |
+| JSON Schema validation already handles type checking, value constraints, and required field validation, and implementations MUST continue to validate all inputs and outputs against declared schemas | Restates pre-existing schema-validation behavior and is too broad to attribute to a specific observable SEP-2106 check; input/output validation overlaps existing tool scenarios |
+| An opt-in mode that fetches non-local `$ref`s SHOULD enforce an allowlist of hosts (or at minimum reject loopback, link-local, and private network addresses), apply timeouts and size limits, and log dereferenced URIs | Applies only when the non-default opt-in network-$ref fetch mode is enabled; not observable in default conformance runs |
+| Implementations SHOULD apply reasonable bounds — for example, a maximum schema depth, a cap on the total number of subschemas, or a per-validation time budget — to prevent a malicious tool definition from acting as a CPU DoS vector against the validator | Internal validator resource limits (max schema depth, subschema cap, per-validation time budget); a defensive measure not observable on the wire |
+
+<a id="sep-2106-untested"></a>
+
+**Untested (0)**
+
+_None._
+
+### SEP-2164
+
+<a id="sep-2164-tested"></a>
+
+**Tested (2)**
+
+- [`sep-2164-no-empty-contents`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2164.yaml)
+- [`sep-2164-error-code`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2164.yaml)
+
+<a id="sep-2164-excluded"></a>
+
+**Excluded (1)**
+
+| Requirement | Upstream reason |
+|---|---|
+| clients SHOULD also accept -32002 as a resource not found error | Client-side error handling is implementation-defined; not protocol-observable |
+
+<a id="sep-2164-untested"></a>
+
+**Untested (0)**
+
+_None._
+
+### SEP-2207
+
+<a id="sep-2207-tested"></a>
+
+**Tested (1)**
+
+- [`sep-2207-client-metadata-grant-types`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2207.yaml)
+
+<a id="sep-2207-excluded"></a>
+
+**Excluded (3)**
+
+| Requirement | Upstream reason |
+|---|---|
+| MCP Servers (Protected Resources) SHOULD NOT include `offline_access` in `WWW-Authenticate` scope or Protected Resource Metadata `scopes_supported`, as refresh tokens are not a resource requirement | The server suite does not yet exercise the SDK server as an OAuth protected resource (no Protected Resource Metadata or WWW-Authenticate probing); revisit once server-side authorization scenarios exist (https://github.com/modelcontextprotocol/conformance/issues/116) |
+| MCP Clients that desire refresh tokens MUST keep refresh tokens confidential in transit and storage as specified in OAuth 2.1 Section 4.3 | Confidentiality of refresh tokens in storage is client-internal state, and in-transit (TLS) confidentiality is not exercised by the harness over localhost HTTP; not protocol-observable |
+| MCP Clients that desire refresh tokens MUST NOT assume refresh tokens will be issued; the AS retains discretion | A client "assuming" refresh tokens will be issued is mental-state; only manifests as general authorization-flow completion, which other checks already cover; not directly protocol-observable |
+
+<a id="sep-2207-untested"></a>
+
+**Untested (0)**
+
+_None._
+
+### SEP-2243
+
+<a id="sep-2243-tested"></a>
+
+**Tested (18)**
+
+- [`sep-2243-client-includes-standard-headers`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2243.yaml)
+- [`sep-2243-header-name-case-insensitive`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2243.yaml)
+- [`sep-2243-server-reject-invalid-headers`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2243.yaml)
+- [`sep-2243-server-reject-error-code`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2243.yaml)
+- [`sep-2243-client-supports-custom-headers`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2243.yaml)
+- [`sep-2243-client-mirrors-designated-params`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2243.yaml)
+- [`sep-2243-x-mcp-header-not-empty`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2243.yaml)
+- [`sep-2243-x-mcp-header-charset`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2243.yaml)
+- [`sep-2243-x-mcp-header-unique`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2243.yaml)
+- [`sep-2243-x-mcp-header-primitive-only`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2243.yaml)
+- [`sep-2243-client-reject-invalid-tool`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2243.yaml)
+- [`sep-2243-client-encode-values`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2243.yaml)
+- [`sep-2243-client-base64-unsafe`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2243.yaml)
+- [`sep-2243-server-decode-base64`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2243.yaml)
+- [`sep-2243-client-omit-null`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2243.yaml)
+- [`sep-2243-server-reject-invalid-param-chars`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2243.yaml)
+- [`sep-2243-server-validate-param-match`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2243.yaml)
+- [`sep-2243-server-reject-param-mismatch`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2243.yaml)
+
+<a id="sep-2243-excluded"></a>
+
+**Excluded (4)**
+
+| Requirement | Upstream reason |
+|---|---|
+| Clients SHOULD log a warning when rejecting a tool definition due to invalid x-mcp-header, including the tool name and the reason. | Log output is not wire-observable. |
+| Server developers SHOULD NOT mark sensitive parameters (such as passwords, API keys, tokens, or PII) with x-mcp-header. | Design guidance to humans; not protocol-observable. |
+| Intermediaries MUST return an appropriate HTTP error status for validation failures. | Intermediary requirement; conformance harness tests clients and servers, not intermediaries. |
+| Intermediate servers that do not recognize an Mcp-Param-{Name} header MUST forward it and otherwise ignore it. | Intermediary requirement; conformance harness tests clients and servers, not intermediaries. |
+
+<a id="sep-2243-untested"></a>
+
+**Untested (2)**
+
+- [`sep-2243-server-not-expect-null`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2243.yaml) — Parameter value is null or omitted: Server MUST NOT expect the header.
+- [`sep-2243-server-reject-missing-required`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2243.yaml) — Required parameter is omitted: Server MUST reject with JSON-RPC error.
+
+### SEP-2260
+
+<a id="sep-2260-tested"></a>
+
+**Tested (0)**
+
+_None._
+
+<a id="sep-2260-excluded"></a>
+
+**Excluded (12)**
+
+| Requirement | Upstream reason |
+|---|---|
+| roots/list, sampling/createMessage, and elicitation/create requests MUST NOT be sent on standalone streams. | No longer needed this behavior is enabled by default SEP-2322 MRTR. |
+| Clients MUST return standard JSON-RPC errors for common failure cases: Server sends an elicitation/create request with no associated client-to-server request: -32602 (Invalid params) | No longer needed this behavior is enabled by default SEP-2322 MRTR. |
+| Clients SHOULD return standard JSON-RPC errors for common failure cases: Server sends a roots/list request with no associated client-to-server request: -32602 (Invalid params) | No longer needed this behavior is enabled by default SEP-2322 MRTR. |
+| Clients SHOULD return errors for common failure cases: Sampling request not associated with a client-to-server request: -32602 (Invalid params) | No longer needed this behavior is enabled by default SEP-2322 MRTR. |
+| These messages MUST relate to the originating client request. | Semantic association ("relate to") is not protocol-observable. The harness cannot determine whether a server request conceptually relates to the client request without understanding application logic. |
+| Implementations SHOULD prefer transport-level SSE keepalive mechanisms for idle-connection maintenance. | Implementation preference for keepalive mechanism choice; not observable on the wire. |
+| Servers MUST send server-to-client requests (such as roots/list, sampling/createMessage, or elicitation/create) only in association with an originating client request (e.g., during tools/call, resources/read, or prompts/get processing). | No longer needed this behavior is enabled by default SEP-2322 MRTR. |
+| Standalone server-initiated requests of these types on independent communication streams (unrelated to any client request) are not supported and MUST NOT be implemented. | No longer needed this behavior is enabled by default SEP-2322 MRTR. |
+| Servers MUST send sampling/createMessage requests only in association with an originating client request (e.g., during tools/call, resources/read, or prompts/get processing). | No longer needed this behavior is enabled by default SEP-2322 MRTR. |
+| Standalone server-initiated sampling on independent communication streams (unrelated to any client request) is not supported and MUST NOT be implemented. | No longer needed this behavior is enabled by default SEP-2322 MRTR. |
+| Servers MUST send server-to-client requests (such as roots/list, sampling/createMessage, or elicitation/create) only in association with an originating client request (e.g., during tools/call, resources/read, or prompts/get processing). | No longer needed this behavior is enabled by default SEP-2322 MRTR. |
+| Standalone server-initiated requests of these types on independent communication streams (unrelated to any client request) are not supported and MUST NOT be implemented. | No longer needed this behavior is enabled by default SEP-2322 MRTR. |
+
+<a id="sep-2260-untested"></a>
+
+**Untested (0)**
+
+_None._
+
+### SEP-2322
+
+<a id="sep-2322-tested"></a>
+
+**Tested (17)**
+
+- [`sep-2322-result-type-included`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2322.yaml)
+- [`sep-2322-default-result-type-complete`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2322.yaml)
+- [`sep-2322-not-on-unsupported-requests`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2322.yaml)
+- [`sep-2322-elicitation-incomplete`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2322.yaml)
+- [`sep-2322-sampling-incomplete`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2322.yaml)
+- [`sep-2322-list-roots-incomplete`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2322.yaml)
+- [`sep-2322-reject-tampered-state`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2322.yaml)
+- [`sep-2322-request-state-incomplete`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2322.yaml)
+- [`sep-2322-respect-client-capabilities`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2322.yaml)
+- [`sep-2322-client-request-state-echoed`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2322.yaml)
+- [`sep-2322-client-no-state-omitted`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2322.yaml)
+- [`sep-2322-client-jsonrpc-id-different`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2322.yaml)
+- [`sep-2322-client-parallel-isolation`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2322.yaml)
+- [`sep-2322-validate-input-responses`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2322.yaml)
+- [`sep-2322-error-on-protocol-error`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2322.yaml)
+- [`sep-2322-ignore-unexpected-params`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2322.yaml)
+- [`sep-2322-missing-response-rerequests`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2322.yaml)
+
+<a id="sep-2322-excluded"></a>
+
+**Excluded (16)**
+
+| Requirement | Upstream reason |
+|---|---|
+| inputRequests keys are server assigned identifiers and MUST be unique within the scope of the request. | inputRequests is a JSON object; duplicate keys are collapsed by JSON parsing before the harness can observe them, so key uniqueness is not testable at the protocol level |
+| Servers MUST send server-to-client requests (such as roots/list, sampling/createMessage, or elicitation/create) using the MRTR pattern. | Architectural migration statement; tested indirectly through all MRTR scenarios |
+| servers MUST treat requestState as an attacker-controlled input | Internal security posture; not observable at protocol level |
+| servers MUST protect its integrity (e.g. HMAC or AEAD) | Internal implementation choice about encryption/signing; not observable at protocol level |
+| servers SHOULD include the authenticated principal, a short expiry (TTL), and an identifier for the originating request inside the integrity-protected requestState payload and verify each on receipt | Internal requestState format; not observable at protocol level |
+| Servers for which a given requestState must be consumed at most once MUST enforce that invariant server-side | Internal enforcement policy; conformance harness cannot determine which servers require single-use semantics |
+| Servers MUST NOT assume that clients will fulfill the inputRequests or retry the original request | Server-internal robustness assumption; not observable at protocol level |
+| Servers MUST validate request state as described in the server requirements above. | Duplicates integrity-protection requirements above; internal security detail |
+| Servers MUST include an inputRequests field in the tasks/result response when the task is in status input_required. | Tasks moved to an extension as of SEP-2663; no longer part of core conformance |
+| inputRequests keys are server assigned identifiers and MUST be unique within the scope of a Task. | Tasks moved to an extension as of SEP-2663; no longer part of core conformance |
+| When tasks/get shows status input_required, clients MUST call tasks/result to get the inputRequests and optional requestState. | Tasks moved to an extension as of SEP-2663; no longer part of core conformance |
+| Clients SHOULD construct the results of those requests and call tasks/input_response with the inputResponses & requestState (if present). | Tasks moved to an extension as of SEP-2663; no longer part of core conformance |
+| Receivers MUST reject tasks/input_response requests for tasks that are not in input_required status with error code -32602 (Invalid params). | Tasks moved to an extension as of SEP-2663; no longer part of core conformance |
+| When a receiver receives a tasks/result request for a task in working status, it MUST block the response until the task reaches a terminal status or input_required status. | Tasks moved to an extension as of SEP-2663; no longer part of core conformance |
+| When a receiver receives a tasks/result request for a task in input_required status, it MUST return an InputRequiredResult containing the inputRequests that the requestor must fulfill. | Tasks moved to an extension as of SEP-2663; no longer part of core conformance |
+| After sending tasks/input_response, the requestor SHOULD resume polling via tasks/get. | Tasks moved to an extension as of SEP-2663; no longer part of core conformance |
+
+<a id="sep-2322-untested"></a>
+
+**Untested (0)**
+
+_None._
+
+### SEP-2350
+
+<a id="sep-2350-tested"></a>
+
+**Tested (1)**
+
+- [`sep-2350-scope-union-on-reauth`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2350.yaml)
+
+<a id="sep-2350-excluded"></a>
+
+**Excluded (2)**
+
+| Requirement | Upstream reason |
+|---|---|
+| Regardless of the approach chosen, servers SHOULD include all scopes required for the current operation in a single challenge. | "All scopes required for the current operation" has no harness-observable ground truth; the challenge is the only place the server declares its requirements. Detecting the negative (incremental challenging) would need server-side auth scenarios that do not exist yet and would test the example app's scope config rather than SDK behavior; the spec also permits dynamic per-request scope determination, so a second challenge is not conclusively non-conformant. |
+| When responding with insufficient scope errors, servers SHOULD include the scopes needed to satisfy the current operation in the scope parameter, consistent with RFC 6750 Section 3.1. | reword of pre-existing requirement (request->operation, +RFC6750 cite); no normative delta; harness already emits scope= in WWW-Authenticate |
+
+<a id="sep-2350-untested"></a>
+
+**Untested (0)**
+
+_None._
+
+### SEP-2352
+
+<a id="sep-2352-tested"></a>
+
+**Tested (3)**
+
+- [`sep-2352-no-cross-as-credential-reuse`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2352.yaml)
+- [`sep-2352-no-reuse-on-as-change`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2352.yaml)
+- [`sep-2352-reregister-on-as-change`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2352.yaml)
+
+<a id="sep-2352-excluded"></a>
+
+**Excluded (3)**
+
+| Requirement | Upstream reason |
+|---|---|
+| Clients MUST maintain separate registration state (client credentials, tokens) per authorization server. | internal storage requirement; not directly observable on the wire |
+| Clients that use pre-registered credentials, or persist client credentials obtained via Dynamic Client Registration, MUST associate those credentials with the specific authorization server that issued them, keyed by the authorization server issuer identifier. | internal state-keying requirement; not protocol-observable |
+| If the authorization server indicated by protected resource metadata no longer matches the one the credentials were registered with, clients SHOULD surface an error rather than silently attempting to use mismatched credentials. | UI behavior; the negative half (do not send mismatched credentials) is covered by sep-2352-no-reuse-on-as-change |
+
+<a id="sep-2352-untested"></a>
+
+**Untested (0)**
+
+_None._
+
+### SEP-2468
+
+<a id="sep-2468-tested"></a>
+
+**Tested (6)**
+
+- [`sep-2468-client-validate-metadata-issuer`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2468.yaml)
+- [`sep-2468-client-compare-iss-supported`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2468.yaml)
+- [`sep-2468-client-reject-missing-iss`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2468.yaml)
+- [`sep-2468-client-compare-iss-unadvertised`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2468.yaml)
+- [`sep-2468-client-proceed-no-iss`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2468.yaml)
+- [`sep-2468-client-no-normalization`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2468.yaml)
+
+<a id="sep-2468-excluded"></a>
+
+**Excluded (3)**
+
+| Requirement | Upstream reason |
+|---|---|
+| MCP authorization servers SHOULD include the iss parameter in authorization responses, including error responses, as defined in RFC9207 Section 2. | Targets the authorization server under test; observing iss in an authorization response requires driving an Authorization Code Grant against the AS, which the authorization-server suite does not implement yet (it only probes the metadata endpoint). (https://github.com/modelcontextprotocol/conformance/issues/208) |
+| Authorization servers that include the iss parameter MUST advertise this by setting authorization_response_iss_parameter_supported to true in their metadata (RFC9207 Section 2.3). | Conditional on the AS actually including iss in an authorization response, which requires driving an Authorization Code Grant against the AS under test; the authorization-server suite does not implement that yet. (https://github.com/modelcontextprotocol/conformance/issues/208) |
+| This validation applies equally to error responses - on mismatch the client MUST NOT act on or display error, error_description, or error_uri. | display is UI-facing; act-on has no protocol-observable signal beyond the existing reject-on-mismatch checks |
+
+<a id="sep-2468-untested"></a>
+
+**Untested (0)**
+
+_None._
+
+### SEP-2549
+
+<a id="sep-2549-tested"></a>
+
+**Tested (7)**
+
+- [`sep-2549-tools-list-caching-hints`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2549.yaml)
+- [`sep-2549-prompts-list-caching-hints`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2549.yaml)
+- [`sep-2549-resources-list-caching-hints`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2549.yaml)
+- [`sep-2549-resources-templates-list-caching-hints`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2549.yaml)
+- [`sep-2549-resources-read-caching-hints`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2549.yaml)
+- [`sep-2549-ttl-non-negative`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2549.yaml)
+- [`sep-2549-cache-scope-valid`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2549.yaml)
+
+<a id="sep-2549-excluded"></a>
+
+**Excluded (13)**
+
+| Requirement | Upstream reason |
+|---|---|
+| If ttlMs is 0, the response SHOULD be considered immediately stale. | Client-side caching behavior; not observable at the protocol level |
+| If ttlMs is positive, the client SHOULD consider the result fresh for that many milliseconds after receiving the response. | Client-side caching behavior; not observable at the protocol level |
+| If ttlMs is absent, clients SHOULD assume a default of 0 (immediately stale) and rely on their own caching heuristics or notifications. | Client-side caching behavior; not observable at the protocol level |
+| If ttlMs is negative, clients SHOULD ignore it and treat it as 0. | Client-side caching behavior; not observable at the protocol level |
+| Once the TTL expires, the response is stale and the client SHOULD re-fetch on next access. | Client-side caching behavior; not observable at the protocol level |
+| Clients SHOULD NOT treat TTL as a polling interval that triggers automatic background refetches. | Client-side caching behavior; not observable at the protocol level |
+| Implementations that do choose to poll MUST apply jitter and backoff. | Client-side polling behavior; not observable at the protocol level |
+| Cached responses MAY be reused for the same authorization context. Caches MUST NOT be shared across authorization contexts (e.g. a different access token requires a different cache). | Client/cache-side behavior; not observable at the protocol level |
+| When a cached page expires, the client SHOULD re-fetch that page using its cursor. | Client-side caching behavior; not observable at the protocol level |
+| Clients that require a consistent snapshot of the full list SHOULD re-fetch from the beginning (without a cursor). | Client-side caching behavior; not observable at the protocol level |
+| If a cursor becomes invalid (e.g., the server returns an error for a previously valid cursor), the client SHOULD discard all cached pages and re-fetch from the beginning. | Client-side caching behavior; not observable at the protocol level |
+| Servers MUST be aware that responses with a "public" cacheScope may be shared between callers even if the Result is coming from an authenticated endpoint. | Server-side awareness requirement; implementation guidance not testable via protocol messages |
+| Server implementors MUST apply appropriate per-primitive access controls, and MUST NOT rely on cacheScope alone to prevent unauthorized access to primitives. | Server-side access control; implementation guidance not testable via protocol messages |
+
+<a id="sep-2549-untested"></a>
+
+**Untested (0)**
+
+_None._
+
+### SEP-2575
+
+<a id="sep-2575-tested"></a>
+
+**Tested (22)**
+
+- [`sep-2575-client-populates-meta`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2575.yaml)
+- [`sep-2575-server-rejects-undeclared-capability`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2575.yaml)
+- [`sep-2575-missing-capability-http-400`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2575.yaml)
+- [`sep-2575-server-tags-subscription-id`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2575.yaml)
+- [`sep-2575-server-unsupported-version-error`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2575.yaml)
+- [`sep-2575-client-retry-supported-version`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2575.yaml)
+- [`sep-2575-server-implements-discover`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2575.yaml)
+- [`sep-2575-http-server-no-independent-requests-on-stream`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2575.yaml)
+- [`sep-2575-http-client-sends-version-header`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2575.yaml)
+- [`sep-2575-http-version-header-matches-meta`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2575.yaml)
+- [`sep-2575-http-server-header-mismatch-400`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2575.yaml)
+- [`sep-2575-http-server-unsupported-version-400`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2575.yaml)
+- [`sep-2575-http-server-method-not-found-404`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2575.yaml)
+- [`sep-2575-server-honors-notification-filter`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2575.yaml)
+- [`sep-2575-server-sends-subscription-ack`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2575.yaml)
+- [`sep-2575-client-declares-elicitation-capability`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2575.yaml)
+- [`sep-2575-client-declares-roots-capability`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2575.yaml)
+- [`sep-2575-client-declares-sampling-capability`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2575.yaml)
+- [`sep-2575-server-declares-prompts-in-discover`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2575.yaml)
+- [`sep-2575-server-sends-prompts-list-changed-on-subscription`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2575.yaml)
+- [`sep-2575-server-sends-tools-list-changed-on-subscription`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2575.yaml)
+- [`sep-2575-server-no-log-without-loglevel`](https://github.com/modelcontextprotocol/conformance/blob/bcfd400c9a53dd133f315c3afafc7961e488a005/src/seps/sep-2575.yaml)
+
+<a id="sep-2575-excluded"></a>
+
+**Excluded (13)**
+
+| Requirement | Upstream reason |
+|---|---|
+| A server MUST NOT treat connection or process identity as a proxy for conversation or session continuity. / Servers MUST NOT rely on prior requests over the same connection to establish context (e.g., capabilities, protocol version, client identity). | internal server state, not directly wire-observable; the observable consequence (rejecting requests with incomplete _meta rather than falling back to remembered state) is covered by sep-2575-request-meta-invalid-* — see https://github.com/modelcontextprotocol/conformance/issues/296 |
+| Servers MUST NOT require that a client reuse the same connection to perform related operations. | not observable from a black-box harness; every harness request already arrives on an independent connection — see https://github.com/modelcontextprotocol/conformance/issues/296 |
+| Closing the SSE response stream MUST be treated by the server as cancellation of that request. | "treated as cancellation" is internal server state; once the stream is closed there is no channel left on which to observe the effect — see https://github.com/modelcontextprotocol/conformance/issues/296 |
+| The server SHOULD stop work on the cancelled request as soon as practical and MUST NOT send any further messages for it [HTTP]. | "stop work as soon as practical" is unobservable from a black-box harness, and "no further messages" cannot be verified once the response stream is closed — see https://github.com/modelcontextprotocol/conformance/issues/296 |
+| State that needs to span multiple requests (e.g., long-running tasks, application-level handles) MUST be referenced by an explicit identifier the client passes on each request. | architectural guidance, observable only via subscriptionId/task-id rows already listed |
+| To distinguish notifications belonging to different concurrent subscriptions, clients MUST correlate notifications using the io.modelcontextprotocol/subscriptionId field carried in _meta. | client-internal demux; not observable on the wire from the harness |
+| The client SHOULD check the acknowledged filter against what it requested and handle any unsupported types gracefully. | internal comparison; "gracefully" has no wire-observable definition |
+| Because there is no per-request status code to drive fallback, a client that supports both eras SHOULD probe with server/discover first [stdio backward compatibility]. | stdio client harness not implemented — see https://github.com/modelcontextprotocol/conformance/issues/258 |
+| To cancel an in-flight request [on stdio], the client MUST send a notifications/cancelled notification referencing the request ID. | stdio client harness not implemented — see https://github.com/modelcontextprotocol/conformance/issues/258 |
+| Servers SHOULD stop work on a cancelled request as soon as practical and MUST NOT send any further messages for it [stdio]. | stdio client harness not implemented — see https://github.com/modelcontextprotocol/conformance/issues/258 |
+| If the server process exits unexpectedly, the client SHOULD restart it. | stdio client harness not implemented — see https://github.com/modelcontextprotocol/conformance/issues/258 |
+| If the server returns UnsupportedProtocolVersionError, [the stdio client] SHOULD retry using one of the advertised supportedVersions rather than falling back to initialize. | stdio client harness not implemented — see https://github.com/modelcontextprotocol/conformance/issues/258 |
+| On stdio, if the connection is terminated and then re-established, the client MUST re-send subscriptions/listen to re-establish its subscriptions. | stdio client harness not implemented — see https://github.com/modelcontextprotocol/conformance/issues/258 |
+
+<a id="sep-2575-untested"></a>
+
+**Untested (0)**
+
+_None._
+
 
 ## Open Gaps
 

--- a/tools/conformance-report/src/render.ts
+++ b/tools/conformance-report/src/render.ts
@@ -37,6 +37,10 @@ export function renderGeneratedBlock(input: RenderInput): string {
   lines.push('');
   lines.push(...renderSepTable(input));
   lines.push('');
+  lines.push('## SEP Detail');
+  lines.push('');
+  lines.push(...renderSepDetail(input));
+  lines.push('');
   lines.push('## Open Gaps');
   lines.push('');
   lines.push(...renderGaps(input));
@@ -145,15 +149,184 @@ function renderSepTable(input: RenderInput): string[] {
         : s.summary.tested === 0
           ? '_untested_'
           : 'partial';
-    lines.push(
-      `| ${label} | ${s.summary.tested} | ${s.summary.excluded} | ${s.summary.untested} | ${status} |`
-    );
+    const tested = numericCell(s.summary.tested, sep, 'tested', summarizeTested(s));
+    const excluded = numericCell(s.summary.excluded, sep, 'excluded', summarizeExcluded(s));
+    const untested = numericCell(s.summary.untested, sep, 'untested', summarizeUntested(s));
+    lines.push(`| ${label} | ${tested} | ${excluded} | ${untested} | ${status} |`);
   }
   lines.push('');
   lines.push(
-    '_Status reflects upstream-declared requirements only. Scenario→SEP attribution is not exposed in tier-check JSON today; this column tracks "does upstream have a check ID for this SEP requirement", not "does mcpkit pass it". Per-SEP scenario pass/fail lives in `conformance/UPSTREAM_AUDIT.md`._'
+    '_Numeric cells link to per-SEP detail below; hover/long-press surfaces a one-line summary. Status reflects upstream-declared requirements only — Scenario→SEP attribution is not exposed in tier-check JSON today; this column tracks "does upstream have a check ID for this SEP requirement", not "does mcpkit pass it". Per-SEP scenario pass/fail lives in `conformance/UPSTREAM_AUDIT.md`._'
   );
   return lines;
+}
+
+// numericCell renders an integer count as either a plain `0` (no anchor when
+// there's nothing to link to) or a clickable markdown link of the form
+// `[N](#sep-NNNN-status "tooltip text")`. On GitHub-flavored markdown this
+// becomes a hover tooltip on desktop and a tap-to-jump anchor on mobile.
+function numericCell(
+  count: number,
+  sep: string,
+  status: 'tested' | 'excluded' | 'untested',
+  tooltip: string
+): string {
+  if (count === 0) return '0';
+  return `[${count}](#sep-${sep}-${status} "${escapeTitle(tooltip)}")`;
+}
+
+// escapeTitle keeps the title attribute parseable as markdown. Double-quotes
+// would close the title; backslashes are escape characters in many markdown
+// parsers. Newlines collapse to spaces in browser tooltip rendering, so we
+// drop them too.
+function escapeTitle(s: string): string {
+  return s.replace(/[\\"]/g, '').replace(/\s+/g, ' ').trim();
+}
+
+// summarizeTested returns a short string for the hover tooltip on the
+// "Tested reqs" cell — first three check IDs and an ellipsis if more.
+function summarizeTested(s: TraceabilityManifest['seps'][string]): string {
+  const ids = s.requirements
+    .filter((r) => r.status === 'tested')
+    .map((r) => r.check);
+  if (ids.length === 0) return 'No tested requirements.';
+  const shown = ids.slice(0, 3).join(', ');
+  return ids.length <= 3 ? `Tested: ${shown}.` : `Tested: ${shown}, +${ids.length - 3} more.`;
+}
+
+// summarizeUntested returns the untested check IDs verbatim — they are
+// almost always few enough to fit.
+function summarizeUntested(s: TraceabilityManifest['seps'][string]): string {
+  const ids = s.requirements
+    .filter((r) => r.status === 'untested')
+    .map((r) => r.check);
+  if (ids.length === 0) return 'No untested requirements.';
+  return `Untested: ${ids.join(', ')}.`;
+}
+
+// summarizeExcluded groups exclusions by reason and emits a "Nx <reason>"
+// breakdown. Long reasons are truncated so the tooltip stays readable;
+// the full text lives in the SEP Detail section below.
+function summarizeExcluded(s: TraceabilityManifest['seps'][string]): string {
+  if (s.excluded.length === 0) return 'No exclusions.';
+  const tally = new Map<string, number>();
+  for (const e of s.excluded) {
+    const r = (e.reason || '(no reason given)').slice(0, 60);
+    tally.set(r, (tally.get(r) ?? 0) + 1);
+  }
+  const parts = Array.from(tally.entries())
+    .sort((a, b) => b[1] - a[1])
+    .map(([reason, n]) => `${n}x ${reason}`);
+  return parts.join('; ');
+}
+
+// --- SEP detail -------------------------------------------------------------
+//
+// One subsection per SEP that enumerates tested check IDs, excluded
+// requirements (with reasons), and untested check IDs. The SEP Coverage
+// table's numeric cells link here. The detail anchors are stable HTML
+// `<a id="sep-NNNN-status">` so they survive markdown auto-id changes
+// across renderers (GitHub, goldmark on the docs site, etc.).
+
+function renderSepDetail(input: RenderInput): string[] {
+  const sepIds = Object.keys(input.traceability.seps).sort((a, b) => Number(a) - Number(b));
+  if (sepIds.length === 0) {
+    return ['_No SEPs declared._'];
+  }
+  const lines: string[] = [];
+  lines.push(
+    'Per-SEP breakdown of upstream traceability — what is exercised, what is intentionally excluded, and what is declared but not yet exercised. Useful for auditing whether each exclusion still makes sense as upstream evolves. Check IDs link to their definition in the upstream SEP YAML.'
+  );
+  lines.push('');
+  for (const sep of sepIds) {
+    const s = input.traceability.seps[sep];
+    lines.push(`### SEP-${sep}`);
+    lines.push('');
+    lines.push(...renderSepDetailBlock(sep, s, input.upstreamSha));
+    lines.push('');
+  }
+  return lines;
+}
+
+// upstreamYamlUrl builds the GitHub blob URL for the upstream SEP YAML at
+// the pinned conformance SHA. Returns null when traceability did not record
+// a yaml path for this SEP (the manifest field is nullable).
+function upstreamYamlUrl(yamlPath: string | null, sha: string): string | null {
+  if (!yamlPath) return null;
+  return `https://github.com/modelcontextprotocol/conformance/blob/${sha}/${yamlPath}`;
+}
+
+// linkCheck wraps a check ID in a markdown link to the upstream SEP YAML so
+// the reader can jump straight to the scenario/check definition. Falls back
+// to a plain code span when no yaml path is available.
+function linkCheck(checkId: string, yamlUrl: string | null): string {
+  if (!yamlUrl) return `\`${checkId}\``;
+  return `[\`${checkId}\`](${yamlUrl})`;
+}
+
+function renderSepDetailBlock(
+  sep: string,
+  s: TraceabilityManifest['seps'][string],
+  sha: string
+): string[] {
+  const out: string[] = [];
+  const yamlUrl = upstreamYamlUrl(s.yaml, sha);
+
+  const tested = s.requirements.filter((r) => r.status === 'tested');
+  out.push(`<a id="sep-${sep}-tested"></a>`);
+  out.push('');
+  out.push(`**Tested (${tested.length})**`);
+  out.push('');
+  if (tested.length === 0) {
+    out.push('_None._');
+  } else {
+    for (const r of tested) {
+      out.push(`- ${linkCheck(r.check, yamlUrl)}`);
+    }
+  }
+  out.push('');
+
+  out.push(`<a id="sep-${sep}-excluded"></a>`);
+  out.push('');
+  out.push(`**Excluded (${s.excluded.length})**`);
+  out.push('');
+  if (s.excluded.length === 0) {
+    out.push('_None._');
+  } else {
+    out.push('| Requirement | Upstream reason |');
+    out.push('|---|---|');
+    for (const e of s.excluded) {
+      const reqText = inlineCell(e.text);
+      const reasonAndIssue = e.issue
+        ? `${inlineCell(e.reason || 'No reason given.')} (${inlineCell(e.issue)})`
+        : inlineCell(e.reason || 'No reason given.');
+      out.push(`| ${reqText} | ${reasonAndIssue} |`);
+    }
+  }
+  out.push('');
+
+  const untested = s.requirements.filter((r) => r.status === 'untested');
+  out.push(`<a id="sep-${sep}-untested"></a>`);
+  out.push('');
+  out.push(`**Untested (${untested.length})**`);
+  out.push('');
+  if (untested.length === 0) {
+    out.push('_None._');
+  } else {
+    for (const r of untested) {
+      const detail = r.text ? ` — ${inlineCell(r.text)}` : '';
+      out.push(`- ${linkCheck(r.check, yamlUrl)}${detail}`);
+    }
+  }
+
+  return out;
+}
+
+// inlineCell collapses whitespace and escapes pipe characters so a
+// requirement quote stays on one table row without breaking the markdown
+// table's column boundaries.
+function inlineCell(s: string): string {
+  return s.replace(/\s+/g, ' ').replace(/\|/g, '\\|').trim();
 }
 
 // --- Open gaps --------------------------------------------------------------

--- a/tools/conformance-report/test/fixtures/expected.md
+++ b/tools/conformance-report/test/fixtures/expected.md
@@ -12,10 +12,58 @@
 
 | SEP | Tested reqs | Excluded | Untested | Status |
 |---|---:|---:|---:|---|
-| [SEP-2322](https://modelcontextprotocol.io/specification/draft/basic/utilities/mrtr) | 1 | 0 | 1 | partial |
-| [SEP-2549](https://modelcontextprotocol.io/seps/2549-list-ttl) | 1 | 0 | 0 | **pass** |
+| [SEP-2322](https://modelcontextprotocol.io/specification/draft/basic/utilities/mrtr) | [1](#sep-2322-tested "Tested: sep-2322-result-type-included.") | [2](#sep-2322-excluded "1x Server-internal opaque blob — only protocol-observable invar; 1x Not protocol-observable post-parsing.") | [1](#sep-2322-untested "Untested: sep-2322-input-required-on-allowed-method.") | partial |
+| [SEP-2549](https://modelcontextprotocol.io/seps/2549-list-ttl) | [1](#sep-2549-tested "Tested: sep-2549-ttl-ms-respected.") | 0 | 0 | **pass** |
 
-_Status reflects upstream-declared requirements only. Scenario→SEP attribution is not exposed in tier-check JSON today; this column tracks "does upstream have a check ID for this SEP requirement", not "does mcpkit pass it". Per-SEP scenario pass/fail lives in `conformance/UPSTREAM_AUDIT.md`._
+_Numeric cells link to per-SEP detail below; hover/long-press surfaces a one-line summary. Status reflects upstream-declared requirements only — Scenario→SEP attribution is not exposed in tier-check JSON today; this column tracks "does upstream have a check ID for this SEP requirement", not "does mcpkit pass it". Per-SEP scenario pass/fail lives in `conformance/UPSTREAM_AUDIT.md`._
+
+## SEP Detail
+
+Per-SEP breakdown of upstream traceability — what is exercised, what is intentionally excluded, and what is declared but not yet exercised. Useful for auditing whether each exclusion still makes sense as upstream evolves. Check IDs link to their definition in the upstream SEP YAML.
+
+### SEP-2322
+
+<a id="sep-2322-tested"></a>
+
+**Tested (1)**
+
+- [`sep-2322-result-type-included`](https://github.com/modelcontextprotocol/conformance/blob/abc1234567890abcdef1234567890abcdef123456/src/seps/sep-2322.yaml)
+
+<a id="sep-2322-excluded"></a>
+
+**Excluded (2)**
+
+| Requirement | Upstream reason |
+|---|---|
+| Internal requestState format; not observable at protocol level | Server-internal opaque blob — only protocol-observable invariant is round-trip equality, exercised elsewhere. |
+| inputRequests is a JSON object; duplicate keys are collapsed by JSON parsing before the harness sees the request. | Not protocol-observable post-parsing. (modelcontextprotocol/conformance#999) |
+
+<a id="sep-2322-untested"></a>
+
+**Untested (1)**
+
+- [`sep-2322-input-required-on-allowed-method`](https://github.com/modelcontextprotocol/conformance/blob/abc1234567890abcdef1234567890abcdef123456/src/seps/sep-2322.yaml) — Servers MUST only send InputRequiredResult for tools/call, prompts/get, or completion/complete.
+
+### SEP-2549
+
+<a id="sep-2549-tested"></a>
+
+**Tested (1)**
+
+- [`sep-2549-ttl-ms-respected`](https://github.com/modelcontextprotocol/conformance/blob/abc1234567890abcdef1234567890abcdef123456/src/seps/sep-2549.yaml)
+
+<a id="sep-2549-excluded"></a>
+
+**Excluded (0)**
+
+_None._
+
+<a id="sep-2549-untested"></a>
+
+**Untested (0)**
+
+_None._
+
 
 ## Open Gaps
 

--- a/tools/conformance-report/test/fixtures/traceability.json
+++ b/tools/conformance-report/test/fixtures/traceability.json
@@ -18,13 +18,23 @@
           "text": "Servers MUST only send InputRequiredResult for tools/call, prompts/get, or completion/complete."
         }
       ],
-      "excluded": [],
+      "excluded": [
+        {
+          "text": "Internal requestState format; not observable at protocol level",
+          "reason": "Server-internal opaque blob — only protocol-observable invariant is round-trip equality, exercised elsewhere."
+        },
+        {
+          "text": "inputRequests is a JSON object; duplicate keys are collapsed by JSON parsing before the harness sees the request.",
+          "reason": "Not protocol-observable post-parsing.",
+          "issue": "modelcontextprotocol/conformance#999"
+        }
+      ],
       "unkeyed": [],
       "untracked": [],
       "summary": {
         "tested": 1,
         "untested": 1,
-        "excluded": 0,
+        "excluded": 2,
         "untracked": 0,
         "unkeyed": 0
       }


### PR DESCRIPTION
## What changes

Two related additions to the rendered \`CONFORMANCE.md\`:

1. **Numeric cells in the SEP Coverage table become clickable links with hover tooltips.** Tested / Excluded / Untested counts are now markdown links: title attribute gives a one-line summary on hover (desktop) / long-press (mobile); the link itself jumps to a per-SEP detail section. \`0\` cells stay plain text since there's nothing to link.

2. **New \`## SEP Detail\` section** below SEP Coverage. For every SEP, three sub-blocks: tested check IDs (linked to their definition in the upstream SEP YAML), excluded requirements (each with its full text + upstream reason), and untested check IDs.

## Motivation

The old report rendered SEP-2260 as "0 tested / 12 excluded / 0 untested / _untested_" — looks like a coverage gap. The new detail section makes it visible that **all 12 SEP-2260 requirements were intentionally moved into SEP-2322 (MRTR)** by upstream; mcpkit's Streamable HTTP impl is exercised under the SEP-2322 rows (17/16). Same pattern documents every other SEP's exclusions, so periodic audits ("does this exclusion still make sense?") have something to grep against.

## Reviewer's guide

1. \`tools/conformance-report/src/render.ts\` — start here. New helpers: \`numericCell\`, \`escapeTitle\`, \`summarize{Tested,Untested,Excluded}\`, \`linkCheck\`, \`renderSepDetail\`, \`renderSepDetailBlock\`. The first three feed the new link-with-tooltip cells; the last three build the new section.
2. \`tools/conformance-report/test/fixtures/traceability.json\` — fixture's SEP-2322 gained two \`excluded\` rows to exercise the new code paths (with-issue and without-issue variants).
3. \`tools/conformance-report/test/fixtures/expected.md\` — golden regenerated.
4. \`CONFORMANCE.md\` — live artifact regenerated against the same upstream-conformance SHA the file was already pinned at. No scenario verdicts changed; only the rendering grows from 73 to 477 lines.

## Decision log

- **Link-with-title over \`<details>\` collapse.** Title attributes render as hover tooltips on desktop and tap-to-show on mobile, plus the link itself is tappable to navigate to the anchored section below. \`<details>\` would force an extra click on every cell.
- **Anchors via inline HTML \`<a id="...">\`** rather than markdown-auto-id. Stable across renderers (GitHub, goldmark for the docs site, etc.) and survives renames of header text. Both GitHub-flavored markdown and goldmark accept this.
- **YAML link, not spec link, for check IDs.** The traceability manifest has a \`url\` field on individual requirements (~40% populated, points at the spec). The YAML path is recorded once per SEP and consistently available. Linking to the YAML lets readers jump to the test definition — Cmd+F finds the check ID; the spec link sits on the SEP row label.
- **Tooltip text caps reason snippets at 60 chars** and joins with semicolons. Browser tooltip rendering collapses whitespace and silently truncates around 200 chars depending on platform; keeping per-snippet short keeps the tooltip parseable.

## Verification

- \`npx vitest run\` in \`tools/conformance-report\` — 9/9 tests pass.
- \`bash scripts/refresh-conformance.sh\` reproduces \`CONFORMANCE.md\` byte-for-byte locally.
- The CI staleness gate (\`make check-conformance-stale\`) will pass since the renderer change is reflected in both the committed \`CONFORMANCE.md\` and the regeneration recipe.

## Risk

Renderer surface only. The file grows from ~73 to ~477 lines, but the content is generated and the CI gate verifies reproducibility. No protocol/library code touched.

## Out of scope

- Per-failed-check IDs in the "Failing scenarios" tooltip. Upstream \`tier-check\` JSON only records per-scenario \`checks_passed\`/\`checks_failed\` counts — not the individual check IDs — so this would need an upstream contract change. Filed separately if you want.