### PR TITLE
examples: client-side telemetry adoption across 9 walkthroughs (follow-up to PR 684)

### DIFF
--- a/examples/CONVENTIONS.md
+++ b/examples/CONVENTIONS.md
@@ -225,6 +225,57 @@ Grafana.
 `defaultExporter = "stdout"` because the example's whole purpose is
 showing traces. Every other example defaults to `""`.
 
+#### Client-side wiring (walkthrough.go)
+
+Walkthroughs (runDemo) typically don't call `flag.Parse` — they rely
+on `common.ServerURL`'s ad-hoc `os.Args` scan for `--url`. The
+symmetric helper for telemetry is `common.ExporterFromArgs()`, which
+scans `os.Args` for `--exporter` / `--otlp-endpoint` and returns the
+same `*TelemetryFlags` shape `RegisterTelemetryFlags` would have
+populated. Pair it with `commonotel.SetupClientTelemetry`, which
+pre-sets the client-side instrumentation library name so spans group
+correctly in OTel-aware backends:
+
+```go
+import (
+    "context"
+    "log"
+
+    "github.com/panyam/mcpkit/client"
+    "github.com/panyam/mcpkit/examples/common"
+    commonotel "github.com/panyam/mcpkit/examples/common/otel"
+)
+
+func runDemo() {
+    serverURL := common.ServerURL()
+
+    tel := common.ExporterFromArgs()
+    tp, shutdown, err := commonotel.SetupClientTelemetry(context.Background(),
+        commonotel.WithExporter(*tel.Exporter),
+        commonotel.WithOTLPEndpoint(*tel.OTLPEndpoint),
+        commonotel.WithServiceName("<example-name>-host"),
+    )
+    if err != nil { log.Fatalf("commonotel.SetupClientTelemetry: %v", err) }
+    defer shutdown(context.Background())
+
+    // ... demo definition ...
+
+    c := client.NewClient(serverURL+"/mcp", info,
+        client.WithTracerProvider(tp),
+        // ... other client options ...
+    )
+}
+```
+
+Service-name convention: `<example-name>-host` for the walkthrough
+side, matching the server's `<example-name>` / `<example-name>-demo`
+so Grafana / Tempo filter-by-service distinguishes the two halves of
+each stitched trace.
+
+For walkthroughs that DO call `flag.Parse` (e.g. when they need
+example-specific flags), use `common.RegisterTelemetryFlags(flag.CommandLine)`
+instead of `ExporterFromArgs` — both populate the same struct shape.
+
 - Side endpoints (e.g. `/inject` for synthetic events) go through
   `server.WithMux(func(mux *http.ServeMux) { ... })` (in `TransportOptions`)
   — not a hand-rolled `http.Server{}`. Graceful shutdown is built into

