### PR TITLE
server: SEP-414 P2 — server-side spans + W3C _meta propagation

### DIFF
--- a/core/background.go
+++ b/core/background.go
@@ -64,6 +64,47 @@ func ReplaceSessionNotifyFunc(ctx context.Context, fn NotifyFunc) context.Contex
 	return context.WithValue(ctx, sessionCtxKey, &newSC)
 }
 
+// WrapSessionNotifyFunc replaces the session's notifyFunc with the result of
+// applying wrap to the current one. Returns ctx unchanged when no session is
+// attached or wrap is nil. Provided so cross-cutting concerns (trace context
+// injection, audit logging) can wrap notify without re-implementing the
+// sessionCtx clone dance — symmetric with WrapSessionRequestFunc.
+//
+// Common usage from middleware that has the request ctx:
+//
+//	ctx = core.WrapSessionNotifyFunc(ctx, func(orig core.NotifyFunc) core.NotifyFunc {
+//	    return func(method string, params any) {
+//	        // mutate params or method, then forward
+//	        orig(method, params)
+//	    }
+//	})
+func WrapSessionNotifyFunc(ctx context.Context, wrap func(NotifyFunc) NotifyFunc) context.Context {
+	if wrap == nil {
+		return ctx
+	}
+	sc := sessionFromContext(ctx)
+	if sc == nil || sc.notify == nil {
+		return ctx
+	}
+	return ReplaceSessionNotifyFunc(ctx, wrap(sc.notify))
+}
+
+// WrapSessionRequestFunc replaces the session's requestFunc with the result of
+// applying wrap to the current one. Returns ctx unchanged when no session is
+// attached, the session has no requestFunc (e.g., transports that do not
+// support server-to-client requests), or wrap is nil. Symmetric with
+// WrapSessionNotifyFunc.
+func WrapSessionRequestFunc(ctx context.Context, wrap func(RequestFunc) RequestFunc) context.Context {
+	if wrap == nil {
+		return ctx
+	}
+	sc := sessionFromContext(ctx)
+	if sc == nil || sc.request == nil {
+		return ctx
+	}
+	return ReplaceSessionRequestFunc(ctx, wrap(sc.request))
+}
+
 // ApplySessionNotifyFilter wraps the session's current notifyFunc with a
 // filter that silently drops notifications whose method matches any entry in
 // dropMethods, forwarding everything else to the inner notifyFunc. Used by

--- a/core/trace.go
+++ b/core/trace.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"encoding/json"
 )
 
 // SEP-414 / W3C Trace Context — contract surface.
@@ -174,6 +175,28 @@ func InjectTraceContext(meta map[string]any, tc TraceContext) {
 	if tc.Tracestate != "" {
 		meta[MetaKeyTracestate] = tc.Tracestate
 	}
+}
+
+// ExtractTraceContextFromParams reads the W3C `traceparent` / `tracestate`
+// fields out of a JSON-RPC request's raw `params` envelope by parsing the
+// `_meta` object inside. Returns a zero TraceContext when params is nil,
+// when params is not a JSON object, when `_meta` is absent or non-object,
+// or when the traceparent value fails the same W3C validation as
+// ExtractTraceContext. Provided so server middleware can read the inbound
+// trace context without coupling to method-specific envelope structs
+// (tools/call's `name`/`arguments`, prompts/get's `name`, ...) — all of
+// them carry the same `_meta` shape per the MCP spec.
+func ExtractTraceContextFromParams(params json.RawMessage) TraceContext {
+	if len(params) == 0 {
+		return TraceContext{}
+	}
+	var envelope struct {
+		Meta map[string]any `json:"_meta"`
+	}
+	if err := json.Unmarshal(params, &envelope); err != nil {
+		return TraceContext{}
+	}
+	return ExtractTraceContext(envelope.Meta)
 }
 
 // isValidTraceparent enforces the W3C version-00 structural form:

--- a/docs/SEP_414_OTEL.md
+++ b/docs/SEP_414_OTEL.md
@@ -1,10 +1,12 @@
 # SEP-414: OpenTelemetry Trace Context Propagation
 
-Status: **Phase 1 landed (contract surface only).** Wiring to come.
+Status: **Phases 1–2 landed.** Adapter (Phase 4) and client-side spans
+(Phase 3) still to come.
 
