### PR TITLE
ext/otel + examples/otel/stdout: NewTracerProvider helper + 4-tool exploratory loop (issue 674)

### DIFF
--- a/docs/SEP_414_OTEL.md
+++ b/docs/SEP_414_OTEL.md
@@ -307,6 +307,43 @@ Unblocks issue 659 (`ext/tasks` task lifecycle linking) and the
 detached edge of issue 664 (server outbound reverse-call spans linked
 to the originating client request).
 
+### `mcpotel.NewTracerProvider` helper — landed (issue 674)
+
+Examples and surface integrations no longer have to import
+`go.opentelemetry.io/otel/sdk/resource` + `.../semconv` just to set a
+`service.name` on their TracerProvider. `mcpotel.NewTracerProvider`
+is a thin functional-options wrapper around `sdktrace.NewTracerProvider`:
+
+```go
+otelTP := mcpotel.NewTracerProvider(exp,
+    mcpotel.WithServiceName("my-server"),
+    mcpotel.WithSyncer(),
+)
+mcpotel.NewProvider(otelTP)
+```
+
+Options today:
+
+- `mcpotel.WithServiceName(name)` — bakes the value into an OTel
+  `Resource` with `semconv.ServiceName(...)`. Empty name is a no-op
+  so defensive callers can pass through config values without
+  branching.
+- `mcpotel.WithSyncer()` — switches the default Batcher to a sync
+  span processor. Right for teaching demos and tests; production
+  servers should stay on the batched default and handle SIGTERM with
+  explicit `ForceFlush` + `Shutdown`.
+
+`NewTracerProvider(nil)` panics — silently constructing a
+TracerProvider that emits no spans loses signals without surfacing
+the misconfig. Matches `NewProvider(nil)`'s fail-fast.
+
+Future options (`WithDeploymentEnvironment`, `WithServiceVersion`,
+`WithResource(*resource.Resource)` escape hatch) compose against the
+same internal config — file when a consumer asks. The
+`examples/common/otel/` sub-package already migrated to consume this
+helper; future P6 surface examples (issues 658 / 659 / 660 / 664)
+inherit the cleanup without any extra plumbing.
+
 The pattern is identical across all five: each `ext/` surface optionally
 accepts a `core.TracerProvider` and instruments its own work, depending on
 the **`core` abstraction only** — never `ext/otel`. Same composition shape

--- a/examples/common/go.mod
+++ b/examples/common/go.mod
@@ -4,10 +4,12 @@ go 1.26.3
 
 replace github.com/panyam/mcpkit => ../..
 
