### PR TITLE
ext/skills: core types + SKILL.md frontmatter parser (557, 558)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,9 @@ test-auth: ## Run auth sub-module tests
 test-ui: ## Run UI extension sub-module tests
 	cd ext/ui && $(MAKE) test
 
+test-skills: ## Run skills extension sub-module tests (SEP-2640, experimental)
+	cd ext/skills && go test ./... -count=1 -timeout 30s
+
 build-bridge: ## Compile mcp-app-bridge.ts → .js (delegates to ext/ui)
 	cd ext/ui && $(MAKE) build-bridge
 
@@ -461,5 +464,5 @@ setup: setup-tools setup-hooks ## Full development setup
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-18s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: build test test-race test-v cover cover-html cover-func cover-all test-auth test-ui test-protogen test-e2e test-experimental test-apps-playwright test-apps-playwright-docker demo-app inspect-app testkcl testkcl-auto testall test-report smoke testconfall testconf testconfauth testconf-tasks testconf-tasks-v2 testconf-mrtr testconf-file-inputs testconf-auth-server testconf-elicitation refresh-conformance check-conformance-stale refresh-apps-compat-report check-apps-compat-stale vet lint vulncheck seccheck secrets verify-submodule-deps audit ci ci-full serve serve-streamable serve-both tidy tidy-all bump-root docs-site-build docs-site-serve docs-site-deploy tag tag-push setup-tools setup-hooks setup upkcl downkcl kcllogs build-bridge help
+.PHONY: build test test-race test-v cover cover-html cover-func cover-all test-auth test-ui test-skills test-protogen test-e2e test-experimental test-apps-playwright test-apps-playwright-docker demo-app inspect-app testkcl testkcl-auto testall test-report smoke testconfall testconf testconfauth testconf-tasks testconf-tasks-v2 testconf-mrtr testconf-file-inputs testconf-auth-server testconf-elicitation refresh-conformance check-conformance-stale refresh-apps-compat-report check-apps-compat-stale vet lint vulncheck seccheck secrets verify-submodule-deps audit ci ci-full serve serve-streamable serve-both tidy tidy-all bump-root docs-site-build docs-site-serve docs-site-deploy tag tag-push setup-tools setup-hooks setup upkcl downkcl kcllogs build-bridge help
 .DEFAULT_GOAL := help

--- a/ext/skills/doc.go
+++ b/ext/skills/doc.go
@@ -1,0 +1,58 @@
+// Package skills implements the Skills Extension binding for MCP (SEP-2640).
+//
+// Experimental: SEP-2640 is a Draft Extensions Track SEP. Its surface, URI
+// grammar, index shape, and capability identifier may change while the
+// Skills Over MCP Working Group iterates. This package tracks the current
+// draft and breaking changes are expected on pre-1.0 tags. Pin to a
+// specific version if you need stability.
+//
+// The extension defines a convention for serving Agent Skills over MCP
+// using the existing Resources primitive. A skill is a directory containing
+// a SKILL.md file at its root, addressed by the skill:// URI scheme. Files
+// inside a skill are exposed as ordinary MCP resources; clients read them
+// with resources/read and resolve relative references against the skill's
+// root.
+//
+// This package provides the value types (Index, IndexEntry, Frontmatter,
+// Metadata), the skill:// URI parser, and the SKILL.md frontmatter parser.
+// Higher-level affordances (provider, index generator, archives, client
+// helpers) live in sibling files in this package.
+//
+// See: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640
+package skills
+
+// ExperimentalNotice is a human-readable string examples and CLIs MAY emit
+// to stderr on startup to signal that the package implements a Draft SEP.
+const ExperimentalNotice = "ext/skills tracks Draft SEP-2640; the surface may change on pre-1.0 tags."
+
+// ExtensionID is the SEP-2133 extension identifier declared by servers in
+// their initialize response under capabilities.extensions.
+const ExtensionID = "io.modelcontextprotocol/skills"
+
+// Scheme is the URI scheme reserved for skill resources.
+const Scheme = "skill"
+
+// ManifestFilename is the required filename at the root of every skill.
+const ManifestFilename = "SKILL.md"
+
+// IndexPath is the well-known URI at which a server SHOULD expose its
+// discovery index. The full URI is skill://index.json.
+const IndexPath = "index.json"
+
+// IndexURI is the full well-known URI for the discovery index.
+const IndexURI = "skill://index.json"
+
+// IndexSchemaURI is the JSON schema version URI the SEP currently pins to.
+// Servers populate Index.Schema with this value; clients SHOULD compare
+// against a known set before processing the rest of the document.
+const IndexSchemaURI = "https://schemas.agentskills.io/discovery/0.2.0/schema.json"
+
+// MetaPrefix is the reverse-domain prefix recommended by the SEP for any
+// SKILL.md frontmatter fields surfaced through a resource's _meta object.
+const MetaPrefix = "io.modelcontextprotocol.skills/"
+
+// ArchiveTarGz is the file suffix for gzip-compressed tar archive entries.
+const ArchiveTarGz = ".tar.gz"
+
+// ArchiveZip is the file suffix for zip archive entries.
+const ArchiveZip = ".zip"

--- a/ext/skills/errors.go
+++ b/ext/skills/errors.go
@@ -1,0 +1,73 @@
+package skills
+
+import "errors"
+
+// URI parsing errors.
+var (
+	// ErrInvalidScheme is returned when a URI's scheme is not "skill".
+	ErrInvalidScheme = errors.New("skills: scheme must be skill://")
+
+	// ErrEmptySkillPath is returned when a skill:// URI has no path
+	// segments at all (e.g., "skill://").
+	ErrEmptySkillPath = errors.New("skills: empty skill path")
+
+	// ErrEmptySkillName is returned when the final segment of the skill
+	// path is empty (e.g., "skill://foo//SKILL.md").
+	ErrEmptySkillName = errors.New("skills: empty skill name")
+
+	// ErrInvalidSkillName is returned when the final segment of the skill
+	// path violates the Agent Skills naming rules (lowercase letters,
+	// digits, hyphens).
+	ErrInvalidSkillName = errors.New("skills: invalid skill name")
+
+	// ErrManifestNotInRoot is returned when a SKILL.md appears anywhere
+	// other than the immediate root of a skill. SEP-2640 forbids nested
+	// skills.
+	ErrManifestNotInRoot = errors.New("skills: SKILL.md must be at skill root")
+
+	// ErrEmptyPathSegment is returned when a URI contains an empty path
+	// segment (consecutive slashes).
+	ErrEmptyPathSegment = errors.New("skills: empty path segment")
+
+	// ErrRelativeEscapesSkill is returned by ResolveRelative when the
+	// resolved file path would escape the skill's root using "..".
+	ErrRelativeEscapesSkill = errors.New("skills: relative reference escapes skill root")
+
+	// ErrNotManifestURI is returned when an operation requires a manifest
+	// URI (ending in /SKILL.md) but received a different shape.
+	ErrNotManifestURI = errors.New("skills: not a SKILL.md URI")
+)
+
+// Index validation errors.
+var (
+	ErrIndexMissingSchema           = errors.New("skills: index missing $schema")
+	ErrUnknownSkillType             = errors.New("skills: unknown skill type")
+	ErrIndexEntryMissingDescription = errors.New("skills: index entry missing description")
+	ErrIndexEntryMissingURL         = errors.New("skills: index entry missing url")
+	ErrIndexEntryMissingName        = errors.New("skills: index entry missing name")
+	ErrIndexEntryMissingDigest      = errors.New("skills: index entry missing digest")
+)
+
+// Frontmatter parsing errors.
+var (
+	// ErrMissingFrontmatter is returned when a SKILL.md does not begin with
+	// a "---" YAML delimiter.
+	ErrMissingFrontmatter = errors.New("skills: missing YAML frontmatter")
+
+	// ErrUnterminatedFrontmatter is returned when a SKILL.md opens with
+	// "---" but never closes it.
+	ErrUnterminatedFrontmatter = errors.New("skills: unterminated YAML frontmatter")
+
+	// ErrNonMappingFrontmatter is returned when the frontmatter parses as
+	// YAML but the top-level value is not a mapping (e.g., a list or
+	// scalar).
+	ErrNonMappingFrontmatter = errors.New("skills: frontmatter must be a YAML mapping")
+
+	// ErrFrontmatterMissingName is returned when the frontmatter parses but
+	// has no non-empty name field.
+	ErrFrontmatterMissingName = errors.New("skills: frontmatter missing required field: name")
+
+	// ErrFrontmatterMissingDescription is returned when the frontmatter
+	// parses but has no non-empty description field.
+	ErrFrontmatterMissingDescription = errors.New("skills: frontmatter missing required field: description")
+)

