### PR TITLE
server/stateless: response-as-SSE on POST so ctx.Notify works on the SEP-2575 wire (issue 753)

### DIFF
--- a/core/handler_context.go
+++ b/core/handler_context.go
@@ -363,12 +363,28 @@ func stripFileInputKeywordsRaw(raw json.RawMessage) json.RawMessage {
 
 // Notify sends an arbitrary server-to-client JSON-RPC notification.
 // Returns false if no notification sender is available.
+//
+// Resolution order:
+//
+//  1. Legacy wire: sessionCtx-attached notify func (set by the GET SSE
+//     stream or by handlePostSSE for a POST that opted into SSE
+//     streaming).
+//  2. Stateless wire: ctx-attached NotifyFunc threaded by
+//     WithStatelessNotifyFunc when the stateless transport handles a
+//     POST with Accept: text/event-stream (response-as-SSE).
+//
+// Returns false when neither source is present — for example, a
+// stateless POST that did NOT request SSE has no channel to push to.
 func (bc BaseContext) Notify(method string, params any) bool {
-	if bc.sc == nil || bc.sc.notify == nil {
-		return false
+	if bc.sc != nil && bc.sc.notify != nil {
+		bc.sc.notify(method, params)
+		return true
 	}
-	bc.sc.notify(method, params)
-	return true
+	if fn := statelessNotifyFuncFromContext(bc.Context); fn != nil {
+		fn(method, params)
+		return true
+	}
+	return false
 }
 
 // AuthClaims returns the authenticated identity, or nil if unavailable.

--- a/core/session.go
+++ b/core/session.go
@@ -92,6 +92,15 @@ const (
 	// claims ride on ctx directly. BaseContext.AuthClaims coalesces the
 	// two so handlers do not special-case the wire.
 	statelessClaimsCtxKey
+	// statelessNotifyCtxKey carries the request-scoped NotifyFunc the
+	// stateless transport installs when a POST request carries
+	// Accept: text/event-stream. The handler's ctx.Notify(...) writes
+	// notification frames down the open POST response stream. Legacy
+	// wire's POST-as-SSE path (handlePostSSE) and GET SSE path both
+	// stash the notify func on the sessionCtx; this is the stateless
+	// equivalent — BaseContext.Notify coalesces the two so events/stream
+	// (and any other streaming handler) works identically on either wire.
+	statelessNotifyCtxKey
 )
 
 // ContextWithSession returns a context carrying the session's notification state,
@@ -231,6 +240,37 @@ func WithStatelessClaims(ctx context.Context, claims *Claims) context.Context {
 func statelessClaimsFromContext(ctx context.Context) *Claims {
 	claims, _ := ctx.Value(statelessClaimsCtxKey).(*Claims)
 	return claims
+}
+
+// WithStatelessNotifyFunc threads a NotifyFunc onto ctx for the SEP-2575
+// stateless dispatch path. The stateless transport calls this when a
+// POST request carries Accept: text/event-stream — the handler's
+// ctx.Notify(...) writes notification frames down the open POST
+// response stream (response-as-SSE).
+//
+// On the legacy wire the notify channel lives on the sessionCtx (set
+// when a GET SSE stream attaches, or when handlePostSSE wraps the
+// dispatch). BaseContext.Notify coalesces the two sources so the
+// events/stream handler (and any other streaming endpoint) does not
+// special-case the wire.
+//
+// Returns ctx unchanged when fn is nil so callers can drop the
+// nil-check at the call site.
+func WithStatelessNotifyFunc(ctx context.Context, fn NotifyFunc) context.Context {
+	if fn == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, statelessNotifyCtxKey, fn)
+}
+
+// statelessNotifyFuncFromContext returns the NotifyFunc attached by the
+// SEP-2575 stateless transport for the SSE response path, or nil if
+// absent. Internal — handlers should call BaseContext.Notify, which
+// falls back to this source when no session-attached notify func is
+// present.
+func statelessNotifyFuncFromContext(ctx context.Context) NotifyFunc {
+	fn, _ := ctx.Value(statelessNotifyCtxKey).(NotifyFunc)
+	return fn
 }
 
 // ClientSupportsExtension checks whether the connected client declared support

--- a/server/streamable_stateless.go
+++ b/server/streamable_stateless.go
@@ -2,7 +2,9 @@ package server
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"sync"
 
 	core "github.com/panyam/mcpkit/core"
 	"github.com/panyam/mcpkit/server/stateless"
@@ -96,6 +98,118 @@ func peekMetaProtocolVersion(params json.RawMessage) string {
 		return ""
 	}
 	return probe.Meta.ProtocolVersion
+}
+
+// handleStatelessPostSSE is the SEP-2575 dispatch path for a single
+// JSON-RPC request whose Accept header asked for text/event-stream
+// (issue #753). The POST response itself becomes the SSE channel:
+// handler-emitted notifications via ctx.Notify(...) are framed as
+// SSE events on the open response stream; the handler's terminal
+// *core.Response is the final SSE event before the server closes
+// the connection.
+//
+// Mirrors the legacy handlePostSSE shape — same lazy-headers + flusher
+// + serialized writes + closed-after-handler-return safety — but
+// simpler because the stateless wire has no event store to replay,
+// no session ID to namespace event IDs under, no server-to-client
+// request channel (sampling/elicitation are not available on the
+// stateless wire by SEP-2575 spec), and no retry hint to forward to a
+// long-lived GET stream.
+//
+// Notifications get framed via WithStatelessNotifyFunc on ctx so
+// BaseContext.Notify resolves them through the stateless fallback
+// branch. The events/stream handler — and any other streaming-shaped
+// custom method registered via Server.HandleMethod — works
+// identically on either wire.
+func (t *streamableTransport) handleStatelessPostSSE(w http.ResponseWriter, r *http.Request, claims *core.Claims, req *core.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		// Fallback to synchronous JSON for the rare ResponseWriter
+		// that doesn't support flushing — same defensive shape as
+		// the legacy path.
+		t.handleStatelessPost(w, r, claims, req)
+		return
+	}
+
+	dispatchCtx := core.WithResponseHeaderCollector(r.Context())
+	dispatchCtx = core.WithStatelessClaims(dispatchCtx, claims)
+
+	// SSE headers are set lazily on first write so a dispatch-time
+	// error response (-32001 header mismatch, -32004 unsupported
+	// protocol version, -32601 method not found from the bare default
+	// branch) can still be surfaced as a normal JSON-RPC response over
+	// HTTP 200 (the legacy path stages an HTTP-level auth error
+	// instead; stateless has no such transport-error path).
+	var mu sync.Mutex
+	var closed bool
+	var sseStarted bool
+	writeSSE := func(data []byte) {
+		mu.Lock()
+		defer mu.Unlock()
+		if closed {
+			return
+		}
+		if !sseStarted {
+			applyStagedResponseHeaders(w, dispatchCtx)
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.Header().Set("Cache-Control", "no-cache")
+			w.Header().Set("Connection", "keep-alive")
+			w.Header().Set("X-Accel-Buffering", "no")
+			sseStarted = true
+		}
+		fmt.Fprintf(w, "event: message\ndata: %s\n\n", data)
+		flusher.Flush()
+	}
+
+	requestNotify := core.NotifyFunc(func(method string, params any) {
+		raw, err := core.MarshalNotification(method, params)
+		if err != nil {
+			return
+		}
+		writeSSE(raw)
+	})
+	dispatchCtx = core.WithStatelessNotifyFunc(dispatchCtx, requestNotify)
+
+	// Header / _meta version cross-check (mirrored from handleStatelessPost).
+	if hdrVer := r.Header.Get(mcpProtocolVersionHeader); hdrVer != "" {
+		metaVer := peekMetaProtocolVersion(req.Params)
+		if mismatchResp := statelessVersionMismatch(req.ID, hdrVer, metaVer); mismatchResp != nil {
+			writeHeaderMismatch(w, mismatchResp)
+			return
+		}
+	}
+
+	// SEP-2243 routing-header validation (mirrored from handleStatelessPost).
+	if r.Header.Get(core.McpMethodHeader) != "" {
+		if errResp := validateRoutingHeaders(req, r.Header); errResp != nil {
+			writeHeaderMismatch(w, errResp)
+			return
+		}
+	}
+
+	resp := t.statelessDispatcher.Dispatch(dispatchCtx, req)
+
+	// Terminal frame. resp is normally non-nil for SSE-eligible requests
+	// (notifications return 202 from handleStatelessPost and never reach
+	// here — shouldStreamSSE short-circuits on IsNotification first).
+	// Belt-and-suspenders nil-check matches handlePostSSE.
+	if resp != nil {
+		if sseStarted {
+			raw, _ := marshalJSON(resp)
+			writeSSE(raw)
+		} else {
+			// Dispatcher returned an error before the handler emitted
+			// any notification — surface as a normal JSON response.
+			// Stateless-wire HTTP status mapping (HTTPStatusForCode)
+			// still applies.
+			applyStagedResponseHeaders(w, dispatchCtx)
+			writeStatelessResponse(w, resp)
+		}
+	}
+
+	mu.Lock()
+	closed = true
+	mu.Unlock()
 }
 
 // writeStatelessResponse marshals a JSON-RPC response and writes it

