### PR TITLE
examples/apps/compat: unify README structure across all 21 fixtures + add TEMPLATE.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ test-apps-playwright-all: ## Sweep every registered compat fixture sequentially.
 test-apps-playwright-docker-all: ## --all + --docker. The canonical visual gate across all 21 compat fixtures.
 	uv run scripts/apps_playwright_test.py --docker --all
 
-demo-app: ## Browse a compat fixture interactively. Default: mcpkit-Go server + basic-host (no LLM needed). Override with RENDERER=mcpjam for wire inspection. Usage: make demo-app EXAMPLE=<name>.
+demo-app: ## Browse a compat fixture interactively. Default: mcpkit-Go server + basic-host (no LLM needed). basic-host runs on :8080; open it manually (or pass OPEN=1 to auto-open). Override with RENDERER=mcpjam for wire inspection. Usage: make demo-app EXAMPLE=<name>.
 	EXAMPLE=$(EXAMPLE) SERVER=$${SERVER:-go} RENDERER=$${RENDERER:-basic-host} OPEN=$(OPEN) uv run scripts/apps_demo.py
 
 demo-upstream: ## Browse the upstream TS reference server instead of the Go fixture. Same axes as demo-app. Use this for SKIP examples (lazy-auth-server, video-resource-server, qr-server, say-server) that have no Go drop-in. Usage: make demo-upstream EXAMPLE=<name>.

--- a/examples/apps/compat/README.md
+++ b/examples/apps/compat/README.md
@@ -175,7 +175,17 @@ upstream's TS server at the wire level.
    DOCKER=1 EXAMPLE=<name> make test-apps-playwright   # visual + protocol gate
    EXAMPLE=<name> make test-apps-playwright            # native — `loads app UI` only
    ```
-5. Commit the fixture, the script arm, and the baseline PNG.
+5. Write the fixture's `README.md` from the canonical template:
+   ```bash
+   cp ../../common/TEMPLATE.md <name>/README.md
+   ```
+   Then walk top-to-bottom and replace each `{PLACEHOLDER}`. Strip the
+   HTML-comment author-guidance once you're done. The 6-section structure
+   (What it Shows → Run Pre-Recorded → Or Run Live → Try It Out on
+   basic-host → Try It Out from a Host → What to Try Next) is consistent
+   across every fixture in this folder — `basic-vanillajs/README.md` is
+   the canonical example to crib from.
+6. Commit the fixture, the script arm, the baseline PNG, and the README.
 
 ## Native vs Docker modes
 
@@ -309,8 +319,9 @@ For either `demo-app` or `demo-upstream`:
    `SERVER_PORT` (default 3101).
 4. Start the renderer:
    - `RENDERER=basic-host` (default): start basic-host on `HARNESS_PORT`
-     (default 8080) with `SERVERS` pointing at the MCP server, auto-open
-     the browser (suppress with `OPEN=0`).
+     (default 8080) with `SERVERS` pointing at the MCP server. The browser
+     is **not** auto-opened — open `http://localhost:8080` manually, or
+     pass `OPEN=1` to opt in to auto-open.
    - `RENDERER=mcpjam`: launch `npx -y @mcpjam/inspector@latest`, opens
      its own browser tab. Paste `http://localhost:3101/mcp` into the
      server list.

