### PR TITLE
feat(examples/auth): step-up-keycloak SUT + transport-level scope-challenge integration tests

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -2588,6 +2588,25 @@ func DoWithAuthRetry(
 			if inv, ok := ts.(core.InvalidatingTokenSource); ok {
 				inv.Invalidate()
 			}
+			// Per RFC 6750 §3.1 + SEP-2350: when the 401 challenge advertises
+			// scope=, the next token request SHOULD use that exact scope
+			// rather than whatever broader set was discovered earlier (e.g.
+			// PRM scopes_supported). PRM is the server's catalog of what it
+			// COULD accept; the WWW-Authenticate scope= is what the current
+			// operation actually NEEDS. The two are deliberately allowed to
+			// diverge by the spec (clients MUST NOT assume any set
+			// relationship between them), so a least-privilege client uses
+			// the per-operation hint when present.
+			//
+			// Falls back to plain Token() when the source isn't scope-aware
+			// or the 401 didn't carry a scope=, preserving the previous
+			// behavior for non-SEP-2350 paths.
+			wwa := resp.Header.Get("WWW-Authenticate")
+			_, scopes, _ := ssehttp.ParseWWWAuthenticate(wwa)
+			if sats, ok := ts.(core.ScopeAwareTokenSource); ok && len(scopes) > 0 {
+				_, err := sats.TokenForScopes(scopes)
+				return err
+			}
 			// Token() on a dynamic source will refresh; on a static source
 			// it returns the same token and the retry will fail → gives up.
 			_, err := ts.Token()

--- a/examples/auth/step-up-keycloak/Makefile
+++ b/examples/auth/step-up-keycloak/Makefile
@@ -1,0 +1,29 @@
+PORT ?= 3020
+KEYCLOAK_URL ?= http://localhost:8180
+KC_REALM ?= mcpkit-test
+
+.PHONY: help run build smoke clean
+
+help: ## Show available targets
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+run: ## Start the SUT (expects Keycloak already running at $(KEYCLOAK_URL))
+	go run . -addr :$(PORT) -keycloak-url $(KEYCLOAK_URL) -realm $(KC_REALM)
+
+build: ## Compile the SUT to ./step-up-keycloak-sut
+	go build -o step-up-keycloak-sut .
+
+smoke: ## curl-test the 403 path with an under-scoped token
+	@TOKEN=$$(curl -fsS -X POST $(KEYCLOAK_URL)/realms/$(KC_REALM)/protocol/openid-connect/token \
+		-d "grant_type=client_credentials" \
+		-d "client_id=mcp-confidential" \
+		-d "client_secret=mcp-test-secret-for-confidential" \
+		-d "scope=openid tools-read" | python3 -c "import json,sys; print(json.load(sys.stdin)['access_token'])"); \
+	echo "--- under-scoped (expect 403 + WWW-Authenticate) ---"; \
+	curl -i -X POST http://localhost:$(PORT)/mcp \
+		-H "Content-Type: application/json" \
+		-H "Authorization: Bearer $$TOKEN" \
+		-d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"admin_call","arguments":{}}}' 2>&1 | head -15
+
+clean: ## Remove built binary
+	rm -f step-up-keycloak-sut

