### PR TITLE
ext/skills: fsnotify-driven Detector + Provider.Shutdown(ctx) (#800)

### DIFF
--- a/examples/skills/WALKTHROUGH.md
+++ b/examples/skills/WALKTHROUGH.md
@@ -15,6 +15,7 @@ SEP-2640 serves Agent Skills over MCP's Resources primitive: each file under a s
 - **Read a nested-prefix skill (acme/billing/refunds)** — Demonstrates that the prefix-segment routing works end-to-end. The skill name is refunds; the acme/billing/ prefix is server-chosen and is opaque to the skill's own frontmatter.
 - **Read a supporting file in the nested skill (templates/email.md)** — Same relative-reference resolution as the pdf-processing example, this time across a multi-segment prefix.
 - **Read the version, refresh, observe it bump** — The version field lives under `_meta` with the reverse-domain key `io.modelcontextprotocol.skills/version`, matching mcpkit's existing convention for extension metadata. The dual-wire story: subscribed stateful clients get the push notification; stateless clients see the same change by re-reading and comparing the version.
+- **Observe an fsnotify-driven broadcast** — In `--non-interactive` mode this step synthesizes the edit (writes the same SKILL.md back to itself) and restores the original content; the actual broadcast still fires. In interactive mode it prompts you to edit a SKILL.md in a side terminal — the notification arrives as soon as your editor flushes the save.
 - **List a directory inside a skill and recurse into a subdirectory** — Subdirectories surface with mimeType inode/directory; the client descends by issuing a second call. The SDK wraps this into a single call; the curl below shows both round trips explicitly.
 - **Wrap reads in skills.NewClient(...) and call Client.Activate** — Activate is intra-process — no wire traffic. Run with `make serve EXPORTER=stdout` + `make demo EXPORTER=stdout` to see spans.
 - **Read pdf-processing archive, verify digest, unpack, list recovered files** — Only meaningful in archive mode. In file mode the step prints the detected mode and exits — see the per-file read steps above for the equivalent file-mode story.
@@ -68,17 +69,22 @@ sequenceDiagram
     Server-->>Host: notifications/resources/list_changed (stateful wire only)
     Host->>Server: resources/read uri=skill://index.json (observe version bumped)
 
-    Note over Host,Server: Step 12: List a directory inside a skill and recurse into a subdirectory
+    Note over Host,Server: Step 12: Observe an fsnotify-driven broadcast
+    Detector->>Server: fsnotify Write event on skills/git-workflow/SKILL.md
+    Server->>Server: Provider.NotifyChangedEvents (mapped from fsnotify.Op)
+    Server-->>Host: notifications/resources/list_changed (after 200ms coalesce)
+
+    Note over Host,Server: Step 13: List a directory inside a skill and recurse into a subdirectory
     Host->>Server: resources/directory/read uri=skill://acme/billing/refunds/templates
     Server-->>Host: 2 files + 1 subdirectory (`regional`, inode/directory)
     Host->>Server: resources/directory/read uri=skill://acme/billing/refunds/templates/regional
     Server-->>Host: 1 file (eu.md)
 
-    Note over Host,Server: Step 13: Wrap reads in skills.NewClient(...) and call Client.Activate
+    Note over Host,Server: Step 14: Wrap reads in skills.NewClient(...) and call Client.Activate
     Host->>Server: resources/read via sc.ReadAndVerify (span: skills.read_and_verify)
     Server-->>Host: bytes + digest match
 
-    Note over Host,Server: Step 14: Read pdf-processing archive, verify digest, unpack, list recovered files
+    Note over Host,Server: Step 15: Read pdf-processing archive, verify digest, unpack, list recovered files
     Host->>Server: resources/read uri=skill://pdf-processing.tar.gz (or .zip)
     Server-->>Host: application/gzip OR application/zip blob
 ```
@@ -311,11 +317,38 @@ V2=$(curl -s -X POST http://localhost:8080/mcp \
 echo "before=$V1 after=$V2"
 ```
 
+### fsnotify-driven invalidation (issue #800)
+
+The previous step called `Provider.Refresh()` synchronously via the demo tool. Real deployments wire a Detector — fsnotify, webhook, or admin endpoint — that observes file changes and calls into the Applier on its own. `make serve` with `--watch` enables `skills.WithFSWatcher` + a 200ms coalesce window. Edit any file under `skills/` in another terminal and the server emits one `notifications/resources/list_changed` per logical change.
+
+### Step 12: Observe an fsnotify-driven broadcast
+
+In `--non-interactive` mode this step synthesizes the edit (writes the same SKILL.md back to itself) and restores the original content; the actual broadcast still fires. In interactive mode it prompts you to edit a SKILL.md in a side terminal — the notification arrives as soon as your editor flushes the save.
+
+#### Reproduce on the wire
+
+```bash
+# In one terminal:
+make serve  # opt-in fsnotify:
+            # (edit Makefile to add --watch to the serve target, or run directly:)
+            # go run . --serve --watch
+
+# In another terminal: subscribe + listen.
+SID=$(curl -s -X POST http://localhost:8080/mcp \
+  -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":"i","method":"initialize","params":{"protocolVersion":"2025-11-25","clientInfo":{"name":"watcher","version":"1.0"},"capabilities":{}}}' \
+  -D - -o /dev/null | grep -i 'mcp-session-id' | awk '{print $2}' | tr -d '\r\n')
+curl -s -N http://localhost:8080/mcp -H "Mcp-Session-Id: $SID" -H 'Accept: text/event-stream' &
+
+# Edit a SKILL.md and watch the SSE stream emit list_changed within 200ms.
+echo "---" >> skills/git-workflow/SKILL.md
+```
+
 ### SEP-2640 directoryRead — scoped subtree navigation
 
 SEP commit `2e04c48d` (2026-06-09) added `resources/directory/read` for listing a directory's direct children without enumerating the server's entire resource space. Capability-gated via `io.modelcontextprotocol/skills.directoryRead`. mcpkit's Provider auto-supports it (#781).
 
-### Step 12: List a directory inside a skill and recurse into a subdirectory
+### Step 13: List a directory inside a skill and recurse into a subdirectory
 
 Subdirectories surface with mimeType inode/directory; the client descends by issuing a second call. The SDK wraps this into a single call; the curl below shows both round trips explicitly.
 
@@ -341,7 +374,7 @@ curl -s -X POST http://localhost:8080/mcp \
 
 Fetch ≠ activation. Server `resources/read` spans now carry `mcp.skill.*` attrs (#748). Client `ext/skills.Client` emits `skills.read*` spans + `Activate(ctx, uri)` for post-cache use the wire can't see (SDK-only — no spec change).
 
-### Step 13: Wrap reads in skills.NewClient(...) and call Client.Activate
+### Step 14: Wrap reads in skills.NewClient(...) and call Client.Activate
 
 Activate is intra-process — no wire traffic. Run with `make serve EXPORTER=stdout` + `make demo EXPORTER=stdout` to see spans.
 
@@ -349,7 +382,7 @@ Activate is intra-process — no wire traffic. Run with `make serve EXPORTER=std
 
 In archive mode every skill is delivered as a single `.tar.gz` or `.zip` resource. The host hashes the archive bytes against the index digest, then unpacks in-memory to recover the post-unpack virtual namespace — same files the file-mode wire would have served piecemeal. Demonstrates pdf-processing (multi-file skill) because the unpacked listing actually shows something.
 
-### Step 14: Read pdf-processing archive, verify digest, unpack, list recovered files
+### Step 15: Read pdf-processing archive, verify digest, unpack, list recovered files
 
 Only meaningful in archive mode. In file mode the step prints the detected mode and exits — see the per-file read steps above for the equivalent file-mode story.
 

--- a/examples/skills/go.mod
+++ b/examples/skills/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
+	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/examples/skills/go.sum
+++ b/examples/skills/go.sum
@@ -42,6 +42,8 @@ github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxK
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
+github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
+github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/examples/skills/main.go
+++ b/examples/skills/main.go
@@ -37,6 +37,7 @@ import (
 	"log"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/panyam/demokit"
 	"github.com/panyam/mcpkit/core"
@@ -62,6 +63,8 @@ func serve() {
 		"distribution shape: file (per-resource SKILL.md + supporting files) | archive (one .tar.gz per skill) | zip (one .zip per skill)")
 	skillsDir := flag.String("skills", "skills",
 		"directory of skill bundles to register (default ./skills)")
+	watch := flag.Bool("watch", false,
+		"enable fsnotify-driven push invalidation (skills.WithFSWatcher); pairs with coalesce window to suppress editor-save bursts")
 	tel := common.RegisterTelemetryFlags(flag.CommandLine)
 	flag.CommandLine.Parse(demokit.FilterArgs(os.Args[1:],
 		demokit.BoolFlag("--serve"),  // dual-mode dispatch; override demokit's value-form default
@@ -82,6 +85,14 @@ func serve() {
 	provOpts := []skills.ProviderOption{
 		skills.WithDirectory(*skillsDir),
 	}
+	if *watch {
+		provOpts = append(provOpts,
+			skills.WithFSWatcher(skills.WithFSWatcherErrorHandler(func(err error) {
+				log.Printf("[skills] fsnotify: %v", err)
+			})),
+			skills.WithCoalesceWindow(200*time.Millisecond),
+		)
+	}
 	switch strings.ToLower(*modeFlag) {
 	case "file":
 		// default
@@ -98,7 +109,7 @@ func serve() {
 		log.Fatalf("skills.NewProvider: %v", err)
 	}
 
-	log.Printf("[skills-demo] mode=%s skills=%s", *modeFlag, *skillsDir)
+	log.Printf("[skills-demo] mode=%s skills=%s watch=%v", *modeFlag, *skillsDir, *watch)
 	if err := common.RunServer(common.ServerConfig{
 		Name:           "skills-demo",
 		Addr:           *addr,

--- a/examples/skills/walkthrough.go
+++ b/examples/skills/walkthrough.go
@@ -14,7 +14,9 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os"
 	"strings"
+	"time"
 
 	"github.com/panyam/demokit"
 	"github.com/panyam/mcpkit/client"
@@ -573,6 +575,89 @@ fmt.Printf("before=%d after=%d\n", uint64(before), uint64(after))`),
 			return nil
 		})
 
