### PR TITLE
whole-enchilada: TTL + receiver-behavior matrix beats for the spec-alignment sweep

### DIFF
--- a/examples/whole-enchilada/events/Makefile
+++ b/examples/whole-enchilada/events/Makefile
@@ -155,13 +155,16 @@ poller: ## Long-running poll subscriber. TENANT=A|B|C plus either TOKEN=<bearer>
 		$(if $(USERNAME),--username $(USERNAME) --password $(if $(PASSWORD),$(PASSWORD),$(USERNAME))) \
 		--event $(EVENT)
 
-webhook: ## Long-running webhook subscriber. TENANT=A|B|C plus either TOKEN=<bearer> or USERNAME=<u> [PASSWORD=<p>; defaults to USERNAME].
+webhook: ## Long-running webhook subscriber. TENANT=A|B|C plus either TOKEN=<bearer> or USERNAME=<u> [PASSWORD=<p>; defaults to USERNAME]. Demo knobs: TTL_MS=<int|null> REPLY_STATUS=<int> EXIT_AFTER=<int>.
 	@if [ -z "$(TOKEN)" ] && [ -z "$(USERNAME)" ]; then \
-		echo "usage: make webhook TENANT=A|B|C [TOKEN=<bearer> | USERNAME=<u> [PASSWORD=<p>]]" >&2; exit 2; fi
+		echo "usage: make webhook TENANT=A|B|C [TOKEN=<bearer> | USERNAME=<u> [PASSWORD=<p>]] [TTL_MS=<int|null>] [REPLY_STATUS=<int>] [EXIT_AFTER=<int>]" >&2; exit 2; fi
 	go -C webhook run . --tenant $(call tenant-realm,$(TENANT)) \
 		$(if $(TOKEN),--token $(TOKEN)) \
 		$(if $(USERNAME),--username $(USERNAME) --password $(if $(PASSWORD),$(PASSWORD),$(USERNAME))) \
-		--event $(EVENT)
+		--event $(EVENT) \
+		$(if $(TTL_MS),--ttl-ms $(TTL_MS)) \
+		$(if $(REPLY_STATUS),--reply-status $(REPLY_STATUS)) \
+		$(if $(EXIT_AFTER),--exit-after $(EXIT_AFTER))
 
 streamer: ## Long-running events/stream subscriber over the stateless wire (push delivery). TENANT=A|B|C plus either TOKEN=<bearer> or USERNAME=<u> [PASSWORD=<p>; defaults to USERNAME].
 	@if [ -z "$(TOKEN)" ] && [ -z "$(USERNAME)" ]; then \
@@ -253,6 +256,19 @@ logs: ## Tail logs from all services.
 
 ps: ## docker compose ps.
 	docker compose ps
+
+# Demo helpers for the TTL / no-expiry / failure-GC walkthrough beats
+# (PRs 778, 779, 783). Each is a one-liner pointed at the running
+# compose stack — no surprises.
+
+psql-webhooks: ## Print the webhooks table from Postgres — used by the no-expiry restart-survival beat to confirm rows survive a `make restart-event-servers`.
+	docker compose -f $(BACKENDS_COMPOSE) exec -T postgres \
+		psql -U postgres -d events \
+		-c "SELECT id, principal, url, expires_at, status_failing_continuously_since FROM webhooks ORDER BY principal;"
+
+restart-event-servers: ## Rolling-restart the event-server replicas. Used by the no-expiry restart-survival beat — finite subs and no-expiry subs both survive (rows stay in Postgres), proving the GORM-backed WebhookStore is the durability backbone.
+	docker compose restart event-server-1 event-server-2 event-server-3
+	docker compose up -d --wait event-server-1 event-server-2 event-server-3
 
 clean: ## docker compose down -v on the events stack + remove built binaries. Backends data is preserved — use `make clean-backends` for a full reset.
 	docker compose down -v 2>/dev/null || true

--- a/examples/whole-enchilada/events/WALKTHROUGH.md
+++ b/examples/whole-enchilada/events/WALKTHROUGH.md
@@ -1,26 +1,26 @@
 # MCP Events — whole-enchilada stage 2 walkthrough
 
-Production-shape multi-tier reference. nginx fronts the event-server tier; Keycloak provides three pre-configured OAuth realms (asgard, babylon, camelot). The stack comes up silent — operator-runnable synthetic drivers (make drive-chat, make drive-presence) start producing events from sibling terminals. This walkthrough guides you through a multi-terminal demo where each tenant gets its own poller and webhook receiver — per-tenant isolation is the headline.
+Production-shape multi-tier reference. nginx fronts the event-server tier; Keycloak provides three pre-configured OAuth realms (asgard, babylon, camelot). The stack comes up silent — operator-runnable synthetic drivers (make drive-chat, make drive-presence) start producing events from sibling terminals. This walkthrough guides you through a multi-terminal demo where each tenant gets its own streaming push subscriber and webhook receiver — per-tenant isolation is the headline.
 
 ## What you'll learn
 
-- **A1-Poll — Asgard poller (alice).** — - Demonstrates: per-tenant delivery scoping (realm-in-bearer is what gates delivery).
-- **B1-Poll — Babylon poller (bob).** — - Demonstrates: the scoping claim holds across a second tenant.
-- **C1-Poll — Camelot poller (carol).** — - Demonstrates: clean three-way isolation on the wire.
-- **A2-Webhook — Asgard webhook receiver (anand).** — - Demonstrates: push-based webhook delivery surface (sibling to poll mode).
-- **B2-Webhook — Babylon webhook receiver (bhavna).** — - Demonstrates: webhook scoping for a second tenant.
-- **C2-Webhook — Camelot webhook receiver (chandan).** — - Demonstrates: completes the 3×2 matrix (3 tenants × {poll, webhook}).
+- **Open six terminals and run these.** — - Demonstrates: per-tenant delivery scoping (realm-in-bearer gates delivery) on both push surfaces.
 - **Admin — inject one event per tenant.** — - Demonstrates: per-event tenant tag is the authoritative delivery scope; same inject endpoint can target any tenant.
-- **Chat-Driver + Monitor + Admin — kill a replica mid-stream.** — - Demonstrates: Redis pub/sub fan-out keeps deliveries flowing through surviving replicas; nginx round-robin routes new connections to the survivors.
-- **A1-Poll — restart with the last cursor; resume gap-free.** — - Demonstrates: cross-replica cursor durability (any replica reads the same Postgres buffer).
+- **Chat-Driver + Monitor + Admin — kill a replica mid-stream.** — - Demonstrates: Redis pub/sub fan-out keeps deliveries flowing through surviving replicas; nginx round-robin routes new connections to the survivors. Every event-server replica stamps X-Replica on its HTTP responses AND on every outbound webhook POST, so the round-robin spray is visible directly in the streamer windows' 'served by event-server-N' log lines AND in the webhook receiver's replica= field.
+- **Walkthrough — fire events/list × N, log X-Replica rotation.** — - Demonstrates: replica-agnostic read path. nginx round-robin spreads calls across event-server-1/2/3; every replica answers from the same in-process source registry, so the response is byte-identical content-wise.
+- **Ad-hoc Poller — restart with the last cursor; resume gap-free.** — - Demonstrates: cross-replica cursor durability (any replica reads the same Postgres buffer).
 - **Admin — observe buffer TTL truncation.** — - Demonstrates: bounded replay (POSTGRES_BUFFER_TTL=10m in the compose); stale cursor → server returns truncated:true and client resyncs from latest.
-- **Aarti × 4 — trip the subscription cap.** — - Demonstrates: cap is enforced GLOBALLY (Redis Lua-atomic INCR-with-check) — replica-locality of subscribes doesn't help bypass it.
+- **Aarti × 4 — trip a tightened subscription cap.** — - Demonstrates: cap is enforced GLOBALLY (Redis Lua-atomic INCR-with-check) — replica-locality of subscribes doesn't help bypass it.
+- **TTL matrix — three tenants suggest different ttlMs values, observe the granted refreshBefore.** — - Demonstrates: server clamps client suggestions to the [MinWebhookTTL, MaxWebhookTTL] envelope; the 'one sanctioned exception' (clamp UP to the floor) is observable in window A; window B's in-envelope suggestion lands verbatim; window C's `null` request yields `refreshBefore: null` because the demo's event-server is started with EVENTS_ALLOW_INFINITE_TTL=true.
+- **Receiver-behavior matrix — same `make webhook` target, different reply status.** — - Demonstrates: server's per-delivery response branching: 410 abandons THIS delivery without affecting the subscription (PR 778 / spec PR1 commit 905ade36); 500 triggers the retry loop + the suspend transition past threshold.
+- **No-expiry restart-survival — restart the event-server tier, confirm the no-expiry sub stays.** — - Demonstrates: GORM-backed WebhookStore is the durability backbone — both finite-TTL and no-expiry subs survive a rolling restart of the event-server tier because their rows persist in Postgres (PR 779 made ExpiresAt nullable; the row survives regardless).
+- **Failure-based GC capstone — no-expiry subscriber dies after 3 deliveries; server drops the sub.** — - Demonstrates: the full failure-based GC end-to-end (PR 783). EXIT_AFTER=3 kills the receiver after 3 deliveries → next inject fails with connection_refused → server's `FailingContinuouslySince` anchors → past `EVENTS_NO_EXPIRY_GC_WINDOW=2m` (set on the event-server) the registry drops the no-expiry sub + POSTs a `terminated` envelope.
 - **Topology — subscribe to the topology stream (alex).** — - Demonstrates: events.topology is a normal source — any client can subscribe to it.
 - **Admin — add a real Discord source on replicas 1 and 3 only.** — - Demonstrates: operator-controlled source topology (replicas 1+3 own the Discord WebSocket; replica 2 deliberately skipped to expose per-replica divergence).
 - **Discord-Poll — subscribe to discord.message as Asgard (alice).** — - Demonstrates: dynamic source events flow through the same SSE + tenant scoping; subscribers on replica 2 (no Discord adapter) still receive events via Redis pubsub.
 - **Admin — compare per-replica source views.** — - Demonstrates: adapter configs are per-replica state (no cross-replica gossip); the topology stream is what unifies the view.
 - **Admin — remove the Discord source.** — - Demonstrates: evctl sources rm tears down both registry membership AND the upstream Discord WebSocket session.
