### PR TITLE
fix(server/stateless): surface middleware *core.AuthError as HTTP 403 + WWW-Authenticate on the SEP-2575 wire

### DIFF
--- a/server/stateless/backend.go
+++ b/server/stateless/backend.go
@@ -73,10 +73,15 @@ type Backend interface {
 	// via Server.UseMiddleware / HandleMethod would be invisible to the
 	// stateless dispatcher.
 	//
-	// Returns (response, true) when the backend handled the request; the
-	// dispatcher uses that response verbatim. Returns (nil, false) to let
-	// the dispatcher fall back to its built-in per-method handler — used
-	// by minimal test fakes that don't carry middleware or custom-method
+	// Returns (response, err, true) when the backend handled the request.
+	// A non-nil err is a middleware short-circuit (typically *core.AuthError)
+	// that the transport surfaces as an HTTP-level response via writeAuthError
+	// — the dispatcher forwards it verbatim rather than folding it into a
+	// generic -32603 JSON-RPC body, so the legacy and stateless wires share
+	// the same 403 + WWW-Authenticate signaling (issue 815). When err is nil
+	// the response is used verbatim. Returns (nil, nil, false) to let the
+	// dispatcher fall back to its built-in per-method handler — used by
+	// minimal test fakes that don't carry middleware or custom-method
 	// registrations.
-	InvokeWithMiddleware(ctx context.Context, req *core.Request) (*core.Response, bool)
+	InvokeWithMiddleware(ctx context.Context, req *core.Request) (*core.Response, error, bool)
 }

--- a/server/stateless/dispatch.go
+++ b/server/stateless/dispatch.go
@@ -51,10 +51,19 @@ var removedLegacyMethods = map[string]struct{}{
 	"notifications/roots/list_changed": {},
 }
 
-// Dispatch routes one stateless-wire request. The returned *core.Response
-// always carries a JSON-RPC payload; transport-layer error → HTTP status
-// mapping happens in errors.go (HTTPStatusForCode) at the transport boundary.
-func (d *Dispatcher) Dispatch(ctx context.Context, req *core.Request) *core.Response {
+// Dispatch routes one stateless-wire request, returning (*core.Response, error).
+//
+// On the happy path err is nil and the *core.Response carries a JSON-RPC
+// payload; transport-layer error → HTTP status mapping happens in errors.go
+// (HTTPStatusForCode) at the transport boundary.
+//
+// A non-nil error is a middleware short-circuit (typically *core.AuthError)
+// raised by the backend's middleware chain on tools/call, prompts/get, or a
+// custom method. The transport surfaces it via writeAuthError — emitting the
+// correct HTTP status (e.g. 403) + WWW-Authenticate header — so the stateless
+// wire matches the legacy wire's auth signaling instead of folding it into a
+// generic -32603 body (issue 815). When err is non-nil the *core.Response is nil.
+func (d *Dispatcher) Dispatch(ctx context.Context, req *core.Request) (*core.Response, error) {
 	id := req.ID
 	if id == nil {
 		id = json.RawMessage("null")
@@ -65,14 +74,14 @@ func (d *Dispatcher) Dispatch(ctx context.Context, req *core.Request) *core.Resp
 	// returning -32601 here is unambiguous regardless of envelope state.
 	if _, removed := removedLegacyMethods[req.Method]; removed {
 		return core.NewErrorResponse(id, core.ErrCodeMethodNotFound,
-			"method not found on SEP-2575 stateless wire: "+req.Method)
+			"method not found on SEP-2575 stateless wire: "+req.Method), nil
 	}
 
 	// Every other method requires a valid _meta envelope.
 	meta, err := core.DecodeRequestMeta(req.Params)
 	if err != nil {
 		// MetaValidationError carries the specific missing field for diagnostics.
-		return core.NewErrorResponse(id, core.ErrCodeInvalidParams, err.Error())
+		return core.NewErrorResponse(id, core.ErrCodeInvalidParams, err.Error()), nil
 	}
 
 	// Validate the protocol version against what this server speaks.
@@ -96,7 +105,7 @@ func (d *Dispatcher) Dispatch(ctx context.Context, req *core.Request) *core.Resp
 				Supported: supported,
 				Requested: meta.ProtocolVersion,
 			},
-		)
+		), nil
 	}
 
 	// Thread the validated envelope through ctx so handlers and
