### PR TITLE
docker/observability: canonical /d/mcpkit-overview dashboard; per-example becomes escape hatch

### DIFF
--- a/docker/observability/README.md
+++ b/docker/observability/README.md
@@ -52,11 +52,12 @@ reference — pass `--exporter=otlp` to its `serve` or `demo` target.
   `mcp.tool.duration` (ms), `mcp.sessions.active` — through the OTel
   meter adapter → OTLP → Collector → Mimir. Exemplars are stamped
   by default so Grafana panels link directly to the matching trace
-  in Tempo. `examples/otel/stdout/` is the reference adopter and
-  ships its starter dashboard at
-  [`/d/otel-stdout`](http://localhost:3000/d/otel-stdout) (per-example
-  UID convention — see `examples/CONVENTIONS.md` § Per-example
-  Grafana dashboards).
+  in Tempo. The bundled
+  [`mcpkit — overview`](http://localhost:3000/d/mcpkit-overview)
+  dashboard works for ANY example: pick the example from the
+  `$service` dropdown. Per-example dashboards are an escape hatch
+  for genuinely-bespoke metrics — see `examples/CONVENTIONS.md`
+  § Grafana dashboards.
 
 Shipping the full LGTM stack now means no rework when the empty lanes
 fill in. The trade-off is ~6 YAML config files to maintain vs the

--- a/docker/observability/grafana/provisioning/dashboards/files/mcpkit-overview.json
+++ b/docker/observability/grafana/provisioning/dashboards/files/mcpkit-overview.json
@@ -1,7 +1,7 @@
 {
-  "uid": "otel-stdout",
-  "title": "otel-stdout — overview",
-  "tags": ["mcpkit", "example:otel-stdout"],
+  "uid": "mcpkit-overview",
+  "title": "mcpkit — overview",
+  "tags": ["mcpkit", "overview"],
   "schemaVersion": 39,
   "version": 1,
   "editable": true,
@@ -28,11 +28,11 @@
           "uid": "mimir"
         },
         "label": "Service",
-        "query": "label_values(mcp_tool_calls_total{service_name=~\"otel-stdout.*\"}, service_name)",
+        "query": "label_values(mcp_tool_calls_total, service_name)",
         "refresh": 2,
         "includeAll": true,
         "multi": true,
-        "allValue": "otel-stdout.*",
+        "allValue": ".*",
         "current": {
           "selected": false,
           "text": "All",

--- a/examples/CONVENTIONS.md
+++ b/examples/CONVENTIONS.md
@@ -314,27 +314,40 @@ ctx unchanged, and the OTel SDK stamps the active span's identity
 onto each measurement. Grafana renders these as clickable dots that
 pivot to the matching trace in Tempo.
 
-#### Per-example Grafana dashboards (issue 668)
+#### Grafana dashboards (issue 668)
 
-Each example that wires `SetupMetrics` SHOULD ship a starter dashboard
-under `docker/observability/grafana/provisioning/dashboards/files/<example-name>/overview.json`
-following this convention:
+**Canonical first.** The bundled [`mcpkit — overview`](http://localhost:3000/d/mcpkit-overview)
+dashboard (stable permalink `/d/mcpkit-overview`) works for ANY example
+that emits the four canonical instruments — pick the example from the
+`$service` dropdown, the rest of the panels rescope automatically.
+The four canonical instruments + the `tool` / `code` attributes are
+the shared contract, so no per-example wiring is needed to see
+metrics on day one.
 
-- **UID equals the example name** (`"uid": "<example-name>"`) — gives
-  the dashboard a stable Grafana permalink at
-  `http://localhost:3000/d/<example-name>` that operators can bookmark.
-- **Folder structure** — Grafana's provisioning auto-creates a folder
-  named after the directory (`foldersFromFilesStructure: true` in
-  `dashboards.yaml`), so dashboards group cleanly in the UI.
-- **`$service` variable** scoped to `<example-name>.*` — covers both
-  the server (`<example-name>`) and walkthrough host
-  (`<example-name>-host`) service names.
-- **`$tool` variable** lets the operator pin a single tool across
-  every panel — useful when chasing one misbehaving tool.
+**Per-example dashboards are an escape hatch**, NOT the default.
+Reach for one only when an example surfaces metrics the canonical
+dashboard can't express — e.g., `ext/tasks` task-lifecycle panels,
+`events` replica fanout, `apps` iframe-bridge latency. Most examples
+will never need one.
 
-`examples/otel/stdout/` ships the reference dashboard; later examples
-can copy + rename the UID. See [`docker/observability/`](../docker/observability/README.md)
-for the LGTM stack the dashboards consume.
+When an example DOES need its own dashboard, the convention is:
+
+- Drop the JSON at `docker/observability/grafana/provisioning/dashboards/files/<example>/overview.json`.
+- Set `"uid": "<example>"` so the dashboard is reachable at
+  `/d/<example>` (Grafana-native stable URL).
+- Grafana's `foldersFromFilesStructure: true` provisioning option
+  auto-creates a folder named `<example>` in the UI from the
+  directory name.
+- Scope the `$service` variable to `<example>.*` so it covers the
+  server (`<example>`) plus the walkthrough host (`<example>-host`).
+
+A scaling story (Make-driven template + manifest generator) is
+tracked on issue 737 — fires when more than one example needs a
+specialized dashboard. Today, per-example dashboards are
+hand-checked-in copies (fine for 0-3 of them).
+
+See [`docker/observability/`](../docker/observability/README.md) for
+the LGTM stack the dashboards consume.
 
 #### Logs wiring (issue 668)
 


### PR DESCRIPTION
## What changes

Reframes PR 736's dashboard pattern after operator feedback. PR 736 made every example responsible for its own dashboard JSON (manual copy + rename UID), which gets tedious fast. Reality: every example emits the same four canonical instruments through the same `tool` / `code` / `service_name` attribute vocabulary, so **a single dashboard with a `$service` dropdown serves them all**.

```mermaid
flowchart LR
    subgraph "Before this PR"
        A1[Example A] --> D1["files/A/overview.json"]
        A2[Example B] --> D2["files/B/overview.json"]
        A3[Example C] --> D3["files/C/overview.json"]
        D1 -. "all 99% identical" .-> D2
        D2 -. "all 99% identical" .-> D3
    end
    subgraph "After this PR"
        B1[Example A] --> CD["/d/mcpkit-overview"]
        B2[Example B] --> CD
        B3[Example C] --> CD
        B4["Example with unique metrics"] --> SD["files/&lt;example&gt;/overview.json (escape hatch)"]
    end
```

Per-example dashboards remain supported via the same convention — they're just no longer the default. Issue 737 tracks the future scaling story (template + manifest generator) for when bespoke dashboards proliferate.

## Reviewer's guide

Read in this order:

1. [docker/observability/grafana/provisioning/dashboards/files/mcpkit-overview.json](https://github.com/panyam/mcpkit/pull/738/files#diff-8e0e536df6a5d6f24130495825dd2dccae6369d78ecf3655229de23a20dfd7e4) — the renamed dashboard. 10-line content delta vs PR 736's `otel-stdout` version: new UID, new title, new tags, widened `$service` query + `allValue`.
2. [examples/CONVENTIONS.md](https://github.com/panyam/mcpkit/pull/738/files#diff-d763a016b06b1c666cdb643f94ccb8a6c1138b2a8327802b93aec40519b40e27) § Grafana dashboards — reframed: "canonical first; per-example only when bespoke." The escape-hatch convention is preserved verbatim from PR 736 for the rare case it's needed.
3. [docker/observability/README.md](https://github.com/panyam/mcpkit/pull/738/files#diff-b2822068c182abbd00d14d17eb0f30777aa792ac13036238ca17b3b39e3a08a4) — points at `/d/mcpkit-overview` instead of `/d/otel-stdout`.

## Diff groups

- **File rename + metadata changes:** `files/{otel-stdout/overview.json → mcpkit-overview.json}` (git detected as rename with 98% similarity)
- **Docs:** `examples/CONVENTIONS.md`, `docker/observability/README.md`

## Decision log

- **Single canonical dashboard, not per-example default.** Every example today emits the same instruments with the same attribute vocabulary. Per-example dashboards become dead-code copies of the same panels. Single canonical + `$service` dropdown gets us per-example filtering without per-example files.
- **UID = `mcpkit-overview`**, not `mcpkit`. The shorter UID is more aesthetically clean but reads ambiguously ("mcpkit what?"). `mcpkit-overview` reads correctly when surfaced in Grafana's dashboard picker.
- **Per-example pattern preserved as escape hatch.** When `ext/tasks` lands its v2 task-lifecycle dashboard, or `events` lands its replica-fanout dashboard, they drop a JSON at `files/<example>/overview.json` with `uid: "<example>"` and get `/d/<example>` for free. The escape hatch is documented in `examples/CONVENTIONS.md`.
- **Generator deferred to issue 737, not built in this PR.** The trigger condition (more than one specialized dashboard) hasn't fired yet. Premature generator = premature abstraction.

## Risk / blast radius

- **Affects:** the dashboard URL changes from `/d/otel-stdout` → `/d/mcpkit-overview`. Anyone who bookmarked the old URL after PR 736 merged needs to update. Since PR 736 just merged, that exposure is minimal.
- **Tests covering this:** no automated test for dashboard JSON validity. Manual verification recipe at the bottom of PR 736 still applies — the dashboard structure is unchanged, only the metadata.
- **Be paranoid about:** the `$service` variable now reads `label_values(mcp_tool_calls_total, service_name)` (no filter). If a non-mcpkit service is also pushing the `mcp_tool_calls_total` metric into the same Mimir instance (unlikely, but possible in a shared observability stack), it'll show up in the dropdown. Acceptable: the local LGTM stack is single-tenant by design.

## Before / after

Before this PR (post-736): every example wanting metrics observability had to author its own dashboard JSON. Bookmark URL: `/d/<example>` per example.

After this PR: any example that adopts `SetupMetrics` gets dashboarded for free at `/d/mcpkit-overview` — pick from the `$service` dropdown. Examples that need specialized panels still drop their own JSON, but they're the exception.

## Out of scope (deliberately deferred)

- **Template + manifest generator** for per-example dashboard duplication — tracked on issue 737. Fires when more than one example needs a specialized dashboard.
- **nginx URL rewrites for `/dashboards/<example>`** — UID-based URLs (`/d/<example>`) work fine.
- **Versioning the dashboard JSON in a build pipeline** — out of scope; current `version: 1` is fine for a hand-maintained artifact.

Follow-up to PR 736. Closes operator feedback on the per-example pattern being too eager.

