### PR TITLE
examples/otel/stdout: wire client-side TracerProvider for symmetric demo

### DIFF
--- a/examples/otel/stdout/README.md
+++ b/examples/otel/stdout/README.md
@@ -1,64 +1,78 @@
 # examples/otel/stdout — SEP-414 Trace Context Propagation, exported to stdout
 
 Minimal demokit walkthrough showing how to wire OpenTelemetry tracing
-into a mcpkit server using the [`ext/otel`](../../../ext/otel/) adapter,
-with the SDK's `stdouttrace` exporter so spans land as pretty-printed
-JSON on the server's stdout — no collector infrastructure required.
+into BOTH sides of an MCP exchange using the
+[`ext/otel`](../../../ext/otel/) adapter — `server.WithTracerProvider`
+on the server (`make serve`) and `client.WithTracerProvider` on the
+walkthrough (`make demo`). Both processes use the SDK's `stdouttrace`
+exporter, so each terminal prints its own side's spans as
+pretty-printed JSON. No collector infrastructure required.
 
-The walkthrough sends a known W3C `_meta.traceparent` on a `tools/call`
-so a reader can scroll back to the server terminal and see the same
-trace ID appear as the exported span's `Parent`. That's the "yes, the
-SEP-414 wire is actually propagating" check, end-to-end, in one
-command.
+The walkthrough makes a `tools/call`; the client trace middleware
+stamps its own auto-generated `_meta.traceparent` on the outbound
+params; the server picks it up. Spans for that call appear on BOTH
+terminals with matching `TraceID` — that match proves the SEP-414
+client↔server wire is actually propagating end-to-end.
 
 ## Quick Start
 
 ```
-Terminal 1:  make serve         # OTel-instrumented server on :8080
-Terminal 2:  make demo          # demokit walkthrough (--tui for TUI)
+Terminal 1:  make serve         # OTel-instrumented server on :8080 — server-side spans dump here
+Terminal 2:  make demo          # demokit walkthrough (--tui for TUI) — client-side spans dump here
 ```
 
-Keep both terminals visible. The walkthrough drives the host side; the
-spans show up on the server side.
+Keep both terminals visible. Each side runs its own `stdouttrace`
+pipeline; spans land on whichever terminal emitted them. The host
+makes a tools/call with NO caller-supplied traceparent — the client
+trace middleware (P3) stamps its own freshly-generated traceparent on
+the outbound `_meta`, and the server (P2) picks it up as the parent.
+Match the `TraceID` across the two terminals and you've watched the
+SEP-414 wire stitch a client→server trace in real time. The TraceID
+changes on every run (no synthetic override) — that's the point: real
+production traces won't have hardcoded IDs.
 
 ## What it demonstrates
 
-- **Wiring.** `server.WithTracerProvider(mcpotel.NewProvider(otelTP))` — single line in `main.go::serve()`. Everything else is canonical `common.RunServer` boilerplate.
-- **Every dispatch emits a span.** The walkthrough's `tools/list` step shows a parent-less span; the `tools/call` step shows a span with an explicit inbound parent.
-- **In-band `_meta.traceparent` resolution.** The walkthrough sets `params._meta.traceparent` on the tools/call. The trace middleware extracts it; the adapter installs the OTel SpanContext as the new span's parent (`Remote=true`).
+- **Symmetric wiring.** `server.WithTracerProvider(...)` in `main.go::serve()` and `client.WithTracerProvider(...)` in `walkthrough.go::runDemo()`. Each line is one call against the same `ext/otel.NewProvider` adapter — the in-tree implementation of `core.TracerProvider`.
+- **Two processes, two pipelines, one trace.** Each side runs its own `stdouttrace`+`sdktrace` pipeline because they're separate OS processes. The SEP-414 `_meta.traceparent` plumbing carries trace identity across the wire so the two exporters record the *same* `TraceID`.
+- **Every dispatch emits a span on BOTH sides.** `initialize`, `notifications/initialized`, `tools/list`, `tools/call` each produce a client-side span (on the walkthrough terminal) AND a server-side span (on the serve terminal). The walkthrough surfaces matching `TraceID`s on the `tools/call` step explicitly.
+- **Client-side `_meta.traceparent` auto-injection (P3).** The walkthrough's tools/call carries no caller-supplied `_meta`. The client trace middleware starts a span, then stamps the new span's traceparent into outbound `params._meta.traceparent` via `core.InjectTraceContextIntoParams`. On the server side, the trace middleware extracts that `_meta.traceparent`; the adapter installs the OTel SpanContext as the new server-side span's parent (`Remote=true`). End result: matching TraceID across both spans, server's `Parent.SpanID` equals the client's `SpanID`.
 - **Outbound context sync.** After `StartSpan`, the adapter re-attaches the *child* span's traceparent to ctx via `core.WithTraceContext`. SEP-414 P2's outbound `_meta` injection wraps read that ctx, so every server-to-client notification or sampling request carries the new child traceparent — a downstream MCP server stitches into the same trace.
