### PR TITLE
ext/skills: skill://index.json with SHA-256 digests via Indexer (560)

### DIFF
--- a/ext/skills/indexer.go
+++ b/ext/skills/indexer.go
@@ -1,0 +1,271 @@
+package skills
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/server"
+)
+
+// Indexer computes the SEP-2640 discovery index for a Provider's skills,
+// digests each artifact with SHA-256, and exposes the result via
+// resources/read of skill://index.json.
+//
+// The zero value is not useful. Call NewIndexer.
+//
+// Indexer is safe for concurrent use; Index() takes the cache lock
+// internally. The cache invalidates on the first of two events:
+//
+//   - the configured cache TTL elapses, or
+//   - any cataloged skill's SKILL.md mtime differs from its mtime at
+//     cache-build time.
+//
+// When the underlying fs.FS reports a zero ModTime (notably embed.FS),
+// mtime invalidation cannot run for that build and the cache reverts to
+// TTL-only freshness. With TTL also unset (zero), every Index() call
+// recomputes.
+type Indexer struct {
+	provider *Provider
+	cfg      indexerConfig
+
+	mu     sync.Mutex
+	cached *cacheEntry
+}
+
+type indexerConfig struct {
+	ttl time.Duration
+}
+
+type cacheEntry struct {
+	index   Index
+	builtAt time.Time
+	mtimes  map[string]time.Time // skill dir path → SKILL.md mtime at build time
+	// noMtime is true when any skill's SKILL.md reported zero ModTime at
+	// build time. While noMtime is true the cache falls back to TTL-only
+	// invalidation; mtime comparison is skipped.
+	noMtime bool
+}
+
+// IndexerOption configures an Indexer via NewIndexer.
+type IndexerOption func(*indexerConfig)
+
+// WithIndexerCacheTTL sets the duration the indexer caches a computed
+// Index before recomputing. The default (zero) means every Index() call
+// recomputes. Mtime-based invalidation runs in addition to TTL on
+// fs.FS implementations that report a non-zero ModTime.
+func WithIndexerCacheTTL(d time.Duration) IndexerOption {
+	return func(c *indexerConfig) {
+		c.ttl = d
+	}
+}
+
+// NewIndexer constructs an Indexer that draws skills from provider.
+// The provider must already be populated (NewProvider returned without
+// error); subsequent changes to the provider's catalog are not picked
+// up here. Live mutation is the concern of ext/skills issue 564
+// (hot-reload).
+func NewIndexer(provider *Provider, opts ...IndexerOption) *Indexer {
+	idx := &Indexer{provider: provider}
+	for _, opt := range opts {
+		opt(&idx.cfg)
+	}
+	return idx
+}
+
+// IndexResourceDef is the ResourceDef registered for skill://index.json.
+// Servers reuse this for documentation surfaces (READMEs, OpenAPI-style
+// catalogs) so the wire-level name stays in lock-step with the runtime
+// resource.
+var IndexResourceDef = core.ResourceDef{
+	URI:         IndexURI,
+	Name:        "Skill discovery index",
+	Description: "JSON catalog of skills served by this server per SEP-2640.",
+	MimeType:    "application/json",
+}
+
+// Index returns the discovery index per SEP-2640.
+//
+// Each entry's Digest is a sha256:{64-hex} string over the raw bytes of
+// the entry's canonical artifact. For skill-md entries that artifact is
+// the SKILL.md file; archive entries (ext/skills issue 561) will hash the
+// archive bytes instead.
+//
+// The returned Index is the cached value when cache freshness rules
+// allow; otherwise it is freshly computed. Callers should treat the
+// returned Index as immutable. Subsequent calls may return the same
+// underlying slices.
+//
+// Errors propagate the underlying fs.FS read errors with the source
+// path attached.
+func (i *Indexer) Index() (Index, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	if i.isFresh() {
+		return i.cached.index, nil
+	}
+
+	idx, mtimes, noMtime, err := i.build()
+	if err != nil {
+		return Index{}, err
+	}
+	i.cached = &cacheEntry{
+		index:   idx,
+		builtAt: time.Now(),
+		mtimes:  mtimes,
+		noMtime: noMtime,
+	}
+	return idx, nil
+}
+
+func (i *Indexer) isFresh() bool {
+	if i.cached == nil {
+		return false
+	}
+	if i.cfg.ttl > 0 && time.Since(i.cached.builtAt) > i.cfg.ttl {
+		return false
+	}
+	if i.cfg.ttl == 0 && i.cached.noMtime {
+		// Zero TTL plus no mtime signal means we have nothing to drive
+		// invalidation off; recompute every call to avoid serving a
+		// permanently stale index.
+		return false
+	}
+	if i.cached.noMtime {
+		return true
+	}
+	for _, skill := range i.provider.skills {
+		want, ok := i.cached.mtimes[skill.dirPath]
+		if !ok {
+			return false
+		}
+		manifest := manifestPath(skill.dirPath)
+		got, err := mtimeOf(i.provider.cfg.fsys, manifest)
+		if err != nil {
+			return false
+		}
+		if !got.Equal(want) {
+			return false
+		}
+	}
+	return true
+}
+
+func (i *Indexer) build() (Index, map[string]time.Time, bool, error) {
+	entries := make([]IndexEntry, 0, len(i.provider.skills))
+	mtimes := make(map[string]time.Time, len(i.provider.skills))
+	var anyZeroMtime bool
+
+	for _, skill := range i.provider.skills {
+		manifest := manifestPath(skill.dirPath)
+		raw, err := fs.ReadFile(i.provider.cfg.fsys, manifest)
+		if err != nil {
+			return Index{}, nil, false, fmt.Errorf("skills: read %s for digest: %w", manifest, err)
+		}
+		digest := digestOf(raw)
+		entries = append(entries, IndexEntry{
+			Type:        SkillTypeSkillMD,
+			Name:        skill.fm.Name,
+			Description: skill.fm.Description,
+			URL:         skillManifestURI(skill.uriSegs),
+			Digest:      digest,
+		})
+
+		mtime, err := mtimeOf(i.provider.cfg.fsys, manifest)
+		if err != nil {
+			return Index{}, nil, false, fmt.Errorf("skills: stat %s: %w", manifest, err)
+		}
+		if mtime.IsZero() {
+			anyZeroMtime = true
+		}
+		mtimes[skill.dirPath] = mtime
+	}
+
+	sortIndexEntries(entries)
+
+	return NewIndex(entries...), mtimes, anyZeroMtime, nil
+}
+
+// RegisterWith installs the index resource onto srv. The handler calls
+// Index() at request time so the result reflects cache state plus any
+// invalidation since the last call.
+func (i *Indexer) RegisterWith(srv *server.Server) {
+	srv.RegisterResource(IndexResourceDef, i.handler())
+}
+
+func (i *Indexer) handler() core.ResourceHandler {
+	return func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
+		idx, err := i.Index()
+		if err != nil {
+			return core.ResourceResult{}, err
+		}
+		body, err := json.Marshal(idx)
+		if err != nil {
+			return core.ResourceResult{}, fmt.Errorf("skills: marshal index: %w", err)
+		}
+		return core.ResourceResult{
+			Contents: []core.ResourceReadContent{{
+				URI:      IndexURI,
+				MimeType: "application/json",
+				Text:     string(body),
+			}},
+		}, nil
+	}
+}
+
+// digestOf computes the SEP-2640 digest format over the raw artifact
+// bytes: "sha256:" followed by 64 lowercase hex characters.
+func digestOf(b []byte) string {
+	sum := sha256.Sum256(b)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// mtimeOf returns the mtime of path within fsys, or the zero time
+// when the underlying fs.FS does not expose timing information.
+func mtimeOf(fsys fs.FS, p string) (time.Time, error) {
+	info, err := fs.Stat(fsys, p)
+	if err != nil {
+		var pathErr *fs.PathError
+		if errors.As(err, &pathErr) {
+			return time.Time{}, fmt.Errorf("%w", err)
+		}
+		return time.Time{}, err
+	}
+	return info.ModTime(), nil
+}
+
+func manifestPath(skillDir string) string {
+	return skillDir + "/" + ManifestFilename
+}
+
+func skillManifestURI(uriSegs []string) string {
+	return Scheme + "://" + joinSegments(uriSegs) + "/" + ManifestFilename
+}
+
+func joinSegments(segs []string) string {
+	switch len(segs) {
+	case 0:
+		return ""
+	case 1:
+		return segs[0]
+	}
+	out := segs[0]
+	for _, s := range segs[1:] {
+		out = out + "/" + s
+	}
+	return out
+}
+
+func sortIndexEntries(entries []IndexEntry) {
+	sort.SliceStable(entries, func(i, j int) bool {
+		return entries[i].URL < entries[j].URL
+	})
+}

--- a/ext/skills/indexer_test.go
+++ b/ext/skills/indexer_test.go
@@ -356,6 +356,60 @@ func TestIndexer_RegisterWith_AddsIndexResource(t *testing.T) {
 	}
 }
 
