### PR TITLE
examples/skills: adopt FilterArgs convention + wire-mode InputStep

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1427,6 +1427,19 @@ func (c *Client) ServerSupportsExtension(id string) bool {
 	return ok
 }
 
+// UsingStatelessWire reports whether Connect() landed on the SEP-2575
+// stateless wire (server/discover) rather than the legacy initialize
+// handshake. Always false before Connect(). True when the client was
+// constructed with WithClientMode(ClientModeStateless), or when
+// ClientModeAdaptive's probe succeeded against a server that speaks
+// server/discover.
+//
+// Use to display which wire a session is on (walkthroughs, debug
+// tools) or to gate behavior that only makes sense on one wire.
+func (c *Client) UsingStatelessWire() bool {
+	return c.useStatelessWire
+}
+
 // ServerExtensionCapability returns the cached ExtensionCapability the
 // server advertised for id during initialize, or false when the server
 // did not declare the extension.

--- a/examples/skills/WALKTHROUGH.md
+++ b/examples/skills/WALKTHROUGH.md
@@ -4,7 +4,8 @@ SEP-2640 serves Agent Skills over MCP's Resources primitive: each file under a s
 
 ## What you'll learn
 
-- **Connect to the skills server** — `client.NewClient(...)` + `Connect()`. The server side wired the extension automatically via `Provider.RegisterWith`.
+- **Choose the client wire mode** — `adaptive` (default): probe `server/discover`, fall back to `initialize` on `-32601`. `stateless`: force `server/discover`, error if the server can't answer. `legacy`: skip the probe, go straight to `initialize`.
+- **Connect to the skills server** — `client.NewClient(..., client.WithClientMode(mode))` then `Connect()`. Inspect `c.UsingStatelessWire()` after the call to see which wire engaged.
 - **resources/list returns every cataloged skill URI** — In file mode the list has N entries per skill (one for SKILL.md, one for each supporting file) plus the index. In archive mode it's one entry per skill plus the index.
 - **Read skill://index.json** — The Indexer caches the result with TTL + per-skill mtime invalidation. Repeated reads return the same bytes until something in a SKILL.md actually changes.
 - **Verify digest by re-fetching SKILL.md and recomputing SHA-256** — Treat the response bytes as the artifact, hash them, and compare against the digest field from the index. A mismatch indicates corruption or tampering and per the SEP the host MUST NOT use the content.
@@ -12,6 +13,7 @@ SEP-2640 serves Agent Skills over MCP's Resources primitive: each file under a s
 - **Read a supporting file via skill:// (references/FORMS.md)** — Relative reference `references/FORMS.md` from within pdf-processing/SKILL.md resolves to this full URI via `skills.ResolveRelative(skillRoot, "references/FORMS.md")`.
 - **Read a nested-prefix skill (acme/billing/refunds)** — Demonstrates that the prefix-segment routing works end-to-end. The skill's `name` is `refunds`; the prefix `acme/billing/` is server-chosen.
 - **Read a supporting file in the nested skill (templates/email.md)** — Same relative-reference resolution: `templates/email.md` from refunds/SKILL.md.
+- **List a directory inside a skill and recurse into a subdirectory** — Subdirectories surface with `mimeType: "inode/directory"`; client descends by issuing a second call. SDK wrapper: `Client.ReadDirectory(ctx, uri)`.
 - **Wrap reads in skills.NewClient(...) and call Client.Activate** — Activate is intra-process — no wire traffic. Run with `make serve EXPORTER=stdout` + `make demo EXPORTER=stdout` to see spans.
 
 ## Flow
@@ -21,39 +23,47 @@ sequenceDiagram
     participant Host as MCP Host (this client)
     participant Server as MCP Server (make serve, file mode by default)
 
-    Note over Host,Server: Step 1: Connect to the skills server
-    Host->>Server: POST /mcp — initialize
-    Server-->>Host: serverInfo + capabilities (with extensions.skills = {})
+    Note over Host,Server: Step 1: Choose the client wire mode
 
