### PR TITLE
ext/skills + client: client-side SEP-2640 helpers + public Client.Discover (563, 590)

### DIFF
--- a/client/stateless.go
+++ b/client/stateless.go
@@ -40,7 +40,13 @@ import (
 // the stateless dispatcher requires; servers that ignore _meta but
 // understand the method (none currently exist) still get classified
 // as stateless via the success path.
-func (c *Client) adaptiveProbe() (result *discoverResult, fallback bool, err error) {
+//
+// adaptiveProbe is the internal classifier; ad-hoc callers (CLI
+// inspectors, conformance harnesses) use the public Client.Discover()
+// helper which calls into the same machinery and surfaces -32601 /
+// HTTP 404 as a typed *UnsupportedDiscoverError instead of a
+// fallback bool.
+func (c *Client) adaptiveProbe() (result *DiscoverResult, fallback bool, err error) {
 	params := map[string]any{
 		"_meta": c.buildRequestMeta(),
 	}
@@ -76,20 +82,66 @@ func (c *Client) adaptiveProbe() (result *discoverResult, fallback bool, err err
 		// reason (invalid _meta, version mismatch, etc.).
 		return nil, false, fmt.Errorf("server/discover failed: %s", resp.Error.Message)
 	}
-	var dr discoverResult
+	var dr DiscoverResult
 	if err := json.Unmarshal(resp.Result, &dr); err != nil {
 		return nil, false, fmt.Errorf("server/discover returned malformed result: %w", err)
 	}
 	return &dr, false, nil
 }
 
-// discoverResult mirrors stateless.DiscoverResult shape. Defined locally
+// DiscoverResult mirrors stateless.DiscoverResult shape. Defined locally
 // so client/ does not import server/stateless/ (the package boundary
 // runs the other direction; client only knows wire types in core/).
-type discoverResult struct {
+//
+// Surfaced through the public Client.Discover() helper for ad-hoc
+// callers (CLI inspectors, conformance harnesses) that want to
+// introspect a server's discovery payload without going through the
+// Connect handshake.
+type DiscoverResult struct {
 	SupportedVersions []string                `json:"supportedVersions"`
 	Capabilities      core.ServerCapabilities `json:"capabilities"`
 	ServerInfo        core.ServerInfo         `json:"serverInfo"`
+}
+
+// UnsupportedDiscoverError is returned by Client.Discover() when the
+// server reports it does not implement server/discover (either via
+// JSON-RPC -32601 in a 200 body, which is what mcpkit's legacy
+// dispatcher emits, or via HTTP 404 from a transport that does not
+// route the method). Callers branch on this to fall back to the
+// legacy initialize handshake when appropriate.
+type UnsupportedDiscoverError struct {
+	// Source describes how the server signaled the gap, useful for
+	// diagnostics. Either "jsonrpc-32601" or "http-404".
+	Source string
+}
+
+func (e *UnsupportedDiscoverError) Error() string {
+	return "server does not implement server/discover (" + e.Source + ")"
+}
+
+// Discover sends server/discover and returns the server's discovery
+// response payload. Does not mutate the client's session state. On a
+// server that does not implement server/discover (e.g., a legacy-only
+// mcpkit server before SEP-2575 rolled out), Discover returns a typed
+// *UnsupportedDiscoverError so callers can branch cleanly. Transport-
+// level failures (network, TLS) propagate as-is.
+//
+// Connect must be called before Discover so the underlying transport
+// is initialized. Discover is the public entry point built on top of
+// adaptiveProbe; Connect's ClientModeAdaptive path continues to call
+// adaptiveProbe directly for the boolean fallback signal.
+func (c *Client) Discover() (*DiscoverResult, error) {
+	dr, fallback, err := c.adaptiveProbe()
+	if err != nil {
+		return nil, err
+	}
+	if fallback {
+		// adaptiveProbe folds both -32601 and HTTP 404 into the same
+		// boolean. Tag the source from the call site so Source carries
+		// useful diagnostics.
+		return nil, &UnsupportedDiscoverError{Source: "jsonrpc-32601-or-http-404"}
+	}
+	return dr, nil
 }
 
 // buildRequestMeta builds the per-request _meta envelope the SEP-2575

--- a/ext/skills/client.go
+++ b/ext/skills/client.go
@@ -1,0 +1,287 @@
+package skills
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/panyam/mcpkit/client"
+	"github.com/panyam/mcpkit/core"
+)
+
+// Client wraps a *client.Client with SEP-2640 host-workflow helpers:
+// capability detection, discovery index fetch, manifest and supporting
+// file reads, digest verification.
+//
+// The wrapper holds no state of its own beyond the underlying client
+// pointer. Methods are safe for concurrent use to the same degree
+// *client.Client is.
+//
+// Typical host workflow:
+//
+//	mcp := client.NewClient(serverURL, info)
+//	mcp.Connect()
+//	sc := skills.NewClient(mcp)
+//	if !sc.SupportsSkills() { return }
+//	idx, err := sc.ListSkills(ctx)
+//	for _, entry := range idx.Skills {
+//	    result, err := sc.ReadAndVerify(ctx, entry.URL, entry.Digest)
+//	    // result.DigestVerified is true on match; ErrDigestMismatch otherwise
+//	}
+type Client struct {
+	mcp *client.Client
+}
+
+// NewClient builds a SEP-2640 host helper over the given mcpkit client.
+// The underlying client must already be Connect()ed for any read method
+// to succeed.
+func NewClient(mcp *client.Client) *Client {
+	return &Client{mcp: mcp}
+}
+
+// SupportsSkills reports whether the connected server advertises the
+// io.modelcontextprotocol/skills extension in its initialize (or
+// server/discover) response. Hosts iterating connected servers can
+// use this to skip ListSkills calls against servers that do not
+// support the extension.
+//
+// The signal is read from the cached initialize/discover response on
+// the underlying client; this method does not issue a network call.
+func (c *Client) SupportsSkills() bool {
+	return c.mcp.ServerSupportsExtension(ExtensionID)
+}
+
+// ListSkills reads skill://index.json and returns the parsed Index.
+//
+// SEP-2640 makes the index OPTIONAL: a server MAY decline to expose
+// it. When the read returns a not-found error, ListSkills returns an
+// empty Index (with the Schema field unset) and no error so callers
+// can treat absent indexes the same as empty ones. Other read errors
+// (transport, malformed JSON) propagate.
+func (c *Client) ListSkills() (Index, error) {
+	body, err := c.mcp.ReadResource(IndexURI)
+	if err != nil {
+		if isNotFoundErr(err) {
+			return Index{}, nil
+		}
+		return Index{}, fmt.Errorf("skills: read %s: %w", IndexURI, err)
+	}
+	var idx Index
+	if err := json.Unmarshal([]byte(body), &idx); err != nil {
+		return Index{}, fmt.Errorf("skills: parse %s: %w", IndexURI, err)
+	}
+	return idx, nil
+}
+
+// ReadSkillURI reads any skill:// URI and returns the bytes the server
+// served. Used when a host receives a skill URI from server
+// instructions, the user, or another skill and wants to fetch the
+// content without going through the index.
+//
+// Returns text bytes when the resource is text-typed; base64-decoded
+// blob bytes when the resource is binary-typed (e.g., archive entries
+// served in archive mode).
+func (c *Client) ReadSkillURI(uri string) ([]byte, error) {
+	result, err := c.mcp.ReadResourceFull(uri)
+	if err != nil {
+		return nil, fmt.Errorf("skills: read %s: %w", uri, err)
+	}
+	return extractBytes(result.Contents, uri)
+}
+
+// SkillManifest holds a parsed SKILL.md plus the raw bytes the server
+// served. Raw is preserved so the caller can verify against a digest
+// after parsing — the digest is computed over the raw artifact, not the
+// post-parse representation.
+type SkillManifest struct {
+	URI         string
+	Frontmatter Frontmatter
+	Body        []byte
+	Raw         []byte
+}
+
+// ReadSkillManifest fetches a SKILL.md URI, parses the YAML frontmatter,
+// and returns both the typed Frontmatter and the raw + post-frontmatter
+// body bytes.
+//
+// Validates that uri is a manifest URI (ends in /SKILL.md). For non-
+// manifest URIs use ReadSkillURI.
+func (c *Client) ReadSkillManifest(uri string) (*SkillManifest, error) {
+	parts, err := ParseURI(uri)
+	if err != nil {
+		return nil, fmt.Errorf("skills: %s: %w", uri, err)
+	}
+	if !parts.IsManifest {
+		return nil, fmt.Errorf("%w: %q", ErrNotManifestURI, uri)
+	}
+	raw, err := c.ReadSkillURI(uri)
+	if err != nil {
+		return nil, err
+	}
+	fm, body, err := ParseFrontmatter(raw)
+	if err != nil {
+		return nil, fmt.Errorf("skills: parse frontmatter for %s: %w", uri, err)
+	}
+	return &SkillManifest{
+		URI:         uri,
+		Frontmatter: fm,
+		Body:        body,
+		Raw:         raw,
+	}, nil
+}
+
+// ReadSkillFile resolves a relative reference against a manifest's
+// skill root and reads the result via skill://. Used to follow links
+// inside a SKILL.md body (e.g., "references/GUIDE.md") per SEP-2640's
+// filesystem-style resolution.
+//
+// Returns the same byte semantics as ReadSkillURI.
+func (c *Client) ReadSkillFile(manifest *SkillManifest, relPath string) ([]byte, error) {
+	if manifest == nil {
+		return nil, fmt.Errorf("skills: ReadSkillFile: nil manifest")
+	}
+	root, err := ParseURI(manifest.URI)
+	if err != nil {
+		return nil, fmt.Errorf("skills: ReadSkillFile: re-parse manifest URI: %w", err)
+	}
+	resolved, err := ResolveRelative(root, relPath)
+	if err != nil {
+		return nil, fmt.Errorf("skills: resolve %q against %s: %w", relPath, manifest.URI, err)
+	}
+	return c.ReadSkillURI(resolved.String())
+}
+
+// ReadResult is the typed return from ReadAndVerify. Bytes carries the
+// served content; DigestVerified is true when the SHA-256 over Bytes
+// equals the expected digest the caller supplied.
+type ReadResult struct {
+	URI            string
+	Bytes          []byte
+	DigestVerified bool
+}
+
+// ReadAndVerify reads uri and checks the SHA-256 of the served bytes
+// against expectedDigest (in SEP-2640's "sha256:{64-hex}" format).
+//
+// On match, returns a ReadResult with DigestVerified=true and no
+// error. On mismatch, returns ErrDigestMismatch wrapped with the
+// expected and actual digests for diagnostics — per SEP-2640 the host
+// MUST NOT use the bytes in that case.
+//
+// expectedDigest of "" disables verification: ReadAndVerify behaves
+// like ReadSkillURI and returns DigestVerified=false. This is a
+// convenience for hosts that have a URI but no catalogued digest
+// (server instructions, user-supplied URIs).
+func (c *Client) ReadAndVerify(uri, expectedDigest string) (*ReadResult, error) {
+	body, err := c.ReadSkillURI(uri)
+	if err != nil {
+		return nil, err
+	}
+	result := &ReadResult{URI: uri, Bytes: body}
+	if expectedDigest == "" {
+		return result, nil
+	}
+	sum := sha256.Sum256(body)
+	got := "sha256:" + hex.EncodeToString(sum[:])
+	if !strings.EqualFold(got, expectedDigest) {
+		return nil, fmt.Errorf("%w: want %s, got %s", ErrDigestMismatch, expectedDigest, got)
+	}
+	result.DigestVerified = true
+	return result, nil
+}
+
+// ReadResourceTool surfaces the SEP-2640 Implementation Guidelines
+// host-exposed tool schema. Hosts that want to expose a generic
+// resource-reading tool to their LLM can register this without
+// copy-pasting the JSON Schema literal from the spec.
+//
+// The shape matches SEP-2640 verbatim:
+//
+//	{
+//	  "name": "read_resource",
+//	  "description": "Read an MCP resource from a connected server.",
+//	  "inputSchema": {
+//	    "type": "object",
+//	    "properties": {
+//	      "server": { "type": "string", "description": "Name of the connected MCP server" },
+//	      "uri":    { "type": "string", "description": "The resource URI" }
+//	    },
+//	    "required": ["server", "uri"]
+//	  }
+//	}
+const ReadResourceToolName = "read_resource"
+
+// ReadResourceToolDescription is the description string SEP-2640
+// suggests for the tool, useful as the model-facing summary.
+const ReadResourceToolDescription = "Read an MCP resource from a connected server."
+
+// ReadResourceToolInputSchema is the JSON Schema for the tool's
+// arguments per the SEP-2640 sketch. Exposed as a map[string]any so
+// hosts can register it directly through mcpkit's tool registration
+// path without an intermediate JSON round-trip.
+var ReadResourceToolInputSchema = map[string]any{
+	"type": "object",
+	"properties": map[string]any{
+		"server": map[string]any{
+			"type":        "string",
+			"description": "Name of the connected MCP server",
+		},
+		"uri": map[string]any{
+			"type":        "string",
+			"description": "The resource URI",
+		},
+	},
+	"required": []string{"server", "uri"},
+}
+
+// --- internal helpers -------------------------------------------------------
+
+// isNotFoundErr classifies the wire-level signals mcpkit's resources/read
+// returns when the target URI is absent. SEP-2640 says hosts MUST
+// tolerate an absent skill://index.json; this helper centralizes the
+// matching so the public surface stays simple. Match shape:
+//
+//   - "not found" — generic JSON-RPC error text from older servers
+//   - "unknown resource" — mcpkit's current resources/read shape on
+//     resources that were not registered
+//
+// Both surface as JSON-RPC -32602 in practice; the message substring
+// is the stable signal because transports vary in how they expose the
+// numeric code.
+func isNotFoundErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "not found") || strings.Contains(msg, "unknown resource")
+}
+
+// extractBytes pulls the served bytes out of a ResourceResult's
+// Contents slice. Per the wire shape, each entry has either Text (for
+// text-typed resources) or Blob (base64-encoded for binary). For the
+// skill: scheme today, SKILL.md and supporting files are text;
+// archive resources are binary. Returns the first content entry's
+// bytes since SEP-2640 resources never carry multi-content responses.
+func extractBytes(contents []core.ResourceReadContent, uri string) ([]byte, error) {
+	if len(contents) == 0 {
+		return nil, fmt.Errorf("skills: %s: empty contents", uri)
+	}
+	c := contents[0]
+	if c.Blob != "" {
+		decoded, err := base64.StdEncoding.DecodeString(c.Blob)
+		if err != nil {
+			return nil, fmt.Errorf("skills: %s: blob base64 decode: %w", uri, err)
+		}
+		return decoded, nil
+	}
+	return []byte(c.Text), nil
+}
+
+// _ json is referenced indirectly via the ParseFrontmatter call chain.
+// Keep the import alive for callers that re-decode the JSON-RPC envelope
+// directly (none today, but mcpkit's wire surface is split across
+// versions).
+var _ = json.Marshal

