### PR TITLE
examples/skills: walkthrough exercises archive + github sub-mounts

### DIFF
--- a/examples/skills/WALKTHROUGH.md
+++ b/examples/skills/WALKTHROUGH.md
@@ -14,6 +14,8 @@ SEP-2640 serves Agent Skills over MCP's Resources primitive: each file under a s
 - **Read a supporting file via skill:// (references/FORMS.md)** — Relative reference resolution: references/FORMS.md from inside pdf-processing/SKILL.md resolves to this full URI via the SDK helper that walks the skill root.
 - **Read a nested-prefix skill (acme/billing/refunds)** — Demonstrates that the prefix-segment routing works end-to-end. The skill name is refunds; the acme/billing/ prefix is server-chosen and is opaque to the skill's own frontmatter.
 - **Read a supporting file in the nested skill (templates/email.md)** — Same relative-reference resolution as the pdf-processing example, this time across a multi-segment prefix.
+- **Read a skill via the archive sub-mount (proves auto-wrap end-to-end)** — `make serve` packs the bundled `git-workflow` skill into a tempfile tar.gz and mounts it under the `archived/` sub-mount. `OpenArchive` auto-wraps the archive's root-level SKILL.md under `git-workflow/` (matching the frontmatter name), so the served URI is `skill://archived/git-workflow/SKILL.md`. Bytes match the local copy — same skill, different transport. Recompute the digest if you want to verify.
+- **Discover and read a skill via the github sub-mount** — Robust against changes in the upstream repo: instead of hardcoding a github URI, we enumerate `resources/list`, pick the first entry under the `github/` prefix, and read it. Proves the entire FetchGitHubArchive → MountFS sub-mount → resources/read chain — server reaches out to GitHub at boot, the bytes flow through the same MCP wire as everything else.
 - **Read the version, refresh, observe it bump** — The version field lives under `_meta` with the reverse-domain key `io.modelcontextprotocol.skills/version`, matching mcpkit's existing convention for extension metadata. The dual-wire story: subscribed stateful clients get the push notification; stateless clients see the same change by re-reading and comparing the version.
 - **List a directory inside a skill and recurse into a subdirectory** — Subdirectories surface with mimeType inode/directory; the client descends by issuing a second call. The SDK wraps this into a single call; the curl below shows both round trips explicitly.
 - **Wrap reads in skills.NewClient(...) and call Client.Activate** — Activate is intra-process — no wire traffic. Run with `make serve EXPORTER=stdout` + `make demo EXPORTER=stdout` to see spans.
@@ -62,23 +64,32 @@ sequenceDiagram
     Host->>Server: resources/read uri=skill://acme/billing/refunds/templates/email.md
     Server-->>Host: text/markdown body
 
