### PR TITLE
events: thread W3C trace context through the events bus (SEP-414 P6, issue 683)

### DIFF
--- a/experimental/ext/events/README.md
+++ b/experimental/ext/events/README.md
@@ -316,3 +316,35 @@ Based on Peter Alexander's design sketch (triggers-events-wg PR #1). Notable cho
 | **`events/stream`** | Deferred — push uses `Server.Broadcast` for now |
 | **Typed contexts** | Handlers receive `core.MethodContext` (EmitLog, AuthClaims, etc.) |
 | **Yield-style SDK** | `YieldingSource` (Casey + Peter, WG PR #1 line 609) — non-normative SDK ergonomic |
+
+## Tracing across the events bus (SEP-414 P6, issue 683)
+
+W3C Trace Context propagates across every gate in the event lifecycle so a yield on replica A and a downstream webhook delivery (or a poll-side replay on replica B) appear in Tempo as one stitched trace.
+
+**Four gates, three carriers, one consistent rule.** The carriers are picked per gate by what's available at that boundary:
+
+| Gate | Carrier | Where |
+|---|---|---|
+| 1. `yield(ctx, data)` | `event.Meta.traceparent` (persistent) + `ctx` (in-process) | `YieldingSource.yield` stamps `Meta` from `ctx`; emit hook receives the same `ctx` |
+| 2. emit hook → `Emitter.Emit(ctx, event)` | `ctx` | `Register` passes the hook's `ctx` straight to the configured Emitter |
+| 3. `WebhookRegistry.Deliver(ctx, event)` → outbound HTTP | HTTP `traceparent` header | `deliver()` extracts from `ctx` (preferred) or `event.Meta` (fallback for replayed events), stamps the header before `client.Do` |
+| 4. `HTTPSource.serveInject` (receiving replica) | inbound HTTP header → `ctx` → `event.Meta` | The handler reads the `traceparent` header, builds `core.TraceContext`, attaches via `core.WithTraceContext`, and calls `s.yield(ctx, data)` — closes the round-trip |
+
+**Caller-preserves rule.** If `SetMetaFunc` pre-stamps `event.Meta.traceparent`, the yield-time auto-injection is skipped — matches the same caller-wins semantic used by `core.InjectTraceContextIntoParams` (server outbound `_meta`) and the TS-side Apps Bridge relay (PR 702). The rule is uniform across every trace-context carrier in mcpkit.
+
+**Why three carriers, not one?** `ctx` is gone the moment a goroutine exits or an HTTP request crosses the wire. `event.Meta` survives JSON serialization, persistence, and replay. HTTP headers survive the network hop. Each carrier is appropriate to its gate; together they keep the trace ID intact across every transition.
+
+**End-to-end demo shape** (multi-replica, with webhook fanout to a peer):
+
+```
+yield(ctx, data) on replica A
+└─ event.Meta.traceparent stamped
+   └─ emit hook (ctx) → LocalEmitter → WebhookRegistry.Deliver(ctx, event)
+      └─ HTTP POST to replica B with `traceparent` header
+         └─ replica B HTTPSource.serveInject reads header
+            └─ yield(ctx, data) on replica B
+               └─ event.Meta.traceparent stamped again (same trace ID)
+                  └─ downstream subscribers / webhooks continue the chain
+```
+
+A single TraceID stitches all of this in Grafana / Tempo.

--- a/experimental/ext/events/body_cap_test.go
+++ b/experimental/ext/events/body_cap_test.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -46,7 +47,7 @@ func TestDelivery_OversizedEventNotPosted(t *testing.T) {
 	// Build a payload that, when JSON-marshaled with the envelope,
 	// exceeds 1 KiB. 2 KiB of "A" inside Data is enough.
 	bigData, _ := json.Marshal(map[string]string{"text": strings.Repeat("A", 2048)})
-	r.Deliver(Event{
+	r.Deliver(context.Background(), Event{
 		EventID:   "evt_oversize",
 		Name:      "fake.event",
 		Timestamp: time.Now().Format(time.RFC3339),
@@ -76,7 +77,7 @@ func TestDelivery_OversizedEventLogged(t *testing.T) {
 	r.Register(RegisterParams{CanonicalKey: []byte("k"), DerivedID: "sub_test", URL: srv.URL, Secret: "whsec_secret", MaxAgeSeconds: 0})
 
 	bigData, _ := json.Marshal(map[string]string{"text": strings.Repeat("B", 2048)})
-	r.Deliver(Event{
+	r.Deliver(context.Background(), Event{
 		EventID:   "evt_oversize_logged",
 		Name:      "fake.event",
 		Timestamp: time.Now().Format(time.RFC3339),
@@ -112,7 +113,7 @@ func TestDelivery_413NotRetried(t *testing.T) {
 	r := NewWebhookRegistry(WithWebhookAllowPrivateNetworks(true))
 	r.Register(RegisterParams{CanonicalKey: []byte("k"), DerivedID: "sub_test", URL: srv.URL, Secret: "whsec_secret", MaxAgeSeconds: 0})
 
-	r.Deliver(MakeEvent("fake.event", "evt_413", "1", time.Now(),
+	r.Deliver(context.Background(), MakeEvent("fake.event", "evt_413", "1", time.Now(),
 		map[string]string{"text": "tiny"}))
 
 	// Generous wait — if 413 were retried with backoff, we'd see 4 attempts

--- a/experimental/ext/events/cursorless_test.go
+++ b/experimental/ext/events/cursorless_test.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -65,9 +66,9 @@ func TestYieldingSource_WithoutCursorsEmitsNilCursor(t *testing.T) {
 	src, yield := NewYieldingSource[fakePayload](EventDef{Name: "fake"}, WithoutCursors())
 
 	var captured Event
-	src.SetEmitHook(func(e Event) { captured = e })
+	src.SetEmitHook(func(ctx context.Context, e Event) { captured = e })
 
-	require.NoError(t, yield(fakePayload{Msg: "x"}))
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "x"}))
 	assert.False(t, captured.HasCursor(),
 		"cursorless source must emit events with nil cursor")
 }
@@ -77,8 +78,8 @@ func TestYieldingSource_WithoutCursorsEmitsNilCursor(t *testing.T) {
 // memory and signals to operators that replay isn't supported.
 func TestYieldingSource_WithoutCursorsDoesNotBuffer(t *testing.T) {
 	src, yield := NewYieldingSource[fakePayload](EventDef{Name: "fake"}, WithoutCursors())
-	require.NoError(t, yield(fakePayload{Msg: "a"}))
-	require.NoError(t, yield(fakePayload{Msg: "b"}))
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "a"}))
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "b"}))
 
 	assert.Equal(t, 0, src.Len(), "cursorless source must not buffer")
 	assert.Empty(t, src.Recent(50), "Recent on cursorless source must be empty")
@@ -92,7 +93,7 @@ func TestYieldingSource_WithoutCursorsDoesNotBuffer(t *testing.T) {
 func TestYieldingSource_WithoutCursorsPollIsAlwaysEmpty(t *testing.T) {
 	src, yield := NewYieldingSource[fakePayload](EventDef{Name: "fake"}, WithoutCursors())
 	for i := 0; i < 3; i++ {
-		require.NoError(t, yield(fakePayload{Msg: "x"}))
+		require.NoError(t, yield(context.Background(), fakePayload{Msg: "x"}))
 	}
 
 	pr := src.Poll("", 100)
@@ -105,7 +106,7 @@ func TestYieldingSource_WithoutCursorsPollIsAlwaysEmpty(t *testing.T) {
 // `cursor: null` should resolve to a real value or stay null.
 func TestYieldingSource_WithoutCursorsLatestIsEmpty(t *testing.T) {
 	src, yield := NewYieldingSource[fakePayload](EventDef{Name: "fake"}, WithoutCursors())
-	require.NoError(t, yield(fakePayload{Msg: "x"}))
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "x"}))
 	assert.Equal(t, "", src.Latest())
 }
 
@@ -127,8 +128,8 @@ func TestYieldingSource_DefIsCursorless(t *testing.T) {
 func TestYieldingSource_LatestReturnsHeadCursor(t *testing.T) {
 	src, yield := NewYieldingSource[fakePayload](EventDef{Name: "fake"})
 	assert.Equal(t, "", src.Latest(), "empty source has no head")
-	require.NoError(t, yield(fakePayload{Msg: "a"}))
-	require.NoError(t, yield(fakePayload{Msg: "b"}))
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "a"}))
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "b"}))
 	assert.NotEmpty(t, src.Latest())
 	assert.Equal(t, "2", src.Latest(), "memory store assigns monotonic int cursors starting at 1")
 }

--- a/experimental/ext/events/delivery_status_test.go
+++ b/experimental/ext/events/delivery_status_test.go
@@ -116,7 +116,7 @@ func TestDeliveryStatus_AfterSuccessPopulatesLastDeliveryAt(t *testing.T) {
 	require.Nil(t, dispatchSubscribe(t, srv, params).Error)
 
 	// Drive one successful delivery.
-	webhooks.Deliver(MakeEvent("fake.event", "evt_1", "1", time.Now(), map[string]string{"k": "v"}))
+	webhooks.Deliver(context.Background(), MakeEvent("fake.event", "evt_1", "1", time.Now(), map[string]string{"k": "v"}))
 	require.Eventually(t, func() bool { return hits.Load() >= 1 },
 		2*time.Second, 20*time.Millisecond, "delivery should have landed")
 
@@ -156,7 +156,7 @@ func TestDeliveryStatus_LastErrorIsCategorical(t *testing.T) {
 	}
 	require.Nil(t, dispatchSubscribe(t, srv, params).Error)
 
-	webhooks.Deliver(MakeEvent("fake.event", "evt_fail", "1", time.Now(), map[string]string{"k": "v"}))
+	webhooks.Deliver(context.Background(), MakeEvent("fake.event", "evt_fail", "1", time.Now(), map[string]string{"k": "v"}))
 	// Wait long enough for the deliver loop to retry-and-fail (3 retries
 	// with backoff 0.5s + 1s + 2s = ~3.5s total).
 	time.Sleep(4 * time.Second)
@@ -211,7 +211,7 @@ func TestSuspend_AfterThresholdConsecutiveFailures(t *testing.T) {
 	// Drive `threshold` consecutive failed deliveries (each deliver()
 	// internally retries; we count whole-call outcomes, not retries).
 	for i := 0; i < threshold; i++ {
-		r.deliver(r.Targets()[0], "evt_"+string(rune('a'+i)), []byte(`{}`))
+		r.deliver(r.Targets()[0], "evt_"+string(rune('a'+i)), []byte(`{}`), core.TraceContext{})
 	}
 
 	st := r.DeliveryStatus(canonical)
@@ -245,13 +245,13 @@ func TestSuspend_FailuresOutsideWindowDontAccumulate(t *testing.T) {
 	// 2 failures, then sleep past the window, then 2 more.
 	// First-failure-time should reset on the post-sleep failures, so
 	// total counted-toward-current-run = 2 < threshold = 3 → still Active.
-	r.deliver(r.Targets()[0], "evt_1", []byte(`{}`))
-	r.deliver(r.Targets()[0], "evt_2", []byte(`{}`))
+	r.deliver(r.Targets()[0], "evt_1", []byte(`{}`), core.TraceContext{})
+	r.deliver(r.Targets()[0], "evt_2", []byte(`{}`), core.TraceContext{})
 
 	time.Sleep(300 * time.Millisecond) // > 200ms window
 
-	r.deliver(r.Targets()[0], "evt_3", []byte(`{}`))
-	r.deliver(r.Targets()[0], "evt_4", []byte(`{}`))
+	r.deliver(r.Targets()[0], "evt_3", []byte(`{}`), core.TraceContext{})
+	r.deliver(r.Targets()[0], "evt_4", []byte(`{}`), core.TraceContext{})
 
 	st := r.DeliveryStatus(canonical)
 	assert.True(t, st.Active,
@@ -281,8 +281,8 @@ func TestSuspend_SuccessfulRefreshReactivates(t *testing.T) {
 	r.Register(RegisterParams{CanonicalKey: canonical, DerivedID: "sub_react", URL: receiver.URL, Secret: "whsec_secret", MaxAgeSeconds: 0})
 
 	// Drive 2 consecutive failures → suspended.
-	r.deliver(r.Targets()[0], "evt_a", []byte(`{}`))
-	r.deliver(r.Targets()[0], "evt_b", []byte(`{}`))
+	r.deliver(r.Targets()[0], "evt_a", []byte(`{}`), core.TraceContext{})
+	r.deliver(r.Targets()[0], "evt_b", []byte(`{}`), core.TraceContext{})
 	require.False(t, r.DeliveryStatus(canonical).Active, "precondition: target should be suspended")
 
 	// Refresh — same canonical tuple, idempotent re-Register.
@@ -333,15 +333,15 @@ func TestSuspend_SuspendedTargetSkippedInDeliver(t *testing.T) {
 	r.Register(RegisterParams{CanonicalKey: canonical, DerivedID: "sub_skip", URL: receiver.URL, Secret: "whsec_secret", MaxAgeSeconds: 0})
 
 	// Drive 2 failures → suspended.
-	r.deliver(r.Targets()[0], "evt_a", []byte(`{}`))
-	r.deliver(r.Targets()[0], "evt_b", []byte(`{}`))
+	r.deliver(r.Targets()[0], "evt_a", []byte(`{}`), core.TraceContext{})
+	r.deliver(r.Targets()[0], "evt_b", []byte(`{}`), core.TraceContext{})
 	require.False(t, r.DeliveryStatus(canonical).Active)
 
 	// Note hits up to here so we measure only what happens AFTER suspension.
 	hitsBeforeSuspendYield := eventHits.Load()
 
 	// Yield via Deliver — suspended target should be skipped.
-	r.Deliver(MakeEvent("fake.event", "evt_post_suspend", "1", time.Now(), map[string]string{"k": "v"}))
+	r.Deliver(context.Background(), MakeEvent("fake.event", "evt_post_suspend", "1", time.Now(), map[string]string{"k": "v"}))
 	time.Sleep(200 * time.Millisecond)
 
 	assert.Equal(t, hitsBeforeSuspendYield, eventHits.Load(),
@@ -391,8 +391,8 @@ func TestSuspend_AutoPostsTerminatedEnvelopeOnSuspension(t *testing.T) {
 	r.Register(RegisterParams{CanonicalKey: canonical, DerivedID: "sub_at", URL: receiver.URL, Secret: "whsec_secret", MaxAgeSeconds: 0})
 
 	// Drive 2 failures → suspend transition fires.
-	r.deliver(r.Targets()[0], "evt_a", []byte(`{}`))
-	r.deliver(r.Targets()[0], "evt_b", []byte(`{}`))
+	r.deliver(r.Targets()[0], "evt_a", []byte(`{}`), core.TraceContext{})
+	r.deliver(r.Targets()[0], "evt_b", []byte(`{}`), core.TraceContext{})
 
 	require.Eventually(t, func() bool {
 		return sawTerminated.Load() == 1
@@ -437,8 +437,8 @@ func TestSuspend_DoesNotAutoPostTerminatedTwice(t *testing.T) {
 	r.Register(RegisterParams{CanonicalKey: canonical, DerivedID: "sub_idem", URL: receiver.URL, Secret: "whsec_secret", MaxAgeSeconds: 0})
 
 	// Suspend.
-	r.deliver(r.Targets()[0], "evt_a", []byte(`{}`))
-	r.deliver(r.Targets()[0], "evt_b", []byte(`{}`))
+	r.deliver(r.Targets()[0], "evt_a", []byte(`{}`), core.TraceContext{})
+	r.deliver(r.Targets()[0], "evt_b", []byte(`{}`), core.TraceContext{})
 	require.Eventually(t, func() bool { return sawTerminated.Load() == 1 },
 		2*time.Second, 20*time.Millisecond)
 
@@ -455,7 +455,7 @@ func TestSuspend_DoesNotAutoPostTerminatedTwice(t *testing.T) {
 	// lookupTarget's internal RLock.
 	target, ok := r.lookupTarget(canonical)
 	require.True(t, ok)
-	r.deliver(target, "evt_c", []byte(`{}`))
+	r.deliver(target, "evt_c", []byte(`{}`), core.TraceContext{})
 
 	// Wait long enough that any auto-Post would have happened.
 	time.Sleep(500 * time.Millisecond)
@@ -480,7 +480,7 @@ func TestDeliveryStatus_LastErrorBucketsForConnectionRefused(t *testing.T) {
 	}
 	require.Nil(t, dispatchSubscribe(t, srv, params).Error)
 
-	webhooks.Deliver(MakeEvent("fake.event", "evt_refused", "1", time.Now(), map[string]string{"k": "v"}))
+	webhooks.Deliver(context.Background(), MakeEvent("fake.event", "evt_refused", "1", time.Now(), map[string]string{"k": "v"}))
 	time.Sleep(4 * time.Second) // 3 retries with backoff
 
 	result := dispatchSubscribeForStatus(t, srv, deadURL, params["delivery"].(map[string]any)["secret"].(string))

--- a/experimental/ext/events/emitter.go
+++ b/experimental/ext/events/emitter.go
@@ -79,12 +79,12 @@ type localEmitter struct {
 	webhooks *WebhookRegistry
 }
 
-func (e *localEmitter) Emit(_ context.Context, event Event) error {
+func (e *localEmitter) Emit(ctx context.Context, event Event) error {
 	if e.srv != nil {
-		Emit(e.srv, event)
+		Emit(ctx, e.srv, event)
 	}
 	if e.webhooks != nil {
-		EmitToWebhooks(e.webhooks, event)
+		EmitToWebhooks(ctx, e.webhooks, event)
 	}
 	return nil
 }

--- a/experimental/ext/events/emitter_test.go
+++ b/experimental/ext/events/emitter_test.go
@@ -149,8 +149,8 @@ func TestRegister_DefaultEmitterIsLocalEmitter(t *testing.T) {
 		UnsafeAnonymousPrincipal: "test-principal",
 	})
 
-	require.NoError(t, yield(map[string]any{"k": "v"}))
-	require.NoError(t, yield(map[string]any{"k": "v"}))
+	require.NoError(t, yield(context.Background(), map[string]any{"k": "v"}))
+	require.NoError(t, yield(context.Background(), map[string]any{"k": "v"}))
 
 	assert.Equal(t, int32(2), spy.count.Load(),
 		"configured Emitter must receive every yielded event")

--- a/experimental/ext/events/events.go
+++ b/experimental/ext/events/events.go
@@ -314,8 +314,8 @@ func Register(cfg Config) {
 			// the source's internal fanout. The default LocalEmitter
 			// runs Emit + EmitToWebhooks inline, preserving today's
 			// yield-blocks-on-delivery semantics.
-			ea.SetEmitHook(func(event Event) {
-				_ = emitter.Emit(context.Background(), event)
+			ea.SetEmitHook(func(ctx context.Context, event Event) {
+				_ = emitter.Emit(ctx, event)
 			})
 		}
 	}
@@ -426,13 +426,21 @@ func Register(cfg Config) {
 
 // Emit broadcasts an event to all connected SSE clients via Server.Broadcast.
 // This is the push delivery path.
-func Emit(srv *server.Server, event Event) {
+//
+// ctx threads through for SEP-414 trace propagation. Server.Broadcast
+// doesn't take ctx today (the SSE push path is its own concern); the
+// param is accepted for signature symmetry with EmitToWebhooks and so
+// future Broadcast(ctx, ...) plumbing slots in without churning every
+// caller.
+func Emit(_ context.Context, srv *server.Server, event Event) {
 	srv.Broadcast("notifications/events/event", event)
 }
 
-// EmitToWebhooks delivers an event to all registered webhooks.
-func EmitToWebhooks(webhooks *WebhookRegistry, event Event) {
-	webhooks.Deliver(event)
+// EmitToWebhooks delivers an event to all registered webhooks. ctx is
+// threaded through to WebhookRegistry.Deliver so the outbound HTTP
+// POST carries the W3C traceparent header (SEP-414 P6, issue 683).
+func EmitToWebhooks(ctx context.Context, webhooks *WebhookRegistry, event Event) {
+	webhooks.Deliver(ctx, event)
 }
 
 // --- Protocol method implementations ---
@@ -817,7 +825,7 @@ func registerSubscribe(srv *server.Server, sourceMap map[string]EventSource, web
 				SubscriptionID: derivedID,
 				Mode:           DeliveryModeWebhook,
 				Deliver: func(event Event) {
-					webhooks.DeliverToTarget(canonicalCopy, event)
+					webhooks.DeliverToTarget(ctx, canonicalCopy, event)
 				},
 			})
 		}

--- a/experimental/ext/events/http_source.go
+++ b/experimental/ext/events/http_source.go
@@ -1,11 +1,14 @@
 package events
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
 	"strings"
+
+	"github.com/panyam/mcpkit/core"
 )
 
 // HTTPSource is the third source pattern (sibling to YieldingSource and
@@ -35,7 +38,7 @@ import (
 // available on *HTTPSource[Data] without explicit delegation.
 type HTTPSource[Data any] struct {
 	*YieldingSource[Data]
-	yield func(Data) error
+	yield func(context.Context, Data) error
 	cfg   HTTPSourceConfig
 }
 
@@ -98,7 +101,11 @@ func NewHTTPSource[Data any](def EventDef, cfg HTTPSourceConfig) *HTTPSource[Dat
 // holds the *HTTPSource directly can emit events without going through
 // HTTP. Useful for tests and for hybrid demos that mix in-process feeds
 // with HTTP-fed feeds against the same source.
-func (s *HTTPSource[Data]) Yield(data Data) error { return s.yield(data) }
+//
+// ctx threads the W3C trace context through into the underlying
+// yield (and onward through emit hook → webhook delivery's
+// outbound HTTP traceparent header) — SEP-414 P6 (issue 683).
+func (s *HTTPSource[Data]) Yield(ctx context.Context, data Data) error { return s.yield(ctx, data) }
 
 // InjectPath returns the URL path the Handler is mounted at. Defaults
 // to "/events/<def.Name>/inject" unless overridden in HTTPSourceConfig.
@@ -162,7 +169,23 @@ func (s *HTTPSource[Data]) serveInject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.yield(data); err != nil {
+	// SEP-414 P6 (issue 683): extract W3C trace context from the
+	// inbound HTTP headers and attach to ctx so the underlying yield
+	// stamps it onto event.Meta + flows it through the emit hook to
+	// any downstream emitter. Closes the round-trip with the
+	// outbound traceparent header webhook delivery sets — replica A
+	// yields with ctx → webhook out → replica B's serveInject in →
+	// yield with the same trace ID.
+	ctx := r.Context()
+	if tp := r.Header.Get(traceparentHTTPHeader); tp != "" {
+		tc := core.TraceContext{
+			Traceparent: tp,
+			Tracestate:  r.Header.Get(tracestateHTTPHeader),
+		}
+		ctx = core.WithTraceContext(ctx, tc)
+	}
+
+	if err := s.yield(ctx, data); err != nil {
 		http.Error(w, "yield failed: "+err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/experimental/ext/events/http_source_test.go
+++ b/experimental/ext/events/http_source_test.go
@@ -1,6 +1,7 @@
 package events_test
 
 import (
+	"context"
 	"bytes"
 	"net/http"
 	"net/http/httptest"
@@ -142,7 +143,7 @@ func TestHTTPSource_YieldingOptionsForwarded(t *testing.T) {
 func TestHTTPSource_InProcessYieldEquivalentToHTTP(t *testing.T) {
 	src, srv := newChatHTTPSource(t, events.HTTPSourceConfig{})
 
-	require.NoError(t, src.Yield(chatMsg{Sender: "alice", Text: "in-proc"}))
+	require.NoError(t, src.Yield(context.Background(), chatMsg{Sender: "alice", Text: "in-proc"}))
 
 	resp := postInject(t, srv, "", `{"sender":"bob","text":"via-http"}`)
 	resp.Body.Close()

--- a/experimental/ext/events/identity_handler_test.go
+++ b/experimental/ext/events/identity_handler_test.go
@@ -239,7 +239,7 @@ func TestDelivery_EmitsXMCPSubscriptionIDHeader(t *testing.T) {
 	// Direct Deliver bypasses the JSON-RPC handler — what we want to
 	// inspect is the registry's outbound HTTP shape, not the subscribe
 	// flow (covered by other tests).
-	webhooks.Deliver(Event{EventID: "evt_1", Name: "fake.event", Data: json.RawMessage(`{}`)})
+	webhooks.Deliver(context.Background(), Event{EventID: "evt_1", Name: "fake.event", Data: json.RawMessage(`{}`)})
 
 	select {
 	case got := <-gotHeader:

--- a/experimental/ext/events/lifecycle_test.go
+++ b/experimental/ext/events/lifecycle_test.go
@@ -97,7 +97,7 @@ type lifecycleFixture struct {
 	t        *testing.T
 	srv      *server.Server
 	source   *YieldingSource[map[string]any]
-	yield    func(map[string]any) error
+	yield    func(context.Context, map[string]any) error
 	def      EventDef
 	webhooks *WebhookRegistry
 	leases   *PollLeaseTable
@@ -363,7 +363,7 @@ func TestLifecycle_Webhook_SuspendDoesNotFireOnUnsubscribe(t *testing.T) {
 	// deletion → onRemove must not fire.
 	target := f.webhooks.Targets()[0]
 	for i := 0; i < threshold; i++ {
-		f.webhooks.deliver(target, "evt_"+string(rune('a'+i)), []byte(`{}`))
+		f.webhooks.deliver(target, "evt_"+string(rune('a'+i)), []byte(`{}`), core.TraceContext{})
 	}
 
 	st := f.webhooks.DeliveryStatus(target.CanonicalKey)

--- a/experimental/ext/events/match_transform_test.go
+++ b/experimental/ext/events/match_transform_test.go
@@ -96,7 +96,7 @@ func TestMatchTransform_Push_MatchFiltersSubscribers(t *testing.T) {
 	chLow, _ := src.Subscribe(ctx, SubscribeOpts{Principal: "bob", Params: map[string]any{"severity": "low"}})
 	chAll, _ := src.Subscribe(ctx, SubscribeOpts{Principal: "carol", Params: nil})
 
-	require.NoError(t, yield(sevPayload{Severity: "high", Reporter: "alice@x"}))
+	require.NoError(t, yield(context.Background(), sevPayload{Severity: "high", Reporter: "alice@x"}))
 
 	// chHigh + chAll should see it; chLow should not.
 	expectEvent := func(label string, ch <-chan SubscriberEvent, want bool) {
@@ -131,7 +131,7 @@ func TestMatchTransform_Push_TransformShapesPerSubscriber(t *testing.T) {
 	chRedact, _ := src.Subscribe(ctx, SubscribeOpts{Params: map[string]any{"redact_pii": true}})
 	chRaw, _ := src.Subscribe(ctx, SubscribeOpts{Params: map[string]any{"redact_pii": false}})
 
-	require.NoError(t, yield(sevPayload{Severity: "high", Reporter: "alice@x"}))
+	require.NoError(t, yield(context.Background(), sevPayload{Severity: "high", Reporter: "alice@x"}))
 
 	pickPayload := func(ch <-chan SubscriberEvent) sevPayload {
 		t.Helper()
@@ -166,7 +166,7 @@ func TestMatchTransform_Push_NilHooksAreNoop(t *testing.T) {
 	defer cancel()
 	ch, _ := src.Subscribe(ctx, SubscribeOpts{Params: map[string]any{"severity": "low"}})
 
-	require.NoError(t, yield(sevPayload{Severity: "high", Reporter: "alice@x"}))
+	require.NoError(t, yield(context.Background(), sevPayload{Severity: "high", Reporter: "alice@x"}))
 
 	select {
 	case se := <-ch:
@@ -198,7 +198,7 @@ func TestMatchTransform_Push_PanicSafe(t *testing.T) {
 	defer cancel()
 	ch, _ := src.Subscribe(ctx, SubscribeOpts{Params: map[string]any{"severity": "high"}})
 
-	require.NoError(t, yield(sevPayload{Severity: "high", Reporter: "alice@x"}))
+	require.NoError(t, yield(context.Background(), sevPayload{Severity: "high", Reporter: "alice@x"}))
 
 	// Match panic → safeMatch returns false → subscriber does not
 	// receive. The fanout itself MUST NOT crash.
@@ -280,7 +280,7 @@ func TestMatchTransform_Webhook_MatchAndTransformPerTarget(t *testing.T) {
 	// C: match high, redact → receives body with empty Reporter
 	subscribe(rC.URL, map[string]any{"severity": "high", "redact_pii": true}, 'c')
 
-	require.NoError(t, yield(sevPayload{Severity: "high", Reporter: "alice@x"}))
+	require.NoError(t, yield(context.Background(), sevPayload{Severity: "high", Reporter: "alice@x"}))
 
 	// Async deliver — wait briefly for all three (or just the
 	// expected two) to land.
@@ -379,7 +379,7 @@ func TestMatchTransform_Webhook_FiltersByEventName(t *testing.T) {
 	require.Nil(t, resp.Error)
 
 	// Yield from src.a — should NOT deliver to src.b's webhook.
-	require.NoError(t, yieldA(sevPayload{Severity: "high"}))
+	require.NoError(t, yieldA(context.Background(), sevPayload{Severity: "high"}))
 
 	time.Sleep(150 * time.Millisecond)
 	if got := hits.Load(); got != 0 {
@@ -408,8 +408,8 @@ func TestMatchTransform_Poll_AppliesPerCall(t *testing.T) {
 	finishInitHandshake(t, srv)
 
 	// Pre-populate two events of differing severity.
-	require.NoError(t, yield(sevPayload{Severity: "high", Reporter: "h@x"}))
-	require.NoError(t, yield(sevPayload{Severity: "low", Reporter: "l@x"}))
+	require.NoError(t, yield(context.Background(), sevPayload{Severity: "high", Reporter: "h@x"}))
+	require.NoError(t, yield(context.Background(), sevPayload{Severity: "low", Reporter: "l@x"}))
 
 	pollAndDecode := func(params map[string]any) []sevPayload {
 		t.Helper()
@@ -512,7 +512,7 @@ func TestMatchTransform_CrossModeParity(t *testing.T) {
 	require.Nil(t, resp.Error)
 
 	// Yield matches.
-	require.NoError(t, yield(sevPayload{Severity: "high", Reporter: "h@x"}))
+	require.NoError(t, yield(context.Background(), sevPayload{Severity: "high", Reporter: "h@x"}))
 
 	// Push delivery
 	var pushPayload sevPayload

--- a/experimental/ext/events/ssrf_delivery_test.go
+++ b/experimental/ext/events/ssrf_delivery_test.go
@@ -100,7 +100,7 @@ func TestDelivery_RejectsLoopbackAtDialTime(t *testing.T) {
 	r := ssrfTestRegistry(false, logCap) // allowPrivate=false → loopback BLOCKED
 
 	r.Register(RegisterParams{CanonicalKey: []byte("k"), DerivedID: "sub_test", URL: srv.URL, Secret: "whsec_secret", MaxAgeSeconds: 0})
-	r.Deliver(MakeEvent("fake.event", "evt_1", "1", time.Now(),
+	r.Deliver(context.Background(), MakeEvent("fake.event", "evt_1", "1", time.Now(),
 		map[string]string{"text": "hi"}))
 
 	// Give the deliver goroutine a moment to fail.
@@ -125,7 +125,7 @@ func TestDelivery_AllowsLoopbackWithEscape(t *testing.T) {
 
 	r := ssrfTestRegistry(true, nil) // allowPrivate=true → demo mode
 	r.Register(RegisterParams{CanonicalKey: []byte("k"), DerivedID: "sub_test", URL: srv.URL, Secret: "whsec_secret", MaxAgeSeconds: 0})
-	r.Deliver(MakeEvent("fake.event", "evt_1", "1", time.Now(),
+	r.Deliver(context.Background(), MakeEvent("fake.event", "evt_1", "1", time.Now(),
 		map[string]string{"text": "hi"}))
 
 	require.Eventually(t, func() bool { return hits.Load() == 1 },
@@ -226,7 +226,7 @@ func TestDelivery_DoesNotFollowRedirects(t *testing.T) {
 	// not the SSRF dial guard.
 	r := ssrfTestRegistry(true, nil)
 	r.Register(RegisterParams{CanonicalKey: []byte("k"), DerivedID: "sub_test", URL: srv.URL, Secret: "whsec_secret", MaxAgeSeconds: 0})
-	r.Deliver(MakeEvent("fake.event", "evt_1", "1", time.Now(),
+	r.Deliver(context.Background(), MakeEvent("fake.event", "evt_1", "1", time.Now(),
 		map[string]string{"text": "hi"}))
 
 	// Wait long enough for the deliver loop to retry-and-fail (3xx

--- a/experimental/ext/events/stream_routing_test.go
+++ b/experimental/ext/events/stream_routing_test.go
@@ -116,7 +116,7 @@ func TestStream_TwoConcurrentStreamsIsolated(t *testing.T) {
 
 	// Yield only on source A. Stream A should see one event notif; stream
 	// B should see none.
-	require.NoError(t, yieldA(fakePayload{Msg: "for-A-only"}))
+	require.NoError(t, yieldA(context.Background(), fakePayload{Msg: "for-A-only"}))
 
 	// Wait briefly for notification propagation, then drain whatever
 	// arrived. We assert: every events/event has requestId=100 (stream A).
@@ -167,7 +167,7 @@ func TestStream_TwoConcurrentStreamsSameSourceBothReceive(t *testing.T) {
 	expectNotif(t, st.notifs, "notifications/events/active", time.Second)
 	expectNotif(t, st.notifs, "notifications/events/active", time.Second)
 
-	require.NoError(t, yield(fakePayload{Msg: "broadcast"}))
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "broadcast"}))
 
 	deadline := time.After(time.Second)
 	var sawX, sawY bool

--- a/experimental/ext/events/stream_test.go
+++ b/experimental/ext/events/stream_test.go
@@ -25,7 +25,7 @@ type streamTestStack struct {
 	srv       *server.Server
 	transport *server.InProcessTransport
 	source    *YieldingSource[fakePayload]
-	yield     func(fakePayload) error
+	yield     func(context.Context, fakePayload) error
 	notifs    chan capturedNotif
 }
 
@@ -233,7 +233,7 @@ func TestStream_EventNotificationCarriesRequestId(t *testing.T) {
 	// Drain the initial active notification.
 	expectNotif(t, st.notifs, "notifications/events/active", time.Second)
 
-	require.NoError(t, st.yield(fakePayload{Msg: "hello"}))
+	require.NoError(t, st.yield(context.Background(), fakePayload{Msg: "hello"}))
 	n := expectNotif(t, st.notifs, "notifications/events/event", time.Second)
 
 	var p map[string]any

--- a/experimental/ext/events/trace_propagation_test.go
+++ b/experimental/ext/events/trace_propagation_test.go
@@ -1,0 +1,288 @@
+package events
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/panyam/mcpkit/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	demoTraceparent  = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+	demoTraceparent2 = "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1111111111111111-01"
+	demoTracestate   = "vendor=val,other=x"
+)
+
+func ctxWithTraceparent(tp string) context.Context {
+	return core.WithTraceContext(context.Background(), core.TraceContext{Traceparent: tp})
+}
+
+// Gate 1+2: yield(ctx, data) stamps event.Meta.traceparent and the
+// emit hook receives ctx with the same trace context attached.
+func TestYieldCtx_StampsMetaAndFlowsToHook(t *testing.T) {
+	src, yield := NewYieldingSource[fakePayload](EventDef{Name: "fake"})
+
+	var (
+		hookEvent Event
+		hookCtx   context.Context
+		done      = make(chan struct{})
+	)
+	src.SetEmitHook(func(ctx context.Context, e Event) {
+		hookCtx = ctx
+		hookEvent = e
+		close(done)
+	})
+
+	require.NoError(t, yield(ctxWithTraceparent(demoTraceparent), fakePayload{Msg: "hi"}))
+	<-done
+
+	require.NotNil(t, hookEvent.Meta, "yield with ctx carrying traceparent must populate Event.Meta")
+	assert.Equal(t, demoTraceparent, hookEvent.Meta[core.MetaKeyTraceparent],
+		"event.Meta must carry the traceparent (persistent carrier for cross-process consumers)")
+	assert.Equal(t, demoTraceparent, core.TraceContextFromContext(hookCtx).Traceparent,
+		"emit hook must receive ctx with the same trace context (in-process carrier)")
+}
+
+func TestYieldCtx_NoTraceContext_NoStamp(t *testing.T) {
+	src, yield := NewYieldingSource[fakePayload](EventDef{Name: "fake"})
+	var got Event
+	done := make(chan struct{})
+	src.SetEmitHook(func(_ context.Context, e Event) {
+		got = e
+		close(done)
+	})
+
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "hi"}))
+	<-done
+
+	if got.Meta != nil {
+		_, has := got.Meta[core.MetaKeyTraceparent]
+		assert.False(t, has, "background ctx must not stamp a traceparent into Meta")
+	}
+}
+
+// metaFunc setting traceparent wins over the yield-time auto-stamp —
+// matches the caller-preserves semantic used by core.InjectTraceContextIntoParams
+// and the Apps Bridge TS-side relay (PR 702).
+func TestYieldCtx_MetaFuncSetTraceparent_NotClobbered(t *testing.T) {
+	src, yield := NewYieldingSource[fakePayload](EventDef{Name: "fake"})
+	src.SetMetaFunc(func(_ context.Context, _ fakePayload) map[string]any {
+		return map[string]any{core.MetaKeyTraceparent: demoTraceparent2}
+	})
+	var got Event
+	done := make(chan struct{})
+	src.SetEmitHook(func(_ context.Context, e Event) {
+		got = e
+		close(done)
+	})
+
+	require.NoError(t, yield(ctxWithTraceparent(demoTraceparent), fakePayload{Msg: "hi"}))
+	<-done
+
+	assert.Equal(t, demoTraceparent2, got.Meta[core.MetaKeyTraceparent],
+		"metaFunc-set traceparent must be preserved; the yield-time auto-stamp is a fallback only")
+}
+
+func TestYieldCtx_TracestateAlongsideTraceparent(t *testing.T) {
+	src, yield := NewYieldingSource[fakePayload](EventDef{Name: "fake"})
+	var got Event
+	done := make(chan struct{})
+	src.SetEmitHook(func(_ context.Context, e Event) {
+		got = e
+		close(done)
+	})
+
+	ctx := core.WithTraceContext(context.Background(), core.TraceContext{
+		Traceparent: demoTraceparent,
+		Tracestate:  demoTracestate,
+	})
+	require.NoError(t, yield(ctx, fakePayload{Msg: "hi"}))
+	<-done
+
+	assert.Equal(t, demoTraceparent, got.Meta[core.MetaKeyTraceparent])
+	assert.Equal(t, demoTracestate, got.Meta[core.MetaKeyTracestate])
+}
+
+// Gate 3: WebhookRegistry.Deliver injects the W3C traceparent HTTP
+// header on every outbound POST when ctx (or event.Meta as a
+// fallback) carries one.
+func TestWebhookDeliver_InjectsTraceparentHeader(t *testing.T) {
+	var (
+		mu              sync.Mutex
+		seenTraceparent string
+		seenTracestate  string
+	)
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		seenTraceparent = r.Header.Get("traceparent")
+		seenTracestate = r.Header.Get("tracestate")
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer receiver.Close()
+
+	wh := newWebhookRegistryWithTarget(t, receiver.URL)
+
+	ctx := core.WithTraceContext(context.Background(), core.TraceContext{
+		Traceparent: demoTraceparent,
+		Tracestate:  demoTracestate,
+	})
+	event := MakeEvent("fake.event", "evt_relay_1", "1", time.Now(), map[string]string{"k": "v"})
+	wh.Deliver(ctx, event)
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return seenTraceparent != ""
+	}, 3*time.Second, 20*time.Millisecond, "receiver should see the traceparent header within retry window")
+
+	assert.Equal(t, demoTraceparent, seenTraceparent)
+	assert.Equal(t, demoTracestate, seenTracestate)
+}
+
+func TestWebhookDeliver_NoTraceContext_NoHeader(t *testing.T) {
+	var (
+		mu          sync.Mutex
+		seenHeaders http.Header
+		hits        int
+	)
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		seenHeaders = r.Header.Clone()
+		hits++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer receiver.Close()
+
+	wh := newWebhookRegistryWithTarget(t, receiver.URL)
+	event := MakeEvent("fake.event", "evt_no_trace", "1", time.Now(), map[string]string{"k": "v"})
+	wh.Deliver(context.Background(), event)
+
+	require.Eventually(t, func() bool { mu.Lock(); defer mu.Unlock(); return hits >= 1 },
+		2*time.Second, 20*time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Empty(t, seenHeaders.Get("traceparent"),
+		"no traceparent in ctx or event.Meta must mean no traceparent header on the wire")
+}
+
+// event.Meta carries the traceparent on the fallback path — used by
+// callers that haven't been threaded with ctx but pre-stamped Meta
+// themselves (e.g., persisted-and-replayed events).
+func TestWebhookDeliver_FallsBackToEventMeta(t *testing.T) {
+	var (
+		mu              sync.Mutex
+		seenTraceparent string
+	)
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		seenTraceparent = r.Header.Get("traceparent")
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer receiver.Close()
+
+	wh := newWebhookRegistryWithTarget(t, receiver.URL)
+	event := MakeEvent("fake.event", "evt_meta_only", "1", time.Now(), map[string]string{"k": "v"})
+	event.Meta = map[string]any{core.MetaKeyTraceparent: demoTraceparent}
+	// Context has NO trace context — exercises the event.Meta fallback path.
+	wh.Deliver(context.Background(), event)
+
+	require.Eventually(t, func() bool { mu.Lock(); defer mu.Unlock(); return seenTraceparent != "" },
+		3*time.Second, 20*time.Millisecond)
+
+	assert.Equal(t, demoTraceparent, seenTraceparent,
+		"event.Meta.traceparent must be picked up when ctx has none (replayed-event path)")
+}
+
+// Gate 4: HTTPSource.serveInject extracts the W3C traceparent HTTP
+// header from inbound POSTs and threads it through into yield so
+// Event.Meta carries the trace ID. Closes the round-trip with Gate 3.
+func TestHTTPSourceInject_ExtractsTraceparentFromHTTPHeader(t *testing.T) {
+	src := NewHTTPSource[fakePayload](EventDef{Name: "chat"}, HTTPSourceConfig{})
+
+	var (
+		got  Event
+		done = make(chan struct{})
+	)
+	src.SetEmitHook(func(_ context.Context, e Event) {
+		got = e
+		close(done)
+	})
+
+	ts := httptest.NewServer(src.Handler())
+	defer ts.Close()
+
+	body, _ := json.Marshal(fakePayload{Msg: "hi from peer A"})
+	req, err := http.NewRequest("POST", ts.URL, strings.NewReader(string(body)))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("traceparent", demoTraceparent)
+	req.Header.Set("tracestate", demoTracestate)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusAccepted, resp.StatusCode)
+	_ = resp.Body.Close()
+
+	<-done
+	require.NotNil(t, got.Meta, "yield-from-HTTP must populate Event.Meta with the inbound traceparent")
+	assert.Equal(t, demoTraceparent, got.Meta[core.MetaKeyTraceparent],
+		"inbound traceparent header → event.Meta.traceparent — closes the cross-process round-trip")
+	assert.Equal(t, demoTracestate, got.Meta[core.MetaKeyTracestate])
+}
+
+func TestHTTPSourceInject_NoTraceparent_NoStamp(t *testing.T) {
+	src := NewHTTPSource[fakePayload](EventDef{Name: "chat"}, HTTPSourceConfig{})
+	var got Event
+	done := make(chan struct{})
+	src.SetEmitHook(func(_ context.Context, e Event) {
+		got = e
+		close(done)
+	})
+
+	ts := httptest.NewServer(src.Handler())
+	defer ts.Close()
+
+	body, _ := json.Marshal(fakePayload{Msg: "no trace"})
+	resp, err := http.Post(ts.URL, "application/json", strings.NewReader(string(body)))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusAccepted, resp.StatusCode)
+	_ = resp.Body.Close()
+
+	<-done
+	if got.Meta != nil {
+		_, has := got.Meta[core.MetaKeyTraceparent]
+		assert.False(t, has, "no inbound traceparent header → no traceparent on Event.Meta")
+	}
+}
+
+// newWebhookRegistryWithTarget spins up a minimal WebhookRegistry +
+// registers one target pointing at receiverURL. Shared helper for the
+// trace-relay tests (each tests the same outbound delivery shape).
+func newWebhookRegistryWithTarget(t *testing.T, receiverURL string) *WebhookRegistry {
+	t.Helper()
+	wh := NewWebhookRegistry(WithWebhookAllowPrivateNetworks(true))
+	target := WebhookTarget{
+		EventName: "fake.event",
+		URL:       receiverURL,
+		Secret:    generateSecret(),
+		ExpiresAt: time.Now().Add(time.Hour),
+		Status:    DeliveryStatus{Active: true},
+	}
+	target.CanonicalKey = canonicalKey("test-principal", receiverURL, "fake.event", nil)
+	target.ID = deriveSubscriptionID(target.CanonicalKey)
+	_, err := wh.store.SaveWebhook(context.Background(), SaveWebhookRequest{Target: target})
+	require.NoError(t, err)
+	return wh
+}

--- a/experimental/ext/events/webhook.go
+++ b/experimental/ext/events/webhook.go
@@ -13,7 +13,36 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/panyam/mcpkit/core"
 )
+
+// HTTP header names for the W3C Trace Context propagation that
+// Deliver / DeliverToTarget stamp on every outbound POST when a
+// trace context is available — SEP-414 P6 (issue 683). Bare W3C
+// names; not under any io.modelcontextprotocol/ namespace.
+const (
+	traceparentHTTPHeader = "traceparent"
+	tracestateHTTPHeader  = "tracestate"
+)
+
+// traceContextForDelivery resolves the trace context to stamp on an
+// outbound webhook POST. Precedence:
+//  1. ctx (passed in from the in-process call chain — Register's
+//     emit hook, EmitToWebhooks helper, etc.)
+//  2. event.Meta (the persistent carrier — caller pre-stamped via
+//     YieldingSource.SetMetaFunc or the yield-time auto-injection)
+//
+// Returns a zero TraceContext when no source has one — the caller
+// skips setting the HTTP headers in that case, preserving "no
+// propagation when none was intended" for backward-compat with
+// pre-SEP-414 receivers.
+func traceContextForDelivery(ctx context.Context, event Event) core.TraceContext {
+	if tc := core.TraceContextFromContext(ctx); !tc.IsZero() {
+		return tc
+	}
+	return core.ExtractTraceContext(event.Meta)
+}
 
 // Webhook TTL spec envelope. WG guidance (Peter, 2026-06-05 in
 // #triggers-events-wg) is that webhook subscription TTLs must fall in
@@ -734,7 +763,11 @@ func (r *WebhookRegistry) pruneExpiredLocked() []WebhookTarget {
 // (unregistered between the index lookup and this call, suspended,
 // or expired). Caller treats this as a normal drop — racing
 // targeted-emit against teardown is expected, not an error.
-func (r *WebhookRegistry) DeliverToTarget(canonicalKey []byte, event Event) bool {
+//
+// ctx threads through to r.deliver so the outbound HTTP POST carries
+// the W3C `traceparent` header — SEP-414 P6 propagation across the
+// cross-process events bus boundary (issue 683).
+func (r *WebhookRegistry) DeliverToTarget(ctx context.Context, canonicalKey []byte, event Event) bool {
 	r.mu.RLock()
 	resp, _ := r.store.GetWebhook(context.Background(), GetWebhookRequest{CanonicalKey: canonicalKey})
 	r.mu.RUnlock()
@@ -756,7 +789,8 @@ func (r *WebhookRegistry) DeliverToTarget(canonicalKey []byte, event Event) bool
 			event.EventID, len(body), r.maxBodyBytes, target.ID)
 		return false
 	}
-	go r.deliver(target, event.EventID, body)
+	tc := traceContextForDelivery(ctx, event)
+	go r.deliver(target, event.EventID, body, tc)
 	return true
 }
 
@@ -792,7 +826,7 @@ func (r *WebhookRegistry) ExpireAll() {
 // haven't installed a resolver (TypedSource authors hand-emitting)
 // get a passthrough — Match=nil delivers to all matching-name targets,
 // Transform=nil reuses the original body.
-func (r *WebhookRegistry) Deliver(event Event) {
+func (r *WebhookRegistry) Deliver(ctx context.Context, event Event) {
 	targets := r.Targets()
 	if len(targets) == 0 {
 		return
@@ -856,7 +890,12 @@ func (r *WebhookRegistry) Deliver(event Event) {
 			}
 			body = b
 		}
-		go r.deliver(t, delivered.EventID, body)
+		// Resolve the per-target trace context off the outer ctx /
+		// event.Meta (we resolve once per target rather than once
+		// outside the loop so each target's delivery span lifetime
+		// is independent). See SEP-414 P6 (issue 683).
+		tc := traceContextForDelivery(ctx, delivered)
+		go r.deliver(t, delivered.EventID, body, tc)
 	}
 }
 
@@ -994,7 +1033,12 @@ func classifyTransportError(err error) DeliveryErrorBucket {
 // eventID is the event's identifier; used as webhook-id (stable across
 // retries so the receiver's dedup works). Spec: SHOULD retry with
 // exponential backoff.
-func (r *WebhookRegistry) deliver(target WebhookTarget, eventID string, body []byte) {
+//
+// tc is the W3C trace context resolved at Deliver-time; when non-zero
+// the `traceparent` (and `tracestate` if present) HTTP headers are
+// stamped on every retry attempt so the receiver can stitch in.
+// SEP-414 P6 (issue 683).
+func (r *WebhookRegistry) deliver(target WebhookTarget, eventID string, body []byte, tc core.TraceContext) {
 	backoff := initialBackoff
 	// Tracks the last per-attempt failure bucket. Recorded onto
 	// deliveryStatus only after all retries are exhausted (i.e., this
@@ -1033,6 +1077,12 @@ func (r *WebhookRegistry) deliver(target WebhookTarget, eventID string, body []b
 			return // not retryable
 		}
 		signed.applyHeaders(req)
+		if !tc.IsZero() {
+			req.Header.Set(traceparentHTTPHeader, tc.Traceparent)
+			if tc.Tracestate != "" {
+				req.Header.Set(tracestateHTTPHeader, tc.Tracestate)
+			}
+		}
 
 		resp, err := r.client.Do(req)
 		if err != nil {

--- a/experimental/ext/events/yield.go
+++ b/experimental/ext/events/yield.go
@@ -204,8 +204,17 @@ func WithoutCursors() YieldingOption {
 //	    Server:   srv,
 //	})
 //
-//	go alertWatcher(func(a AlertData) { _ = yield(a) })
-func NewYieldingSource[Data any](def EventDef, opts ...YieldingOption) (*YieldingSource[Data], func(Data) error) {
+//	go alertWatcher(func(ctx context.Context, a AlertData) { _ = yield(ctx, a) })
+//
+// The returned yield closure takes a ctx so the W3C trace context
+// carried on it (`core.TraceContext`) is stamped onto `event.Meta`
+// at yield time. Cross-process consumers (webhook delivery,
+// HTTPSource inject) read the persistent traceparent from `Meta`;
+// in-process consumers (the emit hook, subscribers) get ctx
+// directly. Caller-set `event.Meta.traceparent` via `SetMetaFunc`
+// is preserved — the auto-stamp is a fallback. See SEP-414 P6
+// (issue 683).
+func NewYieldingSource[Data any](def EventDef, opts ...YieldingOption) (*YieldingSource[Data], func(context.Context, Data) error) {
 	cfg := &yieldingConfig{maxSize: defaultYieldingMaxSize, subscriberBuf: defaultSubscriberBufferSize}
 	for _, o := range opts {
 		o(cfg)
@@ -224,8 +233,8 @@ func NewYieldingSource[Data any](def EventDef, opts ...YieldingOption) (*Yieldin
 		cursorless:    cfg.cursorless,
 		subscriberBuf: cfg.subscriberBuf,
 	}
-	yield := func(data Data) error {
-		return s.yield(data)
+	yield := func(ctx context.Context, data Data) error {
+		return s.yield(ctx, data)
 	}
 	return s, yield
 }
@@ -234,8 +243,13 @@ func NewYieldingSource[Data any](def EventDef, opts ...YieldingOption) (*Yieldin
 // install a fanout hook (push + webhook). Register type-asserts this and
 // wires the hook. EventSources that don't implement it (e.g., TypedSource)
 // are responsible for their own fanout via Emit / EmitToWebhooks.
+//
+// The hook signature takes ctx so the W3C trace context carried by
+// the yield call flows through to the Emitter (and onward to the
+// outbound webhook delivery's HTTP `traceparent` header) without
+// going through an Event.Meta round-trip on every hop.
 type emitterAware interface {
-	SetEmitHook(func(Event))
+	SetEmitHook(func(context.Context, Event))
 }
 
 // yieldedEntry holds the typed payload alongside its wire-format Event.
@@ -262,8 +276,8 @@ type YieldingSource[Data any] struct {
 
 	mu          sync.RWMutex
 	entries     []yieldedEntry[Data]
-	emitHook    func(Event)
-	metaFunc    func(Data) map[string]any
+	emitHook    func(context.Context, Event)
+	metaFunc    func(context.Context, Data) map[string]any
 	subscribers []*subscriberSlot
 	terminated  bool // one-shot YieldTerminated has fired; subsequent yields are no-ops
 }
@@ -279,7 +293,7 @@ func (s *YieldingSource[Data]) Def() EventDef { return s.def }
 // Set on a separate method (not via NewYieldingSource opts) because
 // the mapper is type-parameterized over Data, which doesn't compose
 // cleanly with the option-function pattern.
-func (s *YieldingSource[Data]) SetMetaFunc(f func(Data) map[string]any) {
+func (s *YieldingSource[Data]) SetMetaFunc(f func(context.Context, Data) map[string]any) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.metaFunc = f
@@ -538,13 +552,13 @@ func (s *YieldingSource[Data]) Len() int {
 
 // SetEmitHook is called by Register to install the push + webhook fanout
 // hook. User code should not normally call this directly.
-func (s *YieldingSource[Data]) SetEmitHook(hook func(Event)) {
+func (s *YieldingSource[Data]) SetEmitHook(hook func(context.Context, Event)) {
 	s.mu.Lock()
 	s.emitHook = hook
 	s.mu.Unlock()
 }
 
-func (s *YieldingSource[Data]) yield(data Data) error {
+func (s *YieldingSource[Data]) yield(ctx context.Context, data Data) error {
 	// One-shot terminated check. Sources that have signaled terminal
 	// can't deliver new events to subscribers (chans are closed).
 	// Returning nil rather than error so callers wrapping yield in
@@ -577,8 +591,23 @@ func (s *YieldingSource[Data]) yield(data Data) error {
 
 	s.mu.Lock()
 	if s.metaFunc != nil {
-		if m := s.metaFunc(data); len(m) > 0 {
+		if m := s.metaFunc(ctx, data); len(m) > 0 {
 			event.Meta = m
+		}
+	}
+	// SEP-414 P6 (issue 683): stamp the ctx's W3C trace context onto
+	// event.Meta so cross-process consumers (webhook HTTP delivery,
+	// HTTPSource inject) can read it from the event itself without
+	// the hop-by-hop ctx chain. metaFunc-set traceparent wins —
+	// matches the caller-preserves semantic used by
+	// core.InjectTraceContextIntoParams (server outbound _meta) and
+	// the TS-side Apps Bridge relay (PR 702).
+	if tc := core.TraceContextFromContext(ctx); !tc.IsZero() {
+		if event.Meta == nil {
+			event.Meta = map[string]any{}
+		}
+		if _, has := event.Meta[core.MetaKeyTraceparent]; !has {
+			core.InjectTraceContext(event.Meta, tc)
 		}
 	}
 	if !s.cursorless {
@@ -608,7 +637,7 @@ func (s *YieldingSource[Data]) yield(data Data) error {
 	}
 
 	if hook != nil {
-		hook(event)
+		hook(ctx, event)
 	}
 	return nil
 }

--- a/experimental/ext/events/yield_test.go
+++ b/experimental/ext/events/yield_test.go
@@ -33,13 +33,13 @@ func TestYieldingSource_AutoDerivesPayloadSchema(t *testing.T) {
 	assert.NotNil(t, src.Def().PayloadSchema, "schema should be auto-derived from generic param")
 }
 
-// TestYieldingSource_YieldAppearsOnPoll verifies the round-trip: yield(data)
+// TestYieldingSource_YieldAppearsOnPoll verifies the round-trip: yield(context.Background(), data)
 // stores the event so a subsequent Poll surfaces it. Core spec contract:
 // push-style production with pull-style consumption.
 func TestYieldingSource_YieldAppearsOnPoll(t *testing.T) {
 	src, yield := NewYieldingSource[fakePayload](EventDef{Name: "fake"})
-	require.NoError(t, yield(fakePayload{Msg: "hello"}))
-	require.NoError(t, yield(fakePayload{Msg: "world"}))
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "hello"}))
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "world"}))
 
 	pr := src.Poll("", 10)
 	require.Len(t, pr.Events, 2)
@@ -58,11 +58,11 @@ func TestYieldingSource_YieldAppearsOnPoll(t *testing.T) {
 // semantics. Without this clients would receive duplicates on every poll.
 func TestYieldingSource_PollHonorsCursor(t *testing.T) {
 	src, yield := NewYieldingSource[fakePayload](EventDef{Name: "fake"})
-	require.NoError(t, yield(fakePayload{Msg: "a"}))
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "a"}))
 	c1 := src.Poll("", 10).Events[0].CursorStr()
 
-	require.NoError(t, yield(fakePayload{Msg: "b"}))
-	require.NoError(t, yield(fakePayload{Msg: "c"}))
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "b"}))
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "c"}))
 
 	pr := src.Poll(c1, 10)
 	require.Len(t, pr.Events, 2)
@@ -74,7 +74,7 @@ func TestYieldingSource_PollHonorsCursor(t *testing.T) {
 func TestYieldingSource_PollRespectsLimit(t *testing.T) {
 	src, yield := NewYieldingSource[fakePayload](EventDef{Name: "fake"})
 	for i := 0; i < 5; i++ {
-		require.NoError(t, yield(fakePayload{Msg: "x"}))
+		require.NoError(t, yield(context.Background(), fakePayload{Msg: "x"}))
 	}
 	pr := src.Poll("", 2)
 	assert.Len(t, pr.Events, 2)
@@ -86,12 +86,12 @@ func TestYieldingSource_PollRespectsLimit(t *testing.T) {
 // truncated signal — clients SHOULD treat it as a possible gap.
 func TestYieldingSource_EvictionAndTruncated(t *testing.T) {
 	src, yield := NewYieldingSource[fakePayload](EventDef{Name: "fake"}, WithMaxSize(3))
-	require.NoError(t, yield(fakePayload{Msg: "1"}))
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "1"}))
 	c1 := src.Poll("", 10).Events[0].CursorStr()
-	require.NoError(t, yield(fakePayload{Msg: "2"}))
-	require.NoError(t, yield(fakePayload{Msg: "3"}))
-	require.NoError(t, yield(fakePayload{Msg: "4"})) // evicts c1
-	require.NoError(t, yield(fakePayload{Msg: "5"})) // evicts second
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "2"}))
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "3"}))
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "4"})) // evicts c1
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "5"})) // evicts second
 
 	assert.Equal(t, 3, src.Len(), "buffer stays bounded at WithMaxSize")
 
@@ -106,7 +106,7 @@ func TestYieldingSource_EvictionAndTruncated(t *testing.T) {
 // re-polling the same tail.
 func TestYieldingSource_PollReportsLatestCursorWhenNoNewEvents(t *testing.T) {
 	src, yield := NewYieldingSource[fakePayload](EventDef{Name: "fake"})
-	require.NoError(t, yield(fakePayload{Msg: "a"}))
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "a"}))
 	first := src.Poll("", 10)
 	headCursor := first.Cursor
 
@@ -126,16 +126,16 @@ func TestYieldingSource_FanoutHookFiresOncePerYield(t *testing.T) {
 	var mu sync.Mutex
 	var seen []Event
 
-	src.SetEmitHook(func(e Event) {
+	src.SetEmitHook(func(ctx context.Context, e Event) {
 		atomic.AddInt32(&fired, 1)
 		mu.Lock()
 		seen = append(seen, e)
 		mu.Unlock()
 	})
 
-	require.NoError(t, yield(fakePayload{Msg: "one"}))
-	require.NoError(t, yield(fakePayload{Msg: "two"}))
-	require.NoError(t, yield(fakePayload{Msg: "three"}))
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "one"}))
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "two"}))
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "three"}))
 
 	assert.Equal(t, int32(3), atomic.LoadInt32(&fired))
 	mu.Lock()
@@ -149,7 +149,7 @@ func TestYieldingSource_FanoutHookFiresOncePerYield(t *testing.T) {
 // constructed before Register wires fanout. Events still land in the buffer.
 func TestYieldingSource_NoFanoutBeforeRegister(t *testing.T) {
 	src, yield := NewYieldingSource[fakePayload](EventDef{Name: "fake"})
-	require.NoError(t, yield(fakePayload{Msg: "early"}))
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "early"}))
 	pr := src.Poll("", 10)
 	assert.Len(t, pr.Events, 1)
 }
@@ -161,7 +161,7 @@ func TestYieldingSource_NoFanoutBeforeRegister(t *testing.T) {
 func TestYieldingSource_RecentReturnsTypedTail(t *testing.T) {
 	src, yield := NewYieldingSource[fakePayload](EventDef{Name: "fake"})
 	for _, msg := range []string{"a", "b", "c", "d", "e"} {
-		require.NoError(t, yield(fakePayload{Msg: msg}))
+		require.NoError(t, yield(context.Background(), fakePayload{Msg: msg}))
 	}
 
 	got := src.Recent(3)
@@ -175,7 +175,7 @@ func TestYieldingSource_RecentReturnsTypedTail(t *testing.T) {
 // the buffer holds returns everything available rather than panicking.
 func TestYieldingSource_RecentClampsToBufferSize(t *testing.T) {
 	src, yield := NewYieldingSource[fakePayload](EventDef{Name: "fake"})
-	require.NoError(t, yield(fakePayload{Msg: "only"}))
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "only"}))
 
 	got := src.Recent(50)
 	assert.Len(t, got, 1)
@@ -185,7 +185,7 @@ func TestYieldingSource_RecentClampsToBufferSize(t *testing.T) {
 // the entire buffer — guards against accidental "give me everything" calls.
 func TestYieldingSource_RecentEmptyOnZero(t *testing.T) {
 	src, yield := NewYieldingSource[fakePayload](EventDef{Name: "fake"})
-	require.NoError(t, yield(fakePayload{Msg: "x"}))
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "x"}))
 	assert.Nil(t, src.Recent(0))
 	assert.Nil(t, src.Recent(-1))
 }
@@ -195,8 +195,8 @@ func TestYieldingSource_RecentEmptyOnZero(t *testing.T) {
 // per-event URIs use this.
 func TestYieldingSource_ByCursorFindsTypedPayload(t *testing.T) {
 	src, yield := NewYieldingSource[fakePayload](EventDef{Name: "fake"})
-	require.NoError(t, yield(fakePayload{Msg: "first"}))
-	require.NoError(t, yield(fakePayload{Msg: "second"}))
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "first"}))
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "second"}))
 
 	first := src.Poll("", 10).Events[0]
 	got, ok := src.ByCursor(first.CursorStr())
@@ -208,7 +208,7 @@ func TestYieldingSource_ByCursorFindsTypedPayload(t *testing.T) {
 // returns (zero, false). Caller must check ok before using the value.
 func TestYieldingSource_ByCursorMissingReturnsZero(t *testing.T) {
 	src, yield := NewYieldingSource[fakePayload](EventDef{Name: "fake"})
-	require.NoError(t, yield(fakePayload{Msg: "x"}))
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "x"}))
 
 	got, ok := src.ByCursor("nonexistent-cursor")
 	assert.False(t, ok)
@@ -229,7 +229,7 @@ func TestYieldingSource_DefaultsMaxSize(t *testing.T) {
 	assert.Equal(t, defaultYieldingMaxSize, s3.maxSize, "WithMaxSize(-5) keeps default")
 }
 
-// TestYieldingSource_ConcurrentYields verifies concurrent yield() calls are
+// TestYieldingSource_ConcurrentYields verifies concurrent yield(context.Background()) calls are
 // safe and all events land in the buffer. Exercises the source under
 // contention.
 func TestYieldingSource_ConcurrentYields(t *testing.T) {
@@ -241,7 +241,7 @@ func TestYieldingSource_ConcurrentYields(t *testing.T) {
 	for i := 0; i < n; i++ {
 		go func() {
 			defer wg.Done()
-			_ = yield(fakePayload{Msg: "x"})
+			_ = yield(context.Background(), fakePayload{Msg: "x"})
 		}()
 	}
 	wg.Wait()
@@ -258,10 +258,10 @@ func TestYieldingSource_ConcurrentYields(t *testing.T) {
 // wire_shape_test.go).
 func TestYieldingSource_MetaFunc(t *testing.T) {
 	src, yield := NewYieldingSource[fakePayload](EventDef{Name: "fake"})
-	src.SetMetaFunc(func(d fakePayload) map[string]any {
+	src.SetMetaFunc(func(ctx context.Context, d fakePayload) map[string]any {
 		return map[string]any{"length": len(d.Msg)}
 	})
-	require.NoError(t, yield(fakePayload{Msg: "hello"}))
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "hello"}))
 
 	pr := src.Poll("", 10)
 	require.Len(t, pr.Events, 1)
@@ -275,8 +275,8 @@ func TestYieldingSource_MetaFunc(t *testing.T) {
 // event, defeating the bytes-on-wire-free common case.
 func TestYieldingSource_MetaFuncReturningNilOmits(t *testing.T) {
 	src, yield := NewYieldingSource[fakePayload](EventDef{Name: "fake"})
-	src.SetMetaFunc(func(d fakePayload) map[string]any { return nil })
-	require.NoError(t, yield(fakePayload{Msg: "x"}))
+	src.SetMetaFunc(func(ctx context.Context, d fakePayload) map[string]any { return nil })
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "x"}))
 
 	pr := src.Poll("", 10)
 	require.Len(t, pr.Events, 1)
@@ -304,8 +304,8 @@ func TestYieldingSource_SubscribeReceivesYieldedEvents(t *testing.T) {
 	ch, _ := src.Subscribe(ctx, SubscribeOpts{})
 	require.NotNil(t, ch, "Subscribe must return a non-nil channel")
 
-	require.NoError(t, yield(fakePayload{Msg: "alpha"}))
-	require.NoError(t, yield(fakePayload{Msg: "beta"}))
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "alpha"}))
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "beta"}))
 
 	first := readSubscriberEvent(t, ch, time.Second)
 	assert.False(t, first.Truncated)
@@ -334,7 +334,7 @@ func TestYieldingSource_MultipleSubscribersAllReceive(t *testing.T) {
 	subB, _ := src.Subscribe(ctx, SubscribeOpts{})
 	subC, _ := src.Subscribe(ctx, SubscribeOpts{})
 
-	require.NoError(t, yield(fakePayload{Msg: "x"}))
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "x"}))
 
 	for name, ch := range map[string]<-chan SubscriberEvent{"A": subA, "B": subB, "C": subC} {
 		ev := readSubscriberEvent(t, ch, time.Second)
@@ -361,7 +361,7 @@ func TestYieldingSource_SubscribeCleanupOnContextCancel(t *testing.T) {
 	}, time.Second, 10*time.Millisecond, "ctx cancel must release the subscriber slot")
 
 	// Yield after cancel must not panic on the closed chan.
-	require.NoError(t, yield(fakePayload{Msg: "post-cancel"}))
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "post-cancel"}))
 }
 
 // TestYieldingSource_SubscribeDropsOnSlowConsumer verifies the bounded
@@ -381,9 +381,9 @@ func TestYieldingSource_SubscribeDropsOnSlowConsumer(t *testing.T) {
 	ch, _ := src.Subscribe(ctx, SubscribeOpts{})
 
 	// Fill the buffer (cap=1) and then keep yielding without draining.
-	require.NoError(t, yield(fakePayload{Msg: "a"}))
-	require.NoError(t, yield(fakePayload{Msg: "b"})) // dropped — buffer full
-	require.NoError(t, yield(fakePayload{Msg: "c"})) // dropped
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "a"}))
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "b"})) // dropped — buffer full
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "c"})) // dropped
 
 	// Drain the queued event — was buffered before any drop.
 	first := readSubscriberEvent(t, ch, time.Second)
@@ -394,14 +394,14 @@ func TestYieldingSource_SubscribeDropsOnSlowConsumer(t *testing.T) {
 
 	// Recovery yield: the dropped events surface as Truncated=true on
 	// this next event.
-	require.NoError(t, yield(fakePayload{Msg: "d"}))
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "d"}))
 	recovered := readSubscriberEvent(t, ch, time.Second)
 	assert.True(t, recovered.Truncated, "next event after a drop must carry Truncated=true")
 	require.NoError(t, json.Unmarshal(recovered.Event.Data, &d))
 	assert.Equal(t, "d", d.Msg, "the carrying event is the recovery yield, not a re-emission")
 
 	// And the flag clears after one successful flagged delivery.
-	require.NoError(t, yield(fakePayload{Msg: "e"}))
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "e"}))
 	clear := readSubscriberEvent(t, ch, time.Second)
 	assert.False(t, clear.Truncated, "Truncated flag must clear after one delivery")
 }
