### PR TITLE
events: pin canonical -32013 ResourceExhausted wire shape (two-emission-paths table)

### DIFF
--- a/examples/events/kitchen-sink/e2e_test.go
+++ b/examples/events/kitchen-sink/e2e_test.go
@@ -359,6 +359,69 @@ func TestQuota_RejectsBeyondCapWithStructuredError(t *testing.T) {
 	assert.EqualValues(t, quotaCap, dataMap["max"], "spec quota error data should include max=cap configured")
 }
 
+// TestQuota_OnSubscribeRejection_WireShape pins the SECOND -32013
+// emission path documented in experimental/ext/events/errors.go's
+// ResourceExhaustedData godoc: when an EventDef's OnSubscribe hook
+// returns an error AFTER the Reserve granted, the response carries
+// code=-32013, limit="subscriptions", max ABSENT on the wire (the
+// server didn't impose the rejection — the author did), and a message
+// starting with "on_subscribe rejected:".
+//
+// Complements TestQuota_RejectsBeyondCapWithStructuredError above,
+// which pins the Reserve-failure path (max present, > 0).
+func TestQuota_OnSubscribeRejection_WireShape(t *testing.T) {
+	srcWithRejectingHook, _ := events.NewYieldingSource[ChatMessageData](events.EventDef{
+		Name:        "rejecting.event",
+		Description: "Source whose OnSubscribe always rejects.",
+		Delivery:    []string{"webhook"},
+		OnSubscribe: func(_ events.HookContext, _ map[string]any) error {
+			return assert.AnError
+		},
+	})
+
+	webhooks := events.NewWebhookRegistry(events.WithWebhookAllowPrivateNetworks(true))
+	srv := server.NewServer(
+		core.ServerInfo{Name: "kitchen-sink-rejecting-hook-test", Version: "0.1.0"},
+		server.WithSubscriptions(),
+	)
+	events.Register(events.Config{
+		Sources:                  []events.EventSource{srcWithRejectingHook},
+		Webhooks:                 webhooks,
+		Server:                   srv,
+		UnsafeAnonymousPrincipal: "test-principal",
+	})
+
+	handler := srv.Handler(server.WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "test", Version: "1.0"})
+	require.NoError(t, c.Connect())
+	defer c.Close()
+
+	recv := nopReceiverServer()
+	defer recv.Close()
+
+	_, err := eventsclient.Subscribe(context.Background(), c, eventsclient.SubscribeOptions{
+		EventName:   "rejecting.event",
+		CallbackURL: recv.URL,
+	})
+	require.Error(t, err, "subscribe must fail when OnSubscribe rejects")
+
+	rpc := unwrapRPC(err)
+	require.NotNil(t, rpc, "error must unwrap to *client.RPCError; got %T: %v", err, err)
+	assert.Equal(t, -32013, rpc.Code, "second emission path uses the same code as Reserve failure")
+	assert.Contains(t, rpc.Message, "on_subscribe rejected:",
+		"second emission path's message starts with %q; got %q", "on_subscribe rejected:", rpc.Message)
+
+	dataMap, ok := rpc.Data.(map[string]any)
+	require.True(t, ok, "rpc.Data should be a map, got %T", rpc.Data)
+	assert.Equal(t, "subscriptions", dataMap["limit"], "limit name is constant across emission paths")
+	_, hasMax := dataMap["max"]
+	assert.False(t, hasMax,
+		"max MUST be absent on the wire for on_subscribe-rejection path (omitempty + value 0); presence is the canonical discriminator from the Reserve-failure path")
+}
+
 func unwrapRPC(err error) *client.RPCError {
 	for err != nil {
 		if rpc, ok := err.(*client.RPCError); ok {

--- a/examples/events/kitchen-sink/walkthrough.go
+++ b/examples/events/kitchen-sink/walkthrough.go
@@ -221,7 +221,12 @@ func runDemo() {
 	demo.Step("What stops a noisy client from subscribing 100 times?").
 		Arrow("Host", "Server", "events/subscribe ×3 (chat.message)").
 		DashedArrow("Server", "Host", "1st: id=sub_...; 2nd: id=sub_...; 3rd: error -32013").
-		Note("Quota is configured per-principal-per-event-type at events.Register time. The third subscribe under the same principal returns -32013 TooManySubscriptions with structured data {limit:\"subscriptions\", max:N} — clients can read the max to know the cap without consulting docs.").
+		Note("Quota is configured per-principal-per-event-type at events.Register time. The third subscribe under the same principal returns -32013 ResourceExhausted with structured data {limit:\"subscriptions\", max:N} — clients read the max to know the cap without consulting docs. " +
+			"Two emission paths share this shape (see experimental/ext/events/errors.go's ResourceExhaustedData godoc for the canonical table): " +
+			"(a) Reserve failure — quota counter at the configured cap; message names the cap; data.max > 0. " +
+			"(b) on_subscribe rejection — author OnSubscribe hook returned an error AFTER Reserve granted; message starts \"on_subscribe rejected:\"; data.max absent on the wire (the server didn't impose this rejection, the author did). " +
+			"Clients that want to discriminate read data.max presence; clients that just want \"too many subscriptions\" UX treat both uniformly. " +
+			"This shape is the canonical reference for whole-enchilada stages 2/3/4 (tenant-level quotas, multi-replica): same code, same data shape, same two emission paths.").
 		Run(func(_ demokit.StepContext) *demokit.StepResult {
 			if c == nil {
 				return nil

--- a/examples/events/whole-enchilada/walkthrough/walkthrough.go
+++ b/examples/events/whole-enchilada/walkthrough/walkthrough.go
@@ -212,6 +212,7 @@ func runDemo(serverURL, receiverURL string) {
 		"- Keycloak realm with multi-tenant subscriptions (events/subscribe rejected if not authenticated).",
 		"- Tenant identifier flows from token claims into source/subscription scoping.",
 		"- Anonymous principal demo escape removed.",
+		"- Per-tenant quota with the canonical -32013 ResourceExhausted wire shape pinned by kitchen-sink ({limit:\"subscriptions\", max:N}; see experimental/ext/events/errors.go's ResourceExhaustedData godoc). Same shape, same two emission paths (Reserve failure vs on_subscribe rejection) — a single client switch over (code, data) works for both demos.",
 	)
 	demo.Section("What stage 3 adds",
 		"- Postgres-backed cursor / webhook / quota stores. Restart-survival for the demo.",

--- a/experimental/ext/events/errors.go
+++ b/experimental/ext/events/errors.go
@@ -57,6 +57,27 @@ type NotFoundData struct {
 // server is willing to expose it. Max is omitted when zero so the
 // client can distinguish "limit hit, ceiling not disclosed" from
 // "limit hit, ceiling = 0".
+//
+// Canonical wire shape for the quota-rejection path. Both demos in
+// examples/events/ (kitchen-sink, whole-enchilada) emit responses
+// matching this shape; a single client-side switch over (code, data)
+// works across both deployments. Two distinct emission paths share
+// the shape — the discriminator is whether Max is present on the wire:
+//
+//	Path             | When                                | message                                              | data.max
+//	─────────────────┼─────────────────────────────────────┼──────────────────────────────────────────────────────┼─────────────────────────────
+//	Reserve failure  | Quota counter at configured cap     | "TooManySubscriptions: principal %q at cap %d for %q" | >0 (the configured cap)
+//	on_subscribe     | Author OnSubscribe hook returned an | "on_subscribe rejected: <author err>"                | 0 → omitted on the wire via
+//	rejection        | error AFTER Reserve granted         |                                                      | omitempty (Max key absent)
+//
+// Clients that want to discriminate the two paths read `data.max`
+// presence: present → server-imposed quota with a known ceiling;
+// absent → author-imposed refusal without a disclosed ceiling. Both
+// paths return identical Code (-32013) and Limit ("subscriptions"),
+// so generic "too many subscriptions" UX can treat them uniformly.
+//
+// emission sites: experimental/ext/events/events.go (registerPoll and
+// registerSubscribe). Both call newResourceExhaustedError below.
 type ResourceExhaustedData struct {
 	Limit string `json:"limit"`
 	Max   int64  `json:"max,omitempty"`


### PR DESCRIPTION
## What changes

Pins the `{limit, max}` wire shape kitchen-sink already exercises as the canonical reference for the future whole-enchilada quota walkthrough step (stages 2–4). Cross-documents the **two distinct emission paths** so a single client switch over `(code, data)` works across both demos. Pure documentation + one new test.

Closes 635.

### The two paths

| Path | When | message | `data.max` |
|---|---|---|---|
| `Reserve` failure | quota counter at the configured cap | `"TooManySubscriptions: principal %q at cap %d for %q"` | `> 0` (the configured cap) |
| `on_subscribe` rejection | author OnSubscribe hook returned an error AFTER Reserve granted | `"on_subscribe rejected: <author err>"` | `0` → omitted on the wire (omitempty) |

Both share `code: -32013` and `data.limit: "subscriptions"`. Discriminator is whether `data.max` is present on the wire.

## Reviewer's guide

Read in this order:

1. [experimental/ext/events/errors.go](https://github.com/panyam/mcpkit/pull/678/files#diff-a4f6e6ce5fc8c7f858f262a5879257bc40bbd530e76d9b540f6e4b20454a950a) — start here. `ResourceExhaustedData` godoc gains the two-emission-paths table inline. This is the source of truth (no separate docs file to go stale).
2. [examples/events/kitchen-sink/e2e_test.go](https://github.com/panyam/mcpkit/pull/678/files#diff-f0a53f62bfe1bdb89d8540cd5a219ba2f2e7ce07433b27c91eb8ec63f28e74b2) — new `TestQuota_OnSubscribeRejection_WireShape` pins the second emission path. The existing `TestQuota_RejectsBeyondCapWithStructuredError` (further up the file) continues to pin the Reserve-failure path. Together they lock the canon in code.
3. [examples/events/kitchen-sink/walkthrough.go](https://github.com/panyam/mcpkit/pull/678/files#diff-7236e2f0b8c14abc7c0d931b466ed6dad8f6652f52afee6b5c00e682d4b06fb5) — quota step's `Note(...)` expanded to describe both paths and point at the godoc.
4. [examples/events/whole-enchilada/walkthrough/walkthrough.go](https://github.com/panyam/mcpkit/pull/678/files#diff-e28ceaefb14db6814312769a48b6994afaa628a23206094dd79efe235486dd83) — "What stage 2 adds" callout includes a per-tenant quota bullet that forward-references the kitchen-sink quota step / godoc as the canon. Wires the cross-reference even before stage-2's quota walkthrough lands.

Skim: nothing else changes.

## Test counts

- **Added: 5 assertions** in one new test (`TestQuota_OnSubscribeRejection_WireShape`).
- **Existing tests: unchanged.** Repo-wide `make test` green; kitchen-sink quota tests both pass; full events sub-module suite still green.
- **Removed / weakened: 0.**

## Decision log

| Decision | Chose | Over | Why |
|---|---|---|---|
| Where to put the canon | Inline godoc on `ResourceExhaustedData` | New `docs/QUOTA_WIRE_SHAPE.md` | The godoc is grep-able from any consumer's IDE; a separate file goes stale faster. |
| Test the second path? | Yes | Skip, rely on existing Reserve-path test | If the canon is two paths, the test set should pin both. ~50 LOC of test for permanent coverage. |
| Whole-enchilada quota step | Forward-reference only | Add an actual quota step in stage-1 | Stage-1 is single-tenant in-memory; tenant-level quota is stage-2/3 territory. Stub the cross-reference now; flesh out when stages land. |
| SDK helper in `clients/go` | Defer | Add `ParseResourceExhausted(rpcErr)` helper | Pure docs PR; the helper is value-add but adds review surface. File as follow-up if reviewer wants it. |

## Risk / blast radius

- **Affects:** documentation + one new test. No library API changes.
- **Tests covering this:** the new test (`TestQuota_OnSubscribeRejection_WireShape`) + the pre-existing `TestQuota_RejectsBeyondCapWithStructuredError`. Together they cover both paths of the canon.
- **Be paranoid about:** the new test's assertion that `max` is **absent** on the wire (omitempty on int64 + value 0 → key dropped). The test reads `rpc.Data.(map[string]any)` and checks `_, hasMax := dataMap["max"]; !hasMax` — verifies the JSON-decoded map actually omits the key, not that it has a zero value.

## Out of scope (deliberately deferred)

- SDK helper to parse `ResourceExhaustedData` typed — useful but not blocking; defer.
- Whole-enchilada stage-2/3/4 actual quota walkthrough — lands with those stages (637/639/638), not here. This PR just wires the cross-reference.
