### PR TITLE
server: wrap tools/call schema validation as isError tool results

### DIFF
--- a/server/dispatch.go
+++ b/server/dispatch.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -553,13 +554,28 @@ func (d *Dispatcher) handleToolsCall(ctx context.Context, id json.RawMessage, pa
 	}
 
 	// Validate arguments against the advertised InputSchema before invoking
-	// the handler. Failures return -32602 Invalid Params with structured
-	// error data so agents can self-correct on the next call. Skipped when
-	// the tool declared no schema or WithSchemaValidation(false) is set.
+	// the handler. Failures surface as a SUCCESSFUL JSON-RPC response
+	// carrying a tool result with isError: true and a descriptive content
+	// block. Skipped when the tool declared no schema or WithSchemaValidation(false)
+	// is set.
+	//
+	// Why a tool result instead of a -32602 JSON-RPC error: tool input is
+	// largely shaped by hosts and apps (basic-host's input form, an iframe's
+	// bridge call, an LLM's structured output). Surfacing those failures as
+	// hard JSON-RPC errors means the host treats them as protocol-level
+	// faults — basic-host renders a "MCP error -32602" banner that pre-empts
+	// the iframe's own error UI. Wrapping as `isError: true` lets the host
+	// hand the message back to the model / app for self-correction the same
+	// way a runtime handler error would. Matches upstream's TypeScript SDK
+	// behavior; verified via apps/compat parity testing against
+	// modelcontextprotocol/ext-apps.
+	//
+	// Consumers that want the prior -32602 wire shape can use
+	// WithSchemaValidation(false) and perform validation in their own
+	// handler, returning whatever response shape they need.
 	if !d.skipSchemaValidation && entry.schema != nil {
 		if ve := entry.schema.validate(envelope.Arguments); ve != nil {
-			return core.NewErrorResponseWithData(id, core.ErrCodeInvalidParams,
-				"argument validation failed", ve)
+			return core.NewResponse(id, toolValidationErrorResult(envelope.Name, ve))
 		}
 	}
 
@@ -634,6 +650,32 @@ func (d *Dispatcher) handleToolsCall(ctx context.Context, id json.RawMessage, pa
 		})
 	default:
 		return core.NewResponse(id, resp)
+	}
+}
+
+// toolValidationErrorResult builds the tool result returned when a
+// tools/call request's arguments fail schema validation. The result
+// carries IsError: true plus a human-readable text content block
+// describing what went wrong, and the structured ValidationErrors
+// payload is preserved in StructuredContent so machine-readable
+// consumers (LLMs, programmatic clients) can self-correct.
+//
+// The message format leads with the canonical "Invalid arguments" hint
+// so that an agent reading the text content learns what shape of error
+// it's looking at; the structured `errors` array is the spec-recommended
+// payload for re-prompting.
+func toolValidationErrorResult(toolName string, ve *ValidationErrors) core.ToolResult {
+	var lines []string
+	lines = append(lines, fmt.Sprintf("Invalid arguments for tool %q:", toolName))
+	for _, e := range ve.Errors {
+		lines = append(lines, fmt.Sprintf("  - %s", e.Message))
+	}
+	return core.ToolResult{
+		Content: []core.Content{
+			{Type: "text", Text: strings.Join(lines, "\n")},
+		},
+		IsError:           true,
+		StructuredContent: ve,
 	}
 }
 

--- a/server/schema_validation_test.go
+++ b/server/schema_validation_test.go
@@ -122,8 +122,12 @@ func TestRegisterPromptInvalidSchemaPanics(t *testing.T) {
 }
 
 // TestToolValidateTypeMismatch verifies that an argument with the wrong
