### PR TITLE
spec: rename DRAFT-2026-v1 wire string to 2026-07-28

### DIFF
--- a/client/version_negotiate_test.go
+++ b/client/version_negotiate_test.go
@@ -18,12 +18,12 @@ func TestPickSupportedVersion(t *testing.T) {
 		client           []string
 		want             string
 	}{
-		{"single-match", []string{"DRAFT-2026-v1"}, []string{"DRAFT-2026-v1"}, "DRAFT-2026-v1"},
-		{"client-preference-newest-first", []string{"2024-11-05", "DRAFT-2026-v1"}, []string{"DRAFT-2026-v1", "2024-11-05"}, "DRAFT-2026-v1"},
-		{"server-only-old", []string{"2024-11-05"}, []string{"DRAFT-2026-v1"}, ""},
-		{"empty-server", []string{}, []string{"DRAFT-2026-v1"}, ""},
-		{"empty-client", []string{"DRAFT-2026-v1"}, []string{}, ""},
-		{"no-overlap", []string{"2025-03-26"}, []string{"DRAFT-2026-v1"}, ""},
+		{"single-match", []string{"2026-07-28"}, []string{"2026-07-28"}, "2026-07-28"},
+		{"client-preference-newest-first", []string{"2024-11-05", "2026-07-28"}, []string{"2026-07-28", "2024-11-05"}, "2026-07-28"},
+		{"server-only-old", []string{"2024-11-05"}, []string{"2026-07-28"}, ""},
+		{"empty-server", []string{}, []string{"2026-07-28"}, ""},
+		{"empty-client", []string{"2026-07-28"}, []string{}, ""},
+		{"no-overlap", []string{"2025-03-26"}, []string{"2026-07-28"}, ""},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := pickSupportedVersion(tc.server, tc.client); got != tc.want {
@@ -46,17 +46,17 @@ func TestIsUnsupportedVersionError(t *testing.T) {
 			"32001-with-supported-draft",
 			&rpcResponse{Error: &core.Error{
 				Code: -32001, Message: "Unsupported protocol version",
-				Data: map[string]any{"supported": []any{"DRAFT-2026-v1"}},
+				Data: map[string]any{"supported": []any{"2026-07-28"}},
 			}},
-			true, "DRAFT-2026-v1",
+			true, "2026-07-28",
 		},
 		{
 			"32004-with-supported-draft",
 			&rpcResponse{Error: &core.Error{
 				Code: -32004, Message: "UnsupportedVersion",
-				Data: map[string]any{"supported": []any{"DRAFT-2026-v1"}},
+				Data: map[string]any{"supported": []any{"2026-07-28"}},
 			}},
-			true, "DRAFT-2026-v1",
+			true, "2026-07-28",
 		},
 		{
 			"32001-header-mismatch-no-supported",
@@ -78,7 +78,7 @@ func TestIsUnsupportedVersionError(t *testing.T) {
 			"other-error-code-with-supported",
 			&rpcResponse{Error: &core.Error{
 				Code: -32603, Message: "internal error",
-				Data: map[string]any{"supported": []any{"DRAFT-2026-v1"}},
+				Data: map[string]any{"supported": []any{"2026-07-28"}},
 			}},
 			false, "",
 		},
@@ -86,9 +86,9 @@ func TestIsUnsupportedVersionError(t *testing.T) {
 			"typed-string-slice-supported",
 			&rpcResponse{Error: &core.Error{
 				Code: -32004,
-				Data: map[string]any{"supported": []string{"DRAFT-2026-v1"}},
+				Data: map[string]any{"supported": []string{"2026-07-28"}},
 			}},
-			true, "DRAFT-2026-v1",
+			true, "2026-07-28",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/testclient/request_metadata.go
+++ b/cmd/testclient/request_metadata.go
@@ -5,7 +5,7 @@ package main
 //
 // The scenario's mock server is a bare HTTP server — no MCP initialize
 // handshake — but it DOES handle `server/discover` (returning a
-// DRAFT-2026-v1 supported version), which means a stateless-wire mcpkit
+// 2026-07-28 supported version), which means a stateless-wire mcpkit
 // client connects cleanly. After connect, every subsequent POST carries
 // the SEP-2575 `_meta` envelope (protocolVersion, clientInfo,
 // clientCapabilities) and the `MCP-Protocol-Version` header — exactly

--- a/conformance/baseline.yml
+++ b/conformance/baseline.yml
@@ -38,7 +38,7 @@ client:
   # 2025-03-26 spec backcompat — wontfix per #451. Both scenarios test
   # the auth flow shapes the spec removed in 2025-06-18 (rootless OAuth
   # metadata, fallback to OAuth-standard endpoints when no metadata
-  # endpoints exist). mcpkit targets 2025-11-25 + DRAFT-2026-v1; servers
+  # endpoints exist). mcpkit targets 2025-11-25 + 2026-07-28; servers
   # stuck on 2025-03-26 hit a clear "PRM endpoint missing" error from
   # ext/auth/discovery.go that points at the spec gap. See
   # ext/auth/docs/DESIGN.md "Supported spec versions" for the policy.

--- a/core/header_mismatch_data_test.go
+++ b/core/header_mismatch_data_test.go
@@ -86,15 +86,15 @@ func TestHeaderMismatchData_DecodeWithoutExtras(t *testing.T) {
 	wire := []byte(`{
 		"reason":   "MCP-Protocol-Version header value does not match request body",
 		"header":   "MCP-Protocol-Version",
-		"expected": "DRAFT-2026-v1",
+		"expected": "2026-07-28",
 		"received": "v999.0.0"
 	}`)
 	var d HeaderMismatchData
 	if err := json.Unmarshal(wire, &d); err != nil {
 		t.Fatalf("Unmarshal: %v", err)
 	}
-	if d.Expected != "DRAFT-2026-v1" {
-		t.Errorf("Expected = %q, want DRAFT-2026-v1", d.Expected)
+	if d.Expected != "2026-07-28" {
+		t.Errorf("Expected = %q, want 2026-07-28", d.Expected)
 	}
 	if d.Extra != nil {
 		t.Errorf("Extra populated when wire carried no extras: %+v", d.Extra)

--- a/core/protocol.go
+++ b/core/protocol.go
@@ -133,4 +133,11 @@ const StreamableHTTPAccept = "application/json, text/event-stream"
 // of their inclusion in a dated stable. Shared by every draft-targeted SEP,
 // not specific to any one of them — see core/stateless.go for the SEP-2575
 // stateless-wire surfaces that key off this version string.
-const DraftProtocolVersion2026V1 = "DRAFT-2026-v1"
+//
+// The CONSTANT NAME labels the draft window. The VALUE is the dated wire
+// string the spec adopted in modelcontextprotocol/spec PR 331 (merged
+// 2026-06-08): the prior DRAFT placeholder was replaced with the dated
+// "2026-07-28" form, which is the literal that now appears on the wire in
+// `MCP-Protocol-Version` headers and `_meta.io.modelcontextprotocol/protocolVersion`.
+// Treat this constant as the source of truth — never hardcode either form.
+const DraftProtocolVersion2026V1 = "2026-07-28"

--- a/core/stateless_test.go
+++ b/core/stateless_test.go
@@ -57,7 +57,7 @@ func TestDecodeRequestMeta_MissingRequiredSubfields(t *testing.T) {
 		{
 			"missing clientInfo",
 			`{
-				"io.modelcontextprotocol/protocolVersion":"DRAFT-2026-v1",
+				"io.modelcontextprotocol/protocolVersion":"2026-07-28",
 				"io.modelcontextprotocol/clientCapabilities":{}
 			}`,
 			"clientInfo",
@@ -65,7 +65,7 @@ func TestDecodeRequestMeta_MissingRequiredSubfields(t *testing.T) {
 		{
 			"missing clientCapabilities",
 			`{
-				"io.modelcontextprotocol/protocolVersion":"DRAFT-2026-v1",
+				"io.modelcontextprotocol/protocolVersion":"2026-07-28",
 				"io.modelcontextprotocol/clientInfo":{"name":"c","version":"1"}
 			}`,
 			"clientCapabilities",
@@ -129,7 +129,7 @@ func TestClientCaps_BareContext_NilSafe(t *testing.T) {
 func TestDecodeRequestMeta_ValidEnvelope(t *testing.T) {
 	params := []byte(`{
 		"_meta": {
-			"io.modelcontextprotocol/protocolVersion": "DRAFT-2026-v1",
+			"io.modelcontextprotocol/protocolVersion": "2026-07-28",
 			"io.modelcontextprotocol/clientInfo": {"name":"conformance-client","version":"1.0.0"},
 			"io.modelcontextprotocol/clientCapabilities": {"sampling": {}}
 		},
@@ -153,7 +153,7 @@ func TestDecodeRequestMeta_ValidEnvelope(t *testing.T) {
 func TestDecodeRequestMeta_LogLevelOptIn(t *testing.T) {
 	params := []byte(`{
 		"_meta": {
-			"io.modelcontextprotocol/protocolVersion": "DRAFT-2026-v1",
+			"io.modelcontextprotocol/protocolVersion": "2026-07-28",
 			"io.modelcontextprotocol/clientInfo": {"name":"c","version":"1"},
 			"io.modelcontextprotocol/clientCapabilities": {},
 			"io.modelcontextprotocol/logLevel": "info"
@@ -190,7 +190,7 @@ func TestErrorPayloadShapes(t *testing.T) {
 	// SEP-2575 conformance suite's JSON path expectations.
 	t.Run("UnsupportedProtocolVersionData", func(t *testing.T) {
 		d := UnsupportedProtocolVersionData{
-			Supported: []string{"DRAFT-2026-v1", "2025-11-25"},
+			Supported: []string{"2026-07-28", "2025-11-25"},
 			Requested: "1900-01-01",
 		}
 		b, err := json.Marshal(d)

--- a/docs/MRTR_TUTORIAL.md
+++ b/docs/MRTR_TUTORIAL.md
@@ -164,7 +164,7 @@ On stateless, the envelope is required on every request:
   "params": {
     "name": "tools/call",
     "_meta": {
-      "io.modelcontextprotocol/protocolVersion":    "DRAFT-2026-v1",
+      "io.modelcontextprotocol/protocolVersion":    "2026-07-28",
       "io.modelcontextprotocol/clientInfo":         { ... },
       "io.modelcontextprotocol/clientCapabilities": {
         "elicitation": {},
@@ -552,7 +552,7 @@ tasks.Register(tasks.Config{Server: srv})  // if any tools opt into TaskSupport
     "arguments": { ... },
     "_meta": {
       // Stateless requires the full envelope on every request.
-      "io.modelcontextprotocol/protocolVersion":    "DRAFT-2026-v1",
+      "io.modelcontextprotocol/protocolVersion":    "2026-07-28",
       "io.modelcontextprotocol/clientInfo":         { ... },
       "io.modelcontextprotocol/clientCapabilities": {
         "elicitation": {},

--- a/ext/auth/docs/DESIGN.md
+++ b/ext/auth/docs/DESIGN.md
@@ -6,7 +6,7 @@ MCPKit implements the MCP Authorization specification (draft, based on OAuth 2.1
 
 ## Supported spec versions
 
-mcpkit targets the **2025-11-25 MCP Authorization spec** and the in-flight **DRAFT-2026-v1** draft. The auth-flow shapes from the **2025-03-26 spec** (rootless OAuth metadata, OAuth-endpoint root fallback when no metadata endpoints exist) are intentionally **not supported** — those shapes were removed by the spec itself in 2025-06-18, and implementing them would mean carrying deprecated code paths indefinitely for a tiny pool of servers that haven't tracked the spec for more than a year.
+mcpkit targets the **2025-11-25 MCP Authorization spec** and the in-flight **2026-07-28** draft. The auth-flow shapes from the **2025-03-26 spec** (rootless OAuth metadata, OAuth-endpoint root fallback when no metadata endpoints exist) are intentionally **not supported** — those shapes were removed by the spec itself in 2025-06-18, and implementing them would mean carrying deprecated code paths indefinitely for a tiny pool of servers that haven't tracked the spec for more than a year.
 
 Concretely:
 
@@ -15,7 +15,7 @@ Concretely:
 
 The conformance audit's two `auth/2025-03-26-*` scenarios live in `conformance/baseline.yml` as expected-failures and in `conformance/known-gaps.yaml` with this rationale + a tracking link to #451. The upstream audit report (`conformance/UPSTREAM_AUDIT.md`) still shows them as `partial`; that's correct — we don't pass them, and that's intentional.
 
-Note: this is distinct from MCP **protocol version** negotiation. mcpkit's `server.supportedProtocolVersions` includes `2024-11-05`, `2025-03-26`, `2025-11-25`, and `DRAFT-2026-v1` — clients on the older protocol version still negotiate successfully. The thing that's unsupported is the *auth-flow shape* the 2025-03-26 spec mandated, which is independent of the protocol version field.
+Note: this is distinct from MCP **protocol version** negotiation. mcpkit's `server.supportedProtocolVersions` includes `2024-11-05`, `2025-03-26`, `2025-11-25`, and `2026-07-28` — clients on the older protocol version still negotiate successfully. The thing that's unsupported is the *auth-flow shape* the 2025-03-26 spec mandated, which is independent of the protocol version field.
 
 ## Design Principles
 

--- a/ext/tasks/stateless_wire_test.go
+++ b/ext/tasks/stateless_wire_test.go
@@ -23,7 +23,7 @@ import (
 	server "github.com/panyam/mcpkit/server"
 )
 
-const statelessDraftVersion = "DRAFT-2026-v1"
+const statelessDraftVersion = "2026-07-28"
 
 // newStatelessTaskServer registers a server that intentionally covers the
 // scenarios the conformance fork's stateless-mode run exercises:

--- a/server/dispatch.go
+++ b/server/dispatch.go
@@ -20,12 +20,12 @@ import (
 // ordered newest-first. During initialization the server picks the client's requested
 // version if it appears in this list; otherwise it rejects with the full list.
 //
-// "DRAFT-2026-v1" is the in-flight 2026 protocol revision that carries the SEP-2663
+// "2026-07-28" is the in-flight 2026 protocol revision that carries the SEP-2663
 // tasks extension, SEP-2575 stateless capability override, and SEP-2322 MRTR base
 // types. Accepting it lets draft-aware conformance suites (panyam/mcpconformance
 // feat/tasks-mrtr-extension, upstream PR 262) complete the initialize handshake
 // without forcing them to lie about which version they speak.
-var supportedProtocolVersions = []string{"DRAFT-2026-v1", "2025-11-25", "2025-03-26", "2024-11-05"}
+var supportedProtocolVersions = []string{core.DraftProtocolVersion2026V1, "2025-11-25", "2025-03-26", "2024-11-05"}
 
 // ErrCodeCancelled is the JSON-RPC error code for a cancelled request.
 const ErrCodeCancelled = -32800
@@ -136,7 +136,7 @@ type Dispatcher struct {
 	readCacheScope string
 
 	// allowLegacyOnDraft is an opt-in back-compat escape hatch: when true,
-	// the legacy initialize+session wire is accepted on DRAFT-2026-v1 without
+	// the legacy initialize+session wire is accepted on 2026-07-28 without
 	// per-request _meta enforcement. Default false — SEP-2575 (Accepted)
 	// removes the initialize handshake on draft and mandates per-request
 	// `params._meta.io.modelcontextprotocol/{protocolVersion,clientInfo,
@@ -358,12 +358,12 @@ func (d *Dispatcher) Dispatch(ctx context.Context, req *core.Request) *core.Resp
 			return core.NewErrorResponse(id, core.ErrCodeInvalidRequest, "server not initialized")
 		}
 
-		// SEP-2575 (Accepted): on DRAFT-2026-v1, the initialize handshake is
+		// SEP-2575 (Accepted): on 2026-07-28, the initialize handshake is
 		// removed; every request MUST carry the per-request _meta envelope
 		// (params._meta.io.modelcontextprotocol/{protocolVersion, clientInfo,
 		// clientCapabilities}). We retain initialize+session as a back-compat
 		// entry point so clients pinned to older versions still negotiate, but
-		// once the negotiated version is DRAFT-2026-v1 every follow-up request
+		// once the negotiated version is 2026-07-28 every follow-up request
 		// must carry _meta or the server MUST reject with -32602 InvalidParams.
 		// allowLegacyOnDraft (WithAllowLegacyOnDraft) is an opt-in escape
 		// hatch for server authors who want to be forgiving — off by default.

--- a/server/header_validation.go
+++ b/server/header_validation.go
@@ -15,7 +15,7 @@ import (
 // release picks up the requirement (and the official SDKs ship clients
 // that emit Mcp-Method / Mcp-Name).
 var sep2243EnforcedVersions = map[string]bool{
-	"DRAFT-2026-v1": true,
+	core.DraftProtocolVersion2026V1: true,
 }
 
 // isSEP2243EnforcedVersion reports whether the session's negotiated

--- a/server/header_validation_integration_test.go
+++ b/server/header_validation_integration_test.go
@@ -14,7 +14,7 @@ import (
 // testStreamableServerAllowLegacyOnDraft builds a streamable server
 // configured with WithAllowLegacyOnDraft so the SEP-2243 routing-header
 // integration tests can drive the legacy initialize+session wire on
-// DRAFT-2026-v1 without tripping the strict SEP-2575 _meta enforcement.
+// 2026-07-28 without tripping the strict SEP-2575 _meta enforcement.
 // These tests precisely cover the back-compat path the new option
 // preserves; everywhere else the default (strict, off) applies.
 func testStreamableServerAllowLegacyOnDraft() *httptest.Server {
@@ -45,7 +45,7 @@ func testStreamableServerAllowLegacyOnDraft() *httptest.Server {
 }
 
 // initDraftSession bootstraps a Streamable HTTP session that negotiated
-// the DRAFT-2026-v1 protocol version, so subsequent POSTs go through
+// the 2026-07-28 protocol version, so subsequent POSTs go through
 // the SEP-2243 routing-header gate.
 func initDraftSession(t *testing.T, url string) string {
 	t.Helper()
@@ -53,7 +53,7 @@ func initDraftSession(t *testing.T, url string) string {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "initialize",
-		Params:  json.RawMessage(`{"protocolVersion":"DRAFT-2026-v1","capabilities":{},"clientInfo":{"name":"draft-test","version":"1.0"}}`),
+		Params:  json.RawMessage(`{"protocolVersion":"2026-07-28","capabilities":{},"clientInfo":{"name":"draft-test","version":"1.0"}}`),
 	})
 	if err != nil {
 		t.Fatalf("initialize POST failed: %v", err)

--- a/server/server.go
+++ b/server/server.go
@@ -496,17 +496,17 @@ func WithAllowedRoots(roots ...string) Option {
 }
 
 // WithAllowLegacyOnDraft is an opt-in back-compat escape hatch for the
-// SEP-2575 enforcement on DRAFT-2026-v1. When set, the legacy session
+// SEP-2575 enforcement on 2026-07-28. When set, the legacy session
 // wire (initialize + Mcp-Session-Id) is accepted on the draft protocol
 // version without enforcing the per-request _meta envelope on follow-up
 // requests.
 //
 // Default (option NOT set): the dispatcher enforces SEP-2575 strictly —
-// on DRAFT-2026-v1, every post-initialize request MUST carry
+// on 2026-07-28, every post-initialize request MUST carry
 // `params._meta.io.modelcontextprotocol/{protocolVersion, clientInfo,
 // clientCapabilities}`; missing _meta is rejected with -32602.
 //
-// Use this only if you have legacy clients pinned to DRAFT-2026-v1 that
+// Use this only if you have legacy clients pinned to 2026-07-28 that
 // haven't migrated to per-request metadata yet. New servers should leave
 // this off so non-conformant clients fail loudly.
 func WithAllowLegacyOnDraft() Option {

--- a/server/stateless/discover.go
+++ b/server/stateless/discover.go
@@ -11,7 +11,7 @@ import (
 // Wire shape:
 //
 //	{
-//	  "supportedVersions": ["DRAFT-2026-v1"],
+//	  "supportedVersions": ["2026-07-28"],
 //	  "capabilities":      { ...ServerCapabilities... },
 //	  "serverInfo":        { "name": "...", "version": "..." }
 //	}

--- a/server/stateless/dispatch_test.go
+++ b/server/stateless/dispatch_test.go
@@ -64,7 +64,7 @@ func validMetaParams(t *testing.T) json.RawMessage {
 	t.Helper()
 	return json.RawMessage(`{
 		"_meta": {
-			"io.modelcontextprotocol/protocolVersion": "DRAFT-2026-v1",
+			"io.modelcontextprotocol/protocolVersion": "2026-07-28",
 			"io.modelcontextprotocol/clientInfo": {"name": "test-client", "version": "1"},
 			"io.modelcontextprotocol/clientCapabilities": {}
 		}
@@ -223,7 +223,7 @@ func TestDispatch_ToolsCallMissingCapReturns32003(t *testing.T) {
 		"name": "test_missing_capability",
 		"arguments": {},
 		"_meta": {
-			"io.modelcontextprotocol/protocolVersion": "DRAFT-2026-v1",
+			"io.modelcontextprotocol/protocolVersion": "2026-07-28",
 			"io.modelcontextprotocol/clientInfo": {"name": "c", "version": "1"},
 			"io.modelcontextprotocol/clientCapabilities": {}
 		}
@@ -277,7 +277,7 @@ func TestRequestMetaFromContext(t *testing.T) {
 	if got := RequestMetaFromContext(context.Background()); got != nil {
 		t.Errorf("RequestMetaFromContext(bare) = %+v, want nil", got)
 	}
-	meta := &core.RequestMeta{ProtocolVersion: "DRAFT-2026-v1"}
+	meta := &core.RequestMeta{ProtocolVersion: "2026-07-28"}
 	ctx := core.WithRequestMeta(context.Background(), meta)
 	if got := RequestMetaFromContext(ctx); got != meta {
 		t.Errorf("RequestMetaFromContext: got %+v, want %+v", got, meta)

--- a/server/stateless/loglevel_gate_test.go
+++ b/server/stateless/loglevel_gate_test.go
@@ -39,7 +39,7 @@ func TestRequestMeta_LogLevelThreadingExposedToHandlers(t *testing.T) {
 		{
 			"absent logLevel — handler sees empty",
 			`{
-				"io.modelcontextprotocol/protocolVersion": "DRAFT-2026-v1",
+				"io.modelcontextprotocol/protocolVersion": "2026-07-28",
 				"io.modelcontextprotocol/clientInfo": {"name": "c", "version": "1"},
 				"io.modelcontextprotocol/clientCapabilities": {}
 			}`,
@@ -48,7 +48,7 @@ func TestRequestMeta_LogLevelThreadingExposedToHandlers(t *testing.T) {
 		{
 			"opt-in info — handler sees info",
 			`{
-				"io.modelcontextprotocol/protocolVersion": "DRAFT-2026-v1",
+				"io.modelcontextprotocol/protocolVersion": "2026-07-28",
 				"io.modelcontextprotocol/clientInfo": {"name": "c", "version": "1"},
 				"io.modelcontextprotocol/clientCapabilities": {},
 				"io.modelcontextprotocol/logLevel": "info"
@@ -58,7 +58,7 @@ func TestRequestMeta_LogLevelThreadingExposedToHandlers(t *testing.T) {
 		{
 			"opt-in debug — handler sees debug",
 			`{
-				"io.modelcontextprotocol/protocolVersion": "DRAFT-2026-v1",
+				"io.modelcontextprotocol/protocolVersion": "2026-07-28",
 				"io.modelcontextprotocol/clientInfo": {"name": "c", "version": "1"},
 				"io.modelcontextprotocol/clientCapabilities": {},
 				"io.modelcontextprotocol/logLevel": "debug"

--- a/server/streamable_stateless.go
+++ b/server/streamable_stateless.go
@@ -45,7 +45,7 @@ func (t *streamableTransport) handleStatelessPost(w http.ResponseWriter, r *http
 	}
 
 	// (1b) SEP-2243 routing-header validation. The stateless wire only
-	// speaks DRAFT-2026-v1 (the version that adopted SEP-2243), so any
+	// speaks 2026-07-28 (the version that adopted SEP-2243), so any
 	// Mcp-Method / Mcp-Name a client does send MUST agree with the body.
 	// Lenient on absent headers — keeps clients that haven't adopted
 	// SEP-2243 yet working — strict on mismatched values, which is what

--- a/server/streamable_transport.go
+++ b/server/streamable_transport.go
@@ -325,7 +325,7 @@ func (t *streamableTransport) handlePost(w http.ResponseWriter, r *http.Request)
 	// the server rejects with HTTP 400 + JSON-RPC -32001.
 	//
 	// Gated on the session's negotiated protocol version because
-	// SEP-2243 lives in DRAFT-2026-v1 only — no dated release imposes
+	// SEP-2243 lives in 2026-07-28 only — no dated release imposes
 	// the routing-header contract today, and the SDKs every MCP client
 	// uses (official TS/Python, mcpjam, VS Code, Cursor, ...) do not
 	// emit these headers yet. Validating unconditionally would 400

--- a/tools/conformance-report/test/fixtures/scorecard.json
+++ b/tools/conformance-report/test/fixtures/scorecard.json
@@ -23,14 +23,14 @@
           "passed": true,
           "checks_passed": 5,
           "checks_failed": 0,
-          "specVersions": ["2025-11-25", "DRAFT-2026-v1"]
+          "specVersions": ["2025-11-25", "2026-07-28"]
         },
         {
           "scenario": "server-mrtr-basic-2026-05-31T00-07-41-512Z",
           "passed": false,
           "checks_passed": 3,
           "checks_failed": 2,
-          "specVersions": ["DRAFT-2026-v1"]
+          "specVersions": ["2026-07-28"]
         },
         {
           "scenario": "server-tools-structured-output-2026-05-31T00-07-42-001Z",


### PR DESCRIPTION
## What changes

The MCP spec finalized its next dated revision: in [modelcontextprotocol/modelcontextprotocol PR 331](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/331) (\"fix: update the draft wire version to 2026-07-28\", merged 2026-06-08) the spec repo's `schema/draft/schema.ts` flipped `LATEST_PROTOCOL_VERSION` from the placeholder `\"DRAFT-2026-v1\"` to the dated `\"2026-07-28\"`. This PR brings mcpkit's wire string in line.

Routed through the existing `core.DraftProtocolVersion2026V1` constant rather than spreading the new literal: keep the constant **name** (it still labels the draft window, useful if we ever need to roll back) and update only the **value**. The docstring spells out the name-vs-value split so future readers don't hardcode either form again.

## Reviewer's guide

Read in this order:

1. [core/protocol.go](https://github.com/panyam/mcpkit/pull/707/files#diff-3b2663f9e8f48aee8ba2b111c68b3a24dca2db346f5dbc961dddb976f4917094) — the constant value flips here. Updated docstring captures *why* the name and the value diverge.
2. [server/dispatch.go](https://github.com/panyam/mcpkit/pull/707/files#diff-7640bcbef23148a16e477c63c7092f0ba89780f5278a9d6ba6ed513d62f68a92) — `supportedProtocolVersions` and one Dispatcher field doc move from the literal to the constant.
3. [server/header_validation.go](https://github.com/panyam/mcpkit/pull/707/files#diff-5a541595ad85736d66e51215dee6a6479e47188446e5bc9ece9b5a7c5e8a8551) — SEP-2243 enforcement map likewise routes through the constant.
4. Everything else — godoc text, tests, conformance fixtures, design docs swap the embedded literal `\"DRAFT-2026-v1\"` for `\"2026-07-28\"`. Behavior-equivalent; just the string the wire carries changes.

Skim or skip: the YAML / JSON / Markdown swaps in `conformance/`, `docs/`, `ext/auth/docs/`, `tools/conformance-report/test/fixtures/`.

## Decision log

- **Kept the constant name** `DraftProtocolVersion2026V1` even though the value is now a dated string. The name labels a *draft window*, not a date — and if the spec rolls back, we want one edit, not 19. (Per session direction.)
- **Promoted to the constant in production code only** (`dispatch.go`, `header_validation.go`). Tests, fixtures, and docs kept the bare literal — tests assert wire behavior, fixtures are JSON, docs are prose; routing them through a Go symbol buys nothing and trades clarity for indirection.

## Risk / blast radius

- Affects: every initialize handshake mcpkit speaks on the draft revision; SEP-2243 routing-header enforcement; SEP-2575 stateless wire dispatch; SEP-2663 tasks-v2 / SEP-2322 MRTR fork-conformance scenarios.
- Tests covering this: `make test` (core/server/client/testutil), `make test-auth`, `ext/tasks` package tests — all pass.
- Be paranoid about: conformance fork worktrees (`conf-template`, `conf-pending`, `conf-main`, `conf-upstream-main`) — if a worktree pin lags behind the spec PR, that suite will start failing with version-mismatch errors rather than test errors. Re-run after merge to confirm fork pins agree.

## Out of scope (deliberately deferred)

- Cross-repo: `panyam/mcpconformance` fork branches and the upstream `modelcontextprotocol/conformance` worktree pins may need re-pulls if those test suites still emit \"DRAFT-2026-v1\" client-side. Not gated here; handled when running `make testconf-*` next.