-- **Browser + Admin — sign alice out in Keycloak admin and watch the asgard windows die.** — - Demonstrates: synchronously revocable bearer tokens — the demo's headline win over plain JWT.
+- **Browser + Admin — sign alice out in Keycloak admin and watch the asgard windows die.** — - Demonstrates: synchronously revocable bearer tokens — the demo's headline win over plain JWT. Revocation fires across both push surfaces uniformly.
 
 ## Flow
 
@@ -32,27 +32,27 @@ sequenceDiagram
     participant Drivers as Operator-runnable synthetic producers (make drive-chat, make drive-presence)
     participant Keycloak as OAuth AS — three realms pre-imported on first start (localhost:8180)
 
-    Note over Operator,Keycloak: Step 1: A1-Poll — Asgard poller (alice).
+    Note over Operator,Keycloak: Step 1: Open six terminals and run these.
 
-    Note over Operator,Keycloak: Step 2: B1-Poll — Babylon poller (bob).
+    Note over Operator,Keycloak: Step 2: Admin — inject one event per tenant.
 
-    Note over Operator,Keycloak: Step 3: C1-Poll — Camelot poller (carol).
+    Note over Operator,Keycloak: Step 3: Chat-Driver + Monitor + Admin — kill a replica mid-stream.
 
-    Note over Operator,Keycloak: Step 4: A2-Webhook — Asgard webhook receiver (anand).
+    Note over Operator,Keycloak: Step 4: Walkthrough — fire events/list × N, log X-Replica rotation.
 
-    Note over Operator,Keycloak: Step 5: B2-Webhook — Babylon webhook receiver (bhavna).
+    Note over Operator,Keycloak: Step 5: Ad-hoc Poller — restart with the last cursor; resume gap-free.
 
-    Note over Operator,Keycloak: Step 6: C2-Webhook — Camelot webhook receiver (chandan).
+    Note over Operator,Keycloak: Step 6: Admin — observe buffer TTL truncation.
 
-    Note over Operator,Keycloak: Step 7: Admin — inject one event per tenant.
+    Note over Operator,Keycloak: Step 7: Aarti × 4 — trip a tightened subscription cap.
 
-    Note over Operator,Keycloak: Step 8: Chat-Driver + Monitor + Admin — kill a replica mid-stream.
+    Note over Operator,Keycloak: Step 8: TTL matrix — three tenants suggest different ttlMs values, observe the granted refreshBefore.
 
-    Note over Operator,Keycloak: Step 9: A1-Poll — restart with the last cursor; resume gap-free.
+    Note over Operator,Keycloak: Step 9: Receiver-behavior matrix — same `make webhook` target, different reply status.
 
-    Note over Operator,Keycloak: Step 10: Admin — observe buffer TTL truncation.
+    Note over Operator,Keycloak: Step 10: No-expiry restart-survival — restart the event-server tier, confirm the no-expiry sub stays.
 
-    Note over Operator,Keycloak: Step 11: Aarti × 4 — trip the subscription cap.
+    Note over Operator,Keycloak: Step 11: Failure-based GC capstone — no-expiry subscriber dies after 3 deliveries; server drops the sub.
 
     Note over Operator,Keycloak: Step 12: Topology — subscribe to the topology stream (alex).
 
@@ -73,118 +73,79 @@ sequenceDiagram
 
 Run 'make predemo' once first — it gives you a clean Keycloak slate, brings up the backends + observability + events stacks fresh, and opens the Keycloak admin (localhost:8180) and Grafana (localhost:3000) in your browser. Optionally run 'make alllogs' for a single iTerm window with 3 panes tailing each stack's logs.
 
-The walkthrough binary you're reading does not make MCP calls. Each Step tells you which window to open and exactly what command to run; the actual protocol traffic happens in those operator-run binaries.
+This walkthrough mostly orchestrates what you read between actions — only Phase 4's replica-rotation beat makes MCP calls from inside this binary. Each Step that requires terminal work tells you which window to open and what command to run; the actual protocol traffic happens in those operator-run binaries.
 
 Window plan — at peak you'll have these open:
 
-  - A1-Poll, B1-Poll, C1-Poll       — tenant poll subscribers (alice / bob / carol). First used in steps 1 / 2 / 3.
-  - A2-Webhook, B2-Webhook, C2-Webhook — tenant webhook subscribers (anand / bhavna / chandan). First used in steps 4 / 5 / 6.
-  - Admin                            — one-shot commands (inject, evctl, docker exec, psql). First used in step 7.
-  - Chat-Driver                      — synth producer (continuous flow for the kill-replica beat). First used in step 8.
-  - Monitor                          — Redis MONITOR. First used in step 8.
-  - Topology                         — events.topology meta-source subscriber. First used in step 12.
-  - Discord-Poll                     — discord.message poller. First used in step 14.
-  - Browser                          — Keycloak admin UI for revocation. First used in step 17.
+  - A1-Stream, B1-Stream, C1-Stream     — tenant streaming push subscribers (alice / bob / carol; SEP-2575 response-as-SSE). First used in step 1.
+  - A2-Webhook, B2-Webhook, C2-Webhook   — tenant webhook receivers (anand / bhavna / chandan). First used in step 1.
+  - Admin                                — one-shot commands (inject, evctl, docker exec, psql). First used in step 2.
+  - Chat-Driver                          — synth producer (continuous flow for the kill-replica beat). First used in step 3.
+  - Monitor                              — Redis MONITOR. First used in step 3.
+  - Topology                             — events.topology meta-source subscriber. First used in step 8.
+  - Discord-Poll                         — discord.message poller. First used in step 10.
+  - Browser                              — Keycloak admin UI for revocation. First used in step 13.
 
-### Phase 1 — Set up the poll-mode subscriber matrix
+### Phase 1 — Set up the subscriber matrix (six silent windows)
 
-Three poll-mode subscribers, one per realm. Each will sit silent until Phase 3 fires the first events — that's intentional; we're proving the path with a single deliberate inject rather than ambient noise.
+Six push subscribers: three streaming (alice/bob/carol) and three webhook receivers (anand/bhavna/chandan). All six sit silent until Phase 2 fires the first events — proving the path with a single deliberate inject rather than ambient noise. Poll mode is still available via `make poller` for ad-hoc operator use, but it isn't part of the headline narrative — the push surfaces are.
 
-### Step 1: A1-Poll — Asgard poller (alice).
+### Step 1: Open six terminals and run these.
 
-- Demonstrates: per-tenant delivery scoping (realm-in-bearer is what gates delivery).
-- Expected: window sits silent until Phase 3. Once events flow, prints chat.message events tagged for asgard; babylon / camelot events never reach this window.
+- Demonstrates: per-tenant delivery scoping (realm-in-bearer gates delivery) on both push surfaces.
+- A1/B1/C1 are streaming push on the SEP-2575 stateless wire — open POST + response-as-SSE, nginx round-robins every replica freely. Lowest delivery latency.
+- A2/B2/C2 are HTTP webhook receivers — HMAC-signed POSTs, retry-on-failure, durable delivery records.
+- Expected: all six windows sit silent. Once Phase 2 fires, each asgard event lights up A1+A2; babylon events light up B1+B2; camelot events light up C1+C2. No cross-tenant leakage on any surface.
 