-    Note over Host,Server: Step 11: Read the version, refresh, observe it bump
+    Note over Host,Server: Step 11: Read a skill via the archive sub-mount (proves auto-wrap end-to-end)
+    Host->>Server: resources/read uri=skill://archived/git-workflow/SKILL.md
+    Server-->>Host: text/markdown body (same content as skill://git-workflow/SKILL.md)
+
+    Note over Host,Server: Step 12: Discover and read a skill via the github sub-mount
+    Host->>Server: resources/list (filter for skill://github/...)
+    Host->>Server: resources/read uri=<first github URI>
+    Server-->>Host: content fetched from anthropics/skills at server boot
+
+    Note over Host,Server: Step 13: Read the version, refresh, observe it bump
     Host->>Server: resources/read uri=skill://index.json (capture _meta version)
     Host->>Server: tools/call name=_demo/refresh (server calls Provider.Refresh())
     Server-->>Host: notifications/resources/list_changed (stateful wire only)
     Host->>Server: resources/read uri=skill://index.json (observe version bumped)
 
-    Note over Host,Server: Step 12: List a directory inside a skill and recurse into a subdirectory
+    Note over Host,Server: Step 14: List a directory inside a skill and recurse into a subdirectory
     Host->>Server: resources/directory/read uri=skill://acme/billing/refunds/templates
     Server-->>Host: 2 files + 1 subdirectory (`regional`, inode/directory)
     Host->>Server: resources/directory/read uri=skill://acme/billing/refunds/templates/regional
     Server-->>Host: 1 file (eu.md)
 
-    Note over Host,Server: Step 13: Wrap reads in skills.NewClient(...) and call Client.Activate
+    Note over Host,Server: Step 15: Wrap reads in skills.NewClient(...) and call Client.Activate
     Host->>Server: resources/read via sc.ReadAndVerify (span: skills.read_and_verify)
     Server-->>Host: bytes + digest match
 
-    Note over Host,Server: Step 14: Read pdf-processing archive, verify digest, unpack, list recovered files
+    Note over Host,Server: Step 16: Read pdf-processing archive, verify digest, unpack, list recovered files
     Host->>Server: resources/read uri=skill://pdf-processing.tar.gz (or .zip)
     Server-->>Host: application/gzip OR application/zip blob
 ```
@@ -274,11 +285,51 @@ curl -s -X POST http://localhost:8080/mcp \
   | jq -r '.result.contents[0].text'
 ```
 
+### Cross-source reads (issues #797 + #808)
+
+`make serve` composes multiple sources into one catalog via `fsutil.NewMountFS`: bundled local skills at the FS root + an `archived/` sub-mount (a `.tar.gz` packed from one bundled skill, auto-wrapped by frontmatter name) + a `github/` sub-mount (fetched from anthropics/skills). The previous read steps exercised the local layer. These two steps probe the sub-mounts so the cross-source story is visible in the demo, not just in resource counts. Both steps gracefully skip when running against `--source=dir` (no sub-mounts present).
+
+### Step 11: Read a skill via the archive sub-mount (proves auto-wrap end-to-end)
+
+`make serve` packs the bundled `git-workflow` skill into a tempfile tar.gz and mounts it under the `archived/` sub-mount. `OpenArchive` auto-wraps the archive's root-level SKILL.md under `git-workflow/` (matching the frontmatter name), so the served URI is `skill://archived/git-workflow/SKILL.md`. Bytes match the local copy — same skill, different transport. Recompute the digest if you want to verify.
+
+#### Reproduce on the wire
+
+```bash
+curl -s -X POST http://localhost:8080/mcp \
+  -H 'Content-Type: application/json' -H 'Accept: application/json' \
+  -H "Mcp-Session-Id: $SID" \
+  -d '{"jsonrpc":"2.0","id":15,"method":"resources/read","params":{"uri":"skill://archived/git-workflow/SKILL.md"}}' \
+  | jq -r '.result.contents[0].text'
+```
+
+### Step 12: Discover and read a skill via the github sub-mount
+
+Robust against changes in the upstream repo: instead of hardcoding a github URI, we enumerate `resources/list`, pick the first entry under the `github/` prefix, and read it. Proves the entire FetchGitHubArchive → MountFS sub-mount → resources/read chain — server reaches out to GitHub at boot, the bytes flow through the same MCP wire as everything else.
+
+#### Reproduce on the wire
+
+```bash
+# Find the first github URI in the catalog.
+GH=$(curl -s -X POST http://localhost:8080/mcp \
+  -H 'Content-Type: application/json' -H 'Accept: application/json' \
+  -H "Mcp-Session-Id: $SID" \
+  -d '{"jsonrpc":"2.0","id":16,"method":"resources/list"}' \
+  | jq -r '.result.resources[].uri' | grep '^skill://github/' | head -1)
+echo "$GH"
+# Read it.
+curl -s -X POST http://localhost:8080/mcp \
+  -H 'Content-Type: application/json' -H 'Accept: application/json' \
+  -H "Mcp-Session-Id: $SID" \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":17,\"method\":\"resources/read\",\"params\":{\"uri\":\"$GH\"}}" \
+  | jq -r '.result.contents[0].text' | head -20
+```
+
 ### Push-based invalidation (issue #795)
 
 `skill://index.json` carries `_meta.io.modelcontextprotocol.skills/version` — a monotonic counter the server bumps whenever skill content changes. Stateful clients also receive `notifications/resources/list_changed` when the bump happens. Stateless clients (no persistent push channel) detect the change by polling the index and observing the field. Detectors that drive the bump (fsnotify, webhook, manual sweep) are pluggable; this walkthrough uses a demo-only `_demo/refresh` tool that calls `Provider.Refresh()` directly.
 
-### Step 11: Read the version, refresh, observe it bump
+### Step 13: Read the version, refresh, observe it bump
 
 The version field lives under `_meta` with the reverse-domain key `io.modelcontextprotocol.skills/version`, matching mcpkit's existing convention for extension metadata. The dual-wire story: subscribed stateful clients get the push notification; stateless clients see the same change by re-reading and comparing the version.
 
@@ -315,7 +366,7 @@ echo "before=$V1 after=$V2"
 
 SEP commit `2e04c48d` (2026-06-09) added `resources/directory/read` for listing a directory's direct children without enumerating the server's entire resource space. Capability-gated via `io.modelcontextprotocol/skills.directoryRead`. mcpkit's Provider auto-supports it (#781).
 
-### Step 12: List a directory inside a skill and recurse into a subdirectory
+### Step 14: List a directory inside a skill and recurse into a subdirectory
 
 Subdirectories surface with mimeType inode/directory; the client descends by issuing a second call. The SDK wraps this into a single call; the curl below shows both round trips explicitly.
 
@@ -341,7 +392,7 @@ curl -s -X POST http://localhost:8080/mcp \
 
 Fetch ≠ activation. Server `resources/read` spans now carry `mcp.skill.*` attrs (#748). Client `ext/skills.Client` emits `skills.read*` spans + `Activate(ctx, uri)` for post-cache use the wire can't see (SDK-only — no spec change).
 
-### Step 13: Wrap reads in skills.NewClient(...) and call Client.Activate
+### Step 15: Wrap reads in skills.NewClient(...) and call Client.Activate
 
 Activate is intra-process — no wire traffic. Run with `make serve EXPORTER=stdout` + `make demo EXPORTER=stdout` to see spans.
 
@@ -349,7 +400,7 @@ Activate is intra-process — no wire traffic. Run with `make serve EXPORTER=std
 
 In archive mode every skill is delivered as a single `.tar.gz` or `.zip` resource. The host hashes the archive bytes against the index digest, then unpacks in-memory to recover the post-unpack virtual namespace — same files the file-mode wire would have served piecemeal. Demonstrates pdf-processing (multi-file skill) because the unpacked listing actually shows something.
 
-### Step 14: Read pdf-processing archive, verify digest, unpack, list recovered files
+### Step 16: Read pdf-processing archive, verify digest, unpack, list recovered files
 
 Only meaningful in archive mode. In file mode the step prints the detected mode and exits — see the per-file read steps above for the equivalent file-mode story.
 

--- a/examples/skills/walkthrough.go
+++ b/examples/skills/walkthrough.go
@@ -495,6 +495,98 @@ body, _ := c.ReadResource(target.String())`),
 			return nil
 		})
 
