### PR TITLE
examples/apps/compat/*: adopt common.RunServer across upstream-parity fixtures (593)

### DIFF
--- a/examples/apps/compat/basic-preact/main.go
+++ b/examples/apps/compat/basic-preact/main.go
@@ -46,42 +46,46 @@ func main() {
 	}
 	html := string(htmlBytes)
 
-	opts := common.MCPServerOptions(*addr, "[basic-preact] ")
-	opts = append(opts, server.WithExtension(&ui.UIExtension{}))
-	srv := server.NewServer(
-		core.ServerInfo{Name: "Basic MCP App Server (Preact)", Version: "1.0.0"},
-		opts...,
-	)
+	log.Printf("[basic-preact] serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
 
-	resourceURI := "ui://get-time/mcp-app.html"
-
-	// Out=string so RegisterTypedAppTool emits no outputSchema, matching
-	// upstream basic-server-preact's text-only get-time output.
-	ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[struct{}, string]{
-		Name:        "get-time",
-		Title:       "Get Time",
-		Description: "Returns the current server time as an ISO 8601 string.",
-		Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportForbidden},
-		Handler: func(ctx core.ToolContext, _ struct{}) (string, error) {
-			return time.Now().UTC().Format(time.RFC3339Nano), nil
-		},
-		ResourceURI: resourceURI,
-		ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
-			return core.ResourceResult{Contents: []core.ResourceReadContent{{
-				URI: req.URI, MimeType: core.AppMIMEType, Text: html,
-			}}}, nil
-		},
-	})
-
-	log.Printf("basic-preact compat fixture listening on %s (MCP at /mcp)", *addr)
-	log.Printf("serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
 	cors := middleware.CORS(nil,
 		middleware.CORSAllowMethods("GET", "POST", "DELETE", "OPTIONS"),
 		middleware.CORSAllowHeaders("Content-Type", "Authorization", "Mcp-Session-Id", "Mcp-Protocol-Version"),
 		middleware.CORSExposeHeaders("Mcp-Session-Id"),
 	)
 
-	if err := srv.Run(*addr, server.WithHandlerWrap(cors)); err != nil {
+	resourceURI := "ui://get-time/mcp-app.html"
+	if err := common.RunServer(common.ServerConfig{
+		Name:      "Basic MCP App Server (Preact)",
+		Version:   "1.0.0",
+		Addr:      *addr,
+		LogPrefix: "[basic-preact] ",
+		Options: []server.Option{
+			server.WithExtension(&ui.UIExtension{}),
+		},
+		Register: func(srv *server.Server) {
+			// Out=string so RegisterTypedAppTool emits no outputSchema, matching
+			// upstream basic-server-preact's text-only get-time output.
+			ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[struct{}, string]{
+				Name:        "get-time",
+				Title:       "Get Time",
+				Description: "Returns the current server time as an ISO 8601 string.",
+				Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportForbidden},
+				Handler: func(ctx core.ToolContext, _ struct{}) (string, error) {
+					return time.Now().UTC().Format(time.RFC3339Nano), nil
+				},
+				ResourceURI: resourceURI,
+				ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
+					return core.ResourceResult{Contents: []core.ResourceReadContent{{
+						URI: req.URI, MimeType: core.AppMIMEType, Text: html,
+					}}}, nil
+				},
+			})
+		},
+		TransportOptions: []server.TransportOption{
+			server.WithHandlerWrap(cors),
+		},
+	}); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/examples/apps/compat/basic-react/main.go
+++ b/examples/apps/compat/basic-react/main.go
@@ -46,42 +46,46 @@ func main() {
 	}
 	html := string(htmlBytes)
 
-	opts := common.MCPServerOptions(*addr, "[basic-react] ")
-	opts = append(opts, server.WithExtension(&ui.UIExtension{}))
-	srv := server.NewServer(
-		core.ServerInfo{Name: "Basic MCP App Server (React)", Version: "1.0.0"},
-		opts...,
-	)
+	log.Printf("[basic-react] serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
 
-	resourceURI := "ui://get-time/mcp-app.html"
-
-	// Out=string so RegisterTypedAppTool emits no outputSchema, matching
-	// upstream basic-server-react's text-only get-time output.
-	ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[struct{}, string]{
-		Name:        "get-time",
-		Title:       "Get Time",
-		Description: "Returns the current server time as an ISO 8601 string.",
-		Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportForbidden},
-		Handler: func(ctx core.ToolContext, _ struct{}) (string, error) {
-			return time.Now().UTC().Format(time.RFC3339Nano), nil
-		},
-		ResourceURI: resourceURI,
-		ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
-			return core.ResourceResult{Contents: []core.ResourceReadContent{{
-				URI: req.URI, MimeType: core.AppMIMEType, Text: html,
-			}}}, nil
-		},
-	})
-
-	log.Printf("basic-react compat fixture listening on %s (MCP at /mcp)", *addr)
-	log.Printf("serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
 	cors := middleware.CORS(nil,
 		middleware.CORSAllowMethods("GET", "POST", "DELETE", "OPTIONS"),
 		middleware.CORSAllowHeaders("Content-Type", "Authorization", "Mcp-Session-Id", "Mcp-Protocol-Version"),
 		middleware.CORSExposeHeaders("Mcp-Session-Id"),
 	)
 
-	if err := srv.Run(*addr, server.WithHandlerWrap(cors)); err != nil {
+	resourceURI := "ui://get-time/mcp-app.html"
+	if err := common.RunServer(common.ServerConfig{
+		Name:      "Basic MCP App Server (React)",
+		Version:   "1.0.0",
+		Addr:      *addr,
+		LogPrefix: "[basic-react] ",
+		Options: []server.Option{
+			server.WithExtension(&ui.UIExtension{}),
+		},
+		Register: func(srv *server.Server) {
+			// Out=string so RegisterTypedAppTool emits no outputSchema, matching
+			// upstream basic-server-react's text-only get-time output.
+			ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[struct{}, string]{
+				Name:        "get-time",
+				Title:       "Get Time",
+				Description: "Returns the current server time as an ISO 8601 string.",
+				Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportForbidden},
+				Handler: func(ctx core.ToolContext, _ struct{}) (string, error) {
+					return time.Now().UTC().Format(time.RFC3339Nano), nil
+				},
+				ResourceURI: resourceURI,
+				ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
+					return core.ResourceResult{Contents: []core.ResourceReadContent{{
+						URI: req.URI, MimeType: core.AppMIMEType, Text: html,
+					}}}, nil
+				},
+			})
+		},
+		TransportOptions: []server.TransportOption{
+			server.WithHandlerWrap(cors),
+		},
+	}); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/examples/apps/compat/basic-solid/main.go
+++ b/examples/apps/compat/basic-solid/main.go
@@ -46,42 +46,46 @@ func main() {
 	}
 	html := string(htmlBytes)
 
-	opts := common.MCPServerOptions(*addr, "[basic-solid] ")
-	opts = append(opts, server.WithExtension(&ui.UIExtension{}))
-	srv := server.NewServer(
-		core.ServerInfo{Name: "Basic MCP App Server (Solid)", Version: "1.0.0"},
-		opts...,
-	)
+	log.Printf("[basic-solid] serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
 
-	resourceURI := "ui://get-time/mcp-app.html"
-
-	// Out=string so RegisterTypedAppTool emits no outputSchema, matching
-	// upstream basic-server-solid's text-only get-time output.
-	ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[struct{}, string]{
-		Name:        "get-time",
-		Title:       "Get Time",
-		Description: "Returns the current server time as an ISO 8601 string.",
-		Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportForbidden},
-		Handler: func(ctx core.ToolContext, _ struct{}) (string, error) {
-			return time.Now().UTC().Format(time.RFC3339Nano), nil
-		},
-		ResourceURI: resourceURI,
-		ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
-			return core.ResourceResult{Contents: []core.ResourceReadContent{{
-				URI: req.URI, MimeType: core.AppMIMEType, Text: html,
-			}}}, nil
-		},
-	})
-
-	log.Printf("basic-solid compat fixture listening on %s (MCP at /mcp)", *addr)
-	log.Printf("serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
 	cors := middleware.CORS(nil,
 		middleware.CORSAllowMethods("GET", "POST", "DELETE", "OPTIONS"),
 		middleware.CORSAllowHeaders("Content-Type", "Authorization", "Mcp-Session-Id", "Mcp-Protocol-Version"),
 		middleware.CORSExposeHeaders("Mcp-Session-Id"),
 	)
 
-	if err := srv.Run(*addr, server.WithHandlerWrap(cors)); err != nil {
+	resourceURI := "ui://get-time/mcp-app.html"
+	if err := common.RunServer(common.ServerConfig{
+		Name:      "Basic MCP App Server (Solid)",
+		Version:   "1.0.0",
+		Addr:      *addr,
+		LogPrefix: "[basic-solid] ",
+		Options: []server.Option{
+			server.WithExtension(&ui.UIExtension{}),
+		},
+		Register: func(srv *server.Server) {
+			// Out=string so RegisterTypedAppTool emits no outputSchema, matching
+			// upstream basic-server-solid's text-only get-time output.
+			ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[struct{}, string]{
+				Name:        "get-time",
+				Title:       "Get Time",
+				Description: "Returns the current server time as an ISO 8601 string.",
+				Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportForbidden},
+				Handler: func(ctx core.ToolContext, _ struct{}) (string, error) {
+					return time.Now().UTC().Format(time.RFC3339Nano), nil
+				},
+				ResourceURI: resourceURI,
+				ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
+					return core.ResourceResult{Contents: []core.ResourceReadContent{{
+						URI: req.URI, MimeType: core.AppMIMEType, Text: html,
+					}}}, nil
+				},
+			})
+		},
+		TransportOptions: []server.TransportOption{
+			server.WithHandlerWrap(cors),
+		},
+	}); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/examples/apps/compat/basic-svelte/main.go
+++ b/examples/apps/compat/basic-svelte/main.go
@@ -46,42 +46,46 @@ func main() {
 	}
 	html := string(htmlBytes)
 
-	opts := common.MCPServerOptions(*addr, "[basic-svelte] ")
-	opts = append(opts, server.WithExtension(&ui.UIExtension{}))
-	srv := server.NewServer(
-		core.ServerInfo{Name: "Basic MCP App Server (Svelte)", Version: "1.0.0"},
-		opts...,
-	)
+	log.Printf("[basic-svelte] serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
 
-	resourceURI := "ui://get-time/mcp-app.html"
-
-	// Out=string so RegisterTypedAppTool emits no outputSchema, matching
-	// upstream basic-server-svelte's text-only get-time output.
-	ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[struct{}, string]{
-		Name:        "get-time",
-		Title:       "Get Time",
-		Description: "Returns the current server time as an ISO 8601 string.",
-		Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportForbidden},
-		Handler: func(ctx core.ToolContext, _ struct{}) (string, error) {
-			return time.Now().UTC().Format(time.RFC3339Nano), nil
-		},
-		ResourceURI: resourceURI,
-		ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
-			return core.ResourceResult{Contents: []core.ResourceReadContent{{
-				URI: req.URI, MimeType: core.AppMIMEType, Text: html,
-			}}}, nil
-		},
-	})
-
-	log.Printf("basic-svelte compat fixture listening on %s (MCP at /mcp)", *addr)
-	log.Printf("serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
 	cors := middleware.CORS(nil,
 		middleware.CORSAllowMethods("GET", "POST", "DELETE", "OPTIONS"),
 		middleware.CORSAllowHeaders("Content-Type", "Authorization", "Mcp-Session-Id", "Mcp-Protocol-Version"),
 		middleware.CORSExposeHeaders("Mcp-Session-Id"),
 	)
 
-	if err := srv.Run(*addr, server.WithHandlerWrap(cors)); err != nil {
+	resourceURI := "ui://get-time/mcp-app.html"
+	if err := common.RunServer(common.ServerConfig{
+		Name:      "Basic MCP App Server (Svelte)",
+		Version:   "1.0.0",
+		Addr:      *addr,
+		LogPrefix: "[basic-svelte] ",
+		Options: []server.Option{
+			server.WithExtension(&ui.UIExtension{}),
+		},
+		Register: func(srv *server.Server) {
+			// Out=string so RegisterTypedAppTool emits no outputSchema, matching
+			// upstream basic-server-svelte's text-only get-time output.
+			ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[struct{}, string]{
+				Name:        "get-time",
+				Title:       "Get Time",
+				Description: "Returns the current server time as an ISO 8601 string.",
+				Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportForbidden},
+				Handler: func(ctx core.ToolContext, _ struct{}) (string, error) {
+					return time.Now().UTC().Format(time.RFC3339Nano), nil
+				},
+				ResourceURI: resourceURI,
+				ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
+					return core.ResourceResult{Contents: []core.ResourceReadContent{{
+						URI: req.URI, MimeType: core.AppMIMEType, Text: html,
+					}}}, nil
+				},
+			})
+		},
+		TransportOptions: []server.TransportOption{
+			server.WithHandlerWrap(cors),
+		},
+	}); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/examples/apps/compat/basic-vanillajs/main.go
+++ b/examples/apps/compat/basic-vanillajs/main.go
@@ -49,44 +49,48 @@ func main() {
 	}
 	html := string(htmlBytes)
 
-	opts := common.MCPServerOptions(*addr, "[basic-vanillajs] ")
-	opts = append(opts, server.WithExtension(&ui.UIExtension{}))
-	srv := server.NewServer(
-		core.ServerInfo{Name: "Basic MCP App Server (Vanilla JS)", Version: "1.0.0"},
-		opts...,
-	)
+	log.Printf("[basic-vanillajs] serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
 
-	resourceURI := "ui://get-time/mcp-app.html"
-
-	// Fields match upstream basic-server-vanillajs's registerAppTool call
-	// byte-for-byte (Title, Description, Execution.TaskSupport=forbidden).
-	// Visibility intentionally NOT set — upstream doesn't emit
-	// _meta.ui.visibility either.
-	ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[struct{}, getTimeOutput]{
-		Name:        "get-time",
-		Title:       "Get Time",
-		Description: "Returns the current server time as an ISO 8601 string.",
-		Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportForbidden},
-		Handler: func(ctx core.ToolContext, _ struct{}) (getTimeOutput, error) {
-			return getTimeOutput{Time: time.Now().UTC().Format(time.RFC3339Nano)}, nil
-		},
-		ResourceURI: resourceURI,
-		ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
-			return core.ResourceResult{Contents: []core.ResourceReadContent{{
-				URI: req.URI, MimeType: core.AppMIMEType, Text: html,
-			}}}, nil
-		},
-	})
-
-	log.Printf("basic-vanillajs compat fixture listening on %s (MCP at /mcp)", *addr)
-	log.Printf("serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
 	cors := middleware.CORS(nil,
 		middleware.CORSAllowMethods("GET", "POST", "DELETE", "OPTIONS"),
 		middleware.CORSAllowHeaders("Content-Type", "Authorization", "Mcp-Session-Id", "Mcp-Protocol-Version"),
 		middleware.CORSExposeHeaders("Mcp-Session-Id"),
 	)
 
-	if err := srv.Run(*addr, server.WithHandlerWrap(cors)); err != nil {
+	resourceURI := "ui://get-time/mcp-app.html"
+	if err := common.RunServer(common.ServerConfig{
+		Name:      "Basic MCP App Server (Vanilla JS)",
+		Version:   "1.0.0",
+		Addr:      *addr,
+		LogPrefix: "[basic-vanillajs] ",
+		Options: []server.Option{
+			server.WithExtension(&ui.UIExtension{}),
+		},
+		Register: func(srv *server.Server) {
+			// Fields match upstream basic-server-vanillajs's registerAppTool
+			// call byte-for-byte (Title, Description, Execution.TaskSupport=
+			// forbidden). Visibility intentionally NOT set — upstream doesn't
+			// emit _meta.ui.visibility either.
+			ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[struct{}, getTimeOutput]{
+				Name:        "get-time",
+				Title:       "Get Time",
+				Description: "Returns the current server time as an ISO 8601 string.",
+				Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportForbidden},
+				Handler: func(ctx core.ToolContext, _ struct{}) (getTimeOutput, error) {
+					return getTimeOutput{Time: time.Now().UTC().Format(time.RFC3339Nano)}, nil
+				},
+				ResourceURI: resourceURI,
+				ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
+					return core.ResourceResult{Contents: []core.ResourceReadContent{{
+						URI: req.URI, MimeType: core.AppMIMEType, Text: html,
+					}}}, nil
+				},
+			})
+		},
+		TransportOptions: []server.TransportOption{
+			server.WithHandlerWrap(cors),
+		},
+	}); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/examples/apps/compat/basic-vue/main.go
+++ b/examples/apps/compat/basic-vue/main.go
@@ -46,42 +46,46 @@ func main() {
 	}
 	html := string(htmlBytes)
 
-	opts := common.MCPServerOptions(*addr, "[basic-vue] ")
-	opts = append(opts, server.WithExtension(&ui.UIExtension{}))
-	srv := server.NewServer(
-		core.ServerInfo{Name: "Basic MCP App Server (Vue)", Version: "1.0.0"},
-		opts...,
-	)
+	log.Printf("[basic-vue] serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
 
-	resourceURI := "ui://get-time/mcp-app.html"
-
-	// Out=string so RegisterTypedAppTool emits no outputSchema, matching
-	// upstream basic-server-vue's text-only get-time output.
-	ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[struct{}, string]{
-		Name:        "get-time",
-		Title:       "Get Time",
-		Description: "Returns the current server time as an ISO 8601 string.",
-		Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportForbidden},
-		Handler: func(ctx core.ToolContext, _ struct{}) (string, error) {
-			return time.Now().UTC().Format(time.RFC3339Nano), nil
-		},
-		ResourceURI: resourceURI,
-		ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
-			return core.ResourceResult{Contents: []core.ResourceReadContent{{
-				URI: req.URI, MimeType: core.AppMIMEType, Text: html,
-			}}}, nil
-		},
-	})
-
-	log.Printf("basic-vue compat fixture listening on %s (MCP at /mcp)", *addr)
-	log.Printf("serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
 	cors := middleware.CORS(nil,
 		middleware.CORSAllowMethods("GET", "POST", "DELETE", "OPTIONS"),
 		middleware.CORSAllowHeaders("Content-Type", "Authorization", "Mcp-Session-Id", "Mcp-Protocol-Version"),
 		middleware.CORSExposeHeaders("Mcp-Session-Id"),
 	)
 
-	if err := srv.Run(*addr, server.WithHandlerWrap(cors)); err != nil {
+	resourceURI := "ui://get-time/mcp-app.html"
+	if err := common.RunServer(common.ServerConfig{
+		Name:      "Basic MCP App Server (Vue)",
+		Version:   "1.0.0",
+		Addr:      *addr,
+		LogPrefix: "[basic-vue] ",
+		Options: []server.Option{
+			server.WithExtension(&ui.UIExtension{}),
+		},
+		Register: func(srv *server.Server) {
+			// Out=string so RegisterTypedAppTool emits no outputSchema, matching
+			// upstream basic-server-vue's text-only get-time output.
+			ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[struct{}, string]{
+				Name:        "get-time",
+				Title:       "Get Time",
+				Description: "Returns the current server time as an ISO 8601 string.",
+				Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportForbidden},
+				Handler: func(ctx core.ToolContext, _ struct{}) (string, error) {
+					return time.Now().UTC().Format(time.RFC3339Nano), nil
+				},
+				ResourceURI: resourceURI,
+				ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
+					return core.ResourceResult{Contents: []core.ResourceReadContent{{
+						URI: req.URI, MimeType: core.AppMIMEType, Text: html,
+					}}}, nil
+				},
+			})
+		},
+		TransportOptions: []server.TransportOption{
+			server.WithHandlerWrap(cors),
+		},
+	}); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/examples/apps/compat/budget-allocator/main.go
+++ b/examples/apps/compat/budget-allocator/main.go
@@ -84,54 +84,58 @@ func main() {
 	}
 	html := string(htmlBytes)
 
-	opts := common.MCPServerOptions(*addr, "[budget-allocator] ")
-	opts = append(opts, server.WithExtension(&ui.UIExtension{}))
-	srv := server.NewServer(
-		core.ServerInfo{Name: "Budget Allocator Server", Version: "1.0.0"},
-		opts...,
-	)
-
-	resourceURI := "ui://budget-allocator/mcp-app.html"
-
-	ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[struct{}, budgetDataOutput]{
-		Name:        "get-budget-data",
-		Title:       "Get Budget Data",
-		Description: "Returns budget configuration with 24 months of historical allocations and industry benchmarks by company stage. The widget is interactive and exposes tools for reading/modifying allocations, adjusting budgets, and comparing against industry benchmarks.",
-		Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportForbidden},
-		Handler: func(ctx core.ToolContext, _ struct{}) (budgetDataOutput, error) {
-			// Visual test doesn't depend on the data shape; the iframe renders
-			// its own demo content. Return an empty-but-typed payload.
-			return budgetDataOutput{
-				Config: budgetConfig{
-					Categories:     []budgetCategory{},
-					PresetBudgets:  []float64{},
-					Currency:       "USD",
-					CurrencySymbol: "$",
-				},
-				Analytics: budgetAnalytics{
-					History:    []historicalMonth{},
-					Benchmarks: []stageBenchmark{},
-					Stages:     []string{},
-				},
-			}, nil
-		},
-		ResourceURI: resourceURI,
-		ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
-			return core.ResourceResult{Contents: []core.ResourceReadContent{{
-				URI: req.URI, MimeType: core.AppMIMEType, Text: html,
-			}}}, nil
-		},
-	})
-
 	cors := middleware.CORS(nil,
 		middleware.CORSAllowMethods("GET", "POST", "DELETE", "OPTIONS"),
 		middleware.CORSAllowHeaders("Content-Type", "Authorization", "Mcp-Session-Id", "Mcp-Protocol-Version"),
 		middleware.CORSExposeHeaders("Mcp-Session-Id"),
 	)
 
-	log.Printf("budget-allocator compat fixture listening on %s (MCP at /mcp)", *addr)
-	log.Printf("serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
-	if err := srv.Run(*addr, server.WithHandlerWrap(cors)); err != nil {
+	log.Printf("[budget-allocator] serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
+
+	resourceURI := "ui://budget-allocator/mcp-app.html"
+	if err := common.RunServer(common.ServerConfig{
+		Name:      "Budget Allocator Server",
+		Version:   "1.0.0",
+		Addr:      *addr,
+		LogPrefix: "[budget-allocator] ",
+		Options: []server.Option{
+			server.WithExtension(&ui.UIExtension{}),
+		},
+		Register: func(srv *server.Server) {
+			ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[struct{}, budgetDataOutput]{
+				Name:        "get-budget-data",
+				Title:       "Get Budget Data",
+				Description: "Returns budget configuration with 24 months of historical allocations and industry benchmarks by company stage. The widget is interactive and exposes tools for reading/modifying allocations, adjusting budgets, and comparing against industry benchmarks.",
+				Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportForbidden},
+				Handler: func(ctx core.ToolContext, _ struct{}) (budgetDataOutput, error) {
+					// Visual test doesn't depend on the data shape; the iframe renders
+					// its own demo content. Return an empty-but-typed payload.
+					return budgetDataOutput{
+						Config: budgetConfig{
+							Categories:     []budgetCategory{},
+							PresetBudgets:  []float64{},
+							Currency:       "USD",
+							CurrencySymbol: "$",
+						},
+						Analytics: budgetAnalytics{
+							History:    []historicalMonth{},
+							Benchmarks: []stageBenchmark{},
+							Stages:     []string{},
+						},
+					}, nil
+				},
+				ResourceURI: resourceURI,
+				ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
+					return core.ResourceResult{Contents: []core.ResourceReadContent{{
+						URI: req.URI, MimeType: core.AppMIMEType, Text: html,
+					}}}, nil
+				},
+			})
+		},
+		TransportOptions: []server.TransportOption{
+			server.WithHandlerWrap(cors),
+		},
+	}); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/examples/apps/compat/cohort-heatmap/main.go
+++ b/examples/apps/compat/cohort-heatmap/main.go
@@ -75,50 +75,54 @@ func main() {
 	}
 	html := string(htmlBytes)
 
-	opts := common.MCPServerOptions(*addr, "[cohort-heatmap] ")
-	opts = append(opts, server.WithExtension(&ui.UIExtension{}))
-	srv := server.NewServer(
-		core.ServerInfo{Name: "Cohort Heatmap Server", Version: "1.0.0"},
-		opts...,
-	)
-
-	resourceURI := "ui://get-cohort-data/mcp-app.html"
-
-	ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[cohortInput, cohortDataOutput]{
-		Name:        "get-cohort-data",
-		Title:       "Get Cohort Retention Data",
-		Description: "Returns cohort retention heatmap data showing customer retention over time by signup month",
-		Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportForbidden},
-		Handler: func(ctx core.ToolContext, in cohortInput) (cohortDataOutput, error) {
-			// Visual test never asserts on the data shape — return a stub
-			// matching the declared types. Upstream's iframe generates its
-			// own demo data when the tool returns empty arrays.
-			return cohortDataOutput{
-				Cohorts:      []cohortRow{},
-				Periods:      []string{},
-				PeriodLabels: []string{},
-				Metric:       in.Metric,
-				PeriodType:   in.PeriodType,
-				GeneratedAt:  time.Now().UTC().Format(time.RFC3339Nano),
-			}, nil
-		},
-		ResourceURI: resourceURI,
-		ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
-			return core.ResourceResult{Contents: []core.ResourceReadContent{{
-				URI: req.URI, MimeType: core.AppMIMEType, Text: html,
-			}}}, nil
-		},
-	})
-
 	cors := middleware.CORS(nil,
 		middleware.CORSAllowMethods("GET", "POST", "DELETE", "OPTIONS"),
 		middleware.CORSAllowHeaders("Content-Type", "Authorization", "Mcp-Session-Id", "Mcp-Protocol-Version"),
 		middleware.CORSExposeHeaders("Mcp-Session-Id"),
 	)
 
-	log.Printf("cohort-heatmap compat fixture listening on %s (MCP at /mcp)", *addr)
-	log.Printf("serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
-	if err := srv.Run(*addr, server.WithHandlerWrap(cors)); err != nil {
+	log.Printf("[cohort-heatmap] serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
+
+	resourceURI := "ui://get-cohort-data/mcp-app.html"
+	if err := common.RunServer(common.ServerConfig{
+		Name:      "Cohort Heatmap Server",
+		Version:   "1.0.0",
+		Addr:      *addr,
+		LogPrefix: "[cohort-heatmap] ",
+		Options: []server.Option{
+			server.WithExtension(&ui.UIExtension{}),
+		},
+		Register: func(srv *server.Server) {
+			ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[cohortInput, cohortDataOutput]{
+				Name:        "get-cohort-data",
+				Title:       "Get Cohort Retention Data",
+				Description: "Returns cohort retention heatmap data showing customer retention over time by signup month",
+				Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportForbidden},
+				Handler: func(ctx core.ToolContext, in cohortInput) (cohortDataOutput, error) {
+					// Visual test never asserts on the data shape — return a stub
+					// matching the declared types. Upstream's iframe generates its
+					// own demo data when the tool returns empty arrays.
+					return cohortDataOutput{
+						Cohorts:      []cohortRow{},
+						Periods:      []string{},
+						PeriodLabels: []string{},
+						Metric:       in.Metric,
+						PeriodType:   in.PeriodType,
+						GeneratedAt:  time.Now().UTC().Format(time.RFC3339Nano),
+					}, nil
+				},
+				ResourceURI: resourceURI,
+				ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
+					return core.ResourceResult{Contents: []core.ResourceReadContent{{
+						URI: req.URI, MimeType: core.AppMIMEType, Text: html,
+					}}}, nil
+				},
+			})
+		},
+		TransportOptions: []server.TransportOption{
+			server.WithHandlerWrap(cors),
+		},
+	}); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/examples/apps/compat/customer-segmentation/main.go
+++ b/examples/apps/compat/customer-segmentation/main.go
@@ -70,43 +70,47 @@ func main() {
 	}
 	html := string(htmlBytes)
 
-	opts := common.MCPServerOptions(*addr, "[customer-segmentation] ")
-	opts = append(opts, server.WithExtension(&ui.UIExtension{}))
-	srv := server.NewServer(
-		core.ServerInfo{Name: "Customer Segmentation Server", Version: "1.0.0"},
-		opts...,
-	)
-
-	resourceURI := "ui://customer-segmentation/mcp-app.html"
-
-	ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[customerInput, customerDataOutput]{
-		Name:        "get-customer-data",
-		Title:       "Get Customer Data",
-		Description: "Returns customer data with segment information for visualization. Optionally filter by segment.",
-		Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportForbidden},
-		Handler: func(ctx core.ToolContext, in customerInput) (customerDataOutput, error) {
-			return customerDataOutput{
-				Customers: []customer{},
-				Segments:  []segmentSummary{},
-			}, nil
-		},
-		ResourceURI: resourceURI,
-		ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
-			return core.ResourceResult{Contents: []core.ResourceReadContent{{
-				URI: req.URI, MimeType: core.AppMIMEType, Text: html,
-			}}}, nil
-		},
-	})
-
 	cors := middleware.CORS(nil,
 		middleware.CORSAllowMethods("GET", "POST", "DELETE", "OPTIONS"),
 		middleware.CORSAllowHeaders("Content-Type", "Authorization", "Mcp-Session-Id", "Mcp-Protocol-Version"),
 		middleware.CORSExposeHeaders("Mcp-Session-Id"),
 	)
 
-	log.Printf("customer-segmentation compat fixture listening on %s (MCP at /mcp)", *addr)
-	log.Printf("serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
-	if err := srv.Run(*addr, server.WithHandlerWrap(cors)); err != nil {
+	log.Printf("[customer-segmentation] serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
+
+	resourceURI := "ui://customer-segmentation/mcp-app.html"
+	if err := common.RunServer(common.ServerConfig{
+		Name:      "Customer Segmentation Server",
+		Version:   "1.0.0",
+		Addr:      *addr,
+		LogPrefix: "[customer-segmentation] ",
+		Options: []server.Option{
+			server.WithExtension(&ui.UIExtension{}),
+		},
+		Register: func(srv *server.Server) {
+			ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[customerInput, customerDataOutput]{
+				Name:        "get-customer-data",
+				Title:       "Get Customer Data",
+				Description: "Returns customer data with segment information for visualization. Optionally filter by segment.",
+				Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportForbidden},
+				Handler: func(ctx core.ToolContext, in customerInput) (customerDataOutput, error) {
+					return customerDataOutput{
+						Customers: []customer{},
+						Segments:  []segmentSummary{},
+					}, nil
+				},
+				ResourceURI: resourceURI,
+				ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
+					return core.ResourceResult{Contents: []core.ResourceReadContent{{
+						URI: req.URI, MimeType: core.AppMIMEType, Text: html,
+					}}}, nil
+				},
+			})
+		},
+		TransportOptions: []server.TransportOption{
+			server.WithHandlerWrap(cors),
+		},
+	}); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/examples/apps/compat/debug-server/main.go
+++ b/examples/apps/compat/debug-server/main.go
@@ -80,13 +80,34 @@ func main() {
 	}
 	html := string(htmlBytes)
 
-	opts := common.MCPServerOptions(*addr, "[debug-server] ")
-	opts = append(opts, server.WithExtension(&ui.UIExtension{}))
-	srv := server.NewServer(
-		core.ServerInfo{Name: "Debug MCP App Server", Version: "1.0.0"},
-		opts...,
+	cors := middleware.CORS(nil,
+		middleware.CORSAllowMethods("GET", "POST", "DELETE", "OPTIONS"),
+		middleware.CORSAllowHeaders("Content-Type", "Authorization", "Mcp-Session-Id", "Mcp-Protocol-Version"),
+		middleware.CORSExposeHeaders("Mcp-Session-Id"),
 	)
 
+	log.Printf("[debug-server] serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
+
+	if err := common.RunServer(common.ServerConfig{
+		Name:      "Debug MCP App Server",
+		Version:   "1.0.0",
+		Addr:      *addr,
+		LogPrefix: "[debug-server] ",
+		Options: []server.Option{
+			server.WithExtension(&ui.UIExtension{}),
+		},
+		Register: func(srv *server.Server) {
+			registerDebugServerTools(srv, html)
+		},
+		TransportOptions: []server.TransportOption{
+			server.WithHandlerWrap(cors),
+		},
+	}); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func registerDebugServerTools(srv *server.Server, html string) {
 	resourceURI := "ui://debug-tool/mcp-app.html"
 
 	// Tool 1: debug-tool — the kitchen-sink tool with its own UI resource.
@@ -160,16 +181,4 @@ func main() {
 	)
 	logTyped.Title = "Log to File"
 	srv.RegisterTool(logTyped.ToolDef, logTyped.Handler)
-
-	cors := middleware.CORS(nil,
-		middleware.CORSAllowMethods("GET", "POST", "DELETE", "OPTIONS"),
-		middleware.CORSAllowHeaders("Content-Type", "Authorization", "Mcp-Session-Id", "Mcp-Protocol-Version"),
-		middleware.CORSExposeHeaders("Mcp-Session-Id"),
-	)
-
-	log.Printf("debug-server compat fixture listening on %s (MCP at /mcp)", *addr)
-	log.Printf("serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
-	if err := srv.Run(*addr, server.WithHandlerWrap(cors)); err != nil {
-		log.Fatal(err)
-	}
 }

--- a/examples/apps/compat/integration/main.go
+++ b/examples/apps/compat/integration/main.go
@@ -47,13 +47,34 @@ func main() {
 	}
 	html := string(htmlBytes)
 
-	opts := common.MCPServerOptions(*addr, "[integration] ")
-	opts = append(opts, server.WithExtension(&ui.UIExtension{}))
-	srv := server.NewServer(
-		core.ServerInfo{Name: "Integration Test Server", Version: "1.0.0"},
-		opts...,
+	cors := middleware.CORS(nil,
+		middleware.CORSAllowMethods("GET", "POST", "DELETE", "OPTIONS"),
+		middleware.CORSAllowHeaders("Content-Type", "Authorization", "Mcp-Session-Id", "Mcp-Protocol-Version"),
+		middleware.CORSExposeHeaders("Mcp-Session-Id"),
 	)
 
+	log.Printf("[integration] serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
+
+	if err := common.RunServer(common.ServerConfig{
+		Name:      "Integration Test Server",
+		Version:   "1.0.0",
+		Addr:      *addr,
+		LogPrefix: "[integration] ",
+		Options: []server.Option{
+			server.WithExtension(&ui.UIExtension{}),
+		},
+		Register: func(srv *server.Server) {
+			registerIntegrationTools(srv, html)
+		},
+		TransportOptions: []server.TransportOption{
+			server.WithHandlerWrap(cors),
+		},
+	}); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func registerIntegrationTools(srv *server.Server, html string) {
 	resourceURI := "ui://get-time/mcp-app.html"
 	const sampleDownloadURI = "resource:///sample-report.txt"
 
@@ -93,16 +114,4 @@ func main() {
 			}}}, nil
 		},
 	)
-
-	cors := middleware.CORS(nil,
-		middleware.CORSAllowMethods("GET", "POST", "DELETE", "OPTIONS"),
-		middleware.CORSAllowHeaders("Content-Type", "Authorization", "Mcp-Session-Id", "Mcp-Protocol-Version"),
-		middleware.CORSExposeHeaders("Mcp-Session-Id"),
-	)
-
-	log.Printf("integration compat fixture listening on %s (MCP at /mcp)", *addr)
-	log.Printf("serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
-	if err := srv.Run(*addr, server.WithHandlerWrap(cors)); err != nil {
-		log.Fatal(err)
-	}
 }

--- a/examples/apps/compat/map/main.go
+++ b/examples/apps/compat/map/main.go
@@ -53,63 +53,67 @@ func main() {
 	}
 	html := string(htmlBytes)
 
-	opts := common.MCPServerOptions(*addr, "[map] ")
-	opts = append(opts, server.WithExtension(&ui.UIExtension{}))
-	srv := server.NewServer(
-		core.ServerInfo{Name: "CesiumJS Map Server", Version: "1.0.0"},
-		opts...,
-	)
-
-	resourceURI := "ui://cesium-map/mcp-app.html"
-
-	// Tool 1: show-map — App tool with its own UI iframe.
-	ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[showMapInput, string]{
-		Name:        "show-map",
-		Title:       "Show Map",
-		Description: "Display an interactive world map zoomed to a specific bounding box. Use the GeoCode tool to find the bounding box of a location. The widget is interactive and exposes tools for navigation (fly to locations) and querying the current view.",
-		Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportForbidden},
-		Handler: func(ctx core.ToolContext, in showMapInput) (string, error) {
-			// Visual test doesn't depend on the response content; the iframe's
-			// CesiumJS does the rendering. Upstream returns a text summary.
-			return "Displaying globe.", nil
-		},
-		ResourceURI: resourceURI,
-		ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
-			return core.ResourceResult{Contents: []core.ResourceReadContent{{
-				URI: req.URI, MimeType: core.AppMIMEType, Text: html,
-			}}}, nil
-		},
-	})
-
-	// Tool 2: geocode — plain MCP tool (no UI), called by the App via the
-	// bridge. InputSchemaPatch lets us land the comma-rich description
-	// without struct-tag truncation; reflection still emits the
-	// `type: string` shape.
-	geocodeTyped := core.TypedTool[geocodeInput, string](
-		"geocode",
-		"Search for places using OpenStreetMap. Returns coordinates and bounding boxes for up to 5 matches.",
-		func(ctx core.ToolContext, _ geocodeInput) (string, error) {
-			return "No results.", nil
-		},
-		core.WithToolExecution(&core.ToolExecution{TaskSupport: core.TaskSupportForbidden}),
-		core.WithInputSchemaPatch(func(s *core.SchemaBuilder) {
-			s.Prop("query").
-				Desc("Place name or address to search for (e.g., 'Paris', 'Golden Gate Bridge', '1600 Pennsylvania Ave')").
-				Required()
-		}),
-	)
-	geocodeTyped.Title = "Geocode"
-	srv.RegisterTool(geocodeTyped.ToolDef, geocodeTyped.Handler)
-
 	cors := middleware.CORS(nil,
 		middleware.CORSAllowMethods("GET", "POST", "DELETE", "OPTIONS"),
 		middleware.CORSAllowHeaders("Content-Type", "Authorization", "Mcp-Session-Id", "Mcp-Protocol-Version"),
 		middleware.CORSExposeHeaders("Mcp-Session-Id"),
 	)
 
-	log.Printf("map compat fixture listening on %s (MCP at /mcp)", *addr)
-	log.Printf("serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
-	if err := srv.Run(*addr, server.WithHandlerWrap(cors)); err != nil {
+	log.Printf("[map] serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
+
+	resourceURI := "ui://cesium-map/mcp-app.html"
+	if err := common.RunServer(common.ServerConfig{
+		Name:      "CesiumJS Map Server",
+		Version:   "1.0.0",
+		Addr:      *addr,
+		LogPrefix: "[map] ",
+		Options: []server.Option{
+			server.WithExtension(&ui.UIExtension{}),
+		},
+		Register: func(srv *server.Server) {
+			// Tool 1: show-map — App tool with its own UI iframe.
+			ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[showMapInput, string]{
+				Name:        "show-map",
+				Title:       "Show Map",
+				Description: "Display an interactive world map zoomed to a specific bounding box. Use the GeoCode tool to find the bounding box of a location. The widget is interactive and exposes tools for navigation (fly to locations) and querying the current view.",
+				Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportForbidden},
+				Handler: func(ctx core.ToolContext, in showMapInput) (string, error) {
+					// Visual test doesn't depend on the response content; the iframe's
+					// CesiumJS does the rendering. Upstream returns a text summary.
+					return "Displaying globe.", nil
+				},
+				ResourceURI: resourceURI,
+				ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
+					return core.ResourceResult{Contents: []core.ResourceReadContent{{
+						URI: req.URI, MimeType: core.AppMIMEType, Text: html,
+					}}}, nil
+				},
+			})
+
+			// Tool 2: geocode — plain MCP tool (no UI), called by the App via the
+			// bridge. InputSchemaPatch lets us land the comma-rich description
+			// without struct-tag truncation; reflection still emits the
+			// `type: string` shape.
+			geocodeTyped := core.TypedTool[geocodeInput, string](
+				"geocode",
+				"Search for places using OpenStreetMap. Returns coordinates and bounding boxes for up to 5 matches.",
+				func(ctx core.ToolContext, _ geocodeInput) (string, error) {
+					return "No results.", nil
+				},
+				core.WithToolExecution(&core.ToolExecution{TaskSupport: core.TaskSupportForbidden}),
+				core.WithInputSchemaPatch(func(s *core.SchemaBuilder) {
+					s.Prop("query").
+						Desc("Place name or address to search for (e.g., 'Paris', 'Golden Gate Bridge', '1600 Pennsylvania Ave')").
+						Required()
+				}),
+			)
+			geocodeTyped.Title = "Geocode"
+			srv.RegisterTool(geocodeTyped.ToolDef, geocodeTyped.Handler)
+		},
+		TransportOptions: []server.TransportOption{
+			server.WithHandlerWrap(cors),
+		},
+	}); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/examples/apps/compat/pdf-server/main.go
+++ b/examples/apps/compat/pdf-server/main.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/panyam/mcpkit/core"
 	"github.com/panyam/mcpkit/examples/common"
 	"github.com/panyam/mcpkit/ext/ui"
 	"github.com/panyam/mcpkit/server"
@@ -60,24 +59,30 @@ func main() {
 	}
 	html := string(htmlBytes)
 
-	opts := common.MCPServerOptions(*addr, defaultLogTag)
-	opts = append(opts, server.WithExtension(&ui.UIExtension{}))
-	srv := server.NewServer(
-		core.ServerInfo{Name: pdfDisplayName, Version: pdfServerVer},
-		opts...,
-	)
-
-	registerAllTools(srv, newHub(), html)
-
 	cors := middleware.CORS(nil,
 		middleware.CORSAllowMethods("GET", "POST", "DELETE", "OPTIONS"),
 		middleware.CORSAllowHeaders("Content-Type", "Authorization", "Mcp-Session-Id", "Mcp-Protocol-Version"),
 		middleware.CORSExposeHeaders("Mcp-Session-Id"),
 	)
 
-	log.Printf("pdf-server compat fixture listening on %s (MCP at /mcp)", *addr)
-	log.Printf("serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
-	if err := srv.Run(*addr, server.WithHandlerWrap(cors)); err != nil {
+	log.Printf("%sserving mcp-app.html from %s (%d bytes)", defaultLogTag, htmlPath, len(html))
+
+	hub := newHub()
+	if err := common.RunServer(common.ServerConfig{
+		Name:      pdfDisplayName,
+		Version:   pdfServerVer,
+		Addr:      *addr,
+		LogPrefix: defaultLogTag,
+		Options: []server.Option{
+			server.WithExtension(&ui.UIExtension{}),
+		},
+		Register: func(srv *server.Server) {
+			registerAllTools(srv, hub, html)
+		},
+		TransportOptions: []server.TransportOption{
+			server.WithHandlerWrap(cors),
+		},
+	}); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/examples/apps/compat/quickstart/main.go
+++ b/examples/apps/compat/quickstart/main.go
@@ -42,44 +42,48 @@ func main() {
 	}
 	html := string(htmlBytes)
 
-	opts := common.MCPServerOptions(*addr, "[quickstart] ")
-	opts = append(opts, server.WithExtension(&ui.UIExtension{}))
-	srv := server.NewServer(
-		core.ServerInfo{Name: "Quickstart MCP App Server", Version: "1.0.0"},
-		opts...,
-	)
+	log.Printf("[quickstart] serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
 
-	resourceURI := "ui://get-time/mcp-app.html"
-
-	// Matches upstream's quickstart registerAppTool: same tool name, same
-	// title, slightly shorter description ("Returns the current server
-	// time." with no ISO 8601 suffix — drift check enforces this), text-only
-	// output (no outputSchema).
-	ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[struct{}, string]{
-		Name:        "get-time",
-		Title:       "Get Time",
-		Description: "Returns the current server time.",
-		Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportForbidden},
-		Handler: func(ctx core.ToolContext, _ struct{}) (string, error) {
-			return time.Now().UTC().Format(time.RFC3339Nano), nil
-		},
-		ResourceURI: resourceURI,
-		ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
-			return core.ResourceResult{Contents: []core.ResourceReadContent{{
-				URI: req.URI, MimeType: core.AppMIMEType, Text: html,
-			}}}, nil
-		},
-	})
-
-	log.Printf("quickstart compat fixture listening on %s (MCP at /mcp)", *addr)
-	log.Printf("serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
 	cors := middleware.CORS(nil,
 		middleware.CORSAllowMethods("GET", "POST", "DELETE", "OPTIONS"),
 		middleware.CORSAllowHeaders("Content-Type", "Authorization", "Mcp-Session-Id", "Mcp-Protocol-Version"),
 		middleware.CORSExposeHeaders("Mcp-Session-Id"),
 	)
 
-	if err := srv.Run(*addr, server.WithHandlerWrap(cors)); err != nil {
+	resourceURI := "ui://get-time/mcp-app.html"
+	if err := common.RunServer(common.ServerConfig{
+		Name:      "Quickstart MCP App Server",
+		Version:   "1.0.0",
+		Addr:      *addr,
+		LogPrefix: "[quickstart] ",
+		Options: []server.Option{
+			server.WithExtension(&ui.UIExtension{}),
+		},
+		Register: func(srv *server.Server) {
+			// Matches upstream's quickstart registerAppTool: same tool name, same
+			// title, slightly shorter description ("Returns the current server
+			// time." with no ISO 8601 suffix — drift check enforces this), text-only
+			// output (no outputSchema).
+			ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[struct{}, string]{
+				Name:        "get-time",
+				Title:       "Get Time",
+				Description: "Returns the current server time.",
+				Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportForbidden},
+				Handler: func(ctx core.ToolContext, _ struct{}) (string, error) {
+					return time.Now().UTC().Format(time.RFC3339Nano), nil
+				},
+				ResourceURI: resourceURI,
+				ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
+					return core.ResourceResult{Contents: []core.ResourceReadContent{{
+						URI: req.URI, MimeType: core.AppMIMEType, Text: html,
+					}}}, nil
+				},
+			})
+		},
+		TransportOptions: []server.TransportOption{
+			server.WithHandlerWrap(cors),
+		},
+	}); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/examples/apps/compat/scenario-modeler/main.go
+++ b/examples/apps/compat/scenario-modeler/main.go
@@ -152,71 +152,75 @@ func main() {
 	}
 	html := string(htmlBytes)
 
-	opts := common.MCPServerOptions(*addr, "[scenario-modeler] ")
-	opts = append(opts, server.WithExtension(&ui.UIExtension{}))
-	srv := server.NewServer(
-		core.ServerInfo{Name: "SaaS Scenario Modeler", Version: "1.0.0"},
-		opts...,
-	)
-
-	resourceURI := "ui://scenario-modeler/mcp-app.html"
-
-	ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[getScenarioInput, getScenarioOutput]{
-		Name:        "get-scenario-data",
-		Title:       "Get Scenario Data",
-		Description: "Returns SaaS scenario templates and optionally computes custom projections for given inputs",
-		Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportForbidden},
-		// InputSchemaPatch just adds the description on `customInputs` —
-		// reflection of `*scenarioInputs` already produces the matching
-		// nested object shape.
-		InputSchemaPatch: func(s *core.SchemaBuilder) {
-			s.Prop("customInputs").Desc("Custom scenario parameters to compute projections for")
-		},
-		// OutputSchemaOverride stays: the nullable `breakEvenMonth` appears
-		// at two nesting depths (templates[].summary.breakEvenMonth and
-		// customSummary.breakEvenMonth) via the same scenarioSummarySchema
-		// map. Hand-stitching that with Patch.Replace at deep paths is
-		// uglier than the explicit override.
-		OutputSchemaOverride: map[string]any{
-			"type": "object",
-			"properties": map[string]any{
-				"templates": map[string]any{
-					"type":  "array",
-					"items": scenarioTemplateSchema,
-				},
-				"defaultInputs": scenarioInputsSchemaMap,
-				"customProjections": map[string]any{
-					"type":  "array",
-					"items": monthlyProjectionSchema,
-				},
-				"customSummary": scenarioSummarySchema,
-			},
-			"required": []string{"templates", "defaultInputs"},
-		},
-		Handler: func(ctx core.ToolContext, _ getScenarioInput) (getScenarioOutput, error) {
-			// Visual test doesn't depend on the data shape.
-			return getScenarioOutput{
-				Templates:     []scenarioTemplate{},
-				DefaultInputs: scenarioInputs{},
-			}, nil
-		},
-		ResourceURI: resourceURI,
-		ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
-			return core.ResourceResult{Contents: []core.ResourceReadContent{{
-				URI: req.URI, MimeType: core.AppMIMEType, Text: html,
-			}}}, nil
-		},
-	})
-
 	cors := middleware.CORS(nil,
 		middleware.CORSAllowMethods("GET", "POST", "DELETE", "OPTIONS"),
 		middleware.CORSAllowHeaders("Content-Type", "Authorization", "Mcp-Session-Id", "Mcp-Protocol-Version"),
 		middleware.CORSExposeHeaders("Mcp-Session-Id"),
 	)
 
-	log.Printf("scenario-modeler compat fixture listening on %s (MCP at /mcp)", *addr)
-	log.Printf("serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
-	if err := srv.Run(*addr, server.WithHandlerWrap(cors)); err != nil {
+	log.Printf("[scenario-modeler] serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
+
+	resourceURI := "ui://scenario-modeler/mcp-app.html"
+	if err := common.RunServer(common.ServerConfig{
+		Name:      "SaaS Scenario Modeler",
+		Version:   "1.0.0",
+		Addr:      *addr,
+		LogPrefix: "[scenario-modeler] ",
+		Options: []server.Option{
+			server.WithExtension(&ui.UIExtension{}),
+		},
+		Register: func(srv *server.Server) {
+			ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[getScenarioInput, getScenarioOutput]{
+				Name:        "get-scenario-data",
+				Title:       "Get Scenario Data",
+				Description: "Returns SaaS scenario templates and optionally computes custom projections for given inputs",
+				Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportForbidden},
+				// InputSchemaPatch just adds the description on `customInputs` —
+				// reflection of `*scenarioInputs` already produces the matching
+				// nested object shape.
+				InputSchemaPatch: func(s *core.SchemaBuilder) {
+					s.Prop("customInputs").Desc("Custom scenario parameters to compute projections for")
+				},
+				// OutputSchemaOverride stays: the nullable `breakEvenMonth` appears
+				// at two nesting depths (templates[].summary.breakEvenMonth and
+				// customSummary.breakEvenMonth) via the same scenarioSummarySchema
+				// map. Hand-stitching that with Patch.Replace at deep paths is
+				// uglier than the explicit override.
+				OutputSchemaOverride: map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"templates": map[string]any{
+							"type":  "array",
+							"items": scenarioTemplateSchema,
+						},
+						"defaultInputs": scenarioInputsSchemaMap,
+						"customProjections": map[string]any{
+							"type":  "array",
+							"items": monthlyProjectionSchema,
+						},
+						"customSummary": scenarioSummarySchema,
+					},
+					"required": []string{"templates", "defaultInputs"},
+				},
+				Handler: func(ctx core.ToolContext, _ getScenarioInput) (getScenarioOutput, error) {
+					// Visual test doesn't depend on the data shape.
+					return getScenarioOutput{
+						Templates:     []scenarioTemplate{},
+						DefaultInputs: scenarioInputs{},
+					}, nil
+				},
+				ResourceURI: resourceURI,
+				ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
+					return core.ResourceResult{Contents: []core.ResourceReadContent{{
+						URI: req.URI, MimeType: core.AppMIMEType, Text: html,
+					}}}, nil
+				},
+			})
+		},
+		TransportOptions: []server.TransportOption{
+			server.WithHandlerWrap(cors),
+		},
+	}); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/examples/apps/compat/shadertoy/main.go
+++ b/examples/apps/compat/shadertoy/main.go
@@ -108,52 +108,56 @@ func main() {
 	}
 	html := string(htmlBytes)
 
-	opts := common.MCPServerOptions(*addr, "[shadertoy] ")
-	opts = append(opts, server.WithExtension(&ui.UIExtension{}))
-	srv := server.NewServer(
-		core.ServerInfo{Name: "ShaderToy Server", Version: "1.0.0"},
-		opts...,
-	)
-
-	resourceURI := "ui://shadertoy/mcp-app.html"
-
-	ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[renderShadertoyInput, string]{
-		Name:        "render-shadertoy",
-		Title:       "ShaderToy Renderer",
-		Description: toolDescription,
-		Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportForbidden},
-		// InputSchemaPatch lands the multi-line GLSL default verbatim
-		// without struct-tag truncation at the first comma (issue 542).
-		InputSchemaPatch: func(s *core.SchemaBuilder) {
-			s.Prop("fragmentShader").
-				Desc("Main Image shader - ShaderToy GLSL code").
-				Default(defaultFragmentShader)
-			s.Prop("common").Desc("Common code shared across all shaders (optional)")
-			s.Prop("bufferA").Desc("Buffer A shader code - accessible as iChannel0 (optional)")
-			s.Prop("bufferB").Desc("Buffer B shader code - accessible as iChannel1 (optional)")
-			s.Prop("bufferC").Desc("Buffer C shader code - accessible as iChannel2 (optional)")
-			s.Prop("bufferD").Desc("Buffer D shader code - accessible as iChannel3 (optional)")
-		},
-		Handler: func(ctx core.ToolContext, _ renderShadertoyInput) (string, error) {
-			return "Shader rendered successfully", nil
-		},
-		ResourceURI: resourceURI,
-		ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
-			return core.ResourceResult{Contents: []core.ResourceReadContent{{
-				URI: req.URI, MimeType: core.AppMIMEType, Text: html,
-			}}}, nil
-		},
-	})
-
 	cors := middleware.CORS(nil,
 		middleware.CORSAllowMethods("GET", "POST", "DELETE", "OPTIONS"),
 		middleware.CORSAllowHeaders("Content-Type", "Authorization", "Mcp-Session-Id", "Mcp-Protocol-Version"),
 		middleware.CORSExposeHeaders("Mcp-Session-Id"),
 	)
 
-	log.Printf("shadertoy compat fixture listening on %s (MCP at /mcp)", *addr)
-	log.Printf("serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
-	if err := srv.Run(*addr, server.WithHandlerWrap(cors)); err != nil {
+	log.Printf("[shadertoy] serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
+
+	resourceURI := "ui://shadertoy/mcp-app.html"
+	if err := common.RunServer(common.ServerConfig{
+		Name:      "ShaderToy Server",
+		Version:   "1.0.0",
+		Addr:      *addr,
+		LogPrefix: "[shadertoy] ",
+		Options: []server.Option{
+			server.WithExtension(&ui.UIExtension{}),
+		},
+		Register: func(srv *server.Server) {
+			ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[renderShadertoyInput, string]{
+				Name:        "render-shadertoy",
+				Title:       "ShaderToy Renderer",
+				Description: toolDescription,
+				Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportForbidden},
+				// InputSchemaPatch lands the multi-line GLSL default verbatim
+				// without struct-tag truncation at the first comma (issue 542).
+				InputSchemaPatch: func(s *core.SchemaBuilder) {
+					s.Prop("fragmentShader").
+						Desc("Main Image shader - ShaderToy GLSL code").
+						Default(defaultFragmentShader)
+					s.Prop("common").Desc("Common code shared across all shaders (optional)")
+					s.Prop("bufferA").Desc("Buffer A shader code - accessible as iChannel0 (optional)")
+					s.Prop("bufferB").Desc("Buffer B shader code - accessible as iChannel1 (optional)")
+					s.Prop("bufferC").Desc("Buffer C shader code - accessible as iChannel2 (optional)")
+					s.Prop("bufferD").Desc("Buffer D shader code - accessible as iChannel3 (optional)")
+				},
+				Handler: func(ctx core.ToolContext, _ renderShadertoyInput) (string, error) {
+					return "Shader rendered successfully", nil
+				},
+				ResourceURI: resourceURI,
+				ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
+					return core.ResourceResult{Contents: []core.ResourceReadContent{{
+						URI: req.URI, MimeType: core.AppMIMEType, Text: html,
+					}}}, nil
+				},
+			})
+		},
+		TransportOptions: []server.TransportOption{
+			server.WithHandlerWrap(cors),
+		},
+	}); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/examples/apps/compat/sheet-music/main.go
+++ b/examples/apps/compat/sheet-music/main.go
@@ -63,56 +63,60 @@ func main() {
 	}
 	html := string(htmlBytes)
 
-	opts := common.MCPServerOptions(*addr, "[sheet-music] ")
-	opts = append(opts, server.WithExtension(&ui.UIExtension{}))
-	srv := server.NewServer(
-		core.ServerInfo{Name: "Sheet Music Server", Version: "1.0.0"},
-		opts...,
-	)
-
-	resourceURI := "ui://sheet-music/mcp-app.html"
-
-	ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[playSheetMusicInput, string]{
-		Name:  "play-sheet-music",
-		Title: "Play Sheet Music",
-		Description: "Plays music from ABC notation with audio playback and visual sheet music. " +
-			"Use this to compose original songs (for birthdays, holidays, or any occasion) " +
-			"or perform well-known tunes (folk songs, nursery rhymes, hymns, classical melodies). " +
-			"For accurate renditions of well-known tunes, look up the ABC notation from " +
-			"abcnotation.com or thesession.org rather than recalling from memory.",
-		Execution: &core.ToolExecution{TaskSupport: core.TaskSupportForbidden},
-		// InputSchemaPatch lands the multi-comma default verbatim without
-		// the struct-tag parser truncating at the first comma (issue 542).
-		// Reflection still emits `type: string`; the patch just adds the
-		// description + default.
-		InputSchemaPatch: func(s *core.SchemaBuilder) {
-			s.Prop("abcNotation").
-				Desc("ABC notation string to render as sheet music with audio playback").
-				Default(defaultABCNotation)
-		},
-		Handler: func(ctx core.ToolContext, _ playSheetMusicInput) (string, error) {
-			// Upstream validates ABC notation via abcjs; the screenshot test
-			// never clicks "play" so only the success-path response shape
-			// matters here.
-			return "Input parsed successfully.", nil
-		},
-		ResourceURI: resourceURI,
-		ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
-			return core.ResourceResult{Contents: []core.ResourceReadContent{{
-				URI: req.URI, MimeType: core.AppMIMEType, Text: html,
-			}}}, nil
-		},
-	})
-
 	cors := middleware.CORS(nil,
 		middleware.CORSAllowMethods("GET", "POST", "DELETE", "OPTIONS"),
 		middleware.CORSAllowHeaders("Content-Type", "Authorization", "Mcp-Session-Id", "Mcp-Protocol-Version"),
 		middleware.CORSExposeHeaders("Mcp-Session-Id"),
 	)
 
-	log.Printf("sheet-music compat fixture listening on %s (MCP at /mcp)", *addr)
-	log.Printf("serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
-	if err := srv.Run(*addr, server.WithHandlerWrap(cors)); err != nil {
+	log.Printf("[sheet-music] serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
+
+	resourceURI := "ui://sheet-music/mcp-app.html"
+	if err := common.RunServer(common.ServerConfig{
+		Name:      "Sheet Music Server",
+		Version:   "1.0.0",
+		Addr:      *addr,
+		LogPrefix: "[sheet-music] ",
+		Options: []server.Option{
+			server.WithExtension(&ui.UIExtension{}),
+		},
+		Register: func(srv *server.Server) {
+			ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[playSheetMusicInput, string]{
+				Name:  "play-sheet-music",
+				Title: "Play Sheet Music",
+				Description: "Plays music from ABC notation with audio playback and visual sheet music. " +
+					"Use this to compose original songs (for birthdays, holidays, or any occasion) " +
+					"or perform well-known tunes (folk songs, nursery rhymes, hymns, classical melodies). " +
+					"For accurate renditions of well-known tunes, look up the ABC notation from " +
+					"abcnotation.com or thesession.org rather than recalling from memory.",
+				Execution: &core.ToolExecution{TaskSupport: core.TaskSupportForbidden},
+				// InputSchemaPatch lands the multi-comma default verbatim without
+				// the struct-tag parser truncating at the first comma (issue 542).
+				// Reflection still emits `type: string`; the patch just adds the
+				// description + default.
+				InputSchemaPatch: func(s *core.SchemaBuilder) {
+					s.Prop("abcNotation").
+						Desc("ABC notation string to render as sheet music with audio playback").
+						Default(defaultABCNotation)
+				},
+				Handler: func(ctx core.ToolContext, _ playSheetMusicInput) (string, error) {
+					// Upstream validates ABC notation via abcjs; the screenshot test
+					// never clicks "play" so only the success-path response shape
+					// matters here.
+					return "Input parsed successfully.", nil
+				},
+				ResourceURI: resourceURI,
+				ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
+					return core.ResourceResult{Contents: []core.ResourceReadContent{{
+						URI: req.URI, MimeType: core.AppMIMEType, Text: html,
+					}}}, nil
+				},
+			})
+		},
+		TransportOptions: []server.TransportOption{
+			server.WithHandlerWrap(cors),
+		},
+	}); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/examples/apps/compat/system-monitor/main.go
+++ b/examples/apps/compat/system-monitor/main.go
@@ -127,13 +127,34 @@ func main() {
 	}
 	html := string(htmlBytes)
 
-	opts := common.MCPServerOptions(*addr, "[system-monitor] ")
-	opts = append(opts, server.WithExtension(&ui.UIExtension{}))
-	srv := server.NewServer(
-		core.ServerInfo{Name: "System Monitor Server", Version: "1.0.0"},
-		opts...,
+	cors := middleware.CORS(nil,
+		middleware.CORSAllowMethods("GET", "POST", "DELETE", "OPTIONS"),
+		middleware.CORSAllowHeaders("Content-Type", "Authorization", "Mcp-Session-Id", "Mcp-Protocol-Version"),
+		middleware.CORSExposeHeaders("Mcp-Session-Id"),
 	)
 
+	log.Printf("[system-monitor] serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
+
+	if err := common.RunServer(common.ServerConfig{
+		Name:      "System Monitor Server",
+		Version:   "1.0.0",
+		Addr:      *addr,
+		LogPrefix: "[system-monitor] ",
+		Options: []server.Option{
+			server.WithExtension(&ui.UIExtension{}),
+		},
+		Register: func(srv *server.Server) {
+			registerSystemMonitorTools(srv, html)
+		},
+		TransportOptions: []server.TransportOption{
+			server.WithHandlerWrap(cors),
+		},
+	}); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func registerSystemMonitorTools(srv *server.Server, html string) {
 	resourceURI := "ui://system-monitor/mcp-app.html"
 
 	// Tool 1: get-system-info — has the UI resource (standard pattern).
@@ -172,16 +193,4 @@ func main() {
 	)
 	pollTyped.Title = "Poll System Stats"
 	srv.RegisterTool(pollTyped.ToolDef, pollTyped.Handler)
-
-	cors := middleware.CORS(nil,
-		middleware.CORSAllowMethods("GET", "POST", "DELETE", "OPTIONS"),
-		middleware.CORSAllowHeaders("Content-Type", "Authorization", "Mcp-Session-Id", "Mcp-Protocol-Version"),
-		middleware.CORSExposeHeaders("Mcp-Session-Id"),
-	)
-
-	log.Printf("system-monitor compat fixture listening on %s (MCP at /mcp)", *addr)
-	log.Printf("serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
-	if err := srv.Run(*addr, server.WithHandlerWrap(cors)); err != nil {
-		log.Fatal(err)
-	}
 }

--- a/examples/apps/compat/threejs/main.go
+++ b/examples/apps/compat/threejs/main.go
@@ -75,73 +75,77 @@ func main() {
 	}
 	html := string(htmlBytes)
 
-	opts := common.MCPServerOptions(*addr, "[threejs] ")
-	opts = append(opts, server.WithExtension(&ui.UIExtension{}))
-	srv := server.NewServer(
-		core.ServerInfo{Name: "Three.js Server", Version: "1.0.0"},
-		opts...,
-	)
-
-	resourceURI := "ui://threejs/mcp-app.html"
-
-	// Tool 1: show_threejs_scene — the App tool with its own UI iframe.
-	ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[showThreeJSInput, showThreeJSOutput]{
-		Name:        "show_threejs_scene",
-		Title:       "Show Three.js Scene",
-		Description: "Render an interactive 3D scene with custom Three.js code. Supports transparent backgrounds (alpha: true) for seamless host UI integration. Available globals: THREE, OrbitControls, EffectComposer, RenderPass, UnrealBloomPass, canvas, width, height.",
-		Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportForbidden},
-		// `code` uses Patch (multi-line default with commas would lose to
-		// struct-tag truncation); `height` uses Replace because upstream
-		// emits exclusiveMinimum + Number.MAX_SAFE_INTEGER bounds the
-		// PropertyBuilder doesn't have direct methods for.
-		InputSchemaPatch: func(s *core.SchemaBuilder) {
-			s.Prop("code").
-				Desc("JavaScript code to render the 3D scene").
-				Default(defaultThreeJSCode)
-			s.Prop("height").Replace(map[string]any{
-				"type":             "integer",
-				"exclusiveMinimum": 0,
-				// Mirror upstream's zod `.int()` Number.MAX_SAFE_INTEGER cap.
-				"maximum":     9007199254740991,
-				"default":     400,
-				"description": "Height in pixels",
-			})
-		},
-		Handler: func(ctx core.ToolContext, _ showThreeJSInput) (showThreeJSOutput, error) {
-			return showThreeJSOutput{Success: true}, nil
-		},
-		ResourceURI: resourceURI,
-		ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
-			return core.ResourceResult{Contents: []core.ResourceReadContent{{
-				URI: req.URI, MimeType: core.AppMIMEType, Text: html,
-			}}}, nil
-		},
-	})
-
-	// Tool 2: learn_threejs — plain MCP tool returning Three.js documentation.
-	// Visual test never invokes it; the actual doc string returned isn't
-	// asserted on. Tool definition (name/title/description/empty input
-	// schema) is what the drift check compares.
-	learnTyped := core.TypedTool[struct{}, string](
-		"learn_threejs",
-		"Get documentation and examples for using the Three.js View",
-		func(ctx core.ToolContext, _ struct{}) (string, error) {
-			return "See https://threejs.org for documentation.", nil
-		},
-		core.WithToolExecution(&core.ToolExecution{TaskSupport: core.TaskSupportForbidden}),
-	)
-	learnTyped.Title = "Learn Three.js"
-	srv.RegisterTool(learnTyped.ToolDef, learnTyped.Handler)
-
 	cors := middleware.CORS(nil,
 		middleware.CORSAllowMethods("GET", "POST", "DELETE", "OPTIONS"),
 		middleware.CORSAllowHeaders("Content-Type", "Authorization", "Mcp-Session-Id", "Mcp-Protocol-Version"),
 		middleware.CORSExposeHeaders("Mcp-Session-Id"),
 	)
 
-	log.Printf("threejs compat fixture listening on %s (MCP at /mcp)", *addr)
-	log.Printf("serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
-	if err := srv.Run(*addr, server.WithHandlerWrap(cors)); err != nil {
+	log.Printf("[threejs] serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
+
+	resourceURI := "ui://threejs/mcp-app.html"
+	if err := common.RunServer(common.ServerConfig{
+		Name:      "Three.js Server",
+		Version:   "1.0.0",
+		Addr:      *addr,
+		LogPrefix: "[threejs] ",
+		Options: []server.Option{
+			server.WithExtension(&ui.UIExtension{}),
+		},
+		Register: func(srv *server.Server) {
+			// Tool 1: show_threejs_scene — the App tool with its own UI iframe.
+			ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[showThreeJSInput, showThreeJSOutput]{
+				Name:        "show_threejs_scene",
+				Title:       "Show Three.js Scene",
+				Description: "Render an interactive 3D scene with custom Three.js code. Supports transparent backgrounds (alpha: true) for seamless host UI integration. Available globals: THREE, OrbitControls, EffectComposer, RenderPass, UnrealBloomPass, canvas, width, height.",
+				Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportForbidden},
+				// `code` uses Patch (multi-line default with commas would lose to
+				// struct-tag truncation); `height` uses Replace because upstream
+				// emits exclusiveMinimum + Number.MAX_SAFE_INTEGER bounds the
+				// PropertyBuilder doesn't have direct methods for.
+				InputSchemaPatch: func(s *core.SchemaBuilder) {
+					s.Prop("code").
+						Desc("JavaScript code to render the 3D scene").
+						Default(defaultThreeJSCode)
+					s.Prop("height").Replace(map[string]any{
+						"type":             "integer",
+						"exclusiveMinimum": 0,
+						// Mirror upstream's zod `.int()` Number.MAX_SAFE_INTEGER cap.
+						"maximum":     9007199254740991,
+						"default":     400,
+						"description": "Height in pixels",
+					})
+				},
+				Handler: func(ctx core.ToolContext, _ showThreeJSInput) (showThreeJSOutput, error) {
+					return showThreeJSOutput{Success: true}, nil
+				},
+				ResourceURI: resourceURI,
+				ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
+					return core.ResourceResult{Contents: []core.ResourceReadContent{{
+						URI: req.URI, MimeType: core.AppMIMEType, Text: html,
+					}}}, nil
+				},
+			})
+
+			// Tool 2: learn_threejs — plain MCP tool returning Three.js documentation.
+			// Visual test never invokes it; the actual doc string returned isn't
+			// asserted on. Tool definition (name/title/description/empty input
+			// schema) is what the drift check compares.
+			learnTyped := core.TypedTool[struct{}, string](
+				"learn_threejs",
+				"Get documentation and examples for using the Three.js View",
+				func(ctx core.ToolContext, _ struct{}) (string, error) {
+					return "See https://threejs.org for documentation.", nil
+				},
+				core.WithToolExecution(&core.ToolExecution{TaskSupport: core.TaskSupportForbidden}),
+			)
+			learnTyped.Title = "Learn Three.js"
+			srv.RegisterTool(learnTyped.ToolDef, learnTyped.Handler)
+		},
+		TransportOptions: []server.TransportOption{
+			server.WithHandlerWrap(cors),
+		},
+	}); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/examples/apps/compat/transcript/main.go
+++ b/examples/apps/compat/transcript/main.go
@@ -46,42 +46,46 @@ func main() {
 	}
 	html := string(htmlBytes)
 
-	opts := common.MCPServerOptions(*addr, "[transcript] ")
-	opts = append(opts, server.WithExtension(&ui.UIExtension{}))
-	srv := server.NewServer(
-		core.ServerInfo{Name: "Transcript Server", Version: "1.0.0"},
-		opts...,
-	)
+	log.Printf("[transcript] serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
 
-	// Resource URI matches upstream's transcript-server (not the get-time
-	// pattern the basic-* cluster uses).
-	resourceURI := "ui://transcript/mcp-app.html"
-
-	ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[struct{}, string]{
-		Name:        "transcribe",
-		Title:       "Transcribe Speech",
-		Description: "Opens a live speech transcription interface using the Web Speech API.",
-		Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportForbidden},
-		Handler: func(ctx core.ToolContext, _ struct{}) (string, error) {
-			return transcribeReady, nil
-		},
-		ResourceURI: resourceURI,
-		ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
-			return core.ResourceResult{Contents: []core.ResourceReadContent{{
-				URI: req.URI, MimeType: core.AppMIMEType, Text: html,
-			}}}, nil
-		},
-	})
-
-	log.Printf("transcript compat fixture listening on %s (MCP at /mcp)", *addr)
-	log.Printf("serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
 	cors := middleware.CORS(nil,
 		middleware.CORSAllowMethods("GET", "POST", "DELETE", "OPTIONS"),
 		middleware.CORSAllowHeaders("Content-Type", "Authorization", "Mcp-Session-Id", "Mcp-Protocol-Version"),
 		middleware.CORSExposeHeaders("Mcp-Session-Id"),
 	)
 
-	if err := srv.Run(*addr, server.WithHandlerWrap(cors)); err != nil {
+	// Resource URI matches upstream's transcript-server (not the get-time
+	// pattern the basic-* cluster uses).
+	resourceURI := "ui://transcript/mcp-app.html"
+	if err := common.RunServer(common.ServerConfig{
+		Name:      "Transcript Server",
+		Version:   "1.0.0",
+		Addr:      *addr,
+		LogPrefix: "[transcript] ",
+		Options: []server.Option{
+			server.WithExtension(&ui.UIExtension{}),
+		},
+		Register: func(srv *server.Server) {
+			ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[struct{}, string]{
+				Name:        "transcribe",
+				Title:       "Transcribe Speech",
+				Description: "Opens a live speech transcription interface using the Web Speech API.",
+				Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportForbidden},
+				Handler: func(ctx core.ToolContext, _ struct{}) (string, error) {
+					return transcribeReady, nil
+				},
+				ResourceURI: resourceURI,
+				ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
+					return core.ResourceResult{Contents: []core.ResourceReadContent{{
+						URI: req.URI, MimeType: core.AppMIMEType, Text: html,
+					}}}, nil
+				},
+			})
+		},
+		TransportOptions: []server.TransportOption{
+			server.WithHandlerWrap(cors),
+		},
+	}); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/examples/apps/compat/wiki-explorer/main.go
+++ b/examples/apps/compat/wiki-explorer/main.go
@@ -61,58 +61,62 @@ func main() {
 	}
 	html := string(htmlBytes)
 
-	opts := common.MCPServerOptions(*addr, "[wiki-explorer] ")
-	opts = append(opts, server.WithExtension(&ui.UIExtension{}))
-	srv := server.NewServer(
-		core.ServerInfo{Name: "Wiki Explorer", Version: "1.0.0"},
-		opts...,
-	)
-
-	resourceURI := "ui://wiki-explorer/mcp-app.html"
-
-	ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[wikiInput, wikiLinksOutput]{
-		Name:        "get-first-degree-links",
-		Title:       "Get First-Degree Links",
-		Description: "Returns all Wikipedia pages that the given page links to directly. The widget is interactive and exposes tools for exploring the graph (expanding nodes to see their links), searching for articles, and querying visible nodes.",
-		Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportForbidden},
-		// Reflection covers page + links cleanly from the Go struct; only
-		// the nullable `error` field needs help. Upstream's `z.string()
-		// .nullable()` emits an anyOf — Go's `*string` reflects to plain
-		// `"type": "string"`. Patch.Replace lands the matching shape.
-		OutputSchemaPatch: func(s *core.SchemaBuilder) {
-			s.Prop("error").Replace(map[string]any{
-				"anyOf": []any{
-					map[string]any{"type": "string"},
-					map[string]any{"type": "null"},
-				},
-			})
-		},
-		Handler: func(ctx core.ToolContext, in wikiInput) (wikiLinksOutput, error) {
-			// Visual test masks the graph (HOST_MASKS["wiki-explorer"] = ["#graph"]).
-			// Stub response — iframe renders its own layout.
-			return wikiLinksOutput{
-				Page:  wikiPage{URL: in.URL, Title: "Model Context Protocol"},
-				Links: []wikiPage{},
-				Error: nil, // serializes to JSON null
-			}, nil
-		},
-		ResourceURI: resourceURI,
-		ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
-			return core.ResourceResult{Contents: []core.ResourceReadContent{{
-				URI: req.URI, MimeType: core.AppMIMEType, Text: html,
-			}}}, nil
-		},
-	})
-
 	cors := middleware.CORS(nil,
 		middleware.CORSAllowMethods("GET", "POST", "DELETE", "OPTIONS"),
 		middleware.CORSAllowHeaders("Content-Type", "Authorization", "Mcp-Session-Id", "Mcp-Protocol-Version"),
 		middleware.CORSExposeHeaders("Mcp-Session-Id"),
 	)
 
-	log.Printf("wiki-explorer compat fixture listening on %s (MCP at /mcp)", *addr)
-	log.Printf("serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
-	if err := srv.Run(*addr, server.WithHandlerWrap(cors)); err != nil {
+	log.Printf("[wiki-explorer] serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
+
+	resourceURI := "ui://wiki-explorer/mcp-app.html"
+	if err := common.RunServer(common.ServerConfig{
+		Name:      "Wiki Explorer",
+		Version:   "1.0.0",
+		Addr:      *addr,
+		LogPrefix: "[wiki-explorer] ",
+		Options: []server.Option{
+			server.WithExtension(&ui.UIExtension{}),
+		},
+		Register: func(srv *server.Server) {
+			ui.RegisterTypedAppTool(srv, ui.TypedAppToolConfig[wikiInput, wikiLinksOutput]{
+				Name:        "get-first-degree-links",
+				Title:       "Get First-Degree Links",
+				Description: "Returns all Wikipedia pages that the given page links to directly. The widget is interactive and exposes tools for exploring the graph (expanding nodes to see their links), searching for articles, and querying visible nodes.",
+				Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportForbidden},
+				// Reflection covers page + links cleanly from the Go struct; only
+				// the nullable `error` field needs help. Upstream's `z.string()
+				// .nullable()` emits an anyOf — Go's `*string` reflects to plain
+				// `"type": "string"`. Patch.Replace lands the matching shape.
+				OutputSchemaPatch: func(s *core.SchemaBuilder) {
+					s.Prop("error").Replace(map[string]any{
+						"anyOf": []any{
+							map[string]any{"type": "string"},
+							map[string]any{"type": "null"},
+						},
+					})
+				},
+				Handler: func(ctx core.ToolContext, in wikiInput) (wikiLinksOutput, error) {
+					// Visual test masks the graph (HOST_MASKS["wiki-explorer"] = ["#graph"]).
+					// Stub response — iframe renders its own layout.
+					return wikiLinksOutput{
+						Page:  wikiPage{URL: in.URL, Title: "Model Context Protocol"},
+						Links: []wikiPage{},
+						Error: nil, // serializes to JSON null
+					}, nil
+				},
+				ResourceURI: resourceURI,
+				ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
+					return core.ResourceResult{Contents: []core.ResourceReadContent{{
+						URI: req.URI, MimeType: core.AppMIMEType, Text: html,
+					}}}, nil
+				},
+			})
+		},
+		TransportOptions: []server.TransportOption{
+			server.WithHandlerWrap(cors),
+		},
+	}); err != nil {
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
## What changes

Closes the `common.RunServer` adoption arc started by PRs 585 / 589 / 592. All 21 `examples/apps/compat/*` fixtures now follow the same canonical UI bootstrap shape PR 592 established for the non-compat `examples/apps/*` examples:

```go
common.RunServer(common.ServerConfig{
    Name: ..., Version: ..., Addr: *addr,
    LogPrefix:        "[name] ",
    Options:          []server.Option{server.WithExtension(&ui.UIExtension{})},
    Register:         func(srv *server.Server) { /* tools */ },
    TransportOptions: []server.TransportOption{server.WithHandlerWrap(cors)},
})
```

No HTML rendering changes, no tool-registration semantics changes, no CORS posture changes, no transport wiring changes — purely the bootstrap glue is swapped to the shared helper.

## Reviewer's guide

Read in this order to walk the variant ladder:

1. [examples/apps/compat/basic-vanillajs/main.go](https://github.com/panyam/mcpkit/pull/598/files#diff-c565b0e82d36665b146efe0a5d94bc1fbca7e220e2c17881b45d803747c352cc) — start here. Smallest fixture, cleanest before/after.
2. [examples/apps/compat/sheet-music/main.go](https://github.com/panyam/mcpkit/pull/598/files#diff-73840c91e5132e5dd2d9e29e807f7cf5d2dab01720ff213236e02256702d96c9) — adds `InputSchemaPatch` inside `Register`.
3. [examples/apps/compat/map/main.go](https://github.com/panyam/mcpkit/pull/598/files#diff-7057a17732ec00b178b3b8bfaae5312e387fc3e79ece2f40cdfad80d90de5c32) — multi-tool: shows two `RegisterTypedAppTool` calls inside one `Register` closure.
4. [examples/apps/compat/system-monitor/main.go](https://github.com/panyam/mcpkit/pull/598/files#diff-31a255f12076f09a3c26dd4db8783d071d5f93695f3e80164dc80aa01e350dc2) and [examples/apps/compat/debug-server/main.go](https://github.com/panyam/mcpkit/pull/598/files#diff-e6efe7922a9cc0591546c59d49d2a92ad40ba830716cc46d4f28c0e0e5238dd6) — exercise the helper-extraction pattern (`registerSystemMonitorTools` / `registerDebugServerTools`) so the `Register:` callback stays a one-liner. Same approach PR 592 used for `todolist` and `interactive`.
5. [examples/apps/compat/pdf-server/main.go](https://github.com/panyam/mcpkit/pull/598/files#diff-2760a2edf9920e6505df8d499c9ad067086555252f00011f03c18483a13e04d7) — `registerAllTools` was already extracted; this just swaps the bootstrap. Dropped the now-unused `core` import.

Skim:
- `examples/apps/compat/basic-{preact,react,solid,svelte,vue}/main.go` — identical to vanillajs modulo framework name.
- `examples/apps/compat/{quickstart,transcript,budget-allocator,scenario-modeler,cohort-heatmap,customer-segmentation,wiki-explorer,shadertoy,threejs,integration}/main.go` — same shape as the canonical examples above.

## Diff groups

Single intent across all 21 files: replace `opts := ...; srv := server.NewServer(...); /* registrations */; srv.Run(...)` with the `common.RunServer(common.ServerConfig{...})` form.

## Decision log

- **Helper extraction for 3 of the 21 fixtures only.** `system-monitor`, `debug-server`, and `integration` have multi-tool registrations large enough that inlining them in the `Register:` closure would obscure the bootstrap shape. Extracted `registerSystemMonitorTools`, `registerDebugServerTools`, and `registerIntegrationTools` — same approach PR 592 used for `todolist` / `interactive`. The other 18 fixtures' registrations are small enough to stay inline.
- **`pdf-server` lost its `core` import.** The only `core.` reference in `main.go` was `core.ServerInfo{...}`, which `RunServer` now constructs internally from `ServerConfig.Name` + `ServerConfig.Version`. `registerAllTools` (already a separate file) keeps its own `core` import. Dropped the now-unused import to keep `go vet` clean.
- **Did NOT touch fixture HTML, tool definitions, CORS configuration, or any non-bootstrap code.** The whole point is that this refactor should be invisible to `tools/list` parity and visual baselines.

## Risk / blast radius

- Affects: 21 example servers under `examples/apps/compat/<subdir>/`. Each is its own go.mod; no shared module surface changed.
- Tests covering this: `go vet ./...` clean across all 21 sub-modules.
- Be paranoid about: `tools/list` parity vs upstream's TypeScript reference (DOCKER mode); golden PNG visual baselines per fixture. Neither should drift — tool registration shape and rendered HTML are unchanged. The acceptance gate is `make test-apps-playwright-docker-all` (PR 596).

## Acceptance gate

```
make test-apps-playwright-docker-all
```

Expected outcome — same as on `main` today:

- **20 fixtures pass.**
- **1 fixture fails — pdf-server** — on the `pdf-incremental-load.spec.ts:84` form-fields-names test. This is **issue 574** (open), a pre-existing AcroForm parser gap, not a regression from this refactor.

If any *other* fixture flips from pass to fail under this PR, that's a regression and the PR should not merge.

If pdf-server *also* starts passing, that's a welcome surprise — verify it's not a false positive (e.g. the form-fields test got disabled rather than the parser implemented).

## Before / after

`basic-vanillajs` (the simplest case):

```diff
-opts := common.MCPServerOptions(*addr, "[basic-vanillajs] ")
-opts = append(opts, server.WithExtension(&ui.UIExtension{}))
-srv := server.NewServer(
-    core.ServerInfo{Name: "Basic MCP App Server (Vanilla JS)", Version: "1.0.0"},
-    opts...,
-)
-…RegisterTypedAppTool…
-log.Printf("basic-vanillajs compat fixture listening on %s (MCP at /mcp)", *addr)
-log.Printf("serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
-cors := middleware.CORS(nil, …)
-if err := srv.Run(*addr, server.WithHandlerWrap(cors)); err != nil {
-    log.Fatal(err)
-}
+log.Printf("[basic-vanillajs] serving mcp-app.html from %s (%d bytes)", htmlPath, len(html))
+cors := middleware.CORS(nil, …)
+resourceURI := "ui://get-time/mcp-app.html"
+if err := common.RunServer(common.ServerConfig{
+    Name:      "Basic MCP App Server (Vanilla JS)",
+    Version:   "1.0.0",
+    Addr:      *addr,
+    LogPrefix: "[basic-vanillajs] ",
+    Options:          []server.Option{server.WithExtension(&ui.UIExtension{})},
+    Register:         func(srv *server.Server) { ui.RegisterTypedAppTool(srv, … ) },
+    TransportOptions: []server.TransportOption{server.WithHandlerWrap(cors)},
+}); err != nil {
+    log.Fatal(err)
+}
```

The canonical `[<name>] listening on <addr>` line now comes from the helper instead of each fixture's hand-rolled `"X compat fixture listening on %s (MCP at /mcp)"`.

## Out of scope (deliberately deferred)

- Issue 574 (AcroForm parser for pdf-server form-fields-names test) — pre-existing, separate ticket.
- Any new helper in `examples/common` or `ext/ui` — the existing `RunServer` covered every variation observed.

## Test plan

- [x] `go vet ./...` green per fixture across all 21 sub-modules
- [x] `go mod tidy` no-op per fixture
- [ ] `make test-apps-playwright-docker-all` reports 20/21 pass (same as `main`)
