### PR TITLE
events: ttlMs client-suggested + refreshBefore null no-expiry (closes #760)

### DIFF
--- a/experimental/ext/events/DEPLOYMENT.md
+++ b/experimental/ext/events/DEPLOYMENT.md
@@ -94,22 +94,42 @@ Worst-case wall clock for a fully-failing delivery: roughly `5s + 0.5s + 5s + 1s
 - Returning **HTTP 4xx** stops retries. Use 4xx for "I will never accept this" (bad signature, malformed payload). Use 5xx for "try again" (transient infrastructure issue).
 - Returning **HTTP 2xx fast** matters more than the body — the body is ignored. A WAF that buffers responses can hold up the delivery loop briefly but won't cause re-delivery if the upstream returned 2xx.
 
-## TTL refresh as keepalive
+## TTL negotiation and refresh
 
-Webhook subscriptions are soft state. The default TTL is 1 hour, clamped to the spec envelope **[5 min, 24 h]** at `WithWebhookTTL` registration time (out-of-envelope values are clamped and logged). Tests and demos that need sub-minimum TTLs to drive SDK refresh behavior pass `WithUnsafeWebhookTTLBypass` — production deployments MUST NOT use the bypass. Subscribers MUST re-subscribe before the TTL expires or the registry evicts them and deliveries stop.
+Per spec PR1 commit `99f3589c` §"Subscription TTL", the wire shape is a client-suggested TTL the server grants or clamps:
 
-The shipped client SDKs handle this automatically:
+- Request: `ttlMs` is optional and tristate. Absent → server picks. Numeric → suggested ms. Explicit `null` → request no-expiry.
+- Response: `refreshBefore` is always present and nullable. An ISO 8601 string is a finite grant; JSON `null` is a no-expiry grant.
 
-- **Go** (`experimental/ext/events/clients/go`): `Subscription` runs a background loop that re-calls `events/subscribe` at `RefreshFactor × TTL` (default 0.5).
-- **Python** (`experimental/ext/events/clients/python/events_client.py`): `WebhookSubscription` does the same.
+mcpkit's default TTL is 1 hour, clamped to the spec envelope **[5 min, 24 h]** at `WithWebhookTTL` registration time. Client suggestions outside the envelope are clamped UP to the floor (the spec's "one sanctioned exception") or DOWN to the ceiling. Tests and demos that need sub-minimum TTLs to drive SDK refresh behavior pass `WithUnsafeWebhookTTLBypass` — production deployments MUST NOT use the bypass. Per spec there is no rejection path for TTL values: clamping is self-announcing on the wire, so a client reading the granted `refreshBefore` just learns what was actually granted.
 
-Both helpers handle the boundary race: if a refresh hits the registry just after the TTL expired (subscription not found), they immediately re-subscribe and fire the `OnRecover` callback.
+### No-expiry subscriptions
+
+`WithAllowInfiniteWebhookTTL()` opts the registry into accepting `ttlMs: null` requests and returning `refreshBefore: null`. Default is OFF — without the option, `ttlMs: null` collapses to the server-default finite grant, which the client treats like any other finite refresh-before.
+
+A server granting no-expiry accepts the spec's durability obligations:
+
+- subscriptions persist until `events/unsubscribe` or server-initiated termination;
+- subscriptions MUST persist across restarts (no refresh cycle to recover them otherwise — use a durable `WebhookStore` backend like Postgres);
+- verification status MUST be persisted alongside the subscription (a persisted sub resumes delivery without a re-subscribe handshake);
+- TTL expiry no longer GCs orphans — the server MAY drop after sustained delivery failure (failure-based GC) and SHOULD attempt a `terminated` envelope when it does.
+
+The library wires the in-process pieces: prune loop skips no-expiry targets, `WebhookStore` round-trips the nil `ExpiresAt` sentinel, and the response emits `refreshBefore: null`. The deployment-side durability of the store backend is the operator's choice. Failure-based GC + persisted verification status are tracked as follow-up work (issue 764).
+
+### Refresh loop
+
+The shipped client SDKs handle TTL refresh automatically:
+
+- **Go** (`experimental/ext/events/clients/go`): `Subscription` runs a background loop that re-calls `events/subscribe` at `RefreshFactor × (refreshBefore - now)` (default factor 0.5). For no-expiry grants the loop drops to a 1-hour health-check cadence (per spec: "Even with no expiry, clients SHOULD still re-call events/subscribe occasionally" for cursor advancement, `deliveryStatus` observation, and reactivation).
+- **Python** (`experimental/ext/events/clients/python/events_client.py`): `WebhookSubscription` does the same finite-TTL refresh; no-expiry support is pending.
+
+Both Go helpers handle the boundary race: if a refresh hits the registry just after the TTL expired (subscription not found), they immediately re-subscribe and fire the `OnRecover` callback.
 
 **Operational implications:**
 
 - The refresh traffic is `events/subscribe` calls on the MCP wire, **not** webhook traffic. Stateful firewalls between the subscriber and the MCP server need to allow that.
-- If the network between the subscriber and the MCP server flaps, the refresh won't land and the registry will GC the subscription. A new `events/subscribe` once connectivity returns is the recovery path; expect a small gap in deliveries.
-- Sizing: 60 s default TTL × 0.5 refresh factor = one refresh call per subscription per 30 s. With 10K active subscriptions this is ~333 r/s of subscribe traffic — small but not zero.
+- If the network between the subscriber and the MCP server flaps, the refresh won't land and (for finite-TTL subs) the registry will GC the subscription. A new `events/subscribe` once connectivity returns is the recovery path; expect a small gap in deliveries. No-expiry subscriptions survive the flap because the registry doesn't GC them on TTL.
+- Sizing: 1 hour default TTL × 0.5 refresh factor = one refresh call per subscription per 30 min. No-expiry subscriptions drop to one health-check per hour. With 10K active finite subscriptions this is ~5 r/s of subscribe traffic; with 10K no-expiry subs it's ~3 r/s.
 
 ## Webhook secret considerations
 

--- a/experimental/ext/events/clients/go/subscription.go
+++ b/experimental/ext/events/clients/go/subscription.go
@@ -60,19 +60,49 @@ type SubscribeOptions struct {
 	// Zero means no floor (server defaults to "no maxAge"). Resolution is
 	// seconds; sub-second precision is dropped on the wire.
 	MaxAge time.Duration
+
+	// TTLMs is the client's suggested subscription lifetime in
+	// milliseconds (spec PR1 commit 99f3589c §"Subscription TTL").
+	// - nil: omit from the wire — server picks its default
+	// - non-nil: emit on the wire as a JSON number — server SHOULD
+	//   grant ≤ this value (with one exception: clamp UP to server min)
+	//
+	// To request a no-expiry subscription, leave TTLMs nil and set
+	// NoExpiry=true instead. The SDK emits `ttlMs: null` and reads
+	// `refreshBefore: null` from the response.
+	TTLMs *int64
+
+	// NoExpiry, when true, asks the server for a subscription that
+	// never expires (spec PR1 commit 99f3589c). The SDK emits
+	// `ttlMs: null` on the wire. If the server grants it
+	// (refreshBefore: null), the auto-refresh loop drops to an
+	// occasional health-check cadence rather than the
+	// refresh-before-expiry rhythm. If the server is unwilling to
+	// grant no-expiry (operator did not set WithAllowInfiniteWebhookTTL),
+	// the response carries a finite refreshBefore and the SDK
+	// transparently falls back to normal refresh behavior — no client
+	// re-work needed.
+	//
+	// Takes precedence over TTLMs: if both are set, TTLMs is ignored.
+	NoExpiry bool
 }
 
 // Subscription manages an events/subscribe lifecycle with automatic TTL
 // refresh. Construct via Subscribe; stop via Stop or by cancelling the
 // parent context.
 type Subscription struct {
-	mu            sync.RWMutex
-	sess          *client.Client
-	opts          SubscribeOptions
-	id            string
-	secret        string
-	cursor        *string
-	refreshBefore time.Time
+	mu     sync.RWMutex
+	sess   *client.Client
+	opts   SubscribeOptions
+	id     string
+	secret string
+	cursor *string
+	// refreshBefore is nil when the server granted a no-expiry
+	// subscription (spec PR1 commit 99f3589c — response carries
+	// `refreshBefore: null`). The refresh loop drops to an occasional
+	// health-check cadence in that case rather than the
+	// refresh-before-expiry rhythm.
+	refreshBefore *time.Time
 	stop          chan struct{}
 	stopped       chan struct{}
 }
@@ -148,10 +178,18 @@ func (s *Subscription) Cursor() *string {
 
 // RefreshBefore returns the timestamp by which the next refresh must
 // land. Refreshes are scheduled at RefreshFactor * (RefreshBefore - now).
-func (s *Subscription) RefreshBefore() time.Time {
+// Returns nil when the server granted a no-expiry subscription (spec PR1
+// commit 99f3589c) — there is no per-refresh deadline; the SDK refreshes
+// at the configured no-expiry cadence for cursor advancement +
+// deliveryStatus observation.
+func (s *Subscription) RefreshBefore() *time.Time {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.refreshBefore
+	if s.refreshBefore == nil {
+		return nil
+	}
+	t := *s.refreshBefore
+	return &t
 }
 
 // Stop ends the refresh loop. Does not unsubscribe — call sess.Call
@@ -196,6 +234,15 @@ func (s *Subscription) subscribe() error {
 	if len(s.opts.Arguments) > 0 {
 		params["arguments"] = s.opts.Arguments
 	}
+	// ttlMs wire emission (spec PR1 commit 99f3589c). NoExpiry wins
+	// over a numeric TTLMs because the spec's null path is more
+	// specific than any finite suggestion.
+	switch {
+	case s.opts.NoExpiry:
+		params["ttlMs"] = nil // explicit JSON null
+	case s.opts.TTLMs != nil:
+		params["ttlMs"] = *s.opts.TTLMs
+	}
 
 	resp, err := s.sess.Call("events/subscribe", params)
 	if err != nil {
@@ -203,19 +250,24 @@ func (s *Subscription) subscribe() error {
 	}
 
 	// Per spec the response no longer carries `secret` — the SDK
-	// already knows the value it supplied (s.opts.Secret).
+	// already knows the value it supplied (s.opts.Secret). RefreshBefore
+	// is *string because JSON `null` is the server's "no expiry" signal.
 	var result struct {
 		ID            string  `json:"id"`
 		Cursor        *string `json:"cursor"`
-		RefreshBefore string  `json:"refreshBefore"`
+		RefreshBefore *string `json:"refreshBefore"`
 	}
 	if err := unmarshalResult(resp.Raw, &result); err != nil {
 		return fmt.Errorf("decode subscribe response: %w", err)
 	}
 
-	rb, err := time.Parse(time.RFC3339, result.RefreshBefore)
-	if err != nil {
-		return fmt.Errorf("parse refreshBefore %q: %w", result.RefreshBefore, err)
+	var rb *time.Time
+	if result.RefreshBefore != nil {
+		parsed, err := time.Parse(time.RFC3339, *result.RefreshBefore)
+		if err != nil {
+			return fmt.Errorf("parse refreshBefore %q: %w", *result.RefreshBefore, err)
+		}
+		rb = &parsed
 	}
 
 	s.mu.Lock()
@@ -272,13 +324,26 @@ func (s *Subscription) refreshLoop(parent context.Context) {
 	}
 }
 
+// noExpiryRefreshCadence is the SDK's default re-subscribe interval
+// when the server granted a no-expiry subscription. The spec (PR1
+// commit 99f3589c) says: "Even with no expiry, clients SHOULD still
+// re-call events/subscribe occasionally" for cursor advancement,
+// deliveryStatus observation, and reactivation. One hour matches the
+// finite default TTL ceiling, so a noop-refresh of a no-expiry sub
+// does not stand out from a finite-TTL refresh in operator metrics.
+const noExpiryRefreshCadence = 1 * time.Hour
+
 // nextRefreshDelay returns how long to wait before the next refresh.
-// Bounded by [1s, RefreshFactor * (RefreshBefore - now)].
+// For finite grants: bounded by [1s, RefreshFactor * (RefreshBefore - now)].
+// For no-expiry grants (refreshBefore nil): fixed at noExpiryRefreshCadence.
 func (s *Subscription) nextRefreshDelay() time.Duration {
 	s.mu.RLock()
 	rb := s.refreshBefore
 	s.mu.RUnlock()
-	remaining := time.Until(rb)
+	if rb == nil {
+		return noExpiryRefreshCadence
+	}
+	remaining := time.Until(*rb)
 	if remaining <= 0 {
 		return 1 * time.Second
 	}

--- a/experimental/ext/events/clients/go/ttl_wire_test.go
+++ b/experimental/ext/events/clients/go/ttl_wire_test.go
@@ -1,0 +1,195 @@
+package eventsclient_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/panyam/mcpkit/client"
+	"github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/experimental/ext/events"
+	eventsclient "github.com/panyam/mcpkit/experimental/ext/events/clients/go"
+	"github.com/panyam/mcpkit/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Tests for issue 760 — Go SDK's ttlMs wire emission and refreshBefore
+// null no-expiry handling. The client-side counterpart to the
+// negotiation matrix on the server (ttl_negotiation_test.go).
+//
+// Wire sniffing pattern: stand up an httptest.Server with a sniffer
+// handler that captures the request body, then forwards via
+// httputil.ReverseProxy to the real MCP test server. The SDK points
+// at the sniffer URL — every request gets captured before forwarding.
+
+// snifferStack returns a connected MCP client whose requests are
+// captured into the returned holder. Optional whOpts configure the
+// underlying webhook registry (e.g. WithAllowInfiniteWebhookTTL).
+func snifferStack(t *testing.T, whOpts ...events.WebhookOption) (*client.Client, *atomic.Pointer[string]) {
+	t.Helper()
+
+	whOpts = append([]events.WebhookOption{events.WithWebhookAllowPrivateNetworks(true)}, whOpts...)
+	webhooks := events.NewWebhookRegistry(whOpts...)
+	src, _ := events.NewYieldingSource[fakePayload](events.EventDef{
+		Name:        "fake.event",
+		Description: "test source",
+		Delivery:    []string{"push", "poll", "webhook"},
+	})
+
+	srv := server.NewServer(
+		core.ServerInfo{Name: "ttl-wire-test", Version: "0.1.0"},
+		server.WithSubscriptions(),
+	)
+	events.Register(events.Config{
+		Sources:                  []events.EventSource{src},
+		Webhooks:                 webhooks,
+		Server:                   srv,
+		UnsafeAnonymousPrincipal: "test-principal",
+	})
+
+	realTS := httptest.NewServer(srv.Handler(server.WithStreamableHTTP(true)))
+	t.Cleanup(realTS.Close)
+
+	target, err := url.Parse(realTS.URL)
+	require.NoError(t, err)
+
+	captured := atomic.Pointer[string]{}
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	sniffTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Body != nil {
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			// Capture subscribe bodies only; initialize/etc. would clobber.
+			if strings.Contains(string(body), `"method":"events/subscribe"`) {
+				s := string(body)
+				captured.Store(&s)
+			}
+			r.Body = io.NopCloser(bytes.NewReader(body))
+			r.ContentLength = int64(len(body))
+		}
+		proxy.ServeHTTP(w, r)
+	}))
+	t.Cleanup(sniffTS.Close)
+
+	c := client.NewClient(sniffTS.URL+"/mcp", core.ClientInfo{Name: "test", Version: "1.0"})
+	require.NoError(t, c.Connect())
+	return c, &captured
+}
+
+// TestClient_TTLMs_Absent_OmittedFromWire — when SubscribeOptions
+// leaves both TTLMs and NoExpiry at zero, the wire body MUST NOT
+// carry a ttlMs key. Servers reading absent-vs-null at the
+// json.RawMessage layer rely on "absent" actually meaning "key not
+// present in the JSON object."
+func TestClient_TTLMs_Absent_OmittedFromWire(t *testing.T) {
+	c, captured := snifferStack(t)
+	sub, err := eventsclient.Subscribe(context.Background(), c, eventsclient.SubscribeOptions{
+		EventName:   "fake.event",
+		CallbackURL: "http://localhost:1/sink",
+	})
+	require.NoError(t, err)
+	defer sub.Stop()
+
+	wire := derefString(captured)
+	require.NotEmpty(t, wire)
+	assert.NotContains(t, wire, `"ttlMs"`,
+		"absent TTLMs MUST NOT emit a wire key (spec PR1 commit 99f3589c); got %s", wire)
+}
+
+// TestClient_TTLMs_Finite_AppearsAsNumber — a finite TTLMs is on the
+// wire as a JSON number, not a string and not omitted.
+func TestClient_TTLMs_Finite_AppearsAsNumber(t *testing.T) {
+	ms := int64(900_000) // 15 minutes
+	c, captured := snifferStack(t)
+	sub, err := eventsclient.Subscribe(context.Background(), c, eventsclient.SubscribeOptions{
+		EventName:   "fake.event",
+		CallbackURL: "http://localhost:1/sink",
+		TTLMs:       &ms,
+	})
+	require.NoError(t, err)
+	defer sub.Stop()
+
+	wire := derefString(captured)
+	require.NotEmpty(t, wire)
+	assert.Contains(t, wire, `"ttlMs":900000`,
+		"finite TTLMs MUST serialise as a JSON number; got %s", wire)
+}
+
+// TestClient_NoExpiry_AppearsAsNull — NoExpiry=true takes precedence
+// over any TTLMs value and emits an explicit JSON null. Distinguishing
+// null from absent on the wire is what unlocks the no-expiry grant
+// path on the server.
+func TestClient_NoExpiry_AppearsAsNull(t *testing.T) {
+	ms := int64(900_000)
+	c, captured := snifferStack(t, events.WithAllowInfiniteWebhookTTL())
+	sub, err := eventsclient.Subscribe(context.Background(), c, eventsclient.SubscribeOptions{
+		EventName:   "fake.event",
+		CallbackURL: "http://localhost:1/sink",
+		TTLMs:       &ms, // explicitly ignored when NoExpiry=true
+		NoExpiry:    true,
+	})
+	require.NoError(t, err)
+	defer sub.Stop()
+
+	wire := derefString(captured)
+	require.NotEmpty(t, wire)
+	assert.Contains(t, wire, `"ttlMs":null`,
+		"NoExpiry=true MUST emit ttlMs:null verbatim; got %s", wire)
+	assert.NotContains(t, wire, `"ttlMs":900000`,
+		"NoExpiry=true MUST override numeric TTLMs; got %s", wire)
+}
+
+// TestClient_NoExpiry_AcceptsRefreshBeforeNull — the SDK must decode
+// `refreshBefore: null` on the response and surface it via
+// Subscription.RefreshBefore() returning nil.
+func TestClient_NoExpiry_AcceptsRefreshBeforeNull(t *testing.T) {
+	c, _, _ := stack(t, events.WithAllowInfiniteWebhookTTL())
+	sub, err := eventsclient.Subscribe(context.Background(), c, eventsclient.SubscribeOptions{
+		EventName:   "fake.event",
+		CallbackURL: "http://localhost:1/sink",
+		NoExpiry:    true,
+	})
+	require.NoError(t, err)
+	defer sub.Stop()
+
+	assert.Nil(t, sub.RefreshBefore(),
+		"no-expiry grant MUST surface as RefreshBefore() == nil")
+}
+
+// TestClient_NoExpiry_FallbackWhenServerDoesntOptIn — server without
+// WithAllowInfiniteWebhookTTL collapses ttlMs:null into the default
+// finite TTL. The SDK transparently accepts the finite refreshBefore.
+func TestClient_NoExpiry_FallbackWhenServerDoesntOptIn(t *testing.T) {
+	c, _, _ := stack(t) // no WithAllowInfiniteWebhookTTL
+	sub, err := eventsclient.Subscribe(context.Background(), c, eventsclient.SubscribeOptions{
+		EventName:   "fake.event",
+		CallbackURL: "http://localhost:1/sink",
+		NoExpiry:    true,
+	})
+	require.NoError(t, err)
+	defer sub.Stop()
+
+	rb := sub.RefreshBefore()
+	require.NotNil(t, rb, "server without WithAllowInfiniteWebhookTTL MUST return a finite refreshBefore")
+	assert.True(t, rb.After(time.Now()),
+		"finite fallback grant MUST land in the future; got %v", rb)
+}
+
+func derefString(p *atomic.Pointer[string]) string {
+	if v := p.Load(); v != nil {
+		return *v
+	}
+	return ""
+}

--- a/experimental/ext/events/events.go
+++ b/experimental/ext/events/events.go
@@ -755,6 +755,18 @@ func registerSubscribe(srv *server.Server, reg *Registry, webhooks *WebhookRegis
 			} `json:"delivery"`
 			Cursor *string `json:"cursor"`
 			MaxAge int     `json:"maxAge,omitempty"` // spec §"Cursor Lifecycle" L529; seconds, 0 = no floor
+			// TTLMs is the client's suggested subscription lifetime
+			// (spec PR1 commit 99f3589c §"Subscription TTL"). Tristate:
+			// absent (server default), `null` (request no-expiry), or
+			// a non-negative integer (suggest N ms). Decoded as
+			// json.RawMessage because Go's *int64 collapses absent
+			// and null both to nil; the handler passes it through to
+			// WebhookRegistry.NegotiateExpiry which preserves the
+			// distinction. Recommended grant range is minutes up to
+			// ~1 day (spec PR1 commit 6967f2ba) — beyond that, prefer
+			// an explicit `ttlMs: null` no-expiry over a long finite
+			// TTL.
+			TTLMs json.RawMessage `json:"ttlMs"`
 		}
 		if err := json.Unmarshal(params, &req); err != nil {
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, err.Error())
@@ -825,17 +837,20 @@ func registerSubscribe(srv *server.Server, reg *Registry, webhooks *WebhookRegis
 		canonical := canonicalKey(principal, req.Delivery.URL, req.Name, req.Arguments)
 		derivedID := deriveSubscriptionID(canonical)
 
+		noExpiry, expiresOverride := webhooks.NegotiateExpiry(req.TTLMs)
 		expiresAt, isNew := webhooks.Register(RegisterParams{
-			CanonicalKey:  canonical,
-			DerivedID:     derivedID,
-			URL:           req.Delivery.URL,
-			Secret:        req.Delivery.Secret,
-			MaxAgeSeconds: req.MaxAge,
-			EventName:     req.Name,
-			Principal:     principal,
-			Subject:       subSubject,
-			SessionID:     subSessionID,
-			Arguments:     req.Arguments,
+			CanonicalKey:      canonical,
+			DerivedID:         derivedID,
+			URL:               req.Delivery.URL,
+			Secret:            req.Delivery.Secret,
+			MaxAgeSeconds:     req.MaxAge,
+			EventName:         req.Name,
+			Principal:         principal,
+			Subject:           subSubject,
+			SessionID:         subSessionID,
+			Arguments:         req.Arguments,
+			NoExpiry:          noExpiry,
+			ExpiresAtOverride: expiresOverride,
 		})
 
 		// On first registration only, enforce the quota then fire
@@ -910,10 +925,20 @@ func registerSubscribe(srv *server.Server, reg *Registry, webhooks *WebhookRegis
 		// X-MCP-Subscription-Id header value on delivery POSTs (per
 		// §"Webhook Event Delivery" L390). Knowing the id grants no
 		// operations on the subscription (L378).
+		// refreshBefore is always present per spec PR1 commit 99f3589c
+		// §"Subscription TTL". Nullable: a finite grant serializes as
+		// an RFC3339 string; a no-expiry grant (nil expiresAt) serializes
+		// as JSON null. The map[string]any entry MUST stay present in
+		// the no-expiry case — omitting the field would falsely look
+		// like an absent grant to a strict client.
+		var refreshBefore any
+		if expiresAt != nil {
+			refreshBefore = expiresAt.Format(time.RFC3339)
+		}
 		respBody := map[string]any{
 			"id":            derivedID,
 			"cursor":        wireCursor,
-			"refreshBefore": expiresAt.Format(time.RFC3339),
+			"refreshBefore": refreshBefore,
 		}
 		// Include deliveryStatus on refresh response when the target
 		// has prior delivery attempts (spec §"Webhook Delivery

--- a/experimental/ext/events/identity_handler_test.go
+++ b/experimental/ext/events/identity_handler_test.go
@@ -30,12 +30,19 @@ import (
 //   - "" → strict (§"Subscription Identity" → "Authentication required" L361)
 //   - non-empty → escape hatch (events.Config.UnsafeAnonymousPrincipal docs)
 func buildAuthGateStack(t *testing.T, unsafeAnon string) (*server.Server, *WebhookRegistry) {
+	return buildAuthGateStackWithOpts(t, unsafeAnon)
+}
+
+// buildAuthGateStackWithOpts variant lets a test pass extra WebhookOptions
+// (e.g., WithAllowInfiniteWebhookTTL for ttlMs negotiation tests).
+// SSRF private-network allowance is forced on regardless — every test
+// here subscribes to httptest URLs (127.0.0.1:N) and would fail the
+// production dial guard otherwise.
+func buildAuthGateStackWithOpts(t *testing.T, unsafeAnon string, extra ...WebhookOption) (*server.Server, *WebhookRegistry) {
 	t.Helper()
 	srv := server.NewServer(core.ServerInfo{Name: "test", Version: "1.0"})
-	// Tests subscribe to httptest URLs (127.0.0.1:N) — bypass the
-	// production-default SSRF dial guard (spec §"Webhook Security"
-	// → "SSRF prevention" L464).
-	webhooks := NewWebhookRegistry(WithWebhookAllowPrivateNetworks(true))
+	opts := append([]WebhookOption{WithWebhookAllowPrivateNetworks(true)}, extra...)
+	webhooks := NewWebhookRegistry(opts...)
 	Register(Config{
 		Sources:                  []EventSource{fakeSecretValidationSource{}},
 		Webhooks:                 webhooks,

--- a/experimental/ext/events/stores/gorm/webhook_store.go
+++ b/experimental/ext/events/stores/gorm/webhook_store.go
@@ -28,9 +28,12 @@ type webhookRow struct {
 	// Secret is stored as-is; the store relies on disk-level encryption
 	// rather than column-level encryption (pgcrypto is documented as
 	// future hardening in README.md).
-	Secret        string         `gorm:"not null"`
-	ExpiresAt     time.Time      `gorm:"not null"`
-	MaxAgeSeconds int            `gorm:"not null"`
+	Secret string `gorm:"not null"`
+	// ExpiresAt is nullable: NULL means no-expiry per spec PR1 commit
+	// 99f3589c §"Subscription TTL". The events package's
+	// WebhookTarget.ExpiresAt mirrors this with *time.Time.
+	ExpiresAt     *time.Time
+	MaxAgeSeconds int `gorm:"not null"`
 	EventName     string         `gorm:"not null;index:idx_webhooks_principal_event"`
 	Principal     string         `gorm:"not null;index:idx_webhooks_principal_event"`
 	Arguments     map[string]any `gorm:"serializer:json"` // column renamed from params: spec PR1 commit 082166f0

--- a/experimental/ext/events/stores/gorm/webhook_store_test.go
+++ b/experimental/ext/events/stores/gorm/webhook_store_test.go
@@ -10,13 +10,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func ptr[T any](v T) *T { return &v }
+
 func mkTarget(canonicalKey []byte, principal, eventName string) events.WebhookTarget {
 	return events.WebhookTarget{
 		CanonicalKey:  canonicalKey,
 		ID:            "sub_" + principal + "_" + eventName,
 		URL:           "https://example.test/webhook",
 		Secret:        "whsec_test",
-		ExpiresAt:     time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC),
+		ExpiresAt:     ptr(time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)),
 		MaxAgeSeconds: 60,
 		EventName:     eventName,
 		Principal:     principal,
@@ -58,7 +60,8 @@ func TestWebhookStore_GetSaveDeleteCount(t *testing.T) {
 			assert.Equal(t, target.URL, getResp.Target.URL)
 			assert.Equal(t, target.Principal, getResp.Target.Principal)
 			assert.Equal(t, target.Arguments["channel"], getResp.Target.Arguments["channel"])
-			assert.True(t, target.ExpiresAt.Equal(getResp.Target.ExpiresAt))
+			require.NotNil(t, getResp.Target.ExpiresAt, "expected finite ExpiresAt in round-trip")
+			assert.True(t, target.ExpiresAt.Equal(*getResp.Target.ExpiresAt))
 
 			// Update via Save overwrites; FailureCount round-trips
 			target.FailureCount = 3
@@ -119,6 +122,37 @@ func TestWebhookStore_ListReturnsSnapshot(t *testing.T) {
 			countResp, err := store.CountWebhooks(ctx, events.CountWebhooksRequest{})
 			require.NoError(t, err)
 			assert.Equal(t, len(ids), countResp.Count)
+		})
+	}
+}
+
+// TestWebhookStore_NoExpiryRoundTrip verifies that a target with nil
+// ExpiresAt (no-expiry per spec PR1 commit 99f3589c §"Subscription
+// TTL") survives a Save → Get round-trip without the nullable column
+// silently rehydrating as the zero time.Time. Operators relying on
+// failure-based GC for no-expiry subs need the nil sentinel preserved
+// across persistence — a zero-time rehydrate would look like "expired
+// 0001-01-01" to the prune loop guard.
+func TestWebhookStore_NoExpiryRoundTrip(t *testing.T) {
+	for _, bk := range backends(t) {
+		bk := bk
+		t.Run(bk.name, func(t *testing.T) {
+			store := bk.newWebhookStore(t)
+			ctx := context.Background()
+
+			key := []byte("no-expiry-key")
+			target := mkTarget(key, "alice", "fake.event")
+			target.ID = "sub_noexpiry"
+			target.ExpiresAt = nil
+
+			_, err := store.SaveWebhook(ctx, events.SaveWebhookRequest{Target: target})
+			require.NoError(t, err)
+
+			getResp, err := store.GetWebhook(ctx, events.GetWebhookRequest{CanonicalKey: key})
+			require.NoError(t, err)
+			require.True(t, getResp.Found)
+			assert.Nil(t, getResp.Target.ExpiresAt,
+				"no-expiry target MUST round-trip with ExpiresAt nil; got %v", getResp.Target.ExpiresAt)
 		})
 	}
 }

--- a/experimental/ext/events/trace_propagation_test.go
+++ b/experimental/ext/events/trace_propagation_test.go
@@ -277,7 +277,7 @@ func newWebhookRegistryWithTarget(t *testing.T, receiverURL string) *WebhookRegi
 		EventName: "fake.event",
 		URL:       receiverURL,
 		Secret:    generateSecret(),
-		ExpiresAt: time.Now().Add(time.Hour),
+		ExpiresAt: ptrTime(time.Now().Add(time.Hour)),
 		Status:    DeliveryStatus{Active: true},
 	}
 	target.CanonicalKey = canonicalKey("test-principal", receiverURL, "fake.event", nil)

--- a/experimental/ext/events/ttl_negotiation_test.go
+++ b/experimental/ext/events/ttl_negotiation_test.go
@@ -1,0 +1,349 @@
+package events
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Tests for the ttlMs + refreshBefore:null no-expiry shape (issue 760,
+// spec PR1 commits 99f3589c + 6967f2ba). Cover the wire-shape matrix
+// the spec lays out: absent, in-envelope, below floor (clamp UP),
+// above ceiling (clamp DOWN), null without opt-in (finite default),
+// null with opt-in (refreshBefore: null). Plus prune-loop exemption
+// for no-expiry targets and canonical-key stability across ttlMs
+// variants.
+
+const ttlTestReceiverURL = "https://example.test/wh"
+
+func subscribeWithTTL(t *testing.T, srv *server.Server, ttlMsJSON string) map[string]any {
+	t.Helper()
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer receiver.Close()
+
+	// Build the body manually so we can splice an arbitrary `ttlMs`
+	// JSON literal (number, null, or absent) without going through Go's
+	// *int64 collapse.
+	body := `{"name":"fake.event","delivery":{"mode":"webhook","url":"` + receiver.URL +
+		`","secret":"` + generateSecret() + `"}`
+	if ttlMsJSON != "" {
+		body += `,"ttlMs":` + ttlMsJSON
+	}
+	body += `}`
+
+	resp, err := srv.Dispatch(context.Background(), &core.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "events/subscribe",
+		Params: json.RawMessage(body),
+	})
+	require.NoError(t, err)
+	require.Nil(t, resp.Error, "subscribe failed: %+v", resp.Error)
+
+	// resp.Result is the map[string]any the handler returned.
+	raw, err := json.Marshal(resp.Result)
+	require.NoError(t, err)
+	out := map[string]any{}
+	require.NoError(t, json.Unmarshal(raw, &out))
+	return out
+}
+
+// TestSubscribe_TTLMs_Absent_GrantsServerDefault — omitting ttlMs means
+// "server picks." mcpkit's default is 1h (DefaultWebhookTTL); the
+// granted refreshBefore should be ~1h in the future.
+func TestSubscribe_TTLMs_Absent_GrantsServerDefault(t *testing.T) {
+	srv, _ := buildAuthGateStack(t, "test-principal")
+	result := subscribeWithTTL(t, srvAdapter(srv), "")
+
+	rb, ok := result["refreshBefore"].(string)
+	require.True(t, ok, "refreshBefore should be a string for finite grant; got %T", result["refreshBefore"])
+
+	parsed, err := time.Parse(time.RFC3339, rb)
+	require.NoError(t, err)
+	delta := time.Until(parsed)
+	assert.InDelta(t, DefaultWebhookTTL.Seconds(), delta.Seconds(), 5,
+		"absent ttlMs should produce a grant near DefaultWebhookTTL (~1h); got delta=%v", delta)
+}
+
+// TestSubscribe_TTLMs_InEnvelope_GrantedAsSuggested — a suggestion that
+// falls cleanly inside [MinWebhookTTL, MaxWebhookTTL] flows through
+// unmodified. spec PR1 commit 99f3589c: "SHOULD be ≤ the suggestion."
+// mcpkit honours the suggestion verbatim when in-envelope (= the
+// strongest possible ≤).
+func TestSubscribe_TTLMs_InEnvelope_GrantedAsSuggested(t *testing.T) {
+	srv, _ := buildAuthGateStack(t, "test-principal")
+	suggestion := 10 * time.Minute
+	result := subscribeWithTTL(t, srvAdapter(srv), formatMs(suggestion))
+
+	rb, ok := result["refreshBefore"].(string)
+	require.True(t, ok)
+	parsed, err := time.Parse(time.RFC3339, rb)
+	require.NoError(t, err)
+	delta := time.Until(parsed)
+	assert.InDelta(t, suggestion.Seconds(), delta.Seconds(), 5,
+		"in-envelope suggestion should be granted ~verbatim; got delta=%v", delta)
+}
+
+// TestSubscribe_TTLMs_BelowFloor_ClampedUpToMinimum — the spec's "one
+// sanctioned exception" to SHOULD-be-≤: a server MAY clamp UP to its
+// minimum TTL to defend against refresh storms. mcpkit clamps to
+// MinWebhookTTL (5 minutes by default).
+func TestSubscribe_TTLMs_BelowFloor_ClampedUpToMinimum(t *testing.T) {
+	srv, _ := buildAuthGateStack(t, "test-principal")
+	// Suggest 10 seconds — well below the 5-minute floor.
+	result := subscribeWithTTL(t, srvAdapter(srv), formatMs(10*time.Second))
+
+	rb, ok := result["refreshBefore"].(string)
+	require.True(t, ok)
+	parsed, err := time.Parse(time.RFC3339, rb)
+	require.NoError(t, err)
+	delta := time.Until(parsed)
+	assert.InDelta(t, MinWebhookTTL.Seconds(), delta.Seconds(), 5,
+		"sub-floor suggestion should be clamped UP to MinWebhookTTL; got delta=%v", delta)
+}
+
+// TestSubscribe_TTLMs_AboveCeiling_ClampedDownToMaximum — a 1-year
+// suggestion exceeds MaxWebhookTTL (24h); mcpkit clamps DOWN. Spec
+// PR1 commit 99f3589c: "SHOULD be ≤ the suggestion." Clamping down
+// honours the inequality straightforwardly.
+func TestSubscribe_TTLMs_AboveCeiling_ClampedDownToMaximum(t *testing.T) {
+	srv, _ := buildAuthGateStack(t, "test-principal")
+	// Suggest 1 year (well above the 24-hour ceiling).
+	result := subscribeWithTTL(t, srvAdapter(srv), formatMs(365*24*time.Hour))
+
+	rb, ok := result["refreshBefore"].(string)
+	require.True(t, ok)
+	parsed, err := time.Parse(time.RFC3339, rb)
+	require.NoError(t, err)
+	delta := time.Until(parsed)
+	assert.InDelta(t, MaxWebhookTTL.Seconds(), delta.Seconds(), 5,
+		"super-ceiling suggestion should be clamped DOWN to MaxWebhookTTL; got delta=%v", delta)
+}
+
+// TestSubscribe_TTLMs_Null_NotOptedIn_GrantsFiniteDefault — the spec's
+// "A server unwilling to grant it simply returns a finite refreshBefore,
+// which the client treats like any other grant" path. Without
+// WithAllowInfiniteWebhookTTL, `ttlMs: null` collapses to the server
+// default. No rejection.
+func TestSubscribe_TTLMs_Null_NotOptedIn_GrantsFiniteDefault(t *testing.T) {
+	srv, _ := buildAuthGateStack(t, "test-principal")
+	result := subscribeWithTTL(t, srvAdapter(srv), "null")
+
+	rb, ok := result["refreshBefore"].(string)
+	require.True(t, ok, "without opt-in, refreshBefore MUST be a finite RFC3339 string; got %T", result["refreshBefore"])
+	parsed, err := time.Parse(time.RFC3339, rb)
+	require.NoError(t, err)
+	delta := time.Until(parsed)
+	assert.InDelta(t, DefaultWebhookTTL.Seconds(), delta.Seconds(), 5,
+		"null without opt-in should fall through to DefaultWebhookTTL; got delta=%v", delta)
+}
+
+// TestSubscribe_TTLMs_Null_OptedIn_GrantsRefreshBeforeNull — operator
+// opted into no-expiry via WithAllowInfiniteWebhookTTL. ttlMs:null
+// gets the explicit no-expiry grant: refreshBefore serialises as JSON
+// null.
+func TestSubscribe_TTLMs_Null_OptedIn_GrantsRefreshBeforeNull(t *testing.T) {
+	srv, _ := buildAuthGateStackWithOpts(t, "test-principal", WithAllowInfiniteWebhookTTL())
+	result := subscribeWithTTL(t, srvAdapter(srv), "null")
+
+	rb, has := result["refreshBefore"]
+	require.True(t, has, "refreshBefore MUST be present even on no-expiry; got %+v", result)
+	assert.Nil(t, rb, "with opt-in, ttlMs:null MUST emit refreshBefore: null; got %T = %v", rb, rb)
+}
+
+// TestRefreshBefore_WireShape_NullSerialisesAsJSONNull — independent
+// of the handler, the response shape must actually serialise refreshBefore
+// as JSON null, not as the string "null" or as omitted. Marshal the
+// handler's response via json.Marshal and grep the bytes.
+func TestRefreshBefore_WireShape_NullSerialisesAsJSONNull(t *testing.T) {
+	srv, _ := buildAuthGateStackWithOpts(t, "test-principal", WithAllowInfiniteWebhookTTL())
+
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer receiver.Close()
+
+	body := `{"name":"fake.event","ttlMs":null,"delivery":{"mode":"webhook","url":"` + receiver.URL +
+		`","secret":"` + generateSecret() + `"}}`
+	resp, err := srvAdapter(srv).Dispatch(context.Background(), &core.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "events/subscribe",
+		Params: json.RawMessage(body),
+	})
+	require.NoError(t, err)
+	require.Nil(t, resp.Error)
+
+	wireBytes, err := json.Marshal(resp.Result)
+	require.NoError(t, err)
+	assert.Contains(t, string(wireBytes), `"refreshBefore":null`,
+		"no-expiry grant MUST serialise refreshBefore as JSON null; got %s", string(wireBytes))
+}
+
+// TestPruneLoop_SkipsNoExpiryTargets — the prune loop is the GC for
+// finite-TTL subscriptions. Per spec PR1 commit 99f3589c: "TTL expiry
+// no longer garbage-collects orphans" for no-expiry subs. Test:
+// register a no-expiry target with a stale ExpiresAt sentinel (nil),
+// fire pruneExpiredLocked, assert the target survives.
+func TestPruneLoop_SkipsNoExpiryTargets(t *testing.T) {
+	r := NewWebhookRegistry(WithWebhookAllowPrivateNetworks(true), WithAllowInfiniteWebhookTTL())
+
+	// Register one no-expiry + one finite-but-expired target.
+	noExpiryKey := canonicalKey("alice", "https://no.expiry.test/wh", "fake.event", nil)
+	_, _ = r.Register(RegisterParams{
+		CanonicalKey: noExpiryKey, DerivedID: "sub_noexpiry", URL: "https://no.expiry.test/wh",
+		Secret: "whsec_test", EventName: "fake.event", Principal: "alice",
+		NoExpiry: true,
+	})
+	expiredKey := canonicalKey("alice", "https://finite.test/wh", "fake.event", nil)
+	past := time.Now().Add(-1 * time.Hour)
+	_, _ = r.Register(RegisterParams{
+		CanonicalKey: expiredKey, DerivedID: "sub_expired", URL: "https://finite.test/wh",
+		Secret: "whsec_test", EventName: "fake.event", Principal: "alice",
+		ExpiresAtOverride: &past,
+	})
+
+	// pruneExpiredLocked is private; the simplest way to fire it is to
+	// register again, which is documented as "Side effect: prunes
+	// expired targets before registering."
+	probeKey := canonicalKey("alice", "https://probe.test/wh", "fake.event", nil)
+	_, _ = r.Register(RegisterParams{
+		CanonicalKey: probeKey, DerivedID: "sub_probe", URL: "https://probe.test/wh",
+		Secret: "whsec_test", EventName: "fake.event", Principal: "alice",
+	})
+
+	_, foundNoExpiry := r.lookupTarget(noExpiryKey)
+	_, foundExpired := r.lookupTarget(expiredKey)
+	assert.True(t, foundNoExpiry, "no-expiry target MUST survive prune loop")
+	assert.False(t, foundExpired, "expired finite target MUST be pruned")
+}
+
+// TestCanonicalKey_IndependentOfTTLMs — two subscribes with different
+// ttlMs values on the same (principal, name, arguments, url) hit the
+// SAME canonical key, so the registry treats the second as an
+// idempotent refresh. The TTL only changes the resulting ExpiresAt,
+// not the identity.
+func TestCanonicalKey_IndependentOfTTLMs(t *testing.T) {
+	srv, _ := buildAuthGateStack(t, "test-principal")
+
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer receiver.Close()
+
+	secret := generateSecret()
+	subscribe := func(ttlMsJSON string) string {
+		body := `{"name":"fake.event","delivery":{"mode":"webhook","url":"` + receiver.URL +
+			`","secret":"` + secret + `"}`
+		if ttlMsJSON != "" {
+			body += `,"ttlMs":` + ttlMsJSON
+		}
+		body += `}`
+		resp, err := srvAdapter(srv).Dispatch(context.Background(), &core.Request{
+			JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "events/subscribe",
+			Params: json.RawMessage(body),
+		})
+		require.NoError(t, err)
+		require.Nil(t, resp.Error)
+		raw, _ := json.Marshal(resp.Result)
+		var r struct {
+			ID string `json:"id"`
+		}
+		require.NoError(t, json.Unmarshal(raw, &r))
+		return r.ID
+	}
+
+	id1 := subscribe(formatMs(10 * time.Minute))
+	id2 := subscribe(formatMs(1 * time.Hour))
+	id3 := subscribe("")
+	assert.Equal(t, id1, id2, "same (principal, name, url) with different ttlMs MUST hit same canonical id")
+	assert.Equal(t, id1, id3, "absent ttlMs MUST also resolve to the same canonical id")
+}
+
+// TestNegotiateExpiry_DirectMatrix exercises the helper directly so
+// regressions surface without spinning up the dispatch path. Cheap
+// table-driven coverage of the absent/null/numeric branches.
+func TestNegotiateExpiry_DirectMatrix(t *testing.T) {
+	type want struct {
+		noExpiry bool
+		// expectedDuration is roughly time.Until(expiresAt); 0 means
+		// "expect nil" (no-expiry case).
+		expectedDuration time.Duration
+		// tolerance is how much the test allows for the time between
+		// the negotiation call and the assertion.
+		tolerance time.Duration
+	}
+	cases := []struct {
+		name        string
+		raw         string
+		allowInfTTL bool
+		want        want
+	}{
+		{"absent", "", false, want{false, DefaultWebhookTTL, 2 * time.Second}},
+		{"null without opt-in", "null", false, want{false, DefaultWebhookTTL, 2 * time.Second}},
+		{"null with opt-in", "null", true, want{true, 0, 0}},
+		{"in-envelope number", formatMs(10 * time.Minute), false, want{false, 10 * time.Minute, 2 * time.Second}},
+		{"below floor", "10000", false, want{false, MinWebhookTTL, 2 * time.Second}},
+		{"above ceiling", formatMs(365 * 24 * time.Hour), false, want{false, MaxWebhookTTL, 2 * time.Second}},
+		{"negative ms treated as absent", "-1", false, want{false, DefaultWebhookTTL, 2 * time.Second}},
+		{"garbage treated as absent", `"not a number"`, false, want{false, DefaultWebhookTTL, 2 * time.Second}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := []WebhookOption{WithWebhookAllowPrivateNetworks(true)}
+			if tc.allowInfTTL {
+				opts = append(opts, WithAllowInfiniteWebhookTTL())
+			}
+			r := NewWebhookRegistry(opts...)
+			noExpiry, expiresAt := r.NegotiateExpiry(json.RawMessage(tc.raw))
+			assert.Equal(t, tc.want.noExpiry, noExpiry)
+			if tc.want.noExpiry {
+				assert.Nil(t, expiresAt)
+				return
+			}
+			require.NotNil(t, expiresAt)
+			delta := time.Until(*expiresAt)
+			assert.InDelta(t, tc.want.expectedDuration.Seconds(), delta.Seconds(), tc.want.tolerance.Seconds())
+		})
+	}
+}
+
+// srvAdapter exists only to let earlier iterations of these tests
+// pass an interface to the dispatch fixture. Final shape just passes
+// *server.Server through, so this is a no-op identity that keeps the
+// call sites readable.
+func srvAdapter(s *server.Server) *server.Server { return s }
+
+func formatMs(d time.Duration) string {
+	return formatInt(d.Milliseconds())
+}
+
+func formatInt(n int64) string {
+	// itoa without depending on strconv just for one call.
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/experimental/ext/events/webhook.go
+++ b/experimental/ext/events/webhook.go
@@ -154,6 +154,114 @@ func WithUnsafeWebhookTTLBypass() WebhookOption {
 	}
 }
 
