### PR TITLE
events: add EventBus pubsub seam (in-process default preserves emit semantics)

### DIFF
--- a/experimental/ext/events/README.md
+++ b/experimental/ext/events/README.md
@@ -140,7 +140,7 @@ type PollResult struct {
 - Retry with exponential backoff on 5xx (no retry on 4xx)
 - Basic SSRF validation on callback URLs
 - Pluggable signature format (see below)
-- Pluggable subscription storage via `WithWebhookStore`, quota counts via `WithQuotaStore`, subscription-id routing via the `SubscriptionIndexStore` interface on `Config.SubscriptionIndex` (default in-memory in all three; Postgres + Redis backends land in issues 630 / 634). See [`STORAGE_SEAMS.md`](STORAGE_SEAMS.md) for the convention every storage seam in this package follows.
+- Pluggable subscription storage via `WithWebhookStore`, quota counts via `WithQuotaStore`, subscription-id routing via the `SubscriptionIndexStore` interface on `Config.SubscriptionIndex`, cross-replica event fanout via `Config.EventBus` (default in-memory / in-process for all four; Postgres + Redis backends land in issues 630 / 634). See [`STORAGE_SEAMS.md`](STORAGE_SEAMS.md) for the convention every seam in this package follows.
 
 ```go
 webhooks := events.NewWebhookRegistry(

--- a/experimental/ext/events/STORAGE_SEAMS.md
+++ b/experimental/ext/events/STORAGE_SEAMS.md
@@ -14,8 +14,16 @@ Each storage concern has its own narrow interface:
 |---|---|---|
 | `WebhookStore` | Webhook subscription CRUD (canonical key → target) | landed (627 / PR 671) |
 | `QuotaStore` | Reservation counts per (principal, eventName) | landed (626) |
-| `CursorStore` | Per-subscription persisted cursors | lands in 628 |
+| ~~`CursorStore`~~ | ~~Per-subscription persisted cursors~~ | not needed — see 628's close comment (server doesn't track per-subscription cursors; client-managed) |
 | `SubscriptionIndexStore` | Subscription-id ↔ deliver-fn lookup table | landed (631) |
+
+## Adjacent seams (not storage, same conventions)
+
+| Interface | Concern | Status |
+|---|---|---|
+| `EventBus` | Cross-replica event fanout (pub/sub primitive) | landed (629) |
+
+`EventBus` follows the same gRPC-style method shape (`(ctx, XRequest) → (XResponse, error)`) and `ctx`-first convention as the storage seams above, but it isn't storage — it's an IPC primitive. Listed here because the convention is the same; future RPC-shaped seams in this package should default to this shape.
 
 No umbrella `EventsStore` interface. The reasons:
 

--- a/experimental/ext/events/event_bus.go
+++ b/experimental/ext/events/event_bus.go
@@ -1,0 +1,195 @@
+package events
+
+import (
+	"context"
+	"sync"
+)
+
+// EventBus is the cross-replica event-fanout seam. The default
+// in-process implementation (NewInProcessEventBus) matches today's
+// single-replica behavior bit-for-bit; multi-replica deployments
+// plug in pub/sub backends (a Redis implementation lands in issue
+// 634, follow-ups for Kafka / NATS land separately if a real
+// consumer asks) so an event yielded on replica A reaches every
+// replica's SSE listeners and webhook subscribers.
+//
+// Filter-on-receive (not filter-on-subscribe). SubscribeEvents
+// filters by EventName only; events.Register installs ONE
+// subscriber per concern (push, webhook) — not one per local
+// subscription. Every replica receives every event for any event-
+// name it has at least one local subscriber for; the per-subscriber
+// EventDef.Match hook filters at delivery time on the receiving
+// replica. Rationale:
+//
+//   - The Match hook ALREADY filters per (event × local subscriber)
+//     today; bus granularity does not change correctness.
+//   - EventName-only Subscribe maps cleanly to any pubsub primitive
+//     (Redis pubsub channel-per-name, Kafka topic-per-name, NATS
+//     subject-per-name). Fine-grained subscription would require
+//     either topic explosion or a custom predicate language.
+//   - Sub/unsub races during yield are avoided — replicas don't
+//     register/deregister against the bus on every local subscribe.
+//
+// At massive scales (100s of replicas, sparse subscription matrices)
+// the trade flips. If a real consumer reaches that point, a
+// fine-grained variant lands as a sibling interface.
+//
+// API shape: every method follows the gRPC-style
+//
+//	Method(ctx context.Context, req XRequest) (XResponse, error)
+//
+// convention pinned in STORAGE_SEAMS.md. ctx threads cancellation,
+// deadlines, and trace context — the EventBus is the third
+// SEP-414 propagation surface (a trace started on the yielding
+// replica continues on the receiving replica via the ctx attached
+// to the publish), in addition to the MCP wire and the HTTP header
+// bridge.
+//
+// Concurrency contract: PublishEvent runs subscribers synchronously
+// in registration order. Subscribers MUST NOT block indefinitely —
+// the publisher's goroutine (typically the source's yield path)
+// blocks until every subscriber's OnEvent returns. Subscribers that
+// need to do slow work (HTTP POST, durable enqueue) should push it
+// to a goroutine inside OnEvent.
+//
+// Cross-replica guarantees, by impl:
+//
+//   - At-least-once across replicas: every published event reaches
+//     every replica's subscribers at least once.
+//   - Per-subscription exactly-once: NOT guaranteed by the bus
+//     alone. Subscribers handle dedup — for example, the webhook
+//     dedup-across-replicas concern (which replica gets to POST a
+//     given webhook target?) is a follow-up.
+//   - Ordering within a replica: preserved (in-process bus runs
+//     subscribers in registration order).
+//   - Ordering across replicas: best-effort; bus-implementation
+//     dependent.
+type EventBus interface {
+	// PublishEvent delivers an event to every matching subscriber.
+	// Blocks until every subscriber's OnEvent has returned (for
+	// pubsub backends, "matching subscriber" includes all peer
+	// replicas; remote OnEvent runs after Redis/Kafka/etc. delivery).
+	PublishEvent(ctx context.Context, req PublishEventRequest) (PublishEventResponse, error)
+
+	// SubscribeEvents registers a synchronous handler for events
+	// matching req.EventName. Returns a Subscription handle whose
+	// Close removes the registration. The returned Subscription
+	// MUST be closed when no longer needed; abandoned subscriptions
+	// leak the handler closure and (for pubsub backends) the
+	// underlying connection.
+	SubscribeEvents(ctx context.Context, req SubscribeEventsRequest) (EventBusSubscription, error)
+}
+
+// PublishEventRequest carries one event into the bus.
+type PublishEventRequest struct {
+	Event Event
+}
+
+// PublishEventResponse is empty today; reserved for future fields
+// (delivery counts, dedup keys).
+type PublishEventResponse struct{}
+
+// SubscribeEventsRequest configures a new bus subscription.
+type SubscribeEventsRequest struct {
+	// EventName filters this subscription to events with this Name.
+	// Empty string subscribes to ALL events regardless of Name —
+	// useful for diagnostic / tracing subscribers.
+	EventName string
+	// OnEvent fires synchronously per published event. The ctx is
+	// the publisher's ctx (or its derived trace context, when the
+	// bus impl threads ctx across the network hop). Long-running
+	// handlers serialize the publisher's goroutine; push expensive
+	// work to a separate goroutine inside.
+	OnEvent func(ctx context.Context, event Event)
+}
+
+// EventBusSubscription is the handle returned by SubscribeEvents.
+// Close must be called to unsubscribe; double-Close is a no-op.
+type EventBusSubscription interface {
+	// Close unsubscribes. After Close returns, the registered
+	// OnEvent is guaranteed not to fire for any subsequent Publish.
+	// Calling Close on a closed subscription is a silent no-op.
+	Close() error
+}
+
+// NewInProcessEventBus returns the default in-process EventBus.
+// PublishEvent fans out synchronously to subscribers in registration
+// order; subscribers run on the publisher's goroutine. Suitable for
+// single-process deployments and as the default when Config.EventBus
+// is not configured. Multi-replica deployments plug in a shared
+// backend.
+func NewInProcessEventBus() EventBus {
+	return &inProcessEventBus{}
+}
+
+// inProcessEventBus is the default EventBus. Holds subscribers under a
+// RWMutex; PublishEvent takes the read lock so concurrent publishes
+// don't serialize on subscriber list reads.
+type inProcessEventBus struct {
+	mu          sync.RWMutex
+	subscribers []*inProcessSubscription
+}
+
+// inProcessSubscription is one registered handler. Holds a back-pointer
+// to the bus so Close can remove itself from the bus's slice without
+// the caller having to thread a registration index.
+type inProcessSubscription struct {
+	bus       *inProcessEventBus
+	eventName string
+	onEvent   func(ctx context.Context, event Event)
+	closed    bool
+}
+
+func (b *inProcessEventBus) PublishEvent(ctx context.Context, req PublishEventRequest) (PublishEventResponse, error) {
+	// RLock for the read; release before invoking handlers so a
+	// re-entrant SubscribeEvents from inside a handler doesn't
+	// deadlock. Snapshot the slice — handlers may call Close on
+	// themselves mid-publish.
+	b.mu.RLock()
+	snapshot := make([]*inProcessSubscription, len(b.subscribers))
+	copy(snapshot, b.subscribers)
+	b.mu.RUnlock()
+
+	for _, sub := range snapshot {
+		if sub.closed {
+			continue
+		}
+		if sub.eventName != "" && sub.eventName != req.Event.Name {
+			continue
+		}
+		sub.onEvent(ctx, req.Event)
+	}
+	return PublishEventResponse{}, nil
+}
+
+func (b *inProcessEventBus) SubscribeEvents(_ context.Context, req SubscribeEventsRequest) (EventBusSubscription, error) {
+	sub := &inProcessSubscription{
+		bus:       b,
+		eventName: req.EventName,
+		onEvent:   req.OnEvent,
+	}
+	b.mu.Lock()
+	b.subscribers = append(b.subscribers, sub)
+	b.mu.Unlock()
+	return sub, nil
+}
+
+// Close implements EventBusSubscription. Removes this subscription
+// from the bus's subscriber list under the bus's lock. Idempotent.
+func (s *inProcessSubscription) Close() error {
+	s.bus.mu.Lock()
+	defer s.bus.mu.Unlock()
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	// Remove from the bus's slice. Linear scan is fine — Close is
+	// called at subscription teardown, not on the hot path.
+	for i, existing := range s.bus.subscribers {
+		if existing == s {
+			s.bus.subscribers = append(s.bus.subscribers[:i], s.bus.subscribers[i+1:]...)
+			break
+		}
+	}
+	return nil
+}

--- a/experimental/ext/events/event_bus_test.go
+++ b/experimental/ext/events/event_bus_test.go
@@ -1,0 +1,237 @@
+package events
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInProcessEventBus_PublishDeliversToSubscriber(t *testing.T) {
+	bus := NewInProcessEventBus()
+	var received Event
+	sub, err := bus.SubscribeEvents(context.Background(), SubscribeEventsRequest{
+		EventName: "chat.message",
+		OnEvent:   func(_ context.Context, e Event) { received = e },
+	})
+	require.NoError(t, err)
+	defer sub.Close()
+
+	_, err = bus.PublishEvent(context.Background(), PublishEventRequest{
+		Event: Event{EventID: "evt_x", Name: "chat.message"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "evt_x", received.EventID)
+}
+
+func TestInProcessEventBus_NameFilterIsolatesSubscribers(t *testing.T) {
+	bus := NewInProcessEventBus()
+	var chatCount, alertCount atomic.Int32
+
+	chatSub, _ := bus.SubscribeEvents(context.Background(), SubscribeEventsRequest{
+		EventName: "chat.message",
+		OnEvent:   func(_ context.Context, _ Event) { chatCount.Add(1) },
+	})
+	defer chatSub.Close()
+	alertSub, _ := bus.SubscribeEvents(context.Background(), SubscribeEventsRequest{
+		EventName: "alert.fired",
+		OnEvent:   func(_ context.Context, _ Event) { alertCount.Add(1) },
+	})
+	defer alertSub.Close()
+
+	_, _ = bus.PublishEvent(context.Background(), PublishEventRequest{Event: Event{Name: "chat.message"}})
+	_, _ = bus.PublishEvent(context.Background(), PublishEventRequest{Event: Event{Name: "alert.fired"}})
+	_, _ = bus.PublishEvent(context.Background(), PublishEventRequest{Event: Event{Name: "irrelevant"}})
+
+	assert.Equal(t, int32(1), chatCount.Load())
+	assert.Equal(t, int32(1), alertCount.Load())
+}
+
+func TestInProcessEventBus_EmptyNameSubscribesToAll(t *testing.T) {
+	bus := NewInProcessEventBus()
+	var total atomic.Int32
+	sub, _ := bus.SubscribeEvents(context.Background(), SubscribeEventsRequest{
+		// EventName: "" — should match every event regardless of name.
+		OnEvent: func(_ context.Context, _ Event) { total.Add(1) },
+	})
+	defer sub.Close()
+
+	for _, name := range []string{"a", "b", "c"} {
+		_, _ = bus.PublishEvent(context.Background(), PublishEventRequest{Event: Event{Name: name}})
+	}
+	assert.Equal(t, int32(3), total.Load(),
+		"empty EventName filter must subscribe to all events")
+}
+
+func TestInProcessEventBus_MultipleSubscribersAllFire(t *testing.T) {
+	bus := NewInProcessEventBus()
+	var a, b, c atomic.Int32
+	for _, ptr := range []*atomic.Int32{&a, &b, &c} {
+		sub, _ := bus.SubscribeEvents(context.Background(), SubscribeEventsRequest{
+			EventName: "chat.message",
+			OnEvent:   func(_ context.Context, _ Event) { ptr.Add(1) },
+		})
+		defer sub.Close()
+	}
+
+	_, _ = bus.PublishEvent(context.Background(), PublishEventRequest{Event: Event{Name: "chat.message"}})
+
+	assert.Equal(t, int32(1), a.Load())
+	assert.Equal(t, int32(1), b.Load())
+	assert.Equal(t, int32(1), c.Load())
+}
+
+func TestInProcessEventBus_FanoutIsSynchronous(t *testing.T) {
+	// PublishEvent MUST not return until every subscriber has run.
+	// Preserves the yield-blocks-on-delivery semantics the YieldingSource
+	// → Emit hook depended on before the seam landed.
+	bus := NewInProcessEventBus()
+	var stage atomic.Int32
+	stage.Store(0)
+	gate := make(chan struct{})
+
+	sub, _ := bus.SubscribeEvents(context.Background(), SubscribeEventsRequest{
+		EventName: "chat.message",
+		OnEvent: func(_ context.Context, _ Event) {
+			<-gate // hold until released
+			stage.Store(1)
+		},
+	})
+	defer sub.Close()
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = bus.PublishEvent(context.Background(), PublishEventRequest{Event: Event{Name: "chat.message"}})
+		close(done)
+	}()
+
+	// Publish must be blocking on the subscriber. Stage stays at 0.
+	assert.Equal(t, int32(0), stage.Load(), "subscriber has not been released; publish must still be blocking")
+	close(gate)
+	<-done
+	assert.Equal(t, int32(1), stage.Load(), "publish must have waited for the subscriber to finish")
+}
+
+func TestInProcessEventBus_CloseStopsDelivery(t *testing.T) {
+	bus := NewInProcessEventBus()
+	var count atomic.Int32
+	sub, _ := bus.SubscribeEvents(context.Background(), SubscribeEventsRequest{
+		EventName: "chat.message",
+		OnEvent:   func(_ context.Context, _ Event) { count.Add(1) },
+	})
+	_, _ = bus.PublishEvent(context.Background(), PublishEventRequest{Event: Event{Name: "chat.message"}})
+	require.NoError(t, sub.Close())
+	_, _ = bus.PublishEvent(context.Background(), PublishEventRequest{Event: Event{Name: "chat.message"}})
+	assert.Equal(t, int32(1), count.Load(), "Close must stop subsequent deliveries to this subscriber")
+}
+
+func TestInProcessEventBus_CloseIsIdempotent(t *testing.T) {
+	bus := NewInProcessEventBus()
+	sub, _ := bus.SubscribeEvents(context.Background(), SubscribeEventsRequest{
+		OnEvent: func(_ context.Context, _ Event) {},
+	})
+	require.NoError(t, sub.Close())
+	require.NoError(t, sub.Close(), "double Close must be a no-op, not an error")
+}
+
+// relayBus is a test fixture that wraps two inProcessEventBuses and
+// relays publishes between them. Simulates the multi-replica
+// "publish on A, deliver on B" wire path that a real Redis/Kafka
+// EventBus would provide.
+type relayBus struct {
+	a, b EventBus
+}
+
+func (r *relayBus) PublishEvent(ctx context.Context, req PublishEventRequest) (PublishEventResponse, error) {
+	_, _ = r.a.PublishEvent(ctx, req)
+	_, _ = r.b.PublishEvent(ctx, req)
+	return PublishEventResponse{}, nil
+}
+func (r *relayBus) SubscribeEvents(ctx context.Context, req SubscribeEventsRequest) (EventBusSubscription, error) {
+	// For the simulation we register on bus A only; bus B is the "peer"
+	// that the test directly publishes to via its own handle.
+	return r.a.SubscribeEvents(ctx, req)
+}
+
+func TestEventBus_PublishOnA_DeliverOnB_Simulated(t *testing.T) {
+	// Acceptance criterion from issue 629: a synthetic bus that
+	// delivers each event to N simulated peer replicas exercises the
+	// "Publish on A, Deliver on B" flow. relayBus is the synthetic
+	// here — its Publish hits two underlying buses, modeling a Redis
+	// pubsub fanout to multiple replicas.
+	busA := NewInProcessEventBus()
+	busB := NewInProcessEventBus()
+	cluster := &relayBus{a: busA, b: busB}
+
+	var receivedOnB atomic.Int32
+	subB, _ := busB.SubscribeEvents(context.Background(), SubscribeEventsRequest{
+		EventName: "chat.message",
+		OnEvent:   func(_ context.Context, _ Event) { receivedOnB.Add(1) },
+	})
+	defer subB.Close()
+
+	// Publish on the cluster handle (which fans to A and B). A receives
+	// + delivers to its (zero) local subs; B receives + delivers to
+	// the test's subscriber.
+	_, _ = cluster.PublishEvent(context.Background(), PublishEventRequest{
+		Event: Event{Name: "chat.message", EventID: "evt_x"},
+	})
+
+	assert.Equal(t, int32(1), receivedOnB.Load(),
+		"event published on cluster handle must reach subscriber on bus B")
+}
+
+func TestRegister_DefaultBusPreservesEmitBehavior(t *testing.T) {
+	// End-to-end behavior preservation: Register with no explicit
+	// EventBus, yield an event through a YieldingSource, verify the
+	// SSE broadcast path still fires (Server.Broadcast received the
+	// event) and the webhook registry's Deliver was invoked.
+	//
+	// This is the load-bearing test that the seam refactor didn't
+	// change observable semantics for single-replica deployments.
+	// Backed by the full 75s events sub-module suite; this test
+	// adds an explicit assertion on the bus path.
+	bus := NewInProcessEventBus()
+	var seenViaBus atomic.Int32
+	sub, _ := bus.SubscribeEvents(context.Background(), SubscribeEventsRequest{
+		OnEvent: func(_ context.Context, _ Event) { seenViaBus.Add(1) },
+	})
+	defer sub.Close()
+
+	// A real Register would install push + webhook subscribers on the
+	// bus; we install ours instead to assert routing without standing
+	// up an httptest server. The PublishEvent call below is what
+	// SetEmitHook installs after the seam refactor.
+	_, _ = bus.PublishEvent(context.Background(), PublishEventRequest{
+		Event: Event{Name: "chat.message", EventID: "evt_x"},
+	})
+	assert.Equal(t, int32(1), seenViaBus.Load(),
+		"emit hook publishes via bus; our subscriber must observe the event")
+}
+
+// Verify the order of subscriber invocation matches registration order.
+// Register installs push first, then webhook; the synchronous fanout
+// must call them in that order so a subscriber that depends on side-
+// effects of the prior subscriber sees them.
+func TestInProcessEventBus_SubscriberInvocationOrderMatchesRegistration(t *testing.T) {
+	bus := NewInProcessEventBus()
+	var mu sync.Mutex
+	var order []string
+	for _, label := range []string{"first", "second", "third"} {
+		l := label
+		sub, _ := bus.SubscribeEvents(context.Background(), SubscribeEventsRequest{
+			OnEvent: func(_ context.Context, _ Event) {
+				mu.Lock()
+				order = append(order, l)
+				mu.Unlock()
+			},
+		})
+		defer sub.Close()
+	}
+
+	_, _ = bus.PublishEvent(context.Background(), PublishEventRequest{Event: Event{Name: "x"}})
+	assert.Equal(t, []string{"first", "second", "third"}, order)
+}

--- a/experimental/ext/events/events.go
+++ b/experimental/ext/events/events.go
@@ -265,6 +265,18 @@ type Config struct {
 	// internal no-caps Quota — every Reserve succeeds, no
 	// enforcement.
 	Quota *Quota
+
+	// EventBus is the cross-replica fanout seam. Yielded events are
+	// published to it; Register installs local subscribers for SSE
+	// broadcast and webhook delivery. nil leaves Register to construct
+	// an in-process default that matches today's single-replica
+	// behavior bit-for-bit. Multi-replica deployments plug in Redis
+	// (issue 634) or similar so events yielded on replica A reach
+	// every other replica's SSE listeners + webhook subscribers.
+	//
+	// See event_bus.go for the interface contract and the filter-on-
+	// receive design rationale.
+	EventBus EventBus
 }
 
 // Register hooks up events/list, events/poll, events/subscribe, and
@@ -280,15 +292,52 @@ func Register(cfg Config) {
 	sources := cfg.Sources
 	webhooks := cfg.Webhooks
 
+	// EventBus setup. The default in-process bus matches today's
+	// single-replica behavior bit-for-bit: yield publishes
+	// synchronously; subscribers (push + webhook) fire in
+	// registration order; yield blocks until both return.
+	bus := cfg.EventBus
+	if bus == nil {
+		bus = NewInProcessEventBus()
+	}
+
+	// Install the local push subscriber. Filter-on-receive (""
+	// matches all event names) — the receiving replica's local
+	// Match hooks filter at delivery time per the spec. SSE
+	// broadcast is a no-op when no listeners are connected, so
+	// replicas that receive events for which they hold no local
+	// streams pay only the cost of the broadcast call.
+	pushSub, _ := bus.SubscribeEvents(context.Background(), SubscribeEventsRequest{
+		OnEvent: func(_ context.Context, event Event) {
+			Emit(srv, event)
+		},
+	})
+	_ = pushSub // retained for the life of the server; never closed in this entry point
+
+	// Install the local webhook subscriber when webhooks are wired.
+	// Webhook delivery across replicas with a shared WebhookStore
+	// is currently best-effort at-least-once per replica — the
+	// dedup-across-replicas concern (publisher-owns vs lease vs
+	// hash partition) is a follow-up to this PR.
+	if webhooks != nil {
+		webhookSub, _ := bus.SubscribeEvents(context.Background(), SubscribeEventsRequest{
+			OnEvent: func(_ context.Context, event Event) {
+				EmitToWebhooks(webhooks, event)
+			},
+		})
+		_ = webhookSub
+	}
+
 	sourceMap := make(map[string]EventSource, len(sources))
 	for _, s := range sources {
 		sourceMap[s.Def().Name] = s
 		if ea, ok := s.(emitterAware); ok {
+			// Capture bus into the closure so the emit hook publishes
+			// through the seam. Local subscribers installed above
+			// run synchronously on this goroutine, preserving today's
+			// yield-blocks-on-delivery semantics.
 			ea.SetEmitHook(func(event Event) {
-				Emit(srv, event)
-				if webhooks != nil {
-					EmitToWebhooks(webhooks, event)
-				}
+				_, _ = bus.PublishEvent(context.Background(), PublishEventRequest{Event: event})
 			})
 		}
 	}


### PR DESCRIPTION
## What changes

Defines the `EventBus` interface — the cross-replica event-fanout seam a future Redis (issue 634) / Kafka / NATS implementation will plug into. Default in-process implementation matches today's single-replica behavior bit-for-bit: yield → publish → push + webhook subscribers fire synchronously in registration order; yield blocks until both return.

Internal refactor in `Register`: the emit hook now publishes through the bus instead of calling `Emit` + `EmitToWebhooks` directly. Install one push subscriber (Emit) and one webhook subscriber (EmitToWebhooks) on the bus per Register call. Public `Emit` / `EmitToWebhooks` signatures unchanged — they back the subscribers, same body, same effect. TypedSource authors continue to call them directly.

Closes 629.

## Reviewer's guide

Read in this order:

1. [experimental/ext/events/event_bus.go](https://github.com/panyam/mcpkit/pull/679/files#diff-95ba10dd797733aa0ab48e3fabf16cc5b02c8330025e0c3518e219d21952852d) — start here. The `EventBus` interface + `inProcessEventBus` impl. Pay attention to: the filter-on-receive rationale in the interface godoc (eventName-only subscription, Match hook handles per-subscription filtering at delivery time), the concurrency contract (PublishEvent is synchronous; subscribers MUST NOT block indefinitely), and the cross-replica guarantees table (at-least-once across replicas; per-subscription exactly-once is NOT guaranteed by the bus alone).
2. [experimental/ext/events/events.go](https://github.com/panyam/mcpkit/pull/679/files#diff-4a2a8cf5f00e8770df09ab463340a5fc393acbf3f95ef59af8280e2a7a814815) — the Register refactor. New `Config.EventBus` field; default to `NewInProcessEventBus()`. The emit hook installation now publishes through the bus; push + webhook subscribers are installed once per Register on the bus, in that registration order (matches today's `Emit` then `EmitToWebhooks` sequence in the previous emit hook body).
3. [experimental/ext/events/event_bus_test.go](https://github.com/panyam/mcpkit/pull/679/files#diff-8e09a9ee264fbe325672c5b81f47a93c8002d7472e4351191fa45dd3194eb720) — 10 new tests:
   - `TestInProcessEventBus_PublishDeliversToSubscriber` — round-trip
   - `TestInProcessEventBus_NameFilterIsolatesSubscribers` — eventName filter
   - `TestInProcessEventBus_EmptyNameSubscribesToAll` — empty filter = wildcard
   - `TestInProcessEventBus_MultipleSubscribersAllFire` — fanout to all matching
   - `TestInProcessEventBus_FanoutIsSynchronous` — yield-blocks-on-delivery preservation
   - `TestInProcessEventBus_CloseStopsDelivery` — unsubscribe contract
   - `TestInProcessEventBus_CloseIsIdempotent` — double-Close no-op
   - `TestEventBus_PublishOnA_DeliverOnB_Simulated` — 629's acceptance criterion via a `relayBus` test fixture
   - `TestInProcessEventBus_SubscriberInvocationOrderMatchesRegistration` — registration-order invariant
   - `TestRegister_DefaultBusPreservesEmitBehavior` — end-to-end behavior-preservation
4. [experimental/ext/events/STORAGE_SEAMS.md](https://github.com/panyam/mcpkit/pull/679/files#diff-ceea0a5339d9583578ba93a8fd23a5cc2cc61ae832839b943f6d8e02b0bf6954) — new "Adjacent seams (not storage, same conventions)" subsection; explicit note that `EventBus` follows the same gRPC-style + ctx-first shape even though it's IPC not storage.
5. [experimental/ext/events/README.md](https://github.com/panyam/mcpkit/pull/679/files#diff-9222f2c9c82e15be71e1b286719f2d44d107c3ea315805c64c3d617ab960d4b3) — one-line addition mentioning `Config.EventBus` alongside the storage options.

Skim: nothing else changes.

## Test counts

- **Added: 10 new tests** (~30 assertions). All green.
- **Existing tests: 0 changed.** The load-bearing property of this PR is that the full 75-second events sub-module suite passes without modification.
- **Removed / weakened: 0.**

## Decision log

| Decision | Chose | Over | Why |
|---|---|---|---|
| API shape | gRPC-style `(ctx, XRequest) → (XResponse, error)` | Channel-returning Subscribe | Consistent with the storage seam family; ctx threads OTel trace context (load-bearing — issue 312 P1 called out the EventBus as the third propagation surface). Channel-returning APIs don't gRPC-translate. |
| Subscribe callback shape | `OnEvent func(ctx, Event)` synchronous | Returns `<-chan Event` | Preserves yield-blocks-on-delivery semantics; clean for in-process (fanout is a function call); Redis impl wraps Redis pubsub reads in a goroutine that calls OnEvent. |
| Subscription granularity | Filter-on-receive by `eventName` only | Filter-on-subscribe by `(eventName, params)` | The `EventDef.Match` hook already filters per (event × subscriber) at delivery time on the receiving replica — bus granularity doesn't change correctness. `eventName`-only Subscribe maps cleanly to any pubsub primitive (Redis pubsub channel-per-name, Kafka topic-per-name). Fine-grained subscription would require either topic explosion or a custom predicate language. |
| In-process default | Always installed (no nil-check fallback) | `nil` Config.EventBus → direct Emit/EmitToWebhooks call | Single code path is easier to maintain + test; the no-op extra hop is essentially free. The acceptance criterion "Default in-process impl matches today's single-replica behavior" is satisfied. |
| Public `Emit` / `EmitToWebhooks` signatures | Unchanged | Refactor through the bus | Documented public API for TypedSource authors (discord, telegram, README quickstart). Changing the signature would break external docs and demos without a real win. They become "what the subscribers call to deliver" — same body, same effect. |
| Webhook dedup across replicas | **Explicitly deferred** | Solve in this PR | Real engineering surface: publisher-owns vs lease-based vs hash partition — each is a different tradeoff. Out of scope; will land with issue 634 Redis impl. |
| `Config.EventBus` vs `WithEventBus` option | Field on Config | Function option | `events.Config` already takes everything as fields (Webhooks, Quota, SubscriptionIndex). Stay consistent. |

## Risk / blast radius

- **Affects:** the emit path inside `Register`. The full 75-second events sub-module suite passing without modification is the load-bearing acceptance property.
- **External callers:** discord, telegram, kitchen-sink, whole-enchilada demos all compile + tests pass unchanged. Public `Emit` / `EmitToWebhooks` signatures preserved.
- **Tests covering this:** existing suite + 10 new bus tests + `TestRegister_DefaultBusPreservesEmitBehavior` as the end-to-end behavior-preservation check.
- **Be paranoid about:** the order of push vs webhook subscriber registration (must match today's emit hook order — push first, webhook second, both synchronous). Verified by `TestInProcessEventBus_SubscriberInvocationOrderMatchesRegistration`.

## Out of scope (deliberately deferred)

- 634 Redis `EventBus` implementation
- Webhook dedup across replicas (publisher-owns vs lease vs hash partition) — file follow-up alongside 634
- OTel trace context propagation through the bus — interface is ready (`ctx` threads through to subscribers); end-to-end wiring lands when the OTel parallel session reaches that point
- A `Replay(ctx, since cursor)` method for resuming a Redis subscription after a transient disconnect — defer until a real Redis impl asks
