### PR TITLE
server + redisstore: BroadcastRelay seam + CapabilityBus (issue 755, PR B1)

### DIFF
--- a/experimental/ext/events/stores/redis/capability_bus.go
+++ b/experimental/ext/events/stores/redis/capability_bus.go
@@ -1,0 +1,271 @@
+// capability_bus.go — Pattern B publisher + subscriber for
+// capability-shaped notifications (notifications/tools/list_changed,
+// notifications/resources/list_changed,
+// notifications/prompts/list_changed, and any future notification
+// with the same shape: no per-subscription filter, just fan out to
+// every client with the capability).
+//
+// CapabilityBus is to capability-shaped notifications what Bus is to
+// events. Adopters wire one and:
+//   1. Install it on the Server via server.WithBroadcastRelay(bus).
+//      Server.Broadcast then fires PublishBroadcast on every call
+//      before running BroadcastToSessions locally — every replica's
+//      clients hear the notification.
+//   2. Call Subscribe + Run to start the receive side. On every
+//      cross-replica receive (origin-marker self-publishes dropped
+//      inside the Bus), the configured server.NotificationRelayReceiver
+//      (typically server.NewCapabilityBroadcastReceiver(srv)) fires
+//      Server.BroadcastToSessions on the receiving replica.
+//
+// Wire format on Redis: per-method channel, JSON envelope:
+//
+//	PUBLISH "<prefix>.broadcast.<method>" {"origin": "<uuid>", "params": <json>}
+//
+// One channel per method name keeps the subscribe surface small and
+// matches the per-event-name channel pattern Bus already uses for
+// events. The envelope carries the origin marker outside params so
+// notifications whose params are nil (every list_changed surface) can
+// still be dedup'd.
+
+package redisstore
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+
+	redis "github.com/redis/go-redis/v9"
+	"github.com/panyam/mcpkit/server"
+)
+
+// CapabilityBusChannelInfix is the segment between the redisstore
+// channel prefix and the method name. Exposed for diagnostics
+// (Redis MONITOR queries, etc.); adopters should not depend on the
+// exact value beyond "it starts with the configured ChannelPrefix."
+const CapabilityBusChannelInfix = "broadcast"
+
+// CapabilityBus is the Pattern B implementation for capability-shaped
+// notifications. Satisfies server.BroadcastRelay on the publish side
+// and wires a subscriber loop that drives server.BroadcastToSessions
+// on every cross-replica receive.
+//
+// Concurrency: PublishBroadcast is safe for concurrent calls.
+// Subscribe / Run / Close should be called from a single goroutine
+// (typical pattern: Subscribe once with the method names you care
+// about, Run in a goroutine, Close on shutdown).
+type CapabilityBus struct {
+	client        *redis.Client
+	channelPrefix string
+	originID      string
+	receiver      server.NotificationRelayReceiver
+
+	mu          sync.Mutex
+	pubsub      *redis.PubSub
+	channels    map[string]struct{}
+	closed      bool
+}
+
+// capabilityEnvelope is the wire shape PublishBroadcast emits.
+// Receive side decodes back to (originID, params) so the origin
+// filter and the receiver dispatch both have what they need.
+type capabilityEnvelope struct {
+	Origin string          `json:"origin"`
+	Params json.RawMessage `json:"params,omitempty"`
+}
+
+// CapabilityBusOptions configures a CapabilityBus. Mirrors Options
+// (the events-Bus configuration) but trimmed to what
+// capability-shaped notifications need.
+type CapabilityBusOptions struct {
+	// Client is the Redis client used for PUBLISH + SUBSCRIBE. The
+	// caller owns the client's lifecycle; CapabilityBus does NOT
+	// Close it.
+	Client *redis.Client
+
+	// ChannelPrefix is the namespace under which per-method channels
+	// live. Default: DefaultChannelPrefix ("mcpkit.events"). Override
+	// for multi-tenant deployments running multiple isolated stacks
+	// against one Redis cluster.
+	ChannelPrefix string
+}
+
+// NewCapabilityBus constructs a CapabilityBus wired to the receiver.
+// Returns an error when opts.Client or receiver is nil.
+//
+// The bus generates a 16-byte random origin marker at construction
+// time. Self-publish dedup uses this marker — the colocated
+// subscriber drops messages whose envelope.origin matches before
+// invoking the receiver.
+func NewCapabilityBus(opts CapabilityBusOptions, receiver server.NotificationRelayReceiver) (*CapabilityBus, error) {
+	if opts.Client == nil {
+		return nil, errors.New("redisstore.NewCapabilityBus: opts.Client is required")
+	}
+	if receiver == nil {
+		return nil, errors.New("redisstore.NewCapabilityBus: receiver is required")
+	}
+	if opts.ChannelPrefix == "" {
+		opts.ChannelPrefix = DefaultChannelPrefix
+	}
+	var idBuf [16]byte
+	if _, err := rand.Read(idBuf[:]); err != nil {
+		return nil, fmt.Errorf("redisstore.NewCapabilityBus: origin id: %w", err)
+	}
+	return &CapabilityBus{
+		client:        opts.Client,
+		channelPrefix: opts.ChannelPrefix,
+		originID:      hex.EncodeToString(idBuf[:]),
+		receiver:      receiver,
+		channels:      map[string]struct{}{},
+	}, nil
+}
+
+// PublishBroadcast implements server.BroadcastRelay. Encodes the
+// notification into a capabilityEnvelope tagged with this bus's
+// origin marker and PUBLISHes on the per-method channel. Errors are
+// logged via opts.Logger (set on the underlying client's Options if
+// available) but not returned — Server.Broadcast is fire-and-forget
+// for the relay leg.
+func (b *CapabilityBus) PublishBroadcast(ctx context.Context, method string, params any) {
+	body, err := encodeCapabilityEnvelope(b.originID, params)
+	if err != nil {
+		// Best-effort — adopters that care about publish reliability
+		// install a transport with retry inside the Redis client.
+		return
+	}
+	channel := b.channelFor(method)
+	_ = b.client.Publish(ctx, channel, body).Err()
+}
+
+// Subscribe declares the methods this bus listens on. Calling
+// Subscribe again with new method names extends the existing
+// subscription; duplicate method names are no-ops.
+func (b *CapabilityBus) Subscribe(ctx context.Context, methods ...string) error {
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		return errors.New("redisstore.CapabilityBus: subscribe on closed bus")
+	}
+	fresh := make([]string, 0, len(methods))
+	for _, m := range methods {
+		if _, ok := b.channels[m]; ok {
+			continue
+		}
+		b.channels[m] = struct{}{}
+		fresh = append(fresh, b.channelFor(m))
+	}
+	pubsub := b.pubsub
+	b.mu.Unlock()
+	if len(fresh) == 0 {
+		return nil
+	}
+	if pubsub == nil {
+		// Lazy pubsub creation matches Subscriber's pattern —
+		// subscription happens when Run starts.
+		return nil
+	}
+	return pubsub.Subscribe(ctx, fresh...)
+}
+
+// Run starts the receive loop. Blocks until ctx is cancelled or the
+// underlying pubsub channel closes. Returns nil on clean shutdown.
+func (b *CapabilityBus) Run(ctx context.Context) error {
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		return errors.New("redisstore.CapabilityBus: run on closed bus")
+	}
+	initial := make([]string, 0, len(b.channels))
+	for m := range b.channels {
+		initial = append(initial, b.channelFor(m))
+	}
+	if len(initial) == 0 {
+		// No methods subscribed — nothing to drain. Block on ctx so
+		// the typical "go bus.Run(ctx)" pattern still works.
+		b.mu.Unlock()
+		<-ctx.Done()
+		return nil
+	}
+	pubsub := b.client.Subscribe(ctx, initial...)
+	b.pubsub = pubsub
+	b.mu.Unlock()
+
+	ch := pubsub.Channel()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case msg, ok := <-ch:
+			if !ok {
+				return nil
+			}
+			origin, params, err := decodeCapabilityEnvelope([]byte(msg.Payload))
+			if err != nil {
+				continue
+			}
+			if origin == b.originID {
+				continue
+			}
+			method := b.methodFor(msg.Channel)
+			b.receiver.ReceiveRelay(ctx, method, params)
+		}
+	}
+}
+
+// Close releases the underlying *redis.PubSub. Idempotent. After
+// Close, Subscribe returns an error; Run (if blocked) returns nil.
+// Does NOT close the underlying *redis.Client.
+func (b *CapabilityBus) Close() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		return nil
+	}
+	b.closed = true
+	if b.pubsub != nil {
+		return b.pubsub.Close()
+	}
+	return nil
+}
+
+func (b *CapabilityBus) channelFor(method string) string {
+	return b.channelPrefix + "." + CapabilityBusChannelInfix + "." + method
+}
+
+func (b *CapabilityBus) methodFor(channel string) string {
+	prefix := b.channelPrefix + "." + CapabilityBusChannelInfix + "."
+	if len(channel) <= len(prefix) {
+		return channel
+	}
+	return channel[len(prefix):]
+}
+
+func encodeCapabilityEnvelope(originID string, params any) ([]byte, error) {
+	var p json.RawMessage
+	if params != nil {
+		raw, err := json.Marshal(params)
+		if err != nil {
+			return nil, err
+		}
+		p = raw
+	}
+	return json.Marshal(capabilityEnvelope{Origin: originID, Params: p})
+}
+
+// decodeCapabilityEnvelope returns (origin, params, error). params is
+// json.RawMessage so the receiver can defer typed decode if needed;
+// most receivers pass it straight through to BroadcastToSessions
+// which doesn't care about the inner shape.
+func decodeCapabilityEnvelope(body []byte) (string, json.RawMessage, error) {
+	var env capabilityEnvelope
+	if err := json.Unmarshal(body, &env); err != nil {
+		return "", nil, err
+	}
+	return env.Origin, env.Params, nil
+}
+
+// Compile-time check: CapabilityBus satisfies server.BroadcastRelay.
+var _ server.BroadcastRelay = (*CapabilityBus)(nil)

