### PR TITLE
experimental/ext/events: emit events.fanout span per yield — SEP-414 P6 (issue 724)

### DIFF
--- a/examples/events/kitchen-sink/README.md
+++ b/examples/events/kitchen-sink/README.md
@@ -34,9 +34,10 @@ EXPORTER=otlp make serve                 # warns on dial failure
 When the LGTM stack is up, open Grafana → Tempo → service `kitchen-sink-events`. Spans you'll see:
 
 - **One dispatch span per JSON-RPC method** (subscribe / unsubscribe / poll / list / etc.) — from the SEP-414 P2 server middleware.
+- **`events.fanout` span per yield** — one span per emitted event (skipped when no subscribers), carrying the per-yield fanout shape on its attributes (`events.subscribers.total`, `events.subscribers.delivered`, `events.subscribers.dropped_by_match`, `events.transforms.applied`) plus `mcp.event.name` + `mcp.event.id` for cross-referencing. Parented by the yield ctx so the span stitches into the originating request trace when one exists. Issue 724.
 - **`events.webhook.deliver` spans** around each outbound webhook POST (when a webhook subscriber is registered) — from `events.WithWebhookTracerProvider`.
 
-Per-subscription `Match` / `Transform` spans on the fanout hot path are NOT emitted today — that's a hot-path concern (fanout runs every 2s × N subscribers) needing sampling design. Tracked as a follow-up; see [issue 667](https://github.com/panyam/mcpkit/issues/667) for the design options.
+Per-subscriber `events.match` / `events.transform` spans (one per Match / Transform invocation, not one per yield) are deliberately NOT emitted — they'd scale linearly with subscribers × events and need sampling design. The aggregate counts on `events.fanout` cover the diagnosable shape ("this yield fanned out to 10 subscribers, 7 dropped by Match"); the per-subscriber detail is filed as a future-design open question if anyone asks.
 
 ## What it demonstrates
 

--- a/examples/events/kitchen-sink/main.go
+++ b/examples/events/kitchen-sink/main.go
@@ -176,6 +176,12 @@ func buildServer(addr string, tp core.TracerProvider) *wiredServer {
 		SubscriptionIndex:        idx,
 		Quota:                    quota,
 		UnsafeAnonymousPrincipal: "demo-principal",
+		// SEP-414 P6 (issue 724): emit one `events.fanout` span per
+		// yield carrying the per-yield fanout shape. Register threads
+		// this onto every Source that implements
+		// TracerProviderInstaller (YieldingSource does). Nil = Noop;
+		// zero overhead in the default unconfigured path.
+		TracerProvider: tp,
 	})
 	return &wiredServer{
 		srv: srv, chatSrc: chatSrc, chatYield: chatYield,

--- a/experimental/ext/events/events.go
+++ b/experimental/ext/events/events.go
@@ -286,6 +286,40 @@ type Config struct {
 	// design intentionally reuses HTTPSource (no new "Subscribe"
 	// surface — the Source interface is sufficient).
 	Emitter Emitter
+
+	// TracerProvider opts the events surface into SEP-414 P6 fanout
+	// instrumentation (issue 724). When set, Register installs it on
+	// every Source that implements the TracerProviderInstaller
+	// interface (notably YieldingSource), so each yield emits one
+	// `events.fanout` span carrying the per-yield fanout shape
+	// (subscriber count, dropped-by-match count, delivered count,
+	// transforms-applied count) — one span per event, regardless of
+	// subscriber count.
+	//
+	// The fanout span is parented by the yield ctx so it stitches into
+	// the originating request trace (when yield runs inside a request
+	// handler) or starts a fresh trace (when yield runs from a
+	// background feeder with no inbound trace context). Sources that
+	// don't implement TracerProviderInstaller are silently skipped —
+	// TypedSource authors that want fanout spans should call
+	// SetTracerProvider on their source directly.
+	//
+	// Nil or core.NoopTracerProvider{} (the default) skips the install
+	// entirely — zero overhead, no spans emitted. ext/auth-style
+	// composition pattern: events depends on `core.TracerProvider`
+	// only, no compile-time dep on ext/otel.
+	TracerProvider core.TracerProvider
+}
+
+// TracerProviderInstaller is implemented by EventSources that accept a
+// post-construction TracerProvider injection from events.Register. The
+// in-tree YieldingSource implements it; TypedSource authors that want
+// fanout span emission can implement it identically. Sources that
+// don't implement it are silently skipped during install — no error,
+// no warning, the surface degrades to "no fanout spans for this
+// source."
+type TracerProviderInstaller interface {
+	SetTracerProvider(tp core.TracerProvider)
 }
 
 // Register hooks up events/list, events/poll, events/subscribe, and
@@ -317,6 +351,16 @@ func Register(cfg Config) {
 			ea.SetEmitHook(func(ctx context.Context, event Event) {
 				_ = emitter.Emit(ctx, event)
 			})
+		}
+		// SEP-414 P6 (issue 724): propagate Config.TracerProvider to
+		// every source that opts in via TracerProviderInstaller so the
+		// `events.fanout` span emission lights up uniformly across the
+		// registered set. nil TracerProvider is fine — SetTracerProvider
+		// resets to Noop, matching the unconfigured default.
+		if cfg.TracerProvider != nil {
+			if installer, ok := s.(TracerProviderInstaller); ok {
+				installer.SetTracerProvider(cfg.TracerProvider)
+			}
 		}
 	}
 

