### PR TITLE
apps/compat: publish per-fixture report on gh-pages (closes 541)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,6 +17,7 @@ on:
       - 'CAPABILITIES.md'
       - 'conformance/UPSTREAM_AUDIT.md'
       - 'conformance/FIXTURE_AUDIT.md'
+      - 'conformance/apps/COMPAT.md'
       - '.github/workflows/pages.yml'
   workflow_dispatch:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,3 +137,32 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MCPCONFORMANCE_BASE_PATH: ${{ github.workspace }}/conf-upstream-main
         run: make check-conformance-stale
+
+  apps-compat-report:
+    # Mirrors conformance-report: regenerates conformance/apps/COMPAT.md
+    # from umbrella tracking issue panyam/mcpkit#533 and fails if the
+    # committed file is stale. Forces every fixture PR to update both the
+    # umbrella row and the rendered report in lock-step. See issue 541.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Run apps-compat renderer unit tests
+        working-directory: tools/compat-reports
+        run: |
+          npm install --silent
+          npm test
+
+      - name: Check conformance/apps/COMPAT.md is fresh
+        env:
+          # GH_TOKEN is enough — the umbrella body is read via gh CLI
+          # which inherits this from the env.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: make check-apps-compat-stale

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,16 @@ refresh-conformance: ## Regenerate CONFORMANCE.md from upstream tier-check + tra
 check-conformance-stale: ## Fail if CONFORMANCE.md is stale relative to current testserver + upstream (CI gate)
 	$(MAKE) -C conformance check-conformance-stale
 
+refresh-apps-compat-report: ## Regenerate conformance/apps/COMPAT.md from umbrella tracking issue (#533). Uses gh CLI.
+	./scripts/refresh-apps-compat-report.sh
+
+check-apps-compat-stale: refresh-apps-compat-report ## Fail if conformance/apps/COMPAT.md is stale relative to umbrella #533 (CI gate)
+	@git diff --exit-code conformance/apps/COMPAT.md || ( \
+		echo "::error::conformance/apps/COMPAT.md is stale."; \
+		echo "::error::Run 'make refresh-apps-compat-report' locally and commit the diff."; \
+		exit 1 \
+	)
+
 test-auth: ## Run auth sub-module tests
 	cd ext/auth && go test ./... -count=1 -timeout 30s
 
@@ -451,5 +461,5 @@ setup: setup-tools setup-hooks ## Full development setup
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-18s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: build test test-race test-v cover cover-html cover-func cover-all test-auth test-ui test-protogen test-e2e test-experimental test-apps-playwright test-apps-playwright-docker demo-app inspect-app testkcl testkcl-auto testall test-report smoke testconfall testconf testconfauth testconf-tasks testconf-tasks-v2 testconf-mrtr testconf-file-inputs testconf-auth-server testconf-elicitation refresh-conformance check-conformance-stale vet lint vulncheck seccheck secrets verify-submodule-deps audit ci ci-full serve serve-streamable serve-both tidy tidy-all bump-root docs-site-build docs-site-serve docs-site-deploy tag tag-push setup-tools setup-hooks setup upkcl downkcl kcllogs build-bridge help
+.PHONY: build test test-race test-v cover cover-html cover-func cover-all test-auth test-ui test-protogen test-e2e test-experimental test-apps-playwright test-apps-playwright-docker demo-app inspect-app testkcl testkcl-auto testall test-report smoke testconfall testconf testconfauth testconf-tasks testconf-tasks-v2 testconf-mrtr testconf-file-inputs testconf-auth-server testconf-elicitation refresh-conformance check-conformance-stale refresh-apps-compat-report check-apps-compat-stale vet lint vulncheck seccheck secrets verify-submodule-deps audit ci ci-full serve serve-streamable serve-both tidy tidy-all bump-root docs-site-build docs-site-serve docs-site-deploy tag tag-push setup-tools setup-hooks setup upkcl downkcl kcllogs build-bridge help
 .DEFAULT_GOAL := help

