### PR TITLE
events: extract WebhookStore seam from WebhookRegistry (in-memory default preserved)

### DIFF
--- a/experimental/ext/events/README.md
+++ b/experimental/ext/events/README.md
@@ -140,6 +140,7 @@ type PollResult struct {
 - Retry with exponential backoff on 5xx (no retry on 4xx)
 - Basic SSRF validation on callback URLs
 - Pluggable signature format (see below)
+- Pluggable subscription storage via `WithWebhookStore` (default in-memory; Postgres lands in issue 630). See [`STORAGE_SEAMS.md`](STORAGE_SEAMS.md) for the convention every storage seam in this package follows.
 
 ```go
 webhooks := events.NewWebhookRegistry(

--- a/experimental/ext/events/STORAGE_SEAMS.md
+++ b/experimental/ext/events/STORAGE_SEAMS.md
@@ -1,0 +1,95 @@
+# Storage seam convention — `experimental/ext/events/`
+
+This file pins the conventions every storage seam in `experimental/ext/events/` follows. The first seam (`WebhookStore`, this PR) establishes the shape; sibling PRs add `QuotaStore` (issue 626), `CursorStore` (issue 628), and the `SubscriptionIndex` storage seam (issue 631) under the same rules. The single source of truth — when in doubt, follow `webhook_store.go`'s precedent.
+
+## Why seams
+
+The MCP Events extension's reference deployment (the `whole-enchilada` demo, issue 407) needs the registry's subscription table, quota counters, cursor positions, and subscription index shared across N replicas. The library's POC implementation kept all of that as in-memory Go maps. Seaming those concerns out into interfaces is the prerequisite for multi-replica state-sharing — Postgres lands in issue 630, Redis lands in 634.
+
+## One interface per concern — no umbrella
+
+Each storage concern has its own narrow interface:
+
+| Interface | Concern | Lands in |
+|---|---|---|
+| `WebhookStore` | Webhook subscription CRUD (canonical key → target) | this PR (627) |
+| `QuotaStore` | Quota counters per (principal, eventType) | 626 |
+| `CursorStore` | Per-subscription persisted cursors | 628 |
+| `SubscriptionIndex` storage seam | Subscription-id ↔ deliver-fn lookup table | 631 |
+
+No umbrella `EventsStore` interface. The reasons:
+
+- **Backends pick the subset they need.** A Redis backend implements `QuotaStore` only (Redis pubsub + counters); a Postgres backend implements `WebhookStore` + `QuotaStore` + `CursorStore` (durable rows); a future Kafka backend might implement the SubscriptionIndex seam alone. An umbrella interface forces every backend to either implement everything or carry no-op methods that lie about their semantics.
+- **Method conflicts dodge.** Different storage concerns name their primary methods the same way (`GetX` / `SaveX` / `ListX`). One umbrella interface either ends up with `GetWebhookByKey` / `GetQuotaByPrincipalEvent` / etc. (verbose) or generic `Get` / `Save` (untyped). Narrow interfaces keep the types crisp.
+- **Independent evolution.** Adding a method to `WebhookStore` doesn't ripple through unrelated backends.
+
+## API shape: gRPC-style request / response
+
+Every method on every storage seam follows the same convention:
+
+```go
+Method(ctx context.Context, req XRequest) (XResponse, error)
+```
+
+- **`ctx` is the first parameter on every method.** Threads cancellation, deadlines, and trace context. The in-memory implementation may ignore it; persistent backends honor it for I/O cancellation and for OTel span propagation (the SEP-414 P1 surface in `core.TracerProvider` is already threaded through ctx, so a Postgres backend gets distributed tracing for free).
+- **Request / Response types are named per-operation** (`GetWebhookRequest` / `GetWebhookResponse`, `SaveWebhookRequest` / `SaveWebhookResponse`, etc.). Each type lives in the same file as the interface. Adding a field (pagination tokens, version stamps, hints) doesn't change the method signature — it's backwards-compatible.
+- **Error semantics:** the `error` return is reserved for **storage-layer failures** (connection drops, transaction conflicts, serialization issues). Application-level absence ("the row didn't exist") is reported via `Found` / `Removed` booleans on the Response — callers never interpret error sentinels for routine flow control.
+- **Forward compatibility with gRPC.** If a future deployment puts a store behind a gRPC service, the interface translates 1:1 to a `.proto` service definition. No reshaping at the consumer.
+
+### Operation verb conventions
+
+Per-seam operations use these verbs uniformly:
+
+| Verb | Semantics |
+|---|---|
+| `GetX` | Return one entity by primary key. Found=false when absent; no error. |
+| `SaveX` | Upsert one entity. Overwrites without conflict. SaveResponse may grow a version field later. |
+| `DeleteX` | Remove one entity by key. Found=false when absent; no error. Removed entity is returned for hook firing. |
+| `ListX` | Return a snapshot slice. Request is empty today; pagination fields land here later. |
+| `CountX` | Return the cardinality. Implementations MAY approximate. |
+
+Per-seam additions follow the same shape: for example, `QuotaStore` may add `IncrementQuotaRequest / Response` for atomic-increment semantics.
+
+## Concurrency contract
+
+The default in-memory implementation does NOT lock internally — its caller (the registry) holds a mutex around every call. Implementations shared across multiple registry instances (Postgres, Redis) handle their own concurrency:
+
+- **In-memory** — single-process, single registry, no internal lock.
+- **Postgres** — each call is a transaction or wraps a caller-supplied `*sql.Tx`. Cross-process concurrency safe by construction.
+- **Redis** — atomic operations via `INCR` / `WATCH` / `EVAL` per call.
+
+The contract from the registry's perspective is: "I call you under my own mutex; you do whatever locking your backend needs."
+
+## Constructor convention
+
+Every seam exposes a public constructor for the default in-memory implementation, plus an option that lets the registry receive a custom one:
+
+```go
+func NewInMemoryWebhookStore() WebhookStore
+func WithWebhookStore(s WebhookStore) WebhookOption
+```
+
+- The in-memory implementation type is private (`inMemoryWebhookStore`) — operators get a `WebhookStore` interface back, not a concrete pointer.
+- The `WithXStore` option accepts `nil` as "fall back to default" — keeps wiring sites tolerant.
+
+## Naming and file layout
+
+- One file per seam: `webhook_store.go`, `quota_store.go`, `cursor_store.go`, `subscription_index_store.go`.
+- Tests live alongside: `webhook_store_test.go`, etc.
+- The interface, request / response types, default in-memory impl, and option function all live in the seam's file. No splits.
+
+## What the seam is NOT
+
+- **NOT a transaction abstraction.** Backends own their own transaction boundaries. If a future use case needs atomic multi-seam writes (e.g., delete a webhook + decrement its quota in one transaction), that's a separate cross-seam abstraction added on top.
+- **NOT a caching layer.** Backends decide their own caching policy. The registry talks to the seam directly.
+- **NOT a migration tool.** Schema changes on a backend (e.g., adding columns to a Postgres `webhook` table) are operator concerns, not seam concerns.
+
+## Adding a new seam
+
+1. Define the interface + Request/Response types in a single file named after the concern.
+2. Provide a `NewInMemoryX()` constructor and a private `inMemoryX` implementation.
+3. Provide a `WithXStore` option on the consumer's constructor.
+4. Plumb the consumer's call sites through the interface — no direct field access to the old in-memory state.
+5. Add the seam's row to the table above in this doc.
+
+The other seams (#626, #628, #631) follow this template. Reviews check against this file.

--- a/experimental/ext/events/control.go
+++ b/experimental/ext/events/control.go
@@ -58,9 +58,9 @@ type controlEnvelope struct {
 // the deliver-loop's existing exponential backoff.
 func (r *WebhookRegistry) PostGap(canonicalKey []byte, freshCursor string) {
 	r.mu.RLock()
-	target, ok := r.targets[string(canonicalKey)]
+	resp, _ := r.store.GetWebhook(context.Background(), GetWebhookRequest{CanonicalKey: canonicalKey})
 	r.mu.RUnlock()
-	if !ok {
+	if !resp.Found {
 		return
 	}
 	body, err := json.Marshal(controlEnvelope{Type: "gap", Cursor: freshCursor})
@@ -68,7 +68,7 @@ func (r *WebhookRegistry) PostGap(canonicalKey []byte, freshCursor string) {
 		r.logf("[webhook] PostGap: marshal failed: %v", err)
 		return
 	}
-	go r.deliverControl(target, "gap", body)
+	go r.deliverControl(resp.Target, "gap", body)
 }
 
 // PostTerminated delivers a {type:terminated, error:...} envelope to
@@ -83,14 +83,12 @@ func (r *WebhookRegistry) PostGap(canonicalKey []byte, freshCursor string) {
 // entry in the registry.
 func (r *WebhookRegistry) PostTerminated(canonicalKey []byte, controlErr ControlError) {
 	r.mu.Lock()
-	target, ok := r.targets[string(canonicalKey)]
-	if ok {
-		delete(r.targets, string(canonicalKey))
-	}
+	resp, _ := r.store.DeleteWebhook(context.Background(), DeleteWebhookRequest{CanonicalKey: canonicalKey})
 	r.mu.Unlock()
-	if !ok {
+	if !resp.Found {
 		return
 	}
+	target := resp.Removed
 	// PostTerminated is server-initiated subscription death;
 	// onRemove fires on actual registry deletion (per spec §"Server
 	// SDK Guidance" → "Unsubscribe timing by mode" L707). Suspend

--- a/experimental/ext/events/delivery_status_test.go
+++ b/experimental/ext/events/delivery_status_test.go
@@ -449,10 +449,11 @@ func TestSuspend_DoesNotAutoPostTerminatedTwice(t *testing.T) {
 	require.False(t, st.Active)
 
 	// Reach into the registry directly (this is what a corrupt caller
-	// or future code path might do).
-	r.mu.RLock()
-	target, ok := r.targets[string(canonical)]
-	r.mu.RUnlock()
+	// or future code path might do). Uses the package-private
+	// lookupTarget helper since the targets map is now behind a
+	// WebhookStore seam — the test still owns mu coordination via
+	// lookupTarget's internal RLock.
+	target, ok := r.lookupTarget(canonical)
 	require.True(t, ok)
 	r.deliver(target, "evt_c", []byte(`{}`))
 

--- a/experimental/ext/events/webhook.go
+++ b/experimental/ext/events/webhook.go
@@ -287,7 +287,7 @@ const (
 // principal is part of the key.
 type WebhookRegistry struct {
 	mu                   sync.RWMutex
-	targets              map[string]WebhookTarget // keyed by string(canonicalKey)
+	store                WebhookStore // canonicalKey → WebhookTarget; default in-memory
 	client               *http.Client
 	ttl                  time.Duration
 	ttlExplicit          bool // operator passed WithWebhookTTL (drives clamp decision)
@@ -412,7 +412,7 @@ func (r *WebhookRegistry) fireOnRemove(t WebhookTarget) {
 // see its docs for when (not) to use it.
 func NewWebhookRegistry(opts ...WebhookOption) *WebhookRegistry {
 	r := &WebhookRegistry{
-		targets:          make(map[string]WebhookTarget),
+		store:            NewInMemoryWebhookStore(),
 		ttl:              DefaultWebhookTTL,
 		headerMode:       StandardWebhooks,
 		maxBodyBytes:     defaultWebhookMaxBodyBytes,
@@ -583,8 +583,9 @@ func (r *WebhookRegistry) Register(p RegisterParams) (expiresAt time.Time, isNew
 	r.mu.Lock()
 	pruned := r.pruneExpiredLocked()
 	expiresAt = time.Now().Add(r.ttl)
-	key := string(p.CanonicalKey)
-	if existing, ok := r.targets[key]; ok {
+	getResp, _ := r.store.GetWebhook(context.Background(), GetWebhookRequest{CanonicalKey: p.CanonicalKey})
+	if getResp.Found {
+		existing := getResp.Target
 		// Refresh: update expiry and secret if provided. Secret rotation
 		// per spec is allowed by supplying a new value on refresh.
 		existing.ExpiresAt = expiresAt
@@ -606,10 +607,10 @@ func (r *WebhookRegistry) Register(p RegisterParams) (expiresAt time.Time, isNew
 			existing.Status.FailedSince = nil
 			existing.failureCount = 0
 		}
-		r.targets[key] = existing
+		_, _ = r.store.SaveWebhook(context.Background(), SaveWebhookRequest{Target: existing})
 		isNew = false
 	} else {
-		r.targets[key] = WebhookTarget{
+		_, _ = r.store.SaveWebhook(context.Background(), SaveWebhookRequest{Target: WebhookTarget{
 			CanonicalKey:  p.CanonicalKey,
 			ID:            p.DerivedID,
 			URL:           p.URL,
@@ -624,7 +625,7 @@ func (r *WebhookRegistry) Register(p RegisterParams) (expiresAt time.Time, isNew
 			// repeated failures (spec §"Webhook Delivery Status"
 			// L460); a successful refresh resets it.
 			Status: DeliveryStatus{Active: true},
-		}
+		}})
 		isNew = true
 	}
 	r.mu.Unlock()
@@ -650,13 +651,10 @@ func (r *WebhookRegistry) Register(p RegisterParams) (expiresAt time.Time, isNew
 // PostTerminated.
 func (r *WebhookRegistry) Unregister(canonicalKey []byte) {
 	r.mu.Lock()
-	target, ok := r.targets[string(canonicalKey)]
-	if ok {
-		delete(r.targets, string(canonicalKey))
-	}
+	resp, _ := r.store.DeleteWebhook(context.Background(), DeleteWebhookRequest{CanonicalKey: canonicalKey})
 	r.mu.Unlock()
-	if ok {
-		r.fireOnRemove(target)
+	if resp.Found {
+		r.fireOnRemove(resp.Removed)
 	}
 }
 
@@ -673,13 +671,26 @@ func (r *WebhookRegistry) Targets() []WebhookTarget {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	now := time.Now()
-	out := make([]WebhookTarget, 0, len(r.targets))
-	for _, t := range r.targets {
+	listResp, _ := r.store.ListWebhooks(context.Background(), ListWebhooksRequest{})
+	out := make([]WebhookTarget, 0, len(listResp.Targets))
+	for _, t := range listResp.Targets {
 		if t.ExpiresAt.After(now) && t.Status.Active {
 			out = append(out, t)
 		}
 	}
 	return out
+}
+
+// lookupTarget returns the stored target for canonicalKey, or
+// (zero, false) when absent. Package-private helper used by tests
+// inside experimental/ext/events that need to inspect a specific
+// target without going through the public Targets() snapshot. NOT
+// part of the public surface.
+func (r *WebhookRegistry) lookupTarget(canonicalKey []byte) (WebhookTarget, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	resp, _ := r.store.GetWebhook(context.Background(), GetWebhookRequest{CanonicalKey: canonicalKey})
+	return resp.Target, resp.Found
 }
 
 // pruneExpiredLocked removes expired subscriptions and returns the
@@ -688,12 +699,22 @@ func (r *WebhookRegistry) Targets() []WebhookTarget {
 // → "Unsubscribe timing by mode" L707. Must hold r.mu write lock.
 func (r *WebhookRegistry) pruneExpiredLocked() []WebhookTarget {
 	now := time.Now()
+	ctx := context.Background()
+	// ListWebhooks snapshot + per-key DeleteWebhook avoids mutating
+	// the store during iteration — the in-memory impl tolerates Go map
+	// delete-during-range, but a Postgres / SQL impl wouldn't. The
+	// seam contract is the same for both backends; #630 doesn't have
+	// to special-case this path.
+	listResp, _ := r.store.ListWebhooks(ctx, ListWebhooksRequest{})
 	var removed []WebhookTarget
-	for key, t := range r.targets {
-		if t.ExpiresAt.Before(now) {
-			log.Printf("[webhook] subscription %s expired, removing", t.ID)
-			delete(r.targets, key)
-			removed = append(removed, t)
+	for _, t := range listResp.Targets {
+		if t.ExpiresAt.After(now) || t.ExpiresAt.Equal(now) {
+			continue
+		}
+		delResp, _ := r.store.DeleteWebhook(ctx, DeleteWebhookRequest{CanonicalKey: t.CanonicalKey})
+		if delResp.Found {
+			log.Printf("[webhook] subscription %s expired, removing", delResp.Removed.ID)
+			removed = append(removed, delResp.Removed)
 		}
 	}
 	return removed
@@ -712,11 +733,12 @@ func (r *WebhookRegistry) pruneExpiredLocked() []WebhookTarget {
 // targeted-emit against teardown is expected, not an error.
 func (r *WebhookRegistry) DeliverToTarget(canonicalKey []byte, event Event) bool {
 	r.mu.RLock()
-	target, ok := r.targets[string(canonicalKey)]
+	resp, _ := r.store.GetWebhook(context.Background(), GetWebhookRequest{CanonicalKey: canonicalKey})
 	r.mu.RUnlock()
-	if !ok {
+	if !resp.Found {
 		return false
 	}
+	target := resp.Target
 	if !target.Status.Active || time.Now().After(target.ExpiresAt) {
 		return false
 	}
@@ -740,9 +762,11 @@ func (r *WebhookRegistry) ExpireAll() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	past := time.Now().Add(-1 * time.Second)
-	for k, v := range r.targets {
-		v.ExpiresAt = past
-		r.targets[k] = v
+	ctx := context.Background()
+	listResp, _ := r.store.ListWebhooks(ctx, ListWebhooksRequest{})
+	for _, t := range listResp.Targets {
+		t.ExpiresAt = past
+		_, _ = r.store.SaveWebhook(ctx, SaveWebhookRequest{Target: t})
 	}
 }
 
@@ -847,17 +871,19 @@ const (
 func (r *WebhookRegistry) recordDeliverySuccess(canonicalKey []byte, at time.Time) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	t, ok := r.targets[string(canonicalKey)]
-	if !ok {
+	ctx := context.Background()
+	getResp, _ := r.store.GetWebhook(ctx, GetWebhookRequest{CanonicalKey: canonicalKey})
+	if !getResp.Found {
 		return
 	}
+	t := getResp.Target
 	atCopy := at
 	t.Status.Active = true
 	t.Status.LastDeliveryAt = &atCopy
 	t.Status.LastError = DeliveryErrorNone
 	t.Status.FailedSince = nil
 	t.failureCount = 0
-	r.targets[string(canonicalKey)] = t
+	_, _ = r.store.SaveWebhook(ctx, SaveWebhookRequest{Target: t})
 }
 
 // recordDeliveryFailure updates the target's DeliveryStatus after the
@@ -874,10 +900,12 @@ func (r *WebhookRegistry) recordDeliverySuccess(canonicalKey []byte, at time.Tim
 func (r *WebhookRegistry) recordDeliveryFailure(canonicalKey []byte, bucket DeliveryErrorBucket) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	t, ok := r.targets[string(canonicalKey)]
-	if !ok {
+	ctx := context.Background()
+	getResp, _ := r.store.GetWebhook(ctx, GetWebhookRequest{CanonicalKey: canonicalKey})
+	if !getResp.Found {
 		return
 	}
+	t := getResp.Target
 	now := time.Now()
 	t.Status.LastError = bucket
 
@@ -896,7 +924,7 @@ func (r *WebhookRegistry) recordDeliveryFailure(canonicalKey []byte, bucket Deli
 	if t.failureCount >= r.suspendThreshold {
 		t.Status.Active = false
 	}
-	r.targets[string(canonicalKey)] = t
+	_, _ = r.store.SaveWebhook(ctx, SaveWebhookRequest{Target: t})
 	// On the Active true→false transition, auto-Post a
 	// {type:terminated} envelope to the receiver as a courtesy
 	// notification (spec §"Non-event webhook bodies" L420). Uses
@@ -918,8 +946,9 @@ func (r *WebhookRegistry) recordDeliveryFailure(canonicalKey []byte, bucket Deli
 func (r *WebhookRegistry) DeliveryStatus(canonicalKey []byte) DeliveryStatus {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	if t, ok := r.targets[string(canonicalKey)]; ok {
-		return t.Status
+	resp, _ := r.store.GetWebhook(context.Background(), GetWebhookRequest{CanonicalKey: canonicalKey})
+	if resp.Found {
+		return resp.Target.Status
 	}
 	return DeliveryStatus{}
 }

--- a/experimental/ext/events/webhook_store.go
+++ b/experimental/ext/events/webhook_store.go
@@ -1,0 +1,176 @@
+package events
+
+import "context"
+
+// WebhookStore is the storage seam behind WebhookRegistry. The default
+// in-memory implementation (NewInMemoryWebhookStore) matches the
+// registry's historical behavior exactly; alternative implementations
+// plug in via WithWebhookStore. The Postgres-backed implementation
+// lands in a follow-up issue (#630); a Redis-backed implementation
+// would live alongside it.
+//
+// API shape: every method follows the gRPC-style
+//
+//	Method(ctx context.Context, req XRequest) (XResponse, error)
+//
+// convention so the same interface can sit directly behind a gRPC
+// service in a future remote-store deployment without reshaping
+// callers. ctx threads cancellation, deadlines, and trace context
+// (SEP-414 / core.TracerProvider) into the store; Request and Response
+// types are extensible — adding a PageToken to ListWebhooksRequest, for
+// example, won't change the method signature.
+//
+// Error semantics: the error return is reserved for storage-layer
+// failures (connection drops, transaction conflicts, serialization
+// issues). Application-level absence ("the row didn't exist") is
+// reported via Found / Removed booleans on the response — a caller
+// never has to interpret error sentinels for routine flow control.
+//
+// Concurrency contract: WebhookRegistry calls these methods under its
+// own mutex today, so the in-memory implementation does not take
+// internal locks. Implementations that share state across multiple
+// registry instances (Postgres, Redis) take their own locks or use
+// transaction semantics — the registry's local mutex is not enough at
+// that scale.
+//
+// Naming convention: each storage concern in experimental/ext/events/
+// has its own narrow interface (WebhookStore here; QuotaStore,
+// CursorStore, and SubscriptionIndex-storage land in sibling PRs).
+// Backends implement the subset they need — there is no umbrella
+// EventsStore. See STORAGE_SEAMS.md for the full convention.
+type WebhookStore interface {
+	GetWebhook(ctx context.Context, req GetWebhookRequest) (GetWebhookResponse, error)
+	SaveWebhook(ctx context.Context, req SaveWebhookRequest) (SaveWebhookResponse, error)
+	DeleteWebhook(ctx context.Context, req DeleteWebhookRequest) (DeleteWebhookResponse, error)
+	ListWebhooks(ctx context.Context, req ListWebhooksRequest) (ListWebhooksResponse, error)
+	CountWebhooks(ctx context.Context, req CountWebhooksRequest) (CountWebhooksResponse, error)
+}
+
+// GetWebhookRequest identifies a single webhook target by canonical key.
+type GetWebhookRequest struct {
+	// CanonicalKey is the spec's canonical-tuple bytes — opaque to the
+	// store; the registry composes it from (principal, name, params, url).
+	CanonicalKey []byte
+}
+
+// GetWebhookResponse carries the lookup result. Found is false when no
+// row matched; the Target field is the zero value in that case.
+type GetWebhookResponse struct {
+	Target WebhookTarget
+	Found  bool
+}
+
+// SaveWebhookRequest upserts a target — implementations overwrite any
+// existing row keyed by Target.CanonicalKey without a separate signal.
+type SaveWebhookRequest struct {
+	Target WebhookTarget
+}
+
+// SaveWebhookResponse is empty today; reserved for future fields (e.g.,
+// a write-conflict version stamp) without breaking the interface.
+type SaveWebhookResponse struct{}
+
+// DeleteWebhookRequest identifies a target to remove by canonical key.
+type DeleteWebhookRequest struct {
+	CanonicalKey []byte
+}
+
+// DeleteWebhookResponse carries the removed target plus a Found flag
+// so callers can fire onRemove hooks without a separate Get round
+// trip. Found is false when no row matched; the Removed field is the
+// zero value in that case.
+type DeleteWebhookResponse struct {
+	Removed WebhookTarget
+	Found   bool
+}
+
+// ListWebhooksRequest is empty today; pagination fields land here when
+// a real backend needs them.
+type ListWebhooksRequest struct{}
+
+// ListWebhooksResponse carries every stored target as a snapshot slice.
+// Implementations MUST copy out, not return their internal storage —
+// callers iterate without holding any external lock. Ordering is
+// unspecified.
+type ListWebhooksResponse struct {
+	Targets []WebhookTarget
+}
+
+// CountWebhooksRequest is empty today.
+type CountWebhooksRequest struct{}
+
+// CountWebhooksResponse carries the current target count. Implementations
+// MAY approximate Count for performance (returning a value off by a few
+// when contention is high) — callers use it for capacity hints only,
+// never for correctness.
+type CountWebhooksResponse struct {
+	Count int
+}
+
+// NewInMemoryWebhookStore returns the default in-memory storage
+// implementation — a plain map[string]WebhookTarget with no internal
+// locking. Suitable for single-process deployments and the default
+// when WithWebhookStore is not configured. Multi-replica deployments
+// plug in a shared backend (e.g., the Postgres-backed implementation
+// in #630). ctx is accepted on every method to honor the convention,
+// but the in-memory implementation never observes cancellation —
+// every call is a synchronous map operation.
+func NewInMemoryWebhookStore() WebhookStore {
+	return &inMemoryWebhookStore{
+		targets: make(map[string]WebhookTarget),
+	}
+}
+
+// WithWebhookStore overrides the registry's storage implementation.
+// Passing nil is treated as "use the default in-memory store" — the
+// constructor materializes a fresh NewInMemoryWebhookStore in that case.
+// Explicit configuration is recommended for clarity at registry
+// construction sites.
+func WithWebhookStore(s WebhookStore) WebhookOption {
+	return func(r *WebhookRegistry) {
+		if s != nil {
+			r.store = s
+		}
+	}
+}
+
+// inMemoryWebhookStore is the default WebhookStore implementation.
+// Unlocked because WebhookRegistry calls every method under its own
+// mutex — the store sees a single goroutine at a time.
+type inMemoryWebhookStore struct {
+	targets map[string]WebhookTarget
+}
+
+func (s *inMemoryWebhookStore) GetWebhook(_ context.Context, req GetWebhookRequest) (GetWebhookResponse, error) {
+	t, ok := s.targets[string(req.CanonicalKey)]
+	if !ok {
+		return GetWebhookResponse{}, nil
+	}
+	return GetWebhookResponse{Target: t, Found: true}, nil
+}
+
+func (s *inMemoryWebhookStore) SaveWebhook(_ context.Context, req SaveWebhookRequest) (SaveWebhookResponse, error) {
+	s.targets[string(req.Target.CanonicalKey)] = req.Target
+	return SaveWebhookResponse{}, nil
+}
+
+func (s *inMemoryWebhookStore) DeleteWebhook(_ context.Context, req DeleteWebhookRequest) (DeleteWebhookResponse, error) {
+	t, ok := s.targets[string(req.CanonicalKey)]
+	if !ok {
+		return DeleteWebhookResponse{}, nil
+	}
+	delete(s.targets, string(req.CanonicalKey))
+	return DeleteWebhookResponse{Removed: t, Found: true}, nil
+}
+
+func (s *inMemoryWebhookStore) ListWebhooks(_ context.Context, _ ListWebhooksRequest) (ListWebhooksResponse, error) {
+	out := make([]WebhookTarget, 0, len(s.targets))
+	for _, t := range s.targets {
+		out = append(out, t)
+	}
+	return ListWebhooksResponse{Targets: out}, nil
+}
+
+func (s *inMemoryWebhookStore) CountWebhooks(_ context.Context, _ CountWebhooksRequest) (CountWebhooksResponse, error) {
+	return CountWebhooksResponse{Count: len(s.targets)}, nil
+}

--- a/experimental/ext/events/webhook_store_test.go
+++ b/experimental/ext/events/webhook_store_test.go
@@ -1,0 +1,195 @@
+package events
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestTarget(keyByte byte) WebhookTarget {
+	return WebhookTarget{
+		CanonicalKey: []byte{keyByte},
+		ID:           "sub_test_" + string([]byte{keyByte}),
+		URL:          "http://example.test/sink",
+		Secret:       "whsec_test_secret_xxxxxxxxxxxxxxxxxxxx",
+		ExpiresAt:    time.Now().Add(time.Hour),
+		EventName:    "test.event",
+		Status:       DeliveryStatus{Active: true},
+	}
+}
+
+func TestInMemoryWebhookStore_SaveThenGetRoundTrip(t *testing.T) {
+	s := NewInMemoryWebhookStore()
+	want := newTestTarget('a')
+	_, err := s.SaveWebhook(context.Background(), SaveWebhookRequest{Target: want})
+	require.NoError(t, err)
+
+	resp, err := s.GetWebhook(context.Background(), GetWebhookRequest{CanonicalKey: want.CanonicalKey})
+	require.NoError(t, err)
+	require.True(t, resp.Found)
+	assert.Equal(t, want.ID, resp.Target.ID)
+	assert.Equal(t, want.URL, resp.Target.URL)
+	assert.Equal(t, want.Secret, resp.Target.Secret)
+	assert.WithinDuration(t, want.ExpiresAt, resp.Target.ExpiresAt, time.Millisecond)
+}
+
+func TestInMemoryWebhookStore_DeleteSemantics(t *testing.T) {
+	s := NewInMemoryWebhookStore()
+	want := newTestTarget('b')
+	_, _ = s.SaveWebhook(context.Background(), SaveWebhookRequest{Target: want})
+
+	resp, err := s.DeleteWebhook(context.Background(), DeleteWebhookRequest{CanonicalKey: want.CanonicalKey})
+	require.NoError(t, err)
+	require.True(t, resp.Found)
+	assert.Equal(t, want.ID, resp.Removed.ID)
+
+	// Delete is idempotent — second call returns Found=false, no error,
+	// no mutation. Matches Go map delete semantics.
+	resp2, err := s.DeleteWebhook(context.Background(), DeleteWebhookRequest{CanonicalKey: want.CanonicalKey})
+	require.NoError(t, err)
+	assert.False(t, resp2.Found)
+	assert.Equal(t, WebhookTarget{}, resp2.Removed)
+}
+
+func TestInMemoryWebhookStore_ListReturnsSnapshotNotInternalSlice(t *testing.T) {
+	s := NewInMemoryWebhookStore()
+	_, _ = s.SaveWebhook(context.Background(), SaveWebhookRequest{Target: newTestTarget('a')})
+	_, _ = s.SaveWebhook(context.Background(), SaveWebhookRequest{Target: newTestTarget('b')})
+
+	first, _ := s.ListWebhooks(context.Background(), ListWebhooksRequest{})
+	require.Len(t, first.Targets, 2)
+
+	// Mutate the returned slice; the next List must still see two.
+	first.Targets = first.Targets[:0]
+	second, _ := s.ListWebhooks(context.Background(), ListWebhooksRequest{})
+	assert.Len(t, second.Targets, 2, "ListWebhooks must return a snapshot — mutating the returned slice cannot affect store state")
+}
+
+func TestInMemoryWebhookStore_CountTracksSavesAndDeletes(t *testing.T) {
+	s := NewInMemoryWebhookStore()
+	zero, _ := s.CountWebhooks(context.Background(), CountWebhooksRequest{})
+	assert.Equal(t, 0, zero.Count)
+
+	_, _ = s.SaveWebhook(context.Background(), SaveWebhookRequest{Target: newTestTarget('a')})
+	_, _ = s.SaveWebhook(context.Background(), SaveWebhookRequest{Target: newTestTarget('b')})
+	twoAfter, _ := s.CountWebhooks(context.Background(), CountWebhooksRequest{})
+	assert.Equal(t, 2, twoAfter.Count)
+
+	// Save of existing key is upsert — count stays the same.
+	_, _ = s.SaveWebhook(context.Background(), SaveWebhookRequest{Target: newTestTarget('a')})
+	stillTwo, _ := s.CountWebhooks(context.Background(), CountWebhooksRequest{})
+	assert.Equal(t, 2, stillTwo.Count)
+
+	_, _ = s.DeleteWebhook(context.Background(), DeleteWebhookRequest{CanonicalKey: []byte{'a'}})
+	oneAfter, _ := s.CountWebhooks(context.Background(), CountWebhooksRequest{})
+	assert.Equal(t, 1, oneAfter.Count)
+}
+
+// spyStore wraps the in-memory store with a call recorder so tests can
+// assert that WebhookRegistry exercises the seam in the expected
+// sequence on Register → Deliver → Unregister.
+type spyStore struct {
+	inner WebhookStore
+	mu    sync.Mutex
+	calls []string
+}
+
+func newSpyStore() *spyStore {
+	return &spyStore{inner: NewInMemoryWebhookStore()}
+}
+
+func (s *spyStore) record(op string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = append(s.calls, op)
+}
+
+func (s *spyStore) snapshot() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, len(s.calls))
+	copy(out, s.calls)
+	return out
+}
+
+func (s *spyStore) GetWebhook(ctx context.Context, req GetWebhookRequest) (GetWebhookResponse, error) {
+	s.record("Get")
+	return s.inner.GetWebhook(ctx, req)
+}
+func (s *spyStore) SaveWebhook(ctx context.Context, req SaveWebhookRequest) (SaveWebhookResponse, error) {
+	s.record("Save")
+	return s.inner.SaveWebhook(ctx, req)
+}
+func (s *spyStore) DeleteWebhook(ctx context.Context, req DeleteWebhookRequest) (DeleteWebhookResponse, error) {
+	s.record("Delete")
+	return s.inner.DeleteWebhook(ctx, req)
+}
+func (s *spyStore) ListWebhooks(ctx context.Context, req ListWebhooksRequest) (ListWebhooksResponse, error) {
+	s.record("List")
+	return s.inner.ListWebhooks(ctx, req)
+}
+func (s *spyStore) CountWebhooks(ctx context.Context, req CountWebhooksRequest) (CountWebhooksResponse, error) {
+	s.record("Count")
+	return s.inner.CountWebhooks(ctx, req)
+}
+
+func TestWebhookRegistry_UsesCustomStore_RegisterAndUnregister(t *testing.T) {
+	spy := newSpyStore()
+	r := NewWebhookRegistry(WithWebhookStore(spy))
+
+	canonical := []byte("canonical-key-x")
+	r.Register(RegisterParams{
+		CanonicalKey: canonical,
+		DerivedID:    "sub_x",
+		URL:          "http://example.test/sink",
+		Secret:       "whsec_xxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		EventName:    "test.event",
+	})
+	r.Unregister(canonical)
+
+	calls := spy.snapshot()
+	// Register's first action is pruneExpiredLocked (List). Then a
+	// Get to detect refresh-vs-new, then a Save for the new target.
+	// Unregister fires one Delete.
+	require.Contains(t, calls, "List", "pruneExpired must list")
+	require.Contains(t, calls, "Get", "Register must Get to detect refresh-vs-new")
+	require.Contains(t, calls, "Save", "Register must Save the new target")
+	require.Contains(t, calls, "Delete", "Unregister must Delete by canonical key")
+}
+
+func TestWebhookRegistry_DefaultStoreIsInMemory(t *testing.T) {
+	// Behavior-preserving property: a registry constructed without
+	// WithWebhookStore must use NewInMemoryWebhookStore as the default,
+	// and the Targets() snapshot must work without further wiring.
+	r := NewWebhookRegistry()
+	canonical := []byte("default-store-test")
+	r.Register(RegisterParams{
+		CanonicalKey: canonical,
+		DerivedID:    "sub_default",
+		URL:          "http://example.test/sink",
+		Secret:       "whsec_xxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		EventName:    "test.event",
+	})
+	targets := r.Targets()
+	require.Len(t, targets, 1)
+	assert.Equal(t, "sub_default", targets[0].ID)
+}
+
+func TestWebhookRegistry_WithWebhookStoreNilFallsBackToDefault(t *testing.T) {
+	// Passing nil keeps the constructor's default — no panic, no
+	// surprise behavior.
+	r := NewWebhookRegistry(WithWebhookStore(nil))
+	canonical := []byte("nil-store-test")
+	r.Register(RegisterParams{
+		CanonicalKey: canonical,
+		DerivedID:    "sub_nil",
+		URL:          "http://example.test/sink",
+		Secret:       "whsec_xxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		EventName:    "test.event",
+	})
+	assert.Len(t, r.Targets(), 1)
+}


### PR DESCRIPTION
## What changes

Behavior-preserving refactor that pulls the in-memory `targets` map out of `WebhookRegistry` into a new `WebhookStore` interface. Default in-memory implementation matches today's behavior exactly; the seam is what the Postgres backend (issue 630) will plug into. Also pins the **storage-seam family naming + shape convention** the rest of the family (issues 626 QuotaStore, 628 CursorStore, 631 SubscriptionIndex storage) will follow.

Closes 627.

## API shape — gRPC-style, ctx threaded throughout

Every method on the seam follows the same convention:

```go
Method(ctx context.Context, req XRequest) (XResponse, error)
```

- `ctx` is the first parameter so the same interface translates 1:1 to a `.proto` service definition later, and so persistent backends naturally honor cancellation + deadlines + the SEP-414 `core.TracerProvider` distributed-tracing surface.
- Request/Response types are named per-operation (`GetWebhookRequest` / `GetWebhookResponse`, `SaveWebhookRequest`, etc.); adding fields (pagination tokens, version stamps) doesn't break the interface.
- Error return is reserved for **storage-layer failures**; application-level absence is reported via `Found` / `Removed` booleans so callers never interpret error sentinels for routine flow control.

Full convention pinned in `experimental/ext/events/STORAGE_SEAMS.md` so the sibling seam PRs (626/628/631) don't re-decide.

## Reviewer's guide

Read in this order:

1. [experimental/ext/events/webhook_store.go](https://github.com/panyam/mcpkit/pull/671/files#diff-c39c98a34a1ae9fe96706843f074aec4b42e1ced3c1e0d1ae48f407f142d8392) — start here. The new interface + Request/Response types + `inMemoryWebhookStore` default + `NewInMemoryWebhookStore()` constructor + `WithWebhookStore()` option. Pay attention to the doc comments: each pins the contract (Found semantics, snapshot guarantees, ctx ignore-vs-honor).
2. [experimental/ext/events/STORAGE_SEAMS.md](https://github.com/panyam/mcpkit/pull/671/files#diff-ceea0a5339d9583578ba93a8fd23a5cc2cc61ae832839b943f6d8e02b0bf6954) — naming + API shape convention. The other three seam PRs (626 / 628 / 631) reference this; review with future authors in mind.
3. [experimental/ext/events/webhook.go](https://github.com/panyam/mcpkit/pull/671/files#diff-f61c2bd42ae83936aba2fe7dab3bcda1606ca810bd7263d9afbe42147f9c8f5a) — every `r.targets[...]` access site refactored through the interface (Register, Unregister, Targets, lookupTarget, pruneExpiredLocked, DeliverToTarget, ExpireAll, recordDeliverySuccess, recordDeliveryFailure, DeliveryStatus). Confirm the call sequences match what was there before — refactor is mechanical except for the prune-path snapshot-then-delete change (avoids mutate-during-iterate for SQL backends).
4. [experimental/ext/events/control.go](https://github.com/panyam/mcpkit/pull/671/files#diff-601fd7ab3d5d1a8e78f66bc045596de768af7f42ba67c1ffa49432cdf06290bb) — PostGap and PostTerminated routed through the seam.
5. [experimental/ext/events/webhook_store_test.go](https://github.com/panyam/mcpkit/pull/671/files#diff-dca33544e17c6a03a50c5e1f1a93ceb2589fbbc603f078e117f6ac6825e7589d) — 7 tests pinning the interface contract: round-trip, delete semantics, snapshot guarantee, count tracking, registry-uses-custom-store call sequence, default-is-in-memory, nil-falls-back-to-default.
6. [experimental/ext/events/delivery_status_test.go](https://github.com/panyam/mcpkit/pull/671/files#diff-eb63a35a464c7dd69b298a550ac9291e03dd1a03f08781f3dea7374088226e37) — the one test that reached into `r.targets` directly now uses the new package-private `r.lookupTarget` helper.
7. [experimental/ext/events/README.md](https://github.com/panyam/mcpkit/pull/671/files#diff-9222f2c9c82e15be71e1b286719f2d44d107c3ea315805c64c3d617ab960d4b3) — one bullet under "Webhook delivery" pointing at the new seam doc.

Skim: nothing else changes.

## Test counts

- **Added: 7 new tests** in `webhook_store_test.go` covering Save/Get/Delete/List/Count semantics and the WithWebhookStore option path.
- **Existing tests:** all unchanged. The full events sub-module suite (75s) is green; the main repo `make test` is green.
- **Removed / weakened: 0.** That's the refactor's correctness property.

## Decision log

| Decision | Chose | Over | Why |
|---|---|---|---|
| API shape | gRPC-style `(ctx, XRequest) → (XResponse, error)` | Stdlib-style positional args | Threads ctx for tracing + cancellation; Request/Response types extensible without breaking the interface; translates 1:1 to gRPC if the backend ever moves remote. Pins the convention for sibling seams 626/628/631. |
| Seam at the interface level | `WebhookStore` interface | Reflection / hooks-based plugin | Lets backends own their own transaction boundaries (Postgres rows + per-tenant indexes); hooks would bake one model in. |
| Configuration surface | `WithWebhookStore` option | `events.Config.Store` field | Matches the existing option-pattern on `NewWebhookRegistry`; keeps the public `events.Config` minimal. |
| One interface per concern | Separate `WebhookStore` / `QuotaStore` / `CursorStore` / `SubscriptionIndex` storage | Umbrella `EventsStore` interface | Backends implement the subset they want (Redis just QuotaStore; Postgres all three). No no-op methods that lie about semantics. |
| Error semantics | Application-level absence via `Found` boolean; error reserved for storage failures | Sentinel errors (`ErrNotFound`) | Callers never read errors to decide routine flow. Matches gRPC `NOT_FOUND` status semantics; pin the convention. |
| In-memory store visibility | Public constructor `NewInMemoryWebhookStore()` returns interface; impl type private | Public concrete type | Operators don't need the type; constructor is enough. Reduces surface. |
| `lookupTarget` for the test | Package-private helper | Public `Get` on the registry | Don't expand the public surface for a test convenience. |
| Naming-convention durability | Standalone `STORAGE_SEAMS.md` | Inline comment | 626 / 628 / 631 are separate PRs; a doc the next author can grep for is more reliable. |

## Risk / blast radius

- **Affects:** every internal access to the webhook subscription table inside `experimental/ext/events/`. Public API surface is additive: new `WebhookStore` interface + Request/Response types + `NewInMemoryWebhookStore()` + `WithWebhookStore()` option. Existing callers compile unchanged.
- **Tests covering this:** entire events sub-module suite passes without modification. Plus 7 new tests on the seam itself.
- **Be paranoid about:** the prune-path change (snapshot then per-key delete instead of delete-during-iterate). Mechanical replacement; preserves order, fires onRemove hooks identically. Test coverage on prune is pre-existing (lifecycle_test.go).

## Before / after

```
$ go test ./... -count=1 -timeout 180s
ok  github.com/panyam/mcpkit/experimental/ext/events  75.483s

$ go test ./... -run "TestInMemoryWebhookStore|TestWebhookRegistry_UsesCustomStore" -v
=== RUN   TestInMemoryWebhookStore_SaveThenGetRoundTrip
--- PASS
=== RUN   TestInMemoryWebhookStore_DeleteSemantics
--- PASS
=== RUN   TestInMemoryWebhookStore_ListReturnsSnapshotNotInternalSlice
--- PASS
=== RUN   TestInMemoryWebhookStore_CountTracksSavesAndDeletes
--- PASS
=== RUN   TestWebhookRegistry_UsesCustomStore_RegisterAndUnregister
--- PASS
PASS
```

## Out of scope (deliberately deferred)

- 626 QuotaStore, 628 CursorStore, 631 SubscriptionIndex storage — sibling seams in the family, follow the convention pinned here.
- 630 Postgres-backed `WebhookStore` — separate ticket, depends on this.
- ctx propagation on `WebhookRegistry`'s own public methods (`Register` / `Unregister` / `Targets` etc.) — the registry passes `context.Background()` to the store today. Adding ctx parameters is a larger public-API change for a future PR.
- Cross-process state migration — issue 639 stage-3 demo concern.
