### PR TITLE
ext/events/stores/redis: SEP-414 trace context propagation across the pubsub hop

### DIFF
--- a/experimental/ext/events/stores/redis/README.md
+++ b/experimental/ext/events/stores/redis/README.md
@@ -78,6 +78,32 @@ Wire-format is `Codec`-pluggable. Default is `JSONCodec` (`encoding/json` over t
 
 The `Codec` interface lives in this sub-module for now. When a second cross-process backend (Kafka, NATS) wants the same shape, we promote it to the parent package.
 
+## Trace context propagation (SEP-414)
+
+Trace context propagates across the Redis pubsub hop end-to-end:
+
+- `Publisher.Emit(ctx, event)` reads the W3C `TraceContext` off `ctx` via `core.TraceContextFromContext` and stamps `traceparent` + `tracestate` onto `event.Meta` under the bare-name keys (matching the wire convention for every other mcpkit transport).
+- `Subscriber` extracts the same keys off each received `event.Meta` via `core.ExtractTraceContext` and derives a per-message `ctx` via `core.WithTraceContext`. The `DeliverFunc` receives that child `ctx`, so any span it opens parents to the publisher-side span automatically.
+
+Caller-set precedence: if you explicitly stamped `_meta.traceparent` on an event before calling `Emit`, that value wins — the publisher will NOT overwrite it. Mirrors `core.InjectTraceContextIntoParams`'s "caller-set wins" rule for MCP wire calls.
+
+### Redis-client-level spans (opt-in)
+
+The pubsub-level trace propagation above stitches publisher → subscriber across the Redis hop. To also see per-`PUBLISH` and per-`SUBSCRIBE` spans on the Redis client itself (latency to Redis, command parsing, etc.), wire `redisotel.InstrumentTracing` on the client BEFORE handing it to `Options.Client`:
+
+```go
+import (
+    "github.com/redis/go-redis/v9"
+    "github.com/redis/go-redis/extra/redisotel/v9"
+)
+
+cli := redis.NewClient(&redis.Options{Addr: "redis:6379"})
+_ = redisotel.InstrumentTracing(cli)  // emits redis.publish / redis.subscribe spans
+opts := redisstore.Options{Client: cli}
+```
+
+This is a deliberate opt-in — `Options` doesn't take a `TracerProvider` because OTel SDK wiring is the user's choice, and pinning a specific OTel pipeline inside this sub-module would couple it to one observability stack.
+
 ## Testing
 
 ```

--- a/experimental/ext/events/stores/redis/go.mod
+++ b/experimental/ext/events/stores/redis/go.mod
@@ -8,6 +8,7 @@ replace github.com/panyam/mcpkit/experimental/ext/events => ../..
 
 require (
 	github.com/alicebob/miniredis/v2 v2.38.0
+	github.com/panyam/mcpkit v0.2.33
 	github.com/panyam/mcpkit/experimental/ext/events v0.0.0-00010101000000-000000000000
 	github.com/redis/go-redis/v9 v9.7.0
 	github.com/stretchr/testify v1.11.1
@@ -24,7 +25,6 @@ require (
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/panyam/gocurrent v0.1.1 // indirect
 	github.com/panyam/goutils v0.1.8 // indirect
-	github.com/panyam/mcpkit v0.2.33 // indirect
 	github.com/panyam/servicekit v0.1.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect

--- a/experimental/ext/events/stores/redis/publisher.go
+++ b/experimental/ext/events/stores/redis/publisher.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	mcpcore "github.com/panyam/mcpkit/core"
 	"github.com/panyam/mcpkit/experimental/ext/events"
 )
 
@@ -39,7 +40,16 @@ func NewPublisher(opts Options) (*Publisher, error) {
 // PUBLISH (Redis returns the receiver count, zero is fine) is NOT an
 // error — late subscribers missing messages is the documented
 // at-most-once contract.
+//
+// SEP-414 trace context propagation: if ctx carries a TraceContext
+// (set by core.WithTraceContext or the server's trace middleware),
+// Emit stamps the W3C `traceparent` / `tracestate` keys onto
+// event.Meta so the subscriber side can stitch its delivery span to
+// the publisher's span via core.ExtractTraceContext. Caller-set
+// values on event.Meta win — explicit traceparent on the event is
+// never clobbered (mirrors core.InjectTraceContextIntoParams).
 func (p *Publisher) Emit(ctx context.Context, event events.Event) error {
+	event.Meta = injectTraceContext(ctx, event.Meta)
 	body, err := p.opts.Codec.Encode(event)
 	if err != nil {
 		return fmt.Errorf("redisstore: encode failed: %w", err)
@@ -49,6 +59,30 @@ func (p *Publisher) Emit(ctx context.Context, event events.Event) error {
 		return fmt.Errorf("redisstore: PUBLISH %s failed: %w", channel, err)
 	}
 	return nil
+}
+
+// injectTraceContext returns a Meta map that carries the inbound
+// ctx's TraceContext under the W3C bare-name keys. Returns the input
+// Meta unchanged when ctx has no TraceContext or when Meta already
+// carries an explicit traceparent (caller-set wins).
+//
+// Always returns a freshly-allocated map when injection happens, so
+// the caller's Event.Meta is never mutated through aliasing — events
+// are passed by value but Meta is a reference type.
+func injectTraceContext(ctx context.Context, meta map[string]any) map[string]any {
+	tc := mcpcore.TraceContextFromContext(ctx)
+	if tc.IsZero() {
+		return meta
+	}
+	if _, callerSet := meta[mcpcore.MetaKeyTraceparent]; callerSet {
+		return meta
+	}
+	cp := make(map[string]any, len(meta)+2)
+	for k, v := range meta {
+		cp[k] = v
+	}
+	mcpcore.InjectTraceContext(cp, tc)
+	return cp
 }
 
 // Compile-time check that *Publisher satisfies events.Emitter — if

--- a/experimental/ext/events/stores/redis/subscriber.go
+++ b/experimental/ext/events/stores/redis/subscriber.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/redis/go-redis/v9"
 
+	mcpcore "github.com/panyam/mcpkit/core"
 	"github.com/panyam/mcpkit/experimental/ext/events"
 )
 
@@ -137,7 +138,17 @@ func (s *Subscriber) Run(ctx context.Context) error {
 				s.opts.Logger("redisstore: decode failed on channel %q: %v", msg.Channel, err)
 				continue
 			}
-			if err := s.deliver(ctx, event); err != nil {
+			// SEP-414 trace context propagation: stitch the
+			// per-message ctx to the publisher-side span when the
+			// event.Meta carried one. ExtractTraceContext returns a
+			// zero TraceContext when Meta is absent / malformed; in
+			// that case msgCtx equals ctx (no derivation happens
+			// because WithTraceContext on a zero TC is a no-op).
+			msgCtx := ctx
+			if tc := mcpcore.ExtractTraceContext(event.Meta); !tc.IsZero() {
+				msgCtx = mcpcore.WithTraceContext(ctx, tc)
+			}
+			if err := s.deliver(msgCtx, event); err != nil {
 				s.opts.Logger("redisstore: deliver failed for event %q: %v", event.Name, err)
 				// Per the Emitter contract, errors are reported but
 				// do not halt further fanout. Same applies here —

--- a/experimental/ext/events/stores/redis/trace_propagation_test.go
+++ b/experimental/ext/events/stores/redis/trace_propagation_test.go
@@ -1,0 +1,169 @@
+package redisstore
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	mcpcore "github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/experimental/ext/events"
+)
+
+// W3C example traceparent — valid per the spec (version 00, all-hex,
+// non-zero trace-id + parent-id). Used as the publisher-side input
+// and asserted on the subscriber side.
+const (
+	testTraceparent = "00-0af7651916cd43dd8448eb211c80319c-b9c7c989f97918e1-01"
+	testTracestate  = "vendor=truth"
+)
+
+// TestEmit_InjectsTraceContextFromContext verifies the load-bearing
+// publisher behavior: when ctx carries a TraceContext (set by the
+// server trace middleware in real deployments), Emit stamps the
+// W3C bare-name keys onto event.Meta before encoding so the
+// subscriber side can stitch.
+func TestEmit_InjectsTraceContextFromContext(t *testing.T) {
+	opts := Options{Client: newTestClient(t)}
+	cap := &captureDeliver{}
+	_, stop := startSubscriber(t, opts, cap, "chat.message")
+	defer stop()
+
+	pub, err := NewPublisher(opts)
+	require.NoError(t, err)
+
+	ctx := mcpcore.WithTraceContext(t.Context(), mcpcore.TraceContext{
+		Traceparent: testTraceparent,
+		Tracestate:  testTracestate,
+	})
+	require.NoError(t, pub.Emit(ctx, sample("chat.message", "with-trace")))
+
+	require.Eventually(t, func() bool {
+		return len(cap.snapshot()) == 1
+	}, 2*time.Second, 10*time.Millisecond)
+
+	got := cap.snapshot()[0]
+	assert.Equal(t, testTraceparent, got.Meta[mcpcore.MetaKeyTraceparent])
+	assert.Equal(t, testTracestate, got.Meta[mcpcore.MetaKeyTracestate])
+}
+
+// TestEmit_PreservesCallerSetTraceparent locks the precedence rule:
+// when the caller has already stamped `_meta.traceparent` explicitly
+// on the event, the publisher MUST NOT clobber it with the ctx's
+// value. Mirrors core.InjectTraceContextIntoParams's "caller-set
+// wins" semantics — important for systems that bridge in a
+// different trace context (e.g., a webhook receiver replaying an
+// upstream traceparent it parsed from headers).
+func TestEmit_PreservesCallerSetTraceparent(t *testing.T) {
+	opts := Options{Client: newTestClient(t)}
+	cap := &captureDeliver{}
+	_, stop := startSubscriber(t, opts, cap, "chat.message")
+	defer stop()
+
+	pub, err := NewPublisher(opts)
+	require.NoError(t, err)
+
+	const callerTP = "00-aabbccddeeff00112233445566778899-1122334455667788-01"
+	ctx := mcpcore.WithTraceContext(t.Context(), mcpcore.TraceContext{
+		Traceparent: testTraceparent, // would lose
+	})
+	ev := sample("chat.message", "caller-set")
+	ev.Meta = map[string]any{mcpcore.MetaKeyTraceparent: callerTP}
+	require.NoError(t, pub.Emit(ctx, ev))
+
+	require.Eventually(t, func() bool {
+		return len(cap.snapshot()) == 1
+	}, 2*time.Second, 10*time.Millisecond)
+
+	got := cap.snapshot()[0]
+	assert.Equal(t, callerTP, got.Meta[mcpcore.MetaKeyTraceparent],
+		"caller-set traceparent must win over ctx-derived value")
+}
+
+// TestEmit_NoCtxTraceContext_LeavesMetaClean verifies that when ctx
+// carries no TraceContext, Emit does NOT pollute event.Meta with
+// empty keys or a derived blank map. Important for the common
+// single-replica path where tracing isn't wired — operators
+// shouldn't see a phantom `_meta.traceparent` appear on every wire
+// message.
+func TestEmit_NoCtxTraceContext_LeavesMetaClean(t *testing.T) {
+	opts := Options{Client: newTestClient(t)}
+	cap := &captureDeliver{}
+	_, stop := startSubscriber(t, opts, cap, "chat.message")
+	defer stop()
+
+	pub, err := NewPublisher(opts)
+	require.NoError(t, err)
+
+	require.NoError(t, pub.Emit(t.Context(), sample("chat.message", "no-trace")))
+
+	require.Eventually(t, func() bool {
+		return len(cap.snapshot()) == 1
+	}, 2*time.Second, 10*time.Millisecond)
+
+	got := cap.snapshot()[0]
+	_, hasTP := got.Meta[mcpcore.MetaKeyTraceparent]
+	assert.False(t, hasTP, "no ctx trace context: traceparent must NOT appear in Meta")
+	_, hasTS := got.Meta[mcpcore.MetaKeyTracestate]
+	assert.False(t, hasTS, "no ctx trace context: tracestate must NOT appear in Meta")
+}
+
+// TestRoundTrip_TraceContextStitchesAcrossPubsub is the end-to-end
+// contract: publisher emits with a TraceContext in ctx; subscriber's
+// deliverFn receives a ctx that carries the SAME TraceContext via
+// core.TraceContextFromContext. That's what makes the publisher's
+// span the parent of the deliverFn's span in Tempo / Jaeger.
+func TestRoundTrip_TraceContextStitchesAcrossPubsub(t *testing.T) {
+	opts := Options{Client: newTestClient(t)}
+
+	var (
+		mu          sync.Mutex
+		deliveredTC mcpcore.TraceContext
+		hits        int
+	)
+	deliver := func(ctx context.Context, _ events.Event) error {
+		mu.Lock()
+		defer mu.Unlock()
+		deliveredTC = mcpcore.TraceContextFromContext(ctx)
+		hits++
+		return nil
+	}
+	sub, err := NewSubscriber(opts, deliver)
+	require.NoError(t, err)
+	require.NoError(t, sub.Subscribe(t.Context(), "chat.message"))
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() {
+		_ = sub.Run(ctx)
+		close(done)
+	}()
+	defer func() {
+		cancel()
+		_ = sub.Close()
+		<-done
+	}()
+	time.Sleep(50 * time.Millisecond)
+
+	pub, err := NewPublisher(opts)
+	require.NoError(t, err)
+	pubCtx := mcpcore.WithTraceContext(t.Context(), mcpcore.TraceContext{
+		Traceparent: testTraceparent,
+		Tracestate:  testTracestate,
+	})
+	require.NoError(t, pub.Emit(pubCtx, sample("chat.message", "stitched")))
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return hits == 1
+	}, 2*time.Second, 10*time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, testTraceparent, deliveredTC.Traceparent,
+		"deliverFn ctx must carry the publisher's traceparent across the Redis hop")
+	assert.Equal(t, testTracestate, deliveredTC.Tracestate)
+}


### PR DESCRIPTION
## What changes

Closes the trace-continuity gap PR 716 left behind. After this PR, a multi-replica whole-enchilada deployment that publishes on replica A and consumes on replica B produces a **single end-to-end trace** in Tempo / Jaeger / Grafana, instead of two unrelated traces with no causal link.

The work is pure plumbing — `core/trace.go` already ships the helpers:

```
Publisher.Emit:
  core.TraceContextFromContext(ctx)  →  inject under W3C bare-name keys on event.Meta  →  encode  →  PUBLISH

Subscriber.Run (per message):
  decode  →  core.ExtractTraceContext(event.Meta)  →  core.WithTraceContext(ctx, tc)  →  deliverFn(childCtx, event)
```

No new core API surface. No new module deps. The `redisotel.InstrumentTracing(client)` recipe for per-PUBLISH/per-SUBSCRIBE Redis-client spans stays opt-in (operator wires it on the `*redis.Client` before handing it to `Options.Client`) — documented in README.

## Reviewer's guide

1. [experimental/ext/events/stores/redis/publisher.go](https://github.com/panyam/mcpkit/pull/717/files#diff-2468c823a5d7446be2a46b37b12e1a044315db7144ccda6c18caddb6538a1ae7) — `Emit` gains one line + the new `injectTraceContext` helper. The defensive Meta clone is the non-obvious bit: `events.Event` is by value but `Meta` is a map (reference type), so aliasing the caller's map would be a footgun.
2. [experimental/ext/events/stores/redis/subscriber.go](https://github.com/panyam/mcpkit/pull/717/files#diff-5595c9e5a602e88f9e6e7c5d0d4d1246abea8729f88132bfcd59865c3ec4536c) — three lines inside the receive loop. The per-message `msgCtx := ctx` derivation is what stitches the trace across the Redis hop.
3. [experimental/ext/events/stores/redis/trace_propagation_test.go](https://github.com/panyam/mcpkit/pull/717/files#diff-a4d73284d7e3787cb8a16810ee00e36bfdc914c74f75556dc82c4f69089b0e1c) — 4 new tests:
   - `TestEmit_InjectsTraceContextFromContext` — the load-bearing publisher behavior
   - `TestEmit_PreservesCallerSetTraceparent` — caller-set wins (mirrors `core.InjectTraceContextIntoParams`)
   - `TestEmit_NoCtxTraceContext_LeavesMetaClean` — no-op when ctx is empty (no phantom keys on the wire)
   - `TestRoundTrip_TraceContextStitchesAcrossPubsub` — the end-to-end stitch through miniredis
4. [experimental/ext/events/stores/redis/README.md](https://github.com/panyam/mcpkit/pull/717/files#diff-4309c899768e545e244ce0f504bcc4fd8e55b6fd0e58205a0e8531c2695119fa) — new "Trace context propagation (SEP-414)" section + the opt-in `redisotel.InstrumentTracing` recipe.

Skim or skip: `go.mod` (one indirect-dep added: `mcpkit/core` is now direct).

## Decision log

- **Caller-set traceparent wins** — mirrors `core.InjectTraceContextIntoParams`. Important for systems that bridge a different trace context (e.g., a webhook receiver replaying an upstream `traceparent` it parsed from inbound headers).
- **Defensive Meta clone in `injectTraceContext`** — events are by value, but `Meta` is a map. Aliasing the caller's map would mutate state they may still reference. The clone is cheap (Meta is typically empty or tiny) and removes a class of foot-guns.
- **No `TracerProvider` on `Options`** — `redisotel.InstrumentTracing(client)` is an operator opt-in on the `*redis.Client` before it's handed to `Options.Client`. Adding a `TracerProvider` field would couple this sub-module to one OTel pipeline; documented recipe instead.
- **Per-message `WithTraceContext` derivation** — the Subscriber's `Run` ctx is a single long-lived ctx. We derive a child per message so the trace boundary is correct without dragging the loop ctx around.
- **No new core helpers** — `core.ExtractTraceContext` + `core.InjectTraceContext` + `core.WithTraceContext` + `core.TraceContextFromContext` cover the whole need.

## Risk / blast radius

- 4 lines of new code in `publisher.go`, 3 lines in `subscriber.go`, both behind explicit zero-context checks (no behavior change when tracing isn't wired).
- Existing 6 tests from PR 716 still pass (asserts no regression in encode/decode/channel-routing).
- New `trace_propagation_test.go` covers the 4 new contracts with miniredis (no Docker required — runs in `make test`).

## Out of scope (deliberately deferred)

- Redis-client-level instrumentation (`redisotel.InstrumentTracing`) — operator opt-in via README recipe; not bundled.
- Custom propagator beyond W3C `traceparent`/`tracestate` — `core.TraceContext` is W3C-shaped; b3-headers / jaeger-binary live on the OTel SDK side.
- Per-event-channel sampling decisions — the sampler is the OTel SDK's concern; we just propagate.

