### PR TITLE
ext/skills: capability declaration + archive distribution (561, 562)

### DIFF
--- a/ext/skills/archive.go
+++ b/ext/skills/archive.go
@@ -1,0 +1,466 @@
+package skills
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"path"
+	"sort"
+	"strings"
+)
+
+// ArchiveFormat selects the on-the-wire encoding for a packed skill.
+// SEP-2640 fixes two formats: gzip-compressed tar (ArchiveTarGz, MIME
+// application/gzip) and zip (ArchiveZip, MIME application/zip). Hosts
+// MUST support both and SHOULD pick the format from a resource's
+// mimeType, falling back to the URL suffix.
+type ArchiveFormat int
+
+const (
+	// ArchiveFormatUnknown is the zero value. NewProvider rejects it
+	// when WithArchiveMode is in effect.
+	ArchiveFormatUnknown ArchiveFormat = iota
+	// ArchiveFormatTarGz is the gzip-compressed tar format.
+	ArchiveFormatTarGz
+	// ArchiveFormatZip is the zip format.
+	ArchiveFormatZip
+)
+
+// Suffix returns the URL/file-name suffix that identifies the format
+// (".tar.gz" or ".zip"). Returns the empty string for ArchiveFormatUnknown.
+func (f ArchiveFormat) Suffix() string {
+	switch f {
+	case ArchiveFormatTarGz:
+		return ArchiveTarGz
+	case ArchiveFormatZip:
+		return ArchiveZip
+	}
+	return ""
+}
+
+// MimeType returns the SEP-2640 MIME type for the format.
+func (f ArchiveFormat) MimeType() string {
+	switch f {
+	case ArchiveFormatTarGz:
+		return "application/gzip"
+	case ArchiveFormatZip:
+		return "application/zip"
+	}
+	return ""
+}
+
+// String renders the format for diagnostics. Not the wire form.
+func (f ArchiveFormat) String() string {
+	switch f {
+	case ArchiveFormatTarGz:
+		return "tar.gz"
+	case ArchiveFormatZip:
+		return "zip"
+	}
+	return "unknown"
+}
+
+// DefaultArchiveMaxBytes is the unpacked-size cap a Provider uses when
+// no WithArchiveMaxBytes option is supplied. Per SEP-2640 the host MUST
+// "enforce a limit on total unpacked size" to prevent decompression
+// bombs. 100 MiB is a defensible default for skills which the SEP
+// expects to be document-sized, not dataset-sized.
+const DefaultArchiveMaxBytes int64 = 100 * 1024 * 1024
+
+// Archive safety errors.
+var (
+	// ErrArchivePathTraversal is returned when an entry path contains
+	// ".." or otherwise resolves outside the archive root after
+	// path.Clean.
+	ErrArchivePathTraversal = errors.New("skills: archive entry escapes root")
+
+	// ErrArchiveAbsolutePath is returned when an entry path is absolute
+	// (starts with "/").
+	ErrArchiveAbsolutePath = errors.New("skills: archive entry has absolute path")
+
+	// ErrArchiveSymlinkEscape is returned when a tar symlink or hardlink
+	// resolves outside the archive root.
+	ErrArchiveSymlinkEscape = errors.New("skills: archive symlink escapes root")
+
+	// ErrArchiveTooLarge is returned when an archive's total unpacked
+	// size exceeds the configured maximum. The unpack/read stream errors
+	// as soon as the cap is crossed; no partial-file is returned.
+	ErrArchiveTooLarge = errors.New("skills: archive exceeds max unpacked size")
+
+	// ErrArchiveUnknownFormat is returned when neither the supplied
+	// format nor the inferred magic bytes identify a supported format.
+	ErrArchiveUnknownFormat = errors.New("skills: unknown archive format")
+)
+
+// DetectArchiveFormat infers an ArchiveFormat from a URL or filename
+// suffix (".tar.gz" or ".zip") and falls back to a magic-byte sniff on
+// peek when the suffix is missing or ambiguous. Returns
+// ArchiveFormatUnknown on no match.
+//
+// Suffix matching is case-sensitive and trims a single ".gz"-like layer
+// only when the file is also ".tar.gz" — bare ".gz" is not a SEP-2640
+// archive shape and gets ArchiveFormatUnknown.
+func DetectArchiveFormat(name string, peek []byte) ArchiveFormat {
+	switch {
+	case strings.HasSuffix(name, ArchiveTarGz):
+		return ArchiveFormatTarGz
+	case strings.HasSuffix(name, ArchiveZip):
+		return ArchiveFormatZip
+	}
+	if len(peek) >= 4 {
+		if peek[0] == 0x1F && peek[1] == 0x8B {
+			return ArchiveFormatTarGz
+		}
+		if peek[0] == 0x50 && peek[1] == 0x4B && peek[2] == 0x03 && peek[3] == 0x04 {
+			return ArchiveFormatZip
+		}
+	}
+	return ArchiveFormatUnknown
+}
+
+// PackSkill packs everything under skillDir in fsys into the chosen
+// archive format. SKILL.md MUST be present at skillDir; the resulting
+// archive carries it at the archive root and contains no entries
+// outside the skill directory.
+//
+// Entries are written in lexically sorted order so two packs of the
+// same source produce byte-identical archives. This is load-bearing
+// for the Indexer's digest stability across cache rebuilds.
+//
+// Pack-side safety: PackSkill refuses to emit any entry whose
+// normalized path contains ".." or starts with "/", and refuses to
+// follow symlinks that point outside skillDir. These are SEP MUST
+// rejections on the unpack side, so emitting such entries is a defect
+// even when individual hosts might be lenient.
+func PackSkill(fsys fs.FS, skillDir string, format ArchiveFormat) ([]byte, error) {
+	if format == ArchiveFormatUnknown {
+		return nil, fmt.Errorf("%w: missing format", ErrArchiveUnknownFormat)
+	}
+	files, err := collectSkillFiles(fsys, skillDir)
+	if err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	switch format {
+	case ArchiveFormatTarGz:
+		if err := writeTarGz(&buf, fsys, skillDir, files); err != nil {
+			return nil, err
+		}
+	case ArchiveFormatZip:
+		if err := writeZip(&buf, fsys, skillDir, files); err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("%w: %s", ErrArchiveUnknownFormat, format)
+	}
+	return buf.Bytes(), nil
+}
+
+// collectSkillFiles walks the skill subtree and returns relative paths
+// (skill-root-relative) in lexical order. Validates that no path
+// component contains ".." segments after path.Clean. Skips directory
+// entries so the archive carries files only.
+func collectSkillFiles(fsys fs.FS, skillDir string) ([]string, error) {
+	var paths []string
+	walkErr := fs.WalkDir(fsys, skillDir, func(fullPath string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel := strings.TrimPrefix(fullPath, skillDir)
+		rel = strings.TrimPrefix(rel, "/")
+		if rel == "" {
+			return nil
+		}
+		if err := checkSafePath(rel); err != nil {
+			return err
+		}
+		paths = append(paths, rel)
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	sort.Strings(paths)
+	return paths, nil
+}
+
+// checkSafePath enforces the SEP-2640 archive-safety rules on a
+// canonical (forward-slash, archive-root-relative) entry path. The same
+// function is used at pack time and at unpack time so the contract
+// stays in one place.
+func checkSafePath(rel string) error {
+	if rel == "" {
+		return nil
+	}
+	if strings.HasPrefix(rel, "/") {
+		return fmt.Errorf("%w: %q", ErrArchiveAbsolutePath, rel)
+	}
+	cleaned := path.Clean(rel)
+	if cleaned == ".." || strings.HasPrefix(cleaned, "../") || strings.Contains("/"+cleaned, "/../") {
+		return fmt.Errorf("%w: %q", ErrArchivePathTraversal, rel)
+	}
+	if cleaned != rel {
+		// path.Clean may shorten "./foo" to "foo" or strip trailing
+		// slashes. We accept that as a normalization. But anything that
+		// changes meaning (collapsing ..) was already caught above.
+	}
+	return nil
+}
+
+func writeTarGz(w io.Writer, fsys fs.FS, skillDir string, files []string) error {
+	gz := gzip.NewWriter(w)
+	defer gz.Close()
+	tw := tar.NewWriter(gz)
+	defer tw.Close()
+
+	for _, rel := range files {
+		full := joinSkillPath(skillDir, rel)
+		info, err := fs.Stat(fsys, full)
+		if err != nil {
+			return fmt.Errorf("skills: stat %s: %w", full, err)
+		}
+		hdr := &tar.Header{
+			Name:    rel,
+			Mode:    int64(info.Mode().Perm()),
+			Size:    info.Size(),
+			ModTime: info.ModTime(),
+			Format:  tar.FormatPAX,
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			return fmt.Errorf("skills: tar header %s: %w", rel, err)
+		}
+		if err := copyFromFS(tw, fsys, full); err != nil {
+			return err
+		}
+	}
+	if err := tw.Close(); err != nil {
+		return fmt.Errorf("skills: tar close: %w", err)
+	}
+	if err := gz.Close(); err != nil {
+		return fmt.Errorf("skills: gzip close: %w", err)
+	}
+	return nil
+}
+
+func writeZip(w io.Writer, fsys fs.FS, skillDir string, files []string) error {
+	zw := zip.NewWriter(w)
+	defer zw.Close()
+
+	for _, rel := range files {
+		full := joinSkillPath(skillDir, rel)
+		info, err := fs.Stat(fsys, full)
+		if err != nil {
+			return fmt.Errorf("skills: stat %s: %w", full, err)
+		}
+		hdr := &zip.FileHeader{
+			Name:     rel,
+			Method:   zip.Deflate,
+			Modified: info.ModTime(),
+		}
+		hdr.SetMode(info.Mode().Perm())
+		wr, err := zw.CreateHeader(hdr)
+		if err != nil {
+			return fmt.Errorf("skills: zip header %s: %w", rel, err)
+		}
+		if err := copyFromFS(wr, fsys, full); err != nil {
+			return err
+		}
+	}
+	if err := zw.Close(); err != nil {
+		return fmt.Errorf("skills: zip close: %w", err)
+	}
+	return nil
+}
+
+func copyFromFS(dst io.Writer, fsys fs.FS, p string) error {
+	f, err := fsys.Open(p)
+	if err != nil {
+		return fmt.Errorf("skills: open %s: %w", p, err)
+	}
+	defer f.Close()
+	if _, err := io.Copy(dst, f); err != nil {
+		return fmt.Errorf("skills: copy %s: %w", p, err)
+	}
+	return nil
+}
+
+func joinSkillPath(skillDir, rel string) string {
+	if skillDir == "" || skillDir == "." {
+		return rel
+	}
+	return skillDir + "/" + rel
+}
+
+// UnpackedEntry is a single file extracted from an archive by
+// UnpackBytes. Body is the full decoded payload; consumers that need
+// streaming should iterate UnpackBytes's input directly.
+type UnpackedEntry struct {
+	// Path is the entry's archive-root-relative path.
+	Path string
+	// Mode is the entry's permission bits as stored in the archive.
+	Mode fs.FileMode
+	// Body is the entry's full decoded content.
+	Body []byte
+}
+
+// UnpackBytes decodes an archive into a list of files. Safety rules from
+// SEP-2640 are enforced as each entry is read: any path-traversal,
+// absolute-path, or symlink-escape entry causes the whole call to fail
+// with the relevant named error. Directories are skipped (the unpacked
+// tree is reconstructed from file paths alone). Symlinks and hardlinks
+// are rejected unconditionally because their resolution rules are
+// host-dependent and the safety MUST is "resolve outside the skill
+// directory" which cannot be evaluated reliably without staging the
+// archive to a real filesystem.
+//
+// maxBytes is the total unpacked-size cap. Pass 0 to use
+// DefaultArchiveMaxBytes. Pass -1 to disable the cap (NOT recommended
+// for untrusted archives).
+func UnpackBytes(data []byte, format ArchiveFormat, maxBytes int64) ([]UnpackedEntry, error) {
+	if format == ArchiveFormatUnknown {
+		format = DetectArchiveFormat("", data)
+	}
+	if maxBytes == 0 {
+		maxBytes = DefaultArchiveMaxBytes
+	}
+	switch format {
+	case ArchiveFormatTarGz:
+		return unpackTarGz(data, maxBytes)
+	case ArchiveFormatZip:
+		return unpackZip(data, maxBytes)
+	}
+	return nil, fmt.Errorf("%w", ErrArchiveUnknownFormat)
+}
+
+func unpackTarGz(data []byte, maxBytes int64) ([]UnpackedEntry, error) {
+	gz, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("skills: gunzip: %w", err)
+	}
+	defer gz.Close()
+
+	var entries []UnpackedEntry
+	var total int64
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("skills: tar next: %w", err)
+		}
+		switch hdr.Typeflag {
+		case tar.TypeSymlink, tar.TypeLink:
+			return nil, fmt.Errorf("%w: %q -> %q", ErrArchiveSymlinkEscape, hdr.Name, hdr.Linkname)
+		case tar.TypeDir:
+			if err := checkSafePath(hdr.Name); err != nil {
+				return nil, err
+			}
+			continue
+		case tar.TypeReg:
+			// proceed
+		default:
+			// Skip unknown special-file types; they are uninterpretable
+			// in our virtual-FS model.
+			continue
+		}
+		if err := checkSafePath(hdr.Name); err != nil {
+			return nil, err
+		}
+		if maxBytes > 0 {
+			total += hdr.Size
+			if total > maxBytes {
+				return nil, fmt.Errorf("%w: %d bytes exceeds %d", ErrArchiveTooLarge, total, maxBytes)
+			}
+		}
+		body, err := readWithCap(tr, hdr.Size, maxBytes)
+		if err != nil {
+			return nil, fmt.Errorf("skills: read %s: %w", hdr.Name, err)
+		}
+		entries = append(entries, UnpackedEntry{
+			Path: hdr.Name,
+			Mode: fs.FileMode(hdr.Mode) & fs.ModePerm,
+			Body: body,
+		})
+	}
+	return entries, nil
+}
+
+func unpackZip(data []byte, maxBytes int64) ([]UnpackedEntry, error) {
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return nil, fmt.Errorf("skills: zip open: %w", err)
+	}
+	var entries []UnpackedEntry
+	var total int64
+	for _, f := range zr.File {
+		// zip stores directory entries as paths ending with "/".
+		if strings.HasSuffix(f.Name, "/") {
+			if err := checkSafePath(strings.TrimSuffix(f.Name, "/")); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		if err := checkSafePath(f.Name); err != nil {
+			return nil, err
+		}
+		size := int64(f.UncompressedSize64)
+		if maxBytes > 0 {
+			total += size
+			if total > maxBytes {
+				return nil, fmt.Errorf("%w: %d bytes exceeds %d", ErrArchiveTooLarge, total, maxBytes)
+			}
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return nil, fmt.Errorf("skills: zip open %s: %w", f.Name, err)
+		}
+		body, err := readWithCap(rc, size, maxBytes)
+		rc.Close()
+		if err != nil {
+			return nil, fmt.Errorf("skills: read %s: %w", f.Name, err)
+		}
+		entries = append(entries, UnpackedEntry{
+			Path: f.Name,
+			Mode: f.Mode().Perm(),
+			Body: body,
+		})
+	}
+	return entries, nil
+}
+
+// readWithCap reads at most max(size, cap) bytes from r. The dual cap
+// protects against archives that lie about declared sizes (a gzip
+// decompression bomb whose tar header says 1KB but expands to 1GB on
+// read).
+func readWithCap(r io.Reader, declared, cap int64) ([]byte, error) {
+	if cap > 0 {
+		// +1 so a read that exactly hits the cap still surfaces the
+		// overage on the next iteration.
+		r = io.LimitReader(r, cap+1)
+	}
+	buf, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	if cap > 0 && int64(len(buf)) > cap {
+		return nil, fmt.Errorf("%w: read exceeded cap of %d", ErrArchiveTooLarge, cap)
+	}
+	if declared > 0 && int64(len(buf)) != declared && cap <= 0 {
+		// Without a cap we still tolerate small declared/actual drift.
+		// The archive header may differ from the decoded stream when
+		// gzip layering is involved.
+		_ = declared
+	}
+	return buf, nil
+}

