### PR TITLE
events: extract QuotaStore seam from Quota (in-memory default preserved)

### DIFF
--- a/examples/events/whole-enchilada/event-server/go.mod
+++ b/examples/events/whole-enchilada/event-server/go.mod
@@ -28,7 +28,6 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
 	golang.org/x/time v0.15.0 // indirect

--- a/examples/events/whole-enchilada/event-server/go.sum
+++ b/examples/events/whole-enchilada/event-server/go.sum
@@ -43,8 +43,6 @@ github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zI
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 golang.org/x/net v0.49.0 h1:eeHFmOGUTtaaPSGNmjBKpbng9MulQsJURQUAfUwY++o=
 golang.org/x/net v0.49.0/go.mod h1:/ysNB2EvaqvesRkuLAyjI1ycPZlQHM3q01F02UY/MV8=
-golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
-golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
 golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.33.0 h1:B3njUFyqtHDUI5jMn1YIr5B0IE2U0qck04r6d4KPAxE=

--- a/examples/events/whole-enchilada/push-server/go.mod
+++ b/examples/events/whole-enchilada/push-server/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
 	golang.org/x/time v0.15.0 // indirect

--- a/examples/events/whole-enchilada/push-server/go.sum
+++ b/examples/events/whole-enchilada/push-server/go.sum
@@ -43,8 +43,6 @@ github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zI
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 golang.org/x/net v0.49.0 h1:eeHFmOGUTtaaPSGNmjBKpbng9MulQsJURQUAfUwY++o=
 golang.org/x/net v0.49.0/go.mod h1:/ysNB2EvaqvesRkuLAyjI1ycPZlQHM3q01F02UY/MV8=
-golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
-golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
 golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.33.0 h1:B3njUFyqtHDUI5jMn1YIr5B0IE2U0qck04r6d4KPAxE=

