### PR TITLE
experimental/ext/events: align errors.go with spec's reusable error-code set (#491)

### DIFF
--- a/examples/events/discord/WALKTHROUGH.md
+++ b/examples/events/discord/WALKTHROUGH.md
@@ -143,7 +143,7 @@ Terminal 2:  make demo                                 # this walkthrough
 - **Webhook + auto-refresh** — `events/subscribe` with the typed `Subscription` + `Receiver[Data]` from `clients/go`. Includes the hardened delivery loop: dial-time SSRF guard, no-redirects, 256 KiB body cap with 413 non-retryable, Standard Webhooks signature scheme as default.
 - **Multi-subscription routing** — two subs to `discord.message` with different params; one event fans out to both, distinguished by `X-MCP-Subscription-Id` plus push-side `requestId` echo on every notification.
 - **Webhook delivery health** — `deliveryStatus` block on subscribe-refresh response after a failed delivery; suspend state machine flips Active=false after N consecutive failures and auto-Posts a `{type:terminated}` control envelope when run with `make serve-fast-suspend`.
-- **Auth posture** — `events/subscribe` requires an authenticated principal per spec; demo runs anonymously via `UnsafeAnonymousPrincipal`. Production deployments wire real OIDC and reject anonymous subscribes with `-32012`.
+- **Auth posture** — `events/subscribe` requires an authenticated principal per spec; demo runs anonymously via `UnsafeAnonymousPrincipal`. Production deployments wire real OIDC and reject anonymous subscribes with `-32012 Forbidden`.
 - **Spec validation** — empty / malformed `delivery.secret` rejected; client-supplied `id` rejected; valid `whsec_` accepted with no secret echoed.
 
 Identity-mode subscribe and Standard Webhooks header naming are exercised by the unit tests in `experimental/ext/events/` and by `discord-events`'s e2e tests; they require the server to be started with mode flags so they're documented in the README rather than driven from this walkthrough.
@@ -275,7 +275,7 @@ Use webhook delivery. `events/subscribe` registers a callback URL plus a client-
 - 256 KiB body cap (REJECT not TRUNCATE — truncation would corrupt the HMAC); 413 from the receiver is non-retryable. Spec L487.
 - 5xx retry with exponential backoff (4 attempts: 500ms → 1s → 2s → 5s cap). Standard webhook convention.
 
-**Auth posture:** `events/subscribe` requires an authenticated principal per spec §"Subscription Identity" → "Authentication required" L361. The demo runs anonymously via `events.Config.UnsafeAnonymousPrincipal="demo-user"` (logged at startup as "auth: demo (anonymous → UnsafeAnonymousPrincipal)"). Production deployments unset that field AND wire `server.WithAuth(JWTValidator)` so anonymous subscribes hit the spec-mandated `-32012 Unauthorized`. See README "Auth posture: demo escape vs real OIDC".
+**Auth posture:** `events/subscribe` requires an authenticated principal per spec §"Subscription Identity" → "Authentication required" L361. The demo runs anonymously via `events.Config.UnsafeAnonymousPrincipal="demo-user"` (logged at startup as "auth: demo (anonymous → UnsafeAnonymousPrincipal)"). Production deployments unset that field AND wire `server.WithAuth(JWTValidator)` so anonymous subscribes hit the spec-mandated `-32012 Forbidden`. See README "Auth posture: demo escape vs real OIDC".
 
 #### Reproduce on the wire
 