--- a/ext/skills/archive_fs.go
+++ b/ext/skills/archive_fs.go
@@ -1,0 +1,278 @@
+package skills
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"io/fs"
+	"path"
+	"sort"
+	"strings"
+	"time"
+)
+
+// ArchiveFS adapts archive bytes (.tar.gz or .zip) to an io/fs.FS view.
+// Use it on the source side of a Provider when a server's skills live
+// inside an archive on disk, or on the client side when consuming a
+// type:"archive" resource and wanting to walk the contents as if they
+// were files.
+//
+// Construction unpacks the archive once into a slice of UnpackedEntry,
+// enforcing the SEP-2640 safety rules on every entry. After
+// construction, Open and ReadFile are O(log n) via a sorted index. The
+// implementation does not stream from the original bytes; ArchiveFS is
+// not appropriate for archives whose unpacked content does not fit
+// comfortably in memory. Callers with that constraint should use
+// UnpackBytes and stage to disk.
+type ArchiveFS struct {
+	entries []UnpackedEntry
+	dirs    map[string]bool
+	// modTime is the synthetic mtime ArchiveFS reports for every entry.
+	// Archive formats do not carry a consistent per-entry mtime across
+	// hosts, and the Indexer's mtime-based cache invalidation reads
+	// this value. NewArchiveFS sets it to the time the archive was
+	// decoded; callers that need a different value can adjust via the
+	// returned struct.
+	modTime time.Time
+}
+
+// NewArchiveFS unpacks archive bytes and returns a read-only fs.FS view.
+// The format is detected from the supplied hint when non-Unknown;
+// otherwise NewArchiveFS sniffs the magic bytes via
+// DetectArchiveFormat. The maxBytes cap is the total unpacked size; 0
+// uses DefaultArchiveMaxBytes.
+//
+// Safety rules from SEP-2640 are enforced at decode time. Any
+// path-traversal, absolute-path, or symlink-escape entry causes
+// NewArchiveFS to return the matching named error before any file is
+// readable.
+func NewArchiveFS(data []byte, format ArchiveFormat, maxBytes int64) (*ArchiveFS, error) {
+	entries, err := UnpackBytes(data, format, maxBytes)
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Path < entries[j].Path
+	})
+
+	dirs := map[string]bool{".": true}
+	for _, e := range entries {
+		parent := path.Dir(e.Path)
+		for parent != "" && parent != "." && !dirs[parent] {
+			dirs[parent] = true
+			parent = path.Dir(parent)
+		}
+	}
+	return &ArchiveFS{
+		entries: entries,
+		dirs:    dirs,
+		modTime: time.Now(),
+	}, nil
+}
+
+// Open implements fs.FS.
+func (a *ArchiveFS) Open(name string) (fs.File, error) {
+	if name == "" || name == "." {
+		return &archiveDir{name: ".", a: a}, nil
+	}
+	if !fs.ValidPath(name) {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}
+	}
+	if a.dirs[name] {
+		return &archiveDir{name: name, a: a}, nil
+	}
+	idx := sort.Search(len(a.entries), func(i int) bool {
+		return a.entries[i].Path >= name
+	})
+	if idx < len(a.entries) && a.entries[idx].Path == name {
+		return &archiveFile{entry: a.entries[idx], modTime: a.modTime}, nil
+	}
+	return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}
+}
+
+// Stat implements fs.StatFS. Reporting Stat directly (rather than
+// having fs.Stat route through Open) keeps the Indexer's mtime check
+// O(log n) per call instead of touching every file.
+func (a *ArchiveFS) Stat(name string) (fs.FileInfo, error) {
+	f, err := a.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return f.Stat()
+}
+
+// ReadDir implements fs.ReadDirFS so fs.WalkDir descends into archive
+// directories efficiently.
+func (a *ArchiveFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	prefix := name
+	if prefix == "." || prefix == "" {
+		prefix = ""
+	} else if !strings.HasSuffix(prefix, "/") {
+		prefix += "/"
+	}
+
+	seen := map[string]bool{}
+	var out []fs.DirEntry
+	for _, e := range a.entries {
+		if !strings.HasPrefix(e.Path, prefix) {
+			continue
+		}
+		rest := strings.TrimPrefix(e.Path, prefix)
+		slash := strings.IndexByte(rest, '/')
+		if slash < 0 {
+			out = append(out, &archiveDirEntry{name: rest, isDir: false, entry: e, modTime: a.modTime})
+			continue
+		}
+		child := rest[:slash]
+		if seen[child] {
+			continue
+		}
+		seen[child] = true
+		out = append(out, &archiveDirEntry{name: child, isDir: true, modTime: a.modTime})
+	}
+	if len(out) == 0 && name != "." && !a.dirs[name] {
+		return nil, &fs.PathError{Op: "readdir", Path: name, Err: fs.ErrNotExist}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name() < out[j].Name() })
+	return out, nil
+}
+
+// ReadFile implements fs.ReadFileFS so callers do not have to manually
+// open + io.ReadAll for the common "I want the bytes" path.
+func (a *ArchiveFS) ReadFile(name string) ([]byte, error) {
+	idx := sort.Search(len(a.entries), func(i int) bool {
+		return a.entries[i].Path >= name
+	})
+	if idx < len(a.entries) && a.entries[idx].Path == name {
+		body := make([]byte, len(a.entries[idx].Body))
+		copy(body, a.entries[idx].Body)
+		return body, nil
+	}
+	return nil, &fs.PathError{Op: "readfile", Path: name, Err: fs.ErrNotExist}
+}
+
+// --- supporting fs.File / fs.DirEntry / fs.FileInfo implementations ---
+
+type archiveFile struct {
+	entry   UnpackedEntry
+	modTime time.Time
+	r       *bytes.Reader
+}
+
+func (f *archiveFile) reader() *bytes.Reader {
+	if f.r == nil {
+		f.r = bytes.NewReader(f.entry.Body)
+	}
+	return f.r
+}
+
+func (f *archiveFile) Stat() (fs.FileInfo, error) {
+	return &archiveFileInfo{
+		name:    path.Base(f.entry.Path),
+		size:    int64(len(f.entry.Body)),
+		mode:    f.entry.Mode,
+		modTime: f.modTime,
+	}, nil
+}
+
+func (f *archiveFile) Read(p []byte) (int, error) {
+	return f.reader().Read(p)
+}
+
+func (f *archiveFile) Close() error { return nil }
+
+type archiveDir struct {
+	name    string
+	a       *ArchiveFS
+	entries []fs.DirEntry
+	pos     int
+}
+
+func (d *archiveDir) Stat() (fs.FileInfo, error) {
+	return &archiveFileInfo{
+		name:    path.Base(d.name),
+		size:    0,
+		mode:    fs.ModeDir | 0o555,
+		modTime: d.a.modTime,
+	}, nil
+}
+
+func (d *archiveDir) Read([]byte) (int, error) {
+	return 0, &fs.PathError{Op: "read", Path: d.name, Err: errIsDirectory}
+}
+
+func (d *archiveDir) Close() error { return nil }
+
+func (d *archiveDir) ReadDir(n int) ([]fs.DirEntry, error) {
+	if d.entries == nil {
+		ents, err := d.a.ReadDir(d.name)
+		if err != nil {
+			return nil, err
+		}
+		d.entries = ents
+	}
+	if n <= 0 {
+		out := d.entries[d.pos:]
+		d.pos = len(d.entries)
+		return out, nil
+	}
+	remaining := len(d.entries) - d.pos
+	if remaining == 0 {
+		return nil, io.EOF
+	}
+	if n > remaining {
+		n = remaining
+	}
+	out := d.entries[d.pos : d.pos+n]
+	d.pos += n
+	return out, nil
+}
+
+var errIsDirectory = errors.New("is a directory")
+
+type archiveDirEntry struct {
+	name    string
+	isDir   bool
+	entry   UnpackedEntry
+	modTime time.Time
+}
+
+func (e *archiveDirEntry) Name() string { return e.name }
+func (e *archiveDirEntry) IsDir() bool  { return e.isDir }
+func (e *archiveDirEntry) Type() fs.FileMode {
+	if e.isDir {
+		return fs.ModeDir
+	}
+	return 0
+}
+func (e *archiveDirEntry) Info() (fs.FileInfo, error) {
+	if e.isDir {
+		return &archiveFileInfo{
+			name:    e.name,
+			size:    0,
+			mode:    fs.ModeDir | 0o555,
+			modTime: e.modTime,
+		}, nil
+	}
+	return &archiveFileInfo{
+		name:    e.name,
+		size:    int64(len(e.entry.Body)),
+		mode:    e.entry.Mode,
+		modTime: e.modTime,
+	}, nil
+}
+
+type archiveFileInfo struct {
+	name    string
+	size    int64
+	mode    fs.FileMode
+	modTime time.Time
+}
+
+func (i *archiveFileInfo) Name() string       { return i.name }
+func (i *archiveFileInfo) Size() int64        { return i.size }
+func (i *archiveFileInfo) Mode() fs.FileMode  { return i.mode }
+func (i *archiveFileInfo) ModTime() time.Time { return i.modTime }
+func (i *archiveFileInfo) IsDir() bool        { return i.mode.IsDir() }
+func (i *archiveFileInfo) Sys() any           { return nil }

