### PR TITLE
ext/tasks: trace async task lifecycle via span links — SEP-414 P6 (issue 659)

### DIFF
--- a/core/trace.go
+++ b/core/trace.go
@@ -508,6 +508,51 @@ func WithActiveSpan(ctx context.Context, span Span) context.Context {
 	return context.WithValue(ctx, activeSpanCtxKey{}, span)
 }
 
+// --- New-root-span signaling (P6 ext/tasks contract complement — issue 659) --
+
+type newRootSpanCtxKey struct{}
+
+// WithNewRootSpan marks ctx so that the next TracerProvider.StartSpan /
+// StartSpanLinked call produces a span with no parent — even when ctx
+// carries an inherited parent (a core.TraceContext attached upstream,
+// or the adapter's own internal span context, e.g. the OTel
+// trace.SpanContext installed by a previous StartSpan).
+//
+// Use this when spawning work that conceptually outlives the
+// originating request — async tasks, events-bus producers — so the new
+// span shows up as a root trace rather than as a long-running child
+// nested under a short request span. Pair with StartSpanLinked plus a
+// Link back to the originating span so the lifecycle stays navigable
+// across the boundary.
+//
+// The marker is read by the TracerProvider adapter via
+// IsNewRootSpanRequested. Adapters that don't honor the marker (or the
+// NoopTracerProvider) silently ignore it — the spawned span starts
+// under whatever parent ctx happened to carry, which degrades to the
+// same trace tree the unmarked path would produce. Best-effort by
+// design: callers don't have to branch on adapter capability.
+//
+// The marker is one-shot in spirit (it signals the upcoming StartSpan)
+// but is NOT auto-consumed — any nested StartSpan call on the returned
+// ctx would also see the marker. In practice this doesn't matter
+// because the adapter's StartSpan publishes a fresh span context (and
+// a fresh core.TraceContext) on the returned ctx, so nested calls
+// naturally derive from the new root. Callers that want to defensively
+// gate further reads can branch on IsNewRootSpanRequested themselves.
+func WithNewRootSpan(ctx context.Context) context.Context {
+	return context.WithValue(ctx, newRootSpanCtxKey{}, true)
+}
+
+// IsNewRootSpanRequested reports whether ctx was marked by
+// WithNewRootSpan. TracerProvider adapter implementations read this to
+// decide whether to strip any inherited parent before starting the
+// new span. End-user code should not need to call this — use
+// WithNewRootSpan at the call site and let the adapter do the rest.
+func IsNewRootSpanRequested(ctx context.Context) bool {
+	v, _ := ctx.Value(newRootSpanCtxKey{}).(bool)
+	return v
+}
+
 // SpanFromContext returns the currently active Span carried by ctx, or
 // a no-op Span when none has been attached. The returned Span is
 // NEVER nil — callers can unconditionally call SetAttribute /

--- a/core/trace_test.go
+++ b/core/trace_test.go
@@ -484,3 +484,26 @@ func TestStartSpanLinked_LinkedProvider_RoutedToInterface(t *testing.T) {
 		t.Fatalf("StartSpanLinked must preserve per-link attributes")
 	}
 }
+
+// --- P6 ext/tasks complement: WithNewRootSpan (issue 659) -------------------
+
+func TestWithNewRootSpan_DefaultCtx_NotRequested(t *testing.T) {
+	if IsNewRootSpanRequested(context.Background()) {
+		t.Fatalf("plain ctx must not be marked as new-root by default")
+	}
+}
+
+func TestWithNewRootSpan_MarkedCtx_Requested(t *testing.T) {
+	ctx := WithNewRootSpan(context.Background())
+	if !IsNewRootSpanRequested(ctx) {
+		t.Fatalf("WithNewRootSpan must set the marker so adapters can detect it")
+	}
+}
+
+func TestWithNewRootSpan_DerivedCtx_PropagatesMarker(t *testing.T) {
+	ctx := WithNewRootSpan(context.Background())
+	ctx = WithTraceContext(ctx, TraceContext{}) // simulate scrub layered on top
+	if !IsNewRootSpanRequested(ctx) {
+		t.Fatalf("marker must survive other ctx derivations layered on top — adapters read it just before StartSpan")
+	}
+}

