### PR TITLE
examples/events/kitchen-sink: wire SetupTelemetry + finish PR 712 ctx sweep (issue 667)

### DIFF
--- a/examples/events/kitchen-sink/Makefile
+++ b/examples/events/kitchen-sink/Makefile
@@ -1,13 +1,23 @@
-ADDR ?= http://localhost:8080
-MCP  := $(ADDR)/mcp
+ADDR     ?= http://localhost:8080
+MCP      := $(ADDR)/mcp
 
-.PHONY: help serve demo demo-test note readme build test test-race clean
+# SEP-414 P6 observability selector (issue 667). See examples/CONVENTIONS.md
+# § Telemetry wiring for the four-value matrix ("" = Noop / stdout / otlp /
+# auto). Pair `EXPORTER=otlp` or `EXPORTER=auto` with the docker/observability
+# LGTM stack to land spans in Tempo under service `kitchen-sink-events`.
+# Default is "" — zero overhead, no SDK pulled.
+EXPORTER ?=
+
+.PHONY: help serve serve-otlp demo demo-test note readme build test test-race clean
 
 help: ## Show this help.
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / { printf "  \033[36m%-14s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 
-serve: ## Start the kitchen-sink server standalone.
-	go run . --serve -addr :8080
+serve: ## Start the kitchen-sink server standalone. Pass EXPORTER=stdout|otlp|auto to opt into spans.
+	go run . --serve -addr :8080 --exporter=$(EXPORTER)
+
+serve-otlp: ## Start with EXPORTER=auto (probes docker/observability stack; silent Noop fallback if unreachable).
+	go run . --serve -addr :8080 --exporter=auto
 
 demo: ## Run the demokit walkthrough (interactive TUI). Server must be up via `make serve` in another terminal.
 	go run . --tui

--- a/examples/events/kitchen-sink/README.md
+++ b/examples/events/kitchen-sink/README.md
@@ -13,6 +13,31 @@ make demo-test        # OR: non-interactive (for CI / scripting)
 make readme           # regenerate WALKTHROUGH.md
 ```
 
+## Tracing (optional, SEP-414 P6 — issue 667)
+
+The server is wired to opt into OpenTelemetry trace emission via the `--exporter` flag (or `EXPORTER` env var). Four values, matching every other mcpkit example — see [`examples/CONVENTIONS.md`](../../CONVENTIONS.md) § Telemetry wiring for the full matrix.
+
+```bash
+# Default — Noop TracerProvider, zero overhead, no spans.
+make serve
+
+# Print every span to stdout (teaching / debugging mode).
+EXPORTER=stdout make serve
+
+# Hand spans to the docker/observability LGTM stack.
+# Bring it up first: (cd ../../../docker/observability && docker compose up -d)
+# Then either:
+make serve-otlp                          # equivalent to EXPORTER=auto — silent fallback if stack isn't up
+EXPORTER=otlp make serve                 # warns on dial failure
+```
+
+When the LGTM stack is up, open Grafana → Tempo → service `kitchen-sink-events`. Spans you'll see:
+
+- **One dispatch span per JSON-RPC method** (subscribe / unsubscribe / poll / list / etc.) — from the SEP-414 P2 server middleware.
+- **`events.webhook.deliver` spans** around each outbound webhook POST (when a webhook subscriber is registered) — from `events.WithWebhookTracerProvider`.
+
+Per-subscription `Match` / `Transform` spans on the fanout hot path are NOT emitted today — that's a hot-path concern (fanout runs every 2s × N subscribers) needing sampling design. Tracked as a follow-up; see [issue 667](https://github.com/panyam/mcpkit/issues/667) for the design options.
+
 ## What it demonstrates
 
 Each bullet maps to a walkthrough step:

--- a/examples/events/kitchen-sink/e2e_test.go
+++ b/examples/events/kitchen-sink/e2e_test.go
@@ -19,7 +19,7 @@ import (
 
 func newTestStack(t *testing.T) (*httptest.Server, *wiredServer) {
 	t.Helper()
-	w := buildServer(":0")
+	w := buildServer(":0", nil)
 	handler := w.srv.Handler(server.WithStreamableHTTP(true))
 	ts := httptest.NewServer(handler)
 	t.Cleanup(ts.Close)
@@ -73,9 +73,9 @@ func TestMatch_ChannelFiltering_RoutesOnlyMatchingEventsToEachSub(t *testing.T) 
 	require.NoError(t, err)
 	defer streamB.Stop()
 
-	require.NoError(t, injectChat(w.chatYield, "general", "alice", "hi general"))
-	require.NoError(t, injectChat(w.chatYield, "dev", "bob", "hi dev"))
-	require.NoError(t, injectChat(w.chatYield, "alerts", "carol", "irrelevant"))
+	require.NoError(t, injectChat(context.Background(), w.chatYield, "general", "alice", "hi general"))
+	require.NoError(t, injectChat(context.Background(), w.chatYield, "dev", "bob", "hi dev"))
+	require.NoError(t, injectChat(context.Background(), w.chatYield, "alerts", "carol", "irrelevant"))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -126,7 +126,7 @@ func TestTransform_RedactsPII_OnlyForOptedInSubscriber(t *testing.T) {
 	require.NoError(t, err)
 	defer streamRedact.Stop()
 
-	require.NoError(t, injectAlert(w.alertYield, "P1", "api-gateway", "alice",
+	require.NoError(t, injectAlert(context.Background(), w.alertYield, "P1", "api-gateway", "alice",
 		"latency spike — page alice@example.com"))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -163,8 +163,8 @@ func TestMatch_FiltersBeforeTransform(t *testing.T) {
 	require.NoError(t, err)
 	defer stream.Stop()
 
-	require.NoError(t, injectAlert(w.alertYield, "P2", "api-gateway", "alice", "p2 noise"))
-	require.NoError(t, injectAlert(w.alertYield, "P1", "api-gateway", "alice", "p1 match"))
+	require.NoError(t, injectAlert(context.Background(), w.alertYield, "P2", "api-gateway", "alice", "p2 noise"))
+	require.NoError(t, injectAlert(context.Background(), w.alertYield, "P1", "api-gateway", "alice", "p1 match"))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()

--- a/examples/events/kitchen-sink/main.go
+++ b/examples/events/kitchen-sink/main.go
@@ -153,10 +153,14 @@ func buildServer(addr string, tp core.TracerProvider) *wiredServer {
 	idx := events.NewSubscriptionIndex()
 	quota := events.NewQuota(events.WithMaxSubscriptionsPerPrincipal("chat.message", quotaCap))
 
-	srvOpts := []server.Option{
-		server.WithSubscriptions(),
-		server.WithListen(addr),
-	}
+	// Canonical baseline (WithListen + the color logger wired to both
+	// transport request logging and dispatch middleware) per
+	// examples/CONVENTIONS.md § serve-srv-listenandserve. Mirrors the
+	// discord precedent — kitchen-sink can't use `common.RunServer`
+	// because of the three goroutine feeders + custom /inject mux, but
+	// the per-option baseline still applies.
+	srvOpts := common.MCPServerOptions(addr, "[mcp] ")
+	srvOpts = append(srvOpts, server.WithSubscriptions())
 	if tp != nil {
 		srvOpts = append(srvOpts, server.WithTracerProvider(tp))
 	}

--- a/examples/events/kitchen-sink/main.go
+++ b/examples/events/kitchen-sink/main.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/panyam/demokit"
 	"github.com/panyam/mcpkit/core"
+	common "github.com/panyam/mcpkit/examples/common"
+	commonotel "github.com/panyam/mcpkit/examples/common/otel"
 	"github.com/panyam/mcpkit/experimental/ext/events"
 	"github.com/panyam/mcpkit/server"
 	gohttp "github.com/panyam/servicekit/http"
@@ -57,15 +59,32 @@ func serve() {
 	chatEvery := flag.Duration("chat-every", defaultChatEvery, "synthetic chat feeder cadence")
 	alertEvery := flag.Duration("alert-every", defaultAlertEvery, "synthetic alert feeder cadence")
 	presenceEvery := flag.Duration("presence-every", defaultPresenceEvery, "synthetic presence feeder cadence")
+	tel := common.RegisterTelemetryFlags(flag.CommandLine)
 	flag.CommandLine.Parse(demokit.FilterArgs(os.Args[1:],
 		demokit.BoolFlag("--serve"),
 		demokit.ValueFlag("--addr"),
 		demokit.ValueFlag("--chat-every"),
 		demokit.ValueFlag("--alert-every"),
 		demokit.ValueFlag("--presence-every"),
+		demokit.ValueFlag("--exporter"),
+		demokit.ValueFlag("--otlp-endpoint"),
 	))
 
-	wired := buildServer(*addr)
+	// SEP-414 P6 observability wiring (issue 667). Default selector
+	// ("") returns a Noop TracerProvider — zero overhead. Operators
+	// opt in via --exporter / EXPORTER env. See examples/CONVENTIONS.md
+	// § Telemetry wiring for the four-value selector matrix.
+	tp, shutdown, err := commonotel.SetupTelemetry(context.Background(),
+		commonotel.WithExporter(*tel.Exporter),
+		commonotel.WithOTLPEndpoint(*tel.OTLPEndpoint),
+		commonotel.WithServiceName("kitchen-sink-events"),
+	)
+	if err != nil {
+		log.Fatalf("commonotel.SetupTelemetry: %v", err)
+	}
+	defer shutdown(context.Background())
+
+	wired := buildServer(*addr, tp)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -95,9 +114,9 @@ func serve() {
 type wiredServer struct {
 	srv         *server.Server
 	chatSrc     *events.YieldingSource[ChatMessageData]
-	chatYield   func(ChatMessageData) error
+	chatYield   func(context.Context, ChatMessageData) error
 	alertSrc    *events.YieldingSource[AlertData]
-	alertYield  func(AlertData) error
+	alertYield  func(context.Context, AlertData) error
 	presenceSrc *events.YieldingSource[PresenceChangedData]
 	idx         *events.SubscriptionIndex
 	registry    *watchListRegistry
@@ -107,7 +126,11 @@ type wiredServer struct {
 // SubscriptionIndex (passed to events.Register so EmitToSubscription
 // can find subs), and the Quota cap. Returned so e2e_test.go can
 // stand up the same shape without spawning ListenAndServe.
-func buildServer(addr string) *wiredServer {
+//
+// tp opts the dispatch spine + webhook delivery path into SEP-414
+// instrumentation. Nil or core.NoopTracerProvider{} = zero overhead.
+// Tests pass nil; the serve() path passes the configured TracerProvider.
+func buildServer(addr string, tp core.TracerProvider) *wiredServer {
 	registry := newWatchListRegistry()
 
 	chatSrc, chatYield := events.NewYieldingSource[ChatMessageData](chatEventDef(), events.WithMaxSize(eventStoreCap))
@@ -120,16 +143,26 @@ func buildServer(addr string) *wiredServer {
 	// EmitToSubscription.
 	presenceSrc, _ := events.NewYieldingSource[PresenceChangedData](presenceEventDef(registry), events.WithoutCursors())
 
-	webhooks := events.NewWebhookRegistry(
+	webhookOpts := []events.WebhookOption{
 		events.WithWebhookAllowPrivateNetworks(true),
-	)
+	}
+	if tp != nil {
+		webhookOpts = append(webhookOpts, events.WithWebhookTracerProvider(tp))
+	}
+	webhooks := events.NewWebhookRegistry(webhookOpts...)
 	idx := events.NewSubscriptionIndex()
 	quota := events.NewQuota(events.WithMaxSubscriptionsPerPrincipal("chat.message", quotaCap))
 
-	srv := server.NewServer(
-		core.ServerInfo{Name: "kitchen-sink-events", Version: "0.1.0"},
+	srvOpts := []server.Option{
 		server.WithSubscriptions(),
 		server.WithListen(addr),
+	}
+	if tp != nil {
+		srvOpts = append(srvOpts, server.WithTracerProvider(tp))
+	}
+	srv := server.NewServer(
+		core.ServerInfo{Name: "kitchen-sink-events", Version: "0.1.0"},
+		srvOpts...,
 	)
 	registerResources(srv, chatSrc, alertSrc)
 	events.Register(events.Config{
@@ -171,14 +204,14 @@ func injectHandlerFor(w *wiredServer) http.HandlerFunc {
 				http.Error(rw, err.Error(), http.StatusBadRequest)
 				return
 			}
-			_ = injectChat(w.chatYield, body.Channel, body.Sender, body.Text)
+			_ = injectChat(r.Context(), w.chatYield, body.Channel, body.Sender, body.Text)
 		case "alert.fired":
 			var body alertBody
 			if err := decodeJSON(r, &body); err != nil {
 				http.Error(rw, err.Error(), http.StatusBadRequest)
 				return
 			}
-			_ = injectAlert(w.alertYield, body.Severity, body.Service, body.Reporter, body.Message)
+			_ = injectAlert(r.Context(), w.alertYield, body.Severity, body.Service, body.Reporter, body.Message)
 		case "presence.changed":
 			var body presenceBody
 			if err := decodeJSON(r, &body); err != nil {

--- a/examples/events/kitchen-sink/synthetic_alert.go
+++ b/examples/events/kitchen-sink/synthetic_alert.go
@@ -13,7 +13,11 @@ import (
 // Each alert carries a reporter username (PII) and an email-bearing
 // message body so the Transform redaction story is visible on
 // subscribers that opt in.
-func runAlertFeeder(ctx context.Context, yield func(AlertData) error, interval time.Duration) {
+//
+// yield takes ctx so SEP-414 trace context (when configured) flows
+// from the feeder's ctx into event.Meta.traceparent — same shape PR
+// 712 established for discord / telegram / whole-enchilada feeders.
+func runAlertFeeder(ctx context.Context, yield func(context.Context, AlertData) error, interval time.Duration) {
 	severities := []string{"P1", "P2", "P3"}
 	services := []string{"api-gateway", "auth-service", "payments", "search"}
 	reporters := []string{"alice", "bob", "carol"}
@@ -39,7 +43,7 @@ func runAlertFeeder(ctx context.Context, yield func(AlertData) error, interval t
 				Message:   messages[rng.Intn(len(messages))],
 				Timestamp: ts.UTC().Format(time.RFC3339),
 			}
-			if err := yield(a); err != nil {
+			if err := yield(ctx, a); err != nil {
 				log.Printf("[alert] yield: %v", err)
 			}
 		}
@@ -48,8 +52,8 @@ func runAlertFeeder(ctx context.Context, yield func(AlertData) error, interval t
 
 // injectAlert posts one specific alert event for the walkthrough's
 // deterministic Match + Transform steps.
-func injectAlert(yield func(AlertData) error, severity, service, reporter, message string) error {
-	return yield(AlertData{
+func injectAlert(ctx context.Context, yield func(context.Context, AlertData) error, severity, service, reporter, message string) error {
+	return yield(ctx, AlertData{
 		Severity:  severity,
 		Service:   service,
 		Reporter:  reporter,

--- a/examples/events/kitchen-sink/synthetic_chat.go
+++ b/examples/events/kitchen-sink/synthetic_chat.go
@@ -10,7 +10,11 @@ import (
 // runChatFeeder yields a synthetic chat message every interval until
 // ctx is done, cycling across a small fixed set of channels so the
 // Match-by-channel demo has events on every channel to filter.
-func runChatFeeder(ctx context.Context, yield func(ChatMessageData) error, interval time.Duration) {
+//
+// yield takes ctx so SEP-414 trace context (when configured) flows
+// from the feeder's ctx into event.Meta.traceparent — same shape PR
+// 712 established for discord / telegram / whole-enchilada feeders.
+func runChatFeeder(ctx context.Context, yield func(context.Context, ChatMessageData) error, interval time.Duration) {
 	channels := []string{"general", "dev", "alerts"}
 	senders := []string{"alice", "bob", "carol", "dave"}
 	templates := []string{
@@ -36,7 +40,7 @@ func runChatFeeder(ctx context.Context, yield func(ChatMessageData) error, inter
 				Text:      templates[rng.Intn(len(templates))],
 				Timestamp: ts.UTC().Format(time.RFC3339),
 			}
-			if err := yield(msg); err != nil {
+			if err := yield(ctx, msg); err != nil {
 				log.Printf("[chat] yield: %v", err)
 			}
 		}
@@ -46,8 +50,8 @@ func runChatFeeder(ctx context.Context, yield func(ChatMessageData) error, inter
 // injectChat is a /inject-style helper exposed to the walkthrough so
 // the live demo can deterministically post one event of a given
 // channel rather than wait for the random feeder to land it.
-func injectChat(yield func(ChatMessageData) error, channel, sender, text string) error {
-	return yield(ChatMessageData{
+func injectChat(ctx context.Context, yield func(context.Context, ChatMessageData) error, channel, sender, text string) error {
+	return yield(ctx, ChatMessageData{
 		Channel:   channel,
 		Sender:    sender,
 		Text:      text,


### PR DESCRIPTION
## What changes

Closes the remaining piece of issue 667 — `examples/events/kitchen-sink` now opts into the same SEP-414 observability surface as `whole-enchilada/event-server`. Pass `EXPORTER=stdout|otlp|auto` (or use `make serve-otlp`) to emit spans either at stdout or against the `docker/observability/` LGTM stack under service `kitchen-sink-events`.

**Discovered in passing** (and folded into this PR because the wiring change can't compile without it): kitchen-sink was missed in PR 712's `yield(ctx, ...)` signature sweep — only `examples/events/discord` + `telegram` + `whole-enchilada` got swept. `go build ./examples/events/kitchen-sink/` was failing on main before this PR.

```mermaid
sequenceDiagram
    participant F as feeder goroutine (ctx)
    participant Y as yield(ctx, Data)
    participant S as Server (SEP-414 P2)
    participant W as WebhookRegistry (PR 714)
    F->>Y: synthetic chat / alert message
    Y->>S: events.Emit(ctx, ...) → broadcast / fanout
    S-->>S: dispatch spans (events/subscribe / poll / ...)
    Y->>W: webhook delivery
    W-->>W: events.webhook.deliver span (attributes set)
    Note over S,W: kitchen-sink-events service in Grafana
```

## Reviewer's guide

Read in this order:

1. [examples/events/kitchen-sink/main.go](https://github.com/panyam/mcpkit/pull/725/files#diff-00227e3ff7d30e48422daed74f9cb228708d8e8ce9c7294358114d64c21173ac) — start here. New `commonotel.SetupTelemetry` block in `serve()` (mirrors whole-enchilada/event-server's setup); `buildServer` gains a `tp core.TracerProvider` param and conditionally appends `events.WithWebhookTracerProvider(tp)` + `server.WithTracerProvider(tp)` (nil-safe — tests pass nil for Noop). Two yield call sites switched to `r.Context()`.
2. [examples/events/kitchen-sink/synthetic_chat.go](https://github.com/panyam/mcpkit/pull/725/files#diff-f21b864b88a7fffa58b02b7e9fbaa5ef3ebdd29081631c55b488890186684d1c) + `synthetic_alert.go` — PR 712 follow-up sweep. `runChatFeeder` / `runAlertFeeder` / `injectChat` / `injectAlert` all take ctx now and thread it into `yield(ctx, data)`. Docstring on each call out the PR 712 lineage so a cold reader knows the why.
3. [examples/events/kitchen-sink/e2e_test.go](https://github.com/panyam/mcpkit/pull/725/files#diff-f0a53f62bfe1bdb89d8540cd5a219ba2f2e7ce07433b27c91eb8ec63f28e74b2) — mechanical sweep. `buildServer(":0")` → `buildServer(":0", nil)`; 3 `injectChat` + 3 `injectAlert` calls take `context.Background()` first arg.
4. [examples/events/kitchen-sink/Makefile](https://github.com/panyam/mcpkit/pull/725/files#diff-24df60a0f80a06fc1e2348fbcbd0eb3d1d8b11208e0f1f7a0ee90553a751bee0) — new `EXPORTER` doc-block, `--exporter` arg threaded into `serve`, new `serve-otlp` convenience target.
5. [examples/events/kitchen-sink/README.md](https://github.com/panyam/mcpkit/pull/725/files#diff-fce4a8a3a4987fa9c6d517630dd5564f3517d169cccd632735e688318d5c7c55) — new "Tracing" subsection with the four-value EXPORTER matrix + Grafana navigation hint + link to follow-up issue 724 for the deferred Match/Transform spans.

## Diff groups

- **Production wiring**: `main.go`
- **PR 712 follow-up sweep**: `synthetic_chat.go`, `synthetic_alert.go`, `main.go` (struct + call sites), `e2e_test.go`
- **Docs**: `README.md`, `Makefile`

## Decision log

- **Bundle the PR 712 sweep with the wiring change.** Build was broken on main; the wiring change can't compile without the sweep. Splitting would have meant filing a "fix kitchen-sink build" PR first as a prerequisite — same files, double the review overhead, no clarity gain.
- **`buildServer(addr, tp)` over a Config struct.** kitchen-sink's tests already pass strings as positional args; growing to a Config struct would be over-engineering for two parameters. `tp` is nil-safe (tests pass nil) — matches the `server.WithTracerProvider(nil)` precedent.
- **Per-subscription Match/Transform spans deferred to issue 724.** Acceptance bullet "per-subscriber spans visible" is partly satisfied here: each subscribe / unsubscribe / poll dispatch IS a span (free from `server.WithTracerProvider`). What's NOT delivered: a span per `safeMatch` / `safeTransform` invocation on the fanout. That's hot-path territory — kitchen-sink's feeders fire every 2-4s × N subscribers, so per-call spans need sampling design. Filed as #724 with three options laid out (per-call / per-fanout summary / sampled).
- **`make serve-otlp` convenience target.** Lower-friction than `EXPORTER=auto make serve` for the demo-first audience. `auto` semantics (silent Noop fallback) keep `make demo-otlp` from breaking when the LGTM stack isn't up.

## Risk / blast radius

- **Affects**: only `examples/events/kitchen-sink/`. No core / server / events module changes.
- **Backwards compat**: default `EXPORTER=""` produces a Noop TracerProvider — zero behavior change for anyone running `make serve` without the env. The PR 712 sweep is forced (build was broken on main); existing callers of `injectChat` / `injectAlert` in any downstream consumer (none exist outside this module) would need a one-line ctx update.
- **Tests covering this**: existing `e2e_test.go` (full suite passes — `cd examples/events/kitchen-sink && go test ./...` ✅). No new tests added — the precedent (whole-enchilada/event-server doesn't have dedicated TP tests either) is to rely on existing e2e tests as the regression guard.
- **Be paranoid about**: nothing — change is additive when `EXPORTER` is unset.

## Before / after

```
$ go build ./examples/events/kitchen-sink/  # before this PR
./main.go:144:42: cannot use chatYield (variable of type
   func(context.Context, ChatMessageData) error) as
   func(ChatMessageData) error value in struct literal
./main.go:145:35: cannot use alertYield (variable of type
   func(context.Context, AlertData) error) as
   func(AlertData) error value in struct literal

$ go build ./examples/events/kitchen-sink/  # after
(clean)

$ EXPORTER=stdout go test -count=1 ./examples/events/kitchen-sink/
ok  github.com/panyam/mcpkit/examples/events/kitchen-sink  1.292s
```

## Out of scope (filed as follow-ups)

- **Per-subscription Match/Transform span emission** on the fanout hot path — needs sampling design. Tracked as issue 724.
- **Walkthrough beat** demonstrating the trace stitching in Grafana — could land alongside #724 when the per-subscription spans actually exist; without them the walkthrough only has dispatch + webhook spans to show, which is thin demo value vs. the per-subscriber story the walkthrough already tells in prose.

Closes issue 667. Part of the SEP-414 P6 / examples observability umbrella (663 / 669).