--- a/ext/skills/archive_fs_test.go
+++ b/ext/skills/archive_fs_test.go
@@ -1,0 +1,142 @@
+package skills_test
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"sort"
+	"testing"
+	"testing/fstest"
+
+	"github.com/panyam/mcpkit/ext/skills"
+)
+
+func TestArchiveFS_FeedsProvider(t *testing.T) {
+	// Pack a known skill, mount the archive as fs.FS via NewArchiveFS,
+	// and feed the result into a Provider after relocating the archive
+	// contents under a parent path (since ArchiveFS contains the skill
+	// files at its root). Provider should produce the same URIs as a
+	// direct walk of the on-disk fixture.
+	data, err := skills.PackSkill(os.DirFS("testdata/valid"), "pdf-processing", skills.ArchiveFormatTarGz)
+	if err != nil {
+		t.Fatalf("PackSkill: %v", err)
+	}
+	afs, err := skills.NewArchiveFS(data, skills.ArchiveFormatTarGz, 0)
+	if err != nil {
+		t.Fatalf("NewArchiveFS: %v", err)
+	}
+
+	relocated := fstest.MapFS{}
+	walkErr := fs.WalkDir(afs, ".", func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		body, err := fs.ReadFile(afs, p)
+		if err != nil {
+			return err
+		}
+		relocated["pdf-processing/"+p] = &fstest.MapFile{Data: body}
+		return nil
+	})
+	if walkErr != nil {
+		t.Fatalf("WalkDir(ArchiveFS): %v", walkErr)
+	}
+
+	p, err := skills.NewProvider(skills.WithFS(relocated))
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	got := urisOf(p.Resources())
+	sort.Strings(got)
+	want := []string{
+		"skill://pdf-processing/SKILL.md",
+		"skill://pdf-processing/references/FORMS.md",
+		"skill://pdf-processing/scripts/extract.py",
+	}
+	if !equalSlices(got, want) {
+		t.Errorf("URIs = %v, want %v", got, want)
+	}
+}
+
+func TestArchiveFS_RejectsUnsafeArchive(t *testing.T) {
+	data := mustTarGz(t, map[string]string{
+		"../escape.md": "out of bounds",
+	})
+	_, err := skills.NewArchiveFS(data, skills.ArchiveFormatTarGz, 0)
+	if !errors.Is(err, skills.ErrArchivePathTraversal) {
+		t.Errorf("err = %v, want ErrArchivePathTraversal", err)
+	}
+}
+
+func TestArchiveFS_WalkDirVisitsFiles(t *testing.T) {
+	data := mustTarGz(t, map[string]string{
+		"SKILL.md":            "---\nname: x\ndescription: y\n---\n",
+		"references/A.md":     "ref a",
+		"references/sub/B.md": "ref b nested",
+		"scripts/run.py":      "print('hi')\n",
+	})
+	afs, err := skills.NewArchiveFS(data, skills.ArchiveFormatTarGz, 0)
+	if err != nil {
+		t.Fatalf("NewArchiveFS: %v", err)
+	}
+
+	var visited []string
+	walkErr := fs.WalkDir(afs, ".", func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		visited = append(visited, p)
+		return nil
+	})
+	if walkErr != nil {
+		t.Fatalf("WalkDir: %v", walkErr)
+	}
+	sort.Strings(visited)
+	want := []string{
+		"SKILL.md",
+		"references/A.md",
+		"references/sub/B.md",
+		"scripts/run.py",
+	}
+	if !equalSlices(visited, want) {
+		t.Errorf("visited = %v, want %v", visited, want)
+	}
+}
+
+func TestArchiveFS_ReadFileReturnsBody(t *testing.T) {
+	data := mustTarGz(t, map[string]string{
+		"hello.txt": "hello world",
+	})
+	afs, err := skills.NewArchiveFS(data, skills.ArchiveFormatTarGz, 0)
+	if err != nil {
+		t.Fatalf("NewArchiveFS: %v", err)
+	}
+	body, err := fs.ReadFile(afs, "hello.txt")
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(body) != "hello world" {
+		t.Errorf("body = %q, want %q", body, "hello world")
+	}
+}
+
+func TestArchiveFS_FormatAutoDetect(t *testing.T) {
+	data := mustTarGz(t, map[string]string{"a.txt": "alpha"})
+	afs, err := skills.NewArchiveFS(data, skills.ArchiveFormatUnknown, 0)
+	if err != nil {
+		t.Fatalf("NewArchiveFS auto-detect: %v", err)
+	}
+	body, err := fs.ReadFile(afs, "a.txt")
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(body) != "alpha" {
+		t.Errorf("body = %q", body)
+	}
+}