--- a/server/streamable_stateless_sse_test.go
+++ b/server/streamable_stateless_sse_test.go
@@ -1,0 +1,232 @@
+package server
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	core "github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/server/stateless"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStatelessPostSSE_NotifyFlowsDownPOSTResponse verifies issue #753 —
+// a stateless POST that carries Accept: text/event-stream opens the
+// response itself as the SSE channel. ctx.Notify() calls during dispatch
+// frame as notifications on that stream; the handler's terminal
+// *core.Response is the final SSE event.
+//
+// This is the contract events/stream relies on; the same path works for
+// any custom method registered via Server.HandleMethod that emits
+// notifications during dispatch.
+func TestStatelessPostSSE_NotifyFlowsDownPOSTResponse(t *testing.T) {
+	srv := NewServer(core.ServerInfo{Name: "stateless-sse-test", Version: "0.0.1"})
+
+	// Custom JSON-RPC method that emits 3 notifications then returns
+	// a terminal result. Mirrors what events/stream does but without
+	// the events package overhead.
+	srv.HandleMethod("test/streamemit", func(ctx core.MethodContext, id json.RawMessage, params json.RawMessage) *core.Response {
+		ctx.Notify("test/notify", map[string]any{"seq": 1, "msg": "first"})
+		ctx.Notify("test/notify", map[string]any{"seq": 2, "msg": "second"})
+		ctx.Notify("test/notify", map[string]any{"seq": 3, "msg": "third"})
+		return core.NewResponse(id, map[string]any{"done": true})
+	})
+
+	_, url, teardown := buildStatelessSSEHarness(t, srv, stateless.ModeDual)
+	defer teardown()
+
+	// POST with Accept: text/event-stream — should trigger response-as-SSE.
+	resp := postStatelessRequestForSSE(t, url, "test/streamemit", map[string]any{
+		"_meta": map[string]any{
+			"io.modelcontextprotocol/protocolVersion":    "2026-07-28",
+			"io.modelcontextprotocol/clientInfo":         map[string]any{"name": "test-client", "version": "0.0.1"},
+			"io.modelcontextprotocol/clientCapabilities": map[string]any{},
+		},
+	})
+	defer resp.Body.Close()
+
+	if ct := resp.Header.Get("Content-Type"); ct != "text/event-stream" {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("Content-Type=%q status=%d body=%s", ct, resp.StatusCode, body)
+	}
+
+	frames := readSSEPostFrames(t, resp.Body)
+	require.GreaterOrEqual(t, len(frames), 4,
+		"expected 3 notifications + 1 terminal frame, got %d", len(frames))
+
+	// First three frames must be notifications/test/notify with seq 1/2/3.
+	for i, expectedSeq := range []float64{1, 2, 3} {
+		var msg map[string]any
+		require.NoError(t, json.Unmarshal(frames[i], &msg), "frame %d: %s", i, string(frames[i]))
+		assert.Equal(t, "test/notify", msg["method"], "frame %d should be a notification", i)
+		params := msg["params"].(map[string]any)
+		assert.Equal(t, expectedSeq, params["seq"], "frame %d wrong seq", i)
+	}
+
+	// Terminal frame must be the JSON-RPC response with result.
+	var terminal map[string]any
+	require.NoError(t, json.Unmarshal(frames[3], &terminal),
+		"terminal frame: %s", string(frames[3]))
+	assert.Nil(t, terminal["method"], "terminal frame must NOT be a notification")
+	assert.NotNil(t, terminal["result"], "terminal frame must carry result")
+	result := terminal["result"].(map[string]any)
+	assert.Equal(t, true, result["done"])
+}
+
+// TestStatelessPostSSE_NoAcceptHeaderFallsBackToJSON verifies that when
+// the client does NOT request SSE, a stateless POST returns a plain
+// application/json response and ctx.Notify silently no-ops (matches
+// pre-#753 behavior — no regression for non-streaming clients).
+func TestStatelessPostSSE_NoAcceptHeaderFallsBackToJSON(t *testing.T) {
+	srv := NewServer(core.ServerInfo{Name: "stateless-sse-test", Version: "0.0.1"})
+
+	notifyAttempted := false
+	srv.HandleMethod("test/streamemit", func(ctx core.MethodContext, id json.RawMessage, params json.RawMessage) *core.Response {
+		// Notify returns false in this case (no SSE channel attached);
+		// handler is expected to fall back to a synchronous return.
+		notifyAttempted = ctx.Notify("test/notify", map[string]any{"seq": 1})
+		return core.NewResponse(id, map[string]any{"done": true})
+	})
+
+	_, url, teardown := buildStatelessSSEHarness(t, srv, stateless.ModeDual)
+	defer teardown()
+
+	resp := postStatelessRequestPlain(t, url, "test/streamemit", map[string]any{
+		"_meta": map[string]any{
+			"io.modelcontextprotocol/protocolVersion":    "2026-07-28",
+			"io.modelcontextprotocol/clientInfo":         map[string]any{"name": "test-client", "version": "0.0.1"},
+			"io.modelcontextprotocol/clientCapabilities": map[string]any{},
+		},
+	})
+	defer resp.Body.Close()
+
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+	assert.False(t, notifyAttempted,
+		"ctx.Notify must return false on stateless POST without Accept: text/event-stream")
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	var msg map[string]any
+	require.NoError(t, json.Unmarshal(body, &msg))
+	result := msg["result"].(map[string]any)
+	assert.Equal(t, true, result["done"])
+}
+
+// TestStatelessPostSSE_HandlerErrorBeforeNotifyFallsBackToJSON verifies
+// the lazy-headers safety property — if the handler returns an error
+// response before emitting any notification, the transport still has
+// the chance to write an HTTP-status-coded application/json response
+// rather than committing to text/event-stream prematurely. Matches the
+// legacy handlePostSSE behavior.
+func TestStatelessPostSSE_HandlerErrorBeforeNotifyFallsBackToJSON(t *testing.T) {
+	srv := NewServer(core.ServerInfo{Name: "stateless-sse-test", Version: "0.0.1"})
+
+	srv.HandleMethod("test/streamemit", func(ctx core.MethodContext, id json.RawMessage, params json.RawMessage) *core.Response {
+		return core.NewErrorResponse(id, core.ErrCodeInvalidParams, "no good")
+	})
+
+	_, url, teardown := buildStatelessSSEHarness(t, srv, stateless.ModeDual)
+	defer teardown()
+
+	resp := postStatelessRequestForSSE(t, url, "test/streamemit", map[string]any{
+		"_meta": map[string]any{
+			"io.modelcontextprotocol/protocolVersion":    "2026-07-28",
+			"io.modelcontextprotocol/clientInfo":         map[string]any{"name": "test-client", "version": "0.0.1"},
+			"io.modelcontextprotocol/clientCapabilities": map[string]any{},
+		},
+	})
+	defer resp.Body.Close()
+
+	// HTTP 400 from stateless.HTTPStatusForCode for -32602 + JSON body.
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
+		"InvalidParams should surface as 400")
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"),
+		"handler error before any notify should NOT commit to SSE headers")
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	var msg map[string]any
+	require.NoError(t, json.Unmarshal(body, &msg))
+	errObj := msg["error"].(map[string]any)
+	assert.Equal(t, float64(core.ErrCodeInvalidParams), errObj["code"])
+	assert.Equal(t, "no good", errObj["message"])
+}
+
+// --- helpers ------------------------------------------------------
+
+func buildStatelessSSEHarness(t *testing.T, srv *Server, mode stateless.Mode) (*Server, string, func()) {
+	t.Helper()
+	handler := srv.Handler(WithStreamableHTTP(true), WithStatelessMode(mode))
+	ts := httptest.NewServer(handler)
+	return srv, ts.URL + "/mcp", ts.Close
+}
+
+// postStatelessRequestForSSE sends a JSON-RPC POST with the SSE-eligible
+// Accept header and returns the raw HTTP response so the caller can
+// read the SSE-framed body line-by-line.
+func postStatelessRequestForSSE(t *testing.T, url, method string, params any) *http.Response {
+	t.Helper()
+	body := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  method,
+		"params":  params,
+	}
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(context.Background(), "POST", url, bytes.NewReader(raw))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "text/event-stream, application/json")
+	req.Header.Set(mcpProtocolVersionHeader, "2026-07-28")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	return resp
+}
+
+// postStatelessRequestPlain mirrors postStatelessRequestForSSE without
+// the SSE-eligible Accept header — used to verify the non-SSE path
+// regresses cleanly.
+func postStatelessRequestPlain(t *testing.T, url, method string, params any) *http.Response {
+	t.Helper()
+	body := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  method,
+		"params":  params,
+	}
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(context.Background(), "POST", url, bytes.NewReader(raw))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set(mcpProtocolVersionHeader, "2026-07-28")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	return resp
+}
+
+// readSSEPostFrames parses the SSE body into a slice of raw JSON payloads
+// (one per `data:` line). Stops at EOF.
+func readSSEPostFrames(t *testing.T, r io.Reader) [][]byte {
+	t.Helper()
+	var frames [][]byte
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		frames = append(frames, []byte(strings.TrimSpace(line[len("data:"):])))
+	}
+	return frames
+}

