### PR TITLE
ext/skills: harden ParseURI + walkthrough mode-aware narrative

### DIFF
--- a/examples/skills/Makefile
+++ b/examples/skills/Makefile
@@ -6,10 +6,10 @@ serve: ## Start the skills-demo server in file mode (default :8080)
 	go run . --serve
 
 serve-archive: ## Start the server in archive mode (.tar.gz per skill)
-	go run . --serve --mode=archive
+	go run . --serve --bundle=archive
 
 serve-zip: ## Start the server in archive mode (.zip per skill)
-	go run . --serve --mode=zip
+	go run . --serve --bundle=zip
 
 run: ## Run the walkthrough in interactive TUI mode (paginated, key-driven).
 	go run .

--- a/examples/skills/WALKTHROUGH.md
+++ b/examples/skills/WALKTHROUGH.md
@@ -8,13 +8,15 @@ SEP-2640 serves Agent Skills over MCP's Resources primitive: each file under a s
 - **Connect to the skills server** — Construct the client with the chosen wire mode, then connect. After the call returns, inspect the new accessor to see which wire engaged. The curl chain below uses the legacy wire and mints a session id reused by every subsequent step; the stateless wire skips that — each call posts directly to /mcp with no Mcp-Session-Id header.
 - **resources/list returns every cataloged skill URI** — In file mode the list has N entries per skill (one for SKILL.md, one per supporting file) plus the index. In archive mode it's one entry per skill plus the index.
 - **Read skill://index.json** — The Indexer caches the result with a TTL and per-skill mtime invalidation. Repeated reads return the same bytes until something in a SKILL.md actually changes. The file is not on disk — mcpkit generates it from the live provider catalog on each cache miss.
-- **Verify digest by re-fetching SKILL.md and recomputing SHA-256** — Treat the response bytes as the artifact, hash them, compare against the digest field from the index. A mismatch indicates corruption or tampering, and per the SEP the host MUST NOT use the content.
+- **Detect server distribution mode from the index** — In file mode every entry's type is skill-md; the host fetches SKILL.md plus any supporting files individually. In archive mode every entry's type is archive and the URL ends in .tar.gz or .zip; the host fetches one resource per skill and unpacks it in-process. The current Provider is per-mode (no mixing), so the first archive entry sighted in the index is enough to decide.
+- **Verify digest by re-fetching git-workflow's canonical artifact** — Treat the response bytes as the artifact, hash them, compare against the digest field from the index. The artifact is the SKILL.md in file mode and the packed archive in archive mode — the verify ritual is the same either way. A mismatch indicates corruption or tampering, and per the SEP the host MUST NOT use the content.
 - **Read the pdf-processing SKILL.md** — This skill's frontmatter carries version and tags Extra fields. mcpkit surfaces those under ResourceDef.Annotations keyed by the io.modelcontextprotocol.skills/ reverse-domain prefix.
 - **Read a supporting file via skill:// (references/FORMS.md)** — Relative reference resolution: references/FORMS.md from inside pdf-processing/SKILL.md resolves to this full URI via the SDK helper that walks the skill root.
 - **Read a nested-prefix skill (acme/billing/refunds)** — Demonstrates that the prefix-segment routing works end-to-end. The skill name is refunds; the acme/billing/ prefix is server-chosen and is opaque to the skill's own frontmatter.
 - **Read a supporting file in the nested skill (templates/email.md)** — Same relative-reference resolution as the pdf-processing example, this time across a multi-segment prefix.
 - **List a directory inside a skill and recurse into a subdirectory** — Subdirectories surface with mimeType inode/directory; the client descends by issuing a second call. The SDK wraps this into a single call; the curl below shows both round trips explicitly.
 - **Wrap reads in skills.NewClient(...) and call Client.Activate** — Activate is intra-process — no wire traffic. Run with `make serve EXPORTER=stdout` + `make demo EXPORTER=stdout` to see spans.
+- **Read pdf-processing archive, verify digest, unpack, list recovered files** — Only meaningful in archive mode. In file mode the step prints the detected mode and exits — see the per-file read steps above for the equivalent file-mode story.
 
 ## Flow
 
@@ -37,35 +39,41 @@ sequenceDiagram
     Host->>Server: resources/read uri=skill://index.json
     Server-->>Host: { $schema, skills: [...] }
 
-    Note over Host,Server: Step 5: Verify digest by re-fetching SKILL.md and recomputing SHA-256
-    Host->>Server: resources/read uri=skill://git-workflow/SKILL.md
-    Server-->>Host: text/markdown body
+    Note over Host,Server: Step 5: Detect server distribution mode from the index
 
-    Note over Host,Server: Step 6: Read the pdf-processing SKILL.md
+    Note over Host,Server: Step 6: Verify digest by re-fetching git-workflow's canonical artifact
+    Host->>Server: resources/read uri=skill://git-workflow{/SKILL.md | .tar.gz | .zip}
+    Server-->>Host: text/markdown body (file mode) OR archive bytes (archive mode)
+
+    Note over Host,Server: Step 7: Read the pdf-processing SKILL.md
     Host->>Server: resources/read uri=skill://pdf-processing/SKILL.md
     Server-->>Host: text/markdown body
 
-    Note over Host,Server: Step 7: Read a supporting file via skill:// (references/FORMS.md)
+    Note over Host,Server: Step 8: Read a supporting file via skill:// (references/FORMS.md)
     Host->>Server: resources/read uri=skill://pdf-processing/references/FORMS.md
     Server-->>Host: text/markdown body
 
-    Note over Host,Server: Step 8: Read a nested-prefix skill (acme/billing/refunds)
+    Note over Host,Server: Step 9: Read a nested-prefix skill (acme/billing/refunds)
     Host->>Server: resources/read uri=skill://acme/billing/refunds/SKILL.md
     Server-->>Host: text/markdown body
 
-    Note over Host,Server: Step 9: Read a supporting file in the nested skill (templates/email.md)
+    Note over Host,Server: Step 10: Read a supporting file in the nested skill (templates/email.md)
     Host->>Server: resources/read uri=skill://acme/billing/refunds/templates/email.md
     Server-->>Host: text/markdown body
 
-    Note over Host,Server: Step 10: List a directory inside a skill and recurse into a subdirectory
+    Note over Host,Server: Step 11: List a directory inside a skill and recurse into a subdirectory
     Host->>Server: resources/directory/read uri=skill://acme/billing/refunds/templates
     Server-->>Host: 2 files + 1 subdirectory (`regional`, inode/directory)
     Host->>Server: resources/directory/read uri=skill://acme/billing/refunds/templates/regional
     Server-->>Host: 1 file (eu.md)
 
-    Note over Host,Server: Step 11: Wrap reads in skills.NewClient(...) and call Client.Activate
+    Note over Host,Server: Step 12: Wrap reads in skills.NewClient(...) and call Client.Activate
     Host->>Server: resources/read via sc.ReadAndVerify (span: skills.read_and_verify)
     Server-->>Host: bytes + digest match
+
+    Note over Host,Server: Step 13: Read pdf-processing archive, verify digest, unpack, list recovered files
+    Host->>Server: resources/read uri=skill://pdf-processing.tar.gz (or .zip)
+    Server-->>Host: application/gzip OR application/zip blob
 ```
 
 ## Steps
@@ -75,8 +83,10 @@ sequenceDiagram
 ```
 Terminal 1:  make serve         # default (file mode, :8080)
              make serve-archive # one .tar.gz per skill