--- a/experimental/ext/events/README.md
+++ b/experimental/ext/events/README.md
@@ -140,7 +140,7 @@ type PollResult struct {
 - Retry with exponential backoff on 5xx (no retry on 4xx)
 - Basic SSRF validation on callback URLs
 - Pluggable signature format (see below)
-- Pluggable subscription storage via `WithWebhookStore` (default in-memory; Postgres lands in issue 630). See [`STORAGE_SEAMS.md`](STORAGE_SEAMS.md) for the convention every storage seam in this package follows.
+- Pluggable subscription storage via `WithWebhookStore` (default in-memory; Postgres lands in issue 630). Pluggable quota reservation counts via `WithQuotaStore`. See [`STORAGE_SEAMS.md`](STORAGE_SEAMS.md) for the convention every storage seam in this package follows.
 
 ```go
 webhooks := events.NewWebhookRegistry(

--- a/experimental/ext/events/STORAGE_SEAMS.md
+++ b/experimental/ext/events/STORAGE_SEAMS.md
@@ -10,12 +10,12 @@ The MCP Events extension's reference deployment (the `whole-enchilada` demo, iss
 
 Each storage concern has its own narrow interface:
 
-| Interface | Concern | Lands in |
+| Interface | Concern | Status |
 |---|---|---|
-| `WebhookStore` | Webhook subscription CRUD (canonical key → target) | this PR (627) |
-| `QuotaStore` | Quota counters per (principal, eventType) | 626 |
-| `CursorStore` | Per-subscription persisted cursors | 628 |
-| `SubscriptionIndex` storage seam | Subscription-id ↔ deliver-fn lookup table | 631 |
+| `WebhookStore` | Webhook subscription CRUD (canonical key → target) | landed (627 / PR 671) |
+| `QuotaStore` | Reservation counts per (principal, eventName) | landed (626) |
+| `CursorStore` | Per-subscription persisted cursors | lands in 628 |
+| `SubscriptionIndex` storage seam | Subscription-id ↔ deliver-fn lookup table | lands in 631 |
 
 No umbrella `EventsStore` interface. The reasons:
 

--- a/experimental/ext/events/clients/go/go.mod
+++ b/experimental/ext/events/clients/go/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
 	golang.org/x/time v0.15.0 // indirect

--- a/experimental/ext/events/clients/go/go.sum
+++ b/experimental/ext/events/clients/go/go.sum
@@ -43,8 +43,6 @@ github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zI
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 golang.org/x/net v0.49.0 h1:eeHFmOGUTtaaPSGNmjBKpbng9MulQsJURQUAfUwY++o=
 golang.org/x/net v0.49.0/go.mod h1:/ysNB2EvaqvesRkuLAyjI1ycPZlQHM3q01F02UY/MV8=
-golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
-golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
 golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.33.0 h1:B3njUFyqtHDUI5jMn1YIr5B0IE2U0qck04r6d4KPAxE=

--- a/experimental/ext/events/go.mod
+++ b/experimental/ext/events/go.mod
@@ -7,7 +7,6 @@ replace github.com/panyam/mcpkit => ../../..
 require (
 	github.com/panyam/mcpkit v0.2.33
 	github.com/stretchr/testify v1.11.1
-	golang.org/x/sync v0.20.0
 )
 
 require (

--- a/experimental/ext/events/go.sum
+++ b/experimental/ext/events/go.sum
@@ -44,8 +44,6 @@ github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zI
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 golang.org/x/net v0.49.0 h1:eeHFmOGUTtaaPSGNmjBKpbng9MulQsJURQUAfUwY++o=
 golang.org/x/net v0.49.0/go.mod h1:/ysNB2EvaqvesRkuLAyjI1ycPZlQHM3q01F02UY/MV8=
-golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
-golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
 golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.33.0 h1:B3njUFyqtHDUI5jMn1YIr5B0IE2U0qck04r6d4KPAxE=

--- a/experimental/ext/events/quota.go
+++ b/experimental/ext/events/quota.go
@@ -20,18 +20,16 @@ package events
 // (per-principal, per-event-type) is the default; the other axes
 // can be added behind options later if a deployment needs them.
 //
-// Implementation note: built on golang.org/x/sync/semaphore.Weighted,
-// which is the canonical Go primitive for "at most N concurrent
-// holders of a resource." Our bookkeeping is just per-(principal,
-// event-name) instantiation of that primitive — we don't add our own
-// counter math on top.
+// Reservation-count state lives behind the QuotaStore seam — see
+// quota_store.go. The default in-memory implementation matches the
+// historical behavior; multi-replica deployments plug in Postgres
+// (#630) or Redis (#634) for cross-replica counter atomicity.
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sync"
-
-	"golang.org/x/sync/semaphore"
 )
 
 // ErrTooManySubscriptions is returned by Quota.Reserve when the cap
@@ -69,33 +67,26 @@ func WithMaxSubscriptionsPerPrincipal(eventName string, n int) QuotaOption {
 // and enforces per-event-type caps configured via
 // WithMaxSubscriptionsPerPrincipal. Construct via NewQuota.
 //
-// Backed by golang.org/x/sync/semaphore.Weighted — one weighted
-// semaphore per (principal, eventName) tuple, sized to that event's
-// cap. Reserve = TryAcquire(1); Release = Release(1). Atomicity is
-// the semaphore's job; we just route to the right one.
-//
-// All state is in-process; counts do not persist across restart.
-// After restart a previously-suspended principal that was at cap
-// will be allowed back up to the cap again on first re-subscribe.
+// The wrapper owns the caps map (static operator config) and routes
+// dynamic reservation state through a QuotaStore (see quota_store.go).
+// The default in-memory store has no internal locking — the wrapper's
+// mu serializes calls. Multi-replica deployments plug in a shared
+// backend via WithQuotaStore.
 type Quota struct {
-	mu   sync.Mutex
-	sems map[quotaKey]*semaphore.Weighted
-	caps map[string]int
-}
-
-type quotaKey struct {
-	principal string
-	eventName string
+	mu    sync.Mutex
+	store QuotaStore
+	caps  map[string]int
 }
 
 // NewQuota constructs a quota with the given options. With no
 // WithMaxSubscriptionsPerPrincipal options, every Reserve call
 // succeeds — the quota is effectively a no-op. Authors register
-// caps explicitly per event-type.
+// caps explicitly per event-type. The default reservation-count
+// store is in-memory; override via WithQuotaStore.
 func NewQuota(opts ...QuotaOption) *Quota {
 	q := &Quota{
-		sems: make(map[quotaKey]*semaphore.Weighted),
-		caps: make(map[string]int),
+		store: NewInMemoryQuotaStore(),
+		caps:  make(map[string]int),
 	}
 	for _, o := range opts {
 		o(q)
@@ -103,37 +94,26 @@ func NewQuota(opts ...QuotaOption) *Quota {
 	return q
 }
 
-// semFor returns the per-(principal, eventName) semaphore, lazily
-// creating it on first use. Caller MUST hold q.mu.
-func (q *Quota) semForLocked(principal, eventName string) *semaphore.Weighted {
-	cap, ok := q.caps[eventName]
-	if !ok {
-		return nil
-	}
-	key := quotaKey{principal: principal, eventName: eventName}
-	sem, exists := q.sems[key]
-	if !exists {
-		sem = semaphore.NewWeighted(int64(cap))
-		q.sems[key] = sem
-	}
-	return sem
-}
-
 // Reserve attempts to claim one subscription slot for (principal,
 // eventName). Returns nil on success. Returns a wrapped
 // ErrTooManySubscriptions when the cap is exceeded.
 //
-// Event types without a configured cap always succeed (no semaphore
-// is created — keeps the map from growing for uncapped event-types).
+// Event types without a configured cap always succeed (no store call
+// is made — keeps the store from accumulating state for uncapped
+// event-types).
 func (q *Quota) Reserve(principal, eventName string) error {
 	q.mu.Lock()
-	sem := q.semForLocked(principal, eventName)
-	cap := q.caps[eventName]
-	q.mu.Unlock()
-	if sem == nil {
+	defer q.mu.Unlock()
+	cap, ok := q.caps[eventName]
+	if !ok || cap <= 0 {
 		return nil
 	}
-	if !sem.TryAcquire(1) {
+	resp, _ := q.store.ReserveQuota(context.Background(), ReserveQuotaRequest{
+		Principal: principal,
+		EventName: eventName,
+		Max:       cap,
+	})
+	if !resp.Granted {
 		return fmt.Errorf("%w: principal %q at cap %d for %q",
 			ErrTooManySubscriptions, principal, cap, eventName)
 	}
@@ -142,25 +122,32 @@ func (q *Quota) Reserve(principal, eventName string) error {
 
 // Release returns one subscription slot for (principal, eventName).
 //
-// Pair with Reserve 1:1 from the calling site. Excess Release would
-// panic (semaphore.Weighted.Release semantics). The SDK's wiring
-// pairs them by construction:
+// Pair with Reserve 1:1 from the calling site. Release-at-zero is a
+// silent no-op (the store-seam contract), so double-Release does not
+// panic — that's a more permissive semantics than the previous
+// semaphore-backed implementation, but matches Postgres /
+// Redis-backed implementations where the underlying ops are
+// idempotent. The SDK's wiring pairs Reserve/Release by construction:
+//
 //   - Webhook: Reserve in registerSubscribe after isNew; Release in
 //     the registry's onRemove hook (one fire per actual removal).
 //   - Push: Reserve before Subscribe; defer Release.
 //   - Poll: Reserve after Touch returns isNew; Release in the lease
 //     table's chained onExpire.
 //
-// Event types without a configured cap are no-ops (no semaphore
-// existed).
+// Event types without a configured cap are no-ops (no store call is
+// made).
 func (q *Quota) Release(principal, eventName string) {
 	q.mu.Lock()
-	sem := q.sems[quotaKey{principal: principal, eventName: eventName}]
-	q.mu.Unlock()
-	if sem == nil {
+	defer q.mu.Unlock()
+	cap, ok := q.caps[eventName]
+	if !ok || cap <= 0 {
 		return
 	}
-	sem.Release(1)
+	_, _ = q.store.ReleaseQuota(context.Background(), ReleaseQuotaRequest{
+		Principal: principal,
+		EventName: eventName,
+	})
 }
 
 // Cap returns the configured per-principal cap for eventName, or 0 if

--- a/experimental/ext/events/quota_store.go
+++ b/experimental/ext/events/quota_store.go
@@ -1,0 +1,150 @@
+package events
+
+import "context"
+
+// QuotaStore is the storage seam behind Quota's per-(principal, eventName)
+// reservation counts. The default in-memory implementation
+// (NewInMemoryQuotaStore) matches the historical behavior exactly;
+// alternative implementations plug in via WithQuotaStore.
+//
+// Cap configuration stays on the Quota wrapper — caps are static
+// operator config set at construction. The store owns dynamic
+// reservation state only: how many slots are currently held for each
+// (Principal, EventName). The wrapper passes Max on every
+// ReserveQuota call, so the store's atomicity unit is "compare current
+// count against Max and conditionally increment" — a one-shot
+// compare-and-set that maps cleanly onto Postgres `ON CONFLICT DO
+// UPDATE … WHERE count < $max` and Redis `EVAL` scripts.
+//
+// API shape: every method follows the gRPC-style
+//
+//	Method(ctx context.Context, req XRequest) (XResponse, error)
+//
+// convention pinned in STORAGE_SEAMS.md. ctx threads cancellation,
+// deadlines, and trace context. Application-level state (Granted,
+// Count) lives on the response — error is reserved for storage-layer
+// failures (connection drops, transaction conflicts).
+//
+// Concurrency contract: Quota calls these methods under its own
+// mutex today, so the in-memory implementation does NOT take internal
+// locks. Implementations that share state across multiple Quota
+// instances (Postgres, Redis) take their own locks or use transaction
+// semantics — the wrapper's local mutex is not enough at that scale.
+type QuotaStore interface {
+	ReserveQuota(ctx context.Context, req ReserveQuotaRequest) (ReserveQuotaResponse, error)
+	ReleaseQuota(ctx context.Context, req ReleaseQuotaRequest) (ReleaseQuotaResponse, error)
+	CountQuota(ctx context.Context, req CountQuotaRequest) (CountQuotaResponse, error)
+}
+
+// ReserveQuotaRequest asks the store to claim one slot for
+// (Principal, EventName) only if the current count is strictly less
+// than Max. Implementations MUST perform the check + increment
+// atomically with respect to concurrent Reserve / Release calls for
+// the same key.
+type ReserveQuotaRequest struct {
+	Principal string
+	EventName string
+	// Max is the cap the wrapper read from its caps map. Must be > 0;
+	// the wrapper short-circuits for uncapped event types and never
+	// calls the store with Max <= 0.
+	Max int
+}
+
+// ReserveQuotaResponse carries the reservation outcome. Granted is
+// true iff the slot was claimed; Count is the current count after
+// reservation (when Granted) or the count that blocked reservation
+// (when not).
+type ReserveQuotaResponse struct {
+	Granted bool
+	Count   int
+}
+
+// ReleaseQuotaRequest returns one slot for (Principal, EventName).
+// The store decrements the count if it is currently > 0, otherwise
+// no-ops (silent — release-at-zero is not an error). Pair with
+// ReserveQuota 1:1 from the wrapper's call sites; double-Release is
+// treated as a benign no-op rather than an underflow.
+type ReleaseQuotaRequest struct {
+	Principal string
+	EventName string
+}
+
+// ReleaseQuotaResponse is empty today; reserved for future fields.
+type ReleaseQuotaResponse struct{}
+
+// CountQuotaRequest reads the current count for (Principal, EventName)
+// without mutating state. Used by inspection paths (admin frontends,
+// debugging); not on the Reserve / Release hot path.
+type CountQuotaRequest struct {
+	Principal string
+	EventName string
+}
+
+// CountQuotaResponse carries the current count. Implementations MAY
+// approximate Count for performance (returning a value off by a few
+// when contention is high) — callers use it for inspection, never for
+// correctness-critical comparisons.
+type CountQuotaResponse struct {
+	Count int
+}
+
+// NewInMemoryQuotaStore returns the default in-memory storage
+// implementation — a plain map[quotaStoreKey]int with no internal
+// locking. Suitable for single-process deployments and the default
+// when WithQuotaStore is not configured. Multi-replica deployments
+// plug in a shared backend (e.g., the Postgres / Redis implementations
+// in #630 / #634).
+func NewInMemoryQuotaStore() QuotaStore {
+	return &inMemoryQuotaStore{counts: make(map[quotaStoreKey]int)}
+}
+
+// WithQuotaStore overrides the wrapper's storage implementation.
+// Passing nil is treated as "use the default in-memory store" — the
+// constructor materializes a fresh NewInMemoryQuotaStore in that case.
+// Explicit configuration is recommended for clarity at Quota
+// construction sites.
+func WithQuotaStore(s QuotaStore) QuotaOption {
+	return func(q *Quota) {
+		if s != nil {
+			q.store = s
+		}
+	}
+}
+
+// quotaStoreKey is the in-memory store's composite key. Distinct from
+// the historical quotaKey type so the seam refactor doesn't accidentally
+// hand out the old type to external callers.
+type quotaStoreKey struct {
+	principal string
+	eventName string
+}
+
+// inMemoryQuotaStore is the default QuotaStore implementation.
+// Unlocked because Quota calls every method under its own mutex —
+// the store sees a single goroutine at a time per wrapper instance.
+type inMemoryQuotaStore struct {
+	counts map[quotaStoreKey]int
+}
+
+func (s *inMemoryQuotaStore) ReserveQuota(_ context.Context, req ReserveQuotaRequest) (ReserveQuotaResponse, error) {
+	k := quotaStoreKey{principal: req.Principal, eventName: req.EventName}
+	cur := s.counts[k]
+	if cur >= req.Max {
+		return ReserveQuotaResponse{Granted: false, Count: cur}, nil
+	}
+	s.counts[k] = cur + 1
+	return ReserveQuotaResponse{Granted: true, Count: cur + 1}, nil
+}
+
+func (s *inMemoryQuotaStore) ReleaseQuota(_ context.Context, req ReleaseQuotaRequest) (ReleaseQuotaResponse, error) {
+	k := quotaStoreKey{principal: req.Principal, eventName: req.EventName}
+	if s.counts[k] > 0 {
+		s.counts[k]--
+	}
+	return ReleaseQuotaResponse{}, nil
+}
+
+func (s *inMemoryQuotaStore) CountQuota(_ context.Context, req CountQuotaRequest) (CountQuotaResponse, error) {
+	k := quotaStoreKey{principal: req.Principal, eventName: req.EventName}
+	return CountQuotaResponse{Count: s.counts[k]}, nil
+}

--- a/experimental/ext/events/quota_store_test.go
+++ b/experimental/ext/events/quota_store_test.go
@@ -1,0 +1,164 @@
+package events
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInMemoryQuotaStore_ReserveBelowMaxGrants(t *testing.T) {
+	s := NewInMemoryQuotaStore()
+	resp, err := s.ReserveQuota(context.Background(), ReserveQuotaRequest{
+		Principal: "alice", EventName: "chat.message", Max: 3,
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Granted)
+	assert.Equal(t, 1, resp.Count)
+}
+
+func TestInMemoryQuotaStore_ReserveAtMaxDenies(t *testing.T) {
+	s := NewInMemoryQuotaStore()
+	for i := 0; i < 2; i++ {
+		resp, err := s.ReserveQuota(context.Background(), ReserveQuotaRequest{
+			Principal: "alice", EventName: "chat.message", Max: 2,
+		})
+		require.NoError(t, err)
+		require.True(t, resp.Granted)
+	}
+	denied, err := s.ReserveQuota(context.Background(), ReserveQuotaRequest{
+		Principal: "alice", EventName: "chat.message", Max: 2,
+	})
+	require.NoError(t, err)
+	assert.False(t, denied.Granted, "third reservation must be denied")
+	assert.Equal(t, 2, denied.Count, "denied response carries the count that blocked it")
+}
+
+func TestInMemoryQuotaStore_ReleaseDecrements(t *testing.T) {
+	s := NewInMemoryQuotaStore()
+	ctx := context.Background()
+	_, _ = s.ReserveQuota(ctx, ReserveQuotaRequest{Principal: "alice", EventName: "e", Max: 5})
+	_, _ = s.ReserveQuota(ctx, ReserveQuotaRequest{Principal: "alice", EventName: "e", Max: 5})
+	_, _ = s.ReleaseQuota(ctx, ReleaseQuotaRequest{Principal: "alice", EventName: "e"})
+
+	resp, _ := s.CountQuota(ctx, CountQuotaRequest{Principal: "alice", EventName: "e"})
+	assert.Equal(t, 1, resp.Count)
+}
+
+func TestInMemoryQuotaStore_ReleaseAtZeroIsNoOp(t *testing.T) {
+	s := NewInMemoryQuotaStore()
+	ctx := context.Background()
+	// Release before any Reserve must be a silent no-op (no underflow,
+	// no panic). The contract is the QuotaStore's, not the wrapper's.
+	_, err := s.ReleaseQuota(ctx, ReleaseQuotaRequest{Principal: "alice", EventName: "e"})
+	require.NoError(t, err)
+	resp, _ := s.CountQuota(ctx, CountQuotaRequest{Principal: "alice", EventName: "e"})
+	assert.Equal(t, 0, resp.Count, "release-at-zero must not push the count negative")
+}
+
+func TestInMemoryQuotaStore_KeyScopedByPrincipalAndEventName(t *testing.T) {
+	s := NewInMemoryQuotaStore()
+	ctx := context.Background()
+	_, _ = s.ReserveQuota(ctx, ReserveQuotaRequest{Principal: "alice", EventName: "chat.message", Max: 10})
+	_, _ = s.ReserveQuota(ctx, ReserveQuotaRequest{Principal: "alice", EventName: "chat.message", Max: 10})
+
+	// Other (principal, eventName) tuples must be unaffected.
+	cross1, _ := s.CountQuota(ctx, CountQuotaRequest{Principal: "alice", EventName: "alert.fired"})
+	cross2, _ := s.CountQuota(ctx, CountQuotaRequest{Principal: "bob", EventName: "chat.message"})
+	assert.Equal(t, 0, cross1.Count)
+	assert.Equal(t, 0, cross2.Count)
+
+	own, _ := s.CountQuota(ctx, CountQuotaRequest{Principal: "alice", EventName: "chat.message"})
+	assert.Equal(t, 2, own.Count)
+}
+
+// spyQuotaStore wraps the in-memory store with a call recorder so tests
+// can assert that Quota routes through the seam in the expected order.
+type spyQuotaStore struct {
+	inner QuotaStore
+	mu    sync.Mutex
+	calls []string
+}
+
+func newSpyQuotaStore() *spyQuotaStore {
+	return &spyQuotaStore{inner: NewInMemoryQuotaStore()}
+}
+
+func (s *spyQuotaStore) record(op string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = append(s.calls, op)
+}
+
+func (s *spyQuotaStore) snapshot() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, len(s.calls))
+	copy(out, s.calls)
+	return out
+}
+
+func (s *spyQuotaStore) ReserveQuota(ctx context.Context, req ReserveQuotaRequest) (ReserveQuotaResponse, error) {
+	s.record("Reserve")
+	return s.inner.ReserveQuota(ctx, req)
+}
+func (s *spyQuotaStore) ReleaseQuota(ctx context.Context, req ReleaseQuotaRequest) (ReleaseQuotaResponse, error) {
+	s.record("Release")
+	return s.inner.ReleaseQuota(ctx, req)
+}
+func (s *spyQuotaStore) CountQuota(ctx context.Context, req CountQuotaRequest) (CountQuotaResponse, error) {
+	s.record("Count")
+	return s.inner.CountQuota(ctx, req)
+}
+
+func TestQuota_UsesCustomStore_RoutesReserveAndRelease(t *testing.T) {
+	spy := newSpyQuotaStore()
+	q := NewQuota(
+		WithMaxSubscriptionsPerPrincipal("chat.message", 2),
+		WithQuotaStore(spy),
+	)
+
+	require.NoError(t, q.Reserve("alice", "chat.message"))
+	q.Release("alice", "chat.message")
+
+	calls := spy.snapshot()
+	require.Equal(t, []string{"Reserve", "Release"}, calls,
+		"Quota wrapper must route Reserve then Release through the store in that order")
+}
+
+func TestQuota_UncappedEventTypeDoesNotCallStore(t *testing.T) {
+	// When no cap is configured, the wrapper short-circuits and never
+	// calls the store — keeps the store from accumulating state for
+	// uncapped event types.
+	spy := newSpyQuotaStore()
+	q := NewQuota(WithQuotaStore(spy))
+
+	require.NoError(t, q.Reserve("alice", "uncapped.event"))
+	q.Release("alice", "uncapped.event")
+
+	assert.Empty(t, spy.snapshot(),
+		"wrapper must not call the store for uncapped event types")
+}
+
+func TestQuota_DefaultStoreIsInMemory(t *testing.T) {
+	q := NewQuota(WithMaxSubscriptionsPerPrincipal("e", 1))
+	require.NoError(t, q.Reserve("alice", "e"))
+
+	err := q.Reserve("alice", "e")
+	require.Error(t, err, "second Reserve at cap=1 must error")
+	assert.True(t, errors.Is(err, ErrTooManySubscriptions),
+		"error must wrap ErrTooManySubscriptions for callers using errors.Is")
+}
+
+func TestQuota_WithQuotaStoreNilFallsBackToDefault(t *testing.T) {
+	q := NewQuota(
+		WithMaxSubscriptionsPerPrincipal("e", 1),
+		WithQuotaStore(nil),
+	)
+	require.NoError(t, q.Reserve("alice", "e"))
+	err := q.Reserve("alice", "e")
+	require.Error(t, err)
+}