--- a/server/streamable_transport.go
+++ b/server/streamable_transport.go
@@ -273,6 +273,16 @@ func (t *streamableTransport) handlePost(w http.ResponseWriter, r *http.Request)
 				t.handleStatelessSubscribe(w, r, &req)
 				return
 			}
+			// Issue #753: a stateless POST that accepts SSE opens the
+			// response itself as the SSE channel — handler's ctx.Notify
+			// frames flow down the response stream, terminal *core.Response
+			// is the final SSE event before close. Matches the legacy
+			// handlePostSSE shape; needed for events/stream and any other
+			// streaming-shaped custom method to work on the stateless wire.
+			if shouldStreamSSE(r.Header.Get("Accept"), &req) {
+				t.handleStatelessPostSSE(w, r, claims, &req)
+				return
+			}
 			t.handleStatelessPost(w, r, claims, &req)
 			return
 		}


### PR DESCRIPTION
## Summary

Closes the architectural gap that prevents events/stream from working at N > 1 with clients in SEP-2575 stateless mode. Now a stateless POST that carries `Accept: text/event-stream` opens the response itself as the SSE channel — handler-emitted notifications via `ctx.Notify(...)` frame as SSE events on the open response stream; the handler's terminal `*core.Response` is the final SSE event before the transport closes the connection.

