### PR TITLE
events: sweep PR 714 yield(ctx) signature + drop 4 demo tests asserting deprecated SSE auto-fanout

### DIFF
--- a/examples/events/discord/e2e_test.go
+++ b/examples/events/discord/e2e_test.go
@@ -305,39 +305,6 @@ func TestE2EStreamCursorless(t *testing.T) {
 	}
 }
 
-// TestE2EPushDelivery verifies the library's automatic push fanout — yield()
-// triggers events.Emit via the SetEmitHook wired by Register, and the SSE
-// notification reaches the client. Source author writes no fanout code.
-func TestE2EPushDelivery(t *testing.T) {
-	srv, _, yield, _ := buildTestStack()
-
-	var mu sync.Mutex
-	var received []string
-
-	handler := srv.Handler(server.WithStreamableHTTP(true))
-	ts := httptest.NewServer(handler)
-	defer ts.Close()
-
-	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "push-test", Version: "1.0"},
-		client.WithGetSSEStream(),
-		client.WithNotificationCallback(func(method string, params any) {
-			mu.Lock()
-			received = append(received, method)
-			mu.Unlock()
-		}),
-	)
-	require.NoError(t, c.Connect())
-	defer c.Close()
-
-	time.Sleep(200 * time.Millisecond)
-	require.NoError(t, yield(context.Background(), newDiscordEvent("g", "c", "alice", "push test", time.Now())))
-	time.Sleep(500 * time.Millisecond)
-
-	mu.Lock()
-	defer mu.Unlock()
-	assert.Contains(t, received, "notifications/events/event")
-}
-
 // TestE2EWebhookDelivery verifies webhook fanout via the default modes:
 // Server-generated secret + StandardWebhooks header naming. The latter is
 // the post-r3167245184 default (upstream WG PR#1 line 434, author aligned
@@ -565,49 +532,6 @@ func TestE2EWebhookDelivery_MCPHeadersOptIn(t *testing.T) {
 	mu.Lock()
 	defer mu.Unlock()
 	assert.Equal(t, 1, deliveries)
-}
-
-// TestE2ECursorlessPushDelivery verifies the cursorless typing source: yield
-// triggers a push notification whose Event.cursor is JSON null on the wire.
-// Confirms the `*string` cursor field round-trips correctly through the
-// notification fanout path.
-func TestE2ECursorlessPushDelivery(t *testing.T) {
-	srv, _, yieldTyping, _ := buildTestStackWithTyping()
-
-	var mu sync.Mutex
-	var receivedRaw []map[string]any
-
-	handler := srv.Handler(server.WithStreamableHTTP(true))
-	ts := httptest.NewServer(handler)
-	defer ts.Close()
-
-	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "cursorless-push", Version: "1.0"},
-		client.WithGetSSEStream(),
-		client.WithNotificationCallback(func(method string, params any) {
-			if method != "notifications/events/event" {
-				return
-			}
-			b, _ := json.Marshal(params)
-			var p map[string]any
-			_ = json.Unmarshal(b, &p)
-			mu.Lock()
-			receivedRaw = append(receivedRaw, p)
-			mu.Unlock()
-		}),
-	)
-	require.NoError(t, c.Connect())
-	defer c.Close()
-
-	time.Sleep(200 * time.Millisecond)
-	require.NoError(t, yieldTyping(context.Background(), newDiscordTypingEvent("g", "c", "alice", time.Now())))
-	time.Sleep(500 * time.Millisecond)
-
-	mu.Lock()
-	defer mu.Unlock()
-	require.Len(t, receivedRaw, 1, "push must deliver the typing event")
-	cursorVal, present := receivedRaw[0]["cursor"]
-	require.True(t, present, "cursor field must be present on the wire (not omitted)")
-	assert.Nil(t, cursorVal, "cursorless event must wire as cursor:null")
 }
 
 // TestE2ECursorlessWebhookDelivery verifies the cursorless typing source's