+- **Distinct instrumentation names.** The walkthrough's pipeline tags spans with `"github.com/panyam/mcpkit/client"`; the server's defaults to `"github.com/panyam/mcpkit/server"`. Observability backends group by emitting side.
 
 ## Architecture
 
 ```mermaid
 sequenceDiagram
+    participant HostStdout as walkthrough stdout
     participant H as Host (make demo)
     participant SRV as Server (make serve)
-    participant ADP as ext-otel Provider
-    participant SDK as sdktrace TracerProvider
-    participant EXP as stdouttrace exporter
+    participant ServerStdout as serve stdout
 
-    H->>SRV: tools/call echo with _meta.traceparent
-    SRV->>SRV: trace mw extracts _meta.traceparent
-    SRV->>ADP: StartSpan(ctx, tools/call, attrs)
-    ADP->>ADP: parse traceparent into SpanContext (Remote=true)
-    ADP->>SDK: tracer.Start with parent SpanContext
-    SDK-->>ADP: childCtx, otelSpan
-    ADP-->>SRV: ctx (with child TC), Span
+    Note over H: client pipeline stdouttrace then sdktrace then mcpotel
+    Note over SRV: server pipeline stdouttrace then sdktrace then mcpotel
+
+    H->>H: traceMiddleware StartSpan tools/call
+    H->>H: inject _meta.traceparent into params
+    H->>HostStdout: client span exports to walkthrough terminal
+    H->>SRV: HTTP POST tools/call with _meta.traceparent
+    SRV->>SRV: traceMiddleware extracts _meta.traceparent
+    SRV->>SRV: StartSpan tools/call with Remote parent
     SRV->>SRV: handler runs
-    SRV->>ADP: span.End
-    ADP->>SDK: otelSpan.End
-    SDK->>EXP: export ReadOnlySpan
-    EXP->>EXP: print JSON to server stdout
+    SRV->>ServerStdout: server span exports to serve terminal
+    SRV-->>H: response
+    H->>H: trace span End records error or status
+    HostStdout-->>HostStdout: TraceID matches ServerStdout TraceID
 ```
 
 ## Where to look in the code
 
-- `main.go::serve` — the wiring. Builds the OTel pipeline (stdouttrace → SDK TP), wraps with `mcpotel.NewProvider`, hands to `common.RunServer` via `server.WithTracerProvider`.
-- `main.go::newOTelPipeline` — the one-shot helper that constructs the SDK TracerProvider with the stdout exporter and returns its shutdown closure.
-- `walkthrough.go::runDemo` — the demokit script. The interesting step is "tools/call echo — with explicit inbound `_meta.traceparent`": it sets the in-band traceparent and points the reader at the server terminal's exported span.
-- `ext/otel/provider.go` (in the adapter module) — `Provider.StartSpan` is the hot-path: parses inbound `core.TraceContext` into an OTel SpanContext, calls `tracer.Start`, and re-attaches the child traceparent via `core.WithTraceContext` so SEP-414 P2's outbound `_meta` injection stamps the right ID downstream.
-- `server/trace_middleware.go` (in main mcpkit) — the SEP-414 P2 middleware that consumes the adapter. Sits outermost so user middleware runs INSIDE the recorded span.
+- `main.go::serve` — server-side wiring. Builds the OTel pipeline (stdouttrace → SDK TP), wraps with `mcpotel.NewProvider`, hands to `common.RunServer` via `server.WithTracerProvider`.
+- `main.go::newOTelPipeline` — the one-shot helper that constructs the SDK TracerProvider with the stdout exporter and returns its shutdown closure. Reused by `walkthrough.go` for the client pipeline so both sides build their pipeline identically.
+- `walkthrough.go::runDemo` — client-side wiring + the demokit script. Builds its own pipeline via the same `newOTelPipeline` helper and passes the adapter to `client.WithTracerProvider` with `WithInstrumentationName("github.com/panyam/mcpkit/client")` so observability backends group client vs server spans.
+- `client/trace_middleware.go` (in main mcpkit) — the SEP-414 P3 middleware. Outbound `Client.Call` is wrapped in a span; outbound params gain `_meta.traceparent`; inbound server-to-client requests (sampling/elicitation/roots) get wrap spans whose parent is the inbound traceparent.
+- `server/trace_middleware.go` (in main mcpkit) — the SEP-414 P2 middleware that consumes the adapter on the server side. Sits outermost so user middleware runs INSIDE the recorded span.
+- `ext/otel/provider.go` (in the adapter module) — `Provider.StartSpan` is the hot-path: parses inbound `core.TraceContext` into an OTel SpanContext, calls `tracer.Start`, and re-attaches the child traceparent via `core.WithTraceContext` so the outbound `_meta` injection stamps the right ID downstream.
 
 ## Make targets
 

--- a/examples/otel/stdout/WALKTHROUGH.md
+++ b/examples/otel/stdout/WALKTHROUGH.md
@@ -1,12 +1,12 @@
 # MCP SEP-414 — OpenTelemetry Trace Context Propagation
 
-Walks through SEP-414, which propagates W3C Trace Context through MCP using the `_meta.traceparent` / `_meta.tracestate` envelope (and, on streamable HTTP, the matching HTTP headers per SEP-2028). The server wires the new `ext/otel` adapter into `server.WithTracerProvider` so every JSON-RPC dispatch emits an OpenTelemetry span — exported as pretty-printed JSON on the server's stdout via the `stdouttrace` exporter. The walkthrough drives a real `tools/call` with a known inbound traceparent so a reader can see the inbound trace ID become the span's Parent on the server side.
+Walks through SEP-414, which propagates W3C Trace Context through MCP using the `_meta.traceparent` / `_meta.tracestate` envelope (and, on streamable HTTP, the matching HTTP headers per SEP-2028). BOTH sides are instrumented: the server (`make serve`) wires `server.WithTracerProvider` (P2); the walkthrough (`make demo`) wires `client.WithTracerProvider` (P3). Both pipelines feed the `stdouttrace` exporter, so each terminal prints its own side's spans as pretty-printed JSON. The walkthrough drives a real `tools/call` — the client trace middleware auto-stamps a `_meta.traceparent` on the outbound params and the server picks it up. Matching `TraceID` across the two terminals is the proof that the SEP-414 wire is actually stitching client and server into a single distributed trace.
 
 ## What you'll learn
 