+	demo.Section("Cross-source reads (issues #797 + #808)",
+		"`make serve` composes multiple sources into one catalog via `fsutil.NewMountFS`: bundled local skills at the FS root + an `archived/` sub-mount (a `.tar.gz` packed from one bundled skill, auto-wrapped by frontmatter name) + a `github/` sub-mount (fetched from anthropics/skills). The previous read steps exercised the local layer. These two steps probe the sub-mounts so the cross-source story is visible in the demo, not just in resource counts. Both steps gracefully skip when running against `--source=dir` (no sub-mounts present).",
+	)
+
+	demo.Step("Read a skill via the archive sub-mount (proves auto-wrap end-to-end)").
+		Arrow("Host", "Server", "resources/read uri=skill://archived/git-workflow/SKILL.md").
+		DashedArrow("Server", "Host", "text/markdown body (same content as skill://git-workflow/SKILL.md)").
+		Note("`make serve` packs the bundled `git-workflow` skill into a tempfile tar.gz and mounts it under the `archived/` sub-mount. `OpenArchive` auto-wraps the archive's root-level SKILL.md under `git-workflow/` (matching the frontmatter name), so the served URI is `skill://archived/git-workflow/SKILL.md`. Bytes match the local copy — same skill, different transport. Recompute the digest if you want to verify.").
+		VerbatimVariants("Reproduce on the wire",
+			demokit.MakeVariant("curl", "bash", `curl -s -X POST http://localhost:8080/mcp \
+  -H 'Content-Type: application/json' -H 'Accept: application/json' \
+  -H "Mcp-Session-Id: $SID" \
+  -d '{"jsonrpc":"2.0","id":15,"method":"resources/read","params":{"uri":"skill://archived/git-workflow/SKILL.md"}}' \
+  | jq -r '.result.contents[0].text'`).Default(),
+			demokit.MakeVariant("go", "go", `body, _ := c.ReadResource("skill://archived/git-workflow/SKILL.md")
+fmt.Println(body)`),
+		).
+		Run(func(ctx demokit.StepContext) *demokit.StepResult {
+			if c == nil {
+				return nil
+			}
+			body, err := c.ReadResource("skill://archived/git-workflow/SKILL.md")
+			if err != nil {
+				fmt.Printf("    SKIP: %v (run with `make serve` for the multi-source demo)\n", err)
+				return nil
+			}
+			fmt.Printf("    served via archived/ sub-mount (auto-wrapped by frontmatter name):\n")
+			previewBody(body)
+			return nil
+		})
+
+	demo.Step("Discover and read a skill via the github sub-mount").
+		Arrow("Host", "Server", "resources/list (filter for skill://github/...)").
+		Arrow("Host", "Server", "resources/read uri=<first github URI>").
+		DashedArrow("Server", "Host", "content fetched from anthropics/skills at server boot").
+		Note("Robust against changes in the upstream repo: instead of hardcoding a github URI, we enumerate `resources/list`, pick the first entry under the `github/` prefix, and read it. Proves the entire FetchGitHubArchive → MountFS sub-mount → resources/read chain — server reaches out to GitHub at boot, the bytes flow through the same MCP wire as everything else.").
+		VerbatimVariants("Reproduce on the wire",
+			demokit.MakeVariant("curl", "bash", `# Find the first github URI in the catalog.
+GH=$(curl -s -X POST http://localhost:8080/mcp \
+  -H 'Content-Type: application/json' -H 'Accept: application/json' \
+  -H "Mcp-Session-Id: $SID" \
+  -d '{"jsonrpc":"2.0","id":16,"method":"resources/list"}' \
+  | jq -r '.result.resources[].uri' | grep '^skill://github/' | head -1)
+echo "$GH"
+# Read it.
+curl -s -X POST http://localhost:8080/mcp \
+  -H 'Content-Type: application/json' -H 'Accept: application/json' \
+  -H "Mcp-Session-Id: $SID" \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":17,\"method\":\"resources/read\",\"params\":{\"uri\":\"$GH\"}}" \
+  | jq -r '.result.contents[0].text' | head -20`).Default(),
+			demokit.MakeVariant("go", "go", `defs, _ := c.ListResources(ctx)
+var githubURI string
+for _, d := range defs {
+    if strings.HasPrefix(d.URI, "skill://github/") {
+        githubURI = d.URI
+        break
+    }
+}
+body, _ := c.ReadResource(githubURI)
+fmt.Println(body)`),
+		).
+		Run(func(ctx demokit.StepContext) *demokit.StepResult {
+			if c == nil {
+				return nil
+			}
+			defs, err := c.ListResources(ctx.Ctx)
+			if err != nil {
+				fmt.Printf("    ERROR listing resources: %v\n", err)
+				return nil
+			}
+			var githubURI string
+			for _, d := range defs {
+				if strings.HasPrefix(d.URI, "skill://github/") {
+					githubURI = d.URI
+					break
+				}
+			}
+			if githubURI == "" {
+				fmt.Printf("    SKIP: no skill://github/... resources in the catalog (run with `make serve` and ensure network is available)\n")
+				return nil
+			}
+			fmt.Printf("    discovered: %s\n", githubURI)
+			body, err := c.ReadResource(githubURI)
+			if err != nil {
+				fmt.Printf("    ERROR reading %s: %v\n", githubURI, err)
+				return nil
+			}
+			fmt.Printf("    served via github/ sub-mount (fetched at server boot):\n")
+			previewBody(body)
+			return nil
+		})
+
 	demo.Section("Push-based invalidation (issue #795)",
 		"`skill://index.json` carries `_meta.io.modelcontextprotocol.skills/version` — a monotonic counter the server bumps whenever skill content changes. Stateful clients also receive `notifications/resources/list_changed` when the bump happens. Stateless clients (no persistent push channel) detect the change by polling the index and observing the field. Detectors that drive the bump (fsnotify, webhook, manual sweep) are pluggable; this walkthrough uses a demo-only `_demo/refresh` tool that calls `Provider.Refresh()` directly.",
 	)