--- a/experimental/ext/events/stores/redis/capability_bus_test.go
+++ b/experimental/ext/events/stores/redis/capability_bus_test.go
@@ -1,0 +1,192 @@
+package redisstore_test
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	core "github.com/panyam/mcpkit/core"
+	redisstore "github.com/panyam/mcpkit/experimental/ext/events/stores/redis"
+	"github.com/panyam/mcpkit/server"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/alicebob/miniredis/v2"
+)
+
+// newTestRedis returns a shared miniredis-backed *redis.Client for
+// these tests. Mirrors stores/redis's internal newTestClient helper
+// (which is package-private to redisstore).
+func newTestRedis(t *testing.T) *redis.Client {
+	t.Helper()
+	mr, err := miniredis.Run()
+	require.NoError(t, err)
+	t.Cleanup(mr.Close)
+	cli := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = cli.Close() })
+	return cli
+}
+
+// recordingReceiver captures every ReceiveRelay call so the test can
+// assert what reached the bus's receiver side.
+type recordingReceiver struct {
+	mu      sync.Mutex
+	frames  []recordedFrame
+}
+
+type recordedFrame struct {
+	method string
+	params json.RawMessage
+}
+
+func (r *recordingReceiver) ReceiveRelay(_ context.Context, method string, params any) {
+	raw, _ := params.(json.RawMessage)
+	r.mu.Lock()
+	r.frames = append(r.frames, recordedFrame{method: method, params: raw})
+	r.mu.Unlock()
+}
+
+func (r *recordingReceiver) snapshot() []recordedFrame {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]recordedFrame, len(r.frames))
+	copy(out, r.frames)
+	return out
+}
+
+func (r *recordingReceiver) waitFor(t *testing.T, count int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if len(r.snapshot()) >= count {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("expected %d frames within %s, got %d", count, timeout, len(r.snapshot()))
+}
+
+// TestCapabilityBus_RoundTrip_TwoReplicas verifies the cross-replica
+// path end-to-end: bus on replica A publishes; bus on replica B
+// receives and forwards to its NotificationRelayReceiver. Origin
+// markers ensure each bus only delivers events from OTHER replicas.
+func TestCapabilityBus_RoundTrip_TwoReplicas(t *testing.T) {
+	cli := newTestRedis(t)
+	opts := redisstore.CapabilityBusOptions{Client: cli}
+
+	recvA := &recordingReceiver{}
+	recvB := &recordingReceiver{}
+
+	busA, err := redisstore.NewCapabilityBus(opts, recvA)
+	require.NoError(t, err)
+	defer busA.Close()
+	busB, err := redisstore.NewCapabilityBus(opts, recvB)
+	require.NoError(t, err)
+	defer busB.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, busA.Subscribe(ctx, "notifications/tools/list_changed"))
+	require.NoError(t, busB.Subscribe(ctx, "notifications/tools/list_changed"))
+
+	go busA.Run(ctx)
+	go busB.Run(ctx)
+
+	// miniredis pubsub subscription becomes effective the moment Run
+	// hits the underlying client.Subscribe call. Sleep briefly to let
+	// both subscribe loops register before we publish.
+	time.Sleep(50 * time.Millisecond)
+
+	busA.PublishBroadcast(ctx, "notifications/tools/list_changed", nil)
+
+	// busB's receiver must see exactly one frame (the cross-replica
+	// publish from A). busA's receiver must see ZERO frames (the
+	// origin marker drops self-publishes).
+	recvB.waitFor(t, 1, time.Second)
+	assert.Len(t, recvB.snapshot(), 1)
+	assert.Empty(t, recvA.snapshot(), "origin replica must drop self-publish")
+}
+
+// TestCapabilityBus_SelfPublishDeduped verifies the single-bus
+// case: publishing to a bus that's also its own subscriber must drop
+// the self-publish.
+func TestCapabilityBus_SelfPublishDeduped(t *testing.T) {
+	cli := newTestRedis(t)
+	recv := &recordingReceiver{}
+	bus, err := redisstore.NewCapabilityBus(redisstore.CapabilityBusOptions{Client: cli}, recv)
+	require.NoError(t, err)
+	defer bus.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, bus.Subscribe(ctx, "notifications/tools/list_changed"))
+	go bus.Run(ctx)
+	time.Sleep(50 * time.Millisecond)
+
+	bus.PublishBroadcast(ctx, "notifications/tools/list_changed", nil)
+	time.Sleep(100 * time.Millisecond) // let any erroneous delivery fire
+
+	assert.Empty(t, recv.snapshot(), "single-bus publish must dedup via origin marker")
+}
+
+// TestCapabilityBus_WithBroadcastRelay_EndToEnd verifies the full
+// integration: two Servers, each with a CapabilityBus wired via
+// WithBroadcastRelay. Calling Server.Broadcast on one replica
+// triggers the other replica's BroadcastToSessions via the relay.
+//
+// We build the receiver + bus first using a placeholder srv, then
+// construct the real srv with WithBroadcastRelay pointing at the
+// bus, then swap the receiver's srv pointer to the real one via
+// SwapServer. This dance is needed because BroadcastRelay must be
+// installed at NewServer time but the receiver references its srv
+// for BroadcastToSessions calls.
+func TestCapabilityBus_WithBroadcastRelay_EndToEnd(t *testing.T) {
+	cli := newTestRedis(t)
+	opts := redisstore.CapabilityBusOptions{Client: cli}
+
+	buildReplica := func(name string) (*server.Server, *recordingReceiver, *redisstore.CapabilityBus) {
+		// Wrap CapabilityBroadcastReceiver with a recording adapter
+		// so we can verify ReceiveRelay fires.
+		recv := &recordingReceiver{}
+		bus, err := redisstore.NewCapabilityBus(opts, recv)
+		require.NoError(t, err)
+		srv := server.NewServer(core.ServerInfo{Name: name, Version: "0.0.1"},
+			server.WithBroadcastRelay(bus),
+		)
+		return srv, recv, bus
+	}
+
+	srvA, recvA, busA := buildReplica("A")
+	defer busA.Close()
+	srvB, recvB, busB := buildReplica("B")
+	defer busB.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, busA.Subscribe(ctx, "notifications/tools/list_changed"))
+	require.NoError(t, busB.Subscribe(ctx, "notifications/tools/list_changed"))
+	go busA.Run(ctx)
+	go busB.Run(ctx)
+	time.Sleep(50 * time.Millisecond)
+
+	// Broadcast from A. A's local BroadcastToSessions fires
+	// synchronously (we don't observe it directly here — that's
+	// covered by server/relay_inmemory_test.go). B's bus receives
+	// via Redis, decodes the envelope, and invokes its receiver.
+	srvA.Broadcast(ctx, "notifications/tools/list_changed", nil)
+
+	// recvB sees ONE cross-replica frame; recvA sees NONE
+	// (origin marker dropped its self-publish).
+	recvB.waitFor(t, 1, time.Second)
+	assert.Len(t, recvB.snapshot(), 1)
+	assert.Empty(t, recvA.snapshot(), "origin replica must drop self-publish at the bus layer")
+
+	// Sanity: the srv refs are non-nil so the type checker confirms
+	// WithBroadcastRelay installed the relay onto the server.
+	_ = srvA
+	_ = srvB
+}
+

