### PR TITLE
SEP-414 P7 — Skills observability + CONSTRAINTS C4

### DIFF
--- a/CONSTRAINTS.md
+++ b/CONSTRAINTS.md
@@ -42,3 +42,20 @@ Don't use package-level `var` for mutable state that should be per-instance (e.g
 Scope mutable state to the struct/instance created during registration. E.g., the `Register()` function should create a struct that both middleware and handlers close over.
 
 **Verify:** `grep -rn 'var.*sync.Map\|var.*make(map' --include='*.go' | grep -v '_test.go' | grep -v 'func '` — package-level mutable maps should not exist.
+
+## C4: No cross-extension dependencies unless SEP-mandated
+
+Modules under `ext/` and `experimental/ext/` MUST NOT import each other (runtime OR test) unless the coupling is explicitly mandated by an SEP. Extensions are independent surfaces; each consumes only `core/` abstractions (e.g., `core.TracerProvider`, `core.Claims`).
+
+The rule prevents two failure modes:
+
+- **Hidden coupling cascade**: a single test-only import (e.g., `ext/otel` importing `ext/skills` for an e2e) silently inverts the layering. The adapter that other extensions consume now depends on one of those extensions, and version bumps become entangled.
+- **Drive-by interop expectations**: when extension A imports extension B, the API of B is implicitly stabilized for A's benefit, even though no SEP says they must interoperate. Future B-only refactors break A.
+
+Real-world example: `ext/otel` is the OTel SDK adapter implementing `core.TracerProvider`. Every extension that wants real spans imports it. If `ext/otel` were to import `ext/skills` (e.g., to ship an e2e test that exercises both), the layering inverts — `ext/skills` can no longer evolve without considering `ext/otel`'s test surface, and the adapter's go.sum drags in skills-specific deps.
+
+Escape hatch for cross-extension e2e tests: put the test in a separate top-level module (e.g., `tests/<ext-a>_<ext-b>_e2e/`) that imports both. Keeps the cross-cut isolated from either extension's go.mod.
+
+If a future SEP explicitly cross-cuts two extensions, document the SEP reference in the importing module's README so the coupling is auditable.
+
+**Verify:** `bash -c 'for m in ext/*/go.mod experimental/ext/*/go.mod; do owner=$(dirname "$m" | xargs basename); m_=$(grep -E "^[[:space:]]+github\.com/panyam/mcpkit/(ext|experimental/ext)/" "$m" | grep -vE "github\.com/panyam/mcpkit/(ext|experimental/ext)/$owner([[:space:]/]|$)"); if [ -n "$m_" ]; then echo "VIOLATION: $m"; echo "$m_"; fi; done'` — must print nothing. Matches indented `require` lines (skipping module-declaration lines) and excludes the module's own path.

--- a/cmd/mcpskills/inspect.go
+++ b/cmd/mcpskills/inspect.go
@@ -70,7 +70,7 @@ Examples:
 				return renderText(out, painter, report)
 			}
 
-			idx, err := sc.ListSkills()
+			idx, err := sc.ListSkills(cmd.Context())
 			if err != nil {
 				return fmt.Errorf("ListSkills: %w", err)
 			}
@@ -85,7 +85,7 @@ Examples:
 					Digest:      e.Digest,
 					Description: e.Description,
 				}