+	demo.Section("fsnotify-driven invalidation (issue #800)",
+		"The previous step called `Provider.Refresh()` synchronously via the demo tool. Real deployments wire a Detector — fsnotify, webhook, or admin endpoint — that observes file changes and calls into the Applier on its own. `make serve` with `--watch` enables `skills.WithFSWatcher` + a 200ms coalesce window. Edit any file under `skills/` in another terminal and the server emits one `notifications/resources/list_changed` per logical change.",
+	)
+
+	demo.Step("Observe an fsnotify-driven broadcast").
+		Arrow("Detector", "Server", "fsnotify Write event on skills/git-workflow/SKILL.md").
+		Arrow("Server", "Server", "Provider.NotifyChangedEvents (mapped from fsnotify.Op)").
+		DashedArrow("Server", "Host", "notifications/resources/list_changed (after 200ms coalesce)").
+		Note("In `--non-interactive` mode this step synthesizes the edit (writes the same SKILL.md back to itself) and restores the original content; the actual broadcast still fires. In interactive mode it prompts you to edit a SKILL.md in a side terminal — the notification arrives as soon as your editor flushes the save.").
+		VerbatimVariants("Reproduce on the wire",
+			demokit.MakeVariant("server", "bash", `# In one terminal:
+make serve  # opt-in fsnotify:
+            # (edit Makefile to add --watch to the serve target, or run directly:)
+            # go run . --serve --watch
+
+# In another terminal: subscribe + listen.
+SID=$(curl -s -X POST http://localhost:8080/mcp \
+  -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":"i","method":"initialize","params":{"protocolVersion":"2025-11-25","clientInfo":{"name":"watcher","version":"1.0"},"capabilities":{}}}' \
+  -D - -o /dev/null | grep -i 'mcp-session-id' | awk '{print $2}' | tr -d '\r\n')
+curl -s -N http://localhost:8080/mcp -H "Mcp-Session-Id: $SID" -H 'Accept: text/event-stream' &
+
+# Edit a SKILL.md and watch the SSE stream emit list_changed within 200ms.
+echo "---" >> skills/git-workflow/SKILL.md`).Default(),
+			demokit.MakeVariant("go", "go", `// Server-side wiring (already done in main.go when --watch is set):
+provider, _ := skills.NewProvider(
+    skills.WithDirectory("skills"),
+    skills.WithFSWatcher(skills.WithFSWatcherErrorHandler(func(err error) {
+        log.Printf("fsnotify: %v", err)
+    })),
+    skills.WithCoalesceWindow(200 * time.Millisecond),
+)
+provider.RegisterWith(srv)
+defer provider.Shutdown(context.Background()) // graceful drain on signal
+
+// The fsnotify goroutine maps Create/Write/Remove events to
+// ChangeAction and calls Provider.NotifyChangedEvents internally —
+// adopters don't touch the Detector directly. They opt in via the
+// Provider option and receive the same notifications/resources/list_changed
+// the synchronous Refresh call would produce.`),
+		).
+		Run(func(ctx demokit.StepContext) *demokit.StepResult {
+			if c == nil {
+				return nil
+			}
+			before := readIndexVersion(c)
+			fmt.Printf("    before edit: version = %d\n", before)
+
+			target := "skills/git-workflow/SKILL.md"
+			original, err := os.ReadFile(target)
+			if err != nil {
+				fmt.Printf("    SKIP: cannot read %s: %v (server may be in --bundle=archive mode or running from a different cwd)\n", target, err)
+				return nil
+			}
+			if isInteractive() {
+				fmt.Printf("    Edit %s in another terminal and save. Waiting up to 10s for a broadcast…\n", target)
+			} else {
+				fmt.Printf("    Synthesizing an edit to %s (non-interactive mode)…\n", target)
+				edited := append(append([]byte{}, original...), []byte("\n<!-- demo edit -->\n")...)
+				if err := os.WriteFile(target, edited, 0o644); err != nil {
+					fmt.Printf("    ERROR writing %s: %v\n", target, err)
+					return nil
+				}
+				defer func() {
+					if err := os.WriteFile(target, original, 0o644); err != nil {
+						fmt.Printf("    WARNING failed to restore %s: %v\n", target, err)
+					}
+				}()
+			}
+
+			deadline := time.Now().Add(10 * time.Second)
+			for time.Now().Before(deadline) {
+				time.Sleep(300 * time.Millisecond)
+				after := readIndexVersion(c)
+				if after > before {
+					fmt.Printf("    after edit: version = %d (bump observed via fsnotify; coalesced into one broadcast)\n", after)
+					return nil
+				}
+			}
+			fmt.Printf("    WARNING: no version bump observed within 10s — server may have been started without --watch\n")
+			return nil
+		})
+
 	demo.Section("SEP-2640 directoryRead — scoped subtree navigation",
 		"SEP commit `2e04c48d` (2026-06-09) added `resources/directory/read` for listing a directory's direct children without enumerating the server's entire resource space. Capability-gated via `io.modelcontextprotocol/skills.directoryRead`. mcpkit's Provider auto-supports it (#781).",
 	)