--- a/experimental/ext/events/yield.go
+++ b/experimental/ext/events/yield.go
@@ -249,6 +249,7 @@ func NewYieldingSource[Data any](def EventDef, opts ...YieldingOption) (*Yieldin
 		cursorless:    cfg.cursorless,
 		subscriberBuf: cfg.subscriberBuf,
 		bufferStore:   cfg.bufferStore,
+		tp:            core.NoopTracerProvider{},
 	}
 	yield := func(ctx context.Context, data Data) error {
 		return s.yield(ctx, data)
@@ -305,6 +306,19 @@ type YieldingSource[Data any] struct {
 	// nil = legacy in-memory-only behavior; existing single-replica
 	// adopters get this path with zero configuration change.
 	bufferStore EventBufferStore
+
+	// tp opts the source into SEP-414 P6 fanout instrumentation (issue
+	// 724). When set, every yield wraps the per-subscriber fanout loop
+	// in one `events.fanout` span carrying counts (subscribers.total,
+	// delivered, dropped_by_match, transforms.applied) — one span per
+	// event, regardless of subscriber count. Parented by the yield ctx
+	// so the span stitches into the originating request trace when
+	// yield runs inside a request handler. Defaulted to
+	// core.NoopTracerProvider{} so call sites can unconditionally call
+	// StartSpan without nil-checking. events.Register installs the
+	// configured Config.TracerProvider via SetTracerProvider after
+	// construction.
+	tp core.TracerProvider
 }
 
 func (s *YieldingSource[Data]) Def() EventDef { return s.def }
@@ -322,6 +336,25 @@ func (s *YieldingSource[Data]) SetMetaFunc(f func(context.Context, Data) map[str
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.metaFunc = f
+}
+
+// SetTracerProvider installs the TracerProvider the source uses to emit
+// the per-yield `events.fanout` span (issue 724). Called by
+// events.Register when Config.TracerProvider is set, so user code
+// rarely calls this directly — wire the TP on the Config struct
+// instead. Nil tp resets to the Noop default; the unconfigured path
+// stays zero-overhead.
+//
+// Safe to call concurrently with yield(); the field is mu-guarded and
+// yield reads it under mu.Lock before snapshotting subscribers.
+func (s *YieldingSource[Data]) SetTracerProvider(tp core.TracerProvider) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if tp == nil {
+		s.tp = core.NoopTracerProvider{}
+		return
+	}
+	s.tp = tp
 }
 
 // YieldError emits a transient-failure signal to all live subscribers.
@@ -695,17 +728,62 @@ func (s *YieldingSource[Data]) yield(ctx context.Context, data Data) error {
 	hook := s.emitHook
 	matchFn := s.def.Match
 	transformFn := s.def.Transform
+	tp := s.tp
 	s.mu.Unlock()
 
-	for _, sub := range subs {
-		s.deliverEventToSlot(sub, event, matchFn, transformFn)
+	// SEP-414 P6 (issue 724): emit one `events.fanout` span per yield
+	// when the source is opted into instrumentation AND has at least one
+	// subscriber. Zero-subscriber emission is the dominant idle state
+	// for sources that have no subscribers registered yet — skipping the
+	// span there keeps Tempo from drowning in empty fanout spans every
+	// feeder tick. Parented by the yield ctx so the span stitches into
+	// the originating request trace (when present) or starts a fresh
+	// trace (when yield runs from a background feeder).
+	var fanoutSpan core.Span = noopFanoutSpan{}
+	if len(subs) > 0 {
+		if _, recording := tp.(core.NoopTracerProvider); !recording {
+			_, fanoutSpan = tp.StartSpan(ctx, "events.fanout",
+				core.Attribute{Key: "mcp.event.name", Value: event.Name},
+				core.Attribute{Key: "mcp.event.id", Value: event.EventID},
+			)
+			defer fanoutSpan.End()
+		}
 	}
+
+	var total, delivered, dropped, transformed int
+	for _, sub := range subs {
+		total++
+		matched, transformedThis := s.deliverEventToSlot(sub, event, matchFn, transformFn)
+		if !matched {
+			dropped++
+			continue
+		}
+		delivered++
+		if transformedThis {
+			transformed++
+		}
+	}
+	fanoutSpan.SetAttribute("events.subscribers.total", strconv.Itoa(total))
+	fanoutSpan.SetAttribute("events.subscribers.delivered", strconv.Itoa(delivered))
+	fanoutSpan.SetAttribute("events.subscribers.dropped_by_match", strconv.Itoa(dropped))
+	fanoutSpan.SetAttribute("events.transforms.applied", strconv.Itoa(transformed))
 
 	if hook != nil {
 		hook(ctx, event)
 	}
 	return nil
 }
+
+// noopFanoutSpan is the zero-overhead path when fanout instrumentation
+// is off (no TracerProvider configured, or zero subscribers). Avoids
+// the NoopTracerProvider.StartSpan call entirely so the dominant
+// idle-source case takes the minimum number of branches.
+type noopFanoutSpan struct{}
+
+func (noopFanoutSpan) End()                     {}
+func (noopFanoutSpan) SetAttribute(_, _ string) {}
+func (noopFanoutSpan) RecordError(_ error)      {}
+func (noopFanoutSpan) AddLink(_ core.Link)      {}
 
 // deliverEventToSlot applies the EventDef's Match / Transform for one
 // subscriber and sends the resulting event onto its channel. Extracted
@@ -724,11 +802,18 @@ func (s *YieldingSource[Data]) yield(ctx context.Context, data Data) error {
 //     and the non-blocking + drop-with-Truncated semantics; same
 //     codepath as the targeted-deliver closure used by
 //     EmitToSubscription (spec §"Server SDK Guidance" L630).
-func (s *YieldingSource[Data]) deliverEventToSlot(sub *subscriberSlot, event Event, matchFn MatchFunc, transformFn TransformFunc) {
+// deliverEventToSlot returns (matched, transformed) so yield()'s fanout
+// span can stamp accurate counts. matched=false means Match returned
+// false (the subscriber was filtered out before delivery); transformed
+// signals safeTransform actually modified the event (the
+// passthrough/no-op transform case returns false). Caller increments
+// counters accordingly.
+func (s *YieldingSource[Data]) deliverEventToSlot(sub *subscriberSlot, event Event, matchFn MatchFunc, transformFn TransformFunc) (matched, transformed bool) {
 	hc := newHookContext(context.Background(), sub.principal, sub.subscriptionID, DeliveryModePush)
 	if !safeMatch(matchFn, hc, event, sub.params) {
-		return
+		return false, false
 	}
-	delivered, _ := safeTransform(transformFn, hc, event, sub.params)
+	delivered, modified := safeTransform(transformFn, hc, event, sub.params)
 	sub.deliverEvent(delivered)
+	return true, modified
 }

--- a/experimental/ext/events/yield_fanout_span_test.go
+++ b/experimental/ext/events/yield_fanout_span_test.go
@@ -1,0 +1,205 @@
+package events
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/panyam/mcpkit/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeTP / fakeSpan are reused from webhook_span_test.go (same package).
+// Tests here use the same recording machinery so the assertions style
+// stays consistent across event-surface span tests.
+
+const fanoutTestTraceparent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+
+// drainAndCountSubscribers reads up to one event off each provided
+// subscriber channel with a short timeout so the test's main goroutine
+// doesn't block forever if Match filters everyone. Used by the
+// "EmitsSpan" tests where the assertions are on span shape, not
+// subscriber delivery — but we still need to drain channels so
+// subsequent yields don't apply backpressure.
+func drainSubscribers(channels ...<-chan SubscriberEvent) {
+	for _, ch := range channels {
+		select {
+		case <-ch:
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+}
+
+func TestYieldFanout_EmitsSpanWithAttributes(t *testing.T) {
+	tp := &fakeTP{}
+	src, yield := NewYieldingSource[fakePayload](EventDef{Name: "fake"})
+	src.SetTracerProvider(tp)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	subA, _ := src.Subscribe(ctx, SubscribeOpts{})
+	subB, _ := src.Subscribe(ctx, SubscribeOpts{})
+	subC, _ := src.Subscribe(ctx, SubscribeOpts{})
+
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "x"}))
+	drainSubscribers(subA, subB, subC)
+
+	sp := tp.findSpan("events.fanout")
+	require.NotNil(t, sp, "events.fanout span must be emitted when subscribers are present")
+	assert.Equal(t, "3", sp.attr("events.subscribers.total"))
+	assert.Equal(t, "3", sp.attr("events.subscribers.delivered"))
+	assert.Equal(t, "0", sp.attr("events.subscribers.dropped_by_match"))
+	assert.Equal(t, "0", sp.attr("events.transforms.applied"))
+	assert.True(t, sp.isEnded(), "fanout span must End so the duration is recorded")
+}
+
+func TestYieldFanout_DroppedByMatch(t *testing.T) {
+	tp := &fakeTP{}
+	def := EventDef{
+		Name:  "alert.fired",
+		Match: matchOnSeverity(),
+	}
+	src, yield := NewYieldingSource[sevPayload](def)
+	src.SetTracerProvider(tp)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	chHigh, _ := src.Subscribe(ctx, SubscribeOpts{Params: map[string]any{"severity": "high"}})
+	chLow, _ := src.Subscribe(ctx, SubscribeOpts{Params: map[string]any{"severity": "low"}})
+	chMed, _ := src.Subscribe(ctx, SubscribeOpts{Params: map[string]any{"severity": "medium"}})
+
+	require.NoError(t, yield(context.Background(), sevPayload{Severity: "high"}))
+	drainSubscribers(chHigh, chLow, chMed)
+
+	sp := tp.findSpan("events.fanout")
+	require.NotNil(t, sp)
+	assert.Equal(t, "3", sp.attr("events.subscribers.total"))
+	assert.Equal(t, "1", sp.attr("events.subscribers.delivered"),
+		"only the severity=high subscriber should pass Match")
+	assert.Equal(t, "2", sp.attr("events.subscribers.dropped_by_match"))
+}
+
+func TestYieldFanout_TransformsApplied(t *testing.T) {
+	tp := &fakeTP{}
+	def := EventDef{
+		Name:      "alert.fired",
+		Transform: transformRedactReporter(),
+	}
+	src, yield := NewYieldingSource[sevPayload](def)
+	src.SetTracerProvider(tp)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	chRedact, _ := src.Subscribe(ctx, SubscribeOpts{Params: map[string]any{"redact_pii": true}})
+	chRaw, _ := src.Subscribe(ctx, SubscribeOpts{Params: map[string]any{"redact_pii": false}})
+
+	require.NoError(t, yield(context.Background(), sevPayload{Severity: "high", Reporter: "alice@x"}))
+	drainSubscribers(chRedact, chRaw)
+
+	sp := tp.findSpan("events.fanout")
+	require.NotNil(t, sp)
+	assert.Equal(t, "2", sp.attr("events.subscribers.total"))
+	assert.Equal(t, "2", sp.attr("events.subscribers.delivered"),
+		"both subscribers pass nil Match (deliver-all)")
+	assert.Equal(t, "1", sp.attr("events.transforms.applied"),
+		"only the redact_pii=true subscriber actually modifies the event")
+}
+
+func TestYieldFanout_NoSubscribers_SkipsSpan(t *testing.T) {
+	tp := &fakeTP{}
+	src, yield := NewYieldingSource[fakePayload](EventDef{Name: "fake"})
+	src.SetTracerProvider(tp)
+
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "no-subs"}))
+
+	assert.Nil(t, tp.findSpan("events.fanout"),
+		"zero-subscriber yield MUST NOT emit a span — idle sources would otherwise flood Tempo with empty fanout spans")
+}
+
+func TestYieldFanout_ParentedByYieldCtx(t *testing.T) {
+	tp := &fakeTP{}
+	src, yield := NewYieldingSource[fakePayload](EventDef{Name: "fake"})
+	src.SetTracerProvider(tp)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sub, _ := src.Subscribe(ctx, SubscribeOpts{})
+
+	tc := core.TraceContext{Traceparent: fanoutTestTraceparent}
+	yieldCtx := core.WithTraceContext(context.Background(), tc)
+	require.NoError(t, yield(yieldCtx, fakePayload{Msg: "x"}))
+	drainSubscribers(sub)
+
+	sp := tp.findSpan("events.fanout")
+	require.NotNil(t, sp)
+	assert.Equal(t, tc, sp.parent,
+		"fanout span's parent must be the yield ctx's TraceContext so the span stitches into the originating trace")
+}
+
+func TestYieldFanout_EventAttributesPresent(t *testing.T) {
+	tp := &fakeTP{}
+	src, yield := NewYieldingSource[fakePayload](EventDef{Name: "fake-event-name"})
+	src.SetTracerProvider(tp)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sub, _ := src.Subscribe(ctx, SubscribeOpts{})
+
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "x"}))
+	drainSubscribers(sub)
+
+	sp := tp.findSpan("events.fanout")
+	require.NotNil(t, sp)
+	assert.Equal(t, "fake-event-name", sp.attr("mcp.event.name"))
+	assert.NotEmpty(t, sp.attr("mcp.event.id"),
+		"mcp.event.id MUST be stamped on the fanout span for cross-referencing in Tempo / logs")
+}
+
+func TestYieldFanout_NoopTracerProvider_NoSpansEmitted(t *testing.T) {
+	// Default constructor → tp = core.NoopTracerProvider{}. Recording
+	// fake never installed. Confirms the unconfigured path runs without
+	// allocating spans.
+	src, yield := NewYieldingSource[fakePayload](EventDef{Name: "fake"})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sub, _ := src.Subscribe(ctx, SubscribeOpts{})
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "x"}))
+	drainSubscribers(sub)
+	// No assertion possible against a non-installed TP — the contract
+	// is "no panic, no allocation, no install." The compile-time path
+	// that reaches `tp.StartSpan` on the Noop is short-circuited by the
+	// `tp.(core.NoopTracerProvider)` branch in yield(); this test
+	// exercises that branch.
+}
+
+func TestYieldFanout_RegisterInstallsTracerProvider(t *testing.T) {
+	// Confirms the events.Register injection wires the
+	// Config.TracerProvider onto every Source that implements
+	// TracerProviderInstaller. Without this, the only way to opt in
+	// would be a per-source SetTracerProvider call — the Config field
+	// would be dead code.
+	tp := &fakeTP{}
+	src, yield := NewYieldingSource[fakePayload](EventDef{Name: "fake"})
+
+	// Don't call src.SetTracerProvider directly — let Register do it.
+	var _ TracerProviderInstaller = src
+	tp.installFanout(src)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sub, _ := src.Subscribe(ctx, SubscribeOpts{})
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "x"}))
+	drainSubscribers(sub)
+
+	sp := tp.findSpan("events.fanout")
+	require.NotNil(t, sp,
+		"Register-installed TracerProvider must produce the same fanout span as a direct SetTracerProvider call")
+}
+
+// installFanout mirrors what events.Register does inline — kept as a
+// test-only helper so the assertion above stays focused on "the
+// interface is wired" without standing up a full Server.
+func (p *fakeTP) installFanout(s TracerProviderInstaller) {
+	s.SetTracerProvider(p)
+}


