### PR TITLE
ext/skills: implement resources/directory/read per SEP-2640 2e04c48d (#781)

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1427,6 +1427,27 @@ func (c *Client) ServerSupportsExtension(id string) bool {
 	return ok
 }
 
+// ServerExtensionCapability returns the cached ExtensionCapability the
+// server advertised for id during initialize, or false when the server
+// did not declare the extension.
+//
+// Use this to inspect extension-specific Config settings (e.g., the
+// SEP-2640 directoryRead flag). The returned capability is decoded from
+// the raw JSON captured at initialize time and reflects whatever the
+// server emitted on the wire; callers should treat unknown Config keys
+// permissively.
+func (c *Client) ServerExtensionCapability(id string) (core.ExtensionCapability, bool) {
+	raw, ok := c.serverExtensions[id]
+	if !ok {
+		return core.ExtensionCapability{}, false
+	}
+	var cap core.ExtensionCapability
+	if err := json.Unmarshal(raw, &cap); err != nil {
+		return core.ExtensionCapability{}, false
+	}
+	return cap, true
+}
+
 // ServerSupportsUI checks whether the server advertised MCP Apps
 // (io.modelcontextprotocol/ui) support. Convenience wrapper around
 // ServerSupportsExtension.

--- a/core/protocol.go
+++ b/core/protocol.go
@@ -119,9 +119,16 @@ type InitializeResult struct {
 
 // ExtensionCapability describes a server extension's metadata in the
 // initialize response capabilities.
+//
+// Config carries extension-specific settings. SEP-2640 (Skills) uses it
+// for the directoryRead flag added in commit 2e04c48d on 2026-06-09;
+// other extensions define their own shape under their own reverse-domain
+// ID. Absent or empty when the extension declares no settings (the
+// wire-level value is then the bare empty object {}).
 type ExtensionCapability struct {
-	SpecVersion string `json:"specVersion"`
-	Stability   string `json:"stability"`
+	SpecVersion string         `json:"specVersion"`
+	Stability   string         `json:"stability"`
+	Config      map[string]any `json:"config,omitempty"`
 }
 
 // StreamableHTTPAccept is the Accept header value for Streamable HTTP requests.

--- a/examples/skills/WALKTHROUGH.md
+++ b/examples/skills/WALKTHROUGH.md
@@ -120,17 +120,25 @@ Demonstrates that the prefix-segment routing works end-to-end. The skill's `name
 
 Same relative-reference resolution: `templates/email.md` from refunds/SKILL.md.
 
+### SEP-2640 directoryRead — scoped subtree navigation
+
+SEP commit `2e04c48d` (2026-06-09) added `resources/directory/read` for listing a directory's direct children without enumerating the server's entire resource space. Capability-gated via `io.modelcontextprotocol/skills.directoryRead`. mcpkit's Provider auto-supports it (#781).
+
+### Step 9: List a directory inside a skill and recurse into a subdirectory
+
+Subdirectories surface with `mimeType: "inode/directory"`; client descends by issuing a second call. SDK wrapper: `Client.ReadDirectory(ctx, uri)`. The walkthrough hand-rolls a one-level recursion for clarity — the SDK does not ship a `WalkDirectory` helper (file an issue if you need one).
+
 ### SEP-414 P7 — Skills observability
 
 Fetch ≠ activation. Server `resources/read` spans now carry `mcp.skill.*` attrs (#748). Client `ext/skills.Client` emits `skills.read*` spans + `Activate(ctx, uri)` for post-cache use the wire can't see (SDK-only — no spec change).
 
-### Step 9: Wrap reads in skills.NewClient(...) and call Client.Activate
+### Step 10: Wrap reads in skills.NewClient(...) and call Client.Activate
 
 Activate is intra-process — no wire traffic. Run with `make serve EXPORTER=stdout` + `make demo EXPORTER=stdout` to see spans.
 
 ### Wrap-up
 
-Negotiated extension, enumerated index, verified one digest, read manifest + supporting files across single-segment and nested-prefix paths, emitted skill-shape spans + an activation event. `make serve-archive` flips the wire to one `.tar.gz` per skill — host code unchanged.
+Negotiated extension, enumerated index, verified one digest, read manifest + supporting files across single-segment and nested-prefix paths, navigated a directory subtree via the SEP-2640 `directoryRead` capability, emitted skill-shape spans + an activation event. `make serve-archive` flips the wire to one `.tar.gz` per skill — host code unchanged.
 
 ## Run it
 

--- a/examples/skills/skills/acme/billing/refunds/templates/refund-receipt.md
+++ b/examples/skills/skills/acme/billing/refunds/templates/refund-receipt.md
@@ -1,0 +1,11 @@
+Refund Receipt
+==============
+
+Customer:   {customer_name}
+Order ID:   {order_id}
+Refund:     {amount}
+Processed:  {date}
+
+Reason:     {reason}
+
+Please retain this receipt for your records.

--- a/examples/skills/skills/acme/billing/refunds/templates/regional/eu.md
+++ b/examples/skills/skills/acme/billing/refunds/templates/regional/eu.md
@@ -1,0 +1,8 @@
+Sehr geehrte/r {customer_name},
+
+Ihre Rückerstattung über {amount} wurde gemäß den EU-Verbraucherrechten
+bearbeitet. Der Betrag wird innerhalb von 14 Werktagen auf Ihr
+Ursprungs-Zahlungsmittel zurückgebucht.
+
+Mit freundlichen Grüßen,
+Acme Billing

--- a/examples/skills/walkthrough.go
+++ b/examples/skills/walkthrough.go
@@ -19,12 +19,13 @@ import (
 )
 
 const (
-	uriGitWorkflow    = "skill://git-workflow/SKILL.md"
-	uriPDFManifest    = "skill://pdf-processing/SKILL.md"
-	uriPDFRef         = "skill://pdf-processing/references/FORMS.md"
-	uriRefundsManifest = "skill://acme/billing/refunds/SKILL.md"
-	uriRefundsEmail    = "skill://acme/billing/refunds/templates/email.md"
-	uriIndex           = skills.IndexURI
+	uriGitWorkflow         = "skill://git-workflow/SKILL.md"
+	uriPDFManifest         = "skill://pdf-processing/SKILL.md"
+	uriPDFRef              = "skill://pdf-processing/references/FORMS.md"
+	uriRefundsManifest     = "skill://acme/billing/refunds/SKILL.md"
+	uriRefundsEmail        = "skill://acme/billing/refunds/templates/email.md"
+	uriRefundsTemplatesDir = "skill://acme/billing/refunds/templates"
+	uriIndex               = skills.IndexURI
 )
 
 func runDemo() {
@@ -273,6 +274,53 @@ func runDemo() {
 			return nil
 		})
 
+	demo.Section("SEP-2640 directoryRead — scoped subtree navigation",
+		"SEP commit `2e04c48d` (2026-06-09) added `resources/directory/read` for listing a directory's direct children without enumerating the server's entire resource space. Capability-gated via `io.modelcontextprotocol/skills.directoryRead`. mcpkit's Provider auto-supports it (#781).",
+	)
+
+	demo.Step("List a directory inside a skill and recurse into a subdirectory").
+		Arrow("Host", "Server", "resources/directory/read uri=skill://acme/billing/refunds/templates").
+		DashedArrow("Server", "Host", "2 files + 1 subdirectory (`regional`, inode/directory)").
+		Arrow("Host", "Server", "resources/directory/read uri=skill://acme/billing/refunds/templates/regional").
+		DashedArrow("Server", "Host", "1 file (eu.md)").
+		Note("Subdirectories surface with `mimeType: \"inode/directory\"`; client descends by issuing a second call. SDK wrapper: `Client.ReadDirectory(ctx, uri)`.").
+		Run(func(ctx demokit.StepContext) *demokit.StepResult {
+			if c == nil {
+				return nil
+			}
+			sc := skills.NewClient(c, skills.WithTracerProvider(tp))
+			if !sc.SupportsDirectoryRead() {
+				fmt.Printf("    SKIP: server does not advertise directoryRead\n")
+				return nil
+			}
+			// First listing: the templates/ subtree.
+			result, err := sc.ReadDirectory(context.Background(), uriRefundsTemplatesDir)
+			if err != nil {
+				fmt.Printf("    SKIP: %v\n", err)
+				return nil
+			}
+			fmt.Printf("    ReadDirectory(%s):\n", uriRefundsTemplatesDir)
+			for _, r := range result.Resources {
+				fmt.Printf("      %-12s %s\n", marker(r.MimeType), r.URI)
+			}
+			// Hand-rolled recursion: descend into any subdirectory we see.
+			for _, r := range result.Resources {
+				if r.MimeType != skills.MimeTypeDirectory {
+					continue
+				}
+				sub, err := sc.ReadDirectory(context.Background(), r.URI)
+				if err != nil {
+					fmt.Printf("    SKIP %s: %v\n", r.URI, err)
+					continue
+				}
+				fmt.Printf("    ReadDirectory(%s):\n", r.URI)
+				for _, e := range sub.Resources {
+					fmt.Printf("      %-12s %s\n", marker(e.MimeType), e.URI)
+				}
+			}
+			return nil
+		})
+
 	demo.Section("SEP-414 P7 — Skills observability",
 		"Fetch ≠ activation. Server `resources/read` spans now carry `mcp.skill.*` attrs (#748). Client `ext/skills.Client` emits `skills.read*` spans + `Activate(ctx, uri)` for post-cache use the wire can't see (SDK-only — no spec change).",
 	)
@@ -313,6 +361,17 @@ func runDemo() {
 	_ = serverInfo
 	common.SetupRenderer(demo)
 	demo.Execute()
+}
+
+// marker returns a one-glyph indicator for a directory listing entry based
+// on its MIME type. "dir/" for SEP-2640 inode/directory entries, "file" for
+// everything else. Aligns the walkthrough table without depending on a
+// terminal capability lib.
+func marker(mimeType string) string {
+	if mimeType == skills.MimeTypeDirectory {
+		return "dir/"
+	}
+	return "file"
 }
 
 // previewBody prints up to n lines of the body for the walkthrough output.

--- a/ext/skills/client.go
+++ b/ext/skills/client.go
@@ -80,6 +80,24 @@ func (c *Client) SupportsSkills() bool {
 	return c.mcp.ServerSupportsExtension(ExtensionID)
 }
 
+// SupportsDirectoryRead reports whether the connected server advertised
+// the SEP-2640 directoryRead capability (added by SEP commit 2e04c48d
+// on 2026-06-09) inside the io.modelcontextprotocol/skills extension.
+// Per the SEP's normative wording, clients MUST NOT call
+// resources/directory/read against a server that has not declared
+// directoryRead: true. ReadDirectory's pre-call guard uses this check.
+//
+// The signal is read from the cached initialize/discover response; this
+// method does not issue a network call.
+func (c *Client) SupportsDirectoryRead() bool {
+	cap, ok := c.mcp.ServerExtensionCapability(ExtensionID)
+	if !ok {
+		return false
+	}
+	v, _ := cap.Config[CapabilityDirectoryRead].(bool)
+	return v
+}
+
 // ListSkills reads skill://index.json and returns the parsed Index.
 //
 // SEP-2640 makes the index OPTIONAL: a server MAY decline to expose
@@ -147,6 +165,67 @@ func (c *Client) ReadSkillURI(ctx context.Context, uri string) ([]byte, error) {
 		return nil, err
 	}
 	return bytes, nil
+}
+
+// ReadDirectoryOption tunes a single ReadDirectory call.
+type ReadDirectoryOption func(*readDirectoryConfig)
+
+type readDirectoryConfig struct {
+	cursor string
+}
+
+// WithDirectoryCursor sets the pagination cursor for the call. Pass the
+// NextCursor returned by a prior ReadDirectory result to fetch the next
+// page. Empty cursor (the default) requests the first page.
+func WithDirectoryCursor(cursor string) ReadDirectoryOption {
+	return func(c *readDirectoryConfig) { c.cursor = cursor }
+}
+
+// ReadDirectory issues a SEP-2640 resources/directory/read call for uri
+// and returns the directory's direct children.
+//
+// Per the SEP (commit 2e04c48d, 2026-06-09): files carry their ordinary
+// resource metadata; subdirectories carry MimeTypeDirectory and a URI
+// without trailing slash. Clients descend by calling ReadDirectory again
+// on a child directory.
+//
+// Pre-call guard: SupportsDirectoryRead must return true on the
+// underlying connection, otherwise ReadDirectory returns
+// ErrDirectoryReadNotSupported without issuing a network call. This
+// matches the SEP's normative "Clients MUST NOT call" wording.
+//
+// ctx parents the SEP-414 P7 (#748) `skills.read_directory` span when a
+// TracerProvider is installed. On success the span carries
+// mcp.skill.uri and mcp.skill.entries (count of returned ResourceDefs).
+func (c *Client) ReadDirectory(ctx context.Context, uri string, opts ...ReadDirectoryOption) (DirectoryReadResult, error) {
+	var cfg readDirectoryConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	_, span := c.cfg.tp.StartSpan(ctx, "skills.read_directory",
+		core.Attribute{Key: "mcp.skill.uri", Value: uri},
+	)
+	defer span.End()
+
+	if !c.SupportsDirectoryRead() {
+		span.RecordError(ErrDirectoryReadNotSupported)
+		return DirectoryReadResult{}, ErrDirectoryReadNotSupported
+	}
+
+	params := DirectoryReadRequest{URI: uri, Cursor: cfg.cursor}
+	result, err := c.mcp.Call(MethodResourcesDirectoryRead, params)
+	if err != nil {
+		span.RecordError(err)
+		return DirectoryReadResult{}, fmt.Errorf("skills: %s %s: %w", MethodResourcesDirectoryRead, uri, err)
+	}
+	var out DirectoryReadResult
+	if err := result.Unmarshal(&out); err != nil {
+		span.RecordError(err)
+		return DirectoryReadResult{}, fmt.Errorf("skills: decode %s response: %w", MethodResourcesDirectoryRead, err)
+	}
+	span.SetAttribute("mcp.skill.entries", fmt.Sprintf("%d", len(out.Resources)))
+	return out, nil
 }
 
 // SkillManifest holds a parsed SKILL.md plus the raw bytes the server

--- a/ext/skills/client_directory_test.go
+++ b/ext/skills/client_directory_test.go
@@ -1,0 +1,124 @@
+package skills_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/panyam/mcpkit/client"
+	"github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/ext/skills"
+	"github.com/panyam/mcpkit/server"
+)
+
+// TestClient_ReadDirectory_HappyPath drives the ext/skills.Client wrapper
+// against a real Provider-backed server. Confirms the SDK shape matches
+// the wire shape: the result returned by Client.ReadDirectory is the
+// typed view of what the server emitted.
+func TestClient_ReadDirectory_HappyPath(t *testing.T) {
+	_, _, c := boot(t, "testdata/valid")
+	sc := skills.NewClient(c)
+	if !sc.SupportsDirectoryRead() {
+		t.Fatalf("server should advertise directoryRead capability")
+	}
+	result, err := sc.ReadDirectory(context.Background(), "skill://pdf-processing/references")
+	if err != nil {
+		t.Fatalf("ReadDirectory: %v", err)
+	}
+	if len(result.Resources) != 1 || result.Resources[0].Name != "FORMS.md" {
+		t.Errorf("got %v, want [FORMS.md]", namesOf(result.Resources))
+	}
+	if result.NextCursor != "" {
+		t.Errorf("NextCursor = %q, want empty", result.NextCursor)
+	}
+}
+
+// TestClient_ReadDirectory_PreCallGuard verifies the SDK enforces the
+// SEP's normative "Clients MUST NOT call ..." wording — when the server
+// has not advertised directoryRead, ReadDirectory returns the typed
+// sentinel without issuing a network call.
+func TestClient_ReadDirectory_PreCallGuard(t *testing.T) {
+	// Boot a server with directoryRead deliberately suppressed.
+	srv := newServerWithoutDirectoryRead(t)
+	c := newConnectedClient(t, srv)
+
+	sc := skills.NewClient(c)
+	if sc.SupportsDirectoryRead() {
+		t.Fatalf("server should NOT advertise directoryRead in this setup")
+	}
+	_, err := sc.ReadDirectory(context.Background(), "skill://pdf-processing")
+	if !errors.Is(err, skills.ErrDirectoryReadNotSupported) {
+		t.Errorf("err = %v, want ErrDirectoryReadNotSupported", err)
+	}
+}
+
+// TestClient_ReadDirectory_RecurseManually walks a two-level subtree by
+// hand-rolling recursion at the call site, matching the walkthrough's
+// usage pattern in examples/skills/walkthrough.go.
+func TestClient_ReadDirectory_RecurseManually(t *testing.T) {
+	_, _, c := boot(t, "testdata/valid")
+	sc := skills.NewClient(c)
+	root, err := sc.ReadDirectory(context.Background(), "skill://pdf-processing")
+	if err != nil {
+		t.Fatalf("ReadDirectory(root): %v", err)
+	}
+	seen := map[string]bool{}
+	for _, r := range root.Resources {
+		seen[r.Name] = true
+		if r.MimeType != skills.MimeTypeDirectory {
+			continue
+		}
+		sub, err := sc.ReadDirectory(context.Background(), r.URI)
+		if err != nil {
+			t.Errorf("ReadDirectory(%s): %v", r.URI, err)
+			continue
+		}
+		for _, e := range sub.Resources {
+			seen[e.Name] = true
+		}
+	}
+	// pdf-processing skill has SKILL.md, references/FORMS.md,
+	// scripts/extract.py — one level of descent should reveal all three
+	// child files plus the two subdir markers.
+	for _, want := range []string{"SKILL.md", "FORMS.md", "extract.py", "references", "scripts"} {
+		if !seen[want] {
+			t.Errorf("hand-rolled recursion missed %q", want)
+		}
+	}
+}
+
+// newServerWithoutDirectoryRead builds a Provider-backed server that
+// explicitly suppresses directoryRead — exercises the WithoutDirectoryRead
+// opt-out and gives the pre-call-guard test a server that legitimately
+// lacks the capability.
+func newServerWithoutDirectoryRead(t *testing.T) *server.Server {
+	t.Helper()
+	srv := server.NewServer(core.ServerInfo{Name: "skills-no-dirread", Version: "0.0.1"})
+	p, err := skills.NewProvider(
+		skills.WithDirectory("testdata/valid"),
+		skills.WithoutDirectoryRead(),
+	)
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	p.RegisterWith(srv)
+	return srv
+}
+
+// newConnectedClient spins up an httptest server fronted by srv's
+// Handler, connects a client, and registers cleanup. Shares the wiring
+// pattern with boot() in indexer_test.go but takes a caller-supplied
+// server so tests can configure Provider options.
+func newConnectedClient(t *testing.T, srv *server.Server) *client.Client {
+	t.Helper()
+	handler := srv.Handler(server.WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "dirread-probe", Version: "0.0.1"})
+	if err := c.Connect(); err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+	return c
+}