+// WithAllowInfiniteWebhookTTL gates the events/subscribe handler's
+// acceptance of `ttlMs: null` requests. Per spec PR1 commit 99f3589c
+// §"Subscription TTL": a client suggesting `ttlMs: null` is asking for
+// a no-expiry subscription, and the server's grant of `refreshBefore:
+// null` is the acceptance signal. Default is OFF — handlers translate
+// `ttlMs: null` into the server's default TTL grant ("A server
+// unwilling to grant it simply returns a finite refreshBefore, which
+// the client treats like any other grant").
+//
+// A server opting in accepts the spec's durability obligations:
+//
+//   - the client is not expected to refresh or unsubscribe, ever — the
+//     server keeps the subscription alive
+//   - subscriptions MUST persist across server restarts (no refresh
+//     cycle to recover them otherwise)
+//   - persisted verification status MUST travel with the subscription
+//     (no later handshake to re-verify the endpoint)
+//   - TTL expiry no longer garbage-collects orphans — the server MAY
+//     drop after sustained delivery failure (failure-based GC) and
+//     SHOULD attempt a `terminated` envelope when it does
+//
+// mcpkit's library wires up the in-process side (prune loop skips
+// no-expiry, the WebhookStore seam preserves them, and the response
+// emits `refreshBefore: null`); the deployment-side durability of the
+// store backend, the failure-based GC, and the persisted-verification
+// pieces are operator obligations the option signals consent to. The
+// failure-based GC + verification persistence are tracked under
+// follow-up issue 764.
+func WithAllowInfiniteWebhookTTL() WebhookOption {
+	return func(r *WebhookRegistry) {
+		r.allowInfiniteWebhookTTL = true
+	}
+}
+
+// AllowsInfiniteWebhookTTL reports whether the registry has been opted
+// into accepting `ttlMs: null` requests via WithAllowInfiniteWebhookTTL.
+// The events/subscribe handler reads this to gate its acceptance path;
+// callers using the registry directly do not need to consult it
+// (RegisterParams.NoExpiry bypasses the policy gate by construction —
+// hand-built callers are presumed to know what they're doing).
+func (r *WebhookRegistry) AllowsInfiniteWebhookTTL() bool {
+	return r.allowInfiniteWebhookTTL
+}
+
+// NegotiateExpiry computes the granted ExpiresAt from a client-supplied
+// ttlMs suggestion per spec PR1 commit 99f3589c §"Subscription TTL".
+// Returns (noExpiry=true, expiresAt=nil) when the client suggested
+// `ttlMs: null` AND the registry was opted into infinite TTL via
+// WithAllowInfiniteWebhookTTL. Otherwise returns (false, finite time)
+// — absent / null-without-opt-in / numeric all collapse to a finite
+// grant under the registry's clamp envelope.
+//
+// Per spec there is no rejection path for TTL values: clamping is
+// self-announcing on the wire. A negative or unparseable ttlMs is
+// treated identically to "absent" — the server picks its default.
+//
+// The clamp envelope is [MinWebhookTTL, MaxWebhookTTL], with the same
+// WithUnsafeWebhookTTLBypass escape that disables the registry-default
+// clamp at construction (so tests/demos that legitimately need
+// sub-minimum TTLs can request them via ttlMs without the floor
+// silently kicking in).
+//
+// rawTTLMs is the un-decoded `ttlMs` field from the events/subscribe
+// request body. The handler passes it through as json.RawMessage to
+// preserve the absent/null/value tristate that Go's *int64 collapses.
+func (r *WebhookRegistry) NegotiateExpiry(rawTTLMs json.RawMessage) (noExpiry bool, expiresAt *time.Time) {
+	// Absent → server default
+	if len(rawTTLMs) == 0 {
+		t := time.Now().Add(r.ttl)
+		return false, &t
+	}
+
+	trimmed := bytes.TrimSpace(rawTTLMs)
+
+	// Explicit null → client requests no-expiry
+	if bytes.Equal(trimmed, []byte("null")) {
+		if r.allowInfiniteWebhookTTL {
+			return true, nil
+		}
+		// Server unwilling to grant no-expiry → finite default. Spec:
+		// "A server unwilling to grant it simply returns a finite
+		// refreshBefore, which the client treats like any other grant."
+		t := time.Now().Add(r.ttl)
+		return false, &t
+	}
+
+	// Numeric ms — parse and clamp
+	var ms int64
+	if err := json.Unmarshal(trimmed, &ms); err != nil || ms < 0 {
+		t := time.Now().Add(r.ttl)
+		return false, &t
+	}
+	requested := time.Duration(ms) * time.Millisecond
+
+	// Apply envelope clamp unless bypass is active (matches the
+	// registry-default clamp policy at construction time).
+	if !r.ttlClampBypass {
+		if requested < MinWebhookTTL {
+			requested = MinWebhookTTL // clamp UP — spec's "one sanctioned exception"
+		}
+		if requested > MaxWebhookTTL {
+			requested = MaxWebhookTTL // clamp DOWN — server choice, ≤ suggestion
+		}
+	}
+	t := time.Now().Add(requested)
+	return false, &t
+}
+
 // WithWebhookHeaderMode selects the header / signature wire format used for
 // outbound deliveries. Defaults to StandardWebhooks (per upstream WG PR#1
 // line 434, comment r3167245184). See WebhookHeaderMode for the available
