### PR TITLE
relay: rename BroadcastRelay → NotificationRelay + family (issue 770 PR A)

### DIFF
--- a/CONSTRAINTS.md
+++ b/CONSTRAINTS.md
@@ -92,10 +92,10 @@ At N>1 (multiple server replicas), five notification surfaces silently break wit
 
 Adopters deploying mcpkit at N>1 MUST either:
 
-1. **Configure a `BroadcastRelay`** for capability + subscription-shaped notifications (`server.WithBroadcastRelay(redisstore.NewCapabilityBus(...))`) AND a `redisstore.Bus` for events. The reference wiring is in `docs/MULTI_REPLICA.md` § Configuration recipes.
+1. **Configure a `NotificationRelay`** for capability + subscription-shaped notifications (`server.WithNotificationRelay(redisstore.NewCapabilityBus(...))`) AND a `redisstore.Bus` for events. The reference wiring is in `docs/MULTI_REPLICA.md` § Configuration recipes.
 2. **Use sticky sessions** so each client only ever hits one replica. The notifications stay broken cross-replica but a single client's experience is consistent.
 3. **Document the limitation** if they use neither — adopters should not silently ship a broken setup expecting the notifications to work.
 
-The full architecture (Pattern B, BroadcastRelay seam, NotificationRelayReceiver routing, per-surface end-to-end flows, scenario walkthroughs) is in `docs/MULTI_REPLICA.md`. Issue 755 tracks the work.
+The full architecture (Pattern B, NotificationRelay seam, NotificationRelayReceiver routing, per-surface end-to-end flows, scenario walkthroughs) is in `docs/MULTI_REPLICA.md`. Issue 755 tracks the work.
 
 **Verify:** there is no automated check today — the constraint is documented to prevent silent breakage, not enforced at build time. Adopters running N>1 should verify their wiring matches one of the recipes in `docs/MULTI_REPLICA.md` § Configuration recipes.

--- a/docs/MULTI_REPLICA.md
+++ b/docs/MULTI_REPLICA.md
@@ -35,12 +35,12 @@ flowchart LR
     subgraph Replica K
         K_Trigger["Notification trigger<br/>(Registry.OnChange,<br/>NotifyResourceUpdated,<br/>YieldingSource.yield)"]
         K_Local["Local delivery<br/>(BroadcastToSessions,<br/>notifyLocal, slot fanout)"]
-        K_Publish["BroadcastRelay /<br/>events.Emitter"]
+        K_Publish["NotificationRelay /<br/>events.Emitter"]
         K_Clients["Local clients"]
     end
     subgraph Replica K'
         Kp_Receive["Bus subscriber<br/>(drops self-publishes)"]
-        Kp_Receiver["NotificationRelayReceiver<br/>(Multiplex by method)"]
+        Kp_Receiver["NotificationRelayReceiver<br/>(NotificationRouter by method)"]
         Kp_Local["Local delivery<br/>(BroadcastToSessions,<br/>notifyLocal, slot fanout)"]
         Kp_Clients["Local clients"]
     end
@@ -93,33 +93,33 @@ Surfaces and their per-replica filters:
 
 ```mermaid
 classDiagram
-    class BroadcastRelay {
+    class NotificationRelay {
         <<interface>>
-        +PublishBroadcast(ctx, method, params)
+        +Publish(ctx, method, params)
     }
     class NotificationRelayReceiver {
         <<interface>>
-        +ReceiveRelay(ctx, method, params)
+        +Receive(ctx, method, params)
     }
     class CapabilityBroadcastReceiver {
         -srv: *Server
-        +ReceiveRelay() calls srv.BroadcastToSessions
+        +Receive() calls srv.BroadcastToSessions
     }
     class ResourcesUpdatedReceiver {
         -srv: *Server
-        +ReceiveRelay() calls srv.NotifyResourceUpdatedLocal
+        +Receive() calls srv.NotifyResourceUpdatedLocal
     }
-    class MultiplexRelayReceiver {
+    class NotificationRouter {
         -handlers: map[method]Receiver
         +Handle(method, receiver)
-        +ReceiveRelay() routes by method
+        +Receive() routes by method
     }
     class YieldingSource {
-        +ReceiveRelay() calls LocalDeliver (per-slot Match)
+        +Receive() calls LocalDeliver (per-slot Match)
     }
     NotificationRelayReceiver <|.. CapabilityBroadcastReceiver
     NotificationRelayReceiver <|.. ResourcesUpdatedReceiver
-    NotificationRelayReceiver <|.. MultiplexRelayReceiver
+    NotificationRelayReceiver <|.. NotificationRouter
     NotificationRelayReceiver <|.. YieldingSource
 ```
 
@@ -128,7 +128,7 @@ classDiagram
 ```mermaid
 classDiagram
     class CapabilityBus {
-        +PublishBroadcast() PUBLISH to Redis
+        +Publish() PUBLISH to Redis
         +Subscribe(methods...)
         +Run(ctx) receive loop
         +Close()
@@ -144,7 +144,7 @@ classDiagram
         +Subscribe(eventNames...)
         +Run(ctx) receive loop
     }
-    BroadcastRelay <|.. CapabilityBus
+    NotificationRelay <|.. CapabilityBus
     Emitter <|.. EventsBus
     Emitter <|.. MemoryBus
     note for CapabilityBus "redisstore.CapabilityBus<br/>capability-shaped + sub-shaped<br/>over per-method channels"
@@ -159,8 +159,8 @@ classDiagram
 ```mermaid
 flowchart TB
     Broadcast["Server.Broadcast(ctx, method, params)"]
-    HasRelay{Has<br/>BroadcastRelay?}
-    Publish["relay.PublishBroadcast(ctx, method, params)"]
+    HasRelay{Has<br/>NotificationRelay?}
+    Publish["relay.Publish(ctx, method, params)"]
     BroadcastToSessions["Server.BroadcastToSessions"]
     Sessions["Local session broadcasters"]
 
@@ -170,28 +170,28 @@ flowchart TB
     BroadcastToSessions --> Sessions
 ```
 
-`Broadcast` always fires `BroadcastToSessions`. The relay's `PublishBroadcast` runs ALSO when a relay is installed. There's no else branch — local fan-out is universal.
+`Broadcast` always fires `BroadcastToSessions`. The relay's `Publish` runs ALSO when a relay is installed. There's no else branch — local fan-out is universal.
 
 `BroadcastToSessions` is the **local-only** path. The receive side of Pattern B calls this (NOT `Broadcast`) so a cross-replica relay receive doesn't re-publish through the relay and loop.
 
-### `BroadcastRelay` — publish side
+### `NotificationRelay` — publish side
 
 ```mermaid
 sequenceDiagram
     participant H as Handler
     participant S as Server
-    participant R as BroadcastRelay
+    participant R as NotificationRelay
     participant T as Transport
 
     H->>S: Broadcast(method, params)
-    S->>R: PublishBroadcast(method, params)
+    S->>R: Publish(method, params)
     R->>T: encode + send
     Note over R,T: Origin marker stamped<br/>inside transport adapter
     S->>S: BroadcastToSessions(method, params)
     Note right of S: local delivery happens regardless<br/>of relay errors (fire-and-forget)
 ```
 
-`BroadcastRelay` is fire-and-forget — errors are not surfaced. Transports log internally if a publish fails; local fan-out still runs.
+`NotificationRelay` is fire-and-forget — errors are not surfaced. Transports log internally if a publish fails; local fan-out still runs.
 
 ### `NotificationRelayReceiver` — receive side
 
@@ -202,20 +202,20 @@ sequenceDiagram
     participant Local as Local delivery
 
     Note over T: Decode message,<br/>check origin marker,<br/>drop if self-publish
-    T->>Recv: ReceiveRelay(method, params)
+    T->>Recv: Receive(method, params)
     Recv->>Local: domain-specific routing<br/>(BroadcastToSessions / notifyLocal / LocalDeliver)
 ```
 
 The receiver is the **routing decision** for cross-replica notifications. The transport handles dedup; the receiver decides what to do with each message destined for this replica.
 
-### `MultiplexRelayReceiver` — per-method dispatch
+### `NotificationRouter` — per-method dispatch
 
 ```mermaid
 flowchart TB
-    Receive["ReceiveRelay(ctx, method, params)"]
+    Receive["Receive(ctx, method, params)"]
     Lookup{handlers<br/>contains<br/>method?}
     Drop["drop silently"]
-    Forward["handler.ReceiveRelay(ctx, method, params)"]
+    Forward["handler.Receive(ctx, method, params)"]
 
     Receive --> Lookup
     Lookup -->|no| Drop
@@ -225,7 +225,7 @@ flowchart TB
 Multiplexer adopters wire one Bus + one multiplexer + multiple per-method receivers:
 
 ```go
-mux := server.NewMultiplexRelayReceiver().
+mux := server.NewNotificationRouter().
     Handle("notifications/tools/list_changed",        server.NewCapabilityBroadcastReceiver(srv)).
     Handle("notifications/resources/list_changed",    server.NewCapabilityBroadcastReceiver(srv)).
     Handle("notifications/prompts/list_changed",      server.NewCapabilityBroadcastReceiver(srv)).
@@ -242,7 +242,7 @@ sequenceDiagram
     participant Srv as Server
     participant Sess as Local sessions
 
-    Bus->>Recv: ReceiveRelay(method, params)
+    Bus->>Recv: Receive(method, params)
     Recv->>Srv: BroadcastToSessions(method, params)
     Srv->>Sess: notify(method, params)
     Note over Recv,Srv: BroadcastToSessions, NOT Broadcast<br/>(would loop through the relay)
@@ -258,7 +258,7 @@ sequenceDiagram
     participant Reg as subscriptionRegistry
     participant Sub as Subscribed sessions
 
-    Bus->>Recv: ReceiveRelay("notifications/resources/updated", params)
+    Bus->>Recv: Receive("notifications/resources/updated", params)
     Note right of Recv: extract URI from params<br/>(typed or map shape)
     Recv->>Srv: NotifyResourceUpdatedLocal(uri)
     Srv->>Reg: notifyLocal(uri)
@@ -266,7 +266,7 @@ sequenceDiagram
     Note over Reg,Sub: notifyLocal does NOT re-publish<br/>via the relay (no loop)
 ```
 
-### `YieldingSource.ReceiveRelay` — subscription-shaped routing for events
+### `YieldingSource.Receive` — subscription-shaped routing for events
 
 ```mermaid
 sequenceDiagram
@@ -274,7 +274,7 @@ sequenceDiagram
     participant Src as YieldingSource
     participant Slots as Local subscriber slots
 
-    Bus->>Src: ReceiveRelay("notifications/events/event", event)
+    Bus->>Src: Receive("notifications/events/event", event)
     Note right of Src: params.(Event) type-assert<br/>defensive guard
     Src->>Src: LocalDeliver(ctx, event)
     loop for each slot
@@ -287,13 +287,13 @@ sequenceDiagram
     end
 ```
 
-`YieldingSource.ReceiveRelay` is a thin adapter; `LocalDeliver` is the work — runs the per-slot fanout loop without firing the configured `Emitter` (so no re-publish).
+`YieldingSource.Receive` is a thin adapter; `LocalDeliver` is the work — runs the per-slot fanout loop without firing the configured `Emitter` (so no re-publish).
 
 ### `redisstore.CapabilityBus` — capability-shaped Pattern B
 
 ```mermaid
 flowchart LR
-    subgraph "PublishBroadcast (origin)"
+    subgraph "Publish (origin)"
         P1[method + params]
         P2["envelope: {origin, params}"]
         P3[Codec.Encode]
@@ -306,7 +306,7 @@ flowchart LR
         S2[Codec.Decode envelope]
         S3{origin == self?}
         S4[drop]
-        S5[receiver.ReceiveRelay]
+        S5[receiver.Receive]
         S1 --> S2 --> S3
         S3 -->|yes| S4
         S3 -->|no| S5
