### PR TITLE
ext/auth: OIDC Back-Channel Logout 1.0 receiver (issue 709 part 1)

### DIFF
--- a/ext/auth/back_channel_logout.go
+++ b/ext/auth/back_channel_logout.go
@@ -1,0 +1,401 @@
+// Package auth: OIDC Back-Channel Logout 1.0 receiver.
+//
+// Spec: https://openid.net/specs/openid-connect-backchannel-1_0.html
+//
+// The receiver accepts the AS-initiated POST that fires when a session
+// is revoked, validates the carried logout_token JWT, and invokes
+// registered listeners with the (sub, sid) tuple that identifies which
+// session ended. Application-level code (e.g., panyam/mcpkit's
+// experimental/ext/events lib) hooks the listener to do the actual
+// downstream work — kill webhook subscriptions, evict caches, log
+// audit events.
+//
+// The handler is deliberately separate from JWTValidator and
+// IntrospectionValidator: BCL logout_tokens have non-overlapping claim
+// constraints with access tokens (events claim required, nonce
+// forbidden, sub-or-sid one-of), and BCL semantically isn't request
+// authentication — it's a server-to-server notification on its own
+// URL. Sharing a validator with access tokens would just produce an
+// option bag of "is this a logout_token? then enforce these extra
+// rules".
+//
+// Mount example:
+//
+//	h, err := auth.NewBackChannelLogoutHandler(auth.BackChannelLogoutConfig{
+//	    Issuer:   "http://keycloak.example.com/realms/tenant-a",
+//	    Audience: "mcp-event-server",
+//	    JWKSURL:  "http://keycloak.example.com/realms/tenant-a/protocol/openid-connect/certs",
+//	})
+//	if err != nil { ... }
+//	h.RegisterListener(func(ctx context.Context, sub, sid string) {
+//	    log.Printf("session ended: sub=%s sid=%s", sub, sid)
+//	    // walk subscriptions, fire PostTerminated, etc.
+//	})
+//	mux.Handle("/backchannel-logout", h)
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	jwt "github.com/golang-jwt/jwt/v5"
+	"github.com/panyam/oneauth/keys"
+	"github.com/panyam/oneauth/utils"
+)
+
+// BackChannelLogoutEventURI is the JWT `events` claim member that
+// every OIDC Back-Channel Logout token MUST carry (spec § 2.4).
+const BackChannelLogoutEventURI = "http://schemas.openid.net/event/backchannel-logout"
+
+// BackChannelLogoutConfig configures the receiver. Required fields
+// have a "required" callout; the rest pick defaults that match
+// the spec's MUST window plus a small clock-skew leeway.
+type BackChannelLogoutConfig struct {
+	// Issuer is the expected `iss` claim value (the AS issuer URL).
+	// Required. Mirrors the same iss the AS publishes on its
+	// /.well-known/openid-configuration document.
+	Issuer string
+
+	// Audience is the expected `aud` claim value — typically the
+	// resource server's client_id registered with the AS.
+	// Required. The spec mandates aud validation against the
+	// registered client_id (§ 2.6).
+	Audience string
+
+	// JWKSURL is the AS JWKS endpoint used to fetch the signing
+	// key for the logout_token via its kid header. Required.
+	// Wrapped in oneauth's JWKSKeyStore for cached lookups.
+	JWKSURL string
+
+	// JTIStore stores seen `jti` values for replay protection.
+	// Default: a fresh MemoryJTIStore. Multi-replica deployments
+	// should swap for a Redis / SQL backed impl so a replay seen
+	// on replica A is also rejected on replica B.
+	JTIStore JTIStore
+
+	// ReplayWindow is the TTL applied to recorded jtis — how long
+	// a jti remains visible to JTIStore.Seen. Default 10 minutes.
+	// Set this to at least 2x the AS's max-clock-skew tolerance so
+	// a delayed-replay attack can't slip past the eviction.
+	ReplayWindow time.Duration
+
+	// AllowedClockSkew is the leeway applied to exp / iat / nbf
+	// checks during JWT validation. Default 60s. The spec is silent
+	// on a concrete value; a minute is the common floor across OIDC
+	// libraries.
+	AllowedClockSkew time.Duration
+
+	// Now returns the current time. Defaults to time.Now. Tests
+	// inject a fixed clock so exp / iat / replay-window assertions
+	// are deterministic.
+	Now func() time.Time
+}
+
+// LogoutListener is invoked synchronously after a logout_token
+// validates. sub is the OIDC subject claim (may be empty if the token
+// only carried sid); sid is the OIDC session ID claim (may be empty
+// if the token only carried sub). At least one is guaranteed
+// non-empty by the spec-mandated sub-or-sid check in ServeHTTP.
+//
+// ctx is the request context; cancellation propagates through it.
+// Listeners that do expensive work should spawn their own goroutine
+// — the receiver does not impose a deadline, but slow listeners
+// extend the AS-side BCL POST latency, which can lead to AS retries
+// or alerts depending on the AS implementation.
+type LogoutListener func(ctx context.Context, sub, sid string)
+
+// BackChannelLogoutHandler implements http.Handler for the OIDC
+// Back-Channel Logout 1.0 receiver endpoint. Construct via
+// NewBackChannelLogoutHandler; mount on any http.ServeMux at the
+// path the AS was configured to POST to.
+type BackChannelLogoutHandler struct {
+	cfg BackChannelLogoutConfig
+	ks  *keys.JWKSKeyStore
+
+	mu        sync.RWMutex
+	listeners []LogoutListener
+}
+
+// NewBackChannelLogoutHandler constructs a receiver from cfg.
+// Returns an error when a required field is missing or empty.
+func NewBackChannelLogoutHandler(cfg BackChannelLogoutConfig) (*BackChannelLogoutHandler, error) {
+	if cfg.Issuer == "" {
+		return nil, errors.New("BackChannelLogoutConfig.Issuer is required")
+	}
+	if cfg.Audience == "" {
+		return nil, errors.New("BackChannelLogoutConfig.Audience is required")
+	}
+	if cfg.JWKSURL == "" {
+		return nil, errors.New("BackChannelLogoutConfig.JWKSURL is required")
+	}
+	if cfg.JTIStore == nil {
+		cfg.JTIStore = NewMemoryJTIStore()
+	}
+	if cfg.ReplayWindow <= 0 {
+		cfg.ReplayWindow = 10 * time.Minute
+	}
+	if cfg.AllowedClockSkew <= 0 {
+		cfg.AllowedClockSkew = 60 * time.Second
+	}
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	return &BackChannelLogoutHandler{
+		cfg: cfg,
+		ks:  keys.NewJWKSKeyStore(cfg.JWKSURL),
+	}, nil
+}
+
+// RegisterListener appends a listener invoked for every valid
+// logout_token. Listeners run synchronously in registration order;
+// short callbacks only, or hand off to a goroutine.
+func (h *BackChannelLogoutHandler) RegisterListener(fn LogoutListener) {
+	if fn == nil {
+		return
+	}
+	h.mu.Lock()
+	h.listeners = append(h.listeners, fn)
+	h.mu.Unlock()
+}
+
+// ServeHTTP implements the OIDC BCL POST endpoint per spec § 2.7.
+// The handler returns:
+//   - 200 OK with `Cache-Control: no-store` on successful validation
+//   - 400 Bad Request with a categorical reason on any validation
+//     failure
+//   - 405 Method Not Allowed on non-POST methods
+//
+// The 400 response body is a JSON object {"error":"..."} where the
+// error string identifies which check failed — useful for operators
+// debugging an AS misconfiguration without leaking secrets.
+func (h *BackChannelLogoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Cache-Control", "no-store")
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		writeBCLError(w, "bad form body: "+err.Error())
+		return
+	}
+	token := r.PostForm.Get("logout_token")
+	if token == "" {
+		writeBCLError(w, "missing logout_token")
+		return
+	}
+
+	sub, sid, err := h.validate(r.Context(), token)
+	if err != nil {
+		writeBCLError(w, err.Error())
+		return
+	}
+
+	h.fire(r.Context(), sub, sid)
+	w.WriteHeader(http.StatusOK)
+}
+
+// validate runs the full spec § 2.6 acceptance check on a single
+// logout_token. Returns (sub, sid, nil) on success. Returns a
+// descriptive error on any failure; the error string is what the
+// 400 response body will carry, so it must be safe to surface to
+// the operator.
+func (h *BackChannelLogoutHandler) validate(ctx context.Context, token string) (sub, sid string, err error) {
+	// WithoutClaimsValidation: jwt.Parse's built-in exp/iat/nbf checks
+	// hit time.Now() directly, which would bypass our injectable
+	// cfg.Now (used by tests for deterministic exp/iat assertions).
+	// checkTimeClaims below runs the same checks against cfg.Now.
+	parsed, err := jwt.Parse(token, h.keyFunc(),
+		jwt.WithValidMethods([]string{"RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"}),
+		jwt.WithoutClaimsValidation(),
+	)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid logout_token: %w", err)
+	}
+	if !parsed.Valid {
+		return "", "", errors.New("invalid logout_token")
+	}
+	mc, ok := parsed.Claims.(jwt.MapClaims)
+	if !ok {
+		return "", "", errors.New("invalid logout_token claims shape")
+	}
+
+	now := h.cfg.Now()
+	if err := checkTimeClaims(mc, now, h.cfg.AllowedClockSkew); err != nil {
+		return "", "", err
+	}
+	if iss, _ := mc["iss"].(string); iss != h.cfg.Issuer {
+		return "", "", fmt.Errorf("invalid iss: expected %q", h.cfg.Issuer)
+	}
+	if err := checkAudience(mc, h.cfg.Audience); err != nil {
+		return "", "", err
+	}
+	if err := checkEventsClaim(mc); err != nil {
+		return "", "", err
+	}
+	if _, hasNonce := mc["nonce"]; hasNonce {
+		// Spec § 2.4: "A nonce Claim MUST NOT be present" — its
+		// presence is one of the signature-forgery red flags a
+		// well-meaning AS could be tricked into.
+		return "", "", errors.New("nonce claim must not be present in logout_token")
+	}
+
+	sub, _ = mc["sub"].(string)
+	sid, _ = mc["sid"].(string)
+	if sub == "" && sid == "" {
+		return "", "", errors.New("logout_token must carry at least one of sub or sid")
+	}
+
+	jti, _ := mc["jti"].(string)
+	if jti == "" {
+		// Spec § 2.4: jti is REQUIRED.
+		return "", "", errors.New("missing required jti claim")
+	}
+	seen, err := h.cfg.JTIStore.Seen(ctx, SeenRequest{JTI: jti})
+	if err != nil {
+		return "", "", fmt.Errorf("jti store lookup failed: %w", err)
+	}
+	if seen.Found {
+		return "", "", errors.New("logout_token jti has been seen before (replay)")
+	}
+	if _, err := h.cfg.JTIStore.Record(ctx, RecordRequest{JTI: jti, TTL: h.cfg.ReplayWindow}); err != nil {
+		return "", "", fmt.Errorf("jti store record failed: %w", err)
+	}
+	return sub, sid, nil
+}
+
+// keyFunc returns a jwt.Keyfunc that resolves the verification key
+// from the configured JWKS. Mirrors JWTValidator.jwksKeyFuncCtx —
+// keyed on the token's `kid` header.
+func (h *BackChannelLogoutHandler) keyFunc() jwt.Keyfunc {
+	return func(token *jwt.Token) (any, error) {
+		kid, ok := token.Header["kid"].(string)
+		if !ok || kid == "" {
+			return nil, errors.New("missing kid header")
+		}
+		rec, err := h.ks.GetKeyByKid(context.Background(), &keys.GetKeyByKidRequest{Kid: kid})
+		if err != nil {
+			return nil, fmt.Errorf("key not found for kid %q: %w", kid, err)
+		}
+		if rec == nil || rec.Record == nil {
+			return nil, fmt.Errorf("key not found for kid %q", kid)
+		}
+		alg, _ := token.Header["alg"].(string)
+		if alg != rec.Record.Algorithm {
+			return nil, fmt.Errorf("algorithm mismatch: token has %s, key expects %s", alg, rec.Record.Algorithm)
+		}
+		return utils.DecodeVerifyKey(rec.Record.Key, rec.Record.Algorithm)
+	}
+}
+
+// fire dispatches the validated logout to each registered listener
+// in registration order. Listeners run synchronously; the handler
+// completes its 200 response only after all listeners return.
+func (h *BackChannelLogoutHandler) fire(ctx context.Context, sub, sid string) {
+	h.mu.RLock()
+	listeners := append([]LogoutListener(nil), h.listeners...)
+	h.mu.RUnlock()
+	for _, fn := range listeners {
+		fn(ctx, sub, sid)
+	}
+}
+
+// checkTimeClaims enforces exp/iat presence + freshness with the
+// configured clock-skew leeway. iat is allowed to be slightly in the
+// future to tolerate clock drift between the AS and the receiver.
+func checkTimeClaims(mc jwt.MapClaims, now time.Time, skew time.Duration) error {
+	exp, ok := toUnix(mc["exp"])
+	if !ok {
+		return errors.New("missing exp claim")
+	}
+	if now.After(exp.Add(skew)) {
+		return errors.New("logout_token expired")
+	}
+	iat, ok := toUnix(mc["iat"])
+	if !ok {
+		return errors.New("missing iat claim")
+	}
+	if iat.After(now.Add(skew)) {
+		return errors.New("logout_token issued in the future")
+	}
+	return nil
+}
+
+// checkAudience accepts either a string or []any audience claim and
+// returns nil iff the configured Audience appears as one of the
+// values. Spec § 2.6: the receiver MUST validate aud.
+func checkAudience(mc jwt.MapClaims, want string) error {
+	switch aud := mc["aud"].(type) {
+	case string:
+		if aud != want {
+			return fmt.Errorf("invalid aud: expected %q, got %q", want, aud)
+		}
+		return nil
+	case []any:
+		for _, a := range aud {
+			if s, _ := a.(string); s == want {
+				return nil
+			}
+		}
+		return fmt.Errorf("invalid aud: expected %q to appear in audience list", want)
+	default:
+		return errors.New("missing aud claim")
+	}
+}
+
+// checkEventsClaim enforces spec § 2.4: the `events` claim is a JSON
+// object whose members declare the logout-style event types. The BCL
+// member URI MUST be present (its value is an empty object per the
+// spec; we don't inspect the inner shape because future SETs may add
+// fields).
+func checkEventsClaim(mc jwt.MapClaims) error {
+	raw, ok := mc["events"]
+	if !ok {
+		return errors.New("missing events claim")
+	}
+	events, ok := raw.(map[string]any)
+	if !ok {
+		return errors.New("events claim is not a JSON object")
+	}
+	if _, hasBCL := events[BackChannelLogoutEventURI]; !hasBCL {
+		return fmt.Errorf("events claim missing %q member", BackChannelLogoutEventURI)
+	}
+	return nil
+}
+
+// toUnix coerces a jwt.MapClaims numeric claim (which json.Unmarshal
+// represents as float64 by default) to a time.Time. Returns ok=false
+// if the value is missing or not numeric.
+func toUnix(v any) (time.Time, bool) {
+	switch n := v.(type) {
+	case float64:
+		return time.Unix(int64(n), 0), true
+	case json.Number:
+		i, err := n.Int64()
+		if err != nil {
+			return time.Time{}, false
+		}
+		return time.Unix(i, 0), true
+	case int64:
+		return time.Unix(n, 0), true
+	case int:
+		return time.Unix(int64(n), 0), true
+	default:
+		return time.Time{}, false
+	}
+}
+
+// writeBCLError writes a 400 response carrying the categorical
+// reason. JSON shape mirrors how the introspection-error path formats
+// failures elsewhere in ext/auth so operators see a consistent
+// debugging surface.
+func writeBCLError(w http.ResponseWriter, reason string) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(http.StatusBadRequest)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": reason})
+}