-				result, verifyErr := sc.ReadAndVerify(e.URL, e.Digest)
+				result, verifyErr := sc.ReadAndVerify(cmd.Context(), e.URL, e.Digest)
 				switch {
 				case verifyErr == nil && result.DigestVerified:
 					t := true

--- a/docs/SEP_414_OTEL.md
+++ b/docs/SEP_414_OTEL.md
@@ -707,6 +707,49 @@ server span (TraceID T1)              server span (TraceID T2)
 
 End-to-end correctness proof: `ext/otel/mrtr_tracelink_e2e_test.go` drives a real `CallToolWithInputs` against a real OTel-SDK-backed server + client, then asserts the recorded round-2 server span has an OTel Link whose TraceID matches round-1's.
 
+### Skills observability — landed (issue 748; PR forthcoming)
+
+Tool calls have natural telemetry: every `tools/call` is one wire event → one server-side dispatch span. Skills (SEP-2640) don't — the host fetches a manifest once via `resources/read`, caches it client-side, then **activates** it N times invisibly. Without intervention, post-cache activation is unobservable to either side.
+
+Issue 748 closes the gap in two layers.
+
+**Layer 1 — server dispatch span enrichment.** `server/trace_middleware.go` now stamps the `resources/read` span with `mcp.resource.uri` (always, for any URI) plus `mcp.skill.uri` / `mcp.skill.path` / `mcp.skill.file` when the URI uses the `skill://` scheme. Mirrors the existing `tools/call → mcp.tool.name` pattern. Server-side dashboards can now chart fetch volume + error rate per skill.
+
+`mcp.skill.path` and `mcp.skill.file` only populate for SEP-2640 **manifest URIs** (terminal `/SKILL.md`) where the path/file boundary is unambiguous from the URI alone. Non-manifest URIs (e.g. `skill://pdf-processing/references/FORMS.md`) surface as `mcp.skill.uri` only — SEP-2640 documents that the boundary in those cases requires external knowledge from the discovery index or a prior manifest read.
+
+**Layer 2 — client-side `ext/skills.Client` instrumentation.** `NewClient(mcp, opts...)` is variadic; new `WithTracerProvider(tp)` option wraps the read-path methods in spans:
+
+| Method | Span name | Attributes |
+|---|---|---|
+| `ListSkills` | `skills.list` | `mcp.skill.uri` (index URI), `mcp.skill.count` on success |
+| `ReadSkillURI` | `skills.read` | `mcp.skill.uri` |
+| `ReadSkillManifest` | `skills.read_manifest` | `mcp.skill.uri`, `mcp.skill.path`, `mcp.skill.name` |
+| `ReadAndVerify` | `skills.read_and_verify` | `mcp.skill.uri`, `mcp.skill.expected_digest`, `mcp.skill.digest_verified` |
+
+Stitching is automatic: the client read span runs inside ctx that already carries `_meta.traceparent` from the existing W3C trace context propagation (PR 644 / PR 649 / PR 652), so the server-side dispatch span (now enriched per Layer 1) lands as a child of the client wrapping span in the same trace.
+
+**The activation hook — purely SDK-side, no wire change.** `Client.Activate(ctx, uri, opts...) ActivationEvent` is the answer to the "skill used" telemetry the wire can't capture. Hosts call it at the point in the agent loop where the skill enters model context. Side effects:
+
+- Emits an instant `skills.activate` span (Start + End back-to-back — activation is point-in-time, not a duration) carrying `mcp.skill.uri`, `mcp.skill.path` (when the URI parses as a manifest URI), and `mcp.skill.activation.reason` when `WithReason(...)` is supplied.
+- Invokes the optional `WithActivationHook(fn)` callback synchronously, so non-OTel hosts can feed their own telemetry pipeline (structured logging, internal counters, alternate tracing) without configuring a TracerProvider.
+- Returns the `ActivationEvent{URI, Reason, Timestamp}` to the caller for pull-style stamping.
+
+`Activate` accepts any string URI — it never blocks dispatch or validates input. Designed for the agent-loop case where the URI may be a manifest URI, a sub-file URI, or even an opaque identifier the host minted for an in-process bundle.
+
+**Considered alternatives**:
+
+- **Wire-level `notifications/...skills/activated`** — a cross-process notification carrying `{uri, digest, reason, _meta.traceparent}` so the server can record activation events from connected clients. Tractable but cross-cuts SEP-2640 spec territory and requires WG engagement before minting the method name. Tracked as issue 749 — a separable opt-in extension on `ext/skills` that can ride atop `Client.Activate` without breaking callers when (if) the upstream method name lands.
+- **Provider-side activation telemetry** — N/A. The provider handles resource reads; activation is a client/host concept.
+- **Activation counter on the issue 735 MeterProvider seam** — useful follow-up. The TracerProvider half ships in 748; counter wiring can land cleanly in a small follow-up PR.
+
+Coverage:
+
+- `server/trace_middleware_test.go` — three tests pin Layer 1: skill manifest URI emits all four attrs; non-skill URI emits `mcp.resource.uri` only; non-manifest skill URI emits `mcp.skill.uri` only.
+- `ext/skills/client_trace_test.go` — eight tests pin Layer 2: each wrapped method emits the right span + attrs; `Activate` fires hook + span; `Activate` omits the reason attr when not supplied; hook fires independently of tracer install; zero-overhead path (no `WithTracerProvider`) emits no observable spans.
+- End-to-end trace context propagation across `resources/read` is the same code path the MRTR e2e already exercises for `tools/call` (`_meta.traceparent` injection in dispatch is method-agnostic). A skills-specific real-SDK e2e is deliberately omitted — it would require either inverting the `ext/otel`-doesn't-import-`ext/skills` layering or adding the real OTel SDK as a test-only dep on `ext/skills`.
+
+**Runnable demo**: `examples/skills/walkthrough.go` exercises the wrap span + Activate path with the `--exporter=stdout` (or `--exporter=otlp`) flag pair. Run with `make serve EXPORTER=stdout` + `make demo EXPORTER=stdout`.
+
 ## Downstream consumers of the Phase 1 contract
 
 - **`experimental/ext/events/` cross-replica bus (issue #629).** The

--- a/examples/skills/WALKTHROUGH.md
+++ b/examples/skills/WALKTHROUGH.md
@@ -1,6 +1,6 @@
 # MCP Skills Extension (SEP-2640) — Reference Walkthrough
 
-Walks through SEP-2640, which serves Agent Skills over MCP using the existing Resources primitive. Each file in a skill directory is exposed as a `skill://` resource, the server declares the `io.modelcontextprotocol/skills` capability in `initialize`, and the well-known `skill://index.json` resource enumerates concrete skills with SHA-256 digests. mcpkit's `ext/skills.SkillProvider` walks an `io/fs.FS` once at construction and registers each file with the configured Provider.
+SEP-2640 serves Agent Skills over MCP's Resources primitive: each file under a skill directory is a `skill://` URI; `skill://index.json` enumerates them with SHA-256 digests.
 
 ## What you'll learn
 
@@ -12,6 +12,7 @@ Walks through SEP-2640, which serves Agent Skills over MCP using the existing Re
 - **Read a supporting file via skill:// (references/FORMS.md)** — Relative reference `references/FORMS.md` from within pdf-processing/SKILL.md resolves to this full URI via `skills.ResolveRelative(skillRoot, "references/FORMS.md")`.
 - **Read a nested-prefix skill (acme/billing/refunds)** — Demonstrates that the prefix-segment routing works end-to-end. The skill's `name` is `refunds`; the prefix `acme/billing/` is server-chosen.
 - **Read a supporting file in the nested skill (templates/email.md)** — Same relative-reference resolution: `templates/email.md` from refunds/SKILL.md.
+- **Wrap reads in skills.NewClient(...) and call Client.Activate** — Activate is intra-process — no wire traffic. Run with `make serve EXPORTER=stdout` + `make demo EXPORTER=stdout` to see spans.
 
 ## Flow
 
@@ -51,49 +52,29 @@ sequenceDiagram
     Note over Host,Server: Step 8: Read a supporting file in the nested skill (templates/email.md)
     Host->>Server: resources/read uri=skill://acme/billing/refunds/templates/email.md
     Server-->>Host: text/markdown body
+
+    Note over Host,Server: Step 9: Wrap reads in skills.NewClient(...) and call Client.Activate
+    Host->>Server: resources/read via sc.ReadAndVerify (span: skills.read_and_verify)
+    Server-->>Host: bytes + digest match
 ```
 
 ## Steps
 
 ### Setup
 
-Start the MCP server in a separate terminal first:
-
 ```
-Terminal 1:  make serve         # skills server on :8080 in file mode
-Terminal 2:  make demo          # this walkthrough (--tui for the interactive TUI)
-```
-
-The default fixture under `skills/` walks three SEP-2640 examples: a single-segment skill (`git-workflow`), a single-segment skill with supporting files (`pdf-processing`), and a nested-prefix skill (`acme/billing/refunds`).
-
-Two alternative server modes flip the wire shape:
-
-```
-make serve-archive   # publishes each skill as one .tar.gz resource
-make serve-zip       # publishes each skill as one .zip resource
+Terminal 1:  make serve         # default (file mode, :8080)
+             make serve-archive # one .tar.gz per skill
+Terminal 2:  make demo          # this walkthrough (--tui interactive)
 ```
 
-In archive mode `resources/list` returns one URI per skill (e.g. `skill://pdf-processing.tar.gz`) instead of N URIs per file. The post-unpack virtual namespace hosts observe is identical either way — that's the SEP's whole-skill atomic-delivery story.
+### URI shape
 
-Optional: `make fetch-docx` clones the [`anthropics/skills`](https://github.com/anthropics/skills) repo and stages the `docx` skill into the `skills/` fixture directory before you start the server. It's a multi-file real-world skill that exercises the supporting-file paths beyond the toy fixtures.
-
-### The skill:// URI scheme
-
-SEP-2640 defines `skill://<skill-path>/<file-path>` where `<skill-path>` is a `/`-separated path locating the skill directory and `<file-path>` is the file within it. The final segment of `<skill-path>` MUST equal the skill's `name` frontmatter field. Prefix segments (anything before that final segment) are an optional server-chosen organizational namespace.
-
-Examples from the SEP table that this walkthrough exercises:
-
-| Skill path             | File                  | URI                                              |
-| ---------------------- | --------------------- | ------------------------------------------------ |
-| `git-workflow`         | `SKILL.md`            | `skill://git-workflow/SKILL.md`                  |
-| `pdf-processing`       | `references/FORMS.md` | `skill://pdf-processing/references/FORMS.md`     |
-| `acme/billing/refunds` | `SKILL.md`            | `skill://acme/billing/refunds/SKILL.md`          |
-
-The `acme/billing/refunds` shape demonstrates the prefix-segment behavior: `acme/billing` is the prefix and `refunds` is the skill name. The walkthrough reads files from each shape to confirm the routing is uniform.
+`skill://<path>/<file>`. Final path segment = the skill's frontmatter `name`. Prefix segments (e.g. `acme/billing/`) are an optional server-chosen namespace. Walkthrough exercises `git-workflow`, `pdf-processing`, and `acme/billing/refunds`.
 
 ### Capability declaration
 
-Per SEP-2640's Capability Declaration section, a server advertises `io.modelcontextprotocol/skills` under `capabilities.extensions` in its `initialize` response. The value is the empty object `{}` — never an array. mcpkit's `ext/skills.SkillsExtension{}` plus `Provider.RegisterWith(srv)` handles this automatically; nothing else to wire on the server side.
+Server advertises `io.modelcontextprotocol/skills` under `capabilities.extensions` (always `{}`, never an array). `Provider.RegisterWith(srv)` wires it automatically.
 
 ### Step 1: Connect to the skills server
 
@@ -103,17 +84,17 @@ Per SEP-2640's Capability Declaration section, a server advertises `io.modelcont
 
 In file mode the list has N entries per skill (one for SKILL.md, one for each supporting file) plus the index. In archive mode it's one entry per skill plus the index.
 
-### The discovery index
+### Discovery index
 
-`skill://index.json` is the well-known enumeration resource. It's optional in the SEP (servers MAY decline to expose it) but mcpkit auto-registers it unless `WithoutIndex()` is supplied. The index has a fixed JSON shape: a `$schema` URI pinning the index version and a `skills[]` array where each entry has `type` (`skill-md` or `archive`), `description`, `url`, `name`, and `digest`.
+`skill://index.json` enumerates skills with `{$schema, skills:[{type, name, description, url, digest}]}`. Optional in the SEP; mcpkit auto-registers unless `WithoutIndex()`.
 
 ### Step 3: Read skill://index.json
 
 The Indexer caches the result with TTL + per-skill mtime invalidation. Repeated reads return the same bytes until something in a SKILL.md actually changes.
 
-### The digest contract
+### Digest contract
 
-Per SEP-2640's Integrity and Verification section, each `skill-md` and `archive` entry carries a `sha256:{64-lowercase-hex}` digest computed over the artifact's raw bytes. For `skill-md` entries the artifact is the SKILL.md file itself; for `archive` entries it's the packed archive bytes. Hosts MUST verify retrieved content against this digest before using it. The walkthrough does exactly that for the `git-workflow` skill.
+Each entry carries `sha256:{64hex}` over the raw artifact bytes (SKILL.md for skill-md, packed archive for archive). Hosts MUST verify before use.
 
 ### Step 4: Verify digest by re-fetching SKILL.md and recomputing SHA-256
 
@@ -121,7 +102,7 @@ Treat the response bytes as the artifact, hash them, and compare against the dig
 
 ### Reading skill files
 
-Once a host has loaded a SKILL.md, the skill's body may reference supporting files via relative paths. mcpkit's `ext/skills.ResolveRelative(skillRoot, ref)` resolves these against the skill's root URI per SEP-2640's Reading section (filesystem-style resolution, escapes via `..` rejected). The walkthrough exercises both forms: the manifest, and a supporting file deep in the skill tree.
+Manifest body may reference supporting files via relative paths. `skills.ResolveRelative(skillRoot, ref)` resolves them filesystem-style; `..` escapes are rejected.
 
 ### Step 5: Read the pdf-processing SKILL.md
 
@@ -139,16 +120,17 @@ Demonstrates that the prefix-segment routing works end-to-end. The skill's `name
 
 Same relative-reference resolution: `templates/email.md` from refunds/SKILL.md.
 
+### SEP-414 P7 — Skills observability
+
+Fetch ≠ activation. Server `resources/read` spans now carry `mcp.skill.*` attrs (#748). Client `ext/skills.Client` emits `skills.read*` spans + `Activate(ctx, uri)` for post-cache use the wire can't see (SDK-only — no spec change).
+
+### Step 9: Wrap reads in skills.NewClient(...) and call Client.Activate
+
+Activate is intra-process — no wire traffic. Run with `make serve EXPORTER=stdout` + `make demo EXPORTER=stdout` to see spans.
+
 ### Wrap-up
 
-The host has now:
-
-- Negotiated the skills extension via the standard `initialize` handshake.
-- Enumerated every skill the server publishes by reading `skill://index.json` once.
-- Verified one artifact's bytes against its SHA-256 digest, satisfying the SEP MUST.
-- Read SKILL.md plus supporting files across single-segment and nested-prefix skill paths.
-
-To switch the same walkthrough into archive mode, restart the server with `make serve-archive`. The host code stays exactly the same; the wire-level shape switches to one `.tar.gz` resource per skill, and the digest in the index covers the packed archive bytes instead of the SKILL.md alone.
+Negotiated extension, enumerated index, verified one digest, read manifest + supporting files across single-segment and nested-prefix paths, emitted skill-shape spans + an activation event. `make serve-archive` flips the wire to one `.tar.gz` per skill — host code unchanged.
 
 ## Run it
 

--- a/examples/skills/walkthrough.go
+++ b/examples/skills/walkthrough.go
@@ -43,50 +43,26 @@ func runDemo() {
 
 	demo := demokit.New("MCP Skills Extension (SEP-2640) — Reference Walkthrough").
 		Dir("skills").
-		Description("Walks through SEP-2640, which serves Agent Skills over MCP using the existing Resources primitive. Each file in a skill directory is exposed as a `skill://` resource, the server declares the `io.modelcontextprotocol/skills` capability in `initialize`, and the well-known `skill://index.json` resource enumerates concrete skills with SHA-256 digests. mcpkit's `ext/skills.SkillProvider` walks an `io/fs.FS` once at construction and registers each file with the configured Provider.").
+		Description("SEP-2640 serves Agent Skills over MCP's Resources primitive: each file under a skill directory is a `skill://` URI; `skill://index.json` enumerates them with SHA-256 digests.").
 		Actors(
 			demokit.Actor("Host", "MCP Host (this client)"),
 			demokit.Actor("Server", "MCP Server (make serve, file mode by default)"),
 		)
 
 	demo.Section("Setup",
-		"Start the MCP server in a separate terminal first:",
-		"",
 		"```",
-		"Terminal 1:  make serve         # skills server on :8080 in file mode",
-		"Terminal 2:  make demo          # this walkthrough (--tui for the interactive TUI)",
+		"Terminal 1:  make serve         # default (file mode, :8080)",
+		"             make serve-archive # one .tar.gz per skill",
+		"Terminal 2:  make demo          # this walkthrough (--tui interactive)",
 		"```",
-		"",
-		"The default fixture under `skills/` walks three SEP-2640 examples: a single-segment skill (`git-workflow`), a single-segment skill with supporting files (`pdf-processing`), and a nested-prefix skill (`acme/billing/refunds`).",
-		"",
-		"Two alternative server modes flip the wire shape:",
-		"",
-		"```",
-		"make serve-archive   # publishes each skill as one .tar.gz resource",
-		"make serve-zip       # publishes each skill as one .zip resource",
-		"```",
-		"",
-		"In archive mode `resources/list` returns one URI per skill (e.g. `skill://pdf-processing.tar.gz`) instead of N URIs per file. The post-unpack virtual namespace hosts observe is identical either way — that's the SEP's whole-skill atomic-delivery story.",
-		"",
-		"Optional: `make fetch-docx` clones the [`anthropics/skills`](https://github.com/anthropics/skills) repo and stages the `docx` skill into the `skills/` fixture directory before you start the server. It's a multi-file real-world skill that exercises the supporting-file paths beyond the toy fixtures.",
 	)
 
-	demo.Section("The skill:// URI scheme",
-		"SEP-2640 defines `skill://<skill-path>/<file-path>` where `<skill-path>` is a `/`-separated path locating the skill directory and `<file-path>` is the file within it. The final segment of `<skill-path>` MUST equal the skill's `name` frontmatter field. Prefix segments (anything before that final segment) are an optional server-chosen organizational namespace.",
-		"",
-		"Examples from the SEP table that this walkthrough exercises:",
-		"",
-		"| Skill path             | File                  | URI                                              |",
-		"| ---------------------- | --------------------- | ------------------------------------------------ |",
-		"| `git-workflow`         | `SKILL.md`            | `skill://git-workflow/SKILL.md`                  |",
-		"| `pdf-processing`       | `references/FORMS.md` | `skill://pdf-processing/references/FORMS.md`     |",
-		"| `acme/billing/refunds` | `SKILL.md`            | `skill://acme/billing/refunds/SKILL.md`          |",
-		"",
-		"The `acme/billing/refunds` shape demonstrates the prefix-segment behavior: `acme/billing` is the prefix and `refunds` is the skill name. The walkthrough reads files from each shape to confirm the routing is uniform.",
+	demo.Section("URI shape",
+		"`skill://<path>/<file>`. Final path segment = the skill's frontmatter `name`. Prefix segments (e.g. `acme/billing/`) are an optional server-chosen namespace. Walkthrough exercises `git-workflow`, `pdf-processing`, and `acme/billing/refunds`.",
 	)
 
 	demo.Section("Capability declaration",
-		"Per SEP-2640's Capability Declaration section, a server advertises `io.modelcontextprotocol/skills` under `capabilities.extensions` in its `initialize` response. The value is the empty object `{}` — never an array. mcpkit's `ext/skills.SkillsExtension{}` plus `Provider.RegisterWith(srv)` handles this automatically; nothing else to wire on the server side.",
+		"Server advertises `io.modelcontextprotocol/skills` under `capabilities.extensions` (always `{}`, never an array). `Provider.RegisterWith(srv)` wires it automatically.",
 	)
 
 	var (
@@ -137,8 +113,8 @@ func runDemo() {
 			return nil
 		})
 
-	demo.Section("The discovery index",
-		"`skill://index.json` is the well-known enumeration resource. It's optional in the SEP (servers MAY decline to expose it) but mcpkit auto-registers it unless `WithoutIndex()` is supplied. The index has a fixed JSON shape: a `$schema` URI pinning the index version and a `skills[]` array where each entry has `type` (`skill-md` or `archive`), `description`, `url`, `name`, and `digest`.",
+	demo.Section("Discovery index",
+		"`skill://index.json` enumerates skills with `{$schema, skills:[{type, name, description, url, digest}]}`. Optional in the SEP; mcpkit auto-registers unless `WithoutIndex()`.",
 	)
 
 	var indexBody []byte
@@ -174,8 +150,8 @@ func runDemo() {
 			return nil
 		})
 
-	demo.Section("The digest contract",
-		"Per SEP-2640's Integrity and Verification section, each `skill-md` and `archive` entry carries a `sha256:{64-lowercase-hex}` digest computed over the artifact's raw bytes. For `skill-md` entries the artifact is the SKILL.md file itself; for `archive` entries it's the packed archive bytes. Hosts MUST verify retrieved content against this digest before using it. The walkthrough does exactly that for the `git-workflow` skill.",
+	demo.Section("Digest contract",
+		"Each entry carries `sha256:{64hex}` over the raw artifact bytes (SKILL.md for skill-md, packed archive for archive). Hosts MUST verify before use.",
 	)
 
 	demo.Step("Verify digest by re-fetching SKILL.md and recomputing SHA-256").
@@ -226,7 +202,7 @@ func runDemo() {
 		})
 
 	demo.Section("Reading skill files",
-		"Once a host has loaded a SKILL.md, the skill's body may reference supporting files via relative paths. mcpkit's `ext/skills.ResolveRelative(skillRoot, ref)` resolves these against the skill's root URI per SEP-2640's Reading section (filesystem-style resolution, escapes via `..` rejected). The walkthrough exercises both forms: the manifest, and a supporting file deep in the skill tree.",
+		"Manifest body may reference supporting files via relative paths. `skills.ResolveRelative(skillRoot, ref)` resolves them filesystem-style; `..` escapes are rejected.",
 	)
 
 	demo.Step("Read the pdf-processing SKILL.md").
@@ -297,15 +273,41 @@ func runDemo() {
 			return nil
 		})
 
+	demo.Section("SEP-414 P7 — Skills observability",
+		"Fetch ≠ activation. Server `resources/read` spans now carry `mcp.skill.*` attrs (#748). Client `ext/skills.Client` emits `skills.read*` spans + `Activate(ctx, uri)` for post-cache use the wire can't see (SDK-only — no spec change).",
+	)
+
+	demo.Step("Wrap reads in skills.NewClient(...) and call Client.Activate").
+		Arrow("Host", "Server", "resources/read via sc.ReadAndVerify (span: skills.read_and_verify)").
+		DashedArrow("Server", "Host", "bytes + digest match").
+		Note("Activate is intra-process — no wire traffic. Run with `make serve EXPORTER=stdout` + `make demo EXPORTER=stdout` to see spans.").
+		Run(func(ctx demokit.StepContext) *demokit.StepResult {
+			if c == nil {
+				return nil
+			}
+			activations := 0
+			sc := skills.NewClient(c,
+				skills.WithTracerProvider(tp),
+				skills.WithActivationHook(func(_ context.Context, ev skills.ActivationEvent) {
+					activations++
+					fmt.Printf("    activation hook: uri=%s reason=%q ts=%s\n",
+						ev.URI, ev.Reason, ev.Timestamp.Format("15:04:05.000"))
+				}),
+			)
+			if _, err := sc.ReadAndVerify(context.Background(), uriPDFManifest, ""); err != nil {
+				fmt.Printf("    SKIP ReadAndVerify: %v (server may be in archive mode)\n", err)
+				return nil
+			}
+			fmt.Printf("    sc.ReadAndVerify emitted skills.read_and_verify span\n")
+			ev := sc.Activate(context.Background(), uriPDFManifest,
+				skills.WithReason("walkthrough_demonstration"))
+			fmt.Printf("    sc.Activate returned ActivationEvent{URI=%s, Reason=%q}\n", ev.URI, ev.Reason)
+			fmt.Printf("    %d hook invocation(s)\n", activations)
+			return nil
+		})
+
 	demo.Section("Wrap-up",
-		"The host has now:",
-		"",
-		"- Negotiated the skills extension via the standard `initialize` handshake.",
-		"- Enumerated every skill the server publishes by reading `skill://index.json` once.",
-		"- Verified one artifact's bytes against its SHA-256 digest, satisfying the SEP MUST.",
-		"- Read SKILL.md plus supporting files across single-segment and nested-prefix skill paths.",
-		"",
-		"To switch the same walkthrough into archive mode, restart the server with `make serve-archive`. The host code stays exactly the same; the wire-level shape switches to one `.tar.gz` resource per skill, and the digest in the index covers the packed archive bytes instead of the SKILL.md alone.",
+		"Negotiated extension, enumerated index, verified one digest, read manifest + supporting files across single-segment and nested-prefix paths, emitted skill-shape spans + an activation event. `make serve-archive` flips the wire to one `.tar.gz` per skill — host code unchanged.",
 	)
 
 	_ = serverInfo

--- a/ext/skills/client.go
+++ b/ext/skills/client.go
@@ -1,12 +1,14 @@
 package skills
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/panyam/mcpkit/client"
 	"github.com/panyam/mcpkit/core"
@@ -14,32 +16,56 @@ import (
 
 // Client wraps a *client.Client with SEP-2640 host-workflow helpers:
 // capability detection, discovery index fetch, manifest and supporting
-// file reads, digest verification.
+// file reads, digest verification, and SEP-414 P7 (#748) activation
+// telemetry.
 //
-// The wrapper holds no state of its own beyond the underlying client
-// pointer. Methods are safe for concurrent use to the same degree
-// *client.Client is.
+// The wrapper holds the underlying client pointer plus optional
+// telemetry plumbing (TracerProvider + activation hook). Methods are
+// safe for concurrent use to the same degree *client.Client is.
 //
 // Typical host workflow:
 //
 //	mcp := client.NewClient(serverURL, info)
 //	mcp.Connect()
-//	sc := skills.NewClient(mcp)
+//	sc := skills.NewClient(mcp,
+//	    skills.WithTracerProvider(tp),
+//	    skills.WithActivationHook(myMetrics.RecordSkillActivation),
+//	)
 //	if !sc.SupportsSkills() { return }
 //	idx, err := sc.ListSkills(ctx)
 //	for _, entry := range idx.Skills {
 //	    result, err := sc.ReadAndVerify(ctx, entry.URL, entry.Digest)
 //	    // result.DigestVerified is true on match; ErrDigestMismatch otherwise
 //	}
+//	// At the point in the agent loop where the skill enters model context:
+//	sc.Activate(ctx, "skill://pdf-processing/SKILL.md",
+//	    skills.WithReason("agent_decided"))
 type Client struct {
 	mcp *client.Client
+	cfg clientConfig
 }
 
 // NewClient builds a SEP-2640 host helper over the given mcpkit client.
 // The underlying client must already be Connect()ed for any read method
 // to succeed.
-func NewClient(mcp *client.Client) *Client {
-	return &Client{mcp: mcp}
+//
+// Options configure SEP-414 P7 (#748) telemetry plumbing:
+//
+//   - WithTracerProvider — span emission around read methods + Activate
+//   - WithActivationHook — non-OTel telemetry callback fired from Activate
+//
+// With no options, the helper behaves identically to the pre-P7 shape:
+// zero overhead, no spans, no hook calls. NoopTracerProvider is the
+// default — call sites do not nil-check.
+func NewClient(mcp *client.Client, opts ...Option) *Client {
+	cfg := clientConfig{tp: core.NoopTracerProvider{}}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	if cfg.tp == nil {
+		cfg.tp = core.NoopTracerProvider{}
+	}
+	return &Client{mcp: mcp, cfg: cfg}
 }
 
 // SupportsSkills reports whether the connected server advertises the
@@ -61,18 +87,33 @@ func (c *Client) SupportsSkills() bool {
 // empty Index (with the Schema field unset) and no error so callers
 // can treat absent indexes the same as empty ones. Other read errors
 // (transport, malformed JSON) propagate.
-func (c *Client) ListSkills() (Index, error) {
+//
+// ctx parents the SEP-414 P7 (#748) `skills.list` span when a
+// TracerProvider is installed. On success the span carries
+// `mcp.skill.count`. ctx is not threaded to the underlying client
+// (the legacy ReadResource API is ctx-free); it only governs span
+// parentage.
+func (c *Client) ListSkills(ctx context.Context) (Index, error) {
+	_, span := c.cfg.tp.StartSpan(ctx, "skills.list",
+		core.Attribute{Key: "mcp.skill.uri", Value: IndexURI},
+	)
+	defer span.End()
+
 	body, err := c.mcp.ReadResource(IndexURI)
 	if err != nil {
 		if isNotFoundErr(err) {
+			span.SetAttribute("mcp.skill.index_absent", "true")
 			return Index{}, nil
 		}
+		span.RecordError(err)
 		return Index{}, fmt.Errorf("skills: read %s: %w", IndexURI, err)
 	}
 	var idx Index
 	if err := json.Unmarshal([]byte(body), &idx); err != nil {
+		span.RecordError(err)
 		return Index{}, fmt.Errorf("skills: parse %s: %w", IndexURI, err)
 	}
+	span.SetAttribute("mcp.skill.count", fmt.Sprintf("%d", len(idx.Skills)))
 	return idx, nil
 }
 
@@ -84,12 +125,28 @@ func (c *Client) ListSkills() (Index, error) {
 // Returns text bytes when the resource is text-typed; base64-decoded
 // blob bytes when the resource is binary-typed (e.g., archive entries
 // served in archive mode).
-func (c *Client) ReadSkillURI(uri string) ([]byte, error) {
+//
+// ctx parents the SEP-414 P7 (#748) `skills.read` span when a
+// TracerProvider is installed. ctx is not threaded to the underlying
+// client (the legacy ReadResourceFull API is ctx-free); it only
+// governs span parentage.
+func (c *Client) ReadSkillURI(ctx context.Context, uri string) ([]byte, error) {
+	_, span := c.cfg.tp.StartSpan(ctx, "skills.read",
+		core.Attribute{Key: "mcp.skill.uri", Value: uri},
+	)
+	defer span.End()
+
 	result, err := c.mcp.ReadResourceFull(uri)
 	if err != nil {
+		span.RecordError(err)
 		return nil, fmt.Errorf("skills: read %s: %w", uri, err)
 	}
-	return extractBytes(result.Contents, uri)
+	bytes, err := extractBytes(result.Contents, uri)
+	if err != nil {
+		span.RecordError(err)
+		return nil, err
+	}
+	return bytes, nil
 }
 
 // SkillManifest holds a parsed SKILL.md plus the raw bytes the server
@@ -109,21 +166,41 @@ type SkillManifest struct {
 //
 // Validates that uri is a manifest URI (ends in /SKILL.md). For non-
 // manifest URIs use ReadSkillURI.
-func (c *Client) ReadSkillManifest(uri string) (*SkillManifest, error) {
+//
+// ctx parents the SEP-414 P7 (#748) `skills.read_manifest` span when a
+// TracerProvider is installed. On success the span carries
+// mcp.skill.path and mcp.skill.name in addition to mcp.skill.uri.
+func (c *Client) ReadSkillManifest(ctx context.Context, uri string) (*SkillManifest, error) {
+	ctx, span := c.cfg.tp.StartSpan(ctx, "skills.read_manifest",
+		core.Attribute{Key: "mcp.skill.uri", Value: uri},
+	)
+	defer span.End()
+
 	parts, err := ParseURI(uri)
 	if err != nil {
+		span.RecordError(err)
 		return nil, fmt.Errorf("skills: %s: %w", uri, err)
 	}
 	if !parts.IsManifest {
-		return nil, fmt.Errorf("%w: %q", ErrNotManifestURI, uri)
+		err := fmt.Errorf("%w: %q", ErrNotManifestURI, uri)
+		span.RecordError(err)
+		return nil, err
 	}
-	raw, err := c.ReadSkillURI(uri)
+	if path := strings.Join(parts.SkillPath, "/"); path != "" {
+		span.SetAttribute("mcp.skill.path", path)
+	}
+	raw, err := c.ReadSkillURI(ctx, uri)
 	if err != nil {
+		// inner span on c.ReadSkillURI already recorded the error
 		return nil, err
 	}
 	fm, body, err := ParseFrontmatter(raw)
 	if err != nil {
+		span.RecordError(err)
 		return nil, fmt.Errorf("skills: parse frontmatter for %s: %w", uri, err)
+	}
+	if fm.Name != "" {
+		span.SetAttribute("mcp.skill.name", fm.Name)
 	}
 	return &SkillManifest{
 		URI:         uri,
@@ -138,8 +215,11 @@ func (c *Client) ReadSkillManifest(uri string) (*SkillManifest, error) {
 // inside a SKILL.md body (e.g., "references/GUIDE.md") per SEP-2640's
 // filesystem-style resolution.
 //
-// Returns the same byte semantics as ReadSkillURI.
-func (c *Client) ReadSkillFile(manifest *SkillManifest, relPath string) ([]byte, error) {
+// Returns the same byte semantics as ReadSkillURI. The inner
+// ReadSkillURI call emits the SEP-414 P7 (#748) `skills.read` span;
+// ReadSkillFile itself adds no wrapping span (it's a thin URI
+// resolver + delegated read).
+func (c *Client) ReadSkillFile(ctx context.Context, manifest *SkillManifest, relPath string) ([]byte, error) {
 	if manifest == nil {
 		return nil, fmt.Errorf("skills: ReadSkillFile: nil manifest")
 	}
@@ -151,7 +231,7 @@ func (c *Client) ReadSkillFile(manifest *SkillManifest, relPath string) ([]byte,
 	if err != nil {
 		return nil, fmt.Errorf("skills: resolve %q against %s: %w", relPath, manifest.URI, err)
 	}
-	return c.ReadSkillURI(resolved.String())
+	return c.ReadSkillURI(ctx, resolved.String())
 }
 
 // ReadResult is the typed return from ReadAndVerify. Bytes carries the
@@ -175,22 +255,106 @@ type ReadResult struct {
 // like ReadSkillURI and returns DigestVerified=false. This is a
 // convenience for hosts that have a URI but no catalogued digest
 // (server instructions, user-supplied URIs).
-func (c *Client) ReadAndVerify(uri, expectedDigest string) (*ReadResult, error) {
-	body, err := c.ReadSkillURI(uri)
+//
+// ctx parents the SEP-414 P7 (#748) `skills.read_and_verify` span when
+// a TracerProvider is installed. The span carries mcp.skill.uri,
+// mcp.skill.expected_digest, and (on a non-error return)
+// mcp.skill.digest_verified.
+func (c *Client) ReadAndVerify(ctx context.Context, uri, expectedDigest string) (*ReadResult, error) {
+	ctx, span := c.cfg.tp.StartSpan(ctx, "skills.read_and_verify",
+		core.Attribute{Key: "mcp.skill.uri", Value: uri},
+		core.Attribute{Key: "mcp.skill.expected_digest", Value: expectedDigest},
+	)
+	defer span.End()
+
+	body, err := c.ReadSkillURI(ctx, uri)
 	if err != nil {
+		// inner span on ReadSkillURI already recorded the error
 		return nil, err
 	}
 	result := &ReadResult{URI: uri, Bytes: body}
 	if expectedDigest == "" {
+		span.SetAttribute("mcp.skill.digest_verified", "false")
 		return result, nil
 	}
 	sum := sha256.Sum256(body)
 	got := "sha256:" + hex.EncodeToString(sum[:])
 	if !strings.EqualFold(got, expectedDigest) {
-		return nil, fmt.Errorf("%w: want %s, got %s", ErrDigestMismatch, expectedDigest, got)
+		mismatchErr := fmt.Errorf("%w: want %s, got %s", ErrDigestMismatch, expectedDigest, got)
+		span.RecordError(mismatchErr)
+		return nil, mismatchErr
 	}
+	span.SetAttribute("mcp.skill.digest_verified", "true")
 	result.DigestVerified = true
 	return result, nil
+}
+
+// Activate signals SEP-414 P7 (#748) that the host just put the skill
+// at uri into the model context. It is a PURE SDK-side telemetry emit
+// point — no MCP wire traffic, no spec contract. The activation may
+// follow a cached manifest read, a freshly-loaded skill, or any other
+// path the agent loop chose; mcpkit's wire surface cannot otherwise
+// observe the use because cached skills activate invisibly.
+//
+// Side effects:
+//
+//   - When a TracerProvider is installed, emits an instant
+//     `skills.activate` span (Start+End back-to-back — activation is
+//     point-in-time, not a duration). Span attributes:
+//     mcp.skill.uri, mcp.skill.path (when uri is a manifest URI),
+//     mcp.skill.activation.reason (when WithReason is supplied).
+//   - When an activation hook is installed (WithActivationHook), calls
+//     it synchronously with the same ActivationEvent that is returned.
+//
+// The returned ActivationEvent is a structured pull-style emit
+// duplicate of what the span / hook saw, suitable for non-OTel
+// telemetry the caller wants to feed independently. Both telemetry
+// sinks see the same Timestamp.
+//
+// uri is not validated — Activate accepts any string the host wants to
+// report (manifest URI, sub-file URI, even an opaque identifier the
+// host minted for an in-process bundle). When uri parses as a SEP-2640
+// manifest URI, mcp.skill.path is emitted as well.
+//
+// ctx parents the span. A canceled ctx does not block the activation —
+// activation telemetry MUST NOT depend on context liveness because the
+// agent loop reports activations after the originating handler ctx may
+// have ended.
+func (c *Client) Activate(ctx context.Context, uri string, opts ...ActivateOption) ActivationEvent {
+	cfg := activateConfig{}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	event := ActivationEvent{
+		URI:       uri,
+		Reason:    cfg.reason,
+		Timestamp: time.Now(),
+	}
+
+	attrs := []core.Attribute{
+		{Key: "mcp.skill.uri", Value: uri},
+	}
+	if parts, err := ParseURI(uri); err == nil && len(parts.SkillPath) > 0 {
+		attrs = append(attrs, core.Attribute{
+			Key:   "mcp.skill.path",
+			Value: strings.Join(parts.SkillPath, "/"),
+		})
+	}
+	if cfg.reason != "" {
+		attrs = append(attrs, core.Attribute{
+			Key:   "mcp.skill.activation.reason",
+			Value: cfg.reason,
+		})
+	}
+
+	_, span := c.cfg.tp.StartSpan(ctx, "skills.activate", attrs...)
+	span.End()
+
+	if c.cfg.activationHook != nil {
+		c.cfg.activationHook(ctx, event)
+	}
+	return event
 }
 
 // ReadResourceTool surfaces the SEP-2640 Implementation Guidelines

--- a/ext/skills/client_options.go
+++ b/ext/skills/client_options.go
@@ -1,0 +1,119 @@
+package skills
+
+import (
+	"context"
+	"time"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+// Option configures a Client built via NewClient.
+//
+// SEP-414 P7 (issue 748) introduces tracer + activation-hook plumbing on
+// the SEP-2640 host helper. Options follow the same shape as the
+// Provider options in this package: pass to NewClient, evaluated once
+// at construction, immutable after.
+type Option func(*clientConfig)
+
+type clientConfig struct {
+	tp             core.TracerProvider
+	activationHook func(context.Context, ActivationEvent)
+}
+
+// WithTracerProvider opts the Client into SEP-414 P7 (#748) span
+// emission around its read-path methods + Activate.
+//
+// When set to a non-Noop provider, each read method emits a span:
+//
+//   - ListSkills      → skills.list
+//   - ReadSkillURI    → skills.read           (attr: mcp.skill.uri)
+//   - ReadSkillManifest → skills.read_manifest (attrs: mcp.skill.uri,
+//     mcp.skill.path, mcp.skill.name on success)
+//   - ReadAndVerify   → skills.read_and_verify (attrs: mcp.skill.uri,
+//     mcp.skill.expected_digest, mcp.skill.digest_verified on success)
+//   - Activate        → skills.activate        (instant span — Start +
+//     End back-to-back; attrs: mcp.skill.uri, mcp.skill.path,
+//     mcp.skill.activation.reason when WithReason is set)
+//
+// Spans inherit the W3C traceparent on the supplied ctx via the
+// existing trace context propagation (#644 / #649 / #652), so the
+// server-side resources/read dispatch span (now skill-attribute
+// enriched per #748 Layer 1) lands as a child of the client read span
+// automatically.
+//
+// nil and core.NoopTracerProvider{} both short-circuit to zero
+// overhead — the Client stores NoopTracerProvider as its default so
+// call sites do not nil-check.
+func WithTracerProvider(tp core.TracerProvider) Option {
+	return func(c *clientConfig) {
+		if tp == nil {
+			tp = core.NoopTracerProvider{}
+		}
+		c.tp = tp
+	}
+}
+
+// WithActivationHook installs a callback invoked from Client.Activate
+// in addition to the OTel span. The hook fires synchronously inside
+// Activate before it returns.
+//
+// Hosts that do not use OpenTelemetry can install the hook to feed
+// their own telemetry pipeline (structured logging, internal counters,
+// alternate tracing) without configuring a TracerProvider. The two
+// telemetry sinks are independent — installing both fires both.
+//
+// fn==nil is a no-op (equivalent to omitting the option).
+func WithActivationHook(fn func(context.Context, ActivationEvent)) Option {
+	return func(c *clientConfig) {
+		c.activationHook = fn
+	}
+}
+
+// ActivationEvent is the payload Client.Activate returns and passes to
+// the WithActivationHook callback. It captures the activation moment
+// the agent loop signaled — the URI of the skill the host is about to
+// put into the model context, an optional human-readable reason, and
+// the activation timestamp.
+//
+// Returned to the caller so non-OTel telemetry pipelines that prefer a
+// pull-style emit point can stamp the event in whatever shape they
+// want. The same struct is delivered to any installed activation hook,
+// so a host with both span emission and a hook installed sees a
+// consistent record across both sinks.
+type ActivationEvent struct {
+	// URI is the skill:// URI the host activated. May be a manifest URI
+	// (skill://path/SKILL.md) or a sub-file URI within a skill — the
+	// host decides which level of granularity to report.
+	URI string
+
+	// Reason is an optional human-readable explanation for the
+	// activation, populated when the caller passed WithReason.
+	// Surfaced as the mcp.skill.activation.reason span attribute when a
+	// TracerProvider is installed.
+	Reason string
+
+	// Timestamp is when Activate was called. Hosts can use this to
+	// correlate activations against external event logs.
+	Timestamp time.Time
+}
+
+// ActivateOption tunes a single Client.Activate call.
+type ActivateOption func(*activateConfig)
+
+type activateConfig struct {
+	reason string
+}
+
+// WithReason annotates the activation with a short human-readable
+// reason (e.g., "agent_decided_pdf_processing", "user_requested",
+// "test").
+//
+// Surfaced as the mcp.skill.activation.reason span attribute (when a
+// TracerProvider is installed) and as the Reason field on the
+// returned ActivationEvent. Stays out of band for non-OTel hosts that
+// rely solely on the WithActivationHook callback.
+func WithReason(reason string) ActivateOption {
+	return func(c *activateConfig) {
+		c.reason = reason
+	}
+}

--- a/ext/skills/client_test.go
+++ b/ext/skills/client_test.go
@@ -1,6 +1,7 @@
 package skills_test
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -39,6 +40,31 @@ func connectSkillsClient(t *testing.T, dir string, opts ...skills.ProviderOption
 	return skills.NewClient(c), c
 }
 
+// connectSkillsClientWithClientOpts is the sibling of
+// connectSkillsClient that wires SEP-414 P7 (#748) Client options
+// (WithTracerProvider, WithActivationHook, ...) instead of provider
+// options. Used by client_trace_test.go.
+func connectSkillsClientWithClientOpts(t *testing.T, dir string, clientOpts ...skills.Option) (*skills.Client, *client.Client) {
+	t.Helper()
+	srv := server.NewServer(core.ServerInfo{Name: "skills-client-test", Version: "0.0.1"})
+	p, err := skills.NewProvider(skills.WithDirectory(dir))
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	p.RegisterWith(srv)
+
+	handler := srv.Handler(server.WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "skills-client-test", Version: "0.0.1"})
+	if err := c.Connect(); err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+	return skills.NewClient(c, clientOpts...), c
+}
+
 func TestClient_SupportsSkills_DeclaredServer(t *testing.T) {
 	sc, _ := connectSkillsClient(t, "testdata/valid")
 	if !sc.SupportsSkills() {
@@ -66,7 +92,7 @@ func TestClient_SupportsSkills_PlainServer(t *testing.T) {
 
 func TestClient_ListSkills_Populated(t *testing.T) {
 	sc, _ := connectSkillsClient(t, "testdata/valid")
-	idx, err := sc.ListSkills()
+	idx, err := sc.ListSkills(context.Background())
 	if err != nil {
 		t.Fatalf("ListSkills: %v", err)
 	}
@@ -80,7 +106,7 @@ func TestClient_ListSkills_Populated(t *testing.T) {
 
 func TestClient_ListSkills_Absent(t *testing.T) {
 	sc, _ := connectSkillsClient(t, "testdata/valid", skills.WithoutIndex())
-	idx, err := sc.ListSkills()
+	idx, err := sc.ListSkills(context.Background())
 	if err != nil {
 		t.Fatalf("ListSkills should tolerate missing index, got: %v", err)
 	}
@@ -91,7 +117,7 @@ func TestClient_ListSkills_Absent(t *testing.T) {
 
 func TestClient_Index_Lookup_Hit(t *testing.T) {
 	sc, _ := connectSkillsClient(t, "testdata/valid")
-	idx, err := sc.ListSkills()
+	idx, err := sc.ListSkills(context.Background())
 	if err != nil {
 		t.Fatalf("ListSkills: %v", err)
 	}
@@ -106,7 +132,7 @@ func TestClient_Index_Lookup_Hit(t *testing.T) {
 
 func TestClient_Index_Lookup_Miss(t *testing.T) {
 	sc, _ := connectSkillsClient(t, "testdata/valid")
-	idx, err := sc.ListSkills()
+	idx, err := sc.ListSkills(context.Background())
 	if err != nil {
 		t.Fatalf("ListSkills: %v", err)
 	}
@@ -121,7 +147,7 @@ func TestClient_Index_Lookup_Miss(t *testing.T) {
 
 func TestClient_ReadSkillURI(t *testing.T) {
 	sc, _ := connectSkillsClient(t, "testdata/valid")
-	body, err := sc.ReadSkillURI("skill://git-workflow/SKILL.md")
+	body, err := sc.ReadSkillURI(context.Background(), "skill://git-workflow/SKILL.md")
 	if err != nil {
 		t.Fatalf("ReadSkillURI: %v", err)
 	}
@@ -132,7 +158,7 @@ func TestClient_ReadSkillURI(t *testing.T) {
 
 func TestClient_ReadSkillManifest(t *testing.T) {
 	sc, _ := connectSkillsClient(t, "testdata/valid")
-	m, err := sc.ReadSkillManifest("skill://pdf-processing/SKILL.md")
+	m, err := sc.ReadSkillManifest(context.Background(), "skill://pdf-processing/SKILL.md")
 	if err != nil {
 		t.Fatalf("ReadSkillManifest: %v", err)
 	}
@@ -152,7 +178,7 @@ func TestClient_ReadSkillManifest(t *testing.T) {
 
 func TestClient_ReadSkillManifest_RejectsNonManifestURI(t *testing.T) {
 	sc, _ := connectSkillsClient(t, "testdata/valid")
-	_, err := sc.ReadSkillManifest("skill://pdf-processing/references/FORMS.md")
+	_, err := sc.ReadSkillManifest(context.Background(), "skill://pdf-processing/references/FORMS.md")
 	if !errors.Is(err, skills.ErrNotManifestURI) {
 		t.Errorf("err = %v, want ErrNotManifestURI", err)
 	}
@@ -160,11 +186,11 @@ func TestClient_ReadSkillManifest_RejectsNonManifestURI(t *testing.T) {
 
 func TestClient_ReadSkillFile(t *testing.T) {
 	sc, _ := connectSkillsClient(t, "testdata/valid")
-	m, err := sc.ReadSkillManifest("skill://pdf-processing/SKILL.md")
+	m, err := sc.ReadSkillManifest(context.Background(), "skill://pdf-processing/SKILL.md")
 	if err != nil {
 		t.Fatalf("ReadSkillManifest: %v", err)
 	}
-	body, err := sc.ReadSkillFile(m, "references/FORMS.md")
+	body, err := sc.ReadSkillFile(context.Background(), m, "references/FORMS.md")
 	if err != nil {
 		t.Fatalf("ReadSkillFile: %v", err)
 	}
@@ -175,7 +201,7 @@ func TestClient_ReadSkillFile(t *testing.T) {
 
 func TestClient_ReadAndVerify_Match(t *testing.T) {
 	sc, _ := connectSkillsClient(t, "testdata/valid")
-	idx, err := sc.ListSkills()
+	idx, err := sc.ListSkills(context.Background())
 	if err != nil {
 		t.Fatalf("ListSkills: %v", err)
 	}
@@ -183,7 +209,7 @@ func TestClient_ReadAndVerify_Match(t *testing.T) {
 	if !ok {
 		t.Fatal("git-workflow not in index")
 	}
-	result, err := sc.ReadAndVerify(entry.URL, entry.Digest)
+	result, err := sc.ReadAndVerify(context.Background(), entry.URL, entry.Digest)
 	if err != nil {
 		t.Fatalf("ReadAndVerify match: %v", err)
 	}
@@ -198,6 +224,7 @@ func TestClient_ReadAndVerify_Match(t *testing.T) {
 func TestClient_ReadAndVerify_Mismatch(t *testing.T) {
 	sc, _ := connectSkillsClient(t, "testdata/valid")
 	_, err := sc.ReadAndVerify(
+		context.Background(),
 		"skill://git-workflow/SKILL.md",
 		"sha256:"+strings.Repeat("0", 64), // deliberately wrong
 	)
@@ -208,7 +235,7 @@ func TestClient_ReadAndVerify_Mismatch(t *testing.T) {
 
 func TestClient_ReadAndVerify_EmptyDigestDisables(t *testing.T) {
 	sc, _ := connectSkillsClient(t, "testdata/valid")
-	result, err := sc.ReadAndVerify("skill://git-workflow/SKILL.md", "")
+	result, err := sc.ReadAndVerify(context.Background(), "skill://git-workflow/SKILL.md", "")
 	if err != nil {
 		t.Fatalf("ReadAndVerify empty digest: %v", err)
 	}
@@ -222,7 +249,7 @@ func TestClient_ReadAndVerify_EmptyDigestDisables(t *testing.T) {
 
 func TestClient_RoundTrip_CatalogVerify(t *testing.T) {
 	sc, _ := connectSkillsClient(t, "testdata/valid")
-	idx, err := sc.ListSkills()
+	idx, err := sc.ListSkills(context.Background())
 	if err != nil {
 		t.Fatalf("ListSkills: %v", err)
 	}
@@ -231,7 +258,7 @@ func TestClient_RoundTrip_CatalogVerify(t *testing.T) {
 		if e.Type != skills.SkillTypeSkillMD {
 			continue
 		}
-		result, err := sc.ReadAndVerify(e.URL, e.Digest)
+		result, err := sc.ReadAndVerify(context.Background(), e.URL, e.Digest)
 		if err != nil {
 			t.Errorf("ReadAndVerify %s: %v", e.URL, err)
 			continue

--- a/ext/skills/client_trace_test.go
+++ b/ext/skills/client_trace_test.go
@@ -1,0 +1,335 @@
+package skills_test
+
+// SEP-414 P7 (#748) — span emission + activation-hook tests for the
+// SEP-2640 host helper. Uses a fake TracerProvider that records every
+// span it starts so the suite can run without depending on
+// go.opentelemetry.io/otel (mirrors server/trace_middleware_test.go's
+// pattern).
+//
+// Black-box (`package skills_test`) — the production Client + options
+// must be reachable through the exported surface alone.
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/ext/skills"
+)
+
+type fakeSpan struct {
+	mu    sync.Mutex
+	name  string
+	attrs map[string]string
+	errs  []error
+	ended bool
+}
+
+func (s *fakeSpan) End() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ended = true
+}
+
+func (s *fakeSpan) SetAttribute(k, v string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.attrs == nil {
+		s.attrs = make(map[string]string)
+	}
+	s.attrs[k] = v
+}
+
+func (s *fakeSpan) RecordError(err error) {
+	if err == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.errs = append(s.errs, err)
+}
+
+func (s *fakeSpan) AddLink(_ core.Link) {}
+
+func (s *fakeSpan) attr(k string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.attrs[k]
+}
+
+type fakeTracerProvider struct {
+	mu    sync.Mutex
+	spans []*fakeSpan
+}
+
+func (p *fakeTracerProvider) StartSpan(ctx context.Context, name string, attrs ...core.Attribute) (context.Context, core.Span) {
+	sp := &fakeSpan{name: name, attrs: make(map[string]string, len(attrs))}
+	for _, a := range attrs {
+		sp.attrs[a.Key] = a.Value
+	}
+	p.mu.Lock()
+	p.spans = append(p.spans, sp)
+	p.mu.Unlock()
+	return ctx, sp
+}
+
+func (p *fakeTracerProvider) snapshot() []*fakeSpan {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]*fakeSpan, len(p.spans))
+	copy(out, p.spans)
+	return out
+}
+
+func (p *fakeTracerProvider) byName(name string) []*fakeSpan {
+	var out []*fakeSpan
+	for _, s := range p.snapshot() {
+		if s.name == name {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// TestClient_ListSkills_EmitsSpan_WithCount is the SEP-414 P7 happy
+// path: ListSkills under a TracerProvider emits a `skills.list` span
+// carrying mcp.skill.uri (the index URI) and mcp.skill.count on
+// success.
+func TestClient_ListSkills_EmitsSpan_WithCount(t *testing.T) {
+	tp := &fakeTracerProvider{}
+	sc, _ := connectSkillsClientWithClientOpts(t, "testdata/valid", skills.WithTracerProvider(tp))
+
+	_, err := sc.ListSkills(context.Background())
+	if err != nil {
+		t.Fatalf("ListSkills: %v", err)
+	}
+
+	spans := tp.byName("skills.list")
+	if len(spans) != 1 {
+		t.Fatalf("skills.list span count = %d, want 1", len(spans))
+	}
+	if got := spans[0].attr("mcp.skill.uri"); got != skills.IndexURI {
+		t.Errorf("mcp.skill.uri = %q, want %q", got, skills.IndexURI)
+	}
+	if got := spans[0].attr("mcp.skill.count"); got == "" || got == "0" {
+		t.Errorf("mcp.skill.count = %q, want a non-zero count", got)
+	}
+	if !spans[0].ended {
+		t.Errorf("span not ended")
+	}
+}
+
+// TestClient_ReadSkillURI_EmitsSpan_WithURI pins that ReadSkillURI
+// emits skills.read with mcp.skill.uri.
+func TestClient_ReadSkillURI_EmitsSpan_WithURI(t *testing.T) {
+	tp := &fakeTracerProvider{}
+	sc, _ := connectSkillsClientWithClientOpts(t, "testdata/valid", skills.WithTracerProvider(tp))
+
+	const uri = "skill://git-workflow/SKILL.md"
+	if _, err := sc.ReadSkillURI(context.Background(), uri); err != nil {
+		t.Fatalf("ReadSkillURI: %v", err)
+	}
+
+	spans := tp.byName("skills.read")
+	if len(spans) != 1 {
+		t.Fatalf("skills.read span count = %d, want 1", len(spans))
+	}
+	if got := spans[0].attr("mcp.skill.uri"); got != uri {
+		t.Errorf("mcp.skill.uri = %q, want %q", got, uri)
+	}
+}
+
+// TestClient_ReadSkillManifest_EmitsPathAndName verifies the manifest
+// read wraps with skills.read_manifest and stamps mcp.skill.path +
+// mcp.skill.name on success.
+func TestClient_ReadSkillManifest_EmitsPathAndName(t *testing.T) {
+	tp := &fakeTracerProvider{}
+	sc, _ := connectSkillsClientWithClientOpts(t, "testdata/valid", skills.WithTracerProvider(tp))
+
+	const uri = "skill://pdf-processing/SKILL.md"
+	if _, err := sc.ReadSkillManifest(context.Background(), uri); err != nil {
+		t.Fatalf("ReadSkillManifest: %v", err)
+	}
+
+	spans := tp.byName("skills.read_manifest")
+	if len(spans) != 1 {
+		t.Fatalf("skills.read_manifest span count = %d, want 1", len(spans))
+	}
+	if got := spans[0].attr("mcp.skill.uri"); got != uri {
+		t.Errorf("mcp.skill.uri = %q, want %q", got, uri)
+	}
+	if got := spans[0].attr("mcp.skill.path"); got != "pdf-processing" {
+		t.Errorf("mcp.skill.path = %q, want %q", got, "pdf-processing")
+	}
+	if got := spans[0].attr("mcp.skill.name"); got != "pdf-processing" {
+		t.Errorf("mcp.skill.name = %q, want %q", got, "pdf-processing")
+	}
+}
+
+// TestClient_ReadAndVerify_EmitsDigestVerified verifies the
+// skills.read_and_verify span carries both the expected digest and the
+// digest_verified outcome.
+func TestClient_ReadAndVerify_EmitsDigestVerified(t *testing.T) {
+	tp := &fakeTracerProvider{}
+	sc, _ := connectSkillsClientWithClientOpts(t, "testdata/valid", skills.WithTracerProvider(tp))
+
+	idx, err := sc.ListSkills(context.Background())
+	if err != nil {
+		t.Fatalf("ListSkills: %v", err)
+	}
+	entry, ok := idx.Lookup("skill://git-workflow/SKILL.md")
+	if !ok {
+		t.Fatal("git-workflow not in index")
+	}
+
+	if _, err := sc.ReadAndVerify(context.Background(), entry.URL, entry.Digest); err != nil {
+		t.Fatalf("ReadAndVerify: %v", err)
+	}
+
+	spans := tp.byName("skills.read_and_verify")
+	if len(spans) != 1 {
+		t.Fatalf("skills.read_and_verify span count = %d, want 1", len(spans))
+	}
+	if got := spans[0].attr("mcp.skill.uri"); got != entry.URL {
+		t.Errorf("mcp.skill.uri = %q, want %q", got, entry.URL)
+	}
+	if got := spans[0].attr("mcp.skill.expected_digest"); got != entry.Digest {
+		t.Errorf("mcp.skill.expected_digest = %q, want %q", got, entry.Digest)
+	}
+	if got := spans[0].attr("mcp.skill.digest_verified"); got != "true" {
+		t.Errorf("mcp.skill.digest_verified = %q, want %q", got, "true")
+	}
+}
+
+// TestClient_Activate_FiresHookAndSpan is the marquee SEP-414 P7 test:
+// Activate emits skills.activate, populates skill-shape attributes,
+// invokes the WithActivationHook callback with a matching
+// ActivationEvent, and returns the same event to the caller.
+func TestClient_Activate_FiresHookAndSpan(t *testing.T) {
+	tp := &fakeTracerProvider{}
+	var captured []skills.ActivationEvent
+	var mu sync.Mutex
+	hook := func(_ context.Context, ev skills.ActivationEvent) {
+		mu.Lock()
+		defer mu.Unlock()
+		captured = append(captured, ev)
+	}
+
+	sc, _ := connectSkillsClientWithClientOpts(t, "testdata/valid",
+		skills.WithTracerProvider(tp),
+		skills.WithActivationHook(hook),
+	)
+
+	const uri = "skill://pdf-processing/SKILL.md"
+	const reason = "agent_decided_pdf_for_invoice"
+	ev := sc.Activate(context.Background(), uri, skills.WithReason(reason))
+
+	// Returned event shape
+	if ev.URI != uri {
+		t.Errorf("ev.URI = %q, want %q", ev.URI, uri)
+	}
+	if ev.Reason != reason {
+		t.Errorf("ev.Reason = %q, want %q", ev.Reason, reason)
+	}
+	if ev.Timestamp.IsZero() {
+		t.Errorf("ev.Timestamp is zero")
+	}
+	if time.Since(ev.Timestamp) > time.Minute {
+		t.Errorf("ev.Timestamp = %v, want recent", ev.Timestamp)
+	}
+
+	// Hook fired with the same event
+	mu.Lock()
+	defer mu.Unlock()
+	if len(captured) != 1 {
+		t.Fatalf("hook calls = %d, want 1", len(captured))
+	}
+	if captured[0].URI != ev.URI || captured[0].Reason != ev.Reason ||
+		!captured[0].Timestamp.Equal(ev.Timestamp) {
+		t.Errorf("hook event %+v, want %+v", captured[0], ev)
+	}
+
+	// Span emitted with correct shape
+	spans := tp.byName("skills.activate")
+	if len(spans) != 1 {
+		t.Fatalf("skills.activate span count = %d, want 1", len(spans))
+	}
+	if got := spans[0].attr("mcp.skill.uri"); got != uri {
+		t.Errorf("mcp.skill.uri = %q, want %q", got, uri)
+	}
+	if got := spans[0].attr("mcp.skill.path"); got != "pdf-processing" {
+		t.Errorf("mcp.skill.path = %q, want %q", got, "pdf-processing")
+	}
+	if got := spans[0].attr("mcp.skill.activation.reason"); got != reason {
+		t.Errorf("mcp.skill.activation.reason = %q, want %q", got, reason)
+	}
+	if !spans[0].ended {
+		t.Errorf("skills.activate span not ended (Activate is instant — Start+End must both fire)")
+	}
+}
+
+// TestClient_Activate_NoReason_OmitsReasonAttr pins that
+// WithReason is optional — when absent, the attr is NOT emitted (vs.
+// being emitted as an empty string).
+func TestClient_Activate_NoReason_OmitsReasonAttr(t *testing.T) {
+	tp := &fakeTracerProvider{}
+	sc, _ := connectSkillsClientWithClientOpts(t, "testdata/valid", skills.WithTracerProvider(tp))
+
+	_ = sc.Activate(context.Background(), "skill://pdf-processing/SKILL.md")
+
+	spans := tp.byName("skills.activate")
+	if len(spans) != 1 {
+		t.Fatalf("skills.activate span count = %d, want 1", len(spans))
+	}
+	if got, ok := spans[0].attrs["mcp.skill.activation.reason"]; ok {
+		t.Errorf("mcp.skill.activation.reason present (%q) when WithReason was not supplied", got)
+	}
+}
+
+// TestClient_Activate_NoTracer_StillFiresHook_NoSpan pins that the
+// hook path is independent of the tracer path — a host that wants
+// activation telemetry without OTel can install WithActivationHook
+// alone and still see every activation.
+func TestClient_Activate_NoTracer_StillFiresHook_NoSpan(t *testing.T) {
+	var captured []skills.ActivationEvent
+	hook := func(_ context.Context, ev skills.ActivationEvent) {
+		captured = append(captured, ev)
+	}
+
+	sc, _ := connectSkillsClientWithClientOpts(t, "testdata/valid",
+		skills.WithActivationHook(hook))
+
+	const uri = "skill://git-workflow/SKILL.md"
+	_ = sc.Activate(context.Background(), uri)
+
+	if len(captured) != 1 {
+		t.Fatalf("hook calls = %d, want 1", len(captured))
+	}
+	if captured[0].URI != uri {
+		t.Errorf("captured URI = %q, want %q", captured[0].URI, uri)
+	}
+}
+
+// TestClient_NoTracer_EmitsNoSpans pins the zero-overhead path: a
+// Client built without WithTracerProvider (or with nil /
+// NoopTracerProvider) does not produce any span observable to the
+// adapter — the read methods complete normally but the noop tracer
+// records nothing the fakeTracerProvider would see.
+func TestClient_NoTracer_EmitsNoSpans(t *testing.T) {
+	tp := &fakeTracerProvider{}
+	// Deliberately NOT passing WithTracerProvider.
+	sc, _ := connectSkillsClient(t, "testdata/valid")
+
+	if _, err := sc.ListSkills(context.Background()); err != nil {
+		t.Fatalf("ListSkills: %v", err)
+	}
+	if _, err := sc.ReadSkillURI(context.Background(), "skill://git-workflow/SKILL.md"); err != nil {
+		t.Fatalf("ReadSkillURI: %v", err)
+	}
+
+	if got := len(tp.snapshot()); got != 0 {
+		t.Errorf("fake tracer saw %d spans, want 0 (Client default is NoopTracerProvider)", got)
+	}
+}

--- a/server/trace_middleware.go
+++ b/server/trace_middleware.go
@@ -181,6 +181,28 @@ func traceMiddleware(tp core.TracerProvider) Middleware {
 				attrs = append(attrs, core.Attribute{Key: "mcp.tool.name", Value: name})
 			}
 		}
+		if req.Method == "resources/read" {
+			if uri := parseResourceReadURI(req.Params); uri != "" {
+				attrs = append(attrs, core.Attribute{Key: "mcp.resource.uri", Value: uri})
+				// SEP-414 P7 (issue 748): when the read targets a
+				// `skill://` URI, also emit skill-shaped attributes so
+				// server-side dashboards can chart fetch volume per
+				// skill. `mcp.skill.path` and `mcp.skill.file` only
+				// populate for SEP-2640 manifest URIs (terminal
+				// `/SKILL.md`) where the path/file boundary is
+				// unambiguous from the URI alone; non-manifest URIs
+				// surface as `mcp.skill.uri` only.
+				if path, file, ok := decomposeSkillURI(uri); ok {
+					attrs = append(attrs, core.Attribute{Key: "mcp.skill.uri", Value: uri})
+					if path != "" {
+						attrs = append(attrs, core.Attribute{Key: "mcp.skill.path", Value: path})
+					}
+					if file != "" {
+						attrs = append(attrs, core.Attribute{Key: "mcp.skill.file", Value: file})
+					}
+				}
+			}
+		}
 
 		spanName := req.Method
 		if spanName == "" {
@@ -259,6 +281,51 @@ func parseToolCallName(params json.RawMessage) string {
 		return ""
 	}
 	return envelope.Name
+}
+
+// parseResourceReadURI extracts the `uri` field from a resources/read
+// params envelope. Returns "" on decode failure — best-effort attribute
+// enrichment never blocks dispatch (mirrors parseToolCallName).
+func parseResourceReadURI(params json.RawMessage) string {
+	if len(params) == 0 {
+		return ""
+	}
+	var envelope struct {
+		URI string `json:"uri"`
+	}
+	if err := json.Unmarshal(params, &envelope); err != nil {
+		return ""
+	}
+	return envelope.URI
+}
+
+// decomposeSkillURI splits a `skill://` URI into its skill-path / file-path
+// components for span-attribute purposes. The returned `ok` is true when
+// the URI uses the `skill://` scheme; path/file are populated only for
+// SEP-2640 manifest URIs (terminal `/SKILL.md`) because the path/file
+// boundary in non-manifest URIs is ambiguous from the URI alone — the
+// SEP frames it as a host-workflow concern resolved via the discovery
+// index or a prior manifest read (see ext/skills.URIParts doc).
+//
+// This is intentionally a minimal in-package parser rather than an
+// import of ext/skills.ParseURI: `server/` is in the root module and
+// ext/skills is a separate go.mod, so taking the dep would invert the
+// layering. Attribute emission tolerates URIs the strict parser would
+// reject — that is the right tradeoff for best-effort telemetry.
+func decomposeSkillURI(uri string) (skillPath, filePath string, ok bool) {
+	const scheme = "skill://"
+	if len(uri) <= len(scheme) || uri[:len(scheme)] != scheme {
+		return "", "", false
+	}
+	body := uri[len(scheme):]
+	const manifestSuffix = "/SKILL.md"
+	if len(body) > len(manifestSuffix) && body[len(body)-len(manifestSuffix):] == manifestSuffix {
+		return body[:len(body)-len(manifestSuffix)], "SKILL.md", true
+	}
+	if body == "SKILL.md" {
+		return "", "SKILL.md", true
+	}
+	return "", "", true
 }
 
 // recordSpanOutcome stamps error / tool-error attributes on the span before

--- a/server/trace_middleware_test.go
+++ b/server/trace_middleware_test.go
@@ -313,6 +313,88 @@ func TestTraceMiddleware_SetsCoreAttributes(t *testing.T) {
 	assert.Equal(t, "echo", spans[0].attr("mcp.tool.name"))
 }
 
+// dispatchResourcesRead builds a resources/read request envelope and
+// routes it through dispatchWithNotifyAndRequest. Sibling to
+// dispatchToolsCall, used by the SEP-414 P7 (#748) tests below.
+func dispatchResourcesRead(t *testing.T, srv *Server, ctx context.Context, params string) (*core.Response, error) {
+	t.Helper()
+	req := &core.Request{
+		ID:     json.RawMessage(`1`),
+		Method: "resources/read",
+		Params: json.RawMessage(params),
+	}
+	return srv.dispatchWithNotifyAndRequest(srv.dispatcher, ctx, nil, nil, nil, req)
+}
+
+// TestTraceMiddleware_EmitsSkillAttrsOnManifestRead is the SEP-414 P7
+// happy path: a resources/read targeting `skill://acme/billing/refunds/
+// SKILL.md` emits mcp.resource.uri, mcp.skill.uri, mcp.skill.path, and
+// mcp.skill.file so server-side dashboards can chart fetch volume per
+// skill. Dispatch returns an "unknown resource" error because the
+// resource isn't registered, but the span attrs were stamped before the
+// inner handler ran.
+func TestTraceMiddleware_EmitsSkillAttrsOnManifestRead(t *testing.T) {
+	tp := &fakeTracerProvider{}
+	srv := newInitializedServer(t, WithTracerProvider(tp))
+
+	const uri = "skill://acme/billing/refunds/SKILL.md"
+	params := `{"uri":"` + uri + `"}`
+	_, err := dispatchResourcesRead(t, srv, context.Background(), params)
+	require.NoError(t, err)
+
+	spans := tp.snapshot()
+	require.Len(t, spans, 1)
+	assert.Equal(t, "resources/read", spans[0].attr("mcp.method"))
+	assert.Equal(t, uri, spans[0].attr("mcp.resource.uri"))
+	assert.Equal(t, uri, spans[0].attr("mcp.skill.uri"))
+	assert.Equal(t, "acme/billing/refunds", spans[0].attr("mcp.skill.path"))
+	assert.Equal(t, "SKILL.md", spans[0].attr("mcp.skill.file"))
+}
+
+// TestTraceMiddleware_EmitsResourceURI_NonSkillRead pins the contract
+// boundary: mcp.resource.uri is emitted for ANY resources/read, but the
+// skill-specific attrs (mcp.skill.*) stay absent when the URI does not
+// use the skill:// scheme.
+func TestTraceMiddleware_EmitsResourceURI_NonSkillRead(t *testing.T) {
+	tp := &fakeTracerProvider{}
+	srv := newInitializedServer(t, WithTracerProvider(tp))
+
+	const uri = "file:///etc/motd"
+	params := `{"uri":"` + uri + `"}`
+	_, err := dispatchResourcesRead(t, srv, context.Background(), params)
+	require.NoError(t, err)
+
+	spans := tp.snapshot()
+	require.Len(t, spans, 1)
+	assert.Equal(t, uri, spans[0].attr("mcp.resource.uri"))
+	assert.Empty(t, spans[0].attr("mcp.skill.uri"))
+	assert.Empty(t, spans[0].attr("mcp.skill.path"))
+	assert.Empty(t, spans[0].attr("mcp.skill.file"))
+}
+
+// TestTraceMiddleware_NonManifestSkillURI_EmitsURIOnly verifies that a
+// non-manifest skill URI (e.g., a supporting file like references/
+// FORMS.md) gets mcp.skill.uri but NOT mcp.skill.path / mcp.skill.file —
+// SEP-2640 documents that the skill/file boundary cannot be recovered
+// from the URI alone for non-manifest reads. Span attrs follow the
+// strict parser's behavior.
+func TestTraceMiddleware_NonManifestSkillURI_EmitsURIOnly(t *testing.T) {
+	tp := &fakeTracerProvider{}
+	srv := newInitializedServer(t, WithTracerProvider(tp))
+
+	const uri = "skill://pdf-processing/references/FORMS.md"
+	params := `{"uri":"` + uri + `"}`
+	_, err := dispatchResourcesRead(t, srv, context.Background(), params)
+	require.NoError(t, err)
+
+	spans := tp.snapshot()
+	require.Len(t, spans, 1)
+	assert.Equal(t, uri, spans[0].attr("mcp.resource.uri"))
+	assert.Equal(t, uri, spans[0].attr("mcp.skill.uri"))
+	assert.Empty(t, spans[0].attr("mcp.skill.path"))
+	assert.Empty(t, spans[0].attr("mcp.skill.file"))
+}
+
 // TestTraceMiddleware_RPCError_RecordsErrorAndCode verifies that a
 // JSON-RPC error response sets mcp.error.code and calls RecordError with
 // the error message. Routes through the tools/call "unknown tool" path


### PR DESCRIPTION
Closes #748. Two-layer answer to the forum/Discord ask for client-side "skill used" telemetry. Followup tracked as #749 (opt-in extension-namespaced wire notification).

## What changes

Tool calls have natural telemetry; skills don't. Agents fetch a manifest once, cache it, then **activate** it N times invisibly. Server-side `resources/read` instrumentation only catches the fetch.

Two layers close the gap, plus a constraint promotion:

1. **Server-side** — `resources/read` dispatch spans now carry `mcp.resource.uri` (always) plus `mcp.skill.uri` / `mcp.skill.path` / `mcp.skill.file` when the URI is `skill://`.
2. **Client-side** — `ext/skills.NewClient(mcp, opts...)` accepts `WithTracerProvider` to wrap read methods in spans, and new `Client.Activate(ctx, uri, opts...) ActivationEvent` emits an instant `skills.activate` span + fires an optional `WithActivationHook` callback for non-OTel hosts.
3. **CONSTRAINTS.md C4** — extensions MUST NOT import each other unless an SEP mandates it. Promoted from feedback caught mid-PR (a draft skills e2e tried to add `ext/skills` as a dep on `ext/otel/go.mod`).

Stitching is free: client spans inherit ctx that carries `_meta.traceparent` from #644 / #649 / #652, so the server's enriched dispatch span lands as a child of the client wrap span in the same trace.

```mermaid
sequenceDiagram
  participant Agent
  participant Client as ext/skills.Client
  participant Server as resources/read
  Note over Agent: agent loop decides skill X
  Agent->>Client: sc.ReadAndVerify(ctx, uri, digest)
  Note right of Client: span: skills.read_and_verify<br/>mcp.skill.uri, mcp.skill.expected_digest
  Client->>Server: resources/read uri=skill://...<br/>_meta.traceparent
  Note right of Server: span: resources/read<br/>mcp.resource.uri, mcp.skill.uri, mcp.skill.path, mcp.skill.file
  Server-->>Client: bytes
  Client-->>Agent: ReadResult{DigestVerified=true}
  Note over Agent: cache — some time later
  Agent->>Client: sc.Activate(ctx, uri, WithReason("..."))
  Note right of Client: span: skills.activate (instant)<br/>+ WithActivationHook callback fires
  Client-->>Agent: ActivationEvent{URI, Reason, Timestamp}
```

## Reviewer's guide

Read in this order:

1. [server/trace_middleware.go](https://github.com/panyam/mcpkit/pull/750/files#diff-7e0ee26d4d523ebdecda4da033cb2f40c364eb05edb5f41b1d90d76fd374546e) — start here. New `parseResourceReadURI` + `decomposeSkillURI` helpers + the attr-emission block inside `traceMiddleware`. Mirrors the existing `tools/call → mcp.tool.name` pattern.
2. [server/trace_middleware_test.go](https://github.com/panyam/mcpkit/pull/750/files#diff-9afc268cfbcbcd1d48ab89407746d243ef738f0e6f5eabb2b7a5f221a462ea1e) — three new tests pin the Layer 1 contract (manifest / non-skill / non-manifest skill URI shapes).
3. [ext/skills/client_options.go](https://github.com/panyam/mcpkit/pull/750/files#diff-460210c62b76c09758722130056994995c8c8a0cb219a83e4c2f83d0c551db88) — new file: `Option` / `WithTracerProvider` / `WithActivationHook` + `ActivateOption` / `WithReason` + `ActivationEvent` struct.
4. [ext/skills/client.go](https://github.com/panyam/mcpkit/pull/750/files#diff-ab4abcac994a6acf009e0587fa6e9100b455944cfd76714f0f82040d1219589a) — variadic `NewClient(mcp, opts...)`; ctx threaded through all read methods; each method wrapped in its named span; new `Client.Activate(ctx, uri, opts...) ActivationEvent` at the bottom.
5. [ext/skills/client_trace_test.go](https://github.com/panyam/mcpkit/pull/750/files#diff-ee3648b1c70cdc84e84a68fb431c50b58f32483251c8eb2a4db2b3bbc6824433) — new file: eight tests pin Layer 2.
6. [docs/SEP_414_OTEL.md](https://github.com/panyam/mcpkit/pull/750/files#diff-471fd7f72ab0a2ff1e1398303fa41c3e0173c19ac5439e8b833ce242fa81f3e6) — new `### Skills observability` section under P6. Closes the loop on the architecture intent + decision log.
7. [CONSTRAINTS.md](https://github.com/panyam/mcpkit/pull/750/files#diff-f2043ef583480706f62a74d47dae3d7ae2402f1b42cff01383b08fe8b37fdf3b) — new C4 (no cross-extension deps unless SEP-mandated) with `Verify` command.
8. [examples/skills/walkthrough.go](https://github.com/panyam/mcpkit/pull/750/files#diff-94afaa0ca3ed61f670feefe88925e3b5ecfc827cfcdb7612d48a01dd289c10e7) + regenerated `WALKTHROUGH.md` — new step demonstrating `skills.NewClient(c, WithTracerProvider, WithActivationHook)` + `Activate`. Section description blocks slimmed to 1-2 lines each per in-session direction.

Skim or skip: [cmd/mcpskills/inspect.go](https://github.com/panyam/mcpkit/pull/750/files#diff-bf806b2ef29c8b3bb1c9c37bf83980ac5857538c28eac6fc62af0981ac2801f1) (mechanical `cmd.Context()` threading for the ctx-aware methods).

## Decision log

| Decision | Why |
|---|---|
| Variadic `NewClient(mcp, opts...)` — variadic signature, not a sibling constructor | Variadic params are backward-compatible (zero args = old shape). Cleaner than `NewClientWithOptions`. |
| Break the signature: ctx-aware reads | All callers we control. Tracing without ctx threading is fundamentally broken (no parent propagation). Updates in `cmd/mcpskills/inspect.go` + `ext/skills/client_test.go` are mechanical. |
| Span name `skills.activate` (not `skills.use`) | Matches SEP-2640 / frontmatter verb; reads as "entering model context". |
| Instant span for `Activate` (Start+End back-to-back), not a scope | Activation is point-in-time, not a duration. Scopes invite forgot-to-End bugs. Caller still gets `ActivationEvent` for pull-style telemetry. |
| Callback hook AND span | Non-OTel hosts shouldn't need a TracerProvider just to log activations. The two telemetry sinks are independent. |
| No wire-level `notifications/skills/activated` here | Spec change; cross-cuts SEP-2640. Tracked separately as #749. |
| Emit `mcp.resource.uri` for ALL `resources/read` | One-line cost; useful beyond skills. |
| Drop the cross-extension e2e | Would have required `ext/otel` to import `ext/skills` — exactly the layering inversion C4 now codifies. Unit tests + MRTR e2e (same `_meta.traceparent` code path for any dispatch) cover the contract. |
| C4 as a project-wide constraint, not a memory | The verify command is mechanizable + the violation pattern is recurring (auth/tasks/ui/events all face the same temptation). |

## Coverage

- `server/trace_middleware_test.go`: 3 new tests (manifest URI emits 4 attrs; non-skill URI emits `mcp.resource.uri` only; non-manifest skill URI emits `mcp.skill.uri` only).
- `ext/skills/client_trace_test.go`: 8 new tests (per-method span emission + attrs; `Activate` fires hook + span; `WithReason` omitted → reason attr absent; hook works without tracer; no-tracer path emits 0 observable spans).
- Existing `make test` + `ext/skills` tests still green after the signature changes.
- C4 verify run on all 7 ext / experimental/ext modules — clean (no actual cross-ext deps; the rule formalizes current practice).

## Out of scope (deliberately deferred)

- Wire-level `notifications/io.modelcontextprotocol.skills/activated` extension → #749 (separable opt-in on `ext/skills`, designed to ride atop the SDK `Activate` without breaking callers).
- Activation counter metric on the issue 735 MeterProvider seam — straightforward follow-up.
- Cross-extension real-SDK e2e — would need a new `tests/<a>_<b>_e2e/` module per C4. Not needed for this PR; the propagation infrastructure is proven elsewhere.

