### PR TITLE
ext/skills: push-based index freshness + Applier API (#795)

### DIFF
--- a/examples/skills/WALKTHROUGH.md
+++ b/examples/skills/WALKTHROUGH.md
@@ -14,6 +14,7 @@ SEP-2640 serves Agent Skills over MCP's Resources primitive: each file under a s
 - **Read a supporting file via skill:// (references/FORMS.md)** — Relative reference resolution: references/FORMS.md from inside pdf-processing/SKILL.md resolves to this full URI via the SDK helper that walks the skill root.
 - **Read a nested-prefix skill (acme/billing/refunds)** — Demonstrates that the prefix-segment routing works end-to-end. The skill name is refunds; the acme/billing/ prefix is server-chosen and is opaque to the skill's own frontmatter.
 - **Read a supporting file in the nested skill (templates/email.md)** — Same relative-reference resolution as the pdf-processing example, this time across a multi-segment prefix.
+- **Read the version, refresh, observe it bump** — The version field lives under `_meta` with the reverse-domain key `io.modelcontextprotocol.skills/version`, matching mcpkit's existing convention for extension metadata. The dual-wire story: subscribed stateful clients get the push notification; stateless clients see the same change by re-reading and comparing the version.
 - **List a directory inside a skill and recurse into a subdirectory** — Subdirectories surface with mimeType inode/directory; the client descends by issuing a second call. The SDK wraps this into a single call; the curl below shows both round trips explicitly.
 - **Wrap reads in skills.NewClient(...) and call Client.Activate** — Activate is intra-process — no wire traffic. Run with `make serve EXPORTER=stdout` + `make demo EXPORTER=stdout` to see spans.
 - **Read pdf-processing archive, verify digest, unpack, list recovered files** — Only meaningful in archive mode. In file mode the step prints the detected mode and exits — see the per-file read steps above for the equivalent file-mode story.
@@ -61,17 +62,23 @@ sequenceDiagram
     Host->>Server: resources/read uri=skill://acme/billing/refunds/templates/email.md
     Server-->>Host: text/markdown body
 
-    Note over Host,Server: Step 11: List a directory inside a skill and recurse into a subdirectory
+    Note over Host,Server: Step 11: Read the version, refresh, observe it bump
+    Host->>Server: resources/read uri=skill://index.json (capture _meta version)
+    Host->>Server: tools/call name=_demo/refresh (server calls Provider.Refresh())
+    Server-->>Host: notifications/resources/list_changed (stateful wire only)
+    Host->>Server: resources/read uri=skill://index.json (observe version bumped)
+
+    Note over Host,Server: Step 12: List a directory inside a skill and recurse into a subdirectory
     Host->>Server: resources/directory/read uri=skill://acme/billing/refunds/templates
     Server-->>Host: 2 files + 1 subdirectory (`regional`, inode/directory)
     Host->>Server: resources/directory/read uri=skill://acme/billing/refunds/templates/regional
     Server-->>Host: 1 file (eu.md)
 
-    Note over Host,Server: Step 12: Wrap reads in skills.NewClient(...) and call Client.Activate
+    Note over Host,Server: Step 13: Wrap reads in skills.NewClient(...) and call Client.Activate
     Host->>Server: resources/read via sc.ReadAndVerify (span: skills.read_and_verify)
     Server-->>Host: bytes + digest match
 
-    Note over Host,Server: Step 13: Read pdf-processing archive, verify digest, unpack, list recovered files
+    Note over Host,Server: Step 14: Read pdf-processing archive, verify digest, unpack, list recovered files
     Host->>Server: resources/read uri=skill://pdf-processing.tar.gz (or .zip)
     Server-->>Host: application/gzip OR application/zip blob
 ```
@@ -267,11 +274,48 @@ curl -s -X POST http://localhost:8080/mcp \
   | jq -r '.result.contents[0].text'
 ```
 
+### Push-based invalidation (issue #795)
+
+`skill://index.json` carries `_meta.io.modelcontextprotocol.skills/version` — a monotonic counter the server bumps whenever skill content changes. Stateful clients also receive `notifications/resources/list_changed` when the bump happens. Stateless clients (no persistent push channel) detect the change by polling the index and observing the field. Detectors that drive the bump (fsnotify, webhook, manual sweep) are pluggable; this walkthrough uses a demo-only `_demo/refresh` tool that calls `Provider.Refresh()` directly.
+
+### Step 11: Read the version, refresh, observe it bump
+
+The version field lives under `_meta` with the reverse-domain key `io.modelcontextprotocol.skills/version`, matching mcpkit's existing convention for extension metadata. The dual-wire story: subscribed stateful clients get the push notification; stateless clients see the same change by re-reading and comparing the version.
+
+#### Reproduce on the wire
+
+```bash
+# Read once, capture version.
+V1=$(curl -s -X POST http://localhost:8080/mcp \
+  -H 'Content-Type: application/json' -H 'Accept: application/json' \
+  -H "Mcp-Session-Id: $SID" \
+  -d '{"jsonrpc":"2.0","id":20,"method":"resources/read","params":{"uri":"skill://index.json"}}' \
+  | jq -r '.result.contents[0].text' \
+  | jq -r '._meta["io.modelcontextprotocol.skills/version"]')
+
+# Refresh.
+curl -s -X POST http://localhost:8080/mcp \
+  -H 'Content-Type: application/json' -H 'Accept: application/json' \
+  -H "Mcp-Session-Id: $SID" \
+  -d '{"jsonrpc":"2.0","id":21,"method":"tools/call","params":{"name":"_demo/refresh","arguments":{}}}' \
+  | jq -r '.result.content[0].text'
+
+# Read again, observe bump.
+V2=$(curl -s -X POST http://localhost:8080/mcp \
+  -H 'Content-Type: application/json' -H 'Accept: application/json' \
+  -H "Mcp-Session-Id: $SID" \
+  -d '{"jsonrpc":"2.0","id":22,"method":"resources/read","params":{"uri":"skill://index.json"}}' \
+  | jq -r '.result.contents[0].text' \
+  | jq -r '._meta["io.modelcontextprotocol.skills/version"]')
+
+echo "before=$V1 after=$V2"
+```
+
 ### SEP-2640 directoryRead — scoped subtree navigation
 
 SEP commit `2e04c48d` (2026-06-09) added `resources/directory/read` for listing a directory's direct children without enumerating the server's entire resource space. Capability-gated via `io.modelcontextprotocol/skills.directoryRead`. mcpkit's Provider auto-supports it (#781).
 
-### Step 11: List a directory inside a skill and recurse into a subdirectory
+### Step 12: List a directory inside a skill and recurse into a subdirectory
 
 Subdirectories surface with mimeType inode/directory; the client descends by issuing a second call. The SDK wraps this into a single call; the curl below shows both round trips explicitly.
 
@@ -297,7 +341,7 @@ curl -s -X POST http://localhost:8080/mcp \
 
 Fetch ≠ activation. Server `resources/read` spans now carry `mcp.skill.*` attrs (#748). Client `ext/skills.Client` emits `skills.read*` spans + `Activate(ctx, uri)` for post-cache use the wire can't see (SDK-only — no spec change).
 
-### Step 12: Wrap reads in skills.NewClient(...) and call Client.Activate
+### Step 13: Wrap reads in skills.NewClient(...) and call Client.Activate
 
 Activate is intra-process — no wire traffic. Run with `make serve EXPORTER=stdout` + `make demo EXPORTER=stdout` to see spans.
 
@@ -305,7 +349,7 @@ Activate is intra-process — no wire traffic. Run with `make serve EXPORTER=std
 
 In archive mode every skill is delivered as a single `.tar.gz` or `.zip` resource. The host hashes the archive bytes against the index digest, then unpacks in-memory to recover the post-unpack virtual namespace — same files the file-mode wire would have served piecemeal. Demonstrates pdf-processing (multi-file skill) because the unpacked listing actually shows something.
 
-### Step 13: Read pdf-processing archive, verify digest, unpack, list recovered files
+### Step 14: Read pdf-processing archive, verify digest, unpack, list recovered files
 
 Only meaningful in archive mode. In file mode the step prints the detected mode and exits — see the per-file read steps above for the equivalent file-mode story.
 

--- a/examples/skills/main.go
+++ b/examples/skills/main.go
@@ -33,11 +33,13 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
 	"os"
 	"strings"
 
 	"github.com/panyam/demokit"
+	"github.com/panyam/mcpkit/core"
 	"github.com/panyam/mcpkit/examples/common"
 	commonotel "github.com/panyam/mcpkit/examples/common/otel"
 	"github.com/panyam/mcpkit/ext/skills"
@@ -104,9 +106,37 @@ func serve() {
 		TracerProvider: tp,
 		Register: func(srv *server.Server) {
 			provider.RegisterWith(srv)
+			registerRefreshTool(srv, provider)
 		},
 	}); err != nil {
 		log.Fatalf("ListenAndServe: %v", err)
 	}
+}
+
+// refreshInput is the empty-args envelope for the _demo/refresh tool.
+// Kept as a named struct (rather than an inline struct{}) so the
+// derived JSON Schema carries a stable title.
+type refreshInput struct{}
+
+// registerRefreshTool exposes a "_demo/refresh" tool that calls
+// Provider.Refresh — the same hook a real adopter would wire to a
+// webhook, build-pipeline event, or admin endpoint. The walkthrough
+// step demonstrating issue #795's invalidation flow calls this tool
+// between two skill://index.json reads to prove the
+// _meta.io.modelcontextprotocol.skills/version field bumps. The
+// underscore-prefixed name signals it is a demo affordance, not part
+// of the SEP-2640 surface — production servers should expose Refresh
+// through whatever control plane fits their deployment.
+func registerRefreshTool(srv *server.Server, provider *skills.Provider) {
+	tool := core.TextTool[refreshInput]("_demo/refresh",
+		"Demo-only: calls skills.Provider.Refresh() to bump the index version and broadcast notifications/resources/list_changed.",
+		func(ctx core.ToolContext, _ refreshInput) (string, error) {
+			if err := provider.Refresh(); err != nil {
+				return "", err
+			}
+			return fmt.Sprintf("refreshed — provider version now %d", provider.Version()), nil
+		},
+	)
+	srv.RegisterTool(tool.ToolDef, tool.Handler)
 }
 

--- a/examples/skills/walkthrough.go
+++ b/examples/skills/walkthrough.go
@@ -495,6 +495,84 @@ body, _ := c.ReadResource(target.String())`),
 			return nil
 		})
 
