### PR TITLE
fix(core/ui): _meta.ui.permissions wire shape — array → spec'd object

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -50,7 +50,7 @@ func newTestMCPServer() *server.Server {
 				Meta: &core.ResourceContentMeta{
 					UI: &core.UIMetadata{
 						ResourceUri: "ui://test/view",
-						Permissions: []string{"clipboard-write"},
+						Permissions: &core.UIPermissions{ClipboardWrite: &struct{}{}},
 					},
 				},
 			}}}, nil
@@ -335,8 +335,8 @@ func TestClientReadResourceMeta(t *testing.T) {
 		if content.Meta.UI.ResourceUri != "ui://test/view" {
 			t.Errorf("resourceUri = %q, want %q", content.Meta.UI.ResourceUri, "ui://test/view")
 		}
-		if len(content.Meta.UI.Permissions) != 1 || content.Meta.UI.Permissions[0] != "clipboard-write" {
-			t.Errorf("permissions = %v, want [clipboard-write]", content.Meta.UI.Permissions)
+		if content.Meta.UI.Permissions == nil || content.Meta.UI.Permissions.ClipboardWrite == nil {
+			t.Errorf("permissions: expected ClipboardWrite set, got %+v", content.Meta.UI.Permissions)
 		}
 	})
 }

--- a/cmd/testserver/conformance_apps.go
+++ b/cmd/testserver/conformance_apps.go
@@ -40,7 +40,7 @@ func registerConformanceApps(srv *server.Server) {
 				CSP: &core.UICSPConfig{
 					ResourceDomains: []string{"cdn.example.com"},
 				},
-				Permissions:           []string{"clipboard-write"},
+				Permissions:           &core.UIPermissions{ClipboardWrite: &struct{}{}},
 				PrefersBorder:         &border,
 				SupportedDisplayModes: []core.DisplayMode{core.DisplayModeInline, core.DisplayModeFullscreen},
 			},
@@ -147,7 +147,7 @@ func registerConformanceApps(srv *server.Server) {
 				Meta: &core.ResourceContentMeta{
 					UI: &core.UIMetadata{
 						ResourceUri: "ui://dashboard/view",
-						Permissions: []string{"clipboard-write"},
+						Permissions: &core.UIPermissions{ClipboardWrite: &struct{}{}},
 					},
 				},
 			}}}, nil

--- a/core/ui.go
+++ b/core/ui.go
@@ -32,9 +32,18 @@ type UIMetadata struct {
 	// Hosts construct Content-Security-Policy from these declarations.
 	CSP *UICSPConfig `json:"csp,omitempty"`
 
-	// Permissions lists browser capabilities the app requests
-	// (e.g., "camera", "microphone", "geolocation", "clipboardWrite").
-	Permissions []string `json:"permissions,omitempty"`
+	// Permissions declares browser Permission-Policy capabilities the App
+	// requests (camera, microphone, geolocation, clipboardWrite).
+	//
+	// Per the MCP Apps spec (McpUiResourcePermissions), permissions belong
+	// on the UI **resource** _meta.ui — NOT on tool _meta. mcpkit emits
+	// permissions only via ResourceContentMeta.UI; setting Permissions on
+	// a tool's UIMetadata has no wire effect.
+	//
+	// Wire shape is an object with optional keys per the spec, each value
+	// an empty object `{}` (placeholder for future per-permission options):
+	//   "permissions": { "microphone": {}, "clipboardWrite": {} }
+	Permissions *UIPermissions `json:"permissions,omitempty"`
 
 	// PrefersBorder hints whether the host should draw a visible border.
 	// nil = host decides, true = border, false = no border.
@@ -47,6 +56,34 @@ type UIMetadata struct {
 	// SupportedDisplayModes declares which display modes this app can render in.
 	// Nil means the host decides. Hosts use this to offer mode switching UI.
 	SupportedDisplayModes []DisplayMode `json:"supportedDisplayModes,omitempty"`
+}
+
+// UIPermissions declares browser Permission-Policy capabilities the App
+// requests. Mirrors the upstream MCP Apps spec's McpUiResourcePermissions
+// shape: a named struct with optional pointer-to-struct{} fields.
+//
+// The pointer-to-empty-struct pattern matches the spec's wire shape — each
+// permission field marshals to `{}` when set (placeholder for future
+// per-permission options) and is omitted entirely when nil.
+//
+// Wire example:
+//
+//	"permissions": { "microphone": {}, "clipboardWrite": {} }
+//
+// Hosts MAY honor these by setting iframe `allow=` attributes. Apps SHOULD
+// NOT assume permissions are granted — use JS feature detection as fallback.
+type UIPermissions struct {
+	// Camera maps to Permission Policy `camera`.
+	Camera *struct{} `json:"camera,omitempty"`
+
+	// Microphone maps to Permission Policy `microphone`.
+	Microphone *struct{} `json:"microphone,omitempty"`
+
+	// Geolocation maps to Permission Policy `geolocation`.
+	Geolocation *struct{} `json:"geolocation,omitempty"`
+
+	// ClipboardWrite maps to Permission Policy `clipboard-write`.
+	ClipboardWrite *struct{} `json:"clipboardWrite,omitempty"`
 }
 
 // UICSPConfig declares external domains for Content-Security-Policy construction.

--- a/core/ui_test.go
+++ b/core/ui_test.go
@@ -270,7 +270,10 @@ func TestUIMetadataJSONRoundTrip(t *testing.T) {
 			FrameDomains:    []string{"embed.example.com"},
 			BaseUriDomains:  []string{"example.com"},
 		},
-		Permissions:   []string{"camera", "microphone"},
+		Permissions: &UIPermissions{
+			Camera:     &struct{}{},
+			Microphone: &struct{}{},
+		},
 		PrefersBorder: &border,
 		Domain:        "myapp",
 	}