--- a/examples/events/discord/walkthrough.go
+++ b/examples/events/discord/walkthrough.go
@@ -75,7 +75,7 @@ func runDemo() {
 		"- **Webhook + auto-refresh** — `events/subscribe` with the typed `Subscription` + `Receiver[Data]` from `clients/go`. Includes the hardened delivery loop: dial-time SSRF guard, no-redirects, 256 KiB body cap with 413 non-retryable, Standard Webhooks signature scheme as default.",
 		"- **Multi-subscription routing** — two subs to `discord.message` with different params; one event fans out to both, distinguished by `X-MCP-Subscription-Id` plus push-side `requestId` echo on every notification.",
 		"- **Webhook delivery health** — `deliveryStatus` block on subscribe-refresh response after a failed delivery; suspend state machine flips Active=false after N consecutive failures and auto-Posts a `{type:terminated}` control envelope when run with `make serve-fast-suspend`.",
-		"- **Auth posture** — `events/subscribe` requires an authenticated principal per spec; demo runs anonymously via `UnsafeAnonymousPrincipal`. Production deployments wire real OIDC and reject anonymous subscribes with `-32012`.",
+		"- **Auth posture** — `events/subscribe` requires an authenticated principal per spec; demo runs anonymously via `UnsafeAnonymousPrincipal`. Production deployments wire real OIDC and reject anonymous subscribes with `-32012 Forbidden`.",
 		"- **Spec validation** — empty / malformed `delivery.secret` rejected; client-supplied `id` rejected; valid `whsec_` accepted with no secret echoed.",
 		"",
 		"Identity-mode subscribe and Standard Webhooks header naming are exercised by the unit tests in `experimental/ext/events/` and by `discord-events`'s e2e tests; they require the server to be started with mode flags so they're documented in the README rather than driven from this walkthrough.",
@@ -436,7 +436,7 @@ defer stream.Stop()`),
 			"- 256 KiB body cap (REJECT not TRUNCATE — truncation would corrupt the HMAC); 413 from the receiver is non-retryable. Spec L487.",
 			"- 5xx retry with exponential backoff (4 attempts: 500ms → 1s → 2s → 5s cap). Standard webhook convention.",
 			"",
-			"**Auth posture:** `events/subscribe` requires an authenticated principal per spec §\"Subscription Identity\" → \"Authentication required\" L361. The demo runs anonymously via `events.Config.UnsafeAnonymousPrincipal=\"demo-user\"` (logged at startup as \"auth: demo (anonymous → UnsafeAnonymousPrincipal)\"). Production deployments unset that field AND wire `server.WithAuth(JWTValidator)` so anonymous subscribes hit the spec-mandated `-32012 Unauthorized`. See README \"Auth posture: demo escape vs real OIDC\".",
+			"**Auth posture:** `events/subscribe` requires an authenticated principal per spec §\"Subscription Identity\" → \"Authentication required\" L361. The demo runs anonymously via `events.Config.UnsafeAnonymousPrincipal=\"demo-user\"` (logged at startup as \"auth: demo (anonymous → UnsafeAnonymousPrincipal)\"). Production deployments unset that field AND wire `server.WithAuth(JWTValidator)` so anonymous subscribes hit the spec-mandated `-32012 Forbidden`. See README \"Auth posture: demo escape vs real OIDC\".",
 		).
 		VerbatimVariants("Reproduce on the wire",
 			demokit.MakeVariant("curl", "bash", `# events/subscribe registers a callback URL + a client-supplied whsec_ secret with a TTL.

--- a/examples/events/telegram/handlers_test.go
+++ b/examples/events/telegram/handlers_test.go
@@ -131,7 +131,7 @@ func TestEventsPollEmptyStore(t *testing.T) {
 }
 
 // TestEventsPollUnknownEvent verifies unknown event names surface as a
-// top-level JSON-RPC error (-32011 EventNotFound per spec), not as an
+// top-level JSON-RPC error (-32011 NotFound, data.kind="event" per spec), not as an
 // embedded per-result error from the legacy partial-success model.
 // Single-sub call, single-sub response, single-sub error path.
 func TestEventsPollUnknownEvent(t *testing.T) {
@@ -145,7 +145,7 @@ func TestEventsPollUnknownEvent(t *testing.T) {
 	require.Error(t, err, "unknown event must return a JSON-RPC error")
 	rpcErr, ok := err.(*client.RPCError)
 	require.True(t, ok, "error should be RPCError, got %T", err)
-	assert.Equal(t, events.ErrCodeEventNotFound, rpcErr.Code, "spec code -32011 EventNotFound")
+	assert.Equal(t, events.ErrCodeNotFound, rpcErr.Code, "spec code -32011 NotFound")
 }
 
 // TestResourceRecentMessages verifies the recent messages resource returns

--- a/experimental/ext/events/DEPLOYMENT.md
+++ b/experimental/ext/events/DEPLOYMENT.md
@@ -123,7 +123,7 @@ Operational notes:
 
 ## Auth and tuple subscription identity
 
-Per spec §"Subscription Identity" → "Authentication required" L361, webhook `events/subscribe` and `events/unsubscribe` MUST require an authenticated principal — servers reject unauthenticated calls with `-32012 Unauthorized`. The registry keys subscriptions on the canonical tuple `(principal, delivery.url, name, params)`; cross-tenant isolation is by construction since the principal is part of the key.
+Per spec §"Subscription Identity" → "Authentication required" L361, webhook `events/subscribe` and `events/unsubscribe` MUST require an authenticated principal — servers reject unauthenticated calls with `-32012 Forbidden`. The registry keys subscriptions on the canonical tuple `(principal, delivery.url, name, params)`; cross-tenant isolation is by construction since the principal is part of the key.
 
 Production wiring (the spec-strict path):
 
@@ -138,7 +138,7 @@ validator.Start()
 srv := server.NewServer(
     core.ServerInfo{...},
     server.WithSubscriptions(),
-    server.WithAuth(validator),  // ← anonymous webhook subscribes → -32012
+    server.WithAuth(validator),  // ← anonymous webhook subscribes → -32012 Forbidden
 )
 events.Register(events.Config{
     Sources:  ...,
@@ -155,7 +155,7 @@ The `events` package only depends on `core.Claims` (the abstract auth contract),
 
 The `events.Config.UnsafeAnonymousPrincipal` field deliberately deviates from the spec — when set, anonymous calls are accepted under the configured principal. **Production deployments MUST leave this field empty.** The startup log line emitted by `events.Register` explicitly warns when it's non-empty so misconfiguration is loud rather than silent.
 
-If a production deployment sets it: the spec's `-32012` rejection is bypassed; webhook subscribe accepts anonymous calls under a single shared principal; cross-tenant isolation breaks (everyone is "the demo user"); the audit trail loses its principal field. None of these are acceptable production properties.
+If a production deployment sets it: the spec's `-32012 Forbidden` rejection is bypassed; webhook subscribe accepts anonymous calls under a single shared principal; cross-tenant isolation breaks (everyone is "the demo user"); the audit trail loses its principal field. None of these are acceptable production properties.
 
 The demos use it as an escape hatch so `make demo` works without standing up an auth provider. Each demo also auto-detects `OAUTH_ISSUER` and switches to real auth when present — see `examples/events/discord/README.md` for the env-var contract.
 
@@ -191,7 +191,7 @@ Before going live with a webhook-enabled events server in a private-cloud deploy
 - [ ] Receiver is idempotent on `event.eventId`.
 - [ ] Receiver returns 2xx for accept, 4xx for reject-permanently, 5xx for retry.
 - [ ] Webhook secrets (each subscription's `whsec_` value) reach the receiver via your secrets-management path; rotation procedure documented.
-- [ ] **`events.Config.UnsafeAnonymousPrincipal` is EMPTY** in production code paths. Auth is wired via `server.WithAuth(...)`. Anonymous webhook subscribes return `-32012 Unauthorized`.
+- [ ] **`events.Config.UnsafeAnonymousPrincipal` is EMPTY** in production code paths. Auth is wired via `server.WithAuth(...)`. Anonymous webhook subscribes return `-32012 Forbidden`.
 - [ ] Server startup log shows `[events] WARNING: UnsafeAnonymousPrincipal=...` is **NOT** present. (Its presence indicates the demo escape hatch is on.)
 - [ ] If using Standard Webhooks header mode, WAF allowlist has the `webhook-*` headers (not `X-MCP-*`).
 - [ ] Subscribers run an SDK that auto-refreshes (or have explicit refresh logic that fires before `refreshBefore`).

--- a/experimental/ext/events/README.md
+++ b/experimental/ext/events/README.md
@@ -95,7 +95,7 @@ myDB.OnInsert = func(row Row) {
 | Method | Description |
 |--------|-------------|
 | `events/list` | Returns event definitions with auto-derived `payloadSchema` and `cursorless` flag |
-| `events/poll` | Single-subscription polling, flat top-level response shape (`{events, cursor, hasMore, truncated, nextPollSeconds}`); error responses use spec error codes `-32011 EventNotFound` / `-32015 InvalidCallbackUrl` |
+| `events/poll` | Single-subscription polling, flat top-level response shape (`{events, cursor, hasMore, truncated, nextPollSeconds}`); error responses use spec error codes `-32011 NotFound` (`data.kind: "event"`) / `-32015 CallbackEndpointError` |
 | `events/subscribe` | Webhook registration with HMAC secret + TTL + `refreshBefore`. `cursor: null` means "from now" — server resolves to source's current head |
 | `events/unsubscribe` | Webhook removal by `(url, id)` or `(url, secret)` |
 
@@ -182,7 +182,7 @@ events.Register(events.Config{
 })
 ```
 
-When set, anonymous webhook subscribes are accepted under the configured principal. The server logs a startup warning so deployments using it know they're off-spec. **Production deployments leave this empty AND wire `server.WithAuth(validator)` so unauthenticated subscribe attempts hit the spec-mandated `-32012 Unauthorized` rejection.**
+When set, anonymous webhook subscribes are accepted under the configured principal. The server logs a startup warning so deployments using it know they're off-spec. **Production deployments leave this empty AND wire `server.WithAuth(validator)` so unauthenticated subscribe attempts hit the spec-mandated `-32012 Forbidden` rejection.**
 
 ### Auth + extension composition
 

--- a/experimental/ext/events/clients/go/stream.go
+++ b/experimental/ext/events/clients/go/stream.go
@@ -14,7 +14,7 @@ package eventsclient
 //  3. Returns from the constructor once the initial
 //     notifications/events/active arrives — at that point the server has
 //     accepted the subscription and the stream is live.
-//  4. Surfaces server-side validation errors (-32011, -32012, -32017,
+//  4. Surfaces server-side validation errors (-32011, -32012, -32014,
 //     -32602) as constructor errors before the goroutine ever starts.
 //
 // Per-stream isolation comes from the per-call notify hook: each Stream
@@ -91,8 +91,8 @@ type StreamCall struct {
 // Stream opens an events/stream call and dispatches incoming notifications
 // to the typed callbacks in opts. Returns once the initial
 // notifications/events/active arrives (signaling the stream is live) or
-// the call fails immediately (e.g., -32011 EventNotFound, -32012
-// Unauthorized, -32017 DeliveryModeUnsupported).
+// the call fails immediately (e.g., -32011 NotFound, -32012
+// Forbidden, -32014 Unsupported).
 //
 // The returned *StreamCall's Stop() cancels the underlying context, ending
 // the stream — the server returns StreamEventsResult and the goroutine

--- a/experimental/ext/events/errors.go
+++ b/experimental/ext/events/errors.go
@@ -1,31 +1,122 @@
 package events
 
-// JSON-RPC error codes for the MCP Events extension.
+import (
+	"encoding/json"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+// JSON-RPC error codes used by the MCP Events extension.
 //
-// The spec reserves the range -32011..-32017 for events errors
-// (-32014 is intentionally unused). Codes outside this range MUST
-// NOT be added here — events handlers should either use one of the
-// spec codes below, fall back to a base JSON-RPC code (-32602
-// InvalidParams, -32603 InternalError, -32601 MethodNotFound), or
-// surface the issue through the body shape rather than a new code.
+// These five codes are intentionally general-purpose. The MCP Events
+// spec consolidated its error surface on 2026-05-22 (design-sketch
+// commit 567be29): seven events-specific codes collapsed into five
+// reusable codes carrying typed `data` discriminators. The spec frames
+// the new set as "candidates for promotion to the base MCP error
+// registry" with the directive that "future SEPs SHOULD reuse them
+// rather than introduce overlapping codes."
+//
+// The codes live here pending that promotion. Other extensions in
+// this repo (or downstream SEPs) should feel free to reuse these
+// constants rather than mint new ones in the same JSON-RPC server
+// range [-32000, -32099].
 //
 // Spec-defined codes (full set):
-//   -32011 EventNotFound           — Unknown event name
-//   -32012 Unauthorized            — Caller lacks permission for this event/params
-//   -32013 TooManySubscriptions    — Server-imposed subscription limit reached
-//   -32014 (reserved by the spec)
-//   -32015 InvalidCallbackUrl      — Webhook URL unreachable / rejected
-//   -32016 SubscriptionNotFound    — Unsubscribe target doesn't exist
-//   -32017 DeliveryModeUnsupported — Event type doesn't support requested mode
 //
-// Only codes the events handlers currently emit are declared below.
-// New constants get added in the same commit that introduces the
-// behavior using them — keeps each new code visible alongside its
-// first use.
+//	-32011 NotFound              — Unknown event or subscription (discriminate via data.kind)
+//	-32012 Forbidden             — Caller lacks permission for this operation
+//	-32013 ResourceExhausted     — Server-imposed limit reached (e.g., subscription cap)
+//	-32014 Unsupported           — Requested feature/value combination is unsupported
+//	-32015 CallbackEndpointError — Webhook endpoint is unreachable or rejected the request
+//
+// Each emission site SHOULD attach the matching typed `data` payload so
+// clients can branch on machine-readable discriminators without
+// string-matching the human-readable `message` field. The helpers
+// further down (newNotFoundError, newForbiddenError, …) enforce this:
+// they wrap core.NewErrorResponseWithData with the right struct shape.
 const (
-	ErrCodeEventNotFound           = -32011 // Unknown event name
-	ErrCodeUnauthorized            = -32012 // Caller lacks permission for this event/params
-	ErrCodeTooManySubscriptions    = -32013 // Server-imposed subscription limit reached / on_subscribe refused
-	ErrCodeInvalidCallbackUrl      = -32015 // Webhook URL unreachable / rejected
-	ErrCodeDeliveryModeUnsupported = -32017 // Event type doesn't support requested mode
+	ErrCodeNotFound              = -32011
+	ErrCodeForbidden             = -32012
+	ErrCodeResourceExhausted     = -32013
+	ErrCodeUnsupported           = -32014
+	ErrCodeCallbackEndpointError = -32015
 )
+
+// NotFoundData is the typed `data` payload attached to -32011 NotFound
+// responses. The Kind discriminator tells the client what was missing
+// without parsing the human-readable message — "event" for an unknown
+// event name on poll/subscribe/stream, "subscription" for an
+// unsubscribe target that doesn't exist.
+type NotFoundData struct {
+	Kind string `json:"kind"` // "event" | "subscription"
+}
+
+// ResourceExhaustedData is the typed `data` payload attached to -32013
+// ResourceExhausted responses. Limit names the exhausted resource
+// (e.g., "subscriptions"); Max carries the configured ceiling when the
+// server is willing to expose it. Max is omitted when zero so the
+// client can distinguish "limit hit, ceiling not disclosed" from
+// "limit hit, ceiling = 0".
+type ResourceExhaustedData struct {
+	Limit string `json:"limit"`
+	Max   int64  `json:"max,omitempty"`
+}
+
+// UnsupportedData is the typed `data` payload attached to -32014
+// Unsupported responses. Feature names the dimension the server is
+// rejecting on (e.g., "deliveryMode"); Value carries the specific
+// rejected input ("push", "webhook") when one applies.
+type UnsupportedData struct {
+	Feature string `json:"feature"`
+	Value   string `json:"value,omitempty"`
+}
+
+// CallbackEndpointErrorData is the typed `data` payload attached to
+// -32015 CallbackEndpointError responses. Reason mirrors the
+// DeliveryErrorBucket categorical set used on the runtime delivery
+// side, so a client gets the same vocabulary for subscribe-time
+// validation failures and subsequent delivery failures.
+type CallbackEndpointErrorData struct {
+	Reason string `json:"reason"` // "connection_refused" | "timeout" | "tls_error" | "http_4xx" | "http_5xx" | "challenge_failed"
+}
+
+// newNotFoundError returns a -32011 response with a typed
+// NotFoundData{Kind: kind} payload. Use kind "event" when the named
+// event source is not registered; use "subscription" when an
+// unsubscribe target cannot be located.
+func newNotFoundError(id json.RawMessage, kind, message string) *core.Response {
+	return core.NewErrorResponseWithData(id, ErrCodeNotFound, message, NotFoundData{Kind: kind})
+}
+
+// newForbiddenError returns a -32012 response. Forbidden has no
+// machine-readable discriminators today; the helper exists so emission
+// sites stay symmetrical with the other typed-data helpers and so a
+// future spec revision can add a data shape in one place.
+func newForbiddenError(id json.RawMessage, message string) *core.Response {
+	return core.NewErrorResponse(id, ErrCodeForbidden, message)
+}
+
+// newResourceExhaustedError returns a -32013 response with a typed
+// ResourceExhaustedData payload. Pass max=0 when the configured
+// ceiling is not exposed; the field is omitted in that case.
+func newResourceExhaustedError(id json.RawMessage, limit string, max int64, message string) *core.Response {
+	return core.NewErrorResponseWithData(id, ErrCodeResourceExhausted, message,
+		ResourceExhaustedData{Limit: limit, Max: max})
+}
+
+// newUnsupportedError returns a -32014 response with a typed
+// UnsupportedData payload. Use empty value when the feature itself is
+// unsupported regardless of the input.
+func newUnsupportedError(id json.RawMessage, feature, value, message string) *core.Response {
+	return core.NewErrorResponseWithData(id, ErrCodeUnsupported, message,
+		UnsupportedData{Feature: feature, Value: value})
+}
+
+// newCallbackEndpointError returns a -32015 response with a typed
+// CallbackEndpointErrorData payload. The reason MUST be drawn from the
+// DeliveryErrorBucket vocabulary so client decoders can use one switch
+// across both subscribe-time and delivery-time failures.
+func newCallbackEndpointError(id json.RawMessage, reason, message string) *core.Response {
+	return core.NewErrorResponseWithData(id, ErrCodeCallbackEndpointError, message,
+		CallbackEndpointErrorData{Reason: reason})
+}

--- a/experimental/ext/events/errors_test.go
+++ b/experimental/ext/events/errors_test.go
@@ -1,0 +1,121 @@
+package events
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNotFoundData_WireShape pins the JSON wire shape for the typed
+// data payload on -32011 NotFound responses. The Kind discriminator
+// is what lets clients tell "unknown event" apart from "unknown
+// subscription" without parsing the human-readable message.
+func TestNotFoundData_WireShape(t *testing.T) {
+	cases := []struct {
+		name string
+		kind string
+		want string
+	}{
+		{"event", "event", `{"kind":"event"}`},
+		{"subscription", "subscription", `{"kind":"subscription"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, err := json.Marshal(NotFoundData{Kind: tc.kind})
+			require.NoError(t, err)
+			assert.JSONEq(t, tc.want, string(raw))
+		})
+	}
+}
+
+// TestResourceExhaustedData_WireShape pins the JSON wire shape for
+// the typed data payload on -32013 ResourceExhausted responses,
+// including the omitempty behavior on Max: a zero Max signals "limit
+// hit, ceiling not disclosed" and must not appear in the encoded JSON.
+func TestResourceExhaustedData_WireShape(t *testing.T) {
+	t.Run("with cap", func(t *testing.T) {
+		raw, err := json.Marshal(ResourceExhaustedData{Limit: "subscriptions", Max: 5})
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"limit":"subscriptions","max":5}`, string(raw))
+	})
+	t.Run("cap omitted", func(t *testing.T) {
+		raw, err := json.Marshal(ResourceExhaustedData{Limit: "subscriptions"})
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"limit":"subscriptions"}`, string(raw),
+			"Max=0 must be omitted so 'cap unknown' is distinguishable from 'cap is zero'")
+	})
+}
+
+// TestUnsupportedData_WireShape pins the JSON wire shape for -32014
+// Unsupported. Value is omitempty so a server can reject a feature
+// outright (no specific value carried) by passing Value="".
+func TestUnsupportedData_WireShape(t *testing.T) {
+	t.Run("feature + value", func(t *testing.T) {
+		raw, err := json.Marshal(UnsupportedData{Feature: "deliveryMode", Value: "push"})
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"feature":"deliveryMode","value":"push"}`, string(raw))
+	})
+	t.Run("feature only", func(t *testing.T) {
+		raw, err := json.Marshal(UnsupportedData{Feature: "deliveryMode"})
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"feature":"deliveryMode"}`, string(raw))
+	})
+}
+
+// TestCallbackEndpointErrorData_WireShape pins the JSON wire shape
+// for -32015 CallbackEndpointError. The Reason draws from
+// DeliveryErrorBucket so subscribe-time and delivery-time failures
+// share one vocabulary on the wire.
+func TestCallbackEndpointErrorData_WireShape(t *testing.T) {
+	raw, err := json.Marshal(CallbackEndpointErrorData{Reason: "connection_refused"})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"reason":"connection_refused"}`, string(raw))
+}
+
+// TestErrorConstructors_AttachTypedData verifies the helper constructors
+// in errors.go actually wire the typed struct into the response's
+// Error.Data field. Without this test a future contributor could
+// "simplify" a helper to NewErrorResponse-without-data and lose the
+// discriminator silently — wire-shape tests above wouldn't fire on
+// production code paths.
+func TestErrorConstructors_AttachTypedData(t *testing.T) {
+	id := json.RawMessage(`1`)
+
+	t.Run("NotFound", func(t *testing.T) {
+		resp := newNotFoundError(id, "subscription", "NotFound")
+		require.NotNil(t, resp.Error)
+		assert.Equal(t, ErrCodeNotFound, resp.Error.Code)
+		assert.Equal(t, NotFoundData{Kind: "subscription"}, resp.Error.Data)
+	})
+
+	t.Run("ResourceExhausted with cap", func(t *testing.T) {
+		resp := newResourceExhaustedError(id, "subscriptions", 7, "at cap")
+		require.NotNil(t, resp.Error)
+		assert.Equal(t, ErrCodeResourceExhausted, resp.Error.Code)
+		assert.Equal(t, ResourceExhaustedData{Limit: "subscriptions", Max: 7}, resp.Error.Data)
+	})
+
+	t.Run("Unsupported", func(t *testing.T) {
+		resp := newUnsupportedError(id, "deliveryMode", "push", "Unsupported")
+		require.NotNil(t, resp.Error)
+		assert.Equal(t, ErrCodeUnsupported, resp.Error.Code)
+		assert.Equal(t, UnsupportedData{Feature: "deliveryMode", Value: "push"}, resp.Error.Data)
+	})
+
+	t.Run("CallbackEndpointError", func(t *testing.T) {
+		resp := newCallbackEndpointError(id, "tls_error", "TLS handshake failed")
+		require.NotNil(t, resp.Error)
+		assert.Equal(t, ErrCodeCallbackEndpointError, resp.Error.Code)
+		assert.Equal(t, CallbackEndpointErrorData{Reason: "tls_error"}, resp.Error.Data)
+	})
+
+	t.Run("Forbidden has no data payload by design", func(t *testing.T) {
+		resp := newForbiddenError(id, "Forbidden")
+		require.NotNil(t, resp.Error)
+		assert.Equal(t, ErrCodeForbidden, resp.Error.Code)
+		assert.Nil(t, resp.Error.Data,
+			"Forbidden carries no discriminators today; if the spec adds one, update this test and the helper together")
+	})
+}

--- a/experimental/ext/events/events.go
+++ b/experimental/ext/events/events.go
@@ -198,7 +198,7 @@ type Config struct {
 	//
 	// This is a deliberate spec deviation. Per spec §"Subscription
 	// Identity" → "Authentication required" L361, servers MUST reject
-	// unauthenticated webhook subscribes with -32012 Unauthorized. The
+	// unauthenticated webhook subscribes with -32012 Forbidden. The
 	// escape hatch exists so demos and unauthenticated mcpkit servers
 	// can exercise webhook delivery end-to-end without standing up an
 	// OAuth provider; it is named with the "Unsafe" prefix and produces
@@ -250,9 +250,9 @@ type Config struct {
 	// per spec §"Server SDK Guidance" → "Subscription lifecycle
 	// hooks" L705 ("Servers SHOULD enforce TooManySubscriptions
 	// before invoking on_subscribe"). If the principal is at cap,
-	// the request is rejected with -32013 TooManySubscriptions and
-	// on_subscribe never runs (no upstream resource provisioning
-	// for a rejected sub).
+	// the request is rejected with -32013 ResourceExhausted (data.
+	// limit="subscriptions") and on_subscribe never runs (no upstream
+	// resource provisioning for a rejected sub).
 	//
 	// Authors configure caps via NewQuota(WithMaxSubscriptionsPerPrincipal(name, n)...)
 	// and pass the result here. nil leaves Register to construct an
@@ -416,7 +416,7 @@ func EmitToWebhooks(webhooks *WebhookRegistry, event Event) {
 // Per-result errors used to live inside this struct (legacy partial-
 // success model). They now surface as top-level JSON-RPC errors per
 // the spec — single-sub call, single-sub response, single-sub error
-// path. See the EventNotFound branch in registerPoll.
+// path. See the NotFound branch in registerPoll.
 type pollResultWire struct {
 	Events          []Event `json:"events,omitempty"`
 	Cursor          *string `json:"cursor"`
@@ -484,7 +484,7 @@ func registerPoll(srv *server.Server, sourceMap map[string]EventSource, unsafeAn
 
 		source, ok := sourceMap[req.Name]
 		if !ok {
-			return core.NewErrorResponse(id, ErrCodeEventNotFound, "EventNotFound")
+			return newNotFoundError(id, "event", "NotFound")
 		}
 
 		// Poll-lease bookkeeping per spec §"Server SDK Guidance" →
@@ -516,7 +516,7 @@ func registerPoll(srv *server.Server, sourceMap map[string]EventSource, unsafeAn
 			// the live line).
 			if err := quota.Reserve(principal, req.Name); err != nil {
 				leases.Remove(principal, req.Name, req.Params)
-				return core.NewErrorResponse(id, ErrCodeTooManySubscriptions, err.Error())
+				return newResourceExhaustedError(id, "subscriptions", int64(quota.Cap(req.Name)), err.Error())
 			}
 			hc := newHookContext(ctx, principal, "", DeliveryModePoll)
 			if err := safeOnSubscribe(source.Def().OnSubscribe, hc, req.Params); err != nil {
@@ -526,7 +526,9 @@ func registerPoll(srv *server.Server, sourceMap map[string]EventSource, unsafeAn
 				// state.
 				leases.Remove(principal, req.Name, req.Params)
 				quota.Release(principal, req.Name)
-				return core.NewErrorResponse(id, ErrCodeTooManySubscriptions,
+				// Cap unknown at this site — author-defined refusal
+				// is not a server-side quota, so Max is omitted.
+				return newResourceExhaustedError(id, "subscriptions", 0,
 					"on_subscribe rejected: "+err.Error())
 			}
 		}
@@ -626,7 +628,7 @@ func registerPoll(srv *server.Server, sourceMap map[string]EventSource, unsafeAn
 // UnsafeAnonymousPrincipal escape hatch (events.Config field).
 //
 // Returns: (principal, ok). When ok is false, the handler MUST reject
-// the request with -32012 Unauthorized — there is neither real auth
+// the request with -32012 Forbidden — there is neither real auth
 // nor a configured anonymous fallback.
 //
 // Path-1 (real auth): claims != nil → claims.Subject. Spec-correct.
@@ -673,7 +675,7 @@ func registerSubscribe(srv *server.Server, sourceMap map[string]EventSource, web
 				"client-supplied id is not accepted; server derives id over (principal, name, params, url) per spec — drop the id field from your subscribe request")
 		}
 		if _, ok := sourceMap[req.Name]; !ok {
-			return core.NewErrorResponse(id, ErrCodeEventNotFound, "EventNotFound")
+			return newNotFoundError(id, "event", "NotFound")
 		}
 		if req.Delivery.Mode != "webhook" {
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, "only webhook delivery mode is supported")
@@ -682,7 +684,13 @@ func registerSubscribe(srv *server.Server, sourceMap map[string]EventSource, web
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, "delivery.url is required")
 		}
 		if err := webhooks.ValidateWebhookURL(req.Delivery.URL); err != nil {
-			return core.NewErrorResponse(id, ErrCodeInvalidCallbackUrl, err.Error())
+			// Subscribe-time URL validation rejects scheme / loopback /
+			// parse failures — none map cleanly onto the runtime
+			// DeliveryErrorBucket categories. "connection_refused" is
+			// the closest fit for "callback endpoint is not reachable
+			// from this server". Real delivery-time failures use the
+			// finer-grained bucket via the DeliveryStatus path.
+			return newCallbackEndpointError(id, string(DeliveryErrorConnectionRefused), err.Error())
 		}
 
 		// Spec: delivery.secret is REQUIRED, client-supplied, and MUST
@@ -700,12 +708,12 @@ func registerSubscribe(srv *server.Server, sourceMap map[string]EventSource, web
 
 		// Spec §"Subscription Identity" → "Authentication required" L361:
 		// events/subscribe MUST be called with an authenticated principal;
-		// servers MUST reject unauthenticated calls with -32012. The
+		// servers MUST reject unauthenticated calls with -32012 Forbidden. The
 		// UnsafeAnonymousPrincipal escape hatch (Config field) lets demos
 		// run anonymously — see resolvePrincipal docs.
 		principal, ok := resolvePrincipal(ctx, unsafeAnon)
 		if !ok {
-			return core.NewErrorResponse(id, ErrCodeUnauthorized, "Unauthorized")
+			return newForbiddenError(id, "Forbidden")
 		}
 
 		// Spec §"Subscription Identity" → "Key composition" L363: the
@@ -745,7 +753,7 @@ func registerSubscribe(srv *server.Server, sourceMap map[string]EventSource, web
 			// successfully Reserved) and idx.Remove (also no-op).
 			if err := quota.Reserve(principal, req.Name); err != nil {
 				webhooks.Unregister(canonical)
-				return core.NewErrorResponse(id, ErrCodeTooManySubscriptions, err.Error())
+				return newResourceExhaustedError(id, "subscriptions", int64(quota.Cap(req.Name)), err.Error())
 			}
 			source := sourceMap[req.Name]
 			def := source.Def()
@@ -755,7 +763,9 @@ func registerSubscribe(srv *server.Server, sourceMap map[string]EventSource, web
 				// Unregister fires onRemove → quota.Release pairs
 				// with the Reserve above (one Release per Reserve).
 				webhooks.Unregister(canonical)
-				return core.NewErrorResponse(id, ErrCodeTooManySubscriptions,
+				// Cap unknown at this site — author-defined refusal
+				// is not a server-side quota, so Max is omitted.
+				return newResourceExhaustedError(id, "subscriptions", 0,
 					"on_subscribe rejected: "+err.Error())
 			}
 			// Register this webhook target in the SubscriptionIndex
@@ -867,7 +877,7 @@ func registerUnsubscribe(srv *server.Server, webhooks *WebhookRegistry, unsafeAn
 
 		principal, ok := resolvePrincipal(ctx, unsafeAnon)
 		if !ok {
-			return core.NewErrorResponse(id, ErrCodeUnauthorized, "Unauthorized")
+			return newForbiddenError(id, "Forbidden")
 		}
 
 		canonical := canonicalKey(principal, req.Delivery.URL, req.Name, req.Params)

--- a/experimental/ext/events/hooks.go
+++ b/experimental/ext/events/hooks.go
@@ -209,8 +209,9 @@ type TransformFunc func(ctx HookContext, event Event, params map[string]any) (Ev
 // per-event-type state.
 //
 // Returning a non-nil error fails the subscribe call: the SDK
-// surfaces it as -32013 TooManySubscriptions today (a dedicated
-// SubscribeFailed code may follow if a real use case appears). The
+// surfaces it as -32013 ResourceExhausted (data.limit="subscriptions")
+// today; a dedicated SubscribeFailed code may follow if a real use
+// case appears. The
 // SDK does NOT roll back webhook registration / push stream open on
 // hook failure; authors that need rollback should arrange it inside
 // the hook before returning the error.

--- a/experimental/ext/events/identity_handler_test.go
+++ b/experimental/ext/events/identity_handler_test.go
@@ -92,8 +92,8 @@ func TestSubscribe_RejectsAnonymousUnderStrictSpec(t *testing.T) {
 	resp := dispatchSubscribe(t, srv, validSubscribeParams())
 
 	require.NotNil(t, resp.Error, "expected -32012; got success result")
-	assert.Equal(t, ErrCodeUnauthorized, resp.Error.Code,
-		"spec-mandated -32012 Unauthorized for anonymous webhook subscribe")
+	assert.Equal(t, ErrCodeForbidden, resp.Error.Code,
+		"spec-mandated -32012 Forbidden for anonymous webhook subscribe")
 }
 
 // TestSubscribe_AcceptsAnonymousWithEscape verifies the demo escape

--- a/experimental/ext/events/lifecycle_test.go
+++ b/experimental/ext/events/lifecycle_test.go
@@ -408,7 +408,7 @@ func TestLifecycle_Webhook_OnSubscribeError_RollsBack(t *testing.T) {
 		},
 	})
 	require.NotNil(t, resp.Error, "on_subscribe error should produce a JSON-RPC error response")
-	require.Equal(t, ErrCodeTooManySubscriptions, resp.Error.Code)
+	require.Equal(t, ErrCodeResourceExhausted, resp.Error.Code)
 
 	// Rollback assertion: registry should not retain the rejected sub.
 	if got := len(f.webhooks.Targets()); got != 0 {
@@ -496,7 +496,7 @@ func TestLifecycle_Push_OnSubscribeError_RejectsStream(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, resp.Error)
-	require.Equal(t, ErrCodeTooManySubscriptions, resp.Error.Code)
+	require.Equal(t, ErrCodeResourceExhausted, resp.Error.Code)
 	// on_unsubscribe deliberately does NOT fire — we never crossed
 	// the live-subscription line. (defer is set up after the
 	// safeOnSubscribe error check.)
@@ -583,7 +583,7 @@ func TestLifecycle_Poll_OnSubscribeError_Rejects(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, resp.Error, "poll on_subscribe error should surface via JSON-RPC error")
-	require.Equal(t, ErrCodeTooManySubscriptions, resp.Error.Code)
+	require.Equal(t, ErrCodeResourceExhausted, resp.Error.Code)
 }
 
 // --- Concurrency safety ---

--- a/experimental/ext/events/quota.go
+++ b/experimental/ext/events/quota.go
@@ -36,10 +36,13 @@ import (
 
 // ErrTooManySubscriptions is returned by Quota.Reserve when the cap
 // for (principal, event-type) is exceeded. Surfaces on the wire as
-// -32013 TooManySubscriptions per spec.
+// -32013 ResourceExhausted with data.limit="subscriptions" per the
+// MCP Events spec's reusable error-code set.
 //
 // Use errors.Is(err, ErrTooManySubscriptions) to test; the wrapping
-// error includes the event-type name and cap in its message.
+// error includes the event-type name and cap in its message. Use
+// Quota.Cap(eventName) to read the cap as a typed value (for the
+// ResourceExhausted data.max field) without parsing the message.
 var ErrTooManySubscriptions = errors.New("TooManySubscriptions")
 
 // QuotaOption configures a Quota at construction time.
@@ -158,4 +161,14 @@ func (q *Quota) Release(principal, eventName string) {
 		return
 	}
 	sem.Release(1)
+}
+
+// Cap returns the configured per-principal cap for eventName, or 0 if
+// the event-type is uncapped. Wire-format helper: emission sites use
+// the returned value to populate ResourceExhaustedData.Max on -32013
+// responses without parsing the wrapped error's message.
+func (q *Quota) Cap(eventName string) int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.caps[eventName]
 }

--- a/experimental/ext/events/quota_test.go
+++ b/experimental/ext/events/quota_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/panyam/mcpkit/core"
 	"github.com/panyam/mcpkit/server"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -147,9 +148,15 @@ func TestQuota_Webhook_RejectsThirdSubscribe(t *testing.T) {
 	require.Nil(t, subscribe(t, "b").Error)
 	resp := subscribe(t, "c")
 	require.NotNil(t, resp.Error, "third subscribe should be rejected")
-	require.Equal(t, ErrCodeTooManySubscriptions, resp.Error.Code)
+	require.Equal(t, ErrCodeResourceExhausted, resp.Error.Code)
 	require.Contains(t, resp.Error.Message, "alert.fired")
 	require.Contains(t, resp.Error.Message, "cap 2")
+	// Typed data payload: clients branch on (limit, max) without
+	// parsing the human-readable message.
+	dataBytes, err := json.Marshal(resp.Error.Data)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"limit":"subscriptions","max":2}`, string(dataBytes),
+		"quota Reserve failure must carry typed ResourceExhaustedData with the configured cap")
 }
 
 func TestQuota_Webhook_UnsubscribeReleases(t *testing.T) {
@@ -428,7 +435,7 @@ func TestQuota_Poll_RejectsOverCap(t *testing.T) {
 	// Distinct params → would be a NEW lease → should hit cap.
 	resp := poll("b")
 	require.NotNil(t, resp.Error)
-	require.Equal(t, ErrCodeTooManySubscriptions, resp.Error.Code)
+	require.Equal(t, ErrCodeResourceExhausted, resp.Error.Code)
 	// Lease for "b" must NOT have been retained — rollback path.
 	require.Equal(t, 1, leases.Len(), "rejected poll should not leave a lease behind")
 

--- a/experimental/ext/events/stream.go
+++ b/experimental/ext/events/stream.go
@@ -48,8 +48,8 @@ type StreamEventsResult struct {
 // streamSubscribable is the optional interface a source implements to support
 // events/stream push delivery. YieldingSource satisfies this; TypedSource
 // does not (it has no internal buffer to fan out from). registerStream
-// rejects events/stream for sources lacking this capability with -32017
-// DeliveryModeUnsupported per spec.
+// rejects events/stream for sources lacking this capability with -32014
+// Unsupported (data.feature="deliveryMode", data.value="push") per spec.
 //
 // SubscribeOpts: the SDK passes the resolved subscriber identity
 // (Principal / SubscriptionID / Params) at Subscribe time so the
@@ -132,25 +132,25 @@ func registerStream(srv *server.Server, sourceMap map[string]EventSource, unsafe
 		}
 		source, ok := sourceMap[req.Name]
 		if !ok {
-			return core.NewErrorResponse(id, ErrCodeEventNotFound, "EventNotFound")
+			return newNotFoundError(id, "event", "NotFound")
 		}
 
 		// Spec §"Subscription Identity" → "Authentication required" L361:
 		// events/stream MUST be called with an authenticated principal —
-		// the spec lists Unauthorized among events/stream's immediate
+		// the spec lists -32012 Forbidden among events/stream's immediate
 		// errors at L267. Same auth gate as events/subscribe.
 		principal, ok := resolvePrincipal(ctx, unsafeAnon)
 		if !ok {
-			return core.NewErrorResponse(id, ErrCodeUnauthorized, "Unauthorized")
+			return newForbiddenError(id, "Forbidden")
 		}
 
 		// Sources that don't expose a Subscribe channel (TypedSource today)
-		// can't be served via push. Spec lists DeliveryModeUnsupported
-		// among events/stream's immediate errors at L267.
+		// can't be served via push. Spec lists -32014 Unsupported among
+		// events/stream's immediate errors at L267.
 		sub, ok := source.(streamSubscribable)
 		if !ok {
-			return core.NewErrorResponse(id, ErrCodeDeliveryModeUnsupported,
-				"DeliveryModeUnsupported: source does not support push delivery")
+			return newUnsupportedError(id, "deliveryMode", "push",
+				"Unsupported: source does not support push delivery")
 		}
 
 		// Enforce quota BEFORE Subscribe + on_subscribe per spec
@@ -161,7 +161,7 @@ func registerStream(srv *server.Server, sourceMap map[string]EventSource, unsafe
 		// of how the stream ends (ctx cancel, evCh close, terminated
 		// frame, panic).
 		if err := quota.Reserve(principal, req.Name); err != nil {
-			return core.NewErrorResponse(id, ErrCodeTooManySubscriptions, err.Error())
+			return newResourceExhaustedError(id, "subscriptions", int64(quota.Cap(req.Name)), err.Error())
 		}
 		defer quota.Release(principal, req.Name)
 
@@ -236,7 +236,9 @@ func registerStream(srv *server.Server, sourceMap map[string]EventSource, unsafe
 			// before any delivery happens. Returning an error here
 			// produces a JSON-RPC error response per the spec's
 			// "events/stream's immediate errors" at L267.
-			return core.NewErrorResponse(id, ErrCodeTooManySubscriptions,
+			// Cap unknown at this site — author-defined refusal is
+			// not a server-side quota, so Max is omitted.
+			return newResourceExhaustedError(id, "subscriptions", 0,
 				"on_subscribe rejected: "+err.Error())
 		}
 		defer safeOnUnsubscribe(def.OnUnsubscribe, hc, req.Params)

--- a/experimental/ext/events/stream_test.go
+++ b/experimental/ext/events/stream_test.go
@@ -174,7 +174,7 @@ func validStreamParams() map[string]any {
 }
 
 // TestStream_RejectsUnknownEvent verifies the spec contract that an
-// events/stream against an unknown event name fails with -32011 EventNotFound
+// events/stream against an unknown event name fails with -32011 NotFound
 // before any stream is opened (§"Push-Based Delivery" → "Request: events/stream"
 // L269: "If the subscription is invalid, the server responds immediately with
 // a JSON-RPC error and no stream is opened").
@@ -184,7 +184,7 @@ func TestStream_RejectsUnknownEvent(t *testing.T) {
 	r := rs.endAndAwait(t, time.Second)
 	require.NoError(t, r.err)
 	require.NotNil(t, r.resp.Error, "expected -32011; got result")
-	assert.Equal(t, ErrCodeEventNotFound, r.resp.Error.Code)
+	assert.Equal(t, ErrCodeNotFound, r.resp.Error.Code)
 }
 
 // TestStream_RejectsAnonymousUnderStrictSpec verifies events/stream enforces
@@ -199,8 +199,8 @@ func TestStream_RejectsAnonymousUnderStrictSpec(t *testing.T) {
 	rs := st.startStream(t, validStreamParams())
 	r := rs.endAndAwait(t, time.Second)
 	require.NoError(t, r.err)
-	require.NotNil(t, r.resp.Error, "expected -32012 Unauthorized; got result")
-	assert.Equal(t, ErrCodeUnauthorized, r.resp.Error.Code)
+	require.NotNil(t, r.resp.Error, "expected -32012 Forbidden; got result")
+	assert.Equal(t, ErrCodeForbidden, r.resp.Error.Code)
 }
 
 // TestStream_ActiveNotificationFiresFirst verifies the first frame on a

--- a/experimental/ext/events/webhook.go
+++ b/experimental/ext/events/webhook.go
@@ -967,8 +967,8 @@ func (r *WebhookRegistry) deliver(target WebhookTarget, eventID string, body []b
 // authoritative SSRF guard is the dial-time check in dialContext, which
 // is TOCTOU-safe under DNS rebinding (per spec §"Webhook Security" →
 // "SSRF prevention" L464). ValidateWebhookURL is a UX aid: catches
-// obvious mistakes at subscribe so the client gets -32015 InvalidCallbackUrl
-// immediately rather than a delayed delivery failure.
+// obvious mistakes at subscribe so the client gets -32015
+// CallbackEndpointError immediately rather than a delayed delivery failure.
 func (r *WebhookRegistry) ValidateWebhookURL(rawURL string) error {
 	u, err := url.Parse(rawURL)
 	if err != nil {

--- a/experimental/ext/events/wire_shape_test.go
+++ b/experimental/ext/events/wire_shape_test.go
@@ -72,23 +72,26 @@ func TestPollResponse_FlatShape_Truncated(t *testing.T) {
 		"legacy cursorGap field must be gone: got %s", body)
 }
 
-// TestEventNotFound_UsesSpecCode verifies the EventNotFound error response
-// uses the spec-mandated code -32011 (ErrCodeEventNotFound), not the legacy
-// -32001 which collides with base MCP ResourceNotFound. The spec reserves
-// -32011..-32017 for events errors specifically.
+// TestNotFound_UsesSpecCodeWithKindEvent pins the wire shape for the
+// spec's reusable -32011 NotFound error: same code as the pre-2026-05-22
+// EventNotFound, but now general-purpose with a typed `data.kind`
+// discriminator. Server emits kind="event" for unknown event names and
+// (in future) kind="subscription" for missing unsubscribe targets.
 //
-// The spec's flat-response shape means EventNotFound surfaces as a
-// top-level JSON-RPC error, not an embedded per-result error from the
-// legacy partial-success model.
-func TestEventNotFound_UsesSpecCode(t *testing.T) {
+// The spec's flat-response shape means NotFound surfaces as a top-level
+// JSON-RPC error, not an embedded per-result error from the legacy
+// partial-success model.
+func TestNotFound_UsesSpecCodeWithKindEvent(t *testing.T) {
 	id := json.RawMessage(`1`)
-	resp := core.NewErrorResponse(id, ErrCodeEventNotFound, "EventNotFound")
+	resp := newNotFoundError(id, "event", "NotFound")
 	raw, err := json.Marshal(resp)
 	require.NoError(t, err)
 	body := string(raw)
 
-	assert.Contains(t, body, `"code":-32011`, "EventNotFound must use spec code -32011")
-	assert.Contains(t, body, `"message":"EventNotFound"`)
+	assert.Contains(t, body, `"code":-32011`, "NotFound must use spec code -32011")
+	assert.Contains(t, body, `"message":"NotFound"`)
+	assert.Contains(t, body, `"kind":"event"`,
+		"typed data.kind discriminator must be present so clients can branch without parsing the message")
 	assert.False(t, strings.Contains(body, `"code":-32001`),
 		"legacy -32001 code must not appear (collides with base MCP ResourceNotFound)")
 }
@@ -443,16 +446,21 @@ func TestList_NextCursorPresentWhenSet(t *testing.T) {
 		"populated NextCursor must serialize under the camelCase key; got %s", body)
 }
 
-// TestInvalidCallbackUrl_UsesSpecCode verifies the InvalidCallbackUrl error
-// uses spec code -32015, not the legacy -32005.
-func TestInvalidCallbackUrl_UsesSpecCode(t *testing.T) {
+// TestCallbackEndpointError_UsesSpecCode pins the wire shape for
+// -32015 CallbackEndpointError (renamed from InvalidCallbackUrl on
+// 2026-05-22, same code). The typed data.reason carries a value from
+// the DeliveryErrorBucket vocabulary so a client can use one switch
+// across subscribe-time validation and delivery-time failures.
+func TestCallbackEndpointError_UsesSpecCode(t *testing.T) {
 	id := json.RawMessage(`1`)
-	resp := core.NewErrorResponse(id, ErrCodeInvalidCallbackUrl, "url not allowed")
+	resp := newCallbackEndpointError(id, string(DeliveryErrorConnectionRefused), "url not allowed")
 	raw, err := json.Marshal(resp)
 	require.NoError(t, err)
 	body := string(raw)
 
 	assert.Contains(t, body, `"code":-32015`)
+	assert.Contains(t, body, `"reason":"connection_refused"`,
+		"typed data.reason must carry a DeliveryErrorBucket value")
 	assert.False(t, strings.Contains(body, `"code":-32005`),
 		"legacy -32005 code must not appear")
 }


### PR DESCRIPTION
## What changes

Aligns `experimental/ext/events` with the MCP Events spec's 2026-05-22 error-code consolidation: seven events-specific codes collapse into five general-purpose codes with typed `data` discriminators. Wire codes are unchanged on the four sites that survive the collapse — only the constant names and the human-readable `message` text change — plus `-32017 DeliveryModeUnsupported` is absorbed into `-32014 Unsupported` with `data: {feature: "deliveryMode", value: "push"}`.

Every emission site now attaches a typed payload via small constructor helpers, so a client can branch on `data.kind`, `data.limit`, `data.feature`, or `data.reason` without parsing the message string.

## Reviewer's guide

Read in this order:

1. [experimental/ext/events/errors.go](https://github.com/panyam/mcpkit/pull/620/files#diff-a4f6e6ce5fc8c7f858f262a5879257bc40bbd530e76d9b540f6e4b20454a950a) — start here. The whole rename + data-payload story is in one file: five renamed constants, four typed structs, five thin constructors. Header comment explains the spec rationale.
2. [experimental/ext/events/errors_test.go](https://github.com/panyam/mcpkit/pull/620/files#diff-f755556eec2ab072340227d622dcf0400fbe0e0f173321b149daa0dbb24814cb) — acceptance for the above. Wire-shape tests pin each struct's JSON, including the `omitempty` behaviors that distinguish "cap unknown" from "cap=0". `TestErrorConstructors_AttachTypedData` catches a future contributor "simplifying" a helper to drop the data field.
3. [experimental/ext/events/quota.go](https://github.com/panyam/mcpkit/pull/620/files#diff-7bf082a849c19d20a25d57807e77b1ce8caaa1337059e99bbe022c2a24697a75) — adds `Quota.Cap(eventName) int` so `ResourceExhaustedData.Max` carries the real cap on quota failures instead of being parsed out of the wrapped error message. Sentinel `ErrTooManySubscriptions` keeps its Go-level name (it's a sentinel identity, not a wire code) — only the comment is updated.
4. [experimental/ext/events/events.go](https://github.com/panyam/mcpkit/pull/620/files#diff-4a2a8cf5f00e8770df09ab463340a5fc393acbf3f95ef59af8280e2a7a814815) and [experimental/ext/events/stream.go](https://github.com/panyam/mcpkit/pull/620/files#diff-96edd7245bb56be7d7b0c1cd748792b42a783f433aa3306d5078210e7881800a) — the 13 emission-site updates. Each replaces `core.NewErrorResponse` with the matching helper. Two patterns to look for:
   - Real `quota.Reserve` failures: helper gets `int64(quota.Cap(req.Name))` so `Max` is populated.
   - `on_subscribe` author rejections: also use `-32013` per existing behavior, but `Max=0` (omitted) since "author refused" isn't a server-side quota.
5. Test updates ([experimental/ext/events/quota_test.go](https://github.com/panyam/mcpkit/pull/620/files#diff-084eb45fccc9e4e080f6ace67f21f0041ef92fc67a3b3b8f1f9ca333b56f3b48), `lifecycle_test.go`, `identity_handler_test.go`, `stream_test.go`, `wire_shape_test.go`, [examples/events/telegram/handlers_test.go](https://github.com/panyam/mcpkit/pull/620/files#diff-aa2a519249afecf0fd624f248cdb90c51e31200550c0d6e65a76970102cc877d)) — pure rename + a few added `data.*` shape assertions on canonical sites.
6. Doc updates ([experimental/ext/events/README.md](https://github.com/panyam/mcpkit/pull/620/files#diff-9222f2c9c82e15be71e1b286719f2d44d107c3ea315805c64c3d617ab960d4b3), [experimental/ext/events/DEPLOYMENT.md](https://github.com/panyam/mcpkit/pull/620/files#diff-c75bb17c9b123df102747038873bda868dc6e576a2eba2b10b4fd373a8a8f0b3), [examples/events/discord/WALKTHROUGH.md](https://github.com/panyam/mcpkit/pull/620/files#diff-223925bcbe5cc304ce9e3fab47cf1f0c92badbbbd1586d9fe903b67eff562aeb), [examples/events/discord/walkthrough.go](https://github.com/panyam/mcpkit/pull/620/files#diff-a91452f7910a7461ef1e9d7a389dcbdfde4d9df7d3308d1c03c2ef2b4d417416)) — narrative `-32012 Unauthorized` -> `-32012 Forbidden` and `-32011 EventNotFound` -> `-32011 NotFound (data.kind="event")`. No code behavior touched.

Skim or skip: comment-only changes in `webhook.go`, `hooks.go`, and `clients/go/stream.go`.

## Diff groups

- Production: `errors.go`, `events.go`, `stream.go`, `quota.go`
- Tests: `errors_test.go` (new), `wire_shape_test.go`, `quota_test.go`, `lifecycle_test.go`, `identity_handler_test.go`, `stream_test.go`, `examples/events/telegram/handlers_test.go`
- Docs: `README.md`, `DEPLOYMENT.md`, discord walkthrough pair
- Mechanical comment touch-ups: `webhook.go`, `hooks.go`, `clients/go/stream.go`

## Decision log

- **Hard rename, no deprecated aliases.** `experimental/ext/events` is pre-stable; consumers (in-tree examples) get updated in the same PR. Aliases would bury the rename intent.
- **`-32012` message text changes from `"Unauthorized"` to `"Forbidden"`.** Same wire code, new constant name; the human-readable message follows the constant so a reader greps for the same word.
- **`Quota.Cap()` added (3 LOC) instead of parsing the error message** to populate `ResourceExhaustedData.Max`. Keeps the typed-data contract honest.
- **on_subscribe rejections share `-32013` with quota failures** (existing behavior preserved). Typed data carries `limit="subscriptions"` with `Max=0` (omitted) so a client *can* still distinguish them via the message; the issue calls out a future `SubscribeFailed` code if a real consumer needs the split.
- **`-32015 CallbackEndpointError` from `ValidateWebhookURL` maps all failures to `data.reason="connection_refused"`** for now. Subscribe-time URL validation rejects scheme / loopback / parse failures, none of which map cleanly onto runtime `DeliveryErrorBucket` categories. Conservative first cut; refine if a real consumer needs the split.
- **`ErrTooManySubscriptions` Go sentinel kept as-is.** The issue is about wire codes, not Go-internal sentinel identities. Renaming the sentinel would break callers using `errors.Is` for no wire-format benefit.

## Risk / blast radius

- Affects: `experimental/ext/events`, its `clients/go` SDK, and the two `examples/events/*` demos.
- Tests covering this: full `experimental/ext/events` suite, `clients/go` suite, both example suites. All green locally (`go test ./...` x4 modules, plus root `make test`).
- Be paranoid about: the `Quota.Cap` lock ordering (separate `mu.Lock` from `Reserve` — no nested critical sections, but worth a second look), and the `int -> int64` widening on the wire payload (Go's default JSON numbers; fine).

## Out of scope (deliberately deferred)

- Promotion of these codes into the base `core/` error registry — needs a separate SEP-level conversation, not this PR's job.
- Retiring `docs/EVENTS_SPEC_ALIGNMENT_PLAN.md` and `docs/EVENTS_ETA_PLAN.md` — both are completed-and-stale planning docs (alpha-eta all shipped), and three in-tree citations point at them. Worth its own cleanup PR with the doc churn isolated. Filing a follow-up issue.
- Distinguishing "quota cap reached" from "on_subscribe author rejection" via separate error codes / data shapes. Same wire code today; add a `SubscribeFailed` discriminator if a real consumer asks.

## Test plan

- [x] `go build` clean across `experimental/ext/events`, its `clients/go`, `examples/events/discord`, `examples/events/telegram`.
- [x] `go test -count=1 ./...` green in all four modules above.
- [x] `make test` (root) still green.
- [x] `grep -rn "ErrCodeEventNotFound|ErrCodeUnauthorized|ErrCodeTooManySubscriptions|ErrCodeInvalidCallbackUrl|ErrCodeDeliveryModeUnsupported" --include='*.go'` returns zero hits.
- [x] `errors_test.go` covers all four typed `data` payloads + omitempty behaviors + helper-attaches-data invariant.
- [x] No assertions weakened. New assertions added: 15 (5 typed-data wire shapes + 5 helper-attaches-data + 5 omitempty / cap-present rows).

Closes issue 491.