### PR DESCRIPTION
## What changes

#806 + #808 shipped multi-source `make serve` (bundled local at root + `archived/` and `github/` sub-mounts), but the walkthrough's hardcoded URIs all read the local layer. The cross-source story was visible in `resources/list` counts but invisible in the lessons the walkthrough demonstrates. This PR closes that gap with two new steps right after the existing per-file reads.

### New steps

1. **Read `skill://archived/git-workflow/SKILL.md`** — proves `OpenArchive`'s auto-wrap end-to-end. The bundled `git-workflow` skill is packed as a tar.gz and mounted under `archived/`; the served bytes match the local layer's copy (same skill, different transport). Documents the auto-wrap step (root SKILL.md wrapped under `<frontmatter.name>/`) so a reader understands why the URI works under any prefix.

2. **Discover and read a skill from `github/`** — instead of hardcoding a github URI (brittle against `anthropics/skills` repo changes), enumerate `resources/list`, filter for `skill://github/...`, pick the first, and read it. Proves the entire `FetchGitHubArchive → MountFS sub-mount → resources/read` chain — server reaches out to GitHub at boot, bytes flow through the same MCP wire as everything else.

Both steps **gracefully skip** when running against `--source=dir` (no sub-mounts present); SKIP message guides the operator to `make serve` for the rich demo.