@@ -106,25 +115,30 @@ func (d *Dispatcher) Dispatch(ctx context.Context, req *core.Request) *core.Resp
 	// ctx.ClientCaps() can read it without an import cycle.
 	ctx = core.WithRequestMeta(ctx, meta)
 
+	// Handlers that route through the backend's middleware chain
+	// (tools/call, prompts/get, and the default custom-method branch)
+	// return (resp, err); the err is a middleware short-circuit forwarded
+	// to the transport's writeAuthError. The remaining handlers can't raise
+	// a middleware auth error, so they're wrapped with a nil error here.
 	switch req.Method {
 	case "server/discover":
-		return d.handleDiscover(id)
+		return d.handleDiscover(id), nil
 	case "tools/list":
-		return d.handleToolsList(id, req.Params)
+		return d.handleToolsList(id, req.Params), nil
 	case "tools/call":
 		return d.handleToolsCall(ctx, id, req.Params)
 	case "resources/list":
-		return d.handleResourcesList(id, req.Params)
+		return d.handleResourcesList(id, req.Params), nil
 	case "resources/read":
-		return d.handleResourcesRead(ctx, id, req.Params)
+		return d.handleResourcesRead(ctx, id, req.Params), nil
 	case "resources/templates/list":
-		return d.handleResourcesTemplatesList(id, req.Params)
+		return d.handleResourcesTemplatesList(id, req.Params), nil
 	case "prompts/list":
-		return d.handlePromptsList(id, req.Params)
+		return d.handlePromptsList(id, req.Params), nil
 	case "prompts/get":
 		return d.handlePromptsGet(ctx, id, req.Params)
 	case "completion/complete":
-		return d.handleCompletionComplete(ctx, id, req.Params)
+		return d.handleCompletionComplete(ctx, id, req.Params), nil
 	default:
 		// Any other method (custom JSON-RPC verbs registered via
 		// Server.HandleMethod — events/poll, events/list,
@@ -147,11 +161,11 @@ func (d *Dispatcher) Dispatch(ctx context.Context, req *core.Request) *core.Resp
 			Method:  req.Method,
 			Params:  req.Params,
 		}
-		if resp, ok := d.Backend.InvokeWithMiddleware(ctx, out); ok {
-			return resp
+		if resp, err, ok := d.Backend.InvokeWithMiddleware(ctx, out); ok {
+			return resp, err
 		}
 		return core.NewErrorResponse(id, core.ErrCodeMethodNotFound,
-			"method not found: "+req.Method)
+			"method not found: "+req.Method), nil
 	}
 }
 