--- a/experimental/ext/events/quota_test.go
+++ b/experimental/ext/events/quota_test.go
@@ -507,31 +507,17 @@ func TestQuota_OnSubscribeNeverFiresWhenAtCap(t *testing.T) {
 }
 
 // countForTest exposes the per-(principal, eventName) count from a
-// Quota for assertions. The semaphore's slot count isn't directly
-// observable, so this helper uses the package-internal counts via
-// a probe Reserve+Release dance — kept here in the test file so the
-// production surface stays minimal.
-//
-// Implementation: try to fully reserve up to the cap; the count is
-// (cap - successfully-reserved). Then release everything we
-// reserved to leave the quota in its prior state.
+// Quota for assertions. Routes through the QuotaStore's CountQuota
+// directly — the seam lift in #626 made counts first-class queryable
+// state, so the previous probe-Reserve-Release dance is no longer
+// necessary. The wrapper's mu serializes with concurrent
+// Reserve/Release in the same test.
 func (q *Quota) countForTest(principal, eventName string) int {
 	q.mu.Lock()
-	cap, ok := q.caps[eventName]
-	sem := q.sems[quotaKey{principal: principal, eventName: eventName}]
-	q.mu.Unlock()
-	if !ok || sem == nil {
-		return 0
-	}
-	reserved := 0
-	for i := 0; i < cap; i++ {
-		if !sem.TryAcquire(1) {
-			break
-		}
-		reserved++
-	}
-	for i := 0; i < reserved; i++ {
-		sem.Release(1)
-	}
-	return cap - reserved
+	defer q.mu.Unlock()
+	resp, _ := q.store.CountQuota(context.Background(), CountQuotaRequest{
+		Principal: principal,
+		EventName: eventName,
+	})
+	return resp.Count
 }