+replace github.com/panyam/mcpkit/ext/otel => ../../ext/otel
+
 require (
 	github.com/panyam/demokit v0.0.29
-	github.com/panyam/mcpkit v0.2.41
-	go.opentelemetry.io/otel v1.44.0
+	github.com/panyam/mcpkit v0.2.45
+	github.com/panyam/mcpkit/ext/otel v0.0.0-20260608053428-44b944d79f00
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0
@@ -60,6 +62,7 @@ require (
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	github.com/yuin/goldmark v1.8.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/otel v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect

--- a/examples/common/otel/pipeline.go
+++ b/examples/common/otel/pipeline.go
@@ -1,8 +1,9 @@
 // Package otel collects the OpenTelemetry pipeline boilerplate that
 // every mcpkit example with `--exporter=stdout|otlp` support needs:
-// dispatching between exporter modes, baking a `service.name` into
-// the SDK Resource so observability backends index spans under a
-// recognizable name, and tidying up the shutdown closure on exit.
+// dispatching between exporter modes, building an SDK TracerProvider
+// with the right service.name + sync exporting via the
+// `mcpotel.NewTracerProvider` helper, and tidying up the shutdown
+// closure on exit.
 //
 // Why this lives in examples/common/otel/ rather than each example
 // re-implementing it: the helpers are surface-agnostic. The first
@@ -11,16 +12,10 @@
 // will all want the same shape when they add their own OTel wiring.
 // Centralising here avoids the copy-paste-and-drift loop.
 //
-// Why NOT in ext/otel/: the helpers compose against the OTel SDK
-// (sdk/resource, semconv, otlptracegrpc) — those are demo-side deps
-// that the ext/otel library adapter deliberately doesn't pull. The
-// adapter contracts on core.TracerProvider; this package wraps SDK
-// construction for examples.
-//
-// Issue 674 tracks an adapter-side `mcpotel.WithServiceName` helper
-// that would eliminate the ResourceFor boilerplate from this
-// package's callers. Once that ships, the *Pipeline helpers here can
-// thin down to a single line each.
+// Why NOT entirely in ext/otel/: the exporter construction is demo-
+// specific (which exporter library, stdouttrace vs otlptracegrpc).
+// ext/otel ships the TracerProvider helper (`NewTracerProvider`)
+// that this file consumes; the per-exporter construction stays here.
 package otel
 
 import (
@@ -28,11 +23,10 @@ import (
 	"fmt"
 	"os"
 
+	mcpotel "github.com/panyam/mcpkit/ext/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
-	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 )
 
 // Exporter names. These are what examples spell on the command line —
@@ -80,9 +74,10 @@ func BuildPipeline(exporter, otlpEndpoint, serviceName string, stdoutWriter *os.
 // shutdown closure flushes the exporter; defer it so buffered spans
 // land on stdout before the process exits.
 //
-// Use this in `--exporter=stdout` mode (CI-friendly: no external
-// stack required) and in tests that want to inspect span output
-// without a backend.
+// Uses sync exporting via mcpotel.WithSyncer — for stdout output,
+// every span renders as the operator watches the terminal. Batched
+// stdout would make the demo's small burst of spans clump together
+// in confusing order.
 func NewStdoutPipeline(w *os.File, serviceName string) (*sdktrace.TracerProvider, func(), error) {
 	exp, err := stdouttrace.New(
 		stdouttrace.WithWriter(w),
@@ -91,9 +86,9 @@ func NewStdoutPipeline(w *os.File, serviceName string) (*sdktrace.TracerProvider
 	if err != nil {
 		return nil, nil, fmt.Errorf("stdouttrace.New: %w", err)
 	}
-	tp := sdktrace.NewTracerProvider(
-		sdktrace.WithSyncer(exp),
-		sdktrace.WithResource(ResourceFor(serviceName)),
+	tp := mcpotel.NewTracerProvider(exp,
+		mcpotel.WithServiceName(serviceName),
+		mcpotel.WithSyncer(),
 	)
 	shutdown := func() { _ = tp.Shutdown(context.Background()) }
 	return tp, shutdown, nil
@@ -107,15 +102,12 @@ func NewStdoutPipeline(w *os.File, serviceName string) (*sdktrace.TracerProvider
 // production deployments would supply credentials and a non-insecure
 // endpoint via the standard OTel env vars.
 //
-// Uses a synchronous span processor (WithSyncer, NOT WithBatcher) so
-// every dispatched span ships immediately rather than waiting for a
-// batch to fill. Slightly slower per-span at the gRPC layer, but the
-// trade-off is the right one for a teaching example: an operator who
-// kills the demo a second after `tools/call` returns sees their
-// spans in Grafana, not an empty search result because the batch
-// processor hadn't flushed yet. Real high-throughput servers would
-// prefer WithBatcher and explicit ForceFlush + Shutdown signal
-// handling.
+// Uses sync exporting (via mcpotel.WithSyncer) so the demo doesn't
+// hit the batch-flush foot-gun where the operator's SIGTERM
+// terminates the process before the batch processor pushes its
+// queue. Real high-throughput servers should compose
+// mcpotel.NewTracerProvider directly (without WithSyncer) and handle
+// SIGTERM with explicit ForceFlush + Shutdown.
 func NewOTLPPipeline(endpoint, serviceName string) (*sdktrace.TracerProvider, func(), error) {
 	exp, err := otlptracegrpc.New(
 		context.Background(),
@@ -125,9 +117,9 @@ func NewOTLPPipeline(endpoint, serviceName string) (*sdktrace.TracerProvider, fu
 	if err != nil {
 		return nil, nil, fmt.Errorf("otlptracegrpc.New: %w", err)
 	}
-	tp := sdktrace.NewTracerProvider(
-		sdktrace.WithSyncer(exp),
-		sdktrace.WithResource(ResourceFor(serviceName)),
+	tp := mcpotel.NewTracerProvider(exp,
+		mcpotel.WithServiceName(serviceName),
+		mcpotel.WithSyncer(),
 	)
 	shutdown := func() {
 		shutdownCtx, cancel := context.WithCancel(context.Background())
@@ -135,23 +127,4 @@ func NewOTLPPipeline(endpoint, serviceName string) (*sdktrace.TracerProvider, fu
 		_ = tp.Shutdown(shutdownCtx)
 	}
 	return tp, shutdown, nil
-}
-
-// ResourceFor builds the OTel Resource carrying the given
-// `service.name`. Observability backends index telemetry by this
-// attribute — Grafana / Tempo / Jaeger / Honeycomb all search by
-// service.name as the primary axis. Without it, traces appear under
-// `unknown_service:<binary>`.
-//
-// Exposed so callers that want to compose additional attributes
-// (e.g., `service.version`, `deployment.environment`) can build their
-// own Resource off this one's base.
-//
-// Issue 674 tracks a `mcpotel.WithServiceName` adapter helper that
-// would eliminate the need to import this package solely for the
-// resource setup.
-func ResourceFor(serviceName string) *resource.Resource {
-	return resource.NewSchemaless(
-		semconv.ServiceName(serviceName),
-	)
 }

--- a/examples/otel/stdout/README.md
+++ b/examples/otel/stdout/README.md
@@ -1,10 +1,22 @@
 # examples/otel/stdout — SEP-414 Trace Context Propagation
 
-Minimal demokit walkthrough showing how to wire OpenTelemetry tracing
-into BOTH sides of an MCP exchange using the
+Interactive demokit walkthrough showing how to wire OpenTelemetry
+tracing into BOTH sides of an MCP exchange using the
 [`ext/otel`](../../../ext/otel/) adapter — `server.WithTracerProvider`
-on the server and `client.WithTracerProvider` on the walkthrough. Two
-exporter modes:
+on the server and `client.WithTracerProvider` on the walkthrough.
+
+The walkthrough's "Explore trace shapes" step loops through a
+**menu of four tool calls**, each chosen to produce a distinct trace
+shape an operator can compare in their backend of choice:
+
+- `echo` — baseline single-RPC trace
+- `slow_echo` — 750ms `time.Sleep` in the handler; visible span duration
+- `failing_tool` — IsError result; span carries `mcp.tool.is_error="true"`
+- `count_tool` — emits 3 `notifications/progress`; trace fan-out shows the parent plus 3 outbound notification spans with matching `_meta.traceparent`
+
+Pick `quit` from the menu to exit the loop.
+
+Two exporter modes:
 
 - **`--exporter=stdout` (default).** Both processes use the
   `stdouttrace` exporter; each terminal prints its own side's spans
@@ -15,13 +27,8 @@ exporter modes:
   the `docker/observability/` stack (default endpoint
   `localhost:4317`). Spans land in Grafana, indexed by `service.name`
   (`otel-stdout-demo` for the server, `otel-stdout-host` for the
-  walkthrough). Search by either name in Grafana → Explore → Tempo to
-  see the stitched client→server trace in the UI.
-
-The walkthrough makes a `tools/call`; the client trace middleware
-stamps its own auto-generated `_meta.traceparent` on the outbound
-params; the server picks it up as Parent. End result: matching
-TraceID on both sides regardless of exporter mode.
+  walkthrough). Each Explore-step iteration prints a pre-filtered
+  Grafana Explore deep link so you drill straight into Tempo.
 
 ## Quick Start
 
@@ -41,15 +48,16 @@ client→server stitch.
 Terminal 1:  make -C ../../../docker up           # bring observability stack up
 Terminal 2:  make serve EXPORTER=otlp             # server → OTLP collector
 Terminal 3:  make demo EXPORTER=otlp              # walkthrough → OTLP collector
-Browser:     open http://localhost:3000           # Grafana → Explore → Tempo
+Browser:     open http://localhost:3000           # Grafana — anonymous Admin
 
 # When done:
 make -C ../../../docker down
 ```
 
-In Grafana, search service `otel-stdout-host` or `otel-stdout-demo`
-in the Tempo data source — both spans for one `tools/call` appear in
-the same trace view, linked by parent-of.
+Each iteration of the Explore step prints a pre-filtered Grafana
+Explore deep link — open it directly to see the trace you just
+emitted. Both spans for one `tools/call` (client + server) appear in
+the same trace view, linked by parent-of via `_meta.traceparent`.
 
 ## What it demonstrates
 

--- a/examples/otel/stdout/WALKTHROUGH.md
+++ b/examples/otel/stdout/WALKTHROUGH.md
@@ -1,31 +1,24 @@
 # MCP SEP-414 — OpenTelemetry Trace Context Propagation
 
-Walks through SEP-414, which propagates W3C Trace Context through MCP using the `_meta.traceparent` / `_meta.tracestate` envelope (and, on streamable HTTP, the matching HTTP headers per SEP-2028). BOTH sides are instrumented: the server (`make serve`) wires `server.WithTracerProvider` (P2); the walkthrough (`make demo`) wires `client.WithTracerProvider` (P3). Both pipelines feed the `stdouttrace` exporter, so each terminal prints its own side's spans as pretty-printed JSON. The walkthrough drives a real `tools/call` — the client trace middleware auto-stamps a `_meta.traceparent` on the outbound params and the server picks it up. Matching `TraceID` across the two terminals is the proof that the SEP-414 wire is actually stitching client and server into a single distributed trace.
+Walks through SEP-414 in stdout-exporter mode (no external stack required). Both sides — server (`make serve`) and walkthrough (`make demo`) — print spans as pretty JSON on their respective terminals. The looping "Explore trace shapes" step lets you A/B four distinct tool calls; matching TraceIDs across the two terminals is the SEP-414 wire stitching client and server into a single distributed trace. Run with `EXPORTER=otlp` after `make -C docker up` to ship spans to Grafana instead.
 
 ## What you'll learn
 
-- **Connect to the OTel-instrumented server** — `client.NewClient(...)` + `client.WithTracerProvider(...)` + `Connect()`. Each JSON-RPC dispatch now emits TWO spans — one on each side. The initialize handshake will print `initialize` and `notifications/initialized` spans on BOTH terminals; matching them by TraceID is the visual proof that the SEP-414 wire is propagating from the very first call.
-- **tools/list — every dispatch is a span** — The trace middleware sits OUTERMOST in the dispatch chain on both sides, so *every* JSON-RPC request emits a pair of spans (one per side, stitched via `_meta.traceparent`). This step is functionally identical to the next one in terms of propagation — the only difference is what attributes get set. Watch the TraceID match across terminals for this list call too.
-- **tools/call echo — let the client auto-inject _meta.traceparent** — With both wires instrumented (PR 649 server + PR 654 client), this single tools/call produces TWO spans on TWO terminals:
+- **Connect to the OTel-instrumented server** — `client.NewClient(...)` + `client.WithTracerProvider(...)` + `Connect()`. Each JSON-RPC dispatch emits a pair of spans — one on each side, stitched via `_meta.traceparent`. The initialize handshake produces the first pair before any tool call runs.
+- **Explore trace shapes** — Pick a tool from the menu. Each one produces a distinct trace shape on the stdout exporters:
 
 ## Flow
 
 ```mermaid
 sequenceDiagram
     participant Host as MCP Host (this walkthrough)
-    participant Server as MCP Server (make serve) — spans dump on its stdout
+    participant Server as MCP Server (make serve)
 
     Note over Host,Server: Step 1: Connect to the OTel-instrumented server
     Host->>Server: POST /mcp — initialize
     Server-->>Host: serverInfo + capabilities
 
-    Note over Host,Server: Step 2: tools/list — every dispatch is a span
-    Host->>Server: tools/list
-    Server-->>Host: tools[]
-
-    Note over Host,Server: Step 3: tools/call echo — let the client auto-inject _meta.traceparent
-    Host->>Server: tools/call echo (no caller _meta; client trace mw stamps its own)
-    Server-->>Host: text result; server span's Parent matches the client SpanID
+    Note over Host,Server: Step 2: Explore trace shapes
 ```
 
 ## Steps
@@ -39,7 +32,9 @@ Terminal 1:  make serve         # OTel-instrumented server on :8080
 Terminal 2:  make demo          # this walkthrough (--tui for the interactive TUI)
 ```
 
-Keep both terminals visible — the walkthrough surfaces what the *Host* sees on the wire (JSON-RPC results), while the OpenTelemetry spans land on the *Server* terminal's stdout via the `stdouttrace` exporter.
+Keep both terminals visible — the walkthrough surfaces what the *Host* sees on the wire (JSON-RPC results); the OpenTelemetry spans land on the *Server* terminal's stdout via the `stdouttrace` exporter. Match the TraceID across the two terminals to see the SEP-414 stitch.
+
+To send spans to a real backend instead, run with `EXPORTER=otlp` after `make -C ../../../docker up`.
 
 ### Wire format
 
@@ -52,42 +47,28 @@ On the server side, `server.WithTracerProvider(tp)` installs an outermost trace 
 
 ### Step 1: Connect to the OTel-instrumented server
 
-`client.NewClient(...)` + `client.WithTracerProvider(...)` + `Connect()`. Each JSON-RPC dispatch now emits TWO spans — one on each side. The initialize handshake will print `initialize` and `notifications/initialized` spans on BOTH terminals; matching them by TraceID is the visual proof that the SEP-414 wire is propagating from the very first call.
+`client.NewClient(...)` + `client.WithTracerProvider(...)` + `Connect()`. Each JSON-RPC dispatch emits a pair of spans — one on each side, stitched via `_meta.traceparent`. The initialize handshake produces the first pair before any tool call runs.
 
-### Step 2: tools/list — every dispatch is a span
+### Step 2: Explore trace shapes
 
-The trace middleware sits OUTERMOST in the dispatch chain on both sides, so *every* JSON-RPC request emits a pair of spans (one per side, stitched via `_meta.traceparent`). This step is functionally identical to the next one in terms of propagation — the only difference is what attributes get set. Watch the TraceID match across terminals for this list call too.
+Pick a tool from the menu. Each one produces a distinct trace shape on the stdout exporters:
 
-### Step 3: tools/call echo — let the client auto-inject _meta.traceparent
+- `echo` — baseline single span on each terminal.
+- `slow_echo` — 750ms handler sleep; the span's StartTime → EndTime is visibly long.
+- `failing_tool` — server span carries `mcp.tool.is_error="true"`.
+- `count_tool` — server emits 3 `notifications/progress`, each as its own outbound span with `_meta.traceparent` set.
+- `quit` — exit the loop.
 
-With both wires instrumented (PR 649 server + PR 654 client), this single tools/call produces TWO spans on TWO terminals:
-
-1. **Client side (THIS terminal).** The `Client.Call` outbound trace middleware emits a span named `tools/call` with a fresh TraceID + SpanID. Before the call hits the wire, the middleware stamps that TraceID and SpanID into `params._meta.traceparent` via `core.InjectTraceContextIntoParams` (P3, shared helper).
-2. **Server side (the SERVER terminal).** The server trace middleware extracts the stamped `_meta.traceparent` and emits its own `tools/call` span whose `SpanContext.TraceID` MATCHES the client's, and whose `Parent.SpanID` MATCHES the client span's SpanID with `Parent.Remote == true`.
-
-Match the spans by TraceID across the two terminals — that IS the SEP-414 wire stitching client and server into a single distributed trace. The TraceID is auto-generated each run (no synthetic override), so it'll be different every time — that's the point: real production traces won't have hardcoded IDs.
-
-#### Reproduce on the wire
-
-```bash
-# When using curl directly, no client trace middleware exists, so
-# YOU supply the traceparent. Match it across terminals by inspection.
-curl -s -X POST http://localhost:8080/mcp \
-  -H 'Content-Type: application/json' \
-  -H 'Accept: text/event-stream, application/json' \
-  -H "Mcp-Session-Id: $SID" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"message":"hello"}}}' | jq '.result'
-```
+After each call, match the TraceID printed on this terminal against the SERVER terminal — that match IS the SEP-414 client↔server stitching.
 
 ### Where to look in the code
 
-- `examples/otel/stdout/walkthrough.go::runDemo` — the client-side wiring. `mcpotel.NewProvider(clientOTelTP, WithInstrumentationName(".../client"))` plugged into `client.WithTracerProvider`. The pipeline uses the same `stdouttrace` exporter as the server, just pointing at this process's stdout.
-- `client/trace_middleware.go` (in main mcpkit) — the SEP-414 P3 middleware that consumes the adapter on the client side. Outbound `Client.Call` is wrapped in a span; outbound params gain `_meta.traceparent` derived from the active span; inbound server-to-client requests (sampling/elicitation/roots) extract the inbound traceparent and emit a wrap span.
-- `ext/otel/provider.go` — `Provider.StartSpan` is the adapter's single hot-path: parses inbound `core.TraceContext` into an OTel `SpanContext`, installs as the new span's parent, and after `tracer.Start` re-attaches the *child* span's traceparent via `core.WithTraceContext` so P2's outbound `_meta` injection stamps the right trace ID on downstream messages.
-- `ext/otel/span.go` — narrows OTel's broader Span surface to mcpkit's three-method `core.Span` contract. CAS-guarded `End` prevents the SDK's noisy double-End warning.
-- `ext/otel/propagation.go` — pure W3C ↔ OTel SpanContext conversions. `traceContextToSpanContext` validates structurally before installing; `spanContextToTraceContext` formats the new span back into the W3C version-00 string the wire expects.
-- `server/trace_middleware.go` (in main mcpkit) — the SEP-414 P2 middleware that consumes the adapter. Sits outermost in the dispatch chain so user middleware runs INSIDE the span.
-- `examples/otel/stdout/main.go` — the wiring: `server.WithTracerProvider(mcpotel.NewProvider(otelTP))` is the one new line in `serve()`. Everything else is canonical `common.RunServer` boilerplate.
+- `examples/otel/stdout/main.go::registerDemoTools` — the four tools that drive distinct trace shapes (echo / slow_echo / failing_tool / count_tool).
+- `examples/otel/stdout/walkthrough.go::runDemo` — the client-side wiring. `mcpotel.NewProvider(clientOTelTP, WithInstrumentationName(".../client"))` plugged into `client.WithTracerProvider`.
+- `client/trace_middleware.go` (in main mcpkit) — the SEP-414 P3 middleware. Outbound `Client.Call` is wrapped in a span; outbound params gain `_meta.traceparent`; inbound server-to-client requests (sampling/elicitation/roots) extract the inbound traceparent and emit a wrap span.
+- `ext/otel/provider.go` — `Provider.StartSpan` is the adapter's hot-path: parses inbound `core.TraceContext` into an OTel `SpanContext`, installs as the new span's parent, and re-attaches the child traceparent via `core.WithTraceContext` for outbound `_meta` injection.
+- `ext/otel/tracerprovider.go` — `mcpotel.NewTracerProvider` (issue 674): one-line helper that bakes `service.name` into the SDK Resource via `WithServiceName` without examples having to import `sdk/resource` + `semconv` themselves.
+- `server/trace_middleware.go` (in main mcpkit) — the SEP-414 P2 middleware. Sits outermost in the dispatch chain so user middleware runs INSIDE the span.
 
 ## Run it
 

--- a/examples/otel/stdout/e2e_test.go
+++ b/examples/otel/stdout/e2e_test.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/panyam/mcpkit/client"
 	"github.com/panyam/mcpkit/core"
@@ -52,7 +53,7 @@ func TestEndToEnd_StdoutDemoWiring(t *testing.T) {
 		core.ServerInfo{Name: "otel-stdout-demo", Version: "0.1.0"},
 		server.WithTracerProvider(mcpotel.NewProvider(otelTP)),
 	)
-	registerEcho(srv)
+	registerDemoTools(srv)
 
 	ts := httptest.NewServer(srv.Handler(server.WithStreamableHTTP(true)))
 	t.Cleanup(ts.Close)
@@ -163,7 +164,7 @@ func TestEndToEnd_BothSidesEmitSpans(t *testing.T) {
 		core.ServerInfo{Name: "otel-stdout-demo", Version: "0.1.0"},
 		server.WithTracerProvider(mcpotel.NewProvider(serverTP)),
 	)
-	registerEcho(srv)
+	registerDemoTools(srv)
 
 	ts := httptest.NewServer(srv.Handler(server.WithStreamableHTTP(true)))
 	t.Cleanup(ts.Close)
@@ -238,3 +239,96 @@ func flattenAttrs(s *tracetest.SpanStub) map[string]string {
 	}
 	return out
 }
+
+// TestEndToEnd_ToolMenu_AllToolsEmit drives each of the four
+// registerDemoTools tools and asserts the tool-specific span shape an
+// operator would see in Tempo. This is the regression guard for the
+// "Explore trace shapes" looping step in the walkthrough — if any
+// tool's span attribute pattern drifts, the demo's teaching value
+// drifts with it.
+func TestEndToEnd_ToolMenu_AllToolsEmit(t *testing.T) {
+	exp := tracetest.NewInMemoryExporter()
+	otelTP := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	t.Cleanup(func() { _ = otelTP.Shutdown(context.Background()) })
+
+	srv := server.NewServer(
+		core.ServerInfo{Name: "otel-stdout-demo", Version: "0.1.0"},
+		server.WithTracerProvider(mcpotel.NewProvider(otelTP)),
+	)
+	registerDemoTools(srv)
+
+	ts := httptest.NewServer(srv.Handler(server.WithStreamableHTTP(true)))
+	t.Cleanup(ts.Close)
+
+	c := client.NewClient(ts.URL+"/mcp",
+		core.ClientInfo{Name: "otel-stdout-test", Version: "1.0"},
+	)
+	require.NoError(t, c.Connect())
+	t.Cleanup(func() { _ = c.Close() })
+
+	type expectation struct {
+		assertSpan func(t *testing.T, span *tracetest.SpanStub)
+	}
+	cases := map[string]expectation{
+		"echo": {
+			assertSpan: func(t *testing.T, span *tracetest.SpanStub) {
+				attrs := flattenAttrs(span)
+				assert.Equal(t, "echo", attrs["mcp.tool.name"])
+				assert.NotEqual(t, "true", attrs["mcp.tool.is_error"],
+					"echo is the baseline; must not be flagged as a tool error")
+			},
+		},
+		"slow_echo": {
+			assertSpan: func(t *testing.T, span *tracetest.SpanStub) {
+				attrs := flattenAttrs(span)
+				assert.Equal(t, "slow_echo", attrs["mcp.tool.name"])
+				duration := span.EndTime.Sub(span.StartTime)
+				assert.GreaterOrEqual(t, duration, 700*time.Millisecond,
+					"slow_echo should have ~750ms duration; got %s", duration)
+			},
+		},
+		"failing_tool": {
+			assertSpan: func(t *testing.T, span *tracetest.SpanStub) {
+				attrs := flattenAttrs(span)
+				assert.Equal(t, "failing_tool", attrs["mcp.tool.name"])
+				assert.Equal(t, "true", attrs["mcp.tool.is_error"],
+					"failing_tool's IsError result must surface as mcp.tool.is_error=true on the span")
+			},
+		},
+		"count_tool": {
+			assertSpan: func(t *testing.T, span *tracetest.SpanStub) {
+				attrs := flattenAttrs(span)
+				assert.Equal(t, "count_tool", attrs["mcp.tool.name"])
+			},
+		},
+	}
+
+	for _, toolName := range []string{"echo", "slow_echo", "failing_tool", "count_tool"} {
+		t.Run(toolName, func(t *testing.T) {
+			exp.Reset()
+
+			_, err := c.Call("tools/call", map[string]any{
+				"name":      toolName,
+				"arguments": map[string]any{"message": "test"},
+			})
+			require.NoError(t, err)
+
+			spans := exp.GetSpans()
+			toolSpan := findToolsCallSpan(spans)
+			require.NotNil(t, toolSpan, "tools/call span must be exported for %s; saw %v", toolName, spanNames(spans))
+			cases[toolName].assertSpan(t, toolSpan)
+		})
+	}
+
+	// count_tool's progress notifications cross the wire as
+	// `notifications/progress` messages, but those aren't dispatch-
+	// path spans on the server (notifications don't have request IDs
+	// and the trace middleware only spans request dispatches). The
+	// per-notification _meta.traceparent injection is verified by
+	// server/trace_middleware_test.go::TestTraceMiddleware_InjectsOutboundNotification_Meta
+	// — covered there, not duplicated here.
+}
+
+// Ensure the `time` package import stays meaningful for the test
+// file's slow_echo duration assertion.
+var _ = time.Millisecond

--- a/examples/otel/stdout/go.mod
+++ b/examples/otel/stdout/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/panyam/demokit v0.0.29
 	github.com/panyam/mcpkit v0.2.45
 	github.com/panyam/mcpkit/examples/common v0.0.0-00010101000000-000000000000
-	github.com/panyam/mcpkit/ext/otel v0.0.0-00010101000000-000000000000
+	github.com/panyam/mcpkit/ext/otel v0.0.0-20260608053428-44b944d79f00
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel/sdk v1.44.0
 )

--- a/examples/otel/stdout/main.go
+++ b/examples/otel/stdout/main.go
@@ -31,9 +31,12 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
+	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/panyam/demokit"
 	"github.com/panyam/mcpkit/core"
@@ -109,19 +112,35 @@ func serve() {
 			// binding that makes spans actually flow to the exporter.
 			server.WithTracerProvider(mcpotel.NewProvider(otelTP)),
 		},
-		Register: registerEcho,
+		Register: registerDemoTools,
 	}); err != nil {
 		log.Fatalf("ListenAndServe: %v", err)
 	}
 }
 
-// registerEcho installs the single demo tool. Trivially synchronous so
-// the demo focuses on the trace mechanics rather than the tool surface.
-func registerEcho(srv *server.Server) {
+// registerDemoTools installs four demo tools, each chosen to produce
+// a distinct trace shape an operator can compare in Grafana / Tempo:
+//
+//   - echo          — baseline single-RPC trace; tells you what a
+//     "normal" span looks like.
+//   - slow_echo     — sleeps 750ms in the handler; the trace's span
+//     duration shows how Tempo renders latency.
+//   - failing_tool  — returns a ToolResult with IsError=true; the
+//     span carries `mcp.tool.is_error="true"` and
+//     Grafana renders it red.
+//   - count_tool    — emits 3 `notifications/progress` via
+//     ctx.Progress(); the parent span's children
+//     include 3 outbound notification spans with
+//     matching `_meta.traceparent` (SEP-414 P2's
+//     outbound _meta injection in action).
+//
+// All four are intentionally trivial so the demo's value lives in
+// the span shape, not the tool surface.
+func registerDemoTools(srv *server.Server) {
 	srv.RegisterTool(
 		core.ToolDef{
 			Name:        "echo",
-			Description: "Returns the message argument unchanged. Trivial body — the demo is about the span the dispatch emits, not the result.",
+			Description: "Returns the message argument unchanged. Baseline span shape — single-RPC trace, no surprises.",
 			InputSchema: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
@@ -143,6 +162,55 @@ func registerEcho(srv *server.Server) {
 			return core.TextResult(args.Message), nil
 		},
 	)
+
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "slow_echo",
+			Description: "Sleeps 750ms then echoes. Span duration is visible in Tempo's trace view.",
+			InputSchema: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{},
+			},
+		},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+			time.Sleep(750 * time.Millisecond)
+			return core.TextResult("slow_echo: slept 750ms"), nil
+		},
+	)
+
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "failing_tool",
+			Description: "Returns ToolResult{IsError: true}. Span carries mcp.tool.is_error=\"true\" — renders red in Grafana.",
+			InputSchema: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{},
+			},
+		},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+			return core.ToolResult{
+				IsError: true,
+				Content: []core.Content{{Type: "text", Text: "simulated tool failure"}},
+			}, nil
+		},
+	)
+
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "count_tool",
+			Description: "Calls ctx.Progress 3 times. Parent span's notifications fan out as outbound spans with _meta.traceparent stamped.",
+			InputSchema: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{},
+			},
+		},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+			for i := 1; i <= 3; i++ {
+				ctx.Progress(float64(i), 3, fmt.Sprintf("step %d/3", i))
+			}
+			return core.TextResult("count_tool: emitted 3 progress notifications"), nil
+		},
+	)
 }
 
 // newOTelPipeline preserves the original stdout-pipeline entrypoint