--- a/server/stateless/dispatch_autherror_test.go
+++ b/server/stateless/dispatch_autherror_test.go
@@ -1,0 +1,77 @@
+package stateless
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	core "github.com/panyam/mcpkit/core"
+)
+
+// A middleware short-circuit raised inside InvokeWithMiddleware must propagate
+// out of Dispatch as the second return value, unfolded — NOT collapsed into a
+// generic -32603 *core.Response. The transport relies on this to emit HTTP 403
+// + WWW-Authenticate via writeAuthError (issue 815). Before the fix, Dispatch
+// had no error return and the backend folded the AuthError into -32603, which
+// HTTPStatusForCode maps to HTTP 200 — silently losing the scope challenge.
+func TestDispatch_MiddlewareAuthErrorPropagates(t *testing.T) {
+	authErr := &core.AuthError{
+		Code:            http.StatusForbidden,
+		Message:         "insufficient scope",
+		WWWAuthenticate: `Bearer error="insufficient_scope", scope="docs:write"`,
+	}
+	// Method "tools/call" routes through the backend's middleware path.
+	d := New(&fakeBackend{authErr: authErr})
+
+	req := &core.Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage("1"),
+		Method:  "tools/call",
+		Params:  validMetaParams(t),
+	}
+	resp, err := d.Dispatch(context.Background(), req)
+
+	if err == nil {
+		t.Fatalf("Dispatch err = nil; want the middleware *core.AuthError to propagate")
+	}
+	var got *core.AuthError
+	if !errors.As(err, &got) {
+		t.Fatalf("Dispatch err = %T (%v); want *core.AuthError", err, err)
+	}
+	if got.Code != http.StatusForbidden {
+		t.Errorf("AuthError.Code = %d, want 403", got.Code)
+	}
+	if got.WWWAuthenticate != authErr.WWWAuthenticate {
+		t.Errorf("AuthError.WWWAuthenticate = %q, want %q", got.WWWAuthenticate, authErr.WWWAuthenticate)
+	}
+	// The response must be nil on the error path — a non-nil -32603 body here
+	// would mean the transport writes HTTP 200 + a generic JSON-RPC error
+	// instead of the auth challenge.
+	if resp != nil {
+		t.Errorf("Dispatch resp = %+v; want nil on the error path", resp)
+	}
+}
+
+// The custom-method (default) branch routes through the same middleware path,
+// so an AuthError there must propagate identically.
+func TestDispatch_MiddlewareAuthErrorPropagatesForCustomMethod(t *testing.T) {
+	authErr := &core.AuthError{Code: http.StatusForbidden, Message: "denied"}
+	d := New(&fakeBackend{authErr: authErr})
+
+	req := &core.Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage("2"),
+		Method:  "events/poll",
+		Params:  validMetaParams(t),
+	}
+	resp, err := d.Dispatch(context.Background(), req)
+
+	if err == nil {
+		t.Fatalf("Dispatch err = nil; want the custom-method middleware AuthError to propagate")
+	}
+	if resp != nil {
+		t.Errorf("Dispatch resp = %+v; want nil on the error path", resp)
+	}
+}

--- a/server/stateless/dispatch_test.go
+++ b/server/stateless/dispatch_test.go
@@ -18,6 +18,7 @@ type fakeBackend struct {
 	tool     func(name string) (core.ToolDef, core.ToolHandler, bool)
 	ttlMs    *int
 	scope    string
+	authErr  error // when non-nil, InvokeWithMiddleware short-circuits with it
 }
 
 func (f *fakeBackend) ServerInfo() core.ServerInfo           { return f.info }
@@ -51,12 +52,17 @@ func (f *fakeBackend) Completion(string, string) (core.CompletionHandler, bool) 
 func (f *fakeBackend) ListTTLMs() *int                                          { return f.ttlMs }
 func (f *fakeBackend) ListCacheScope() string                                   { return f.scope }
 
-// InvokeWithMiddleware returns (nil, false) so the dispatcher falls back
+// InvokeWithMiddleware returns (nil, nil, false) so the dispatcher falls back
 // to its built-in per-method handler. The fake doesn't model server-level
 // middleware or custom-method registrations — both belong to production
