### PR TITLE
examples/apps/*: adopt common.RunServer across UI examples (588)

### DIFF
--- a/examples/apps/dashboard/main.go
+++ b/examples/apps/dashboard/main.go
@@ -43,31 +43,32 @@ func main() {
 	}
 	dashboardHTML := buf.String()
 
-	opts := common.MCPServerOptions(*addr, "[mcp] ")
-	opts = append(opts, server.WithExtension(&ui.UIExtension{}))
-	srv := server.NewServer(
-		core.ServerInfo{Name: "dashboard-app", Version: "0.1.0"},
-		opts...,
-	)
+	log.Printf("MCP at /mcp")
 
-	// Server-side tool: open_dashboard — opens the dashboard UI.
-	ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[struct{}, string]{
-		Name:        "open_dashboard",
-		Description: "Open the interactive dashboard with data tools",
-		Handler: func(ctx core.ToolContext, _ struct{}) (string, error) {
-			return "Dashboard opened. The app provides tools for querying data, filtering, exporting, and settings. Ask the model to query data or check settings.", nil
+	if err := common.RunServer(common.ServerConfig{
+		Name: "dashboard-app",
+		Addr: *addr,
+		Options: []server.Option{
+			server.WithExtension(&ui.UIExtension{}),
 		},
-		ResourceURI: "ui://dashboard/view",
-		Visibility:  []core.UIVisibility{core.UIVisibilityModel, core.UIVisibilityApp},
-		ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
-			return core.ResourceResult{Contents: []core.ResourceReadContent{{
-				URI: req.URI, MimeType: core.AppMIMEType, Text: dashboardHTML,
-			}}}, nil
+		Register: func(srv *server.Server) {
+			// Server-side tool: open_dashboard — opens the dashboard UI.
+			ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[struct{}, string]{
+				Name:        "open_dashboard",
+				Description: "Open the interactive dashboard with data tools",
+				Handler: func(ctx core.ToolContext, _ struct{}) (string, error) {
+					return "Dashboard opened. The app provides tools for querying data, filtering, exporting, and settings. Ask the model to query data or check settings.", nil
+				},
+				ResourceURI: "ui://dashboard/view",
+				Visibility:  []core.UIVisibility{core.UIVisibilityModel, core.UIVisibilityApp},
+				ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
+					return core.ResourceResult{Contents: []core.ResourceReadContent{{
+						URI: req.URI, MimeType: core.AppMIMEType, Text: dashboardHTML,
+					}}}, nil
+				},
+			})
 		},
-	})
-
-	log.Printf("dashboard-app listening on %s (MCP at /mcp)", *addr)
-	if err := srv.Run(*addr); err != nil {
+	}); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/examples/apps/interactive/main.go
+++ b/examples/apps/interactive/main.go
@@ -88,13 +88,22 @@ func main() {
 	}
 	gameHTML := buf.String()
 
-	opts := common.MCPServerOptions(*addr, "[mcp] ")
-	opts = append(opts, server.WithExtension(&ui.UIExtension{}))
-	srv := server.NewServer(
-		core.ServerInfo{Name: "tictactoe-app", Version: "0.1.0"},
-		opts...,
-	)
+	log.Printf("MCP at /mcp")
+	if err := common.RunServer(common.ServerConfig{
+		Name: "tictactoe-app",
+		Addr: *addr,
+		Options: []server.Option{
+			server.WithExtension(&ui.UIExtension{}),
+		},
+		Register: func(srv *server.Server) {
+			registerTicTacToeTools(srv, gameHTML)
+		},
+	}); err != nil {
+		log.Fatal(err)
+	}
+}
 
+func registerTicTacToeTools(srv *server.Server, gameHTML string) {
 	// Server-side tool: new_game — resets the board.
 	ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[struct{}, string]{
 		Name:        "new_game",
@@ -172,8 +181,4 @@ func main() {
 		},
 	))
 
-	log.Printf("tictactoe-app listening on %s (MCP at /mcp)", *addr)
-	if err := srv.Run(*addr); err != nil {
-		log.Fatal(err)
-	}
 }

--- a/examples/apps/todolist/main.go
+++ b/examples/apps/todolist/main.go
@@ -74,13 +74,22 @@ func main() {
 		return buf.String()
 	}
 
-	opts := common.MCPServerOptions(*addr, "[mcp] ")
-	opts = append(opts, server.WithExtension(&ui.UIExtension{}))
-	srv := server.NewServer(
-		core.ServerInfo{Name: "task-board", Version: "0.1.0"},
-		opts...,
-	)
+	log.Printf("MCP at /mcp")
+	if err := common.RunServer(common.ServerConfig{
+		Name: "task-board",
+		Addr: *addr,
+		Options: []server.Option{
+			server.WithExtension(&ui.UIExtension{}),
+		},
+		Register: func(srv *server.Server) {
+			registerTodoTools(srv, renderPage)
+		},
+	}); err != nil {
+		log.Fatal(err)
+	}
+}
 
+func registerTodoTools(srv *server.Server, renderPage func() string) {
 	// Register tools.
 	type addTaskInput struct {
 		Title    string `json:"title"    jsonschema:"description=Task title,required"`
@@ -270,8 +279,4 @@ func main() {
 		},
 	)
 
-	log.Printf("task-board listening on %s (MCP at /mcp)", *addr)
-	if err := srv.Run(*addr, server.WithStreamableHTTP(true)); err != nil {
-		log.Fatal(err)
-	}
 }

--- a/examples/apps/vanilla/main.go
+++ b/examples/apps/vanilla/main.go
@@ -48,52 +48,53 @@ func main() {
 	}
 	diceHTML := buf.String()
 
-	opts := common.MCPServerOptions(*addr, "[mcp] ")
-	opts = append(opts, server.WithExtension(&ui.UIExtension{}))
-	srv := server.NewServer(
-		core.ServerInfo{Name: "dice-app", Version: "0.1.0"},
-		opts...,
-	)
+	log.Printf("MCP at /mcp")
 
-	type rollDiceInput struct {
-		Sides int `json:"sides,omitempty" jsonschema:"description=Number of sides on the die,default=6"`
-	}
-	ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[rollDiceInput, string]{
-		Name:        "roll_dice",
-		Description: "Roll a die and show the result in a rich UI",
-		Handler: func(ctx core.ToolContext, input rollDiceInput) (string, error) {
-			if input.Sides <= 0 {
-				input.Sides = 6
-			}
-			result := rand.Intn(input.Sides) + 1
-			return fmt.Sprintf("Rolled a d%d: %d", input.Sides, result), nil
+	if err := common.RunServer(common.ServerConfig{
+		Name: "dice-app",
+		Addr: *addr,
+		Options: []server.Option{
+			server.WithExtension(&ui.UIExtension{}),
 		},
-		ResourceURI: "ui://dice/view",
-		Visibility:  []core.UIVisibility{core.UIVisibilityModel, core.UIVisibilityApp},
-		ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
-			result := core.ResourceResult{Contents: []core.ResourceReadContent{{
-				URI: req.URI, MimeType: core.AppMIMEType, Text: diceHTML,
-			}}}
-			// Debug: check if <script> tags survive serialization
-			raw, _ := core.MarshalJSON(result)
-			s := string(raw)
-			if idx := strings.Index(s, "script"); idx > 0 {
-				start := idx - 10
-				if start < 0 {
-					start = 0
-				}
-				end := idx + 50
-				if end > len(s) {
-					end = len(s)
-				}
-				log.Printf("DEBUG script context: ...%s...", s[start:end])
+		Register: func(srv *server.Server) {
+			type rollDiceInput struct {
+				Sides int `json:"sides,omitempty" jsonschema:"description=Number of sides on the die,default=6"`
 			}
-			return result, nil
+			ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[rollDiceInput, string]{
+				Name:        "roll_dice",
+				Description: "Roll a die and show the result in a rich UI",
+				Handler: func(ctx core.ToolContext, input rollDiceInput) (string, error) {
+					if input.Sides <= 0 {
+						input.Sides = 6
+					}
+					result := rand.Intn(input.Sides) + 1
+					return fmt.Sprintf("Rolled a d%d: %d", input.Sides, result), nil
+				},
+				ResourceURI: "ui://dice/view",
+				Visibility:  []core.UIVisibility{core.UIVisibilityModel, core.UIVisibilityApp},
+				ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
+					result := core.ResourceResult{Contents: []core.ResourceReadContent{{
+						URI: req.URI, MimeType: core.AppMIMEType, Text: diceHTML,
+					}}}
+					// Debug: check if <script> tags survive serialization
+					raw, _ := core.MarshalJSON(result)
+					s := string(raw)
+					if idx := strings.Index(s, "script"); idx > 0 {
+						start := idx - 10
+						if start < 0 {
+							start = 0
+						}
+						end := idx + 50
+						if end > len(s) {
+							end = len(s)
+						}
+						log.Printf("DEBUG script context: ...%s...", s[start:end])
+					}
+					return result, nil
+				},
+			})
 		},
-	})
-
-	log.Printf("dice-app listening on %s (MCP at /mcp)", *addr)
-	if err := srv.Run(*addr); err != nil {
+	}); err != nil {
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
## What changes

Third (and likely final) PR in the `common.RunServer` adoption sweep started by PR 585 and continued by PR 589. The four UI/Apps examples — `vanilla`, `dashboard`, `todolist`, `interactive` — all rolled their own `common.MCPServerOptions + WithExtension(&ui.UIExtension{}) + srv.Run(addr)` bootstrap, identical to the non-UI shape modulo the extension wiring. This PR adopts the existing helper, no new symbols.

## Reviewer's guide

Read in this order:

1. [examples/apps/vanilla/main.go](https://github.com/panyam/mcpkit/pull/592/files#diff-d52aec69217e70a8d5e89ba5ca83606a2ef533801b2c5a0af64be4329fca9871) — start here. Smallest example, cleanest before/after for the canonical UI shape.
2. [examples/apps/dashboard/main.go](https://github.com/panyam/mcpkit/pull/592/files#diff-62725f41c890db78b8612620aad6158f970c450c68adb8194432b05d217d119f) — same shape, single tool, no per-example helpers needed.
3. [examples/apps/todolist/main.go](https://github.com/panyam/mcpkit/pull/592/files#diff-6a204a78802617d55e08e08b9bbbddea94d18f99e03cadb1133b34c173921cab) — exercises the helper extraction pattern. Registrations close over a `renderPage` closure; pulled into `registerTodoTools(srv, renderPage)` so the `Register` callback stays a one-liner (same approach as PR 585's `tasks`/`tasks-v2` refactor).
4. [examples/apps/interactive/main.go](https://github.com/panyam/mcpkit/pull/592/files#diff-ff7d83c38fbbf71ebbfead0b52fdd842c511b477f2e3cd5ac4681adcd61118e0) — same extraction pattern (`registerTicTacToeTools(srv, gameHTML)`).

## Diff groups

Single intent: one mechanical adoption per file plus a helper-function extraction for the two examples whose registrations don't fit in an inline closure.

## Decision log

- **No new `common.RunUIServer` helper, contradicting issue 588's literal proposal.** After looking at the actual code, the only UI-specific bootstrap line is `server.WithExtension(&ui.UIExtension{})`. Auto-appending it via a new helper would (a) save one line per example, (b) pull `mcpkit/ext/ui` into `examples/common`'s go.mod, and (c) add a second helper to keep in sync with `RunServer`. The trade was lopsided enough that adopting the existing helper with `Options: []server.Option{server.WithExtension(&ui.UIExtension{})}` is the honest call. Will update issue 588's body to reflect this finding before closing.
- **HTML/bridge template render dance stays in each example.** Explicitly scoped out by issue 588's body ("HTML payload rendering stays in the example, no template smuggled into the helper") and reaffirmed here. If we want a `ui.MustRenderBridge` helper later it belongs in `ext/ui`, not `examples/common`.
- **Per-example helper extraction for todolist + interactive only.** Vanilla and dashboard's registrations are small enough to keep inline in the `Register` closure. Todolist (~200 lines, closes over `renderPage`) and interactive (~80 lines, closes over `gameHTML`) get `registerTodoTools` / `registerTicTacToeTools` package-level helpers so the `Register` field stays readable.
- **Did NOT touch `examples/apps/compat/*` (20 fixtures).** They follow the same bootstrap pattern but carry Playwright golden PNG baselines and a strict `tools/list` parity check vs upstream's TypeScript reference. Will file as a separate ticket gated on `make test-apps-playwright-docker`.

## Risk / blast radius

- Affects: 4 example servers under `examples/apps/<subdir>/`. Each is its own go.mod; no shared module surface changed.
- Tests covering this: `go vet ./...` clean per sub-module. No `*_test.go` exists in any of these.
- Be paranoid about: the `ui.UIExtension` wiring still propagates through `RunServer` to the initialize response. Verified — smoke ran `vanilla` against `:18092`, the initialize response includes `extensions.io.modelcontextprotocol/ui` in `capabilities`, proving the extension was applied before `ListenAndServe`.

## Before / after

`vanilla` (the simplest case):

```diff
-opts := common.MCPServerOptions(*addr, "[mcp] ")
-opts = append(opts, server.WithExtension(&ui.UIExtension{}))
-srv := server.NewServer(
-    core.ServerInfo{Name: "dice-app", Version: "0.1.0"},
-    opts...,
-)
-
-ui.RegisterTypedAppTool(srv, …)
-
-log.Printf("dice-app listening on %s (MCP at /mcp)", *addr)
-if err := srv.Run(*addr); err != nil {
-    log.Fatal(err)
-}
+log.Printf("MCP at /mcp")
+if err := common.RunServer(common.ServerConfig{
+    Name: "dice-app",
+    Addr: *addr,
+    Options: []server.Option{
+        server.WithExtension(&ui.UIExtension{}),
+    },
+    Register: func(srv *server.Server) {
+        ui.RegisterTypedAppTool(srv, …)
+    },
+}); err != nil {
+    log.Fatal(err)
+}
```

Smoke transcript (`vanilla` on `:18092`):

```
data: {"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25",
  "capabilities":{"tools":{"listChanged":true},…,
    "extensions":{"io.modelcontextprotocol/ui":{"specVersion":"2026-01-26","stability":"experimental"}}},
  "serverInfo":{"name":"dice-app","version":"0.1.0"}}}
```

The `extensions.io.modelcontextprotocol/ui` block is what confirms `WithExtension` survived the refactor.

## Out of scope (deliberately deferred)

- `examples/apps/compat/*` — same bootstrap pattern, separate PR gated on `make test-apps-playwright-docker` (golden PNG baselines + strict tools/list parity check). Will file as a follow-up ticket.
- `ui.MustRenderBridge` template render helper — issue 588's body explicitly excluded it; separate ticket if we want it; touches `ext/ui` sub-module surface.

## Test plan

- [x] `go mod tidy` no-op in each of the 4 `examples/apps/<subdir>/` modules
- [x] `go vet ./...` green across all 4 modules
- [x] Smoke: `vanilla` on `:18092` binds, accepts authenticated initialize, response includes the ui extension capability, exits cleanly on SIGTERM