@@ -152,4 +220,23 @@ func registerEcho(srv *server.Server) {
 // change just because OTLP-mode landed via the shared helpers.
 func newOTelPipeline(w *os.File) (*sdktrace.TracerProvider, func(), error) {
 	return commonotel.NewStdoutPipeline(w, serverServiceName)
+}
+
+// tempoExploreURL builds a Grafana Explore deep link pre-filtered to
+// traces from the given service. The URL pre-loads Grafana's Explore
+// view with Tempo as the data source and a TraceQL search filtering
+// by resource.service.name, plus a "Last 15 minutes" time range so
+// the operator's just-emitted spans are in scope without manual
+// adjustment.
+//
+// Encoding follows Grafana's documented Explore URL shape: the
+// `left` query parameter is a URL-encoded JSON object specifying the
+// data source + queries + range. Grafana parses this on page load
+// and populates the UI as if the operator had constructed the query
+// by hand. Tested against Grafana 11.x; the JSON shape may shift in
+// future versions — re-validate after a major Grafana bump.
+func tempoExploreURL(serviceName string) string {
+	const left = `{"datasource":"tempo","queries":[{"refId":"A","queryType":"traceqlSearch","filters":[{"id":"service-name","tag":"service.name","operator":"=","value":"%s","scope":"resource"}]}],"range":{"from":"now-15m","to":"now"}}`
+	encoded := url.QueryEscape(fmt.Sprintf(left, serviceName))
+	return "http://localhost:3000/explore?orgId=1&left=" + encoded
 }

--- a/examples/otel/stdout/walkthrough.go
+++ b/examples/otel/stdout/walkthrough.go
@@ -15,29 +15,22 @@ import (
 	mcpotel "github.com/panyam/mcpkit/ext/otel"
 )
 
-// (Previously this file defined an explicit inbound traceparent and
-// supplied it in the tools/call. Removed once the client side was
-// instrumented: SEP-414's "explicit caller-set _meta wins" rule means
-// that an externally-supplied traceparent ends up on the SERVER side
-// only, while the client emits a SEPARATE auto-generated trace — the
-// two would NOT share a TraceID and the symmetric-stitching narrative
-// would break. The auto-inject path the walkthrough now exercises
-// produces matching TraceIDs on both terminals — what the reader is
-// supposed to see.)
+// toolMenu is the ordered list of tools the looping "Explore trace
+// shapes" step cycles through. Each is registered on the server side
+// in registerDemoTools (see main.go) and produces a distinct trace
+// shape an operator can compare in Grafana / Tempo. The synthetic
+// "quit" entry is the exit option in interactive mode; non-
+// interactive mode drives through `toolMenu` once and exits.
+var toolMenu = []string{"echo", "slow_echo", "failing_tool", "count_tool"}
 
 func runDemo() {
 	serverURL := common.ServerURL()
 
 	// Walkthrough-side flags. Mirror serve()'s flag set so an operator
 	// can pass --exporter=otlp to both processes and watch matching
-	// TraceIDs land in Grafana (server.service.name=otel-stdout-demo,
-	// host.service.name=otel-stdout-host).
+	// TraceIDs land in Grafana.
 	exporter := flag.String("exporter", defaultExporter, "trace exporter: stdout | otlp")
 	otlpEndpoint := flag.String("otlp-endpoint", commonotel.DefaultOTLPEndpoint, "OTLP gRPC endpoint when --exporter=otlp")
-	// The walkthrough side already parses demokit flags via SetupRenderer
-	// + Execute; pulling our own values out of os.Args directly here would
-	// double-parse. Use flag.Parse only on the residual args demokit
-	// returns via FilterArgs.
 	flag.CommandLine.Parse(demokit.FilterArgs(os.Args[1:],
 		demokit.ValueFlag("--url"),
 	))
@@ -55,29 +48,21 @@ func runDemo() {
 		log.Fatalf("failed to build client-side OTel pipeline: %v", err)
 	}
 	defer shutdownClientOTel()
-	if *exporter == commonotel.ExporterOTLP {
+	otlpMode := *exporter == commonotel.ExporterOTLP
+	if otlpMode {
 		log.Printf("[otel-stdout-host] exporter=otlp endpoint=%s service.name=%s", *otlpEndpoint, hostServiceName)
-		log.Printf("[otel-stdout-host] view in Grafana: http://localhost:3000  (search service.name=%s)", hostServiceName)
+		log.Printf("[otel-stdout-host] view your traces: %s", tempoExploreURL(hostServiceName))
 	}
 
 	demo := demokit.New("MCP SEP-414 — OpenTelemetry Trace Context Propagation").
 		Dir("otel/stdout").
-		Description("Walks through SEP-414, which propagates W3C Trace Context through MCP using the `_meta.traceparent` / `_meta.tracestate` envelope (and, on streamable HTTP, the matching HTTP headers per SEP-2028). BOTH sides are instrumented: the server (`make serve`) wires `server.WithTracerProvider` (P2); the walkthrough (`make demo`) wires `client.WithTracerProvider` (P3). Both pipelines feed the `stdouttrace` exporter, so each terminal prints its own side's spans as pretty-printed JSON. The walkthrough drives a real `tools/call` — the client trace middleware auto-stamps a `_meta.traceparent` on the outbound params and the server picks it up. Matching `TraceID` across the two terminals is the proof that the SEP-414 wire is actually stitching client and server into a single distributed trace.").
+		Description(buildDescription(otlpMode)).
 		Actors(
 			demokit.Actor("Host", "MCP Host (this walkthrough)"),
-			demokit.Actor("Server", "MCP Server (make serve) — spans dump on its stdout"),
+			demokit.Actor("Server", "MCP Server (make serve)"),
 		)
 
-	demo.Section("Setup",
-		"Start the MCP server in a separate terminal first:",
-		"",
-		"```",
-		"Terminal 1:  make serve         # OTel-instrumented server on :8080",
-		"Terminal 2:  make demo          # this walkthrough (--tui for the interactive TUI)",
-		"```",
-		"",
-		"Keep both terminals visible — the walkthrough surfaces what the *Host* sees on the wire (JSON-RPC results), while the OpenTelemetry spans land on the *Server* terminal's stdout via the `stdouttrace` exporter.",
-	)
+	demo.Section("Setup", buildSetupLines(otlpMode)...)
 
 	demo.Section("Wire format",
 		"SEP-414 carries W3C Trace Context two ways:",
@@ -93,15 +78,10 @@ func runDemo() {
 	demo.Step("Connect to the OTel-instrumented server").
 		Arrow("Host", "Server", "POST /mcp — initialize").
 		DashedArrow("Server", "Host", "serverInfo + capabilities").
-		Note("`client.NewClient(...)` + `client.WithTracerProvider(...)` + `Connect()`. Each JSON-RPC dispatch now emits TWO spans — one on each side. The initialize handshake will print `initialize` and `notifications/initialized` spans on BOTH terminals; matching them by TraceID is the visual proof that the SEP-414 wire is propagating from the very first call.").
+		Note("`client.NewClient(...)` + `client.WithTracerProvider(...)` + `Connect()`. Each JSON-RPC dispatch emits a pair of spans — one on each side, stitched via `_meta.traceparent`. The initialize handshake produces the first pair before any tool call runs.").
 		Run(func(ctx demokit.StepContext) *demokit.StepResult {
 			c = client.NewClient(serverURL+"/mcp",
 				core.ClientInfo{Name: "otel-stdout-host", Version: "1.0"},
-				// SEP-414 P3 — client-side trace surface. Outbound
-				// Client.Call emits a span and stamps _meta.traceparent
-				// on params; inbound server-to-client requests
-				// (sampling/elicitation/roots) get wrap spans whose
-				// parent is the inbound _meta.traceparent.
 				client.WithTracerProvider(mcpotel.NewProvider(clientOTelTP,
 					mcpotel.WithInstrumentationName("github.com/panyam/mcpkit/client"),
 				)),
@@ -111,78 +91,65 @@ func runDemo() {
 				return nil
 			}
 			fmt.Printf("    Connected to %s %s\n", c.ServerInfo.Name, c.ServerInfo.Version)
-			fmt.Printf("    Watch THIS terminal: initialize and notifications/initialized client-side spans will appear below.\n")
-			fmt.Printf("    Watch the SERVER terminal: matching server-side spans land there for the same JSON-RPC requests.\n")
+			if otlpMode {
+				fmt.Printf("    Watch Grafana: %s\n", tempoExploreURL(hostServiceName))
+			} else {
+				fmt.Printf("    Watch BOTH terminals — matching TraceIDs prove the wire stitched the trace.\n")
+			}
 			return nil
 		})
 
-	demo.Step("tools/list — every dispatch is a span").
-		Arrow("Host", "Server", "tools/list").
-		DashedArrow("Server", "Host", "tools[]").
-		Note("The trace middleware sits OUTERMOST in the dispatch chain on both sides, so *every* JSON-RPC request emits a pair of spans (one per side, stitched via `_meta.traceparent`). This step is functionally identical to the next one in terms of propagation — the only difference is what attributes get set. Watch the TraceID match across terminals for this list call too.").
+	// One looping "Explore" step that demokit re-enters via
+	// StepResult.Next until the user picks "quit" (interactive) or the
+	// Visits counter has cycled through every tool in `toolMenu`
+	// (non-interactive). Demokit's Choice input handles the menu UX in
+	// every renderer (TUI, plain, notebook, doc).
+	demo.Step("Explore trace shapes").
+		ID("explore").
+		Input(demokit.Choice(append(toolMenu, "quit")...).
+			Named("tool", "Pick a tool to call (or `quit` to exit)").
+			WithDefault(toolMenu[0])).
+		Note(buildExploreNote(otlpMode)).
 		Run(func(ctx demokit.StepContext) *demokit.StepResult {
-			page, err := c.ListToolsPage("")
-			if err != nil {
-				fmt.Printf("    ERROR: %v\n", err)
+			tool := selectTool(ctx)
+			if tool == "" {
+				if otlpMode {
+					fmt.Printf("    Done. Final Grafana view: %s\n", tempoExploreURL(hostServiceName))
+				}
 				return nil
 			}
-			for _, tool := range page.Tools {
-				fmt.Printf("    %-10s %s\n", tool.Name, tool.Description)
+
+			dispatchTool(c, tool)
+
+			if otlpMode {
+				fmt.Printf("\n    See this trace in Grafana: %s\n", tempoExploreURL(hostServiceName))
+				fmt.Printf("    (server-side spans: %s)\n", tempoExploreURL(serverServiceName))
+			} else {
+				fmt.Printf("\n    Match the TraceID across THIS terminal and the SERVER terminal.\n")
 			}
-			return nil
+
+			return &demokit.StepResult{Next: "explore"}
 		})
 
-	demo.Step("tools/call echo — let the client auto-inject _meta.traceparent").
-		Arrow("Host", "Server", "tools/call echo (no caller _meta; client trace mw stamps its own)").
-		DashedArrow("Server", "Host", "text result; server span's Parent matches the client SpanID").
-		Note("With both wires instrumented (PR 649 server + PR 654 client), this single tools/call produces TWO spans on TWO terminals:\n\n1. **Client side (THIS terminal).** The `Client.Call` outbound trace middleware emits a span named `tools/call` with a fresh TraceID + SpanID. Before the call hits the wire, the middleware stamps that TraceID and SpanID into `params._meta.traceparent` via `core.InjectTraceContextIntoParams` (P3, shared helper).\n2. **Server side (the SERVER terminal).** The server trace middleware extracts the stamped `_meta.traceparent` and emits its own `tools/call` span whose `SpanContext.TraceID` MATCHES the client's, and whose `Parent.SpanID` MATCHES the client span's SpanID with `Parent.Remote == true`.\n\nMatch the spans by TraceID across the two terminals — that IS the SEP-414 wire stitching client and server into a single distributed trace. The TraceID is auto-generated each run (no synthetic override), so it'll be different every time — that's the point: real production traces won't have hardcoded IDs.").
-		VerbatimVariants("Reproduce on the wire",
-			demokit.MakeVariant("curl", "bash", `# When using curl directly, no client trace middleware exists, so
-# YOU supply the traceparent. Match it across terminals by inspection.
-curl -s -X POST http://localhost:8080/mcp \
-  -H 'Content-Type: application/json' \
-  -H 'Accept: text/event-stream, application/json' \
-  -H "Mcp-Session-Id: $SID" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"message":"hello"}}}' | jq '.result'`).Default(),
-			demokit.MakeVariant("go", "go", `// Note: the Client must be constructed with
-// client.WithTracerProvider(mcpotel.NewProvider(...)) for the
-// auto-inject to fire. See walkthrough.go::runDemo.
-res, _ := c.Call("tools/call", map[string]any{
-    "name":      "echo",
-    "arguments": map[string]any{"message": "hello"},
-})`),
-		).
-		Run(func(ctx demokit.StepContext) *demokit.StepResult {
-			res, err := c.Call("tools/call", map[string]any{
-				"name":      "echo",
-				"arguments": map[string]any{"message": "hello"},
-			})
-			if err != nil {
-				fmt.Printf("    ERROR: %v\n", err)
-				return nil
-			}
-			var v any
-			if err := json.Unmarshal(res.Raw, &v); err != nil {
-				fmt.Printf("    ERROR decoding raw: %v\n", err)
-				return nil
-			}
-			pretty, _ := json.MarshalIndent(v, "    ", "  ")
-			fmt.Printf("    %s\n", string(pretty))
-			fmt.Printf("\n    Match by TraceID:\n")
-			fmt.Printf("    - THIS terminal: client-side span Name=\"tools/call\" with a fresh TraceID + SpanID.\n")
-			fmt.Printf("    - SERVER terminal: a span with the SAME TraceID, plus Parent.SpanID == client SpanID and Parent.Remote=true.\n")
-			return nil
-		})
-
-	demo.Section("Where to look in the code",
-		"- `examples/otel/stdout/walkthrough.go::runDemo` — the client-side wiring. `mcpotel.NewProvider(clientOTelTP, WithInstrumentationName(\".../client\"))` plugged into `client.WithTracerProvider`. The pipeline uses the same `stdouttrace` exporter as the server, just pointing at this process's stdout.",
-		"- `client/trace_middleware.go` (in main mcpkit) — the SEP-414 P3 middleware that consumes the adapter on the client side. Outbound `Client.Call` is wrapped in a span; outbound params gain `_meta.traceparent` derived from the active span; inbound server-to-client requests (sampling/elicitation/roots) extract the inbound traceparent and emit a wrap span.",
-		"- `ext/otel/provider.go` — `Provider.StartSpan` is the adapter's single hot-path: parses inbound `core.TraceContext` into an OTel `SpanContext`, installs as the new span's parent, and after `tracer.Start` re-attaches the *child* span's traceparent via `core.WithTraceContext` so P2's outbound `_meta` injection stamps the right trace ID on downstream messages.",
-		"- `ext/otel/span.go` — narrows OTel's broader Span surface to mcpkit's three-method `core.Span` contract. CAS-guarded `End` prevents the SDK's noisy double-End warning.",
-		"- `ext/otel/propagation.go` — pure W3C ↔ OTel SpanContext conversions. `traceContextToSpanContext` validates structurally before installing; `spanContextToTraceContext` formats the new span back into the W3C version-00 string the wire expects.",
-		"- `server/trace_middleware.go` (in main mcpkit) — the SEP-414 P2 middleware that consumes the adapter. Sits outermost in the dispatch chain so user middleware runs INSIDE the span.",
-		"- `examples/otel/stdout/main.go` — the wiring: `server.WithTracerProvider(mcpotel.NewProvider(otelTP))` is the one new line in `serve()`. Everything else is canonical `common.RunServer` boilerplate.",
-	)
+	if !otlpMode {
+		demo.Section("Where to look in the code",
+			"- `examples/otel/stdout/main.go::registerDemoTools` — the four tools that drive distinct trace shapes (echo / slow_echo / failing_tool / count_tool).",
+			"- `examples/otel/stdout/walkthrough.go::runDemo` — the client-side wiring. `mcpotel.NewProvider(clientOTelTP, WithInstrumentationName(\".../client\"))` plugged into `client.WithTracerProvider`.",
+			"- `client/trace_middleware.go` (in main mcpkit) — the SEP-414 P3 middleware. Outbound `Client.Call` is wrapped in a span; outbound params gain `_meta.traceparent`; inbound server-to-client requests (sampling/elicitation/roots) extract the inbound traceparent and emit a wrap span.",
+			"- `ext/otel/provider.go` — `Provider.StartSpan` is the adapter's hot-path: parses inbound `core.TraceContext` into an OTel `SpanContext`, installs as the new span's parent, and re-attaches the child traceparent via `core.WithTraceContext` for outbound `_meta` injection.",
+			"- `ext/otel/tracerprovider.go` — `mcpotel.NewTracerProvider` (issue 674): one-line helper that bakes `service.name` into the SDK Resource via `WithServiceName` without examples having to import `sdk/resource` + `semconv` themselves.",
+			"- `server/trace_middleware.go` (in main mcpkit) — the SEP-414 P2 middleware. Sits outermost in the dispatch chain so user middleware runs INSIDE the span.",
+		)
+	} else {
+		demo.Section("Where to view the traces",
+			"All spans this walkthrough emits land in Tempo via the OTel Collector at `localhost:4317`. Pre-filtered Grafana Explore links:",
+			"",
+			fmt.Sprintf("- **Client-side spans** (this walkthrough): %s", tempoExploreURL(hostServiceName)),
+			fmt.Sprintf("- **Server-side spans**: %s", tempoExploreURL(serverServiceName)),
+			"",
+			"Click any trace row in either view to see the full span tree, then use the \"View linked logs\" / \"View linked metrics\" buttons in the trace UI to follow the data into Loki / Mimir when those lanes light up (currently idle).",
+		)
+	}
 
 	common.SetupRenderer(demo)
 	demo.Execute()
@@ -190,4 +157,119 @@ res, _ := c.Call("tools/call", map[string]any{
 	if c != nil {
 		c.Close()
 	}
+}
+
+// buildDescription returns the top-level description that demokit
+// embeds in the rendered output, branched on the exporter mode so a
+// reader doesn't see references to the WRONG mode's setup.
+func buildDescription(otlpMode bool) string {
+	if otlpMode {
+		return "Walks through SEP-414 against the LGTM observability stack at `docker/observability/`. Both sides — server (`make serve EXPORTER=otlp`) and walkthrough (`make demo EXPORTER=otlp`) — ship spans via OTLP gRPC to the OTel Collector, which fans them out to Tempo. Grafana renders the stitched client→server trace under one TraceID per `tools/call`. Each step prints a pre-filtered Grafana Explore deep link so you can drill straight into Tempo. The looping \"Explore trace shapes\" step lets you A/B four distinct tools and compare their span shapes in Grafana."
+	}
+	return "Walks through SEP-414 in stdout-exporter mode (no external stack required). Both sides — server (`make serve`) and walkthrough (`make demo`) — print spans as pretty JSON on their respective terminals. The looping \"Explore trace shapes\" step lets you A/B four distinct tool calls; matching TraceIDs across the two terminals is the SEP-414 wire stitching client and server into a single distributed trace. Run with `EXPORTER=otlp` after `make -C docker up` to ship spans to Grafana instead."
+}
+
+// buildSetupLines returns the markdown lines for the Setup section,
+// mode-branched. OTLP mode includes the docker stack-up step and the
+// Grafana URL up-front so the reader knows where to look BEFORE the
+// steps run.
+func buildSetupLines(otlpMode bool) []string {
+	if otlpMode {
+		return []string{
+			"Bring up the LGTM observability stack and start the OTel-instrumented server:",
+			"",
+			"```",
+			"Terminal 1:  make -C ../../../docker up           # Tempo + Loki + Mimir + Grafana + OTel Collector",
+			"Terminal 2:  make serve EXPORTER=otlp             # MCP server, exports OTLP",
+			"Terminal 3:  make demo EXPORTER=otlp              # this walkthrough, exports OTLP",
+			"```",
+			"",
+			"Then open Grafana — the steps below print pre-filtered Explore deep links you can click straight into:",
+			"",
+			fmt.Sprintf("- Grafana home: http://localhost:3000"),
+			fmt.Sprintf("- Client-side traces: %s", tempoExploreURL(hostServiceName)),
+			fmt.Sprintf("- Server-side traces: %s", tempoExploreURL(serverServiceName)),
+			"",
+			"Anonymous Admin access — no Grafana login form. Time range defaults to \"Last 15 minutes\" so just-emitted traces are in scope.",
+		}
+	}
+	return []string{
+		"Start the MCP server in a separate terminal first:",
+		"",
+		"```",
+		"Terminal 1:  make serve         # OTel-instrumented server on :8080",
+		"Terminal 2:  make demo          # this walkthrough (--tui for the interactive TUI)",
+		"```",
+		"",
+		"Keep both terminals visible — the walkthrough surfaces what the *Host* sees on the wire (JSON-RPC results); the OpenTelemetry spans land on the *Server* terminal's stdout via the `stdouttrace` exporter. Match the TraceID across the two terminals to see the SEP-414 stitch.",
+		"",
+		"To send spans to a real backend instead, run with `EXPORTER=otlp` after `make -C ../../../docker up`.",
+	}
+}
+
+// buildExploreNote returns the Note shown at the looping Explore step,
+// branched to surface Grafana deep links in OTLP mode and terminal
+// match instructions in stdout mode.
+func buildExploreNote(otlpMode bool) string {
+	if otlpMode {
+		return "Pick a tool from the menu. Each one produces a distinct trace shape in Tempo:\n\n" +
+			"- `echo` — baseline single-RPC trace.\n" +
+			"- `slow_echo` — 750ms `time.Sleep` in the handler; span duration is visible in Tempo.\n" +
+			"- `failing_tool` — handler returns IsError=true; span carries `mcp.tool.is_error=\"true\"` and Grafana renders it red.\n" +
+			"- `count_tool` — handler emits 3 `notifications/progress`; the trace fan-out shows the parent `tools/call` plus 3 outbound notification spans, each carrying `_meta.traceparent` from the parent.\n" +
+			"- `quit` — exit the loop.\n\n" +
+			"After each call this step prints a pre-filtered Grafana Explore link so you can drill straight into the new trace."
+	}
+	return "Pick a tool from the menu. Each one produces a distinct trace shape on the stdout exporters:\n\n" +
+		"- `echo` — baseline single span on each terminal.\n" +
+		"- `slow_echo` — 750ms handler sleep; the span's StartTime → EndTime is visibly long.\n" +
+		"- `failing_tool` — server span carries `mcp.tool.is_error=\"true\"`.\n" +
+		"- `count_tool` — server emits 3 `notifications/progress`, each as its own outbound span with `_meta.traceparent` set.\n" +
+		"- `quit` — exit the loop.\n\n" +
+		"After each call, match the TraceID printed on this terminal against the SERVER terminal — that match IS the SEP-414 client↔server stitching."
+}
+
+// selectTool resolves which tool to dispatch on this Explore-step
+// iteration. In interactive mode it reads the user's Choice input;
+// the Sentinel "quit" returns "" so the caller stops looping. In non-
+// interactive mode it walks toolMenu by Visits, returning "" once
+// every tool has been exercised so the loop exits without manual
+// intervention.
+func selectTool(ctx demokit.StepContext) string {
+	if demokit.IsNonInteractive() {
+		if ctx.Visits > len(toolMenu) {
+			return ""
+		}
+		return toolMenu[ctx.Visits-1]
+	}
+	tool, _ := ctx.Inputs["tool"].(string)
+	if tool == "quit" {
+		return ""
+	}
+	return tool
+}
+
+// dispatchTool calls the named tool through the *client.Client. Each
+// tool's argument shape is intentionally minimal so the demo focuses
+// on the resulting trace shape rather than tool-input mechanics.
+func dispatchTool(c *client.Client, tool string) {
+	args := map[string]any{}
+	if tool == "echo" {
+		args["message"] = "hello from explore step"
+	}
+	res, err := c.Call("tools/call", map[string]any{
+		"name":      tool,
+		"arguments": args,
+	})
+	if err != nil {
+		fmt.Printf("    %s: ERROR: %v\n", tool, err)
+		return
+	}
+	var v any
+	if err := json.Unmarshal(res.Raw, &v); err != nil {
+		fmt.Printf("    %s: ERROR decoding raw: %v\n", tool, err)
+		return
+	}
+	pretty, _ := json.MarshalIndent(v, "    ", "  ")
+	fmt.Printf("    %s →\n    %s\n", tool, string(pretty))
 }

--- a/ext/otel/tracerprovider.go
+++ b/ext/otel/tracerprovider.go
@@ -1,0 +1,123 @@
+package otel
+
+// SEP-414 P6 — `mcpotel.NewTracerProvider` helper (issue 674).
+//
+// Examples wiring OTel against the mcpkit adapter end up building a
+// fairly stereotyped `*sdktrace.TracerProvider`: an exporter, a
+// Resource with `service.name` set so the observability backend
+// indexes spans under a recognizable label, and either WithBatcher
+// (production) or WithSyncer (demo / test). This file collects that
+// boilerplate behind a single `NewTracerProvider(exp, opts...)`
+// constructor so the consumer doesn't have to import
+// go.opentelemetry.io/otel/sdk/resource + .../semconv just to set a
+// service name.
+//
+// The functional-options pattern leaves room for future additions
+// (`WithDeploymentEnvironment`, `WithServiceVersion`, `WithResource`
+// escape hatch) without disturbing the constructor signature. The
+// option set today is intentionally small — extend when a real
+// consumer asks.
+//
+// Existing mcpotel.NewProvider(otelTP) is unchanged; this file adds a
+// sibling helper that callers compose with it:
+//
+//	otelTP := mcpotel.NewTracerProvider(exp, mcpotel.WithServiceName("my-server"))
+//	srv := server.NewServer(info, server.WithTracerProvider(mcpotel.NewProvider(otelTP)))
+
+import (
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+)
+
+// TracerProviderOption mutates the SDK TracerProvider construction
+// performed by NewTracerProvider. Pass any combination of the
+// With... options below; later options override earlier ones when
+// they touch the same config field.
+type TracerProviderOption func(*tracerProviderConfig)
+
+type tracerProviderConfig struct {
+	serviceName string
+	syncer      bool // true = WithSyncer; false (default) = WithBatcher
+}
+
+// WithServiceName sets the OpenTelemetry `service.name` Resource
+// attribute on the constructed TracerProvider. Observability
+// backends (Grafana / Tempo / Jaeger / Honeycomb) index spans by
+// this attribute as the primary axis — without it, traces appear
+// under `unknown_service:<binary>`.
+//
+// An empty name is treated as "leave default" — the caller may
+// pass through a config-file value without branching on whether
+// the field is populated. The SDK's default Resource still applies
+// in that case (which usually means `unknown_service:<binary>` in
+// Grafana, but at least the call site doesn't crash).
+func WithServiceName(name string) TracerProviderOption {
+	return func(c *tracerProviderConfig) {
+		if name != "" {
+			c.serviceName = name
+		}
+	}
+}
+
+// WithSyncer switches the TracerProvider from the default batched
+// span processor to a synchronous one: every span ships immediately
+// on End(), no batch-flush window. Slightly slower per-span at the
+// transport layer (gRPC for OTLP, line write for stdout), but the
+// trade-off is the right one for teaching demos and tests where an
+// operator who kills the process seconds after `tools/call` returns
+// must see their spans in the backend, not wait for a batch flush
+// that never happens.
+//
+// Real high-throughput servers should stay on the default
+// (WithBatcher) and handle SIGTERM with an explicit ForceFlush +
+// Shutdown sequence.
+func WithSyncer() TracerProviderOption {
+	return func(c *tracerProviderConfig) {
+		c.syncer = true
+	}
+}
+
+// NewTracerProvider builds an `*sdktrace.TracerProvider` with the
+// supplied exporter and options. The returned TracerProvider is
+// ready to hand to mcpotel.NewProvider(otelTP) for wiring into
+// server.WithTracerProvider or client.WithTracerProvider.
+//
+// Panics if exporter is nil — silently constructing a TracerProvider
+// that emits no spans loses signals without surfacing the
+// misconfiguration. Same fail-fast convention as
+// mcpotel.NewProvider(nil otelTP).
+//
+// The default span processor is batched (production-aligned). Pass
+// WithSyncer to switch to sync exporting. The default Resource is
+// the SDK default (no service.name); pass WithServiceName to set it.
+//
+// Future options (`WithDeploymentEnvironment`, `WithServiceVersion`,
+// `WithResource` escape hatch) compose against the same internal
+// config — they will land when a real consumer asks. Issue 663 (P6
+// umbrella) tracks the SEP-414 surface work that consumes this
+// helper.
+func NewTracerProvider(exporter sdktrace.SpanExporter, opts ...TracerProviderOption) *sdktrace.TracerProvider {
+	if exporter == nil {
+		panic("ext/otel: NewTracerProvider called with nil SpanExporter")
+	}
+
+	cfg := tracerProviderConfig{}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	sdkOpts := make([]sdktrace.TracerProviderOption, 0, 3)
+	if cfg.serviceName != "" {
+		sdkOpts = append(sdkOpts, sdktrace.WithResource(resource.NewSchemaless(
+			semconv.ServiceName(cfg.serviceName),
+		)))
+	}
+	if cfg.syncer {
+		sdkOpts = append(sdkOpts, sdktrace.WithSyncer(exporter))
+	} else {
+		sdkOpts = append(sdkOpts, sdktrace.WithBatcher(exporter))
+	}
+
+	return sdktrace.NewTracerProvider(sdkOpts...)
+}

--- a/ext/otel/tracerprovider_test.go
+++ b/ext/otel/tracerprovider_test.go
@@ -1,0 +1,130 @@
+package otel_test
+
+import (
+	"context"
+	"testing"
+
+	mcpotel "github.com/panyam/mcpkit/ext/otel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func TestNewTracerProvider_NilExporter_Panics(t *testing.T) {
+	assert.Panics(t, func() {
+		_ = mcpotel.NewTracerProvider(nil)
+	})
+}
+
+func TestNewTracerProvider_NoOpts_BuildsValidTP(t *testing.T) {
+	exp := tracetest.NewInMemoryExporter()
+	tp := mcpotel.NewTracerProvider(exp, mcpotel.WithSyncer())
+	require.NotNil(t, tp)
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	_, span := tp.Tracer("test").Start(context.Background(), "span-without-service-name")
+	span.End()
+
+	spans := exp.GetSpans()
+	require.Len(t, spans, 1)
+	// Resource attributes vary by SDK default; we just assert the
+	// span was recorded without panicking.
+	assert.Equal(t, "span-without-service-name", spans[0].Name)
+}
+
+func TestWithServiceName_FlowsToRecordedResource(t *testing.T) {
+	exp := tracetest.NewInMemoryExporter()
+	tp := mcpotel.NewTracerProvider(exp,
+		mcpotel.WithServiceName("my-test-service"),
+		mcpotel.WithSyncer(),
+	)
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	_, span := tp.Tracer("test").Start(context.Background(), "span-with-service-name")
+	span.End()
+
+	spans := exp.GetSpans()
+	require.Len(t, spans, 1)
+
+	var serviceName string
+	for _, kv := range spans[0].Resource.Attributes() {
+		if string(kv.Key) == "service.name" {
+			serviceName = kv.Value.AsString()
+		}
+	}
+	assert.Equal(t, "my-test-service", serviceName,
+		"WithServiceName must set the OTel Resource service.name attribute the SDK exporter records")
+}
+
+func TestWithServiceName_Empty_NoOp(t *testing.T) {
+	exp := tracetest.NewInMemoryExporter()
+	tp := mcpotel.NewTracerProvider(exp,
+		mcpotel.WithServiceName(""),
+		mcpotel.WithSyncer(),
+	)
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	_, span := tp.Tracer("test").Start(context.Background(), "empty-service-name-span")
+	span.End()
+
+	spans := exp.GetSpans()
+	require.Len(t, spans, 1)
+	for _, kv := range spans[0].Resource.Attributes() {
+		// SDK default Resource sets service.name to something like
+		// "unknown_service:<binary>" — the absence of our value is
+		// what we're asserting, not the absence of any value.
+		assert.NotEqual(t, "my-test-service", kv.Value.AsString())
+	}
+}
+
+func TestWithSyncer_EmitsImmediately(t *testing.T) {
+	exp := tracetest.NewInMemoryExporter()
+	tp := mcpotel.NewTracerProvider(exp,
+		mcpotel.WithServiceName("sync-test"),
+		mcpotel.WithSyncer(),
+	)
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	_, span := tp.Tracer("test").Start(context.Background(), "sync-span")
+	span.End()
+
+	// No explicit ForceFlush — sync processor must have already
+	// pushed the span to the exporter by the time End() returned.
+	assert.Len(t, exp.GetSpans(), 1,
+		"WithSyncer must push spans on End() without an explicit ForceFlush — the test would fail with WithBatcher (default)")
+}
+
+func TestNewTracerProvider_DefaultsToBatcher(t *testing.T) {
+	exp := tracetest.NewInMemoryExporter()
+	tp := mcpotel.NewTracerProvider(exp,
+		mcpotel.WithServiceName("batcher-test"),
+	)
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	_, span := tp.Tracer("test").Start(context.Background(), "batched-span")
+	span.End()
+
+	// Without WithSyncer, the batch processor holds the span — it
+	// hasn't flushed yet, so the exporter is empty. ForceFlush
+	// drains it.
+	assert.Empty(t, exp.GetSpans(), "default Batcher must hold spans until ForceFlush")
+
+	require.NoError(t, tp.ForceFlush(context.Background()))
+	assert.Len(t, exp.GetSpans(), 1)
+}
+
+// Sanity: the helper returns a *sdktrace.TracerProvider that can be
+// composed with the existing mcpotel.NewProvider wrapper.
+func TestNewTracerProvider_ComposesWithNewProvider(t *testing.T) {
+	exp := tracetest.NewInMemoryExporter()
+	tp := mcpotel.NewTracerProvider(exp,
+		mcpotel.WithServiceName("compose-test"),
+		mcpotel.WithSyncer(),
+	)
+	require.NotNil(t, tp)
+	// Just confirm the type is what NewProvider expects.
+	var _ sdktrace.SpanExporter = exp
+	provider := mcpotel.NewProvider(tp)
+	require.NotNil(t, provider)
+}


### PR DESCRIPTION
## What changes

Bundled PR delivering three packaged improvements: (1) the `mcpotel.NewTracerProvider` + `WithServiceName` + `WithSyncer` helpers from issue 674 to eliminate `sdk/resource` + `semconv` boilerplate from examples, (2) OTLP-mode discoverability polish (mode-aware Setup with pre-filtered Grafana Explore deep links so operators see where their traces go BEFORE running the demo), and (3) replacing the linear single-tool walkthrough with a looping menu of four tool calls covering distinct trace shapes (baseline / slow / failing / progress fan-out). Live smoke verified: 22/22 spans accepted + exported, both service names indexed in Tempo, deep links open straight to the trace.

## Reviewer's guide

Read in this order:

1. [ext/otel/tracerprovider.go](https://github.com/panyam/mcpkit/pull/680/files#diff-22e258b51e1b8ca9fbea683875ac89dec596f9e2e7d64e34cf498821e7dbffa1) — the issue 674 helper. Functional-options pattern; `WithServiceName` bakes `semconv.ServiceName` into a Resource; `WithSyncer` flips default Batcher to sync exporting. Nil exporter panics, empty service name no-ops. Confirm the doc comments explain the production-vs-demo trade-off on Batcher vs Syncer.
2. [ext/otel/tracerprovider_test.go](https://github.com/panyam/mcpkit/pull/680/files#diff-a63e11f6d1ff9d7197e2f56674e467b72f2959339d20d5b58b746423bc17786b) — 7 tests via `tracetest.InMemoryExporter`: nil panics, no-opts default, service.name flows to recorded Resource, empty no-op, sync emits immediately on End, default batcher requires ForceFlush, composes with existing NewProvider.
3. [examples/common/otel/pipeline.go](https://github.com/panyam/mcpkit/pull/680/files#diff-ced5b147376a501a802a5a9d1055a3d92fa0ab59572d6c4a860b204fc5bbb8c8) (diff) — migration to the helper. Drops `sdk/resource` + `semconv` direct imports; both `NewStdoutPipeline` and `NewOTLPPipeline` collapse their construction to a single `mcpotel.NewTracerProvider(exp, WithServiceName(...), WithSyncer())` call.
4. [examples/common/go.mod](https://github.com/panyam/mcpkit/pull/680/files#diff-bd232a7f42080ccdea8f4c4a82f9dce7b6cecdf4ef10517715c69360124259e3) (diff) — `semconv/v1.26.0` removed from direct deps. New `replace github.com/panyam/mcpkit/ext/otel => ../../ext/otel` so the migration consumes the in-tree helper rather than a published version.
5. [examples/otel/stdout/main.go](https://github.com/panyam/mcpkit/pull/680/files#diff-8e7fe32638abdc84adfc20acdb9b158681eaf9f1b1b93478ce28f6dada7d156d) (diff) — `registerDemoTools` registers the four tools (echo / slow_echo / failing_tool / count_tool). New `tempoExploreURL(serviceName)` builds a pre-filtered Grafana Explore deep link.
6. [examples/otel/stdout/walkthrough.go](https://github.com/panyam/mcpkit/pull/680/files#diff-23562a492c507ed5bc81de5aa2d992faf3fbc2018be37ca8fe8667cafc529844) — major restructure. Mode-aware Setup (`buildSetupLines`), Description (`buildDescription`), and Explore-step Note (`buildExploreNote`). The single looping "Explore trace shapes" Step uses `demokit.Choice(...).Named(...).WithDefault(...)` as its Input + `StepResult{Next: "explore"}` to re-enter until the user picks "quit". Non-interactive mode walks the 4 tools via `ctx.Visits`. Each iteration prints either the Grafana deep link (OTLP mode) or the "match TraceID across terminals" hint (stdout mode).
7. [examples/otel/stdout/e2e_test.go](https://github.com/panyam/mcpkit/pull/680/files#diff-ace28f6ca514066d3e4eb48762a460fc713b020599831da474eaadd13e415fcb) (diff) — `TestEndToEnd_ToolMenu_AllToolsEmit` drives each of the 4 tools through a real `*client.Client` and asserts the tool-specific span attribute pattern.
8. [examples/otel/stdout/README.md](https://github.com/panyam/mcpkit/pull/680/files#diff-e301bfde5a96f1efea927ca0cce4c356cf64dff5afc3774accd5bcaaff8139ee), [examples/otel/stdout/WALKTHROUGH.md](https://github.com/panyam/mcpkit/pull/680/files#diff-0e84daeca4318b432f2bd2656590286f7fb6282ae7dfc8c1638193ce3f27aa23) (regenerated), [docs/SEP_414_OTEL.md](https://github.com/panyam/mcpkit/pull/680/files#diff-471fd7f72ab0a2ff1e1398303fa41c3e0173c19ac5439e8b833ce242fa81f3e6), `CAPABILITIES.md` — doc updates.

Skim or skip: [examples/otel/stdout/go.mod](https://github.com/panyam/mcpkit/pull/680/files#diff-bc07003cf321937ee37ff7f50cfbd146e5674d20632ad3b79e26e9b4b007d253)/`go.sum`, `examples/common/go.sum` (mechanical), `WALKTHROUGH.md` (regenerated from walkthrough.go).

## Decision log

| Decision | Choice | Alternative | Why |
|---|---|---|---|
| Helper shape | `NewTracerProvider(exp, opts...)` with functional options | Struct config (`Config{ServiceName: ...}`) | Matches OTel SDK's own idiom (`WithSyncer`, `WithBatcher`, `WithResource`). Future options compose without disturbing the constructor signature. |
| Include `WithSyncer` in 674's first cut | Yes | Defer to follow-up | Without it the `examples/common/otel/` migration is incomplete — the OTLP path still needs sync exporting (PR 677 fix). Same shape as `WithServiceName`, no scope creep. |
| `WithServiceName("")` handling | Silent no-op | Reject / error | Matches `core.WithActiveSpan(nil)` precedent. Defensive callers pass through config values without branching. |
| Nil exporter handling | Panic | Return error / return no-op TracerProvider | Matches `NewProvider(nil)` fail-fast. Silent no-op would lose signals without surfacing the misconfig. |
| `ext/otel` gains `sdk` + `semconv` deps | Yes | Keep helper in examples/common/otel/ | Real consumers of `mcpotel.NewProvider(otelTP)` already need `otel/sdk` to construct the TracerProvider they pass in — the net new transitive dep is just `semconv` (small). Centralising the helper in `ext/otel` puts it in the natural import path. |
| Looping shape | One demokit `Step` with `Choice` Input + `StepResult{Next: id}` to re-enter | Multiple sequential steps OR manual `bufio.NewReader(os.Stdin)` | Demokit's input system handles the menu UX in every renderer (TUI / plain / notebook / doc) for free. `StepResult.Next` is the documented "re-enter step" primitive. Sequential would force operators to see each variant before moving on; the user explicitly asked for "loop." |
| Non-interactive mode strategy | `ctx.Visits`-driven walk through `toolMenu`, then exit | Skip the loop entirely; non-interactive runs once with default | Walking all four exercises the e2e_test.go path AND demonstrates each shape on CI runs. Single-default would mask regressions on the other three tools. |
| Tool menu picks | echo / slow_echo / failing_tool / count_tool | Add MRTR + Sampling | MRTR + Sampling require client-side handling that complicates the demo significantly. Filed as out-of-scope for a future follow-up. |
| OTLP "Where to look in the code" → Tempo deep links | Drop the code section in OTLP mode; replace with "Where to view the traces" with pre-filtered Explore links | Show both | The user's question in OTLP mode is "where did my trace go," not "where's the wiring." Code section stays in stdout mode (where code-reading IS the teaching value). |
| Setup section structure | Mode-branched via `buildSetupLines(otlpMode)` | Single setup that mentions both modes | Mode-branched avoids muddling — a reader running OTLP shouldn't have to filter out stdout instructions to find their Grafana URL. |
| `tempoExploreURL` URL construction | URL-encode a JSON `left` parameter matching Grafana 11.x Explore docs | Use Grafana's `/d/<dashboard>?var-service=...` parameterized dashboard URL | Explore-deep-links don't require a pre-built dashboard to ship with the PR. Documented in the helper's doc comment that the URL shape is Grafana-11.x-specific. |

## Test plan

Added: ~25 assertions across 7 new tests in `ext/otel/tracerprovider_test.go` + 4 sub-tests (one per tool, with 2-3 assertions each) in `examples/otel/stdout/e2e_test.go::TestEndToEnd_ToolMenu_AllToolsEmit`. Removed / weakened: 0.

Coverage:

- `ext/otel/tracerprovider_test.go` — 7 tests proving the helper's contract via real `sdktrace.InMemoryExporter`: nil panic, no-opts default, `WithServiceName` flow-through, empty no-op, sync emits immediately, default Batcher requires ForceFlush, composition with `NewProvider`.
- `examples/otel/stdout/e2e_test.go` — extended `TestEndToEnd_ToolMenu_AllToolsEmit` drives all four tools through a real `*client.Client` connected to a real `httptest.Server`. Asserts:
  - `slow_echo` span duration ≥ 700ms
  - `failing_tool` span has `mcp.tool.is_error="true"`
  - `echo` span has no error flags
  - `count_tool` span emits without panicking (notification span attribution is covered by `server/trace_middleware_test.go`)

Verification:

- `make test` (root): clean.
- `make test-otel`: clean.
- `make test-otel-example`: clean.
- `gofmt -l`: clean (after one auto-fix).
- `go vet ./...`: clean.
- Live smoke against `make -C docker up`:
  1. `make serve EXPORTER=otlp` → server boots, logs OTLP endpoint + Grafana URL.
  2. `make demo EXPORTER=otlp --non-interactive` → all 4 tools dispatch via the looping Explore step's `ctx.Visits` walk.
  3. Collector self-metrics: 22 spans accepted + 22 exported to Tempo, zero failed.
  4. Tempo `/api/search/tag/service.name/values` returns both `otel-stdout-demo` and `otel-stdout-host`.
  5. The Grafana Explore deep link the walkthrough printed opens straight to the trace view, pre-filtered to `service.name=otel-stdout-host`.

## Risk / blast radius

- **`ext/otel` adapter module gains `sdk` + `semconv` direct deps.** Existing consumers (only `examples/common/otel/` today) already pull `otel/sdk` to construct their TracerProvider — net new transitive dep is just `semconv`. Future third-party consumers of `mcpotel.NewProvider` who hand-build their own SDK config don't have to touch the new helper.
- **`examples/common/otel/ResourceFor` dropped.** A 24-hour-old exported symbol with no out-of-tree consumers; the helper replaces its single use site.
- **`registerEcho` renamed to `registerDemoTools` in `examples/otel/stdout/main.go`.** Caller updated in `e2e_test.go`; no other consumers.
- **walkthrough.go is substantially rewritten.** Linear 3-step structure (Connect → tools/list → tools/call) replaced by 1 connect step + 1 looping Explore step. WALKTHROUGH.md regenerated accordingly.
- **Be paranoid about:** the Grafana Explore URL shape (`tempoExploreURL`). Grafana's deep-link JSON-as-query-param format may shift across major versions; the helper's doc comment calls out the v11.x assumption. Live smoke confirmed Grafana 11.3.1 renders the URL correctly.

## Before / after

Before: walkthrough emits one `tools/call echo` then exits. OTLP-mode operator opens Grafana and has to manually navigate to Explore → Tempo → pick service name → adjust time range. Often concludes the wire is broken because of the default "Last 1 hour" range plus Tempo's block-conversion latency.

After: walkthrough's Setup section in OTLP mode prints the Grafana home URL + two pre-filtered Explore deep links (one per service.name) BEFORE running steps. Each looping Explore-step iteration prints a fresh deep link. The deep links pre-load the Tempo TraceQL search filtered by service.name + a "Last 15 minutes" time range so just-emitted traces are in scope without manual adjustment. Operator clicks → sees their trace.

## Out of scope (deliberately deferred)

- **MRTR + Sampling tools in the menu** — complicated client-side handling; revisit if a teaching scenario warrants.
- **`ext/otel.WithDeploymentEnvironment`, `WithServiceVersion`, `WithResource` escape hatch** — future options on the same internal config; file when a real consumer asks.
- **Grafana dashboard JSON** in `docker/observability/grafana/provisioning/dashboards/files/` — placeholder directory wired but no dashboards yet; lands alongside the surface PRs (658 / 659 / 660 / 664) that produce the data.
- **Migrating non-OTel examples to use the helper** — there are no non-OTel examples using OTel yet. As 658 / 659 / 660 / 664 land, they consume `examples/common/otel/` for free.
- **Conformance suite (issue 429)** — unchanged.

Closes issue 674.