--- a/ext/otel/provider.go
+++ b/ext/otel/provider.go
@@ -162,7 +162,16 @@ func (p *Provider) StartSpanLinked(ctx context.Context, name string, links []cor
 // doesn't duplicate the parent-install / WithTraceContext / WithActiveSpan
 // sequence — only the option-list construction varies.
 func (p *Provider) startSpanInternal(ctx context.Context, name string, links []core.Link, attrs []core.Attribute) (context.Context, core.Span) {
-	if parent := core.TraceContextFromContext(ctx); !parent.IsZero() {
+	// Honor core.WithNewRootSpan first (issue 659). When the caller has
+	// asked for a new root, strip any OTel parent already on ctx so the
+	// SDK's tracer.Start doesn't silently re-parent the new span under
+	// the inherited span context. Skip the core.TraceContext-based
+	// parent install entirely in this branch — the marker's whole point
+	// is to suppress inheritance, even when an upstream layer wrote a
+	// non-zero TraceContext.
+	if core.IsNewRootSpanRequested(ctx) {
+		ctx = oteltrace.ContextWithSpanContext(ctx, oteltrace.SpanContext{})
+	} else if parent := core.TraceContextFromContext(ctx); !parent.IsZero() {
 		if parentSC, ok := traceContextToSpanContext(parent); ok {
 			ctx = oteltrace.ContextWithSpanContext(ctx, parentSC)
 		}

--- a/ext/otel/provider_test.go
+++ b/ext/otel/provider_test.go
@@ -415,3 +415,109 @@ func TestProvider_SpanAddLink_InvalidLink_Dropped(t *testing.T) {
 	require.Len(t, spans, 1)
 	assert.Empty(t, spans[0].Links, "invalid AddLink calls must be silently dropped")
 }
+
+// --- P6 ext/tasks complement: WithNewRootSpan (issue 659) -------------------
+
+// When ctx carries an inbound trace context, StartSpan parents the new
+// span under it (default behavior, regression-guards the existing
+// adapter contract).
+func TestStartSpan_InheritsParentFromTraceContext(t *testing.T) {
+	p, exp := newRecordingProvider(t)
+	parentTC := core.TraceContext{Traceparent: linkTP1}
+	ctx := core.WithTraceContext(context.Background(), parentTC)
+
+	_, span := p.StartSpan(ctx, "child")
+	span.End()
+
+	spans := exp.GetSpans()
+	require.Len(t, spans, 1)
+	assert.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", spans[0].SpanContext.TraceID().String(),
+		"child span must share the inbound trace ID — the adapter's default parent-inheritance path")
+}
+
+// When ctx is marked via core.WithNewRootSpan, the adapter MUST strip
+// any inherited parent (both the core.TraceContext and any latent OTel
+// span context already installed) so the new span emits as a fresh
+// root trace. This is the ext/otel-side enabler for the ext/tasks
+// task.execute root + link pattern (issue 659).
+func TestStartSpan_NewRootSpan_DetachesFromCoreTraceContext(t *testing.T) {
+	p, exp := newRecordingProvider(t)
+	parentTC := core.TraceContext{Traceparent: linkTP1}
+	ctx := core.WithTraceContext(context.Background(), parentTC)
+	ctx = core.WithNewRootSpan(ctx)
+
+	_, span := p.StartSpan(ctx, "task.execute")
+	span.End()
+
+	spans := exp.GetSpans()
+	require.Len(t, spans, 1)
+	assert.NotEqual(t, "4bf92f3577b34da6a3ce929d0e0e4736", spans[0].SpanContext.TraceID().String(),
+		"WithNewRootSpan must scrub the inherited core.TraceContext so the new span emits its own root trace ID")
+	assert.False(t, spans[0].Parent.IsValid(),
+		"new-root span must have no parent SpanContext — observability backends render it as a top-level trace")
+}
+
+// When ctx already carries an OTel parent installed by an earlier
+// StartSpan, WithNewRootSpan must strip THAT too — not just the
+// core.TraceContext. This is the exact shape goroutine bgCtx ends up
+// in after core.DetachForBackground (context.WithoutCancel preserves
+// every value, including the OTel span context, so a subsequent
+// StartSpan would otherwise silently re-parent under the dispatch
+// span).
+func TestStartSpan_NewRootSpan_DetachesFromOTelParent(t *testing.T) {
+	p, exp := newRecordingProvider(t)
+	parentCtx, parentSpan := p.StartSpan(context.Background(), "create")
+	parentTraceID := parentSpan.(*mcpotel.Span)
+	_ = parentTraceID
+	defer parentSpan.End()
+
+	rootCtx := core.WithNewRootSpan(parentCtx)
+	_, rootSpan := p.StartSpan(rootCtx, "task.execute")
+	rootSpan.End()
+
+	spans := exp.GetSpans()
+	require.Len(t, spans, 1, "only the inner span has ended; outer parent stays open")
+	assert.False(t, spans[0].Parent.IsValid(),
+		"new-root span must not inherit OTel parent installed by the outer StartSpan")
+}
+
+// Sanity check: marking a brand-new ctx as new-root is a no-op
+// (nothing to scrub) and produces the same root-trace shape as a
+// plain StartSpan on context.Background. Adapters that silently honor
+// the marker on already-rootless ctx are correct.
+func TestStartSpan_NewRootSpan_PlainCtx_StillProducesRoot(t *testing.T) {
+	p, exp := newRecordingProvider(t)
+	ctx := core.WithNewRootSpan(context.Background())
+
+	_, span := p.StartSpan(ctx, "root-from-empty")
+	span.End()
+
+	spans := exp.GetSpans()
+	require.Len(t, spans, 1)
+	assert.False(t, spans[0].Parent.IsValid(),
+		"new-root on plain ctx must produce a root span")
+}
+
+// The new-root marker composes with StartSpanLinked: the result is a
+// root span (no parent inherited) carrying the supplied links. This is
+// the exact shape ext/tasks uses for task.execute.
+func TestStartSpanLinked_NewRootSpan_EmitsRootWithLinks(t *testing.T) {
+	p, exp := newRecordingProvider(t)
+	parentTC := core.TraceContext{Traceparent: linkTP1}
+	ctx := core.WithTraceContext(context.Background(), parentTC)
+	ctx = core.WithNewRootSpan(ctx)
+
+	links := []core.Link{core.LinkFromTraceContext(parentTC)}
+	_, span := p.StartSpanLinked(ctx, "task.execute", links,
+		core.Attribute{Key: "mcp.task.id", Value: "t-root"},
+	)
+	span.End()
+
+	spans := exp.GetSpans()
+	require.Len(t, spans, 1)
+	assert.False(t, spans[0].Parent.IsValid(),
+		"task.execute must be a root, not a child of the create span")
+	require.Len(t, spans[0].Links, 1, "the link to the create span MUST survive the root-strip")
+	assert.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", spans[0].Links[0].SpanContext.TraceID().String(),
+		"link still points at the originating trace identity")
+}

--- a/ext/tasks/go.mod
+++ b/ext/tasks/go.mod
@@ -2,11 +2,15 @@ module github.com/panyam/mcpkit/ext/tasks
 
 go 1.26.4
 
-require github.com/panyam/mcpkit v0.2.45
+require (
+	github.com/panyam/mcpkit v0.2.45
+	github.com/stretchr/testify v1.11.1
+)
 
 require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/invopop/jsonschema v0.13.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
@@ -14,6 +18,7 @@ require (
 	github.com/panyam/gocurrent v0.1.1 // indirect
 	github.com/panyam/goutils v0.1.8 // indirect
 	github.com/panyam/servicekit v0.1.2 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect

--- a/ext/tasks/tasks.go
+++ b/ext/tasks/tasks.go
@@ -27,6 +27,29 @@ type Config struct {
 	// DefaultPollMs is the suggested poll interval in milliseconds,
 	// returned to clients in CreateTaskResult as pollIntervalMs. Default: 1000 (1 second).
 	DefaultPollMs int
+
+	// TracerProvider opts the runtime into SEP-414 P6 instrumentation of
+	// the async task lifecycle (issue 659). When set, spawnGoAsyncTask
+	// emits a `task.execute` span as a NEW root trace (so the long-running
+	// task work doesn't render as a multi-hour child under a few-ms create
+	// span) carrying a Link back to the originating tools/call create
+	// span. Each tasks/get / tasks/update / tasks/cancel dispatch span
+	// additionally Adds a Link to the originating create span so a backend
+	// can pivot from any poll into the whole task lifecycle.
+	//
+	// Span attributes:
+	//   - `mcp.task.id`     — task identifier
+	//   - `mcp.task.status` — final status stamped at End (completed /
+	//                         failed / cancelled / input_required)
+	//
+	// On the failure paths (handler error, protocol error, panic recover)
+	// the span also gets RecordError so observability backends count it
+	// as an error trace and surface the underlying message.
+	//
+	// Nil or core.NoopTracerProvider{} (the default) skips the install —
+	// zero allocation, no spans emitted. ext/tasks depends on the core
+	// abstraction only; no compile-time dep on ext/otel.
+	TracerProvider core.TracerProvider
 }
 
 func (c *Config) defaults() {
@@ -39,6 +62,9 @@ func (c *Config) defaults() {
 	if c.DefaultPollMs <= 0 {
 		c.DefaultPollMs = 1000
 	}
+	if c.TracerProvider == nil {
+		c.TracerProvider = core.NoopTracerProvider{}
+	}
 }
 
 // v2TaskRuntime holds per-registration state for v2 tasks, shared between
@@ -47,6 +73,11 @@ type v2TaskRuntime struct {
 	store    server.TaskStore
 	registry *server.Registry
 
+	// tp is the optional SEP-414 P6 TracerProvider (issue 659). Defaulted
+	// to core.NoopTracerProvider{} by Config.defaults() so call sites can
+	// unconditionally StartSpanLinked / StartSpan without nil-checking.
+	tp core.TracerProvider
+
 	mu sync.Mutex
 	active   map[string]*activeTask
 	// taskErrors stores protocol-level errors (TaskError) for failed tasks.
@@ -54,15 +85,24 @@ type v2TaskRuntime struct {
 	taskErrors map[string]*core.TaskError
 	// creatorToolForTask maps taskID → tool name for callback dispatch.
 	creatorToolForTask map[string]string
+	// originTC stashes the originating tools/call create-span's trace
+	// context per task. Survives terminal transition (the entry is NOT
+	// cleared in unregister) so polls landing on a finished task still
+	// AddLink back to the original create span. Matches the lifetime of
+	// taskErrors / creatorToolForTask — same coarse "outlives the
+	// goroutine" bucket of post-terminal lookups.
+	originTC map[string]core.TraceContext
 }
 
 func newV2TaskRuntime(cfg Config) *v2TaskRuntime {
 	return &v2TaskRuntime{
 		store:              cfg.Store,
 		registry:           cfg.Server.Registry(),
+		tp:                 cfg.TracerProvider,
 		active:             make(map[string]*activeTask),
 		taskErrors:         make(map[string]*core.TaskError),
 		creatorToolForTask: make(map[string]string),
+		originTC:           make(map[string]core.TraceContext),
 	}
 }
 
@@ -89,6 +129,26 @@ func (rt *v2TaskRuntime) getTaskError(taskID string) *core.TaskError {
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
 	return rt.taskErrors[taskID]
+}
+
+// setOrigin records the originating tools/call create-span's trace
+// identity for taskID. Called once from spawnGoAsyncTask BEFORE the
+// background goroutine starts, so the goroutine and any later
+// tasks/get / tasks/update / tasks/cancel handler can reach it.
+func (rt *v2TaskRuntime) setOrigin(taskID string, tc core.TraceContext) {
+	rt.mu.Lock()
+	rt.originTC[taskID] = tc
+	rt.mu.Unlock()
+}
+
+// getOrigin returns the originating create-span trace context for
+// taskID, or a zero TraceContext when the task was never recorded
+// (sync-as-completed path, unknown ID, or pre-tracing-install task).
+// Adapters silently drop zero links so callers don't have to pre-filter.
+func (rt *v2TaskRuntime) getOrigin(taskID string) core.TraceContext {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	return rt.originTC[taskID]
 }
 
 func (rt *v2TaskRuntime) cancelTask(taskID string) {
@@ -518,9 +578,36 @@ func spawnGoAsyncTask(
 		return core.NewErrorResponse(req.ID, -32603, "failed to create task: "+err.Error()), nil
 	}
 
+	// Capture the originating tools/call dispatch span identity BEFORE
+	// the goroutine spawns — ctx still carries the create span as its
+	// active trace context. Stash on the runtime so the goroutine
+	// (task.execute) and any later tasks/get / update / cancel handler
+	// can build a Link back to it. A zero originTC is fine: adapters
+	// silently drop zero-traceparent links downstream.
+	originTC := core.TraceContextFromContext(ctx)
+	rt.setOrigin(taskID, originTC)
+
 	go func() {
 		bgCtx := core.DetachForBackground(ctx)
 		bgCtx, cancelFunc := context.WithCancel(bgCtx)
+
+		// SEP-414 P6 (issue 659): task.execute is a NEW root trace
+		// linked back to the create span, NOT a child. The work runs
+		// long after the create span ends — nesting it would render as
+		// a multi-hour child under a few-ms parent in observability
+		// backends. WithNewRootSpan tells the adapter to scrub any
+		// inherited parent (the create span's OTel span context
+		// preserved by context.WithoutCancel inside DetachForBackground)
+		// before StartSpanLinked. The link keeps the lifecycle
+		// navigable across the boundary.
+		bgCtx = core.WithNewRootSpan(bgCtx)
+		var links []core.Link
+		if !originTC.IsZero() {
+			links = []core.Link{core.LinkFromTraceContext(originTC)}
+		}
+		bgCtx, taskSpan := core.StartSpanLinked(rt.tp, bgCtx, "task.execute", links,
+			core.Attribute{Key: "mcp.task.id", Value: taskID},
+		)
 
 		// SEP-2663 input-request flow: each v2 task gets its own inputState.
 		// TaskContext.TaskElicit / TaskSample stash pending requests here;
@@ -557,7 +644,18 @@ func spawnGoAsyncTask(
 				rt.setTaskError(taskID, te)
 				store.StoreTerminalResult(taskID, sessionID, core.TaskFailed, core.ErrorResult(msg), msg)
 				notifyV2TaskStatus(bgCtx, rt, store, taskID, sessionID)
+				taskSpan.RecordError(fmt.Errorf("%s", msg))
 			}
+			// Stamp final status from whatever the store ended up with —
+			// covers every terminal path (completed / failed / cancelled)
+			// without the defer having to know which branch ran. Then End
+			// once. Safe even when the goroutine exits before any store
+			// transition (the task stays Working in the store; we record
+			// that and downstream backends see the abandoned span).
+			if info, ok := store.Get(taskID, sessionID); ok {
+				taskSpan.SetAttribute("mcp.task.status", string(info.Status))
+			}
+			taskSpan.End()
 		}()
 
 		resp, mwErr := next(bgCtx, req)
@@ -566,6 +664,7 @@ func spawnGoAsyncTask(
 			rt.setTaskError(taskID, te)
 			store.StoreTerminalResult(taskID, sessionID, core.TaskFailed, core.ErrorResult(mwErr.Error()), mwErr.Error())
 			notifyV2TaskStatus(bgCtx, rt, store, taskID, sessionID)
+			taskSpan.RecordError(mwErr)
 			return
 		}
 		if resp.Error != nil {
@@ -573,6 +672,7 @@ func spawnGoAsyncTask(
 			rt.setTaskError(taskID, te)
 			store.StoreTerminalResult(taskID, sessionID, core.TaskFailed, core.ErrorResult(resp.Error.Message), resp.Error.Message)
 			notifyV2TaskStatus(bgCtx, rt, store, taskID, sessionID)
+			taskSpan.RecordError(fmt.Errorf("%s", resp.Error.Message))
 			return
 		}
 
@@ -588,6 +688,7 @@ func spawnGoAsyncTask(
 			rt.setTaskError(taskID, te)
 			store.StoreTerminalResult(taskID, sessionID, core.TaskFailed, core.ErrorResult(msg), msg)
 			notifyV2TaskStatus(bgCtx, rt, store, taskID, sessionID)
+			taskSpan.RecordError(fmt.Errorf("%s", msg))
 			return
 		}
 
@@ -679,6 +780,13 @@ func makeV2GetHandler(rt *v2TaskRuntime) server.MethodHandler {
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, err.Error())
 		}
 
+		// SEP-414 P6: link this dispatch span back to the originating
+		// tools/call create span so a backend can pivot from any poll
+		// into the task's whole lifecycle. SpanFromContext returns the
+		// dispatch span when TracerProvider is configured, a no-op span
+		// otherwise; AddLink with a zero origin is silently dropped.
+		core.SpanFromContext(ctx).AddLink(core.LinkFromTraceContext(rt.getOrigin(p.TaskID)))
+
 		sid := ctx.SessionID()
 		info, ok := rt.store.Get(p.TaskID, sid)
 		if !ok {
@@ -752,6 +860,10 @@ func makeV2UpdateHandler(rt *v2TaskRuntime) server.MethodHandler {
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, "missing taskId")
 		}
 
+		// SEP-414 P6: link dispatch span back to the create span. See
+		// makeV2GetHandler for the rationale.
+		core.SpanFromContext(ctx).AddLink(core.LinkFromTraceContext(rt.getOrigin(p.TaskID)))
+
 		sid := ctx.SessionID()
 		info, ok := rt.store.Get(p.TaskID, sid)
 		if !ok {
@@ -782,6 +894,10 @@ func makeV2CancelHandler(rt *v2TaskRuntime) server.MethodHandler {
 		if err := json.Unmarshal(params, &p); err != nil {
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, err.Error())
 		}
+
+		// SEP-414 P6: link dispatch span back to the create span. See
+		// makeV2GetHandler for the rationale.
+		core.SpanFromContext(ctx).AddLink(core.LinkFromTraceContext(rt.getOrigin(p.TaskID)))
 
 		// SEP-2663 cancel is idempotent — if the task is already terminal,
 		// return the same empty ack as on an active task so clients don't

--- a/ext/tasks/trace_test.go
+++ b/ext/tasks/trace_test.go
@@ -1,0 +1,670 @@
+package tasks_test
+
+// SEP-414 P6 — ext/tasks span links (issue 659).
+//
+// Each test wires a recording core.TracerProvider into BOTH the server
+// (so the inbound dispatch span exists and SpanFromContext returns it
+// inside v2 method handlers) AND tasks.Register (so spawnGoAsyncTask
+// can emit the task.execute root span). The fake TP records every
+// StartSpan / StartSpanLinked / AddLink / SetAttribute / RecordError /
+// End call so assertions can inspect the full shape without depending
+// on a real OTel SDK exporter — keeps ext/tasks dep-free of ext/otel.
+//
+// End-to-end materialization against a real exporter is proven by
+// ext/otel/provider_test.go (the StartSpanLinked / AddLink / new-root
+// scrub paths all have OTel-SDK-backed coverage). This file proves
+// ext/tasks calls the contract correctly.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/panyam/mcpkit/client"
+	"github.com/panyam/mcpkit/core"
+	. "github.com/panyam/mcpkit/server"
+	tasks "github.com/panyam/mcpkit/ext/tasks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Recording fake TracerProvider ------------------------------------------
+
+type recordedCall struct {
+	name      string
+	links     []core.Link
+	attrs     []core.Attribute
+	rootSpan  bool // ctx was marked WithNewRootSpan when StartSpan(Linked) ran
+	parentTC  core.TraceContext
+	useLinked bool // came in via StartSpanLinked rather than plain StartSpan
+}
+
+type fakeSpan struct {
+	mu       sync.Mutex
+	name     string
+	attrs    map[string]string
+	errors   []error
+	links    []core.Link
+	ended    bool
+	endCount int
+}
+
+func (s *fakeSpan) End() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ended = true
+	s.endCount++
+}
+func (s *fakeSpan) SetAttribute(k, v string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.attrs == nil {
+		s.attrs = map[string]string{}
+	}
+	s.attrs[k] = v
+}
+func (s *fakeSpan) RecordError(err error) {
+	if err == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.errors = append(s.errors, err)
+}
+func (s *fakeSpan) AddLink(l core.Link) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.links = append(s.links, l)
+}
+
+func (s *fakeSpan) attr(k string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.attrs[k]
+}
+func (s *fakeSpan) errCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.errors)
+}
+func (s *fakeSpan) isEnded() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.ended
+}
+func (s *fakeSpan) endTimes() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.endCount
+}
+func (s *fakeSpan) addLinkCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.links)
+}
+
+// fakeTP implements core.TracerProvider AND core.LinkedTracerProvider.
+// Records every call so tests can inspect what ext/tasks asked for.
+type fakeTP struct {
+	mu    sync.Mutex
+	calls []recordedCall
+	spans []*fakeSpan
+}
+
+func (p *fakeTP) StartSpan(ctx context.Context, name string, attrs ...core.Attribute) (context.Context, core.Span) {
+	return p.record(ctx, name, nil, attrs, false)
+}
+
+func (p *fakeTP) StartSpanLinked(ctx context.Context, name string, links []core.Link, attrs ...core.Attribute) (context.Context, core.Span) {
+	return p.record(ctx, name, links, attrs, true)
+}
+
+func (p *fakeTP) record(ctx context.Context, name string, links []core.Link, attrs []core.Attribute, useLinked bool) (context.Context, core.Span) {
+	sp := &fakeSpan{name: name}
+	p.mu.Lock()
+	idx := len(p.spans)
+	p.calls = append(p.calls, recordedCall{
+		name:      name,
+		links:     append([]core.Link(nil), links...),
+		attrs:     append([]core.Attribute(nil), attrs...),
+		rootSpan:  core.IsNewRootSpanRequested(ctx),
+		parentTC:  core.TraceContextFromContext(ctx),
+		useLinked: useLinked,
+	})
+	p.spans = append(p.spans, sp)
+	p.mu.Unlock()
+	// Mirror what the real ext/otel adapter does: publish the new
+	// span's identity on ctx as a core.TraceContext so downstream
+	// callers (spawnGoAsyncTask reading the create-span identity for
+	// task.execute's link) see a non-zero traceparent. Without this
+	// step the fake TP would never produce parent identities to link
+	// to. The synthesized traceparent only has to be W3C-structurally
+	// valid; the parent TraceID portion encodes the call index so each
+	// span gets a distinct identity.
+	synthTC := core.TraceContext{
+		Traceparent: fmt.Sprintf("00-%032d-%016d-01", idx+1, idx+1),
+	}
+	ctx = core.WithTraceContext(ctx, synthTC)
+	return core.WithActiveSpan(ctx, sp), sp
+}
+
+func (p *fakeTP) findCall(name string) *recordedCall {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for i := range p.calls {
+		if p.calls[i].name == name {
+			return &p.calls[i]
+		}
+	}
+	return nil
+}
+
+func (p *fakeTP) findSpan(name string) *fakeSpan {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, sp := range p.spans {
+		if sp.name == name {
+			return sp
+		}
+	}
+	return nil
+}
+
+func (p *fakeTP) lastSpan(name string) *fakeSpan {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	var last *fakeSpan
+	for _, sp := range p.spans {
+		if sp.name == name {
+			last = sp
+		}
+	}
+	return last
+}
+
+func (p *fakeTP) spanCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.spans)
+}
+
+// --- Server fixture parameterized on tools + completion semantics -----------
+
+type traceTestOpts struct {
+	// includes whichever async-eligible tools the test needs:
+	//   "fast-task"  — completes immediately, no blocking
+	//   "fail-task"  — returns an error (handler path failure)
+	//   "panic-task" — panics inside the handler
+	//   "slow-task"  — blocks on releaseSignal until released, useful for cancel
+	includeSlow bool
+	releaseCh   chan struct{}
+}
+
+// newTraceServer builds a server identical in shape to newTaskV2Server but
+// installs `tp` on BOTH server.WithTracerProvider (so the inbound dispatch
+// span exists for v2 method handlers' SpanFromContext) AND
+// tasks.Config.TracerProvider (so the goroutine emits task.execute).
+func newTraceServer(t *testing.T, tp core.TracerProvider, opts traceTestOpts) *Server {
+	t.Helper()
+	srv := NewServer(
+		core.ServerInfo{Name: "tasks-v2-trace", Version: "0.0.1"},
+		WithTracerProvider(tp),
+	)
+
+	// Every tool follows the SEP-2663 Option-2 two-phase shape:
+	//   - first sync invocation (no TaskContext on ctx) → return
+	//     core.GoAsyncResult{} to opt into background continuation.
+	//   - goroutine re-invocation (TaskContext present) → do the
+	//     actual work and return a sync ToolResult.
+	// This is the shape the existing newTaskV2ServerWithSlow fixture
+	// uses; we mirror it so each new tool exercises the
+	// spawnGoAsyncTask path the span instrumentation lives on.
+
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "fast-task",
+			Description: "Async-eligible, completes immediately in the goroutine",
+			InputSchema: map[string]any{"type": "object"},
+			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
+		},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+			if tasks.GetTaskContext(ctx) == nil {
+				return core.GoAsyncResult{}, nil
+			}
+			return core.TextResult("fast-done"), nil
+		},
+	)
+
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "fail-task",
+			Description: "Async-eligible, handler returns an error in the goroutine",
+			InputSchema: map[string]any{"type": "object"},
+			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
+		},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+			if tasks.GetTaskContext(ctx) == nil {
+				return core.GoAsyncResult{}, nil
+			}
+			return nil, errors.New("intentional handler failure")
+		},
+	)
+
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "panic-task",
+			Description: "Async-eligible, handler panics in the goroutine",
+			InputSchema: map[string]any{"type": "object"},
+			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
+		},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+			if tasks.GetTaskContext(ctx) == nil {
+				return core.GoAsyncResult{}, nil
+			}
+			panic("intentional handler panic")
+		},
+	)
+
+	// sync-task is the wrapSyncAsCompletedTask path: handler returns a
+	// plain ToolResult on the FIRST invocation (no GoAsync sentinel), so
+	// the middleware mints a task that's born terminal — no goroutine,
+	// no task.execute span. Used by TestTrace_SyncAsCompletedTask_NoExecuteSpan
+	// to pin the "work inside the create span doesn't get a separate
+	// span" guard.
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "sync-task",
+			Description: "Async-eligible, completes synchronously (no GoAsync)",
+			InputSchema: map[string]any{"type": "object"},
+			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
+		},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+			return core.TextResult("sync-done"), nil
+		},
+	)
+
+	if opts.includeSlow {
+		release := opts.releaseCh
+		srv.RegisterTool(
+			core.ToolDef{
+				Name:        "slow-task",
+				Description: "Async-eligible, blocks until released or ctx cancelled",
+				InputSchema: map[string]any{"type": "object"},
+				Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
+			},
+			func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+				if tasks.GetTaskContext(ctx) == nil {
+					return core.GoAsyncResult{}, nil
+				}
+				select {
+				case <-release:
+					return core.TextResult("slow-done"), nil
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+			},
+		)
+	}
+
+	tasks.Register(tasks.Config{Server: srv, TracerProvider: tp, DefaultPollMs: 25})
+	return srv
+}
+
+func connectTraceClient(t *testing.T, srv *Server) *client.Client {
+	t.Helper()
+	handler := srv.Handler(WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "v2-trace", Version: "0.0.1"},
+		client.WithTasksExtension())
+	require.NoError(t, c.Connect())
+	t.Cleanup(func() { c.Close() })
+	return c
+}
+
+func mustCreateTask(t *testing.T, c *client.Client, toolName string) string {
+	t.Helper()
+	res, err := c.Call("tools/call", map[string]any{
+		"name":      toolName,
+		"arguments": map[string]any{},
+	})
+	require.NoError(t, err)
+	var ctr core.CreateTaskResult
+	require.NoError(t, json.Unmarshal(res.Raw, &ctr))
+	require.NotEmpty(t, ctr.TaskID)
+	return ctr.TaskID
+}
+
+// waitForCondition polls cond every 5ms up to 1s. Returns true when cond
+// returns true, false on timeout. Used instead of fixed sleeps so tests
+// don't fall over on slow CI.
+func waitForCondition(cond func() bool) bool {
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return false
+}
+
+func waitForTaskTerminal(t *testing.T, c *client.Client, taskID string) core.DetailedTask {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		res, err := c.Call("tasks/get", map[string]any{"taskId": taskID})
+		require.NoError(t, err)
+		var dt core.DetailedTask
+		require.NoError(t, json.Unmarshal(res.Raw, &dt))
+		if dt.Status.IsTerminal() || dt.Status == core.TaskInputRequired {
+			return dt
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("task %s never reached terminal", taskID)
+	return core.DetailedTask{}
+}
+
+// --- Tests ------------------------------------------------------------------
+
+// TestTrace_GoAsync_Completion: task.execute span is emitted on the GoAsync
+// path, via the LinkedTracerProvider path (not plain StartSpan), is marked
+// as a NEW root (so the OTel adapter would scrub the inherited parent),
+// carries a Link back to the originating create span, and ends with
+// mcp.task.status="completed" stamped exactly once.
+func TestTrace_GoAsync_Completion(t *testing.T) {
+	tp := &fakeTP{}
+	srv := newTraceServer(t, tp, traceTestOpts{})
+	c := connectTraceClient(t, srv)
+
+	taskID := mustCreateTask(t, c, "fast-task")
+	waitForTaskTerminal(t, c, taskID)
+
+	// task.execute span emission
+	call := tp.findCall("task.execute")
+	require.NotNil(t, call, "task.execute span must be emitted on the GoAsync path")
+	assert.True(t, call.useLinked, "task.execute MUST come in via StartSpanLinked, not plain StartSpan")
+	assert.True(t, call.rootSpan, "bgCtx MUST be marked WithNewRootSpan so the OTel adapter scrubs the inherited parent")
+	require.Len(t, call.links, 1, "task.execute MUST carry exactly one Link back to the create span")
+	assert.NotEmpty(t, call.links[0].TraceContext.Traceparent, "linked TraceContext must reflect a non-zero create-span traceparent")
+
+	// mcp.task.id attribute set at StartSpan time
+	var foundID bool
+	for _, a := range call.attrs {
+		if a.Key == "mcp.task.id" {
+			assert.Equal(t, taskID, a.Value)
+			foundID = true
+		}
+	}
+	assert.True(t, foundID, "task.execute span MUST carry mcp.task.id at start")
+
+	// Terminal status + End
+	sp := tp.findSpan("task.execute")
+	require.NotNil(t, sp)
+	require.True(t, waitForCondition(func() bool { return sp.isEnded() }),
+		"task.execute span must End once the goroutine terminates")
+	assert.Equal(t, string(core.TaskCompleted), sp.attr("mcp.task.status"),
+		"mcp.task.status MUST reflect the final terminal status (completed)")
+	assert.Equal(t, 1, sp.endTimes(), "End MUST be called exactly once")
+	assert.Equal(t, 0, sp.errCount(), "completion path MUST NOT call RecordError")
+}
+
+// TestTrace_GoAsync_HandlerError pins v2 semantics for handler-returned
+// errors: SEP-2663 treats `(nil, err)` from a tool handler as a
+// COMPLETED task whose ToolResult carries IsError=true — NOT a "failed"
+// task. The "failed" status (and the matching span RecordError) is
+// reserved for protocol-level errors (mwErr, resp.Error, unexpected
+// result shape, panic recover). The span still ends cleanly with
+// mcp.task.status="completed". The panic / protocol-error coverage
+// lives in TestTrace_GoAsync_Panic.
+func TestTrace_GoAsync_HandlerError(t *testing.T) {
+	tp := &fakeTP{}
+	srv := newTraceServer(t, tp, traceTestOpts{})
+	c := connectTraceClient(t, srv)
+
+	taskID := mustCreateTask(t, c, "fail-task")
+	waitForTaskTerminal(t, c, taskID)
+
+	sp := tp.findSpan("task.execute")
+	require.NotNil(t, sp)
+	require.True(t, waitForCondition(func() bool { return sp.isEnded() }))
+	assert.Equal(t, string(core.TaskCompleted), sp.attr("mcp.task.status"),
+		"handler-returned errors are v2 'completed' (IsError=true on the inner ToolResult), not 'failed'")
+	assert.Equal(t, 0, sp.errCount(),
+		"RecordError is reserved for protocol-level failures; handler errors flow through completion")
+}
+
+// TestTrace_GoAsync_Panic: handler panics → goroutine recovers, RecordError
+// fires for the panic, span Ends with mcp.task.status="failed". The recover
+// branch and the goroutine's exit are distinct code paths; both must
+// converge on a single End call.
+func TestTrace_GoAsync_Panic(t *testing.T) {
+	tp := &fakeTP{}
+	srv := newTraceServer(t, tp, traceTestOpts{})
+	c := connectTraceClient(t, srv)
+
+	// panic-task call may itself surface a synthesized error in the
+	// initial response; the goroutine still spawns and emits the span,
+	// which is what we're asserting on. Ignore the call's own error.
+	res, err := c.Call("tools/call", map[string]any{
+		"name":      "panic-task",
+		"arguments": map[string]any{},
+	})
+	require.NoError(t, err)
+	var ctr core.CreateTaskResult
+	require.NoError(t, json.Unmarshal(res.Raw, &ctr))
+	require.NotEmpty(t, ctr.TaskID)
+	waitForTaskTerminal(t, c, ctr.TaskID)
+
+	sp := tp.findSpan("task.execute")
+	require.NotNil(t, sp)
+	require.True(t, waitForCondition(func() bool { return sp.isEnded() }))
+	assert.Equal(t, string(core.TaskFailed), sp.attr("mcp.task.status"))
+	assert.Equal(t, 1, sp.endTimes(),
+		"panic recover + terminal stamp converge on a single End call (defer guards against double-End)")
+}
+
+// TestTrace_GoAsync_Cancel: cancelling the task via tasks/cancel transitions
+// the store to cancelled, the goroutine's ctx is cancelled, the handler
+// returns ctx.Err(), and the span ends with mcp.task.status="cancelled".
+func TestTrace_GoAsync_Cancel(t *testing.T) {
+	tp := &fakeTP{}
+	release := make(chan struct{})
+	srv := newTraceServer(t, tp, traceTestOpts{includeSlow: true, releaseCh: release})
+	c := connectTraceClient(t, srv)
+
+	taskID := mustCreateTask(t, c, "slow-task")
+
+	// Wait for the goroutine to actually start before cancelling — the
+	// task.execute span has to exist before we can assert it ended.
+	require.True(t, waitForCondition(func() bool {
+		return tp.findCall("task.execute") != nil
+	}), "task.execute span must be emitted before cancel")
+
+	_, err := c.Call("tasks/cancel", map[string]any{"taskId": taskID})
+	require.NoError(t, err)
+
+	sp := tp.findSpan("task.execute")
+	require.NotNil(t, sp)
+	require.True(t, waitForCondition(func() bool { return sp.isEnded() }),
+		"cancelled task.execute must End once the goroutine exits")
+	assert.Equal(t, string(core.TaskCancelled), sp.attr("mcp.task.status"))
+
+	// Release the channel so the (already-cancelled) handler's select
+	// can return without leaking the goroutine into other tests.
+	close(release)
+}
+
+// TestTrace_TasksGet_AddsLink: tasks/get dispatch span receives one AddLink
+// back to the originating create span so backends can navigate
+// poll → lifecycle. With TracerProvider configured on the server, the
+// dispatch span is the active span returned by core.SpanFromContext inside
+// the handler.
+func TestTrace_TasksGet_AddsLink(t *testing.T) {
+	tp := &fakeTP{}
+	srv := newTraceServer(t, tp, traceTestOpts{})
+	c := connectTraceClient(t, srv)
+
+	taskID := mustCreateTask(t, c, "fast-task")
+	waitForTaskTerminal(t, c, taskID)
+
+	// Snapshot AddLink counts on existing spans before tasks/get so the
+	// assertion isolates the new link to the just-issued request.
+	preLinkCounts := map[*fakeSpan]int{}
+	for _, sp := range tp.spans {
+		preLinkCounts[sp] = sp.addLinkCount()
+	}
+
+	_, err := c.Call("tasks/get", map[string]any{"taskId": taskID})
+	require.NoError(t, err)
+
+	// Find the dispatch span that gained an AddLink.
+	var pollSpan *fakeSpan
+	for _, sp := range tp.spans {
+		if sp.addLinkCount() > preLinkCounts[sp] {
+			pollSpan = sp
+			break
+		}
+	}
+	require.NotNil(t, pollSpan, "tasks/get dispatch span MUST receive an AddLink back to the create span")
+}
+
+// TestTrace_TasksUpdate_AddsLink mirrors the tasks/get AddLink assertion
+// for tasks/update. The handler validates inputs against a non-terminal
+// task; we don't drive a real input-response flow here because the link
+// emission is unconditional on parse success.
+func TestTrace_TasksUpdate_AddsLink(t *testing.T) {
+	tp := &fakeTP{}
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	srv := newTraceServer(t, tp, traceTestOpts{includeSlow: true, releaseCh: release})
+	c := connectTraceClient(t, srv)
+
+	taskID := mustCreateTask(t, c, "slow-task")
+	require.True(t, waitForCondition(func() bool {
+		return tp.findCall("task.execute") != nil
+	}), "task.execute span must emit before tasks/update")
+
+	preLinkCounts := map[*fakeSpan]int{}
+	for _, sp := range tp.spans {
+		preLinkCounts[sp] = sp.addLinkCount()
+	}
+
+	// Send tasks/update with no input responses — the AddLink fires before
+	// the body is processed. The handler may return an error (task isn't
+	// in input_required), but the link emission is what we're asserting.
+	_, _ = c.Call("tasks/update", map[string]any{"taskId": taskID, "inputResponses": map[string]any{}})
+
+	var updateSpan *fakeSpan
+	for _, sp := range tp.spans {
+		if sp.addLinkCount() > preLinkCounts[sp] {
+			updateSpan = sp
+			break
+		}
+	}
+	require.NotNil(t, updateSpan, "tasks/update dispatch span MUST receive an AddLink back to the create span")
+}
+
+// TestTrace_TasksCancel_AddsLink mirrors the AddLink assertion for
+// tasks/cancel.
+func TestTrace_TasksCancel_AddsLink(t *testing.T) {
+	tp := &fakeTP{}
+	release := make(chan struct{})
+	srv := newTraceServer(t, tp, traceTestOpts{includeSlow: true, releaseCh: release})
+	c := connectTraceClient(t, srv)
+
+	taskID := mustCreateTask(t, c, "slow-task")
+	require.True(t, waitForCondition(func() bool {
+		return tp.findCall("task.execute") != nil
+	}))
+
+	preLinkCounts := map[*fakeSpan]int{}
+	for _, sp := range tp.spans {
+		preLinkCounts[sp] = sp.addLinkCount()
+	}
+
+	_, err := c.Call("tasks/cancel", map[string]any{"taskId": taskID})
+	require.NoError(t, err)
+	close(release)
+
+	var cancelSpan *fakeSpan
+	for _, sp := range tp.spans {
+		if sp.addLinkCount() > preLinkCounts[sp] {
+			cancelSpan = sp
+			break
+		}
+	}
+	require.NotNil(t, cancelSpan, "tasks/cancel dispatch span MUST receive an AddLink back to the create span")
+}
+
+// TestTrace_SyncAsCompletedTask_NoExecuteSpan: when the handler returns a
+// plain ToolResult (no GoAsync sentinel) we still mint a task envelope so
+// the wire shape stays uniform, but we do NOT emit task.execute — the
+// "work that escapes the request span" framing in issue 659 does not
+// apply to the synchronous path. The dispatch span already covers it.
+func TestTrace_SyncAsCompletedTask_NoExecuteSpan(t *testing.T) {
+	tp := &fakeTP{}
+	srv := newTraceServer(t, tp, traceTestOpts{})
+	c := connectTraceClient(t, srv)
+
+	// sync-task returns a plain ToolResult on the FIRST handler
+	// invocation, so wrapSyncAsCompletedTask is the branch taken — no
+	// goroutine spawns, no task.execute span is emitted. The dispatch
+	// span already covers the work; emitting an additional zero-
+	// duration span would be noise.
+	_ = mustCreateTask(t, c, "sync-task")
+	time.Sleep(50 * time.Millisecond) // beat for any background work
+
+	assert.Nil(t, tp.findCall("task.execute"),
+		"wrapSyncAsCompletedTask path MUST NOT emit task.execute — the work lives inside the create span")
+}
+
+// TestTrace_NoopTracerProvider_NoSpansEmitted pins the zero-overhead
+// contract: leaving Config.TracerProvider unset (or core.NoopTracerProvider)
+// emits no spans, even on the GoAsync path. The existing test suite
+// already exercises the unconfigured path; this test makes the contract
+// explicit so a future refactor doesn't silently start emitting spans
+// against an unconfigured registration.
+func TestTrace_NoopTracerProvider_NoSpansEmitted(t *testing.T) {
+	srv := NewServer(core.ServerInfo{Name: "tasks-v2-noop", Version: "0.0.1"})
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "fast-task",
+			Description: "Async-eligible, goes through the GoAsync path",
+			InputSchema: map[string]any{"type": "object"},
+			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
+		},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+			if tasks.GetTaskContext(ctx) == nil {
+				return core.GoAsyncResult{}, nil
+			}
+			return core.TextResult("fast-done"), nil
+		},
+	)
+	// No TracerProvider on either Server or Config — defaults route to Noop.
+	tasks.Register(tasks.Config{Server: srv, DefaultPollMs: 25})
+
+	handler := srv.Handler(WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "v2-noop", Version: "0.0.1"},
+		client.WithTasksExtension())
+	require.NoError(t, c.Connect())
+	defer c.Close()
+
+	taskID := mustCreateTask(t, c, "fast-task")
+	waitForTaskTerminal(t, c, taskID)
+
+	// Nothing to assert about a span here — the contract is "no panic, no
+	// allocation, no install." The compile-time path that calls
+	// core.StartSpanLinked on core.NoopTracerProvider returns a noopSpan;
+	// the assertion is that the call completed without error.
+}