@@ -333,7 +333,7 @@ flowchart LR
         S3{"event.Meta[origin] == self?"}
         S4[drop]
         S5["strip origin marker from Meta"]
-        S6["receiver.ReceiveRelay(method, event)"]
+        S6["receiver.Receive(method, event)"]
         S1 --> S2 --> S3
         S3 -->|yes| S4
         S3 -->|no| S5 --> S6
@@ -348,11 +348,11 @@ Wire format: per-event-name channel `<ChannelPrefix>.<event.Name>`. Payload is t
 flowchart LR
     subgraph Bus_A
         Emit_A[Emit] --> Pub_A[hub.publish]
-        Run_A[Run loop] --> Recv_A[ReceiveRelay]
+        Run_A[Run loop] --> Recv_A[Receive]
     end
     subgraph Bus_B
         Emit_B[Emit] --> Pub_B[hub.publish]
-        Run_B[Run loop] --> Recv_B[ReceiveRelay]
+        Run_B[Run loop] --> Recv_B[Receive]
     end
     Hub[(memorystore.Hub<br/>shared chan-based bus)]
     Pub_A --> Hub
@@ -377,21 +377,21 @@ sequenceDiagram
     participant Bus as CapabilityBus (K1)
     participant Redis as Redis pubsub
     participant Bus2 as CapabilityBus (K2)
-    participant Mux as MultiplexRelayReceiver (K2)
+    participant Mux as NotificationRouter (K2)
     participant Cap as CapabilityBroadcastReceiver (K2)
     participant Srv2 as Server (K2)
     participant Cli2 as Client on K2
 
     App->>Reg: AddTool(...)
     Reg->>Srv: OnChange("notifications/tools/list_changed")
-    Srv->>Bus: PublishBroadcast(method, nil)
+    Srv->>Bus: Publish(method, nil)
     Bus->>Redis: PUBLISH (envelope with K1 origin)
     Srv->>Srv: BroadcastToSessions (K1 local clients hear)
 
     Redis->>Bus2: deliver message
     Note over Bus2: origin == K2's marker? no — proceed
-    Bus2->>Mux: ReceiveRelay(method, nil)
-    Mux->>Cap: handlers["...list_changed"].ReceiveRelay
+    Bus2->>Mux: Receive(method, nil)
+    Mux->>Cap: handlers["...list_changed"].Receive
     Cap->>Srv2: BroadcastToSessions(method, nil)
     Srv2->>Cli2: notify("notifications/tools/list_changed", nil)
 ```
@@ -409,7 +409,7 @@ sequenceDiagram
     participant Bus as CapabilityBus (K1)
     participant Redis as Redis pubsub
     participant Bus2 as CapabilityBus (K2)
-    participant Mux as MultiplexRelayReceiver (K2)
+    participant Mux as NotificationRouter (K2)
     participant Rur as ResourcesUpdatedReceiver (K2)
     participant Srv2 as Server (K2)
     participant SubReg2 as subscriptionRegistry (K2)
@@ -418,12 +418,12 @@ sequenceDiagram
     App->>Srv: NotifyResourceUpdated("file:///x")
     Srv->>SubReg: notify("file:///x")
     SubReg->>SubReg: notifyLocal("file:///x")<br/>(K1 local subscribers hear)
-    SubReg->>Bus: PublishBroadcast(method, ResourceUpdatedNotification{URI:"file:///x"})
+    SubReg->>Bus: Publish(method, ResourceUpdatedNotification{URI:"file:///x"})
     Bus->>Redis: PUBLISH (envelope with K1 origin)
 
     Redis->>Bus2: deliver message
-    Bus2->>Mux: ReceiveRelay(method, params)
-    Mux->>Rur: handlers["resources/updated"].ReceiveRelay
+    Bus2->>Mux: Receive(method, params)
+    Mux->>Rur: handlers["resources/updated"].Receive
     Rur->>Rur: extract URI from params
     Rur->>Srv2: NotifyResourceUpdatedLocal("file:///x")
     Srv2->>SubReg2: notifyLocal("file:///x")
@@ -453,7 +453,7 @@ sequenceDiagram
 
     Redis->>Bus2: deliver message
     Note over Bus2: origin == K2's marker? no — proceed<br/>strip origin marker from Meta
-    Bus2->>Src2: ReceiveRelay("notifications/events/event", event)
+    Bus2->>Src2: Receive("notifications/events/event", event)
     Src2->>Src2: LocalDeliver(ctx, event)
     loop for each K2 slot
         Src2->>Slots2: EventDef.Match(slot, event)?
@@ -473,7 +473,7 @@ The per-surface sequence diagrams above show the high-level flow. Below are the 
 
 ### Life of `notifications/tools/list_changed` (capability-shaped, N=3)
 
-Setup: replica K1 has `WithBroadcastRelay(busK1)` installed; replica K2 has `WithBroadcastRelay(busK2)`. Both Buses subscribed to `notifications/tools/list_changed`. A client `cliK2` is connected to K2 via Streamable HTTP. App code on K1 calls `srv.RegisterTool`.
+Setup: replica K1 has `WithNotificationRelay(busK1)` installed; replica K2 has `WithNotificationRelay(busK2)`. Both Buses subscribed to `notifications/tools/list_changed`. A client `cliK2` is connected to K2 via Streamable HTTP. App code on K1 calls `srv.RegisterTool`.
 
 ```
 [K1]  app: srv.RegisterTool(def, handler)                                 server.go:649
@@ -485,8 +485,8 @@ Setup: replica K1 has `WithBroadcastRelay(busK1)` installed; replica K2 has `Wit
                 (closure installed in NewServer wires OnChange →)
                 s.Broadcast(ctx, "notifications/tools/list_changed", nil)  server.go:562
                   if relay != nil:
-                    relay.PublishBroadcast(ctx, method, nil)               server.go:1007
-                      ──> redisstore.CapabilityBus.PublishBroadcast        capability_bus.go:129
+                    relay.Publish(ctx, method, nil)               server.go:1007
+                      ──> redisstore.CapabilityBus.Publish        capability_bus.go:132
                             encodeCapabilityEnvelope(b.originID, params)   capability_bus.go:225
                               json.Marshal({"origin": "<K1>", "params": null})
                             b.client.Publish(ctx, channel, body)           ──> Redis
@@ -505,16 +505,16 @@ Setup: replica K1 has `WithBroadcastRelay(busK1)` installed; replica K2 has `Wit
 
 [Redis]   PUBLISH "mcpkit.events.broadcast.notifications/tools/list_changed" → fanout to all SUBSCRIBE'd clients
 
-[K2]  redisstore.CapabilityBus.Run goroutine reading pubsub channel       capability_bus.go:170
+[K2]  redisstore.CapabilityBus.Run goroutine reading pubsub channel       capability_bus.go:175
         decodeCapabilityEnvelope(msg.Payload)                              capability_bus.go:241
           json.Unmarshal → envelope{origin: "<K1>", params: nil}
-        if envelope.origin == b.originID (== "<K2>"): drop  ── NOT self    capability_bus.go:184
-        receiver.ReceiveRelay(ctx, method, nil)                            capability_bus.go:188
-          ──> MultiplexRelayReceiver.ReceiveRelay                          relay.go:282
+        if envelope.origin == b.originID (== "<K2>"): drop  ── NOT self    capability_bus.go:209
+        receiver.Receive(ctx, method, nil)                            capability_bus.go:188
+          ──> NotificationRouter.Receive                          relay.go:240
                 h := handlers["notifications/tools/list_changed"]
-                h.ReceiveRelay(ctx, method, nil)
-                  ──> CapabilityBroadcastReceiver.ReceiveRelay             relay.go:138
-                        srv.BroadcastToSessions(ctx, method, nil)          relay.go:144
+                h.Receive(ctx, method, nil)
+                  ──> CapabilityBroadcastReceiver.Receive             relay.go:141
+                        srv.BroadcastToSessions(ctx, method, nil)          relay.go:142
                           ── NOTE: BroadcastToSessions, NOT Broadcast
                           ── (otherwise would re-fire relay and loop)
                         for bc in s.sessionBroadcasters:
@@ -536,10 +536,10 @@ Key landmarks:
 |---|---|---|
 | `r.notify` → `OnChange` → `s.Broadcast` | Registry mutation triggers Broadcast | `server.go:562` (wired in `NewServer`) |
 | `s.Broadcast` forks publish + local | Single call, two paths | `server.go:1007`, `:1009` |
-| `relay.PublishBroadcast` | Outbound transport hop | `capability_bus.go:129` |
-| Self-publish drop on receive | `envelope.origin == b.originID` | `capability_bus.go:184` |
-| Receiver routes by method | `MultiplexRelayReceiver.handlers[method]` | `relay.go:282` |
-| Final hop: receiver → `BroadcastToSessions` | **Not** `Broadcast` (recursion guard) | `relay.go:144` |
+| `relay.Publish` | Outbound transport hop | `capability_bus.go:132` |
+| Self-publish drop on receive | `envelope.origin == b.originID` | `capability_bus.go:209` |
+| Receiver routes by method | `NotificationRouter.handlers[method]` | `relay.go:240` |
+| Final hop: receiver → `BroadcastToSessions` | **Not** `Broadcast` (recursion guard) | `relay.go:142` |
 
 ### Life of `notifications/events/event` (subscription-shaped, N=3, tenant scoping)
 