-    Note over Host,Server: Step 2: resources/list returns every cataloged skill URI
+    Note over Host,Server: Step 2: Connect to the skills server
+    Host->>Server: POST /mcp — `server/discover` (stateless) OR `initialize` (legacy)
+    Server-->>Host: serverInfo + capabilities (with extensions.skills)
+
+    Note over Host,Server: Step 3: resources/list returns every cataloged skill URI
     Host->>Server: resources/list
     Server-->>Host: resources[] including skill://index.json + each SKILL.md
 
-    Note over Host,Server: Step 3: Read skill://index.json
+    Note over Host,Server: Step 4: Read skill://index.json
     Host->>Server: resources/read uri=skill://index.json
     Server-->>Host: { $schema, skills: [...] }
 
-    Note over Host,Server: Step 4: Verify digest by re-fetching SKILL.md and recomputing SHA-256
+    Note over Host,Server: Step 5: Verify digest by re-fetching SKILL.md and recomputing SHA-256
     Host->>Server: resources/read uri=skill://git-workflow/SKILL.md
     Server-->>Host: text/markdown body
 
-    Note over Host,Server: Step 5: Read the pdf-processing SKILL.md
+    Note over Host,Server: Step 6: Read the pdf-processing SKILL.md
     Host->>Server: resources/read uri=skill://pdf-processing/SKILL.md
     Server-->>Host: text/markdown body
 
-    Note over Host,Server: Step 6: Read a supporting file via skill:// (references/FORMS.md)
+    Note over Host,Server: Step 7: Read a supporting file via skill:// (references/FORMS.md)
     Host->>Server: resources/read uri=skill://pdf-processing/references/FORMS.md
     Server-->>Host: text/markdown body
 
-    Note over Host,Server: Step 7: Read a nested-prefix skill (acme/billing/refunds)
+    Note over Host,Server: Step 8: Read a nested-prefix skill (acme/billing/refunds)
     Host->>Server: resources/read uri=skill://acme/billing/refunds/SKILL.md
     Server-->>Host: text/markdown body
 
-    Note over Host,Server: Step 8: Read a supporting file in the nested skill (templates/email.md)
+    Note over Host,Server: Step 9: Read a supporting file in the nested skill (templates/email.md)
     Host->>Server: resources/read uri=skill://acme/billing/refunds/templates/email.md
     Server-->>Host: text/markdown body
 
-    Note over Host,Server: Step 9: Wrap reads in skills.NewClient(...) and call Client.Activate
+    Note over Host,Server: Step 10: List a directory inside a skill and recurse into a subdirectory
+    Host->>Server: resources/directory/read uri=skill://acme/billing/refunds/templates
+    Server-->>Host: 2 files + 1 subdirectory (`regional`, inode/directory)
+    Host->>Server: resources/directory/read uri=skill://acme/billing/refunds/templates/regional
+    Server-->>Host: 1 file (eu.md)
+
+    Note over Host,Server: Step 11: Wrap reads in skills.NewClient(...) and call Client.Activate
     Host->>Server: resources/read via sc.ReadAndVerify (span: skills.read_and_verify)
     Server-->>Host: bytes + digest match
 ```
@@ -76,11 +86,19 @@ Terminal 2:  make demo          # this walkthrough (--tui interactive)
 
 Server advertises `io.modelcontextprotocol/skills` under `capabilities.extensions` (always `{}`, never an array). `Provider.RegisterWith(srv)` wires it automatically.
 
-### Step 1: Connect to the skills server
+### Wire mode (SEP-2575 dual-wire)
 
-`client.NewClient(...)` + `Connect()`. The server side wired the extension automatically via `Provider.RegisterWith`.
+mcpkit's server defaults to `ModeDual` — every URL serves both the legacy `initialize` handshake and the SEP-2575 `server/discover` probe. Pick which wire the client should use; the rest of the walkthrough works identically either way.
 
-### Step 2: resources/list returns every cataloged skill URI
+### Step 1: Choose the client wire mode
+
+`adaptive` (default): probe `server/discover`, fall back to `initialize` on `-32601`. `stateless`: force `server/discover`, error if the server can't answer. `legacy`: skip the probe, go straight to `initialize`.
+
+### Step 2: Connect to the skills server
+
+`client.NewClient(..., client.WithClientMode(mode))` then `Connect()`. Inspect `c.UsingStatelessWire()` after the call to see which wire engaged.
+
+### Step 3: resources/list returns every cataloged skill URI
 
 In file mode the list has N entries per skill (one for SKILL.md, one for each supporting file) plus the index. In archive mode it's one entry per skill plus the index.
 
@@ -88,7 +106,7 @@ In file mode the list has N entries per skill (one for SKILL.md, one for each su
 
 `skill://index.json` enumerates skills with `{$schema, skills:[{type, name, description, url, digest}]}`. Optional in the SEP; mcpkit auto-registers unless `WithoutIndex()`.
 
