### PR TITLE
examples/auth/*: adopt common.RunServer across auth subdirs (587)

### DIFF
--- a/examples/auth/bearer/main.go
+++ b/examples/auth/bearer/main.go
@@ -10,7 +10,6 @@ import (
 	"flag"
 	"log"
 
-	"github.com/panyam/mcpkit/core"
 	"github.com/panyam/mcpkit/examples/auth/common"
 	mcpcommon "github.com/panyam/mcpkit/examples/common"
 	"github.com/panyam/mcpkit/server"
@@ -20,17 +19,20 @@ func main() {
 	addr := flag.String("addr", ":8081", "listen address")
 	flag.Parse()
 
-	opts := mcpcommon.MCPServerOptions(*addr, "[mcp] ")
-	opts = append(opts, server.WithBearerToken("my-secret-token"))
-	srv := server.NewServer(
-		core.ServerInfo{Name: "auth-bearer", Version: "1.0"},
-		opts...,
-	)
-	common.RegisterEchoTools(srv)
-
-	log.Printf("Bearer auth example on %s (token: my-secret-token)", *addr)
+	log.Printf("Token: my-secret-token")
 	log.Printf("Connect MCPJam: http://localhost%s/mcp with header Authorization: Bearer my-secret-token", *addr)
-	if err := srv.Run(*addr); err != nil {
+
+	if err := mcpcommon.RunServer(mcpcommon.ServerConfig{
+		Name:    "auth-bearer",
+		Version: "1.0",
+		Addr:    *addr,
+		Options: []server.Option{
+			server.WithBearerToken("my-secret-token"),
+		},
+		Register: func(srv *server.Server) {
+			common.RegisterEchoTools(srv)
+		},
+	}); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/examples/auth/jwt/main.go
+++ b/examples/auth/jwt/main.go
@@ -13,7 +13,6 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/panyam/mcpkit/core"
 	"github.com/panyam/mcpkit/examples/auth/common"
 	mcpcommon "github.com/panyam/mcpkit/examples/common"
 	"github.com/panyam/mcpkit/ext/auth"
@@ -31,33 +30,34 @@ func main() {
 	listenURL := fmt.Sprintf("http://localhost%s", *addr)
 	validator := env.NewValidator(listenURL)
 
-	opts := mcpcommon.MCPServerOptions(*addr, "[mcp] ")
-	opts = append(opts, server.WithAuth(validator))
-	srv := server.NewServer(
-		core.ServerInfo{Name: "auth-jwt", Version: "1.0"},
-		opts...,
-	)
-	common.RegisterEchoTools(srv)
-
 	// Print a token for the user to copy-paste.
 	token := env.MintToken("alice", []string{"read", "write"})
-	log.Printf("JWT auth example on %s", *addr)
 	log.Printf("AS: %s (JWKS: %s)", env.AS.URL(), env.AS.JWKSURL())
 	log.Printf("")
 	log.Printf("Connect MCPJam: http://localhost%s/mcp", *addr)
 	log.Printf("Authorization: Bearer %s", token)
 
-	if err := srv.Run(*addr,
-		server.WithStreamableHTTP(true),
-		server.WithMux(func(mux *http.ServeMux) {
-			auth.MountAuth(mux, auth.AuthConfig{
-				ResourceURI:          listenURL,
-				AuthorizationServers: []string{env.AS.Issuer()},
-				ScopesSupported:      env.Scopes,
-				MCPPath:              "/mcp",
-			})
-		}),
-	); err != nil {
+	if err := mcpcommon.RunServer(mcpcommon.ServerConfig{
+		Name:    "auth-jwt",
+		Version: "1.0",
+		Addr:    *addr,
+		Options: []server.Option{
+			server.WithAuth(validator),
+		},
+		Register: func(srv *server.Server) {
+			common.RegisterEchoTools(srv)
+		},
+		TransportOptions: []server.TransportOption{
+			server.WithMux(func(mux *http.ServeMux) {
+				auth.MountAuth(mux, auth.AuthConfig{
+					ResourceURI:          listenURL,
+					AuthorizationServers: []string{env.AS.Issuer()},
+					ScopesSupported:      env.Scopes,
+					MCPPath:              "/mcp",
+				})
+			}),
+		},
+	}); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/examples/auth/public-discovery/main.go
+++ b/examples/auth/public-discovery/main.go
@@ -13,7 +13,6 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/panyam/mcpkit/core"
 	"github.com/panyam/mcpkit/examples/auth/common"
 	mcpcommon "github.com/panyam/mcpkit/examples/common"
 	"github.com/panyam/mcpkit/ext/auth"
@@ -30,20 +29,8 @@ func main() {
 	listenURL := fmt.Sprintf("http://localhost%s", *addr)
 	validator := env.NewValidator(listenURL)
 
-	opts := mcpcommon.MCPServerOptions(*addr, "[mcp] ")
-	opts = append(opts,
-		server.WithAuth(validator),
-		server.WithPublicMethods("initialize", "notifications/initialized", "tools/list", "prompts/list", "ping"),
-	)
-	srv := server.NewServer(
-		core.ServerInfo{Name: "auth-public-discovery", Version: "1.0"},
-		opts...,
-	)
-	common.RegisterEchoTools(srv)
-
 	token := env.MintToken("alice", []string{"read"})
 
-	log.Printf("Pre-auth discovery example on %s", *addr)
 	log.Printf("Connect MCPJam: http://localhost%s/mcp", *addr)
 	log.Printf("")
 	log.Printf("Public methods: initialize, tools/list, prompts/list, ping")
@@ -54,17 +41,28 @@ func main() {
 	log.Printf("")
 	log.Printf("Token: %s", token)
 
-	if err := srv.Run(*addr,
-		server.WithStreamableHTTP(true),
-		server.WithMux(func(mux *http.ServeMux) {
-			auth.MountAuth(mux, auth.AuthConfig{
-				ResourceURI:          listenURL,
-				AuthorizationServers: []string{env.AS.Issuer()},
-				ScopesSupported:      env.Scopes,
-				MCPPath:              "/mcp",
-			})
-		}),
-	); err != nil {
+	if err := mcpcommon.RunServer(mcpcommon.ServerConfig{
+		Name:    "auth-public-discovery",
+		Version: "1.0",
+		Addr:    *addr,
+		Options: []server.Option{
+			server.WithAuth(validator),
+			server.WithPublicMethods("initialize", "notifications/initialized", "tools/list", "prompts/list", "ping"),
+		},
+		Register: func(srv *server.Server) {
+			common.RegisterEchoTools(srv)
+		},
+		TransportOptions: []server.TransportOption{
+			server.WithMux(func(mux *http.ServeMux) {
+				auth.MountAuth(mux, auth.AuthConfig{
+					ResourceURI:          listenURL,
+					AuthorizationServers: []string{env.AS.Issuer()},
+					ScopesSupported:      env.Scopes,
+					MCPPath:              "/mcp",
+				})
+			}),
+		},
+	}); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/examples/auth/scopes/main.go
+++ b/examples/auth/scopes/main.go
@@ -13,7 +13,6 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/panyam/mcpkit/core"
 	"github.com/panyam/mcpkit/examples/auth/common"
 	mcpcommon "github.com/panyam/mcpkit/examples/common"
 	"github.com/panyam/mcpkit/ext/auth"
@@ -30,20 +29,10 @@ func main() {
 	listenURL := fmt.Sprintf("http://localhost%s", *addr)
 	validator := env.NewValidator(listenURL)
 
-	opts := mcpcommon.MCPServerOptions(*addr, "[mcp] ")
-	opts = append(opts, server.WithAuth(validator))
-	srv := server.NewServer(
-		core.ServerInfo{Name: "auth-scopes", Version: "1.0"},
-		opts...,
-	)
-	common.RegisterEchoTools(srv)
-	srv.UseMiddleware(auth.NewToolScopeMiddleware(srv.Registry()))
-
 	tokRead := env.MintToken("alice", []string{"read"})
 	tokReadWrite := env.MintToken("alice", []string{"read", "write"})
 	tokAll := env.MintToken("alice", []string{"read", "write", "admin"})
 
-	log.Printf("Scope enforcement example on %s", *addr)
 	log.Printf("Connect MCPJam: http://localhost%s/mcp", *addr)
 	log.Printf("")
 	log.Printf("Tokens (copy-paste into Authorization: Bearer <token>):")
@@ -53,17 +42,28 @@ func main() {
 	log.Printf("")
 	log.Printf("Try: echo (any token), write-tool (needs write), admin-tool (needs admin)")
 
-	if err := srv.Run(*addr,
-		server.WithStreamableHTTP(true),
-		server.WithMux(func(mux *http.ServeMux) {
-			auth.MountAuth(mux, auth.AuthConfig{
-				ResourceURI:          listenURL,
-				AuthorizationServers: []string{env.AS.Issuer()},
-				ScopesSupported:      env.Scopes,
-				MCPPath:              "/mcp",
-			})
-		}),
-	); err != nil {
+	if err := mcpcommon.RunServer(mcpcommon.ServerConfig{
+		Name:    "auth-scopes",
+		Version: "1.0",
+		Addr:    *addr,
+		Options: []server.Option{
+			server.WithAuth(validator),
+		},
+		Register: func(srv *server.Server) {
+			common.RegisterEchoTools(srv)
+			srv.UseMiddleware(auth.NewToolScopeMiddleware(srv.Registry()))
+		},
+		TransportOptions: []server.TransportOption{
+			server.WithMux(func(mux *http.ServeMux) {
+				auth.MountAuth(mux, auth.AuthConfig{
+					ResourceURI:          listenURL,
+					AuthorizationServers: []string{env.AS.Issuer()},
+					ScopesSupported:      env.Scopes,
+					MCPPath:              "/mcp",
+				})
+			}),
+		},
+	}); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/examples/auth/session-binding/main.go
+++ b/examples/auth/session-binding/main.go
@@ -13,7 +13,6 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/panyam/mcpkit/core"
 	"github.com/panyam/mcpkit/examples/auth/common"
 	mcpcommon "github.com/panyam/mcpkit/examples/common"
 	"github.com/panyam/mcpkit/ext/auth"
@@ -30,18 +29,9 @@ func main() {
 	listenURL := fmt.Sprintf("http://localhost%s", *addr)
 	validator := env.NewValidator(listenURL)
 
-	opts := mcpcommon.MCPServerOptions(*addr, "[mcp] ")
-	opts = append(opts, server.WithAuth(validator))
-	srv := server.NewServer(
-		core.ServerInfo{Name: "auth-session-binding", Version: "1.0"},
-		opts...,
-	)
-	common.RegisterEchoTools(srv)
-
 	tokAlice := env.MintToken("alice", []string{"read"})
 	tokBob := env.MintToken("bob", []string{"read"})
 
-	log.Printf("Session hijacking prevention example on %s", *addr)
 	log.Printf("Connect MCPJam: http://localhost%s/mcp", *addr)
 	log.Printf("")
 	log.Printf("Tokens (each creates a session bound to the user's sub claim):")
@@ -51,17 +41,27 @@ func main() {
 	log.Printf("Try: connect with alice's token, note session ID.")
 	log.Printf("Then try sending a request with bob's token to alice's session → 403")
 
-	if err := srv.Run(*addr,
-		server.WithStreamableHTTP(true),
-		server.WithMux(func(mux *http.ServeMux) {
-			auth.MountAuth(mux, auth.AuthConfig{
-				ResourceURI:          listenURL,
-				AuthorizationServers: []string{env.AS.Issuer()},
-				ScopesSupported:      env.Scopes,
-				MCPPath:              "/mcp",
-			})
-		}),
-	); err != nil {
+	if err := mcpcommon.RunServer(mcpcommon.ServerConfig{
+		Name:    "auth-session-binding",
+		Version: "1.0",
+		Addr:    *addr,
+		Options: []server.Option{
+			server.WithAuth(validator),
+		},
+		Register: func(srv *server.Server) {
+			common.RegisterEchoTools(srv)
+		},
+		TransportOptions: []server.TransportOption{
+			server.WithMux(func(mux *http.ServeMux) {
+				auth.MountAuth(mux, auth.AuthConfig{
+					ResourceURI:          listenURL,
+					AuthorizationServers: []string{env.AS.Issuer()},
+					ScopesSupported:      env.Scopes,
+					MCPPath:              "/mcp",
+				})
+			}),
+		},
+	}); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/examples/auth/unified/main.go
+++ b/examples/auth/unified/main.go
@@ -15,7 +15,6 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/panyam/mcpkit/core"
 	"github.com/panyam/mcpkit/examples/auth/common"
 	mcpcommon "github.com/panyam/mcpkit/examples/common"
 	"github.com/panyam/mcpkit/ext/auth"
@@ -32,25 +31,12 @@ func main() {
 	listenURL := fmt.Sprintf("http://localhost%s", *addr)
 	validator := env.NewValidator(listenURL)
 
-	opts := mcpcommon.MCPServerOptions(*addr, "[mcp] ")
-	opts = append(opts,
-		server.WithAuth(validator),
-		server.WithPublicMethods("initialize", "notifications/initialized", "tools/list", "prompts/list", "ping"),
-	)
-	srv := server.NewServer(
-		core.ServerInfo{Name: "auth-unified", Version: "1.0"},
-		opts...,
-	)
-	common.RegisterEchoTools(srv)
-	srv.UseMiddleware(auth.NewToolScopeMiddleware(srv.Registry()))
-
 	// Mint tokens for each exercise scenario.
 	tokReadOnly := env.MintToken("alice", []string{"read"})
 	tokReadWrite := env.MintToken("alice", []string{"read", "write"})
 	tokAll := env.MintToken("alice", []string{"read", "write", "admin"})
 	tokBob := env.MintToken("bob", []string{"read", "write", "admin"})
 
-	log.Printf("Unified auth example on %s", *addr)
 	log.Printf("MCP endpoint: http://localhost%s/mcp", *addr)
 	log.Printf("")
 	log.Printf("=== Exercise 1: Public Discovery ===")
@@ -70,17 +56,29 @@ func main() {
 	log.Printf("Connect as alice. Then try bob's token on alice's session → 403.")
 	log.Printf("  Token (bob, all scopes): %s", tokBob)
 
-	if err := srv.Run(*addr,
-		server.WithStreamableHTTP(true),
-		server.WithMux(func(mux *http.ServeMux) {
-			auth.MountAuth(mux, auth.AuthConfig{
-				ResourceURI:          listenURL,
-				AuthorizationServers: []string{env.AS.Issuer()},
-				ScopesSupported:      env.Scopes,
-				MCPPath:              "/mcp",
-			})
-		}),
-	); err != nil {
+	if err := mcpcommon.RunServer(mcpcommon.ServerConfig{
+		Name:    "auth-unified",
+		Version: "1.0",
+		Addr:    *addr,
+		Options: []server.Option{
+			server.WithAuth(validator),
+			server.WithPublicMethods("initialize", "notifications/initialized", "tools/list", "prompts/list", "ping"),
+		},
+		Register: func(srv *server.Server) {
+			common.RegisterEchoTools(srv)
+			srv.UseMiddleware(auth.NewToolScopeMiddleware(srv.Registry()))
+		},
+		TransportOptions: []server.TransportOption{
+			server.WithMux(func(mux *http.ServeMux) {
+				auth.MountAuth(mux, auth.AuthConfig{
+					ResourceURI:          listenURL,
+					AuthorizationServers: []string{env.AS.Issuer()},
+					ScopesSupported:      env.Scopes,
+					MCPPath:              "/mcp",
+				})
+			}),
+		},
+	}); err != nil {
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
## What changes

PR 585 extracted `common.RunServer` for the canonical mcpkit-example serve loop. Issue 587 was filed for the `examples/auth/*` subdirs that were out of that PR's scope — they used `srv.Run(addr, …)` on top of `common.MCPServerOptions` with a uniform `WithMux(MountAuth)` block. This PR adopts `common.RunServer` across all six.

No helper changes — `RunServer` already supports every variation observed across these six.

## Reviewer's guide

Read in this order:

1. [examples/auth/unified/main.go](https://github.com/panyam/mcpkit/pull/589/files#diff-a96b3f1fdea98b57daba2d785756b0518a71fe143e305cb0df27b6ecfda7dd4b) — start here. The "everything together" example: exercises `Options` (WithAuth + WithPublicMethods), `Register` (RegisterEchoTools + UseMiddleware), and `TransportOptions` (WithMux + MountAuth) in one config.
2. [examples/auth/bearer/main.go](https://github.com/panyam/mcpkit/pull/589/files#diff-4fc62662db0dbebeecc736e04e334341f635be89049bb3ae1809727303dfb21b) — the simplest case (no validator, no MountAuth, no TransportOptions).
3. [examples/auth/scopes/main.go](https://github.com/panyam/mcpkit/pull/589/files#diff-69836720a9b2cba63c224ef5ab00e8ab29d07c0f5759ebd17e2ad245a8ec4f75) — exercises the Register-with-UseMiddleware pattern from PR 585's `fine-grained-auth` refactor.
4. [examples/auth/jwt/main.go](https://github.com/panyam/mcpkit/pull/589/files#diff-55c3dff5952d9b70ef40e8552b2368853c586f2257ddcfccc29146a05f268dd7), [examples/auth/session-binding/main.go](https://github.com/panyam/mcpkit/pull/589/files#diff-ce0ec75fb0379a0767e74261da3657b06ac7fc4a96d6672aa53eabbfd13cd105), [examples/auth/public-discovery/main.go](https://github.com/panyam/mcpkit/pull/589/files#diff-025f8cf1fae2af712937083e61c1b42dc318c31442231b190bfd8cd4de2626e1) — same shape as `unified` minus one or two pieces; skim.

## Diff groups

Single intent: one mechanical adoption per file. Each example loses its `opts := …; opts = append(...); srv := server.NewServer(...); …; srv.Run(addr, WithStreamableHTTP(true), WithMux(...))` six-line block and gains the `common.RunServer(common.ServerConfig{...})` form.

## Decision log

- **Kept the per-example token-printing `log.Printf` block intact.** Each example mints scenario-specific tokens (`tokRead`, `tokReadWrite`, `tokAll`, `tokBob`, etc.) and prints them as part of the operator UX. These now log before `RunServer` since `ListenAndServe` blocks — same pattern as `file-inputs` in PR 585. The canonical `[<name>] listening on <addr>` line from the helper replaces each example's hand-rolled `"X example on <addr>"` preamble.
- **No `auth.MountAuthMux` shorthand.** The `WithMux(func(mux){ auth.MountAuth(mux, …) })` block appears in 5 of the 6 examples and is mechanically identical. Could be folded into a helper, but with only 5 sites and one always-identical structure, the cost (another import path to teach) outweighs the saving. Noted as out-of-scope in issue 587.
- **Did not add a `--serve` dispatch loop.** These examples have no companion `walkthrough.go` — `main()` IS the server. Different from PR 585's targets where the dispatch pattern is canonical.

## Risk / blast radius

- Affects: 6 example servers under `examples/auth/<subdir>/`. The shared `examples/auth` go.mod was tidied; nothing else changed in the module's import graph.
- Tests covering this: `go vet ./...` clean across the whole `examples/auth` sub-module. No `*_test.go` exists here.
- Be paranoid about: graceful shutdown — these examples previously used `srv.Run(addr, …)` which routes through `srv.ListenAndServe(WithStreamableHTTP(true), …)` internally, so the path is unchanged. Verified `bearer` binds, accepts an authenticated `initialize` round-trip through the color logger, and exits cleanly on SIGTERM.

## Before / after

`bearer` (the simplest case):

```diff
-opts := mcpcommon.MCPServerOptions(*addr, "[mcp] ")
-opts = append(opts, server.WithBearerToken("my-secret-token"))
-srv := server.NewServer(
-    core.ServerInfo{Name: "auth-bearer", Version: "1.0"},
-    opts...,
-)
-common.RegisterEchoTools(srv)
-
-log.Printf("Bearer auth example on %s (token: my-secret-token)", *addr)
-log.Printf("Connect MCPJam: …", *addr)
-if err := srv.Run(*addr); err != nil {
-    log.Fatal(err)
-}
+log.Printf("Token: my-secret-token")
+log.Printf("Connect MCPJam: …", *addr)
+if err := mcpcommon.RunServer(mcpcommon.ServerConfig{
+    Name:    "auth-bearer",
+    Version: "1.0",
+    Addr:    *addr,
+    Options: []server.Option{
+        server.WithBearerToken("my-secret-token"),
+    },
+    Register: func(srv *server.Server) {
+        common.RegisterEchoTools(srv)
+    },
+}); err != nil {
+    log.Fatal(err)
+}
```

`jwt` / `scopes` / `session-binding` / `public-discovery` / `unified` follow the same shape, additionally moving their `WithMux(MountAuth)` block into `TransportOptions`.

## Out of scope (deliberately deferred)

- `auth.MountAuthMux` shorthand — see Decision log; file as a follow-up if a 6th MountAuth-in-WithMux call site appears.

## Test plan

- [x] `go mod tidy` no-op in `examples/auth/`
- [x] `go vet ./...` green across `examples/auth/...`
- [x] Smoke: `examples/auth/bearer -addr :18091` binds, accepts authenticated `initialize` round-trip through the color logger, exits cleanly on SIGTERM.