--- a/ext/skills/frontmatter.go
+++ b/ext/skills/frontmatter.go
@@ -1,0 +1,179 @@
+package skills
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"gopkg.in/yaml.v3"
+)
+
+// frontmatterDelimiter is the YAML front-matter fence per the Agent Skills
+// specification. SEP-2640 delegates the format to that spec.
+var frontmatterDelimiter = []byte("---")
+
+// utf8BOM is the UTF-8 byte-order mark. Some editors (notably Windows
+// Notepad) prepend it; the parser strips it before scanning.
+var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
+
+// ParseFrontmatter parses the YAML front-matter block at the head of a
+// SKILL.md document and returns the parsed Frontmatter together with the
+// remaining body bytes.
+//
+// Behavior:
+//   - A leading UTF-8 BOM is stripped before scanning.
+//   - CRLF line endings are normalized to LF.
+//   - The document MUST begin with a line containing exactly "---"
+//     (ErrMissingFrontmatter otherwise).
+//   - The block MUST be terminated by another line containing exactly "---"
+//     (ErrUnterminatedFrontmatter otherwise).
+//   - The YAML between the delimiters MUST decode to a mapping
+//     (ErrNonMappingFrontmatter otherwise).
+//   - The mapping MUST contain non-empty name and description fields
+//     (ErrFrontmatterMissingName / ErrFrontmatterMissingDescription).
+//
+// The returned body bytes are everything after the closing delimiter line
+// (including the trailing newline that follows it, if any). The body is
+// returned verbatim so callers can republish it without re-encoding.
+func ParseFrontmatter(src []byte) (Frontmatter, []byte, error) {
+	src = bytes.TrimPrefix(src, utf8BOM)
+	src = bytes.ReplaceAll(src, []byte("\r\n"), []byte("\n"))
+	src = bytes.ReplaceAll(src, []byte("\r"), []byte("\n"))
+
+	open, openEnd, ok := matchDelimiter(src, 0)
+	if !ok || open != 0 {
+		return Frontmatter{}, nil, ErrMissingFrontmatter
+	}
+
+	close, closeEnd, ok := matchDelimiter(src, openEnd)
+	if !ok {
+		return Frontmatter{}, nil, ErrUnterminatedFrontmatter
+	}
+
+	yamlBytes := src[openEnd:close]
+
+	var node yaml.Node
+	if err := yaml.Unmarshal(yamlBytes, &node); err != nil {
+		return Frontmatter{}, nil, fmt.Errorf("skills: invalid YAML frontmatter: %w", err)
+	}
+	mapping, err := mappingFrom(&node)
+	if err != nil {
+		return Frontmatter{}, nil, err
+	}
+
+	fm := Frontmatter{Extra: map[string]any{}}
+	for i := 0; i < len(mapping.Content); i += 2 {
+		k := mapping.Content[i]
+		v := mapping.Content[i+1]
+		if k.Kind != yaml.ScalarNode {
+			continue
+		}
+		switch k.Value {
+		case "name":
+			if v.Kind == yaml.ScalarNode {
+				fm.Name = v.Value
+			}
+		case "description":
+			if v.Kind == yaml.ScalarNode {
+				fm.Description = v.Value
+			}
+		default:
+			var x any
+			if err := v.Decode(&x); err != nil {
+				return Frontmatter{}, nil, fmt.Errorf("skills: invalid YAML value for %q: %w", k.Value, err)
+			}
+			fm.Extra[k.Value] = x
+		}
+	}
+
+	if fm.Name == "" {
+		return Frontmatter{}, nil, ErrFrontmatterMissingName
+	}
+	if fm.Description == "" {
+		return Frontmatter{}, nil, ErrFrontmatterMissingDescription
+	}
+
+	body := src[closeEnd:]
+	// Strip at most one leading newline that follows the closing delimiter.
+	// The closing delimiter line ends in a newline that's part of the
+	// fence, not the body; the user-authored body conventionally starts on
+	// the next line.
+	body = bytes.TrimPrefix(body, []byte("\n"))
+	return fm, body, nil
+}
+
+// ParseFrontmatterReader streams from r and delegates to ParseFrontmatter.
+// SKILL.md files are small in practice, so this buffers fully.
+func ParseFrontmatterReader(r io.Reader) (Frontmatter, []byte, error) {
+	src, err := io.ReadAll(r)
+	if err != nil {
+		return Frontmatter{}, nil, fmt.Errorf("skills: read SKILL.md: %w", err)
+	}
+	return ParseFrontmatter(src)
+}
+
+// matchDelimiter searches for a YAML "---" fence line starting at or after
+// offset. A fence line consists of exactly the three dashes followed by
+// either end-of-input or a newline. Trailing whitespace before the newline
+// is accepted (some editors add it). Returns (lineStart, postNewline, true)
+// on match, where lineStart points at the first dash and postNewline points
+// at the byte after the consumed newline (or len(src) if at EOF).
+func matchDelimiter(src []byte, offset int) (int, int, bool) {
+	for offset <= len(src) {
+		// Find next position which is start-of-line.
+		lineStart := offset
+		// Identify the end of this line.
+		newline := bytes.IndexByte(src[lineStart:], '\n')
+		var lineEnd, postNewline int
+		if newline < 0 {
+			lineEnd = len(src)
+			postNewline = lineEnd
+		} else {
+			lineEnd = lineStart + newline
+			postNewline = lineEnd + 1
+		}
+		line := src[lineStart:lineEnd]
+		// Strip trailing whitespace from the line so editors that pad with
+		// spaces still match.
+		line = bytes.TrimRight(line, " \t")
+		if bytes.Equal(line, frontmatterDelimiter) {
+			return lineStart, postNewline, true
+		}
+		// Only the FIRST line is a candidate for the opening fence; for
+		// the closing fence we must scan subsequent lines. We do this by
+		// advancing offset past this line and continuing. But callers ask
+		// for "first match at or after offset" — for the opening fence,
+		// they pass offset=0 and we'll either match line 1 or not match at
+		// all (any subsequent match is not the opening fence). The early
+		// return on non-equal handles this:
+		if offset == 0 {
+			return 0, 0, false
+		}
+		if newline < 0 {
+			return 0, 0, false
+		}
+		offset = postNewline
+	}
+	return 0, 0, false
+}
+
+// mappingFrom returns the underlying mapping node of a parsed YAML
+// document. yaml.Unmarshal into a *yaml.Node wraps the document in a
+// DocumentNode containing a single content node; we descend through that.
+// Returns ErrNonMappingFrontmatter if the structure does not resolve to a
+// mapping.
+func mappingFrom(node *yaml.Node) (*yaml.Node, error) {
+	if node == nil {
+		return nil, ErrNonMappingFrontmatter
+	}
+	if node.Kind == yaml.DocumentNode {
+		if len(node.Content) == 0 {
+			return nil, ErrNonMappingFrontmatter
+		}
+		return mappingFrom(node.Content[0])
+	}
+	if node.Kind != yaml.MappingNode {
+		return nil, ErrNonMappingFrontmatter
+	}
+	return node, nil
+}

