### PR TITLE
server: per-session subscription cap + rate limit (568)

### DIFF
--- a/core/jsonrpc.go
+++ b/core/jsonrpc.go
@@ -61,6 +61,18 @@ const (
 	// Avoid using this directly — prefer the MCP-specific codes below.
 	ErrCodeServerError = -32000
 
+	// ErrCodeSubscriptionLimitExceeded is returned by resources/subscribe
+	// when the requesting session has hit a server-configured cap on
+	// concurrent subscriptions or on subscribe/unsubscribe churn rate.
+	// The error data SHOULD carry a `reason` string ("cap_exceeded" or
+	// "rate_limited") and MAY carry the configured limit for client-side
+	// adaptive backoff. Mcpkit servers ship the cap off by default; it
+	// is opt-in via server.WithSubscriptionCap and
+	// server.WithSubscriptionRateLimit. The wire shape is a standard
+	// JSON-RPC error response so spec-conformant clients handle it
+	// generically.
+	ErrCodeSubscriptionLimitExceeded = -32010
+
 	// MCP application error codes — outside the JSON-RPC reserved range.
 	// These indicate application-level failures in tool, resource, or prompt handlers.
 	ErrCodeToolExecutionError = -31000 // Tool handler returned an error

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/stretchr/testify v1.11.1
 	github.com/yosida95/uritemplate/v3 v3.0.2
+	golang.org/x/time v0.15.0
 )
 
 require (
@@ -24,7 +25,6 @@ require (
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
-	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260120221211-b8f7ae30c516 // indirect
 	google.golang.org/grpc v1.80.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect

--- a/server/dispatch.go
+++ b/server/dispatch.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -722,6 +723,11 @@ func (d *Dispatcher) handleResourcesTemplatesList(id json.RawMessage, params jso
 // handleResourcesSubscribe registers the current session's interest in a resource URI.
 // The server will send notifications/resources/updated to this session when the
 // resource changes (triggered by Server.NotifyResourceUpdated).
+//
+// Returns ErrCodeSubscriptionLimitExceeded (-32010) when the session has hit
+// the per-session cap or rate limit configured via WithSubscriptionCap /
+// WithSubscriptionRateLimit. The error.data carries a `reason` field
+// ("cap_exceeded" or "rate_limited") for client-side adaptive backoff.
 func (d *Dispatcher) handleResourcesSubscribe(id json.RawMessage, params json.RawMessage) *core.Response {
 	var p struct {
 		URI string `json:"uri"`
@@ -730,7 +736,17 @@ func (d *Dispatcher) handleResourcesSubscribe(id json.RawMessage, params json.Ra
 		return core.NewErrorResponse(id, core.ErrCodeInvalidParams, err.Error())
 	}
 	if d.subManager != nil {
-		d.subManager.subscribe(d.sessionID, d, p.URI)
+		if err := d.subManager.subscribe(d.sessionID, d, p.URI); err != nil {
+			reason := "cap_exceeded"
+			if errors.Is(err, ErrSubscriptionRateLimited) {
+				reason = "rate_limited"
+			}
+			return core.NewErrorResponseWithData(id,
+				core.ErrCodeSubscriptionLimitExceeded,
+				err.Error(),
+				map[string]any{"reason": reason, "uri": p.URI},
+			)
+		}
 	}
 	return core.NewResponse(id, struct{}{})
 }

--- a/server/server.go
+++ b/server/server.go
@@ -5,6 +5,7 @@ import (
 	"crypto/subtle"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
 	"net/http"
 	"strings"
@@ -14,6 +15,7 @@ import (
 	core "github.com/panyam/mcpkit/core"
 	"github.com/panyam/mcpkit/server/stateless"
 	gohttp "github.com/panyam/servicekit/http"
+	"golang.org/x/time/rate"
 )
 
 // Server is an MCP server that can run over multiple transports.
@@ -39,6 +41,10 @@ type serverOptions struct {
 	requestInterceptors  []RequestInterceptor // outgoing server-to-client request interceptors
 	requestLogger        *log.Logger          // HTTP-level request/response logging
 	subscriptionsEnabled bool        // enable resources/subscribe and resources/unsubscribe
+	subscriptionCap      int         // per-session concurrent-subscription cap (0 = unlimited)
+	subscriptionRate     rate.Limit  // per-session subscribe/unsubscribe rate cap (0 = unlimited)
+	subscriptionBurst    int         // per-session burst alongside subscriptionRate (ignored when subscriptionRate == 0)
+	subscriptionReject   SubscriptionRejectFunc // optional hook fired when a subscribe is refused
 	errorHandler         ErrorHandler // optional out-of-band error callback
 	contentChunkMethod   string       // custom notification method for streaming content (empty = default)
 	onRootsChanged       func([]core.Root) // optional callback when client sends roots/list_changed
@@ -197,8 +203,59 @@ func WithContentChunkMethod(method string) Option {
 //
 // Use Server.NotifyResourceUpdated(uri) to push change notifications to all
 // sessions that have subscribed to the given URI.
+//
+// For public-facing deployments also pass [WithSubscriptionCap] (and
+// optionally [WithSubscriptionRateLimit]); without those a misbehaving
+// client can subscribe unboundedly and exhaust server resources.
 func WithSubscriptions() Option {
 	return func(o *serverOptions) { o.subscriptionsEnabled = true }
+}
+
+// SubscriptionRejectFunc is invoked when resources/subscribe is refused
+// because the session has hit the configured cap or rate limit. reason is
+// one of "cap_exceeded" or "rate_limited". The hook is called outside the
+// subscription registry's lock; implementations may block but doing so
+// will not delay other requests on the session.
+type SubscriptionRejectFunc func(sessionID, uri, reason string)
+
+// WithSubscriptionCap sets the maximum number of concurrent
+// resources/subscribe registrations a single session may hold. Once the
+// session is at the cap, additional resources/subscribe calls fail with
+// [core.ErrCodeSubscriptionLimitExceeded] (-32010). Unsubscribing frees
+// a slot for the same session.
+//
+// Off by default (n <= 0 means unlimited). Recommended for any
+// public-facing deployment; 100 is a reasonable starting point. The cap
+// is per-session, not global — two sessions can each hold n
+// subscriptions simultaneously.
+func WithSubscriptionCap(n int) Option {
+	return func(o *serverOptions) { o.subscriptionCap = n }
+}
+
+// WithSubscriptionRateLimit bounds how fast a single session may issue
+// resources/subscribe calls. Implemented as a per-session token bucket
+// with refill rate r and burst b. burst is the largest spike the bucket
+// will admit before throttling kicks in; the steady-state ceiling is r
+// subscribes per second per session. Exceeded calls fail with
+// [core.ErrCodeSubscriptionLimitExceeded] (-32010) carrying reason
+// "rate_limited".
+//
+// Off by default (r <= 0 means unlimited). unsubscribe is not metered —
+// the goal is to bound the cost of registration churn, not to penalize
+// cleanup.
+func WithSubscriptionRateLimit(r rate.Limit, burst int) Option {
+	return func(o *serverOptions) {
+		o.subscriptionRate = r
+		o.subscriptionBurst = burst
+	}
+}
+
+// WithSubscriptionRejectHook installs a callback fired every time a
+// resources/subscribe is refused by [WithSubscriptionCap] or
+// [WithSubscriptionRateLimit]. Operators can use it to emit metrics or
+// audit logs without changing the wire response.
+func WithSubscriptionRejectHook(fn SubscriptionRejectFunc) Option {
+	return func(o *serverOptions) { o.subscriptionReject = fn }
 }
 
 // WithToolTimeout sets the maximum duration for tool execution.
@@ -410,6 +467,12 @@ func NewServer(info core.ServerInfo, opts ...Option) *Server {
 	if s.options.subscriptionsEnabled {
 		s.subRegistry = &subscriptionRegistry{
 			subscribers: make(map[string]map[string]*Dispatcher),
+			counts:      make(map[string]int),
+			limiters:    make(map[string]*rate.Limiter),
+			cap:         s.options.subscriptionCap,
+			rateLimit:   s.options.subscriptionRate,
+			rateBurst:   s.options.subscriptionBurst,
+			onReject:    s.options.subscriptionReject,
 		}
 		s.dispatcher.subscriptionsEnabled = true
 		s.dispatcher.subManager = s.subRegistry
@@ -1228,36 +1291,112 @@ var errUnauthorized = &core.AuthError{Code: http.StatusUnauthorized, Message: "u
 // subscriptionRegistry tracks which sessions have subscribed to which resource URIs.
 // It lives on the Server so it can fan out notifications across all sessions.
 // Thread-safe: all methods acquire the mutex.
+//
+// Cap and rate-limit enforcement also lives here. Counts are tracked per
+// sessionID so subscribe() can refuse without scanning the subscribers
+// map. Limiters are lazy: created on first metered call and dropped when
+// the session unsubscribes all (or disconnects). Per-session bookkeeping
+// is the right scope because the issue motivating the backpressure (PR
+// 568) is a single client exhausting the registry, not aggregate load.
 type subscriptionRegistry struct {
 	mu          sync.RWMutex
 	subscribers map[string]map[string]*Dispatcher // uri → sessionID → dispatcher
+	counts      map[string]int                    // sessionID → live subscription count
+	limiters    map[string]*rate.Limiter          // sessionID → token bucket (nil when rate limit disabled)
+
+	// Configured once at construction time; safe to read without the
+	// mutex.
+	cap       int
+	rateLimit rate.Limit
+	rateBurst int
+	onReject  SubscriptionRejectFunc
 }
 
-// subscribe registers a session's interest in a resource URI.
-func (r *subscriptionRegistry) subscribe(sessionID string, d *Dispatcher, uri string) {
+// ErrSubscriptionCapExceeded indicates the calling session has hit
+// the per-session concurrent-subscription cap configured via
+// [WithSubscriptionCap]. Returned by subscribe so handleResourcesSubscribe
+// can map it to the wire error.
+var ErrSubscriptionCapExceeded = errors.New("subscription cap exceeded")
+
+// ErrSubscriptionRateLimited indicates the calling session has exceeded
+// the per-session subscribe rate configured via
+// [WithSubscriptionRateLimit].
+var ErrSubscriptionRateLimited = errors.New("subscription rate limited")
+
+// subscribe registers a session's interest in a resource URI. Returns
+// nil on success, [ErrSubscriptionCapExceeded] or
+// [ErrSubscriptionRateLimited] when refused. Idempotent: subscribing the
+// same (session, uri) pair twice succeeds without double-counting.
+func (r *subscriptionRegistry) subscribe(sessionID string, d *Dispatcher, uri string) error {
+	r.mu.Lock()
+	subs, ok := r.subscribers[uri]
+	if !ok {
+		subs = make(map[string]*Dispatcher)
+	}
+	_, alreadyHeld := subs[sessionID]
+
+	if !alreadyHeld && r.cap > 0 && r.counts[sessionID] >= r.cap {
+		r.mu.Unlock()
+		if r.onReject != nil {
+			r.onReject(sessionID, uri, "cap_exceeded")
+		}
+		return fmt.Errorf("%w: session at %d/%d subscriptions", ErrSubscriptionCapExceeded, r.cap, r.cap)
+	}
+
+	if !alreadyHeld && r.rateLimit > 0 {
+		lim, ok := r.limiters[sessionID]
+		if !ok {
+			lim = rate.NewLimiter(r.rateLimit, r.rateBurst)
+			r.limiters[sessionID] = lim
+		}
+		if !lim.Allow() {
+			r.mu.Unlock()
+			if r.onReject != nil {
+				r.onReject(sessionID, uri, "rate_limited")
+			}
+			return fmt.Errorf("%w: %v subscribes/sec, burst %d", ErrSubscriptionRateLimited, r.rateLimit, r.rateBurst)
+		}
+	}
+
+	if !ok {
+		r.subscribers[uri] = subs
+	}
+	if !alreadyHeld {
+		subs[sessionID] = d
+		r.counts[sessionID]++
+	}
+	r.mu.Unlock()
+	return nil
+}
+
+// unsubscribe removes a session's subscription for a resource URI. No-op
+// if the session was not subscribed to the URI.
+func (r *subscriptionRegistry) unsubscribe(sessionID, uri string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	subs, ok := r.subscribers[uri]
 	if !ok {
-		subs = make(map[string]*Dispatcher)
-		r.subscribers[uri] = subs
+		return
 	}
-	subs[sessionID] = d
-}
-
-// unsubscribe removes a session's subscription for a resource URI.
-func (r *subscriptionRegistry) unsubscribe(sessionID, uri string) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if subs, ok := r.subscribers[uri]; ok {
-		delete(subs, sessionID)
-		if len(subs) == 0 {
-			delete(r.subscribers, uri)
-		}
+	if _, held := subs[sessionID]; !held {
+		return
+	}
+	delete(subs, sessionID)
+	if len(subs) == 0 {
+		delete(r.subscribers, uri)
+	}
+	if r.counts[sessionID] > 0 {
+		r.counts[sessionID]--
+	}
+	if r.counts[sessionID] == 0 {
+		delete(r.counts, sessionID)
+		delete(r.limiters, sessionID)
 	}
 }
 
 // unsubscribeAll removes all subscriptions for a session (called on disconnect).
+// Drops the per-session count and limiter so the session leaves no state
+// behind on the registry.
 func (r *subscriptionRegistry) unsubscribeAll(sessionID string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -1267,6 +1406,8 @@ func (r *subscriptionRegistry) unsubscribeAll(sessionID string) {
 			delete(r.subscribers, uri)
 		}
 	}
+	delete(r.counts, sessionID)
+	delete(r.limiters, sessionID)
 }
 
 // notify sends a notifications/resources/updated to all sessions subscribed to the URI.

--- a/server/server_subscription_caps_test.go
+++ b/server/server_subscription_caps_test.go
@@ -1,0 +1,198 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+
+	core "github.com/panyam/mcpkit/core"
+	"golang.org/x/time/rate"
+)
+
+// newSubscriptionTestSession returns an initialized dispatcher attached to
+// srv with the chosen sessionID. Wraps the same wiring testSubscriptionDispatcher
+// uses but lets the cap tests stand up multiple sessions on one server.
+func newSubscriptionTestSession(srv *Server, sessionID string) *Dispatcher {
+	d := srv.newSession()
+	d.sessionID = sessionID
+	initDispatcher(d)
+	return d
+}
+
+// subscribeReq builds a resources/subscribe JSON-RPC request for uri with
+// the named request id. Keeps each test compact.
+func subscribeReq(id int, uri string) *core.Request {
+	idRaw, _ := json.Marshal(id)
+	params, _ := json.Marshal(struct {
+		URI string `json:"uri"`
+	}{URI: uri})
+	return &core.Request{JSONRPC: "2.0", ID: idRaw, Method: "resources/subscribe", Params: params}
+}
+
+func unsubscribeReq(id int, uri string) *core.Request {
+	idRaw, _ := json.Marshal(id)
+	params, _ := json.Marshal(struct {
+		URI string `json:"uri"`
+	}{URI: uri})
+	return &core.Request{JSONRPC: "2.0", ID: idRaw, Method: "resources/unsubscribe", Params: params}
+}
+
+func makeCapTestServer(t *testing.T, opts ...Option) *Server {
+	t.Helper()
+	srv := NewServer(core.ServerInfo{Name: "cap-test", Version: "1.0"},
+		append([]Option{WithSubscriptions()}, opts...)...,
+	)
+	// Three subscribable URIs is enough for cap=2 and cap=200 cases.
+	for _, uri := range []string{"test://a", "test://b", "test://c", "test://d"} {
+		uri := uri
+		srv.RegisterResource(
+			core.ResourceDef{URI: uri, Name: uri, MimeType: "text/plain"},
+			func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
+				return core.ResourceResult{}, nil
+			},
+		)
+	}
+	return srv
+}
+
+func TestSubscriptionCap_RejectsOverLimit(t *testing.T) {
+	srv := makeCapTestServer(t, WithSubscriptionCap(2))
+	d := newSubscriptionTestSession(srv, "session-A")
+	ctx := context.Background()
+
+	for i, uri := range []string{"test://a", "test://b"} {
+		resp := d.Dispatch(ctx, subscribeReq(i+1, uri))
+		if resp.Error != nil {
+			t.Fatalf("subscribe %d (under cap) failed: %s", i+1, resp.Error.Message)
+		}
+	}
+	resp := d.Dispatch(ctx, subscribeReq(3, "test://c"))
+	if resp.Error == nil {
+		t.Fatal("subscribe over cap: want error, got nil")
+	}
+	if resp.Error.Code != core.ErrCodeSubscriptionLimitExceeded {
+		t.Errorf("error code = %d, want %d", resp.Error.Code, core.ErrCodeSubscriptionLimitExceeded)
+	}
+	if data, ok := resp.Error.Data.(map[string]any); ok {
+		if data["reason"] != "cap_exceeded" {
+			t.Errorf("error.data.reason = %v, want cap_exceeded", data["reason"])
+		}
+	} else {
+		t.Errorf("error.data has unexpected shape: %#v", resp.Error.Data)
+	}
+}
+
+func TestSubscriptionCap_AllowsAfterUnsubscribe(t *testing.T) {
+	srv := makeCapTestServer(t, WithSubscriptionCap(2))
+	d := newSubscriptionTestSession(srv, "session-A")
+	ctx := context.Background()
+
+	d.Dispatch(ctx, subscribeReq(1, "test://a"))
+	d.Dispatch(ctx, subscribeReq(2, "test://b"))
+	resp := d.Dispatch(ctx, unsubscribeReq(3, "test://a"))
+	if resp.Error != nil {
+		t.Fatalf("unsubscribe failed: %s", resp.Error.Message)
+	}
+	resp = d.Dispatch(ctx, subscribeReq(4, "test://c"))
+	if resp.Error != nil {
+		t.Fatalf("subscribe after unsubscribe under cap: want nil error, got %s", resp.Error.Message)
+	}
+}
+
+func TestSubscriptionCap_PerSession(t *testing.T) {
+	srv := makeCapTestServer(t, WithSubscriptionCap(2))
+	a := newSubscriptionTestSession(srv, "session-A")
+	b := newSubscriptionTestSession(srv, "session-B")
+	ctx := context.Background()
+
+	for _, sess := range []*Dispatcher{a, b} {
+		for i, uri := range []string{"test://a", "test://b"} {
+			resp := sess.Dispatch(ctx, subscribeReq(i+1, uri))
+			if resp.Error != nil {
+				t.Fatalf("session %s subscribe %d failed: %s", sess.sessionID, i+1, resp.Error.Message)
+			}
+		}
+	}
+	// Each session is at its own cap of 2. A third subscribe on either
+	// would be refused, but only after they each got their own 2.
+	resp := a.Dispatch(ctx, subscribeReq(99, "test://c"))
+	if resp.Error == nil || resp.Error.Code != core.ErrCodeSubscriptionLimitExceeded {
+		t.Errorf("session-A third subscribe: want cap-exceeded, got %#v", resp.Error)
+	}
+}
+
+func TestSubscriptionCap_UnlimitedByDefault(t *testing.T) {
+	srv := makeCapTestServer(t) // no cap opt
+	d := newSubscriptionTestSession(srv, "session-A")
+	ctx := context.Background()
+
+	// 4 known URIs registered; subscribe each once.
+	for i, uri := range []string{"test://a", "test://b", "test://c", "test://d"} {
+		resp := d.Dispatch(ctx, subscribeReq(i+1, uri))
+		if resp.Error != nil {
+			t.Fatalf("default cap should be unlimited; subscribe %d failed: %s", i+1, resp.Error.Message)
+		}
+	}
+}
+
+func TestSubscriptionRateLimit_BurstHonored(t *testing.T) {
+	// 1 token/second steady state, burst 2 — so three rapid subs admit
+	// two and refuse the third.
+	srv := makeCapTestServer(t, WithSubscriptionRateLimit(rate.Limit(1), 2))
+	d := newSubscriptionTestSession(srv, "session-A")
+	ctx := context.Background()
+
+	results := make([]*core.Response, 0, 3)
+	for i, uri := range []string{"test://a", "test://b", "test://c"} {
+		results = append(results, d.Dispatch(ctx, subscribeReq(i+1, uri)))
+	}
+	if results[0].Error != nil || results[1].Error != nil {
+		t.Fatalf("first two subscribes (within burst) should succeed; got %v / %v", results[0].Error, results[1].Error)
+	}
+	if results[2].Error == nil {
+		t.Fatal("third rapid subscribe: want rate-limited error, got nil")
+	}
+	if results[2].Error.Code != core.ErrCodeSubscriptionLimitExceeded {
+		t.Errorf("error code = %d, want %d", results[2].Error.Code, core.ErrCodeSubscriptionLimitExceeded)
+	}
+	if data, ok := results[2].Error.Data.(map[string]any); ok {
+		if data["reason"] != "rate_limited" {
+			t.Errorf("error.data.reason = %v, want rate_limited", data["reason"])
+		}
+	}
+}
+
+func TestSubscriptionRejectHook_Fires(t *testing.T) {
+	type rejection struct{ sessionID, uri, reason string }
+	var (
+		mu        sync.Mutex
+		rejections []rejection
+	)
+	hook := func(sessionID, uri, reason string) {
+		mu.Lock()
+		defer mu.Unlock()
+		rejections = append(rejections, rejection{sessionID, uri, reason})
+	}
+
+	srv := makeCapTestServer(t, WithSubscriptionCap(1), WithSubscriptionRejectHook(hook))
+	d := newSubscriptionTestSession(srv, "session-A")
+	ctx := context.Background()
+
+	if resp := d.Dispatch(ctx, subscribeReq(1, "test://a")); resp.Error != nil {
+		t.Fatalf("under-cap subscribe failed: %s", resp.Error.Message)
+	}
+	if resp := d.Dispatch(ctx, subscribeReq(2, "test://b")); resp.Error == nil {
+		t.Fatal("over-cap subscribe: want error, got nil")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(rejections) != 1 {
+		t.Fatalf("hook fired %d times, want 1", len(rejections))
+	}
+	r := rejections[0]
+	if r.sessionID != "session-A" || r.uri != "test://b" || r.reason != "cap_exceeded" {
+		t.Errorf("hook received %+v, want {session-A test://b cap_exceeded}", r)
+	}
+}


### PR DESCRIPTION
## What changes

Opt-in per-session backpressure on `resources/subscribe`. Operators can now cap the number of concurrent subscriptions one session may hold (`WithSubscriptionCap`), optionally rate-limit subscribe churn (`WithSubscriptionRateLimit`), and observe rejections via a hook (`WithSubscriptionRejectHook`). When either limit fires, the server returns a structured JSON-RPC error (code -32010, reason in `error.data`) instead of silently accepting the subscribe. Defaults are unchanged: both knobs are off until the operator opts in. Closes 568.

Motivated by a third-party MCP-skills server that went down when a single client hammered `resources/subscribe` in a tight loop. mcpkit now ships the protection in the box.

## Reviewer's guide

Read in this order:

1. [core/jsonrpc.go](https://github.com/panyam/mcpkit/pull/600/files#diff-f9f4f09be0f88717867046128a5e4338f60aaea6764fda9b9a6c95c4089797f4) - start here. The new `ErrCodeSubscriptionLimitExceeded = -32010` constant with the contract godoc on what the wire shape promises.
2. [server/server.go](https://github.com/panyam/mcpkit/pull/600/files#diff-78f42ba40d0f10b08c73b7e6bb8376f398e249c963cf549e89591d6b6826b9a4) - the public surface. Look for the three new options (`WithSubscriptionCap`, `WithSubscriptionRateLimit`, `WithSubscriptionRejectHook`), the new exported `SubscriptionRejectFunc` type, and the recommendation note added to `WithSubscriptions`. Then drop down to `subscriptionRegistry` for the registry-side change: counts and limiters added under the same RWMutex, `subscribe()` now returns an error, `unsubscribe`/`unsubscribeAll` drop the counts.
3. [server/dispatch.go](https://github.com/panyam/mcpkit/pull/600/files#diff-7640bcbef23148a16e477c63c7092f0ba89780f5278a9d6ba6ed513d62f68a92) - the dispatch-side mapping. `handleResourcesSubscribe` reads the error and maps to `ErrCodeSubscriptionLimitExceeded` with `error.data.reason` ("cap_exceeded" or "rate_limited") for client-side adaptive backoff.
4. [server/server_subscription_caps_test.go](https://github.com/panyam/mcpkit/pull/600/files#diff-73db688eda5293dcf8291f2d47c05982941f12057c960453a4f36a9e441cbc63) - acceptance. 6 tests covering reject-over-limit, allow-after-unsubscribe, per-session isolation, unlimited default, rate-limit burst, and the reject hook callback.
5. [go.mod](https://github.com/panyam/mcpkit/pull/600/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6) - mechanical. `golang.org/x/time` promoted from indirect to direct (it backs the rate limiter).

Skim or skip: `go.sum`.

## Decision log

- **Cap defaults off, not 100.** Shipping cap=100 by default would silently regress any deployment that legitimately holds more subscriptions per session. Off-by-default with a strong recommendation in `WithSubscriptions` godoc (and in the new option's godoc) is the conservative landing. Operators who hit the DoS can configure their way out; existing servers don't break.
- **Error code in the implementation-defined JSON-RPC range, not application range.** -32010 sits in -32000 to -32099, which JSON-RPC 2.0 explicitly reserves for server-defined errors. The neighborhood is used by SEP-2575 (-32003, -32004) and the in-flight extension-versioning proposal (-32005), so -32010 leaves a gap and signals "this is an mcpkit decision, not a spec field."
- **`golang.org/x/time/rate` over an inline token bucket.** The dep was already transitive. Token buckets aren't where bugs should live.
- **Per-session scope, not global or per-URI.** Issue 568 specifically calls out per-client. Global and per-URI are out of scope (and listed as such in the issue).
- **Hook fires outside the registry lock.** A blocking observability backend should not stall other requests on the session.
- **Idempotent subscribe.** Subscribing the same `(session, uri)` pair twice succeeds without double-counting against the cap. Matches the pre-existing behavior where the registry simply overwrites the slot.

## Risk / blast radius

- Affects: callers of `server.WithSubscriptions()` who opt in to the new caps. Without the opt-in, behavior is identical to before.
- Tests covering this: 6 new in `server_subscription_caps_test.go`. Existing `TestResourcesSubscribe*` and the streamable-subscriptions tests continue passing unchanged.
- Be paranoid about: the lock-ordering around the reject hook. The hook fires after `r.mu.Unlock()` to avoid holding the registry mutex during a potentially blocking callback. The cost is that a fast caller calling `subscribe` again may observe a slightly-stale count, but the count-check inside the mutex is the canonical gate; the worst case is an extra accepted subscription past the cap if the hook is mid-callback when a second request arrives, and that's a one-off bounded by burst, not unbounded. Worth a second look from a reviewer.

## Before / after

Test run with the new cap engaged:

```
TestSubscriptionCap_RejectsOverLimit         PASS
TestSubscriptionCap_AllowsAfterUnsubscribe   PASS
TestSubscriptionCap_PerSession               PASS
TestSubscriptionCap_UnlimitedByDefault       PASS
TestSubscriptionRateLimit_BurstHonored       PASS
TestSubscriptionRejectHook_Fires             PASS
```

Race detector clean on the full server package (`go test -race ./server/... -count=1 -timeout 60s`).

## Out of scope (deliberately deferred)

- Stateless-wire `subscriptions/listen` cap. Different scoping key (no session concept), tracked as issue 599.
- Global server-wide subscription cap (across all sessions).
- Per-URI subscription cap (max sessions subscribed to one URI).
- Prometheus / slog integration beyond the rejection hook. The hook is the building block; callers wire it to whatever observability they have.

## Test plan

- [x] `make test` (root unit tests) green including the 6 new subscription cap tests
- [x] `go test -race ./server/... -count=1 -timeout 60s` green
- [x] `make tidy-all` clean (x/time promoted from indirect to direct require)
- [x] Red-before-green check: with the impl reverted, the new tests fail to compile (undefined `WithSubscriptionCap`, `WithSubscriptionRateLimit`, `core.ErrCodeSubscriptionLimitExceeded`) confirming the assertions exercise the new contract
- [x] Manual smoke: existing `TestResourcesSubscribe` and `TestResourcesUnsubscribe` continue to pass under the default (no cap)