+	demo.Section("Push-based invalidation (issue #795)",
+		"`skill://index.json` carries `_meta.io.modelcontextprotocol.skills/version` — a monotonic counter the server bumps whenever skill content changes. Stateful clients also receive `notifications/resources/list_changed` when the bump happens. Stateless clients (no persistent push channel) detect the change by polling the index and observing the field. Detectors that drive the bump (fsnotify, webhook, manual sweep) are pluggable; this walkthrough uses a demo-only `_demo/refresh` tool that calls `Provider.Refresh()` directly.",
+	)
+
+	demo.Step("Read the version, refresh, observe it bump").
+		Arrow("Host", "Server", "resources/read uri=skill://index.json (capture _meta version)").
+		Arrow("Host", "Server", "tools/call name=_demo/refresh (server calls Provider.Refresh())").
+		DashedArrow("Server", "Host", "notifications/resources/list_changed (stateful wire only)").
+		Arrow("Host", "Server", "resources/read uri=skill://index.json (observe version bumped)").
+		Note("The version field lives under `_meta` with the reverse-domain key `io.modelcontextprotocol.skills/version`, matching mcpkit's existing convention for extension metadata. The dual-wire story: subscribed stateful clients get the push notification; stateless clients see the same change by re-reading and comparing the version.").
+		VerbatimVariants("Reproduce on the wire",
+			demokit.MakeVariant("curl", "bash", `# Read once, capture version.
+V1=$(curl -s -X POST http://localhost:8080/mcp \
+  -H 'Content-Type: application/json' -H 'Accept: application/json' \
+  -H "Mcp-Session-Id: $SID" \
+  -d '{"jsonrpc":"2.0","id":20,"method":"resources/read","params":{"uri":"skill://index.json"}}' \
+  | jq -r '.result.contents[0].text' \
+  | jq -r '._meta["io.modelcontextprotocol.skills/version"]')
+
+# Refresh.
+curl -s -X POST http://localhost:8080/mcp \
+  -H 'Content-Type: application/json' -H 'Accept: application/json' \
+  -H "Mcp-Session-Id: $SID" \
+  -d '{"jsonrpc":"2.0","id":21,"method":"tools/call","params":{"name":"_demo/refresh","arguments":{}}}' \
+  | jq -r '.result.content[0].text'
+
+# Read again, observe bump.
+V2=$(curl -s -X POST http://localhost:8080/mcp \
+  -H 'Content-Type: application/json' -H 'Accept: application/json' \
+  -H "Mcp-Session-Id: $SID" \
+  -d '{"jsonrpc":"2.0","id":22,"method":"resources/read","params":{"uri":"skill://index.json"}}' \
+  | jq -r '.result.contents[0].text' \
+  | jq -r '._meta["io.modelcontextprotocol.skills/version"]')
+
+echo "before=$V1 after=$V2"`).Default(),
+			demokit.MakeVariant("go", "go", `// Read once, capture version.
+body, _ := c.ReadResource(skills.IndexURI)
+var idx struct {
+    Meta map[string]any ` + "`" + `json:"_meta"` + "`" + `
+}
+json.Unmarshal([]byte(body), &idx)
+before, _ := idx.Meta["io.modelcontextprotocol.skills/version"].(float64)
+
+// Trigger Refresh via the demo tool. Production deployments would call
+// Provider.Refresh() directly from their own admin endpoint / webhook
+// handler / fsnotify goroutine (see follow-up tickets #799 + the
+// pushdown-to-templar issue).
+c.CallTool("_demo/refresh", map[string]any{})
+
+// Read again, observe bump.
+body, _ = c.ReadResource(skills.IndexURI)
+json.Unmarshal([]byte(body), &idx)
+after, _ := idx.Meta["io.modelcontextprotocol.skills/version"].(float64)
+fmt.Printf("before=%d after=%d\n", uint64(before), uint64(after))`),
+		).
+		Run(func(ctx demokit.StepContext) *demokit.StepResult {
+			if c == nil {
+				return nil
+			}
+			before := readIndexVersion(c)
+			fmt.Printf("    before refresh: version = %d\n", before)
+
+			if _, err := c.ToolCall("_demo/refresh", map[string]any{}); err != nil {
+				fmt.Printf("    ERROR calling _demo/refresh: %v\n", err)
+				return nil
+			}
+			fmt.Printf("    called _demo/refresh — server bumped Provider.Version()\n")
+
+			after := readIndexVersion(c)
+			fmt.Printf("    after refresh:  version = %d\n", after)
+			if after > before {
+				fmt.Printf("    version bumped by %d — stateful subscribers also received notifications/resources/list_changed\n", after-before)
+			} else {
+				fmt.Printf("    WARNING: version did not advance (%d → %d)\n", before, after)
+			}
+			return nil
+		})
+
 	demo.Section("SEP-2640 directoryRead — scoped subtree navigation",
 		"SEP commit `2e04c48d` (2026-06-09) added `resources/directory/read` for listing a directory's direct children without enumerating the server's entire resource space. Capability-gated via `io.modelcontextprotocol/skills.directoryRead`. mcpkit's Provider auto-supports it (#781).",
 	)
@@ -722,6 +800,32 @@ func marker(mimeType string) string {
 		return "dir/"
 	}
 	return "file"
+}
+
+// readIndexVersion fetches skill://index.json and returns the
+// _meta.io.modelcontextprotocol.skills/version counter (issue #795).
+// Returns 0 when the field is absent — the field is opt-in metadata,
+// not a SEP requirement, so older / non-mcpkit servers will lack it.
+func readIndexVersion(c *client.Client) uint64 {
+	body, err := c.ReadResource(skills.IndexURI)
+	if err != nil {
+		return 0
+	}
+	var idx struct {
+		Meta map[string]any `json:"_meta"`
+	}
+	if err := json.Unmarshal([]byte(body), &idx); err != nil {
+		return 0
+	}
+	v, ok := idx.Meta["io.modelcontextprotocol.skills/version"]
+	if !ok {
+		return 0
+	}
+	f, ok := v.(float64)
+	if !ok {
+		return 0
+	}
+	return uint64(f)
 }
 
 // modeInfo captures the distribution shape detected from the server's