--- a/examples/auth/step-up-keycloak/README.md
+++ b/examples/auth/step-up-keycloak/README.md
@@ -1,0 +1,82 @@
+# step-up-keycloak
+
+**Experimental.** SEP-2350 server-side scope-challenge demo running against a Keycloak realm.
+
+An experimental Go SDK exercising the same conformance scenario the TypeScript reference implementation in [`modelcontextprotocol/typescript-sdk` PR 1624](https://github.com/modelcontextprotocol/typescript-sdk/pull/1624) is being validated against. The canonical end-to-end runbook lives in [`panyam/mcpconformance`](https://github.com/panyam/mcpconformance/pull/19) under `examples/auth-fixtures/keycloak/README.md` on the `feat/sep-2350-server-scope-challenge` branch. This README is the mcpkit-side runbook for the same flow.
+
+## What it shows
+
+mcpkit's `ext/auth.NewToolScopeMiddleware` emits the SEP-2350 + RFC 6750 §3.1 wire shape any spec-conformant server must:
+
+- HTTP 403 with `WWW-Authenticate: Bearer error="insufficient_scope", scope="admin-write", resource_metadata="..."` when the bearer token lacks the required scope.
+- The handler does not run; the middleware short-circuits before dispatch.
+- A 2xx response when the same call is retried with a sufficiently-scoped token.
+
+## Quick run
+
+Requires Docker and the Keycloak fixture from `panyam/mcpconformance`'s `feat/sep-2350-server-scope-challenge` branch:
+
+```bash
+# Terminal 1: bring up Keycloak (in the mcpconformance clone)
+git clone https://github.com/panyam/mcpconformance.git
+cd mcpconformance && git checkout feat/sep-2350-server-scope-challenge
+make -C examples/auth-fixtures/keycloak up
+make -C examples/auth-fixtures/keycloak wait
+
+# Terminal 2: start the SUT (in the mcpkit clone)
+cd ~/path/to/mcpkit/examples/auth
+go run ./step-up-keycloak -addr :3020
+
+# Terminal 3: smoke test the wire shape directly
+INSUFFICIENT=$(curl -sS -X POST http://localhost:8180/realms/mcpkit-test/protocol/openid-connect/token \
+    -d "grant_type=client_credentials" \
+    -d "client_id=mcp-confidential" \
+    -d "client_secret=mcp-test-secret-for-confidential" \
+    -d "scope=openid tools-read" | python3 -c "import json,sys; print(json.load(sys.stdin)['access_token'])")
+
+curl -i -X POST http://localhost:3020/mcp \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $INSUFFICIENT" \
+    -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"admin_call","arguments":{}}}'
+# Expect: HTTP/1.1 403 Forbidden
+# WWW-Authenticate: Bearer error="insufficient_scope", scope="admin-write", ...
+```
+
+## Driving the conformance scenario against this SUT
+
+In the same mcpconformance clone:
+
+```bash
+npm install && npm run build
+CONTEXT=$(make -s -C examples/auth-fixtures/keycloak tokens-context)
+MCP_CONFORMANCE_CONTEXT="$CONTEXT" node dist/index.js server \
+    --url http://localhost:3020/mcp \
+    --scenario scope-challenge
+```
+
+Expected pass shape:
+
+```
+Passed: 8/8, 0 failed, 0 warnings
+```
+
+with two `scope-challenge-accepted-*` rows SKIPPED (those activate when the scope-gated tool declares `AcceptedScopes`; this example doesn't, to keep the demo focused on the basic shape).
+
+## Where this fits
+
+| | Server side | Client side |
+|---|---|---|
+| Spec | SEP-2350 (merged) | SEP-2350 (merged) |
+| TypeScript SDK reference | PR 1624 (open) | PR 1657 (open) |
+| mcpkit | `ext/auth.NewToolScopeMiddleware` (this example) | `ext/auth.OAuthTokenSource.TokenForScopes` (already accumulates via `core.UnionScopes`) |
+| Conformance scenario | `scope-challenge` (mcpconformance PR 19) | `scope-handling` (already in mcpconformance main, covers `sep-2350-scope-union-on-reauth`) |
+
+The mcpkit client side is exercised separately by pointing the existing client-side `scope-handling` scenario at `cmd/testclient`; see the parent PR for details.
+
+## Why experimental
+
+- PR 1624 has not merged upstream. API surface in `ext/auth` is stable, but the wire shape we're matching could move if review surfaces changes.
+- The mcpkit-side conformance scenario lives in our fork (`panyam/mcpconformance` PR 19) until it lifts upstream after PR 1624 lands.
+- The Keycloak fixture is currently the only authorization server validated end-to-end. Entra / Okta / WorkOS coverage is a separate follow-up.
+
+When PR 1624 lands and the scenario lifts upstream, this example loses the experimental marker.

--- a/examples/auth/step-up-keycloak/main.go
+++ b/examples/auth/step-up-keycloak/main.go
@@ -37,19 +37,18 @@
 package main
 
 import (
-	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
-	"time"
 
 	"github.com/panyam/mcpkit/core"
 	mcpcommon "github.com/panyam/mcpkit/examples/common"
 	"github.com/panyam/mcpkit/ext/auth"
 	"github.com/panyam/mcpkit/server"
 	"github.com/panyam/mcpkit/server/stateless"
+	oneauthclient "github.com/panyam/oneauth/client"
 )
 
 const (
@@ -59,30 +58,6 @@ const (
 	scopeToolsCall     = "tools-call"
 	scopeAdminWrite    = "admin-write"
 )
-
-// discoverOIDC fetches Keycloak's openid-configuration document and returns
-// the issuer + JWKS URI. Inline rather than depending on testutil's helper
-// (test-only); ~10 lines and clearer about what we're hitting.
-func discoverOIDC(realmURL string) (issuer, jwksURI string, err error) {
-	url := realmURL + "/.well-known/openid-configuration"
-	c := &http.Client{Timeout: 5 * time.Second}
-	resp, err := c.Get(url)
-	if err != nil {
-		return "", "", fmt.Errorf("GET %s: %w", url, err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return "", "", fmt.Errorf("GET %s: status %d", url, resp.StatusCode)
-	}
-	var meta struct {
-		Issuer  string `json:"issuer"`
-		JWKSURI string `json:"jwks_uri"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&meta); err != nil {
-		return "", "", fmt.Errorf("decode %s: %w", url, err)
-	}
-	return meta.Issuer, meta.JWKSURI, nil
-}
 
 func envOr(k, def string) string {
 	if v := os.Getenv(k); v != "" {
@@ -98,10 +73,18 @@ func main() {
 	flag.Parse()
 
 	realmURL := fmt.Sprintf("%s/realms/%s", *kcURL, *realm)
-	issuer, jwksURI, err := discoverOIDC(realmURL)
+
+	// AS discovery via oneauth — same RFC 8414 + OIDC fallback path mcpkit's
+	// ext/auth.DiscoverMCPAuth uses internally. Avoids hand-rolling a
+	// well-known fetch + JSON decode, and keeps the example aligned with
+	// "oneauth is the strategic destination for MCP auth" — for any
+	// production deployment, this is the same helper you'd reach for.
+	asMeta, err := oneauthclient.DiscoverAS(realmURL)
 	if err != nil {
-		log.Fatalf("OIDC discovery failed against %s: %v", realmURL, err)
+		log.Fatalf("AS discovery failed against %s: %v", realmURL, err)
 	}
+	issuer := asMeta.Issuer
+	jwksURI := asMeta.JWKSURI
 
 	listenURL := fmt.Sprintf("http://localhost%s", *addr)
 	allScopes := []string{scopeToolsRead, scopeToolsCall, scopeAdminWrite}

--- a/examples/auth/step-up-keycloak/main.go
+++ b/examples/auth/step-up-keycloak/main.go
@@ -1,0 +1,163 @@
+// Example: SEP-2350 step-up auth against Keycloak.
+//
+// Experimental. SEP-2350 (client-side scope accumulation in step-up
+// authorization) is merged into the spec, but the server-side reference
+// implementation in modelcontextprotocol/typescript-sdk PR 1624 is still under
+// review. This example exists to demonstrate that mcpkit's
+// ext/auth.NewToolScopeMiddleware emits the same wire shape PR 1624's
+// reference impl emits, and to drive the conformance scenario in
+// panyam/mcpconformance PR 19 (the fork) against a real Keycloak realm.
+// Both will move once upstream lands; expect API or naming churn here.
+//
+// What this does:
+//
+//   - Wires ext/auth.JWTValidator against the Keycloak realm at KEYCLOAK_URL
+//     (default http://localhost:8180/realms/mcpkit-test).
+//   - Registers one scope-gated tool, admin_call, requiring the admin-write
+//     scope (matching the scope-challenge scenario's default context).
+//   - Installs auth.NewToolScopeMiddleware so a tools/call with an
+//     under-scoped token returns HTTP 403 with a WWW-Authenticate Bearer
+//     insufficient_scope challenge per RFC 6750 Section 3.1, instead of
+//     reaching the handler.
+//   - Publishes the Protected Resource Metadata document at
+//     /.well-known/oauth-protected-resource/mcp pointing at the Keycloak
+//     realm as the authorization server.
+//
+// Operator runbook lives in README.md alongside this file. The canonical
+// end-to-end runbook (including how to drive the conformance scenario
+// against this server) is panyam/mcpconformance examples/auth-fixtures/
+// keycloak/README.md on the feat/sep-2350-server-scope-challenge branch.
+//
+// Run:
+//
+//	go run ./examples/auth/step-up-keycloak \
+//	    -addr :3020 \
+//	    -keycloak-url http://localhost:8180 \
+//	    -realm mcpkit-test
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/panyam/mcpkit/core"
+	mcpcommon "github.com/panyam/mcpkit/examples/common"
+	"github.com/panyam/mcpkit/ext/auth"
+	"github.com/panyam/mcpkit/server"
+	"github.com/panyam/mcpkit/server/stateless"
+)
+
+const (
+	defaultKeycloakURL = "http://localhost:8180"
+	defaultRealm       = "mcpkit-test"
+	scopeToolsRead     = "tools-read"
+	scopeToolsCall     = "tools-call"
+	scopeAdminWrite    = "admin-write"
+)
+
+// discoverOIDC fetches Keycloak's openid-configuration document and returns
+// the issuer + JWKS URI. Inline rather than depending on testutil's helper
+// (test-only); ~10 lines and clearer about what we're hitting.
+func discoverOIDC(realmURL string) (issuer, jwksURI string, err error) {
+	url := realmURL + "/.well-known/openid-configuration"
+	c := &http.Client{Timeout: 5 * time.Second}
+	resp, err := c.Get(url)
+	if err != nil {
+		return "", "", fmt.Errorf("GET %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf("GET %s: status %d", url, resp.StatusCode)
+	}
+	var meta struct {
+		Issuer  string `json:"issuer"`
+		JWKSURI string `json:"jwks_uri"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&meta); err != nil {
+		return "", "", fmt.Errorf("decode %s: %w", url, err)
+	}
+	return meta.Issuer, meta.JWKSURI, nil
+}
+
+func envOr(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}
+
+func main() {
+	addr := flag.String("addr", ":3020", "listen address")
+	kcURL := flag.String("keycloak-url", envOr("KEYCLOAK_URL", defaultKeycloakURL), "Keycloak base URL")
+	realm := flag.String("realm", envOr("KC_REALM", defaultRealm), "Keycloak realm name")
+	flag.Parse()
+
+	realmURL := fmt.Sprintf("%s/realms/%s", *kcURL, *realm)
+	issuer, jwksURI, err := discoverOIDC(realmURL)
+	if err != nil {
+		log.Fatalf("OIDC discovery failed against %s: %v", realmURL, err)
+	}
+
+	listenURL := fmt.Sprintf("http://localhost%s", *addr)
+	allScopes := []string{scopeToolsRead, scopeToolsCall, scopeAdminWrite}
+
+	prmURL := listenURL + "/.well-known/oauth-protected-resource/mcp"
+	validator := auth.NewJWTValidator(auth.JWTConfig{
+		JWKSURL:             jwksURI,
+		Issuer:              issuer,
+		Audience:            "", // Keycloak doesn't set aud on client_credentials by default.
+		ResourceMetadataURL: prmURL,
+		AllScopes:           allScopes,
+	})
+	validator.Start()
+	defer validator.Stop()
+
+	log.Printf("step-up-keycloak: serving %s/mcp", listenURL)
+	log.Printf("  AS issuer:  %s", issuer)
+	log.Printf("  JWKS URI:   %s", jwksURI)
+	log.Printf("  scope-gated tool: admin_call requires '%s'", scopeAdminWrite)
+
+	cfg := mcpcommon.ServerConfig{
+		Name:    "step-up-keycloak",
+		Version: "0.1.0-experimental",
+		Addr:    *addr,
+		Options: []server.Option{
+			server.WithAuth(validator),
+		},
+		Register: func(srv *server.Server) {
+			srv.Register(core.TextTool[struct{}]("admin_call",
+				"Requires admin-write scope. Returns ok when scope is sufficient; otherwise the scope middleware returns HTTP 403 with WWW-Authenticate before this handler runs.",
+				func(_ core.ToolContext, _ struct{}) (string, error) {
+					return "admin_call: ok", nil
+				},
+				core.WithToolRequiredScopes(scopeAdminWrite),
+			))
+			srv.UseMiddleware(auth.NewToolScopeMiddleware(srv.Registry(),
+				auth.WithResourceMetadataURL(prmURL),
+			))
+		},
+		TransportOptions: []server.TransportOption{
+			// SEP-2575 stateless wire so the conformance scenario can hit
+			// tools/call directly without an initialize handshake or
+			// Mcp-Session-Id. Matches the wire mode PR 1624's reference
+			// impl uses when sessionIdGenerator is undefined.
+			server.WithStatelessMode(stateless.ModeStateless),
+			server.WithMux(func(mux *http.ServeMux) {
+				auth.MountAuth(mux, auth.AuthConfig{
+					ResourceURI:          listenURL,
+					AuthorizationServers: []string{issuer},
+					ScopesSupported:      allScopes,
+					MCPPath:              "/mcp",
+				})
+			}),
+		},
+	}
+	if err := mcpcommon.RunServer(cfg); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/ext/auth/introspection_validator.go
+++ b/ext/auth/introspection_validator.go
@@ -193,7 +193,7 @@ func (v *IntrospectionValidator) Validate(r *http.Request) error {
 		return &mcpcore.AuthError{
 			Code:            http.StatusForbidden,
 			Message:         "insufficient scope",
-			WWWAuthenticate: WWWAuth403(v.cfg.RequiredScopes...),
+			WWWAuthenticate: WWWAuth403(v.cfg.ResourceMetadataURL, v.cfg.RequiredScopes...),
 		}
 	}
 

--- a/ext/auth/jwt_validator.go
+++ b/ext/auth/jwt_validator.go
@@ -272,7 +272,7 @@ func (v *JWTValidator) Validate(r *http.Request) error {
 		return &mcpcore.AuthError{
 			Code:            http.StatusForbidden,
 			Message:         "insufficient scope",
-			WWWAuthenticate: WWWAuth403(v.RequiredScopes...),
+			WWWAuthenticate: WWWAuth403(v.ResourceMetadataURL, v.RequiredScopes...),
 		}
 	}
 

--- a/ext/auth/scope_middleware.go
+++ b/ext/auth/scope_middleware.go
@@ -22,6 +22,7 @@ type ToolScopeOption func(*toolScopeConfig)
 
 type toolScopeConfig struct {
 	includeGrantedScopes bool
+	resourceMetadataURL  string
 }
 
 // WithIncludeGrantedScopes opts the middleware into advertising the union of
@@ -47,6 +48,25 @@ type toolScopeConfig struct {
 // scopes and required scopes; tolerated alternates stay private to the server.
 func WithIncludeGrantedScopes(v bool) ToolScopeOption {
 	return func(c *toolScopeConfig) { c.includeGrantedScopes = v }
+}
+
+// WithResourceMetadataURL plumbs the server's RFC 9728 Protected Resource
+// Metadata URL into the 403 challenge the middleware emits. When set, the
+// WWW-Authenticate header carries `resource_metadata="<URL>"` alongside
+// `error="insufficient_scope"` and `scope="..."`, so clients hitting a
+// first-call 403 on the stateless wire (no preceding 401) can discover the
+// authorization server without falling back to the well-known path.
+//
+// Empty (default) omits the segment — the 401 path's PRM advertisement is
+// the only discovery hint. This is correct when every client passes through
+// a 401 before any 403, but breaks down on SEP-2575 stateless wire where the
+// first tools/call can be a 403 with no prior context.
+//
+// Typically the same URL passed to JWTValidator.ResourceMetadataURL — the two
+// configs live on separate components by design (JWTValidator emits 401s,
+// NewToolScopeMiddleware emits 403s) but referencing the same PRM document.
+func WithResourceMetadataURL(url string) ToolScopeOption {
+	return func(c *toolScopeConfig) { c.resourceMetadataURL = url }
 }
 
 // NewToolScopeMiddleware returns a server middleware that enforces per-tool
@@ -123,7 +143,7 @@ func NewToolScopeMiddleware(lookup ToolDefLookup, opts ...ToolScopeOption) serve
 			return nil, &core.AuthError{
 				Code:            http.StatusForbidden,
 				Message:         "insufficient scope",
-				WWWAuthenticate: WWWAuth403(challengeScopes...),
+				WWWAuthenticate: WWWAuth403(cfg.resourceMetadataURL, challengeScopes...),
 			}
 		}
 

--- a/ext/auth/scopes.go
+++ b/ext/auth/scopes.go
@@ -26,10 +26,14 @@ func RequireScope(ctx context.Context, scope string) error {
 	if core.HasScope(ctx, scope) {
 		return nil
 	}
+	// RequireScope is the handler-level helper; the server's PRM URL is not
+	// reachable from a handler ctx today, so the emitted challenge omits the
+	// resource_metadata link. Use NewToolScopeMiddleware with WithResourceMetadataURL
+	// for middleware-level enforcement that includes the link in the 403.
 	return &core.AuthError{
 		Code:            http.StatusForbidden,
 		Message:         "insufficient scope: " + scope,
-		WWWAuthenticate: WWWAuth403(scope),
+		WWWAuthenticate: WWWAuth403("", scope),
 	}
 }
 

--- a/ext/auth/www_authenticate.go
+++ b/ext/auth/www_authenticate.go
@@ -22,14 +22,29 @@ func WWWAuth401(resourceMetadataURL string, scopes ...string) string {
 }
 
 // WWWAuth403 builds a WWW-Authenticate header value for 403 Forbidden responses
-// with insufficient scope. Per MCP spec (2025-11-25), includes error code and
-// required scopes.
+// with insufficient scope. Per MCP spec (2025-11-25) and RFC 6750 §3.1, includes
+// the `error="insufficient_scope"` token plus the required scopes, and optionally
+// the `resource_metadata="<URL>"` link to the server's RFC 9728 PRM document so
+// callers don't have to fall back to the well-known path to discover it.
+//
+// resourceMetadataURL empty omits the `resource_metadata` segment entirely. This
+// is symmetric with WWWAuth401, which always emits the link, and matches the
+// shape modelcontextprotocol/typescript-sdk PR 1624 (the SEP-2350 server-side
+// reference impl) emits on its own scope-challenge 403s — see RFC 9728 §5.1
+// for the discovery semantics this enables.
+//
+// Stateless-wire 403s are the load-bearing case: there is no preceding 401 to
+// learn the PRM link from, so the very first request that lands a 403 needs
+// the link inline to discover the AS.
 //
 // Example output:
 //
-//	Bearer error="insufficient_scope", scope="admin:write files:read"
-func WWWAuth403(scopes ...string) string {
+//	Bearer error="insufficient_scope", resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource/mcp", scope="admin:write files:read"
+func WWWAuth403(resourceMetadataURL string, scopes ...string) string {
 	parts := []string{`error="insufficient_scope"`}
+	if resourceMetadataURL != "" {
+		parts = append(parts, fmt.Sprintf(`resource_metadata="%s"`, resourceMetadataURL))
+	}
 	if len(scopes) > 0 {
 		parts = append(parts, fmt.Sprintf(`scope="%s"`, strings.Join(scopes, " ")))
 	}

--- a/ext/auth/www_authenticate_test.go
+++ b/ext/auth/www_authenticate_test.go
@@ -49,17 +49,25 @@ func TestWWWAuth401(t *testing.T) {
 }
 
 func TestWWWAuth403(t *testing.T) {
-	got := WWWAuth403("admin:write", "files:read")
-	want := `Bearer error="insufficient_scope", scope="admin:write files:read"`
+	// With PRM URL + scopes
+	got := WWWAuth403("https://mcp.example.com/.well-known/oauth-protected-resource/mcp", "admin:write", "files:read")
+	want := `Bearer error="insufficient_scope", resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource/mcp", scope="admin:write files:read"`
 	if got != want {
-		t.Errorf("WWWAuth403 = %q, want %q", got, want)
+		t.Errorf("WWWAuth403 with URL = %q, want %q", got, want)
 	}
 
-	// Without scopes
-	got2 := WWWAuth403()
-	want2 := `Bearer error="insufficient_scope"`
-	if got2 != want2 {
-		t.Errorf("WWWAuth403() = %q, want %q", got2, want2)
+	// Without PRM URL, with scopes
+	gotNoURL := WWWAuth403("", "admin:write", "files:read")
+	wantNoURL := `Bearer error="insufficient_scope", scope="admin:write files:read"`
+	if gotNoURL != wantNoURL {
+		t.Errorf("WWWAuth403 empty URL = %q, want %q", gotNoURL, wantNoURL)
+	}
+
+	// Bare error, no URL, no scopes
+	gotBare := WWWAuth403("")
+	wantBare := `Bearer error="insufficient_scope"`
+	if gotBare != wantBare {
+		t.Errorf("WWWAuth403 bare = %q, want %q", gotBare, wantBare)
 	}
 }
 

--- a/tests/keycloak/step_up_test.go
+++ b/tests/keycloak/step_up_test.go
@@ -1,0 +1,243 @@
+package keycloak_test
+
+// SEP-2350 step-up scope-challenge coverage. The existing
+// TestKeycloak_MCPServer_ScopeDenied test exercises RequireScope (the
+// handler-level helper that returns an error string), not the transport-
+// level 403 + WWW-Authenticate flow SEP-2350 actually mandates. These
+// tests cover the middleware-emitted challenge so the conformance suite's
+// expectations and mcpkit's behavior stay in lockstep.
+//
+// Both wire modes (default Dual + SEP-2575 stateless) are exercised: the
+// fix from panyam/mcpkit issue 815 ensures the typed *core.AuthError
+// surfaces on the stateless wire too; this test locks that in.
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	core "github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/ext/auth"
+	server "github.com/panyam/mcpkit/server"
+	"github.com/panyam/mcpkit/server/stateless"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	stepUpToolName = "admin_call"
+)
+
+// newStepUpEnv builds an mcpkit MCP server wired with
+// auth.NewToolScopeMiddleware against the Keycloak realm. Distinct from
+// NewMCPTestEnv: this one declares the scope requirement via
+// core.ToolDef.RequiredScopes + the middleware so a scope failure produces
+// HTTP 403 + WWW-Authenticate at the transport, instead of a handler-
+// returned error string. extraOpts append to the base server.Options so
+// callers can flip wire mode via server.WithStatelessMode.
+func newStepUpEnv(t *testing.T, extraTransport ...server.TransportOption) (*httptest.Server, string) {
+	t.Helper()
+
+	cfg := discoverOIDC(t)
+
+	var handler http.Handler
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if handler == nil {
+			http.Error(w, "server not ready", http.StatusServiceUnavailable)
+			return
+		}
+		handler.ServeHTTP(w, r)
+	}))
+	t.Cleanup(ts.Close)
+
+	prmURL := ts.URL + "/.well-known/oauth-protected-resource/mcp"
+	allScopes := []string{scopeToolsRead, scopeToolsCall, scopeAdminWrite}
+
+	validator := auth.NewJWTValidator(auth.JWTConfig{
+		JWKSURL:             cfg.JWKSURI,
+		Issuer:              cfg.Issuer,
+		Audience:            "",
+		ResourceMetadataURL: prmURL,
+		AllScopes:           allScopes,
+	})
+	validator.Start()
+	t.Cleanup(validator.Stop)
+
+	srv := server.NewServer(
+		core.ServerInfo{Name: "mcp-keycloak-step-up", Version: "0.1.0"},
+		server.WithAuth(validator),
+	)
+
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:           stepUpToolName,
+			Description:    "Requires admin-write scope; middleware emits 403 before handler runs.",
+			InputSchema:    json.RawMessage(`{"type":"object"}`),
+			RequiredScopes: []string{scopeAdminWrite},
+		},
+		func(_ core.ToolContext, _ core.ToolRequest) (core.ToolResponse, error) {
+			return core.TextResult(stepUpToolName + ": ok"), nil
+		},
+	)
+	srv.UseMiddleware(auth.NewToolScopeMiddleware(srv.Registry(),
+		auth.WithResourceMetadataURL(prmURL),
+	))
+
+	transportOpts := append([]server.TransportOption{server.WithStreamableHTTP(true)}, extraTransport...)
+	mux := http.NewServeMux()
+	mux.Handle("/mcp", srv.Handler(transportOpts...))
+	auth.MountAuth(mux, auth.AuthConfig{
+		ResourceURI:          ts.URL,
+		AuthorizationServers: []string{cfg.Issuer},
+		ScopesSupported:      allScopes,
+		MCPPath:              "/mcp",
+	})
+	handler = mux
+
+	return ts, cfg.TokenEndpoint
+}
+
+// toolsCallStateless sends a raw stateless tools/call POST and returns the
+// HTTP status, WWW-Authenticate header value, and response body. Mirrors
+// the wire shape the conformance suite's scope-challenge scenario uses.
+func toolsCallStateless(t *testing.T, serverURL, bearer, toolName string) (int, string, string) {
+	t.Helper()
+	body := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{` +
+		`"name":"` + toolName + `","arguments":{},` +
+		`"_meta":{` +
+		`"io.modelcontextprotocol/protocolVersion":"2026-07-28",` +
+		`"io.modelcontextprotocol/clientInfo":{"name":"step-up-test","version":"0.0.0"},` +
+		`"io.modelcontextprotocol/clientCapabilities":{}` +
+		`}}}`
+
+	req, err := http.NewRequest(http.MethodPost, serverURL, bytes.NewBufferString(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("MCP-Protocol-Version", "2026-07-28")
+	req.Header.Set("Authorization", "Bearer "+bearer)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, resp.Header.Get("WWW-Authenticate"), string(raw)
+}
+
+// TestKeycloak_StepUp_StatelessWire exercises the SEP-2350 wire shape on
+// the SEP-2575 stateless wire end-to-end against a real Keycloak realm.
+// Closes the gap mcpkit issue 815 documented and that the conformance
+// scenario in panyam/mcpconformance PR 19 originally surfaced.
+func TestKeycloak_StepUp_StatelessWire(t *testing.T) {
+	skipIfKeycloakNotRunning(t)
+
+	ts, tokenEndpoint := newStepUpEnv(t, server.WithStatelessMode(stateless.ModeStateless))
+	mcpURL := ts.URL + "/mcp"
+
+	insufficient := getClientCredentialsToken(t, tokenEndpoint, scopeToolsRead)
+	sufficient := getClientCredentialsToken(t, tokenEndpoint, scopeToolsRead, scopeToolsCall, scopeAdminWrite)
+
+	status, wwwAuth, _ := toolsCallStateless(t, mcpURL, insufficient.AccessToken, stepUpToolName)
+	require.Equal(t, http.StatusForbidden, status, "under-scoped token must produce 403")
+	require.NotEmpty(t, wwwAuth, "403 must carry a WWW-Authenticate header")
+	require.True(t, strings.HasPrefix(wwwAuth, "Bearer "), "challenge must use Bearer scheme; got %q", wwwAuth)
+	require.Contains(t, wwwAuth, `error="insufficient_scope"`, "challenge must advertise insufficient_scope")
+	require.Contains(t, wwwAuth, `scope="`+scopeAdminWrite+`"`, "challenge must advertise the required scope only (least-privilege); got %q", wwwAuth)
+	require.NotContains(t, wwwAuth, scopeToolsRead, "challenge must NOT leak the caller's granted scopes")
+	require.Contains(t, wwwAuth, `resource_metadata="`, "challenge must include the RFC 9728 PRM link")
+
+	statusOK, _, body := toolsCallStateless(t, mcpURL, sufficient.AccessToken, stepUpToolName)
+	require.Equal(t, http.StatusOK, statusOK, "properly-scoped token must succeed; body=%s", body)
+	require.Contains(t, body, stepUpToolName+": ok", "handler should have run; body=%s", body)
+}
+
+// TestKeycloak_StepUp_LegacyWire exercises the same SEP-2350 wire shape on
+// the default Dual / legacy session wire. The legacy path is the one that
+// has shipped longest in mcpkit; this lock-in test ensures the PRM-link
+// fix and middleware emission continue to work alongside the stateless
+// path. Performs initialize handshake first to obtain a session id, then
+// fires tools/call with the under-scoped token.
+func TestKeycloak_StepUp_LegacyWire(t *testing.T) {
+	skipIfKeycloakNotRunning(t)
+
+	ts, tokenEndpoint := newStepUpEnv(t)
+	mcpURL := ts.URL + "/mcp"
+
+	sufficient := getClientCredentialsToken(t, tokenEndpoint, scopeToolsRead, scopeToolsCall, scopeAdminWrite)
+	sessionID := legacyInitialize(t, mcpURL, sufficient.AccessToken)
+	require.NotEmpty(t, sessionID, "initialize must return an Mcp-Session-Id")
+
+	insufficient := getClientCredentialsToken(t, tokenEndpoint, scopeToolsRead)
+	status, wwwAuth, _ := legacyToolsCall(t, mcpURL, sessionID, insufficient.AccessToken, stepUpToolName)
+	require.Equal(t, http.StatusForbidden, status, "under-scoped token must produce 403 on legacy wire")
+	require.Contains(t, wwwAuth, `error="insufficient_scope"`)
+	require.Contains(t, wwwAuth, `scope="`+scopeAdminWrite+`"`)
+	require.Contains(t, wwwAuth, `resource_metadata="`)
+
+	statusOK, _, body := legacyToolsCall(t, mcpURL, sessionID, sufficient.AccessToken, stepUpToolName)
+	require.Equal(t, http.StatusOK, statusOK, "properly-scoped token must succeed on legacy wire; body=%s", body)
+	require.Contains(t, body, stepUpToolName+": ok")
+}
+
+// legacyInitialize runs the legacy initialize handshake plus the required
+// notifications/initialized follow-up and returns the server-assigned
+// Mcp-Session-Id. The legacy wire requires the session to be fully
+// initialized before any tools/call dispatch; sending just `initialize`
+// without the follow-up notification leaves the session in a half-open
+// state and tools/call returns -32600 "server not initialized".
+func legacyInitialize(t *testing.T, serverURL, bearer string) string {
+	t.Helper()
+	initBody := `{"jsonrpc":"2.0","id":0,"method":"initialize","params":{` +
+		`"protocolVersion":"2025-11-25",` +
+		`"capabilities":{},` +
+		`"clientInfo":{"name":"step-up-test","version":"0.0.0"}` +
+		`}}`
+	req, err := http.NewRequest(http.MethodPost, serverURL, bytes.NewBufferString(initBody))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode, "initialize must succeed")
+	sessionID := resp.Header.Get("Mcp-Session-Id")
+	require.NotEmpty(t, sessionID, "initialize must return an Mcp-Session-Id")
+
+	notifBody := `{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}`
+	notifReq, err := http.NewRequest(http.MethodPost, serverURL, bytes.NewBufferString(notifBody))
+	require.NoError(t, err)
+	notifReq.Header.Set("Content-Type", "application/json")
+	notifReq.Header.Set("Accept", "application/json, text/event-stream")
+	notifReq.Header.Set("Authorization", "Bearer "+bearer)
+	notifReq.Header.Set("Mcp-Session-Id", sessionID)
+	notifResp, err := http.DefaultClient.Do(notifReq)
+	require.NoError(t, err)
+	notifResp.Body.Close()
+	require.Less(t, notifResp.StatusCode, 300, "notifications/initialized must succeed; got %d", notifResp.StatusCode)
+
+	return sessionID
+}
+
+// legacyToolsCall sends a tools/call POST on the legacy wire with the
+// session id from initialize. Returns status + WWW-Authenticate + body
+// like the stateless variant for assertion symmetry.
+func legacyToolsCall(t *testing.T, serverURL, sessionID, bearer, toolName string) (int, string, string) {
+	t.Helper()
+	body := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{` +
+		`"name":"` + toolName + `","arguments":{}}}`
+	req, err := http.NewRequest(http.MethodPost, serverURL, bytes.NewBufferString(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	req.Header.Set("Mcp-Session-Id", sessionID)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, resp.Header.Get("WWW-Authenticate"), string(raw)
+}


### PR DESCRIPTION
## What changes

Experimental Go SDK validation track for SEP-2350 server-side scope challenges. Lands three things in lock-step:

1. **`examples/auth/step-up-keycloak/`** — Go MCP server wired against the Keycloak realm from `panyam/mcpconformance` PR 19, registering one scope-gated tool (`admin_call` requires `admin-write`). Demonstrates that mcpkit's `ext/auth.NewToolScopeMiddleware` emits the same SEP-2350 / RFC 6750 §3.1 wire shape modelcontextprotocol/typescript-sdk PR 1624's reference impl emits. Runs in SEP-2575 stateless wire mode by default so the conformance scenario can drive `tools/call` without a session handshake.

2. **`tests/keycloak/step_up_test.go`** — two integration tests (legacy/Dual wire + SEP-2575 stateless wire) driving the middleware-emitted 403 + WWW-Authenticate flow against a real Keycloak realm. Closes the G7 gap in the auth-wg-tool-scopes proposal folder where `tests/keycloak/` had zero transport-level scope-challenge coverage.

3. **Two narrow `ext/auth` + `client` fixes** the example surfaced:
   - `WWWAuth403` now includes `resource_metadata="<URL>"` symmetric with `WWWAuth401`, plumbed through a new `auth.WithResourceMetadataURL` option on `NewToolScopeMiddleware`. RFC 9728 advisory; load-bearing on the stateless wire where the first 403 may have no preceding 401 to learn the PRM link from.
   - `OnUnauthorized` on the client transport now parses `WWW-Authenticate` `scope=` and calls `TokenForScopes` (symmetric with the existing `OnForbidden` path), making the 401 retry path RFC 6750 §3.1-compliant.

The example + integration test verify end-to-end against the conformance scenario in panyam/mcpconformance PR 19: **8/8 SUCCESS, 0 failed, 0 warnings** with 2 conditional `AcceptedScopes` checks SKIPPED (the example doesn't declare `AcceptedScopes` to keep the demo focused).

## Reviewer's guide

Read in this order:

1. [examples/auth/step-up-keycloak/main.go](https://github.com/panyam/mcpkit/pull/819/files#diff-f5733274858681e28244e8a9477b223e7ce2eb2fb5e608638a9953d8da5ab850) — start here. The Go SUT: OIDC discovery + JWTValidator + scope-gated tool + middleware wiring. Inline `discoverOIDC` so the example is dep-free of testutil.
2. [examples/auth/step-up-keycloak/README.md](https://github.com/panyam/mcpkit/pull/819/files#diff-4ef44eed0fef359cbb0905107713ace428c7e7a1c7540dac6580e2ca82869104) — operator runbook. Modest framing ("experimental Go SDK") per the user-feedback rule — points back at `panyam/mcpconformance` as the canonical conformance source.
3. [examples/auth/step-up-keycloak/Makefile](https://github.com/panyam/mcpkit/pull/819/files#diff-a4934c31b7f1cb04cf590383c0732ac377c5d023c8cb10c52f998d4f5312d93b) — `run`, `build`, `smoke` (curl test against the 403 path).
4. [tests/keycloak/step_up_test.go](https://github.com/panyam/mcpkit/pull/819/files#diff-3966e1dec84f8106d97fa60ee4c771cbeba0e9b86967276d0ee2cb5a408a1743) — two test functions, raw-HTTP probing for wire-shape inspection. `legacyInitialize` does the `initialize` + `notifications/initialized` handshake the legacy session wire requires; stateless variant skips it.
5. [ext/auth/www_authenticate.go](https://github.com/panyam/mcpkit/pull/819/files#diff-7d67a1cac3b8952516b0ff78e4d7224babb578fa5c282ffdedb0df3a2220f6c8) — `WWWAuth403` signature now takes `resourceMetadataURL` first (symmetric with `WWWAuth401`). Empty string omits the segment for cases where the URL isn't reachable (e.g. handler-level `RequireScope`).
6. [ext/auth/scope_middleware.go](https://github.com/panyam/mcpkit/pull/819/files#diff-e9f2a0b5b4639ac0f368a630b80e9b61f019f319eaaf03fed829d2f9030811a3) — new `WithResourceMetadataURL` option follows the existing `WithIncludeGrantedScopes` shape.
7. `ext/auth/{jwt_validator,introspection_validator,scopes}.go` — call-site updates for the new `WWWAuth403` signature.
8. [ext/auth/www_authenticate_test.go](https://github.com/panyam/mcpkit/pull/819/files#diff-1b36a863191469c332b49c55ec99577d9c0316e49d7dadb952c71c03edf1b716) — tests cover URL-present, URL-empty, and bare cases.
9. [client/client.go](https://github.com/panyam/mcpkit/pull/819/files#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09) — `OnUnauthorized` parses `WWW-Authenticate` scope= and routes through `TokenForScopes` when the token source supports it, mirroring the `OnForbidden` path immediately below.

Skim or skip: nothing of note.

## Decision log

- **WWWAuth403 signature change (breaking)** rather than adding a `WWWAuth403WithPRM` sibling. `ext/auth` is a v0.x sub-module and only had three production callers, all in-tree; symmetry with `WWWAuth401` was worth the churn.
- **`WithResourceMetadataURL` option on the middleware** rather than reading the URL from the validator on ctx. The validator's URL isn't staged on ctx today, and threading it through a new `core.WithResourceMetadataURL`/`core.ResourceMetadataURLFromContext` ctx pair was out of scope. The explicit option (one extra setup line) is honest about where the URL comes from.
- **`OnUnauthorized` fix is contained to the 401 retry path.** The initial token acquisition still picks PRM `scopes_supported` when the discovery probe doesn't see a 401. That's a real spec departure but requires an eager → lazy `OAuthTokenSource` refactor — tracked separately in panyam/mcpkit issue 818 to keep this PR focused.
- **Stateless mode for the example SUT** rather than default Dual mode. The conformance scenario uses raw HTTP without a session handshake, and stateless wire is the SEP-2575 mode every tier-1 SDK is moving toward. Real-world deployments can override with `server.WithStatelessMode(stateless.ModeDual)` if they need legacy session compatibility.
- **`tests/keycloak/step_up_test.go` covers both wires** because the legacy/Dual path is where mcpkit has the longest tail of production usage; ensuring the PRM-link fix + middleware emission work on the legacy session wire as well as the new stateless one prevents future regressions.

## Risk / blast radius

- **Breaking change in `ext/auth`**: `WWWAuth403`'s signature gained a leading `resourceMetadataURL string` parameter. Any out-of-tree caller has to add `""` (or the URL) as the first argument. All three in-tree callers updated in this PR.
- **Behavior change on `client/client.go`'s 401 retry**: token sources implementing `core.ScopeAwareTokenSource` will now see `TokenForScopes(scope)` calls on 401 when the challenge advertises a scope. Sources that only implement `core.TokenSource` are unaffected — the fallback `ts.Token()` path is preserved.
- **Tests covering this**: `ext/auth/www_authenticate_test.go` (URL-present, URL-empty, bare). `tests/keycloak/step_up_test.go` (both wires, end-to-end). Full `ext/auth` test suite and `make testkcl` pass.
- **Be paranoid about**: the stateless wire path interaction with the recent fix from panyam/mcpkit issue 815. Both this PR's `OnUnauthorized` fix and 815's stateless `AuthError` surface assume `*core.AuthError` flows correctly through the dispatch path — the integration test exercises both ends.

## Before / after

Conformance scenario `scope-challenge` from panyam/mcpconformance PR 19 run against this SUT in stateless mode (operator drove `MCP_CONFORMANCE_CONTEXT` via `make tokens-context`):

```
[scope-challenge-403-on-insufficient                 ] SUCCESS  tools/call with an under-scoped token returns HTTP 403
[scope-challenge-www-authenticate-present            ] SUCCESS  403 response includes a WWW-Authenticate header
[scope-challenge-www-authenticate-bearer             ] SUCCESS  challenge uses the Bearer auth scheme per RFC 6750
[scope-challenge-www-authenticate-error              ] SUCCESS  challenge carries error="insufficient_scope" per RFC 6750 §3.1
[scope-challenge-scope-advertised                    ] SUCCESS  challenge advertises a scope parameter naming the required scopes
[scope-challenge-scope-required-only                 ] SUCCESS  advertised scope is the per-operation required set (least-privilege)
[scope-challenge-resource-metadata-link              ] SUCCESS  challenge advertises a resource_metadata URL per RFC 9728
[scope-challenge-passes-with-sufficient-token        ] SUCCESS  tools/call with a properly-scoped token returns 2xx
[scope-challenge-accepted-or-hierarchy               ] SKIPPED  context.features.acceptedScopes is false
[scope-challenge-www-authenticate-accepted-not-leaked] SKIPPED  context.features.acceptedScopes is false