events/stream's handler code in [`experimental/ext/events/stream.go`](https://github.com/panyam/mcpkit/blob/feat/753-events-stream-streamable-response/experimental/ext/events/stream.go) is **unchanged** — its `ctx.Notify` calls now just work on the stateless wire because `BaseContext.Notify` finds the ctx-attached fallback the transport installs.

Tracks issue 753. Design pass posted there (issue 753 first comment) confirmed Option A — the lightweight ctx-fallback approach — and that's what's implemented here.

## Why this matters

events/stream is the headline push delivery mode for the MCP Events extension, but it relies on `ctx.Notify(...)` to push notifications. Today that resolves through the per-session notification channel which exists only on the legacy wire. On stateless wire `ctx.Notify` silently no-ops.

For N > 1 deployments the choice was: (a) sticky session affinity on the legacy wire (defeats load balancing), (b) the not-yet-built shared MCP session store (issue 752), or (c) don't use stream. None acceptable.

This PR adds a third option that matches what the SEP-2575 wire was designed for: one TCP connection per long-running operation, response itself is the channel, no session lookup needed, nginx round-robins freely.

## What changed

**[`core/session.go`](https://github.com/panyam/mcpkit/blob/feat/753-events-stream-streamable-response/core/session.go)** — new `WithStatelessNotifyFunc` / `statelessNotifyFuncFromContext` helpers, symmetric to the existing `WithStatelessClaims` pattern. Internal ctx key joins the stateless-aware key group.

**[`core/handler_context.go`](https://github.com/panyam/mcpkit/blob/feat/753-events-stream-streamable-response/core/handler_context.go)** — `BaseContext.Notify` falls back to the ctx-attached notify when the session-attached one is nil. Resolution order documented on the method (legacy first, stateless second, false when neither present).

**[`server/streamable_stateless.go`](https://github.com/panyam/mcpkit/blob/feat/753-events-stream-streamable-response/server/streamable_stateless.go)** — new `handleStatelessPostSSE` mirrors the legacy `handlePostSSE` shape: lazy headers, mutex-serialized writes, closed-after-return safety. Simpler than legacy: no event store replay, no session-scoped event IDs, no server→client request channel (sampling/elicitation are spec-forbidden on stateless), no retry hint forwarding.

**[`server/streamable_transport.go`](https://github.com/panyam/mcpkit/blob/feat/753-events-stream-streamable-response/server/streamable_transport.go)** — branches into `handleStatelessPostSSE` when `shouldStreamSSE` returns true (reuses the existing helper from the legacy path).

## Tests

3 focused tests in [`server/streamable_stateless_sse_test.go`](https://github.com/panyam/mcpkit/blob/feat/753-events-stream-streamable-response/server/streamable_stateless_sse_test.go) (~250 LoC):

- **NotifyFlowsDownPOSTResponse** — handler emits 3 notifications + 1 terminal response; asserts `Content-Type=text/event-stream`, all 4 SSE frames arrive in order, terminal frame carries result.
- **NoAcceptHeaderFallsBackToJSON** — same handler, no SSE Accept; asserts `ctx.Notify` returns false and response is plain `application/json` (no regression for non-streaming clients).
- **HandlerErrorBeforeNotifyFallsBackToJSON** — handler returns -32602 immediately; asserts the transport surfaces it as HTTP 400 + `application/json` instead of committing to SSE headers prematurely.

Full sweep:

- ✅ `server/...` — all pass
- ✅ `server/stateless/...` — all pass
- ✅ `experimental/ext/events/...` — all pass (existing tests untouched; events package doesn't yet ride this path but the change is non-breaking)

## What this doesn't include (follow-up PR off this branch)

- Integration test proving `events/stream` actually rides the new path end-to-end (subscribe via stateless client → server yields → notifications flow down response stream).
- `streamer` binary + walkthrough beat in [`examples/whole-enchilada/events`](https://github.com/panyam/mcpkit/blob/feat/753-events-stream-streamable-response/examples/whole-enchilada/events).

Those land in a separate PR after this one — they're the consumer side of this PR's capability, but they're additive and can ship behind it.

## Reviewer notes

Smallest scope that closes the architectural gap. The ctx-fallback approach (Option A from the design comment on 753) was chosen over a separate handler signature (Option B) or channel-shaped return (Option C) because:

1. Smallest API surface change — existing `HandleMethod` works as is.
2. Dual-mode is handled naturally — handler checks for stream availability via Notify return; falls back to synchronous if absent.
3. Middleware chain unchanged — middleware wraps the synchronous handler; the stream is acquired inside the handler so all middleware before/after still applies.

The lazy-headers safety (Content-Type isn't committed until first write) is load-bearing: a dispatcher-time error (-32602 invalid params, -32004 version mismatch) can still be surfaced as a normal JSON-RPC error response with the right HTTP status code. The third test locks that property.

---

## Reviewer guide

PR is ~420 lines total (~170 production + ~250 tests). Two architectural boundaries crossed: the ctx-fallback addition in `core`, and the new SSE handler in `server`. Here's how to read it efficiently and what to push back on.

### Read in this order

1. **Design rationale on issue 753** ([first comment](https://github.com/panyam/mcpkit/issues/753#issuecomment-4692734246)). Three options compared (ctx fallback / new handler signature / channel return); Option A (ctx fallback) won because it preserves the existing `HandleMethod` surface and handles dual-mode (legacy session push channel + stateless response-as-SSE) in a single handler without dual registration. If you disagree with that, the rest of the PR follows from it.

2. **Core fallback semantics** — start with the resolution rules.
   - `BaseContext.Notify` resolution order (legacy session.notify → stateless ctx fallback → false).
   - The ctx-key helpers are symmetric with the existing `WithStatelessClaims` pattern from #748 — same shape, different field.
   - Key question to scrutinize: should the fallback ordering ever differ (e.g., stateless ctx fallback wins if both are present)? My read is no — sessions never have a stateless ctx fallback installed (the transport's SSE-write path is a stateless-only thing); legacy and stateless are mutually exclusive at the request level.

3. **Transport branching** — the new SSE path is one `if shouldStreamSSE` that reuses the existing helper from the legacy path. Only branches when (a) request is dispatched as stateless wire AND (b) client's Accept header indicates SSE.

4. **The SSE handler itself** — read this against `handlePostSSE` in `streamable_transport.go` (line 410). My handler is the deliberate simpler-twin: same lazy-headers + mutex-serialized writes + closed-after-return safety, but no event store replay, no session-scoped event IDs, no server→client request channel (sampling/elicitation are spec-forbidden on stateless), no retry-hint forwarding. Worth confirming that those omissions are correct vs. accidentally lost features.

5. **Tests** — three focused cases. The third one (handler error before notify) is the load-bearing safety property — lazy headers mean the transport can still surface dispatcher-time errors as HTTP-status-coded JSON instead of committing to SSE prematurely.

### Architectural decisions worth pushing back on

- **ctx-fallback over a new handler signature** (Options A vs B from the design comment on issue 753). Option B would type-enforce "this is a streaming endpoint" but forces dual-mode handlers into either rejection or dual registration. Option A's implicit contract is documentable in one Godoc paragraph; chose smaller blast radius. Counter-argument: if mcpkit ever wants type-system enforcement (e.g., a streaming-method codegen path), B is the better foundation.

- **Reused `shouldStreamSSE` helper as-is**. The function checks IsNotification + Accept header, which is the right signal for legacy too. If the stateless wire ever wants stricter rules (e.g., require explicit MCP-Protocol-Version header before opting into SSE), the helper would split. Today they share semantics cleanly.

- **No streaming for `subscriptions/listen`**. That method already runs its own SSE pump independent of the dispatcher (`handleStatelessSubscribe`); branching into POST-as-SSE for it would double-mount. Left untouched — explicit comment in the routing branch.

- **`handleStatelessPostSSE`'s "no notify before error" path falls back to plain JSON** (rather than committing SSE headers then writing a JSON-RPC error frame). Matches the legacy `handlePostSSE` choice. The alternative would commit SSE headers + write the error as a final frame, but that's surprising for clients that didn't expect SSE-framed responses for a request that errored before any notification. Locked by `TestStatelessPostSSE_HandlerErrorBeforeNotifyFallsBackToJSON`.

### What's intentionally not in this PR (follow-up)

- **End-to-end integration test against `events/stream`.** The unit tests here exercise the transport mechanism with a stand-in custom method. The events package's `events/stream` handler will work on this path because its `ctx.Notify` calls just flow through the new fallback — but proving it requires a multi-replica test fixture, which lands in the follow-up PR alongside the `streamer` binary.
- **`streamer` binary + walkthrough beat for the whole-enchilada demo.** The consumer side of this PR's capability; additive.
- **`subscriptions/listen` over POST-as-SSE.** That method's existing SSE pump (`handleStatelessSubscribe`) covers the same shape today; folding it into the new path is a follow-up cleanup, not a behavioral change.

### How to verify locally

```bash
go test -count=1 -timeout 60s -run='TestStatelessPostSSE' ./server/...
# All 3 cases pass:
#   - NotifyFlowsDownPOSTResponse
#   - NoAcceptHeaderFallsBackToJSON
#   - HandlerErrorBeforeNotifyFallsBackToJSON

# Full sweep for regression check:
go test -count=1 -timeout 120s ./server/...
(cd experimental/ext/events && go test -count=1 -timeout 180s ./...)
```

### Where I'd genuinely value your judgment

- Does the dual-mode handling shape (Option A) feel right, or is Option B's explicitness worth the dual-registration cost in the long run?
- The `handleStatelessPostSSE` omissions vs `handlePostSSE` — anything in that list (event store, server→client requests, retry hints) that's actually a feature we want on stateless too, not just a legacy-only artifact?
- Test coverage — three cases enough, or is there a fourth I'm missing (e.g., client disconnect mid-stream)?