-// JSON type produces a -32602 error with a structured errors list pointing
-// at the offending field path.
+// JSON type produces a successful response carrying a tool result with
+// isError: true and a structured ValidationErrors payload pointing at the
+// offending field path. Wrapping as a tool result (rather than a -32602
+// JSON-RPC error) matches upstream's ext-apps SDK behavior so apps/compat
+// fixtures can surface validation failures through the iframe's normal
+// result-rendering UI.
 func TestToolValidateTypeMismatch(t *testing.T) {
 	srv := newSchemaTestServer(t)
 	srv.RegisterTool(core.ToolDef{
@@ -137,16 +141,25 @@ func TestToolValidateTypeMismatch(t *testing.T) {
 	}, okHandler)
 
 	resp := callTool(t, srv, "typed", map[string]any{"age": "not a number"})
-	require.NotNil(t, resp.Error, "expected validation error")
-	assert.Equal(t, core.ErrCodeInvalidParams, resp.Error.Code)
-	assert.Contains(t, resp.Error.Message, "argument validation failed")
+	require.Nil(t, resp.Error, "expected success-wrapped tool result, got JSON-RPC error: %+v", resp.Error)
+	require.NotNil(t, resp.Result)
 
-	// The error data should be a ValidationErrors struct with a path
-	// pointing at /age. Round-trip through JSON since Data is `any`.
-	raw, err := json.Marshal(resp.Error.Data)
+	var result core.ToolResult
+	raw, err := json.Marshal(resp.Result)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(raw, &result))
+	assert.True(t, result.IsError, "expected isError: true on the tool result")
+	require.NotEmpty(t, result.Content, "expected at least one content block")
+	// The human-readable text mentions the tool name + that arguments were invalid.
+	assert.Contains(t, result.Content[0].Text, "Invalid arguments")
+	assert.Contains(t, result.Content[0].Text, "typed")
+
+	// StructuredContent carries the machine-readable error list — same payload
+	// shape that used to live in error.data, just on the tool result.
+	structRaw, err := json.Marshal(result.StructuredContent)
 	require.NoError(t, err)
 	var ve server.ValidationErrors
-	require.NoError(t, json.Unmarshal(raw, &ve))
+	require.NoError(t, json.Unmarshal(structRaw, &ve))
 	require.NotEmpty(t, ve.Errors)
 	found := false
 	for _, e := range ve.Errors {
@@ -159,7 +172,8 @@ func TestToolValidateTypeMismatch(t *testing.T) {
 }
 
 // TestToolValidateMissingRequired verifies that missing required fields
-// are reported so agents know what to supply on the retry.
+// are reported via isError tool result so agents know what to supply on
+// the retry.
 func TestToolValidateMissingRequired(t *testing.T) {
 	srv := newSchemaTestServer(t)
 	srv.RegisterTool(core.ToolDef{
@@ -174,8 +188,12 @@ func TestToolValidateMissingRequired(t *testing.T) {
 	}, okHandler)
 
 	resp := callTool(t, srv, "req", map[string]any{"other": "value"})
-	require.NotNil(t, resp.Error)
-	assert.Equal(t, core.ErrCodeInvalidParams, resp.Error.Code)
+	require.Nil(t, resp.Error)
+	require.NotNil(t, resp.Result)
+	var result core.ToolResult
+	raw, _ := json.Marshal(resp.Result)
+	require.NoError(t, json.Unmarshal(raw, &result))
+	assert.True(t, result.IsError, "expected isError: true")
 }
 
 // TestToolValidateSuccess is the happy path — a valid call reaches the
@@ -389,8 +407,13 @@ func TestSchema2020_12Conformance(t *testing.T) {
 	})
 	require.Nil(t, ok.Error, "valid 2020-12 input should reach the handler")
 
-	// id must be a positive integer per $ref
+	// id must be a positive integer per $ref — validation failure surfaces
+	// as an isError tool result, not a -32602 JSON-RPC error.
 	bad := callTool(t, srv, "conform", map[string]any{"id": -5})
-	require.NotNil(t, bad.Error)
-	assert.Equal(t, core.ErrCodeInvalidParams, bad.Error.Code)
+	require.Nil(t, bad.Error)
+	require.NotNil(t, bad.Result)
+	var result core.ToolResult
+	raw, _ := json.Marshal(bad.Result)
+	require.NoError(t, json.Unmarshal(raw, &result))
+	assert.True(t, result.IsError, "expected isError: true on bad input")
 }

--- a/server/typed_tool_test.go
+++ b/server/typed_tool_test.go
@@ -223,7 +223,7 @@ func TestTypedTool_InvalidInput(t *testing.T) {
 		var result core.ToolResult
 		require.NoError(t, resp.ResultAs(&result))
 		assert.True(t, result.IsError, "deserialization failure should produce isError=true")
-		assert.Contains(t, result.Content[0].Text, "invalid arguments")
+		assert.Contains(t, result.Content[0].Text, "Invalid arguments")
 	}
 }
 

--- a/tests/e2e/schema_validation_test.go
+++ b/tests/e2e/schema_validation_test.go
@@ -4,9 +4,10 @@ package e2e_test
 // Unit tests in server/schema_validation_test.go exercise the Dispatch
 // path directly; this test exercises the full HTTP wire — Client →
 // Streamable HTTP transport → dispatcher → validator → error response —