--- a/ext/skills/client_test.go
+++ b/ext/skills/client_test.go
@@ -1,0 +1,288 @@
+package skills_test
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/panyam/mcpkit/client"
+	"github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/ext/skills"
+	"github.com/panyam/mcpkit/server"
+)
+
+// connectSkillsClient boots a mcpkit server with a SkillProvider rooted
+// at the named testdata directory, returns the wrapped client plus the
+// underlying mcpkit client.
+func connectSkillsClient(t *testing.T, dir string, opts ...skills.ProviderOption) (*skills.Client, *client.Client) {
+	t.Helper()
+	srv := server.NewServer(core.ServerInfo{Name: "skills-client-test", Version: "0.0.1"})
+	provOpts := append([]skills.ProviderOption{skills.WithDirectory(dir)}, opts...)
+	p, err := skills.NewProvider(provOpts...)
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	p.RegisterWith(srv)
+
+	handler := srv.Handler(server.WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "skills-client-test", Version: "0.0.1"})
+	if err := c.Connect(); err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+	return skills.NewClient(c), c
+}
+
+func TestClient_SupportsSkills_DeclaredServer(t *testing.T) {
+	sc, _ := connectSkillsClient(t, "testdata/valid")
+	if !sc.SupportsSkills() {
+		t.Errorf("SupportsSkills = false, want true for a Provider-backed server")
+	}
+}
+
+func TestClient_SupportsSkills_PlainServer(t *testing.T) {
+	srv := server.NewServer(core.ServerInfo{Name: "plain-server", Version: "0.0.1"})
+	handler := srv.Handler(server.WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "plain-client", Version: "0.0.1"})
+	if err := c.Connect(); err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+
+	sc := skills.NewClient(c)
+	if sc.SupportsSkills() {
+		t.Errorf("SupportsSkills = true, want false for a server without the extension")
+	}
+}
+
+func TestClient_ListSkills_Populated(t *testing.T) {
+	sc, _ := connectSkillsClient(t, "testdata/valid")
+	idx, err := sc.ListSkills()
+	if err != nil {
+		t.Fatalf("ListSkills: %v", err)
+	}
+	if idx.Schema != skills.IndexSchemaURI {
+		t.Errorf("Schema = %q, want %q", idx.Schema, skills.IndexSchemaURI)
+	}
+	if len(idx.Skills) != 3 {
+		t.Errorf("entry count = %d, want 3", len(idx.Skills))
+	}
+}
+
+func TestClient_ListSkills_Absent(t *testing.T) {
+	sc, _ := connectSkillsClient(t, "testdata/valid", skills.WithoutIndex())
+	idx, err := sc.ListSkills()
+	if err != nil {
+		t.Fatalf("ListSkills should tolerate missing index, got: %v", err)
+	}
+	if len(idx.Skills) != 0 {
+		t.Errorf("expected empty index, got %d entries", len(idx.Skills))
+	}
+}
+
+func TestClient_Index_Lookup_Hit(t *testing.T) {
+	sc, _ := connectSkillsClient(t, "testdata/valid")
+	idx, err := sc.ListSkills()
+	if err != nil {
+		t.Fatalf("ListSkills: %v", err)
+	}
+	entry, ok := idx.Lookup("skill://git-workflow/SKILL.md")
+	if !ok {
+		t.Fatalf("Lookup miss for known URL")
+	}
+	if entry.Name != "git-workflow" {
+		t.Errorf("entry.Name = %q, want git-workflow", entry.Name)
+	}
+}
+
+func TestClient_Index_Lookup_Miss(t *testing.T) {
+	sc, _ := connectSkillsClient(t, "testdata/valid")
+	idx, err := sc.ListSkills()
+	if err != nil {
+		t.Fatalf("ListSkills: %v", err)
+	}
+	entry, ok := idx.Lookup("skill://nonexistent/SKILL.md")
+	if ok {
+		t.Errorf("Lookup hit for unknown URL, got %+v", entry)
+	}
+	if entry != (skills.IndexEntry{}) {
+		t.Errorf("miss should return zero IndexEntry, got %+v", entry)
+	}
+}
+
+func TestClient_ReadSkillURI(t *testing.T) {
+	sc, _ := connectSkillsClient(t, "testdata/valid")
+	body, err := sc.ReadSkillURI("skill://git-workflow/SKILL.md")
+	if err != nil {
+		t.Fatalf("ReadSkillURI: %v", err)
+	}
+	if !strings.Contains(string(body), "name: git-workflow") {
+		t.Errorf("body missing frontmatter name field; got: %s", body)
+	}
+}
+
+func TestClient_ReadSkillManifest(t *testing.T) {
+	sc, _ := connectSkillsClient(t, "testdata/valid")
+	m, err := sc.ReadSkillManifest("skill://pdf-processing/SKILL.md")
+	if err != nil {
+		t.Fatalf("ReadSkillManifest: %v", err)
+	}
+	if m.Frontmatter.Name != "pdf-processing" {
+		t.Errorf("Frontmatter.Name = %q", m.Frontmatter.Name)
+	}
+	if len(m.Body) == 0 {
+		t.Errorf("Body is empty")
+	}
+	if len(m.Raw) == 0 {
+		t.Errorf("Raw is empty")
+	}
+	if !strings.HasPrefix(string(m.Raw), "---") {
+		t.Errorf("Raw should start with frontmatter fence: %s", m.Raw[:20])
+	}
+}
+
+func TestClient_ReadSkillManifest_RejectsNonManifestURI(t *testing.T) {
+	sc, _ := connectSkillsClient(t, "testdata/valid")
+	_, err := sc.ReadSkillManifest("skill://pdf-processing/references/FORMS.md")
+	if !errors.Is(err, skills.ErrNotManifestURI) {
+		t.Errorf("err = %v, want ErrNotManifestURI", err)
+	}
+}
+
+func TestClient_ReadSkillFile(t *testing.T) {
+	sc, _ := connectSkillsClient(t, "testdata/valid")
+	m, err := sc.ReadSkillManifest("skill://pdf-processing/SKILL.md")
+	if err != nil {
+		t.Fatalf("ReadSkillManifest: %v", err)
+	}
+	body, err := sc.ReadSkillFile(m, "references/FORMS.md")
+	if err != nil {
+		t.Fatalf("ReadSkillFile: %v", err)
+	}
+	if !strings.Contains(string(body), "AcroForm") {
+		t.Errorf("expected FORMS.md content, got: %s", body)
+	}
+}
+
+func TestClient_ReadAndVerify_Match(t *testing.T) {
+	sc, _ := connectSkillsClient(t, "testdata/valid")
+	idx, err := sc.ListSkills()
+	if err != nil {
+		t.Fatalf("ListSkills: %v", err)
+	}
+	entry, ok := idx.Lookup("skill://git-workflow/SKILL.md")
+	if !ok {
+		t.Fatal("git-workflow not in index")
+	}
+	result, err := sc.ReadAndVerify(entry.URL, entry.Digest)
+	if err != nil {
+		t.Fatalf("ReadAndVerify match: %v", err)
+	}
+	if !result.DigestVerified {
+		t.Errorf("DigestVerified = false on a known-good digest")
+	}
+	if len(result.Bytes) == 0 {
+		t.Errorf("Bytes empty")
+	}
+}
+
+func TestClient_ReadAndVerify_Mismatch(t *testing.T) {
+	sc, _ := connectSkillsClient(t, "testdata/valid")
+	_, err := sc.ReadAndVerify(
+		"skill://git-workflow/SKILL.md",
+		"sha256:"+strings.Repeat("0", 64), // deliberately wrong
+	)
+	if !errors.Is(err, skills.ErrDigestMismatch) {
+		t.Errorf("err = %v, want ErrDigestMismatch", err)
+	}
+}
+
+func TestClient_ReadAndVerify_EmptyDigestDisables(t *testing.T) {
+	sc, _ := connectSkillsClient(t, "testdata/valid")
+	result, err := sc.ReadAndVerify("skill://git-workflow/SKILL.md", "")
+	if err != nil {
+		t.Fatalf("ReadAndVerify empty digest: %v", err)
+	}
+	if result.DigestVerified {
+		t.Errorf("DigestVerified = true with empty expectedDigest, want false")
+	}
+	if len(result.Bytes) == 0 {
+		t.Errorf("Bytes empty")
+	}
+}
+
+func TestClient_RoundTrip_CatalogVerify(t *testing.T) {
+	sc, _ := connectSkillsClient(t, "testdata/valid")
+	idx, err := sc.ListSkills()
+	if err != nil {
+		t.Fatalf("ListSkills: %v", err)
+	}
+	verified := 0
+	for _, e := range idx.Skills {
+		if e.Type != skills.SkillTypeSkillMD {
+			continue
+		}
+		result, err := sc.ReadAndVerify(e.URL, e.Digest)
+		if err != nil {
+			t.Errorf("ReadAndVerify %s: %v", e.URL, err)
+			continue
+		}
+		if !result.DigestVerified {
+			t.Errorf("%s: DigestVerified = false", e.URL)
+			continue
+		}
+		// Recompute locally as a belt-and-braces check.
+		sum := sha256.Sum256(result.Bytes)
+		got := "sha256:" + hex.EncodeToString(sum[:])
+		if got != e.Digest {
+			t.Errorf("%s: local digest %s != catalog %s", e.URL, got, e.Digest)
+		}
+		verified++
+	}
+	if verified == 0 {
+		t.Fatal("no skill-md entries verified end-to-end")
+	}
+}
+
+func TestReadResourceTool_Schema(t *testing.T) {
+	if skills.ReadResourceToolName != "read_resource" {
+		t.Errorf("ToolName = %q, want read_resource", skills.ReadResourceToolName)
+	}
+	if !strings.Contains(skills.ReadResourceToolDescription, "MCP resource") {
+		t.Errorf("Description should mention 'MCP resource': %q", skills.ReadResourceToolDescription)
+	}
+	schema := skills.ReadResourceToolInputSchema
+	if schema["type"] != "object" {
+		t.Errorf("schema.type = %v, want object", schema["type"])
+	}
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("schema.properties not a map: %T", schema["properties"])
+	}
+	for _, key := range []string{"server", "uri"} {
+		field, ok := props[key].(map[string]any)
+		if !ok {
+			t.Errorf("schema.properties[%q] missing or wrong type: %T", key, props[key])
+			continue
+		}
+		if field["type"] != "string" {
+			t.Errorf("schema.properties[%q].type = %v, want string", key, field["type"])
+		}
+	}
+	required, ok := schema["required"].([]string)
+	if !ok {
+		t.Fatalf("schema.required not []string: %T", schema["required"])
+	}
+	if len(required) != 2 || required[0] != "server" || required[1] != "uri" {
+		t.Errorf("schema.required = %v, want [server uri]", required)
+	}
+}

