### PR TITLE
events: wire GORM stores into testall as stage 7c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,12 @@ test-experimental-events: ## Run experimental ext/events library tests
 test-experimental-events-clients-go: ## Run experimental ext/events Go client SDK tests
 	$(MAKE) -C experimental test-events-clients-go
 
+test-experimental-events-stores-gorm: ## Run experimental ext/events GORM stores (sqlite + inmemory; no Docker required)
+	$(MAKE) -C experimental test-events-stores-gorm
+
+test-experimental-events-stores-gorm-pg: ## Run experimental ext/events GORM stores against a real Postgres container (Docker)
+	$(MAKE) -C experimental test-events-stores-gorm-pg
+
 test-experimental-events-discord: ## Run experimental events Discord example tests
 	$(MAKE) -C experimental test-events-discord
 
@@ -278,8 +284,9 @@ testall: ## Run ALL tests (starts Keycloak if needed) + per-stage HTML reports
 	$(call run_stage,6,9,e2e,test-e2e) \
 	$(call run_stage,7a,9,experimental-events,test-experimental-events) \
 	$(call run_stage,7b,9,experimental-events-clients-go,test-experimental-events-clients-go) \
-	$(call run_stage,7c,9,experimental-events-discord,test-experimental-events-discord) \
-	$(call run_stage,7d,9,experimental-events-telegram,test-experimental-events-telegram) \
+	$(call run_stage,7c,9,experimental-events-stores-gorm,test-experimental-events-stores-gorm) \
+	$(call run_stage,7d,9,experimental-events-discord,test-experimental-events-discord) \
+	$(call run_stage,7e,9,experimental-events-telegram,test-experimental-events-telegram) \
 	$(call run_stage,8a,9,conformance,testconf) \
 	$(call run_stage,8b,9,auth-conformance,testconfauth) \
 	$(call run_stage,8c,9,tasks-conformance,testconf-tasks) \

--- a/experimental/Makefile
+++ b/experimental/Makefile
@@ -3,7 +3,7 @@
 # Runs as one umbrella (`make test`) or per sub-suite. The top-level
 # repo Makefile delegates to these targets via `make -C experimental ...`,
 # and testall uses the per-suite targets to record sub-stage timing
-# (7a/7b/7c/7d) instead of a single bucket.
+# (7a/7b/7c/7d/7e) instead of a single bucket.
 #
 # Two of the sub-suites live under `examples/events/` rather than
 # `experimental/`, but they're conceptually part of the experimental
@@ -13,15 +13,21 @@
 EXPERIMENTAL_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 REPO_ROOT := $(abspath $(EXPERIMENTAL_DIR)/..)
 
-.PHONY: test test-events test-events-clients-go test-events-discord test-events-telegram help
+.PHONY: test test-events test-events-clients-go test-events-stores-gorm test-events-stores-gorm-pg test-events-discord test-events-telegram help
 
-test: test-events test-events-clients-go test-events-discord test-events-telegram ## Run all experimental POC tests
+test: test-events test-events-clients-go test-events-stores-gorm test-events-discord test-events-telegram ## Run all experimental POC tests
 
 test-events: ## Run experimental ext/events library tests
 	cd $(EXPERIMENTAL_DIR)/ext/events && go test ./... -count=1 -timeout 120s
 
 test-events-clients-go: ## Run experimental ext/events Go client SDK tests
 	cd $(EXPERIMENTAL_DIR)/ext/events/clients/go && go test ./... -count=1 -timeout 60s
+
+test-events-stores-gorm: ## Run GORM-backed Webhook + Quota stores (sqlite + inmemory; no Docker required)
+	cd $(EXPERIMENTAL_DIR)/ext/events/stores/gorm && go test ./... -count=1 -timeout 60s
+
+test-events-stores-gorm-pg: ## Run GORM stores against a real Postgres container (full matrix; needs Docker)
+	$(MAKE) -C $(EXPERIMENTAL_DIR)/ext/events/stores/gorm testpg
 
 test-events-discord: ## Run experimental events Discord example tests
 	cd $(REPO_ROOT)/examples/events/discord && go test ./... -count=1 -timeout 60s


### PR DESCRIPTION
## What changes

Adds the GORM-backed events stores (Webhook + Quota) that landed in PR 685 to the testall stage matrix as stage 7c. Sqlite + inmemory only — Docker-free, matches the rest of testall's no-extra-deps posture.

## Reviewer's guide

1. [`experimental/Makefile`](https://github.com/panyam/mcpkit/pull/687/files#diff-b67e077548afb7fbc286b76d36e98b2e69b9580843b390f2ee3a2395b3ff88d8) — new `test-events-stores-gorm` (sqlite-only) and `test-events-stores-gorm-pg` (full Postgres matrix, opt-in) targets. The sqlite-only one goes into the default `test` umbrella; the pg variant is reserved for ad-hoc invocation.
2. [`Makefile`](https://github.com/panyam/mcpkit/pull/687/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52) — two new top-level delegates (`test-experimental-events-stores-gorm` + `-pg`), and the testall stage map gains `7c` for the new suite. Discord and telegram shift to 7d and 7e to keep insertion order chronological.

## Verified

```
$ make test-experimental-events-stores-gorm
cd .../stores/gorm && go test ./... -count=1 -timeout 60s
ok      github.com/panyam/mcpkit/experimental/ext/events/stores/gorm    0.41s
```

## Out of scope / follow-up

Separate issue I'll file: extract `examples/Makefile` (mirroring `conformance/Makefile`'s pattern), move `test-events-discord` / `test-events-telegram` out of `experimental/Makefile` (they're tests of examples, not of the experimental library), wire up the currently-unwired `examples/events/kitchen-sink`, `examples/events/whole-enchilada/event-server`, and `examples/common/otel`. The last of those is also presently broken on main with a go.mod-tidy diff — unrelated to this PR but in scope for the follow-up.