+             make serve-zip     # one .zip per skill
 Terminal 2:  make demo          # this walkthrough (--tui interactive)
 ```
+This walkthrough auto-detects which of the three distribution modes the server is serving. The mode-aware section near the bottom shows the archive read-and-unpack flow; the file-mode read steps in the middle SKIP cleanly when archive mode is in effect (and vice versa).
 
 ### URI shape
 
@@ -149,18 +159,38 @@ curl -s -X POST http://localhost:8080/mcp \
   | jq -r '.result.contents[0].text' | jq '.'
 ```
 
-### Digest contract
+### Distribution mode
 
-Each entry carries `sha256:{64hex}` over the raw artifact bytes (SKILL.md for skill-md, packed archive for archive). Hosts MUST verify before use.
+SEP-2640 lets a server publish each skill as either individual files (`type:skill-md`) or one packed archive per skill (`type:archive` with `.tar.gz` / `.zip` suffix). The shape is visible on the index entries — the walkthrough sniffs it once and threads the result through the rest of the steps so the file-mode and archive-mode narratives stay tidy.
 
-### Step 5: Verify digest by re-fetching SKILL.md and recomputing SHA-256
+### Step 5: Detect server distribution mode from the index
 
-Treat the response bytes as the artifact, hash them, compare against the digest field from the index. A mismatch indicates corruption or tampering, and per the SEP the host MUST NOT use the content.
+In file mode every entry's type is skill-md; the host fetches SKILL.md plus any supporting files individually. In archive mode every entry's type is archive and the URL ends in .tar.gz or .zip; the host fetches one resource per skill and unpacks it in-process. The current Provider is per-mode (no mixing), so the first archive entry sighted in the index is enough to decide.
 
 #### Reproduce on the wire
 
 ```bash
-# Re-read the SKILL.md, recompute sha256, compare against the index entry's digest.
+# Distinct types appearing in the index — "skill-md" or "archive".
+curl -s -X POST http://localhost:8080/mcp \
+  -H 'Content-Type: application/json' -H 'Accept: application/json' \
+  -H "Mcp-Session-Id: $SID" \
+  -d '{"jsonrpc":"2.0","id":11,"method":"resources/read","params":{"uri":"skill://index.json"}}' \
+  | jq -r '.result.contents[0].text' \
+  | jq -r '[.skills[].type] | unique | join(",")'
+```
+
+### Digest contract
+
+Each entry carries `sha256:{64hex}` over the raw artifact bytes (SKILL.md for skill-md, packed archive for archive). Hosts MUST verify before use.
+
+### Step 6: Verify digest by re-fetching git-workflow's canonical artifact
+
+Treat the response bytes as the artifact, hash them, compare against the digest field from the index. The artifact is the SKILL.md in file mode and the packed archive in archive mode — the verify ritual is the same either way. A mismatch indicates corruption or tampering, and per the SEP the host MUST NOT use the content.
+
+#### Reproduce on the wire
+
+```bash
+# File mode — re-read SKILL.md, recompute sha256, compare against the index entry's digest.
 WANT=$(curl -s -X POST http://localhost:8080/mcp \
   -H 'Content-Type: application/json' -H 'Accept: application/json' -H "Mcp-Session-Id: $SID" \
   -d '{"jsonrpc":"2.0","id":3,"method":"resources/read","params":{"uri":"skill://index.json"}}' \
@@ -171,13 +201,17 @@ GOT="sha256:$(curl -s -X POST http://localhost:8080/mcp \
   -d '{"jsonrpc":"2.0","id":4,"method":"resources/read","params":{"uri":"skill://git-workflow/SKILL.md"}}' \
   | jq -r '.result.contents[0].text' | shasum -a 256 | awk '{print $1}')"
 [ "$WANT" = "$GOT" ] && echo "verified" || echo "MISMATCH"
+
+# Archive mode — swap the URI; the body is base64-encoded under .contents[0].blob.
+#   uri=skill://git-workflow.tar.gz     # or skill://git-workflow.zip
+#   jq -r '.result.contents[0].blob' | base64 -d | shasum -a 256
 ```
 
 ### Reading skill files
 
 Manifest body may reference supporting files via relative paths. `skills.ResolveRelative(skillRoot, ref)` resolves them filesystem-style; `..` escapes are rejected.
 
-### Step 6: Read the pdf-processing SKILL.md
+### Step 7: Read the pdf-processing SKILL.md
 
 This skill's frontmatter carries version and tags Extra fields. mcpkit surfaces those under ResourceDef.Annotations keyed by the io.modelcontextprotocol.skills/ reverse-domain prefix.
 
@@ -191,7 +225,7 @@ curl -s -X POST http://localhost:8080/mcp \
   | jq -r '.result.contents[0].text'
 ```
 
-### Step 7: Read a supporting file via skill:// (references/FORMS.md)
+### Step 8: Read a supporting file via skill:// (references/FORMS.md)
 
 Relative reference resolution: references/FORMS.md from inside pdf-processing/SKILL.md resolves to this full URI via the SDK helper that walks the skill root.
 
@@ -205,7 +239,7 @@ curl -s -X POST http://localhost:8080/mcp \
   | jq -r '.result.contents[0].text'
 ```
 
-### Step 8: Read a nested-prefix skill (acme/billing/refunds)
+### Step 9: Read a nested-prefix skill (acme/billing/refunds)
 
 Demonstrates that the prefix-segment routing works end-to-end. The skill name is refunds; the acme/billing/ prefix is server-chosen and is opaque to the skill's own frontmatter.
 
