### PR TITLE
events: Broadcast(ctx) + WebhookRegistry.WithTracerProvider + adopter sweep (PR 712 follow-up)

### DIFF
--- a/examples/events/discord/events.go
+++ b/examples/events/discord/events.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+
 	"github.com/panyam/mcpkit/experimental/ext/events"
 )
 
@@ -14,14 +16,14 @@ import (
 // mention_count are app-defined classifications that don't fit
 // `data` — exactly what `_meta` is for. Receivers see them under the
 // spec-canonical `_meta` key.
-func newDiscordSource() (*events.YieldingSource[DiscordEventData], func(DiscordEventData) error) {
+func newDiscordSource() (*events.YieldingSource[DiscordEventData], func(context.Context, DiscordEventData) error) {
 	src, yield := events.NewYieldingSource[DiscordEventData](events.EventDef{
 		Name:        "discord.message",
 		Description: "Fires when a message is sent in a Discord channel the bot can see",
 		Delivery:    []string{"push", "poll", "webhook"},
 		Meta:        map[string]any{"category": "messaging"},
 	}, events.WithMaxSize(1000))
-	src.SetMetaFunc(func(d DiscordEventData) map[string]any {
+	src.SetMetaFunc(func(_ context.Context, d DiscordEventData) map[string]any {
 		channelType := "guild"
 		if d.GuildID == "" {
 			channelType = "dm"
@@ -39,7 +41,7 @@ func newDiscordSource() (*events.YieldingSource[DiscordEventData], func(DiscordE
 // buffering and events emit with `cursor: null` on the wire. Push and webhook
 // delivery still work; poll always returns empty (subscribers can't replay
 // missed indicators, which matches the semantics of the underlying state).
-func newDiscordTypingSource() (*events.YieldingSource[DiscordTypingData], func(DiscordTypingData) error) {
+func newDiscordTypingSource() (*events.YieldingSource[DiscordTypingData], func(context.Context, DiscordTypingData) error) {
 	return events.NewYieldingSource[DiscordTypingData](events.EventDef{
 		Name:        "discord.typing",
 		Description: "Fires when a user starts typing in a Discord channel",

--- a/examples/events/discord/main.go
+++ b/examples/events/discord/main.go
@@ -11,6 +11,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -104,7 +105,7 @@ func serve() {
 			if m.Author.ID == s.State.User.ID {
 				return // ignore own messages
 			}
-			_ = yield(newDiscordEvent(m.GuildID, m.ChannelID, m.Author.Username, m.Content, time.Now()))
+			_ = yield(context.Background(), newDiscordEvent(m.GuildID, m.ChannelID, m.Author.Username, m.Content, time.Now()))
 			// The yield above already broadcasts push + webhook via the
 			// library's fanout hook. The resource notification stays explicit
 			// because the events library doesn't know about MCP resources.
@@ -125,7 +126,7 @@ func serve() {
 					username = member.User.Username
 				}
 			}
-			_ = yieldTyping(newDiscordTypingEvent(ts.GuildID, ts.ChannelID, username, time.Unix(int64(ts.Timestamp), 0)))
+			_ = yieldTyping(context.Background(), newDiscordTypingEvent(ts.GuildID, ts.ChannelID, username, time.Unix(int64(ts.Timestamp), 0)))
 		})
 
 		dg.Identify.Intents = discordgo.IntentsGuildMessages |
@@ -236,7 +237,7 @@ func serve() {
 			if msg.Sender == "" {
 				msg.Sender = "injected"
 			}
-			_ = yield(newDiscordEvent(msg.GuildID, msg.ChannelID, msg.Sender, msg.Text, time.Now()))
+			_ = yield(r.Context(), newDiscordEvent(msg.GuildID, msg.ChannelID, msg.Sender, msg.Text, time.Now()))
 			srv.NotifyResourceUpdated("discord://messages/recent")
 
 		case "discord.typing":
@@ -252,7 +253,7 @@ func serve() {
 			if msg.User == "" {
 				msg.User = "injected-typing"
 			}
-			_ = yieldTyping(newDiscordTypingEvent(msg.GuildID, msg.ChannelID, msg.User, time.Now()))
+			_ = yieldTyping(r.Context(), newDiscordTypingEvent(msg.GuildID, msg.ChannelID, msg.User, time.Now()))
 
 		default:
 			http.Error(w, fmt.Sprintf("unknown event %q (want discord.message or discord.typing)", eventName), http.StatusBadRequest)

--- a/examples/events/telegram/events.go
+++ b/examples/events/telegram/events.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+
 	"github.com/panyam/mcpkit/experimental/ext/events"
 )
 
@@ -8,7 +10,7 @@ import (
 // events. The library owns the in-memory ring buffer; the resource handlers
 // read typed payloads back via source.Recent / source.ByCursor — single
 // source of truth, no duplication, no resource-side unmarshaling.
-func newTelegramSource() (*events.YieldingSource[TelegramEventData], func(TelegramEventData) error) {
+func newTelegramSource() (*events.YieldingSource[TelegramEventData], func(context.Context, TelegramEventData) error) {
 	return events.NewYieldingSource[TelegramEventData](events.EventDef{
 		Name:        "telegram.message",
 		Description: "Fires when a message is received by the Telegram bot",
@@ -20,7 +22,7 @@ func newTelegramSource() (*events.YieldingSource[TelegramEventData], func(Telegr
 // telegram.typing events. Typing indicators are ephemeral — the source skips
 // buffering and events emit with `cursor: null` on the wire. Push and webhook
 // delivery still work; poll always returns empty.
-func newTelegramTypingSource() (*events.YieldingSource[TelegramTypingData], func(TelegramTypingData) error) {
+func newTelegramTypingSource() (*events.YieldingSource[TelegramTypingData], func(context.Context, TelegramTypingData) error) {
 	return events.NewYieldingSource[TelegramTypingData](events.EventDef{
 		Name:        "telegram.typing",
 		Description: "Fires when a user starts typing in a Telegram chat",

--- a/examples/events/telegram/main.go
+++ b/examples/events/telegram/main.go
@@ -11,6 +11,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -154,7 +155,7 @@ func serve() {
 						msg.Sender = "injected"
 					}
 					now := time.Now()
-					_ = yield(TelegramEventData{
+					_ = yield(r.Context(), TelegramEventData{
 						ChatID:    strconv.FormatInt(msg.ChatID, 10),
 						User:      msg.Sender,
 						Text:      msg.Text,
@@ -175,7 +176,7 @@ func serve() {
 					if msg.User == "" {
 						msg.User = "injected-typing"
 					}
-					_ = yieldTyping(newTelegramTypingEvent(msg.ChatID, msg.User, time.Now()))
+					_ = yieldTyping(r.Context(), newTelegramTypingEvent(msg.ChatID, msg.User, time.Now()))
 
 				default:
 					http.Error(w, fmt.Sprintf("unknown event %q (want telegram.message or telegram.typing)", eventName), http.StatusBadRequest)
@@ -199,7 +200,7 @@ func serve() {
 
 // startTelegramPolling uses long-polling to receive updates from Telegram and
 // yields each text message as a TelegramEventData event.
-func startTelegramPolling(bot *tgbotapi.BotAPI, yield func(TelegramEventData) error) {
+func startTelegramPolling(bot *tgbotapi.BotAPI, yield func(context.Context, TelegramEventData) error) {
 	u := tgbotapi.NewUpdate(0)
 	u.Timeout = 60
 
@@ -211,7 +212,7 @@ func startTelegramPolling(bot *tgbotapi.BotAPI, yield func(TelegramEventData) er
 			continue
 		}
 		ev := makeTelegramEvent(update.Message)
-		if err := yield(ev); err != nil {
+		if err := yield(context.Background(), ev); err != nil {
 			log.Printf("[telegram] yield failed: %v", err)
 			continue
 		}

--- a/examples/events/telegram/telegram.go
+++ b/examples/events/telegram/telegram.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 	"net/http"
@@ -69,7 +70,7 @@ func newTelegramTypingEvent(chatID int64, user string, ts time.Time) TelegramTyp
 
 // handleTelegramWebhook processes a Telegram Bot API webhook POST and yields
 // the resulting event. Returns true if an event was published.
-func handleTelegramWebhook(yield func(TelegramEventData) error, r *http.Request) bool {
+func handleTelegramWebhook(yield func(context.Context, TelegramEventData) error, r *http.Request) bool {
 	var update tgbotapi.Update
 	if err := json.NewDecoder(r.Body).Decode(&update); err != nil {
 		log.Printf("[telegram] failed to decode webhook: %v", err)
@@ -78,7 +79,7 @@ func handleTelegramWebhook(yield func(TelegramEventData) error, r *http.Request)
 	if update.Message == nil || update.Message.Text == "" {
 		return false
 	}
-	if err := yield(makeTelegramEvent(update.Message)); err != nil {
+	if err := yield(r.Context(), makeTelegramEvent(update.Message)); err != nil {
 		log.Printf("[telegram] yield failed: %v", err)
 		return false
 	}

--- a/examples/events/whole-enchilada/event-server/main.go
+++ b/examples/events/whole-enchilada/event-server/main.go
@@ -91,6 +91,11 @@ func main() {
 		// resolves to private IPs); production-default SSRF guard would
 		// reject. Production stages will wire a real allowlist.
 		events.WithWebhookAllowPrivateNetworks(true),
+		// SEP-414 P6 follow-up: emit events.webhook.deliver spans
+		// around each outbound POST so Peter's demo shows the full
+		// chain (client tools/call → server dispatch → webhook
+		// delivery) as one row in Tempo.
+		events.WithWebhookTracerProvider(tp),
 	)
 
 	srvOpts := []server.Option{

--- a/experimental/ext/events/delivery_status_test.go
+++ b/experimental/ext/events/delivery_status_test.go
@@ -211,7 +211,7 @@ func TestSuspend_AfterThresholdConsecutiveFailures(t *testing.T) {
 	// Drive `threshold` consecutive failed deliveries (each deliver()
 	// internally retries; we count whole-call outcomes, not retries).
 	for i := 0; i < threshold; i++ {
-		r.deliver(r.Targets()[0], "evt_"+string(rune('a'+i)), []byte(`{}`), core.TraceContext{})
+		r.deliver(r.Targets()[0], "evt_"+string(rune('a'+i)), "", []byte(`{}`), core.TraceContext{})
 	}
 
 	st := r.DeliveryStatus(canonical)
@@ -245,13 +245,13 @@ func TestSuspend_FailuresOutsideWindowDontAccumulate(t *testing.T) {
 	// 2 failures, then sleep past the window, then 2 more.
 	// First-failure-time should reset on the post-sleep failures, so
 	// total counted-toward-current-run = 2 < threshold = 3 → still Active.
-	r.deliver(r.Targets()[0], "evt_1", []byte(`{}`), core.TraceContext{})
-	r.deliver(r.Targets()[0], "evt_2", []byte(`{}`), core.TraceContext{})
+	r.deliver(r.Targets()[0], "evt_1", "", []byte(`{}`), core.TraceContext{})
+	r.deliver(r.Targets()[0], "evt_2", "", []byte(`{}`), core.TraceContext{})
 
 	time.Sleep(300 * time.Millisecond) // > 200ms window
 
-	r.deliver(r.Targets()[0], "evt_3", []byte(`{}`), core.TraceContext{})
-	r.deliver(r.Targets()[0], "evt_4", []byte(`{}`), core.TraceContext{})
+	r.deliver(r.Targets()[0], "evt_3", "", []byte(`{}`), core.TraceContext{})
+	r.deliver(r.Targets()[0], "evt_4", "", []byte(`{}`), core.TraceContext{})
 
 	st := r.DeliveryStatus(canonical)
 	assert.True(t, st.Active,
@@ -281,8 +281,8 @@ func TestSuspend_SuccessfulRefreshReactivates(t *testing.T) {
 	r.Register(RegisterParams{CanonicalKey: canonical, DerivedID: "sub_react", URL: receiver.URL, Secret: "whsec_secret", MaxAgeSeconds: 0})
 
 	// Drive 2 consecutive failures → suspended.
-	r.deliver(r.Targets()[0], "evt_a", []byte(`{}`), core.TraceContext{})
-	r.deliver(r.Targets()[0], "evt_b", []byte(`{}`), core.TraceContext{})
+	r.deliver(r.Targets()[0], "evt_a", "", []byte(`{}`), core.TraceContext{})
+	r.deliver(r.Targets()[0], "evt_b", "", []byte(`{}`), core.TraceContext{})
 	require.False(t, r.DeliveryStatus(canonical).Active, "precondition: target should be suspended")
 
 	// Refresh — same canonical tuple, idempotent re-Register.
@@ -333,8 +333,8 @@ func TestSuspend_SuspendedTargetSkippedInDeliver(t *testing.T) {
 	r.Register(RegisterParams{CanonicalKey: canonical, DerivedID: "sub_skip", URL: receiver.URL, Secret: "whsec_secret", MaxAgeSeconds: 0})
 
 	// Drive 2 failures → suspended.
-	r.deliver(r.Targets()[0], "evt_a", []byte(`{}`), core.TraceContext{})
-	r.deliver(r.Targets()[0], "evt_b", []byte(`{}`), core.TraceContext{})
+	r.deliver(r.Targets()[0], "evt_a", "", []byte(`{}`), core.TraceContext{})
+	r.deliver(r.Targets()[0], "evt_b", "", []byte(`{}`), core.TraceContext{})
 	require.False(t, r.DeliveryStatus(canonical).Active)
 
 	// Note hits up to here so we measure only what happens AFTER suspension.
@@ -391,8 +391,8 @@ func TestSuspend_AutoPostsTerminatedEnvelopeOnSuspension(t *testing.T) {
 	r.Register(RegisterParams{CanonicalKey: canonical, DerivedID: "sub_at", URL: receiver.URL, Secret: "whsec_secret", MaxAgeSeconds: 0})
 
 	// Drive 2 failures → suspend transition fires.
-	r.deliver(r.Targets()[0], "evt_a", []byte(`{}`), core.TraceContext{})
-	r.deliver(r.Targets()[0], "evt_b", []byte(`{}`), core.TraceContext{})
+	r.deliver(r.Targets()[0], "evt_a", "", []byte(`{}`), core.TraceContext{})
+	r.deliver(r.Targets()[0], "evt_b", "", []byte(`{}`), core.TraceContext{})
 
 	require.Eventually(t, func() bool {
 		return sawTerminated.Load() == 1
@@ -437,8 +437,8 @@ func TestSuspend_DoesNotAutoPostTerminatedTwice(t *testing.T) {
 	r.Register(RegisterParams{CanonicalKey: canonical, DerivedID: "sub_idem", URL: receiver.URL, Secret: "whsec_secret", MaxAgeSeconds: 0})
 
 	// Suspend.
-	r.deliver(r.Targets()[0], "evt_a", []byte(`{}`), core.TraceContext{})
-	r.deliver(r.Targets()[0], "evt_b", []byte(`{}`), core.TraceContext{})
+	r.deliver(r.Targets()[0], "evt_a", "", []byte(`{}`), core.TraceContext{})
+	r.deliver(r.Targets()[0], "evt_b", "", []byte(`{}`), core.TraceContext{})
 	require.Eventually(t, func() bool { return sawTerminated.Load() == 1 },
 		2*time.Second, 20*time.Millisecond)
 
@@ -455,7 +455,7 @@ func TestSuspend_DoesNotAutoPostTerminatedTwice(t *testing.T) {
 	// lookupTarget's internal RLock.
 	target, ok := r.lookupTarget(canonical)
 	require.True(t, ok)
-	r.deliver(target, "evt_c", []byte(`{}`), core.TraceContext{})
+	r.deliver(target, "evt_c", "", []byte(`{}`), core.TraceContext{})
 
 	// Wait long enough that any auto-Post would have happened.
 	time.Sleep(500 * time.Millisecond)

--- a/experimental/ext/events/events.go
+++ b/experimental/ext/events/events.go
@@ -427,13 +427,13 @@ func Register(cfg Config) {
 // Emit broadcasts an event to all connected SSE clients via Server.Broadcast.
 // This is the push delivery path.
 //
-// ctx threads through for SEP-414 trace propagation. Server.Broadcast
-// doesn't take ctx today (the SSE push path is its own concern); the
-// param is accepted for signature symmetry with EmitToWebhooks and so
-// future Broadcast(ctx, ...) plumbing slots in without churning every
-// caller.
-func Emit(_ context.Context, srv *server.Server, event Event) {
-	srv.Broadcast("notifications/events/event", event)
+// ctx threads through to Server.Broadcast for SEP-414 trace
+// propagation. The notification payload itself is the Event envelope;
+// session-side outbound _meta.traceparent injection happens via the
+// existing SEP-414 P2 NotifyInterceptor wraps the server installs
+// when WithTracerProvider is configured.
+func Emit(ctx context.Context, srv *server.Server, event Event) {
+	srv.Broadcast(ctx, "notifications/events/event", event)
 }
 
 // EmitToWebhooks delivers an event to all registered webhooks. ctx is

--- a/experimental/ext/events/lifecycle_test.go
+++ b/experimental/ext/events/lifecycle_test.go
@@ -363,7 +363,7 @@ func TestLifecycle_Webhook_SuspendDoesNotFireOnUnsubscribe(t *testing.T) {
 	// deletion → onRemove must not fire.
 	target := f.webhooks.Targets()[0]
 	for i := 0; i < threshold; i++ {
-		f.webhooks.deliver(target, "evt_"+string(rune('a'+i)), []byte(`{}`), core.TraceContext{})
+		f.webhooks.deliver(target, "evt_"+string(rune('a'+i)), "", []byte(`{}`), core.TraceContext{})
 	}
 
 	st := f.webhooks.DeliveryStatus(target.CanonicalKey)

--- a/experimental/ext/events/webhook.go
+++ b/experimental/ext/events/webhook.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -224,6 +225,28 @@ func WithWebhookAllowPrivateNetworks(allow bool) WebhookOption {
 	}
 }
 
+// WithWebhookTracerProvider opts the registry into SEP-414
+// instrumentation of the outbound HTTP delivery path. When set,
+// every retry-loop attempt is wrapped in an `events.webhook.deliver`
+// span (parent: the trace context resolved from ctx or event.Meta
+// at Deliver time) with attributes:
+//
+//	webhook.target.id           — derived id (X-MCP-Subscription-Id)
+//	webhook.url                 — receiver URL
+//	mcp.event.name              — event type the delivery is for
+//	http.method                 — always "POST"
+//	http.response.status_code   — last attempt's status (success or last failure)
+//	webhook.retry.attempts      — number of attempts made
+//
+// On final retry-exhausted, RecordError fires with the categorical
+// failure bucket. Nil or core.NoopTracerProvider{} (the default)
+// skips the wrap — zero overhead unconfigured. SEP-414 P6.
+func WithWebhookTracerProvider(tp core.TracerProvider) WebhookOption {
+	return func(r *WebhookRegistry) {
+		r.tp = tp
+	}
+}
+
 // WebhookTarget is a registered outbound webhook callback with TTL-based expiry.
 //
 // The CanonicalKey is the spec's identity tuple bytes
@@ -366,6 +389,15 @@ type WebhookRegistry struct {
 	// Set under mu, read under mu.RLock.
 	defResolver func(eventName string) EventDef
 
+	// tp opts the deliver goroutine into emitting an
+	// `events.webhook.deliver` span around each outbound HTTP POST
+	// (the full retry loop is one span; per-attempt counts land on
+	// span attributes). Configured via WithWebhookTracerProvider.
+	// Defaults to core.NoopTracerProvider{} after the constructor
+	// so call sites can unconditionally StartSpan without nil-
+	// checking. SEP-414 P6 (issue 683 follow-up).
+	tp core.TracerProvider
+
 	// logf is the logging hook used by deliver paths. Defaults to log.Printf;
 	// tests override via setLogfForTest to capture failures (including SSRF
 	// dial-time rejections) for assertions.
@@ -449,6 +481,11 @@ func (r *WebhookRegistry) fireOnRemove(t WebhookTarget) {
 	}
 }
 
+// noopTP is the package's canonical Noop TracerProvider used when
+// WithWebhookTracerProvider is not supplied. Stored as a package
+// var rather than allocated on each NewWebhookRegistry call.
+var noopTP core.TracerProvider = core.NoopTracerProvider{}
+
 // NewWebhookRegistry creates an empty registry with the documented defaults:
 // 5-second HTTP timeout, DefaultWebhookTTL (1h) TTL inside the
 // [MinWebhookTTL, MaxWebhookTTL] envelope, StandardWebhooks signing,
@@ -471,6 +508,9 @@ func NewWebhookRegistry(opts ...WebhookOption) *WebhookRegistry {
 	}
 	for _, o := range opts {
 		o(r)
+	}
+	if r.tp == nil {
+		r.tp = noopTP
 	}
 	r.applyTTLClamp()
 	// http.Client wired AFTER options apply so the Dialer.Control callback
@@ -816,7 +856,7 @@ func (r *WebhookRegistry) DeliverToTarget(ctx context.Context, canonicalKey []by
 		return false
 	}
 	tc := traceContextForDelivery(ctx, event)
-	go r.deliver(target, event.EventID, body, tc)
+	go r.deliver(target, event.EventID, event.Name, body, tc)
 	return true
 }
 
@@ -921,7 +961,7 @@ func (r *WebhookRegistry) Deliver(ctx context.Context, event Event) {
 		// outside the loop so each target's delivery span lifetime
 		// is independent). See SEP-414 P6 (issue 683).
 		tc := traceContextForDelivery(ctx, delivered)
-		go r.deliver(t, delivered.EventID, body, tc)
+		go r.deliver(t, delivered.EventID, delivered.Name, body, tc)
 	}
 }
 
@@ -1064,7 +1104,36 @@ func classifyTransportError(err error) DeliveryErrorBucket {
 // the `traceparent` (and `tracestate` if present) HTTP headers are
 // stamped on every retry attempt so the receiver can stitch in.
 // SEP-414 P6 (issue 683).
-func (r *WebhookRegistry) deliver(target WebhookTarget, eventID string, body []byte, tc core.TraceContext) {
+//
+// eventName is included as the `mcp.event.name` attribute on the
+// emitted span when WithWebhookTracerProvider is configured.
+func (r *WebhookRegistry) deliver(target WebhookTarget, eventID, eventName string, body []byte, tc core.TraceContext) {
+	// SEP-414 P6 follow-up: span around the entire retry loop with
+	// per-attempt counts on the span attributes. Parent comes from
+	// the resolved tc (replica A's yield ctx ⇒ event.Meta ⇒ tc).
+	// Noop default = zero overhead unconfigured.
+	spanCtx := context.Background()
+	if !tc.IsZero() {
+		spanCtx = core.WithTraceContext(spanCtx, tc)
+	}
+	spanCtx, span := r.tp.StartSpan(spanCtx, "events.webhook.deliver",
+		core.Attribute{Key: "webhook.target.id", Value: target.ID},
+		core.Attribute{Key: "webhook.url", Value: target.URL},
+		core.Attribute{Key: "mcp.event.name", Value: eventName},
+		core.Attribute{Key: "http.method", Value: "POST"},
+	)
+	defer span.End()
+	_ = spanCtx
+	var (
+		finalStatus int
+		attempts    int
+	)
+	defer func() {
+		span.SetAttribute("webhook.retry.attempts", strconv.Itoa(attempts))
+		if finalStatus > 0 {
+			span.SetAttribute("http.response.status_code", strconv.Itoa(finalStatus))
+		}
+	}()
 	backoff := initialBackoff
 	// Tracks the last per-attempt failure bucket. Recorded onto
 	// deliveryStatus only after all retries are exhausted (i.e., this
@@ -1074,6 +1143,7 @@ func (r *WebhookRegistry) deliver(target WebhookTarget, eventID string, body []b
 	lastErrBucket := DeliveryErrorNone
 
 	for attempt := 0; attempt <= maxRetries; attempt++ {
+		attempts = attempt + 1
 		if attempt > 0 {
 			r.logf("[webhook] retry %d/%d for %s (backoff %v)", attempt, maxRetries, target.URL, backoff)
 			time.Sleep(backoff)
@@ -1121,6 +1191,7 @@ func (r *WebhookRegistry) deliver(target WebhookTarget, eventID string, body []b
 			lastErrBucket = classifyTransportError(err)
 			continue // retry
 		}
+		finalStatus = resp.StatusCode
 		resp.Body.Close()
 
 		if resp.StatusCode < 300 {
@@ -1154,6 +1225,7 @@ func (r *WebhookRegistry) deliver(target WebhookTarget, eventID string, body []b
 	}
 	r.logf("[webhook] delivery to %s failed after %d retries, giving up", target.URL, maxRetries)
 	r.recordDeliveryFailure(target.CanonicalKey, lastErrBucket)
+	span.RecordError(fmt.Errorf("webhook delivery exhausted retries: %s", lastErrBucket))
 }
 
 // ValidateWebhookURL is a fail-fast subscribe-time check on a webhook

--- a/experimental/ext/events/webhook_span_test.go
+++ b/experimental/ext/events/webhook_span_test.go
@@ -1,0 +1,223 @@
+package events
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/panyam/mcpkit/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeSpan + fakeTracerProvider — local stub matching server/trace_middleware_test.go
+// shape so the webhook tests can assert span emission without a real
+// OTel SDK (experimental/ext/events stays dep-free of ext/otel).
+type fakeSpan struct {
+	name   string
+	parent core.TraceContext
+	attrs  map[string]string
+	errors []error
+	ended  bool
+	mu     sync.Mutex
+}
+
+func (s *fakeSpan) End() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ended = true
+}
+func (s *fakeSpan) SetAttribute(k, v string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.attrs == nil {
+		s.attrs = map[string]string{}
+	}
+	s.attrs[k] = v
+}
+func (s *fakeSpan) RecordError(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.errors = append(s.errors, err)
+}
+func (s *fakeSpan) AddLink(core.Link) {}
+
+func (s *fakeSpan) attr(k string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.attrs[k]
+}
+func (s *fakeSpan) errCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.errors)
+}
+func (s *fakeSpan) isEnded() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.ended
+}
+
+type fakeTP struct {
+	mu    sync.Mutex
+	spans []*fakeSpan
+}
+
+func (p *fakeTP) StartSpan(ctx context.Context, name string, attrs ...core.Attribute) (context.Context, core.Span) {
+	sp := &fakeSpan{
+		name:   name,
+		parent: core.TraceContextFromContext(ctx),
+		attrs:  make(map[string]string, len(attrs)),
+	}
+	for _, a := range attrs {
+		sp.attrs[a.Key] = a.Value
+	}
+	p.mu.Lock()
+	p.spans = append(p.spans, sp)
+	p.mu.Unlock()
+	return core.WithActiveSpan(ctx, sp), sp
+}
+
+func (p *fakeTP) snapshot() []*fakeSpan {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]*fakeSpan, len(p.spans))
+	copy(out, p.spans)
+	return out
+}
+
+func (p *fakeTP) findSpan(name string) *fakeSpan {
+	for _, sp := range p.snapshot() {
+		if sp.name == name {
+			return sp
+		}
+	}
+	return nil
+}
+
+// WebhookRegistry with WithWebhookTracerProvider emits an
+// events.webhook.deliver span around each outbound POST. Span parent
+// matches the inbound trace context resolved from ctx, attributes
+// describe the delivery, and the span ends after the retry loop
+// terminates (success or exhaustion).
+func TestWebhookDeliver_EmitsSpanWithAttributes(t *testing.T) {
+	var hits int
+	var mu sync.Mutex
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		hits++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer receiver.Close()
+
+	tp := &fakeTP{}
+	wh := NewWebhookRegistry(
+		WithWebhookAllowPrivateNetworks(true),
+		WithWebhookTracerProvider(tp),
+	)
+	registerTestTarget(t, wh, receiver.URL)
+
+	ctx := ctxWithTraceparent(demoTraceparent)
+	event := MakeEvent("fake.event", "evt_span_1", "1", time.Now(), map[string]string{"k": "v"})
+	wh.Deliver(ctx, event)
+
+	require.Eventually(t, func() bool { mu.Lock(); defer mu.Unlock(); return hits >= 1 },
+		3*time.Second, 20*time.Millisecond)
+
+	// Spans are emitted in a goroutine, so give them a moment to land.
+	require.Eventually(t, func() bool { return tp.findSpan("events.webhook.deliver") != nil },
+		3*time.Second, 20*time.Millisecond, "events.webhook.deliver span must emit")
+
+	span := tp.findSpan("events.webhook.deliver")
+	require.NotNil(t, span)
+	require.Eventually(t, func() bool { return span.isEnded() },
+		3*time.Second, 20*time.Millisecond, "span must end after retry loop terminates")
+
+	assert.Equal(t, demoTraceparent, span.parent.Traceparent,
+		"inbound trace context must become the span's parent (Gate 3 stitching)")
+	assert.NotEmpty(t, span.attr("webhook.target.id"))
+	assert.Equal(t, receiver.URL, span.attr("webhook.url"))
+	assert.Equal(t, "fake.event", span.attr("mcp.event.name"))
+	assert.Equal(t, "POST", span.attr("http.method"))
+	assert.Equal(t, "200", span.attr("http.response.status_code"))
+	assert.Equal(t, "1", span.attr("webhook.retry.attempts"))
+	assert.Equal(t, 0, span.errCount(), "success path must not record any error")
+}
+
+// 5xx retry-exhausted path → span carries the final status code + the
+// total attempts count + a RecordError reflecting the categorical bucket.
+func TestWebhookDeliver_RetriesExhausted_RecordsError(t *testing.T) {
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer receiver.Close()
+
+	tp := &fakeTP{}
+	wh := NewWebhookRegistry(
+		WithWebhookAllowPrivateNetworks(true),
+		WithWebhookTracerProvider(tp),
+	)
+	registerTestTarget(t, wh, receiver.URL)
+
+	wh.Deliver(context.Background(),
+		MakeEvent("fake.event", "evt_500", "1", time.Now(), map[string]string{"k": "v"}))
+
+	// Retry timing: 0.5s + 1s + 2s = ~3.5s total; wait a bit longer for end.
+	require.Eventually(t, func() bool {
+		sp := tp.findSpan("events.webhook.deliver")
+		return sp != nil && sp.isEnded()
+	}, 6*time.Second, 50*time.Millisecond, "span must end after retries exhausted")
+
+	span := tp.findSpan("events.webhook.deliver")
+	require.NotNil(t, span)
+	assert.Equal(t, "500", span.attr("http.response.status_code"),
+		"final attempt's status code lands on the span")
+	assert.Equal(t, "4", span.attr("webhook.retry.attempts"),
+		"4 total attempts (1 initial + 3 retries)")
+	assert.GreaterOrEqual(t, span.errCount(), 1,
+		"final retry-exhausted path must RecordError with categorical bucket")
+}
+
+// Nil / default TracerProvider must skip span emission cleanly —
+// zero overhead on the unconfigured path. Matches the
+// JWTValidator / AppHost SEP-414 P6 precedent.
+func TestWebhookDeliver_NoTracerProvider_NoSpan(t *testing.T) {
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer receiver.Close()
+
+	wh := NewWebhookRegistry(WithWebhookAllowPrivateNetworks(true))
+	registerTestTarget(t, wh, receiver.URL)
+
+	// Drive a delivery; the Noop StartSpan returns a no-op Span; should
+	// not panic and the goroutine should exit cleanly.
+	wh.Deliver(context.Background(),
+		MakeEvent("fake.event", "evt_noop", "1", time.Now(), map[string]string{"k": "v"}))
+
+	time.Sleep(200 * time.Millisecond)
+	// No assertion to make beyond "didn't panic" — the value of the
+	// test is exercising the unconfigured path under the same
+	// signatures as the instrumented path.
+}
+
+// registerTestTarget — same minimal helper used by trace_propagation_test.go,
+// inlined here so this file can run standalone.
+func registerTestTarget(t *testing.T, wh *WebhookRegistry, receiverURL string) {
+	t.Helper()
+	target := WebhookTarget{
+		EventName: "fake.event",
+		URL:       receiverURL,
+		Secret:    generateSecret(),
+		ExpiresAt: time.Now().Add(time.Hour),
+		Status:    DeliveryStatus{Active: true},
+	}
+	target.CanonicalKey = canonicalKey("test-principal", receiverURL, "fake.event", nil)
+	target.ID = deriveSubscriptionID(target.CanonicalKey)
+	_, err := wh.store.SaveWebhook(context.Background(), SaveWebhookRequest{Target: target})
+	require.NoError(t, err)
+}

--- a/server/broadcast_test.go
+++ b/server/broadcast_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"sync"
 	"testing"
 
@@ -43,7 +44,7 @@ func TestBroadcastSingleSession(t *testing.T) {
 		},
 	)
 
-	srv.Broadcast("notifications/tools/list_changed", nil)
+	srv.Broadcast(context.Background(), "notifications/tools/list_changed", nil)
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -90,7 +91,7 @@ func TestBroadcastMultipleSessions(t *testing.T) {
 		)
 	}
 
-	srv.Broadcast("notifications/prompts/list_changed", nil)
+	srv.Broadcast(context.Background(), "notifications/prompts/list_changed", nil)
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -137,7 +138,7 @@ func TestBroadcastSkipsNilNotifyFunc(t *testing.T) {
 	)
 
 	// Must not panic
-	srv.Broadcast("notifications/tools/list_changed", nil)
+	srv.Broadcast(context.Background(), "notifications/tools/list_changed", nil)
 
 	if !received {
 		t.Error("ok-session did not receive notification")
@@ -150,7 +151,7 @@ func TestBroadcastSkipsNilNotifyFunc(t *testing.T) {
 func TestBroadcastNoSessions(t *testing.T) {
 	srv := NewServer(core.ServerInfo{Name: "test", Version: "1.0"})
 	// No sessions registered — must not panic
-	srv.Broadcast("notifications/tools/list_changed", nil)
+	srv.Broadcast(context.Background(), "notifications/tools/list_changed", nil)
 }
 
 // TestBroadcastDoesNotRequireSubscription verifies the key difference between
@@ -181,7 +182,7 @@ func TestBroadcastDoesNotRequireSubscription(t *testing.T) {
 	)
 
 	// Do NOT subscribe — Broadcast should still deliver
-	srv.Broadcast("notifications/resources/list_changed", nil)
+	srv.Broadcast(context.Background(), "notifications/resources/list_changed", nil)
 
 	if !received {
 		t.Error("session did not receive broadcast despite not subscribing")
@@ -213,7 +214,7 @@ func TestBroadcastWithParams(t *testing.T) {
 	)
 
 	payload := map[string]any{"uri": "test://doc", "reason": "updated"}
-	srv.Broadcast("notifications/resources/updated", payload)
+	srv.Broadcast(context.Background(), "notifications/resources/updated", payload)
 
 	m, ok := capturedParams.(map[string]any)
 	if !ok {

--- a/server/server.go
+++ b/server/server.go
@@ -545,7 +545,7 @@ func NewServer(info core.ServerInfo, opts ...Option) *Server {
 	// Wire registry change notifications to Server.Broadcast so that
 	// dynamic adds/removes automatically notify all connected sessions.
 	s.dispatcher.Reg.OnChange = func(method string) {
-		s.Broadcast(method, nil)
+		s.Broadcast(context.Background(), method, nil)
 	}
 	// Wire roots configuration
 	if s.options.onRootsChanged != nil {
@@ -940,11 +940,17 @@ func (s *Server) CloseAllSessions() {
 // Streamable HTTP transports). In-process transports manage their own
 // notification delivery via WithNotificationHandler.
 //
+// ctx threads through SEP-414 trace context for downstream
+// instrumentation — currently consumed by callers (e.g., events.Emit
+// for outbound _meta.traceparent injection on notification params).
+// The underlying session broadcasters don't take ctx today; that
+// plumbing slots in without churning callers when it's added.
+//
 // Example:
 //
 //	// After registering a new tool at runtime:
-//	srv.Broadcast("notifications/tools/list_changed", nil)
-func (s *Server) Broadcast(method string, params any) {
+//	srv.Broadcast(ctx, "notifications/tools/list_changed", nil)
+func (s *Server) Broadcast(_ context.Context, method string, params any) {
 	s.mu.Lock()
 	broadcasters := make([]func(string, any), len(s.sessionBroadcasters))
 	copy(broadcasters, s.sessionBroadcasters)

--- a/server/streamable_subscriptions_test.go
+++ b/server/streamable_subscriptions_test.go
@@ -152,7 +152,7 @@ func TestSubscriptionStream_SubscriptionIdOnAllFrames(t *testing.T) {
 	// Cleaner than fighting the SSE buffer here.
 	go func() {
 		time.Sleep(150 * time.Millisecond)
-		s.Broadcast("notifications/tools/list_changed", nil)
+		s.Broadcast(context.Background(), "notifications/tools/list_changed", nil)
 	}()
 
 	frames := readSSEFrames(t, resp, 2, 3*time.Second)
@@ -204,7 +204,7 @@ func TestSubscriptionStream_FilterHonored(t *testing.T) {
 	}
 
 	// Broadcast a tools event the filter does NOT permit.
-	s.Broadcast("notifications/tools/list_changed", nil)
+	s.Broadcast(context.Background(), "notifications/tools/list_changed", nil)
 
 	// Read with a short deadline — nothing should arrive.
 	leaked := readSSEFrames(t, resp, 1, 600*time.Millisecond)
@@ -243,7 +243,7 @@ func TestSubscriptionStream_DisconnectUnregisters(t *testing.T) {
 	// fail — proves cleanup unwound the registration.
 	done := make(chan struct{})
 	go func() {
-		s.Broadcast("notifications/tools/list_changed", nil)
+		s.Broadcast(context.Background(), "notifications/tools/list_changed", nil)
 		close(done)
 	}()
 	select {
@@ -271,7 +271,7 @@ func TestSubscriptionStream_PromptsListChangedDeliversToPromptsFilter(t *testing
 
 	go func() {
 		time.Sleep(150 * time.Millisecond)
-		s.Broadcast("notifications/prompts/list_changed", nil)
+		s.Broadcast(context.Background(), "notifications/prompts/list_changed", nil)
 	}()
 
 	frames := readSSEFrames(t, resp, 2, 3*time.Second)


### PR DESCRIPTION
## What changes

Closes the realistic items from PR 712's deferred list — Plan A from the post-712 follow-up triage. Server.Broadcast widens to take ctx; WebhookRegistry gains a `WithTracerProvider` option so every outbound HTTP POST emits an `events.webhook.deliver` span; the whole-enchilada event-server wires the new option so Peter's demo renders the full chain (client → server → webhook) as one row in Tempo. discord + telegram adopters get the PR 712 signature sweep. Cross-replica peer-fanout Emitter stays parked on issues #634 / #639 with concrete design comments added.

```mermaid
sequenceDiagram
    participant C as Client
    participant S as MCP Server
    participant W as Webhook Receiver

    Note over C: tools/call with _meta.traceparent
    C->>S: POST /mcp
    Note over S: server.dispatch span (SEP-414 P2)
    S->>S: yield(ctx, event) → event.Meta.traceparent
    S->>S: emit hook (ctx) → Emitter
    Note over S: events.webhook.deliver span (this PR)<br/>parent: ctx trace
    S->>W: POST receiver with traceparent header
    Note over C,W: One TraceID in Tempo: client → dispatch → webhook
```

## Reviewer's guide

Read in this order:

1. [server/server.go](https://github.com/panyam/mcpkit/pull/714/files#diff-78f42ba40d0f10b08c73b7e6bb8376f398e249c963cf549e89591d6b6826b9a4) — `Server.Broadcast(ctx, method, params)` signature change. The underlying session broadcasters don't consume ctx yet (their plumbing is its own concern); the param accepts the trace context so events.Emit can thread it through without churning callers when the future P2 NotifyInterceptor wiring lands.
2. [experimental/ext/events/webhook.go](https://github.com/panyam/mcpkit/pull/714/files#diff-f61c2bd42ae83936aba2fe7dab3bcda1606ca810bd7263d9afbe42147f9c8f5a) — new `WithWebhookTracerProvider` option + `noopTP` package var for the zero-overhead default. `WebhookRegistry.deliver` now takes `eventName` and wraps the retry loop in `events.webhook.deliver` span with documented attributes (parent from ctx/Meta, attributes set per-attempt, RecordError on retries-exhausted). New `traceContextForDelivery` helper unchanged.
3. [experimental/ext/events/webhook_span_test.go](https://github.com/panyam/mcpkit/pull/714/files#diff-c428308beae0e4d63372b8acef694e043472295eabe0bbd475f0cfbb0d4f565e) — 3 new tests: span emitted with all attributes on success, retries-exhausted records error + final status, no TracerProvider = no span (zero overhead).
4. [experimental/ext/events/events.go](https://github.com/panyam/mcpkit/pull/714/files#diff-4a2a8cf5f00e8770df09ab463340a5fc393acbf3f95ef59af8280e2a7a814815) — Register's emit hook + package-level `Emit` / `EmitToWebhooks` now thread ctx through to `Server.Broadcast` and `WebhookRegistry.Deliver`.
5. [examples/events/whole-enchilada/event-server/main.go](https://github.com/panyam/mcpkit/pull/714/files#diff-b68bee649bce17c0a368e1338cfca30c1f0941204495cefb18dc61655d352796) — adopts `events.WithWebhookTracerProvider(tp)`. Already had `commonotel.SetupTelemetry` from a prior PR.
6. [examples/events/discord/events.go](https://github.com/panyam/mcpkit/pull/714/files#diff-0481815681015a3336446aae74c1db2f9895b60e6cc895d5dd9a630ac276eefd) + `discord/main.go` — yield closures and SetMetaFunc threaded with ctx per PR 712 signature changes. Mechanical.
7. [examples/events/telegram/events.go](https://github.com/panyam/mcpkit/pull/714/files#diff-3b46267107a5fd5ed05f15a1d2e8d16b31e4adac236511d74f45b1d2427a1e05) + `telegram/main.go` + `telegram/telegram.go` — same shape.
8. [experimental/ext/events/delivery_status_test.go](https://github.com/panyam/mcpkit/pull/714/files#diff-eb63a35a464c7dd69b298a550ac9291e03dd1a03f08781f3dea7374088226e37) + `lifecycle_test.go` — mechanical sweep to pass `eventName` (empty in tests) + tc through the renamed `deliver` signature.
9. [server/broadcast_test.go](https://github.com/panyam/mcpkit/pull/714/files#diff-5610cc18a859ad8e51cc8fbcb89ad9479a5a08d649d0c9a46570d261cfdfa70d) + `streamable_subscriptions_test.go` — mechanical sweep to pass `context.Background()` to `Broadcast`.

Skim or skip: nothing — single-purpose PR per task.

## Decision log

| Decision | Choice | Alternative | Why |
|---|---|---|---|
| Server.Broadcast takes ctx (param accepted, not yet consumed by underlying broadcasters) | Yes | Defer Broadcast signature change | Even if underlying broadcasters don't consume ctx today, events.Emit needs to thread it through; deferring means a second breaking change later. Param accepted as no-op now, slots in cleanly. |
| WebhookRegistry option signature: `WithWebhookTracerProvider` | Matches `WithWebhook...` naming convention | `WithTracerProvider` (shorter) | Webhook prefix matches the 8 other `WithWebhook*` options on the registry. Discoverability + uniformity wins. |
| Span placement: one span per retry loop (not per attempt) | Yes | Span per attempt | Operator value is "how long did this delivery take, end-to-end, including retries". Per-attempt would bloat span counts on the failure path (4 spans per failure × N targets). Attempts captured as attribute. |
| `eventName` plumbed through `deliver` as separate param | Yes | Wrap event into a struct | Smallest signature change; deliver doesn't need full Event for anything else. Passing just `eventName` matches the minimal-attribute philosophy. |
| Standard OTel attribute names (`http.method`, `http.response.status_code`) | Yes | Custom names (`webhook.http.method`) | OTel semantic conventions exist for a reason — Tempo's UI knows how to render `http.*`. Vendor-specific would lose that. |
| `events.webhook.deliver` span name (not `webhook.deliver`) | Yes | `webhook.deliver` | mcp prefix matches the rest of mcpkit's span names (`apps.host.forward`, `auth.jwks_lookup`). Consistent vocabulary for filter-by-instrumentation in Grafana. |
| Spec-note as separate tracking issue (713), not in this PR | Yes | Document inline in PR description | The spec note is its own deliverable when upstream interest surfaces. Issue keeps it visible without coupling to this PR's review. |
| Cross-replica peer-fanout Emitter still deferred to #634/#639 | Yes | Include in this PR | Genuinely huge — needs design doc + implementation + integration tests. Comments added to #634 and #639 with the trace propagation requirements so when that work picks up, it's specified. |

## Risk / blast radius

- **Server.Broadcast signature change** — 1 internal site + 7 test sites; all swept. No external consumers beyond mcpkit itself (Broadcast is a public method but the events module is the only known caller). External callers will need to pass `context.Background()` as the first arg — trivial migration.
- **WebhookRegistry deliver signature change** — internal method, no external impact.
- **WebhookRegistry option addition** — purely additive.
- **Span goroutine lifecycle** — `deliver` runs in a goroutine spawned by Deliver/DeliverToTarget. Span is created at goroutine start, ended via defer. CAS-guarded `End()` on the Noop implementation handles double-end safely; ext/otel handles it via the existing CAS guard on `Provider.Span.End`.
- **Defer ordering**: the span's `defer span.End()` fires before the defer that sets `finalStatus` / `attempts` attributes. Reordered to ensure attribute defer runs first.

## Test plan

Added: 3 webhook span tests. Removed/weakened: 0.

- `TestWebhookDeliver_EmitsSpanWithAttributes` — happy path: span emits with parent = inbound trace context, all attributes set, no error recorded.
- `TestWebhookDeliver_RetriesExhausted_RecordsError` — 5xx receiver: 4 attempts, span ends with final 500 status + RecordError carrying the categorical bucket.
- `TestWebhookDeliver_NoTracerProvider_NoSpan` — bare `NewWebhookRegistry`: deliver runs cleanly through the Noop path, no panic, no observable spans.

Verification:
- `make test` (root): clean
- `experimental/ext/events && go test ./...` (events): clean (79.6s — same retry-and-fail tests as before dominate the time)
- `examples/events/discord && go build ./...`: clean
- `examples/events/telegram && go build ./...`: clean
- `examples/events/whole-enchilada/event-server && go build ./...`: clean

Live smoke against the docker/observability stack deferred to manual (same pattern PR 712 followed).

## Out of scope (deliberately deferred)

- **Cross-replica Redis EventBus** — issue 634, design notes added. Will consume ctx-aware Emit + the Event.Meta carrier this PR's predecessor (PR 712) shipped. No new work needed in this PR.
- **Multi-replica whole-enchilada stage-3 telemetry walkthrough** — issue 639, design notes added. Builds on this PR's WebhookRegistry tracer.
- **Underlying session broadcasters consuming ctx** — separate ticket. Today `Server.Broadcast` accepts ctx but the session-side notify-interceptor wraps don't yet thread it; that's a SEP-414 P2 follow-up.
- **Upstream events-spec note re `_meta.traceparent` carrier** — issue 713, filed as internal tracker. Only push upstream if cross-SDK interop interest surfaces.
