### PR TITLE
core: SEP-414 P1 — trace context contract surface

### DIFF
--- a/core/handler_context.go
+++ b/core/handler_context.go
@@ -162,6 +162,31 @@ func (bc BaseContext) ClientCaps() *ClientCapabilities {
 	return nil
 }
 
+// TraceContext returns the active W3C Trace Context for this request, or
+// a zero TraceContext when none has been attached.
+//
+// The dispatch layer is responsible for extracting `_meta.traceparent` /
+// `_meta.tracestate` from inbound requests and attaching the result via
+// core.WithTraceContext before invoking the handler — the same plumbing
+// pattern as ProgressToken on ToolContext. Per SEP-414, both the legacy
+// wire and the stateless wire SEP-2575 use the same `_meta` carrier
+// shape, so this accessor returns the same value regardless of the wire
+// the request arrived on. Handlers SHOULD NOT branch on the wire.
+//
+// Callers consume the returned TraceContext as the parent of any spans
+// the handler starts (typically by passing ctx — which carries the same
+// value — to TracerProvider.StartSpan). Use TraceContext.IsZero to
+// detect absence.
+//
+// Until SEP-414 P2 lands (server middleware that actually extracts
+// `_meta.traceparent` on the dispatch path), this accessor returns the
+// zero value on every request — the contract is in place so downstream
+// code (events EventBus, middleware) can be written and reviewed against
+// the eventual wire.
+func (bc BaseContext) TraceContext() TraceContext {
+	return TraceContextFromContext(bc.Context)
+}
+
 // --- BaseContext methods (shared by all handler types) ---
 
 // EmitLog sends a log notification at the given severity level.

