### PR TITLE
events: raise defaultWebhookTTL into spec envelope (1h, [5m, 24h]) + clamp

### DIFF
--- a/examples/events/discord/Makefile
+++ b/examples/events/discord/Makefile
@@ -48,7 +48,7 @@ test-race:
 # POSIX-only (uses lsof, xargs -r, bash trap, kill -9). On Windows, run the
 # server and the Python driver manually:
 #   1. Manually kill anything bound to TTL_PORT / TTL_HOOK_PORT
-#   2. go run . -addr :18080 -webhook-ttl 3s
+#   2. go run . -addr :18080 -webhook-ttl 3s -unsafe-webhook-ttl-bypass
 #   3. python3 test_ttl.py --mcp http://localhost:18080/mcp \
 #        --inject-url http://localhost:18080/inject --port 19999 --ttl 3 --duration 8
 TTL_PORT       ?= 18080
@@ -65,7 +65,7 @@ test-ttl:
 	@bash -c '\
 	  set -e; \
 	  go build -o /tmp/discord-events-ttl-bin . ; \
-	  /tmp/discord-events-ttl-bin --serve -addr :$(TTL_PORT) -webhook-ttl $(TTL_SECONDS)s > /tmp/discord-events-ttl.log 2>&1 & \
+	  /tmp/discord-events-ttl-bin --serve -addr :$(TTL_PORT) -webhook-ttl $(TTL_SECONDS)s -unsafe-webhook-ttl-bypass > /tmp/discord-events-ttl.log 2>&1 & \
 	  SERVER_PID=$$!; \
 	  trap "kill -9 $$SERVER_PID 2>/dev/null || true; lsof -ti :$(TTL_PORT) 2>/dev/null | xargs -r kill -9 2>/dev/null || true; rm -f /tmp/discord-events-ttl-bin" EXIT; \
 	  for i in 1 2 3 4 5 6 7 8 9 10; do \