### PR DESCRIPTION
## What changes

Behavior-preserving refactor that pulls the per-(principal, eventName) reservation state out of the `Quota` struct into a new `QuotaStore` interface, following the gRPC-style storage-seam convention pinned by 627 / PR 671 in `STORAGE_SEAMS.md`. Quota wrapper now owns only static config (the caps map); dynamic reservation state routes through the store. Default in-memory implementation matches today's behavior exactly.

Drops the `golang.org/x/sync/semaphore` dependency along the way — `semaphore.Weighted` per (principal, eventName) collapsed into a plain `map[key]int` under the wrapper's mutex, since the wrapper already serializes calls and the in-memory store has no internal locking by convention.

Closes 626.

## Reviewer's guide

Read in this order:

1. [experimental/ext/events/quota_store.go](https://github.com/panyam/mcpkit/pull/673/files#diff-83c43bf708a48cba3fa07f882688d9b835e0a852f69e14adf525ba31ff3b5143) — start here. The new `QuotaStore` interface + Request/Response types + `inMemoryQuotaStore` + `NewInMemoryQuotaStore()` + `WithQuotaStore()` option. Pay attention to: `Max` is on every `ReserveQuotaRequest` (no separate cap config on the store); the in-memory `ReserveQuota` is a one-shot compare-and-increment that maps directly onto Postgres / Redis atomicity primitives.
2. [experimental/ext/events/quota.go](https://github.com/panyam/mcpkit/pull/673/files#diff-7bf082a849c19d20a25d57807e77b1ce8caaa1337059e99bbe022c2a24697a75) — refactored wrapper. `semaphore.Weighted` map and `semForLocked` removed; `store QuotaStore` field added with default `NewInMemoryQuotaStore`. `Reserve` and `Release` route through the store under `q.mu`. `ErrTooManySubscriptions` and the public `Cap` API are unchanged.
3. [experimental/ext/events/STORAGE_SEAMS.md](https://github.com/panyam/mcpkit/pull/673/files#diff-ceea0a5339d9583578ba93a8fd23a5cc2cc61ae832839b943f6d8e02b0bf6954) — table row for QuotaStore flipped from "lands in 626" to "landed (626)."
4. [experimental/ext/events/quota_store_test.go](https://github.com/panyam/mcpkit/pull/673/files#diff-8d9f6b1cf6dc796f8e07dd224a4eb4f06859308b1e29ef02cf0544f8f47a3887) — 9 new tests: Reserve below/at Max, Release decrements, Release-at-zero no-op, key-scoping across (principal, eventName), spy-store call sequence on the wrapper, uncapped event-type bypasses the store, default-is-in-memory, nil-falls-back-to-default.
5. [experimental/ext/events/quota_test.go](https://github.com/panyam/mcpkit/pull/673/files#diff-084eb45fccc9e4e080f6ace67f21f0041ef92fc67a3b3b8f1f9ca333b56f3b48) — one helper (`countForTest`) updated to route through `CountQuota` (the previous probe-Reserve-Release dance is unnecessary now that counts are first-class queryable state). All other existing tests pass unchanged.
6. [experimental/ext/events/README.md](https://github.com/panyam/mcpkit/pull/673/files#diff-9222f2c9c82e15be71e1b286719f2d44d107c3ea315805c64c3d617ab960d4b3) — one-bullet update mentioning `WithQuotaStore` alongside `WithWebhookStore`.

Skim: go.mod / go.sum changes across the events sub-module and its transitive consumers (whole-enchilada/event-server, push-server, clients/go) — all just `golang.org/x/sync` dropping out.

## Test counts

- **Added: 9 tests** in `quota_store_test.go`.
- **Existing tests: 0 changed assertions.** `quota_test.go` has one helper (`countForTest`) rewritten to use the new `CountQuota` method, but no test's assertions changed.
- **Removed / weakened: 0.**

`make test` (repo-wide) green. Events sub-module suite green (75s). `make tidy-all` clean.

## Decision log

| Decision | Chose | Over | Why |
|---|---|---|---|
| Cap config location | Stays on the `Quota` wrapper | Moved into the store as a "set cap" op | Caps are static operator config; counts are dynamic state. Separation matches the spec's "configure caps once at startup" model and avoids a separate config-sync surface on the seam. |
| `Max` on every Reserve call | Pass cap with each Reserve | Store maintains its own cap map | Maps directly to Postgres `WHERE count < $max` and Redis `EVAL` scripts — atomicity is the store's job, parameterized per call. |
| Drop `golang.org/x/sync/semaphore` | Plain `map[key]int` under wrapper's mu | Keep semaphore for in-memory atomicity | Wrapper's `mu` already serializes calls. Semaphore added a dep without value; in-memory becomes a tidy 4-line `map` impl. |
| `Granted` boolean on Response | Application-level signal | `error == ErrTooManySubscriptions` from the store | Follows the STORAGE_SEAMS.md convention: error reserved for storage-layer failures, application state in response fields. The wrapper still surfaces `ErrTooManySubscriptions` to callers — it's a translation, not a removed sentinel. |
| Release-at-zero | Silent no-op | Return error / panic | Easier for callers; matches Go map-decrement semantics; matches Postgres `UPDATE ... WHERE count > 0` idempotency; more permissive than the previous `semaphore.Weighted.Release(1)` panic-on-excess, but acceptable since the SDK pairs Reserve/Release by construction. |
| `CountQuota` method | Include from day 1 | Add later if needed | Inspection use case is real (admin frontend stage-4); zero cost to ship now. Also replaces `quota_test.go`'s probe-dance helper. |

## Risk / blast radius

- **Affects:** Quota internal state path. Public API surface is additive: new `QuotaStore` interface + Request/Response types + `NewInMemoryQuotaStore()` + `WithQuotaStore()` option. Existing callers (`registerSubscribe`, `registerStream`, `registerPoll`, the discord / kitchen-sink / whole-enchilada demos) compile unchanged.
- **Behavior change:** Release-at-zero now silently no-ops instead of panicking. The previous semaphore-backed implementation would have panicked on double-Release. The SDK pairs Reserve/Release by construction so this shouldn't trigger in practice — but it does mean a bug that would have surfaced as a panic now slides as a silent over-release. Confirm none of the existing callers rely on panic-on-double-Release.
- **Tests covering this:** entire events sub-module suite passes without modification, plus 9 new tests on the seam.
- **Be paranoid about:** the dep cleanup. `golang.org/x/sync` drops from the events sub-module go.mod and from every consumer sub-module's go.sum (whole-enchilada/event-server, push-server, clients/go). Mechanical; verified with `make tidy-all`.

## Before / after

```
$ go test ./... -run "TestInMemoryQuotaStore|TestQuota_UsesCustomStore" -v
=== RUN   TestInMemoryQuotaStore_ReserveBelowMaxGrants    --- PASS
=== RUN   TestInMemoryQuotaStore_ReserveAtMaxDenies       --- PASS
=== RUN   TestInMemoryQuotaStore_ReleaseDecrements        --- PASS
=== RUN   TestInMemoryQuotaStore_ReleaseAtZeroIsNoOp      --- PASS
=== RUN   TestInMemoryQuotaStore_KeyScopedByPrincipalAndEventName --- PASS
=== RUN   TestQuota_UsesCustomStore_RoutesReserveAndRelease --- PASS
PASS

$ go test ./... -count=1 -timeout 180s
ok  github.com/panyam/mcpkit/experimental/ext/events  75.808s
```

## Out of scope (deliberately deferred)

- 628 CursorStore — flagged during planning that the issue's premise is partially aspirational (server doesn't currently persist per-subscription cursors; would need new behavior added before seaming). Separate, larger PR.
- 631 SubscriptionIndex storage seam — follows the same template.
- 630 Postgres-backed `QuotaStore` (likely lands as part of the Postgres-backed bundle for Webhook + Quota + Cursor stores).
- 634 Redis-backed `QuotaStore` via `INCR` + `EVAL`.
- Per-event-type total caps + per-principal total caps — separate axes; the existing Quota only does per-(principal, event-type) and this PR doesn't change that.
