### PR TITLE
sheet-music: fix CSP _meta soundfont allowlist + author real walkthroughs surfacing fixture-specific _meta

### DIFF
--- a/examples/apps/compat/basic-preact/walkthrough.go
+++ b/examples/apps/compat/basic-preact/walkthrough.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/panyam/demokit"
 	"github.com/panyam/mcpkit/client"
@@ -29,7 +28,7 @@ import (
 // equivalent *client.Client call). Both render outside the TUI bordered
 // box for mouse-select friendliness.
 func runDemo() {
-	serverURL := serverURLFor3101()
+	serverURL := common.MCPServerURL()
 
 	demo := demokit.New("basic-preact — same App, Preact iframe").
 		Dir("basic-preact").
@@ -203,15 +202,4 @@ fmt.Printf("first 200 bytes: %.200s\n", text)`,
 
 	common.SetupRenderer(demo)
 	demo.Execute()
-}
-
-// serverURLFor3101 returns the walkthrough's target MCP server URL.
-// Defaults to localhost:3101 (the compat-fixture default port, not the
-// :8080 default common.ServerURL() uses for non-UI examples). Honors
-// $MCPKIT_SERVER_URL as an explicit override.
-func serverURLFor3101() string {
-	if u := os.Getenv(common.ServerURLEnv); u != "" {
-		return u
-	}
-	return "http://localhost:3101"
 }

--- a/examples/apps/compat/basic-react/walkthrough.go
+++ b/examples/apps/compat/basic-react/walkthrough.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/panyam/demokit"
 	"github.com/panyam/mcpkit/client"
@@ -29,7 +28,7 @@ import (
 // equivalent *client.Client call). Both render outside the TUI bordered
 // box for mouse-select friendliness.
 func runDemo() {
-	serverURL := serverURLFor3101()
+	serverURL := common.MCPServerURL()
 
 	demo := demokit.New("basic-react — same App, React iframe").
 		Dir("basic-react").
@@ -203,15 +202,4 @@ fmt.Printf("first 200 bytes: %.200s\n", text)`,
 
 	common.SetupRenderer(demo)
 	demo.Execute()
-}
-
-// serverURLFor3101 returns the walkthrough's target MCP server URL.
-// Defaults to localhost:3101 (the compat-fixture default port, not the
-// :8080 default common.ServerURL() uses for non-UI examples). Honors
-// $MCPKIT_SERVER_URL as an explicit override.
-func serverURLFor3101() string {
-	if u := os.Getenv(common.ServerURLEnv); u != "" {
-		return u
-	}
-	return "http://localhost:3101"
 }

--- a/examples/apps/compat/basic-solid/walkthrough.go
+++ b/examples/apps/compat/basic-solid/walkthrough.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/panyam/demokit"
 	"github.com/panyam/mcpkit/client"
@@ -29,7 +28,7 @@ import (
 // equivalent *client.Client call). Both render outside the TUI bordered
 // box for mouse-select friendliness.
 func runDemo() {
-	serverURL := serverURLFor3101()
+	serverURL := common.MCPServerURL()
 
 	demo := demokit.New("basic-solid — same App, Solid iframe").
 		Dir("basic-solid").
@@ -203,15 +202,4 @@ fmt.Printf("first 200 bytes: %.200s\n", text)`,
 
 	common.SetupRenderer(demo)
 	demo.Execute()
-}
-
-// serverURLFor3101 returns the walkthrough's target MCP server URL.
-// Defaults to localhost:3101 (the compat-fixture default port, not the
-// :8080 default common.ServerURL() uses for non-UI examples). Honors
-// $MCPKIT_SERVER_URL as an explicit override.
-func serverURLFor3101() string {
-	if u := os.Getenv(common.ServerURLEnv); u != "" {
-		return u
-	}
-	return "http://localhost:3101"
 }

--- a/examples/apps/compat/basic-svelte/walkthrough.go
+++ b/examples/apps/compat/basic-svelte/walkthrough.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/panyam/demokit"
 	"github.com/panyam/mcpkit/client"
@@ -29,7 +28,7 @@ import (
 // equivalent *client.Client call). Both render outside the TUI bordered
 // box for mouse-select friendliness.
 func runDemo() {
-	serverURL := serverURLFor3101()
+	serverURL := common.MCPServerURL()
 
 	demo := demokit.New("basic-svelte — same App, Svelte iframe").
 		Dir("basic-svelte").
@@ -203,15 +202,4 @@ fmt.Printf("first 200 bytes: %.200s\n", text)`,
 
 	common.SetupRenderer(demo)
 	demo.Execute()
-}
-
-// serverURLFor3101 returns the walkthrough's target MCP server URL.
-// Defaults to localhost:3101 (the compat-fixture default port, not the
-// :8080 default common.ServerURL() uses for non-UI examples). Honors
-// $MCPKIT_SERVER_URL as an explicit override.
-func serverURLFor3101() string {
-	if u := os.Getenv(common.ServerURLEnv); u != "" {
-		return u
-	}
-	return "http://localhost:3101"
 }

--- a/examples/apps/compat/basic-vanillajs/walkthrough.go
+++ b/examples/apps/compat/basic-vanillajs/walkthrough.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/panyam/demokit"
 	"github.com/panyam/mcpkit/client"
@@ -29,7 +28,7 @@ import (
 // equivalent *client.Client call). Both render outside the TUI bordered
 // box for mouse-select friendliness.
 func runDemo() {
-	serverURL := serverURLFor3101()
+	serverURL := common.MCPServerURL()
 
 	demo := demokit.New("basic-vanillajs — minimum-viable MCP App").
 		Dir("basic-vanillajs").
@@ -203,15 +202,4 @@ fmt.Printf("first 200 bytes: %.200s\n", text)`,
 
 	common.SetupRenderer(demo)
 	demo.Execute()
-}
-
-// serverURLFor3101 returns the walkthrough's target MCP server URL.
-// Defaults to localhost:3101 (the compat-fixture default port, not the
-// :8080 default common.ServerURL() uses for non-UI examples). Honors
-// $MCPKIT_SERVER_URL as an explicit override.
-func serverURLFor3101() string {
-	if u := os.Getenv(common.ServerURLEnv); u != "" {
-		return u
-	}
-	return "http://localhost:3101"
 }

--- a/examples/apps/compat/basic-vue/walkthrough.go
+++ b/examples/apps/compat/basic-vue/walkthrough.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/panyam/demokit"
 	"github.com/panyam/mcpkit/client"
@@ -29,7 +28,7 @@ import (
 // equivalent *client.Client call). Both render outside the TUI bordered
 // box for mouse-select friendliness.
 func runDemo() {
-	serverURL := serverURLFor3101()
+	serverURL := common.MCPServerURL()
 
 	demo := demokit.New("basic-vue — same App, Vue iframe").
 		Dir("basic-vue").
@@ -203,15 +202,4 @@ fmt.Printf("first 200 bytes: %.200s\n", text)`,
 
 	common.SetupRenderer(demo)
 	demo.Execute()
-}
-
-// serverURLFor3101 returns the walkthrough's target MCP server URL.
-// Defaults to localhost:3101 (the compat-fixture default port, not the
-// :8080 default common.ServerURL() uses for non-UI examples). Honors
-// $MCPKIT_SERVER_URL as an explicit override.
-func serverURLFor3101() string {
-	if u := os.Getenv(common.ServerURLEnv); u != "" {
-		return u
-	}
-	return "http://localhost:3101"
 }

--- a/examples/apps/compat/budget-allocator/walkthrough.go
+++ b/examples/apps/compat/budget-allocator/walkthrough.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/panyam/demokit"
 	"github.com/panyam/mcpkit/client"
@@ -20,7 +19,7 @@ import (
 //
 // TODO: replace this stub with a curated walkthrough.
 func runDemo() {
-	serverURL := serverURLFor3101()
+	serverURL := common.MCPServerURL()
 
 	demo := demokit.New("budget-allocator walkthrough (stub)").
 		Description("TODO: describe what this walkthrough demonstrates.").
@@ -64,14 +63,4 @@ func runDemo() {
 
 	common.SetupRenderer(demo)
 	demo.Execute()
-}
-
-// serverURLFor3101 returns the walkthrough's target MCP server URL.
-// Honors $MCPKIT_SERVER_URL as an explicit override; defaults to
-// localhost:3101 (the compat-fixture port).
-func serverURLFor3101() string {
-	if u := os.Getenv(common.ServerURLEnv); u != "" {
-		return u
-	}
-	return "http://localhost:3101"
 }

--- a/examples/apps/compat/cohort-heatmap/walkthrough.go
+++ b/examples/apps/compat/cohort-heatmap/walkthrough.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/panyam/demokit"
 	"github.com/panyam/mcpkit/client"
@@ -20,7 +19,7 @@ import (
 //
 // TODO: replace this stub with a curated walkthrough.
 func runDemo() {
-	serverURL := serverURLFor3101()
+	serverURL := common.MCPServerURL()
 
 	demo := demokit.New("cohort-heatmap walkthrough (stub)").
 		Description("TODO: describe what this walkthrough demonstrates.").
@@ -64,14 +63,4 @@ func runDemo() {
 
 	common.SetupRenderer(demo)
 	demo.Execute()
-}
-
-// serverURLFor3101 returns the walkthrough's target MCP server URL.
-// Honors $MCPKIT_SERVER_URL as an explicit override; defaults to
-// localhost:3101 (the compat-fixture port).
-func serverURLFor3101() string {
-	if u := os.Getenv(common.ServerURLEnv); u != "" {
-		return u
-	}
-	return "http://localhost:3101"
 }

--- a/examples/apps/compat/customer-segmentation/walkthrough.go
+++ b/examples/apps/compat/customer-segmentation/walkthrough.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/panyam/demokit"
 	"github.com/panyam/mcpkit/client"
@@ -20,7 +19,7 @@ import (
 //
 // TODO: replace this stub with a curated walkthrough.
 func runDemo() {
-	serverURL := serverURLFor3101()
+	serverURL := common.MCPServerURL()
 
 	demo := demokit.New("customer-segmentation walkthrough (stub)").
 		Description("TODO: describe what this walkthrough demonstrates.").
@@ -64,14 +63,4 @@ func runDemo() {
 
 	common.SetupRenderer(demo)
 	demo.Execute()
-}
-
-// serverURLFor3101 returns the walkthrough's target MCP server URL.
-// Honors $MCPKIT_SERVER_URL as an explicit override; defaults to
-// localhost:3101 (the compat-fixture port).
-func serverURLFor3101() string {
-	if u := os.Getenv(common.ServerURLEnv); u != "" {
-		return u
-	}
-	return "http://localhost:3101"
 }

--- a/examples/apps/compat/debug-server/walkthrough.go
+++ b/examples/apps/compat/debug-server/walkthrough.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/panyam/demokit"
 	"github.com/panyam/mcpkit/client"
@@ -20,7 +19,7 @@ import (
 //
 // TODO: replace this stub with a curated walkthrough.
 func runDemo() {
-	serverURL := serverURLFor3101()
+	serverURL := common.MCPServerURL()
 
 	demo := demokit.New("debug-server walkthrough (stub)").
 		Description("TODO: describe what this walkthrough demonstrates.").
@@ -64,14 +63,4 @@ func runDemo() {
 
 	common.SetupRenderer(demo)
 	demo.Execute()
-}
-
-// serverURLFor3101 returns the walkthrough's target MCP server URL.
-// Honors $MCPKIT_SERVER_URL as an explicit override; defaults to
-// localhost:3101 (the compat-fixture port).
-func serverURLFor3101() string {
-	if u := os.Getenv(common.ServerURLEnv); u != "" {
-		return u
-	}
-	return "http://localhost:3101"
 }

--- a/examples/apps/compat/integration/walkthrough.go
+++ b/examples/apps/compat/integration/walkthrough.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/panyam/demokit"
 	"github.com/panyam/mcpkit/client"
@@ -20,7 +19,7 @@ import (
 //
 // TODO: replace this stub with a curated walkthrough.
 func runDemo() {
-	serverURL := serverURLFor3101()
+	serverURL := common.MCPServerURL()
 
 	demo := demokit.New("integration walkthrough (stub)").
 		Description("TODO: describe what this walkthrough demonstrates.").
@@ -64,14 +63,4 @@ func runDemo() {
 
 	common.SetupRenderer(demo)
 	demo.Execute()
-}
-
-// serverURLFor3101 returns the walkthrough's target MCP server URL.
-// Honors $MCPKIT_SERVER_URL as an explicit override; defaults to
-// localhost:3101 (the compat-fixture port).
-func serverURLFor3101() string {
-	if u := os.Getenv(common.ServerURLEnv); u != "" {
-		return u
-	}
-	return "http://localhost:3101"
 }

--- a/examples/apps/compat/map/walkthrough.go
+++ b/examples/apps/compat/map/walkthrough.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/panyam/demokit"
 	"github.com/panyam/mcpkit/client"
@@ -20,7 +19,7 @@ import (
 //
 // TODO: replace this stub with a curated walkthrough.
 func runDemo() {
-	serverURL := serverURLFor3101()
+	serverURL := common.MCPServerURL()
 
 	demo := demokit.New("map walkthrough (stub)").
 		Description("TODO: describe what this walkthrough demonstrates.").
@@ -64,14 +63,4 @@ func runDemo() {
 
 	common.SetupRenderer(demo)
 	demo.Execute()
-}
-
-// serverURLFor3101 returns the walkthrough's target MCP server URL.
-// Honors $MCPKIT_SERVER_URL as an explicit override; defaults to
-// localhost:3101 (the compat-fixture port).
-func serverURLFor3101() string {
-	if u := os.Getenv(common.ServerURLEnv); u != "" {
-		return u
-	}
-	return "http://localhost:3101"
 }

--- a/examples/apps/compat/pdf-server/walkthrough.go
+++ b/examples/apps/compat/pdf-server/walkthrough.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/panyam/demokit"
 	"github.com/panyam/mcpkit/client"
@@ -20,7 +19,7 @@ import (
 //
 // TODO: replace this stub with a curated walkthrough.
 func runDemo() {
-	serverURL := serverURLFor3101()
+	serverURL := common.MCPServerURL()
 
 	demo := demokit.New("pdf-server walkthrough (stub)").
 		Description("TODO: describe what this walkthrough demonstrates.").
@@ -64,14 +63,4 @@ func runDemo() {
 
 	common.SetupRenderer(demo)
 	demo.Execute()
-}
-
-// serverURLFor3101 returns the walkthrough's target MCP server URL.
-// Honors $MCPKIT_SERVER_URL as an explicit override; defaults to
-// localhost:3101 (the compat-fixture port).
-func serverURLFor3101() string {
-	if u := os.Getenv(common.ServerURLEnv); u != "" {
-		return u
-	}
-	return "http://localhost:3101"
 }

--- a/examples/apps/compat/quickstart/walkthrough.go
+++ b/examples/apps/compat/quickstart/walkthrough.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/panyam/demokit"
 	"github.com/panyam/mcpkit/client"
@@ -20,7 +19,7 @@ import (
 //
 // TODO: replace this stub with a curated walkthrough.
 func runDemo() {
-	serverURL := serverURLFor3101()
+	serverURL := common.MCPServerURL()
 
 	demo := demokit.New("quickstart walkthrough (stub)").
 		Description("TODO: describe what this walkthrough demonstrates.").
@@ -64,14 +63,4 @@ func runDemo() {
 
 	common.SetupRenderer(demo)
 	demo.Execute()
-}
-
-// serverURLFor3101 returns the walkthrough's target MCP server URL.
-// Honors $MCPKIT_SERVER_URL as an explicit override; defaults to
-// localhost:3101 (the compat-fixture port).
-func serverURLFor3101() string {
-	if u := os.Getenv(common.ServerURLEnv); u != "" {
-		return u
-	}
-	return "http://localhost:3101"
 }

--- a/examples/apps/compat/scenario-modeler/walkthrough.go
+++ b/examples/apps/compat/scenario-modeler/walkthrough.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/panyam/demokit"
 	"github.com/panyam/mcpkit/client"
@@ -20,7 +19,7 @@ import (
 //
 // TODO: replace this stub with a curated walkthrough.
 func runDemo() {
-	serverURL := serverURLFor3101()
+	serverURL := common.MCPServerURL()
 
 	demo := demokit.New("scenario-modeler walkthrough (stub)").
 		Description("TODO: describe what this walkthrough demonstrates.").
@@ -64,14 +63,4 @@ func runDemo() {
 
 	common.SetupRenderer(demo)
 	demo.Execute()
-}
-
-// serverURLFor3101 returns the walkthrough's target MCP server URL.
-// Honors $MCPKIT_SERVER_URL as an explicit override; defaults to
-// localhost:3101 (the compat-fixture port).
-func serverURLFor3101() string {
-	if u := os.Getenv(common.ServerURLEnv); u != "" {
-		return u
-	}
-	return "http://localhost:3101"
 }

--- a/examples/apps/compat/shadertoy/walkthrough.go
+++ b/examples/apps/compat/shadertoy/walkthrough.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/panyam/demokit"
 	"github.com/panyam/mcpkit/client"
@@ -20,7 +19,7 @@ import (
 //
 // TODO: replace this stub with a curated walkthrough.
 func runDemo() {
-	serverURL := serverURLFor3101()
+	serverURL := common.MCPServerURL()
 
 	demo := demokit.New("shadertoy walkthrough (stub)").
 		Description("TODO: describe what this walkthrough demonstrates.").
@@ -64,14 +63,4 @@ func runDemo() {
 
 	common.SetupRenderer(demo)
 	demo.Execute()
-}
-
-// serverURLFor3101 returns the walkthrough's target MCP server URL.
-// Honors $MCPKIT_SERVER_URL as an explicit override; defaults to
-// localhost:3101 (the compat-fixture port).
-func serverURLFor3101() string {
-	if u := os.Getenv(common.ServerURLEnv); u != "" {
-		return u
-	}
-	return "http://localhost:3101"
 }

--- a/examples/apps/compat/sheet-music/README.md
+++ b/examples/apps/compat/sheet-music/README.md
@@ -16,6 +16,18 @@ schema. Introduces the `InputSchemaPatch` escape hatch.
   default at the first comma. The fixture uses `InputSchemaPatch` to
   land the default verbatim via
   `s.Prop("abcNotation").Default(defaultABCNotation)`.
+- **CSP `connect-src` declaration on the resource.** First fixture
+  whose iframe fetches a runtime resource from an external origin —
+  abcjs streams soundfonts from `paulrosen.github.io` when you click
+  ▶ Play. The fixture declares that origin under the resource's
+  `_meta.ui.csp.connectDomains` so basic-host adds it to the iframe's
+  `connect-src` CSP directive. Without this, the soundfont fetch is
+  blocked and the play button silently does nothing. See
+  [The CSP connect-src contract](#the-csp-connect-src-contract) below.
+
+## Run Pre-Recorded
+
+> ▶ **[Play the walkthrough in your browser](https://panyam.github.io/mcpkit/walkthroughs/examples/apps/compat/sheet-music/)** — animated playback of every curl / Go call the walkthrough makes, step-by-step. The trace surfaces the two distinctive things about this fixture on the wire: `inputSchema.properties.abcNotation.default` landing the multi-line ABC verbatim, and `_meta.ui.csp.connectDomains` declaring the soundfont allowlist that unblocks audio. No clone, no setup.
 
 ## Or Run Live
 
@@ -67,6 +79,65 @@ play it back.
 | Verify the multi-line default landed intact | Expand `inputSchema.properties.abcNotation.default` | The full 11-line ABC notation including commas — no truncation. This is what `InputSchemaPatch` preserves. |
 
 See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, the strict Playwright gate, and connecting from VS Code / Claude Desktop / other MCP hosts.
+
+## The CSP connect-src contract
+
+abcjs renders sheet music statically with what's already in the iframe,
+but audio playback is different: clicking ▶ Play makes the library `fetch`
+soundfont samples from `https://paulrosen.github.io` (abcjs's hosted
+soundfont CDN) and decode them via WebAudio. That fetch is governed by
+the iframe sandbox's Content-Security-Policy. If the origin isn't on the
+`connect-src` allowlist, the browser blocks the fetch silently — the
+sheet music still renders, but ▶ Play does nothing.
+
+The mcpkit-Go fixture declares the origin on the resource's per-content
+`_meta.ui.csp`:
+
+```go
+return core.ResourceResult{Contents: []core.ResourceReadContent{{
+    URI:      req.URI,
+    MimeType: core.AppMIMEType,
+    Text:     html,
+    Meta: &core.ResourceContentMeta{
+        UI: &core.UIMetadata{
+            CSP: &core.UICSPConfig{
+                ConnectDomains: []string{"https://paulrosen.github.io"},
+            },
+        },
+    },
+}}}, nil
+```
+
+On the wire (`resources/read` response):
+
+```json
+"_meta": {
+  "ui": {
+    "csp": {
+      "connectDomains": ["https://paulrosen.github.io"]
+    }
+  }
+}
+```
+
+basic-host reads this and adds the origin to the iframe's `connect-src`
+directive. The soundfont fetch succeeds, the buffer decodes, and audio
+plays. This is the same family of bug as the transcript fixture's missing
+`microphone` permission ([PR 623](https://github.com/panyam/mcpkit/pull/623))
+— a one-line iframe sandbox declaration that's invisible if you only
+trust the visual render, and silent on failure.
+
+### CSP fields
+
+`core.UICSPConfig` maps to the four common CSP directives. Each accepts
+a `[]string` of origins:
+
+| Go field | CSP directive | Use case |
+|---|---|---|
+| `ConnectDomains` | `connect-src` | `fetch` / `XMLHttpRequest` / WebSocket targets (this fixture: soundfont CDN) |
+| `ResourceDomains` | `script-src` / `style-src` / `img-src` / `font-src` / `media-src` | static assets the iframe loads (CDN-hosted libs, images, fonts) |
+| `FrameDomains` | `frame-src` | nested iframes the App embeds |
+| `BaseUriDomains` | `base-uri` | `<base href>` overrides |
 
 ## What to Try Next
 

--- a/examples/apps/compat/sheet-music/bundle/ansi_up.js
+++ b/examples/apps/compat/sheet-music/bundle/ansi_up.js
@@ -1,0 +1,431 @@
+"use strict";
+var __makeTemplateObject = (this && this.__makeTemplateObject) || function (cooked, raw) {
+    if (Object.defineProperty) { Object.defineProperty(cooked, "raw", { value: raw }); } else { cooked.raw = raw; }
+    return cooked;
+};
+var PacketKind;
+(function (PacketKind) {
+    PacketKind[PacketKind["EOS"] = 0] = "EOS";
+    PacketKind[PacketKind["Text"] = 1] = "Text";
+    PacketKind[PacketKind["Incomplete"] = 2] = "Incomplete";
+    PacketKind[PacketKind["ESC"] = 3] = "ESC";
+    PacketKind[PacketKind["Unknown"] = 4] = "Unknown";
+    PacketKind[PacketKind["SGR"] = 5] = "SGR";
+    PacketKind[PacketKind["OSCURL"] = 6] = "OSCURL";
+})(PacketKind || (PacketKind = {}));
+export class AnsiUp {
+    constructor() {
+        this.VERSION = "6.0.6";
+        this.setup_palettes();
+        this._use_classes = false;
+        this.bold = false;
+        this.faint = false;
+        this.italic = false;
+        this.underline = false;
+        this.fg = this.bg = null;
+        this._buffer = '';
+        this._url_allowlist = { 'http': 1, 'https': 1 };
+        this._escape_html = true;
+        this.boldStyle = 'font-weight:bold';
+        this.faintStyle = 'opacity:0.7';
+        this.italicStyle = 'font-style:italic';
+        this.underlineStyle = 'text-decoration:underline';
+    }
+    set use_classes(arg) {
+        this._use_classes = arg;
+    }
+    get use_classes() {
+        return this._use_classes;
+    }
+    set url_allowlist(arg) {
+        this._url_allowlist = arg;
+    }
+    get url_allowlist() {
+        return this._url_allowlist;
+    }
+    set escape_html(arg) {
+        this._escape_html = arg;
+    }
+    get escape_html() {
+        return this._escape_html;
+    }
+    set boldStyle(arg) { this._boldStyle = arg; }
+    get boldStyle() { return this._boldStyle; }
+    set faintStyle(arg) { this._faintStyle = arg; }
+    get faintStyle() { return this._faintStyle; }
+    set italicStyle(arg) { this._italicStyle = arg; }
+    get italicStyle() { return this._italicStyle; }
+    set underlineStyle(arg) { this._underlineStyle = arg; }
+    get underlineStyle() { return this._underlineStyle; }
+    setup_palettes() {
+        this.ansi_colors =
+            [
+                [
+                    { rgb: [0, 0, 0], class_name: "ansi-black" },
+                    { rgb: [187, 0, 0], class_name: "ansi-red" },
+                    { rgb: [0, 187, 0], class_name: "ansi-green" },
+                    { rgb: [187, 187, 0], class_name: "ansi-yellow" },
+                    { rgb: [0, 0, 187], class_name: "ansi-blue" },
+                    { rgb: [187, 0, 187], class_name: "ansi-magenta" },
+                    { rgb: [0, 187, 187], class_name: "ansi-cyan" },
+                    { rgb: [255, 255, 255], class_name: "ansi-white" }
+                ],
+                [
+                    { rgb: [85, 85, 85], class_name: "ansi-bright-black" },
+                    { rgb: [255, 85, 85], class_name: "ansi-bright-red" },
+                    { rgb: [0, 255, 0], class_name: "ansi-bright-green" },
+                    { rgb: [255, 255, 85], class_name: "ansi-bright-yellow" },
+                    { rgb: [85, 85, 255], class_name: "ansi-bright-blue" },
+                    { rgb: [255, 85, 255], class_name: "ansi-bright-magenta" },
+                    { rgb: [85, 255, 255], class_name: "ansi-bright-cyan" },
+                    { rgb: [255, 255, 255], class_name: "ansi-bright-white" }
+                ]
+            ];
+        this.palette_256 = [];
+        this.ansi_colors.forEach(palette => {
+            palette.forEach(rec => {
+                this.palette_256.push(rec);
+            });
+        });
+        let levels = [0, 95, 135, 175, 215, 255];
+        for (let r = 0; r < 6; ++r) {
+            for (let g = 0; g < 6; ++g) {
+                for (let b = 0; b < 6; ++b) {
+                    let col = { rgb: [levels[r], levels[g], levels[b]], class_name: 'truecolor' };
+                    this.palette_256.push(col);
+                }
+            }
+        }
+        let grey_level = 8;
+        for (let i = 0; i < 24; ++i, grey_level += 10) {
+            let gry = { rgb: [grey_level, grey_level, grey_level], class_name: 'truecolor' };
+            this.palette_256.push(gry);
+        }
+    }
+    escape_txt_for_html(txt) {
+        if (!this._escape_html)
+            return txt;
+        return txt.replace(/[&<>"']/gm, (str) => {
+            if (str === "&")
+                return "&amp;";
+            if (str === "<")
+                return "&lt;";
+            if (str === ">")
+                return "&gt;";
+            if (str === "\"")
+                return "&quot;";
+            if (str === "'")
+                return "&#x27;";
+        });
+    }
+    append_buffer(txt) {
+        var str = this._buffer + txt;
+        this._buffer = str;
+    }
+    get_next_packet() {
+        var pkt = {
+            kind: PacketKind.EOS,
+            text: '',
+            url: ''
+        };
+        var len = this._buffer.length;
+        if (len == 0)
+            return pkt;
+        var pos = this._buffer.indexOf("\x1B");
+        if (pos == -1) {
+            pkt.kind = PacketKind.Text;
+            pkt.text = this._buffer;
+            this._buffer = '';
+            return pkt;
+        }
+        if (pos > 0) {
+            pkt.kind = PacketKind.Text;
+            pkt.text = this._buffer.slice(0, pos);
+            this._buffer = this._buffer.slice(pos);
+            return pkt;
+        }
+        if (pos == 0) {
+            if (len < 3) {
+                pkt.kind = PacketKind.Incomplete;
+                return pkt;
+            }
+            var next_char = this._buffer.charAt(1);
+            if ((next_char != '[') && (next_char != ']') && (next_char != '(')) {
+                pkt.kind = PacketKind.ESC;
+                pkt.text = this._buffer.slice(0, 1);
+                this._buffer = this._buffer.slice(1);
+                return pkt;
+            }
+            if (next_char == '[') {
+                if (!this._csi_regex) {
+                    this._csi_regex = rgx(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\n                        ^                           # beginning of line\n                                                    #\n                                                    # First attempt\n                        (?:                         # legal sequence\n                          \u001B[                      # CSI\n                          ([<-?]?)              # private-mode char\n                          ([d;]*)                    # any digits or semicolons\n                          ([ -/]?               # an intermediate modifier\n                          [@-~])                # the command\n                        )\n                        |                           # alternate (second attempt)\n                        (?:                         # illegal sequence\n                          \u001B[                      # CSI\n                          [ -~]*                # anything legal\n                          ([\0-\u001F:])              # anything illegal\n                        )\n                    "], ["\n                        ^                           # beginning of line\n                                                    #\n                                                    # First attempt\n                        (?:                         # legal sequence\n                          \\x1b\\[                      # CSI\n                          ([\\x3c-\\x3f]?)              # private-mode char\n                          ([\\d;]*)                    # any digits or semicolons\n                          ([\\x20-\\x2f]?               # an intermediate modifier\n                          [\\x40-\\x7e])                # the command\n                        )\n                        |                           # alternate (second attempt)\n                        (?:                         # illegal sequence\n                          \\x1b\\[                      # CSI\n                          [\\x20-\\x7e]*                # anything legal\n                          ([\\x00-\\x1f:])              # anything illegal\n                        )\n                    "])));
+                }
+                let match = this._buffer.match(this._csi_regex);
+                if (match === null) {
+                    pkt.kind = PacketKind.Incomplete;
+                    return pkt;
+                }
+                if (match[4]) {
+                    pkt.kind = PacketKind.ESC;
+                    pkt.text = this._buffer.slice(0, 1);
+                    this._buffer = this._buffer.slice(1);
+                    return pkt;
+                }
+                if ((match[1] != '') || (match[3] != 'm'))
+                    pkt.kind = PacketKind.Unknown;
+                else
+                    pkt.kind = PacketKind.SGR;
+                pkt.text = match[2];
+                var rpos = match[0].length;
+                this._buffer = this._buffer.slice(rpos);
+                return pkt;
+            }
+            else if (next_char == ']') {
+                if (len < 4) {
+                    pkt.kind = PacketKind.Incomplete;
+                    return pkt;
+                }
+                if ((this._buffer.charAt(2) != '8')
+                    || (this._buffer.charAt(3) != ';')) {
+                    pkt.kind = PacketKind.ESC;
+                    pkt.text = this._buffer.slice(0, 1);
+                    this._buffer = this._buffer.slice(1);
+                    return pkt;
+                }
+                if (!this._osc_st) {
+                    this._osc_st = rgxG(templateObject_2 || (templateObject_2 = __makeTemplateObject(["\n                        (?:                         # legal sequence\n                          (\u001B\\)                    # ESC                           |                           # alternate\n                          (\u0007)                      # BEL (what xterm did)\n                        )\n                        |                           # alternate (second attempt)\n                        (                           # illegal sequence\n                          [\0-\u0006]                 # anything illegal\n                          |                           # alternate\n                          [\b-\u001A]                 # anything illegal\n                          |                           # alternate\n                          [\u001C-\u001F]                 # anything illegal\n                        )\n                    "], ["\n                        (?:                         # legal sequence\n                          (\\x1b\\\\)                    # ESC \\\n                          |                           # alternate\n                          (\\x07)                      # BEL (what xterm did)\n                        )\n                        |                           # alternate (second attempt)\n                        (                           # illegal sequence\n                          [\\x00-\\x06]                 # anything illegal\n                          |                           # alternate\n                          [\\x08-\\x1a]                 # anything illegal\n                          |                           # alternate\n                          [\\x1c-\\x1f]                 # anything illegal\n                        )\n                    "])));
+                }
+                this._osc_st.lastIndex = 0;
+                {
+                    let match = this._osc_st.exec(this._buffer);
+                    if (match === null) {
+                        pkt.kind = PacketKind.Incomplete;
+                        return pkt;
+                    }
+                    if (match[3]) {
+                        pkt.kind = PacketKind.ESC;
+                        pkt.text = this._buffer.slice(0, 1);
+                        this._buffer = this._buffer.slice(1);
+                        return pkt;
+                    }
+                }
+                {
+                    let match = this._osc_st.exec(this._buffer);
+                    if (match === null) {
+                        pkt.kind = PacketKind.Incomplete;
+                        return pkt;
+                    }
+                    if (match[3]) {
+                        pkt.kind = PacketKind.ESC;
+                        pkt.text = this._buffer.slice(0, 1);
+                        this._buffer = this._buffer.slice(1);
+                        return pkt;
+                    }
+                }
+                if (!this._osc_regex) {
+                    this._osc_regex = rgx(templateObject_3 || (templateObject_3 = __makeTemplateObject(["\n                        ^                           # beginning of line\n                                                    #\n                        \u001B]8;                    # OSC Hyperlink\n                        [ -:<-~]*       # params (excluding ;)\n                        ;                           # end of params\n                        ([!-~]{0,512})        # URL capture\n                        (?:                         # ST\n                          (?:\u001B\\)                  # ESC                           |                           # alternate\n                          (?:\u0007)                    # BEL (what xterm did)\n                        )\n                        ([ -~]+)              # TEXT capture\n                        \u001B]8;;                   # OSC Hyperlink End\n                        (?:                         # ST\n                          (?:\u001B\\)                  # ESC                           |                           # alternate\n                          (?:\u0007)                    # BEL (what xterm did)\n                        )\n                    "], ["\n                        ^                           # beginning of line\n                                                    #\n                        \\x1b\\]8;                    # OSC Hyperlink\n                        [\\x20-\\x3a\\x3c-\\x7e]*       # params (excluding ;)\n                        ;                           # end of params\n                        ([\\x21-\\x7e]{0,512})        # URL capture\n                        (?:                         # ST\n                          (?:\\x1b\\\\)                  # ESC \\\n                          |                           # alternate\n                          (?:\\x07)                    # BEL (what xterm did)\n                        )\n                        ([\\x20-\\x7e]+)              # TEXT capture\n                        \\x1b\\]8;;                   # OSC Hyperlink End\n                        (?:                         # ST\n                          (?:\\x1b\\\\)                  # ESC \\\n                          |                           # alternate\n                          (?:\\x07)                    # BEL (what xterm did)\n                        )\n                    "])));
+                }
+                let match = this._buffer.match(this._osc_regex);
+                if (match === null) {
+                    pkt.kind = PacketKind.ESC;
+                    pkt.text = this._buffer.slice(0, 1);
+                    this._buffer = this._buffer.slice(1);
+                    return pkt;
+                }
+                pkt.kind = PacketKind.OSCURL;
+                pkt.url = match[1];
+                pkt.text = match[2];
+                var rpos = match[0].length;
+                this._buffer = this._buffer.slice(rpos);
+                return pkt;
+            }
+            else if (next_char == '(') {
+                pkt.kind = PacketKind.Unknown;
+                this._buffer = this._buffer.slice(3);
+                return pkt;
+            }
+        }
+    }
+    ansi_to_html(txt) {
+        this.append_buffer(txt);
+        var blocks = [];
+        while (true) {
+            var packet = this.get_next_packet();
+            if ((packet.kind == PacketKind.EOS)
+                || (packet.kind == PacketKind.Incomplete))
+                break;
+            if ((packet.kind == PacketKind.ESC)
+                || (packet.kind == PacketKind.Unknown))
+                continue;
+            if (packet.kind == PacketKind.Text)
+                blocks.push(this.transform_to_html(this.with_state(packet)));
+            else if (packet.kind == PacketKind.SGR)
+                this.process_ansi(packet);
+            else if (packet.kind == PacketKind.OSCURL)
+                blocks.push(this.process_hyperlink(packet));
+        }
+        return blocks.join("");
+    }
+    with_state(pkt) {
+        return { bold: this.bold, faint: this.faint, italic: this.italic, underline: this.underline, fg: this.fg, bg: this.bg, text: pkt.text };
+    }
+    process_ansi(pkt) {
+        let sgr_cmds = pkt.text.split(';');
+        while (sgr_cmds.length > 0) {
+            let sgr_cmd_str = sgr_cmds.shift();
+            let num = parseInt(sgr_cmd_str, 10);
+            if (isNaN(num) || num === 0) {
+                this.fg = null;
+                this.bg = null;
+                this.bold = false;
+                this.faint = false;
+                this.italic = false;
+                this.underline = false;
+            }
+            else if (num === 1) {
+                this.bold = true;
+            }
+            else if (num === 2) {
+                this.faint = true;
+            }
+            else if (num === 3) {
+                this.italic = true;
+            }
+            else if (num === 4) {
+                this.underline = true;
+            }
+            else if (num === 21) {
+                this.bold = false;
+            }
+            else if (num === 22) {
+                this.faint = false;
+                this.bold = false;
+            }
+            else if (num === 23) {
+                this.italic = false;
+            }
+            else if (num === 24) {
+                this.underline = false;
+            }
+            else if (num === 39) {
+                this.fg = null;
+            }
+            else if (num === 49) {
+                this.bg = null;
+            }
+            else if ((num >= 30) && (num < 38)) {
+                this.fg = this.ansi_colors[0][(num - 30)];
+            }
+            else if ((num >= 40) && (num < 48)) {
+                this.bg = this.ansi_colors[0][(num - 40)];
+            }
+            else if ((num >= 90) && (num < 98)) {
+                this.fg = this.ansi_colors[1][(num - 90)];
+            }
+            else if ((num >= 100) && (num < 108)) {
+                this.bg = this.ansi_colors[1][(num - 100)];
+            }
+            else if (num === 38 || num === 48) {
+                if (sgr_cmds.length > 0) {
+                    let is_foreground = (num === 38);
+                    let mode_cmd = sgr_cmds.shift();
+                    if (mode_cmd === '5' && sgr_cmds.length > 0) {
+                        let palette_index = parseInt(sgr_cmds.shift(), 10);
+                        if (palette_index >= 0 && palette_index <= 255) {
+                            if (is_foreground)
+                                this.fg = this.palette_256[palette_index];
+                            else
+                                this.bg = this.palette_256[palette_index];
+                        }
+                    }
+                    if (mode_cmd === '2' && sgr_cmds.length > 2) {
+                        let r = parseInt(sgr_cmds.shift(), 10);
+                        let g = parseInt(sgr_cmds.shift(), 10);
+                        let b = parseInt(sgr_cmds.shift(), 10);
+                        if ((r >= 0 && r <= 255) && (g >= 0 && g <= 255) && (b >= 0 && b <= 255)) {
+                            let c = { rgb: [r, g, b], class_name: 'truecolor' };
+                            if (is_foreground)
+                                this.fg = c;
+                            else
+                                this.bg = c;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    transform_to_html(fragment) {
+        let txt = fragment.text;
+        if (txt.length === 0)
+            return txt;
+        txt = this.escape_txt_for_html(txt);
+        if (!fragment.bold && !fragment.italic && !fragment.faint && !fragment.underline && fragment.fg === null && fragment.bg === null)
+            return txt;
+        let styles = [];
+        let classes = [];
+        let fg = fragment.fg;
+        let bg = fragment.bg;
+        if (fragment.bold)
+            styles.push(this._boldStyle);
+        if (fragment.faint)
+            styles.push(this._faintStyle);
+        if (fragment.italic)
+            styles.push(this._italicStyle);
+        if (fragment.underline)
+            styles.push(this._underlineStyle);
+        if (!this._use_classes) {
+            if (fg)
+                styles.push(`color:rgb(${fg.rgb.join(',')})`);
+            if (bg)
+                styles.push(`background-color:rgb(${bg.rgb})`);
+        }
+        else {
+            if (fg) {
+                if (fg.class_name !== 'truecolor') {
+                    classes.push(`${fg.class_name}-fg`);
+                }
+                else {
+                    styles.push(`color:rgb(${fg.rgb.join(',')})`);
+                }
+            }
+            if (bg) {
+                if (bg.class_name !== 'truecolor') {
+                    classes.push(`${bg.class_name}-bg`);
+                }
+                else {
+                    styles.push(`background-color:rgb(${bg.rgb.join(',')})`);
+                }
+            }
+        }
+        let class_string = '';
+        let style_string = '';
+        if (classes.length)
+            class_string = ` class="${classes.join(' ')}"`;
+        if (styles.length)
+            style_string = ` style="${styles.join(';')}"`;
+        return `<span${style_string}${class_string}>${txt}</span>`;
+    }
+    ;
+    process_hyperlink(pkt) {
+        let parts = pkt.url.split(':');
+        if (parts.length < 1)
+            return '';
+        if (!this._url_allowlist[parts[0]])
+            return '';
+        let result = `<a href="${this.escape_txt_for_html(pkt.url)}">${this.escape_txt_for_html(pkt.text)}</a>`;
+        return result;
+    }
+}
+function rgx(tmplObj, ...subst) {
+    let regexText = tmplObj.raw[0];
+    let wsrgx = /^\s+|\s+\n|\s*#[\s\S]*?\n|\n/gm;
+    let txt2 = regexText.replace(wsrgx, '');
+    return new RegExp(txt2);
+}
+function rgxG(tmplObj, ...subst) {
+    let regexText = tmplObj.raw[0];
+    let wsrgx = /^\s+|\s+\n|\s*#[\s\S]*?\n|\n/gm;
+    let txt2 = regexText.replace(wsrgx, '');
+    return new RegExp(txt2, 'g');
+}
+var templateObject_1, templateObject_2, templateObject_3;

--- a/examples/apps/compat/sheet-music/bundle/demokit-player.css
+++ b/examples/apps/compat/sheet-music/bundle/demokit-player.css
@@ -1,0 +1,253 @@
+/* demokit-player styles. BEM-ish class names; no shadow DOM so host
+   themes can override via CSS variables. Hosts can set:
+
+     --demokit-bg, --demokit-fg, --demokit-muted, --demokit-accent,
+     --demokit-border, --demokit-error, --demokit-warning,
+     --demokit-info, --demokit-mono
+
+   on a parent element to retheme the player.
+
+   The widget is layout-agnostic: it claims width: 100% and grows
+   in height to fit its feed. Wrap it in an iframe or a sized
+   container if you need a fixed viewport.
+*/
+
+.demokit-player {
+  --demokit-bg: #ffffff;
+  --demokit-fg: #1f2328;
+  --demokit-muted: #57606a;
+  --demokit-accent: #0969da;
+  --demokit-border: #d0d7de;
+  --demokit-error: #cf222e;
+  --demokit-warning: #9a6700;
+  --demokit-info: #0969da;
+  --demokit-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+
+  display: block;
+  width: 100%;
+  font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  color: var(--demokit-fg);
+  background: var(--demokit-bg);
+  border: 1px solid var(--demokit-border);
+  border-radius: 6px;
+  overflow: hidden;
+  outline: none;
+}
+
+.demokit-player:focus {
+  box-shadow: 0 0 0 2px var(--demokit-accent);
+}
+
+.demokit-player__header {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--demokit-border);
+}
+
+.demokit-player__title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.demokit-player__description {
+  margin: 4px 0 0;
+  color: var(--demokit-muted);
+  font-size: 13px;
+}
+
+.demokit-player__feed {
+  padding: 16px;
+  max-height: 70vh;
+  overflow-y: auto;
+}
+
+.demokit-player__controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  border-top: 1px solid var(--demokit-border);
+  background: rgba(0, 0, 0, 0.02);
+}
+
+.demokit-player__btn {
+  font: inherit;
+  padding: 4px 10px;
+  border: 1px solid var(--demokit-border);
+  background: var(--demokit-bg);
+  color: var(--demokit-fg);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.demokit-player__btn:hover:not(:disabled) {
+  background: rgba(0, 0, 0, 0.04);
+}
+
+.demokit-player__btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.demokit-player__counter {
+  margin-left: auto;
+  color: var(--demokit-muted);
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+}
+
+.demokit-player__error {
+  padding: 12px;
+  border-left: 4px solid var(--demokit-error);
+  color: var(--demokit-error);
+  background: rgba(207, 34, 46, 0.06);
+  border-radius: 4px;
+}
+
+/* --- Per-entry blocks --- */
+
+.demokit-section,
+.demokit-step {
+  margin: 0 0 16px;
+  padding: 12px 14px;
+  border: 1px solid var(--demokit-border);
+  border-radius: 6px;
+  background: var(--demokit-bg);
+}
+
+.demokit-section__title,
+.demokit-step__title {
+  margin: 0 0 8px;
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.demokit-step__visit {
+  color: var(--demokit-muted);
+  font-weight: 400;
+}
+
+.demokit-section__body {
+  margin: 0;
+  color: var(--demokit-muted);
+  white-space: pre-wrap;
+}
+
+.demokit-step__note {
+  margin: 0 0 8px;
+  padding: 6px 10px;
+  border-left: 3px solid var(--demokit-border);
+  color: var(--demokit-muted);
+  font-style: italic;
+  background: rgba(0, 0, 0, 0.02);
+}
+
+.demokit-step__refs {
+  margin: 0 0 8px;
+  font-size: 12px;
+  color: var(--demokit-muted);
+}
+.demokit-step__refs a {
+  color: var(--demokit-accent);
+}
+
+.demokit-step__inputs {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 2px 12px;
+  margin: 0 0 8px;
+  padding: 6px 10px;
+  font-family: var(--demokit-mono);
+  font-size: 12px;
+  background: rgba(0, 0, 0, 0.03);
+  border-radius: 4px;
+}
+.demokit-step__inputs dt {
+  color: var(--demokit-muted);
+}
+.demokit-step__inputs dd {
+  margin: 0;
+}
+
+.demokit-step__output {
+  margin: 0 0 8px;
+  padding: 8px 10px;
+  background: rgba(0, 0, 0, 0.04);
+  border-radius: 4px;
+  font-family: var(--demokit-mono);
+  font-size: 12px;
+  white-space: pre-wrap;
+  overflow-x: auto;
+}
+
+.demokit-step__verbatim-label {
+  margin: 8px 0 4px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--demokit-muted);
+}
+.demokit-step__verbatim {
+  margin: 0 0 8px;
+  padding: 8px 10px;
+  background: rgba(0, 0, 0, 0.04);
+  border-radius: 4px;
+  font-family: var(--demokit-mono);
+  font-size: 12px;
+  white-space: pre;
+  overflow-x: auto;
+}
+
+.demokit-step__status {
+  margin: 0;
+  padding: 6px 10px;
+  border-radius: 4px;
+  font-weight: 500;
+}
+
+.demokit-step__jump {
+  margin: 6px 0 0;
+  font-size: 12px;
+  color: var(--demokit-muted);
+  font-family: var(--demokit-mono);
+}
+
+/* Status colors — match ResultStatus const ordering: 0 success, 1 error, 2 warning, 3 info */
+.demokit-step--status-1 {
+  border-left: 4px solid var(--demokit-error);
+}
+.demokit-step--status-1 .demokit-step__status {
+  background: rgba(207, 34, 46, 0.08);
+  color: var(--demokit-error);
+}
+.demokit-step--status-2 {
+  border-left: 4px solid var(--demokit-warning);
+}
+.demokit-step--status-2 .demokit-step__status {
+  background: rgba(154, 103, 0, 0.08);
+  color: var(--demokit-warning);
+}
+.demokit-step--status-3 {
+  border-left: 4px solid var(--demokit-info);
+}
+.demokit-step--status-3 .demokit-step__status {
+  background: rgba(9, 105, 218, 0.08);
+  color: var(--demokit-info);
+}
+
+@media (prefers-color-scheme: dark) {
+  .demokit-player {
+    --demokit-bg: #0d1117;
+    --demokit-fg: #e6edf3;
+    --demokit-muted: #8b949e;
+    --demokit-accent: #58a6ff;
+    --demokit-border: #30363d;
+  }
+  .demokit-player__btn:hover:not(:disabled) {
+    background: rgba(255, 255, 255, 0.06);
+  }
+  .demokit-step__note,
+  .demokit-step__inputs,
+  .demokit-step__output {
+    background: rgba(255, 255, 255, 0.03);
+  }
+}

--- a/examples/apps/compat/sheet-music/bundle/demokit-player.js
+++ b/examples/apps/compat/sheet-music/bundle/demokit-player.js
@@ -1,0 +1,858 @@
+// demokit-player — vanilla-JS web component for playing back demokit
+// traces in any HTML host. Registers <demokit-demo> as a Custom
+// Element. No framework dependencies.
+//
+// Data sources, in priority order:
+//   1. Programmatic: el.trace = traceObject (assigning the property
+//      triggers a re-render).
+//   2. data-src URL: fetch JSON; render as static playback.
+//   3. data-src URL with data-mode="live": connect via WebSocket and
+//      render incrementally as the server emits structured events
+//      (header / section / step-start / chunk / step-end /
+//      input-needed / done). Driven by `demokit --serve`.
+//   4. Inline blob: <demokit-demo>{...JSON...}</demokit-demo>.
+//
+// Public API on the element:
+//   .trace = obj            // programmatic data injection
+//   .play(), .pause(), .reset(), .step(), .goTo(n)
+//   .currentStep (read), .totalEntries (read), .isPlaying (read)
+//
+// Events dispatched on the element (notifications, past tense):
+//   demokit:loaded   — once trace data is available
+//   demokit:stepped  — the visible step just advanced
+//   demokit:done     — last entry shown
+//   demokit:error    — fatal load/render error
+//
+// Events listened for (commands; host fires these to drive the
+// widget without knowing the player's class name):
+//   demokit:play, demokit:pause, demokit:reset, demokit:step
+//
+// The command/notification names are deliberately distinct
+// (demokit:step vs demokit:stepped) — using one name for both
+// would create a recursion loop the moment a step() advance
+// dispatches the same event the host listener handles.
+//
+// Keyboard (when the element is focused):
+//   Space / ArrowRight  — next step
+//   ArrowLeft           — previous step (rewinds the visible feed)
+//   P                   — play/pause toggle
+//   R                   — reset to first entry
+
+// This file is an ES module. Bundle templates load it via
+// <script type="module" src="...">.
+//
+// ansi_up is pulled in via a dynamic import wrapped in try/catch so
+// the player still loads when the CDN is unreachable — opening the
+// bundle on file:// without internet, behind a strict CSP that
+// blocks third-party scripts, or in air-gapped contexts. The
+// fallback strips ANSI escapes to plain text rather than failing
+// the whole module.
+
+// ansi_up is loaded from a commit-pinned jsdelivr URL — content-
+// addressable since the commit SHA is immutable, so no separate
+// integrity check is needed. We don't vendor a copy under our repo
+// because the file is already at the CDN; duplicating the bytes
+// adds nothing.
+//
+// file:// pages can't fetch cross-origin scripts (Chrome blocks
+// null-origin → https). For those cases the answer is the demokit
+// serve command (HTTP origin → CDN imports work) rather than a
+// chained fallback chasing every constraint.
+//
+// The stripper fallback below catches the residual case where the
+// import genuinely fails (no network, hard CSP, or a future demokit
+// air-gapped mode). Output stays readable (just without colour)
+// rather than garbled or absent.
+
+let AnsiUp;
+try {
+  const mod = await import(
+    'https://cdn.jsdelivr.net/gh/drudru/ansi_up@07a4824757d4dfbb41236a4245a6ce37f21aeb91/ansi_up.js'
+  );
+  AnsiUp = mod.AnsiUp;
+} catch (err) {
+  console.warn(
+    'demokit-player: ansi_up failed to load — captured ANSI escapes will render as plain text:',
+    err && err.message ? err.message : err,
+  );
+  AnsiUp = class {
+    constructor() { this.use_classes = false; }
+    ansi_to_html(text) {
+      // Strip ANSI escapes AND HTML-escape `<`, `>`, `&` so DOMParser
+      // doesn't misinterpret literals (e.g. the dragon ASCII body)
+      // as malformed tags. ansi_up's real ansi_to_html escapes
+      // internally; the stripper has to do the same.
+      return String(text)
+        .replace(/\x1b\[[0-9;]*m/g, '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+    }
+  };
+}
+
+const PLAY_INTERVAL_MS = 1500; // tune via Demo author later if needed
+
+class DemokitDemoElement extends HTMLElement {
+    constructor() {
+      super();
+      this._trace = null;
+      this._programmaticTrace = null;
+      this._currentStep = 0; // index of next entry to reveal
+      this._isPlaying = false;
+      this._timer = null;
+      this._kbHandler = null;
+      this._evtHandlers = {};
+    }
+
+    connectedCallback() {
+      this.classList.add('demokit-player');
+      if (!this.hasAttribute('tabindex')) {
+        this.setAttribute('tabindex', '0'); // make focusable for keyboard
+      }
+      // Snapshot inline JSON before _renderShell() replaces the
+      // element's children — otherwise _loadTrace would read the
+      // rendered button labels as if they were the trace blob.
+      this._inlineText = (this.textContent || '').trim();
+      this._renderShell();
+      this._bindKeyboard();
+      this._bindHostEvents();
+      this._loadTrace();
+    }
+
+    disconnectedCallback() {
+      this._stopPlayback();
+      this._unbindKeyboard();
+      this._unbindHostEvents();
+    }
+
+    // --- Programmatic data source ---
+
+    set trace(obj) {
+      this._programmaticTrace = obj;
+      this._loadTrace();
+    }
+    get trace() {
+      return this._trace;
+    }
+
+    // --- Public controls ---
+
+    play() {
+      if (this._isPlaying || !this._trace) return;
+      this._isPlaying = true;
+      this._updateControls();
+      this._timer = setInterval(() => {
+        this.step();
+        if (this._currentStep >= this._entries().length) {
+          this._stopPlayback();
+        }
+      }, PLAY_INTERVAL_MS);
+    }
+
+    pause() {
+      this._stopPlayback();
+    }
+
+    reset() {
+      this._stopPlayback();
+      this._currentStep = 0;
+      this._feedEl.replaceChildren();
+      this._updateControls();
+    }
+
+    step() {
+      const entries = this._entries();
+      if (this._currentStep >= entries.length) return;
+      const e = entries[this._currentStep];
+      this._renderEntry(e, this._currentStep + 1);
+      this._currentStep++;
+      this._updateControls();
+      this.dispatchEvent(new CustomEvent('demokit:stepped', {
+        detail: { index: this._currentStep, entry: e },
+      }));
+      if (this._currentStep >= entries.length) {
+        this.dispatchEvent(new CustomEvent('demokit:done'));
+      }
+    }
+
+    goTo(n) {
+      const entries = this._entries();
+      this._stopPlayback();
+      this._feedEl.replaceChildren();
+      this._currentStep = 0;
+      const target = Math.max(0, Math.min(n, entries.length));
+      for (let i = 0; i < target; i++) {
+        this.step();
+      }
+    }
+
+    get currentStep() { return this._currentStep; }
+    get totalEntries() { return this._entries().length; }
+    get isPlaying() { return this._isPlaying; }
+
+    // --- Internals ---
+
+    _entries() {
+      if (!this._trace) return [];
+      // The trace JSON shipped by --doc json wraps trace entries
+      // under a "trace" key alongside the demo definition. Inline
+      // blobs may carry just the entries array directly.
+      if (Array.isArray(this._trace)) return this._trace;
+      return this._trace.trace || [];
+    }
+
+    _demo() {
+      if (!this._trace || Array.isArray(this._trace)) return null;
+      return this._trace.demo || null;
+    }
+
+    _renderShell() {
+      this.replaceChildren();
+      const header = document.createElement('div');
+      header.className = 'demokit-player__header';
+      this._titleEl = document.createElement('h2');
+      this._titleEl.className = 'demokit-player__title';
+      this._descEl = document.createElement('p');
+      this._descEl.className = 'demokit-player__description';
+      header.appendChild(this._titleEl);
+      header.appendChild(this._descEl);
+
+      this._feedEl = document.createElement('div');
+      this._feedEl.className = 'demokit-player__feed';
+
+      const controls = document.createElement('div');
+      controls.className = 'demokit-player__controls';
+      this._prevBtn = this._mkBtn('◀', 'Previous (←)', () => this.goTo(this._currentStep - 1));
+      this._stepBtn = this._mkBtn('▶ Next', 'Next step (Space)', () => this.step());
+      this._playBtn = this._mkBtn('▶▶ Play', 'Play (P)', () => this.play());
+      this._pauseBtn = this._mkBtn('❚❚ Pause', 'Pause (P)', () => this.pause());
+      this._resetBtn = this._mkBtn('⟲ Reset', 'Reset (R)', () => this.reset());
+      this._counterEl = document.createElement('span');
+      this._counterEl.className = 'demokit-player__counter';
+      controls.append(this._prevBtn, this._stepBtn, this._playBtn, this._pauseBtn, this._resetBtn, this._counterEl);
+
+      // Controls position is configurable via data-controls
+      // ("top" default, "bottom" for legacy/footer-style layouts).
+      // Top is the default because the feed grows downward; with
+      // controls at the bottom, the user has to scroll past their
+      // own steps to reach Next/Play.
+      this.appendChild(header);
+      const controlsAtBottom = (this.dataset.controls || 'top') === 'bottom';
+      if (controlsAtBottom) {
+        this.appendChild(this._feedEl);
+        this.appendChild(controls);
+        controls.classList.add('demokit-player__controls--bottom');
+      } else {
+        this.appendChild(controls);
+        this.appendChild(this._feedEl);
+        controls.classList.add('demokit-player__controls--top');
+      }
+    }
+
+    _mkBtn(label, title, onClick) {
+      const b = document.createElement('button');
+      b.type = 'button';
+      b.className = 'demokit-player__btn';
+      b.textContent = label;
+      b.title = title;
+      b.addEventListener('click', (e) => { e.stopPropagation(); onClick(); });
+      return b;
+    }
+
+    _updateControls() {
+      const total = this.totalEntries;
+      this._counterEl.textContent = `${this._currentStep} / ${total}`;
+      this._prevBtn.disabled = this._currentStep <= 0;
+      this._stepBtn.disabled = this._currentStep >= total;
+      this._playBtn.style.display = this._isPlaying ? 'none' : '';
+      this._pauseBtn.style.display = this._isPlaying ? '' : 'none';
+    }
+
+    async _loadTrace() {
+      const mode = this.dataset.mode || 'static';
+      const src = this.dataset.src;
+
+      try {
+        if (this._programmaticTrace) {
+          this._trace = this._programmaticTrace;
+        } else if (src && mode === 'live') {
+          // Live mode: open a WebSocket and stream structured events.
+          // Returns immediately; events drive the render incrementally.
+          this._connectWS(src);
+          return;
+        } else if (src) {
+          const res = await fetch(src);
+          if (!res.ok) {
+            throw new Error(`demokit-player: fetch ${src} → HTTP ${res.status}`);
+          }
+          this._trace = await res.json();
+        } else {
+          // _inlineText was captured in connectedCallback before the
+          // shell render replaced our children. Falls back to current
+          // textContent if connectedCallback hasn't run yet (rare).
+          const text = (this._inlineText !== undefined
+            ? this._inlineText
+            : (this.textContent || '').trim());
+          if (!text) {
+            this._renderError(
+              'demokit-player: no trace data. Provide data-src, inline JSON, or set the .trace property.',
+            );
+            return;
+          }
+          this._trace = JSON.parse(text);
+        }
+
+        this._renderHeader();
+        this._currentStep = 0;
+        this._feedEl.replaceChildren();
+        this._updateControls();
+        this.dispatchEvent(new CustomEvent('demokit:loaded', {
+          detail: { totalEntries: this.totalEntries },
+        }));
+      } catch (err) {
+        this._renderError(err && err.message ? err.message : String(err));
+        this.dispatchEvent(new CustomEvent('demokit:error', {
+          detail: { message: err && err.message ? err.message : String(err) },
+        }));
+      }
+    }
+
+    _renderHeader() {
+      const demo = this._demo();
+      this._titleEl.textContent = demo && demo.title ? demo.title : '';
+      this._descEl.textContent = demo && demo.description ? demo.description : '';
+      this._descEl.style.display = this._descEl.textContent ? '' : 'none';
+    }
+
+    _renderError(message) {
+      this._feedEl.replaceChildren();
+      const box = document.createElement('div');
+      box.className = 'demokit-player__error';
+      box.textContent = message;
+      this._feedEl.appendChild(box);
+    }
+
+    _renderEntry(entry, indexOneBased) {
+      if (entry.kind === 'section') {
+        this._renderSection(entry);
+      } else {
+        this._renderStep(entry, indexOneBased);
+      }
+      this._feedEl.lastElementChild.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+
+    _renderSection(entry) {
+      const sec = document.createElement('section');
+      sec.className = 'demokit-section';
+      const h = document.createElement('h3');
+      h.className = 'demokit-section__title';
+      h.textContent = entry.title || '';
+      sec.appendChild(h);
+      if (entry.body) {
+        const p = document.createElement('p');
+        p.className = 'demokit-section__body';
+        p.textContent = entry.body;
+        sec.appendChild(p);
+      }
+      this._feedEl.appendChild(sec);
+    }
+
+    _renderStep(entry, indexOneBased) {
+      const art = document.createElement('article');
+      const status = entry.status || 0; // 0 = success
+      art.className = `demokit-step demokit-step--status-${status}`;
+      const h = document.createElement('h3');
+      h.className = 'demokit-step__title';
+      h.textContent = `${indexOneBased}. ${entry.title || entry.step_id || ''}`;
+      if (entry.visit && entry.visit > 1) {
+        const v = document.createElement('span');
+        v.className = 'demokit-step__visit';
+        v.textContent = ` (visit ${entry.visit})`;
+        h.appendChild(v);
+      }
+      art.appendChild(h);
+
+      // Note from the demo definition (if available)
+      const stepDef = this._lookupStepDef(entry.step_id);
+      if (stepDef && stepDef.note) {
+        const blk = document.createElement('blockquote');
+        blk.className = 'demokit-step__note';
+        blk.textContent = stepDef.note;
+        art.appendChild(blk);
+      }
+      if (stepDef && stepDef.refs && stepDef.refs.length > 0) {
+        const refs = document.createElement('p');
+        refs.className = 'demokit-step__refs';
+        refs.appendChild(document.createTextNode('References: '));
+        stepDef.refs.forEach((ref, i) => {
+          if (i > 0) refs.appendChild(document.createTextNode(', '));
+          const a = document.createElement('a');
+          a.href = ref.url;
+          a.textContent = ref.name;
+          a.target = '_blank';
+          a.rel = 'noopener noreferrer';
+          refs.appendChild(a);
+        });
+        art.appendChild(refs);
+      }
+
+      if (stepDef && Array.isArray(stepDef.verbatim) && stepDef.verbatim.length) {
+        this._appendVerbatim(art, stepDef.verbatim);
+      }
+
+      // Inputs collected for this entry (read-only)
+      if (entry.inputs && Object.keys(entry.inputs).length > 0) {
+        const wrap = document.createElement('dl');
+        wrap.className = 'demokit-step__inputs';
+        Object.keys(entry.inputs).sort().forEach((k) => {
+          const dt = document.createElement('dt');
+          dt.textContent = k;
+          const dd = document.createElement('dd');
+          dd.textContent = String(entry.inputs[k]);
+          wrap.appendChild(dt);
+          wrap.appendChild(dd);
+        });
+        art.appendChild(wrap);
+      }
+
+      // Captured output — interpret ANSI SGR escapes so streamed
+      // colored output (e.g. the dungeon's dragon scene) renders
+      // with styling instead of leaking the literal "[38;5;245m"
+      // sequences as text.
+      if (entry.output) {
+        const pre = document.createElement('pre');
+        pre.className = 'demokit-step__output';
+        appendANSI(pre, entry.output.replace(/\n+$/, ''));
+        art.appendChild(pre);
+      }
+
+      // Status footer (error/warning/info messages)
+      if (status !== 0 && (entry.message || entry.label)) {
+        const foot = document.createElement('p');
+        foot.className = 'demokit-step__status';
+        const label = entry.label || statusLabel(status);
+        foot.textContent = `${label}: ${entry.message || ''}`;
+        art.appendChild(foot);
+      }
+
+      // Jump arrow
+      if (entry.next) {
+        const j = document.createElement('p');
+        j.className = 'demokit-step__jump';
+        j.textContent = `→ jumped to ${entry.next}`;
+        art.appendChild(j);
+      }
+
+      this._feedEl.appendChild(art);
+    }
+
+    _lookupStepDef(stepId) {
+      const demo = this._demo();
+      if (!demo || !demo.items || !stepId) return null;
+      for (const it of demo.items) {
+        if (it.kind === 'step' && it.id === stepId) return it;
+      }
+      return null;
+    }
+
+    // Append each verbatim block as an optional label + a <pre><code>
+    // with white-space: pre and overflow-x: auto. The browser does not
+    // soft-wrap, so triple-clicking a long line yields the original
+    // bytes — same copy-paste invariant the TUI guarantees.
+    _appendVerbatim(parent, blocks) {
+      blocks.forEach((b) => {
+        if (b.label) {
+          const h = document.createElement('p');
+          h.className = 'demokit-step__verbatim-label';
+          h.textContent = b.label;
+          parent.appendChild(h);
+        }
+        const pre = document.createElement('pre');
+        pre.className = 'demokit-step__verbatim';
+        const code = document.createElement('code');
+        if (b.lang) code.className = 'language-' + b.lang;
+        code.textContent = b.content || '';
+        pre.appendChild(code);
+        parent.appendChild(pre);
+      });
+    }
+
+    _stopPlayback() {
+      if (this._timer) {
+        clearInterval(this._timer);
+        this._timer = null;
+      }
+      this._isPlaying = false;
+      if (this._counterEl) this._updateControls();
+    }
+
+    _bindKeyboard() {
+      this._kbHandler = (e) => {
+        if (document.activeElement !== this) return;
+        switch (e.key) {
+          case ' ':
+          case 'ArrowRight':
+            e.preventDefault();
+            this.step();
+            break;
+          case 'ArrowLeft':
+            e.preventDefault();
+            this.goTo(this._currentStep - 1);
+            break;
+          case 'p':
+          case 'P':
+            e.preventDefault();
+            if (this._isPlaying) this.pause(); else this.play();
+            break;
+          case 'r':
+          case 'R':
+            e.preventDefault();
+            this.reset();
+            break;
+        }
+      };
+      this.addEventListener('keydown', this._kbHandler);
+    }
+
+    _unbindKeyboard() {
+      if (this._kbHandler) {
+        this.removeEventListener('keydown', this._kbHandler);
+        this._kbHandler = null;
+      }
+    }
+
+    _bindHostEvents() {
+      const evts = ['demokit:play', 'demokit:pause', 'demokit:reset', 'demokit:step'];
+      evts.forEach((name) => {
+        const handler = () => {
+          switch (name) {
+            case 'demokit:play':  this.play();  break;
+            case 'demokit:pause': this.pause(); break;
+            case 'demokit:reset': this.reset(); break;
+            case 'demokit:step':  this.step();  break;
+          }
+        };
+        this._evtHandlers[name] = handler;
+        this.addEventListener(name, handler);
+      });
+    }
+
+    _unbindHostEvents() {
+      Object.keys(this._evtHandlers).forEach((name) => {
+        this.removeEventListener(name, this._evtHandlers[name]);
+      });
+      this._evtHandlers = {};
+    }
+
+    // --- Live-mode WS ---
+    //
+    // When data-mode="live", the player connects to data-src as a
+    // WebSocket and renders incoming structured events incrementally
+    // (instead of fetching a static trace once). Outgoing messages
+    // are user actions: input submissions, reset.
+
+    _connectWS(rawURL) {
+      const wsURL = this._toWSURL(rawURL);
+      let ws;
+      try {
+        ws = new WebSocket(wsURL);
+      } catch (err) {
+        this._renderError('demokit-player: WS connect failed: ' + (err && err.message ? err.message : err));
+        return;
+      }
+      this._ws = ws;
+      this._currentStepEl = null;
+      this._currentStepID = null;
+
+      ws.onmessage = (e) => {
+        let evt;
+        try { evt = JSON.parse(e.data); } catch (_) { return; }
+        this._handleServerEvent(evt);
+      };
+      ws.onerror = () => {
+        this._renderError('demokit-player: WS error connecting to ' + wsURL);
+      };
+      ws.onclose = () => {
+        const note = document.createElement('p');
+        note.className = 'demokit-player__disconnected';
+        note.textContent = '(disconnected)';
+        this._feedEl.appendChild(note);
+      };
+    }
+
+    // _toWSURL converts an http(s):// or relative URL into ws(s)://
+    // so the host can write data-src as either a path or full URL.
+    _toWSURL(url) {
+      if (url.startsWith('ws://') || url.startsWith('wss://')) return url;
+      if (url.startsWith('http://')) return 'ws://' + url.slice(7);
+      if (url.startsWith('https://')) return 'wss://' + url.slice(8);
+      const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+      const path = url.startsWith('/') ? url : '/' + url;
+      return proto + '//' + location.host + path;
+    }
+
+    _handleServerEvent(evt) {
+      switch (evt.kind) {
+        case 'header':
+          if (evt.demo) {
+            this._titleEl.textContent = evt.demo.title || '';
+            this._descEl.textContent = evt.demo.description || '';
+            this._descEl.style.display = this._descEl.textContent ? '' : 'none';
+          }
+          break;
+        case 'section':
+          this._renderLiveSection(evt.extra || {});
+          break;
+        case 'step-start':
+          this._openLiveStep(evt.extra || {});
+          break;
+        case 'chunk':
+          this._appendChunkToLiveStep(evt.chunk || '');
+          break;
+        case 'step-end':
+          this._closeLiveStep(evt.status || 0, evt.extra || {});
+          break;
+        case 'input-needed':
+          this._renderLiveInputForm(evt.step_id, evt.inputs || []);
+          break;
+        case 'input-timeout':
+          this._dismissLiveInputForm(evt.extra && evt.extra.timeout_ms);
+          break;
+        case 'done':
+          this._renderLiveDone();
+          break;
+        case 'reset':
+          this._feedEl.replaceChildren();
+          this._currentStepEl = null;
+          this._currentStepID = null;
+          break;
+      }
+    }
+
+    _renderLiveSection(extra) {
+      const sec = document.createElement('section');
+      sec.className = 'demokit-section';
+      const h = document.createElement('h3');
+      h.className = 'demokit-section__title';
+      h.textContent = extra.title || '';
+      sec.appendChild(h);
+      if (extra.body) {
+        const p = document.createElement('p');
+        p.className = 'demokit-section__body';
+        p.textContent = extra.body;
+        sec.appendChild(p);
+      }
+      this._feedEl.appendChild(sec);
+      sec.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+
+    _openLiveStep(extra) {
+      const art = document.createElement('article');
+      art.className = 'demokit-step demokit-step--status-0';
+      const h = document.createElement('h3');
+      h.className = 'demokit-step__title';
+      const num = extra.step_num;
+      const title = extra.title || extra.id || '';
+      h.textContent = num ? num + '. ' + title : title;
+      art.appendChild(h);
+
+      if (extra.note) {
+        const blk = document.createElement('blockquote');
+        blk.className = 'demokit-step__note';
+        blk.textContent = extra.note;
+        art.appendChild(blk);
+      }
+      if (Array.isArray(extra.refs) && extra.refs.length) {
+        const refs = document.createElement('p');
+        refs.className = 'demokit-step__refs';
+        refs.appendChild(document.createTextNode('References: '));
+        extra.refs.forEach((ref, i) => {
+          if (i > 0) refs.appendChild(document.createTextNode(', '));
+          const a = document.createElement('a');
+          a.href = ref.url || ref.URL || '#';
+          a.textContent = ref.name || ref.Name || ref.url || '';
+          a.target = '_blank';
+          a.rel = 'noopener noreferrer';
+          refs.appendChild(a);
+        });
+        art.appendChild(refs);
+      }
+
+      if (Array.isArray(extra.verbatim) && extra.verbatim.length) {
+        this._appendVerbatim(art, extra.verbatim);
+      }
+
+      const pre = document.createElement('pre');
+      pre.className = 'demokit-step__output';
+      pre.style.display = 'none'; // shown when first chunk arrives
+      art.appendChild(pre);
+
+      this._feedEl.appendChild(art);
+      this._currentStepEl = art;
+      this._currentStepPreEl = pre;
+      this._currentStepID = extra.id || '';
+      art.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+
+    _appendChunkToLiveStep(text) {
+      if (!this._currentStepPreEl) return;
+      this._currentStepPreEl.style.display = '';
+      appendANSI(this._currentStepPreEl, text);
+    }
+
+    _closeLiveStep(status, extra) {
+      const el = this._currentStepEl;
+      if (!el) return;
+      el.classList.remove('demokit-step--status-0');
+      el.classList.add('demokit-step--status-' + status);
+
+      if (status !== 0 && extra && extra.message) {
+        const foot = document.createElement('p');
+        foot.className = 'demokit-step__status';
+        foot.textContent = (extra.label || statusLabel(status)) + ': ' + extra.message;
+        el.appendChild(foot);
+      }
+      if (extra && extra.next) {
+        const j = document.createElement('p');
+        j.className = 'demokit-step__jump';
+        j.textContent = '→ jumped to ' + extra.next;
+        el.appendChild(j);
+      }
+      this._currentStepEl = null;
+      this._currentStepPreEl = null;
+      this._currentStepID = null;
+    }
+
+    _renderLiveInputForm(stepID, inputs) {
+      const form = document.createElement('form');
+      form.className = 'demokit-input-form';
+      const fields = [];
+      inputs.forEach((inp) => {
+        const wrap = document.createElement('label');
+        wrap.className = 'demokit-input-form__field';
+        const lbl = document.createElement('span');
+        lbl.textContent = (inp.Prompt || inp.Name || inp.name || 'input') + ': ';
+        wrap.appendChild(lbl);
+
+        let ctrl;
+        const kind = inp.Kind || inp.kind;
+        if (kind === 'choice') {
+          ctrl = document.createElement('select');
+          (inp.Options || inp.options || []).forEach((opt) => {
+            const o = document.createElement('option');
+            o.value = opt;
+            o.textContent = opt;
+            ctrl.appendChild(o);
+          });
+        } else if (kind === 'int') {
+          ctrl = document.createElement('input');
+          ctrl.type = 'number';
+        } else {
+          ctrl = document.createElement('input');
+          ctrl.type = 'text';
+        }
+        ctrl.name = inp.Name || inp.name || '';
+        if (inp.Default !== undefined && inp.Default !== null) {
+          ctrl.value = String(inp.Default);
+        } else if (inp.default !== undefined && inp.default !== null) {
+          ctrl.value = String(inp.default);
+        }
+        wrap.appendChild(ctrl);
+        form.appendChild(wrap);
+        fields.push({ name: ctrl.name, el: ctrl, kind });
+      });
+
+      const submit = document.createElement('button');
+      submit.type = 'submit';
+      submit.className = 'demokit-player__btn';
+      submit.textContent = 'Submit';
+      form.appendChild(submit);
+
+      form.addEventListener('submit', (e) => {
+        e.preventDefault();
+        const values = {};
+        fields.forEach((f) => {
+          if (f.kind === 'int') {
+            values[f.name] = parseInt(f.el.value, 10);
+          } else {
+            values[f.name] = f.el.value;
+          }
+        });
+        if (this._ws && this._ws.readyState === WebSocket.OPEN) {
+          this._ws.send(JSON.stringify({ kind: 'input', values }));
+        }
+        form.remove();
+      });
+
+      this._feedEl.appendChild(form);
+      form.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+
+    _dismissLiveInputForm(timeoutMs) {
+      // Server timed out waiting for input and is continuing with
+      // declared defaults. Find the most recent input form (the one
+      // we just rendered for the current step) and replace it with
+      // a small notice.
+      const forms = this._feedEl.querySelectorAll('form.demokit-input-form');
+      const form = forms[forms.length - 1];
+      if (!form) return;
+      const note = document.createElement('p');
+      note.className = 'demokit-input-form__timeout';
+      const secs = timeoutMs ? (timeoutMs / 1000).toFixed(1) : '';
+      note.textContent = secs
+        ? `(no input after ${secs}s — continuing with defaults)`
+        : '(input timed out — continuing with defaults)';
+      form.replaceWith(note);
+      note.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+
+    _renderLiveDone() {
+      const note = document.createElement('p');
+      note.className = 'demokit-player__done';
+      note.textContent = '(demo ended)';
+      this._feedEl.appendChild(note);
+    }
+  }
+
+  // --- ANSI SGR → DOM ---
+  //
+  // Delegates to ansi_up (https://github.com/drudru/ansi_up, MIT;
+  // vendored under web/player/vendor/ — see VENDOR.md for the pin).
+  // The bundle and dev harness load ansi_up.umd.js *before* this
+  // file, so window.AnsiUp is available when appendANSI runs.
+  // Covers the full SGR table: 8-color, 256-color, true-color RGB,
+  // bold/dim/italic/underline/strikethrough.
+  //
+  // ansi_to_html escapes input itself and emits only text plus
+  // <span style=...> wrappers; running its output through DOMParser
+  // and reparenting the resulting nodes is safe and avoids touching
+  // innerHTML on the live document.
+  //
+  // Fallback: if AnsiUp isn't loaded (player JS used standalone
+  // without the vendor bundle), output renders as plain text — the
+  // escape sequences appear as literals but the step still loads.
+
+  function appendANSI(parent, text) {
+    if (text == null) return;
+    const ansiUp = new AnsiUp();
+    ansiUp.use_classes = false;
+    const safeHTML = ansiUp.ansi_to_html(String(text));
+    const parsed = new DOMParser().parseFromString(safeHTML, 'text/html');
+    while (parsed.body.firstChild) {
+      parent.appendChild(parsed.body.firstChild);
+    }
+  }
+
+  function statusLabel(status) {
+    switch (status) {
+      case 1: return 'Error';
+      case 2: return 'Warning';
+      case 3: return 'Info';
+      default: return 'Result';
+    }
+  }
+
+if (!customElements.get('demokit-demo')) {
+  customElements.define('demokit-demo', DemokitDemoElement);
+}

--- a/examples/apps/compat/sheet-music/bundle/index.html
+++ b/examples/apps/compat/sheet-music/bundle/index.html
@@ -1,0 +1,208 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>sheet-music — multi-line default &#43; CSP-allowlisted iframe</title>
+<link rel="stylesheet" href="./demokit-player.css">
+<style>
+body { margin: 2em auto; max-width: 900px; padding: 0 1em; font-family: -apple-system, BlinkMacSystemFont, sans-serif; }
+</style>
+</head>
+<body>
+<demokit-demo>{
+  "demo": {
+    "title": "sheet-music — multi-line default + CSP-allowlisted iframe",
+    "description": "Walks the play-sheet-music round trip end-to-end as a scripted MCP client. The two distinctive things about this fixture are visible on the wire: the InputSchemaPatch default (a multi-line comma-laden ABC notation string that struct-tag reflection would have truncated) and the resource's _meta.ui.csp.connectDomains (the soundfont CDN allowlist that lets abcjs play audio). Run `make serve` in another terminal first.",
+    "actors": [
+      {
+        "id": "Host",
+        "label": "MCP Host (this client)"
+      },
+      {
+        "id": "Server",
+        "label": "mcpkit-Go fixture (make serve)"
+      }
+    ],
+    "items": [
+      {
+        "kind": "section",
+        "title": "Setup",
+        "body": "Start the MCP server in a separate terminal first:\n\n```\nTerminal 1:  make serve         # mcpkit-Go fixture on :3101\nTerminal 2:  make demo          # this walkthrough (--tui for interactive TUI)\n```\n\nAny MCP host can connect to the running server (Claude Desktop, VS Code, MCPJam, basic-host). The walkthrough below acts as a scripted host that issues the protocol calls directly through `*mcpkit/client.Client` — no LLM, no browser. The same calls drive the iframe when you run `make demo-app EXAMPLE=sheet-music` in basic-host (see the [centralized guide](../README.md#other-ways-to-test-a-fixture))."
+      },
+      {
+        "kind": "step",
+        "title": "Connect to the fixture",
+        "note": "Session establishment is a single initialize round-trip plus the notifications/initialized ack. `*client.Client.Connect()` does both behind one call; the curl form below shows the raw shape.",
+        "arrows": [
+          {
+            "from": "Host",
+            "to": "Server",
+            "label": "POST /mcp — initialize"
+          },
+          {
+            "from": "Server",
+            "to": "Host",
+            "label": "serverInfo + capabilities + Mcp-Session-Id",
+            "dashed": true
+          }
+        ],
+        "verbatim": [
+          {
+            "label": "Reproduce on the wire",
+            "variants": [
+              {
+                "label": "curl",
+                "lang": "bash",
+                "content": "# Initialize. Mcp-Session-Id comes back in the response headers.\nSID=$(curl -si -X POST http://localhost:3101/mcp \\\n  -H 'Content-Type: application/json' \\\n  -H 'Accept: text/event-stream, application/json' \\\n  -d '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"clientInfo\":{\"name\":\"curl\",\"version\":\"1\"}}}' \\\n  | awk 'tolower($1) == \"mcp-session-id:\" {gsub(/\\r/,\"\"); print $2}')\n\n# Acknowledge so the server's dispatcher unblocks.\ncurl -s -X POST http://localhost:3101/mcp \\\n  -H \"Mcp-Session-Id: $SID\" \\\n  -H 'Content-Type: application/json' \\\n  -H 'Accept: text/event-stream, application/json' \\\n  -d '{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}'",
+                "default": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "step",
+        "title": "tools/list — verify the multi-line default landed intact",
+        "note": "The pedagogically interesting bit isn't that play-sheet-music exists — it's `inputSchema.properties.abcNotation.default`. The fixture uses `InputSchemaPatch` (`s.Prop(\"abcNotation\").Default(defaultABCNotation)`) to land the 11-line, comma-laden ABC notation default verbatim. invopop's struct-tag parser would have truncated at the first comma. The walkthrough prints just that default field below — confirm every line is present.",
+        "arrows": [
+          {
+            "from": "Host",
+            "to": "Server",
+            "label": "tools/list"
+          },
+          {
+            "from": "Server",
+            "to": "Host",
+            "label": "tools[] including play-sheet-music",
+            "dashed": true
+          }
+        ],
+        "verbatim": [
+          {
+            "label": "Reproduce on the wire",
+            "variants": [
+              {
+                "label": "curl",
+                "lang": "bash",
+                "content": "curl -s -X POST http://localhost:3101/mcp \\\n  -H \"Mcp-Session-Id: $SID\" \\\n  -H 'Content-Type: application/json' \\\n  -H 'Accept: text/event-stream, application/json' \\\n  -d '{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{}}' \\\n  | jq -r '.result.tools[] | select(.name==\"play-sheet-music\") | .inputSchema.properties.abcNotation.default'",
+                "default": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "step",
+        "title": "tools/call play-sheet-music — round-trip the ABC notation",
+        "note": "The server-side handler is intentionally minimal — it returns a small text envelope confirming the parse. The wire-level lesson is that the full 184-char ABC notation crosses verbatim and is unmarshaled into the typed `playSheetMusicInput.ABCNotation` field. The iframe does the actual rendering + audio playback work; see step 4 for what makes that work.",
+        "arrows": [
+          {
+            "from": "Host",
+            "to": "Server",
+            "label": "tools/call play-sheet-music { abcNotation: \u003c184 chars\u003e }"
+          },
+          {
+            "from": "Server",
+            "to": "Host",
+            "label": "ToolResult.content[0].text = \"Input parsed successfully.\"",
+            "dashed": true
+          }
+        ],
+        "verbatim": [
+          {
+            "label": "Reproduce on the wire",
+            "variants": [
+              {
+                "label": "curl",
+                "lang": "bash",
+                "content": "curl -s -X POST http://localhost:3101/mcp \\\n  -H \"Mcp-Session-Id: $SID\" \\\n  -H 'Content-Type: application/json' \\\n  -H 'Accept: text/event-stream, application/json' \\\n  -d '{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"play-sheet-music\",\"arguments\":{\"abcNotation\":\"X:1\\nT:Twinkle, Twinkle Little Star\\nM:4/4\\nL:1/4\\nK:C\\nC C G G | A A G2 | F F E E | D D C2 |\\nG G F F | E E D2 | G G F F | E E D2 |\\nC C G G | A A G2 | F F E E | D D C2 |\"}}}' \\\n  | jq -r '.result.content[0].text'",
+                "default": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "step",
+        "title": "resources/read — the CSP allowlist that unblocks audio",
+        "note": "This walkthrough does NOT dump the HTML body — it's a build artifact mirrored verbatim from upstream. The pedagogically interesting bit is `_meta.ui.csp.connectDomains` on the resource read response. abcjs streams soundfonts from `paulrosen.github.io` when the user clicks ▶ Play; without that origin on the iframe's `connect-src` allowlist, basic-host's CSP blocks the fetch and audio silently fails. The fixture declares it on the resource _meta — same shape upstream's sheet-music-server uses, same shape every CSP-aware MCP host can read.",
+        "arrows": [
+          {
+            "from": "Host",
+            "to": "Server",
+            "label": "resources/read { uri: ui://sheet-music/mcp-app.html }"
+          },
+          {
+            "from": "Server",
+            "to": "Host",
+            "label": "Contents[0]._meta.ui.csp.connectDomains",
+            "dashed": true
+          }
+        ],
+        "verbatim": [
+          {
+            "label": "Reproduce on the wire",
+            "variants": [
+              {
+                "label": "curl",
+                "lang": "bash",
+                "content": "curl -s -X POST http://localhost:3101/mcp \\\n  -H \"Mcp-Session-Id: $SID\" \\\n  -H 'Content-Type: application/json' \\\n  -H 'Accept: text/event-stream, application/json' \\\n  -d '{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"resources/read\",\"params\":{\"uri\":\"ui://sheet-music/mcp-app.html\"}}' \\\n  | jq '.result.contents[0]._meta'",
+                "default": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "section",
+        "title": "Where to look in the code",
+        "body": "- `main.go` — the InputSchemaPatch landing the default + the ResourceHandler setting `_meta.ui.csp.connectDomains`. Both are visible in single contiguous edits.\n- `walkthrough.go` — this file. Each step's curl + Go recipe is the canonical wire reproduction.\n- `../README.md` — narrative + the [CSP connect-src contract](../sheet-music/README.md#the-csp-connect-src-contract) section explains why the resource `_meta` matters."
+      }
+    ]
+  },
+  "trace": [
+    {
+      "kind": "section",
+      "title": "Setup",
+      "body": "Start the MCP server in a separate terminal first:\n\n```\nTerminal 1:  make serve         # mcpkit-Go fixture on :3101\nTerminal 2:  make demo          # this walkthrough (--tui for interactive TUI)\n```\n\nAny MCP host can connect to the running server (Claude Desktop, VS Code, MCPJam, basic-host). The walkthrough below acts as a scripted host that issues the protocol calls directly through `*mcpkit/client.Client` — no LLM, no browser. The same calls drive the iframe when you run `make demo-app EXAMPLE=sheet-music` in basic-host (see the [centralized guide](../README.md#other-ways-to-test-a-fixture))."
+    },
+    {
+      "kind": "step",
+      "title": "Connect to the fixture",
+      "step_id": "step-1",
+      "visit": 1,
+      "output": "    connected to Sheet Music Server 1.0.0\n"
+    },
+    {
+      "kind": "step",
+      "title": "tools/list — verify the multi-line default landed intact",
+      "step_id": "step-2",
+      "visit": 1,
+      "output": "    inputSchema.properties.abcNotation.default:\n      X:1\n      T:Twinkle, Twinkle Little Star\n      M:4/4\n      L:1/4\n      K:C\n      C C G G | A A G2 | F F E E | D D C2 |\n      G G F F | E E D2 | G G F F | E E D2 |\n      C C G G | A A G2 | F F E E | D D C2 |\n"
+    },
+    {
+      "kind": "step",
+      "title": "tools/call play-sheet-music — round-trip the ABC notation",
+      "step_id": "step-3",
+      "visit": 1,
+      "output": "    server said: Input parsed successfully.\n    (sent 164-char ABC notation; round-tripped through the typed handler)\n"
+    },
+    {
+      "kind": "step",
+      "title": "resources/read — the CSP allowlist that unblocks audio",
+      "step_id": "step-4",
+      "visit": 1,
+      "output": "    _meta:\n      {\n        \"ui\": {\n          \"csp\": {\n            \"connectDomains\": [\n              \"https://paulrosen.github.io\"\n            ]\n          }\n        }\n      }\n"
+    },
+    {
+      "kind": "section",
+      "title": "Where to look in the code",
+      "body": "- `main.go` — the InputSchemaPatch landing the default + the ResourceHandler setting `_meta.ui.csp.connectDomains`. Both are visible in single contiguous edits.\n- `walkthrough.go` — this file. Each step's curl + Go recipe is the canonical wire reproduction.\n- `../README.md` — narrative + the [CSP connect-src contract](../sheet-music/README.md#the-csp-connect-src-contract) section explains why the resource `_meta` matters."
+    }
+  ]
+}
+</demokit-demo>
+<script type="module" src="./demokit-player.js"></script>
+</body>
+</html>

--- a/examples/apps/compat/sheet-music/main.go
+++ b/examples/apps/compat/sheet-music/main.go
@@ -123,7 +123,21 @@ func serve() {
 				ResourceURI: resourceURI,
 				ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
 					return core.ResourceResult{Contents: []core.ResourceReadContent{{
-						URI: req.URI, MimeType: core.AppMIMEType, Text: html,
+						URI:      req.URI,
+						MimeType: core.AppMIMEType,
+						Text:     html,
+						// abcjs streams soundfonts from paulrosen.github.io on first
+						// ▶ Play click. Without this CSP connect-src allowlist on
+						// the resource _meta, basic-host's CSP blocks the fetch and
+						// audio playback silently fails — the sheet music renders
+						// but the play button does nothing.
+						Meta: &core.ResourceContentMeta{
+							UI: &core.UIMetadata{
+								CSP: &core.UICSPConfig{
+									ConnectDomains: []string{"https://paulrosen.github.io"},
+								},
+							},
+						},
 					}}}, nil
 				},
 			})

--- a/examples/apps/compat/sheet-music/walkthrough.go
+++ b/examples/apps/compat/sheet-music/walkthrough.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/panyam/demokit"
 	"github.com/panyam/mcpkit/client"
@@ -11,67 +10,249 @@ import (
 	"github.com/panyam/mcpkit/examples/common"
 )
 
-// runDemo is a STUB walkthrough — it connects to the fixture and lists
-// its tools. Refine it: add a tools/call step per tool, attach
-// common.WireRecipe(step, curl, go) for the wire reproduction, drop
-// fixture-specific narrative in .Note(...). See
-// examples/apps/compat/basic-vanillajs/walkthrough.go for the full
-// pattern.
+// runDemo is the sheet-music walkthrough. Acts as a scripted MCP host
+// against a server started by `make serve` in another terminal.
 //
-// TODO: replace this stub with a curated walkthrough.
+// Walks four steps, each one anchored on a fixture-specific protocol
+// surface (not generic protocol mechanics — that's basic-vanillajs's
+// job):
+//
+//  1. Connect to the fixture (POST /mcp initialize → session).
+//  2. tools/list — focus on `inputSchema.properties.abcNotation.default`.
+//     The multi-line, multi-comma ABC notation default landing intact is
+//     the whole InputSchemaPatch payoff and the reason this fixture
+//     exists. invopop's struct-tag parser would have truncated the
+//     default at the first comma; `s.Prop("abcNotation").Default(...)`
+//     bypasses that.
+//  3. tools/call play-sheet-music with the default ABC — confirm the
+//     round trip works and the handler returns the small "Input parsed
+//     successfully" text envelope. The interesting wire-level fact is
+//     that the input crossed at 184 chars verbatim.
+//  4. resources/read on the iframe URI — focus on `_meta.ui.csp.connectDomains`.
+//     The walkthrough does NOT dump the HTML body; the pedagogically
+//     interesting bit is the CSP allowlist that unblocks abcjs's
+//     soundfont fetch. Same family of bug as the transcript fixture's
+//     missing `microphone` permission — silent failure if you only
+//     trust the visual render.
+//
+// Each step attaches two unboxed Verbatim blocks via common.WireRecipe:
+// a curl form (copy-pastable into a terminal) and a Go form (the
+// equivalent *client.Client call).
 func runDemo() {
-	serverURL := serverURLFor3101()
+	serverURL := common.MCPServerURL()
 
-	demo := demokit.New("sheet-music walkthrough (stub)").
-		Description("TODO: describe what this walkthrough demonstrates.").
+	demo := demokit.New("sheet-music — multi-line default + CSP-allowlisted iframe").
+		Dir("sheet-music").
+		Description("Walks the play-sheet-music round trip end-to-end as a scripted MCP client. The two distinctive things about this fixture are visible on the wire: the InputSchemaPatch default (a multi-line comma-laden ABC notation string that struct-tag reflection would have truncated) and the resource's _meta.ui.csp.connectDomains (the soundfont CDN allowlist that lets abcjs play audio). Run `make serve` in another terminal first.").
 		Actors(
 			demokit.Actor("Host", "MCP Host (this client)"),
 			demokit.Actor("Server", "mcpkit-Go fixture (make serve)"),
 		)
 
+	demo.Section("Setup",
+		"Start the MCP server in a separate terminal first:",
+		"",
+		"```",
+		"Terminal 1:  make serve         # mcpkit-Go fixture on :3101",
+		"Terminal 2:  make demo          # this walkthrough (--tui for interactive TUI)",
+		"```",
+		"",
+		"Any MCP host can connect to the running server (Claude Desktop, VS Code, MCPJam, basic-host). The walkthrough below acts as a scripted host that issues the protocol calls directly through `*mcpkit/client.Client` — no LLM, no browser. The same calls drive the iframe when you run `make demo-app EXAMPLE=sheet-music` in basic-host (see the [centralized guide](../README.md#other-ways-to-test-a-fixture)).",
+	)
+
 	var c *client.Client
 
-	demo.Step("Connect to the fixture").
+	step1 := demo.Step("Connect to the fixture").
 		Arrow("Host", "Server", "POST /mcp — initialize").
 		DashedArrow("Server", "Host", "serverInfo + capabilities + Mcp-Session-Id").
-		Note("Stub — refine in walkthrough.go.").
-		Run(func(ctx demokit.StepContext) *demokit.StepResult {
-			c = client.NewClient(serverURL+"/mcp",
-				core.ClientInfo{Name: "sheet-music-host", Version: "1.0"},
-			)
-			if err := c.Connect(); err != nil {
-				fmt.Printf("    ERROR: %v\n    Start the server with: make serve\n", err)
-				return nil
-			}
-			fmt.Printf("    connected to %s %s\n", c.ServerInfo.Name, c.ServerInfo.Version)
-			return nil
-		})
+		Note("Session establishment is a single initialize round-trip plus the notifications/initialized ack. `*client.Client.Connect()` does both behind one call; the curl form below shows the raw shape.")
+	common.WireRecipe(step1,
+		`# Initialize. Mcp-Session-Id comes back in the response headers.
+SID=$(curl -si -X POST `+serverURL+`/mcp \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: text/event-stream, application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"curl","version":"1"}}}' \
+  | awk 'tolower($1) == "mcp-session-id:" {gsub(/\r/,""); print $2}')
 
-	demo.Step("List tools").
-		Arrow("Host", "Server", "tools/list").
-		DashedArrow("Server", "Host", "tools[]").
-		Note("Stub — refine in walkthrough.go.").
-		Run(func(ctx demokit.StepContext) *demokit.StepResult {
-			res, err := c.Call("tools/list", map[string]any{})
-			if err != nil {
-				fmt.Printf("    ERROR: %v\n", err)
-				return nil
-			}
-			pretty, _ := json.MarshalIndent(json.RawMessage(res.Raw), "    ", "  ")
-			fmt.Printf("    %s\n", string(pretty))
+# Acknowledge so the server's dispatcher unblocks.
+curl -s -X POST `+serverURL+`/mcp \
+  -H "Mcp-Session-Id: $SID" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: text/event-stream, application/json' \
+  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}'`,
+		`c := client.NewClient("`+serverURL+`/mcp",
+    core.ClientInfo{Name: "sheet-music-host", Version: "1.0"},
+)
+if err := c.Connect(); err != nil {
+    log.Fatalf("connect: %v", err)
+}
+// Connect() handles initialize + notifications/initialized + session header.
+fmt.Printf("connected to %s %s\n", c.ServerInfo.Name, c.ServerInfo.Version)`,
+	).Run(func(ctx demokit.StepContext) *demokit.StepResult {
+		c = client.NewClient(serverURL+"/mcp",
+			core.ClientInfo{Name: "sheet-music-host", Version: "1.0"},
+		)
+		if err := c.Connect(); err != nil {
+			fmt.Printf("    ERROR: %v\n    Start the server with: make serve\n", err)
 			return nil
+		}
+		fmt.Printf("    connected to %s %s\n", c.ServerInfo.Name, c.ServerInfo.Version)
+		return nil
+	})
+
+	step2 := demo.Step("tools/list — verify the multi-line default landed intact").
+		Arrow("Host", "Server", "tools/list").
+		DashedArrow("Server", "Host", "tools[] including play-sheet-music").
+		Note("The pedagogically interesting bit isn't that play-sheet-music exists — it's `inputSchema.properties.abcNotation.default`. The fixture uses `InputSchemaPatch` (`s.Prop(\"abcNotation\").Default(defaultABCNotation)`) to land the 11-line, comma-laden ABC notation default verbatim. invopop's struct-tag parser would have truncated at the first comma. The walkthrough prints just that default field below — confirm every line is present.")
+	common.WireRecipe(step2,
+		`curl -s -X POST `+serverURL+`/mcp \
+  -H "Mcp-Session-Id: $SID" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: text/event-stream, application/json' \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' \
+  | jq -r '.result.tools[] | select(.name=="play-sheet-music") | .inputSchema.properties.abcNotation.default'`,
+		`res, _ := c.Call("tools/list", map[string]any{})
+var out struct {
+    Tools []struct {
+        Name        string         `+"`json:\"name\"`"+`
+        InputSchema map[string]any `+"`json:\"inputSchema\"`"+`
+    } `+"`json:\"tools\"`"+`
+}
+json.Unmarshal(res.Raw, &out)
+for _, t := range out.Tools {
+    if t.Name == "play-sheet-music" {
+        props := t.InputSchema["properties"].(map[string]any)
+        abc := props["abcNotation"].(map[string]any)
+        fmt.Printf("default:\n%s\n", abc["default"])
+    }
+}`,
+	).Run(func(ctx demokit.StepContext) *demokit.StepResult {
+		res, err := c.Call("tools/list", map[string]any{})
+		if err != nil {
+			fmt.Printf("    ERROR: %v\n", err)
+			return nil
+		}
+		var out struct {
+			Tools []struct {
+				Name        string         `json:"name"`
+				InputSchema map[string]any `json:"inputSchema"`
+			} `json:"tools"`
+		}
+		if err := json.Unmarshal(res.Raw, &out); err != nil {
+			fmt.Printf("    ERROR decoding tools/list: %v\n", err)
+			return nil
+		}
+		for _, t := range out.Tools {
+			if t.Name != "play-sheet-music" {
+				continue
+			}
+			props, _ := t.InputSchema["properties"].(map[string]any)
+			abc, _ := props["abcNotation"].(map[string]any)
+			if def, ok := abc["default"].(string); ok {
+				fmt.Printf("    inputSchema.properties.abcNotation.default:\n")
+				for _, line := range common.SplitLines(def) {
+					fmt.Printf("      %s\n", line)
+				}
+			}
+		}
+		return nil
+	})
+
+	step3 := demo.Step("tools/call play-sheet-music — round-trip the ABC notation").
+		Arrow("Host", "Server", "tools/call play-sheet-music { abcNotation: <184 chars> }").
+		DashedArrow("Server", "Host", "ToolResult.content[0].text = \"Input parsed successfully.\"").
+		Note("The server-side handler is intentionally minimal — it returns a small text envelope confirming the parse. The wire-level lesson is that the full 184-char ABC notation crosses verbatim and is unmarshaled into the typed `playSheetMusicInput.ABCNotation` field. The iframe does the actual rendering + audio playback work; see step 4 for what makes that work.")
+	common.WireRecipe(step3,
+		`curl -s -X POST `+serverURL+`/mcp \
+  -H "Mcp-Session-Id: $SID" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: text/event-stream, application/json' \
+  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"play-sheet-music","arguments":{"abcNotation":"X:1\nT:Twinkle, Twinkle Little Star\nM:4/4\nL:1/4\nK:C\nC C G G | A A G2 | F F E E | D D C2 |\nG G F F | E E D2 | G G F F | E E D2 |\nC C G G | A A G2 | F F E E | D D C2 |"}}}' \
+  | jq -r '.result.content[0].text'`,
+		`tr, _ := c.ToolCallFull("play-sheet-music", map[string]any{
+    "abcNotation": defaultABCNotation, // the const from main.go
+})
+// tr.Content[0].Text is the small text envelope.
+fmt.Printf("server said: %s\n", tr.Content[0].Text)`,
+	).Run(func(ctx demokit.StepContext) *demokit.StepResult {
+		tr, err := c.ToolCallFull("play-sheet-music", map[string]any{
+			"abcNotation": defaultABCNotation,
 		})
+		if err != nil {
+			fmt.Printf("    ERROR: %v\n", err)
+			return nil
+		}
+		if len(tr.Content) > 0 {
+			fmt.Printf("    server said: %s\n", tr.Content[0].Text)
+		}
+		fmt.Printf("    (sent %d-char ABC notation; round-tripped through the typed handler)\n", len(defaultABCNotation))
+		return nil
+	})
+
+	step4 := demo.Step("resources/read — the CSP allowlist that unblocks audio").
+		Arrow("Host", "Server", "resources/read { uri: ui://sheet-music/mcp-app.html }").
+		DashedArrow("Server", "Host", "Contents[0]._meta.ui.csp.connectDomains").
+		Note("This walkthrough does NOT dump the HTML body — it's a build artifact mirrored verbatim from upstream. The pedagogically interesting bit is `_meta.ui.csp.connectDomains` on the resource read response. abcjs streams soundfonts from `paulrosen.github.io` when the user clicks ▶ Play; without that origin on the iframe's `connect-src` allowlist, basic-host's CSP blocks the fetch and audio silently fails. The fixture declares it on the resource _meta — same shape upstream's sheet-music-server uses, same shape every CSP-aware MCP host can read.")
+	common.WireRecipe(step4,
+		`curl -s -X POST `+serverURL+`/mcp \
+  -H "Mcp-Session-Id: $SID" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: text/event-stream, application/json' \
+  -d '{"jsonrpc":"2.0","id":4,"method":"resources/read","params":{"uri":"ui://sheet-music/mcp-app.html"}}' \
+  | jq '.result.contents[0]._meta'`,
+		`var raw struct {
+    Contents []struct {
+        Meta json.RawMessage `+"`json:\"_meta\"`"+`
+    } `+"`json:\"contents\"`"+`
+}
+res, _ := c.Call("resources/read", map[string]any{
+    "uri": "ui://sheet-music/mcp-app.html",
+})
+json.Unmarshal(res.Raw, &raw)
+// The bytes of _meta are the wire-level proof: csp.connectDomains
+// lists the soundfont origin.
+fmt.Printf("_meta: %s\n", string(raw.Contents[0].Meta))`,
+	).Run(func(ctx demokit.StepContext) *demokit.StepResult {
+		res, err := c.Call("resources/read", map[string]any{
+			"uri": "ui://sheet-music/mcp-app.html",
+		})
+		if err != nil {
+			fmt.Printf("    ERROR: %v\n", err)
+			return nil
+		}
+		var raw struct {
+			Contents []struct {
+				Meta json.RawMessage `json:"_meta"`
+			} `json:"contents"`
+		}
+		if err := json.Unmarshal(res.Raw, &raw); err != nil {
+			fmt.Printf("    ERROR decoding resources/read: %v\n", err)
+			return nil
+		}
+		if len(raw.Contents) == 0 {
+			fmt.Printf("    no contents returned\n")
+			return nil
+		}
+		if len(raw.Contents[0].Meta) == 0 {
+			fmt.Printf("    _meta is empty — CSP allowlist would NOT be applied; audio playback would silently fail\n")
+			return nil
+		}
+		pretty, _ := json.MarshalIndent(json.RawMessage(raw.Contents[0].Meta), "      ", "  ")
+		fmt.Printf("    _meta:\n      %s\n", string(pretty))
+		return nil
+	})
+
+	demo.Section("Where to look in the code",
+		"- `main.go` — the InputSchemaPatch landing the default + the ResourceHandler setting `_meta.ui.csp.connectDomains`. Both are visible in single contiguous edits.",
+		"- `walkthrough.go` — this file. Each step's curl + Go recipe is the canonical wire reproduction.",
+		"- `../README.md` — narrative + the [CSP connect-src contract](../sheet-music/README.md#the-csp-connect-src-contract) section explains why the resource `_meta` matters.",
+	)
+
+	_ = step1
+	_ = step2
+	_ = step3
+	_ = step4
 
 	common.SetupRenderer(demo)
 	demo.Execute()
-}
-
-// serverURLFor3101 returns the walkthrough's target MCP server URL.
-// Honors $MCPKIT_SERVER_URL as an explicit override; defaults to
-// localhost:3101 (the compat-fixture port).
-func serverURLFor3101() string {
-	if u := os.Getenv(common.ServerURLEnv); u != "" {
-		return u
-	}
-	return "http://localhost:3101"
 }

--- a/examples/apps/compat/sheet-music/walkthrough.trace.json
+++ b/examples/apps/compat/sheet-music/walkthrough.trace.json
@@ -1,0 +1,40 @@
+[
+  {
+    "kind": "section",
+    "title": "Setup",
+    "body": "Start the MCP server in a separate terminal first:\n\n```\nTerminal 1:  make serve         # mcpkit-Go fixture on :3101\nTerminal 2:  make demo          # this walkthrough (--tui for interactive TUI)\n```\n\nAny MCP host can connect to the running server (Claude Desktop, VS Code, MCPJam, basic-host). The walkthrough below acts as a scripted host that issues the protocol calls directly through `*mcpkit/client.Client` — no LLM, no browser. The same calls drive the iframe when you run `make demo-app EXAMPLE=sheet-music` in basic-host (see the [centralized guide](../README.md#other-ways-to-test-a-fixture))."
+  },
+  {
+    "kind": "step",
+    "title": "Connect to the fixture",
+    "step_id": "step-1",
+    "visit": 1,
+    "output": "    connected to Sheet Music Server 1.0.0\n"
+  },
+  {
+    "kind": "step",
+    "title": "tools/list — verify the multi-line default landed intact",
+    "step_id": "step-2",
+    "visit": 1,
+    "output": "    inputSchema.properties.abcNotation.default:\n      X:1\n      T:Twinkle, Twinkle Little Star\n      M:4/4\n      L:1/4\n      K:C\n      C C G G | A A G2 | F F E E | D D C2 |\n      G G F F | E E D2 | G G F F | E E D2 |\n      C C G G | A A G2 | F F E E | D D C2 |\n"
+  },
+  {
+    "kind": "step",
+    "title": "tools/call play-sheet-music — round-trip the ABC notation",
+    "step_id": "step-3",
+    "visit": 1,
+    "output": "    server said: Input parsed successfully.\n    (sent 164-char ABC notation; round-tripped through the typed handler)\n"
+  },
+  {
+    "kind": "step",
+    "title": "resources/read — the CSP allowlist that unblocks audio",
+    "step_id": "step-4",
+    "visit": 1,
+    "output": "    _meta:\n      {\n        \"ui\": {\n          \"csp\": {\n            \"connectDomains\": [\n              \"https://paulrosen.github.io\"\n            ]\n          }\n        }\n      }\n"
+  },
+  {
+    "kind": "section",
+    "title": "Where to look in the code",
+    "body": "- `main.go` — the InputSchemaPatch landing the default + the ResourceHandler setting `_meta.ui.csp.connectDomains`. Both are visible in single contiguous edits.\n- `walkthrough.go` — this file. Each step's curl + Go recipe is the canonical wire reproduction.\n- `../README.md` — narrative + the [CSP connect-src contract](../sheet-music/README.md#the-csp-connect-src-contract) section explains why the resource `_meta` matters."
+  }
+]

--- a/examples/apps/compat/system-monitor/walkthrough.go
+++ b/examples/apps/compat/system-monitor/walkthrough.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/panyam/demokit"
 	"github.com/panyam/mcpkit/client"
@@ -20,7 +19,7 @@ import (
 //
 // TODO: replace this stub with a curated walkthrough.
 func runDemo() {
-	serverURL := serverURLFor3101()
+	serverURL := common.MCPServerURL()
 
 	demo := demokit.New("system-monitor walkthrough (stub)").
 		Description("TODO: describe what this walkthrough demonstrates.").
@@ -64,14 +63,4 @@ func runDemo() {
 
 	common.SetupRenderer(demo)
 	demo.Execute()
-}
-
-// serverURLFor3101 returns the walkthrough's target MCP server URL.
-// Honors $MCPKIT_SERVER_URL as an explicit override; defaults to
-// localhost:3101 (the compat-fixture port).
-func serverURLFor3101() string {
-	if u := os.Getenv(common.ServerURLEnv); u != "" {
-		return u
-	}
-	return "http://localhost:3101"
 }

--- a/examples/apps/compat/threejs/walkthrough.go
+++ b/examples/apps/compat/threejs/walkthrough.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/panyam/demokit"
 	"github.com/panyam/mcpkit/client"
@@ -20,7 +19,7 @@ import (
 //
 // TODO: replace this stub with a curated walkthrough.
 func runDemo() {
-	serverURL := serverURLFor3101()
+	serverURL := common.MCPServerURL()
 
 	demo := demokit.New("threejs walkthrough (stub)").
 		Description("TODO: describe what this walkthrough demonstrates.").
@@ -64,14 +63,4 @@ func runDemo() {
 
 	common.SetupRenderer(demo)
 	demo.Execute()
-}
-
-// serverURLFor3101 returns the walkthrough's target MCP server URL.
-// Honors $MCPKIT_SERVER_URL as an explicit override; defaults to
-// localhost:3101 (the compat-fixture port).
-func serverURLFor3101() string {
-	if u := os.Getenv(common.ServerURLEnv); u != "" {
-		return u
-	}
-	return "http://localhost:3101"
 }

--- a/examples/apps/compat/transcript/README.md
+++ b/examples/apps/compat/transcript/README.md
@@ -23,6 +23,10 @@ meaningful work in the iframe (rather than just rendering a value).
   See [The iframe permission contract](#the-iframe-permission-contract)
   below for the wire shape and the spec-conformance footnote.
 
+## Run Pre-Recorded
+
+> ▶ **[Play the walkthrough in your browser](https://panyam.github.io/mcpkit/walkthroughs/examples/apps/compat/transcript/)** — animated playback of every curl / Go call the walkthrough makes, step-by-step. Step 4 surfaces the distinctive thing about this fixture on the wire: `_meta.ui.permissions` declaring microphone + clipboardWrite, which is what lets basic-host pass through Permission-Policy grants to the iframe. No clone, no setup.
+
 ## Or Run Live
 
 ### Start Server

--- a/examples/apps/compat/transcript/bundle/index.html
+++ b/examples/apps/compat/transcript/bundle/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>transcript walkthrough (stub)</title>
+<title>transcript — Web Speech App with Permission-Policy _meta</title>
 <link rel="stylesheet" href="./demokit-player.css">
 <style>
 body { margin: 2em auto; max-width: 900px; padding: 0 1em; font-family: -apple-system, BlinkMacSystemFont, sans-serif; }
@@ -12,8 +12,8 @@ body { margin: 2em auto; max-width: 900px; padding: 0 1em; font-family: -apple-s
 <body>
 <demokit-demo>{
   "demo": {
-    "title": "transcript walkthrough (stub)",
-    "description": "TODO: describe what this walkthrough demonstrates.",
+    "title": "transcript — Web Speech App with Permission-Policy _meta",
+    "description": "Walks the transcribe round trip end-to-end as a scripted MCP client. The distinctive thing about this fixture is visible on the wire: the resource's _meta.ui.permissions block (microphone + clipboardWrite). Without that declaration, basic-host loads the iframe with no Permission-Policy grant and the browser blocks recognition.start() silently. Run `make serve` in another terminal first.",
     "actors": [
       {
         "id": "Host",
@@ -26,9 +26,14 @@ body { margin: 2em auto; max-width: 900px; padding: 0 1em; font-family: -apple-s
     ],
     "items": [
       {
+        "kind": "section",
+        "title": "Setup",
+        "body": "Start the MCP server in a separate terminal first:\n\n```\nTerminal 1:  make serve         # mcpkit-Go fixture on :3101\nTerminal 2:  make demo          # this walkthrough (--tui for interactive TUI)\n```\n\nAny MCP host can connect to the running server (Claude Desktop, VS Code, MCPJam, basic-host). The walkthrough below acts as a scripted host that issues the protocol calls directly through `*mcpkit/client.Client` — no LLM, no browser. The same calls drive the iframe when you run `make demo-app EXAMPLE=transcript` in basic-host (see the [centralized guide](../README.md#other-ways-to-test-a-fixture))."
+      },
+      {
         "kind": "step",
         "title": "Connect to the fixture",
-        "note": "Stub — refine in walkthrough.go.",
+        "note": "Session establishment is a single initialize round-trip plus the notifications/initialized ack. `*client.Client.Connect()` does both behind one call; the curl form below shows the raw shape.",
         "arrows": [
           {
             "from": "Host",
@@ -41,12 +46,25 @@ body { margin: 2em auto; max-width: 900px; padding: 0 1em; font-family: -apple-s
             "label": "serverInfo + capabilities + Mcp-Session-Id",
             "dashed": true
           }
+        ],
+        "verbatim": [
+          {
+            "label": "Reproduce on the wire",
+            "variants": [
+              {
+                "label": "curl",
+                "lang": "bash",
+                "content": "# Initialize. Mcp-Session-Id comes back in the response headers.\nSID=$(curl -si -X POST http://localhost:3101/mcp \\\n  -H 'Content-Type: application/json' \\\n  -H 'Accept: text/event-stream, application/json' \\\n  -d '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"clientInfo\":{\"name\":\"curl\",\"version\":\"1\"}}}' \\\n  | awk 'tolower($1) == \"mcp-session-id:\" {gsub(/\\r/,\"\"); print $2}')\n\n# Acknowledge so the server's dispatcher unblocks.\ncurl -s -X POST http://localhost:3101/mcp \\\n  -H \"Mcp-Session-Id: $SID\" \\\n  -H 'Content-Type: application/json' \\\n  -H 'Accept: text/event-stream, application/json' \\\n  -d '{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}'",
+                "default": true
+              }
+            ]
+          }
         ]
       },
       {
         "kind": "step",
-        "title": "List tools",
-        "note": "Stub — refine in walkthrough.go.",
+        "title": "tools/list — verify transcribe + its UI resource",
+        "note": "`transcribe` has an empty input schema — the tool is the iframe-open signal, not a parameterized call. `_meta.ui.resourceUri` points at the iframe HTML the host loads.",
         "arrows": [
           {
             "from": "Host",
@@ -56,14 +74,99 @@ body { margin: 2em auto; max-width: 900px; padding: 0 1em; font-family: -apple-s
           {
             "from": "Server",
             "to": "Host",
-            "label": "tools[]",
+            "label": "tools[] including transcribe",
             "dashed": true
           }
+        ],
+        "verbatim": [
+          {
+            "label": "Reproduce on the wire",
+            "variants": [
+              {
+                "label": "curl",
+                "lang": "bash",
+                "content": "curl -s -X POST http://localhost:3101/mcp \\\n  -H \"Mcp-Session-Id: $SID\" \\\n  -H 'Content-Type: application/json' \\\n  -H 'Accept: text/event-stream, application/json' \\\n  -d '{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{}}' \\\n  | jq '.result.tools[] | {name, _meta}'",
+                "default": true
+              }
+            ]
+          }
         ]
+      },
+      {
+        "kind": "step",
+        "title": "tools/call transcribe — the iframe-open signal",
+        "note": "The server-side handler is intentionally minimal — `transcribeReady` is a fixed string mirroring upstream's transcript-server. All the real transcription work happens in the iframe via the Web Speech API; this call just signals the host \"open my UI now.\" The iframe-side work is invisible on the wire; what's visible is the small text envelope returned synchronously.",
+        "arrows": [
+          {
+            "from": "Host",
+            "to": "Server",
+            "label": "tools/call transcribe {}"
+          },
+          {
+            "from": "Server",
+            "to": "Host",
+            "label": "ToolResult.content[0].text = `{\"status\":\"ready\",...}`",
+            "dashed": true
+          }
+        ],
+        "verbatim": [
+          {
+            "label": "Reproduce on the wire",
+            "variants": [
+              {
+                "label": "curl",
+                "lang": "bash",
+                "content": "curl -s -X POST http://localhost:3101/mcp \\\n  -H \"Mcp-Session-Id: $SID\" \\\n  -H 'Content-Type: application/json' \\\n  -H 'Accept: text/event-stream, application/json' \\\n  -d '{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"transcribe\",\"arguments\":{}}}' \\\n  | jq -r '.result.content[0].text'",
+                "default": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "step",
+        "title": "resources/read — the Permission-Policy block that unblocks the mic",
+        "note": "This walkthrough does NOT dump the HTML body — it's a build artifact mirrored verbatim from upstream. The pedagogically interesting bit is `_meta.ui.permissions` on the resource read response. The iframe calls `recognition.start()` (Web Speech API) and the copy-transcript button (Clipboard API); both need Permission-Policy grants on the iframe sandbox. The Go fixture declares them on the resource _meta — same shape upstream's transcript-server uses, same shape every Permission-Policy-aware MCP host can read.",
+        "arrows": [
+          {
+            "from": "Host",
+            "to": "Server",
+            "label": "resources/read { uri: ui://transcript/mcp-app.html }"
+          },
+          {
+            "from": "Server",
+            "to": "Host",
+            "label": "Contents[0]._meta.ui.permissions",
+            "dashed": true
+          }
+        ],
+        "verbatim": [
+          {
+            "label": "Reproduce on the wire",
+            "variants": [
+              {
+                "label": "curl",
+                "lang": "bash",
+                "content": "curl -s -X POST http://localhost:3101/mcp \\\n  -H \"Mcp-Session-Id: $SID\" \\\n  -H 'Content-Type: application/json' \\\n  -H 'Accept: text/event-stream, application/json' \\\n  -d '{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"resources/read\",\"params\":{\"uri\":\"ui://transcript/mcp-app.html\"}}' \\\n  | jq '.result.contents[0]._meta'",
+                "default": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "section",
+        "title": "Where to look in the code",
+        "body": "- `main.go` — the ResourceHandler setting `_meta.ui.permissions`. The microphone + clipboardWrite fields are visible in a single contiguous edit.\n- `walkthrough.go` — this file. Each step's curl + Go recipe is the canonical wire reproduction.\n- `../README.md` — narrative + the [iframe permission contract](../transcript/README.md#the-iframe-permission-contract) section explains why the resource `_meta` matters."
       }
     ]
   },
   "trace": [
+    {
+      "kind": "section",
+      "title": "Setup",
+      "body": "Start the MCP server in a separate terminal first:\n\n```\nTerminal 1:  make serve         # mcpkit-Go fixture on :3101\nTerminal 2:  make demo          # this walkthrough (--tui for interactive TUI)\n```\n\nAny MCP host can connect to the running server (Claude Desktop, VS Code, MCPJam, basic-host). The walkthrough below acts as a scripted host that issues the protocol calls directly through `*mcpkit/client.Client` — no LLM, no browser. The same calls drive the iframe when you run `make demo-app EXAMPLE=transcript` in basic-host (see the [centralized guide](../README.md#other-ways-to-test-a-fixture))."
+    },
     {
       "kind": "step",
       "title": "Connect to the fixture",
@@ -73,10 +176,29 @@ body { margin: 2em auto; max-width: 900px; padding: 0 1em; font-family: -apple-s
     },
     {
       "kind": "step",
-      "title": "List tools",
+      "title": "tools/list — verify transcribe + its UI resource",
       "step_id": "step-2",
       "visit": 1,
-      "output": "    {\n      \"tools\": [\n        {\n          \"name\": \"transcribe\",\n          \"title\": \"Transcribe Speech\",\n          \"description\": \"Opens a live speech transcription interface using the Web Speech API.\",\n          \"inputSchema\": {\n            \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n            \"properties\": {},\n            \"type\": \"object\"\n          },\n          \"execution\": {\n            \"taskSupport\": \"forbidden\"\n          },\n          \"_meta\": {\n            \"ui\": {\n              \"resourceUri\": \"ui://transcript/mcp-app.html\"\n            },\n            \"ui/resourceUri\": \"ui://transcript/mcp-app.html\"\n          }\n        }\n      ]\n    }\n"
+      "output": "    transcribe\n      _meta: {\n        \"ui\": {\n          \"resourceUri\": \"ui://transcript/mcp-app.html\"\n        },\n        \"ui/resourceUri\": \"ui://transcript/mcp-app.html\"\n      }\n"
+    },
+    {
+      "kind": "step",
+      "title": "tools/call transcribe — the iframe-open signal",
+      "step_id": "step-3",
+      "visit": 1,
+      "output": "    server said: {\"status\":\"ready\",\"message\":\"Transcription UI opened. Speak into your microphone.\"}\n"
+    },
+    {
+      "kind": "step",
+      "title": "resources/read — the Permission-Policy block that unblocks the mic",
+      "step_id": "step-4",
+      "visit": 1,
+      "output": "    _meta:\n      {\n        \"ui\": {\n          \"permissions\": {\n            \"microphone\": {},\n            \"clipboardWrite\": {}\n          }\n        }\n      }\n"
+    },
+    {
+      "kind": "section",
+      "title": "Where to look in the code",
+      "body": "- `main.go` — the ResourceHandler setting `_meta.ui.permissions`. The microphone + clipboardWrite fields are visible in a single contiguous edit.\n- `walkthrough.go` — this file. Each step's curl + Go recipe is the canonical wire reproduction.\n- `../README.md` — narrative + the [iframe permission contract](../transcript/README.md#the-iframe-permission-contract) section explains why the resource `_meta` matters."
     }
   ]
 }

--- a/examples/apps/compat/transcript/walkthrough.go
+++ b/examples/apps/compat/transcript/walkthrough.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/panyam/demokit"
 	"github.com/panyam/mcpkit/client"
@@ -11,67 +10,226 @@ import (
 	"github.com/panyam/mcpkit/examples/common"
 )
 
-// runDemo is a STUB walkthrough — it connects to the fixture and lists
-// its tools. Refine it: add a tools/call step per tool, attach
-// common.WireRecipe(step, curl, go) for the wire reproduction, drop
-// fixture-specific narrative in .Note(...). See
-// examples/apps/compat/basic-vanillajs/walkthrough.go for the full
-// pattern.
+// runDemo is the transcript walkthrough. Acts as a scripted MCP host
+// against a server started by `make serve` in another terminal.
 //
-// TODO: replace this stub with a curated walkthrough.
+// Walks four steps, each one anchored on a fixture-specific protocol
+// surface (not generic protocol mechanics — that's basic-vanillajs's
+// job):
+//
+//  1. Connect to the fixture (POST /mcp initialize → session).
+//  2. tools/list — verify transcribe is advertised.
+//  3. tools/call transcribe — capture the small `{status: "ready", ...}`
+//     text envelope the Go handler returns synchronously. The actual
+//     transcription work happens in the iframe via the Web Speech API;
+//     the wire call is just the open-the-UI signal.
+//  4. resources/read on the iframe URI — focus on `_meta.ui.permissions`.
+//     The walkthrough does NOT dump the HTML body; the pedagogically
+//     interesting bit is the Permission-Policy declaration that lets the
+//     iframe ask for microphone access. Without that _meta block, basic-host
+//     renders the iframe with no policy grant and `recognition.start()`
+//     silently fails (no mic prompt, no transcription). Same family of
+//     bug as the sheet-music fixture's missing CSP allowlist.
+//
+// Each step attaches two unboxed Verbatim blocks via common.WireRecipe:
+// a curl form (copy-pastable into a terminal) and a Go form (the
+// equivalent *client.Client call).
 func runDemo() {
-	serverURL := serverURLFor3101()
+	serverURL := common.MCPServerURL()
 
-	demo := demokit.New("transcript walkthrough (stub)").
-		Description("TODO: describe what this walkthrough demonstrates.").
+	demo := demokit.New("transcript — Web Speech App with Permission-Policy _meta").
+		Dir("transcript").
+		Description("Walks the transcribe round trip end-to-end as a scripted MCP client. The distinctive thing about this fixture is visible on the wire: the resource's _meta.ui.permissions block (microphone + clipboardWrite). Without that declaration, basic-host loads the iframe with no Permission-Policy grant and the browser blocks recognition.start() silently. Run `make serve` in another terminal first.").
 		Actors(
 			demokit.Actor("Host", "MCP Host (this client)"),
 			demokit.Actor("Server", "mcpkit-Go fixture (make serve)"),
 		)
 
+	demo.Section("Setup",
+		"Start the MCP server in a separate terminal first:",
+		"",
+		"```",
+		"Terminal 1:  make serve         # mcpkit-Go fixture on :3101",
+		"Terminal 2:  make demo          # this walkthrough (--tui for interactive TUI)",
+		"```",
+		"",
+		"Any MCP host can connect to the running server (Claude Desktop, VS Code, MCPJam, basic-host). The walkthrough below acts as a scripted host that issues the protocol calls directly through `*mcpkit/client.Client` — no LLM, no browser. The same calls drive the iframe when you run `make demo-app EXAMPLE=transcript` in basic-host (see the [centralized guide](../README.md#other-ways-to-test-a-fixture)).",
+	)
+
 	var c *client.Client
 
-	demo.Step("Connect to the fixture").
+	step1 := demo.Step("Connect to the fixture").
 		Arrow("Host", "Server", "POST /mcp — initialize").
 		DashedArrow("Server", "Host", "serverInfo + capabilities + Mcp-Session-Id").
-		Note("Stub — refine in walkthrough.go.").
-		Run(func(ctx demokit.StepContext) *demokit.StepResult {
-			c = client.NewClient(serverURL+"/mcp",
-				core.ClientInfo{Name: "transcript-host", Version: "1.0"},
-			)
-			if err := c.Connect(); err != nil {
-				fmt.Printf("    ERROR: %v\n    Start the server with: make serve\n", err)
-				return nil
-			}
-			fmt.Printf("    connected to %s %s\n", c.ServerInfo.Name, c.ServerInfo.Version)
-			return nil
-		})
+		Note("Session establishment is a single initialize round-trip plus the notifications/initialized ack. `*client.Client.Connect()` does both behind one call; the curl form below shows the raw shape.")
+	common.WireRecipe(step1,
+		`# Initialize. Mcp-Session-Id comes back in the response headers.
+SID=$(curl -si -X POST `+serverURL+`/mcp \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: text/event-stream, application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"curl","version":"1"}}}' \
+  | awk 'tolower($1) == "mcp-session-id:" {gsub(/\r/,""); print $2}')
 
-	demo.Step("List tools").
-		Arrow("Host", "Server", "tools/list").
-		DashedArrow("Server", "Host", "tools[]").
-		Note("Stub — refine in walkthrough.go.").
-		Run(func(ctx demokit.StepContext) *demokit.StepResult {
-			res, err := c.Call("tools/list", map[string]any{})
-			if err != nil {
-				fmt.Printf("    ERROR: %v\n", err)
-				return nil
-			}
-			pretty, _ := json.MarshalIndent(json.RawMessage(res.Raw), "    ", "  ")
-			fmt.Printf("    %s\n", string(pretty))
+# Acknowledge so the server's dispatcher unblocks.
+curl -s -X POST `+serverURL+`/mcp \
+  -H "Mcp-Session-Id: $SID" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: text/event-stream, application/json' \
+  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}'`,
+		`c := client.NewClient("`+serverURL+`/mcp",
+    core.ClientInfo{Name: "transcript-host", Version: "1.0"},
+)
+if err := c.Connect(); err != nil {
+    log.Fatalf("connect: %v", err)
+}
+// Connect() handles initialize + notifications/initialized + session header.
+fmt.Printf("connected to %s %s\n", c.ServerInfo.Name, c.ServerInfo.Version)`,
+	).Run(func(ctx demokit.StepContext) *demokit.StepResult {
+		c = client.NewClient(serverURL+"/mcp",
+			core.ClientInfo{Name: "transcript-host", Version: "1.0"},
+		)
+		if err := c.Connect(); err != nil {
+			fmt.Printf("    ERROR: %v\n    Start the server with: make serve\n", err)
 			return nil
+		}
+		fmt.Printf("    connected to %s %s\n", c.ServerInfo.Name, c.ServerInfo.Version)
+		return nil
+	})
+
+	step2 := demo.Step("tools/list — verify transcribe + its UI resource").
+		Arrow("Host", "Server", "tools/list").
+		DashedArrow("Server", "Host", "tools[] including transcribe").
+		Note("`transcribe` has an empty input schema — the tool is the iframe-open signal, not a parameterized call. `_meta.ui.resourceUri` points at the iframe HTML the host loads.")
+	common.WireRecipe(step2,
+		`curl -s -X POST `+serverURL+`/mcp \
+  -H "Mcp-Session-Id: $SID" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: text/event-stream, application/json' \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' \
+  | jq '.result.tools[] | {name, _meta}'`,
+		`res, _ := c.Call("tools/list", map[string]any{})
+var out struct {
+    Tools []struct {
+        Name string         `+"`json:\"name\"`"+`
+        Meta map[string]any `+"`json:\"_meta,omitempty\"`"+`
+    } `+"`json:\"tools\"`"+`
+}
+json.Unmarshal(res.Raw, &out)
+for _, t := range out.Tools {
+    fmt.Printf("  %s: %v\n", t.Name, t.Meta)
+}`,
+	).Run(func(ctx demokit.StepContext) *demokit.StepResult {
+		res, err := c.Call("tools/list", map[string]any{})
+		if err != nil {
+			fmt.Printf("    ERROR: %v\n", err)
+			return nil
+		}
+		var out struct {
+			Tools []struct {
+				Name string         `json:"name"`
+				Meta map[string]any `json:"_meta,omitempty"`
+			} `json:"tools"`
+		}
+		if err := json.Unmarshal(res.Raw, &out); err != nil {
+			fmt.Printf("    ERROR decoding tools/list: %v\n", err)
+			return nil
+		}
+		for _, t := range out.Tools {
+			pretty, _ := json.MarshalIndent(t.Meta, "      ", "  ")
+			fmt.Printf("    %s\n      _meta: %s\n", t.Name, string(pretty))
+		}
+		return nil
+	})
+
+	step3 := demo.Step("tools/call transcribe — the iframe-open signal").
+		Arrow("Host", "Server", "tools/call transcribe {}").
+		DashedArrow("Server", "Host", "ToolResult.content[0].text = `{\"status\":\"ready\",...}`").
+		Note("The server-side handler is intentionally minimal — `transcribeReady` is a fixed string mirroring upstream's transcript-server. All the real transcription work happens in the iframe via the Web Speech API; this call just signals the host \"open my UI now.\" The iframe-side work is invisible on the wire; what's visible is the small text envelope returned synchronously.")
+	common.WireRecipe(step3,
+		`curl -s -X POST `+serverURL+`/mcp \
+  -H "Mcp-Session-Id: $SID" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: text/event-stream, application/json' \
+  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"transcribe","arguments":{}}}' \
+  | jq -r '.result.content[0].text'`,
+		`tr, _ := c.ToolCallFull("transcribe", map[string]any{})
+// tr.Content[0].Text is `+"`{\"status\":\"ready\",\"message\":\"Transcription UI opened. Speak into your microphone.\"}`"+`
+fmt.Printf("server said: %s\n", tr.Content[0].Text)`,
+	).Run(func(ctx demokit.StepContext) *demokit.StepResult {
+		tr, err := c.ToolCallFull("transcribe", map[string]any{})
+		if err != nil {
+			fmt.Printf("    ERROR: %v\n", err)
+			return nil
+		}
+		if len(tr.Content) > 0 {
+			fmt.Printf("    server said: %s\n", tr.Content[0].Text)
+		}
+		return nil
+	})
+
+	step4 := demo.Step("resources/read — the Permission-Policy block that unblocks the mic").
+		Arrow("Host", "Server", "resources/read { uri: ui://transcript/mcp-app.html }").
+		DashedArrow("Server", "Host", "Contents[0]._meta.ui.permissions").
+		Note("This walkthrough does NOT dump the HTML body — it's a build artifact mirrored verbatim from upstream. The pedagogically interesting bit is `_meta.ui.permissions` on the resource read response. The iframe calls `recognition.start()` (Web Speech API) and the copy-transcript button (Clipboard API); both need Permission-Policy grants on the iframe sandbox. The Go fixture declares them on the resource _meta — same shape upstream's transcript-server uses, same shape every Permission-Policy-aware MCP host can read.")
+	common.WireRecipe(step4,
+		`curl -s -X POST `+serverURL+`/mcp \
+  -H "Mcp-Session-Id: $SID" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: text/event-stream, application/json' \
+  -d '{"jsonrpc":"2.0","id":4,"method":"resources/read","params":{"uri":"ui://transcript/mcp-app.html"}}' \
+  | jq '.result.contents[0]._meta'`,
+		`var raw struct {
+    Contents []struct {
+        Meta json.RawMessage `+"`json:\"_meta\"`"+`
+    } `+"`json:\"contents\"`"+`
+}
+res, _ := c.Call("resources/read", map[string]any{
+    "uri": "ui://transcript/mcp-app.html",
+})
+json.Unmarshal(res.Raw, &raw)
+// _meta.ui.permissions is what the host reads to set the iframe's allow= attribute.
+fmt.Printf("_meta: %s\n", string(raw.Contents[0].Meta))`,
+	).Run(func(ctx demokit.StepContext) *demokit.StepResult {
+		res, err := c.Call("resources/read", map[string]any{
+			"uri": "ui://transcript/mcp-app.html",
 		})
+		if err != nil {
+			fmt.Printf("    ERROR: %v\n", err)
+			return nil
+		}
+		var raw struct {
+			Contents []struct {
+				Meta json.RawMessage `json:"_meta"`
+			} `json:"contents"`
+		}
+		if err := json.Unmarshal(res.Raw, &raw); err != nil {
+			fmt.Printf("    ERROR decoding resources/read: %v\n", err)
+			return nil
+		}
+		if len(raw.Contents) == 0 {
+			fmt.Printf("    no contents returned\n")
+			return nil
+		}
+		if len(raw.Contents[0].Meta) == 0 {
+			fmt.Printf("    _meta is empty — iframe would NOT get Permission-Policy grants; recognition.start() would silently fail\n")
+			return nil
+		}
+		pretty, _ := json.MarshalIndent(json.RawMessage(raw.Contents[0].Meta), "      ", "  ")
+		fmt.Printf("    _meta:\n      %s\n", string(pretty))
+		return nil
+	})
+
+	demo.Section("Where to look in the code",
+		"- `main.go` — the ResourceHandler setting `_meta.ui.permissions`. The microphone + clipboardWrite fields are visible in a single contiguous edit.",
+		"- `walkthrough.go` — this file. Each step's curl + Go recipe is the canonical wire reproduction.",
+		"- `../README.md` — narrative + the [iframe permission contract](../transcript/README.md#the-iframe-permission-contract) section explains why the resource `_meta` matters.",
+	)
+
+	_ = step1
+	_ = step2
+	_ = step3
+	_ = step4
 
 	common.SetupRenderer(demo)
 	demo.Execute()
-}
-
-// serverURLFor3101 returns the walkthrough's target MCP server URL.
-// Honors $MCPKIT_SERVER_URL as an explicit override; defaults to
-// localhost:3101 (the compat-fixture port).
-func serverURLFor3101() string {
-	if u := os.Getenv(common.ServerURLEnv); u != "" {
-		return u
-	}
-	return "http://localhost:3101"
 }

--- a/examples/apps/compat/transcript/walkthrough.trace.json
+++ b/examples/apps/compat/transcript/walkthrough.trace.json
@@ -1,5 +1,10 @@
 [
   {
+    "kind": "section",
+    "title": "Setup",
+    "body": "Start the MCP server in a separate terminal first:\n\n```\nTerminal 1:  make serve         # mcpkit-Go fixture on :3101\nTerminal 2:  make demo          # this walkthrough (--tui for interactive TUI)\n```\n\nAny MCP host can connect to the running server (Claude Desktop, VS Code, MCPJam, basic-host). The walkthrough below acts as a scripted host that issues the protocol calls directly through `*mcpkit/client.Client` — no LLM, no browser. The same calls drive the iframe when you run `make demo-app EXAMPLE=transcript` in basic-host (see the [centralized guide](../README.md#other-ways-to-test-a-fixture))."
+  },
+  {
     "kind": "step",
     "title": "Connect to the fixture",
     "step_id": "step-1",
@@ -8,9 +13,28 @@
   },
   {
     "kind": "step",
-    "title": "List tools",
+    "title": "tools/list — verify transcribe + its UI resource",
     "step_id": "step-2",
     "visit": 1,
-    "output": "    {\n      \"tools\": [\n        {\n          \"name\": \"transcribe\",\n          \"title\": \"Transcribe Speech\",\n          \"description\": \"Opens a live speech transcription interface using the Web Speech API.\",\n          \"inputSchema\": {\n            \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n            \"properties\": {},\n            \"type\": \"object\"\n          },\n          \"execution\": {\n            \"taskSupport\": \"forbidden\"\n          },\n          \"_meta\": {\n            \"ui\": {\n              \"resourceUri\": \"ui://transcript/mcp-app.html\"\n            },\n            \"ui/resourceUri\": \"ui://transcript/mcp-app.html\"\n          }\n        }\n      ]\n    }\n"
+    "output": "    transcribe\n      _meta: {\n        \"ui\": {\n          \"resourceUri\": \"ui://transcript/mcp-app.html\"\n        },\n        \"ui/resourceUri\": \"ui://transcript/mcp-app.html\"\n      }\n"
+  },
+  {
+    "kind": "step",
+    "title": "tools/call transcribe — the iframe-open signal",
+    "step_id": "step-3",
+    "visit": 1,
+    "output": "    server said: {\"status\":\"ready\",\"message\":\"Transcription UI opened. Speak into your microphone.\"}\n"
+  },
+  {
+    "kind": "step",
+    "title": "resources/read — the Permission-Policy block that unblocks the mic",
+    "step_id": "step-4",
+    "visit": 1,
+    "output": "    _meta:\n      {\n        \"ui\": {\n          \"permissions\": {\n            \"microphone\": {},\n            \"clipboardWrite\": {}\n          }\n        }\n      }\n"
+  },
+  {
+    "kind": "section",
+    "title": "Where to look in the code",
+    "body": "- `main.go` — the ResourceHandler setting `_meta.ui.permissions`. The microphone + clipboardWrite fields are visible in a single contiguous edit.\n- `walkthrough.go` — this file. Each step's curl + Go recipe is the canonical wire reproduction.\n- `../README.md` — narrative + the [iframe permission contract](../transcript/README.md#the-iframe-permission-contract) section explains why the resource `_meta` matters."
   }
 ]

--- a/examples/apps/compat/wiki-explorer/walkthrough.go
+++ b/examples/apps/compat/wiki-explorer/walkthrough.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/panyam/demokit"
 	"github.com/panyam/mcpkit/client"
@@ -20,7 +19,7 @@ import (
 //
 // TODO: replace this stub with a curated walkthrough.
 func runDemo() {
-	serverURL := serverURLFor3101()
+	serverURL := common.MCPServerURL()
 
 	demo := demokit.New("wiki-explorer walkthrough (stub)").
 		Description("TODO: describe what this walkthrough demonstrates.").
@@ -64,14 +63,4 @@ func runDemo() {
 
 	common.SetupRenderer(demo)
 	demo.Execute()
-}
-
-// serverURLFor3101 returns the walkthrough's target MCP server URL.
-// Honors $MCPKIT_SERVER_URL as an explicit override; defaults to
-// localhost:3101 (the compat-fixture port).
-func serverURLFor3101() string {
-	if u := os.Getenv(common.ServerURLEnv); u != "" {
-		return u
-	}
-	return "http://localhost:3101"
 }

--- a/examples/common/walkthrough.go
+++ b/examples/common/walkthrough.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"os"
+	"strings"
 
 	"github.com/panyam/demokit"
 	"github.com/panyam/demokit/notebookbridge"
@@ -18,14 +19,21 @@ const DefaultServerURL = "http://localhost:8080"
 // when no --url flag is passed.
 const ServerURLEnv = "MCPKIT_SERVER_URL"
 
-// ServerURL returns the MCP server endpoint a walkthrough should connect
-// to. Precedence (highest first):
+// DefaultMCPServerURL is the default endpoint for apps/compat-style
+// MCP fixtures (one MCP server per fixture, always on :3101). MCPServerURL
+// returns this unless overridden via the env var.
+const DefaultMCPServerURL = "http://localhost:3101"
+
+// ServerURL returns the endpoint a non-UI example's walkthrough should
+// connect to. Precedence (highest first):
 //
 //  1. --url <addr> on the command line
 //  2. $MCPKIT_SERVER_URL env var
 //  3. DefaultServerURL ("http://localhost:8080")
 //
-// Examples just call common.ServerURL() — no per-example default to drift.
+// Non-UI examples (auth, tasks, file-inputs, etc.) call common.ServerURL().
+// apps/compat fixtures, which always bind :3101, call common.MCPServerURL()
+// instead.
 func ServerURL() string {
 	for i, arg := range os.Args[1:] {
 		if arg == "--url" && i+2 < len(os.Args) {
@@ -36,6 +44,27 @@ func ServerURL() string {
 		return u
 	}
 	return DefaultServerURL
+}
+
+// MCPServerURL returns the endpoint an apps/compat-style fixture's
+// walkthrough should connect to. Same env-var override as ServerURL,
+// different default port (:3101 vs :8080). Every compat fixture's
+// walkthrough.go calls this — keeps the :3101 default in one place
+// instead of duplicating a serverURLFor3101 helper per fixture.
+func MCPServerURL() string {
+	if u := os.Getenv(ServerURLEnv); u != "" {
+		return u
+	}
+	return DefaultMCPServerURL
+}
+
+// SplitLines splits a multi-line string on '\n'. Wraps the stdlib idiom
+// to keep walkthrough.go bodies focused on the demo narrative rather
+// than line-iteration mechanics — `for _, line := range common.SplitLines(s)`
+// reads cleanly in step Run() callbacks where the typical use is "print
+// each line of a multi-line value with consistent indent."
+func SplitLines(s string) []string {
+	return strings.Split(s, "\n")
 }
 
 // SetupRenderer wires the renderer matching demokit's --mode (or the


### PR DESCRIPTION
## What changes

Three coordinated themes:

### 1. Bug fix: sheet-music silently fails audio playback

`examples/apps/compat/sheet-music/main.go` now sets `_meta.ui.csp.connectDomains = ["https://paulrosen.github.io"]` on the resource ReadResponse. That origin hosts the soundfonts abcjs streams when the user clicks ▶ Play. Without the CSP allowlist, basic-host's iframe sandbox blocks the fetch and audio silently fails — sheet music renders fine but ▶ Play does nothing.

Same family of bug as transcript's missing `microphone` permission ([PR 623](https://github.com/panyam/mcpkit/pull/623)) — invisible if you only trust the visual render. Verified via live `curl resources/read` against the fixture.

### 2. Real walkthroughs for sheet-music + transcript, surfacing the fixture-specific `_meta`

Both fixtures shipped Phase 1 stub walkthroughs (Connect + tools/list, no `tools/call`). Replaced with 4-step walks anchored on what each fixture exists to demonstrate:

| Fixture | Step 2 lesson | Step 4 lesson |
|---|---|---|
| **sheet-music** | `inputSchema.properties.abcNotation.default` — the InputSchemaPatch landing the multi-line, comma-laden ABC notation default that struct-tag reflection would have truncated | `_meta.ui.csp.connectDomains` — the soundfont allowlist this PR adds |
| **transcript** | `_meta.ui.resourceUri` on `transcribe` | `_meta.ui.permissions` — the Permission-Policy block from PR 623 |

Step 4 in both walkthroughs deliberately **does not** dump the iframe HTML body — that's a build artifact. The pedagogically interesting bit is the metadata that drives iframe-sandbox behavior. Each step's `.Note()` explains *why* the wire-level thing matters; the curl + Go variants in `common.WireRecipe` show how to reproduce.

### 3. Common-utils sweep — drop duplicated `serverURLFor3101` across 20 walkthroughs

`examples/common/walkthrough.go` gains:
- `MCPServerURL()` — compat-fixture default (:3101); honors `$MCPKIT_SERVER_URL`. Companion to existing `ServerURL()` which defaults to :8080 for non-UI examples.
- `SplitLines()` — thin wrapper over `strings.Split(s, "\n")` for walkthrough step Run callbacks.

Every compat walkthrough.go drops its locally-defined `serverURLFor3101` (was duplicated 20× verbatim) and the now-unused `os` import. Pure refactor, no behavior change.

### 4. README pedagogy sections + Run Pre-Recorded play links

Both fixture READMEs gain a `## Run Pre-Recorded` section pointing at the gh-pages play link. sheet-music gains a new `## The CSP connect-src contract` section mirroring transcript's existing `## The iframe permission contract` — explains the wire shape, the resource-vs-tool meta distinction, and a table mapping `core.UICSPConfig` fields to CSP directives.

## Reviewer's guide

Read in this order:

1. [examples/apps/compat/sheet-music/main.go](https://github.com/panyam/mcpkit/pull/643/files#diff-73840c91e5132e5dd2d9e29e807f7cf5d2dab01720ff213236e02256702d96c9) — the CSP fix. One contiguous edit. The mirror of the transcript fix from PR 623.
2. [examples/apps/compat/sheet-music/README.md](https://github.com/panyam/mcpkit/pull/643/files#diff-cc30c621d46f7d520dd8d8f60a7bb20d20d6dd8f0817a37449187e3106624d77) — `## The CSP connect-src contract` section is the load-bearing addition. Same pattern as transcript's iframe-permission-contract section.
3. [examples/apps/compat/sheet-music/walkthrough.go](https://github.com/panyam/mcpkit/pull/643/files#diff-8a8b9a62f6b0263fc05524ad4debf365a9130c8b5a68f72cd413671fd6e9d80e) — 4 steps; step 2 (InputSchemaPatch payoff) and step 4 (CSP `_meta`) are the fixture-specific anchors.
4. [examples/apps/compat/transcript/walkthrough.go](https://github.com/panyam/mcpkit/pull/643/files#diff-ed7843fe5a2a326bb91b6b4b7c5b82069d6b9ea342331ca695e953c1518a6852) — mirror structure; step 4 surfaces the permissions `_meta`.
5. [examples/common/walkthrough.go](https://github.com/panyam/mcpkit/pull/643/files#diff-058737fb5cea8755994fd87ebb7959280a825208e3b0313aa54e9b6455bdc51e) — the `MCPServerURL()` + `SplitLines()` additions. ~30 lines of new code.
6. Any one compat walkthrough.go (e.g. `basic-vanillajs/walkthrough.go`) to spot-check the mechanical `serverURLFor3101` → `common.MCPServerURL` rewrite.

Skim or skip: the other 18 compat walkthrough.go diffs (mechanical, all identical), trace JSON files, bundle/ assets, screenshots PNGs.

## Decision log

- **Bundled walkthrough rewrites with the CSP fix** even though they're separate concerns. The walkthrough surfaces the `_meta` block this PR adds — splitting would leave a "fixed but unverified" intermediate state for one merge cycle.
- **Did NOT auto-inject `_meta.ui.csp` from a config field.** The user must set it in their ResourceHandler explicitly — same pattern as the permissions story. Convenience wrapper would be a future API question.
- **Step 4 prints `_meta`, not the HTML body.** Set the convention for future walkthroughs ("call out fixture-specific headers / `_meta` we want to show off") and gave it teeth in the walkthrough notes.

## Risk / blast radius

- **Behavior change:** sheet-music's audio playback now works. No other behavior change.
- **Wire impact:** sheet-music's `resources/read` response now carries `_meta.ui.csp.connectDomains`. Hosts that previously got no `_meta` will now see it; the field is documented as host-honoring-optional in the MCP Apps spec.
- **Tests:** trace files are the regression artifact for the new walkthroughs — they're committed and the gh-pages player replays them. No new unit tests; the CSP type system was added in [PR 623](https://github.com/panyam/mcpkit/pull/623).
- **Be paranoid about:** the common-utils refactor. 20 walkthroughs touched by the same mechanical substitution; spot-check one to gain confidence in the rest.

## Out of scope

- Other compat fixtures may also have missing `_meta` declarations causing silent functionality failures (this is the third one we've caught — permissions, CSP, both via manual testing). A systematic audit of every fixture's resource `_meta` against its upstream counterpart would be a worthwhile follow-up.
- Promoting walkthrough authoring to phase 2 for the other 12 stub fixtures still on the Phase 1 stub. Separate PR(s) per fixture.