+func TestIndexer_Index_ConcurrentSafe(t *testing.T) {
+	// Race-detector smoke test. The cache mutex is taken at the top of
+	// Index() and held through both isFresh() and build(). Multiple
+	// goroutines hammering Index() with a short TTL must produce no
+	// data race and consistent digests for the same artifact.
+	p := mustProvider(t, "testdata/valid")
+	idx := skills.NewIndexer(p, skills.WithIndexerCacheTTL(2*time.Millisecond))
+
+	const goroutines = 16
+	const iterations = 50
+
+	first, err := idx.Index()
+	if err != nil {
+		t.Fatalf("Index #1: %v", err)
+	}
+	wantDigests := make(map[string]string, len(first.Skills))
+	for _, e := range first.Skills {
+		wantDigests[e.URL] = e.Digest
+	}
+
+	errCh := make(chan error, goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			for i := 0; i < iterations; i++ {
+				got, err := idx.Index()
+				if err != nil {
+					errCh <- err
+					return
+				}
+				for _, e := range got.Skills {
+					if want := wantDigests[e.URL]; e.Digest != want {
+						errCh <- &digestDriftErr{url: e.URL, want: want, got: e.Digest}
+						return
+					}
+				}
+			}
+			errCh <- nil
+		}()
+	}
+	for g := 0; g < goroutines; g++ {
+		if err := <-errCh; err != nil {
+			t.Fatalf("goroutine err: %v", err)
+		}
+	}
+}
+
+type digestDriftErr struct {
+	url, want, got string
+}
+
+func (e *digestDriftErr) Error() string {
+	return "digest drift for " + e.url + ": want " + e.want + ", got " + e.got
+}
+
 // --- helpers ---
 
 func mustProvider(t *testing.T, dir string) *skills.Provider {

--- a/ext/skills/indexer_test.go
+++ b/ext/skills/indexer_test.go
@@ -1,0 +1,434 @@
+package skills_test
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io/fs"
+	"net/http/httptest"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	"github.com/panyam/mcpkit/client"
+	"github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/ext/skills"
+	"github.com/panyam/mcpkit/server"
+)
+
+func TestIndexer_Index_SchemaURI(t *testing.T) {
+	p := mustProvider(t, "testdata/valid")
+	idx, err := skills.NewIndexer(p).Index()
+	if err != nil {
+		t.Fatalf("Index: %v", err)
+	}
+	if idx.Schema != skills.IndexSchemaURI {
+		t.Errorf("Schema = %q, want %q", idx.Schema, skills.IndexSchemaURI)
+	}
+}
+
+func TestIndexer_Index_DigestFormat(t *testing.T) {
+	p := mustProvider(t, "testdata/valid")
+	idx, err := skills.NewIndexer(p).Index()
+	if err != nil {
+		t.Fatalf("Index: %v", err)
+	}
+	if len(idx.Skills) == 0 {
+		t.Fatal("expected populated Skills")
+	}
+	re := regexp.MustCompile(`^sha256:[a-f0-9]{64}$`)
+	for _, e := range idx.Skills {
+		if !re.MatchString(e.Digest) {
+			t.Errorf("entry %q: digest %q does not match sha256:[a-f0-9]{64}", e.Name, e.Digest)
+		}
+	}
+}
+
+func TestIndexer_Index_DigestCorrectness(t *testing.T) {
+	p := mustProvider(t, "testdata/valid")
+	idx, err := skills.NewIndexer(p).Index()
+	if err != nil {
+		t.Fatalf("Index: %v", err)
+	}
+	raw, err := os.ReadFile("testdata/valid/git-workflow/SKILL.md")
+	if err != nil {
+		t.Fatalf("read testdata: %v", err)
+	}
+	sum := sha256.Sum256(raw)
+	wantDigest := "sha256:" + hex.EncodeToString(sum[:])
+
+	var got string
+	for _, e := range idx.Skills {
+		if e.URL == "skill://git-workflow/SKILL.md" {
+			got = e.Digest
+			break
+		}
+	}
+	if got != wantDigest {
+		t.Errorf("git-workflow digest = %q, want %q", got, wantDigest)
+	}
+}
+
+func TestIndexer_Index_URLSorted(t *testing.T) {
+	p := mustProvider(t, "testdata/valid")
+	idx, err := skills.NewIndexer(p).Index()
+	if err != nil {
+		t.Fatalf("Index: %v", err)
+	}
+	urls := make([]string, len(idx.Skills))
+	for i, e := range idx.Skills {
+		urls[i] = e.URL
+	}
+	sorted := append([]string(nil), urls...)
+	sort.Strings(sorted)
+	if !equalSlices(urls, sorted) {
+		t.Errorf("entries not URL-sorted: %v", urls)
+	}
+}
+
+func TestIndexer_Index_Empty(t *testing.T) {
+	p, err := skills.NewProvider(skills.WithFS(fstest.MapFS{}))
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	idx, err := skills.NewIndexer(p).Index()
+	if err != nil {
+		t.Fatalf("Index: %v", err)
+	}
+	if idx.Schema != skills.IndexSchemaURI {
+		t.Errorf("Schema = %q, want %q", idx.Schema, skills.IndexSchemaURI)
+	}
+	if idx.Skills == nil {
+		t.Errorf("Skills slice should be non-nil for empty index")
+	}
+	if len(idx.Skills) != 0 {
+		t.Errorf("Skills should be empty, got %d entries", len(idx.Skills))
+	}
+}
+
+func TestIndexer_CacheTTL_HitsAndMiss(t *testing.T) {
+	mfs := singleSkillMapFS(t, time.Unix(1_700_000_000, 0))
+	cfs := &countingFS{FS: mfs}
+	p := mustProviderFromFS(t, cfs)
+
+	idx := skills.NewIndexer(p, skills.WithIndexerCacheTTL(50*time.Millisecond))
+	if _, err := idx.Index(); err != nil {
+		t.Fatalf("Index #1: %v", err)
+	}
+	reads1 := atomic.LoadInt32(&cfs.openCount)
+	if _, err := idx.Index(); err != nil {
+		t.Fatalf("Index #2 (within TTL): %v", err)
+	}
+	reads2 := atomic.LoadInt32(&cfs.openCount)
+	if reads2 != reads1 {
+		t.Errorf("Index() within TTL re-read SKILL.md: opens went %d -> %d", reads1, reads2)
+	}
+
+	time.Sleep(60 * time.Millisecond)
+	if _, err := idx.Index(); err != nil {
+		t.Fatalf("Index #3 (after TTL): %v", err)
+	}
+	reads3 := atomic.LoadInt32(&cfs.openCount)
+	if reads3 == reads2 {
+		t.Errorf("Index() after TTL expiry did not re-read SKILL.md: opens stayed at %d", reads3)
+	}
+}
+
+func TestIndexer_CacheMtimeInvalidates(t *testing.T) {
+	original := time.Unix(1_700_000_000, 0)
+	mfs := singleSkillMapFS(t, original)
+	p := mustProviderFromFS(t, mfs)
+
+	idx := skills.NewIndexer(p, skills.WithIndexerCacheTTL(time.Hour))
+	first, err := idx.Index()
+	if err != nil {
+		t.Fatalf("Index #1: %v", err)
+	}
+	if len(first.Skills) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(first.Skills))
+	}
+
+	// Mutate the SKILL.md bytes and bump mtime. Index() within TTL must
+	// detect the mtime change and recompute the digest.
+	mfs["solo/SKILL.md"].Data = []byte(`---
+name: solo
+description: A solitary skill, edited
+---
+
+new body
+`)
+	mfs["solo/SKILL.md"].ModTime = original.Add(time.Minute)
+
+	second, err := idx.Index()
+	if err != nil {
+		t.Fatalf("Index #2: %v", err)
+	}
+	if second.Skills[0].Digest == first.Skills[0].Digest {
+		t.Errorf("digest did not change after mutating SKILL.md: %q", first.Skills[0].Digest)
+	}
+}
+
+func TestIndexer_ZeroMtimeFallback(t *testing.T) {
+	// fstest.MapFS files whose ModTime is the zero value report mtime
+	// as time.Time{}. With TTL set and noMtime true the cache must fall
+	// back to TTL freshness; without TTL it must recompute every call to
+	// avoid serving a permanently stale index.
+	mfs := fstest.MapFS{
+		"solo/SKILL.md": &fstest.MapFile{
+			Data: []byte(`---
+name: solo
+description: Zero-mtime fixture
+---
+`),
+		},
+	}
+	cfs := &countingFS{FS: mfs}
+	p := mustProviderFromFS(t, cfs)
+
+	// No TTL → recompute every call.
+	idx0 := skills.NewIndexer(p)
+	if _, err := idx0.Index(); err != nil {
+		t.Fatalf("Index #1: %v", err)
+	}
+	reads1 := atomic.LoadInt32(&cfs.openCount)
+	if _, err := idx0.Index(); err != nil {
+		t.Fatalf("Index #2: %v", err)
+	}
+	reads2 := atomic.LoadInt32(&cfs.openCount)
+	if reads2 == reads1 {
+		t.Errorf("zero-mtime + zero-TTL: expected re-read, opens stayed at %d", reads2)
+	}
+
+	// TTL set → cache by TTL even though mtime cannot drive invalidation.
+	idxT := skills.NewIndexer(p, skills.WithIndexerCacheTTL(time.Hour))
+	if _, err := idxT.Index(); err != nil {
+		t.Fatalf("TTL Index #1: %v", err)
+	}
+	readsA := atomic.LoadInt32(&cfs.openCount)
+	if _, err := idxT.Index(); err != nil {
+		t.Fatalf("TTL Index #2: %v", err)
+	}
+	readsB := atomic.LoadInt32(&cfs.openCount)
+	if readsB != readsA {
+		t.Errorf("zero-mtime + TTL: TTL hit should not re-read, opens went %d -> %d", readsA, readsB)
+	}
+}
+
+func TestProvider_RegisterWith_IndexExposed(t *testing.T) {
+	srv, ts, c := boot(t, "testdata/valid")
+	_ = ts
+
+	defs, err := c.ListResources()
+	if err != nil {
+		t.Fatalf("ListResources: %v", err)
+	}
+	var found bool
+	for _, d := range defs {
+		if d.URI == skills.IndexURI {
+			found = true
+			if d.MimeType != "application/json" {
+				t.Errorf("index MimeType = %q, want application/json", d.MimeType)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Errorf("resources/list missing %q in %v", skills.IndexURI, urisOf(defs))
+	}
+
+	body, err := c.ReadResource(skills.IndexURI)
+	if err != nil {
+		t.Fatalf("ReadResource %q: %v", skills.IndexURI, err)
+	}
+	var idx skills.Index
+	if err := json.Unmarshal([]byte(body), &idx); err != nil {
+		t.Fatalf("Unmarshal index: %v\nbody=%s", err, body)
+	}
+	if idx.Schema != skills.IndexSchemaURI {
+		t.Errorf("Schema = %q", idx.Schema)
+	}
+	if len(idx.Skills) != 3 {
+		t.Errorf("Skills count = %d, want 3 (testdata/valid has 3 skills)", len(idx.Skills))
+	}
+	_ = srv
+}
+
+func TestProvider_WithoutIndex(t *testing.T) {
+	srv := server.NewServer(core.ServerInfo{Name: "skills-no-index", Version: "0.0.1"})
+	p, err := skills.NewProvider(
+		skills.WithDirectory("testdata/valid"),
+		skills.WithoutIndex(),
+	)
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	p.RegisterWith(srv)
+
+	handler := srv.Handler(server.WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "skills-no-index-client", Version: "0.0.1"})
+	if err := c.Connect(); err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+
+	defs, err := c.ListResources()
+	if err != nil {
+		t.Fatalf("ListResources: %v", err)
+	}
+	for _, d := range defs {
+		if d.URI == skills.IndexURI {
+			t.Errorf("WithoutIndex did not suppress %q; resources = %v", skills.IndexURI, urisOf(defs))
+		}
+	}
+}
+
+func TestProvider_WithIndexCacheTTL_ForwardsToIndexer(t *testing.T) {
+	mfs := singleSkillMapFS(t, time.Unix(1_700_000_000, 0))
+	cfs := &countingFS{FS: mfs}
+
+	srv := server.NewServer(core.ServerInfo{Name: "skills-ttl-fwd", Version: "0.0.1"})
+	p, err := skills.NewProvider(
+		skills.WithFS(cfs),
+		skills.WithIndexCacheTTL(time.Hour),
+	)
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	p.RegisterWith(srv)
+
+	handler := srv.Handler(server.WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "skills-ttl-fwd-client", Version: "0.0.1"})
+	if err := c.Connect(); err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+
+	if _, err := c.ReadResource(skills.IndexURI); err != nil {
+		t.Fatalf("ReadResource #1: %v", err)
+	}
+	reads1 := atomic.LoadInt32(&cfs.openCount)
+	if _, err := c.ReadResource(skills.IndexURI); err != nil {
+		t.Fatalf("ReadResource #2: %v", err)
+	}
+	reads2 := atomic.LoadInt32(&cfs.openCount)
+	if reads2 != reads1 {
+		t.Errorf("WithIndexCacheTTL did not forward cache to Indexer: opens %d -> %d", reads1, reads2)
+	}
+}
+
+func TestIndexer_RegisterWith_AddsIndexResource(t *testing.T) {
+	srv := server.NewServer(core.ServerInfo{Name: "skills-indexer-only", Version: "0.0.1"})
+	p, err := skills.NewProvider(
+		skills.WithDirectory("testdata/valid"),
+		skills.WithoutIndex(),
+	)
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	p.RegisterWith(srv)
+
+	skills.NewIndexer(p).RegisterWith(srv)
+
+	handler := srv.Handler(server.WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "skills-indexer-only-client", Version: "0.0.1"})
+	if err := c.Connect(); err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+
+	body, err := c.ReadResource(skills.IndexURI)
+	if err != nil {
+		t.Fatalf("ReadResource %q: %v", skills.IndexURI, err)
+	}
+	if !strings.Contains(body, skills.IndexSchemaURI) {
+		t.Errorf("index body missing $schema URI: %s", body)
+	}
+}
+
+// --- helpers ---
+
+func mustProvider(t *testing.T, dir string) *skills.Provider {
+	t.Helper()
+	p, err := skills.NewProvider(skills.WithDirectory(dir))
+	if err != nil {
+		t.Fatalf("NewProvider(%s): %v", dir, err)
+	}
+	return p
+}
+
+func mustProviderFromFS(t *testing.T, fsys fs.FS) *skills.Provider {
+	t.Helper()
+	p, err := skills.NewProvider(skills.WithFS(fsys))
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	return p
+}
+
+func singleSkillMapFS(t *testing.T, mtime time.Time) fstest.MapFS {
+	t.Helper()
+	return fstest.MapFS{
+		"solo/SKILL.md": &fstest.MapFile{
+			Data: []byte(`---
+name: solo
+description: A solitary skill
+---
+
+body
+`),
+			ModTime: mtime,
+		},
+	}
+}
+
+func boot(t *testing.T, dir string) (*server.Server, *httptest.Server, *client.Client) {
+	t.Helper()
+	srv := server.NewServer(core.ServerInfo{Name: "skills-boot", Version: "0.0.1"})
+	p, err := skills.NewProvider(skills.WithDirectory(dir))
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	p.RegisterWith(srv)
+
+	handler := srv.Handler(server.WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "skills-boot-client", Version: "0.0.1"})
+	if err := c.Connect(); err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+	return srv, ts, c
+}
+
+// countingFS wraps an fs.FS and counts Open calls so cache hits/misses
+// can be asserted without timing-sensitive comparisons. It implements
+// fs.StatFS so the mtime check in Indexer.isFresh dispatches to the
+// underlying FS via Stat rather than Open, keeping the openCount focused
+// on actual full-file reads.
+type countingFS struct {
+	fs.FS
+	openCount int32
+	statCount int32
+}
+
+func (c *countingFS) Open(name string) (fs.File, error) {
+	atomic.AddInt32(&c.openCount, 1)
+	return c.FS.Open(name)
+}
+
+func (c *countingFS) Stat(name string) (fs.FileInfo, error) {
+	atomic.AddInt32(&c.statCount, 1)
+	return fs.Stat(c.FS, name)
+}

