### PR TITLE
examples: extract common.RunServer helper across examples/ (581)

### DIFF
--- a/examples/CONVENTIONS.md
+++ b/examples/CONVENTIONS.md
@@ -98,32 +98,52 @@ func main() {
   ```
   Renderer / mode predicates use `demokit.IsTUI()` and `demokit.IsNonInteractive()` —
   no hand-rolled `os.Args` scans.
-- Listen + logger + middleware come from `examples/common` in one call:
+- The full bootstrap-and-serve loop comes from `common.RunServer`. Construct
+  the canonical baseline (listen + logger + middleware), register tools, log
+  `[<name>] listening on <addr>`, and call `srv.ListenAndServe(WithStreamableHTTP(true), ...)`
+  with graceful-shutdown wiring in one call:
   ```go
-  srv := server.NewServer(
-      core.ServerInfo{Name: "<name>", Version: "0.1.0"},
-      common.MCPServerOptions(*addr, "[mcp] ")...,
-  )
+  if err := common.RunServer(common.ServerConfig{
+      Name: "<name>",
+      Addr: *addr,
+      Options: []server.Option{
+          server.WithExtension(&ui.UIExtension{}),
+          server.WithFileInputValidation(),
+      },
+      Register: func(srv *server.Server) {
+          registerTools(srv)
+      },
+  }); err != nil {
+      log.Fatalf("ListenAndServe: %v", err)
+  }
   ```
-  `common.MCPServerOptions` returns `[]server.Option` containing
-  `WithListen` plus the canonical color-logger wired to both
-  `WithRequestLogging` and `WithMiddleware(LoggingMiddleware)`. To append
-  example-specific options:
-  ```go
-  opts := common.MCPServerOptions(*addr, "[mcp] ")
-  opts = append(opts, server.WithListTTL(60), server.WithExtension(...))
-  srv := server.NewServer(info, opts...)
-  ```
-  Need the logger handle for non-server use (extra rules, custom log
-  lines)? Drop down to `common.NewMCPLogger(prefix, ...extraRules)` +
-  `common.WithMCPLogging(logger)`.
-- Serve via `srv.ListenAndServe(server.WithStreamableHTTP(true))` — graceful
-  shutdown is built in (server/server.go:879 wraps
-  `gohttp.ListenAndServeGraceful`). **Never** call `http.ListenAndServe`
-  directly.
+  Fields beyond `Name`/`Addr`:
+  - `Version` defaults to `"0.1.0"`.
+  - `LogPrefix` defaults to `"[mcp] "` and is passed to the canonical
+    color logger.
+  - `Options` appends `server.Option`s (e.g. `WithExtension`,
+    `WithListCacheControl`, `WithAuth`) to the baseline before `NewServer`.
+  - `Register` runs after `NewServer` so it has the `*server.Server` for
+    `RegisterTool` / `UseMiddleware` / extension registration.
+  - `TransportOptions` appends `server.TransportOption`s after
+    `WithStreamableHTTP(true)` at `ListenAndServe` time — use for
+    `WithStatelessMode`, `WithMux`, `WithHandlerWrap`, `WithSSE`, etc.
+  - `Logger` (optional `*log.Logger`) — when set, RunServer skips
+    `MCPServerOptions` and uses `WithMCPLogging(Logger)` instead, so
+    callers that need custom color rules (`NewMCPLogger(prefix, extras...)`)
+    keep their handle.
+
+  When the serve loop diverges substantially from this shape (parallel
+  webhook listeners, multiple servers in one process), fall back to
+  manual `common.MCPServerOptions(*addr, "[mcp] ")` + `server.NewServer`
+  + `srv.ListenAndServe(...)`. The canonical exception today is
+  `examples/events/discord/` — see its `main.go` for why.
+
 - Side endpoints (e.g. `/inject` for synthetic events) go through
-  `server.WithMux(func(mux *http.ServeMux) { ... })` — not a hand-rolled
-  `http.Server{}`.
+  `server.WithMux(func(mux *http.ServeMux) { ... })` (in `TransportOptions`)
+  — not a hand-rolled `http.Server{}`. Graceful shutdown is built into
+  `srv.ListenAndServe` via `gohttp.ListenAndServeGraceful`; **never** call
+  `http.ListenAndServe` directly.
 
 ### Logger color rules (canonical set)
 
@@ -416,8 +436,11 @@ output rather than emitted as N/A.
   through to `runDemo()` otherwise.
 - [ ] `logger-colorlogger` — `serve()` uses `demokit.NewColorLogger` (not
   `log.Default()`, not stdlib `log` only).
-- [ ] `serve-srv-listenandserve` — `serve()` uses `srv.ListenAndServe(...)`,
-  not `http.ListenAndServe(...)`.
+- [ ] `serve-srv-listenandserve` — `serve()` uses `common.RunServer(...)` or
+  `srv.ListenAndServe(...)` (never `http.ListenAndServe(...)`). Prefer
+  `common.RunServer` for the canonical bootstrap-and-serve loop; fall back
+  to manual `ListenAndServe` only when the example has a documented
+  divergence (e.g. `examples/events/discord/`).
 - [ ] `mux-withmux` — side-endpoint registration uses `server.WithMux(...)`,
   not a hand-rolled `http.Server{}`. (Skip if the example has no side
   endpoints.)

--- a/examples/auth/main.go
+++ b/examples/auth/main.go
@@ -459,20 +459,6 @@ func serve() {
 	listenURL := fmt.Sprintf("http://localhost%s", *addr)
 	validator := env.NewValidator(listenURL)
 
-	opts := []server.Option{server.WithListen(*addr)}
-	opts = append(opts, common.WithMCPLogging(logger)...)
-	opts = append(opts,
-		server.WithAuth(validator),
-		server.WithPublicMethods("initialize", "notifications/initialized", "tools/list", "prompts/list", "ping"),
-		server.WithMiddleware(server.ToolCallLogger(logger)),
-	)
-	srv := server.NewServer(
-		core.ServerInfo{Name: "auth-unified", Version: "1.0"},
-		opts...,
-	)
-	authcommon.RegisterEchoTools(srv)
-	srv.UseMiddleware(auth.NewToolScopeMiddleware(srv.Registry()))
-
 	// Pre-mint tokens for the walkthrough.
 	tokRead := env.MintToken("alice", []string{"read"})
 	tokReadWrite := env.MintToken("alice", []string{"read", "write"})
@@ -492,7 +478,6 @@ func serve() {
 	// `subject_token` parameter for the RFC 8693 token-exchange grant.
 	tokUpstreamAssertion := env.MintUpstreamAssertion("alice")
 
-	log.Printf("Auth example on %s", addr)
 	log.Printf("MCP endpoint: %s/mcp", listenURL)
 	log.Printf("Bootstrap:    %s/demo/bootstrap", listenURL)
 	log.Printf("AS issuer:    %s", env.AS.Issuer())
@@ -503,32 +488,46 @@ func serve() {
 	log.Printf("  alice/[read write admin]:  %s", tokAll)
 	log.Printf("  bob/[read write admin]:    %s", tokBob)
 
-	if err := srv.ListenAndServe(
-		server.WithStreamableHTTP(true),
-		server.WithMux(func(m *http.ServeMux) {
-			// Bootstrap endpoint for the demokit walkthrough.
-			m.HandleFunc("GET /demo/bootstrap", func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(bootstrapInfo{
-					MCPURL:               listenURL + "/mcp",
-					TokRead:              tokRead,
-					TokReadWrite:         tokReadWrite,
-					TokAll:               tokAll,
-					TokBob:               tokBob,
-					TokExpired:           tokExpired,
-					TokWrongAudience:     tokWrongAud,
-					TokWrongIssuer:       tokWrongIss,
-					TokUpstreamAssertion: tokUpstreamAssertion,
+	if err := common.RunServer(common.ServerConfig{
+		Name:    "auth-unified",
+		Version: "1.0",
+		Addr:    *addr,
+		Logger:  logger,
+		Options: []server.Option{
+			server.WithAuth(validator),
+			server.WithPublicMethods("initialize", "notifications/initialized", "tools/list", "prompts/list", "ping"),
+			server.WithMiddleware(server.ToolCallLogger(logger)),
+		},
+		Register: func(srv *server.Server) {
+			authcommon.RegisterEchoTools(srv)
+			srv.UseMiddleware(auth.NewToolScopeMiddleware(srv.Registry()))
+		},
+		TransportOptions: []server.TransportOption{
+			server.WithMux(func(m *http.ServeMux) {
+				// Bootstrap endpoint for the demokit walkthrough.
+				m.HandleFunc("GET /demo/bootstrap", func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					json.NewEncoder(w).Encode(bootstrapInfo{
+						MCPURL:               listenURL + "/mcp",
+						TokRead:              tokRead,
+						TokReadWrite:         tokReadWrite,
+						TokAll:               tokAll,
+						TokBob:               tokBob,
+						TokExpired:           tokExpired,
+						TokWrongAudience:     tokWrongAud,
+						TokWrongIssuer:       tokWrongIss,
+						TokUpstreamAssertion: tokUpstreamAssertion,
+					})
 				})
-			})
-			auth.MountAuth(m, auth.AuthConfig{
-				ResourceURI:          listenURL,
-				AuthorizationServers: []string{env.AS.Issuer()},
-				ScopesSupported:      env.Scopes,
-				MCPPath:              "/mcp",
-			})
-		}),
-	); err != nil {
+				auth.MountAuth(m, auth.AuthConfig{
+					ResourceURI:          listenURL,
+					AuthorizationServers: []string{env.AS.Issuer()},
+					ScopesSupported:      env.Scopes,
+					MCPPath:              "/mcp",
+				})
+			}),
+		},
+	}); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/examples/common/runserver.go
+++ b/examples/common/runserver.go
@@ -1,0 +1,108 @@
+package common
+
+import (
+	"log"
+
+	"github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/server"
+)
+
+// ServerConfig is the canonical config for a non-UI mcpkit example
+// server. Name and Addr are required; everything else has a sensible
+// default. See RunServer for the wiring contract.
+type ServerConfig struct {
+	// Name is the server name reported via core.ServerInfo (required).
+	Name string
+
+	// Version is reported via core.ServerInfo. Defaults to "0.1.0" when
+	// empty — examples rarely care about the value and benefit from a
+	// stable default.
+	Version string
+
+	// Addr is the TCP listen address passed to server.WithListen
+	// (required). Defaults are intentionally NOT applied here so a
+	// missing addr surfaces at startup instead of binding ":8080"
+	// silently.
+	Addr string
+
+	// LogPrefix is the canonical color-logger prefix passed to
+	// MCPServerOptions. Defaults to "[mcp] " when empty.
+	//
+	// Ignored when Logger is non-nil — the caller is then responsible
+	// for the prefix attached to the logger they pass in.
+	LogPrefix string
+
+	// Logger is an optional pre-built logger. When set, RunServer skips
+	// MCPServerOptions and wires logging via WithMCPLogging(Logger) so
+	// callers that need custom color rules (NewMCPLogger extras) keep
+	// their handle. When nil, the canonical 5-rule logger is used.
+	Logger *log.Logger
+
+	// Options are additional server options appended to the canonical
+	// baseline (WithListen + logging) before NewServer is called. Use
+	// for construct-time wiring like WithExtension, WithAuth,
+	// WithListCacheControl, etc.
+	Options []server.Option
+
+	// Register is invoked after NewServer for tool/middleware/extension
+	// registration that requires the constructed *server.Server. Called
+	// before ListenAndServe so registrations are live by the time the
+	// transport starts accepting connections. May be nil.
+	Register func(*server.Server)
+
+	// TransportOptions are appended after server.WithStreamableHTTP(true)
+	// when calling ListenAndServe. Use for serve-time wiring like
+	// WithStatelessMode, WithSSE, WithEventStore, etc.
+	TransportOptions []server.TransportOption
+}
+
+// RunServer wires up the canonical mcpkit-example server lifecycle:
+//
+//  1. Build baseline options (WithListen + canonical color logger via
+//     MCPServerOptions, or WithListen + WithMCPLogging(cfg.Logger) when
+//     a pre-built logger is supplied).
+//  2. Append cfg.Options.
+//  3. Construct *server.Server with core.ServerInfo{Name, Version}.
+//  4. Invoke cfg.Register (if set) for tool/middleware registration.
+//  5. Log "[<name>] listening on <addr>".
+//  6. Call srv.ListenAndServe(WithStreamableHTTP(true), cfg.TransportOptions...).
+//
+// Behaves like a normal blocking serve — returns whatever
+// ListenAndServe returns (typically a graceful-shutdown nil or a bind
+// error). Callers that need to log additional info (extra tool names,
+// temp dirs, etc.) should log before calling RunServer; the helper's
+// own "listening on" line stays minimal and uniform across examples.
+//
+// For examples whose serve loop diverges substantially from this
+// shape (mux setup with side endpoints, parallel webhook listeners),
+// build the server manually with NewMCPLogger + MCPServerOptions and
+// call srv.ListenAndServe directly — see examples/events/discord/ for
+// the canonical exception.
+func RunServer(cfg ServerConfig) error {
+	if cfg.Version == "" {
+		cfg.Version = "0.1.0"
+	}
+	if cfg.LogPrefix == "" {
+		cfg.LogPrefix = "[mcp] "
+	}
+
+	var opts []server.Option
+	if cfg.Logger != nil {
+		opts = append(opts, server.WithListen(cfg.Addr))
+		opts = append(opts, WithMCPLogging(cfg.Logger)...)
+	} else {
+		opts = append(opts, MCPServerOptions(cfg.Addr, cfg.LogPrefix)...)
+	}
+	opts = append(opts, cfg.Options...)
+
+	srv := server.NewServer(core.ServerInfo{Name: cfg.Name, Version: cfg.Version}, opts...)
+
+	if cfg.Register != nil {
+		cfg.Register(srv)
+	}
+
+	log.Printf("[%s] listening on %s", cfg.Name, cfg.Addr)
+
+	transportOpts := append([]server.TransportOption{server.WithStreamableHTTP(true)}, cfg.TransportOptions...)
+	return srv.ListenAndServe(transportOpts...)
+}

--- a/examples/elicitation/main.go
+++ b/examples/elicitation/main.go
@@ -326,38 +326,7 @@ func serve() {
 	))
 	listenURL := fmt.Sprintf("http://localhost%s", *addr)
 	consent := newConsentStore()
-
 	logger := common.NewMCPLogger("[mcp] ")
-	srv := server.NewServer(core.ServerInfo{
-		Name:    "elicitation-example",
-		Version: "1.0.0",
-	}, append([]server.Option{server.WithListen(*addr)}, common.WithMCPLogging(logger)...)...)
-
-	srv.RegisterTool(
-		core.ToolDef{
-			Name:        "access_protected_resource",
-			Description: "Access a protected resource. Requires user approval via URL consent flow on first call.",
-			InputSchema: json.RawMessage(`{
-				"type": "object",
-				"properties": {
-					"resourceId": {"type": "string", "description": "Resource to access"}
-				}
-			}`),
-		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
-			var args struct {
-				ResourceID string `json:"resourceId"`
-			}
-			json.Unmarshal(req.Arguments, &args)
-			if args.ResourceID == "" {
-				args.ResourceID = "default-resource"
-			}
-			return core.TextResult(fmt.Sprintf(
-				"Access granted to resource %q (approved via consent)", args.ResourceID)), nil
-		},
-	)
-
-	srv.UseMiddleware(consentMiddleware(consent, listenURL))
 
 	cors := middleware.CORS(nil,
 		middleware.CORSAllowMethods("GET", "POST", "DELETE", "OPTIONS"),
@@ -365,19 +334,49 @@ func serve() {
 		middleware.CORSExposeHeaders("Mcp-Session-Id"),
 	)
 
-	fmt.Printf("Elicitation example server on %s\n", *addr)
 	fmt.Printf("MCP endpoint: %s/mcp\n", listenURL)
 	fmt.Printf("Tools: access_protected_resource\n")
 
-	if err := srv.ListenAndServe(
-		server.WithStreamableHTTP(true),
-		server.WithMux(func(mux *http.ServeMux) {
-			mux.HandleFunc("/approve", consent.handleApprove)
-		}),
-		// Browser-based MCP hosts (MCPJam) need CORS on /mcp; WithHandlerWrap
-		// applies it to every route the server exposes, including /approve.
-		server.WithHandlerWrap(cors),
-	); err != nil {
+	if err := common.RunServer(common.ServerConfig{
+		Name:    "elicitation-example",
+		Version: "1.0.0",
+		Addr:    *addr,
+		Logger:  logger,
+		Register: func(srv *server.Server) {
+			srv.RegisterTool(
+				core.ToolDef{
+					Name:        "access_protected_resource",
+					Description: "Access a protected resource. Requires user approval via URL consent flow on first call.",
+					InputSchema: json.RawMessage(`{
+						"type": "object",
+						"properties": {
+							"resourceId": {"type": "string", "description": "Resource to access"}
+						}
+					}`),
+				},
+				func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+					var args struct {
+						ResourceID string `json:"resourceId"`
+					}
+					json.Unmarshal(req.Arguments, &args)
+					if args.ResourceID == "" {
+						args.ResourceID = "default-resource"
+					}
+					return core.TextResult(fmt.Sprintf(
+						"Access granted to resource %q (approved via consent)", args.ResourceID)), nil
+				},
+			)
+			srv.UseMiddleware(consentMiddleware(consent, listenURL))
+		},
+		TransportOptions: []server.TransportOption{
+			server.WithMux(func(mux *http.ServeMux) {
+				mux.HandleFunc("/approve", consent.handleApprove)
+			}),
+			// Browser-based MCP hosts (MCPJam) need CORS on /mcp; WithHandlerWrap
+			// applies it to every route the server exposes, including /approve.
+			server.WithHandlerWrap(cors),
+		},
+	}); err != nil {
 		fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
 		os.Exit(1)
 	}

--- a/examples/file-inputs/main.go
+++ b/examples/file-inputs/main.go
@@ -57,29 +57,27 @@ func serve() {
 		log.Fatalf("mktemp: %v", err)
 	}
 
-	opts := common.MCPServerOptions(*addr, "[mcp] ")
-	opts = append(opts,
-		// MCP Apps extension powers the in-iframe file picker apps
-		// registered in apps.go (SEP-2356 Phase 2.1).
-		server.WithExtension(&ui.UIExtension{}),
-		// SEP-2356 Phase 1.4 — auto-validate file-typed args (size +
-		// MIME) against the descriptor declared in each tool's
-		// InputSchema. Failures surface as -32602 with structured data.
-		server.WithFileInputValidation(),
-	)
-	srv := server.NewServer(
-		core.ServerInfo{Name: "file-inputs-demo", Version: "0.1.0"},
-		opts...,
-	)
-
-	registerTools(srv, uploadDir)
-	registerAppsTools(srv, uploadDir)
-
-	log.Printf("[file-inputs-demo] listening on %s — POST /mcp", *addr)
+	log.Printf("[file-inputs-demo] POST /mcp")
 	log.Printf("[file-inputs-demo] tools: upload_image, analyze_documents, process_any_file")
 	log.Printf("[file-inputs-demo] apps:  apps_upload_image, apps_analyze_documents (in-iframe pickers)")
 	log.Printf("[file-inputs-demo] uploads will be written to %s (not auto-cleaned)", uploadDir)
-	if err := srv.ListenAndServe(server.WithStreamableHTTP(true)); err != nil {
+	if err := common.RunServer(common.ServerConfig{
+		Name: "file-inputs-demo",
+		Addr: *addr,
+		Options: []server.Option{
+			// MCP Apps extension powers the in-iframe file picker apps
+			// registered in apps.go (SEP-2356 Phase 2.1).
+			server.WithExtension(&ui.UIExtension{}),
+			// SEP-2356 Phase 1.4 — auto-validate file-typed args (size +
+			// MIME) against the descriptor declared in each tool's
+			// InputSchema. Failures surface as -32602 with structured data.
+			server.WithFileInputValidation(),
+		},
+		Register: func(srv *server.Server) {
+			registerTools(srv, uploadDir)
+			registerAppsTools(srv, uploadDir)
+		},
+	}); err != nil {
 		log.Fatalf("ListenAndServe: %v", err)
 	}
 }

--- a/examples/fine-grained-auth/main.go
+++ b/examples/fine-grained-auth/main.go
@@ -704,21 +704,6 @@ func serve() {
 	validator.Start()
 	defer validator.Stop()
 
-	// 3. MCP server with auth + scope-enforcement middleware.
-	opts := []server.Option{server.WithListen(*addr)}
-	opts = append(opts, common.WithMCPLogging(logger)...)
-	opts = append(opts,
-		server.WithAuth(validator),
-		server.WithMiddleware(server.ToolCallLogger(logger)),
-	)
-	srv := server.NewServer(
-		core.ServerInfo{Name: "fine-grained-auth-example", Version: "1.0.0"},
-		opts...,
-	)
-	registerTools(srv)
-	srv.UseMiddleware(auth.NewToolScopeMiddleware(srv.Registry()))
-	srv.UseMiddleware(paymentAuthorizationMiddleware())
-
 	// 4. CORS for browser-based MCP hosts; applied via WithHandlerWrap so
 	// it covers /mcp + the auth.MountAuth routes + /demo/bootstrap uniformly.
 	cors := middleware.CORS(nil,
@@ -727,7 +712,6 @@ func serve() {
 		middleware.CORSExposeHeaders("Mcp-Session-Id"),
 	)
 
-	fmt.Printf("Fine-Grained Auth server on %s\n", *addr)
 	fmt.Printf("MCP endpoint:   %s/mcp\n", listenURL)
 	fmt.Printf("AS URL:         %s\n", asInfo.ASURL)
 	fmt.Printf("AS JWKS:        %s\n", asInfo.JWKSURL)
@@ -742,28 +726,43 @@ func serve() {
 	fmt.Printf("\nSeed docs: doc-001, doc-123, doc-456\n")
 	fmt.Printf("Inspect:   ls %s/ ; cat %s/doc-123.txt\n", docDir, docDir)
 
-	if err := srv.ListenAndServe(
-		server.WithStreamableHTTP(true),
-		server.WithMux(func(mux *http.ServeMux) {
-			auth.MountAuth(mux, auth.AuthConfig{
-				ResourceURI:          listenURL,
-				AuthorizationServers: []string{asInfo.ASURL},
-				ScopesSupported:      []string{scopeRead, scopeCall},
-				MCPPath:              "/mcp",
-			})
-			mux.HandleFunc("GET /demo/bootstrap", func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(bootstrapInfo{
-					ASURL:         asInfo.ASURL,
-					TokenEndpoint: asInfo.TokenEndpoint,
-					JWKSURL:       asInfo.JWKSURL,
-					ClientID:      asInfo.ClientID,
-					ClientSecret:  asInfo.ClientSecret,
+	// 3. MCP server with auth + scope-enforcement middleware.
+	if err := common.RunServer(common.ServerConfig{
+		Name:    "fine-grained-auth-example",
+		Version: "1.0.0",
+		Addr:    *addr,
+		Logger:  logger,
+		Options: []server.Option{
+			server.WithAuth(validator),
+			server.WithMiddleware(server.ToolCallLogger(logger)),
+		},
+		Register: func(srv *server.Server) {
+			registerTools(srv)
+			srv.UseMiddleware(auth.NewToolScopeMiddleware(srv.Registry()))
+			srv.UseMiddleware(paymentAuthorizationMiddleware())
+		},
+		TransportOptions: []server.TransportOption{
+			server.WithMux(func(mux *http.ServeMux) {
+				auth.MountAuth(mux, auth.AuthConfig{
+					ResourceURI:          listenURL,
+					AuthorizationServers: []string{asInfo.ASURL},
+					ScopesSupported:      []string{scopeRead, scopeCall},
+					MCPPath:              "/mcp",
 				})
-			})
-		}),
-		server.WithHandlerWrap(cors),
-	); err != nil {
+				mux.HandleFunc("GET /demo/bootstrap", func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					json.NewEncoder(w).Encode(bootstrapInfo{
+						ASURL:         asInfo.ASURL,
+						TokenEndpoint: asInfo.TokenEndpoint,
+						JWKSURL:       asInfo.JWKSURL,
+						ClientID:      asInfo.ClientID,
+						ClientSecret:  asInfo.ClientSecret,
+					})
+				})
+			}),
+			server.WithHandlerWrap(cors),
+		},
+	}); err != nil {
 		fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
 		os.Exit(1)
 	}

--- a/examples/list-ttl/main.go
+++ b/examples/list-ttl/main.go
@@ -51,65 +51,15 @@ func serve() {
 		demokit.ValueFlag("--url"),
 	))
 
-	opts := common.MCPServerOptions(*addr, "[mcp] ")
 	// The same ttlMs / cacheScope applies to the four list endpoints and to
 	// resources/read — SEP-2549 added resources/read to the coverage list.
+	var extraOpts []server.Option
 	if *ttlMs >= 0 || *scope != "" {
-		opts = append(opts,
+		extraOpts = append(extraOpts,
 			server.WithListCacheControl(*ttlMs, *scope),
 			server.WithReadResourceCacheControl(*ttlMs, *scope),
 		)
 	}
-
-	srv := server.NewServer(core.ServerInfo{Name: "list-ttl-demo", Version: "0.1.0"}, opts...)
-
-	srv.RegisterTool(
-		core.ToolDef{
-			Name:        "ping",
-			Description: "Returns 'pong'",
-			InputSchema: map[string]any{"type": "object"},
-		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
-			return core.TextResult("pong"), nil
-		},
-	)
-
-	srv.RegisterResource(
-		core.ResourceDef{
-			URI:      "file:///fixture",
-			Name:     "fixture",
-			MimeType: "text/plain",
-		},
-		func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
-			return core.ResourceResult{
-				Contents: []core.ResourceReadContent{{
-					URI:      req.URI,
-					MimeType: "text/plain",
-					Text:     "fixture",
-				}},
-			}, nil
-		},
-	)
-
-	srv.RegisterResourceTemplate(
-		core.ResourceTemplate{URITemplate: "file:///t/{name}", Name: "tmpl"},
-		func(ctx core.ResourceContext, uri string, params map[string]string) (core.ResourceResult, error) {
-			return core.ResourceResult{
-				Contents: []core.ResourceReadContent{{
-					URI:      uri,
-					MimeType: "text/plain",
-					Text:     "templated:" + params["name"],
-				}},
-			}, nil
-		},
-	)
-
-	srv.RegisterPrompt(
-		core.PromptDef{Name: "hello", Description: "Sample prompt"},
-		func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResponse, error) {
-			return core.PromptResult{}, nil
-		},
-	)
 
 	mode := "unset"
 	if *ttlMs == 0 {
@@ -121,8 +71,62 @@ func serve() {
 	if scopeMode == "" {
 		scopeMode = "unset"
 	}
-	log.Printf("[list-ttl-demo] listening on %s — ttlMs: %s, cacheScope: %s", *addr, mode, scopeMode)
-	if err := srv.ListenAndServe(server.WithStreamableHTTP(true)); err != nil {
+	log.Printf("[list-ttl-demo] ttlMs: %s, cacheScope: %s", mode, scopeMode)
+
+	if err := common.RunServer(common.ServerConfig{
+		Name:    "list-ttl-demo",
+		Addr:    *addr,
+		Options: extraOpts,
+		Register: func(srv *server.Server) {
+			srv.RegisterTool(
+				core.ToolDef{
+					Name:        "ping",
+					Description: "Returns 'pong'",
+					InputSchema: map[string]any{"type": "object"},
+				},
+				func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+					return core.TextResult("pong"), nil
+				},
+			)
+
+			srv.RegisterResource(
+				core.ResourceDef{
+					URI:      "file:///fixture",
+					Name:     "fixture",
+					MimeType: "text/plain",
+				},
+				func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
+					return core.ResourceResult{
+						Contents: []core.ResourceReadContent{{
+							URI:      req.URI,
+							MimeType: "text/plain",
+							Text:     "fixture",
+						}},
+					}, nil
+				},
+			)
+
+			srv.RegisterResourceTemplate(
+				core.ResourceTemplate{URITemplate: "file:///t/{name}", Name: "tmpl"},
+				func(ctx core.ResourceContext, uri string, params map[string]string) (core.ResourceResult, error) {
+					return core.ResourceResult{
+						Contents: []core.ResourceReadContent{{
+							URI:      uri,
+							MimeType: "text/plain",
+							Text:     "templated:" + params["name"],
+						}},
+					}, nil
+				},
+			)
+
+			srv.RegisterPrompt(
+				core.PromptDef{Name: "hello", Description: "Sample prompt"},
+				func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResponse, error) {
+					return core.PromptResult{}, nil
+				},
+			)
+		},
+	}); err != nil {
 		log.Fatalf("ListenAndServe: %v", err)
 	}
 }

--- a/examples/mrtr/main.go
+++ b/examples/mrtr/main.go
@@ -68,24 +68,25 @@ func serve() {
 		demokit.ValueFlag("--url"),
 	))
 
-	opts := common.MCPServerOptions(*addr, "[mcp] ")
+	var extraOpts []server.Option
 	if *signingKey != "" {
-		opts = append(opts, server.WithRequestStateSigning([]byte(*signingKey), 24*time.Hour))
+		extraOpts = append(extraOpts, server.WithRequestStateSigning([]byte(*signingKey), 24*time.Hour))
 	}
 
-	srv := server.NewServer(core.ServerInfo{Name: "mrtr-demo", Version: "0.1.0"}, opts...)
-
-	registerMRTRTools(srv)
-
-	// SEP-2322 + SEP-2663 composition: the registry holds at least one
-	// task-eligible tool (test_tool_with_task) that gathers input via MRTR
-	// rounds and then escalates to async via the GoAsync sentinel. The
-	// taskV2Middleware is what observes the GoAsync return and spawns the
-	// continuation goroutine.
-	tasks.Register(tasks.Config{Server: srv})
-
-	log.Printf("[mrtr-demo] listening on %s", *addr)
-	if err := srv.ListenAndServe(server.WithStreamableHTTP(true)); err != nil {
+	if err := common.RunServer(common.ServerConfig{
+		Name:    "mrtr-demo",
+		Addr:    *addr,
+		Options: extraOpts,
+		Register: func(srv *server.Server) {
+			registerMRTRTools(srv)
+			// SEP-2322 + SEP-2663 composition: the registry holds at least one
+			// task-eligible tool (test_tool_with_task) that gathers input via
+			// MRTR rounds and then escalates to async via the GoAsync sentinel.
+			// The taskV2Middleware is what observes the GoAsync return and spawns
+			// the continuation goroutine.
+			tasks.Register(tasks.Config{Server: srv})
+		},
+	}); err != nil {
 		log.Fatalf("ListenAndServe: %v", err)
 	}
 }

--- a/examples/skills/main.go
+++ b/examples/skills/main.go
@@ -29,7 +29,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/panyam/mcpkit/core"
 	"github.com/panyam/mcpkit/examples/common"
 	"github.com/panyam/mcpkit/ext/skills"
 	"github.com/panyam/mcpkit/server"
@@ -72,15 +71,15 @@ func serve() {
 		log.Fatalf("skills.NewProvider: %v", err)
 	}
 
-	srvOpts := common.MCPServerOptions(*addr, "[skills] ")
-	srv := server.NewServer(
-		core.ServerInfo{Name: "skills-demo", Version: "0.1.0"},
-		srvOpts...,
-	)
-	provider.RegisterWith(srv)
-
-	log.Printf("[skills-demo] mode=%s skills=%s listening on %s", *modeFlag, *skillsDir, *addr)
-	if err := srv.ListenAndServe(server.WithStreamableHTTP(true)); err != nil {
+	log.Printf("[skills-demo] mode=%s skills=%s", *modeFlag, *skillsDir)
+	if err := common.RunServer(common.ServerConfig{
+		Name:      "skills-demo",
+		Addr:      *addr,
+		LogPrefix: "[skills] ",
+		Register: func(srv *server.Server) {
+			provider.RegisterWith(srv)
+		},
+	}); err != nil {
 		log.Fatalf("ListenAndServe: %v", err)
 	}
 }

--- a/examples/stateless/main.go
+++ b/examples/stateless/main.go
@@ -67,21 +67,20 @@ func serve() {
 		log.Fatalf("invalid --mode: %q (want legacy|dual|stateless)", *modeFlag)
 	}
 
-	opts := common.MCPServerOptions(*addr, "[stateless] ")
-	srv := server.NewServer(
-		core.ServerInfo{Name: "stateless-demo", Version: "0.1.0"},
-		opts...,
-	)
-
-	registerCartTools(srv, newCartStore())
-	registerDiagnosticTools(srv)
-	registerSeedPrompt(srv)
-
-	log.Printf("[stateless-demo] mode=%s listening on %s", mode, *addr)
-	if err := srv.ListenAndServe(
-		server.WithStreamableHTTP(true),
-		server.WithStatelessMode(mode),
-	); err != nil {
+	log.Printf("[stateless-demo] mode=%s", mode)
+	if err := common.RunServer(common.ServerConfig{
+		Name:      "stateless-demo",
+		Addr:      *addr,
+		LogPrefix: "[stateless] ",
+		Register: func(srv *server.Server) {
+			registerCartTools(srv, newCartStore())
+			registerDiagnosticTools(srv)
+			registerSeedPrompt(srv)
+		},
+		TransportOptions: []server.TransportOption{
+			server.WithStatelessMode(mode),
+		},
+	}); err != nil {
 		log.Fatalf("ListenAndServe: %v", err)
 	}
 }

--- a/examples/tasks-v2/main.go
+++ b/examples/tasks-v2/main.go
@@ -47,11 +47,29 @@ func serve() {
 		demokit.ValueFlag("--url"),
 	))
 
-	srv := server.NewServer(
-		core.ServerInfo{Name: "tasks-v2-demo", Version: "0.1.0"},
-		common.MCPServerOptions(*addr, "[mcp] ")...,
-	)
+	log.Printf("Connect: http://localhost%s/mcp", *addr)
+	log.Printf("")
+	log.Printf("Tools:")
+	log.Printf("  greet              — sync-only")
+	log.Printf("  slow_compute       — optional task (server-directed)")
+	log.Printf("  failing_job        — required task (tool error → completed + isError)")
+	log.Printf("  confirm_delete     — required task (input_required → tasks/update → completed)")
+	log.Printf("  multi_input        — required task (two simultaneous inputRequests for partial fulfillment)")
+	log.Printf("  protocol_error_job — required task (protocol error → failed + error)")
+	log.Printf("  external_job       — required task (TaskCallbacks proxy)")
 
+	if err := common.RunServer(common.ServerConfig{
+		Name: "tasks-v2-demo",
+		Addr: *addr,
+		Register: func(srv *server.Server) {
+			registerTasksV2DemoTools(srv)
+		},
+	}); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func registerTasksV2DemoTools(srv *server.Server) {
 	// greet: sync-only tool. No Execution field = taskSupport forbidden.
 	type greetInput struct {
 		Name string `json:"name" jsonschema:"description=Name to greet,required"`
@@ -311,19 +329,4 @@ func serve() {
 	// Register v2 tasks on the server (canonical RegisterTasks since SEP-2663
 	// — v2 takes the canonical name; v1 lives at RegisterTasksV1).
 	tasks.Register(tasks.Config{Server: srv})
-
-	log.Printf("Tasks v2 demo server on %s", *addr)
-	log.Printf("Connect: http://localhost%s/mcp", *addr)
-	log.Printf("")
-	log.Printf("Tools:")
-	log.Printf("  greet              — sync-only")
-	log.Printf("  slow_compute       — optional task (server-directed)")
-	log.Printf("  failing_job        — required task (tool error → completed + isError)")
-	log.Printf("  confirm_delete     — required task (input_required → tasks/update → completed)")
-	log.Printf("  multi_input        — required task (two simultaneous inputRequests for partial fulfillment)")
-	log.Printf("  protocol_error_job — required task (protocol error → failed + error)")
-	log.Printf("  external_job       — required task (TaskCallbacks proxy)")
-	if err := srv.Run(*addr); err != nil {
-		log.Fatal(err)
-	}
 }

--- a/examples/tasks/main.go
+++ b/examples/tasks/main.go
@@ -46,11 +46,27 @@ func serve() {
 		demokit.ValueFlag("--url"),
 	))
 
-	srv := server.NewServer(
-		core.ServerInfo{Name: "tasks-demo", Version: "0.1.0"},
-		common.MCPServerOptions(*addr, "[mcp] ")...,
-	)
+	registerAll := func(srv *server.Server) { registerTasksDemoTools(srv) }
 
+	log.Printf("Connect MCPJam or VS Code: http://localhost%s/mcp", *addr)
+	log.Printf("")
+	log.Printf("Tools:")
+	log.Printf("  greet          — sync-only (no task support)")
+	log.Printf("  slow_compute   — optional task support (try with/without 'task' hint)")
+	log.Printf("  failing_job    — required task support (must include 'task' hint)")
+	log.Printf("  confirm_delete — required task + elicitation (asks user before deleting)")
+	log.Printf("  write_haiku    — required task + sampling (asks LLM to write a haiku)")
+
+	if err := common.RunServer(common.ServerConfig{
+		Name:     "tasks-demo",
+		Addr:     *addr,
+		Register: registerAll,
+	}); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func registerTasksDemoTools(srv *server.Server) {
 	// greet: sync-only tool. No Execution field means taskSupport = forbidden.
 	// Calling with a task hint will return an error.
 	type greetInput struct {
@@ -277,17 +293,4 @@ func serve() {
 
 	// Register v1 tasks capability on the server.
 	server.RegisterTasksV1(server.TasksConfigV1{Server: srv})
-
-	log.Printf("Tasks demo server on %s", *addr)
-	log.Printf("Connect MCPJam or VS Code: http://localhost%s/mcp", *addr)
-	log.Printf("")
-	log.Printf("Tools:")
-	log.Printf("  greet          — sync-only (no task support)")
-	log.Printf("  slow_compute   — optional task support (try with/without 'task' hint)")
-	log.Printf("  failing_job    — required task support (must include 'task' hint)")
-	log.Printf("  confirm_delete — required task + elicitation (asks user before deleting)")
-	log.Printf("  write_haiku    — required task + sampling (asks LLM to write a haiku)")
-	if err := srv.Run(*addr); err != nil {
-		log.Fatal(err)
-	}
 }


### PR DESCRIPTION
## What changes

Every `examples/<name>/main.go` rolled its own ~30-line `serve()` that did the same five things — build options via `common.MCPServerOptions`, construct the `*server.Server`, register tools/middleware, log `"listening on …"`, and call `srv.ListenAndServe(WithStreamableHTTP(true))`. This PR extracts that loop into `common.RunServer(common.ServerConfig{…})` and rewrites every example whose serve loop fits the shape.

Refactored 10 examples:

- **Clean fit (7):** `file-inputs`, `list-ttl`, `mrtr`, `skills`, `stateless`, `tasks`, `tasks-v2`.
- **Custom-logger (3):** `elicitation`, `auth`, `fine-grained-auth` — they use `Logger` so their `NewMCPLogger(prefix, ...extras)` handle (color rules for `isError=`, `tool=`, etc.) keeps applying.

Deliberately not refactored (different bootstrap shape):

- `examples/events/discord/`, `examples/events/telegram/` — parallel webhook listeners and SSE / event-store wiring.
- `examples/apps/*` — different HTML-rendering shape, use `srv.Run`.
- `examples/auth/*` subdirs, `examples/host/*`, `examples/protogen/*` — out of the issue's "About 12 directories" scope.

## Reviewer's guide

Read in this order:

1. [examples/common/runserver.go](https://github.com/panyam/mcpkit/pull/585/files#diff-cd2029731d70db9b28a30c4c30e0e6fe798067de938d0f4c2c9314420abc1464) — start here. The helper and its `ServerConfig` struct (Name, Version, Addr, LogPrefix, Options, Register, TransportOptions, Logger).
2. [examples/CONVENTIONS.md](https://github.com/panyam/mcpkit/pull/585/files#diff-d763a016b06b1c666cdb643f94ccb8a6c1138b2a8327802b93aec40519b40e27) — the canonical shape documented for `/example-audit` and friends.
3. [examples/stateless/main.go](https://github.com/panyam/mcpkit/pull/585/files#diff-2e6c96495967b8c2087e545fb0cad0b339ab5ff0d9d88dcc017a51f654d7229d) — exercises `TransportOptions` (`WithStatelessMode`).
4. [examples/fine-grained-auth/main.go](https://github.com/panyam/mcpkit/pull/585/files#diff-cc8039b26a5505a2251ca47a3305daf3afc79ddc12a7655dbfb988074bf704d5) — exercises every field (Logger with extra color rules, Options with WithAuth + WithMiddleware, Register with three calls, TransportOptions with WithMux + WithHandlerWrap).
5. [examples/list-ttl/main.go](https://github.com/panyam/mcpkit/pull/585/files#diff-27c1fdd89acf3e5af2dd89ddda0b06a87005f5893fcf746eaab8cf0ec04fb0aa), [examples/mrtr/main.go](https://github.com/panyam/mcpkit/pull/585/files#diff-d999e8347c6d39541b70a61c0e2d2e454dd8e4ba01e9abff0f901e3958320040) — exercise conditional `Options`.

Skim or skip:
- [examples/file-inputs/main.go](https://github.com/panyam/mcpkit/pull/585/files#diff-dc43b578d1acfab45e65ebd6bfeb5afd34881709e8076ff8c00829798a640743), [examples/skills/main.go](https://github.com/panyam/mcpkit/pull/585/files#diff-5b14977a06843ef8ea751a41d80e1cd9eb927a784069536cf93b0857dc9261fc), [examples/tasks/main.go](https://github.com/panyam/mcpkit/pull/585/files#diff-afb90cb7ac0e1de0166e72d0c4945dda9b993efd078f5a8e8dcc598aa00a1b00), [examples/tasks-v2/main.go](https://github.com/panyam/mcpkit/pull/585/files#diff-072aac4bbcff96610a88cdebff776b325764aae392f71ad9c85bee454810f997), [examples/elicitation/main.go](https://github.com/panyam/mcpkit/pull/585/files#diff-0727bcf88d8f992e667962bb3b6fe7a76434d30adf3340b0575e6ee62641ce12), [examples/auth/main.go](https://github.com/panyam/mcpkit/pull/585/files#diff-fa43b479d6f58f3260149e5b8a86f09e921abb2f76b29038313564d4b5921a3a) — same shape as the above, no new patterns.

## Decision log

- **Struct config over the issue's positional `RunServer(name, addr, prefix, register, extraOpts...)`.** The issue's variadic mixed `server.Option` and `server.TransportOption` (incompatible types — `WithStreamableHTTP` is a `TransportOption`). The struct cleanly separates construct-time `Options` from serve-time `TransportOptions`, and matches the typed-entry preference captured in project memory.
- **`Logger *log.Logger` field, opt-in.** Three examples (elicitation, auth, fine-grained-auth) build the canonical logger with extra color rules via `NewMCPLogger(prefix, extras...)`. Without this field they would have to fall back to manual `MCPServerOptions` + `NewServer` + `ListenAndServe` — same boilerplate this PR set out to delete. When `Logger == nil`, RunServer uses `MCPServerOptions(Addr, LogPrefix)` like before.
- **Logging order shift.** The helper logs `[<name>] listening on <addr>` at one canonical point. Examples that previously embedded extra info in the same line (e.g. `"… — POST /mcp"`) now print those as separate `log.Printf` lines BEFORE calling RunServer, since ListenAndServe blocks. Stdout shape is preserved across smoke runs; only the inline grouping changes.

## Risk / blast radius

- Affects: 10 example servers; the helper lives in `examples/common` (already imported by every example sub-module — additive API).
- Tests covering this: `make test` (core) green; per-example `go vet ./...` green for all 10 refactored modules. No `*_test.go` exists in any example today, so coverage falls back to manual smoke + downstream conformance suites picking up regressions if anything broke.
- Be paranoid about: graceful-shutdown wiring on examples that previously called `srv.Run` (tasks, tasks-v2) — RunServer routes through `srv.ListenAndServe`, which wraps `gohttp.ListenAndServeGraceful`, same as the previous `srv.Run` path internally. Verified file-inputs binds, accepts initialize, and exits cleanly on SIGTERM.

## Before / after

`file-inputs` serve loop:

```diff
-opts := common.MCPServerOptions(*addr, "[mcp] ")
-opts = append(opts,
-    server.WithExtension(&ui.UIExtension{}),
-    server.WithFileInputValidation(),
-)
-srv := server.NewServer(
-    core.ServerInfo{Name: "file-inputs-demo", Version: "0.1.0"},
-    opts...,
-)
-registerTools(srv, uploadDir)
-registerAppsTools(srv, uploadDir)
-
-log.Printf("[file-inputs-demo] listening on %s — POST /mcp", *addr)
-log.Printf("[file-inputs-demo] tools: …")
-…
-if err := srv.ListenAndServe(server.WithStreamableHTTP(true)); err != nil {
-    log.Fatalf("ListenAndServe: %v", err)
-}
+log.Printf("[file-inputs-demo] POST /mcp")
+log.Printf("[file-inputs-demo] tools: …")
+…
+if err := common.RunServer(common.ServerConfig{
+    Name: "file-inputs-demo",
+    Addr: *addr,
+    Options: []server.Option{
+        server.WithExtension(&ui.UIExtension{}),
+        server.WithFileInputValidation(),
+    },
+    Register: func(srv *server.Server) {
+        registerTools(srv, uploadDir)
+        registerAppsTools(srv, uploadDir)
+    },
+}); err != nil {
+    log.Fatalf("ListenAndServe: %v", err)
+}
```

Smoke run output preserved (color logger lines, request logging, graceful SIGTERM shutdown).

## Out of scope (deliberately deferred)

- `examples/auth/*` subdirs (jwt/bearer/scopes/etc.) — use `srv.Run` with much shorter boilerplate; separate refactor if worth it.
- `examples/apps/*` — different bootstrap (HTML rendering, `srv.Run`); separate refactor if needed.
- `examples/events/discord/` exception is documented in `examples/CONVENTIONS.md` rather than this PR's body — the doc is the durable record.

## Test plan

- [x] `make test` (core) green
- [x] `go vet ./...` green in each refactored example sub-module
- [x] `go mod tidy` no-op in each refactored sub-module
- [x] Smoke: `examples/file-inputs --serve --addr=:18080` binds, accepts initialize, exits cleanly on SIGTERM. Log preserves canonical 5-rule color tints and request logging.