-This document is the future home of the OTel wiring guide for mcpkit.
-Today it links the contract surface that Phase 1 ships and points at the
-remaining phases tracked on [issue #312][issue].
+This document is the wiring guide for mcpkit's OpenTelemetry surface. It
+covers what the shipped phases give you, what to expect once you wire a
+real `TracerProvider`, and where the remaining work lives on
+[issue 312][issue].
 
 ## What Phase 1 ships
 
@@ -35,29 +37,68 @@ Phase 1 introduces **no behavior change**: nothing in mcpkit calls
 `_meta` trace keys. The surface exists so downstream work can be
 written and reviewed against a stable contract.
 
+## What Phase 2 ships
+
+Phase 2 wires the server-side propagation surface:
+
+- `server.WithTracerProvider(tp core.TracerProvider) Option` — install a
+  tracer. Default and `core.NoopTracerProvider{}` both skip the trace
+  middleware entirely so the zero-overhead path stays untouched.
+- An internal `traceMiddleware` wraps every JSON-RPC dispatch in an
+  inbound span, positioned OUTERMOST so user-registered middleware
+  contributes to the recorded latency. Span attributes:
+  - `mcp.method` on every span
+  - `mcp.tool.name` on `tools/call`
+  - `mcp.session.id` when a session is attached
+  - `mcp.error.code` + `Span.RecordError` on JSON-RPC errors
+  - `mcp.tool.is_error="true"` on `tools/call` results carrying `IsError`
+- Inbound trace context resolution: `params._meta.traceparent` wins
+  over the out-of-band TraceContext bridged through `context.Context`.
+  Malformed traceparent values are dropped per the W3C "MUST NOT
+  forward" rule — the span still emits with no parent.
+- The streamable HTTP transport bridges the W3C `traceparent` /
+  `tracestate` HTTP headers (SEP-2028) into `context.Context` once at
+  the POST entry point. All downstream dispatch paths (sync JSON, SSE,
+  batch, stateless, initialize) inherit the bridge.
+- Outbound `_meta.traceparent` / `_meta.tracestate` are injected on
+  every server-to-client message — notifications (logging, progress,
+  resource updates, custom) and server-to-client requests (legacy push
+  for sampling/elicitation/roots). The wrap sits OUTSIDE any
+  user-registered `NotifyInterceptor` / `RequestInterceptor`, so those
+  interceptors observe the same wire form the client receives.
+
+Wiring is a single line in your server bootstrap:
+
+```go
+srv := server.NewServer(info,
+    // ...your other options...
+    server.WithTracerProvider(myTracerProvider),
+)
+```
+
+`myTracerProvider` must implement `core.TracerProvider`. Until the
+Phase 4 `ext/otel/` adapter ships, the only options that emit spans are
+custom implementations — the in-tree `core.NoopTracerProvider`
+intentionally treats "spans" as no-ops.
+
 ## What comes next
 
-Tracked phases on [issue #312][issue]:
+Tracked phases on [issue 312][issue]:
 
-- **P2 — server-side spans.** A `traceMiddleware` in `server/` wraps
-  every dispatch in an inbound span; the streamable transport bridges
-  the HTTP `traceparent` header into `_meta` per SEP-2028; outbound
-  notifications and server-to-client requests inject the active span's
-  trace context into `_meta`.
 - **P3 — client-side spans.** Outbound client calls wrap in spans and
   inject `_meta.traceparent`; incoming server-to-client requests
   extract the parent.
 - **P4 — `ext/otel/` adapter.** A new sub-module (separate `go.mod`)
   that implements `core.TracerProvider` on top of
   `go.opentelemetry.io/otel`. Required for traces to actually flow to
-  an exporter (Jaeger, OTLP, etc.). Until this lands, the
-  `NoopTracerProvider` default means traces go nowhere.
-- **P5 — docs + examples.** This file fills out with the wiring recipe;
-  `examples/otel/` ships a minimal end-to-end walkthrough.
+  an exporter (Jaeger, OTLP, etc.). Until this lands,
+  `NoopTracerProvider` and hand-rolled adapters are the only choices.
+- **P5 — examples.** `examples/otel/` ships a minimal end-to-end
+  walkthrough once an adapter is available.
 
-The four phases can be developed in parallel branches on top of P1 —
-they touch disjoint trees (P2 = `server/`, P3 = `client/`, P4 = a new
-`ext/otel/` module, P5 = docs).
+P3, P4, P5 can be developed in parallel branches on top of P2 — they
+touch disjoint trees (P3 = `client/`, P4 = a new `ext/otel/` module,
+P5 = examples).
 
 ## Downstream consumers of the Phase 1 contract
 

--- a/server/server.go
+++ b/server/server.go
@@ -65,6 +65,7 @@ type serverOptions struct {
 	readTTLMs            *int                     // SEP-2549 resources/read default cache-freshness hint (ms); handler may override per-read
 	readCacheScope       string                   // SEP-2549 resources/read default cacheScope; handler may override per-read
 	allowLegacyOnDraft   bool                     // WithAllowLegacyOnDraft — opt-in SEP-2575 leniency on the legacy wire (off by default; strict per spec)
+	tracerProvider       core.TracerProvider      // SEP-414 P2 — WithTracerProvider; nil/Noop = trace middleware not installed
 }
 
 type httpHandlerEntry struct {
@@ -853,7 +854,34 @@ func (s *Server) dispatchWithOpts(d *Dispatcher, ctx context.Context, claims *co
 		}
 	}
 
+	// SEP-414 P2 — wrap with the trace middleware as the outermost layer so
+	// user middleware (rate limit, audit, custom auth) executes inside the
+	// span and contributes to the recorded latency. Skipped when no
+	// TracerProvider is configured or the default NoopTracerProvider is in
+	// use — zero overhead on the default path.
+	if tracingEnabled(s.options.tracerProvider) {
+		next := handler
+		mw := traceMiddleware(s.options.tracerProvider)
+		handler = func(ctx context.Context, req *core.Request) (*core.Response, error) {
+			return mw(ctx, req, next)
+		}
+	}
+
 	return handler(ctx, req)
+}
+
+// tracingEnabled reports whether the configured TracerProvider should
+// install the SEP-414 trace middleware. nil and the default
+// core.NoopTracerProvider both report false so the zero-overhead path is
+// preserved when no tracing is wired.
+func tracingEnabled(tp core.TracerProvider) bool {
+	if tp == nil {
+		return false
+	}
+	if _, isNoop := tp.(core.NoopTracerProvider); isNoop {
+		return false
+	}
+	return true
 }
 
 // newSession creates a per-session Dispatcher clone with fresh session state.

--- a/server/streamable_transport.go
+++ b/server/streamable_transport.go
@@ -196,6 +196,15 @@ func (t *streamableTransport) handlePost(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	// SEP-2028 — bridge W3C trace context HTTP headers into ctx. The trace
+	// middleware (SEP-414 P2) uses this as a fallback when the request has
+	// no in-band `_meta.traceparent`. Done once here at the entry point
+	// so all dispatch paths (sync, SSE, batch, stateless, initialize)
+	// inherit the trace context via r.Context().
+	if r.Header.Get(httpHeaderTraceparent) != "" {
+		r = r.WithContext(withTraceContextFromHTTPHeaders(r.Context(), r.Header))
+	}
+
 	body, claims, ok := readAndAuthorize(w, r, t.server)
 	if !ok {
 		return

--- a/server/trace_middleware.go
+++ b/server/trace_middleware.go
@@ -1,0 +1,316 @@
+package server
+
+// SEP-414 Phase 2 — server-side OpenTelemetry trace context propagation.
+//
+// This file holds the internal middleware and helpers that take the
+// dependency-free TracerProvider contract from core (PR 644) and wire it
+// into the dispatch path. Wiring is gated on server.WithTracerProvider —
+// when no provider is configured (or NoopTracerProvider is in use), this
+// middleware is not installed and there is zero runtime cost.
+//
+// Out of scope here:
+//   - Outbound child-span emission around server-to-client requests
+//     (P3 client-side spans).
+//   - The OTel SDK adapter that implements core.TracerProvider on top of
+//     go.opentelemetry.io/otel (P4, lands as a separate ext/otel/ module).
+//   - HTTP traceparent header → _meta bridging — lives in the streamable
+//     transport (SEP-2028) and is independent of this middleware; it
+//     attaches the inbound TraceContext via core.WithTraceContext so the
+//     middleware's fallback path picks it up.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+
+	core "github.com/panyam/mcpkit/core"
+)
+
+// SEP-2028 — W3C Trace Context HTTP headers. The canonical W3C names are
+// lowercase (`traceparent` / `tracestate`); Go's net/http canonicalizes
+// header keys to title-case, but http.Header.Get is case-insensitive, so
+// these constants serve as documentation of the spec name and a single
+// edit point if a future version renames them.
+const (
+	httpHeaderTraceparent = "Traceparent"
+	httpHeaderTracestate  = "Tracestate"
+)
+
+// withTraceContextFromHTTPHeaders bridges the W3C `traceparent` /
+// `tracestate` HTTP headers (SEP-2028) into ctx via core.WithTraceContext.
+// Returns ctx unchanged when the traceparent header is absent or its
+// value fails W3C structural validation; tracestate without traceparent
+// is silently dropped per the same W3C rule that ExtractTraceContext
+// enforces.
+//
+// The trace middleware consults this out-of-band context only when the
+// inbound `params._meta.traceparent` is absent — explicit in-band trace
+// context always wins. SEP-2028 frames the HTTP header as a vehicle for
+// `_meta`; we honor the semantic without rewriting the request body.
+func withTraceContextFromHTTPHeaders(ctx context.Context, h http.Header) context.Context {
+	tp := h.Get(httpHeaderTraceparent)
+	if tp == "" {
+		return ctx
+	}
+	tc := core.ExtractTraceContext(map[string]any{
+		core.MetaKeyTraceparent: tp,
+		core.MetaKeyTracestate:  h.Get(httpHeaderTracestate),
+	})
+	if tc.IsZero() {
+		return ctx
+	}
+	return core.WithTraceContext(ctx, tc)
+}
+
+// WithTracerProvider registers a core.TracerProvider that wraps every
+// dispatched JSON-RPC request in an inbound span and propagates the W3C
+// Trace Context on outbound notifications and server-to-client requests.
+//
+// When nil or core.NoopTracerProvider{} is passed, no trace middleware is
+// installed and no outbound _meta injection occurs — the server stays on
+// the zero-overhead default. The default (no Option set) is the same
+// "tracing disabled" behavior.
+//
+// The trace middleware is positioned OUTERMOST in the user middleware
+// chain, so user-registered middleware (rate limit, audit, custom auth)
+// executes inside the span and contributes to the recorded latency.
+// Outbound _meta injection (traceparent/tracestate) sits OUTSIDE any
+// user-registered NotifyInterceptor / RequestInterceptor, so user
+// interceptors observe the same wire form the client will receive —
+// useful for audit logs that want the full envelope.
+//
+// Inbound trace context resolution order:
+//  1. params._meta.traceparent / params._meta.tracestate (in-band).
+//  2. The TraceContext attached to ctx by the transport (e.g., the
+//     streamable HTTP transport bridges the HTTP `traceparent` header
+//     into ctx per SEP-2028).
+//
+// In-band wins over out-of-band. Malformed traceparent values are
+// dropped per W3C ("MUST NOT forward"); the span still emits with no
+// parent.
+//
+// Adapters (P4 ext/otel) MAY update the active TraceContext in ctx after
+// StartSpan so outbound _meta carries the new child span's traceparent.
+// The Noop default leaves ctx unchanged, so outbound _meta carries the
+// inbound traceparent verbatim — still correlates within the trace, just
+// without a finer parent-child link at the next hop. P4 will tighten
+// this for OTel users.
+func WithTracerProvider(tp core.TracerProvider) Option {
+	return func(o *serverOptions) {
+		o.tracerProvider = tp
+	}
+}
+
+// traceMiddleware returns a Middleware that wraps every JSON-RPC dispatch
+// in a span emitted by tp. The middleware:
+//
+//   - Extracts the inbound W3C Trace Context from `params._meta`
+//     (preferred) or from ctx (HTTP-header bridge); attaches the result
+//     via core.WithTraceContext so handlers can read it via
+//     ctx.TraceContext().
+//   - Calls tp.StartSpan with the JSON-RPC method as the span name and
+//     `mcp.method`, `mcp.session.id`, and `mcp.tool.name` (tools/call
+//     only) as attributes.
+//   - Wraps the session's NotifyFunc and RequestFunc so every outbound
+//     server-to-client message carries `_meta.traceparent` /
+//     `_meta.tracestate` derived from the active span's TraceContext.
+//   - Records `mcp.error.code` + RecordError on JSON-RPC errors, and
+//     `mcp.tool.is_error="true"` on `tools/call` results with isError.
+//   - Ends the span exactly once on return.
+//
+// Caller must hold tp != nil; the dispatch wiring layer guarantees this
+// by installing the middleware only when WithTracerProvider received a
+// non-Noop provider.
+func traceMiddleware(tp core.TracerProvider) Middleware {
+	return func(ctx context.Context, req *core.Request, next MiddlewareFunc) (*core.Response, error) {
+		tc := core.ExtractTraceContextFromParams(req.Params)
+		if tc.IsZero() {
+			tc = core.TraceContextFromContext(ctx)
+		}
+		ctx = core.WithTraceContext(ctx, tc)
+
+		attrs := make([]core.Attribute, 0, 3)
+		if req.Method != "" {
+			attrs = append(attrs, core.Attribute{Key: "mcp.method", Value: req.Method})
+		}
+		if sid := core.GetSessionID(ctx); sid != "" {
+			attrs = append(attrs, core.Attribute{Key: "mcp.session.id", Value: sid})
+		}
+		if req.Method == "tools/call" {
+			if name := parseToolCallName(req.Params); name != "" {
+				attrs = append(attrs, core.Attribute{Key: "mcp.tool.name", Value: name})
+			}
+		}
+
+		spanName := req.Method
+		if spanName == "" {
+			spanName = "mcp.request"
+		}
+		ctx, span := tp.StartSpan(ctx, spanName, attrs...)
+		defer span.End()
+
+		// Adapters may update the trace context in ctx during StartSpan
+		// to reflect the newly-created child span. Re-read so outbound
+		// _meta carries the child traceparent when available; falls
+		// back to the inbound TraceContext otherwise.
+		outbound := core.TraceContextFromContext(ctx)
+		if !outbound.IsZero() {
+			ctx = core.WrapSessionNotifyFunc(ctx, traceInjectNotifyWrap(outbound))
+			ctx = core.WrapSessionRequestFunc(ctx, traceInjectRequestWrap(outbound))
+		}
+
+		resp, err := next(ctx, req)
+		recordSpanOutcome(span, resp, err)
+		return resp, err
+	}
+}
+
+// traceInjectNotifyWrap returns a NotifyFunc wrapper that injects tc into
+// outbound `_meta.traceparent` / `_meta.tracestate` before forwarding to
+// the next NotifyFunc in the chain. Existing `_meta.traceparent` set
+// explicitly by the handler wins — the wrap never clobbers.
+func traceInjectNotifyWrap(tc core.TraceContext) func(core.NotifyFunc) core.NotifyFunc {
+	return func(orig core.NotifyFunc) core.NotifyFunc {
+		return func(method string, params any) {
+			orig(method, injectTraceContextIntoParams(params, tc))
+		}
+	}
+}
+
+// traceInjectRequestWrap returns a RequestFunc wrapper that injects tc into
+// outbound server-to-client request params. Sibling to traceInjectNotifyWrap.
+func traceInjectRequestWrap(tc core.TraceContext) func(core.RequestFunc) core.RequestFunc {
+	return func(orig core.RequestFunc) core.RequestFunc {
+		return func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+			return orig(ctx, method, injectTraceContextIntoParams(params, tc))
+		}
+	}
+}
+
+// injectTraceContextIntoParams returns a params value with `_meta.traceparent`
+// and (if non-empty) `_meta.tracestate` populated from tc. Behavior:
+//
+//   - If params is nil, returns a fresh object with just `_meta`.
+//   - If params marshals to a JSON object, the object's `_meta` is
+//     read/created and the trace keys are added. Existing entries are
+//     preserved — explicit handler-set values win.
+//   - If params marshals but is not a JSON object (positional array,
+//     scalar, etc.), the value is returned unchanged. The JSON-RPC spec
+//     permits non-object params; `_meta` is only defined inside objects.
+//   - If params fails to marshal, it is returned unchanged so the
+//     downstream encoder can surface the original error.
+//
+// The function clones the decoded map rather than mutating any value the
+// handler may still reference.
+func injectTraceContextIntoParams(params any, tc core.TraceContext) any {
+	if tc.IsZero() {
+		return params
+	}
+	if params == nil {
+		meta := map[string]any{}
+		core.InjectTraceContext(meta, tc)
+		return map[string]any{"_meta": meta}
+	}
+	raw, err := json.Marshal(params)
+	if err != nil {
+		return params
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		// Non-object params (positional array, scalar, etc.). Leave alone.
+		return params
+	}
+	if obj == nil {
+		obj = map[string]any{}
+	}
+	meta, _ := obj["_meta"].(map[string]any)
+	if meta == nil {
+		meta = map[string]any{}
+	}
+	if _, exists := meta[core.MetaKeyTraceparent]; !exists {
+		meta[core.MetaKeyTraceparent] = tc.Traceparent
+	}
+	if tc.Tracestate != "" {
+		if _, exists := meta[core.MetaKeyTracestate]; !exists {
+			meta[core.MetaKeyTracestate] = tc.Tracestate
+		}
+	}
+	obj["_meta"] = meta
+	return obj
+}
+
+// parseToolCallName extracts the `name` field from a tools/call params
+// envelope. Returns "" on any decode failure — best-effort attribute
+// enrichment never blocks dispatch.
+func parseToolCallName(params json.RawMessage) string {
+	if len(params) == 0 {
+		return ""
+	}
+	var envelope struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(params, &envelope); err != nil {
+		return ""
+	}
+	return envelope.Name
+}
+
+// recordSpanOutcome stamps error / tool-error attributes on the span before
+// it ends. Three layers, in priority order:
+//
+//   - transport-level error (err != nil): RecordError only. The error
+//     surfaces to the transport, which maps it to an HTTP-level response.
+//   - JSON-RPC protocol error (resp.Error != nil): SetAttribute
+//     `mcp.error.code` and RecordError with the error message.
+//   - tools/call in-stream error (resp.Result is a ToolResult with
+//     IsError): SetAttribute `mcp.tool.is_error="true"`.
+//
+// Non-error responses leave the span attribute set unchanged.
+func recordSpanOutcome(span core.Span, resp *core.Response, err error) {
+	if err != nil {
+		span.RecordError(err)
+		return
+	}
+	if resp == nil {
+		return
+	}
+	if resp.Error != nil {
+		span.SetAttribute("mcp.error.code", strconv.Itoa(resp.Error.Code))
+		span.RecordError(errors.New(resp.Error.Message))
+		return
+	}
+	if isToolErrorResult(resp.Result) {
+		span.SetAttribute("mcp.tool.is_error", "true")
+	}
+}
+
+// isToolErrorResult reports whether result is a tools/call ToolResult
+// carrying IsError == true. The dispatch layer assigns the concrete
+// core.ToolResult struct on the success path, so a fast type-switch
+// covers the common case; the JSON round-trip is the conservative
+// fallback for unusual handler return types (custom JSON-marshalable
+// shapes routed through HandleMethod, etc.).
+func isToolErrorResult(result any) bool {
+	if result == nil {
+		return false
+	}
+	if tr, ok := result.(core.ToolResult); ok {
+		return tr.IsError
+	}
+	if tr, ok := result.(*core.ToolResult); ok && tr != nil {
+		return tr.IsError
+	}
+	raw, err := json.Marshal(result)
+	if err != nil {
+		return false
+	}
+	var probe struct {
+		IsError bool `json:"isError"`
+	}
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		return false
+	}
+	return probe.IsError
+}