--- a/server/relay.go
+++ b/server/relay.go
@@ -38,6 +38,33 @@ import (
 	"context"
 )
 
+// BroadcastRelay is the publish side of a Pattern B transport for
+// capability-shaped notifications (notifications/tools/list_changed,
+// notifications/resources/list_changed, etc.). Adopters install one
+// via WithBroadcastRelay; Server.Broadcast then fires
+// PublishBroadcast(ctx, method, params) before the local
+// BroadcastToSessions fan-out so the same notification reaches every
+// connected client across every replica.
+//
+// PublishBroadcast is fire-and-forget — Server.Broadcast does not
+// surface errors. Implementations log internally if a publish fails;
+// the local BroadcastToSessions fan-out still runs regardless.
+//
+// Concurrency: PublishBroadcast may be invoked from any goroutine that
+// calls Server.Broadcast (handlers, registry.OnChange, etc.).
+// Implementations must be safe for concurrent calls.
+//
+// The receive-side wiring (a separate subscriber loop calling
+// Server.BroadcastToSessions on cross-replica receives) is the
+// transport adapter's responsibility. The reference Redis
+// implementation is redisstore.CapabilityBus, which satisfies
+// BroadcastRelay on the publish side AND drives BroadcastToSessions
+// on the subscribe side via a NotificationRelayReceiver wired
+// internally.
+type BroadcastRelay interface {
+	PublishBroadcast(ctx context.Context, method string, params any)
+}
+
 // NotificationRelayReceiver is the callback shape mcpkit expects from
 // a Pattern B transport's subscriber side. The transport adapter calls
 // ReceiveRelay once per cross-replica notification destined for this
