### PR TITLE
whole-enchilada/event-server: adopt common.MCPServerOptions (CONVENTIONS gap)

### DIFF
--- a/examples/events/whole-enchilada/event-server/main.go
+++ b/examples/events/whole-enchilada/event-server/main.go
@@ -109,11 +109,17 @@ func main() {
 	}
 	webhooks := events.NewWebhookRegistry(webhookOpts...)
 
-	srvOpts := []server.Option{
+	// Canonical baseline (WithListen + the color logger wired to both
+	// transport request logging and dispatch middleware) per
+	// examples/CONVENTIONS.md § serve-srv-listenandserve. Matches the
+	// discord precedent — event-server can't use `common.RunServer`
+	// because of the per-realm BCL handler wiring + custom mux + Postgres
+	// backend lifecycle, but the per-option baseline still applies.
+	srvOpts := common.MCPServerOptions(*addr, "[mcp] ")
+	srvOpts = append(srvOpts,
 		server.WithSubscriptions(),
-		server.WithListen(*addr),
 		server.WithTracerProvider(tp),
-	}
+	)
 
 	// Auth posture (introspection > JWT > anonymous), matching the
 	// discord / telegram demo pattern. Introspection wins when both


### PR DESCRIPTION
## What changes

Folds the canonical color-logger baseline into `examples/events/whole-enchilada/event-server/main.go` — same pattern PR 725 (the kitchen-sink obs wiring PR) applied. event-server was creating its server with raw `server.NewServer(info, []server.Option{WithSubscriptions, WithListen, WithTracerProvider}...)`, skipping the `NewMCPLogger` + `WithRequestLogging` + `LoggingMiddleware` triple that `common.MCPServerOptions(addr, "[mcp] ")` ships. Now matches the discord precedent (`examples/events/discord/main.go:152`) and the `examples/CONVENTIONS.md` § serve-srv-listenandserve checklist.

## Reviewer's guide

1. [examples/events/whole-enchilada/event-server/main.go](https://github.com/panyam/mcpkit/pull/728/files#diff-b68bee649bce17c0a368e1338cfca30c1f0941204495cefb18dc61655d352796) — only file. The `srvOpts` initialization switches from raw `[]server.Option{...}` to `common.MCPServerOptions(*addr, "[mcp] ")` + append. `server.WithListen` moves into the helper (was explicit before); `WithSubscriptions` + `WithTracerProvider(tp)` + the auth branch all stay as-is.

## Diff groups

Single-purpose — one conventions adoption.

## Decision log

- **`common.MCPServerOptions` over `common.RunServer`.** event-server has substantial divergence from the canonical `RunServer` shape: per-realm BCL handler wiring, custom mux, Postgres backend lifecycle. `common.RunServer` doesn't fit. The per-option `MCPServerOptions` baseline does (matches the discord carve-out documented in the conventions).
- **Why now, not later.** Was a known gap captured in session memory after the PR 725 audit. Easier to fold in as a standalone ~5-line PR than to wait for a prod-events sweep that might never happen.

## Risk / blast radius

- **Affects**: only `examples/events/whole-enchilada/event-server/main.go`. No library / module changes.
- **Backwards compat**: functional behavior unchanged. The server still listens on `*addr` (now via the helper). TracerProvider + auth wiring preserved exactly. Logger output gains the `[mcp]` prefix + canonical color formatting.
- **Tests covering this**: `go test ./examples/events/whole-enchilada/event-server/...` passes. Build clean.

## Before / after

```
$ go test ./examples/events/whole-enchilada/event-server/...
ok  github.com/panyam/mcpkit/examples/events/whole-enchilada/event-server  0.784s
```

Refs PR 725 (kitchen-sink applied the same pattern). Closes the known unfiled gap captured during the PR 725 conventions audit.