--- a/ext/skills/decoder.go
+++ b/ext/skills/decoder.go
@@ -1,0 +1,68 @@
+package skills
+
+import (
+	"encoding/json"
+)
+
+// DecodeListChangedNotification extracts the optional ext/skills
+// PathsChangedPayload from a notifications/resources/list_changed
+// params object. Returns (payload, true) when the params carry the
+// payload under _meta[MetaKeyPathsChanged]; returns (zero, false) for
+// everything else — bare list_changed notifications, malformed
+// payloads, or notifications from non-mcpkit servers.
+//
+// The params argument accepts anything the standard
+// client.WithNotificationCallback produces (map[string]any from
+// generic unmarshal, json.RawMessage from custom transports). Internal
+// JSON round-trip handles both shapes without forcing callers to
+// reason about types.
+//
+// Typical use from a client.WithNotificationCallback handler:
+//
+//	client.WithNotificationCallback(func(method string, params any) {
+//	    if method != "notifications/resources/list_changed" {
+//	        return
+//	    }
+//	    payload, ok := skills.DecodeListChangedNotification(params)
+//	    if !ok {
+//	        // Bare list_changed from a non-mcpkit server, or empty
+//	        // params — re-read everything.
+//	        return
+//	    }
+//	    for path, entry := range payload.Paths {
+//	        switch entry.Action {
+//	        case skills.ChangeActionDeleted:
+//	            // prune local cache entry for `path`
+//	        default:
+//	            // re-fetch and re-verify digest
+//	        }
+//	    }
+//	})
+//
+// Subscribers that compare entry.Digest against a cached digest can
+// skip re-fetches entirely when the content already matches what they
+// have; treat absent Digest as "fetch to find out."
+func DecodeListChangedNotification(params any) (PathsChangedPayload, bool) {
+	if params == nil {
+		return PathsChangedPayload{}, false
+	}
+	raw, err := json.Marshal(params)
+	if err != nil {
+		return PathsChangedPayload{}, false
+	}
+	var envelope struct {
+		Meta map[string]json.RawMessage `json:"_meta"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return PathsChangedPayload{}, false
+	}
+	payloadRaw, ok := envelope.Meta[MetaKeyPathsChanged]
+	if !ok {
+		return PathsChangedPayload{}, false
+	}
+	var payload PathsChangedPayload
+	if err := json.Unmarshal(payloadRaw, &payload); err != nil {
+		return PathsChangedPayload{}, false
+	}
+	return payload, true
+}

--- a/ext/skills/indexer.go
+++ b/ext/skills/indexer.go
@@ -48,6 +48,7 @@ type cacheEntry struct {
 	index   Index
 	builtAt time.Time
 	mtimes  map[string]time.Time // skill dir path → SKILL.md mtime at build time
+	version uint64               // Provider.Version() at the time this entry was built
 	// noMtime is true when any skill's SKILL.md reported zero ModTime at
 	// build time. While noMtime is true the cache falls back to TTL-only
 	// invalidation; mtime comparison is skipped.
@@ -113,21 +114,47 @@ func (i *Indexer) Index() (Index, error) {
 		return i.cached.index, nil
 	}
 
+	version := i.provider.Version()
 	idx, mtimes, noMtime, err := i.build()
 	if err != nil {
 		return Index{}, err
 	}
+	if idx.Meta == nil {
+		idx.Meta = map[string]any{}
+	}
+	idx.Meta[MetaPrefix+"version"] = version
 	i.cached = &cacheEntry{
 		index:   idx,
 		builtAt: time.Now(),
 		mtimes:  mtimes,
+		version: version,
 		noMtime: noMtime,
 	}
 	return idx, nil
 }
 
+// Invalidate marks the cached index entry stale so the next Index()
+// call rebuilds. Provider.NotifyChanged calls this when the version
+// counter bumps; tests can use it to drive cache regeneration
+// deterministically without waiting for TTL or mtime changes.
+//
+// Safe to call before any cache has been built (no-op) and from any
+// goroutine.
+func (i *Indexer) Invalidate() {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.cached = nil
+}
+
 func (i *Indexer) isFresh() bool {
 	if i.cached == nil {
+		return false
+	}
+	// Version is the explicit invalidation signal — any NotifyChanged
+	// call bumps it past the cached value, so a mismatch trumps the
+	// TTL / mtime paths below. The two slower checks remain as fallback
+	// invalidation drivers for adopters who never call NotifyChanged.
+	if i.provider.Version() != i.cached.version {
 		return false
 	}
 	if i.cfg.ttl > 0 && time.Since(i.cached.builtAt) > i.cfg.ttl {

--- a/ext/skills/provider.go
+++ b/ext/skills/provider.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/panyam/mcpkit/core"
 	"github.com/panyam/mcpkit/server"
@@ -37,6 +38,12 @@ type Provider struct {
 	version   uint64
 	srv       *server.Server
 	indexer   *Indexer
+
+	notifyMu      sync.Mutex
+	pendingPaths  map[string]PathChangeEntry
+	flushTimer    *time.Timer
+	lastBroadcast time.Time
+	closed        bool
 }
 
 type skillEntry struct {
@@ -311,50 +318,210 @@ func (p *Provider) Version() uint64 {
 	return p.version
 }
 
-// NotifyChanged is the Applier entry point: pass the relative fs.FS
-// paths that changed and the Provider bumps its version counter,
-// invalidates the Indexer cache (so the next skill://index.json read
-// rebuilds), and — if RegisterWith has bound a server — broadcasts a
-// notifications/resources/list_changed event to subscribed sessions on
-// the stateful wire.
+// NotifyChanged is the simple Applier entry point: every path in the
+// argument list is treated as ChangeActionModified with the call-time
+// timestamp. Sugar over NotifyChangedEvents for Detectors that only
+// know "this path is dirty"; Detectors with richer signals (fsnotify
+// distinguishing CREATE / WRITE / REMOVE, webhooks carrying mtime)
+// should call NotifyChangedEvents directly.
 //
-// For #795 scope the paths argument is advisory only — any call (with
-// any path list, empty included) bumps the global counter once and
-// invalidates the whole index cache. Issues #796 (sub-indexes) and
-// #798 (per-artifact pack cache) will refine this to per-path
-// invalidation via a dependency DAG, keying off the same NotifyChanged
-// entry point so detector implementations don't change.
-//
-// Stateless wire honesty: this call alone cannot push to stateless
-// clients (no persistent channel exists by construction). Stateless
-// clients learn of changes by polling skill://index.json and observing
-// the _meta.io.modelcontextprotocol.skills/version field bump.
-//
-// Safe to call before RegisterWith (the broadcast is a no-op) and from
-// any goroutine.
+// See NotifyChangedEvents for coalesce / throttle / dedup semantics
+// and dual-wire delivery behavior.
 func (p *Provider) NotifyChanged(paths ...string) error {
+	events := make([]PathChange, len(paths))
+	for i, ph := range paths {
+		events[i] = PathChange{Path: ph}
+	}
+	return p.NotifyChangedEvents(events...)
+}
+
+// NotifyChangedEvents is the typed Applier entry point. The Provider
+// bumps its version counter, invalidates the Indexer cache so the
+// next skill://index.json read rebuilds, accumulates the events into a
+// deduplicated pending set, and — subject to the coalesce window and
+// throttle interval — broadcasts a notifications/resources/list_changed
+// event to subscribed sessions on the stateful wire.
+//
+// # Dedup semantics
+//
+// Pending paths are keyed by Path; multiple events for the same path
+// within a coalesce window collapse to one entry under latest-wins
+// rules (action, timestamp, and digest from the most recent event
+// supersede earlier ones). Five NotifyChangedEvents calls naming the
+// same path produce one entry in the broadcast payload.
+//
+// # Flow control
+//
+// WithCoalesceWindow(d): when set, NotifyChangedEvents schedules a
+// trailing-edge flush at now+d (resetting the timer on each call).
+// When d is zero, every call flushes immediately.
+//
+// WithMinBroadcastInterval(d): when set, a flush arriving within d of
+// the last broadcast defers to last+d so subscribers never see two
+// broadcasts closer than d apart.
+//
+// The version counter bump and index cache invalidation happen
+// immediately on every call regardless of coalesce/throttle — only
+// the broadcast is deferred. Polling stateless clients see the bumped
+// _meta version on the next index read without waiting for the
+// coalesce window.
+//
+// # Dual-wire
+//
+// Broadcast targets the stateful/streamable-HTTP wire. Stateless
+// clients (SEP-2575) have no persistent push channel; they detect
+// changes by polling skill://index.json and observing
+// _meta.io.modelcontextprotocol.skills/version.
+//
+// # Lifecycle
+//
+// Safe to call before RegisterWith (the broadcast is a no-op until a
+// server is bound) and from any goroutine. After Close(), version and
+// index invalidation still fire but broadcasts are suppressed.
+func (p *Provider) NotifyChangedEvents(events ...PathChange) error {
+	now := time.Now()
+
 	p.versionMu.Lock()
 	p.version++
 	srv := p.srv
 	idx := p.indexer
 	p.versionMu.Unlock()
 
+	p.notifyMu.Lock()
+	if p.closed {
+		p.notifyMu.Unlock()
+		if idx != nil {
+			idx.Invalidate()
+		}
+		return nil
+	}
+	if p.pendingPaths == nil {
+		p.pendingPaths = make(map[string]PathChangeEntry, len(events))
+	}
+	for _, ev := range events {
+		if ev.Path == "" {
+			continue
+		}
+		entry := PathChangeEntry{
+			Action:    ev.Action,
+			Timestamp: ev.Timestamp,
+			Digest:    ev.Digest,
+		}
+		if entry.Action == "" {
+			entry.Action = ChangeActionModified
+		}
+		if entry.Timestamp.IsZero() {
+			entry.Timestamp = now
+		}
+		p.pendingPaths[ev.Path] = entry
+	}
+	coalesce := p.cfg.coalesceWindow
+	p.notifyMu.Unlock()
+
 	if idx != nil {
 		idx.Invalidate()
 	}
-	if srv != nil {
-		srv.Broadcast(context.Background(), "notifications/resources/list_changed", nil)
+	if srv == nil {
+		return nil
 	}
+
+	if coalesce <= 0 {
+		p.flush()
+		return nil
+	}
+	p.notifyMu.Lock()
+	p.scheduleFlushLocked(coalesce)
+	p.notifyMu.Unlock()
 	return nil
 }
 
-// Refresh is sugar for NotifyChanged() with no paths — signals "the
-// underlying content changed in some way; recompute everything." Use
-// from adopter-driven hot-reload hooks (webhook handler, build
+// Refresh signals "something in the underlying content changed but I
+// don't know what." Bumps the version counter, invalidates the index
+// cache, and (subject to coalesce + throttle) broadcasts an empty-paths
+// notifications/resources/list_changed event. Subscribers seeing an
+// empty Paths map should re-read everything; the Version bump remains
+// the load-bearing identity.
+//
+// Use from adopter-driven hot-reload hooks (webhook handler, build
 // pipeline, manual sweep) when the caller doesn't have a precise
-// changed-path list.
+// changed-path list. Detectors that do have a path list should call
+// NotifyChanged / NotifyChangedEvents instead so subscribers get the
+// richer payload.
 func (p *Provider) Refresh() error {
-	return p.NotifyChanged()
+	return p.NotifyChangedEvents()
+}
+
+// Close stops any pending broadcast timer and prevents future
+// broadcasts. Idempotent. After Close, the version counter still
+// bumps on NotifyChanged calls and the index cache still invalidates
+// (polling clients continue to see fresh state), but the stateful-wire
+// broadcast goroutine is dormant. Tests and adopters that own the
+// Provider's lifecycle should call Close on shutdown.
+func (p *Provider) Close() error {
+	p.notifyMu.Lock()
+	defer p.notifyMu.Unlock()
+	if p.flushTimer != nil {
+		p.flushTimer.Stop()
+		p.flushTimer = nil
+	}
+	p.closed = true
+	return nil
+}
+
+// scheduleFlushLocked sets or resets the flush timer to fire after d.
+// Caller must hold p.notifyMu.
+func (p *Provider) scheduleFlushLocked(d time.Duration) {
+	if p.flushTimer != nil {
+		p.flushTimer.Reset(d)
+		return
+	}
+	p.flushTimer = time.AfterFunc(d, p.flush)
+}
+
+// flush snapshots the pending path set and broadcasts
+// notifications/resources/list_changed with the typed PathsChangedPayload
+// under params._meta[MetaKeyPathsChanged]. Honors WithMinBroadcastInterval
+// by deferring to last+interval when the previous broadcast was too
+// recent.
+func (p *Provider) flush() {
+	p.notifyMu.Lock()
+	if p.closed {
+		p.notifyMu.Unlock()
+		return
+	}
+	now := time.Now()
+	if p.cfg.minBroadcastInterval > 0 {
+		elapsed := now.Sub(p.lastBroadcast)
+		if !p.lastBroadcast.IsZero() && elapsed < p.cfg.minBroadcastInterval {
+			p.scheduleFlushLocked(p.cfg.minBroadcastInterval - elapsed)
+			p.notifyMu.Unlock()
+			return
+		}
+	}
+	pending := p.pendingPaths
+	p.pendingPaths = nil
+	p.lastBroadcast = now
+	srv := p.srv
+	p.notifyMu.Unlock()
+
+	if srv == nil {
+		return
+	}
+
+	p.versionMu.RLock()
+	version := p.version
+	p.versionMu.RUnlock()
+
+	payload := PathsChangedPayload{
+		Paths:   pending,
+		Version: version,
+	}
+	params := map[string]any{
+		"_meta": map[string]any{
+			MetaKeyPathsChanged: payload,
+		},
+	}
+	srv.Broadcast(context.Background(), "notifications/resources/list_changed", params)
 }
 
 // skillURIValidationMiddleware short-circuits resources/read and

--- a/ext/skills/provider.go
+++ b/ext/skills/provider.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/panyam/mcpkit/core"
 	"github.com/panyam/mcpkit/server"
@@ -31,6 +32,11 @@ type Provider struct {
 	skills    []*skillEntry
 	resources []*resourceEntry
 	byURI     map[string]*resourceEntry
+
+	versionMu sync.RWMutex
+	version   uint64
+	srv       *server.Server
+	indexer   *Indexer
 }
 
 type skillEntry struct {
@@ -262,6 +268,10 @@ func (p *Provider) Resources() []core.ResourceDef {
 // WithoutIndex to suppress registration entirely (when, for example,
 // the caller wants to construct and register a custom Indexer).
 func (p *Provider) RegisterWith(srv *server.Server) {
+	p.versionMu.Lock()
+	p.srv = srv
+	p.versionMu.Unlock()
+
 	sort.SliceStable(p.resources, func(i, j int) bool {
 		return p.resources[i].URI < p.resources[j].URI
 	})
@@ -277,9 +287,74 @@ func (p *Provider) RegisterWith(srv *server.Server) {
 		if p.cfg.indexCacheTTL > 0 {
 			opts = append(opts, WithIndexerCacheTTL(p.cfg.indexCacheTTL))
 		}
-		NewIndexer(p, opts...).RegisterWith(srv)
+		idx := NewIndexer(p, opts...)
+		p.versionMu.Lock()
+		p.indexer = idx
+		p.versionMu.Unlock()
+		idx.RegisterWith(srv)
 	}
 	srv.UseMiddleware(skillURIValidationMiddleware)
+}
+
+// Version returns the Provider's monotonic invalidation counter. The
+// counter starts at zero and increments on every NotifyChanged /
+// Refresh call. Consumers use Version() to drive cache freshness — the
+// Indexer compares the counter at cache-build time against the current
+// value and rebuilds on mismatch.
+//
+// Forward-compatible with the per-artifact counters proposed in #798:
+// when those land, the global counter remains as the ceiling that any
+// per-artifact counter increments alongside.
+func (p *Provider) Version() uint64 {
+	p.versionMu.RLock()
+	defer p.versionMu.RUnlock()
+	return p.version
+}
+
+// NotifyChanged is the Applier entry point: pass the relative fs.FS
+// paths that changed and the Provider bumps its version counter,
+// invalidates the Indexer cache (so the next skill://index.json read
+// rebuilds), and — if RegisterWith has bound a server — broadcasts a
+// notifications/resources/list_changed event to subscribed sessions on
+// the stateful wire.
+//
+// For #795 scope the paths argument is advisory only — any call (with
+// any path list, empty included) bumps the global counter once and
+// invalidates the whole index cache. Issues #796 (sub-indexes) and
+// #798 (per-artifact pack cache) will refine this to per-path
+// invalidation via a dependency DAG, keying off the same NotifyChanged
+// entry point so detector implementations don't change.
+//
+// Stateless wire honesty: this call alone cannot push to stateless
+// clients (no persistent channel exists by construction). Stateless
+// clients learn of changes by polling skill://index.json and observing
+// the _meta.io.modelcontextprotocol.skills/version field bump.
+//
+// Safe to call before RegisterWith (the broadcast is a no-op) and from
+// any goroutine.
+func (p *Provider) NotifyChanged(paths ...string) error {
+	p.versionMu.Lock()
+	p.version++
+	srv := p.srv
+	idx := p.indexer
+	p.versionMu.Unlock()
+
+	if idx != nil {
+		idx.Invalidate()
+	}
+	if srv != nil {
+		srv.Broadcast(context.Background(), "notifications/resources/list_changed", nil)
+	}
+	return nil
+}
+
+// Refresh is sugar for NotifyChanged() with no paths — signals "the
+// underlying content changed in some way; recompute everything." Use
+// from adopter-driven hot-reload hooks (webhook handler, build
+// pipeline, manual sweep) when the caller doesn't have a precise
+// changed-path list.
+func (p *Provider) Refresh() error {
+	return p.NotifyChanged()
 }
 
 // skillURIValidationMiddleware short-circuits resources/read and

--- a/ext/skills/provider_options.go
+++ b/ext/skills/provider_options.go
@@ -19,6 +19,8 @@ type providerConfig struct {
 	indexCacheTTL        time.Duration
 	archiveMode          ArchiveFormat
 	archiveMaxBytes      int64
+	coalesceWindow       time.Duration
+	minBroadcastInterval time.Duration
 }
 
 // WithFS supplies the io/fs.FS that the Provider walks for skills. The
@@ -114,6 +116,44 @@ func WithArchiveMode(format ArchiveFormat) ProviderOption {
 func WithArchiveMaxBytes(n int64) ProviderOption {
 	return func(c *providerConfig) {
 		c.archiveMaxBytes = n
+	}
+}
+
+// WithCoalesceWindow groups NotifyChanged calls that land within d of
+// each other into a single version bump + broadcast. Trailing-edge: the
+// timer resets on each call, so a sustained burst defers the flush
+// until the burst settles. Set to 0 (default) to disable coalescing —
+// every NotifyChanged call flushes immediately (subject to throttle).
+//
+// Within the window, paths are accumulated into a deduplicated set;
+// five NotifyChanged calls naming the same path produce one entry, one
+// version bump, and one broadcast. The set is reserved for the
+// per-path dependency DAG that lands with #796 (sub-indexes) and #798
+// (pack cache); today it serves only as the dedup key.
+//
+// Recommended: 100ms–500ms for fsnotify-style Detectors (editor saves
+// typically fire 3–5 events in <50ms); 0 for explicit-call Detectors
+// like admin endpoints where each call is intentional and unique.
+func WithCoalesceWindow(d time.Duration) ProviderOption {
+	return func(c *providerConfig) {
+		c.coalesceWindow = d
+	}
+}
+
+// WithMinBroadcastInterval enforces a minimum gap between consecutive
+// broadcasts. A flush arriving within d of the last broadcast queues a
+// single trailing broadcast at last+d. Set to 0 (default) to disable
+// throttling.
+//
+// Composes with WithCoalesceWindow: coalesce runs first (group events
+// into one broadcast intent); throttle enforces the minimum-interval
+// contract on the actual broadcast. The version counter and the index
+// cache invalidation still fire on the coalesce boundary so polling
+// stateless clients see changes promptly — only the stateful-wire
+// notification rate is throttled.
+func WithMinBroadcastInterval(d time.Duration) ProviderOption {
+	return func(c *providerConfig) {
+		c.minBroadcastInterval = d
 	}
 }
 

--- a/ext/skills/provider_test.go
+++ b/ext/skills/provider_test.go
@@ -1,13 +1,18 @@
 package skills_test
 
 import (
+	"encoding/json"
 	"errors"
+	"maps"
 	"net/http/httptest"
 	"os"
+	"slices"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"testing/fstest"
+	"time"
 
 	"github.com/panyam/mcpkit/client"
 	"github.com/panyam/mcpkit/core"
@@ -374,6 +379,202 @@ func TestProvider_RejectsTraversalURIs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestProvider_VersionStartsZero(t *testing.T) {
+	p, err := skills.NewProvider(skills.WithDirectory("testdata/valid"))
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	if got := p.Version(); got != 0 {
+		t.Errorf("Version() = %d, want 0 on a freshly constructed Provider", got)
+	}
+}
+
+func TestProvider_NotifyChanged_BumpsVersion(t *testing.T) {
+	p, err := skills.NewProvider(skills.WithDirectory("testdata/valid"))
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	if err := p.NotifyChanged("git-workflow/SKILL.md"); err != nil {
+		t.Fatalf("NotifyChanged: %v", err)
+	}
+	if got := p.Version(); got != 1 {
+		t.Errorf("Version() = %d after one NotifyChanged, want 1", got)
+	}
+	if err := p.NotifyChanged(); err != nil {
+		t.Fatalf("NotifyChanged (no paths): %v", err)
+	}
+	if got := p.Version(); got != 2 {
+		t.Errorf("Version() = %d after two NotifyChanged calls, want 2", got)
+	}
+}
+
+func TestProvider_Refresh_BumpsVersion(t *testing.T) {
+	p, err := skills.NewProvider(skills.WithDirectory("testdata/valid"))
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	if err := p.Refresh(); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if got := p.Version(); got != 1 {
+		t.Errorf("Version() = %d after Refresh, want 1", got)
+	}
+}
+
+func TestProvider_NotifyChanged_InvalidatesIndexCache(t *testing.T) {
+	srv := server.NewServer(core.ServerInfo{Name: "skills-test", Version: "0.0.1"})
+
+	p, err := skills.NewProvider(skills.WithDirectory("testdata/valid"))
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	p.RegisterWith(srv)
+
+	handler := srv.Handler(server.WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "skills-test-client", Version: "0.0.1"})
+	if err := c.Connect(); err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+
+	first, err := c.ReadResource(skills.IndexURI)
+	if err != nil {
+		t.Fatalf("ReadResource initial: %v", err)
+	}
+	v0 := indexVersion(t, first)
+	if v0 != 0 {
+		t.Errorf("initial index version = %d, want 0", v0)
+	}
+
+	if err := p.Refresh(); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+
+	second, err := c.ReadResource(skills.IndexURI)
+	if err != nil {
+		t.Fatalf("ReadResource after Refresh: %v", err)
+	}
+	v1 := indexVersion(t, second)
+	if v1 != 1 {
+		t.Errorf("post-Refresh index version = %d, want 1", v1)
+	}
+}
+
+func TestIndex_VersionUnderMeta(t *testing.T) {
+	srv := server.NewServer(core.ServerInfo{Name: "skills-test", Version: "0.0.1"})
+
+	p, err := skills.NewProvider(skills.WithDirectory("testdata/valid"))
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	p.RegisterWith(srv)
+
+	handler := srv.Handler(server.WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "skills-test-client", Version: "0.0.1"})
+	if err := c.Connect(); err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+
+	body, err := c.ReadResource(skills.IndexURI)
+	if err != nil {
+		t.Fatalf("ReadResource: %v", err)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(body), &raw); err != nil {
+		t.Fatalf("unmarshal index: %v", err)
+	}
+	meta, ok := raw["_meta"].(map[string]any)
+	if !ok {
+		t.Fatalf("_meta missing or wrong type: %T (full body: %s)", raw["_meta"], body)
+	}
+	const wantKey = "io.modelcontextprotocol.skills/version"
+	v, ok := meta[wantKey]
+	if !ok {
+		t.Fatalf("_meta does not carry %q (keys: %v)", wantKey, slices.Sorted(maps.Keys(meta)))
+	}
+	// JSON numbers unmarshal as float64 — accept any numeric type.
+	if _, ok := v.(float64); !ok {
+		t.Errorf("_meta[%q] = %v (type %T), want numeric", wantKey, v, v)
+	}
+}
+
+func TestProvider_NotifyChanged_BroadcastsListChanged(t *testing.T) {
+	srv := server.NewServer(core.ServerInfo{Name: "skills-test", Version: "0.0.1"})
+
+	p, err := skills.NewProvider(skills.WithDirectory("testdata/valid"))
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	p.RegisterWith(srv)
+
+	handler := srv.Handler(server.WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	var got atomic.Int32
+	gotMethod := make(chan string, 4)
+	c := client.NewClient(ts.URL+"/mcp",
+		core.ClientInfo{Name: "skills-test-client", Version: "0.0.1"},
+		client.WithGetSSEStream(),
+		client.WithNotificationCallback(func(method string, params any) {
+			if method == "notifications/resources/list_changed" {
+				got.Add(1)
+				select {
+				case gotMethod <- method:
+				default:
+				}
+			}
+		}),
+	)
+	if err := c.Connect(); err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+
+	// Give the background GET SSE stream a beat to attach before bumping;
+	// without this the broadcast can race past an unsubscribed session.
+	time.Sleep(100 * time.Millisecond)
+
+	if err := p.Refresh(); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+
+	select {
+	case <-gotMethod:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("did not receive notifications/resources/list_changed within deadline (got count=%d)", got.Load())
+	}
+}
+
+func indexVersion(t *testing.T, body string) uint64 {
+	t.Helper()
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(body), &raw); err != nil {
+		t.Fatalf("unmarshal index: %v", err)
+	}
+	meta, _ := raw["_meta"].(map[string]any)
+	if meta == nil {
+		return 0
+	}
+	v, ok := meta["io.modelcontextprotocol.skills/version"]
+	if !ok {
+		return 0
+	}
+	f, ok := v.(float64)
+	if !ok {
+		t.Fatalf("version field has unexpected type %T", v)
+	}
+	return uint64(f)
 }
 
 func urisOf(defs []core.ResourceDef) []string {

--- a/ext/skills/provider_test.go
+++ b/ext/skills/provider_test.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"testing/fstest"
@@ -554,6 +555,314 @@ func TestProvider_NotifyChanged_BroadcastsListChanged(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatalf("did not receive notifications/resources/list_changed within deadline (got count=%d)", got.Load())
 	}
+}
+
+func TestProvider_NotifyChangedEvents_PayloadShape(t *testing.T) {
+	srv, c, p := bootBroadcastTest(t)
+
+	payloads := make(chan skills.PathsChangedPayload, 4)
+	listenForPayloads(t, c, payloads)
+
+	now := time.Now()
+	if err := p.NotifyChangedEvents(
+		skills.PathChange{Path: "git-workflow/SKILL.md", Action: skills.ChangeActionModified, Timestamp: now, Digest: "sha256:abc"},
+		skills.PathChange{Path: "new-skill/SKILL.md", Action: skills.ChangeActionCreated, Timestamp: now},
+		skills.PathChange{Path: "gone-skill/SKILL.md", Action: skills.ChangeActionDeleted, Timestamp: now},
+	); err != nil {
+		t.Fatalf("NotifyChangedEvents: %v", err)
+	}
+
+	select {
+	case payload := <-payloads:
+		if got := len(payload.Paths); got != 3 {
+			t.Fatalf("payload.Paths = %d entries, want 3 (%+v)", got, payload.Paths)
+		}
+		mod := payload.Paths["git-workflow/SKILL.md"]
+		if mod.Action != skills.ChangeActionModified {
+			t.Errorf("git-workflow action = %q, want %q", mod.Action, skills.ChangeActionModified)
+		}
+		if mod.Digest != "sha256:abc" {
+			t.Errorf("git-workflow digest = %q, want sha256:abc", mod.Digest)
+		}
+		created := payload.Paths["new-skill/SKILL.md"]
+		if created.Action != skills.ChangeActionCreated {
+			t.Errorf("new-skill action = %q, want %q", created.Action, skills.ChangeActionCreated)
+		}
+		deleted := payload.Paths["gone-skill/SKILL.md"]
+		if deleted.Action != skills.ChangeActionDeleted {
+			t.Errorf("gone-skill action = %q, want %q", deleted.Action, skills.ChangeActionDeleted)
+		}
+		if payload.Version == 0 {
+			t.Errorf("payload.Version = 0, want positive")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("no payload received within deadline")
+	}
+	_ = srv
+}
+
+func TestProvider_NotifyChanged_DedupesByPath(t *testing.T) {
+	srv, c, p := bootBroadcastTest(t, skills.WithCoalesceWindow(150*time.Millisecond))
+
+	payloads := make(chan skills.PathsChangedPayload, 4)
+	listenForPayloads(t, c, payloads)
+
+	for i := 0; i < 5; i++ {
+		if err := p.NotifyChanged("foo/SKILL.md"); err != nil {
+			t.Fatalf("NotifyChanged: %v", err)
+		}
+	}
+
+	select {
+	case payload := <-payloads:
+		if got := len(payload.Paths); got != 1 {
+			t.Errorf("after 5 dup NotifyChanged calls, payload.Paths = %d entries, want 1 (%+v)", got, payload.Paths)
+		}
+		if _, ok := payload.Paths["foo/SKILL.md"]; !ok {
+			t.Errorf("payload missing foo/SKILL.md (paths: %v)", payload.Paths)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("no payload received within deadline")
+	}
+
+	select {
+	case extra := <-payloads:
+		t.Errorf("got unexpected second broadcast: %+v", extra)
+	case <-time.After(250 * time.Millisecond):
+	}
+	_ = srv
+}
+
+func TestProvider_LatestWinsForRepeatedPath(t *testing.T) {
+	srv, c, p := bootBroadcastTest(t, skills.WithCoalesceWindow(150*time.Millisecond))
+
+	payloads := make(chan skills.PathsChangedPayload, 4)
+	listenForPayloads(t, c, payloads)
+
+	if err := p.NotifyChangedEvents(skills.PathChange{Path: "foo/SKILL.md", Action: skills.ChangeActionCreated}); err != nil {
+		t.Fatal(err)
+	}
+	if err := p.NotifyChangedEvents(skills.PathChange{Path: "foo/SKILL.md", Action: skills.ChangeActionModified}); err != nil {
+		t.Fatal(err)
+	}
+	if err := p.NotifyChangedEvents(skills.PathChange{Path: "foo/SKILL.md", Action: skills.ChangeActionDeleted, Digest: "sha256:latest"}); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case payload := <-payloads:
+		entry, ok := payload.Paths["foo/SKILL.md"]
+		if !ok {
+			t.Fatalf("foo/SKILL.md missing from payload (%v)", payload.Paths)
+		}
+		if entry.Action != skills.ChangeActionDeleted {
+			t.Errorf("action = %q, want %q (latest-wins)", entry.Action, skills.ChangeActionDeleted)
+		}
+		if entry.Digest != "sha256:latest" {
+			t.Errorf("digest = %q, want sha256:latest", entry.Digest)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("no payload received within deadline")
+	}
+	_ = srv
+}
+
+func TestProvider_Coalesce_BatchesIntoOneBroadcast(t *testing.T) {
+	srv, c, p := bootBroadcastTest(t, skills.WithCoalesceWindow(200*time.Millisecond))
+
+	count := atomic.Int32{}
+	c.RegisterNotificationOnList(func() { count.Add(1) }, t)
+
+	for i := 0; i < 10; i++ {
+		if err := p.NotifyChanged("path-" + string(rune('a'+i))); err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(15 * time.Millisecond)
+	}
+
+	time.Sleep(450 * time.Millisecond)
+	if got := count.Load(); got != 1 {
+		t.Errorf("after 10 NotifyChanged within coalesce window, got %d broadcasts, want 1", got)
+	}
+	_ = srv
+}
+
+func TestProvider_Throttle_DefersWithinInterval(t *testing.T) {
+	srv, c, p := bootBroadcastTest(t,
+		skills.WithCoalesceWindow(50*time.Millisecond),
+		skills.WithMinBroadcastInterval(400*time.Millisecond),
+	)
+
+	count := atomic.Int32{}
+	c.RegisterNotificationOnList(func() { count.Add(1) }, t)
+
+	if err := p.NotifyChanged("first"); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(150 * time.Millisecond) // coalesce fires, broadcast #1
+	if err := p.NotifyChanged("second"); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(150 * time.Millisecond) // coalesce fires, throttle kicks in; broadcast #2 deferred
+	if got := count.Load(); got != 1 {
+		t.Errorf("inside throttle window: got %d broadcasts, want 1", got)
+	}
+	time.Sleep(400 * time.Millisecond) // throttle window elapses; broadcast #2 lands
+	if got := count.Load(); got != 2 {
+		t.Errorf("after throttle window: got %d broadcasts, want 2", got)
+	}
+	_ = srv
+}
+
+func TestProvider_Close_StopsPendingFlush(t *testing.T) {
+	srv, c, p := bootBroadcastTest(t, skills.WithCoalesceWindow(200*time.Millisecond))
+
+	count := atomic.Int32{}
+	c.RegisterNotificationOnList(func() { count.Add(1) }, t)
+
+	if err := p.NotifyChanged("foo"); err != nil {
+		t.Fatal(err)
+	}
+	if err := p.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	time.Sleep(400 * time.Millisecond)
+	if got := count.Load(); got != 0 {
+		t.Errorf("after Close before coalesce timer fires, got %d broadcasts, want 0", got)
+	}
+	_ = srv
+}
+
+func TestDecodeListChangedNotification_RoundTrip(t *testing.T) {
+	// Construct a wire-shaped params object and decode it back.
+	params := map[string]any{
+		"_meta": map[string]any{
+			skills.MetaKeyPathsChanged: map[string]any{
+				"paths": map[string]any{
+					"foo/SKILL.md": map[string]any{
+						"action":    "deleted",
+						"timestamp": "2026-06-16T12:00:00Z",
+						"digest":    "sha256:abc",
+					},
+				},
+				"version": 42,
+			},
+		},
+	}
+	payload, ok := skills.DecodeListChangedNotification(params)
+	if !ok {
+		t.Fatalf("DecodeListChangedNotification(...) = ok=false; want true")
+	}
+	if payload.Version != 42 {
+		t.Errorf("Version = %d, want 42", payload.Version)
+	}
+	entry, ok := payload.Paths["foo/SKILL.md"]
+	if !ok {
+		t.Fatalf("paths missing foo/SKILL.md (%v)", payload.Paths)
+	}
+	if entry.Action != skills.ChangeActionDeleted {
+		t.Errorf("action = %q, want %q", entry.Action, skills.ChangeActionDeleted)
+	}
+	if entry.Digest != "sha256:abc" {
+		t.Errorf("digest = %q, want sha256:abc", entry.Digest)
+	}
+}
+
+func TestDecodeListChangedNotification_BareList(t *testing.T) {
+	if _, ok := skills.DecodeListChangedNotification(nil); ok {
+		t.Errorf("nil params: ok=true; want false")
+	}
+	if _, ok := skills.DecodeListChangedNotification(map[string]any{}); ok {
+		t.Errorf("empty params: ok=true; want false")
+	}
+	if _, ok := skills.DecodeListChangedNotification(map[string]any{"_meta": map[string]any{"unrelated": 1}}); ok {
+		t.Errorf("_meta without paths-changed key: ok=true; want false")
+	}
+}
+
+// bootBroadcastTest spins up a Provider + Server + connected client
+// ready for broadcast-style tests. Returns the server (for keeping
+// alive), client (for callback registration), and provider (for
+// driving NotifyChanged). Cleanups are registered against t.
+func bootBroadcastTest(t *testing.T, providerOpts ...skills.ProviderOption) (*server.Server, *clientWithCallbacks, *skills.Provider) {
+	t.Helper()
+	srv := server.NewServer(core.ServerInfo{Name: "skills-test", Version: "0.0.1"})
+
+	opts := append([]skills.ProviderOption{skills.WithDirectory("testdata/valid")}, providerOpts...)
+	p, err := skills.NewProvider(opts...)
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	p.RegisterWith(srv)
+	t.Cleanup(func() { p.Close() })
+
+	handler := srv.Handler(server.WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	wrapper := &clientWithCallbacks{}
+	c := client.NewClient(ts.URL+"/mcp",
+		core.ClientInfo{Name: "skills-test-client", Version: "0.0.1"},
+		client.WithGetSSEStream(),
+		client.WithNotificationCallback(wrapper.onNotify),
+	)
+	wrapper.Client = c
+	if err := c.Connect(); err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+
+	// Give the background GET SSE stream a beat to attach.
+	time.Sleep(100 * time.Millisecond)
+	return srv, wrapper, p
+}
+
+// clientWithCallbacks lets each test register its own list_changed
+// observer without colliding with bootBroadcastTest's shared callback.
+type clientWithCallbacks struct {
+	*client.Client
+	mu       sync.Mutex
+	onListed []func()
+	onParams []func(params any)
+}
+
+func (cwc *clientWithCallbacks) onNotify(method string, params any) {
+	if method != "notifications/resources/list_changed" {
+		return
+	}
+	cwc.mu.Lock()
+	listed := append([]func(){}, cwc.onListed...)
+	withParams := append([]func(any){}, cwc.onParams...)
+	cwc.mu.Unlock()
+	for _, fn := range listed {
+		fn()
+	}
+	for _, fn := range withParams {
+		fn(params)
+	}
+}
+
+func (cwc *clientWithCallbacks) RegisterNotificationOnList(fn func(), t *testing.T) {
+	t.Helper()
+	cwc.mu.Lock()
+	cwc.onListed = append(cwc.onListed, fn)
+	cwc.mu.Unlock()
+}
+
+func listenForPayloads(t *testing.T, cwc *clientWithCallbacks, ch chan<- skills.PathsChangedPayload) {
+	t.Helper()
+	cwc.mu.Lock()
+	cwc.onParams = append(cwc.onParams, func(params any) {
+		payload, ok := skills.DecodeListChangedNotification(params)
+		if !ok {
+			return
+		}
+		select {
+		case ch <- payload:
+		default:
+		}
+	})
+	cwc.mu.Unlock()
 }
 
 func indexVersion(t *testing.T, body string) uint64 {

--- a/ext/skills/types.go
+++ b/ext/skills/types.go
@@ -78,9 +78,18 @@ func (e IndexEntry) Validate() error {
 }
 
 // Index is the document served at the well-known IndexURI.
+//
+// Meta carries opt-in extension metadata under the `_meta` key per the
+// MCP convention. Keys are reverse-domain-namespaced
+// (io.modelcontextprotocol.skills/...) so they will not collide with
+// any field the SEP may add in the future. mcpkit populates
+// "io.modelcontextprotocol.skills/version" with Provider.Version() at
+// index build time; stateless clients poll the index and observe this
+// field bumping when content changes (issue #795).
 type Index struct {
-	Schema string       `json:"$schema"`
-	Skills []IndexEntry `json:"skills"`
+	Schema string         `json:"$schema"`
+	Skills []IndexEntry   `json:"skills"`
+	Meta   map[string]any `json:"_meta,omitempty"`
 }
 
 // NewIndex returns an Index pre-populated with the schema URI defined by

--- a/ext/skills/types.go
+++ b/ext/skills/types.go
@@ -2,6 +2,7 @@ package skills
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/panyam/mcpkit/core"
 )
@@ -75,6 +76,113 @@ func (e IndexEntry) Validate() error {
 		}
 	}
 	return nil
+}
+
+// MetaKeyVersion is the reverse-domain key under skill://index.json's
+// _meta map that carries Provider.Version() at index build time.
+// Stateless polling clients read this field to detect changes without
+// a persistent push channel (issue #795).
+const MetaKeyVersion = MetaPrefix + "version"
+
+// MetaKeyPathsChanged is the reverse-domain key under the
+// notifications/resources/list_changed params._meta map that carries
+// a PathsChangedPayload. Subscribers that decode this payload get the
+// deduplicated set of paths that changed plus the version counter at
+// broadcast time; subscribers that ignore _meta still receive the
+// standard list_changed signal and can re-read at their leisure.
+const MetaKeyPathsChanged = MetaPrefix + "paths-changed"
+
+// ChangeAction discriminates how a path entered the pending set in
+// PathsChangedPayload. The zero value (empty string) is treated as
+// ChangeActionModified on decode, so omitempty on the wire produces
+// the most compact representation for the common case.
+type ChangeAction string
+
+const (
+	// ChangeActionModified signals the path's content changed in place.
+	// Subscribers should re-fetch and re-verify the digest.
+	ChangeActionModified ChangeAction = "modified"
+
+	// ChangeActionCreated signals the path is newly served. Subscribers
+	// add the URI to their local cache; re-fetch on first access.
+	ChangeActionCreated ChangeAction = "created"
+
+	// ChangeActionDeleted signals the path is no longer served.
+	// Subscribers prune the URI from their local cache without
+	// re-fetching (a fetch would return a not-found error).
+	ChangeActionDeleted ChangeAction = "deleted"
+)
+
+// PathChange is the typed event a Detector passes to
+// Provider.NotifyChangedEvents. Detectors that have richer signals
+// than "this path is dirty" (fsnotify producing CREATE / WRITE /
+// REMOVE; webhooks carrying mtime + content hash) populate the action
+// + timestamp + digest fields; the Applier preserves them through
+// coalesce + dedup into the broadcast payload. Detectors that only
+// know "something changed" can use the simpler
+// Provider.NotifyChanged(paths ...string) sugar; all entries default
+// to ChangeActionModified with the call-time timestamp.
+type PathChange struct {
+	// Path is the fs.FS-relative path that changed. Required.
+	Path string
+
+	// Action is one of Created / Modified / Deleted. Empty value is
+	// treated as Modified.
+	Action ChangeAction
+
+	// Timestamp is when the Detector observed the change. Empty value
+	// is replaced with the Applier's call-time timestamp.
+	Timestamp time.Time
+
+	// Digest is the optional SHA-256 ("sha256:" + 64-hex) of the
+	// post-change content. Detectors that already have the digest
+	// supply it; the Applier does not compute it. Subscribers compare
+	// against their cached digest to avoid unnecessary re-fetches
+	// when the content matches what they already have.
+	Digest string
+}
+
+// PathChangeEntry is the per-path value in PathsChangedPayload.Paths.
+// Wire-format counterpart of PathChange minus the Path itself (which
+// is the map key).
+type PathChangeEntry struct {
+	Action    ChangeAction `json:"action,omitempty"`
+	Timestamp time.Time    `json:"timestamp"`
+	Digest    string       `json:"digest,omitempty"`
+}
+
+// PathsChangedPayload is the structured _meta hint mcpkit attaches to
+// notifications/resources/list_changed when ext/skills's Applier has
+// path-level information about what changed (issue #795). Decode with
+// DecodeListChangedNotification.
+//
+// Paths is a map of fs.FS-relative path → PathChangeEntry, covering
+// every path reported via Provider.NotifyChangedEvents (or
+// NotifyChanged) in the coalesce window leading up to this broadcast.
+// Repeated reports for the same path collapse to one entry under
+// latest-wins semantics: the most recent action / timestamp / digest
+// supersedes earlier ones. Empty when only opaque "something changed"
+// signals were available (e.g., Refresh() called with no arguments) —
+// subscribers should treat an empty Paths map as "re-read everything"
+// and rely on Version alone.
+//
+// Version is Provider.Version() at the moment this broadcast was
+// constructed — the same counter the index will carry when a
+// subscriber re-reads it within the same instant. Two contractual
+// uses:
+//
+//   - Idempotency: a duplicate broadcast carrying the same Version
+//     can be silently dropped.
+//   - ETag-like staleness check: if lastKnownVersion >= payload.Version
+//     the subscriber is already current and may skip the re-read.
+//
+// Race note: between broadcast and re-read, another bump may land. The
+// subscriber's re-read may legitimately return Version >
+// payload.Version. Treat the re-read as the new ground truth; do not
+// assume equality with the broadcast's Version.
+type PathsChangedPayload struct {
+	Paths   map[string]PathChangeEntry `json:"paths,omitempty"`
+	Version uint64                     `json:"version"`
 }
 
 // Index is the document served at the well-known IndexURI.


### PR DESCRIPTION
Closes #795.

## What changes

Introduces the **Detector/Applier split** for invalidating ext/skills's generated artifacts and ships the full Applier-side SDK surface in one PR. The Applier (Provider's new public methods) handles change events from any source; **Detectors** (fsnotify, webhook, admin endpoint) are pluggable producers filed as separate follow-ups.

### Core surface
- `Provider.Version() uint64` — monotonic invalidation counter.
- `Provider.NotifyChanged(paths ...string) error` — sugar entry point; every path treated as `ChangeActionModified` at call time.
- `Provider.NotifyChangedEvents(events ...PathChange) error` — typed entry point for Detectors with action/timestamp/digest signals.
- `Provider.Refresh() error` — "I don't know what changed" hot-reload hook.
- `Provider.Close() error` — stops pending broadcast timers.

### Wire shape
- `skill://index.json` carries `_meta.io.modelcontextprotocol.skills/version` — stateless polling clients (SEP-2575) detect change without a persistent push channel.
- `notifications/resources/list_changed` carries `_meta.io.modelcontextprotocol.skills/paths-changed` with the typed `PathsChangedPayload`:
  - `Paths map[string]PathChangeEntry` — deduplicated path → `{Action, Timestamp, Digest}`.
  - `Action ∈ {created, modified, deleted}` — subscribers can prune cached entries on Deleted without a 404 round-trip.
  - `Digest` — optional SHA-256; subscribers can skip re-fetch when content already matches.
  - `Version` — counter at broadcast time; ETag-like idempotency token.

### SDK decoder
- `skills.DecodeListChangedNotification(params any) (PathsChangedPayload, bool)` — extracts the typed payload from any params shape `client.WithNotificationCallback` produces. Returns `(zero, false)` for bare list_changed from non-mcpkit servers.

### Flow control
- `WithCoalesceWindow(d)` — groups NotifyChanged calls within `d` ms into a single trailing-edge broadcast.
- `WithMinBroadcastInterval(d)` — minimum gap between consecutive broadcasts; composes with coalesce.
- Per-path dedup with **latest-wins** semantics inside the coalesce window. Five touches on `foo/SKILL.md` collapse to one entry whose action/timestamp/digest come from the 5th touch.
- Version counter + index cache invalidation always fire immediately; only the wire notification is throttled. Polling stateless clients see fresh state without waiting for the coalesce window.

### Demo wiring
- `examples/skills/main.go` registers a `_demo/refresh` tool (using `core.TextTool` for typed schema). Walkthrough step 11 reads the index, calls the tool, re-reads, prints the version bumping.

## Reviewer's guide

Read in this order:

1. [ext/skills/types.go](https://github.com/panyam/mcpkit/pull/799/files#diff-c6a1fd454bc3289de88115aac3e3eb9bdcf381e5e16ffe515d75048fea08d4b8) — start here. `ChangeAction`, `PathChange`, `PathChangeEntry`, `PathsChangedPayload`, `Index.Meta`, meta-key constants.
2. [ext/skills/provider_options.go](https://github.com/panyam/mcpkit/pull/799/files#diff-02ce7b9d8644be81ed6118ce376e8e695e085c46c041d0192f11b905f267fd79) — `WithCoalesceWindow` + `WithMinBroadcastInterval` options + the trade-offs in their godoc.
3. [ext/skills/provider.go](https://github.com/panyam/mcpkit/pull/799/files#diff-bc1bc138c97cce27ab4ebcc05b5b90bce9519a5b6ece2cd00da30248841d7021) — Applier methods (`Version`, `NotifyChanged`, `NotifyChangedEvents`, `Refresh`, `Close`), the `flush()` state machine, coalesce/throttle timer logic.
4. [ext/skills/decoder.go](https://github.com/panyam/mcpkit/pull/799/files#diff-02eb382d47afa1391e88f8ee6ef00e2bc70fd5de58300d89f6b50a3a685fa2c2) — `DecodeListChangedNotification` with usage example.
5. [ext/skills/indexer.go](https://github.com/panyam/mcpkit/pull/799/files#diff-044da778667a5797524e83fc8839f9948b2261f0576c8f36d13ee59c8a8c9c57) — `isFresh` consults Version; `Index()` stamps `_meta.version`; `Invalidate()`.
6. [ext/skills/provider_test.go](https://github.com/panyam/mcpkit/pull/799/files#diff-4a2b1ae742952de7bc72050fd0f381f22c09f21632e4f9137abeff3a9a3cee54) — 14 tests covering version + NotifyChanged + Refresh + InvalidatesIndexCache + version-in-meta + broadcast-fires + payload-shape + dedup + latest-wins + coalesce + throttle + Close + decoder round-trip + decoder bare-list fallback.
7. [examples/skills/main.go](https://github.com/panyam/mcpkit/pull/799/files#diff-5b14977a06843ef8ea751a41d80e1cd9eb927a784069536cf93b0857dc9261fc) — `_demo/refresh` tool via `core.TextTool`.
8. [examples/skills/walkthrough.go](https://github.com/panyam/mcpkit/pull/799/files#diff-94afaa0ca3ed61f670feefe88925e3b5ecfc827cfcdb7612d48a01dd289c10e7) — new "Push-based invalidation" section + step; `readIndexVersion` helper at the bottom.
9. [examples/skills/WALKTHROUGH.md](https://github.com/panyam/mcpkit/pull/799/files#diff-f7567dfcd105e517415a8fc5aada2b08489ad36774f38681b85f5855a3638884) — regenerated; sanity-skim.

## Decision log

- **Detector/Applier naming** chosen over "watcher/notifier" — conventional Linux/Go usage has watcher=source, notifier=sink (inverse of intuition). Detector/Applier is unambiguous.
- **Per-server Applier, not per-client.** One Provider drives one Applier; broadcasts fan out to every subscribed session with identical payload. Matches MCP's broadcast notification semantic. Per-client filtering / partial subscriptions is a cross-cutting mcpkit concern (affects tools/resources/prompts equally) — filed as separate follow-up.
- **`_meta` over flat `version` field** — `_meta.io.modelcontextprotocol.skills/...` matches mcpkit's existing reverse-domain convention; survives any future SEP revision that might add top-level fields. SEP-2640 allows additional properties.
- **Keep `Version` (uint64) alongside per-path `Timestamp`** — Version is strict-monotonic and clock-safe (no NTP skew, no sub-ms collisions), used for ETag/idempotency. Timestamps are human-meaningful, used for audit/prioritization. Different jobs; both cheap.
- **Action flags + Digest field** — Deleted is asymmetric (subscriber must prune, not re-fetch); Created lets subscribers add to cache without enumerating `resources/list`; Digest lets subscribers skip re-fetches when content matches. fsnotify already produces these distinctions; throwing them on the floor at NotifyChanged-time is information loss the API cannot recover later.
- **`NotifyChangedEvents` as the typed entry; `NotifyChanged` as sugar** — typed API is honest about what Detectors produce; sugar covers the common "I only know it's dirty" path.
- **Coalesce + throttle on the Applier, not in each Detector** — one canonical implementation; every Detector benefits. Goroutine cost paid once.
- **Latest-wins for dedup** — simpler than "merge actions" and matches the "subscriber treats this as the current state" mental model.

## Risk / blast radius

- **Affects:** `ext/skills.Provider` (new public methods + struct fields), `Index` JSON wire shape (additive `_meta` field), `notifications/resources/list_changed` params (additive `_meta.paths-changed` payload), `examples/skills` demo binary. No core/server/client changes.
- **Tests covering this:** 14 tests in `ext/skills/provider_test.go`. Full ext/skills + core + server + client suites pass.
- **Be paranoid about:** the coalesce/throttle/Close tests are timing-sensitive. Sleep margins chosen to give ample slack on slow CI but tighten if they get flaky. The 100ms `time.Sleep` between `Connect()` and the first bump is the same shape other notification tests in the repo use to let the background `GET SSE` stream attach.

## Before / after

Walkthrough step 11 output (file mode):

```
before refresh: version = 0
called _demo/refresh — server bumped Provider.Version()
after refresh:  version = 1
version bumped by 1 — stateful subscribers also received notifications/resources/list_changed
```

Broadcast payload shape (when `NotifyChangedEvents` is used):

```json
{
  "jsonrpc": "2.0",
  "method": "notifications/resources/list_changed",
  "params": {
    "_meta": {
      "io.modelcontextprotocol.skills/paths-changed": {
        "version": 42,
        "paths": {
          "foo/SKILL.md": {"timestamp": "2026-06-16T12:00:00Z", "digest": "sha256:abc"},
          "gone/SKILL.md": {"action": "deleted", "timestamp": "2026-06-16T12:00:01Z"}
        }
      }
    }
  }
}
```

Subscribers that ignore `_meta` (standard MCP clients) still receive the bare list_changed signal and re-read; subscribers that decode the payload via `DecodeListChangedNotification` get richer hints.

## Out of scope (deliberately deferred)

- **fsnotify-driven Detector** — `WithFSWatcher(root)` that spawns a goroutine, debounces, calls `Provider.NotifyChangedEvents(...)` with action flags derived from fsnotify event types. Filed separately.
- **HTTP / admin control-plane Detector** — POST endpoint that accepts change-path lists and calls `Provider.NotifyChangedEvents`. Sibling of fsnotify.
- **Pushdown to templar** — generic Applier pattern; templar has dependency tracking but no change-event ingest. Defer until a second consumer surfaces.
- **Per-client subscription filtering for list_changed** — cross-cutting mcpkit concern (affects tools/resources/prompts equally). Filed as a separate core ticket; #796 (sub-indexes) will reference it.
- **Per-artifact counters** — global counter is enough for #795. #796 + #798 can refine.

## Test plan

- [x] `go test ./ext/skills/...` (14 new tests + all existing)
- [x] `go test ./core/... ./server/... ./client/...` (no regressions)
- [x] `make serve` + walkthrough — refresh step prints `before=0, after=1`.
- [x] `make readme` regenerates `WALKTHROUGH.md` cleanly.