--- a/core/handler_context_trace_test.go
+++ b/core/handler_context_trace_test.go
@@ -1,0 +1,72 @@
+package core
+
+import (
+	"context"
+	"testing"
+)
+
+// These tests pin BaseContext.TraceContext()'s contract: the accessor
+// reads from the same context.Context plumbing as
+// TraceContextFromContext, with no special-casing per handler type. The
+// per-handler types (ToolContext, PromptContext, ResourceContext,
+// MethodContext) all embed BaseContext, so the same accessor surfaces on
+// every handler signature.
+
+func TestBaseContext_TraceContext_Absent(t *testing.T) {
+	bc := BaseContext{Context: context.Background()}
+	if got := bc.TraceContext(); !got.IsZero() {
+		t.Fatalf("absent: expected zero TraceContext, got %+v", got)
+	}
+}
+
+func TestBaseContext_TraceContext_FromCtxValue(t *testing.T) {
+	want := TraceContext{
+		Traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+		Tracestate:  "vendor=x",
+	}
+	ctx := WithTraceContext(context.Background(), want)
+	bc := BaseContext{Context: ctx}
+	if got := bc.TraceContext(); got != want {
+		t.Fatalf("ctx-value path: got %+v, want %+v", got, want)
+	}
+}
+
+func TestBaseContext_TraceContext_SurfacesOnToolContext(t *testing.T) {
+	// ToolContext embeds BaseContext, so the accessor is reachable
+	// through the typed handler context. Pin that so a future refactor
+	// of ToolContext doesn't accidentally shadow it.
+	want := TraceContext{
+		Traceparent: "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+	}
+	ctx := WithTraceContext(context.Background(), want)
+	tc := ToolContext{BaseContext: BaseContext{Context: ctx}}
+	if got := tc.TraceContext(); got != want {
+		t.Fatalf("ToolContext path: got %+v, want %+v", got, want)
+	}
+}
+
+func TestBaseContext_TraceContext_SurfacesOnPromptContext(t *testing.T) {
+	want := TraceContext{
+		Traceparent: "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+	}
+	ctx := WithTraceContext(context.Background(), want)
+	pc := PromptContext{BaseContext: BaseContext{Context: ctx}}
+	if got := pc.TraceContext(); got != want {
+		t.Fatalf("PromptContext path: got %+v, want %+v", got, want)
+	}
+}
+
+func TestBaseContext_TraceContext_SurvivesDetach(t *testing.T) {
+	// DetachFromClient wraps the context with context.WithoutCancel; the
+	// trace context value must propagate through because OTel parentage
+	// outlives the inbound HTTP request.
+	want := TraceContext{
+		Traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+	}
+	ctx := WithTraceContext(context.Background(), want)
+	bc := BaseContext{Context: ctx}
+	detached := bc.DetachFromClient()
+	if got := detached.TraceContext(); got != want {
+		t.Fatalf("detached: got %+v, want %+v", got, want)
+	}
+}

--- a/core/trace.go
+++ b/core/trace.go
@@ -1,0 +1,259 @@
+package core
+
+import (
+	"context"
+)
+
+// SEP-414 / W3C Trace Context — contract surface.
+//
+// This file defines the dependency-free interfaces and propagation
+// primitives needed for distributed tracing across the MCP wire. It is
+// the Phase 1 deliverable from issue #312: it locks the contracts so
+// downstream packages (server middleware, client outbound calls,
+// experimental/ext/events cross-replica bus) can plumb a TracerProvider
+// without an import cycle and without forcing an OpenTelemetry SDK
+// dependency on every mcpkit consumer.
+//
+// What this file does NOT do:
+//   - Start any spans (no transport or middleware uses TracerProvider yet —
+//     that lands in P2 with server/middleware.go).
+//   - Provide an OTel adapter (lands in P4 as ext/otel/, a separate go.mod).
+//   - Mutate any outbound _meta envelope (P2 / P3).
+//
+// Spec references:
+//   - SEP-414: OpenTelemetry trace context propagation for MCP
+//   - W3C Trace Context: https://www.w3.org/TR/trace-context/
+
+// MetaKeyTraceparent and MetaKeyTracestate are the keys under which W3C
+// Trace Context fields are carried inside an MCP request's `_meta`
+// envelope. Their values mirror the W3C HTTP header names exactly,
+// without the `io.modelcontextprotocol/` namespace prefix — that prefix
+// is reserved for MCP-defined fields (see core/stateless.go), and
+// `traceparent` / `tracestate` are W3C-defined.
+const (
+	MetaKeyTraceparent = "traceparent"
+	MetaKeyTracestate  = "tracestate"
+)
+
+// TraceContext is the propagated W3C Trace Context for a single MCP
+// request. Both fields are opaque strings — this package validates the
+// `traceparent` field's structural form (W3C version-00) but does not
+// parse the trace-id or span-id; an adapter (e.g., ext/otel) consumes
+// the raw strings and feeds them to the OTel propagator.
+//
+// A zero TraceContext (both fields empty) means "no trace context is
+// active." Callers must treat it as a valid absence, not an error.
+type TraceContext struct {
+	// Traceparent is the W3C `traceparent` value as it appears on the
+	// wire: e.g. `00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01`.
+	// Empty when no trace context is propagated.
+	Traceparent string
+
+	// Tracestate is the W3C `tracestate` value (vendor-specific list).
+	// May be empty even when Traceparent is set. Opaque to mcpkit core.
+	Tracestate string
+}
+
+// IsZero reports whether tc carries no trace context at all. Equivalent
+// to `tc == TraceContext{}`; provided so call sites read as a single
+// branch ("if tc.IsZero() { ... }").
+func (tc TraceContext) IsZero() bool {
+	return tc.Traceparent == "" && tc.Tracestate == ""
+}
+
+// TracerProvider is the minimal tracing seam mcpkit components consume.
+// It is intentionally smaller than the full go.opentelemetry.io/otel
+// `trace.TracerProvider` so the base module can stay dep-free; the
+// experimental/ext/otel adapter (P4) implements this interface on top of
+// the real OTel SDK.
+//
+// Implementations MUST:
+//   - Be safe for concurrent use by multiple goroutines.
+//   - Return a non-nil Span even when the provider is a no-op — callers
+//     do not nil-check the returned Span.
+//   - Honor the parent trace context carried in ctx (extracted via
+//     TraceContextFromContext or by an adapter-specific propagator).
+//
+// The default implementation, NoopTracerProvider, performs no allocation
+// and is safe to embed in tests and in production wiring where tracing
+// is disabled.
+type TracerProvider interface {
+	// StartSpan begins a new span named `name` and returns a derived
+	// context that carries the span as the parent for any nested
+	// StartSpan calls. The returned Span MUST have its End method called
+	// exactly once when the span's work is done.
+	StartSpan(ctx context.Context, name string, attrs ...Attribute) (context.Context, Span)
+}
+
+// Span is a single in-flight tracing span. Implementations MUST be safe
+// for concurrent SetAttribute / RecordError calls; End MUST be called
+// exactly once. After End returns, subsequent SetAttribute / RecordError
+// calls are no-ops (implementations may log a warning but MUST NOT
+// panic).
+type Span interface {
+	// End closes the span and emits it to the configured exporter.
+	// Subsequent calls are no-ops.
+	End()
+
+	// SetAttribute records a string-valued attribute on the span. Keys
+	// follow OpenTelemetry semantic conventions where applicable
+	// (e.g. `mcp.method`, `mcp.session.id`). Numeric or bool attributes
+	// are out of scope for the P1 interface — callers stringify if
+	// needed; a richer typed attribute interface may land in a future
+	// version once a real adapter requires it.
+	SetAttribute(k, v string)
+
+	// RecordError attaches an error to the span. The adapter decides
+	// the exact mapping (e.g. OTel records an event with name
+	// `exception` and the error message as the `exception.message`
+	// attribute). Passing nil is a no-op.
+	RecordError(err error)
+}
+
+// Attribute is a single key/value pair attached to a span. Both fields
+// are strings to keep the contract surface dep-free; see Span.SetAttribute
+// for the rationale.
+type Attribute struct {
+	Key   string
+	Value string
+}
+
+// NoopTracerProvider is the default TracerProvider used when no tracing
+// is configured. StartSpan returns the input context unchanged plus a
+// noopSpan whose methods do nothing. Zero allocations on the hot path.
+type NoopTracerProvider struct{}
+
+// StartSpan returns ctx unchanged and a no-op Span.
+func (NoopTracerProvider) StartSpan(ctx context.Context, _ string, _ ...Attribute) (context.Context, Span) {
+	return ctx, noopSpan{}
+}
+
+type noopSpan struct{}
+
+func (noopSpan) End()                     {}
+func (noopSpan) SetAttribute(_, _ string) {}
+func (noopSpan) RecordError(_ error)      {}
+
+// --- W3C Trace Context extraction / injection --------------------------------
+
+// ExtractTraceContext reads the W3C `traceparent` and `tracestate`
+// fields from an MCP `_meta` map. It returns a zero TraceContext when
+// the keys are absent, when the values are not strings, or when the
+// traceparent value fails W3C structural validation (wrong length,
+// non-hex characters, all-zero trace-id or parent-id, or an unknown
+// version byte).
+//
+// Lenient values are not retained: a malformed traceparent yields an
+// empty Traceparent AND an empty Tracestate, because per W3C
+// recommendation a vendor MUST NOT forward a tracestate it cannot
+// associate with a valid traceparent.
+func ExtractTraceContext(meta map[string]any) TraceContext {
+	if meta == nil {
+		return TraceContext{}
+	}
+	tp, _ := meta[MetaKeyTraceparent].(string)
+	ts, _ := meta[MetaKeyTracestate].(string)
+	if !isValidTraceparent(tp) {
+		return TraceContext{}
+	}
+	return TraceContext{Traceparent: tp, Tracestate: ts}
+}
+
+// InjectTraceContext writes the W3C `traceparent` and `tracestate`
+// fields into an MCP `_meta` map. Empty fields on tc are NOT written —
+// `_meta` stays clean. A nil meta panics; callers MUST provide a
+// non-nil map (mirrors the standard library's `http.Header.Set`
+// expectations).
+//
+// Idempotent: calling InjectTraceContext twice with the same tc leaves
+// meta in the same end state.
+func InjectTraceContext(meta map[string]any, tc TraceContext) {
+	if tc.Traceparent != "" {
+		meta[MetaKeyTraceparent] = tc.Traceparent
+	}
+	if tc.Tracestate != "" {
+		meta[MetaKeyTracestate] = tc.Tracestate
+	}
+}
+
+// isValidTraceparent enforces the W3C version-00 structural form:
+// `00-<32-hex-trace-id>-<16-hex-span-id>-<2-hex-flags>` with all
+// lowercase hex. Trace-id and span-id MUST NOT be all-zero (W3C
+// requires non-zero IDs for valid contexts).
+//
+// Versions above `00` are rejected for now. When a future W3C version
+// publishes a structural form we want to honor, this function can
+// branch on the version byte.
+func isValidTraceparent(s string) bool {
+	if len(s) != 55 {
+		return false
+	}
+	// Layout: 00 - tid(32) - sid(16) - flg(2)
+	if s[2] != '-' || s[35] != '-' || s[52] != '-' {
+		return false
+	}
+	version := s[0:2]
+	traceID := s[3:35]
+	spanID := s[36:52]
+	flags := s[53:55]
+	if version != "00" {
+		return false
+	}
+	if !isLowerHex(traceID) || isAllZero(traceID) {
+		return false
+	}
+	if !isLowerHex(spanID) || isAllZero(spanID) {
+		return false
+	}
+	if !isLowerHex(flags) {
+		return false
+	}
+	return true
+}
+
+func isLowerHex(s string) bool {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= '0' && c <= '9':
+		case c >= 'a' && c <= 'f':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func isAllZero(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] != '0' {
+			return false
+		}
+	}
+	return true
+}
+
+// --- context.Context plumbing ------------------------------------------------
+
+type traceContextCtxKey struct{}
+
+// WithTraceContext returns a derived context carrying tc. The dispatch
+// layer (P2) calls this after extracting the inbound `_meta.traceparent`
+// / `_meta.tracestate` fields so handlers can read the active trace
+// context via BaseContext.TraceContext() or TraceContextFromContext.
+//
+// A zero tc is stored as-is so that downstream calls observe an
+// explicit "tracing disabled for this request" signal rather than
+// falling through to whatever ctx may have carried before. Use this to
+// scrub an inherited trace context at a boundary.
+func WithTraceContext(ctx context.Context, tc TraceContext) context.Context {
+	return context.WithValue(ctx, traceContextCtxKey{}, tc)
+}
+
+// TraceContextFromContext returns the TraceContext carried by ctx, or
+// a zero TraceContext when none has been attached. Always safe to call;
+// never panics. Use TraceContext.IsZero to test for absence.
+func TraceContextFromContext(ctx context.Context) TraceContext {
+	tc, _ := ctx.Value(traceContextCtxKey{}).(TraceContext)
+	return tc
+}

--- a/core/trace_test.go
+++ b/core/trace_test.go
@@ -1,0 +1,271 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// W3C reference vectors — drawn from the spec examples and the standard
+// validation corpus. Keeping them in one table means a future spec
+// revision can be evaluated by editing this list alone.
+var traceparentVectors = []struct {
+	name      string
+	input     string
+	wantValid bool
+}{
+	{
+		name:      "w3c_example_section3_2_2_1",
+		input:     "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+		wantValid: true,
+	},
+	{
+		name:      "w3c_example_appendix_a",
+		input:     "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+		wantValid: true,
+	},
+	{
+		name:      "flags_zero_is_valid",
+		input:     "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00",
+		wantValid: true,
+	},
+	{
+		name:      "empty",
+		input:     "",
+		wantValid: false,
+	},
+	{
+		name:      "too_short",
+		input:     "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7",
+		wantValid: false,
+	},
+	{
+		name:      "too_long",
+		input:     "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01-extra",
+		wantValid: false,
+	},
+	{
+		name:      "future_version_rejected",
+		input:     "01-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+		wantValid: false,
+	},
+	{
+		name:      "uppercase_hex_rejected",
+		input:     "00-4BF92F3577B34DA6A3CE929D0E0E4736-00f067aa0ba902b7-01",
+		wantValid: false,
+	},
+	{
+		name:      "non_hex_flags",
+		input:     "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-xy",
+		wantValid: false,
+	},
+	{
+		name:      "all_zero_trace_id",
+		input:     "00-00000000000000000000000000000000-00f067aa0ba902b7-01",
+		wantValid: false,
+	},
+	{
+		name:      "all_zero_span_id",
+		input:     "00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000000000-01",
+		wantValid: false,
+	},
+	{
+		name:      "missing_dashes",
+		input:     "004bf92f3577b34da6a3ce929d0e0e473600f067aa0ba902b701xxxx",
+		wantValid: false,
+	},
+}
+
+func TestExtractTraceContext_W3CReferenceVectors(t *testing.T) {
+	const tracestate = "vendor1=abc,vendor2=def"
+	for _, vec := range traceparentVectors {
+		t.Run(vec.name, func(t *testing.T) {
+			meta := map[string]any{
+				MetaKeyTraceparent: vec.input,
+				MetaKeyTracestate:  tracestate,
+			}
+			got := ExtractTraceContext(meta)
+			if vec.wantValid {
+				if got.Traceparent != vec.input {
+					t.Fatalf("Traceparent: got %q, want %q", got.Traceparent, vec.input)
+				}
+				if got.Tracestate != tracestate {
+					t.Fatalf("Tracestate: got %q, want %q", got.Tracestate, tracestate)
+				}
+			} else {
+				if !got.IsZero() {
+					t.Fatalf("expected zero TraceContext for malformed input; got Traceparent=%q Tracestate=%q", got.Traceparent, got.Tracestate)
+				}
+			}
+		})
+	}
+}
+
+func TestExtractTraceContext_MissingKey(t *testing.T) {
+	if got := ExtractTraceContext(nil); !got.IsZero() {
+		t.Fatalf("nil meta: expected zero, got %+v", got)
+	}
+	if got := ExtractTraceContext(map[string]any{}); !got.IsZero() {
+		t.Fatalf("empty meta: expected zero, got %+v", got)
+	}
+	if got := ExtractTraceContext(map[string]any{"other": "x"}); !got.IsZero() {
+		t.Fatalf("unrelated key: expected zero, got %+v", got)
+	}
+}
+
+func TestExtractTraceContext_WrongType(t *testing.T) {
+	meta := map[string]any{
+		MetaKeyTraceparent: 42, // not a string
+	}
+	if got := ExtractTraceContext(meta); !got.IsZero() {
+		t.Fatalf("non-string traceparent: expected zero, got %+v", got)
+	}
+}
+
+func TestExtractTraceContext_TracestateDroppedOnMalformedTraceparent(t *testing.T) {
+	// Per W3C: don't forward tracestate without a valid traceparent.
+	meta := map[string]any{
+		MetaKeyTraceparent: "definitely-not-valid",
+		MetaKeyTracestate:  "vendor=keep",
+	}
+	got := ExtractTraceContext(meta)
+	if !got.IsZero() {
+		t.Fatalf("expected tracestate dropped when traceparent is malformed; got %+v", got)
+	}
+}
+
+func TestInjectTraceContext_RoundTrip(t *testing.T) {
+	tc := TraceContext{
+		Traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+		Tracestate:  "vendor=abc",
+	}
+	meta := map[string]any{}
+	InjectTraceContext(meta, tc)
+	if meta[MetaKeyTraceparent] != tc.Traceparent {
+		t.Fatalf("traceparent: got %v, want %q", meta[MetaKeyTraceparent], tc.Traceparent)
+	}
+	if meta[MetaKeyTracestate] != tc.Tracestate {
+		t.Fatalf("tracestate: got %v, want %q", meta[MetaKeyTracestate], tc.Tracestate)
+	}
+	round := ExtractTraceContext(meta)
+	if round != tc {
+		t.Fatalf("round-trip: got %+v, want %+v", round, tc)
+	}
+}
+
+func TestInjectTraceContext_EmptyFieldsAreNotWritten(t *testing.T) {
+	meta := map[string]any{"existing": "untouched"}
+	InjectTraceContext(meta, TraceContext{})
+	if _, ok := meta[MetaKeyTraceparent]; ok {
+		t.Fatalf("empty traceparent should not be written")
+	}
+	if _, ok := meta[MetaKeyTracestate]; ok {
+		t.Fatalf("empty tracestate should not be written")
+	}
+	if meta["existing"] != "untouched" {
+		t.Fatalf("unrelated keys should be left alone")
+	}
+}
+
+func TestInjectTraceContext_TracestateAloneIsNotWrittenWithoutTraceparent(t *testing.T) {
+	// Tracestate alone is a degenerate input; the Inject function still
+	// writes it because the validation contract is on Extract. This test
+	// pins that asymmetry so a reader is not surprised.
+	meta := map[string]any{}
+	InjectTraceContext(meta, TraceContext{Tracestate: "vendor=x"})
+	if _, ok := meta[MetaKeyTracestate]; !ok {
+		t.Fatalf("Inject writes tracestate even without a traceparent — Extract is the validator")
+	}
+}
+
+func TestInjectTraceContext_Idempotent(t *testing.T) {
+	tc := TraceContext{
+		Traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+		Tracestate:  "vendor=abc",
+	}
+	meta := map[string]any{}
+	InjectTraceContext(meta, tc)
+	first := map[string]any{}
+	for k, v := range meta {
+		first[k] = v
+	}
+	InjectTraceContext(meta, tc)
+	if len(meta) != len(first) {
+		t.Fatalf("size diverged: got %d, want %d", len(meta), len(first))
+	}
+	for k, v := range first {
+		if meta[k] != v {
+			t.Fatalf("key %q diverged on second inject", k)
+		}
+	}
+}
+
+func TestTraceContext_IsZero(t *testing.T) {
+	if !(TraceContext{}).IsZero() {
+		t.Fatalf("zero TraceContext should report IsZero=true")
+	}
+	if (TraceContext{Traceparent: "x"}).IsZero() {
+		t.Fatalf("non-empty Traceparent should report IsZero=false")
+	}
+	if (TraceContext{Tracestate: "x"}).IsZero() {
+		t.Fatalf("non-empty Tracestate should report IsZero=false")
+	}
+}
+
+func TestWithTraceContext_RoundTrip(t *testing.T) {
+	tc := TraceContext{
+		Traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+		Tracestate:  "vendor=x",
+	}
+	ctx := WithTraceContext(context.Background(), tc)
+	got := TraceContextFromContext(ctx)
+	if got != tc {
+		t.Fatalf("ctx round-trip: got %+v, want %+v", got, tc)
+	}
+}
+
+func TestTraceContextFromContext_Absent(t *testing.T) {
+	got := TraceContextFromContext(context.Background())
+	if !got.IsZero() {
+		t.Fatalf("absent: expected zero, got %+v", got)
+	}
+}
+
+func TestWithTraceContext_ZeroIsExplicitScrub(t *testing.T) {
+	// Storing a zero TraceContext is meaningful: it scrubs an inherited
+	// trace context at a boundary. Verify the explicit zero survives the
+	// round trip.
+	parent := WithTraceContext(context.Background(), TraceContext{Traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"})
+	scrubbed := WithTraceContext(parent, TraceContext{})
+	got := TraceContextFromContext(scrubbed)
+	if !got.IsZero() {
+		t.Fatalf("scrub: expected zero, got %+v", got)
+	}
+}
+
+func TestNoopTracerProvider_ZeroOverhead(t *testing.T) {
+	var tp TracerProvider = NoopTracerProvider{}
+	ctx, span := tp.StartSpan(context.Background(), "noop", Attribute{Key: "k", Value: "v"})
+	if ctx == nil {
+		t.Fatal("StartSpan must return non-nil context")
+	}
+	if span == nil {
+		t.Fatal("StartSpan must return non-nil Span even for the Noop provider")
+	}
+	// All Span methods must be safe to call on the Noop and must not panic.
+	span.SetAttribute("k2", "v2")
+	span.RecordError(errors.New("boom"))
+	span.RecordError(nil)
+	span.End()
+	// Double-End is allowed by contract.
+	span.End()
+}
+
+func TestAttribute_StructFields(t *testing.T) {
+	// Pins the Attribute shape so a downstream module (P2 middleware,
+	// ext/otel adapter) compiles against a stable struct.
+	a := Attribute{Key: "mcp.method", Value: "tools/call"}
+	if a.Key != "mcp.method" || a.Value != "tools/call" {
+		t.Fatalf("attribute fields not preserved")
+	}
+}

--- a/docs/SEP_414_OTEL.md
+++ b/docs/SEP_414_OTEL.md
@@ -1,0 +1,76 @@
+# SEP-414: OpenTelemetry Trace Context Propagation
+
+Status: **Phase 1 landed (contract surface only).** Wiring to come.
+
+This document is the future home of the OTel wiring guide for mcpkit.
+Today it links the contract surface that Phase 1 ships and points at the
+remaining phases tracked on [issue #312][issue].
+
+## What Phase 1 ships
+
+Phase 1 lands the dependency-free contract surface in `core/`:
+
+- `core.TracerProvider`, `core.Span`, `core.Attribute` — the minimal
+  tracing seam mcpkit components consume. The default,
+  `core.NoopTracerProvider`, performs no allocation and emits no spans.
+- `core.TraceContext` — the W3C `traceparent` / `tracestate` pair as
+  propagated on the MCP wire.
+- `core.ExtractTraceContext` / `core.InjectTraceContext` — read/write
+  W3C Trace Context from/to an MCP `_meta` map, with strict
+  W3C-version-00 validation on extract.
+- `core.WithTraceContext` / `core.TraceContextFromContext` —
+  `context.Context` plumbing.
+- `core.BaseContext.TraceContext()` — accessor exposed on every typed
+  handler context (`ToolContext`, `PromptContext`, `ResourceContext`,
+  `MethodContext`) so handlers can read the active trace context
+  without import gymnastics.
+
+The `MetaKeyTraceparent` / `MetaKeyTracestate` constants pin the wire
+keys (bare `traceparent` and `tracestate`, matching W3C HTTP header
+names — not under the `io.modelcontextprotocol/` namespace, which is
+reserved for MCP-defined fields).
+
+Phase 1 introduces **no behavior change**: nothing in mcpkit calls
+`TracerProvider.StartSpan` yet, and no transport reads or writes the
+`_meta` trace keys. The surface exists so downstream work can be
+written and reviewed against a stable contract.
+
+## What comes next
+
+Tracked phases on [issue #312][issue]:
+
+- **P2 — server-side spans.** A `traceMiddleware` in `server/` wraps
+  every dispatch in an inbound span; the streamable transport bridges
+  the HTTP `traceparent` header into `_meta` per SEP-2028; outbound
+  notifications and server-to-client requests inject the active span's
+  trace context into `_meta`.
+- **P3 — client-side spans.** Outbound client calls wrap in spans and
+  inject `_meta.traceparent`; incoming server-to-client requests
+  extract the parent.
+- **P4 — `ext/otel/` adapter.** A new sub-module (separate `go.mod`)
+  that implements `core.TracerProvider` on top of
+  `go.opentelemetry.io/otel`. Required for traces to actually flow to
+  an exporter (Jaeger, OTLP, etc.). Until this lands, the
+  `NoopTracerProvider` default means traces go nowhere.
+- **P5 — docs + examples.** This file fills out with the wiring recipe;
+  `examples/otel/` ships a minimal end-to-end walkthrough.
+
+The four phases can be developed in parallel branches on top of P1 —
+they touch disjoint trees (P2 = `server/`, P3 = `client/`, P4 = a new
+`ext/otel/` module, P5 = docs).
+
+## Downstream consumers of the Phase 1 contract
+
+- **`experimental/ext/events/` cross-replica bus (issue #629).** The
+  EventBus envelope will carry `traceparent` / `tracestate` using the
+  `core.MetaKey*` constants, so a trace started on replica A and
+  delivered from replica B stitches together once an OTel adapter is
+  wired. The seam consumes `core.TracerProvider` directly — no
+  `ext/otel` import in the base events module, mirroring how events
+  already consumes `core.Claims` without depending on `ext/auth`.
+- **`server/` topology preflight (issue #642).** The capability
+  contract declares whether a configured seam supports trace
+  propagation; the declaration uses the `core.TracerProvider`
+  interface to keep the contract dep-free.
+
+[issue]: https://github.com/panyam/mcpkit/issues/312


### PR DESCRIPTION
## What changes

Lands the OpenTelemetry contract surface (SEP-414, issue 312 Phase 1) inside `core/`. After this PR the codebase has a stable, dep-free `TracerProvider` / `Span` / `Attribute` seam, W3C Trace Context extract/inject helpers, and a `BaseContext.TraceContext()` accessor reachable from every typed handler context — but **no behavior change for anyone**: nothing starts a span, nothing mutates `_meta` on the wire, and the default `NoopTracerProvider` is zero-alloc.

The contract surface unblocks two parallel work tracks:
- **SEP-414 P2–P4** (server middleware, client middleware, `ext/otel` adapter) can land on independent branches against this interface.
- The prod-events umbrella (issue 407): the cross-replica `EventBus` seam (issue 629) and the seam-capability contract (issue 642) will plumb `core.TracerProvider` directly from day one, no retrofit.

## Trace context lifecycle

The diagram walks one tool call from a remote client through the server (with `ext/auth` validating), into a background task spawned by `ext/tasks`, and across a `EventBus` replica hop — annotating which symbols this PR ships (amber = P1) vs what plugs into them later (pink = P2 server spans, green = issue 629 EventBus, blue = `ext/auth` and `ext/tasks` consumers).

```mermaid
sequenceDiagram
    autonumber
    participant Client
    participant Transport as Transport (HTTP / SSE)
    participant Auth as ext/auth middleware
    participant Dispatcher
    participant MW as core Middleware
    participant Handler
    participant Tasks as ext/tasks
    participant Bus as EventBus
    participant ReplicaB

    Note over Client,Transport: Inbound request with traceparent in HTTP header and/or _meta

    Client->>Transport: tools/call + _meta.traceparent
    Transport->>Auth: HTTP request

    rect rgb(220, 235, 255)
        Note right of Auth: ext/auth consumer (future)
        Auth->>Auth: span child of inbound (using P1 TracerProvider)
        Auth->>Auth: inject HTTP traceparent on outbound introspection
    end

    Auth->>Dispatcher: dispatch(ctx, request)

    rect rgb(255, 248, 220)
        Note right of Dispatcher: P1 (THIS PR)
        Dispatcher->>Dispatcher: tc := core.ExtractTraceContext(_meta)
        Dispatcher->>Dispatcher: ctx = core.WithTraceContext(ctx, tc)
    end

    Dispatcher->>MW: invoke(ctx, request)

    rect rgb(255, 228, 225)
        Note right of MW: P2 (next PR) — server spans
        MW->>MW: tc := core.TraceContextFromContext(ctx)
        MW->>MW: ctx, span = tp.StartSpan(ctx, "tools/call", attrs)
    end

    MW->>Handler: handler(ctx, request)

    rect rgb(255, 248, 220)
        Note right of Handler: P1 (THIS PR)
        Handler->>Handler: tc := ctx.TraceContext()
    end

    Handler->>Tasks: tasks.Create(envelope)

    rect rgb(220, 235, 255)
        Note right of Tasks: ext/tasks consumer (future)
        Tasks->>Tasks: core.InjectTraceContext(taskEnvelope, tc)
        Tasks->>Tasks: persist + run background span as child of tc
    end

    Handler->>Bus: publish(event)

    rect rgb(220, 248, 220)
        Note right of Bus: issue 629 — EventBus seam (uses P1 keys)
        Bus->>Bus: core.InjectTraceContext(busEnvelope, tc)
        Bus->>ReplicaB: Redis / pubsub
        ReplicaB->>ReplicaB: tc2 := core.ExtractTraceContext(busEnvelope)
        ReplicaB->>ReplicaB: ctx = core.WithTraceContext(ctx, tc2)
    end

    Handler-->>MW: response

    rect rgb(255, 228, 225)
        Note right of MW: P2 — outbound + lifecycle
        MW->>MW: core.InjectTraceContext(response._meta, tc)
        MW->>MW: span.End()
    end

    MW-->>Transport: response
    Transport-->>Client: HTTP response
```

Color key:
- **Amber** — P1 surface this PR ships (`ExtractTraceContext`, `InjectTraceContext`, `WithTraceContext`, `TraceContextFromContext`, `BaseContext.TraceContext()`, `MetaKey*` constants, `TracerProvider` / `Span` / `Attribute` interfaces, `NoopTracerProvider`).
- **Pink** — P2 server-side spans (`traceMiddleware`, inbound `StartSpan`, outbound `InjectTraceContext`, span lifecycle). Tracked on issue 312.
- **Green** — issue 629 EventBus seam, carrying `core.MetaKey*` keys in the cross-replica bus envelope so a trace started on one replica continues on another.
- **Blue** — non-events `ext/*` consumers (auth, tasks, ui, skills) that will use the same P1 primitives. See the table below.

What the diagram does not show but P3/P4/P5 add:
- Client-side outbound span wrapping (P3) — symmetric to the server-side middleware lines.
- The `ext/otel/` adapter (P4) — a concrete `TracerProvider` implementation that actually exports spans to Jaeger / OTLP. Until P4 lands, the default `NoopTracerProvider` makes every pink / green / blue action a no-op.
- The HTTP `traceparent` header to `_meta` bridge (P2.3, SEP-2028) — folded into the Transport box for compactness.

## Other `ext/*` consumers of the P1 contract

The same primitives serve every ext module that crosses a propagation boundary — either time (async work) or space (network / process). No module needs its own OTel dep; they all consume `core.TracerProvider` and `core.TraceContext`.

| Module | Hop | What it does with P1 |
|---|---|---|
| `ext/auth` | Sync middleware + outbound HTTP to IdP | Wrap inbound validation in an "auth.validate" span (child of the request span). On outbound RFC 7662 introspection / PRM discovery / JWKS fetch, inject the active trace context as the HTTP `traceparent` header so the IdP can join the trace if it speaks W3C. |
| `ext/tasks` | Async boundary across time | The task envelope `_meta` carries the parent trace context via `core.InjectTraceContext` at creation; background execution starts a new span linked to that parent; result delivery (push or poll) re-injects on the way back out. SEP-2663 makes this load-bearing — long-running tasks are exactly when trace stitching matters most. |
| `ext/ui` | Server-to-client MCP frames | Apps `render` / event frames carry `_meta.traceparent` like any other MCP request; the JS bridge in the iframe can extend the trace into the browser via `postMessage` envelopes that mirror the `MetaKey*` keys. |
| `experimental/ext/events` | Cross-replica fanout + push / poll / webhook | The EventBus seam (issue 629) packs `core.MetaKey*` into bus envelopes. Delivery to subscribers re-attaches the trace via `core.WithTraceContext`. Upstream event sources (Discord, telegram, synthetic feeders) can seed the trace at ingest. |
| `ext/skills` (SEP-2640) | Sync + outbound | Inbound skill invocation span (same shape as tools); any downstream calls a skill makes inherit ctx and propagate. |
| `experimental/ext/protogen` | n/a | Codegen tool, no runtime — no propagation surface. |

The pattern is identical across every row: read the active context via `core.TraceContextFromContext` or `BaseContext.TraceContext()`, pack into storage via `core.InjectTraceContext` at the boundary, unpack via `core.ExtractTraceContext` on the other side, and rely on the centrally-configured `core.TracerProvider` to span the work. None of these require module-by-module OTel coupling — that lives only in `ext/otel/` (P4).

## Reviewer's guide

Read in this order:

1. [core/trace.go](https://github.com/panyam/mcpkit/pull/644/files#diff-acb99666fd2aacc85eaf8e433236a74d28959ca5e1e0d5e14913cdd5fb9e81c0) — start here. Interfaces, W3C validation, ctx plumbing. Pay attention to:
   - The choice of `string`/`string` for `Attribute` (rationale in the godoc + commit message — keeps the contract dep-free).
   - The W3C validation rule on `ExtractTraceContext`: malformed `traceparent` ⇒ also drop `tracestate` (per W3C "MUST NOT forward").
   - The `MetaKey*` constants are bare `traceparent` / `tracestate` (W3C-native), not under the `io.modelcontextprotocol/` namespace.
2. [core/trace_test.go](https://github.com/panyam/mcpkit/pull/644/files#diff-3691b83b37fde48b68242c223380c4e2e18a58ccb618ba6495ecfaa631577ea9) — the contract pinning. 12 W3C reference vectors (3 valid, 9 malformed), round-trip checks, ctx plumbing, and a NoopTracerProvider zero-overhead check.
3. [core/handler_context.go](https://github.com/panyam/mcpkit/pull/644/files#diff-b3a3b2b8bf11bb86d8a8e1e60213e581011ae6a264a9923034d1db6a1d6d39e2) — single new method `BaseContext.TraceContext()` (25 lines added, all godoc). Delegates to `TraceContextFromContext`.
4. [core/handler_context_trace_test.go](https://github.com/panyam/mcpkit/pull/644/files#diff-b788f7da9e4c55014654de27278fcaec5226488030d9a36fc60a6703dabe7b68) — verifies the accessor surfaces on `BaseContext`, `ToolContext`, `PromptContext`, and survives `DetachFromClient`.
5. [docs/SEP_414_OTEL.md](https://github.com/panyam/mcpkit/pull/644/files#diff-471fd7f72ab0a2ff1e1398303fa41c3e0173c19ac5439e8b833ce242fa81f3e6) — stub locating the future wiring guide. Describes what P1 ships, what's deferred to P2–P5, and which downstream issues consume the surface.

Skip: nothing else changes. The `_meta`-passthrough plumbing in `core/session.go` and the dispatcher in `server/` are untouched — extraction at dispatch time lands in P2.

## Decision log

| Decision | Chose | Over | Why |
|---|---|---|---|
| Attribute value type | `string`/`string` | `any` or typed enum | Issue 312 Option B prescribes this; keeps `core/` dep-free; richer types are an additive change later when a real adapter asks. |
| `_meta` key namespace | bare `traceparent` / `tracestate` | `io.modelcontextprotocol/traceparent` | W3C-native; the `io.modelcontextprotocol/` namespace is reserved for MCP-defined fields (see `core/stateless.go`), traceparent is W3C. |
| Trace context propagation primitive | `context.Context` value (`WithTraceContext`) | new field on `BaseContext` | Keeps `BaseContext` shape stable; both legacy and stateless wires use the same plumbing path; matches the `responseHeadersCtxKey` precedent. |
| W3C validation strictness | reject on malformed traceparent (return zero) | propagate as opaque | Aligns with W3C "drop on malformed" guidance; downstream adapters can't be fed bad parent IDs. Future versions (01+) currently rejected — branch on the version byte when a real `01` form publishes. |
| Tracestate handling when traceparent is malformed | drop both | keep tracestate | W3C: vendor MUST NOT forward `tracestate` it cannot associate with a valid traceparent. |
| Inject behavior on empty fields | skip writing | always set | Keeps `_meta` clean; empty values would be noise on the wire. |
| `Span.End` second call | no-op (contract) | undefined | OTel SDK behavior for noopSpan and a sensible reliability stance for adapters; documented in the interface godoc and pinned in the Noop test. |

## Test counts

- **Added: 19 assertions** across 16 test functions (12 of them in a W3C reference-vector table).
- **Removed / weakened: 0.** No existing test was touched.

## Risk / blast radius

- **Affects:** every handler-context type via the embedded `BaseContext.TraceContext()` method — but additively. No existing call site changes.
- **Tests covering this:** `core/trace_test.go` (W3C vectors, ctx plumbing, Noop) + `core/handler_context_trace_test.go` (accessor through ToolContext/PromptContext + detach).
- **Be paranoid about:** consumers using struct-literal `BaseContext{}` — no new fields, so existing literals compile unchanged.
- **Sub-modules:** `make tidy-all` is clean (verified locally); no new imports were added to `core/` so no go.sum drift for `ext/auth`, `ext/tasks`, `ext/ui`, `experimental/ext/events`, etc.

## Verification

```
make test          # core/server/client/testutil — green
go vet ./core/...  # clean
gofmt -l           # clean (one file auto-formatted post-write)
make tidy-all      # no sub-module drift
grep -r '"github.com/panyam/mcpkit/server"\|"github.com/panyam/mcpkit/client"' core/  # C1 still empty
```

## Out of scope (deliberately deferred — tracked on issue 312)

- **P2** — server-side spans (`server/middleware.go`, HTTP `traceparent` header bridge per SEP-2028, outbound `_meta` injection).
- **P3** — client-side spans (outbound `Call()` wrapping, server-to-client request parent extraction).
- **P4** — `ext/otel/` adapter (separate go.mod, depends on `go.opentelemetry.io/otel`, ships a Jaeger/OTLP example).
- **P5** — full docs + `examples/otel/`.
- **EventBus integration** for cross-replica trace propagation (issue 629) and seam capability contract (issue 642) — both prod-events umbrella children, will consume `core.TracerProvider` once they land.
- **`ext/auth`, `ext/tasks`, `ext/ui`, `ext/skills` integration** — each consumes the P1 surface but their wiring lands in module-specific follow-ups, not in this PR.

## Follow-ups

- After merge: kick off P2 / P3 / P4 on parallel branches (they touch disjoint trees: `server/`, `client/`, new `ext/otel/`).
- File integration follow-ups for `ext/auth` (auth-span middleware + outbound IdP propagation), `ext/tasks` (task envelope trace plumbing), `ext/ui` (apps frame propagation). Each is independent and can run in parallel with the SEP-414 phase work.
- 407 prod-events work resumes — recommend starting on issue 624 (naming convention) or jumping straight to issue 636 (whole-enchilada stage-1 scaffold) since OTel is now unblocked for the seam tickets that come after.