@@ -219,7 +253,7 @@ curl -s -X POST http://localhost:8080/mcp \
   | jq -r '.result.contents[0].text'
 ```
 
-### Step 9: Read a supporting file in the nested skill (templates/email.md)
+### Step 10: Read a supporting file in the nested skill (templates/email.md)
 
 Same relative-reference resolution as the pdf-processing example, this time across a multi-segment prefix.
 
@@ -237,7 +271,7 @@ curl -s -X POST http://localhost:8080/mcp \
 
 SEP commit `2e04c48d` (2026-06-09) added `resources/directory/read` for listing a directory's direct children without enumerating the server's entire resource space. Capability-gated via `io.modelcontextprotocol/skills.directoryRead`. mcpkit's Provider auto-supports it (#781).
 
-### Step 10: List a directory inside a skill and recurse into a subdirectory
+### Step 11: List a directory inside a skill and recurse into a subdirectory
 
 Subdirectories surface with mimeType inode/directory; the client descends by issuing a second call. The SDK wraps this into a single call; the curl below shows both round trips explicitly.
 
@@ -263,13 +297,36 @@ curl -s -X POST http://localhost:8080/mcp \
 
 Fetch ≠ activation. Server `resources/read` spans now carry `mcp.skill.*` attrs (#748). Client `ext/skills.Client` emits `skills.read*` spans + `Activate(ctx, uri)` for post-cache use the wire can't see (SDK-only — no spec change).
 
-### Step 11: Wrap reads in skills.NewClient(...) and call Client.Activate
+### Step 12: Wrap reads in skills.NewClient(...) and call Client.Activate
 
 Activate is intra-process — no wire traffic. Run with `make serve EXPORTER=stdout` + `make demo EXPORTER=stdout` to see spans.
 
+### Archive mode — atomic delivery + in-process unpack
+
+In archive mode every skill is delivered as a single `.tar.gz` or `.zip` resource. The host hashes the archive bytes against the index digest, then unpacks in-memory to recover the post-unpack virtual namespace — same files the file-mode wire would have served piecemeal. Demonstrates pdf-processing (multi-file skill) because the unpacked listing actually shows something.
+
+### Step 13: Read pdf-processing archive, verify digest, unpack, list recovered files
+
+Only meaningful in archive mode. In file mode the step prints the detected mode and exits — see the per-file read steps above for the equivalent file-mode story.
+
+#### Reproduce on the wire
+
+```bash
+# Fetch the archive blob (base64-encoded under .contents[0].blob in archive mode).
+curl -s -X POST http://localhost:8080/mcp \
+  -H 'Content-Type: application/json' -H 'Accept: application/json' \
+  -H "Mcp-Session-Id: $SID" \
+  -d '{"jsonrpc":"2.0","id":12,"method":"resources/read","params":{"uri":"skill://pdf-processing.tar.gz"}}' \
+  | jq -r '.result.contents[0].blob' | base64 -d > /tmp/pdf.tgz
+
+# Verify and list:
+shasum -a 256 /tmp/pdf.tgz                 # compare against index entry digest
+tar -tzf /tmp/pdf.tgz                      # recovered file tree
+```
+
 ### Wrap-up
 
-Negotiated extension, enumerated index, verified one digest, read manifest + supporting files across single-segment and nested-prefix paths, emitted skill-shape spans + an activation event. `make serve-archive` flips the wire to one `.tar.gz` per skill — host code unchanged.
+Negotiated extension, enumerated index, sniffed the distribution mode, verified one digest against the canonical artifact (SKILL.md in file mode, packed archive in archive mode), and exercised the mode-specific read flow. The same client code paths served both — only the URI shape and the post-fetch unpack step differ.
 
 ## Run it
 

--- a/examples/skills/main.go
+++ b/examples/skills/main.go
@@ -14,13 +14,20 @@
 //
 // Run modes:
 //
-//	go run . --serve                    # file mode on :8080
-//	go run . --serve --mode=archive     # archive mode on :8080
-//	go run . --serve --addr=:9090       # different port
-//	go run .                            # walkthrough (against --url, default localhost:8080)
-//	go run . --tui                      # walkthrough in interactive TUI
-//	go run . --note                     # walkthrough in notebook mode
-//	go run . --doc=md                   # regenerate WALKTHROUGH.md
+//	go run . --serve                      # file mode on :8080
+//	go run . --serve --bundle=archive     # one .tar.gz per skill
+//	go run . --serve --bundle=zip         # one .zip per skill
+//	go run . --serve --addr=:9090         # different port
+//	go run .                              # walkthrough (against --url, default localhost:8080)
+//	go run . --tui                        # walkthrough in interactive TUI
+//	go run . --note                       # walkthrough in notebook mode
+//	go run . --doc=md                     # regenerate WALKTHROUGH.md
+//
+// The --bundle name is deliberate: demokit's FilterArgs reserves the
+// bare --mode flag for its own renderer selection (tui / plain /
+// notebook). Naming the example's distribution flag --mode silently
+// strips it before flag.Parse, leaving the server in file mode no
+// matter what the operator passed.
 package main
 
 import (
@@ -49,8 +56,8 @@ func main() {
 
 func serve() {
 	addr := flag.String("addr", ":8080", "listen address")
-	modeFlag := flag.String("mode", "file",
-		"distribution mode: file (per-resource SKILL.md + supporting files) | archive (one .tar.gz per skill)")
+	modeFlag := flag.String("bundle", "file",
+		"distribution shape: file (per-resource SKILL.md + supporting files) | archive (one .tar.gz per skill) | zip (one .zip per skill)")
 	skillsDir := flag.String("skills", "skills",
 		"directory of skill bundles to register (default ./skills)")
 	tel := common.RegisterTelemetryFlags(flag.CommandLine)
@@ -81,7 +88,7 @@ func serve() {
 	case "zip":
 		provOpts = append(provOpts, skills.WithArchiveMode(skills.ArchiveFormatZip))
 	default:
-		log.Fatalf("invalid --mode: %q (want file|archive|zip)", *modeFlag)
+		log.Fatalf("invalid --bundle: %q (want file|archive|zip)", *modeFlag)
 	}
 
 	provider, err := skills.NewProvider(provOpts...)

--- a/examples/skills/walkthrough.go
+++ b/examples/skills/walkthrough.go
@@ -1,12 +1,18 @@
 package main
 
 import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"log"
 	"strings"
 
@@ -61,8 +67,10 @@ func runDemo() {
 		"```",
 		"Terminal 1:  make serve         # default (file mode, :8080)",
 		"             make serve-archive # one .tar.gz per skill",
+		"             make serve-zip     # one .zip per skill",
 		"Terminal 2:  make demo          # this walkthrough (--tui interactive)",
 		"```",
+		"This walkthrough auto-detects which of the three distribution modes the server is serving. The mode-aware section near the bottom shows the archive read-and-unpack flow; the file-mode read steps in the middle SKIP cleanly when archive mode is in effect (and vice versa).",
 	)
 
 	demo.Section("URI shape",
@@ -185,7 +193,10 @@ for _, d := range defs {
 		"`skill://index.json` enumerates skills with `{$schema, skills:[{type, name, description, url, digest}]}`. Optional in the SEP; mcpkit auto-registers unless `WithoutIndex()`.",
 	)
 
-	var indexBody []byte
+	var (
+		indexBody []byte
+		detected  modeInfo
+	)
 
 	demo.Step("Read skill://index.json").
 		Arrow("Host", "Server", "resources/read uri=skill://index.json").
@@ -231,16 +242,61 @@ for _, e := range idx.Skills {
 			return nil
 		})
 
+	demo.Section("Distribution mode",
+		"SEP-2640 lets a server publish each skill as either individual files (`type:skill-md`) or one packed archive per skill (`type:archive` with `.tar.gz` / `.zip` suffix). The shape is visible on the index entries — the walkthrough sniffs it once and threads the result through the rest of the steps so the file-mode and archive-mode narratives stay tidy.",
+	)
+
+	demo.Step("Detect server distribution mode from the index").
+		Note("In file mode every entry's type is skill-md; the host fetches SKILL.md plus any supporting files individually. In archive mode every entry's type is archive and the URL ends in .tar.gz or .zip; the host fetches one resource per skill and unpacks it in-process. The current Provider is per-mode (no mixing), so the first archive entry sighted in the index is enough to decide.").
+		VerbatimVariants("Reproduce on the wire",
+			demokit.MakeVariant("jq", "bash", `# Distinct types appearing in the index — "skill-md" or "archive".
+curl -s -X POST http://localhost:8080/mcp \
+  -H 'Content-Type: application/json' -H 'Accept: application/json' \
+  -H "Mcp-Session-Id: $SID" \
+  -d '{"jsonrpc":"2.0","id":11,"method":"resources/read","params":{"uri":"skill://index.json"}}' \
+  | jq -r '.result.contents[0].text' \
+  | jq -r '[.skills[].type] | unique | join(",")'`).Default(),
+			demokit.MakeVariant("go", "go", `var idx skills.Index
+json.Unmarshal(indexBody, &idx)
+for _, e := range idx.Skills {
+    if e.Type == skills.SkillTypeArchive {
+        f := skills.DetectArchiveFormat(e.URL, nil) // .tar.gz or .zip
+        // archive mode — fetch one resource per skill, unpack in-memory
+        _ = f
+        break
+    }
+}`),
+		).
+		Run(func(ctx demokit.StepContext) *demokit.StepResult {
+			if c == nil || len(indexBody) == 0 {
+				return nil
+			}
+			var idx skills.Index
+			if err := json.Unmarshal(indexBody, &idx); err != nil {
+				fmt.Printf("    ERROR: %v\n", err)
+				return nil
+			}
+			detected = detectMode(idx)
+			if detected.archive {
+				fmt.Printf("    Detected mode: archive (%s)\n", detected.suffix)
+				fmt.Printf("    Each skill is one packed resource — see the Archive mode section below for read + verify + unpack.\n")
+			} else {
+				fmt.Printf("    Detected mode: file\n")
+				fmt.Printf("    Each skill is a tree of individual resources — the per-file reads below exercise that path.\n")
+			}
+			return nil
+		})
+
 	demo.Section("Digest contract",
 		"Each entry carries `sha256:{64hex}` over the raw artifact bytes (SKILL.md for skill-md, packed archive for archive). Hosts MUST verify before use.",
 	)
 