-#### Run this
-
-```bash
-make poller TENANT=A USERNAME=alice
-```
-
-### Step 2: B1-Poll — Babylon poller (bob).
-
-- Demonstrates: the scoping claim holds across a second tenant.
-- Expected: sits silent for now; will print only babylon events once Phase 3 fires.
-
-#### Run this
+#### Open six terminal windows and run one of these in each
 
 ```bash
-make poller TENANT=B USERNAME=bob
-```
+# A1-Stream — Asgard streaming subscriber (alice)
+make streamer TENANT=A USERNAME=alice
 
-### Step 3: C1-Poll — Camelot poller (carol).
+# B1-Stream — Babylon streaming subscriber (bob)
+make streamer TENANT=B USERNAME=bob
 
-- Demonstrates: clean three-way isolation on the wire.
-- Expected: sits silent for now; once Phase 3 fires, each event lights up exactly one of A1 / B1 / C1 — never two at once.
+# C1-Stream — Camelot streaming subscriber (carol)
+make streamer TENANT=C USERNAME=carol
 
-#### Run this
-
-```bash
-make poller TENANT=C USERNAME=carol
-```
-
-### Phase 2 — Add webhook-mode subscribers (still silent)
-
-Webhook is the second delivery surface. Distinct users per role (anand / bhavna / chandan) keep Keycloak sessions clean and avoid bumping into the subscription cap demo later. These also stay silent until Phase 3.
-
-### Step 4: A2-Webhook — Asgard webhook receiver (anand).
-
-- Demonstrates: push-based webhook delivery surface (sibling to poll mode).
-- Expected: sits silent for now; once Phase 3 fires, logs an HMAC-verified delivery for every asgard chat.message — same event also lights up A1 via poll mode.
-
-#### Run this
-
-```bash
+# A2-Webhook — Asgard webhook receiver (anand)
 make webhook TENANT=A USERNAME=anand
-```
 
-### Step 5: B2-Webhook — Babylon webhook receiver (bhavna).
-
-- Demonstrates: webhook scoping for a second tenant.
-- Expected: sits silent for now; once Phase 3 fires, receives only babylon events; never sees asgard or camelot deliveries.
-
-#### Run this
-
-```bash
+# B2-Webhook — Babylon webhook receiver (bhavna)
 make webhook TENANT=B USERNAME=bhavna
-```
 
-### Step 6: C2-Webhook — Camelot webhook receiver (chandan).
-
-- Demonstrates: completes the 3×2 matrix (3 tenants × {poll, webhook}).
-- Expected: sits silent for now; once Phase 3 fires, every chat.message lights up exactly TWO windows (one poll + one webhook), both for the same tenant.
-
-#### Run this
-
-```bash
+# C2-Webhook — Camelot webhook receiver (chandan)
 make webhook TENANT=C USERNAME=chandan
 ```
 
-### Phase 3 — First events: manual inject validates the path
+### Phase 2 — First events: manual inject validates the path
 
 Subscribers are up and silent. Now fire one event per tenant and watch which windows light up — this proves the per-event tenant tag is the authoritative scope (not the producer or the connection).
 
-### Step 7: Admin — inject one event per tenant.
+### Step 2: Admin — inject one event per tenant.
 
 - Demonstrates: per-event tenant tag is the authoritative delivery scope; same inject endpoint can target any tenant.
-- Expected: A's inject lights up A1+A2 only (asgard windows); B's lights up B1+B2 only; C's (presence.changed) lights up C1+C2 only. No cross-tenant leakage.
+- Expected: A's inject lights up A1+A2 (asgard stream + webhook); B's lights up B1+B2; C's lights up C1+C2. No cross-tenant leakage on any surface.
+- All six Phase 1 windows subscribed to chat.message specifically (the events SDK takes one source name per subscription; no wildcard), so we use the same event type for every inject and watch the per-tenant scoping decide who sees it.
 
 #### Run these in turn
 
 ```bash
 make inject TENANT=A EVENT=chat.message TEXT='hi from Asgard'
 make inject TENANT=B EVENT=chat.message TEXT='hi from Babylon'
-make inject TENANT=C EVENT=presence.changed USER=carol STATE=online
+make inject TENANT=C EVENT=chat.message TEXT='hi from Camelot'
 ```
 
-### Phase 4 — Multi-replica resilience
+### Phase 3 — Multi-replica resilience
 
-Stack is N=3 by default. Redis Publisher/Subscriber fans every yielded event to every replica's local delivery loop, so killing a replica mid-stream doesn't drop subscriber state on the survivors. This step needs continuous traffic to make the 'mid-stream' claim observable, so we fire up the chat driver as part of the setup.
+Stack is N=3 by default. Redis Publisher/Subscriber fans every yielded event to every replica's local delivery loop, so killing a replica mid-stream doesn't drop subscriber state on the survivors.
 
-### Step 8: Chat-Driver + Monitor + Admin — kill a replica mid-stream.
+### Step 3: Chat-Driver + Monitor + Admin — kill a replica mid-stream.
 
-- Demonstrates: Redis pub/sub fan-out keeps deliveries flowing through surviving replicas; nginx round-robin routes new connections to the survivors.
-- Expected: Once make drive-chat runs, A1/B1/C1/A2/B2/C2 all start ticking through their tenant's events. Redis MONITOR shows publish mcpkit.events.chat.message ... on every event. After killing replica 1, subscriber windows keep printing without gaps. Start replica 1 again when done; leave drive-chat running for the rest of the demo (Phases 5-6 need the stream).
+- Demonstrates: Redis pub/sub fan-out keeps deliveries flowing through surviving replicas; nginx round-robin routes new connections to the survivors. Every event-server replica stamps X-Replica on its HTTP responses AND on every outbound webhook POST, so the round-robin spray is visible directly in the streamer windows' 'served by event-server-N' log lines AND in the webhook receiver's replica= field.
+- The stream subscriber is the most telling check — SEP-2575 stateless wire means its open POST connection lands on ONE specific replica. Killing that replica forces a reconnection; the stream client transparently resumes against a survivor, and the next 'served by' log line shows the new X-Replica value.
+- Expected: Once make drive-chat runs, A1/B1/C1/A2/B2/C2 all start ticking through their tenant's events. Redis MONITOR shows publish mcpkit.events.chat.message ... on every event. Webhook receiver logs show replica= rotating across event-server-1/2/3. After killing replica 1, webhook windows keep printing without gaps; the stream window whose connection was bound to replica 1 briefly reconnects (operator may see a terminated frame then a fresh subscribe) and resumes delivery on a surviving replica. Start replica 1 again when done; leave drive-chat running for the rest of the demo.
 
 #### Three windows: Chat-Driver, Monitor, Admin
 
@@ -200,11 +161,20 @@ docker compose kill event-server-1
 docker compose start event-server-1
 ```
 
+### Phase 4 — Replica-rotation poll: same data, any replica
+
+With Phase 3 still running (drive-chat + N=3 replicas), this walkthrough binary itself fires a handful of events/list calls in a row against the nginx frontdoor. Each call lands on whichever replica nginx round-robins to; we log the X-Replica response header per call and compare response shapes — same source list, different replica.
+
+### Step 4: Walkthrough — fire events/list × N, log X-Replica rotation.
+
+- Demonstrates: replica-agnostic read path. nginx round-robin spreads calls across event-server-1/2/3; every replica answers from the same in-process source registry, so the response is byte-identical content-wise.
+- Expected: prints one line per call: 'call k served by event-server-N — events=M'. Over ~6 calls you'll see at least two distinct X-Replica values (nginx round-robin); the event count M is identical across all calls.
+
 ### Phase 5 — Cursor durability
 
-Postgres-backed event buffer is the single source of truth across replicas. Poll-mode subscribers can stop, restart on a different replica, and resume gap-free.
+Postgres-backed event buffer is the single source of truth across replicas. A poll-mode subscriber can stop, restart on a different replica, and resume gap-free. We use the make poller binary ad-hoc for this beat — it's the right surface for showing cursor restart.
 
-### Step 9: A1-Poll — restart with the last cursor; resume gap-free.
+### Step 5: Ad-hoc Poller — restart with the last cursor; resume gap-free.
 
 - Demonstrates: cross-replica cursor durability (any replica reads the same Postgres buffer).
 - Expected: after Ctrl+C, restart with --start-cursor=<N> and the poller resumes exactly where it left off, even if nginx routes the new connection to a different replica.
@@ -217,7 +187,7 @@ make poller TENANT=A USERNAME=alice
 make poller TENANT=A USERNAME=alice -- --start-cursor=<N>
 ```
 
-### Step 10: Admin — observe buffer TTL truncation.
+### Step 6: Admin — observe buffer TTL truncation.
 
 - Demonstrates: bounded replay (POSTGRES_BUFFER_TTL=10m in the compose); stale cursor → server returns truncated:true and client resyncs from latest.
 - Expected: after waiting past the TTL, restarting the poller with the old cursor produces a truncated:true response visible in the poller logs; it then continues from latest.
@@ -231,20 +201,116 @@ docker exec mcpkit-postgres psql -U postgres -d events \
 
 ### Phase 6 — Subscription quota enforcement
 