--- a/server/trace_middleware_test.go
+++ b/server/trace_middleware_test.go
@@ -1,0 +1,602 @@
+package server
+
+// SEP-414 Phase 2 — server-side OTel span emission + W3C trace context
+// propagation tests. Uses a fake TracerProvider that records every span
+// it starts so the suite can run without depending on go.opentelemetry.io/otel.
+//
+// White-box (`package server`) because the test wires the dispatcher
+// directly via dispatchWithNotifyAndRequest to attach test notify/request
+// hooks without spinning up a transport. The OTel SDK adapter and any
+// end-to-end exporter coverage land in P4 with the new ext/otel/ module.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	core "github.com/panyam/mcpkit/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// Valid W3C version-00 traceparent values used across the suite.
+	tpInbound = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+	tpHTTPHdr = "00-aaaa1234567890abcdef1234567890aa-1111222233334444-01"
+	tpChild   = "00-0af7651916cd43dd8448eb211c80319c-cccccccccccccccc-01"
+)
+
+// fakeSpan records every attribute / RecordError call and end-state so
+// individual tests can assert the exact OTel signal emitted.
+type fakeSpan struct {
+	mu     sync.Mutex
+	name   string
+	attrs  map[string]string
+	errs   []error
+	ended  bool
+	parent core.TraceContext // captured from ctx at StartSpan
+}
+
+func (s *fakeSpan) End() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ended = true
+}
+
+func (s *fakeSpan) SetAttribute(k, v string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.attrs == nil {
+		s.attrs = make(map[string]string)
+	}
+	s.attrs[k] = v
+}
+
+func (s *fakeSpan) RecordError(err error) {
+	if err == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.errs = append(s.errs, err)
+}
+
+func (s *fakeSpan) attr(k string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.attrs[k]
+}
+
+// fakeTracerProvider records every span StartSpan creates. When childTC
+// is non-zero, StartSpan attaches it via core.WithTraceContext to mimic
+// an OTel adapter that updates the active TraceContext with the new
+// child span's identity — drives the outbound-_meta assertions below.
+type fakeTracerProvider struct {
+	mu      sync.Mutex
+	spans   []*fakeSpan
+	childTC core.TraceContext
+}
+
+func (p *fakeTracerProvider) StartSpan(ctx context.Context, name string, attrs ...core.Attribute) (context.Context, core.Span) {
+	sp := &fakeSpan{
+		name:   name,
+		parent: core.TraceContextFromContext(ctx),
+		attrs:  make(map[string]string, len(attrs)),
+	}
+	for _, a := range attrs {
+		sp.attrs[a.Key] = a.Value
+	}
+	p.mu.Lock()
+	p.spans = append(p.spans, sp)
+	p.mu.Unlock()
+	if !p.childTC.IsZero() {
+		ctx = core.WithTraceContext(ctx, p.childTC)
+	}
+	return ctx, sp
+}
+
+func (p *fakeTracerProvider) snapshot() []*fakeSpan {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]*fakeSpan, len(p.spans))
+	copy(out, p.spans)
+	return out
+}
+
+// newInitializedServer returns a server with the dispatcher flipped to
+// initialized so tests can call tools/call without the full handshake.
+func newInitializedServer(t *testing.T, opts ...Option) *Server {
+	t.Helper()
+	srv := NewServer(core.ServerInfo{Name: "trace-test", Version: "1.0"}, opts...)
+	srv.dispatcher.initialized = true
+	return srv
+}
+
+// dispatchToolsCall is a one-line wrapper that builds a tools/call request
+// envelope and routes it through dispatchWithNotifyAndRequest so tests can
+// supply their own notify and request hooks.
+func dispatchToolsCall(t *testing.T, srv *Server, ctx context.Context, params string, notify core.NotifyFunc, request core.RequestFunc) (*core.Response, error) {
+	t.Helper()
+	req := &core.Request{
+		ID:     json.RawMessage(`1`),
+		Method: "tools/call",
+		Params: json.RawMessage(params),
+	}
+	return srv.dispatchWithNotifyAndRequest(srv.dispatcher, ctx, nil, notify, request, req)
+}
+
+// TestTraceMiddleware_NoProviderInstallsNothing verifies that the default
+// configuration (no WithTracerProvider) does not install the trace
+// middleware, does not parse _meta for trace fields, and does not inject
+// _meta on outbound notifications. This is the zero-overhead path.
+func TestTraceMiddleware_NoProviderInstallsNothing(t *testing.T) {
+	srv := newInitializedServer(t)
+	srv.RegisterTool(core.ToolDef{Name: "noop"}, func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+		ctx.Notify("notifications/test", map[string]any{"hello": "world"})
+		return core.TextResult("ok"), nil
+	})
+
+	var captured []map[string]any
+	notify := core.NotifyFunc(func(method string, params any) {
+		raw, _ := json.Marshal(params)
+		var obj map[string]any
+		_ = json.Unmarshal(raw, &obj)
+		captured = append(captured, obj)
+	})
+
+	params := `{"name":"noop","_meta":{"traceparent":"` + tpInbound + `"}}`
+	_, err := dispatchToolsCall(t, srv, context.Background(), params, notify, nil)
+	require.NoError(t, err)
+
+	require.Len(t, captured, 1)
+	_, hasTraceparent := captured[0]["_meta"].(map[string]any)
+	if hasTraceparent {
+		m := captured[0]["_meta"].(map[string]any)
+		assert.NotContains(t, m, "traceparent", "outbound notify must not carry traceparent when no provider is configured")
+	}
+}
+
+// TestTraceMiddleware_NoopProviderInstallsNothing pins the behavior that
+// passing core.NoopTracerProvider{} explicitly is equivalent to the
+// default — no middleware installed, no _meta injection.
+func TestTraceMiddleware_NoopProviderInstallsNothing(t *testing.T) {
+	srv := newInitializedServer(t, WithTracerProvider(core.NoopTracerProvider{}))
+	srv.RegisterTool(core.ToolDef{Name: "noop"}, func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+		ctx.Notify("notifications/test", nil)
+		return core.TextResult("ok"), nil
+	})
+
+	var notifyCalls int
+	notify := core.NotifyFunc(func(method string, params any) {
+		notifyCalls++
+		if params != nil {
+			t.Fatalf("Noop provider must not inject _meta; got params=%v", params)
+		}
+	})
+
+	params := `{"name":"noop","_meta":{"traceparent":"` + tpInbound + `"}}`
+	_, err := dispatchToolsCall(t, srv, context.Background(), params, notify, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, notifyCalls)
+}
+
+// TestTraceMiddleware_ExtractsInboundMetaTraceparent verifies that the
+// middleware reads _meta.traceparent from the request envelope and uses
+// it as the parent of the emitted span.
+func TestTraceMiddleware_ExtractsInboundMetaTraceparent(t *testing.T) {
+	tp := &fakeTracerProvider{}
+	srv := newInitializedServer(t, WithTracerProvider(tp))
+	srv.RegisterTool(core.ToolDef{Name: "echo"}, func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+		assert.Equal(t, tpInbound, ctx.TraceContext().Traceparent, "handler must observe extracted trace context via ctx.TraceContext()")
+		return core.TextResult("ok"), nil
+	})
+
+	params := `{"name":"echo","_meta":{"traceparent":"` + tpInbound + `","tracestate":"vendor=on"}}`
+	_, err := dispatchToolsCall(t, srv, context.Background(), params, nil, nil)
+	require.NoError(t, err)
+
+	spans := tp.snapshot()
+	require.Len(t, spans, 1)
+	assert.Equal(t, "tools/call", spans[0].name)
+	assert.Equal(t, tpInbound, spans[0].parent.Traceparent)
+	assert.Equal(t, "vendor=on", spans[0].parent.Tracestate)
+	assert.True(t, spans[0].ended, "span must be ended exactly once on return")
+}
+
+// TestTraceMiddleware_FallsBackToContextTraceContext verifies that when
+// no _meta.traceparent is in the request, the middleware reads the
+// TraceContext that the transport (or another middleware) attached via
+// core.WithTraceContext — the same path the streamable HTTP transport
+// uses for the SEP-2028 header bridge.
+func TestTraceMiddleware_FallsBackToContextTraceContext(t *testing.T) {
+	tp := &fakeTracerProvider{}
+	srv := newInitializedServer(t, WithTracerProvider(tp))
+	srv.RegisterTool(core.ToolDef{Name: "echo"}, func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+		return core.TextResult("ok"), nil
+	})
+
+	ctx := core.WithTraceContext(context.Background(), core.TraceContext{Traceparent: tpHTTPHdr})
+	params := `{"name":"echo"}`
+	_, err := dispatchToolsCall(t, srv, ctx, params, nil, nil)
+	require.NoError(t, err)
+
+	spans := tp.snapshot()
+	require.Len(t, spans, 1)
+	assert.Equal(t, tpHTTPHdr, spans[0].parent.Traceparent)
+}
+
+// TestTraceMiddleware_MetaWinsOverContext verifies precedence: an in-band
+// _meta.traceparent always beats whatever the transport bridged onto ctx.
+// Mirrors SEP-2028's spec stance — the HTTP header is a convenience, but
+// the request body is authoritative when both are present.
+func TestTraceMiddleware_MetaWinsOverContext(t *testing.T) {
+	tp := &fakeTracerProvider{}
+	srv := newInitializedServer(t, WithTracerProvider(tp))
+	srv.RegisterTool(core.ToolDef{Name: "echo"}, func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+		return core.TextResult("ok"), nil
+	})
+
+	ctx := core.WithTraceContext(context.Background(), core.TraceContext{Traceparent: tpHTTPHdr})
+	params := `{"name":"echo","_meta":{"traceparent":"` + tpInbound + `"}}`
+	_, err := dispatchToolsCall(t, srv, ctx, params, nil, nil)
+	require.NoError(t, err)
+
+	spans := tp.snapshot()
+	require.Len(t, spans, 1)
+	assert.Equal(t, tpInbound, spans[0].parent.Traceparent, "_meta.traceparent must win over ctx-attached value")
+}
+
+// TestTraceMiddleware_MalformedTraceparentDropsSilently verifies that an
+// inbound traceparent failing W3C validation does NOT prevent the span
+// from emitting — the span just has no parent. Matches the contract in
+// core.ExtractTraceContext, which returns a zero TraceContext for
+// malformed input and never errors.
+func TestTraceMiddleware_MalformedTraceparentDropsSilently(t *testing.T) {
+	tp := &fakeTracerProvider{}
+	srv := newInitializedServer(t, WithTracerProvider(tp))
+	srv.RegisterTool(core.ToolDef{Name: "echo"}, func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+		assert.True(t, ctx.TraceContext().IsZero(), "handler must observe zero TraceContext when inbound traceparent is malformed")
+		return core.TextResult("ok"), nil
+	})
+
+	params := `{"name":"echo","_meta":{"traceparent":"not-a-real-traceparent","tracestate":"vendor=x"}}`
+	resp, err := dispatchToolsCall(t, srv, context.Background(), params, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Nil(t, resp.Error)
+
+	spans := tp.snapshot()
+	require.Len(t, spans, 1)
+	assert.True(t, spans[0].parent.IsZero())
+}
+
+// TestTraceMiddleware_SetsCoreAttributes verifies the inbound-span
+// attribute set: mcp.method always, mcp.tool.name on tools/call.
+// mcp.session.id is exercised by the streamable HTTP integration test
+// since SetSessionID needs a session context.
+func TestTraceMiddleware_SetsCoreAttributes(t *testing.T) {
+	tp := &fakeTracerProvider{}
+	srv := newInitializedServer(t, WithTracerProvider(tp))
+	srv.RegisterTool(core.ToolDef{Name: "echo"}, func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+		return core.TextResult("ok"), nil
+	})
+
+	params := `{"name":"echo"}`
+	_, err := dispatchToolsCall(t, srv, context.Background(), params, nil, nil)
+	require.NoError(t, err)
+
+	spans := tp.snapshot()
+	require.Len(t, spans, 1)
+	assert.Equal(t, "tools/call", spans[0].attr("mcp.method"))
+	assert.Equal(t, "echo", spans[0].attr("mcp.tool.name"))
+}
+
+// TestTraceMiddleware_RPCError_RecordsErrorAndCode verifies that a
+// JSON-RPC error response sets mcp.error.code and calls RecordError with
+// the error message. Routes through the tools/call "unknown tool" path
+// so the response carries a real *core.Error from dispatch.
+func TestTraceMiddleware_RPCError_RecordsErrorAndCode(t *testing.T) {
+	tp := &fakeTracerProvider{}
+	srv := newInitializedServer(t, WithTracerProvider(tp))
+
+	params := `{"name":"does-not-exist"}`
+	resp, err := dispatchToolsCall(t, srv, context.Background(), params, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Error)
+
+	spans := tp.snapshot()
+	require.Len(t, spans, 1)
+	assert.NotEmpty(t, spans[0].attr("mcp.error.code"))
+	require.Len(t, spans[0].errs, 1)
+	assert.Contains(t, spans[0].errs[0].Error(), "unknown tool")
+}
+
+// TestTraceMiddleware_ToolIsError_SetsAttribute verifies that a
+// tools/call returning a ToolResult with IsError stamps
+// mcp.tool.is_error="true" on the span. The JSON-RPC response itself is
+// success (resp.Error == nil) — this attribute is the only signal that
+// distinguishes "tool ran and reported failure" from "tool ran and
+// reported success."
+func TestTraceMiddleware_ToolIsError_SetsAttribute(t *testing.T) {
+	tp := &fakeTracerProvider{}
+	srv := newInitializedServer(t, WithTracerProvider(tp))
+	srv.RegisterTool(core.ToolDef{Name: "bad"}, func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+		return core.ToolResult{IsError: true, Content: []core.Content{{Type: "text", Text: "boom"}}}, nil
+	})
+
+	params := `{"name":"bad"}`
+	resp, err := dispatchToolsCall(t, srv, context.Background(), params, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Nil(t, resp.Error)
+
+	spans := tp.snapshot()
+	require.Len(t, spans, 1)
+	assert.Equal(t, "true", spans[0].attr("mcp.tool.is_error"))
+}
+
+// TestTraceMiddleware_InjectsOutboundNotification_Meta verifies that when
+// the handler emits a notification (ctx.Notify, EmitProgress, EmitLog,
+// EmitContent — all funnel through sc.notify), the params carry
+// _meta.traceparent set to the active span's TraceContext. Uses the
+// fakeTracerProvider.childTC path so the assertion proves the wrap reads
+// the post-StartSpan trace context (not just the inbound parent).
+func TestTraceMiddleware_InjectsOutboundNotification_Meta(t *testing.T) {
+	tp := &fakeTracerProvider{
+		childTC: core.TraceContext{Traceparent: tpChild, Tracestate: "vendor=child"},
+	}
+	srv := newInitializedServer(t, WithTracerProvider(tp))
+	srv.RegisterTool(core.ToolDef{Name: "emit"}, func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+		ctx.Notify("notifications/test", map[string]any{"hello": "world"})
+		return core.TextResult("ok"), nil
+	})
+
+	var captured map[string]any
+	notify := core.NotifyFunc(func(method string, params any) {
+		raw, _ := json.Marshal(params)
+		_ = json.Unmarshal(raw, &captured)
+	})
+
+	params := `{"name":"emit","_meta":{"traceparent":"` + tpInbound + `"}}`
+	_, err := dispatchToolsCall(t, srv, context.Background(), params, notify, nil)
+	require.NoError(t, err)
+
+	meta, _ := captured["_meta"].(map[string]any)
+	require.NotNil(t, meta, "outbound notify params must include _meta")
+	assert.Equal(t, tpChild, meta[core.MetaKeyTraceparent])
+	assert.Equal(t, "vendor=child", meta[core.MetaKeyTracestate])
+	assert.Equal(t, "world", captured["hello"], "non-_meta fields must pass through unchanged")
+}
+
+// TestTraceMiddleware_InjectsOutboundRequest_Meta verifies the same
+// injection for server-to-client requests (sampling/createMessage,
+// elicitation/create, roots/list — all routed through sc.request).
+func TestTraceMiddleware_InjectsOutboundRequest_Meta(t *testing.T) {
+	tp := &fakeTracerProvider{
+		childTC: core.TraceContext{Traceparent: tpChild},
+	}
+	srv := newInitializedServer(t, WithTracerProvider(tp))
+	srv.RegisterTool(core.ToolDef{Name: "ask"}, func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+		_, _ = ctx.Sample(core.CreateMessageRequest{MaxTokens: 16})
+		return core.TextResult("ok"), nil
+	})
+
+	// Force the legacy push path to be available so ctx.Sample reaches
+	// the test request hook (handler_context.Sample early-returns when
+	// sc.request == nil or client did not declare sampling capability).
+	srv.dispatcher.clientCaps = core.ClientCapabilities{Sampling: &struct{}{}}
+
+	var captured map[string]any
+	request := core.RequestFunc(func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+		raw, _ := json.Marshal(params)
+		_ = json.Unmarshal(raw, &captured)
+		return json.RawMessage(`{"role":"assistant","content":{"type":"text","text":"ok"},"model":"x"}`), nil
+	})
+
+	params := `{"name":"ask","_meta":{"traceparent":"` + tpInbound + `"}}`
+	_, err := dispatchToolsCall(t, srv, context.Background(), params, nil, request)
+	require.NoError(t, err)
+
+	meta, _ := captured["_meta"].(map[string]any)
+	require.NotNil(t, meta, "outbound server-to-client request must carry _meta")
+	assert.Equal(t, tpChild, meta[core.MetaKeyTraceparent])
+}
+
+// TestTraceMiddleware_UserMiddlewareRunsInsideSpan verifies that
+// WithTracerProvider installs the trace middleware as the OUTERMOST
+// layer — user middleware (rate limit, audit, custom auth) executes
+// inside the span, so its latency is captured.
+func TestTraceMiddleware_UserMiddlewareRunsInsideSpan(t *testing.T) {
+	tp := &fakeTracerProvider{}
+	var order []string
+	userMW := func(ctx context.Context, req *core.Request, next MiddlewareFunc) (*core.Response, error) {
+		order = append(order, "user-before")
+		resp, err := next(ctx, req)
+		order = append(order, "user-after")
+		return resp, err
+	}
+
+	srv := newInitializedServer(t,
+		WithTracerProvider(tp),
+		WithMiddleware(userMW),
+	)
+	srv.RegisterTool(core.ToolDef{Name: "echo"}, func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+		order = append(order, "handler")
+		return core.TextResult("ok"), nil
+	})
+
+	params := `{"name":"echo"}`
+	_, err := dispatchToolsCall(t, srv, context.Background(), params, nil, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"user-before", "handler", "user-after"}, order)
+
+	spans := tp.snapshot()
+	require.Len(t, spans, 1)
+	assert.True(t, spans[0].ended)
+}
+
+// TestInjectTraceContextIntoParams_RespectsExplicitMeta verifies that a
+// handler that explicitly set _meta.traceparent on its outbound message
+// is NOT overwritten by the inject wrap — explicit caller intent wins.
+func TestInjectTraceContextIntoParams_RespectsExplicitMeta(t *testing.T) {
+	tc := core.TraceContext{Traceparent: tpChild, Tracestate: "vendor=child"}
+	explicit := "00-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-1234567812345678-01"
+	in := map[string]any{
+		"_meta": map[string]any{core.MetaKeyTraceparent: explicit},
+		"data":  "x",
+	}
+
+	got := injectTraceContextIntoParams(in, tc)
+	obj, ok := got.(map[string]any)
+	require.True(t, ok)
+	meta := obj["_meta"].(map[string]any)
+	assert.Equal(t, explicit, meta[core.MetaKeyTraceparent], "explicit handler-set traceparent must win")
+	assert.Equal(t, "vendor=child", meta[core.MetaKeyTracestate], "tracestate may still be added when not explicitly set")
+}
+
+// TestInjectTraceContextIntoParams_HandlesNilAndNonObject covers the
+// edge cases the wrap must not corrupt:
+//   - nil params → fresh object with just _meta;
+//   - non-object params (positional array) → returned unchanged;
+//   - zero TraceContext → returned unchanged.
+func TestInjectTraceContextIntoParams_HandlesNilAndNonObject(t *testing.T) {
+	tc := core.TraceContext{Traceparent: tpChild}
+
+	got := injectTraceContextIntoParams(nil, tc)
+	obj, ok := got.(map[string]any)
+	require.True(t, ok)
+	meta := obj["_meta"].(map[string]any)
+	assert.Equal(t, tpChild, meta[core.MetaKeyTraceparent])
+
+	arr := []any{1, 2, 3}
+	got2 := injectTraceContextIntoParams(arr, tc)
+	assert.Equal(t, arr, got2, "non-object params must pass through unchanged")
+
+	got3 := injectTraceContextIntoParams(map[string]any{"a": 1}, core.TraceContext{})
+	assert.Equal(t, map[string]any{"a": 1}, got3, "zero TraceContext must pass through unchanged")
+}
+
+// TestWithTraceContextFromHTTPHeaders_Bridges directly exercises the
+// SEP-2028 helper. Covers the three branches: absent header → ctx
+// unchanged; valid header → ctx carries the TraceContext; malformed
+// header → ctx unchanged (W3C MUST NOT forward).
+func TestWithTraceContextFromHTTPHeaders_Bridges(t *testing.T) {
+	t.Run("absent", func(t *testing.T) {
+		ctx := withTraceContextFromHTTPHeaders(context.Background(), http.Header{})
+		assert.True(t, core.TraceContextFromContext(ctx).IsZero())
+	})
+	t.Run("valid", func(t *testing.T) {
+		h := http.Header{}
+		h.Set(httpHeaderTraceparent, tpHTTPHdr)
+		h.Set(httpHeaderTracestate, "vendor=on")
+		ctx := withTraceContextFromHTTPHeaders(context.Background(), h)
+		got := core.TraceContextFromContext(ctx)
+		assert.Equal(t, tpHTTPHdr, got.Traceparent)
+		assert.Equal(t, "vendor=on", got.Tracestate)
+	})
+	t.Run("malformed", func(t *testing.T) {
+		h := http.Header{}
+		h.Set(httpHeaderTraceparent, "not-a-traceparent")
+		h.Set(httpHeaderTracestate, "vendor=on")
+		ctx := withTraceContextFromHTTPHeaders(context.Background(), h)
+		got := core.TraceContextFromContext(ctx)
+		assert.True(t, got.IsZero(), "malformed traceparent must drop tracestate too (W3C)")
+	})
+}
+
+// TestParseToolCallName_Robust exercises the attribute helper's failure
+// modes: empty params, non-JSON, missing name field.
+func TestParseToolCallName_Robust(t *testing.T) {
+	assert.Equal(t, "", parseToolCallName(nil))
+	assert.Equal(t, "", parseToolCallName(json.RawMessage(`not-json`)))
+	assert.Equal(t, "", parseToolCallName(json.RawMessage(`{"other":"x"}`)))
+	assert.Equal(t, "echo", parseToolCallName(json.RawMessage(`{"name":"echo","arguments":{}}`)))
+}
+
+// TestIsToolErrorResult covers the three result-shape branches: typed
+// value, typed pointer, and the json round-trip fallback for arbitrary
+// JSON-marshalable shapes (e.g., a map carrying isError).
+func TestIsToolErrorResult(t *testing.T) {
+	assert.False(t, isToolErrorResult(nil))
+	assert.False(t, isToolErrorResult(core.ToolResult{IsError: false}))
+	assert.True(t, isToolErrorResult(core.ToolResult{IsError: true}))
+	assert.True(t, isToolErrorResult(&core.ToolResult{IsError: true}))
+	assert.True(t, isToolErrorResult(map[string]any{"isError": true}))
+	assert.False(t, isToolErrorResult(map[string]any{"isError": false}))
+	// Channels do not marshal — fallback returns false rather than panicking.
+	ch := make(chan int)
+	assert.False(t, isToolErrorResult(ch))
+}
+
+// TestStreamableTransport_BridgesHTTPTraceparentHeader is the integration
+// check for P2.3: a real HTTP POST carrying the `traceparent` header (no
+// in-band _meta) reaches the trace middleware as the inbound trace
+// context. Exercises the handlePost bridge call.
+func TestStreamableTransport_BridgesHTTPTraceparentHeader(t *testing.T) {
+	tp := &fakeTracerProvider{}
+	srv := NewServer(core.ServerInfo{Name: "trace-http", Version: "1.0"},
+		WithTracerProvider(tp))
+	srv.RegisterTool(core.ToolDef{Name: "echo"}, func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+		return core.TextResult("ok"), nil
+	})
+
+	handler := srv.Handler(WithStreamableHTTP(true), WithStateless(true))
+
+	body := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo"}}`)
+	r, err := http.NewRequest(http.MethodPost, "/mcp", body)
+	require.NoError(t, err)
+	r.Header.Set("Content-Type", "application/json")
+	r.Header.Set("Accept", "application/json, text/event-stream")
+	r.Header.Set(httpHeaderTraceparent, tpHTTPHdr)
+
+	w := newRespRecorder()
+	handler.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusOK, w.statusCode())
+
+	spans := tp.snapshot()
+	require.NotEmpty(t, spans)
+	// The tools/call span (last in the chain — initialize, if any, would
+	// also have been recorded, but stateless mode skips it).
+	last := spans[len(spans)-1]
+	assert.Equal(t, tpHTTPHdr, last.parent.Traceparent, "HTTP traceparent header must bridge into the inbound span's parent")
+}
+
+// respRecorder is a minimal http.ResponseWriter that captures the status
+// code and body so the integration test does not depend on net/http/httptest.
+type respRecorder struct {
+	mu      sync.Mutex
+	hdr     http.Header
+	status  int
+	written []byte
+}
+
+func newRespRecorder() *respRecorder {
+	return &respRecorder{hdr: http.Header{}}
+}
+
+func (r *respRecorder) Header() http.Header        { return r.hdr }
+func (r *respRecorder) WriteHeader(statusCode int) { r.mu.Lock(); r.status = statusCode; r.mu.Unlock() }
+func (r *respRecorder) Write(b []byte) (int, error) {
+	r.mu.Lock()
+	if r.status == 0 {
+		r.status = http.StatusOK
+	}
+	r.written = append(r.written, b...)
+	r.mu.Unlock()
+	return len(b), nil
+}
+
+func (r *respRecorder) statusCode() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.status == 0 {
+		return http.StatusOK
+	}
+	return r.status
+}