--- a/examples/events/discord/e2e_test.go
+++ b/examples/events/discord/e2e_test.go
@@ -27,7 +27,7 @@ import (
 //
 // The cursorless typing source is registered alongside discord.message so
 // cursor-shape tests can exercise both modes against the same server.
-func buildTestStack(whOpts ...events.WebhookOption) (*server.Server, *events.YieldingSource[DiscordEventData], func(DiscordEventData) error, *events.WebhookRegistry) {
+func buildTestStack(whOpts ...events.WebhookOption) (*server.Server, *events.YieldingSource[DiscordEventData], func(context.Context, DiscordEventData) error, *events.WebhookRegistry) {
 	// Tests subscribe to httptest URLs (127.0.0.1:N); bypass the
 	// production-default SSRF dial guard (spec §"Webhook Security"
 	// → "SSRF prevention" L464).
@@ -54,7 +54,7 @@ func buildTestStack(whOpts ...events.WebhookOption) (*server.Server, *events.Yie
 
 // buildTestStackWithTyping returns the same wired server but exposes the
 // cursorless typing yield function too. Used by the cursorless e2e tests.
-func buildTestStackWithTyping(whOpts ...events.WebhookOption) (*server.Server, func(DiscordEventData) error, func(DiscordTypingData) error, *events.WebhookRegistry) {
+func buildTestStackWithTyping(whOpts ...events.WebhookOption) (*server.Server, func(context.Context, DiscordEventData) error, func(context.Context, DiscordTypingData) error, *events.WebhookRegistry) {
 	// Tests subscribe to httptest URLs (127.0.0.1:N); bypass the
 	// production-default SSRF dial guard (spec §"Webhook Security"
 	// → "SSRF prevention" L464).
@@ -106,8 +106,8 @@ func TestE2EPollDelivery(t *testing.T) {
 	srv, _, yield, _ := buildTestStack()
 	c, _ := connectClient(t, srv)
 
-	require.NoError(t, yield(newDiscordEvent("guild-1", "channel-1", "alice", "hello", time.Now())))
-	require.NoError(t, yield(newDiscordEvent("guild-1", "channel-1", "bob", "world", time.Now())))
+	require.NoError(t, yield(context.Background(), newDiscordEvent("guild-1", "channel-1", "alice", "hello", time.Now())))
+	require.NoError(t, yield(context.Background(), newDiscordEvent("guild-1", "channel-1", "bob", "world", time.Now())))
 
 	// Flat events/poll request shape per spec §"Poll-Based Delivery"
 	// → "Request: events/poll" L139-149.
@@ -157,7 +157,7 @@ func TestE2EStreamDelivery(t *testing.T) {
 	require.NoError(t, err, "Stream open should succeed against the discord demo stack")
 	defer stream.Stop()
 
-	require.NoError(t, yield(newDiscordEvent("g1", "c1", "alice", "stream-test", time.Now())))
+	require.NoError(t, yield(context.Background(), newDiscordEvent("g1", "c1", "alice", "stream-test", time.Now())))
 
 	select {
 	case ev := <-got:
@@ -291,7 +291,7 @@ func TestE2EStreamCursorless(t *testing.T) {
 	require.NoError(t, err)
 	defer stream.Stop()
 
-	require.NoError(t, yieldTyping(DiscordTypingData{
+	require.NoError(t, yieldTyping(context.Background(), DiscordTypingData{
 		GuildID: "g", ChannelID: "c", User: "alice",
 		StartedAt: time.Now().Format(time.RFC3339),
 	}))
@@ -330,7 +330,7 @@ func TestE2EPushDelivery(t *testing.T) {
 	defer c.Close()
 
 	time.Sleep(200 * time.Millisecond)
-	require.NoError(t, yield(newDiscordEvent("g", "c", "alice", "push test", time.Now())))
+	require.NoError(t, yield(context.Background(), newDiscordEvent("g", "c", "alice", "push test", time.Now())))
 	time.Sleep(500 * time.Millisecond)
 
 	mu.Lock()
@@ -394,7 +394,7 @@ func TestE2EWebhookDelivery(t *testing.T) {
 	assignedSecret = clientSecret
 	mu.Unlock()
 
-	require.NoError(t, yield(newDiscordEvent("g", "c", "bob", "webhook test", time.Now())))
+	require.NoError(t, yield(context.Background(), newDiscordEvent("g", "c", "bob", "webhook test", time.Now())))
 	time.Sleep(500 * time.Millisecond)
 
 	mu.Lock()
@@ -447,7 +447,7 @@ func TestE2EResourceRead(t *testing.T) {
 	srv, _, yield, _ := buildTestStack()
 	c, _ := connectClient(t, srv)
 
-	require.NoError(t, yield(newDiscordEvent("g", "c", "alice", "resource test", time.Now())))
+	require.NoError(t, yield(context.Background(), newDiscordEvent("g", "c", "alice", "resource test", time.Now())))
 
 	text, err := c.ReadResource("discord://messages/recent")
 	require.NoError(t, err)
@@ -506,7 +506,7 @@ func TestE2EWebhookDelivery_StandardHeaders(t *testing.T) {
 	assignedSecret = clientSecret
 	mu.Unlock()
 
-	require.NoError(t, yield(newDiscordEvent("g", "c", "alice", "standard-headers test", time.Now())))
+	require.NoError(t, yield(context.Background(), newDiscordEvent("g", "c", "alice", "standard-headers test", time.Now())))
 	time.Sleep(500 * time.Millisecond)
 
 	mu.Lock()
@@ -559,7 +559,7 @@ func TestE2EWebhookDelivery_MCPHeadersOptIn(t *testing.T) {
 	assignedSecret = clientSecret
 	mu.Unlock()
 
-	require.NoError(t, yield(newDiscordEvent("g", "c", "alice", "mcp-headers test", time.Now())))
+	require.NoError(t, yield(context.Background(), newDiscordEvent("g", "c", "alice", "mcp-headers test", time.Now())))
 	time.Sleep(500 * time.Millisecond)
 
 	mu.Lock()
@@ -599,7 +599,7 @@ func TestE2ECursorlessPushDelivery(t *testing.T) {
 	defer c.Close()
 
 	time.Sleep(200 * time.Millisecond)
-	require.NoError(t, yieldTyping(newDiscordTypingEvent("g", "c", "alice", time.Now())))
+	require.NoError(t, yieldTyping(context.Background(), newDiscordTypingEvent("g", "c", "alice", time.Now())))
 	time.Sleep(500 * time.Millisecond)
 
 	mu.Lock()
@@ -651,7 +651,7 @@ func TestE2ECursorlessWebhookDelivery(t *testing.T) {
 	mu.Unlock()
 	_ = assignedSecret
 
-	require.NoError(t, yieldTyping(newDiscordTypingEvent("g", "c", "alice", time.Now())))
+	require.NoError(t, yieldTyping(context.Background(), newDiscordTypingEvent("g", "c", "alice", time.Now())))
 	time.Sleep(500 * time.Millisecond)
 
 	mu.Lock()
@@ -670,7 +670,7 @@ func TestE2ECursorlessPollAlwaysEmpty(t *testing.T) {
 	c, _ := connectClient(t, srv)
 
 	for i := 0; i < 3; i++ {
-		require.NoError(t, yieldTyping(newDiscordTypingEvent("g", "c", "alice", time.Now())))
+		require.NoError(t, yieldTyping(context.Background(), newDiscordTypingEvent("g", "c", "alice", time.Now())))
 	}
 
 	result, err := c.Call("events/poll", map[string]any{
@@ -693,8 +693,8 @@ func TestE2ESubscribeCursorNullOnCursoredSourceReturnsLatest(t *testing.T) {
 	srv, source, yield, _ := buildTestStack()
 	c, _ := connectClient(t, srv)
 
-	require.NoError(t, yield(newDiscordEvent("g", "c", "a", "first", time.Now())))
-	require.NoError(t, yield(newDiscordEvent("g", "c", "b", "second", time.Now())))
+	require.NoError(t, yield(context.Background(), newDiscordEvent("g", "c", "a", "first", time.Now())))
+	require.NoError(t, yield(context.Background(), newDiscordEvent("g", "c", "b", "second", time.Now())))
 	expected := source.Latest()
 	require.NotEmpty(t, expected, "precondition: source has a head cursor")
 
@@ -744,8 +744,8 @@ func TestE2EResourceByCursor(t *testing.T) {
 	srv, _, yield, _ := buildTestStack()
 	c, _ := connectClient(t, srv)
 
-	require.NoError(t, yield(newDiscordEvent("g", "c", "alice", "first", time.Now())))
-	require.NoError(t, yield(newDiscordEvent("g", "c", "bob", "second", time.Now())))
+	require.NoError(t, yield(context.Background(), newDiscordEvent("g", "c", "alice", "first", time.Now())))
+	require.NoError(t, yield(context.Background(), newDiscordEvent("g", "c", "bob", "second", time.Now())))
 
 	// Cursors are assigned monotonically by NewMemoryStore — first event = "1".
 	text, err := c.ReadResource("discord://message/1")

--- a/examples/events/telegram/e2e_test.go
+++ b/examples/events/telegram/e2e_test.go
@@ -28,7 +28,7 @@ import (
 //
 // The cursorless typing source is registered alongside telegram.message so
 // cursor-shape tests can exercise both modes against the same server.
-func buildTestStack(whOpts ...events.WebhookOption) (*server.Server, *events.YieldingSource[TelegramEventData], func(TelegramEventData) error, *events.WebhookRegistry) {
+func buildTestStack(whOpts ...events.WebhookOption) (*server.Server, *events.YieldingSource[TelegramEventData], func(context.Context, TelegramEventData) error, *events.WebhookRegistry) {
 	// Tests subscribe to httptest URLs (127.0.0.1:N); bypass the
 	// production-default SSRF dial guard (spec §"Webhook Security"
 	// → "SSRF prevention" L464).
@@ -57,7 +57,7 @@ func buildTestStack(whOpts ...events.WebhookOption) (*server.Server, *events.Yie
 // yield closure alongside the message yield. Used by the cursorless e2e
 // tests so they can publish typing events without spinning up a Telegram
 // session.
-func buildTestStackWithTyping() (*server.Server, func(TelegramEventData) error, func(TelegramTypingData) error) {
+func buildTestStackWithTyping() (*server.Server, func(context.Context, TelegramEventData) error, func(context.Context, TelegramTypingData) error) {
 	webhooks := events.NewWebhookRegistry(events.WithWebhookAllowPrivateNetworks(true))
 	source, yield := newTelegramSource()
 	typingSource, yieldTyping := newTelegramTypingSource()
@@ -78,8 +78,8 @@ func buildTestStackWithTyping() (*server.Server, func(TelegramEventData) error, 
 }
 
 // yieldText is a small helper for tests that just need to publish a message.
-func yieldText(yield func(TelegramEventData) error, chatID int64, sender, text string) error {
-	return yield(TelegramEventData{
+func yieldText(yield func(context.Context, TelegramEventData) error, chatID int64, sender, text string) error {
+	return yield(context.Background(), TelegramEventData{
 		ChatID:    strconv.FormatInt(chatID, 10),
 		User:      sender,
 		Text:      text,
@@ -201,7 +201,7 @@ func TestE2EStreamCursorless(t *testing.T) {
 	require.NoError(t, err)
 	defer stream.Stop()
 
-	require.NoError(t, yieldTyping(TelegramTypingData{
+	require.NoError(t, yieldTyping(context.Background(), TelegramTypingData{
 		ChatID: "100", User: "alice",
 		StartedAt: time.Now().Format(time.RFC3339),
 	}))
@@ -507,7 +507,7 @@ func TestE2ECursorlessPushDelivery(t *testing.T) {
 	defer c.Close()
 
 	time.Sleep(200 * time.Millisecond)
-	require.NoError(t, yieldTyping(newTelegramTypingEvent(100, "alice", time.Now())))
+	require.NoError(t, yieldTyping(context.Background(), newTelegramTypingEvent(100, "alice", time.Now())))
 	time.Sleep(500 * time.Millisecond)
 
 	mu.Lock()
@@ -552,7 +552,7 @@ func TestE2ECursorlessWebhookDelivery(t *testing.T) {
 	require.NoError(t, json.Unmarshal(raw.Raw, &resp))
 	assert.Nil(t, resp.Cursor, "subscribe response cursor must be null for cursorless source")
 
-	require.NoError(t, yieldTyping(newTelegramTypingEvent(100, "alice", time.Now())))
+	require.NoError(t, yieldTyping(context.Background(), newTelegramTypingEvent(100, "alice", time.Now())))
 	time.Sleep(500 * time.Millisecond)
 
 	mu.Lock()

--- a/examples/events/telegram/e2e_test.go
+++ b/examples/events/telegram/e2e_test.go
@@ -215,39 +215,6 @@ func TestE2EStreamCursorless(t *testing.T) {
 	}
 }
 
-// TestE2EPushDelivery verifies the library's automatic push fanout — yield()
-// triggers events.Emit via the SetEmitHook wired by Register, and the SSE
-// notification reaches the client. Source author writes no fanout code.
-func TestE2EPushDelivery(t *testing.T) {
-	srv, _, yield, _ := buildTestStack()
-
-	var mu sync.Mutex
-	var received []string
-
-	handler := srv.Handler(server.WithStreamableHTTP(true))
-	ts := httptest.NewServer(handler)
-	defer ts.Close()
-
-	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "push-test", Version: "1.0"},
-		client.WithGetSSEStream(),
-		client.WithNotificationCallback(func(method string, params any) {
-			mu.Lock()
-			defer mu.Unlock()
-			received = append(received, method)
-		}),
-	)
-	require.NoError(t, c.Connect())
-	defer c.Close()
-
-	time.Sleep(200 * time.Millisecond)
-	require.NoError(t, yieldText(yield, 100, "alice", "push test"))
-	time.Sleep(500 * time.Millisecond)
-
-	mu.Lock()
-	defer mu.Unlock()
-	assert.Contains(t, received, "notifications/events/event")
-}
-
 // TestE2EWebhookDelivery verifies webhook fanout via the default modes:
 // Server-generated secret + StandardWebhooks header naming. The latter is
 // the post-r3167245184 default (upstream WG PR#1 line 434, author aligned
@@ -474,48 +441,6 @@ func TestE2EEventsList(t *testing.T) {
 	typing := resp.Events[byName["telegram.typing"]]
 	assert.ElementsMatch(t, []string{"push", "webhook"}, typing.Delivery)
 	assert.True(t, typing.Cursorless, "telegram.typing is cursorless")
-}
-
-// TestE2ECursorlessPushDelivery verifies the cursorless typing source on
-// telegram-events: yield triggers a push notification whose Event.cursor
-// is JSON null on the wire.
-func TestE2ECursorlessPushDelivery(t *testing.T) {
-	srv, _, yieldTyping := buildTestStackWithTyping()
-
-	var mu sync.Mutex
-	var receivedRaw []map[string]any
-
-	handler := srv.Handler(server.WithStreamableHTTP(true))
-	tsrv := httptest.NewServer(handler)
-	defer tsrv.Close()
-
-	c := client.NewClient(tsrv.URL+"/mcp", core.ClientInfo{Name: "cursorless-push", Version: "1.0"},
-		client.WithGetSSEStream(),
-		client.WithNotificationCallback(func(method string, params any) {
-			if method != "notifications/events/event" {
-				return
-			}
-			b, _ := json.Marshal(params)
-			var p map[string]any
-			_ = json.Unmarshal(b, &p)
-			mu.Lock()
-			receivedRaw = append(receivedRaw, p)
-			mu.Unlock()
-		}),
-	)
-	require.NoError(t, c.Connect())
-	defer c.Close()
-
-	time.Sleep(200 * time.Millisecond)
-	require.NoError(t, yieldTyping(context.Background(), newTelegramTypingEvent(100, "alice", time.Now())))
-	time.Sleep(500 * time.Millisecond)
-
-	mu.Lock()
-	defer mu.Unlock()
-	require.Len(t, receivedRaw, 1, "push must deliver the typing event")
-	cursorVal, present := receivedRaw[0]["cursor"]
-	require.True(t, present, "cursor field must be present on the wire")
-	assert.Nil(t, cursorVal, "cursorless event must wire as cursor:null")
 }
 
 // TestE2ECursorlessWebhookDelivery verifies the cursorless typing source's

--- a/examples/events/telegram/handlers_test.go
+++ b/examples/events/telegram/handlers_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
@@ -25,10 +26,10 @@ import (
 
 // preloadedSource constructs a YieldingSource pre-populated with n test
 // messages — the test fixture replacement for the old newTestStore helper.
-func preloadedSource(n int) (*events.YieldingSource[TelegramEventData], func(TelegramEventData) error) {
+func preloadedSource(n int) (*events.YieldingSource[TelegramEventData], func(context.Context, TelegramEventData) error) {
 	source, yield := newTelegramSource()
 	for i := 1; i <= n; i++ {
-		_ = yield(TelegramEventData{
+		_ = yield(context.Background(), TelegramEventData{
 			ChatID:    "100",
 			MessageID: strconv.Itoa(i),
 			User:      "testuser",
@@ -219,7 +220,7 @@ func TestWebhookHMACSignature_MCPHeaders(t *testing.T) {
 
 	event := events.MakeEvent("telegram.message", "evt_1", "1", time.Now(),
 		map[string]string{"text": "hello"})
-	webhooks.Deliver(event)
+	webhooks.Deliver(context.Background(), event)
 
 	time.Sleep(100 * time.Millisecond)
 
@@ -356,7 +357,7 @@ func TestWebhookRetryOnServerError(t *testing.T) {
 
 	event := events.MakeEvent("telegram.message", "evt_retry", "1", time.Now(),
 		map[string]string{"text": "retry me"})
-	webhooks.Deliver(event)
+	webhooks.Deliver(context.Background(), event)
 
 	time.Sleep(3 * time.Second)
 
@@ -384,7 +385,7 @@ func TestWebhookNoRetryOn4xx(t *testing.T) {
 
 	event := events.MakeEvent("telegram.message", "evt_4xx", "1", time.Now(),
 		map[string]string{"text": "no retry"})
-	webhooks.Deliver(event)
+	webhooks.Deliver(context.Background(), event)
 
 	time.Sleep(500 * time.Millisecond)
 

--- a/experimental/ext/events/clients/go/eventsclient_test.go
+++ b/experimental/ext/events/clients/go/eventsclient_test.go
@@ -27,7 +27,7 @@ type fakePayload struct {
 // stack wires a server with one cursored fake.* event source, returns the
 // connected MCP client + the yield closure for the source. Optional
 // WebhookOptions configure the registry for mode-specific tests.
-func stack(t *testing.T, whOpts ...events.WebhookOption) (*client.Client, func(fakePayload) error, *events.WebhookRegistry) {
+func stack(t *testing.T, whOpts ...events.WebhookOption) (*client.Client, func(context.Context, fakePayload) error, *events.WebhookRegistry) {
 	t.Helper()
 
 	// SDK tests subscribe to httptest URLs (127.0.0.1:N). Prepend
@@ -175,7 +175,7 @@ func TestReceiver_DeliversTypedEvents(t *testing.T) {
 	defer sub.Stop()
 	recv.SetSecret(sub.Secret())
 
-	require.NoError(t, yield(fakePayload{Msg: "hello"}))
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "hello"}))
 
 	select {
 	case ev := <-recv.Events():
@@ -211,7 +211,7 @@ func TestReceiver_RejectsBadSignature(t *testing.T) {
 	defer sub.Stop()
 	// deliberately do NOT call recv.SetSecret(sub.Secret())
 
-	require.NoError(t, yield(fakePayload{Msg: "should-be-rejected"}))
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "should-be-rejected"}))
 
 	select {
 	case ev := <-recv.Events():
@@ -244,7 +244,7 @@ func TestReceiver_AcceptsStandardWebhooksHeaders(t *testing.T) {
 	defer sub.Stop()
 	recv.SetSecret(sub.Secret())
 
-	require.NoError(t, yield(fakePayload{Msg: "via-standard-webhooks"}))
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "via-standard-webhooks"}))
 
 	select {
 	case ev := <-recv.Events():
@@ -297,7 +297,7 @@ func TestReceiver_DropsOnFullChannel(t *testing.T) {
 	recv.SetSecret(sub.Secret())
 
 	for i := 0; i < 80; i++ {
-		_ = yield(fakePayload{Msg: "x"})
+		_ = yield(context.Background(), fakePayload{Msg: "x"})
 	}
 	time.Sleep(500 * time.Millisecond)
 

--- a/experimental/ext/events/clients/go/stream_test.go
+++ b/experimental/ext/events/clients/go/stream_test.go
@@ -18,7 +18,7 @@ import (
 // streamStack is a stream-test variant of stack() that lets the test set
 // the server-side StreamHeartbeatInterval (so tests can observe heartbeats
 // quickly without waiting 30s).
-func streamStack(t *testing.T, heartbeat time.Duration) (*client.Client, func(fakePayload) error) {
+func streamStack(t *testing.T, heartbeat time.Duration) (*client.Client, func(context.Context, fakePayload) error) {
 	t.Helper()
 	src, yield := events.NewYieldingSource[fakePayload](events.EventDef{
 		Name:        "fake.event",
@@ -69,7 +69,7 @@ func TestStream_DeliversEventsViaCallback(t *testing.T) {
 	require.NoError(t, err)
 	defer stream.Stop()
 
-	require.NoError(t, yield(fakePayload{Msg: "alpha"}))
+	require.NoError(t, yield(context.Background(), fakePayload{Msg: "alpha"}))
 
 	select {
 	case ev := <-got:


### PR DESCRIPTION
## What changes

Two intertwined cleanups for the events demos:

1. **Signature sweep.** PR 7a53c54 (PR 712 follow-up) widened
   `yield(T) error` → `yield(ctx, T) error` and
   `WebhookRegistry.Deliver(Event)` → `Deliver(ctx, Event)` to thread
   trace context across the events bus (SEP-414). That commit swept
   production adopters under `examples/events/discord` and
   `examples/events/telegram` but missed their `*_test.go` files plus
   the events SDK client module's tests. Three sub-modules have been
   **build-failing** since. `make testall` stages **7b / 7e / 7f**
   surface it. This PR fixes the build by passing
   `context.Background()` at every test call site and widening helper
   return types.
2. **Delete 4 stale tests** asserting the deprecated SSE auto-fanout
   model — `TestE2EPushDelivery` + `TestE2ECursorlessPushDelivery` in
   each of discord and telegram. Once the build was fixed and these
   tests actually ran, they failed because the model they assert no
   longer exists (see Decision log).

No production code changes. All three sub-modules now build clean
AND test clean.

## Reviewer's guide

Read in this order:

1. [experimental/ext/events/clients/go/eventsclient_test.go](https://github.com/panyam/mcpkit/pull/776/files#diff-3713ec86d780f18142504489aa607a78335890e41bf69511ae973b82374e3321) — `stack()` helper return type widened; 4 yield call sites updated.
2. [experimental/ext/events/clients/go/stream_test.go](https://github.com/panyam/mcpkit/pull/776/files#diff-bf11abc4796755663f0c8f26d779654e5ef1d2257376297e9a1bb6c7ed484cb0) — same shape for `streamStack()`; 1 yield call site.
3. [examples/events/discord/e2e_test.go](https://github.com/panyam/mcpkit/pull/776/files#diff-bd0f9a4f8fbde6717f6918e2a0603430a844ae70f3f52e818e73d651d010e6c2) — 2 helper return types (`buildTestStack`, `buildTestStackWithTyping`); ~16 yield / yieldTyping call sites updated; 2 deleted tests (`TestE2EPushDelivery`, `TestE2ECursorlessPushDelivery`).
4. [examples/events/telegram/e2e_test.go](https://github.com/panyam/mcpkit/pull/776/files#diff-27a55bd78a37651bf4987a80418d0c1fe53794658d548054406077e2701d7afb) — 2 helper return types + `yieldText` helper signature + body; 3 yieldTyping call sites updated; 2 deleted tests (same names).
5. [examples/events/telegram/handlers_test.go](https://github.com/panyam/mcpkit/pull/776/files#diff-aa2a519249afecf0fd624f248cdb90c51e31200550c0d6e65a76970102cc877d) — added `context` import; `preloadedSource()` return type + body; 3 `webhooks.Deliver(...)` call sites updated.

## Decision log

- **Deleted rather than rewrote the 4 demo push tests.** They assert: "client connects with `WithGetSSEStream()` + `WithNotificationCallback(...)`, no `events/subscribe`, just `yield()` and expect `notifications/events/event` to fire." That's the pre-7a53c54 "broadcast every yield to all GET-SSE-connected clients" model. The current `localEmitter.Emit` only fans out to webhooks — see the explicit `NewLocalEmitter` godoc at `emitter.go:48-50`: *"The srv argument is accepted for API compatibility but no longer carries any behavior — local stream subscribers receive yielded events through the per-source subscriber-slot channel registered by their handler (events/stream calls source.Subscribe), not through Server.Broadcast."* The current model requires explicit `events/stream`. Rewriting the demo tests to use `events/stream` would duplicate the events SDK's own `stream_test.go` + `stream_routing_test.go` end-to-end coverage. The cursorless wire-shape assertion (`cursor:null` on the wire) is also covered at SDK level.
- **Used `context.Background()` at every test call site.** Tests don't propagate trace context; matches the in-package precedent in `match_transform_test.go` and `webhook_span_test.go`. The "caller-preserves" rule still holds — tests don't set traceparent, so passing background is correct.
- **`replace_all=true` for repetitive patterns** (e.g. `yield(newDiscordEvent` → `yield(context.Background(), newDiscordEvent`) — anchored on the opening paren only, so the nested-paren regex gotcha from CLAUDE.md doesn't apply.

## Risk / blast radius

- Affects: 5 test files in 3 sub-modules.
- No production code touched. No exported API surface change.
- No core/sub-module dep bumps; `make tidy-all` not required.

## Test results

```
cd experimental/ext/events/clients/go && go test ./...  # ok
cd examples/events/discord            && go test ./...  # ok
cd examples/events/telegram           && go test ./...  # ok
```

## Out of scope (deliberately deferred)

None — the surfaced push-delivery test failures are addressed by deletion in this same PR.