@@ -800,6 +885,21 @@ func marker(mimeType string) string {
 		return "dir/"
 	}
 	return "file"
+}
+
+// isInteractive returns false when demokit's --non-interactive flag
+// is present on the command line. The fsnotify walkthrough step
+// synthesizes an edit + revert in non-interactive mode so CI runs
+// drive the end-to-end path without operator action; interactive
+// mode prompts the operator to make a real edit so the live demo
+// feels live.
+func isInteractive() bool {
+	for _, arg := range os.Args[1:] {
+		if arg == "--non-interactive" {
+			return false
+		}
+	}
+	return true
 }
 
 // readIndexVersion fetches skill://index.json and returns the

--- a/ext/skills/errors.go
+++ b/ext/skills/errors.go
@@ -90,6 +90,19 @@ var (
 	// ErrNestedSkill is returned by NewProvider when a SKILL.md is found
 	// inside an existing skill's subtree. SEP-2640 forbids skill nesting.
 	ErrNestedSkill = errors.New("skills: nested skill")
+
+	// ErrFSWatcherMissingHostRoot is returned by NewProvider when
+	// WithFSWatcher is supplied alongside WithFS (which does not
+	// populate the hostRoot path). Watcher-based change detection
+	// requires a real filesystem; use WithDirectory or arrange your
+	// own Detector to call NotifyChangedEvents manually.
+	ErrFSWatcherMissingHostRoot = errors.New("skills: WithFSWatcher requires WithDirectory (hostRoot not set)")
+
+	// ErrFSWatcherSetupFailed is returned by NewProvider when the
+	// underlying fsnotify.NewWatcher call or the initial directory
+	// walk fails in a way that prevents any watching from happening.
+	// Wraps the underlying error.
+	ErrFSWatcherSetupFailed = errors.New("skills: fsnotify watcher setup failed")
 )
 
 // Frontmatter parsing errors.

--- a/ext/skills/export_test.go
+++ b/ext/skills/export_test.go
@@ -1,0 +1,10 @@
+package skills
+
+import "github.com/fsnotify/fsnotify"
+
+// exportedMapFSNotifyOp surfaces the unexported event-op mapper to the
+// skills_test package so its behavior can be unit-tested without
+// promoting it to the public API.
+func ExportedMapFSNotifyOp(op fsnotify.Op) (ChangeAction, bool) {
+	return mapFSNotifyOp(op)
+}

