### PR TITLE
ext/skills: align resources/directory/read default pageSize with server (#791)

### DIFF
--- a/ext/skills/directory.go
+++ b/ext/skills/directory.go
@@ -12,11 +12,17 @@ import (
 	"github.com/panyam/mcpkit/core"
 )
 
-// defaultDirectoryReadPageSize matches the page size server/dispatch.go
-// uses for resources/list. Kept local rather than imported because the
-// upstream helper is package-private and one-line duplication beats a
-// promotion to the public surface for a single off-package consumer.
-const defaultDirectoryReadPageSize = 100
+// defaultDirectoryReadPageSize matches mcpkit's server-wide
+// defaultPageSize (0 = "return everything in one page, no cursor"). The
+// client-side cap added in #790 (Client.WithMaxListPages, default 1000)
+// handles the unbounded-server runaway case, so the server-side page
+// size doesn't need to enforce a ceiling here.
+//
+// Servers that need true paging on resources/directory/read can opt in
+// via a future WithDirectoryReadPageSize provider option — file when a
+// real deployment needs it. The paginateDirectoryRead helper below
+// already does the right thing for any positive override.
+const defaultDirectoryReadPageSize = 0
 
 // handleDirectoryRead serves SEP-2640's resources/directory/read method.
 //
@@ -192,10 +198,20 @@ func (p *Provider) enumerateDirectory(skill *skillEntry, relPath, parentURI stri
 // the cursor offset, plus the next-cursor string (empty when the page
 // includes the tail). Cursor encoding is a base-10 offset; opaque to
 // callers per the resources/list contract.
+//
+// A pageSize of zero or negative means "return every item from the
+// cursor offset forward in one page, no nextCursor" — matches the
+// behavior of server/pagination.go::paginate and the production
+// defaultDirectoryReadPageSize of 0 set above. Without this
+// short-circuit the production default would silently truncate every
+// response to an empty page.
 func paginateDirectoryRead(items []core.ResourceDef, cursor string, pageSize int) ([]core.ResourceDef, string) {
 	start := parseDirectoryReadCursor(cursor)
 	if start > len(items) {
 		start = len(items)
+	}
+	if pageSize <= 0 {
+		return items[start:], ""
 	}
 	end := start + pageSize
 	if end >= len(items) {

--- a/ext/skills/directory_pagination_test.go
+++ b/ext/skills/directory_pagination_test.go
@@ -63,6 +63,37 @@ func TestPaginateDirectoryRead_MalformedCursorDefaultsToStart(t *testing.T) {
 	}
 }
 
+// TestPaginateDirectoryRead_ZeroPageSizeReturnsAll pins the production
+// defaultDirectoryReadPageSize = 0 contract: a non-positive pageSize
+// means "return everything from the cursor offset forward in one page,
+// no nextCursor." Matches server/pagination.go::paginate. Without this
+// short-circuit the production default would silently truncate every
+// response to an empty page.
+func TestPaginateDirectoryRead_ZeroPageSizeReturnsAll(t *testing.T) {
+	items := []core.ResourceDef{{URI: "a"}, {URI: "b"}, {URI: "c"}}
+	page, next := paginateDirectoryRead(items, "", 0)
+	if got := urisOf(page); !equalSlices(got, []string{"a", "b", "c"}) {
+		t.Errorf("page = %v, want [a b c]", got)
+	}
+	if next != "" {
+		t.Errorf("NextCursor = %q, want empty", next)
+	}
+}
+
+// TestPaginateDirectoryRead_NegativePageSizeReturnsAll keeps the
+// boundary tight: any non-positive value short-circuits to "all,"
+// not just literal 0.
+func TestPaginateDirectoryRead_NegativePageSizeReturnsAll(t *testing.T) {
+	items := []core.ResourceDef{{URI: "a"}, {URI: "b"}}
+	page, next := paginateDirectoryRead(items, "", -1)
+	if got := urisOf(page); !equalSlices(got, []string{"a", "b"}) {
+		t.Errorf("page = %v, want [a b]", got)
+	}
+	if next != "" {
+		t.Errorf("NextCursor = %q, want empty", next)
+	}
+}
+
 func urisOf(rs []core.ResourceDef) []string {
 	out := make([]string, len(rs))
 	for i, r := range rs {


### PR DESCRIPTION
## What changes

Closes #791. Drops `ext/skills/directory.go::defaultDirectoryReadPageSize`
from 100 to 0 to match mcpkit's server-wide
`server/pagination.go::defaultPageSize = 0` ("return everything in one
page, no `nextCursor`"). The client-side cap added in #792
(`Client.WithMaxListPages`, default 1000) handles the unbounded-server
runaway case, so the server-side page size doesn't need to enforce a
ceiling here.

Caught a latent bug in `paginateDirectoryRead` while doing this — the
helper lacked the `pageSize <= 0 = return all` short-circuit that
`server/pagination.go::paginate` already implements. Without the fix,
dropping the default to 0 would silently truncate every response to an
empty page. First test run after the constant change caught it
(`TestDirectoryRead_NestedDirectoryURI` went red). The short-circuit is
added at the top of `paginateDirectoryRead` and pinned by two new unit
tests.

## Reviewer's guide

Read in this order:

1. [ext/skills/directory.go](https://github.com/panyam/mcpkit/pull/793/files#diff-f4ed6017503d235f572e8544f27ca1432fe6baccc13bdae1f187cff8371089a4) — start here. Two pieces: the constant
   rewrite at the top of the file (`100 → 0` with a doc comment that
   explains the alignment rationale and points at #792's client cap as
   the safety net), and the new `pageSize <= 0` short-circuit at the top
   of `paginateDirectoryRead` (with a doc comment block explaining why
   it has to mirror `server/pagination.go`'s behavior).
2. [ext/skills/directory_pagination_test.go](https://github.com/panyam/mcpkit/pull/793/files#diff-57bbd4af10976093c597c22434e4a2ca1838bff732870169e5832873005f579e) — two new tests pin the
   contract: `TestPaginateDirectoryRead_ZeroPageSizeReturnsAll` and
   `TestPaginateDirectoryRead_NegativePageSizeReturnsAll`. The three
   existing pagination tests (RoundTrip, EmptyInput, MalformedCursor)
   stay green — they all pass explicit `pageSize` values and don't
   depend on the production default.

Skim or skip: the wire-level tests in `ext/skills/directory_test.go`
weren't touched. They use small fixtures (3-5 entries per directory)
that fit in one page regardless of cap value, and none of them assert
that `NextCursor` is present.

## Decision log

- **Kept the constant rather than deleting it.** A future operator
  who wants per-deployment paging can flip the constant or wire a
  provider option in one diff line. Deleting would force a function-
  signature change at the call site.
- **Mirrored `server/pagination.go::paginate` semantics for
  non-positive page sizes** rather than treating 0 as "no items." The
  upstream helper's choice ("zero = unbounded") is what `defaultPageSize
  = 0` actually means across the rest of mcpkit; if I'd diverged here
  the alignment would be skin-deep.
- **Did not promote the upstream `paginate` helper to a shared
  package.** A 15-line local copy beats a public-API expansion for one
  off-package consumer (same call out as the original PR 785
  introduced this helper).
- **No `WithDirectoryReadPageSize(n)` provider option.** YAGNI; file
  when a real deployment surfaces.

## Risk / blast radius

- **Wire change**: every `resources/directory/read` response now omits
  `nextCursor` (the field is empty-string + `omitempty`, so it's
  dropped from the JSON entirely). Any consumer that asserted
  `nextCursor` was *present* would break — none exist today (I
  grepped). The 8 wire-level tests in `directory_test.go` don't
  assert `NextCursor` presence.
- **Latent-bug fix**: any pre-existing call site that explicitly
  passed `pageSize=0` would have previously got an empty page. There
  was no such caller (the only production call site uses the
  constant).
- **No core/ or server/ changes** — purely `ext/skills/`-local.
- Tests covered: `ext/skills/directory_pagination_test.go` (5 tests
  total: 3 existing + 2 new), `ext/skills/directory_test.go` (8
  wire-level tests stay green), live walkthrough smoke against
  `examples/skills`.

## Before / after

Walkthrough Step 10 output (against `make serve` in `examples/skills`):

```
ReadDirectory(skill://acme/billing/refunds/templates):
  file         skill://acme/billing/refunds/templates/email.md
  file         skill://acme/billing/refunds/templates/refund-receipt.md
  dir/         skill://acme/billing/refunds/templates/regional
ReadDirectory(skill://acme/billing/refunds/templates/regional):
  file         skill://acme/billing/refunds/templates/regional/eu.md
```

Identical to before; the only invisible change is that the
`resources/directory/read` JSON-RPC response no longer carries
`nextCursor`.

## Out of scope (deliberately deferred)

- **`WithDirectoryReadPageSize(n)` provider option** — file if a real
  deployment needs per-directory paging.
- **Raise `server/pagination.go::defaultPageSize` above 0** — the
  parent "make mcpkit's server actually paginate" discussion, safe to
  reopen now that #792 has shipped client-side iteration.

