### PR TITLE
examples/apps/compat/budget-allocator: real walkthrough surfacing the app-side bridge dance

### DIFF
--- a/examples/apps/compat/budget-allocator/README.md
+++ b/examples/apps/compat/budget-allocator/README.md
@@ -16,6 +16,10 @@ without override.
 - **No override needed.** Standard struct tags get this right. Sits
   in the sweet spot of what reflection can handle.
 
+## Run Pre-Recorded
+
+> ▶ **[Play the walkthrough in your browser](https://panyam.github.io/mcpkit/walkthroughs/examples/apps/compat/budget-allocator/)** — animated playback of every curl / Go call the walkthrough makes, step-by-step. Steps 1-4 walk the server-side surface (initialize → tools/list → tools/call get-budget-data → resources/read on the iframe HTML); the final narrative section spells out the app-side bridge dance that takes over from there: `app.ontoolresult`, five tools the iframe registers via `app.registerTool`, and `app.updateModelContext` pushing UI state back to the model. The protocol surface a Go-only host sees is the *floor* of an MCP Apps interaction; the bridge dance is what makes this a *widget*. No clone, no setup.
+
 ## Or Run Live
 
 ### Start Server

--- a/examples/apps/compat/budget-allocator/bundle/ansi_up.js
+++ b/examples/apps/compat/budget-allocator/bundle/ansi_up.js
@@ -1,0 +1,431 @@
+"use strict";
+var __makeTemplateObject = (this && this.__makeTemplateObject) || function (cooked, raw) {
+    if (Object.defineProperty) { Object.defineProperty(cooked, "raw", { value: raw }); } else { cooked.raw = raw; }
+    return cooked;
+};
+var PacketKind;
+(function (PacketKind) {
+    PacketKind[PacketKind["EOS"] = 0] = "EOS";
+    PacketKind[PacketKind["Text"] = 1] = "Text";
+    PacketKind[PacketKind["Incomplete"] = 2] = "Incomplete";
+    PacketKind[PacketKind["ESC"] = 3] = "ESC";
+    PacketKind[PacketKind["Unknown"] = 4] = "Unknown";
+    PacketKind[PacketKind["SGR"] = 5] = "SGR";
+    PacketKind[PacketKind["OSCURL"] = 6] = "OSCURL";
+})(PacketKind || (PacketKind = {}));
+export class AnsiUp {
+    constructor() {
+        this.VERSION = "6.0.6";
+        this.setup_palettes();
+        this._use_classes = false;
+        this.bold = false;
+        this.faint = false;
+        this.italic = false;
+        this.underline = false;
+        this.fg = this.bg = null;
+        this._buffer = '';
+        this._url_allowlist = { 'http': 1, 'https': 1 };
+        this._escape_html = true;
+        this.boldStyle = 'font-weight:bold';
+        this.faintStyle = 'opacity:0.7';
+        this.italicStyle = 'font-style:italic';
+        this.underlineStyle = 'text-decoration:underline';
+    }
+    set use_classes(arg) {
+        this._use_classes = arg;
+    }
+    get use_classes() {
+        return this._use_classes;
+    }
+    set url_allowlist(arg) {
+        this._url_allowlist = arg;
+    }
+    get url_allowlist() {
+        return this._url_allowlist;
+    }
+    set escape_html(arg) {
+        this._escape_html = arg;
+    }
+    get escape_html() {
+        return this._escape_html;
+    }
+    set boldStyle(arg) { this._boldStyle = arg; }
+    get boldStyle() { return this._boldStyle; }
+    set faintStyle(arg) { this._faintStyle = arg; }
+    get faintStyle() { return this._faintStyle; }
+    set italicStyle(arg) { this._italicStyle = arg; }
+    get italicStyle() { return this._italicStyle; }
+    set underlineStyle(arg) { this._underlineStyle = arg; }
+    get underlineStyle() { return this._underlineStyle; }
+    setup_palettes() {
+        this.ansi_colors =
+            [
+                [
+                    { rgb: [0, 0, 0], class_name: "ansi-black" },
+                    { rgb: [187, 0, 0], class_name: "ansi-red" },
+                    { rgb: [0, 187, 0], class_name: "ansi-green" },
+                    { rgb: [187, 187, 0], class_name: "ansi-yellow" },
+                    { rgb: [0, 0, 187], class_name: "ansi-blue" },
+                    { rgb: [187, 0, 187], class_name: "ansi-magenta" },
+                    { rgb: [0, 187, 187], class_name: "ansi-cyan" },
+                    { rgb: [255, 255, 255], class_name: "ansi-white" }
+                ],
+                [
+                    { rgb: [85, 85, 85], class_name: "ansi-bright-black" },
+                    { rgb: [255, 85, 85], class_name: "ansi-bright-red" },
+                    { rgb: [0, 255, 0], class_name: "ansi-bright-green" },
+                    { rgb: [255, 255, 85], class_name: "ansi-bright-yellow" },
+                    { rgb: [85, 85, 255], class_name: "ansi-bright-blue" },
+                    { rgb: [255, 85, 255], class_name: "ansi-bright-magenta" },
+                    { rgb: [85, 255, 255], class_name: "ansi-bright-cyan" },
+                    { rgb: [255, 255, 255], class_name: "ansi-bright-white" }
+                ]
+            ];
+        this.palette_256 = [];
+        this.ansi_colors.forEach(palette => {
+            palette.forEach(rec => {
+                this.palette_256.push(rec);
+            });
+        });
+        let levels = [0, 95, 135, 175, 215, 255];
+        for (let r = 0; r < 6; ++r) {
+            for (let g = 0; g < 6; ++g) {
+                for (let b = 0; b < 6; ++b) {
+                    let col = { rgb: [levels[r], levels[g], levels[b]], class_name: 'truecolor' };
+                    this.palette_256.push(col);
+                }
+            }
+        }
+        let grey_level = 8;
+        for (let i = 0; i < 24; ++i, grey_level += 10) {
+            let gry = { rgb: [grey_level, grey_level, grey_level], class_name: 'truecolor' };
+            this.palette_256.push(gry);
+        }
+    }
+    escape_txt_for_html(txt) {
+        if (!this._escape_html)
+            return txt;
+        return txt.replace(/[&<>"']/gm, (str) => {
+            if (str === "&")
+                return "&amp;";
+            if (str === "<")
+                return "&lt;";
+            if (str === ">")
+                return "&gt;";
+            if (str === "\"")
+                return "&quot;";
+            if (str === "'")
+                return "&#x27;";
+        });
+    }
+    append_buffer(txt) {
+        var str = this._buffer + txt;
+        this._buffer = str;
+    }
+    get_next_packet() {
+        var pkt = {
+            kind: PacketKind.EOS,
+            text: '',
+            url: ''
+        };
+        var len = this._buffer.length;
+        if (len == 0)
+            return pkt;
+        var pos = this._buffer.indexOf("\x1B");
+        if (pos == -1) {
+            pkt.kind = PacketKind.Text;
+            pkt.text = this._buffer;
+            this._buffer = '';
+            return pkt;
+        }
+        if (pos > 0) {
+            pkt.kind = PacketKind.Text;
+            pkt.text = this._buffer.slice(0, pos);
+            this._buffer = this._buffer.slice(pos);
+            return pkt;
+        }
+        if (pos == 0) {
+            if (len < 3) {
+                pkt.kind = PacketKind.Incomplete;
+                return pkt;
+            }
+            var next_char = this._buffer.charAt(1);
+            if ((next_char != '[') && (next_char != ']') && (next_char != '(')) {
+                pkt.kind = PacketKind.ESC;
+                pkt.text = this._buffer.slice(0, 1);
+                this._buffer = this._buffer.slice(1);
+                return pkt;
+            }
+            if (next_char == '[') {
+                if (!this._csi_regex) {
+                    this._csi_regex = rgx(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\n                        ^                           # beginning of line\n                                                    #\n                                                    # First attempt\n                        (?:                         # legal sequence\n                          \u001B[                      # CSI\n                          ([<-?]?)              # private-mode char\n                          ([d;]*)                    # any digits or semicolons\n                          ([ -/]?               # an intermediate modifier\n                          [@-~])                # the command\n                        )\n                        |                           # alternate (second attempt)\n                        (?:                         # illegal sequence\n                          \u001B[                      # CSI\n                          [ -~]*                # anything legal\n                          ([\0-\u001F:])              # anything illegal\n                        )\n                    "], ["\n                        ^                           # beginning of line\n                                                    #\n                                                    # First attempt\n                        (?:                         # legal sequence\n                          \\x1b\\[                      # CSI\n                          ([\\x3c-\\x3f]?)              # private-mode char\n                          ([\\d;]*)                    # any digits or semicolons\n                          ([\\x20-\\x2f]?               # an intermediate modifier\n                          [\\x40-\\x7e])                # the command\n                        )\n                        |                           # alternate (second attempt)\n                        (?:                         # illegal sequence\n                          \\x1b\\[                      # CSI\n                          [\\x20-\\x7e]*                # anything legal\n                          ([\\x00-\\x1f:])              # anything illegal\n                        )\n                    "])));
+                }
+                let match = this._buffer.match(this._csi_regex);
+                if (match === null) {
+                    pkt.kind = PacketKind.Incomplete;
+                    return pkt;
+                }
+                if (match[4]) {
+                    pkt.kind = PacketKind.ESC;
+                    pkt.text = this._buffer.slice(0, 1);
+                    this._buffer = this._buffer.slice(1);
+                    return pkt;
+                }
+                if ((match[1] != '') || (match[3] != 'm'))
+                    pkt.kind = PacketKind.Unknown;
+                else
+                    pkt.kind = PacketKind.SGR;
+                pkt.text = match[2];
+                var rpos = match[0].length;
+                this._buffer = this._buffer.slice(rpos);
+                return pkt;
+            }
+            else if (next_char == ']') {
+                if (len < 4) {
+                    pkt.kind = PacketKind.Incomplete;
+                    return pkt;
+                }
+                if ((this._buffer.charAt(2) != '8')
+                    || (this._buffer.charAt(3) != ';')) {
+                    pkt.kind = PacketKind.ESC;
+                    pkt.text = this._buffer.slice(0, 1);
+                    this._buffer = this._buffer.slice(1);
+                    return pkt;
+                }
+                if (!this._osc_st) {
+                    this._osc_st = rgxG(templateObject_2 || (templateObject_2 = __makeTemplateObject(["\n                        (?:                         # legal sequence\n                          (\u001B\\)                    # ESC                           |                           # alternate\n                          (\u0007)                      # BEL (what xterm did)\n                        )\n                        |                           # alternate (second attempt)\n                        (                           # illegal sequence\n                          [\0-\u0006]                 # anything illegal\n                          |                           # alternate\n                          [\b-\u001A]                 # anything illegal\n                          |                           # alternate\n                          [\u001C-\u001F]                 # anything illegal\n                        )\n                    "], ["\n                        (?:                         # legal sequence\n                          (\\x1b\\\\)                    # ESC \\\n                          |                           # alternate\n                          (\\x07)                      # BEL (what xterm did)\n                        )\n                        |                           # alternate (second attempt)\n                        (                           # illegal sequence\n                          [\\x00-\\x06]                 # anything illegal\n                          |                           # alternate\n                          [\\x08-\\x1a]                 # anything illegal\n                          |                           # alternate\n                          [\\x1c-\\x1f]                 # anything illegal\n                        )\n                    "])));
+                }
+                this._osc_st.lastIndex = 0;
+                {
+                    let match = this._osc_st.exec(this._buffer);
+                    if (match === null) {
+                        pkt.kind = PacketKind.Incomplete;
+                        return pkt;
+                    }
+                    if (match[3]) {
+                        pkt.kind = PacketKind.ESC;
+                        pkt.text = this._buffer.slice(0, 1);
+                        this._buffer = this._buffer.slice(1);
+                        return pkt;
+                    }
+                }
+                {
+                    let match = this._osc_st.exec(this._buffer);
+                    if (match === null) {
+                        pkt.kind = PacketKind.Incomplete;
+                        return pkt;
+                    }
+                    if (match[3]) {
+                        pkt.kind = PacketKind.ESC;
+                        pkt.text = this._buffer.slice(0, 1);
+                        this._buffer = this._buffer.slice(1);
+                        return pkt;
+                    }
+                }
+                if (!this._osc_regex) {
+                    this._osc_regex = rgx(templateObject_3 || (templateObject_3 = __makeTemplateObject(["\n                        ^                           # beginning of line\n                                                    #\n                        \u001B]8;                    # OSC Hyperlink\n                        [ -:<-~]*       # params (excluding ;)\n                        ;                           # end of params\n                        ([!-~]{0,512})        # URL capture\n                        (?:                         # ST\n                          (?:\u001B\\)                  # ESC                           |                           # alternate\n                          (?:\u0007)                    # BEL (what xterm did)\n                        )\n                        ([ -~]+)              # TEXT capture\n                        \u001B]8;;                   # OSC Hyperlink End\n                        (?:                         # ST\n                          (?:\u001B\\)                  # ESC                           |                           # alternate\n                          (?:\u0007)                    # BEL (what xterm did)\n                        )\n                    "], ["\n                        ^                           # beginning of line\n                                                    #\n                        \\x1b\\]8;                    # OSC Hyperlink\n                        [\\x20-\\x3a\\x3c-\\x7e]*       # params (excluding ;)\n                        ;                           # end of params\n                        ([\\x21-\\x7e]{0,512})        # URL capture\n                        (?:                         # ST\n                          (?:\\x1b\\\\)                  # ESC \\\n                          |                           # alternate\n                          (?:\\x07)                    # BEL (what xterm did)\n                        )\n                        ([\\x20-\\x7e]+)              # TEXT capture\n                        \\x1b\\]8;;                   # OSC Hyperlink End\n                        (?:                         # ST\n                          (?:\\x1b\\\\)                  # ESC \\\n                          |                           # alternate\n                          (?:\\x07)                    # BEL (what xterm did)\n                        )\n                    "])));
+                }
+                let match = this._buffer.match(this._osc_regex);
+                if (match === null) {
+                    pkt.kind = PacketKind.ESC;
+                    pkt.text = this._buffer.slice(0, 1);
+                    this._buffer = this._buffer.slice(1);
+                    return pkt;
+                }
+                pkt.kind = PacketKind.OSCURL;
+                pkt.url = match[1];
+                pkt.text = match[2];
+                var rpos = match[0].length;
+                this._buffer = this._buffer.slice(rpos);
+                return pkt;
+            }
+            else if (next_char == '(') {
+                pkt.kind = PacketKind.Unknown;
+                this._buffer = this._buffer.slice(3);
+                return pkt;
+            }
+        }
+    }
+    ansi_to_html(txt) {
+        this.append_buffer(txt);
+        var blocks = [];
+        while (true) {
+            var packet = this.get_next_packet();
+            if ((packet.kind == PacketKind.EOS)
+                || (packet.kind == PacketKind.Incomplete))
+                break;
+            if ((packet.kind == PacketKind.ESC)
+                || (packet.kind == PacketKind.Unknown))
+                continue;
+            if (packet.kind == PacketKind.Text)
+                blocks.push(this.transform_to_html(this.with_state(packet)));
+            else if (packet.kind == PacketKind.SGR)
+                this.process_ansi(packet);
+            else if (packet.kind == PacketKind.OSCURL)
+                blocks.push(this.process_hyperlink(packet));
+        }
+        return blocks.join("");
+    }
+    with_state(pkt) {
+        return { bold: this.bold, faint: this.faint, italic: this.italic, underline: this.underline, fg: this.fg, bg: this.bg, text: pkt.text };
+    }
+    process_ansi(pkt) {
+        let sgr_cmds = pkt.text.split(';');
+        while (sgr_cmds.length > 0) {
+            let sgr_cmd_str = sgr_cmds.shift();
+            let num = parseInt(sgr_cmd_str, 10);
+            if (isNaN(num) || num === 0) {
+                this.fg = null;
+                this.bg = null;
+                this.bold = false;
+                this.faint = false;
+                this.italic = false;
+                this.underline = false;
+            }
+            else if (num === 1) {
+                this.bold = true;
+            }
+            else if (num === 2) {
+                this.faint = true;
+            }
+            else if (num === 3) {
+                this.italic = true;
+            }
+            else if (num === 4) {
+                this.underline = true;
+            }
+            else if (num === 21) {
+                this.bold = false;
+            }
+            else if (num === 22) {
+                this.faint = false;
+                this.bold = false;
+            }
+            else if (num === 23) {
+                this.italic = false;
+            }
+            else if (num === 24) {
+                this.underline = false;
+            }
+            else if (num === 39) {
+                this.fg = null;
+            }
+            else if (num === 49) {
+                this.bg = null;
+            }
+            else if ((num >= 30) && (num < 38)) {
+                this.fg = this.ansi_colors[0][(num - 30)];
+            }
+            else if ((num >= 40) && (num < 48)) {
+                this.bg = this.ansi_colors[0][(num - 40)];
+            }
+            else if ((num >= 90) && (num < 98)) {
+                this.fg = this.ansi_colors[1][(num - 90)];
+            }
+            else if ((num >= 100) && (num < 108)) {
+                this.bg = this.ansi_colors[1][(num - 100)];
+            }
+            else if (num === 38 || num === 48) {
+                if (sgr_cmds.length > 0) {
+                    let is_foreground = (num === 38);
+                    let mode_cmd = sgr_cmds.shift();
+                    if (mode_cmd === '5' && sgr_cmds.length > 0) {
+                        let palette_index = parseInt(sgr_cmds.shift(), 10);
+                        if (palette_index >= 0 && palette_index <= 255) {
+                            if (is_foreground)
+                                this.fg = this.palette_256[palette_index];
+                            else
+                                this.bg = this.palette_256[palette_index];
+                        }
+                    }
+                    if (mode_cmd === '2' && sgr_cmds.length > 2) {
+                        let r = parseInt(sgr_cmds.shift(), 10);
+                        let g = parseInt(sgr_cmds.shift(), 10);
+                        let b = parseInt(sgr_cmds.shift(), 10);
+                        if ((r >= 0 && r <= 255) && (g >= 0 && g <= 255) && (b >= 0 && b <= 255)) {
+                            let c = { rgb: [r, g, b], class_name: 'truecolor' };
+                            if (is_foreground)
+                                this.fg = c;
+                            else
+                                this.bg = c;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    transform_to_html(fragment) {
+        let txt = fragment.text;
+        if (txt.length === 0)
+            return txt;
+        txt = this.escape_txt_for_html(txt);
+        if (!fragment.bold && !fragment.italic && !fragment.faint && !fragment.underline && fragment.fg === null && fragment.bg === null)
+            return txt;
+        let styles = [];
+        let classes = [];
+        let fg = fragment.fg;
+        let bg = fragment.bg;
+        if (fragment.bold)
+            styles.push(this._boldStyle);
+        if (fragment.faint)
+            styles.push(this._faintStyle);
+        if (fragment.italic)
+            styles.push(this._italicStyle);
+        if (fragment.underline)
+            styles.push(this._underlineStyle);
+        if (!this._use_classes) {
+            if (fg)
+                styles.push(`color:rgb(${fg.rgb.join(',')})`);
+            if (bg)
+                styles.push(`background-color:rgb(${bg.rgb})`);
+        }
+        else {
+            if (fg) {
+                if (fg.class_name !== 'truecolor') {
+                    classes.push(`${fg.class_name}-fg`);
+                }
+                else {
+                    styles.push(`color:rgb(${fg.rgb.join(',')})`);
+                }
+            }
+            if (bg) {
+                if (bg.class_name !== 'truecolor') {
+                    classes.push(`${bg.class_name}-bg`);
+                }
+                else {
+                    styles.push(`background-color:rgb(${bg.rgb.join(',')})`);
+                }
+            }
+        }
+        let class_string = '';
+        let style_string = '';
+        if (classes.length)
+            class_string = ` class="${classes.join(' ')}"`;
+        if (styles.length)
+            style_string = ` style="${styles.join(';')}"`;
+        return `<span${style_string}${class_string}>${txt}</span>`;
+    }
+    ;
+    process_hyperlink(pkt) {
+        let parts = pkt.url.split(':');
+        if (parts.length < 1)
+            return '';
+        if (!this._url_allowlist[parts[0]])
+            return '';
+        let result = `<a href="${this.escape_txt_for_html(pkt.url)}">${this.escape_txt_for_html(pkt.text)}</a>`;
+        return result;
+    }
+}
+function rgx(tmplObj, ...subst) {
+    let regexText = tmplObj.raw[0];
+    let wsrgx = /^\s+|\s+\n|\s*#[\s\S]*?\n|\n/gm;
+    let txt2 = regexText.replace(wsrgx, '');
+    return new RegExp(txt2);
+}
+function rgxG(tmplObj, ...subst) {
+    let regexText = tmplObj.raw[0];
+    let wsrgx = /^\s+|\s+\n|\s*#[\s\S]*?\n|\n/gm;
+    let txt2 = regexText.replace(wsrgx, '');
+    return new RegExp(txt2, 'g');
+}
+var templateObject_1, templateObject_2, templateObject_3;

--- a/examples/apps/compat/budget-allocator/bundle/demokit-player.css
+++ b/examples/apps/compat/budget-allocator/bundle/demokit-player.css
@@ -1,0 +1,253 @@
+/* demokit-player styles. BEM-ish class names; no shadow DOM so host
+   themes can override via CSS variables. Hosts can set:
+
+     --demokit-bg, --demokit-fg, --demokit-muted, --demokit-accent,
+     --demokit-border, --demokit-error, --demokit-warning,
+     --demokit-info, --demokit-mono
+
+   on a parent element to retheme the player.
+
+   The widget is layout-agnostic: it claims width: 100% and grows
+   in height to fit its feed. Wrap it in an iframe or a sized
+   container if you need a fixed viewport.
+*/
+
+.demokit-player {
+  --demokit-bg: #ffffff;
+  --demokit-fg: #1f2328;
+  --demokit-muted: #57606a;
+  --demokit-accent: #0969da;
+  --demokit-border: #d0d7de;
+  --demokit-error: #cf222e;
+  --demokit-warning: #9a6700;
+  --demokit-info: #0969da;
+  --demokit-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+
+  display: block;
+  width: 100%;
+  font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  color: var(--demokit-fg);
+  background: var(--demokit-bg);
+  border: 1px solid var(--demokit-border);
+  border-radius: 6px;
+  overflow: hidden;
+  outline: none;
+}
+
+.demokit-player:focus {
+  box-shadow: 0 0 0 2px var(--demokit-accent);
+}
+
+.demokit-player__header {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--demokit-border);
+}
+
+.demokit-player__title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.demokit-player__description {
+  margin: 4px 0 0;
+  color: var(--demokit-muted);
+  font-size: 13px;
+}
+
+.demokit-player__feed {
+  padding: 16px;
+  max-height: 70vh;
+  overflow-y: auto;
+}
+
+.demokit-player__controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  border-top: 1px solid var(--demokit-border);
+  background: rgba(0, 0, 0, 0.02);
+}
+
+.demokit-player__btn {
+  font: inherit;
+  padding: 4px 10px;
+  border: 1px solid var(--demokit-border);
+  background: var(--demokit-bg);
+  color: var(--demokit-fg);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.demokit-player__btn:hover:not(:disabled) {
+  background: rgba(0, 0, 0, 0.04);
+}
+
+.demokit-player__btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.demokit-player__counter {
+  margin-left: auto;
+  color: var(--demokit-muted);
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+}
+
+.demokit-player__error {
+  padding: 12px;
+  border-left: 4px solid var(--demokit-error);
+  color: var(--demokit-error);
+  background: rgba(207, 34, 46, 0.06);
+  border-radius: 4px;
+}
+
+/* --- Per-entry blocks --- */
+
+.demokit-section,
+.demokit-step {
+  margin: 0 0 16px;
+  padding: 12px 14px;
+  border: 1px solid var(--demokit-border);
+  border-radius: 6px;
+  background: var(--demokit-bg);
+}
+
+.demokit-section__title,
+.demokit-step__title {
+  margin: 0 0 8px;
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.demokit-step__visit {
+  color: var(--demokit-muted);
+  font-weight: 400;
+}
+
+.demokit-section__body {
+  margin: 0;
+  color: var(--demokit-muted);
+  white-space: pre-wrap;
+}
+
+.demokit-step__note {
+  margin: 0 0 8px;
+  padding: 6px 10px;
+  border-left: 3px solid var(--demokit-border);
+  color: var(--demokit-muted);
+  font-style: italic;
+  background: rgba(0, 0, 0, 0.02);
+}
+
+.demokit-step__refs {
+  margin: 0 0 8px;
+  font-size: 12px;
+  color: var(--demokit-muted);
+}
+.demokit-step__refs a {
+  color: var(--demokit-accent);
+}
+
+.demokit-step__inputs {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 2px 12px;
+  margin: 0 0 8px;
+  padding: 6px 10px;
+  font-family: var(--demokit-mono);
+  font-size: 12px;
+  background: rgba(0, 0, 0, 0.03);
+  border-radius: 4px;
+}
+.demokit-step__inputs dt {
+  color: var(--demokit-muted);
+}
+.demokit-step__inputs dd {
+  margin: 0;
+}
+
+.demokit-step__output {
+  margin: 0 0 8px;
+  padding: 8px 10px;
+  background: rgba(0, 0, 0, 0.04);
+  border-radius: 4px;
+  font-family: var(--demokit-mono);
+  font-size: 12px;
+  white-space: pre-wrap;
+  overflow-x: auto;
+}
+
+.demokit-step__verbatim-label {
+  margin: 8px 0 4px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--demokit-muted);
+}
+.demokit-step__verbatim {
+  margin: 0 0 8px;
+  padding: 8px 10px;
+  background: rgba(0, 0, 0, 0.04);
+  border-radius: 4px;
+  font-family: var(--demokit-mono);
+  font-size: 12px;
+  white-space: pre;
+  overflow-x: auto;
+}
+
+.demokit-step__status {
+  margin: 0;
+  padding: 6px 10px;
+  border-radius: 4px;
+  font-weight: 500;
+}
+
+.demokit-step__jump {
+  margin: 6px 0 0;
+  font-size: 12px;
+  color: var(--demokit-muted);
+  font-family: var(--demokit-mono);
+}
+
+/* Status colors — match ResultStatus const ordering: 0 success, 1 error, 2 warning, 3 info */
+.demokit-step--status-1 {
+  border-left: 4px solid var(--demokit-error);
+}
+.demokit-step--status-1 .demokit-step__status {
+  background: rgba(207, 34, 46, 0.08);
+  color: var(--demokit-error);
+}
+.demokit-step--status-2 {
+  border-left: 4px solid var(--demokit-warning);
+}
+.demokit-step--status-2 .demokit-step__status {
+  background: rgba(154, 103, 0, 0.08);
+  color: var(--demokit-warning);
+}
+.demokit-step--status-3 {
+  border-left: 4px solid var(--demokit-info);
+}
+.demokit-step--status-3 .demokit-step__status {
+  background: rgba(9, 105, 218, 0.08);
+  color: var(--demokit-info);
+}
+
+@media (prefers-color-scheme: dark) {
+  .demokit-player {
+    --demokit-bg: #0d1117;
+    --demokit-fg: #e6edf3;
+    --demokit-muted: #8b949e;
+    --demokit-accent: #58a6ff;
+    --demokit-border: #30363d;
+  }
+  .demokit-player__btn:hover:not(:disabled) {
+    background: rgba(255, 255, 255, 0.06);
+  }
+  .demokit-step__note,
+  .demokit-step__inputs,
+  .demokit-step__output {
+    background: rgba(255, 255, 255, 0.03);
+  }
+}

--- a/examples/apps/compat/budget-allocator/bundle/demokit-player.js
+++ b/examples/apps/compat/budget-allocator/bundle/demokit-player.js
@@ -1,0 +1,858 @@
+// demokit-player — vanilla-JS web component for playing back demokit
+// traces in any HTML host. Registers <demokit-demo> as a Custom
+// Element. No framework dependencies.
+//
+// Data sources, in priority order:
+//   1. Programmatic: el.trace = traceObject (assigning the property
+//      triggers a re-render).
+//   2. data-src URL: fetch JSON; render as static playback.
+//   3. data-src URL with data-mode="live": connect via WebSocket and
+//      render incrementally as the server emits structured events
+//      (header / section / step-start / chunk / step-end /
+//      input-needed / done). Driven by `demokit --serve`.
+//   4. Inline blob: <demokit-demo>{...JSON...}</demokit-demo>.
+//
+// Public API on the element:
+//   .trace = obj            // programmatic data injection
+//   .play(), .pause(), .reset(), .step(), .goTo(n)
+//   .currentStep (read), .totalEntries (read), .isPlaying (read)
+//
+// Events dispatched on the element (notifications, past tense):
+//   demokit:loaded   — once trace data is available
+//   demokit:stepped  — the visible step just advanced
+//   demokit:done     — last entry shown
+//   demokit:error    — fatal load/render error
+//
+// Events listened for (commands; host fires these to drive the
+// widget without knowing the player's class name):
+//   demokit:play, demokit:pause, demokit:reset, demokit:step
+//
+// The command/notification names are deliberately distinct
+// (demokit:step vs demokit:stepped) — using one name for both
+// would create a recursion loop the moment a step() advance
+// dispatches the same event the host listener handles.
+//
+// Keyboard (when the element is focused):
+//   Space / ArrowRight  — next step
+//   ArrowLeft           — previous step (rewinds the visible feed)
+//   P                   — play/pause toggle
+//   R                   — reset to first entry
+
+// This file is an ES module. Bundle templates load it via
+// <script type="module" src="...">.
+//
+// ansi_up is pulled in via a dynamic import wrapped in try/catch so
+// the player still loads when the CDN is unreachable — opening the
+// bundle on file:// without internet, behind a strict CSP that
+// blocks third-party scripts, or in air-gapped contexts. The
+// fallback strips ANSI escapes to plain text rather than failing
+// the whole module.
+
+// ansi_up is loaded from a commit-pinned jsdelivr URL — content-
+// addressable since the commit SHA is immutable, so no separate
+// integrity check is needed. We don't vendor a copy under our repo
+// because the file is already at the CDN; duplicating the bytes
+// adds nothing.
+//
+// file:// pages can't fetch cross-origin scripts (Chrome blocks
+// null-origin → https). For those cases the answer is the demokit
+// serve command (HTTP origin → CDN imports work) rather than a
+// chained fallback chasing every constraint.
+//
+// The stripper fallback below catches the residual case where the
+// import genuinely fails (no network, hard CSP, or a future demokit
+// air-gapped mode). Output stays readable (just without colour)
+// rather than garbled or absent.
+
+let AnsiUp;
+try {
+  const mod = await import(
+    'https://cdn.jsdelivr.net/gh/drudru/ansi_up@07a4824757d4dfbb41236a4245a6ce37f21aeb91/ansi_up.js'
+  );
+  AnsiUp = mod.AnsiUp;
+} catch (err) {
+  console.warn(
+    'demokit-player: ansi_up failed to load — captured ANSI escapes will render as plain text:',
+    err && err.message ? err.message : err,
+  );
+  AnsiUp = class {
+    constructor() { this.use_classes = false; }
+    ansi_to_html(text) {
+      // Strip ANSI escapes AND HTML-escape `<`, `>`, `&` so DOMParser
+      // doesn't misinterpret literals (e.g. the dragon ASCII body)
+      // as malformed tags. ansi_up's real ansi_to_html escapes
+      // internally; the stripper has to do the same.
+      return String(text)
+        .replace(/\x1b\[[0-9;]*m/g, '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+    }
+  };
+}
+
+const PLAY_INTERVAL_MS = 1500; // tune via Demo author later if needed
+
+class DemokitDemoElement extends HTMLElement {
+    constructor() {
+      super();
+      this._trace = null;
+      this._programmaticTrace = null;
+      this._currentStep = 0; // index of next entry to reveal
+      this._isPlaying = false;
+      this._timer = null;
+      this._kbHandler = null;
+      this._evtHandlers = {};
+    }
+
+    connectedCallback() {
+      this.classList.add('demokit-player');
+      if (!this.hasAttribute('tabindex')) {
+        this.setAttribute('tabindex', '0'); // make focusable for keyboard
+      }
+      // Snapshot inline JSON before _renderShell() replaces the
+      // element's children — otherwise _loadTrace would read the
+      // rendered button labels as if they were the trace blob.
+      this._inlineText = (this.textContent || '').trim();
+      this._renderShell();
+      this._bindKeyboard();
+      this._bindHostEvents();
+      this._loadTrace();
+    }
+
+    disconnectedCallback() {
+      this._stopPlayback();
+      this._unbindKeyboard();
+      this._unbindHostEvents();
+    }
+
+    // --- Programmatic data source ---
+
+    set trace(obj) {
+      this._programmaticTrace = obj;
+      this._loadTrace();
+    }
+    get trace() {
+      return this._trace;
+    }
+
+    // --- Public controls ---
+
+    play() {
+      if (this._isPlaying || !this._trace) return;
+      this._isPlaying = true;
+      this._updateControls();
+      this._timer = setInterval(() => {
+        this.step();
+        if (this._currentStep >= this._entries().length) {
+          this._stopPlayback();
+        }
+      }, PLAY_INTERVAL_MS);
+    }
+
+    pause() {
+      this._stopPlayback();
+    }
+
+    reset() {
+      this._stopPlayback();
+      this._currentStep = 0;
+      this._feedEl.replaceChildren();
+      this._updateControls();
+    }
+
+    step() {
+      const entries = this._entries();
+      if (this._currentStep >= entries.length) return;
+      const e = entries[this._currentStep];
+      this._renderEntry(e, this._currentStep + 1);
+      this._currentStep++;
+      this._updateControls();
+      this.dispatchEvent(new CustomEvent('demokit:stepped', {
+        detail: { index: this._currentStep, entry: e },
+      }));
+      if (this._currentStep >= entries.length) {
+        this.dispatchEvent(new CustomEvent('demokit:done'));
+      }
+    }
+
+    goTo(n) {
+      const entries = this._entries();
+      this._stopPlayback();
+      this._feedEl.replaceChildren();
+      this._currentStep = 0;
+      const target = Math.max(0, Math.min(n, entries.length));
+      for (let i = 0; i < target; i++) {
+        this.step();
+      }
+    }
+
+    get currentStep() { return this._currentStep; }
+    get totalEntries() { return this._entries().length; }
+    get isPlaying() { return this._isPlaying; }
+
+    // --- Internals ---
+
+    _entries() {
+      if (!this._trace) return [];
+      // The trace JSON shipped by --doc json wraps trace entries
+      // under a "trace" key alongside the demo definition. Inline
+      // blobs may carry just the entries array directly.
+      if (Array.isArray(this._trace)) return this._trace;
+      return this._trace.trace || [];
+    }
+
+    _demo() {
+      if (!this._trace || Array.isArray(this._trace)) return null;
+      return this._trace.demo || null;
+    }
+
+    _renderShell() {
+      this.replaceChildren();
+      const header = document.createElement('div');
+      header.className = 'demokit-player__header';
+      this._titleEl = document.createElement('h2');
+      this._titleEl.className = 'demokit-player__title';
+      this._descEl = document.createElement('p');
+      this._descEl.className = 'demokit-player__description';
+      header.appendChild(this._titleEl);
+      header.appendChild(this._descEl);
+
+      this._feedEl = document.createElement('div');
+      this._feedEl.className = 'demokit-player__feed';
+
+      const controls = document.createElement('div');
+      controls.className = 'demokit-player__controls';
+      this._prevBtn = this._mkBtn('◀', 'Previous (←)', () => this.goTo(this._currentStep - 1));
+      this._stepBtn = this._mkBtn('▶ Next', 'Next step (Space)', () => this.step());
+      this._playBtn = this._mkBtn('▶▶ Play', 'Play (P)', () => this.play());
+      this._pauseBtn = this._mkBtn('❚❚ Pause', 'Pause (P)', () => this.pause());
+      this._resetBtn = this._mkBtn('⟲ Reset', 'Reset (R)', () => this.reset());
+      this._counterEl = document.createElement('span');
+      this._counterEl.className = 'demokit-player__counter';
+      controls.append(this._prevBtn, this._stepBtn, this._playBtn, this._pauseBtn, this._resetBtn, this._counterEl);
+
+      // Controls position is configurable via data-controls
+      // ("top" default, "bottom" for legacy/footer-style layouts).
+      // Top is the default because the feed grows downward; with
+      // controls at the bottom, the user has to scroll past their
+      // own steps to reach Next/Play.
+      this.appendChild(header);
+      const controlsAtBottom = (this.dataset.controls || 'top') === 'bottom';
+      if (controlsAtBottom) {
+        this.appendChild(this._feedEl);
+        this.appendChild(controls);
+        controls.classList.add('demokit-player__controls--bottom');
+      } else {
+        this.appendChild(controls);
+        this.appendChild(this._feedEl);
+        controls.classList.add('demokit-player__controls--top');
+      }
+    }
+
+    _mkBtn(label, title, onClick) {
+      const b = document.createElement('button');
+      b.type = 'button';
+      b.className = 'demokit-player__btn';
+      b.textContent = label;
+      b.title = title;
+      b.addEventListener('click', (e) => { e.stopPropagation(); onClick(); });
+      return b;
+    }
+
+    _updateControls() {
+      const total = this.totalEntries;
+      this._counterEl.textContent = `${this._currentStep} / ${total}`;
+      this._prevBtn.disabled = this._currentStep <= 0;
+      this._stepBtn.disabled = this._currentStep >= total;
+      this._playBtn.style.display = this._isPlaying ? 'none' : '';
+      this._pauseBtn.style.display = this._isPlaying ? '' : 'none';
+    }
+
+    async _loadTrace() {
+      const mode = this.dataset.mode || 'static';
+      const src = this.dataset.src;
+
+      try {
+        if (this._programmaticTrace) {
+          this._trace = this._programmaticTrace;
+        } else if (src && mode === 'live') {
+          // Live mode: open a WebSocket and stream structured events.
+          // Returns immediately; events drive the render incrementally.
+          this._connectWS(src);
+          return;
+        } else if (src) {
+          const res = await fetch(src);
+          if (!res.ok) {
+            throw new Error(`demokit-player: fetch ${src} → HTTP ${res.status}`);
+          }
+          this._trace = await res.json();
+        } else {
+          // _inlineText was captured in connectedCallback before the
+          // shell render replaced our children. Falls back to current
+          // textContent if connectedCallback hasn't run yet (rare).
+          const text = (this._inlineText !== undefined
+            ? this._inlineText
+            : (this.textContent || '').trim());
+          if (!text) {
+            this._renderError(
+              'demokit-player: no trace data. Provide data-src, inline JSON, or set the .trace property.',
+            );
+            return;
+          }
+          this._trace = JSON.parse(text);
+        }
+
+        this._renderHeader();
+        this._currentStep = 0;
+        this._feedEl.replaceChildren();
+        this._updateControls();
+        this.dispatchEvent(new CustomEvent('demokit:loaded', {
+          detail: { totalEntries: this.totalEntries },
+        }));
+      } catch (err) {
+        this._renderError(err && err.message ? err.message : String(err));
+        this.dispatchEvent(new CustomEvent('demokit:error', {
+          detail: { message: err && err.message ? err.message : String(err) },
+        }));
+      }
+    }
+
+    _renderHeader() {
+      const demo = this._demo();
+      this._titleEl.textContent = demo && demo.title ? demo.title : '';
+      this._descEl.textContent = demo && demo.description ? demo.description : '';
+      this._descEl.style.display = this._descEl.textContent ? '' : 'none';
+    }
+
+    _renderError(message) {
+      this._feedEl.replaceChildren();
+      const box = document.createElement('div');
+      box.className = 'demokit-player__error';
+      box.textContent = message;
+      this._feedEl.appendChild(box);
+    }
+
+    _renderEntry(entry, indexOneBased) {
+      if (entry.kind === 'section') {
+        this._renderSection(entry);
+      } else {
+        this._renderStep(entry, indexOneBased);
+      }
+      this._feedEl.lastElementChild.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+
+    _renderSection(entry) {
+      const sec = document.createElement('section');
+      sec.className = 'demokit-section';
+      const h = document.createElement('h3');
+      h.className = 'demokit-section__title';
+      h.textContent = entry.title || '';
+      sec.appendChild(h);
+      if (entry.body) {
+        const p = document.createElement('p');
+        p.className = 'demokit-section__body';
+        p.textContent = entry.body;
+        sec.appendChild(p);
+      }
+      this._feedEl.appendChild(sec);
+    }
+
+    _renderStep(entry, indexOneBased) {
+      const art = document.createElement('article');
+      const status = entry.status || 0; // 0 = success
+      art.className = `demokit-step demokit-step--status-${status}`;
+      const h = document.createElement('h3');
+      h.className = 'demokit-step__title';
+      h.textContent = `${indexOneBased}. ${entry.title || entry.step_id || ''}`;
+      if (entry.visit && entry.visit > 1) {
+        const v = document.createElement('span');
+        v.className = 'demokit-step__visit';
+        v.textContent = ` (visit ${entry.visit})`;
+        h.appendChild(v);
+      }
+      art.appendChild(h);
+
+      // Note from the demo definition (if available)
+      const stepDef = this._lookupStepDef(entry.step_id);
+      if (stepDef && stepDef.note) {
+        const blk = document.createElement('blockquote');
+        blk.className = 'demokit-step__note';
+        blk.textContent = stepDef.note;
+        art.appendChild(blk);
+      }
+      if (stepDef && stepDef.refs && stepDef.refs.length > 0) {
+        const refs = document.createElement('p');
+        refs.className = 'demokit-step__refs';
+        refs.appendChild(document.createTextNode('References: '));
+        stepDef.refs.forEach((ref, i) => {
+          if (i > 0) refs.appendChild(document.createTextNode(', '));
+          const a = document.createElement('a');
+          a.href = ref.url;
+          a.textContent = ref.name;
+          a.target = '_blank';
+          a.rel = 'noopener noreferrer';
+          refs.appendChild(a);
+        });
+        art.appendChild(refs);
+      }
+
+      if (stepDef && Array.isArray(stepDef.verbatim) && stepDef.verbatim.length) {
+        this._appendVerbatim(art, stepDef.verbatim);
+      }
+
+      // Inputs collected for this entry (read-only)
+      if (entry.inputs && Object.keys(entry.inputs).length > 0) {
+        const wrap = document.createElement('dl');
+        wrap.className = 'demokit-step__inputs';
+        Object.keys(entry.inputs).sort().forEach((k) => {
+          const dt = document.createElement('dt');
+          dt.textContent = k;
+          const dd = document.createElement('dd');
+          dd.textContent = String(entry.inputs[k]);
+          wrap.appendChild(dt);
+          wrap.appendChild(dd);
+        });
+        art.appendChild(wrap);
+      }
+
+      // Captured output — interpret ANSI SGR escapes so streamed
+      // colored output (e.g. the dungeon's dragon scene) renders
+      // with styling instead of leaking the literal "[38;5;245m"
+      // sequences as text.
+      if (entry.output) {
+        const pre = document.createElement('pre');
+        pre.className = 'demokit-step__output';
+        appendANSI(pre, entry.output.replace(/\n+$/, ''));
+        art.appendChild(pre);
+      }
+
+      // Status footer (error/warning/info messages)
+      if (status !== 0 && (entry.message || entry.label)) {
+        const foot = document.createElement('p');
+        foot.className = 'demokit-step__status';
+        const label = entry.label || statusLabel(status);
+        foot.textContent = `${label}: ${entry.message || ''}`;
+        art.appendChild(foot);
+      }
+
+      // Jump arrow
+      if (entry.next) {
+        const j = document.createElement('p');
+        j.className = 'demokit-step__jump';
+        j.textContent = `→ jumped to ${entry.next}`;
+        art.appendChild(j);
+      }
+
+      this._feedEl.appendChild(art);
+    }
+
+    _lookupStepDef(stepId) {
+      const demo = this._demo();
+      if (!demo || !demo.items || !stepId) return null;
+      for (const it of demo.items) {
+        if (it.kind === 'step' && it.id === stepId) return it;
+      }
+      return null;
+    }
+
+    // Append each verbatim block as an optional label + a <pre><code>
+    // with white-space: pre and overflow-x: auto. The browser does not
+    // soft-wrap, so triple-clicking a long line yields the original
+    // bytes — same copy-paste invariant the TUI guarantees.
+    _appendVerbatim(parent, blocks) {
+      blocks.forEach((b) => {
+        if (b.label) {
+          const h = document.createElement('p');
+          h.className = 'demokit-step__verbatim-label';
+          h.textContent = b.label;
+          parent.appendChild(h);
+        }
+        const pre = document.createElement('pre');
+        pre.className = 'demokit-step__verbatim';
+        const code = document.createElement('code');
+        if (b.lang) code.className = 'language-' + b.lang;
+        code.textContent = b.content || '';
+        pre.appendChild(code);
+        parent.appendChild(pre);
+      });
+    }
+
+    _stopPlayback() {
+      if (this._timer) {
+        clearInterval(this._timer);
+        this._timer = null;
+      }
+      this._isPlaying = false;
+      if (this._counterEl) this._updateControls();
+    }
+
+    _bindKeyboard() {
+      this._kbHandler = (e) => {
+        if (document.activeElement !== this) return;
+        switch (e.key) {
+          case ' ':
+          case 'ArrowRight':
+            e.preventDefault();
+            this.step();
+            break;
+          case 'ArrowLeft':
+            e.preventDefault();
+            this.goTo(this._currentStep - 1);
+            break;
+          case 'p':
+          case 'P':
+            e.preventDefault();
+            if (this._isPlaying) this.pause(); else this.play();
+            break;
+          case 'r':
+          case 'R':
+            e.preventDefault();
+            this.reset();
+            break;
+        }
+      };
+      this.addEventListener('keydown', this._kbHandler);
+    }
+
+    _unbindKeyboard() {
+      if (this._kbHandler) {
+        this.removeEventListener('keydown', this._kbHandler);
+        this._kbHandler = null;
+      }
+    }
+
+    _bindHostEvents() {
+      const evts = ['demokit:play', 'demokit:pause', 'demokit:reset', 'demokit:step'];
+      evts.forEach((name) => {
+        const handler = () => {
+          switch (name) {
+            case 'demokit:play':  this.play();  break;
+            case 'demokit:pause': this.pause(); break;
+            case 'demokit:reset': this.reset(); break;
+            case 'demokit:step':  this.step();  break;
+          }
+        };
+        this._evtHandlers[name] = handler;
+        this.addEventListener(name, handler);
+      });
+    }
+
+    _unbindHostEvents() {
+      Object.keys(this._evtHandlers).forEach((name) => {
+        this.removeEventListener(name, this._evtHandlers[name]);
+      });
+      this._evtHandlers = {};
+    }
+
+    // --- Live-mode WS ---
+    //
+    // When data-mode="live", the player connects to data-src as a
+    // WebSocket and renders incoming structured events incrementally
+    // (instead of fetching a static trace once). Outgoing messages
+    // are user actions: input submissions, reset.
+
+    _connectWS(rawURL) {
+      const wsURL = this._toWSURL(rawURL);
+      let ws;
+      try {
+        ws = new WebSocket(wsURL);
+      } catch (err) {
+        this._renderError('demokit-player: WS connect failed: ' + (err && err.message ? err.message : err));
+        return;
+      }
+      this._ws = ws;
+      this._currentStepEl = null;
+      this._currentStepID = null;
+
+      ws.onmessage = (e) => {
+        let evt;
+        try { evt = JSON.parse(e.data); } catch (_) { return; }
+        this._handleServerEvent(evt);
+      };
+      ws.onerror = () => {
+        this._renderError('demokit-player: WS error connecting to ' + wsURL);
+      };
+      ws.onclose = () => {
+        const note = document.createElement('p');
+        note.className = 'demokit-player__disconnected';
+        note.textContent = '(disconnected)';
+        this._feedEl.appendChild(note);
+      };
+    }
+
+    // _toWSURL converts an http(s):// or relative URL into ws(s)://
+    // so the host can write data-src as either a path or full URL.
+    _toWSURL(url) {
+      if (url.startsWith('ws://') || url.startsWith('wss://')) return url;
+      if (url.startsWith('http://')) return 'ws://' + url.slice(7);
+      if (url.startsWith('https://')) return 'wss://' + url.slice(8);
+      const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+      const path = url.startsWith('/') ? url : '/' + url;
+      return proto + '//' + location.host + path;
+    }
+
+    _handleServerEvent(evt) {
+      switch (evt.kind) {
+        case 'header':
+          if (evt.demo) {
+            this._titleEl.textContent = evt.demo.title || '';
+            this._descEl.textContent = evt.demo.description || '';
+            this._descEl.style.display = this._descEl.textContent ? '' : 'none';
+          }
+          break;
+        case 'section':
+          this._renderLiveSection(evt.extra || {});
+          break;
+        case 'step-start':
+          this._openLiveStep(evt.extra || {});
+          break;
+        case 'chunk':
+          this._appendChunkToLiveStep(evt.chunk || '');
+          break;
+        case 'step-end':
+          this._closeLiveStep(evt.status || 0, evt.extra || {});
+          break;
+        case 'input-needed':
+          this._renderLiveInputForm(evt.step_id, evt.inputs || []);
+          break;
+        case 'input-timeout':
+          this._dismissLiveInputForm(evt.extra && evt.extra.timeout_ms);
+          break;
+        case 'done':
+          this._renderLiveDone();
+          break;
+        case 'reset':
+          this._feedEl.replaceChildren();
+          this._currentStepEl = null;
+          this._currentStepID = null;
+          break;
+      }
+    }
+
+    _renderLiveSection(extra) {
+      const sec = document.createElement('section');
+      sec.className = 'demokit-section';
+      const h = document.createElement('h3');
+      h.className = 'demokit-section__title';
+      h.textContent = extra.title || '';
+      sec.appendChild(h);
+      if (extra.body) {
+        const p = document.createElement('p');
+        p.className = 'demokit-section__body';
+        p.textContent = extra.body;
+        sec.appendChild(p);
+      }
+      this._feedEl.appendChild(sec);
+      sec.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+
+    _openLiveStep(extra) {
+      const art = document.createElement('article');
+      art.className = 'demokit-step demokit-step--status-0';
+      const h = document.createElement('h3');
+      h.className = 'demokit-step__title';
+      const num = extra.step_num;
+      const title = extra.title || extra.id || '';
+      h.textContent = num ? num + '. ' + title : title;
+      art.appendChild(h);
+
+      if (extra.note) {
+        const blk = document.createElement('blockquote');
+        blk.className = 'demokit-step__note';
+        blk.textContent = extra.note;
+        art.appendChild(blk);
+      }
+      if (Array.isArray(extra.refs) && extra.refs.length) {
+        const refs = document.createElement('p');
+        refs.className = 'demokit-step__refs';
+        refs.appendChild(document.createTextNode('References: '));
+        extra.refs.forEach((ref, i) => {
+          if (i > 0) refs.appendChild(document.createTextNode(', '));
+          const a = document.createElement('a');
+          a.href = ref.url || ref.URL || '#';
+          a.textContent = ref.name || ref.Name || ref.url || '';
+          a.target = '_blank';
+          a.rel = 'noopener noreferrer';
+          refs.appendChild(a);
+        });
+        art.appendChild(refs);
+      }
+
+      if (Array.isArray(extra.verbatim) && extra.verbatim.length) {
+        this._appendVerbatim(art, extra.verbatim);
+      }
+
+      const pre = document.createElement('pre');
+      pre.className = 'demokit-step__output';
+      pre.style.display = 'none'; // shown when first chunk arrives
+      art.appendChild(pre);
+
+      this._feedEl.appendChild(art);
+      this._currentStepEl = art;
+      this._currentStepPreEl = pre;
+      this._currentStepID = extra.id || '';
+      art.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+
+    _appendChunkToLiveStep(text) {
+      if (!this._currentStepPreEl) return;
+      this._currentStepPreEl.style.display = '';
+      appendANSI(this._currentStepPreEl, text);
+    }
+
+    _closeLiveStep(status, extra) {
+      const el = this._currentStepEl;
+      if (!el) return;
+      el.classList.remove('demokit-step--status-0');
+      el.classList.add('demokit-step--status-' + status);
+
+      if (status !== 0 && extra && extra.message) {
+        const foot = document.createElement('p');
+        foot.className = 'demokit-step__status';
+        foot.textContent = (extra.label || statusLabel(status)) + ': ' + extra.message;
+        el.appendChild(foot);
+      }
+      if (extra && extra.next) {
+        const j = document.createElement('p');
+        j.className = 'demokit-step__jump';
+        j.textContent = '→ jumped to ' + extra.next;
+        el.appendChild(j);
+      }
+      this._currentStepEl = null;
+      this._currentStepPreEl = null;
+      this._currentStepID = null;
+    }
+
+    _renderLiveInputForm(stepID, inputs) {
+      const form = document.createElement('form');
+      form.className = 'demokit-input-form';
+      const fields = [];
+      inputs.forEach((inp) => {
+        const wrap = document.createElement('label');
+        wrap.className = 'demokit-input-form__field';
+        const lbl = document.createElement('span');
+        lbl.textContent = (inp.Prompt || inp.Name || inp.name || 'input') + ': ';
+        wrap.appendChild(lbl);
+
+        let ctrl;
+        const kind = inp.Kind || inp.kind;
+        if (kind === 'choice') {
+          ctrl = document.createElement('select');
+          (inp.Options || inp.options || []).forEach((opt) => {
+            const o = document.createElement('option');
+            o.value = opt;
+            o.textContent = opt;
+            ctrl.appendChild(o);
+          });
+        } else if (kind === 'int') {
+          ctrl = document.createElement('input');
+          ctrl.type = 'number';
+        } else {
+          ctrl = document.createElement('input');
+          ctrl.type = 'text';
+        }
+        ctrl.name = inp.Name || inp.name || '';
+        if (inp.Default !== undefined && inp.Default !== null) {
+          ctrl.value = String(inp.Default);
+        } else if (inp.default !== undefined && inp.default !== null) {
+          ctrl.value = String(inp.default);
+        }
+        wrap.appendChild(ctrl);
+        form.appendChild(wrap);
+        fields.push({ name: ctrl.name, el: ctrl, kind });
+      });
+
+      const submit = document.createElement('button');
+      submit.type = 'submit';
+      submit.className = 'demokit-player__btn';
+      submit.textContent = 'Submit';
+      form.appendChild(submit);
+
+      form.addEventListener('submit', (e) => {
+        e.preventDefault();
+        const values = {};
+        fields.forEach((f) => {
+          if (f.kind === 'int') {
+            values[f.name] = parseInt(f.el.value, 10);
+          } else {
+            values[f.name] = f.el.value;
+          }
+        });
+        if (this._ws && this._ws.readyState === WebSocket.OPEN) {
+          this._ws.send(JSON.stringify({ kind: 'input', values }));
+        }
+        form.remove();
+      });
+
+      this._feedEl.appendChild(form);
+      form.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+
+    _dismissLiveInputForm(timeoutMs) {
+      // Server timed out waiting for input and is continuing with
+      // declared defaults. Find the most recent input form (the one
+      // we just rendered for the current step) and replace it with
+      // a small notice.
+      const forms = this._feedEl.querySelectorAll('form.demokit-input-form');
+      const form = forms[forms.length - 1];
+      if (!form) return;
+      const note = document.createElement('p');
+      note.className = 'demokit-input-form__timeout';
+      const secs = timeoutMs ? (timeoutMs / 1000).toFixed(1) : '';
+      note.textContent = secs
+        ? `(no input after ${secs}s — continuing with defaults)`
+        : '(input timed out — continuing with defaults)';
+      form.replaceWith(note);
+      note.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+
+    _renderLiveDone() {
+      const note = document.createElement('p');
+      note.className = 'demokit-player__done';
+      note.textContent = '(demo ended)';
+      this._feedEl.appendChild(note);
+    }
+  }
+
+  // --- ANSI SGR → DOM ---
+  //
+  // Delegates to ansi_up (https://github.com/drudru/ansi_up, MIT;
+  // vendored under web/player/vendor/ — see VENDOR.md for the pin).
+  // The bundle and dev harness load ansi_up.umd.js *before* this
+  // file, so window.AnsiUp is available when appendANSI runs.
+  // Covers the full SGR table: 8-color, 256-color, true-color RGB,
+  // bold/dim/italic/underline/strikethrough.
+  //
+  // ansi_to_html escapes input itself and emits only text plus
+  // <span style=...> wrappers; running its output through DOMParser
+  // and reparenting the resulting nodes is safe and avoids touching
+  // innerHTML on the live document.
+  //
+  // Fallback: if AnsiUp isn't loaded (player JS used standalone
+  // without the vendor bundle), output renders as plain text — the
+  // escape sequences appear as literals but the step still loads.
+
+  function appendANSI(parent, text) {
+    if (text == null) return;
+    const ansiUp = new AnsiUp();
+    ansiUp.use_classes = false;
+    const safeHTML = ansiUp.ansi_to_html(String(text));
+    const parsed = new DOMParser().parseFromString(safeHTML, 'text/html');
+    while (parsed.body.firstChild) {
+      parent.appendChild(parsed.body.firstChild);
+    }
+  }
+
+  function statusLabel(status) {
+    switch (status) {
+      case 1: return 'Error';
+      case 2: return 'Warning';
+      case 3: return 'Info';
+      default: return 'Result';
+    }
+  }
+
+if (!customElements.get('demokit-demo')) {
+  customElements.define('demokit-demo', DemokitDemoElement);
+}

--- a/examples/apps/compat/budget-allocator/bundle/index.html
+++ b/examples/apps/compat/budget-allocator/bundle/index.html
@@ -1,0 +1,218 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>budget-allocator — deeply nested SaaS budget data &#43; 5 app-side tools</title>
+<link rel="stylesheet" href="./demokit-player.css">
+<style>
+body { margin: 2em auto; max-width: 900px; padding: 0 1em; font-family: -apple-system, BlinkMacSystemFont, sans-serif; }
+</style>
+</head>
+<body>
+<demokit-demo>{
+  "demo": {
+    "title": "budget-allocator — deeply nested SaaS budget data + 5 app-side tools",
+    "description": "Walks the get-budget-data round trip end-to-end as a scripted MCP client. Two distinctive things about this fixture are visible on the wire: the deeply nested structuredContent payload (config + analytics) that the Go reflector emits cleanly from struct tags + maps, and the iframe HTML that hosts the App. The final narrative section paints the app-side picture — five tools the iframe registers via the bridge — that a Go-only host can't directly drive. Run `make serve` in another terminal first.",
+    "actors": [
+      {
+        "id": "Host",
+        "label": "MCP Host (this client)"
+      },
+      {
+        "id": "Server",
+        "label": "mcpkit-Go fixture (make serve)"
+      }
+    ],
+    "items": [
+      {
+        "kind": "section",
+        "title": "Setup",
+        "body": "Start the MCP server in a separate terminal first:\n\n```\nTerminal 1:  make serve         # mcpkit-Go fixture on :3101\nTerminal 2:  make demo          # this walkthrough (--tui for interactive TUI)\n```\n\nAny MCP host can connect to the running server (Claude Desktop, VS Code, MCPJam, basic-host). The walkthrough below acts as a scripted host that issues the protocol calls directly through `*mcpkit/client.Client` — no LLM, no browser, no JS. The same protocol calls drive the iframe when you run `make demo-app EXAMPLE=budget-allocator` in basic-host (see the [centralized guide](../README.md#other-ways-to-test-a-fixture))."
+      },
+      {
+        "kind": "step",
+        "title": "Connect to the fixture",
+        "note": "Session establishment is a single initialize round-trip plus the notifications/initialized ack. `*client.Client.Connect()` does both behind one call; the curl form below shows the raw shape.",
+        "arrows": [
+          {
+            "from": "Host",
+            "to": "Server",
+            "label": "POST /mcp — initialize"
+          },
+          {
+            "from": "Server",
+            "to": "Host",
+            "label": "serverInfo + capabilities + Mcp-Session-Id",
+            "dashed": true
+          }
+        ],
+        "verbatim": [
+          {
+            "label": "Reproduce on the wire",
+            "variants": [
+              {
+                "label": "curl",
+                "lang": "bash",
+                "content": "# Initialize. Mcp-Session-Id comes back in the response headers.\nSID=$(curl -si -X POST http://localhost:3101/mcp \\\n  -H 'Content-Type: application/json' \\\n  -H 'Accept: text/event-stream, application/json' \\\n  -d '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"clientInfo\":{\"name\":\"curl\",\"version\":\"1\"}}}' \\\n  | awk 'tolower($1) == \"mcp-session-id:\" {gsub(/\\r/,\"\"); print $2}')\n\n# Acknowledge so the server's dispatcher unblocks.\ncurl -s -X POST http://localhost:3101/mcp \\\n  -H \"Mcp-Session-Id: $SID\" \\\n  -H 'Content-Type: application/json' \\\n  -H 'Accept: text/event-stream, application/json' \\\n  -d '{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}'",
+                "default": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "step",
+        "title": "tools/list — verify get-budget-data + its UI resource",
+        "note": "`get-budget-data` is the single server-side tool. The pedagogically interesting bit isn't the tool name — it's `_meta.ui.resourceUri` (`ui://budget-allocator/mcp-app.html`). That URI is the signal to an MCP Apps host: \"render this tool's result inside the iframe served from that resource.\" A non-Apps host would just see a JSON tool result; an Apps host wires it into a sandboxed iframe.",
+        "arrows": [
+          {
+            "from": "Host",
+            "to": "Server",
+            "label": "tools/list"
+          },
+          {
+            "from": "Server",
+            "to": "Host",
+            "label": "tools[] including get-budget-data",
+            "dashed": true
+          }
+        ],
+        "verbatim": [
+          {
+            "label": "Reproduce on the wire",
+            "variants": [
+              {
+                "label": "curl",
+                "lang": "bash",
+                "content": "curl -s -X POST http://localhost:3101/mcp \\\n  -H \"Mcp-Session-Id: $SID\" \\\n  -H 'Content-Type: application/json' \\\n  -H 'Accept: text/event-stream, application/json' \\\n  -d '{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{}}' \\\n  | jq '.result.tools[] | {name, _meta}'",
+                "default": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "step",
+        "title": "tools/call get-budget-data — the rich nested payload",
+        "note": "The handler returns a typed `budgetDataOutput` struct with deeply nested fields: Config (categories + preset budgets + currency) and Analytics (24 months of historical allocations + per-stage benchmark bands). The framework marshals it into `structuredContent` automatically via reflection — no `OutputSchemaOverride`, no `OutputSchemaPatch`. The walkthrough prints just the field tree below; the full payload is large enough that dumping it would drown the wire detail. This same payload is what the iframe receives via `app.ontoolresult`; see the final section.",
+        "arrows": [
+          {
+            "from": "Host",
+            "to": "Server",
+            "label": "tools/call get-budget-data {}"
+          },
+          {
+            "from": "Server",
+            "to": "Host",
+            "label": "ToolResult.structuredContent = { config: {...}, analytics: {...} }",
+            "dashed": true
+          }
+        ],
+        "verbatim": [
+          {
+            "label": "Reproduce on the wire",
+            "variants": [
+              {
+                "label": "curl",
+                "lang": "bash",
+                "content": "curl -s -X POST http://localhost:3101/mcp \\\n  -H \"Mcp-Session-Id: $SID\" \\\n  -H 'Content-Type: application/json' \\\n  -H 'Accept: text/event-stream, application/json' \\\n  -d '{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"get-budget-data\",\"arguments\":{}}}' \\\n  | jq '.result.structuredContent | { config_keys: (.config | keys), analytics_keys: (.analytics | keys), category_count: (.config.categories | length), history_months: (.analytics.history | length), benchmark_stages: (.analytics.benchmarks | length) }'",
+                "default": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "step",
+        "title": "resources/read — the iframe HTML the App ships in",
+        "note": "Pulls the iframe HTML the App loads inside. The walkthrough reports just the byte count (the body is upstream's verbatim bundled JS+HTML; not interesting to dump on the wire) plus whatever `_meta` the resource carries. budget-allocator's `_meta` is currently bare — compare to sheet-music's `_meta.ui.csp.connectDomains` (soundfont CDN) and transcript's `_meta.ui.permissions.microphone` for the per-fixture _meta story.",
+        "arrows": [
+          {
+            "from": "Host",
+            "to": "Server",
+            "label": "resources/read { uri: ui://budget-allocator/mcp-app.html }"
+          },
+          {
+            "from": "Server",
+            "to": "Host",
+            "label": "Contents[0].text + Contents[0]._meta",
+            "dashed": true
+          }
+        ],
+        "verbatim": [
+          {
+            "label": "Reproduce on the wire",
+            "variants": [
+              {
+                "label": "curl",
+                "lang": "bash",
+                "content": "curl -s -X POST http://localhost:3101/mcp \\\n  -H \"Mcp-Session-Id: $SID\" \\\n  -H 'Content-Type: application/json' \\\n  -H 'Accept: text/event-stream, application/json' \\\n  -d '{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"resources/read\",\"params\":{\"uri\":\"ui://budget-allocator/mcp-app.html\"}}' \\\n  | jq '.result.contents[0] | { mimeType, bytes: (.text | length), _meta }'",
+                "default": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "section",
+        "title": "What the App iframe does with all this",
+        "body": "This is the point where a Go-only scripted host hits its limit: everything from here runs in the iframe's JavaScript via the MCP Apps bridge, not over the MCP wire. A reader walking this section learns where the server-side story ends and the app-side story begins.\n\nWhen `make demo-app EXAMPLE=budget-allocator` runs this fixture inside basic-host, the host:\n\n1. Calls `tools/call get-budget-data` exactly as step 3 above.\n2. Reads `ui://budget-allocator/mcp-app.html` exactly as step 4 above.\n3. Renders the iframe in a sandbox, loads the JS bundle, and pushes the tool result into the iframe via the [mcp-app-bridge](https://github.com/modelcontextprotocol/ext-apps/blob/main/src/app-bridge.ts) `postMessage` channel.\n\nInside the iframe — which is what you saw in step 4's bytes — the App SDK then:\n\n- Receives the tool result via `app.ontoolresult` and unpacks `result.structuredContent` into the typed `BudgetDataResponse` shape. The categories / sliders / chart are bound directly to that data.\n- Registers **five app-side tools** that the model can call back through the bridge: `get-allocations`, `set-allocation`, `set-total-budget`, `set-company-stage`, `get-benchmark-comparison`. None of these are visible from a direct server-side `tools/list` (you can confirm by re-reading step 2's output) — they live in the iframe's runtime and the bridge proxies them to the host.\n- Calls `app.updateModelContext()` after every UI interaction to push the current allocation state back to the model, so a next-turn LLM prompt sees the updated budget.\n\nThe protocol surface a Go-only host sees (steps 1-4) is the *floor* of an MCP Apps interaction. The app-side bridge dance is the part that makes Budget Allocator a *widget* and not just a JSON tool result."
+      },
+      {
+        "kind": "section",
+        "title": "Where to look in the code",
+        "body": "- `main.go` — the fixture is one TypedAppTool (~100 lines plus the LCG'd historical data). The whole nested output reflects from the `budgetDataOutput` struct + maps.\n- `walkthrough.go` — this file. Each step's curl + Go recipe is the canonical wire reproduction.\n- `../README.md` — narrative + screenshots + the [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) guide.\n- Upstream's iframe source: `/tmp/ext-apps/examples/budget-allocator-server/src/mcp-app.ts` — the JS that consumes `ontoolresult` and registers the five app-side tools. Worth a read to see the bridge dance end-to-end."
+      }
+    ]
+  },
+  "trace": [
+    {
+      "kind": "section",
+      "title": "Setup",
+      "body": "Start the MCP server in a separate terminal first:\n\n```\nTerminal 1:  make serve         # mcpkit-Go fixture on :3101\nTerminal 2:  make demo          # this walkthrough (--tui for interactive TUI)\n```\n\nAny MCP host can connect to the running server (Claude Desktop, VS Code, MCPJam, basic-host). The walkthrough below acts as a scripted host that issues the protocol calls directly through `*mcpkit/client.Client` — no LLM, no browser, no JS. The same protocol calls drive the iframe when you run `make demo-app EXAMPLE=budget-allocator` in basic-host (see the [centralized guide](../README.md#other-ways-to-test-a-fixture))."
+    },
+    {
+      "kind": "step",
+      "title": "Connect to the fixture",
+      "step_id": "step-1",
+      "visit": 1,
+      "output": "    connected to Budget Allocator Server 1.0.0\n"
+    },
+    {
+      "kind": "step",
+      "title": "tools/list — verify get-budget-data + its UI resource",
+      "step_id": "step-2",
+      "visit": 1,
+      "output": "    get-budget-data\n      _meta: {\n        \"ui\": {\n          \"resourceUri\": \"ui://budget-allocator/mcp-app.html\"\n        },\n        \"ui/resourceUri\": \"ui://budget-allocator/mcp-app.html\"\n      }\n"
+    },
+    {
+      "kind": "step",
+      "title": "tools/call get-budget-data — the rich nested payload",
+      "step_id": "step-3",
+      "visit": 1,
+      "output": "    structuredContent shape:\n      config.categories       = 5 entries\n      config.presetBudgets    = 4 entries\n      config.defaultBudget    = 100000\n      config.currency         = USD\n      analytics.history       = 24 months\n      analytics.benchmarks    = 4 stages\n      analytics.stages        = 4 names\n      analytics.defaultStage  = Series A\n"
+    },
+    {
+      "kind": "step",
+      "title": "resources/read — the iframe HTML the App ships in",
+      "step_id": "step-4",
+      "visit": 1,
+      "output": "    uri:      ui://budget-allocator/mcp-app.html\n    mimeType: text/html;profile=mcp-app\n    bytes:    553966  (iframe HTML+JS bundle)\n    _meta:    \u003cnone\u003e  (no csp / permissions declared)\n"
+    },
+    {
+      "kind": "section",
+      "title": "What the App iframe does with all this",
+      "body": "This is the point where a Go-only scripted host hits its limit: everything from here runs in the iframe's JavaScript via the MCP Apps bridge, not over the MCP wire. A reader walking this section learns where the server-side story ends and the app-side story begins.\n\nWhen `make demo-app EXAMPLE=budget-allocator` runs this fixture inside basic-host, the host:\n\n1. Calls `tools/call get-budget-data` exactly as step 3 above.\n2. Reads `ui://budget-allocator/mcp-app.html` exactly as step 4 above.\n3. Renders the iframe in a sandbox, loads the JS bundle, and pushes the tool result into the iframe via the [mcp-app-bridge](https://github.com/modelcontextprotocol/ext-apps/blob/main/src/app-bridge.ts) `postMessage` channel.\n\nInside the iframe — which is what you saw in step 4's bytes — the App SDK then:\n\n- Receives the tool result via `app.ontoolresult` and unpacks `result.structuredContent` into the typed `BudgetDataResponse` shape. The categories / sliders / chart are bound directly to that data.\n- Registers **five app-side tools** that the model can call back through the bridge: `get-allocations`, `set-allocation`, `set-total-budget`, `set-company-stage`, `get-benchmark-comparison`. None of these are visible from a direct server-side `tools/list` (you can confirm by re-reading step 2's output) — they live in the iframe's runtime and the bridge proxies them to the host.\n- Calls `app.updateModelContext()` after every UI interaction to push the current allocation state back to the model, so a next-turn LLM prompt sees the updated budget.\n\nThe protocol surface a Go-only host sees (steps 1-4) is the *floor* of an MCP Apps interaction. The app-side bridge dance is the part that makes Budget Allocator a *widget* and not just a JSON tool result."
+    },
+    {
+      "kind": "section",
+      "title": "Where to look in the code",
+      "body": "- `main.go` — the fixture is one TypedAppTool (~100 lines plus the LCG'd historical data). The whole nested output reflects from the `budgetDataOutput` struct + maps.\n- `walkthrough.go` — this file. Each step's curl + Go recipe is the canonical wire reproduction.\n- `../README.md` — narrative + screenshots + the [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) guide.\n- Upstream's iframe source: `/tmp/ext-apps/examples/budget-allocator-server/src/mcp-app.ts` — the JS that consumes `ontoolresult` and registers the five app-side tools. Worth a read to see the bridge dance end-to-end."
+    }
+  ]
+}
+</demokit-demo>
+<script type="module" src="./demokit-player.js"></script>
+</body>
+</html>

--- a/examples/apps/compat/budget-allocator/walkthrough.go
+++ b/examples/apps/compat/budget-allocator/walkthrough.go
@@ -10,57 +10,304 @@ import (
 	"github.com/panyam/mcpkit/examples/common"
 )
 
-// runDemo is a STUB walkthrough — it connects to the fixture and lists
-// its tools. Refine it: add a tools/call step per tool, attach
-// common.WireRecipe(step, curl, go) for the wire reproduction, drop
-// fixture-specific narrative in .Note(...). See
-// examples/apps/compat/basic-vanillajs/walkthrough.go for the full
-// pattern.
+// runDemo is the budget-allocator walkthrough. Acts as a scripted MCP host
+// against a server started by `make serve` in another terminal.
 //
-// TODO: replace this stub with a curated walkthrough.
+// Walks four steps, each anchored on a fixture-specific surface — and
+// ends with a narrative Section painting the *app-side* picture that
+// a Go-only scripted host can't directly execute (because it has no
+// JS runtime and no basic-host bridge):
+//
+//  1. Connect (initialize + notifications/initialized).
+//  2. tools/list — focus on get-budget-data's `_meta.ui.resourceUri`,
+//     which is what tells an MCP Apps host "this tool has an iframe to
+//     render."
+//  3. tools/call get-budget-data — capture the structuredContent and
+//     summarize its shape: nested Config (categories + presets) +
+//     Analytics (24 months of history + benchmarks by stage). The
+//     wire-level fact is that this rich nested payload reflects cleanly
+//     from Go structs + maps without any schema overrides — the whole
+//     reason this fixture exists.
+//  4. resources/read on ui://budget-allocator/mcp-app.html — pull the
+//     iframe HTML (just report the byte count) plus inspect the
+//     per-content `_meta` payload. budget-allocator's _meta is currently
+//     bare; the contrast with sheet-music's CSP block and transcript's
+//     permissions block makes the per-fixture `_meta` story visible.
+//  5. (Section) "What the App iframe does with all this" — narrates the
+//     app-side dance that takes over from here when this fixture is
+//     loaded inside an MCP Apps host like basic-host: the iframe's JS
+//     receives the tool result via `app.ontoolresult`, registers FIVE
+//     app-side tools the model can call through the bridge
+//     (`get-allocations`, `set-allocation`, `set-total-budget`,
+//     `set-company-stage`, `get-benchmark-comparison`), and uses
+//     `app.updateModelContext` to push UI state back to the model. The
+//     scripted walkthrough can't run JS, but a reader walking step-by-
+//     step learns where the server-side story ends and the app-side
+//     story begins.
+//
+// Each tool/resource step attaches two unboxed Verbatim blocks via
+// common.WireRecipe: a curl form (copy-pastable) and a Go form (the
+// equivalent *client.Client call).
 func runDemo() {
 	serverURL := common.MCPServerURL()
 
-	demo := demokit.New("budget-allocator walkthrough (stub)").
-		Description("TODO: describe what this walkthrough demonstrates.").
+	demo := demokit.New("budget-allocator — deeply nested SaaS budget data + 5 app-side tools").
+		Dir("budget-allocator").
+		Description("Walks the get-budget-data round trip end-to-end as a scripted MCP client. Two distinctive things about this fixture are visible on the wire: the deeply nested structuredContent payload (config + analytics) that the Go reflector emits cleanly from struct tags + maps, and the iframe HTML that hosts the App. The final narrative section paints the app-side picture — five tools the iframe registers via the bridge — that a Go-only host can't directly drive. Run `make serve` in another terminal first.").
 		Actors(
 			demokit.Actor("Host", "MCP Host (this client)"),
 			demokit.Actor("Server", "mcpkit-Go fixture (make serve)"),
 		)
 
+	demo.Section("Setup",
+		"Start the MCP server in a separate terminal first:",
+		"",
+		"```",
+		"Terminal 1:  make serve         # mcpkit-Go fixture on :3101",
+		"Terminal 2:  make demo          # this walkthrough (--tui for interactive TUI)",
+		"```",
+		"",
+		"Any MCP host can connect to the running server (Claude Desktop, VS Code, MCPJam, basic-host). The walkthrough below acts as a scripted host that issues the protocol calls directly through `*mcpkit/client.Client` — no LLM, no browser, no JS. The same protocol calls drive the iframe when you run `make demo-app EXAMPLE=budget-allocator` in basic-host (see the [centralized guide](../README.md#other-ways-to-test-a-fixture)).",
+	)
+
 	var c *client.Client
 
-	demo.Step("Connect to the fixture").
+	step1 := demo.Step("Connect to the fixture").
 		Arrow("Host", "Server", "POST /mcp — initialize").
 		DashedArrow("Server", "Host", "serverInfo + capabilities + Mcp-Session-Id").
-		Note("Stub — refine in walkthrough.go.").
-		Run(func(ctx demokit.StepContext) *demokit.StepResult {
-			c = client.NewClient(serverURL+"/mcp",
-				core.ClientInfo{Name: "budget-allocator-host", Version: "1.0"},
-			)
-			if err := c.Connect(); err != nil {
-				fmt.Printf("    ERROR: %v\n    Start the server with: make serve\n", err)
-				return nil
-			}
-			fmt.Printf("    connected to %s %s\n", c.ServerInfo.Name, c.ServerInfo.Version)
-			return nil
-		})
+		Note("Session establishment is a single initialize round-trip plus the notifications/initialized ack. `*client.Client.Connect()` does both behind one call; the curl form below shows the raw shape.")
+	common.WireRecipe(step1,
+		`# Initialize. Mcp-Session-Id comes back in the response headers.
+SID=$(curl -si -X POST `+serverURL+`/mcp \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: text/event-stream, application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"curl","version":"1"}}}' \
+  | awk 'tolower($1) == "mcp-session-id:" {gsub(/\r/,""); print $2}')
 
-	demo.Step("List tools").
-		Arrow("Host", "Server", "tools/list").
-		DashedArrow("Server", "Host", "tools[]").
-		Note("Stub — refine in walkthrough.go.").
-		Run(func(ctx demokit.StepContext) *demokit.StepResult {
-			res, err := c.Call("tools/list", map[string]any{})
-			if err != nil {
-				fmt.Printf("    ERROR: %v\n", err)
-				return nil
-			}
-			pretty, _ := json.MarshalIndent(json.RawMessage(res.Raw), "    ", "  ")
-			fmt.Printf("    %s\n", string(pretty))
+# Acknowledge so the server's dispatcher unblocks.
+curl -s -X POST `+serverURL+`/mcp \
+  -H "Mcp-Session-Id: $SID" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: text/event-stream, application/json' \
+  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}'`,
+		`c := client.NewClient("`+serverURL+`/mcp",
+    core.ClientInfo{Name: "budget-allocator-host", Version: "1.0"},
+)
+if err := c.Connect(); err != nil {
+    log.Fatalf("connect: %v", err)
+}
+// Connect() handles initialize + notifications/initialized + session header.
+fmt.Printf("connected to %s %s\n", c.ServerInfo.Name, c.ServerInfo.Version)`,
+	).Run(func(ctx demokit.StepContext) *demokit.StepResult {
+		c = client.NewClient(serverURL+"/mcp",
+			core.ClientInfo{Name: "budget-allocator-host", Version: "1.0"},
+		)
+		if err := c.Connect(); err != nil {
+			fmt.Printf("    ERROR: %v\n    Start the server with: make serve\n", err)
 			return nil
+		}
+		fmt.Printf("    connected to %s %s\n", c.ServerInfo.Name, c.ServerInfo.Version)
+		return nil
+	})
+
+	step2 := demo.Step("tools/list — verify get-budget-data + its UI resource").
+		Arrow("Host", "Server", "tools/list").
+		DashedArrow("Server", "Host", "tools[] including get-budget-data").
+		Note("`get-budget-data` is the single server-side tool. The pedagogically interesting bit isn't the tool name — it's `_meta.ui.resourceUri` (`ui://budget-allocator/mcp-app.html`). That URI is the signal to an MCP Apps host: \"render this tool's result inside the iframe served from that resource.\" A non-Apps host would just see a JSON tool result; an Apps host wires it into a sandboxed iframe.")
+	common.WireRecipe(step2,
+		`curl -s -X POST `+serverURL+`/mcp \
+  -H "Mcp-Session-Id: $SID" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: text/event-stream, application/json' \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' \
+  | jq '.result.tools[] | {name, _meta}'`,
+		`res, _ := c.Call("tools/list", map[string]any{})
+var out struct {
+    Tools []struct {
+        Name string         `+"`json:\"name\"`"+`
+        Meta map[string]any `+"`json:\"_meta,omitempty\"`"+`
+    } `+"`json:\"tools\"`"+`
+}
+json.Unmarshal(res.Raw, &out)
+for _, t := range out.Tools {
+    fmt.Printf("  %s: %v\n", t.Name, t.Meta)
+}`,
+	).Run(func(ctx demokit.StepContext) *demokit.StepResult {
+		res, err := c.Call("tools/list", map[string]any{})
+		if err != nil {
+			fmt.Printf("    ERROR: %v\n", err)
+			return nil
+		}
+		var out struct {
+			Tools []struct {
+				Name string         `json:"name"`
+				Meta map[string]any `json:"_meta,omitempty"`
+			} `json:"tools"`
+		}
+		if err := json.Unmarshal(res.Raw, &out); err != nil {
+			fmt.Printf("    ERROR decoding tools/list: %v\n", err)
+			return nil
+		}
+		for _, t := range out.Tools {
+			pretty, _ := json.MarshalIndent(t.Meta, "      ", "  ")
+			fmt.Printf("    %s\n      _meta: %s\n", t.Name, string(pretty))
+		}
+		return nil
+	})
+
+	step3 := demo.Step("tools/call get-budget-data — the rich nested payload").
+		Arrow("Host", "Server", "tools/call get-budget-data {}").
+		DashedArrow("Server", "Host", "ToolResult.structuredContent = { config: {...}, analytics: {...} }").
+		Note("The handler returns a typed `budgetDataOutput` struct with deeply nested fields: Config (categories + preset budgets + currency) and Analytics (24 months of historical allocations + per-stage benchmark bands). The framework marshals it into `structuredContent` automatically via reflection — no `OutputSchemaOverride`, no `OutputSchemaPatch`. The walkthrough prints just the field tree below; the full payload is large enough that dumping it would drown the wire detail. This same payload is what the iframe receives via `app.ontoolresult`; see the final section.")
+	common.WireRecipe(step3,
+		`curl -s -X POST `+serverURL+`/mcp \
+  -H "Mcp-Session-Id: $SID" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: text/event-stream, application/json' \
+  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"get-budget-data","arguments":{}}}' \
+  | jq '.result.structuredContent | { config_keys: (.config | keys), analytics_keys: (.analytics | keys), category_count: (.config.categories | length), history_months: (.analytics.history | length), benchmark_stages: (.analytics.benchmarks | length) }'`,
+		`tr, _ := c.ToolCallFull("get-budget-data", map[string]any{})
+// tr.StructuredContent is map[string]any with deeply nested config + analytics.
+sc := tr.StructuredContent.(map[string]any)
+cfg := sc["config"].(map[string]any)
+an := sc["analytics"].(map[string]any)
+fmt.Printf("categories:       %d\n", len(cfg["categories"].([]any)))
+fmt.Printf("history months:   %d\n", len(an["history"].([]any)))
+fmt.Printf("benchmark stages: %d\n", len(an["benchmarks"].([]any)))`,
+	).Run(func(ctx demokit.StepContext) *demokit.StepResult {
+		tr, err := c.ToolCallFull("get-budget-data", map[string]any{})
+		if err != nil {
+			fmt.Printf("    ERROR: %v\n", err)
+			return nil
+		}
+		sc, _ := tr.StructuredContent.(map[string]any)
+		if sc == nil {
+			fmt.Printf("    ERROR: no structuredContent on tool result\n")
+			return nil
+		}
+		cfg, _ := sc["config"].(map[string]any)
+		an, _ := sc["analytics"].(map[string]any)
+		fmt.Printf("    structuredContent shape:\n")
+		fmt.Printf("      config.categories       = %d entries\n", lengthOf(cfg, "categories"))
+		fmt.Printf("      config.presetBudgets    = %d entries\n", lengthOf(cfg, "presetBudgets"))
+		if v, ok := cfg["defaultBudget"]; ok {
+			fmt.Printf("      config.defaultBudget    = %v\n", v)
+		}
+		if v, ok := cfg["currency"]; ok {
+			fmt.Printf("      config.currency         = %v\n", v)
+		}
+		fmt.Printf("      analytics.history       = %d months\n", lengthOf(an, "history"))
+		fmt.Printf("      analytics.benchmarks    = %d stages\n", lengthOf(an, "benchmarks"))
+		fmt.Printf("      analytics.stages        = %d names\n", lengthOf(an, "stages"))
+		if v, ok := an["defaultStage"]; ok {
+			fmt.Printf("      analytics.defaultStage  = %v\n", v)
+		}
+		return nil
+	})
+
+	step4 := demo.Step("resources/read — the iframe HTML the App ships in").
+		Arrow("Host", "Server", "resources/read { uri: ui://budget-allocator/mcp-app.html }").
+		DashedArrow("Server", "Host", "Contents[0].text + Contents[0]._meta").
+		Note("Pulls the iframe HTML the App loads inside. The walkthrough reports just the byte count (the body is upstream's verbatim bundled JS+HTML; not interesting to dump on the wire) plus whatever `_meta` the resource carries. budget-allocator's `_meta` is currently bare — compare to sheet-music's `_meta.ui.csp.connectDomains` (soundfont CDN) and transcript's `_meta.ui.permissions.microphone` for the per-fixture _meta story.")
+	common.WireRecipe(step4,
+		`curl -s -X POST `+serverURL+`/mcp \
+  -H "Mcp-Session-Id: $SID" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: text/event-stream, application/json' \
+  -d '{"jsonrpc":"2.0","id":4,"method":"resources/read","params":{"uri":"ui://budget-allocator/mcp-app.html"}}' \
+  | jq '.result.contents[0] | { mimeType, bytes: (.text | length), _meta }'`,
+		`var raw struct {
+    Contents []struct {
+        URI      string          `+"`json:\"uri\"`"+`
+        MimeType string          `+"`json:\"mimeType\"`"+`
+        Text     string          `+"`json:\"text\"`"+`
+        Meta     json.RawMessage `+"`json:\"_meta\"`"+`
+    } `+"`json:\"contents\"`"+`
+}
+res, _ := c.Call("resources/read", map[string]any{
+    "uri": "ui://budget-allocator/mcp-app.html",
+})
+json.Unmarshal(res.Raw, &raw)
+fmt.Printf("mimeType: %s\n", raw.Contents[0].MimeType)
+fmt.Printf("bytes:    %d\n", len(raw.Contents[0].Text))
+fmt.Printf("_meta:    %s\n", string(raw.Contents[0].Meta))`,
+	).Run(func(ctx demokit.StepContext) *demokit.StepResult {
+		res, err := c.Call("resources/read", map[string]any{
+			"uri": "ui://budget-allocator/mcp-app.html",
 		})
+		if err != nil {
+			fmt.Printf("    ERROR: %v\n", err)
+			return nil
+		}
+		var raw struct {
+			Contents []struct {
+				URI      string          `json:"uri"`
+				MimeType string          `json:"mimeType"`
+				Text     string          `json:"text"`
+				Meta     json.RawMessage `json:"_meta"`
+			} `json:"contents"`
+		}
+		if err := json.Unmarshal(res.Raw, &raw); err != nil {
+			fmt.Printf("    ERROR decoding resources/read: %v\n", err)
+			return nil
+		}
+		if len(raw.Contents) == 0 {
+			fmt.Printf("    no contents returned\n")
+			return nil
+		}
+		c0 := raw.Contents[0]
+		fmt.Printf("    uri:      %s\n", c0.URI)
+		fmt.Printf("    mimeType: %s\n", c0.MimeType)
+		fmt.Printf("    bytes:    %d  (iframe HTML+JS bundle)\n", len(c0.Text))
+		if len(c0.Meta) > 0 {
+			pretty, _ := json.MarshalIndent(json.RawMessage(c0.Meta), "      ", "  ")
+			fmt.Printf("    _meta:\n      %s\n", string(pretty))
+		} else {
+			fmt.Printf("    _meta:    <none>  (no csp / permissions declared)\n")
+		}
+		return nil
+	})
+
+	demo.Section("What the App iframe does with all this",
+		"This is the point where a Go-only scripted host hits its limit: everything from here runs in the iframe's JavaScript via the MCP Apps bridge, not over the MCP wire. A reader walking this section learns where the server-side story ends and the app-side story begins.",
+		"",
+		"When `make demo-app EXAMPLE=budget-allocator` runs this fixture inside basic-host, the host:",
+		"",
+		"1. Calls `tools/call get-budget-data` exactly as step 3 above.",
+		"2. Reads `ui://budget-allocator/mcp-app.html` exactly as step 4 above.",
+		"3. Renders the iframe in a sandbox, loads the JS bundle, and pushes the tool result into the iframe via the [mcp-app-bridge](https://github.com/modelcontextprotocol/ext-apps/blob/main/src/app-bridge.ts) `postMessage` channel.",
+		"",
+		"Inside the iframe — which is what you saw in step 4's bytes — the App SDK then:",
+		"",
+		"- Receives the tool result via `app.ontoolresult` and unpacks `result.structuredContent` into the typed `BudgetDataResponse` shape. The categories / sliders / chart are bound directly to that data.",
+		"- Registers **five app-side tools** that the model can call back through the bridge: `get-allocations`, `set-allocation`, `set-total-budget`, `set-company-stage`, `get-benchmark-comparison`. None of these are visible from a direct server-side `tools/list` (you can confirm by re-reading step 2's output) — they live in the iframe's runtime and the bridge proxies them to the host.",
+		"- Calls `app.updateModelContext()` after every UI interaction to push the current allocation state back to the model, so a next-turn LLM prompt sees the updated budget.",
+		"",
+		"The protocol surface a Go-only host sees (steps 1-4) is the *floor* of an MCP Apps interaction. The app-side bridge dance is the part that makes Budget Allocator a *widget* and not just a JSON tool result.",
+	)
+
+	demo.Section("Where to look in the code",
+		"- `main.go` — the fixture is one TypedAppTool (~100 lines plus the LCG'd historical data). The whole nested output reflects from the `budgetDataOutput` struct + maps.",
+		"- `walkthrough.go` — this file. Each step's curl + Go recipe is the canonical wire reproduction.",
+		"- `../README.md` — narrative + screenshots + the [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) guide.",
+		"- Upstream's iframe source: `/tmp/ext-apps/examples/budget-allocator-server/src/mcp-app.ts` — the JS that consumes `ontoolresult` and registers the five app-side tools. Worth a read to see the bridge dance end-to-end.",
+	)
+
+	_ = step1
+	_ = step2
+	_ = step3
+	_ = step4
 
 	common.SetupRenderer(demo)
 	demo.Execute()
+}
+
+// lengthOf is a small helper for printing the size of a nested array field
+// without panicking on missing keys / wrong types. Returns 0 when the key
+// is absent or the value isn't a JSON array.
+func lengthOf(m map[string]any, key string) int {
+	if v, ok := m[key].([]any); ok {
+		return len(v)
+	}
+	return 0
 }

--- a/examples/apps/compat/budget-allocator/walkthrough.trace.json
+++ b/examples/apps/compat/budget-allocator/walkthrough.trace.json
@@ -1,0 +1,45 @@
+[
+  {
+    "kind": "section",
+    "title": "Setup",
+    "body": "Start the MCP server in a separate terminal first:\n\n```\nTerminal 1:  make serve         # mcpkit-Go fixture on :3101\nTerminal 2:  make demo          # this walkthrough (--tui for interactive TUI)\n```\n\nAny MCP host can connect to the running server (Claude Desktop, VS Code, MCPJam, basic-host). The walkthrough below acts as a scripted host that issues the protocol calls directly through `*mcpkit/client.Client` — no LLM, no browser, no JS. The same protocol calls drive the iframe when you run `make demo-app EXAMPLE=budget-allocator` in basic-host (see the [centralized guide](../README.md#other-ways-to-test-a-fixture))."
+  },
+  {
+    "kind": "step",
+    "title": "Connect to the fixture",
+    "step_id": "step-1",
+    "visit": 1,
+    "output": "    connected to Budget Allocator Server 1.0.0\n"
+  },
+  {
+    "kind": "step",
+    "title": "tools/list — verify get-budget-data + its UI resource",
+    "step_id": "step-2",
+    "visit": 1,
+    "output": "    get-budget-data\n      _meta: {\n        \"ui\": {\n          \"resourceUri\": \"ui://budget-allocator/mcp-app.html\"\n        },\n        \"ui/resourceUri\": \"ui://budget-allocator/mcp-app.html\"\n      }\n"
+  },
+  {
+    "kind": "step",
+    "title": "tools/call get-budget-data — the rich nested payload",
+    "step_id": "step-3",
+    "visit": 1,
+    "output": "    structuredContent shape:\n      config.categories       = 5 entries\n      config.presetBudgets    = 4 entries\n      config.defaultBudget    = 100000\n      config.currency         = USD\n      analytics.history       = 24 months\n      analytics.benchmarks    = 4 stages\n      analytics.stages        = 4 names\n      analytics.defaultStage  = Series A\n"
+  },
+  {
+    "kind": "step",
+    "title": "resources/read — the iframe HTML the App ships in",
+    "step_id": "step-4",
+    "visit": 1,
+    "output": "    uri:      ui://budget-allocator/mcp-app.html\n    mimeType: text/html;profile=mcp-app\n    bytes:    553966  (iframe HTML+JS bundle)\n    _meta:    \u003cnone\u003e  (no csp / permissions declared)\n"
+  },
+  {
+    "kind": "section",
+    "title": "What the App iframe does with all this",
+    "body": "This is the point where a Go-only scripted host hits its limit: everything from here runs in the iframe's JavaScript via the MCP Apps bridge, not over the MCP wire. A reader walking this section learns where the server-side story ends and the app-side story begins.\n\nWhen `make demo-app EXAMPLE=budget-allocator` runs this fixture inside basic-host, the host:\n\n1. Calls `tools/call get-budget-data` exactly as step 3 above.\n2. Reads `ui://budget-allocator/mcp-app.html` exactly as step 4 above.\n3. Renders the iframe in a sandbox, loads the JS bundle, and pushes the tool result into the iframe via the [mcp-app-bridge](https://github.com/modelcontextprotocol/ext-apps/blob/main/src/app-bridge.ts) `postMessage` channel.\n\nInside the iframe — which is what you saw in step 4's bytes — the App SDK then:\n\n- Receives the tool result via `app.ontoolresult` and unpacks `result.structuredContent` into the typed `BudgetDataResponse` shape. The categories / sliders / chart are bound directly to that data.\n- Registers **five app-side tools** that the model can call back through the bridge: `get-allocations`, `set-allocation`, `set-total-budget`, `set-company-stage`, `get-benchmark-comparison`. None of these are visible from a direct server-side `tools/list` (you can confirm by re-reading step 2's output) — they live in the iframe's runtime and the bridge proxies them to the host.\n- Calls `app.updateModelContext()` after every UI interaction to push the current allocation state back to the model, so a next-turn LLM prompt sees the updated budget.\n\nThe protocol surface a Go-only host sees (steps 1-4) is the *floor* of an MCP Apps interaction. The app-side bridge dance is the part that makes Budget Allocator a *widget* and not just a JSON tool result."
+  },
+  {
+    "kind": "section",
+    "title": "Where to look in the code",
+    "body": "- `main.go` — the fixture is one TypedAppTool (~100 lines plus the LCG'd historical data). The whole nested output reflects from the `budgetDataOutput` struct + maps.\n- `walkthrough.go` — this file. Each step's curl + Go recipe is the canonical wire reproduction.\n- `../README.md` — narrative + screenshots + the [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) guide.\n- Upstream's iframe source: `/tmp/ext-apps/examples/budget-allocator-server/src/mcp-app.ts` — the JS that consumes `ontoolresult` and registers the five app-side tools. Worth a read to see the bridge dance end-to-end."
+  }
+]


### PR DESCRIPTION
## What changes

Replaces budget-allocator's Phase 1 stub walkthrough (Connect + tools/list) with a real one that exercises the full server-side surface end-to-end and then has a narrative Section painting the app-side picture a Go-only scripted host can't directly drive. The narrative is the load-bearing piece: it spells out the bridge dance that makes Budget Allocator a *widget* and not just a JSON tool result.

Trace recorded against the live fixture (no `connection refused` strings); bundle/ regenerated; README gains the `## Run Pre-Recorded` play link.

## Reviewer's guide

1. [examples/apps/compat/budget-allocator/walkthrough.go](https://github.com/panyam/mcpkit/pull/691/files#diff-0c5d63dabed7358b81404c62d4beae4e9ba852863114434204598081d5652050) — the rewrite. Four wire-level steps (initialize → tools/list → tools/call get-budget-data → resources/read on the iframe HTML) plus two narrative Sections (the app-side bridge dance + code pointers). Each wire step attaches the curl + Go-client recipe via `common.WireRecipe`. The "What the App iframe does with all this" section is the differentiator — it explicitly names the FIVE app-side tools the iframe registers via the bridge (`get-allocations`, `set-allocation`, `set-total-budget`, `set-company-stage`, `get-benchmark-comparison`), the `ontoolresult` handler that unpacks `structuredContent`, and the `updateModelContext` calls that push UI state back to the model.
2. [examples/apps/compat/budget-allocator/walkthrough.trace.json](https://github.com/panyam/mcpkit/pull/691/files#diff-8b3a7b800c9a9bb6e57bb67154a1b152b522b07cc9be72a880b0d4f8a747b854) — recorded trace.
3. [examples/apps/compat/budget-allocator/bundle/index.html](https://github.com/panyam/mcpkit/pull/691/files#diff-d9ce1fca43544f6deceac55a9961ed3c15bd077c62475eec5c9e84cca2ba21bb) — playable HTML. Other files in `bundle/` are demokit's player runtime (identical across fixtures).
4. [examples/apps/compat/budget-allocator/README.md](https://github.com/panyam/mcpkit/pull/691/files#diff-398060f3c462889ab3d2f4b1472dba1578e75e194ac96c6cd82b6a398f4e8b1f) — adds `## Run Pre-Recorded` between `## What it Shows` and `## Or Run Live`. Same shape as the other Phase 2 fixtures.

## Decision log

- **Narrative Section instead of trying to drive the bridge.** A scripted Go host has no JS runtime and no postMessage channel to basic-host's iframe, so it physically can't call `app.registerTool`-registered tools. Faking it would lie about the wire. Naming the bridge dance in prose, with the exact tool names + handler hooks, gives readers the conceptual scaffolding to recognize the same dance when they trace it through basic-host later.
- **Step 3 prints structuredContent SHAPE, not the full payload.** The full payload is ~5KB (24 months × 5 categories of allocations + per-stage benchmark bands). Dumping it would drown the wire detail; printing the shape (category count / history months / benchmark stages / default values) makes the "deeply nested but cleanly reflected from Go structs" story visible without the noise.
- **Step 4 reports just byte count for the iframe body.** Same rationale: the iframe is upstream's verbatim bundled JS+HTML (~30KB+), and dumping it would obscure the `_meta` block which is the only fixture-specific wire content. Calling out that this fixture's `_meta` is currently bare (with cross-refs to sheet-music's CSP block and transcript's permissions block) makes the per-fixture `_meta` story discoverable.

## Out of scope (deliberately deferred)

- Other Phase 1 stubs that still need real walkthroughs (debug-server, integration, map, pdf-server, system-monitor, threejs, wiki-explorer, shadertoy, scenario-modeler, cohort-heatmap, customer-segmentation, quickstart). Same pattern; one PR per fixture per the convention from PR 618.
- Wiring the budget-allocator iframe's missing `_meta` block (if any) — separate issue if/when the parity audit surfaces one. The walkthrough's step 4 already calls out that the `_meta` is currently bare so a future fix lands in a visible place.