### PR DESCRIPTION
## What changes

ext/tasks gains optional SEP-414 P6 trace instrumentation. When a TracerProvider is configured (`Config.TracerProvider`), every background-spawned task emits a `task.execute` span as a **NEW root trace** linked back to the originating `tools/call` create span, and every `tasks/get` / `tasks/update` / `tasks/cancel` dispatch span gets an `AddLink` back to the same create span so a backend can pivot from any poll into the whole task lifecycle. Span attributes: `mcp.task.id` (at start), `mcp.task.status` (at End). `RecordError` fires on protocol-level failures (mwErr, resp.Error, unexpected result shape, panic recover). Nil or `core.NoopTracerProvider{}` = zero overhead, no install — the existing test suite stays green without touching the option.

```mermaid
sequenceDiagram
    participant C as Client
    participant S as Server (dispatch span)
    participant G as Goroutine (task.execute root)
    C->>S: tools/call (creates task)
    S-->>S: dispatch span "tools/call"
    S->>G: spawn goroutine (WithNewRootSpan + Link → dispatch)
    S-->>C: CreateTaskResult
    Note over G: task.execute<br/>(root trace, link → dispatch)<br/>mcp.task.id, mcp.task.status
    C->>S: tasks/get
    S-->>S: dispatch span "tasks/get"<br/>AddLink → original dispatch
    S-->>C: DetailedTask
```

