### PR TITLE
ext/events/stores/redis: Redis-backed QuotaStore (issue 718)

### DIFF
--- a/experimental/ext/events/STORAGE_SEAMS.md
+++ b/experimental/ext/events/STORAGE_SEAMS.md
@@ -100,7 +100,7 @@ The other seams (626, 631) follow this template. Reviews check against this file
 |---|---|---|
 | In-memory (default) | All seams | Each seam's own file in this directory |
 | GORM (Postgres + SQLite) | `WebhookStore`, `QuotaStore` | `stores/gorm/` (own go.mod; GORM dependency stays out of the events lib) |
-| Redis | `Emitter` pubsub (`stores/redis/`) | Issue 634 — `Emitter` landed; `QuotaStore` deferred to a separate follow-up |
+| Redis | `Emitter` pubsub + `QuotaStore` atomic counters (`stores/redis/`) | Issue 634 (Emitter) + issue 718 (QuotaStore) |
 
 ## Adjacent seams (not storage, same code conventions)
 

--- a/experimental/ext/events/stores/redis/README.md
+++ b/experimental/ext/events/stores/redis/README.md
@@ -87,6 +87,27 @@ Trace context propagates across the Redis pubsub hop end-to-end:
 
 Caller-set precedence: if you explicitly stamped `_meta.traceparent` on an event before calling `Emit`, that value wins — the publisher will NOT overwrite it. Mirrors `core.InjectTraceContextIntoParams`'s "caller-set wins" rule for MCP wire calls.
 
+## Quota
+
+`NewQuotaStore(opts)` returns an `events.QuotaStore` backed by Redis atomic counters. Per-tuple key: `<ChannelPrefix>.quota.<principal>.<eventName>`.
+
+```go
+qs, _ := redisstore.NewQuotaStore(opts)
+cfg.Quota = events.NewQuota(qs, events.WithMaxSubscriptionsPerPrincipal("chat.message", 5))
+```
+
+**Atomic primitives.** `ReserveQuota` and `ReleaseQuota` each run a Lua script server-side via `EVALSHA` (with `EVAL` fallback on `NOSCRIPT`). One round trip per call; the check + increment + EXPIRE on Reserve, and decrement + delete-if-zero on Release, all happen atomically on the Redis side. Concurrent `Reserve`s on the same key under high contention never over-grant.
+
+**Sliding TTL** (`Options.QuotaTTL`, default `1h`). Every successful `Reserve` refreshes the counter's TTL — active counters never expire under load. A counter that's been leaked (caller crashed before `Release`) drops after `QuotaTTL` of inactivity. Set `QuotaTTL` shorter for faster leak recovery, longer for safer tolerance of slow Reserve→Release loops.
+
+**Release semantics.** `Release` at zero is a silent no-op (matches the in-memory store's contract — `double-Release` shouldn't underflow). When `Release` brings the counter to zero, the script deletes the key so `redis-cli KEYS` doesn't show drifted zero rows.
+
+**Out of scope for v1:**
+
+- Cluster-aware key sharding (hash-tag co-location)
+- Sliding-window quotas (this is fixed-bucket — same as the in-memory + GORM defaults)
+- Cross-tenant aggregate quotas
+
 ### Redis-client-level spans (opt-in)
 
 The pubsub-level trace propagation above stitches publisher → subscriber across the Redis hop. To also see per-`PUBLISH` and per-`SUBSCRIBE` spans on the Redis client itself (latency to Redis, command parsing, etc.), wire `redisotel.InstrumentTracing` on the client BEFORE handing it to `Options.Client`:

--- a/experimental/ext/events/stores/redis/options.go
+++ b/experimental/ext/events/stores/redis/options.go
@@ -2,6 +2,7 @@ package redisstore
 
 import (
 	"encoding/json"
+	"time"
 
 	"github.com/redis/go-redis/v9"
 
@@ -12,6 +13,15 @@ import (
 // channels are organized. Per-event channel name is
 // "<prefix>.<event.Name>" — see channelFor.
 const DefaultChannelPrefix = "mcpkit.events"
+
+// DefaultQuotaTTL is the default leak-survival window for
+// QuotaStore-managed counter keys. Long enough that a legitimate
+// slow Reserve → Release loop never trips it; short enough that a
+// leaked Reserve (caller crashed before releasing) drops within a
+// typical operator shift. Sliding — every Reserve refreshes the
+// TTL on the counter key, so active counters never expire under
+// load.
+const DefaultQuotaTTL = time.Hour
 
 // Options bundles configuration for both Publisher and Subscriber.
 // Client is required; everything else has a working default.
@@ -39,6 +49,15 @@ type Options struct {
 	// failure, etc.). Default: a no-op logger. Wire log.Printf or a
 	// structured logger when debugging multi-replica setups.
 	Logger func(format string, args ...any)
+
+	// QuotaTTL is the sliding-window TTL the QuotaStore applies to
+	// each counter key on every Reserve. Default DefaultQuotaTTL (1
+	// hour). A leaked Reserve (caller crashed before Release) drops
+	// after this many seconds of inactivity; active counters never
+	// expire under load because EXPIRE is refreshed on every Reserve.
+	// Set to 0 to use the default; negative values are invalid and
+	// will produce an error from NewQuotaStore.
+	QuotaTTL time.Duration
 }
 
 // withDefaults returns a copy of opts with zero-valued fields filled
@@ -55,7 +74,18 @@ func (o Options) withDefaults() Options {
 	if o.Logger == nil {
 		o.Logger = func(string, ...any) {}
 	}
+	if o.QuotaTTL == 0 {
+		o.QuotaTTL = DefaultQuotaTTL
+	}
 	return o
+}
+
+// quotaKeyFor returns the Redis key holding the counter for the given
+// (principal, eventName). Lives under "<ChannelPrefix>.quota.<...>"
+// so the events lib's logical namespace stays consistent across
+// pubsub channels and quota keys.
+func (o Options) quotaKeyFor(principal, eventName string) string {
+	return o.ChannelPrefix + ".quota." + principal + "." + eventName
 }
 
 // channelFor returns the Redis channel name an event with the given

--- a/experimental/ext/events/stores/redis/quota_store.go
+++ b/experimental/ext/events/stores/redis/quota_store.go
@@ -1,0 +1,149 @@
+package redisstore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/redis/go-redis/v9"
+
+	"github.com/panyam/mcpkit/experimental/ext/events"
+)
+
+// reserveScript is the Lua atomic primitive backing ReserveQuota.
+// One round trip — Redis runs the body to completion before any
+// other command on the same key, so the check + increment can't
+// race against concurrent Reserves under any client load.
+//
+// KEYS[1] is the counter key. ARGV[1] is the cap (Max from the
+// request). ARGV[2] is the sliding TTL window in seconds.
+//
+// Returns a two-element array:
+//
+//	{1, count}   — granted, count is the post-increment value
+//	{0, count}   — rejected (count >= Max), count is the value
+//	               that blocked the reservation
+//
+// EXPIRE is applied on every Reserve so the TTL slides forward with
+// activity. A leaked Reserve (caller crashed before Release) drops
+// after Options.QuotaTTL of inactivity; active counters stay alive
+// under load.
+var reserveScript = redis.NewScript(`
+local current = tonumber(redis.call("GET", KEYS[1]) or "0")
+local max = tonumber(ARGV[1])
+if current >= max then
+  return {0, current}
+end
+local next = redis.call("INCR", KEYS[1])
+redis.call("EXPIRE", KEYS[1], ARGV[2])
+return {1, next}
+`)
+
+// releaseScript decrements the counter and deletes the key when the
+// post-decrement value is <= 0. Two ops in one server-side execution
+// — keeps Redis's KEYS view clean (no zero-value rows lying around)
+// and removes the timing window between DECR returning 0 and a
+// concurrent Reserve observing it.
+//
+// Release at zero is a benign no-op (matches the in-memory store's
+// contract: double-release shouldn't underflow). If GET returns nil
+// (key already expired or never existed), the script returns 0
+// without touching anything.
+var releaseScript = redis.NewScript(`
+local current = tonumber(redis.call("GET", KEYS[1]) or "0")
+if current <= 0 then
+  return 0
+end
+local next = redis.call("DECR", KEYS[1])
+if next <= 0 then
+  redis.call("DEL", KEYS[1])
+end
+return next
+`)
+
+// QuotaStore implements events.QuotaStore over Redis atomic counters.
+// One key per (Principal, EventName) tuple under
+// "<Options.ChannelPrefix>.quota.<principal>.<eventName>".
+//
+// ReserveQuota and ReleaseQuota are both atomic via per-call Lua
+// scripts cached at process startup (EVALSHA, with EVAL fallback on
+// NOSCRIPT). CountQuota is a plain GET — no atomicity needed for
+// inspection.
+type QuotaStore struct {
+	opts Options
+}
+
+// NewQuotaStore returns a Redis-backed events.QuotaStore. Returns an
+// error when Options.Client is nil or Options.QuotaTTL is negative.
+// Zero QuotaTTL means "use DefaultQuotaTTL" (1 hour).
+func NewQuotaStore(opts Options) (*QuotaStore, error) {
+	if opts.Client == nil {
+		return nil, errors.New("redisstore.NewQuotaStore: Options.Client is required")
+	}
+	if opts.QuotaTTL < 0 {
+		return nil, fmt.Errorf("redisstore.NewQuotaStore: Options.QuotaTTL must be >= 0; got %s", opts.QuotaTTL)
+	}
+	return &QuotaStore{opts: opts.withDefaults()}, nil
+}
+
+// ReserveQuota claims one slot for (Principal, EventName) only if
+// the current count is strictly less than Max. Atomic via a Lua
+// script — concurrent Reserves on the same key never race. Refreshes
+// the key's TTL on success so active counters slide forward with
+// activity.
+//
+// Returns Granted=true + the post-increment Count on success;
+// Granted=false + the blocking Count on cap. Storage errors (Redis
+// connection drop, NOSCRIPT mid-script-cache transition) surface as
+// the second return.
+func (s *QuotaStore) ReserveQuota(ctx context.Context, req events.ReserveQuotaRequest) (events.ReserveQuotaResponse, error) {
+	key := s.opts.quotaKeyFor(req.Principal, req.EventName)
+	ttlSecs := int(s.opts.QuotaTTL.Seconds())
+	raw, err := reserveScript.Run(ctx, s.opts.Client, []string{key}, req.Max, ttlSecs).Result()
+	if err != nil {
+		return events.ReserveQuotaResponse{}, fmt.Errorf("redisstore: ReserveQuota EVAL failed: %w", err)
+	}
+	arr, ok := raw.([]any)
+	if !ok || len(arr) != 2 {
+		return events.ReserveQuotaResponse{}, fmt.Errorf("redisstore: ReserveQuota: unexpected script return shape %T %v", raw, raw)
+	}
+	granted, _ := arr[0].(int64)
+	count, _ := arr[1].(int64)
+	return events.ReserveQuotaResponse{
+		Granted: granted == 1,
+		Count:   int(count),
+	}, nil
+}
+
+// ReleaseQuota returns one slot for (Principal, EventName). Decrements
+// the counter if currently > 0; deletes the key when the decrement
+// brings it to zero (keeps Redis's KEYS view clean). Release-at-zero
+// is a silent no-op — matches the in-memory store's contract so
+// double-release doesn't underflow.
+func (s *QuotaStore) ReleaseQuota(ctx context.Context, req events.ReleaseQuotaRequest) (events.ReleaseQuotaResponse, error) {
+	key := s.opts.quotaKeyFor(req.Principal, req.EventName)
+	if _, err := releaseScript.Run(ctx, s.opts.Client, []string{key}).Result(); err != nil {
+		return events.ReleaseQuotaResponse{}, fmt.Errorf("redisstore: ReleaseQuota EVAL failed: %w", err)
+	}
+	return events.ReleaseQuotaResponse{}, nil
+}
+
+// CountQuota reads the current count for (Principal, EventName)
+// without mutating state. Returns 0 for absent keys (never reserved,
+// or already TTL-expired). Storage errors surface as the second
+// return; Redis's "key does not exist" is NOT an error — it's
+// just Count=0.
+func (s *QuotaStore) CountQuota(ctx context.Context, req events.CountQuotaRequest) (events.CountQuotaResponse, error) {
+	key := s.opts.quotaKeyFor(req.Principal, req.EventName)
+	v, err := s.opts.Client.Get(ctx, key).Int()
+	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return events.CountQuotaResponse{Count: 0}, nil
+		}
+		return events.CountQuotaResponse{}, fmt.Errorf("redisstore: CountQuota GET failed: %w", err)
+	}
+	return events.CountQuotaResponse{Count: v}, nil
+}
+
+// Compile-time check that *QuotaStore satisfies events.QuotaStore.
+var _ events.QuotaStore = (*QuotaStore)(nil)

