### PR TITLE
tracing: stitch MRTR rounds via _meta.io.modelcontextprotocol/tracelink — SEP-414 P6 (issue 682)

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1013,6 +1013,20 @@ func (c *Client) CallContext(cc *CallContext, method string, params any) (*CallR
 
 // Call makes a JSON-RPC call and returns the parsed response.
 func (c *Client) Call(method string, params any) (*CallResult, error) {
+	return c.callImpl(context.Background(), method, params)
+}
+
+// callImpl is the ctx-aware body of Call. Extracted so package-private
+// callers (notably CallToolWithInputs for the SEP-414 P6 / issue 682
+// MRTR tracelink capture) can thread a ctx carrying
+// core.WithCapturedTraceContext through the middleware chain. The
+// trace middleware reads the captured-trace-context holder off ctx
+// and writes the outbound TraceContext into it, letting the caller
+// learn the round's identity for cross-round linking.
+//
+// Public Call() preserves the existing ctx-free signature by passing
+// context.Background() — no behavior change for non-MRTR callers.
+func (c *Client) callImpl(ctx context.Context, method string, params any) (*CallResult, error) {
 	traceEnabled := tracingEnabled(c.tracerProvider)
 	if len(c.callMiddleware) == 0 && !traceEnabled {
 		return c.callDirect(method, params)
@@ -1041,7 +1055,7 @@ func (c *Client) Call(method string, params any) (*CallResult, error) {
 			return mw(ctx, method, params, next)
 		}
 	}
-	return handler(context.Background(), method, params)
+	return handler(ctx, method, params)
 }
 
 // callDirect is the non-middleware Call path.

--- a/client/mrtr.go
+++ b/client/mrtr.go
@@ -73,8 +73,25 @@ func CallToolWithInputs(ctx context.Context, c *Client, name string, args any, h
 		opt(&cfg)
 	}
 
-	// First call: bare tools/call with no inputResponses.
-	resp, err := c.Call("tools/call", map[string]any{
+	// SEP-414 P6 (issue 682): capture round 1's outbound traceparent so
+	// every subsequent round can stamp it as
+	// `_meta.io.modelcontextprotocol/tracelink`. Server-side trace
+	// middleware reads the link and AddLink's the round-2+ dispatch span
+	// back to round-1's, stitching the logical operation across separate
+	// W3C traces. Star semantic — every round 2+ links to round 1, not
+	// the immediately-previous round, so backends show round 1 as the
+	// anchor regardless of how deep the loop goes.
+	//
+	// Holder remains zero when tracing isn't configured (Noop path) — the
+	// per-round Inject is a no-op in that case, so this costs at most
+	// one ctx.Value allocation on the unconfigured path.
+	ctx, capturedTC := core.WithCapturedTraceContext(ctx)
+
+	// First call: bare tools/call with no inputResponses. Use callImpl
+	// so the captured-trace-context ctx (above) actually reaches the
+	// trace middleware — Client.Call uses context.Background() and
+	// would drop our holder.
+	resp, err := c.callImpl(ctx, "tools/call", map[string]any{
 		"name":      name,
 		"arguments": args,
 	})
@@ -85,6 +102,10 @@ func CallToolWithInputs(ctx context.Context, c *Client, name string, args any, h
 	if err != nil {
 		return nil, err
 	}
+	// Snapshot the round-1 identity (if any) before the holder gets
+	// overwritten by round-2's middleware. Subsequent rounds all link
+	// to this anchor, not to the immediately-previous round.
+	round1TC := *capturedTC
 
 	for round := 0; res.IsInputRequired(); round++ {
 		if round >= cfg.maxRounds {
@@ -110,7 +131,14 @@ func CallToolWithInputs(ctx context.Context, c *Client, name string, args any, h
 		if res.InputRequired.RequestState != "" {
 			params["requestState"] = res.InputRequired.RequestState
 		}
-		resp, err := c.Call("tools/call", params)
+		// Stamp the round-1 tracelink onto round-2+ params so the
+		// server dispatch span AddLinks back to round 1. Zero-TC is a
+		// no-op so the unconfigured path stays clean.
+		var callParams any = params
+		if !round1TC.IsZero() {
+			callParams = core.InjectTraceLinkIntoParams(params, round1TC)
+		}
+		resp, err := c.callImpl(ctx, "tools/call", callParams)
 		if err != nil {
 			return nil, err
 		}

--- a/client/mrtr_test.go
+++ b/client/mrtr_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/panyam/mcpkit/client"
@@ -177,4 +178,286 @@ func connectMRTRClient(t *testing.T, srv *server.Server, opts ...client.ClientOp
 	}
 	t.Cleanup(func() { c.Close() })
 	return c, ts
+}
+
+// --- SEP-414 P6: MRTR tracelink stamping (issue 682) ----------------------
+
+const (
+	mrtrTestTraceparent1 = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+	mrtrTestTraceparent2 = "00-aabbccddeeff00112233445566778899-1122334455667788-01"
+	mrtrTestTraceparent3 = "00-deadbeefcafebabe0123456789abcdef-fedcba9876543210-01"
+)
+
+// sequencedFakeTP returns a distinct TraceContext per StartSpan call so
+// tests can verify the star-link semantic (round-2/3+ link to round 1,
+// not the immediately-previous round). Indexed by call order.
+type sequencedFakeTP struct {
+	mu  sync.Mutex
+	tcs []core.TraceContext
+	idx int
+}
+
+func (p *sequencedFakeTP) StartSpan(ctx context.Context, _ string, _ ...core.Attribute) (context.Context, core.Span) {
+	p.mu.Lock()
+	var tc core.TraceContext
+	if p.idx < len(p.tcs) {
+		tc = p.tcs[p.idx]
+	}
+	p.idx++
+	p.mu.Unlock()
+	if !tc.IsZero() {
+		ctx = core.WithTraceContext(ctx, tc)
+	}
+	return ctx, mrtrNoopSpan{}
+}
+
+type mrtrNoopSpan struct{}
+
+func (mrtrNoopSpan) End()                     {}
+func (mrtrNoopSpan) SetAttribute(_, _ string) {}
+func (mrtrNoopSpan) RecordError(_ error)      {}
+func (mrtrNoopSpan) AddLink(_ core.Link)      {}
+
+// mrtrParamsCaptureMiddleware records the raw req.Params per round so
+// tests can assert what `_meta.io.modelcontextprotocol/tracelink` the
+// client actually stamped on the wire. Records every tools/call request
+// in arrival order.
+type mrtrParamsCaptureMiddleware struct {
+	mu      sync.Mutex
+	rounds  []json.RawMessage
+}
+
+func (m *mrtrParamsCaptureMiddleware) middleware() server.Middleware {
+	return func(ctx context.Context, req *core.Request, next server.MiddlewareFunc) (*core.Response, error) {
+		if req.Method == "tools/call" {
+			m.mu.Lock()
+			// Copy so any later mutation doesn't bleed into our snapshot.
+			cp := make(json.RawMessage, len(req.Params))
+			copy(cp, req.Params)
+			m.rounds = append(m.rounds, cp)
+			m.mu.Unlock()
+		}
+		return next(ctx, req)
+	}
+}
+
+func (m *mrtrParamsCaptureMiddleware) snapshot() []json.RawMessage {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]json.RawMessage, len(m.rounds))
+	copy(out, m.rounds)
+	return out
+}
+
+// extractTraceLink pulls out _meta.io.modelcontextprotocol/tracelink from
+// a captured params payload for assertion. "" when absent.
+func extractTraceLink(t *testing.T, raw json.RawMessage) string {
+	t.Helper()
+	var envelope struct {
+		Meta map[string]any `json:"_meta"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		t.Fatalf("unmarshal params: %v (raw=%s)", err, raw)
+	}
+	if envelope.Meta == nil {
+		return ""
+	}
+	tp, _ := envelope.Meta[core.MetaKeyTraceLink].(string)
+	return tp
+}
+
+// TestCallToolWithInputs_StampsTracelinkOnRound2 — minimal acceptance
+// for issue 682. Round 1's outbound traceparent must appear as
+// `_meta.io.modelcontextprotocol/tracelink` on round 2's outbound
+// params (and NOT on round 1's — only rounds 2+ carry the link).
+func TestCallToolWithInputs_StampsTracelinkOnRound2(t *testing.T) {
+	capture := &mrtrParamsCaptureMiddleware{}
+	srv := mrtrTestServerWithMiddleware(t, capture.middleware())
+
+	tp := &sequencedFakeTP{tcs: []core.TraceContext{
+		{Traceparent: mrtrTestTraceparent1},
+		{Traceparent: mrtrTestTraceparent2},
+	}}
+	c, _ := connectMRTRClient(t, srv,
+		client.WithTracerProvider(tp),
+		client.WithElicitationHandler(func(ctx context.Context, req core.ElicitationRequest) (core.ElicitationResult, error) {
+			return core.ElicitationResult{
+				Action:  "accept",
+				Content: map[string]any{"name": "Alice"},
+			}, nil
+		}),
+	)
+
+	_, err := client.CallToolWithInputs(context.Background(), c,
+		"test_tool_with_elicitation", map[string]any{},
+		client.DefaultInputHandler(c),
+	)
+	if err != nil {
+		t.Fatalf("CallToolWithInputs: %v", err)
+	}
+
+	rounds := capture.snapshot()
+	if len(rounds) != 2 {
+		t.Fatalf("got %d rounds, want 2", len(rounds))
+	}
+	if got := extractTraceLink(t, rounds[0]); got != "" {
+		t.Errorf("round 1 MUST NOT carry tracelink (only rounds 2+ do); got %q", got)
+	}
+	if got := extractTraceLink(t, rounds[1]); got != mrtrTestTraceparent1 {
+		t.Errorf("round 2 tracelink = %q, want round-1 traceparent %q", got, mrtrTestTraceparent1)
+	}
+}
+
+// TestCallToolWithInputs_StarSemantic — round 3's tracelink MUST point
+// at round 1, NOT round 2. The mcpkit decision is star (anchor =
+// round 1), not chain (anchor = previous round). Backends following
+// the link from round 3 land directly on the originating request.
+func TestCallToolWithInputs_StarSemantic(t *testing.T) {
+	srv := server.NewServer(core.ServerInfo{Name: "mrtr-star", Version: "0.0.1"})
+	var calls int
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "three_round_tool",
+			Description: "asks for input twice, then completes",
+			InputSchema: map[string]any{"type": "object"},
+		},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+			calls++
+			switch calls {
+			case 1:
+				return ctx.RequestInput(core.InputRequests{
+					"q1": core.InputRequest{
+						Method: "elicitation/create",
+						Params: json.RawMessage(`{"message":"Q1","requestedSchema":{"type":"object","properties":{"a":{"type":"string"}},"required":["a"]}}`),
+					},
+				})
+			case 2:
+				return ctx.RequestInput(core.InputRequests{
+					"q2": core.InputRequest{
+						Method: "elicitation/create",
+						Params: json.RawMessage(`{"message":"Q2","requestedSchema":{"type":"object","properties":{"a":{"type":"string"}},"required":["a"]}}`),
+					},
+				})
+			default:
+				return core.TextResult("done"), nil
+			}
+		},
+	)
+	capture := &mrtrParamsCaptureMiddleware{}
+	srv = configureMiddleware(srv, capture.middleware())
+
+	tp := &sequencedFakeTP{tcs: []core.TraceContext{
+		{Traceparent: mrtrTestTraceparent1},
+		{Traceparent: mrtrTestTraceparent2},
+		{Traceparent: mrtrTestTraceparent3},
+	}}
+	c, _ := connectMRTRClient(t, srv,
+		client.WithTracerProvider(tp),
+		client.WithElicitationHandler(func(ctx context.Context, req core.ElicitationRequest) (core.ElicitationResult, error) {
+			return core.ElicitationResult{Action: "accept", Content: map[string]any{"a": "ok"}}, nil
+		}),
+	)
+
+	_, err := client.CallToolWithInputs(context.Background(), c,
+		"three_round_tool", map[string]any{},
+		client.DefaultInputHandler(c),
+	)
+	if err != nil {
+		t.Fatalf("CallToolWithInputs: %v", err)
+	}
+
+	rounds := capture.snapshot()
+	if len(rounds) != 3 {
+		t.Fatalf("got %d rounds, want 3", len(rounds))
+	}
+	if got := extractTraceLink(t, rounds[1]); got != mrtrTestTraceparent1 {
+		t.Errorf("round 2 tracelink = %q, want round 1 traceparent %q", got, mrtrTestTraceparent1)
+	}
+	if got := extractTraceLink(t, rounds[2]); got != mrtrTestTraceparent1 {
+		t.Errorf("round 3 tracelink = %q, want round 1 traceparent %q (STAR semantic — not chain)", got, mrtrTestTraceparent1)
+	}
+}
+
+// TestCallToolWithInputs_NoTracerProvider_NoTracelink pins zero
+// overhead: without WithTracerProvider, the captured traceparent stays
+// zero, and the InjectTraceLinkIntoParams call short-circuits, so the
+// wire stays clean.
+func TestCallToolWithInputs_NoTracerProvider_NoTracelink(t *testing.T) {
+	capture := &mrtrParamsCaptureMiddleware{}
+	srv := mrtrTestServerWithMiddleware(t, capture.middleware())
+
+	c, _ := connectMRTRClient(t, srv,
+		client.WithElicitationHandler(func(ctx context.Context, req core.ElicitationRequest) (core.ElicitationResult, error) {
+			return core.ElicitationResult{Action: "accept", Content: map[string]any{"name": "Alice"}}, nil
+		}),
+	)
+
+	_, err := client.CallToolWithInputs(context.Background(), c,
+		"test_tool_with_elicitation", map[string]any{},
+		client.DefaultInputHandler(c),
+	)
+	if err != nil {
+		t.Fatalf("CallToolWithInputs: %v", err)
+	}
+
+	rounds := capture.snapshot()
+	if len(rounds) != 2 {
+		t.Fatalf("got %d rounds, want 2", len(rounds))
+	}
+	for i, r := range rounds {
+		if got := extractTraceLink(t, r); got != "" {
+			t.Errorf("round %d carried tracelink %q despite no TracerProvider", i+1, got)
+		}
+	}
+}
+
+// mrtrTestServerWithMiddleware builds the same server as mrtrTestServer
+// but registers the supplied middleware (used to capture inbound params
+// per round for tracelink assertions).
+func mrtrTestServerWithMiddleware(t *testing.T, mw server.Middleware) *server.Server {
+	t.Helper()
+	srv := server.NewServer(core.ServerInfo{Name: "mrtr-client-test", Version: "0.0.1"},
+		server.WithMiddleware(mw),
+	)
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "test_tool_with_elicitation",
+			Description: "Asks for user name then greets them",
+			InputSchema: map[string]any{"type": "object"},
+		},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+			if !ctx.HasInputResponses() {
+				return ctx.RequestInput(core.InputRequests{
+					"user_name": core.InputRequest{
+						Method: "elicitation/create",
+						Params: json.RawMessage(`{"message":"What is your name?","requestedSchema":{"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}}`),
+					},
+				})
+			}
+			raw := ctx.InputResponse("user_name")
+			var er struct {
+				Action  string `json:"action"`
+				Content struct {
+					Name string `json:"name"`
+				} `json:"content"`
+			}
+			if err := json.Unmarshal(raw, &er); err != nil {
+				return core.ErrorResult("malformed elicitation response"), nil
+			}
+			return core.TextResult("Hello, " + er.Content.Name + "!"), nil
+		},
+	)
+	return srv
+}
+
+// configureMiddleware is a hack: server.WithMiddleware is a constructor
+// option, so we use it via re-construction. For tests that register a
+// tool BEFORE wanting the middleware, this works around that.
+// In real adopters this would be a single NewServer call.
+func configureMiddleware(srv *server.Server, mw server.Middleware) *server.Server {
+	// In the three_round_tool test, we register the tool then need
+	// middleware. The cleanest thing is to use server.UseMiddleware
+	// post-construction. Verify that API exists.
+	srv.UseMiddleware(mw)
+	return srv
 }

--- a/client/trace_middleware.go
+++ b/client/trace_middleware.go
@@ -107,6 +107,17 @@ func traceMiddleware(c *Client, tp core.TracerProvider) ClientMiddleware {
 		defer span.End()
 
 		outbound := core.TraceContextFromContext(ctx)
+		// SEP-414 P6 (issue 682): publish the outbound identity into the
+		// captured-trace-context holder when one is present on ctx. MRTR's
+		// CallToolWithInputs reads it back after round 1 to stamp round-2+
+		// requests' `_meta.io.modelcontextprotocol/tracelink`. The holder
+		// is goroutine-private (caller allocates fresh per call) so this
+		// write is safe and lock-free.
+		if !outbound.IsZero() {
+			if holder := core.CapturedTraceContextHolder(ctx); holder != nil {
+				*holder = outbound
+			}
+		}
 		injected := params
 		if !outbound.IsZero() {
 			injected = core.InjectTraceContextIntoParams(params, outbound)

--- a/core/trace.go
+++ b/core/trace.go
@@ -34,6 +34,21 @@ import (
 const (
 	MetaKeyTraceparent = "traceparent"
 	MetaKeyTracestate  = "tracestate"
+
+	// MetaKeyTraceLink carries the W3C `traceparent` of a logically-related
+	// upstream span that should be attached as an OTel Link to the
+	// receiving dispatch span. Used by SEP-2322 MRTR multi-round-trip
+	// requests (issue 682) so round-2's server dispatch span links back
+	// to round-1's, stitching the logical operation across separate
+	// W3C traces.
+	//
+	// Vendor-namespaced because W3C doesn't define a `tracelink` field;
+	// bare names are reserved for W3C-defined keys (see MetaKeyTraceparent).
+	// The mcpkit-side convention is fixed; upstream MCP WG standardization
+	// of a bare cross-SDK name is a future-discussion item — when (if)
+	// that lands, this constant gets a sibling under the new name, with
+	// adapters reading both during the transition window.
+	MetaKeyTraceLink = "io.modelcontextprotocol/tracelink"
 )
 
 // TraceContext is the propagated W3C Trace Context for a single MCP
@@ -396,6 +411,88 @@ func InjectTraceContextIntoParams(params any, tc TraceContext) any {
 	return obj
 }
 
+// ExtractTraceLinkFromParams reads `_meta.io.modelcontextprotocol/tracelink`
+// from a JSON-RPC request's raw `params` envelope, returning the carried
+// W3C traceparent as a TraceContext (Tracestate is intentionally NOT
+// part of the link payload — a link is identity-only, not a full
+// propagation context). Returns a zero TraceContext when params is nil /
+// non-object / missing the key, or when the value fails W3C
+// structural validation (same rules ExtractTraceContext applies).
+//
+// Used by the server's SEP-414 P2 trace middleware to detect MRTR
+// round-2+ requests and Add an OTel Link from the new dispatch span
+// back to the originating round-1 span — see SEP-414 P6 / issue 682.
+//
+// Defensive: never panics on malformed input.
+func ExtractTraceLinkFromParams(params json.RawMessage) TraceContext {
+	if len(params) == 0 {
+		return TraceContext{}
+	}
+	var envelope struct {
+		Meta map[string]any `json:"_meta"`
+	}
+	if err := json.Unmarshal(params, &envelope); err != nil {
+		return TraceContext{}
+	}
+	if envelope.Meta == nil {
+		return TraceContext{}
+	}
+	tp, _ := envelope.Meta[MetaKeyTraceLink].(string)
+	if !isValidTraceparent(tp) {
+		return TraceContext{}
+	}
+	return TraceContext{Traceparent: tp}
+}
+
+// InjectTraceLinkIntoParams returns a params value with
+// `_meta.io.modelcontextprotocol/tracelink` populated from tc.
+// Contract mirrors InjectTraceContextIntoParams:
+//
+//   - If tc is zero, params is returned unchanged.
+//   - If params is nil, a fresh map with just `_meta` is returned.
+//   - If params marshals to a JSON object, `_meta` is read/created and
+//     the tracelink key is set. Existing entries are preserved (the
+//     injection never clobbers — explicit caller-set values win).
+//   - If params marshals but is not a JSON object (positional array,
+//     scalar, etc.), the value is returned unchanged.
+//
+// Tracestate is intentionally NOT injected — the tracelink field carries
+// link IDENTITY only, not a full propagation context. Backends use the
+// link's traceparent to navigate; tracestate vendor data isn't relevant
+// to the link relationship.
+//
+// Used by the SEP-2322 MRTR client loop (CallToolWithInputs) on rounds
+// 2+ to stamp the round-1 traceparent so the server dispatch span can
+// AddLink back to it. SEP-414 P6 / issue 682.
+func InjectTraceLinkIntoParams(params any, tc TraceContext) any {
+	if tc.IsZero() {
+		return params
+	}
+	if params == nil {
+		return map[string]any{"_meta": map[string]any{MetaKeyTraceLink: tc.Traceparent}}
+	}
+	raw, err := json.Marshal(params)
+	if err != nil {
+		return params
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return params
+	}
+	if obj == nil {
+		obj = map[string]any{}
+	}
+	meta, _ := obj["_meta"].(map[string]any)
+	if meta == nil {
+		meta = map[string]any{}
+	}
+	if _, exists := meta[MetaKeyTraceLink]; !exists {
+		meta[MetaKeyTraceLink] = tc.Traceparent
+	}
+	obj["_meta"] = meta
+	return obj
+}
+
 // isValidTraceparent enforces the W3C version-00 structural form:
 // `00-<32-hex-trace-id>-<16-hex-span-id>-<2-hex-flags>` with all
 // lowercase hex. Trace-id and span-id MUST NOT be all-zero (W3C
@@ -578,4 +675,53 @@ func SpanFromContext(ctx context.Context) Span {
 		return span
 	}
 	return noopSpan{}
+}
+
+// --- Captured trace-context plumbing (P6 / issue 682) -----------------------
+
+type capturedTraceContextCtxKey struct{}
+
+// WithCapturedTraceContext returns a derived context carrying a holder
+// the TracerProvider adapter (or trace middleware) writes the call's
+// outbound TraceContext into. Used by callers that need to learn what
+// identity their outbound call ended up emitting under, without
+// changing the Call / Notify return shape.
+//
+// Primary consumer: SEP-2322 MRTR's CallToolWithInputs (issue 682).
+// Round 1's tools/call goes through the client trace middleware, which
+// writes the round-1 span's identity into the holder. CallToolWithInputs
+// reads the holder, captures round-1's traceparent, and on subsequent
+// rounds stamps it as `_meta.io.modelcontextprotocol/tracelink` so the
+// server dispatch span can AddLink back to it. Star-link semantic —
+// every round 2+ links to round 1, not the previous round.
+//
+// The holder is goroutine-private (each WithCapturedTraceContext call
+// allocates a fresh holder). The middleware writes to the holder at
+// most once per call (after StartSpan resolves the outbound identity).
+// Reading the holder after the call completes is safe — no concurrent
+// writes once the call has returned.
+//
+// Zero overhead unconfigured: when neither the middleware nor the caller
+// reads the holder, this is a single ctx.WithValue allocation per call
+// site that opts in. Holder pointers are NOT propagated by
+// context.WithoutCancel / detach — the holder is scoped to the active
+// request's ctx tree.
+func WithCapturedTraceContext(ctx context.Context) (context.Context, *TraceContext) {
+	holder := &TraceContext{}
+	return context.WithValue(ctx, capturedTraceContextCtxKey{}, holder), holder
+}
+
+// CapturedTraceContextHolder returns the holder a previous
+// WithCapturedTraceContext placed on ctx, or nil if none. TracerProvider
+// adapters and trace middleware call this immediately after StartSpan
+// resolves the outbound TraceContext and (if non-nil holder) write the
+// new identity into *holder.
+//
+// Defensive: nil-holder is silently the no-op path — callers writing
+// into the holder check non-nil first. Reading by the requester after
+// the call completes always returns the holder they constructed via
+// WithCapturedTraceContext — no nil-check needed on that side.
+func CapturedTraceContextHolder(ctx context.Context) *TraceContext {
+	holder, _ := ctx.Value(capturedTraceContextCtxKey{}).(*TraceContext)
+	return holder
 }

--- a/core/trace_test.go
+++ b/core/trace_test.go
@@ -507,3 +507,111 @@ func TestWithNewRootSpan_DerivedCtx_PropagatesMarker(t *testing.T) {
 		t.Fatalf("marker must survive other ctx derivations layered on top — adapters read it just before StartSpan")
 	}
 }
+
+// --- P6 MRTR tracelink (issue 682) ------------------------------------------
+
+const (
+	mrtrLinkTraceparent1 = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+	mrtrLinkTraceparent2 = "00-aabbccddeeff00112233445566778899-1122334455667788-01"
+)
+
+func TestExtractTraceLinkFromParams_ReadsValidLink(t *testing.T) {
+	raw := []byte(`{"name":"x","_meta":{"io.modelcontextprotocol/tracelink":"` + mrtrLinkTraceparent1 + `"}}`)
+	got := ExtractTraceLinkFromParams(raw)
+	if got.Traceparent != mrtrLinkTraceparent1 {
+		t.Errorf("Traceparent = %q, want %q", got.Traceparent, mrtrLinkTraceparent1)
+	}
+	if got.Tracestate != "" {
+		t.Errorf("Tracestate must be empty — link payload is identity-only, not full propagation context; got %q", got.Tracestate)
+	}
+}
+
+func TestExtractTraceLinkFromParams_MissingKey_ReturnsZero(t *testing.T) {
+	raw := []byte(`{"name":"x","_meta":{"traceparent":"` + mrtrLinkTraceparent1 + `"}}`)
+	if got := ExtractTraceLinkFromParams(raw); !got.IsZero() {
+		t.Errorf("missing tracelink key must yield zero; got %+v", got)
+	}
+}
+
+func TestExtractTraceLinkFromParams_MalformedTraceparent_ReturnsZero(t *testing.T) {
+	raw := []byte(`{"_meta":{"io.modelcontextprotocol/tracelink":"not-a-traceparent"}}`)
+	if got := ExtractTraceLinkFromParams(raw); !got.IsZero() {
+		t.Errorf("malformed tracelink must be silently dropped; got %+v", got)
+	}
+}
+
+func TestExtractTraceLinkFromParams_NilParams_ReturnsZero(t *testing.T) {
+	if got := ExtractTraceLinkFromParams(nil); !got.IsZero() {
+		t.Errorf("nil params must yield zero TraceContext; got %+v", got)
+	}
+}
+
+func TestInjectTraceLinkIntoParams_StampsKey(t *testing.T) {
+	tc := TraceContext{Traceparent: mrtrLinkTraceparent1}
+	params := map[string]any{"name": "x"}
+	out := InjectTraceLinkIntoParams(params, tc).(map[string]any)
+	meta := out["_meta"].(map[string]any)
+	if meta[MetaKeyTraceLink] != mrtrLinkTraceparent1 {
+		t.Errorf("_meta.io.modelcontextprotocol/tracelink = %v, want %q", meta[MetaKeyTraceLink], mrtrLinkTraceparent1)
+	}
+}
+
+func TestInjectTraceLinkIntoParams_ZeroTC_LeavesParamsUntouched(t *testing.T) {
+	params := map[string]any{"name": "x"}
+	out := InjectTraceLinkIntoParams(params, TraceContext{})
+	if _, exists := out.(map[string]any)["_meta"]; exists {
+		t.Errorf("zero TC must not synthesize an empty _meta envelope; got %+v", out)
+	}
+}
+
+func TestInjectTraceLinkIntoParams_CallerSetWins(t *testing.T) {
+	params := map[string]any{
+		"_meta": map[string]any{MetaKeyTraceLink: mrtrLinkTraceparent1},
+	}
+	tc := TraceContext{Traceparent: mrtrLinkTraceparent2}
+	out := InjectTraceLinkIntoParams(params, tc).(map[string]any)
+	meta := out["_meta"].(map[string]any)
+	if meta[MetaKeyTraceLink] != mrtrLinkTraceparent1 {
+		t.Errorf("caller-set tracelink must win; got %v, want caller value %q", meta[MetaKeyTraceLink], mrtrLinkTraceparent1)
+	}
+}
+
+func TestInjectTraceLinkIntoParams_NonObjectParams_LeavesUntouched(t *testing.T) {
+	positional := []any{"arg1", 42}
+	tc := TraceContext{Traceparent: mrtrLinkTraceparent1}
+	out := InjectTraceLinkIntoParams(positional, tc)
+	if _, ok := out.([]any); !ok {
+		t.Errorf("non-object params must pass through untouched; got %T", out)
+	}
+}
+
+func TestInjectTraceLinkIntoParams_NilParams_SynthesizesMeta(t *testing.T) {
+	tc := TraceContext{Traceparent: mrtrLinkTraceparent1}
+	out := InjectTraceLinkIntoParams(nil, tc).(map[string]any)
+	meta := out["_meta"].(map[string]any)
+	if meta[MetaKeyTraceLink] != mrtrLinkTraceparent1 {
+		t.Errorf("nil-params path must synthesize _meta with tracelink; got %+v", out)
+	}
+}
+
+func TestWithCapturedTraceContext_HolderRoundtrip(t *testing.T) {
+	ctx, holder := WithCapturedTraceContext(context.Background())
+	if holder == nil {
+		t.Fatalf("WithCapturedTraceContext must return non-nil holder")
+	}
+	got := CapturedTraceContextHolder(ctx)
+	if got != holder {
+		t.Fatalf("CapturedTraceContextHolder must return the same holder WithCapturedTraceContext placed on ctx")
+	}
+	// Simulate the middleware-side write.
+	*got = TraceContext{Traceparent: mrtrLinkTraceparent1}
+	if holder.Traceparent != mrtrLinkTraceparent1 {
+		t.Errorf("write through CapturedTraceContextHolder pointer must reflect on the WithCapturedTraceContext return; got %+v", *holder)
+	}
+}
+
+func TestCapturedTraceContextHolder_AbsentCtx_ReturnsNil(t *testing.T) {
+	if got := CapturedTraceContextHolder(context.Background()); got != nil {
+		t.Fatalf("absent holder must return nil so middleware can no-op-skip the write; got %+v", got)
+	}
+}

--- a/docs/MRTR_TUTORIAL.md
+++ b/docs/MRTR_TUTORIAL.md
@@ -597,3 +597,9 @@ tasks.Register(tasks.Config{Server: srv})  // if any tools opt into TaskSupport
 - [panyam/mcpconformance](https://github.com/panyam/mcpconformance), branch `feat/tasks-mrtr-extension` — SEP-2322 + SEP-2663 conformance scenarios.
 - [Issue 452](https://github.com/panyam/mcpkit/issues/452) — stateless wire MRTR support follow-up.
 - [Issue 485](https://github.com/panyam/mcpkit/issues/485) — multi-tenant isolation for stateless task store follow-up.
+
+## Tracing across MRTR rounds
+
+`CallToolWithInputs` automatically stitches multi-round traces when the client has a `TracerProvider` configured. Round 1's outbound traceparent is captured and stamped onto rounds 2+ as `_meta.io.modelcontextprotocol/tracelink`; the server's trace middleware reads the link and calls `AddLink` on the round-N dispatch span. Star semantic — every round 2+ links to round 1, not the previous round.
+
+See [`docs/SEP_414_OTEL.md`](SEP_414_OTEL.md) § **MRTR multi-round trace stitching** for the full wire-shape design, considered alternatives, and the end-to-end correctness test. The `examples/mrtr/` walkthrough has a beat showing the stitched trace in Grafana.

--- a/docs/SEP_414_OTEL.md
+++ b/docs/SEP_414_OTEL.md
@@ -633,6 +633,42 @@ tasks/cancel (dispatch, link → original tools/call create span)
 
 End-to-end materialization is proven by `ext/otel/provider_test.go`'s coverage of the `WithNewRootSpan` scrub + `StartSpanLinked` + `AddLink` paths against a real OTel SDK exporter. `ext/tasks/trace_test.go` uses a recording fake `core.TracerProvider` + `core.LinkedTracerProvider` to prove ext/tasks calls the contract correctly without dragging ext/otel into its module graph.
 
+### MRTR multi-round trace stitching — landed (issue 682; PR forthcoming)
+
+SEP-2322 MRTR splits one logical operation across N JSON-RPC dispatches (round 1: server returns `InputRequiredResult` → client gathers input → round 2: client retries with `inputResponses`). Each round's `tools/call` mints its own span on each side, so without intervention an MRTR operation produces N unrelated traces — an operator looking at the final ToolResult's trace cannot navigate to the input-gathering work that produced it.
+
+This is fundamental once stateless (SEP-2575) replaces stateful as the default wire — stateful's `ctx.Sample` / `ctx.Elicit` are deprecated per SEP-2577 and will go away in v0.4. MRTR becomes the canonical input-gathering pattern; the trace story has to follow.
+
+**Wire shape**: rounds 2+ carry the round-1 traceparent in a new `_meta.io.modelcontextprotocol/tracelink` field. The server's trace middleware reads it and calls `core.SpanFromContext(ctx).AddLink(...)` on the round-N dispatch span, stitching the operation across separate W3C traces.
+
+```
+Round 1:                              Round 2 (and beyond):
+client.Call("tools/call", args)       client.Call("tools/call", args+inputResponses)
+  ↓                                     ↓
+_meta: {                              _meta: {
+  traceparent: T1                       traceparent: T2,
+}                                       io.modelcontextprotocol/tracelink: T1,  ← NEW (issue 682)
+                                      }
+  ↓                                     ↓
+server span (TraceID T1)              server span (TraceID T2)
+                                        AddLink → T1  ← server stitches the operation
+```
+
+**Star semantic** — rounds 2, 3, 4… all link back to round 1, NOT the immediately-previous round. Backends show round 1 as the anchor regardless of how deep the MRTR loop goes. One click navigates from any round to the originating request.
+
+**Vendor-namespaced field**: `_meta.io.modelcontextprotocol/tracelink` (not bare `_meta.tracelink`) because W3C doesn't define a `tracelink` field — bare names are reserved for W3C-defined keys. mcpkit-specific until upstream WG agrees on a cross-SDK shape.
+
+**Client-side identity capture**: `CallToolWithInputs` uses the new `core.WithCapturedTraceContext` ctx-holder primitive. The client trace middleware writes round-1's outbound TraceContext into the holder; `CallToolWithInputs` snapshots it and stamps it onto every subsequent round's params via `core.InjectTraceLinkIntoParams`. Tracestate is intentionally NOT part of the link payload — link is identity-only, not full propagation context. `Client.callImpl(ctx, ...)` (a ctx-aware refactor of `Client.Call`) is what threads the holder through the middleware chain; `Client.Call` itself stays ctx-free for back-compat by passing `context.Background()`.
+
+**Considered alternatives**:
+
+- **Embed traceparent in `requestState`** — works, but `requestState` was designed as opaque from the client's perspective. Baking tracing semantics into it muddies the contract.
+- **Continue an outer span across rounds on the client side** — simpler (no wire change), but the outer span's duration would include user-paced gather-input time, which can be minutes. Distorts span duration semantics. Rejected.
+
+**Spec engagement TBD**: this lands as mcpkit-internal first; the field name + semantic could be a candidate for upstream MCP WG standardization for cross-SDK interop. See the PR description for the working-group post draft.
+
+End-to-end correctness proof: `ext/otel/mrtr_tracelink_e2e_test.go` drives a real `CallToolWithInputs` against a real OTel-SDK-backed server + client, then asserts the recorded round-2 server span has an OTel Link whose TraceID matches round-1's.
+
 ## Downstream consumers of the Phase 1 contract
 
 - **`experimental/ext/events/` cross-replica bus (issue #629).** The

--- a/examples/mrtr/walkthrough.go
+++ b/examples/mrtr/walkthrough.go
@@ -258,6 +258,11 @@ res, _ := client.CallToolWithInputs(context.Background(), c,
 			return
 		})
 
+	demo.Step("Tracing: rounds 2+ link back to round 1 (SEP-414 P6)").
+		Note("`CallToolWithInputs` captures round 1's outbound traceparent and stamps it onto round 2+ as `_meta.io.modelcontextprotocol/tracelink` (SEP-414 P6 / issue 682). The server's trace middleware reads the link and calls `AddLink` on the round-N dispatch span, stitching the logical operation across separate W3C traces. **Star semantic** — every round 2+ links to round 1, not the previous round, so Tempo / Jaeger / Honeycomb show round 1 as the anchor regardless of how deep the loop goes.").
+		Note("To see the stitched trace, bring up the LGTM observability stack alongside the demo: `(cd ../../docker/observability && docker compose up -d)` then `EXPORTER=auto make serve` here. Open Grafana → Tempo → service `mrtr-demo`. Click any round-2/3 dispatch span's Link entry — one click navigates to round 1's trace tree, looking at the original input-required handoff that the final ToolResult resolved from.").
+		Note("Without this PR the same operation produced N unrelated traces — operators looking at round N had no way to navigate to round 1. The vendor-namespaced `_meta.io.modelcontextprotocol/tracelink` field is mcpkit-specific today; upstream WG standardization of a bare cross-SDK name is a future-discussion item.")
+
 	demo.Section("Where to look in the code",
 		"- Server dispatch: `server/dispatch.go` (handleToolsCall reshapes InputRequired into the wire envelope; merges accumulated answers from `requestState`)",
 		"- Server runtime: `server/mrtr.go` (`mrtrRuntime` — sign / verify / mint requestState tokens; `WithRequestStateSigning(key, ttl)` shared with SEP-2663 Tasks)",

--- a/ext/otel/mrtr_tracelink_e2e_test.go
+++ b/ext/otel/mrtr_tracelink_e2e_test.go
@@ -1,0 +1,128 @@
+package otel_test
+
+// SEP-414 P6 MRTR multi-round trace stitching (issue 682) — end-to-end
+// against the real OTel SDK. Drives a full CallToolWithInputs round trip
+// against a server tracer + client tracer (both real Providers), then
+// asserts the recorded round-2 server span carries an OTel Link whose
+// TraceID matches round-1's server span — the wire-shape correctness
+// proof that the mcpkit-internal fakes can't deliver.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/panyam/mcpkit/client"
+	core "github.com/panyam/mcpkit/core"
+	mcpotel "github.com/panyam/mcpkit/ext/otel"
+	"github.com/panyam/mcpkit/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func TestMRTRTracelink_E2E_RoundTwoLinksToRoundOne(t *testing.T) {
+	serverExp := tracetest.NewInMemoryExporter()
+	serverSDK := sdktrace.NewTracerProvider(sdktrace.WithSyncer(serverExp))
+	defer serverSDK.Shutdown(context.Background())
+	serverTP := mcpotel.NewProvider(serverSDK)
+
+	clientExp := tracetest.NewInMemoryExporter()
+	clientSDK := sdktrace.NewTracerProvider(sdktrace.WithSyncer(clientExp))
+	defer clientSDK.Shutdown(context.Background())
+	clientTP := mcpotel.NewProvider(clientSDK)
+
+	srv := server.NewServer(
+		core.ServerInfo{Name: "mrtr-e2e-trace", Version: "0.0.1"},
+		server.WithTracerProvider(serverTP),
+	)
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "greet",
+			Description: "asks for the user's name then greets them",
+			InputSchema: map[string]any{"type": "object"},
+		},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+			if !ctx.HasInputResponses() {
+				return ctx.RequestInput(core.InputRequests{
+					"user_name": core.InputRequest{
+						Method: "elicitation/create",
+						Params: json.RawMessage(`{"message":"name?","requestedSchema":{"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}}`),
+					},
+				})
+			}
+			raw := ctx.InputResponse("user_name")
+			var er struct {
+				Action  string `json:"action"`
+				Content struct {
+					Name string `json:"name"`
+				} `json:"content"`
+			}
+			if err := json.Unmarshal(raw, &er); err != nil {
+				return core.ErrorResult("malformed"), nil
+			}
+			return core.TextResult("Hello, " + er.Content.Name + "!"), nil
+		},
+	)
+
+	handler := srv.Handler(server.WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "mrtr-e2e-client", Version: "0.0.1"},
+		client.WithTracerProvider(clientTP),
+		client.WithElicitationHandler(func(ctx context.Context, req core.ElicitationRequest) (core.ElicitationResult, error) {
+			return core.ElicitationResult{Action: "accept", Content: map[string]any{"name": "Alice"}}, nil
+		}),
+	)
+	require.NoError(t, c.Connect())
+	defer c.Close()
+
+	res, err := client.CallToolWithInputs(context.Background(), c,
+		"greet", map[string]any{},
+		client.DefaultInputHandler(c),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, res.Sync)
+	assert.Contains(t, res.Sync.Content[0].Text, "Alice")
+
+	// Server-side spans for tools/call. There may be other spans for
+	// initialize / notifications/initialized etc; filter to the two
+	// tools/call dispatch spans.
+	serverSpans := serverExp.GetSpans()
+	var round1, round2 sdktrace.ReadOnlySpan
+	for _, s := range serverSpans {
+		if s.Name != "tools/call" {
+			continue
+		}
+		if round1 == nil {
+			round1 = s.Snapshot()
+			continue
+		}
+		round2 = s.Snapshot()
+		break
+	}
+	require.NotNil(t, round1, "round-1 server tools/call span MUST exist")
+	require.NotNil(t, round2, "round-2 server tools/call span MUST exist")
+
+	// Round-2 server span MUST carry an OTel Link whose TraceID matches
+	// round-1's TraceID. This is the wire-shape correctness proof —
+	// without the client-side tracelink injection AND the server-side
+	// AddLink, this assertion fails.
+	links := round2.Links()
+	require.NotEmpty(t, links, "round-2 server span MUST carry an OTel Link back to round-1")
+
+	round1TraceID := round1.SpanContext().TraceID()
+	var matched bool
+	for _, lk := range links {
+		if lk.SpanContext.TraceID() == round1TraceID {
+			matched = true
+			break
+		}
+	}
+	assert.True(t, matched,
+		"round-2's Link list MUST contain an entry whose TraceID == round-1's TraceID; got links=%v, want match for %s",
+		links, round1TraceID)
+}

--- a/server/trace_middleware.go
+++ b/server/trace_middleware.go
@@ -151,6 +151,17 @@ func traceMiddleware(tp core.TracerProvider) Middleware {
 		ctx, span := tp.StartSpan(ctx, spanName, attrs...)
 		defer span.End()
 
+		// SEP-414 P6 (issue 682): if the inbound request carries a
+		// `_meta.io.modelcontextprotocol/tracelink`, attach it as an OTel
+		// Link on the new dispatch span. Used by SEP-2322 MRTR rounds 2+
+		// so the round-N dispatch span links back to round-1's,
+		// stitching the logical operation across separate W3C traces.
+		// Zero / malformed tracelink is silently dropped — AddLink on
+		// the noop / invalid path is a no-op (CAS-guarded wrapper).
+		if linkTC := core.ExtractTraceLinkFromParams(req.Params); !linkTC.IsZero() {
+			span.AddLink(core.LinkFromTraceContext(linkTC))
+		}
+
 		// Adapters may update the trace context in ctx during StartSpan
 		// to reflect the newly-created child span. Re-read so outbound
 		// _meta carries the child traceparent when available; falls

--- a/server/trace_middleware_test.go
+++ b/server/trace_middleware_test.go
@@ -38,6 +38,7 @@ type fakeSpan struct {
 	errs   []error
 	ended  bool
 	parent core.TraceContext // captured from ctx at StartSpan
+	links  []core.Link        // recorded via AddLink — tests assert MRTR tracelink stitching
 }
 
 func (s *fakeSpan) End() {
@@ -64,7 +65,23 @@ func (s *fakeSpan) RecordError(err error) {
 	s.errs = append(s.errs, err)
 }
 
-func (s *fakeSpan) AddLink(_ core.Link) {}
+func (s *fakeSpan) AddLink(l core.Link) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.links = append(s.links, l)
+}
+
+func (s *fakeSpan) linkCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.links)
+}
+
+func (s *fakeSpan) linkAt(i int) core.Link {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.links[i]
+}
 
 func (s *fakeSpan) attr(k string) string {
 	s.mu.Lock()
@@ -565,4 +582,72 @@ func (r *respRecorder) statusCode() int {
 		return http.StatusOK
 	}
 	return r.status
+}
+
+// --- SEP-414 P6 MRTR tracelink (issue 682) ---
+
+const tpMRTRLink = "00-deadbeefcafebabe0123456789abcdef-fedcba9876543210-01"
+
+// TestTraceMiddleware_ReadsTracelink_AddsLinkToDispatchSpan pins the
+// server-side half of MRTR trace stitching: when an inbound tools/call
+// carries `_meta.io.modelcontextprotocol/tracelink`, the dispatch span
+// receives an AddLink call carrying that TraceContext. The link makes
+// round-2+ server spans navigable back to round-1 in Tempo / Grafana.
+func TestTraceMiddleware_ReadsTracelink_AddsLinkToDispatchSpan(t *testing.T) {
+	tp := &fakeTracerProvider{}
+	srv := newInitializedServer(t, WithTracerProvider(tp))
+	srv.RegisterTool(core.ToolDef{Name: "echo"}, func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+		return core.TextResult("ok"), nil
+	})
+
+	params := `{"name":"echo","_meta":{"traceparent":"` + tpInbound + `","io.modelcontextprotocol/tracelink":"` + tpMRTRLink + `"}}`
+	_, err := dispatchToolsCall(t, srv, context.Background(), params, nil, nil)
+	require.NoError(t, err)
+
+	spans := tp.snapshot()
+	require.Len(t, spans, 1)
+	require.Equal(t, 1, spans[0].linkCount(), "dispatch span MUST receive AddLink when tracelink is present")
+	link := spans[0].linkAt(0)
+	assert.Equal(t, tpMRTRLink, link.TraceContext.Traceparent,
+		"AddLink's TraceContext.Traceparent MUST match the inbound tracelink (anchor of star semantic)")
+}
+
+// TestTraceMiddleware_NoTracelink_NoAddLink pins the zero-overhead
+// path: tools/call without tracelink emits a span with NO AddLink
+// calls. Critical for the dominant non-MRTR path — every regular
+// tools/call MUST NOT incur a spurious link.
+func TestTraceMiddleware_NoTracelink_NoAddLink(t *testing.T) {
+	tp := &fakeTracerProvider{}
+	srv := newInitializedServer(t, WithTracerProvider(tp))
+	srv.RegisterTool(core.ToolDef{Name: "echo"}, func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+		return core.TextResult("ok"), nil
+	})
+
+	params := `{"name":"echo","_meta":{"traceparent":"` + tpInbound + `"}}`
+	_, err := dispatchToolsCall(t, srv, context.Background(), params, nil, nil)
+	require.NoError(t, err)
+
+	spans := tp.snapshot()
+	require.Len(t, spans, 1)
+	assert.Equal(t, 0, spans[0].linkCount(), "non-MRTR tools/call MUST NOT trigger AddLink")
+}
+
+// TestTraceMiddleware_MalformedTracelink_DroppedSilently pins the
+// defensive contract: a malformed tracelink (e.g., garbage string)
+// must NOT crash dispatch and MUST NOT produce a link. Same W3C
+// validation rules ExtractTraceContext applies — silent drop.
+func TestTraceMiddleware_MalformedTracelink_DroppedSilently(t *testing.T) {
+	tp := &fakeTracerProvider{}
+	srv := newInitializedServer(t, WithTracerProvider(tp))
+	srv.RegisterTool(core.ToolDef{Name: "echo"}, func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+		return core.TextResult("ok"), nil
+	})
+
+	params := `{"name":"echo","_meta":{"io.modelcontextprotocol/tracelink":"not-a-valid-traceparent"}}`
+	_, err := dispatchToolsCall(t, srv, context.Background(), params, nil, nil)
+	require.NoError(t, err)
+
+	spans := tp.snapshot()
+	require.Len(t, spans, 1)
+	assert.Equal(t, 0, spans[0].linkCount(), "malformed tracelink MUST be silently dropped — no AddLink")
 }