-// statelessBackend (server package).
-func (f *fakeBackend) InvokeWithMiddleware(context.Context, *core.Request) (*core.Response, bool) {
-	return nil, false
+// statelessBackend (server package). The authErr field, when set, models a
+// middleware short-circuit so dispatch_autherror_test.go can assert the error
+// propagates out of Dispatch unfolded.
+func (f *fakeBackend) InvokeWithMiddleware(context.Context, *core.Request) (*core.Response, error, bool) {
+	if f.authErr != nil {
+		return nil, f.authErr, true
+	}
+	return nil, nil, false
 }
 
 // validMetaParams is a params blob with the minimum valid _meta envelope.
@@ -89,7 +95,7 @@ func TestDispatch_RemovedMethodReturns32601(t *testing.T) {
 				Method:  method,
 				Params:  validMetaParams(t),
 			}
-			resp := d.Dispatch(context.Background(), req)
+			resp, _ := d.Dispatch(context.Background(), req)
 			if resp == nil || resp.Error == nil {
 				t.Fatalf("expected error response for removed method %q", method)
 			}
@@ -112,7 +118,7 @@ func TestDispatch_MissingMetaReturns32602(t *testing.T) {
 		Method:  "tools/list",
 		Params:  json.RawMessage(`{}`),
 	}
-	resp := d.Dispatch(context.Background(), req)
+	resp, _ := d.Dispatch(context.Background(), req)
 	if resp == nil || resp.Error == nil {
 		t.Fatal("expected error response for missing _meta")
 	}
@@ -140,7 +146,7 @@ func TestDispatch_UnsupportedVersionReturns32004(t *testing.T) {
 		Method:  "tools/list",
 		Params:  bad,
 	}
-	resp := d.Dispatch(context.Background(), req)
+	resp, _ := d.Dispatch(context.Background(), req)
 	if resp == nil || resp.Error == nil {
 		t.Fatal("expected error response for unsupported version")
 	}
@@ -177,7 +183,7 @@ func TestDispatch_ServerDiscoverShape(t *testing.T) {
 		Method:  "server/discover",
 		Params:  validMetaParams(t),
 	}
-	resp := d.Dispatch(context.Background(), req)
+	resp, _ := d.Dispatch(context.Background(), req)
 	if resp == nil || resp.Error != nil {
 		t.Fatalf("server/discover failed: %+v", resp)
 	}
@@ -234,7 +240,7 @@ func TestDispatch_ToolsCallMissingCapReturns32003(t *testing.T) {
 		Method:  "tools/call",
 		Params:  params,
 	}
-	resp := d.Dispatch(context.Background(), req)
+	resp, _ := d.Dispatch(context.Background(), req)
 	if resp == nil || resp.Error == nil {
 		t.Fatal("expected -32021 for missing-capability tool")
 	}
@@ -264,7 +270,7 @@ func TestDispatch_UnknownMethodReturns32601(t *testing.T) {
 		Method:  "frobnicate",
 		Params:  validMetaParams(t),
 	}
-	resp := d.Dispatch(context.Background(), req)
+	resp, _ := d.Dispatch(context.Background(), req)
 	if resp == nil || resp.Error == nil || resp.Error.Code != core.ErrCodeMethodNotFound {
 		t.Fatalf("got %+v, want -32601 method-not-found", resp)
 	}

--- a/server/stateless/handlers.go
+++ b/server/stateless/handlers.go
@@ -42,7 +42,12 @@ type toolsCallEnvelope struct {
 	// dispatcher does not consume them here.
 }
 
-func (d *Dispatcher) handleToolsCall(ctx context.Context, id json.RawMessage, params json.RawMessage) *core.Response {
+// handleToolsCall returns (*core.Response, error). A non-nil error is a
+// middleware short-circuit (typically *core.AuthError) propagated unfolded so
+// the transport surfaces it as HTTP 403 + WWW-Authenticate rather than a
+// generic -32603 body (issue 815). The fallback path (test fakes with no
+// middleware) never returns a non-nil error.
+func (d *Dispatcher) handleToolsCall(ctx context.Context, id json.RawMessage, params json.RawMessage) (*core.Response, error) {
 	// Prefer the middleware-aware path so server-level middleware (notably
 	// the v2 task middleware from ext/tasks) fires on the stateless wire
 	// just like it does on the legacy wire. Backends that don't carry
@@ -54,20 +59,20 @@ func (d *Dispatcher) handleToolsCall(ctx context.Context, id json.RawMessage, pa
 		Method:  "tools/call",
 		Params:  params,
 	}
-	if resp, ok := d.Backend.InvokeWithMiddleware(ctx, req); ok {
-		return resp
+	if resp, err, ok := d.Backend.InvokeWithMiddleware(ctx, req); ok {
+		return resp, err
 	}
 
 	// Fallback path: no middleware support on this backend.
 	var env toolsCallEnvelope
 	if err := json.Unmarshal(params, &env); err != nil {
 		return core.NewErrorResponse(id, core.ErrCodeInvalidParams,
-			"invalid tools/call params: "+err.Error())
+			"invalid tools/call params: "+err.Error()), nil
 	}
 	def, handler, ok := d.Backend.Tool(env.Name)
 	if !ok {
 		return core.NewErrorResponse(id, core.ErrCodeInvalidParams,
-			"unknown tool: "+env.Name)
+			"unknown tool: "+env.Name), nil
 	}
 	_ = def // tool definition reserved for schema validation in a follow-up commit
 
@@ -77,9 +82,9 @@ func (d *Dispatcher) handleToolsCall(ctx context.Context, id json.RawMessage, pa
 		Arguments: env.Arguments,
 	})
 	if err != nil {
-		return translateToolError(id, err)
+		return translateToolError(id, err), nil
 	}
-	return core.NewResponse(id, result)
+	return core.NewResponse(id, result), nil
 }
 
 // translateToolError converts a tool-handler error into the right