-	demo.Step("Verify digest by re-fetching SKILL.md and recomputing SHA-256").
-		Arrow("Host", "Server", "resources/read uri=skill://git-workflow/SKILL.md").
-		DashedArrow("Server", "Host", "text/markdown body").
-		Note("Treat the response bytes as the artifact, hash them, compare against the digest field from the index. A mismatch indicates corruption or tampering, and per the SEP the host MUST NOT use the content.").
+	demo.Step("Verify digest by re-fetching git-workflow's canonical artifact").
+		Arrow("Host", "Server", "resources/read uri=skill://git-workflow{/SKILL.md | .tar.gz | .zip}").
+		DashedArrow("Server", "Host", "text/markdown body (file mode) OR archive bytes (archive mode)").
+		Note("Treat the response bytes as the artifact, hash them, compare against the digest field from the index. The artifact is the SKILL.md in file mode and the packed archive in archive mode — the verify ritual is the same either way. A mismatch indicates corruption or tampering, and per the SEP the host MUST NOT use the content.").
 		VerbatimVariants("Reproduce on the wire",
-			demokit.MakeVariant("curl", "bash", `# Re-read the SKILL.md, recompute sha256, compare against the index entry's digest.
+			demokit.MakeVariant("curl", "bash", `# File mode — re-read SKILL.md, recompute sha256, compare against the index entry's digest.
 WANT=$(curl -s -X POST http://localhost:8080/mcp \
   -H 'Content-Type: application/json' -H 'Accept: application/json' -H "Mcp-Session-Id: $SID" \
   -d '{"jsonrpc":"2.0","id":3,"method":"resources/read","params":{"uri":"skill://index.json"}}' \
@@ -250,9 +306,20 @@ GOT="sha256:$(curl -s -X POST http://localhost:8080/mcp \
   -H 'Content-Type: application/json' -H 'Accept: application/json' -H "Mcp-Session-Id: $SID" \
   -d '{"jsonrpc":"2.0","id":4,"method":"resources/read","params":{"uri":"skill://git-workflow/SKILL.md"}}' \
   | jq -r '.result.contents[0].text' | shasum -a 256 | awk '{print $1}')"
-[ "$WANT" = "$GOT" ] && echo "verified" || echo "MISMATCH"`).Default(),
-			demokit.MakeVariant("go", "go", `result, _ := c.ReadResourceFull("skill://git-workflow/SKILL.md")
+[ "$WANT" = "$GOT" ] && echo "verified" || echo "MISMATCH"
+
+# Archive mode — swap the URI; the body is base64-encoded under .contents[0].blob.
+#   uri=skill://git-workflow.tar.gz     # or skill://git-workflow.zip
+#   jq -r '.result.contents[0].blob' | base64 -d | shasum -a 256`).Default(),
+			demokit.MakeVariant("go", "go", `target := uriGitWorkflow                 // file mode default
+if detected.archive {
+    target = "skill://git-workflow" + detected.suffix
+}
+result, _ := c.ReadResourceFull(target)
 raw := []byte(result.Contents[0].Text)
+if raw == nil {                          // archive mode returns base64 blob
+    raw, _ = base64.StdEncoding.DecodeString(result.Contents[0].Blob)
+}
 sum := sha256.Sum256(raw)
 got := "sha256:" + hex.EncodeToString(sum[:])
 // compare got against e.Digest from skill://index.json — host MUST NOT use mismatched content`),
@@ -265,18 +332,22 @@ got := "sha256:" + hex.EncodeToString(sum[:])
 			if err := json.Unmarshal(indexBody, &idx); err != nil {
 				return nil
 			}
+			target := uriGitWorkflow
+			if detected.archive {
+				target = "skill://git-workflow" + detected.suffix
+			}
 			var want string
 			for _, e := range idx.Skills {
-				if e.URL == uriGitWorkflow {
+				if e.URL == target {
 					want = e.Digest
 					break
 				}
 			}
 			if want == "" {
-				fmt.Printf("    git-workflow not found in index (server may be in archive mode)\n")
+				fmt.Printf("    %s not found in index\n", target)
 				return nil
 			}
-			result, err := c.ReadResourceFull(uriGitWorkflow)
+			result, err := c.ReadResourceFull(target)
 			if err != nil {
 				fmt.Printf("    ERROR: %v\n", err)
 				return nil
@@ -290,6 +361,7 @@ got := "sha256:" + hex.EncodeToString(sum[:])
 			}
 			sum := sha256.Sum256(raw)
 			got := "sha256:" + hex.EncodeToString(sum[:])
+			fmt.Printf("    artifact: %s (%d bytes)\n", target, len(raw))
 			fmt.Printf("    want %s\n", want)
 			fmt.Printf("    got  %s\n", got)
 			if got == want {
@@ -321,9 +393,13 @@ fmt.Println(body)`),
 			if c == nil {
 				return nil
 			}
+			if detected.archive {
+				fmt.Printf("    Detected archive mode — per-file SKILL.md reads are unavailable; see the Archive mode section below.\n")
+				return nil
+			}
 			body, err := c.ReadResource(uriPDFManifest)
 			if err != nil {
-				fmt.Printf("    SKIP: %v (server may be in archive mode)\n", err)
+				fmt.Printf("    ERROR: %v\n", err)
 				return nil
 			}
 			previewBody(body)
@@ -348,9 +424,13 @@ body, _ := c.ReadResource(target.String())`),
 			if c == nil {
 				return nil
 			}
+			if detected.archive {
+				fmt.Printf("    Detected archive mode — supporting files surface only after unpack; see the Archive mode section below.\n")
+				return nil
+			}
 			body, err := c.ReadResource(uriPDFRef)
 			if err != nil {
-				fmt.Printf("    SKIP: %v\n", err)
+				fmt.Printf("    ERROR: %v\n", err)
 				return nil
 			}
 			previewBody(body)
@@ -373,9 +453,13 @@ body, _ := c.ReadResource(target.String())`),
 			if c == nil {
 				return nil
 			}
+			if detected.archive {
+				fmt.Printf("    Detected archive mode — nested-prefix skills become skill://acme/billing/refunds%s; see the Archive mode section below.\n", detected.suffix)
+				return nil
+			}
 			body, err := c.ReadResource(uriRefundsManifest)
 			if err != nil {
-				fmt.Printf("    SKIP: %v\n", err)
+				fmt.Printf("    ERROR: %v\n", err)
 				return nil
 			}
 			previewBody(body)
@@ -398,9 +482,13 @@ body, _ := c.ReadResource(target.String())`),
 			if c == nil {
 				return nil
 			}
+			if detected.archive {
+				fmt.Printf("    Detected archive mode — supporting files surface only after unpack; see the Archive mode section below.\n")
+				return nil
+			}
 			body, err := c.ReadResource(uriRefundsEmail)
 			if err != nil {
-				fmt.Printf("    SKIP: %v\n", err)
+				fmt.Printf("    ERROR: %v\n", err)
 				return nil
 			}
 			previewBody(body)
@@ -443,6 +531,10 @@ for _, r := range result.Resources {
 		).
 		Run(func(ctx demokit.StepContext) *demokit.StepResult {
 			if c == nil {
+				return nil
+			}
+			if detected.archive {
+				fmt.Printf("    Detected archive mode — directoryRead lists per-file resources, which archive mode does not publish. The unpacked archive (see below) recovers the same shape.\n")
 				return nil
 			}
 			sc := skills.NewClient(c, skills.WithTracerProvider(tp))
@@ -499,20 +591,110 @@ for _, r := range result.Resources {
 						ev.URI, ev.Reason, ev.Timestamp.Format("15:04:05.000"))
 				}),
 			)
-			if _, err := sc.ReadAndVerify(context.Background(), uriPDFManifest, ""); err != nil {
-				fmt.Printf("    SKIP ReadAndVerify: %v (server may be in archive mode)\n", err)
+			target := uriPDFManifest
+			if detected.archive {
+				target = "skill://pdf-processing" + detected.suffix
+			}
+			if _, err := sc.ReadAndVerify(context.Background(), target, ""); err != nil {
+				fmt.Printf("    ERROR ReadAndVerify(%s): %v\n", target, err)
 				return nil
 			}
-			fmt.Printf("    sc.ReadAndVerify emitted skills.read_and_verify span\n")
-			ev := sc.Activate(context.Background(), uriPDFManifest,
+			fmt.Printf("    sc.ReadAndVerify(%s) emitted skills.read_and_verify span\n", target)
+			ev := sc.Activate(context.Background(), target,
 				skills.WithReason("walkthrough_demonstration"))
 			fmt.Printf("    sc.Activate returned ActivationEvent{URI=%s, Reason=%q}\n", ev.URI, ev.Reason)
 			fmt.Printf("    %d hook invocation(s)\n", activations)
 			return nil
 		})
 
+	demo.Section("Archive mode — atomic delivery + in-process unpack",
+		"In archive mode every skill is delivered as a single `.tar.gz` or `.zip` resource. The host hashes the archive bytes against the index digest, then unpacks in-memory to recover the post-unpack virtual namespace — same files the file-mode wire would have served piecemeal. Demonstrates pdf-processing (multi-file skill) because the unpacked listing actually shows something.",
+	)
+
+	demo.Step("Read pdf-processing archive, verify digest, unpack, list recovered files").
+		Arrow("Host", "Server", "resources/read uri=skill://pdf-processing.tar.gz (or .zip)").
+		DashedArrow("Server", "Host", "application/gzip OR application/zip blob").
+		Note("Only meaningful in archive mode. In file mode the step prints the detected mode and exits — see the per-file read steps above for the equivalent file-mode story.").
+		VerbatimVariants("Reproduce on the wire",
+			demokit.MakeVariant("curl", "bash", `# Fetch the archive blob (base64-encoded under .contents[0].blob in archive mode).
+curl -s -X POST http://localhost:8080/mcp \
+  -H 'Content-Type: application/json' -H 'Accept: application/json' \
+  -H "Mcp-Session-Id: $SID" \
+  -d '{"jsonrpc":"2.0","id":12,"method":"resources/read","params":{"uri":"skill://pdf-processing.tar.gz"}}' \
+  | jq -r '.result.contents[0].blob' | base64 -d > /tmp/pdf.tgz
+
+# Verify and list:
+shasum -a 256 /tmp/pdf.tgz                 # compare against index entry digest
+tar -tzf /tmp/pdf.tgz                      # recovered file tree`).Default(),
+			demokit.MakeVariant("go", "go", `result, _ := c.ReadResourceFull("skill://pdf-processing" + detected.suffix)
+raw, _ := base64.StdEncoding.DecodeString(result.Contents[0].Blob)
+// hash raw, compare against index digest
+files, _ := unpackArchive(detected.format, raw)
+for _, f := range files {
+    fmt.Printf("%s (%d bytes)\n", f.Name, len(f.Bytes))
+}`),
+		).
+		Run(func(ctx demokit.StepContext) *demokit.StepResult {
+			if c == nil || len(indexBody) == 0 {
+				return nil
+			}
+			if !detected.archive {
+				fmt.Printf("    Detected file mode — archive-mode flow is gated; see the per-file read steps above for the equivalent file-mode story.\n")
+				return nil
+			}
+			var idx skills.Index
+			if err := json.Unmarshal(indexBody, &idx); err != nil {
+				return nil
+			}
+			target := "skill://pdf-processing" + detected.suffix
+			var want string
+			for _, e := range idx.Skills {
+				if e.URL == target {
+					want = e.Digest
+					break
+				}
+			}
+			result, err := c.ReadResourceFull(target)
+			if err != nil {
+				fmt.Printf("    ERROR: %v\n", err)
+				return nil
+			}
+			raw, err := base64.StdEncoding.DecodeString(result.Contents[0].Blob)
+			if err != nil {
+				fmt.Printf("    ERROR: archive body did not arrive as base64 blob: %v\n", err)
+				return nil
+			}
+			sum := sha256.Sum256(raw)
+			got := "sha256:" + hex.EncodeToString(sum[:])
+			fmt.Printf("    archive: %s (%d bytes)\n", target, len(raw))
+			fmt.Printf("    want %s\n", want)
+			fmt.Printf("    got  %s\n", got)
+			if got != want {
+				fmt.Printf("    DIGEST MISMATCH — content MUST NOT be used per the SEP\n")
+				return nil
+			}
+			fmt.Printf("    digest matches — unpacking via stdlib (%s)…\n", detected.format.String())
+			files, err := unpackArchive(detected.format, raw)
+			if err != nil {
+				fmt.Printf("    ERROR: unpack failed: %v\n", err)
+				return nil
+			}
+			fmt.Printf("    recovered %d files:\n", len(files))
+			for _, f := range files {
+				fmt.Printf("      %-32s %d bytes\n", f.Name, len(f.Bytes))
+			}
+			for _, f := range files {
+				if strings.HasSuffix(f.Name, "SKILL.md") {
+					fmt.Printf("    SKILL.md preview from the unpacked archive:\n")
+					previewBody(string(f.Bytes))
+					break
+				}
+			}
+			return nil
+		})
+
 	demo.Section("Wrap-up",
-		"Negotiated extension, enumerated index, verified one digest, read manifest + supporting files across single-segment and nested-prefix paths, emitted skill-shape spans + an activation event. `make serve-archive` flips the wire to one `.tar.gz` per skill — host code unchanged.",
+		"Negotiated extension, enumerated index, sniffed the distribution mode, verified one digest against the canonical artifact (SKILL.md in file mode, packed archive in archive mode), and exercised the mode-specific read flow. The same client code paths served both — only the URI shape and the post-fetch unpack step differ.",
 	)
 
 	_ = serverInfo
@@ -540,6 +722,103 @@ func marker(mimeType string) string {
 		return "dir/"
 	}
 	return "file"
+}
+
+// modeInfo captures the distribution shape detected from the server's
+// skill://index.json. It controls which steps below take the file-mode
+// path (per-file SKILL.md reads) vs the archive-mode path (one archive
+// per skill, unpacked in-process to recover the same files).
+type modeInfo struct {
+	archive bool
+	format  skills.ArchiveFormat
+	suffix  string
+}
+
+// detectMode scans a parsed Index for the first archive-typed entry and
+// returns the implied distribution mode. Provider.WithArchiveMode is
+// per-Provider in this revision, so a mixed index is impossible today
+// and the first archive sighting decides for the whole index.
+func detectMode(idx skills.Index) modeInfo {
+	for _, e := range idx.Skills {
+		if e.Type != skills.SkillTypeArchive {
+			continue
+		}
+		f := skills.DetectArchiveFormat(e.URL, nil)
+		return modeInfo{
+			archive: true,
+			format:  f,
+			suffix:  f.Suffix(),
+		}
+	}
+	return modeInfo{}
+}
+
+// archiveMember is one regular file recovered from an unpacked archive.
+// Name is the entry path as it appeared inside the archive (no leading
+// slash; relative to the archive root). Bytes is the unpacked content.
+type archiveMember struct {
+	Name  string
+	Bytes []byte
+}
+
+// unpackArchive decodes raw archive bytes into the list of recovered
+// regular files using nothing but the stdlib. The walkthrough calls
+// this after the SHA-256 digest has been verified against the index
+// entry — production hosts SHOULD also enforce an unpacked-size cap
+// (see skills.DefaultArchiveMaxBytes); omitted here because the demo
+// fixtures are tiny and the focus is the verify-then-unpack shape.
+func unpackArchive(format skills.ArchiveFormat, raw []byte) ([]archiveMember, error) {
+	switch format {
+	case skills.ArchiveFormatTarGz:
+		gz, err := gzip.NewReader(bytes.NewReader(raw))
+		if err != nil {
+			return nil, err
+		}
+		defer gz.Close()
+		tr := tar.NewReader(gz)
+		var out []archiveMember
+		for {
+			h, err := tr.Next()
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			if err != nil {
+				return nil, err
+			}
+			if h.Typeflag != tar.TypeReg {
+				continue
+			}
+			data, err := io.ReadAll(tr)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, archiveMember{Name: h.Name, Bytes: data})
+		}
+		return out, nil
+	case skills.ArchiveFormatZip:
+		zr, err := zip.NewReader(bytes.NewReader(raw), int64(len(raw)))
+		if err != nil {
+			return nil, err
+		}
+		var out []archiveMember
+		for _, f := range zr.File {
+			if f.FileInfo().IsDir() {
+				continue
+			}
+			rc, err := f.Open()
+			if err != nil {
+				return nil, err
+			}
+			data, err := io.ReadAll(rc)
+			rc.Close()
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, archiveMember{Name: f.Name, Bytes: data})
+		}
+		return out, nil
+	}
+	return nil, fmt.Errorf("unknown archive format: %v", format)
 }
 
 // previewBody prints the body of a read with head-and-tail bracketing