--- a/ext/auth/back_channel_logout_test.go
+++ b/ext/auth/back_channel_logout_test.go
@@ -1,0 +1,230 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	jwt "github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// bclTestFixture spins up an httptest server hosting a JWKS document
+// + the BackChannelLogoutHandler under test. Its `mint` helper builds
+// a logout_token signed with the matching key — callers override
+// claim fields case-by-case to exercise good + negative paths.
+type bclTestFixture struct {
+	t        *testing.T
+	signKey  *rsa.PrivateKey
+	kid      string
+	asServer *httptest.Server
+	rsServer *httptest.Server
+	handler  *BackChannelLogoutHandler
+	now      time.Time
+
+	mu              sync.Mutex
+	receivedSub     string
+	receivedSid     string
+	listenerInvoked bool
+}
+
+func newBCLFixture(t *testing.T) *bclTestFixture {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	fx := &bclTestFixture{
+		t:       t,
+		signKey: key,
+		kid:     "test-kid-1",
+		now:     time.Date(2026, 6, 9, 0, 0, 0, 0, time.UTC),
+	}
+	fx.asServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Minimal RFC 7517 JWKS doc carrying the test public key.
+		// oneauth's JWKSKeyStore looks up by kid via this document.
+		n := key.PublicKey.N.Bytes()
+		eBuf := make([]byte, 8)
+		binary.BigEndian.PutUint64(eBuf, uint64(key.PublicKey.E))
+		// Strip leading zero bytes — JWKS wants the minimal big-endian form.
+		eBytes := eBuf
+		for len(eBytes) > 1 && eBytes[0] == 0 {
+			eBytes = eBytes[1:]
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"keys": []map[string]any{{
+				"kty": "RSA",
+				"use": "sig",
+				"alg": "RS256",
+				"kid": fx.kid,
+				"n":   base64.RawURLEncoding.EncodeToString(n),
+				"e":   base64.RawURLEncoding.EncodeToString(eBytes),
+			}},
+		})
+	}))
+	t.Cleanup(fx.asServer.Close)
+
+	h, err := NewBackChannelLogoutHandler(BackChannelLogoutConfig{
+		Issuer:           "https://as.example.com",
+		Audience:         "mcp-event-server",
+		JWKSURL:          fx.asServer.URL + "/jwks",
+		ReplayWindow:     10 * time.Minute,
+		AllowedClockSkew: 60 * time.Second,
+		Now:              func() time.Time { return fx.now },
+	})
+	require.NoError(t, err)
+	h.RegisterListener(func(_ context.Context, sub, sid string) {
+		fx.mu.Lock()
+		defer fx.mu.Unlock()
+		fx.listenerInvoked = true
+		fx.receivedSub = sub
+		fx.receivedSid = sid
+	})
+	fx.handler = h
+	fx.rsServer = httptest.NewServer(h)
+	t.Cleanup(fx.rsServer.Close)
+	return fx
+}
+
+// goodClaims returns a spec-compliant logout_token claim set for the
+// fixture. Tests mutate the returned map to construct negative cases.
+func (fx *bclTestFixture) goodClaims() jwt.MapClaims {
+	return jwt.MapClaims{
+		"iss": "https://as.example.com",
+		"aud": "mcp-event-server",
+		"iat": fx.now.Unix(),
+		"exp": fx.now.Add(2 * time.Minute).Unix(),
+		"jti": "jti-good-1",
+		"sub": "user-abc",
+		"sid": "sess-xyz",
+		"events": map[string]any{
+			BackChannelLogoutEventURI: map[string]any{},
+		},
+	}
+}
+
+// mint signs the given claims with the fixture's key and kid.
+func (fx *bclTestFixture) mint(claims jwt.MapClaims) string {
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	tok.Header["kid"] = fx.kid
+	signed, err := tok.SignedString(fx.signKey)
+	require.NoError(fx.t, err)
+	return signed
+}
+
+// post fires the BCL POST to the handler with the given logout_token,
+// returning status code + parsed JSON body.
+func (fx *bclTestFixture) post(token string) (int, map[string]string) {
+	body := url.Values{"logout_token": {token}}
+	resp, err := http.Post(fx.rsServer.URL, "application/x-www-form-urlencoded", strings.NewReader(body.Encode()))
+	require.NoError(fx.t, err)
+	defer resp.Body.Close()
+	out := map[string]string{}
+	_ = json.NewDecoder(resp.Body).Decode(&out)
+	return resp.StatusCode, out
+}
+
+func TestBCL_Good_FiresListener(t *testing.T) {
+	fx := newBCLFixture(t)
+	status, _ := fx.post(fx.mint(fx.goodClaims()))
+	assert.Equal(t, http.StatusOK, status)
+	fx.mu.Lock()
+	defer fx.mu.Unlock()
+	assert.True(t, fx.listenerInvoked, "listener must fire on valid logout_token")
+	assert.Equal(t, "user-abc", fx.receivedSub)
+	assert.Equal(t, "sess-xyz", fx.receivedSid)
+}
+
+func TestBCL_BadSignature_Rejected(t *testing.T) {
+	fx := newBCLFixture(t)
+	// Replace the signature with garbage.
+	signed := fx.mint(fx.goodClaims())
+	parts := strings.Split(signed, ".")
+	parts[2] = "AAAA" + parts[2][4:]
+	status, body := fx.post(strings.Join(parts, "."))
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Contains(t, body["error"], "invalid")
+	assert.False(t, fx.listenerInvoked)
+}
+
+func TestBCL_WrongIssuer_Rejected(t *testing.T) {
+	fx := newBCLFixture(t)
+	cl := fx.goodClaims()
+	cl["iss"] = "https://attacker.example.com"
+	status, body := fx.post(fx.mint(cl))
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Contains(t, body["error"], "iss")
+	assert.False(t, fx.listenerInvoked)
+}
+
+func TestBCL_MissingEventsClaim_Rejected(t *testing.T) {
+	fx := newBCLFixture(t)
+	cl := fx.goodClaims()
+	delete(cl, "events")
+	status, body := fx.post(fx.mint(cl))
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Contains(t, body["error"], "events")
+	assert.False(t, fx.listenerInvoked)
+}
+
+func TestBCL_MissingSubAndSid_Rejected(t *testing.T) {
+	fx := newBCLFixture(t)
+	cl := fx.goodClaims()
+	delete(cl, "sub")
+	delete(cl, "sid")
+	status, body := fx.post(fx.mint(cl))
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Contains(t, body["error"], "sub or sid")
+	assert.False(t, fx.listenerInvoked)
+}
+
+func TestBCL_NoncePresent_Rejected(t *testing.T) {
+	fx := newBCLFixture(t)
+	cl := fx.goodClaims()
+	cl["nonce"] = "abc"
+	status, body := fx.post(fx.mint(cl))
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Contains(t, body["error"], "nonce")
+	assert.False(t, fx.listenerInvoked)
+}
+
+func TestBCL_Expired_Rejected(t *testing.T) {
+	fx := newBCLFixture(t)
+	cl := fx.goodClaims()
+	cl["exp"] = fx.now.Add(-5 * time.Minute).Unix() // well past clock-skew leeway
+	status, body := fx.post(fx.mint(cl))
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Contains(t, body["error"], "expired")
+	assert.False(t, fx.listenerInvoked)
+}
+
+func TestBCL_ReplayedJTI_Rejected(t *testing.T) {
+	fx := newBCLFixture(t)
+	token := fx.mint(fx.goodClaims())
+
+	// First delivery: succeeds.
+	status, _ := fx.post(token)
+	require.Equal(t, http.StatusOK, status)
+	fx.mu.Lock()
+	require.True(t, fx.listenerInvoked, "first delivery must succeed")
+	fx.listenerInvoked = false
+	fx.mu.Unlock()
+
+	// Same token, second delivery: must be rejected as replay.
+	status, body := fx.post(token)
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Contains(t, body["error"], "replay")
+	fx.mu.Lock()
+	defer fx.mu.Unlock()
+	assert.False(t, fx.listenerInvoked, "replay must not fire the listener")
+}
+