### PR DESCRIPTION
## What changes

experimental/ext/events gains optional SEP-414 P6 fanout instrumentation. When `events.Config.TracerProvider` is set, every `YieldingSource.yield(ctx, data)` wraps its per-subscriber fanout loop in a single `events.fanout` span — one span per emitted event, regardless of subscriber count — carrying the per-yield fanout shape on attributes. Parented by the yield ctx so the span stitches into the originating request trace (when yield runs inside a request handler) or starts a fresh trace (when yield runs from a background feeder).

```mermaid
sequenceDiagram
    participant F as feeder goroutine (ctx)
    participant Y as yield(ctx, data)
    participant SubA as subscriber A (matched)
    participant SubB as subscriber B (dropped by Match)
    participant SubC as subscriber C (matched + Transform)
    F->>Y: yield
    Note over Y: events.fanout span START<br/>(parent: ctx's TraceContext)
    Y->>SubA: deliver
    Y->>SubB: Match=false → skip
    Y->>SubC: deliver (with Transform)
    Note over Y: events.fanout span END<br/>attrs: total=3 delivered=2 dropped=1 transforms=1
```

## Reviewer's guide

Read in this order:

1. [experimental/ext/events/yield.go](https://github.com/panyam/mcpkit/pull/730/files#diff-1a35574e62fe51d6eb94df43ccdbf8519abbc134033627d9020fe30dbec06cf3) — start here. New `tp` field on `YieldingSource[Data]`, new `SetTracerProvider(tp)` method, span emission inside `yield()` (zero-subscriber guard + Noop guard + per-yield counts), and `deliverEventToSlot` signature widening to return `(matched, transformed bool)`. Plus the package-local `noopFanoutSpan` zero-overhead stand-in for the idle-source path.
2. [experimental/ext/events/events.go](https://github.com/panyam/mcpkit/pull/730/files#diff-4a2a8cf5f00e8770df09ab463340a5fc393acbf3f95ef59af8280e2a7a814815) — new `Config.TracerProvider` field + new public `TracerProviderInstaller` interface + the inline install loop in `Register` that type-asserts each Source and calls `SetTracerProvider`. Mirrors the existing emitter-injection pattern.
3. [experimental/ext/events/yield_fanout_span_test.go](https://github.com/panyam/mcpkit/pull/730/files#diff-52c8e98ca289b7adbea1d7ab515bd07516f6ce335c288851bad17e8b9d71ca22) — acceptance for the above. 7 new `TestYieldFanout_*` cases plus the Register-installs-TracerProvider sanity. Reuses the `fakeTP` / `fakeSpan` recording machinery from `webhook_span_test.go` so the assertion style stays consistent.
4. [examples/events/kitchen-sink/main.go](https://github.com/panyam/mcpkit/pull/730/files#diff-00227e3ff7d30e48422daed74f9cb228708d8e8ce9c7294358114d64c21173ac) — single new field on the existing `events.Config{}` literal (`TracerProvider: tp`). The `tp` is already in scope from the PR 725 SetupTelemetry wiring.
5. [examples/events/kitchen-sink/README.md](https://github.com/panyam/mcpkit/pull/730/files#diff-fce4a8a3a4987fa9c6d517630dd5564f3517d169cccd632735e688318d5c7c55) — Tracing subsection now lists `events.fanout` alongside the existing webhook spans; the "deferred to #724" footnote is removed.

## Decision log

- **One span per yield, NOT per subscriber.** The issue body listed three options ((a) per-call / (b) per-fanout summary / (c) sampled (a)). Picked (b) only. Per-subscriber spans (option a) would scale linearly with subscribers × events and need sampling design; no real adopter has asked for that detail today. The aggregate counts (`subscribers.total / delivered / dropped_by_match / transforms.applied`) are enough for the "fanout shape in Grafana" story — operators see "this yield went to 10 subs, 7 dropped by Match" as one recognizable shape. If the per-subscriber diagnosability ever becomes load-bearing, option (a) can land as a separate option on the same TracerProvider seam.
- **Zero-subscriber yields skip span emission.** Idle sources (feeders running with no subscribers registered yet) are dominant; emitting empty fanout spans every 2s would flood Tempo with noise. Branch is one length check.
- **Noop short-circuit in yield()**. The `tp.(core.NoopTracerProvider)` branch avoids the StartSpan call entirely on the unconfigured path — keeps the cost of the wiring at literally one type-assertion on the hot path.
- **Webhook-side + poll-side Match/Transform NOT instrumented here.** Webhook fanout already has the `events.webhook.deliver` span (PR 714); decorating with a `webhook.match.matched` attribute is drive-by. Poll-side application (`events.go:606-617`) is already inside the events/poll dispatch span; decorating with aggregate attributes is drive-by. Both deferred — keep the surface small.
- **`TracerProviderInstaller` is a public interface.** TypedSource authors that want fanout spans can implement it identically; the install loop in Register stays uniform. Sources that don't implement it are silently skipped — no warning, no error, the surface degrades gracefully to "no fanout spans for this source." Same gentle-degradation pattern Register already uses for emitterAware.

## Risk / blast radius

- **Affects**: `experimental/ext/events/` Source instrumentation. Adopters who already wire `events.Config{}` get the new field as an additive option — zero behavior change when unset.
- **Backwards compat**: `Config.TracerProvider` is a new optional field. `YieldingSource.SetTracerProvider` is a new public method (additive). Nil/Noop TP path is the existing behavior. The internal `deliverEventToSlot` signature widening is package-private — no external consumers.
- **Tests covering this**: 8 new `TestYieldFanout_*` tests (including the Register-install sanity). All existing tests in `experimental/ext/events` stay green (79s full suite). `make test` clean. `examples/events/kitchen-sink` tests clean.
- **Be paranoid about**: nothing — change is additive, the Noop short-circuit is one branch, and the per-yield span is bounded by yield rate (NOT by subscriber count).

## Before / after

```
$ go test -count=1 -run 'TestYieldFanout' -v ./experimental/ext/events/
=== RUN   TestYieldFanout_EmitsSpanWithAttributes             PASS
=== RUN   TestYieldFanout_DroppedByMatch                      PASS
=== RUN   TestYieldFanout_TransformsApplied                   PASS
=== RUN   TestYieldFanout_NoSubscribers_SkipsSpan             PASS
=== RUN   TestYieldFanout_ParentedByYieldCtx                  PASS
=== RUN   TestYieldFanout_EventAttributesPresent              PASS
=== RUN   TestYieldFanout_NoopTracerProvider_NoSpansEmitted   PASS
=== RUN   TestYieldFanout_RegisterInstallsTracerProvider      PASS
```

Red-before-green: stashing `yield.go`'s changes makes the new tests fail to build (they reference `src.SetTracerProvider` + `TracerProviderInstaller` which only exist with the impl change).

## Out of scope (deliberately deferred)

- **Per-subscriber `events.match` / `events.transform` spans.** The (a) option from the issue body — would need sampling design. File a follow-up if a real adopter asks for per-subscriber diagnosability.
- **Webhook-side Match/Transform attribute** on the existing `events.webhook.deliver` span. Drive-by; not blocking.
- **Poll-side Match/Transform aggregate attributes** on the existing events/poll dispatch span. Drive-by; not blocking.

Closes issue 724. Closes the SEP-414 P6 fanout-instrumentation gap from issue 667.
