### PR TITLE
customer-segmentation: port clustered-Gaussian generator + walkthrough

### DIFF
--- a/examples/apps/compat/customer-segmentation/README.md
+++ b/examples/apps/compat/customer-segmentation/README.md
@@ -1,18 +1,28 @@
 # customer-segmentation — customer clusters with multi-dimension features
 
 Rung 4 on the [examples ladder](../README.md#reading-order--examples-ladder).
-One tool, customer cluster data. The iframe renders cluster scatter
-plots + per-segment summaries.
+One tool, 250-row customer payload. The iframe renders an interactive
+Chart.js scatter plot with two configurable axes, a configurable size
+metric, and a per-segment legend / hover detail panel.
 
 ## What it Shows
 
-- **Customer segmentation output.** `get-customer-data` returns
-  cluster assignments + per-cluster feature averages + per-customer
-  records. The iframe lets you explore segments interactively.
-- **Multi-dimensional records.** Each customer record carries
-  numeric + categorical features; clusters carry feature averages
-  + sizes. Reflection of the nested Go shape produces the schema
-  cleanly without override.
+- **Real clustered data on the wire.** `get-customer-data` returns 250
+  customers split across 4 segments (Enterprise / Mid-Market / SMB /
+  Startup), each drawn from a Box-Muller-clustered Gaussian shaped by
+  per-segment ranges. Server-side, the RNG is seeded with `PCG(42, 42)`
+  so the scatter plot is bit-stable across runs.
+- **Segment filter round trip.** The tool accepts an optional
+  `segment` enum (`All` + the four segments). The iframe's dropdown
+  re-issues `tools/call` with `{segment: "Enterprise"}` etc. — same
+  call shape, server-side filter.
+- **Session-stable pool.** The 250-row pool is generated once per
+  process via `sync.Once`, so flipping the dropdown re-filters the
+  same dataset rather than redrawing the chart.
+
+## Run Pre-Recorded
+
+> ▶ **[Play the walkthrough in your browser](https://panyam.github.io/mcpkit/walkthroughs/examples/apps/compat/customer-segmentation/)** — animated playback of every curl / Go call the walkthrough makes, step-by-step. No clone, no setup.
 
 ## Or Run Live
 
@@ -29,8 +39,8 @@ Starts the mcpkit-Go fixture on `http://localhost:3101/mcp` and basic-host on `h
 Open <http://localhost:8080> in your browser. Then:
 
 1. Pick **Customer Segmentation Server** from the server dropdown.
-2. Pick **get-customer-data** from the tool dropdown, click **Call Tool**.
-3. The iframe renders the result; interact with it directly to drive subsequent tool calls (no model in the loop).
+2. Pick **get-customer-data** from the tool dropdown, click **Call Tool** with empty input.
+3. The iframe renders the scatter plot. Flip the segment dropdown to see basic-host re-issue `tools/call` with the new filter; flip the X / Y axis selectors or the size metric to re-plot the same dataset (no model in the loop).
 
 <a href="screenshots/01-cluster-view.png" target="_blank"><img src="screenshots/01-cluster-view.png" alt="Customer Segmentation App: iframe shows the cluster scatter plot with color-coded segments + the per-segment summary panel on the right" width="50%"></a>
 
@@ -41,25 +51,19 @@ Connect to `http://localhost:3101/mcp` from your favorite MCP host — VS Code, 
 **Prompts to try** (LLM-driven hosts):
 
 > "Show me my customer segments."
-> "Cluster my customers and visualize the segments."
-> "Which customer segments are most valuable?"
-> "Display customer segmentation with average revenue per cluster."
+> "Which customer segments are most valuable by revenue?"
+> "Just the Enterprise customers, please."
 
-The model calls `get-customer-data`; the iframe renders the cluster
-scatter plot + per-segment summaries.
-
-**Verify the wire shape** (no LLM needed):
-
-| What | How | What you should see |
-|---|---|---|
-| Smoke test | Select `get-customer-data`, call with empty input | Tool result: nested clusters + customer records in `structuredContent` |
-| Iframe renders the clusters | Same call, scroll up | Scatter plot + segment summary in the App iframe |
+The model calls `get-customer-data` (optionally with `segment`); the
+iframe renders the resulting scatter plot + per-segment legend.
 
 See [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) in the compat README for wire inspection, upstream comparison, the strict Playwright gate, and connecting from VS Code / Claude Desktop / other MCP hosts.
 
 ## What to Try Next
 
 - [`cohort-heatmap`](../cohort-heatmap/README.md) — rung-4 sibling,
-  different analytical shape.
+  different analytical shape (heatmap instead of scatter plot).
 - [`budget-allocator`](../budget-allocator/README.md) — rung-4 with
-  config + analytics nested model.
+  config + analytics nested model and richer bridge dance.
+- See [`main.go`](main.go) for the data generator port — clustered
+  Gaussian, seeded RNG.

--- a/examples/apps/compat/customer-segmentation/bundle/ansi_up.js
+++ b/examples/apps/compat/customer-segmentation/bundle/ansi_up.js
@@ -1,0 +1,431 @@
+"use strict";
+var __makeTemplateObject = (this && this.__makeTemplateObject) || function (cooked, raw) {
+    if (Object.defineProperty) { Object.defineProperty(cooked, "raw", { value: raw }); } else { cooked.raw = raw; }
+    return cooked;
+};
+var PacketKind;
+(function (PacketKind) {
+    PacketKind[PacketKind["EOS"] = 0] = "EOS";
+    PacketKind[PacketKind["Text"] = 1] = "Text";
+    PacketKind[PacketKind["Incomplete"] = 2] = "Incomplete";
+    PacketKind[PacketKind["ESC"] = 3] = "ESC";
+    PacketKind[PacketKind["Unknown"] = 4] = "Unknown";
+    PacketKind[PacketKind["SGR"] = 5] = "SGR";
+    PacketKind[PacketKind["OSCURL"] = 6] = "OSCURL";
+})(PacketKind || (PacketKind = {}));
+export class AnsiUp {
+    constructor() {
+        this.VERSION = "6.0.6";
+        this.setup_palettes();
+        this._use_classes = false;
+        this.bold = false;
+        this.faint = false;
+        this.italic = false;
+        this.underline = false;
+        this.fg = this.bg = null;
+        this._buffer = '';
+        this._url_allowlist = { 'http': 1, 'https': 1 };
+        this._escape_html = true;
+        this.boldStyle = 'font-weight:bold';
+        this.faintStyle = 'opacity:0.7';
+        this.italicStyle = 'font-style:italic';
+        this.underlineStyle = 'text-decoration:underline';
+    }
+    set use_classes(arg) {
+        this._use_classes = arg;
+    }
+    get use_classes() {
+        return this._use_classes;
+    }
+    set url_allowlist(arg) {
+        this._url_allowlist = arg;
+    }
+    get url_allowlist() {
+        return this._url_allowlist;
+    }
+    set escape_html(arg) {
+        this._escape_html = arg;
+    }
+    get escape_html() {
+        return this._escape_html;
+    }
+    set boldStyle(arg) { this._boldStyle = arg; }
+    get boldStyle() { return this._boldStyle; }
+    set faintStyle(arg) { this._faintStyle = arg; }
+    get faintStyle() { return this._faintStyle; }
+    set italicStyle(arg) { this._italicStyle = arg; }
+    get italicStyle() { return this._italicStyle; }
+    set underlineStyle(arg) { this._underlineStyle = arg; }
+    get underlineStyle() { return this._underlineStyle; }
+    setup_palettes() {
+        this.ansi_colors =
+            [
+                [
+                    { rgb: [0, 0, 0], class_name: "ansi-black" },
+                    { rgb: [187, 0, 0], class_name: "ansi-red" },
+                    { rgb: [0, 187, 0], class_name: "ansi-green" },
+                    { rgb: [187, 187, 0], class_name: "ansi-yellow" },
+                    { rgb: [0, 0, 187], class_name: "ansi-blue" },
+                    { rgb: [187, 0, 187], class_name: "ansi-magenta" },
+                    { rgb: [0, 187, 187], class_name: "ansi-cyan" },
+                    { rgb: [255, 255, 255], class_name: "ansi-white" }
+                ],
+                [
+                    { rgb: [85, 85, 85], class_name: "ansi-bright-black" },
+                    { rgb: [255, 85, 85], class_name: "ansi-bright-red" },
+                    { rgb: [0, 255, 0], class_name: "ansi-bright-green" },
+                    { rgb: [255, 255, 85], class_name: "ansi-bright-yellow" },
+                    { rgb: [85, 85, 255], class_name: "ansi-bright-blue" },
+                    { rgb: [255, 85, 255], class_name: "ansi-bright-magenta" },
+                    { rgb: [85, 255, 255], class_name: "ansi-bright-cyan" },
+                    { rgb: [255, 255, 255], class_name: "ansi-bright-white" }
+                ]
+            ];
+        this.palette_256 = [];
+        this.ansi_colors.forEach(palette => {
+            palette.forEach(rec => {
+                this.palette_256.push(rec);
+            });
+        });
+        let levels = [0, 95, 135, 175, 215, 255];
+        for (let r = 0; r < 6; ++r) {
+            for (let g = 0; g < 6; ++g) {
+                for (let b = 0; b < 6; ++b) {
+                    let col = { rgb: [levels[r], levels[g], levels[b]], class_name: 'truecolor' };
+                    this.palette_256.push(col);
+                }
+            }
+        }
+        let grey_level = 8;
+        for (let i = 0; i < 24; ++i, grey_level += 10) {
+            let gry = { rgb: [grey_level, grey_level, grey_level], class_name: 'truecolor' };
+            this.palette_256.push(gry);
+        }
+    }
+    escape_txt_for_html(txt) {
+        if (!this._escape_html)
+            return txt;
+        return txt.replace(/[&<>"']/gm, (str) => {
+            if (str === "&")
+                return "&amp;";
+            if (str === "<")
+                return "&lt;";
+            if (str === ">")
+                return "&gt;";
+            if (str === "\"")
+                return "&quot;";
+            if (str === "'")
+                return "&#x27;";
+        });
+    }
+    append_buffer(txt) {
+        var str = this._buffer + txt;
+        this._buffer = str;
+    }
+    get_next_packet() {
+        var pkt = {
+            kind: PacketKind.EOS,
+            text: '',
+            url: ''
+        };
+        var len = this._buffer.length;
+        if (len == 0)
+            return pkt;
+        var pos = this._buffer.indexOf("\x1B");
+        if (pos == -1) {
+            pkt.kind = PacketKind.Text;
+            pkt.text = this._buffer;
+            this._buffer = '';
+            return pkt;
+        }
+        if (pos > 0) {
+            pkt.kind = PacketKind.Text;
+            pkt.text = this._buffer.slice(0, pos);
+            this._buffer = this._buffer.slice(pos);
+            return pkt;
+        }
+        if (pos == 0) {
+            if (len < 3) {
+                pkt.kind = PacketKind.Incomplete;
+                return pkt;
+            }
+            var next_char = this._buffer.charAt(1);
+            if ((next_char != '[') && (next_char != ']') && (next_char != '(')) {
+                pkt.kind = PacketKind.ESC;
+                pkt.text = this._buffer.slice(0, 1);
+                this._buffer = this._buffer.slice(1);
+                return pkt;
+            }
+            if (next_char == '[') {
+                if (!this._csi_regex) {
+                    this._csi_regex = rgx(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\n                        ^                           # beginning of line\n                                                    #\n                                                    # First attempt\n                        (?:                         # legal sequence\n                          \u001B[                      # CSI\n                          ([<-?]?)              # private-mode char\n                          ([d;]*)                    # any digits or semicolons\n                          ([ -/]?               # an intermediate modifier\n                          [@-~])                # the command\n                        )\n                        |                           # alternate (second attempt)\n                        (?:                         # illegal sequence\n                          \u001B[                      # CSI\n                          [ -~]*                # anything legal\n                          ([\0-\u001F:])              # anything illegal\n                        )\n                    "], ["\n                        ^                           # beginning of line\n                                                    #\n                                                    # First attempt\n                        (?:                         # legal sequence\n                          \\x1b\\[                      # CSI\n                          ([\\x3c-\\x3f]?)              # private-mode char\n                          ([\\d;]*)                    # any digits or semicolons\n                          ([\\x20-\\x2f]?               # an intermediate modifier\n                          [\\x40-\\x7e])                # the command\n                        )\n                        |                           # alternate (second attempt)\n                        (?:                         # illegal sequence\n                          \\x1b\\[                      # CSI\n                          [\\x20-\\x7e]*                # anything legal\n                          ([\\x00-\\x1f:])              # anything illegal\n                        )\n                    "])));
+                }
+                let match = this._buffer.match(this._csi_regex);
+                if (match === null) {
+                    pkt.kind = PacketKind.Incomplete;
+                    return pkt;
+                }
+                if (match[4]) {
+                    pkt.kind = PacketKind.ESC;
+                    pkt.text = this._buffer.slice(0, 1);
+                    this._buffer = this._buffer.slice(1);
+                    return pkt;
+                }
+                if ((match[1] != '') || (match[3] != 'm'))
+                    pkt.kind = PacketKind.Unknown;
+                else
+                    pkt.kind = PacketKind.SGR;
+                pkt.text = match[2];
+                var rpos = match[0].length;
+                this._buffer = this._buffer.slice(rpos);
+                return pkt;
+            }
+            else if (next_char == ']') {
+                if (len < 4) {
+                    pkt.kind = PacketKind.Incomplete;
+                    return pkt;
+                }
+                if ((this._buffer.charAt(2) != '8')
+                    || (this._buffer.charAt(3) != ';')) {
+                    pkt.kind = PacketKind.ESC;
+                    pkt.text = this._buffer.slice(0, 1);
+                    this._buffer = this._buffer.slice(1);
+                    return pkt;
+                }
+                if (!this._osc_st) {
+                    this._osc_st = rgxG(templateObject_2 || (templateObject_2 = __makeTemplateObject(["\n                        (?:                         # legal sequence\n                          (\u001B\\)                    # ESC                           |                           # alternate\n                          (\u0007)                      # BEL (what xterm did)\n                        )\n                        |                           # alternate (second attempt)\n                        (                           # illegal sequence\n                          [\0-\u0006]                 # anything illegal\n                          |                           # alternate\n                          [\b-\u001A]                 # anything illegal\n                          |                           # alternate\n                          [\u001C-\u001F]                 # anything illegal\n                        )\n                    "], ["\n                        (?:                         # legal sequence\n                          (\\x1b\\\\)                    # ESC \\\n                          |                           # alternate\n                          (\\x07)                      # BEL (what xterm did)\n                        )\n                        |                           # alternate (second attempt)\n                        (                           # illegal sequence\n                          [\\x00-\\x06]                 # anything illegal\n                          |                           # alternate\n                          [\\x08-\\x1a]                 # anything illegal\n                          |                           # alternate\n                          [\\x1c-\\x1f]                 # anything illegal\n                        )\n                    "])));
+                }
+                this._osc_st.lastIndex = 0;
+                {
+                    let match = this._osc_st.exec(this._buffer);
+                    if (match === null) {
+                        pkt.kind = PacketKind.Incomplete;
+                        return pkt;
+                    }
+                    if (match[3]) {
+                        pkt.kind = PacketKind.ESC;
+                        pkt.text = this._buffer.slice(0, 1);
+                        this._buffer = this._buffer.slice(1);
+                        return pkt;
+                    }
+                }
+                {
+                    let match = this._osc_st.exec(this._buffer);
+                    if (match === null) {
+                        pkt.kind = PacketKind.Incomplete;
+                        return pkt;
+                    }
+                    if (match[3]) {
+                        pkt.kind = PacketKind.ESC;
+                        pkt.text = this._buffer.slice(0, 1);
+                        this._buffer = this._buffer.slice(1);
+                        return pkt;
+                    }
+                }
+                if (!this._osc_regex) {
+                    this._osc_regex = rgx(templateObject_3 || (templateObject_3 = __makeTemplateObject(["\n                        ^                           # beginning of line\n                                                    #\n                        \u001B]8;                    # OSC Hyperlink\n                        [ -:<-~]*       # params (excluding ;)\n                        ;                           # end of params\n                        ([!-~]{0,512})        # URL capture\n                        (?:                         # ST\n                          (?:\u001B\\)                  # ESC                           |                           # alternate\n                          (?:\u0007)                    # BEL (what xterm did)\n                        )\n                        ([ -~]+)              # TEXT capture\n                        \u001B]8;;                   # OSC Hyperlink End\n                        (?:                         # ST\n                          (?:\u001B\\)                  # ESC                           |                           # alternate\n                          (?:\u0007)                    # BEL (what xterm did)\n                        )\n                    "], ["\n                        ^                           # beginning of line\n                                                    #\n                        \\x1b\\]8;                    # OSC Hyperlink\n                        [\\x20-\\x3a\\x3c-\\x7e]*       # params (excluding ;)\n                        ;                           # end of params\n                        ([\\x21-\\x7e]{0,512})        # URL capture\n                        (?:                         # ST\n                          (?:\\x1b\\\\)                  # ESC \\\n                          |                           # alternate\n                          (?:\\x07)                    # BEL (what xterm did)\n                        )\n                        ([\\x20-\\x7e]+)              # TEXT capture\n                        \\x1b\\]8;;                   # OSC Hyperlink End\n                        (?:                         # ST\n                          (?:\\x1b\\\\)                  # ESC \\\n                          |                           # alternate\n                          (?:\\x07)                    # BEL (what xterm did)\n                        )\n                    "])));
+                }
+                let match = this._buffer.match(this._osc_regex);
+                if (match === null) {
+                    pkt.kind = PacketKind.ESC;
+                    pkt.text = this._buffer.slice(0, 1);
+                    this._buffer = this._buffer.slice(1);
+                    return pkt;
+                }
+                pkt.kind = PacketKind.OSCURL;
+                pkt.url = match[1];
+                pkt.text = match[2];
+                var rpos = match[0].length;
+                this._buffer = this._buffer.slice(rpos);
+                return pkt;
+            }
+            else if (next_char == '(') {
+                pkt.kind = PacketKind.Unknown;
+                this._buffer = this._buffer.slice(3);
+                return pkt;
+            }
+        }
+    }
+    ansi_to_html(txt) {
+        this.append_buffer(txt);
+        var blocks = [];
+        while (true) {
+            var packet = this.get_next_packet();
+            if ((packet.kind == PacketKind.EOS)
+                || (packet.kind == PacketKind.Incomplete))
+                break;
+            if ((packet.kind == PacketKind.ESC)
+                || (packet.kind == PacketKind.Unknown))
+                continue;
+            if (packet.kind == PacketKind.Text)
+                blocks.push(this.transform_to_html(this.with_state(packet)));
+            else if (packet.kind == PacketKind.SGR)
+                this.process_ansi(packet);
+            else if (packet.kind == PacketKind.OSCURL)
+                blocks.push(this.process_hyperlink(packet));
+        }
+        return blocks.join("");
+    }
+    with_state(pkt) {
+        return { bold: this.bold, faint: this.faint, italic: this.italic, underline: this.underline, fg: this.fg, bg: this.bg, text: pkt.text };
+    }
+    process_ansi(pkt) {
+        let sgr_cmds = pkt.text.split(';');
+        while (sgr_cmds.length > 0) {
+            let sgr_cmd_str = sgr_cmds.shift();
+            let num = parseInt(sgr_cmd_str, 10);
+            if (isNaN(num) || num === 0) {
+                this.fg = null;
+                this.bg = null;
+                this.bold = false;
+                this.faint = false;
+                this.italic = false;
+                this.underline = false;
+            }
+            else if (num === 1) {
+                this.bold = true;
+            }
+            else if (num === 2) {
+                this.faint = true;
+            }
+            else if (num === 3) {
+                this.italic = true;
+            }
+            else if (num === 4) {
+                this.underline = true;
+            }
+            else if (num === 21) {
+                this.bold = false;
+            }
+            else if (num === 22) {
+                this.faint = false;
+                this.bold = false;
+            }
+            else if (num === 23) {
+                this.italic = false;
+            }
+            else if (num === 24) {
+                this.underline = false;
+            }
+            else if (num === 39) {
+                this.fg = null;
+            }
+            else if (num === 49) {
+                this.bg = null;
+            }
+            else if ((num >= 30) && (num < 38)) {
+                this.fg = this.ansi_colors[0][(num - 30)];
+            }
+            else if ((num >= 40) && (num < 48)) {
+                this.bg = this.ansi_colors[0][(num - 40)];
+            }
+            else if ((num >= 90) && (num < 98)) {
+                this.fg = this.ansi_colors[1][(num - 90)];
+            }
+            else if ((num >= 100) && (num < 108)) {
+                this.bg = this.ansi_colors[1][(num - 100)];
+            }
+            else if (num === 38 || num === 48) {
+                if (sgr_cmds.length > 0) {
+                    let is_foreground = (num === 38);
+                    let mode_cmd = sgr_cmds.shift();
+                    if (mode_cmd === '5' && sgr_cmds.length > 0) {
+                        let palette_index = parseInt(sgr_cmds.shift(), 10);
+                        if (palette_index >= 0 && palette_index <= 255) {
+                            if (is_foreground)
+                                this.fg = this.palette_256[palette_index];
+                            else
+                                this.bg = this.palette_256[palette_index];
+                        }
+                    }
+                    if (mode_cmd === '2' && sgr_cmds.length > 2) {
+                        let r = parseInt(sgr_cmds.shift(), 10);
+                        let g = parseInt(sgr_cmds.shift(), 10);
+                        let b = parseInt(sgr_cmds.shift(), 10);
+                        if ((r >= 0 && r <= 255) && (g >= 0 && g <= 255) && (b >= 0 && b <= 255)) {
+                            let c = { rgb: [r, g, b], class_name: 'truecolor' };
+                            if (is_foreground)
+                                this.fg = c;
+                            else
+                                this.bg = c;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    transform_to_html(fragment) {
+        let txt = fragment.text;
+        if (txt.length === 0)
+            return txt;
+        txt = this.escape_txt_for_html(txt);
+        if (!fragment.bold && !fragment.italic && !fragment.faint && !fragment.underline && fragment.fg === null && fragment.bg === null)
+            return txt;
+        let styles = [];
+        let classes = [];
+        let fg = fragment.fg;
+        let bg = fragment.bg;
+        if (fragment.bold)
+            styles.push(this._boldStyle);
+        if (fragment.faint)
+            styles.push(this._faintStyle);
+        if (fragment.italic)
+            styles.push(this._italicStyle);
+        if (fragment.underline)
+            styles.push(this._underlineStyle);
+        if (!this._use_classes) {
+            if (fg)
+                styles.push(`color:rgb(${fg.rgb.join(',')})`);
+            if (bg)
+                styles.push(`background-color:rgb(${bg.rgb})`);
+        }
+        else {
+            if (fg) {
+                if (fg.class_name !== 'truecolor') {
+                    classes.push(`${fg.class_name}-fg`);
+                }
+                else {
+                    styles.push(`color:rgb(${fg.rgb.join(',')})`);
+                }
+            }
+            if (bg) {
+                if (bg.class_name !== 'truecolor') {
+                    classes.push(`${bg.class_name}-bg`);
+                }
+                else {
+                    styles.push(`background-color:rgb(${bg.rgb.join(',')})`);
+                }
+            }
+        }
+        let class_string = '';
+        let style_string = '';
+        if (classes.length)
+            class_string = ` class="${classes.join(' ')}"`;
+        if (styles.length)
+            style_string = ` style="${styles.join(';')}"`;
+        return `<span${style_string}${class_string}>${txt}</span>`;
+    }
+    ;
+    process_hyperlink(pkt) {
+        let parts = pkt.url.split(':');
+        if (parts.length < 1)
+            return '';
+        if (!this._url_allowlist[parts[0]])
+            return '';
+        let result = `<a href="${this.escape_txt_for_html(pkt.url)}">${this.escape_txt_for_html(pkt.text)}</a>`;
+        return result;
+    }
+}
+function rgx(tmplObj, ...subst) {
+    let regexText = tmplObj.raw[0];
+    let wsrgx = /^\s+|\s+\n|\s*#[\s\S]*?\n|\n/gm;
+    let txt2 = regexText.replace(wsrgx, '');
+    return new RegExp(txt2);
+}
+function rgxG(tmplObj, ...subst) {
+    let regexText = tmplObj.raw[0];
+    let wsrgx = /^\s+|\s+\n|\s*#[\s\S]*?\n|\n/gm;
+    let txt2 = regexText.replace(wsrgx, '');
+    return new RegExp(txt2, 'g');
+}
+var templateObject_1, templateObject_2, templateObject_3;

--- a/examples/apps/compat/customer-segmentation/bundle/demokit-player.css
+++ b/examples/apps/compat/customer-segmentation/bundle/demokit-player.css
@@ -1,0 +1,253 @@
+/* demokit-player styles. BEM-ish class names; no shadow DOM so host
+   themes can override via CSS variables. Hosts can set:
+
+     --demokit-bg, --demokit-fg, --demokit-muted, --demokit-accent,
+     --demokit-border, --demokit-error, --demokit-warning,
+     --demokit-info, --demokit-mono
+
+   on a parent element to retheme the player.
+
+   The widget is layout-agnostic: it claims width: 100% and grows
+   in height to fit its feed. Wrap it in an iframe or a sized
+   container if you need a fixed viewport.
+*/
+
+.demokit-player {
+  --demokit-bg: #ffffff;
+  --demokit-fg: #1f2328;
+  --demokit-muted: #57606a;
+  --demokit-accent: #0969da;
+  --demokit-border: #d0d7de;
+  --demokit-error: #cf222e;
+  --demokit-warning: #9a6700;
+  --demokit-info: #0969da;
+  --demokit-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+
+  display: block;
+  width: 100%;
+  font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  color: var(--demokit-fg);
+  background: var(--demokit-bg);
+  border: 1px solid var(--demokit-border);
+  border-radius: 6px;
+  overflow: hidden;
+  outline: none;
+}
+
+.demokit-player:focus {
+  box-shadow: 0 0 0 2px var(--demokit-accent);
+}
+
+.demokit-player__header {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--demokit-border);
+}
+
+.demokit-player__title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.demokit-player__description {
+  margin: 4px 0 0;
+  color: var(--demokit-muted);
+  font-size: 13px;
+}
+
+.demokit-player__feed {
+  padding: 16px;
+  max-height: 70vh;
+  overflow-y: auto;
+}
+
+.demokit-player__controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  border-top: 1px solid var(--demokit-border);
+  background: rgba(0, 0, 0, 0.02);
+}
+
+.demokit-player__btn {
+  font: inherit;
+  padding: 4px 10px;
+  border: 1px solid var(--demokit-border);
+  background: var(--demokit-bg);
+  color: var(--demokit-fg);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.demokit-player__btn:hover:not(:disabled) {
+  background: rgba(0, 0, 0, 0.04);
+}
+
+.demokit-player__btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.demokit-player__counter {
+  margin-left: auto;
+  color: var(--demokit-muted);
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+}
+
+.demokit-player__error {
+  padding: 12px;
+  border-left: 4px solid var(--demokit-error);
+  color: var(--demokit-error);
+  background: rgba(207, 34, 46, 0.06);
+  border-radius: 4px;
+}
+
+/* --- Per-entry blocks --- */
+
+.demokit-section,
+.demokit-step {
+  margin: 0 0 16px;
+  padding: 12px 14px;
+  border: 1px solid var(--demokit-border);
+  border-radius: 6px;
+  background: var(--demokit-bg);
+}
+
+.demokit-section__title,
+.demokit-step__title {
+  margin: 0 0 8px;
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.demokit-step__visit {
+  color: var(--demokit-muted);
+  font-weight: 400;
+}
+
+.demokit-section__body {
+  margin: 0;
+  color: var(--demokit-muted);
+  white-space: pre-wrap;
+}
+
+.demokit-step__note {
+  margin: 0 0 8px;
+  padding: 6px 10px;
+  border-left: 3px solid var(--demokit-border);
+  color: var(--demokit-muted);
+  font-style: italic;
+  background: rgba(0, 0, 0, 0.02);
+}
+
+.demokit-step__refs {
+  margin: 0 0 8px;
+  font-size: 12px;
+  color: var(--demokit-muted);
+}
+.demokit-step__refs a {
+  color: var(--demokit-accent);
+}
+
+.demokit-step__inputs {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 2px 12px;
+  margin: 0 0 8px;
+  padding: 6px 10px;
+  font-family: var(--demokit-mono);
+  font-size: 12px;
+  background: rgba(0, 0, 0, 0.03);
+  border-radius: 4px;
+}
+.demokit-step__inputs dt {
+  color: var(--demokit-muted);
+}
+.demokit-step__inputs dd {
+  margin: 0;
+}
+
+.demokit-step__output {
+  margin: 0 0 8px;
+  padding: 8px 10px;
+  background: rgba(0, 0, 0, 0.04);
+  border-radius: 4px;
+  font-family: var(--demokit-mono);
+  font-size: 12px;
+  white-space: pre-wrap;
+  overflow-x: auto;
+}
+
+.demokit-step__verbatim-label {
+  margin: 8px 0 4px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--demokit-muted);
+}
+.demokit-step__verbatim {
+  margin: 0 0 8px;
+  padding: 8px 10px;
+  background: rgba(0, 0, 0, 0.04);
+  border-radius: 4px;
+  font-family: var(--demokit-mono);
+  font-size: 12px;
+  white-space: pre;
+  overflow-x: auto;
+}
+
+.demokit-step__status {
+  margin: 0;
+  padding: 6px 10px;
+  border-radius: 4px;
+  font-weight: 500;
+}
+
+.demokit-step__jump {
+  margin: 6px 0 0;
+  font-size: 12px;
+  color: var(--demokit-muted);
+  font-family: var(--demokit-mono);
+}
+
+/* Status colors — match ResultStatus const ordering: 0 success, 1 error, 2 warning, 3 info */
+.demokit-step--status-1 {
+  border-left: 4px solid var(--demokit-error);
+}
+.demokit-step--status-1 .demokit-step__status {
+  background: rgba(207, 34, 46, 0.08);
+  color: var(--demokit-error);
+}
+.demokit-step--status-2 {
+  border-left: 4px solid var(--demokit-warning);
+}
+.demokit-step--status-2 .demokit-step__status {
+  background: rgba(154, 103, 0, 0.08);
+  color: var(--demokit-warning);
+}
+.demokit-step--status-3 {
+  border-left: 4px solid var(--demokit-info);
+}
+.demokit-step--status-3 .demokit-step__status {
+  background: rgba(9, 105, 218, 0.08);
+  color: var(--demokit-info);
+}
+
+@media (prefers-color-scheme: dark) {
+  .demokit-player {
+    --demokit-bg: #0d1117;
+    --demokit-fg: #e6edf3;
+    --demokit-muted: #8b949e;
+    --demokit-accent: #58a6ff;
+    --demokit-border: #30363d;
+  }
+  .demokit-player__btn:hover:not(:disabled) {
+    background: rgba(255, 255, 255, 0.06);
+  }
+  .demokit-step__note,
+  .demokit-step__inputs,
+  .demokit-step__output {
+    background: rgba(255, 255, 255, 0.03);
+  }
+}

--- a/examples/apps/compat/customer-segmentation/bundle/demokit-player.js
+++ b/examples/apps/compat/customer-segmentation/bundle/demokit-player.js
@@ -1,0 +1,858 @@
+// demokit-player — vanilla-JS web component for playing back demokit
+// traces in any HTML host. Registers <demokit-demo> as a Custom
+// Element. No framework dependencies.
+//
+// Data sources, in priority order:
+//   1. Programmatic: el.trace = traceObject (assigning the property
+//      triggers a re-render).
+//   2. data-src URL: fetch JSON; render as static playback.
+//   3. data-src URL with data-mode="live": connect via WebSocket and
+//      render incrementally as the server emits structured events
+//      (header / section / step-start / chunk / step-end /
+//      input-needed / done). Driven by `demokit --serve`.
+//   4. Inline blob: <demokit-demo>{...JSON...}</demokit-demo>.
+//
+// Public API on the element:
+//   .trace = obj            // programmatic data injection
+//   .play(), .pause(), .reset(), .step(), .goTo(n)
+//   .currentStep (read), .totalEntries (read), .isPlaying (read)
+//
+// Events dispatched on the element (notifications, past tense):
+//   demokit:loaded   — once trace data is available
+//   demokit:stepped  — the visible step just advanced
+//   demokit:done     — last entry shown
+//   demokit:error    — fatal load/render error
+//
+// Events listened for (commands; host fires these to drive the
+// widget without knowing the player's class name):
+//   demokit:play, demokit:pause, demokit:reset, demokit:step
+//
+// The command/notification names are deliberately distinct
+// (demokit:step vs demokit:stepped) — using one name for both
+// would create a recursion loop the moment a step() advance
+// dispatches the same event the host listener handles.
+//
+// Keyboard (when the element is focused):
+//   Space / ArrowRight  — next step
+//   ArrowLeft           — previous step (rewinds the visible feed)
+//   P                   — play/pause toggle
+//   R                   — reset to first entry
+
+// This file is an ES module. Bundle templates load it via
+// <script type="module" src="...">.
+//
+// ansi_up is pulled in via a dynamic import wrapped in try/catch so
+// the player still loads when the CDN is unreachable — opening the
+// bundle on file:// without internet, behind a strict CSP that
+// blocks third-party scripts, or in air-gapped contexts. The
+// fallback strips ANSI escapes to plain text rather than failing
+// the whole module.
+
+// ansi_up is loaded from a commit-pinned jsdelivr URL — content-
+// addressable since the commit SHA is immutable, so no separate
+// integrity check is needed. We don't vendor a copy under our repo
+// because the file is already at the CDN; duplicating the bytes
+// adds nothing.
+//
+// file:// pages can't fetch cross-origin scripts (Chrome blocks
+// null-origin → https). For those cases the answer is the demokit
+// serve command (HTTP origin → CDN imports work) rather than a
+// chained fallback chasing every constraint.
+//
+// The stripper fallback below catches the residual case where the
+// import genuinely fails (no network, hard CSP, or a future demokit
+// air-gapped mode). Output stays readable (just without colour)
+// rather than garbled or absent.
+
+let AnsiUp;
+try {
+  const mod = await import(
+    'https://cdn.jsdelivr.net/gh/drudru/ansi_up@07a4824757d4dfbb41236a4245a6ce37f21aeb91/ansi_up.js'
+  );
+  AnsiUp = mod.AnsiUp;
+} catch (err) {
+  console.warn(
+    'demokit-player: ansi_up failed to load — captured ANSI escapes will render as plain text:',
+    err && err.message ? err.message : err,
+  );
+  AnsiUp = class {
+    constructor() { this.use_classes = false; }
+    ansi_to_html(text) {
+      // Strip ANSI escapes AND HTML-escape `<`, `>`, `&` so DOMParser
+      // doesn't misinterpret literals (e.g. the dragon ASCII body)
+      // as malformed tags. ansi_up's real ansi_to_html escapes
+      // internally; the stripper has to do the same.
+      return String(text)
+        .replace(/\x1b\[[0-9;]*m/g, '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+    }
+  };
+}
+
+const PLAY_INTERVAL_MS = 1500; // tune via Demo author later if needed
+
+class DemokitDemoElement extends HTMLElement {
+    constructor() {
+      super();
+      this._trace = null;
+      this._programmaticTrace = null;
+      this._currentStep = 0; // index of next entry to reveal
+      this._isPlaying = false;
+      this._timer = null;
+      this._kbHandler = null;
+      this._evtHandlers = {};
+    }
+
+    connectedCallback() {
+      this.classList.add('demokit-player');
+      if (!this.hasAttribute('tabindex')) {
+        this.setAttribute('tabindex', '0'); // make focusable for keyboard
+      }
+      // Snapshot inline JSON before _renderShell() replaces the
+      // element's children — otherwise _loadTrace would read the
+      // rendered button labels as if they were the trace blob.
+      this._inlineText = (this.textContent || '').trim();
+      this._renderShell();
+      this._bindKeyboard();
+      this._bindHostEvents();
+      this._loadTrace();
+    }
+
+    disconnectedCallback() {
+      this._stopPlayback();
+      this._unbindKeyboard();
+      this._unbindHostEvents();
+    }
+
+    // --- Programmatic data source ---
+
+    set trace(obj) {
+      this._programmaticTrace = obj;
+      this._loadTrace();
+    }
+    get trace() {
+      return this._trace;
+    }
+
+    // --- Public controls ---
+
+    play() {
+      if (this._isPlaying || !this._trace) return;
+      this._isPlaying = true;
+      this._updateControls();
+      this._timer = setInterval(() => {
+        this.step();
+        if (this._currentStep >= this._entries().length) {
+          this._stopPlayback();
+        }
+      }, PLAY_INTERVAL_MS);
+    }
+
+    pause() {
+      this._stopPlayback();
+    }
+
+    reset() {
+      this._stopPlayback();
+      this._currentStep = 0;
+      this._feedEl.replaceChildren();
+      this._updateControls();
+    }
+
+    step() {
+      const entries = this._entries();
+      if (this._currentStep >= entries.length) return;
+      const e = entries[this._currentStep];
+      this._renderEntry(e, this._currentStep + 1);
+      this._currentStep++;
+      this._updateControls();
+      this.dispatchEvent(new CustomEvent('demokit:stepped', {
+        detail: { index: this._currentStep, entry: e },
+      }));
+      if (this._currentStep >= entries.length) {
+        this.dispatchEvent(new CustomEvent('demokit:done'));
+      }
+    }
+
+    goTo(n) {
+      const entries = this._entries();
+      this._stopPlayback();
+      this._feedEl.replaceChildren();
+      this._currentStep = 0;
+      const target = Math.max(0, Math.min(n, entries.length));
+      for (let i = 0; i < target; i++) {
+        this.step();
+      }
+    }
+
+    get currentStep() { return this._currentStep; }
+    get totalEntries() { return this._entries().length; }
+    get isPlaying() { return this._isPlaying; }
+
+    // --- Internals ---
+
+    _entries() {
+      if (!this._trace) return [];
+      // The trace JSON shipped by --doc json wraps trace entries
+      // under a "trace" key alongside the demo definition. Inline
+      // blobs may carry just the entries array directly.
+      if (Array.isArray(this._trace)) return this._trace;
+      return this._trace.trace || [];
+    }
+
+    _demo() {
+      if (!this._trace || Array.isArray(this._trace)) return null;
+      return this._trace.demo || null;
+    }
+
+    _renderShell() {
+      this.replaceChildren();
+      const header = document.createElement('div');
+      header.className = 'demokit-player__header';
+      this._titleEl = document.createElement('h2');
+      this._titleEl.className = 'demokit-player__title';
+      this._descEl = document.createElement('p');
+      this._descEl.className = 'demokit-player__description';
+      header.appendChild(this._titleEl);
+      header.appendChild(this._descEl);
+
+      this._feedEl = document.createElement('div');
+      this._feedEl.className = 'demokit-player__feed';
+
+      const controls = document.createElement('div');
+      controls.className = 'demokit-player__controls';
+      this._prevBtn = this._mkBtn('◀', 'Previous (←)', () => this.goTo(this._currentStep - 1));
+      this._stepBtn = this._mkBtn('▶ Next', 'Next step (Space)', () => this.step());
+      this._playBtn = this._mkBtn('▶▶ Play', 'Play (P)', () => this.play());
+      this._pauseBtn = this._mkBtn('❚❚ Pause', 'Pause (P)', () => this.pause());
+      this._resetBtn = this._mkBtn('⟲ Reset', 'Reset (R)', () => this.reset());
+      this._counterEl = document.createElement('span');
+      this._counterEl.className = 'demokit-player__counter';
+      controls.append(this._prevBtn, this._stepBtn, this._playBtn, this._pauseBtn, this._resetBtn, this._counterEl);
+
+      // Controls position is configurable via data-controls
+      // ("top" default, "bottom" for legacy/footer-style layouts).
+      // Top is the default because the feed grows downward; with
+      // controls at the bottom, the user has to scroll past their
+      // own steps to reach Next/Play.
+      this.appendChild(header);
+      const controlsAtBottom = (this.dataset.controls || 'top') === 'bottom';
+      if (controlsAtBottom) {
+        this.appendChild(this._feedEl);
+        this.appendChild(controls);
+        controls.classList.add('demokit-player__controls--bottom');
+      } else {
+        this.appendChild(controls);
+        this.appendChild(this._feedEl);
+        controls.classList.add('demokit-player__controls--top');
+      }
+    }
+
+    _mkBtn(label, title, onClick) {
+      const b = document.createElement('button');
+      b.type = 'button';
+      b.className = 'demokit-player__btn';
+      b.textContent = label;
+      b.title = title;
+      b.addEventListener('click', (e) => { e.stopPropagation(); onClick(); });
+      return b;
+    }
+
+    _updateControls() {
+      const total = this.totalEntries;
+      this._counterEl.textContent = `${this._currentStep} / ${total}`;
+      this._prevBtn.disabled = this._currentStep <= 0;
+      this._stepBtn.disabled = this._currentStep >= total;
+      this._playBtn.style.display = this._isPlaying ? 'none' : '';
+      this._pauseBtn.style.display = this._isPlaying ? '' : 'none';
+    }
+
+    async _loadTrace() {
+      const mode = this.dataset.mode || 'static';
+      const src = this.dataset.src;
+
+      try {
+        if (this._programmaticTrace) {
+          this._trace = this._programmaticTrace;
+        } else if (src && mode === 'live') {
+          // Live mode: open a WebSocket and stream structured events.
+          // Returns immediately; events drive the render incrementally.
+          this._connectWS(src);
+          return;
+        } else if (src) {
+          const res = await fetch(src);
+          if (!res.ok) {
+            throw new Error(`demokit-player: fetch ${src} → HTTP ${res.status}`);
+          }
+          this._trace = await res.json();
+        } else {
+          // _inlineText was captured in connectedCallback before the
+          // shell render replaced our children. Falls back to current
+          // textContent if connectedCallback hasn't run yet (rare).
+          const text = (this._inlineText !== undefined
+            ? this._inlineText
+            : (this.textContent || '').trim());
+          if (!text) {
+            this._renderError(
+              'demokit-player: no trace data. Provide data-src, inline JSON, or set the .trace property.',
+            );
+            return;
+          }
+          this._trace = JSON.parse(text);
+        }
+
+        this._renderHeader();
+        this._currentStep = 0;
+        this._feedEl.replaceChildren();
+        this._updateControls();
+        this.dispatchEvent(new CustomEvent('demokit:loaded', {
+          detail: { totalEntries: this.totalEntries },
+        }));
+      } catch (err) {
+        this._renderError(err && err.message ? err.message : String(err));
+        this.dispatchEvent(new CustomEvent('demokit:error', {
+          detail: { message: err && err.message ? err.message : String(err) },
+        }));
+      }
+    }
+
+    _renderHeader() {
+      const demo = this._demo();
+      this._titleEl.textContent = demo && demo.title ? demo.title : '';
+      this._descEl.textContent = demo && demo.description ? demo.description : '';
+      this._descEl.style.display = this._descEl.textContent ? '' : 'none';
+    }
+
+    _renderError(message) {
+      this._feedEl.replaceChildren();
+      const box = document.createElement('div');
+      box.className = 'demokit-player__error';
+      box.textContent = message;
+      this._feedEl.appendChild(box);
+    }
+
+    _renderEntry(entry, indexOneBased) {
+      if (entry.kind === 'section') {
+        this._renderSection(entry);
+      } else {
+        this._renderStep(entry, indexOneBased);
+      }
+      this._feedEl.lastElementChild.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+
+    _renderSection(entry) {
+      const sec = document.createElement('section');
+      sec.className = 'demokit-section';
+      const h = document.createElement('h3');
+      h.className = 'demokit-section__title';
+      h.textContent = entry.title || '';
+      sec.appendChild(h);
+      if (entry.body) {
+        const p = document.createElement('p');
+        p.className = 'demokit-section__body';
+        p.textContent = entry.body;
+        sec.appendChild(p);
+      }
+      this._feedEl.appendChild(sec);
+    }
+
+    _renderStep(entry, indexOneBased) {
+      const art = document.createElement('article');
+      const status = entry.status || 0; // 0 = success
+      art.className = `demokit-step demokit-step--status-${status}`;
+      const h = document.createElement('h3');
+      h.className = 'demokit-step__title';
+      h.textContent = `${indexOneBased}. ${entry.title || entry.step_id || ''}`;
+      if (entry.visit && entry.visit > 1) {
+        const v = document.createElement('span');
+        v.className = 'demokit-step__visit';
+        v.textContent = ` (visit ${entry.visit})`;
+        h.appendChild(v);
+      }
+      art.appendChild(h);
+
+      // Note from the demo definition (if available)
+      const stepDef = this._lookupStepDef(entry.step_id);
+      if (stepDef && stepDef.note) {
+        const blk = document.createElement('blockquote');
+        blk.className = 'demokit-step__note';
+        blk.textContent = stepDef.note;
+        art.appendChild(blk);
+      }
+      if (stepDef && stepDef.refs && stepDef.refs.length > 0) {
+        const refs = document.createElement('p');
+        refs.className = 'demokit-step__refs';
+        refs.appendChild(document.createTextNode('References: '));
+        stepDef.refs.forEach((ref, i) => {
+          if (i > 0) refs.appendChild(document.createTextNode(', '));
+          const a = document.createElement('a');
+          a.href = ref.url;
+          a.textContent = ref.name;
+          a.target = '_blank';
+          a.rel = 'noopener noreferrer';
+          refs.appendChild(a);
+        });
+        art.appendChild(refs);
+      }
+
+      if (stepDef && Array.isArray(stepDef.verbatim) && stepDef.verbatim.length) {
+        this._appendVerbatim(art, stepDef.verbatim);
+      }
+
+      // Inputs collected for this entry (read-only)
+      if (entry.inputs && Object.keys(entry.inputs).length > 0) {
+        const wrap = document.createElement('dl');
+        wrap.className = 'demokit-step__inputs';
+        Object.keys(entry.inputs).sort().forEach((k) => {
+          const dt = document.createElement('dt');
+          dt.textContent = k;
+          const dd = document.createElement('dd');
+          dd.textContent = String(entry.inputs[k]);
+          wrap.appendChild(dt);
+          wrap.appendChild(dd);
+        });
+        art.appendChild(wrap);
+      }
+
+      // Captured output — interpret ANSI SGR escapes so streamed
+      // colored output (e.g. the dungeon's dragon scene) renders
+      // with styling instead of leaking the literal "[38;5;245m"
+      // sequences as text.
+      if (entry.output) {
+        const pre = document.createElement('pre');
+        pre.className = 'demokit-step__output';
+        appendANSI(pre, entry.output.replace(/\n+$/, ''));
+        art.appendChild(pre);
+      }
+
+      // Status footer (error/warning/info messages)
+      if (status !== 0 && (entry.message || entry.label)) {
+        const foot = document.createElement('p');
+        foot.className = 'demokit-step__status';
+        const label = entry.label || statusLabel(status);
+        foot.textContent = `${label}: ${entry.message || ''}`;
+        art.appendChild(foot);
+      }
+
+      // Jump arrow
+      if (entry.next) {
+        const j = document.createElement('p');
+        j.className = 'demokit-step__jump';
+        j.textContent = `→ jumped to ${entry.next}`;
+        art.appendChild(j);
+      }
+
+      this._feedEl.appendChild(art);
+    }
+
+    _lookupStepDef(stepId) {
+      const demo = this._demo();
+      if (!demo || !demo.items || !stepId) return null;
+      for (const it of demo.items) {
+        if (it.kind === 'step' && it.id === stepId) return it;
+      }
+      return null;
+    }
+
+    // Append each verbatim block as an optional label + a <pre><code>
+    // with white-space: pre and overflow-x: auto. The browser does not
+    // soft-wrap, so triple-clicking a long line yields the original
+    // bytes — same copy-paste invariant the TUI guarantees.
+    _appendVerbatim(parent, blocks) {
+      blocks.forEach((b) => {
+        if (b.label) {
+          const h = document.createElement('p');
+          h.className = 'demokit-step__verbatim-label';
+          h.textContent = b.label;
+          parent.appendChild(h);
+        }
+        const pre = document.createElement('pre');
+        pre.className = 'demokit-step__verbatim';
+        const code = document.createElement('code');
+        if (b.lang) code.className = 'language-' + b.lang;
+        code.textContent = b.content || '';
+        pre.appendChild(code);
+        parent.appendChild(pre);
+      });
+    }
+
+    _stopPlayback() {
+      if (this._timer) {
+        clearInterval(this._timer);
+        this._timer = null;
+      }
+      this._isPlaying = false;
+      if (this._counterEl) this._updateControls();
+    }
+
+    _bindKeyboard() {
+      this._kbHandler = (e) => {
+        if (document.activeElement !== this) return;
+        switch (e.key) {
+          case ' ':
+          case 'ArrowRight':
+            e.preventDefault();
+            this.step();
+            break;
+          case 'ArrowLeft':
+            e.preventDefault();
+            this.goTo(this._currentStep - 1);
+            break;
+          case 'p':
+          case 'P':
+            e.preventDefault();
+            if (this._isPlaying) this.pause(); else this.play();
+            break;
+          case 'r':
+          case 'R':
+            e.preventDefault();
+            this.reset();
+            break;
+        }
+      };
+      this.addEventListener('keydown', this._kbHandler);
+    }
+
+    _unbindKeyboard() {
+      if (this._kbHandler) {
+        this.removeEventListener('keydown', this._kbHandler);
+        this._kbHandler = null;
+      }
+    }
+
+    _bindHostEvents() {
+      const evts = ['demokit:play', 'demokit:pause', 'demokit:reset', 'demokit:step'];
+      evts.forEach((name) => {
+        const handler = () => {
+          switch (name) {
+            case 'demokit:play':  this.play();  break;
+            case 'demokit:pause': this.pause(); break;
+            case 'demokit:reset': this.reset(); break;
+            case 'demokit:step':  this.step();  break;
+          }
+        };
+        this._evtHandlers[name] = handler;
+        this.addEventListener(name, handler);
+      });
+    }
+
+    _unbindHostEvents() {
+      Object.keys(this._evtHandlers).forEach((name) => {
+        this.removeEventListener(name, this._evtHandlers[name]);
+      });
+      this._evtHandlers = {};
+    }
+
+    // --- Live-mode WS ---
+    //
+    // When data-mode="live", the player connects to data-src as a
+    // WebSocket and renders incoming structured events incrementally
+    // (instead of fetching a static trace once). Outgoing messages
+    // are user actions: input submissions, reset.
+
+    _connectWS(rawURL) {
+      const wsURL = this._toWSURL(rawURL);
+      let ws;
+      try {
+        ws = new WebSocket(wsURL);
+      } catch (err) {
+        this._renderError('demokit-player: WS connect failed: ' + (err && err.message ? err.message : err));
+        return;
+      }
+      this._ws = ws;
+      this._currentStepEl = null;
+      this._currentStepID = null;
+
+      ws.onmessage = (e) => {
+        let evt;
+        try { evt = JSON.parse(e.data); } catch (_) { return; }
+        this._handleServerEvent(evt);
+      };
+      ws.onerror = () => {
+        this._renderError('demokit-player: WS error connecting to ' + wsURL);
+      };
+      ws.onclose = () => {
+        const note = document.createElement('p');
+        note.className = 'demokit-player__disconnected';
+        note.textContent = '(disconnected)';
+        this._feedEl.appendChild(note);
+      };
+    }
+
+    // _toWSURL converts an http(s):// or relative URL into ws(s)://
+    // so the host can write data-src as either a path or full URL.
+    _toWSURL(url) {
+      if (url.startsWith('ws://') || url.startsWith('wss://')) return url;
+      if (url.startsWith('http://')) return 'ws://' + url.slice(7);
+      if (url.startsWith('https://')) return 'wss://' + url.slice(8);
+      const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+      const path = url.startsWith('/') ? url : '/' + url;
+      return proto + '//' + location.host + path;
+    }
+
+    _handleServerEvent(evt) {
+      switch (evt.kind) {
+        case 'header':
+          if (evt.demo) {
+            this._titleEl.textContent = evt.demo.title || '';
+            this._descEl.textContent = evt.demo.description || '';
+            this._descEl.style.display = this._descEl.textContent ? '' : 'none';
+          }
+          break;
+        case 'section':
+          this._renderLiveSection(evt.extra || {});
+          break;
+        case 'step-start':
+          this._openLiveStep(evt.extra || {});
+          break;
+        case 'chunk':
+          this._appendChunkToLiveStep(evt.chunk || '');
+          break;
+        case 'step-end':
+          this._closeLiveStep(evt.status || 0, evt.extra || {});
+          break;
+        case 'input-needed':
+          this._renderLiveInputForm(evt.step_id, evt.inputs || []);
+          break;
+        case 'input-timeout':
+          this._dismissLiveInputForm(evt.extra && evt.extra.timeout_ms);
+          break;
+        case 'done':
+          this._renderLiveDone();
+          break;
+        case 'reset':
+          this._feedEl.replaceChildren();
+          this._currentStepEl = null;
+          this._currentStepID = null;
+          break;
+      }
+    }
+
+    _renderLiveSection(extra) {
+      const sec = document.createElement('section');
+      sec.className = 'demokit-section';
+      const h = document.createElement('h3');
+      h.className = 'demokit-section__title';
+      h.textContent = extra.title || '';
+      sec.appendChild(h);
+      if (extra.body) {
+        const p = document.createElement('p');
+        p.className = 'demokit-section__body';
+        p.textContent = extra.body;
+        sec.appendChild(p);
+      }
+      this._feedEl.appendChild(sec);
+      sec.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+
+    _openLiveStep(extra) {
+      const art = document.createElement('article');
+      art.className = 'demokit-step demokit-step--status-0';
+      const h = document.createElement('h3');
+      h.className = 'demokit-step__title';
+      const num = extra.step_num;
+      const title = extra.title || extra.id || '';
+      h.textContent = num ? num + '. ' + title : title;
+      art.appendChild(h);
+
+      if (extra.note) {
+        const blk = document.createElement('blockquote');
+        blk.className = 'demokit-step__note';
+        blk.textContent = extra.note;
+        art.appendChild(blk);
+      }
+      if (Array.isArray(extra.refs) && extra.refs.length) {
+        const refs = document.createElement('p');
+        refs.className = 'demokit-step__refs';
+        refs.appendChild(document.createTextNode('References: '));
+        extra.refs.forEach((ref, i) => {
+          if (i > 0) refs.appendChild(document.createTextNode(', '));
+          const a = document.createElement('a');
+          a.href = ref.url || ref.URL || '#';
+          a.textContent = ref.name || ref.Name || ref.url || '';
+          a.target = '_blank';
+          a.rel = 'noopener noreferrer';
+          refs.appendChild(a);
+        });
+        art.appendChild(refs);
+      }
+
+      if (Array.isArray(extra.verbatim) && extra.verbatim.length) {
+        this._appendVerbatim(art, extra.verbatim);
+      }
+
+      const pre = document.createElement('pre');
+      pre.className = 'demokit-step__output';
+      pre.style.display = 'none'; // shown when first chunk arrives
+      art.appendChild(pre);
+
+      this._feedEl.appendChild(art);
+      this._currentStepEl = art;
+      this._currentStepPreEl = pre;
+      this._currentStepID = extra.id || '';
+      art.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+
+    _appendChunkToLiveStep(text) {
+      if (!this._currentStepPreEl) return;
+      this._currentStepPreEl.style.display = '';
+      appendANSI(this._currentStepPreEl, text);
+    }
+
+    _closeLiveStep(status, extra) {
+      const el = this._currentStepEl;
+      if (!el) return;
+      el.classList.remove('demokit-step--status-0');
+      el.classList.add('demokit-step--status-' + status);
+
+      if (status !== 0 && extra && extra.message) {
+        const foot = document.createElement('p');
+        foot.className = 'demokit-step__status';
+        foot.textContent = (extra.label || statusLabel(status)) + ': ' + extra.message;
+        el.appendChild(foot);
+      }
+      if (extra && extra.next) {
+        const j = document.createElement('p');
+        j.className = 'demokit-step__jump';
+        j.textContent = '→ jumped to ' + extra.next;
+        el.appendChild(j);
+      }
+      this._currentStepEl = null;
+      this._currentStepPreEl = null;
+      this._currentStepID = null;
+    }
+
+    _renderLiveInputForm(stepID, inputs) {
+      const form = document.createElement('form');
+      form.className = 'demokit-input-form';
+      const fields = [];
+      inputs.forEach((inp) => {
+        const wrap = document.createElement('label');
+        wrap.className = 'demokit-input-form__field';
+        const lbl = document.createElement('span');
+        lbl.textContent = (inp.Prompt || inp.Name || inp.name || 'input') + ': ';
+        wrap.appendChild(lbl);
+
+        let ctrl;
+        const kind = inp.Kind || inp.kind;
+        if (kind === 'choice') {
+          ctrl = document.createElement('select');
+          (inp.Options || inp.options || []).forEach((opt) => {
+            const o = document.createElement('option');
+            o.value = opt;
+            o.textContent = opt;
+            ctrl.appendChild(o);
+          });
+        } else if (kind === 'int') {
+          ctrl = document.createElement('input');
+          ctrl.type = 'number';
+        } else {
+          ctrl = document.createElement('input');
+          ctrl.type = 'text';
+        }
+        ctrl.name = inp.Name || inp.name || '';
+        if (inp.Default !== undefined && inp.Default !== null) {
+          ctrl.value = String(inp.Default);
+        } else if (inp.default !== undefined && inp.default !== null) {
+          ctrl.value = String(inp.default);
+        }
+        wrap.appendChild(ctrl);
+        form.appendChild(wrap);
+        fields.push({ name: ctrl.name, el: ctrl, kind });
+      });
+
+      const submit = document.createElement('button');
+      submit.type = 'submit';
+      submit.className = 'demokit-player__btn';
+      submit.textContent = 'Submit';
+      form.appendChild(submit);
+
+      form.addEventListener('submit', (e) => {
+        e.preventDefault();
+        const values = {};
+        fields.forEach((f) => {
+          if (f.kind === 'int') {
+            values[f.name] = parseInt(f.el.value, 10);
+          } else {
+            values[f.name] = f.el.value;
+          }
+        });
+        if (this._ws && this._ws.readyState === WebSocket.OPEN) {
+          this._ws.send(JSON.stringify({ kind: 'input', values }));
+        }
+        form.remove();
+      });
+
+      this._feedEl.appendChild(form);
+      form.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+
+    _dismissLiveInputForm(timeoutMs) {
+      // Server timed out waiting for input and is continuing with
+      // declared defaults. Find the most recent input form (the one
+      // we just rendered for the current step) and replace it with
+      // a small notice.
+      const forms = this._feedEl.querySelectorAll('form.demokit-input-form');
+      const form = forms[forms.length - 1];
+      if (!form) return;
+      const note = document.createElement('p');
+      note.className = 'demokit-input-form__timeout';
+      const secs = timeoutMs ? (timeoutMs / 1000).toFixed(1) : '';
+      note.textContent = secs
+        ? `(no input after ${secs}s — continuing with defaults)`
+        : '(input timed out — continuing with defaults)';
+      form.replaceWith(note);
+      note.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+
+    _renderLiveDone() {
+      const note = document.createElement('p');
+      note.className = 'demokit-player__done';
+      note.textContent = '(demo ended)';
+      this._feedEl.appendChild(note);
+    }
+  }
+
+  // --- ANSI SGR → DOM ---
+  //
+  // Delegates to ansi_up (https://github.com/drudru/ansi_up, MIT;
+  // vendored under web/player/vendor/ — see VENDOR.md for the pin).
+  // The bundle and dev harness load ansi_up.umd.js *before* this
+  // file, so window.AnsiUp is available when appendANSI runs.
+  // Covers the full SGR table: 8-color, 256-color, true-color RGB,
+  // bold/dim/italic/underline/strikethrough.
+  //
+  // ansi_to_html escapes input itself and emits only text plus
+  // <span style=...> wrappers; running its output through DOMParser
+  // and reparenting the resulting nodes is safe and avoids touching
+  // innerHTML on the live document.
+  //
+  // Fallback: if AnsiUp isn't loaded (player JS used standalone
+  // without the vendor bundle), output renders as plain text — the
+  // escape sequences appear as literals but the step still loads.
+
+  function appendANSI(parent, text) {
+    if (text == null) return;
+    const ansiUp = new AnsiUp();
+    ansiUp.use_classes = false;
+    const safeHTML = ansiUp.ansi_to_html(String(text));
+    const parsed = new DOMParser().parseFromString(safeHTML, 'text/html');
+    while (parsed.body.firstChild) {
+      parent.appendChild(parsed.body.firstChild);
+    }
+  }
+
+  function statusLabel(status) {
+    switch (status) {
+      case 1: return 'Error';
+      case 2: return 'Warning';
+      case 3: return 'Info';
+      default: return 'Result';
+    }
+  }
+
+if (!customElements.get('demokit-demo')) {
+  customElements.define('demokit-demo', DemokitDemoElement);
+}

--- a/examples/apps/compat/customer-segmentation/bundle/index.html
+++ b/examples/apps/compat/customer-segmentation/bundle/index.html
@@ -1,0 +1,256 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>customer-segmentation — clustered scatter plot over MCP Apps</title>
+<link rel="stylesheet" href="./demokit-player.css">
+<style>
+body { margin: 2em auto; max-width: 900px; padding: 0 1em; font-family: -apple-system, BlinkMacSystemFont, sans-serif; }
+</style>
+</head>
+<body>
+<demokit-demo>{
+  "demo": {
+    "title": "customer-segmentation — clustered scatter plot over MCP Apps",
+    "description": "Walks the get-customer-data round trip end-to-end as a scripted MCP client: initialize, tools/list, tools/call with and without a segment filter, and resources/read on the App's iframe HTML. The fixture mirrors upstream's customer-segmentation-server example: 250 customers in 4 segments, drawn from clustered Gaussians (PCG-seeded server-side so the visual baseline is stable). Run `make serve` in another terminal first.",
+    "actors": [
+      {
+        "id": "Host",
+        "label": "MCP Host (this client)"
+      },
+      {
+        "id": "Server",
+        "label": "mcpkit-Go fixture (make serve)"
+      }
+    ],
+    "items": [
+      {
+        "kind": "section",
+        "title": "Setup",
+        "body": "Start the MCP server in a separate terminal first:\n\n```\nTerminal 1:  make serve         # mcpkit-Go fixture on :3101\nTerminal 2:  make demo          # this walkthrough (--tui for interactive TUI)\n```\n\nAny MCP host can connect to the running server (Claude Desktop, VS Code, MCPJam, basic-host). The walkthrough below acts as a scripted host that issues the protocol calls directly through `*mcpkit/client.Client` — no LLM, no browser. The same calls drive the iframe when you run `make demo-app EXAMPLE=customer-segmentation` in basic-host (see the [centralized guide](../README.md#other-ways-to-test-a-fixture))."
+      },
+      {
+        "kind": "step",
+        "title": "Connect to the fixture",
+        "note": "Standard MCP initialize handshake. `*client.Client.Connect()` runs initialize + notifications/initialized + stashes the session header for every subsequent call.",
+        "arrows": [
+          {
+            "from": "Host",
+            "to": "Server",
+            "label": "POST /mcp — initialize"
+          },
+          {
+            "from": "Server",
+            "to": "Host",
+            "label": "serverInfo + capabilities + Mcp-Session-Id",
+            "dashed": true
+          }
+        ],
+        "verbatim": [
+          {
+            "label": "Reproduce on the wire",
+            "variants": [
+              {
+                "label": "curl",
+                "lang": "bash",
+                "content": "# Initialize. Mcp-Session-Id comes back in the response headers.\nSID=$(curl -si -X POST http://localhost:3101/mcp \\\n  -H 'Content-Type: application/json' \\\n  -H 'Accept: text/event-stream, application/json' \\\n  -d '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"clientInfo\":{\"name\":\"curl\",\"version\":\"1\"}}}' \\\n  | awk 'tolower($1) == \"mcp-session-id:\" {gsub(/\\r/,\"\"); print $2}')\n\n# Acknowledge so the server's dispatcher unblocks.\ncurl -s -X POST http://localhost:3101/mcp \\\n  -H \"Mcp-Session-Id: $SID\" \\\n  -H 'Content-Type: application/json' \\\n  -H 'Accept: text/event-stream, application/json' \\\n  -d '{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}'",
+                "default": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "step",
+        "title": "tools/list — verify get-customer-data + its UI resource",
+        "note": "The marker that flags this tool as an App is `_meta.ui.resourceUri` (`ui://customer-segmentation/mcp-app.html`). Hosts that read either the nested (`_meta.ui.resourceUri`) or flat (`_meta.ui/resourceUri`) form both find it. The same tool list is what basic-host renders into its tools sidebar.",
+        "arrows": [
+          {
+            "from": "Host",
+            "to": "Server",
+            "label": "tools/list"
+          },
+          {
+            "from": "Server",
+            "to": "Host",
+            "label": "tools[] including get-customer-data",
+            "dashed": true
+          }
+        ],
+        "verbatim": [
+          {
+            "label": "Reproduce on the wire",
+            "variants": [
+              {
+                "label": "curl",
+                "lang": "bash",
+                "content": "curl -s -X POST http://localhost:3101/mcp \\\n  -H \"Mcp-Session-Id: $SID\" \\\n  -H 'Content-Type: application/json' \\\n  -H 'Accept: text/event-stream, application/json' \\\n  -d '{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{}}' \\\n  | jq '.result.tools[] | {name, _meta}'",
+                "default": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "step",
+        "title": "tools/call get-customer-data — full 250-row payload",
+        "note": "This is the call the iframe issues on connect — no arguments, server defaults segment to All. The handler memoizes the 250-customer pool behind sync.Once, so subsequent calls reuse the same pool and the scatter plot stays stable as you flip the dropdown.",
+        "arrows": [
+          {
+            "from": "Host",
+            "to": "Server",
+            "label": "tools/call get-customer-data {}"
+          },
+          {
+            "from": "Server",
+            "to": "Host",
+            "label": "structuredContent = { customers[250], segments[4] }",
+            "dashed": true
+          }
+        ],
+        "verbatim": [
+          {
+            "label": "Reproduce on the wire",
+            "variants": [
+              {
+                "label": "curl",
+                "lang": "bash",
+                "content": "curl -s -X POST http://localhost:3101/mcp \\\n  -H \"Mcp-Session-Id: $SID\" \\\n  -H 'Content-Type: application/json' \\\n  -H 'Accept: text/event-stream, application/json' \\\n  -d '{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"get-customer-data\",\"arguments\":{}}}' \\\n  | jq '.result.structuredContent | {n_customers: (.customers | length), segments}'",
+                "default": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "step",
+        "title": "tools/call get-customer-data {segment: \"Enterprise\"}",
+        "note": "This is the exact call the iframe issues when a user picks `Enterprise` from the segment dropdown. The handler filters the cached pool — same `segments[]` summary comes back so the legend can still show the full distribution, but `customers[]` is the Enterprise-only slice. Demonstrates the dropdown round trip without the iframe.",
+        "arrows": [
+          {
+            "from": "Host",
+            "to": "Server",
+            "label": "tools/call get-customer-data {segment:\"Enterprise\"}"
+          },
+          {
+            "from": "Server",
+            "to": "Host",
+            "label": "structuredContent.customers filtered to Enterprise only",
+            "dashed": true
+          }
+        ],
+        "verbatim": [
+          {
+            "label": "Reproduce on the wire",
+            "variants": [
+              {
+                "label": "curl",
+                "lang": "bash",
+                "content": "curl -s -X POST http://localhost:3101/mcp \\\n  -H \"Mcp-Session-Id: $SID\" \\\n  -H 'Content-Type: application/json' \\\n  -H 'Accept: text/event-stream, application/json' \\\n  -d '{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"tools/call\",\"params\":{\"name\":\"get-customer-data\",\"arguments\":{\"segment\":\"Enterprise\"}}}' \\\n  | jq '.result.structuredContent.customers | length'",
+                "default": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "step",
+        "title": "resources/read on ui://customer-segmentation/mcp-app.html",
+        "note": "Confirms the App's iframe HTML is actually served on the MCP wire. basic-host fetches the same URI once it sees `_meta.ui.resourceUri`. The bytes here should match upstream's `dist/mcp-app.html` build under `EXT_APPS_DIR=/tmp/ext-apps/examples/customer-segmentation-server/dist/`.",
+        "arrows": [
+          {
+            "from": "Host",
+            "to": "Server",
+            "label": "resources/read { uri: ui://customer-segmentation/mcp-app.html }"
+          },
+          {
+            "from": "Server",
+            "to": "Host",
+            "label": "Contents[0].Text = the iframe HTML",
+            "dashed": true
+          }
+        ],
+        "verbatim": [
+          {
+            "label": "Reproduce on the wire",
+            "variants": [
+              {
+                "label": "curl",
+                "lang": "bash",
+                "content": "curl -s -X POST http://localhost:3101/mcp \\\n  -H \"Mcp-Session-Id: $SID\" \\\n  -H 'Content-Type: application/json' \\\n  -H 'Accept: text/event-stream, application/json' \\\n  -d '{\"jsonrpc\":\"2.0\",\"id\":5,\"method\":\"resources/read\",\"params\":{\"uri\":\"ui://customer-segmentation/mcp-app.html\"}}' \\\n  | jq -r '.result.contents[0].text' | head -c 200",
+                "default": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "section",
+        "title": "What the App iframe does with all this",
+        "body": "The host → iframe handoff mechanics (`tools/call` → `resources/read` → sandboxed iframe → `postMessage`) are covered once in [The basic-host bridge dance](../README.md#the-basic-host-bridge-dance). Steps 1-5 above are the floor every MCP Apps interaction starts from.\n\ncustomer-segmentation's iframe sits at the **moderate** end of the App-ness spectrum — one tool call on load, then a few host-context hooks. The bridge calls its App SDK makes:\n\n- `app.callServerTool({name: \"get-customer-data\"})` once on connect — fetches the full 250-row pool and seeds Chart.js. The dropdown re-issues the same call with `{segment: ...}`.\n- `app.getHostContext()` — reads `theme`, `styles.variables`, `styles.css.fonts`, and `safeAreaInsets` from the host so the chart matches basic-host's light/dark mode and CSS variables.\n- `app.onhostcontextchanged` — same handler re-runs when the host flips theme, so Chart.js is destroyed + reinitialised to repaint with the new palette.\n\nNO `app.registerTool`, NO `app.updateModelContext`, NO `app.ontoolresult` — the iframe drives its own fetch loop instead of waiting for the host to push a tool result. Same shape as `cohort-heatmap`; one rung below the rich `budget-allocator` / `scenario-modeler` patterns that register app-side tools the host can call back into."
+      },
+      {
+        "kind": "section",
+        "title": "Where to look in the code",
+        "body": "- `main.go` — fixture is ~250 lines: typed tool, paired UI resource, plus the ported clustered-Gaussian generator (`generateCustomers` + `clusteredValue` + Box-Muller). The 250-customer pool is memoized via `sync.Once` so the scatter plot stays stable across calls within a session.\n- `walkthrough.go` — this file. Each step's curl + Go recipe is the canonical wire reproduction.\n- `../README.md` — narrative + screenshots + the centralized [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) guide and the bridge-dance reference section."
+      }
+    ]
+  },
+  "trace": [
+    {
+      "kind": "section",
+      "title": "Setup",
+      "body": "Start the MCP server in a separate terminal first:\n\n```\nTerminal 1:  make serve         # mcpkit-Go fixture on :3101\nTerminal 2:  make demo          # this walkthrough (--tui for interactive TUI)\n```\n\nAny MCP host can connect to the running server (Claude Desktop, VS Code, MCPJam, basic-host). The walkthrough below acts as a scripted host that issues the protocol calls directly through `*mcpkit/client.Client` — no LLM, no browser. The same calls drive the iframe when you run `make demo-app EXAMPLE=customer-segmentation` in basic-host (see the [centralized guide](../README.md#other-ways-to-test-a-fixture))."
+    },
+    {
+      "kind": "step",
+      "title": "Connect to the fixture",
+      "step_id": "step-1",
+      "visit": 1,
+      "output": "    connected to Customer Segmentation Server 1.0.0\n"
+    },
+    {
+      "kind": "step",
+      "title": "tools/list — verify get-customer-data + its UI resource",
+      "step_id": "step-2",
+      "visit": 1,
+      "output": "    get-customer-data\n      _meta: {\n        \"ui\": {\n          \"resourceUri\": \"ui://customer-segmentation/mcp-app.html\"\n        },\n        \"ui/resourceUri\": \"ui://customer-segmentation/mcp-app.html\"\n      }\n"
+    },
+    {
+      "kind": "step",
+      "title": "tools/call get-customer-data — full 250-row payload",
+      "step_id": "step-3",
+      "visit": 1,
+      "output": "    customers: 250, segments: 4\n    first customer:\n      {\n        \"accountAge\": 61,\n        \"annualRevenue\": 1819322,\n        \"employeeCount\": 292,\n        \"engagementScore\": 73,\n        \"id\": \"cust-0001\",\n        \"name\": \"Nexus Wave Industries\",\n        \"nps\": 16,\n        \"segment\": \"Mid-Market\",\n        \"supportTickets\": 19\n      }\n    segments: [\n      {\n        \"color\": \"#1e40af\",\n        \"count\": 28,\n        \"name\": \"Enterprise\"\n      },\n      {\n        \"color\": \"#0d9488\",\n        \"count\": 64,\n        \"name\": \"Mid-Market\"\n      },\n      {\n        \"color\": \"#059669\",\n        \"count\": 94,\n        \"name\": \"SMB\"\n      },\n      {\n        \"color\": \"#6366f1\",\n        \"count\": 64,\n        \"name\": \"Startup\"\n      }\n    ]\n"
+    },
+    {
+      "kind": "step",
+      "title": "tools/call get-customer-data {segment: \"Enterprise\"}",
+      "step_id": "step-4",
+      "visit": 1,
+      "output": "    Enterprise-only customers: 28 (of 250 total)\n    distinct segment values in response: [Enterprise] (expect: [Enterprise])\n"
+    },
+    {
+      "kind": "step",
+      "title": "resources/read on ui://customer-segmentation/mcp-app.html",
+      "step_id": "step-5",
+      "visit": 1,
+      "output": "    548590 bytes total; first 200:\n      \u003c!DOCTYPE html\u003e\n\u003chtml lang=\"en\"\u003e\n\u003chead\u003e\n  \u003cmeta charset=\"UTF-8\"\u003e\n  \u003cmeta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\"\u003e\n  \u003cmeta name=\"color-scheme\" content=\"light dark\"\u003e\n  \u003ctitle\u003eCus…\n"
+    },
+    {
+      "kind": "section",
+      "title": "What the App iframe does with all this",
+      "body": "The host → iframe handoff mechanics (`tools/call` → `resources/read` → sandboxed iframe → `postMessage`) are covered once in [The basic-host bridge dance](../README.md#the-basic-host-bridge-dance). Steps 1-5 above are the floor every MCP Apps interaction starts from.\n\ncustomer-segmentation's iframe sits at the **moderate** end of the App-ness spectrum — one tool call on load, then a few host-context hooks. The bridge calls its App SDK makes:\n\n- `app.callServerTool({name: \"get-customer-data\"})` once on connect — fetches the full 250-row pool and seeds Chart.js. The dropdown re-issues the same call with `{segment: ...}`.\n- `app.getHostContext()` — reads `theme`, `styles.variables`, `styles.css.fonts`, and `safeAreaInsets` from the host so the chart matches basic-host's light/dark mode and CSS variables.\n- `app.onhostcontextchanged` — same handler re-runs when the host flips theme, so Chart.js is destroyed + reinitialised to repaint with the new palette.\n\nNO `app.registerTool`, NO `app.updateModelContext`, NO `app.ontoolresult` — the iframe drives its own fetch loop instead of waiting for the host to push a tool result. Same shape as `cohort-heatmap`; one rung below the rich `budget-allocator` / `scenario-modeler` patterns that register app-side tools the host can call back into."
+    },
+    {
+      "kind": "section",
+      "title": "Where to look in the code",
+      "body": "- `main.go` — fixture is ~250 lines: typed tool, paired UI resource, plus the ported clustered-Gaussian generator (`generateCustomers` + `clusteredValue` + Box-Muller). The 250-customer pool is memoized via `sync.Once` so the scatter plot stays stable across calls within a session.\n- `walkthrough.go` — this file. Each step's curl + Go recipe is the canonical wire reproduction.\n- `../README.md` — narrative + screenshots + the centralized [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) guide and the bridge-dance reference section."
+    }
+  ]
+}
+</demokit-demo>
+<script type="module" src="./demokit-player.js"></script>
+</body>
+</html>

--- a/examples/apps/compat/customer-segmentation/main.go
+++ b/examples/apps/compat/customer-segmentation/main.go
@@ -4,19 +4,24 @@
 // SEGMENTS) and a structured output of customers + segment summaries. No
 // commas in the input description, so struct tags work. Idiomatic Go types:
 // counts and dollar/score figures are int; EngagementScore stays float64
-// (it's typically a 0-100 fractional). Visual test is a random scatter
-// plot upstream masks at the host level — our stub returns empty arrays;
-// the iframe generates its own demo data.
+// (it's typically a 0-100 fractional). The handler now ports upstream's
+// clustered-Gaussian customer generator so the iframe scatter plot renders
+// with the same shape as upstream — seeded via PCG(42, 42) for stable
+// visual baselines.
 //
 // Run:  EXT_APPS_DIR=/tmp/ext-apps PORT=3101 go run .
 package main
 
 import (
-	"strings"
 	"flag"
+	"fmt"
 	"log"
+	"math"
+	"math/rand/v2"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 
 	"github.com/panyam/mcpkit/core"
 	"github.com/panyam/mcpkit/examples/common"
@@ -50,6 +55,210 @@ type segmentSummary struct {
 type customerDataOutput struct {
 	Customers []customer       `json:"customers"`
 	Segments  []segmentSummary `json:"segments"`
+}
+
+// segments is the ordered enum used in both the input schema and the
+// generated segmentSummary list. Order matches upstream's SEGMENTS const.
+var segments = []string{"Enterprise", "Mid-Market", "SMB", "Startup"}
+
+// segmentColors mirrors upstream's SEGMENT_COLORS map — the iframe paints
+// each scatter point using these hex codes.
+var segmentColors = map[string]string{
+	"Enterprise": "#1e40af",
+	"Mid-Market": "#0d9488",
+	"SMB":        "#059669",
+	"Startup":    "#6366f1",
+}
+
+// segmentWeights mirrors upstream's SEGMENT_WEIGHTS — selectSegment picks
+// a bucket by cumulative weight so the overall distribution stays SMB-heavy.
+var segmentWeights = map[string]float64{
+	"Enterprise": 0.15,
+	"Mid-Market": 0.25,
+	"SMB":        0.35,
+	"Startup":    0.25,
+}
+
+// clusterRange is one inclusive numeric range used to draw a clustered
+// Gaussian value for one (segment, metric) cell.
+type clusterRange struct{ Min, Max float64 }
+
+// clusterCenter mirrors upstream's CLUSTER_CENTERS entry — six metric
+// ranges that shape the Gaussian distribution for one segment.
+type clusterCenter struct {
+	AnnualRevenue, EmployeeCount, AccountAge clusterRange
+	EngagementScore, SupportTickets, NPS     clusterRange
+}
+
+// clusterCenters mirrors upstream's CLUSTER_CENTERS table verbatim — these
+// numbers shape what a "typical Enterprise" vs "typical Startup" customer
+// looks like across the six metrics the scatter plot can axis on.
+var clusterCenters = map[string]clusterCenter{
+	"Enterprise": {
+		AnnualRevenue:   clusterRange{2_000_000, 10_000_000},
+		EmployeeCount:   clusterRange{500, 5000},
+		AccountAge:      clusterRange{60, 120},
+		EngagementScore: clusterRange{70, 95},
+		SupportTickets:  clusterRange{5, 20},
+		NPS:             clusterRange{40, 80},
+	},
+	"Mid-Market": {
+		AnnualRevenue:   clusterRange{500_000, 2_000_000},
+		EmployeeCount:   clusterRange{100, 500},
+		AccountAge:      clusterRange{36, 84},
+		EngagementScore: clusterRange{60, 85},
+		SupportTickets:  clusterRange{10, 30},
+		NPS:             clusterRange{20, 60},
+	},
+	"SMB": {
+		AnnualRevenue:   clusterRange{50_000, 500_000},
+		EmployeeCount:   clusterRange{10, 100},
+		AccountAge:      clusterRange{12, 48},
+		EngagementScore: clusterRange{40, 70},
+		SupportTickets:  clusterRange{15, 40},
+		NPS:             clusterRange{0, 40},
+	},
+	"Startup": {
+		AnnualRevenue:   clusterRange{10_000, 200_000},
+		EmployeeCount:   clusterRange{1, 50},
+		AccountAge:      clusterRange{1, 24},
+		EngagementScore: clusterRange{50, 90},
+		SupportTickets:  clusterRange{5, 25},
+		NPS:             clusterRange{10, 70},
+	},
+}
+
+// Company-name parts ported verbatim from upstream's data-generator.ts.
+var (
+	namePrefixes = []string{
+		"Apex", "Nova", "Prime", "Vertex", "Atlas", "Quantum", "Summit",
+		"Nexus", "Titan", "Pinnacle", "Zenith", "Vanguard", "Horizon",
+		"Stellar", "Onyx", "Cobalt", "Vector", "Pulse", "Forge", "Spark",
+	}
+	nameCores = []string{
+		"Tech", "Data", "Cloud", "Logic", "Sync", "Flow", "Core", "Net",
+		"Soft", "Wave", "Link", "Mind", "Byte", "Grid", "Hub",
+	}
+	nameSuffixes = []string{
+		"Corp", "Inc", "Solutions", "Systems", "Labs", "Group", "Industries",
+		"Dynamics", "Partners", "Ventures", "Global", "Digital",
+	}
+)
+
+// gaussianRandom is the Box-Muller transform — ported byte-for-byte from
+// upstream's gaussianRandom() so cluster shapes line up.
+func gaussianRandom(rng *rand.Rand, mean, stdDev float64) float64 {
+	u1 := rng.Float64()
+	u2 := rng.Float64()
+	z0 := math.Sqrt(-2.0*math.Log(u1)) * math.Cos(2.0*math.Pi*u2)
+	return z0*stdDev + mean
+}
+
+// clusteredValue draws one Gaussian sample centered in [min, max] with
+// stdDev = (max-min)/4, then clamps to [min*0.8, max*1.2] so an occasional
+// tail still lands plausibly. Mirrors upstream's generateClusteredValue().
+func clusteredValue(rng *rand.Rand, min, max float64) float64 {
+	mean := (min + max) / 2
+	stdDev := (max - min) / 4
+	v := gaussianRandom(rng, mean, stdDev)
+	lo := min * 0.8
+	hi := max * 1.2
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}
+
+// selectSegment picks a segment by cumulative weight, falling back to SMB
+// like upstream's selectSegment().
+func selectSegment(rng *rand.Rand) string {
+	r := rng.Float64()
+	cum := 0.0
+	for _, s := range segments {
+		cum += segmentWeights[s]
+		if r < cum {
+			return s
+		}
+	}
+	return "SMB"
+}
+
+// generateCompanyName composes a unique prefix-core-suffix triple. After
+// 100 collisions it falls back to prefix+core+random-number, same as upstream.
+func generateCompanyName(rng *rand.Rand, used map[string]bool) string {
+	for i := 0; i < 100; i++ {
+		p := namePrefixes[rng.IntN(len(namePrefixes))]
+		c := nameCores[rng.IntN(len(nameCores))]
+		s := nameSuffixes[rng.IntN(len(nameSuffixes))]
+		name := p + " " + c + " " + s
+		if !used[name] {
+			used[name] = true
+			return name
+		}
+	}
+	p := namePrefixes[rng.IntN(len(namePrefixes))]
+	c := nameCores[rng.IntN(len(nameCores))]
+	return fmt.Sprintf("%s %s %d", p, c, rng.IntN(1000))
+}
+
+// generateCustomers materialises `count` customers using the seeded RNG.
+// One deliberate Go-side change: rng is PCG(42, 42) so the visual baseline
+// under __snapshots__/ stays stable. Upstream uses Math.random() which is
+// fine for an interactive demo but not for a committed snapshot.
+func generateCustomers(count int) []customer {
+	rng := rand.New(rand.NewPCG(42, 42))
+	used := map[string]bool{}
+	out := make([]customer, 0, count)
+	for i := 0; i < count; i++ {
+		seg := selectSegment(rng)
+		center := clusterCenters[seg]
+		out = append(out, customer{
+			ID:              fmt.Sprintf("cust-%04d", i+1),
+			Name:            generateCompanyName(rng, used),
+			Segment:         seg,
+			AnnualRevenue:   int(math.Round(clusteredValue(rng, center.AnnualRevenue.Min, center.AnnualRevenue.Max))),
+			EmployeeCount:   int(math.Round(clusteredValue(rng, center.EmployeeCount.Min, center.EmployeeCount.Max))),
+			AccountAge:      int(math.Round(clusteredValue(rng, center.AccountAge.Min, center.AccountAge.Max))),
+			EngagementScore: math.Round(clusteredValue(rng, center.EngagementScore.Min, center.EngagementScore.Max)),
+			SupportTickets:  int(math.Round(clusteredValue(rng, center.SupportTickets.Min, center.SupportTickets.Max))),
+			NPS:             int(math.Round(clusteredValue(rng, center.NPS.Min, center.NPS.Max))),
+		})
+	}
+	return out
+}
+
+// generateSegmentSummaries collapses a customer slice into the four
+// segment-summary rows the iframe legend renders.
+func generateSegmentSummaries(custs []customer) []segmentSummary {
+	counts := map[string]int{}
+	for _, c := range custs {
+		counts[c.Segment]++
+	}
+	out := make([]segmentSummary, 0, len(segments))
+	for _, s := range segments {
+		out = append(out, segmentSummary{Name: s, Count: counts[s], Color: segmentColors[s]})
+	}
+	return out
+}
+
+// Session-level cache — upstream's server.ts memoizes the full 250-customer
+// generation across calls so the scatter plot stays stable as the iframe
+// flips the segment dropdown. We do the same with sync.Once.
+var (
+	custOnce         sync.Once
+	cachedCustomers  []customer
+	cachedSummaries  []segmentSummary
+)
+
+func loadCustomers() ([]customer, []segmentSummary) {
+	custOnce.Do(func() {
+		cachedCustomers = generateCustomers(250)
+		cachedSummaries = generateSegmentSummaries(cachedCustomers)
+	})
+	return cachedCustomers, cachedSummaries
 }
 
 func main() {
@@ -109,10 +318,17 @@ func serve() {
 				Description: "Returns customer data with segment information for visualization. Optionally filter by segment.",
 				Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportForbidden},
 				Handler: func(ctx core.ToolContext, in customerInput) (customerDataOutput, error) {
-					return customerDataOutput{
-						Customers: []customer{},
-						Segments:  []segmentSummary{},
-					}, nil
+					all, summaries := loadCustomers()
+					filtered := all
+					if in.Segment != "" && in.Segment != "All" {
+						filtered = filtered[:0:0]
+						for _, c := range all {
+							if c.Segment == in.Segment {
+								filtered = append(filtered, c)
+							}
+						}
+					}
+					return customerDataOutput{Customers: filtered, Segments: summaries}, nil
 				},
 				ResourceURI: resourceURI,
 				ResourceHandler: func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {

--- a/examples/apps/compat/customer-segmentation/walkthrough.go
+++ b/examples/apps/compat/customer-segmentation/walkthrough.go
@@ -10,56 +10,264 @@ import (
 	"github.com/panyam/mcpkit/examples/common"
 )
 
-// runDemo is a STUB walkthrough — it connects to the fixture and lists
-// its tools. Refine it: add a tools/call step per tool, attach
-// common.WireRecipe(step, curl, go) for the wire reproduction, drop
-// fixture-specific narrative in .Note(...). See
-// examples/apps/compat/basic-vanillajs/walkthrough.go for the full
-// pattern.
+// runDemo is the customer-segmentation walkthrough. Acts as a scripted MCP
+// host against a server started by `make serve` in another terminal.
 //
-// TODO: replace this stub with a curated walkthrough.
+// Walks five steps:
+//
+//  1. Connect to the fixture (initialize → session)
+//  2. tools/list — verify get-customer-data + its _meta.ui resourceUri
+//  3. tools/call get-customer-data {} — full 250-row payload (no filter)
+//  4. tools/call get-customer-data {segment: "Enterprise"} — same call
+//     shape the iframe's segment dropdown drives
+//  5. resources/read on the iframe resourceUri — sanity-check the HTML is
+//     served on the wire
+//
+// Each step attaches a common.WireRecipe (curl + Go) for the wire
+// reproduction.
 func runDemo() {
 	serverURL := common.MCPServerURL()
 
-	demo := demokit.New("customer-segmentation walkthrough (stub)").
-		Description("TODO: describe what this walkthrough demonstrates.").
+	demo := demokit.New("customer-segmentation — clustered scatter plot over MCP Apps").
+		Dir("customer-segmentation").
+		Description("Walks the get-customer-data round trip end-to-end as a scripted MCP client: initialize, tools/list, tools/call with and without a segment filter, and resources/read on the App's iframe HTML. The fixture mirrors upstream's customer-segmentation-server example: 250 customers in 4 segments, drawn from clustered Gaussians (PCG-seeded server-side so the visual baseline is stable). Run `make serve` in another terminal first.").
 		Actors(
 			demokit.Actor("Host", "MCP Host (this client)"),
 			demokit.Actor("Server", "mcpkit-Go fixture (make serve)"),
 		)
 
+	demo.Section("Setup",
+		"Start the MCP server in a separate terminal first:",
+		"",
+		"```",
+		"Terminal 1:  make serve         # mcpkit-Go fixture on :3101",
+		"Terminal 2:  make demo          # this walkthrough (--tui for interactive TUI)",
+		"```",
+		"",
+		"Any MCP host can connect to the running server (Claude Desktop, VS Code, MCPJam, basic-host). The walkthrough below acts as a scripted host that issues the protocol calls directly through `*mcpkit/client.Client` — no LLM, no browser. The same calls drive the iframe when you run `make demo-app EXAMPLE=customer-segmentation` in basic-host (see the [centralized guide](../README.md#other-ways-to-test-a-fixture)).",
+	)
+
 	var c *client.Client
 
-	demo.Step("Connect to the fixture").
+	step1 := demo.Step("Connect to the fixture").
 		Arrow("Host", "Server", "POST /mcp — initialize").
 		DashedArrow("Server", "Host", "serverInfo + capabilities + Mcp-Session-Id").
-		Note("Stub — refine in walkthrough.go.").
-		Run(func(ctx demokit.StepContext) *demokit.StepResult {
-			c = client.NewClient(serverURL+"/mcp",
-				core.ClientInfo{Name: "customer-segmentation-host", Version: "1.0"},
-			)
-			if err := c.Connect(); err != nil {
-				fmt.Printf("    ERROR: %v\n    Start the server with: make serve\n", err)
-				return nil
-			}
-			fmt.Printf("    connected to %s %s\n", c.ServerInfo.Name, c.ServerInfo.Version)
-			return nil
-		})
+		Note("Standard MCP initialize handshake. `*client.Client.Connect()` runs initialize + notifications/initialized + stashes the session header for every subsequent call.")
+	common.WireRecipe(step1,
+		`# Initialize. Mcp-Session-Id comes back in the response headers.
+SID=$(curl -si -X POST `+serverURL+`/mcp \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: text/event-stream, application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"curl","version":"1"}}}' \
+  | awk 'tolower($1) == "mcp-session-id:" {gsub(/\r/,""); print $2}')
 
-	demo.Step("List tools").
-		Arrow("Host", "Server", "tools/list").
-		DashedArrow("Server", "Host", "tools[]").
-		Note("Stub — refine in walkthrough.go.").
-		Run(func(ctx demokit.StepContext) *demokit.StepResult {
-			res, err := c.Call("tools/list", map[string]any{})
-			if err != nil {
-				fmt.Printf("    ERROR: %v\n", err)
-				return nil
-			}
-			pretty, _ := json.MarshalIndent(json.RawMessage(res.Raw), "    ", "  ")
-			fmt.Printf("    %s\n", string(pretty))
+# Acknowledge so the server's dispatcher unblocks.
+curl -s -X POST `+serverURL+`/mcp \
+  -H "Mcp-Session-Id: $SID" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: text/event-stream, application/json' \
+  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}'`,
+		`c := client.NewClient("`+serverURL+`/mcp",
+    core.ClientInfo{Name: "customer-segmentation-host", Version: "1.0"},
+)
+if err := c.Connect(); err != nil {
+    log.Fatalf("connect: %v", err)
+}`,
+	).Run(func(ctx demokit.StepContext) *demokit.StepResult {
+		c = client.NewClient(serverURL+"/mcp",
+			core.ClientInfo{Name: "customer-segmentation-host", Version: "1.0"},
+		)
+		if err := c.Connect(); err != nil {
+			fmt.Printf("    ERROR: %v\n    Start the server with: make serve\n", err)
 			return nil
+		}
+		fmt.Printf("    connected to %s %s\n", c.ServerInfo.Name, c.ServerInfo.Version)
+		return nil
+	})
+
+	step2 := demo.Step("tools/list — verify get-customer-data + its UI resource").
+		Arrow("Host", "Server", "tools/list").
+		DashedArrow("Server", "Host", "tools[] including get-customer-data").
+		Note("The marker that flags this tool as an App is `_meta.ui.resourceUri` (`ui://customer-segmentation/mcp-app.html`). Hosts that read either the nested (`_meta.ui.resourceUri`) or flat (`_meta.ui/resourceUri`) form both find it. The same tool list is what basic-host renders into its tools sidebar.")
+	common.WireRecipe(step2,
+		`curl -s -X POST `+serverURL+`/mcp \
+  -H "Mcp-Session-Id: $SID" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: text/event-stream, application/json' \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' \
+  | jq '.result.tools[] | {name, _meta}'`,
+		`res, _ := c.Call("tools/list", map[string]any{})
+var out struct {
+    Tools []struct {
+        Name string         `+"`json:\"name\"`"+`
+        Meta map[string]any `+"`json:\"_meta,omitempty\"`"+`
+    } `+"`json:\"tools\"`"+`
+}
+json.Unmarshal(res.Raw, &out)
+for _, t := range out.Tools {
+    fmt.Printf("  %s: %v\n", t.Name, t.Meta)
+}`,
+	).Run(func(ctx demokit.StepContext) *demokit.StepResult {
+		res, err := c.Call("tools/list", map[string]any{})
+		if err != nil {
+			fmt.Printf("    ERROR: %v\n", err)
+			return nil
+		}
+		var out struct {
+			Tools []struct {
+				Name string         `json:"name"`
+				Meta map[string]any `json:"_meta,omitempty"`
+			} `json:"tools"`
+		}
+		if err := json.Unmarshal(res.Raw, &out); err != nil {
+			fmt.Printf("    ERROR decoding tools/list: %v\n", err)
+			return nil
+		}
+		for _, t := range out.Tools {
+			pretty, _ := json.MarshalIndent(t.Meta, "      ", "  ")
+			fmt.Printf("    %s\n      _meta: %s\n", t.Name, string(pretty))
+		}
+		return nil
+	})
+
+	step3 := demo.Step("tools/call get-customer-data — full 250-row payload").
+		Arrow("Host", "Server", "tools/call get-customer-data {}").
+		DashedArrow("Server", "Host", "structuredContent = { customers[250], segments[4] }").
+		Note("This is the call the iframe issues on connect — no arguments, server defaults segment to All. The handler memoizes the 250-customer pool behind sync.Once, so subsequent calls reuse the same pool and the scatter plot stays stable as you flip the dropdown.")
+	common.WireRecipe(step3,
+		`curl -s -X POST `+serverURL+`/mcp \
+  -H "Mcp-Session-Id: $SID" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: text/event-stream, application/json' \
+  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"get-customer-data","arguments":{}}}' \
+  | jq '.result.structuredContent | {n_customers: (.customers | length), segments}'`,
+		`tr, _ := c.ToolCallFull("get-customer-data", map[string]any{})
+// tr.StructuredContent: { customers: [...], segments: [...] }
+sc := tr.StructuredContent.(map[string]any)
+fmt.Printf("customers: %d\n", len(sc["customers"].([]any)))
+pretty, _ := json.MarshalIndent(sc["segments"], "", "  ")
+fmt.Println(string(pretty))`,
+	).Run(func(ctx demokit.StepContext) *demokit.StepResult {
+		tr, err := c.ToolCallFull("get-customer-data", map[string]any{})
+		if err != nil {
+			fmt.Printf("    ERROR: %v\n", err)
+			return nil
+		}
+		sc, _ := tr.StructuredContent.(map[string]any)
+		if sc == nil {
+			fmt.Printf("    structuredContent missing or wrong shape\n")
+			return nil
+		}
+		custs, _ := sc["customers"].([]any)
+		segs, _ := sc["segments"].([]any)
+		fmt.Printf("    customers: %d, segments: %d\n", len(custs), len(segs))
+		if len(custs) > 0 {
+			first, _ := json.MarshalIndent(custs[0], "      ", "  ")
+			fmt.Printf("    first customer:\n      %s\n", string(first))
+		}
+		pretty, _ := json.MarshalIndent(segs, "    ", "  ")
+		fmt.Printf("    segments: %s\n", string(pretty))
+		return nil
+	})
+
+	step4 := demo.Step("tools/call get-customer-data {segment: \"Enterprise\"}").
+		Arrow("Host", "Server", "tools/call get-customer-data {segment:\"Enterprise\"}").
+		DashedArrow("Server", "Host", "structuredContent.customers filtered to Enterprise only").
+		Note("This is the exact call the iframe issues when a user picks `Enterprise` from the segment dropdown. The handler filters the cached pool — same `segments[]` summary comes back so the legend can still show the full distribution, but `customers[]` is the Enterprise-only slice. Demonstrates the dropdown round trip without the iframe.")
+	common.WireRecipe(step4,
+		`curl -s -X POST `+serverURL+`/mcp \
+  -H "Mcp-Session-Id: $SID" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: text/event-stream, application/json' \
+  -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"get-customer-data","arguments":{"segment":"Enterprise"}}}' \
+  | jq '.result.structuredContent.customers | length'`,
+		`tr, _ := c.ToolCallFull("get-customer-data", map[string]any{
+    "segment": "Enterprise",
+})
+sc := tr.StructuredContent.(map[string]any)
+fmt.Printf("enterprise customers: %d\n", len(sc["customers"].([]any)))`,
+	).Run(func(ctx demokit.StepContext) *demokit.StepResult {
+		tr, err := c.ToolCallFull("get-customer-data", map[string]any{
+			"segment": "Enterprise",
 		})
+		if err != nil {
+			fmt.Printf("    ERROR: %v\n", err)
+			return nil
+		}
+		sc, _ := tr.StructuredContent.(map[string]any)
+		if sc == nil {
+			fmt.Printf("    structuredContent missing\n")
+			return nil
+		}
+		custs, _ := sc["customers"].([]any)
+		fmt.Printf("    Enterprise-only customers: %d (of 250 total)\n", len(custs))
+		if len(custs) > 0 {
+			seen := map[string]bool{}
+			for _, c := range custs {
+				cm, _ := c.(map[string]any)
+				if seg, ok := cm["segment"].(string); ok {
+					seen[seg] = true
+				}
+			}
+			segs := make([]string, 0, len(seen))
+			for s := range seen {
+				segs = append(segs, s)
+			}
+			fmt.Printf("    distinct segment values in response: %v (expect: [Enterprise])\n", segs)
+		}
+		return nil
+	})
+
+	step5 := demo.Step("resources/read on ui://customer-segmentation/mcp-app.html").
+		Arrow("Host", "Server", "resources/read { uri: ui://customer-segmentation/mcp-app.html }").
+		DashedArrow("Server", "Host", "Contents[0].Text = the iframe HTML").
+		Note("Confirms the App's iframe HTML is actually served on the MCP wire. basic-host fetches the same URI once it sees `_meta.ui.resourceUri`. The bytes here should match upstream's `dist/mcp-app.html` build under `EXT_APPS_DIR=/tmp/ext-apps/examples/customer-segmentation-server/dist/`.")
+	common.WireRecipe(step5,
+		`curl -s -X POST `+serverURL+`/mcp \
+  -H "Mcp-Session-Id: $SID" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: text/event-stream, application/json' \
+  -d '{"jsonrpc":"2.0","id":5,"method":"resources/read","params":{"uri":"ui://customer-segmentation/mcp-app.html"}}' \
+  | jq -r '.result.contents[0].text' | head -c 200`,
+		`text, _ := c.ReadResource("ui://customer-segmentation/mcp-app.html")
+fmt.Printf("first 200 bytes: %.200s\n", text)`,
+	).Run(func(ctx demokit.StepContext) *demokit.StepResult {
+		text, err := c.ReadResource("ui://customer-segmentation/mcp-app.html")
+		if err != nil {
+			fmt.Printf("    ERROR: %v\n", err)
+			return nil
+		}
+		preview := text
+		if len(preview) > 200 {
+			preview = preview[:200] + "…"
+		}
+		fmt.Printf("    %d bytes total; first 200:\n      %s\n", len(text), preview)
+		return nil
+	})
+
+	demo.Section("What the App iframe does with all this",
+		"The host → iframe handoff mechanics (`tools/call` → `resources/read` → sandboxed iframe → `postMessage`) are covered once in [The basic-host bridge dance](../README.md#the-basic-host-bridge-dance). Steps 1-5 above are the floor every MCP Apps interaction starts from.",
+		"",
+		"customer-segmentation's iframe sits at the **moderate** end of the App-ness spectrum — one tool call on load, then a few host-context hooks. The bridge calls its App SDK makes:",
+		"",
+		"- `app.callServerTool({name: \"get-customer-data\"})` once on connect — fetches the full 250-row pool and seeds Chart.js. The dropdown re-issues the same call with `{segment: ...}`.",
+		"- `app.getHostContext()` — reads `theme`, `styles.variables`, `styles.css.fonts`, and `safeAreaInsets` from the host so the chart matches basic-host's light/dark mode and CSS variables.",
+		"- `app.onhostcontextchanged` — same handler re-runs when the host flips theme, so Chart.js is destroyed + reinitialised to repaint with the new palette.",
+		"",
+		"NO `app.registerTool`, NO `app.updateModelContext`, NO `app.ontoolresult` — the iframe drives its own fetch loop instead of waiting for the host to push a tool result. Same shape as `cohort-heatmap`; one rung below the rich `budget-allocator` / `scenario-modeler` patterns that register app-side tools the host can call back into.",
+	)
+
+	demo.Section("Where to look in the code",
+		"- `main.go` — fixture is ~250 lines: typed tool, paired UI resource, plus the ported clustered-Gaussian generator (`generateCustomers` + `clusteredValue` + Box-Muller). The 250-customer pool is memoized via `sync.Once` so the scatter plot stays stable across calls within a session.",
+		"- `walkthrough.go` — this file. Each step's curl + Go recipe is the canonical wire reproduction.",
+		"- `../README.md` — narrative + screenshots + the centralized [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) guide and the bridge-dance reference section.",
+	)
+
+	_ = step1
+	_ = step2
+	_ = step3
+	_ = step4
+	_ = step5
 
 	common.SetupRenderer(demo)
 	demo.Execute()

--- a/examples/apps/compat/customer-segmentation/walkthrough.trace.json
+++ b/examples/apps/compat/customer-segmentation/walkthrough.trace.json
@@ -1,0 +1,52 @@
+[
+  {
+    "kind": "section",
+    "title": "Setup",
+    "body": "Start the MCP server in a separate terminal first:\n\n```\nTerminal 1:  make serve         # mcpkit-Go fixture on :3101\nTerminal 2:  make demo          # this walkthrough (--tui for interactive TUI)\n```\n\nAny MCP host can connect to the running server (Claude Desktop, VS Code, MCPJam, basic-host). The walkthrough below acts as a scripted host that issues the protocol calls directly through `*mcpkit/client.Client` — no LLM, no browser. The same calls drive the iframe when you run `make demo-app EXAMPLE=customer-segmentation` in basic-host (see the [centralized guide](../README.md#other-ways-to-test-a-fixture))."
+  },
+  {
+    "kind": "step",
+    "title": "Connect to the fixture",
+    "step_id": "step-1",
+    "visit": 1,
+    "output": "    connected to Customer Segmentation Server 1.0.0\n"
+  },
+  {
+    "kind": "step",
+    "title": "tools/list — verify get-customer-data + its UI resource",
+    "step_id": "step-2",
+    "visit": 1,
+    "output": "    get-customer-data\n      _meta: {\n        \"ui\": {\n          \"resourceUri\": \"ui://customer-segmentation/mcp-app.html\"\n        },\n        \"ui/resourceUri\": \"ui://customer-segmentation/mcp-app.html\"\n      }\n"
+  },
+  {
+    "kind": "step",
+    "title": "tools/call get-customer-data — full 250-row payload",
+    "step_id": "step-3",
+    "visit": 1,
+    "output": "    customers: 250, segments: 4\n    first customer:\n      {\n        \"accountAge\": 61,\n        \"annualRevenue\": 1819322,\n        \"employeeCount\": 292,\n        \"engagementScore\": 73,\n        \"id\": \"cust-0001\",\n        \"name\": \"Nexus Wave Industries\",\n        \"nps\": 16,\n        \"segment\": \"Mid-Market\",\n        \"supportTickets\": 19\n      }\n    segments: [\n      {\n        \"color\": \"#1e40af\",\n        \"count\": 28,\n        \"name\": \"Enterprise\"\n      },\n      {\n        \"color\": \"#0d9488\",\n        \"count\": 64,\n        \"name\": \"Mid-Market\"\n      },\n      {\n        \"color\": \"#059669\",\n        \"count\": 94,\n        \"name\": \"SMB\"\n      },\n      {\n        \"color\": \"#6366f1\",\n        \"count\": 64,\n        \"name\": \"Startup\"\n      }\n    ]\n"
+  },
+  {
+    "kind": "step",
+    "title": "tools/call get-customer-data {segment: \"Enterprise\"}",
+    "step_id": "step-4",
+    "visit": 1,
+    "output": "    Enterprise-only customers: 28 (of 250 total)\n    distinct segment values in response: [Enterprise] (expect: [Enterprise])\n"
+  },
+  {
+    "kind": "step",
+    "title": "resources/read on ui://customer-segmentation/mcp-app.html",
+    "step_id": "step-5",
+    "visit": 1,
+    "output": "    548590 bytes total; first 200:\n      \u003c!DOCTYPE html\u003e\n\u003chtml lang=\"en\"\u003e\n\u003chead\u003e\n  \u003cmeta charset=\"UTF-8\"\u003e\n  \u003cmeta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\"\u003e\n  \u003cmeta name=\"color-scheme\" content=\"light dark\"\u003e\n  \u003ctitle\u003eCus…\n"
+  },
+  {
+    "kind": "section",
+    "title": "What the App iframe does with all this",
+    "body": "The host → iframe handoff mechanics (`tools/call` → `resources/read` → sandboxed iframe → `postMessage`) are covered once in [The basic-host bridge dance](../README.md#the-basic-host-bridge-dance). Steps 1-5 above are the floor every MCP Apps interaction starts from.\n\ncustomer-segmentation's iframe sits at the **moderate** end of the App-ness spectrum — one tool call on load, then a few host-context hooks. The bridge calls its App SDK makes:\n\n- `app.callServerTool({name: \"get-customer-data\"})` once on connect — fetches the full 250-row pool and seeds Chart.js. The dropdown re-issues the same call with `{segment: ...}`.\n- `app.getHostContext()` — reads `theme`, `styles.variables`, `styles.css.fonts`, and `safeAreaInsets` from the host so the chart matches basic-host's light/dark mode and CSS variables.\n- `app.onhostcontextchanged` — same handler re-runs when the host flips theme, so Chart.js is destroyed + reinitialised to repaint with the new palette.\n\nNO `app.registerTool`, NO `app.updateModelContext`, NO `app.ontoolresult` — the iframe drives its own fetch loop instead of waiting for the host to push a tool result. Same shape as `cohort-heatmap`; one rung below the rich `budget-allocator` / `scenario-modeler` patterns that register app-side tools the host can call back into."
+  },
+  {
+    "kind": "section",
+    "title": "Where to look in the code",
+    "body": "- `main.go` — fixture is ~250 lines: typed tool, paired UI resource, plus the ported clustered-Gaussian generator (`generateCustomers` + `clusteredValue` + Box-Muller). The 250-customer pool is memoized via `sync.Once` so the scatter plot stays stable across calls within a session.\n- `walkthrough.go` — this file. Each step's curl + Go recipe is the canonical wire reproduction.\n- `../README.md` — narrative + screenshots + the centralized [Other ways to test a fixture](../README.md#other-ways-to-test-a-fixture) guide and the bridge-dance reference section."
+  }
+]

--- a/examples/common/walkthrough.go
+++ b/examples/common/walkthrough.go
@@ -52,6 +52,11 @@ func ServerURL() string {
 // walkthrough.go calls this — keeps the :3101 default in one place
 // instead of duplicating a serverURLFor3101 helper per fixture.
 func MCPServerURL() string {
+	for i, arg := range os.Args[1:] {
+		if arg == "--url" && i+2 < len(os.Args) {
+			return os.Args[i+2]
+		}
+	}
 	if u := os.Getenv(ServerURLEnv); u != "" {
 		return u
 	}


### PR DESCRIPTION
## What changes

`customer-segmentation` was a blank-iframe fixture — handler returned empty `Customers[]` / `Segments[]` slices, so basic-host loaded the App and got nothing to plot. Same bug family as `cohort-heatmap` (PR 695).

This PR:

1. **Data port (main.go).** Ports upstream's `data-generator.ts` byte-for-byte — segment weights, cluster centers, Box-Muller Gaussian, name pools. Seeded `PCG(42, 42)` server-side so visual baselines stay stable across runs. 250-row pool memoized via `sync.Once` so the iframe's segment dropdown re-filters the same dataset.
2. **Walkthrough (walkthrough.go).** Five steps with curl + Go recipes: connect, tools/list, tools/call default (250 rows), tools/call `{segment: "Enterprise"}` (filter round trip), resources/read. Narrative section links to the central bridge-dance section in `compat/README.md` (matches the dedup refactor in b554cb6).
3. **Drive-by infra fix (common/walkthrough.go).** `MCPServerURL()` now honours `--url <addr>` parallel to `ServerURL()`. Without this, walkthroughs silently connected to whatever was on `:3101` (e.g. a long-running `make demo-app` preview the user left open), shadowing the dev-port server under test. Caught this exact footgun mid-recording.
4. **README to TEMPLATE.md shape.** Walkthrough player link, real "what it shows" bullets describing the generator + filter round trip, expanded basic-host steps that walk the axis selectors.

## Reviewer's guide

Read in this order:

1. [examples/apps/compat/customer-segmentation/main.go](https://github.com/panyam/mcpkit/pull/698/files#diff-4b761cbe0f95ad48f32bc21a6b631b3566b10ef126d0aa740d3fb47942159193) — start here. The data port is ~200 new lines: segment weights, cluster centers, Box-Muller Gaussian, name generator, session-level cache. Handler now calls `loadCustomers()` + filters by segment.
2. [examples/apps/compat/customer-segmentation/walkthrough.go](https://github.com/panyam/mcpkit/pull/698/files#diff-f1d2d5b7bc6426f2b4f5b915ee645199bdce12b4fa2f7f1df597da52942ba989) — 5-step walkthrough. Step 4 is the interesting one — same call shape the iframe's dropdown drives.
3. [examples/common/walkthrough.go](https://github.com/panyam/mcpkit/pull/698/files#diff-058737fb5cea8755994fd87ebb7959280a825208e3b0313aa54e9b6455bdc51e) — 5-line `--url` flag addition. Confirm shape matches `ServerURL()`.
4. [examples/apps/compat/customer-segmentation/README.md](https://github.com/panyam/mcpkit/pull/698/files#diff-804844719d15e95036ed4c76b15a29fd02f8853e1a56c1ff3a5d01c1f4d5d472) — TEMPLATE.md shape.

Skim or skip: `walkthrough.trace.json`, `bundle/*` (generated artifacts).

## Decision log

- **Bundled data port + walkthrough in one PR.** Same pattern as PR 695 (cohort-heatmap). Walkthrough needs working data to record cleanly; splitting would mean two re-records.
- **`PCG(42, 42)` seed, not `Math.random()`.** Upstream's TS is non-deterministic. Fine for an interactive demo, but the committed `__snapshots__/` baselines need a stable layout. Determinism only matters for the snapshot gate; runtime behavior is identical.
- **`sync.Once` for the 250-row pool, not a map cache.** Upstream uses a module-level `cachedCustomers`. `sync.Once` is the Go-idiomatic equivalent and avoids the race a plain nil-check would have under concurrent first-call.
- **`--url` flag on `MCPServerURL()` is technically scope creep**, but the bug it papered over (silent connect to `:3101`) cost a re-record and would bite every future fixture walkthrough. 5 lines, parallel to existing `ServerURL()`.

## Risk / blast radius

- **Affects:** `customer-segmentation` fixture (data, walkthrough, README) + the shared `common.MCPServerURL()` helper.
- **Tests covering this:** Manual verification — server probe confirmed 250 customers / 4 segments returned, first customer deterministic across two processes. Walkthrough trace re-recorded and inspected; step 3 shows 250 customers + 4 segment summaries, step 4 shows 28 Enterprise-only customers.
- **Be paranoid about:** the `--url` flag change. Other compat fixture walkthroughs already shipped use `common.MCPServerURL()` — they'll now also pick up `--url` next time they're re-recorded. No behavioural change for runs that don't pass the flag.

## Before / after

Before — handler returned `{Customers: []customer{}, Segments: []segmentSummary{}}`:

```
trace step 3 output: "customers: 0, segments: 0"
```

After — handler returns the clustered-Gaussian pool:

```
trace step 3 output: "customers: 250, segments: 4"
trace step 4 output: "Enterprise-only customers: 28 (of 250 total)"
```

Determinism check (PCG seed):

```
cust-0001 = Nexus Wave Industries, Mid-Market, $1,819,322 rev, 292 emp
(same across runs / processes)
```

## Out of scope (deliberately deferred)

- `scenario-modeler` likely has the same blank-iframe bug (last remaining rung-4 fixture). Will surface as the user runs the demo on it.
- Screenshots stay user-supplied — `screenshots/` still contains only the placeholder README. The user is in the screenshot+pause loop with me; they will drop a real `01-cluster-view.png` after eyeballing the live demo.