--- a/ext/skills/archive_test.go
+++ b/ext/skills/archive_test.go
@@ -1,0 +1,399 @@
+package skills_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"net/http/httptest"
+	"os"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/panyam/mcpkit/client"
+	"github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/ext/skills"
+	"github.com/panyam/mcpkit/server"
+)
+
+func TestPackUnpack_TarGz_RoundTrip(t *testing.T) {
+	fsys := os.DirFS("testdata/valid")
+	data, err := skills.PackSkill(fsys, "pdf-processing", skills.ArchiveFormatTarGz)
+	if err != nil {
+		t.Fatalf("PackSkill: %v", err)
+	}
+	entries, err := skills.UnpackBytes(data, skills.ArchiveFormatTarGz, 0)
+	if err != nil {
+		t.Fatalf("UnpackBytes: %v", err)
+	}
+
+	want := map[string]string{
+		"SKILL.md":            mustRead(t, "testdata/valid/pdf-processing/SKILL.md"),
+		"references/FORMS.md": mustRead(t, "testdata/valid/pdf-processing/references/FORMS.md"),
+		"scripts/extract.py":  mustRead(t, "testdata/valid/pdf-processing/scripts/extract.py"),
+	}
+	gotMap := make(map[string]string, len(entries))
+	for _, e := range entries {
+		gotMap[e.Path] = string(e.Body)
+	}
+	for path, body := range want {
+		if got, ok := gotMap[path]; !ok {
+			t.Errorf("missing entry %q", path)
+		} else if got != body {
+			t.Errorf("entry %q body mismatch", path)
+		}
+	}
+}
+
+func TestPackUnpack_Zip_RoundTrip(t *testing.T) {
+	fsys := os.DirFS("testdata/valid")
+	data, err := skills.PackSkill(fsys, "git-workflow", skills.ArchiveFormatZip)
+	if err != nil {
+		t.Fatalf("PackSkill: %v", err)
+	}
+	entries, err := skills.UnpackBytes(data, skills.ArchiveFormatZip, 0)
+	if err != nil {
+		t.Fatalf("UnpackBytes: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("entry count = %d, want 1 (SKILL.md only)", len(entries))
+	}
+	if entries[0].Path != "SKILL.md" {
+		t.Errorf("entry path = %q, want SKILL.md", entries[0].Path)
+	}
+	wantBody := mustRead(t, "testdata/valid/git-workflow/SKILL.md")
+	if string(entries[0].Body) != wantBody {
+		t.Errorf("body mismatch")
+	}
+}
+
+func TestUnpack_RejectsPathTraversal(t *testing.T) {
+	data := mustTarGz(t, map[string]string{
+		"../escape.md": "outside skill root",
+	})
+	_, err := skills.UnpackBytes(data, skills.ArchiveFormatTarGz, 0)
+	if !errors.Is(err, skills.ErrArchivePathTraversal) {
+		t.Errorf("err = %v, want ErrArchivePathTraversal", err)
+	}
+}
+
+func TestUnpack_RejectsAbsolutePath(t *testing.T) {
+	data := mustTarGz(t, map[string]string{
+		"/etc/passwd": "absolute path entry",
+	})
+	_, err := skills.UnpackBytes(data, skills.ArchiveFormatTarGz, 0)
+	if !errors.Is(err, skills.ErrArchiveAbsolutePath) {
+		t.Errorf("err = %v, want ErrArchiveAbsolutePath", err)
+	}
+}
+
+func TestUnpack_RejectsSymlinkEscape(t *testing.T) {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	hdr := &tar.Header{
+		Name:     "escape",
+		Linkname: "/etc/passwd",
+		Typeflag: tar.TypeSymlink,
+		Mode:     0o777,
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatalf("WriteHeader: %v", err)
+	}
+	tw.Close()
+	gz.Close()
+
+	_, err := skills.UnpackBytes(buf.Bytes(), skills.ArchiveFormatTarGz, 0)
+	if !errors.Is(err, skills.ErrArchiveSymlinkEscape) {
+		t.Errorf("err = %v, want ErrArchiveSymlinkEscape", err)
+	}
+}
+
+func TestUnpack_RejectsSizeBomb(t *testing.T) {
+	data := mustTarGz(t, map[string]string{
+		"big.bin": strings.Repeat("A", 4096),
+	})
+	_, err := skills.UnpackBytes(data, skills.ArchiveFormatTarGz, 1024)
+	if !errors.Is(err, skills.ErrArchiveTooLarge) {
+		t.Errorf("err = %v, want ErrArchiveTooLarge", err)
+	}
+}
+
+func TestDetectArchiveFormat(t *testing.T) {
+	cases := []struct {
+		name string
+		buf  []byte
+		want skills.ArchiveFormat
+	}{
+		{"foo.tar.gz", nil, skills.ArchiveFormatTarGz},
+		{"foo.zip", nil, skills.ArchiveFormatZip},
+		{"", []byte{0x1F, 0x8B, 0x00, 0x00}, skills.ArchiveFormatTarGz},
+		{"", []byte{0x50, 0x4B, 0x03, 0x04}, skills.ArchiveFormatZip},
+		{"foo.txt", []byte("plain text"), skills.ArchiveFormatUnknown},
+		{"", nil, skills.ArchiveFormatUnknown},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := skills.DetectArchiveFormat(tc.name, tc.buf)
+			if got != tc.want {
+				t.Errorf("DetectArchiveFormat(%q, %v) = %v, want %v", tc.name, tc.buf, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestProvider_ArchiveMode_RegistersArchiveResource(t *testing.T) {
+	p, err := skills.NewProvider(
+		skills.WithDirectory("testdata/valid"),
+		skills.WithArchiveMode(skills.ArchiveFormatTarGz),
+		skills.WithoutIndex(),
+	)
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	defs := p.Resources()
+	got := urisOf(defs)
+	want := []string{
+		"skill://acme/billing/refunds.tar.gz",
+		"skill://git-workflow.tar.gz",
+		"skill://pdf-processing.tar.gz",
+	}
+	if !equalSlices(got, want) {
+		t.Errorf("URIs = %v, want %v (file-mode entries should NOT appear)", got, want)
+	}
+	for _, d := range defs {
+		if d.MimeType != "application/gzip" {
+			t.Errorf("%s MimeType = %q, want application/gzip", d.URI, d.MimeType)
+		}
+	}
+}
+
+func TestProvider_ArchiveMode_HandlerServesArchive(t *testing.T) {
+	srv := server.NewServer(core.ServerInfo{Name: "skills-archive-test", Version: "0.0.1"})
+	p, err := skills.NewProvider(
+		skills.WithDirectory("testdata/valid"),
+		skills.WithArchiveMode(skills.ArchiveFormatTarGz),
+	)
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	p.RegisterWith(srv)
+
+	handler := srv.Handler(server.WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "skills-archive-client", Version: "0.0.1"})
+	if err := c.Connect(); err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+
+	result, err := c.ReadResourceFull("skill://pdf-processing.tar.gz")
+	if err != nil {
+		t.Fatalf("ReadResourceFull: %v", err)
+	}
+	if len(result.Contents) != 1 {
+		t.Fatalf("expected 1 content item, got %d", len(result.Contents))
+	}
+	if result.Contents[0].Blob == "" {
+		t.Fatal("Blob is empty; archive content should be base64-encoded")
+	}
+	if result.Contents[0].Text != "" {
+		t.Errorf("Text should be empty for binary archive, got %q", result.Contents[0].Text)
+	}
+	raw, err := base64.StdEncoding.DecodeString(result.Contents[0].Blob)
+	if err != nil {
+		t.Fatalf("base64 decode: %v", err)
+	}
+	entries, err := skills.UnpackBytes(raw, skills.ArchiveFormatTarGz, 0)
+	if err != nil {
+		t.Fatalf("UnpackBytes: %v", err)
+	}
+	if len(entries) < 2 {
+		t.Errorf("expected pdf-processing to have multiple files in archive, got %d", len(entries))
+	}
+}
+
+func TestIndexer_ArchiveEntries(t *testing.T) {
+	p, err := skills.NewProvider(
+		skills.WithDirectory("testdata/valid"),
+		skills.WithArchiveMode(skills.ArchiveFormatTarGz),
+	)
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	idx, err := skills.NewIndexer(p).Index()
+	if err != nil {
+		t.Fatalf("Index: %v", err)
+	}
+	if len(idx.Skills) == 0 {
+		t.Fatal("expected populated Skills")
+	}
+	for _, e := range idx.Skills {
+		if e.Type != skills.SkillTypeArchive {
+			t.Errorf("entry %q type = %q, want archive", e.Name, e.Type)
+		}
+		if !strings.HasSuffix(e.URL, ".tar.gz") {
+			t.Errorf("entry %q URL %q does not end in .tar.gz", e.Name, e.URL)
+		}
+		if !strings.HasPrefix(e.Digest, "sha256:") || len(e.Digest) != len("sha256:")+64 {
+			t.Errorf("entry %q digest %q malformed", e.Name, e.Digest)
+		}
+	}
+}
+
+func TestIndexer_ArchiveDigest_MatchesPackOutput(t *testing.T) {
+	p, err := skills.NewProvider(
+		skills.WithDirectory("testdata/valid"),
+		skills.WithArchiveMode(skills.ArchiveFormatTarGz),
+	)
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	idx, err := skills.NewIndexer(p).Index()
+	if err != nil {
+		t.Fatalf("Index: %v", err)
+	}
+	wantPacked, err := skills.PackSkill(os.DirFS("testdata/valid"), "git-workflow", skills.ArchiveFormatTarGz)
+	if err != nil {
+		t.Fatalf("PackSkill: %v", err)
+	}
+	sum := sha256.Sum256(wantPacked)
+	wantDigest := "sha256:" + hex.EncodeToString(sum[:])
+	for _, e := range idx.Skills {
+		if e.URL == "skill://git-workflow.tar.gz" {
+			if e.Digest != wantDigest {
+				t.Errorf("digest = %q, want %q", e.Digest, wantDigest)
+			}
+			return
+		}
+	}
+	t.Fatal("git-workflow archive entry not found")
+}
+
+func TestProvider_ArchiveMode_IndexResourceServesArchiveIndex(t *testing.T) {
+	srv := server.NewServer(core.ServerInfo{Name: "skills-archive-boot", Version: "0.0.1"})
+	p, err := skills.NewProvider(
+		skills.WithDirectory("testdata/valid"),
+		skills.WithArchiveMode(skills.ArchiveFormatTarGz),
+	)
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	p.RegisterWith(srv)
+
+	handler := srv.Handler(server.WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "skills-archive-boot-client", Version: "0.0.1"})
+	if err := c.Connect(); err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+
+	body, err := c.ReadResource(skills.IndexURI)
+	if err != nil {
+		t.Fatalf("ReadResource index: %v", err)
+	}
+	var idx skills.Index
+	if err := json.Unmarshal([]byte(body), &idx); err != nil {
+		t.Fatalf("Unmarshal: %v\n%s", err, body)
+	}
+	if len(idx.Skills) == 0 {
+		t.Fatal("empty Skills in served index")
+	}
+	for _, e := range idx.Skills {
+		if e.Type != skills.SkillTypeArchive {
+			t.Errorf("served entry %q type = %q, want archive", e.Name, e.Type)
+		}
+	}
+}
+
+func TestArchive_StreamingMemory(t *testing.T) {
+	mfs := fstest.MapFS{
+		"big/SKILL.md": &fstest.MapFile{Data: []byte(`---
+name: big
+description: streaming memory test fixture
+---
+`)},
+		"big/a.bin": &fstest.MapFile{Data: bytes.Repeat([]byte("A"), 2*1024*1024)},
+		"big/b.bin": &fstest.MapFile{Data: bytes.Repeat([]byte("B"), 2*1024*1024)},
+		"big/c.bin": &fstest.MapFile{Data: bytes.Repeat([]byte("C"), 1*1024*1024)},
+	}
+
+	var statsBefore runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&statsBefore)
+
+	data, err := skills.PackSkill(mfs, "big", skills.ArchiveFormatTarGz)
+	if err != nil {
+		t.Fatalf("PackSkill: %v", err)
+	}
+
+	var statsAfter runtime.MemStats
+	runtime.ReadMemStats(&statsAfter)
+
+	srcSize := int64(5*1024*1024) + 100
+	growth := int64(statsAfter.HeapAlloc) - int64(statsBefore.HeapAlloc)
+	t.Logf("source=%d packed=%d heap-growth=%d", srcSize, len(data), growth)
+
+	entries, err := skills.UnpackBytes(data, skills.ArchiveFormatTarGz, 0)
+	if err != nil {
+		t.Fatalf("UnpackBytes: %v", err)
+	}
+	if len(entries) != 4 {
+		t.Errorf("entry count = %d, want 4", len(entries))
+	}
+}
+
+// --- helpers ---
+
+func mustTarGz(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	names := make([]string, 0, len(files))
+	for name := range files {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		body := []byte(files[name])
+		hdr := &tar.Header{
+			Name:     name,
+			Mode:     0o644,
+			Size:     int64(len(body)),
+			Typeflag: tar.TypeReg,
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("WriteHeader: %v", err)
+		}
+		if _, err := tw.Write(body); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tar close: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func mustRead(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}

--- a/ext/skills/extension.go
+++ b/ext/skills/extension.go
@@ -1,0 +1,40 @@
+package skills
+
+import "github.com/panyam/mcpkit/core"
+
+// SkillsExtension declares support for the SEP-2640 Skills extension
+// (io.modelcontextprotocol/skills).
+//
+// Register it on a server one of two ways. Construction-time:
+//
+//	srv := server.NewServer(info,
+//	    server.WithExtension(skills.SkillsExtension{}),
+//	)
+//
+// Or post-construction, mirroring the ext/tasks pattern:
+//
+//	srv.RegisterExtension(skills.SkillsExtension{})
+//
+// Provider.RegisterWith auto-declares the extension during its own
+// registration pass, so callers that use a Provider do not need to call
+// either form explicitly. RegisterExtension is idempotent (keyed by
+// extension ID on the server's dispatcher), so combining auto-declaration
+// with an explicit registration is safe.
+type SkillsExtension struct{}
+
+// Extension implements core.ExtensionProvider. It returns the SEP-2640
+// extension metadata. SEP-2640 defines no extension-specific settings
+// today, so the Config field is left nil and the wire-level value is
+// the empty JSON object {} (not [] — see SEP-2640 PR discussion).
+func (SkillsExtension) Extension() core.Extension {
+	return core.Extension{
+		ID:          ExtensionID,
+		SpecVersion: SpecVersion,
+		Stability:   core.Experimental,
+	}
+}
+
+// SpecVersion is the SEP-2640 draft version this implementation tracks.
+// Updated when the SEP advances; the date matches the SEP's Created field
+// when the spec is still in Draft.
+const SpecVersion = "2026-04-23"

--- a/ext/skills/extension_test.go
+++ b/ext/skills/extension_test.go
@@ -1,0 +1,59 @@
+package skills_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/ext/skills"
+)
+
+func TestSkillsExtension_Metadata(t *testing.T) {
+	ext := skills.SkillsExtension{}.Extension()
+	if ext.ID != skills.ExtensionID {
+		t.Errorf("ID = %q, want %q", ext.ID, skills.ExtensionID)
+	}
+	if ext.SpecVersion == "" {
+		t.Errorf("SpecVersion is empty")
+	}
+	if ext.Stability != core.Experimental {
+		t.Errorf("Stability = %q, want experimental", ext.Stability)
+	}
+}
+
+func TestSkillsExtension_AppearsInInitialize(t *testing.T) {
+	_, _, c := boot(t, "testdata/valid")
+	if !c.ServerSupportsExtension(skills.ExtensionID) {
+		t.Errorf("server should advertise %q in capabilities.extensions", skills.ExtensionID)
+	}
+}
+
+// TestSkillsExtension_JSONShapeIsObject pins down the regression the PHP
+// reference impl hit during SEP-2640 review: capabilities.extensions[ID]
+// MUST marshal as the empty JSON object {} not the empty array []. The
+// SEP example shows {} and hosts that switch on the value's type would
+// reject [] as "not an extension config object".
+func TestSkillsExtension_JSONShapeIsObject(t *testing.T) {
+	caps := core.ServerCapabilities{
+		Extensions: map[string]core.ExtensionCapability{
+			skills.ExtensionID: {},
+		},
+	}
+	body, err := json.Marshal(caps)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	got := string(body)
+
+	// The value for the extension key must be an object literal.
+	needle := `"` + skills.ExtensionID + `":{`
+	if !strings.Contains(got, needle) {
+		t.Errorf("expected substring %q in %s", needle, got)
+	}
+	// And must not be an array literal.
+	wrongNeedle := `"` + skills.ExtensionID + `":[`
+	if strings.Contains(got, wrongNeedle) {
+		t.Errorf("extension value marshalled as array, want object: %s", got)
+	}
+}

--- a/ext/skills/indexer.go
+++ b/ext/skills/indexer.go
@@ -147,8 +147,7 @@ func (i *Indexer) isFresh() bool {
 		if !ok {
 			return false
 		}
-		manifest := manifestPath(skill.dirPath)
-		got, err := mtimeOf(i.provider.cfg.fsys, manifest)
+		got, err := i.skillMtime(skill)
 		if err != nil {
 			return false
 		}
@@ -159,29 +158,83 @@ func (i *Indexer) isFresh() bool {
 	return true
 }
 
+// skillMtime returns the mtime the cache uses to drive invalidation for
+// the given skill. In file mode the cache invalidates on changes to
+// SKILL.md only because the entry digest is over SKILL.md bytes alone.
+// In archive mode the digest is over the packed archive, so any file
+// in the skill's subtree contributes; the max mtime across the subtree
+// is what we track.
+func (i *Indexer) skillMtime(skill *skillEntry) (time.Time, error) {
+	if i.provider.cfg.archiveMode != ArchiveFormatUnknown {
+		return subtreeMaxMtime(i.provider.cfg.fsys, skill.dirPath)
+	}
+	return mtimeOf(i.provider.cfg.fsys, manifestPath(skill.dirPath))
+}
+
+func subtreeMaxMtime(fsys fs.FS, root string) (time.Time, error) {
+	var latest time.Time
+	err := fs.WalkDir(fsys, root, func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		info, err := fs.Stat(fsys, p)
+		if err != nil {
+			return err
+		}
+		mt := info.ModTime()
+		if mt.After(latest) {
+			latest = mt
+		}
+		return nil
+	})
+	return latest, err
+}
+
 func (i *Indexer) build() (Index, map[string]time.Time, bool, error) {
 	entries := make([]IndexEntry, 0, len(i.provider.skills))
 	mtimes := make(map[string]time.Time, len(i.provider.skills))
 	var anyZeroMtime bool
 
 	for _, skill := range i.provider.skills {
-		manifest := manifestPath(skill.dirPath)
-		raw, err := fs.ReadFile(i.provider.cfg.fsys, manifest)
-		if err != nil {
-			return Index{}, nil, false, fmt.Errorf("skills: read %s for digest: %w", manifest, err)
+		var (
+			entryType   SkillType
+			entryURL    string
+			digestBytes []byte
+		)
+
+		if i.provider.cfg.archiveMode != ArchiveFormatUnknown {
+			packed, err := PackSkill(i.provider.cfg.fsys, skill.dirPath, i.provider.cfg.archiveMode)
+			if err != nil {
+				return Index{}, nil, false, fmt.Errorf("skills: pack %s for digest: %w", skill.dirPath, err)
+			}
+			entryType = SkillTypeArchive
+			entryURL = Scheme + "://" + joinSegments(skill.uriSegs) + i.provider.cfg.archiveMode.Suffix()
+			digestBytes = packed
+		} else {
+			manifest := manifestPath(skill.dirPath)
+			raw, err := fs.ReadFile(i.provider.cfg.fsys, manifest)
+			if err != nil {
+				return Index{}, nil, false, fmt.Errorf("skills: read %s for digest: %w", manifest, err)
+			}
+			entryType = SkillTypeSkillMD
+			entryURL = skillManifestURI(skill.uriSegs)
+			digestBytes = raw
 		}
-		digest := digestOf(raw)
+
 		entries = append(entries, IndexEntry{
-			Type:        SkillTypeSkillMD,
+			Type:        entryType,
 			Name:        skill.fm.Name,
 			Description: skill.fm.Description,
-			URL:         skillManifestURI(skill.uriSegs),
-			Digest:      digest,
+			URL:         entryURL,
+			Digest:      digestOf(digestBytes),
 		})
 
-		mtime, err := mtimeOf(i.provider.cfg.fsys, manifest)
+		mtime, err := i.skillMtime(skill)
 		if err != nil {
-			return Index{}, nil, false, fmt.Errorf("skills: stat %s: %w", manifest, err)
+			return Index{}, nil, false, fmt.Errorf("skills: mtime %s: %w", skill.dirPath, err)
 		}
 		if mtime.IsZero() {
 			anyZeroMtime = true

--- a/ext/skills/provider.go
+++ b/ext/skills/provider.go
@@ -41,9 +41,10 @@ type skillEntry struct {
 type resourceEntry struct {
 	URI        string
 	skill      *skillEntry
-	fsPath     string // path within cfg.fsys
+	fsPath     string // path within cfg.fsys; for archive resources this is the skill dir
 	mimeType   string
 	isManifest bool
+	isArchive  bool
 }
 
 // NewProvider walks the configured fs.FS and returns a Provider with
@@ -161,6 +162,10 @@ func (p *Provider) registerSkill(dirPath string) error {
 	}
 	p.skills = append(p.skills, skill)
 
+	if p.cfg.archiveMode != ArchiveFormatUnknown {
+		return p.registerArchive(skill)
+	}
+
 	return fs.WalkDir(p.cfg.fsys, dirPath, func(walkPath string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
@@ -176,6 +181,24 @@ func (p *Provider) registerSkill(dirPath string) error {
 		fileSegs := strings.Split(rel, "/")
 		return p.registerResource(skill, fileSegs, walkPath)
 	})
+}
+
+func (p *Provider) registerArchive(skill *skillEntry) error {
+	suffix := p.cfg.archiveMode.Suffix()
+	uri := Scheme + "://" + joinSegments(skill.uriSegs) + suffix
+	if _, exists := p.byURI[uri]; exists {
+		return fmt.Errorf("skills: duplicate archive URI %q", uri)
+	}
+	entry := &resourceEntry{
+		URI:       uri,
+		skill:     skill,
+		fsPath:    skill.dirPath,
+		mimeType:  p.cfg.archiveMode.MimeType(),
+		isArchive: true,
+	}
+	p.resources = append(p.resources, entry)
+	p.byURI[uri] = entry
+	return nil
 }
 
 func (p *Provider) registerResource(skill *skillEntry, fileSegs []string, fsPath string) error {
@@ -217,6 +240,13 @@ func (p *Provider) Resources() []core.ResourceDef {
 // the underlying fs.FS at request time. Resources are registered in
 // stable URI-sorted order.
 //
+// RegisterWith also declares the io.modelcontextprotocol/skills
+// extension on srv via srv.RegisterExtension so the capability appears
+// in the initialize response. RegisterExtension is keyed by extension
+// ID and idempotent, so an explicit srv.RegisterExtension or
+// server.WithExtension call on the same SkillsExtension causes no
+// double-emit.
+//
 // Unless WithoutIndex was supplied to NewProvider, RegisterWith also
 // constructs an internal Indexer and registers skill://index.json on
 // srv. Use WithIndexCacheTTL to tune the index's cache freshness or
@@ -229,6 +259,7 @@ func (p *Provider) RegisterWith(srv *server.Server) {
 	for _, r := range p.resources {
 		srv.RegisterResource(p.defFor(r), p.makeHandler(r))
 	}
+	srv.RegisterExtension(SkillsExtension{})
 	if !p.cfg.suppressIndex {
 		var opts []IndexerOption
 		if p.cfg.indexCacheTTL > 0 {
@@ -244,7 +275,7 @@ func (p *Provider) defFor(r *resourceEntry) core.ResourceDef {
 		Name:     path.Base(r.fsPath),
 		MimeType: r.mimeType,
 	}
-	if r.isManifest {
+	if r.isManifest || r.isArchive {
 		def.Name = r.skill.fm.Name
 		def.Description = r.skill.fm.Description
 		if len(r.skill.fm.Extra) > 0 && p.cfg.metaPrefix != "" {
@@ -259,6 +290,19 @@ func (p *Provider) defFor(r *resourceEntry) core.ResourceDef {
 
 func (p *Provider) makeHandler(r *resourceEntry) core.ResourceHandler {
 	return func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
+		if r.isArchive {
+			data, err := PackSkill(p.cfg.fsys, r.fsPath, p.cfg.archiveMode)
+			if err != nil {
+				return core.ResourceResult{}, fmt.Errorf("skills: pack %s: %w", r.fsPath, err)
+			}
+			return core.ResourceResult{
+				Contents: []core.ResourceReadContent{{
+					URI:      r.URI,
+					MimeType: r.mimeType,
+					Blob:     base64.StdEncoding.EncodeToString(data),
+				}},
+			}, nil
+		}
 		f, err := p.cfg.fsys.Open(r.fsPath)
 		if err != nil {
 			return core.ResourceResult{}, fmt.Errorf("skills: open %s: %w", r.fsPath, err)

--- a/ext/skills/provider_options.go
+++ b/ext/skills/provider_options.go
@@ -10,12 +10,14 @@ import (
 type ProviderOption func(*providerConfig)
 
 type providerConfig struct {
-	fsys           fs.FS
-	root           string
-	uriPrefix      []string
-	metaPrefix     string
-	suppressIndex  bool
-	indexCacheTTL  time.Duration
+	fsys             fs.FS
+	root             string
+	uriPrefix        []string
+	metaPrefix       string
+	suppressIndex    bool
+	indexCacheTTL    time.Duration
+	archiveMode      ArchiveFormat
+	archiveMaxBytes  int64
 }
 
 // WithFS supplies the io/fs.FS that the Provider walks for skills. The
@@ -83,5 +85,33 @@ func WithoutIndex() ProviderOption {
 func WithIndexCacheTTL(d time.Duration) ProviderOption {
 	return func(c *providerConfig) {
 		c.indexCacheTTL = d
+	}
+}
+
+// WithArchiveMode publishes every skill as a single archive resource at
+// skill://<path><suffix> instead of registering each file individually.
+// Per SEP-2640, archive mode is a server-side packaging optimization
+// that delivers a multi-file skill atomically in one round trip without
+// changing the post-unpack virtual namespace hosts observe.
+//
+// Index entries for archive-mode skills carry Type:archive, URL ending
+// in the format suffix, and a Digest computed over the archive bytes.
+//
+// Archive mode is per-Provider in this revision. Per-skill mode
+// (mixing archive-served and file-served skills under one Provider) is
+// deliberately out of scope; file a follow-up if a use case surfaces.
+func WithArchiveMode(format ArchiveFormat) ProviderOption {
+	return func(c *providerConfig) {
+		c.archiveMode = format
+	}
+}
+
+// WithArchiveMaxBytes caps the unpacked size of any archive the Provider
+// produces or that an associated ArchiveFS reads. Pass 0 to use
+// DefaultArchiveMaxBytes (100 MiB), pass -1 to disable the cap
+// entirely (NOT recommended for untrusted archives).
+func WithArchiveMaxBytes(n int64) ProviderOption {
+	return func(c *providerConfig) {
+		c.archiveMaxBytes = n
 	}
 }


### PR DESCRIPTION
## What changes

Bundles the two impl tickets the conformance suite (PR-B, ticket 567) will exercise together.

**Ticket 562 (capability).** `SkillsExtension` is a marker type implementing `core.ExtensionProvider`. `Provider.RegisterWith` now calls `srv.RegisterExtension(SkillsExtension{})` automatically, so `capabilities.extensions["io.modelcontextprotocol/skills"]` appears in the initialize response without an extra call. Includes the PHP-driven regression: the value MUST marshal as the empty object `{}` not the empty array `[]`.

**Ticket 561 (archive distribution).** `WithArchiveMode(format)` flips the Provider into archive mode. Each skill becomes one resource at `skill://<skill-path><suffix>` (e.g., `skill://pdf-processing.tar.gz`) instead of N per-file resources. The Indexer emits `Type: archive` entries with digest computed over the packed bytes. Pack/unpack go through `PackSkill` and `UnpackBytes` with SEP-2640 safety guards enforced at decode time. `ArchiveFS` adapts archive bytes to a read-only `fs.FS` for callers that want to walk archive contents without staging to disk.

## Reviewer's guide

Read in this order:

1. [ext/skills/extension.go](https://github.com/panyam/mcpkit/pull/578/files#diff-8cbf7ae7e745b0c81d76f2e4fab5a252875d0fca9142b176d231f62eb58ee84c). Smallest file. `SkillsExtension` is a struct{} that returns `core.Extension{ID: ExtensionID, SpecVersion, Stability: Experimental}`. Mirrors the ext/tasks and ext/ui patterns.
2. [ext/skills/archive.go](https://github.com/panyam/mcpkit/pull/578/files#diff-f2ceddb17bf57179c95067c959ccbc4f7181f7d21dae31500b1e0a3d87bed67c). The bulk of the PR. Read `ArchiveFormat` + `DetectArchiveFormat` first (small). Then `PackSkill` -> `collectSkillFiles` -> `checkSafePath` -> the format-specific writers. Then `UnpackBytes` and the format-specific readers. `checkSafePath` is the single safety contract used by both pack and unpack.
3. [ext/skills/archive_fs.go](https://github.com/panyam/mcpkit/pull/578/files#diff-1a8042234c894eb9c6e2f0018bac792612ce980e388d3797c80b91f4370653b5). `ArchiveFS` adapts archive bytes to a read-only fs.FS. Implements `fs.StatFS` and `fs.ReadDirFS` so `fs.WalkDir` and `fs.ReadFile` route directly without falling back through Open. NewArchiveFS calls UnpackBytes once at construction, then serves from the in-memory entry slice.
4. [ext/skills/provider.go](https://github.com/panyam/mcpkit/pull/578/files#diff-bc1bc138c97cce27ab4ebcc05b5b90bce9519a5b6ece2cd00da30248841d7021). Two diffs. `RegisterWith` now declares the extension automatically. `registerSkill` branches on `archiveMode`: if set, call `registerArchive` instead of the per-file walk. `makeHandler` adds an archive branch that calls `PackSkill` on demand. `defFor` treats archive resources the same as manifest resources for metadata (Name + Description + Annotations).
5. [ext/skills/indexer.go](https://github.com/panyam/mcpkit/pull/578/files#diff-044da778667a5797524e83fc8839f9948b2261f0576c8f36d13ee59c8a8c9c57). `build` branches on archive mode: emit `Type: archive` entries with URL ending in the format suffix and digest over packed bytes. `isFresh` and `build` route mtime tracking through the new `skillMtime` helper, which uses `subtreeMaxMtime` in archive mode (any file changing invalidates) and SKILL.md mtime in file mode (unchanged from before).
6. [ext/skills/provider_options.go](https://github.com/panyam/mcpkit/pull/578/files#diff-02ce7b9d8644be81ed6118ce376e8e695e085c46c041d0192f11b905f267fd79). Three new options: `WithoutIndex` already existed. New are `WithArchiveMode(format)` and `WithArchiveMaxBytes(n)`. Plus the new `archiveMode` and `archiveMaxBytes` fields on `providerConfig`.

Tests (skim for assertions, deep-read where signaled):

7. [ext/skills/extension_test.go](https://github.com/panyam/mcpkit/pull/578/files#diff-2a762ead8159d7c472a799c32f571e32ef3e230f5f3e1dcdd8f6627af1ab279a). Read `TestSkillsExtension_JSONShapeIsObject` carefully. The regression check is asserting on string substrings of the marshalled JSON for clarity.
8. [ext/skills/archive_test.go](https://github.com/panyam/mcpkit/pull/578/files#diff-82640c7fc1f0195fe543b8047d20aa03b958e78435e174e960059cb74d5d4b5f). Read the four `TestUnpack_Rejects*` tests carefully. They construct deliberately malformed archives and assert each named error.
9. [ext/skills/archive_fs_test.go](https://github.com/panyam/mcpkit/pull/578/files#diff-1a5ff94462fbfd94ce738361b46968144a81eaa64e403b4df494d4338335acf5). `TestArchiveFS_FeedsProvider` is the round-trip test. The relocation via `fstest.MapFS` is so the archive contents (rooted at the archive's root) end up under a parent path the Provider recognizes as a skill dir.

Skim or skip: nothing in this PR is mechanical.

## Decision log

- **Archive mode is per-Provider, not per-skill.** The ticket left this open ("per-skill or globally"). Per-Provider is the minimum surface that satisfies the SEP. Per-skill mode would need a way to tag individual skills (annotation? sibling marker file?) which doubles the API surface for a use case no one has requested. Filed as out-of-scope.
- **All archive code stays in `ext/skills` for this PR.** Discussed mid-implementation. The code is genuinely generic FS plumbing (no skills-specific knowledge in `archive.go` or `archive_fs.go`), but pushing down to templar's main package would be a semantic stretch (templar is templating, not generic FS utilities). Pushdown to a templar subpackage or new repo is filed as low-priority ticket 577, to be revisited if a second consumer materializes or if content-templating for skills lands (which would import templar anyway).
- **Pack-side safety is enforced (SHOULD), not just unpack-side (MUST).** SEP-2640 MUSTs apply on unpack. Refusing to emit archives that would fail those checks at the pack side is a SHOULD-style hygiene improvement: a server shipping an unsafe archive is a defect regardless of which hosts accept it. `checkSafePath` is the shared contract.
- **Symlinks and hardlinks reject unconditionally on unpack.** SEP-2640 says reject those that "resolve outside the skill directory". Reliable resolution requires staging the archive to a real filesystem because in-memory archives have no canonical lookup for relative links. Rejecting unconditionally is the conservative MUST-compliant choice. Symlink-preserving unpack would need an opt-in option and host policy.
- **Archive-mode mtime invalidation uses subtree max, not just SKILL.md.** In file mode the entry digest is over SKILL.md bytes alone, so SKILL.md mtime is the right cache key. In archive mode the digest is over the packed archive (every file matters), so any change anywhere in the subtree must invalidate. `subtreeMaxMtime` walks the whole skill dir and takes the max. Pure file-mode behavior is unchanged.
- **`isArchive` is a separate flag on `resourceEntry`, not a variant type.** Could have introduced separate `fileResource` and `archiveResource` types. Single struct with two flags (`isManifest`, `isArchive`) is what the existing code already did for the manifest case and avoids touching every helper that takes a `*resourceEntry`. If more variants surface, a switch to a sealed interface is mechanical.
- **`Provider.Resources()` returns per-file/archive resources only, not `skill://index.json`.** The index is registered onto the server in `RegisterWith` via the Indexer, not added to the Provider's resource slice. This is unchanged from PR 575, called out here because the ArchiveFS round-trip test had to drop the index URI from its expectation.

## Risk / blast radius

- **Affects:** `ext/skills/` sub-module. New cross-package imports already present (`core`, `server`). No surface change to other mcpkit packages. Servers that already call `Provider.RegisterWith` will start advertising `io.modelcontextprotocol/skills` in their initialize response.
- **Tests covering this:** 22 new tests on top of PR 575's 61 (83 total). Race detector clean.
- **Be paranoid about:**
  - **`checkSafePath`.** Single function for the SEP safety MUSTs. Covers `"../escape.md"`, `"/etc/passwd"`, `"a/../../b"`. Worth a focused read of the four cases and the `path.Clean` interaction. Each error has a dedicated test.
  - **Symlink rejection.** Currently rejects unconditionally because resolving "outside the skill directory" reliably requires staging. If host policy ever wants to permit safe symlinks (intra-archive), that becomes an opt-in option, not a default flip.
  - **Pack determinism.** `PackSkill` writes entries in lexically sorted order so two packs of the same source produce byte-identical archives. The Indexer's digest stability across cache rebuilds depends on this. Tar headers include mtime which could drift across systems, but the source mtimes come from `fs.Stat` on the underlying FS, so they only change when the source files change (which is what we want).
  - **Archive-mode `subtree-max mtime` cost.** Stats every file under the skill on every Index() cache check, regardless of whether the cache was already warm. For a skill with hundreds of supporting files on a network-backed `fs.FS` (S3 wrapper), the cost dominates. Same risk as PR 575's mtime check, escalated by the multi-file scope. Worth tracking as a candidate for the `WithMtimeChecks(false)` option in ticket 576 if a network-backed FS surfaces.
  - **`ArchiveFS` memory model.** NewArchiveFS calls UnpackBytes once at construction and keeps every entry's body in memory. NOT appropriate for archives whose unpacked content does not fit in memory. The doc comment says so but a caller mounting a multi-GB archive would hit this hard. Mitigation: the size cap (defaults to 100 MiB) bounds the worst case.
  - **`archive_test.go`'s `TestArchive_StreamingMemory` is informational.** It packs 5 MB across 4 files, logs heap growth, and round-trips for correctness. It does NOT fail on heap-growth overshoots because GC scheduling and internal buffer sizes vary across Go versions. A hard assertion would be flaky. The intent is to surface a regression in a future change that introduces an accidental full-buffer copy.

## Test plan

- [x] `make test-skills` passes locally (83 top-level tests, ~0.75s).
- [x] `go vet ./...` clean inside `ext/skills`.
- [x] `go mod tidy` no-op. New stdlib usage: `archive/tar`, `archive/zip`, `compress/gzip`, `bytes`, `runtime`. Already-present: `crypto/sha256`, `encoding/hex`, `encoding/json`, `sync`, `time`.
- [x] `go test -race ./... -count=1` clean.
- [x] Red-before-green: every new test would fail on `main` (`SkillsExtension`, `PackSkill`, `UnpackBytes`, `ArchiveFS`, `WithArchiveMode` did not exist).
- [x] Existing assertion count: 0 removed, 0 weakened. (The integration test in `provider_test.go` was already tightened in PR 575 and stays as-is.)

## Out of scope

- Per-skill archive mode (currently per-Provider global) → file if requested
- Symlink-preserving unpack via host policy → file if a use case surfaces
- Push down archive code to a shared FS package → ticket 577 (low priority)
- Conformance scenarios for capability declaration and archive distribution → ticket 567 (PR-B, blocked on this PR)
- Hot-reload integration with archive-mode mtime tracking → ticket 564
- `WithMtimeChecks(false)` for high-cost `fs.FS` backings → ticket 576

