### PR TITLE
chore(deps): bump oneauth to v0.1.31 + adopt AudienceFunc

### DIFF
--- a/cmd/testclient/go.mod
+++ b/cmd/testclient/go.mod
@@ -5,7 +5,7 @@ go 1.26.4
 require (
 	github.com/panyam/mcpkit v0.2.3
 	github.com/panyam/mcpkit/ext/auth v0.0.0
-	github.com/panyam/oneauth v0.1.20
+	github.com/panyam/oneauth v0.1.31
 )
 
 require (

--- a/cmd/testclient/go.sum
+++ b/cmd/testclient/go.sum
@@ -41,8 +41,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.8 h1:5UscYTP892k54+Nyb01tKGGwZxczZ5k7BC+c0nXmcoc=
 github.com/panyam/goutils v0.1.8/go.mod h1:ntucs8GJOHQ0LmlRGRjeup3aDC2t7xPMudrRwUHrJNM=
-github.com/panyam/oneauth v0.1.20 h1:z59UdXdnQRdlmk5gsKojQv779NAta4+EFbOeKYv65lc=
-github.com/panyam/oneauth v0.1.20/go.mod h1:UPCcpcL6q8vhcuEagIGEWw5g0bsWtQVT6XYcTAWUBFI=
+github.com/panyam/oneauth v0.1.31 h1:CDnVWxZo+7WO6hPvLamvDtdT1spDfBqBdByImQzTcIU=
+github.com/panyam/oneauth v0.1.31/go.mod h1:UPCcpcL6q8vhcuEagIGEWw5g0bsWtQVT6XYcTAWUBFI=
 github.com/panyam/servicekit v0.1.2 h1:2IfSVhgjQonUM6lkqVH6dm0QA700UsJSbASE95lWj+Y=
 github.com/panyam/servicekit v0.1.2/go.mod h1:wk/9hY9Vgl83WuYJt7n4NYPvV6nbxnZwpKpNRIAPoR8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/examples/auth/common/setup.go
+++ b/examples/auth/common/setup.go
@@ -55,6 +55,13 @@ type Env struct {
 	Validator *auth.JWTValidator
 	Scopes    []string
 
+	// audience is the `aud` claim value examples want minted into
+	// their tokens. It is also what the AS validator + issuer read on
+	// every mint / validate via the AudienceFunc closure handed to
+	// testutil. Set once by NewValidator before any tokens are minted
+	// — the call sites are synchronous so plain field access is safe.
+	audience string
+
 	// upstreamKey is the RSA private key for the synthetic
 	// UpstreamIdpIssuer the fixture trusts. Used by MintUpstreamAssertion
 	// to sign assertions for the conformance suite's RFC 7523 / RFC 8693
@@ -63,7 +70,9 @@ type Env struct {
 }
 
 // NewEnv creates an in-process authorization server with JWKS + token endpoint.
-// Call SetAudience(url) after the MCP server starts to bind tokens to the server URL.
+// Call NewValidator(audience, ...) after the MCP server starts to bind
+// tokens to the server URL — the AS reads the audience on every mint
+// + validate via the AudienceFunc closure plumbed below.
 //
 // The fixture advertises RFC 9207 (iss parameter) and the RFC 7523 §2.1
 // jwt-bearer + RFC 8693 token-exchange grants by default — this is what
@@ -80,9 +89,11 @@ func NewEnv(scopes []string) *Env {
 		log.Fatal(err)
 	}
 
+	env := &Env{Scopes: scopes, upstreamKey: upstreamKey}
 	as, err := testutil.NewAuthServer(
 		testutil.WithScopes(scopes),
 		testutil.WithIssParameterSupported(true),
+		testutil.WithAudienceFunc(env.getAudience),
 		testutil.WithTrustedAssertionIssuers([]apiauth.TrustedAssertionIssuer{{
 			Issuer:             UpstreamIdpIssuer,
 			PublicKey:          &upstreamKey.PublicKey,
@@ -92,7 +103,15 @@ func NewEnv(scopes []string) *Env {
 	if err != nil {
 		log.Fatal(err)
 	}
-	return &Env{AS: as, Scopes: scopes, upstreamKey: upstreamKey}
+	env.AS = as
+	return env
+}
+
+// getAudience is the closure handed to testutil.WithAudienceFunc. The
+// AS validator + issuer call it on every mint and every validation.
+// Returns "" until NewValidator binds the audience.
+func (e *Env) getAudience() string {
+	return e.audience
 }
 
 // NewValidator creates a JWTValidator pointed at the AS's JWKS.
@@ -100,7 +119,7 @@ func NewEnv(scopes []string) *Env {
 // Optional ValidatorOption args plumb tracing providers through —
 // see WithMCPTracerProvider / WithOneauthTracerProvider.
 func (e *Env) NewValidator(audience string, opts ...ValidatorOption) *auth.JWTValidator {
-	e.AS.APIAuth.JWTAudience = audience
+	e.audience = audience
 	cfg := auth.JWTConfig{
 		JWKSURL:   e.AS.JWKSURL(),
 		Issuer:    e.AS.Issuer(),
@@ -141,7 +160,7 @@ func (e *Env) MintUpstreamAssertion(subject string) string {
 	claims := jwt.MapClaims{
 		"iss": UpstreamIdpIssuer,
 		"sub": subject,
-		"aud": e.AS.APIAuth.JWTAudience,
+		"aud": e.audience,
 		"iat": now.Unix(),
 		"exp": now.Add(5 * time.Minute).Unix(),
 	}
@@ -159,8 +178,8 @@ func (e *Env) MintToken(subject string, scopes []string) string {
 	claims := jwt.MapClaims{
 		"sub": subject,
 	}
-	if e.AS.APIAuth.JWTAudience != "" {
-		claims["aud"] = e.AS.APIAuth.JWTAudience
+	if e.audience != "" {
+		claims["aud"] = e.audience
 	}
 	if len(scopes) > 0 {
 		claims["scope"] = strings.Join(scopes, " ")
@@ -183,8 +202,8 @@ func (e *Env) MintExpiredToken(subject string, scopes []string) string {
 		"iat": now.Add(-2 * time.Hour).Unix(),
 		"exp": now.Add(-1 * time.Hour).Unix(),
 	}
-	if e.AS.APIAuth.JWTAudience != "" {
-		claims["aud"] = e.AS.APIAuth.JWTAudience
+	if e.audience != "" {
+		claims["aud"] = e.audience
 	}
 	if len(scopes) > 0 {
 		claims["scope"] = strings.Join(scopes, " ")
@@ -224,8 +243,8 @@ func (e *Env) MintWrongIssuerToken(subject string, scopes []string) string {
 		"sub": subject,
 		"iss": "https://wrong-issuer.example.invalid",
 	}
-	if e.AS.APIAuth.JWTAudience != "" {
-		claims["aud"] = e.AS.APIAuth.JWTAudience
+	if e.audience != "" {
+		claims["aud"] = e.audience
 	}
 	if len(scopes) > 0 {
 		claims["scope"] = strings.Join(scopes, " ")

--- a/examples/auth/go.mod
+++ b/examples/auth/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/panyam/mcpkit v0.2.45
 	github.com/panyam/mcpkit/examples/common v0.0.0-00010101000000-000000000000
 	github.com/panyam/mcpkit/ext/auth v0.2.36
-	github.com/panyam/oneauth v0.1.20
+	github.com/panyam/oneauth v0.1.31
 	go.opentelemetry.io/otel/trace v1.44.0
 )
 

--- a/examples/auth/go.sum
+++ b/examples/auth/go.sum
@@ -96,8 +96,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.13 h1:V819IdZTEJ3rpu33ZqohC6O9ou7KOu6cxfigoYT12OQ=
 github.com/panyam/goutils v0.1.13/go.mod h1:vd3iFcv1DjaeV6h8tslIJh9d09RLndg8UYNSGROBrM4=
-github.com/panyam/oneauth v0.1.20 h1:z59UdXdnQRdlmk5gsKojQv779NAta4+EFbOeKYv65lc=
-github.com/panyam/oneauth v0.1.20/go.mod h1:UPCcpcL6q8vhcuEagIGEWw5g0bsWtQVT6XYcTAWUBFI=
+github.com/panyam/oneauth v0.1.31 h1:CDnVWxZo+7WO6hPvLamvDtdT1spDfBqBdByImQzTcIU=
+github.com/panyam/oneauth v0.1.31/go.mod h1:UPCcpcL6q8vhcuEagIGEWw5g0bsWtQVT6XYcTAWUBFI=
 github.com/panyam/servicekit v0.1.2 h1:2IfSVhgjQonUM6lkqVH6dm0QA700UsJSbASE95lWj+Y=
 github.com/panyam/servicekit v0.1.2/go.mod h1:wk/9hY9Vgl83WuYJt7n4NYPvV6nbxnZwpKpNRIAPoR8=
 github.com/panyam/templar v0.1.0 h1:yy4sqois9gvNhIy2xsNyRoI5r/qvz1tVY+YuxnmzbWY=

--- a/examples/events/discord/go.mod
+++ b/examples/events/discord/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/panyam/gocurrent v0.1.1 // indirect
 	github.com/panyam/goutils v0.1.13 // indirect
 	github.com/panyam/mcpkit/ext/otel v0.0.0-20260608053428-44b944d79f00 // indirect
-	github.com/panyam/oneauth v0.1.20 // indirect
+	github.com/panyam/oneauth v0.1.31 // indirect
 	github.com/panyam/templar v0.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/examples/events/discord/go.sum
+++ b/examples/events/discord/go.sum
@@ -99,8 +99,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.13 h1:V819IdZTEJ3rpu33ZqohC6O9ou7KOu6cxfigoYT12OQ=
 github.com/panyam/goutils v0.1.13/go.mod h1:vd3iFcv1DjaeV6h8tslIJh9d09RLndg8UYNSGROBrM4=
-github.com/panyam/oneauth v0.1.20 h1:z59UdXdnQRdlmk5gsKojQv779NAta4+EFbOeKYv65lc=
-github.com/panyam/oneauth v0.1.20/go.mod h1:UPCcpcL6q8vhcuEagIGEWw5g0bsWtQVT6XYcTAWUBFI=
+github.com/panyam/oneauth v0.1.31 h1:CDnVWxZo+7WO6hPvLamvDtdT1spDfBqBdByImQzTcIU=
+github.com/panyam/oneauth v0.1.31/go.mod h1:UPCcpcL6q8vhcuEagIGEWw5g0bsWtQVT6XYcTAWUBFI=
 github.com/panyam/servicekit v0.1.2 h1:2IfSVhgjQonUM6lkqVH6dm0QA700UsJSbASE95lWj+Y=
 github.com/panyam/servicekit v0.1.2/go.mod h1:wk/9hY9Vgl83WuYJt7n4NYPvV6nbxnZwpKpNRIAPoR8=
 github.com/panyam/templar v0.1.0 h1:yy4sqois9gvNhIy2xsNyRoI5r/qvz1tVY+YuxnmzbWY=

--- a/examples/events/telegram/go.mod
+++ b/examples/events/telegram/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/panyam/gocurrent v0.1.1 // indirect
 	github.com/panyam/goutils v0.1.13 // indirect
 	github.com/panyam/mcpkit/ext/otel v0.0.0-20260608053428-44b944d79f00 // indirect
-	github.com/panyam/oneauth v0.1.20 // indirect
+	github.com/panyam/oneauth v0.1.31 // indirect
 	github.com/panyam/templar v0.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/examples/events/telegram/go.sum
+++ b/examples/events/telegram/go.sum
@@ -98,8 +98,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.13 h1:V819IdZTEJ3rpu33ZqohC6O9ou7KOu6cxfigoYT12OQ=
 github.com/panyam/goutils v0.1.13/go.mod h1:vd3iFcv1DjaeV6h8tslIJh9d09RLndg8UYNSGROBrM4=
-github.com/panyam/oneauth v0.1.20 h1:z59UdXdnQRdlmk5gsKojQv779NAta4+EFbOeKYv65lc=
-github.com/panyam/oneauth v0.1.20/go.mod h1:UPCcpcL6q8vhcuEagIGEWw5g0bsWtQVT6XYcTAWUBFI=
+github.com/panyam/oneauth v0.1.31 h1:CDnVWxZo+7WO6hPvLamvDtdT1spDfBqBdByImQzTcIU=
+github.com/panyam/oneauth v0.1.31/go.mod h1:UPCcpcL6q8vhcuEagIGEWw5g0bsWtQVT6XYcTAWUBFI=
 github.com/panyam/servicekit v0.1.2 h1:2IfSVhgjQonUM6lkqVH6dm0QA700UsJSbASE95lWj+Y=
 github.com/panyam/servicekit v0.1.2/go.mod h1:wk/9hY9Vgl83WuYJt7n4NYPvV6nbxnZwpKpNRIAPoR8=
 github.com/panyam/templar v0.1.0 h1:yy4sqois9gvNhIy2xsNyRoI5r/qvz1tVY+YuxnmzbWY=

--- a/examples/fine-grained-auth/go.mod
+++ b/examples/fine-grained-auth/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/panyam/mcpkit v0.2.45
 	github.com/panyam/mcpkit/examples/common v0.0.0-00010101000000-000000000000
 	github.com/panyam/mcpkit/ext/auth v0.2.36
-	github.com/panyam/oneauth v0.1.20
+	github.com/panyam/oneauth v0.1.31
 	github.com/panyam/servicekit v0.1.2
 )
 

--- a/examples/fine-grained-auth/go.sum
+++ b/examples/fine-grained-auth/go.sum
@@ -96,8 +96,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.13 h1:V819IdZTEJ3rpu33ZqohC6O9ou7KOu6cxfigoYT12OQ=
 github.com/panyam/goutils v0.1.13/go.mod h1:vd3iFcv1DjaeV6h8tslIJh9d09RLndg8UYNSGROBrM4=
-github.com/panyam/oneauth v0.1.20 h1:z59UdXdnQRdlmk5gsKojQv779NAta4+EFbOeKYv65lc=
-github.com/panyam/oneauth v0.1.20/go.mod h1:UPCcpcL6q8vhcuEagIGEWw5g0bsWtQVT6XYcTAWUBFI=
+github.com/panyam/oneauth v0.1.31 h1:CDnVWxZo+7WO6hPvLamvDtdT1spDfBqBdByImQzTcIU=
+github.com/panyam/oneauth v0.1.31/go.mod h1:UPCcpcL6q8vhcuEagIGEWw5g0bsWtQVT6XYcTAWUBFI=
 github.com/panyam/servicekit v0.1.2 h1:2IfSVhgjQonUM6lkqVH6dm0QA700UsJSbASE95lWj+Y=
 github.com/panyam/servicekit v0.1.2/go.mod h1:wk/9hY9Vgl83WuYJt7n4NYPvV6nbxnZwpKpNRIAPoR8=
 github.com/panyam/templar v0.1.0 h1:yy4sqois9gvNhIy2xsNyRoI5r/qvz1tVY+YuxnmzbWY=

--- a/examples/fine-grained-auth/main.go
+++ b/examples/fine-grained-auth/main.go
@@ -838,14 +838,10 @@ func startInProcessAS() (*inProcessAS, error) {
 		return nil, fmt.Errorf("register AS key: %w", err)
 	}
 
-	// AS components.
+	// AS components. OneAuth's token issuer snapshots the `iss` URL at
+	// construction time, so we postpone building it until httptest has
+	// assigned the server URL (mirrors testutil.NewTestAuthServer).
 	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
-	apiAuth := &apiauth.APIAuth{
-		JWTSigningAlg:  "RS256",
-		JWTSigningKey:  privKey,
-		JWTVerifyKey:   &privKey.PublicKey,
-		ClientKeyStore: ks,
-	}
 	jwksHandler := &keys.JWKSHandler{KeyStore: ks}
 
 	// metadataMu guards lazy initialization of asMetadataHandler with the AS
@@ -854,7 +850,6 @@ func startInProcessAS() (*inProcessAS, error) {
 
 	mux := http.NewServeMux()
 	mux.Handle("/apps/", registrar.Handler())
-	mux.HandleFunc("POST /token", apiAuth.ServeHTTP)
 	mux.Handle("GET /.well-known/jwks.json", jwksHandler)
 	mux.HandleFunc("GET /.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
 		if asMetadataHandler == nil {
@@ -865,7 +860,15 @@ func startInProcessAS() (*inProcessAS, error) {
 	})
 
 	ts := httptest.NewServer(mux)
-	apiAuth.JWTIssuer = ts.URL
+
+	oa := apiauth.NewOneAuth(apiauth.OneAuthConfig{
+		KeyStore:   ks,
+		SigningKey: privKey,
+		VerifyKey:  &privKey.PublicKey,
+		SigningAlg: "RS256",
+		Issuer:     ts.URL,
+	})
+	mux.Handle("POST /token", apiauth.NewTokenEndpointHandler(oa))
 
 	asMetadataHandler = apiauth.NewASMetadataHandler(&apiauth.ASServerMetadata{
 		Issuer:                             ts.URL,

--- a/examples/whole-enchilada/events/event-server/go.mod
+++ b/examples/whole-enchilada/events/event-server/go.mod
@@ -79,7 +79,7 @@ require (
 	github.com/panyam/goutils v0.1.13 // indirect
 	github.com/panyam/mcpkit/ext/otel v0.0.0-20260608053428-44b944d79f00 // indirect
 	github.com/panyam/mcpkit/stores/redis v0.0.0-00010101000000-000000000000 // indirect
-	github.com/panyam/oneauth v0.1.20 // indirect
+	github.com/panyam/oneauth v0.1.31 // indirect
 	github.com/panyam/templar v0.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/examples/whole-enchilada/events/event-server/go.sum
+++ b/examples/whole-enchilada/events/event-server/go.sum
@@ -122,8 +122,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.13 h1:V819IdZTEJ3rpu33ZqohC6O9ou7KOu6cxfigoYT12OQ=
 github.com/panyam/goutils v0.1.13/go.mod h1:vd3iFcv1DjaeV6h8tslIJh9d09RLndg8UYNSGROBrM4=
-github.com/panyam/oneauth v0.1.20 h1:z59UdXdnQRdlmk5gsKojQv779NAta4+EFbOeKYv65lc=
-github.com/panyam/oneauth v0.1.20/go.mod h1:UPCcpcL6q8vhcuEagIGEWw5g0bsWtQVT6XYcTAWUBFI=
+github.com/panyam/oneauth v0.1.31 h1:CDnVWxZo+7WO6hPvLamvDtdT1spDfBqBdByImQzTcIU=
+github.com/panyam/oneauth v0.1.31/go.mod h1:UPCcpcL6q8vhcuEagIGEWw5g0bsWtQVT6XYcTAWUBFI=
 github.com/panyam/servicekit v0.1.2 h1:2IfSVhgjQonUM6lkqVH6dm0QA700UsJSbASE95lWj+Y=
 github.com/panyam/servicekit v0.1.2/go.mod h1:wk/9hY9Vgl83WuYJt7n4NYPvV6nbxnZwpKpNRIAPoR8=
 github.com/panyam/templar v0.1.0 h1:yy4sqois9gvNhIy2xsNyRoI5r/qvz1tVY+YuxnmzbWY=

--- a/ext/auth/go.mod
+++ b/ext/auth/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/panyam/gocurrent v0.1.1
 	github.com/panyam/mcpkit v0.2.3
-	github.com/panyam/oneauth v0.1.20
+	github.com/panyam/oneauth v0.1.31
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel/sdk v1.39.0
 	go.opentelemetry.io/otel/trace v1.39.0

--- a/ext/auth/go.sum
+++ b/ext/auth/go.sum
@@ -42,8 +42,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.8 h1:5UscYTP892k54+Nyb01tKGGwZxczZ5k7BC+c0nXmcoc=
 github.com/panyam/goutils v0.1.8/go.mod h1:ntucs8GJOHQ0LmlRGRjeup3aDC2t7xPMudrRwUHrJNM=
-github.com/panyam/oneauth v0.1.20 h1:z59UdXdnQRdlmk5gsKojQv779NAta4+EFbOeKYv65lc=
-github.com/panyam/oneauth v0.1.20/go.mod h1:UPCcpcL6q8vhcuEagIGEWw5g0bsWtQVT6XYcTAWUBFI=
+github.com/panyam/oneauth v0.1.31 h1:CDnVWxZo+7WO6hPvLamvDtdT1spDfBqBdByImQzTcIU=
+github.com/panyam/oneauth v0.1.31/go.mod h1:UPCcpcL6q8vhcuEagIGEWw5g0bsWtQVT6XYcTAWUBFI=
 github.com/panyam/servicekit v0.1.2 h1:2IfSVhgjQonUM6lkqVH6dm0QA700UsJSbASE95lWj+Y=
 github.com/panyam/servicekit v0.1.2/go.mod h1:wk/9hY9Vgl83WuYJt7n4NYPvV6nbxnZwpKpNRIAPoR8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/ext/auth/jwt_validator.go
+++ b/ext/auth/jwt_validator.go
@@ -12,21 +12,23 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	conc "github.com/panyam/gocurrent"
 	mcpcore "github.com/panyam/mcpkit/core"
-	"github.com/panyam/oneauth/apiauth"
 	oacore "github.com/panyam/oneauth/core"
 	"github.com/panyam/oneauth/keys"
 	"github.com/panyam/oneauth/utils"
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
-// JWTValidator validates MCP requests using JWT Bearer tokens.
-// It implements mcpcore.AuthValidator and mcpmcpcore.ClaimsProvider by wrapping
-// oneauth's APIMiddleware for JWKS-based JWT signature verification, and
-// APIAuth for issuer/audience/scope checks.
+// JWTValidator validates MCP requests using JWT Bearer tokens. It
+// resolves verification keys from a JWKS endpoint by kid and applies
+// issuer / audience / scope checks before stamping the claims on the
+// active dispatch span.
 //
-// Uses APIMiddleware (not APIAuth.ValidateAccessTokenFull) because the middleware
-// supports kid-based key lookup from a KeyStore (including JWKSKeyStore), while
-// APIAuth's jwtKeyFunc only supports fixed symmetric/asymmetric keys.
+// We resolve keys + verify the JWT directly here (rather than going
+// through oneauth's TokenValidator) because the validation surface
+// MCP wants is narrow and kid-based: a single JWKS, a fixed expected
+// issuer + audience, and the scope-array vs space-delimited-string
+// fallback Keycloak emits. The oneauth dependency stays scoped to
+// the JWKS key store + utility helpers.
 //
 // Usage:
 //
@@ -38,8 +40,9 @@ import (
 //	})
 //	srv := mcpcore.NewServer(info, core.WithAuth(validator))
 type JWTValidator struct {
-	auth *apiauth.APIAuth
-	ks   *keys.JWKSKeyStore
+	issuer   string
+	audience string
+	ks       *keys.JWKSKeyStore
 
 	// ResourceMetadataURL is included in WWW-Authenticate headers on 401 responses.
 	ResourceMetadataURL string
@@ -150,19 +153,14 @@ func NewJWTValidator(cfg JWTConfig) *JWTValidator {
 	}
 	ks := keys.NewJWKSKeyStore(cfg.JWKSURL, jwksOpts...)
 
-	auth := &apiauth.APIAuth{
-		JWTIssuer:   cfg.Issuer,
-		JWTAudience: cfg.Audience,
-	}
-	auth.ClientKeyStore = ks
-
 	tp := cfg.TracerProvider
 	if tp == nil {
 		tp = mcpcore.NoopTracerProvider{}
 	}
 
 	return &JWTValidator{
-		auth:                auth,
+		issuer:              cfg.Issuer,
+		audience:            cfg.Audience,
 		ks:                  ks,
 		ResourceMetadataURL: cfg.ResourceMetadataURL,
 		RequiredScopes:      cfg.RequiredScopes,
@@ -224,28 +222,28 @@ func (v *JWTValidator) Validate(r *http.Request) error {
 	}
 
 	// Verify issuer
-	if v.auth.JWTIssuer != "" {
-		if iss, _ := mapClaims["iss"].(string); iss != v.auth.JWTIssuer {
+	if v.issuer != "" {
+		if iss, _ := mapClaims["iss"].(string); iss != v.issuer {
 			return v.unauthorized("invalid issuer")
 		}
 	}
 
 	// Verify audience (RFC 8707 resource indicator)
-	if v.auth.JWTAudience != "" {
+	if v.audience != "" {
 		audOK := false
 		switch aud := mapClaims["aud"].(type) {
 		case string:
-			audOK = aud == v.auth.JWTAudience
+			audOK = aud == v.audience
 		case []any:
 			for _, a := range aud {
-				if s, ok := a.(string); ok && s == v.auth.JWTAudience {
+				if s, ok := a.(string); ok && s == v.audience {
 					audOK = true
 					break
 				}
 			}
 		}
 		if !audOK {
-			return v.unauthorized(fmt.Sprintf("invalid audience: expected %q", v.auth.JWTAudience))
+			return v.unauthorized(fmt.Sprintf("invalid audience: expected %q", v.audience))
 		}
 	}
 
@@ -302,11 +300,11 @@ func (v *JWTValidator) Validate(r *http.Request) error {
 		Scopes:    scopes,
 		Extra:     customClaims,
 	}
-	if v.auth.JWTIssuer != "" {
-		claims.Issuer = v.auth.JWTIssuer
+	if v.issuer != "" {
+		claims.Issuer = v.issuer
 	}
-	if v.auth.JWTAudience != "" {
-		claims.Audience = []string{v.auth.JWTAudience}
+	if v.audience != "" {
+		claims.Audience = []string{v.audience}
 	}
 
 	// Stamp the resolved principal info on the active dispatch span

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/panyam/mcpkit v0.2.3
 	github.com/panyam/mcpkit/ext/auth v0.0.0
 	github.com/panyam/mcpkit/ext/ui v0.0.0
-	github.com/panyam/oneauth v0.1.20
+	github.com/panyam/oneauth v0.1.31
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/tests/e2e/go.sum
+++ b/tests/e2e/go.sum
@@ -41,8 +41,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.8 h1:5UscYTP892k54+Nyb01tKGGwZxczZ5k7BC+c0nXmcoc=
 github.com/panyam/goutils v0.1.8/go.mod h1:ntucs8GJOHQ0LmlRGRjeup3aDC2t7xPMudrRwUHrJNM=
-github.com/panyam/oneauth v0.1.20 h1:z59UdXdnQRdlmk5gsKojQv779NAta4+EFbOeKYv65lc=
-github.com/panyam/oneauth v0.1.20/go.mod h1:UPCcpcL6q8vhcuEagIGEWw5g0bsWtQVT6XYcTAWUBFI=
+github.com/panyam/oneauth v0.1.31 h1:CDnVWxZo+7WO6hPvLamvDtdT1spDfBqBdByImQzTcIU=
+github.com/panyam/oneauth v0.1.31/go.mod h1:UPCcpcL6q8vhcuEagIGEWw5g0bsWtQVT6XYcTAWUBFI=
 github.com/panyam/servicekit v0.1.2 h1:2IfSVhgjQonUM6lkqVH6dm0QA700UsJSbASE95lWj+Y=
 github.com/panyam/servicekit v0.1.2/go.mod h1:wk/9hY9Vgl83WuYJt7n4NYPvV6nbxnZwpKpNRIAPoR8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/tests/e2e/testenv_test.go
+++ b/tests/e2e/testenv_test.go
@@ -10,6 +10,7 @@
 package e2e_test
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -21,9 +22,37 @@ import (
 // testScopes are the scopes supported by the test MCP server.
 var testScopes = []string{"tools:read", "tools:call", "admin:write"}
 
+// audienceHolder owns the late-bound audience value the AS's
+// validator + issuer read on every mint / validate. The MCP server
+// URL is only known after buildMCPServer runs, so the AS is built
+// once with a closure (audienceHolder.get) and the value is filled
+// in once the URL is allocated. This is the canonical pattern oneauth
+// docs/MIGRATION.md "Late-binding the audience" describes; testutil's
+// WithAudienceFunc option plumbs the closure to OneAuthConfig.
+type audienceHolder struct {
+	mu  sync.Mutex
+	val string
+}
+
+func (a *audienceHolder) get() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.val
+}
+
+func (a *audienceHolder) set(v string) {
+	a.mu.Lock()
+	a.val = v
+	a.mu.Unlock()
+}
+
 // TestEnv holds an in-process oneauth authorization server and an mcpkit MCP
 // server wired together via JWKS. Create one per test via NewTestEnv.
 type TestEnv struct {
+	// audVar backs the AudienceFunc the AS reads on every mint /
+	// validate. Populated after the MCP server URL is known.
+	audVar *audienceHolder
+
 	// AS is the oneauth test authorization server (JWKS, token endpoint, AS metadata).
 	AS *testutil.TestAuthServer
 
@@ -43,19 +72,22 @@ type TestEnv struct {
 func NewTestEnv(t *testing.T) *TestEnv {
 	t.Helper()
 
-	env := &TestEnv{}
+	env := &TestEnv{audVar: &audienceHolder{}}
 
-	// Step 1: Start auth server. Audience is set after MCP server starts.
+	// Step 1: Start auth server. The audience closure returns "" until
+	// the MCP server URL is allocated; tokens minted before that point
+	// (none in practice) would have no aud claim, which is correct.
 	env.AS = testutil.NewTestAuthServer(t,
 		testutil.WithScopes(testScopes),
+		testutil.WithAudienceFunc(env.audVar.get),
 	)
 
 	// Step 2: Start MCP server (uses AS's JWKS URL for JWT validation)
 	env.buildMCPServer(t)
 
-	// Step 3: Now set the audience on the auth server so minted tokens
-	// include the MCP server URL as the "aud" claim.
-	env.AS.APIAuth.JWTAudience = env.MCPServerURL
+	// Step 3: Bind the audience to the MCP server URL. The AS issuer +
+	// validator pick this up on every subsequent mint / validate.
+	env.audVar.set(env.MCPServerURL)
 
 	return env
 }
@@ -64,10 +96,13 @@ func NewTestEnv(t *testing.T) *TestEnv {
 // with WithPublicMethods configured on the MCP server.
 func NewTestEnvWithPublicMethods(t *testing.T, methods ...string) *TestEnv {
 	t.Helper()
-	env := &TestEnv{}
-	env.AS = testutil.NewTestAuthServer(t, testutil.WithScopes(testScopes))
+	env := &TestEnv{audVar: &audienceHolder{}}
+	env.AS = testutil.NewTestAuthServer(t,
+		testutil.WithScopes(testScopes),
+		testutil.WithAudienceFunc(env.audVar.get),
+	)
 	env.buildMCPServerWithOpts(t, server.WithPublicMethods(methods...))
-	env.AS.APIAuth.JWTAudience = env.MCPServerURL
+	env.audVar.set(env.MCPServerURL)
 	return env
 }
 

--- a/tests/keycloak/go.mod
+++ b/tests/keycloak/go.mod
@@ -5,7 +5,7 @@ go 1.26.4
 require (
 	github.com/panyam/mcpkit v0.2.3
 	github.com/panyam/mcpkit/ext/auth v0.0.0
-	github.com/panyam/oneauth v0.1.20
+	github.com/panyam/oneauth v0.1.31
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/tests/keycloak/go.sum
+++ b/tests/keycloak/go.sum
@@ -41,8 +41,8 @@ github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezega
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.8 h1:5UscYTP892k54+Nyb01tKGGwZxczZ5k7BC+c0nXmcoc=
 github.com/panyam/goutils v0.1.8/go.mod h1:ntucs8GJOHQ0LmlRGRjeup3aDC2t7xPMudrRwUHrJNM=
-github.com/panyam/oneauth v0.1.20 h1:z59UdXdnQRdlmk5gsKojQv779NAta4+EFbOeKYv65lc=
-github.com/panyam/oneauth v0.1.20/go.mod h1:UPCcpcL6q8vhcuEagIGEWw5g0bsWtQVT6XYcTAWUBFI=
+github.com/panyam/oneauth v0.1.31 h1:CDnVWxZo+7WO6hPvLamvDtdT1spDfBqBdByImQzTcIU=
+github.com/panyam/oneauth v0.1.31/go.mod h1:UPCcpcL6q8vhcuEagIGEWw5g0bsWtQVT6XYcTAWUBFI=
 github.com/panyam/servicekit v0.1.2 h1:2IfSVhgjQonUM6lkqVH6dm0QA700UsJSbASE95lWj+Y=
 github.com/panyam/servicekit v0.1.2/go.mod h1:wk/9hY9Vgl83WuYJt7n4NYPvV6nbxnZwpKpNRIAPoR8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
## What changes

Bumps `github.com/panyam/oneauth` to v0.1.31 across all 9 mcpkit modules. Picks up two upstream changes:

- **oneauth 298** — `apiauth.APIAuth` god struct retired, replaced by transport-independent `*OneAuth`. Affects `ext/auth/jwt_validator.go` (drops the apiauth dep entirely) and `examples/fine-grained-auth/main.go` (in-process AS uses `apiauth.NewOneAuth` + `NewTokenEndpointHandler`).
- **oneauth 343** — `OneAuthConfig.AudienceFunc` for deferred audience resolution. `tests/e2e/testenv_test.go` and `examples/auth/common/setup.go` adopt `testutil.WithAudienceFunc(fn)` to bind the AS audience to the MCP server URL only after it's allocated.

## Why

`*OneAuth` is immutable post-construction, which broke the prior pattern where tests mutated `apiAuth.JWTAudience = mcpServerURL` after `httptest.NewServer` ran. `AudienceFunc` is oneauth's canonical fix: build once, swap the value in via a closure when it's known. Adopting this pattern in the fixtures means community-facing examples (the conformance suite + the auth example walkthrough) show the right shape without leaking testutil-specific shims.

## Reviewer's guide

Read in this order:

1. [ext/auth/jwt_validator.go](https://github.com/panyam/mcpkit/pull/812/files#diff-e6c5bfccc6d222d3735a5835e709c9f8ad03ca99e4739143cbcc146154806a87) — biggest semantic change. The validator no longer wraps APIAuth; it stores `issuer` + `audience` strings and resolves keys via `JWKSKeyStore` directly. Verify the doc comment captures the WHY (oneauth dep stays scoped to the JWKS key store).
2. [tests/e2e/testenv_test.go](https://github.com/panyam/mcpkit/pull/812/files#diff-ce7f233525f6790c96bf215bb24b36e8c1a6ec9d045dfdd023f350174bb5efac) — `audienceHolder` struct + `WithAudienceFunc` wiring. This is the canonical late-binding recipe; the rest of the diff is a literal application of it.
3. [examples/auth/common/setup.go](https://github.com/panyam/mcpkit/pull/812/files#diff-6946c9666ab94376f1c83c51af5a527c1de763cd4528f0841352d9053ab3e308) — same pattern on the examples side. `Env.getAudience` is the closure handed to testutil.
4. [examples/fine-grained-auth/main.go](https://github.com/panyam/mcpkit/pull/812/files#diff-cc8039b26a5505a2251ca47a3305daf3afc79ddc12a7655dbfb988074bf704d5) — `&apiauth.APIAuth{}` → `apiauth.NewOneAuth(...)` + `apiauth.NewTokenEndpointHandler(oa)`. The `iss` deferral (separate from audience) keeps the "build httptest first, then OneAuth" order — `AudienceFunc` doesn't apply to iss.

Skim or skip: the 9 `go.mod` / `go.sum` bumps — all v0.1.30 → v0.1.31, no other changes.

## Decision log

- **`ext/auth/jwt_validator.go` drops apiauth entirely** instead of switching to `OneAuth.Validator`. The validation surface mcpkit wants is narrow (single JWKS, fixed iss+aud, scope-array-or-string Keycloak fallback). Going through oneauth's TokenValidator would re-introduce a fat dependency for code we can inline in 20 lines.
- **`audienceHolder` in `testenv_test.go` is a `sync.Mutex` + string**, not a `*sync/atomic.Value`. The audience is set once early, read many times concurrently — Mutex+string is clearer than swapping `Value`'s type-erased semantics.
- **`Env.getAudience` in `common/setup.go` has no mutex.** The call sites are synchronous (`NewEnv → NewValidator → Mint*` in a single goroutine). Adding a mutex would suggest a contention story that doesn't exist; the comment on the field captures the invariant.
- **`examples/fine-grained-auth/main.go` keeps the "build httptest first, then OneAuth" order.** The reason this file defers is the `Issuer:` field (iss URL is set to `ts.URL`), not the audience. `AudienceFunc` is a different lever; using it here would not collapse the order.

## Risk / blast radius

- Affects: any mcpkit consumer of `ext/auth.JWTValidator` (most production users) — internals changed but the public API (`JWTConfig`, `NewJWTValidator`, `Validate`) is unchanged. Public field `ResourceMetadataURL` and the constructor signature are preserved.
- Tests covering this: `tests/e2e/...` (full e2e + apps), `ext/auth/...`, mcpkit main module tests — all green.
- Be paranoid about: the JWT verification path in `jwt_validator.go`. The previous code routed through `apiauth.APIAuth.jwtKeyFunc`; this PR inlines key resolution via `JWKSKeyStore.GetKey(kid)`. Both paths use the same `JWKSKeyStore` under the hood — verify by reading lines 222–249 of `jwt_validator.go`.

## Before / after

`TestE2E_ClientCredentials_FullFlow` was failing on v0.1.30 because the AS validator never learned the audience (audience was snapshot-empty when the AS was built; the prior `apiAuth.JWTAudience = url` pattern is gone). Passes on this branch.

## Out of scope

- mcpkit's own version tag — separate `make tag` after this PR merges.
