### PR TITLE
apps/compat: improve `make demo-app` help when EXAMPLE is missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,8 +125,7 @@ test-apps-playwright: ## Run ext-apps Playwright tests against testserver (needs
 test-apps-playwright-docker: ## Same as test-apps-playwright but inside upstream's playwright Docker image — CI-identical baselines
 	DOCKER=1 bash scripts/apps-playwright-test.sh
 
-demo-app: ## Browse a single upstream ext-apps example in your browser (no Playwright). Usage: make demo-app EXAMPLE=<name> [OPEN=1]
-	@if [ -z "$(EXAMPLE)" ]; then echo "ERROR: pass EXAMPLE=<upstream-example-name>, e.g. make demo-app EXAMPLE=video-resource-server"; exit 1; fi
+demo-app: ## Browse a single upstream ext-apps example in your browser (no Playwright). Usage: make demo-app EXAMPLE=<name> [OPEN=1]. Run without EXAMPLE for help.
 	EXAMPLE=$(EXAMPLE) OPEN=$(OPEN) bash scripts/apps-demo.sh
 
 testkcl: ## Run Keycloak auth interop tests (requires Docker, run upkcl first)

--- a/scripts/apps-demo.sh
+++ b/scripts/apps-demo.sh
@@ -38,13 +38,48 @@ EXAMPLE="${EXAMPLE:-}"
 OPEN="${OPEN:-}"
 
 if [ -z "$EXAMPLE" ]; then
-    echo "ERROR: EXAMPLE is required. Set to an upstream ext-apps example folder name."
+    cat <<'HELP'
+Usage:
+  make demo-app EXAMPLE=<name> [OPEN=1]
+
+What it does:
+  Spins up upstream's TS server + basic-host for one ext-apps example so
+  you can browse it in a real browser. No Playwright, no Docker, no drift
+  check. Useful for SKIP examples (no automated tests) or just looking at
+  what something renders to.
+
+Quick examples:
+  make demo-app EXAMPLE=video-resource-server
+  make demo-app EXAMPLE=lazy-auth-server
+  make demo-app EXAMPLE=quickstart OPEN=1
+  make demo-app EXAMPLE=basic-server-vanillajs SERVER_PORT=3201 HARNESS_PORT=8180
+
+Env vars (with defaults):
+  EXT_APPS_DIR=/tmp/ext-apps    where ext-apps is cloned / will be cloned
+  HARNESS_PORT=8080             basic-host port
+  SANDBOX_PORT=8081             basic-host sandbox port
+  SERVER_PORT=3101              upstream TS server port
+  OPEN=                         set to 1 to auto-open the browser
+
+HELP
+    if [ -d "${EXT_APPS_DIR:-/tmp/ext-apps}/examples" ]; then
+        echo "Available examples (from ${EXT_APPS_DIR:-/tmp/ext-apps}/examples/):"
+        for d in "${EXT_APPS_DIR:-/tmp/ext-apps}/examples/"*/; do
+            name="$(basename "$d")"
+            # Skip basic-host (the harness, not a demo target)
+            if [ "$name" = "basic-host" ]; then continue; fi
+            echo "  $name"
+        done
+    else
+        echo "Available examples: ${EXT_APPS_DIR:-/tmp/ext-apps} isn't cloned yet."
+        echo "Pass any EXAMPLE=<name> to trigger the first clone; pick from"
+        echo "the upstream list at https://github.com/modelcontextprotocol/ext-apps/tree/main/examples"
+    fi
     echo ""
-    echo "Examples:"
-    echo "  make demo-app EXAMPLE=video-resource-server"
-    echo "  make demo-app EXAMPLE=lazy-auth-server"
-    echo "  make demo-app EXAMPLE=basic-server-vanillajs"
-    exit 1
+    echo "Tip: 'make test-apps-playwright EXAMPLE=<name>' runs the full Playwright suite"
+    echo "against a mcpkit-Go fixture if one exists under examples/apps/compat/. The"
+    echo "demo-app target is the lighter-weight 'just let me look at it' alternative."
+    exit 0
 fi
 
 # --- Prerequisites ----------------------------------------------------------


### PR DESCRIPTION
## What changes

`make demo-app` (no args) previously errored with a one-line message because the Makefile pre-checked `$(EXAMPLE)` and exited before the script's own (slightly better) help block fired. Now it prints a proper help screen:

- Usage + one-paragraph description of what the target does
- Sample invocations covering the common modes (SKIP examples, `OPEN=1`, custom ports)
- All five env vars with defaults
- Lists every example from `$EXT_APPS_DIR/examples/` (skips `basic-host` since it's the harness, not a demo target)
- Falls back gracefully when ext-apps isn't cloned yet
- Tip pointing at `make test-apps-playwright EXAMPLE=<name>` as the heavier-weight alternative when there's a mcpkit-Go fixture

Exit code is 0 for the help path so users don't see a `make: *** Error 1` on what's really a "you forgot to pass an arg" case.

## Reviewer's guide

1. `Makefile` — pre-check removed. Target now just delegates to the script unconditionally.
2. `scripts/apps-demo.sh` — the help block is the diff; everything below the EXAMPLE check is unchanged.

## Verified

```
$ make demo-app
Usage:
  make demo-app EXAMPLE=<name> [OPEN=1]

What it does:
  ...

Available examples (from /tmp/ext-apps/examples/):
  basic-server-preact
  basic-server-react
  ...
```

No other changes.