-### Step 3: Read skill://index.json
+### Step 4: Read skill://index.json
 
 The Indexer caches the result with TTL + per-skill mtime invalidation. Repeated reads return the same bytes until something in a SKILL.md actually changes.
 
@@ -96,7 +114,7 @@ The Indexer caches the result with TTL + per-skill mtime invalidation. Repeated 
 
 Each entry carries `sha256:{64hex}` over the raw artifact bytes (SKILL.md for skill-md, packed archive for archive). Hosts MUST verify before use.
 
-### Step 4: Verify digest by re-fetching SKILL.md and recomputing SHA-256
+### Step 5: Verify digest by re-fetching SKILL.md and recomputing SHA-256
 
 Treat the response bytes as the artifact, hash them, and compare against the digest field from the index. A mismatch indicates corruption or tampering and per the SEP the host MUST NOT use the content.
 
@@ -104,19 +122,19 @@ Treat the response bytes as the artifact, hash them, and compare against the dig
 
 Manifest body may reference supporting files via relative paths. `skills.ResolveRelative(skillRoot, ref)` resolves them filesystem-style; `..` escapes are rejected.
 
-### Step 5: Read the pdf-processing SKILL.md
+### Step 6: Read the pdf-processing SKILL.md
 
 This skill's frontmatter has `version` and `tags` Extra fields. mcpkit surfaces those under `ResourceDef.Annotations` keyed by `io.modelcontextprotocol.skills/`.
 
-### Step 6: Read a supporting file via skill:// (references/FORMS.md)
+### Step 7: Read a supporting file via skill:// (references/FORMS.md)
 
 Relative reference `references/FORMS.md` from within pdf-processing/SKILL.md resolves to this full URI via `skills.ResolveRelative(skillRoot, "references/FORMS.md")`.
 
-### Step 7: Read a nested-prefix skill (acme/billing/refunds)
+### Step 8: Read a nested-prefix skill (acme/billing/refunds)
 
 Demonstrates that the prefix-segment routing works end-to-end. The skill's `name` is `refunds`; the prefix `acme/billing/` is server-chosen.
 
-### Step 8: Read a supporting file in the nested skill (templates/email.md)
+### Step 9: Read a supporting file in the nested skill (templates/email.md)
 
 Same relative-reference resolution: `templates/email.md` from refunds/SKILL.md.
 
@@ -124,21 +142,21 @@ Same relative-reference resolution: `templates/email.md` from refunds/SKILL.md.
 
 SEP commit `2e04c48d` (2026-06-09) added `resources/directory/read` for listing a directory's direct children without enumerating the server's entire resource space. Capability-gated via `io.modelcontextprotocol/skills.directoryRead`. mcpkit's Provider auto-supports it (#781).
 
-### Step 9: List a directory inside a skill and recurse into a subdirectory
+### Step 10: List a directory inside a skill and recurse into a subdirectory
 