--- a/ext/auth/jti_store.go
+++ b/ext/auth/jti_store.go
@@ -1,0 +1,128 @@
+package auth
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// JTIStore is the storage seam behind logout_token replay protection.
+// OIDC Back-Channel Logout 1.0 § 2.6 says the receiver "MUST verify
+// that no `jti` claim in the [Logout] Token has been seen before".
+// Implementations must therefore retain seen jtis at least as long as
+// the spec-allowed replay window (the spec is silent on a concrete
+// window; we default to twice the max permitted clock skew, which is
+// the same minimum-floor every BCL impl seems to converge on).
+//
+// gRPC-style request/response signatures so the in-memory default in
+// this file can be swapped for a Redis / SQL / shared-cache impl
+// without changing call sites. Forward-compatible with a future
+// remote JTIStore that wraps a gRPC client — ctx threads cancellation
+// and trace context to the storage backend.
+type JTIStore interface {
+	// Seen returns whether the jti has been recorded within its TTL
+	// window. Used by the BCL receiver to reject replays. Spec §2.6:
+	// "If the Logout Token has been seen before, [the receiver] MUST
+	// reject the request as a replay."
+	Seen(ctx context.Context, req SeenRequest) (SeenResponse, error)
+
+	// Record stores a jti with the given TTL. Re-recording an existing
+	// jti is allowed and resets its TTL — the spec does not require
+	// monotonic-only recording, and forcing it would complicate the
+	// in-memory impl for no observable gain.
+	Record(ctx context.Context, req RecordRequest) (RecordResponse, error)
+}
+
+// SeenRequest carries the jti being checked. JTI is the bare
+// `jti` claim value from the logout_token — callers do not need
+// to prefix or namespace it; the store treats the value as opaque.
+type SeenRequest struct {
+	JTI string
+}
+
+// SeenResponse reports whether the jti has been recorded within
+// its TTL. Found=false is the success path (jti is fresh, proceed
+// to Record). Found=true means the BCL handler MUST respond 400.
+type SeenResponse struct {
+	Found bool
+}
+
+// RecordRequest carries the jti + TTL to persist. TTL is the
+// duration the jti must remain visible to Seen() — typically set
+// from the BCL handler's configured replay window, NOT from the
+// logout_token's `exp` claim (because a malicious AS could shrink
+// exp and turn a replay window into nothing).
+type RecordRequest struct {
+	JTI string
+	TTL time.Duration
+}
+
+// RecordResponse is a marker; success is err=nil. No Found-style
+// field because the spec doesn't require any signal on the record
+// path (overwriting an existing jti is fine — the handler already
+// rejected the replay via Seen()).
+type RecordResponse struct{}
+
+// MemoryJTIStore is the default in-memory JTIStore implementation —
+// a map of jti → expiry, swept lazily on each Seen / Record call.
+// Suitable for single-process deployments and tests. Multi-replica
+// setups should swap for a Redis / shared-cache impl so a replay
+// caught on replica A is also rejected on replica B.
+//
+// Thread-safe via an internal RWMutex. Lazy sweep keeps memory
+// bounded to the rate of unique jtis arriving during the active
+// TTL window — there is no background goroutine, which keeps the
+// store lifecycle equal to the receiver's lifecycle (no shutdown
+// dance required).
+type MemoryJTIStore struct {
+	mu      sync.RWMutex
+	entries map[string]time.Time
+	now     func() time.Time
+}
+
+// NewMemoryJTIStore constructs a fresh in-memory JTIStore.
+func NewMemoryJTIStore() *MemoryJTIStore {
+	return &MemoryJTIStore{
+		entries: make(map[string]time.Time),
+		now:     time.Now,
+	}
+}
+
+// Seen reports whether the jti exists and is unexpired. Lazily
+// evicts an entry that is past its TTL so the next Record call for
+// the same jti starts a fresh window.
+func (s *MemoryJTIStore) Seen(_ context.Context, req SeenRequest) (SeenResponse, error) {
+	if req.JTI == "" {
+		return SeenResponse{}, nil
+	}
+	s.mu.RLock()
+	exp, ok := s.entries[req.JTI]
+	s.mu.RUnlock()
+	if !ok {
+		return SeenResponse{Found: false}, nil
+	}
+	if s.now().After(exp) {
+		// Past TTL — evict and report as not seen.
+		s.mu.Lock()
+		// Double-check under write lock so a concurrent Record
+		// that re-extended the TTL is preserved.
+		if exp2, stillThere := s.entries[req.JTI]; stillThere && s.now().After(exp2) {
+			delete(s.entries, req.JTI)
+		}
+		s.mu.Unlock()
+		return SeenResponse{Found: false}, nil
+	}
+	return SeenResponse{Found: true}, nil
+}
+
+// Record persists the jti with the given TTL. Re-recording is
+// allowed; the new TTL replaces the old one.
+func (s *MemoryJTIStore) Record(_ context.Context, req RecordRequest) (RecordResponse, error) {
+	if req.JTI == "" || req.TTL <= 0 {
+		return RecordResponse{}, nil
+	}
+	s.mu.Lock()
+	s.entries[req.JTI] = s.now().Add(req.TTL)
+	s.mu.Unlock()
+	return RecordResponse{}, nil
+}