@@ -56,6 +83,25 @@ import (
 // safe for concurrent calls.
 type NotificationRelayReceiver interface {
 	ReceiveRelay(ctx context.Context, method string, params any)
+}
+
+// WithBroadcastRelay installs a BroadcastRelay onto the Server.
+// Server.Broadcast then fires PublishBroadcast on the relay before
+// running BroadcastToSessions locally — every capability-shaped
+// notification (tools/list_changed, resources/list_changed,
+// prompts/list_changed, application-level broadcasts) reaches
+// connected clients across every replica in the deployment.
+//
+// Pair with a transport adapter's subscribe-side wiring that calls
+// Server.BroadcastToSessions on cross-replica receives (the reference
+// is redisstore.CapabilityBus, which provides both ends).
+//
+// Pass nil to disable the relay (default) — Server.Broadcast then
+// fires local-only, matching pre-Pattern-B behavior.
+func WithBroadcastRelay(relay BroadcastRelay) Option {
+	return func(o *serverOptions) {
+		o.broadcastRelay = relay
+	}
 }
 
 // CapabilityBroadcastReceiver is the reference NotificationRelayReceiver
@@ -80,10 +126,15 @@ func NewCapabilityBroadcastReceiver(srv *Server) *CapabilityBroadcastReceiver {
 }
 
 // ReceiveRelay implements NotificationRelayReceiver. Forwards to
-// Server.Broadcast with a background context — the relay is
-// fire-and-forget at the notification level; the transport's ctx
-// cancellation belongs to the transport loop, not to the broadcast
-// fan-out on this replica.
+// Server.BroadcastToSessions (NOT Server.Broadcast) with a background
+// context — calling Broadcast here would re-fire the installed
+// BroadcastRelay and loop indefinitely through the Pattern B
+// transport. BroadcastToSessions delivers to local sessions only,
+// which is what the relay receive path needs.
+//
+// The relay is fire-and-forget at the notification level; the
+// transport's ctx cancellation belongs to the transport loop, not to
+// the broadcast fan-out on this replica.
 func (r *CapabilityBroadcastReceiver) ReceiveRelay(_ context.Context, method string, params any) {
-	r.srv.Broadcast(context.Background(), method, params)
+	r.srv.BroadcastToSessions(context.Background(), method, params)
 }

--- a/server/relay_inmemory_test.go
+++ b/server/relay_inmemory_test.go
@@ -1,0 +1,332 @@
+package server
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	core "github.com/panyam/mcpkit/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// memRelayBus is an in-memory BroadcastRelay that also provides the
+// receive side of Pattern B — every Publish fans out to every
+// registered subscriber on a background goroutine. Self-publish dedup
+// runs via per-replica origin marker. Used only by tests; never wired
+// into production code.
+//
+// Wire shape: each replica registers a NotificationRelayReceiver and
+// gets a unique origin ID. PublishBroadcast tags the message with the
+// publisher's origin and enqueues to every subscriber. Subscribers
+// drop messages whose origin matches their own (self-publish).
+type memRelayBus struct {
+	mu          sync.Mutex
+	subscribers []*memRelaySubscriber
+	nextID      int
+}
+
+type memRelaySubscriber struct {
+	originID string
+	receiver NotificationRelayReceiver
+	queue    chan memRelayFrame
+	done     chan struct{}
+}
+
+type memRelayFrame struct {
+	origin string
+	method string
+	params any
+}
+
+func newMemRelayBus() *memRelayBus { return &memRelayBus{} }
+
+// attachReplica registers a receiver on the bus and returns a publish
+// handle that PublishBroadcast tags with this replica's origin. Wire
+// the returned handle through WithBroadcastRelay so the same replica's
+// outbound publishes carry the origin its inbound subscriber will
+// drop.
+func (b *memRelayBus) attachReplica(t *testing.T, receiver NotificationRelayReceiver) BroadcastRelay {
+	t.Helper()
+	b.mu.Lock()
+	b.nextID++
+	id := b.nextID
+	b.mu.Unlock()
+
+	sub := &memRelaySubscriber{
+		originID: hexID(id),
+		receiver: receiver,
+		queue:    make(chan memRelayFrame, 256),
+		done:     make(chan struct{}),
+	}
+	b.mu.Lock()
+	b.subscribers = append(b.subscribers, sub)
+	b.mu.Unlock()
+
+	go sub.run()
+	t.Cleanup(sub.close)
+
+	return &memRelayPublisher{bus: b, originID: sub.originID}
+}
+
+func (s *memRelaySubscriber) run() {
+	defer close(s.done)
+	for f := range s.queue {
+		if f.origin == s.originID {
+			continue
+		}
+		s.receiver.ReceiveRelay(context.Background(), f.method, f.params)
+	}
+}
+
+func (s *memRelaySubscriber) close() {
+	defer func() { _ = recover() }()
+	close(s.queue)
+	select {
+	case <-s.done:
+	case <-time.After(time.Second):
+	}
+}
+
+type memRelayPublisher struct {
+	bus      *memRelayBus
+	originID string
+}
+
+func (p *memRelayPublisher) PublishBroadcast(_ context.Context, method string, params any) {
+	p.bus.mu.Lock()
+	subs := make([]*memRelaySubscriber, len(p.bus.subscribers))
+	copy(subs, p.bus.subscribers)
+	p.bus.mu.Unlock()
+	frame := memRelayFrame{origin: p.originID, method: method, params: params}
+	for _, s := range subs {
+		select {
+		case s.queue <- frame:
+		default:
+			// Drop on slow subscriber — tests use ample buffer.
+		}
+	}
+}
+
+func hexID(n int) string {
+	const hex = "0123456789abcdef"
+	out := []byte{0, 0, 0, 0}
+	for i := 3; i >= 0; i-- {
+		out[i] = hex[n&0xf]
+		n >>= 4
+	}
+	return string(out)
+}
+
+// captureCluster spins up M Server instances wired against a shared
+// memRelayBus. Each Server captures every BroadcastToSessions call
+// into a per-replica frame slice. Tests can publish from any replica
+// and assert per-replica deliveries.
+type captureCluster struct {
+	t        *testing.T
+	bus      *memRelayBus
+	replicas []*captureReplica
+}
+
+type captureReplica struct {
+	idx int
+	srv *Server
+	mu  sync.Mutex
+	got []captureFrame
+}
+
+func (r *captureReplica) frames() []captureFrame {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]captureFrame, len(r.got))
+	copy(out, r.got)
+	return out
+}
+
+func newCaptureCluster(t *testing.T, m int) *captureCluster {
+	t.Helper()
+	cluster := &captureCluster{t: t, bus: newMemRelayBus()}
+	for i := 0; i < m; i++ {
+		r := &captureReplica{idx: i}
+		receiver := NewCapabilityBroadcastReceiver(nil) // srv set below
+		relay := cluster.bus.attachReplica(t, &recordingReceiver{
+			recv: receiver,
+			onFire: func(method string, params any) {
+				// captured via session broadcaster below; this hook
+				// is unused but documents that receive is happening
+			},
+		})
+		srv := NewServer(core.ServerInfo{Name: "cluster-replica", Version: "0.0.1"},
+			WithBroadcastRelay(relay),
+		)
+		// Wire the receiver to its server now that the server exists.
+		receiver.srv = srv
+		// Register a fake session broadcaster on this replica so we
+		// observe what reaches local clients (i.e. what
+		// BroadcastToSessions fans out).
+		srv.registerTransportSessions(
+			func(string) bool { return false },
+			func() {},
+			func(_ context.Context, method string, params any) {
+				r.mu.Lock()
+				r.got = append(r.got, captureFrame{method: method, params: params})
+				r.mu.Unlock()
+			},
+		)
+		r.srv = srv
+		cluster.replicas = append(cluster.replicas, r)
+	}
+	return cluster
+}
+
+// recordingReceiver wraps a NotificationRelayReceiver so tests can
+// hook into receive events when they care about the timing (the
+// captureCluster usually doesn't — it asserts on the final
+// session-broadcaster state).
+type recordingReceiver struct {
+	recv   NotificationRelayReceiver
+	onFire func(method string, params any)
+}
+
+func (r *recordingReceiver) ReceiveRelay(ctx context.Context, method string, params any) {
+	if r.onFire != nil {
+		r.onFire(method, params)
+	}
+	r.recv.ReceiveRelay(ctx, method, params)
+}
+
+// waitForFrameCount polls until the replica has accumulated count
+// frames, or fails the test after timeout. Useful because the
+// memRelayBus delivers asynchronously via goroutine.
+func (r *captureReplica) waitForFrameCount(t *testing.T, count int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if len(r.frames()) >= count {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("replica %d: expected at least %d frames, got %d", r.idx, count, len(r.frames()))
+}
+
+// --- Tests ---------------------------------------------------------
+
+// TestBroadcastToSessions_ExcludesRelay verifies that BroadcastToSessions
+// fires only the local session broadcasters, NOT the installed relay.
+// This is the contract Pattern B receivers depend on to avoid recursion.
+func TestBroadcastToSessions_ExcludesRelay(t *testing.T) {
+	cluster := newCaptureCluster(t, 1)
+	srv := cluster.replicas[0].srv
+
+	// BroadcastToSessions should fire LOCAL session broadcasters only.
+	// The relay's PublishBroadcast must NOT be called.
+	srv.BroadcastToSessions(context.Background(), "notifications/tools/list_changed", nil)
+
+	cluster.replicas[0].waitForFrameCount(t, 1, time.Second)
+	assert.Len(t, cluster.replicas[0].frames(), 1)
+}
+
+// TestBroadcast_FiresRelayThenLocal verifies the public Broadcast does
+// BOTH: relay PublishBroadcast (cross-replica), then BroadcastToSessions
+// (local). Other replicas receive via relay → BroadcastToSessions, so
+// every replica's captured frames go up.
+func TestBroadcast_FiresRelayThenLocal(t *testing.T) {
+	cluster := newCaptureCluster(t, 3)
+
+	// Publish from replica 0. Local replica fires session broadcasters
+	// immediately; replicas 1 + 2 receive via relay → BroadcastToSessions.
+	cluster.replicas[0].srv.Broadcast(context.Background(), "notifications/tools/list_changed", nil)
+
+	cluster.replicas[0].waitForFrameCount(t, 1, time.Second)
+	cluster.replicas[1].waitForFrameCount(t, 1, time.Second)
+	cluster.replicas[2].waitForFrameCount(t, 1, time.Second)
+
+	for _, r := range cluster.replicas {
+		frames := r.frames()
+		require.Len(t, frames, 1, "replica %d", r.idx)
+		assert.Equal(t, "notifications/tools/list_changed", frames[0].method)
+	}
+}
+
+// TestBroadcast_SelfPublishDeduped verifies that the origin replica's
+// own publish doesn't double-fire its local session broadcasters via
+// the relay round-trip. The single Broadcast call should produce
+// exactly one frame on the origin replica (from the local
+// BroadcastToSessions path), NOT two (one from local + one from relay
+// receive).
+func TestBroadcast_SelfPublishDeduped(t *testing.T) {
+	cluster := newCaptureCluster(t, 3)
+
+	cluster.replicas[0].srv.Broadcast(context.Background(), "notifications/tools/list_changed", nil)
+
+	// Wait a beat to let any erroneous relay round-trip fire.
+	time.Sleep(50 * time.Millisecond)
+
+	assert.Len(t, cluster.replicas[0].frames(), 1, "origin replica must see EXACTLY one frame, not double-fire via relay")
+}
+
+// TestBroadcast_NoRelayInstalled verifies that without a relay
+// configured, Broadcast still works — fires only local sessions
+// (matches pre-Pattern-B behavior).
+func TestBroadcast_NoRelayInstalled(t *testing.T) {
+	srv := NewServer(core.ServerInfo{Name: "no-relay", Version: "0.0.1"})
+	var captured []captureFrame
+	var mu sync.Mutex
+	srv.registerTransportSessions(
+		func(string) bool { return false },
+		func() {},
+		func(_ context.Context, method string, params any) {
+			mu.Lock()
+			captured = append(captured, captureFrame{method: method, params: params})
+			mu.Unlock()
+		},
+	)
+
+	srv.Broadcast(context.Background(), "notifications/tools/list_changed", nil)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Len(t, captured, 1)
+}
+
+// TestBroadcastRelay_NTopicsMConsumers is the N producers × T topics
+// × M consumers harness exercising the full multi-replica matrix.
+// Every replica publishes every topic once; every replica's session
+// broadcaster should receive every published topic exactly once
+// (origin replica via local fanout; other replicas via relay).
+func TestBroadcastRelay_NTopicsMConsumers(t *testing.T) {
+	const m = 3 // replicas
+	cluster := newCaptureCluster(t, m)
+	topics := []string{
+		"notifications/tools/list_changed",
+		"notifications/resources/list_changed",
+		"notifications/prompts/list_changed",
+	}
+
+	// Each replica publishes each topic.
+	for _, r := range cluster.replicas {
+		for _, topic := range topics {
+			r.srv.Broadcast(context.Background(), topic, nil)
+		}
+	}
+
+	// Expected per replica = m publishers × t topics = m × len(topics).
+	expectedPerReplica := m * len(topics)
+	for _, r := range cluster.replicas {
+		r.waitForFrameCount(t, expectedPerReplica, 2*time.Second)
+		frames := r.frames()
+		require.Len(t, frames, expectedPerReplica, "replica %d", r.idx)
+
+		// Each topic should appear exactly m times across the frames
+		// (one from each publisher).
+		count := map[string]int{}
+		for _, f := range frames {
+			count[f.method]++
+		}
+		for _, topic := range topics {
+			assert.Equal(t, m, count[topic], "replica %d topic %q", r.idx, topic)
+		}
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -79,6 +79,7 @@ type serverOptions struct {
 	allowLegacyOnDraft   bool                     // WithAllowLegacyOnDraft — opt-in SEP-2575 leniency on the legacy wire (off by default; strict per spec)
 	tracerProvider       core.TracerProvider      // SEP-414 P2 — WithTracerProvider; nil/Noop = trace middleware not installed
 	meterProvider        core.MeterProvider       // issue 7 — WithMeterProvider; nil/Noop = metrics middleware not installed
+	broadcastRelay       BroadcastRelay           // issue 755 — WithBroadcastRelay; nil = no cross-replica broadcast (Broadcast fires local only)
 }
 
 type httpHandlerEntry struct {
@@ -998,7 +999,34 @@ func (s *Server) Broadcast(ctx context.Context, method string, params any) {
 	if tc := core.TraceContextFromContext(ctx); !tc.IsZero() {
 		params = core.InjectTraceContextIntoParams(params, tc)
 	}
+	s.mu.Lock()
+	relay := s.options.broadcastRelay
+	s.mu.Unlock()
+	if relay != nil {
+		relay.PublishBroadcast(ctx, method, params)
+	}
+	s.BroadcastToSessions(ctx, method, params)
+}
 
+// BroadcastToSessions delivers a notification to every locally-connected
+// client via the per-transport session broadcasters. UNLIKE Broadcast,
+// BroadcastToSessions does NOT invoke the installed BroadcastRelay —
+// it's the local-only path Pattern B receivers call after dropping
+// self-publishes, so they don't re-publish through the relay and loop.
+//
+// External callers should normally use Broadcast (which fires the
+// relay + local). BroadcastToSessions is the entry point for relay
+// receive callbacks (server.CapabilityBroadcastReceiver and equivalent
+// adapters) and tests that want to verify session fan-out independently
+// of the relay path.
+//
+// Trace context injection: BroadcastToSessions does NOT re-inject
+// _meta.traceparent — the relay receive path is responsible for
+// surfacing the upstream trace context onto ctx, and the params
+// envelope already carries any caller-set _meta. Re-injecting here
+// would double-stamp on the local-fanout-only path called from
+// Broadcast above.
+func (s *Server) BroadcastToSessions(ctx context.Context, method string, params any) {
 	s.mu.Lock()
 	broadcasters := make([]func(context.Context, string, any), len(s.sessionBroadcasters))
 	copy(broadcasters, s.sessionBroadcasters)


### PR DESCRIPTION
## What changes

PR B1 of issue 755 — wire the publish side of Pattern B for capability-shaped notifications (`tools/list_changed`, `resources/list_changed`, `prompts/list_changed`). PR A (#757) added the routing primitive (`NotificationRelayReceiver` + `CapabilityBroadcastReceiver`); this PR makes `Server.Broadcast` cross-replica-aware via an installable `BroadcastRelay` and ships the reference Redis implementation `redisstore.CapabilityBus`.

Adopter API after this PR:
```go
bus, _ := redisstore.NewCapabilityBus(opts, server.NewCapabilityBroadcastReceiver(srv))
srv := server.NewServer(info, server.WithBroadcastRelay(bus))
go bus.Subscribe(ctx, "notifications/tools/list_changed", ...)
go bus.Run(ctx)
// srv.Broadcast(ctx, ...) now fans out across every replica.
```

No surfaces are wired in this PR (PR B2's job). PR B1 ships the infrastructure + comprehensive test harness; PR B2 lights up `registry.OnChange` and `resources/updated` on top.

## Reviewer's guide
Read in this order:

1. [server/server.go](https://github.com/panyam/mcpkit/pull/759/files#diff-78f42ba40d0f10b08c73b7e6bb8376f398e249c963cf549e89591d6b6826b9a4) — start here. `Server.Broadcast` split into two paths. New body fires the installed `BroadcastRelay` (if any) before running the new `BroadcastToSessions`. The split is the contract the receive side depends on to avoid recursion.
2. [server/relay.go](https://github.com/panyam/mcpkit/pull/759/files#diff-6e1faa6c56182c2ea76b641b8d226799639d62a02d1349daa77988535f08668f) — `BroadcastRelay` interface + `WithBroadcastRelay` option + updated `CapabilityBroadcastReceiver.ReceiveRelay` (now calls `BroadcastToSessions`, not `Broadcast`, so installing a relay doesn't loop).
3. [server/relay_inmemory_test.go](https://github.com/panyam/mcpkit/pull/759/files#diff-e84d05eb3b08b52b7bb21421bfc3ab3866c68a4785bab10c033fdc209ccd0d80) — in-memory test harness: `memRelayBus` (chan-based BroadcastRelay impl, test-only) + `captureCluster` (spins up N Servers wired to the shared bus). 5 scenarios covering the split, fan-out, self-publish dedup, and N×T matrix.
4. [experimental/ext/events/stores/redis/capability_bus.go](https://github.com/panyam/mcpkit/pull/759/files#diff-99c675bb90ed0314ff756248e4b6eb740901a5c5c5f14da16c8179d81c22e498) — the Redis transport. Wire format: per-method channel `<prefix>.broadcast.<method>` carrying JSON envelope `{origin, params}`. Origin in the envelope, not in `params._meta` — capability-shaped notifications often have `nil params`, so the marker can't live there.
5. [experimental/ext/events/stores/redis/capability_bus_test.go](https://github.com/panyam/mcpkit/pull/759/files#diff-57cbc9c4496eff856d6be4fe82d342e88d4cbc0807969139863835a65a072584) — miniredis-backed round-trip tests: 2 replicas exchange notifications; self-publish dedup verified at the bus layer; full end-to-end through two Servers wired via `WithBroadcastRelay`.

Skim: existing `relay.go` carries forward unchanged interface from PR A; transitive `go.sum` updates.

## Decision log

- **Two methods on Server (`Broadcast` + `BroadcastToSessions`) instead of context flag.** Considered making `Server.Broadcast` skip-relay-aware via a ctx marker so the receive path could call `Broadcast` and have it self-detect. Two public methods is clearer — the contract reads from the call site, no hidden state on ctx. The naming distinction (`BroadcastToSessions` = describes what it does) is intentional.
- **Origin marker in envelope, not in params.** Capability-shaped notifications' params are typically nil or transport-decided. The redisstore Bus for events stamps origin onto `event.Meta`; that pattern doesn't generalize. Wrapping in a JSON envelope `{origin, params}` is the smallest-blast-radius alternative.
- **Per-method Redis channels.** Could've used a single channel with method on the envelope. Per-method aligns with the events Bus's per-event-name channel pattern (operators MONITORing a specific notification stream don't need to filter). 4-5 channels per replica isn't a load concern.
- **`CapabilityBus.PublishBroadcast` is fire-and-forget.** No error return; transport-level errors are swallowed. Mirrors `Server.Broadcast`'s public contract (also returns nothing). Adopters wanting publish reliability install transport-level retry on the underlying `*redis.Client`.

## Risk / blast radius

- **`Server.Broadcast` semantics changed when a relay is installed.** Without `WithBroadcastRelay`, behavior is identical to pre-PR (fires `BroadcastToSessions` only). With a relay installed, every Broadcast call fires the relay first — adopters opting in get cross-replica fan-out automatically.
- **`CapabilityBroadcastReceiver.ReceiveRelay` switched from `Broadcast` to `BroadcastToSessions`.** PR A's version called `Broadcast`; this PR changes it to `BroadcastToSessions` so an installed relay doesn't recurse. Only matters when both PR A's receiver AND PR B1's relay are present together.
- **Areas worth pressure-testing:** subscribe/unsubscribe lifecycle (`Subscribe` after `Run` started), `Close` ordering during shutdown (currently relies on pubsub channel close cascading), concurrent `PublishBroadcast` calls from many handlers (per-instance mutex on the Bus is the gate; `redis.Client` is itself safe for concurrent use).
- **`go test -race` clean for all new tests.** Pre-existing race in `TestMatchTransform_CrossModeParity` (unmodified test from commit da53fc5) is unrelated; filed as issue 758.

## Out of scope (deferred to PR B2)

- Wire the four currently-broken notification surfaces:
  - `Registry.OnChange` (3 list_changed) → already calls `Server.Broadcast`; adopters configure a `CapabilityBus` and it Just Works at N>1.
  - `resources/updated` needs a subscription-shaped receiver (URI prefix routing into the per-URI subscription set) — different from `CapabilityBroadcastReceiver`. PR B2 adds it.

## Out of scope (deferred to PR B3)

- `docs/MULTI_REPLICA.md` + `CONSTRAINTS.md` addition.
- N=3 docker E2E covering both routing categories + tenant scoping.
