### PR TITLE
ext/auth: trace JWT validation — auth.jwks_lookup sub-span + mcp.auth.* active-span attrs (issue 658)

### DIFF
--- a/ext/auth/docs/DESIGN.md
+++ b/ext/auth/docs/DESIGN.md
@@ -507,3 +507,31 @@ MCPKit's JWTValidator supports any algorithm the JWKS key store provides (RS256,
 The validated-token cache (`JWTValidator.CacheTTL`) mitigates verification cost for repeated tokens in steady-state. But cold starts, cache misses, and high-cardinality token scenarios (many distinct users) still hit the verification path, where ES256 has a clear advantage.
 
 **Caveat**: RS256 remains the default signing algorithm in most identity providers (including Keycloak, as configured in our test realm). Switching to ES256 requires explicit authorization server configuration. Consult your IdP documentation for key generation and algorithm settings.
+
+## Tracing (SEP-414 P6, issue 658)
+
+`JWTConfig.TracerProvider` opts the validator into SEP-414 instrumentation. Nil (or `core.NoopTracerProvider{}`, the default) means zero spans, zero attributes, zero allocation added — and zero compile-time dependency on `ext/otel`; the validator codes against `core.TracerProvider` only.
+
+What's emitted when a `TracerProvider` is wired:
+
+- **`auth.jwks_lookup` sub-span** — wraps each `JWKSKeyStore.GetKeyByKid` call from `jwksKeyFuncCtx`. Carries the `mcp.auth.jwks.kid` attribute. Surfaces both cache-hit and cache-miss latency through the OTel adapter — oneauth's `JWKSKeyStore` owns the internal HTTP fetch decision, so we measure the call to the store (where `ext/auth`'s responsibility ends), not the fetch itself.
+
+- **`mcp.auth.*` attributes on the active dispatch span** (the outer span the SEP-414 P2 trace middleware started; reached via `core.SpanFromContext(r.Context())`):
+  - `mcp.auth.method = "jwt"` — set unconditionally at the top of `Validate`, even on failure paths, so a failed auth still shows up as "we attempted JWT validation here".
+  - `mcp.auth.subject` — the `sub` claim of the validated JWT.
+  - `mcp.auth.issuer` — the `iss` claim.
+  - `mcp.auth.scopes` — comma-joined granted scopes (one searchable attribute in Tempo's TraceQL; per-element indexing reserved for if/when consumers ask).
+  - `mcp.auth.cache_hit` — `"true"` on token-cache fast-path hits, `"false"` after a full validation. Both branches emit so cache effectiveness is visible without a separate metric.
+
+When no active dispatch span is present (auth running outside a traced path), `core.SpanFromContext` returns a no-op span and every `SetAttribute` is a no-op — no nil-checking required at the call site.
+
+### Documented limitation: transport-level 401 is not traced
+
+If the streamable transport rejects a request before the dispatch span starts (e.g., a malformed `Authorization` header caught at transport setup), the rejection happens **before** the SEP-414 P2 trace middleware runs, so there's no active span to decorate and no parent for an `auth.*` sub-span. That 401 is invisible in trace data today. Adding a transport-level span purely for rejected auth would change the spine semantics of "one inbound span per JSON-RPC dispatch" — deferred until a real adopter reports it as a missing signal.
+
+### What's deliberately deferred
+
+- **`auth.introspect` sub-span (RFC 7662 token introspection)** — no introspection validator exists in `ext/auth` today. Will land when that surface does.
+- **`auth.oauth_exchange` sub-span** — outbound OAuth token-exchange flow (`client_credentials.go` / `enterprise_managed.go`) is a client-side `TokenSource` path with its own instrumentation arc.
+- **Outbound `traceparent` HTTP header on the JWKS fetch** — `keys.JWKSKeyStore` (in oneauth) owns the HTTP call, so ext/auth can't inject `traceparent` without an oneauth-side option. Tracked as a separate oneauth ticket; once landed, oneauth-internal work appears as a child of the `auth.jwks_lookup` span we already emit.
+- **`scope_middleware.go` (`auth.NewToolScopeMiddleware`)** — scope enforcement is a separate concern from token validation; a follow-up ticket can decorate its decision points with `mcp.auth.scope.required` / `mcp.auth.scope.granted` attributes.

--- a/ext/auth/jwt_validator.go
+++ b/ext/auth/jwt_validator.go
@@ -71,6 +71,15 @@ type JWTValidator struct {
 	// tokenCache stores validated claims keyed by SHA-256 hash of the token.
 	// Lazy eviction: expired entries are removed on access, not by background goroutine.
 	tokenCache conc.SyncMap[string, *cachedClaims]
+
+	// tp optionally instruments Validate() with sub-spans for the
+	// latency-bearing JWKS lookup AND active-span attributes
+	// (mcp.auth.method / subject / issuer / scopes / cache_hit) on
+	// the dispatch span set up by server.WithTracerProvider. Defaults
+	// to core.NoopTracerProvider{} — see ensureTP — so all the
+	// instrumentation call sites can unconditionally call StartSpan
+	// without nil-checking. Configured via JWTConfig.TracerProvider.
+	tp mcpcore.TracerProvider
 }
 
 // cachedClaims wraps claims with an expiry time for TTL-based caching.
@@ -100,6 +109,16 @@ type JWTConfig struct {
 	// AllScopes is the complete set of scopes this server supports.
 	// Included in WWW-Authenticate 401 headers for client scope selection.
 	AllScopes []string
+
+	// TracerProvider optionally enables SEP-414 instrumentation of
+	// token validation: a sub-span per JWKS key lookup plus
+	// mcp.auth.* attributes (method / subject / issuer / scopes /
+	// cache_hit) on the active dispatch span set up by
+	// server.WithTracerProvider. Nil (or core.NoopTracerProvider{})
+	// is the default — zero spans, zero attributes, zero allocation
+	// added to the validation path. ext/auth depends on the core
+	// abstraction only; no compile-time dependency on ext/otel.
+	TracerProvider mcpcore.TracerProvider
 }
 
 // NewJWTValidator creates a JWTValidator backed by oneauth's JWT validation
@@ -113,12 +132,18 @@ func NewJWTValidator(cfg JWTConfig) *JWTValidator {
 	}
 	auth.ClientKeyStore = ks
 
+	tp := cfg.TracerProvider
+	if tp == nil {
+		tp = mcpcore.NoopTracerProvider{}
+	}
+
 	return &JWTValidator{
 		auth:                auth,
 		ks:                  ks,
 		ResourceMetadataURL: cfg.ResourceMetadataURL,
 		RequiredScopes:      cfg.RequiredScopes,
 		AllScopes:           cfg.AllScopes,
+		tp:                  tp,
 	}
 }
 
