### PR TITLE
skills: drop mcp-resource-template type per SEP-2640 HEAD removal (614)

### DIFF
--- a/cmd/mcpskills/inspect.go
+++ b/cmd/mcpskills/inspect.go
@@ -79,17 +79,11 @@ Examples:
 
 			for _, e := range idx.Skills {
 				row := inspectEntry{
-					Name:        firstNonEmpty(e.Name, "(template)"),
+					Name:        e.Name,
 					Type:        string(e.Type),
 					URL:         e.URL,
 					Digest:      e.Digest,
 					Description: e.Description,
-				}
-				if e.Type == skills.SkillTypeResourceTemplate {
-					// Templates carry no digest; skip verification.
-					row.Verified = nil
-					report.Entries = append(report.Entries, row)
-					continue
 				}
 				result, verifyErr := sc.ReadAndVerify(e.URL, e.Digest)
 				switch {
@@ -145,9 +139,10 @@ type inspectEntry struct {
 	URL         string `json:"url"`
 	Digest      string `json:"digest,omitempty"`
 	Description string `json:"description,omitempty"`
-	// Verified is nil for template entries (no digest), true on match,
-	// false on mismatch or read failure. Pointer-of-bool keeps the
-	// three-state semantic over the wire and in JSON.
+	// Verified is true on digest match, false on mismatch or read
+	// failure. Pointer-of-bool is retained so a future SEP revision
+	// that re-introduces a digest-less entry type can flow through
+	// without a struct-shape change.
 	Verified *bool  `json:"verified,omitempty"`
 	Error    string `json:"error,omitempty"`
 }
@@ -169,7 +164,7 @@ func renderText(out io.Writer, p *common.Painter, r *inspectReport) error {
 	}
 	for _, e := range r.Entries {
 		marker := p.Dim("·")
-		status := p.Dim("(template, no digest)")
+		status := p.Dim("(no digest)")
 		if e.Verified != nil {
 			if *e.Verified {
 				marker = p.Green("✓")

--- a/conformance/skills/README.md
+++ b/conformance/skills/README.md
@@ -18,8 +18,8 @@ Coverage in this revision:
 - Manifest required at root (negative)
 - Frontmatter required fields: `name`, `description`
 - Index `$schema` URI present
-- Index entry conditional fields (`name` + `digest` required for
-  `skill-md` and `archive`, omitted for `mcp-resource-template`)
+- Index entry required fields: `name` and `digest` for every entry
+  (both `skill-md` and `archive`)
 - Digest format (`sha256:` + 64 lowercase hex)
 - Digest correctness (recompute over the served bytes, compare)
 - Archive safety: reject path traversal, absolute paths, escaping
@@ -30,11 +30,6 @@ Coverage in this revision:
 - `_meta` reverse-domain prefix
 - Host loads by URI alone (no index required)
 - Server exposes `skill://index.json`
-
-Skipped with documented reasons:
-
-- `mcp-resource-template` entries — Provider does not register
-  resource templates yet, tracked separately.
 
 ## Prerequisites
 

--- a/examples/skills/WALKTHROUGH.md
+++ b/examples/skills/WALKTHROUGH.md
@@ -105,7 +105,7 @@ In file mode the list has N entries per skill (one for SKILL.md, one for each su
 
 ### The discovery index
 
-`skill://index.json` is the well-known enumeration resource. It's optional in the SEP (servers MAY decline to expose it) but mcpkit auto-registers it unless `WithoutIndex()` is supplied. The index has a fixed JSON shape: a `$schema` URI pinning the index version and a `skills[]` array where each entry has `type` (`skill-md`, `archive`, or `mcp-resource-template`), `description`, `url`, plus (for `skill-md` and `archive` entries) `name` and `digest`.
+`skill://index.json` is the well-known enumeration resource. It's optional in the SEP (servers MAY decline to expose it) but mcpkit auto-registers it unless `WithoutIndex()` is supplied. The index has a fixed JSON shape: a `$schema` URI pinning the index version and a `skills[]` array where each entry has `type` (`skill-md` or `archive`), `description`, `url`, `name`, and `digest`.
 
 ### Step 3: Read skill://index.json
 

--- a/examples/skills/walkthrough.go
+++ b/examples/skills/walkthrough.go
@@ -123,7 +123,7 @@ func runDemo() {
 		})
 
 	demo.Section("The discovery index",
-		"`skill://index.json` is the well-known enumeration resource. It's optional in the SEP (servers MAY decline to expose it) but mcpkit auto-registers it unless `WithoutIndex()` is supplied. The index has a fixed JSON shape: a `$schema` URI pinning the index version and a `skills[]` array where each entry has `type` (`skill-md`, `archive`, or `mcp-resource-template`), `description`, `url`, plus (for `skill-md` and `archive` entries) `name` and `digest`.",
+		"`skill://index.json` is the well-known enumeration resource. It's optional in the SEP (servers MAY decline to expose it) but mcpkit auto-registers it unless `WithoutIndex()` is supplied. The index has a fixed JSON shape: a `$schema` URI pinning the index version and a `skills[]` array where each entry has `type` (`skill-md` or `archive`), `description`, `url`, `name`, and `digest`.",
 	)
 
 	var indexBody []byte

--- a/ext/skills/types.go
+++ b/ext/skills/types.go
@@ -14,35 +14,33 @@ const (
 	// resource. The archive's URL suffix (.tar.gz or .zip) determines the
 	// expected format.
 	SkillTypeArchive SkillType = "archive"
-
-	// SkillTypeResourceTemplate describes a parameterized skill namespace as
-	// an RFC 6570 URI template. Hosts surface these as interactive discovery
-	// points, not as concrete skills.
-	SkillTypeResourceTemplate SkillType = "mcp-resource-template"
 )
 
 // Valid reports whether t is one of the SkillType values defined by SEP-2640.
+// The previously valid "mcp-resource-template" type was dropped from the SEP
+// on 2026-06-04; entries that carry it are now invalid.
 func (t SkillType) Valid() bool {
 	switch t {
-	case SkillTypeSkillMD, SkillTypeArchive, SkillTypeResourceTemplate:
+	case SkillTypeSkillMD, SkillTypeArchive:
 		return true
 	}
 	return false
 }
 
 // HasManifestFields reports whether entries of this type carry a Name and
-// Digest. The mcp-resource-template type omits both because no concrete
-// SKILL.md is materialized at index time.
+// Digest. After the 2026-06-04 SEP HEAD removal of mcp-resource-template,
+// both surviving types require both fields; the helper is retained for
+// callers that still want to dispatch on the type symbolically.
 func (t SkillType) HasManifestFields() bool {
 	return t == SkillTypeSkillMD || t == SkillTypeArchive
 }
 
 // IndexEntry is a single skill entry in a server's skill://index.json.
 //
-// Per SEP-2640, Name and Digest are required for the skill-md and archive
-// types and omitted for mcp-resource-template. The JSON encoding uses
-// omitempty so unmarshalled documents round-trip cleanly when those fields
-// are absent.
+// Per SEP-2640, Name and Digest are required for both the skill-md and
+// archive types. The JSON encoding keeps `omitempty` on both fields so
+// future spec revisions that re-introduce a manifest-less entry type can
+// be parsed without a struct-shape change.
 type IndexEntry struct {
 	Type        SkillType `json:"type"`
 	Name        string    `json:"name,omitempty"`

--- a/ext/skills/types_test.go
+++ b/ext/skills/types_test.go
@@ -35,11 +35,6 @@ const sepExampleIndex = `{
       "description": "Extract, fill, and assemble PDF documents",
       "url": "skill://pdf-processing.tar.gz",
       "digest": "sha256:c4d5e6f7..."
-    },
-    {
-      "type": "mcp-resource-template",
-      "description": "Per-product documentation skill",
-      "url": "skill://docs/{product}/SKILL.md"
     }
   ]
 }`
@@ -52,8 +47,8 @@ func TestIndex_UnmarshalSEPExample(t *testing.T) {
 	if idx.Schema != skills.IndexSchemaURI {
 		t.Errorf("Schema = %q, want %q", idx.Schema, skills.IndexSchemaURI)
 	}
-	if len(idx.Skills) != 4 {
-		t.Fatalf("Skills count = %d, want 4", len(idx.Skills))
+	if len(idx.Skills) != 3 {
+		t.Fatalf("Skills count = %d, want 3", len(idx.Skills))
 	}
 
 	// Verify each entry's type-specific shape.
@@ -66,7 +61,6 @@ func TestIndex_UnmarshalSEPExample(t *testing.T) {
 		{skills.SkillTypeSkillMD, "git-workflow", "skill://git-workflow/SKILL.md", true},
 		{skills.SkillTypeSkillMD, "refunds", "skill://acme/billing/refunds/SKILL.md", true},
 		{skills.SkillTypeArchive, "pdf-processing", "skill://pdf-processing.tar.gz", true},
-		{skills.SkillTypeResourceTemplate, "", "skill://docs/{product}/SKILL.md", false},
 	}
 	for i, w := range want {
 		got := idx.Skills[i]
@@ -111,23 +105,6 @@ func TestIndexEntry_RoundTrip(t *testing.T) {
 			t.Errorf("entry %d: round-trip mismatch\n  orig = %#v\n  new  = %#v", i, orig.Skills[i], second.Skills[i])
 		}
 	}
-
-	// The mcp-resource-template entry must encode without name or digest
-	// keys (omitempty in practice). Re-encode it individually to assert.
-	tmpl := orig.Skills[3]
-	if tmpl.Type != skills.SkillTypeResourceTemplate {
-		t.Fatalf("test fixture drift: expected template at index 3, got %q", tmpl.Type)
-	}
-	tplBytes, err := json.Marshal(tmpl)
-	if err != nil {
-		t.Fatalf("Marshal template: %v", err)
-	}
-	if strings.Contains(string(tplBytes), `"name"`) {
-		t.Errorf("template entry should omit name: %s", tplBytes)
-	}
-	if strings.Contains(string(tplBytes), `"digest"`) {
-		t.Errorf("template entry should omit digest: %s", tplBytes)
-	}
 }
 
 func TestIndexEntry_Validate(t *testing.T) {
@@ -157,12 +134,9 @@ func TestIndexEntry_Validate(t *testing.T) {
 			},
 		},
 		{
-			name: "valid template",
-			entry: skills.IndexEntry{
-				Type:        skills.SkillTypeResourceTemplate,
-				Description: "per-product docs",
-				URL:         "skill://docs/{product}/SKILL.md",
-			},
+			name:  "removed mcp-resource-template type",
+			entry: skills.IndexEntry{Type: "mcp-resource-template", Description: "x", URL: "y"},
+			want:  skills.ErrUnknownSkillType,
 		},
 		{
 			name:  "unknown type",
@@ -231,11 +205,11 @@ func TestSkillType(t *testing.T) {
 	if !skills.SkillTypeArchive.HasManifestFields() {
 		t.Error("archive should have manifest fields")
 	}
-	if skills.SkillTypeResourceTemplate.HasManifestFields() {
-		t.Error("template should not have manifest fields")
-	}
 	if skills.SkillType("nope").Valid() {
 		t.Error("garbage value should not validate")
+	}
+	if skills.SkillType("mcp-resource-template").Valid() {
+		t.Error("mcp-resource-template was dropped from SEP-2640 HEAD on 2026-06-04; Valid() must return false")
 	}
 }
 


### PR DESCRIPTION
## What changes

SEP-2640 dropped `mcp-resource-template` from the index entry type enum on 2026-06-04 (HEAD commits `fd50cc91` and `556154c0`). The enum is now `skill-md` or `archive` only. This PR removes the constant, prunes the matching tests, drops the now-unreachable inspect branch, fixes the walkthrough prose, and updates the conformance README. Net diff: 28 insertions, 66 deletions. Closes 614.

## Reviewer's guide

Read in this order:

1. [ext/skills/types.go](https://github.com/panyam/mcpkit/pull/617/files#diff-c6a1fd454bc3289de88115aac3e3eb9bdcf381e5e16ffe515d75048fea08d4b8) - start here. The constant goes, `Valid()` and `HasManifestFields()` shrink to the two remaining types, doc comments anchor the 2026-06-04 removal date for future archaeology. `IndexEntry.Name` / `IndexEntry.Digest` keep `omitempty` for forward compatibility.
2. [ext/skills/types_test.go](https://github.com/panyam/mcpkit/pull/617/files#diff-7d61581d8a865503b75567c2d69b80d121deba3a85b0f6aeafd4cd824009e364) - the test acceptance. Prunes the template entry from the SEP fixture (3 entries instead of 4), drops the template-only encoding subtest, and adds a regression assertion that `SkillType("mcp-resource-template").Valid()` returns false plus a Validate-table case that the same string returns `ErrUnknownSkillType`. Net assertion delta: -4 template-specific + 2 new regression = -2 (intentional, tracks spec scope).
3. [cmd/mcpskills/inspect.go](https://github.com/panyam/mcpkit/pull/617/files#diff-bf806b2ef29c8b3bb1c9c37bf83980ac5857538c28eac6fc62af0981ac2801f1) - drop the unreachable `SkillTypeResourceTemplate` branch in the per-entry loop. Switches `inspectEntry.Name` fallback from "(template)" to the entry's literal name, and the text-mode no-Verified status from "(template, no digest)" to "(no digest)". `inspectEntry.Verified` stays `*bool` for the same forward-compat reason as `IndexEntry`.
4. [examples/skills/walkthrough.go](https://github.com/panyam/mcpkit/pull/617/files#diff-94afaa0ca3ed61f670feefe88925e3b5ecfc827cfcdb7612d48a01dd289c10e7) - prose update at the index-shape description. Both remaining types carry name+digest so the paragraph collapses.
5. [examples/skills/WALKTHROUGH.md](https://github.com/panyam/mcpkit/pull/617/files#diff-f7567dfcd105e517415a8fc5aada2b08489ad36774f38681b85f5855a3638884) - regenerated via `go run . --doc=md`. Mechanical.
6. [conformance/skills/README.md](https://github.com/panyam/mcpkit/pull/617/files#diff-c181b18b8aefcf6b80482cbdcf00cecc36f7bde73682c89c0c1c4681fe1d1a0d) - drop the conditional-fields parenthetical and the "tracked separately" bullet that referenced the removed type.

Skim or skip: nothing generated outside `WALKTHROUGH.md`.

## Decision log

- **Drop the `inspect.go` template branch in this PR**, rather than leaving it as a forward-compat hedge. The branch is unreachable after the constant removal — a hedge for "spec might re-add the type" would carry dead code without saving meaningful future work. If the spec does re-add a manifest-less type, re-introducing the branch is a few lines.
- **Keep `omitempty` on `IndexEntry.Name` and `IndexEntry.Digest`**. The wire shape is unchanged: a future spec revision that re-introduces a manifest-less entry type can flow through without a struct shape change. The post-removal `Valid()` would reject it on the read path, which is the right place to enforce spec scope.
- **Anchor the removal date in `types.go` doc comments**. The constant removal is a small grep target; tying the doc to a date plus the commit hashes gives the next person who hits "why doesn't `mcp-resource-template` validate?" a one-line answer.
- **Add a regression test for the removed string**. Without it, a future commit could accidentally re-introduce the constant and silently re-validate. With it, the test fails immediately.

## Risk / blast radius

- Affects: any external caller importing `skills.SkillTypeResourceTemplate` (compile break — correct for a spec-removed type) and any index document that still carries the removed type (parses but fails `Validate()` with `ErrUnknownSkillType`).
- Tests covering this: existing `ext/skills` tests pass; the new regression case fires when the rule slips.
- Be paranoid about: the upstream conformance fork. `modelcontextprotocol/conformance#330` commit `1e50cad` already re-extracted the YAML at the same SEP HEAD, so `make testconf-skills` should stay green. Re-run after the worktree pulls if the fork drifts.

## Before / after

```
$ go test ./ext/skills/... -run TestSkillType -count=1
PASS
ok  	github.com/panyam/mcpkit/ext/skills	0.276s

$ grep -rn "mcp-resource-template\|SkillTypeResourceTemplate" --include="*.go" --include="*.md" .
ext/skills/types.go:20:// The previously valid "mcp-resource-template" type was dropped from the SEP
ext/skills/types.go:31:// Digest. After the 2026-06-04 SEP HEAD removal of mcp-resource-template,
ext/skills/types_test.go:137:			name:  "removed mcp-resource-template type",
ext/skills/types_test.go:138:			entry: skills.IndexEntry{Type: "mcp-resource-template", Description: "x", URL: "y"},
ext/skills/types_test.go:211:	if skills.SkillType("mcp-resource-template").Valid() {
ext/skills/types_test.go:212:		t.Error("mcp-resource-template was dropped from SEP-2640 HEAD on 2026-06-04; Valid() must return false")
```

The six remaining mentions are all intentional: two doc comments anchoring the date, four lines wired to the regression assertion.

## Out of scope (deliberately deferred)

- The indirect `yosida95/uritemplate/v3` dep in `go.mod` (different layer, unrelated to the SEP type).
- `RegisterResourceTemplate` references in `conformance/FIXTURE_AUDIT.md` (those are the generic MCP resource template registration API, separate from the SEP-2640 index entry type).
- Spec history annotations beyond the two anchor lines in `types.go`. `git log -S` covers the rest.

## Test plan

- [x] `make test` (root unit tests) green
- [x] `make test-skills` (ext/skills sub-module) green including the new regression assertion
- [x] `make test-mcpskills` green after dropping the inspect template branch
- [x] `make test-mcpskills-walkthrough` green (the embedded fixture is two-type, so already compatible)
- [x] Red-before-green check: with the pre-change `types.go` restored, `TestSkillType` fails with the recorded regression message, confirming the assertion exercises the contract
- [x] Repo-wide sweep: zero non-intentional `mcp-resource-template` mentions remain
