### PR TITLE
events: add SubscriptionIndexStore seam (existing struct kept as default in-memory impl)

### DIFF
--- a/experimental/ext/events/README.md
+++ b/experimental/ext/events/README.md
@@ -140,7 +140,7 @@ type PollResult struct {
 - Retry with exponential backoff on 5xx (no retry on 4xx)
 - Basic SSRF validation on callback URLs
 - Pluggable signature format (see below)
-- Pluggable subscription storage via `WithWebhookStore` (default in-memory; Postgres lands in issue 630). Pluggable quota reservation counts via `WithQuotaStore`. See [`STORAGE_SEAMS.md`](STORAGE_SEAMS.md) for the convention every storage seam in this package follows.
+- Pluggable subscription storage via `WithWebhookStore`, quota counts via `WithQuotaStore`, subscription-id routing via the `SubscriptionIndexStore` interface on `Config.SubscriptionIndex` (default in-memory in all three; Postgres + Redis backends land in issues 630 / 634). See [`STORAGE_SEAMS.md`](STORAGE_SEAMS.md) for the convention every storage seam in this package follows.
 
 ```go
 webhooks := events.NewWebhookRegistry(

--- a/experimental/ext/events/STORAGE_SEAMS.md
+++ b/experimental/ext/events/STORAGE_SEAMS.md
@@ -15,7 +15,7 @@ Each storage concern has its own narrow interface:
 | `WebhookStore` | Webhook subscription CRUD (canonical key → target) | landed (627 / PR 671) |
 | `QuotaStore` | Reservation counts per (principal, eventName) | landed (626) |
 | `CursorStore` | Per-subscription persisted cursors | lands in 628 |
-| `SubscriptionIndex` storage seam | Subscription-id ↔ deliver-fn lookup table | lands in 631 |
+| `SubscriptionIndexStore` | Subscription-id ↔ deliver-fn lookup table | landed (631) |
 
 No umbrella `EventsStore` interface. The reasons:
 

--- a/experimental/ext/events/emit_targeted.go
+++ b/experimental/ext/events/emit_targeted.go
@@ -1,6 +1,9 @@
 package events
 
-import "log"
+import (
+	"context"
+	"log"
+)
 
 // EmitToSubscription delivers an event to exactly one subscription
 // identified by sub id, bypassing the broadcast fanout.
@@ -26,17 +29,17 @@ import "log"
 // id (the lease tuple is the routing identity per Q4). Calling
 // EmitToSubscription with a poll-mode id is a no-op of the
 // "unknown subID" variety.
-func EmitToSubscription(idx *SubscriptionIndex, event Event, subID string) {
+func EmitToSubscription(idx SubscriptionIndexStore, event Event, subID string) {
 	if idx == nil {
 		log.Printf("[events] EmitToSubscription: nil index; drop subID=%q event=%q",
 			subID, event.EventID)
 		return
 	}
-	_, deliver, ok := idx.Lookup(subID)
-	if !ok {
+	resp, _ := idx.LookupSubscription(context.Background(), LookupSubscriptionRequest{SubscriptionID: subID})
+	if !resp.Found || resp.Deliver == nil {
 		log.Printf("[events] EmitToSubscription: unknown subID=%q (already unsubscribed?); drop event=%q",
 			subID, event.EventID)
 		return
 	}
-	deliver(event)
+	resp.Deliver(event)
 }

--- a/experimental/ext/events/events.go
+++ b/experimental/ext/events/events.go
@@ -240,11 +240,17 @@ type Config struct {
 	// routing identity).
 	//
 	// Authors that want to call EmitToSubscription should construct
-	// one via NewSubscriptionIndex and pass it here so they hold a
-	// reference to the same instance the SDK populates. nil leaves
+	// one via NewSubscriptionIndex (or NewInMemorySubscriptionIndex
+	// for the typed-as-interface form) and pass it here so they hold
+	// a reference to the same instance the SDK populates. nil leaves
 	// Register to construct an internal default — fine for servers
 	// that only do broadcast emit.
-	SubscriptionIndex *SubscriptionIndex
+	//
+	// Field type is the SubscriptionIndexStore interface so multi-
+	// replica implementations plug in directly. *SubscriptionIndex
+	// (the default in-memory struct) satisfies the interface — no
+	// caller-side change for single-process deployments.
+	SubscriptionIndex SubscriptionIndexStore
 
 	// Quota enforces per-principal-per-event-type subscription caps
 	// per spec §"Server SDK Guidance" → "Subscription lifecycle
@@ -317,7 +323,7 @@ func Register(cfg Config) {
 			// Lookup will get the unknown-id branch (clean drop)
 			// rather than calling DeliverToTarget on a registry
 			// the target was just removed from.
-			idx.Remove(t.ID)
+			_, _ = idx.RemoveSubscription(context.Background(), RemoveSubscriptionRequest{SubscriptionID: t.ID})
 			// Release the quota slot. Pairs with the Reserve in
 			// registerSubscribe — fires once per actual removal
 			// (Unregister, prune, PostTerminated; NOT suspend —
@@ -633,8 +639,10 @@ func registerPoll(srv *server.Server, sourceMap map[string]EventSource, unsafeAn
 //
 // Path-1 (real auth): claims != nil → claims.Subject. Spec-correct.
 // Path-2 (demo escape): claims == nil and unsafeAnon != "" → unsafeAnon.
-//   Deliberately deviates from the spec; gated by Unsafe-prefix + startup
-//   warning in Register.
+//
+//	Deliberately deviates from the spec; gated by Unsafe-prefix + startup
+//	warning in Register.
+//
 // Path-3 (strict): claims == nil and unsafeAnon == "" → reject. Spec-correct.
 func resolvePrincipal(ctx core.MethodContext, unsafeAnon string) (string, bool) {
 	if claims := ctx.AuthClaims(); claims != nil {
@@ -646,7 +654,7 @@ func resolvePrincipal(ctx core.MethodContext, unsafeAnon string) (string, bool) 
 	return "", false
 }
 
-func registerSubscribe(srv *server.Server, sourceMap map[string]EventSource, webhooks *WebhookRegistry, unsafeAnon string, idx *SubscriptionIndex, quota *Quota) {
+func registerSubscribe(srv *server.Server, sourceMap map[string]EventSource, webhooks *WebhookRegistry, unsafeAnon string, idx SubscriptionIndexStore, quota *Quota) {
 	srv.HandleMethod("events/subscribe", func(ctx core.MethodContext, id json.RawMessage, params json.RawMessage) *core.Response {
 		var req struct {
 			// ID is parsed only to surface a helpful error if a client
@@ -774,8 +782,12 @@ func registerSubscribe(srv *server.Server, sourceMap map[string]EventSource, web
 			// (entry from the original subscribe still routes
 			// correctly; the canonical key didn't change).
 			canonicalCopy := append([]byte(nil), canonical...)
-			idx.Add(derivedID, DeliveryModeWebhook, func(event Event) {
-				webhooks.DeliverToTarget(canonicalCopy, event)
+			_, _ = idx.AddSubscription(context.Background(), AddSubscriptionRequest{
+				SubscriptionID: derivedID,
+				Mode:           DeliveryModeWebhook,
+				Deliver: func(event Event) {
+					webhooks.DeliverToTarget(canonicalCopy, event)
+				},
 			})
 		}
 

--- a/experimental/ext/events/stream.go
+++ b/experimental/ext/events/stream.go
@@ -114,7 +114,7 @@ type errPayload struct {
 	Message string `json:"message"`
 }
 
-func registerStream(srv *server.Server, sourceMap map[string]EventSource, unsafeAnon string, heartbeat time.Duration, idx *SubscriptionIndex, quota *Quota) {
+func registerStream(srv *server.Server, sourceMap map[string]EventSource, unsafeAnon string, heartbeat time.Duration, idx SubscriptionIndexStore, quota *Quota) {
 	if heartbeat <= 0 {
 		heartbeat = defaultStreamHeartbeatInterval
 	}
@@ -213,8 +213,14 @@ func registerStream(srv *server.Server, sourceMap map[string]EventSource, unsafe
 		// (spec §"Server SDK Guidance" L630). Removed on every
 		// return path so a closed stream's id can't match a stale
 		// entry.
-		idx.Add(streamSubID, DeliveryModePush, sender)
-		defer idx.Remove(streamSubID)
+		_, _ = idx.AddSubscription(ctx, AddSubscriptionRequest{
+			SubscriptionID: streamSubID,
+			Mode:           DeliveryModePush,
+			Deliver:        sender,
+		})
+		defer func() {
+			_, _ = idx.RemoveSubscription(context.Background(), RemoveSubscriptionRequest{SubscriptionID: streamSubID})
+		}()
 
 		// Send the confirmation notification. The loop below reads
 		// from evCh; active goes out via ctx.Notify before the loop

--- a/experimental/ext/events/subscription_index.go
+++ b/experimental/ext/events/subscription_index.go
@@ -1,6 +1,119 @@
 package events
 
-import "sync"
+import (
+	"context"
+	"sync"
+)
+
+// SubscriptionIndexStore is the storage seam behind subscription
+// routing. The default in-memory implementation — the SubscriptionIndex
+// struct in this file — matches the historical behavior exactly;
+// alternative implementations plug in for multi-replica deployments
+// where the cross-replica fanout layer (issue 629) handles non-local
+// subscriptions.
+//
+// Spec §"Server SDK Guidance" L630 names the use case: targeted
+// delivery via EmitToSubscription depends on a fast subID → destination
+// lookup. The index is maintained by the lifecycle wiring in
+// events.Register — per-mode registration sites call AddSubscription
+// when a subscription becomes live, RemoveSubscription when it tears
+// down.
+//
+// API shape: every method follows the gRPC-style
+//
+//	Method(ctx context.Context, req XRequest) (XResponse, error)
+//
+// convention pinned in STORAGE_SEAMS.md. ctx threads cancellation,
+// deadlines, and trace context. Application-level absence is reported
+// via Found on LookupSubscriptionResponse; error is reserved for
+// storage-layer failures.
+//
+// Closure non-serializability: AddSubscriptionRequest.Deliver is a
+// per-replica closure that captures local state (http.Client, push
+// channel). It cannot cross a network. Remote implementations of
+// SubscriptionIndexStore handle non-local subscriptions through a
+// separate cross-replica forwarding path (the EventBus seam, issue
+// 629), not by passing closures over the wire.
+//
+// Concurrency contract: the in-memory implementation takes its own
+// RWMutex (different from the WebhookStore and QuotaStore pattern,
+// where the wrapper holds a mutex around store calls — here, there
+// is no wrapper, the index is consumed directly). Implementations
+// shared across replicas (Redis, Kafka topic listing) take their own
+// locks or use transaction semantics.
+type SubscriptionIndexStore interface {
+	AddSubscription(ctx context.Context, req AddSubscriptionRequest) (AddSubscriptionResponse, error)
+	RemoveSubscription(ctx context.Context, req RemoveSubscriptionRequest) (RemoveSubscriptionResponse, error)
+	LookupSubscription(ctx context.Context, req LookupSubscriptionRequest) (LookupSubscriptionResponse, error)
+	CountSubscriptions(ctx context.Context, req CountSubscriptionsRequest) (CountSubscriptionsResponse, error)
+}
+
+// AddSubscriptionRequest registers a subscription. Replaces any
+// existing entry for the same SubscriptionID — webhook
+// subscribe-then-refresh on the same canonical tuple keeps the same
+// id but may have re-targeted; the latest wiring wins.
+type AddSubscriptionRequest struct {
+	SubscriptionID string
+	Mode           DeliveryMode
+	// Deliver is the local delivery closure. Captures per-replica
+	// state — fundamentally non-serializable. Remote implementations
+	// reject Add requests with a non-nil Deliver (returning an error)
+	// and route non-local subscriptions through the cross-replica
+	// EventBus seam instead.
+	Deliver func(Event)
+}
+
+// AddSubscriptionResponse is empty today; reserved for future fields.
+type AddSubscriptionResponse struct{}
+
+// RemoveSubscriptionRequest drops the entry for SubscriptionID. Idempotent
+// — removing an unknown id is a silent no-op.
+type RemoveSubscriptionRequest struct {
+	SubscriptionID string
+}
+
+// RemoveSubscriptionResponse is empty today.
+type RemoveSubscriptionResponse struct{}
+
+// LookupSubscriptionRequest fetches the routing entry for SubscriptionID.
+type LookupSubscriptionRequest struct {
+	SubscriptionID string
+}
+
+// LookupSubscriptionResponse carries the routing entry. Found is
+// false when the subscription is unknown — caller should treat as
+// "subscription was torn down" and drop the event with a debug log
+// (the canonical EmitToSubscription path does this).
+//
+// Mode is the delivery mode the subscription was registered with;
+// caller may shape the forwarded payload accordingly. Deliver is the
+// per-replica delivery closure for local subscriptions; nil when the
+// subscription is registered remotely (the cross-replica forwarder
+// reconstructs delivery without a closure).
+type LookupSubscriptionResponse struct {
+	Mode    DeliveryMode
+	Deliver func(Event)
+	Found   bool
+}
+
+// CountSubscriptionsRequest is empty today.
+type CountSubscriptionsRequest struct{}
+
+// CountSubscriptionsResponse carries the current entry count.
+// Implementations MAY approximate Count for performance.
+type CountSubscriptionsResponse struct {
+	Count int
+}
+
+// NewInMemorySubscriptionIndex returns the default in-memory storage
+// implementation typed as the SubscriptionIndexStore interface.
+// Matches the family pattern (NewInMemoryWebhookStore /
+// NewInMemoryQuotaStore). For backward compatibility, NewSubscriptionIndex
+// continues to return the concrete *SubscriptionIndex struct, which
+// also satisfies SubscriptionIndexStore.
+func NewInMemorySubscriptionIndex() SubscriptionIndexStore {
+	return NewSubscriptionIndex()
+}
 
 // SubscriptionIndex maps a server-derived subscription id to the
 // callback that delivers an event to that specific subscription. It
@@ -8,11 +121,12 @@ import "sync"
 // SDK Guidance" L630) so an author who knows the target sub id can
 // bypass broadcast fanout.
 //
-// The index is maintained by the lifecycle wiring in Register:
-// per-mode registration sites call Add when a subscription becomes
-// live and Remove when it's torn down. Mode is recorded so callers
-// that want to introspect ("is this a push or webhook subscription?")
-// can do so without scanning the deliver closure.
+// SubscriptionIndex is the default in-memory implementation of the
+// SubscriptionIndexStore interface — the struct name is preserved
+// for backward compatibility with existing callers that hold
+// *SubscriptionIndex references. Construct via NewSubscriptionIndex
+// or NewInMemorySubscriptionIndex (the latter returns the interface
+// type, matching the family convention).
 //
 // Push subscriptions: each open events/stream gets its own random
 // sub id — concurrent streams from the same principal/name/params
@@ -41,52 +155,90 @@ func NewSubscriptionIndex() *SubscriptionIndex {
 	return &SubscriptionIndex{entries: make(map[string]subscriptionEntry)}
 }
 
-// Add registers a subscription. Subsequent EmitToSubscription calls
-// for subID will route to deliver. Replaces any existing entry for the
-// same subID — webhook subscribe-then-refresh on the same canonical
-// tuple keeps the same id but may have re-targeted; the latest wiring
-// wins.
-//
-// deliver should be non-blocking and tolerate the subscription being
-// torn down concurrently (Remove may race with delivery).
-func (i *SubscriptionIndex) Add(subID string, mode DeliveryMode, deliver func(Event)) {
-	if subID == "" || deliver == nil {
-		return
+// AddSubscription implements SubscriptionIndexStore. Empty
+// SubscriptionID or nil Deliver are silently dropped — preserves the
+// old Add's defensive behavior.
+func (i *SubscriptionIndex) AddSubscription(_ context.Context, req AddSubscriptionRequest) (AddSubscriptionResponse, error) {
+	if req.SubscriptionID == "" || req.Deliver == nil {
+		return AddSubscriptionResponse{}, nil
 	}
 	i.mu.Lock()
 	defer i.mu.Unlock()
-	i.entries[subID] = subscriptionEntry{mode: mode, deliver: deliver}
+	i.entries[req.SubscriptionID] = subscriptionEntry{mode: req.Mode, deliver: req.Deliver}
+	return AddSubscriptionResponse{}, nil
 }
 
-// Remove drops the entry for subID. Safe to call for an unknown id
-// (no-op).
-func (i *SubscriptionIndex) Remove(subID string) {
-	if subID == "" {
-		return
+// RemoveSubscription implements SubscriptionIndexStore. Empty
+// SubscriptionID is a no-op.
+func (i *SubscriptionIndex) RemoveSubscription(_ context.Context, req RemoveSubscriptionRequest) (RemoveSubscriptionResponse, error) {
+	if req.SubscriptionID == "" {
+		return RemoveSubscriptionResponse{}, nil
 	}
 	i.mu.Lock()
 	defer i.mu.Unlock()
-	delete(i.entries, subID)
+	delete(i.entries, req.SubscriptionID)
+	return RemoveSubscriptionResponse{}, nil
 }
 
-// Lookup returns the entry's mode and deliver function. ok is false
-// when the id is unknown — caller should treat as "subscription was
-// torn down" and drop the event with a debug log (the canonical
-// EmitToSubscription path does this).
-func (i *SubscriptionIndex) Lookup(subID string) (mode DeliveryMode, deliver func(Event), ok bool) {
+// LookupSubscription implements SubscriptionIndexStore.
+func (i *SubscriptionIndex) LookupSubscription(_ context.Context, req LookupSubscriptionRequest) (LookupSubscriptionResponse, error) {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
-	e, ok := i.entries[subID]
+	e, ok := i.entries[req.SubscriptionID]
 	if !ok {
+		return LookupSubscriptionResponse{}, nil
+	}
+	return LookupSubscriptionResponse{Mode: e.mode, Deliver: e.deliver, Found: true}, nil
+}
+
+// CountSubscriptions implements SubscriptionIndexStore.
+func (i *SubscriptionIndex) CountSubscriptions(_ context.Context, _ CountSubscriptionsRequest) (CountSubscriptionsResponse, error) {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return CountSubscriptionsResponse{Count: len(i.entries)}, nil
+}
+
+// Add registers a subscription via the legacy positional API. Routes
+// through AddSubscription.
+//
+// Deprecated: use AddSubscription(ctx, AddSubscriptionRequest{…}).
+// Retained for backward compatibility with callers that constructed
+// *SubscriptionIndex before the storage seam landed.
+func (i *SubscriptionIndex) Add(subID string, mode DeliveryMode, deliver func(Event)) {
+	_, _ = i.AddSubscription(context.Background(), AddSubscriptionRequest{
+		SubscriptionID: subID,
+		Mode:           mode,
+		Deliver:        deliver,
+	})
+}
+
+// Remove drops the entry via the legacy positional API.
+//
+// Deprecated: use RemoveSubscription(ctx, RemoveSubscriptionRequest{…}).
+func (i *SubscriptionIndex) Remove(subID string) {
+	_, _ = i.RemoveSubscription(context.Background(), RemoveSubscriptionRequest{
+		SubscriptionID: subID,
+	})
+}
+
+// Lookup returns the entry via the legacy positional API.
+//
+// Deprecated: use LookupSubscription(ctx, LookupSubscriptionRequest{…}).
+func (i *SubscriptionIndex) Lookup(subID string) (mode DeliveryMode, deliver func(Event), ok bool) {
+	resp, _ := i.LookupSubscription(context.Background(), LookupSubscriptionRequest{
+		SubscriptionID: subID,
+	})
+	if !resp.Found {
 		return deliveryModeUnset, nil, false
 	}
-	return e.mode, e.deliver, true
+	return resp.Mode, resp.Deliver, true
 }
 
-// Len returns the number of currently-indexed subscriptions. Snapshot
-// — callers must not race on it for correctness.
+// Len returns the number of currently-indexed subscriptions via the
+// legacy API.
+//
+// Deprecated: use CountSubscriptions(ctx, CountSubscriptionsRequest{}).
 func (i *SubscriptionIndex) Len() int {
-	i.mu.RLock()
-	defer i.mu.RUnlock()
-	return len(i.entries)
+	resp, _ := i.CountSubscriptions(context.Background(), CountSubscriptionsRequest{})
+	return resp.Count
 }

--- a/experimental/ext/events/subscription_index_test.go
+++ b/experimental/ext/events/subscription_index_test.go
@@ -1,0 +1,204 @@
+package events
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInMemorySubscriptionIndex_AddLookupRoundTrip(t *testing.T) {
+	idx := NewInMemorySubscriptionIndex()
+	var delivered Event
+	deliver := func(e Event) { delivered = e }
+
+	_, err := idx.AddSubscription(context.Background(), AddSubscriptionRequest{
+		SubscriptionID: "sub_a",
+		Mode:           DeliveryModePush,
+		Deliver:        deliver,
+	})
+	require.NoError(t, err)
+
+	resp, err := idx.LookupSubscription(context.Background(), LookupSubscriptionRequest{SubscriptionID: "sub_a"})
+	require.NoError(t, err)
+	require.True(t, resp.Found)
+	assert.Equal(t, DeliveryModePush, resp.Mode)
+	require.NotNil(t, resp.Deliver)
+
+	resp.Deliver(Event{EventID: "evt_x"})
+	assert.Equal(t, "evt_x", delivered.EventID)
+}
+
+func TestInMemorySubscriptionIndex_ReplaceOnSameID(t *testing.T) {
+	idx := NewInMemorySubscriptionIndex()
+	var which string
+
+	_, _ = idx.AddSubscription(context.Background(), AddSubscriptionRequest{
+		SubscriptionID: "sub_a",
+		Mode:           DeliveryModePush,
+		Deliver:        func(Event) { which = "first" },
+	})
+	_, _ = idx.AddSubscription(context.Background(), AddSubscriptionRequest{
+		SubscriptionID: "sub_a",
+		Mode:           DeliveryModeWebhook,
+		Deliver:        func(Event) { which = "second" },
+	})
+
+	resp, _ := idx.LookupSubscription(context.Background(), LookupSubscriptionRequest{SubscriptionID: "sub_a"})
+	resp.Deliver(Event{})
+	assert.Equal(t, "second", which, "second Add must replace the first; latest wiring wins")
+	assert.Equal(t, DeliveryModeWebhook, resp.Mode, "mode must reflect the replacing entry")
+
+	count, _ := idx.CountSubscriptions(context.Background(), CountSubscriptionsRequest{})
+	assert.Equal(t, 1, count.Count, "replace must not duplicate")
+}
+
+func TestInMemorySubscriptionIndex_RemoveDropsEntry(t *testing.T) {
+	idx := NewInMemorySubscriptionIndex()
+	_, _ = idx.AddSubscription(context.Background(), AddSubscriptionRequest{
+		SubscriptionID: "sub_a", Mode: DeliveryModePush, Deliver: func(Event) {},
+	})
+	_, _ = idx.RemoveSubscription(context.Background(), RemoveSubscriptionRequest{SubscriptionID: "sub_a"})
+
+	resp, _ := idx.LookupSubscription(context.Background(), LookupSubscriptionRequest{SubscriptionID: "sub_a"})
+	assert.False(t, resp.Found)
+	assert.Nil(t, resp.Deliver)
+}
+
+func TestInMemorySubscriptionIndex_RemoveUnknownIsNoOp(t *testing.T) {
+	idx := NewInMemorySubscriptionIndex()
+	_, err := idx.RemoveSubscription(context.Background(), RemoveSubscriptionRequest{SubscriptionID: "nope"})
+	require.NoError(t, err)
+
+	count, _ := idx.CountSubscriptions(context.Background(), CountSubscriptionsRequest{})
+	assert.Equal(t, 0, count.Count)
+}
+
+func TestInMemorySubscriptionIndex_LookupMissReturnsZeroValues(t *testing.T) {
+	idx := NewInMemorySubscriptionIndex()
+	resp, err := idx.LookupSubscription(context.Background(), LookupSubscriptionRequest{SubscriptionID: "nope"})
+	require.NoError(t, err)
+	assert.False(t, resp.Found)
+	assert.Nil(t, resp.Deliver)
+	assert.Equal(t, deliveryModeUnset, resp.Mode, "lookup miss returns the zero DeliveryMode (unset)")
+}
+
+func TestInMemorySubscriptionIndex_CountTracksAddsAndRemoves(t *testing.T) {
+	idx := NewInMemorySubscriptionIndex()
+	ctx := context.Background()
+
+	zero, _ := idx.CountSubscriptions(ctx, CountSubscriptionsRequest{})
+	assert.Equal(t, 0, zero.Count)
+
+	_, _ = idx.AddSubscription(ctx, AddSubscriptionRequest{SubscriptionID: "a", Mode: DeliveryModePush, Deliver: func(Event) {}})
+	_, _ = idx.AddSubscription(ctx, AddSubscriptionRequest{SubscriptionID: "b", Mode: DeliveryModePush, Deliver: func(Event) {}})
+	two, _ := idx.CountSubscriptions(ctx, CountSubscriptionsRequest{})
+	assert.Equal(t, 2, two.Count)
+
+	_, _ = idx.RemoveSubscription(ctx, RemoveSubscriptionRequest{SubscriptionID: "a"})
+	one, _ := idx.CountSubscriptions(ctx, CountSubscriptionsRequest{})
+	assert.Equal(t, 1, one.Count)
+}
+
+func TestInMemorySubscriptionIndex_AddEmptySubIDIsDropped(t *testing.T) {
+	// Preserves the legacy defensive behavior the old Add had.
+	idx := NewInMemorySubscriptionIndex()
+	_, _ = idx.AddSubscription(context.Background(), AddSubscriptionRequest{
+		SubscriptionID: "", Mode: DeliveryModePush, Deliver: func(Event) {},
+	})
+	count, _ := idx.CountSubscriptions(context.Background(), CountSubscriptionsRequest{})
+	assert.Equal(t, 0, count.Count, "empty SubscriptionID must be silently dropped")
+}
+
+func TestInMemorySubscriptionIndex_AddNilDeliverIsDropped(t *testing.T) {
+	idx := NewInMemorySubscriptionIndex()
+	_, _ = idx.AddSubscription(context.Background(), AddSubscriptionRequest{
+		SubscriptionID: "sub_a", Mode: DeliveryModePush, Deliver: nil,
+	})
+	count, _ := idx.CountSubscriptions(context.Background(), CountSubscriptionsRequest{})
+	assert.Equal(t, 0, count.Count, "nil Deliver must be silently dropped")
+}
+
+// spySubscriptionIndex wraps an in-memory index with a call recorder so
+// EmitToSubscription's interface-routing path is verifiable end-to-end.
+type spySubscriptionIndex struct {
+	inner SubscriptionIndexStore
+	mu    sync.Mutex
+	calls []string
+}
+
+func newSpySubscriptionIndex() *spySubscriptionIndex {
+	return &spySubscriptionIndex{inner: NewInMemorySubscriptionIndex()}
+}
+
+func (s *spySubscriptionIndex) record(op string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = append(s.calls, op)
+}
+
+func (s *spySubscriptionIndex) snapshot() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, len(s.calls))
+	copy(out, s.calls)
+	return out
+}
+
+func (s *spySubscriptionIndex) AddSubscription(ctx context.Context, req AddSubscriptionRequest) (AddSubscriptionResponse, error) {
+	s.record("Add")
+	return s.inner.AddSubscription(ctx, req)
+}
+func (s *spySubscriptionIndex) RemoveSubscription(ctx context.Context, req RemoveSubscriptionRequest) (RemoveSubscriptionResponse, error) {
+	s.record("Remove")
+	return s.inner.RemoveSubscription(ctx, req)
+}
+func (s *spySubscriptionIndex) LookupSubscription(ctx context.Context, req LookupSubscriptionRequest) (LookupSubscriptionResponse, error) {
+	s.record("Lookup")
+	return s.inner.LookupSubscription(ctx, req)
+}
+func (s *spySubscriptionIndex) CountSubscriptions(ctx context.Context, req CountSubscriptionsRequest) (CountSubscriptionsResponse, error) {
+	s.record("Count")
+	return s.inner.CountSubscriptions(ctx, req)
+}
+
+func TestEmitToSubscription_RoutesViaInterface(t *testing.T) {
+	spy := newSpySubscriptionIndex()
+	var delivered Event
+	_, _ = spy.AddSubscription(context.Background(), AddSubscriptionRequest{
+		SubscriptionID: "sub_a", Mode: DeliveryModePush,
+		Deliver: func(e Event) { delivered = e },
+	})
+
+	EmitToSubscription(spy, Event{EventID: "evt_y"}, "sub_a")
+
+	assert.Equal(t, []string{"Add", "Lookup"}, spy.snapshot())
+	assert.Equal(t, "evt_y", delivered.EventID)
+}
+
+func TestEmitToSubscription_LookupMissDropsSilently(t *testing.T) {
+	spy := newSpySubscriptionIndex()
+	// No Add — Lookup will miss.
+	EmitToSubscription(spy, Event{EventID: "evt_z"}, "unknown")
+	assert.Equal(t, []string{"Lookup"}, spy.snapshot(), "miss must not panic; only one Lookup")
+}
+
+func TestLegacyAddRemoveLookupShimsStillWork(t *testing.T) {
+	// Backward compat: the deprecated Add / Remove / Lookup / Len
+	// methods still drive the underlying state via the new gRPC-style
+	// methods.
+	idx := NewSubscriptionIndex()
+	idx.Add("sub_a", DeliveryModePush, func(Event) {})
+	assert.Equal(t, 1, idx.Len())
+
+	mode, deliver, ok := idx.Lookup("sub_a")
+	assert.True(t, ok)
+	assert.Equal(t, DeliveryModePush, mode)
+	assert.NotNil(t, deliver)
+
+	idx.Remove("sub_a")
+	_, _, ok = idx.Lookup("sub_a")
+	assert.False(t, ok)
+}


### PR DESCRIPTION
## What changes

Adds the `SubscriptionIndexStore` interface alongside the existing `SubscriptionIndex` struct, following the gRPC-style storage-seam convention pinned by 627/PR 671 and 626/PR 673 in `STORAGE_SEAMS.md`. The existing struct is preserved as the default in-memory implementation; external callers holding `*events.SubscriptionIndex` (kitchen-sink demo from PR 655) compile and pass tests without any changes — `*SubscriptionIndex` satisfies the new interface naturally.

Closes 631.

## Reviewer's guide

Read in this order:

1. [experimental/ext/events/subscription_index.go](https://github.com/panyam/mcpkit/pull/675/files#diff-274d0440e9d82da76ec95cee7d1385ec9c4bd676eec8f6d8370eca0588f51527) — start here. The new `SubscriptionIndexStore` interface + Request/Response types are at the top. The existing `SubscriptionIndex` struct stays as the default in-memory impl with new gRPC-style methods (`AddSubscription` / `RemoveSubscription` / `LookupSubscription` / `CountSubscriptions`). Existing `Add` / `Remove` / `Lookup` / `Len` methods are kept as `// Deprecated:` shims routing through the new methods — zero churn for external callers, future cleanup pass can remove them. Pay attention to: the `AddSubscriptionRequest.Deliver` doc spells out closure non-serializability (remote impls handle non-local subs through the cross-replica EventBus seam, not by passing closures over the wire).
2. [experimental/ext/events/emit_targeted.go](https://github.com/panyam/mcpkit/pull/675/files#diff-1b33a181fc018a8a90729dc6cc9e57f72c37baa93514730e42e63c8995c9adde) — `EmitToSubscription` takes the interface now instead of `*SubscriptionIndex`. Pointer-to-struct still works because the struct satisfies the interface.
3. [experimental/ext/events/events.go](https://github.com/panyam/mcpkit/pull/675/files#diff-4a2a8cf5f00e8770df09ab463340a5fc393acbf3f95ef59af8280e2a7a814815) — `Config.SubscriptionIndex` field type widened from `*SubscriptionIndex` to `SubscriptionIndexStore`. `registerSubscribe` parameter widened. The internal Add/Remove call sites at lines 326 and 783 switched to the gRPC-style methods.
4. [experimental/ext/events/stream.go](https://github.com/panyam/mcpkit/pull/675/files#diff-96edd7245bb56be7d7b0c1cd748792b42a783f433aa3306d5078210e7881800a) — `registerStream` parameter widened; the Add/Remove pair inside the handler uses the new methods.
5. [experimental/ext/events/subscription_index_test.go](https://github.com/panyam/mcpkit/pull/675/files#diff-4d23b0cb590c92a11f97640c92bcdd870192bf7ac3bb038b37b1bb2fc696586c) — 11 new tests: round-trip, replace-on-same-id, remove semantics, remove-unknown no-op, lookup-miss zero values, count tracking, empty-subID + nil-Deliver defensive drops (preserves old behavior), spy-store call sequence via `EmitToSubscription`, lookup-miss drop, and legacy-shim backward-compat.
6. [experimental/ext/events/STORAGE_SEAMS.md](https://github.com/panyam/mcpkit/pull/675/files#diff-ceea0a5339d9583578ba93a8fd23a5cc2cc61ae832839b943f6d8e02b0bf6954) + [experimental/ext/events/README.md](https://github.com/panyam/mcpkit/pull/675/files#diff-9222f2c9c82e15be71e1b286719f2d44d107c3ea315805c64c3d617ab960d4b3) — table row flipped to landed; README one-line mention of the interface alongside `WithWebhookStore` / `WithQuotaStore`.

Skim: nothing else changes.

## Test counts

- **Added: 11 new tests** in `subscription_index_test.go`.
- **Existing tests: 0 changed assertions.** Full events sub-module suite (75s) green; main `make test` green; kitchen-sink demo's e2e tests pass unchanged.
- **Removed / weakened: 0.**

## Decision log

| Decision | Chose | Over | Why |
|---|---|---|---|
| Interface name | `SubscriptionIndexStore` (additive) | Hoist `SubscriptionIndex` as the interface | Hoisting would break external callers using `*events.SubscriptionIndex` (kitchen-sink demo from PR 655). Additive interface preserves backward compat with zero kitchen-sink edits. Naming is slightly redundant ("SubscriptionIndex storage seam") but consistent with the `*Store` family suffix. |
| Keep Add/Remove/Lookup/Len | Deprecated shims routing through the new methods | Remove entirely | Internal callers + external kitchen-sink demo + future-reader expectations all read better with both APIs present during the transition. Future cleanup pass can remove the shims. |
| `Deliver` closure in Request | Yes, as a non-serializable field | Pass a routing key + reconstruct on the impl side | The in-memory case is the load-bearing path today; remote impls handle non-local subs through the cross-replica EventBus seam (issue 629), not by accepting closures. Documented loudly in the Request godoc. |
| Remote-fallback wrapper | Deferred to #629 | Include a `WithRemoteFallback` constructor here | Stays in scope of #631's "interface only" framing; the forwarding semantics are EventBus design territory. |
| `Config.SubscriptionIndex` type change | Interface | Keep `*SubscriptionIndex` | Pointer-to-struct still satisfies the interface, so existing `Config{SubscriptionIndex: events.NewSubscriptionIndex()}` continues to work. |

## Risk / blast radius

- **Affects:** subscription routing internal call sites. Public API surface is additive — new `SubscriptionIndexStore` interface + Request/Response types + `NewInMemorySubscriptionIndex()` constructor. Existing `SubscriptionIndex` struct keeps every existing method (legacy ones marked Deprecated).
- **External callers:** kitchen-sink demo from PR 655 continues to compile + pass tests without code changes — `*events.SubscriptionIndex` satisfies the new interface.
- **Be paranoid about:** the closure non-serializability note. Real remote impls will reject Add calls with non-nil Deliver; the godoc on `AddSubscriptionRequest.Deliver` spells this out so future implementors don't try to wire a "send the closure over gRPC" model.

## Out of scope (deliberately deferred)

- 629 EventBus cross-replica forwarding (the "remote-fallback" hook from 631's body lives there)
- 630 Postgres / 634 Redis backends — neither implements SubscriptionIndexStore because the closure model doesn't translate
- Removing the legacy `Add` / `Remove` / `Lookup` / `Len` shims — future cleanup pass after consumers migrate
