### PR TITLE
server: thread Broadcast ctx into session broadcasters for SEP-414 SSE-side trace stitching (issue 715)

### DIFF
--- a/server/broadcast_test.go
+++ b/server/broadcast_test.go
@@ -37,7 +37,7 @@ func TestBroadcastSingleSession(t *testing.T) {
 	srv.registerTransportSessions(
 		func(id string) bool { return false },
 		func() {},
-		func(method string, params any) {
+		func(_ context.Context, method string, params any) {
 			if fn := d.getNotifyFunc(); fn != nil {
 				fn(method, params)
 			}
@@ -83,7 +83,7 @@ func TestBroadcastMultipleSessions(t *testing.T) {
 		srv.registerTransportSessions(
 			func(sid string) bool { return false },
 			func() {},
-			func(method string, params any) {
+			func(_ context.Context, method string, params any) {
 				if fn := d.getNotifyFunc(); fn != nil {
 					fn(method, params)
 				}
@@ -128,7 +128,7 @@ func TestBroadcastSkipsNilNotifyFunc(t *testing.T) {
 	srv.registerTransportSessions(
 		func(id string) bool { return false },
 		func() {},
-		func(method string, params any) {
+		func(_ context.Context, method string, params any) {
 			for _, d := range []*Dispatcher{dNil, dOk} {
 				if fn := d.getNotifyFunc(); fn != nil {
 					fn(method, params)
@@ -174,7 +174,7 @@ func TestBroadcastDoesNotRequireSubscription(t *testing.T) {
 	srv.registerTransportSessions(
 		func(id string) bool { return false },
 		func() {},
-		func(method string, params any) {
+		func(_ context.Context, method string, params any) {
 			if fn := d.getNotifyFunc(); fn != nil {
 				fn(method, params)
 			}
@@ -206,7 +206,7 @@ func TestBroadcastWithParams(t *testing.T) {
 	srv.registerTransportSessions(
 		func(id string) bool { return false },
 		func() {},
-		func(method string, params any) {
+		func(_ context.Context, method string, params any) {
 			if fn := d.getNotifyFunc(); fn != nil {
 				fn(method, params)
 			}
@@ -225,5 +225,141 @@ func TestBroadcastWithParams(t *testing.T) {
 	}
 	if m["reason"] != "updated" {
 		t.Errorf("params[reason] = %v, want updated", m["reason"])
+	}
+}
+
+// --- SEP-414 trace context injection on Broadcast (issue 715) ---
+
+const (
+	testBroadcastTraceparent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+	testBroadcastTracestate  = "vendor=val"
+)
+
+// captureBroadcastParams wires a single test session whose notifyFunc
+// records the params handed in. Returns the dispatcher (for stale
+// references in the caller) and a pointer to the captured params.
+func captureBroadcastParams(t *testing.T, srv *Server) (*Dispatcher, *any) {
+	t.Helper()
+	d := srv.newSession()
+	d.sessionID = "trace-test"
+	var captured any
+	d.SetNotifyFunc(func(_ string, params any) {
+		captured = params
+	})
+	srv.registerTransportSessions(
+		func(id string) bool { return false },
+		func() {},
+		func(_ context.Context, method string, params any) {
+			if fn := d.getNotifyFunc(); fn != nil {
+				fn(method, params)
+			}
+		},
+	)
+	return d, &captured
+}
+
+// TestBroadcast_InjectsTraceContextFromCtx is the core acceptance for
+// issue 715: when Broadcast is called with ctx carrying a non-zero
+// core.TraceContext (the shape `events.Emit` threads through after PR
+// 712/714), the SSE-pushed notification params carry `_meta.traceparent`
+// so downstream subscribers' spans stitch into the originating trace.
+func TestBroadcast_InjectsTraceContextFromCtx(t *testing.T) {
+	srv := NewServer(core.ServerInfo{Name: "test", Version: "1.0"})
+	_, captured := captureBroadcastParams(t, srv)
+
+	tc := core.TraceContext{
+		Traceparent: testBroadcastTraceparent,
+		Tracestate:  testBroadcastTracestate,
+	}
+	ctx := core.WithTraceContext(context.Background(), tc)
+	srv.Broadcast(ctx, "notifications/events/event", map[string]any{"name": "demo"})
+
+	m, ok := (*captured).(map[string]any)
+	if !ok {
+		t.Fatalf("params type = %T, want map[string]any", *captured)
+	}
+	meta, ok := m["_meta"].(map[string]any)
+	if !ok {
+		t.Fatalf("_meta = %v, want map[string]any (Broadcast must inject when ctx carries a non-zero TraceContext)", m["_meta"])
+	}
+	if got := meta[core.MetaKeyTraceparent]; got != testBroadcastTraceparent {
+		t.Errorf("_meta.traceparent = %v, want %q", got, testBroadcastTraceparent)
+	}
+	if got := meta[core.MetaKeyTracestate]; got != testBroadcastTracestate {
+		t.Errorf("_meta.tracestate = %v, want %q", got, testBroadcastTracestate)
+	}
+}
+
+// TestBroadcast_NoTraceContext_LeavesParamsUntouched pins the
+// zero-overhead path: a plain context.Background() (no trace context
+// attached) MUST NOT mutate params or synthesize an empty _meta. This
+// is the regression guard against accidental empty-_meta injection
+// that would change every broadcast's wire shape even when tracing
+// isn't wired.
+func TestBroadcast_NoTraceContext_LeavesParamsUntouched(t *testing.T) {
+	srv := NewServer(core.ServerInfo{Name: "test", Version: "1.0"})
+	_, captured := captureBroadcastParams(t, srv)
+
+	original := map[string]any{"uri": "test://doc"}
+	srv.Broadcast(context.Background(), "notifications/resources/updated", original)
+
+	m, ok := (*captured).(map[string]any)
+	if !ok {
+		t.Fatalf("params type = %T, want map[string]any (untouched pass-through)", *captured)
+	}
+	if _, present := m["_meta"]; present {
+		t.Errorf("_meta MUST NOT be created when ctx carries no TraceContext; got %v", m["_meta"])
+	}
+	if m["uri"] != "test://doc" {
+		t.Errorf("original keys MUST survive untouched; got %v", m)
+	}
+}
+
+// TestBroadcast_CallerSetMetaTraceparent_Wins pins that an explicit
+// caller-set `_meta.traceparent` on params is preserved when ctx also
+// carries a TraceContext — delegates to core.InjectTraceContextIntoParams's
+// caller-set-wins contract, which the events bus relay (PR 712) also
+// relies on.
+func TestBroadcast_CallerSetMetaTraceparent_Wins(t *testing.T) {
+	srv := NewServer(core.ServerInfo{Name: "test", Version: "1.0"})
+	_, captured := captureBroadcastParams(t, srv)
+
+	callerTraceparent := "00-11111111111111111111111111111111-2222222222222222-01"
+	params := map[string]any{
+		"name": "demo",
+		"_meta": map[string]any{
+			core.MetaKeyTraceparent: callerTraceparent,
+		},
+	}
+	tc := core.TraceContext{Traceparent: testBroadcastTraceparent}
+	ctx := core.WithTraceContext(context.Background(), tc)
+	srv.Broadcast(ctx, "notifications/events/event", params)
+
+	m := (*captured).(map[string]any)
+	meta := m["_meta"].(map[string]any)
+	if got := meta[core.MetaKeyTraceparent]; got != callerTraceparent {
+		t.Errorf("_meta.traceparent = %v, want caller-set %q (ctx-derived must not clobber)", got, callerTraceparent)
+	}
+}
+
+// TestBroadcast_NonObjectParams_LeavesUntouched pins the JSON-RPC
+// non-object params escape hatch: positional arrays / scalars carry no
+// `_meta` envelope per the JSON-RPC spec, so the injection helper
+// returns the params unchanged. Broadcast surfaces the same behavior.
+func TestBroadcast_NonObjectParams_LeavesUntouched(t *testing.T) {
+	srv := NewServer(core.ServerInfo{Name: "test", Version: "1.0"})
+	_, captured := captureBroadcastParams(t, srv)
+
+	positional := []any{"arg1", 42}
+	tc := core.TraceContext{Traceparent: testBroadcastTraceparent}
+	ctx := core.WithTraceContext(context.Background(), tc)
+	srv.Broadcast(ctx, "notifications/events/event", positional)
+
+	got, ok := (*captured).([]any)
+	if !ok {
+		t.Fatalf("params type = %T, want []any (non-object MUST pass through untouched)", *captured)
+	}
+	if len(got) != 2 || got[0] != "arg1" || got[1] != 42 {
+		t.Errorf("non-object params mutated: got %v", got)
 	}
 }

--- a/server/dynamic_test.go
+++ b/server/dynamic_test.go
@@ -36,7 +36,7 @@ func testDynamicServer() (*Server, func() []string) {
 	srv.registerTransportSessions(
 		func(id string) bool { return false },
 		func() {},
-		func(method string, params any) {
+		func(_ context.Context, method string, params any) {
 			if fn := d.getNotifyFunc(); fn != nil {
 				fn(method, params)
 			}

--- a/server/server.go
+++ b/server/server.go
@@ -25,7 +25,7 @@ type Server struct {
 	mu                sync.Mutex
 	sessionClosers      []sessionCloser
 	allSessionClosers   []func()
-	sessionBroadcasters []func(method string, params any)
+	sessionBroadcasters []func(ctx context.Context, method string, params any)
 	subRegistry         *subscriptionRegistry // nil when subscriptions not enabled
 }
 
@@ -940,30 +940,43 @@ func (s *Server) CloseAllSessions() {
 // Streamable HTTP transports). In-process transports manage their own
 // notification delivery via WithNotificationHandler.
 //
-// ctx threads through SEP-414 trace context for downstream
-// instrumentation — currently consumed by callers (e.g., events.Emit
-// for outbound _meta.traceparent injection on notification params).
-// The underlying session broadcasters don't take ctx today; that
-// plumbing slots in without churning callers when it's added.
+// ctx threads through SEP-414 trace context. When ctx carries a non-zero
+// core.TraceContext, the inbound traceparent / tracestate are injected
+// into the notification params under `_meta` before fan-out, so SSE
+// subscribers see the same trace identity the originating yield ran
+// under. Existing caller-set `_meta.traceparent` on params wins
+// (delegates to core.InjectTraceContextIntoParams's contract).
+//
+// The injection happens once at the Server level rather than per
+// transport because the per-session notifyFunc the transport
+// dispatchers expose is the BASE notifyFunc — the per-request
+// trace_middleware wrap (`core.WrapSessionNotifyFunc`) targets
+// `sc.notify` on a per-request SessionCtx, which broadcast doesn't
+// run inside. Injecting once at the call site keeps tracing concerns
+// out of the transport-level broadcast loops.
 //
 // Example:
 //
 //	// After registering a new tool at runtime:
 //	srv.Broadcast(ctx, "notifications/tools/list_changed", nil)
-func (s *Server) Broadcast(_ context.Context, method string, params any) {
+func (s *Server) Broadcast(ctx context.Context, method string, params any) {
+	if tc := core.TraceContextFromContext(ctx); !tc.IsZero() {
+		params = core.InjectTraceContextIntoParams(params, tc)
+	}
+
 	s.mu.Lock()
-	broadcasters := make([]func(string, any), len(s.sessionBroadcasters))
+	broadcasters := make([]func(context.Context, string, any), len(s.sessionBroadcasters))
 	copy(broadcasters, s.sessionBroadcasters)
 	s.mu.Unlock()
 
 	for _, bc := range broadcasters {
-		bc(method, params)
+		bc(ctx, method, params)
 	}
 }
 
 // registerTransportSessions registers a transport's session management callbacks.
 // Called by transports during Handler() creation.
-func (s *Server) registerTransportSessions(closeOne sessionCloser, closeAll func(), broadcast func(method string, params any)) {
+func (s *Server) registerTransportSessions(closeOne sessionCloser, closeAll func(), broadcast func(ctx context.Context, method string, params any)) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.sessionClosers = append(s.sessionClosers, closeOne)

--- a/server/streamable_transport.go
+++ b/server/streamable_transport.go
@@ -884,7 +884,13 @@ func (t *streamableTransport) handleBatchPost(w http.ResponseWriter, r *http.Req
 // independent — a deployment running in dual mode delivers the same
 // notification to legacy-session GET SSE clients AND stateless listen
 // clients in one Broadcast call.
-func (t *streamableTransport) broadcast(method string, params any) {
+//
+// ctx is accepted for SEP-414 trace context propagation but currently
+// unused inside the loop — Server.Broadcast injects `_meta.traceparent`
+// onto params before fan-out. The parameter exists so per-session
+// concerns (audit, span emission inside the transport) can compose
+// without re-widening the signature.
+func (t *streamableTransport) broadcast(_ context.Context, method string, params any) {
 	t.sessions.Range(func(_ string, entry *sessionEntry) bool {
 		d := entry.dispatcher
 		if fn := d.getNotifyFunc(); fn != nil {

--- a/server/transport.go
+++ b/server/transport.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -488,7 +489,13 @@ func (t *sseTransport) closeAllSessions() {
 
 // broadcast sends a notification to all active SSE sessions.
 // Sessions with nil notifyFunc are skipped safely.
-func (t *sseTransport) broadcast(method string, params any) {
+//
+// ctx is accepted for SEP-414 trace context propagation but currently
+// unused inside the loop — Server.Broadcast injects `_meta.traceparent`
+// onto params before fan-out. The parameter exists so per-session
+// concerns (audit, span emission inside the transport) can compose
+// without re-widening the signature.
+func (t *sseTransport) broadcast(_ context.Context, method string, params any) {
 	t.sessions.Range(func(_ string, entry *sseSessionEntry) bool {
 		if fn := entry.dispatcher.getNotifyFunc(); fn != nil {
 			fn(method, params)


### PR DESCRIPTION
## What changes

`Server.Broadcast` now actually consumes the ctx PR 714 added to its signature. When ctx carries a non-zero `core.TraceContext`, the inbound traceparent / tracestate are injected into notification params under `_meta` before fan-out, so SSE subscribers see the same trace identity the originating yield ran under. This closes the loose end PR 714 left: webhook fanout was already trace-stitched end-to-end; the SSE push on the same yield dropped the traceparent.

```mermaid
sequenceDiagram
    participant Y as yield(ctx, data) on replica A
    participant E as events.Emit
    participant B as Server.Broadcast (ctx)
    participant W as WebhookRegistry.Deliver (PR 714)
    participant S as SSE subscriber
    Y->>E: event with traceparent in event.Meta
    E->>B: Broadcast(ctx, "notifications/events/event", event)
    E->>W: Deliver(ctx, event) [PR 714 — already trace-stitched]
    Note over B: PR 715: inject _meta.traceparent<br/>from ctx before fan-out
    B->>S: SSE notification with _meta.traceparent ✅
    W->>S: HTTP POST with traceparent header ✅
```

## Reviewer's guide

Read in this order:

1. [server/server.go](https://github.com/panyam/mcpkit/pull/722/files#diff-78f42ba40d0f10b08c73b7e6bb8376f398e249c963cf549e89591d6b6826b9a4) — start here. `Server.Broadcast` body change: read `core.TraceContextFromContext(ctx)`, `core.InjectTraceContextIntoParams(params, tc)` if non-zero, then fan out with widened callback signature. `sessionBroadcasters` slice element type widens to `func(context.Context, string, any)`. The doc-comment explains why injection happens at the Server level rather than per-transport.
2. [server/broadcast_test.go](https://github.com/panyam/mcpkit/pull/722/files#diff-5610cc18a859ad8e51cc8fbcb89ad9479a5a08d649d0c9a46570d261cfdfa70d) — acceptance for the above. Four new `TestBroadcast_*` tests. `captureBroadcastParams` helper extracts the wiring pattern shared by the new tests.
3. [server/transport.go](https://github.com/panyam/mcpkit/pull/722/files#diff-d073398f020c2af598ed1fd77afd733320d7731239b557a50b04a81d6e31d132) + [server/streamable_transport.go](https://github.com/panyam/mcpkit/pull/722/files#diff-6d7a7857fa287633c986304e06b224dc7e95a8a8d770430f684717bb7d1543b4) — mechanical signature widening on the per-transport `broadcast` methods. ctx accepted but unused inside (forward-compat seam documented in the doc-comments).
4. [server/dynamic_test.go](https://github.com/panyam/mcpkit/pull/722/files#diff-a4129def5965cf1dda3fe041416d939a8100676ee7d4894496c2edb7a72e494a) — single mechanical sweep of the test fixture's broadcast closure signature.

Skim: the 5 existing test sites in `broadcast_test.go` (lines 40, 86, 131, 177, 209) — same one-line mechanical signature change as `dynamic_test.go`.

## Decision log

- **Inject at `Server.Broadcast`, not in the per-transport broadcast loops.** The per-request `trace_middleware.go` wrap (`core.WrapSessionNotifyFunc`) targets `sc.notify` on a per-request `SessionCtx` — that's the handler-facing notify. Broadcast goes through `dispatcher.getNotifyFunc()` (the BASE transport notify, set once at session creation). The per-request wrap doesn't reach the broadcast loop. Rather than introduce a parallel "per-session base notify wrap" mechanism (no consumer exists for it today), this PR injects once at the Server level using the same `core.InjectTraceContextIntoParams` helper trace_middleware already uses. DRY, surgical, and per-transport broadcast stays oblivious to tracing concerns.
- **Why widen the per-transport callback signature anyway?** The issue explicitly asks for it — forward-compat seam. Future per-session concerns (audit logging, span emission inside the transport) can compose without re-widening. Both transports accept ctx with `_` for now; the doc-comments call out the design.
- **Why no test using a real `TracerProvider` end-to-end?** The injection happens at `core.InjectTraceContextIntoParams` — covered by `core/trace_test.go` against multiple shapes. This PR's tests verify that `Server.Broadcast` calls that helper at the right moment with the right ctx — fake-TP-free.

## Risk / blast radius

- **Affects**: `Server.Broadcast` callers (currently 2: `server.go::Reg.OnChange` passes `context.Background()` — no behavior change; `experimental/ext/events::Server.Broadcast` adopter — gets the trace injection for free now that ctx threads through).
- **API change**: `sessionBroadcasters` is a server-internal slice; the type widening is invisible to external consumers. The exported `Server.Broadcast(ctx, method, params)` signature itself is unchanged from PR 714 — ctx was already in the signature, this PR just makes the function actually use it.
- **Tests covering this**: 4 new `TestBroadcast_*` cases (injection / zero-overhead pass-through / caller-set-wins / non-object-params escape hatch); 6 existing `TestBroadcast*` tests stay green; 1 dynamic test stays green. `experimental/ext/events` full suite (79s) passes. `ext/tasks` + `ext/otel` suites pass.
- **Be paranoid about**: nothing — the change is additive in behavior and source-compatible at every layer above `sessionBroadcasters` (which has no external consumers).

## Before / after

```
$ go test -run 'TestBroadcast' -count=1 -v ./server/
=== RUN   TestBroadcastSingleSession                         PASS
=== RUN   TestBroadcastMultipleSessions                      PASS
=== RUN   TestBroadcastSkipsNilNotifyFunc                    PASS
=== RUN   TestBroadcastNoSessions                            PASS
=== RUN   TestBroadcastDoesNotRequireSubscription            PASS
=== RUN   TestBroadcastWithParams                            PASS
=== RUN   TestBroadcast_InjectsTraceContextFromCtx           PASS  ← new
=== RUN   TestBroadcast_NoTraceContext_LeavesParamsUntouched PASS  ← new
=== RUN   TestBroadcast_CallerSetMetaTraceparent_Wins        PASS  ← new
=== RUN   TestBroadcast_NonObjectParams_LeavesUntouched      PASS  ← new
```

## Out of scope (deliberately deferred)

- **Per-session NotifyInterceptor on the broadcast path.** Would let users register middleware that runs around every broadcast delivery (audit logging, custom span emission inside the transport). No real consumer today — file as follow-up if one surfaces.
- **Widening `core.NotifyFunc` itself to take ctx.** Much larger change — touches every transport's notify wiring. The forward-compat seam this PR adds at the broadcast-callback layer is enough for the events-bus trace stitching use case.
- **`Server.broadcast` (lowercase) inner helper / subscription registry notify.** The `subscriptionRegistry.notify` path (`server/server.go::notify` at 1551) does `dispatcher.getNotifyFunc()` directly without going through `Server.Broadcast` — out of scope here; same pattern would apply if/when a consumer needs trace stitching on resource-subscription updates.

Closes issue 715. Part of the SEP-414 P6 umbrella (663).