### PR DESCRIPTION
## What changes

SEP-2322 MRTR splits one logical operation across N JSON-RPC dispatches (round 1: server returns `InputRequiredResult` → client gathers input → round 2: client retries with `inputResponses`). Without intervention each round mints its own W3C trace; operators looking at round N can't navigate back to round 1.

This PR adds a vendor-namespaced wire field, `_meta.io.modelcontextprotocol/tracelink`, carrying round-1's W3C traceparent. Rounds 2+ stamp it; server middleware reads it and calls `core.SpanFromContext(ctx).AddLink(...)` on the round-N dispatch span. **Star semantic** — every round 2+ links to round 1, not the previous round. Backends show round 1 as the anchor regardless of how deep the MRTR loop goes.

```mermaid
sequenceDiagram
    participant C as Client
    participant S as Server
    C->>S: tools/call (round 1, traceparent T1)
    S-->>S: dispatch span (TraceID T1)
    S-->>C: InputRequiredResult + requestState
    Note over C: input gathering<br/>(sampling, elicit, etc.)
    C->>S: tools/call (round 2, traceparent T2, tracelink T1)
    S-->>S: dispatch span (TraceID T2)<br/>AddLink → T1
    S-->>C: InputRequiredResult (more input)
    C->>S: tools/call (round 3, traceparent T3, tracelink T1)
    S-->>S: dispatch span (TraceID T3)<br/>AddLink → T1 (star semantic)
    S-->>C: final ToolResult
```