@@ -306,14 +309,45 @@ func TestUIMetadataJSONRoundTrip(t *testing.T) {
 	if len(got.CSP.BaseUriDomains) != 1 || got.CSP.BaseUriDomains[0] != "example.com" {
 		t.Errorf("CSP.BaseUriDomains = %v, want [example.com]", got.CSP.BaseUriDomains)
 	}
-	if len(got.Permissions) != 2 {
-		t.Errorf("Permissions length = %d, want 2", len(got.Permissions))
+	if got.Permissions == nil {
+		t.Fatal("Permissions is nil after round-trip")
+	}
+	if got.Permissions.Camera == nil || got.Permissions.Microphone == nil {
+		t.Errorf("Permissions: Camera or Microphone is nil, got %+v", got.Permissions)
+	}
+	if got.Permissions.Geolocation != nil || got.Permissions.ClipboardWrite != nil {
+		t.Errorf("Permissions: Geolocation/ClipboardWrite should be nil, got %+v", got.Permissions)
 	}
 	if got.PrefersBorder == nil || *got.PrefersBorder != true {
 		t.Errorf("PrefersBorder = %v, want true", got.PrefersBorder)
 	}
 	if got.Domain != "myapp" {
 		t.Errorf("Domain = %q, want %q", got.Domain, "myapp")
+	}
+}
+
+// TestUIPermissionsWireShape pins the wire shape of permissions to the
+// upstream MCP Apps spec form: a JSON object with per-permission keys whose
+// values are empty objects (placeholders for future per-permission options).
+//
+// Pre-fix, mcpkit emitted permissions as a JSON array of strings
+// (`["microphone", "clipboardWrite"]`). basic-host's app-bridge.ts reads
+// `permissions.microphone` etc. as property lookups on an object, so the
+// array form produced empty `<iframe allow=>` attributes and silently
+// blocked browser-policy capabilities. This test guards the new shape.
+func TestUIPermissionsWireShape(t *testing.T) {
+	p := UIPermissions{
+		Microphone:     &struct{}{},
+		ClipboardWrite: &struct{}{},
+	}
+	data, err := json.Marshal(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+	want := `{"microphone":{},"clipboardWrite":{}}`
+	if got != want {
+		t.Errorf("UIPermissions wire shape = %s, want %s", got, want)
 	}
 }
 

--- a/examples/apps/compat/transcript/README.md
+++ b/examples/apps/compat/transcript/README.md
@@ -13,6 +13,15 @@ meaningful work in the iframe (rather than just rendering a value).
   from the struct alone — no override needed. A clean middle ground
   between rung 1's trivial output and rung 4's nullable / nested
   shapes.
+- **Iframe Permission-Policy declaration.** First fixture to set
+  `_meta.ui.permissions` on the resource read response — declares the
+  Web Speech API (`microphone`) and the copy-transcript button
+  (`clipboardWrite`) so basic-host (and any spec-compliant host)
+  passes the right `<iframe allow=...>` attribute through to the
+  sandbox. Without this declaration, `recognition.start()` silently
+  fails inside the iframe — the browser blocks mic access by default.
+  See [The iframe permission contract](#the-iframe-permission-contract)
+  below for the wire shape and the spec-conformance footnote.
 
 ## Or Run Live
 
@@ -55,6 +64,77 @@ structured transcript view.
 | Iframe renders the transcript | Same call, scroll up | App iframe lays out the transcript with segments |
 
 See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, the strict Playwright gate, and connecting from VS Code / Claude Desktop / other MCP hosts.
+
+## The iframe permission contract
+
+The transcript App calls the browser's Web Speech API (`recognition.start()`),
+which requires the host to grant the `microphone` Permission-Policy on the
+sandbox iframe. The mcpkit-Go fixture declares this on the resource's
+per-content `_meta.ui.permissions`:
+
+```go
+return core.ResourceResult{Contents: []core.ResourceReadContent{{
+    URI:      req.URI,
+    MimeType: core.AppMIMEType,
+    Text:     html,
+    Meta: &core.ResourceContentMeta{
+        UI: &core.UIMetadata{
+            Permissions: &core.UIPermissions{
+                Microphone:     &struct{}{},
+                ClipboardWrite: &struct{}{},
+            },
+        },
+    },
+}}}, nil
+```
+
+On the wire (`resources/read` response):
+
+```json
+"_meta": {
+  "ui": {
+    "permissions": { "microphone": {}, "clipboardWrite": {} }
+  }
+}
+```
+
+basic-host reads this object and propagates each key into the iframe's
+`allow=` attribute (`microphone; clipboard-write`). The browser then prompts
+for mic access on the first `recognition.start()` call. Without the `_meta`
+block, the iframe loads with no policy grant and recognition silently fails
+with no prompt.
+
+### Why an object (and not an array)?
+
+The spec defines `McpUiResourcePermissions` as a named-and-typed interface
+where each value is an empty object `{}`:
+
+```ts
+interface McpUiResourcePermissions {
+  camera?: {};
+  microphone?: {};
+  geolocation?: {};
+  clipboardWrite?: {};
+}
+```
+
+The empty-object values are a placeholder — future revisions can add
+per-permission options without a wire break (e.g. `microphone: { autoGain: true }`).
+mcpkit mirrors this with the `core.UIPermissions` struct (pointer-to-`struct{}`
+fields, JSON-marshalled to the object form). Pre-`v0.3.x`, mcpkit serialized
+permissions as a JSON array of strings — basic-host did property lookups on
+that array and treated every permission as absent. The shape fix landed
+alongside this fixture's `_meta` wiring.
+
+### Spec-conformance footnote
+
+The MCP Apps spec also says permissions belong **only on the UI resource**,
+not on tool `_meta` (`permissions?: never` on `McpUiToolMeta`). The
+`AppToolConfig.Permissions` / `TypedAppToolConfig.Permissions` fields in
+`ext/ui` currently flow into tool `_meta.ui` for backward compatibility,
+but basic-host does not read them from there. To make a permission take
+effect in the iframe, you must set it on the **resource's** per-content
+`_meta.ui` as shown above. A follow-up will deprecate the tool-meta path.
 
 ## What to Try Next
 

--- a/examples/apps/compat/transcript/main.go
+++ b/examples/apps/compat/transcript/main.go
@@ -92,7 +92,24 @@ func serve() {
 				ResourceURI: resourceURI,
 				ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
 					return core.ResourceResult{Contents: []core.ResourceReadContent{{
-						URI: req.URI, MimeType: core.AppMIMEType, Text: html,
+						URI:      req.URI,
+						MimeType: core.AppMIMEType,
+						Text:     html,
+						// Spec puts iframe Permission-Policy capabilities on the
+						// resource's _meta.ui.permissions — hosts read this to set
+						// the `<iframe allow=...>` attribute. The transcript App
+						// needs microphone (Web Speech API) and clipboardWrite
+						// (its copy-transcript button). Without this _meta block,
+						// basic-host renders the iframe with no policy grant and
+						// recognition.start() silently fails.
+						Meta: &core.ResourceContentMeta{
+							UI: &core.UIMetadata{
+								Permissions: &core.UIPermissions{
+									Microphone:     &struct{}{},
+									ClipboardWrite: &struct{}{},
+								},
+							},
+						},
 					}}}, nil
 				},
 			})

--- a/ext/ui/app_helpers_test.go
+++ b/ext/ui/app_helpers_test.go
@@ -26,7 +26,7 @@ func TestRegisterAppTool(t *testing.T) {
 			return core.ResourceResult{}, nil
 		},
 		Visibility:  []core.UIVisibility{core.UIVisibilityModel, core.UIVisibilityApp},
-		Permissions: []string{"clipboard-write"},
+		Permissions: &core.UIPermissions{ClipboardWrite: &struct{}{}},
 	})
 
 	// Verify tool was registered with _meta.ui
