### PR TITLE
events: add Emitter output seam (replaces over-abstracted EventBus from closed PR 679)

### DIFF
--- a/experimental/ext/events/README.md
+++ b/experimental/ext/events/README.md
@@ -140,7 +140,7 @@ type PollResult struct {
 - Retry with exponential backoff on 5xx (no retry on 4xx)
 - Basic SSRF validation on callback URLs
 - Pluggable signature format (see below)
-- Pluggable subscription storage via `WithWebhookStore`, quota counts via `WithQuotaStore`, subscription-id routing via the `SubscriptionIndexStore` interface on `Config.SubscriptionIndex` (default in-memory in all three; Postgres + Redis backends land in issues 630 / 634). See [`STORAGE_SEAMS.md`](STORAGE_SEAMS.md) for the convention every storage seam in this package follows.
+- Pluggable subscription storage via `WithWebhookStore`, quota counts via `WithQuotaStore`, subscription-id routing via the `SubscriptionIndexStore` interface on `Config.SubscriptionIndex`, output delivery via `Config.Emitter` (default in-memory / local in all four; Postgres + Redis backends land in issues 630 / 634; multi-replica composition is `NewCompositeEmitter(local, yourPeerFanout)` and receive-side reuses `HTTPSource`). See [`STORAGE_SEAMS.md`](STORAGE_SEAMS.md) for the convention every seam in this package follows.
 
 ```go
 webhooks := events.NewWebhookRegistry(

--- a/experimental/ext/events/STORAGE_SEAMS.md
+++ b/experimental/ext/events/STORAGE_SEAMS.md
@@ -93,3 +93,11 @@ func WithWebhookStore(s WebhookStore) WebhookOption
 5. Add the seam's row to the table above in this doc.
 
 The other seams (#626, #628, #631) follow this template. Reviews check against this file.
+
+## Adjacent seams (not storage, same code conventions)
+
+| Interface | Concern | Status |
+|---|---|---|
+| `Emitter` | Output-side seam: "given an event, deliver it." Dual of `EventSource`. Default `NewLocalEmitter` matches today's single-replica behavior; multi-replica deployments compose with `NewCompositeEmitter` to add peer fanout. Receive-side cross-replica reuses the existing `HTTPSource` pattern — no new "Subscribe" API needed. | landed (629) |
+
+`Emitter` is not a storage seam (it doesn't persist anything), but follows the same `ctx`-first method shape and lives in its own file (`emitter.go`) per the same conventions. Listed here so future readers see the full set of seams in one place.

--- a/experimental/ext/events/emitter.go
+++ b/experimental/ext/events/emitter.go
@@ -1,0 +1,109 @@
+package events
+
+import (
+	"context"
+
+	"github.com/panyam/mcpkit/server"
+)
+
+// Emitter is the output-side seam: "given an event, deliver it." It
+// is the dual of EventSource — Source produces events; Emitter
+// consumes them. The default implementation (NewLocalEmitter) delivers
+// to local SSE listeners (via Server.Broadcast) and to the local
+// WebhookRegistry, matching today's single-replica behavior bit-for-
+// bit. Multi-replica deployments compose alternative emitters via
+// NewCompositeEmitter — e.g., a fanout emitter that POSTs to peer
+// replicas' HTTPSource inject endpoints (which already exist as a
+// public source pattern), or a Redis-backed emitter that publishes to
+// a pubsub channel.
+//
+// Why an output interface (not a pub/sub bus): the asymmetry mirrors
+// what the codebase already does on the input side. EventSource
+// abstracts "where events come from"; Emitter abstracts "where they
+// go." A pub/sub bus is one possible implementation of an Emitter
+// (publishing to the bus is one fanout target), not a separate seam.
+// Receive-side cross-replica reuses the existing HTTPSource pattern
+// (PR 653) — no new "Subscribe" API is needed; replicas already
+// accept incoming events via HTTPSource's /inject endpoint.
+//
+// API shape: ctx-first, error return. Errors are reported but do not
+// halt further fanout — a composite continues delivering to remaining
+// children after a child returns an error, and returns the first
+// error it saw (or nil). This matches "at-least-once across child
+// emitters" semantics; callers that want strict ordering can wrap
+// individual emitters with retry logic.
+//
+// Concurrency: implementations MUST be safe for concurrent Emit
+// calls. The default LocalEmitter and CompositeEmitter satisfy this
+// because their underlying targets (Server.Broadcast, WebhookRegistry.Deliver)
+// are already concurrent-safe.
+type Emitter interface {
+	// Emit delivers one event. Blocks until all of this emitter's
+	// targets have accepted or rejected the event — the yield path
+	// depends on this to preserve back-pressure semantics.
+	Emit(ctx context.Context, event Event) error
+}
+
+// NewLocalEmitter returns the default in-process emitter: broadcasts
+// to local SSE listeners via Server.Broadcast AND delivers to local
+// webhook targets via WebhookRegistry.Deliver. Either srv or webhooks
+// may be nil; a nil component is skipped. This matches the historical
+// emit-hook body that ran inline in Register before the seam landed.
+//
+// Multi-replica deployments wrap this in a composite with additional
+// targets (a peer-fanout emitter that POSTs to sibling replicas'
+// HTTPSource inject endpoints, a Redis pubsub emitter, etc.).
+func NewLocalEmitter(srv *server.Server, webhooks *WebhookRegistry) Emitter {
+	return &localEmitter{srv: srv, webhooks: webhooks}
+}
+
+// NewCompositeEmitter returns an Emitter that fans Emit out to every
+// child in order. Continues after a child returns an error so a slow
+// or failing target does not silently drop deliveries to others;
+// returns the first error encountered (or nil). Composition is the
+// primary way to add cross-replica fanout without changing existing
+// single-replica wiring.
+//
+// Pass no children to get a no-op emitter (Emit always returns nil).
+// Children may themselves be composites — nesting works.
+func NewCompositeEmitter(children ...Emitter) Emitter {
+	return compositeEmitter(children)
+}
+
+// localEmitter wraps the public Emit + EmitToWebhooks functions so
+// they're invocable through the Emitter interface. The public
+// functions retain their existing signatures so external TypedSource
+// authors continue to call them directly.
+type localEmitter struct {
+	srv      *server.Server
+	webhooks *WebhookRegistry
+}
+
+func (e *localEmitter) Emit(_ context.Context, event Event) error {
+	if e.srv != nil {
+		Emit(e.srv, event)
+	}
+	if e.webhooks != nil {
+		EmitToWebhooks(e.webhooks, event)
+	}
+	return nil
+}
+
+// compositeEmitter is a Slice of children, fanning Emit to each in
+// order. Defined as a type alias on the slice (rather than a struct
+// holding a slice) so a zero-children value is well-defined and
+// callers can construct via type assertion in tests.
+type compositeEmitter []Emitter
+
+func (c compositeEmitter) Emit(ctx context.Context, event Event) error {
+	var firstErr error
+	for _, child := range c {
+		if child == nil {
+			continue
+		}
+		if err := child.Emit(ctx, event); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}

--- a/experimental/ext/events/emitter_test.go
+++ b/experimental/ext/events/emitter_test.go
@@ -1,0 +1,157 @@
+package events
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingEmitter is a test-only Emitter that captures every event it
+// received and an optional error to return.
+type recordingEmitter struct {
+	mu     sync.Mutex
+	events []Event
+	err    error
+	label  string
+}
+
+func (e *recordingEmitter) Emit(_ context.Context, event Event) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.events = append(e.events, event)
+	return e.err
+}
+
+func (e *recordingEmitter) seen() []Event {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]Event, len(e.events))
+	copy(out, e.events)
+	return out
+}
+
+func TestCompositeEmitter_FansToAllChildrenInOrder(t *testing.T) {
+	a := &recordingEmitter{label: "a"}
+	b := &recordingEmitter{label: "b"}
+	c := &recordingEmitter{label: "c"}
+	emitter := NewCompositeEmitter(a, b, c)
+
+	require.NoError(t, emitter.Emit(context.Background(), Event{EventID: "evt_x"}))
+
+	assert.Len(t, a.seen(), 1)
+	assert.Len(t, b.seen(), 1)
+	assert.Len(t, c.seen(), 1)
+	assert.Equal(t, "evt_x", a.seen()[0].EventID)
+}
+
+func TestCompositeEmitter_ContinuesAfterChildErrorAndReturnsFirstError(t *testing.T) {
+	first := errors.New("first")
+	second := errors.New("second")
+	a := &recordingEmitter{label: "a"}
+	b := &recordingEmitter{label: "b", err: first}
+	c := &recordingEmitter{label: "c", err: second}
+	d := &recordingEmitter{label: "d"}
+	emitter := NewCompositeEmitter(a, b, c, d)
+
+	err := emitter.Emit(context.Background(), Event{EventID: "evt_y"})
+	assert.ErrorIs(t, err, first, "composite must return the first error encountered")
+
+	// d still received the event even though b and c errored before it.
+	assert.Len(t, d.seen(), 1, "composite must continue to subsequent children after a child errors")
+}
+
+func TestCompositeEmitter_NilChildrenAreSkipped(t *testing.T) {
+	a := &recordingEmitter{label: "a"}
+	emitter := NewCompositeEmitter(nil, a, nil)
+	require.NoError(t, emitter.Emit(context.Background(), Event{EventID: "evt_z"}))
+	assert.Len(t, a.seen(), 1)
+}
+
+func TestCompositeEmitter_NoChildrenIsNoOp(t *testing.T) {
+	emitter := NewCompositeEmitter()
+	require.NoError(t, emitter.Emit(context.Background(), Event{EventID: "evt"}))
+}
+
+func TestCompositeEmitter_Nesting(t *testing.T) {
+	leaf := &recordingEmitter{}
+	inner := NewCompositeEmitter(leaf)
+	outer := NewCompositeEmitter(inner)
+	require.NoError(t, outer.Emit(context.Background(), Event{EventID: "evt_n"}))
+	assert.Len(t, leaf.seen(), 1)
+}
+
+func TestLocalEmitter_NilSrvAndWebhooksIsNoOp(t *testing.T) {
+	// Edge case: an emitter constructed with nil collaborators must
+	// not panic. Useful for tests that exercise the Emitter contract
+	// without standing up a server.
+	emitter := NewLocalEmitter(nil, nil)
+	require.NoError(t, emitter.Emit(context.Background(), Event{EventID: "evt_nilnil"}))
+}
+
+func TestEmitter_ConcurrentEmitsAreSafe(t *testing.T) {
+	// The composite emitter is safe for concurrent Emit calls when its
+	// children are. recordingEmitter takes a mutex; CompositeEmitter
+	// holds no per-call state. Smoke-test that concurrent yields don't
+	// race on the underlying targets.
+	leaf := &recordingEmitter{}
+	emitter := NewCompositeEmitter(leaf)
+
+	const n = 100
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			_ = emitter.Emit(context.Background(), Event{EventID: "evt"})
+		}()
+	}
+	wg.Wait()
+	assert.Len(t, leaf.seen(), n)
+}
+
+// Counterpart spy: a counter-only emitter used by the Register
+// behavior-preservation test below — proves the configured Emitter
+// is invoked once per yielded event without needing the full
+// push/webhook plumbing.
+type counterEmitter struct {
+	count atomic.Int32
+}
+
+func (c *counterEmitter) Emit(_ context.Context, _ Event) error {
+	c.count.Add(1)
+	return nil
+}
+
+func TestRegister_DefaultEmitterIsLocalEmitter(t *testing.T) {
+	// Property check: when Config.Emitter is nil, Register falls back
+	// to NewLocalEmitter. We verify this indirectly — a custom emitter
+	// in Config replaces the default and observes every yielded event.
+	spy := &counterEmitter{}
+
+	srcDef := EventDef{Name: "test.event", Delivery: []string{"push"}}
+	src, yield := NewYieldingSource[map[string]any](srcDef)
+
+	srv := server.NewServer(
+		core.ServerInfo{Name: "emitter-test", Version: "0.1.0"},
+		server.WithSubscriptions(),
+	)
+	Register(Config{
+		Server:                   srv,
+		Sources:                  []EventSource{src},
+		Emitter:                  spy,
+		UnsafeAnonymousPrincipal: "test-principal",
+	})
+
+	require.NoError(t, yield(map[string]any{"k": "v"}))
+	require.NoError(t, yield(map[string]any{"k": "v"}))
+
+	assert.Equal(t, int32(2), spy.count.Load(),
+		"configured Emitter must receive every yielded event")
+}

--- a/experimental/ext/events/events.go
+++ b/experimental/ext/events/events.go
@@ -265,6 +265,27 @@ type Config struct {
 	// internal no-caps Quota — every Reserve succeeds, no
 	// enforcement.
 	Quota *Quota
+
+	// Emitter is the output seam: where yielded events are delivered.
+	// The default (nil) constructs NewLocalEmitter(Server, Webhooks),
+	// which broadcasts to local SSE listeners and POSTs to local
+	// webhook targets — matching today's single-replica behavior
+	// bit-for-bit.
+	//
+	// Multi-replica deployments wrap the default in a composite that
+	// also fans to peer replicas (e.g., by POSTing to peers' HTTPSource
+	// inject endpoints from PR 653, or by publishing to a Redis
+	// pubsub channel — issue 634):
+	//
+	//	cfg.Emitter = events.NewCompositeEmitter(
+	//	    events.NewLocalEmitter(srv, webhooks),
+	//	    myPeerFanoutEmitter,  // your own Emitter impl
+	//	)
+	//
+	// See emitter.go for the interface contract; the receive-side
+	// design intentionally reuses HTTPSource (no new "Subscribe"
+	// surface — the Source interface is sufficient).
+	Emitter Emitter
 }
 
 // Register hooks up events/list, events/poll, events/subscribe, and
@@ -280,15 +301,21 @@ func Register(cfg Config) {
 	sources := cfg.Sources
 	webhooks := cfg.Webhooks
 
+	emitter := cfg.Emitter
+	if emitter == nil {
+		emitter = NewLocalEmitter(srv, webhooks)
+	}
+
 	sourceMap := make(map[string]EventSource, len(sources))
 	for _, s := range sources {
 		sourceMap[s.Def().Name] = s
 		if ea, ok := s.(emitterAware); ok {
+			// Capture emitter; SetEmitHook fires synchronously after
+			// the source's internal fanout. The default LocalEmitter
+			// runs Emit + EmitToWebhooks inline, preserving today's
+			// yield-blocks-on-delivery semantics.
 			ea.SetEmitHook(func(event Event) {
-				Emit(srv, event)
-				if webhooks != nil {
-					EmitToWebhooks(webhooks, event)
-				}
+				_ = emitter.Emit(context.Background(), event)
 			})
 		}
 	}


### PR DESCRIPTION
## What changes

Defines `Emitter` — the output-side seam: "given an event, deliver it." Dual of the existing `EventSource` interface. Default `NewLocalEmitter` matches today's single-replica behavior bit-for-bit (broadcasts to local SSE listeners + POSTs to local webhook targets); multi-replica deployments compose alternatives via `NewCompositeEmitter`.

Replaces the EventBus seam from closed PR 679. The previous design exposed pub/sub mechanics directly, which conflated "what does the fanout look like" (the implementation pattern) with "where do events go" (the actual seam). `Emitter` is the cleaner abstraction; a Redis pubsub backend or peer-HTTP-fanout backend is one Emitter implementation among many, not the seam itself.

Closes 629.

## The clean shape

```go
type Emitter interface {
    Emit(ctx context.Context, event Event) error
}

// Single-replica (today's behavior):
cfg.Emitter = events.NewLocalEmitter(srv, webhooks)

// Multi-replica with peer fanout:
cfg.Emitter = events.NewCompositeEmitter(
    events.NewLocalEmitter(srv, webhooks),
    myPeerFanoutEmitter,  // your impl: POSTs to peers' HTTPSource /inject endpoints
)
```

Receive-side cross-replica reuses **the existing HTTPSource pattern from PR 653** — replicas already accept incoming events via HTTPSource's `/inject` endpoint. No new "Subscribe" API surface needed; the Source interface is already sufficient.

## Reviewer's guide

Read in this order:

1. [experimental/ext/events/emitter.go](https://github.com/panyam/mcpkit/pull/681/files#diff-16bddc124cd18d766b95899f99b33b5051f089d48bf0e52aad52841078932b95) — start here. The `Emitter` interface (single `Emit(ctx, Event) error` method), `NewLocalEmitter` (wraps the existing public `Emit` + `EmitToWebhooks` functions; same body, same effect), `NewCompositeEmitter` (fanout to all children in order, continues after errors, returns the first). Pay attention to the godoc rationale: why an output interface rather than a pub/sub seam.
2. [experimental/ext/events/events.go](https://github.com/panyam/mcpkit/pull/681/files#diff-4a2a8cf5f00e8770df09ab463340a5fc393acbf3f95ef59af8280e2a7a814815) — the Register refactor. New `Config.Emitter Emitter` field; default to `NewLocalEmitter(srv, webhooks)` when nil. The emit-hook installation now calls `emitter.Emit(ctx, event)` instead of the inline `Emit + EmitToWebhooks` pair.
3. [experimental/ext/events/emitter_test.go](https://github.com/panyam/mcpkit/pull/681/files#diff-85242930c13c162d4ae982199c5fa642f9b126ed2900e3c2385ff1dae3a0df38) — 8 tests pinning the contract:
   - `TestCompositeEmitter_FansToAllChildrenInOrder` — fanout + order
   - `TestCompositeEmitter_ContinuesAfterChildErrorAndReturnsFirstError` — error semantics
   - `TestCompositeEmitter_NilChildrenAreSkipped` — defensive
   - `TestCompositeEmitter_NoChildrenIsNoOp` — empty composite is a no-op
   - `TestCompositeEmitter_Nesting` — composites compose
   - `TestLocalEmitter_NilSrvAndWebhooksIsNoOp` — nil-collaborator tolerance
   - `TestEmitter_ConcurrentEmitsAreSafe` — concurrent yields don't race
   - `TestRegister_DefaultEmitterIsLocalEmitter` — the Register integration: a custom Emitter in Config replaces the default and observes every yielded event
4. [experimental/ext/events/STORAGE_SEAMS.md](https://github.com/panyam/mcpkit/pull/681/files#diff-ceea0a5339d9583578ba93a8fd23a5cc2cc61ae832839b943f6d8e02b0bf6954) — new "Adjacent seams (not storage, same code conventions)" subsection mentioning `Emitter`. Explicit note that it's not a storage seam but follows the same `ctx`-first method shape.
5. [experimental/ext/events/README.md](https://github.com/panyam/mcpkit/pull/681/files#diff-9222f2c9c82e15be71e1b286719f2d44d107c3ea315805c64c3d617ab960d4b3) — one-line update mentioning `Config.Emitter` alongside the storage options.

Skim: nothing else changes.

## Test counts

- **Added: 8 tests** (~16 assertions). All green.
- **Existing tests: 0 changed.** Full 75-second events sub-module suite passes without modification — that's the load-bearing behavior-preservation property.
- **Removed / weakened: 0.**

## Decision log

| Decision | Chose | Over | Why |
|---|---|---|---|
| Abstraction | `Emitter` (output) interface | `EventBus` pub/sub seam | EventBus conflated "what does the fanout look like" with "where do events go." Emitter is the dual of EventSource — Source produces events; Emitter consumes them. A pub/sub bus is one possible Emitter impl, not a separate seam. |
| Receive-side cross-replica | Reuse existing `HTTPSource` pattern (PR 653) | New `Subscribe` API | HTTPSource already accepts incoming events via `/inject`. Replicas with peer fanout just POST to peers' HTTPSource endpoints. No new SDK surface. |
| Composition pattern | `NewCompositeEmitter(...)` slice-based | Single `Emitter` field with internal fanout logic | Composition lets operators add new Emitter impls (Redis, peer-HTTP, OTel-trace, log-only) without changing the library. Slice ordering is deterministic and inspectable. |
| Error semantics | Continue after child errors; return first | Halt on first error | At-least-once across child emitters preserves the "all targets get the event if any of them succeed" intent. Callers wrap individual emitters with retry. |
| Default emitter | `nil` Config.Emitter → `NewLocalEmitter(srv, webhooks)` | Field on Config preserved | Behavior-preserving; existing callers pass no Emitter and get today's behavior. |
| Public `Emit` / `EmitToWebhooks` signatures | Unchanged | Refactor through Emitter | Documented public API for TypedSource authors (discord, telegram, README quickstart). `LocalEmitter` calls them internally; same body, same effect. |
| EventBus from closed PR 679 | Dropped entirely | Keep as one Emitter impl | The EventBus was carrying its weight only as a renamed inline fanout. Future Redis impl will be a different Emitter (`redisFanoutEmitter`); EventBus pubsub mechanics, if any, are internal to that impl. |

## Risk / blast radius

- **Affects:** the emit path inside `Register`. Full 75-second events sub-module suite passes without modification — load-bearing behavior-preservation check.
- **External callers:** discord, telegram, kitchen-sink, whole-enchilada demos all compile + tests pass unchanged. Public `Emit` / `EmitToWebhooks` signatures preserved.
- **Tests covering this:** existing suite + 8 new emitter tests + `TestRegister_DefaultEmitterIsLocalEmitter` for the integration.
- **Be paranoid about:** the ordering of children in composite (order is deterministic; tests verify). The yield-blocks-on-delivery semantics are preserved because Emit is synchronous + LocalEmitter calls `Emit + EmitToWebhooks` inline, same as before.

## Out of scope (deliberately deferred)

- 634 Redis-backed `Emitter` implementation (publishes to Redis pubsub + composes with `LocalEmitter`).
- Peer-HTTP fanout `Emitter` for the whole-enchilada multi-replica demo (uses HTTPSource's `/inject` on peers).
- Webhook dedup across replicas (publisher-owns vs lease vs hash partition) — handled at the Emitter-impl level, not in this PR's surface.
- OTel trace context propagation through `Emit(ctx, ...)` — interface is ready; end-to-end wiring lands when the parallel OTel session reaches that point.

## Context

This PR replaces [PR 679](https://github.com/panyam/mcpkit/pull/679) which I opened earlier today with the EventBus seam. The review surfaced that EventBus was over-abstracting — `Subscribe` was being called only from inside `Register` with the same callback bodies as the previous emit hook, so the "seam" was just a thin disguise on the old code. Emitter is the right shape; closed 679, opened this with the cleaner design.
