### PR TITLE
CONSTRAINTS C4: tighten Verify command for nested intra-ext submodules

### DIFF
--- a/CONSTRAINTS.md
+++ b/CONSTRAINTS.md
@@ -58,4 +58,24 @@ Escape hatch for cross-extension e2e tests: put the test in a separate top-level
 
 If a future SEP explicitly cross-cuts two extensions, document the SEP reference in the importing module's README so the coupling is auditable.
 
-**Verify:** `bash -c 'for m in ext/*/go.mod experimental/ext/*/go.mod; do owner=$(dirname "$m" | xargs basename); m_=$(grep -E "^[[:space:]]+github\.com/panyam/mcpkit/(ext|experimental/ext)/" "$m" | grep -vE "github\.com/panyam/mcpkit/(ext|experimental/ext)/$owner([[:space:]/]|$)"); if [ -n "$m_" ]; then echo "VIOLATION: $m"; echo "$m_"; fi; done'` — must print nothing. Matches indented `require` lines (skipping module-declaration lines) and excludes the module's own path.
+A cross-extension reference is a violation **only** when the referenced module is neither the importing module itself nor an ancestor of it. Nested intra-extension submodules (e.g., `experimental/ext/events/stores/redis` depending on its parent `experimental/ext/events`) are intentional and allowed.
+
+**Verify:** the script below catches `require`/`replace` lines pointing at another extension after subtracting (a) the module's own path and (b) any ancestor of it. It walks every `go.mod` under `ext/` and `experimental/ext/`, including nested submodules. Must print nothing.
+
+```bash
+bash -c '
+for m in $(find ext experimental/ext -name go.mod); do
+  mod=$(grep -E "^module " "$m" | awk "{print \$2}")
+  refs=$(grep -E "github\.com/panyam/mcpkit/(ext|experimental/ext)/" "$m" \
+    | grep -vE "^module " \
+    | grep -oE "github\.com/panyam/mcpkit/(ext|experimental/ext)/[a-zA-Z0-9_/-]+" \
+    | sort -u)
+  for ref in $refs; do
+    case "$mod" in
+      "$ref"|"$ref"/*) continue;;
+    esac
+    echo "VIOLATION $m: $ref"
+  done
+done
+'
+```


### PR DESCRIPTION
Follow-up to PR #750 (which introduced C4). Caught during a post-merge audit.

## What changes

`CONSTRAINTS.md` C4's `Verify` command was reporting false positives for legitimate parent-of-self deps:

- `experimental/ext/events/clients/go` → depends on `experimental/ext/events` (its parent module)
- `experimental/ext/events/stores/gorm` → depends on `experimental/ext/events`
- `experimental/ext/events/stores/redis` → depends on `experimental/ext/events`

All three are intra-extension nesting, not cross-extension coupling, and should be allowed by C4.

The fix: compare each go.mod reference against the importing module's own `module` declaration. Skip when the reference is either the module itself or an ancestor of it (i.e., `mod` starts with `ref/`). Walks every `go.mod` under `ext/` and `experimental/ext/` via `find` instead of the previous glob, so nested submodules are visited too.

## Reviewer's guide

Single file: [CONSTRAINTS.md](https://github.com/panyam/mcpkit/pull/751/files#diff-f2043ef583480706f62a74d47dae3d7ae2402f1b42cff01383b08fe8b37fdf3b) — the Verify block under C4. Replaces the prior `for m in ext/*/go.mod experimental/ext/*/go.mod; do owner=$(basename ...)` form with a `module`-declaration-aware comparison.

## Verification

Run against current `main`:

```
$ bash -c '...' (the new Verify command)
$ echo done
done
```

No violations — the prior false positives (3 nested submodules under `events`) are now correctly recognized as parent-of-self deps. Real cross-ext imports (e.g., a hypothetical `ext/auth` → `ext/tasks`) would still surface.

## Out of scope

- No production code change.
- No other constraints touched.