## Reviewer's guide

Read in this order:

1. [core/trace.go](https://github.com/panyam/mcpkit/pull/719/files#diff-acb99666fd2aacc85eaf8e433236a74d28959ca5e1e0d5e14913cdd5fb9e81c0) — new `WithNewRootSpan` / `IsNewRootSpanRequested` helpers (the contract complement to issue 662). One small surface, well-documented; the body is two `context.Value` wraps.
2. [ext/otel/provider.go](https://github.com/panyam/mcpkit/pull/719/files#diff-09d1629d66151e0e38509a6bf451d8a9bb42346a8d716d9b3878d24c87d705ca) — three-line refinement in `startSpanInternal` honors the marker by stripping the OTel parent SpanContext before `tracer.Start`. Without this, `context.WithoutCancel` inside `DetachForBackground` would silently re-parent `task.execute` under the (now-ended) create span.
3. [ext/otel/provider_test.go](https://github.com/panyam/mcpkit/pull/719/files#diff-5d343f081b6ad0d5a5ebe07b861744fd5409321007096274afb10b3be807f966) — five new tests pinning the scrub behavior end-to-end against a real OTel SDK exporter. The regression-guard test (inheriting-from-TraceContext) proves the default path still parents under inbound trace context.
4. [ext/tasks/tasks.go](https://github.com/panyam/mcpkit/pull/719/files#diff-6b15314e7b637ac95e29f77601d89c4731b2aa4943266a4013345595095df47b) — `Config.TracerProvider` + runtime threading (`tp`, `originTC` map, `setOrigin` / `getOrigin`); `spawnGoAsyncTask` captures the create-span identity before spawn, marks bgCtx with `WithNewRootSpan`, emits `task.execute` via `core.StartSpanLinked`, defers terminal-stamp + End; the three v2 handlers add the back-link via `core.SpanFromContext(ctx).AddLink(...)`.
5. [ext/tasks/trace_test.go](https://github.com/panyam/mcpkit/pull/719/files#diff-d5ae30c7969c7c0173f612e69db808b7c491bfecf70468079604105c5518589b) — recording fake `core.TracerProvider` + `core.LinkedTracerProvider` proves ext/tasks calls the contract correctly. End-to-end materialization against a real exporter is already proven by [ext/otel/provider_test.go](https://github.com/panyam/mcpkit/pull/719/files#diff-5d343f081b6ad0d5a5ebe07b861744fd5409321007096274afb10b3be807f966)'s coverage of `StartSpanLinked` / `AddLink` / new-root scrub.

Skim: [core/trace_test.go](https://github.com/panyam/mcpkit/pull/719/files#diff-3691b83b37fde48b68242c223380c4e2e18a58ccb618ba6495ecfaa631577ea9) (3 small tests for the new helpers), [ext/tasks/go.mod](https://github.com/panyam/mcpkit/pull/719/files#diff-0c779013bc641ffd1a054e5151918bf3e0df094b792eb6939e1e9f7273686510) (testify added — used by the new test file).

## Decision log

- **Why a new `WithNewRootSpan` marker instead of reusing `WithTraceContext(ctx, zero)` semantics**: `WithTraceContext(ctx, zero)` already documents "scrub", but the present-vs-absent distinction on a single ctx value leaks an awkward two-meaning into a `TraceContext` accessor most consumers don't need. A dedicated marker makes intent explicit at call sites and at the adapter boundary.
- **Why bundle the core/ext-otel contract complement with the ext/tasks consumer work**: the ext/otel-side scrub is a 3-line change with one new public helper; landing it as its own PR would double the review overhead with no clarity gain. Same composition the umbrella has used for the other P6 children (#658 paired with #661, #659 paired with #662).
- **Why `task.execute` is emitted only on the GoAsync path**: `wrapSyncAsCompletedTask` returns inside the create span — the work doesn't "escape the request span" (the framing in issue 659). Emitting a zero-duration `task.execute` for the sync path would be noise.
- **Why `originTC` outlives `active[taskID]`** (lives in its own map alongside `taskErrors` / `creatorToolForTask`, NOT inside `activeTask`): polls landing on a terminal task still need the AddLink back to the create span. The TaskStore handles TTL-based cleanup of the underlying task; the runtime maps follow the existing convention of growing until process restart (pre-existing pattern, not regressed by this PR).
- **Why fake `core.TracerProvider` in ext/tasks tests, not a real OTel exporter**: ext/tasks's `go.mod` does not depend on ext/otel today. The contract surface is `core.LinkedTracerProvider` / `core.SpanFromContext` — `ext/otel/provider_test.go` already proves the contract maps correctly to OTel SDK semantics. This PR's fake-TP tests prove ext/tasks calls the contract correctly.
- **Why v2 handler-returned errors (`(nil, err)`) result in `mcp.task.status="completed"`, not `"failed"`**: SEP-2663 maps handler errors to `ToolResult.IsError=true` on a completed task; only protocol-level errors (mwErr, resp.Error, unexpected result shape, panic recover) become `"failed"`. The fail-task test pins this; the panic-task test covers the RecordError + failed path.

## Risk / blast radius

- **Affects**: ext/tasks goroutine path, ext/otel `startSpanInternal`, the `core.WithTraceContext(ctx, zero)`-as-scrub contract for OTel-backed callers.
- **Backwards compat**: every change is additive when `Config.TracerProvider` is unset (the default, including pre-existing registrations). All existing tests pass without touching the option.
- **Tests covering this**: 8 new `TestTrace_*` tests in `ext/tasks/trace_test.go`; 3 new `TestWithNewRootSpan_*` in `core/trace_test.go`; 5 new `TestStartSpan*_NewRootSpan_*` + 1 regression-guard in `ext/otel/provider_test.go`. Red-before-green confirmed: stashing the adapter change makes the new ext/otel tests fail with parent-leak; stashing the ext/tasks consumer code makes the new ext/tasks tests fail to compile.
- **Be paranoid about**: existing tests that may have relied on the latent "WithTraceContext(ctx, zero) is a no-op against OTel parent" behavior — `make test`, `ext/tasks`, `ext/otel` suites all pass; no fixture changes needed.

## Before / after

```
$ make test && (cd ext/tasks && go test ./...) && (cd ext/otel && go test ./...)
ok  	github.com/panyam/mcpkit/client      8.936s
ok  	github.com/panyam/mcpkit/core        0.675s
ok  	github.com/panyam/mcpkit/server     11.363s
ok  	github.com/panyam/mcpkit/server/stateless  0.744s
ok  	github.com/panyam/mcpkit/testutil    1.188s
ok  	github.com/panyam/mcpkit/ext/tasks   0.946s
ok  	github.com/panyam/mcpkit/ext/otel    0.392s
```

## Out of scope (deliberately deferred)

- **End-to-end exporter walkthrough** (e.g. `examples/otel/tasks/`) — the contract is proven both sides; a polished demo + Tempo screenshots fit a follow-up alongside other examples/otel/ work.
- **Memory growth of `originTC` map after terminal** — matches the pre-existing `taskErrors` / `creatorToolForTask` lifecycle; not introduced by this PR. File a follow-up if production usage warrants TTL.
- **Conformance suite for SEP-414 tracing** — tracked separately on issue 429.
- **Span links from the events bus** (#642 / #629) — independent surface, available to consume the same `core.LinkedTracerProvider` contract.

Closes issue 659. Part of the SEP-414 P6 umbrella (663).