-`EVENTS_QUOTA_CAPS=chat.message=3` is wired in compose. The Redis-backed QuotaStore enforces this per-principal globally — the 4th subscribe rejects even when it lands on a different replica.
+Compose ships `EVENTS_QUOTA_CAPS=chat.message=10` as the default (room for normal multi-window play without tripping). The Redis-backed QuotaStore enforces this per-principal globally — the cap+1'th subscribe rejects even when it lands on a different replica. For a tight demonstration this step overrides the cap down to 3 for the duration of the beat.
 
-### Step 11: Aarti × 4 — trip the subscription cap.
+### Step 7: Aarti × 4 — trip a tightened subscription cap.
 
 - Demonstrates: cap is enforced GLOBALLY (Redis Lua-atomic INCR-with-check) — replica-locality of subscribes doesn't help bypass it.
-- Expected: first three windows print steady delivery; the fourth exits immediately with -32013 ResourceExhausted limit=subscriptions max=3. We use aarti (not alice/anand) so the existing subscriptions from Phases 2-3 don't already count toward her cap.
+- Expected: first three windows print steady delivery; the fourth exits immediately with -32013 ResourceExhausted limit=subscriptions max=3. We use aarti (not alice/anand) so the subscriptions from Phase 1 don't already count toward her cap.
 
-#### Run in four sibling windows; the 4th rejects
+#### Tighten the cap first, then run in four sibling windows; the 4th rejects
 
 ```bash
+# Lower the cap to 3 for this beat, restart the event-server tier:
+EVENTS_QUOTA_CAPS=chat.message=3 docker compose up -d event-server-1 event-server-2 event-server-3
+make clear-all   # clear stale aarti subs from any prior runs
+
 make webhook TENANT=A USERNAME=aarti   # window 1 — succeeds
 make webhook TENANT=A USERNAME=aarti   # window 2 — succeeds
 make webhook TENANT=A USERNAME=aarti   # window 3 — succeeds (at cap)
 make webhook TENANT=A USERNAME=aarti   # window 4 — rejects with -32013
+
+# Restore the looser default afterwards:
+docker compose up -d event-server-1 event-server-2 event-server-3
+```
+
+### Phase 6b — TTL negotiation and receiver-behavior matrix
+
+The just-merged spec-alignment work (PRs 778, 779, 783) introduces three orthogonal subscription knobs the operator can mix and match on `make webhook`. TTL_MS shapes the client-side suggestion to the server (absent / int / null per spec PR1 commit 99f3589c). REPLY_STATUS shapes what the receiver returns per delivery (200 default / 410 abandon / 5xx retry-then-suspend). EXIT_AFTER shapes whether the receiver lives long enough for the server's failure-based GC to fire on a no-expiry sub. This phase walks the matrix one knob at a time, ending with the capstone combo.
+
+### Step 8: TTL matrix — three tenants suggest different ttlMs values, observe the granted refreshBefore.
+
+- Demonstrates: server clamps client suggestions to the [MinWebhookTTL, MaxWebhookTTL] envelope; the 'one sanctioned exception' (clamp UP to the floor) is observable in window A; window B's in-envelope suggestion lands verbatim; window C's `null` request yields `refreshBefore: null` because the demo's event-server is started with EVENTS_ALLOW_INFINITE_TTL=true.
+- Expected: A's window logs `refreshBefore=<now+~5min>` (clamped UP); B's logs `refreshBefore=<now+~15min>` (granted as-is); C's logs `refreshBefore=null (no-expiry granted)`.
+
+#### Open three sibling webhook windows, one per tenant
+
+```bash
+# Sub-floor suggestion → clamped UP to MinWebhookTTL (5 minutes).
+make webhook TENANT=A USERNAME=anand TTL_MS=30000
+
+# In-envelope suggestion → granted as-is (15 minutes).
+make webhook TENANT=B USERNAME=bhavna TTL_MS=900000
+
+# null → no-expiry, refreshBefore:null on the wire (event-server has EVENTS_ALLOW_INFINITE_TTL=true).
+make webhook TENANT=C USERNAME=chandan TTL_MS=null
+```
+
+### Step 9: Receiver-behavior matrix — same `make webhook` target, different reply status.
+
+- Demonstrates: server's per-delivery response branching: 410 abandons THIS delivery without affecting the subscription (PR 778 / spec PR1 commit 905ade36); 500 triggers the retry loop + the suspend transition past threshold.
+- Expected: 410 window logs the verification + receives the inject, server-side logs (`make logs | grep webhook`) show `abandoned per receiver 410 Gone (subscription unaffected)`; the next inject in the same tenant lands on a separate (default-200) window normally. 500 window: server retries 3× with backoff, then logs the suspend transition + posts a `terminated` envelope; the sub stays in the registry as paused, observable via `make psql-webhooks`.
+
+#### Open two sibling windows, then fire injects from Admin
+
+```bash
+# Window 1: receiver abandons each delivery with 410.
+make webhook TENANT=A USERNAME=aarti REPLY_STATUS=410
+
+# Window 2: receiver fails with 500 — server retries then suspends.
+make webhook TENANT=A USERNAME=ananya REPLY_STATUS=500
+
+# Admin window — inject one event per receiver type:
+make inject TENANT=A EVENT=chat.message TEXT='aarti gets 410, sub unaffected'
+make inject TENANT=A EVENT=chat.message TEXT='ananya gets 500, retried then suspended'
+
+# Then inspect the registry:
+make psql-webhooks
+```
+
+### Step 10: No-expiry restart-survival — restart the event-server tier, confirm the no-expiry sub stays.
+
+- Demonstrates: GORM-backed WebhookStore is the durability backbone — both finite-TTL and no-expiry subs survive a rolling restart of the event-server tier because their rows persist in Postgres (PR 779 made ExpiresAt nullable; the row survives regardless).
+- Expected: the chandan window's no-expiry sub appears in `make psql-webhooks` before AND after the restart, with `expires_at IS NULL`. A post-restart inject still lands on chandan's window. Finite-TTL subs survive the restart too — the meaningful contrast surfaces only when the CLIENT stops refreshing (which the no-expiry sub never needs to do).
+
+#### With Phase 6b TTL window C still running, do this in Admin
+
+```bash
+# Before the restart — confirm chandan's no-expiry row exists.
+make psql-webhooks
+
+# Rolling restart of all three event-server replicas.
+make restart-event-servers
+
+# After the restart — same row, same expires_at IS NULL.
+make psql-webhooks
+
+# Inject one event — chandan's no-expiry window still receives it.
+make inject TENANT=C EVENT=chat.message TEXT='hi after restart'
+```
+
+### Step 11: Failure-based GC capstone — no-expiry subscriber dies after 3 deliveries; server drops the sub.
+
+- Demonstrates: the full failure-based GC end-to-end (PR 783). EXIT_AFTER=3 kills the receiver after 3 deliveries → next inject fails with connection_refused → server's `FailingContinuouslySince` anchors → past `EVENTS_NO_EXPIRY_GC_WINDOW=2m` (set on the event-server) the registry drops the no-expiry sub + POSTs a `terminated` envelope.
+- Expected: the receiver window receives 3 events then exits with the log line `exit-after target reached`. Next inject lands in the server logs as a delivery retry; after ~2 minutes of continuous failure, `make psql-webhooks` no longer shows chandan's no-expiry row. The failing-continuously-since column would be visible mid-flight if you queried during the failure run.
+
+#### Run in a fresh window — the receiver self-terminates
+
+```bash
+# No-expiry sub that intentionally dies after 3 events.
+make webhook TENANT=C USERNAME=chandan TTL_MS=null EXIT_AFTER=3
+
+# In another window, fire 3 events to trip EXIT_AFTER, then a 4th to start the failure run:
+make inject TENANT=C EVENT=chat.message TEXT='1 — delivers'
+make inject TENANT=C EVENT=chat.message TEXT='2 — delivers'
+make inject TENANT=C EVENT=chat.message TEXT='3 — delivers, then receiver exits'
+make inject TENANT=C EVENT=chat.message TEXT='4 — first failure of the run'
+
+# Watch the registry. Within ~2m the no-expiry sub vanishes:
+watch -n 30 make psql-webhooks
+
+# Server logs show the eventual drop:
+make logs | grep -E "no-expiry subscription dropped|FailingContinuouslySince"
 ```
 
 ### Phase 7 — Dynamic source topology (PULL pattern)