### PR DESCRIPTION
## What changes

Wires the dependency-free `core.TracerProvider` surface from PR 644 into the server dispatch path. Adds `server.WithTracerProvider`, an outermost trace middleware that emits an inbound span on every JSON-RPC dispatch, an SEP-2028 HTTP-header → `ctx` bridge in the streamable transport, and outbound `_meta.traceparent` / `_meta.tracestate` injection on every server-to-client message. Default and `core.NoopTracerProvider{}` both skip the install entirely, so the zero-overhead path stays untouched until an operator opts in. Implements issue 312 sub-tasks P2.1–P2.4. No client-side spans (P3), no `ext/otel` adapter (P4), no examples (P5).

```mermaid
sequenceDiagram
    participant C as Client
    participant T as Streamable Transport
    participant M as traceMiddleware
    participant U as User middleware
    participant H as Handler
    participant N as Outbound notify

    C->>T: POST tools/call (traceparent header OR _meta)
    T->>T: bridge HTTP traceparent → ctx (WithTraceContext)
    T->>M: Dispatch(ctx, req)
    M->>M: extract _meta.traceparent (fallback: ctx)
    M->>M: StartSpan with attrs (mcp.method, mcp.tool.name, mcp.session.id)
    M->>M: wrap session notify/request to inject _meta
    M->>U: next(ctx, req)
    U->>H: next(ctx, req)
    H->>N: ctx.Notify(...) or ctx.Sample(...)
    N->>N: inject _meta.traceparent from active span
    N->>C: outbound message (with _meta.traceparent)
    H->>U: response
    U->>M: response
    M->>M: SetAttribute error/tool flags, End()
    M->>T: response
    T->>C: response
```