Passed: 8/8, 0 failed, 0 warnings
```

`make testkcl` (includes the new `TestKeycloak_StepUp_LegacyWire` + `TestKeycloak_StepUp_StatelessWire`): all tests pass.

## Out of scope (deliberately deferred)

- `OAuthTokenSource` eager → lazy refactor — tracked in panyam/mcpkit issue 818. The `OnUnauthorized` fix in this PR covers the 401 retry path; the initial-acquisition path needs a separate, contained PR.
- `RequireScope` handler helper plumbing the PRM URL via ctx — same eager → lazy refactor opens that up too.
- modelcontextprotocol/typescript-sdk PR 2157 (stacked scope challenges for resources / prompts / completions) — phase 2 once 1624 lands.
- asciinema recording of the end-to-end runbook — polish for the public deliverable.

## Refs

Plain-text references (no live `#N` to avoid noisy cross-repo backlinks):

- modelcontextprotocol/specification PR 2350 — the SEP this work implements (merged).
- modelcontextprotocol/typescript-sdk PR 1624 — TS SDK server-side reference impl (open).
- modelcontextprotocol/typescript-sdk PR 1657 — TS SDK client-side scope-accumulation fix (open).
- panyam/mcpconformance PR 19 — companion: the brand-neutral `scope-challenge` conformance scenario.
- panyam/mcpkit issue 815 (closed) — sibling: stateless wire AuthError preservation (landed via PR 816).
- panyam/mcpkit issue 818 — follow-up: eager → lazy `OAuthTokenSource`.