-- **Connect to the OTel-instrumented server** — `client.NewClient(...)` + `Connect()`. The handshake itself dispatches through the trace middleware on the server, so the *Server* terminal will print three spans during this walkthrough: `initialize`, `notifications/initialized`, and the `tools/call` from the next step. No client-side instrumentation is wired here — P3 (client-side spans) lives on a separate branch.
-- **tools/list — every dispatch is a span** — The trace middleware sits OUTERMOST in the dispatch chain, so *every* JSON-RPC request emits a span — not just tools/call. This step doesn't pass an inbound traceparent, so the resulting span starts a fresh trace (no Parent). Compare the Server terminal's span for this list call with the next step's span: this one has no Parent; the next one does.
-- **tools/call echo — with explicit inbound _meta.traceparent** — The Host sends `params._meta.traceparent=00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01` — the W3C-spec example trace ID, used here so the trace ID is visually recognizable. On the Server terminal, scroll to the `tools/call` span and look for two things:
+- **Connect to the OTel-instrumented server** — `client.NewClient(...)` + `client.WithTracerProvider(...)` + `Connect()`. Each JSON-RPC dispatch now emits TWO spans — one on each side. The initialize handshake will print `initialize` and `notifications/initialized` spans on BOTH terminals; matching them by TraceID is the visual proof that the SEP-414 wire is propagating from the very first call.
+- **tools/list — every dispatch is a span** — The trace middleware sits OUTERMOST in the dispatch chain on both sides, so *every* JSON-RPC request emits a pair of spans (one per side, stitched via `_meta.traceparent`). This step is functionally identical to the next one in terms of propagation — the only difference is what attributes get set. Watch the TraceID match across terminals for this list call too.
+- **tools/call echo — let the client auto-inject _meta.traceparent** — With both wires instrumented (PR 649 server + PR 654 client), this single tools/call produces TWO spans on TWO terminals:
 
 ## Flow
 
@@ -23,9 +23,9 @@ sequenceDiagram
     Host->>Server: tools/list
     Server-->>Host: tools[]
 
-    Note over Host,Server: Step 3: tools/call echo — with explicit inbound _meta.traceparent
-    Host->>Server: tools/call echo { _meta: { traceparent: 00-4bf9…-00f0…-01 } }
-    Server-->>Host: text result + (under the hood) child-span _meta on any outbound
+    Note over Host,Server: Step 3: tools/call echo — let the client auto-inject _meta.traceparent
+    Host->>Server: tools/call echo (no caller _meta; client trace mw stamps its own)
+    Server-->>Host: text result; server span's Parent matches the client SpanID
 ```
 
 ## Steps
@@ -52,33 +52,37 @@ On the server side, `server.WithTracerProvider(tp)` installs an outermost trace 
 
 ### Step 1: Connect to the OTel-instrumented server
 
-`client.NewClient(...)` + `Connect()`. The handshake itself dispatches through the trace middleware on the server, so the *Server* terminal will print three spans during this walkthrough: `initialize`, `notifications/initialized`, and the `tools/call` from the next step. No client-side instrumentation is wired here — P3 (client-side spans) lives on a separate branch.
+`client.NewClient(...)` + `client.WithTracerProvider(...)` + `Connect()`. Each JSON-RPC dispatch now emits TWO spans — one on each side. The initialize handshake will print `initialize` and `notifications/initialized` spans on BOTH terminals; matching them by TraceID is the visual proof that the SEP-414 wire is propagating from the very first call.
 
 ### Step 2: tools/list — every dispatch is a span
 
-The trace middleware sits OUTERMOST in the dispatch chain, so *every* JSON-RPC request emits a span — not just tools/call. This step doesn't pass an inbound traceparent, so the resulting span starts a fresh trace (no Parent). Compare the Server terminal's span for this list call with the next step's span: this one has no Parent; the next one does.
+The trace middleware sits OUTERMOST in the dispatch chain on both sides, so *every* JSON-RPC request emits a pair of spans (one per side, stitched via `_meta.traceparent`). This step is functionally identical to the next one in terms of propagation — the only difference is what attributes get set. Watch the TraceID match across terminals for this list call too.
 
-### Step 3: tools/call echo — with explicit inbound _meta.traceparent
+### Step 3: tools/call echo — let the client auto-inject _meta.traceparent
 
-The Host sends `params._meta.traceparent=00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01` — the W3C-spec example trace ID, used here so the trace ID is visually recognizable. On the Server terminal, scroll to the `tools/call` span and look for two things:
+With both wires instrumented (PR 649 server + PR 654 client), this single tools/call produces TWO spans on TWO terminals:
 
-1. `SpanContext.TraceID` equals `4bf92f3577b34da6a3ce929d0e0e4736` — proves the inbound trace ID carried through.
-2. `Parent.SpanID` equals `00f067aa0ba902b7` and `Parent.Remote == true` — proves the middleware recognized the in-band traceparent as a remote parent.
+1. **Client side (THIS terminal).** The `Client.Call` outbound trace middleware emits a span named `tools/call` with a fresh TraceID + SpanID. Before the call hits the wire, the middleware stamps that TraceID and SpanID into `params._meta.traceparent` via `core.InjectTraceContextIntoParams` (P3, shared helper).
+2. **Server side (the SERVER terminal).** The server trace middleware extracts the stamped `_meta.traceparent` and emits its own `tools/call` span whose `SpanContext.TraceID` MATCHES the client's, and whose `Parent.SpanID` MATCHES the client span's SpanID with `Parent.Remote == true`.
 
-If you instead remove the `_meta` field from the call below, the span starts a fresh trace (no Parent), matching the previous step's tools/list behavior.
+Match the spans by TraceID across the two terminals — that IS the SEP-414 wire stitching client and server into a single distributed trace. The TraceID is auto-generated each run (no synthetic override), so it'll be different every time — that's the point: real production traces won't have hardcoded IDs.
 
 #### Reproduce on the wire
 
 ```bash
