### PR TITLE
ext/auth: AcceptedScopes OR + includeGrantedScopes opt-in on tool-scope middleware

### DIFF
--- a/core/auth.go
+++ b/core/auth.go
@@ -101,6 +101,19 @@ func HasScope(ctx context.Context, scope string) bool {
 	return false
 }
 
+// GetScopes returns the scope set granted to the authenticated caller, or nil
+// when no claims are attached to ctx. Consistent with HasScope, absent claims
+// and present-but-empty scopes both yield nil — callers that need to
+// distinguish "unauthenticated" from "authenticated but no scopes" must reach
+// for AuthClaims directly.
+func GetScopes(ctx context.Context) []string {
+	claims := AuthClaims(ctx)
+	if claims == nil {
+		return nil
+	}
+	return claims.Scopes
+}
+
 // AuthValidator validates an HTTP request and returns claims on success.
 type AuthValidator interface {
 	Validate(r *http.Request) error

--- a/core/scopes_test.go
+++ b/core/scopes_test.go
@@ -1,0 +1,24 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetScopes_NoClaims(t *testing.T) {
+	assert.Nil(t, GetScopes(context.Background()), "absent claims must yield nil, not empty slice")
+}
+
+func TestGetScopes_PresentWithScopes(t *testing.T) {
+	ctx := ContextWithSession(context.Background(), nil, nil, nil, nil,
+		&Claims{Subject: "u", Scopes: []string{"docs:read", "docs:write"}})
+	assert.Equal(t, []string{"docs:read", "docs:write"}, GetScopes(ctx))
+}
+
+func TestGetScopes_PresentEmptyScopes(t *testing.T) {
+	ctx := ContextWithSession(context.Background(), nil, nil, nil, nil,
+		&Claims{Subject: "u", Scopes: nil})
+	assert.Nil(t, GetScopes(ctx))
+}

--- a/core/tool.go
+++ b/core/tool.go
@@ -57,6 +57,23 @@ type ToolDef struct {
 	// Empty/nil means no per-tool scope check; the tool is callable by any
 	// authenticated client (subject to global server.WithRequiredScopes).
 	RequiredScopes []string `json:"-"`
+
+	// AcceptedScopes is an opt-in OR escape hatch on top of RequiredScopes'
+	// AND semantics. When non-empty, the scope middleware passes the gate if
+	// the caller's token includes ANY scope in AcceptedScopes — supporting
+	// hierarchies where a parent scope like `repo` satisfies a tool nominally
+	// requiring `repo:read`. Nil or an explicitly empty slice falls back to
+	// the AND-on-RequiredScopes default (the two-state is deliberate so
+	// allocating `[]string{}` cannot silently disable enforcement).
+	//
+	// Gate-only contract: AcceptedScopes participates in the satisfaction
+	// check but NEVER appears in the 403 WWW-Authenticate challenge. Re-auth
+	// guidance stays least-privilege — the challenge advertises RequiredScopes
+	// alone so clients don't escalate by requesting tolerated alternatives.
+	// Aligns with the upstream TypeScript SDK PR modelcontextprotocol/typescript-sdk#1624.
+	//
+	// Not serialized to clients.
+	AcceptedScopes []string `json:"-"`
 }
 
 // ToolsListResult is the typed result for tools/list responses.

--- a/core/typed_tool.go
+++ b/core/typed_tool.go
@@ -96,6 +96,7 @@ func TypedTool[In, Out any](name, desc string,
 		Meta:           cfg.meta,
 		Timeout:        cfg.timeout,
 		RequiredScopes: cfg.requiredScopes,
+		AcceptedScopes: cfg.acceptedScopes,
 		Execution:      cfg.toolExecution,
 	}
 
@@ -139,6 +140,7 @@ type typedToolConfig struct {
 	meta                 *ToolMeta
 	timeout              time.Duration
 	requiredScopes       []string
+	acceptedScopes       []string
 	inputSchemaOverride  any
 	outputSchemaOverride any
 	inputSchemaPatch     func(*SchemaBuilder)

--- a/ext/auth/scope_middleware.go
+++ b/ext/auth/scope_middleware.go
@@ -33,10 +33,9 @@ type toolScopeConfig struct {
 // set on every challenge instead of accumulating it. The classic broken
 // behavior is "client sees insufficient_scope=docs:write, re-requests a token
 // for ONLY docs:write, loses the docs:read it already had." Union-on-challenge
-// defends against that by re-stating the granted set every time. The upstream
-// TypeScript SDK PR modelcontextprotocol/typescript-sdk#1657 exists to fix
-// the same bug client-side; this option is the server-side counterpart for
-// deployments that can't wait for every client to upgrade.
+// defends against that by re-stating the granted set every time. this option is
+// the server-side counterpart for deployments that can't wait for every client
+// to upgrade.
 //
 // When to leave off: mcpkit's own clients accumulate scopes correctly (the
 // OAuthTokenSource.TokenForScopes contract enforces it), so mcpkit-on-mcpkit

--- a/ext/auth/scope_middleware.go
+++ b/ext/auth/scope_middleware.go
@@ -15,13 +15,59 @@ type ToolDefLookup interface {
 	ToolDef(name string) (core.ToolDef, bool)
 }
 
-// NewToolScopeMiddleware returns a server middleware that enforces per-tool
-// OAuth scopes (declared via core.ToolDef.RequiredScopes) for tools/call
-// requests. It runs pre-dispatch and short-circuits with *core.AuthError
-// (HTTP 403 + WWW-Authenticate: insufficient_scope) when the request's
-// claims don't include all required scopes.
+// ToolScopeOption configures NewToolScopeMiddleware. Use the With* functions
+// in this package; the underlying type is opaque so future fields can be
+// added without breaking callers that pass zero options.
+type ToolScopeOption func(*toolScopeConfig)
+
+type toolScopeConfig struct {
+	includeGrantedScopes bool
+}
+
+// WithIncludeGrantedScopes opts the middleware into advertising the union of
+// (caller's currently-granted scopes ∪ tool's required scopes) in the 403
+// WWW-Authenticate scope parameter. Default is false (per-operation, matching
+// SEP-2350 semantics).
 //
-// Per SEP-2643 (FineGrainedAuth UC2): scope step-up is fully described by
+// When to opt in: facing non-mcpkit clients that may overwrite their scope
+// set on every challenge instead of accumulating it. The classic broken
+// behavior is "client sees insufficient_scope=docs:write, re-requests a token
+// for ONLY docs:write, loses the docs:read it already had." Union-on-challenge
+// defends against that by re-stating the granted set every time. The upstream
+// TypeScript SDK PR modelcontextprotocol/typescript-sdk#1657 exists to fix
+// the same bug client-side; this option is the server-side counterpart for
+// deployments that can't wait for every client to upgrade.
+//
+// When to leave off: mcpkit's own clients accumulate scopes correctly (the
+// OAuthTokenSource.TokenForScopes contract enforces it), so mcpkit-on-mcpkit
+// deployments gain nothing from the union. Leaving it off also keeps the
+// challenge minimal, which suits least-privilege re-auth.
+//
+// Interaction with AcceptedScopes: AcceptedScopes (gate-only) NEVER appears
+// in the challenge regardless of this option. The union is over granted
+// scopes and required scopes; tolerated alternates stay private to the server.
+func WithIncludeGrantedScopes(v bool) ToolScopeOption {
+	return func(c *toolScopeConfig) { c.includeGrantedScopes = v }
+}
+
+// NewToolScopeMiddleware returns a server middleware that enforces per-tool
+// OAuth scopes (declared via core.ToolDef.RequiredScopes and optionally
+// core.ToolDef.AcceptedScopes) for tools/call requests. It runs pre-dispatch
+// and short-circuits with *core.AuthError (HTTP 403 + WWW-Authenticate:
+// insufficient_scope) when the request's claims don't satisfy the gate.
+//
+// Gate semantics:
+//   - RequiredScopes alone: AND — the caller must hold every listed scope.
+//   - AcceptedScopes non-empty: OR — the caller satisfies the gate by holding
+//     ANY scope in AcceptedScopes. Supports scope hierarchies (a parent `repo`
+//     scope satisfies a tool nominally requiring `repo:read`). AcceptedScopes
+//     is gate-only — it never appears in the 403 challenge, keeping re-auth
+//     guidance least-privilege.
+//   - AcceptedScopes nil or empty: falls back to the AND semantics above. The
+//     two-state is deliberate so allocating []string{} cannot silently bypass
+//     enforcement.
+//
+// Per SEP-2643 (FineGrainedAuth UC2): the scope step-up is fully described by
 // the WWW-Authenticate challenge. The body is a JSON-RPC error with the
 // authorization-denial classification metadata only — no remediationHints,
 // because the scopes are already in the WWW-Authenticate header.
@@ -33,13 +79,21 @@ type ToolDefLookup interface {
 //
 //	srv := server.NewServer(info,
 //	    server.WithAuth(jwtValidator),
-//	    server.WithMiddleware(auth.NewToolScopeMiddleware(srv.Registry())),
+//	    server.WithMiddleware(auth.NewToolScopeMiddleware(srv.Registry(),
+//	        auth.WithIncludeGrantedScopes(true), // optional
+//	    )),
 //	)
 //	srv.RegisterTool(core.ToolDef{
-//	    Name: "update_doc",
+//	    Name:           "update_doc",
 //	    RequiredScopes: []string{"docs:write"},
+//	    AcceptedScopes: []string{"docs:write", "docs"}, // optional OR hierarchy
 //	}, handler)
-func NewToolScopeMiddleware(lookup ToolDefLookup) server.Middleware {
+func NewToolScopeMiddleware(lookup ToolDefLookup, opts ...ToolScopeOption) server.Middleware {
+	cfg := toolScopeConfig{}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
 	return func(ctx context.Context, req *core.Request, next server.MiddlewareFunc) (*core.Response, error) {
 		if req.Method != "tools/call" {
 			return next(ctx, req)
@@ -62,17 +116,38 @@ func NewToolScopeMiddleware(lookup ToolDefLookup) server.Middleware {
 			return next(ctx, req) // no per-tool scope check
 		}
 
-		// Verify all required scopes are present.
-		for _, scope := range def.RequiredScopes {
-			if !core.HasScope(ctx, scope) {
-				return nil, &core.AuthError{
-					Code:            http.StatusForbidden,
-					Message:         "insufficient scope: " + scope,
-					WWWAuthenticate: WWWAuth403(def.RequiredScopes...),
-				}
+		if !scopeGateSatisfied(ctx, def) {
+			challengeScopes := def.RequiredScopes
+			if cfg.includeGrantedScopes {
+				challengeScopes = UnionScopes(core.GetScopes(ctx), def.RequiredScopes)
+			}
+			return nil, &core.AuthError{
+				Code:            http.StatusForbidden,
+				Message:         "insufficient scope",
+				WWWAuthenticate: WWWAuth403(challengeScopes...),
 			}
 		}
 
 		return next(ctx, req)
 	}
+}
+
+// scopeGateSatisfied returns true when the caller's claims satisfy def's
+// scope requirements. When AcceptedScopes is non-empty the gate is OR over
+// AcceptedScopes; otherwise it is AND over RequiredScopes.
+func scopeGateSatisfied(ctx context.Context, def core.ToolDef) bool {
+	if len(def.AcceptedScopes) > 0 {
+		for _, scope := range def.AcceptedScopes {
+			if core.HasScope(ctx, scope) {
+				return true
+			}
+		}
+		return false
+	}
+	for _, scope := range def.RequiredScopes {
+		if !core.HasScope(ctx, scope) {
+			return false
+		}
+	}
+	return true
 }

--- a/ext/auth/scope_middleware_test.go
+++ b/ext/auth/scope_middleware_test.go
@@ -198,3 +198,204 @@ func TestToolScopeMiddleware_AllRequiredScopesChecked(t *testing.T) {
 			strings.Contains(authErr.WWWAuthenticate, "admin"),
 		"WWW-Authenticate must list all required scopes; got %q", authErr.WWWAuthenticate)
 }
+
+// TestToolScopeMiddleware_AcceptedScopesHierarchyPasses verifies that when
+// AcceptedScopes is set, the gate passes if the caller holds ANY scope in
+// AcceptedScopes — even when RequiredScopes would otherwise demand a more
+// specific scope. Use case: a `repo` scope satisfies a tool that nominally
+// requires `repo:read`.
+func TestToolScopeMiddleware_AcceptedScopesHierarchyPasses(t *testing.T) {
+	lookup := fakeLookup{tools: map[string]core.ToolDef{
+		"read_repo": {
+			Name:           "read_repo",
+			RequiredScopes: []string{"repo:read"},
+			AcceptedScopes: []string{"repo:read", "repo"},
+		},
+	}}
+
+	mw := auth.NewToolScopeMiddleware(lookup)
+	called := false
+	next := server.MiddlewareFunc(func(ctx context.Context, req *core.Request) (*core.Response, error) {
+		called = true
+		return core.NewResponse(req.ID, "ok"), nil
+	})
+
+	// Token has the hierarchy parent `repo`, not the specific `repo:read`.
+	ctx := withClaims(context.Background(), "repo")
+	req := &core.Request{
+		ID:     json.RawMessage(`1`),
+		Method: "tools/call",
+		Params: json.RawMessage(`{"name":"read_repo"}`),
+	}
+
+	_, err := mw(ctx, req, next)
+	require.NoError(t, err)
+	assert.True(t, called, "hierarchy parent `repo` must satisfy AcceptedScopes gate")
+}
+
+// TestToolScopeMiddleware_AcceptedScopesEmptyFallsBackToAND verifies that
+// AcceptedScopes is two-state: only non-empty turns on the OR semantics. An
+// explicit empty slice (vs nil) behaves identically to nil — the gate falls
+// back to the AND-on-RequiredScopes default. This prevents a footgun where
+// allocating `[]string{}` would silently disable the scope check.
+func TestToolScopeMiddleware_AcceptedScopesEmptyFallsBackToAND(t *testing.T) {
+	lookup := fakeLookup{tools: map[string]core.ToolDef{
+		"update_doc": {
+			Name:           "update_doc",
+			RequiredScopes: []string{"docs:write"},
+			AcceptedScopes: []string{},
+		},
+	}}
+
+	mw := auth.NewToolScopeMiddleware(lookup)
+	next := server.MiddlewareFunc(func(ctx context.Context, req *core.Request) (*core.Response, error) {
+		return core.NewResponse(req.ID, "ok"), nil
+	})
+
+	// Token missing docs:write — empty AcceptedScopes must NOT bypass the check.
+	ctx := withClaims(context.Background(), "docs:read")
+	req := &core.Request{
+		ID:     json.RawMessage(`1`),
+		Method: "tools/call",
+		Params: json.RawMessage(`{"name":"update_doc"}`),
+	}
+
+	_, err := mw(ctx, req, next)
+	require.Error(t, err, "empty AcceptedScopes must fall back to AND, not bypass the gate")
+	var authErr *core.AuthError
+	require.True(t, errors.As(err, &authErr))
+	assert.Equal(t, http.StatusForbidden, authErr.Code)
+}
+
+// TestToolScopeMiddleware_AcceptedScopesDeniedAdvertisesRequiredOnly captures
+// the gate-only contract: AcceptedScopes participates in the satisfaction
+// check but NEVER appears in the WWW-Authenticate challenge. Re-auth guidance
+// stays least-privilege — the client is told to request RequiredScopes, not
+// the broader tolerated set.
+func TestToolScopeMiddleware_AcceptedScopesDeniedAdvertisesRequiredOnly(t *testing.T) {
+	lookup := fakeLookup{tools: map[string]core.ToolDef{
+		"read_repo": {
+			Name:           "read_repo",
+			RequiredScopes: []string{"repo:read"},
+			AcceptedScopes: []string{"repo:read", "repo", "admin"},
+		},
+	}}
+
+	mw := auth.NewToolScopeMiddleware(lookup)
+	next := server.MiddlewareFunc(func(ctx context.Context, req *core.Request) (*core.Response, error) {
+		return nil, nil
+	})
+
+	// Token has neither required nor any accepted scope.
+	ctx := withClaims(context.Background(), "unrelated")
+	req := &core.Request{
+		ID:     json.RawMessage(`1`),
+		Method: "tools/call",
+		Params: json.RawMessage(`{"name":"read_repo"}`),
+	}
+
+	_, err := mw(ctx, req, next)
+	require.Error(t, err)
+	var authErr *core.AuthError
+	require.True(t, errors.As(err, &authErr))
+	assert.Contains(t, authErr.WWWAuthenticate, `scope="repo:read"`,
+		"challenge must advertise RequiredScopes only")
+	assert.NotContains(t, authErr.WWWAuthenticate, "admin",
+		"accepted-but-tolerated scopes must NOT leak into the challenge (gate-only contract)")
+	assert.NotContains(t, authErr.WWWAuthenticate, `scope="repo:read repo`,
+		"accepted hierarchy parents must NOT leak into the challenge")
+}
+
+// TestToolScopeMiddleware_IncludeGrantedScopesOffByDefault verifies that the
+// existing 403 challenge shape is unchanged when the new option is not passed.
+// Together with the other unmodified tests above, this is the back-compat gate
+// for callers who haven't opted in.
+func TestToolScopeMiddleware_IncludeGrantedScopesOffByDefault(t *testing.T) {
+	lookup := fakeLookup{tools: map[string]core.ToolDef{
+		"update_doc": {Name: "update_doc", RequiredScopes: []string{"docs:write"}},
+	}}
+
+	mw := auth.NewToolScopeMiddleware(lookup) // no options
+	next := server.MiddlewareFunc(func(ctx context.Context, req *core.Request) (*core.Response, error) {
+		return nil, nil
+	})
+
+	ctx := withClaims(context.Background(), "docs:read") // partial token
+	req := &core.Request{
+		ID:     json.RawMessage(`1`),
+		Method: "tools/call",
+		Params: json.RawMessage(`{"name":"update_doc"}`),
+	}
+
+	_, err := mw(ctx, req, next)
+	require.Error(t, err)
+	var authErr *core.AuthError
+	require.True(t, errors.As(err, &authErr))
+	assert.Contains(t, authErr.WWWAuthenticate, `scope="docs:write"`,
+		"default behavior: challenge advertises RequiredScopes only")
+	assert.NotContains(t, authErr.WWWAuthenticate, "docs:read",
+		"granted scopes must NOT appear in the challenge without opt-in")
+}
+
+// TestToolScopeMiddleware_IncludeGrantedScopesUnionsInChallenge verifies the
+// opt-in path: when WithIncludeGrantedScopes(true) is set, the 403 challenge
+// advertises the union of (caller's already-held scopes ∪ tool's required
+// scopes). This defends against non-mcpkit clients that overwrite granted
+// scopes on every challenge (mirrors typescript-sdk PR 1657's workaround).
+func TestToolScopeMiddleware_IncludeGrantedScopesUnionsInChallenge(t *testing.T) {
+	lookup := fakeLookup{tools: map[string]core.ToolDef{
+		"update_doc": {Name: "update_doc", RequiredScopes: []string{"docs:write"}},
+	}}
+
+	mw := auth.NewToolScopeMiddleware(lookup, auth.WithIncludeGrantedScopes(true))
+	next := server.MiddlewareFunc(func(ctx context.Context, req *core.Request) (*core.Response, error) {
+		return nil, nil
+	})
+
+	ctx := withClaims(context.Background(), "docs:read")
+	req := &core.Request{
+		ID:     json.RawMessage(`1`),
+		Method: "tools/call",
+		Params: json.RawMessage(`{"name":"update_doc"}`),
+	}
+
+	_, err := mw(ctx, req, next)
+	require.Error(t, err)
+	var authErr *core.AuthError
+	require.True(t, errors.As(err, &authErr))
+	assert.Contains(t, authErr.WWWAuthenticate, "docs:read",
+		"opt-in: granted scope must appear in the challenge")
+	assert.Contains(t, authErr.WWWAuthenticate, "docs:write",
+		"opt-in: required scope still appears in the challenge")
+}
+
+// TestToolScopeMiddleware_IncludeGrantedScopesEmptyGrantedSameAsOff verifies
+// the degenerate path: when WithIncludeGrantedScopes(true) but the caller
+// holds no scopes, the union collapses to RequiredScopes alone — identical
+// to the default-off behavior. Useful because the opt-in is set per-server,
+// not per-request; servers with the flag on still see unauthenticated-ish
+// calls (valid token, zero scopes).
+func TestToolScopeMiddleware_IncludeGrantedScopesEmptyGrantedSameAsOff(t *testing.T) {
+	lookup := fakeLookup{tools: map[string]core.ToolDef{
+		"update_doc": {Name: "update_doc", RequiredScopes: []string{"docs:write"}},
+	}}
+
+	mw := auth.NewToolScopeMiddleware(lookup, auth.WithIncludeGrantedScopes(true))
+	next := server.MiddlewareFunc(func(ctx context.Context, req *core.Request) (*core.Response, error) {
+		return nil, nil
+	})
+
+	ctx := withClaims(context.Background()) // no scopes
+	req := &core.Request{
+		ID:     json.RawMessage(`1`),
+		Method: "tools/call",
+		Params: json.RawMessage(`{"name":"update_doc"}`),
+	}
+
+	_, err := mw(ctx, req, next)
+	require.Error(t, err)
+	var authErr *core.AuthError
+	require.True(t, errors.As(err, &authErr))
+	assert.Contains(t, authErr.WWWAuthenticate, `scope="docs:write"`,
+		"empty granted: challenge advertises RequiredScopes only (degenerate union)")
+}

--- a/ext/auth/scope_middleware_test.go
+++ b/ext/auth/scope_middleware_test.go
@@ -341,7 +341,7 @@ func TestToolScopeMiddleware_IncludeGrantedScopesOffByDefault(t *testing.T) {
 // opt-in path: when WithIncludeGrantedScopes(true) is set, the 403 challenge
 // advertises the union of (caller's already-held scopes ∪ tool's required
 // scopes). This defends against non-mcpkit clients that overwrite granted
-// scopes on every challenge (mirrors typescript-sdk PR 1657's workaround).
+// scopes on every challenge.
 func TestToolScopeMiddleware_IncludeGrantedScopesUnionsInChallenge(t *testing.T) {
 	lookup := fakeLookup{tools: map[string]core.ToolDef{
 		"update_doc": {Name: "update_doc", RequiredScopes: []string{"docs:write"}},

--- a/ext/auth/scopes.go
+++ b/ext/auth/scopes.go
@@ -42,3 +42,37 @@ func RequireAllScopes(ctx context.Context, scopes ...string) error {
 	}
 	return nil
 }
+
+// UnionScopes returns the set union of a and b preserving first-seen order:
+// every element of a comes first in its original order, then every element
+// of b that did not already appear in a. Duplicates within either input are
+// collapsed. Returns nil when both inputs are empty so callers can treat the
+// "no scopes anywhere" case uniformly. The returned slice is always a fresh
+// allocation — callers may safely retain and mutate it without affecting the
+// inputs.
+//
+// Primarily used by NewToolScopeMiddleware to compose granted-and-required
+// scope sets for the WWW-Authenticate challenge under WithIncludeGrantedScopes.
+// Custom middleware that builds its own scope challenges can use it directly.
+func UnionScopes(a, b []string) []string {
+	if len(a) == 0 && len(b) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(a)+len(b))
+	seen := make(map[string]struct{}, len(a)+len(b))
+	for _, s := range a {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	for _, s := range b {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}

--- a/ext/auth/scopes_test.go
+++ b/ext/auth/scopes_test.go
@@ -1,0 +1,38 @@
+package auth_test
+
+import (
+	"testing"
+
+	"github.com/panyam/mcpkit/ext/auth"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnionScopes_BothNil(t *testing.T) {
+	assert.Nil(t, auth.UnionScopes(nil, nil))
+}
+
+func TestUnionScopes_DisjointSetsPreserveOrder(t *testing.T) {
+	got := auth.UnionScopes([]string{"a", "b"}, []string{"c", "d"})
+	assert.Equal(t, []string{"a", "b", "c", "d"}, got, "disjoint sets concatenate in (a, b) order")
+}
+
+func TestUnionScopes_OverlapDedupsKeepingFirstOccurrence(t *testing.T) {
+	got := auth.UnionScopes([]string{"a", "b"}, []string{"b", "c"})
+	assert.Equal(t, []string{"a", "b", "c"}, got, "overlapping entries appear once, in first-seen order")
+}
+
+func TestUnionScopes_NilFirstReturnsSecondCopy(t *testing.T) {
+	b := []string{"x", "y"}
+	got := auth.UnionScopes(nil, b)
+	assert.Equal(t, []string{"x", "y"}, got)
+	got[0] = "MUTATED"
+	assert.Equal(t, "x", b[0], "caller's slice must not be mutated through the returned union")
+}
+
+func TestUnionScopes_NilSecondReturnsFirstCopy(t *testing.T) {
+	a := []string{"x", "y"}
+	got := auth.UnionScopes(a, nil)
+	assert.Equal(t, []string{"x", "y"}, got)
+	got[0] = "MUTATED"
+	assert.Equal(t, "x", a[0])
+}


### PR DESCRIPTION
## What changes

Two ergonomic improvements to `ext/auth.NewToolScopeMiddleware`, bundled because they touch the same signature and share test scaffolding. Closes issues 742 and 743.

- **`ToolDef.AcceptedScopes`** (issue 742) — opt-in OR escape hatch on top of `RequiredScopes`' AND semantics, supporting hierarchies like a `repo` scope satisfying a tool nominally requiring `repo:read`. Gate-only: never appears in the 403 challenge, so re-auth guidance stays least-privilege.
- **`WithIncludeGrantedScopes(bool)`** (issue 743) — server-side defense against non-mcpkit clients that overwrite scopes on every challenge. When true, the 403 advertises the union of (caller's granted scopes ∪ required scopes). Default off.

## Reviewer's guide

Read in this order:

1. [core/tool.go](https://github.com/panyam/mcpkit/pull/811/files#diff-0c4cfc445e145347f6ac8b4edaa2ca030b6512a3a99e6379f5122df3ca014d22) — the new `AcceptedScopes` field on `ToolDef`. Doc-block spells the gate-only contract and two-state nil-vs-empty semantics — both deliberate, both tested.
2. [ext/auth/scope_middleware.go](https://github.com/panyam/mcpkit/pull/811/files#diff-e9f2a0b5b4639ac0f368a630b80e9b61f019f319eaaf03fed829d2f9030811a3) — the new shape. `NewToolScopeMiddleware` becomes variadic-options; `scopeGateSatisfied` factors out the AND-vs-OR branching; the challenge-construction path branches on `cfg.includeGrantedScopes`.
3. [ext/auth/scope_middleware_test.go](https://github.com/panyam/mcpkit/pull/811/files#diff-07fe99fb8bd1cd184446291098d6f5c485238645682c1340f8e900bc382dff06) — six new acceptance tests covering both features and their interaction. All five pre-existing tests still pass unchanged (back-compat gate).
4. [core/auth.go](https://github.com/panyam/mcpkit/pull/811/files#diff-3e25dee8210000495ed39b87f0f2f4503034f791d0759f8c5c17f6a7b1ede783) + [core/scopes_test.go](https://github.com/panyam/mcpkit/pull/811/files#diff-73a9dacb7aad35a6e86eaca7ca22fdf675c05586260fed4840ec71e1b4f3240d) — new `core.GetScopes(ctx)` sibling to `core.HasScope`. Three tests.
5. [ext/auth/scopes.go](https://github.com/panyam/mcpkit/pull/811/files#diff-41f9df9cecd5047335d65853ffcf03e8c0c07f928b99e9fe58d103d31ac98f8d) + [ext/auth/scopes_test.go](https://github.com/panyam/mcpkit/pull/811/files#diff-83dc9ff7930cdaffedded4695243a30f21137491524a8ef9de66b523054e9117) — new `auth.UnionScopes(a, b)` helper. Lives in ext/auth (not core) because the only in-tree caller is the middleware's challenge path. Five tests.
6. [core/typed_tool.go](https://github.com/panyam/mcpkit/pull/811/files#diff-2a38d67d5979f975464d4ad38d21b6a6a1e9d22f1e4e78a2ccae5651b8f77f32) — wires `WithToolAcceptedScopes` mirror of `WithToolRequiredScopes`.

Skim: the doc-comment additions on existing surface (no behavior change).

## Decision log

1. **Two helpers split across core and ext/auth** rather than both in core. `GetScopes` is a sibling of `HasScope` (already in core) — handlers shouldn't need to import ext/auth just to inspect their own claims. `UnionScopes` had no cross-cutting caller in mcpkit — it lives where it's actually used. Heads off the awkward "mcpkit/core duplicates oneauth/core.UnionScopes" footnote.

2. **AcceptedScopes is gate-only** — it never appears in the 403 challenge. Re-auth guidance stays least-privilege so clients don't escalate by requesting tolerated alternatives. Aligns with the upstream TypeScript SDK PR modelcontextprotocol/typescript-sdk#1624 (same choice cross-SDK). Flipping this post-merge would be a wire-format change.

3. **AcceptedScopes is two-state** — nil and explicit `[]string{}` both fall back to AND-on-RequiredScopes. Prevents the footgun where allocating an empty slice silently disables enforcement. Explicit test covers this.

4. **Variadic options on `NewToolScopeMiddleware`** rather than a struct argument. Matches mcpkit precedent (`server.WithMiddleware`, every `core.WithTool*`). All five existing callsite tests compile unchanged.

5. **`RequireAnyScope` handler helper NOT added** despite #742's "optionally" mention. The static OR case is handled by `AcceptedScopes` declaratively (with correct WWW-Authenticate semantics for free). Dynamic OR in a handler body is two `core.HasScope` calls in three lines. File a follow-up if a real use surfaces.

## Risk / blast radius

- **Affects**: callers of `auth.NewToolScopeMiddleware`. Verified zero in-tree call sites outside the test file via `grep -rn NewToolScopeMiddleware`.
- **Back-compat**: existing five tests run unchanged. The variadic-opts signature is additive.
- **Pressure-test areas**:
  - Empty-slice vs nil discrimination on `AcceptedScopes` (Go footgun zone).
  - Gate-only invariant of `AcceptedScopes` vs union-in-challenge invariant of `IncludeGrantedScopes` — these are orthogonal and tested together.

## Before / after — 403 challenge shape

| Configuration | Token has | Challenge |
|---|---|---|
| `RequiredScopes=["docs:write"]` | `["docs:read"]` | `scope="docs:write"` (unchanged) |
| `+ AcceptedScopes=["docs:write","docs"]` | `["unrelated"]` | `scope="docs:write"` (accepted set hidden) |
| `+ WithIncludeGrantedScopes(true)` | `["docs:read"]` | `scope="docs:read docs:write"` |

## Out of scope (deliberately deferred)

- `IntrospectionConfig.RequiredScopes` / `JWTValidator.RequiredScopes` global gates — stay AND, per issue 742.
- `WWWAuth401` granted-scope union — unauthenticated path has no granted scopes to union with, per issue 743.
- `RequireAnyScope` handler helper — file follow-up if a real dynamic-OR-in-handler case surfaces.