## Reviewer's guide

Read in this order:

1. [core/trace.go](https://github.com/panyam/mcpkit/pull/649/files#diff-acb99666fd2aacc85eaf8e433236a74d28959ca5e1e0d5e14913cdd5fb9e81c0) — only one new exported symbol (`ExtractTraceContextFromParams`); confirms the helper is a thin wrapper over the P1 `ExtractTraceContext` and stays protocol-level (no server/client coupling).
2. [core/background.go](https://github.com/panyam/mcpkit/pull/649/files#diff-a140d50aedc8a501fb80e6f96a6d14138fb8fccd993931552cf99b9f59a04131) — `WrapSessionNotifyFunc` / `WrapSessionRequestFunc`; both no-op when the session is absent or the underlying func is nil. Symmetric with the existing `ApplySessionNotifyFilter` precedent.
3. [server/trace_middleware.go](https://github.com/panyam/mcpkit/pull/649/files#diff-7e0ee26d4d523ebdecda4da033cb2f40c364eb05edb5f41b1d90d76fd374546e) — the heart of P2. `WithTracerProvider` option, `traceMiddleware`, the inject wraps, and the `withTraceContextFromHTTPHeaders` SEP-2028 helper. Confirm the in-band-wins-over-out-of-band precedence on line tied to `ExtractTraceContextFromParams` + `TraceContextFromContext` fallback.
4. [server/server.go](https://github.com/panyam/mcpkit/pull/649/files#diff-78f42ba40d0f10b08c73b7e6bb8376f398e249c963cf549e89591d6b6826b9a4) — option field on `serverOptions`, install in `dispatchWithOpts` as the OUTERMOST middleware, `tracingEnabled` gating on nil / Noop.
5. [server/streamable_transport.go](https://github.com/panyam/mcpkit/pull/649/files#diff-6d7a7857fa287633c986304e06b224dc7e95a8a8d770430f684717bb7d1543b4) — single bridge call in `handlePost`. Gated on `traceparent` header presence so non-OTel users pay nothing.
6. [server/trace_middleware_test.go](https://github.com/panyam/mcpkit/pull/649/files#diff-9afc268cfbcbcd1d48ab89407746d243ef738f0e6f5eabb2b7a5f221a462ea1e) — start with the 11 `TestTraceMiddleware_*` cases (top-down maps to the design decisions). Then `TestInjectTraceContextIntoParams_*` for the helper edge cases. `TestStreamableTransport_BridgesHTTPTraceparentHeader` is the integration check for P2.3.
7. [docs/SEP_414_OTEL.md](https://github.com/panyam/mcpkit/pull/649/files#diff-471fd7f72ab0a2ff1e1398303fa41c3e0173c19ac5439e8b833ce242fa81f3e6) — Phase 2 section promoted from "what comes next" to "what Phase 2 ships"; wiring snippet shows the single-line server bootstrap.

Skim or skip: nothing — every diff hunk is intentional.

## Decision log

| Decision | Choice | Alternative | Why |
|---|---|---|---|
| Span position in the chain | Outermost (wraps user middleware) | Innermost (handler only) | Matches OTel HTTP server convention; user middleware (rate limit, audit) contributes to recorded latency, so trace timing reflects real client experience. |
| HTTP `traceparent` bridge mechanism | `context.Context` via `core.WithTraceContext` | Mutating raw `req.Params` JSON to inject `_meta.traceparent` | Avoids touching wire bytes; gives explicit `_meta` precedence over the header (the W3C convenience vehicle) without surgery on every transport's body handling. |
| `_meta` precedence | In-band `_meta.traceparent` wins over HTTP header / ctx | Header wins | Explicit beats implicit; spec doesn't mandate either, but in-band intent should not be silently overridden. |
| Outbound `_meta` injection | Internal wrap of `sc.notify` / `sc.request` via the new `core.WrapSessionNotifyFunc` / `WrapSessionRequestFunc` | New ctx-aware `NotifyInterceptor` signature | Keeps `NotifyInterceptor` / `RequestInterceptor` signatures unchanged — no breaking API. Trace inject sits outside user interceptors so user audit logs see the same wire form the client receives. |
| Outbound child-span emission | NOT in P2 | Wrap `ctx.Sample` / `ctx.Elicit` in a child span here | Issue 312 P2.4 says only "inject `_meta.traceparent`"; outbound child spans are P3 client-side territory for symmetry. |
| Noop / nil = no install | Skip middleware entirely, no `_meta` injection | Install Noop middleware and short-circuit inside | Zero-overhead default. Users who want propagation without span emission can implement a thin `TracerProvider` themselves. |
| `Attribute` set | `mcp.method`, `mcp.tool.name`, `mcp.session.id`, `mcp.error.code`, `mcp.tool.is_error` | Larger set (transport, request ID, latency hints) | Minimal high-signal set. `mcp.transport` deferred until a clean accessor exists. |

## Test plan

Added: ~28 assertions across 18 cases (one is a 3-sub-case `t.Run`). Removed / weakened: 0. New file — no existing tests touched.

Coverage matrix:

- Noop default + explicit Noop → no middleware install, no `_meta` injection.
- `_meta.traceparent` extraction → span parent matches.
- HTTP header bridge → fallback path picks up the bridged ctx.
- In-band wins over out-of-band.
- Malformed traceparent → dispatch succeeds, span has no parent (W3C drop).
- Span attribute set on `tools/call`.
- JSON-RPC error → `mcp.error.code` + `RecordError`.
- `ToolResult.IsError` → `mcp.tool.is_error="true"`.
- Outbound notification carries `_meta.traceparent` from active span (uses fake provider's `childTC` to prove the wrap reads post-`StartSpan` ctx).
- Outbound server-to-client request (`ctx.Sample`) carries `_meta.traceparent`.
- User middleware runs INSIDE the trace span.
- `injectTraceContextIntoParams` respects explicit handler-set `_meta.traceparent`; handles nil and non-object params; zero TraceContext passes through.
- `parseToolCallName` survives malformed input.
- `isToolErrorResult` covers value, pointer, map, and unmarshalable values.
- `withTraceContextFromHTTPHeaders` covers absent / valid / malformed header branches.
- Streamable HTTP integration: real HTTP POST with `traceparent` header bridges through to the span's parent.

Reference-impl comparison: deferred to P4 (real OTel adapter). The W3C structural validation is exercised by `core/trace_test.go` (P1).

Verification:

- `make test` (core / server / client / testutil): clean
- `go vet ./...`: clean
- `gofmt -l` on new and edited files: clean
- `go build ./...` on `ext/auth`, `ext/tasks`, `ext/ui`, `ext/skills`: clean (purely additive `core` API — no `tidy-all` required)

## Risk / blast radius

- **Behavior change on the default path:** none. The middleware is not installed when `WithTracerProvider` is unset or set to `core.NoopTracerProvider{}`.
- **Behavior change when a custom provider is set:** outbound notifications and server-to-client requests gain `_meta.traceparent` / `_meta.tracestate`. Audit-style `NotifyInterceptor` / `RequestInterceptor` registered by callers will see the augmented form — intentional.
- **HTTP transport:** `handlePost` does a header read on every POST and re-derives `r` with a new context only when `traceparent` is present. Zero allocation when the header is absent.
- **Be paranoid about:** ordering inside `dispatchWithOpts` — the trace middleware is appended AFTER the user-middleware loop. Re-check the install if the dispatch-chain refactor lands later. Spec-wise, double-check that an explicit handler-set `_meta.traceparent` on an outbound message is preserved (test `TestInjectTraceContextIntoParams_RespectsExplicitMeta` covers this).

## Out of scope (deliberately deferred)

- **P3 client-side spans** — separate branch on top of this. Outbound client `Call` wraps + inbound server-to-client request parent extraction.
- **P4 `ext/otel/` adapter** — separate `go.mod` module mirroring `ext/auth/` / `ext/tasks/` / `ext/ui/`. Without it, only hand-rolled `TracerProvider` implementations emit spans.
- **P5 `examples/otel/`** — minimal end-to-end walkthrough; lands once the adapter is available.
- **`mcp.transport` span attribute** — needs a clean transport-name accessor through dispatch; defer.
- **Outbound child-span emission** around `ctx.Sample` / `ctx.Elicit` — covered by P3 for symmetry with client-side spans.
- **Conformance suite `testconf-otel`** — issue 429.

## Downstream integration consumers unblocked by this PR

These three integration paths are listed on the umbrella issue 312 as soft-blocked on P2; once this lands they can ship spans that carry real parents:

- Issue 645 — `ext/auth` auth-validate span + outbound IdP traceparent propagation.
- Issue 646 — `ext/tasks` v2 task envelope trace plumbing across the async boundary.
- Issue 647 — `ext/ui` (apps) frame propagation + bridge handoff.

The events 407 stage-3 multi-replica fanout (issue 629) also benefits — the EventBus envelope already plumbs `core.MetaKey*` keys, but spans only show up once a `TracerProvider` is wired through the surface added here.
