### PR TITLE
events: fix data race in TestMatchTransform_CrossModeParity (issue 758)

### DIFF
--- a/experimental/ext/events/match_transform_test.go
+++ b/experimental/ext/events/match_transform_test.go
@@ -3,6 +3,7 @@ package events
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -487,11 +488,15 @@ func TestMatchTransform_CrossModeParity(t *testing.T) {
 	pushCh, _ := src.Subscribe(ctx, SubscribeOpts{Principal: "alice", Params: matchParams})
 
 	// Webhook
-	var whBody []byte
+	var (
+		whMu   sync.Mutex
+		whBody []byte
+	)
 	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		buf := make([]byte, r.ContentLength)
-		_, _ = r.Body.Read(buf)
-		whBody = buf
+		body, _ := io.ReadAll(r.Body)
+		whMu.Lock()
+		whBody = body
+		whMu.Unlock()
 		w.WriteHeader(200)
 	}))
 	defer receiver.Close()
@@ -524,15 +529,18 @@ func TestMatchTransform_CrossModeParity(t *testing.T) {
 	}
 
 	// Webhook delivery — async; wait
-	deadline := time.Now().Add(500 * time.Millisecond)
-	for time.Now().Before(deadline) && len(whBody) == 0 {
-		time.Sleep(10 * time.Millisecond)
-	}
-	require.NotEmpty(t, whBody, "webhook receiver got no body")
+	require.Eventually(t, func() bool {
+		whMu.Lock()
+		defer whMu.Unlock()
+		return len(whBody) > 0
+	}, 500*time.Millisecond, 10*time.Millisecond, "webhook receiver got no body")
+	whMu.Lock()
+	bodyCopy := append([]byte(nil), whBody...)
+	whMu.Unlock()
 	var whEnv struct {
 		Data sevPayload `json:"data"`
 	}
-	require.NoError(t, json.Unmarshal(whBody, &whEnv))
+	require.NoError(t, json.Unmarshal(bodyCopy, &whEnv))
 
 	// Poll delivery
 	pollBody, _ := json.Marshal(map[string]any{


### PR DESCRIPTION
## What changes

`TestMatchTransform_CrossModeParity` failed under `go test -race` with two
data races between the httptest webhook receiver goroutine and the test
goroutine. The receiver wrote `whBody` (and the underlying byte buffer)
on the http server goroutine; the test busy-waited on `len(whBody)` then
`json.Unmarshal`ed the same slice — no happens-before relationship between
the two reads/writes.

This PR guards `whBody` with a `sync.Mutex`, replaces the manual deadline
busy-wait with `require.Eventually`, copies the body under the lock
before unmarshaling, and switches the handler's body capture from
`r.Body.Read(buf)` (partial-read prone) to `io.ReadAll(r.Body)`.

Production code is unchanged — the test was racing against itself.

## Reviewer's guide
Read in this order:

1. [experimental/ext/events/match_transform_test.go](https://github.com/panyam/mcpkit/pull/775/files#diff-f6b0a02d77f9cfb879c5ce0d63e9fa0c70c430ae1a5d258e81fac12ea228ed0e) — the only file changed. Look at the diff in two spots:
   - The receiver closure (`whMu` introduced; `io.ReadAll` replaces the partial-read pattern).
   - The webhook-delivery wait (`require.Eventually` replaces the deadline loop; body copied under the lock before `json.Unmarshal`).

The fix matches the mutex + `require.Eventually` pattern already used by `webhook_span_test.go:106-149` in the same package.

## Decision log

- **Mutex + Eventually + io.ReadAll** vs channel-based handoff vs
  `bytes.Buffer` under lock — picked mutex because it matches the
  in-package precedent (`webhook_span_test.go`). Channel handoff would
  diverge from the existing style for no material gain.
- **`io.ReadAll` instead of keeping `r.Body.Read(buf)`** — the existing
  code assumed a single `Read` would consume the full body, which is
  not guaranteed by the `io.Reader` contract. Latent bug; fixed in the
  same pass since the diff was already touching the closure.
- **Copy under lock before `json.Unmarshal`** — even with the mutex, the
  slice header could be observed pointing at memory the next handler
  invocation might rewrite. The copy makes the unmarshal target stable.

## Risk / blast radius

- Affects: one test file in `experimental/ext/events/`. No production
  code change. No exported API surface touched.
- Tests covering this: the test itself — verified red-before-green.
- Be paranoid about: the test's wait timeout (kept at 500ms / 10ms poll,
  same as before).

## Before / after

Before (race-detector output, abbreviated):
```
WARNING: DATA RACE
Write at 0x... by goroutine 29:
  ...TestMatchTransform_CrossModeParity.func1()
      match_transform_test.go:494
Previous read at 0x... by goroutine 22:
  ...TestMatchTransform_CrossModeParity()
      match_transform_test.go:528
--- FAIL: TestMatchTransform_CrossModeParity (0.01s)
```

After:
```
$ go test -race -count=10 -run TestMatchTransform_CrossModeParity .
ok      github.com/panyam/mcpkit/experimental/ext/events    1.855s
$ go test -race -count=1 ./...
ok      github.com/panyam/mcpkit/experimental/ext/events    81.164s
```

## Out of scope

- Consolidating the test webhook receiver pattern across
  `webhook_span_test.go` and `match_transform_test.go` into a shared
  helper — both currently roll their own. Worth a follow-up if a third
  copy lands; not urgent.
