### PR TITLE
docs(apps/compat): expand per-fixture READMEs to "Run it + Optional" pattern

### DIFF
--- a/examples/apps/compat/basic-preact/README.md
+++ b/examples/apps/compat/basic-preact/README.md
@@ -13,19 +13,44 @@ mcpkit hosts can drive a Preact-based App with no special handling.
 
 ## Run it
 
+Boots the mcpkit-Go fixture (`main.go` in this folder) and opens
+[MCPJam Inspector](https://github.com/MCPJam/inspector) so you can poke
+at the protocol surface:
+
 ```bash
-# mcpkit-Go fixture + MCPJam (default — wire-level inspection)
 make demo-app EXAMPLE=basic-server-preact
-
-# Same Go fixture rendered in basic-host (iframe + bridge JS)
-RENDERER=basic-host make demo-app EXAMPLE=basic-server-preact
-
-# Compare against upstream's TS reference server
-make demo-upstream EXAMPLE=basic-server-preact
-
-# Strict parity check (visual baseline + tools/list diff, requires Docker)
-EXAMPLE=basic-server-preact make test-apps-playwright-docker
 ```
+
+Paste `http://localhost:3101/mcp` into MCPJam's server list and connect.
+Then browse `tools/list`, `_meta.ui`, and tool-call payloads on the wire.
+
+### [Optional] You can also do…
+
+- **See the App rendered in basic-host.** Same Go fixture, but driven by
+  basic-host (the canonical reference UI) instead of MCPJam. Opens a
+  browser at `http://localhost:8080`:
+
+  ```bash
+  RENDERER=basic-host make demo-app EXAMPLE=basic-server-preact
+  ```
+
+- **Hit upstream's TS reference server instead.** Useful for comparing
+  the Go fixture's wire surface against the canonical implementation:
+
+  ```bash
+  make demo-upstream EXAMPLE=basic-server-preact
+  ```
+
+  Add `RENDERER=basic-host` to render the upstream TS in basic-host
+  instead of MCPJam.
+
+- **Strict parity check against the mcpkit-Go fixture.** Runs upstream's
+  Playwright suite against the Go binary — wire-level `tools/list` diff
+  + visual PNG gate. Requires Docker:
+
+  ```bash
+  EXAMPLE=basic-server-preact make test-apps-playwright-docker
+  ```
 
 ## Prompts to try
 

--- a/examples/apps/compat/basic-react/README.md
+++ b/examples/apps/compat/basic-react/README.md
@@ -13,19 +13,44 @@ mcpkit hosts can drive a React-based App with no special handling.
 
 ## Run it
 
+Boots the mcpkit-Go fixture (`main.go` in this folder) and opens
+[MCPJam Inspector](https://github.com/MCPJam/inspector) so you can poke
+at the protocol surface:
+
 ```bash
-# mcpkit-Go fixture + MCPJam (default — wire-level inspection)
 make demo-app EXAMPLE=basic-server-react
-
-# Same Go fixture rendered in basic-host (iframe + bridge JS)
-RENDERER=basic-host make demo-app EXAMPLE=basic-server-react
-
-# Compare against upstream's TS reference server
-make demo-upstream EXAMPLE=basic-server-react
-
-# Strict parity check (visual baseline + tools/list diff, requires Docker)
-EXAMPLE=basic-server-react make test-apps-playwright-docker
 ```
+
+Paste `http://localhost:3101/mcp` into MCPJam's server list and connect.
+Then browse `tools/list`, `_meta.ui`, and tool-call payloads on the wire.
+
+### [Optional] You can also do…
+
+- **See the App rendered in basic-host.** Same Go fixture, but driven by
+  basic-host (the canonical reference UI) instead of MCPJam. Opens a
+  browser at `http://localhost:8080`:
+
+  ```bash
+  RENDERER=basic-host make demo-app EXAMPLE=basic-server-react
+  ```
+
+- **Hit upstream's TS reference server instead.** Useful for comparing
+  the Go fixture's wire surface against the canonical implementation:
+
+  ```bash
+  make demo-upstream EXAMPLE=basic-server-react
+  ```
+
+  Add `RENDERER=basic-host` to render the upstream TS in basic-host
+  instead of MCPJam.
+
+- **Strict parity check against the mcpkit-Go fixture.** Runs upstream's
+  Playwright suite against the Go binary — wire-level `tools/list` diff
+  + visual PNG gate. Requires Docker:
+
+  ```bash
+  EXAMPLE=basic-server-react make test-apps-playwright-docker
+  ```
 
 ## Prompts to try
 

--- a/examples/apps/compat/basic-solid/README.md
+++ b/examples/apps/compat/basic-solid/README.md
@@ -14,19 +14,44 @@ mcpkit hosts can drive a Solid-based App with no special handling.
 
 ## Run it
 
+Boots the mcpkit-Go fixture (`main.go` in this folder) and opens
+[MCPJam Inspector](https://github.com/MCPJam/inspector) so you can poke
+at the protocol surface:
+
 ```bash
-# mcpkit-Go fixture + MCPJam (default — wire-level inspection)
 make demo-app EXAMPLE=basic-server-solid
-
-# Same Go fixture rendered in basic-host (iframe + bridge JS)
-RENDERER=basic-host make demo-app EXAMPLE=basic-server-solid
-
-# Compare against upstream's TS reference server
-make demo-upstream EXAMPLE=basic-server-solid
-
-# Strict parity check (visual baseline + tools/list diff, requires Docker)
-EXAMPLE=basic-server-solid make test-apps-playwright-docker
 ```
+
+Paste `http://localhost:3101/mcp` into MCPJam's server list and connect.
+Then browse `tools/list`, `_meta.ui`, and tool-call payloads on the wire.
+
+### [Optional] You can also do…
+
+- **See the App rendered in basic-host.** Same Go fixture, but driven by
+  basic-host (the canonical reference UI) instead of MCPJam. Opens a
+  browser at `http://localhost:8080`:
+
+  ```bash
+  RENDERER=basic-host make demo-app EXAMPLE=basic-server-solid
+  ```
+
+- **Hit upstream's TS reference server instead.** Useful for comparing
+  the Go fixture's wire surface against the canonical implementation:
+
+  ```bash
+  make demo-upstream EXAMPLE=basic-server-solid
+  ```
+
+  Add `RENDERER=basic-host` to render the upstream TS in basic-host
+  instead of MCPJam.
+
+- **Strict parity check against the mcpkit-Go fixture.** Runs upstream's
+  Playwright suite against the Go binary — wire-level `tools/list` diff
+  + visual PNG gate. Requires Docker:
+
+  ```bash
+  EXAMPLE=basic-server-solid make test-apps-playwright-docker
+  ```
 
 ## Prompts to try
 

--- a/examples/apps/compat/basic-svelte/README.md
+++ b/examples/apps/compat/basic-svelte/README.md
@@ -13,19 +13,44 @@ mcpkit hosts can drive a Svelte-based App with no special handling.
 
 ## Run it
 
+Boots the mcpkit-Go fixture (`main.go` in this folder) and opens
+[MCPJam Inspector](https://github.com/MCPJam/inspector) so you can poke
+at the protocol surface:
+
 ```bash
-# mcpkit-Go fixture + MCPJam (default — wire-level inspection)
 make demo-app EXAMPLE=basic-server-svelte
-
-# Same Go fixture rendered in basic-host (iframe + bridge JS)
-RENDERER=basic-host make demo-app EXAMPLE=basic-server-svelte
-
-# Compare against upstream's TS reference server
-make demo-upstream EXAMPLE=basic-server-svelte
-
-# Strict parity check (visual baseline + tools/list diff, requires Docker)
-EXAMPLE=basic-server-svelte make test-apps-playwright-docker
 ```
+
+Paste `http://localhost:3101/mcp` into MCPJam's server list and connect.
+Then browse `tools/list`, `_meta.ui`, and tool-call payloads on the wire.
+
+### [Optional] You can also do…
+
+- **See the App rendered in basic-host.** Same Go fixture, but driven by
+  basic-host (the canonical reference UI) instead of MCPJam. Opens a
+  browser at `http://localhost:8080`:
+
+  ```bash
+  RENDERER=basic-host make demo-app EXAMPLE=basic-server-svelte
+  ```
+
+- **Hit upstream's TS reference server instead.** Useful for comparing
+  the Go fixture's wire surface against the canonical implementation:
+
+  ```bash
+  make demo-upstream EXAMPLE=basic-server-svelte
+  ```
+
+  Add `RENDERER=basic-host` to render the upstream TS in basic-host
+  instead of MCPJam.
+
+- **Strict parity check against the mcpkit-Go fixture.** Runs upstream's
+  Playwright suite against the Go binary — wire-level `tools/list` diff
+  + visual PNG gate. Requires Docker:
+
+  ```bash
+  EXAMPLE=basic-server-svelte make test-apps-playwright-docker
+  ```
 
 ## Prompts to try
 

--- a/examples/apps/compat/basic-vue/README.md
+++ b/examples/apps/compat/basic-vue/README.md
@@ -13,19 +13,44 @@ mcpkit hosts can drive a Vue-based App with no special handling.
 
 ## Run it
 
+Boots the mcpkit-Go fixture (`main.go` in this folder) and opens
+[MCPJam Inspector](https://github.com/MCPJam/inspector) so you can poke
+at the protocol surface:
+
 ```bash
-# mcpkit-Go fixture + MCPJam (default — wire-level inspection)
 make demo-app EXAMPLE=basic-server-vue
-
-# Same Go fixture rendered in basic-host (iframe + bridge JS)
-RENDERER=basic-host make demo-app EXAMPLE=basic-server-vue
-
-# Compare against upstream's TS reference server
-make demo-upstream EXAMPLE=basic-server-vue
-
-# Strict parity check (visual baseline + tools/list diff, requires Docker)
-EXAMPLE=basic-server-vue make test-apps-playwright-docker
 ```
+
+Paste `http://localhost:3101/mcp` into MCPJam's server list and connect.
+Then browse `tools/list`, `_meta.ui`, and tool-call payloads on the wire.
+
+### [Optional] You can also do…
+
+- **See the App rendered in basic-host.** Same Go fixture, but driven by
+  basic-host (the canonical reference UI) instead of MCPJam. Opens a
+  browser at `http://localhost:8080`:
+
+  ```bash
+  RENDERER=basic-host make demo-app EXAMPLE=basic-server-vue
+  ```
+
+- **Hit upstream's TS reference server instead.** Useful for comparing
+  the Go fixture's wire surface against the canonical implementation:
+
+  ```bash
+  make demo-upstream EXAMPLE=basic-server-vue
+  ```
+
+  Add `RENDERER=basic-host` to render the upstream TS in basic-host
+  instead of MCPJam.
+
+- **Strict parity check against the mcpkit-Go fixture.** Runs upstream's
+  Playwright suite against the Go binary — wire-level `tools/list` diff
+  + visual PNG gate. Requires Docker:
+
+  ```bash
+  EXAMPLE=basic-server-vue make test-apps-playwright-docker
+  ```
 
 ## Prompts to try
 

--- a/examples/apps/compat/budget-allocator/README.md
+++ b/examples/apps/compat/budget-allocator/README.md
@@ -18,19 +18,44 @@ without override.
 
 ## Run it
 
+Boots the mcpkit-Go fixture (`main.go` in this folder) and opens
+[MCPJam Inspector](https://github.com/MCPJam/inspector) so you can poke
+at the protocol surface:
+
 ```bash
-# mcpkit-Go fixture + MCPJam (default — wire-level inspection)
 make demo-app EXAMPLE=budget-allocator-server
-
-# Same Go fixture rendered in basic-host (iframe + bridge JS)
-RENDERER=basic-host make demo-app EXAMPLE=budget-allocator-server
-
-# Compare against upstream's TS reference server
-make demo-upstream EXAMPLE=budget-allocator-server
-
-# Strict parity check (visual baseline + tools/list diff, requires Docker)
-EXAMPLE=budget-allocator-server make test-apps-playwright-docker
 ```
+
+Paste `http://localhost:3101/mcp` into MCPJam's server list and connect.
+Then browse `tools/list`, `_meta.ui`, and tool-call payloads on the wire.
+
+### [Optional] You can also do…
+
+- **See the App rendered in basic-host.** Same Go fixture, but driven by
+  basic-host (the canonical reference UI) instead of MCPJam. Opens a
+  browser at `http://localhost:8080`:
+
+  ```bash
+  RENDERER=basic-host make demo-app EXAMPLE=budget-allocator-server
+  ```
+
+- **Hit upstream's TS reference server instead.** Useful for comparing
+  the Go fixture's wire surface against the canonical implementation:
+
+  ```bash
+  make demo-upstream EXAMPLE=budget-allocator-server
+  ```
+
+  Add `RENDERER=basic-host` to render the upstream TS in basic-host
+  instead of MCPJam.
+
+- **Strict parity check against the mcpkit-Go fixture.** Runs upstream's
+  Playwright suite against the Go binary — wire-level `tools/list` diff
+  + visual PNG gate. Requires Docker:
+
+  ```bash
+  EXAMPLE=budget-allocator-server make test-apps-playwright-docker
+  ```
 
 ## Prompts to try
 

--- a/examples/apps/compat/cohort-heatmap/README.md
+++ b/examples/apps/compat/cohort-heatmap/README.md
@@ -18,19 +18,44 @@ cohort-retention heatmap.
 
 ## Run it
 
+Boots the mcpkit-Go fixture (`main.go` in this folder) and opens
+[MCPJam Inspector](https://github.com/MCPJam/inspector) so you can poke
+at the protocol surface:
+
 ```bash
-# mcpkit-Go fixture + MCPJam (default — wire-level inspection)
 make demo-app EXAMPLE=cohort-heatmap-server
-
-# Same Go fixture rendered in basic-host (iframe + bridge JS)
-RENDERER=basic-host make demo-app EXAMPLE=cohort-heatmap-server
-
-# Compare against upstream's TS reference server
-make demo-upstream EXAMPLE=cohort-heatmap-server
-
-# Strict parity check (visual baseline + tools/list diff, requires Docker)
-EXAMPLE=cohort-heatmap-server make test-apps-playwright-docker
 ```
+
+Paste `http://localhost:3101/mcp` into MCPJam's server list and connect.
+Then browse `tools/list`, `_meta.ui`, and tool-call payloads on the wire.
+
+### [Optional] You can also do…
+
+- **See the App rendered in basic-host.** Same Go fixture, but driven by
+  basic-host (the canonical reference UI) instead of MCPJam. Opens a
+  browser at `http://localhost:8080`:
+
+  ```bash
+  RENDERER=basic-host make demo-app EXAMPLE=cohort-heatmap-server
+  ```
+
+- **Hit upstream's TS reference server instead.** Useful for comparing
+  the Go fixture's wire surface against the canonical implementation:
+
+  ```bash
+  make demo-upstream EXAMPLE=cohort-heatmap-server
+  ```
+
+  Add `RENDERER=basic-host` to render the upstream TS in basic-host
+  instead of MCPJam.
+
+- **Strict parity check against the mcpkit-Go fixture.** Runs upstream's
+  Playwright suite against the Go binary — wire-level `tools/list` diff
+  + visual PNG gate. Requires Docker:
+
+  ```bash
+  EXAMPLE=cohort-heatmap-server make test-apps-playwright-docker
+  ```
 
 ## Prompts to try
 

--- a/examples/apps/compat/customer-segmentation/README.md
+++ b/examples/apps/compat/customer-segmentation/README.md
@@ -16,19 +16,44 @@ plots + per-segment summaries.
 
 ## Run it
 
+Boots the mcpkit-Go fixture (`main.go` in this folder) and opens
+[MCPJam Inspector](https://github.com/MCPJam/inspector) so you can poke
+at the protocol surface:
+
 ```bash
-# mcpkit-Go fixture + MCPJam (default — wire-level inspection)
 make demo-app EXAMPLE=customer-segmentation-server
-
-# Same Go fixture rendered in basic-host (iframe + bridge JS)
-RENDERER=basic-host make demo-app EXAMPLE=customer-segmentation-server
-
-# Compare against upstream's TS reference server
-make demo-upstream EXAMPLE=customer-segmentation-server
-
-# Strict parity check (visual baseline + tools/list diff, requires Docker)
-EXAMPLE=customer-segmentation-server make test-apps-playwright-docker
 ```
+
+Paste `http://localhost:3101/mcp` into MCPJam's server list and connect.
+Then browse `tools/list`, `_meta.ui`, and tool-call payloads on the wire.
+
+### [Optional] You can also do…
+
+- **See the App rendered in basic-host.** Same Go fixture, but driven by
+  basic-host (the canonical reference UI) instead of MCPJam. Opens a
+  browser at `http://localhost:8080`:
+
+  ```bash
+  RENDERER=basic-host make demo-app EXAMPLE=customer-segmentation-server
+  ```
+
+- **Hit upstream's TS reference server instead.** Useful for comparing
+  the Go fixture's wire surface against the canonical implementation:
+
+  ```bash
+  make demo-upstream EXAMPLE=customer-segmentation-server
+  ```
+
+  Add `RENDERER=basic-host` to render the upstream TS in basic-host
+  instead of MCPJam.
+
+- **Strict parity check against the mcpkit-Go fixture.** Runs upstream's
+  Playwright suite against the Go binary — wire-level `tools/list` diff
+  + visual PNG gate. Requires Docker:
+
+  ```bash
+  EXAMPLE=customer-segmentation-server make test-apps-playwright-docker
+  ```
 
 ## Prompts to try
 

--- a/examples/apps/compat/debug-server/README.md
+++ b/examples/apps/compat/debug-server/README.md
@@ -19,19 +19,44 @@ app-only helpers (refresh / log) the iframe uses internally.
 
 ## Run it
 
+Boots the mcpkit-Go fixture (`main.go` in this folder) and opens
+[MCPJam Inspector](https://github.com/MCPJam/inspector) so you can poke
+at the protocol surface:
+
 ```bash
-# mcpkit-Go fixture + MCPJam (default — wire-level inspection)
 make demo-app EXAMPLE=debug-server
-
-# Same Go fixture rendered in basic-host (iframe + bridge JS)
-RENDERER=basic-host make demo-app EXAMPLE=debug-server
-
-# Compare against upstream's TS reference server
-make demo-upstream EXAMPLE=debug-server
-
-# Strict parity check (visual baseline + tools/list diff, requires Docker)
-EXAMPLE=debug-server make test-apps-playwright-docker
 ```
+
+Paste `http://localhost:3101/mcp` into MCPJam's server list and connect.
+Then browse `tools/list`, `_meta.ui`, and tool-call payloads on the wire.
+
+### [Optional] You can also do…
+
+- **See the App rendered in basic-host.** Same Go fixture, but driven by
+  basic-host (the canonical reference UI) instead of MCPJam. Opens a
+  browser at `http://localhost:8080`:
+
+  ```bash
+  RENDERER=basic-host make demo-app EXAMPLE=debug-server
+  ```
+
+- **Hit upstream's TS reference server instead.** Useful for comparing
+  the Go fixture's wire surface against the canonical implementation:
+
+  ```bash
+  make demo-upstream EXAMPLE=debug-server
+  ```
+
+  Add `RENDERER=basic-host` to render the upstream TS in basic-host
+  instead of MCPJam.
+
+- **Strict parity check against the mcpkit-Go fixture.** Runs upstream's
+  Playwright suite against the Go binary — wire-level `tools/list` diff
+  + visual PNG gate. Requires Docker:
+
+  ```bash
+  EXAMPLE=debug-server make test-apps-playwright-docker
+  ```
 
 ## Prompts to try
 

--- a/examples/apps/compat/integration/README.md
+++ b/examples/apps/compat/integration/README.md
@@ -23,19 +23,44 @@ Message, Send Log, Open Link).
 
 ## Run it
 
+Boots the mcpkit-Go fixture (`main.go` in this folder) and opens
+[MCPJam Inspector](https://github.com/MCPJam/inspector) so you can poke
+at the protocol surface:
+
 ```bash
-# mcpkit-Go fixture + MCPJam (default — wire-level inspection)
 make demo-app EXAMPLE=integration-server
-
-# Same Go fixture rendered in basic-host (iframe + bridge JS)
-RENDERER=basic-host make demo-app EXAMPLE=integration-server
-
-# Compare against upstream's TS reference server
-make demo-upstream EXAMPLE=integration-server
-
-# Strict parity check (visual baseline + tools/list diff, requires Docker)
-EXAMPLE=integration-server make test-apps-playwright-docker
 ```
+
+Paste `http://localhost:3101/mcp` into MCPJam's server list and connect.
+Then browse `tools/list`, `_meta.ui`, and tool-call payloads on the wire.
+
+### [Optional] You can also do…
+
+- **See the App rendered in basic-host.** Same Go fixture, but driven by
+  basic-host (the canonical reference UI) instead of MCPJam. Opens a
+  browser at `http://localhost:8080`:
+
+  ```bash
+  RENDERER=basic-host make demo-app EXAMPLE=integration-server
+  ```
+
+- **Hit upstream's TS reference server instead.** Useful for comparing
+  the Go fixture's wire surface against the canonical implementation:
+
+  ```bash
+  make demo-upstream EXAMPLE=integration-server
+  ```
+
+  Add `RENDERER=basic-host` to render the upstream TS in basic-host
+  instead of MCPJam.
+
+- **Strict parity check against the mcpkit-Go fixture.** Runs upstream's
+  Playwright suite against the Go binary — wire-level `tools/list` diff
+  + visual PNG gate. Requires Docker:
+
+  ```bash
+  EXAMPLE=integration-server make test-apps-playwright-docker
+  ```
 
 ## Prompts to try
 

--- a/examples/apps/compat/map/README.md
+++ b/examples/apps/compat/map/README.md
@@ -20,19 +20,44 @@ App calls via the bridge.
 
 ## Run it
 
+Boots the mcpkit-Go fixture (`main.go` in this folder) and opens
+[MCPJam Inspector](https://github.com/MCPJam/inspector) so you can poke
+at the protocol surface:
+
 ```bash
-# mcpkit-Go fixture + MCPJam (default — wire-level inspection)
 make demo-app EXAMPLE=map-server
-
-# Same Go fixture rendered in basic-host (iframe + bridge JS)
-RENDERER=basic-host make demo-app EXAMPLE=map-server
-
-# Compare against upstream's TS reference server
-make demo-upstream EXAMPLE=map-server
-
-# Strict parity check (visual baseline + tools/list diff, requires Docker)
-EXAMPLE=map-server make test-apps-playwright-docker
 ```
+
+Paste `http://localhost:3101/mcp` into MCPJam's server list and connect.
+Then browse `tools/list`, `_meta.ui`, and tool-call payloads on the wire.
+
+### [Optional] You can also do…
+
+- **See the App rendered in basic-host.** Same Go fixture, but driven by
+  basic-host (the canonical reference UI) instead of MCPJam. Opens a
+  browser at `http://localhost:8080`:
+
+  ```bash
+  RENDERER=basic-host make demo-app EXAMPLE=map-server
+  ```
+
+- **Hit upstream's TS reference server instead.** Useful for comparing
+  the Go fixture's wire surface against the canonical implementation:
+
+  ```bash
+  make demo-upstream EXAMPLE=map-server
+  ```
+
+  Add `RENDERER=basic-host` to render the upstream TS in basic-host
+  instead of MCPJam.
+
+- **Strict parity check against the mcpkit-Go fixture.** Runs upstream's
+  Playwright suite against the Go binary — wire-level `tools/list` diff
+  + visual PNG gate. Requires Docker:
+
+  ```bash
+  EXAMPLE=map-server make test-apps-playwright-docker
+  ```
 
 ## Prompts to try
 

--- a/examples/apps/compat/pdf-server/README.md
+++ b/examples/apps/compat/pdf-server/README.md
@@ -43,19 +43,44 @@ patterns compound.
 
 ## Run it
 
+Boots the mcpkit-Go fixture (`main.go` in this folder) and opens
+[MCPJam Inspector](https://github.com/MCPJam/inspector) so you can poke
+at the protocol surface:
+
 ```bash
-# mcpkit-Go fixture + MCPJam (default — wire-level inspection)
 make demo-app EXAMPLE=pdf-server
-
-# Same Go fixture rendered in basic-host (iframe + bridge JS)
-RENDERER=basic-host make demo-app EXAMPLE=pdf-server
-
-# Compare against upstream's TS reference server
-make demo-upstream EXAMPLE=pdf-server
-
-# Strict parity check (visual baseline + tools/list diff, requires Docker)
-EXAMPLE=pdf-server make test-apps-playwright-docker
 ```
+
+Paste `http://localhost:3101/mcp` into MCPJam's server list and connect.
+Then browse `tools/list`, `_meta.ui`, and tool-call payloads on the wire.
+
+### [Optional] You can also do…
+
+- **See the App rendered in basic-host.** Same Go fixture, but driven by
+  basic-host (the canonical reference UI) instead of MCPJam. Opens a
+  browser at `http://localhost:8080`:
+
+  ```bash
+  RENDERER=basic-host make demo-app EXAMPLE=pdf-server
+  ```
+
+- **Hit upstream's TS reference server instead.** Useful for comparing
+  the Go fixture's wire surface against the canonical implementation:
+
+  ```bash
+  make demo-upstream EXAMPLE=pdf-server
+  ```
+
+  Add `RENDERER=basic-host` to render the upstream TS in basic-host
+  instead of MCPJam.
+
+- **Strict parity check against the mcpkit-Go fixture.** Runs upstream's
+  Playwright suite against the Go binary — wire-level `tools/list` diff
+  + visual PNG gate. Requires Docker:
+
+  ```bash
+  EXAMPLE=pdf-server make test-apps-playwright-docker
+  ```
 
 Default PDF is `https://arxiv.org/pdf/1706.03762` ("Attention Is All
 You Need") — upstream's default too.

--- a/examples/apps/compat/quickstart/README.md
+++ b/examples/apps/compat/quickstart/README.md
@@ -17,19 +17,44 @@ rather than a hand-rolled minimal one.
 
 ## Run it
 
+Boots the mcpkit-Go fixture (`main.go` in this folder) and opens
+[MCPJam Inspector](https://github.com/MCPJam/inspector) so you can poke
+at the protocol surface:
+
 ```bash
-# mcpkit-Go fixture + MCPJam (default — wire-level inspection)
 make demo-app EXAMPLE=quickstart
-
-# Same Go fixture rendered in basic-host (iframe + bridge JS)
-RENDERER=basic-host make demo-app EXAMPLE=quickstart
-
-# Compare against upstream's TS reference server
-make demo-upstream EXAMPLE=quickstart
-
-# Strict parity check (visual baseline + tools/list diff, requires Docker)
-EXAMPLE=quickstart make test-apps-playwright-docker
 ```
+
+Paste `http://localhost:3101/mcp` into MCPJam's server list and connect.
+Then browse `tools/list`, `_meta.ui`, and tool-call payloads on the wire.
+
+### [Optional] You can also do…
+
+- **See the App rendered in basic-host.** Same Go fixture, but driven by
+  basic-host (the canonical reference UI) instead of MCPJam. Opens a
+  browser at `http://localhost:8080`:
+
+  ```bash
+  RENDERER=basic-host make demo-app EXAMPLE=quickstart
+  ```
+
+- **Hit upstream's TS reference server instead.** Useful for comparing
+  the Go fixture's wire surface against the canonical implementation:
+
+  ```bash
+  make demo-upstream EXAMPLE=quickstart
+  ```
+
+  Add `RENDERER=basic-host` to render the upstream TS in basic-host
+  instead of MCPJam.
+
+- **Strict parity check against the mcpkit-Go fixture.** Runs upstream's
+  Playwright suite against the Go binary — wire-level `tools/list` diff
+  + visual PNG gate. Requires Docker:
+
+  ```bash
+  EXAMPLE=quickstart make test-apps-playwright-docker
+  ```
 
 ## Prompts to try
 

--- a/examples/apps/compat/scenario-modeler/README.md
+++ b/examples/apps/compat/scenario-modeler/README.md
@@ -24,19 +24,44 @@ the full `OutputSchemaOverride` is genuinely cleaner.
 
 ## Run it
 
+Boots the mcpkit-Go fixture (`main.go` in this folder) and opens
+[MCPJam Inspector](https://github.com/MCPJam/inspector) so you can poke
+at the protocol surface:
+
 ```bash
-# mcpkit-Go fixture + MCPJam (default — wire-level inspection)
 make demo-app EXAMPLE=scenario-modeler-server
-
-# Same Go fixture rendered in basic-host (iframe + bridge JS)
-RENDERER=basic-host make demo-app EXAMPLE=scenario-modeler-server
-
-# Compare against upstream's TS reference server
-make demo-upstream EXAMPLE=scenario-modeler-server
-
-# Strict parity check (visual baseline + tools/list diff, requires Docker)
-EXAMPLE=scenario-modeler-server make test-apps-playwright-docker
 ```
+
+Paste `http://localhost:3101/mcp` into MCPJam's server list and connect.
+Then browse `tools/list`, `_meta.ui`, and tool-call payloads on the wire.
+
+### [Optional] You can also do…
+
+- **See the App rendered in basic-host.** Same Go fixture, but driven by
+  basic-host (the canonical reference UI) instead of MCPJam. Opens a
+  browser at `http://localhost:8080`:
+
+  ```bash
+  RENDERER=basic-host make demo-app EXAMPLE=scenario-modeler-server
+  ```
+
+- **Hit upstream's TS reference server instead.** Useful for comparing
+  the Go fixture's wire surface against the canonical implementation:
+
+  ```bash
+  make demo-upstream EXAMPLE=scenario-modeler-server
+  ```
+
+  Add `RENDERER=basic-host` to render the upstream TS in basic-host
+  instead of MCPJam.
+
+- **Strict parity check against the mcpkit-Go fixture.** Runs upstream's
+  Playwright suite against the Go binary — wire-level `tools/list` diff
+  + visual PNG gate. Requires Docker:
+
+  ```bash
+  EXAMPLE=scenario-modeler-server make test-apps-playwright-docker
+  ```
 
 ## Prompts to try
 

--- a/examples/apps/compat/shadertoy/README.md
+++ b/examples/apps/compat/shadertoy/README.md
@@ -21,19 +21,44 @@ fixture targeted at WebGL-style rendering inside the App iframe.
 
 ## Run it
 
+Boots the mcpkit-Go fixture (`main.go` in this folder) and opens
+[MCPJam Inspector](https://github.com/MCPJam/inspector) so you can poke
+at the protocol surface:
+
 ```bash
-# mcpkit-Go fixture + MCPJam (default — wire-level inspection)
 make demo-app EXAMPLE=shadertoy-server
-
-# Same Go fixture rendered in basic-host (iframe + bridge JS)
-RENDERER=basic-host make demo-app EXAMPLE=shadertoy-server
-
-# Compare against upstream's TS reference server
-make demo-upstream EXAMPLE=shadertoy-server
-
-# Strict parity check (visual baseline + tools/list diff, requires Docker)
-EXAMPLE=shadertoy-server make test-apps-playwright-docker
 ```
+
+Paste `http://localhost:3101/mcp` into MCPJam's server list and connect.
+Then browse `tools/list`, `_meta.ui`, and tool-call payloads on the wire.
+
+### [Optional] You can also do…
+
+- **See the App rendered in basic-host.** Same Go fixture, but driven by
+  basic-host (the canonical reference UI) instead of MCPJam. Opens a
+  browser at `http://localhost:8080`:
+
+  ```bash
+  RENDERER=basic-host make demo-app EXAMPLE=shadertoy-server
+  ```
+
+- **Hit upstream's TS reference server instead.** Useful for comparing
+  the Go fixture's wire surface against the canonical implementation:
+
+  ```bash
+  make demo-upstream EXAMPLE=shadertoy-server
+  ```
+
+  Add `RENDERER=basic-host` to render the upstream TS in basic-host
+  instead of MCPJam.
+
+- **Strict parity check against the mcpkit-Go fixture.** Runs upstream's
+  Playwright suite against the Go binary — wire-level `tools/list` diff
+  + visual PNG gate. Requires Docker:
+
+  ```bash
+  EXAMPLE=shadertoy-server make test-apps-playwright-docker
+  ```
 
 ## Prompts to try
 

--- a/examples/apps/compat/sheet-music/README.md
+++ b/examples/apps/compat/sheet-music/README.md
@@ -19,19 +19,44 @@ schema. Introduces the `InputSchemaPatch` escape hatch.
 
 ## Run it
 
+Boots the mcpkit-Go fixture (`main.go` in this folder) and opens
+[MCPJam Inspector](https://github.com/MCPJam/inspector) so you can poke
+at the protocol surface:
+
 ```bash
-# mcpkit-Go fixture + MCPJam (default — wire-level inspection)
 make demo-app EXAMPLE=sheet-music-server
-
-# Same Go fixture rendered in basic-host (iframe + bridge JS)
-RENDERER=basic-host make demo-app EXAMPLE=sheet-music-server
-
-# Compare against upstream's TS reference server
-make demo-upstream EXAMPLE=sheet-music-server
-
-# Strict parity check (visual baseline + tools/list diff, requires Docker)
-EXAMPLE=sheet-music-server make test-apps-playwright-docker
 ```
+
+Paste `http://localhost:3101/mcp` into MCPJam's server list and connect.
+Then browse `tools/list`, `_meta.ui`, and tool-call payloads on the wire.
+
+### [Optional] You can also do…
+
+- **See the App rendered in basic-host.** Same Go fixture, but driven by
+  basic-host (the canonical reference UI) instead of MCPJam. Opens a
+  browser at `http://localhost:8080`:
+
+  ```bash
+  RENDERER=basic-host make demo-app EXAMPLE=sheet-music-server
+  ```
+
+- **Hit upstream's TS reference server instead.** Useful for comparing
+  the Go fixture's wire surface against the canonical implementation:
+
+  ```bash
+  make demo-upstream EXAMPLE=sheet-music-server
+  ```
+
+  Add `RENDERER=basic-host` to render the upstream TS in basic-host
+  instead of MCPJam.
+
+- **Strict parity check against the mcpkit-Go fixture.** Runs upstream's
+  Playwright suite against the Go binary — wire-level `tools/list` diff
+  + visual PNG gate. Requires Docker:
+
+  ```bash
+  EXAMPLE=sheet-music-server make test-apps-playwright-docker
+  ```
 
 ## Prompts to try
 

--- a/examples/apps/compat/system-monitor/README.md
+++ b/examples/apps/compat/system-monitor/README.md
@@ -20,19 +20,44 @@ iframe polls from inside via the bridge. First fixture introducing
 
 ## Run it
 
+Boots the mcpkit-Go fixture (`main.go` in this folder) and opens
+[MCPJam Inspector](https://github.com/MCPJam/inspector) so you can poke
+at the protocol surface:
+
 ```bash
-# mcpkit-Go fixture + MCPJam (default — wire-level inspection)
 make demo-app EXAMPLE=system-monitor-server
-
-# Same Go fixture rendered in basic-host (iframe + bridge JS)
-RENDERER=basic-host make demo-app EXAMPLE=system-monitor-server
-
-# Compare against upstream's TS reference server
-make demo-upstream EXAMPLE=system-monitor-server
-
-# Strict parity check (visual baseline + tools/list diff, requires Docker)
-EXAMPLE=system-monitor-server make test-apps-playwright-docker
 ```
+
+Paste `http://localhost:3101/mcp` into MCPJam's server list and connect.
+Then browse `tools/list`, `_meta.ui`, and tool-call payloads on the wire.
+
+### [Optional] You can also do…
+
+- **See the App rendered in basic-host.** Same Go fixture, but driven by
+  basic-host (the canonical reference UI) instead of MCPJam. Opens a
+  browser at `http://localhost:8080`:
+
+  ```bash
+  RENDERER=basic-host make demo-app EXAMPLE=system-monitor-server
+  ```
+
+- **Hit upstream's TS reference server instead.** Useful for comparing
+  the Go fixture's wire surface against the canonical implementation:
+
+  ```bash
+  make demo-upstream EXAMPLE=system-monitor-server
+  ```
+
+  Add `RENDERER=basic-host` to render the upstream TS in basic-host
+  instead of MCPJam.
+
+- **Strict parity check against the mcpkit-Go fixture.** Runs upstream's
+  Playwright suite against the Go binary — wire-level `tools/list` diff
+  + visual PNG gate. Requires Docker:
+
+  ```bash
+  EXAMPLE=system-monitor-server make test-apps-playwright-docker
+  ```
 
 ## Prompts to try
 

--- a/examples/apps/compat/threejs/README.md
+++ b/examples/apps/compat/threejs/README.md
@@ -24,19 +24,44 @@ literally a multi-line JavaScript program.
 
 ## Run it
 
+Boots the mcpkit-Go fixture (`main.go` in this folder) and opens
+[MCPJam Inspector](https://github.com/MCPJam/inspector) so you can poke
+at the protocol surface:
+
 ```bash
-# mcpkit-Go fixture + MCPJam (default — wire-level inspection)
 make demo-app EXAMPLE=threejs-server
-
-# Same Go fixture rendered in basic-host (iframe + bridge JS)
-RENDERER=basic-host make demo-app EXAMPLE=threejs-server
-
-# Compare against upstream's TS reference server
-make demo-upstream EXAMPLE=threejs-server
-
-# Strict parity check (visual baseline + tools/list diff, requires Docker)
-EXAMPLE=threejs-server make test-apps-playwright-docker
 ```
+
+Paste `http://localhost:3101/mcp` into MCPJam's server list and connect.
+Then browse `tools/list`, `_meta.ui`, and tool-call payloads on the wire.
+
+### [Optional] You can also do…
+
+- **See the App rendered in basic-host.** Same Go fixture, but driven by
+  basic-host (the canonical reference UI) instead of MCPJam. Opens a
+  browser at `http://localhost:8080`:
+
+  ```bash
+  RENDERER=basic-host make demo-app EXAMPLE=threejs-server
+  ```
+
+- **Hit upstream's TS reference server instead.** Useful for comparing
+  the Go fixture's wire surface against the canonical implementation:
+
+  ```bash
+  make demo-upstream EXAMPLE=threejs-server
+  ```
+
+  Add `RENDERER=basic-host` to render the upstream TS in basic-host
+  instead of MCPJam.
+
+- **Strict parity check against the mcpkit-Go fixture.** Runs upstream's
+  Playwright suite against the Go binary — wire-level `tools/list` diff
+  + visual PNG gate. Requires Docker:
+
+  ```bash
+  EXAMPLE=threejs-server make test-apps-playwright-docker
+  ```
 
 ## Prompts to try
 

--- a/examples/apps/compat/transcript/README.md
+++ b/examples/apps/compat/transcript/README.md
@@ -16,19 +16,44 @@ meaningful work in the iframe (rather than just rendering a value).
 
 ## Run it
 
+Boots the mcpkit-Go fixture (`main.go` in this folder) and opens
+[MCPJam Inspector](https://github.com/MCPJam/inspector) so you can poke
+at the protocol surface:
+
 ```bash
-# mcpkit-Go fixture + MCPJam (default — wire-level inspection)
 make demo-app EXAMPLE=transcript-server
-
-# Same Go fixture rendered in basic-host (iframe + bridge JS)
-RENDERER=basic-host make demo-app EXAMPLE=transcript-server
-
-# Compare against upstream's TS reference server
-make demo-upstream EXAMPLE=transcript-server
-
-# Strict parity check (visual baseline + tools/list diff, requires Docker)
-EXAMPLE=transcript-server make test-apps-playwright-docker
 ```
+
+Paste `http://localhost:3101/mcp` into MCPJam's server list and connect.
+Then browse `tools/list`, `_meta.ui`, and tool-call payloads on the wire.
+
+### [Optional] You can also do…
+
+- **See the App rendered in basic-host.** Same Go fixture, but driven by
+  basic-host (the canonical reference UI) instead of MCPJam. Opens a
+  browser at `http://localhost:8080`:
+
+  ```bash
+  RENDERER=basic-host make demo-app EXAMPLE=transcript-server
+  ```
+
+- **Hit upstream's TS reference server instead.** Useful for comparing
+  the Go fixture's wire surface against the canonical implementation:
+
+  ```bash
+  make demo-upstream EXAMPLE=transcript-server
+  ```
+
+  Add `RENDERER=basic-host` to render the upstream TS in basic-host
+  instead of MCPJam.
+
+- **Strict parity check against the mcpkit-Go fixture.** Runs upstream's
+  Playwright suite against the Go binary — wire-level `tools/list` diff
+  + visual PNG gate. Requires Docker:
+
+  ```bash
+  EXAMPLE=transcript-server make test-apps-playwright-docker
+  ```
 
 ## Prompts to try
 

--- a/examples/apps/compat/wiki-explorer/README.md
+++ b/examples/apps/compat/wiki-explorer/README.md
@@ -24,19 +24,44 @@ work, not just printing the tool result.
 
 ## Run it
 
+Boots the mcpkit-Go fixture (`main.go` in this folder) and opens
+[MCPJam Inspector](https://github.com/MCPJam/inspector) so you can poke
+at the protocol surface:
+
 ```bash
-# mcpkit-Go fixture + MCPJam (default — wire-level inspection)
 make demo-app EXAMPLE=wiki-explorer-server
-
-# Same Go fixture rendered in basic-host (iframe + bridge JS)
-RENDERER=basic-host make demo-app EXAMPLE=wiki-explorer-server
-
-# Compare against upstream's TS reference server
-make demo-upstream EXAMPLE=wiki-explorer-server
-
-# Strict parity check (visual baseline + tools/list diff, requires Docker)
-EXAMPLE=wiki-explorer-server make test-apps-playwright-docker
 ```
+
+Paste `http://localhost:3101/mcp` into MCPJam's server list and connect.
+Then browse `tools/list`, `_meta.ui`, and tool-call payloads on the wire.
+
+### [Optional] You can also do…
+
+- **See the App rendered in basic-host.** Same Go fixture, but driven by
+  basic-host (the canonical reference UI) instead of MCPJam. Opens a
+  browser at `http://localhost:8080`:
+
+  ```bash
+  RENDERER=basic-host make demo-app EXAMPLE=wiki-explorer-server
+  ```
+
+- **Hit upstream's TS reference server instead.** Useful for comparing
+  the Go fixture's wire surface against the canonical implementation:
+
+  ```bash
+  make demo-upstream EXAMPLE=wiki-explorer-server
+  ```
+
+  Add `RENDERER=basic-host` to render the upstream TS in basic-host
+  instead of MCPJam.
+
+- **Strict parity check against the mcpkit-Go fixture.** Runs upstream's
+  Playwright suite against the Go binary — wire-level `tools/list` diff
+  + visual PNG gate. Requires Docker:
+
+  ```bash
+  EXAMPLE=wiki-explorer-server make test-apps-playwright-docker
+  ```
 
 ## Prompts to try
 


### PR DESCRIPTION
## What changes

Mechanical follow-up to PR 609. The 20 non-vanillajs compat fixture READMEs got the new server/renderer axes there, but as a flat 4-line code block listing every variant equally. This PR rewrites their "## Run it" sections to match `basic-vanillajs/README.md`'s structure — primary command first with one-sentence context, then a `### [Optional] You can also do…` list for the alternatives.

`basic-vanillajs/README.md` is unchanged (it was already in the target shape; this PR was templated against it).

## Reviewer's guide

Read in this order:

1. `examples/apps/compat/basic-vanillajs/README.md` — the template (unchanged in this PR). Skim if you want the structure context.
2. [examples/apps/compat/basic-preact/README.md](https://github.com/panyam/mcpkit/pull/610/files#diff-5c0bc8692240819ac5ea7825219a66f1470acacd052e4d3c312f4b633631cf19) — see the new shape applied. The other 19 are pattern-substituted to the same shape, only the EXAMPLE name varies.

Skim or skip:
- The other 18 fixture READMEs. Same pattern, same prose, different `EXAMPLE=<name>` values.

## Decision log

- **No new commands, no new options, no shipped code touched.** Pure documentation hygiene.
- **The same prose template for all 20.** Tempted to vary per-fixture wording (e.g. mention specific tools, link to multi-tool examples differently). Resisted — uniformity makes the pattern itself the affordance: once a reader knows the shape on one fixture, they know it everywhere. Fixture-specific guidance lives in the surrounding sections (`## Prompts to try`, `## What it shows`, `## What to look at next`).
- **basic-vanillajs's narrative is slightly longer than the new template.** Intentional. It's the rung-1 primer — readers actually stop there to learn the shape. The other 20 use a tighter version of the same skeleton because they're skim-targets per the reading-order ladder.

## Risk / blast radius

- Pure docs. Zero code touched. No runtime impact.

## Before / after

`basic-preact/README.md` before this PR:

```bash
# mcpkit-Go fixture + MCPJam (default — wire-level inspection)
make demo-app EXAMPLE=basic-server-preact

# Same Go fixture rendered in basic-host (iframe + bridge JS)
RENDERER=basic-host make demo-app EXAMPLE=basic-server-preact

# Compare against upstream's TS reference server
make demo-upstream EXAMPLE=basic-server-preact

# Strict parity check (visual baseline + tools/list diff, requires Docker)
EXAMPLE=basic-server-preact make test-apps-playwright-docker
```

After:

> Boots the mcpkit-Go fixture (`main.go` in this folder) and opens [MCPJam Inspector](https://github.com/MCPJam/inspector) so you can poke at the protocol surface:
>
> ```bash
> make demo-app EXAMPLE=basic-server-preact
> ```
>
> Paste `http://localhost:3101/mcp` into MCPJam's server list and connect. Then browse `tools/list`, `_meta.ui`, and tool-call payloads on the wire.
>
> ### [Optional] You can also do…
>
> - **See the App rendered in basic-host.** … `RENDERER=basic-host make demo-app …`
> - **Hit upstream's TS reference server instead.** … `make demo-upstream …`
> - **Strict parity check against the mcpkit-Go fixture.** … `EXAMPLE=… make test-apps-playwright-docker`

## Test plan

- [x] Pattern-match worked cleanly on all 20 fixtures (no WARNs from the substitution script).
- [x] One spot-check confirms the new shape (basic-preact, shown above).
