### PR TITLE
events: failure-based GC for no-expiry subscriptions (closes #764)

### DIFF
--- a/experimental/ext/events/DEPLOYMENT.md
+++ b/experimental/ext/events/DEPLOYMENT.md
@@ -114,7 +114,13 @@ A server granting no-expiry accepts the spec's durability obligations:
 - verification status MUST be persisted alongside the subscription (a persisted sub resumes delivery without a re-subscribe handshake);
 - TTL expiry no longer GCs orphans — the server MAY drop after sustained delivery failure (failure-based GC) and SHOULD attempt a `terminated` envelope when it does.
 
-The library wires the in-process pieces: prune loop skips no-expiry targets, `WebhookStore` round-trips the nil `ExpiresAt` sentinel, and the response emits `refreshBefore: null`. The deployment-side durability of the store backend is the operator's choice. Failure-based GC + persisted verification status are tracked as follow-up work (issue 764).
+The library wires the in-process pieces: prune loop skips no-expiry targets, `WebhookStore` round-trips the nil `ExpiresAt` sentinel, and the response emits `refreshBefore: null`.
+
+**Failure-based GC.** Each delivery failure anchors a `FailingContinuouslySince` timestamp on the subscription (distinct from the existing `FailedSince` which is reset by the sliding suspend window — the GC anchor is **never** reset by quiet periods, only by a successful delivery). When a no-expiry subscription has been continuously failing for longer than `DefaultNoExpiryFailureGCWindow` (72 hours by default; tune via `WithNoExpiryFailureGCWindow(d time.Duration)`), the registry drops the subscription and POSTs a `terminated` envelope to the receiver as a courtesy notification. The drop fires through the same `PostTerminated` path as `events/unsubscribe` so on-remove hooks run and downstream stores release their per-subscription state. Finite-TTL subscriptions also accumulate `FailingContinuouslySince` for diagnostic purposes but are exempt from the GC trigger — their backstop remains TTL expiry.
+
+**Construction-time validation.** Calling `WithAllowInfiniteWebhookTTL()` without also passing `WithWebhookStore(persistent)` triggers a stark warning at registry construction. No-expiry subscriptions held in the default in-memory store violate the spec's "persist across restarts" obligation — the warning points operators at the GORM-backed implementation as the supported choice. Dev/test setups can ignore it; production deployments must replace the default store.
+
+**Persisted verification status** is the one remaining piece of the spec's no-expiry obligation list still pending — tracked under issue 490 (PostVerification rewrite covering all four verification paths). The current ext/events impl is verification-stub-only; once #490 lands, the stub becomes a real persisted field.
 
 ### Refresh loop
 

--- a/experimental/ext/events/events.go
+++ b/experimental/ext/events/events.go
@@ -959,12 +959,15 @@ func registerSubscribe(srv *server.Server, reg *Registry, webhooks *WebhookRegis
 // Wire shape:
 //
 //	{
-//	  "active":         bool,
-//	  "lastDeliveryAt": "RFC3339" (omitted if nil),
-//	  "lastError":      "categorical" (omitted if empty),
-//	  "failedSince":    "RFC3339" (omitted if nil),
-//	  "throttled":      bool       (omitted if false — spec PR1 commit 21be9c31),
-//	  "retryAfterMs":   int        (omitted if nil — spec PR1 commit 21be9c31)
+//	  "active":                    bool,
+//	  "lastDeliveryAt":            "RFC3339" (omitted if nil),
+//	  "lastError":                 "categorical" (omitted if empty),
+//	  "failedSince":               "RFC3339" (omitted if nil),
+//	  "throttled":                 bool       (omitted if false — spec PR1 commit 21be9c31),
+//	  "retryAfterMs":              int        (omitted if nil — spec PR1 commit 21be9c31),
+//	  "failingContinuouslySince":  "RFC3339" (omitted if nil — diagnostic, drives
+//	                                          no-expiry failure-GC per spec PR1
+//	                                          commit 99f3589c §"Subscription TTL")
 //	}
 func deliveryStatusForResponse(s DeliveryStatus) (map[string]any, bool) {
 	// "Nothing to report" = no successes AND no failures AND not throttled.
@@ -990,6 +993,9 @@ func deliveryStatusForResponse(s DeliveryStatus) (map[string]any, bool) {
 	}
 	if s.RetryAfterMs != nil {
 		out["retryAfterMs"] = *s.RetryAfterMs
+	}
+	if s.FailingContinuouslySince != nil {
+		out["failingContinuouslySince"] = s.FailingContinuouslySince.Format(time.RFC3339)
 	}
 	return out, true
 }

--- a/experimental/ext/events/failure_gc_test.go
+++ b/experimental/ext/events/failure_gc_test.go
@@ -1,0 +1,303 @@
+package events
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Tests for issue 764 — failure-based GC of no-expiry subscriptions.
+// Spec PR1 commit 99f3589c §"Subscription TTL": a server granting
+// no-expiry MAY drop the subscription after sustained delivery
+// failure (server-defined window) and SHOULD attempt a `terminated`
+// envelope.
+//
+// State-machine layering verified here:
+//
+//   - TTL prune (existing, exempted for no-expiry) — covered by
+//     ttl_negotiation_test.go::TestPruneLoop_SkipsNoExpiryTargets
+//   - Suspend (existing, reversible on refresh) — covered by
+//     delivery_status_test.go::TestSuspend_*
+//   - Failure-based GC (new, no-expiry only, irreversible) — covered
+//     here.
+
+// gcTestKey constructs a canonical key consistent with the real
+// subscribe path so the tests exercise the same identity surface.
+func gcTestKey(t *testing.T, principal, eventName, url string) []byte {
+	t.Helper()
+	return canonicalKey(principal, url, eventName, nil)
+}
+
+// registerNoExpiryTarget shoves a no-expiry target straight into the
+// registry, bypassing the events/subscribe handler so the test fixture
+// stays focused on the failure-GC logic. Mirrors what the handler does
+// when WithAllowInfiniteWebhookTTL is enabled and the client sends
+// ttlMs: null.
+func registerNoExpiryTarget(t *testing.T, r *WebhookRegistry, principal, eventName, url string) []byte {
+	t.Helper()
+	key := gcTestKey(t, principal, eventName, url)
+	_, _ = r.Register(RegisterParams{
+		CanonicalKey: key,
+		DerivedID:    "sub_" + principal + "_" + eventName,
+		URL:          url,
+		Secret:       "whsec_" + strings.Repeat("a", 32),
+		EventName:    eventName,
+		Principal:    principal,
+		NoExpiry:     true,
+	})
+	return key
+}
+
+// TestFailureGC_NoExpiry_DropsAfterContinuousFailureWindow — past the
+// configured window of unbroken failure, the registry deletes the
+// subscription entirely AND posts a `terminated` envelope. This is
+// the spec's "MAY drop after sustained delivery failure" path.
+func TestFailureGC_NoExpiry_DropsAfterContinuousFailureWindow(t *testing.T) {
+	r := NewWebhookRegistry(
+		WithWebhookAllowPrivateNetworks(true),
+		WithAllowInfiniteWebhookTTL(),
+		WithNoExpiryFailureGCWindow(50*time.Millisecond),
+	)
+
+	var capturedPath atomic.Pointer[string]
+	recv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		// Capture the webhook-id header so we can verify the GC posted
+		// a `terminated` envelope (vs a normal event delivery).
+		id := req.Header.Get("webhook-id")
+		if strings.HasPrefix(id, "msg_terminated_") {
+			s := id
+			capturedPath.Store(&s)
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer recv.Close()
+
+	key := registerNoExpiryTarget(t, r, "alice", "fake.event", recv.URL)
+
+	// First failure anchors FailingContinuouslySince; verify it's set.
+	r.recordDeliveryFailure(key, DeliveryError5xx)
+	target, found := r.lookupTarget(key)
+	require.True(t, found)
+	require.NotNil(t, target.Status.FailingContinuouslySince,
+		"first failure MUST anchor FailingContinuouslySince")
+
+	// Wait past the GC window.
+	time.Sleep(60 * time.Millisecond)
+
+	// Next failure crosses the window → drop + terminated envelope.
+	r.recordDeliveryFailure(key, DeliveryError5xx)
+
+	_, stillThere := r.lookupTarget(key)
+	assert.False(t, stillThere,
+		"no-expiry sub past GC window MUST be removed from the registry; got found=%v", stillThere)
+
+	// Allow the async terminated envelope to land at the receiver.
+	require.Eventually(t, func() bool { return capturedPath.Load() != nil },
+		2*time.Second, 20*time.Millisecond,
+		"failure-GC drop MUST POST a `terminated` envelope (webhook-id prefix msg_terminated_)")
+}
+
+// TestFailureGC_NoExpiry_DoesNotDropWhileWindowNotElapsed — repeated
+// failures inside the GC window keep the subscription alive (it gets
+// suspended by the existing suspend-threshold path, but not dropped).
+func TestFailureGC_NoExpiry_DoesNotDropWhileWindowNotElapsed(t *testing.T) {
+	r := NewWebhookRegistry(
+		WithWebhookAllowPrivateNetworks(true),
+		WithAllowInfiniteWebhookTTL(),
+		WithNoExpiryFailureGCWindow(10*time.Second), // not going to elapse during this test
+	)
+	recv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer recv.Close()
+
+	key := registerNoExpiryTarget(t, r, "alice", "fake.event", recv.URL)
+
+	// Pile on failures rapidly — well within the 10s GC window.
+	for i := 0; i < 10; i++ {
+		r.recordDeliveryFailure(key, DeliveryError5xx)
+	}
+	target, found := r.lookupTarget(key)
+	require.True(t, found, "no-expiry sub MUST remain in the registry while inside the GC window")
+	// Suspend threshold (default 5) is well exceeded; it will have flipped Active=false.
+	assert.False(t, target.Status.Active, "consecutive failures exceeded suspendThreshold → Active=false")
+	require.NotNil(t, target.Status.FailingContinuouslySince)
+	assert.True(t, time.Since(*target.Status.FailingContinuouslySince) < 10*time.Second,
+		"FailingContinuouslySince MUST still be inside the GC window")
+}
+
+// TestFailureGC_FiniteSub_NotAffectedByGCPath — a finite-TTL sub
+// failing past what would be the no-expiry GC window does NOT get
+// dropped. Its backstop is TTL expiry, not failure-based GC.
+func TestFailureGC_FiniteSub_NotAffectedByGCPath(t *testing.T) {
+	r := NewWebhookRegistry(
+		WithWebhookAllowPrivateNetworks(true),
+		WithNoExpiryFailureGCWindow(50*time.Millisecond),
+	)
+	recv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer recv.Close()
+
+	// Finite-TTL sub: explicit ExpiresAtOverride well in the future.
+	farFuture := time.Now().Add(1 * time.Hour)
+	key := gcTestKey(t, "alice", "fake.event", recv.URL)
+	_, _ = r.Register(RegisterParams{
+		CanonicalKey:      key,
+		DerivedID:         "sub_finite",
+		URL:               recv.URL,
+		Secret:            "whsec_" + strings.Repeat("a", 32),
+		EventName:         "fake.event",
+		Principal:         "alice",
+		ExpiresAtOverride: &farFuture,
+	})
+
+	r.recordDeliveryFailure(key, DeliveryError5xx)
+	time.Sleep(60 * time.Millisecond)
+	r.recordDeliveryFailure(key, DeliveryError5xx)
+
+	target, found := r.lookupTarget(key)
+	assert.True(t, found,
+		"finite-TTL sub MUST NOT be dropped by the failure-GC path even when the no-expiry GC window has elapsed; got found=%v", found)
+	// FailingContinuouslySince is still maintained on finite subs as
+	// diagnostic information — the GC trigger just skips them.
+	require.NotNil(t, target.Status.FailingContinuouslySince)
+}
+
+// TestFailingContinuouslySince_ClearedOnSuccess — a successful
+// delivery resets the GC clock so the next failure starts a fresh
+// continuous run.
+func TestFailingContinuouslySince_ClearedOnSuccess(t *testing.T) {
+	r := NewWebhookRegistry(WithWebhookAllowPrivateNetworks(true))
+	recv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer recv.Close()
+
+	key := gcTestKey(t, "alice", "fake.event", recv.URL)
+	_, _ = r.Register(RegisterParams{
+		CanonicalKey: key, DerivedID: "sub_ok", URL: recv.URL,
+		Secret: "whsec_" + strings.Repeat("a", 32),
+		EventName: "fake.event", Principal: "alice",
+	})
+
+	r.recordDeliveryFailure(key, DeliveryError5xx)
+	target, _ := r.lookupTarget(key)
+	require.NotNil(t, target.Status.FailingContinuouslySince,
+		"failure should anchor the clock")
+
+	r.recordDeliverySuccess(key, time.Now())
+	target, _ = r.lookupTarget(key)
+	assert.Nil(t, target.Status.FailingContinuouslySince,
+		"successful delivery MUST clear FailingContinuouslySince")
+}
+
+// TestFailingContinuouslySince_NotResetBySlidingWindow — contrasts
+// with FailedSince. The sliding suspendWindow resets FailedSince
+// (existing behavior); FailingContinuouslySince stays anchored across
+// the same gap because the GC trigger needs "really been failing"
+// not "failing within a recent window."
+func TestFailingContinuouslySince_NotResetBySlidingWindow(t *testing.T) {
+	r := NewWebhookRegistry(
+		WithWebhookAllowPrivateNetworks(true),
+		WithWebhookSuspendWindow(50*time.Millisecond),
+	)
+	recv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer recv.Close()
+
+	key := gcTestKey(t, "alice", "fake.event", recv.URL)
+	_, _ = r.Register(RegisterParams{
+		CanonicalKey: key, DerivedID: "sub_window", URL: recv.URL,
+		Secret: "whsec_" + strings.Repeat("a", 32),
+		EventName: "fake.event", Principal: "alice",
+	})
+
+	r.recordDeliveryFailure(key, DeliveryError5xx)
+	target, _ := r.lookupTarget(key)
+	require.NotNil(t, target.Status.FailedSince)
+	require.NotNil(t, target.Status.FailingContinuouslySince)
+	firstAnchor := *target.Status.FailingContinuouslySince
+
+	// Wait past the suspendWindow; the next failure resets FailedSince
+	// per the existing sliding-window logic.
+	time.Sleep(60 * time.Millisecond)
+	r.recordDeliveryFailure(key, DeliveryError5xx)
+
+	target, _ = r.lookupTarget(key)
+	require.NotNil(t, target.Status.FailingContinuouslySince)
+	assert.True(t, target.Status.FailingContinuouslySince.Equal(firstAnchor),
+		"FailingContinuouslySince MUST be preserved across sliding-window resets; got %v want %v",
+		target.Status.FailingContinuouslySince, firstAnchor)
+
+	// FailedSince was reset by the sliding-window logic.
+	require.NotNil(t, target.Status.FailedSince)
+	assert.False(t, target.Status.FailedSince.Equal(firstAnchor),
+		"FailedSince SHOULD have been reset by the sliding window")
+}
+
+// TestDeliveryStatus_FailingContinuouslySinceProjected — the
+// diagnostic field appears on the wire when set, omitted when nil.
+func TestDeliveryStatus_FailingContinuouslySinceProjected(t *testing.T) {
+	anchor := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	out, ok := deliveryStatusForResponse(DeliveryStatus{
+		Active:                   true,
+		FailedSince:              &anchor,
+		FailingContinuouslySince: &anchor,
+	})
+	require.True(t, ok)
+	assert.Equal(t, anchor.Format(time.RFC3339), out["failingContinuouslySince"])
+
+	// Absent when nil.
+	out2, ok2 := deliveryStatusForResponse(DeliveryStatus{
+		Active:      true,
+		FailedSince: &anchor,
+	})
+	require.True(t, ok2)
+	_, present := out2["failingContinuouslySince"]
+	assert.False(t, present,
+		"failingContinuouslySince MUST be omitted when nil; got %v", out2["failingContinuouslySince"])
+}
+
+// TestConstructorWarning_InfiniteTTLWithInMemoryStore — flipping
+// WithAllowInfiniteWebhookTTL without replacing the default
+// in-memory store fires a stark warning. Mirrors the
+// WithUnsafeWebhookTTLBypass startup-warning posture.
+func TestConstructorWarning_InfiniteTTLWithInMemoryStore(t *testing.T) {
+	var logs []string
+	logf := func(format string, args ...any) {
+		logs = append(logs, format)
+	}
+
+	// Construct with infinite-TTL but no explicit WebhookStore.
+	r := NewWebhookRegistry(WithAllowInfiniteWebhookTTL())
+	r.setLogfForTest(logf) // log capture happens after construction; manually re-run the check.
+	r.warnIfInfiniteTTLWithDefaultStore()
+
+	require.NotEmpty(t, logs)
+	joined := strings.Join(logs, "\n")
+	assert.Contains(t, joined, "WithAllowInfiniteWebhookTTL")
+	assert.Contains(t, joined, "in-memory")
+	assert.Contains(t, joined, "WithWebhookStore",
+		"warning MUST point operators at the recommended fix")
+}
+
+// TestConstructorWarning_FiniteTTLDoesNotWarn — operator who didn't
+// opt into infinite-TTL gets no warning even with the in-memory store.
+func TestConstructorWarning_FiniteTTLDoesNotWarn(t *testing.T) {
+	var logs []string
+	logf := func(format string, args ...any) {
+		logs = append(logs, format)
+	}
+	r := NewWebhookRegistry()
+	r.setLogfForTest(logf)
+	r.warnIfInfiniteTTLWithDefaultStore()
+	assert.Empty(t, logs, "default registry (no infinite-TTL opt-in) MUST NOT emit a no-expiry warning")
+}

--- a/experimental/ext/events/stores/gorm/no_expiry_survival_test.go
+++ b/experimental/ext/events/stores/gorm/no_expiry_survival_test.go
@@ -1,0 +1,141 @@
+package gormstore
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/panyam/mcpkit/experimental/ext/events"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// TestNoExpirySurvival_RestartSurvivalThroughGORMSQLite is the
+// load-bearing integration test for issue 764. It exercises the
+// end-to-end durability contract spec PR1 commit 99f3589c
+// §"Subscription TTL" attaches to no-expiry grants: persistence
+// across process restart.
+//
+// The shape of this test is deliberately designed to be the
+// precursor of a future whole-enchilada walkthrough beat — same
+// fixture pattern, same store seam, just SQLite locally vs Postgres
+// in the demo. The expected runbook is:
+//
+//  1. Open the persistent backend (SQLite file here; Postgres in
+//     whole-enchilada).
+//  2. Build a registry with WithAllowInfiniteWebhookTTL +
+//     WithWebhookStore(persistent).
+//  3. Register a no-expiry subscription.
+//  4. Tear down the registry, mimicking a process restart (drop
+//     in-memory state, close + reopen the DB).
+//  5. Build a fresh registry pointing at the same backend.
+//  6. Verify the subscription is still there AND deliveries route to
+//     the correct receiver.
+//
+// When the no-expiry-survival walkthrough beat lands on the
+// whole-enchilada, it should literally script these six steps,
+// swapping in `docker compose restart event-server` for the close-
+// and-reopen pair.
+func TestNoExpirySurvival_RestartSurvivalThroughGORMSQLite(t *testing.T) {
+	// SQLite file in a temp dir survives the close-and-reopen pair.
+	// (In-memory `file::memory:` does NOT survive a Close; we
+	// explicitly need on-disk persistence here.)
+	dbPath := filepath.Join(t.TempDir(), "events.db")
+
+	openStore := func() (events.WebhookStore, func()) {
+		db, err := gorm.Open(sqlite.Open(dbPath+"?_busy_timeout=5000"), &gorm.Config{
+			Logger: logger.Default.LogMode(logger.Silent),
+		})
+		require.NoError(t, err)
+		sqlDB, err := db.DB()
+		require.NoError(t, err)
+		sqlDB.SetMaxOpenConns(1)
+		store, err := NewWebhookStore(db)
+		require.NoError(t, err)
+		return store, func() { _ = sqlDB.Close() }
+	}
+
+	// Set up a real httptest receiver so step 6 (post-restart
+	// delivery) is verifiable end-to-end.
+	var receivedAfterRestart atomic.Bool
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		receivedAfterRestart.Store(true)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer receiver.Close()
+
+	canonicalKey := []byte("survival-test-key")
+	derivedID := "sub_survival"
+	const principal = "alice"
+	const eventName = "fake.event"
+
+	// Phase 1: original "process" — register the no-expiry sub.
+	{
+		store, closeDB := openStore()
+		r := events.NewWebhookRegistry(
+			events.WithWebhookAllowPrivateNetworks(true),
+			events.WithAllowInfiniteWebhookTTL(),
+			events.WithWebhookStore(store),
+		)
+		_, isNew := r.Register(events.RegisterParams{
+			CanonicalKey: canonicalKey,
+			DerivedID:    derivedID,
+			URL:          receiver.URL,
+			Secret:       "whsec_" + strings.Repeat("a", 32),
+			EventName:    eventName,
+			Principal:    principal,
+			NoExpiry:     true,
+		})
+		require.True(t, isNew, "first Register MUST report isNew=true")
+
+		// Verify in this process: target is live and ExpiresAt is nil.
+		liveTargets := r.Targets()
+		require.Len(t, liveTargets, 1, "no-expiry sub MUST show in Targets() in the original process")
+		assert.Nil(t, liveTargets[0].ExpiresAt, "ExpiresAt MUST be nil for no-expiry sub")
+
+		closeDB()
+	}
+
+	// Phase 2: fresh "process" — open the same DB, build a new
+	// registry, verify the sub survived. Includes DeliverToTarget
+	// proving the survived sub can route real deliveries.
+	{
+		store, closeDB := openStore()
+		defer closeDB()
+		r := events.NewWebhookRegistry(
+			events.WithWebhookAllowPrivateNetworks(true),
+			events.WithAllowInfiniteWebhookTTL(),
+			events.WithWebhookStore(store),
+		)
+
+		liveTargets := r.Targets()
+		require.Len(t, liveTargets, 1,
+			"no-expiry sub MUST survive process restart (got %d targets after restart)", len(liveTargets))
+		got := liveTargets[0]
+		assert.Equal(t, derivedID, got.ID, "DerivedID MUST round-trip across restart")
+		assert.Equal(t, receiver.URL, got.URL, "URL MUST round-trip across restart")
+		assert.Equal(t, principal, got.Principal, "Principal MUST round-trip across restart")
+		assert.Nil(t, got.ExpiresAt,
+			"ExpiresAt MUST round-trip as nil — restart MUST NOT silently rehydrate a finite expiry on a no-expiry sub")
+
+		// Drive a real delivery to verify the post-restart registry
+		// can actually route to the survived sub. DeliverToTarget
+		// fires the POST in a goroutine.
+		ok := r.DeliverToTarget(
+			context.Background(),
+			canonicalKey,
+			events.MakeEvent(eventName, "evt_after_restart", "1", time.Now(), map[string]string{"k": "v"}),
+		)
+		require.True(t, ok, "DeliverToTarget MUST find the survived target")
+		require.Eventually(t, receivedAfterRestart.Load, 2*time.Second, 20*time.Millisecond,
+			"a no-expiry sub that survived a restart MUST be routable to its receiver")
+	}
+}

--- a/experimental/ext/events/stores/gorm/webhook_store.go
+++ b/experimental/ext/events/stores/gorm/webhook_store.go
@@ -42,12 +42,15 @@ type webhookRow struct {
 	//
 	// StatusThrottled + StatusRetryAfterMs added with spec PR1 commit
 	// 21be9c31 (deliveryStatus throttled + retryAfterMs).
-	StatusActive         bool `gorm:"not null"`
-	StatusLastDeliveryAt *time.Time
-	StatusLastError      string `gorm:"not null"`
-	StatusFailedSince    *time.Time
-	StatusThrottled      bool `gorm:"not null"`
-	StatusRetryAfterMs   *int64
+	// StatusFailingContinuouslySince added for the failure-GC anchor
+	// (spec PR1 commit 99f3589c §"Subscription TTL").
+	StatusActive                    bool `gorm:"not null"`
+	StatusLastDeliveryAt            *time.Time
+	StatusLastError                 string `gorm:"not null"`
+	StatusFailedSince               *time.Time
+	StatusThrottled                 bool `gorm:"not null"`
+	StatusRetryAfterMs              *int64
+	StatusFailingContinuouslySince  *time.Time
 	// FailureCount mirrors events.WebhookTarget.FailureCount — the
 	// suspend-state-machine counter that lets restarts preserve
 	// per-target delivery health. Was unexported on the events struct
@@ -69,13 +72,14 @@ func rowFromTarget(t events.WebhookTarget) webhookRow {
 		EventName:            t.EventName,
 		Principal:            t.Principal,
 		Arguments:            t.Arguments,
-		StatusActive:         t.Status.Active,
-		StatusLastDeliveryAt: t.Status.LastDeliveryAt,
-		StatusLastError:      string(t.Status.LastError),
-		StatusFailedSince:    t.Status.FailedSince,
-		StatusThrottled:      t.Status.Throttled,
-		StatusRetryAfterMs:   t.Status.RetryAfterMs,
-		FailureCount:         t.FailureCount,
+		StatusActive:                    t.Status.Active,
+		StatusLastDeliveryAt:            t.Status.LastDeliveryAt,
+		StatusLastError:                 string(t.Status.LastError),
+		StatusFailedSince:               t.Status.FailedSince,
+		StatusThrottled:                 t.Status.Throttled,
+		StatusRetryAfterMs:              t.Status.RetryAfterMs,
+		StatusFailingContinuouslySince:  t.Status.FailingContinuouslySince,
+		FailureCount:                    t.FailureCount,
 	}
 }
 
@@ -91,12 +95,13 @@ func targetFromRow(r webhookRow) events.WebhookTarget {
 		Principal:     r.Principal,
 		Arguments:     r.Arguments,
 		Status: events.DeliveryStatus{
-			Active:         r.StatusActive,
-			LastDeliveryAt: r.StatusLastDeliveryAt,
-			LastError:      events.DeliveryErrorBucket(r.StatusLastError),
-			FailedSince:    r.StatusFailedSince,
-			Throttled:      r.StatusThrottled,
-			RetryAfterMs:   r.StatusRetryAfterMs,
+			Active:                    r.StatusActive,
+			LastDeliveryAt:            r.StatusLastDeliveryAt,
+			LastError:                 events.DeliveryErrorBucket(r.StatusLastError),
+			FailedSince:               r.StatusFailedSince,
+			Throttled:                 r.StatusThrottled,
+			RetryAfterMs:              r.StatusRetryAfterMs,
+			FailingContinuouslySince:  r.StatusFailingContinuouslySince,
 		},
 		FailureCount: r.FailureCount,
 	}

--- a/experimental/ext/events/webhook.go
+++ b/experimental/ext/events/webhook.go
@@ -77,6 +77,18 @@ const (
 	defaultWebhookSuspendWindow    = 10 * time.Minute // sliding window over which failures accumulate
 )
 
+// DefaultNoExpiryFailureGCWindow is how long a no-expiry subscription
+// may remain in FailingContinuouslySince state (no successful delivery
+// since the first failure of the current run) before the failure-based
+// GC drops it and posts a `terminated` envelope per spec PR1 commit
+// 99f3589c §"Subscription TTL".
+//
+// 72 hours by default — long enough to ride out a long-weekend
+// receiver outage without losing the subscription; short enough that
+// genuinely abandoned receivers get GC'd. Tune via
+// WithNoExpiryFailureGCWindow.
+const DefaultNoExpiryFailureGCWindow = 72 * time.Hour
+
 // DefaultWebhookAckTimeout is the per-delivery ack timeout the registry
 // applies to both the http.Client and the underlying net.Dialer. Aligned
 // with spec PR1 commit b506e347 (§"Webhook Event Delivery" →
@@ -185,6 +197,33 @@ func WithUnsafeWebhookTTLBypass() WebhookOption {
 func WithAllowInfiniteWebhookTTL() WebhookOption {
 	return func(r *WebhookRegistry) {
 		r.allowInfiniteWebhookTTL = true
+	}
+}
+
+// WithNoExpiryFailureGCWindow overrides how long a no-expiry subscription
+// may remain continuously failing before the failure-based GC drops it
+// (spec PR1 commit 99f3589c §"Subscription TTL": "the server MAY drop
+// it after sustained delivery failure"). Default is
+// DefaultNoExpiryFailureGCWindow (72h).
+//
+// Only applies to no-expiry subscriptions (target.ExpiresAt == nil).
+// Finite-TTL subscriptions are unaffected — their backstop remains
+// TTL expiry. Pass <=0 to keep the default.
+//
+// Tuning: shorter windows reclaim resources faster from abandoned
+// receivers but risk dropping a no-expiry subscription whose receiver
+// is offline for a long maintenance window. Longer windows tolerate
+// more receiver downtime at the cost of holding the canonical-key
+// slot + the delivery retry traffic. The GC clock is anchored on
+// DeliveryStatus.FailingContinuouslySince, which is set on first
+// failure since the last success (or first ever) and cleared by any
+// successful delivery — so a single delivery that lands resets the
+// clock.
+func WithNoExpiryFailureGCWindow(d time.Duration) WebhookOption {
+	return func(r *WebhookRegistry) {
+		if d > 0 {
+			r.noExpiryFailureGCWindow = d
+		}
 	}
 }
 
@@ -487,6 +526,21 @@ type DeliveryStatus struct {
 	FailedSince    *time.Time
 	Throttled      bool
 	RetryAfterMs   *int64
+
+	// FailingContinuouslySince anchors the failure-based GC clock for
+	// no-expiry subscriptions (spec PR1 commit 99f3589c §"Subscription
+	// TTL" — "the server MAY drop it after sustained delivery failure").
+	// Distinct from FailedSince: this field is NEVER reset by the
+	// sliding suspendWindow, only by a successful delivery. Set on the
+	// first failure since the last success (or first ever); cleared by
+	// recordDeliverySuccess. The failure-GC trigger in
+	// recordDeliveryFailure fires when (target is no-expiry) AND
+	// (now - *FailingContinuouslySince > r.noExpiryFailureGCWindow).
+	//
+	// Finite-TTL subscriptions get the same field maintained, but the
+	// GC path is gated on ExpiresAt being nil so they're never dropped
+	// by this mechanism — their backstop remains TTL expiry.
+	FailingContinuouslySince *time.Time
 }
 
 // DeliveryErrorBucket is the spec's categorical lastError set per
@@ -526,6 +580,11 @@ type WebhookRegistry struct {
 	ttlExplicit             bool // operator passed WithWebhookTTL (drives clamp decision)
 	ttlClampBypass          bool // WithUnsafeWebhookTTLBypass — disables clamp
 	allowInfiniteWebhookTTL bool // WithAllowInfiniteWebhookTTL — gates ttlMs:null acceptance in events/subscribe handler (spec PR1 commit 99f3589c §"Subscription TTL")
+	// noExpiryFailureGCWindow is how long a no-expiry subscription
+	// may remain FailingContinuouslySince a previous success before
+	// the failure-GC drops it (spec PR1 commit 99f3589c §"Subscription
+	// TTL"). Default is 72h; tune via WithNoExpiryFailureGCWindow.
+	noExpiryFailureGCWindow time.Duration
 	headerMode              WebhookHeaderMode
 	allowPrivateNetworks bool          // when false (default), Dialer.Control rejects private/loopback IPs (spec §"Webhook Security" → "SSRF prevention" L464)
 	extraHeaders         map[string]string // caller-supplied headers (WithWebhookExtraHeaders); applied BEFORE signature/MCP/trace headers so spec-mandated keys always win
@@ -609,6 +668,33 @@ func (r *WebhookRegistry) SetDefResolver(fn func(eventName string) EventDef) {
 	r.defResolver = fn
 }
 
+// warnIfInfiniteTTLWithDefaultStore logs a stark warning when the
+// operator enabled WithAllowInfiniteWebhookTTL but did NOT replace
+// the default in-memory WebhookStore. That combination is
+// semantically broken: no-expiry subscriptions are promised to
+// outlive everything except an explicit events/unsubscribe, but the
+// in-memory store loses them on the first restart. Per spec PR1
+// commit 99f3589c §"Subscription TTL", a server granting no-expiry
+// MUST persist subscriptions across restarts.
+//
+// We warn rather than reject because dev / test setups may
+// legitimately opt in without persistent storage (the durability
+// contract is observable in metrics and operator practice, not
+// load-bearing for happy-path correctness).
+func (r *WebhookRegistry) warnIfInfiniteTTLWithDefaultStore() {
+	if !r.allowInfiniteWebhookTTL {
+		return
+	}
+	if _, isInMemory := r.store.(*inMemoryWebhookStore); !isInMemory {
+		return
+	}
+	r.logf("[events] WARNING: WithAllowInfiniteWebhookTTL is set but the WebhookStore is the default in-memory implementation. " +
+		"No-expiry subscriptions will be LOST on the next restart, which violates spec PR1 commit 99f3589c §\"Subscription TTL\" " +
+		"(\"the server MUST persist no-expiry subscriptions across restarts\"). " +
+		"Production deployments MUST pass WithWebhookStore(persistentStore) — the GORM-backed Postgres/SQLite implementation " +
+		"in experimental/ext/events/stores/gorm is the supported choice.")
+}
+
 // AddOnRemoveHook registers a callback that fires when a target is
 // actually removed from the registry. Equivalent to WithWebhookOnRemove
 // but callable after construction — used by events.Register to install
@@ -661,13 +747,14 @@ var noopTP core.TracerProvider = core.NoopTracerProvider{}
 // see its docs for when (not) to use it.
 func NewWebhookRegistry(opts ...WebhookOption) *WebhookRegistry {
 	r := &WebhookRegistry{
-		store:            NewInMemoryWebhookStore(),
-		ttl:              DefaultWebhookTTL,
-		headerMode:       StandardWebhooks,
-		maxBodyBytes:     defaultWebhookMaxBodyBytes,
-		suspendThreshold: defaultWebhookSuspendThreshold,
-		suspendWindow:    defaultWebhookSuspendWindow,
-		logf:             log.Printf,
+		store:                   NewInMemoryWebhookStore(),
+		ttl:                     DefaultWebhookTTL,
+		headerMode:              StandardWebhooks,
+		maxBodyBytes:             defaultWebhookMaxBodyBytes,
+		suspendThreshold:         defaultWebhookSuspendThreshold,
+		suspendWindow:            defaultWebhookSuspendWindow,
+		noExpiryFailureGCWindow:  DefaultNoExpiryFailureGCWindow,
+		logf:                     log.Printf,
 	}
 	for _, o := range opts {
 		o(r)
@@ -676,6 +763,7 @@ func NewWebhookRegistry(opts ...WebhookOption) *WebhookRegistry {
 		r.tp = noopTP
 	}
 	r.applyTTLClamp()
+	r.warnIfInfiniteTTLWithDefaultStore()
 	// http.Client wired AFTER options apply so the Dialer.Control callback
 	// can read the resolved allowPrivateNetworks setting. Spec
 	// §"Webhook Security" → "SSRF prevention" L464.
@@ -1219,6 +1307,10 @@ func (r *WebhookRegistry) recordDeliverySuccess(canonicalKey []byte, at time.Tim
 	t.Status.LastDeliveryAt = &atCopy
 	t.Status.LastError = DeliveryErrorNone
 	t.Status.FailedSince = nil
+	// A successful delivery clears the failure-GC clock. The next
+	// failure starts a fresh continuous-failure run; the GC threshold
+	// resets to the full window.
+	t.Status.FailingContinuouslySince = nil
 	t.FailureCount = 0
 	_, _ = r.store.SaveWebhook(ctx, SaveWebhookRequest{Target: t})
 }
@@ -1234,12 +1326,21 @@ func (r *WebhookRegistry) recordDeliverySuccess(canonicalKey []byte, at time.Tim
 // is older than suspendWindow, reset the run (this failure starts a
 // new run). Otherwise, count consecutive failures within the run; on
 // hitting suspendThreshold, flip Active=false.
+//
+// Failure-GC rule (spec PR1 commit 99f3589c §"Subscription TTL"): on
+// every failure, also track FailingContinuouslySince — a "true" first-
+// failure-since-last-success anchor that is NEVER reset by the sliding
+// suspend window. For no-expiry subscriptions (target.ExpiresAt == nil)
+// past r.noExpiryFailureGCWindow of continuous failure, drop the
+// subscription entirely and POST a `terminated` envelope. Finite-TTL
+// subs maintain the field but the GC path skips them — their backstop
+// remains TTL expiry.
 func (r *WebhookRegistry) recordDeliveryFailure(canonicalKey []byte, bucket DeliveryErrorBucket) {
 	r.mu.Lock()
-	defer r.mu.Unlock()
 	ctx := context.Background()
 	getResp, _ := r.store.GetWebhook(ctx, GetWebhookRequest{CanonicalKey: canonicalKey})
 	if !getResp.Found {
+		r.mu.Unlock()
 		return
 	}
 	t := getResp.Target
@@ -1257,23 +1358,52 @@ func (r *WebhookRegistry) recordDeliveryFailure(canonicalKey []byte, bucket Deli
 	} else {
 		t.FailureCount++
 	}
+	// FailingContinuouslySince anchors the failure-GC clock. Set only
+	// when nil — successive failures during a continuous run preserve
+	// the original first-failure timestamp.
+	if t.Status.FailingContinuouslySince == nil {
+		startCopy := now
+		t.Status.FailingContinuouslySince = &startCopy
+	}
 	wasActive := t.Status.Active
 	if t.FailureCount >= r.suspendThreshold {
 		t.Status.Active = false
 	}
-	_, _ = r.store.SaveWebhook(ctx, SaveWebhookRequest{Target: t})
-	// On the Active true→false transition, auto-Post a
-	// {type:terminated} envelope to the receiver as a courtesy
-	// notification (spec §"Non-event webhook bodies" L420). Uses
-	// postTerminatedSilent so the target stays in the registry
-	// (Active=false observable; reactivate via refresh per
-	// §"Webhook Delivery Status" L460). Snapshot the target struct
-	// before releasing the lock — the async deliverControl needs
-	// URL/Secret/ID outside the lock.
-	if wasActive && !t.Status.Active {
+
+	// Decide failure-GC before saving — if we're about to drop, skip
+	// the Save (PostTerminated does its own DeleteWebhook). Otherwise
+	// persist the updated Status. Capture all the post-lock actions
+	// here so we can fire them after the Unlock.
+	noExpiryGCFire := t.ExpiresAt == nil &&
+		t.Status.FailingContinuouslySince != nil &&
+		now.Sub(*t.Status.FailingContinuouslySince) > r.noExpiryFailureGCWindow
+	suspendTransitionFire := wasActive && !t.Status.Active && !noExpiryGCFire
+
+	if !noExpiryGCFire {
+		_, _ = r.store.SaveWebhook(ctx, SaveWebhookRequest{Target: t})
+	}
+	r.mu.Unlock()
+
+	// Suspend transition (existing semantics): receiver gets a
+	// `terminated` envelope but the target stays in the registry as
+	// paused (Active=false observable; reactivate via refresh per
+	// §"Webhook Delivery Status" L460). Skipped when the failure-GC
+	// path is firing too — the GC drop supersedes a same-call suspend.
+	if suspendTransitionFire {
 		r.postTerminatedSilent(t, ControlError{
 			Code:    -32603,
 			Message: "subscription suspended after repeated delivery failures: " + string(bucket),
+		})
+	}
+
+	// Failure-GC drop (new for no-expiry subs): delete the
+	// subscription + post a `terminated` envelope per spec PR1 commit
+	// 99f3589c §"Subscription TTL". Distinguishable message from the
+	// suspend-transition envelope so receivers can branch.
+	if noExpiryGCFire {
+		r.PostTerminated(t.CanonicalKey, ControlError{
+			Code:    -32603,
+			Message: "no-expiry subscription dropped after sustained delivery failure: " + string(bucket),
 		})
 	}
 }


### PR DESCRIPTION
## What changes

Implements the durability obligations the spec attaches to no-expiry subscriptions (spec PR1 commit `99f3589c` §"Subscription TTL"). PR 779 landed the wire shape + the `WithAllowInfiniteWebhookTTL()` policy opt-in; this PR makes the opt-in actually mean what it says. Adds a failure-based GC state machine, a construction-time misconfiguration warning, and the first load-bearing restart-survival integration test against the GORM SQLite backend.

## Reviewer's guide

Read in this order:

1. [experimental/ext/events/webhook.go](https://github.com/panyam/mcpkit/pull/783/files#diff-f61c2bd42ae83936aba2fe7dab3bcda1606ca810bd7263d9afbe42147f9c8f5a) — start here. Adds `DeliveryStatus.FailingContinuouslySince *time.Time` (the GC anchor, never reset by quiet periods), `r.noExpiryFailureGCWindow` registry field (default 72h via `DefaultNoExpiryFailureGCWindow`), `WithNoExpiryFailureGCWindow(d)` option, `warnIfInfiniteTTLWithDefaultStore()` constructor check. Updates `recordDeliverySuccess` to clear the anchor and `recordDeliveryFailure` to set the anchor + check the GC trigger (gated on `target.ExpiresAt == nil`) + fire `PostTerminated` with a distinguishable `ControlError` message when crossed.
2. [experimental/ext/events/failure_gc_test.go](https://github.com/panyam/mcpkit/pull/783/files#diff-360d88b20421bba807a336bc5ebf1b45dc1e996bfce3b35e8a368aa1d45218cc) — eight unit tests covering the GC drop, the in-window-no-drop case, the finite-sub exemption, success-clears-anchor, sliding-window-doesn't-reset-anchor, the wire-shape diagnostic projection, and the constructor warning (with + without the opt-in).
3. [experimental/ext/events/stores/gorm/no_expiry_survival_test.go](https://github.com/panyam/mcpkit/pull/783/files#diff-36b7f981dac634a7ea216b882debc480dbe8be10596096eb0a99ef479cd55d70) — the load-bearing integration test. Opens an on-disk SQLite, registers a no-expiry sub, tears the registry down, reopens the DB in a fresh registry, verifies the sub survived AND `DeliverToTarget` routes to a real httptest receiver. Shape deliberately mirrors the eventual whole-enchilada walkthrough beat (SQLite ↔ Postgres, registry-close-and-reopen ↔ `docker compose restart`).
4. [experimental/ext/events/events.go](https://github.com/panyam/mcpkit/pull/783/files#diff-4a2a8cf5f00e8770df09ab463340a5fc393acbf3f95ef59af8280e2a7a814815) — `deliveryStatusForResponse` projects `failingContinuouslySince` as RFC3339 so subscribers can observe the GC anchor on refresh. Omitted when nil.
5. [experimental/ext/events/stores/gorm/webhook_store.go](https://github.com/panyam/mcpkit/pull/783/files#diff-5d145f53ca960584c0bdde7ebfbb8e41504aebef9352329c6f3d01ab576c38fc) — adds `StatusFailingContinuouslySince *time.Time` nullable column; round-trips in `rowFromTarget` / `targetFromRow`.
6. [experimental/ext/events/DEPLOYMENT.md](https://github.com/panyam/mcpkit/pull/783/files#diff-c75bb17c9b123df102747038873bda868dc6e576a2eba2b10b4fd373a8a8f0b3) — § TTL negotiation and refresh expanded with the failure-GC mechanism, the construction-time warning rationale, and the cross-reference to #490 (persisted verification — the one remaining no-expiry obligation still pending).

Skim or skip: nothing — the diff is tight.

## Decision log

- **Separate `FailingContinuouslySince` over reusing `FailedSince`.** The existing sliding suspend-window resets `FailedSince` after quiet periods (correct for finite subs that get reactivated on refresh). The failure-GC trigger needs "really been failing across N days, with no intervening success" — not "failing within a recent window." Two fields tracking subtly different signals beats one field doing double duty.
- **GC trigger lives inside `recordDeliveryFailure`, not in a background goroutine.** The trigger fires exactly when the threshold could be crossed (each new failure). A no-expiry sub that's gone quiet (no failures, because there are no deliveries) is correctly NOT GC'd — the GC clock only advances on actual failed deliveries.
- **Two-stage cleanup (suspend → drop) for no-expiry subs.** Receiver gets one `terminated` envelope on the suspend transition (existing behavior) and another on the GC drop. Messages are distinguishable. When the GC drop and the suspend transition would fire in the same call, the GC drop wins and the suspend envelope is suppressed (otherwise the receiver gets two near-identical envelopes back-to-back).
- **Construction-time warning, not hard rejection.** Mirrors the `WithUnsafeWebhookTTLBypass` UX. Dev environments may legitimately opt in to `WithAllowInfiniteWebhookTTL` without persistent storage (e.g., running the demo locally); hard-rejecting would break their workflow. The warning is stark and points operators at `WithWebhookStore(persistent)` as the fix.
- **Default GC window 72h.** Spec says "server-defined." 24h is aggressive for a no-expiry deployment (a long weekend of receiver downtime would drop subs); 7d feels asleep-at-the-wheel. 3 days lets a holiday weekend ride out, no longer.
- **`failingContinuouslySince` projected on the wire as a diagnostic.** Surfaces the GC anchor to subscribers so they can observe whether the server has flagged their sub as sustained-failing. Omitted when nil so quiet subs don't bloat the response.
- **Verification persistence kept under #490.** The spec's full no-expiry obligation list also requires persisted verification status, but mcpkit has no verification surface yet — that's #490's body-rework scope. DEPLOYMENT.md cross-references the gap.
- **Integration test in `stores/gorm/` over a new top-level integration tree.** The seam under test IS the GORM-backed store; the test reuses the existing test-utility patterns there. Adding a separate integration tree would duplicate scaffolding for one test.

## Risk / blast radius

- **`DeliveryStatus` struct gains one field.** Zero-value default, all existing reads compile cleanly. No callsite needs updating.
- **`recordDeliveryFailure` gains a code path.** The GC trigger is gated on `target.ExpiresAt == nil` so finite-TTL subs are unaffected. Test pinned by `TestFailureGC_FiniteSub_NotAffectedByGCPath`.
- **GORM column addition.** `ADD COLUMN status_failing_continuously_since TIMESTAMP NULL`. Per the established convention from #778/#779, fresh deploys only — no migration story.
- **Construction-time warning is log-only.** No behavior change for operators who don't opt into `WithAllowInfiniteWebhookTTL`. For those who do, the warning fires unless they pass `WithWebhookStore(persistent)` too.

## Out of scope (deferred)

- Persisted verification status → `panyam/mcpkit#490` — the spec's full no-expiry obligation list requires it, but mcpkit has no verification surface yet
- Capability advertisement for infinite-TTL support → future ticket; clients today discover capabilities at the protocol level, not per-feature
- Whole-enchilada walkthrough beats — separate follow-up PR bundling #760 TTL-matrix beat + #764 no-expiry restart-survival beat + #765 410 Gone beat. The integration test here is the runbook precursor