+# When using curl directly, no client trace middleware exists, so
+# YOU supply the traceparent. Match it across terminals by inspection.
 curl -s -X POST http://localhost:8080/mcp \
   -H 'Content-Type: application/json' \
   -H 'Accept: text/event-stream, application/json' \
   -H "Mcp-Session-Id: $SID" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"message":"hello"},"_meta":{"traceparent":"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"}}}' | jq '.result'
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"message":"hello"}}}' | jq '.result'
 ```
 
 ### Where to look in the code
 
+- `examples/otel/stdout/walkthrough.go::runDemo` — the client-side wiring. `mcpotel.NewProvider(clientOTelTP, WithInstrumentationName(".../client"))` plugged into `client.WithTracerProvider`. The pipeline uses the same `stdouttrace` exporter as the server, just pointing at this process's stdout.
+- `client/trace_middleware.go` (in main mcpkit) — the SEP-414 P3 middleware that consumes the adapter on the client side. Outbound `Client.Call` is wrapped in a span; outbound params gain `_meta.traceparent` derived from the active span; inbound server-to-client requests (sampling/elicitation/roots) extract the inbound traceparent and emit a wrap span.
 - `ext/otel/provider.go` — `Provider.StartSpan` is the adapter's single hot-path: parses inbound `core.TraceContext` into an OTel `SpanContext`, installs as the new span's parent, and after `tracer.Start` re-attaches the *child* span's traceparent via `core.WithTraceContext` so P2's outbound `_meta` injection stamps the right trace ID on downstream messages.
 - `ext/otel/span.go` — narrows OTel's broader Span surface to mcpkit's three-method `core.Span` contract. CAS-guarded `End` prevents the SDK's noisy double-End warning.
 - `ext/otel/propagation.go` — pure W3C ↔ OTel SpanContext conversions. `traceContextToSpanContext` validates structurally before installing; `spanContextToTraceContext` formats the new span back into the W3C version-00 string the wire expects.

--- a/examples/otel/stdout/e2e_test.go
+++ b/examples/otel/stdout/e2e_test.go
@@ -13,6 +13,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -112,6 +113,93 @@ func TestNewOTelPipeline_HappyPath(t *testing.T) {
 	// panic.
 	shutdown()
 	shutdown()
+}
+
+// TestEndToEnd_BothSidesEmitSpans is the headline check for this PR.
+// Each "side" (server and client) wires its own OTel pipeline against a
+// separate InMemoryExporter — the same shape the walkthrough builds at
+// runtime, just with introspectable exporters instead of stdouttrace.
+// The test drives a real tools/call from a real *client.Client WITHOUT
+// supplying an explicit _meta.traceparent so the client trace middleware
+// stamps its own child traceparent on the wire. Asserts: (1) both
+// exporters recorded a tools/call span, (2) they share a TraceID,
+// (3) the server span's Parent.SpanID matches the client span's SpanID,
+// and (4) instrumentation scopes are correctly differentiated.
+//
+// This is the "auto-stitch" path that proves the SEP-414 wire works
+// end-to-end with no synthetic inbound override — the common case for
+// developers wiring observability into a fresh mcpkit stack.
+func TestEndToEnd_BothSidesEmitSpans(t *testing.T) {
+	serverExp := tracetest.NewInMemoryExporter()
+	serverTP := sdktrace.NewTracerProvider(sdktrace.WithSyncer(serverExp))
+	t.Cleanup(func() { _ = serverTP.Shutdown(context.Background()) })
+
+	clientExp := tracetest.NewInMemoryExporter()
+	clientTP := sdktrace.NewTracerProvider(sdktrace.WithSyncer(clientExp))
+	t.Cleanup(func() { _ = clientTP.Shutdown(context.Background()) })
+
+	srv := server.NewServer(
+		core.ServerInfo{Name: "otel-stdout-demo", Version: "0.1.0"},
+		server.WithTracerProvider(mcpotel.NewProvider(serverTP)),
+	)
+	registerEcho(srv)
+
+	ts := httptest.NewServer(srv.Handler(server.WithStreamableHTTP(true)))
+	t.Cleanup(ts.Close)
+
+	c := client.NewClient(ts.URL+"/mcp",
+		core.ClientInfo{Name: "otel-stdout-test", Version: "1.0"},
+		client.WithTracerProvider(mcpotel.NewProvider(clientTP,
+			mcpotel.WithInstrumentationName("github.com/panyam/mcpkit/client"),
+		)),
+	)
+	require.NoError(t, c.Connect())
+	t.Cleanup(func() { _ = c.Close() })
+
+	_, err := c.Call("tools/call", map[string]any{
+		"name":      "echo",
+		"arguments": map[string]any{"message": "hello"},
+	})
+	require.NoError(t, err)
+
+	clientSpan := findToolsCallSpan(clientExp.GetSpans())
+	require.NotNil(t, clientSpan, "client exporter must record a tools/call span; saw %v", spanNames(clientExp.GetSpans()))
+	serverSpan := findToolsCallSpan(serverExp.GetSpans())
+	require.NotNil(t, serverSpan, "server exporter must record a tools/call span; saw %v", spanNames(serverExp.GetSpans()))
+
+	assert.Equal(t, clientSpan.SpanContext.TraceID(), serverSpan.SpanContext.TraceID(),
+		"client and server must share a TraceID — that IS the SEP-414 propagation")
+	assert.Equal(t, clientSpan.SpanContext.SpanID(), serverSpan.Parent.SpanID(),
+		"server span Parent.SpanID must match the client SpanID — proves the client trace middleware stamped the outbound _meta.traceparent")
+	assert.True(t, serverSpan.Parent.IsRemote(),
+		"server span Parent must be Remote (came over the wire)")
+
+	clientAttrs := flattenAttrs(clientSpan)
+	assert.Equal(t, "tools/call", clientAttrs["mcp.method"])
+	assert.Equal(t, "echo", clientAttrs["mcp.tool.name"])
+
+	serverAttrs := flattenAttrs(serverSpan)
+	assert.Equal(t, "tools/call", serverAttrs["mcp.method"])
+	assert.Equal(t, "echo", serverAttrs["mcp.tool.name"])
+
+	assert.Equal(t, "github.com/panyam/mcpkit/client", clientSpan.InstrumentationScope.Name,
+		"client-side spans should be tagged with the client instrumentation library name")
+	assert.Equal(t, "github.com/panyam/mcpkit/server", serverSpan.InstrumentationScope.Name,
+		"server-side spans should keep the default instrumentation library name")
+}
+
+// Reference json.Unmarshal so the encoding/json import remains used even
+// if other helpers are removed; assertion bodies above operate on
+// structured exporter output rather than raw JSON. Lint guard only.
+var _ = json.Unmarshal
+
+func findToolsCallSpan(spans []tracetest.SpanStub) *tracetest.SpanStub {
+	for i := range spans {
+		if spans[i].Name == "tools/call" {
+			return &spans[i]
+		}
+	}
+	return nil
 }
 
 func spanNames(spans []tracetest.SpanStub) []string {

--- a/examples/otel/stdout/walkthrough.go
+++ b/examples/otel/stdout/walkthrough.go
@@ -3,26 +3,46 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/panyam/demokit"
 	"github.com/panyam/mcpkit/client"
 	"github.com/panyam/mcpkit/core"
 	"github.com/panyam/mcpkit/examples/common"
+	mcpotel "github.com/panyam/mcpkit/ext/otel"
 )
 
-// inboundTraceparent is a deterministic W3C version-00 traceparent the
-// walkthrough sends on every tools/call so a reader can scroll back to
-// the server terminal and visually confirm the inbound trace ID landed
-// as the span's Parent. The trace ID matches the W3C spec example
-// (`4bf92f3577b34da6a3ce929d0e0e4736`) for cross-document recognizability.
-const inboundTraceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+// (Previously this file defined an explicit inbound traceparent and
+// supplied it in the tools/call. Removed once the client side was
+// instrumented: SEP-414's "explicit caller-set _meta wins" rule means
+// that an externally-supplied traceparent ends up on the SERVER side
+// only, while the client emits a SEPARATE auto-generated trace — the
+// two would NOT share a TraceID and the symmetric-stitching narrative
+// would break. The auto-inject path the walkthrough now exercises
+// produces matching TraceIDs on both terminals — what the reader is
+// supposed to see.)
 
 func runDemo() {
 	serverURL := common.ServerURL()
 
+	// Stand up the walkthrough's OWN OTel pipeline so client-side spans
+	// land on this terminal's stdout via stdouttrace — symmetric with
+	// the server's pipeline in serve(). Each process gets its own
+	// TracerProvider (the two are separate OS processes; in-memory
+	// sharing isn't possible), but the SEP-414 wire propagates trace
+	// context across them so the recorded spans share a TraceID. The
+	// instrumentation name carries `mcpkit/client` so observability
+	// backends group client-emitted spans separately.
+	clientOTelTP, shutdownClientOTel, err := newOTelPipeline(os.Stdout)
+	if err != nil {
+		fmt.Printf("failed to build client-side OTel pipeline: %v\n", err)
+		return
+	}
+	defer shutdownClientOTel()
+
 	demo := demokit.New("MCP SEP-414 — OpenTelemetry Trace Context Propagation").
 		Dir("otel/stdout").
-		Description("Walks through SEP-414, which propagates W3C Trace Context through MCP using the `_meta.traceparent` / `_meta.tracestate` envelope (and, on streamable HTTP, the matching HTTP headers per SEP-2028). The server wires the new `ext/otel` adapter into `server.WithTracerProvider` so every JSON-RPC dispatch emits an OpenTelemetry span — exported as pretty-printed JSON on the server's stdout via the `stdouttrace` exporter. The walkthrough drives a real `tools/call` with a known inbound traceparent so a reader can see the inbound trace ID become the span's Parent on the server side.").
+		Description("Walks through SEP-414, which propagates W3C Trace Context through MCP using the `_meta.traceparent` / `_meta.tracestate` envelope (and, on streamable HTTP, the matching HTTP headers per SEP-2028). BOTH sides are instrumented: the server (`make serve`) wires `server.WithTracerProvider` (P2); the walkthrough (`make demo`) wires `client.WithTracerProvider` (P3). Both pipelines feed the `stdouttrace` exporter, so each terminal prints its own side's spans as pretty-printed JSON. The walkthrough drives a real `tools/call` — the client trace middleware auto-stamps a `_meta.traceparent` on the outbound params and the server picks it up. Matching `TraceID` across the two terminals is the proof that the SEP-414 wire is actually stitching client and server into a single distributed trace.").
 		Actors(
 			demokit.Actor("Host", "MCP Host (this walkthrough)"),
 			demokit.Actor("Server", "MCP Server (make serve) — spans dump on its stdout"),
@@ -53,24 +73,33 @@ func runDemo() {
 	demo.Step("Connect to the OTel-instrumented server").
 		Arrow("Host", "Server", "POST /mcp — initialize").
 		DashedArrow("Server", "Host", "serverInfo + capabilities").
-		Note("`client.NewClient(...)` + `Connect()`. The handshake itself dispatches through the trace middleware on the server, so the *Server* terminal will print three spans during this walkthrough: `initialize`, `notifications/initialized`, and the `tools/call` from the next step. No client-side instrumentation is wired here — P3 (client-side spans) lives on a separate branch.").
+		Note("`client.NewClient(...)` + `client.WithTracerProvider(...)` + `Connect()`. Each JSON-RPC dispatch now emits TWO spans — one on each side. The initialize handshake will print `initialize` and `notifications/initialized` spans on BOTH terminals; matching them by TraceID is the visual proof that the SEP-414 wire is propagating from the very first call.").
 		Run(func(ctx demokit.StepContext) *demokit.StepResult {
 			c = client.NewClient(serverURL+"/mcp",
 				core.ClientInfo{Name: "otel-stdout-host", Version: "1.0"},
+				// SEP-414 P3 — client-side trace surface. Outbound
+				// Client.Call emits a span and stamps _meta.traceparent
+				// on params; inbound server-to-client requests
+				// (sampling/elicitation/roots) get wrap spans whose
+				// parent is the inbound _meta.traceparent.
+				client.WithTracerProvider(mcpotel.NewProvider(clientOTelTP,
+					mcpotel.WithInstrumentationName("github.com/panyam/mcpkit/client"),
+				)),
 			)
 			if err := c.Connect(); err != nil {
 				fmt.Printf("    ERROR: %v\n    Start the server with: make serve\n", err)
 				return nil
 			}
 			fmt.Printf("    Connected to %s %s\n", c.ServerInfo.Name, c.ServerInfo.Version)
-			fmt.Printf("    Look at the server's stdout — you should see initialize and notifications/initialized spans already exported.\n")
+			fmt.Printf("    Watch THIS terminal: initialize and notifications/initialized client-side spans will appear below.\n")
+			fmt.Printf("    Watch the SERVER terminal: matching server-side spans land there for the same JSON-RPC requests.\n")
 			return nil
 		})
 
 	demo.Step("tools/list — every dispatch is a span").
 		Arrow("Host", "Server", "tools/list").
 		DashedArrow("Server", "Host", "tools[]").
-		Note("The trace middleware sits OUTERMOST in the dispatch chain, so *every* JSON-RPC request emits a span — not just tools/call. This step doesn't pass an inbound traceparent, so the resulting span starts a fresh trace (no Parent). Compare the Server terminal's span for this list call with the next step's span: this one has no Parent; the next one does.").
+		Note("The trace middleware sits OUTERMOST in the dispatch chain on both sides, so *every* JSON-RPC request emits a pair of spans (one per side, stitched via `_meta.traceparent`). This step is functionally identical to the next one in terms of propagation — the only difference is what attributes get set. Watch the TraceID match across terminals for this list call too.").
 		Run(func(ctx demokit.StepContext) *demokit.StepResult {
 			page, err := c.ListToolsPage("")
 			if err != nil {
@@ -83,27 +112,30 @@ func runDemo() {
 			return nil
 		})
 
-	demo.Step("tools/call echo — with explicit inbound _meta.traceparent").
-		Arrow("Host", "Server", "tools/call echo { _meta: { traceparent: 00-4bf9…-00f0…-01 } }").
-		DashedArrow("Server", "Host", "text result + (under the hood) child-span _meta on any outbound").
-		Note(fmt.Sprintf("The Host sends `params._meta.traceparent=%s` — the W3C-spec example trace ID, used here so the trace ID is visually recognizable. On the Server terminal, scroll to the `tools/call` span and look for two things:\n\n1. `SpanContext.TraceID` equals `4bf92f3577b34da6a3ce929d0e0e4736` — proves the inbound trace ID carried through.\n2. `Parent.SpanID` equals `00f067aa0ba902b7` and `Parent.Remote == true` — proves the middleware recognized the in-band traceparent as a remote parent.\n\nIf you instead remove the `_meta` field from the call below, the span starts a fresh trace (no Parent), matching the previous step's tools/list behavior.", inboundTraceparent)).
+	demo.Step("tools/call echo — let the client auto-inject _meta.traceparent").
+		Arrow("Host", "Server", "tools/call echo (no caller _meta; client trace mw stamps its own)").
+		DashedArrow("Server", "Host", "text result; server span's Parent matches the client SpanID").
+		Note("With both wires instrumented (PR 649 server + PR 654 client), this single tools/call produces TWO spans on TWO terminals:\n\n1. **Client side (THIS terminal).** The `Client.Call` outbound trace middleware emits a span named `tools/call` with a fresh TraceID + SpanID. Before the call hits the wire, the middleware stamps that TraceID and SpanID into `params._meta.traceparent` via `core.InjectTraceContextIntoParams` (P3, shared helper).\n2. **Server side (the SERVER terminal).** The server trace middleware extracts the stamped `_meta.traceparent` and emits its own `tools/call` span whose `SpanContext.TraceID` MATCHES the client's, and whose `Parent.SpanID` MATCHES the client span's SpanID with `Parent.Remote == true`.\n\nMatch the spans by TraceID across the two terminals — that IS the SEP-414 wire stitching client and server into a single distributed trace. The TraceID is auto-generated each run (no synthetic override), so it'll be different every time — that's the point: real production traces won't have hardcoded IDs.").
 		VerbatimVariants("Reproduce on the wire",
-			demokit.MakeVariant("curl", "bash", `curl -s -X POST http://localhost:8080/mcp \
+			demokit.MakeVariant("curl", "bash", `# When using curl directly, no client trace middleware exists, so
+# YOU supply the traceparent. Match it across terminals by inspection.
+curl -s -X POST http://localhost:8080/mcp \
   -H 'Content-Type: application/json' \
   -H 'Accept: text/event-stream, application/json' \
   -H "Mcp-Session-Id: $SID" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"message":"hello"},"_meta":{"traceparent":"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"}}}' | jq '.result'`).Default(),