@@ -578,9 +578,9 @@ Setup: 3 replicas wired with a `redisstore.Bus` per replica (separate from the c
           ── K1's marker is "<K1>", envelope's origin is "<K3>" → proceed
         event.Meta = stripOriginIDFromMeta(event.Meta)                     subscriber.go:156
         s.deliver(msgCtx, event)
-          ──> Bus's wrapper that calls receiver.ReceiveRelay               bus.go:78
-                receiver.ReceiveRelay(ctx, "notifications/events/event", event)
-                  ──> chatSrc.ReceiveRelay  (YieldingSource[payload])       yield.go:454
+          ──> Bus's wrapper that calls receiver.Receive               bus.go:78
+                receiver.Receive(ctx, "notifications/events/event", event)
+                  ──> chatSrc.Receive  (YieldingSource[payload])       yield.go:454
                         if method != "notifications/events/event": return
                         ev, ok := params.(Event)
                         if !ok: return
@@ -608,7 +608,7 @@ Setup: 3 replicas wired with a `redisstore.Bus` per replica (separate from the c
         Codec.Decode(msg.Payload) → event (origin "<K3>")
         skipOriginID is "<K2>" → proceed
         strip origin marker
-        receiver.ReceiveRelay → chatSrc.ReceiveRelay → s.LocalDeliver
+        receiver.Receive → chatSrc.Receive → s.LocalDeliver
           for sub in subs:
             ── sub.principal = "babylon" (bob's claims)
             ── matched := tenantMatch(ctx, event, ...)
@@ -629,7 +629,7 @@ Key landmarks:
 | Origin marker stamped onto `event.Meta` | Self-publish dedup mechanism | `origin.go:55` |
 | Self-publish drop on receive (origin == self) | Origin replica's own Subscriber drops | `subscriber.go:147` |
 | Strip origin marker | Adopters never see it | `subscriber.go:156` |
-| `chatSrc.ReceiveRelay` → `LocalDeliver` | Cross-replica → local fanout entry | `yield.go:454, :476` |
+| `chatSrc.Receive` → `LocalDeliver` | Cross-replica → local fanout entry | `yield.go:454, :476` |
 | `LocalDeliver` for-loop on local slots | per-slot Match runs HERE (receiving replica) too | `yield.go:439` (mirror of origin's path) |
 | `tenantMatch` per slot | The filter that drops babylon for asgard event | adopter's `EventDef.Match` |
 | Stream handler reads slot channel + `ctx.Notify` | SSE frame to client | `stream.go:331, :404` |
@@ -676,7 +676,7 @@ sequenceDiagram
     Src3->>Bus3: Emit(ctx, event)
     Bus3->>Redis: PUBLISH
     Redis->>Bus1: deliver
-    Bus1->>Src1: ReceiveRelay → LocalDeliver
+    Bus1->>Src1: Receive → LocalDeliver
     Src1->>Cli1: deliver (Match passes)
 ```
 
@@ -720,12 +720,12 @@ sequenceDiagram
     Bus3->>Redis: PUBLISH
     par K1 receives
         Redis->>Bus1: deliver
-        Bus1->>SrcA: ReceiveRelay → LocalDeliver
+        Bus1->>SrcA: Receive → LocalDeliver
         Note over SrcA: per-slot Match: principal="asgard"<br/>vs payload.tenant="asgard" → MATCH
         SrcA->>SrcA: deliver to asgard streamer
     and K2 receives
         Redis->>Bus2: deliver
-        Bus2->>SrcB: ReceiveRelay → LocalDeliver
+        Bus2->>SrcB: Receive → LocalDeliver
         Note over SrcB: per-slot Match: principal="babylon"<br/>vs payload.tenant="asgard" → DROP
     end
 ```
@@ -809,7 +809,7 @@ _ = bus.Subscribe(ctx,
 go bus.Run(ctx)
 
 // Now srv.Broadcast / Registry.OnChange notifications fan across replicas.
-srv := server.NewServer(info, server.WithBroadcastRelay(bus))
+srv := server.NewServer(info, server.WithNotificationRelay(bus))
 ```
 
 ### Events SDK only (events/event)
@@ -834,11 +834,11 @@ events.Register(cfg)
 
 ### Mixed — all 5 surfaces
 
-When your server uses both catalog notifications AND `resources/updated` AND events. Wire one `redisstore.CapabilityBus` + `MultiplexRelayReceiver` for the server-side notifications, and a separate `redisstore.Bus` for events (events have a different wire format):
+When your server uses both catalog notifications AND `resources/updated` AND events. Wire one `redisstore.CapabilityBus` + `NotificationRouter` for the server-side notifications, and a separate `redisstore.Bus` for events (events have a different wire format):
 
 ```go
 // Server-side capability + subscription-shaped (3 list_changed + resources/updated)
-mux := server.NewMultiplexRelayReceiver().
+mux := server.NewNotificationRouter().
     Handle("notifications/tools/list_changed",     server.NewCapabilityBroadcastReceiver(srv)).
     Handle("notifications/resources/list_changed", server.NewCapabilityBroadcastReceiver(srv)).
     Handle("notifications/prompts/list_changed",   server.NewCapabilityBroadcastReceiver(srv)).
@@ -861,7 +861,7 @@ _ = eventsBus.Subscribe(ctx, "chat.message")
 go eventsBus.Run(ctx)
 cfg.Emitter = eventsBus
 
-srv := server.NewServer(info, server.WithBroadcastRelay(capBus))
+srv := server.NewServer(info, server.WithNotificationRelay(capBus))
 events.Register(cfg)
 ```
 
@@ -870,10 +870,10 @@ events.Register(cfg)
 For Kafka / NATS / SNS adopters writing their own transport:
 
 ```go
-// Implement server.BroadcastRelay for the publish side:
+// Implement server.NotificationRelay for the publish side:
 type MyKafkaBus struct{ ... }
 
-func (b *MyKafkaBus) PublishBroadcast(ctx context.Context, method string, params any) {
+func (b *MyKafkaBus) Publish(ctx context.Context, method string, params any) {
     // 1. Encode (method, params) into your wire format with origin marker
     // 2. Publish to Kafka topic
     // 3. Errors are fire-and-forget — log internally
@@ -884,7 +884,7 @@ func (b *MyKafkaBus) Run(ctx context.Context) error {
     for msg := range b.consumer.Consume(ctx) {
         // 1. Decode message
         // 2. Check origin marker — drop if matches b.originID
-        // 3. b.receiver.ReceiveRelay(ctx, method, params)
+        // 3. b.receiver.Receive(ctx, method, params)
     }
 }
 ```
@@ -903,7 +903,7 @@ For most adopters this is fine: list_changed notifications are advisory; the nex
 
 ### Not at-least-once
 
-Redis pubsub does NOT persist messages. A replica that's offline when a publish happens misses the message permanently. If your application semantics require at-least-once delivery (e.g., billing events), use a persistent transport (Redis Streams, Kafka with consumer groups) — the `BroadcastRelay` + `NotificationRelayReceiver` shapes accommodate either, but the reference `redisstore.CapabilityBus` uses pubsub specifically.
+Redis pubsub does NOT persist messages. A replica that's offline when a publish happens misses the message permanently. If your application semantics require at-least-once delivery (e.g., billing events), use a persistent transport (Redis Streams, Kafka with consumer groups) — the `NotificationRelay` + `NotificationRelayReceiver` shapes accommodate either, but the reference `redisstore.CapabilityBus` uses pubsub specifically.
 
 For events, the `EventBufferStore` + `events/poll` path gives at-least-once for clients that opt in.
 
@@ -933,7 +933,7 @@ Two-method API on `Server`:
 | Method | Fires relay? | Fires local sessions? | Who calls it? |
 |---|---|---|---|
 | `Broadcast` | yes (if installed) | yes | application code, `Registry.OnChange` |
-| `BroadcastToSessions` | no | yes | `CapabilityBroadcastReceiver.ReceiveRelay` (the receive side of Pattern B) |
+| `BroadcastToSessions` | no | yes | `CapabilityBroadcastReceiver.Receive` (the receive side of Pattern B) |
 
 The split exists to break the recursion that would happen if the receive side called `Broadcast` (which would re-publish via the relay → receive again → publish again → loop). If you're writing a custom capability-shaped receiver, you MUST call `BroadcastToSessions`, not `Broadcast`.
 
@@ -942,7 +942,7 @@ Symmetric split exists on `subscriptionRegistry`:
 | Method | Fires relay? | Fires local subscribers? | Who calls it? |
 |---|---|---|---|
 | `notify` | yes (if installed) | yes (via `notifyLocal`) | `Server.NotifyResourceUpdated`, internal callers |
-| `notifyLocal` | no | yes | `ResourcesUpdatedReceiver.ReceiveRelay`, `Server.NotifyResourceUpdatedLocal` |
+| `notifyLocal` | no | yes | `ResourcesUpdatedReceiver.Receive`, `Server.NotifyResourceUpdatedLocal` |
 
 Same recursion guard. Custom subscription-shaped receivers call `notifyLocal` (via `Server.NotifyResourceUpdatedLocal`), not `notify`.
 
@@ -950,18 +950,18 @@ Same recursion guard. Custom subscription-shaped receivers call `notifyLocal` (v
 
 | Concept | File |
 |---|---|
-| `BroadcastRelay` interface | `server/relay.go` |
+| `NotificationRelay` interface | `server/relay.go` |
 | `NotificationRelayReceiver` interface | `server/relay.go` |
 | `CapabilityBroadcastReceiver` | `server/relay.go` |
 | `ResourcesUpdatedReceiver` | `server/relay.go` |
-| `MultiplexRelayReceiver` | `server/relay.go` |
+| `NotificationRouter` | `server/relay.go` |
 | `Server.Broadcast` / `BroadcastToSessions` | `server/server.go` |
 | `subscriptionRegistry.notify` / `notifyLocal` | `server/server.go` |
-| `WithBroadcastRelay` option | `server/relay.go` |
+| `WithNotificationRelay` option | `server/relay.go` |
 | `redisstore.CapabilityBus` | `experimental/ext/events/stores/redis/capability_bus.go` |
 | `redisstore.Bus` (events) | `experimental/ext/events/stores/redis/bus.go` |
 | `memorystore.Bus` + `Hub` | `experimental/ext/events/stores/memory/bus.go` |
-| `YieldingSource.LocalDeliver` / `ReceiveRelay` | `experimental/ext/events/yield.go` |
+| `YieldingSource.LocalDeliver` / `Receive` | `experimental/ext/events/yield.go` |
 
 ## Test coverage
 
@@ -969,8 +969,8 @@ Pattern B's contracts are covered by `-race`-clean tests at every layer. Referen
 
 | Layer | Tests |
 |---|---|
-| Server-level primitives | `server/relay_test.go` (15 tests covering `CapabilityBroadcastReceiver`, `ResourcesUpdatedReceiver`, `MultiplexRelayReceiver`, subscriptionRegistry split) |
+| Server-level primitives | `server/relay_test.go` (15 tests covering `CapabilityBroadcastReceiver`, `ResourcesUpdatedReceiver`, `NotificationRouter`, subscriptionRegistry split) |
 | In-memory broadcast harness | `server/relay_inmemory_test.go` (5 tests: split semantics, fan-out, self-publish dedup, no-relay backwards compat, N×T matrix) |
 | Wiring for 5 surfaces | `server/listchanged_relay_test.go` (3 tests covering all 4 list_changed paths + resources/updated end-to-end) |
 | Events multi-replica | `experimental/ext/events/stores/memory/multi_replica_test.go` (5 tests: tenant scoping, self-publish dedup, N×T×M matrix, leave-mid-flight, high concurrency stress) |
-| Redis CapabilityBus round-trip | `experimental/ext/events/stores/redis/capability_bus_test.go` (3 tests: cross-replica round-trip, single-bus self-dedup, full WithBroadcastRelay end-to-end via miniredis) |
+| Redis CapabilityBus round-trip | `experimental/ext/events/stores/redis/capability_bus_test.go` (3 tests: cross-replica round-trip, single-bus self-dedup, full WithNotificationRelay end-to-end via miniredis) |

--- a/examples/whole-enchilada/events/event-server/redis.go
+++ b/examples/whole-enchilada/events/event-server/redis.go
@@ -59,7 +59,7 @@ type redisBackend struct {
 	done   chan struct{}
 	// registry is populated by the caller AFTER events.Register returns
 	// — the router closure dereferences this to look up the source for
-	// ReceiveRelay routing. nil until SetRegistry runs; receives that
+	// Receive routing. nil until SetRegistry runs; receives that
 	// arrive before then are dropped (acceptable: yields can't happen
 	// yet because the source handlers aren't installed).
 	registry *events.Registry
@@ -242,7 +242,7 @@ func configureRedisBackend(cfg *events.Config, srv *server.Server, webhooks *eve
 
 // registryRouter implements server.NotificationRelayReceiver by looking
 // up the destination YieldingSource on the registry and forwarding to
-// its own ReceiveRelay. The lookup runs on every cross-replica event
+// its own Receive. The lookup runs on every cross-replica event
 // because rb.registry only becomes available AFTER events.Register
 // returns (the registry doesn't exist at configureRedisBackend time).
 // Events that arrive before SetRegistry has been called are silently
@@ -251,7 +251,7 @@ type registryRouter struct {
 	rb *redisBackend
 }
 
-func (r *registryRouter) ReceiveRelay(ctx context.Context, method string, params any) {
+func (r *registryRouter) Receive(ctx context.Context, method string, params any) {
 	if r.rb.registry == nil {
 		return
 	}
@@ -271,5 +271,5 @@ func (r *registryRouter) ReceiveRelay(ctx context.Context, method string, params
 		// the origin replica's EmitToWebhooks; only push misses out.
 		return
 	}
-	nrr.ReceiveRelay(ctx, method, params)
+	nrr.Receive(ctx, method, params)
 }

--- a/experimental/ext/events/README.md
+++ b/experimental/ext/events/README.md
@@ -308,7 +308,7 @@ For private-cloud / WAF-fronted deployments, see [`DEPLOYMENT.md`](DEPLOYMENT.md
 
 `notifications/events/event` is one of five server-pushed notification surfaces that silently break at N>1 (multiple server replicas) without explicit Pattern B wiring. The events SDK's `YieldingSource` implements `server.NotificationRelayReceiver` so the receive side of Pattern B routes through its slot system on every replica — per-slot `EventDef.Match` runs the same as for a local yield, preserving tenant scoping and per-subscription filters.
 
-The full architecture (Pattern B, `redisstore.Bus` / `redisstore.CapabilityBus`, the `MultiplexRelayReceiver` recipe, per-surface end-to-end flows) lives in [`docs/MULTI_REPLICA.md`](../../../docs/MULTI_REPLICA.md). The configuration recipe for events specifically:
+The full architecture (Pattern B, `redisstore.Bus` / `redisstore.CapabilityBus`, the `NotificationRouter` recipe, per-surface end-to-end flows) lives in [`docs/MULTI_REPLICA.md`](../../../docs/MULTI_REPLICA.md). The configuration recipe for events specifically:
 
 ```go
 import (

--- a/experimental/ext/events/STORAGE_SEAMS.md
+++ b/experimental/ext/events/STORAGE_SEAMS.md
@@ -108,7 +108,7 @@ The other seams (626, 631) follow this template. Reviews check against this file
 | Interface | Concern | Status |
 |---|---|---|
 | `Emitter` | Output-side seam: "given an event, deliver it." Dual of `EventSource`. Default `NewLocalEmitter` matches today's single-replica behavior; multi-replica deployments use a transport-specific `Bus` (see Pattern B below) as `cfg.Emitter`. | landed (629) |
-| `server.NotificationRelayReceiver` | Routing seam for cross-replica notification delivery. Transport adapters call `ReceiveRelay(ctx, method, params)` on every received notification destined for this replica. Implementations are domain-specific: `server.CapabilityBroadcastReceiver` forwards to `Server.Broadcast` for catalog notifications (tools/list_changed etc.); `events.YieldingSource` routes via per-slot fanout so per-subscription `EventDef.Match` runs. | landed (755) |
+| `server.NotificationRelayReceiver` | Routing seam for cross-replica notification delivery. Transport adapters call `Receive(ctx, method, params)` on every received notification destined for this replica. Implementations are domain-specific: `server.CapabilityBroadcastReceiver` forwards to `Server.Broadcast` for catalog notifications (tools/list_changed etc.); `events.YieldingSource` routes via per-slot fanout so per-subscription `EventDef.Match` runs. | landed (755) |
 
 `Emitter` and `NotificationRelayReceiver` are not storage seams (they don't persist anything), but follow the same `ctx`-first method shape and live in their own files per the same conventions. Listed here so future readers see the full set of seams in one place.
 

--- a/experimental/ext/events/stores/memory/bus.go
+++ b/experimental/ext/events/stores/memory/bus.go
@@ -201,7 +201,7 @@ func (b *Bus) Run(ctx context.Context) error {
 			if !subscribed {
 				continue
 			}
-			b.receiver.ReceiveRelay(ctx, EventMethodName, f.event)
+			b.receiver.Receive(ctx, EventMethodName, f.event)
 		}
 	}
 }

--- a/experimental/ext/events/stores/redis/README.md
+++ b/experimental/ext/events/stores/redis/README.md
@@ -3,7 +3,7 @@
 Cross-replica fanout for MCP server-pushed notifications via Redis pubsub. Provides two Bus types:
 
 - **`redisstore.Bus`** — events-typed Pattern B transport. Implements `events.Emitter`; routes received events through a `server.NotificationRelayReceiver` (typically `events.YieldingSource` or an adapter wrapping a registry).
-- **`redisstore.CapabilityBus`** — `(method, params)`-typed Pattern B transport. Implements `server.BroadcastRelay`; carries capability-shaped notifications (`tools/list_changed`, `resources/list_changed`, `prompts/list_changed`) and the subscription-shaped `resources/updated` via a `server.MultiplexRelayReceiver`.
+- **`redisstore.CapabilityBus`** — `(method, params)`-typed Pattern B transport. Implements `server.NotificationRelay`; carries capability-shaped notifications (`tools/list_changed`, `resources/list_changed`, `prompts/list_changed`) and the subscription-shaped `resources/updated` via a `server.NotificationRouter`.
 
 Both Buses hide origin-marker self-publish dedup internally. Adopters wire `NewBus(opts, receiver)` (or `NewCapabilityBus`) and the round-trip is automatic.
 
@@ -38,7 +38,7 @@ import (
     redisstore "github.com/panyam/mcpkit/experimental/ext/events/stores/redis"
 )
 
-mux := server.NewMultiplexRelayReceiver().
+mux := server.NewNotificationRouter().
     Handle("notifications/tools/list_changed",     server.NewCapabilityBroadcastReceiver(srv)).
     Handle("notifications/resources/list_changed", server.NewCapabilityBroadcastReceiver(srv)).
     Handle("notifications/prompts/list_changed",   server.NewCapabilityBroadcastReceiver(srv)).
@@ -54,7 +54,7 @@ _ = bus.Subscribe(ctx,
 )
 go bus.Run(ctx)
 
-srv := server.NewServer(info, server.WithBroadcastRelay(bus))
+srv := server.NewServer(info, server.WithNotificationRelay(bus))
 ```
 
 ## Why Redis-only outbound (Pattern B)

--- a/experimental/ext/events/stores/redis/bus.go
+++ b/experimental/ext/events/stores/redis/bus.go
@@ -33,7 +33,7 @@ import (
 )
 
 // EventMethodName is the JSON-RPC method name redisstore.Bus uses when
-// invoking server.NotificationRelayReceiver.ReceiveRelay for events
+// invoking server.NotificationRelayReceiver.Receive for events
 // delivered via this transport. Exposed so adopters writing custom
 // receivers can switch on it without hard-coding the string.
 const EventMethodName = "notifications/events/event"
@@ -57,7 +57,7 @@ type Bus struct {
 // opts.Client is nil or the underlying Publisher / Subscriber
 // constructors fail.
 //
-// The receiver's ReceiveRelay is called with method = EventMethodName
+// The receiver's Receive is called with method = EventMethodName
 // and params = the decoded events.Event. Receivers implementing
 // domain-specific routing (events.YieldingSource via a thin adapter,
 // future ResourcesUpdatedRouter, etc.) type-assert params to their
@@ -75,7 +75,7 @@ func NewBus(opts Options, receiver server.NotificationRelayReceiver) (*Bus, erro
 	// before the receiver sees them.
 	opts.skipOriginID = pub.originID
 	sub, err := NewSubscriber(opts, func(ctx context.Context, event events.Event) error {
-		receiver.ReceiveRelay(ctx, EventMethodName, event)
+		receiver.Receive(ctx, EventMethodName, event)
 		return nil
 	})
 	if err != nil {

--- a/experimental/ext/events/stores/redis/capability_bus.go
+++ b/experimental/ext/events/stores/redis/capability_bus.go
@@ -7,8 +7,8 @@
 //
 // CapabilityBus is to capability-shaped notifications what Bus is to
 // events. Adopters wire one and:
-//   1. Install it on the Server via server.WithBroadcastRelay(bus).
-//      Server.Broadcast then fires PublishBroadcast on every call
+//   1. Install it on the Server via server.WithNotificationRelay(bus).
+//      Server.Broadcast then fires Publish on every call
 //      before running BroadcastToSessions locally — every replica's
 //      clients hear the notification.
 //   2. Call Subscribe + Run to start the receive side. On every
@@ -49,11 +49,11 @@ import (
 const CapabilityBusChannelInfix = "broadcast"
 
 // CapabilityBus is the Pattern B implementation for capability-shaped
-// notifications. Satisfies server.BroadcastRelay on the publish side
+// notifications. Satisfies server.NotificationRelay on the publish side
 // and wires a subscriber loop that drives server.BroadcastToSessions
 // on every cross-replica receive.
 //
-// Concurrency: PublishBroadcast is safe for concurrent calls.
+// Concurrency: Publish is safe for concurrent calls.
 // Subscribe / Run / Close should be called from a single goroutine
 // (typical pattern: Subscribe once with the method names you care
 // about, Run in a goroutine, Close on shutdown).
@@ -69,7 +69,7 @@ type CapabilityBus struct {
 	closed      bool
 }
 
-// capabilityEnvelope is the wire shape PublishBroadcast emits.
+// capabilityEnvelope is the wire shape Publish emits.
 // Receive side decodes back to (originID, params) so the origin
 // filter and the receiver dispatch both have what they need.
 type capabilityEnvelope struct {
@@ -123,13 +123,13 @@ func NewCapabilityBus(opts CapabilityBusOptions, receiver server.NotificationRel
 	}, nil
 }
 
-// PublishBroadcast implements server.BroadcastRelay. Encodes the
+// Publish implements server.NotificationRelay. Encodes the
 // notification into a capabilityEnvelope tagged with this bus's
 // origin marker and PUBLISHes on the per-method channel. Errors are
 // logged via opts.Logger (set on the underlying client's Options if
 // available) but not returned — Server.Broadcast is fire-and-forget
 // for the relay leg.
-func (b *CapabilityBus) PublishBroadcast(ctx context.Context, method string, params any) {
+func (b *CapabilityBus) Publish(ctx context.Context, method string, params any) {
 	body, err := encodeCapabilityEnvelope(b.originID, params)
 	if err != nil {
 		// Best-effort — adopters that care about publish reliability
@@ -210,7 +210,7 @@ func (b *CapabilityBus) Run(ctx context.Context) error {
 				continue
 			}
 			method := b.methodFor(msg.Channel)
-			b.receiver.ReceiveRelay(ctx, method, params)
+			b.receiver.Receive(ctx, method, params)
 		}
 	}
 }
@@ -267,5 +267,5 @@ func decodeCapabilityEnvelope(body []byte) (string, json.RawMessage, error) {
 	return env.Origin, env.Params, nil
 }
 
-// Compile-time check: CapabilityBus satisfies server.BroadcastRelay.
-var _ server.BroadcastRelay = (*CapabilityBus)(nil)
+// Compile-time check: CapabilityBus satisfies server.NotificationRelay.
+var _ server.NotificationRelay = (*CapabilityBus)(nil)

--- a/experimental/ext/events/stores/redis/capability_bus_test.go
+++ b/experimental/ext/events/stores/redis/capability_bus_test.go
@@ -30,7 +30,7 @@ func newTestRedis(t *testing.T) *redis.Client {
 	return cli
 }
 
-// recordingReceiver captures every ReceiveRelay call so the test can
+// recordingReceiver captures every Receive call so the test can
 // assert what reached the bus's receiver side.
 type recordingReceiver struct {
 	mu      sync.Mutex
@@ -42,7 +42,7 @@ type recordedFrame struct {
 	params json.RawMessage
 }
 
-func (r *recordingReceiver) ReceiveRelay(_ context.Context, method string, params any) {
+func (r *recordingReceiver) Receive(_ context.Context, method string, params any) {
 	raw, _ := params.(json.RawMessage)
 	r.mu.Lock()
 	r.frames = append(r.frames, recordedFrame{method: method, params: raw})
@@ -100,7 +100,7 @@ func TestCapabilityBus_RoundTrip_TwoReplicas(t *testing.T) {
 	// both subscribe loops register before we publish.
 	time.Sleep(50 * time.Millisecond)
 
-	busA.PublishBroadcast(ctx, "notifications/tools/list_changed", nil)
+	busA.Publish(ctx, "notifications/tools/list_changed", nil)
 
 	// busB's receiver must see exactly one frame (the cross-replica
 	// publish from A). busA's receiver must see ZERO frames (the
@@ -126,35 +126,35 @@ func TestCapabilityBus_SelfPublishDeduped(t *testing.T) {
 	go bus.Run(ctx)
 	time.Sleep(50 * time.Millisecond)
 
-	bus.PublishBroadcast(ctx, "notifications/tools/list_changed", nil)
+	bus.Publish(ctx, "notifications/tools/list_changed", nil)
 	time.Sleep(100 * time.Millisecond) // let any erroneous delivery fire
 
 	assert.Empty(t, recv.snapshot(), "single-bus publish must dedup via origin marker")
 }
 
-// TestCapabilityBus_WithBroadcastRelay_EndToEnd verifies the full
+// TestCapabilityBus_WithNotificationRelay_EndToEnd verifies the full
 // integration: two Servers, each with a CapabilityBus wired via
-// WithBroadcastRelay. Calling Server.Broadcast on one replica
+// WithNotificationRelay. Calling Server.Broadcast on one replica
 // triggers the other replica's BroadcastToSessions via the relay.
 //
 // We build the receiver + bus first using a placeholder srv, then
-// construct the real srv with WithBroadcastRelay pointing at the
+// construct the real srv with WithNotificationRelay pointing at the
 // bus, then swap the receiver's srv pointer to the real one via
-// SwapServer. This dance is needed because BroadcastRelay must be
+// SwapServer. This dance is needed because NotificationRelay must be
 // installed at NewServer time but the receiver references its srv
 // for BroadcastToSessions calls.
-func TestCapabilityBus_WithBroadcastRelay_EndToEnd(t *testing.T) {
+func TestCapabilityBus_WithNotificationRelay_EndToEnd(t *testing.T) {
 	cli := newTestRedis(t)
 	opts := redisstore.CapabilityBusOptions{Client: cli}
 
 	buildReplica := func(name string) (*server.Server, *recordingReceiver, *redisstore.CapabilityBus) {
 		// Wrap CapabilityBroadcastReceiver with a recording adapter
-		// so we can verify ReceiveRelay fires.
+		// so we can verify Receive fires.
 		recv := &recordingReceiver{}
 		bus, err := redisstore.NewCapabilityBus(opts, recv)
 		require.NoError(t, err)
 		srv := server.NewServer(core.ServerInfo{Name: name, Version: "0.0.1"},
-			server.WithBroadcastRelay(bus),
+			server.WithNotificationRelay(bus),
 		)
 		return srv, recv, bus
 	}
@@ -185,7 +185,7 @@ func TestCapabilityBus_WithBroadcastRelay_EndToEnd(t *testing.T) {
 	assert.Empty(t, recvA.snapshot(), "origin replica must drop self-publish at the bus layer")
 
 	// Sanity: the srv refs are non-nil so the type checker confirms
-	// WithBroadcastRelay installed the relay onto the server.
+	// WithNotificationRelay installed the relay onto the server.
 	_ = srvA
 	_ = srvB
 }

--- a/experimental/ext/events/yield.go
+++ b/experimental/ext/events/yield.go
@@ -415,7 +415,7 @@ func (s *YieldingSource[Data]) YieldTerminated(err EventDeliveryError) error {
 	return nil
 }
 
-// ReceiveRelay implements server.NotificationRelayReceiver — the
+// Receive implements server.NotificationRelayReceiver — the
 // routing seam Pattern B transports (redisstore.Bus and equivalents)
 // call on every cross-replica event received by this replica. Routes
 // to LocalDeliver after type-asserting params to Event; silently no-ops
@@ -425,7 +425,7 @@ func (s *YieldingSource[Data]) YieldTerminated(err EventDeliveryError) error {
 // Adopters writing a custom receiver to look up sources by event name
 // can wrap a Registry; this method assumes the receiver IS the source
 // and the caller has already routed by event.Name.
-func (s *YieldingSource[Data]) ReceiveRelay(ctx context.Context, method string, params any) {
+func (s *YieldingSource[Data]) Receive(ctx context.Context, method string, params any) {
 	if method != "notifications/events/event" {
 		return
 	}

--- a/server/listchanged_relay_test.go
+++ b/server/listchanged_relay_test.go
@@ -11,11 +11,11 @@ import (
 
 // TestListChanged_RelayFansAcrossReplicas verifies the four
 // list_changed notifications (tools, resources, prompts) wired
-// through Registry → Server.Broadcast → BroadcastRelay reach
+// through Registry → Server.Broadcast → NotificationRelay reach
 // sessions on every replica.
 //
 // Setup: 3 replicas wired to a shared memRelayBus (the in-memory
-// BroadcastRelay from relay_inmemory_test.go). Mutate the registry
+// NotificationRelay from relay_inmemory_test.go). Mutate the registry
 // on replica 0; assert all 3 replicas' captured frames recorded the
 // notification.
 //
@@ -66,7 +66,7 @@ func TestListChanged_RelayFansAcrossReplicas(t *testing.T) {
 
 			// All 3 replicas should see the notification — replica 0
 			// via its local BroadcastToSessions, replicas 1 + 2 via
-			// the relay → ReceiveRelay → BroadcastToSessions path.
+			// the relay → Receive → BroadcastToSessions path.
 			for _, r := range cluster.replicas {
 				r.waitForFrameCount(t, 1, time.Second)
 				frames := r.frames()
@@ -109,7 +109,7 @@ func TestListChanged_OnlyOneNotifyPerMutation(t *testing.T) {
 func TestResourcesUpdated_RelayFansAcrossReplicas(t *testing.T) {
 	// Build a custom cluster — captureCluster wires its receivers to
 	// CapabilityBroadcastReceiver; for resources/updated we need
-	// ResourcesUpdatedReceiver wrapped in a MultiplexRelayReceiver.
+	// ResourcesUpdatedReceiver wrapped in a NotificationRouter.
 	bus := newMemRelayBus()
 	type rep struct {
 		idx  int
@@ -124,11 +124,11 @@ func TestResourcesUpdated_RelayFansAcrossReplicas(t *testing.T) {
 		// the server reference.
 		var r rep
 		r.idx = i
-		mux := NewMultiplexRelayReceiver()
+		mux := NewNotificationRouter()
 		relay := bus.attachReplica(t, mux)
 		srv := NewServer(core.ServerInfo{Name: "rep", Version: "0.0.1"},
 			WithSubscriptions(),
-			WithBroadcastRelay(relay),
+			WithNotificationRelay(relay),
 		)
 		mux.Handle("notifications/resources/updated", NewResourcesUpdatedReceiver(srv))
 		r.srv = srv

--- a/server/relay.go
+++ b/server/relay.go
@@ -41,36 +41,36 @@ import (
 	"github.com/panyam/mcpkit/core"
 )
 
-// BroadcastRelay is the publish side of a Pattern B transport for
+// NotificationRelay is the publish side of a Pattern B transport for
 // capability-shaped notifications (notifications/tools/list_changed,
 // notifications/resources/list_changed, etc.). Adopters install one
-// via WithBroadcastRelay; Server.Broadcast then fires
-// PublishBroadcast(ctx, method, params) before the local
+// via WithNotificationRelay; Server.Broadcast then fires
+// Publish(ctx, method, params) before the local
 // BroadcastToSessions fan-out so the same notification reaches every
 // connected client across every replica.
 //
-// PublishBroadcast is fire-and-forget — Server.Broadcast does not
-// surface errors. Implementations log internally if a publish fails;
-// the local BroadcastToSessions fan-out still runs regardless.
+// Publish is fire-and-forget — Server.Broadcast does not surface
+// errors. Implementations log internally if a publish fails; the
+// local BroadcastToSessions fan-out still runs regardless.
 //
-// Concurrency: PublishBroadcast may be invoked from any goroutine that
-// calls Server.Broadcast (handlers, registry.OnChange, etc.).
-// Implementations must be safe for concurrent calls.
+// Concurrency: Publish may be invoked from any goroutine that calls
+// Server.Broadcast (handlers, registry.OnChange, etc.). Implementations
+// must be safe for concurrent calls.
 //
 // The receive-side wiring (a separate subscriber loop calling
 // Server.BroadcastToSessions on cross-replica receives) is the
 // transport adapter's responsibility. The reference Redis
 // implementation is redisstore.CapabilityBus, which satisfies
-// BroadcastRelay on the publish side AND drives BroadcastToSessions
+// NotificationRelay on the publish side AND drives BroadcastToSessions
 // on the subscribe side via a NotificationRelayReceiver wired
 // internally.
-type BroadcastRelay interface {
-	PublishBroadcast(ctx context.Context, method string, params any)
+type NotificationRelay interface {
+	Publish(ctx context.Context, method string, params any)
 }
 
 // NotificationRelayReceiver is the callback shape mcpkit expects from
 // a Pattern B transport's subscriber side. The transport adapter calls
-// ReceiveRelay once per cross-replica notification destined for this
+// Receive once per cross-replica notification destined for this
 // replica (i.e. after the transport's own self-publish filtering).
 //
 // Implementations are domain-specific:
@@ -78,22 +78,22 @@ type BroadcastRelay interface {
 //     catalog-mutation notifications.
 //   - events.YieldingSource routes via per-slot fanout so per-
 //     subscription Match / Transform run.
-//   - A future ResourcesUpdatedRouter (PR B) routes via the per-URI
-//     subscription set with prefix match.
+//   - ResourcesUpdatedReceiver routes via the per-URI subscription
+//     set with prefix match.
 //
-// Concurrency: ReceiveRelay may be invoked from any goroutine
-// (typically the transport's receive loop). Implementations must be
-// safe for concurrent calls.
+// Concurrency: Receive may be invoked from any goroutine (typically
+// the transport's receive loop). Implementations must be safe for
+// concurrent calls.
 type NotificationRelayReceiver interface {
-	ReceiveRelay(ctx context.Context, method string, params any)
+	Receive(ctx context.Context, method string, params any)
 }
 
-// WithBroadcastRelay installs a BroadcastRelay onto the Server.
-// Server.Broadcast then fires PublishBroadcast on the relay before
-// running BroadcastToSessions locally — every capability-shaped
-// notification (tools/list_changed, resources/list_changed,
-// prompts/list_changed, application-level broadcasts) reaches
-// connected clients across every replica in the deployment.
+// WithNotificationRelay installs a NotificationRelay onto the Server.
+// Server.Broadcast then fires Publish on the relay before running
+// BroadcastToSessions locally — every capability-shaped notification
+// (tools/list_changed, resources/list_changed, prompts/list_changed,
+// application-level broadcasts) reaches connected clients across every
+// replica in the deployment.
 //
 // Pair with a transport adapter's subscribe-side wiring that calls
 // Server.BroadcastToSessions on cross-replica receives (the reference
@@ -101,9 +101,9 @@ type NotificationRelayReceiver interface {
 //
 // Pass nil to disable the relay (default) — Server.Broadcast then
 // fires local-only, matching pre-Pattern-B behavior.
-func WithBroadcastRelay(relay BroadcastRelay) Option {
+func WithNotificationRelay(relay NotificationRelay) Option {
 	return func(o *serverOptions) {
-		o.broadcastRelay = relay
+		o.notificationRelay = relay
 	}
 }
 
@@ -113,7 +113,7 @@ func WithBroadcastRelay(relay BroadcastRelay) Option {
 // notification with the same shape (no per-subscription filter; every
 // connected client with the capability sees it).
 //
-// On ReceiveRelay it forwards to Server.Broadcast, which the
+// On Receive it forwards to Server.Broadcast, which the
 // per-transport session machinery fans out to every connected client
 // on this replica.
 type CapabilityBroadcastReceiver struct {
@@ -122,32 +122,32 @@ type CapabilityBroadcastReceiver struct {
 
 // NewCapabilityBroadcastReceiver constructs a CapabilityBroadcastReceiver
 // wired to srv. The transport adapter handles self-publish dedup
-// internally before invoking ReceiveRelay — adopters don't pass an
+// internally before invoking Receive — adopters don't pass an
 // origin marker here.
 func NewCapabilityBroadcastReceiver(srv *Server) *CapabilityBroadcastReceiver {
 	return &CapabilityBroadcastReceiver{srv: srv}
 }
 
-// ReceiveRelay implements NotificationRelayReceiver. Forwards to
+// Receive implements NotificationRelayReceiver. Forwards to
 // Server.BroadcastToSessions (NOT Server.Broadcast) with a background
 // context — calling Broadcast here would re-fire the installed
-// BroadcastRelay and loop indefinitely through the Pattern B
+// NotificationRelay and loop indefinitely through the Pattern B
 // transport. BroadcastToSessions delivers to local sessions only,
 // which is what the relay receive path needs.
 //
 // The relay is fire-and-forget at the notification level; the
 // transport's ctx cancellation belongs to the transport loop, not to
 // the broadcast fan-out on this replica.
-func (r *CapabilityBroadcastReceiver) ReceiveRelay(_ context.Context, method string, params any) {
+func (r *CapabilityBroadcastReceiver) Receive(_ context.Context, method string, params any) {
 	r.srv.BroadcastToSessions(context.Background(), method, params)
 }
 
 // ResourcesUpdatedReceiver is the reference NotificationRelayReceiver
 // for the subscription-shaped notifications/resources/updated. On
-// ReceiveRelay it extracts the URI from the payload and dispatches via
+// Receive it extracts the URI from the payload and dispatches via
 // Server.NotifyResourceUpdatedLocal — fires every locally-subscribed
 // session whose subscribe(URI) matches, WITHOUT re-publishing via the
-// BroadcastRelay (which would loop).
+// NotificationRelay (which would loop).
 //
 // Each replica's subscriptionRegistry independently filters by its
 // own per-URI subscriber set; clients subscribed via THIS replica's
@@ -165,12 +165,12 @@ func NewResourcesUpdatedReceiver(srv *Server) *ResourcesUpdatedReceiver {
 	return &ResourcesUpdatedReceiver{srv: srv}
 }
 
-// ReceiveRelay implements NotificationRelayReceiver. Expects params to
-// be a core.ResourceUpdatedNotification (the type
+// Receive implements NotificationRelayReceiver. Expects params to be a
+// core.ResourceUpdatedNotification (the type
 // subscriptionRegistry.notify publishes) — also accepts
 // map[string]any with a "uri" field for transports that decoded
 // generically. Unknown shapes are silently dropped.
-func (r *ResourcesUpdatedReceiver) ReceiveRelay(_ context.Context, method string, params any) {
+func (r *ResourcesUpdatedReceiver) Receive(_ context.Context, method string, params any) {
 	if method != "notifications/resources/updated" {
 		return
 	}
@@ -198,34 +198,34 @@ func uriFromUpdatedParams(params any) string {
 	return ""
 }
 
-// MultiplexRelayReceiver routes received notifications by method name
-// to per-method NotificationRelayReceivers. Adopters configure one
-// MultiplexRelayReceiver as the BroadcastRelay's receiver, registering
+// NotificationRouter routes received notifications by method name to
+// per-method NotificationRelayReceivers. Adopters configure one
+// NotificationRouter as the NotificationRelay's receiver, registering
 // per-method handlers (CapabilityBroadcastReceiver for catalog
 // notifications, ResourcesUpdatedReceiver for subscription-shaped
 // resources/updated, etc.). Methods without a registered handler are
 // dropped silently — appropriate for shared Pattern B transports where
 // not every replica subscribes to every method.
 //
-// Concurrency: Handle and ReceiveRelay are safe for concurrent use.
-// Routing decisions snapshot the dispatch table under a read lock so
-// in-flight notifications don't race with late registrations.
-type MultiplexRelayReceiver struct {
+// Concurrency: Handle and Receive are safe for concurrent use. Routing
+// decisions snapshot the dispatch table under a read lock so in-flight
+// notifications don't race with late registrations.
+type NotificationRouter struct {
 	mu       sync.RWMutex
 	handlers map[string]NotificationRelayReceiver
 }
 
-// NewMultiplexRelayReceiver constructs an empty multiplexer. Register
-// per-method handlers via Handle before installing the multiplexer on
-// a BroadcastRelay's receiver slot.
-func NewMultiplexRelayReceiver() *MultiplexRelayReceiver {
-	return &MultiplexRelayReceiver{handlers: map[string]NotificationRelayReceiver{}}
+// NewNotificationRouter constructs an empty router. Register
+// per-method handlers via Handle before installing the router on a
+// NotificationRelay's receiver slot.
+func NewNotificationRouter() *NotificationRouter {
+	return &NotificationRouter{handlers: map[string]NotificationRelayReceiver{}}
 }
 
 // Handle registers receiver as the handler for the given method.
-// Returns the multiplexer for chaining. A subsequent Handle call for
-// the same method replaces the previous handler.
-func (m *MultiplexRelayReceiver) Handle(method string, receiver NotificationRelayReceiver) *MultiplexRelayReceiver {
+// Returns the router for chaining. A subsequent Handle call for the
+// same method replaces the previous handler.
+func (m *NotificationRouter) Handle(method string, receiver NotificationRelayReceiver) *NotificationRouter {
 	if receiver == nil {
 		return m
 	}
@@ -235,15 +235,14 @@ func (m *MultiplexRelayReceiver) Handle(method string, receiver NotificationRela
 	return m
 }
 
-// ReceiveRelay implements NotificationRelayReceiver. Looks up the
-// per-method handler and forwards. Unknown methods are silently
-// dropped.
-func (m *MultiplexRelayReceiver) ReceiveRelay(ctx context.Context, method string, params any) {
+// Receive implements NotificationRelayReceiver. Looks up the per-method
+// handler and forwards. Unknown methods are silently dropped.
+func (m *NotificationRouter) Receive(ctx context.Context, method string, params any) {
 	m.mu.RLock()
 	h := m.handlers[method]
 	m.mu.RUnlock()
 	if h == nil {
 		return
 	}
-	h.ReceiveRelay(ctx, method, params)
+	h.Receive(ctx, method, params)
 }

--- a/server/relay_inmemory_test.go
+++ b/server/relay_inmemory_test.go
@@ -11,14 +11,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// memRelayBus is an in-memory BroadcastRelay that also provides the
+// memRelayBus is an in-memory NotificationRelay that also provides the
 // receive side of Pattern B — every Publish fans out to every
 // registered subscriber on a background goroutine. Self-publish dedup
 // runs via per-replica origin marker. Used only by tests; never wired
 // into production code.
 //
 // Wire shape: each replica registers a NotificationRelayReceiver and
-// gets a unique origin ID. PublishBroadcast tags the message with the
+// gets a unique origin ID. Publish tags the message with the
 // publisher's origin and enqueues to every subscriber. Subscribers
 // drop messages whose origin matches their own (self-publish).
 type memRelayBus struct {
@@ -43,11 +43,11 @@ type memRelayFrame struct {
 func newMemRelayBus() *memRelayBus { return &memRelayBus{} }
 
 // attachReplica registers a receiver on the bus and returns a publish
-// handle that PublishBroadcast tags with this replica's origin. Wire
-// the returned handle through WithBroadcastRelay so the same replica's
+// handle that Publish tags with this replica's origin. Wire
+// the returned handle through WithNotificationRelay so the same replica's
 // outbound publishes carry the origin its inbound subscriber will
 // drop.
-func (b *memRelayBus) attachReplica(t *testing.T, receiver NotificationRelayReceiver) BroadcastRelay {
+func (b *memRelayBus) attachReplica(t *testing.T, receiver NotificationRelayReceiver) NotificationRelay {
 	t.Helper()
 	b.mu.Lock()
 	b.nextID++
@@ -76,7 +76,7 @@ func (s *memRelaySubscriber) run() {
 		if f.origin == s.originID {
 			continue
 		}
-		s.receiver.ReceiveRelay(context.Background(), f.method, f.params)
+		s.receiver.Receive(context.Background(), f.method, f.params)
 	}
 }
 
@@ -94,7 +94,7 @@ type memRelayPublisher struct {
 	originID string
 }
 
-func (p *memRelayPublisher) PublishBroadcast(_ context.Context, method string, params any) {
+func (p *memRelayPublisher) Publish(_ context.Context, method string, params any) {
 	p.bus.mu.Lock()
 	subs := make([]*memRelaySubscriber, len(p.bus.subscribers))
 	copy(subs, p.bus.subscribers)
@@ -158,7 +158,7 @@ func newCaptureCluster(t *testing.T, m int) *captureCluster {
 			},
 		})
 		srv := NewServer(core.ServerInfo{Name: "cluster-replica", Version: "0.0.1"},
-			WithBroadcastRelay(relay),
+			WithNotificationRelay(relay),
 		)
 		// Wire the receiver to its server now that the server exists.
 		receiver.srv = srv
@@ -189,11 +189,11 @@ type recordingReceiver struct {
 	onFire func(method string, params any)
 }
 
-func (r *recordingReceiver) ReceiveRelay(ctx context.Context, method string, params any) {
+func (r *recordingReceiver) Receive(ctx context.Context, method string, params any) {
 	if r.onFire != nil {
 		r.onFire(method, params)
 	}
-	r.recv.ReceiveRelay(ctx, method, params)
+	r.recv.Receive(ctx, method, params)
 }
 
 // waitForFrameCount polls until the replica has accumulated count
@@ -221,7 +221,7 @@ func TestBroadcastToSessions_ExcludesRelay(t *testing.T) {
 	srv := cluster.replicas[0].srv
 
 	// BroadcastToSessions should fire LOCAL session broadcasters only.
-	// The relay's PublishBroadcast must NOT be called.
+	// The relay's Publish must NOT be called.
 	srv.BroadcastToSessions(context.Background(), "notifications/tools/list_changed", nil)
 
 	cluster.replicas[0].waitForFrameCount(t, 1, time.Second)
@@ -229,7 +229,7 @@ func TestBroadcastToSessions_ExcludesRelay(t *testing.T) {
 }
 
 // TestBroadcast_FiresRelayThenLocal verifies the public Broadcast does
-// BOTH: relay PublishBroadcast (cross-replica), then BroadcastToSessions
+// BOTH: relay Publish (cross-replica), then BroadcastToSessions
 // (local). Other replicas receive via relay → BroadcastToSessions, so
 // every replica's captured frames go up.
 func TestBroadcast_FiresRelayThenLocal(t *testing.T) {
@@ -291,12 +291,12 @@ func TestBroadcast_NoRelayInstalled(t *testing.T) {
 	assert.Len(t, captured, 1)
 }
 
-// TestBroadcastRelay_NTopicsMConsumers is the N producers × T topics
+// TestNotificationRelay_NTopicsMConsumers is the N producers × T topics
 // × M consumers harness exercising the full multi-replica matrix.
 // Every replica publishes every topic once; every replica's session
 // broadcaster should receive every published topic exactly once
 // (origin replica via local fanout; other replicas via relay).
-func TestBroadcastRelay_NTopicsMConsumers(t *testing.T) {
+func TestNotificationRelay_NTopicsMConsumers(t *testing.T) {
 	const m = 3 // replicas
 	cluster := newCaptureCluster(t, m)
 	topics := []string{

--- a/server/relay_test.go
+++ b/server/relay_test.go
@@ -50,7 +50,7 @@ func TestCapabilityBroadcastReceiver_ForwardsToBroadcast(t *testing.T) {
 	srv, cap := newServerWithCapture(t)
 
 	recv := NewCapabilityBroadcastReceiver(srv)
-	recv.ReceiveRelay(context.Background(), "notifications/tools/list_changed", nil)
+	recv.Receive(context.Background(), "notifications/tools/list_changed", nil)
 
 	frames := cap.frame()
 	require.Len(t, frames, 1)
@@ -62,7 +62,7 @@ func TestCapabilityBroadcastReceiver_ForwardsParams(t *testing.T) {
 
 	recv := NewCapabilityBroadcastReceiver(srv)
 	params := map[string]any{"uri": "file:///foo"}
-	recv.ReceiveRelay(context.Background(), "notifications/resources/updated", params)
+	recv.Receive(context.Background(), "notifications/resources/updated", params)
 
 	frames := cap.frame()
 	require.Len(t, frames, 1)
@@ -80,7 +80,7 @@ func TestCapabilityBroadcastReceiver_ConcurrentReceivesAreSafe(t *testing.T) {
 	for i := 0; i < n; i++ {
 		go func() {
 			defer wg.Done()
-			recv.ReceiveRelay(context.Background(), "notifications/tools/list_changed", nil)
+			recv.Receive(context.Background(), "notifications/tools/list_changed", nil)
 		}()
 	}
 	wg.Wait()
@@ -93,7 +93,7 @@ func TestCapabilityBroadcastReceiver_ConcurrentReceivesAreSafe(t *testing.T) {
 // to build if the interface drifts.
 func TestNotificationRelayReceiver_Conformance(t *testing.T) {
 	var _ NotificationRelayReceiver = (*CapabilityBroadcastReceiver)(nil)
-	var _ NotificationRelayReceiver = (*MultiplexRelayReceiver)(nil)
+	var _ NotificationRelayReceiver = (*NotificationRouter)(nil)
 	var _ NotificationRelayReceiver = (*ResourcesUpdatedReceiver)(nil)
 }
 
@@ -122,7 +122,7 @@ func TestResourcesUpdatedReceiver_RoutesToLocalSubscribers(t *testing.T) {
 	require.NoError(t, srv.subRegistry.subscribe("sess-A", d, "file:///foo"))
 
 	recv := NewResourcesUpdatedReceiver(srv)
-	recv.ReceiveRelay(context.Background(),
+	recv.Receive(context.Background(),
 		"notifications/resources/updated",
 		core.ResourceUpdatedNotification{URI: "file:///foo"},
 	)
@@ -153,7 +153,7 @@ func TestResourcesUpdatedReceiver_AcceptsMapShape(t *testing.T) {
 	require.NoError(t, srv.subRegistry.subscribe("sess-A", d, "file:///bar"))
 
 	recv := NewResourcesUpdatedReceiver(srv)
-	recv.ReceiveRelay(context.Background(),
+	recv.Receive(context.Background(),
 		"notifications/resources/updated",
 		map[string]any{"uri": "file:///bar"},
 	)
@@ -168,7 +168,7 @@ func TestResourcesUpdatedReceiver_DropsWrongMethod(t *testing.T) {
 	recv := NewResourcesUpdatedReceiver(srv)
 
 	// Should not panic, should not crash.
-	recv.ReceiveRelay(context.Background(), "notifications/tools/list_changed", nil)
+	recv.Receive(context.Background(), "notifications/tools/list_changed", nil)
 }
 
 func TestResourcesUpdatedReceiver_DropsMissingURI(t *testing.T) {
@@ -176,11 +176,11 @@ func TestResourcesUpdatedReceiver_DropsMissingURI(t *testing.T) {
 	recv := NewResourcesUpdatedReceiver(srv)
 
 	// Params shape doesn't carry a URI — must not fire any subscribers.
-	recv.ReceiveRelay(context.Background(),
+	recv.Receive(context.Background(),
 		"notifications/resources/updated",
 		map[string]any{"unrelated": "value"},
 	)
-	recv.ReceiveRelay(context.Background(),
+	recv.Receive(context.Background(),
 		"notifications/resources/updated",
 		core.ResourceUpdatedNotification{URI: ""},
 	)
@@ -188,13 +188,13 @@ func TestResourcesUpdatedReceiver_DropsMissingURI(t *testing.T) {
 
 // TestSubscriptionRegistry_NotifyPublishesViaRelay verifies that
 // notify() fires BOTH the local subscribers AND the installed
-// BroadcastRelay. notifyLocal() (the receiver's entry point) must NOT
+// NotificationRelay. notifyLocal() (the receiver's entry point) must NOT
 // re-publish — that would loop through the transport.
 func TestSubscriptionRegistry_NotifyPublishesViaRelay(t *testing.T) {
-	relay := &recordingHandler{} // BroadcastRelay = NotificationRelayReceiver with same shape
+	relay := &recordingHandler{} // NotificationRelay = NotificationRelayReceiver with same shape
 	srv := NewServer(core.ServerInfo{Name: "sub-relay", Version: "0.0.1"},
 		WithSubscriptions(),
-		WithBroadcastRelay(broadcastRelayFromHandler{recordingHandler: relay}),
+		WithNotificationRelay(broadcastRelayFromHandler{recordingHandler: relay}),
 	)
 
 	d := srv.newSession()
@@ -228,7 +228,7 @@ func TestSubscriptionRegistry_NotifyLocalSkipsRelay(t *testing.T) {
 	relay := &recordingHandler{}
 	srv := NewServer(core.ServerInfo{Name: "sub-local", Version: "0.0.1"},
 		WithSubscriptions(),
-		WithBroadcastRelay(broadcastRelayFromHandler{recordingHandler: relay}),
+		WithNotificationRelay(broadcastRelayFromHandler{recordingHandler: relay}),
 	)
 
 	d := srv.newSession()
@@ -253,24 +253,24 @@ func TestSubscriptionRegistry_NotifyLocalSkipsRelay(t *testing.T) {
 }
 
 // broadcastRelayFromHandler adapts recordingHandler (a
-// NotificationRelayReceiver) into a BroadcastRelay so tests can install
-// it via WithBroadcastRelay and assert on publish frames.
+// NotificationRelayReceiver) into a NotificationRelay so tests can install
+// it via WithNotificationRelay and assert on publish frames.
 type broadcastRelayFromHandler struct {
 	*recordingHandler
 }
 
-func (b broadcastRelayFromHandler) PublishBroadcast(ctx context.Context, method string, params any) {
-	b.recordingHandler.ReceiveRelay(ctx, method, params)
+func (b broadcastRelayFromHandler) Publish(ctx context.Context, method string, params any) {
+	b.recordingHandler.Receive(ctx, method, params)
 }
 
-// --- MultiplexRelayReceiver ----------------------------------------
+// --- NotificationRouter ----------------------------------------
 
 type recordingHandler struct {
 	mu     sync.Mutex
 	frames []captureFrame
 }
 
-func (r *recordingHandler) ReceiveRelay(_ context.Context, method string, params any) {
+func (r *recordingHandler) Receive(_ context.Context, method string, params any) {
 	r.mu.Lock()
 	r.frames = append(r.frames, captureFrame{method: method, params: params})
 	r.mu.Unlock()
@@ -284,53 +284,53 @@ func (r *recordingHandler) snapshot() []captureFrame {
 	return out
 }
 
-func TestMultiplexRelayReceiver_RoutesByMethod(t *testing.T) {
-	mux := NewMultiplexRelayReceiver()
+func TestNotificationRouter_RoutesByMethod(t *testing.T) {
+	mux := NewNotificationRouter()
 	tools := &recordingHandler{}
 	resources := &recordingHandler{}
 	mux.Handle("notifications/tools/list_changed", tools)
 	mux.Handle("notifications/resources/list_changed", resources)
 
-	mux.ReceiveRelay(context.Background(), "notifications/tools/list_changed", nil)
-	mux.ReceiveRelay(context.Background(), "notifications/resources/list_changed", nil)
-	mux.ReceiveRelay(context.Background(), "notifications/resources/list_changed", nil)
+	mux.Receive(context.Background(), "notifications/tools/list_changed", nil)
+	mux.Receive(context.Background(), "notifications/resources/list_changed", nil)
+	mux.Receive(context.Background(), "notifications/resources/list_changed", nil)
 
 	assert.Len(t, tools.snapshot(), 1)
 	assert.Len(t, resources.snapshot(), 2)
 }
 
-func TestMultiplexRelayReceiver_UnknownMethodDropped(t *testing.T) {
-	mux := NewMultiplexRelayReceiver()
+func TestNotificationRouter_UnknownMethodDropped(t *testing.T) {
+	mux := NewNotificationRouter()
 	tools := &recordingHandler{}
 	mux.Handle("notifications/tools/list_changed", tools)
 
-	mux.ReceiveRelay(context.Background(), "notifications/some/unknown", nil)
+	mux.Receive(context.Background(), "notifications/some/unknown", nil)
 
 	assert.Empty(t, tools.snapshot(), "unknown methods must not fall through to any handler")
 }
 
-func TestMultiplexRelayReceiver_HandleReplacesExisting(t *testing.T) {
-	mux := NewMultiplexRelayReceiver()
+func TestNotificationRouter_HandleReplacesExisting(t *testing.T) {
+	mux := NewNotificationRouter()
 	first := &recordingHandler{}
 	second := &recordingHandler{}
 	mux.Handle("notifications/tools/list_changed", first)
 	mux.Handle("notifications/tools/list_changed", second)
 
-	mux.ReceiveRelay(context.Background(), "notifications/tools/list_changed", nil)
+	mux.Receive(context.Background(), "notifications/tools/list_changed", nil)
 
 	assert.Empty(t, first.snapshot(), "first handler must be replaced")
 	assert.Len(t, second.snapshot(), 1)
 }
 
-func TestMultiplexRelayReceiver_HandleNilIsNoOp(t *testing.T) {
-	mux := NewMultiplexRelayReceiver()
+func TestNotificationRouter_HandleNilIsNoOp(t *testing.T) {
+	mux := NewNotificationRouter()
 	mux.Handle("notifications/tools/list_changed", nil)
-	mux.ReceiveRelay(context.Background(), "notifications/tools/list_changed", nil)
+	mux.Receive(context.Background(), "notifications/tools/list_changed", nil)
 	// No panic, no handler fired — nothing to assert beyond "didn't crash".
 }
 
-func TestMultiplexRelayReceiver_ConcurrentRegisterAndDispatch(t *testing.T) {
-	mux := NewMultiplexRelayReceiver()
+func TestNotificationRouter_ConcurrentRegisterAndDispatch(t *testing.T) {
+	mux := NewNotificationRouter()
 	handler := &recordingHandler{}
 	mux.Handle("notifications/tools/list_changed", handler)
 
@@ -345,7 +345,7 @@ func TestMultiplexRelayReceiver_ConcurrentRegisterAndDispatch(t *testing.T) {
 		}()
 		go func() {
 			defer wg.Done()
-			mux.ReceiveRelay(context.Background(), "notifications/tools/list_changed", nil)
+			mux.Receive(context.Background(), "notifications/tools/list_changed", nil)
 		}()
 	}
 	wg.Wait()

--- a/server/server.go
+++ b/server/server.go
@@ -79,7 +79,7 @@ type serverOptions struct {
 	allowLegacyOnDraft   bool                     // WithAllowLegacyOnDraft — opt-in SEP-2575 leniency on the legacy wire (off by default; strict per spec)
 	tracerProvider       core.TracerProvider      // SEP-414 P2 — WithTracerProvider; nil/Noop = trace middleware not installed
 	meterProvider        core.MeterProvider       // issue 7 — WithMeterProvider; nil/Noop = metrics middleware not installed
-	broadcastRelay       BroadcastRelay           // issue 755 — WithBroadcastRelay; nil = no cross-replica broadcast (Broadcast fires local only)
+	notificationRelay       NotificationRelay           // issue 755 — WithNotificationRelay; nil = no cross-replica broadcast (Broadcast fires local only)
 }
 
 type httpHandlerEntry struct {
@@ -598,7 +598,7 @@ func NewServer(info core.ServerInfo, opts ...Option) *Server {
 			rateLimit:      s.options.subscriptionRate,
 			rateBurst:      s.options.subscriptionBurst,
 			onReject:       s.options.subscriptionReject,
-			broadcastRelay: s.options.broadcastRelay,
+			notificationRelay: s.options.notificationRelay,
 		}
 		s.dispatcher.subscriptionsEnabled = true
 		s.dispatcher.subManager = s.subRegistry
@@ -1001,17 +1001,17 @@ func (s *Server) Broadcast(ctx context.Context, method string, params any) {
 		params = core.InjectTraceContextIntoParams(params, tc)
 	}
 	s.mu.Lock()
-	relay := s.options.broadcastRelay
+	relay := s.options.notificationRelay
 	s.mu.Unlock()
 	if relay != nil {
-		relay.PublishBroadcast(ctx, method, params)
+		relay.Publish(ctx, method, params)
 	}
 	s.BroadcastToSessions(ctx, method, params)
 }
 
 // BroadcastToSessions delivers a notification to every locally-connected
 // client via the per-transport session broadcasters. UNLIKE Broadcast,
-// BroadcastToSessions does NOT invoke the installed BroadcastRelay —
+// BroadcastToSessions does NOT invoke the installed NotificationRelay —
 // it's the local-only path Pattern B receivers call after dropping
 // self-publishes, so they don't re-publish through the relay and loop.
 //
@@ -1523,14 +1523,14 @@ type subscriptionRegistry struct {
 	rateBurst int
 	onReject  SubscriptionRejectFunc
 
-	// broadcastRelay is the Server's configured Pattern B publisher
+	// notificationRelay is the Server's configured Pattern B publisher
 	// for cross-replica fan-out. notify() publishes
 	// notifications/resources/updated through this on top of
 	// notifyLocal() so subscribers on other replicas hear the
 	// notification too. nil = local-only behavior (no relay
-	// installed). Wired by NewServer from s.options.broadcastRelay
+	// installed). Wired by NewServer from s.options.notificationRelay
 	// after both the registry and the option are read.
-	broadcastRelay BroadcastRelay
+	notificationRelay NotificationRelay
 }
 
 // ErrSubscriptionCapExceeded indicates the calling session has hit
@@ -1633,8 +1633,8 @@ func (r *subscriptionRegistry) unsubscribeAll(sessionID string) {
 
 // notifyLocal sends a notifications/resources/updated to all LOCAL
 // sessions subscribed to the URI. Used by the cross-replica receive
-// path (server.ResourcesUpdatedReceiver.ReceiveRelay) to deliver
-// without re-publishing through the BroadcastRelay.
+// path (server.ResourcesUpdatedReceiver.Receive) to deliver
+// without re-publishing through the NotificationRelay.
 //
 // Copies the dispatcher list under read lock, then calls notifyFunc
 // outside the lock to avoid holding the lock during potentially slow
@@ -1657,7 +1657,7 @@ func (r *subscriptionRegistry) notifyLocal(uri string) {
 }
 
 // notify fires notifyLocal AND publishes via the Server's installed
-// BroadcastRelay so cross-replica subscribers on other replicas
+// NotificationRelay so cross-replica subscribers on other replicas
 // receive the same notification. The publish encodes the URI in
 // params so receiving replicas can route by URI on their own
 // subscriptionRegistry.
@@ -1666,8 +1666,8 @@ func (r *subscriptionRegistry) notifyLocal(uri string) {
 // pre-Pattern-B behavior).
 func (r *subscriptionRegistry) notify(uri string) {
 	r.notifyLocal(uri)
-	if r.broadcastRelay != nil {
-		r.broadcastRelay.PublishBroadcast(
+	if r.notificationRelay != nil {
+		r.notificationRelay.Publish(
 			context.Background(),
 			"notifications/resources/updated",
 			core.ResourceUpdatedNotification{URI: uri},
@@ -1682,10 +1682,10 @@ func (r *subscriptionRegistry) notify(uri string) {
 // Safe to call from any goroutine. No-op if subscriptions are not enabled or
 // no clients are subscribed to the URI.
 //
-// When a BroadcastRelay is installed via WithBroadcastRelay, the
+// When a NotificationRelay is installed via WithNotificationRelay, the
 // notification reaches subscribers on every replica — the receive
 // side (typically a server.ResourcesUpdatedReceiver wired into a
-// MultiplexRelayReceiver) calls notifyLocal on each replica's own
+// NotificationRouter) calls notifyLocal on each replica's own
 // subscriptionRegistry.
 //
 // Example:
@@ -1700,7 +1700,7 @@ func (s *Server) NotifyResourceUpdated(uri string) {
 
 // NotifyResourceUpdatedLocal sends a notifications/resources/updated
 // notification to LOCAL subscribers only — does NOT publish via the
-// installed BroadcastRelay. Used by ResourcesUpdatedReceiver.ReceiveRelay
+// installed NotificationRelay. Used by ResourcesUpdatedReceiver.Receive
 // to deliver a cross-replica-received notification without
 // re-publishing.
 //


### PR DESCRIPTION
## What changes

Mechanical rename per issue 770. Zero behavior change. Renames the relay publish-side interface and the multiplex receiver to names that say what's relayed (notifications) and how the router routes (by method).

Before:
```go
type BroadcastRelay interface { PublishBroadcast(...) }
mux := server.NewMultiplexRelayReceiver().Handle(...)
bus, _ := redisstore.NewCapabilityBus(opts, mux)
srv := server.NewServer(info, server.WithBroadcastRelay(bus))
```

After:
```go
type NotificationRelay interface { Publish(...) }
router := server.NewNotificationRouter().Handle(...)
bus, _ := redisstore.NewCapabilityBus(opts, router)
srv := server.NewServer(info, server.WithNotificationRelay(bus))
```

`NotificationRelayReceiver` keeps its name (singular noun) and its method shrinks: `Receive` instead of `ReceiveRelay` (the `Relay` context is now carried by the type name itself, not duplicated on the method).

Issue 770's second half (store infra lift from `experimental/ext/events/stores/redis/` to root `stores/redis/`) lands as a separate PR on top of this one.

## Reviewer's guide
Read in this order:

1. [server/relay.go](https://github.com/panyam/mcpkit/pull/771/files#diff-6e1faa6c56182c2ea76b641b8d226799639d62a02d1349daa77988535f08668f) — start here. All the renamed types + reference receivers. The diff reads as a structured rename: same shape, new names. Doc-comments updated to reference the new symbol names.
2. [server/server.go](https://github.com/panyam/mcpkit/pull/771/files#diff-78f42ba40d0f10b08c73b7e6bb8376f398e249c963cf549e89591d6b6826b9a4) — three field/option references updated: `serverOptions.notificationRelay`, the `Broadcast` dispatch fork in `Server.Broadcast`, and `subscriptionRegistry.notificationRelay`. Cross-references in doc comments swept.
3. [experimental/ext/events/yield.go](https://github.com/panyam/mcpkit/pull/771/files#diff-1a35574e62fe51d6eb94df43ccdbf8519abbc134033627d9020fe30dbec06cf3) — `YieldingSource.Receive` method (renamed from `ReceiveRelay`) implements the renamed interface. Body unchanged.
4. [experimental/ext/events/stores/redis/capability_bus.go](https://github.com/panyam/mcpkit/pull/771/files#diff-99c675bb90ed0314ff756248e4b6eb740901a5c5c5f14da16c8179d81c22e498) + `bus.go` + [experimental/ext/events/stores/memory/bus.go](https://github.com/panyam/mcpkit/pull/771/files#diff-8c2453e1ccb566472aae4b2d950d36a2392cae1c90cd3a1beeae739ae29fe815) — Bus types implement the renamed interface; `Publish` instead of `PublishBroadcast`; `receiver.Receive` call sites updated.
5. [examples/whole-enchilada/events/event-server/redis.go](https://github.com/panyam/mcpkit/pull/771/files#diff-bdfe6a3c5d30e0ba0c34c3e73ae1b4a4a24f1ba17a8fab61316d4c34f0db523a) — adopter wiring uses the renamed option + types.
6. [docs/MULTI_REPLICA.md](https://github.com/panyam/mcpkit/pull/771/files#diff-17934e88ae4afd4b6c4f80b1734fdf574ce8e4fe79cbdc2374fd93e12bb29a30) — every reference renamed (mermaid diagrams, callstacks, recipes, tables). Line-number references in the "life of a notification" callstack section updated to match the new line numbers in [server/relay.go](https://github.com/panyam/mcpkit/pull/771/files#diff-6e1faa6c56182c2ea76b641b8d226799639d62a02d1349daa77988535f08668f) + [experimental/ext/events/stores/redis/capability_bus.go](https://github.com/panyam/mcpkit/pull/771/files#diff-99c675bb90ed0314ff756248e4b6eb740901a5c5c5f14da16c8179d81c22e498).
7. [CONSTRAINTS.md](https://github.com/panyam/mcpkit/pull/771/files#diff-f2043ef583480706f62a74d47dae3d7ae2402f1b42cff01383b08fe8b37fdf3b) § C5 + [experimental/ext/events/README.md](https://github.com/panyam/mcpkit/pull/771/files#diff-9222f2c9c82e15be71e1b286719f2d44d107c3ea315805c64c3d617ab960d4b3) + [experimental/ext/events/stores/redis/README.md](https://github.com/panyam/mcpkit/pull/771/files#diff-4309c899768e545e244ce0f504bcc4fd8e55b6fd0e58205a0e8531c2695119fa) + [experimental/ext/events/STORAGE_SEAMS.md](https://github.com/panyam/mcpkit/pull/771/files#diff-ceea0a5339d9583578ba93a8fd23a5cc2cc61ae832839b943f6d8e02b0bf6954) — naming references updated.
8. Tests — [server/relay_test.go](https://github.com/panyam/mcpkit/pull/771/files#diff-2bdce2c63b8b248c49eac7bf8f25ed3117f43e4afb90c819000534681d6e923d), [server/relay_inmemory_test.go](https://github.com/panyam/mcpkit/pull/771/files#diff-e84d05eb3b08b52b7bb21421bfc3ab3866c68a4785bab10c033fdc209ccd0d80), [server/listchanged_relay_test.go](https://github.com/panyam/mcpkit/pull/771/files#diff-a2fc396d77a5ac93a90383ddd1f38168e7430738d05afa4f439cf68de4daa9a8), `redisstore/capability_bus_test.go`. Test names also renamed for consistency (e.g., `TestMultiplexRelayReceiver_*` → `TestNotificationRouter_*`).

Skim or skip: nothing meaningful — every diff line is part of the rename.

## Decision log

- **`NotificationRelayReceiver` keeps its name.** Already singular; the `XYZRelay` / `XYZRelayReceiver` pairing reads cleanly with the new `NotificationRelay`. The method shrinks from `ReceiveRelay` to `Receive` because the `Relay` context is now carried by the type name itself.
- **`NotificationRouter` instead of `MethodRouter`.** Discussed in issue 770 — `Router` is the noun; routing-by-method is obvious from the `Handle(method, receiver)` signature. Future `RequestRouter` companion (if cross-replica request relay ever materializes) reads naturally with no namespace conflict.
- **No backwards-compat aliases.** User approved full break for the 755 stack; same posture here. The renamed types only existed in main for the duration between PR 768 merge and this PR; no external consumers possible.
- **Test names renamed for consistency.** `TestMultiplexRelayReceiver_RoutesByMethod` → `TestNotificationRouter_RoutesByMethod`. Code references in test bodies were already renamed by the type sweep; the function names trailing in tests would have been the only stale-naming residue.
- **Line-number references in the "Life of a notification" callstack section adjusted.** Rename added/removed bytes in the relay.go bodies; the callstack section's `file.go:line` annotations needed to track the new positions. Spot-checked each by grepping the current code.

## Risk / blast radius

- **Interface contract change for every implementer.** `NotificationRelayReceiver.Receive` (not `ReceiveRelay`) — every implementation simultaneously updated: `CapabilityBroadcastReceiver`, `ResourcesUpdatedReceiver`, `NotificationRouter`, `YieldingSource`, all test-file mocks. The build proves the rename is complete (unrenamed references break compile).
- **Adopter call sites change names.** `srv.NewServer(info, server.WithBroadcastRelay(bus))` won't compile after merge; must read `WithNotificationRelay(bus)`. Same for `NewMultiplexRelayReceiver` → `NewNotificationRouter`. Only the whole-enchilada demo wires these; updated in the same PR.
- **Doc references updated, including line numbers.** Reviewer should spot-check that the callstack section in `docs/MULTI_REPLICA.md` still correctly maps to current code positions.
- **Race tests clean.** `go test -race -count=1` passes across server, events, redisstore, memorystore, event-server demo. Sole pre-existing failure is `TestMatchTransform_CrossModeParity` (issue 758) — not introduced by this PR.

## Before / after

Diff stat: 16 files changed, 249 insertions(+), 250 deletions(-). One-line net (deletions slightly more than insertions because old method names had `Broadcast`/`Multiplex` prefixes longer than new names).

## Out of scope (deferred)

- Store infra lift (Options, Codec, Logger, QuotaStore, CapabilityBus → root `stores/redis/`). Issue 770's second half. Lands as PR 770-B stacked on top of this once it merges.
- Pre-existing race in `TestMatchTransform_CrossModeParity` — tracked as issue 758.