--- a/ext/auth/jti_store_test.go
+++ b/ext/auth/jti_store_test.go
@@ -1,0 +1,83 @@
+package auth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemoryJTIStore_RecordAndSeen(t *testing.T) {
+	s := NewMemoryJTIStore()
+	ctx := context.Background()
+
+	resp, err := s.Seen(ctx, SeenRequest{JTI: "a"})
+	require.NoError(t, err)
+	assert.False(t, resp.Found, "fresh jti must not be Found")
+
+	_, err = s.Record(ctx, RecordRequest{JTI: "a", TTL: time.Hour})
+	require.NoError(t, err)
+
+	resp, err = s.Seen(ctx, SeenRequest{JTI: "a"})
+	require.NoError(t, err)
+	assert.True(t, resp.Found, "recorded jti must be Found")
+}
+
+func TestMemoryJTIStore_EvictsExpired(t *testing.T) {
+	s := NewMemoryJTIStore()
+	clock := time.Date(2026, 6, 9, 0, 0, 0, 0, time.UTC)
+	s.now = func() time.Time { return clock }
+	ctx := context.Background()
+
+	_, err := s.Record(ctx, RecordRequest{JTI: "expiring", TTL: 10 * time.Second})
+	require.NoError(t, err)
+
+	clock = clock.Add(5 * time.Second)
+	resp, err := s.Seen(ctx, SeenRequest{JTI: "expiring"})
+	require.NoError(t, err)
+	assert.True(t, resp.Found, "within TTL window: still Found")
+
+	clock = clock.Add(10 * time.Second) // 15s total, past 10s TTL
+	resp, err = s.Seen(ctx, SeenRequest{JTI: "expiring"})
+	require.NoError(t, err)
+	assert.False(t, resp.Found, "past TTL: must be evicted")
+}
+
+func TestMemoryJTIStore_ReRecordResetsTTL(t *testing.T) {
+	s := NewMemoryJTIStore()
+	clock := time.Date(2026, 6, 9, 0, 0, 0, 0, time.UTC)
+	s.now = func() time.Time { return clock }
+	ctx := context.Background()
+
+	_, _ = s.Record(ctx, RecordRequest{JTI: "a", TTL: 10 * time.Second})
+	clock = clock.Add(9 * time.Second)
+	_, _ = s.Record(ctx, RecordRequest{JTI: "a", TTL: 10 * time.Second})
+
+	// 12s after original record, but only 3s after re-record — must still be Found.
+	clock = clock.Add(3 * time.Second)
+	resp, _ := s.Seen(ctx, SeenRequest{JTI: "a"})
+	assert.True(t, resp.Found, "re-record must extend the TTL window")
+}
+
+func TestMemoryJTIStore_EmptyJTIIsNoop(t *testing.T) {
+	s := NewMemoryJTIStore()
+	ctx := context.Background()
+
+	resp, err := s.Seen(ctx, SeenRequest{JTI: ""})
+	require.NoError(t, err)
+	assert.False(t, resp.Found, "empty jti reports not Found rather than panic")
+
+	_, err = s.Record(ctx, RecordRequest{JTI: "", TTL: time.Hour})
+	require.NoError(t, err, "empty jti record is a no-op, not an error")
+}
+
+func TestMemoryJTIStore_ZeroTTLIsNoop(t *testing.T) {
+	s := NewMemoryJTIStore()
+	ctx := context.Background()
+	_, err := s.Record(ctx, RecordRequest{JTI: "x", TTL: 0})
+	require.NoError(t, err)
+	resp, _ := s.Seen(ctx, SeenRequest{JTI: "x"})
+	assert.False(t, resp.Found, "TTL=0 must not record the jti")
+}