--- a/ext/skills/directory_test.go
+++ b/ext/skills/directory_test.go
@@ -126,22 +126,24 @@ func TestDirectoryRead_NestedDirectoryURI(t *testing.T) {
 
 // TestDirectoryRead_RejectsParentTraversal pins the security boundary:
 // a URI whose tail is `..` must not silently resolve to the parent of
-// the matched skill. Without the segment guard in resolveDirectoryURI,
-// path.Join("acme/billing/refunds", "..") would cleanly collapse to
-// "acme/billing" and enumerate the sibling tree — exactly the surface
-// the directoryRead capability is meant to keep scoped.
+// the matched skill. The Provider's URI-validation middleware intercepts
+// dot-segments at parse time, so the rejection surfaces as an invalid
+// skill URI ErrPathTraversal — sibling enumeration via
+// path.Join("acme/billing/refunds", "..") never reaches the directory
+// handler.
 func TestDirectoryRead_RejectsParentTraversal(t *testing.T) {
 	_, _, c := boot(t, "testdata/valid")
-	assertCallError(t, callDirectoryReadErr(c, "skill://acme/billing/refunds/..", ""), "invalid path segment")
+	assertCallError(t, callDirectoryReadErr(c, "skill://acme/billing/refunds/..", ""), "traversal segment")
 }
 
 // TestDirectoryRead_RejectsDotSegment rejects `.` segments for symmetry
 // with `..` — both are spec-silent at the URI level but semantically
 // ambiguous for a "directory inside the skill" lookup. Easier to reject
-// than to define disposal semantics.
+// than to define disposal semantics. Same middleware gate as the
+// parent-traversal case.
 func TestDirectoryRead_RejectsDotSegment(t *testing.T) {
 	_, _, c := boot(t, "testdata/valid")
-	assertCallError(t, callDirectoryReadErr(c, "skill://acme/billing/refunds/.", ""), "invalid path segment")
+	assertCallError(t, callDirectoryReadErr(c, "skill://acme/billing/refunds/.", ""), "traversal segment")
 }
 
 // TestDirectoryRead_RejectsDeepTraversal asserts the guard fires even
@@ -151,7 +153,7 @@ func TestDirectoryRead_RejectsDotSegment(t *testing.T) {
 // a documented attack pattern.
 func TestDirectoryRead_RejectsDeepTraversal(t *testing.T) {
 	_, _, c := boot(t, "testdata/valid")
-	assertCallError(t, callDirectoryReadErr(c, "skill://acme/billing/refunds/../../../etc/passwd", ""), "invalid path segment")
+	assertCallError(t, callDirectoryReadErr(c, "skill://acme/billing/refunds/../../../etc/passwd", ""), "traversal segment")
 }
 
 // TestDirectoryRead_StableOrdering verifies the result is URI-sorted so

--- a/ext/skills/errors.go
+++ b/ext/skills/errors.go
@@ -33,6 +33,15 @@ var (
 	// resolved file path would escape the skill's root using "..".
 	ErrRelativeEscapesSkill = errors.New("skills: relative reference escapes skill root")
 
+	// ErrPathTraversal is returned by ParseURI when a URI contains a "."
+	// or ".." segment. SEP-2640 skill paths use [a-z0-9-] segments only,
+	// so dot-segments cannot appear legitimately — their presence
+	// indicates either a malformed URI or an attempted traversal probe.
+	// The strict rejection at parse time keeps the registry-miss path
+	// (HTTP 200 + "unknown resource") from masking traversal-shaped
+	// requests as ordinary typos in audit logs.
+	ErrPathTraversal = errors.New("skills: URI contains traversal segment (. or ..)")
+
 	// ErrNotManifestURI is returned when an operation requires a manifest
 	// URI (ending in /SKILL.md) but received a different shape.
 	ErrNotManifestURI = errors.New("skills: not a SKILL.md URI")

--- a/ext/skills/provider.go
+++ b/ext/skills/provider.go
@@ -1,7 +1,9 @@
 package skills
 
 import (
+	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/fs"
@@ -277,6 +279,50 @@ func (p *Provider) RegisterWith(srv *server.Server) {
 		}
 		NewIndexer(p, opts...).RegisterWith(srv)
 	}
+	srv.UseMiddleware(skillURIValidationMiddleware)
+}
+
+// skillURIValidationMiddleware short-circuits resources/read and
+// resources/directory/read requests whose uri is shaped like a skill://
+// URI but fails ParseURI — most importantly URIs that smuggle in dot
+// segments (".", ".."). Without this gate, traversal probes fall
+// through to the registry's exact-match lookup and surface as the
+// generic "unknown resource" InvalidParams response, indistinguishable
+// from a typo. With the gate, traversal probes return InvalidParams
+// with an explicit ErrPathTraversal-derived message, so audit logs and
+// host clients can act on the signal.
+//
+// Pass-through cases (next is invoked unchanged):
+//   - any method other than resources/read or resources/directory/read
+//   - resources/read of a non-skill:// URI (the server may host
+//     additional resource schemes alongside Skills)
+//   - params that don't parse as the read envelope (the dispatcher's
+//     own error path handles that — duplicating here would compete)
+//
+// Registered outermost in Provider.RegisterWith because middleware is
+// append-only and runs in registration order; placing the validator
+// last keeps it innermost-but-still-before-routing, which is the right
+// position for input shaping.
+func skillURIValidationMiddleware(ctx context.Context, req *core.Request, next server.MiddlewareFunc) (*core.Response, error) {
+	switch req.Method {
+	case "resources/read", MethodResourcesDirectoryRead:
+	default:
+		return next(ctx, req)
+	}
+	var envelope struct {
+		URI string `json:"uri"`
+	}
+	if err := json.Unmarshal(req.Params, &envelope); err != nil {
+		return next(ctx, req)
+	}
+	if !strings.HasPrefix(envelope.URI, Scheme+"://") {
+		return next(ctx, req)
+	}
+	if _, err := ParseURI(envelope.URI); err != nil {
+		return core.NewErrorResponse(req.ID, core.ErrCodeInvalidParams,
+			fmt.Sprintf("invalid skill URI %q: %v", envelope.URI, err)), nil
+	}
+	return next(ctx, req)
 }
 
 func (p *Provider) defFor(r *resourceEntry) core.ResourceDef {

--- a/ext/skills/provider_test.go
+++ b/ext/skills/provider_test.go
@@ -331,6 +331,51 @@ func TestProvider_Integration(t *testing.T) {
 	}
 }
 
+func TestProvider_RejectsTraversalURIs(t *testing.T) {
+	srv := server.NewServer(core.ServerInfo{Name: "skills-test", Version: "0.0.1"})
+
+	p, err := skills.NewProvider(skills.WithDirectory("testdata/valid"))
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	p.RegisterWith(srv)
+
+	handler := srv.Handler(server.WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "skills-test-client", Version: "0.0.1"})
+	if err := c.Connect(); err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+
+	cases := []string{
+		"skill://pdf-processing/../../../etc/passwd",
+		"skill://pdf-processing/..",
+		"skill://pdf-processing/./SKILL.md",
+		"skill://pdf-processing/%2E%2E/SKILL.md",
+	}
+	for _, uri := range cases {
+		t.Run(uri, func(t *testing.T) {
+			_, err := c.ReadResource(uri)
+			if err == nil {
+				t.Fatalf("ReadResource(%q) succeeded; want InvalidParams traversal error", uri)
+			}
+			msg := err.Error()
+			if !strings.Contains(msg, "invalid skill URI") {
+				t.Errorf("error message %q missing 'invalid skill URI' prefix", msg)
+			}
+			if !strings.Contains(msg, "traversal") {
+				t.Errorf("error message %q missing 'traversal' marker", msg)
+			}
+			if strings.Contains(msg, "unknown resource") {
+				t.Errorf("error message %q still surfaces as 'unknown resource' — middleware did not intercept", msg)
+			}
+		})
+	}
+}
+
 func urisOf(defs []core.ResourceDef) []string {
 	out := make([]string, len(defs))
 	for i, d := range defs {

--- a/ext/skills/uri.go
+++ b/ext/skills/uri.go
@@ -64,6 +64,14 @@ type URIParts struct {
 
 // ParseURI parses a skill:// URI into a URIParts.
 //
+// Rejects any "." or ".." path segment with ErrPathTraversal — SEP-2640
+// skill names use [a-z0-9-] only, so dot-segments cannot appear in a
+// well-formed URI and their presence indicates a malformed or traversal
+// probe. Production servers SHOULD validate inbound resources/read URIs
+// against this parser before registry lookup so that traversal attempts
+// produce a precise InvalidParams error instead of a generic
+// "unknown resource" miss.
+//
 // Validation rules:
 //   - Scheme must be exactly "skill" (ErrInvalidScheme otherwise).
 //   - At least one path segment is required (ErrEmptySkillPath).
@@ -137,12 +145,21 @@ func ParseURI(s string) (URIParts, error) {
 // RFC 3986 places the first <skill-path> segment in the authority component
 // when the URI has the "skill://" form; the remainder lives in the path.
 // Both contribute to the SEP-2640 skill path.
+//
+// Decoded segments are checked against ErrPathTraversal: "." and ".."
+// are rejected even though they are syntactically valid path components,
+// because SEP-2640 skill paths use [a-z0-9-] and dot-segments cannot
+// appear legitimately. Rejecting at parse time prevents the registry
+// miss path from masking traversal probes as ordinary typos.
 func splitURIPath(u *url.URL) ([]string, error) {
 	var segs []string
 	if u.Host != "" {
 		host, err := url.PathUnescape(u.Host)
 		if err != nil {
 			return nil, fmt.Errorf("%w: invalid host: %v", ErrInvalidScheme, err)
+		}
+		if host == "." || host == ".." {
+			return nil, fmt.Errorf("%w: at authority", ErrPathTraversal)
 		}
 		segs = append(segs, host)
 	}
@@ -164,6 +181,9 @@ func splitURIPath(u *url.URL) ([]string, error) {
 		decoded, err := url.PathUnescape(seg)
 		if err != nil {
 			return nil, fmt.Errorf("%w: %v", ErrInvalidScheme, err)
+		}
+		if decoded == "." || decoded == ".." {
+			return nil, fmt.Errorf("%w: %q at index %d", ErrPathTraversal, decoded, len(segs))
 		}
 		segs = append(segs, decoded)
 	}

--- a/ext/skills/uri_test.go
+++ b/ext/skills/uri_test.go
@@ -155,6 +155,12 @@ func TestParseURI_Errors(t *testing.T) {
 		{"double hyphen", "skill://re--funds/SKILL.md", skills.ErrInvalidSkillName},
 		{"underscore", "skill://my_skill/SKILL.md", skills.ErrInvalidSkillName},
 		{"only manifest", "skill://SKILL.md", skills.ErrEmptySkillPath},
+		{"dot segment authority", "skill://./SKILL.md", skills.ErrPathTraversal},
+		{"dotdot segment authority", "skill://../SKILL.md", skills.ErrPathTraversal},
+		{"dotdot mid path", "skill://pdf-processing/../../../etc/passwd", skills.ErrPathTraversal},
+		{"dotdot trailing", "skill://pdf-processing/..", skills.ErrPathTraversal},
+		{"dot mid path", "skill://pdf-processing/./SKILL.md", skills.ErrPathTraversal},
+		{"percent-encoded dotdot", "skill://pdf-processing/%2E%2E/SKILL.md", skills.ErrPathTraversal},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## What changes

Three folded-together changes that all exercise the same `examples/skills` demo path:

- **ParseURI rejects `.` / `..` segments** at parse time with a new `ErrPathTraversal` sentinel. SEP-2640 skill paths use `[a-z0-9-]` only, so dot-segments cannot appear legitimately — strict rejection makes traversal probes structurally distinguishable from typos in audit logs.
- **Provider installs a URI-validation middleware** via `Server.UseMiddleware`. `resources/read` and `resources/directory/read` for `skill://` URIs route through `ParseURI` before the registry lookup; failures surface as `-32602 InvalidParams` with a traversal-specific message instead of the generic `unknown resource` miss. Non-skill URIs and unrelated methods pass through untouched.
- **Walkthrough sniffs the server's distribution mode** from `skill://index.json` (file vs archive `.tar.gz` vs archive `.zip`) and branches every downstream step on the result. Archive mode gets a dedicated section that reads the archive resource, verifies SHA-256, unpacks via stdlib, and previews the recovered `SKILL.md`. `make serve-archive` / `make serve-zip` actually engage now — the `--mode` flag collided with demokit's own renderer-mode flag and was silently stripped before `flag.Parse`. Renamed to `--bundle`.

## Reviewer's guide

Read in this order:

1. [ext/skills/uri.go](https://github.com/panyam/mcpkit/pull/794/files#diff-3c138e49263788b31f94f2608b2c8613d0bd084b4f9c9921444e66e2332228ce) — start here. `splitURIPath` rejects `.` / `..`; `ParseURI` doc-block calls out the new rule.
2. [ext/skills/errors.go](https://github.com/panyam/mcpkit/pull/794/files#diff-097721358b725e6ce2ea62d43e0c77494d94644f016803b1fb7b949b957b6bc7) — `ErrPathTraversal` sentinel + rationale.
3. [ext/skills/provider.go](https://github.com/panyam/mcpkit/pull/794/files#diff-bc1bc138c97cce27ab4ebcc05b5b90bce9519a5b6ece2cd00da30248841d7021) — `skillURIValidationMiddleware` + the `srv.UseMiddleware` install at the bottom of `RegisterWith`.
4. [ext/skills/uri_test.go](https://github.com/panyam/mcpkit/pull/794/files#diff-9c80eb7daf89b1b0f148959534c8009deedd140d61add23cabe605f8ccb165c6) — six new traversal-rejection cases bolted onto the existing `TestParseURI_Errors` table.
5. [ext/skills/provider_test.go](https://github.com/panyam/mcpkit/pull/794/files#diff-4a2b1ae742952de7bc72050fd0f381f22c09f21632e4f9137abeff3a9a3cee54) — `TestProvider_RejectsTraversalURIs` exercises the middleware end-to-end via `httptest`.
6. [ext/skills/directory_test.go](https://github.com/panyam/mcpkit/pull/794/files#diff-58f13046926b3fb87f65f1b10f5baf0ff02d6421eb845f69e3394f3f5a16032c) — three existing tests update from `"invalid path segment"` to `"traversal segment"`; rejection still fires, just from the outer middleware layer first.
7. [examples/skills/main.go](https://github.com/panyam/mcpkit/pull/794/files#diff-5b14977a06843ef8ea751a41d80e1cd9eb927a784069536cf93b0857dc9261fc) — `--mode` → `--bundle` rename + doc-block explaining the demokit collision.
8. [examples/skills/Makefile](https://github.com/panyam/mcpkit/pull/794/files#diff-89a6fd1faf006dc8b0381a24373161a3f04d460d2fb5e59d6f5ee81968ba1ea0) — `serve-archive` / `serve-zip` targets pass `--bundle=…`.
9. [examples/skills/walkthrough.go](https://github.com/panyam/mcpkit/pull/794/files#diff-94afaa0ca3ed61f670feefe88925e3b5ecfc827cfcdb7612d48a01dd289c10e7) — `detectMode` + `unpackArchive` helpers at the bottom; the new "Detect server distribution mode" step right after the index read; existing steps branch on `detected.archive`; new "Archive mode — atomic delivery + in-process unpack" section reads + verifies + unpacks pdf-processing.
10. [examples/skills/WALKTHROUGH.md](https://github.com/panyam/mcpkit/pull/794/files#diff-f7567dfcd105e517415a8fc5aada2b08489ad36774f38681b85f5855a3638884) — regenerated via `make readme`; sanity-skim.

## Diff groups

- Production: `ext/skills/{uri,errors,provider}.go`, `examples/skills/{main.go,Makefile}`.
- Tests: `ext/skills/{uri,provider,directory}_test.go`.
- Demo: `examples/skills/walkthrough.go`, `examples/skills/WALKTHROUGH.md`.

## Decision log

- **Strict over permissive on dot-segments.** Allowing `..` that normalizes in-bounds would require a normalization pass (encoded-traversal foot-guns, ordering of decode vs normalize). Strict matches `ResolveRelative`'s existing posture (`ErrRelativeEscapesSkill` rejects bare `..` even when it would land in-bounds) and aligns with SEP-2640's `[a-z0-9-]` alphabet. Can relax later if a real caller surfaces.
- **Middleware over server-dispatcher change.** The fix could live in `server/dispatch.go::handleResourcesRead` but that puts skill-specific logic in core. `server.UseMiddleware` is the documented seam for exactly this — append a `Middleware` that intercepts `resources/{read,directory/read}` for `skill://` URIs only.
- **Tri-mounted demo deferred.** Considered mounting file / archive / zip on the same server under three URI prefixes (proposed mid-thread). The conformance fixture and per-mode digest semantics make single-mode serving the cleaner shape; the walkthrough's mode-detect step delivers the equivalent narrative without changing the SEP wire.
- **testconf-skills not run.** The fork's `conf-main` doesn't yet register `sep-2640-skills` (the upstream PR 330 work). Pre-existing condition; this PR doesn't touch the conformance suite path. Core/server/client/ext-skills unit suites all pass.

## Risk / blast radius

- **Affects:** `ext/skills` Provider behavior (now rejects traversal URIs with a precise error), `examples/skills` (binary flag rename, walkthrough output), `ParseURI` callers outside the example (rejection of `.` / `..` is a new error path).
- **Tests covering this:** `TestParseURI_Errors` (6 new cases), `TestProvider_RejectsTraversalURIs` (end-to-end), `TestDirectoryRead_Rejects*` (updated assertions).
- **Be paranoid about:** any external caller passing dot-segments to `ParseURI` deliberately. Only `ResolveRelative` does, and it already runs its own dot-segment normalization before re-calling `ParseURI` on the cleaned form, so it stays unaffected.

## Before / after

Probe against `make serve` (file mode) — was "unknown resource", now precise:

```
$ curl -s ... -d '{"jsonrpc":"2.0","id":5,"method":"resources/read","params":{"uri":"skill://pdf-processing/../../../SKILL.md"}}'
{"jsonrpc":"2.0","id":5,"error":{"code":-32602,"message":"invalid skill URI \"skill://pdf-processing/../../../SKILL.md\": skills: URI contains traversal segment (. or ..): \"..\" at index 1"}}
```

Walkthrough banner across the three modes:

```
file:    Detected mode: file
archive: Detected mode: archive (.tar.gz)
         recovered 3 files: SKILL.md, references/FORMS.md, scripts/extract.py
zip:     Detected mode: archive (.zip)
         recovered 3 files: SKILL.md, references/FORMS.md, scripts/extract.py
```

## Out of scope (deliberately deferred)

- **Adaptive-mode legacy fallback against this example** — `make serve` runs `ModeDual`, so adaptive always picks stateless. Surfacing the legacy fallback requires a `--server-wire=legacy-only` flag on the binary; out of scope here.
- **A `skills.UnpackArchive(bytes, format) fs.FS` SDK helper** — the walkthrough rolls its own ~30-line unpack via stdlib. Promoting it to `ext/skills` would make the verify-then-enumerate pattern reusable for real hosts; not strictly needed for the demo.

## Test plan

- [x] `go test ./core/... ./server/... ./client/...`
- [x] `go test ./ext/skills/...`
- [x] `make serve` → walkthrough → file-mode narrative + legitimate reads work + traversal probe rejected with precise message.
- [x] `make serve-archive` → walkthrough → archive-mode narrative + unpack-and-verify shows 3 recovered files.
- [x] `make serve-zip` → walkthrough → zip-mode narrative + unpack-and-verify shows 3 recovered files.
- [x] `make readme` regenerates `WALKTHROUGH.md` cleanly.