--- a/examples/apps/compat/basic-preact/README.md
+++ b/examples/apps/compat/basic-preact/README.md
@@ -4,65 +4,61 @@ Rung 2 on the [examples ladder](../README.md#reading-order--examples-ladder).
 Same wire surface as [`basic-vanillajs`](../basic-vanillajs/README.md);
 the iframe is built with Preact instead of vanilla JS.
 
-## What it shows
+## What it Shows
 
-The MCP protocol surface doesn't care how the iframe is built. Tool
-name, schema, resource URI, and `_meta.ui` shape are identical to
-basic-vanillajs — only the HTML payload differs. Demonstrates that
-mcpkit hosts can drive a Preact-based App with no special handling.
+- **Identical wire surface to basic-vanillajs.** Same tool name
+  (`get-time`), same input/output schema, same `ui://get-time/mcp-app.html`
+  resource URI, same `_meta.ui` shape. Only the HTML payload differs.
+- **Preact iframe instead of hand-rolled DOM.** The iframe HTML
+  comes from upstream's `basic-server-preact` example's build
+  output — pre-bundled Preact bundle. The mcpkit-Go fixture serves
+  it verbatim as the resource.
+- **Protocol surface is framework-agnostic.** mcpkit hosts can drive
+  any of the rung-2 fixtures with no special handling — the framework
+  choice never reaches the protocol.
 
-## Run it
+## Run Pre-Recorded
 
 > ▶ **[Play the walkthrough in your browser](https://panyam.github.io/mcpkit/walkthroughs/examples/apps/compat/basic-preact/)** — animated playback of every curl / Go call the walkthrough makes, step-by-step. No clone, no setup.
 
-Boots the mcpkit-Go fixture (`main.go` in this folder) and opens
-[MCPJam Inspector](https://github.com/MCPJam/inspector) so you can poke
-at the protocol surface:
+## Or Run Live
+
+### Start Server
 
 ```bash
 make demo-app EXAMPLE=basic-preact
 ```
 
-Paste `http://localhost:3101/mcp` into MCPJam's server list and connect.
-Then browse `tools/list`, `_meta.ui`, and tool-call payloads on the wire.
+Starts the mcpkit-Go fixture on `http://localhost:3101/mcp` and basic-host on `http://localhost:8080`. (Pass `OPEN=1` to auto-open the browser.)
 
-See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, and the strict Playwright gate.
+## Try It Out on basic-host
 
-## Prompts to try
+Open <http://localhost:8080> in your browser. Then:
 
-Connect to `Basic MCP App Server (Preact)`, then paste any of these:
-
-```
-What's the current server time?
-```
+1. Pick **Basic MCP App Server (Preact)** from the server dropdown.
+2. Pick **get-time** from the tool dropdown, click **Call Tool** with empty input.
+3. The iframe inlines the ISO 8601 timestamp. The App also renders a button — click it and the App calls `get-time` itself via the bridge (no model in the loop).
 
 <a href="screenshots/01-get-time.png" target="_blank"><img src="screenshots/01-get-time.png" alt="basic-preact App rendered in basic-host: Preact-built iframe showing the ISO timestamp from get-time" width="50%"></a>
 
-```
-Get the current time and tell me what day of the week that is.
-```
+## Try It Out from a Host
 
-```
-Use the get-time tool.
-```
+Connect to `http://localhost:3101/mcp` from your favorite MCP host — VS Code, Claude Desktop, [MCPJam Inspector](https://github.com/MCPJam/inspector), or any spec-compliant client.
 
-The model calls `get-time`; the Preact iframe renders the result and
-provides a button to call the tool again from the App side.
+**Prompts to try** (LLM-driven hosts):
 
-### Direct tool call (no LLM needed)
+> "What's the current server time?"
+> "Get the current time and tell me what day of the week that is."
+> "Use the get-time tool."
 
-Same as [basic-vanillajs](../basic-vanillajs/README.md#direct-tool-call-no-llm-needed)
-— select `get-time`, call with empty input, verify
-`structuredContent.time` is an ISO 8601 string.
+The model calls `get-time`; the Preact iframe renders the result and exposes a button that calls the tool again from the App side via the bridge.
 
-## What to look at next
+See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, the strict Playwright gate, and connecting from VS Code / Claude Desktop / other MCP hosts.
 
-- [`basic-vanillajs`](../basic-vanillajs/README.md) — the no-framework
-  baseline.
+## What to Try Next
+
+- [`basic-vanillajs`](../basic-vanillajs/README.md) — the no-framework baseline that proves the protocol surface is the same regardless of iframe stack.
 - Other rung-2 framework variants:
-  [`basic-react`](../basic-react/README.md) ·
-  [`basic-solid`](../basic-solid/README.md) ·
-  [`basic-svelte`](../basic-svelte/README.md) ·
-  [`basic-vue`](../basic-vue/README.md).
-- [`quickstart`](../quickstart/README.md) — same `get-time` tool, but
-  upstream's "quickstart" template (default build setup).
+  [`basic-react`](../basic-react/README.md) · [`basic-solid`](../basic-solid/README.md) · [`basic-svelte`](../basic-svelte/README.md) · [`basic-vue`](../basic-vue/README.md).
+- [`quickstart`](../quickstart/README.md) — same `get-time` tool, but upstream's "quickstart" template (default scaffolded build setup).
+- See [`main.go`](main.go) — fixture is ~60 lines.

--- a/examples/apps/compat/basic-react/README.md
+++ b/examples/apps/compat/basic-react/README.md
@@ -2,67 +2,63 @@
 
 Rung 2 on the [examples ladder](../README.md#reading-order--examples-ladder).
 Same wire surface as [`basic-vanillajs`](../basic-vanillajs/README.md);
-the iframe is built with React.
+the iframe is built with React instead of vanilla JS.
 
-## What it shows
+## What it Shows
 
-The MCP protocol surface doesn't care how the iframe is built. Tool
-name, schema, resource URI, and `_meta.ui` shape are identical to
-basic-vanillajs — only the HTML payload differs. Demonstrates that
-mcpkit hosts can drive a React-based App with no special handling.
+- **Identical wire surface to basic-vanillajs.** Same tool name
+  (`get-time`), same input/output schema, same `ui://get-time/mcp-app.html`
+  resource URI, same `_meta.ui` shape. Only the HTML payload differs.
+- **React iframe instead of hand-rolled DOM.** The iframe HTML
+  comes from upstream's `basic-server-react` example's build
+  output — pre-bundled React bundle. The mcpkit-Go fixture serves
+  it verbatim as the resource.
+- **Protocol surface is framework-agnostic.** mcpkit hosts can drive
+  any of the rung-2 fixtures with no special handling — the framework
+  choice never reaches the protocol.
 
-## Run it
+## Run Pre-Recorded
 
 > ▶ **[Play the walkthrough in your browser](https://panyam.github.io/mcpkit/walkthroughs/examples/apps/compat/basic-react/)** — animated playback of every curl / Go call the walkthrough makes, step-by-step. No clone, no setup.
 
-Boots the mcpkit-Go fixture (`main.go` in this folder) and opens
-[MCPJam Inspector](https://github.com/MCPJam/inspector) so you can poke
-at the protocol surface:
+## Or Run Live
+
+### Start Server
 
 ```bash
 make demo-app EXAMPLE=basic-react
 ```
 
-Paste `http://localhost:3101/mcp` into MCPJam's server list and connect.
-Then browse `tools/list`, `_meta.ui`, and tool-call payloads on the wire.
+Starts the mcpkit-Go fixture on `http://localhost:3101/mcp` and basic-host on `http://localhost:8080`. (Pass `OPEN=1` to auto-open the browser.)
 
-See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, and the strict Playwright gate.
+## Try It Out on basic-host
 
-## Prompts to try
+Open <http://localhost:8080> in your browser. Then:
 
-Connect to `Basic MCP App Server (React)`, then paste any of these:
-
-```
-What's the current server time?
-```
+1. Pick **Basic MCP App Server (React)** from the server dropdown.
+2. Pick **get-time** from the tool dropdown, click **Call Tool** with empty input.
+3. The iframe inlines the ISO 8601 timestamp. The App also renders a button — click it and the App calls `get-time` itself via the bridge (no model in the loop).
 
 <a href="screenshots/01-get-time.png" target="_blank"><img src="screenshots/01-get-time.png" alt="basic-react App rendered in basic-host: React-built iframe showing the ISO timestamp from get-time" width="50%"></a>
 
-```
-Get the current time and tell me what day of the week that is.
-```
+## Try It Out from a Host
 
-```
-Use the get-time tool.
-```
+Connect to `http://localhost:3101/mcp` from your favorite MCP host — VS Code, Claude Desktop, [MCPJam Inspector](https://github.com/MCPJam/inspector), or any spec-compliant client.
 
-The model calls `get-time`; the React iframe renders the result and
-provides a button to call the tool again from the App side.
+**Prompts to try** (LLM-driven hosts):
 
-### Direct tool call (no LLM needed)
+> "What's the current server time?"
+> "Get the current time and tell me what day of the week that is."
+> "Use the get-time tool."
 
-Same as [basic-vanillajs](../basic-vanillajs/README.md#direct-tool-call-no-llm-needed)
-— select `get-time`, call with empty input, verify
-`structuredContent.time` is an ISO 8601 string.
+The model calls `get-time`; the React iframe renders the result and exposes a button that calls the tool again from the App side via the bridge.
 
-## What to look at next
+See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, the strict Playwright gate, and connecting from VS Code / Claude Desktop / other MCP hosts.
 
-- [`basic-vanillajs`](../basic-vanillajs/README.md) — the no-framework
-  baseline.
+## What to Try Next
+
+- [`basic-vanillajs`](../basic-vanillajs/README.md) — the no-framework baseline that proves the protocol surface is the same regardless of iframe stack.
 - Other rung-2 framework variants:
-  [`basic-preact`](../basic-preact/README.md) ·
-  [`basic-solid`](../basic-solid/README.md) ·
-  [`basic-svelte`](../basic-svelte/README.md) ·
-  [`basic-vue`](../basic-vue/README.md).
-- [`quickstart`](../quickstart/README.md) — same `get-time` tool, but
-  upstream's "quickstart" template (default build setup).
+  [`basic-preact`](../basic-preact/README.md) · [`basic-solid`](../basic-solid/README.md) · [`basic-svelte`](../basic-svelte/README.md) · [`basic-vue`](../basic-vue/README.md).
+- [`quickstart`](../quickstart/README.md) — same `get-time` tool, but upstream's "quickstart" template (default scaffolded build setup).
+- See [`main.go`](main.go) — fixture is ~60 lines.

--- a/examples/apps/compat/basic-solid/README.md
+++ b/examples/apps/compat/basic-solid/README.md
@@ -2,68 +2,63 @@
 
 Rung 2 on the [examples ladder](../README.md#reading-order--examples-ladder).
 Same wire surface as [`basic-vanillajs`](../basic-vanillajs/README.md);
-the iframe is built with Solid (fine-grained reactivity, no virtual
-DOM).
+the iframe is built with Solid instead of vanilla JS.
 
-## What it shows
+## What it Shows
 
-The MCP protocol surface doesn't care how the iframe is built. Tool
-name, schema, resource URI, and `_meta.ui` shape are identical to
-basic-vanillajs — only the HTML payload differs. Demonstrates that
-mcpkit hosts can drive a Solid-based App with no special handling.
+- **Identical wire surface to basic-vanillajs.** Same tool name
+  (`get-time`), same input/output schema, same `ui://get-time/mcp-app.html`
+  resource URI, same `_meta.ui` shape. Only the HTML payload differs.
+- **Solid iframe instead of hand-rolled DOM.** The iframe HTML
+  comes from upstream's `basic-server-solid` example's build
+  output — pre-bundled Solid bundle. The mcpkit-Go fixture serves
+  it verbatim as the resource.
+- **Protocol surface is framework-agnostic.** mcpkit hosts can drive
+  any of the rung-2 fixtures with no special handling — the framework
+  choice never reaches the protocol.
 
-## Run it
+## Run Pre-Recorded
 
 > ▶ **[Play the walkthrough in your browser](https://panyam.github.io/mcpkit/walkthroughs/examples/apps/compat/basic-solid/)** — animated playback of every curl / Go call the walkthrough makes, step-by-step. No clone, no setup.
 
-Boots the mcpkit-Go fixture (`main.go` in this folder) and opens
-[MCPJam Inspector](https://github.com/MCPJam/inspector) so you can poke
-at the protocol surface:
+## Or Run Live
+
+### Start Server
 
 ```bash
 make demo-app EXAMPLE=basic-solid
 ```
 
-Paste `http://localhost:3101/mcp` into MCPJam's server list and connect.
-Then browse `tools/list`, `_meta.ui`, and tool-call payloads on the wire.
+Starts the mcpkit-Go fixture on `http://localhost:3101/mcp` and basic-host on `http://localhost:8080`. (Pass `OPEN=1` to auto-open the browser.)
 
-See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, and the strict Playwright gate.
+## Try It Out on basic-host
 
-## Prompts to try
+Open <http://localhost:8080> in your browser. Then:
 
-Connect to `Basic MCP App Server (Solid)`, then paste any of these:
-
-```
-What's the current server time?
-```
+1. Pick **Basic MCP App Server (Solid)** from the server dropdown.
+2. Pick **get-time** from the tool dropdown, click **Call Tool** with empty input.
+3. The iframe inlines the ISO 8601 timestamp. The App also renders a button — click it and the App calls `get-time` itself via the bridge (no model in the loop).
 
 <a href="screenshots/01-get-time.png" target="_blank"><img src="screenshots/01-get-time.png" alt="basic-solid App rendered in basic-host: Solid-built iframe showing the ISO timestamp from get-time" width="50%"></a>
 
-```
-Get the current time and tell me what day of the week that is.
-```
+## Try It Out from a Host
 
-```
-Use the get-time tool.
-```
+Connect to `http://localhost:3101/mcp` from your favorite MCP host — VS Code, Claude Desktop, [MCPJam Inspector](https://github.com/MCPJam/inspector), or any spec-compliant client.
 
-The model calls `get-time`; the Solid iframe renders the result and
-provides a button to call the tool again from the App side.
+**Prompts to try** (LLM-driven hosts):
 
-### Direct tool call (no LLM needed)
+> "What's the current server time?"
+> "Get the current time and tell me what day of the week that is."
+> "Use the get-time tool."
 
-Same as [basic-vanillajs](../basic-vanillajs/README.md#direct-tool-call-no-llm-needed)
-— select `get-time`, call with empty input, verify
-`structuredContent.time` is an ISO 8601 string.
+The model calls `get-time`; the Solid iframe renders the result and exposes a button that calls the tool again from the App side via the bridge.
 
-## What to look at next
+See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, the strict Playwright gate, and connecting from VS Code / Claude Desktop / other MCP hosts.
 
-- [`basic-vanillajs`](../basic-vanillajs/README.md) — the no-framework
-  baseline.
+## What to Try Next
+
+- [`basic-vanillajs`](../basic-vanillajs/README.md) — the no-framework baseline that proves the protocol surface is the same regardless of iframe stack.
 - Other rung-2 framework variants:
-  [`basic-preact`](../basic-preact/README.md) ·
-  [`basic-react`](../basic-react/README.md) ·
-  [`basic-svelte`](../basic-svelte/README.md) ·
-  [`basic-vue`](../basic-vue/README.md).
-- [`quickstart`](../quickstart/README.md) — same `get-time` tool, but
-  upstream's "quickstart" template (default build setup).
+  [`basic-preact`](../basic-preact/README.md) · [`basic-react`](../basic-react/README.md) · [`basic-svelte`](../basic-svelte/README.md) · [`basic-vue`](../basic-vue/README.md).
+- [`quickstart`](../quickstart/README.md) — same `get-time` tool, but upstream's "quickstart" template (default scaffolded build setup).
+- See [`main.go`](main.go) — fixture is ~60 lines.

--- a/examples/apps/compat/basic-svelte/README.md
+++ b/examples/apps/compat/basic-svelte/README.md
@@ -2,67 +2,63 @@
 
 Rung 2 on the [examples ladder](../README.md#reading-order--examples-ladder).
 Same wire surface as [`basic-vanillajs`](../basic-vanillajs/README.md);
-the iframe is built with Svelte (compiled at build time, no runtime).
+the iframe is built with Svelte instead of vanilla JS.
 
-## What it shows
+## What it Shows
 
-The MCP protocol surface doesn't care how the iframe is built. Tool
-name, schema, resource URI, and `_meta.ui` shape are identical to
-basic-vanillajs — only the HTML payload differs. Demonstrates that
-mcpkit hosts can drive a Svelte-based App with no special handling.
+- **Identical wire surface to basic-vanillajs.** Same tool name
+  (`get-time`), same input/output schema, same `ui://get-time/mcp-app.html`
+  resource URI, same `_meta.ui` shape. Only the HTML payload differs.
+- **Svelte iframe instead of hand-rolled DOM.** The iframe HTML
+  comes from upstream's `basic-server-svelte` example's build
+  output — pre-bundled Svelte bundle. The mcpkit-Go fixture serves
+  it verbatim as the resource.
+- **Protocol surface is framework-agnostic.** mcpkit hosts can drive
+  any of the rung-2 fixtures with no special handling — the framework
+  choice never reaches the protocol.
 
-## Run it
+## Run Pre-Recorded
 
 > ▶ **[Play the walkthrough in your browser](https://panyam.github.io/mcpkit/walkthroughs/examples/apps/compat/basic-svelte/)** — animated playback of every curl / Go call the walkthrough makes, step-by-step. No clone, no setup.
 
-Boots the mcpkit-Go fixture (`main.go` in this folder) and opens
-[MCPJam Inspector](https://github.com/MCPJam/inspector) so you can poke
-at the protocol surface:
+## Or Run Live
+
+### Start Server
 
 ```bash
 make demo-app EXAMPLE=basic-svelte
 ```
 
-Paste `http://localhost:3101/mcp` into MCPJam's server list and connect.
-Then browse `tools/list`, `_meta.ui`, and tool-call payloads on the wire.
+Starts the mcpkit-Go fixture on `http://localhost:3101/mcp` and basic-host on `http://localhost:8080`. (Pass `OPEN=1` to auto-open the browser.)
 
-See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, and the strict Playwright gate.
+## Try It Out on basic-host
 
-## Prompts to try
+Open <http://localhost:8080> in your browser. Then:
 
-Connect to `Basic MCP App Server (Svelte)`, then paste any of these:
-
-```
-What's the current server time?
-```
+1. Pick **Basic MCP App Server (Svelte)** from the server dropdown.
+2. Pick **get-time** from the tool dropdown, click **Call Tool** with empty input.
+3. The iframe inlines the ISO 8601 timestamp. The App also renders a button — click it and the App calls `get-time` itself via the bridge (no model in the loop).
 
 <a href="screenshots/01-get-time.png" target="_blank"><img src="screenshots/01-get-time.png" alt="basic-svelte App rendered in basic-host: Svelte-built iframe showing the ISO timestamp from get-time" width="50%"></a>
 
-```
-Get the current time and tell me what day of the week that is.
-```
+## Try It Out from a Host
 
-```
-Use the get-time tool.
-```
+Connect to `http://localhost:3101/mcp` from your favorite MCP host — VS Code, Claude Desktop, [MCPJam Inspector](https://github.com/MCPJam/inspector), or any spec-compliant client.
 
-The model calls `get-time`; the Svelte iframe renders the result and
-provides a button to call the tool again from the App side.
+**Prompts to try** (LLM-driven hosts):
 
-### Direct tool call (no LLM needed)
+> "What's the current server time?"
+> "Get the current time and tell me what day of the week that is."
+> "Use the get-time tool."
 
-Same as [basic-vanillajs](../basic-vanillajs/README.md#direct-tool-call-no-llm-needed)
-— select `get-time`, call with empty input, verify
-`structuredContent.time` is an ISO 8601 string.
+The model calls `get-time`; the Svelte iframe renders the result and exposes a button that calls the tool again from the App side via the bridge.
 
-## What to look at next
+See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, the strict Playwright gate, and connecting from VS Code / Claude Desktop / other MCP hosts.
 
-- [`basic-vanillajs`](../basic-vanillajs/README.md) — the no-framework
-  baseline.
+## What to Try Next
+
+- [`basic-vanillajs`](../basic-vanillajs/README.md) — the no-framework baseline that proves the protocol surface is the same regardless of iframe stack.
 - Other rung-2 framework variants:
-  [`basic-preact`](../basic-preact/README.md) ·
-  [`basic-react`](../basic-react/README.md) ·
-  [`basic-solid`](../basic-solid/README.md) ·
-  [`basic-vue`](../basic-vue/README.md).
-- [`quickstart`](../quickstart/README.md) — same `get-time` tool, but
-  upstream's "quickstart" template (default build setup).
+  [`basic-preact`](../basic-preact/README.md) · [`basic-react`](../basic-react/README.md) · [`basic-solid`](../basic-solid/README.md) · [`basic-vue`](../basic-vue/README.md).
+- [`quickstart`](../quickstart/README.md) — same `get-time` tool, but upstream's "quickstart" template (default scaffolded build setup).
+- See [`main.go`](main.go) — fixture is ~60 lines.

--- a/examples/apps/compat/basic-vanillajs/README.md
+++ b/examples/apps/compat/basic-vanillajs/README.md
@@ -4,7 +4,7 @@ The simplest fixture in [`examples/apps/compat`](../) — one tool, one
 resource, vanilla-JS iframe. Start here if you're new to the
 host ↔ server ↔ App-iframe round trip.
 
-## What it shows
+## What it Shows
 
 - **One tool** — `get-time` returns the current server time as an
   ISO 8601 string. Typed handler (`struct{}` input, `getTimeOutput`
@@ -18,47 +18,45 @@ host ↔ server ↔ App-iframe round trip.
   (`basic-preact`, `basic-react`, ...) plug Preact / React / Solid /
   Svelte / Vue behind the same wire.
 
-## Run it
+## Run Pre-Recorded
 
 > ▶ **[Play the walkthrough in your browser](https://panyam.github.io/mcpkit/walkthroughs/examples/apps/compat/basic-vanillajs/)** — animated playback of every curl / Go call the walkthrough makes, step-by-step. No clone, no setup.
 
-Boots the mcpkit-Go fixture (`main.go` in this folder) inside upstream's
-`basic-host` so you can see the App render in a real browser. **No LLM
-required** — the App's bridge JS calls `get-time` on its own and the
-result is inlined into the page:
+## Or Run Live
+
+### Start Server
 
 ```bash
 make demo-app EXAMPLE=basic-vanillajs
 ```
 
-A browser opens at `http://localhost:8080`. First-touch flow:
+Starts the mcpkit-Go fixture on `http://localhost:3101/mcp` and basic-host on `http://localhost:8080`. (Pass `OPEN=1` to auto-open the browser.)
+
+## Try It Out on basic-host
+
+Open <http://localhost:8080> in your browser. Then:
 
 1. Pick **Basic MCP App Server (Vanilla JS)** from the server dropdown.
-2. Pick **get-time** from the tool dropdown, click **Call Tool** with
-   empty input.
-3. The iframe inlines the ISO 8601 timestamp. The App also renders a
-   button — click it and the App calls `get-time` itself via the bridge
-   (no model in the loop).
+2. Pick **get-time** from the tool dropdown, click **Call Tool** with empty input.
+3. The iframe inlines the ISO 8601 timestamp. The App also renders a button — click it and the App calls `get-time` itself via the bridge (no model in the loop).
 
 <a href="screenshots/01-get-time.png" target="_blank"><img src="screenshots/01-get-time.png" alt="basic-vanillajs App rendered in basic-host: iframe with a button showing the ISO timestamp returned by get-time" width="50%"></a>
 
+## Try It Out from a Host
+
+Connect to `http://localhost:3101/mcp` from your favorite MCP host — VS Code, Claude Desktop, [MCPJam Inspector](https://github.com/MCPJam/inspector), or any spec-compliant client.
+
+**Prompts to try** (LLM-driven hosts):
+
+> "What's the current server time?"
+> "Use the get-time tool."
+
+The model calls `get-time`; the iframe renders the result.
+
 See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, the strict Playwright gate, and connecting from VS Code / Claude Desktop / other MCP hosts.
 
-### Verify the wire shape (no LLM needed)
+## What to Try Next
 
-Useful for spot-checking what the Go fixture puts on the wire vs. what the iframe reads:
-
-| What | How | What you should see |
-|---|---|---|
-| Smoke test the tool | Call `get-time` with empty input (basic-host or MCPJam) | Tool result `structuredContent`: `{"time": "2026-…Z"}` — same shape the iframe inlines |
-| Check `_meta.ui.resourceUri` | Expand the tool's `_meta` field in `tools/list` | `{"ui": {"resourceUri": "ui://get-time/mcp-app.html"}, "ui/resourceUri": "ui://get-time/mcp-app.html"}` — both the nested and flat forms are emitted for backward compat |
-
-## What to look at next
-
-- Move up the [examples ladder](../README.md#reading-order--examples-ladder) — rung 2
-  shows the same shape behind frameworks; rung 3 onwards introduces
-  richer payloads.
-- Compare upstream's TS server side-by-side: `make demo-upstream
-  EXAMPLE=basic-vanillajs` runs the TS one; the visual + wire
-  surface should be identical.
+- Move up the [examples ladder](../README.md#reading-order--examples-ladder) — rung 2 (`basic-preact`, `basic-react`, `basic-solid`, `basic-svelte`, `basic-vue`) shows the same shape behind frameworks; rung 3 onwards introduces richer payloads.
+- Compare upstream's TS server side-by-side: `make demo-upstream EXAMPLE=basic-vanillajs` runs the TS one; the visual + wire surface should be identical.
 - See [`main.go`](main.go) — fixture is ~60 lines.

--- a/examples/apps/compat/basic-vue/README.md
+++ b/examples/apps/compat/basic-vue/README.md
@@ -2,67 +2,63 @@
 
 Rung 2 on the [examples ladder](../README.md#reading-order--examples-ladder).
 Same wire surface as [`basic-vanillajs`](../basic-vanillajs/README.md);
-the iframe is built with Vue.
+the iframe is built with Vue instead of vanilla JS.
 
-## What it shows
+## What it Shows
 
-The MCP protocol surface doesn't care how the iframe is built. Tool
-name, schema, resource URI, and `_meta.ui` shape are identical to
-basic-vanillajs — only the HTML payload differs. Demonstrates that
-mcpkit hosts can drive a Vue-based App with no special handling.
+- **Identical wire surface to basic-vanillajs.** Same tool name
+  (`get-time`), same input/output schema, same `ui://get-time/mcp-app.html`
+  resource URI, same `_meta.ui` shape. Only the HTML payload differs.
+- **Vue iframe instead of hand-rolled DOM.** The iframe HTML
+  comes from upstream's `basic-server-vue` example's build
+  output — pre-bundled Vue bundle. The mcpkit-Go fixture serves
+  it verbatim as the resource.
+- **Protocol surface is framework-agnostic.** mcpkit hosts can drive
+  any of the rung-2 fixtures with no special handling — the framework
+  choice never reaches the protocol.
 
-## Run it
+## Run Pre-Recorded
 
 > ▶ **[Play the walkthrough in your browser](https://panyam.github.io/mcpkit/walkthroughs/examples/apps/compat/basic-vue/)** — animated playback of every curl / Go call the walkthrough makes, step-by-step. No clone, no setup.
 
-Boots the mcpkit-Go fixture (`main.go` in this folder) and opens
-[MCPJam Inspector](https://github.com/MCPJam/inspector) so you can poke
-at the protocol surface:
+## Or Run Live
+
+### Start Server
 
 ```bash
 make demo-app EXAMPLE=basic-vue
 ```
 
-Paste `http://localhost:3101/mcp` into MCPJam's server list and connect.
-Then browse `tools/list`, `_meta.ui`, and tool-call payloads on the wire.
+Starts the mcpkit-Go fixture on `http://localhost:3101/mcp` and basic-host on `http://localhost:8080`. (Pass `OPEN=1` to auto-open the browser.)
 
-See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, and the strict Playwright gate.
+## Try It Out on basic-host
 
-## Prompts to try
+Open <http://localhost:8080> in your browser. Then:
 
-Connect to `Basic MCP App Server (Vue)`, then paste any of these:
-
-```
-What's the current server time?
-```
+1. Pick **Basic MCP App Server (Vue)** from the server dropdown.
+2. Pick **get-time** from the tool dropdown, click **Call Tool** with empty input.
+3. The iframe inlines the ISO 8601 timestamp. The App also renders a button — click it and the App calls `get-time` itself via the bridge (no model in the loop).
 
 <a href="screenshots/01-get-time.png" target="_blank"><img src="screenshots/01-get-time.png" alt="basic-vue App rendered in basic-host: Vue-built iframe showing the ISO timestamp from get-time" width="50%"></a>
 
-```
-Get the current time and tell me what day of the week that is.
-```
+## Try It Out from a Host
 
-```
-Use the get-time tool.
-```
+Connect to `http://localhost:3101/mcp` from your favorite MCP host — VS Code, Claude Desktop, [MCPJam Inspector](https://github.com/MCPJam/inspector), or any spec-compliant client.
 
-The model calls `get-time`; the Vue iframe renders the result and
-provides a button to call the tool again from the App side.
+**Prompts to try** (LLM-driven hosts):
 
-### Direct tool call (no LLM needed)
+> "What's the current server time?"
+> "Get the current time and tell me what day of the week that is."
+> "Use the get-time tool."
 
-Same as [basic-vanillajs](../basic-vanillajs/README.md#direct-tool-call-no-llm-needed)
-— select `get-time`, call with empty input, verify
-`structuredContent.time` is an ISO 8601 string.
+The model calls `get-time`; the Vue iframe renders the result and exposes a button that calls the tool again from the App side via the bridge.
 
-## What to look at next
+See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, the strict Playwright gate, and connecting from VS Code / Claude Desktop / other MCP hosts.
 
-- [`basic-vanillajs`](../basic-vanillajs/README.md) — the no-framework
-  baseline.
+## What to Try Next
+
+- [`basic-vanillajs`](../basic-vanillajs/README.md) — the no-framework baseline that proves the protocol surface is the same regardless of iframe stack.
 - Other rung-2 framework variants:
-  [`basic-preact`](../basic-preact/README.md) ·
-  [`basic-react`](../basic-react/README.md) ·
-  [`basic-solid`](../basic-solid/README.md) ·
-  [`basic-svelte`](../basic-svelte/README.md).
-- [`quickstart`](../quickstart/README.md) — same `get-time` tool, but
-  upstream's "quickstart" template (default build setup).
+  [`basic-preact`](../basic-preact/README.md) · [`basic-react`](../basic-react/README.md) · [`basic-solid`](../basic-solid/README.md) · [`basic-svelte`](../basic-svelte/README.md).
+- [`quickstart`](../quickstart/README.md) — same `get-time` tool, but upstream's "quickstart" template (default scaffolded build setup).
+- See [`main.go`](main.go) — fixture is ~60 lines.

--- a/examples/apps/compat/budget-allocator/README.md
+++ b/examples/apps/compat/budget-allocator/README.md
@@ -6,7 +6,7 @@ with multi-month history and stage benchmarks). First fixture where
 reflection of nested Go structs + maps produces the matching shape
 without override.
 
-## What it shows
+## What it Shows
 
 - **Multi-level nested output.** `get-budget-data` returns a Budget
   Config (categories + presets) plus Analytics (24 months of
@@ -16,19 +16,19 @@ without override.
 - **No override needed.** Standard struct tags get this right. Sits
   in the sweet spot of what reflection can handle.
 
-## Run it
+## Or Run Live
 
-Boots the mcpkit-Go fixture (`main.go` in this folder) inside upstream's
-`basic-host` so you can see the App render in a real browser. **No LLM
-required** — the App's bridge JS calls `get-budget-data` on its own and
-all interaction (sliders, stage switcher, benchmark comparison) goes
-through the same MCP wire:
+### Start Server
 
 ```bash
 make demo-app EXAMPLE=budget-allocator
 ```
 
-A browser opens at `http://localhost:8080`. First-touch flow:
+Starts the mcpkit-Go fixture on `http://localhost:3101/mcp` and basic-host on `http://localhost:8080`. (Pass `OPEN=1` to auto-open the browser.)
+
+## Try It Out on basic-host
+
+Open <http://localhost:8080> in your browser. Then:
 
 1. Pick **Budget Allocator Server** from the server dropdown.
 2. Pick **get-budget-data** from the tool dropdown, click **Call Tool**
@@ -42,19 +42,13 @@ A browser opens at `http://localhost:8080`. First-touch flow:
 
 <a href="screenshots/03-series-a-benchmark.png" target="_blank"><img src="screenshots/03-series-a-benchmark.png" alt="Budget Allocator iframe showing benchmark comparison for Series A stage with per-category percentile bands" width="50%"></a>
 
+## Try It Out from a Host
+
+Connect to `http://localhost:3101/mcp` from your favorite MCP host — VS Code, Claude Desktop, [MCPJam Inspector](https://github.com/MCPJam/inspector), or any spec-compliant client.
+
 See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, the strict Playwright gate, and connecting from VS Code / Claude Desktop / other MCP hosts.
 
-### Verify the wire shape (no LLM needed)
-
-Useful for spot-checking what the Go fixture puts on the wire vs. what
-the iframe reads:
-
-| What | How | What you should see |
-|---|---|---|
-| Smoke test | Call `get-budget-data` with empty input (basic-host or MCPJam) | Tool result `structuredContent`: `{"config": {"categories": [...5 entries], "presetBudgets": [50000, 100000, 250000, 500000], "defaultBudget": 100000, "currency": "USD", "currencySymbol": "$"}, "analytics": {"history": [...24 months], "benchmarks": [...4 stages], "stages": ["Seed", "Series A", "Series B", "Growth"], "defaultStage": "Series A"}}` |
-| Verify the nested shape | Expand `outputSchema.properties.analytics.properties.history.items` in MCPJam | Nested item schema with month + per-category allocations — reflected from the Go struct, no override |
-
-## What to look at next
+## What to Try Next
 
 - [`scenario-modeler`](../scenario-modeler/README.md) — rung-4
   sibling; adds a nullable field at depth that reflection alone

--- a/examples/apps/compat/cohort-heatmap/README.md
+++ b/examples/apps/compat/cohort-heatmap/README.md
@@ -4,7 +4,7 @@ Rung 4 on the [examples ladder](../README.md#reading-order--examples-ladder).
 One tool, nested retention data. The iframe renders a classic
 cohort-retention heatmap.
 
-## What it shows
+## What it Shows
 
 - **Retention cohort data.** `get-cohort-data` returns rows of
   cohorts and their retention percentages over time periods. Each
@@ -16,56 +16,50 @@ cohort-retention heatmap.
   normalizes these (PR 549) so the fixture uses idiomatic Go types
   and still passes.
 
-## Run it
+## Or Run Live
 
-Boots the mcpkit-Go fixture (`main.go` in this folder) and opens
-[MCPJam Inspector](https://github.com/MCPJam/inspector) so you can poke
-at the protocol surface:
+### Start Server
 
 ```bash
 make demo-app EXAMPLE=cohort-heatmap
 ```
 
-Paste `http://localhost:3101/mcp` into MCPJam's server list and connect.
-Then browse `tools/list`, `_meta.ui`, and tool-call payloads on the wire.
+Starts the mcpkit-Go fixture on `http://localhost:3101/mcp` and basic-host on `http://localhost:8080`. (Pass `OPEN=1` to auto-open the browser.)
 
-See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, and the strict Playwright gate.
+## Try It Out on basic-host
 
-## Prompts to try
+Open <http://localhost:8080> in your browser. Then:
 
-Connect to `Cohort Heatmap Server`, then paste any of these:
-
-```
-Show me a cohort retention heatmap.
-```
+1. Pick **Cohort Heatmap Server** from the server dropdown.
+2. Pick **get-cohort-data** from the tool dropdown, click **Call Tool**.
+3. The iframe renders the result; interact with it directly to drive subsequent tool calls (no model in the loop).
 
 <a href="screenshots/01-default-heatmap.png" target="_blank"><img src="screenshots/01-default-heatmap.png" alt="Cohort Heatmap App: iframe shows the full retention matrix with cohorts on one axis, time-period columns on the other, color-graded retention percentages" width="50%"></a>
 
-```
-What's my user retention by signup month?
-```
+## Try It Out from a Host
 
-```
-Display the cohort analysis dashboard.
-```
+Connect to `http://localhost:3101/mcp` from your favorite MCP host — VS Code, Claude Desktop, [MCPJam Inspector](https://github.com/MCPJam/inspector), or any spec-compliant client.
 
-```
-How is retention looking month-over-month for the last six cohorts?
-```
+**Prompts to try** (LLM-driven hosts):
 
-<a href="screenshots/02-recent-cohorts.png" target="_blank"><img src="screenshots/02-recent-cohorts.png" alt="Cohort Heatmap iframe filtered to the last six cohorts; the color gradient makes the retention dropoff visible at a glance" width="50%"></a>
+> "Show me a cohort retention heatmap."
+> "What's my user retention by signup month?"
+> "Display the cohort analysis dashboard."
+> "How is retention looking month-over-month for the last six cohorts?"
 
 The model calls `get-cohort-data`; the iframe renders the heatmap
 with cohorts on one axis, time periods on the other.
 
-### Direct tool call (no LLM needed)
+**Verify the wire shape** (no LLM needed):
 
 | What | How | What you should see |
 |---|---|---|
 | Smoke test | Select `get-cohort-data`, call with empty input | Tool result: nested cohort × period retention data in `structuredContent` |
 | Iframe renders the heatmap | Same call, scroll up | Color-graded matrix in the App iframe |
 
-## What to look at next
+See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, the strict Playwright gate, and connecting from VS Code / Claude Desktop / other MCP hosts.
+
+## What to Try Next
 
 - [`customer-segmentation`](../customer-segmentation/README.md) —
   rung-4 sibling, different analytical shape.

--- a/examples/apps/compat/customer-segmentation/README.md
+++ b/examples/apps/compat/customer-segmentation/README.md
@@ -4,7 +4,7 @@ Rung 4 on the [examples ladder](../README.md#reading-order--examples-ladder).
 One tool, customer cluster data. The iframe renders cluster scatter
 plots + per-segment summaries.
 
-## What it shows
+## What it Shows
 
 - **Customer segmentation output.** `get-customer-data` returns
   cluster assignments + per-cluster feature averages + per-customer
@@ -14,56 +14,50 @@ plots + per-segment summaries.
   + sizes. Reflection of the nested Go shape produces the schema
   cleanly without override.
 
-## Run it
+## Or Run Live
 
-Boots the mcpkit-Go fixture (`main.go` in this folder) and opens
-[MCPJam Inspector](https://github.com/MCPJam/inspector) so you can poke
-at the protocol surface:
+### Start Server
 
 ```bash
 make demo-app EXAMPLE=customer-segmentation
 ```
 
-Paste `http://localhost:3101/mcp` into MCPJam's server list and connect.
-Then browse `tools/list`, `_meta.ui`, and tool-call payloads on the wire.
+Starts the mcpkit-Go fixture on `http://localhost:3101/mcp` and basic-host on `http://localhost:8080`. (Pass `OPEN=1` to auto-open the browser.)
 
-See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, and the strict Playwright gate.
+## Try It Out on basic-host
 
-## Prompts to try
+Open <http://localhost:8080> in your browser. Then:
 
-Connect to `Customer Segmentation Server`, then paste any of these:
-
-```
-Show me my customer segments.
-```
+1. Pick **Customer Segmentation Server** from the server dropdown.
+2. Pick **get-customer-data** from the tool dropdown, click **Call Tool**.
+3. The iframe renders the result; interact with it directly to drive subsequent tool calls (no model in the loop).
 
 <a href="screenshots/01-cluster-view.png" target="_blank"><img src="screenshots/01-cluster-view.png" alt="Customer Segmentation App: iframe shows the cluster scatter plot with color-coded segments + the per-segment summary panel on the right" width="50%"></a>
 
-```
-Cluster my customers and visualize the segments.
-```
+## Try It Out from a Host
 
-```
-Which customer segments are most valuable?
-```
+Connect to `http://localhost:3101/mcp` from your favorite MCP host — VS Code, Claude Desktop, [MCPJam Inspector](https://github.com/MCPJam/inspector), or any spec-compliant client.
 
-<a href="screenshots/02-high-value-segment.png" target="_blank"><img src="screenshots/02-high-value-segment.png" alt="Customer Segmentation iframe with the high-value segment highlighted and its feature averages shown in the summary panel" width="50%"></a>
+**Prompts to try** (LLM-driven hosts):
 
-```
-Display customer segmentation with average revenue per cluster.
-```
+> "Show me my customer segments."
+> "Cluster my customers and visualize the segments."
+> "Which customer segments are most valuable?"
+> "Display customer segmentation with average revenue per cluster."
 
 The model calls `get-customer-data`; the iframe renders the cluster
 scatter plot + per-segment summaries.
 
-### Direct tool call (no LLM needed)
+**Verify the wire shape** (no LLM needed):
 
 | What | How | What you should see |
 |---|---|---|
 | Smoke test | Select `get-customer-data`, call with empty input | Tool result: nested clusters + customer records in `structuredContent` |
 | Iframe renders the clusters | Same call, scroll up | Scatter plot + segment summary in the App iframe |
 
-## What to look at next
+See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, the strict Playwright gate, and connecting from VS Code / Claude Desktop / other MCP hosts.
+
+## What to Try Next
 
 - [`cohort-heatmap`](../cohort-heatmap/README.md) — rung-4 sibling,
   different analytical shape.

--- a/examples/apps/compat/debug-server/README.md
+++ b/examples/apps/compat/debug-server/README.md
@@ -4,7 +4,7 @@ Rung 6 on the [examples ladder](../README.md#reading-order--examples-ladder).
 Three tools — a kitchen-sink debug surface for the model, plus two
 app-only helpers (refresh / log) the iframe uses internally.
 
-## What it shows
+## What it Shows
 
 - **Three tools, shared iframe.** `debug-tool` is the model-visible
   kitchen-sink for testing content-type behavior (text, image, audio,
@@ -17,54 +17,43 @@ app-only helpers (refresh / log) the iframe uses internally.
   TypeScript SDK's zod validator). With the fix in place, the field
   reflects to `{}` automatically — no override.
 
-## Run it
+## Or Run Live
 
-Boots the mcpkit-Go fixture (`main.go` in this folder) and opens
-[MCPJam Inspector](https://github.com/MCPJam/inspector) so you can poke
-at the protocol surface:
+### Start Server
 
 ```bash
 make demo-app EXAMPLE=debug-server
 ```
 
-Paste `http://localhost:3101/mcp` into MCPJam's server list and connect.
-Then browse `tools/list`, `_meta.ui`, and tool-call payloads on the wire.
+Starts the mcpkit-Go fixture on `http://localhost:3101/mcp` and basic-host on `http://localhost:8080`. (Pass `OPEN=1` to auto-open the browser.)
 
-See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, and the strict Playwright gate.
+## Try It Out on basic-host
 
-## Prompts to try
+Open <http://localhost:8080> in your browser. Then:
 
-Connect to `Debug MCP App Server`, then paste any of these:
-
-```
-Use the debug tool to show me text content.
-```
+1. Pick **Debug MCP App Server** from the server dropdown.
+2. Pick **debug-tool** from the tool dropdown, click **Call Tool**.
+3. The iframe renders the result; interact with it directly to drive subsequent tool calls (no model in the loop).
 
 <a href="screenshots/01-debug-text.png" target="_blank"><img src="screenshots/01-debug-text.png" alt="Debug Server App: iframe shows the kitchen-sink debug surface with content-type / multiple-blocks / structured-content / error toggles; a recent text-content response is displayed" width="50%"></a>
 
-```
-Debug tool with content type "image" and include structured content.
-```
+## Try It Out from a Host
 
-```
-Run the debug tool with mixed content blocks and a 500ms delay.
-```
+Connect to `http://localhost:3101/mcp` from your favorite MCP host — VS Code, Claude Desktop, [MCPJam Inspector](https://github.com/MCPJam/inspector), or any spec-compliant client.
 
-<a href="screenshots/02-mixed-content.png" target="_blank"><img src="screenshots/02-mixed-content.png" alt="Debug Server iframe rendering a mixed-content response (text + image + audio blocks side by side in the result panel)" width="50%"></a>
+**Prompts to try** (LLM-driven hosts):
 
-```
-Simulate an error in the debug tool.
-```
-
-```
-Send a debug call with a large input string (say 10KB of text).
-```
+> "Use the debug tool to show me text content."
+> "Debug tool with content type "image" and include structured content."
+> "Run the debug tool with mixed content blocks and a 500ms delay."
+> "Simulate an error in the debug tool."
+> "Send a debug call with a large input string (say 10KB of text)."
 
 The model calls `debug-tool` with the corresponding parameters; the
 iframe renders the result and exercises whichever content shape was
 requested.
 
-### Direct tool call (no LLM needed)
+**Verify the wire shape** (no LLM needed):
 
 | What | How | What you should see |
 |---|---|---|
@@ -74,7 +63,9 @@ requested.
 | App-only refresh | Select `debug-refresh`, call with empty input | Tool result has fresh timestamp + counter. (App-only — model won't see this in its tool list by default.) |
 | App-only log | Select `debug-log`, call with `{"type": "test", "payload": {"any": "shape"}}` | Tool result confirms logged. Note the `payload` field accepts any shape — that's the issue-548 Gap 2 fix working. |
 
-## What to look at next
+See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, the strict Playwright gate, and connecting from VS Code / Claude Desktop / other MCP hosts.
+
+## What to Try Next
 
 - [`system-monitor`](../system-monitor/README.md) — rung-6 sibling
   with two tools (one app-only) sharing the iframe.

--- a/examples/apps/compat/integration/README.md
+++ b/examples/apps/compat/integration/README.md
@@ -5,7 +5,7 @@ Most-tested fixture in the cluster — passes the 2 standard
 servers.spec.ts tests PLUS 3 host-callback interaction tests (Send
 Message, Send Log, Open Link).
 
-## What it shows
+## What it Shows
 
 - **Host callbacks from the App.** The App iframe surfaces buttons
   that drive **host-level** interactions over the bridge — not just
@@ -21,46 +21,41 @@ Message, Send Log, Open Link).
   triggers host callback`, `Open Link button triggers host
   callback`). Highest pass count of any compat fixture in DOCKER mode.
 
-## Run it
+## Or Run Live
 
-Boots the mcpkit-Go fixture (`main.go` in this folder) and opens
-[MCPJam Inspector](https://github.com/MCPJam/inspector) so you can poke
-at the protocol surface:
+### Start Server
 
 ```bash
 make demo-app EXAMPLE=integration
 ```
 
-Paste `http://localhost:3101/mcp` into MCPJam's server list and connect.
-Then browse `tools/list`, `_meta.ui`, and tool-call payloads on the wire.
+Starts the mcpkit-Go fixture on `http://localhost:3101/mcp` and basic-host on `http://localhost:8080`. (Pass `OPEN=1` to auto-open the browser.)
 
-See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, and the strict Playwright gate.
+## Try It Out on basic-host
 
-## Prompts to try
+Open <http://localhost:8080> in your browser. Then:
 
-Connect to `Integration Test Server`, then paste any of these:
-
-```
-What's the current server time?
-```
+1. Pick **Integration Test Server** from the server dropdown.
+2. Pick **get-time** from the tool dropdown, click **Call Tool**.
+3. The iframe renders the result; interact with it directly to drive subsequent tool calls (no model in the loop).
 
 <a href="screenshots/01-integration-buttons.png" target="_blank"><img src="screenshots/01-integration-buttons.png" alt="Integration Test Server App: iframe with the get-time result rendered plus three buttons — Send Message, Send Log, Open Link — for host-callback interactions" width="50%"></a>
 
-```
-Use the get-time tool.
-```
+## Try It Out from a Host
 
-After the tool call lands, click any of the three buttons in the
-iframe directly to see the host respond:
+Connect to `http://localhost:3101/mcp` from your favorite MCP host — VS Code, Claude Desktop, [MCPJam Inspector](https://github.com/MCPJam/inspector), or any spec-compliant client.
 
-<a href="screenshots/02-host-callback.png" target="_blank"><img src="screenshots/02-host-callback.png" alt="basic-host showing a host-side message banner after the App clicked Send Message; demonstrates the App-to-host callback over the bridge" width="50%"></a>
+**Prompts to try** (LLM-driven hosts):
+
+> "What's the current server time?"
+> "Use the get-time tool."
 
 The model calls `get-time`. The interesting bits are inside the
 iframe — click "Send Message", "Send Log", or "Open Link" directly in
 the App to see the host pick up the callback (basic-host renders the
 message in its UI).
 
-### Direct tool call (no LLM needed)
+**Verify the wire shape** (no LLM needed):
 
 | What | How | What you should see |
 |---|---|---|
@@ -69,7 +64,9 @@ message in its UI).
 | Send Log button | Click "Send Log" in the App | basic-host's log surface picks it up |
 | Open Link button | Click "Open Link" in the App | basic-host emits an open-link event |
 
-## What to look at next
+See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, the strict Playwright gate, and connecting from VS Code / Claude Desktop / other MCP hosts.
+
+## What to Try Next
 
 - [`system-monitor`](../system-monitor/README.md) /
   [`debug-server`](../debug-server/README.md) — rung-6 siblings,

--- a/examples/apps/compat/map/README.md
+++ b/examples/apps/compat/map/README.md
@@ -4,7 +4,7 @@ Rung 5 on the [examples ladder](../README.md#reading-order--examples-ladder).
 Two tools — one carries the iframe, the other is a plain MCP tool the
 App calls via the bridge.
 
-## What it shows
+## What it Shows
 
 - **App-side bridge calls.** `show-map` renders a CesiumJS globe in
   the iframe. The App calls `geocode` over the bridge (not via the
@@ -18,57 +18,42 @@ App calls via the bridge.
   lands the full description through `Prop("query").Desc(...)
   .Required()`.
 
-## Run it
+## Or Run Live
 
-Boots the mcpkit-Go fixture (`main.go` in this folder) and opens
-[MCPJam Inspector](https://github.com/MCPJam/inspector) so you can poke
-at the protocol surface:
+### Start Server
 
 ```bash
 make demo-app EXAMPLE=map
 ```
 
-Paste `http://localhost:3101/mcp` into MCPJam's server list and connect.
-Then browse `tools/list`, `_meta.ui`, and tool-call payloads on the wire.
+Starts the mcpkit-Go fixture on `http://localhost:3101/mcp` and basic-host on `http://localhost:8080`. (Pass `OPEN=1` to auto-open the browser.)
 
-See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, and the strict Playwright gate.
+## Try It Out on basic-host
 
-## Prompts to try
+Open <http://localhost:8080> in your browser. Then:
 
-In MCPJam Inspector or basic-host, connect to `CesiumJS Map Server`,
-then paste any of these into the chat:
-
-```
-Show me a map of Paris.
-```
+1. Pick **CesiumJS Map Server** from the server dropdown.
+2. Pick **geocode** from the tool dropdown, click **Call Tool**.
+3. The iframe renders the result; interact with it directly to drive subsequent tool calls (no model in the loop).
 
 <a href="screenshots/01-paris-map.png" target="_blank"><img src="screenshots/01-paris-map.png" alt="CesiumJS Map App: iframe shows the globe zoomed to Paris with the camera positioned over the city center" width="50%"></a>
 
-```
-Where is the Golden Gate Bridge? Show it on a map.
-```
+## Try It Out from a Host
 
-<a href="screenshots/02-golden-gate.png" target="_blank"><img src="screenshots/02-golden-gate.png" alt="CesiumJS Map App: iframe shows the bridge bounding box overlay on the San Francisco Bay view" width="50%"></a>
+Connect to `http://localhost:3101/mcp` from your favorite MCP host — VS Code, Claude Desktop, [MCPJam Inspector](https://github.com/MCPJam/inspector), or any spec-compliant client.
 
-```
-Geocode "1600 Pennsylvania Avenue" and then display it on the map.
-```
+**Prompts to try** (LLM-driven hosts):
 
-```
-Zoom in on Tokyo Tower.
-```
-
-<a href="screenshots/03-tokyo-tower.png" target="_blank"><img src="screenshots/03-tokyo-tower.png" alt="CesiumJS Map App: iframe zoomed close to Tokyo Tower; demonstrates fine-grained bounding box from geocode" width="50%"></a>
-
-Each should make the model call `geocode` (to resolve the place name
-into a bounding box) followed by `show-map` (with that bounding box).
-The iframe pans to the location.
+> "Show me a map of Paris."
+> "Where is the Golden Gate Bridge? Show it on a map."
+> "Geocode "1600 Pennsylvania Avenue" and then display it on the map."
+> "Zoom in on Tokyo Tower."
 
 The iframe also has its own search field — type a place name directly
 and the App calls `geocode` via the bridge and updates the map (no
 model in the loop).
 
-### Direct tool call (no LLM needed)
+**Verify the wire shape** (no LLM needed):
 
 | What | How | What you should see |
 |---|---|---|
@@ -76,7 +61,9 @@ model in the loop).
 | Geocode a place | Select `geocode`, call with `{"query": "Paris"}` | Tool result: text block with coordinates + bounding box for up to 5 matches |
 | Inspect comma-rich description | Expand `geocode`'s `inputSchema.properties.query.description` | The full `"...e.g., 'Paris', 'Golden Gate Bridge', '1600 Pennsylvania Ave'"` string survives intact |
 
-## What to look at next
+See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, the strict Playwright gate, and connecting from VS Code / Claude Desktop / other MCP hosts.
+
+## What to Try Next
 
 - [`wiki-explorer`](../wiki-explorer/README.md) (rung 5, sibling) —
   one-tool interactive graph; the App does the work itself.

--- a/examples/apps/compat/pdf-server/README.md
+++ b/examples/apps/compat/pdf-server/README.md
@@ -9,7 +9,7 @@ responds via separate tool, server's `Await` unblocks).
 If you've worked through the earlier rungs, this is where the
 patterns compound.
 
-## What it shows
+## What it Shows
 
 - **9 tools**, mirroring upstream's `--enable-interact` surface:
   - `list_pdfs`, `read_pdf_bytes`, `display_pdf`, `save_pdf` — the
@@ -41,83 +41,40 @@ patterns compound.
   extension-namespaced keys spread at the top level of the meta
   object.
 
-## Run it
+## Or Run Live
 
-Boots the mcpkit-Go fixture (`main.go` in this folder) and opens
-[MCPJam Inspector](https://github.com/MCPJam/inspector) so you can poke
-at the protocol surface:
+### Start Server
 
 ```bash
 make demo-app EXAMPLE=pdf-server
 ```
 
-Paste `http://localhost:3101/mcp` into MCPJam's server list and connect.
-Then browse `tools/list`, `_meta.ui`, and tool-call payloads on the wire.
+Starts the mcpkit-Go fixture on `http://localhost:3101/mcp` and basic-host on `http://localhost:8080`. (Pass `OPEN=1` to auto-open the browser.)
 
-See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, and the strict Playwright gate.
+## Try It Out on basic-host
 
-## Prompts to try
+Open <http://localhost:8080> in your browser. Then:
 
-In MCPJam Inspector or basic-host, connect to `PDF Server`, then paste
-prompts into the chat. Each builds on the previous — start at the top.
-
-Open a PDF:
-
-```
-Show me the "Attention Is All You Need" paper.
-```
+1. Pick **PDF Server** from the server dropdown.
+2. Pick **display_pdf** from the tool dropdown, click **Call Tool**.
+3. The iframe renders the result; interact with it directly to drive subsequent tool calls (no model in the loop).
 
 <a href="screenshots/01-default-pdf.png" target="_blank"><img src="screenshots/01-default-pdf.png" alt="PDF Server with the default arxiv paper rendered in the iframe; tool result panel shows viewUUID in structuredContent and interactEnabled in _meta" width="50%"></a>
 
-Navigate:
+## Try It Out from a Host
 
-```
-Navigate to page 3.
-```
+Connect to `http://localhost:3101/mcp` from your favorite MCP host — VS Code, Claude Desktop, [MCPJam Inspector](https://github.com/MCPJam/inspector), or any spec-compliant client.
 
-Highlight matches across the visible page:
+**Prompts to try** (LLM-driven hosts):
 
-```
-Highlight every occurrence of "attention" in yellow.
-```
-
-<a href="screenshots/02-highlights.png" target="_blank"><img src="screenshots/02-highlights.png" alt="Yellow highlights on every &quot;attention&quot; match on the page; demonstrates fire-and-forget interact → long-poll → iframe rendering" width="50%"></a>
-
-Search:
-
-```
-Search for "transformer" and jump to the first match.
-```
-
-Zoom:
-
-```
-Zoom in to 150%.
-```
-
-<a href="screenshots/03-zoom.png" target="_blank"><img src="screenshots/03-zoom.png" alt="PDF rendered at 150% zoom" width="50%"></a>
-
-Extract content:
-
-```
-Get the text from pages 2 through 4.
-```
-
-```
-Take a screenshot of the current page.
-```
-
-<a href="screenshots/04-screenshot-in-result.png" target="_blank"><img src="screenshots/04-screenshot-in-result.png" alt="Result panel showing a base64-encoded PNG of the current page returned via the submit_page_data rendezvous" width="50%"></a>
-
-Read the live viewer state (server-initiated rendezvous):
-
-```
-What page am I currently on, and what's the zoom level?
-```
-
-<a href="screenshots/05-viewer-state.png" target="_blank"><img src="screenshots/05-viewer-state.png" alt="Result panel showing viewer state JSON — currentPage, zoom, displayMode, selection — returned via submit_viewer_state rendezvous" width="50%"></a>
-
-Behind the scenes:
+> "Show me the "Attention Is All You Need" paper."
+> "Navigate to page 3."
+> "Highlight every occurrence of "attention" in yellow."
+> "Search for "transformer" and jump to the first match."
+> "Zoom in to 150%."
+> "Get the text from pages 2 through 4."
+> "Take a screenshot of the current page."
+> "What page am I currently on, and what's the zoom level?"
 
 - The first prompt makes the model call `display_pdf` (the iframe
   renders the PDF, the tool result carries `viewUUID`). Subsequent
@@ -129,7 +86,7 @@ Behind the scenes:
   request/response: server enqueues + blocks; viewer responds via
   `submit_page_data` / `submit_viewer_state`.
 
-### Direct tool call (no LLM needed)
+**Verify the wire shape** (no LLM needed):
 
 | What | How | What you should see |
 |---|---|---|
@@ -140,7 +97,9 @@ Behind the scenes:
 | Batched commands | `interact` with `{"viewUUID":"<uuid>","commands":[{"action":"navigate","page":1},{"action":"highlight_text","query":"transformer"},{"action":"zoom","scale":1.5}]}` | Three commands ride one tool call. Iframe applies them in order. |
 | Server-initiated rendezvous | `interact` with `{"viewUUID":"<uuid>","action":"get_viewer_state"}` | Server enqueues a command with a generated requestId, blocks on its rendezvous channel. Iframe sees the command via the long-poll, then calls `submit_viewer_state` with that requestId carrying its live state. Server's await unblocks; the rendezvous payload becomes the tool result. |
 
-## What to look at next
+See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, the strict Playwright gate, and connecting from VS Code / Claude Desktop / other MCP hosts.
+
+## What to Try Next
 
 - This is the top of the ladder. If you want to see how the patterns
   compound from the bottom up, walk back through [`map`](../map/README.md)

--- a/examples/apps/compat/quickstart/README.md
+++ b/examples/apps/compat/quickstart/README.md
@@ -5,7 +5,7 @@ Upstream's "quickstart" template — same `get-time` tool as the basic-*
 fixtures, but the iframe ships from a default scaffolded build setup
 rather than a hand-rolled minimal one.
 
-## What it shows
+## What it Shows
 
 - **Same one-tool wire surface** as basic-vanillajs. The
   differentiator is the upstream-side build pipeline (a sensible
@@ -15,48 +15,41 @@ rather than a hand-rolled minimal one.
   `npx tsx main.ts` to run the server. That fallback lives in
   `scripts/apps-playwright-docker-inner.sh`.
 
-## Run it
+## Or Run Live
 
-Boots the mcpkit-Go fixture (`main.go` in this folder) and opens
-[MCPJam Inspector](https://github.com/MCPJam/inspector) so you can poke
-at the protocol surface:
+### Start Server
 
 ```bash
 make demo-app EXAMPLE=quickstart
 ```
 
-Paste `http://localhost:3101/mcp` into MCPJam's server list and connect.
-Then browse `tools/list`, `_meta.ui`, and tool-call payloads on the wire.
+Starts the mcpkit-Go fixture on `http://localhost:3101/mcp` and basic-host on `http://localhost:8080`. (Pass `OPEN=1` to auto-open the browser.)
 
-See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, and the strict Playwright gate.
+## Try It Out on basic-host
 
-## Prompts to try
+Open <http://localhost:8080> in your browser. Then:
 
-Connect to `Quickstart MCP App Server`, then paste any of these:
-
-```
-What's the current server time?
-```
+1. Pick **Quickstart MCP App Server** from the server dropdown.
+2. Pick **get-time** from the tool dropdown, click **Call Tool**.
+3. The iframe renders the result; interact with it directly to drive subsequent tool calls (no model in the loop).
 
 <a href="screenshots/01-get-time.png" target="_blank"><img src="screenshots/01-get-time.png" alt="quickstart App rendered in basic-host: iframe shows the ISO timestamp from get-time" width="50%"></a>
 
-```
-Use the get-time tool.
-```
+## Try It Out from a Host
 
-```
-What time is it right now in UTC?
-```
+Connect to `http://localhost:3101/mcp` from your favorite MCP host — VS Code, Claude Desktop, [MCPJam Inspector](https://github.com/MCPJam/inspector), or any spec-compliant client.
+
+**Prompts to try** (LLM-driven hosts):
+
+> "What's the current server time?"
+> "Use the get-time tool."
+> "What time is it right now in UTC?"
 
 The model calls `get-time`; the iframe renders the result.
 
-### Direct tool call (no LLM needed)
+See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, the strict Playwright gate, and connecting from VS Code / Claude Desktop / other MCP hosts.
 
-Same as [basic-vanillajs](../basic-vanillajs/README.md#direct-tool-call-no-llm-needed)
-— select `get-time`, call with empty input, verify
-`structuredContent.time` is an ISO 8601 string.
-
-## What to look at next
+## What to Try Next
 
 - [`basic-vanillajs`](../basic-vanillajs/README.md) — the
   no-build-pipeline variant of the same tool.

--- a/examples/apps/compat/scenario-modeler/README.md
+++ b/examples/apps/compat/scenario-modeler/README.md
@@ -6,7 +6,7 @@ One tool, but the output's deeply nested templates contain a nullable
 where even the patch builder can't shrink to a one-liner — keeping
 the full `OutputSchemaOverride` is genuinely cleaner.
 
-## What it shows
+## What it Shows
 
 - **SaaS scenario projections.** `get-scenario-data` returns a set of
   pre-built scenario templates (conservative growth, aggressive, etc.)
@@ -22,52 +22,42 @@ the full `OutputSchemaOverride` is genuinely cleaner.
   field just needs a description tweak — patch is shorter than the
   old override there.
 
-## Run it
+## Or Run Live
 
-Boots the mcpkit-Go fixture (`main.go` in this folder) and opens
-[MCPJam Inspector](https://github.com/MCPJam/inspector) so you can poke
-at the protocol surface:
+### Start Server
 
 ```bash
 make demo-app EXAMPLE=scenario-modeler
 ```
 
-Paste `http://localhost:3101/mcp` into MCPJam's server list and connect.
-Then browse `tools/list`, `_meta.ui`, and tool-call payloads on the wire.
+Starts the mcpkit-Go fixture on `http://localhost:3101/mcp` and basic-host on `http://localhost:8080`. (Pass `OPEN=1` to auto-open the browser.)
 
-See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, and the strict Playwright gate.
+## Try It Out on basic-host
 
-## Prompts to try
+Open <http://localhost:8080> in your browser. Then:
 
-Connect to `SaaS Scenario Modeler`, then paste any of these:
-
-```
-Show me SaaS scenario projections.
-```
+1. Pick **SaaS Scenario Modeler** from the server dropdown.
+2. Pick **get-scenario-data** from the tool dropdown, click **Call Tool**.
+3. The iframe renders the result; interact with it directly to drive subsequent tool calls (no model in the loop).
 
 <a href="screenshots/01-templates.png" target="_blank"><img src="screenshots/01-templates.png" alt="Scenario Modeler App: iframe shows the pre-built scenario templates panel (conservative / aggressive / etc.) with summary KPIs" width="50%"></a>
 
-```
-Model an aggressive growth scenario for my startup.
-```
+## Try It Out from a Host
 
-```
-What if my SaaS company starts at $50k MRR with 10% monthly growth and 3% churn? When do I break even at $20k fixed costs?
-```
+Connect to `http://localhost:3101/mcp` from your favorite MCP host — VS Code, Claude Desktop, [MCPJam Inspector](https://github.com/MCPJam/inspector), or any spec-compliant client.
 
-<a href="screenshots/02-custom-projection.png" target="_blank"><img src="screenshots/02-custom-projection.png" alt="Scenario Modeler iframe: custom projection chart showing MRR over 36 months + the customSummary panel with break-even month highlighted" width="50%"></a>
+**Prompts to try** (LLM-driven hosts):
 
-```
-Project my revenue with starting MRR $100k, 5% growth, 2% churn, 80% gross margin, $50k fixed costs.
-```
-
-<a href="screenshots/03-null-breakeven.png" target="_blank"><img src="screenshots/03-null-breakeven.png" alt="Scenario Modeler iframe: same projection panel for a higher-MRR scenario where breakEvenMonth is null (never breaks even within the horizon) — showcases the nullable field on the wire" width="50%"></a>
+> "Show me SaaS scenario projections."
+> "Model an aggressive growth scenario for my startup."
+> "What if my SaaS company starts at $50k MRR with 10% monthly growth and 3% churn? When do I break even at $20k fixed costs?"
+> "Project my revenue with starting MRR $100k, 5% growth, 2% churn, 80% gross margin, $50k fixed costs."
 
 The model calls `get-scenario-data` (with `customInputs` for the
 parameterized prompts); the iframe renders the projection charts +
 template comparison.
 
-### Direct tool call (no LLM needed)
+**Verify the wire shape** (no LLM needed):
 
 | What | How | What you should see |
 |---|---|---|
@@ -75,7 +65,9 @@ template comparison.
 | With custom inputs | Call with `{"customInputs": {"startingMRR": 100000, "monthlyGrowthRate": 0.05, "monthlyChurnRate": 0.02, "grossMargin": 0.8, "fixedCosts": 50000}}` | Result has `customProjections` and `customSummary` populated. `customSummary.breakEvenMonth` is a number or `null`. |
 | Verify nullable on the wire | Expand `outputSchema.properties.customSummary.properties.breakEvenMonth` | `{"anyOf": [{"type":"number"}, {"type":"null"}]}` — the nullable form. |
 
-## What to look at next
+See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, the strict Playwright gate, and connecting from VS Code / Claude Desktop / other MCP hosts.
+
+## What to Try Next
 
 - [`wiki-explorer`](../wiki-explorer/README.md) — also has a nullable
   field, but at the top level (one path, one Replace call — patch

--- a/examples/apps/compat/shadertoy/README.md
+++ b/examples/apps/compat/shadertoy/README.md
@@ -4,7 +4,7 @@ Rung 5 on the [examples ladder](../README.md#reading-order--examples-ladder).
 One tool, but the input is a GLSL fragment shader program. First
 fixture targeted at WebGL-style rendering inside the App iframe.
 
-## What it shows
+## What it Shows
 
 - **GLSL as input.** `render-shadertoy` accepts a `fragmentShader`
   field (plus optional `common` and four buffer channels for
@@ -19,55 +19,42 @@ fixture targeted at WebGL-style rendering inside the App iframe.
   `s.Prop(name).Desc(...)` pattern across multiple properties — much
   shorter than the equivalent override map.
 
-## Run it
+## Or Run Live
 
-Boots the mcpkit-Go fixture (`main.go` in this folder) and opens
-[MCPJam Inspector](https://github.com/MCPJam/inspector) so you can poke
-at the protocol surface:
+### Start Server
 
 ```bash
 make demo-app EXAMPLE=shadertoy
 ```
 
-Paste `http://localhost:3101/mcp` into MCPJam's server list and connect.
-Then browse `tools/list`, `_meta.ui`, and tool-call payloads on the wire.
+Starts the mcpkit-Go fixture on `http://localhost:3101/mcp` and basic-host on `http://localhost:8080`. (Pass `OPEN=1` to auto-open the browser.)
 
-See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, and the strict Playwright gate.
+## Try It Out on basic-host
 
-## Prompts to try
+Open <http://localhost:8080> in your browser. Then:
 
-Connect to `ShaderToy Server`, then paste any of these:
-
-```
-Render a ShaderToy shader.
-```
+1. Pick **ShaderToy Server** from the server dropdown.
+2. Pick **render-shadertoy** from the tool dropdown, click **Call Tool**.
+3. The iframe renders the result; interact with it directly to drive subsequent tool calls (no model in the loop).
 
 <a href="screenshots/01-default-shader.png" target="_blank"><img src="screenshots/01-default-shader.png" alt="ShaderToy App: iframe shows the default UV gradient shader running in WebGL" width="50%"></a>
 
-```
-Show me a shader that displays rainbow colors that shift over time.
-```
+## Try It Out from a Host
 
-```
-Render a Mandelbrot fractal as a fragment shader.
-```
+Connect to `http://localhost:3101/mcp` from your favorite MCP host — VS Code, Claude Desktop, [MCPJam Inspector](https://github.com/MCPJam/inspector), or any spec-compliant client.
 
-<a href="screenshots/02-mandelbrot.png" target="_blank"><img src="screenshots/02-mandelbrot.png" alt="ShaderToy App: iframe shows a Mandelbrot fractal rendered from the model-supplied GLSL fragmentShader" width="50%"></a>
+**Prompts to try** (LLM-driven hosts):
 
-```
-Show me a plasma effect using sin and cos of iTime.
-```
-
-```
-Render a shader that draws concentric pulsing circles centered at the screen.
-```
-
-<a href="screenshots/03-pulsing-circles.png" target="_blank"><img src="screenshots/03-pulsing-circles.png" alt="ShaderToy App: iframe shows pulsing concentric circles animating with iTime; demonstrates the iTime / iResolution uniforms working" width="50%"></a>
+> "Render a ShaderToy shader."
+> "Show me a shader that displays rainbow colors that shift over time."
+> "Render a Mandelbrot fractal as a fragment shader."
+> "Show me a plasma effect using sin and cos of iTime."
+> "Render a shader that draws concentric pulsing circles centered at the screen."
 
 The model calls `render-shadertoy` with the generated GLSL; the
 iframe compiles and runs it on the GPU.
 
-### Direct tool call (no LLM needed)
+**Verify the wire shape** (no LLM needed):
 
 | What | How | What you should see |
 |---|---|---|
@@ -75,7 +62,9 @@ iframe compiles and runs it on the GPU.
 | Verify the multi-line default landed intact | Expand `inputSchema.properties.fragmentShader.default` | The full multi-line GLSL with commas preserved — what `InputSchemaPatch` guarantees |
 | Custom shader | Call with a `{"fragmentShader": "void mainImage(...)"}` payload | Iframe renders whatever GLSL you supplied (errors land in the iframe's console) |
 
-## What to look at next
+See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, the strict Playwright gate, and connecting from VS Code / Claude Desktop / other MCP hosts.
+
+## What to Try Next
 
 - [`threejs`](../threejs/README.md) — rung-5 sibling; also takes code
   as input, but for Three.js scene setup instead of fragment shaders.

--- a/examples/apps/compat/sheet-music/README.md
+++ b/examples/apps/compat/sheet-music/README.md
@@ -5,7 +5,7 @@ One tool, but the input has a multi-line default value with commas —
 the first fixture where reflection alone won't produce the right
 schema. Introduces the `InputSchemaPatch` escape hatch.
 
-## What it shows
+## What it Shows
 
 - **ABC notation input.** `play-sheet-music` accepts an ABC notation
   string and the iframe renders it as both readable sheet music and
@@ -17,57 +17,51 @@ schema. Introduces the `InputSchemaPatch` escape hatch.
   land the default verbatim via
   `s.Prop("abcNotation").Default(defaultABCNotation)`.
 
-## Run it
+## Or Run Live
 
-Boots the mcpkit-Go fixture (`main.go` in this folder) and opens
-[MCPJam Inspector](https://github.com/MCPJam/inspector) so you can poke
-at the protocol surface:
+### Start Server
 
 ```bash
 make demo-app EXAMPLE=sheet-music
 ```
 
-Paste `http://localhost:3101/mcp` into MCPJam's server list and connect.
-Then browse `tools/list`, `_meta.ui`, and tool-call payloads on the wire.
+Starts the mcpkit-Go fixture on `http://localhost:3101/mcp` and basic-host on `http://localhost:8080`. (Pass `OPEN=1` to auto-open the browser.)
 
-See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, and the strict Playwright gate.
+## Try It Out on basic-host
 
-## Prompts to try
+Open <http://localhost:8080> in your browser. Then:
 
-Connect to `Sheet Music Server`, then paste any of these:
-
-```
-Play Twinkle Twinkle Little Star on the sheet music tool.
-```
+1. Pick **Sheet Music Server** from the server dropdown.
+2. Pick **play-sheet-music** from the tool dropdown, click **Call Tool**.
+3. The iframe renders the result; interact with it directly to drive subsequent tool calls (no model in the loop).
 
 <a href="screenshots/01-twinkle.png" target="_blank"><img src="screenshots/01-twinkle.png" alt="Sheet Music App rendered in basic-host: iframe shows Twinkle Twinkle as rendered sheet music with a play button" width="50%"></a>
 
-```
-Show me sheet music for "Mary Had a Little Lamb" in C major.
-```
+## Try It Out from a Host
 
-```
-Use the play-sheet-music tool with the default ABC notation.
-```
+Connect to `http://localhost:3101/mcp` from your favorite MCP host — VS Code, Claude Desktop, [MCPJam Inspector](https://github.com/MCPJam/inspector), or any spec-compliant client.
 
-```
-Render Greensleeves in the key of A minor.
-```
+**Prompts to try** (LLM-driven hosts):
 
-<a href="screenshots/02-greensleeves.png" target="_blank"><img src="screenshots/02-greensleeves.png" alt="Sheet music for Greensleeves in A minor with audio playback controls" width="50%"></a>
+> "Play Twinkle Twinkle Little Star on the sheet music tool."
+> "Show me sheet music for "Mary Had a Little Lamb" in C major."
+> "Use the play-sheet-music tool with the default ABC notation."
+> "Render Greensleeves in the key of A minor."
 
 The model calls `play-sheet-music` with ABC notation (recalling it or
 constructing it); the iframe renders the sheet music and lets you
 play it back.
 
-### Direct tool call (no LLM needed)
+**Verify the wire shape** (no LLM needed):
 
 | What | How | What you should see |
 |---|---|---|
 | Default tune | Select `play-sheet-music`, call with empty input | Iframe renders Twinkle Twinkle as sheet music + audio player |
 | Verify the multi-line default landed intact | Expand `inputSchema.properties.abcNotation.default` | The full 11-line ABC notation including commas — no truncation. This is what `InputSchemaPatch` preserves. |
 
-## What to look at next
+See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, the strict Playwright gate, and connecting from VS Code / Claude Desktop / other MCP hosts.
+
+## What to Try Next
 
 - [`shadertoy`](../shadertoy/README.md) — same "multi-line code as
   input" pattern for GLSL.

--- a/examples/apps/compat/system-monitor/README.md
+++ b/examples/apps/compat/system-monitor/README.md
@@ -5,7 +5,7 @@ Two tools — one the model calls to render the dashboard, one the
 iframe polls from inside via the bridge. First fixture introducing
 `Visibility: ["app"]`.
 
-## What it shows
+## What it Shows
 
 - **One model-visible tool, one app-only tool.** `get-system-info`
   appears in the model's tool dropdown; the model calls it once and
@@ -18,44 +18,41 @@ iframe polls from inside via the bridge. First fixture introducing
   `get-system-info`) and references the same URI from
   `poll-system-stats` without re-registering.
 
-## Run it
+## Or Run Live
 
-Boots the mcpkit-Go fixture (`main.go` in this folder) and opens
-[MCPJam Inspector](https://github.com/MCPJam/inspector) so you can poke
-at the protocol surface:
+### Start Server
 
 ```bash
 make demo-app EXAMPLE=system-monitor
 ```
 
-Paste `http://localhost:3101/mcp` into MCPJam's server list and connect.
-Then browse `tools/list`, `_meta.ui`, and tool-call payloads on the wire.
+Starts the mcpkit-Go fixture on `http://localhost:3101/mcp` and basic-host on `http://localhost:8080`. (Pass `OPEN=1` to auto-open the browser.)
 
-See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, and the strict Playwright gate.
+## Try It Out on basic-host
 
-## Prompts to try
+Open <http://localhost:8080> in your browser. Then:
 
-Connect to `System Monitor Server`, then paste any of these:
-
-```
-Show me the system monitor dashboard.
-```
+1. Pick **System Monitor Server** from the server dropdown.
+2. Pick **get-system-info** from the tool dropdown, click **Call Tool**.
+3. The iframe renders the result; interact with it directly to drive subsequent tool calls (no model in the loop).
 
 <a href="screenshots/01-dashboard.png" target="_blank"><img src="screenshots/01-dashboard.png" alt="System Monitor App: iframe shows the live dashboard with CPU / memory / disk gauges + per-process table; the dashboard updates as the iframe polls poll-system-stats every few seconds" width="50%"></a>
 
-```
-What does my system look like right now? CPU, memory, disk?
-```
+## Try It Out from a Host
 
-```
-Open the live system stats view.
-```
+Connect to `http://localhost:3101/mcp` from your favorite MCP host — VS Code, Claude Desktop, [MCPJam Inspector](https://github.com/MCPJam/inspector), or any spec-compliant client.
+
+**Prompts to try** (LLM-driven hosts):
+
+> "Show me the system monitor dashboard."
+> "What does my system look like right now? CPU, memory, disk?"
+> "Open the live system stats view."
 
 The model calls `get-system-info`; the iframe renders the dashboard
 and starts polling `poll-system-stats` every few seconds from inside
 the iframe (not via the model).
 
-### Direct tool call (no LLM needed)
+**Verify the wire shape** (no LLM needed):
 
 | What | How | What you should see |
 |---|---|---|
@@ -63,7 +60,9 @@ the iframe (not via the model).
 | Verify the app-only tool's visibility | In MCPJam, find `poll-system-stats` and expand `_meta.ui` | `{"visibility": ["app"]}` — the model can't see this tool by default |
 | Call the app-only tool directly | Select `poll-system-stats`, call with empty input | Tool result has live stats. In normal use the iframe drives this every few seconds. |
 
-## What to look at next
+See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, the strict Playwright gate, and connecting from VS Code / Claude Desktop / other MCP hosts.
+
+## What to Try Next
 
 - [`debug-server`](../debug-server/README.md) — rung-6 sibling, takes
   the same app-only pattern further with three tools sharing one

--- a/examples/apps/compat/threejs/README.md
+++ b/examples/apps/compat/threejs/README.md
@@ -5,7 +5,7 @@ Two tools — one renders an interactive Three.js scene, the other
 exposes documentation. First example where a tool's input is
 literally a multi-line JavaScript program.
 
-## What it shows
+## What it Shows
 
 - **Two tools on one server.** `show_threejs_scene` carries the App
   iframe; `learn_threejs` is a plain (no-UI) tool that returns the
@@ -22,56 +22,44 @@ literally a multi-line JavaScript program.
   fixture uses `PropertyBuilder.Replace(rawSchema)` for that one
   field while patching the others normally.
 
-## Run it
+## Or Run Live
 
-Boots the mcpkit-Go fixture (`main.go` in this folder) and opens
-[MCPJam Inspector](https://github.com/MCPJam/inspector) so you can poke
-at the protocol surface:
+### Start Server
 
 ```bash
 make demo-app EXAMPLE=threejs
 ```
 
-Paste `http://localhost:3101/mcp` into MCPJam's server list and connect.
-Then browse `tools/list`, `_meta.ui`, and tool-call payloads on the wire.
+Starts the mcpkit-Go fixture on `http://localhost:3101/mcp` and basic-host on `http://localhost:8080`. (Pass `OPEN=1` to auto-open the browser.)
 
-See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, and the strict Playwright gate.
+## Try It Out on basic-host
 
-## Prompts to try
+Open <http://localhost:8080> in your browser. Then:
 
-In MCPJam Inspector or basic-host, connect to `Three.js Server`, then
-paste any of these into the chat:
-
-```
-Render a 3D scene using Three.js.
-```
+1. Pick **Three.js Server** from the server dropdown.
+2. Pick **show_threejs_scene** from the tool dropdown, click **Call Tool**.
+3. The iframe renders the result; interact with it directly to drive subsequent tool calls (no model in the loop).
 
 <a href="screenshots/01-default-cube.png" target="_blank"><img src="screenshots/01-default-cube.png" alt="Three.js App: iframe shows the default rotating cube rendered with the OrbitControls camera" width="50%"></a>
 
-```
-Show me a green wireframe sphere rotating slowly.
-```
+## Try It Out from a Host
 
-```
-Make a Three.js scene with three colored cubes arranged in a triangle.
-```
+Connect to `http://localhost:3101/mcp` from your favorite MCP host — VS Code, Claude Desktop, [MCPJam Inspector](https://github.com/MCPJam/inspector), or any spec-compliant client.
 
-```
-Render a torus knot with rainbow material that rotates on all three axes.
-```
+**Prompts to try** (LLM-driven hosts):
 
-<a href="screenshots/02-custom-torus.png" target="_blank"><img src="screenshots/02-custom-torus.png" alt="Three.js App: iframe shows a rainbow torus knot generated from a model-supplied code string" width="50%"></a>
-
-```
-How do I use OrbitControls in Three.js?
-```
+> "Render a 3D scene using Three.js."
+> "Show me a green wireframe sphere rotating slowly."
+> "Make a Three.js scene with three colored cubes arranged in a triangle."
+> "Render a torus knot with rainbow material that rotates on all three axes."
+> "How do I use OrbitControls in Three.js?"
 
 The first four should make the model call `show_threejs_scene` with a
 generated `code` payload; the iframe renders the scene. The last one
 should make the model call `learn_threejs` (no iframe — plain text
 docs back).
 
-### Direct tool call (no LLM needed)
+**Verify the wire shape** (no LLM needed):
 
 | What | How | What you should see |
 |---|---|---|
@@ -79,7 +67,9 @@ docs back).
 | Verify the multi-line default landed intact | Expand `show_threejs_scene`'s `inputSchema.properties.code.default` | The full multi-line JavaScript program — newlines and commas preserved verbatim, no struct-tag truncation. |
 | Plain (no-UI) tool | Select `learn_threejs`, call with empty input | Tool result is a text block of Three.js API docs. No iframe — this tool has no `_meta.ui` block. |
 
-## What to look at next
+See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, the strict Playwright gate, and connecting from VS Code / Claude Desktop / other MCP hosts.
+
+## What to Try Next
 
 - [`shadertoy`](../shadertoy/README.md) (rung 5, sibling) — same
   "multi-line code as input" pattern, but for GLSL fragment shaders.

--- a/examples/apps/compat/transcript/README.md
+++ b/examples/apps/compat/transcript/README.md
@@ -4,7 +4,7 @@ Rung 3 on the [examples ladder](../README.md#reading-order--examples-ladder).
 One tool, structured output. First fixture where the tool does
 meaningful work in the iframe (rather than just rendering a value).
 
-## What it shows
+## What it Shows
 
 - **Single tool with richer payload.** `transcribe` accepts an audio
   source and returns a structured transcript. The iframe renders
@@ -14,52 +14,49 @@ meaningful work in the iframe (rather than just rendering a value).
   between rung 1's trivial output and rung 4's nullable / nested
   shapes.
 
-## Run it
+## Or Run Live
 
-Boots the mcpkit-Go fixture (`main.go` in this folder) and opens
-[MCPJam Inspector](https://github.com/MCPJam/inspector) so you can poke
-at the protocol surface:
+### Start Server
 
 ```bash
 make demo-app EXAMPLE=transcript
 ```
 
-Paste `http://localhost:3101/mcp` into MCPJam's server list and connect.
-Then browse `tools/list`, `_meta.ui`, and tool-call payloads on the wire.
+Starts the mcpkit-Go fixture on `http://localhost:3101/mcp` and basic-host on `http://localhost:8080`. (Pass `OPEN=1` to auto-open the browser.)
 
-See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, and the strict Playwright gate.
+## Try It Out on basic-host
 
-## Prompts to try
+Open <http://localhost:8080> in your browser. Then:
 
-Connect to `Transcript Server`, then paste any of these:
-
-```
-Transcribe the audio at <some-audio-url>.
-```
+1. Pick **Transcript Server** from the server dropdown.
+2. Pick **transcribe** from the tool dropdown, click **Call Tool**.
+3. The iframe renders the result; interact with it directly to drive subsequent tool calls (no model in the loop).
 
 <a href="screenshots/01-transcript-view.png" target="_blank"><img src="screenshots/01-transcript-view.png" alt="Transcript Server App rendered in basic-host: iframe shows the structured transcript with segments and timing" width="50%"></a>
 
-```
-Use the transcribe tool to convert this audio to text.
-```
+## Try It Out from a Host
 
-```
-Get me a transcript with timing segments.
-```
+Connect to `http://localhost:3101/mcp` from your favorite MCP host — VS Code, Claude Desktop, [MCPJam Inspector](https://github.com/MCPJam/inspector), or any spec-compliant client.
 
-<a href="screenshots/02-structured-result.png" target="_blank"><img src="screenshots/02-structured-result.png" alt="Tool result panel expanded showing structuredContent with the transcript segments + per-segment timing" width="50%"></a>
+**Prompts to try** (LLM-driven hosts):
+
+> "Transcribe the audio at <some-audio-url>."
+> "Use the transcribe tool to convert this audio to text."
+> "Get me a transcript with timing segments."
 
 The model calls `transcribe`; the iframe renders the result as a
 structured transcript view.
 
-### Direct tool call (no LLM needed)
+**Verify the wire shape** (no LLM needed):
 
 | What | How | What you should see |
 |---|---|---|
 | Smoke test | Select `transcribe`, call with the example input | Tool result panel shows the transcript in `structuredContent` |
 | Iframe renders the transcript | Same call, scroll up | App iframe lays out the transcript with segments |
 
-## What to look at next
+See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, the strict Playwright gate, and connecting from VS Code / Claude Desktop / other MCP hosts.
+
+## What to Try Next
 
 - [`sheet-music`](../sheet-music/README.md) — rung-3 sibling; the
   first place a multi-line default value trips struct-tag reflection.

--- a/examples/apps/compat/wiki-explorer/README.md
+++ b/examples/apps/compat/wiki-explorer/README.md
@@ -5,7 +5,7 @@ One tool, but the App iframe renders an interactive force-directed
 Wikipedia link graph — first example where the iframe is doing real
 work, not just printing the tool result.
 
-## What it shows
+## What it Shows
 
 - **Interactive App UI.** The iframe pulls in a graph library, lays
   out nodes for the linked Wikipedia pages, and lets the user click to
@@ -22,59 +22,52 @@ work, not just printing the tool result.
   still does the heavy lifting for `page` + `links`; the patch only
   touches the field reflection can't get right.
 
-## Run it
+## Or Run Live
 
-Boots the mcpkit-Go fixture (`main.go` in this folder) and opens
-[MCPJam Inspector](https://github.com/MCPJam/inspector) so you can poke
-at the protocol surface:
+### Start Server
 
 ```bash
 make demo-app EXAMPLE=wiki-explorer
 ```
 
-Paste `http://localhost:3101/mcp` into MCPJam's server list and connect.
-Then browse `tools/list`, `_meta.ui`, and tool-call payloads on the wire.
+Starts the mcpkit-Go fixture on `http://localhost:3101/mcp` and basic-host on `http://localhost:8080`. (Pass `OPEN=1` to auto-open the browser.)
 
-See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, and the strict Playwright gate.
+## Try It Out on basic-host
 
-## Prompts to try
+Open <http://localhost:8080> in your browser. Then:
 
-In MCPJam Inspector or basic-host, connect to `Wiki Explorer`, then
-paste any of these into the chat:
-
-```
-Show me what the Wikipedia page for Model Context Protocol links to.
-```
+1. Pick **Wiki Explorer** from the server dropdown.
+2. Pick **get-first-degree-links** from the tool dropdown, click **Call Tool**.
+3. The iframe renders the result; interact with it directly to drive subsequent tool calls (no model in the loop).
 
 <a href="screenshots/01-mcp-graph.png" target="_blank"><img src="screenshots/01-mcp-graph.png" alt="Wiki Explorer App: force-directed graph in the iframe with the Model Context Protocol page at the center and its first-degree links spread around it" width="50%"></a>
 
-```
-Explore the link graph from https://en.wikipedia.org/wiki/Knowledge_graph
-```
+## Try It Out from a Host
 
-```
-Get first-degree links for the Wikipedia article about Transformer architecture.
-```
+Connect to `http://localhost:3101/mcp` from your favorite MCP host — VS Code, Claude Desktop, [MCPJam Inspector](https://github.com/MCPJam/inspector), or any spec-compliant client.
 
-```
-Build me a one-hop link graph starting at https://en.wikipedia.org/wiki/Model_context_protocol
-```
+**Prompts to try** (LLM-driven hosts):
 
-<a href="screenshots/02-expanded-graph.png" target="_blank"><img src="screenshots/02-expanded-graph.png" alt="Wiki Explorer App after clicking a node directly: graph has expanded to show two-hop links; demonstrates the App-side bridge call (no model in the loop)" width="50%"></a>
+> "Show me what the Wikipedia page for Model Context Protocol links to."
+> "Explore the link graph from https://en.wikipedia.org/wiki/Knowledge_graph"
+> "Get first-degree links for the Wikipedia article about Transformer architecture."
+> "Build me a one-hop link graph starting at https://en.wikipedia.org/wiki/Model_context_protocol"
 
 Any of these should make the model call `get-first-degree-links`. The
 App iframe renders the result as a force-directed graph — click a
 node directly and the App calls `get-first-degree-links` itself via
 the bridge to expand from that node (no model in the loop).
 
-### Direct tool call (no LLM needed)
+**Verify the wire shape** (no LLM needed):
 
 | What | How | What you should see |
 |---|---|---|
 | Smoke test the tool | Select `get-first-degree-links`, call with `{"url": "https://en.wikipedia.org/wiki/Model_context_protocol"}` | Result panel: `{"page": {"url":"…","title":"Model Context Protocol"}, "links": [...], "error": null}` |
 | Verify nullable on the wire | Expand the tool's `outputSchema` and find the `error` property | `{"anyOf": [{"type":"string"}, {"type":"null"}]}` — the nullable anyOf form, not `"type": "string"` |
 
-## What to look at next
+See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, the strict Playwright gate, and connecting from VS Code / Claude Desktop / other MCP hosts.
+
+## What to Try Next
 
 - Compare against [`map`](../map/README.md) (rung 5, sibling) — two
   tools instead of one, less interactive iframe.

--- a/examples/common/TEMPLATE.md
+++ b/examples/common/TEMPLATE.md
@@ -1,0 +1,125 @@
+<!--
+TEMPLATE.md — canonical README structure for mcpkit examples.
+
+Used by every fixture under examples/apps/compat/ and meant for new examples
+under examples/ generally. Copy this file into your fixture directory as
+README.md and adapt:
+
+  cp examples/common/TEMPLATE.md examples/apps/compat/<fixture>/README.md
+  # or, for a non-compat example:
+  cp examples/common/TEMPLATE.md examples/<your-example>/README.md
+
+Then walk top-to-bottom and replace every {PLACEHOLDER} with fixture-specific
+content. HTML comments (<!-- ... -->) are author-guidance only — strip them
+before committing if any are still present.
+
+Conditional sections: "## Run Pre-Recorded" and "## Try It Out from a Host"
+each have a comment block above them — read those before deciding whether
+to keep them.
+-->
+
+# {FIXTURE_NAME} — {ONE-LINE TAGLINE}
+
+<!--
+TAGLINE: half-sentence describing what makes this fixture distinct. Pulled
+into the examples-ladder table on compat/README.md. Examples:
+  - "minimum-viable MCP App in Go"
+  - "same App, Preact iframe"
+  - "deeply nested SaaS budget data"
+  - "9-tool backend with per-viewUUID command queue"
+-->
+
+{LADDER_RUNG_AND_INTRO_PARAGRAPH}
+
+<!--
+INTRO: one paragraph naming the rung on the [examples ladder] and what
+the fixture shows. Link to the closest neighbor for context. Example:
+
+  Rung 4 on the [examples ladder](../README.md#reading-order--examples-ladder).
+  One tool, but the output is a deeply nested object (config + analytics
+  with multi-month history and stage benchmarks). First fixture where
+  reflection of nested Go structs + maps produces the matching shape
+  without override.
+-->
+
+## What it Shows
+
+- **{POINT 1}** — {what's distinctive about this fixture's wire surface}
+- **{POINT 2}** — {what's distinctive about this fixture's iframe / data}
+- **{POINT 3}** — {what the reader should take away beyond "it works"}
+
+<!--
+Replace with 2-4 bullet points. Stay focused on what's NEW vs neighboring
+fixtures — not "it's an MCP server with tools" (that's true of all of them).
+Reference upstream parity, schema reflection, framework choice, payload
+shape, etc.
+-->
+
+## Run Pre-Recorded
+
+<!--
+KEEP THIS SECTION if your example has walkthrough.go + walkthrough.trace.json
++ bundle/ committed. DELETE THE WHOLE SECTION (including this comment block
+and the blockquote below) if you haven't authored a walkthrough yet.
+
+The {EXAMPLE_PATH} placeholder is the example's directory relative to the
+repo root (e.g. `examples/apps/compat/basic-vanillajs`, or
+`examples/file-inputs`). The docs-site collector mirrors it 1:1 into the
+published URL.
+-->
+
+> ▶ **[Play the walkthrough in your browser](https://panyam.github.io/mcpkit/walkthroughs/{EXAMPLE_PATH}/)** — animated playback of every curl / Go call the walkthrough makes, step-by-step. No clone, no setup.
+
+## Or Run Live
+
+### Start Server
+
+```bash
+make demo-app EXAMPLE={FIXTURE_NAME}
+```
+
+Starts the mcpkit-Go fixture on `http://localhost:3101/mcp` and basic-host on `http://localhost:8080`. (Pass `OPEN=1` to auto-open the browser.)
+
+## Try It Out on basic-host
+
+Open <http://localhost:8080> in your browser. Then:
+
+1. Pick **{SERVER_INFO_NAME}** from the server dropdown.
+2. Pick **{PRIMARY_TOOL_NAME}** from the tool dropdown, click **Call Tool** {WITH_OR_WITHOUT_INPUT}.
+3. {WHAT_THE_USER_SEES — describe the iframe, any interaction, what the result looks like}
+
+<!--
+Add 1-3 screenshots that show the App rendered. Width=50% with click-to-zoom
+is the convention:
+-->
+
+<a href="screenshots/01-{TOPIC}.png" target="_blank"><img src="screenshots/01-{TOPIC}.png" alt="{ALT_TEXT}" width="50%"></a>
+
+## Try It Out from a Host
+
+<!--
+KEEP THIS SECTION for fixtures that have meaningful behavior when an
+LLM is in the loop (most do). DROP IT for examples where there's no
+"prompt the model" story (a wire-only demo, a CLI-only fixture).
+
+The compat README backlink is compat-specific — drop the last sentence
+for examples outside examples/apps/compat/.
+-->
+
+Connect to `http://localhost:3101/mcp` from your favorite MCP host — VS Code, Claude Desktop, [MCPJam Inspector](https://github.com/MCPJam/inspector), or any spec-compliant client.
+
+**Prompts to try** (LLM-driven hosts):
+
+> "{PROMPT 1}"
+> "{PROMPT 2}"
+> "{PROMPT 3}"
+
+{ONE_SENTENCE — describe what the model will do with the response}
+
+See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, and the strict Playwright gate.
+
+## What to Try Next
+
+- {NEAREST_NEIGHBOR_ON_LADDER — what they should look at to deepen the lesson}
+- {ANOTHER_USEFUL_POINTER — sibling rung, upstream comparison, etc.}
+- See [`main.go`](main.go) — fixture is ~{ESTIMATED_LINE_COUNT} lines.

--- a/scripts/apps_demo.py
+++ b/scripts/apps_demo.py
@@ -49,6 +49,8 @@ Env vars (preserved from the bash predecessors for drop-in Makefile compatibilit
   RENDERER           basic-host | mcpjam (default: basic-host)
   OPEN               1 to auto-open basic-host in a browser (basic-host
                      renderer only; MCPJam manages its own browser).
+                     Default 0 — the README flow asks the user to open
+                     localhost:8080 manually.
 
 Foreground only — Ctrl-C tears the upstream/Go server down. MCPJam
 manages its own lifecycle; when you quit MCPJam you'll need to Ctrl-C
@@ -148,7 +150,7 @@ def build_argparser() -> argparse.ArgumentParser:
     parser.add_argument("--server-port", type=int, default=None,
                         help="MCP server port (Go fixture or upstream TS). Default 3101.")
     parser.add_argument("--open", dest="open_browser", action=argparse.BooleanOptionalAction,
-                        default=None, help="Auto-open basic-host in browser. Basic-host only. Default on.")
+                        default=None, help="Auto-open basic-host in browser. Basic-host only. Default off (set OPEN=1 or --open to opt in).")
     return parser
 
 
@@ -257,7 +259,7 @@ def main() -> int:
     server_port = args.server_port or env_int("SERVER_PORT", DEFAULT_FIXTURE_PORT)
 
     if args.open_browser is None:
-        open_browser = env_str("OPEN", "1") == "1"
+        open_browser = env_str("OPEN", "0") == "1"
     else:
         open_browser = args.open_browser
 


### PR DESCRIPTION
## What changes

Every fixture under `examples/apps/compat/` now follows the same 6-section README structure:

1. **What it Shows** — distinctive payload / wire surface / pedagogy points
2. **Run Pre-Recorded** — gh-pages walkthrough player link (only on the 6 fixtures that have a walkthrough today; omitted for the other 15)
3. **Or Run Live** → **Start Server** — `make demo-app EXAMPLE=<fixture>`
4. **Try It Out on basic-host** — 3-step browser flow + screenshot
5. **Try It Out from a Host** — connect-from-anywhere note + LLM prompts + wire-shape verification table
6. **What to Try Next** — ladder pointers + reading suggestions

Before, fixtures had drifted into three style buckets: MCPJam-first (13), basic-host-first (1 = budget-allocator), and walkthrough-augmented basic-host-first (6 of the basic-* set after PR 618). This PR pulls them all to one shape.

Two side changes ride in this PR for coherence:

- **`OPEN=0` is now the default** in `scripts/apps_demo.py`. The new README flow tells the reader to open `http://localhost:8080` manually; the old auto-open competed with that and created a double-open. Pass `OPEN=1` (or `--open`) to opt back into auto-open. Compat README and demo-app `make` help text updated to match.
- **`examples/common/TEMPLATE.md`** is the canonical source — copy into a new fixture's directory, walk top-to-bottom replacing each `{PLACEHOLDER}`. Documented in compat README's "Adding a fixture for a new upstream example" as step 5.

## Reviewer's guide

Read in this order:
1. [examples/common/TEMPLATE.md](https://github.com/panyam/mcpkit/pull/619/files#diff-451b8dc4ca83245368fc4caf30e56419de50628e83625f463b28519c79c19dc6) — start here. Canonical 6-section shape with inline HTML-comment author guidance. Two conditional sections (Run Pre-Recorded, Try It Out from a Host) are called out.
2. [examples/apps/compat/basic-vanillajs/README.md](https://github.com/panyam/mcpkit/pull/619/files#diff-91ebf98622971200c226f728ddf74ea0a883eb3d1623e8aff64c1c4bfc699e61) — polished reference application of the template. Use this as the comparison baseline for the other fixtures.
3. [examples/apps/compat/basic-preact/README.md](https://github.com/panyam/mcpkit/pull/619/files#diff-5c0bc8692240819ac5ea7825219a66f1470acacd052e4d3c312f4b633631cf19) — one of 5 framework-variant rewrites. Mechanically cloned from basic-vanillajs (substituted fixture name, framework label, server-info name). Skim the others (basic-react/solid/svelte/vue) only if you want to confirm parity.
4. [examples/apps/compat/budget-allocator/README.md](https://github.com/panyam/mcpkit/pull/619/files#diff-398060f3c462889ab3d2f4b1472dba1578e75e194ac96c6cd82b6a398f4e8b1f) — the basic-host-first stub. Existing walkthrough preserved verbatim; "Try It Out from a Host" is intentionally lean because the original had no prompts section.
5. [examples/apps/compat/debug-server/README.md](https://github.com/panyam/mcpkit/pull/619/files#diff-f914aaebee333e07d35fd8ec9ba6ab4aa147d0b995c7868440be5cc2b5d4d865) and `pdf-server/README.md` — two multi-tool stubs. Server name + primary tool extracted from the original prompts; existing prompts + wire-shape verification table preserved.
6. [examples/apps/compat/README.md](https://github.com/panyam/mcpkit/pull/619/files#diff-60a30f28654f154aec12933a1caa2b99afddbd1dea064bf7adf6cf9eef803c42) — diff against main. New step 5 in "Adding a fixture for a new upstream example" points authors at TEMPLATE.md. OPEN=0 reference updated in step "Start the renderer".
7. [scripts/apps_demo.py](https://github.com/panyam/mcpkit/pull/619/files#diff-796eba7f27c489f72fd6087700cdf74a7b709af2110b8e53b99e5e10a815cfbc) — single-line flip of OPEN default + a docstring update.
8. [Makefile](https://github.com/panyam/mcpkit/pull/619/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52) — demo-app target's `## help` text updated.

Skim or skip: every other fixture README — they're mechanical applications of the template with content lifted from the originals (no semantic rewriting).

## Decision log

- **One PR vs split (structure refactor vs OPEN=0 flip).** Bundled because the new README's "open localhost:8080" guidance assumes OPEN=0; splitting would leave the docs out of sync for one merge cycle.
- **Stub fixtures (no walkthrough) omit the "Run Pre-Recorded" section entirely** rather than carrying a "coming soon" placeholder. Cleaner — the section appears when an author lands a real walkthrough, matching the docs-site collector's "bundle exists → publish" rule.
- **Mechanical reflow for 15 stub fixtures over hand-authoring.** Stub fixtures' multi-tool "Try It Out on basic-host" sections pick one primary tool and use a generic 3-step. Multi-tool fixtures (debug-server, integration, map, pdf-server, system-monitor, threejs, wiki-explorer, shadertoy) will benefit from per-fixture polish in follow-ups; the structural skeleton is at least uniform now.

## Risk / blast radius

- **Affects:** every reader landing on a compat fixture README (i.e. the audience we're about to point at mcp-apps-wg). No code paths change apart from OPEN's default value.
- **Behavior change:** `make demo-app` no longer auto-opens the browser by default. The compat README's "Start the renderer" wiring docs are updated to match. Any external doc / blog post that assumed auto-open will see the new flow.
- **Be paranoid about:** mechanical-reflow gaps. Multi-tool fixtures pick one primary tool for the basic-host step — if a reviewer notices their "main" tool isn't the one named, that's intentional scope for a follow-up polish PR, not a fix-it-now issue.

## Out of scope (deliberately deferred)

- Per-fixture polish of the synthesized basic-host walkthroughs on multi-tool fixtures.
- Folding non-compat examples (file-inputs, elicitation, host, etc.) into the same TEMPLATE.md shape — separate follow-up.
- Filling out the "Try It Out from a Host" section on budget-allocator (no prompts in original).