--- a/ext/skills/directory.go
+++ b/ext/skills/directory.go
@@ -101,6 +101,21 @@ func (p *Provider) resolveDirectoryURI(uri string) (*skillEntry, string, error) 
 	// best.dirPath is the FS root for the skill; segs[bestLen:] is the
 	// in-skill path.
 	relSegs := segs[bestLen:]
+
+	// Reject path-traversal segments BEFORE joining. ParseURI does not
+	// forbid "." or ".." segments at the URI level (the SEP is silent on
+	// them) and a naive path.Join would let
+	// `skill://acme/billing/refunds/..` cleanly resolve to
+	// `acme/billing`, enumerating the parent tree — exactly the surface
+	// the directoryRead capability is meant to scope away. The
+	// containment check in enumerateDirectory is defense-in-depth; this
+	// is the load-bearing guard.
+	for _, s := range relSegs {
+		if s == ".." || s == "." || strings.ContainsAny(s, `/\`) {
+			return nil, "", fmt.Errorf("skills: %q contains an invalid path segment %q", uri, s)
+		}
+	}
+
 	relPath := strings.Join(relSegs, "/")
 	return best, relPath, nil
 }
@@ -116,6 +131,17 @@ func (p *Provider) enumerateDirectory(skill *skillEntry, relPath, parentURI stri
 	if relPath != "" {
 		fsRoot = path.Join(skill.dirPath, relPath)
 	}
+
+	// Defense in depth: even with the segment guard in resolveDirectoryURI,
+	// confirm the post-Clean path still names skill.dirPath or a descendant
+	// before touching the FS. Future changes to splitURIPath or the
+	// segment guard surface here as a typed error instead of a silent
+	// out-of-scope enumeration.
+	cleaned := path.Clean(fsRoot)
+	if cleaned != skill.dirPath && !strings.HasPrefix(cleaned, skill.dirPath+"/") {
+		return nil, fmt.Errorf("skills: %q resolves outside the skill subtree", parentURI)
+	}
+
 	// Verify the target is a directory before reading. fs.Stat surfaces
 	// fs.ErrNotExist for unknown paths, which we want to surface as
 	// "no such directory."

--- a/ext/skills/directory.go
+++ b/ext/skills/directory.go
@@ -1,0 +1,207 @@
+package skills
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+// defaultDirectoryReadPageSize matches the page size server/dispatch.go
+// uses for resources/list. Kept local rather than imported because the
+// upstream helper is package-private and one-line duplication beats a
+// promotion to the public surface for a single off-package consumer.
+const defaultDirectoryReadPageSize = 100
+
+// handleDirectoryRead serves SEP-2640's resources/directory/read method.
+//
+// SEP semantics (per commit 2e04c48d on 2026-06-09):
+//
+//   - The URI MUST resolve to a directory resource — a node inside one of
+//     the skills this Provider serves, with no trailing slash. Unknown or
+//     non-directory URIs return -32602 (Invalid params), matching the
+//     resources/read error code for unknown resources.
+//   - The result enumerates only the directory's DIRECT children. Files
+//     carry their ordinary resource metadata; subdirectories carry
+//     MimeTypeDirectory ("inode/directory") so clients descend by issuing
+//     a follow-up call against the child URI.
+//   - Pagination mirrors resources/list: callers may pass a cursor, the
+//     handler returns NextCursor when more entries remain.
+//
+// Resolution rule: the URI must start with one of the Provider's skill
+// roots (Scheme + "://" + uriPrefix.../<skill>). The remainder of the
+// URI is the relative path inside that skill's fs.FS subtree. The skill
+// root itself is a valid directory URI; deeper directories work too as
+// long as the on-FS path is a directory.
+func (p *Provider) handleDirectoryRead(ctx core.MethodContext, id, params json.RawMessage) *core.Response {
+	var req DirectoryReadRequest
+	if len(params) > 0 {
+		if err := json.Unmarshal(params, &req); err != nil {
+			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, err.Error())
+		}
+	}
+	if req.URI == "" {
+		return core.NewErrorResponse(id, core.ErrCodeInvalidParams, "skills: resources/directory/read: uri is required")
+	}
+
+	skill, relPath, err := p.resolveDirectoryURI(req.URI)
+	if err != nil {
+		return core.NewErrorResponse(id, core.ErrCodeInvalidParams, err.Error())
+	}
+
+	children, err := p.enumerateDirectory(skill, relPath, req.URI)
+	if err != nil {
+		return core.NewErrorResponse(id, core.ErrCodeInvalidParams, err.Error())
+	}
+
+	page, next := paginateDirectoryRead(children, req.Cursor, defaultDirectoryReadPageSize)
+	return core.NewResponse(id, DirectoryReadResult{Resources: page, NextCursor: next})
+}
+
+// resolveDirectoryURI maps a skill:// URI to (owning skill, relative
+// path inside the skill's fs.FS subtree). Returns a typed error suitable
+// for -32602 propagation when the URI does not address a directory the
+// Provider knows about.
+func (p *Provider) resolveDirectoryURI(uri string) (*skillEntry, string, error) {
+	parsed, err := ParseURI(uri)
+	if err != nil {
+		return nil, "", fmt.Errorf("skills: directory URI: %w", err)
+	}
+	if parsed.IsManifest {
+		// Manifest URIs (terminal SKILL.md) are file resources, not
+		// directories. resources/read handles them.
+		return nil, "", fmt.Errorf("skills: %q is a file resource, not a directory", uri)
+	}
+	segs := parsed.AllSegments
+	if len(segs) == 0 {
+		return nil, "", fmt.Errorf("skills: directory URI has no segments")
+	}
+
+	// Find the skill whose uriSegs is the longest prefix of segs. Each
+	// skillEntry.uriSegs holds the full skill path (with any URI prefix
+	// applied at registration time).
+	var best *skillEntry
+	bestLen := -1
+	for _, s := range p.skills {
+		if hasPrefixSegments(segs, s.uriSegs) && len(s.uriSegs) > bestLen {
+			best = s
+			bestLen = len(s.uriSegs)
+		}
+	}
+	if best == nil {
+		return nil, "", fmt.Errorf("skills: %q is outside every served skill subtree", uri)
+	}
+
+	// Compute the relative path inside the skill's fs.FS subtree.
+	// best.dirPath is the FS root for the skill; segs[bestLen:] is the
+	// in-skill path.
+	relSegs := segs[bestLen:]
+	relPath := strings.Join(relSegs, "/")
+	return best, relPath, nil
+}
+
+// enumerateDirectory reads one level of fs entries beneath skill.dirPath
+// + relPath and converts them to ResourceDefs. Files use detectMimeType
+// for their ordinary MIME; subdirectories use MimeTypeDirectory.
+//
+// parentURI is the original requested URI; used to construct each
+// child's URI by joining "<parentURI>/<entry-name>".
+func (p *Provider) enumerateDirectory(skill *skillEntry, relPath, parentURI string) ([]core.ResourceDef, error) {
+	fsRoot := skill.dirPath
+	if relPath != "" {
+		fsRoot = path.Join(skill.dirPath, relPath)
+	}
+	// Verify the target is a directory before reading. fs.Stat surfaces
+	// fs.ErrNotExist for unknown paths, which we want to surface as
+	// "no such directory."
+	info, err := fs.Stat(p.cfg.fsys, fsRoot)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, fmt.Errorf("skills: %q does not exist", parentURI)
+		}
+		return nil, fmt.Errorf("skills: stat %q: %w", parentURI, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("skills: %q is not a directory", parentURI)
+	}
+
+	entries, err := fs.ReadDir(p.cfg.fsys, fsRoot)
+	if err != nil {
+		return nil, fmt.Errorf("skills: read dir %q: %w", parentURI, err)
+	}
+
+	// Trim a trailing slash on the parent URI if any caller supplied one
+	// even though the SEP says directory URIs MUST NOT have one — be
+	// permissive on input, strict on output.
+	parent := strings.TrimRight(parentURI, "/")
+
+	out := make([]core.ResourceDef, 0, len(entries))
+	for _, e := range entries {
+		childURI := parent + "/" + e.Name()
+		if e.IsDir() {
+			out = append(out, core.ResourceDef{
+				URI:      childURI,
+				Name:     e.Name(),
+				MimeType: MimeTypeDirectory,
+			})
+			continue
+		}
+		mt := detectMimeType([]string{e.Name()})
+		out = append(out, core.ResourceDef{
+			URI:      childURI,
+			Name:     e.Name(),
+			MimeType: mt,
+		})
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].URI < out[j].URI })
+	return out, nil
+}
+
+// paginateDirectoryRead returns a contiguous slice of items starting at
+// the cursor offset, plus the next-cursor string (empty when the page
+// includes the tail). Cursor encoding is a base-10 offset; opaque to
+// callers per the resources/list contract.
+func paginateDirectoryRead(items []core.ResourceDef, cursor string, pageSize int) ([]core.ResourceDef, string) {
+	start := parseDirectoryReadCursor(cursor)
+	if start > len(items) {
+		start = len(items)
+	}
+	end := start + pageSize
+	if end >= len(items) {
+		return items[start:], ""
+	}
+	return items[start:end], formatDirectoryReadCursor(end)
+}
+
+func parseDirectoryReadCursor(s string) int {
+	if s == "" {
+		return 0
+	}
+	var n int
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return 0
+		}
+		n = n*10 + int(r-'0')
+	}
+	return n
+}
+
+func formatDirectoryReadCursor(n int) string {
+	if n == 0 {
+		return ""
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}

--- a/ext/skills/directory_pagination_test.go
+++ b/ext/skills/directory_pagination_test.go
@@ -1,0 +1,84 @@
+package skills
+
+import (
+	"testing"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+// TestPaginateDirectoryRead_RoundTrip walks a 5-entry input through
+// pageSize=2 windows and verifies (a) each page slices contiguously,
+// (b) the final page returns an empty NextCursor.
+func TestPaginateDirectoryRead_RoundTrip(t *testing.T) {
+	items := []core.ResourceDef{
+		{URI: "a"}, {URI: "b"}, {URI: "c"}, {URI: "d"}, {URI: "e"},
+	}
+
+	page1, next1 := paginateDirectoryRead(items, "", 2)
+	if got := urisOf(page1); !equalSlices(got, []string{"a", "b"}) {
+		t.Fatalf("page1 = %v, want [a b]", got)
+	}
+	if next1 == "" {
+		t.Fatalf("page1 NextCursor empty, expected one")
+	}
+
+	page2, next2 := paginateDirectoryRead(items, next1, 2)
+	if got := urisOf(page2); !equalSlices(got, []string{"c", "d"}) {
+		t.Fatalf("page2 = %v, want [c d]", got)
+	}
+	if next2 == "" {
+		t.Fatalf("page2 NextCursor empty, expected one")
+	}
+
+	page3, next3 := paginateDirectoryRead(items, next2, 2)
+	if got := urisOf(page3); !equalSlices(got, []string{"e"}) {
+		t.Fatalf("page3 = %v, want [e]", got)
+	}
+	if next3 != "" {
+		t.Errorf("final page NextCursor = %q, want empty", next3)
+	}
+}
+
+// TestPaginateDirectoryRead_EmptyInput returns an empty page with no
+// cursor, even when callers pass a stale cursor from a previous run.
+func TestPaginateDirectoryRead_EmptyInput(t *testing.T) {
+	page, next := paginateDirectoryRead(nil, "", 100)
+	if len(page) != 0 || next != "" {
+		t.Errorf("page=%v next=%q, want empty+empty", page, next)
+	}
+	page2, next2 := paginateDirectoryRead(nil, "10", 100)
+	if len(page2) != 0 || next2 != "" {
+		t.Errorf("page=%v next=%q, want empty+empty", page2, next2)
+	}
+}
+
+// TestPaginateDirectoryRead_MalformedCursorDefaultsToStart treats any
+// non-numeric cursor as offset 0 rather than erroring — keeps the wire
+// permissive on cursor decoding per the resources/list precedent.
+func TestPaginateDirectoryRead_MalformedCursorDefaultsToStart(t *testing.T) {
+	items := []core.ResourceDef{{URI: "a"}, {URI: "b"}}
+	page, _ := paginateDirectoryRead(items, "bogus", 100)
+	if len(page) != 2 {
+		t.Errorf("got %d entries, want 2", len(page))
+	}
+}
+
+func urisOf(rs []core.ResourceDef) []string {
+	out := make([]string, len(rs))
+	for i, r := range rs {
+		out[i] = r.URI
+	}
+	return out
+}
+
+func equalSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/ext/skills/directory_test.go
+++ b/ext/skills/directory_test.go
@@ -124,6 +124,36 @@ func TestDirectoryRead_NestedDirectoryURI(t *testing.T) {
 	}
 }
 
+// TestDirectoryRead_RejectsParentTraversal pins the security boundary:
+// a URI whose tail is `..` must not silently resolve to the parent of
+// the matched skill. Without the segment guard in resolveDirectoryURI,
+// path.Join("acme/billing/refunds", "..") would cleanly collapse to
+// "acme/billing" and enumerate the sibling tree — exactly the surface
+// the directoryRead capability is meant to keep scoped.
+func TestDirectoryRead_RejectsParentTraversal(t *testing.T) {
+	_, _, c := boot(t, "testdata/valid")
+	assertCallError(t, callDirectoryReadErr(c, "skill://acme/billing/refunds/..", ""), "invalid path segment")
+}
+
+// TestDirectoryRead_RejectsDotSegment rejects `.` segments for symmetry
+// with `..` — both are spec-silent at the URI level but semantically
+// ambiguous for a "directory inside the skill" lookup. Easier to reject
+// than to define disposal semantics.
+func TestDirectoryRead_RejectsDotSegment(t *testing.T) {
+	_, _, c := boot(t, "testdata/valid")
+	assertCallError(t, callDirectoryReadErr(c, "skill://acme/billing/refunds/.", ""), "invalid path segment")
+}
+
+// TestDirectoryRead_RejectsDeepTraversal asserts the guard fires even
+// when the cleaned path would resolve far outside the skill tree (e.g.,
+// /etc/passwd via successive `..` segments). The check is per-segment,
+// so this is the same code path as the single-`..` case — included as
+// a documented attack pattern.
+func TestDirectoryRead_RejectsDeepTraversal(t *testing.T) {
+	_, _, c := boot(t, "testdata/valid")
+	assertCallError(t, callDirectoryReadErr(c, "skill://acme/billing/refunds/../../../etc/passwd", ""), "invalid path segment")
+}
+
 // TestDirectoryRead_StableOrdering verifies the result is URI-sorted so
 // pagination cursors are deterministic across calls.
 func TestDirectoryRead_StableOrdering(t *testing.T) {

--- a/ext/skills/directory_test.go
+++ b/ext/skills/directory_test.go
@@ -1,0 +1,188 @@
+package skills_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/panyam/mcpkit/client"
+	"github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/ext/skills"
+)
+
+// TestDirectoryRead_Capability_OnByDefault confirms Provider.RegisterWith
+// auto-advertises directoryRead: true on the wire because Provider can
+// always enumerate from its underlying fs.FS at trivial cost. The
+// asymmetric default (Provider opt-out, direct SkillsExtension opt-in)
+// is intentional — see provider.go's RegisterWith doc.
+func TestDirectoryRead_Capability_OnByDefault(t *testing.T) {
+	_, _, c := boot(t, "testdata/valid")
+	cap, ok := c.ServerExtensionCapability(skills.ExtensionID)
+	if !ok {
+		t.Fatalf("server did not advertise %q", skills.ExtensionID)
+	}
+	v, _ := cap.Config[skills.CapabilityDirectoryRead].(bool)
+	if !v {
+		t.Errorf("Config[%q] = %v, want true", skills.CapabilityDirectoryRead, cap.Config)
+	}
+}
+
+// TestDirectoryRead_SkillRoot lists a skill's root directory and expects
+// SKILL.md (file) plus any sibling subdirectories (each with
+// MimeTypeDirectory). pdf-processing has SKILL.md, references/, scripts/.
+func TestDirectoryRead_SkillRoot(t *testing.T) {
+	_, _, c := boot(t, "testdata/valid")
+	result := callDirectoryRead(t, c, "skill://pdf-processing", "")
+	byName := indexByName(result.Resources)
+	if _, ok := byName["SKILL.md"]; !ok {
+		t.Errorf("missing SKILL.md in listing; got %v", namesOf(result.Resources))
+	}
+	for _, dir := range []string{"references", "scripts"} {
+		entry, ok := byName[dir]
+		if !ok {
+			t.Errorf("missing subdir %q in listing", dir)
+			continue
+		}
+		if entry.MimeType != skills.MimeTypeDirectory {
+			t.Errorf("entry %q has mimeType %q, want %q", dir, entry.MimeType, skills.MimeTypeDirectory)
+		}
+	}
+}
+
+// TestDirectoryRead_SubdirectoryListing exercises a non-root subtree.
+// `pdf-processing/references` has FORMS.md only.
+func TestDirectoryRead_SubdirectoryListing(t *testing.T) {
+	_, _, c := boot(t, "testdata/valid")
+	result := callDirectoryRead(t, c, "skill://pdf-processing/references", "")
+	if len(result.Resources) != 1 {
+		t.Fatalf("got %d entries, want 1: %v", len(result.Resources), namesOf(result.Resources))
+	}
+	r := result.Resources[0]
+	if r.Name != "FORMS.md" {
+		t.Errorf("name = %q, want FORMS.md", r.Name)
+	}
+	if r.URI != "skill://pdf-processing/references/FORMS.md" {
+		t.Errorf("uri = %q", r.URI)
+	}
+	if r.MimeType != "text/markdown" {
+		t.Errorf("mimeType = %q, want text/markdown", r.MimeType)
+	}
+}
+
+// TestDirectoryRead_ErrorOnFileURI rejects a URI that resolves to a file
+// (e.g., SKILL.md) with -32602. Matches the SEP's mandate that the
+// method applies only to directory resources.
+func TestDirectoryRead_ErrorOnFileURI(t *testing.T) {
+	_, _, c := boot(t, "testdata/valid")
+	assertCallError(t, callDirectoryReadErr(c, "skill://pdf-processing/SKILL.md", ""), "is a file resource")
+}
+
+// TestDirectoryRead_ErrorOnUnknownSkill rejects URIs whose first segments
+// do not match any skill the Provider serves.
+func TestDirectoryRead_ErrorOnUnknownSkill(t *testing.T) {
+	_, _, c := boot(t, "testdata/valid")
+	assertCallError(t, callDirectoryReadErr(c, "skill://nonexistent/foo", ""), "outside every served skill subtree")
+}
+
+// TestDirectoryRead_ErrorOnUnknownPath rejects URIs whose owning skill is
+// known but the subpath does not exist.
+func TestDirectoryRead_ErrorOnUnknownPath(t *testing.T) {
+	_, _, c := boot(t, "testdata/valid")
+	assertCallError(t, callDirectoryReadErr(c, "skill://pdf-processing/no-such-dir", ""), "does not exist")
+}
+
+// TestDirectoryRead_EmptyURIError pins the required-field rule on params.
+// An empty URI is Invalid params, not a server-side enumeration failure.
+func TestDirectoryRead_EmptyURIError(t *testing.T) {
+	_, _, c := boot(t, "testdata/valid")
+	assertCallError(t, callDirectoryReadErr(c, "", ""), "uri is required")
+}
+
+// TestDirectoryRead_NestedDirectoryURI walks two levels via two calls,
+// matching the SEP's "clients descend by issuing a follow-up call"
+// contract.
+func TestDirectoryRead_NestedDirectoryURI(t *testing.T) {
+	_, _, c := boot(t, "testdata/valid")
+	// First call: refunds/ root directory of the skill. Should contain
+	// SKILL.md (file) + templates (directory).
+	root := callDirectoryRead(t, c, "skill://acme/billing/refunds", "")
+	byName := indexByName(root.Resources)
+	if _, ok := byName["SKILL.md"]; !ok {
+		t.Errorf("expected SKILL.md in refunds root listing, got %v", namesOf(root.Resources))
+	}
+	tplEntry, ok := byName["templates"]
+	if !ok {
+		t.Fatalf("expected templates subdir in refunds root listing, got %v", namesOf(root.Resources))
+	}
+	if tplEntry.MimeType != skills.MimeTypeDirectory {
+		t.Errorf("templates mimeType = %q, want %q", tplEntry.MimeType, skills.MimeTypeDirectory)
+	}
+
+	// Second call: descend into templates/. Single file (email.md).
+	sub := callDirectoryRead(t, c, tplEntry.URI, "")
+	if len(sub.Resources) != 1 || sub.Resources[0].Name != "email.md" {
+		t.Errorf("templates listing = %v, want [email.md]", namesOf(sub.Resources))
+	}
+}
+
+// TestDirectoryRead_StableOrdering verifies the result is URI-sorted so
+// pagination cursors are deterministic across calls.
+func TestDirectoryRead_StableOrdering(t *testing.T) {
+	_, _, c := boot(t, "testdata/valid")
+	result := callDirectoryRead(t, c, "skill://pdf-processing", "")
+	for i := 1; i < len(result.Resources); i++ {
+		if result.Resources[i-1].URI >= result.Resources[i].URI {
+			t.Errorf("not URI-sorted at %d: %q >= %q",
+				i, result.Resources[i-1].URI, result.Resources[i].URI)
+		}
+	}
+}
+
+// callDirectoryRead issues resources/directory/read against the connected
+// server and t.Fatal's on transport-level error. Test bodies that assert
+// the server's typed response use this form.
+func callDirectoryRead(t *testing.T, c *client.Client, uri, cursor string) skills.DirectoryReadResult {
+	t.Helper()
+	res, err := c.Call(skills.MethodResourcesDirectoryRead, skills.DirectoryReadRequest{URI: uri, Cursor: cursor})
+	if err != nil {
+		t.Fatalf("Call(%s, uri=%q): %v", skills.MethodResourcesDirectoryRead, uri, err)
+	}
+	var out skills.DirectoryReadResult
+	if err := res.Unmarshal(&out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	return out
+}
+
+// callDirectoryReadErr issues the same call but returns the transport
+// error directly. Test bodies that assert the error message use this
+// form so they can match strings without fighting t.Fatalf.
+func callDirectoryReadErr(c *client.Client, uri, cursor string) error {
+	_, err := c.Call(skills.MethodResourcesDirectoryRead, skills.DirectoryReadRequest{URI: uri, Cursor: cursor})
+	return err
+}
+
+func indexByName(rs []core.ResourceDef) map[string]core.ResourceDef {
+	out := make(map[string]core.ResourceDef, len(rs))
+	for _, r := range rs {
+		out[r.Name] = r
+	}
+	return out
+}
+
+func namesOf(rs []core.ResourceDef) []string {
+	out := make([]string, len(rs))
+	for i, r := range rs {
+		out[i] = r.Name
+	}
+	return out
+}
+
+func assertCallError(t *testing.T, err error, want string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected error containing %q, got nil", want)
+	}
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("error %q does not contain %q", err, want)
+	}
+}

--- a/ext/skills/doc.go
+++ b/ext/skills/doc.go
@@ -56,3 +56,14 @@ const ArchiveTarGz = ".tar.gz"
 
 // ArchiveZip is the file suffix for zip archive entries.
 const ArchiveZip = ".zip"
+
+// MethodResourcesDirectoryRead is the JSON-RPC method name SEP-2640 added
+// in commit 2e04c48d (2026-06-09) for scoped directory listing inside a
+// resource subtree. Capability-gated via SkillsExtension.DirectoryRead.
+const MethodResourcesDirectoryRead = "resources/directory/read"
+
+// MimeTypeDirectory is the value SEP-2640 reserves for resources that
+// represent directories. Listed entries with this MIME type are intended
+// to be navigated with another resources/directory/read call rather than
+// fetched with resources/read.
+const MimeTypeDirectory = "inode/directory"

--- a/ext/skills/errors.go
+++ b/ext/skills/errors.go
@@ -46,6 +46,15 @@ var (
 	// section, hosts MUST NOT use unverified content; surfacing this as
 	// a typed error makes the contract explicit at the call site.
 	ErrDigestMismatch = errors.New("skills: digest mismatch — content MUST NOT be used")
+
+	// ErrDirectoryReadNotSupported is returned by Client.ReadDirectory
+	// when the connected server has not advertised the
+	// io.modelcontextprotocol/skills.directoryRead capability. SEP-2640
+	// commit 2e04c48d's normative wording: clients MUST NOT call
+	// resources/directory/read against a server that has not declared
+	// directoryRead: true. Returning a typed error from the pre-call
+	// guard keeps the contract explicit at the call site.
+	ErrDirectoryReadNotSupported = errors.New("skills: server does not advertise the directoryRead capability")
 )
 
 // Index validation errors.

--- a/ext/skills/extension.go
+++ b/ext/skills/extension.go
@@ -20,18 +20,41 @@ import "github.com/panyam/mcpkit/core"
 // either form explicitly. RegisterExtension is idempotent (keyed by
 // extension ID on the server's dispatcher), so combining auto-declaration
 // with an explicit registration is safe.
-type SkillsExtension struct{}
+type SkillsExtension struct {
+	// DirectoryRead reports the server's support for the SEP-2640
+	// resources/directory/read method (added by SEP commit 2e04c48d on
+	// 2026-06-09). When true, the extension's wire-level Config carries
+	// {"directoryRead": true}; when false the Config is omitted and clients
+	// MUST NOT call the method per the SEP's normative wording.
+	//
+	// Provider.RegisterWith sets this to true automatically because a
+	// Provider can always enumerate directories from its underlying fs.FS.
+	// Direct callers of RegisterExtension keep the default (false) and must
+	// opt in explicitly when they wire their own directory handler.
+	DirectoryRead bool
+}
+
+// CapabilityDirectoryRead is the SEP-2640 setting key inside the
+// io.modelcontextprotocol/skills extension capability that gates
+// resources/directory/read. Exported so client code can decode the same
+// key without re-stringing the literal.
+const CapabilityDirectoryRead = "directoryRead"
 
 // Extension implements core.ExtensionProvider. It returns the SEP-2640
-// extension metadata. SEP-2640 defines no extension-specific settings
-// today, so the Config field is left nil and the wire-level value is
-// the empty JSON object {} (not [] — see SEP-2640 PR discussion).
-func (SkillsExtension) Extension() core.Extension {
-	return core.Extension{
+// extension metadata. When DirectoryRead is set, the Config map carries
+// the directoryRead capability flag; otherwise Config stays nil and the
+// wire-level value is the empty JSON object {} (not [] — see SEP-2640 PR
+// discussion).
+func (e SkillsExtension) Extension() core.Extension {
+	ext := core.Extension{
 		ID:          ExtensionID,
 		SpecVersion: SpecVersion,
 		Stability:   core.Experimental,
 	}
+	if e.DirectoryRead {
+		ext.Config = map[string]any{CapabilityDirectoryRead: true}
+	}
+	return ext
 }
 
 // SpecVersion is the SEP-2640 draft version this implementation tracks.

--- a/ext/skills/extension_test.go
+++ b/ext/skills/extension_test.go
@@ -27,6 +27,30 @@ func TestSkillsExtension_Metadata(t *testing.T) {
 	}
 }
 
+// TestSkillsExtension_DirectoryReadConfig confirms the SEP-2640
+// directoryRead flag (added by commit 2e04c48d on 2026-06-09) emits on
+// the wire when set. The bare SkillsExtension{} keeps Config nil so
+// servers that wire the extension directly without an attached
+// directory handler don't accidentally advertise a method they don't
+// actually serve.
+func TestSkillsExtension_DirectoryReadConfig(t *testing.T) {
+	// Default: no Config.
+	defaultExt := skills.SkillsExtension{}.Extension()
+	if defaultExt.Config != nil {
+		t.Errorf("default SkillsExtension Config = %v, want nil", defaultExt.Config)
+	}
+
+	// Opted-in: Config carries directoryRead: true.
+	onExt := skills.SkillsExtension{DirectoryRead: true}.Extension()
+	v, ok := onExt.Config[skills.CapabilityDirectoryRead].(bool)
+	if !ok {
+		t.Fatalf("Config[%q] missing or wrong type; Config=%v", skills.CapabilityDirectoryRead, onExt.Config)
+	}
+	if !v {
+		t.Errorf("Config[%q] = false, want true", skills.CapabilityDirectoryRead)
+	}
+}
+
 func TestSkillsExtension_AppearsInInitialize(t *testing.T) {
 	_, _, c := boot(t, "testdata/valid")
 	if !c.ServerSupportsExtension(skills.ExtensionID) {

--- a/ext/skills/provider.go
+++ b/ext/skills/provider.go
@@ -247,6 +247,13 @@ func (p *Provider) Resources() []core.ResourceDef {
 // server.WithExtension call on the same SkillsExtension causes no
 // double-emit.
 //
+// Unless WithoutDirectoryRead was supplied to NewProvider, RegisterWith
+// also installs the SEP-2640 resources/directory/read handler (added by
+// SEP commit 2e04c48d) and emits {"directoryRead": true} inside the
+// extension's capability Config. The Provider walks its underlying
+// fs.FS at request time to enumerate the requested directory's direct
+// children.
+//
 // Unless WithoutIndex was supplied to NewProvider, RegisterWith also
 // constructs an internal Indexer and registers skill://index.json on
 // srv. Use WithIndexCacheTTL to tune the index's cache freshness or
@@ -259,7 +266,10 @@ func (p *Provider) RegisterWith(srv *server.Server) {
 	for _, r := range p.resources {
 		srv.RegisterResource(p.defFor(r), p.makeHandler(r))
 	}
-	srv.RegisterExtension(SkillsExtension{})
+	srv.RegisterExtension(SkillsExtension{DirectoryRead: !p.cfg.suppressDirectoryRead})
+	if !p.cfg.suppressDirectoryRead {
+		srv.HandleMethod(MethodResourcesDirectoryRead, p.handleDirectoryRead)
+	}
 	if !p.cfg.suppressIndex {
 		var opts []IndexerOption
 		if p.cfg.indexCacheTTL > 0 {

--- a/ext/skills/provider_options.go
+++ b/ext/skills/provider_options.go
@@ -10,14 +10,15 @@ import (
 type ProviderOption func(*providerConfig)
 
 type providerConfig struct {
-	fsys             fs.FS
-	root             string
-	uriPrefix        []string
-	metaPrefix       string
-	suppressIndex    bool
-	indexCacheTTL    time.Duration
-	archiveMode      ArchiveFormat
-	archiveMaxBytes  int64
+	fsys                 fs.FS
+	root                 string
+	uriPrefix            []string
+	metaPrefix           string
+	suppressIndex        bool
+	suppressDirectoryRead bool
+	indexCacheTTL        time.Duration
+	archiveMode          ArchiveFormat
+	archiveMaxBytes      int64
 }
 
 // WithFS supplies the io/fs.FS that the Provider walks for skills. The
@@ -113,5 +114,20 @@ func WithArchiveMode(format ArchiveFormat) ProviderOption {
 func WithArchiveMaxBytes(n int64) ProviderOption {
 	return func(c *providerConfig) {
 		c.archiveMaxBytes = n
+	}
+}
+
+// WithoutDirectoryRead suppresses registration of the SEP-2640
+// resources/directory/read method when the Provider's RegisterWith is
+// called. The default is ON because a Provider can always enumerate
+// directories from its underlying fs.FS at trivial cost.
+//
+// Suppress when the caller wants the discovery index without the
+// directory-navigation surface (e.g., to stay on the pre-2e04c48d SEP
+// shape during a transition window, or to gate the capability behind a
+// feature flag the application owns).
+func WithoutDirectoryRead() ProviderOption {
+	return func(c *providerConfig) {
+		c.suppressDirectoryRead = true
 	}
 }

--- a/ext/skills/types.go
+++ b/ext/skills/types.go
@@ -1,6 +1,10 @@
 package skills
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/panyam/mcpkit/core"
+)
 
 // SkillType is the discriminator for an entry in skill://index.json.
 type SkillType string
@@ -177,5 +181,30 @@ func MetadataFromFrontmatter(fm Frontmatter, sourceURI string) Metadata {
 		Extra:       fm.Extra,
 		SourceURI:   sourceURI,
 	}
+}
+
+// DirectoryReadRequest is the typed params shape for the SEP-2640
+// resources/directory/read method.
+//
+// Cursor mirrors the resources/list pagination contract: empty on the
+// first request, then the NextCursor returned by the prior response.
+type DirectoryReadRequest struct {
+	URI    string `json:"uri"`
+	Cursor string `json:"cursor,omitempty"`
+}
+
+// DirectoryReadResult is the typed result shape for the SEP-2640
+// resources/directory/read method.
+//
+// Resources are the directory's direct children — files carry their
+// ordinary resource metadata; subdirectories carry MimeTypeDirectory and
+// a URI without trailing slash. The listing is not recursive: clients
+// descend by calling the method again on a child directory.
+//
+// NextCursor follows the resources/list contract: present and non-empty
+// when more entries remain, omitted when the listing is complete.
+type DirectoryReadResult struct {
+	Resources  []core.ResourceDef `json:"resources"`
+	NextCursor string             `json:"nextCursor,omitempty"`
 }
 

--- a/server/dispatch.go
+++ b/server/dispatch.go
@@ -478,6 +478,7 @@ func (d *Dispatcher) handleInitialize(id json.RawMessage, params json.RawMessage
 			exts[id] = core.ExtensionCapability{
 				SpecVersion: ext.SpecVersion,
 				Stability:   string(ext.Stability),
+				Config:      ext.Config,
 			}
 		}
 		caps.Extensions = exts

--- a/server/stateless_backend.go
+++ b/server/stateless_backend.go
@@ -76,6 +76,7 @@ func (b *statelessBackend) Capabilities() core.ServerCapabilities {
 			caps.Extensions[id] = core.ExtensionCapability{
 				SpecVersion: e.SpecVersion,
 				Stability:   string(e.Stability),
+				Config:      e.Config,
 			}
 		}
 	}

--- a/server/trace_middleware.go
+++ b/server/trace_middleware.go
@@ -181,17 +181,19 @@ func traceMiddleware(tp core.TracerProvider) Middleware {
 				attrs = append(attrs, core.Attribute{Key: "mcp.tool.name", Value: name})
 			}
 		}
-		if req.Method == "resources/read" {
+		// SEP-414 P7 (issue 748): both resources/read and SEP-2640's
+		// resources/directory/read (added in SEP commit 2e04c48d on
+		// 2026-06-09 — issue 781) carry a `uri` field worth surfacing as
+		// `mcp.resource.uri`; skill:// URIs additionally emit
+		// `mcp.skill.*` attributes so dashboards can chart fetch and
+		// navigation volume per skill. `mcp.skill.path` and
+		// `mcp.skill.file` only populate for SEP-2640 manifest URIs
+		// (terminal `/SKILL.md`) where the path/file boundary is
+		// unambiguous from the URI alone; non-manifest URIs surface as
+		// `mcp.skill.uri` only.
+		if req.Method == "resources/read" || req.Method == "resources/directory/read" {
 			if uri := parseResourceReadURI(req.Params); uri != "" {
 				attrs = append(attrs, core.Attribute{Key: "mcp.resource.uri", Value: uri})
-				// SEP-414 P7 (issue 748): when the read targets a
-				// `skill://` URI, also emit skill-shaped attributes so
-				// server-side dashboards can chart fetch volume per
-				// skill. `mcp.skill.path` and `mcp.skill.file` only
-				// populate for SEP-2640 manifest URIs (terminal
-				// `/SKILL.md`) where the path/file boundary is
-				// unambiguous from the URI alone; non-manifest URIs
-				// surface as `mcp.skill.uri` only.
 				if path, file, ok := decomposeSkillURI(uri); ok {
 					attrs = append(attrs, core.Attribute{Key: "mcp.skill.uri", Value: uri})
 					if path != "" {


### PR DESCRIPTION
## What changes

Ships SEP-2640's `resources/directory/read` end-to-end so hosts can navigate a
skill's supporting subdirectories without enumerating the server's entire
resource space. Closes #781.

The SEP added the method on 2026-06-09 (commit `2e04c48d`). It's gated on a
new `directoryRead` boolean inside the `io.modelcontextprotocol/skills`
extension capability — mcpkit's `Provider` auto-opts in at `RegisterWith`
time because the underlying `fs.FS` can always enumerate at zero cost.
Bare `SkillsExtension{}` callers stay opt-in so they don't advertise a
method they haven't actually wired.

The walkthrough at `examples/skills/walkthrough.go` gains a new step (step
9 of 10) that lists `skill://acme/billing/refunds/templates` and hand-rolls
a one-level recursion into the new `regional/` subdirectory.

## Reviewer's guide

Read in this order:

1. `seps/2640-skills-extension.md` commit `2e04c48d` upstream (linked in the
   PR's commit ref via `2e04c48d`) — the spec sections "Capability
   Declaration" + "Directory Listing" are the source of truth this PR
   implements. Skim before the diff so the field names land in context.
2. [ext/skills/directory.go](https://github.com/panyam/mcpkit/pull/785/files#diff-f4ed6017503d235f572e8544f27ca1432fe6baccc13bdae1f187cff8371089a4) — start here. Handler + URI resolver +
   FS-walk-backed enumeration + a local 15-LOC paginate helper. The
   resolveDirectoryURI longest-prefix-match against the Provider's served
   skills is the load-bearing piece — verify it rejects URIs outside any
   served subtree.
3. [ext/skills/provider.go](https://github.com/panyam/mcpkit/pull/785/files#diff-bc1bc138c97cce27ab4ebcc05b5b90bce9519a5b6ece2cd00da30248841d7021) — the RegisterWith change. One line installs
   the handler; the SkillsExtension declaration flips its DirectoryRead
   field based on the WithoutDirectoryRead opt-out.
4. [ext/skills/extension.go](https://github.com/panyam/mcpkit/pull/785/files#diff-8cbf7ae7e745b0c81d76f2e4fab5a252875d0fca9142b176d231f62eb58ee84c) + [ext/skills/doc.go](https://github.com/panyam/mcpkit/pull/785/files#diff-f644939880600e922dbd2fc1e830bc0fc1f8cdde432a9093e776e95b10c5fae5) — capability emission +
   new constants (`MethodResourcesDirectoryRead`, `MimeTypeDirectory`,
   `CapabilityDirectoryRead`). Asymmetric default rationale lives in the
   `SkillsExtension.DirectoryRead` doc comment.
5. [core/protocol.go](https://github.com/panyam/mcpkit/pull/785/files#diff-3b2663f9e8f48aee8ba2b111c68b3a24dca2db346f5dbc961dddb976f4917094) + [server/dispatch.go](https://github.com/panyam/mcpkit/pull/785/files#diff-7640bcbef23148a16e477c63c7092f0ba89780f5278a9d6ba6ed513d62f68a92) + [server/stateless_backend.go](https://github.com/panyam/mcpkit/pull/785/files#diff-d6054c7923eaa9651736c3c6bccd7e7634dbf33d4bdfa89a5a34e069bb4b620e)
   — `ExtensionCapability` gains `Config map[string]any` and both
   emission paths thread `ext.Config` through. Tiny but cross-package, so
   gets its own checklist item.
6. [client/client.go](https://github.com/panyam/mcpkit/pull/785/files#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09) — `ServerExtensionCapability(id)` accessor. Lets
   ext/skills decode the cached capability without re-parsing the raw
   RawMessage.
7. [ext/skills/client.go](https://github.com/panyam/mcpkit/pull/785/files#diff-ab4abcac994a6acf009e0587fa6e9100b455944cfd76714f0f82040d1219589a) — `SupportsDirectoryRead` + `ReadDirectory` +
   `ReadDirectoryOption`. Pre-call guard returns the new
   `ErrDirectoryReadNotSupported` sentinel; OTel span is
   `skills.read_directory` with `mcp.skill.uri` + `mcp.skill.entries` attrs.
8. [server/trace_middleware.go](https://github.com/panyam/mcpkit/pull/785/files#diff-7e0ee26d4d523ebdecda4da033cb2f40c364eb05edb5f41b1d90d76fd374546e) — widens the existing `resources/read`
   enrichment block to also fire on `resources/directory/read`. Both
   methods carry a `uri` field worth surfacing.
9. [ext/skills/directory_test.go](https://github.com/panyam/mcpkit/pull/785/files#diff-58f13046926b3fb87f65f1b10f5baf0ff02d6421eb845f69e3394f3f5a16032c) + [ext/skills/directory_pagination_test.go](https://github.com/panyam/mcpkit/pull/785/files#diff-57bbd4af10976093c597c22434e4a2ca1838bff732870169e5832873005f579e)
   + [ext/skills/client_directory_test.go](https://github.com/panyam/mcpkit/pull/785/files#diff-6a4d6ff250e3fcf0f7f9a142ad325633efdfa2718165d97241a6ff750625aa4a) + [ext/skills/extension_test.go](https://github.com/panyam/mcpkit/pull/785/files#diff-2a762ead8159d7c472a799c32f571e32ef3e230f5f3e1dcdd8f6627af1ab279a)
   — acceptance. 8 server-handler scenarios + 3 pagination units + 3
   client-wrapper scenarios + 2 extension-config emission cases.
10. [examples/skills/walkthrough.go](https://github.com/panyam/mcpkit/pull/785/files#diff-94afaa0ca3ed61f670feefe88925e3b5ecfc827cfcdb7612d48a01dd289c10e7) + [examples/skills/WALKTHROUGH.md](https://github.com/panyam/mcpkit/pull/785/files#diff-f7567dfcd105e517415a8fc5aada2b08489ad36774f38681b85f5855a3638884) +
    fixture additions under `examples/skills/skills/acme/billing/refunds/
    templates/` — the live demo. Step 9 in the walkthrough is what runs
    against the WG audience tomorrow.

Skim or skip: the fixture markdown bodies (`refund-receipt.md`, `eu.md`)
are pure flavor for the listing output.

## Decision log

- **Handler in `ext/skills/` not `server/`.** The SEP itself notes the
  method "is not skill-specific — a server MAY support it on any directory
  resource it serves, under any scheme." Two reasons it stays in
  `ext/skills/` for now: (1) the capability emission is skills-namespaced
  (`capabilities.extensions["io.modelcontextprotocol/skills"]
  .directoryRead`), so even a `server/`-resident handler would need a
  two-step registration with the extension owner agreeing on the flag,
  and (2) the only producer of directory metadata today is `SkillProvider`
  — even a server-side handler would delegate into a skills-side
  enumerator. Promotion to `server/` (with a `server.DirectoryProvider`
  interface) becomes worth it when a second consumer emerges or a future
  SEP moves the capability gate out of the skills namespace.
- **Asymmetric default for `directoryRead`.** Provider opts in by
  default (`WithoutDirectoryRead` to opt out); bare `SkillsExtension{}`
  stays opt-in. Provider has an `fs.FS` so support is free; direct
  extension registration without an attached handler shouldn't silently
  advertise a method that responds with method-not-found.
- **No `Client.WalkDirectory`.** Call sites that need it can write
  ~5 LOC of recursion (the walkthrough demonstrates the shape). Avoids
  picking a streaming-vs-slice vs depth-first-vs-breadth-first contract
  before a second consumer surfaces.
- **Local pagination helper.** `server/dispatch.go`'s `paginate` is
  package-private. A 15-LOC local copy in `ext/skills/directory.go` beats
  promoting the helper for one off-package consumer. Revisit if a third
  user emerges.
- **Pre-call guard returns a typed error.** Matches the SEP's normative
  "Clients MUST NOT call" wording. Callers can `errors.Is(err,
  skills.ErrDirectoryReadNotSupported)` to branch.

## Risk / blast radius

- Affects: `ext/skills/` (foundation + new method), `server/dispatch.go`
  + `server/stateless_backend.go` (extension Config now thread through),
  `core/protocol.go` (`ExtensionCapability` gains `Config map[string]any`
  with `omitempty`), `client/client.go` (new accessor),
  `server/trace_middleware.go` (one-line widening),
  `examples/skills/` (walkthrough + fixtures).
- Tests covering this: `ext/skills/directory_test.go` (8 server-handler
  scenarios), `ext/skills/directory_pagination_test.go` (3 pagination
  scenarios), `ext/skills/client_directory_test.go` (3 client scenarios),
  `ext/skills/extension_test.go` (2 added emission cases).
- Be paranoid about: the longest-prefix URI matching in
  `Provider.resolveDirectoryURI`. The test that descends two skills with
  overlapping segments (`acme/billing/refunds` vs `acme/billing/refunds/
  templates`) exercises this; eyeball the resolution rule for shared-
  prefix configurations specific to your application.
- Be paranoid about: the `core.ExtensionCapability.Config` addition. The
  field uses `omitempty` so existing emissions stay byte-identical; new
  emissions that set Config land as a JSON object. Any caller marshaling
  `ExtensionCapability` directly should re-test their wire shape.

## Before / after

End-to-end run of the walkthrough's step 9 against the live server:

```
ReadDirectory(skill://acme/billing/refunds/templates):
  file         skill://acme/billing/refunds/templates/email.md
  file         skill://acme/billing/refunds/templates/refund-receipt.md
  dir/         skill://acme/billing/refunds/templates/regional
ReadDirectory(skill://acme/billing/refunds/templates/regional):
  file         skill://acme/billing/refunds/templates/regional/eu.md
```

## Out of scope (deliberately deferred)

- **Conformance scenarios for the new method** — split to #784. The
  7-scenario list + `sep-2640.yaml` check rows are detailed in that issue
  so the panyam/mcpconformance fork can pick up the work without
  re-deriving the SEP shape.
- **`Client.WalkDirectory`** — file a follow-up issue if a non-walkthrough
  consumer needs recursive descent in the SDK; the shape (slice vs
  channel, depth-first vs breadth-first) deserves a second use case.
- **G5 indexer refactor** (`#780`) — independent; the schema rewrite
  doesn't touch this PR.
- **G6 conformance #330 second re-extraction** — gated on `#780` landing
  so the YAML check rows can reference real SDK types.