## Reviewer's guide

Read in this order:

1. [core/trace.go](https://github.com/panyam/mcpkit/pull/732/files#diff-acb99666fd2aacc85eaf8e433236a74d28959ca5e1e0d5e14913cdd5fb9e81c0) — start here. New `MetaKeyTraceLink` constant + `ExtractTraceLinkFromParams` / `InjectTraceLinkIntoParams` helpers (mirror existing trace-context helpers) + `WithCapturedTraceContext` / `CapturedTraceContextHolder` ctx-holder primitive.
2. [core/trace_test.go](https://github.com/panyam/mcpkit/pull/732/files#diff-3691b83b37fde48b68242c223380c4e2e18a58ccb618ba6495ecfaa631577ea9) — acceptance for the helpers. Extract round-trip, inject map / non-object / nil paths, caller-set-wins, holder roundtrip, absent-ctx returns nil.
3. [client/trace_middleware.go](https://github.com/panyam/mcpkit/pull/732/files#diff-3851e8e3ac9b41a4e9ecfa487b4e307980131775ea7027b0cc2c041fce4fe650) — three new lines after `tp.StartSpan` write the outbound TraceContext into the captured-trace-context holder when one is present on ctx. Goroutine-private; lock-free.
4. [client/client.go](https://github.com/panyam/mcpkit/pull/732/files#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09) — refactor `Client.Call` body into `callImpl(ctx, method, params)` so package-private callers (notably MRTR) can thread a holder-bearing ctx through the middleware chain. `Client.Call` passes `context.Background()`; behavior preserved for non-MRTR callers.
5. [client/mrtr.go](https://github.com/panyam/mcpkit/pull/732/files#diff-e667cbbe7d6bd96621dd72476158d158245113852f360ed893bfd7cecf52e168) — `CallToolWithInputs` opens with `core.WithCapturedTraceContext(ctx)`, captures round-1's TraceContext after the first call, and on rounds 2+ stamps `_meta.io.modelcontextprotocol/tracelink` via `core.InjectTraceLinkIntoParams`. Star semantic: round-1 TC is captured ONCE, never overwritten by subsequent rounds.
6. [server/trace_middleware.go](https://github.com/panyam/mcpkit/pull/732/files#diff-7e0ee26d4d523ebdecda4da033cb2f40c364eb05edb5f41b1d90d76fd374546e) — three new lines after `tp.StartSpan` extract `_meta.io.modelcontextprotocol/tracelink` from inbound params and call `span.AddLink(core.LinkFromTraceContext(linkTC))` when non-zero.
7. [client/mrtr_test.go](https://github.com/panyam/mcpkit/pull/732/files#diff-6ce43bfe56303e770e8ac1086ea9216f91823eab0bb642b997e4199127f1fdfb) — three new tests: `StampsTracelinkOnRound2` (acceptance), `StarSemantic` (3-round test proving round 3 links to round 1, NOT round 2), `NoTracerProvider_NoTracelink` (zero-overhead guard).
8. [server/trace_middleware_test.go](https://github.com/panyam/mcpkit/pull/732/files#diff-9afc268cfbcbcd1d48ab89407746d243ef738f0e6f5eabb2b7a5f221a462ea1e) — three new tests: `ReadsTracelink_AddsLinkToDispatchSpan` (acceptance), `NoTracelink_NoAddLink` (regression guard for non-MRTR tools/call), `MalformedTracelink_DroppedSilently` (defensive contract).
9. [ext/otel/mrtr_tracelink_e2e_test.go](https://github.com/panyam/mcpkit/pull/732/files#diff-c5fe93a5775069962962cb82c8033db83a420ec6b6312a74b2b8a10ee3d159af) — the end-to-end correctness proof against the real OTel SDK. Drives a full `CallToolWithInputs` against an OTel-backed server + client, asserts the recorded round-2 server span has an OTel Link whose TraceID matches round-1's. Without the client-side inject AND the server-side AddLink, this fails.
10. [examples/mrtr/walkthrough.go](https://github.com/panyam/mcpkit/pull/732/files#diff-b19e0dcbed1a09942a9652e0092fa7de233c23394332fd2a9a83250428a73e02) — new walkthrough beat describing the trace shape + Grafana navigation hint.
11. [docs/SEP_414_OTEL.md](https://github.com/panyam/mcpkit/pull/732/files#diff-471fd7f72ab0a2ff1e1398303fa41c3e0173c19ac5439e8b833ce242fa81f3e6) — new "MRTR multi-round trace stitching" section covering wire shape, star semantic, considered alternatives, and the upstream WG engagement note.
12. [docs/MRTR_TUTORIAL.md](https://github.com/panyam/mcpkit/pull/732/files#diff-53c944e675a34f65ad968289a2f0ee39699bd33e14c7f2ea334ae75b15d2e791) — short pointer paragraph at the end linking to the design doc.

## Decision log

- **Star semantic, not chain.** Every round N+1 links to round 1, not the immediately-previous round. Backends following the link from any round land directly on the originating request. Chain would require N hops; star is one click.
- **Vendor-namespaced field (`io.modelcontextprotocol/tracelink`), not bare W3C-style (`tracelink`).** W3C doesn't define a `tracelink` field — bare names are reserved for W3C-defined keys. Vendor namespace is the safe default until upstream MCP WG standardizes a cross-SDK shape.
- **Embed in `_meta`, not in `requestState`.** `requestState` was designed as opaque from the client's perspective. Baking tracing semantics into it muddies the contract.
- **`Client.callImpl(ctx, ...)` refactor, not a new public `Client.CallWithCtx`.** The capture flow is MRTR-specific; exposing it as a public API surface would invite misuse. Package-private keeps the contract narrow.
- **Identity-only link payload — Tracestate intentionally NOT carried.** A link is "this work is related-to X", not "propagate full trace context from X." Backends use the link's traceparent to navigate; vendor tracestate data isn't relevant.
- **Per-round client.Call spans stay as-is (each round = one span, correct duration).** Considered: an outer wrapping span across the whole MRTR loop. Rejected because the outer span's duration would include user-paced gather-input time (potentially minutes), distorting span duration semantics.

## Risk / blast radius

- **Wire**: new optional `_meta.io.modelcontextprotocol/tracelink` field. Servers / clients that don't know about it ignore it (vendor namespace). Backwards compat preserved.
- **Client API**: `Client.callImpl` is package-private. `Client.Call` body is unchanged behaviorally (just delegates). Existing callers see zero difference.
- **Server middleware**: gated by `tracingEnabled`, so the new AddLink path doesn't execute when no TracerProvider is configured. Zero overhead on the unconfigured path.
- **MRTR loop**: holder allocation per call is a single `&core.TraceContext{}` + one ctx.WithValue. Cost is irrelevant compared to round-trip wire latency.
- **Tests covering this**: 8 new unit tests + 1 e2e + Red-before-green confirmed at every layer (stash impl, watch test fail; restore, watch test pass).
- **Be paranoid about**: nothing — the change is additive at every layer.

## Before / after

```
$ go test -count=1 -run 'TestMRTRTracelink_E2E' ./ext/otel/
ok  github.com/panyam/mcpkit/ext/otel  0.694s
```

Red-before-green proof: with the server-side AddLink code stashed:
```
--- FAIL: TestTraceMiddleware_ReadsTracelink_AddsLinkToDispatchSpan
    expected: 1
    actual  : 0
    Messages: dispatch span MUST receive AddLink when tracelink is present
```

## Out of scope (deliberately deferred)

- **Upstream WG standardization** of a bare cross-SDK `tracelink` name. Draft post for the MRTR / Tasks WG Discord channel is appended below.
- **Outer-loop span variant** (active-span continuation across rounds) — considered, rejected; documented in `docs/SEP_414_OTEL.md` § MRTR multi-round trace stitching for posterity.
- **Tracestate carrying on the link** — link is identity-only by design. If a future need surfaces, a sibling `tracelinkstate` field can be added; not blocking today.

---

## Discord / WG post draft

For posting to the MRTR or Tasks WG Discord channel after merge:

> **MRTR multi-round trace stitching — request for spec feedback**
>
> We just shipped MRTR multi-round trace stitching in mcpkit ([PR link](https://github.com/panyam/mcpkit/pull/THIS_PR), [issue 682](https://github.com/panyam/mcpkit/issues/682)). The problem: SEP-2322 MRTR splits one logical operation across N `tools/call` dispatches, but each round mints its own W3C trace, so operators following round N's trace can't navigate back to round 1 (where the original input-required handoff happened).
>
> Our fix uses OTel **span links** — rounds 2+ carry round-1's traceparent in a new `_meta` field, and the server's trace middleware AddLinks the round-N dispatch span back to round-1. Star semantic — every round 2+ links to round 1, so the originating request is always one click away regardless of how deep the MRTR loop goes.
>
> Wire shape today (mcpkit-specific): `_meta.io.modelcontextprotocol/tracelink` — a single W3C traceparent string. We considered bare `_meta.tracelink` but W3C doesn't define that field name (bare names are reserved for W3C-defined keys), so we vendor-namespaced.
>
> **Question for the WG**: would there be appetite to standardize this for cross-SDK interop? Either:
>
> - The bare name `_meta.tracelink` (with a SEP for the field), or
> - A different name living under the `io.modelcontextprotocol/` namespace that all SDK implementations would honor.
>
> Considered alternatives + reasons rejected are in the PR's `docs/SEP_414_OTEL.md` § MRTR multi-round trace stitching. End-to-end correctness proof is in `ext/otel/mrtr_tracelink_e2e_test.go` — drives a real `CallToolWithInputs` against a real OTel-backed server + client, asserts the round-2 server span carries an OTel Link to round-1.
>
> No urgency — mcpkit can keep using the vendor-namespaced name indefinitely. Filing this as a "is this worth standardizing?" question, not a "please merge a SEP this week" ask. Happy to write up the SEP if there's interest.

Closes issue 682.
