### PR TITLE
examples/skills: demokit walkthrough + docx skill staging (566)

### DIFF
--- a/examples/skills/Makefile
+++ b/examples/skills/Makefile
@@ -7,8 +7,23 @@ serve-archive: ## Start the server in archive mode (.tar.gz per skill)
 serve-zip: ## Start the server in archive mode (.zip per skill)
 	go run . --serve --mode=zip
 
+demo: ## Run the demokit walkthrough (text, non-interactive). Server must be up via `make serve` in another terminal.
+	go run .
+
+tui: ## Run the walkthrough in interactive TUI mode (paginated, key-driven).
+	go run . --tui
+
+note: ## Run the walkthrough in notebook mode (Bubble Tea cells).
+	go run . --note
+
+readme: ## Regenerate WALKTHROUGH.md from the demo definitions.
+	go run . --doc=md > WALKTHROUGH.md
+
+fetch-docx: ## Stage Anthropic's docx skill from github.com/anthropics/skills into skills/ for a real-world demo.
+	bash scripts/fetch-docx-skill.sh
+
 build: ## Build the binary to ./skills-demo
 	go build -o skills-demo .
 
-.PHONY: serve serve-archive serve-zip build
+.PHONY: serve serve-archive serve-zip demo tui note readme fetch-docx build
 .DEFAULT_GOAL := serve

--- a/examples/skills/README.md
+++ b/examples/skills/README.md
@@ -1,86 +1,108 @@
 # examples/skills
 
-Minimal mcpkit server that exposes skills per SEP-2640 (Skills extension).
+End-to-end example for SEP-2640 (Skills extension): a mcpkit server that
+exposes Agent Skills under the `skill://` URI scheme, plus a demokit
+walkthrough that drives a host against it.
 
-This example doubles as the fixture target for `make testconf-skills` in
-the conformance suite. A scripted walkthrough is deferred; see mcpkit
-566 for the full demokit treatment.
-
-## What the server does
-
-Walks the bundled `skills/` directory through
-`github.com/panyam/mcpkit/ext/skills.SkillProvider` and publishes each
-skill as MCP resources. Two distribution modes are supported via the
-`--mode` flag:
-
-- `file` (default): each file in every skill becomes a resource at
-  `skill://<skill-path>/<file-path>`. SKILL.md gets `Name` and
-  `Description` from its frontmatter; Extra frontmatter fields land in
-  `Annotations` keyed by `io.modelcontextprotocol.skills/`.
-- `archive` (`.tar.gz`) or `zip`: each skill becomes one archive
-  resource at `skill://<skill-path>.tar.gz` (or `.zip`). The blob is
-  packed on demand and digested for the index entry.
-
-In both modes `skill://index.json` is auto-registered and the
-`io.modelcontextprotocol/skills` capability appears under
-`capabilities.extensions` in the initialize response.
-
-## Fixture skills
-
-Three skills mirror the SEP-2640 examples table:
-
-| Skill path | Files |
-|---|---|
-| `git-workflow` | `SKILL.md` |
-| `pdf-processing` | `SKILL.md`, `references/FORMS.md`, `scripts/extract.py` |
-| `acme/billing/refunds` | `SKILL.md`, `templates/email.md` |
-
-`pdf-processing/SKILL.md` carries Extra frontmatter (`version`, `tags`)
-to exercise the `Annotations` surface.
+The walkthrough exercises the SEP's wire shape step by step:
+capability declaration, the discovery index, SHA-256 digest
+verification, and reading both single-segment and nested-prefix skills.
+Full step-by-step is in [WALKTHROUGH.md](./WALKTHROUGH.md) (regenerate
+via `make readme`).
 
 ## Running
 
+### Two-terminal walkthrough (recommended)
+
 ```bash
-# file mode on :8080
+# Terminal 1: start the server
 make serve
 
-# archive mode on :8080 (.tar.gz per skill)
-make serve-archive
+# Terminal 2: drive the walkthrough
+make demo        # text mode (non-interactive)
+make tui         # interactive TUI (paginated, key-driven)
+make note        # notebook mode (Bubble Tea cells)
+```
 
-# zip mode on :8080
-make serve-zip
+### Other server modes
 
-# custom port + skills dir
+```bash
+make serve-archive   # publishes each skill as one .tar.gz resource
+make serve-zip       # publishes each skill as one .zip resource
+```
+
+In archive mode `resources/list` returns one URI per skill (e.g.
+`skill://pdf-processing.tar.gz`) instead of N URIs per file. The
+post-unpack virtual namespace hosts see is identical either way — that's
+SEP-2640's whole-skill atomic-delivery story.
+
+### Custom port or skills directory
+
+```bash
 go run . --serve --addr=:9090 --skills=./some-other-skills
 ```
 
-## Smoke test
+## Bundled fixture
+
+Three skills under `skills/` mirror the SEP-2640 Examples table:
+
+| Skill path             | Files                                                       |
+|------------------------|-------------------------------------------------------------|
+| `git-workflow`         | `SKILL.md`                                                  |
+| `pdf-processing`       | `SKILL.md`, `references/FORMS.md`, `scripts/extract.py`     |
+| `acme/billing/refunds` | `SKILL.md`, `templates/email.md`                            |
+
+`pdf-processing/SKILL.md` carries Extra frontmatter (`version`, `tags`)
+to exercise the `Annotations` surface that surfaces extras under the
+`io.modelcontextprotocol.skills/` reverse-domain prefix.
+
+## Adding a real-world skill (anthropics/skills docx)
 
 ```bash
-# in another shell
-curl -s -X POST http://localhost:8080/mcp \
-  -H "Content-Type: application/json" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"initialize",
-       "params":{"protocolVersion":"2025-11-25","capabilities":{},
-                 "clientInfo":{"name":"test","version":"0"}}}' \
-  | grep skills
+make fetch-docx
+make serve
 ```
 