--- a/examples/auth/main.go
+++ b/examples/auth/main.go
@@ -76,6 +76,17 @@ type bootstrapInfo struct {
 func runDemo() {
 	serverURL := common.ServerURL()
 
+	tel := common.ExporterFromArgs()
+	tp, shutdown, err := commonotel.SetupClientTelemetry(context.Background(),
+		commonotel.WithExporter(*tel.Exporter),
+		commonotel.WithOTLPEndpoint(*tel.OTLPEndpoint),
+		commonotel.WithServiceName("auth-unified-host"),
+	)
+	if err != nil {
+		log.Fatalf("commonotel.SetupClientTelemetry: %v", err)
+	}
+	defer shutdown(context.Background())
+
 	demo := demokit.New("MCP Auth — Public Discovery + JWT + Scopes + Session Binding").
 		Dir("auth").
 		Description("Walks through auth patterns layered on a single mcpkit server: public method allowlist, JWT/JWKS validation, per-tool scope enforcement, and session hijacking prevention.").
@@ -176,6 +187,7 @@ tools, _ := c.ListTools() // succeeds without auth`),
 		Run(func(ctx demokit.StepContext) (result *demokit.StepResult) {
 			c := client.NewClient(boot.MCPURL,
 				core.ClientInfo{Name: "demo-host-anon", Version: "1.0"},
+				client.WithTracerProvider(tp),
 			)
 			defer c.Close()
 			if err := c.Connect(); err != nil {
@@ -216,6 +228,7 @@ if errors.As(err, &authErr) {
 		Run(func(ctx demokit.StepContext) (result *demokit.StepResult) {
 			c := client.NewClient(boot.MCPURL,
 				core.ClientInfo{Name: "demo-host-anon", Version: "1.0"},
+				client.WithTracerProvider(tp),
 			)
 			defer c.Close()
 			if err := c.Connect(); err != nil {
@@ -263,6 +276,7 @@ text, _ := readClient.ToolCall("echo", map[string]any{"message": "hello"})`),
 			readClient = client.NewClient(boot.MCPURL,
 				core.ClientInfo{Name: "demo-host-alice", Version: "1.0"},
 				client.WithClientBearerToken(boot.TokRead),
+				client.WithTracerProvider(tp),
 			)
 			if err := readClient.Connect(); err != nil {
 				fmt.Printf("    ERROR: %v\n", err)
@@ -340,6 +354,7 @@ text, _ := readWriteClient.ToolCall("write-tool", map[string]any{"data": "hello 
 			readWriteClient = client.NewClient(boot.MCPURL,
 				core.ClientInfo{Name: "demo-host-alice-rw", Version: "1.0"},
 				client.WithClientBearerToken(boot.TokReadWrite),
+				client.WithTracerProvider(tp),
 			)
 			if err := readWriteClient.Connect(); err != nil {
 				fmt.Printf("    ERROR: %v\n", err)

--- a/examples/common/exporter_flag.go
+++ b/examples/common/exporter_flag.go
@@ -6,9 +6,16 @@ package common
 // passes the returned struct's values into commonotel.SetupTelemetry.
 // Default --exporter="" — operators opt in per invocation; no
 // example dumps spans to stdout unless asked.
+//
+// Walkthroughs (runDemo) often don't call flag.Parse — they rely on
+// common.ServerURL's ad-hoc os.Args scan for --url. For symmetric
+// pickup of --exporter / --otlp-endpoint without flag.Parse, use
+// ExporterFromArgs.
 
 import (
 	"flag"
+	"os"
+	"strings"
 
 	commonotel "github.com/panyam/mcpkit/examples/common/otel"
 )
@@ -58,5 +65,52 @@ func RegisterTelemetryFlags(fs *flag.FlagSet) *TelemetryFlags {
 	return &TelemetryFlags{
 		Exporter:     fs.String("exporter", "", "trace exporter: \"\" (off, default) | stdout | otlp | auto (best-effort OTLP — silent Noop fallback if unreachable)"),
 		OTLPEndpoint: fs.String("otlp-endpoint", commonotel.DefaultOTLPEndpoint, "OTLP gRPC endpoint when --exporter=otlp"),
+	}
+}
+
+// ExporterFromArgs scans os.Args for --exporter / --otlp-endpoint
+// without calling flag.Parse. Mirrors the ad-hoc pattern
+// common.ServerURL uses for --url. Returns a *TelemetryFlags whose
+// pointers are locally allocated, so the API matches what
+// RegisterTelemetryFlags returns — call sites deref the same way
+// (`*tel.Exporter`) regardless of which helper populated it.
+//
+// Use from walkthroughs (runDemo) that don't otherwise call
+// flag.Parse. For binaries that already call flag.Parse (any serve()
+// using common.RunServer with extra example-specific flags), prefer
+// RegisterTelemetryFlags so demokit.FilterArgs sees the registered
+// flag set.
+//
+// Recognized argv shapes:
+//
+//	--exporter=otlp          --otlp-endpoint=localhost:4317
+//	--exporter otlp          --otlp-endpoint localhost:4317
+//
+// Defaults match RegisterTelemetryFlags: exporter="", endpoint=
+// commonotel.DefaultOTLPEndpoint.
+func ExporterFromArgs() *TelemetryFlags {
+	exporter := ""
+	endpoint := commonotel.DefaultOTLPEndpoint
+
+	args := os.Args[1:]
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case a == "--exporter" && i+1 < len(args):
+			exporter = args[i+1]
+			i++
+		case strings.HasPrefix(a, "--exporter="):
+			exporter = strings.TrimPrefix(a, "--exporter=")
+		case a == "--otlp-endpoint" && i+1 < len(args):
+			endpoint = args[i+1]
+			i++
+		case strings.HasPrefix(a, "--otlp-endpoint="):
+			endpoint = strings.TrimPrefix(a, "--otlp-endpoint=")
+		}
+	}
+
+	return &TelemetryFlags{
+		Exporter:     &exporter,
+		OTLPEndpoint: &endpoint,
 	}
 }

--- a/examples/common/otel/setup.go
+++ b/examples/common/otel/setup.go
@@ -206,6 +206,39 @@ func WithResourceAttr(key, value string) SetupOption {
 	}
 }
 
+// ClientInstrumentationName is the OTel instrumentation library
+// label SetupClientTelemetry stamps on client-side spans. Matches
+// the value PR 680's otel/stdout walkthrough used so client/server
+// spans group correctly in OTel-aware backends (Jaeger's "Library"
+// column, Tempo's instrumentation filter).
+const ClientInstrumentationName = "github.com/panyam/mcpkit/client"
+
+// SetupClientTelemetry is SetupTelemetry pre-configured for the
+// host (client) side of an example walkthrough. Equivalent to
+// SetupTelemetry(ctx, opts..., WithInstrumentationName(ClientInstrumentationName))
+// — the instrumentation-name preset is the only difference between
+// the server and client wirings, so this saves every walkthrough
+// from typing the magic string. Explicit
+// WithInstrumentationName(...) in opts still wins (last option
+// applied).
+//
+// Pair the returned core.TracerProvider with client.WithTracerProvider
+// at the client.NewClient call site:
+//
+//	tp, shutdown, err := commonotel.SetupClientTelemetry(ctx,
+//	    commonotel.WithExporter(tel.Exporter),
+//	    commonotel.WithOTLPEndpoint(tel.OTLPEndpoint),
+//	    commonotel.WithServiceName("my-example-host"),
+//	)
+//	defer shutdown(context.Background())
+//	c := client.NewClient(url, info, client.WithTracerProvider(tp))
+func SetupClientTelemetry(ctx context.Context, opts ...SetupOption) (core.TracerProvider, ShutdownFunc, error) {
+	all := make([]SetupOption, 0, len(opts)+1)
+	all = append(all, WithInstrumentationName(ClientInstrumentationName))
+	all = append(all, opts...)
+	return SetupTelemetry(ctx, all...)
+}
+
 // SetupTelemetry constructs a core.TracerProvider per the decision
 // matrix in the package doc. The returned ShutdownFunc must be
 // deferred so buffered spans flush before the process exits — a

--- a/examples/elicitation/main.go
+++ b/examples/elicitation/main.go
@@ -50,6 +50,18 @@ func main() {
 func runDemo() {
 	serverURL := common.ServerURL()
 
+	tel := common.ExporterFromArgs()
+	tp, shutdown, err := commonotel.SetupClientTelemetry(context.Background(),
+		commonotel.WithExporter(*tel.Exporter),
+		commonotel.WithOTLPEndpoint(*tel.OTLPEndpoint),
+		commonotel.WithServiceName("elicitation-example-host"),
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: commonotel.SetupClientTelemetry: %v\n", err)
+		os.Exit(1)
+	}
+	defer shutdown(context.Background())
+
 	demo := demokit.New("URL Elicitation — Consent Approval Flow (UC1)").
 		Dir("elicitation").
 		Description("**EXPERIMENTAL** — Tracks SEP-2643 (Structured Authorization Denials), currently a draft. A scripted MCP host walking through the UC1 consent approval flow. Wire format may change as the SEP evolves.").
@@ -135,6 +147,7 @@ tools, _ := c.ListTools()`),
 					}
 				}),
 				client.WithGetSSEStream(),
+				client.WithTracerProvider(tp),
 			)
 			if err := c.Connect(); err != nil {
 				fmt.Printf("    ERROR: %v\n", err)

--- a/examples/file-inputs/walkthrough.go
+++ b/examples/file-inputs/walkthrough.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"context"
 	_ "embed"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,6 +15,7 @@ import (
 	"github.com/panyam/mcpkit/client"
 	"github.com/panyam/mcpkit/core"
 	"github.com/panyam/mcpkit/examples/common"
+	commonotel "github.com/panyam/mcpkit/examples/common/otel"
 )
 
 // Walkthrough fixtures live on disk under testdata/ so readers can inspect
@@ -35,6 +38,17 @@ var fixtureREADME []byte
 
 func runDemo() {
 	serverURL := common.ServerURL()
+
+	tel := common.ExporterFromArgs()
+	tp, shutdown, err := commonotel.SetupClientTelemetry(context.Background(),
+		commonotel.WithExporter(*tel.Exporter),
+		commonotel.WithOTLPEndpoint(*tel.OTLPEndpoint),
+		commonotel.WithServiceName("file-inputs-host"),
+	)
+	if err != nil {
+		log.Fatalf("commonotel.SetupClientTelemetry: %v", err)
+	}
+	defer shutdown(context.Background())
 
 	demo := demokit.New("MCP File Inputs (SEP-2356) — Data URI File Arguments").
 		Dir("file-inputs").
@@ -74,6 +88,7 @@ func runDemo() {
 			c = client.NewClient(serverURL+"/mcp",
 				core.ClientInfo{Name: "file-inputs-host", Version: "1.0"},
 				client.WithFileInputs(),
+				client.WithTracerProvider(tp),
 			)
 			if err := c.Connect(); err != nil {
 				fmt.Printf("    ERROR: %v\n    Start the server with: make serve\n", err)

--- a/examples/fine-grained-auth/main.go
+++ b/examples/fine-grained-auth/main.go
@@ -69,6 +69,18 @@ func main() {
 func runDemo() {
 	serverURL := common.ServerURL()
 
+	tel := common.ExporterFromArgs()
+	tp, shutdown, err := commonotel.SetupClientTelemetry(context.Background(),
+		commonotel.WithExporter(*tel.Exporter),
+		commonotel.WithOTLPEndpoint(*tel.OTLPEndpoint),
+		commonotel.WithServiceName("fine-grained-auth-example-host"),
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: commonotel.SetupClientTelemetry: %v\n", err)
+		os.Exit(1)
+	}
+	defer shutdown(context.Background())
+
 	demo := demokit.New("Fine-Grained Authorization — Scope Step-Up (UC2) + Ephemeral Credentials (UC3)").
 		Dir("fine-grained-auth").
 		Description("**EXPERIMENTAL** — Tracks SEP-2643 (Structured Authorization Denials), currently a draft. UC2 + UC3 demonstrated end-to-end against an in-process oneauth AS.").
@@ -224,6 +236,7 @@ tools, _ := readClient.ListTools() // JWKS validation passed; scope just limited
 			readClient = client.NewClient(serverURL+"/mcp",
 				core.ClientInfo{Name: "demo-host", Version: "1.0"},
 				client.WithClientBearerToken(tokRead),
+				client.WithTracerProvider(tp),
 			)
 			if err := readClient.Connect(); err != nil {
 				fmt.Printf("    ERROR: %v\n", err)
@@ -392,6 +405,7 @@ text, err := callClient.ToolCall("update_document", map[string]any{
 			callClient = client.NewClient(serverURL+"/mcp",
 				core.ClientInfo{Name: "demo-host", Version: "1.0"},
 				client.WithClientBearerToken(tokReadCall),
+				client.WithTracerProvider(tp),
 			)
 			if err := callClient.Connect(); err != nil {
 				fmt.Printf("    ERROR: %v\n", err)
@@ -580,6 +594,7 @@ text, err := payClient.ToolCall("initiate_payment", map[string]any{
 			payClient = client.NewClient(serverURL+"/mcp",
 				core.ClientInfo{Name: "demo-host", Version: "1.0"},
 				client.WithClientBearerToken(tokPayment),
+				client.WithTracerProvider(tp),
 			)
 			if err := payClient.Connect(); err != nil {
 				fmt.Printf("    ERROR: %v\n", err)

--- a/examples/list-ttl/walkthrough.go
+++ b/examples/list-ttl/walkthrough.go
@@ -1,17 +1,31 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 
 	"github.com/panyam/demokit"
 	"github.com/panyam/mcpkit/client"
 	"github.com/panyam/mcpkit/core"
 	"github.com/panyam/mcpkit/examples/common"
+	commonotel "github.com/panyam/mcpkit/examples/common/otel"
 )
 
 func runDemo() {
 	serverURL := common.ServerURL()
+
+	tel := common.ExporterFromArgs()
+	tp, shutdown, err := commonotel.SetupClientTelemetry(context.Background(),
+		commonotel.WithExporter(*tel.Exporter),
+		commonotel.WithOTLPEndpoint(*tel.OTLPEndpoint),
+		commonotel.WithServiceName("list-ttl-host"),
+	)
+	if err != nil {
+		log.Fatalf("commonotel.SetupClientTelemetry: %v", err)
+	}
+	defer shutdown(context.Background())
 
 	demo := demokit.New("MCP List TTL (SEP-2549) — Cache Hints on List and Read Results").
 		Dir("list-ttl").
@@ -75,6 +89,7 @@ if err := c.Connect(); err != nil { /* server not up — run: make serve */ }`),
 		Run(func(ctx demokit.StepContext) (result *demokit.StepResult) {
 			c = client.NewClient(serverURL+"/mcp",
 				core.ClientInfo{Name: "list-ttl-host", Version: "1.0"},
+				client.WithTracerProvider(tp),
 			)
 			if err := c.Connect(); err != nil {
 				fmt.Printf("    ERROR: %v\n    Start the server with: make serve\n", err)

--- a/examples/mrtr/walkthrough.go
+++ b/examples/mrtr/walkthrough.go
@@ -4,15 +4,28 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 
 	"github.com/panyam/demokit"
 	"github.com/panyam/mcpkit/client"
 	"github.com/panyam/mcpkit/core"
 	"github.com/panyam/mcpkit/examples/common"
+	commonotel "github.com/panyam/mcpkit/examples/common/otel"
 )
 
 func runDemo() {
 	serverURL := common.ServerURL()
+
+	tel := common.ExporterFromArgs()
+	tp, shutdown, err := commonotel.SetupClientTelemetry(context.Background(),
+		commonotel.WithExporter(*tel.Exporter),
+		commonotel.WithOTLPEndpoint(*tel.OTLPEndpoint),
+		commonotel.WithServiceName("mrtr-demo-host"),
+	)
+	if err != nil {
+		log.Fatalf("commonotel.SetupClientTelemetry: %v", err)
+	}
+	defer shutdown(context.Background())
 
 	demo := demokit.New("MCP MRTR (SEP-2322) — Ephemeral InputRequiredResult Round-Trips").
 		Dir("mrtr").
@@ -98,6 +111,7 @@ if err := c.Connect(); err != nil { /* server not up — run: make serve */ }`),
 				client.WithRootsHandler(func(ctx context.Context) ([]core.Root, error) {
 					return []core.Root{{URI: "file:///demo/root", Name: "Demo Root"}}, nil
 				}),
+				client.WithTracerProvider(tp),
 			)
 			if err := c.Connect(); err != nil {
 				fmt.Printf("    ERROR: %v\n    Start the server with: make serve\n", err)

--- a/examples/skills/walkthrough.go
+++ b/examples/skills/walkthrough.go
@@ -1,17 +1,20 @@
 package main
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/panyam/demokit"
 	"github.com/panyam/mcpkit/client"
 	"github.com/panyam/mcpkit/core"
 	"github.com/panyam/mcpkit/examples/common"
+	commonotel "github.com/panyam/mcpkit/examples/common/otel"
 	"github.com/panyam/mcpkit/ext/skills"
 )
 
@@ -26,6 +29,17 @@ const (
 
 func runDemo() {
 	serverURL := common.ServerURL()
+
+	tel := common.ExporterFromArgs()
+	tp, shutdown, err := commonotel.SetupClientTelemetry(context.Background(),
+		commonotel.WithExporter(*tel.Exporter),
+		commonotel.WithOTLPEndpoint(*tel.OTLPEndpoint),
+		commonotel.WithServiceName("skills-host"),
+	)
+	if err != nil {
+		log.Fatalf("commonotel.SetupClientTelemetry: %v", err)
+	}
+	defer shutdown(context.Background())
 
 	demo := demokit.New("MCP Skills Extension (SEP-2640) — Reference Walkthrough").
 		Dir("skills").
@@ -87,6 +101,7 @@ func runDemo() {
 		Run(func(ctx demokit.StepContext) *demokit.StepResult {
 			c = client.NewClient(serverURL+"/mcp",
 				core.ClientInfo{Name: "skills-host", Version: "1.0"},
+				client.WithTracerProvider(tp),
 			)
 			if err := c.Connect(); err != nil {
 				fmt.Printf("    ERROR: %v\n    Start the server with: make serve\n", err)

--- a/examples/tasks-v2/walkthrough.go
+++ b/examples/tasks-v2/walkthrough.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"time"
 
@@ -11,10 +12,22 @@ import (
 	"github.com/panyam/mcpkit/client"
 	"github.com/panyam/mcpkit/core"
 	"github.com/panyam/mcpkit/examples/common"
+	commonotel "github.com/panyam/mcpkit/examples/common/otel"
 )
 
 func runDemo() {
 	serverURL := common.ServerURL()
+
+	tel := common.ExporterFromArgs()
+	tp, shutdown, err := commonotel.SetupClientTelemetry(context.Background(),
+		commonotel.WithExporter(*tel.Exporter),
+		commonotel.WithOTLPEndpoint(*tel.OTLPEndpoint),
+		commonotel.WithServiceName("tasks-v2-host"),
+	)
+	if err != nil {
+		log.Fatalf("commonotel.SetupClientTelemetry: %v", err)
+	}
+	defer shutdown(context.Background())
 
 	demo := demokit.New("MCP Tasks v2 (SEP-2663) — Server-Directed Async + MRTR").
 		Dir("tasks-v2").
@@ -90,6 +103,7 @@ _ = c.ServerSupportsExtension(core.TasksExtensionID) // true once negotiated`),
 						fmt.Fprintf(os.Stderr, "    [notif] progress: %v\n", params)
 					}
 				}),
+				client.WithTracerProvider(tp),
 			)
 			if err := c.Connect(); err != nil {
 				fmt.Printf("    ERROR: %v\n    Start the server with: make serve\n", err)

--- a/examples/tasks/walkthrough.go
+++ b/examples/tasks/walkthrough.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"time"
 
@@ -10,10 +11,22 @@ import (
 	"github.com/panyam/mcpkit/client"
 	"github.com/panyam/mcpkit/core"
 	"github.com/panyam/mcpkit/examples/common"
+	commonotel "github.com/panyam/mcpkit/examples/common/otel"
 )
 
 func runDemo() {
 	serverURL := common.ServerURL()
+
+	tel := common.ExporterFromArgs()
+	tp, shutdown, err := commonotel.SetupClientTelemetry(context.Background(),
+		commonotel.WithExporter(*tel.Exporter),
+		commonotel.WithOTLPEndpoint(*tel.OTLPEndpoint),
+		commonotel.WithServiceName("tasks-demo-host"),
+	)
+	if err != nil {
+		log.Fatalf("commonotel.SetupClientTelemetry: %v", err)
+	}
+	defer shutdown(context.Background())
 
 	demo := demokit.New("MCP Tasks — Async Tool Execution Lifecycle").
 		Dir("tasks").
@@ -86,6 +99,7 @@ tools, _ := c.ListTools() // each tool carries Execution.TaskSupport metadata`),
 						fmt.Fprintf(os.Stderr, "    [notif] progress: %v\n", params)
 					}
 				}),
+				client.WithTracerProvider(tp),
 			)
 			if err := c.Connect(); err != nil {
 				fmt.Printf("    ERROR: %v\n    Start the server with: make serve\n", err)


### PR DESCRIPTION
## What changes

Follow-up to PR 684. Extends the same uniform observability surface PR 684 wired into every example **server** to the example **walkthrough (host) side**. When an operator runs `make demo EXPORTER=otlp`, both halves of each example now ship spans to Tempo — under matched `<name>` / `<name>-host` service names so Grafana's service filter distinguishes the stitched trace's two ends.

```mermaid
sequenceDiagram
    participant Op as Operator
    participant Host as Walkthrough<br/>(client side)
    participant Srv as Example server
    participant Coll as OTel Collector
    participant Tempo

    Op->>Host: make demo EXPORTER=otlp
    Op->>Srv: make serve EXPORTER=otlp
    Host->>Host: commonotel.SetupClientTelemetry(<br/>WithServiceName("foo-host"))
    Srv->>Srv: commonotel.SetupTelemetry(<br/>WithServiceName("foo-demo"))
    Host->>Srv: tools/call + _meta.traceparent
    Host-->>Coll: client span (service.name=foo-host)
    Srv-->>Coll: server span (service.name=foo-demo,<br/>parent=client span)
    Coll->>Tempo: both spans, same TraceID
    Op->>Tempo: Grafana Explore filter by service.name
```

## Reviewer's guide

Read in this order:

1. [examples/common/otel/setup.go](https://github.com/panyam/mcpkit/pull/689/files#diff-e7c81e6d564bfc0478e953dae6e44b522c2a854f483c610b720689189a16d496) — `SetupClientTelemetry(ctx, opts...)` is the new public helper. Thin wrapper around `SetupTelemetry` that pre-pends `WithInstrumentationName("github.com/panyam/mcpkit/client")`. `ClientInstrumentationName` const is exported so callers can reference it for asserts.
2. [examples/common/exporter_flag.go](https://github.com/panyam/mcpkit/pull/689/files#diff-24add4432cf248228c7dd179a12b2312c04a0c1ab3cf693bac2b84f5c0152ff4) — `ExporterFromArgs()` mirrors `common.ServerURL`'s ad-hoc `os.Args` scan pattern (recognized argv shapes documented in the godoc). Returns the same `*TelemetryFlags` shape `RegisterTelemetryFlags` returns so call sites deref identically (`*tel.Exporter`).
3. [examples/CONVENTIONS.md](https://github.com/panyam/mcpkit/pull/689/files#diff-d763a016b06b1c666cdb643f94ccb8a6c1138b2a8327802b93aec40519b40e27) — new "Client-side wiring (walkthrough.go)" subsection with the canonical pattern + service-name convention (`<example-name>-host`).
4. Adoption sweep — 9 walkthroughs, each gets a SetupClientTelemetry call at the top of runDemo + `client.WithTracerProvider(tp)` added to every real `client.NewClient` call site:
   - [examples/file-inputs/walkthrough.go](https://github.com/panyam/mcpkit/pull/689/files#diff-7fcc054821745731325c049e89ffebae0cb74f020912524b623445cce6ceb2f6) · [examples/list-ttl/walkthrough.go](https://github.com/panyam/mcpkit/pull/689/files#diff-3965429a5ee7a8f3a5eb694c9375c86d764eb71e48fa3ffb410684f18a8d059a) · [examples/mrtr/walkthrough.go](https://github.com/panyam/mcpkit/pull/689/files#diff-b19e0dcbed1a09942a9652e0092fa7de233c23394332fd2a9a83250428a73e02) · [examples/skills/walkthrough.go](https://github.com/panyam/mcpkit/pull/689/files#diff-94afaa0ca3ed61f670feefe88925e3b5ecfc827cfcdb7612d48a01dd289c10e7) · [examples/tasks/walkthrough.go](https://github.com/panyam/mcpkit/pull/689/files#diff-d9233b8095e47080936130d709cd62f44cc78d7d0c3705175c47338c85e88feb) · [examples/tasks-v2/walkthrough.go](https://github.com/panyam/mcpkit/pull/689/files#diff-84203486551480d08bf5dad4f513c032154ade216bc4cd2e9e5ea43ba9f5e90d) — single NewClient each
   - [examples/auth/main.go](https://github.com/panyam/mcpkit/pull/689/files#diff-fa43b479d6f58f3260149e5b8a86f09e921abb2f76b29038313564d4b5921a3a) — 3 NewClient sites (anonymous + read + read-write)
   - [examples/elicitation/main.go](https://github.com/panyam/mcpkit/pull/689/files#diff-0727bcf88d8f992e667962bb3b6fe7a76434d30adf3340b0575e6ee62641ce12) — 1 NewClient site
   - [examples/fine-grained-auth/main.go](https://github.com/panyam/mcpkit/pull/689/files#diff-cc8039b26a5505a2251ca47a3305daf3afc79ddc12a7655dbfb988074bf704d5) — 3 NewClient sites (read + call + pay)

Skim or skip: documentation strings inside `demokit.MakeVariant("go", ...)` are deliberately untouched — they demonstrate the auth / wire shape, not telemetry, so adding `WithTracerProvider` there would muddy the teaching code without behavioral effect.

## Decision log

| Decision | Choice | Alternative | Why |
|---|---|---|---|
| Helper shape | `SetupClientTelemetry` as thin wrapper | Make instrumentation-name an option on plain `SetupTelemetry` only | Wrapper saves every walkthrough from typing the magic string `"github.com/panyam/mcpkit/client"`. Composes cleanly — explicit `WithInstrumentationName(...)` in opts still wins. |
| `ExporterFromArgs` vs adding `flag.Parse` to walkthroughs | `ExporterFromArgs` | Add `flag.Parse` everywhere | Walkthroughs already use `common.ServerURL`'s ad-hoc scan pattern for `--url`. Symmetric scan helper preserves that idiom — no `flag.Parse` churn, no demokit.FilterArgs registration to maintain per walkthrough. |
| Return type matches `TelemetryFlags` | Yes (`*TelemetryFlags` with `*string` fields) | Plain `(exporter, endpoint string)` two-return-value | Call sites deref identically regardless of which helper populated them. Lets walkthroughs migrate to `RegisterTelemetryFlags` later (if they grow other flags) without touching the SetupClientTelemetry call. |
| Service-name convention | `<example-name>-host` for client side | `<example-name>-client` | `host` matches what PR 680's otel/stdout already established (`otel-stdout-host`); avoids retroactively renaming. |
| Leave `MakeVariant` Go-source strings alone | Yes | Update them too for completeness | They're focused on auth/wire teaching; adding telemetry noise dilutes the example. Real call sites are what actually execute and get traced. |
| Skip `examples/stateless/` | Yes | Add a walkthrough | No walkthrough exists today (the package directs readers to `make testconf-stateless`); adding one is out of scope. |

## Test plan

Added: 0 new unit tests (helper is a thin wrapper over already-tested `SetupTelemetry`; instrumentation-name preset would need to assert against `tracetest.InMemoryExporter`'s `InstrumentationScope` — covered indirectly by every adopter's traces in OTLP mode).

Verification:
- `make test` (root): clean.
- `make -C examples/common test`: clean (9 SetupTelemetry tests still pass).
- `go build ./...` per example: all 9 adopted examples build clean.
- Live smoke against `docker/observability/`:
  - `file-inputs --doc md --exporter=auto` (no server up): silent fallback to Noop, walkthrough doc renders normally.
  - `list-ttl --doc md --exporter=otlp --otlp-endpoint=127.0.0.1:1`: documented warning + Noop fallback, walkthrough doc renders normally.
  - Default `--doc md` (no `--exporter`): zero overhead, no telemetry init logs.

## Risk / blast radius

- **12 files touched, ~270 LOC added.** Each adopter's diff is mechanical (~15 lines per file = SetupClientTelemetry block + per-NewClient one-line append).
- **No new dependencies** — examples/common already pulled the OTel SDK in PR 684; this just adds API surface in setup.go and exporter_flag.go.
- **Behavior unchanged for adopters who don't pass `--exporter`** — the helper returns Noop and `client.WithTracerProvider(NoopTracerProvider{})` is a no-op on the client dispatch path.

## Out of scope (still deferred)

- `examples/apps/compat/` adoption → issue 660 (ext/ui trace context relay across the Apps postMessage bridge) is the right home.
- `examples/events/discord/` → bypasses both RunServer and the canonical runDemo pattern; will adopt alongside that example's own bootstrap refactor.
- `examples/stateless/` → no walkthrough binary today.
- Whole-enchilada (#407) + kitchen-sink (#406) → issue 667.
- Logs + metrics signals → issue 668.