@@ -254,7 +320,7 @@ The events SDK lets you AddSource / RemoveSource at runtime. mcpkit ships `event
 ### Step 12: Topology — subscribe to the topology stream (alex).
 
 - Demonstrates: events.topology is a normal source — any client can subscribe to it.
-- Expected: window sits silent right now (no sources have been added since boot). Will print source.added / source.removed events the moment Phase 8 fires them.
+- Expected: window sits silent right now (no sources have been added since boot). Will print source.added / source.removed events the moment the next step fires them.
 
 #### Run this
 
@@ -310,12 +376,12 @@ make rm-source SOURCE=discord.message REPLICAS=1,3
 
 ### Phase 8 — Token revocation kills only affected subscribers
 
-One Keycloak admin click fires TWO distinct revocation paths: introspection-cache eviction for poll-mode subscribers (~5s) and OIDC Back-Channel Logout for webhook subscribers (immediate).
+One Keycloak admin click fires TWO distinct revocation paths: introspection-cache eviction for stream-mode subscribers (~5s) and OIDC Back-Channel Logout for webhook subscribers (immediate).
 
 ### Step 17: Browser + Admin — sign alice out in Keycloak admin and watch the asgard windows die.
 
-- Demonstrates: synchronously revocable bearer tokens — the demo's headline win over plain JWT.
-- Expected: within ~5s, A1-Poll exits with token invalidated by AS (401). A2-Webhook receives a {type:terminated} envelope on its webhook stream and disconnects. B and C windows are entirely untouched — revocation is per-realm.
+- Demonstrates: synchronously revocable bearer tokens — the demo's headline win over plain JWT. Revocation fires across both push surfaces uniformly.
+- Expected: within ~5s, A1-Stream receives a terminal frame on its open POST response and exits (the request-scoped principal claims drop out from under the dispatcher). A2-Webhook receives a {type:terminated} envelope on its webhook stream and disconnects. B and C windows are entirely untouched — revocation is per-realm.
 
 #### Open the browser, then tail logs in Admin
 
@@ -330,7 +396,7 @@ docker compose logs -f event-server-1 | grep BCL
 
 ### That's the demo
 
-You've now seen: producer/consumer split, per-tenant scoping on both delivery modes, cross-replica fan-out and resilience, durable cursors with bounded replay, globally-enforced subscription quotas, runtime source topology with the SDK's self-aware meta-stream, and synchronous token revocation. Everything is operator-runnable from sibling terminals — `make predemo` re-runs the prep at any time.
+You've now seen: producer/consumer split, per-tenant scoping on both push surfaces, cross-replica fan-out and resilience, replica-agnostic read path, durable cursors with bounded replay, globally-enforced subscription quotas, runtime source topology with the SDK's self-aware meta-stream, and synchronous token revocation. Everything is operator-runnable from sibling terminals — `make predemo` re-runs the prep at any time.
 
 ## Run it
 

--- a/examples/whole-enchilada/events/docker-compose.yaml
+++ b/examples/whole-enchilada/events/docker-compose.yaml
@@ -148,6 +148,21 @@ services:
       # overrides this down to 3 via EVENTS_QUOTA_CAPS=chat.message=3
       # for its "subscribe 4 times, watch the 4th fail" demonstration.
       EVENTS_QUOTA_CAPS: ${EVENTS_QUOTA_CAPS:-chat.message=10}
+      # EVENTS_ALLOW_INFINITE_TTL=true opts the registry into accepting
+      # `ttlMs: null` requests + returning `refreshBefore: null` (PR 779,
+      # spec PR1 commit 99f3589c §"Subscription TTL"). Default ON in
+      # this demo so the TTL-negotiation + no-expiry walkthrough beats
+      # work out of the box. Production deployments leave this OFF
+      # unless they've also wired a durable WebhookStore (we have —
+      # POSTGRES_DSN above) AND accepted the failure-based GC obligations.
+      EVENTS_ALLOW_INFINITE_TTL: ${EVENTS_ALLOW_INFINITE_TTL:-true}
+      # EVENTS_NO_EXPIRY_GC_WINDOW tightens the failure-based GC clock
+      # for no-expiry subscriptions (PR 783). Library default is 72h
+      # (DefaultNoExpiryFailureGCWindow) — invisible in a 30-min demo;
+      # 2m makes the end-to-end "subscriber dies, server drops the no-
+      # expiry sub after sustained delivery failure" beat observable.
+      # Production deployments leave this at the default (or longer).
+      EVENTS_NO_EXPIRY_GC_WINDOW: ${EVENTS_NO_EXPIRY_GC_WINDOW:-2m}
       # POSTGRES_BUFFER_TTL — retention window for Postgres-backed
       # EventBufferStore rows (issue 727). The background sweeper drops
       # rows past expires_at every 60s; clients polling for an evicted
@@ -255,6 +270,21 @@ services:
       # overrides this down to 3 via EVENTS_QUOTA_CAPS=chat.message=3
       # for its "subscribe 4 times, watch the 4th fail" demonstration.
       EVENTS_QUOTA_CAPS: ${EVENTS_QUOTA_CAPS:-chat.message=10}
+      # EVENTS_ALLOW_INFINITE_TTL=true opts the registry into accepting
+      # `ttlMs: null` requests + returning `refreshBefore: null` (PR 779,
+      # spec PR1 commit 99f3589c §"Subscription TTL"). Default ON in
+      # this demo so the TTL-negotiation + no-expiry walkthrough beats
+      # work out of the box. Production deployments leave this OFF
+      # unless they've also wired a durable WebhookStore (we have —
+      # POSTGRES_DSN above) AND accepted the failure-based GC obligations.
+      EVENTS_ALLOW_INFINITE_TTL: ${EVENTS_ALLOW_INFINITE_TTL:-true}
+      # EVENTS_NO_EXPIRY_GC_WINDOW tightens the failure-based GC clock
+      # for no-expiry subscriptions (PR 783). Library default is 72h
+      # (DefaultNoExpiryFailureGCWindow) — invisible in a 30-min demo;
+      # 2m makes the end-to-end "subscriber dies, server drops the no-
+      # expiry sub after sustained delivery failure" beat observable.
+      # Production deployments leave this at the default (or longer).
+      EVENTS_NO_EXPIRY_GC_WINDOW: ${EVENTS_NO_EXPIRY_GC_WINDOW:-2m}
       # POSTGRES_BUFFER_TTL — retention window for Postgres-backed
       # EventBufferStore rows (issue 727). The background sweeper drops
       # rows past expires_at every 60s; clients polling for an evicted
@@ -362,6 +392,21 @@ services:
       # overrides this down to 3 via EVENTS_QUOTA_CAPS=chat.message=3
       # for its "subscribe 4 times, watch the 4th fail" demonstration.
       EVENTS_QUOTA_CAPS: ${EVENTS_QUOTA_CAPS:-chat.message=10}
+      # EVENTS_ALLOW_INFINITE_TTL=true opts the registry into accepting
+      # `ttlMs: null` requests + returning `refreshBefore: null` (PR 779,
+      # spec PR1 commit 99f3589c §"Subscription TTL"). Default ON in
+      # this demo so the TTL-negotiation + no-expiry walkthrough beats
+      # work out of the box. Production deployments leave this OFF
+      # unless they've also wired a durable WebhookStore (we have —
+      # POSTGRES_DSN above) AND accepted the failure-based GC obligations.
+      EVENTS_ALLOW_INFINITE_TTL: ${EVENTS_ALLOW_INFINITE_TTL:-true}
+      # EVENTS_NO_EXPIRY_GC_WINDOW tightens the failure-based GC clock
+      # for no-expiry subscriptions (PR 783). Library default is 72h
+      # (DefaultNoExpiryFailureGCWindow) — invisible in a 30-min demo;
+      # 2m makes the end-to-end "subscriber dies, server drops the no-
+      # expiry sub after sustained delivery failure" beat observable.
+      # Production deployments leave this at the default (or longer).
+      EVENTS_NO_EXPIRY_GC_WINDOW: ${EVENTS_NO_EXPIRY_GC_WINDOW:-2m}
       # POSTGRES_BUFFER_TTL — retention window for Postgres-backed
       # EventBufferStore rows (issue 727). The background sweeper drops
       # rows past expires_at every 60s; clients polling for an evicted

--- a/examples/whole-enchilada/events/event-server/main.go
+++ b/examples/whole-enchilada/events/event-server/main.go
@@ -151,6 +151,25 @@ func main() {
 	if ws := pgBackend.webhookStore(); ws != nil {
 		webhookOpts = append(webhookOpts, events.WithWebhookStore(ws))
 	}
+	// EVENTS_ALLOW_INFINITE_TTL=true opts the demo into accepting
+	// ttlMs:null requests + returning refreshBefore:null (PR 779, spec
+	// PR1 commit 99f3589c §"Subscription TTL"). Operator-visible in
+	// the compose env; default off in production deployments.
+	if os.Getenv("EVENTS_ALLOW_INFINITE_TTL") == "true" {
+		webhookOpts = append(webhookOpts, events.WithAllowInfiniteWebhookTTL())
+	}
+	// EVENTS_NO_EXPIRY_GC_WINDOW=<duration> tightens the failure-based
+	// GC window for no-expiry subs (PR 783). Library default is 72h
+	// (DefaultNoExpiryFailureGCWindow) which is invisible in a demo
+	// run; compose env sets ~2m so the GC drop is observable
+	// end-to-end.
+	if raw := os.Getenv("EVENTS_NO_EXPIRY_GC_WINDOW"); raw != "" {
+		if d, err := time.ParseDuration(raw); err == nil {
+			webhookOpts = append(webhookOpts, events.WithNoExpiryFailureGCWindow(d))
+		} else {
+			log.Printf("[event-server] WARNING: EVENTS_NO_EXPIRY_GC_WINDOW=%q is not a valid duration; ignoring", raw)
+		}
+	}
 	webhooks := events.NewWebhookRegistry(webhookOpts...)
 
 	// Canonical baseline (WithListen + the color logger wired to both

--- a/examples/whole-enchilada/events/tools/gen-compose/compose.tmpl
+++ b/examples/whole-enchilada/events/tools/gen-compose/compose.tmpl
@@ -146,6 +146,21 @@ services:
       # overrides this down to 3 via EVENTS_QUOTA_CAPS=chat.message=3
       # for its "subscribe 4 times, watch the 4th fail" demonstration.
       EVENTS_QUOTA_CAPS: ${EVENTS_QUOTA_CAPS:-chat.message=10}
+      # EVENTS_ALLOW_INFINITE_TTL=true opts the registry into accepting
+      # `ttlMs: null` requests + returning `refreshBefore: null` (PR 779,
+      # spec PR1 commit 99f3589c §"Subscription TTL"). Default ON in
+      # this demo so the TTL-negotiation + no-expiry walkthrough beats
+      # work out of the box. Production deployments leave this OFF
+      # unless they've also wired a durable WebhookStore (we have —
+      # POSTGRES_DSN above) AND accepted the failure-based GC obligations.
+      EVENTS_ALLOW_INFINITE_TTL: ${EVENTS_ALLOW_INFINITE_TTL:-true}
+      # EVENTS_NO_EXPIRY_GC_WINDOW tightens the failure-based GC clock
+      # for no-expiry subscriptions (PR 783). Library default is 72h
+      # (DefaultNoExpiryFailureGCWindow) — invisible in a 30-min demo;
+      # 2m makes the end-to-end "subscriber dies, server drops the no-
+      # expiry sub after sustained delivery failure" beat observable.
+      # Production deployments leave this at the default (or longer).
+      EVENTS_NO_EXPIRY_GC_WINDOW: ${EVENTS_NO_EXPIRY_GC_WINDOW:-2m}
       # POSTGRES_BUFFER_TTL — retention window for Postgres-backed
       # EventBufferStore rows (issue 727). The background sweeper drops
       # rows past expires_at every 60s; clients polling for an evicted

--- a/examples/whole-enchilada/events/walkthrough/walkthrough.go
+++ b/examples/whole-enchilada/events/walkthrough/walkthrough.go
@@ -219,6 +219,95 @@ docker compose up -d event-server-1 event-server-2 event-server-3`).Default(),
 		)
 
 	// -----------------------------------------------------------------