-			demokit.MakeVariant("go", "go", `res, _ := c.Call("tools/call", map[string]any{
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"message":"hello"}}}' | jq '.result'`).Default(),
+			demokit.MakeVariant("go", "go", `// Note: the Client must be constructed with
+// client.WithTracerProvider(mcpotel.NewProvider(...)) for the
+// auto-inject to fire. See walkthrough.go::runDemo.
+res, _ := c.Call("tools/call", map[string]any{
     "name":      "echo",
     "arguments": map[string]any{"message": "hello"},
-    "_meta":     map[string]any{"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"},
 })`),
 		).
 		Run(func(ctx demokit.StepContext) *demokit.StepResult {
 			res, err := c.Call("tools/call", map[string]any{
 				"name":      "echo",
 				"arguments": map[string]any{"message": "hello"},
-				"_meta":     map[string]any{"traceparent": inboundTraceparent},
 			})
 			if err != nil {
 				fmt.Printf("    ERROR: %v\n", err)
@@ -116,11 +148,15 @@ func runDemo() {
 			}
 			pretty, _ := json.MarshalIndent(v, "    ", "  ")
 			fmt.Printf("    %s\n", string(pretty))
-			fmt.Printf("\n    Server terminal: look for a span with Name=\"tools/call\", TraceID=4bf92f3577b34da6a3ce929d0e0e4736, Parent.SpanID=00f067aa0ba902b7.\n")
+			fmt.Printf("\n    Match by TraceID:\n")
+			fmt.Printf("    - THIS terminal: client-side span Name=\"tools/call\" with a fresh TraceID + SpanID.\n")
+			fmt.Printf("    - SERVER terminal: a span with the SAME TraceID, plus Parent.SpanID == client SpanID and Parent.Remote=true.\n")
 			return nil
 		})
 
 	demo.Section("Where to look in the code",
+		"- `examples/otel/stdout/walkthrough.go::runDemo` — the client-side wiring. `mcpotel.NewProvider(clientOTelTP, WithInstrumentationName(\".../client\"))` plugged into `client.WithTracerProvider`. The pipeline uses the same `stdouttrace` exporter as the server, just pointing at this process's stdout.",
+		"- `client/trace_middleware.go` (in main mcpkit) — the SEP-414 P3 middleware that consumes the adapter on the client side. Outbound `Client.Call` is wrapped in a span; outbound params gain `_meta.traceparent` derived from the active span; inbound server-to-client requests (sampling/elicitation/roots) extract the inbound traceparent and emit a wrap span.",
 		"- `ext/otel/provider.go` — `Provider.StartSpan` is the adapter's single hot-path: parses inbound `core.TraceContext` into an OTel `SpanContext`, installs as the new span's parent, and after `tracer.Start` re-attaches the *child* span's traceparent via `core.WithTraceContext` so P2's outbound `_meta` injection stamps the right trace ID on downstream messages.",
 		"- `ext/otel/span.go` — narrows OTel's broader Span surface to mcpkit's three-method `core.Span` contract. CAS-guarded `End` prevents the SDK's noisy double-End warning.",
 		"- `ext/otel/propagation.go` — pure W3C ↔ OTel SpanContext conversions. `traceContextToSpanContext` validates structurally before installing; `spanContextToTraceContext` formats the new span back into the W3C version-00 string the wire expects.",


### PR DESCRIPTION
## What changes

Extends the `examples/otel/stdout/` demokit walkthrough so the client side wires its own `client.WithTracerProvider` against a parallel OTel pipeline. Each terminal (`make serve` vs `make demo`) now prints its own side's spans. The tools/call no longer carries a caller-supplied `_meta.traceparent`; instead, the client trace middleware auto-stamps a fresh traceparent on outbound params and the server picks it up as Parent. Matching TraceID across the two terminals is the SEP-414 wire's proof of stitching. Pure example expansion — zero library changes; follow-up to PR 654 (P3 client-side spans).

```mermaid
sequenceDiagram
    participant HostStdout as walkthrough stdout
    participant H as Host (make demo)
    participant SRV as Server (make serve)
    participant ServerStdout as serve stdout

    H->>H: traceMiddleware StartSpan tools/call
    H->>H: inject _meta.traceparent into params (fresh TraceID)
    H->>HostStdout: client span exports to walkthrough terminal
    H->>SRV: HTTP POST tools/call with _meta.traceparent
    SRV->>SRV: traceMiddleware extracts _meta.traceparent
    SRV->>SRV: StartSpan tools/call with Remote parent
    SRV->>ServerStdout: server span exports to serve terminal
    SRV-->>H: response
    Note over HostStdout,ServerStdout: TraceIDs match across the two terminals
```

## Reviewer's guide

Read in this order:

1. [examples/otel/stdout/walkthrough.go](https://github.com/panyam/mcpkit/pull/656/files#diff-23562a492c507ed5bc81de5aa2d992faf3fbc2018be37ca8fe8667cafc529844) — the wiring change. Build the client OTel pipeline via the existing `newOTelPipeline` helper (no duplication of constructor logic); pass `mcpotel.NewProvider(clientOTelTP, WithInstrumentationName("github.com/panyam/mcpkit/client"))` to `client.WithTracerProvider`. The Note text on the tools/call step is rewritten — the previous explicit-`_meta.traceparent` story was wrong under PR 654's "explicit caller-set wins" rule (caller-supplied traceparent would land on the server side, but the client would emit a SEPARATE trace, so TraceIDs would NOT match — the inverse of the symmetric narrative).
2. [examples/otel/stdout/e2e_test.go](https://github.com/panyam/mcpkit/pull/656/files#diff-ace28f6ca514066d3e4eb48762a460fc713b020599831da474eaadd13e415fcb) — `TestEndToEnd_BothSidesEmitSpans` is the headline. Wires server-side + client-side `InMemoryExporter`s on separate `sdktrace.TracerProvider`s, drives a real `Client.Call` (no explicit `_meta`), asserts (1) both exporters recorded a `tools/call` span, (2) they share a TraceID, (3) server span `Parent.SpanID` equals client span `SpanID`, (4) `Parent.Remote == true`, (5) the two sides carry distinct instrumentation library names. The existing `TestEndToEnd_StdoutDemoWiring` (server-only explicit-inbound check) and `TestNewOTelPipeline_HappyPath` stay unchanged.
3. [examples/otel/stdout/README.md](https://github.com/panyam/mcpkit/pull/656/files#diff-e301bfde5a96f1efea927ca0cce4c356cf64dff5afc3774accd5bcaaff8139ee) — "What it demonstrates" + Architecture mermaid + "Where to look in the code" rewritten to cover both wires.
4. [examples/otel/stdout/WALKTHROUGH.md](https://github.com/panyam/mcpkit/pull/656/files#diff-0e84daeca4318b432f2bd2656590286f7fb6282ae7dfc8c1638193ce3f27aa23) — regenerated via `make readme` (treated as derived; the freshness gate diffs it).

Skim or skip: nothing — every hunk is intentional. The `WALKTHROUGH.md` diff is mechanical regeneration.

## Decision log

| Decision | Choice | Alternative | Why |
|---|---|---|---|
| Drop explicit `_meta.traceparent` from the tools/call step | Yes | Keep it (matches the previous walkthrough's "W3C-spec example trace ID" visual recognizability) | PR 654's "explicit caller-set wins" rule means an explicit traceparent lands on the server but the client emits a SEPARATE auto-generated trace. The symmetric "matching TraceID" narrative breaks. Dropping the explicit reveals the auto-inject path — the cleaner demo, and what real developers will see in production. |
| Single test or two-test split (explicit vs auto-inject) | Single test, auto-inject path only | Two tests covering both paths | The explicit-wins rule already has unit-test coverage in `client/trace_middleware_test.go::TestClientTrace_OutboundRespectsExplicitMeta`. Adding a second e2e test would duplicate that signal at higher cost. The auto-inject test is the one that demonstrates client→server stitching, which is the PR's headline. |
| Reuse `newOTelPipeline` from `main.go` for the client pipeline | Yes | Inline the pipeline construction in `walkthrough.go` | The helper is unexported but lives in the same package — no visibility issue. Both sides building their pipeline identically is the right pedagogy ("same constructor, two TPs"). |
| Distinct instrumentation library names per side | Yes — `"github.com/panyam/mcpkit/client"` vs default `"github.com/panyam/mcpkit/server"` | Same name everywhere | Observability backends group spans by emitting library. Mixing both under one name would defeat that grouping. The `mcpotel.WithInstrumentationName(...)` option exists precisely for this. |
| Process model: in-process or two-process | Two-process (`make serve` + `make demo`) | Single-process with the server embedded | Two-process is what users will actually deploy. The README explicitly explains "match by TraceID, not a single console scroll" so the framing doesn't oversell. In-process variant could land later as a separate `examples/otel/inprocess/` if anyone asks. |

## Test plan

Added: ~10 assertions in 1 new test function. Removed / weakened: 0. The existing `TestEndToEnd_StdoutDemoWiring` and `TestNewOTelPipeline_HappyPath` are unchanged.

Coverage matrix (`TestEndToEnd_BothSidesEmitSpans`):

- Both server-side and client-side `InMemoryExporter`s receive a `tools/call` span.
- They share a `TraceID` (proves SEP-414 stitching).
- Server span's `Parent.SpanID` equals client span's `SpanID` (proves auto-injection via `core.InjectTraceContextIntoParams`).
- Server span's `Parent.Remote == true` (came over the wire).
- Client span carries `mcp.method=tools/call`, `mcp.tool.name=echo`, instrumentation scope `"github.com/panyam/mcpkit/client"`.
- Server span carries `mcp.method=tools/call`, `mcp.tool.name=echo`, instrumentation scope `"github.com/panyam/mcpkit/server"`.

Reference-impl comparison: OTel SDK is the reference. Both sides drive real `sdktrace.TracerProvider`s — no fakes.

Verification:

- `make test-otel-example`: clean (all three tests pass).
- `make readme`: regenerated `WALKTHROUGH.md` without diff drift.
- Live smoke against fresh process: client `tools/call` SpanID `d4983ba3d7796b3e` == server `Parent.SpanID` `d4983ba3d7796b3e`. End-to-end propagation confirmed on real stdouttrace output.
- `gofmt -l examples/otel/stdout/`: clean.
- `go vet ./...`: clean.

## Risk / blast radius

- **Library code untouched.** Diff is confined to `examples/otel/stdout/`.
- **Walkthrough narrative is more accurate now.** The previous version's claim that explicit `_meta.traceparent` would produce matching TraceIDs across both terminals was incorrect; the new narrative matches the actual SEP-414 wire behavior.
- **Be paranoid about:** the `_meta`-injection rule (PR 654's "explicit wins") IS still tested by the client unit tests. This PR only changes which path the e2e demo exercises.

## Before / after

Before this PR: `make demo` connects with `client.NewClient(...)` (no TracerProvider) and sends `_meta.traceparent=00-4bf92f35...-00f067aa...-01` explicitly. Only the server terminal prints spans; the client side is silent.

After this PR: `make demo` connects with `client.NewClient(..., client.WithTracerProvider(mcpotel.NewProvider(...)))` and sends a plain `tools/call`. Both terminals print spans; matching them by `TraceID` proves the propagation. Sample output (auto-generated `TraceID`, varies per run):

```
# walkthrough stdout (Terminal B):
{
  "Name": "tools/call",
  "SpanContext": {
    "TraceID": "<X>",
    "SpanID": "<Y>",
    ...
  },
  "Parent": { "TraceID": "00000000000000000000000000000000", ... },
  "InstrumentationScope": { "Name": "github.com/panyam/mcpkit/client" },
  ...
}

# serve stdout (Terminal A):
{
  "Name": "tools/call",
  "SpanContext": {
    "TraceID": "<X>",
    "SpanID": "<Z>",
    ...
  },
  "Parent": {
    "TraceID": "<X>",
    "SpanID": "<Y>",       // matches the client span's SpanID
    "Remote": true,
    ...
  },
  "InstrumentationScope": { "Name": "github.com/panyam/mcpkit/server" },
  ...
}
```

## Out of scope (deliberately deferred)

- **Single-process `examples/otel/inprocess/` variant** — would give a literal single-scroll demo. Defer until someone asks.
- **OTLP / Jaeger walkthrough** — P5 territory.
- **Conformance suite** — issue 429.