--- a/ext/skills/go.mod
+++ b/ext/skills/go.mod
@@ -10,6 +10,7 @@ require (
 require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
+	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/invopop/jsonschema v0.13.0 // indirect
 	github.com/kr/text v0.2.0 // indirect

--- a/ext/skills/go.sum
+++ b/ext/skills/go.sum
@@ -7,6 +7,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
+github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/ext/skills/provider.go
+++ b/ext/skills/provider.go
@@ -44,6 +44,9 @@ type Provider struct {
 	flushTimer    *time.Timer
 	lastBroadcast time.Time
 	closed        bool
+	draining      bool
+
+	watcher *fsWatcher
 }
 
 type skillEntry struct {
@@ -94,6 +97,16 @@ func NewProvider(opts ...ProviderOption) (*Provider, error) {
 	p := &Provider{cfg: cfg, byURI: map[string]*resourceEntry{}}
 	if err := p.walk(); err != nil {
 		return nil, err
+	}
+	if cfg.fsWatcherEnabled {
+		if cfg.hostRoot == "" {
+			return nil, ErrFSWatcherMissingHostRoot
+		}
+		w, err := newFSWatcher(cfg.hostRoot, cfg.fsWatcherIgnore, cfg.fsWatcherErrHandler)
+		if err != nil {
+			return nil, err
+		}
+		p.watcher = w
 	}
 	return p, nil
 }
@@ -301,6 +314,10 @@ func (p *Provider) RegisterWith(srv *server.Server) {
 		idx.RegisterWith(srv)
 	}
 	srv.UseMiddleware(skillURIValidationMiddleware)
+
+	if p.watcher != nil {
+		p.watcher.start(p)
+	}
 }
 
 // Version returns the Provider's monotonic invalidation counter. The
@@ -388,7 +405,7 @@ func (p *Provider) NotifyChangedEvents(events ...PathChange) error {
 	p.versionMu.Unlock()
 
 	p.notifyMu.Lock()
-	if p.closed {
+	if p.closed || p.draining {
 		p.notifyMu.Unlock()
 		if idx != nil {
 			idx.Invalidate()
@@ -451,21 +468,75 @@ func (p *Provider) Refresh() error {
 	return p.NotifyChangedEvents()
 }
 
-// Close stops any pending broadcast timer and prevents future
-// broadcasts. Idempotent. After Close, the version counter still
-// bumps on NotifyChanged calls and the index cache still invalidates
-// (polling clients continue to see fresh state), but the stateful-wire
-// broadcast goroutine is dormant. Tests and adopters that own the
-// Provider's lifecycle should call Close on shutdown.
+// Close stops any pending broadcast timer, stops the fsnotify Detector
+// goroutine (when WithFSWatcher is in effect) abruptly, and prevents
+// future broadcasts. Idempotent. After Close, the version counter
+// still bumps on NotifyChanged calls and the index cache still
+// invalidates (polling clients continue to see fresh state), but the
+// stateful-wire broadcast goroutine is dormant and any buffered
+// fsnotify events are dropped.
+//
+// Adopters wanting to drain in-flight events through one final flush
+// before stopping should use Shutdown(ctx) instead — Close is
+// process-exit semantics, Shutdown is the graceful path.
 func (p *Provider) Close() error {
 	p.notifyMu.Lock()
-	defer p.notifyMu.Unlock()
 	if p.flushTimer != nil {
 		p.flushTimer.Stop()
 		p.flushTimer = nil
 	}
 	p.closed = true
+	p.draining = true
+	watcher := p.watcher
+	p.notifyMu.Unlock()
+	if watcher != nil {
+		_ = watcher.close()
+	}
 	return nil
+}
+
+// Shutdown is the graceful counterpart to Close: when WithFSWatcher
+// is in effect, signals the Detector goroutine to drain any events
+// already buffered in fsnotify's channel through one final
+// NotifyChangedEvents call before exiting; runs a final flush so the
+// accumulated PathChanges land in one last broadcast; then closes
+// timers and the watcher.
+//
+// Waits for the goroutine to exit or for ctx to cancel, whichever
+// fires first. On ctx cancellation the watcher is still closed
+// cleanly but ctx.Err() is returned so the caller knows the drain
+// did not complete.
+//
+// Idempotent. Calling Shutdown after Close (or vice versa) is a no-op
+// returning nil. Process-restart-friendly: typical use is
+// signal-handler →  ctx, cancel := context.WithTimeout(ctx, 5*time.Second);
+// defer cancel(); provider.Shutdown(ctx).
+func (p *Provider) Shutdown(ctx context.Context) error {
+	p.notifyMu.Lock()
+	if p.closed && !p.draining {
+		p.notifyMu.Unlock()
+		return nil
+	}
+	p.draining = true
+	watcher := p.watcher
+	p.notifyMu.Unlock()
+
+	var werr error
+	if watcher != nil {
+		werr = watcher.shutdown(ctx)
+	}
+
+	p.flush()
+
+	p.notifyMu.Lock()
+	if p.flushTimer != nil {
+		p.flushTimer.Stop()
+		p.flushTimer = nil
+	}
+	p.closed = true
+	p.notifyMu.Unlock()
+
+	return werr
 }
 
 // scheduleFlushLocked sets or resets the flush timer to fire after d.

--- a/ext/skills/provider_options.go
+++ b/ext/skills/provider_options.go
@@ -12,6 +12,7 @@ type ProviderOption func(*providerConfig)
 type providerConfig struct {
 	fsys                 fs.FS
 	root                 string
+	hostRoot             string // host filesystem path; populated by WithDirectory, empty for WithFS
 	uriPrefix            []string
 	metaPrefix           string
 	suppressIndex        bool
@@ -21,6 +22,9 @@ type providerConfig struct {
 	archiveMaxBytes      int64
 	coalesceWindow       time.Duration
 	minBroadcastInterval time.Duration
+	fsWatcherEnabled     bool
+	fsWatcherIgnore      []string
+	fsWatcherErrHandler  func(error)
 }
 
 // WithFS supplies the io/fs.FS that the Provider walks for skills. The
@@ -38,10 +42,18 @@ func WithFS(fsys fs.FS) ProviderOption {
 // WithDirectory is sugar for WithFS(os.DirFS(path)). It exists for the
 // common local-directory case so callers do not have to spell out the
 // os.DirFS wrap.
+//
+// Additionally captures path as providerConfig.hostRoot so WithFSWatcher
+// can locate the underlying filesystem for fsnotify. Relative paths are
+// fine — the watcher resolves to absolute at startup. Callers using
+// WithFS instead must arrange their own change-detection (the watcher
+// has no fs.FS-only path; non-os filesystems like embed.FS aren't
+// watchable by construction).
 func WithDirectory(path string) ProviderOption {
 	return func(c *providerConfig) {
 		c.fsys = os.DirFS(path)
 		c.root = "."
+		c.hostRoot = path
 	}
 }
 
@@ -154,6 +166,82 @@ func WithCoalesceWindow(d time.Duration) ProviderOption {
 func WithMinBroadcastInterval(d time.Duration) ProviderOption {
 	return func(c *providerConfig) {
 		c.minBroadcastInterval = d
+	}
+}
+
+// WatcherOption tunes the fsnotify-driven Detector that WithFSWatcher
+// installs. Options are applied to providerConfig at NewProvider time.
+type WatcherOption func(*providerConfig)
+
+// WithFSWatcher enables an fsnotify-driven Detector that watches the
+// Provider's hostRoot (populated by WithDirectory) and feeds change
+// events into Provider.NotifyChangedEvents.
+//
+// Requires WithDirectory — fs.FS implementations like embed.FS and
+// skills.ArchiveFS are read-only by construction and have no host
+// path to watch; NewProvider returns ErrFSWatcherMissingHostRoot when
+// WithFSWatcher is set against such a Provider.
+//
+// Lifecycle:
+//   - NewProvider creates the fsnotify.Watcher and walks the host
+//     directory tree to register watches. Errors on individual
+//     watcher.Add calls (permission denied on a subdir, etc.) are
+//     surfaced via the error handler set by WithFSWatcherErrorHandler
+//     and skipped — one unreadable subdir does not fail construction.
+//   - RegisterWith starts the dispatch goroutine that reads
+//     watcher.Events / watcher.Errors and forwards into the Applier.
+//   - Close stops the goroutine abruptly.
+//   - Shutdown(ctx) drains buffered events through one final flush
+//     before stopping (graceful path).
+//
+// Recursive watching is handled by re-walking on directory-create
+// events; directory removals prune the watch set. Ignore patterns
+// from WithFSWatcherIgnore are applied to both the initial walk and
+// runtime additions.
+//
+// The Detector emits no events for the initial catalog — the state
+// at construction IS the baseline. Bursts of fsnotify events (editor
+// saves typically fire 3-5 events in <50ms) collapse naturally
+// through the Applier's WithCoalesceWindow.
+func WithFSWatcher(opts ...WatcherOption) ProviderOption {
+	return func(c *providerConfig) {
+		c.fsWatcherEnabled = true
+		for _, opt := range opts {
+			opt(c)
+		}
+	}
+}
+
+// WithFSWatcherIgnore appends path-fragment patterns to skip during
+// the fsnotify Detector's directory walk. Any directory whose path
+// (relative to hostRoot) contains one of the patterns as a path
+// segment is not watched, and events for files inside it are
+// suppressed.
+//
+// Default ignore set (always applied): ".git", "node_modules",
+// ".DS_Store". Custom patterns supplement the defaults; pass an empty
+// slice to keep only the defaults.
+//
+// Examples that match: ".git", "node_modules", "vendor".
+// Examples that don't: "*.tmp" (no glob support today; file a follow-up
+// if needed).
+func WithFSWatcherIgnore(patterns ...string) WatcherOption {
+	return func(c *providerConfig) {
+		c.fsWatcherIgnore = append(c.fsWatcherIgnore, patterns...)
+	}
+}
+
+// WithFSWatcherErrorHandler routes runtime fsnotify errors (buffer
+// overflows on Linux, channel-level errors, per-subdir watcher.Add
+// failures during the initial walk) to fn. fn is called from the
+// watcher goroutine; implementations MUST NOT block (use a buffered
+// channel + drain goroutine if heavy logging is required).
+//
+// Default is nil: errors are silently dropped. Production deployments
+// SHOULD wire this to their logger / metrics surface.
+func WithFSWatcherErrorHandler(fn func(error)) WatcherOption {
+	return func(c *providerConfig) {
+		c.fsWatcherErrHandler = fn
 	}
 }
 

--- a/ext/skills/watcher.go
+++ b/ext/skills/watcher.go
@@ -1,0 +1,342 @@
+package skills
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// defaultFSWatcherIgnore is the always-on ignore set for the fsnotify
+// Detector — directories that almost certainly aren't skill content
+// and would generate noisy events. Augmented by WithFSWatcherIgnore.
+var defaultFSWatcherIgnore = []string{".git", "node_modules", ".DS_Store"}
+
+// fsWatcher is the fsnotify-driven Detector. It walks hostRoot at
+// setup, watches every directory not matched by the ignore set, and
+// translates fsnotify events into PathChange events forwarded to
+// Provider.NotifyChangedEvents.
+//
+// Lifecycle is owned by Provider: setup happens in NewProvider (so
+// errors surface there), start happens in RegisterWith (so events
+// don't fire before a server is bound), Close stops abruptly, and
+// Shutdown drains in-flight events through one final flush.
+type fsWatcher struct {
+	hostRoot   string
+	ignore     []string
+	errHandler func(error)
+	watcher    *fsnotify.Watcher
+
+	mu          sync.Mutex
+	watchedDirs map[string]struct{}
+
+	started  bool
+	done     chan struct{}
+	exited   chan struct{}
+	stopOnce sync.Once
+}
+
+// newFSWatcher constructs an fsnotify-backed watcher rooted at
+// hostRoot and registers watches on every directory in the tree not
+// matched by ignore. Returns ErrFSWatcherSetupFailed (wrapping the
+// underlying cause) when fsnotify.NewWatcher fails or the initial walk
+// can't even read hostRoot itself; per-subdir Add failures are routed
+// to errHandler and skipped (one unreadable subdir does not fail
+// construction).
+func newFSWatcher(hostRoot string, ignore []string, errHandler func(error)) (*fsWatcher, error) {
+	abs, err := filepath.Abs(hostRoot)
+	if err != nil {
+		return nil, fmt.Errorf("%w: resolve hostRoot %q: %v", ErrFSWatcherSetupFailed, hostRoot, err)
+	}
+	w, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrFSWatcherSetupFailed, err)
+	}
+	fw := &fsWatcher{
+		hostRoot:    abs,
+		ignore:      mergeIgnore(ignore),
+		errHandler:  errHandler,
+		watcher:     w,
+		watchedDirs: map[string]struct{}{},
+		done:        make(chan struct{}),
+		exited:      make(chan struct{}),
+	}
+	if err := fw.walkAndWatch(abs); err != nil {
+		w.Close()
+		return nil, fmt.Errorf("%w: initial walk of %q: %v", ErrFSWatcherSetupFailed, abs, err)
+	}
+	return fw, nil
+}
+
+// mergeIgnore prepends defaults so a caller-supplied empty slice still
+// gets the always-on set; supplied patterns supplement the defaults.
+func mergeIgnore(extra []string) []string {
+	out := append([]string{}, defaultFSWatcherIgnore...)
+	for _, p := range extra {
+		if p == "" {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+// walkAndWatch enumerates every directory under root and registers a
+// watch on each one not matched by the ignore set. Errors from
+// individual watcher.Add calls go through errHandler so a single
+// permission-denied subdir does not abort the whole walk.
+func (fw *fsWatcher) walkAndWatch(root string) error {
+	return filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			fw.reportErr(fmt.Errorf("walk %q: %w", p, err))
+			if p == root {
+				return err
+			}
+			return nil
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		if fw.isIgnored(p) {
+			return filepath.SkipDir
+		}
+		fw.mu.Lock()
+		_, already := fw.watchedDirs[p]
+		fw.mu.Unlock()
+		if already {
+			return nil
+		}
+		if err := fw.watcher.Add(p); err != nil {
+			fw.reportErr(fmt.Errorf("watch add %q: %w", p, err))
+			return nil
+		}
+		fw.mu.Lock()
+		fw.watchedDirs[p] = struct{}{}
+		fw.mu.Unlock()
+		return nil
+	})
+}
+
+// isIgnored returns true when p contains an ignored segment, treated
+// as a path-component match relative to hostRoot.
+func (fw *fsWatcher) isIgnored(p string) bool {
+	rel, err := filepath.Rel(fw.hostRoot, p)
+	if err != nil {
+		return false
+	}
+	if rel == "." {
+		return false
+	}
+	parts := strings.Split(filepath.ToSlash(rel), "/")
+	for _, seg := range parts {
+		for _, pat := range fw.ignore {
+			if seg == pat {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// reportErr delivers an error to the configured handler when set;
+// silently drops otherwise. Never blocks the watcher goroutine —
+// handlers MUST themselves be non-blocking.
+func (fw *fsWatcher) reportErr(err error) {
+	if fw.errHandler == nil {
+		return
+	}
+	fw.errHandler(err)
+}
+
+// start spawns the dispatch goroutine that forwards fsnotify events
+// into provider.NotifyChangedEvents. Idempotent: a second call is a
+// no-op. The goroutine exits when Close or Shutdown signals done OR
+// when fsnotify's channels close on their own.
+func (fw *fsWatcher) start(p *Provider) {
+	fw.mu.Lock()
+	if fw.started {
+		fw.mu.Unlock()
+		return
+	}
+	fw.started = true
+	fw.mu.Unlock()
+	go fw.run(p)
+}
+
+// run is the dispatch loop. Reads fsnotify events, maps them into
+// PathChange + ChangeAction, batches them per outer NotifyChangedEvents
+// call (the Applier's coalesce window further collapses burst events
+// from editor saves). On done, drains buffered events non-blockingly
+// before exiting so Shutdown's graceful path doesn't lose state.
+func (fw *fsWatcher) run(p *Provider) {
+	defer close(fw.exited)
+	for {
+		select {
+		case event, ok := <-fw.watcher.Events:
+			if !ok {
+				return
+			}
+			fw.handleEvent(p, event)
+		case err, ok := <-fw.watcher.Errors:
+			if !ok {
+				return
+			}
+			fw.reportErr(fmt.Errorf("fsnotify runtime: %w", err))
+		case <-fw.done:
+			fw.drainAndExit(p)
+			return
+		}
+	}
+}
+
+// drainAndExit consumes any events already buffered in the fsnotify
+// channel and forwards them, then returns. Called from run when done
+// fires so Shutdown's caller sees a clean state before the goroutine
+// exits.
+func (fw *fsWatcher) drainAndExit(p *Provider) {
+	for {
+		select {
+		case event, ok := <-fw.watcher.Events:
+			if !ok {
+				return
+			}
+			fw.handleEvent(p, event)
+		default:
+			return
+		}
+	}
+}
+
+// handleEvent maps one fsnotify.Event into a PathChange + forwards it
+// to the Applier. Directory-create events extend the watch set;
+// directory-remove events prune it. Path-traversal of the watch set
+// uses the hostRoot-relative form so PathChange.Path matches what
+// Provider.NotifyChangedEvents expects.
+func (fw *fsWatcher) handleEvent(p *Provider, event fsnotify.Event) {
+	if fw.isIgnored(event.Name) {
+		return
+	}
+	rel, err := filepath.Rel(fw.hostRoot, event.Name)
+	if err != nil {
+		fw.reportErr(fmt.Errorf("rel path for %q: %w", event.Name, err))
+		return
+	}
+	rel = filepath.ToSlash(rel)
+
+	action, forward := mapFSNotifyOp(event.Op)
+	if forward {
+		change := PathChange{
+			Path:      rel,
+			Action:    action,
+			Timestamp: time.Now(),
+		}
+		_ = p.NotifyChangedEvents(change)
+	}
+
+	if event.Op&fsnotify.Create != 0 {
+		fw.extendWatchIfDir(event.Name)
+	}
+	if event.Op&(fsnotify.Remove|fsnotify.Rename) != 0 {
+		fw.pruneWatch(event.Name)
+	}
+}
+
+// mapFSNotifyOp translates an fsnotify.Op bitmask into the
+// ChangeAction that subscribers will see. Returns forward=false for
+// no-op events (currently none — kept as the seam if e.g. Chmod-only
+// events should be dropped later).
+func mapFSNotifyOp(op fsnotify.Op) (ChangeAction, bool) {
+	switch {
+	case op&fsnotify.Create != 0:
+		return ChangeActionCreated, true
+	case op&(fsnotify.Remove|fsnotify.Rename) != 0:
+		return ChangeActionDeleted, true
+	case op&(fsnotify.Write|fsnotify.Chmod) != 0:
+		return ChangeActionModified, true
+	}
+	return "", false
+}
+
+// extendWatchIfDir registers a watch on path when it points at a
+// directory (so newly created subtrees become observable without a
+// manual walk). Silently no-ops on stat errors — the Create event
+// already fired into the Applier; missing the recursive expansion is
+// a degradation, not a data-loss bug.
+func (fw *fsWatcher) extendWatchIfDir(p string) {
+	info, err := os.Stat(p)
+	if err != nil || !info.IsDir() {
+		return
+	}
+	if fw.isIgnored(p) {
+		return
+	}
+	if err := fw.walkAndWatch(p); err != nil {
+		fw.reportErr(fmt.Errorf("recursive watch %q: %w", p, err))
+	}
+}
+
+// pruneWatch removes path from the watch set on directory removal so
+// fsnotify's per-watcher capacity isn't pinned by ghost entries.
+// fsnotify auto-removes the kernel watch when the inode goes away;
+// this mirrors our bookkeeping so re-creating the same path later
+// re-walks cleanly.
+func (fw *fsWatcher) pruneWatch(p string) {
+	fw.mu.Lock()
+	defer fw.mu.Unlock()
+	for dir := range fw.watchedDirs {
+		if dir == p || strings.HasPrefix(dir, p+string(filepath.Separator)) {
+			delete(fw.watchedDirs, dir)
+		}
+	}
+}
+
+// close stops the dispatch goroutine abruptly and releases the
+// underlying fsnotify.Watcher. Idempotent. Pending events in the
+// fsnotify channel are dropped.
+func (fw *fsWatcher) close() error {
+	if fw == nil {
+		return nil
+	}
+	var err error
+	fw.stopOnce.Do(func() {
+		close(fw.done)
+		err = fw.watcher.Close()
+	})
+	return err
+}
+
+// shutdown signals graceful drain: the dispatch goroutine consumes
+// any events still buffered in the fsnotify channel, forwards them
+// through the Applier, then exits. Waits for the goroutine to exit
+// or for ctx to cancel, whichever fires first; on ctx cancel the
+// watcher is still closed cleanly but ctx.Err() is returned so the
+// caller knows the drain didn't complete.
+func (fw *fsWatcher) shutdown(ctx context.Context) error {
+	if fw == nil {
+		return nil
+	}
+	var ferr error
+	fw.stopOnce.Do(func() {
+		close(fw.done)
+	})
+	select {
+	case <-fw.exited:
+	case <-ctx.Done():
+		ferr = ctx.Err()
+	}
+	if cerr := fw.watcher.Close(); cerr != nil && ferr == nil {
+		ferr = cerr
+	}
+	if errors.Is(ferr, context.Canceled) || errors.Is(ferr, context.DeadlineExceeded) {
+		return ferr
+	}
+	return nil
+}
+

--- a/ext/skills/watcher_test.go
+++ b/ext/skills/watcher_test.go
@@ -1,0 +1,304 @@
+package skills_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+
+	"github.com/panyam/mcpkit/client"
+	"github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/ext/skills"
+	"github.com/panyam/mcpkit/server"
+)
+
+func TestFSWatcher_EventOpMapping_Create(t *testing.T) {
+	action, fwd := skills.ExportedMapFSNotifyOp(fsnotify.Create)
+	if !fwd {
+		t.Fatalf("Create not forwarded")
+	}
+	if action != skills.ChangeActionCreated {
+		t.Errorf("Create → %q, want %q", action, skills.ChangeActionCreated)
+	}
+}
+
+func TestFSWatcher_EventOpMapping_Write(t *testing.T) {
+	action, fwd := skills.ExportedMapFSNotifyOp(fsnotify.Write)
+	if !fwd {
+		t.Fatalf("Write not forwarded")
+	}
+	if action != skills.ChangeActionModified {
+		t.Errorf("Write → %q, want %q", action, skills.ChangeActionModified)
+	}
+}
+
+func TestFSWatcher_EventOpMapping_Remove(t *testing.T) {
+	action, fwd := skills.ExportedMapFSNotifyOp(fsnotify.Remove)
+	if !fwd {
+		t.Fatalf("Remove not forwarded")
+	}
+	if action != skills.ChangeActionDeleted {
+		t.Errorf("Remove → %q, want %q", action, skills.ChangeActionDeleted)
+	}
+}
+
+func TestFSWatcher_EventOpMapping_Rename(t *testing.T) {
+	action, fwd := skills.ExportedMapFSNotifyOp(fsnotify.Rename)
+	if !fwd {
+		t.Fatalf("Rename not forwarded")
+	}
+	if action != skills.ChangeActionDeleted {
+		t.Errorf("Rename → %q, want %q (rename = deleted from watcher POV)", action, skills.ChangeActionDeleted)
+	}
+}
+
+func TestProvider_FSWatcher_RequiresHostRoot(t *testing.T) {
+	_, err := skills.NewProvider(
+		skills.WithFS(fstest.MapFS{
+			"foo/SKILL.md": &fstest.MapFile{Data: []byte("---\nname: foo\ndescription: x\n---\n")},
+		}),
+		skills.WithFSWatcher(),
+	)
+	if err == nil {
+		t.Fatalf("NewProvider with WithFS + WithFSWatcher succeeded; want ErrFSWatcherMissingHostRoot")
+	}
+	if !errors.Is(err, skills.ErrFSWatcherMissingHostRoot) {
+		t.Errorf("error = %v, want ErrFSWatcherMissingHostRoot", err)
+	}
+}
+
+func TestProvider_FSWatcher_DefaultsToNoWatcher(t *testing.T) {
+	p, err := skills.NewProvider(skills.WithDirectory("testdata/valid"))
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	t.Cleanup(func() { p.Close() })
+}
+
+func TestProvider_FSWatcher_BroadcastsOnFileModify(t *testing.T) {
+	dir := stageSkillsDir(t)
+	c, p := bootFSWatcherTest(t, dir, skills.WithCoalesceWindow(150*time.Millisecond))
+
+	payloads := make(chan skills.PathsChangedPayload, 4)
+	listenForPayloads(t, c, payloads)
+
+	target := filepath.Join(dir, "git-workflow", "SKILL.md")
+	body := []byte("---\nname: git-workflow\ndescription: edited at " + time.Now().Format(time.RFC3339Nano) + "\n---\n\nupdated body\n")
+	if err := os.WriteFile(target, body, 0o644); err != nil {
+		t.Fatalf("write %s: %v", target, err)
+	}
+
+	select {
+	case payload := <-payloads:
+		entry, ok := payload.Paths["git-workflow/SKILL.md"]
+		if !ok {
+			t.Fatalf("payload missing git-workflow/SKILL.md (paths: %v)", payload.Paths)
+		}
+		if entry.Action != skills.ChangeActionModified {
+			t.Errorf("action = %q, want %q", entry.Action, skills.ChangeActionModified)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatalf("no broadcast received within deadline")
+	}
+	_ = p
+}
+
+func TestProvider_FSWatcher_BroadcastsOnFileCreate(t *testing.T) {
+	dir := stageSkillsDir(t)
+	c, p := bootFSWatcherTest(t, dir, skills.WithCoalesceWindow(150*time.Millisecond))
+
+	payloads := make(chan skills.PathsChangedPayload, 4)
+	listenForPayloads(t, c, payloads)
+
+	target := filepath.Join(dir, "git-workflow", "newfile.md")
+	if err := os.WriteFile(target, []byte("# new file"), 0o644); err != nil {
+		t.Fatalf("write %s: %v", target, err)
+	}
+
+	select {
+	case payload := <-payloads:
+		entry, ok := payload.Paths["git-workflow/newfile.md"]
+		if !ok {
+			t.Fatalf("payload missing git-workflow/newfile.md (paths: %v)", payload.Paths)
+		}
+		if entry.Action != skills.ChangeActionCreated && entry.Action != skills.ChangeActionModified {
+			t.Errorf("action = %q, want Created or Modified", entry.Action)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatalf("no broadcast received within deadline")
+	}
+	_ = p
+}
+
+func TestProvider_FSWatcher_BroadcastsOnFileDelete(t *testing.T) {
+	dir := stageSkillsDir(t)
+	c, p := bootFSWatcherTest(t, dir, skills.WithCoalesceWindow(150*time.Millisecond))
+
+	payloads := make(chan skills.PathsChangedPayload, 4)
+	listenForPayloads(t, c, payloads)
+
+	target := filepath.Join(dir, "git-workflow", "SKILL.md")
+	if err := os.Remove(target); err != nil {
+		t.Fatalf("remove %s: %v", target, err)
+	}
+
+	select {
+	case payload := <-payloads:
+		entry, ok := payload.Paths["git-workflow/SKILL.md"]
+		if !ok {
+			t.Fatalf("payload missing git-workflow/SKILL.md (paths: %v)", payload.Paths)
+		}
+		if entry.Action != skills.ChangeActionDeleted {
+			t.Errorf("action = %q, want %q", entry.Action, skills.ChangeActionDeleted)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatalf("no broadcast received within deadline")
+	}
+	_ = p
+}
+
+func TestProvider_FSWatcher_RespectsIgnoreList(t *testing.T) {
+	dir := stageSkillsDir(t)
+	gitDir := filepath.Join(dir, ".git")
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	c, p := bootFSWatcherTest(t, dir, skills.WithCoalesceWindow(100*time.Millisecond))
+
+	got := atomic.Int32{}
+	c.RegisterNotificationOnList(func() { got.Add(1) }, t)
+
+	if err := os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte("ref: refs/heads/main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(400 * time.Millisecond)
+
+	if c := got.Load(); c != 0 {
+		t.Errorf("writes to .git/ triggered %d broadcasts, want 0", c)
+	}
+	_ = p
+}
+
+func TestProvider_Shutdown_DrainsBufferedEvents(t *testing.T) {
+	dir := stageSkillsDir(t)
+	c, p := bootFSWatcherTest(t, dir, skills.WithCoalesceWindow(500*time.Millisecond))
+
+	payloads := make(chan skills.PathsChangedPayload, 4)
+	listenForPayloads(t, c, payloads)
+
+	target := filepath.Join(dir, "git-workflow", "SKILL.md")
+	if err := os.WriteFile(target, []byte("---\nname: git-workflow\ndescription: y\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := p.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	select {
+	case payload := <-payloads:
+		if _, ok := payload.Paths["git-workflow/SKILL.md"]; !ok {
+			t.Errorf("graceful shutdown lost the pending path (paths: %v)", payload.Paths)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatalf("Shutdown did not flush the pending broadcast")
+	}
+}
+
+func TestProvider_Close_StopsWatcherAbruptly(t *testing.T) {
+	dir := stageSkillsDir(t)
+	c, p := bootFSWatcherTest(t, dir, skills.WithCoalesceWindow(100*time.Millisecond))
+
+	got := atomic.Int32{}
+	c.RegisterNotificationOnList(func() { got.Add(1) }, t)
+
+	if err := p.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	target := filepath.Join(dir, "git-workflow", "SKILL.md")
+	if err := os.WriteFile(target, []byte("post-close"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(400 * time.Millisecond)
+	if c := got.Load(); c != 0 {
+		t.Errorf("after Close: %d broadcasts arrived, want 0", c)
+	}
+}
+
+func stageSkillsDir(t *testing.T) string {
+	t.Helper()
+	dst := t.TempDir()
+	if err := copyTree("testdata/valid", dst); err != nil {
+		t.Fatalf("stage skills: %v", err)
+	}
+	return dst
+}
+
+func copyTree(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if info.IsDir() {
+			return os.MkdirAll(target, info.Mode())
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, info.Mode())
+	})
+}
+
+func bootFSWatcherTest(t *testing.T, dir string, providerOpts ...skills.ProviderOption) (*clientWithCallbacks, *skills.Provider) {
+	t.Helper()
+	srv := server.NewServer(core.ServerInfo{Name: "skills-test", Version: "0.0.1"})
+
+	opts := []skills.ProviderOption{
+		skills.WithDirectory(dir),
+		skills.WithFSWatcher(),
+	}
+	opts = append(opts, providerOpts...)
+	p, err := skills.NewProvider(opts...)
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	p.RegisterWith(srv)
+	t.Cleanup(func() { p.Close() })
+
+	handler := srv.Handler(server.WithStreamableHTTP(true))
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	wrapper := &clientWithCallbacks{}
+	c := client.NewClient(ts.URL+"/mcp",
+		core.ClientInfo{Name: "skills-test-client", Version: "0.0.1"},
+		client.WithGetSSEStream(),
+		client.WithNotificationCallback(wrapper.onNotify),
+	)
+	wrapper.Client = c
+	if err := c.Connect(); err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+
+	time.Sleep(150 * time.Millisecond)
+	return wrapper, p
+}


### PR DESCRIPTION
Closes #800.

## What changes

Builds the first concrete Detector that consumes the typed Applier API from #795 / #799 — an fsnotify-backed goroutine that watches the Provider's `hostRoot`, maps `fsnotify.Op` to `ChangeAction` (Create→Created, Write/Chmod→Modified, Remove/Rename→Deleted), and forwards each as a `PathChange` to `Provider.NotifyChangedEvents`. The Applier's `WithCoalesceWindow` collapses editor-save bursts (3–5 fsnotify events per save) into one broadcast.

Also adds **`Provider.Shutdown(ctx context.Context)`** — the graceful counterpart to `Close()`, modeled on `http.Server.Shutdown`. Signals the dispatch goroutine to drain any events still buffered in fsnotify's channel through one final `NotifyChangedEvents` call before exiting; runs a final flush so accumulated PathChanges land in one last broadcast; waits on the goroutine or `ctx`, whichever fires first.

### New surface
- `WithFSWatcher(opts ...WatcherOption)` Provider option (opt-in).
- `WithFSWatcherIgnore(patterns ...string)` — supplements always-on defaults (`.git`, `node_modules`, `.DS_Store`).
- `WithFSWatcherErrorHandler(func(error))` — production-grade hook for fsnotify runtime errors.
- `Provider.Shutdown(ctx)` — graceful drain + final flush + close.
- `ErrFSWatcherMissingHostRoot` / `ErrFSWatcherSetupFailed` sentinels.

### Demo
- `examples/skills/main.go` — `--watch` flag enables `WithFSWatcher` + a 200ms coalesce window. `WithFSWatcherErrorHandler` routes runtime errors to the serve log.
- `examples/skills/walkthrough.go` — new "fsnotify-driven invalidation" step. **Mode-aware**: in `--non-interactive` mode synthesizes an edit via `os.WriteFile` + restores the original content so CI runs stay self-contained; in interactive mode prompts the operator to edit a SKILL.md in another terminal. Either path waits up to 10s for the version bump.

## Reviewer's guide

Read in this order:

1. [ext/skills/provider_options.go](https://github.com/panyam/mcpkit/pull/805/files#diff-02ce7b9d8644be81ed6118ce376e8e695e085c46c041d0192f11b905f267fd79) — start here. `hostRoot` field on `providerConfig` (captured by `WithDirectory`); `WithFSWatcher` + `WatcherOption` helpers; trade-offs in godoc.
2. [ext/skills/watcher.go](https://github.com/panyam/mcpkit/pull/805/files#diff-3cf61cbe0017c59ad3086bc8cb209ce3ccc2b10b1d0e2795db4516b238326386) — `fsWatcher` struct + setup walk + dispatch goroutine + `shutdown(ctx)` / `close()` lifecycle + `mapFSNotifyOp` translator.
3. [ext/skills/provider.go](https://github.com/panyam/mcpkit/pull/805/files#diff-bc1bc138c97cce27ab4ebcc05b5b90bce9519a5b6ece2cd00da30248841d7021) — lifecycle integration: `NewProvider` builds the watcher; `RegisterWith` starts the goroutine; `Close` stops abruptly; new `Shutdown(ctx)` drains gracefully. `draining` flag short-circuits `NotifyChangedEvents` mid-shutdown.
4. [ext/skills/errors.go](https://github.com/panyam/mcpkit/pull/805/files#diff-097721358b725e6ce2ea62d43e0c77494d94644f016803b1fb7b949b957b6bc7) — two new sentinels.
5. [ext/skills/watcher_test.go](https://github.com/panyam/mcpkit/pull/805/files#diff-87c99773049c2443aa2b5c13d001b611fa27c2b10939e4ed768e53ae7dfd3b96) — 11 tests covering op-mapping, requires-hostRoot, file-modify / file-create / file-delete via temp dir + `os.WriteFile`, ignore-list, graceful Shutdown drain, abrupt Close suppression.
6. [ext/skills/export_test.go](https://github.com/panyam/mcpkit/pull/805/files#diff-79baf6501ca8d92aa5a873ee0bba9426aeab8993a3ca245826aa503ced378f80) — test-only seam for the unexported event-op mapper.
7. [examples/skills/main.go](https://github.com/panyam/mcpkit/pull/805/files#diff-5b14977a06843ef8ea751a41d80e1cd9eb927a784069536cf93b0857dc9261fc) — `--watch` wiring.
8. [examples/skills/walkthrough.go](https://github.com/panyam/mcpkit/pull/805/files#diff-94afaa0ca3ed61f670feefe88925e3b5ecfc827cfcdb7612d48a01dd289c10e7) — new step + `isInteractive()` helper.
9. [examples/skills/WALKTHROUGH.md](https://github.com/panyam/mcpkit/pull/805/files#diff-f7567dfcd105e517415a8fc5aada2b08489ad36774f38681b85f5855a3638884) — regenerated; sanity-skim.

## Decision log

- **`Shutdown(ctx)` added alongside `Close()`** (not as a replacement). Matches `http.Server` convention: `Close` is process-exit semantics, `Shutdown` is graceful. The watcher goroutine holds in-flight state (events buffered in fsnotify's channel) that `Close` would drop — `Shutdown` drains it through one final flush.
- **Watcher started at `RegisterWith`, not `NewProvider`.** Events fired before `RegisterWith` would have no server to broadcast to; deferring eliminates that race. Validation (path resolution, fsnotify allocation, initial walk) happens at `NewProvider` so errors surface from construction.
- **Lenient-at-startup error handling.** Per-subdir `watcher.Add` failures (permission denied on one directory) are routed to the `WithFSWatcherErrorHandler` callback and skipped — one bad subdir doesn't fail the whole Provider construction. Brittle alternatives considered + rejected in the planning discussion.
- **Per-server Applier, not per-client.** Single Applier on the Provider; fsnotify events drive one shared bump + broadcast that fans out to every subscribed session. Per-client subscription filtering is the cross-cutting core mcpkit concern tracked in #802.
- **Coalesce lives on the Applier, not in the Detector.** fsnotify firing 3–5 events per editor save naturally collapses through `WithCoalesceWindow` from #799. No Detector-side debounce reinvention.
- **`hostRoot` captured by `WithDirectory`, not a separate `WithFSWatcher(rootPath)`.** DRY for the common case. `WithFS` users get a clear error pointing them at `WithDirectory`.
- **Default ignore set is always on.** `.git` / `node_modules` / `.DS_Store` are skipped regardless of `WithFSWatcherIgnore` — every real adopter wants these out. Custom patterns supplement, not replace.
- **Test seam via `export_test.go`** rather than promoting `mapFSNotifyOp` to public API. Keeps the public surface minimal.

## Risk / blast radius

- **Affects:** `ext/skills.Provider` (new public methods + struct fields), `ext/skills/go.mod` (new `fsnotify` dep — pure Go, no CGO). Sub-module isolation means root module + other ext/* sub-modules unaffected.
- **Tests covering this:** 11 new tests in `watcher_test.go`. Full ext/skills + core + server + client suites pass.
- **Be paranoid about:** the integration tests use 3-second deadlines with `time.Sleep` settle margins. fsnotify event delivery has real-OS jitter; if CI proves flaky, bump deadlines or add `os.Sync` before reads. macOS tests pass locally; CI typically runs linux/darwin both.
- **Shutdown race**: `Shutdown` and `Close` are both idempotent and share the `draining` + `closed` flags under `notifyMu`. Concurrent `Shutdown` + `Close` is well-defined: whichever set `draining=true` first wins; the other becomes a no-op.

## Before / after

Walkthrough step output (non-interactive):

```
--- fsnotify-driven invalidation (issue #800) ---
Step 12: Observe an fsnotify-driven broadcast
  before edit: version = 1
  Synthesizing an edit to skills/git-workflow/SKILL.md (non-interactive mode)…
  after edit: version = 3 (bump observed via fsnotify; coalesced into one broadcast)
```

Version went from 1→3 because the previous Refresh step's bump (1) + the synthetic edit + the restore-original write each trigger a NotifyChangedEvents call; the coalesce window collapses what fsnotify fires from each `os.WriteFile` (which is ~2-3 events) into one bump per write, hence +2 total.

## Out of scope (deliberately deferred)

- **HTTP / admin control-plane Detector** — POST endpoint that accepts change-path lists and calls `NotifyChangedEvents`. Sibling of fsnotify; not yet filed.
- **Polling-based Detector** — for filesystems fsnotify doesn't support (network mounts, weird containers). Not yet filed.
- **Pushdown to templar** — captured in #801; defer until a second consumer surfaces.
- **Per-client subscription filtering** — captured in #802; cross-cutting mcpkit concern, not skills-specific.
- **Artifact-dir backed cache** (URI→path mirror with `_` separator option) — design surfaced during this PR's review; will capture as a comment on #798 (PackSkill cache).

## Test plan

- [x] `go test ./ext/skills/...` (11 new tests + all existing — clean)
- [x] `go test ./core/... ./server/... ./client/...` (no regressions)
- [x] `make serve --watch` + walkthrough → observes version bump after synthetic edit
- [x] `make readme` regenerates `WALKTHROUGH.md` cleanly
- [x] git diff after walkthrough shows no modified files (synth-edit revert clean)