--- a/ext/skills/errors.go
+++ b/ext/skills/errors.go
@@ -38,6 +38,16 @@ var (
 	ErrNotManifestURI = errors.New("skills: not a SKILL.md URI")
 )
 
+// Client-side errors.
+var (
+	// ErrDigestMismatch is returned by Client.ReadAndVerify when the
+	// SHA-256 over the served bytes does not equal the expected digest
+	// the caller supplied. Per SEP-2640's Integrity and Verification
+	// section, hosts MUST NOT use unverified content; surfacing this as
+	// a typed error makes the contract explicit at the call site.
+	ErrDigestMismatch = errors.New("skills: digest mismatch — content MUST NOT be used")
+)
+
 // Index validation errors.
 var (
 	ErrIndexMissingSchema           = errors.New("skills: index missing $schema")

--- a/ext/skills/extension_test.go
+++ b/ext/skills/extension_test.go
@@ -2,11 +2,16 @@ package skills_test
 
 import (
 	"encoding/json"
+	"errors"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/panyam/mcpkit/client"
 	"github.com/panyam/mcpkit/core"
 	"github.com/panyam/mcpkit/ext/skills"
+	"github.com/panyam/mcpkit/server"
+	"github.com/panyam/mcpkit/server/stateless"
 )
 
 func TestSkillsExtension_Metadata(t *testing.T) {
@@ -26,6 +31,109 @@ func TestSkillsExtension_AppearsInInitialize(t *testing.T) {
 	_, _, c := boot(t, "testdata/valid")
 	if !c.ServerSupportsExtension(skills.ExtensionID) {
 		t.Errorf("server should advertise %q in capabilities.extensions", skills.ExtensionID)
+	}
+}
+
+// TestSkillsExtension_AppearsInServerDiscover_ProviderRegisterWith confirms
+// the capability surfaces under the SEP-2575 stateless wire (server/discover)
+// the same way it does on the legacy initialize wire. Provider.RegisterWith
+// is the auto-declaration path; the test asserts the auto-decl carries
+// through to server/discover without an extra registration call.
+func TestSkillsExtension_AppearsInServerDiscover_ProviderRegisterWith(t *testing.T) {
+	srv := server.NewServer(core.ServerInfo{Name: "discover-prov", Version: "0.0.1"})
+	p, err := skills.NewProvider(skills.WithDirectory("testdata/valid"))
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	p.RegisterWith(srv)
+	assertDiscoverHasSkillsCapability(t, srv)
+}
+
+// TestSkillsExtension_AppearsInServerDiscover_WithExtension confirms the
+// explicit WithExtension registration path also flows through to
+// server/discover. Pairs with the Provider.RegisterWith variant above so
+// the dual-wire story is covered for both registration shapes.
+func TestSkillsExtension_AppearsInServerDiscover_WithExtension(t *testing.T) {
+	srv := server.NewServer(
+		core.ServerInfo{Name: "discover-ext", Version: "0.0.1"},
+		server.WithExtension(skills.SkillsExtension{}),
+	)
+	assertDiscoverHasSkillsCapability(t, srv)
+}
+
+// assertDiscoverHasSkillsCapability boots the given server in dual-mode
+// + stateless-friendly transport, fires server/discover via the public
+// Client.Discover() helper, and verifies the skills extension appears
+// in the response. Shared by the two registration-path tests.
+func assertDiscoverHasSkillsCapability(t *testing.T, srv *server.Server) {
+	t.Helper()
+	handler := srv.Handler(
+		server.WithStreamableHTTP(true),
+		server.WithStatelessMode(stateless.ModeDual),
+	)
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	c := client.NewClient(
+		ts.URL+"/mcp",
+		core.ClientInfo{Name: "discover-probe", Version: "0.0.1"},
+		client.WithClientMode(client.ClientModeAdaptive),
+	)
+	if err := c.Connect(); err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+
+	dr, err := c.Discover()
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if dr.Capabilities.Extensions == nil {
+		t.Fatalf("Discover response has no capabilities.extensions")
+	}
+	if _, ok := dr.Capabilities.Extensions[skills.ExtensionID]; !ok {
+		t.Errorf("capabilities.extensions missing %q in server/discover; got keys: %v",
+			skills.ExtensionID, keysOf(dr.Capabilities.Extensions))
+	}
+}
+
+func keysOf(m map[string]core.ExtensionCapability) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// TestClient_Discover_LegacyOnlyServerReturnsTypedError pins down 590's
+// acceptance: a server that does not implement server/discover (legacy-
+// only mode) makes Client.Discover() return *UnsupportedDiscoverError
+// rather than a generic transport-level surprise.
+func TestClient_Discover_LegacyOnlyServerReturnsTypedError(t *testing.T) {
+	srv := server.NewServer(core.ServerInfo{Name: "legacy-only", Version: "0.0.1"})
+	handler := srv.Handler(
+		server.WithStreamableHTTP(true),
+		server.WithStatelessMode(stateless.ModeLegacyOnly),
+	)
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	c := client.NewClient(
+		ts.URL+"/mcp",
+		core.ClientInfo{Name: "discover-probe", Version: "0.0.1"},
+	)
+	if err := c.Connect(); err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+
+	_, err := c.Discover()
+	if err == nil {
+		t.Fatal("expected error from legacy-only server, got nil")
+	}
+	var typed *client.UnsupportedDiscoverError
+	if !errors.As(err, &typed) {
+		t.Errorf("err = %v (%T), want *client.UnsupportedDiscoverError", err, err)
 	}
 }
 

--- a/ext/skills/types.go
+++ b/ext/skills/types.go
@@ -87,6 +87,27 @@ func NewIndex(entries ...IndexEntry) Index {
 	return Index{Schema: IndexSchemaURI, Skills: entries}
 }
 
+// Lookup returns the IndexEntry whose URL exactly matches uri. The
+// second return value reports whether a match was found.
+//
+// Client-side use: a host that receives a skill:// URI from server
+// instructions, the user, or another skill can call Lookup against
+// the index it fetched via ListSkills. A hit gives the host
+// digest-verifiable metadata; a miss is the SEP-2640-sanctioned
+// "skill exists but is not enumerated" case where the host falls back
+// to a bare ReadSkillURI.
+//
+// Comparison is exact-string. A trailing slash or differing percent
+// encoding on the input is the caller's bug, not Lookup's concern.
+func (i Index) Lookup(uri string) (IndexEntry, bool) {
+	for _, e := range i.Skills {
+		if e.URL == uri {
+			return e, true
+		}
+	}
+	return IndexEntry{}, false
+}
+
 // Validate checks every entry and the top-level shape. It is intended for
 // servers preparing an index for publication; clients receiving an index
 // SHOULD skip entries with unrecognized types rather than reject the


### PR DESCRIPTION
## What changes

Closes mcpkit 563 (client-side skills helpers, including the SupportsSkills + Lookup scope amendment) and folds in mcpkit 590 (public `Client.Discover()` + ext/skills server/discover assertion).

`ext/skills.Client` wraps `*client.Client` with the SEP-2640 host workflow: capability detection, discovery index fetch, manifest + supporting-file reads, SHA-256 digest verification. The 590 changes promote the existing internal `discoverResult` to public `client.DiscoverResult` and add `Client.Discover()` plus a typed `*UnsupportedDiscoverError` so ad-hoc callers (CLI inspectors, conformance harnesses) can introspect a server's discovery payload without re-implementing the wire.

## Reviewer's guide

Read in this order:

1. [ext/skills/client.go](https://github.com/panyam/mcpkit/pull/591/files#diff-ab4abcac994a6acf009e0587fa6e9100b455944cfd76714f0f82040d1219589a) (NEW). The whole skills-client surface. Read `Client` doc + `NewClient` first, then SupportsSkills / ListSkills / ReadSkillURI / ReadSkillManifest / ReadSkillFile / ReadAndVerify. ReadResourceTool constants + InputSchema at the bottom are the SEP-2640 Implementation Guidelines tool schema.
2. [ext/skills/types.go](https://github.com/panyam/mcpkit/pull/591/files#diff-c6a1fd454bc3289de88115aac3e3eb9bdcf381e5e16ffe515d75048fea08d4b8). Small addition: `Index.Lookup(uri) (IndexEntry, bool)` lives on the existing typed `Index` (no separate Catalog type per the amendment comment).
3. [ext/skills/errors.go](https://github.com/panyam/mcpkit/pull/591/files#diff-097721358b725e6ce2ea62d43e0c77494d94644f016803b1fb7b949b957b6bc7). One new sentinel: `ErrDigestMismatch`.
4. [client/stateless.go](https://github.com/panyam/mcpkit/pull/591/files#diff-c095a06bc0f1fa5239aedc79840fd85cdd3dfc10886bcee46b7e6d35eaa978c6). Promotes `discoverResult` to `DiscoverResult`, adds `Client.Discover()` + `*UnsupportedDiscoverError`. `adaptiveProbe` stays internal. Connect's ClientModeAdaptive path keeps the existing boolean-fallback signal.
5. [ext/skills/client_test.go](https://github.com/panyam/mcpkit/pull/591/files#diff-3ee358c04453185c37667a7fa907bde75fd9fa2310a7e9db7fb0bbde4b9d8a0f) (NEW). 14 tests using httptest + real Provider. Coverage: SupportsSkills both ways, ListSkills absent/populated, Lookup hit/miss, ReadSkillURI, ReadSkillManifest + rejection of non-manifest URIs, ReadSkillFile via ResolveRelative, ReadAndVerify match/mismatch/empty-digest, end-to-end catalog round-trip, ReadResourceTool schema shape.
6. [ext/skills/extension_test.go](https://github.com/panyam/mcpkit/pull/591/files#diff-2a762ead8159d7c472a799c32f571e32ef3e230f5f3e1dcdd8f6627af1ab279a). 3 new tests: server/discover advertises the capability via both registration paths (Provider.RegisterWith + WithExtension), plus typed-error verification on a legacy-only server.

## Decision log

- **Wrapper type over free functions.** The existing `client/tasks.go` precedent uses free functions taking `*Client`. For skills the ticket sketched a wrapper, and the host workflow has a coherent surface (detect capability, list, read, verify) that's easier to discover via IDE autocomplete on `skillsClient.X`. Free functions stay possible as escape hatches if a future caller needs them.
- **`Lookup` on `Index` directly, not a separate `Catalog` type.** The amendment comment is satisfied with one less type. `Index` already carries the entries. Adding a method is lighter than introducing a wrapper that just embeds Index.
- **`ReadAndVerify` distinct from `ReadSkillURI` rather than auto-verifying.** Hosts handed a URI by server `instructions` or another skill will not have an expected digest. One helper for both shapes muddles the SEP-2640 Integrity MUST. Empty `expectedDigest` is the documented escape hatch.
- **`ReadResourceTool` as constants + a map rather than a JSON literal.** Hosts register through mcpkit's typed tool registration path. No string round-trip. Matches the SEP sketch field-for-field.
- **`Client.Discover()` requires `Connect()` first.** Aspirational "safe before Connect" wording in the original 590 sketch did not survive the transport bootstrap. The underlying `c.transport` is initialized by Connect. Doc-comment now spells this out. Realistic host usage (connect, then introspect) is unaffected.
- **`SupportsSkills()` does NOT issue a network call.** Reads the cached initialize/discover response via the underlying `client.ServerSupportsExtension(ExtensionID)`. Hosts iterating connected servers can call this freely without worrying about latency.
- **Absent-index detection is substring-match on the error message.** mcpkit's resources/read returns "unknown resource: <uri>" for missing URIs today. JSON-RPC -32602 is the canonical code but transports vary in how they surface it. The substring matcher covers both "not found" and "unknown resource" shapes (case-insensitive) so older + newer servers both work.

## Risk / blast radius

- **Affects:** new `ext/skills/client.go` + `ext/skills/client_test.go` + small additions to `ext/skills/types.go`, `errors.go`, `extension_test.go`. One small touch to `client/stateless.go` (promoting `discoverResult` to `DiscoverResult` + adding the public Discover entry). No existing API changed in a breaking way.
- **Tests covering this:** 14 new client tests + 3 server/discover tests = 17 new top-level tests. 83 to 101 ext/skills sub-tests. `go vet ./...` clean. `go test -race ./ext/skills/... -count=1` clean.
- **Be paranoid about:**
  - **The absent-index substring matcher in `isNotFoundErr`.** Tied to mcpkit's current "unknown resource: <uri>" error text. If the server-side message changes, the matcher needs updating in lockstep. Worth tracking as a follow-up if the wire shape evolves toward a typed signal.
  - **`ReadAndVerify` empty-digest semantics.** Passing `""` disables verification and returns `DigestVerified=false`. A caller who forgets to populate the expected digest gets a successful read with verification silently skipped. The doc-comment calls this out but it is a footgun worth eyeballing.
  - **`Discover()` requiring `Connect()`.** Documented constraint. Tests confirm it works post-Connect on both dual-mode and legacy-only servers. If a future caller files an issue about pre-Connect use, the transport bootstrap would need lazy-init.
  - **Index.Lookup is exact-string.** Trailing slashes, percent encoding differences, or scheme casing are caller bugs. The doc-comment says so. Hosts that want fuzzy matching should normalize before calling Lookup.

## Test plan

- [x] `cd ext/skills && go test ./... -count=1` (101 sub-tests, all pass).
- [x] `go vet ./...` clean inside `ext/skills` and `client`.
- [x] `go test -race ./ext/skills/... -count=1` clean.
- [x] `go test ./client/... -count=1` (existing client tests pass, no regression on the `DiscoverResult` rename or the new Discover entry point).
- [x] Red-before-green: every new test would have failed on main (`skills.NewClient`, `Index.Lookup`, `ReadAndVerify`, `client.Discover`, `*UnsupportedDiscoverError` all did not exist).
- [x] Existing assertion counts: 0 weakened, 0 removed. `TestSkillsExtension_AppearsInInitialize` unchanged and still passes.

## Out of scope

- **Streaming reads at the protocol level.** `core.ResourceResult.Contents[].Text` is a single string. There is no streaming MCP read protocol. The ticket's "streaming" item is satisfied by passing bytes through without extra buffering, which is what the underlying client already does.
- **`READ_SKILL_TOOL` (name-keyed skill loader).** SEP-2640 sketches this as a host concern, not a client-library concern. Hosts compose the loader from `SupportsSkills` + `ListSkills` + `ReadSkillURI`.
- **Subscribing to skill changes** via `resources/subscribe`. Independent feature, belongs alongside hot-reload (mcpkit 564).
- **Pre-Connect `Discover()`.** Would require lazy transport init in `*client.Client`. File-when-needed.