-// and inspects the -32602 error shape over the wire.
+// and inspects the isError-tool-result shape over the wire.
 
 import (
+	"encoding/json"
 	"net/http/httptest"
 	"testing"
 
@@ -19,9 +20,11 @@ import (
 
 // TestE2E_SchemaValidationErrorOverWire verifies that a tool declared with
 // an InputSchema rejects invalid arguments at the server and returns a
-// spec-compliant -32602 Invalid Params error to the client. The error's
-// data field must carry a structured errors list that agents can parse to
-// self-correct on the next call.
+// successful JSON-RPC response carrying a tool result with isError: true.
+// Wrapping (rather than emitting -32602) matches upstream's ext-apps SDK
+// behavior so apps/compat hosts (basic-host, the iframe) can surface
+// validation failures through their normal result-rendering UI instead of
+// treating them as protocol-level faults.
 func TestE2E_SchemaValidationErrorOverWire(t *testing.T) {
 	srv := server.NewServer(core.ServerInfo{Name: "schema-e2e", Version: "1.0"})
 	srv.RegisterTool(core.ToolDef{
@@ -49,14 +52,23 @@ func TestE2E_SchemaValidationErrorOverWire(t *testing.T) {
 	require.NoError(t, c.Connect())
 	defer c.Close()
 
-	// Call with a negative value — violates minimum: 1
-	_, err := c.ToolCall("strict", map[string]any{"count": -5})
-	require.Error(t, err, "expected validation error over the wire")
+	// Call with a negative value — violates minimum: 1.
+	// Use the lower-level Call so we can inspect the raw tool result;
+	// ToolCall would unwrap the isError into a Go error and we'd lose the
+	// structured-content payload.
+	result, err := c.Call("tools/call", map[string]any{
+		"name":      "strict",
+		"arguments": map[string]any{"count": -5},
+	})
+	require.NoError(t, err, "expected isError tool result, got JSON-RPC error")
+	require.NotNil(t, result)
 
-	// The error message format from client.go is "RPC error <code>: <msg>".
-	// This locks in both the error code (-32602) and the validation message
-	// shape — the two things agents parse to decide what to do next.
-	assert.Contains(t, err.Error(), "-32602",
-		"validation errors must use -32602 per #184")
-	assert.Contains(t, err.Error(), "argument validation failed")
+	var tr core.ToolResult
+	require.NoError(t, json.Unmarshal(result.Raw, &tr))
+	assert.True(t, tr.IsError, "expected isError: true on the tool result")
+	require.NotEmpty(t, tr.Content, "expected at least one content block")
+	assert.Contains(t, tr.Content[0].Text, "Invalid arguments",
+		"text content should describe what went wrong")
+	require.NotNil(t, tr.StructuredContent,
+		"structured payload should carry the validation errors for programmatic consumers")
 }


### PR DESCRIPTION
## What changes

Tool input validation failures now surface as a **successful JSON-RPC response carrying a tool result with \`IsError: true\`** plus a structured errors payload, instead of a \`-32602\` JSON-RPC error.

### Why

Tool args are largely shaped by hosts and apps — basic-host's input form, an iframe's bridge call, an LLM's structured output. Treating those failures as protocol-level errors means the host renders an "MCP error -32602" banner that pre-empts the iframe's own error UI; the iframe never sees the failure as a result it could surface or the model could self-correct from.

Wrapping as \`IsError: true\` lets the host hand the message back to the model / app the same way a runtime handler error would. Matches upstream's TypeScript SDK behavior; verified via apps/compat parity testing against [modelcontextprotocol/ext-apps](https://github.com/modelcontextprotocol/ext-apps).

### Symptom that prompted this

\`make demo-app EXAMPLE=map\` failed with a banner-level \`-32602\` the moment basic-host's input form populated an optional field with \`null\`:

```
{"error":{"code":-32602,"message":"argument validation failed","data":{"errors":[{"path":"/label","keyword":"type","message":"at '/label': got null, want string"}]}}}
```

After this PR, the same call returns:

```
{"result":{"resultType":"complete","content":[{"type":"text","text":"Invalid arguments for tool \"show-map\":\n  - at '/label': got null, want string"}],"isError":true,"structuredContent":{"errors":[...]}}}
```

Which matches upstream's TS reference exactly in shape and lets basic-host render the error in the Tool Result panel instead of as a banner.

## Reviewer's guide

1. [server/dispatch.go](https://github.com/panyam/mcpkit/pull/686/files#diff-7640bcbef23148a16e477c63c7092f0ba89780f5278a9d6ba6ed513d62f68a92) — the load-bearing change is the \`if !d.skipSchemaValidation && entry.schema != nil { ... }\` block in \`handleToolsCall\`. Same gating condition; the \`return\` now builds a tool result via the new \`toolValidationErrorResult\` helper. The helper itself sits just after \`handleToolsCall\` for proximity — produces a \`core.ToolResult{IsError: true, Content: [...], StructuredContent: ve}\` where \`ve\` is the same \`ValidationErrors\` payload that previously rode \`error.data\`.
2. [server/schema_validation_test.go](https://github.com/panyam/mcpkit/pull/686/files#diff-1210491bdf163ec0e9474cf60914784a7d328c7a3a86ed3e64f9581458c9d927) — three tests updated: \`TestToolValidateTypeMismatch\`, \`TestToolValidateMissingRequired\`, and \`TestSchema2020_12Conformance\`. Each now asserts the isError tool result shape and reads the structured payload from \`StructuredContent\` instead of \`error.data\`.
3. [tests/e2e/schema_validation_test.go](https://github.com/panyam/mcpkit/pull/686/files#diff-51d09991311f468b558ba02e89a55fbe3a112e29ff83df5c5376df6022675d08) — \`TestE2E_SchemaValidationErrorOverWire\` rewritten to use \`c.Call("tools/call", ...)\` so it can inspect the raw tool result. The previous version asserted the \`-32602\`-over-wire shape and would not have caught the apps/compat parity bug.
4. [server/typed_tool_test.go](https://github.com/panyam/mcpkit/pull/686/files#diff-f09ecd7478a7a2df6aea6a4ea83f47ac2110b3adf6a3b1037842d0ea29a53cba) — single-character casing fix (\`"invalid arguments"\` → \`"Invalid arguments"\`) to match the new canonical message.

Skim or skip: imports added (\`strings\`).

## Decision log

- **Scope: only schema validation, not file-input validation or other -32602 sites.** File-input validation (SEP-2356) has its \`-32602\` wire shape locked by the panyam/mcpconformance pending suite; changing it would break that conformance contract. Unknown-tool, malformed-JSON-params, initialize errors, logging/setLevel errors all stay as JSON-RPC errors. The boundary is "tool argument validation failures" specifically.
- **Preserve \`WithSchemaValidation(false)\` as the escape hatch.** Consumers who want the prior \`-32602\` wire shape (some clients may parse it) can disable validation and reject in their own handler with whatever shape they want. No new options added — keeps the surface small.
- **\`StructuredContent\` carries the validation errors payload.** Same \`ValidationErrors\` shape that used to live in \`error.data\` — programmatic consumers (LLM self-correction loops, automated retry) parse the same fields, just from a different location. The human-readable text content describes the failure for non-programmatic consumers.
- **No \`Code\` field on the tool result.** Upstream's TS SDK includes \`"MCP error -32602: Input validation error: ..."\` as the leading text but doesn't carry a numeric code on the tool result either. We mirror that: no protocol-level code, just human + structured content.

## Risk / blast radius

- **Wire-format change visible to every mcpkit consumer that registers a tool with an \`InputSchema\` and \`WithSchemaValidation\` enabled (the default).** Any client that explicitly checked for \`error.code == -32602\` on bad args will need to switch to reading \`result.IsError\`. The MCP spec doesn't mandate either shape; both are arguably compliant. mcpkit's behavior was the outlier compared to upstream's TS SDK.
- **Tests covering this:** \`server/schema_validation_test.go\` (3 tests), \`server/typed_tool_test.go\` (1 test), \`tests/e2e/schema_validation_test.go\` (1 test). The e2e test exercises the full HTTP wire so a regression here would surface on the e2e suite.
- **Be paranoid about:** any external mcpkit consumer with custom client-side \`-32602\` handling for tool calls. None known in the apps/compat suite or the bundled examples; consumers outside this repo will get a clean Go error if they used \`Client.ToolCall\` (which already wraps isError as a Go error today).

## Before / after

Verified via live curl against \`examples/apps/compat/map\`:

**Before:**
```json
{"error":{"code":-32602,"message":"argument validation failed",...}}
```

**After:**
```json
{"result":{"resultType":"complete","content":[{"type":"text","text":"Invalid arguments for tool \"show-map\":\n  - at '/label': got null, want string"}],"isError":true,"structuredContent":{"errors":[...]}}}
```

All test suites green: \`server/\`, \`ext/ui/\`, \`tests/e2e/\`.

## Out of scope (deliberately deferred)

- Moving file-input validation (SEP-2356) to the same wrapping. Its \`-32602\` shape is locked by the conformance suite; would need a separate spec discussion.
- Moving \`prompts/get\` argument validation similarly. Lower-priority because basic-host's iframe doesn't drive prompts.