+	// Phase 6b — TTL negotiation matrix + receiver-behavior matrix
+	// (PRs 778, 779, 783). All three knobs orthogonal on the same
+	// `make webhook` target — TTL_MS shapes what we ask for /
+	// what we get; REPLY_STATUS shapes how the server reacts to
+	// each delivery; EXIT_AFTER shapes whether the receiver lives.
+	// -----------------------------------------------------------------
+
+	demo.Section("Phase 6b — TTL negotiation and receiver-behavior matrix",
+		"The just-merged spec-alignment work (PRs 778, 779, 783) introduces three orthogonal subscription knobs the operator can mix and match on `make webhook`. TTL_MS shapes the client-side suggestion to the server (absent / int / null per spec PR1 commit 99f3589c). REPLY_STATUS shapes what the receiver returns per delivery (200 default / 410 abandon / 5xx retry-then-suspend). EXIT_AFTER shapes whether the receiver lives long enough for the server's failure-based GC to fire on a no-expiry sub. This phase walks the matrix one knob at a time, ending with the capstone combo.",
+	)
+
+	demo.Step("TTL matrix — three tenants suggest different ttlMs values, observe the granted refreshBefore.").
+		Note(
+			"- Demonstrates: server clamps client suggestions to the [MinWebhookTTL, MaxWebhookTTL] envelope; the 'one sanctioned exception' (clamp UP to the floor) is observable in window A; window B's in-envelope suggestion lands verbatim; window C's `null` request yields `refreshBefore: null` because the demo's event-server is started with EVENTS_ALLOW_INFINITE_TTL=true.",
+			"- Expected: A's window logs `refreshBefore=<now+~5min>` (clamped UP); B's logs `refreshBefore=<now+~15min>` (granted as-is); C's logs `refreshBefore=null (no-expiry granted)`.",
+		).
+		VerbatimVariants("Open three sibling webhook windows, one per tenant",
+			demokit.MakeVariant("shell", "bash", `# Sub-floor suggestion → clamped UP to MinWebhookTTL (5 minutes).
+make webhook TENANT=A USERNAME=anand TTL_MS=30000
+
+# In-envelope suggestion → granted as-is (15 minutes).
+make webhook TENANT=B USERNAME=bhavna TTL_MS=900000
+
+# null → no-expiry, refreshBefore:null on the wire (event-server has EVENTS_ALLOW_INFINITE_TTL=true).
+make webhook TENANT=C USERNAME=chandan TTL_MS=null`).Default(),
+		)
+
+	demo.Step("Receiver-behavior matrix — same `make webhook` target, different reply status.").
+		Note(
+			"- Demonstrates: server's per-delivery response branching: 410 abandons THIS delivery without affecting the subscription (PR 778 / spec PR1 commit 905ade36); 500 triggers the retry loop + the suspend transition past threshold.",
+			"- Expected: 410 window logs the verification + receives the inject, server-side logs (`make logs | grep webhook`) show `abandoned per receiver 410 Gone (subscription unaffected)`; the next inject in the same tenant lands on a separate (default-200) window normally. 500 window: server retries 3× with backoff, then logs the suspend transition + posts a `terminated` envelope; the sub stays in the registry as paused, observable via `make psql-webhooks`.",
+		).
+		VerbatimVariants("Open two sibling windows, then fire injects from Admin",
+			demokit.MakeVariant("shell", "bash", `# Window 1: receiver abandons each delivery with 410.
+make webhook TENANT=A USERNAME=aarti REPLY_STATUS=410
+
+# Window 2: receiver fails with 500 — server retries then suspends.
+make webhook TENANT=A USERNAME=ananya REPLY_STATUS=500
+
+# Admin window — inject one event per receiver type:
+make inject TENANT=A EVENT=chat.message TEXT='aarti gets 410, sub unaffected'
+make inject TENANT=A EVENT=chat.message TEXT='ananya gets 500, retried then suspended'
+
+# Then inspect the registry:
+make psql-webhooks`).Default(),
+		)
+
+	demo.Step("No-expiry restart-survival — restart the event-server tier, confirm the no-expiry sub stays.").
+		Note(
+			"- Demonstrates: GORM-backed WebhookStore is the durability backbone — both finite-TTL and no-expiry subs survive a rolling restart of the event-server tier because their rows persist in Postgres (PR 779 made ExpiresAt nullable; the row survives regardless).",
+			"- Expected: the chandan window's no-expiry sub appears in `make psql-webhooks` before AND after the restart, with `expires_at IS NULL`. A post-restart inject still lands on chandan's window. Finite-TTL subs survive the restart too — the meaningful contrast surfaces only when the CLIENT stops refreshing (which the no-expiry sub never needs to do).",
+		).
+		VerbatimVariants("With Phase 6b TTL window C still running, do this in Admin",
+			demokit.MakeVariant("shell", "bash", `# Before the restart — confirm chandan's no-expiry row exists.
+make psql-webhooks
+
+# Rolling restart of all three event-server replicas.
+make restart-event-servers
+
+# After the restart — same row, same expires_at IS NULL.
+make psql-webhooks
+
+# Inject one event — chandan's no-expiry window still receives it.
+make inject TENANT=C EVENT=chat.message TEXT='hi after restart'`).Default(),
+		)
+
+	demo.Step("Failure-based GC capstone — no-expiry subscriber dies after 3 deliveries; server drops the sub.").
+		Note(
+			"- Demonstrates: the full failure-based GC end-to-end (PR 783). EXIT_AFTER=3 kills the receiver after 3 deliveries → next inject fails with connection_refused → server's `FailingContinuouslySince` anchors → past `EVENTS_NO_EXPIRY_GC_WINDOW=2m` (set on the event-server) the registry drops the no-expiry sub + POSTs a `terminated` envelope.",
+			"- Expected: the receiver window receives 3 events then exits with the log line `exit-after target reached`. Next inject lands in the server logs as a delivery retry; after ~2 minutes of continuous failure, `make psql-webhooks` no longer shows chandan's no-expiry row. The failing-continuously-since column would be visible mid-flight if you queried during the failure run.",
+		).
+		VerbatimVariants("Run in a fresh window — the receiver self-terminates",
+			demokit.MakeVariant("shell", "bash", `# No-expiry sub that intentionally dies after 3 events.
+make webhook TENANT=C USERNAME=chandan TTL_MS=null EXIT_AFTER=3
+
+# In another window, fire 3 events to trip EXIT_AFTER, then a 4th to start the failure run:
+make inject TENANT=C EVENT=chat.message TEXT='1 — delivers'
+make inject TENANT=C EVENT=chat.message TEXT='2 — delivers'
+make inject TENANT=C EVENT=chat.message TEXT='3 — delivers, then receiver exits'
+make inject TENANT=C EVENT=chat.message TEXT='4 — first failure of the run'
+
+# Watch the registry. Within ~2m the no-expiry sub vanishes:
+watch -n 30 make psql-webhooks
+
+# Server logs show the eventual drop:
+make logs | grep -E "no-expiry subscription dropped|FailingContinuouslySince"`).Default(),
+		)
+
+	// -----------------------------------------------------------------
 	// Phase 7 — Dynamic source topology (PULL pattern).
 	// -----------------------------------------------------------------
 