--- a/conformance/apps/COMPAT.md
+++ b/conformance/apps/COMPAT.md
@@ -1,0 +1,107 @@
+# Apps Compat — mcpkit ⇄ ext-apps
+
+mcpkit-Go drop-in replacements for upstream's
+[`modelcontextprotocol/ext-apps`](https://github.com/modelcontextprotocol/ext-apps)
+Playwright suite. Each fixture under `examples/apps/compat/<name>/`
+exposes the same MCP tool surface as the upstream TypeScript example,
+serves upstream's verbatim `dist/mcp-app.html`, and is verified
+end-to-end by upstream's own Playwright tests run against the Go
+binary via `basic-host`.
+
+## Coverage
+
+| Metric | Count |
+|---|---|
+| Total upstream examples | 25 |
+| Drift-strict parity (OK) | 21 |
+| In progress (WIP / PROT) | 0 |
+| Skipped by upstream's test set | 4 |
+| Not yet implemented | 0 |
+| Pass rate over implemented | 21 / 21 (100%) |
+
+## Per-fixture status
+
+| # | Fixture | Status | Detail |
+|---|---|---|---|
+| 1 | basic-server-vanillajs | ✅ OK | 2/2 pass against mcpkit-local baseline. Resolution: PR 534 |
+| 2 | basic-server-preact | ✅ OK | 2/2 pass + drift strict OK. PR 540 |
+| 3 | basic-server-react | ✅ OK | 2/2 pass + drift strict OK. PR 540 |
+| 4 | basic-server-solid | ✅ OK | 2/2 pass + drift strict OK. PR 540 |
+| 5 | basic-server-svelte | ✅ OK | 2/2 pass + drift strict OK. PR 540 |
+| 6 | basic-server-vue | ✅ OK | 2/2 pass + drift strict OK. PR 540 |
+| 7 | budget-allocator-server | ✅ OK | 2/2 pass + drift strict OK. Rich nested output (config + analytics with maps); standard struct tags + Go maps reflect cleanly. PR 553 |
+| 8 | cohort-heatmap-server | ✅ OK | 2/2 pass + drift strict OK. PR 549 (float64 numerics workaround for int-vs-number gap, see 548) |
+| 9 | customer-segmentation-server | ✅ OK | 2/2 pass + drift strict OK. PR 549 |
+| 10 | debug-server | ✅ OK | 2/2 pass + drift strict OK. 3 tools (debug-tool/refresh/log). PR 549 (uses InputSchemaOverride for the `payload: any` field — gap 2 in issue 548) |
+| 11 | integration-server | ✅ OK | 5/5 pass (2 standard + 3 interaction: Send Message, Send Log, Open Link). Drift strict OK. PR 549 |
+| 12 | lazy-auth-server | ⏭ SKIP | Not in upstream's servers.spec.ts. Auth-flow specific; no default Playwright test |
+| 13 | map-server | ✅ OK | 2/2 pass + drift strict OK. 2 tools (show-map + geocode). PR 552 |
+| 14 | pdf-server | ✅ OK | 2/2 pass + drift strict OK (4 tools — list_pdfs / read_pdf_bytes / display_pdf / save_pdf, matching upstream's default-without-`--enable-interact` surface). The 4 additional pdf-*.spec.ts files (annotations, annotations-api, incremental-load, viewer-zoom) drive the `--enable-interact` surface and need the interact command-queue + long-poll backend; deferred to follow-up issue 554. PR 555 |
+| 15 | qr-server | ⏭ SKIP | Upstream SKIP_SERVERS |
+| 16 | quickstart | ✅ OK | 2/2 pass + drift strict OK. PR 543 (tsx-fallback for upstream servers without dist/index.js) |
+| 17 | say-server | ⏭ SKIP | Upstream SKIP_SERVERS (HuggingFace TTS download) |
+| 18 | scenario-modeler-server | ✅ OK | 2/2 pass + drift strict OK via OutputSchemaOverride (nullable `breakEvenMonth`). PR 553 |
+| 19 | shadertoy-server | ✅ OK | 2/2 pass + drift strict OK via InputSchemaOverride (multi-line GLSL default). PR 552 |
+| 20 | sheet-music-server | ✅ OK | 2/2 pass + drift strict OK via TypedAppToolConfig.InputSchemaOverride. PR 545 (closes 542) |
+| 21 | system-monitor-server | ✅ OK | 2/2 pass + drift strict OK. 2 tools (info + app-only stats). PR 549 |
+| 22 | threejs-server | ✅ OK | 2/2 pass + drift strict OK via InputSchemaOverride (multi-line code default). 2 tools (show_threejs_scene + learn_threejs). PR 552 |
+| 23 | transcript-server | ✅ OK | 2/2 pass + drift strict OK. PR 543 |
+| 24 | video-resource-server | ⏭ SKIP | Not in upstream's servers.spec.ts; only in generate-grid-screenshots.spec.ts which is excluded from default test runs. No Playwright test to satisfy. |
+| 25 | wiki-explorer-server | ✅ OK | 2/2 pass + drift strict OK via new OutputSchemaOverride (nullable `error` field — PR 552 adds the library symbol) |
+
+## Legend
+
+- **✅ OK** — `loads app UI` + `screenshot matches golden` Playwright
+  tests pass, and the `tools/list` parity check matches upstream's TS
+  server byte-for-byte under DOCKER mode
+  (`mcr.microsoft.com/playwright:v1.57.0-noble`, the same image upstream
+  uses for `test:e2e:docker`).
+- **🟡 WIP / PROT** — surface working; visual baseline or interaction
+  tests pending.
+- **⏭ SKIP** — upstream's `servers.spec.ts` deliberately omits this
+  example (special build-time dependency or not in the default test
+  matrix).
+- **⬜ NOT** — not yet implemented as an mcpkit drop-in.
+
+## How parity is verified
+
+Each fixture runs through `scripts/apps-playwright-test.sh` in two
+modes:
+
+1. **Native** (host OS) — fast `loads app UI` iteration. The visual
+   screenshot test is Docker-pinned and is expected to fail on
+   non-Linux hosts; that gap is intentional.
+2. **DOCKER** — runs the upstream Playwright image with the fixture as
+   the MCP server. The committed baseline is a single canonical
+   Linux PNG per fixture (matching upstream's own pinning convention).
+   This mode also runs a **strict `tools/list` parity check** that
+   spins up upstream's TypeScript reference server on a side port,
+   fetches `tools/list` from both, JSON-diffs them, and fails on any
+   schema drift outside a small filter for SDK-emit differences
+   (`$schema`, `additionalProperties`, `propertyNames`, plus an
+   `integer` ⇄ `number` subtype normalization). Drift fails the gate.
+
+## How this report is generated
+
+`tools/compat-reports/src/apps.ts` fetches the body of umbrella
+tracking issue `panyam/mcpkit#533` and renders its
+status table as this Markdown file. The umbrella issue is the
+hand-maintained source of truth — every fixture PR updates the row
+along with the code. The script is deterministic: re-running on an
+unchanged umbrella body produces a byte-identical file.
+
+To refresh:
+
+```sh
+make refresh-apps-compat-report
+```
+
+The CI `check-apps-compat-stale` gate enforces that PRs touching
+`examples/apps/compat/**` re-run the refresh and commit any diff.
+
+## See also
+
+- [Conformance Coverage](../../CONFORMANCE.md) — MCP spec compliance matrix
+- [Upstream Conformance Audit](../UPSTREAM_AUDIT.md) — scenario-level grading vs upstream's conformance suite
+- [Fixture Parity Audit](../FIXTURE_AUDIT.md) — public-API discipline check on conformance fixtures
+- `examples/apps/compat/README.md` — drop-in fixture pattern + the wrapper script

--- a/docs/site/content/HeaderNavLinks.json
+++ b/docs/site/content/HeaderNavLinks.json
@@ -5,7 +5,8 @@
     "children": [
       { "name": "Coverage matrix", "url": "conformance/" },
       { "name": "Upstream audit",  "url": "conformance/upstream-audit/" },
-      { "name": "Fixture audit",   "url": "conformance/fixture-audit/" }
+      { "name": "Fixture audit",   "url": "conformance/fixture-audit/" },
+      { "name": "Apps compat",     "url": "conformance/apps/compat/" }
     ]
   },
   {

--- a/docs/site/content/conformance/apps/compat.html
+++ b/docs/site/content/conformance/apps/compat.html
@@ -1,0 +1,7 @@
+---
+title: "Apps Compat"
+description: "Per-fixture parity of mcpkit-Go drop-ins vs upstream's modelcontextprotocol/ext-apps Playwright suite."
+source: "conformance/apps/COMPAT.md"
+---
+
+{{ renderMarkdownFile "conformance/apps/COMPAT.md" }}

--- a/scripts/refresh-apps-compat-report.sh
+++ b/scripts/refresh-apps-compat-report.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Regenerates conformance/apps/COMPAT.md from the apps-compat umbrella
+# tracking issue (panyam/mcpkit#533 by default). Thin shell wrapper —
+# the actual parser + renderer lives in tools/compat-reports/src/apps.ts
+# so it shares the umbrella-table parse + render helpers with future
+# extension-compat reports (tasks-v2, mrtr, ...).
+#
+# Deterministic contract: re-running on an unchanged umbrella body
+# produces a byte-identical file. The check-apps-compat-stale CI gate
+# (mirroring check-conformance-stale) enforces refresh + git diff
+# --exit-code on PRs that touch examples/apps/compat/**.
+#
+# Env overrides:
+#   UMBRELLA_NUMBER  — GitHub issue number (default 533)
+#   UMBRELLA_REPO    — owner/repo for the umbrella (default panyam/mcpkit)
+#   REFRESH_OUT      — output path (default conformance/apps/COMPAT.md)
+#   GH_TOKEN         — required for gh CLI; GH_PERSONAL_TOKEN takes
+#                      precedence (EMU accounts can't read personal
+#                      repos with the org token).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+UMBRELLA_NUMBER="${UMBRELLA_NUMBER:-533}"
+UMBRELLA_REPO="${UMBRELLA_REPO:-panyam/mcpkit}"
+OUT="${REFRESH_OUT:-$REPO_ROOT/conformance/apps/COMPAT.md}"
+
+if ! command -v gh >/dev/null 2>&1; then
+    echo "refresh-apps-compat-report: gh CLI required (https://cli.github.com)" >&2
+    exit 1
+fi
+
+if ! command -v npx >/dev/null 2>&1; then
+    echo "refresh-apps-compat-report: npx not found. Install Node.js 22+." >&2
+    exit 1
+fi
+
+mkdir -p "$(dirname "$OUT")"
+
+cd "$REPO_ROOT/tools/compat-reports"
+exec npx --yes tsx@^4.0.0 src/apps.ts \
+    --umbrella "$UMBRELLA_NUMBER" \
+    --repo "$UMBRELLA_REPO" \
+    --out "$OUT"

--- a/tools/compat-reports/.gitignore
+++ b/tools/compat-reports/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+package-lock.json

--- a/tools/compat-reports/package.json
+++ b/tools/compat-reports/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@mcpkit/compat-reports",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "description": "Renders extension-compat conformance reports (apps, tasks-v2, mrtr, ...) from their hand-maintained umbrella-issue status tables. Shared lib/ for issue fetch + table parse + render so each extension's entry point is just CLI flags + extension-specific intro prose.",
+  "bin": {
+    "apps-compat-report": "src/apps.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "tsx": "^4.0.0",
+    "typescript": "^5.4.0",
+    "vitest": "^2.0.0"
+  }
+}

--- a/tools/compat-reports/src/apps.ts
+++ b/tools/compat-reports/src/apps.ts
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+// CLI entry for the apps-compat report. Fetches umbrella issue 533 (by
+// default), parses its status table, and renders conformance/apps/COMPAT.md.
+//
+// Invocation (via scripts/refresh-apps-compat-report.sh):
+//   npx tsx tools/compat-reports/src/apps.ts \
+//     --umbrella 533 \
+//     --repo panyam/mcpkit \
+//     --out conformance/apps/COMPAT.md
+//
+// Deterministic contract: re-running on an unchanged umbrella body
+// produces a byte-identical file. The check-apps-compat-stale CI gate
+// enforces refresh + git diff --exit-code on PRs that touch
+// examples/apps/compat/**.
+
+import { writeFileSync } from 'node:fs';
+import { fetchUmbrellaBody, parseStatusTable } from './lib/umbrella.js';
+import {
+  renderCoverageTable,
+  renderStatusTable,
+  tally,
+} from './lib/render.js';
+
+interface CliArgs {
+  umbrella: number;
+  repo: string;
+  out: string;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  let umbrella = 533;
+  let repo = 'panyam/mcpkit';
+  let out = 'conformance/apps/COMPAT.md';
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const next = (): string => {
+      const v = argv[++i];
+      if (v === undefined) throw new Error(`${arg} requires a value`);
+      return v;
+    };
+    switch (arg) {
+      case '--umbrella': umbrella = Number(next()); break;
+      case '--repo':     repo = next(); break;
+      case '--out':      out = next(); break;
+      case '-h': case '--help':
+        printHelpAndExit();
+    }
+  }
+  if (!Number.isFinite(umbrella) || umbrella <= 0) {
+    throw new Error(`--umbrella must be a positive integer (got ${umbrella})`);
+  }
+  return { umbrella, repo, out };
+}
+
+function printHelpAndExit(): never {
+  process.stderr.write(`Usage: apps-compat-report [options]
+
+Options:
+  --umbrella <num>   GitHub issue number for the umbrella (default: 533)
+  --repo <owner/n>   Repo holding the umbrella (default: panyam/mcpkit)
+  --out <path>       Output markdown path (default: conformance/apps/COMPAT.md)
+  -h, --help         Show this help
+
+Auth: uses GH_PERSONAL_TOKEN if set, falling back to GH_TOKEN.
+`);
+  process.exit(2);
+}
+
+function renderReport(args: CliArgs): string {
+  const body = fetchUmbrellaBody({
+    umbrellaNumber: args.umbrella,
+    repo: args.repo,
+  });
+  const rows = parseStatusTable(body);
+  if (rows.length === 0) {
+    throw new Error(
+      `No status rows parsed from ${args.repo}#${args.umbrella} — ` +
+      `verify the issue has a '## Status' section with a markdown table.`,
+    );
+  }
+  const t = tally(rows);
+  return `# Apps Compat — mcpkit ⇄ ext-apps
+
+mcpkit-Go drop-in replacements for upstream's
+[\`modelcontextprotocol/ext-apps\`](https://github.com/modelcontextprotocol/ext-apps)
+Playwright suite. Each fixture under \`examples/apps/compat/<name>/\`
+exposes the same MCP tool surface as the upstream TypeScript example,
+serves upstream's verbatim \`dist/mcp-app.html\`, and is verified
+end-to-end by upstream's own Playwright tests run against the Go
+binary via \`basic-host\`.
+
+## Coverage
+
+${renderCoverageTable(t)}
+
+## Per-fixture status
+
+${renderStatusTable(rows)}
+
+## Legend
+
+- **✅ OK** — \`loads app UI\` + \`screenshot matches golden\` Playwright
+  tests pass, and the \`tools/list\` parity check matches upstream's TS
+  server byte-for-byte under DOCKER mode
+  (\`mcr.microsoft.com/playwright:v1.57.0-noble\`, the same image upstream
+  uses for \`test:e2e:docker\`).
+- **🟡 WIP / PROT** — surface working; visual baseline or interaction
+  tests pending.
+- **⏭ SKIP** — upstream's \`servers.spec.ts\` deliberately omits this
+  example (special build-time dependency or not in the default test
+  matrix).
+- **⬜ NOT** — not yet implemented as an mcpkit drop-in.
+
+## How parity is verified
+
+Each fixture runs through \`scripts/apps-playwright-test.sh\` in two
+modes:
+
+1. **Native** (host OS) — fast \`loads app UI\` iteration. The visual
+   screenshot test is Docker-pinned and is expected to fail on
+   non-Linux hosts; that gap is intentional.
+2. **DOCKER** — runs the upstream Playwright image with the fixture as
+   the MCP server. The committed baseline is a single canonical
+   Linux PNG per fixture (matching upstream's own pinning convention).
+   This mode also runs a **strict \`tools/list\` parity check** that
+   spins up upstream's TypeScript reference server on a side port,
+   fetches \`tools/list\` from both, JSON-diffs them, and fails on any
+   schema drift outside a small filter for SDK-emit differences
+   (\`$schema\`, \`additionalProperties\`, \`propertyNames\`, plus an
+   \`integer\` ⇄ \`number\` subtype normalization). Drift fails the gate.
+
+## How this report is generated
+
+\`tools/compat-reports/src/apps.ts\` fetches the body of umbrella
+tracking issue \`${args.repo}#${args.umbrella}\` and renders its
+status table as this Markdown file. The umbrella issue is the
+hand-maintained source of truth — every fixture PR updates the row
+along with the code. The script is deterministic: re-running on an
+unchanged umbrella body produces a byte-identical file.
+
+To refresh:
+
+\`\`\`sh
+make refresh-apps-compat-report
+\`\`\`
+
+The CI \`check-apps-compat-stale\` gate enforces that PRs touching
+\`examples/apps/compat/**\` re-run the refresh and commit any diff.
+
+## See also
+
+- [Conformance Coverage](../../CONFORMANCE.md) — MCP spec compliance matrix
+- [Upstream Conformance Audit](../UPSTREAM_AUDIT.md) — scenario-level grading vs upstream's conformance suite
+- [Fixture Parity Audit](../FIXTURE_AUDIT.md) — public-API discipline check on conformance fixtures
+- \`examples/apps/compat/README.md\` — drop-in fixture pattern + the wrapper script
+`;
+}
+
+function main(): void {
+  const args = parseArgs(process.argv.slice(2));
+  const md = renderReport(args);
+  writeFileSync(args.out, md);
+  process.stdout.write(`Wrote ${args.out}\n`);
+}
+
+main();

--- a/tools/compat-reports/src/lib/render.ts
+++ b/tools/compat-reports/src/lib/render.ts
@@ -1,0 +1,87 @@
+// Shared rendering primitives for extension-compat reports. Each
+// extension's entry point composes these into its own report file.
+
+import type { StatusRow } from './umbrella.js';
+
+// Status keys used in the umbrella table. Extensions may extend this
+// set; the badge lookup falls back to "⬜ <status>" for unknown values.
+export type KnownStatus = 'OK' | 'WIP' | 'PROT' | 'SKIP' | 'NOT';
+
+// StatusBadge returns the emoji-prefixed display string for a status.
+// Unknown statuses fall back to a neutral square so rendering doesn't
+// silently swallow a typo in the umbrella table.
+export function statusBadge(status: string): string {
+  switch (status) {
+    case 'OK':   return '✅ OK';
+    case 'WIP':  return '🟡 WIP';
+    case 'PROT': return '🟡 PROT';
+    case 'SKIP': return '⏭ SKIP';
+    case 'NOT':  return '⬜ NOT';
+    default:     return `⬜ ${status}`;
+  }
+}
+
+// Tally is a per-status count plus implementation totals. Implemented
+// = OK + WIP + PROT (everything except SKIP / NOT). Pass rate is OK
+// over implemented; reported as "N / M" plus a rounded percent.
+export interface Tally {
+  total: number;
+  ok: number;
+  wip: number;     // WIP + PROT combined
+  skip: number;
+  not: number;
+  implemented: number;
+  passRate: string; // "100%" | "—"
+}
+
+export function tally(rows: StatusRow[]): Tally {
+  let ok = 0, wip = 0, skip = 0, not = 0;
+  for (const r of rows) {
+    switch (r.status) {
+      case 'OK':            ok++; break;
+      case 'WIP': case 'PROT': wip++; break;
+      case 'SKIP':          skip++; break;
+      case 'NOT':           not++; break;
+    }
+  }
+  const implemented = ok + wip;
+  const passRate = implemented > 0
+    ? `${Math.round((ok / implemented) * 100)}%`
+    : '—';
+  return {
+    total: rows.length,
+    ok, wip, skip, not,
+    implemented,
+    passRate,
+  };
+}
+
+// renderCoverageTable produces the "## Coverage" section's metric table
+// using the tally results.
+export function renderCoverageTable(t: Tally): string {
+  const lines = [
+    '| Metric | Count |',
+    '|---|---|',
+    `| Total upstream examples | ${t.total} |`,
+    `| Drift-strict parity (OK) | ${t.ok} |`,
+    `| In progress (WIP / PROT) | ${t.wip} |`,
+    `| Skipped by upstream's test set | ${t.skip} |`,
+    `| Not yet implemented | ${t.not} |`,
+    `| Pass rate over implemented | ${t.ok} / ${t.implemented} (${t.passRate}) |`,
+  ];
+  return lines.join('\n');
+}
+
+// renderStatusTable produces the per-fixture rows table. The notes
+// column is passed through verbatim — any markdown inside (inline
+// code, PR refs, links) renders as-is in the gh-pages output.
+export function renderStatusTable(rows: StatusRow[]): string {
+  const lines = [
+    '| # | Fixture | Status | Detail |',
+    '|---|---|---|---|',
+  ];
+  for (const r of rows) {
+    lines.push(`| ${r.num} | ${r.name} | ${statusBadge(r.status)} | ${r.notes} |`);
+  }
+  return lines.join('\n');
+}

--- a/tools/compat-reports/src/lib/umbrella.ts
+++ b/tools/compat-reports/src/lib/umbrella.ts
@@ -1,0 +1,113 @@
+// Shared utilities for fetching + parsing an extension-compat tracking
+// umbrella issue. Each MCP extension that ships a drop-in compat suite
+// (apps, tasks-v2, mrtr, ...) keeps its per-fixture status in a single
+// hand-maintained GitHub issue. These helpers turn that issue body into
+// typed rows the per-extension renderers can format.
+
+import { execFileSync } from 'node:child_process';
+
+// StatusRow is one row of the `## Status` table in an umbrella issue.
+// The umbrella convention is:
+//   | # | name | status | notes |
+//
+// Any markdown inside `notes` (inline code, links, PR refs) is preserved
+// verbatim and rendered by the page consumer — we do not parse it.
+export interface StatusRow {
+  num: string;
+  name: string;
+  status: string;
+  notes: string;
+}
+
+// FetchOptions controls how the umbrella body is obtained. The default
+// is to shell out to `gh` because that's already a project-wide
+// dependency and survives both interactive (gh auth) and CI (GH_TOKEN)
+// auth modes uniformly. Callers can inject a `body` directly for
+// testing — that bypass keeps the parser logic independent of network.
+export interface FetchOptions {
+  umbrellaNumber: number;
+  repo: string;
+  // If set, skip the gh CLI call and use this string verbatim.
+  bodyOverride?: string;
+}
+
+// fetchUmbrellaBody resolves the umbrella issue body. Throws on:
+//   - gh CLI missing
+//   - empty body (issue doesn't exist or returned no content)
+// Both conditions are caller errors we want surfaced loudly rather
+// than silently rendering an empty report.
+export function fetchUmbrellaBody(opts: FetchOptions): string {
+  if (opts.bodyOverride !== undefined) {
+    return opts.bodyOverride;
+  }
+  const body = execFileSync(
+    'gh',
+    [
+      'issue', 'view', String(opts.umbrellaNumber),
+      '--repo', opts.repo,
+      '--json', 'body',
+      '--jq', '.body',
+    ],
+    {
+      encoding: 'utf-8',
+      // EMU accounts can't read personal repos with their org token.
+      // GH_PERSONAL_TOKEN (when set) takes precedence over GH_TOKEN —
+      // matches the project-wide convention from scripts/*.sh.
+      env: {
+        ...process.env,
+        GH_TOKEN: process.env.GH_PERSONAL_TOKEN || process.env.GH_TOKEN || '',
+      },
+    },
+  ).trim();
+  if (!body) {
+    throw new Error(
+      `Empty body for ${opts.repo}#${opts.umbrellaNumber} — verify the issue exists and gh auth works.`,
+    );
+  }
+  return body;
+}
+
+// parseStatusTable extracts table rows from the `## Status` section of
+// an umbrella issue body. Strategy: linear scan, enter the section on
+// the `## Status` heading and leave it on the next `## ` heading. Body
+// rows are recognized by `| <num> |` prefix; this skips the header row
+// (`| # |`) and the separator row (`|---|...|`).
+//
+// Returns rows in document order. Empty result means the section is
+// missing or the table is empty — callers decide whether that's an
+// error (it almost always is).
+export function parseStatusTable(body: string): StatusRow[] {
+  const rows: StatusRow[] = [];
+  let inSection = false;
+  for (const line of body.split(/\r?\n/)) {
+    if (/^## Status\b/.test(line)) {
+      inSection = true;
+      continue;
+    }
+    if (inSection && /^## /.test(line)) {
+      break;
+    }
+    if (!inSection) continue;
+    // Body row guard: starts with `| ` followed by a digit. Excludes
+    // the header (`| #`) and the separator (`|---`).
+    if (!/^\|\s*\d+\s*\|/.test(line)) continue;
+    const cells = splitTableRow(line);
+    if (cells.length < 4) continue;
+    rows.push({
+      num: cells[0],
+      name: cells[1],
+      status: cells[2],
+      notes: cells[3],
+    });
+  }
+  return rows;
+}
+
+// splitTableRow strips leading + trailing pipes and splits on `|`,
+// preserving any internal markdown (inline code, `\`pipes-in-code\``
+// would break this but the umbrella convention is plain prose so we
+// don't pay that cost). Trim each cell.
+function splitTableRow(line: string): string[] {
+  const trimmed = line.trim().replace(/^\|/, '').replace(/\|$/, '');
+  return trimmed.split('|').map((c) => c.trim());
+}

--- a/tools/compat-reports/test/render.test.ts
+++ b/tools/compat-reports/test/render.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import type { StatusRow } from '../src/lib/umbrella.js';
+import {
+  renderCoverageTable,
+  renderStatusTable,
+  statusBadge,
+  tally,
+} from '../src/lib/render.js';
+
+const SAMPLE: StatusRow[] = [
+  { num: '1', name: 'fixture-a', status: 'OK',   notes: 'first row, PR 100' },
+  { num: '2', name: 'fixture-b', status: 'OK',   notes: 'second row' },
+  { num: '3', name: 'fixture-c', status: 'WIP',  notes: 'in progress' },
+  { num: '4', name: 'fixture-d', status: 'SKIP', notes: 'upstream skipped' },
+  { num: '5', name: 'fixture-e', status: 'NOT',  notes: 'not yet built' },
+];
+
+describe('statusBadge', () => {
+  it('maps known statuses to their emoji form', () => {
+    expect(statusBadge('OK')).toBe('✅ OK');
+    expect(statusBadge('WIP')).toBe('🟡 WIP');
+    expect(statusBadge('PROT')).toBe('🟡 PROT');
+    expect(statusBadge('SKIP')).toBe('⏭ SKIP');
+    expect(statusBadge('NOT')).toBe('⬜ NOT');
+  });
+
+  it('falls back for unknown statuses so typos surface visibly', () => {
+    expect(statusBadge('UNKOWN')).toBe('⬜ UNKOWN');
+  });
+});
+
+describe('tally', () => {
+  it('counts each status and computes implemented + pass rate', () => {
+    const t = tally(SAMPLE);
+    expect(t.total).toBe(5);
+    expect(t.ok).toBe(2);
+    expect(t.wip).toBe(1);
+    expect(t.skip).toBe(1);
+    expect(t.not).toBe(1);
+    expect(t.implemented).toBe(3); // OK + WIP
+    expect(t.passRate).toBe('67%');
+  });
+
+  it('returns an em-dash pass rate when nothing is implemented', () => {
+    const t = tally([
+      { num: '1', name: 'x', status: 'SKIP', notes: '' },
+      { num: '2', name: 'y', status: 'NOT',  notes: '' },
+    ]);
+    expect(t.passRate).toBe('—');
+  });
+
+  it('100% pass rate renders as 100% not 100.0%', () => {
+    const t = tally([{ num: '1', name: 'x', status: 'OK', notes: '' }]);
+    expect(t.passRate).toBe('100%');
+  });
+});
+
+describe('renderStatusTable', () => {
+  it('includes the markdown header + separator + one row per input', () => {
+    const out = renderStatusTable(SAMPLE);
+    const lines = out.split('\n');
+    expect(lines[0]).toBe('| # | Fixture | Status | Detail |');
+    expect(lines[1]).toBe('|---|---|---|---|');
+    expect(lines).toHaveLength(2 + SAMPLE.length);
+  });
+
+  it('passes notes through verbatim so embedded markdown renders on the page', () => {
+    const out = renderStatusTable(SAMPLE);
+    expect(out).toContain('first row, PR 100');
+  });
+});
+
+describe('renderCoverageTable', () => {
+  it('emits the metric labels the legend documents', () => {
+    const out = renderCoverageTable(tally(SAMPLE));
+    expect(out).toContain('Total upstream examples');
+    expect(out).toContain('Drift-strict parity (OK)');
+    expect(out).toContain('Pass rate over implemented');
+  });
+});

--- a/tools/compat-reports/test/umbrella.test.ts
+++ b/tools/compat-reports/test/umbrella.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { parseStatusTable } from '../src/lib/umbrella.js';
+
+const FIXTURE_BODY = `## Why
+
+Some preamble we should skip.
+
+## Status
+
+Legend: NOT = not-implemented, OK = all-pass, SKIP = skipped upstream
+
+| # | Example | Status | Notes |
+|---|---|---|---|
+| 1 | basic-server-vanillajs | OK | 2/2 pass. PR 534 |
+| 2 | basic-server-preact | OK | 2/2 pass. PR 540 |
+| 3 | lazy-auth-server | SKIP | Not in upstream's servers.spec.ts |
+| 4 | pdf-server | NOT | Lots of additional pdf-* spec files |
+
+## Out of scope
+
+- Some stuff we should NOT pick up.
+
+| 99 | should-be-ignored | OK | this row is after the Status section |
+`;
+
+describe('parseStatusTable', () => {
+  it('extracts only rows inside the ## Status section', () => {
+    const rows = parseStatusTable(FIXTURE_BODY);
+    expect(rows).toHaveLength(4);
+    expect(rows.map((r) => r.name)).toEqual([
+      'basic-server-vanillajs',
+      'basic-server-preact',
+      'lazy-auth-server',
+      'pdf-server',
+    ]);
+  });
+
+  it('preserves notes verbatim including PR refs', () => {
+    const rows = parseStatusTable(FIXTURE_BODY);
+    expect(rows[0].notes).toBe('2/2 pass. PR 534');
+    expect(rows[3].notes).toBe('Lots of additional pdf-* spec files');
+  });
+
+  it('captures the status column for each row', () => {
+    const rows = parseStatusTable(FIXTURE_BODY);
+    expect(rows.map((r) => r.status)).toEqual(['OK', 'OK', 'SKIP', 'NOT']);
+  });
+
+  it('skips header and separator rows', () => {
+    const rows = parseStatusTable(FIXTURE_BODY);
+    // Header `| # | Example | ...` doesn't start with `| <digit>` so it
+    // would be filtered by the prefix guard. Same for the separator.
+    expect(rows.find((r) => r.name === 'Example')).toBeUndefined();
+  });
+
+  it('returns an empty array when there is no Status section', () => {
+    expect(parseStatusTable('# Some doc\n\nNo status section here.\n')).toEqual([]);
+  });
+
+  it('stops scanning at the next top-level heading', () => {
+    // The "99 | should-be-ignored" row sits past the closing `## Out of scope`
+    // heading and must not appear in the output.
+    const rows = parseStatusTable(FIXTURE_BODY);
+    expect(rows.find((r) => r.name === 'should-be-ignored')).toBeUndefined();
+  });
+});

--- a/tools/compat-reports/tsconfig.json
+++ b/tools/compat-reports/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
## What changes

Adds a generated per-fixture parity report at `conformance/apps/COMPAT.md` and wires it onto the gh-pages site at `/conformance/apps/compat/`. Sourced from the hand-maintained `## Status` table on umbrella tracking issue 533.

The renderer lives in a new shared TypeScript package — `tools/compat-reports/` — designed so future extension-compat reports (tasks-v2, mrtr, stateless, ...) drop in alongside the existing apps entry without re-implementing the umbrella-fetch + table-parse + render primitives. Closes issue 541.

## Reviewer's guide

Read in this order:

1. [tools/compat-reports/src/lib/umbrella.ts](https://github.com/panyam/mcpkit/pull/569/files#diff-43bdf5f7aadc0154156a870a2c531f39c41d882e08c2b2f0544a3a51875268e8) — start here. The shared fetch + parser. `parseStatusTable` linearly scans the umbrella body, enters on the `## Status` heading, leaves on the next `## `, and accepts only `| <num> | ...` body rows (which skips the header + separator).
2. [tools/compat-reports/src/lib/render.ts](https://github.com/panyam/mcpkit/pull/569/files#diff-6879c963bd30515ac9ccb972e3a8b04caf181624ac80430db014296326b60934) — shared rendering primitives. Status badges, tally helper (OK / WIP+PROT / SKIP / NOT, plus implemented + pass rate), table renderers. Future extensions reuse these directly.
3. [tools/compat-reports/src/apps.ts](https://github.com/panyam/mcpkit/pull/569/files#diff-1817fbf0ba4ab2b085b61544768e2dda0a47145cf101e075ec15c32056b5b75d) — apps-compat entry. CLI flags + prose specific to apps-compat (legend, parity verification text). The template for future entries.
4. `tools/compat-reports/test/{umbrella,render}.test.ts` — 14 vitest tests covering the parser edge cases (no-Status-section, rows past the section boundary, header/separator filtering) and render output (badges, tally arithmetic, empty / 100% pass rates).
5. [scripts/refresh-apps-compat-report.sh](https://github.com/panyam/mcpkit/pull/569/files#diff-54abda22c6cf2fd6e931a1a52a68443b474adb462752a37826742320267e9bcf) — thin bash wrapper. All parsing/rendering lives in TS; this just resolves env defaults and invokes `npx tsx`.
6. [conformance/apps/COMPAT.md](https://github.com/panyam/mcpkit/pull/569/files#diff-23b48dcff2f8c631b8699528f4dff7e9490b19ca12a75ad35d8af72be3562dae) — the generated artifact. Re-running the renderer must produce a byte-identical file (the staleness contract).
7. [docs/site/content/conformance/apps/compat.html](https://github.com/panyam/mcpkit/pull/569/files#diff-3287c968e41529c5493a9555efe6f61941b06ef8a670ba3a88e0fd5d2b26d5e3) — 4-line stub, same shape as `conformance/upstream-audit.html` / `conformance/fixture-audit.html`.
8. [.github/workflows/test.yml](https://github.com/panyam/mcpkit/pull/569/files#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88) — new `apps-compat-report` job: installs deps, runs vitest, runs `make check-apps-compat-stale`. `GH_TOKEN` passed via `env:` (not interpolated into `run:`).
9. [.github/workflows/pages.yml](https://github.com/panyam/mcpkit/pull/569/files#diff-267452bb53d388a7b14551d9fc53a797edc124dc9085ecc79f5339277a1e53b5) + [Makefile](https://github.com/panyam/mcpkit/pull/569/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52) + `HeaderNavLinks.json` — mechanical wiring.

## Decision log

- **Why a new tools/ package instead of a script under scripts/.** The same shape is going to recur for every extension that ships a compat suite (tasks-v2, mrtr, stateless). Putting the lib bits in a versioned package with tests makes additions cheap; per-extension entry points are ~80 lines each. Modeled directly on the existing `tools/conformance-report/` pattern.
- **Why parse umbrella 533 instead of running fixtures live.** Live DOCKER runs across all 21 fixtures take ~40 min, need Docker, and are fragile to environment. The umbrella is updated atomically with every fixture PR — same source-of-truth contract `make refresh-conformance` uses for `CONFORMANCE.md`. Live runs can come later as a nightly CI job feeding a JSON artifact the renderer consumes.
- **Why no wall-clock timestamp.** Matches `conformance/UPSTREAM_AUDIT.md`'s convention — the file should only diff when the umbrella table content changes. Timestamps would churn the file on every refresh.
- **Why TS, not bash or Python.** Bash awk on a markdown table is fragile (the v1 of this PR shipped a bash version that worked but was hard to test). TS matches the precedent set by `tools/conformance-report/` + `scripts/conformance-audit-report.ts` + `scripts/apps-playwright-tools-diff.mjs`. Python would introduce a third runtime alongside bash + TS + Go without solving anything bash/TS can't.

## Risk / blast radius

- New CI gate on every PR (~20s for npm install + vitest + render + git diff). Mirrors check-conformance-stale; same risk profile.
- The renderer fetches the umbrella body via `gh` CLI, which needs `GH_TOKEN`. CI uses `secrets.GITHUB_TOKEN` (read-only to the repo) — the gate fails closed if the token is missing.
- The umbrella body is rendered into the markdown verbatim (preserves inline `code` / PR refs). A maintainer could insert hostile markdown in the umbrella, which would land on the public site. Acceptable risk: only maintainers can edit the umbrella, and we already render `CAPABILITIES.md` / `CONFORMANCE.md` through the same `renderMarkdownFile` directive with the same trust model.

## Before / after

`conformance/apps/COMPAT.md` (generated):

```
# Apps Compat — mcpkit ⇄ ext-apps

## Coverage
| Metric | Count |
| Total upstream examples | 25 |
| Drift-strict parity (OK) | 21 |
| Pass rate over implemented | 21 / 21 (100%) |

## Per-fixture status
| # | Fixture | Status | Detail |
| 1 | basic-server-vanillajs | ✅ OK | 2/2 pass against mcpkit-local baseline. Resolution: PR 534 |
...
| 14 | pdf-server | ✅ OK | 2/2 pass + drift strict OK (4 tools — ... deferred to follow-up issue 554. PR 555) |
| 25 | wiki-explorer-server | ✅ OK | 2/2 pass + drift strict OK via new OutputSchemaOverride (...) |
```

`make docs-site-build` renders it at `/conformance/apps/compat/` with the rest of the nav.

## Refs

- Closes issue 541
- Source umbrella: issue 533
- Pattern this follows: tools/conformance-report (issue 498) + UPSTREAM_AUDIT.md / FIXTURE_AUDIT.md