--- a/ext/skills/provider.go
+++ b/ext/skills/provider.go
@@ -216,12 +216,25 @@ func (p *Provider) Resources() []core.ResourceDef {
 // existing RegisterResource path. The handler streams the file from
 // the underlying fs.FS at request time. Resources are registered in
 // stable URI-sorted order.
+//
+// Unless WithoutIndex was supplied to NewProvider, RegisterWith also
+// constructs an internal Indexer and registers skill://index.json on
+// srv. Use WithIndexCacheTTL to tune the index's cache freshness or
+// WithoutIndex to suppress registration entirely (when, for example,
+// the caller wants to construct and register a custom Indexer).
 func (p *Provider) RegisterWith(srv *server.Server) {
 	sort.SliceStable(p.resources, func(i, j int) bool {
 		return p.resources[i].URI < p.resources[j].URI
 	})
 	for _, r := range p.resources {
 		srv.RegisterResource(p.defFor(r), p.makeHandler(r))
+	}
+	if !p.cfg.suppressIndex {
+		var opts []IndexerOption
+		if p.cfg.indexCacheTTL > 0 {
+			opts = append(opts, WithIndexerCacheTTL(p.cfg.indexCacheTTL))
+		}
+		NewIndexer(p, opts...).RegisterWith(srv)
 	}
 }
 

--- a/ext/skills/provider_options.go
+++ b/ext/skills/provider_options.go
@@ -3,16 +3,19 @@ package skills
 import (
 	"io/fs"
 	"os"
+	"time"
 )
 
 // ProviderOption configures a Provider via NewProvider.
 type ProviderOption func(*providerConfig)
 
 type providerConfig struct {
-	fsys       fs.FS
-	root       string
-	uriPrefix  []string
-	metaPrefix string
+	fsys           fs.FS
+	root           string
+	uriPrefix      []string
+	metaPrefix     string
+	suppressIndex  bool
+	indexCacheTTL  time.Duration
 }
 
 // WithFS supplies the io/fs.FS that the Provider walks for skills. The
@@ -57,5 +60,28 @@ func WithURIPrefix(prefix string) ProviderOption {
 func WithMetaPrefix(prefix string) ProviderOption {
 	return func(c *providerConfig) {
 		c.metaPrefix = prefix
+	}
+}
+
+// WithoutIndex suppresses the auto-registration of skill://index.json
+// when the Provider's RegisterWith is called. Use this when the server
+// wants to expose individual skill files but not the discovery index
+// (e.g., a generated catalog the SEP says hosts MUST NOT treat absence
+// as proof of "no skills"), or when the caller wants to construct and
+// register an Indexer explicitly with non-default options.
+func WithoutIndex() ProviderOption {
+	return func(c *providerConfig) {
+		c.suppressIndex = true
+	}
+}
+
+// WithIndexCacheTTL forwards a cache TTL to the Indexer that
+// Provider.RegisterWith builds for skill://index.json. Equivalent to
+// constructing an Indexer explicitly with WithIndexerCacheTTL(d).
+// Ignored when WithoutIndex is also supplied. See Indexer for the full
+// cache semantics including the zero-mtime fallback.
+func WithIndexCacheTTL(d time.Duration) ProviderOption {
+	return func(c *providerConfig) {
+		c.indexCacheTTL = d
 	}
 }

--- a/ext/skills/provider_test.go
+++ b/ext/skills/provider_test.go
@@ -298,6 +298,7 @@ func TestProvider_Integration(t *testing.T) {
 		"skill://acme/billing/refunds/SKILL.md",
 		"skill://acme/billing/refunds/templates/email.md",
 		"skill://git-workflow/SKILL.md",
+		"skill://index.json",
 		"skill://pdf-processing/SKILL.md",
 		"skill://pdf-processing/references/FORMS.md",
 		"skill://pdf-processing/scripts/extract.py",


### PR DESCRIPTION
## What changes

`NewIndexer` computes the SEP-2640 discovery index lazily over a `Provider`'s cataloged skills. Each entry's `Digest` is `sha256:{64-hex}` over the raw SKILL.md bytes per the spec's Integrity and Verification section. `RegisterWith` installs the index as the well-known `skill://index.json` resource that serves the marshalled JSON on `resources/read`. `Provider.RegisterWith` now auto-constructs an internal `Indexer` and registers `skill://index.json` unless `WithoutIndex` is supplied. `WithIndexCacheTTL` on the Provider forwards to the internal Indexer so a single options list configures both layers.

Cache freshness uses TTL plus per-skill mtime invalidation. On `Index()` the cache returns the previous result when TTL is unexpired and every cataloged skill's SKILL.md mtime matches what was recorded at cache build time. When the underlying `fs.FS` reports zero `ModTime` (notably `embed.FS`), the build flags noMtime and the cache falls back to TTL-only invalidation. If TTL is also zero the indexer recomputes every call to avoid serving permanently stale content.

## Reviewer's guide

Read in this order:

1. [ext/skills/indexer.go](https://github.com/panyam/mcpkit/pull/575/files#diff-044da778667a5797524e83fc8839f9948b2261f0576c8f36d13ee59c8a8c9c57). The whole feature. Read `Indexer` doc + `Index()` first, then `isFresh()` for the cache rules, then `build()` for digest computation, then the auto-registration in `RegisterWith`. `IndexResourceDef` is the published shape.
2. [ext/skills/provider_options.go](https://github.com/panyam/mcpkit/pull/575/files#diff-02ce7b9d8644be81ed6118ce376e8e695e085c46c041d0192f11b905f267fd79). Two new options. `WithoutIndex` opts out of the auto-registration. `WithIndexCacheTTL` forwards a TTL to the internal Indexer.
3. [ext/skills/provider.go](https://github.com/panyam/mcpkit/pull/575/files#diff-bc1bc138c97cce27ab4ebcc05b5b90bce9519a5b6ece2cd00da30248841d7021). One change. `RegisterWith` now constructs the internal Indexer and calls its `RegisterWith` unless `suppressIndex` is set.
4. [ext/skills/indexer_test.go](https://github.com/panyam/mcpkit/pull/575/files#diff-be24a0cdb556b73fd7a9ff44e21f7837844668594922814cb3e082589ff9dd35). 11 new tests. Read `TestIndexer_Index_DigestCorrectness` to anchor the SEP shape, then `TestIndexer_CacheTTL_HitsAndMiss` and `TestIndexer_CacheMtimeInvalidates` for the cache semantics. `TestIndexer_ZeroMtimeFallback` is the embed.FS-style fixture. `TestProvider_RegisterWith_IndexExposed` is the end-to-end check.
5. [ext/skills/provider_test.go](https://github.com/panyam/mcpkit/pull/575/files#diff-4a2b1ae742952de7bc72050fd0f381f22c09f21632e4f9137abeff3a9a3cee54). One-line tightening of the existing integration test to require `skill://index.json` in the resource set.

Skim or skip: nothing in this PR is mechanical or generated.

## Decision log

- **Separate `Indexer` type instead of a `Provider.Index()` method.** The Provider focuses on walk + per-file registration. Indexer is the digest-and-cache layer. `Catalog()` stays as the cheap pre-digest lookup, used internally. Indexer can be constructed explicitly for advanced cases (per-tenant filtered indexes, custom serialization) without contorting Provider.
- **TTL plus mtime invalidation in this PR, not deferred.** A pure TTL cache risks serving stale digests up to the TTL window even when the source file was edited a millisecond after the build. mtime invalidation closes that window cheaply. mtime watching (push-based via fsnotify) is a different question and stays with ticket 564.
- **Auto-register `skill://index.json` by default.** SEP-2640 says servers SHOULD expose the index. Default-on with `WithoutIndex()` opt-out matches that. The opt-out exists so a server that wants to suppress enumeration entirely, or one that wants to construct a custom Indexer with non-default options, can do so cleanly.
- **`WithIndexCacheTTL` (Provider option) forwards to `WithIndexerCacheTTL` (Indexer option).** Two named options because the surfaces are different (Provider config vs Indexer config). The convenience option keeps the one-liner ergonomic without giving up the explicit form.
- **Zero-mtime fallback chooses correctness over caching for embed.FS without TTL.** When the underlying `fs.FS` reports zero `ModTime` and TTL is also zero, the indexer has no signal to drive invalidation off. Returning a permanently cached index would be silently wrong. Recomputing every call costs a SHA-256 per request which is microseconds on typical SKILL.md sizes.
- **Catalog stays pre-digest.** PR 572 deliberately left Digest empty in `Catalog()` and three existing tests assert that. Replacing Catalog with a digesting version would churn that surface for no real benefit. Indexer is the right layer for the cost.
- **JSON `Schema` field uses the SEP-pinned URI constant.** `Index.Schema = IndexSchemaURI` per the SEP example. Hosts that match against a known set of schema URIs will see the canonical value.

## Risk / blast radius

- **Affects:** `ext/skills/` sub-module. Behavior change for servers that already call `Provider.RegisterWith`. They will start exposing `skill://index.json` automatically. Opt-out via `WithoutIndex()`. No surface change to other mcpkit packages.
- **Tests covering this:** 11 new tests plus a tightened integration test that requires `skill://index.json` in the resource set.
- **Be paranoid about:**
  - **`isFresh` ordering.** Reads `cached`, ttl, noMtime, then per-skill mtime map. Take the mutex once at the top of `Index()` so a concurrent invalidation does not interleave a stale cached read with a fresh build. Covered by `TestIndexer_Index_ConcurrentSafe` (sixteen goroutines, fifty iterations each, race detector clean across five repeated runs).
  - **The mtime invalidation cost.** On a hot cache hit the indexer still calls `fs.Stat` once per skill to check mtime. For N skills that is N `fs.Stat` calls per `Index()` request. Cheap on a local FS, but on a network-backed `fs.FS` (S3 wrapper, etc.) the stat round-trip dominates. May warrant a `WithMtimeChecks(false)` option in a follow-up if a heavyweight `fs.FS` shows up.
  - **`counting fs.FS` test wrapper.** Implements `fs.StatFS` so `fs.Stat` does not dispatch through `Open`. Without that, the cache-hit assertion would see `openCount` increment on every mtime check and report a false negative. Worth a glance to confirm the assertion measures what it claims.
  - **`embed.FS` behavior in production.** I asserted zero-`ModTime` fallback semantics via `fstest.MapFS` with no `ModTime` set. Have not run the indexer against an actual `embed.FS` in this PR. Pre-merge sanity: `embed.FS` definitely returns zero `ModTime` (the file mtime at build time is not preserved), so the fallback path is the production path for embedded skills.
  - **Cache key shape.** Mtimes are keyed by `skillEntry.dirPath`. A skill that disappears between builds leaves a stale key in the cached map. `isFresh` iterates `p.provider.skills` (current state), so a missing skill on rebuild surfaces as a key-not-found in the lookup. Currently `provider.skills` does not change post-construction (ticket 564 is hot-reload), so this is theoretically safe today. Worth re-verifying when 564 lands.

## Test plan

- [x] `make test-skills` passes locally (61 top-level tests, 80+ counting sub-tests).
- [x] `go vet ./...` clean.
- [x] `go mod tidy` no-op (stdlib only: `crypto/sha256`, `encoding/hex`, `encoding/json`, `sync`, `time`, `io/fs`, `sort`, `errors`).
- [x] Red-before-green: every new test would fail on `main` (`skills.NewIndexer` did not exist).
- [x] Existing assertion count: 0 removed, 0 weakened. The integration test gains 1 expected URI (tightening).
- [x] End-to-end coverage via `httptest` for both the auto-register path and the `WithoutIndex` path.

## Out of scope

- mtime-watcher push-based invalidation via fsnotify → ticket 564
- Archive (`type: "archive"`) entries in the index → ticket 561
- Per-tenant filtered indexes → flag if requested in review. Not on the ticket map yet.
- HTTP `/.well-known/agent-skills/index.json` serving → ticket 565 (CLI) or ticket 566 (example)
- Cross-SDK byte-for-byte digest comparison → ticket 567 (conformance)