--- a/examples/whole-enchilada/events/webhook/main.go
+++ b/examples/whole-enchilada/events/webhook/main.go
@@ -37,6 +37,8 @@ import (
 	"os/signal"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -68,6 +70,25 @@ func main() {
 		"Local listen address. Default 127.0.0.1:0 picks a free port and reports the URL.")
 	publicURL := flag.String("public-url", os.Getenv("WEBHOOK_PUBLIC_URL"),
 		"Public URL the event-server uses to call this listener. Defaults to http://<listen-addr>. Override when the event-server runs in Docker and needs host.docker.internal or a tunneled URL.")
+	// ttlMs: tristate via string so absent / null / numeric are
+	// distinguishable on the wire (spec PR1 commit 99f3589c
+	// §"Subscription TTL"). Empty = absent (server picks default),
+	// "null" = no-expiry request, "<int>" = suggested ms.
+	ttlMsFlag := flag.String("ttl-ms", os.Getenv("TTL_MS"),
+		`Client-suggested subscription TTL in ms (spec PR1 commit 99f3589c §"Subscription TTL"). Empty = absent (server picks). "null" = request no-expiry (server returns refreshBefore:null when WithAllowInfiniteWebhookTTL is enabled — see EVENTS_ALLOW_INFINITE_TTL on the event-server side). "<int>" = suggested ms. Demo flavor table: 900000 (15m, granted as-is), 30000 (30s, clamped UP to MinWebhookTTL=5min), null (no-expiry).`)
+	// reply-status: the HTTP status the local receiver returns after
+	// verifying the signature. Demonstrates server-side response
+	// branching (2xx ack vs 410 abandon vs 5xx retry-then-suspend).
+	replyStatus := flag.Int("reply-status", envOrInt("REPLY_STATUS", 200),
+		"HTTP status returned by the local receiver after verifying each delivery. 200 (default) = ack, the happy path. 410 = abandon THIS delivery without affecting the subscription (PR 778 / spec PR1 commit 905ade36). 500 = treat as transient failure, server retries 3× then suspends. Other values pass through unchanged for ad-hoc exploration.")
+	// exit-after: terminate the receiver process after N deliveries.
+	// Composes with TTL_MS=null to demonstrate the failure-based GC
+	// end-to-end (PR 783) — once the listener is gone, the server's
+	// deliveries fail with connection-refused, the failure run
+	// accumulates, and past EVENTS_NO_EXPIRY_GC_WINDOW the no-expiry
+	// sub is dropped + a `terminated` envelope is posted.
+	exitAfter := flag.Int("exit-after", envOrInt("EXIT_AFTER", 0),
+		"Exit the process after N successfully-received deliveries. 0 (default) = run until Ctrl+C. Combined with TTL_MS=null this exercises the no-expiry failure-based GC path end-to-end: deliveries fail with connection_refused after exit, failure run accumulates, past EVENTS_NO_EXPIRY_GC_WINDOW (set on the event-server) the registry drops the sub and POSTs a `terminated` envelope.")
 	flag.Parse()
 
 	if *token == "" && *username != "" && *password != "" {
@@ -133,17 +154,59 @@ func main() {
 	}
 	defer func() { _ = c.Close() }()
 
-	sub, err := eventsclient.Subscribe(context.Background(), c, eventsclient.SubscribeOptions{
+	subOpts := eventsclient.SubscribeOptions{
 		EventName:   *eventName,
 		CallbackURL: callbackURL + "/webhook",
-	})
+	}
+	// Wire the --ttl-ms tristate into the SDK options. "null" sets
+	// NoExpiry; a positive int sets TTLMs; empty leaves both unset so
+	// the SDK omits the ttlMs key entirely.
+	switch *ttlMsFlag {
+	case "":
+		// absent — server picks default
+	case "null":
+		subOpts.NoExpiry = true
+		log.Printf("%s ttlMs=null — requesting no-expiry subscription", prefix)
+	default:
+		n, err := strconv.ParseInt(*ttlMsFlag, 10, 64)
+		if err != nil {
+			log.Fatalf("%s --ttl-ms must be empty, \"null\", or an integer; got %q: %v", prefix, *ttlMsFlag, err)
+		}
+		subOpts.TTLMs = &n
+		log.Printf("%s ttlMs=%d — client-suggested TTL in ms", prefix, n)
+	}
+
+	sub, err := eventsclient.Subscribe(context.Background(), c, subOpts)
 	if err != nil {
 		log.Fatalf("%s subscribe failed: %v", prefix, err)
 	}
 	defer sub.Stop()
-	log.Printf("%s subscribed sub_id=%s — events route to %s/webhook", prefix, sub.ID(), callbackURL)
+	// Surface the server-granted refreshBefore so the demo operator
+	// can see clamp / null / as-suggested directly in this window's
+	// log stream — primary readout for the TTL negotiation beat.
+	if rb := sub.RefreshBefore(); rb != nil {
+		log.Printf("%s subscribed sub_id=%s refreshBefore=%s — events route to %s/webhook",
+			prefix, sub.ID(), rb.Format(time.RFC3339), callbackURL)
+	} else {
+		log.Printf("%s subscribed sub_id=%s refreshBefore=null (no-expiry granted) — events route to %s/webhook",
+			prefix, sub.ID(), callbackURL)
+	}
 
-	receiver := &deliveryReceiver{secret: sub.Secret(), prefix: prefix}
+	receiver := &deliveryReceiver{
+		secret:      sub.Secret(),
+		prefix:      prefix,
+		replyStatus: *replyStatus,
+	}
+	// EXIT_AFTER closes shutdown so the main select loop unwinds.
+	// We make it a function call to avoid a data race between the
+	// receiver writing to a channel and the select reading; the
+	// channel is closed exactly once via sync.Once.
+	shutdown := make(chan struct{})
+	if *exitAfter > 0 {
+		log.Printf("%s exit-after=%d — process will exit after %d successfully-received deliveries", prefix, *exitAfter, *exitAfter)
+		receiver.exitAfter = *exitAfter
+		receiver.exitSignal = shutdown
+	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/webhook", receiver.handle)
 
@@ -163,6 +226,8 @@ func main() {
 	select {
 	case <-ctx.Done():
 		log.Printf("%s shutdown", prefix)
+	case <-shutdown:
+		log.Printf("%s exit-after reached — process exiting; next delivery will fail with connection_refused", prefix)
 	case err := <-serverErr:
 		log.Printf("%s server error: %v", prefix, err)
 	}
@@ -172,9 +237,24 @@ func main() {
 // deliveryReceiver verifies and prints each webhook POST. Reuses the
 // Standard Webhooks signature scheme the events lib emits — the same
 // verification any production receiver would do.
+//
+// replyStatus / exitAfter / exitSignal are demo-flavor knobs (see the
+// --reply-status / --exit-after flags) — they let the same binary
+// simulate happy-path delivery, deliberate per-delivery abandon
+// (410 Gone), transient failure (5xx), or full process death after N
+// deliveries. The server-side response branching IS the demo.
 type deliveryReceiver struct {
-	secret string
-	prefix string
+	secret      string
+	prefix      string
+	replyStatus int
+	// exitAfter > 0 enables the EXIT_AFTER beat: after this many
+	// successfully-received deliveries the receiver closes
+	// exitSignal exactly once, causing main's select to unwind and
+	// the process to exit. delivered counts since process start.
+	exitAfter  int
+	exitSignal chan struct{}
+	exitOnce   sync.Once
+	delivered  atomic.Int64
 }
 
 const standardWebhooksMaxSkewSeconds = 5 * 60
@@ -219,14 +299,39 @@ func (r *deliveryReceiver) handle(w http.ResponseWriter, req *http.Request) {
 	}
 	_ = json.Unmarshal(body, &tagged)
 
-	fmt.Printf("%s %s tenant=%-10s id=%s body=%s\n",
+	// Return the configured reply status (default 200). Demo modes:
+	//   200 — happy path; server records delivery success
+	//   410 — abandon-THIS-delivery; server logs "abandoned per
+	//         receiver 410 Gone (subscription unaffected)" + sub
+	//         stays Active=true (PR 778 / spec PR1 commit 905ade36)
+	//   5xx — transient failure; server retries 3× then suspends
+	//         (refresh reactivates per spec §"Webhook Delivery Status")
+	status := r.replyStatus
+	if status == 0 {
+		status = http.StatusOK
+	}
+	fmt.Printf("%s %s tenant=%-10s id=%s reply=%d body=%s\n",
 		time.Now().Format("15:04:05"),
 		r.prefix,
 		tagged.Tenant,
 		id,
+		status,
 		string(body),
 	)
-	w.WriteHeader(http.StatusOK)
+	w.WriteHeader(status)
+
+	// EXIT_AFTER counts ONLY successfully-received deliveries — a
+	// non-2xx reply still increments because the receiver actually
+	// SAW the delivery; the choice to fail it is the demo's point.
+	if r.exitAfter > 0 && r.exitSignal != nil {
+		seen := r.delivered.Add(1)
+		if int(seen) >= r.exitAfter {
+			r.exitOnce.Do(func() {
+				log.Printf("%s exit-after target reached after %d deliveries", r.prefix, seen)
+				close(r.exitSignal)
+			})
+		}
+	}
 }
 
 func verifySignature(secret, id, ts string, body []byte, signature string) bool {
@@ -299,4 +404,16 @@ func envOr(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+func envOrInt(key string, fallback int) int {
+	v := os.Getenv(key)
+	if v == "" {
+		return fallback
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return fallback
+	}
+	return n
 }


### PR DESCRIPTION
## What changes

Adds operator-runnable demo beats for the just-merged events-package PRs 778 (params→arguments, 410 Gone, ack-timeout, throttled fields), 779 (ttlMs + refreshBefore:null no-expiry), and 783 (failure-based GC for no-expiry subs). Pure example plumbing — zero events-package changes. Three orthogonal knobs on the same `make webhook` target make the whole spec-alignment surface composable in one command:

| Knob | Values | Server path |
|---|---|---|
| `TTL_MS=` | unset / int / `null` | Negotiation matrix (#760): absent, finite (clamp envelope), no-expiry |
| `REPLY_STATUS=` | unset (200) / 410 / 500 / etc | Per-delivery response: ack / abandon-without-failure (#765) / retry-then-suspend |
| `EXIT_AFTER=` | unset / int | Process death → server sees connection_refused → failure run accumulates → past `EVENTS_NO_EXPIRY_GC_WINDOW` the no-expiry sub is GC'd (#764) |

## Reviewer's guide

Read in this order:

1. [examples/whole-enchilada/events/webhook/main.go](https://github.com/panyam/mcpkit/pull/786/files#diff-ba114d119eb60f0afea75cd40a7f22824c943dc298e4b0efeec14f6c97503769) — start here. Three new flags (`--ttl-ms`, `--reply-status`, `--exit-after`), wired into `eventsclient.SubscribeOptions.TTLMs` / `.NoExpiry`, the local receiver's HTTP reply status, and an atomic counter that closes a shutdown channel after N deliveries. Log line surfaces the granted `refreshBefore` (string for finite, literal `null` for no-expiry) so operators see the TTL matrix directly in their window log stream.
2. [examples/whole-enchilada/events/walkthrough/walkthrough.go](https://github.com/panyam/mcpkit/pull/786/files#diff-2346a553b798c3bc87df7e3bbf04f3858f8aae62f96250fbc434f48f55f1fbfa) — new Phase 6b with four steps walking the knobs: TTL matrix → receiver-behavior matrix → no-expiry restart-survival → failure-GC capstone. Pure-narrative steps, no inline `demo.Action`, so non-interactive runs stay green.
3. [examples/whole-enchilada/events/event-server/main.go](https://github.com/panyam/mcpkit/pull/786/files#diff-33a338ff6fbcbad0ae17b84fd95d17ba7b25ff3611476b8bcc68cbecf41177e5) — two env-var-gated WebhookOption appends: `WithAllowInfiniteWebhookTTL()` if `EVENTS_ALLOW_INFINITE_TTL=true`, `WithNoExpiryFailureGCWindow(d)` from `EVENTS_NO_EXPIRY_GC_WINDOW`.
4. [examples/whole-enchilada/events/tools/gen-compose/compose.tmpl](https://github.com/panyam/mcpkit/pull/786/files#diff-bab337ed863f271846c6083f36f7a30d53783bcfc50b983218ceda1265d88d12) — the canonical place for compose env-var changes; `make gen-compose` propagates to all three event-server replicas.
5. [examples/whole-enchilada/events/Makefile](https://github.com/panyam/mcpkit/pull/786/files#diff-76baccd9d1bb5b99c1c9f4db8dab4c2701dd30bda244e2660bf9149a912cc565) — `webhook` target forwards the three env vars to the binary; `psql-webhooks` queries the failure-GC-aware columns; `restart-event-servers` is the rolling-restart wrapper.
6. [examples/whole-enchilada/events/WALKTHROUGH.md](https://github.com/panyam/mcpkit/pull/786/files#diff-47fe1deb7a3547e7916d0baa96c6bd4578a920b5981d48af2fc4734a9dba1e0a) — regenerated via `make readme`. Skim the new Phase 6b section for narrative correctness; the rest is mechanical regen.

Skim or skip: `docker-compose.yaml` — generated artifact, sourced from the template.

## Decision log

- **One knob per concern, composable on the same command.** Alternative was three flavored targets (`webhook-noexpiry`, `webhook-410`, `webhook-die`). Composable wins because the capstone beat (no-expiry + EXIT_AFTER) is exactly the cross-product of two knobs — encoding it as a separate target would duplicate logic and hide the composition.
- **`EVENTS_ALLOW_INFINITE_TTL=true` defaults ON in the demo only.** The library default is OFF (production posture). The demo flips it via compose env so the no-expiry beats work out of the box without extra setup; operators reading the compose see the flip and the rationale comment immediately.
- **`EVENTS_NO_EXPIRY_GC_WINDOW=2m` only in the demo.** Library default is 72h — invisible inside a demo run. 2 minutes makes the failure-GC drop observable; the env-var comment explicitly says production deployments leave it at the default.
- **`psql-webhooks` over a fancier UI.** Aligns with the existing `make logs` / `make ps` one-liner convention. Operators see the SQL exactly, so the failure-GC anchor column is self-documenting.
- **Pure-narrative new steps.** The walkthrough binary's non-interactive mode is what `make test` runs in CI. Adding `demo.Action` steps would require the events stack to be up during `make unittest`, which today it isn't. Narrative-only keeps the regression gate intact.
- **Regenerated `docker-compose.yaml` is committed.** The template is the source of truth, but `docker compose up` uses the rendered file. Other beats already follow this convention (Phase 6 quota-cap mentions the env override directly against the rendered service names).

## Risk / blast radius

- **Existing demo flow** — unchanged. Phase 6b inserts between Phase 6 (quota) and Phase 7 (topology); all existing phases renumber transparently in the renderer.
- **`make unittest`** — passes. The webhook binary's new flags default to behavior-preserving zero values.
- **Non-interactive walkthrough** — passes. New steps are pure narrative.
- **Compose env additions** — backwards-compatible. Existing operators running `make up` see `EVENTS_ALLOW_INFINITE_TTL=true` and `EVENTS_NO_EXPIRY_GC_WINDOW=2m` enabled by default; both are demo-friendly opt-ins (no-expiry needs Postgres, which the demo already wires).
- **Be paranoid about:** the `EXIT_AFTER` capstone interaction with `EVENTS_NO_EXPIRY_GC_WINDOW`. The 2-minute window in the demo is tight enough that a slow operator might inject before the GC fires; the narrative says "watch for ~2 minutes" but a curious operator running the steps too fast may see the suspension transition (after 3-5 retries) before the GC drop. Both are correct server behaviors; the narrative could clarify the timing better if reviewer feedback flags this.

## Out of scope (deliberately deferred)

- E2E test that runs the new beats against a docker-compose-up stack and asserts log lines / DB state — would need a CI gate the repo doesn't have today. Followup ticket worth filing
- Python SDK ttlMs + no-expiry support — Python client doesn't surface a subscribe builder yet (PR 779's same out-of-scope note)
- Throttled state demo for #763 — needs a real rate limiter wired into the WebhookRegistry; that's its own mid-sized PR (separate scope per the earlier "going forward" discussion)
- Whole-enchilada Postgres column migration for ops upgrading from pre-779 — fresh deploys only per the repo-wide convention