## Reviewer's guide

1. [examples/skills/walkthrough.go](https://github.com/panyam/mcpkit/pull/810/files#diff-94afaa0ca3ed61f670feefe88925e3b5ecfc827cfcdb7612d48a01dd289c10e7) — start here. Two new `demo.Step` definitions wrapped in a new "Cross-source reads (issues #797 + #808)" section, inserted right before the existing "Push-based invalidation" section.
2. [examples/skills/WALKTHROUGH.md](https://github.com/panyam/mcpkit/pull/810/files#diff-f7567dfcd105e517415a8fc5aada2b08489ad36774f38681b85f5855a3638884) — regenerated; sanity-skim the two new step entries.

## Decision log

- **Discover-from-list for the github URI**, not hardcoded. The github layer's content depends on the live state of `anthropics/skills@main`; hardcoding a URI invites breakage when the upstream repo evolves. The discovery pattern (first match wins) is robust against any catalog shape.
- **No new SDK changes.** Both steps use `c.ReadResource` and `c.ListResources` — same APIs the existing walkthrough already exercises. Pure additive demo.
- **Graceful skip rather than hard error** when running against `--source=dir`. Conformance and CI runs may hit the binary in dir mode; degrading cleanly preserves their value.
- **No walkthrough rewrite for the existing local-URI steps.** #808's local-at-root design preserved their correctness; those steps don't need to change.

## Risk / blast radius

- **Affects:** `examples/skills/walkthrough.go` + regenerated `WALKTHROUGH.md`. No SDK changes; no test changes.
- **Be paranoid about:** the github discovery step makes a real `resources/list` call. If `make serve` couldn't reach GitHub at boot, the multi-source mode soft-fails to local-only, then the github filter returns empty and the step SKIPs — graceful all the way through.

## Before / after

Walkthrough output against `make serve` (multi-source):

```
--- Cross-source reads (issues #797 + #808) ---
Step 11: Read a skill via the archive sub-mount (proves auto-wrap end-to-end)
  served via archived/ sub-mount (auto-wrapped by frontmatter name):
  ---
  name: git-workflow
  ...

Step 12: Discover and read a skill via the github sub-mount
  discovered: skill://github/algorithmic-art/LICENSE.txt
  served via github/ sub-mount (fetched at server boot):
                                Apache License
  ...
```

Walkthrough output against `make serve --source=dir`:

```
Step 11: ... SKIP: <not found> (run with `make serve` for the multi-source demo)
Step 12: ... SKIP: no skill://github/... resources in the catalog (run with `make serve` and ensure network is available)
```

## Out of scope

- The existing fsnotify-driven step's behavior against `--source=multi` mode. File-edit→bump round trip flows through `WithFSWatcher` which only watches the local fs, so when running multi-source the synthetic edit still triggers correctly via the root mount. No change needed.
- Filed as **#809** during this work: the strategic re-architecture proposal to decouple ext/skills from file-change awareness entirely, using events SEP as the alternative push path. Not in this PR's scope.

## Test plan

- [x] `make serve` + walkthrough — both new steps fire end-to-end, real content delivered from archived/ and github/ sub-mounts
- [x] `make serve --source=dir` + walkthrough — both new steps SKIP gracefully with operator-actionable messages
- [x] `make readme` regenerates `WALKTHROUGH.md` cleanly