--- a/examples/events/discord/main.go
+++ b/examples/events/discord/main.go
@@ -46,7 +46,8 @@ func main() {
 func serve() {
 	addr := flag.String("addr", ":8080", "listen address")
 	token := flag.String("token", "", "Discord bot token (omit for test mode)")
-	whTTL := flag.Duration("webhook-ttl", 0, "override webhook subscription TTL (default 60s; useful for driving the SDK refresh path in tests)")
+	whTTL := flag.Duration("webhook-ttl", 0, "override webhook subscription TTL (default 1h; library clamps to spec envelope [5m, 24h] unless -unsafe-webhook-ttl-bypass is also set)")
+	whTTLBypass := flag.Bool("unsafe-webhook-ttl-bypass", false, "disable the [5m, 24h] envelope clamp on -webhook-ttl; required for the make test-ttl walkthrough (3s TTL). Production deployments MUST NOT use this.")
 	whHeaderMode := flag.String("webhook-header-mode", "standard", "webhook header style: standard | mcp")
 	whSuspendThreshold := flag.Int("webhook-suspend-threshold", 0, "override consecutive-failures count that flips a webhook target to Active=false (default 5; lower to 1 for demoing the suspend transition without waiting 5×retry-cycles)")
 	flag.CommandLine.Parse(demokit.FilterArgs(os.Args[1:],
@@ -54,6 +55,7 @@ func serve() {
 		demokit.ValueFlag("--url"),
 		demokit.ValueFlag("--token"),
 		demokit.ValueFlag("--webhook-ttl"),
+		demokit.BoolFlag("--unsafe-webhook-ttl-bypass"),
 		demokit.ValueFlag("--webhook-header-mode"),
 		demokit.ValueFlag("--webhook-suspend-threshold"),
 		demokit.ValueFlag("--addr"),
@@ -76,6 +78,9 @@ func serve() {
 	if *whTTL > 0 {
 		whOpts = append(whOpts, events.WithWebhookTTL(*whTTL))
 		log.Printf("[server] webhook TTL overridden to %s", *whTTL)
+	}
+	if *whTTLBypass {
+		whOpts = append(whOpts, events.WithUnsafeWebhookTTLBypass())
 	}
 	if *whSuspendThreshold > 0 {
 		whOpts = append(whOpts, events.WithWebhookSuspendThreshold(*whSuspendThreshold))
@@ -285,12 +290,13 @@ func hasOAuthEnv() bool {
 // UnsafeAnonymousPrincipal demo escape.
 //
 // Recognized env vars:
-//   OAUTH_ISSUER    REQUIRED. The OIDC issuer URL.
-//                   For Keycloak: http://localhost:8081/realms/<realm>
-//   OAUTH_JWKS_URL  Optional. Defaults to <issuer>/protocol/openid-connect/certs
-//                   (Keycloak convention). Override for non-Keycloak providers.
-//   OAUTH_AUDIENCE  Optional. Defaults to "mcp-events". Tokens MUST have
-//                   this audience claim to be accepted.
+//
+//	OAUTH_ISSUER    REQUIRED. The OIDC issuer URL.
+//	                For Keycloak: http://localhost:8081/realms/<realm>
+//	OAUTH_JWKS_URL  Optional. Defaults to <issuer>/protocol/openid-connect/certs
+//	                (Keycloak convention). Override for non-Keycloak providers.
+//	OAUTH_AUDIENCE  Optional. Defaults to "mcp-events". Tokens MUST have
+//	                this audience claim to be accepted.
 func tryEnableAuth() *auth.JWTValidator {
 	issuer := os.Getenv("OAUTH_ISSUER")
 	if issuer == "" {

--- a/experimental/ext/events/DEPLOYMENT.md
+++ b/experimental/ext/events/DEPLOYMENT.md
@@ -96,7 +96,7 @@ Worst-case wall clock for a fully-failing delivery: roughly `5s + 0.5s + 5s + 1s
 
 ## TTL refresh as keepalive
 
-Webhook subscriptions are soft state. The default TTL is 60 seconds (`WithWebhookTTL` overrides). Subscribers MUST re-subscribe before the TTL expires or the registry evicts them and deliveries stop.
+Webhook subscriptions are soft state. The default TTL is 1 hour, clamped to the spec envelope **[5 min, 24 h]** at `WithWebhookTTL` registration time (out-of-envelope values are clamped and logged). Tests and demos that need sub-minimum TTLs to drive SDK refresh behavior pass `WithUnsafeWebhookTTLBypass` — production deployments MUST NOT use the bypass. Subscribers MUST re-subscribe before the TTL expires or the registry evicts them and deliveries stop.
 
 The shipped client SDKs handle this automatically:
 

--- a/experimental/ext/events/README.md
+++ b/experimental/ext/events/README.md
@@ -136,7 +136,7 @@ type PollResult struct {
 
 ## Webhook delivery
 
-- TTL-based soft state with automatic expiry (default 60s, override via `WithWebhookTTL`)
+- TTL-based soft state with automatic expiry (default 1h within the spec envelope [5min, 24h]; override via `WithWebhookTTL`; sub-minimum TTLs for tests/demos require `WithUnsafeWebhookTTLBypass`)
 - Retry with exponential backoff on 5xx (no retry on 4xx)
 - Basic SSRF validation on callback URLs
 - Pluggable signature format (see below)

--- a/experimental/ext/events/clients/go/eventsclient_test.go
+++ b/experimental/ext/events/clients/go/eventsclient_test.go
@@ -116,7 +116,9 @@ func TestSubscribe_PreservesCallerSuppliedSecret(t *testing.T) {
 // scheduled refresh) within a short test window. Validates the SDK actually
 // runs the loop and respects RefreshFactor.
 func TestSubscribe_AutoRefreshFiresWithinShortTTL(t *testing.T) {
-	c, _, _ := stack(t, events.WithWebhookTTL(2*time.Second))
+	// 2s TTL is below the spec envelope floor (5min); bypass the clamp so
+	// the test exercises the SDK refresh path on a feasible cadence.
+	c, _, _ := stack(t, events.WithWebhookTTL(2*time.Second), events.WithUnsafeWebhookTTLBypass())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -308,7 +310,9 @@ func TestReceiver_DropsOnFullChannel(t *testing.T) {
 // parent context cancellation. Without this an SDK consumer that cancels
 // its context would still see refresh traffic until Stop was called.
 func TestSubscribe_StopsOnContextCancel(t *testing.T) {
-	c, _, _ := stack(t, events.WithWebhookTTL(2*time.Second))
+	// 2s TTL is below the spec envelope floor (5min); bypass the clamp so
+	// the test exercises the SDK refresh path on a feasible cadence.
+	c, _, _ := stack(t, events.WithWebhookTTL(2*time.Second), events.WithUnsafeWebhookTTLBypass())
 
 	ctx, cancel := context.WithCancel(context.Background())
 

--- a/experimental/ext/events/webhook.go
+++ b/experimental/ext/events/webhook.go
@@ -15,8 +15,33 @@ import (
 	"time"
 )
 
+// Webhook TTL spec envelope. WG guidance (Peter, 2026-06-05 in
+// #triggers-events-wg) is that webhook subscription TTLs must fall in
+// [5min, 24h]: shorter creates excessive refresh churn for a long-
+// running production receiver, longer is a soft-state leak. The
+// envelope is enforced by WithWebhookTTL at registration time —
+// out-of-range values are clamped with a logged warning. Tests / demos
+// that legitimately need a sub-minimum TTL (driving the SDK's
+// auto-refresh path on a fast cadence) opt out via
+// WithUnsafeWebhookTTLBypass(), mirroring the UnsafeAnonymousPrincipal
+// precedent.
 const (
-	defaultWebhookTTL              = 60 * time.Second // 1 minute for POC (production: longer)
+	// DefaultWebhookTTL is the soft-state expiry the registry applies to
+	// every subscription when no explicit TTL is configured. Sits inside
+	// the spec envelope.
+	DefaultWebhookTTL = 1 * time.Hour
+
+	// MinWebhookTTL is the spec envelope floor. WithWebhookTTL clamps
+	// any positive smaller value up to this floor unless
+	// WithUnsafeWebhookTTLBypass is also set.
+	MinWebhookTTL = 5 * time.Minute
+
+	// MaxWebhookTTL is the spec envelope ceiling. WithWebhookTTL clamps
+	// any larger value down to this ceiling. The bypass does not raise
+	// the ceiling — operator intent above 24h is rare enough to handle
+	// with a code change.
+	MaxWebhookTTL = 24 * time.Hour
+
 	defaultWebhookMaxBodyBytes     = 256 * 1024       // spec §"Webhook Security" → "Delivery profile" L487
 	defaultWebhookSuspendThreshold = 5                // N consecutive failures before Active=false
 	defaultWebhookSuspendWindow    = 10 * time.Minute // sliding window over which failures accumulate
@@ -50,15 +75,40 @@ func WithWebhookOnRemove(h WebhookOnRemoveHook) WebhookOption {
 	}
 }
 
-// WithWebhookTTL overrides the registry's subscription TTL. Useful for tests
-// (drive the SDK's TTL refresh behavior in seconds rather than minutes) and
-// for deployments that want longer-lived subscriptions. Pass <=0 to keep
-// the default of 60s.
+// WithWebhookTTL overrides the registry's subscription TTL within the
+// spec envelope [MinWebhookTTL, MaxWebhookTTL]. Out-of-envelope values
+// are clamped at registration time and a warning is logged via the
+// registry's logger (defaults to log.Printf). Pass <=0 to keep the
+// default of DefaultWebhookTTL.
+//
+// For tests and demos that legitimately need a sub-minimum TTL (driving
+// the SDK's auto-refresh path on a fast cadence), also pass
+// WithUnsafeWebhookTTLBypass() to disable the clamp. Production
+// deployments MUST NOT use the bypass.
 func WithWebhookTTL(ttl time.Duration) WebhookOption {
 	return func(r *WebhookRegistry) {
 		if ttl > 0 {
 			r.ttl = ttl
+			r.ttlExplicit = true
 		}
+	}
+}
+
+// WithUnsafeWebhookTTLBypass disables the [MinWebhookTTL, MaxWebhookTTL]
+// envelope clamp on WithWebhookTTL. After this option the registry
+// honors any positive TTL the operator supplied verbatim — including
+// sub-minimum values needed by SDK refresh-loop tests and the
+// discord/test-ttl walkthrough step.
+//
+// Production deployments MUST NOT use this option. Out-of-envelope TTLs
+// either burn through refresh capacity (too short) or leak soft state
+// (too long); the envelope exists for a reason. The constructor logs a
+// stark warning when the bypass is active so an accidental production
+// use shows up in logs immediately, mirroring the UnsafeAnonymousPrincipal
+// posture.
+func WithUnsafeWebhookTTLBypass() WebhookOption {
+	return func(r *WebhookRegistry) {
+		r.ttlClampBypass = true
 	}
 }
 
@@ -240,6 +290,8 @@ type WebhookRegistry struct {
 	targets              map[string]WebhookTarget // keyed by string(canonicalKey)
 	client               *http.Client
 	ttl                  time.Duration
+	ttlExplicit          bool // operator passed WithWebhookTTL (drives clamp decision)
+	ttlClampBypass       bool // WithUnsafeWebhookTTLBypass — disables clamp
 	headerMode           WebhookHeaderMode
 	allowPrivateNetworks bool          // when false (default), Dialer.Control rejects private/loopback IPs (spec §"Webhook Security" → "SSRF prevention" L464)
 	maxBodyBytes         int           // outbound POST body cap (spec §"Webhook Security" → "Delivery profile" L487); default 256 KiB
@@ -276,6 +328,37 @@ type WebhookRegistry struct {
 // is the only caller — it points the resolver at the source map so the
 // registry stays decoupled from EventDef. Safe to call after the
 // registry has been handed out; the field is mu-guarded.
+// applyTTLClamp enforces the [MinWebhookTTL, MaxWebhookTTL] envelope on
+// the TTL the operator configured via WithWebhookTTL. Called from
+// NewWebhookRegistry after all options have applied so the bypass +
+// explicit-TTL flags are known. Logs at most one clamp warning per
+// constructor invocation; the bypass logs its own stark warning so an
+// accidental production bypass is loud.
+func (r *WebhookRegistry) applyTTLClamp() {
+	if r.ttlClampBypass {
+		r.logf("[events] WARNING: WithUnsafeWebhookTTLBypass set — webhook TTL clamp DISABLED. "+
+			"Production deployments MUST NOT use this option; the [%s, %s] envelope exists for a reason.",
+			MinWebhookTTL, MaxWebhookTTL)
+		return
+	}
+	if !r.ttlExplicit {
+		// Default TTL (DefaultWebhookTTL = 1h) is in-envelope by
+		// construction; no clamp + no warning.
+		return
+	}
+	switch {
+	case r.ttl < MinWebhookTTL:
+		r.logf("[events] WARNING: WithWebhookTTL=%s is below the spec envelope floor (%s); clamping up. "+
+			"Use WithUnsafeWebhookTTLBypass for tests / demos that need a sub-minimum TTL.",
+			r.ttl, MinWebhookTTL)
+		r.ttl = MinWebhookTTL
+	case r.ttl > MaxWebhookTTL:
+		r.logf("[events] WARNING: WithWebhookTTL=%s is above the spec envelope ceiling (%s); clamping down.",
+			r.ttl, MaxWebhookTTL)
+		r.ttl = MaxWebhookTTL
+	}
+}
+
 func (r *WebhookRegistry) SetDefResolver(fn func(eventName string) EventDef) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -318,13 +401,19 @@ func (r *WebhookRegistry) fireOnRemove(t WebhookTarget) {
 }
 
 // NewWebhookRegistry creates an empty registry with the documented defaults:
-// 5-second HTTP timeout, 60-second TTL, StandardWebhooks signing,
+// 5-second HTTP timeout, DefaultWebhookTTL (1h) TTL inside the
+// [MinWebhookTTL, MaxWebhookTTL] envelope, StandardWebhooks signing,
 // SSRF-strict outbound dialing (loopback / private / link-local rejected).
 // Override via the With* options.
+//
+// When WithWebhookTTL is passed with an out-of-envelope value, the
+// constructor clamps it to the nearest envelope edge and logs a warning.
+// WithUnsafeWebhookTTLBypass disables the clamp for tests / demos —
+// see its docs for when (not) to use it.
 func NewWebhookRegistry(opts ...WebhookOption) *WebhookRegistry {
 	r := &WebhookRegistry{
 		targets:          make(map[string]WebhookTarget),
-		ttl:              defaultWebhookTTL,
+		ttl:              DefaultWebhookTTL,
 		headerMode:       StandardWebhooks,
 		maxBodyBytes:     defaultWebhookMaxBodyBytes,
 		suspendThreshold: defaultWebhookSuspendThreshold,
@@ -334,6 +423,7 @@ func NewWebhookRegistry(opts ...WebhookOption) *WebhookRegistry {
 	for _, o := range opts {
 		o(r)
 	}
+	r.applyTTLClamp()
 	// http.Client wired AFTER options apply so the Dialer.Control callback
 	// can read the resolved allowPrivateNetworks setting. Spec
 	// §"Webhook Security" → "SSRF prevention" L464.
@@ -439,7 +529,6 @@ func (r *WebhookRegistry) dialContextForTest() func(ctx context.Context, network
 func (r *WebhookRegistry) setLogfForTest(f func(format string, args ...any)) {
 	r.logf = f
 }
-
 
 // RegisterParams bundles the inputs for Register. A struct rather than
 // a positional list because EventName / Principal / Params took the

--- a/experimental/ext/events/webhook_ttl_test.go
+++ b/experimental/ext/events/webhook_ttl_test.go
@@ -1,0 +1,131 @@
+package events
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// withCapturingLogger replaces the registry's logger with a capture
+// function and returns the captured lines after the test. Tests inject
+// this via the package-internal logf field rather than going through a
+// public option, so we can pin the warning shape without exposing
+// logger-injection as a supported API.
+func withCapturingLogger(r *WebhookRegistry) func() []string {
+	var mu sync.Mutex
+	var lines []string
+	r.logf = func(format string, args ...any) {
+		mu.Lock()
+		defer mu.Unlock()
+		lines = append(lines, format)
+	}
+	return func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		out := make([]string, len(lines))
+		copy(out, lines)
+		return out
+	}
+}
+
+func TestWebhookTTL_DefaultIsOneHour(t *testing.T) {
+	r := NewWebhookRegistry()
+	assert.Equal(t, time.Hour, r.ttl, "default TTL must be DefaultWebhookTTL = 1h")
+	assert.Equal(t, time.Hour, DefaultWebhookTTL)
+}
+
+func TestWebhookTTL_InEnvelopeNoClamp(t *testing.T) {
+	// Construct an empty registry, attach the capturing logger BEFORE
+	// applying options so the constructor's logf field stays set to our
+	// capture function.
+	r := &WebhookRegistry{
+		ttl:              DefaultWebhookTTL,
+		headerMode:       StandardWebhooks,
+		maxBodyBytes:     defaultWebhookMaxBodyBytes,
+		suspendThreshold: defaultWebhookSuspendThreshold,
+		suspendWindow:    defaultWebhookSuspendWindow,
+	}
+	getLines := withCapturingLogger(r)
+	WithWebhookTTL(30 * time.Minute)(r)
+	r.applyTTLClamp()
+	assert.Equal(t, 30*time.Minute, r.ttl, "in-envelope TTL must be honored verbatim")
+	for _, line := range getLines() {
+		assert.NotContains(t, line, "WARNING", "no warning should fire for in-envelope TTL")
+	}
+}
+
+func TestWebhookTTL_ClampLowToMinimum(t *testing.T) {
+	r := &WebhookRegistry{
+		ttl:              DefaultWebhookTTL,
+		headerMode:       StandardWebhooks,
+		maxBodyBytes:     defaultWebhookMaxBodyBytes,
+		suspendThreshold: defaultWebhookSuspendThreshold,
+		suspendWindow:    defaultWebhookSuspendWindow,
+	}
+	getLines := withCapturingLogger(r)
+	WithWebhookTTL(30 * time.Second)(r)
+	r.applyTTLClamp()
+	assert.Equal(t, MinWebhookTTL, r.ttl, "sub-floor TTL must clamp UP to MinWebhookTTL (5m)")
+	require.NotEmpty(t, getLines(), "clamp must log a warning")
+	require.True(t, anyLineContains(getLines(), "below the spec envelope floor"),
+		"warning must explain the floor was breached; got %v", getLines())
+}
+
+func TestWebhookTTL_ClampHighToMaximum(t *testing.T) {
+	r := &WebhookRegistry{
+		ttl:              DefaultWebhookTTL,
+		headerMode:       StandardWebhooks,
+		maxBodyBytes:     defaultWebhookMaxBodyBytes,
+		suspendThreshold: defaultWebhookSuspendThreshold,
+		suspendWindow:    defaultWebhookSuspendWindow,
+	}
+	getLines := withCapturingLogger(r)
+	WithWebhookTTL(48 * time.Hour)(r)
+	r.applyTTLClamp()
+	assert.Equal(t, MaxWebhookTTL, r.ttl, "above-ceiling TTL must clamp DOWN to MaxWebhookTTL (24h)")
+	require.NotEmpty(t, getLines(), "clamp must log a warning")
+	require.True(t, anyLineContains(getLines(), "above the spec envelope ceiling"),
+		"warning must explain the ceiling was breached; got %v", getLines())
+}
+
+func TestWebhookTTL_UnsafeBypassDisablesClamp(t *testing.T) {
+	r := &WebhookRegistry{
+		ttl:              DefaultWebhookTTL,
+		headerMode:       StandardWebhooks,
+		maxBodyBytes:     defaultWebhookMaxBodyBytes,
+		suspendThreshold: defaultWebhookSuspendThreshold,
+		suspendWindow:    defaultWebhookSuspendWindow,
+	}
+	getLines := withCapturingLogger(r)
+	WithUnsafeWebhookTTLBypass()(r)
+	WithWebhookTTL(2 * time.Second)(r)
+	r.applyTTLClamp()
+	assert.Equal(t, 2*time.Second, r.ttl, "bypass must honor any positive TTL verbatim")
+	require.True(t, anyLineContains(getLines(), "WithUnsafeWebhookTTLBypass"),
+		"bypass must log a stark warning so an accidental production use is visible; got %v", getLines())
+	// Bypass warning fires; the clamp warnings must NOT also fire.
+	assert.False(t, anyLineContains(getLines(), "below the spec envelope floor"),
+		"floor-clamp warning must NOT fire when bypass is active")
+}
+
+func TestWebhookTTL_NewWebhookRegistry_OptionPathClampsAndLogs(t *testing.T) {
+	// End-to-end: NewWebhookRegistry (not just the apply method) must
+	// run the clamp via the option path. Captures via the standard log
+	// package isn't easy, so just verify the resulting ttl.
+	r := NewWebhookRegistry(WithWebhookTTL(30 * time.Second))
+	assert.Equal(t, MinWebhookTTL, r.ttl,
+		"NewWebhookRegistry must clamp WithWebhookTTL even though the constructor's logger is log.Printf")
+}
+
+func anyLineContains(lines []string, needle string) bool {
+	for _, l := range lines {
+		if strings.Contains(l, needle) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## What changes

Moves the webhook subscription TTL from the POC 60s default to the production-credible 1h, inside an enforced spec envelope of `[MinWebhookTTL = 5min, MaxWebhookTTL = 24h]`. `WithWebhookTTL` clamps any out-of-envelope value at registration time with a logged warning. Adds `WithUnsafeWebhookTTLBypass()` as the escape hatch for tests and demos that legitimately need a sub-minimum TTL — mirrors the existing `UnsafeAnonymousPrincipal` precedent.

Exported constants (`DefaultWebhookTTL` / `MinWebhookTTL` / `MaxWebhookTTL`) so operator code can assert against the envelope without hardcoding.

Closes 625.

## Reviewer's guide

Read in this order:

1. [experimental/ext/events/webhook.go](https://github.com/panyam/mcpkit/pull/657/files#diff-f61c2bd42ae83936aba2fe7dab3bcda1606ca810bd7263d9afbe42147f9c8f5a) — start here. Three new exported constants, the clamp logic on `WithWebhookTTL` (via the new `ttlExplicit` field), the new `WithUnsafeWebhookTTLBypass` option, and the `applyTTLClamp` method called once from `NewWebhookRegistry`. Pay attention to: the bypass logs a stark warning at construction (same posture as `UnsafeAnonymousPrincipal`), and the clamp warning fires once per `NewWebhookRegistry` call so spam isn't a concern.
2. [experimental/ext/events/webhook_ttl_test.go](https://github.com/panyam/mcpkit/pull/657/files#diff-e92ea4afb190b3072c948696229965f7d9d0566d416eecf08e53fb06b7b400e5) — 6 tests pinning the envelope behavior: default is 1h, in-envelope no clamp, clamp-low (30s → 5min) with floor warning, clamp-high (48h → 24h) with ceiling warning, bypass disables clamp with bypass warning, NewWebhookRegistry option-path also clamps. Uses an injectable logger (the package-internal `logf` field) so warning shapes are pinned without exposing logger injection as a public API.
3. [experimental/ext/events/clients/go/eventsclient_test.go](https://github.com/panyam/mcpkit/pull/657/files#diff-3713ec86d780f18142504489aa607a78335890e41bf69511ae973b82374e3321) — two existing 2s-TTL tests now also pass `WithUnsafeWebhookTTLBypass()` so they exercise the refresh loop without the clamp pushing TTL to 5min.
4. [examples/events/discord/main.go](https://github.com/panyam/mcpkit/pull/657/files#diff-5cbb8fdf1f9bb7258f24dd292a3952928578bba5ea5500842626f3fe696f0c19) + [examples/events/discord/Makefile](https://github.com/panyam/mcpkit/pull/657/files#diff-8163d3a957a853020194a8cefd819d5e6d9fccd1155464794984f1ab3858b265) — new `-unsafe-webhook-ttl-bypass` flag wired; `test-ttl` Makefile target uses it so the 3s-TTL refresh-cycle walkthrough keeps working.
5. [experimental/ext/events/README.md](https://github.com/panyam/mcpkit/pull/657/files#diff-9222f2c9c82e15be71e1b286719f2d44d107c3ea315805c64c3d617ab960d4b3) + [experimental/ext/events/DEPLOYMENT.md](https://github.com/panyam/mcpkit/pull/657/files#diff-c75bb17c9b123df102747038873bda868dc6e576a2eba2b10b4fd373a8a8f0b3) — TTL doc lines updated; the 60s mentions are gone.

Skim: nothing else changes.

## Test counts

- **Added: 7 assertions** across 6 new test functions covering default + clamp-low + clamp-high + in-envelope + bypass + option-path.
- **Touched: 2 existing tests** — each gets one additional option call (no assertion change).
- **Removed / weakened: 0.**

`make test` (repo-wide) green. Events sub-module suite green (75s). clients/go sub-module green. `make tidy-all` clean.

## Decision log

| Decision | Chose | Over | Why |
|---|---|---|---|
| Clamp behavior | Hard clamp + warn | SHOULD with config override | Issue's stated default; spec-strict by default; out-of-envelope TTL is operator error worth flagging |
| Escape hatch | New `WithUnsafeWebhookTTLBypass()` option | No escape (refactor tests + delete `test-ttl`) | Existing `TestSubscribe_AutoRefreshFiresWithinShortTTL` and discord `test-ttl` demonstrate real refresh behavior only observable on sub-minute cadence; deleting them loses coverage |
| Constant names | Exported `DefaultWebhookTTL` / `MinWebhookTTL` / `MaxWebhookTTL` | Unexported package-local | Operator code may want to assert against them; minor surface bump, large discoverability win |
| Warning rate | Per-clamp (one per `NewWebhookRegistry`) | Once-only globally | Each `NewWebhookRegistry` typically does one clamp; spam isn't a concern |
| Discord demo wiring | New `-unsafe-webhook-ttl-bypass` flag | Auto-bypass when TTL < envelope minimum | Explicit user opt-in is the precedent set by `UnsafeAnonymousPrincipal`; avoids "did I accidentally bypass?" debugging |
| `ttlExplicit` field on the registry | Track explicit option vs default | Skip the check and clamp the default too | `DefaultWebhookTTL` is in-envelope by construction; no clamp + no warning fires for the common case |

## Risk / blast radius

- **Affects:** webhook TTL default + behavior. Two existing tests get one additional option call; discord/test-ttl target gets a new flag. No behavior change for production deployments that use the default TTL.
- **Behavior change:** any deployment that explicitly passed `WithWebhookTTL` with a sub-5min value silently gets clamped on the next upgrade — they should pass `WithUnsafeWebhookTTLBypass()` too if the short TTL was intentional. The warning fires loudly at startup so this isn't quiet.
- **Be paranoid about:** the clamp warning's wording (read by operators), the bypass warning's stark posture (must match `UnsafeAnonymousPrincipal` so accidental production usage is loud).

## Before / after

```
$ go test ./... -run "TestWebhookTTL" -v
=== RUN   TestWebhookTTL_DefaultIsOneHour
--- PASS
=== RUN   TestWebhookTTL_InEnvelopeNoClamp
--- PASS
=== RUN   TestWebhookTTL_ClampLowToMinimum
--- PASS
=== RUN   TestWebhookTTL_ClampHighToMaximum
--- PASS
=== RUN   TestWebhookTTL_UnsafeBypassDisablesClamp
--- PASS
=== RUN   TestWebhookTTL_NewWebhookRegistry_OptionPathClampsAndLogs
[events] WARNING: WithWebhookTTL=30s is below the spec envelope floor (5m0s); clamping up. ...
--- PASS
PASS
```

## Out of scope (deliberately deferred)

- 635 quota wire-shape consistency — separate follow-up, unrelated to TTL
- whole-enchilada walkthrough surfacing the envelope — not in scope; can land in stage-2 or stage-4 walkthrough polish
- TTL hint negotiation in `events/subscribe` — not in scope per issue 625