--- a/experimental/ext/events/stores/redis/quota_store_test.go
+++ b/experimental/ext/events/stores/redis/quota_store_test.go
@@ -1,0 +1,322 @@
+package redisstore
+
+import (
+	"context"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	goredis "github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/panyam/mcpkit/experimental/ext/events"
+)
+
+// newTestQuotaStore wraps newTestClient with a QuotaStore using the
+// default Options shape — caller can override Options.QuotaTTL by
+// passing a non-zero override for the TTL-expiry test.
+func newTestQuotaStore(t *testing.T, ttl time.Duration) *QuotaStore {
+	t.Helper()
+	opts := Options{
+		Client:   newTestClient(t),
+		QuotaTTL: ttl,
+	}
+	s, err := NewQuotaStore(opts)
+	require.NoError(t, err)
+	return s
+}
+
+// TestQuotaStore_ReserveReleaseCount_RoundTrip is the happy path.
+// Reserve, observe Count=1, Release, observe Count=0, Reserve again,
+// observe Count=1 — i.e., the slot is genuinely returned and reusable.
+func TestQuotaStore_ReserveReleaseCount_RoundTrip(t *testing.T) {
+	s := newTestQuotaStore(t, 0) // default TTL
+	ctx := t.Context()
+
+	resp, err := s.ReserveQuota(ctx, events.ReserveQuotaRequest{
+		Principal: "tenant-a/alice", EventName: "chat.message", Max: 3,
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Granted)
+	assert.Equal(t, 1, resp.Count, "post-increment value")
+
+	cnt, err := s.CountQuota(ctx, events.CountQuotaRequest{
+		Principal: "tenant-a/alice", EventName: "chat.message",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, cnt.Count)
+
+	_, err = s.ReleaseQuota(ctx, events.ReleaseQuotaRequest{
+		Principal: "tenant-a/alice", EventName: "chat.message",
+	})
+	require.NoError(t, err)
+
+	cnt, err = s.CountQuota(ctx, events.CountQuotaRequest{
+		Principal: "tenant-a/alice", EventName: "chat.message",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 0, cnt.Count, "release should bring count back to zero")
+
+	// And the slot is reusable.
+	resp, err = s.ReserveQuota(ctx, events.ReserveQuotaRequest{
+		Principal: "tenant-a/alice", EventName: "chat.message", Max: 3,
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Granted)
+	assert.Equal(t, 1, resp.Count)
+}
+
+// TestQuotaStore_ReserveRespectsMax verifies the cap: once Count
+// reaches Max, further Reserves return Granted=false + Count=Max.
+// Locks the spec that Max is exclusive (Reserve succeeds while Count
+// < Max, not <= Max).
+func TestQuotaStore_ReserveRespectsMax(t *testing.T) {
+	s := newTestQuotaStore(t, 0)
+	ctx := t.Context()
+	const max = 3
+
+	for i := 1; i <= max; i++ {
+		resp, err := s.ReserveQuota(ctx, events.ReserveQuotaRequest{
+			Principal: "tenant-a/alice", EventName: "chat.message", Max: max,
+		})
+		require.NoError(t, err)
+		assert.True(t, resp.Granted, "Reserve #%d should succeed", i)
+		assert.Equal(t, i, resp.Count)
+	}
+
+	// One over the cap.
+	resp, err := s.ReserveQuota(ctx, events.ReserveQuotaRequest{
+		Principal: "tenant-a/alice", EventName: "chat.message", Max: max,
+	})
+	require.NoError(t, err)
+	assert.False(t, resp.Granted, "Reserve at cap must be rejected")
+	assert.Equal(t, max, resp.Count, "Count should report the blocking value (=Max), not bump")
+}
+
+// TestQuotaStore_ReleaseAtZeroIsNoOp matches the in-memory store's
+// contract: Release on a never-Reserved (or already-zero) key is a
+// silent no-op, no underflow, no error. Important because the
+// wrapper sometimes Releases speculatively in error paths.
+func TestQuotaStore_ReleaseAtZeroIsNoOp(t *testing.T) {
+	s := newTestQuotaStore(t, 0)
+	ctx := t.Context()
+
+	// Release before any Reserve.
+	_, err := s.ReleaseQuota(ctx, events.ReleaseQuotaRequest{
+		Principal: "tenant-a/alice", EventName: "chat.message",
+	})
+	assert.NoError(t, err, "Release-at-zero must not error")
+
+	cnt, err := s.CountQuota(ctx, events.CountQuotaRequest{
+		Principal: "tenant-a/alice", EventName: "chat.message",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 0, cnt.Count, "Count must stay at zero (no negative)")
+}
+
+// TestQuotaStore_PerPrincipalEventIsolation verifies the key scheme
+// keeps (Principal, EventName) tuples isolated. A Reserve for
+// (alice, chat) MUST NOT count against (bob, chat) or (alice, presence).
+// Two tenants of the same backend would corrupt each other if this
+// failed.
+func TestQuotaStore_PerPrincipalEventIsolation(t *testing.T) {
+	s := newTestQuotaStore(t, 0)
+	ctx := t.Context()
+
+	// Fill alice's chat.message slot.
+	_, err := s.ReserveQuota(ctx, events.ReserveQuotaRequest{
+		Principal: "tenant-a/alice", EventName: "chat.message", Max: 1,
+	})
+	require.NoError(t, err)
+
+	// bob's chat.message should still be free.
+	resp, err := s.ReserveQuota(ctx, events.ReserveQuotaRequest{
+		Principal: "tenant-a/bob", EventName: "chat.message", Max: 1,
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Granted, "bob's chat.message must be independent of alice's")
+
+	// alice's presence.changed should still be free.
+	resp, err = s.ReserveQuota(ctx, events.ReserveQuotaRequest{
+		Principal: "tenant-a/alice", EventName: "presence.changed", Max: 1,
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Granted, "alice's presence.changed must be independent of chat.message")
+}
+
+// TestQuotaStore_CountReadsWithoutMutation is a sanity test that
+// CountQuota is purely read-only. Read-then-write code accidentally
+// using CountQuota as a "peek + maybe-modify" primitive would break
+// the wrapper's bookkeeping.
+func TestQuotaStore_CountReadsWithoutMutation(t *testing.T) {
+	s := newTestQuotaStore(t, 0)
+	ctx := t.Context()
+
+	_, err := s.ReserveQuota(ctx, events.ReserveQuotaRequest{
+		Principal: "tenant-a/alice", EventName: "chat.message", Max: 5,
+	})
+	require.NoError(t, err)
+
+	// 10 Counts in a row — none should bump the value.
+	for i := 0; i < 10; i++ {
+		cnt, err := s.CountQuota(ctx, events.CountQuotaRequest{
+			Principal: "tenant-a/alice", EventName: "chat.message",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 1, cnt.Count, "Count must stay at 1 after %d reads", i+1)
+	}
+}
+
+// TestQuotaStore_PrefixIsolation verifies the ChannelPrefix namespace
+// extends to quota keys. Two QuotaStores sharing the same Redis but
+// using different ChannelPrefix MUST NOT see each other's counters
+// — load-bearing for the demo's intent that multiple isolated demo
+// stacks can share one Redis cluster.
+func TestQuotaStore_PrefixIsolation(t *testing.T) {
+	cli := newTestClient(t)
+	sA, err := NewQuotaStore(Options{Client: cli, ChannelPrefix: "demoA"})
+	require.NoError(t, err)
+	sB, err := NewQuotaStore(Options{Client: cli, ChannelPrefix: "demoB"})
+	require.NoError(t, err)
+	ctx := t.Context()
+
+	// Fill demoA's (alice, chat) slot.
+	for i := 0; i < 3; i++ {
+		resp, err := sA.ReserveQuota(ctx, events.ReserveQuotaRequest{
+			Principal: "alice", EventName: "chat", Max: 3,
+		})
+		require.NoError(t, err)
+		require.True(t, resp.Granted)
+	}
+
+	// demoB's (alice, chat) MUST be empty.
+	cnt, err := sB.CountQuota(ctx, events.CountQuotaRequest{
+		Principal: "alice", EventName: "chat",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 0, cnt.Count, "ChannelPrefix isolation: demoB must not see demoA's counts")
+
+	resp, err := sB.ReserveQuota(ctx, events.ReserveQuotaRequest{
+		Principal: "alice", EventName: "chat", Max: 1,
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Granted, "demoB's slot must still be available despite demoA being at cap")
+}
+
+// TestQuotaStore_TTLExpiresLeakedReserve verifies the leak-recovery
+// floor. Set a short TTL, Reserve to fill the cap, advance time past
+// the TTL window — the leaked slot should be evictable and a fresh
+// Reserve succeeds.
+//
+// miniredis ships its own clock (Server.FastForward) for this kind
+// of test; the real-Redis variant runs separately under
+// TestQuotaStore_TTLExpiresLeakedReserve_RealRedis (gated below).
+func TestQuotaStore_TTLExpiresLeakedReserve(t *testing.T) {
+	if os.Getenv("MCPKIT_EVENTS_TEST_REDIS_ADDR") != "" {
+		t.Skip("real Redis: covered by TestQuotaStore_TTLExpiresLeakedReserve_RealRedis")
+	}
+	mr, err := miniredis.Run()
+	require.NoError(t, err)
+	t.Cleanup(mr.Close)
+	cli := miniredisClient(t, mr)
+
+	s, err := NewQuotaStore(Options{Client: cli, QuotaTTL: 5 * time.Second})
+	require.NoError(t, err)
+	ctx := t.Context()
+
+	// Fill the slot with Max=1 so any further Reserve is blocked.
+	resp, err := s.ReserveQuota(ctx, events.ReserveQuotaRequest{
+		Principal: "tenant-a/alice", EventName: "chat.message", Max: 1,
+	})
+	require.NoError(t, err)
+	require.True(t, resp.Granted)
+
+	// Cap blocks immediately.
+	resp, err = s.ReserveQuota(ctx, events.ReserveQuotaRequest{
+		Principal: "tenant-a/alice", EventName: "chat.message", Max: 1,
+	})
+	require.NoError(t, err)
+	require.False(t, resp.Granted)
+
+	// Fast-forward miniredis past the TTL window.
+	mr.FastForward(10 * time.Second)
+
+	// Leaked slot evicted; Reserve succeeds again.
+	resp, err = s.ReserveQuota(ctx, events.ReserveQuotaRequest{
+		Principal: "tenant-a/alice", EventName: "chat.message", Max: 1,
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Granted, "after TTL expiry, the leaked slot must be reclaimable")
+}
+
+// TestQuotaStore_ConcurrentReserveAtomicity is the load-bearing
+// atomicity check: 100 goroutines race to Reserve against a Max=10
+// cap on the same (Principal, EventName) key. The Lua script MUST
+// produce exactly 10 Granted=true responses, never 11, never 9.
+// A naive GET-then-INCR would race here and over-grant.
+func TestQuotaStore_ConcurrentReserveAtomicity(t *testing.T) {
+	s := newTestQuotaStore(t, 0)
+	ctx := t.Context()
+	const max = 10
+	const racers = 100
+
+	var granted int64
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < racers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			resp, err := s.ReserveQuota(ctx, events.ReserveQuotaRequest{
+				Principal: "tenant-a/alice", EventName: "chat.message", Max: max,
+			})
+			if err == nil && resp.Granted {
+				atomic.AddInt64(&granted, 1)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	assert.Equal(t, int64(max), granted, "exactly Max Reserves must succeed (no over-grant, no under-grant)")
+
+	// Final count matches.
+	cnt, err := s.CountQuota(ctx, events.CountQuotaRequest{
+		Principal: "tenant-a/alice", EventName: "chat.message",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, max, cnt.Count)
+}
+
+// TestNewQuotaStore_RejectsNilClient + RejectsNegativeTTL lock the
+// constructor's validation. Tiny tests but they prevent a footgun
+// at construction (silent nil-pointer panics deep inside ReserveQuota).
+func TestNewQuotaStore_RejectsNilClient(t *testing.T) {
+	_, err := NewQuotaStore(Options{})
+	assert.ErrorContains(t, err, "Client is required")
+}
+
+func TestNewQuotaStore_RejectsNegativeTTL(t *testing.T) {
+	_, err := NewQuotaStore(Options{
+		Client:   newTestClient(t),
+		QuotaTTL: -1 * time.Second,
+	})
+	assert.ErrorContains(t, err, "QuotaTTL must be >= 0")
+}
+
+// miniredisClient wires a *redis.Client at a miniredis instance's
+// address. Used by the TTL test that needs direct access to the
+// miniredis Server for FastForward — the shared newTestClient
+// helper hides the Server behind t.Cleanup.
+func miniredisClient(t *testing.T, mr *miniredis.Miniredis) *goredis.Client {
+	t.Helper()
+	cli := goredis.NewClient(&goredis.Options{Addr: mr.Addr()})
+	require.NoError(t, cli.FlushDB(context.Background()).Err())
+	t.Cleanup(func() { _ = cli.Close() })
+	return cli
+}


### PR DESCRIPTION
## What changes

Closes the deferred half of issue 634. With this PR, the Redis sub-module implements both `events.Emitter` (PR 716 + 717) and `events.QuotaStore` — the full surface a multi-replica events deployment needs from a shared backend.

The atomic primitive is a Lua script registered via `redis.NewScript` (process-cached `EVALSHA` + `EVAL` fallback on `NOSCRIPT`). One round trip per Reserve/Release; concurrent Reserves on the same key under high contention never over-grant.

New surface:

- `NewQuotaStore(opts) (*QuotaStore, error)` — implements `events.QuotaStore` over Redis atomic counters.
- `Options.QuotaTTL time.Duration` — sliding-window TTL on counter keys (default `1h`). Every Reserve refreshes the TTL so active counters never expire under load; leaked Reserves drop after the window of inactivity.

## Reviewer's guide

1. [experimental/ext/events/stores/redis/quota_store.go](https://github.com/panyam/mcpkit/pull/720/files#diff-9a6021a78f0d1fbfa50dd66b731ab7c9cd827368b559e983cf6a8efbf4fe10b5) — start here. The two Lua scripts at the top of the file (`reserveScript`, `releaseScript`) are the entire atomicity contract; everything else is plumbing. `redis.NewScript` (your preferred form — visible to code review, EVALSHA-cached at runtime) handles the script transport.
2. [experimental/ext/events/stores/redis/quota_store_test.go](https://github.com/panyam/mcpkit/pull/720/files#diff-15510a92c7d020e6bcc5aec6447fc2678e35890a325d99e4fa383783b58a9821) — 9 tests. The load-bearing one is `TestQuotaStore_ConcurrentReserveAtomicity` (100 goroutines race for 10 slots; exactly 10 must succeed). The TTL test uses `miniredis.FastForward` so we don't have to sleep wall-clock seconds.
3. [experimental/ext/events/stores/redis/options.go](https://github.com/panyam/mcpkit/pull/720/files#diff-1a707f6cf25a9e59544725536476d2f69324345dc5ddeab5d83f7cec6dcfc427) — one new field (`QuotaTTL`) + one new helper (`quotaKeyFor`). `withDefaults` learned about `QuotaTTL`; everything else unchanged.
4. [experimental/ext/events/stores/redis/README.md](https://github.com/panyam/mcpkit/pull/720/files#diff-4309c899768e545e244ce0f504bcc4fd8e55b6fd0e58205a0e8531c2695119fa) — new `## Quota` section above the existing trace-propagation one.
5. [experimental/ext/events/STORAGE_SEAMS.md](https://github.com/panyam/mcpkit/pull/720/files#diff-ceea0a5339d9583578ba93a8fd23a5cc2cc61ae832839b943f6d8e02b0bf6954) — row flip ("Emitter landed; QuotaStore deferred" → "Emitter + QuotaStore").

Skim or skip: the Lua script bodies are short enough to read; the doc comments around them spell out what each line does.

## Decision log

- **`redis.NewScript`, not raw `EVAL`.** You preferred this form for review visibility. It also gets EVALSHA caching with `NOSCRIPT` fallback for free.
- **Reuse existing `Options`, add `QuotaTTL`.** Confirmed in plan. Pubsub and quota share the `ChannelPrefix` namespace (pubsub: `<prefix>.<event>`; quota: `<prefix>.quota.<principal>.<event>`).
- **Default `QuotaTTL = 1h`.** Confirmed in plan. Sliding — refreshed on every Reserve so active counters never expire under load.
- **DECR + DEL-if-zero (one Lua script), not just DECR.** Cleaner `redis-cli KEYS` output (no drifted zero rows) and closes the timing window between `DECR → 0` and a concurrent Reserve observing zero. Two ops in one server-side execution.
- **No retry on `NOSCRIPT`.** go-redis/v9's `Script.Run` handles this automatically — re-loads the script and retries.

## Risk / blast radius

- Pure addition to `experimental/ext/events/stores/redis/`. No changes to the parent package or any other module.
- One new optional field on `Options` (`QuotaTTL`). Zero-value behavior: `withDefaults` substitutes `1h`. No caller break.
- 9 new tests; 11 existing tests (Emitter round-trip + trace propagation) still pass.
- `make tidy-all` clean across root + every sub-module.

## Out of scope (deliberately deferred — per the issue body)

- Cluster-aware key sharding (hash-tag co-location)
- Sliding-window quotas (this is fixed-bucket — matches in-memory + GORM defaults)
- Cross-tenant aggregate quotas
- Redis Sentinel HA

## Verification

- `make test` (default — miniredis, no Docker): 20/20 pass
- `make testredis` runs the same bodies against a real Redis container — proves the Lua scripts land intact through go-redis/v9's wire format. Skipped locally because Docker registry was flaky during the PR session; runs unchanged with `MCPKIT_EVENTS_TEST_REDIS_ADDR=localhost:6389`.