--- a/ext/skills/frontmatter_test.go
+++ b/ext/skills/frontmatter_test.go
@@ -1,0 +1,224 @@
+package skills_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/panyam/mcpkit/ext/skills"
+)
+
+// gitWorkflowSkillMD is the sample shape used by SEP-2640 examples and the
+// experimental-ext-skills reference repo: minimal name + description plus
+// a markdown body.
+const gitWorkflowSkillMD = `---
+name: git-workflow
+description: Follow this team's Git conventions for branching and commits
+---
+
+# Git Workflow
+
+Use feature branches off main.
+`
+
+func TestParseFrontmatter_GoodCase(t *testing.T) {
+	fm, body, err := skills.ParseFrontmatter([]byte(gitWorkflowSkillMD))
+	if err != nil {
+		t.Fatalf("ParseFrontmatter: %v", err)
+	}
+	if fm.Name != "git-workflow" {
+		t.Errorf("Name = %q", fm.Name)
+	}
+	if fm.Description != "Follow this team's Git conventions for branching and commits" {
+		t.Errorf("Description = %q", fm.Description)
+	}
+	if len(fm.Extra) != 0 {
+		t.Errorf("Extra = %v, want empty", fm.Extra)
+	}
+	if !strings.HasPrefix(string(body), "# Git Workflow") {
+		t.Errorf("body should start with the H1, got %q", string(body))
+	}
+}
+
+func TestParseFrontmatter_BOM(t *testing.T) {
+	withBOM := append([]byte{0xEF, 0xBB, 0xBF}, []byte(gitWorkflowSkillMD)...)
+	fm, _, err := skills.ParseFrontmatter(withBOM)
+	if err != nil {
+		t.Fatalf("ParseFrontmatter with BOM: %v", err)
+	}
+	if fm.Name != "git-workflow" {
+		t.Errorf("Name = %q", fm.Name)
+	}
+}
+
+func TestParseFrontmatter_CRLF(t *testing.T) {
+	crlf := strings.ReplaceAll(gitWorkflowSkillMD, "\n", "\r\n")
+	fm, body, err := skills.ParseFrontmatter([]byte(crlf))
+	if err != nil {
+		t.Fatalf("ParseFrontmatter CRLF: %v", err)
+	}
+	if fm.Name != "git-workflow" {
+		t.Errorf("Name = %q", fm.Name)
+	}
+	if strings.Contains(string(body), "\r") {
+		t.Errorf("body still contains CR characters")
+	}
+}
+
+func TestParseFrontmatter_CRonly(t *testing.T) {
+	crOnly := strings.ReplaceAll(gitWorkflowSkillMD, "\n", "\r")
+	fm, _, err := skills.ParseFrontmatter([]byte(crOnly))
+	if err != nil {
+		t.Fatalf("ParseFrontmatter CR-only: %v", err)
+	}
+	if fm.Name != "git-workflow" {
+		t.Errorf("Name = %q", fm.Name)
+	}
+}
+
+func TestParseFrontmatter_ExtraFields(t *testing.T) {
+	src := `---
+name: refunds
+description: Process refund requests
+version: 1.2
+tags:
+  - billing
+  - finance
+allowed-tools:
+  - mcp__crm__create_refund
+---
+
+body
+`
+	fm, body, err := skills.ParseFrontmatter([]byte(src))
+	if err != nil {
+		t.Fatalf("ParseFrontmatter: %v", err)
+	}
+	if fm.Name != "refunds" {
+		t.Errorf("Name = %q", fm.Name)
+	}
+	if fm.Description != "Process refund requests" {
+		t.Errorf("Description = %q", fm.Description)
+	}
+	if v, ok := fm.Extra["version"]; !ok || v != 1.2 {
+		t.Errorf("Extra[version] = %v (%T)", v, v)
+	}
+	if v, ok := fm.Extra["tags"].([]any); !ok || len(v) != 2 || v[0] != "billing" {
+		t.Errorf("Extra[tags] = %v", fm.Extra["tags"])
+	}
+	if _, ok := fm.Extra["allowed-tools"]; !ok {
+		t.Errorf("Extra missing allowed-tools")
+	}
+	if !strings.HasPrefix(string(body), "body") {
+		t.Errorf("body = %q", string(body))
+	}
+}
+
+func TestParseFrontmatter_EmptyBody(t *testing.T) {
+	src := `---
+name: empty
+description: This skill has no body
+---
+`
+	fm, body, err := skills.ParseFrontmatter([]byte(src))
+	if err != nil {
+		t.Fatalf("ParseFrontmatter: %v", err)
+	}
+	if fm.Name != "empty" {
+		t.Errorf("Name = %q", fm.Name)
+	}
+	if len(body) != 0 {
+		t.Errorf("body = %q, want empty", string(body))
+	}
+}
+
+func TestParseFrontmatter_Errors(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want error
+	}{
+		{
+			name: "missing opening fence",
+			src:  "# No frontmatter here\n",
+			want: skills.ErrMissingFrontmatter,
+		},
+		{
+			name: "empty input",
+			src:  "",
+			want: skills.ErrMissingFrontmatter,
+		},
+		{
+			name: "unterminated frontmatter",
+			src:  "---\nname: x\ndescription: y\n# body without closing fence\n",
+			want: skills.ErrUnterminatedFrontmatter,
+		},
+		{
+			name: "list frontmatter",
+			src:  "---\n- a\n- b\n---\nbody\n",
+			want: skills.ErrNonMappingFrontmatter,
+		},
+		{
+			name: "scalar frontmatter",
+			src:  "---\nfoo\n---\nbody\n",
+			want: skills.ErrNonMappingFrontmatter,
+		},
+		{
+			name: "missing name",
+			src:  "---\ndescription: x\n---\nbody\n",
+			want: skills.ErrFrontmatterMissingName,
+		},
+		{
+			name: "missing description",
+			src:  "---\nname: x\n---\nbody\n",
+			want: skills.ErrFrontmatterMissingDescription,
+		},
+		{
+			name: "empty name",
+			src:  "---\nname: ''\ndescription: x\n---\nbody\n",
+			want: skills.ErrFrontmatterMissingName,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := skills.ParseFrontmatter([]byte(tc.src))
+			if !errors.Is(err, tc.want) {
+				t.Errorf("err = %v, want %v", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseFrontmatterReader(t *testing.T) {
+	fm, body, err := skills.ParseFrontmatterReader(strings.NewReader(gitWorkflowSkillMD))
+	if err != nil {
+		t.Fatalf("ParseFrontmatterReader: %v", err)
+	}
+	if fm.Name != "git-workflow" {
+		t.Errorf("Name = %q", fm.Name)
+	}
+	if len(body) == 0 {
+		t.Errorf("body should not be empty")
+	}
+}
+
+func TestParseFrontmatter_NullFrontmatter(t *testing.T) {
+	// An "empty" frontmatter block ("---\n---\n") decodes to a YAML null,
+	// which is not a mapping.
+	src := "---\n---\nbody\n"
+	_, _, err := skills.ParseFrontmatter([]byte(src))
+	if !errors.Is(err, skills.ErrNonMappingFrontmatter) {
+		t.Errorf("err = %v, want ErrNonMappingFrontmatter", err)
+	}
+}
+
+func TestParseFrontmatter_DelimiterWithTrailingSpaces(t *testing.T) {
+	src := "---  \nname: x\ndescription: y\n---\t\nbody\n"
+	fm, _, err := skills.ParseFrontmatter([]byte(src))
+	if err != nil {
+		t.Fatalf("ParseFrontmatter: %v", err)
+	}
+	if fm.Name != "x" {
+		t.Errorf("Name = %q", fm.Name)
+	}
+}

--- a/ext/skills/go.mod
+++ b/ext/skills/go.mod
@@ -1,0 +1,5 @@
+module github.com/panyam/mcpkit/ext/skills
+
+go 1.26.3
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/ext/skills/go.sum
+++ b/ext/skills/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/ext/skills/types.go
+++ b/ext/skills/types.go
@@ -1,0 +1,162 @@
+package skills
+
+import "fmt"
+
+// SkillType is the discriminator for an entry in skill://index.json.
+type SkillType string
+
+const (
+	// SkillTypeSkillMD points at an individual SKILL.md resource. Supporting
+	// files are siblings under the same skill path.
+	SkillTypeSkillMD SkillType = "skill-md"
+
+	// SkillTypeArchive points at a packed skill directory served as a single
+	// resource. The archive's URL suffix (.tar.gz or .zip) determines the
+	// expected format.
+	SkillTypeArchive SkillType = "archive"
+
+	// SkillTypeResourceTemplate describes a parameterized skill namespace as
+	// an RFC 6570 URI template. Hosts surface these as interactive discovery
+	// points, not as concrete skills.
+	SkillTypeResourceTemplate SkillType = "mcp-resource-template"
+)
+
+// Valid reports whether t is one of the SkillType values defined by SEP-2640.
+func (t SkillType) Valid() bool {
+	switch t {
+	case SkillTypeSkillMD, SkillTypeArchive, SkillTypeResourceTemplate:
+		return true
+	}
+	return false
+}
+
+// HasManifestFields reports whether entries of this type carry a Name and
+// Digest. The mcp-resource-template type omits both because no concrete
+// SKILL.md is materialized at index time.
+func (t SkillType) HasManifestFields() bool {
+	return t == SkillTypeSkillMD || t == SkillTypeArchive
+}
+
+// IndexEntry is a single skill entry in a server's skill://index.json.
+//
+// Per SEP-2640, Name and Digest are required for the skill-md and archive
+// types and omitted for mcp-resource-template. The JSON encoding uses
+// omitempty so unmarshalled documents round-trip cleanly when those fields
+// are absent.
+type IndexEntry struct {
+	Type        SkillType `json:"type"`
+	Name        string    `json:"name,omitempty"`
+	Description string    `json:"description"`
+	URL         string    `json:"url"`
+	Digest      string    `json:"digest,omitempty"`
+}
+
+// Validate checks the per-type field requirements from SEP-2640's index
+// table. It does not check digest format (use ValidateDigest separately)
+// or that URL is well-formed (use ParseURI).
+func (e IndexEntry) Validate() error {
+	if !e.Type.Valid() {
+		return fmt.Errorf("%w: %q", ErrUnknownSkillType, e.Type)
+	}
+	if e.Description == "" {
+		return ErrIndexEntryMissingDescription
+	}
+	if e.URL == "" {
+		return ErrIndexEntryMissingURL
+	}
+	if e.Type.HasManifestFields() {
+		if e.Name == "" {
+			return ErrIndexEntryMissingName
+		}
+		if e.Digest == "" {
+			return ErrIndexEntryMissingDigest
+		}
+	}
+	return nil
+}
+
+// Index is the document served at the well-known IndexURI.
+type Index struct {
+	Schema string       `json:"$schema"`
+	Skills []IndexEntry `json:"skills"`
+}
+
+// NewIndex returns an Index pre-populated with the schema URI defined by
+// IndexSchemaURI.
+func NewIndex(entries ...IndexEntry) Index {
+	return Index{Schema: IndexSchemaURI, Skills: entries}
+}
+
+// Validate checks every entry and the top-level shape. It is intended for
+// servers preparing an index for publication; clients receiving an index
+// SHOULD skip entries with unrecognized types rather than reject the
+// document, so they MAY validate individually.
+func (i Index) Validate() error {
+	if i.Schema == "" {
+		return ErrIndexMissingSchema
+	}
+	for n, e := range i.Skills {
+		if err := e.Validate(); err != nil {
+			return fmt.Errorf("skills[%d]: %w", n, err)
+		}
+	}
+	return nil
+}
+
+// Frontmatter is the YAML block at the head of a SKILL.md file.
+//
+// SEP-2640 requires only Name and Description; the Agent Skills
+// specification (delegated to by the SEP) may require additional fields,
+// and individual servers MAY surface arbitrary fields via the resource's
+// _meta object. Extra captures anything the parser sees beyond Name and
+// Description so callers can inspect or republish without losing data.
+type Frontmatter struct {
+	Name        string         `yaml:"name"`
+	Description string         `yaml:"description"`
+	Extra       map[string]any `yaml:"-"`
+}
+
+// Get returns the value of a frontmatter field by key. Name and Description
+// are looked up directly; everything else falls through to Extra.
+func (f Frontmatter) Get(key string) (any, bool) {
+	switch key {
+	case "name":
+		if f.Name == "" {
+			return nil, false
+		}
+		return f.Name, true
+	case "description":
+		if f.Description == "" {
+			return nil, false
+		}
+		return f.Description, true
+	}
+	if f.Extra == nil {
+		return nil, false
+	}
+	v, ok := f.Extra[key]
+	return v, ok
+}
+
+// Metadata is the host-side view of a skill, populated from its SKILL.md
+// frontmatter plus the URI it was loaded from. It is what a SkillProvider
+// surfaces to higher layers and what a client receives from helpers like
+// ListSkills.
+type Metadata struct {
+	Name        string
+	Description string
+	Extra       map[string]any
+	SourceURI   string
+}
+
+// MetadataFromFrontmatter constructs a Metadata from a parsed Frontmatter
+// and the URI of the SKILL.md it was loaded from.
+func MetadataFromFrontmatter(fm Frontmatter, sourceURI string) Metadata {
+	return Metadata{
+		Name:        fm.Name,
+		Description: fm.Description,
+		Extra:       fm.Extra,
+		SourceURI:   sourceURI,
+	}
+}
+

--- a/ext/skills/types_test.go
+++ b/ext/skills/types_test.go
@@ -1,0 +1,278 @@
+package skills_test
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/panyam/mcpkit/ext/skills"
+)
+
+// sepExampleIndex is the JSON example from SEP-2640's "Enumeration via
+// skill://index.json" section. Round-tripping it ensures our struct tags,
+// type discriminator, and omitempty rules match the spec example exactly.
+const sepExampleIndex = `{
+  "$schema": "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+  "skills": [
+    {
+      "name": "git-workflow",
+      "type": "skill-md",
+      "description": "Follow this team's Git conventions for branching and commits",
+      "url": "skill://git-workflow/SKILL.md",
+      "digest": "sha256:a1b2c3d4..."
+    },
+    {
+      "name": "refunds",
+      "type": "skill-md",
+      "description": "Process customer refund requests per company policy",
+      "url": "skill://acme/billing/refunds/SKILL.md",
+      "digest": "sha256:b2c3d4e5..."
+    },
+    {
+      "name": "pdf-processing",
+      "type": "archive",
+      "description": "Extract, fill, and assemble PDF documents",
+      "url": "skill://pdf-processing.tar.gz",
+      "digest": "sha256:c4d5e6f7..."
+    },
+    {
+      "type": "mcp-resource-template",
+      "description": "Per-product documentation skill",
+      "url": "skill://docs/{product}/SKILL.md"
+    }
+  ]
+}`
+
+func TestIndex_UnmarshalSEPExample(t *testing.T) {
+	var idx skills.Index
+	if err := json.Unmarshal([]byte(sepExampleIndex), &idx); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if idx.Schema != skills.IndexSchemaURI {
+		t.Errorf("Schema = %q, want %q", idx.Schema, skills.IndexSchemaURI)
+	}
+	if len(idx.Skills) != 4 {
+		t.Fatalf("Skills count = %d, want 4", len(idx.Skills))
+	}
+
+	// Verify each entry's type-specific shape.
+	want := []struct {
+		typ    skills.SkillType
+		name   string
+		url    string
+		hasDig bool
+	}{
+		{skills.SkillTypeSkillMD, "git-workflow", "skill://git-workflow/SKILL.md", true},
+		{skills.SkillTypeSkillMD, "refunds", "skill://acme/billing/refunds/SKILL.md", true},
+		{skills.SkillTypeArchive, "pdf-processing", "skill://pdf-processing.tar.gz", true},
+		{skills.SkillTypeResourceTemplate, "", "skill://docs/{product}/SKILL.md", false},
+	}
+	for i, w := range want {
+		got := idx.Skills[i]
+		if got.Type != w.typ {
+			t.Errorf("skills[%d].Type = %q, want %q", i, got.Type, w.typ)
+		}
+		if got.Name != w.name {
+			t.Errorf("skills[%d].Name = %q, want %q", i, got.Name, w.name)
+		}
+		if got.URL != w.url {
+			t.Errorf("skills[%d].URL = %q, want %q", i, got.URL, w.url)
+		}
+		if w.hasDig && !strings.HasPrefix(got.Digest, "sha256:") {
+			t.Errorf("skills[%d].Digest = %q, want sha256:... prefix", i, got.Digest)
+		}
+		if !w.hasDig && got.Digest != "" {
+			t.Errorf("skills[%d].Digest = %q, want empty for type %q", i, got.Digest, w.typ)
+		}
+	}
+}
+
+func TestIndexEntry_RoundTrip(t *testing.T) {
+	// Each entry should round-trip JSON → struct → JSON with all fields
+	// preserved, including the conditional name/digest behavior.
+	var orig skills.Index
+	if err := json.Unmarshal([]byte(sepExampleIndex), &orig); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	encoded, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var second skills.Index
+	if err := json.Unmarshal(encoded, &second); err != nil {
+		t.Fatalf("Re-unmarshal: %v", err)
+	}
+	if len(second.Skills) != len(orig.Skills) {
+		t.Fatalf("round-trip lost entries: %d → %d", len(orig.Skills), len(second.Skills))
+	}
+	for i := range orig.Skills {
+		if orig.Skills[i] != second.Skills[i] {
+			t.Errorf("entry %d: round-trip mismatch\n  orig = %#v\n  new  = %#v", i, orig.Skills[i], second.Skills[i])
+		}
+	}
+
+	// The mcp-resource-template entry must encode without name or digest
+	// keys (omitempty in practice). Re-encode it individually to assert.
+	tmpl := orig.Skills[3]
+	if tmpl.Type != skills.SkillTypeResourceTemplate {
+		t.Fatalf("test fixture drift: expected template at index 3, got %q", tmpl.Type)
+	}
+	tplBytes, err := json.Marshal(tmpl)
+	if err != nil {
+		t.Fatalf("Marshal template: %v", err)
+	}
+	if strings.Contains(string(tplBytes), `"name"`) {
+		t.Errorf("template entry should omit name: %s", tplBytes)
+	}
+	if strings.Contains(string(tplBytes), `"digest"`) {
+		t.Errorf("template entry should omit digest: %s", tplBytes)
+	}
+}
+
+func TestIndexEntry_Validate(t *testing.T) {
+	cases := []struct {
+		name  string
+		entry skills.IndexEntry
+		want  error
+	}{
+		{
+			name: "valid skill-md",
+			entry: skills.IndexEntry{
+				Type:        skills.SkillTypeSkillMD,
+				Name:        "git-workflow",
+				Description: "git stuff",
+				URL:         "skill://git-workflow/SKILL.md",
+				Digest:      "sha256:abc",
+			},
+		},
+		{
+			name: "valid archive",
+			entry: skills.IndexEntry{
+				Type:        skills.SkillTypeArchive,
+				Name:        "pdf-processing",
+				Description: "pdfs",
+				URL:         "skill://pdf-processing.tar.gz",
+				Digest:      "sha256:def",
+			},
+		},
+		{
+			name: "valid template",
+			entry: skills.IndexEntry{
+				Type:        skills.SkillTypeResourceTemplate,
+				Description: "per-product docs",
+				URL:         "skill://docs/{product}/SKILL.md",
+			},
+		},
+		{
+			name:  "unknown type",
+			entry: skills.IndexEntry{Type: "garbage", Description: "x", URL: "y"},
+			want:  skills.ErrUnknownSkillType,
+		},
+		{
+			name:  "skill-md missing name",
+			entry: skills.IndexEntry{Type: skills.SkillTypeSkillMD, Description: "x", URL: "y", Digest: "sha256:1"},
+			want:  skills.ErrIndexEntryMissingName,
+		},
+		{
+			name:  "skill-md missing digest",
+			entry: skills.IndexEntry{Type: skills.SkillTypeSkillMD, Name: "n", Description: "x", URL: "y"},
+			want:  skills.ErrIndexEntryMissingDigest,
+		},
+		{
+			name:  "missing description",
+			entry: skills.IndexEntry{Type: skills.SkillTypeSkillMD, Name: "n", URL: "y", Digest: "sha256:1"},
+			want:  skills.ErrIndexEntryMissingDescription,
+		},
+		{
+			name:  "missing url",
+			entry: skills.IndexEntry{Type: skills.SkillTypeSkillMD, Name: "n", Description: "x", Digest: "sha256:1"},
+			want:  skills.ErrIndexEntryMissingURL,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.entry.Validate()
+			if tc.want == nil {
+				if err != nil {
+					t.Errorf("Validate err = %v, want nil", err)
+				}
+				return
+			}
+			if !errors.Is(err, tc.want) {
+				t.Errorf("Validate err = %v, want %v", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestIndex_Validate(t *testing.T) {
+	idx := skills.NewIndex(skills.IndexEntry{
+		Type:        skills.SkillTypeSkillMD,
+		Name:        "git-workflow",
+		Description: "x",
+		URL:         "skill://git-workflow/SKILL.md",
+		Digest:      "sha256:abc",
+	})
+	if err := idx.Validate(); err != nil {
+		t.Errorf("Validate good index err = %v", err)
+	}
+
+	bad := skills.Index{} // missing schema
+	if err := bad.Validate(); !errors.Is(err, skills.ErrIndexMissingSchema) {
+		t.Errorf("Validate empty index err = %v, want ErrIndexMissingSchema", err)
+	}
+}
+
+func TestSkillType(t *testing.T) {
+	if !skills.SkillTypeSkillMD.Valid() {
+		t.Error("skill-md should be valid")
+	}
+	if !skills.SkillTypeArchive.HasManifestFields() {
+		t.Error("archive should have manifest fields")
+	}
+	if skills.SkillTypeResourceTemplate.HasManifestFields() {
+		t.Error("template should not have manifest fields")
+	}
+	if skills.SkillType("nope").Valid() {
+		t.Error("garbage value should not validate")
+	}
+}
+
+func TestFrontmatter_Get(t *testing.T) {
+	fm := skills.Frontmatter{
+		Name:        "git-workflow",
+		Description: "follow git",
+		Extra:       map[string]any{"version": "1.0", "tags": []string{"git"}},
+	}
+	v, ok := fm.Get("name")
+	if !ok || v != "git-workflow" {
+		t.Errorf("Get(name) = %v, %v", v, ok)
+	}
+	v, ok = fm.Get("description")
+	if !ok || v != "follow git" {
+		t.Errorf("Get(description) = %v, %v", v, ok)
+	}
+	v, ok = fm.Get("version")
+	if !ok || v != "1.0" {
+		t.Errorf("Get(version) = %v, %v", v, ok)
+	}
+	_, ok = fm.Get("missing")
+	if ok {
+		t.Errorf("Get(missing) should report not found")
+	}
+}
+
+func TestMetadataFromFrontmatter(t *testing.T) {
+	fm := skills.Frontmatter{Name: "n", Description: "d", Extra: map[string]any{"x": 1}}
+	m := skills.MetadataFromFrontmatter(fm, "skill://x/SKILL.md")
+	if m.Name != "n" || m.Description != "d" {
+		t.Errorf("Metadata copy lost fields: %#v", m)
+	}
+	if m.SourceURI != "skill://x/SKILL.md" {
+		t.Errorf("SourceURI = %q", m.SourceURI)
+	}
+	if m.Extra["x"] != 1 {
+		t.Errorf("Extra not copied: %#v", m.Extra)
+	}
+}

--- a/ext/skills/uri.go
+++ b/ext/skills/uri.go
@@ -3,7 +3,6 @@ package skills
 import (
 	"fmt"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -292,20 +291,28 @@ func ValidateSkillName(name string) error {
 //
 // SEP-2640 specifies that relative references within a skill resolve like
 // filesystem paths against the skill's root directory (the directory
-// containing SKILL.md). A SKILL.md URI is treated as identifying that root
-// for resolution purposes, exactly as a filesystem path to SKILL.md does.
+// containing SKILL.md). Resolution delegates to RFC 3986 reference
+// resolution via net/url, then checks the result stays inside the skill's
+// scope.
 //
 // Behavior:
 //   - skillRoot must have SkillPath populated (typically a manifest URI
 //     produced by ParseURI). ResolveRelative returns ErrNotManifestURI if
 //     not.
-//   - rel may use "/" as the separator, ".", and ".." segments. Empty
-//     segments (e.g., trailing "/") are rejected.
-//   - Resolution that escapes the skill root via ".." returns
-//     ErrRelativeEscapesSkill. References to "." or "" stay within scope.
-//   - The result reuses skillRoot.SkillPath; FilePath holds the resolved
-//     file path segments. IsManifest is set if the resolution lands on
-//     SKILL.md.
+//   - rel is a relative reference per RFC 3986. Dot-segment normalization
+//     (". ", "..") is delegated to the stdlib resolver.
+//   - References that carry their own scheme or authority, an absolute path,
+//     or an empty path are rejected before resolution because RFC 3986
+//     would let any of them short-circuit out of the skill scope.
+//   - After resolution, the result MUST still start with
+//     skillRoot.SkillPath. Otherwise the reference escaped (e.g., excess
+//     ".." segments) and ErrRelativeEscapesSkill is returned.
+//   - A resolved URI whose final segment is SKILL.md at a deeper position
+//     than the skill root is rejected with ErrManifestNotInRoot because
+//     SEP-2640 forbids skill nesting.
+//   - The result reuses skillRoot.SkillPath. FilePath holds the resolved
+//     file path segments. IsManifest is set when the resolution lands on
+//     the skill's own SKILL.md (the idempotent case).
 func ResolveRelative(skillRoot URIParts, rel string) (URIParts, error) {
 	if len(skillRoot.SkillPath) == 0 {
 		return URIParts{}, ErrNotManifestURI
@@ -314,44 +321,79 @@ func ResolveRelative(skillRoot URIParts, rel string) (URIParts, error) {
 		return URIParts{}, fmt.Errorf("%w: empty relative reference", ErrEmptyPathSegment)
 	}
 
-	// path.Clean handles . and .. resolution. We normalize the input first
-	// and reject absolute references (those are not "relative").
-	if strings.HasPrefix(rel, "/") {
+	base, err := url.Parse(skillRoot.ManifestURI())
+	if err != nil {
+		return URIParts{}, fmt.Errorf("skills: re-parse skill root: %w", err)
+	}
+	ref, err := url.Parse(rel)
+	if err != nil {
+		return URIParts{}, fmt.Errorf("%w: invalid reference %q: %v", ErrInvalidScheme, rel, err)
+	}
+	// RFC 3986 reference resolution honors a reference's scheme or
+	// authority and treats an absolute path as overriding. All three would
+	// silently short-circuit out of the skill scope, so reject them before
+	// handing off to ResolveReference.
+	if ref.Scheme != "" || ref.Host != "" {
+		return URIParts{}, fmt.Errorf("%w: reference carries its own scheme or authority %q", ErrRelativeEscapesSkill, rel)
+	}
+	if strings.HasPrefix(ref.Path, "/") {
 		return URIParts{}, fmt.Errorf("%w: absolute path %q", ErrRelativeEscapesSkill, rel)
 	}
-	cleaned := path.Clean(rel)
-	if cleaned == "." {
-		return URIParts{}, fmt.Errorf("%w: resolves to skill root", ErrEmptyPathSegment)
+	if ref.Path == "" {
+		return URIParts{}, fmt.Errorf("%w: empty relative reference", ErrEmptyPathSegment)
 	}
-	if cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+
+	resolved := base.ResolveReference(ref)
+
+	// Re-parse the resolved URI through ParseURI so it inherits the
+	// canonical segment shape, percent decoding, and the
+	// no-nested-SKILL.md rule that ParseURI already enforces on the URI
+	// string. Any error from ParseURI propagates with its named sentinel.
+	parsed, err := ParseURI(resolved.String())
+	if err != nil {
+		return URIParts{}, err
+	}
+
+	// RFC 3986 dot-segment removal silently collapses excess ".."
+	// segments against the path root, producing a URI that no longer
+	// starts with skillRoot.SkillPath. The prefix check below is the
+	// canonical escape detector.
+	if !hasPrefixSegments(parsed.AllSegments, skillRoot.SkillPath) {
 		return URIParts{}, fmt.Errorf("%w: %q", ErrRelativeEscapesSkill, rel)
 	}
 
-	segments := strings.Split(cleaned, "/")
-	for i, seg := range segments {
-		if seg == "" {
-			return URIParts{}, fmt.Errorf("%w: at index %d", ErrEmptyPathSegment, i)
-		}
-		// SKILL.md only valid if it's the sole resolved segment AND happens
-		// to be the manifest itself, which is a no-op (already at root).
-		// Per SEP-2640, a SKILL.md anywhere descendant is forbidden.
-		if seg == ManifestFilename && !(len(segments) == 1) {
-			return URIParts{}, ErrManifestNotInRoot
-		}
+	// Resolution landed back on the skill root directory itself (e.g.,
+	// rel normalized to no path segments). Treat as a caller mistake.
+	if len(parsed.AllSegments) == len(skillRoot.SkillPath) {
+		return URIParts{}, fmt.Errorf("%w: resolves to skill root", ErrEmptyPathSegment)
 	}
 
-	skillCopy := append([]string(nil), skillRoot.SkillPath...)
-	allSegs := append(skillCopy, segments...)
+	// ParseURI treats any terminal SKILL.md as a manifest URI. After
+	// resolution, a manifest deeper than the original skill root means the
+	// reference pointed at a nested skill, which SEP-2640 forbids. The
+	// idempotent case (resolving back to the same manifest) is allowed.
+	if parsed.IsManifest && len(parsed.SkillPath) > len(skillRoot.SkillPath) {
+		return URIParts{}, fmt.Errorf("%w: nested SKILL.md in resolved path", ErrManifestNotInRoot)
+	}
 
-	return URIParts{
-		Scheme:      Scheme,
-		AllSegments: allSegs,
-		SkillPath:   skillCopy,
-		FilePath:    segments,
-		SkillName:   skillRoot.SkillName,
-		IsManifest:  len(segments) == 1 && segments[0] == ManifestFilename,
-		Raw:         "",
-	}, nil
+	// Re-split at the original skill boundary so the result reflects this
+	// skill's identity rather than whatever ParseURI inferred from the
+	// terminal segment.
+	return parsed.SplitAt(len(skillRoot.SkillPath))
+}
+
+// hasPrefixSegments reports whether segs begins with prefix, segment by
+// segment.
+func hasPrefixSegments(segs, prefix []string) bool {
+	if len(segs) < len(prefix) {
+		return false
+	}
+	for i, p := range prefix {
+		if segs[i] != p {
+			return false
+		}
+	}
+	return true
 }
 
 // IsIndexURI reports whether s is the reserved skill://index.json URI.

--- a/ext/skills/uri.go
+++ b/ext/skills/uri.go
@@ -1,0 +1,346 @@
+package skills
+
+import (
+	"fmt"
+	"net/url"
+	"path"
+	"strings"
+)
+
+// URIParts is a parsed skill:// URI.
+//
+// SEP-2640 splits a skill URI into a skill path (locating the skill directory
+// within the server's namespace) and a file path (the file inside the skill).
+// For manifest URIs (ending in /SKILL.md) the boundary is uniquely determined
+// by the SKILL.md suffix and ParseURI sets SkillPath, FilePath, SkillName,
+// and IsManifest accordingly. For non-manifest URIs the boundary is not
+// recoverable from the URI alone; ParseURI returns the parsed segments in
+// AllSegments and leaves SkillPath/FilePath empty. Callers establish the
+// boundary via SplitAt (when the skill path is known from the index or a
+// prior manifest read) or via ResolveRelative (when computing a sibling URI
+// from a known skill root).
+type URIParts struct {
+	// Scheme is always "skill" for URIs that pass ParseURI's validation.
+	Scheme string
+
+	// Raw is the original URI string ParseURI was called with.
+	Raw string
+
+	// AllSegments is the canonical segment view: the authority component
+	// followed by the path component, decoded and split on "/". Empty
+	// segments cause a parse error rather than appearing in the slice.
+	AllSegments []string
+
+	// SkillPath is the skill directory path. Populated for manifest URIs;
+	// empty for non-manifest URIs parsed standalone.
+	SkillPath []string
+
+	// FilePath is the file path within the skill. Populated for manifest
+	// URIs (always ["SKILL.md"]) and after a successful SplitAt or
+	// ResolveRelative; empty otherwise.
+	FilePath []string
+
+	// SkillName is the final segment of SkillPath, equal to the skill's
+	// frontmatter name per SEP-2640. Empty when SkillPath is unset.
+	SkillName string
+
+	// IsManifest is true when FilePath equals exactly ["SKILL.md"].
+	IsManifest bool
+}
+
+// ParseURI parses a skill:// URI into a URIParts.
+//
+// Validation rules:
+//   - Scheme must be exactly "skill" (ErrInvalidScheme otherwise).
+//   - At least one path segment is required (ErrEmptySkillPath).
+//   - No segment may be empty, e.g. from consecutive slashes
+//     (ErrEmptyPathSegment).
+//   - SKILL.md, when present, MUST be the final segment of the URI; it MUST
+//     NOT appear at any non-terminal position (ErrManifestNotInRoot).
+//   - For manifest URIs the final skill-path segment (i.e. the segment just
+//     before SKILL.md) MUST be a valid Agent Skills name: lowercase letters,
+//     digits, and hyphens, neither leading nor trailing hyphen
+//     (ErrInvalidSkillName / ErrEmptySkillName).
+//
+// ParseURI does not require a manifest URI. Non-manifest URIs validate
+// scheme, segments, and the no-nested-SKILL.md rule, but SkillPath and
+// FilePath are left empty (see URIParts).
+func ParseURI(s string) (URIParts, error) {
+	if s == "" {
+		return URIParts{}, fmt.Errorf("%w: empty URI", ErrInvalidScheme)
+	}
+
+	u, err := url.Parse(s)
+	if err != nil {
+		return URIParts{}, fmt.Errorf("%w: %v", ErrInvalidScheme, err)
+	}
+	if u.Scheme != Scheme {
+		return URIParts{}, fmt.Errorf("%w: got %q", ErrInvalidScheme, u.Scheme)
+	}
+
+	segments, err := splitURIPath(u)
+	if err != nil {
+		return URIParts{}, err
+	}
+	if len(segments) == 0 {
+		return URIParts{}, ErrEmptySkillPath
+	}
+
+	// SEP-2640: no SKILL.md may appear in a descendant directory. We allow
+	// a single SKILL.md at the terminal position; any other position is a
+	// nesting violation.
+	for i, seg := range segments[:len(segments)-1] {
+		if seg == ManifestFilename {
+			return URIParts{}, fmt.Errorf("%w: SKILL.md at segment %d", ErrManifestNotInRoot, i)
+		}
+	}
+
+	out := URIParts{
+		Scheme:      u.Scheme,
+		Raw:         s,
+		AllSegments: segments,
+	}
+
+	if segments[len(segments)-1] == ManifestFilename {
+		// Manifest URI: split before the trailing SKILL.md.
+		if len(segments) < 2 {
+			return URIParts{}, ErrEmptySkillPath
+		}
+		out.SkillPath = segments[:len(segments)-1]
+		out.FilePath = []string{ManifestFilename}
+		out.IsManifest = true
+		name := out.SkillPath[len(out.SkillPath)-1]
+		if err := ValidateSkillName(name); err != nil {
+			return URIParts{}, err
+		}
+		out.SkillName = name
+	}
+
+	return out, nil
+}
+
+// splitURIPath joins authority + path into a single decoded segment list.
+// RFC 3986 places the first <skill-path> segment in the authority component
+// when the URI has the "skill://" form; the remainder lives in the path.
+// Both contribute to the SEP-2640 skill path.
+func splitURIPath(u *url.URL) ([]string, error) {
+	var segs []string
+	if u.Host != "" {
+		host, err := url.PathUnescape(u.Host)
+		if err != nil {
+			return nil, fmt.Errorf("%w: invalid host: %v", ErrInvalidScheme, err)
+		}
+		segs = append(segs, host)
+	}
+	p := u.Path
+	p = strings.TrimPrefix(p, "/")
+	if p == "" {
+		return segs, nil
+	}
+	parts := strings.Split(p, "/")
+	for i, seg := range parts {
+		// Trailing slash produces a trailing empty segment; treat as
+		// terminator rather than empty segment.
+		if seg == "" && i == len(parts)-1 {
+			continue
+		}
+		if seg == "" {
+			return nil, fmt.Errorf("%w: at index %d", ErrEmptyPathSegment, len(segs))
+		}
+		decoded, err := url.PathUnescape(seg)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %v", ErrInvalidScheme, err)
+		}
+		segs = append(segs, decoded)
+	}
+	return segs, nil
+}
+
+// SplitAt returns a copy of p with the skill/file boundary set after n
+// segments. The first n segments become SkillPath, the remainder become
+// FilePath. This is the explicit-boundary form callers use when the skill
+// path is known from an index entry or a prior manifest read.
+//
+// SplitAt validates that:
+//   - n is in range [1, len(AllSegments)],
+//   - the segment at position n-1 is a valid skill name,
+//   - no SKILL.md appears in FilePath at a non-root position (only allowed
+//     when FilePath is exactly ["SKILL.md"]).
+func (p URIParts) SplitAt(n int) (URIParts, error) {
+	if n < 1 || n > len(p.AllSegments) {
+		return URIParts{}, fmt.Errorf("%w: SplitAt n=%d, segments=%d", ErrEmptySkillPath, n, len(p.AllSegments))
+	}
+	skillPath := append([]string(nil), p.AllSegments[:n]...)
+	filePath := append([]string(nil), p.AllSegments[n:]...)
+	name := skillPath[len(skillPath)-1]
+	if err := ValidateSkillName(name); err != nil {
+		return URIParts{}, err
+	}
+	// SKILL.md only valid as the sole file-path segment.
+	for i, seg := range filePath {
+		if seg == ManifestFilename && !(len(filePath) == 1 && i == 0) {
+			return URIParts{}, fmt.Errorf("%w: SKILL.md inside skill", ErrManifestNotInRoot)
+		}
+	}
+	out := URIParts{
+		Scheme:      p.Scheme,
+		Raw:         p.Raw,
+		AllSegments: p.AllSegments,
+		SkillPath:   skillPath,
+		FilePath:    filePath,
+		SkillName:   name,
+		IsManifest:  len(filePath) == 1 && filePath[0] == ManifestFilename,
+	}
+	return out, nil
+}
+
+// SkillRootURI returns the URI of the skill's root directory (the URI
+// obtained by stripping the trailing SKILL.md, with a trailing slash).
+// Returns the empty string if SkillPath is not populated.
+func (p URIParts) SkillRootURI() string {
+	if len(p.SkillPath) == 0 {
+		return ""
+	}
+	return Scheme + "://" + strings.Join(escapeSegments(p.SkillPath), "/") + "/"
+}
+
+// ManifestURI returns the URI of the skill's SKILL.md. Returns the empty
+// string if SkillPath is not populated.
+func (p URIParts) ManifestURI() string {
+	if len(p.SkillPath) == 0 {
+		return ""
+	}
+	return Scheme + "://" + strings.Join(escapeSegments(p.SkillPath), "/") + "/" + ManifestFilename
+}
+
+// String reconstructs the URI from the parsed segments. If FilePath is
+// populated it joins SkillPath + FilePath; otherwise it falls back to
+// AllSegments. The result is canonical, with each segment percent-encoded
+// per RFC 3986.
+func (p URIParts) String() string {
+	if len(p.SkillPath) > 0 {
+		root := strings.Join(escapeSegments(p.SkillPath), "/")
+		if len(p.FilePath) == 0 {
+			return Scheme + "://" + root + "/"
+		}
+		return Scheme + "://" + root + "/" + strings.Join(escapeSegments(p.FilePath), "/")
+	}
+	if len(p.AllSegments) > 0 {
+		return Scheme + "://" + strings.Join(escapeSegments(p.AllSegments), "/")
+	}
+	return p.Raw
+}
+
+func escapeSegments(in []string) []string {
+	out := make([]string, len(in))
+	for i, s := range in {
+		out[i] = url.PathEscape(s)
+	}
+	return out
+}
+
+// ValidateSkillName checks that name satisfies the Agent Skills naming
+// rules: 1+ characters, lowercase letters / digits / hyphens, no leading or
+// trailing hyphen, no consecutive hyphens.
+//
+// The SEP delegates the format to the Agent Skills specification but states
+// that names cannot collide with the reserved well-known path "index.json"
+// because "." is not permitted.
+func ValidateSkillName(name string) error {
+	if name == "" {
+		return ErrEmptySkillName
+	}
+	if name[0] == '-' || name[len(name)-1] == '-' {
+		return fmt.Errorf("%w: %q", ErrInvalidSkillName, name)
+	}
+	prevHyphen := false
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z':
+			prevHyphen = false
+		case r >= '0' && r <= '9':
+			prevHyphen = false
+		case r == '-':
+			if prevHyphen {
+				return fmt.Errorf("%w: consecutive hyphens in %q", ErrInvalidSkillName, name)
+			}
+			prevHyphen = true
+		default:
+			return fmt.Errorf("%w: %q", ErrInvalidSkillName, name)
+		}
+	}
+	return nil
+}
+
+// ResolveRelative resolves a relative file reference against a known skill
+// root URI, returning a fully-populated URIParts for the referenced file.
+//
+// SEP-2640 specifies that relative references within a skill resolve like
+// filesystem paths against the skill's root directory (the directory
+// containing SKILL.md). A SKILL.md URI is treated as identifying that root
+// for resolution purposes, exactly as a filesystem path to SKILL.md does.
+//
+// Behavior:
+//   - skillRoot must have SkillPath populated (typically a manifest URI
+//     produced by ParseURI). ResolveRelative returns ErrNotManifestURI if
+//     not.
+//   - rel may use "/" as the separator, ".", and ".." segments. Empty
+//     segments (e.g., trailing "/") are rejected.
+//   - Resolution that escapes the skill root via ".." returns
+//     ErrRelativeEscapesSkill. References to "." or "" stay within scope.
+//   - The result reuses skillRoot.SkillPath; FilePath holds the resolved
+//     file path segments. IsManifest is set if the resolution lands on
+//     SKILL.md.
+func ResolveRelative(skillRoot URIParts, rel string) (URIParts, error) {
+	if len(skillRoot.SkillPath) == 0 {
+		return URIParts{}, ErrNotManifestURI
+	}
+	if rel == "" {
+		return URIParts{}, fmt.Errorf("%w: empty relative reference", ErrEmptyPathSegment)
+	}
+
+	// path.Clean handles . and .. resolution. We normalize the input first
+	// and reject absolute references (those are not "relative").
+	if strings.HasPrefix(rel, "/") {
+		return URIParts{}, fmt.Errorf("%w: absolute path %q", ErrRelativeEscapesSkill, rel)
+	}
+	cleaned := path.Clean(rel)
+	if cleaned == "." {
+		return URIParts{}, fmt.Errorf("%w: resolves to skill root", ErrEmptyPathSegment)
+	}
+	if cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return URIParts{}, fmt.Errorf("%w: %q", ErrRelativeEscapesSkill, rel)
+	}
+
+	segments := strings.Split(cleaned, "/")
+	for i, seg := range segments {
+		if seg == "" {
+			return URIParts{}, fmt.Errorf("%w: at index %d", ErrEmptyPathSegment, i)
+		}
+		// SKILL.md only valid if it's the sole resolved segment AND happens
+		// to be the manifest itself, which is a no-op (already at root).
+		// Per SEP-2640, a SKILL.md anywhere descendant is forbidden.
+		if seg == ManifestFilename && !(len(segments) == 1) {
+			return URIParts{}, ErrManifestNotInRoot
+		}
+	}
+
+	skillCopy := append([]string(nil), skillRoot.SkillPath...)
+	allSegs := append(skillCopy, segments...)
+
+	return URIParts{
+		Scheme:      Scheme,
+		AllSegments: allSegs,
+		SkillPath:   skillCopy,
+		FilePath:    segments,
+		SkillName:   skillRoot.SkillName,
+		IsManifest:  len(segments) == 1 && segments[0] == ManifestFilename,
+		Raw:         "",
+	}, nil
+}
+
+// IsIndexURI reports whether s is the reserved skill://index.json URI.
+// The check is exact-match per SEP-2640's reservation rule.
+func IsIndexURI(s string) bool {
+	return s == IndexURI
+}

--- a/ext/skills/uri.go
+++ b/ext/skills/uri.go
@@ -9,16 +9,31 @@ import (
 
 // URIParts is a parsed skill:// URI.
 //
-// SEP-2640 splits a skill URI into a skill path (locating the skill directory
-// within the server's namespace) and a file path (the file inside the skill).
-// For manifest URIs (ending in /SKILL.md) the boundary is uniquely determined
-// by the SKILL.md suffix and ParseURI sets SkillPath, FilePath, SkillName,
-// and IsManifest accordingly. For non-manifest URIs the boundary is not
-// recoverable from the URI alone; ParseURI returns the parsed segments in
-// AllSegments and leaves SkillPath/FilePath empty. Callers establish the
-// boundary via SplitAt (when the skill path is known from the index or a
-// prior manifest read) or via ResolveRelative (when computing a sibling URI
-// from a known skill root).
+// SEP-2640 splits a skill URI into a skill path (locating the skill
+// directory within the server's namespace) and a file path (the file inside
+// the skill). For manifest URIs ending in /SKILL.md the boundary is fixed
+// by the SKILL.md suffix, and ParseURI sets SkillPath, FilePath, SkillName,
+// and IsManifest from it.
+//
+// For non-manifest URIs the boundary cannot be recovered from the URI
+// alone. SEP-2640's claim that "the skill name is always recoverable from
+// the URI alone, without reading frontmatter" is grounded in two
+// manifest-URI examples where SKILL.md acts as the boundary. The spec also
+// allows prefix segments to be any RFC 3986 path segment with no further
+// constraint, so a prefix segment and an intermediate file-path segment
+// share the same character class. In
+// skill://acme/billing/refunds/templates/email.md the segments refunds,
+// templates, billing, and acme all satisfy the Agent Skills name rules,
+// and a URI-only scan cannot pick refunds over templates without external
+// knowledge from the discovery index or a prior manifest read. SEP-2640's
+// host workflow always supplies that knowledge, so the spec's claim holds
+// operationally even though the URI string in isolation is ambiguous.
+//
+// ParseURI therefore returns parsed segments in AllSegments and leaves
+// SkillPath, FilePath, SkillName, and IsManifest unset for non-manifest
+// URIs. Callers establish the boundary by calling SplitAt(n) when the
+// skill path length is known from an index entry or a prior manifest read,
+// or by calling ResolveRelative from a known skill root.
 type URIParts struct {
 	// Scheme is always "skill" for URIs that pass ParseURI's validation.
 	Scheme string

--- a/ext/skills/uri_test.go
+++ b/ext/skills/uri_test.go
@@ -260,6 +260,66 @@ func TestResolveRelative_Absolute(t *testing.T) {
 	}
 }
 
+func TestResolveRelative_IdempotentManifest(t *testing.T) {
+	// Resolving "SKILL.md" from the manifest URI itself is a no-op that
+	// lands back on the same SKILL.md. Allowed by SEP-2640 (no nesting
+	// happens) and exercised here so the deeper-SKILL.md check does not
+	// over-reject.
+	root, err := skills.ParseURI("skill://acme/billing/refunds/SKILL.md")
+	if err != nil {
+		t.Fatalf("ParseURI: %v", err)
+	}
+	got, err := skills.ResolveRelative(root, "SKILL.md")
+	if err != nil {
+		t.Fatalf("ResolveRelative(SKILL.md): %v", err)
+	}
+	if !got.IsManifest {
+		t.Errorf("IsManifest = false, want true")
+	}
+	if got.String() != "skill://acme/billing/refunds/SKILL.md" {
+		t.Errorf("String() = %q", got.String())
+	}
+}
+
+func TestResolveRelative_RejectsResolveToRoot(t *testing.T) {
+	// "." and "./" resolve back to the skill root directory with no file
+	// referenced. The caller almost certainly has a bug; reject rather
+	// than silently return an empty FilePath.
+	root, err := skills.ParseURI("skill://git-workflow/SKILL.md")
+	if err != nil {
+		t.Fatalf("ParseURI: %v", err)
+	}
+	for _, rel := range []string{".", "./", "references/.."} {
+		t.Run(rel, func(t *testing.T) {
+			_, err := skills.ResolveRelative(root, rel)
+			if !errors.Is(err, skills.ErrEmptyPathSegment) {
+				t.Errorf("ResolveRelative(%q) err = %v, want ErrEmptyPathSegment", rel, err)
+			}
+		})
+	}
+}
+
+func TestResolveRelative_RejectsCrossOrigin(t *testing.T) {
+	// A reference that carries its own scheme or authority would
+	// short-circuit RFC 3986 reference resolution to a different origin.
+	root, err := skills.ParseURI("skill://git-workflow/SKILL.md")
+	if err != nil {
+		t.Fatalf("ParseURI: %v", err)
+	}
+	for _, rel := range []string{
+		"https://evil.example.com/payload",
+		"skill://other-skill/SKILL.md",
+		"//other/path",
+	} {
+		t.Run(rel, func(t *testing.T) {
+			_, err := skills.ResolveRelative(root, rel)
+			if !errors.Is(err, skills.ErrRelativeEscapesSkill) {
+				t.Errorf("ResolveRelative(%q) err = %v, want ErrRelativeEscapesSkill", rel, err)
+			}
+		})
+	}
+}
+
 func TestResolveRelative_RejectsNestedManifest(t *testing.T) {
 	root, err := skills.ParseURI("skill://git-workflow/SKILL.md")
 	if err != nil {

--- a/ext/skills/uri_test.go
+++ b/ext/skills/uri_test.go
@@ -1,0 +1,353 @@
+package skills_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/panyam/mcpkit/ext/skills"
+)
+
+func TestParseURI_SEPExamples(t *testing.T) {
+	// Cases drawn from SEP-2640's Examples table (Resource Mapping).
+	cases := []struct {
+		uri        string
+		skillPath  []string
+		filePath   []string
+		skillName  string
+		isManifest bool
+	}{
+		{
+			uri:        "skill://git-workflow/SKILL.md",
+			skillPath:  []string{"git-workflow"},
+			filePath:   []string{"SKILL.md"},
+			skillName:  "git-workflow",
+			isManifest: true,
+		},
+		{
+			uri:        "skill://acme/billing/refunds/SKILL.md",
+			skillPath:  []string{"acme", "billing", "refunds"},
+			filePath:   []string{"SKILL.md"},
+			skillName:  "refunds",
+			isManifest: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.uri, func(t *testing.T) {
+			parts, err := skills.ParseURI(tc.uri)
+			if err != nil {
+				t.Fatalf("ParseURI(%q) error: %v", tc.uri, err)
+			}
+			if !equalSlices(parts.SkillPath, tc.skillPath) {
+				t.Errorf("SkillPath = %v, want %v", parts.SkillPath, tc.skillPath)
+			}
+			if !equalSlices(parts.FilePath, tc.filePath) {
+				t.Errorf("FilePath = %v, want %v", parts.FilePath, tc.filePath)
+			}
+			if parts.SkillName != tc.skillName {
+				t.Errorf("SkillName = %q, want %q", parts.SkillName, tc.skillName)
+			}
+			if parts.IsManifest != tc.isManifest {
+				t.Errorf("IsManifest = %v, want %v", parts.IsManifest, tc.isManifest)
+			}
+			if parts.Scheme != "skill" {
+				t.Errorf("Scheme = %q, want %q", parts.Scheme, "skill")
+			}
+		})
+	}
+}
+
+func TestParseURI_NonManifest(t *testing.T) {
+	// Non-manifest URIs from the SEP's Examples table. The skill/file
+	// boundary is not recoverable from the URI alone, so SkillPath and
+	// FilePath are left empty. AllSegments carries the parsed segments.
+	cases := []struct {
+		uri      string
+		segments []string
+	}{
+		{
+			uri:      "skill://pdf-processing/references/FORMS.md",
+			segments: []string{"pdf-processing", "references", "FORMS.md"},
+		},
+		{
+			uri:      "skill://pdf-processing/scripts/extract.py",
+			segments: []string{"pdf-processing", "scripts", "extract.py"},
+		},
+		{
+			uri:      "skill://acme/billing/refunds/templates/email.md",
+			segments: []string{"acme", "billing", "refunds", "templates", "email.md"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.uri, func(t *testing.T) {
+			parts, err := skills.ParseURI(tc.uri)
+			if err != nil {
+				t.Fatalf("ParseURI(%q) error: %v", tc.uri, err)
+			}
+			if !equalSlices(parts.AllSegments, tc.segments) {
+				t.Errorf("AllSegments = %v, want %v", parts.AllSegments, tc.segments)
+			}
+			if parts.IsManifest {
+				t.Errorf("IsManifest = true, want false for non-manifest URI")
+			}
+			if len(parts.SkillPath) != 0 || len(parts.FilePath) != 0 {
+				t.Errorf("expected unsplit SkillPath/FilePath, got SkillPath=%v FilePath=%v", parts.SkillPath, parts.FilePath)
+			}
+		})
+	}
+}
+
+func TestParseURI_SplitAt(t *testing.T) {
+	parts, err := skills.ParseURI("skill://acme/billing/refunds/templates/email.md")
+	if err != nil {
+		t.Fatalf("ParseURI: %v", err)
+	}
+	split, err := parts.SplitAt(3) // acme/billing/refunds is the skill path
+	if err != nil {
+		t.Fatalf("SplitAt(3): %v", err)
+	}
+	if !equalSlices(split.SkillPath, []string{"acme", "billing", "refunds"}) {
+		t.Errorf("SkillPath after SplitAt = %v", split.SkillPath)
+	}
+	if !equalSlices(split.FilePath, []string{"templates", "email.md"}) {
+		t.Errorf("FilePath after SplitAt = %v", split.FilePath)
+	}
+	if split.SkillName != "refunds" {
+		t.Errorf("SkillName after SplitAt = %q", split.SkillName)
+	}
+	if split.IsManifest {
+		t.Errorf("IsManifest = true, want false")
+	}
+}
+
+func TestParseURI_SplitAt_Manifest(t *testing.T) {
+	parts, err := skills.ParseURI("skill://acme/billing/refunds/SKILL.md")
+	if err != nil {
+		t.Fatalf("ParseURI: %v", err)
+	}
+	// Already determined by ParseURI; SplitAt with the same boundary
+	// should reproduce the same shape.
+	split, err := parts.SplitAt(3)
+	if err != nil {
+		t.Fatalf("SplitAt(3): %v", err)
+	}
+	if !split.IsManifest {
+		t.Errorf("IsManifest = false, want true")
+	}
+}
+
+func TestParseURI_Errors(t *testing.T) {
+	cases := []struct {
+		name string
+		uri  string
+		want error
+	}{
+		{"empty", "", skills.ErrInvalidScheme},
+		{"wrong scheme", "https://example.com/skill", skills.ErrInvalidScheme},
+		{"http scheme", "http://example.com/x", skills.ErrInvalidScheme},
+		{"no path", "skill://", skills.ErrEmptySkillPath},
+		{"consecutive slashes", "skill://foo//SKILL.md", skills.ErrEmptyPathSegment},
+		{"nested SKILL.md", "skill://outer/SKILL.md/inner/something.md", skills.ErrManifestNotInRoot},
+		{"middle SKILL.md", "skill://outer/inner/SKILL.md/x", skills.ErrManifestNotInRoot},
+		{"uppercase skill name", "skill://Git-Workflow/SKILL.md", skills.ErrInvalidSkillName},
+		{"trailing hyphen", "skill://refunds-/SKILL.md", skills.ErrInvalidSkillName},
+		{"leading hyphen", "skill://-refunds/SKILL.md", skills.ErrInvalidSkillName},
+		{"double hyphen", "skill://re--funds/SKILL.md", skills.ErrInvalidSkillName},
+		{"underscore", "skill://my_skill/SKILL.md", skills.ErrInvalidSkillName},
+		{"only manifest", "skill://SKILL.md", skills.ErrEmptySkillPath},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := skills.ParseURI(tc.uri)
+			if !errors.Is(err, tc.want) {
+				t.Errorf("ParseURI(%q) err = %v, want %v", tc.uri, err, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseURI_TrailingSlash(t *testing.T) {
+	// A trailing slash after the skill path is tolerated; it does not
+	// produce an empty trailing segment.
+	parts, err := skills.ParseURI("skill://git-workflow/")
+	if err != nil {
+		t.Fatalf("ParseURI: %v", err)
+	}
+	if len(parts.AllSegments) != 1 || parts.AllSegments[0] != "git-workflow" {
+		t.Errorf("AllSegments = %v", parts.AllSegments)
+	}
+	if parts.IsManifest {
+		t.Errorf("IsManifest = true, want false for non-manifest URI")
+	}
+}
+
+func TestParseURI_PercentEncoded(t *testing.T) {
+	// Path-component segments may carry percent-encoded characters per
+	// RFC 3986; the parser MUST decode them before exposing them in
+	// AllSegments. (Authority-component percent encoding is more
+	// restricted and is not exercised here.)
+	parts, err := skills.ParseURI("skill://my-skill/folder%20a/file.md")
+	if err != nil {
+		t.Fatalf("ParseURI: %v", err)
+	}
+	want := []string{"my-skill", "folder a", "file.md"}
+	if !equalSlices(parts.AllSegments, want) {
+		t.Errorf("AllSegments = %v, want %v", parts.AllSegments, want)
+	}
+}
+
+func TestResolveRelative(t *testing.T) {
+	root, err := skills.ParseURI("skill://acme/billing/refunds/SKILL.md")
+	if err != nil {
+		t.Fatalf("ParseURI: %v", err)
+	}
+	cases := []struct {
+		rel  string
+		want string
+	}{
+		// SEP-2640 reference: references/GUIDE.md within
+		// skill://acme/billing/refunds resolves to
+		// skill://acme/billing/refunds/references/GUIDE.md.
+		{"references/GUIDE.md", "skill://acme/billing/refunds/references/GUIDE.md"},
+		{"templates/email.md", "skill://acme/billing/refunds/templates/email.md"},
+		{"scripts/extract.py", "skill://acme/billing/refunds/scripts/extract.py"},
+		// path.Clean handles . and ..
+		{"./references/GUIDE.md", "skill://acme/billing/refunds/references/GUIDE.md"},
+		{"references/../references/GUIDE.md", "skill://acme/billing/refunds/references/GUIDE.md"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.rel, func(t *testing.T) {
+			got, err := skills.ResolveRelative(root, tc.rel)
+			if err != nil {
+				t.Fatalf("ResolveRelative(%q): %v", tc.rel, err)
+			}
+			if got.String() != tc.want {
+				t.Errorf("ResolveRelative(%q) = %q, want %q", tc.rel, got.String(), tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveRelative_Escape(t *testing.T) {
+	root, err := skills.ParseURI("skill://acme/billing/refunds/SKILL.md")
+	if err != nil {
+		t.Fatalf("ParseURI: %v", err)
+	}
+	cases := []string{
+		"../GUIDE.md",
+		"../../GUIDE.md",
+		"../../../etc/passwd",
+		"references/../../GUIDE.md",
+	}
+	for _, rel := range cases {
+		t.Run(rel, func(t *testing.T) {
+			_, err := skills.ResolveRelative(root, rel)
+			if !errors.Is(err, skills.ErrRelativeEscapesSkill) {
+				t.Errorf("ResolveRelative(%q) err = %v, want ErrRelativeEscapesSkill", rel, err)
+			}
+		})
+	}
+}
+
+func TestResolveRelative_Absolute(t *testing.T) {
+	root, err := skills.ParseURI("skill://git-workflow/SKILL.md")
+	if err != nil {
+		t.Fatalf("ParseURI: %v", err)
+	}
+	_, err = skills.ResolveRelative(root, "/etc/passwd")
+	if !errors.Is(err, skills.ErrRelativeEscapesSkill) {
+		t.Errorf("ResolveRelative(absolute) err = %v, want ErrRelativeEscapesSkill", err)
+	}
+}
+
+func TestResolveRelative_RejectsNestedManifest(t *testing.T) {
+	root, err := skills.ParseURI("skill://git-workflow/SKILL.md")
+	if err != nil {
+		t.Fatalf("ParseURI: %v", err)
+	}
+	_, err = skills.ResolveRelative(root, "references/SKILL.md")
+	if !errors.Is(err, skills.ErrManifestNotInRoot) {
+		t.Errorf("ResolveRelative(refs/SKILL.md) err = %v, want ErrManifestNotInRoot", err)
+	}
+}
+
+func TestResolveRelative_RequiresKnownSkillRoot(t *testing.T) {
+	// A URIParts produced from a non-manifest URI has no SkillPath set.
+	parts, err := skills.ParseURI("skill://pdf-processing/references/FORMS.md")
+	if err != nil {
+		t.Fatalf("ParseURI: %v", err)
+	}
+	_, err = skills.ResolveRelative(parts, "scripts/extract.py")
+	if !errors.Is(err, skills.ErrNotManifestURI) {
+		t.Errorf("ResolveRelative without skill root err = %v, want ErrNotManifestURI", err)
+	}
+}
+
+func TestURIParts_String(t *testing.T) {
+	parts, err := skills.ParseURI("skill://acme/billing/refunds/SKILL.md")
+	if err != nil {
+		t.Fatalf("ParseURI: %v", err)
+	}
+	if got := parts.String(); got != "skill://acme/billing/refunds/SKILL.md" {
+		t.Errorf("String() = %q", got)
+	}
+	if got := parts.SkillRootURI(); got != "skill://acme/billing/refunds/" {
+		t.Errorf("SkillRootURI() = %q", got)
+	}
+	if got := parts.ManifestURI(); got != "skill://acme/billing/refunds/SKILL.md" {
+		t.Errorf("ManifestURI() = %q", got)
+	}
+}
+
+func TestIsIndexURI(t *testing.T) {
+	if !skills.IsIndexURI("skill://index.json") {
+		t.Errorf("IsIndexURI(skill://index.json) = false, want true")
+	}
+	if skills.IsIndexURI("skill://index.json/") {
+		t.Errorf("trailing slash should not match reserved URI")
+	}
+	if skills.IsIndexURI("skill://other/index.json") {
+		t.Errorf("non-root index.json should not match reserved URI")
+	}
+}
+
+func TestValidateSkillName(t *testing.T) {
+	good := []string{"a", "abc", "git-workflow", "acme-billing-refunds", "h2g2", "a1"}
+	for _, n := range good {
+		if err := skills.ValidateSkillName(n); err != nil {
+			t.Errorf("ValidateSkillName(%q) = %v, want nil", n, err)
+		}
+	}
+	bad := []string{"", "A", "Git", "x_y", "a--b", "-a", "a-", "index.json"}
+	for _, n := range bad {
+		if err := skills.ValidateSkillName(n); err == nil {
+			t.Errorf("ValidateSkillName(%q) = nil, want error", n)
+		}
+	}
+}
+
+func equalSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// Ensure errors.As works on wrapped errors with formatted context.
+func TestErrors_Wrapped(t *testing.T) {
+	_, err := skills.ParseURI("skill://BAD/SKILL.md")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, skills.ErrInvalidSkillName) {
+		t.Errorf("err = %v, want wrapping ErrInvalidSkillName", err)
+	}
+	if !strings.Contains(err.Error(), "BAD") {
+		t.Errorf("err message %q, expected to include offending name", err.Error())
+	}
+}


### PR DESCRIPTION
## Summary

Foundation work for the Skills extension binding (SEP-2640) under `ext/skills/`. Lands the value types, the `skill://` URI parser, and the SKILL.md YAML frontmatter parser as pure-Go modules with no dependencies on the rest of mcpkit. Higher-level provider, index generator, archive support, and client helpers land in follow-up issues (mcpkit 559-568) that build on this scaffolding.

The package tracks a Draft Extensions Track SEP. Its public surface may change on pre-1.0 tags. `ExperimentalNotice` is exposed as a startup banner for examples and CLIs to emit.

## Reviewer's guide

Read in this order:

1. [ext/skills/doc.go](https://github.com/panyam/mcpkit/pull/570/files#diff-f644939880600e922dbd2fc1e830bc0fc1f8cdde432a9093e776e95b10c5fae5) — orient. Extension constants (`ExtensionID`, `Scheme`, `ManifestFilename`, `IndexURI`, `IndexSchemaURI`, `MetaPrefix`, archive suffixes), the experimental banner, and the package framing live here.
2. [ext/skills/uri.go](https://github.com/panyam/mcpkit/pull/570/files#diff-3c138e49263788b31f94f2608b2c8613d0bd084b4f9c9921444e66e2332228ce) — the meat of the PR. `URIParts` + `ParseURI` for the manifest case, `SplitAt` for the known-boundary case, `ResolveRelative` for in-skill reference resolution. Read the doc comment on `URIParts` to understand why non-manifest URIs don't auto-split.
3. [ext/skills/uri_test.go](https://github.com/panyam/mcpkit/pull/570/files#diff-9c80eb7daf89b1b0f148959534c8009deedd140d61add23cabe605f8ccb165c6) — acceptance for the above. Direct table mapping from SEP-2640's Examples table to test cases. Error taxonomy and escape detection live here too.
4. [ext/skills/types.go](https://github.com/panyam/mcpkit/pull/570/files#diff-c6a1fd454bc3289de88115aac3e3eb9bdcf381e5e16ffe515d75048fea08d4b8) — value types. Read after `uri.go` because `IndexEntry.URL` references the URI shape. `IndexEntry.Validate` enforces the SEP's per-type field requirements.
5. [ext/skills/types_test.go](https://github.com/panyam/mcpkit/pull/570/files#diff-7d61581d8a865503b75567c2d69b80d121deba3a85b0f6aeafd4cd824009e364) — round-trips SEP-2640's exact JSON example through `Index` / `IndexEntry` and asserts the `mcp-resource-template` variant omits `name` and `digest` from the encoded bytes.
6. [ext/skills/frontmatter.go](https://github.com/panyam/mcpkit/pull/570/files#diff-4ac35a87561b624a484459491901ab21fcf91517855fe147d80225490e3efabc) — orthogonal but smaller. `ParseFrontmatter` strips BOM, normalizes CRLF/CR, finds the fence, decodes the YAML mapping, and returns the body verbatim.
7. [ext/skills/frontmatter_test.go](https://github.com/panyam/mcpkit/pull/570/files#diff-6e6ba2fac59d49448f7de5ab61bfd436c03764919bbed9b963d9f9cca738f69a) — BOM / CRLF / CR-only / extras / null-frontmatter / missing-fence edge cases.

Skim or skip: [ext/skills/errors.go](https://github.com/panyam/mcpkit/pull/570/files#diff-097721358b725e6ce2ea62d43e0c77494d94644f016803b1fb7b949b957b6bc7) (named-error sentinels, mechanical), [ext/skills/go.mod](https://github.com/panyam/mcpkit/pull/570/files#diff-d6790937489d281f6830648e25af9fa4a3fcccf72f08582ebe470827af43e19f) + [ext/skills/go.sum](https://github.com/panyam/mcpkit/pull/570/files#diff-3e9d16804753366ac4d0bea1ee16df6cf5a3621b27fcaee2c0e359311832f84a) (single dep on `gopkg.in/yaml.v3`), [Makefile](https://github.com/panyam/mcpkit/pull/570/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52) (one-line `test-skills` target).

## What's in

**Tickets:** mcpkit 557 (core types and URI parser), mcpkit 558 (SKILL.md frontmatter parser).

| File | Purpose |
|------|---------|
| `ext/skills/doc.go` | Package doc, extension constants (`ExtensionID`, `Scheme`, `ManifestFilename`, `IndexURI`, `IndexSchemaURI`, `MetaPrefix`, archive suffixes), experimental banner |
| `ext/skills/types.go` | `SkillType`, `IndexEntry`, `Index`, `Frontmatter`, `Metadata`, plus `Validate` per the SEP's index table |
| `ext/skills/uri.go` | `URIParts`, `ParseURI`, `SplitAt`, `ResolveRelative`, `ValidateSkillName`, `IsIndexURI` |
| `ext/skills/errors.go` | Named errors for URI, index, and frontmatter validation |
| `ext/skills/frontmatter.go` | `ParseFrontmatter` / `ParseFrontmatterReader` |
| `ext/skills/{uri,types,frontmatter}_test.go` | 58 sub-tests covering SEP examples and edge cases |
| `Makefile` | New `test-skills` target |
| `ext/skills/go.mod` | New sub-module, single dep on `gopkg.in/yaml.v3` |

## Acceptance criteria

**mcpkit 557 (types + URI):**

- [x] All URI examples from the SEP's Examples table parse correctly. Manifest URIs (`skill://git-workflow/SKILL.md`, `skill://acme/billing/refunds/SKILL.md`) yield full `SkillPath` / `FilePath` / `SkillName` / `IsManifest`. Non-manifest URIs (`skill://pdf-processing/references/FORMS.md`, `skill://pdf-processing/scripts/extract.py`, `skill://acme/billing/refunds/templates/email.md`) parse into `AllSegments` and leave the skill / file boundary for `SplitAt` or `ResolveRelative` (the URI alone cannot identify it).
- [x] Invalid URIs reject with named errors: `ErrInvalidScheme`, `ErrEmptySkillPath`, `ErrEmptyPathSegment`, `ErrEmptySkillName`, `ErrInvalidSkillName`, `ErrManifestNotInRoot`. Each is wrapped with context and tested via `errors.Is`.
- [x] `IndexEntry` round-trips JSON against the SEP's exact example. The `mcp-resource-template` variant omits `name` and `digest` (verified by string assertion on the encoded bytes).
- [x] Edge cases covered: single-segment paths, 3+ segment paths, percent-encoded path segments, trailing slash, empty URIs, percent decoding.
- [x] `ResolveRelative` implements filesystem-style resolution against a known manifest URI. Escapes via `..` reject with `ErrRelativeEscapesSkill`. Absolute paths reject. Nested `SKILL.md` references reject.

**mcpkit 558 (frontmatter parser):**

- [x] Round-trip on a known-good SKILL.md (git-workflow sample shape).
- [x] BOM-prefixed, CRLF-only, CR-only, missing fence, unterminated fence, list / scalar / null top-level frontmatter, missing required fields all produce the expected named error.
- [x] Extra frontmatter fields surface verbatim in `Frontmatter.Extra` as `map[string]any` (covered by a test that includes `version`, `tags`, `allowed-tools`).
- [x] Trailing whitespace on the fence line is tolerated.
- [x] Body bytes returned verbatim post-fence; CRLF normalized in transit.
- [x] `ParseFrontmatterReader` wraps `ParseFrontmatter` for the `io.Reader` form.

## Decision log

- **`URIParts.SplitAt` instead of auto-splitting non-manifest URIs.** A URI like `skill://a/b/c/d.md` is structurally ambiguous: it could mean skill `a` with file `b/c/d.md`, or skill `a/b` with file `c/d.md`, etc. The boundary lives in the server's index or in the SKILL.md frontmatter, not in the URI string. `ParseURI` therefore only auto-splits manifest URIs (where `/SKILL.md` is a hard terminator) and exposes `SplitAt(n)` for callers who learn the boundary from an index lookup. The alternative ("just guess single-segment") would silently misclassify multi-segment skills.
- **`ext/skills/` not `experimental/`.** SEP-2640 is Draft but it's a real Extensions Track SEP with reference implementations landing in the TypeScript and PHP SDKs at the same tier. mcpkit's own `ext/tasks/` (SEP-2663 Draft) lives at `ext/`, so the precedent already exists. `experimental/` in this repo is reserved for pre-SEP exploration (events, protogen). The Draft status is communicated via a banner in `doc.go`, the exported `ExperimentalNotice` constant, and pre-1.0 sub-module versioning.
- **Frontmatter parser takes `[]byte` / `io.Reader`, not `fs.FS`.** Keeps storage out of the parser so it composes with anything that can produce bytes: `os.DirFS`, `embed.FS`, archive-extracted virtual FS, third-party wrappers (e.g., templar's `NewLocalFS` / `NewMemFS` already satisfy `fs.FS`). The `fs.FS` contract lands in mcpkit 559 as the `SkillProvider` input, leaving room for the wrapper-FS pattern that synthesizes frontmatter for non-conforming corporate skill directories without changing the parser.
- **YAML node walk vs. unmarshal-into-map.** Walking the `yaml.Node` tree (rather than unmarshalling into `map[string]any`) lets us (a) make the "must be a mapping" check structural — a YAML list, scalar, or null is rejected at the node-kind level rather than via a post-hoc type assertion on `any`, and (b) preserve typed values in `Extra` (e.g., `version: 1.2` stays a `float64`, `tags:` stays a `[]any`) so callers republishing to `_meta` don't lose type information. The cost is ~20 lines more code than the obvious `map[string]any` shape.

## Risk / blast radius

- **Affects:** new sub-module only. No existing mcpkit package imports `ext/skills`. Zero behavior change for current users until follow-up tickets wire the provider / capability into `server/`.
- **Tests covering this:** 58 sub-tests, ~0.3s. SEP-2640 Examples table mapped directly to `TestParseURI_SEPExamples` / `TestParseURI_NonManifest`. SEP JSON example round-tripped in `TestIndex_UnmarshalSEPExample` / `TestIndexEntry_RoundTrip`.
- **Be paranoid about:**
  - **`ResolveRelative` escape handling.** Resolves host-side URIs from skill content, which is untrusted input per the SEP's Security Implications. `..` intermixed with normal segments (`references/../../foo`), absolute paths (`/etc/passwd`), and `SKILL.md` nested at any depth must all reject. Covered by `TestResolveRelative_Escape` / `_Absolute` / `_RejectsNestedManifest`.
  - **`matchDelimiter` fence detection.** Hand-rolled scanner over the post-normalized byte slice. Trailing whitespace on the fence line is tolerated; the `if offset == 0` short-circuit distinguishes the opening fence from any later `---` line that might appear in the body. The single leading-newline strip after the closing fence is intentional ("body starts on the next line" by convention) — reviewers should confirm this matches the experimental-ext-skills samples.
  - **`IndexEntry` JSON omitempty.** Spec MUST: `mcp-resource-template` entries omit both `name` and `digest`. Verified by string assertion on the encoded bytes (`TestIndexEntry_RoundTrip`). Edge case worth eyeballing: a future caller setting `Type: SkillTypeResourceTemplate` plus a non-empty `Name` would emit a `name` key — currently that's the caller's bug, not the library's, but `Validate()` could be tightened in a follow-up if we want defense-in-depth.
  - **Skill-name rule vs. agentskills.io canonical spec.** `ValidateSkillName` enforces `[a-z0-9-]` with no leading / trailing / consecutive hyphens, derived from the SEP's prose ("skill names may contain only lowercase letters, digits, and hyphens, so `index.json` cannot be a skill name"). The SEP delegates the full naming rules to agentskills.io, which I did not fetch. If the canonical spec is stricter or laxer, this needs alignment before mcpkit 559's provider rejects valid skills (or accepts invalid ones).

## Notes for follow-up tickets

- The frontmatter parser deliberately takes `[]byte` / `io.Reader`, not an `fs.FS`. Provider work in mcpkit 559 will introduce an `fs.FS`-based contract so any backing (`os.DirFS`, `embed.FS`, in-memory, archive-extracted, third-party wrappers) can supply skill content. This also leaves room for a wrapper-FS pattern that synthesizes frontmatter for non-conforming corporate skill directories without changing the parser.
- `URIParts.SplitAt(n)` and `ResolveRelative(skillRoot, rel)` are the two ways callers establish the skill / file boundary on non-manifest URIs. mcpkit 559's `SkillProvider` will use both, and mcpkit 563's client helpers will use `ResolveRelative` for relative reference resolution inside a loaded skill.
- `MetaPrefix` is the reverse-domain prefix the SEP recommends for any frontmatter fields surfaced through a resource's `_meta` object. Provider work will key extras through this prefix.

## Test plan

- [x] `make test-skills` passes locally (58 sub-tests, ~0.3s).
- [x] `go vet ./...` clean inside `ext/skills`.
- [x] `go.sum` tidy (`go mod tidy`).
- [x] Reviewer confirms types match the SEP example shape after rebase.
  - Confirmed 2026-06-03. The `sepExampleIndex` constant in `ext/skills/types_test.go` is byte-identical to the JSON block in `seps/2640-skills-extension.md` at `refs/pull/2640/head` after `jq .` normalization. Verified per-entry conditional fields: `skill-md` and `archive` carry both `name` and `digest`, `mcp-resource-template` omits both. Re-run before merge if the upstream SEP advances:
    ```bash
    awk 'NR==15{sub(/^const sepExampleIndex = `/, "")} NR>=15 && NR<=46{sub(/`$/, ""); print}' \
      ext/skills/types_test.go > /tmp/ours.json
    GH_TOKEN="$GH_PERSONAL_TOKEN" gh api \
      'repos/modelcontextprotocol/modelcontextprotocol/contents/seps/2640-skills-extension.md?ref=refs/pull/2640/head' \
      -H "Accept: application/vnd.github.raw" \
      | awk '/^```json/{flag=1; next} /^```/{if(flag){exit}} flag' > /tmp/sep.json
    diff <(jq . /tmp/ours.json) <(jq . /tmp/sep.json)
    ```