@@ -165,7 +170,10 @@ type promptsGetEnvelope struct {
 	Arguments map[string]any `json:"arguments,omitempty"`
 }
 
-func (d *Dispatcher) handlePromptsGet(ctx context.Context, id json.RawMessage, params json.RawMessage) *core.Response {
+// handlePromptsGet returns (*core.Response, error). As with handleToolsCall, a
+// non-nil error is a middleware short-circuit propagated unfolded for the
+// transport's writeAuthError (issue 815); the fallback path never errors.
+func (d *Dispatcher) handlePromptsGet(ctx context.Context, id json.RawMessage, params json.RawMessage) (*core.Response, error) {
 	// Prefer the middleware-aware path so server-level middleware fires
 	// uniformly on the stateless wire AND so the MRTR envelope
 	// (inputResponses + requestState) is decoded and the requestState
@@ -178,8 +186,8 @@ func (d *Dispatcher) handlePromptsGet(ctx context.Context, id json.RawMessage, p
 		Method:  "prompts/get",
 		Params:  params,
 	}
-	if resp, ok := d.Backend.InvokeWithMiddleware(ctx, req); ok {
-		return resp
+	if resp, err, ok := d.Backend.InvokeWithMiddleware(ctx, req); ok {
+		return resp, err
 	}
 
 	// Fallback path (test fakes with no middleware support): no MRTR
@@ -188,21 +196,21 @@ func (d *Dispatcher) handlePromptsGet(ctx context.Context, id json.RawMessage, p
 	var env promptsGetEnvelope
 	if err := json.Unmarshal(params, &env); err != nil {
 		return core.NewErrorResponse(id, core.ErrCodeInvalidParams,
-			"invalid prompts/get params: "+err.Error())
+			"invalid prompts/get params: "+err.Error()), nil
 	}
 	_, handler, ok := d.Backend.Prompt(env.Name)
 	if !ok {
 		return core.NewErrorResponse(id, core.ErrCodeInvalidParams,
-			"unknown prompt: "+env.Name)
+			"unknown prompt: "+env.Name), nil
 	}
 	result, err := handler(core.NewPromptContext(ctx), core.PromptRequest{
 		Name:      env.Name,
 		Arguments: env.Arguments,
 	})
 	if err != nil {
-		return core.NewErrorResponse(id, core.ErrCodePromptError, err.Error())
+		return core.NewErrorResponse(id, core.ErrCodePromptError, err.Error()), nil
 	}
-	return core.NewResponse(id, result)
+	return core.NewResponse(id, result), nil
 }
 
 // ---------- completion ----------

--- a/server/stateless/loglevel_gate_test.go
+++ b/server/stateless/loglevel_gate_test.go
@@ -94,7 +94,7 @@ func TestRequestMeta_LogLevelThreadingExposedToHandlers(t *testing.T) {
 				Method:  "tools/call",
 				Params:  params,
 			}
-			resp := d.Dispatch(context.Background(), req)
+			resp, _ := d.Dispatch(context.Background(), req)
 			if resp == nil || resp.Error != nil {
 				t.Fatalf("tools/call errored: %+v", resp)
 			}

--- a/server/stateless_backend.go
+++ b/server/stateless_backend.go
@@ -239,7 +239,7 @@ func (b *statelessBackend) ListCacheScope() string {
 // which is acceptable for the single-tenant fixtures the conformance
 // suite covers; multi-tenant deployments should layer an auth-subject-
 // keyed store wrapper. Tracked for a follow-up.
-func (b *statelessBackend) InvokeWithMiddleware(ctx context.Context, req *core.Request) (*core.Response, bool) {
+func (b *statelessBackend) InvokeWithMiddleware(ctx context.Context, req *core.Request) (*core.Response, error, bool) {
 	terminal := MiddlewareFunc(func(ctx context.Context, req *core.Request) (*core.Response, error) {
 		switch req.Method {
 		case "tools/call":
@@ -266,9 +266,13 @@ func (b *statelessBackend) InvokeWithMiddleware(ctx context.Context, req *core.R
 
 	resp, err := handler(ctx, req)
 	if err != nil {
-		return core.NewErrorResponse(req.ID, core.ErrCodeInternal, err.Error()), true
+		// Surface the raw middleware error (typically *core.AuthError) so the
+		// transport's writeAuthError can emit the correct HTTP status +
+		// WWW-Authenticate header — mirroring the legacy wire. Folding it into
+		// a generic -32603 here would drop the 403 + scope challenge (issue 815).
+		return nil, err, true
 	}
-	return resp, true
+	return resp, nil, true
 }
 
 // callToolForStateless mirrors the legacy Dispatcher.handleToolsCall MRTR

--- a/server/streamable_stateless.go
+++ b/server/streamable_stateless.go
@@ -69,7 +69,16 @@ func (t *streamableTransport) handleStatelessPost(w http.ResponseWriter, r *http
 	// sessionCtx that the stateless wire deliberately does not create.
 	ctx := core.WithResponseHeaderCollector(r.Context())
 	ctx = core.WithStatelessClaims(ctx, claims)
-	resp := t.statelessDispatcher.Dispatch(ctx, req)
+	resp, dErr := t.statelessDispatcher.Dispatch(ctx, req)
+
+	// A non-nil dispatch error is a middleware short-circuit (typically
+	// *core.AuthError). Surface it through the shared writeAuthError so the
+	// stateless wire emits the same HTTP 403 + WWW-Authenticate as the legacy
+	// wire instead of a generic -32603/HTTP 200 body (issue 815).
+	if dErr != nil {
+		writeAuthError(w, dErr)
+		return
+	}
 
 	if resp == nil {
 		// Notification (no id) — return 202 Accepted with no body.
@@ -187,7 +196,25 @@ func (t *streamableTransport) handleStatelessPostSSE(w http.ResponseWriter, r *h
 		}
 	}
 
-	resp := t.statelessDispatcher.Dispatch(dispatchCtx, req)
+	resp, dErr := t.statelessDispatcher.Dispatch(dispatchCtx, req)
+
+	// A middleware short-circuit (typically *core.AuthError) fires before the
+	// handler runs, so no SSE frame has been written yet (sseStarted is false).
+	// Surface it as an HTTP-level auth error via the shared writeAuthError —
+	// same 403 + WWW-Authenticate the legacy and non-SSE stateless paths emit
+	// (issue 815). The mu/closed guard keeps writeSSE a no-op afterward.
+	if dErr != nil {
+		mu.Lock()
+		started := sseStarted
+		mu.Unlock()
+		if !started {
+			writeAuthError(w, dErr)
+		}
+		mu.Lock()
+		closed = true
+		mu.Unlock()
+		return
+	}
 
 	// Terminal frame. resp is normally non-nil for SSE-eligible requests
 	// (notifications return 202 from handleStatelessPost and never reach

--- a/server/streamable_stateless_autherror_test.go
+++ b/server/streamable_stateless_autherror_test.go
@@ -1,0 +1,68 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	core "github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/server/stateless"
+)
+
+// A server.Middleware that short-circuits a tools/call with *core.AuthError on
+// the SEP-2575 stateless wire must produce HTTP 403 + the WWW-Authenticate
+// header — the same shape the legacy wire emits via writeAuthError — not a
+// generic -32603 JSON-RPC body over HTTP 200 (issue 815). This is the end-to-
+// end transport coverage for the scope-challenge / step-up auth flow that the
+// stateless dispatch path previously dropped.
+func TestStatelessTransport_MiddlewareAuthErrorYields403(t *testing.T) {
+	const challenge = `Bearer error="insufficient_scope", scope="docs:write"`
+
+	scopeGate := func(ctx context.Context, req *core.Request, next MiddlewareFunc) (*core.Response, error) {
+		if req.Method == "tools/call" {
+			return nil, &core.AuthError{
+				Code:            http.StatusForbidden,
+				Message:         "insufficient scope",
+				WWWAuthenticate: challenge,
+			}
+		}
+		return next(ctx, req)
+	}
+
+	s := NewServer(core.ServerInfo{Name: "stateless-autherr", Version: "0.0.1"}, WithMiddleware(scopeGate))
+	if err := s.Registry().AddTool(
+		core.ToolDef{Name: "docs_write", Description: "needs docs:write"},
+		func(_ core.ToolContext, _ core.ToolRequest) (core.ToolResponse, error) {
+			return core.TextResult("should never run"), nil
+		},
+	); err != nil {
+		t.Fatalf("AddTool: %v", err)
+	}
+
+	handler := s.Handler(WithStreamableHTTP(true), WithStatelessMode(stateless.ModeStateless))
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+	url := ts.URL + "/mcp"
+
+	resp := postStatelessJSON(t, url, map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+		"params": map[string]any{
+			"name":      "docs_write",
+			"arguments": map[string]any{},
+			"_meta": map[string]any{
+				"io.modelcontextprotocol/protocolVersion":    draftVersion,
+				"io.modelcontextprotocol/clientInfo":         map[string]any{"name": "t", "version": "1"},
+				"io.modelcontextprotocol/clientCapabilities": map[string]any{},
+			},
+		},
+	}, map[string]string{mcpProtocolVersionHeader: draftVersion})
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("HTTP status = %d, want 403", resp.StatusCode)
+	}
+	if got := resp.Header.Get("WWW-Authenticate"); got != challenge {
+		t.Errorf("WWW-Authenticate = %q, want %q", got, challenge)
+	}
+}


### PR DESCRIPTION
Fixes issue 815.

## What changes

On the SEP-2575 stateless wire, a `server.Middleware` that short-circuits with `*core.AuthError` (carrying `Code: 403` + a `WWWAuthenticate` value) previously lost both the HTTP status and the header: the transport emitted **HTTP 200 + a generic `-32603` JSON-RPC body** instead of **HTTP 403 + `WWW-Authenticate`**. That defeated SEP-2350 server-side scope-challenge / step-up auth on the stateless wire, and would break any auth/authz middleware (rate-limit gates, tenant isolation, custom policy).

The fix threads an error channel through the stateless dispatch path so the transport routes the typed error through the **same `writeAuthError` helper the legacy/Dual wire already uses** — one source of truth for "what a 403 + `WWW-Authenticate` looks like" across both wires.

## Reviewer's guide

Read in this order:
1. [server/stateless_backend.go](https://github.com/panyam/mcpkit/pull/816/files#diff-d6054c7923eaa9651736c3c6bccd7e7634dbf33d4bdfa89a5a34e069bb4b620e) — start here. The fold-to-`-32603` was here; now returns the raw middleware `err`.
2. [server/stateless/dispatch.go](https://github.com/panyam/mcpkit/pull/816/files#diff-1b101922de172cda20b6a044eae5a4fc36b2dce82e136a566765bae575a42b20) — `Dispatch` gains an `error` return; the switch forwards it from the three middleware-bearing branches (tools/call, prompts/get, custom-method default) and wraps the rest with `nil`.
3. [server/stateless/backend.go](https://github.com/panyam/mcpkit/pull/816/files#diff-15c07fee1ac91c5241771bd8216ad8682b848f4792517d63bf6d141f94184288) — `Backend.InvokeWithMiddleware` interface signature + contract doc.
4. [server/stateless/handlers.go](https://github.com/panyam/mcpkit/pull/816/files#diff-19d0510c5a845d30dabee0339a690f58a09c4134ee4d40f474f2fd4800f6e528) — `handleToolsCall` / `handlePromptsGet` propagate the err; fallback paths never error.
5. [server/streamable_stateless.go](https://github.com/panyam/mcpkit/pull/816/files#diff-89ab344bf48139c1aded7077cc0048cb885b6ee534ffd3d83f09d113e3a0beb1) — both transport entry points (`handleStatelessPost`, `handleStatelessPostSSE`) call `writeAuthError` on a non-nil dispatch error.
6. [server/streamable_stateless_autherror_test.go](https://github.com/panyam/mcpkit/pull/816/files#diff-1e63e92ec87163491c9dad2842a2def0102de613feedd95330ed199e73ccd9ec) — end-to-end acceptance: HTTP 403 + `WWW-Authenticate` over the wire.
7. [server/stateless/dispatch_autherror_test.go](https://github.com/panyam/mcpkit/pull/816/files#diff-c364f7e70797714bcb376d939862e7bb0f5c369705d665222419f09fb16b4560) — unit acceptance: the `*core.AuthError` propagates out of `Dispatch` unfolded.

Skim or skip: [server/stateless/dispatch_test.go](https://github.com/panyam/mcpkit/pull/816/files#diff-142d78847d857a6f7083f283917a07fddee55361a32caa97869972c3b4e2a506), [server/stateless/loglevel_gate_test.go](https://github.com/panyam/mcpkit/pull/816/files#diff-0693b5d0d7f5a7c77f240858a4dafde95e920655aba92e19aaaab25a255f9faf) — mechanical `resp :=` → `resp, _ :=` call-site updates for the new signature.

## Diff groups
- Production: `server/stateless_backend.go`, `server/stateless/dispatch.go`, `server/stateless/backend.go`, `server/stateless/handlers.go`, `server/streamable_stateless.go`
- Tests (new): `server/stateless/dispatch_autherror_test.go`, `server/streamable_stateless_autherror_test.go`
- Mechanical (signature accommodation): `server/stateless/dispatch_test.go`, `server/stateless/loglevel_gate_test.go`

## Decision log
- **Fix `Dispatch`, not the scope-challenge consumer.** Hoisting the scope check to the top of `handlePost` (like typescript-sdk PR 1624's `_checkScopeChallenge`) fixes one consumer; surfacing typed errors out of `Dispatch` cures the gap for all current/future auth middleware. mcpkit's middleware idiom is the right home for these checks.
- **Mirror the legacy wire exactly.** All middleware errors now flow to `writeAuthError`, which discriminates `*core.AuthError` (proper status + header) from generic errors (→ HTTP 401). This is a behavior change for **non-auth** middleware errors on the stateless wire: previously folded to `-32603`/HTTP 200, now HTTP 401 — bringing the stateless wire to parity with the legacy wire. Chosen over a surgical "only special-case `*core.AuthError`" to keep a single source of truth.
- **SSE path is safe.** A middleware short-circuit fires before the handler runs, so no SSE frame has been written (`sseStarted == false`); `writeAuthError` can still set headers + status.

## Risk / blast radius
- Affects: the SEP-2575 stateless dispatch path only (`server/stateless` + the two stateless transport handlers). No external callers of `Dispatcher.Dispatch` / `Backend.InvokeWithMiddleware` exist outside the `server` package (grep-verified across ext/, experimental/, examples/, tests/, client/, core/).
- The signature changes are on a package-internal interface + a transport-internal method — no public-API break for library consumers.
- Tests covering this: the two new acceptance tests + full `make test` (core/server/client/testutil) green.
- Be paranoid about: the non-auth-error → HTTP 401 behavior change (deliberate, documented above).

## Before / after

Against old code (transport test, stashed production changes):
```
HTTP status = 200, want 403
WWW-Authenticate = "", want "Bearer error=\"insufficient_scope\", scope=\"docs:write\""
--- FAIL
```
After: HTTP 403 + `WWW-Authenticate: Bearer error="insufficient_scope", scope="docs:write"`.

## Out of scope (deliberately deferred)
- `tests/keycloak/step_up_test.go` + the `scope-challenge` conformance scenario — both depend on `examples/auth/step-up-keycloak/main.go`, which lives on the `feat/sep-2350-server-scope-challenge` branch, not `main`. The transport-level httptest here gives equivalent HTTP-403 coverage without the Keycloak SUT; the integration test + conformance run land with the example branch.
- Stateless `resources/read` / `completion/complete` don't traverse the middleware chain at all today — a separate, broader gap. Will file a follow-up.