### PR DESCRIPTION
## What changes

First half of issue 709 — adds the OIDC Back-Channel Logout 1.0 receiver to ext/auth. Foundation only: no events-lib integration, no demo wiring; those land in the follow-up PR. Useful standalone for any ext/auth adopter that wants to react to AS-initiated session revocation without polling /introspect.

New surface:

- `BackChannelLogoutHandler` — `http.Handler` for the BCL POST endpoint (spec § 2.7). Mount at whatever URL was registered with the AS as `backchannel_logout_uri`.
- `BackChannelLogoutConfig` — required `Issuer`/`Audience`/`JWKSURL`; optional `JTIStore`/`ReplayWindow`/`AllowedClockSkew`/`Now` (clock injection for tests).
- `LogoutListener` — `func(ctx, sub, sid)` callback registered via `handler.RegisterListener`. Fires in registration order on every valid `logout_token`.
- `JTIStore` + `MemoryJTIStore` — storage seam for jti replay protection. gRPC-style request/response signatures so the in-memory default swaps cleanly for Redis / SQL in multi-replica deployments.

## Reviewer's guide

1. [ext/auth/back_channel_logout.go](https://github.com/panyam/mcpkit/pull/710/files#diff-fe077442b64f4a80edc8d23d3fc81c8e05f9e961cffe9cf64996152a4a332e13) — start here. Validation flow in `validate()` is the spec contract; each branch maps to a check in OIDC BCL 1.0 § 2.6. The `jwt.WithoutClaimsValidation()` choice is called out in the doc comment — `jwt.Parse`'s built-in time checks bypass `cfg.Now`, which tests rely on for deterministic exp/iat assertions.
2. [ext/auth/back_channel_logout_test.go](https://github.com/panyam/mcpkit/pull/710/files#diff-c153bea755e09c29af3090e9dd4052a6bda1c37a6b448cea588be01bdebb262a) — 1 happy path + 7 negative cases. Each negative case maps to a spec section (bad signature, wrong iss, missing events claim, missing sub-AND-sid, nonce-must-not-be-present, expired, jti replay).
3. [ext/auth/jti_store.go](https://github.com/panyam/mcpkit/pull/710/files#diff-e078156df1387f8607cbb3f13e9492e1a2a4809d64d9ec39191226c4fd9df1d2) — `JTIStore` interface + `MemoryJTIStore` impl. TTL eviction is lazy under each `Seen`/`Record` call; no background goroutine.
4. [ext/auth/jti_store_test.go](https://github.com/panyam/mcpkit/pull/710/files#diff-d64cf9c1b8980d57dbadc46331e3c7902c233404b15859d41f26547ce9f86ed8) — round-trip, lazy eviction, re-record extends TTL, empty-jti no-op, zero-TTL no-op.

## Decision log

- **Standalone handler, not a middleware.** BCL is semantically server-to-server notification on its own URL; not request-auth. Folding into JWTValidator would produce option bags ("is this a logout_token? then enforce these extra rules").
- **JTI store TTL is set from `ReplayWindow` (default 10 min), NOT from `logout_token.exp`.** A malicious AS could shrink exp and turn the replay window into nothing — operator-controlled window is the safer floor.
- **`jwt.WithoutClaimsValidation()`** — see above; required for the injectable-clock pattern. `checkTimeClaims()` runs the same checks against `cfg.Now` and produces categorical error strings.

## Risk / blast radius

- New package surface, no existing callers in the tree yet — zero regression surface for current adopters.
- Pure addition to `ext/auth`; no changes to `core` or other modules.
- `make test-auth` passes (13 new tests + the full existing suite).

## Out of scope (deliberately deferred — follow-up PR)

- `core.Claims.SessionID` field + introspection/JWT validators stamping it from the `sid` claim
- `experimental/ext/events`: subscription metadata captures `sid`, secondary index by `(sub, sid)`, BCL listener → `PostTerminated` fan-out
- `examples/events/whole-enchilada`: realm-JSON `backchannel_logout_uri` config, mount on event-server mux, walkthrough beat
- AS-side push tracked separately on panyam/oneauth (independent — Keycloak provides the AS half for the demo)

## Spec reference

OpenID Back-Channel Logout 1.0: https://openid.net/specs/openid-connect-backchannel-1_0.html

