### PR TITLE
scripts: fix --all between-fixture state leaks (601)

### DIFF
--- a/scripts/apps-playwright-docker-inner.sh
+++ b/scripts/apps-playwright-docker-inner.sh
@@ -28,6 +28,12 @@ set -euo pipefail
 EXT_APPS_REPO="${EXT_APPS_REPO:-https://github.com/modelcontextprotocol/ext-apps.git}"
 if [ -d "$EXT_APPS_DIR/.git" ]; then
     echo "Updating ext-apps inside container..."
+    # Discard any dirty state left by a prior fixture's run in this shared
+    # volume — `npm install` and example builds can dirty package-lock.json
+    # and dist/ entries. Without this, `git pull` fails with "would be
+    # overwritten by merge" and subsequent fixtures inherit an inconsistent
+    # tree. Issue 601 / PR 596 --all reliability fix.
+    (cd "$EXT_APPS_DIR" && git reset --hard HEAD --quiet && git clean -fd --quiet) || true
     (cd "$EXT_APPS_DIR" && git pull --quiet) || true
 else
     echo "Cloning ext-apps into container volume..."

--- a/scripts/apps_playwright_test.py
+++ b/scripts/apps_playwright_test.py
@@ -61,6 +61,7 @@ import argparse
 import os
 import shutil
 import signal
+import socket
 import subprocess
 import sys
 import time
@@ -336,6 +337,38 @@ def kill_port(port: int) -> None:
                 pass
     except Exception:
         pass
+
+
+def port_is_free(port: int) -> bool:
+    """True if nothing is currently bound on localhost:port.
+
+    Uses a plain bind() probe with SO_REUSEADDR=0 so a socket still in
+    TIME_WAIT counts as in-use — that's the exact race --all hits between
+    fixtures.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        sock.bind(("127.0.0.1", port))
+        return True
+    except OSError:
+        return False
+    finally:
+        sock.close()
+
+
+def wait_for_ports_free(ports: list[int], timeout_s: int = 10) -> bool:
+    """Poll until none of the listed ports are bound (or timeout).
+
+    Used between fixtures in --all mode so the next fixture's Popen doesn't
+    race a TIME_WAIT socket from the previous fixture and time out on its
+    initialize probe.
+    """
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if all(port_is_free(p) for p in ports):
+            return True
+        time.sleep(0.5)
+    return False
 
 
 def wait_for_url(url: str, timeout_s: int, *, method: str = "GET", data: Optional[bytes] = None, headers: Optional[dict] = None) -> bool:
@@ -683,6 +716,7 @@ def report_outcome(rc: int, fixture: Fixture, *, docker: bool, artifacts_dir: Pa
 
 def run_all(config: Config) -> int:
     failed: list[tuple[str, int]] = []
+    shared_ports = [config.harness_port, config.sandbox_port, config.fixture_port]
     for i, fixture in enumerate(FIXTURES, 1):
         info("")
         info(f"=== [{i}/{len(FIXTURES)}] Running {fixture.example} ===")
@@ -695,6 +729,12 @@ def run_all(config: Config) -> int:
         else:
             info(f"FAIL: {fixture.example} (exit {rc})")
             failed.append((fixture.example, rc))
+        # Issue 601: between-fixture port-cleanup wait. The per-fixture
+        # finally block already killed the processes; this lets the kernel
+        # release sockets out of TIME_WAIT before the next fixture binds,
+        # which was the integration-server flake we saw under --all.
+        if i < len(FIXTURES) and not wait_for_ports_free(shared_ports, timeout_s=10):
+            info(f"WARN: ports {shared_ports} still bound after 10s; next fixture may race")
 
     info("")
     info("=== Summary ===")


### PR DESCRIPTION
## What changes

PR 598's acceptance run surfaced a flake under `make test-apps-playwright-docker-all`: `integration-server` failed in the 21-fixture sweep but passed cleanly in isolation (5/5, including `tools/list` strict parity). Root cause was two state leaks between fixtures in the `--all` mode added by PR 596, neither in 598's scope. Issue 601 tracks the work.

This PR adds both fixes.

## Reviewer's guide

Read in this order:

1. [scripts/apps-playwright-docker-inner.sh](https://github.com/panyam/mcpkit/pull/602/files#diff-ce20a4be8d83ffc457423c5ebf4f8f2251a7065bd7c9fede111676584bdb13a5) — adds `git reset --hard HEAD && git clean -fd` before `git pull` inside the shared `mcpkit-ext-apps` Docker volume. Discards any dirty state (typically `package-lock.json` from a fixture's `npm install`, dist/ entries from its build) so the next fixture's pull doesn't fail with "would be overwritten by merge".
2. [scripts/apps_playwright_test.py](https://github.com/panyam/mcpkit/pull/602/files#diff-302da831de82acbf825949d4faa8cd2c5bf55c274edfb1f6bd40206eeca85097) — `port_is_free()` + `wait_for_ports_free()` (raw `socket.bind` probe with `SO_REUSEADDR=0`, so a TIME_WAIT socket correctly counts as in-use), called by `run_all` between fixtures.

## Diff groups

Single intent: two between-fixture state-leak fixes. The first touches inner-script git hygiene; the second touches Python port-cleanup timing. They're paired because they cover the same symptom (`--all` flakes that don't reproduce in isolation) from two different angles.

## Decision log

- **`git reset --hard` not `git stash` in the inner script.** Stash preserves the dirty state but it's never recovered (next fixture's `npm install` will dirty it again the same way) — pure garbage. Reset discards cleanly.
- **`port_is_free` uses raw `socket.bind` with `SO_REUSEADDR=0`, not `lsof`.** `lsof` doesn't report TIME_WAIT sockets — they're not held by a process. The kernel still rejects a `bind()` against them though, which is exactly the race the next fixture's `Popen` was losing. Raw `bind()` probe gives the same truth the next fixture's bind will see.
- **10s timeout on `wait_for_ports_free`, with a WARN-not-fail on timeout.** TIME_WAIT can take longer than 10s on some kernels; we don't want to fail the whole sweep just because a port took 12s instead of 10s to drain — the next fixture's bind may still succeed. WARN surfaces the slow case without halting.
- **No new dependencies.** `socket` is stdlib.
- **Did NOT touch the single-fixture path.** Wait only fires in `run_all` between iterations; one-shot runs are unchanged.

## Risk / blast radius

- Affects: the `--all` sweep mode added by PR 596 and the Docker inner script.
- Single-fixture path unchanged.
- Be paranoid about: the `git reset --hard` inside the Docker volume. It only resets the cloned `ext-apps` tree inside the named `mcpkit-ext-apps` volume — the host's `$EXT_APPS_DIR` (in native mode) is never touched. The named volume is exclusively for `--docker` mode.

## Test plan

- [x] `port_is_free` correctly reports a bound port as in-use and a released port as free (sanity-tested locally with a transient bind).
- [x] `wait_for_ports_free` returns `True` once the bound port releases.
- [ ] **Acceptance gate:** `make test-apps-playwright-docker-all` reports 20/21 pass + pdf-server fail on two consecutive runs. No more integration-server flake.

## Related

- PR 596 — introduced `--all` mode + Python port.
- PR 598 — surfaced the flake during its acceptance gate.
- Issue 574 — pdf-server form-fields-names gap (the legitimate 1/21 failure, unrelated).