-Subdirectories surface with `mimeType: "inode/directory"`; client descends by issuing a second call. SDK wrapper: `Client.ReadDirectory(ctx, uri)`. The walkthrough hand-rolls a one-level recursion for clarity — the SDK does not ship a `WalkDirectory` helper (file an issue if you need one).
+Subdirectories surface with `mimeType: "inode/directory"`; client descends by issuing a second call. SDK wrapper: `Client.ReadDirectory(ctx, uri)`.
 
 ### SEP-414 P7 — Skills observability
 
 Fetch ≠ activation. Server `resources/read` spans now carry `mcp.skill.*` attrs (#748). Client `ext/skills.Client` emits `skills.read*` spans + `Activate(ctx, uri)` for post-cache use the wire can't see (SDK-only — no spec change).
 
-### Step 10: Wrap reads in skills.NewClient(...) and call Client.Activate
+### Step 11: Wrap reads in skills.NewClient(...) and call Client.Activate
 
 Activate is intra-process — no wire traffic. Run with `make serve EXPORTER=stdout` + `make demo EXPORTER=stdout` to see spans.
 
 ### Wrap-up
 
-Negotiated extension, enumerated index, verified one digest, read manifest + supporting files across single-segment and nested-prefix paths, navigated a directory subtree via the SEP-2640 `directoryRead` capability, emitted skill-shape spans + an activation event. `make serve-archive` flips the wire to one `.tar.gz` per skill — host code unchanged.
+Negotiated extension, enumerated index, verified one digest, read manifest + supporting files across single-segment and nested-prefix paths, emitted skill-shape spans + an activation event. `make serve-archive` flips the wire to one `.tar.gz` per skill — host code unchanged.
 
 ## Run it
 

--- a/examples/skills/main.go
+++ b/examples/skills/main.go
@@ -30,6 +30,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/panyam/demokit"
 	"github.com/panyam/mcpkit/examples/common"
 	commonotel "github.com/panyam/mcpkit/examples/common/otel"
 	"github.com/panyam/mcpkit/ext/skills"
@@ -53,7 +54,11 @@ func serve() {
 	skillsDir := flag.String("skills", "skills",
 		"directory of skill bundles to register (default ./skills)")
 	tel := common.RegisterTelemetryFlags(flag.CommandLine)
-	flag.CommandLine.Parse(filterArgs(os.Args[1:], "--serve"))
+	flag.CommandLine.Parse(demokit.FilterArgs(os.Args[1:],
+		demokit.BoolFlag("--serve"),  // dual-mode dispatch; override demokit's value-form default
+		demokit.ValueFlag("--url"),   // walkthrough-side flag; strip from serve args
+		demokit.ValueFlag("--wire"),  // walkthrough-side flag; strip from serve args
+	))
 
 	tp, shutdown, err := commonotel.SetupTelemetry(context.Background(),
 		commonotel.WithExporter(*tel.Exporter),
@@ -98,19 +103,3 @@ func serve() {
 	}
 }
 
-// filterArgs drops dispatch-style flags like --serve before handing
-// the remaining args to flag.Parse.
-func filterArgs(args []string, drop ...string) []string {
-	dropSet := make(map[string]struct{}, len(drop))
-	for _, d := range drop {
-		dropSet[d] = struct{}{}
-	}
-	out := make([]string, 0, len(args))
-	for _, a := range args {
-		if _, hit := dropSet[a]; hit {
-			continue
-		}
-		out = append(out, a)
-	}
-	return out
-}

--- a/examples/skills/walkthrough.go
+++ b/examples/skills/walkthrough.go
@@ -69,16 +69,41 @@ func runDemo() {
 	var (
 		c          *client.Client
 		serverInfo any
+		wireMode   = client.ClientModeAdaptive
 	)
 
+	demo.Section("Wire mode (SEP-2575 dual-wire)",
+		"mcpkit's server defaults to `ModeDual` — every URL serves both the legacy `initialize` handshake and the SEP-2575 `server/discover` probe. Pick which wire the client should use; the rest of the walkthrough works identically either way.",
+	)
+
+	demo.Step("Choose the client wire mode").
+		Input(demokit.Choice("adaptive", "stateless", "legacy").
+			Named("wire", "Wire mode (adaptive probes stateless first, falls back to legacy)").
+			WithDefault("adaptive")).
+		Note("`adaptive` (default): probe `server/discover`, fall back to `initialize` on `-32601`. `stateless`: force `server/discover`, error if the server can't answer. `legacy`: skip the probe, go straight to `initialize`.").
+		Run(func(ctx demokit.StepContext) *demokit.StepResult {
+			choice, _ := ctx.Inputs["wire"].(string)
+			switch choice {
+			case "stateless":
+				wireMode = client.ClientModeStateless
+			case "legacy":
+				wireMode = client.ClientModeLegacyOnly
+			default:
+				wireMode = client.ClientModeAdaptive
+			}
+			fmt.Printf("    Selected: %s — client.WithClientMode(%s)\n", choice, wireMode)
+			return nil
+		})
+
 	demo.Step("Connect to the skills server").
-		Arrow("Host", "Server", "POST /mcp — initialize").
-		DashedArrow("Server", "Host", "serverInfo + capabilities (with extensions.skills = {})").
-		Note("`client.NewClient(...)` + `Connect()`. The server side wired the extension automatically via `Provider.RegisterWith`.").
+		Arrow("Host", "Server", "POST /mcp — `server/discover` (stateless) OR `initialize` (legacy)").
+		DashedArrow("Server", "Host", "serverInfo + capabilities (with extensions.skills)").
+		Note("`client.NewClient(..., client.WithClientMode(mode))` then `Connect()`. Inspect `c.UsingStatelessWire()` after the call to see which wire engaged.").
 		Run(func(ctx demokit.StepContext) *demokit.StepResult {
 			c = client.NewClient(serverURL+"/mcp",
 				core.ClientInfo{Name: "skills-host", Version: "1.0"},
 				client.WithTracerProvider(tp),
+				client.WithClientMode(wireMode),
 			)
 			if err := c.Connect(); err != nil {
 				fmt.Printf("    ERROR: %v\n    Start the server with: make serve\n", err)
@@ -86,6 +111,7 @@ func runDemo() {
 			}
 			serverInfo = c.ServerInfo
 			fmt.Printf("    Connected to %s %s\n", c.ServerInfo.Name, c.ServerInfo.Version)
+			fmt.Printf("    Wire: %s\n", wireLabel(c.UsingStatelessWire()))
 			if c.ServerSupportsExtension(skills.ExtensionID) {
 				fmt.Printf("    Server advertises %q under capabilities.extensions\n", skills.ExtensionID)
 			} else {
@@ -361,6 +387,17 @@ func runDemo() {
 	_ = serverInfo
 	common.SetupRenderer(demo)
 	demo.Execute()
+}
+
+// wireLabel returns a human-readable wire-mode name for the walkthrough
+// output. Picks between the SEP-2575 stateless wire (server/discover at
+// connect, response-as-SSE for notifications) and the legacy wire
+// (initialize handshake, SSE notification stream).
+func wireLabel(stateless bool) string {
+	if stateless {
+		return "SEP-2575 stateless (server/discover)"
+	}
+	return "legacy (initialize handshake)"
 }
 
 // marker returns a one-glyph indicator for a directory listing entry based


### PR DESCRIPTION
## What changes

Two related, demo-day-driven changes:

1. **`examples/skills/main.go`** adopts the canonical `demokit.FilterArgs`
   shape from `examples/CONVENTIONS.md` §2 — last skills-side drift item
   relative to the other examples.
2. **`examples/skills/walkthrough.go`** gains a new Step 1 that prompts
   the user for the wire mode (adaptive / stateless / legacy) via
   `demokit.Choice`, then threads the chosen `client.ClientMode` into
   the Connect step. Audiences see the SEP-2575 dual-wire story
   surfaced as a single visible choice.
3. **`client/client.go`** gains a public `Client.UsingStatelessWire() bool`
   accessor — without it, adaptive mode has no way to report which wire
   the probe landed on.

End-to-end verified: default `adaptive` mode lands on the SEP-2575
stateless wire (server in default `ModeDual`).

## Reviewer's guide

Read in this order:

1. [client/client.go](https://github.com/panyam/mcpkit/pull/787/files#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09) — start here. Adds the `UsingStatelessWire()`
   accessor next to `ServerSupportsExtension`. Naming follows the Go
   boolean-predicate convention (matches `SupportsSkills` /
   `SupportsDirectoryRead` shape from PR 785).
2. [examples/skills/walkthrough.go](https://github.com/panyam/mcpkit/pull/787/files#diff-94afaa0ca3ed61f670feefe88925e3b5ecfc827cfcdb7612d48a01dd289c10e7) — the new InputStep + reworked
   Connect step. Note the `wireMode` closure variable threading the
   user's choice from Step 1 into Step 2's `client.NewClient(...,
   client.WithClientMode(...))` call. The new `wireLabel(stateless
   bool) string` helper renders the post-Connect status line.
3. [examples/skills/main.go](https://github.com/panyam/mcpkit/pull/787/files#diff-5b14977a06843ef8ea751a41d80e1cd9eb927a784069536cf93b0857dc9261fc) — purely mechanical: hand-rolled
   `filterArgs` deleted; replaced with `demokit.FilterArgs` carrying
   `BoolFlag("--serve")` (override demokit's value-form default) +
   `ValueFlag("--url")` + `ValueFlag("--wire")` (strip walkthrough-side
   flags from the serve path).
4. [examples/skills/WALKTHROUGH.md](https://github.com/panyam/mcpkit/pull/787/files#diff-f7567dfcd105e517415a8fc5aada2b08489ad36774f38681b85f5855a3638884) — regenerated via `make readme`.
   Skim only — derived artifact.

## Decision log

- **InputStep, not separate Makefile targets.** The user explicitly
  asked for a single demo binary with an interactive choice rather than
  `make demo-legacy` / `make demo-stateless` targets. Demokit's `Input`
  contract handles the prompt + default + TUI rendering uniformly.
- **`UsingStatelessWire` not `UseStatelessWire`.** Go boolean predicates
  read as state-of-being (Is / Has / Using), not imperative (Use). The
  rename surfaced during review and applies before any caller exists.
- **Closure variable threading, not a Demo-scoped store.** The chosen
  mode lives in a `wireMode client.ClientMode` declared next to the
  client pointer. Demokit doesn't have a typed per-demo store and a map
  would lose type safety; the closure is two lines either way.
- **Default `adaptive`, not `legacy`.** Demos work without a server
  configuration change because mcpkit's server default is `ModeDual`.
  Operators that want to pin to legacy override interactively.

## Risk / blast radius

- Affects: `examples/skills/*` (demo-only), `client/client.go` (one new
  public method, no behavior change).
- Tests covering this: existing `client/client_test.go` mode-pinning
  tests cover all three `ClientMode` values; the InputStep + accessor
  glue is example code and verified end-to-end via the live walkthrough
  (default-mode run included in the commit message).
- Be paranoid about: the `wireMode` closure variable's default. If
  Step 1 is skipped (e.g., the walkthrough is re-entered mid-flow via
  replay), the variable retains its compile-time default
  (`ClientModeAdaptive`), which is the correct fallback. Eyeball this
  if you change Step 1's ordering.

## Before / after

Default run output (no flags, non-interactive, server in default
`ModeDual`):

```
Step 1: Choose the client wire mode
  Wire mode (adaptive probes stateless first, falls back to legacy) [adaptive]:
  Selected: adaptive — client.WithClientMode(adaptive)

Step 2: Connect to the skills server
  Connected to skills-demo 0.1.0
  Wire: SEP-2575 stateless (server/discover)
  Server advertises "io.modelcontextprotocol/skills" under capabilities.extensions
```

Interactive (TUI) run lets the user pick `stateless` or `legacy`; the
Wire line in Step 2 flips accordingly.

## Out of scope (deliberately deferred)

- **Other examples' wire-mode story.** Each example has its own demo
  arc; skills is the one that needs this for tomorrow's WG demo. Cross-
  example wire-mode adoption can follow per-example as use cases
  surface.
- **Demokit input-replay for CI.** Non-interactive renderer
  short-circuits the prompt to the default value; replaying a specific
  choice in CI would need a separate harness. Not blocking the demo.