-Expect the response to include
-`"io.modelcontextprotocol/skills":{...}` under
-`result.capabilities.extensions`.
+`make fetch-docx` clones the public [`anthropics/skills`](https://github.com/anthropics/skills) repo
+to `/tmp/anthropics-skills-cache` (override via `ANTHROPIC_SKILLS_CACHE`),
+copies the `docx` skill into `skills/docx`, and warns if the upstream
+frontmatter `name` does not match the staged path (SEP-2640 requires
+them to be equal). Re-running is idempotent.
+
+The fetch-at-run-time pattern keeps this repo's history small and side-steps
+licence ambiguity around vendoring third-party skill bundles. Same shape
+as `scripts/apps-playwright-test.sh`.
+
+## What the walkthrough proves
+
+- The `io.modelcontextprotocol/skills` capability appears under
+  `capabilities.extensions` in the `initialize` response (object, not
+  array).
+- `skill://index.json` round-trips and parses against the
+  `https://schemas.agentskills.io/discovery/0.2.0/schema.json` shape.
+- Every `skill-md` index entry's `digest` is `sha256:[a-f0-9]{64}` and
+  matches `sha256.Sum256` of the served bytes — satisfies the SEP-2640
+  MUST that hosts verify retrieved content against the digest.
+- Resources/read works for both single-segment skills (`git-workflow`)
+  and nested-prefix skills (`acme/billing/refunds`), confirming the
+  prefix-segment routing is uniform.
+- Relative references inside a skill (e.g. `templates/email.md` from
+  `acme/billing/refunds/SKILL.md`) resolve via
+  `skills.ResolveRelative(skillRoot, ref)`.
 
 ## Conformance
+
+This server also doubles as the fixture for the SEP-2640 conformance
+suite:
 
 ```bash
 # from repo root
 MCPCONFORMANCE_SKILLS_PATH=$HOME/newstack/mcpkit/conf-main make testconf-skills
 ```
 
-The target launches this server in the configured mode, runs the
-SEP-2640 scenario suite from the panyam/mcpconformance fork, and
-reports per-scenario pass/fail wired to check IDs in
-`src/seps/sep-2640.yaml`.
+The Makefile target spawns this binary in `--serve` mode on `:18099`
+before invoking the fork-side scenario runner. The fork-side Scenario
+classes are tracked under mcpkit#567.
 
 ## Spec reference
 

--- a/examples/skills/WALKTHROUGH.md
+++ b/examples/skills/WALKTHROUGH.md
@@ -1,0 +1,163 @@
+# MCP Skills Extension (SEP-2640) — Reference Walkthrough
+
+Walks through SEP-2640, which serves Agent Skills over MCP using the existing Resources primitive. Each file in a skill directory is exposed as a `skill://` resource, the server declares the `io.modelcontextprotocol/skills` capability in `initialize`, and the well-known `skill://index.json` resource enumerates concrete skills with SHA-256 digests. mcpkit's `ext/skills.SkillProvider` walks an `io/fs.FS` once at construction and registers each file with the configured Provider.
+
+## What you'll learn
+
+- **Connect to the skills server** — `client.NewClient(...)` + `Connect()`. The server side wired the extension automatically via `Provider.RegisterWith`.
+- **resources/list returns every cataloged skill URI** — In file mode the list has N entries per skill (one for SKILL.md, one for each supporting file) plus the index. In archive mode it's one entry per skill plus the index.
+- **Read skill://index.json** — The Indexer caches the result with TTL + per-skill mtime invalidation. Repeated reads return the same bytes until something in a SKILL.md actually changes.
+- **Verify digest by re-fetching SKILL.md and recomputing SHA-256** — Treat the response bytes as the artifact, hash them, and compare against the digest field from the index. A mismatch indicates corruption or tampering and per the SEP the host MUST NOT use the content.
+- **Read the pdf-processing SKILL.md** — This skill's frontmatter has `version` and `tags` Extra fields. mcpkit surfaces those under `ResourceDef.Annotations` keyed by `io.modelcontextprotocol.skills/`.
+- **Read a supporting file via skill:// (references/FORMS.md)** — Relative reference `references/FORMS.md` from within pdf-processing/SKILL.md resolves to this full URI via `skills.ResolveRelative(skillRoot, "references/FORMS.md")`.
+- **Read a nested-prefix skill (acme/billing/refunds)** — Demonstrates that the prefix-segment routing works end-to-end. The skill's `name` is `refunds`; the prefix `acme/billing/` is server-chosen.
+- **Read a supporting file in the nested skill (templates/email.md)** — Same relative-reference resolution: `templates/email.md` from refunds/SKILL.md.
+
+## Flow
+
+```mermaid
+sequenceDiagram
+    participant Host as MCP Host (this client)
+    participant Server as MCP Server (make serve, file mode by default)
+
+    Note over Host,Server: Step 1: Connect to the skills server
+    Host->>Server: POST /mcp — initialize
+    Server-->>Host: serverInfo + capabilities (with extensions.skills = {})
+
+    Note over Host,Server: Step 2: resources/list returns every cataloged skill URI
+    Host->>Server: resources/list
+    Server-->>Host: resources[] including skill://index.json + each SKILL.md
+
+    Note over Host,Server: Step 3: Read skill://index.json
+    Host->>Server: resources/read uri=skill://index.json
+    Server-->>Host: { $schema, skills: [...] }
+
+    Note over Host,Server: Step 4: Verify digest by re-fetching SKILL.md and recomputing SHA-256
+    Host->>Server: resources/read uri=skill://git-workflow/SKILL.md
+    Server-->>Host: text/markdown body
+
+    Note over Host,Server: Step 5: Read the pdf-processing SKILL.md
+    Host->>Server: resources/read uri=skill://pdf-processing/SKILL.md
+    Server-->>Host: text/markdown body
+
+    Note over Host,Server: Step 6: Read a supporting file via skill:// (references/FORMS.md)
+    Host->>Server: resources/read uri=skill://pdf-processing/references/FORMS.md
+    Server-->>Host: text/markdown body
+
+    Note over Host,Server: Step 7: Read a nested-prefix skill (acme/billing/refunds)
+    Host->>Server: resources/read uri=skill://acme/billing/refunds/SKILL.md
+    Server-->>Host: text/markdown body
+
+    Note over Host,Server: Step 8: Read a supporting file in the nested skill (templates/email.md)
+    Host->>Server: resources/read uri=skill://acme/billing/refunds/templates/email.md
+    Server-->>Host: text/markdown body
+```
+
+## Steps
+
+### Setup
+
+Start the MCP server in a separate terminal first:
+
+```
+Terminal 1:  make serve         # skills server on :8080 in file mode
+Terminal 2:  make demo          # this walkthrough (--tui for the interactive TUI)
+```
+
+The default fixture under `skills/` walks three SEP-2640 examples: a single-segment skill (`git-workflow`), a single-segment skill with supporting files (`pdf-processing`), and a nested-prefix skill (`acme/billing/refunds`).
+
+Two alternative server modes flip the wire shape:
+
+```
+make serve-archive   # publishes each skill as one .tar.gz resource
+make serve-zip       # publishes each skill as one .zip resource
+```
+
+In archive mode `resources/list` returns one URI per skill (e.g. `skill://pdf-processing.tar.gz`) instead of N URIs per file. The post-unpack virtual namespace hosts observe is identical either way — that's the SEP's whole-skill atomic-delivery story.
+
+Optional: `make fetch-docx` clones the [`anthropics/skills`](https://github.com/anthropics/skills) repo and stages the `docx` skill into the `skills/` fixture directory before you start the server. It's a multi-file real-world skill that exercises the supporting-file paths beyond the toy fixtures.
+
+### The skill:// URI scheme
+
+SEP-2640 defines `skill://<skill-path>/<file-path>` where `<skill-path>` is a `/`-separated path locating the skill directory and `<file-path>` is the file within it. The final segment of `<skill-path>` MUST equal the skill's `name` frontmatter field. Prefix segments (anything before that final segment) are an optional server-chosen organizational namespace.
+
+Examples from the SEP table that this walkthrough exercises:
+
+| Skill path             | File                  | URI                                              |
+| ---------------------- | --------------------- | ------------------------------------------------ |
+| `git-workflow`         | `SKILL.md`            | `skill://git-workflow/SKILL.md`                  |
+| `pdf-processing`       | `references/FORMS.md` | `skill://pdf-processing/references/FORMS.md`     |
+| `acme/billing/refunds` | `SKILL.md`            | `skill://acme/billing/refunds/SKILL.md`          |
+
+The `acme/billing/refunds` shape demonstrates the prefix-segment behavior: `acme/billing` is the prefix and `refunds` is the skill name. The walkthrough reads files from each shape to confirm the routing is uniform.
+
+### Capability declaration
+
+Per SEP-2640's Capability Declaration section, a server advertises `io.modelcontextprotocol/skills` under `capabilities.extensions` in its `initialize` response. The value is the empty object `{}` — never an array. mcpkit's `ext/skills.SkillsExtension{}` plus `Provider.RegisterWith(srv)` handles this automatically; nothing else to wire on the server side.
+
+### Step 1: Connect to the skills server
+
+`client.NewClient(...)` + `Connect()`. The server side wired the extension automatically via `Provider.RegisterWith`.
+
+### Step 2: resources/list returns every cataloged skill URI
+
+In file mode the list has N entries per skill (one for SKILL.md, one for each supporting file) plus the index. In archive mode it's one entry per skill plus the index.
+
+### The discovery index
+
+`skill://index.json` is the well-known enumeration resource. It's optional in the SEP (servers MAY decline to expose it) but mcpkit auto-registers it unless `WithoutIndex()` is supplied. The index has a fixed JSON shape: a `$schema` URI pinning the index version and a `skills[]` array where each entry has `type` (`skill-md`, `archive`, or `mcp-resource-template`), `description`, `url`, plus (for `skill-md` and `archive` entries) `name` and `digest`.
+
+### Step 3: Read skill://index.json
+
+The Indexer caches the result with TTL + per-skill mtime invalidation. Repeated reads return the same bytes until something in a SKILL.md actually changes.
+
+### The digest contract
+
+Per SEP-2640's Integrity and Verification section, each `skill-md` and `archive` entry carries a `sha256:{64-lowercase-hex}` digest computed over the artifact's raw bytes. For `skill-md` entries the artifact is the SKILL.md file itself; for `archive` entries it's the packed archive bytes. Hosts MUST verify retrieved content against this digest before using it. The walkthrough does exactly that for the `git-workflow` skill.
+
+### Step 4: Verify digest by re-fetching SKILL.md and recomputing SHA-256
+
+Treat the response bytes as the artifact, hash them, and compare against the digest field from the index. A mismatch indicates corruption or tampering and per the SEP the host MUST NOT use the content.
+
+### Reading skill files
+
+Once a host has loaded a SKILL.md, the skill's body may reference supporting files via relative paths. mcpkit's `ext/skills.ResolveRelative(skillRoot, ref)` resolves these against the skill's root URI per SEP-2640's Reading section (filesystem-style resolution, escapes via `..` rejected). The walkthrough exercises both forms: the manifest, and a supporting file deep in the skill tree.
+
+### Step 5: Read the pdf-processing SKILL.md
+
+This skill's frontmatter has `version` and `tags` Extra fields. mcpkit surfaces those under `ResourceDef.Annotations` keyed by `io.modelcontextprotocol.skills/`.
+
+### Step 6: Read a supporting file via skill:// (references/FORMS.md)
+
+Relative reference `references/FORMS.md` from within pdf-processing/SKILL.md resolves to this full URI via `skills.ResolveRelative(skillRoot, "references/FORMS.md")`.
+
+### Step 7: Read a nested-prefix skill (acme/billing/refunds)
+
+Demonstrates that the prefix-segment routing works end-to-end. The skill's `name` is `refunds`; the prefix `acme/billing/` is server-chosen.
+
+### Step 8: Read a supporting file in the nested skill (templates/email.md)
+
+Same relative-reference resolution: `templates/email.md` from refunds/SKILL.md.
+
+### Wrap-up
+
+The host has now:
+
+- Negotiated the skills extension via the standard `initialize` handshake.
+- Enumerated every skill the server publishes by reading `skill://index.json` once.
+- Verified one artifact's bytes against its SHA-256 digest, satisfying the SEP MUST.
+- Read SKILL.md plus supporting files across single-segment and nested-prefix skill paths.
+
+To switch the same walkthrough into archive mode, restart the server with `make serve-archive`. The host code stays exactly the same; the wire-level shape switches to one `.tar.gz` resource per skill, and the digest in the index covers the packed archive bytes instead of the SKILL.md alone.
+
+## Run it
+
+```bash
+go run ./examples/skills/
+```
+
+Pass `--non-interactive` to skip pauses:
+
+```bash
+go run ./examples/skills/ --non-interactive
+```

--- a/examples/skills/go.mod
+++ b/examples/skills/go.mod
@@ -9,6 +9,7 @@ replace github.com/panyam/mcpkit/ext/skills => ../../ext/skills
 replace github.com/panyam/mcpkit/examples/common => ../common
 
 require (
+	github.com/panyam/demokit v0.0.25
 	github.com/panyam/mcpkit v0.2.45
 	github.com/panyam/mcpkit/examples/common v0.0.0-00010101000000-000000000000
 	github.com/panyam/mcpkit/ext/skills v0.0.0-00010101000000-000000000000
@@ -43,7 +44,6 @@ require (
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
-	github.com/panyam/demokit v0.0.25 // indirect
 	github.com/panyam/demokit/notebook v0.0.25 // indirect
 	github.com/panyam/gocurrent v0.1.1 // indirect
 	github.com/panyam/goutils v0.1.13 // indirect

--- a/examples/skills/main.go
+++ b/examples/skills/main.go
@@ -1,5 +1,9 @@
-// Example: SEP-2640 skills extension — server fixture for the
-// conformance suite and minimal worked example.
+// Example: SEP-2640 skills extension — server fixture + demokit walkthrough.
+//
+// Two-process architecture (matches the events/discord and tasks examples):
+//
+//	Terminal 1:  make serve         # skills server on :8080 in file mode
+//	Terminal 2:  make demo          # walkthrough (--tui for interactive TUI)
 //
 // Walks the bundled skills/ directory through ext/skills.SkillProvider
 // and exposes each skill either as individual file resources (file
@@ -13,15 +17,14 @@
 //	go run . --serve                    # file mode on :8080
 //	go run . --serve --mode=archive     # archive mode on :8080
 //	go run . --serve --addr=:9090       # different port
-//
-// The walkthrough.go scripted demo is deferred — see mcpkit#566 for
-// the demokit walkthrough sweep that will turn this into a fully
-// documented example.
+//	go run .                            # walkthrough (against --url, default localhost:8080)
+//	go run . --tui                      # walkthrough in interactive TUI
+//	go run . --note                     # walkthrough in notebook mode
+//	go run . --doc=md                   # regenerate WALKTHROUGH.md
 package main
 
 import (
 	"flag"
-	"fmt"
 	"log"
 	"os"
 	"strings"
@@ -39,8 +42,7 @@ func main() {
 			return
 		}
 	}
-	fmt.Println("examples/skills — see --serve to run the MCP server.")
-	fmt.Println("Conformance: cd ../../conformance && make testconf-skills")
+	runDemo()
 }
 
 func serve() {

--- a/examples/skills/scripts/fetch-docx-skill.sh
+++ b/examples/skills/scripts/fetch-docx-skill.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Stage Anthropic's docx skill from the public anthropics/skills repo
+# into examples/skills/skills/ so the demokit walkthrough can exercise a
+# real-world multi-file skill alongside the bundled toy fixtures.
+#
+# The skill is fetched at run time rather than vendored to keep the
+# example's git history small and to avoid licence ambiguity. Re-running
+# is a no-op if the staged copy is up to date.
+#
+# Mirrors the fetch-at-build-time pattern used by
+# scripts/apps-playwright-test.sh.
+#
+# Requires: git
+set -euo pipefail
+
+# Locate the example dir (this script lives at examples/skills/scripts/).
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+EXAMPLE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+STAGE_DIR="$EXAMPLE_DIR/skills/docx"
+CACHE_DIR="${ANTHROPIC_SKILLS_CACHE:-/tmp/anthropics-skills-cache}"
+REPO_URL="https://github.com/anthropics/skills.git"
+
+if ! command -v git >/dev/null 2>&1; then
+    echo "fetch-docx: git not found on PATH" >&2
+    exit 1
+fi
+
+if [ ! -d "$CACHE_DIR" ]; then
+    echo "Cloning $REPO_URL into $CACHE_DIR..."
+    git clone --depth 1 "$REPO_URL" "$CACHE_DIR"
+else
+    echo "Updating cached $CACHE_DIR..."
+    git -C "$CACHE_DIR" fetch --depth 1 origin main
+    git -C "$CACHE_DIR" reset --hard origin/main
+fi
+
+# Find the docx skill. The source repo layout has historically been
+# skills/document-skills/docx, but allow either nesting depth.
+SOURCE=""
+for candidate in "$CACHE_DIR/skills/document-skills/docx" \
+                 "$CACHE_DIR/skills/docx" \
+                 "$CACHE_DIR/docx"; do
+    if [ -f "$candidate/SKILL.md" ]; then
+        SOURCE="$candidate"
+        break
+    fi
+done
+
+if [ -z "$SOURCE" ]; then
+    echo "fetch-docx: could not find docx/SKILL.md under $CACHE_DIR" >&2
+    echo "Inspect the upstream layout and tweak this script." >&2
+    exit 1
+fi
+
+echo "Staging $SOURCE -> $STAGE_DIR"
+rm -rf "$STAGE_DIR"
+mkdir -p "$STAGE_DIR"
+cp -R "$SOURCE/." "$STAGE_DIR/"
+
+# SEP-2640 requires the frontmatter `name` to equal the final segment of
+# the skill path. Our skill path will be "docx" (matching $STAGE_DIR's
+# basename), so the upstream SKILL.md should already say `name: docx`.
+# Verify and warn if not.
+if ! grep -qE '^name:[[:space:]]*docx' "$STAGE_DIR/SKILL.md"; then
+    echo "WARNING: $STAGE_DIR/SKILL.md frontmatter name does not equal 'docx'." >&2
+    echo "         SEP-2640 requires the final skill-path segment to match the name." >&2
+    echo "         The provider will reject this skill at startup. Edit the frontmatter or rename the dir." >&2
+fi
+
+echo "done. Restart 'make serve' to pick up the staged docx skill."

--- a/examples/skills/walkthrough.go
+++ b/examples/skills/walkthrough.go
@@ -1,0 +1,313 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/panyam/demokit"
+	"github.com/panyam/mcpkit/client"
+	"github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/examples/common"
+	"github.com/panyam/mcpkit/ext/skills"
+)
+
+const (
+	uriGitWorkflow    = "skill://git-workflow/SKILL.md"
+	uriPDFManifest    = "skill://pdf-processing/SKILL.md"
+	uriPDFRef         = "skill://pdf-processing/references/FORMS.md"
+	uriRefundsManifest = "skill://acme/billing/refunds/SKILL.md"
+	uriRefundsEmail    = "skill://acme/billing/refunds/templates/email.md"
+	uriIndex           = skills.IndexURI
+)
+
+func runDemo() {
+	serverURL := common.ServerURL()
+
+	demo := demokit.New("MCP Skills Extension (SEP-2640) — Reference Walkthrough").
+		Dir("skills").
+		Description("Walks through SEP-2640, which serves Agent Skills over MCP using the existing Resources primitive. Each file in a skill directory is exposed as a `skill://` resource, the server declares the `io.modelcontextprotocol/skills` capability in `initialize`, and the well-known `skill://index.json` resource enumerates concrete skills with SHA-256 digests. mcpkit's `ext/skills.SkillProvider` walks an `io/fs.FS` once at construction and registers each file with the configured Provider.").
+		Actors(
+			demokit.Actor("Host", "MCP Host (this client)"),
+			demokit.Actor("Server", "MCP Server (make serve, file mode by default)"),
+		)
+
+	demo.Section("Setup",
+		"Start the MCP server in a separate terminal first:",
+		"",
+		"```",
+		"Terminal 1:  make serve         # skills server on :8080 in file mode",
+		"Terminal 2:  make demo          # this walkthrough (--tui for the interactive TUI)",
+		"```",
+		"",
+		"The default fixture under `skills/` walks three SEP-2640 examples: a single-segment skill (`git-workflow`), a single-segment skill with supporting files (`pdf-processing`), and a nested-prefix skill (`acme/billing/refunds`).",
+		"",
+		"Two alternative server modes flip the wire shape:",
+		"",
+		"```",
+		"make serve-archive   # publishes each skill as one .tar.gz resource",
+		"make serve-zip       # publishes each skill as one .zip resource",
+		"```",
+		"",
+		"In archive mode `resources/list` returns one URI per skill (e.g. `skill://pdf-processing.tar.gz`) instead of N URIs per file. The post-unpack virtual namespace hosts observe is identical either way — that's the SEP's whole-skill atomic-delivery story.",
+		"",
+		"Optional: `make fetch-docx` clones the [`anthropics/skills`](https://github.com/anthropics/skills) repo and stages the `docx` skill into the `skills/` fixture directory before you start the server. It's a multi-file real-world skill that exercises the supporting-file paths beyond the toy fixtures.",
+	)
+
+	demo.Section("The skill:// URI scheme",
+		"SEP-2640 defines `skill://<skill-path>/<file-path>` where `<skill-path>` is a `/`-separated path locating the skill directory and `<file-path>` is the file within it. The final segment of `<skill-path>` MUST equal the skill's `name` frontmatter field. Prefix segments (anything before that final segment) are an optional server-chosen organizational namespace.",
+		"",
+		"Examples from the SEP table that this walkthrough exercises:",
+		"",
+		"| Skill path             | File                  | URI                                              |",
+		"| ---------------------- | --------------------- | ------------------------------------------------ |",
+		"| `git-workflow`         | `SKILL.md`            | `skill://git-workflow/SKILL.md`                  |",
+		"| `pdf-processing`       | `references/FORMS.md` | `skill://pdf-processing/references/FORMS.md`     |",
+		"| `acme/billing/refunds` | `SKILL.md`            | `skill://acme/billing/refunds/SKILL.md`          |",
+		"",
+		"The `acme/billing/refunds` shape demonstrates the prefix-segment behavior: `acme/billing` is the prefix and `refunds` is the skill name. The walkthrough reads files from each shape to confirm the routing is uniform.",
+	)
+
+	demo.Section("Capability declaration",
+		"Per SEP-2640's Capability Declaration section, a server advertises `io.modelcontextprotocol/skills` under `capabilities.extensions` in its `initialize` response. The value is the empty object `{}` — never an array. mcpkit's `ext/skills.SkillsExtension{}` plus `Provider.RegisterWith(srv)` handles this automatically; nothing else to wire on the server side.",
+	)
+
+	var (
+		c          *client.Client
+		serverInfo any
+	)
+
+	demo.Step("Connect to the skills server").
+		Arrow("Host", "Server", "POST /mcp — initialize").
+		DashedArrow("Server", "Host", "serverInfo + capabilities (with extensions.skills = {})").
+		Note("`client.NewClient(...)` + `Connect()`. The server side wired the extension automatically via `Provider.RegisterWith`.").
+		Run(func(ctx demokit.StepContext) *demokit.StepResult {
+			c = client.NewClient(serverURL+"/mcp",
+				core.ClientInfo{Name: "skills-host", Version: "1.0"},
+			)
+			if err := c.Connect(); err != nil {
+				fmt.Printf("    ERROR: %v\n    Start the server with: make serve\n", err)
+				return nil
+			}
+			serverInfo = c.ServerInfo
+			fmt.Printf("    Connected to %s %s\n", c.ServerInfo.Name, c.ServerInfo.Version)
+			if c.ServerSupportsExtension(skills.ExtensionID) {
+				fmt.Printf("    Server advertises %q under capabilities.extensions\n", skills.ExtensionID)
+			} else {
+				fmt.Printf("    WARNING: server did NOT advertise the skills capability\n")
+			}
+			return nil
+		})
+
+	demo.Step("resources/list returns every cataloged skill URI").
+		Arrow("Host", "Server", "resources/list").
+		DashedArrow("Server", "Host", "resources[] including skill://index.json + each SKILL.md").
+		Note("In file mode the list has N entries per skill (one for SKILL.md, one for each supporting file) plus the index. In archive mode it's one entry per skill plus the index.").
+		Run(func(ctx demokit.StepContext) *demokit.StepResult {
+			if c == nil {
+				return nil
+			}
+			defs, err := c.ListResources()
+			if err != nil {
+				fmt.Printf("    ERROR: %v\n", err)
+				return nil
+			}
+			fmt.Printf("    %d resources registered:\n", len(defs))
+			for _, d := range defs {
+				fmt.Printf("      %s    [%s]\n", d.URI, d.MimeType)
+			}
+			return nil
+		})
+
+	demo.Section("The discovery index",
+		"`skill://index.json` is the well-known enumeration resource. It's optional in the SEP (servers MAY decline to expose it) but mcpkit auto-registers it unless `WithoutIndex()` is supplied. The index has a fixed JSON shape: a `$schema` URI pinning the index version and a `skills[]` array where each entry has `type` (`skill-md`, `archive`, or `mcp-resource-template`), `description`, `url`, plus (for `skill-md` and `archive` entries) `name` and `digest`.",
+	)
+
+	var indexBody []byte
+
+	demo.Step("Read skill://index.json").
+		Arrow("Host", "Server", "resources/read uri=skill://index.json").
+		DashedArrow("Server", "Host", "{ $schema, skills: [...] }").
+		Note("The Indexer caches the result with TTL + per-skill mtime invalidation. Repeated reads return the same bytes until something in a SKILL.md actually changes.").
+		Run(func(ctx demokit.StepContext) *demokit.StepResult {
+			if c == nil {
+				return nil
+			}
+			body, err := c.ReadResource(uriIndex)
+			if err != nil {
+				fmt.Printf("    ERROR: %v\n", err)
+				return nil
+			}
+			indexBody = []byte(body)
+			var idx skills.Index
+			if err := json.Unmarshal(indexBody, &idx); err != nil {
+				fmt.Printf("    ERROR: index does not parse: %v\n", err)
+				return nil
+			}
+			fmt.Printf("    $schema: %s\n", idx.Schema)
+			fmt.Printf("    %d entries:\n", len(idx.Skills))
+			for _, e := range idx.Skills {
+				suffix := ""
+				if e.Digest != "" {
+					suffix = " digest=" + e.Digest[:14] + "…"
+				}
+				fmt.Printf("      [%s] %s%s\n        url=%s\n", e.Type, e.Name, suffix, e.URL)
+			}
+			return nil
+		})
+
+	demo.Section("The digest contract",
+		"Per SEP-2640's Integrity and Verification section, each `skill-md` and `archive` entry carries a `sha256:{64-lowercase-hex}` digest computed over the artifact's raw bytes. For `skill-md` entries the artifact is the SKILL.md file itself; for `archive` entries it's the packed archive bytes. Hosts MUST verify retrieved content against this digest before using it. The walkthrough does exactly that for the `git-workflow` skill.",
+	)
+
+	demo.Step("Verify digest by re-fetching SKILL.md and recomputing SHA-256").
+		Arrow("Host", "Server", "resources/read uri=skill://git-workflow/SKILL.md").
+		DashedArrow("Server", "Host", "text/markdown body").
+		Note("Treat the response bytes as the artifact, hash them, and compare against the digest field from the index. A mismatch indicates corruption or tampering and per the SEP the host MUST NOT use the content.").
+		Run(func(ctx demokit.StepContext) *demokit.StepResult {
+			if c == nil || len(indexBody) == 0 {
+				return nil
+			}
+			var idx skills.Index
+			if err := json.Unmarshal(indexBody, &idx); err != nil {
+				return nil
+			}
+			var want string
+			for _, e := range idx.Skills {
+				if e.URL == uriGitWorkflow {
+					want = e.Digest
+					break
+				}
+			}
+			if want == "" {
+				fmt.Printf("    git-workflow not found in index (server may be in archive mode)\n")
+				return nil
+			}
+			result, err := c.ReadResourceFull(uriGitWorkflow)
+			if err != nil {
+				fmt.Printf("    ERROR: %v\n", err)
+				return nil
+			}
+			content := result.Contents[0]
+			var raw []byte
+			if content.Text != "" {
+				raw = []byte(content.Text)
+			} else {
+				raw, _ = base64.StdEncoding.DecodeString(content.Blob)
+			}
+			sum := sha256.Sum256(raw)
+			got := "sha256:" + hex.EncodeToString(sum[:])
+			fmt.Printf("    want %s\n", want)
+			fmt.Printf("    got  %s\n", got)
+			if got == want {
+				fmt.Printf("    digest matches — content verified per SEP-2640 §Integrity\n")
+			} else {
+				fmt.Printf("    DIGEST MISMATCH — content MUST NOT be used per the SEP\n")
+			}
+			return nil
+		})
+
+	demo.Section("Reading skill files",
+		"Once a host has loaded a SKILL.md, the skill's body may reference supporting files via relative paths. mcpkit's `ext/skills.ResolveRelative(skillRoot, ref)` resolves these against the skill's root URI per SEP-2640's Reading section (filesystem-style resolution, escapes via `..` rejected). The walkthrough exercises both forms: the manifest, and a supporting file deep in the skill tree.",
+	)
+
+	demo.Step("Read the pdf-processing SKILL.md").
+		Arrow("Host", "Server", "resources/read uri=skill://pdf-processing/SKILL.md").
+		DashedArrow("Server", "Host", "text/markdown body").
+		Note("This skill's frontmatter has `version` and `tags` Extra fields. mcpkit surfaces those under `ResourceDef.Annotations` keyed by `io.modelcontextprotocol.skills/`.").
+		Run(func(ctx demokit.StepContext) *demokit.StepResult {
+			if c == nil {
+				return nil
+			}
+			body, err := c.ReadResource(uriPDFManifest)
+			if err != nil {
+				fmt.Printf("    SKIP: %v (server may be in archive mode)\n", err)
+				return nil
+			}
+			previewBody(body, 6)
+			return nil
+		})
+
+	demo.Step("Read a supporting file via skill:// (references/FORMS.md)").
+		Arrow("Host", "Server", "resources/read uri=skill://pdf-processing/references/FORMS.md").
+		DashedArrow("Server", "Host", "text/markdown body").
+		Note("Relative reference `references/FORMS.md` from within pdf-processing/SKILL.md resolves to this full URI via `skills.ResolveRelative(skillRoot, \"references/FORMS.md\")`.").
+		Run(func(ctx demokit.StepContext) *demokit.StepResult {
+			if c == nil {
+				return nil
+			}
+			body, err := c.ReadResource(uriPDFRef)
+			if err != nil {
+				fmt.Printf("    SKIP: %v\n", err)
+				return nil
+			}
+			previewBody(body, 6)
+			return nil
+		})
+
+	demo.Step("Read a nested-prefix skill (acme/billing/refunds)").
+		Arrow("Host", "Server", "resources/read uri=skill://acme/billing/refunds/SKILL.md").
+		DashedArrow("Server", "Host", "text/markdown body").
+		Note("Demonstrates that the prefix-segment routing works end-to-end. The skill's `name` is `refunds`; the prefix `acme/billing/` is server-chosen.").
+		Run(func(ctx demokit.StepContext) *demokit.StepResult {
+			if c == nil {
+				return nil
+			}
+			body, err := c.ReadResource(uriRefundsManifest)
+			if err != nil {
+				fmt.Printf("    SKIP: %v\n", err)
+				return nil
+			}
+			previewBody(body, 6)
+			return nil
+		})
+
+	demo.Step("Read a supporting file in the nested skill (templates/email.md)").
+		Arrow("Host", "Server", "resources/read uri=skill://acme/billing/refunds/templates/email.md").
+		DashedArrow("Server", "Host", "text/markdown body").
+		Note("Same relative-reference resolution: `templates/email.md` from refunds/SKILL.md.").
+		Run(func(ctx demokit.StepContext) *demokit.StepResult {
+			if c == nil {
+				return nil
+			}
+			body, err := c.ReadResource(uriRefundsEmail)
+			if err != nil {
+				fmt.Printf("    SKIP: %v\n", err)
+				return nil
+			}
+			previewBody(body, 6)
+			return nil
+		})
+
+	demo.Section("Wrap-up",
+		"The host has now:",
+		"",
+		"- Negotiated the skills extension via the standard `initialize` handshake.",
+		"- Enumerated every skill the server publishes by reading `skill://index.json` once.",
+		"- Verified one artifact's bytes against its SHA-256 digest, satisfying the SEP MUST.",
+		"- Read SKILL.md plus supporting files across single-segment and nested-prefix skill paths.",
+		"",
+		"To switch the same walkthrough into archive mode, restart the server with `make serve-archive`. The host code stays exactly the same; the wire-level shape switches to one `.tar.gz` resource per skill, and the digest in the index covers the packed archive bytes instead of the SKILL.md alone.",
+	)
+
+	_ = serverInfo
+	common.SetupRenderer(demo)
+	demo.Execute()
+}
+
+// previewBody prints up to n lines of the body for the walkthrough output.
+// Skill bodies are short so this is enough to confirm the round trip without
+// flooding the terminal.
+func previewBody(body string, n int) {
+	lines := strings.Split(body, "\n")
+	for i, line := range lines {
+		if i >= n {
+			fmt.Printf("    … (%d more lines)\n", len(lines)-n)
+			return
+		}
+		fmt.Printf("    %s\n", line)
+	}
+}


### PR DESCRIPTION
## What changes

End-to-end demokit walkthrough for SEP-2640 stacked on top of the `examples/skills` server fixture that PR 580 landed. main.go gains the standard dual-mode dispatch (`--serve` for the server, bare invocation for the walkthrough). The walkthrough drives a real mcpkit client through every spec interaction: initialize handshake + capability declaration, resources/list, skill://index.json parse, SHA-256 digest verification (satisfies the SEP MUST), reads across single-segment and nested-prefix skills. Closes T11 (mcpkit 566).

Adds `fetch-docx-skill.sh` to stage Anthropic's docx skill at run time from the public anthropics/skills repo, beyond the toy fixtures.

## Reviewer's guide

Read in this order:

1. [examples/skills/walkthrough.go](https://github.com/panyam/mcpkit/pull/582/files#diff-94afaa0ca3ed61f670feefe88925e3b5ecfc827cfcdb7612d48a01dd289c10e7) (NEW). The whole walkthrough. Read demo description + actors first, then Section walkthroughs (URI scheme, capability, digest contract), then the 8 steps. Each step has Arrow/DashedArrow + Note + Run closure. The digest verification step is the SEP-2640 MUST coverage.
2. [examples/skills/main.go](https://github.com/panyam/mcpkit/pull/582/files#diff-5b14977a06843ef8ea751a41d80e1cd9eb927a784069536cf93b0857dc9261fc). Two-line dispatch change: bare invocation now calls runDemo() instead of printing help. `--serve` flow is unchanged.
3. [examples/skills/Makefile](https://github.com/panyam/mcpkit/pull/582/files#diff-89a6fd1faf006dc8b0381a24373161a3f04d460d2fb5e59d6f5ee81968ba1ea0). New targets: `demo`, `tui`, `note`, `readme`, `fetch-docx`. Pattern matches events/discord and tasks-v2.
4. [examples/skills/WALKTHROUGH.md](https://github.com/panyam/mcpkit/pull/582/files#diff-f7567dfcd105e517415a8fc5aada2b08489ad36774f38681b85f5855a3638884) (NEW, auto-generated). Sequence diagram + per-step rationale. Regenerate via `make readme`. SKIM only. The source of truth is the walkthrough.go demo definitions.
5. [examples/skills/scripts/fetch-docx-skill.sh](https://github.com/panyam/mcpkit/pull/582/files#diff-11e95e50904b98bbc358831222567ccf2748a0456a738e6e0e5bf8e083d9a28a) (NEW). Clones anthropics/skills to a cache dir (override via \$ANTHROPIC_SKILLS_CACHE) and stages the docx skill into the fixture tree. Fail-warns if the upstream frontmatter name does not match the staged path basename so the provider's strict SEP-2640 check surfaces cleanly.
6. [examples/skills/README.md](https://github.com/panyam/mcpkit/pull/582/files#diff-838b28f05fc72c41a3a72248334b284415816fa64583f8128a20bc1357ccb420). Updated to call out the demokit modes, the bundled fixture shape, the docx fetch path, and the conformance role.
7. [examples/skills/go.mod](https://github.com/panyam/mcpkit/pull/582/files#diff-8dafe1b9fce133b921232b8dd138744132822b608b6c9913830c506bf1d6b502). demokit promoted from indirect to direct dep.

## Decision log

- **`common.SetupRenderer(demo)` before `demo.Execute()`.** Wires the renderer based on `demokit.Mode()` so `--tui` and `--note` flip into the matching renderer. Same line every other walkthrough-bearing example uses. Without it the `make tui` and `make note` targets fall through to the plain renderer silently.
- **Skip the `mcpkit-skills` CLI from T10 / 565.** The original T11 ticket envisioned `mcpkit skills serve <dir>` as the entry point. The CLI is not built yet, so the walkthrough drives the existing `examples/skills/skills-demo --serve` instead. Functionally identical for the demo purpose. When the CLI lands the README's run command updates without touching the walkthrough.
- **docx fetched at run time, not vendored.** Same shape as `scripts/apps-playwright-test.sh`. Keeps the example repo small and avoids vendoring third-party content with its own licence terms.
- **Fetch script warns instead of fixing the frontmatter mismatch.** Upstream's skill name could change without notice. Rewriting upstream content silently would hide that. A loud warning forces the user to acknowledge and tweak the staging path or the SKILL.md.
- **The walkthrough degrades gracefully in archive mode.** Steps that target file-mode-specific URIs (`skill://pdf-processing/SKILL.md`, etc.) call ReadResource and report SKIP on error rather than fatal. So `make serve-archive` + `make demo` still produces useful output. Only the file-specific steps SKIP, the digest and index steps run against the archive entries.
- **Per-example serve() refactor deferred.** Each example has its own ~30-line serve() with mostly identical scaffolding. Filed as mcpkit 581 to extract `common.RunServer(name, addr, prefix, register, opts...)` across all examples in a focused refactor rather than bundling here.

## Risk / blast radius

- **Affects:** `examples/skills/` only. No other example or package is touched. demokit is the only direct dep added.
- **Tests covering this:** smoke-tested by hand. The walkthrough boots, all 8 steps run, the digest verification succeeds against the served bytes, and `WALKTHROUGH.md` regenerates byte-identical to what's committed. `make testall` stage 8h (testconf-skills) continues to surface the fork-side scenarios as INFO because their state has not changed.
- **Be paranoid about:**
  - **Frontmatter name mismatch on the fetched docx skill.** `scripts/fetch-docx-skill.sh` warns rather than fixes. If upstream renames the skill, `make serve` after `make fetch-docx` errors with `ErrSkillNameMismatch` until someone tweaks the staging path or the SKILL.md.
  - **demokit's notebook renderer (`make note`).** Mode-specific UI. Not exercised end-to-end here because it requires Bubble Tea input. The `make demo` text mode and `make tui` interactive mode were both verified.
  - **WALKTHROUGH.md staleness gate.** Currently no CI gate. If the walkthrough's demo definitions change without regenerating WALKTHROUGH.md, the committed copy drifts. Worth considering a staleness check in a follow-up if drift becomes a problem.

## Test plan

- [x] `go build` on `examples/skills/` succeeds.
- [x] `/tmp/skills-demo --serve --addr=:18080` boots. Initialize response declares the skills capability.
- [x] `/tmp/skills-demo --url http://localhost:18080 --non-interactive` runs all 8 steps, digest verification passes.
- [x] `/tmp/skills-demo --tui` boots without runtime errors.
- [x] `/tmp/skills-demo --doc=md` produces the committed WALKTHROUGH.md byte-identical.
- [ ] `make fetch-docx` against a clean machine. Not exercised today. The script is straightforward git + cp, but the upstream layout may have moved.

## Out of scope

- `mcpkit-skills` CLI binary (T10 / mcpkit 565). Separate ticket.
- `examples/common.RunServer` extraction across all examples (mcpkit 581, filed during this PR).
- Doc-site rendering for INFO conformance stages. Separate PR.
- Fork-side SEP-2640 Scenario classes (mcpkit 567). Separate PR.