@@ -126,6 +151,15 @@ func NewJWTValidator(cfg JWTConfig) *JWTValidator {
 // Extracts the Bearer token, validates signature/issuer/audience/expiry via oneauth,
 // checks required scopes, and stashes parsed claims for Claims() to read.
 func (v *JWTValidator) Validate(r *http.Request) error {
+	ctx := r.Context()
+
+	// Stamp the auth method on the active dispatch span before any
+	// branch that can early-return — even auth FAILURES should leave
+	// the span carrying "we attempted JWT validation here." Noop
+	// provider's SpanFromContext returns a no-op span, so SetAttribute
+	// is a no-op when there's no active span; no nil-check needed.
+	mcpcore.SpanFromContext(ctx).SetAttribute("mcp.auth.method", "jwt")
+
 	// Extract Bearer token
 	authHeader := r.Header.Get("Authorization")
 	const prefix = "Bearer "
@@ -141,6 +175,7 @@ func (v *JWTValidator) Validate(r *http.Request) error {
 			if time.Now().Before(cached.expiry) {
 				// Cache hit — stash claims for Claims() and return
 				v.recentClaims.Store(token, cached.claims)
+				v.stampClaimsAttrs(ctx, cached.claims, true)
 				return nil
 			}
 			// Expired — remove and fall through to full validation
@@ -151,7 +186,7 @@ func (v *JWTValidator) Validate(r *http.Request) error {
 	// Validate JWT with kid-based JWKS key lookup. We use jwt.Parse directly
 	// with a custom keyfunc because APIAuth.ValidateAccessTokenFull only supports
 	// fixed keys, not kid-based KeyStore lookup needed for JWKS.
-	parsed, err := jwt.Parse(token, v.jwksKeyFunc)
+	parsed, err := jwt.Parse(token, v.jwksKeyFuncCtx(ctx))
 	if err != nil {
 		return v.unauthorized("invalid token: " + err.Error())
 	}
@@ -244,6 +279,12 @@ func (v *JWTValidator) Validate(r *http.Request) error {
 		claims.Audience = []string{v.auth.JWTAudience}
 	}
 
+	// Stamp the resolved principal info on the active dispatch span
+	// once the claims are extracted. cache_hit=false because we just
+	// did the full crypto path; the cache-hit branch above sets it to
+	// true.
+	v.stampClaimsAttrs(ctx, claims, false)
+
 	// Cache claims by token so Claims(r) can retrieve them without re-parsing.
 	// This avoids the fragile *r = *r.WithContext(...) pattern.
 	v.recentClaims.Store(token, claims)
@@ -294,28 +335,70 @@ func (v *JWTValidator) Claims(r *http.Request) *mcpcore.Claims {
 	return nil
 }
 
-// jwksKeyFunc resolves the verification key for a JWT by looking up the kid
-// header in the JWKS key store. This enables RS256/ES256 token verification
-// via dynamically fetched JWKS keys.
-func (v *JWTValidator) jwksKeyFunc(token *jwt.Token) (any, error) {
-	kid, ok := token.Header["kid"].(string)
-	if !ok || kid == "" {
-		return nil, fmt.Errorf("missing kid header")
+// jwksKeyFuncCtx returns a jwt.Keyfunc closure that resolves the
+// verification key for a JWT by looking up the kid header in the
+// JWKS key store. The closure captures ctx so the JWKS lookup can
+// span-wrap via the configured TracerProvider — jwt-go's Keyfunc
+// signature has no ctx parameter, hence the closure.
+//
+// The auth.jwks_lookup sub-span wraps each GetKeyByKid call and
+// surfaces both cache-hit and cache-miss latency through the OTel
+// adapter — oneauth's JWKSKeyStore owns the HTTP fetch decision
+// internally, so we measure the call to the store (which is what
+// ext/auth's responsibility ends at), not the fetch itself. When
+// oneauth grows its own observability (separate ticket), the
+// store's internal HTTP work appears as a child of this span.
+func (v *JWTValidator) jwksKeyFuncCtx(ctx context.Context) jwt.Keyfunc {
+	return func(token *jwt.Token) (any, error) {
+		kid, ok := token.Header["kid"].(string)
+		if !ok || kid == "" {
+			return nil, fmt.Errorf("missing kid header")
+		}
+		spanCtx, span := v.tp.StartSpan(ctx, "auth.jwks_lookup",
+			mcpcore.Attribute{Key: "mcp.auth.jwks.kid", Value: kid},
+		)
+		rec, err := v.ks.GetKeyByKid(spanCtx, &keys.GetKeyByKidRequest{Kid: kid})
+		if err != nil {
+			span.RecordError(err)
+			span.End()
+			return nil, fmt.Errorf("key not found for kid %q: %w", kid, err)
+		}
+		span.End()
+		// oneauth 0.1.9 (#217): GetKeyByKidResponse wraps a *KeyRecord rather
+		// than inlining its fields. Access fields via Record.
+		if rec == nil || rec.Record == nil {
+			return nil, fmt.Errorf("key not found for kid %q", kid)
+		}
+		alg, _ := token.Header["alg"].(string)
+		if alg != rec.Record.Algorithm {
+			return nil, fmt.Errorf("algorithm mismatch: token has %s, key expects %s", alg, rec.Record.Algorithm)
+		}
+		return utils.DecodeVerifyKey(rec.Record.Key, rec.Record.Algorithm)
 	}
-	rec, err := v.ks.GetKeyByKid(context.Background(), &keys.GetKeyByKidRequest{Kid: kid})
-	if err != nil {
-		return nil, fmt.Errorf("key not found for kid %q: %w", kid, err)
+}
+
+// stampClaimsAttrs sets the mcp.auth.* attributes on the active
+// dispatch span carried by ctx. Called from both the cache-hit fast
+// path and the post-validation slow path. When no active span is
+// present (Noop provider), SpanFromContext returns a no-op span and
+// every SetAttribute is a no-op — single call site, no nil-check.
+//
+// cacheHit distinguishes the two callers: true from the cache-hit
+// branch, false from the post-validation branch.
+func (v *JWTValidator) stampClaimsAttrs(ctx context.Context, claims *mcpcore.Claims, cacheHit bool) {
+	span := mcpcore.SpanFromContext(ctx)
+	span.SetAttribute("mcp.auth.subject", claims.Subject)
+	if claims.Issuer != "" {
+		span.SetAttribute("mcp.auth.issuer", claims.Issuer)
 	}
-	// oneauth 0.1.9 (#217): GetKeyByKidResponse wraps a *KeyRecord rather
-	// than inlining its fields. Access fields via Record.
-	if rec == nil || rec.Record == nil {
-		return nil, fmt.Errorf("key not found for kid %q", kid)
+	if len(claims.Scopes) > 0 {
+		span.SetAttribute("mcp.auth.scopes", strings.Join(claims.Scopes, ","))
 	}
-	alg, _ := token.Header["alg"].(string)
-	if alg != rec.Record.Algorithm {
-		return nil, fmt.Errorf("algorithm mismatch: token has %s, key expects %s", alg, rec.Record.Algorithm)
+	if cacheHit {
+		span.SetAttribute("mcp.auth.cache_hit", "true")
+	} else {
+		span.SetAttribute("mcp.auth.cache_hit", "false")
 	}
-	return utils.DecodeVerifyKey(rec.Record.Key, rec.Record.Algorithm)
 }
 
 // unauthorized returns an AuthError with 401 and a WWW-Authenticate header

--- a/ext/auth/jwt_validator_trace_test.go
+++ b/ext/auth/jwt_validator_trace_test.go
@@ -1,0 +1,303 @@
+package auth
+
+import (
+	"context"
+	"crypto/rsa"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	mcpcore "github.com/panyam/mcpkit/core"
+	"github.com/panyam/oneauth/keys"
+	"github.com/panyam/oneauth/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeSpan + fakeTracerProvider mirror server/trace_middleware_test.go's
+// shape so the JWT-validator instrumentation tests can assert span
+// emission and attribute placement without pulling in the OTel SDK
+// (ext/auth's whole point is depending on the core abstraction only).
+type fakeSpan struct {
+	name   string
+	parent mcpcore.Span
+	attrs  map[string]string
+	errors []error
+	ended  bool
+}
+
+func (s *fakeSpan) End()                            { s.ended = true }
+func (s *fakeSpan) SetAttribute(k, v string)        { s.attrs[k] = v }
+func (s *fakeSpan) RecordError(err error)           { s.errors = append(s.errors, err) }
+func (s *fakeSpan) AddLink(mcpcore.Link)            {}
+
+type fakeTracerProvider struct {
+	mu    sync.Mutex
+	spans []*fakeSpan
+}
+
+func (p *fakeTracerProvider) StartSpan(ctx context.Context, name string, attrs ...mcpcore.Attribute) (context.Context, mcpcore.Span) {
+	parent := mcpcore.SpanFromContext(ctx)
+	sp := &fakeSpan{
+		name:   name,
+		parent: parent,
+		attrs:  make(map[string]string, len(attrs)),
+	}
+	for _, a := range attrs {
+		sp.attrs[a.Key] = a.Value
+	}
+	p.mu.Lock()
+	p.spans = append(p.spans, sp)
+	p.mu.Unlock()
+	return mcpcore.WithActiveSpan(ctx, sp), sp
+}
+
+func (p *fakeTracerProvider) snapshot() []*fakeSpan {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]*fakeSpan, len(p.spans))
+	copy(out, p.spans)
+	return out
+}
+
+func (p *fakeTracerProvider) findSpan(name string) *fakeSpan {
+	for _, sp := range p.snapshot() {
+		if sp.name == name {
+			return sp
+		}
+	}
+	return nil
+}
+
+// requestWithActiveSpan returns an *http.Request whose ctx carries the
+// supplied active span — simulates the position the SEP-414 P2 trace
+// middleware leaves the dispatch span in by the time auth runs.
+func requestWithActiveSpan(token string, span mcpcore.Span) *http.Request {
+	r := httptest.NewRequest("POST", "/mcp", nil)
+	if token != "" {
+		r.Header.Set("Authorization", "Bearer "+token)
+	}
+	if span != nil {
+		r = r.WithContext(mcpcore.WithActiveSpan(r.Context(), span))
+	}
+	return r
+}
+
+// seedCachedClaims primes the validator's token cache so subsequent
+// Validate(token) takes the cache-hit fast path — exercises the
+// active-span attribute branch without needing real JWKS/RSA wiring.
+func seedCachedClaims(v *JWTValidator, token string, claims *mcpcore.Claims) {
+	v.tokenCache.Store(hashToken(token), &cachedClaims{
+		claims: claims,
+		expiry: time.Now().Add(time.Hour),
+	})
+}
+
+func TestJWTValidator_Trace_NilTracerProvider_NoSpans(t *testing.T) {
+	v := NewJWTValidator(JWTConfig{
+		Issuer:   "https://test.example.com",
+		Audience: "https://mcp.test",
+		// TracerProvider intentionally omitted — must default to Noop.
+	})
+	v.CacheTTL = time.Minute
+	seedCachedClaims(v, "cached.token.value", &mcpcore.Claims{Subject: "u1"})
+
+	// No active span on the request ctx — exercises the "no parent
+	// to decorate" branch in stampClaimsAttrs.
+	r := requestWithActiveSpan("cached.token.value", nil)
+	require.NoError(t, v.Validate(r))
+	// No assertion possible beyond "didn't panic" — the test's value
+	// is the safety contract: nil TracerProvider must not crash.
+}
+
+func TestJWTValidator_Trace_NoopTracerProvider_NoSpans(t *testing.T) {
+	v := NewJWTValidator(JWTConfig{
+		Issuer:         "https://test.example.com",
+		Audience:       "https://mcp.test",
+		TracerProvider: mcpcore.NoopTracerProvider{},
+	})
+	v.CacheTTL = time.Minute
+	seedCachedClaims(v, "cached.token.value", &mcpcore.Claims{Subject: "u1"})
+
+	r := requestWithActiveSpan("cached.token.value", nil)
+	require.NoError(t, v.Validate(r))
+	// Noop path produces no observable spans — the test's value is
+	// confirming the Noop wiring doesn't accidentally fall through to
+	// nil-deref behavior the nil-TP test above doesn't cover.
+}
+
+func TestJWTValidator_Trace_CacheHit_StampsActiveSpanAttributes(t *testing.T) {
+	tp := &fakeTracerProvider{}
+	v := NewJWTValidator(JWTConfig{
+		Issuer:         "https://test.example.com",
+		Audience:       "https://mcp.test",
+		TracerProvider: tp,
+	})
+	v.CacheTTL = time.Minute
+
+	cached := &mcpcore.Claims{
+		Subject: "alice",
+		Issuer:  "https://test.example.com",
+		Scopes:  []string{"read", "write"},
+	}
+	seedCachedClaims(v, "cached.token.value", cached)
+
+	// Start an outer "dispatch" span via the fake provider — mimics
+	// the SEP-414 P2 trace middleware's outermost span. Validate must
+	// stamp the mcp.auth.* attributes on THIS span, not a child.
+	_, dispatchSpan := tp.StartSpan(context.Background(), "dispatch")
+	r := requestWithActiveSpan("cached.token.value", dispatchSpan)
+	require.NoError(t, v.Validate(r))
+
+	parent := dispatchSpan.(*fakeSpan)
+	assert.Equal(t, "jwt", parent.attrs["mcp.auth.method"],
+		"mcp.auth.method must land on the active dispatch span")
+	assert.Equal(t, "alice", parent.attrs["mcp.auth.subject"])
+	assert.Equal(t, "https://test.example.com", parent.attrs["mcp.auth.issuer"])
+	assert.Equal(t, "read,write", parent.attrs["mcp.auth.scopes"],
+		"scopes encoded as comma-joined string (one searchable attr in Tempo)")
+	assert.Equal(t, "true", parent.attrs["mcp.auth.cache_hit"],
+		"cache-hit fast path must set cache_hit=true")
+
+	for _, sp := range tp.snapshot() {
+		assert.NotEqual(t, "auth.jwks_lookup", sp.name,
+			"cache-hit path must NOT emit a jwks_lookup span — that's the whole point of the cache")
+	}
+}
+
+func TestJWTValidator_Trace_FullValidate_EmitsJWKSLookupSpan(t *testing.T) {
+	jwksURL, issuer, token, cleanup := setupTestJWKS(t, "alice", []string{"read"})
+	defer cleanup()
+
+	tp := &fakeTracerProvider{}
+	v := NewJWTValidator(JWTConfig{
+		JWKSURL:        jwksURL,
+		Issuer:         issuer,
+		Audience:       "https://mcp.test",
+		TracerProvider: tp,
+	})
+
+	_, dispatchSpan := tp.StartSpan(context.Background(), "dispatch")
+	r := requestWithActiveSpan(token, dispatchSpan)
+	require.NoError(t, v.Validate(r))
+
+	jwksSpan := tp.findSpan("auth.jwks_lookup")
+	require.NotNil(t, jwksSpan, "full validate path must emit auth.jwks_lookup; spans were: %v", spanNames(tp.snapshot()))
+	assert.NotEmpty(t, jwksSpan.attrs["mcp.auth.jwks.kid"],
+		"jwks_lookup span must carry the kid being resolved")
+	assert.True(t, jwksSpan.ended, "jwks_lookup span must be ended (defer would leave it open under panic)")
+	assert.Same(t, dispatchSpan, jwksSpan.parent,
+		"jwks_lookup must be a child of the active dispatch span, not a top-level orphan")
+
+	parent := dispatchSpan.(*fakeSpan)
+	assert.Equal(t, "false", parent.attrs["mcp.auth.cache_hit"],
+		"first validate of an uncached token must set cache_hit=false")
+	assert.Equal(t, "alice", parent.attrs["mcp.auth.subject"])
+}
+
+func TestJWTValidator_Trace_FullValidate_NoActiveSpan_StillEmitsJWKSChild(t *testing.T) {
+	jwksURL, issuer, token, cleanup := setupTestJWKS(t, "alice", []string{"read"})
+	defer cleanup()
+
+	tp := &fakeTracerProvider{}
+	v := NewJWTValidator(JWTConfig{
+		JWKSURL:        jwksURL,
+		Issuer:         issuer,
+		Audience:       "https://mcp.test",
+		TracerProvider: tp,
+	})
+
+	// No outer dispatch span — simulates auth running outside a traced
+	// dispatch path (transport-level auth, or middleware ordered before
+	// the trace middleware). The jwks_lookup span still emits; the
+	// mcp.auth.* attributes go to a noop span and silently drop.
+	r := requestWithActiveSpan(token, nil)
+	require.NoError(t, v.Validate(r))
+
+	jwksSpan := tp.findSpan("auth.jwks_lookup")
+	require.NotNil(t, jwksSpan, "jwks_lookup must emit even without a dispatch-span parent")
+	assert.True(t, jwksSpan.ended)
+}
+
+// setupTestJWKS spins up an httptest server hosting a JWKS endpoint
+// backed by an oneauth in-memory key store, mints a signed JWT, and
+// returns the JWKS URL + issuer + token + cleanup. Keeps the
+// per-test fixture self-contained — examples/auth/common can't be
+// imported (it depends on ext/auth — would be a cycle).
+func setupTestJWKS(t *testing.T, subject string, scopes []string) (jwksURL, issuer, token string, cleanup func()) {
+	t.Helper()
+
+	privPEM, pubPEM, err := utils.GenerateRSAKeyPair(2048)
+	require.NoError(t, err)
+
+	parsed, err := utils.ParsePrivateKeyPEM(privPEM)
+	require.NoError(t, err)
+	privKey, ok := parsed.(*rsa.PrivateKey)
+	require.True(t, ok, "expected RSA private key")
+
+	const clientID = "test-key-1"
+	ks := keys.NewInMemoryKeyStore()
+	_, err = ks.PutKey(context.Background(), &keys.PutKeyRequest{
+		Record: &keys.KeyRecord{
+			ClientID:  clientID,
+			Key:       pubPEM,
+			Algorithm: "RS256",
+		},
+	})
+	require.NoError(t, err)
+
+	// KeyRecord.Kid is auto-computed from key material when PutKey
+	// stores it — NOT the ClientID. Read it back so the JWT we mint
+	// below carries a kid that matches what JWKSHandler publishes.
+	stored, err := ks.GetKey(context.Background(), &keys.GetKeyRequest{ClientID: clientID})
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	require.NotNil(t, stored.Record)
+	kid := stored.Record.Kid
+	require.NotEmpty(t, kid, "oneauth must compute a kid for the stored key")
+
+	mux := http.NewServeMux()
+	mux.Handle("GET /.well-known/jwks.json", &keys.JWKSHandler{KeyStore: ks})
+	ts := httptest.NewServer(mux)
+
+	jwksURL = ts.URL + "/.well-known/jwks.json"
+	issuer = "https://test.example.com"
+
+	claims := jwt.MapClaims{
+		"iss":    issuer,
+		"aud":    "https://mcp.test",
+		"sub":    subject,
+		"exp":    time.Now().Add(time.Hour).Unix(),
+		"iat":    time.Now().Unix(),
+		"scopes": scopes,
+	}
+	jwtTok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	jwtTok.Header["kid"] = kid
+	token, err = jwtTok.SignedString(privKey)
+	require.NoError(t, err)
+
+	// Sanity — confirm the public PEM is what we expect oneauth to
+	// publish. Catches a future PEM-format drift before the test
+	// fails with an obscure JWT verification error.
+	block, _ := pem.Decode(pubPEM)
+	require.NotNil(t, block, "public key PEM must decode")
+	require.True(t, strings.HasPrefix(block.Type, "PUBLIC") || strings.HasPrefix(block.Type, "RSA PUBLIC"),
+		"unexpected PEM block type: %s", block.Type)
+
+	cleanup = func() { ts.Close() }
+	return
+}
+
+func spanNames(spans []*fakeSpan) string {
+	names := make([]string, 0, len(spans))
+	for _, s := range spans {
+		names = append(names, s.name)
+	}
+	return fmt.Sprintf("%v", names)
+}


### PR DESCRIPTION
## What changes

Closes issue 658. First P6 surface child to land on the SEP-414 dispatch spine (umbrella #663). `JWTValidator` now opts into instrumentation via a new `JWTConfig.TracerProvider` field. With it wired, every authenticated request shows the principal info (`mcp.auth.subject` / `issuer` / `scopes` / `method` / `cache_hit`) on its dispatch span and emits an `auth.jwks_lookup` child for each JWKS key lookup. Nil and `core.NoopTracerProvider{}` produce zero spans, zero attributes, zero allocation on the validation path. ext/auth's dep on the core abstraction stays clean — no compile-time dependency on `ext/otel`.

```mermaid
sequenceDiagram
    participant C as Client
    participant Disp as Server dispatch
    participant V as JWTValidator
    participant KS as oneauth JWKSKeyStore

    C->>Disp: POST /mcp + Bearer JWT
    Note over Disp: span tools/call started by SEP-414 P2 trace middleware
    Disp->>V: Validate(r)
    Note over V: stamp mcp.auth.method=jwt on active dispatch span
    alt token cache hit
        Note over V: stamp mcp.auth.cache_hit=true
        Note over V: stamp subject, issuer, scopes on dispatch span
        V-->>Disp: nil — no JWKS lookup needed
    else cache miss
        V->>KS: StartSpan auth.jwks_lookup with kid attribute
        Note over KS: span auth.jwks_lookup is a child of dispatch span
        KS-->>V: KeyRecord
        Note over V: full JWT verify, extract sub iss scopes
        Note over V: stamp mcp.auth.cache_hit=false
        Note over V: stamp subject, issuer, scopes on dispatch span
        V-->>Disp: nil
    end
```

## Reviewer's guide

Read in this order:

1. [ext/auth/jwt_validator.go](https://github.com/panyam/mcpkit/pull/694/files#diff-e6c5bfccc6d222d3735a5835e709c9f8ad03ca99e4739143cbcc146154806a87) — three diffs to track: (a) new `JWTConfig.TracerProvider` field + matching `*JWTValidator.tp` storage (defaults to `core.NoopTracerProvider{}` in `NewJWTValidator` so the instrumentation call sites never need nil-checks); (b) instrumentation inside `Validate` (early `mcp.auth.method` stamp on the active span, then either cache-hit-branch `stampClaimsAttrs(cacheHit=true)` or full-path `stampClaimsAttrs(cacheHit=false)`); (c) `jwksKeyFunc` method replaced by `jwksKeyFuncCtx(ctx)` closure that captures ctx for the `auth.jwks_lookup` span boundary — needed because jwt-go's `Keyfunc` signature has no ctx param.
2. [ext/auth/jwt_validator_trace_test.go](https://github.com/panyam/mcpkit/pull/694/files#diff-3901668eec67863f21ed4d454064d67d5e63ba7793158080588cf3f4afeeed85) — 5 tests against a local `fakeTracerProvider` mirroring `server/trace_middleware_test.go`'s shape (no OTel SDK dep). `setupTestJWKS` helper at the bottom builds a minimal RSA + JWKS fixture via httptest + oneauth's `InMemoryKeyStore` + `JWKSHandler`. **Note the load-bearing kid lookup** at the end of the helper — `KeyRecord.Kid` is auto-computed from key material by oneauth, NOT the `ClientID` we pass in, so the JWT we mint has to use the read-back computed kid.
3. [ext/auth/docs/DESIGN.md](https://github.com/panyam/mcpkit/pull/694/files#diff-03a5078f128c638aca27e780bfd0c762d7a6122a8867f7df0c519ffb23c54698) — new "Tracing (SEP-414 P6, issue 658)" section documenting what's instrumented, what's deliberately deferred, and the transport-level 401 limitation that's mentioned in issue 658.

Skim or skip: nothing — single-purpose PR.

## Decision log

| Decision | Choice | Alternative | Why |
|---|---|---|---|
| TracerProvider plumbing | Field on `JWTConfig` | Functional `WithTracerProvider(tp)` option | `JWTConfig` is already struct-shaped with optional fields — one more field fits the precedent. No option-pattern infrastructure exists in the package today. |
| Default to `NoopTracerProvider` internally | Yes (in `NewJWTValidator`) | Keep nil and add nil-checks at every call site | Single normalization at construction means `v.tp.StartSpan(...)` and `core.SpanFromContext(ctx).SetAttribute(...)` are unconditionally safe at every call site. Cleaner than scattered `if v.tp != nil` guards. |
| No `auth.validate` parent span | Decorate the dispatch span directly | Wrap Validate in its own span | Issue 658 says "attributes on the active dispatch span" + "child spans for the latency-bearing steps". A wrapper span would nest pointlessly — the dispatch span already covers Validate's whole duration. |
| `mcp.auth.method` stamped early | Before any early-return | Only after successful validation | Failed auth should still show "we attempted JWT validation here" in the trace — distinguishes "no auth attempted" from "auth attempted and failed". |
| Scopes attribute encoding | Comma-joined string | Indexed `scope.0`, `scope.1`, … | One attribute is searchable in Tempo's TraceQL via substring match. Per-element indexing inflates span size; reserved for if a real consumer asks for OTel-spec-aligned `enduser.scope` array semantics. |
| Cache-hit attribute always emits | Both `"true"` and `"false"` | Only emit on hit | `false` is just as informative for cache-effectiveness debugging — operators want to see "cold path took the JWKS lookup". |
| `jwksKeyFunc` method → `jwksKeyFuncCtx(ctx)` closure | Yes | Add ctx field on JWTValidator | jwt-go's `Keyfunc` has no ctx param; the closure is the cleanest way to thread ctx into the JWKS-lookup span. A field would be racy under concurrent Validate calls (different requests, different active spans). |
| Test fixture stays inline (no shared helper) | Yes | Import `examples/auth/common` | examples/auth/common imports ext/auth — would create a cycle. The 50-line `setupTestJWKS` helper is self-contained and demonstrates the minimum a future consumer needs. |
| oneauth-side instrumentation | Out of scope; file separately | Wire here | ext/auth's responsibility ends at the wire — inject `traceparent` on outbound HTTP, span the call. oneauth's internal HTTP / DB / crypto work is its own observability story and should accept a TracerProvider in its own time. Filing the oneauth ticket after this merges so it can reference the concrete inbound wire shape. |

## Risk / blast radius

- **Single sub-module (`ext/auth`), separate `go.mod`** — root `make test` doesn't cover this; gated by `make test-auth` (passing locally).
- **Backward-compatible for existing callers** — `JWTConfig` field additions are zero-impact; existing `NewJWTValidator(JWTConfig{...})` call sites compile and run unchanged with `tp = Noop` by default.
- **`jwksKeyFunc` method removed**, replaced by `jwksKeyFuncCtx(ctx)` closure. Public-API audit: `jwksKeyFunc` was unexported, no external callers possible. Removal is internal-only.
- **`tp` field added to `JWTValidator` struct** — struct fields aren't part of the public API contract, but if any tests construct `JWTValidator{...}` directly (instead of going through `NewJWTValidator`), they'd skip the Noop default and crash on nil-deref. No such tests in tree (verified by grep).

## Test plan

Added: 5 tests / ~25 assertions in `ext/auth/jwt_validator_trace_test.go`. Removed/weakened: 0.

Coverage:

- `TestJWTValidator_Trace_NilTracerProvider_NoSpans` — bare `JWTConfig{}` (no TP field set), cache-hit path; asserts no panic. Confirms the Noop default kicks in.
- `TestJWTValidator_Trace_NoopTracerProvider_NoSpans` — explicit `core.NoopTracerProvider{}`, cache-hit path; asserts no panic. Distinct from the nil test in case the nil-default path ever drifts.
- `TestJWTValidator_Trace_CacheHit_StampsActiveSpanAttributes` — fake TP, pre-seeded cache, outer "dispatch" span via `tp.StartSpan`; asserts `mcp.auth.method/subject/issuer/scopes/cache_hit=true` land on the **outer** span, and no `auth.jwks_lookup` span emits (cache hit skipped it).
- `TestJWTValidator_Trace_FullValidate_EmitsJWKSLookupSpan` — full RSA+JWKS fixture, no pre-seed; asserts `auth.jwks_lookup` span emits as a child of the outer dispatch span, carries `mcp.auth.jwks.kid`, and `cache_hit=false` lands on the outer span.
- `TestJWTValidator_Trace_FullValidate_NoActiveSpan_StillEmitsJWKSChild` — same as above but no outer span; the sub-span still emits (lives at the top of the trace), and the active-span attributes silently drop into the noop span — confirms graceful degradation when auth runs outside a traced path.

Verification:
- `make test-auth`: clean.
- `go test ./server/...` (root): clean (independent of this PR — sub-module isolation).
- `go vet ./...` in `ext/auth/`: clean.

## Out of scope (deliberately deferred)

- **`auth.introspect` sub-span (RFC 7662 token introspection)** — no introspection validator exists in `ext/auth` today; will land when that surface does. Mentioned in issue 658.
- **`auth.oauth_exchange` sub-span** — TokenSource paths (`client_credentials.go` / `enterprise_managed.go`) are client-side outbound flows with their own instrumentation arc. Separate ticket if/when needed.
- **`discovery.go` instrumentation** — client-side discovery utility (used by OAuth flows); same client-side carve-out.
- **`scope_middleware.go` instrumentation** — scope enforcement is a separate concern from token validation; issue 658 explicitly scopes to validation. Follow-up could decorate scope-check decision points with `mcp.auth.scope.required` / `mcp.auth.scope.granted`.
- **Outbound `traceparent` HTTP header on the JWKS fetch** — `keys.JWKSKeyStore` (in `panyam/oneauth`) owns the actual HTTP call; cannot inject from ext/auth without an oneauth-side option. Filing oneauth ticket after this merges so it can reference the concrete inbound expectations (W3C `traceparent` header on JWKS/introspect/token endpoints, OTel TracerProvider option on oneauth's HTTP server side, etc.).
- **Transport-level 401 (pre-middleware)** — mentioned in issue 658 as a known gap; documented in `ext/auth/docs/DESIGN.md`'s "Documented limitation" subsection. No code change in this PR.