@@ -300,12 +408,17 @@ func WithWebhookTracerProvider(tp core.TracerProvider) WebhookOption {
 // bytes. Redundant with CanonicalKey; cheap to store, and the
 // registry already owns the only writer.
 type WebhookTarget struct {
-	CanonicalKey  []byte    // canonical bytes of (principal, url, name, arguments)
-	ID            string    // server-derived routing handle (sub_<base64-of-16-bytes>)
-	URL           string    // delivery callback URL
-	Secret        string    // client-supplied HMAC signing secret (whsec_...)
-	ExpiresAt     time.Time // soft-state TTL expiry
-	MaxAgeSeconds int       // per-spec replay floor (§"Cursor Lifecycle" L529); 0 = no floor
+	CanonicalKey []byte // canonical bytes of (principal, url, name, arguments)
+	ID           string // server-derived routing handle (sub_<base64-of-16-bytes>)
+	URL          string // delivery callback URL
+	Secret       string // client-supplied HMAC signing secret (whsec_...)
+	// ExpiresAt is the soft-state TTL expiry. nil means no expiry — the
+	// subscription persists until events/unsubscribe or server-initiated
+	// termination per spec PR1 commit 99f3589c §"Subscription TTL". The
+	// prune loop and DeliverToTarget MUST guard the nil case; a missing
+	// guard would silently drop no-expiry subs on the first sweep.
+	ExpiresAt     *time.Time
+	MaxAgeSeconds int // per-spec replay floor (§"Cursor Lifecycle" L529); 0 = no floor
 
 	EventName string         // event-type name (used by Match / Transform / OnRemove lookup)
 	Principal string         // resolved subscription principal (used by HookContext)
@@ -408,11 +521,12 @@ const (
 type WebhookRegistry struct {
 	mu                   sync.RWMutex
 	store                WebhookStore // canonicalKey → WebhookTarget; default in-memory
-	client               *http.Client
-	ttl                  time.Duration
-	ttlExplicit          bool // operator passed WithWebhookTTL (drives clamp decision)
-	ttlClampBypass       bool // WithUnsafeWebhookTTLBypass — disables clamp
-	headerMode           WebhookHeaderMode
+	client                  *http.Client
+	ttl                     time.Duration
+	ttlExplicit             bool // operator passed WithWebhookTTL (drives clamp decision)
+	ttlClampBypass          bool // WithUnsafeWebhookTTLBypass — disables clamp
+	allowInfiniteWebhookTTL bool // WithAllowInfiniteWebhookTTL — gates ttlMs:null acceptance in events/subscribe handler (spec PR1 commit 99f3589c §"Subscription TTL")
+	headerMode              WebhookHeaderMode
 	allowPrivateNetworks bool          // when false (default), Dialer.Control rejects private/loopback IPs (spec §"Webhook Security" → "SSRF prevention" L464)
 	extraHeaders         map[string]string // caller-supplied headers (WithWebhookExtraHeaders); applied BEFORE signature/MCP/trace headers so spec-mandated keys always win
 	maxBodyBytes         int           // outbound POST body cap (spec §"Webhook Security" → "Delivery profile" L487); default 256 KiB
@@ -697,6 +811,27 @@ type RegisterParams struct {
 	// WebhookTarget for the longer rationale (issue 709).
 	Subject   string
 	SessionID string
+
+	// NoExpiry, when true, registers the subscription with no TTL
+	// backstop. WebhookTarget.ExpiresAt becomes nil, the prune loop
+	// skips it, and the events/subscribe handler emits
+	// refreshBefore: null on the response. Spec PR1 commit 99f3589c
+	// §"Subscription TTL": this maps to a `ttlMs: null` client
+	// suggestion that the server has chosen to grant.
+	//
+	// Callers using the registry directly (tests, low-level hand-built
+	// integrations) can set this freely; the events/subscribe handler
+	// gates the path behind WithAllowInfiniteWebhookTTL() because
+	// granting no-expiry shifts durability obligations onto the server.
+	NoExpiry bool
+
+	// ExpiresAtOverride, when non-nil and NoExpiry is false, overrides
+	// the registry's r.ttl-based computation. The events/subscribe
+	// handler uses this to inject a per-request TTL derived from the
+	// client's ttlMs suggestion (clamped to the registry's envelope).
+	// Nil + NoExpiry false reverts to the registry's default — preserves
+	// the pre-#760 behavior for unchanged callers.
+	ExpiresAtOverride *time.Time
 }
 
 // Register adds or refreshes a webhook subscription keyed on the spec's
@@ -704,7 +839,10 @@ type RegisterParams struct {
 // Two calls with the same CanonicalKey refer to the same subscription
 // — second call refreshes TTL + replaces secret.
 //
-// Returns (expiresAt, isNew). isNew is true on first registration
+// Returns (expiresAt, isNew). expiresAt is nil when the registration
+// is no-expiry (RegisterParams.NoExpiry true) — the caller's response
+// emitter then sends `refreshBefore: null` per spec PR1 commit
+// 99f3589c §"Subscription TTL". isNew is true on first registration
 // (caller fires safeOnSubscribe per spec §"Server SDK Guidance" L691)
 // and false on refresh — refresh ≠ subscribe, so on_subscribe MUST
 // NOT re-fire. Caller resolves the distinction; the registry just
@@ -727,15 +865,30 @@ type RegisterParams struct {
 // target fires the onRemove hooks — TTL expiry counts as an
 // unsubscribe (spec §"Server SDK Guidance" → "Unsubscribe timing by
 // mode" L707).
-func (r *WebhookRegistry) Register(p RegisterParams) (expiresAt time.Time, isNew bool) {
+func (r *WebhookRegistry) Register(p RegisterParams) (expiresAt *time.Time, isNew bool) {
 	r.mu.Lock()
 	pruned := r.pruneExpiredLocked()
-	expiresAt = time.Now().Add(r.ttl)
+	// Negotiated expiry per spec PR1 commit 99f3589c §"Subscription
+	// TTL". Precedence: NoExpiry > ExpiresAtOverride > registry default.
+	switch {
+	case p.NoExpiry:
+		expiresAt = nil
+	case p.ExpiresAtOverride != nil:
+		expiresAt = p.ExpiresAtOverride
+	default:
+		fallback := time.Now().Add(r.ttl)
+		expiresAt = &fallback
+	}
 	getResp, _ := r.store.GetWebhook(context.Background(), GetWebhookRequest{CanonicalKey: p.CanonicalKey})
 	if getResp.Found {
 		existing := getResp.Target
 		// Refresh: update expiry and secret if provided. Secret rotation
-		// per spec is allowed by supplying a new value on refresh.
+		// per spec is allowed by supplying a new value on refresh. The
+		// new ExpiresAt replaces the prior value verbatim — a refresh
+		// converting finite → no-expiry (or vice versa) is what spec
+		// PR1 commit 99f3589c's Table allows ("a client can lengthen
+		// or shorten its refresh cadence, or convert a no-expiry
+		// subscription back to a finite one").
 		existing.ExpiresAt = expiresAt
 		if p.Secret != "" {
 			existing.Secret = p.Secret
@@ -824,7 +977,12 @@ func (r *WebhookRegistry) Targets() []WebhookTarget {
 	listResp, _ := r.store.ListWebhooks(context.Background(), ListWebhooksRequest{})
 	out := make([]WebhookTarget, 0, len(listResp.Targets))
 	for _, t := range listResp.Targets {
-		if t.ExpiresAt.After(now) && t.Status.Active {
+		if !t.Status.Active {
+			continue
+		}
+		// nil ExpiresAt = no-expiry, always live. Finite must be in
+		// the future.
+		if t.ExpiresAt == nil || t.ExpiresAt.After(now) {
 			out = append(out, t)
 		}
 	}
@@ -858,7 +1016,15 @@ func (r *WebhookRegistry) pruneExpiredLocked() []WebhookTarget {
 	listResp, _ := r.store.ListWebhooks(ctx, ListWebhooksRequest{})
 	var removed []WebhookTarget
 	for _, t := range listResp.Targets {
-		if t.ExpiresAt.After(now) || t.ExpiresAt.Equal(now) {
+		// No-expiry targets have nil ExpiresAt — they are explicitly
+		// exempted from TTL-based GC per spec PR1 commit 99f3589c
+		// §"Subscription TTL": "TTL expiry no longer garbage-collects
+		// orphans or dead endpoints." Their cleanup is failure-based
+		// GC, tracked under follow-up issue 764.
+		if t.ExpiresAt == nil {
+			continue
+		}
+		if (*t.ExpiresAt).After(now) || (*t.ExpiresAt).Equal(now) {
 			continue
 		}
 		delResp, _ := r.store.DeleteWebhook(ctx, DeleteWebhookRequest{CanonicalKey: t.CanonicalKey})
@@ -893,7 +1059,13 @@ func (r *WebhookRegistry) DeliverToTarget(ctx context.Context, canonicalKey []by
 		return false
 	}
 	target := resp.Target
-	if !target.Status.Active || time.Now().After(target.ExpiresAt) {
+	if !target.Status.Active {
+		return false
+	}
+	// nil ExpiresAt = no-expiry subscription, always live (spec PR1
+	// commit 99f3589c §"Subscription TTL"). Only finite expiry can
+	// disqualify a target from delivery.
+	if target.ExpiresAt != nil && time.Now().After(*target.ExpiresAt) {
 		return false
 	}
 
@@ -913,6 +1085,11 @@ func (r *WebhookRegistry) DeliverToTarget(ctx context.Context, canonicalKey []by
 }
 
 // ExpireAll forcibly expires all subscriptions (test helper).
+//
+// No-expiry targets (ExpiresAt nil) are stamped with a past time so
+// they're swept too — the spec's "TTL expiry no longer GCs" exemption
+// is a runtime-prune contract, not a "tests can't force a clean state"
+// rule. Tests calling this expect a real clean slate.
 func (r *WebhookRegistry) ExpireAll() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -920,7 +1097,7 @@ func (r *WebhookRegistry) ExpireAll() {
 	ctx := context.Background()
 	listResp, _ := r.store.ListWebhooks(ctx, ListWebhooksRequest{})
 	for _, t := range listResp.Targets {
-		t.ExpiresAt = past
+		t.ExpiresAt = &past
 		_, _ = r.store.SaveWebhook(ctx, SaveWebhookRequest{Target: t})
 	}
 }

--- a/experimental/ext/events/webhook_span_test.go
+++ b/experimental/ext/events/webhook_span_test.go
@@ -213,7 +213,7 @@ func registerTestTarget(t *testing.T, wh *WebhookRegistry, receiverURL string) {
 		EventName: "fake.event",
 		URL:       receiverURL,
 		Secret:    generateSecret(),
-		ExpiresAt: time.Now().Add(time.Hour),
+		ExpiresAt: ptrTime(time.Now().Add(time.Hour)),
 		Status:    DeliveryStatus{Active: true},
 	}
 	target.CanonicalKey = canonicalKey("test-principal", receiverURL, "fake.event", nil)

--- a/experimental/ext/events/webhook_store_test.go
+++ b/experimental/ext/events/webhook_store_test.go
@@ -16,7 +16,7 @@ func newTestTarget(keyByte byte) WebhookTarget {
 		ID:           "sub_test_" + string([]byte{keyByte}),
 		URL:          "http://example.test/sink",
 		Secret:       "whsec_test_secret_xxxxxxxxxxxxxxxxxxxx",
-		ExpiresAt:    time.Now().Add(time.Hour),
+		ExpiresAt:    ptrTime(time.Now().Add(time.Hour)),
 		EventName:    "test.event",
 		Status:       DeliveryStatus{Active: true},
 	}
@@ -34,7 +34,8 @@ func TestInMemoryWebhookStore_SaveThenGetRoundTrip(t *testing.T) {
 	assert.Equal(t, want.ID, resp.Target.ID)
 	assert.Equal(t, want.URL, resp.Target.URL)
 	assert.Equal(t, want.Secret, resp.Target.Secret)
-	assert.WithinDuration(t, want.ExpiresAt, resp.Target.ExpiresAt, time.Millisecond)
+	require.NotNil(t, resp.Target.ExpiresAt)
+	assert.WithinDuration(t, *want.ExpiresAt, *resp.Target.ExpiresAt, time.Millisecond)
 }
 
 func TestInMemoryWebhookStore_DeleteSemantics(t *testing.T) {


### PR DESCRIPTION
## What changes

Adds the client-suggested-TTL negotiation surface to webhook subscriptions plus a server-side opt-in for no-expiry grants, tracking spec PR1 commits `99f3589c` (2026-06-11) and `6967f2ba` (2026-06-15 — recommended TTL grant range).

Wire shape:

- Request: `ttlMs` is optional + tristate. Absent → server picks. Numeric → suggested ms. Explicit `null` → request no-expiry.
- Response: `refreshBefore` is always present + nullable. RFC3339 string = finite grant. JSON `null` = no-expiry.

Negotiation rules per spec:

- Grant SHOULD be ≤ suggestion, with one exception — clamp UP to a server minimum to protect against refresh storms.
- No rejection path. Clamping is self-announcing on the wire; clients read the granted `refreshBefore` and just schedule from that.
- `refreshBefore: null` ONLY when client suggested `ttlMs: null` AND the server opted into infinite-TTL grants via `WithAllowInfiniteWebhookTTL()`. A server unwilling to grant no-expiry transparently returns a finite default and the client treats it like any other grant.

## Reviewer's guide

Read in this order:

1. [experimental/ext/events/webhook.go](https://github.com/panyam/mcpkit/pull/779/files#diff-f61c2bd42ae83936aba2fe7dab3bcda1606ca810bd7263d9afbe42147f9c8f5a) — start here. `WebhookTarget.ExpiresAt` flips from `time.Time` to `*time.Time` (nil = no-expiry sentinel). `RegisterParams` gains `NoExpiry bool` + `ExpiresAtOverride *time.Time`. `WithAllowInfiniteWebhookTTL()` + `NegotiateExpiry(json.RawMessage)` are the new public surface. Prune loop + `Targets()` + `DeliverToTarget` all guard the nil case.
2. [experimental/ext/events/events.go](https://github.com/panyam/mcpkit/pull/779/files#diff-4a2a8cf5f00e8770df09ab463340a5fc393acbf3f95ef59af8280e2a7a814815) — subscribe handler now decodes `ttlMs` as `json.RawMessage` (Go's `*int64` collapses absent/null), runs `NegotiateExpiry`, and emits `refreshBefore` as either RFC3339 or JSON null. The response always includes the field.
3. [experimental/ext/events/ttl_negotiation_test.go](https://github.com/panyam/mcpkit/pull/779/files#diff-f1fdac8aba4b8d8f39f015316914e71439e41b9cc935502a3885774feba27f06) — full negotiation matrix on the server side (absent / in-envelope / below floor / above ceiling / null without opt-in / null with opt-in) plus prune-loop exemption and canonical-key independence from `ttlMs`.
4. [experimental/ext/events/clients/go/subscription.go](https://github.com/panyam/mcpkit/pull/779/files#diff-0559352a94fe62221a9c68f68addcc91fa11a97e407649b5da9fd8a1b241a6ed) — SDK gains `TTLMs *int64` + `NoExpiry bool` options. `Subscription.RefreshBefore()` returns `*time.Time` (nil for no-expiry). Refresh loop drops to a 1-hour health-check cadence for no-expiry grants.
5. [experimental/ext/events/clients/go/ttl_wire_test.go](https://github.com/panyam/mcpkit/pull/779/files#diff-94a856d0815d49bc1b352f82314fe933128c6207f93e165666664780ab61dc86) — SDK wire emission pins via an httptest reverse-proxy sniffer.
6. [experimental/ext/events/stores/gorm/webhook_store.go](https://github.com/panyam/mcpkit/pull/779/files#diff-5d145f53ca960584c0bdde7ebfbb8e41504aebef9352329c6f3d01ab576c38fc) — column type change to nullable; nil sentinel round-trip pinned by `TestWebhookStore_NoExpiryRoundTrip`.
7. [experimental/ext/events/DEPLOYMENT.md](https://github.com/panyam/mcpkit/pull/779/files#diff-c75bb17c9b123df102747038873bda868dc6e576a2eba2b10b4fd373a8a8f0b3) — TTL section expanded with the no-expiry path and the durability obligations the opt-in implies.

Skim or skip: the test-fixture sweeps in `webhook_store_test.go` / `webhook_span_test.go` / `trace_propagation_test.go` (mechanical `time.Time` → `*time.Time` updates).

## Decision log

- **`*time.Time` over a zero-time sentinel for `WebhookTarget.ExpiresAt`** — explicit nil guard at every deref over a "zero = no-expiry" convention that's easy to miss. The compiler doesn't catch a missing nil-check, but the code reads correctly at every callsite.
- **`json.RawMessage` for the `ttlMs` request field** — `*int64` collapses absent and null in Go; `RawMessage` preserves the tristate. Decoding stays localized to the handler; no new exported type pollution.
- **`NegotiateExpiry` is a public method on `*WebhookRegistry`** — registry owns TTL policy (it already owns the envelope `[Min, Max]WebhookTTL` and the `WithUnsafeWebhookTTLBypass` toggle). External callers building hand-rolled subscribe handlers can re-use it.
- **`WithAllowInfiniteWebhookTTL` is default OFF** — granting no-expiry shifts durability obligations onto the server (persist across restarts, persist verification status, failure-based GC). Default opt-in would be a footgun for operators who haven't wired a durable store. The Go SDK's `NoExpiry: true` transparently falls back when the server doesn't opt in.
- **Refresh loop drops to 1-hour cadence for no-expiry, not zero** — spec: "Even with no expiry, clients SHOULD still re-call events/subscribe occasionally" for cursor advancement, `deliveryStatus` observation, and reactivation.
- **Prune loop explicitly exempts no-expiry targets** — per spec PR1 commit `99f3589c`: "TTL expiry no longer garbage-collects orphans or dead endpoints" for no-expiry subs. Their cleanup is failure-based GC, tracked under #764.
- **GORM column rename (nullable `ExpiresAt`)** — fresh deploys only per the just-established convention from #778.

## Risk / blast radius

- **`WebhookTarget.ExpiresAt` type change** — every consumer that reads this field needs nil handling. In-tree consumers (registry, prune loop, GORM store, response emitter, all test fixtures) are updated; external `WebhookStore` implementors would need to update.
- **GORM column nullability** — `expires_at TIMESTAMP NOT NULL` → `expires_at TIMESTAMP NULL`. Fresh deploys only.
- **`WithAllowInfiniteWebhookTTL()` is a real policy decision** — operators who flip it ON without persistent storage will hand out no-expiry subscriptions that vanish on restart, which is the opposite of what no-expiry means. DEPLOYMENT.md spells this out.
- **Tests covering this:** 9 new tests on the server side (`ttl_negotiation_test.go`), 5 new tests on the SDK side (`ttl_wire_test.go`), 1 new round-trip test on the GORM store, plus the full pre-existing events suite (~84 s) and the GORM/Redis/memory store suites all pass.

## Out of scope (deferred)

- Server-side durability obligations for no-expiry grants → `panyam/mcpkit#764` — failure-based GC, persisted verification, restart-survival
- Endpoint verification persistence → `panyam/mcpkit#490`
- `terminated` envelope on server-initiated drop after sustained failure → `panyam/mcpkit#764`
- Python client SDK update — no current subscribe-with-arguments path; will follow when Python client gains the surface