@@ -46,8 +46,8 @@ func TestRegisterAppTool(t *testing.T) {
 	if len(td.Meta.UI.Visibility) != 2 {
 		t.Errorf("visibility length = %d, want 2", len(td.Meta.UI.Visibility))
 	}
-	if len(td.Meta.UI.Permissions) != 1 || td.Meta.UI.Permissions[0] != "clipboard-write" {
-		t.Errorf("permissions = %v", td.Meta.UI.Permissions)
+	if td.Meta.UI.Permissions == nil || td.Meta.UI.Permissions.ClipboardWrite == nil {
+		t.Errorf("permissions: expected ClipboardWrite set, got %+v", td.Meta.UI.Permissions)
 	}
 
 	// Verify resource was registered with correct MIME type

--- a/ext/ui/extension.go
+++ b/ext/ui/extension.go
@@ -121,8 +121,13 @@ type AppToolConfig struct {
 	// CSP declares external domains the app needs.
 	CSP *core.UICSPConfig
 
-	// Permissions lists browser capabilities the app requests.
-	Permissions []string
+	// Permissions declares Permission-Policy capabilities the App needs.
+	// See core.UIPermissions for the wire shape. Note that per the MCP Apps
+	// spec, permissions belong on the UI resource's _meta.ui — set this
+	// field on your ResourceHandler's per-content Meta to take effect.
+	// Setting it here flows into the tool's _meta.ui for symmetry, but
+	// basic-host does not read permissions from tool meta.
+	Permissions *core.UIPermissions
 
 	// PrefersBorder hints whether the host should draw a visible border.
 	PrefersBorder *bool

--- a/ext/ui/typed_app_tool.go
+++ b/ext/ui/typed_app_tool.go
@@ -86,8 +86,13 @@ type TypedAppToolConfig[In, Out any] struct {
 	// CSP declares external domains the app needs.
 	CSP *core.UICSPConfig
 
-	// Permissions lists browser capabilities the app requests.
-	Permissions []string
+	// Permissions declares Permission-Policy capabilities the App needs.
+	// See core.UIPermissions for the wire shape. Note that per the MCP Apps
+	// spec, permissions belong on the UI resource's _meta.ui — set this
+	// field on your ResourceHandler's per-content Meta to take effect.
+	// Setting it here flows into the tool's _meta.ui for symmetry, but
+	// basic-host does not read permissions from tool meta.
+	Permissions *core.UIPermissions
 
 	// PrefersBorder hints whether the host should draw a visible border.
 	PrefersBorder *bool

--- a/server/resource_integration_test.go
+++ b/server/resource_integration_test.go
@@ -490,7 +490,7 @@ func TestResourcesReadMeta(t *testing.T) {
 				Meta: &core.ResourceContentMeta{
 					UI: &core.UIMetadata{
 						ResourceUri:   "ui://app/view",
-						Permissions:   []string{"clipboard-write"},
+						Permissions:   &core.UIPermissions{ClipboardWrite: &struct{}{}},
 						PrefersBorder: boolPtr(false),
 					},
 				},
@@ -543,8 +543,8 @@ func TestResourcesReadMeta(t *testing.T) {
 	if meta.UI.ResourceUri != "ui://app/view" {
 		t.Errorf("resourceUri = %q, want %q", meta.UI.ResourceUri, "ui://app/view")
 	}
-	if len(meta.UI.Permissions) != 1 || meta.UI.Permissions[0] != "clipboard-write" {
-		t.Errorf("permissions = %v, want [clipboard-write]", meta.UI.Permissions)
+	if meta.UI.Permissions == nil || meta.UI.Permissions.ClipboardWrite == nil {
+		t.Errorf("permissions: expected ClipboardWrite set, got %+v", meta.UI.Permissions)
 	}
 	if meta.UI.PrefersBorder == nil || *meta.UI.PrefersBorder != false {
 		t.Errorf("prefersBorder = %v, want false", meta.UI.PrefersBorder)

--- a/tests/e2e/apps/meta_test.go
+++ b/tests/e2e/apps/meta_test.go
@@ -34,7 +34,7 @@ func newAppTestServer() *server.Server {
 						ConnectDomains:  []string{"api.example.com"},
 						ResourceDomains: []string{"cdn.example.com"},
 					},
-					Permissions:   []string{"clipboard-write"},
+					Permissions:   &core.UIPermissions{ClipboardWrite: &struct{}{}},
 					PrefersBorder: boolPtr(true),
 					Domain:        "slyds",
 				},
@@ -70,7 +70,7 @@ func newAppTestServer() *server.Server {
 				Meta: &core.ResourceContentMeta{
 					UI: &core.UIMetadata{
 						ResourceUri: "ui://decks/view",
-						Permissions: []string{"clipboard-write"},
+						Permissions: &core.UIPermissions{ClipboardWrite: &struct{}{}},
 					},
 				},
 			}}}, nil
@@ -152,8 +152,8 @@ func TestToolsListMetaE2E(t *testing.T) {
 	if len(ui.CSP.ResourceDomains) != 1 || ui.CSP.ResourceDomains[0] != "cdn.example.com" {
 		t.Errorf("CSP.ResourceDomains = %v", ui.CSP.ResourceDomains)
 	}
-	if len(ui.Permissions) != 1 || ui.Permissions[0] != "clipboard-write" {
-		t.Errorf("Permissions = %v", ui.Permissions)
+	if ui.Permissions == nil || ui.Permissions.ClipboardWrite == nil {
+		t.Errorf("Permissions: expected ClipboardWrite set, got %+v", ui.Permissions)
 	}
 	if ui.PrefersBorder == nil || *ui.PrefersBorder != true {
 		t.Errorf("PrefersBorder = %v, want true", ui.PrefersBorder)
@@ -202,8 +202,8 @@ func TestResourcesReadMetaE2E(t *testing.T) {
 	if content.Meta.UI.ResourceUri != "ui://decks/view" {
 		t.Errorf("resourceUri = %q", content.Meta.UI.ResourceUri)
 	}
-	if len(content.Meta.UI.Permissions) != 1 || content.Meta.UI.Permissions[0] != "clipboard-write" {
-		t.Errorf("permissions = %v", content.Meta.UI.Permissions)
+	if content.Meta.UI.Permissions == nil || content.Meta.UI.Permissions.ClipboardWrite == nil {
+		t.Errorf("permissions: expected ClipboardWrite set, got %+v", content.Meta.UI.Permissions)
 	}
 
 	// Plain resource — verify _meta absent at wire level

--- a/tests/e2e/apps/resources_test.go
+++ b/tests/e2e/apps/resources_test.go
@@ -121,7 +121,7 @@ func TestResourceMetaPrecedence(t *testing.T) {
 	if content.Meta.UI.ResourceUri != "ui://dashboard/view" {
 		t.Errorf("per-content resourceUri = %q", content.Meta.UI.ResourceUri)
 	}
-	if len(content.Meta.UI.Permissions) != 1 || content.Meta.UI.Permissions[0] != "clipboard-write" {
-		t.Errorf("per-content permissions = %v", content.Meta.UI.Permissions)
+	if content.Meta.UI.Permissions == nil || content.Meta.UI.Permissions.ClipboardWrite == nil {
+		t.Errorf("per-content permissions: expected ClipboardWrite set, got %+v", content.Meta.UI.Permissions)
 	}
 }

--- a/tests/e2e/apps/testenv_test.go
+++ b/tests/e2e/apps/testenv_test.go
@@ -41,7 +41,7 @@ func newConformanceServer() *server.Server {
 					CSP: &core.UICSPConfig{
 						ResourceDomains: []string{"cdn.example.com"},
 					},
-					Permissions:   []string{"clipboard-write"},
+					Permissions:   &core.UIPermissions{ClipboardWrite: &struct{}{}},
 					PrefersBorder: &border,
 				},
 			},
@@ -133,7 +133,7 @@ func newConformanceServer() *server.Server {
 				Meta: &core.ResourceContentMeta{
 					UI: &core.UIMetadata{
 						ResourceUri: "ui://dashboard/view",
-						Permissions: []string{"clipboard-write"},
+						Permissions: &core.UIPermissions{ClipboardWrite: &struct{}{}},
 					},
 				},
 			}}}, nil

--- a/tests/e2e/apps/tools_test.go
+++ b/tests/e2e/apps/tools_test.go
@@ -73,8 +73,8 @@ func TestToolMetaPermissions(t *testing.T) {
 	}
 
 	tool := findTool(t, tools, "show-dashboard")
-	if len(tool.Meta.UI.Permissions) != 1 || tool.Meta.UI.Permissions[0] != "clipboard-write" {
-		t.Errorf("Permissions = %v, want [clipboard-write]", tool.Meta.UI.Permissions)
+	if tool.Meta.UI.Permissions == nil || tool.Meta.UI.Permissions.ClipboardWrite == nil {
+		t.Errorf("Permissions: expected ClipboardWrite set, got %+v", tool.Meta.UI.Permissions)
 	}
 }
 


### PR DESCRIPTION
## What changes

The MCP Apps spec defines `permissions` on UI resource `_meta.ui` as an
object with named optional keys, each value an empty `{}` placeholder:

```json
"permissions": { "microphone": {}, "clipboardWrite": {} }
```

mcpkit previously declared `UIMetadata.Permissions []string` and serialized
to a JSON array (`["microphone", "clipboardWrite"]`). basic-host's
`app-bridge.ts:193-196` reads each permission as a property lookup on the
object (`permissions.microphone`, `permissions.camera` …), so against our
array form every lookup returned `undefined` and the iframe loaded with no
Permission-Policy grant. Browser blocks mic/clipboard. Silent failure.

The bug surfaced via apps/compat parity testing: the transcript fixture's
Start button didn't prompt for microphone access; the upstream TS reference
did. The shape mismatch was the cause.

## Reviewer's guide

Read in this order:
1. [core/ui.go](https://github.com/panyam/mcpkit/pull/623/files#diff-d246bcdcf6e1a27a5ec782c650475169556df98e532bcb6267228949f78b67f1) — the type fix. New `UIPermissions` struct (pointer-to-`struct{}` per spec field), `UIMetadata.Permissions` field type changes. Godoc spells out the wire shape and the resource-vs-tool spec contract.
2. [core/ui_test.go](https://github.com/panyam/mcpkit/pull/623/files#diff-74a083d4739cd11eba89ca78cd6f579c5ed9c674744094ef9309117e76d53d8a) — new `TestUIPermissionsWireShape` is the regression lock. Round-trip test updated to the struct shape.
3. [examples/apps/compat/transcript/main.go](https://github.com/panyam/mcpkit/pull/623/files#diff-3e3c75b0252e3dbf3816b3c095b04c7afa190560ea10d8a289008d265eacc031) — the fixture wires `Permissions` on the resource handler's per-content `Meta`. This is the canonical recipe for any fixture that needs Permission-Policy capabilities.
4. [examples/apps/compat/transcript/README.md](https://github.com/panyam/mcpkit/pull/623/files#diff-5cfdfcd51bdd86199d7eecaee4cfc49eba53e0ec60ec5f21798c613009aa2b09) — new "The iframe permission contract" section explains the wire shape, the array-vs-object pre-fix bug, and the spec-conformance footnote (`permissions?: never` on tool meta).
5. [ext/ui/extension.go](https://github.com/panyam/mcpkit/pull/623/files#diff-903a917ee98edea791e133735ad6752e950e3d53100e17a54d077e82a9f841b5) + [ext/ui/typed_app_tool.go](https://github.com/panyam/mcpkit/pull/623/files#diff-a5c69fbf2c3e40ebe2521adaaed9d44ad2c716e9cd65d841c0cb3f97b92906b3) — `AppToolConfig.Permissions` / `TypedAppToolConfig.Permissions` field type updated. Godoc calls out that basic-host reads permissions from RESOURCE `_meta` only; setting it here flows into tool `_meta.ui` for back-compat but has no iframe effect.
6. [cmd/testserver/conformance_apps.go](https://github.com/panyam/mcpkit/pull/623/files#diff-09e72d3d9187b554d3511fd93d3b6768f30c1d75fa48f277c73d91a75727cbe1) — fixture-server test config updated (both tool-meta and resource-meta paths).

Skim or skip: [client/client_test.go](https://github.com/panyam/mcpkit/pull/623/files#diff-57cdc3e29d0ef725a50897a4fbd1c4f76353429fa66d3a785dcbc17dcd7b6f31), [server/resource_integration_test.go](https://github.com/panyam/mcpkit/pull/623/files#diff-0738ce2b0ee204c4cd9bde8f26d3986c8896d0ac2ad3a69e126cadd95d6d840c), `tests/e2e/apps/*_test.go` — purely mechanical assertion updates to the new struct form. Same content, new accessor syntax.

## Decision log

- **Struct type vs `map[string]struct{}`.** Chose the dedicated struct after the spec re-read: the upstream `McpUiResourcePermissions` interface enumerates four named fields (`camera`, `microphone`, `geolocation`, `clipboardWrite`), each value `{}` as a placeholder for future per-permission options. Mirroring the spec literally wins on IDE autocomplete, compile-time typo catch, and godoc-per-field. Cost: when upstream adds a permission, mcpkit needs a release (typically hours, not days).
- **Kept tool-meta `Permissions` for back-compat.** Per spec, `permissions?: never` on tool `_meta` — but `AppToolConfig.Permissions` already flowed into tool `_meta.ui` and existing tests assert that. Changing that path is a separate concern; this PR fixes only the wire shape. Field godoc spells out the no-op consequence; deprecation deferred to a follow-up.
- **`&struct{}{}` at call sites is verbose-but-explicit.** Considered convenience constructors (`UIPermissions{}.WithMicrophone()`) but didn't add them — the verbosity is bounded (one site per fixture that needs perms), and the literal form makes the wire shape obvious.

## Risk / blast radius

- **Affects:** any caller setting `UIMetadata.Permissions` or the matching field on `AppToolConfig` / `TypedAppToolConfig`. The new field type is incompatible with the old `[]string` — callers must update their config.
- **Wire impact:** servers that previously emitted `"permissions": [...]` (silently broken in basic-host) now emit the spec'd object form. Hosts that special-cased the array form will need to update; spec-compliant hosts unblock immediately.
- **Tests covering this:** `TestUIPermissionsWireShape` (new, locks the JSON shape), `TestUIMetadataJSONRoundTrip`, `TestResourceReadContentMetaSerialization`, e2e apps suite (4 test files).
- **Be paranoid about:** any downstream user not in this repo who set `Permissions []string`. They'll get a compile error on the field assignment — clear failure mode, not a silent miscompile.

## Before / after

Verified with a live `curl resources/read` against the transcript fixture:

```json
"_meta":{"ui":{"permissions":{"microphone":{},"clipboardWrite":{}}}}
```

Pre-fix the same call returned `"permissions":["microphone","clipboardWrite"]` which basic-host treated as absent.

## Out of scope (deliberately deferred)

- Deprecating `AppToolConfig.Permissions` / `TypedAppToolConfig.Permissions` (which flow into tool `_meta` against spec). Follow-up.
- Auto-injecting `Permissions` from the config into the resource handler's per-content `Meta`. Today the user must set it inside the ResourceHandler — explicit but verbose. Convenience wrapper is a future API question.
