### PR TITLE
docs(ext/ui + examples/apps): architecture explanations — bridge, iframe nesting, Tool vs App tool, payload efficiency

### DIFF
--- a/examples/apps/FLOW.md
+++ b/examples/apps/FLOW.md
@@ -110,11 +110,78 @@ A separate-origin iframe basic-host uses to isolate the App from the host page. 
 - **Sandbox attribute**: the iframe `sandbox` attribute restricts the App's capabilities (no top navigation, no parent access, etc.) from `_meta.ui.permissions`
 - **Origin isolation**: a malicious App can't escape into basic-host's origin
 
-### The App iframe (HTML bundle, served by the MCP server)
+### The App iframe (HTML bundle, delivered by the MCP server)
 
 What the user actually sees. Each upstream example builds its own `dist/mcp-app.html` — a single-file bundle (Vite + `vite-plugin-singlefile`) containing the App's UI code and the `mcp-app-bridge.js` library.
 
 The compat fixtures **don't build their own App HTML**. They read upstream's `dist/mcp-app.html` from `$EXT_APPS_DIR` at startup and serve it byte-for-byte verbatim. That's the contract — pretend to be upstream's TS server, including identical HTML.
+
+### How the App HTML gets to the iframe (and why it's not at the server's URL)
+
+A common misconception: the App iframe is **not** loaded via `<iframe src="http://your-mcp-server/...">`. The flow is:
+
+1. The host calls the MCP `resources/read` method (over the same JSON-RPC channel it's using for everything else)
+2. The MCP server's resource handler returns the App's HTML **as bytes inside the JSON-RPC response**
+3. The host renders those bytes into the iframe using `srcdoc="..."` (inline HTML) or a `blob:` URL
+
+So if your MCP server is at `http://localhost:3101/mcp`, the App is **not** at `http://localhost:3101/myapp` — there's no such HTTP endpoint. The HTML is delivered as a JSON-RPC payload through `/mcp` and rendered into an iframe at whatever origin the host chose for the sandbox (`localhost:8081` in basic-host) or a unique `blob:` / `about:srcdoc` origin.
+
+Consequences:
+
+| Question | Answer |
+|---|---|
+| Can the App make `fetch()` calls directly to the MCP server? | No (and that's intentional) — the iframe doesn't run at the server's origin; cross-origin would be blocked. The App talks to the server only via `mcp.callTool` / `mcp.readResource` through the bridge. |
+| Does the MCP server have to be HTTP-reachable from the browser? | No — only the **host** needs to talk to it. A stdio MCP server (Cursor, Claude Desktop) can still expose Apps; the host receives the HTML over stdio and renders it the same way. |
+| Can the server generate the HTML per-call? | Yes. `resources/read` is just a handler; the server can return different HTML per user, per tenant, per call. |
+| Can the App reference external origins (CDNs, fonts)? | Yes, but only the ones whitelisted in `_meta.ui.csp`. The host builds a Content-Security-Policy header from those declarations and applies it to the sandbox iframe. |
+| Could the App HTML come from somewhere other than the MCP server? | The host decides. By convention the `ui://` URI is a resource on the same MCP server, but nothing in the protocol forbids returning bytes pulled from elsewhere. In practice, App HTML is bundled and returned inline from the MCP server. |
+
+### Why two layers of iframe (not just one)
+
+The sandbox iframe is the *outer* iframe; the App iframe is *nested* inside it.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ Host page (basic-host, origin A: localhost:8080)        │
+│                                                         │
+│   ┌─────────────────────────────────────────────────┐   │
+│   │ Sandbox iframe (origin B: localhost:8081)       │   │
+│   │ Different origin from the host — "origin moat"  │   │
+│   │                                                 │   │
+│   │   ┌─────────────────────────────────────────┐   │   │
+│   │   │ App iframe (sandbox="..." attribute)    │   │   │
+│   │   │ Your App HTML + bridge.js               │   │   │
+│   │   │ User interacts with this                │   │   │
+│   │   └─────────────────────────────────────────┘   │   │
+│   └─────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────┘
+```
+
+Two defenses, layered:
+
+1. **Origin moat** (the outer sandbox iframe): the sandbox runs at a different *origin* from the host. Even if an App escapes the inner sandbox attribute, browser same-origin policy stops it from touching the host's DOM, cookies, or storage. The two halves can communicate ONLY via `postMessage`.
+2. **Sandbox attribute** (the inner App iframe): a per-App `sandbox="..."` HTML attribute built from `_meta.ui.permissions` — restricts top-level navigation, popups, form submission, etc. Per-App finer-grained control.
+
+postMessage flow from App → host crosses both iframe boundaries: App → (boundary) → Sandbox → (boundary) → Host. Each hop is `window.parent.postMessage(...)`.
+
+### Is it efficient to ship the App as a single inline payload?
+
+Yes, with caveats. Typical bundle sizes from our compat fixtures range 100 KB to ~1 MB (the larger ones being Three.js / CesiumJS / shader-heavy Apps). Three reasons it's tolerable:
+
+1. **Fetched once per App invocation, not per tool call.** The host loads the App iframe HTML once when the user invokes the tool with the UI; subsequent `tools/call` operations into the same App don't re-fetch. Data flows separately through `mcp.callTool` bridge calls.
+2. **Inline-everything is intentional.** Upstream examples use `vite-plugin-singlefile` so the bundle has zero extra fetches once delivered. CSS, fonts (base64), JS — all in one payload, no waterfall.
+3. **Local transport.** In practice the bytes flow server-process → host-process on the user's machine (stdio for Cursor / Claude Desktop; localhost HTTP for browser hosts). The wire isn't a public internet link.
+
+When it isn't enough, the escape hatches:
+
+| Scenario | Mitigation |
+|---|---|
+| App needs heavy libraries (Three.js, CesiumJS, WASM) | Reference via CDN URLs in the HTML; CSP-whitelist those origins via `_meta.ui.csp`. Bundle stays small; heavy stuff streams from a real CDN with HTTP caching. |
+| App needs megabytes of user data | Keep data out of the HTML. Return it via `tools/call` `structuredContent` or separate `resources/read` data resources. HTML is the App shell; data flows via bridge calls. |
+| App invoked very frequently | Host implementations cache the App HTML keyed by resource URI between invocations. Not mandated by the spec, but real hosts do it. |
+| Resource templates (`ui://app/{userId}/view`) producing per-user HTML | Same caching, keyed by the resolved URI. Server still generates per-user; host avoids re-fetch within a session. |
+
+The single-payload model trades raw bandwidth for *correctness, simplicity, and stdio-compatibility* — a stdio MCP server can expose Apps without needing an HTTP layer at all, which is a real feature when the server runs in a Cursor or Claude Desktop process.
 
 ### The bridge (`mcp-app-bridge.js`, upstream)
 

--- a/ext/ui/README.md
+++ b/ext/ui/README.md
@@ -71,6 +71,85 @@ This is why mcpkit ships **both** server-side Go code (`core/`, `server/`, `ext/
 
 In the apps-compat flow we test against (`examples/apps/compat/`), the App HTML comes from upstream verbatim and embeds upstream's bridge, so our Go fixtures only need the server side. But when *you* write a new App, mcpkit's bridge JS is what goes in your App HTML.
 
+## "Tool" vs "App tool" — when to use each
+
+A plain MCP **tool** is any callable function a client/host can invoke via `tools/call`. It returns text or structured content. No UI.
+
+An **App tool** is a tool that *also* exposes an interactive UI — its definition carries `_meta.ui.resourceUri` pointing at HTML the host fetches and renders as an iframe. Mechanically it's just a tool with extra metadata + a paired resource.
+
+| Pattern | API | When to use |
+|---|---|---|
+| **Plain tool** | `srv.RegisterTool(def, handler)` or `core.TypedTool[In, Out](...)` | Tool that produces text/structured output. No UI. Most "regular" MCP tools. |
+| **App tool with its own UI** | `ui.RegisterTypedAppTool(reg, TypedAppToolConfig[In, Out]{...})` | Tool whose result is best rendered as an interactive App (chart, map, form, code editor). The helper auto-pairs the tool with its UI resource and sets `_meta.ui.resourceUri`. |
+| **App-only tool sharing another App's iframe** | `core.TypedTool` + manual `ToolDef.Meta.UI` mutation + `srv.RegisterTool` | App-side helper called via the bridge from inside an existing App's iframe (e.g., polling for stats, logging events). Doesn't render anything itself; `_meta.ui.visibility = ["app"]` hides it from the model. See `examples/apps/compat/system-monitor` and `debug-server`. |
+
+So **every App tool is also an MCP tool**; "App tool" is shorthand for "tool with bonus UI metadata + a paired HTML resource". `RegisterTypedAppTool` is the ergonomic helper that sets all the metadata correctly and validates the pairing. When you don't fit its shape (no UI resource of your own), drop down to the lower-level API.
+
+> Improvement tracked in [issue 548](https://github.com/panyam/mcpkit/issues/548): making the `RegisterTypedAppTool` helper accept an optional empty `ResourceURI` for the app-only-tool case so you don't have to drop down to `core.TypedTool`.
+
+## How the server and the App actually talk
+
+The server and the App page **never communicate directly** — they talk through the host (basic-host, Claude.ai, ChatGPT, etc.) using two completely different channels.
+
+```mermaid
+flowchart LR
+  subgraph Server["Server process (Go binary)"]
+    MCP["mcpkit<br/>(core / server / ext/ui)"]
+  end
+  subgraph Browser["Browser process"]
+    direction TB
+    Host["Host page<br/>(basic-host, Claude.ai, ...)"]
+    Sandbox["Sandbox iframe<br/>(different origin)"]
+    App["App iframe<br/>(your HTML)"]
+    Bridge["mcp-app-bridge.js<br/>(inside the App)"]
+    App -.->|loads| Bridge
+  end
+  Host <-- "Channel 1: MCP/JSON-RPC<br/>over Streamable HTTP / stdio" --> MCP
+  Bridge -- "Channel 2: postMessage<br/>(across iframe boundaries)" --> Sandbox
+  Sandbox -- "postMessage relay" --> Host
+```
+
+Channel 1 is **HTTP/JSON-RPC** (or stdio) between the host and the server. That's what `core/` and `server/` implement on the Go side.
+
+Channel 2 is **postMessage** between iframes inside the browser. The App can't reach the host's window directly (they're in different origins by design), so each `mcp.callTool(...)` / `mcp.sendMessage(...)` becomes a `postMessage` to the sandbox iframe, which relays to the host.
+
+The host is the bridge between the two channels: it speaks JSON-RPC to your Go server AND postMessage to the App. The App never makes an HTTP call to your Go server. The Go server never speaks postMessage.
+
+Two example flows make the distinction visible:
+
+```mermaid
+sequenceDiagram
+    participant App
+    participant Bridge as bridge.js
+    participant Sandbox
+    participant Host
+    participant Server as MCP server<br/>(mcpkit)
+
+    Note over App: A — App calls a server tool
+    App->>Bridge: mcp.callTool({name: "refresh-data"})
+    Bridge->>Sandbox: postMessage(tools/call)
+    Sandbox->>Host: relay
+    Host->>Server: tools/call (MCP/JSON-RPC)
+    Server-->>Host: result
+    Host-->>Sandbox: result
+    Sandbox-->>Bridge: postMessage
+    Bridge-->>App: resolve callTool() promise
+
+    Note over App: B — App pushes a host event (no server round-trip)
+    App->>Bridge: mcp.sendMessage("done!")
+    Bridge->>Sandbox: postMessage(ui/message)
+    Sandbox->>Host: relay
+    Host->>Host: handle locally —<br/>e.g., chat insert, log line
+```
+
+Three concrete consequences for Go developers:
+
+1. **You don't need a separate HTTP server for your App's HTML.** The App is delivered as a `resources/read` JSON-RPC response payload — the same `/mcp` endpoint mcpkit's server already exposes handles it. (Even stdio MCP servers can expose Apps; the host just gets the HTML over stdio.)
+2. **The App can't `fetch()` your Go server.** If it tries, browser same-origin policy blocks it (the iframe runs at the host's sandbox origin, not your server's origin). All interaction goes through the bridge.
+3. **You need both halves of mcpkit to write a real App from scratch.** The Go side (`core/` + `server/` + `ext/ui/`) handles Channel 1. The JS bridge (`ext/ui/assets/mcp-app-bridge.ts` → compiled JS) handles Channel 2's App end. In compat fixtures the App HTML comes from upstream verbatim, so the JS bridge is upstream's; for non-compat Apps the JS bridge is mcpkit's.
+
+For the full runtime architecture — iframe nesting, postMessage relay details, where the App HTML comes from — see [`examples/apps/FLOW.md`](../../examples/apps/FLOW.md).
+
 ## What this package provides
 
 ### Server-side Go API

--- a/ext/ui/README.md
+++ b/ext/ui/README.md
@@ -6,6 +6,71 @@ Separate Go module (`github.com/panyam/mcpkit/ext/ui`) so the core mcpkit module
 
 > **Looking for the architecture overview?** Read [`examples/apps/FLOW.md`](../../examples/apps/FLOW.md) — explains how basic-host, the sandbox iframe, the App, the bridge JS, and the MCP server fit together.
 
+## Why the bridge exists
+
+The App is a regular HTML/JS bundle running inside a sandboxed iframe in the host's browser. The MCP server is a separate process speaking JSON-RPC. Three problems immediately:
+
+1. **The App can't speak MCP/JSON-RPC directly.** It's in a sandboxed iframe with no network access to the server (sandbox attribute + CSP enforce this).
+2. **The App needs to talk to the *host*, not just the server.** Things like "push a message into the chat", "trigger a file download", "request fullscreen" — those aren't MCP tool calls; they're host capabilities the App needs to invoke.
+3. **The host and the App live in different iframe origins** (basic-host on `:8080`, sandbox iframe on `:8081`, App iframe nested inside the sandbox). Cross-origin communication has to go through `postMessage`.
+
+The bridge is what lets the App act on all three needs without seeing the MCP protocol directly:
+
+```mermaid
+flowchart LR
+  subgraph Server["Server process (your Go binary)"]
+    MCP["mcpkit<br/>core / server / ext/ui"]
+  end
+  subgraph Browser["Browser process"]
+    direction TB
+    Host["Host page<br/>basic-host, Claude.ai, ..."]
+    Sandbox["Sandbox iframe<br/>(different origin)"]
+    App["App iframe<br/>your HTML"]
+    Bridge["mcp-app-bridge.js<br/>inside the App"]
+    App -.->|loads| Bridge
+  end
+  Host -- "MCP/JSON-RPC<br/>over Streamable HTTP" --> MCP
+  MCP -- "tools, resources" --> Host
+  Bridge -- "postMessage" --> Sandbox
+  Sandbox -- "postMessage" --> Host
+```
+
+The App calls `mcp.callTool(...)` / `mcp.sendMessage(...)` / etc. Those calls become `postMessage` to the parent (sandbox), which relays to the host. The host then either:
+
+- handles the call locally (it's a host-capability like `sendMessage`, `openLink`, `requestDisplayMode`), or
+- forwards it to the MCP server as a JSON-RPC call (it's a `callTool` / `readResource`).
+
+Two example flows make the distinction visible:
+
+```mermaid
+sequenceDiagram
+    participant App
+    participant Bridge as bridge.js
+    participant Sandbox
+    participant Host
+    participant Server as MCP server<br/>(mcpkit)
+
+    Note over App: A — App calls a server tool
+    App->>Bridge: mcp.callTool({name: "refresh-data"})
+    Bridge->>Sandbox: postMessage(tools/call)
+    Sandbox->>Host: relay
+    Host->>Server: tools/call (MCP/JSON-RPC)
+    Server-->>Host: result
+    Host-->>Sandbox: result
+    Sandbox-->>Bridge: postMessage
+    Bridge-->>App: resolve callTool() promise
+
+    Note over App: B — App pushes a host event<br/>(no server round-trip)
+    App->>Bridge: mcp.sendMessage("done!")
+    Bridge->>Sandbox: postMessage(ui/message)
+    Sandbox->>Host: relay
+    Host->>Host: handle locally —<br/>e.g., chat insert, log line
+```
+
+This is why mcpkit ships **both** server-side Go code (`core/`, `server/`, `ext/ui/`) **and** a bridge JS library (`ext/ui/assets/mcp-app-bridge.ts` → compiled JS). You need both to write an App from scratch — server-side for the MCP surface, browser-side for the App's interactive behavior.
+
+In the apps-compat flow we test against (`examples/apps/compat/`), the App HTML comes from upstream verbatim and embeds upstream's bridge, so our Go fixtures only need the server side. But when *you* write a new App, mcpkit's bridge JS is what goes in your App HTML.
+
 ## What this package provides
 
 ### Server-side Go API


### PR DESCRIPTION
## What changes

Pure docs PR — folds in four architecture explanations that came up during sessions of building apps/compat fixtures. No code changes; existing fixtures unaffected.

Currently the WebGL fixture batch (map / threejs / shadertoy / wiki-explorer) is on a separate branch waiting to ship after this docs work lands.

## What's been added

### `examples/apps/FLOW.md` (the runtime architecture doc)

Three new sections:

1. **"How the App HTML gets to the iframe (and why it's not at the server's URL)"** — clarifies that App HTML is delivered as a JSON-RPC payload via `resources/read`, NOT loaded via `<iframe src="http://server/...">`. Includes the natural follow-up Q&A table: can the App fetch the server directly? does the server need HTTP-reachability? can the server generate HTML per-call? can the App reference external CDNs?
2. **"Why two layers of iframe (not just one)"** — ASCII nesting diagram showing host → sandbox iframe → App iframe. Two defenses layered: origin moat (different origin from host, can only `postMessage`) + sandbox attribute (per-App permissions from `_meta.ui.permissions`). postMessage crosses both boundaries.
3. **"Is it efficient to ship the App as a single inline payload?"** — answers the bandwidth concern directly. Typical bundles 100 KB–1 MB, fetched once per invocation. Escape hatches table covers CSP-whitelisted CDNs for heavy libraries, separate resources for big data, host-level caching, and resource templates.

### `ext/ui/README.md` (the Go package README)

Two new sidebars near the top, aimed at Go API consumers:

1. **"Tool vs App tool — when to use each"** with a 3-row table (plain tool, App tool with own UI, app-only tool sharing another App's iframe). Points at the gap-3 entry in issue 548 for the helper improvement that would clean up the third row.
2. **"How the server and the App actually talk"** with two Mermaid diagrams: the channel split (HTTP/JSON-RPC on the server side, postMessage on the browser side) and two example flows (server-bound `callTool` vs host-only `sendMessage`). Three concrete consequences for Go developers spelled out: no separate HTTP server needed for App HTML, App can't fetch your Go server, you need both halves of mcpkit for non-compat Apps.

The existing "Why the bridge exists" section (added in commit ee2b496 on this branch) stays as the introduction; the new sections build on it.

Cross-links between FLOW.md and ext/ui/README.md are bidirectional.

## Reviewer's guide

1. [[examples/apps/FLOW.md](https://github.com/panyam/mcpkit/pull/551/files#diff-86e1fa2a6dd7af34d97a9558c3600db7c7ed1b2eefb778c4e9e3b8f18344ab22)](https://github.com/panyam/mcpkit/pull/551/files) — the three new sections live after the "What each piece does" header. Read for whether the explanations actually land — they're aimed at a developer who's run `make demo-app` and now wants to understand what they just saw.
2. [[ext/ui/README.md](https://github.com/panyam/mcpkit/pull/551/files#diff-5cc7a8afcb9b850d72e158e955902da2e7e11e9e8a3e027fab3ddbcfa8dacfa8)](https://github.com/panyam/mcpkit/pull/551/files) — the two new sidebars live between the "Why the bridge exists" section (intro) and the "What this package provides" table. Read for whether the Tool-vs-App-tool distinction is clear, and whether the channel split + consequences section gives a Go API consumer enough to start.

Both files are pure markdown — no behavioral risk.

## Out of scope

- **WebGL fixture batch** (map, threejs, shadertoy, wiki-explorer) — stashed on this branch, will ship as 552 right after this lands. Surfaced two new gaps mid-batch (map needs a second `geocode` tool I missed, wiki-explorer's nullable-string error field hits the `any`-reflection gap from issue 548); will address in 552.
- **Sub-module pages** (`docs/APPS_DESIGN.md`, `APPS_HOST.md`, `APPS_ONBOARDING.md`) — those are the deeper design docs; this PR only touches the package README and the architecture overview.