@@ -505,7 +505,7 @@ func TestYieldingSource_YieldsAfterTerminatedAreNoOp(t *testing.T) {
 	// events flow. We can't observe "no event flowed" via the closed
 	// chan, but we CAN verify the calls don't panic and don't return
 	// errors.
-	assert.NoError(t, yield(fakePayload{Msg: "ghost"}))
+	assert.NoError(t, yield(context.Background(), fakePayload{Msg: "ghost"}))
 	assert.NoError(t, src.YieldError(EventDeliveryError{Code: 0, Message: "ghost-err"}))
 	assert.NoError(t, src.YieldTerminated(EventDeliveryError{Code: 0, Message: "ghost-term"}))
 


### PR DESCRIPTION
## What changes

Closes issue 683. Adds bidirectional W3C Trace Context propagation across every gate in the event lifecycle so a yield on replica A and a downstream webhook delivery (or a poll-side replay on replica B) appear in Tempo as one stitched trace. Sister to PR 702's Apps Bridge relay — same "non-MCP propagation hop" pattern across a different boundary topology. Production-ish-ready for Peter's events demo.

```mermaid
sequenceDiagram
    participant A as Replica A
    participant H as Webhook receiver
    participant B as Replica B HTTPSource

    Note over A: yield(ctx, data)
    Note over A: event.Meta.traceparent stamped from ctx
    Note over A: emit hook fires with same ctx
    A->>H: POST with traceparent HTTP header
    A->>B: POST /inject with traceparent HTTP header
    Note over B: handler reads header, builds ctx
    Note over B: s.yield(ctx, data) stamps Meta again
    Note over B: downstream subscribers continue the chain
    Note over A,B: Single TraceID stitches everything in Tempo
```

## Reviewer's guide

Read in this order:

1. [experimental/ext/events/yield.go](https://github.com/panyam/mcpkit/pull/712/files#diff-1a35574e62fe51d6eb94df43ccdbf8519abbc134033627d9020fe30dbec06cf3) — Gate 1+2. New `yield(ctx, data)` closure signature; `YieldingSource.yield` stamps `event.Meta.traceparent` from ctx with the caller-preserves check (metaFunc-set traceparent wins, fallback otherwise — uniform with `core.InjectTraceContextIntoParams`). `SetEmitHook` and `SetMetaFunc` now ctx-aware. `emitterAware` interface widens.
2. [experimental/ext/events/events.go](https://github.com/panyam/mcpkit/pull/712/files#diff-4a2a8cf5f00e8770df09ab463340a5fc393acbf3f95ef59af8280e2a7a814815) — Gate 2. `Register`'s emit hook now `func(ctx context.Context, event Event) { emitter.Emit(ctx, event) }` — no Meta reconstruction. Package-level `Emit(ctx, srv, event)` + `EmitToWebhooks(ctx, wh, event)` helpers also threaded.
3. [experimental/ext/events/webhook.go](https://github.com/panyam/mcpkit/pull/712/files#diff-f61c2bd42ae83936aba2fe7dab3bcda1606ca810bd7263d9afbe42147f9c8f5a) — Gate 3. New `traceContextForDelivery(ctx, event)` helper documents the precedence (ctx → event.Meta). `Deliver(ctx, event)` + `DeliverToTarget(ctx, key, event)` thread through to the internal `deliver(target, id, body, tc)` which stamps the `traceparent` + optional `tracestate` HTTP headers on every retry. New `traceparentHTTPHeader` / `tracestateHTTPHeader` constants.
4. [experimental/ext/events/http_source.go](https://github.com/panyam/mcpkit/pull/712/files#diff-8455eeb60c4be97fa23a9c054080a89d248b081b87d6a406022a0f58bcdbed9e) — Gate 4. `serveInject` reads the inbound `traceparent` / `tracestate` HTTP headers, builds `core.TraceContext`, attaches via `core.WithTraceContext(r.Context(), tc)`, calls `s.yield(ctx, data)`. `HTTPSource.Yield(ctx, data)` public method now ctx-aware too.
5. [experimental/ext/events/emitter.go](https://github.com/panyam/mcpkit/pull/712/files#diff-16bddc124cd18d766b95899f99b33b5051f089d48bf0e52aad52841078932b95) — `localEmitter.Emit` threads ctx through to both delivery legs (Server.Broadcast accepts ctx for symmetry but doesn't use it yet — Broadcast ctx-propagation is a separate ticket).
6. [experimental/ext/events/trace_propagation_test.go](https://github.com/panyam/mcpkit/pull/712/files#diff-8569c4d2d9d3a632e747497d63a7eea17471d05b884f06b50715524037d6ecbf) — 9 new tests covering all 4 gates + the caller-preserves semantic + tracestate alongside traceparent + the event.Meta fallback when ctx has no trace.
7. [experimental/ext/events/README.md](https://github.com/panyam/mcpkit/pull/712/files#diff-9222f2c9c82e15be71e1b286719f2d44d107c3ea315805c64c3d617ab960d4b3) — new "Tracing across the events bus (SEP-414 P6, issue 683)" section: 4-gate / 3-carrier model, caller-preserves rule, end-to-end multi-replica trace shape diagram.

Skim or skip: the 12 test-file signature sweeps (`yield_test.go`, `cursorless_test.go`, `body_cap_test.go`, etc.). All mechanical — `webhooks.Deliver(event)` → `webhooks.Deliver(ctx, event)`, `r.deliver(t, id, body)` → `r.deliver(t, id, body, core.TraceContext{})`, etc. Done via a paren-counting Python rewriter to handle nested calls correctly; all 75s of existing tests still pass.

## Diff groups

- **Production**: yield.go, events.go, webhook.go, http_source.go, emitter.go
- **Tests (new)**: trace_propagation_test.go
- **Tests (signature sweep, mechanical)**: 12 existing `*_test.go` files
- **Docs**: README.md

## Decision log

| Decision | Choice | Alternative | Why |
|---|---|---|---|
| Break compat on yield/hook signatures | Yes (per user direction) | Add sibling ctx-aware variants (`YieldCtx`, `SetEmitHookCtx`) | User explicitly OK'd breaking — single clean signature beats parallel sibling methods that drift apart. The events module is experimental anyway. |
| Three carriers (ctx + Meta + HTTP header) | Yes | Single canonical carrier | Each gate has a different boundary: ctx dies at goroutine exit, Meta survives JSON, HTTP header survives the wire. One isn't enough for all four gates. |
| Stamp event.Meta from ctx at yield time | Yes | Only carry via ctx within process | event.Meta is the persistent carrier — survives poll-replay, persistence, store-and-forward. Without it, a polled event has no trace ID. |
| Caller-preserves on Meta stamp | Yes (metaFunc wins) | Auto-injection always wins | Uniform with `core.InjectTraceContextIntoParams` (server outbound `_meta`) and Apps Bridge TS relay (PR 702). One semantic across all four trace-context carriers in mcpkit. |
| `traceContextForDelivery(ctx, event)` precedence: ctx → Meta | ctx wins when set | Always read from Meta | ctx is fresher (runtime-current). Meta is the persistent fallback for callers who pre-stamped (or for replayed events). |
| Server.Broadcast doesn't actually consume ctx today | Accepted ctx as no-op for now | Plumb ctx through Broadcast in this PR | Broadcast's ctx propagation is its own concern (SSE push side); making this PR responsible for it bloats scope. Param accepted now so future Broadcast(ctx) plumbing slots in without churn. |
| `tracestate` propagation alongside `traceparent` | Yes | Just `traceparent` | Vendor-specific routing/sampling lives in tracestate; dropping it silently breaks adopters that use Datadog / Honeycomb / Lightstep extensions. Cost is one extra header. |
| Python paren-counting rewriter for test sweeps | Yes | Hand-edit ~20 test files | First attempt with naive regex corrupted a file via nested-paren matching. Proper paren counting handles `r.deliver(r.Targets()[0], ...)` cleanly. Mechanical sweep, no semantic changes. |

## Risk / blast radius

- **Module-scoped breakage.** Every change is inside `experimental/ext/events` (separate go.mod). Root `make test` unaffected; the module's own 75s suite all green.
- **18 in-module call sites swept.** All mechanical signature additions of `ctx` / `tc`; no behavior change in any swept test.
- **Other modules consuming events**: `experimental/ext/events/clients/go` (the events client SDK) and `experimental/ext/events/stores/gorm` are separate sub-modules; their go.mods don't directly import `events.WebhookRegistry.Deliver` and friends (they go through interfaces). Verified: clean. Adopter modules (`examples/events/discord`, `examples/events/whole-enchilada/event-server`) consume `yield` closures and `webhooks.Deliver` — they'll need to thread ctx through; the breakage is what surfaces the call sites that should have been ctx-aware all along. (Not swept in this PR — adopter sweeps are filed as separate adoption PRs.)
- **HTTP header injection**: the implementation uses `req.Header.Set` after `signed.applyHeaders` — no signature/replay drift because the signature is computed over the body, not headers. Trace headers fall in the same bucket as the existing `User-Agent` header which is also set per-request.

## Test plan

Added: 9 tests in `trace_propagation_test.go`. Removed/weakened: 0.

| Gate | Tests |
|---|---|
| Gate 1+2 | `TestYieldCtx_StampsMetaAndFlowsToHook`, `TestYieldCtx_NoTraceContext_NoStamp`, `TestYieldCtx_MetaFuncSetTraceparent_NotClobbered`, `TestYieldCtx_TracestateAlongsideTraceparent` |
| Gate 3 | `TestWebhookDeliver_InjectsTraceparentHeader`, `TestWebhookDeliver_NoTraceContext_NoHeader`, `TestWebhookDeliver_FallsBackToEventMeta` |
| Gate 4 | `TestHTTPSourceInject_ExtractsTraceparentFromHTTPHeader`, `TestHTTPSourceInject_NoTraceparent_NoStamp` |

Verification:
- `cd experimental/ext/events && go test ./... -count=1 -timeout 180s`: clean (75.6s — webhook retry-and-fail tests dominate the time).
- `make test` at root: clean.
- Smoke against Peter's demo target deferred to manual (same pattern PR 702 followed for Luca's demo).

## Out of scope (deliberately deferred)

- **`Server.Broadcast` ctx propagation** — SSE push side; separate concern. Client subscribers go through SEP-414 P3 already.
- **Span around webhook HTTP delivery** — requires `WebhookRegistry.WithTracerProvider`; narrower follow-up. The HTTP header propagation lands without it.
- **Cross-replica peer-fanout Emitter** (Redis pubsub, peer HTTP) — issue 634 / 639 territory. This PR makes their work easier — they consume `Emitter.Emit(ctx, event)` and inherit the propagation for free.
- **whole-enchilada multi-replica adoption demo** — separate adoption PR if Peter's demo surfaces the need. The relay is wired; demoing it end-to-end is its own narrative.
- **`examples/events/discord` + `examples/events/telegram` + adopter sweep** — these consume the new `yield(ctx, ...)` signature and will need ctx threaded at their call sites. Filed as adopter follow-ups; can be batched after this lands.
- **Upstream events-spec note** on the `_meta.traceparent` carrier convention — described in this PR; raise upstream only if working-group interest surfaces after Peter's demo.
