### PR TITLE
fix(ext/auth): lazy OAuthTokenSource — challenge scope over PRM scopes_supported (issue 818)

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -2557,6 +2558,11 @@ type HTTPStatusError = ssehttp.HTTPStatusError
 // On 401: calls ts.Token() to refresh, retries once.
 // On 403: parses WWW-Authenticate for required scopes, calls
 // core.ScopeAwareTokenSource.TokenForScopes if available, retries once.
+//
+// Lazy token sources (those returning core.ErrNoTokenYet from Token) are
+// supported: the first request is sent WITHOUT an Authorization header so
+// the server's 401 can select the scope, and the OnUnauthorized path below
+// arms the source via TokenForScopes for the retry (RFC 6750 §3.1).
 func DoWithAuthRetry(
 	ts core.TokenSource,
 	buildReq func() (*http.Request, error),
@@ -2569,6 +2575,12 @@ func DoWithAuthRetry(
 	cfg := &ssehttp.AuthRetryConfig{
 		SetAuth: func(req *http.Request) error {
 			token, err := ts.Token()
+			// A lazy source defers acquisition until a challenge selects the
+			// scope: send this request unauthenticated and let the server's
+			// 401 drive OnUnauthorized. Any other error is fatal.
+			if errors.Is(err, core.ErrNoTokenYet) {
+				return nil
+			}
 			if err != nil {
 				return err
 			}
@@ -2598,12 +2610,16 @@ func DoWithAuthRetry(
 			// relationship between them), so a least-privilege client uses
 			// the per-operation hint when present.
 			//
-			// Falls back to plain Token() when the source isn't scope-aware
-			// or the 401 didn't carry a scope=, preserving the previous
-			// behavior for non-SEP-2350 paths.
+			// Route EVERY 401 on a scope-aware source through TokenForScopes,
+			// even when the challenge carries no scope= (scopes is empty).
+			// The empty call is a no-op on the scope set but arms a lazy
+			// source (issue 818) so the retry actually acquires — using the
+			// per-operation scope when present, or the source's PRM
+			// scopes_supported fallback when absent. Non-scope-aware sources
+			// (static tokens, simple bearers) fall through to Token().
 			wwa := resp.Header.Get("WWW-Authenticate")
 			_, scopes, _ := ssehttp.ParseWWWAuthenticate(wwa)
-			if sats, ok := ts.(core.ScopeAwareTokenSource); ok && len(scopes) > 0 {
+			if sats, ok := ts.(core.ScopeAwareTokenSource); ok {
 				_, err := sats.TokenForScopes(scopes)
 				return err
 			}

--- a/client/client_auth_retry_test.go
+++ b/client/client_auth_retry_test.go
@@ -9,10 +9,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 
 	client "github.com/panyam/mcpkit/client"
+	core "github.com/panyam/mcpkit/core"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -224,6 +226,104 @@ func TestClient_RetryLimit_Double401(t *testing.T) {
 type localStaticToken struct{ token string }
 
 func (s *localStaticToken) Token() (string, error) { return s.token, nil }
+
+// lazyScopeAwareTokenSource models a lazy OAuth source (issue 818): Token
+// defers with core.ErrNoTokenYet until a server challenge calls TokenForScopes
+// to arm it. It records the scopes passed to each TokenForScopes call.
+type lazyScopeAwareTokenSource struct {
+	mu           sync.Mutex
+	armed        bool
+	scopesCalled [][]string
+}
+
+func (m *lazyScopeAwareTokenSource) Token() (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if !m.armed {
+		return "", core.ErrNoTokenYet
+	}
+	return "acquired-token", nil
+}
+
+func (m *lazyScopeAwareTokenSource) TokenForScopes(scopes []string) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.scopesCalled = append(m.scopesCalled, scopes)
+	m.armed = true
+	return "acquired-token", nil
+}
+
+// TestClient_LazyTokenSource_DefersThenArmsOn401 verifies the issue-818 lazy
+// path end-to-end at the transport: the first request goes out WITHOUT an
+// Authorization header (Token returned core.ErrNoTokenYet), the server's 401
+// carries scope="mcp:basic", and OnUnauthorized arms the source via
+// TokenForScopes with exactly that scope for the retry.
+func TestClient_LazyTokenSource_DefersThenArmsOn401(t *testing.T) {
+	var requestCount atomic.Int32
+	var firstAuthHeader string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := requestCount.Add(1)
+		if n == 1 {
+			firstAuthHeader = r.Header.Get("Authorization")
+			w.Header().Set("WWW-Authenticate", `Bearer scope="mcp:basic"`)
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":"ok"}`))
+	}))
+	defer ts.Close()
+
+	src := &lazyScopeAwareTokenSource{}
+	buildReq := func() (*http.Request, error) {
+		return http.NewRequest("POST", ts.URL, strings.NewReader(`{}`))
+	}
+
+	resp, err := client.DoWithAuthRetry(src, buildReq, http.DefaultClient.Do)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, 200, resp.StatusCode)
+	assert.Empty(t, firstAuthHeader, "first request MUST be unauthenticated while the source defers")
+	require.Len(t, src.scopesCalled, 1)
+	assert.Equal(t, []string{"mcp:basic"}, src.scopesCalled[0],
+		"OnUnauthorized must arm the source with the per-operation challenge scope")
+}
+
+// TestClient_LazyTokenSource_401NoScopeStillArms verifies that a 401 carrying
+// no scope= still routes through TokenForScopes (with an empty scope set) to
+// arm a lazy source — the issue-818 wiring that lets the retry fall back to the
+// source's PRM scopes_supported catalog. Before the fix, OnUnauthorized only
+// called TokenForScopes when scope= was present, so a lazy source would loop
+// back to core.ErrNoTokenYet and the request would fail.
+func TestClient_LazyTokenSource_401NoScopeStillArms(t *testing.T) {
+	var requestCount atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := requestCount.Add(1)
+		if n == 1 {
+			// 401 with a bare Bearer challenge — no scope= parameter.
+			w.Header().Set("WWW-Authenticate", `Bearer`)
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":"ok"}`))
+	}))
+	defer ts.Close()
+
+	src := &lazyScopeAwareTokenSource{}
+	buildReq := func() (*http.Request, error) {
+		return http.NewRequest("POST", ts.URL, strings.NewReader(`{}`))
+	}
+
+	resp, err := client.DoWithAuthRetry(src, buildReq, http.DefaultClient.Do)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, 200, resp.StatusCode)
+	require.Len(t, src.scopesCalled, 1, "a scope-less 401 must still arm the lazy source")
+	assert.Empty(t, src.scopesCalled[0], "no challenge scope means an empty TokenForScopes call")
+}
 
 // mockInvalidatingTokenSource records the order of Invalidate() vs
 // Token() calls so a test can prove Invalidate fired before the retry's

--- a/core/auth.go
+++ b/core/auth.go
@@ -2,8 +2,27 @@ package core
 
 import (
 	"context"
+	"errors"
 	"net/http"
 )
+
+// ErrNoTokenYet is returned by a TokenSource.Token call when the source
+// has no token to hand out yet and is deliberately deferring acquisition
+// until the server tells it what scope to request.
+//
+// Lazy OAuth sources (e.g. auth.OAuthTokenSource) return this before any
+// operation has triggered a 401: per RFC 6750 §3.1 a least-privilege
+// client SHOULD acquire its token using the scope= from the most recent
+// WWW-Authenticate challenge rather than a broader catalog (PRM
+// scopes_supported), so the source waits for that challenge instead of
+// pre-acquiring.
+//
+// The client transport treats ErrNoTokenYet specially: it sends the next
+// request WITHOUT an Authorization header (rather than failing the
+// request), lets the server respond with a 401 carrying the per-operation
+// scope, and then drives acquisition through the auth-retry path. Any
+// other error from Token is fatal to the request.
+var ErrNoTokenYet = errors.New("no token yet: deferring acquisition until a server challenge selects the scope")
 
 // Claims holds the authenticated identity extracted from a validated request.
 // Populated by AuthValidators that also implement ClaimsProvider.

--- a/ext/auth/client_credentials.go
+++ b/ext/auth/client_credentials.go
@@ -141,7 +141,7 @@ func (s *ClientCredentialsTokenSource) ensureSourceLocked() error {
 
 	scopes := s.Scopes
 	if len(scopes) == 0 {
-		scopes = info.Scopes
+		scopes = info.PRM.ScopesSupported
 	}
 
 	issuer := info.AuthorizationServers[0]

--- a/ext/auth/discovery.go
+++ b/ext/auth/discovery.go
@@ -43,12 +43,6 @@ type MCPAuthInfo struct {
 
 	// ASMetadata is the discovered authorization server metadata.
 	ASMetadata *client.ASMetadata
-
-	// Scopes to request, determined via the MCP scope selection strategy:
-	// 1. scope from WWW-Authenticate header
-	// 2. scopes_supported from PRM
-	// 3. empty (omit scope parameter)
-	Scopes []string
 }
 
 // ProtectedResourceMetadata is the JSON structure served by the PRM endpoint (RFC 9728).
@@ -120,15 +114,20 @@ func DiscoverMCPAuth(serverURL string, opts ...DiscoverOption) (*MCPAuthInfo, er
 	resp.Body.Close()
 
 	if resp.StatusCode == http.StatusUnauthorized {
-		// Step 2: Parse WWW-Authenticate
+		// Step 2: Parse WWW-Authenticate for the resource_metadata link.
+		//
+		// We deliberately do NOT capture the probe's scope= here. The probe
+		// hits a fixed method (initialize) whose challenge scope, if any, is
+		// the scope for THAT method — not necessarily the scope a later
+		// tools/call needs. Per RFC 6750 §3.1 the token's scope is selected
+		// per-operation from the challenge on the real request; discovery's
+		// job is endpoint resolution (PRM + AS metadata), not scope pinning.
+		// Token sources read the catalog fallback from info.PRM.ScopesSupported.
 		wwwAuth := resp.Header.Get("WWW-Authenticate")
 		if wwwAuth != "" {
-			rm, scopes, _ := ParseWWWAuthenticate(wwwAuth)
+			rm, _, _ := ParseWWWAuthenticate(wwwAuth)
 			if rm != "" {
 				info.ResourceMetadataURL = rm
-			}
-			if len(scopes) > 0 {
-				info.Scopes = scopes
 			}
 		}
 	}
@@ -202,13 +201,13 @@ func DiscoverMCPAuth(serverURL string, opts ...DiscoverOption) (*MCPAuthInfo, er
 		return nil, fmt.Errorf("PRM has no authorization_servers")
 	}
 
-	// Step 5: Scope selection (C18)
-	// Priority: WWW-Authenticate scope (already set) > PRM scopes_supported > empty
-	if len(info.Scopes) == 0 && len(info.PRM.ScopesSupported) > 0 {
-		info.Scopes = info.PRM.ScopesSupported
-	}
+	// Scope selection is no longer pinned here. The PRM scopes_supported
+	// catalog stays available to token sources via info.PRM.ScopesSupported,
+	// but it is only a last-resort fallback: per-operation scope comes from
+	// the WWW-Authenticate challenge on the real request (RFC 6750 §3.1),
+	// observed by the token source after a 401, not pre-selected at discovery.
 
-	// Step 6: Discover AS metadata via oneauth (RFC 8414 + OIDC fallback)
+	// Step 5: Discover AS metadata via oneauth (RFC 8414 + OIDC fallback)
 	issuer := info.AuthorizationServers[0]
 	asOpts := []client.DiscoveryOption{client.WithHTTPClientForDiscovery(httpClient)}
 	if cfg.asStore != nil {

--- a/ext/auth/discovery_test.go
+++ b/ext/auth/discovery_test.go
@@ -204,9 +204,13 @@ func TestDiscoverMCPAuth_FullChain(t *testing.T) {
 	}
 }
 
-// TestDiscoverMCPAuth_WWWAuthenticateScope verifies that scope from the
-// WWW-Authenticate header takes priority over PRM scopes_supported (C18).
-func TestDiscoverMCPAuth_WWWAuthenticateScope(t *testing.T) {
+// TestDiscoverMCPAuth_DoesNotPinScopeFromProbe verifies that discovery no
+// longer captures the probe's WWW-Authenticate scope= for token acquisition
+// (issue 818). Discovery's job is endpoint resolution; the only scope it
+// exposes is the PRM scopes_supported catalog (info.PRM.ScopesSupported).
+// Per-operation scope is selected later from the real request's 401
+// challenge (RFC 6750 §3.1), not pinned here from a fixed probe method.
+func TestDiscoverMCPAuth_DoesNotPinScopeFromProbe(t *testing.T) {
 	srv := mockMCPAuthServer(t,
 		withHeaderScope("tools:read admin:write"),
 		withPRMScopes([]string{"tools:read", "tools:call", "admin:write"}),
@@ -218,15 +222,17 @@ func TestDiscoverMCPAuth_WWWAuthenticateScope(t *testing.T) {
 		t.Fatalf("DiscoverMCPAuth failed: %v", err)
 	}
 
-	// Scopes should come from WWW-Authenticate header, not PRM
-	if len(info.Scopes) != 2 {
-		t.Fatalf("expected 2 scopes from header, got %d: %v", len(info.Scopes), info.Scopes)
+	// The probe's scope= ("tools:read admin:write", 2 scopes) must NOT win;
+	// the catalog discovery exposes is the full PRM scopes_supported (3).
+	if got := info.PRM.ScopesSupported; len(got) != 3 {
+		t.Fatalf("expected 3 PRM scopes_supported, got %d: %v", len(got), got)
 	}
 }
 
-// TestDiscoverMCPAuth_PRMScopesFallback verifies that when WWW-Authenticate
-// has no scope parameter, scopes fall back to PRM scopes_supported (C18).
-func TestDiscoverMCPAuth_PRMScopesFallback(t *testing.T) {
+// TestDiscoverMCPAuth_PRMScopesExposed verifies that PRM scopes_supported is
+// surfaced on info.PRM for token sources to use as the catalog fallback when
+// a 401 challenge carries no scope=.
+func TestDiscoverMCPAuth_PRMScopesExposed(t *testing.T) {
 	srv := mockMCPAuthServer(t,
 		// No headerScope — WWW-Authenticate has no scope= param
 		withPRMScopes([]string{"tools:read", "tools:call"}),
@@ -238,8 +244,9 @@ func TestDiscoverMCPAuth_PRMScopesFallback(t *testing.T) {
 		t.Fatalf("DiscoverMCPAuth failed: %v", err)
 	}
 
-	if len(info.Scopes) != 2 {
-		t.Fatalf("expected 2 scopes from PRM fallback, got %d: %v", len(info.Scopes), info.Scopes)
+	if len(info.PRM.ScopesSupported) != 2 {
+		t.Fatalf("expected 2 PRM scopes_supported, got %d: %v",
+			len(info.PRM.ScopesSupported), info.PRM.ScopesSupported)
 	}
 }
 

--- a/ext/auth/go.mod
+++ b/ext/auth/go.mod
@@ -13,6 +13,7 @@ require (
 )
 
 require (
+	github.com/alexedwards/scs/v2 v2.8.0 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/ext/auth/refresh_flow_test.go
+++ b/ext/auth/refresh_flow_test.go
@@ -120,11 +120,18 @@ func seedSourceForRefresh(t *testing.T, src *OAuthTokenSource, mockAS *refreshAS
 	src.authInfo = &MCPAuthInfo{
 		AuthorizationServers: []string{mockAS.URL},
 		ASMetadata: &client.ASMetadata{
-			AuthorizationEndpoint: mockAS.URL + "/authorize",
-			TokenEndpoint:         mockAS.URL + "/token",
+			AuthorizationEndpoint:         mockAS.URL + "/authorize",
+			TokenEndpoint:                 mockAS.URL + "/token",
 			CodeChallengeMethodsSupported: []string{"S256"},
 		},
-		Scopes: []string{"read", "write"},
+	}
+	// Pin explicit scopes so Token() bypasses the lazy gate (issue 818) and
+	// exercises the refresh path these tests target, rather than deferring
+	// with core.ErrNoTokenYet. Scope selection is no longer carried on
+	// MCPAuthInfo. Preserve a caller-set scope set (some tests pin [read]
+	// to drive the step-up-skips-refresh path).
+	if len(src.Scopes) == 0 {
+		src.Scopes = []string{"read", "write"}
 	}
 	// Preset the oaClient with the caller-supplied store.
 	src.oaClient = client.NewAuthClient(mockAS.URL, store,

--- a/ext/auth/token_source.go
+++ b/ext/auth/token_source.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	mcpcore "github.com/panyam/mcpkit/core"
 	"github.com/panyam/oneauth/client"
 	"github.com/panyam/oneauth/core"
 )
@@ -24,13 +25,14 @@ const tokenExpiryBuffer = 30 * time.Second
 // Per MCP spec (2025-11-25): clients MUST implement PKCE with S256,
 // MUST include resource parameter, MUST verify PKCE support in AS metadata.
 //
-// The discovery flow is:
-//  1. Probe MCP server → 401 + WWW-Authenticate header
-//  2. Fetch Protected Resource Metadata (PRM, RFC 9728)
-//  3. Discover Authorization Server metadata (RFC 8414 / OIDC)
-//  4. Validate PKCE S256 support
-//  5. Resolve client identity (pre-registered → CIMD → DCR)
-//  6. Run PKCE authorization code flow via oneauth LoginWithBrowser
+// Acquisition is lazy: the source defers the OAuth flow until a server
+// challenge selects the scope (see Token). The flow, once a challenge
+// arms the source, is:
+//  1. Fetch Protected Resource Metadata (PRM, RFC 9728)
+//  2. Discover Authorization Server metadata (RFC 8414 / OIDC)
+//  3. Validate PKCE S256 support
+//  4. Resolve client identity (pre-registered → CIMD → DCR)
+//  5. Run PKCE authorization code flow via oneauth LoginWithBrowser
 type OAuthTokenSource struct {
 	// ServerURL is the MCP server URL (used for PRM discovery and as resource indicator).
 	ServerURL string
@@ -54,8 +56,12 @@ type OAuthTokenSource struct {
 	// If nil, DefaultClientRegistration() is used.
 	DCRMeta *ClientRegistrationRequest
 
-	// Scopes to request. If empty, determined via MCP scope selection strategy
-	// (WWW-Authenticate scope > PRM scopes_supported > empty).
+	// Scopes to request. Leave empty for the default lazy behavior: the
+	// source acquires no token until a server 401/403 selects the scope via
+	// WWW-Authenticate, then uses that (falling back to PRM scopes_supported
+	// only when the challenge carries no scope=). Setting Scopes explicitly
+	// pins them and acquires eagerly on the first Token call. TokenForScopes
+	// merges challenge scopes into this set as step-up occurs.
 	Scopes []string
 
 	// CredStore persists tokens across sessions (optional).
@@ -104,6 +110,16 @@ type OAuthTokenSource struct {
 	token    string
 	expiry   time.Time
 
+	// armed reports whether acquisition has been authorized by a server
+	// challenge (TokenForScopes, called by the transport on a 401/403) or
+	// by the caller setting explicit Scopes. Until armed, Token defers and
+	// returns core.ErrNoTokenYet so the first request goes out
+	// unauthenticated and the server's WWW-Authenticate challenge selects
+	// the scope (RFC 6750 §3.1). Mutated only under mu. Invalidate
+	// deliberately leaves it set so an in-flight step-up retry still
+	// acquires rather than re-deferring.
+	armed bool
+
 	// memoryStore is the default backing store for the AuthClient when
 	// s.CredStore is nil. Allocated lazily on first Token() call; holds
 	// refresh tokens between Token() invocations so the refresh path can
@@ -136,6 +152,12 @@ type OAuthTokenSource struct {
 // token needed) while still meeting SEP-2352 when the AS truly
 // changes.
 //
+// The armed flag (Token's lazy gate) is intentionally NOT reset: the
+// transport calls Invalidate then TokenForScopes on a 401, and re-arming
+// would be redundant, but more importantly an already-armed source must
+// stay armed across a step-up retry so the re-issued Token acquires
+// rather than re-deferring with core.ErrNoTokenYet.
+//
 // Safe to call multiple times.
 func (s *OAuthTokenSource) Invalidate() {
 	s.mu.Lock()
@@ -153,7 +175,18 @@ func (s *OAuthTokenSource) Invalidate() {
 
 // Token implements core.TokenSource.
 //
-// Attempts are ordered cheap-to-expensive:
+// Acquisition is LAZY by default: until a server challenge selects the
+// scope, Token returns ("", core.ErrNoTokenYet) instead of running the
+// OAuth flow. The transport treats that sentinel as "send this request
+// without an Authorization header", the server replies 401 with a
+// per-operation WWW-Authenticate scope=, and the auth-retry path calls
+// TokenForScopes to arm the source and acquire with that exact scope
+// (RFC 6750 §3.1). This avoids pre-acquiring with the broader PRM
+// scopes_supported catalog before any operation has stated what it needs.
+// Setting explicit Scopes on the source opts out of laziness — a caller
+// that pins scopes acquires eagerly on the first Token call.
+//
+// Once armed (or with explicit Scopes), attempts are ordered cheap-to-expensive:
 //  1. In-memory cached token still valid                        -> return it
 //  2. CredStore has a non-expired credential (fast path)        -> cache + return
 //  3. Refresh path: if the stored credential has a refresh token
@@ -184,6 +217,16 @@ func (s *OAuthTokenSource) Token() (string, error) {
 		}
 	}
 
+	// Lazy gate: defer acquisition until a server challenge has armed us
+	// (via TokenForScopes on a 401/403) or the caller pinned explicit
+	// Scopes. Returning core.ErrNoTokenYet here makes the transport send
+	// the next request unauthenticated, so the server's WWW-Authenticate
+	// scope= drives selection instead of the PRM scopes_supported catalog
+	// (RFC 6750 §3.1). Issue 818.
+	if !s.armed && len(s.Scopes) == 0 {
+		return "", mcpcore.ErrNoTokenYet
+	}
+
 	// Run MCP discovery (cached after first call)
 	if s.authInfo == nil {
 		var opts []DiscoverOption
@@ -212,10 +255,15 @@ func (s *OAuthTokenSource) Token() (string, error) {
 		}
 	}
 
-	// Scope selection: explicit > discovery
+	// Scope selection: explicit/challenge-accumulated (s.Scopes) > PRM
+	// scopes_supported catalog fallback. s.Scopes carries both the caller's
+	// explicit scopes and any challenge scopes merged in by TokenForScopes,
+	// so a per-operation WWW-Authenticate scope (set just before this call
+	// on a 401/403) always wins over the broader PRM catalog. Empty on both
+	// means omit the scope parameter entirely (RFC 6749 §3.3).
 	scopes := s.Scopes
-	if len(scopes) == 0 {
-		scopes = s.authInfo.Scopes
+	if len(scopes) == 0 && s.authInfo.PRM != nil {
+		scopes = s.authInfo.PRM.ScopesSupported
 	}
 
 	// Client registration (C6): pre-registered > CIMD > DCR > error
@@ -378,10 +426,23 @@ func credentialCoversScopes(cred *client.ServerCredential, required []string) bo
 // OAuth flow. Stored-credential invalidation is required so the refresh
 // path cannot silently return a token scoped to the old grant — step-up
 // must re-run LoginWithBrowser to widen the scope set.
+//
+// Calling this also arms the source for acquisition (see Token's lazy
+// gate). The transport routes every 401 on a scope-aware source through
+// here — including 401s whose WWW-Authenticate carries no scope=, where
+// scopes is empty. That empty call is a no-op on the scope set but still
+// arms the source, so the subsequent Token acquires using the PRM
+// scopes_supported fallback rather than deferring with core.ErrNoTokenYet.
 func (s *OAuthTokenSource) TokenForScopes(scopes []string) (string, error) {
 	s.mu.Lock()
 	s.token = ""
 	s.expiry = time.Time{}
+	// Arm acquisition: a server challenge (or explicit step-up) has selected
+	// the scope, so the next Token call must acquire rather than defer with
+	// core.ErrNoTokenYet. Holds even when scopes is empty — an empty union
+	// is a no-op on the scope set but still flips the source out of its lazy
+	// state, so a 401 carrying no scope= falls through to the PRM catalog.
+	s.armed = true
 	s.Scopes = core.UnionScopes(s.Scopes, scopes)
 	// Wipe the stored credential so Token() skips the refresh path and
 	// goes straight to LoginWithBrowser on the next call. Applies to

--- a/ext/auth/token_source_lazy_test.go
+++ b/ext/auth/token_source_lazy_test.go
@@ -1,0 +1,221 @@
+package auth
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+
+	mcpcore "github.com/panyam/mcpkit/core"
+	oneauthclient "github.com/panyam/oneauth/client"
+	"github.com/panyam/oneauth/testutil"
+)
+
+// TestOAuthTokenSource_DefersUntilArmed verifies the issue-818 lazy gate: a
+// source with no explicit Scopes and no server challenge yet returns
+// core.ErrNoTokenYet and does NOT run discovery or open a browser. Before the
+// fix, Token() ran discovery eagerly and would fail with a discovery error
+// (not ErrNoTokenYet) against the unreachable server.
+func TestOAuthTokenSource_DefersUntilArmed(t *testing.T) {
+	src := &OAuthTokenSource{
+		ServerURL: "http://127.0.0.1:1/mcp",
+		ClientID:  "test-cli",
+		OpenBrowser: func(string) error {
+			t.Fatal("OpenBrowser must not be called before the source is armed")
+			return nil
+		},
+	}
+
+	tok, err := src.Token()
+	if !errors.Is(err, mcpcore.ErrNoTokenYet) {
+		t.Fatalf("Token() = (%q, %v), want core.ErrNoTokenYet", tok, err)
+	}
+	if tok != "" {
+		t.Fatalf("Token() returned non-empty token %q while deferring", tok)
+	}
+}
+
+// TestOAuthTokenSource_ExplicitScopesBypassLazyGate verifies that a caller who
+// pins Scopes opts out of laziness — Token() proceeds to discovery (which here
+// fails against an unreachable server) rather than deferring with
+// ErrNoTokenYet.
+func TestOAuthTokenSource_ExplicitScopesBypassLazyGate(t *testing.T) {
+	src := &OAuthTokenSource{
+		ServerURL:     "http://127.0.0.1:1/mcp",
+		ClientID:      "test-cli",
+		Scopes:        []string{"mcp:basic"},
+		AllowInsecure: true,
+		OpenBrowser:   func(string) error { return nil },
+	}
+
+	_, err := src.Token()
+	if errors.Is(err, mcpcore.ErrNoTokenYet) {
+		t.Fatal("explicit Scopes must bypass the lazy gate, got ErrNoTokenYet")
+	}
+	if err == nil {
+		t.Fatal("expected a discovery error against the unreachable server")
+	}
+}
+
+// TestOAuthTokenSource_ChallengeScopeWinsOverPRM is the core issue-818
+// acceptance: when a 401 challenge selects scope "mcp:basic" but the PRM
+// advertises scopes_supported=["mcp:profile"], the source's first (and only)
+// authorization request carries the challenge scope, not the PRM catalog.
+//
+// The flow is driven through the real oneauth authorization-code + PKCE path
+// against oneauth's reusable test AS (testutil.NewTestAuthServer). The scope
+// the source requests is captured from the authorization URL handed to
+// OpenBrowser before FollowRedirects completes the flow.
+func TestOAuthTokenSource_ChallengeScopeWinsOverPRM(t *testing.T) {
+	as := testutil.NewTestAuthServer(t,
+		testutil.WithAuthorizeEnabled(true),
+		testutil.WithAuthorizeAutoApproveSubject("test-user"),
+		testutil.WithScopes([]string{"mcp:basic", "mcp:profile", "mcp:write"}),
+	)
+
+	mcp := newPRMOnlyMCPServer(t, as.URL(), []string{"mcp:profile"})
+	defer mcp.Close()
+
+	var (
+		mu              sync.Mutex
+		authorizeScopes []string
+	)
+	recordScope := func(authURL string) error {
+		u, err := url.Parse(authURL)
+		if err != nil {
+			return err
+		}
+		mu.Lock()
+		authorizeScopes = append(authorizeScopes, u.Query().Get("scope"))
+		mu.Unlock()
+		return oneauthclient.FollowRedirects(nil)(authURL)
+	}
+
+	src := &OAuthTokenSource{
+		ServerURL:     mcp.URL + "/mcp",
+		ClientID:      "test-cli",
+		AllowInsecure: true,
+		OpenBrowser:   recordScope,
+	}
+
+	// Arm with the per-operation challenge scope, as the transport's
+	// OnUnauthorized would after a 401 carrying scope="mcp:basic".
+	tok, err := src.TokenForScopes([]string{"mcp:basic"})
+	if err != nil {
+		t.Fatalf("TokenForScopes: %v", err)
+	}
+	if tok == "" {
+		t.Fatal("expected a non-empty access token")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(authorizeScopes) != 1 {
+		t.Fatalf("expected exactly 1 authorization request, got %d: %v", len(authorizeScopes), authorizeScopes)
+	}
+	got := authorizeScopes[0]
+	if !scopeContains(got, "mcp:basic") {
+		t.Errorf("authorization scope = %q, want it to include the challenge scope mcp:basic", got)
+	}
+	if scopeContains(got, "mcp:profile") {
+		t.Errorf("authorization scope = %q, must NOT include the PRM catalog scope mcp:profile", got)
+	}
+}
+
+// TestOAuthTokenSource_PRMFallbackWhenChallengeHasNoScope verifies the
+// scenario-2 path preserved by issue 818: when a 401 carries no scope=, the
+// transport arms the source with an empty TokenForScopes call and the
+// subsequent acquisition falls back to the PRM scopes_supported catalog.
+func TestOAuthTokenSource_PRMFallbackWhenChallengeHasNoScope(t *testing.T) {
+	as := testutil.NewTestAuthServer(t,
+		testutil.WithAuthorizeEnabled(true),
+		testutil.WithAuthorizeAutoApproveSubject("test-user"),
+		testutil.WithScopes([]string{"mcp:basic", "mcp:read", "mcp:write"}),
+	)
+
+	prmScopes := []string{"mcp:basic", "mcp:read", "mcp:write"}
+	mcp := newPRMOnlyMCPServer(t, as.URL(), prmScopes)
+	defer mcp.Close()
+
+	var (
+		mu              sync.Mutex
+		authorizeScopes []string
+	)
+	recordScope := func(authURL string) error {
+		u, err := url.Parse(authURL)
+		if err != nil {
+			return err
+		}
+		mu.Lock()
+		authorizeScopes = append(authorizeScopes, u.Query().Get("scope"))
+		mu.Unlock()
+		return oneauthclient.FollowRedirects(nil)(authURL)
+	}
+
+	src := &OAuthTokenSource{
+		ServerURL:     mcp.URL + "/mcp",
+		ClientID:      "test-cli",
+		AllowInsecure: true,
+		OpenBrowser:   recordScope,
+	}
+
+	// Empty challenge (no scope= on the 401) — arms the source for the PRM
+	// fallback without contributing any scope of its own.
+	if _, err := src.TokenForScopes(nil); err != nil {
+		t.Fatalf("TokenForScopes(nil): %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(authorizeScopes) != 1 {
+		t.Fatalf("expected exactly 1 authorization request, got %d: %v", len(authorizeScopes), authorizeScopes)
+	}
+	got := authorizeScopes[0]
+	for _, want := range prmScopes {
+		if !scopeContains(got, want) {
+			t.Errorf("authorization scope = %q, want PRM fallback to include %q", got, want)
+		}
+	}
+}
+
+// newPRMOnlyMCPServer returns an httptest server that stands in for an MCP
+// resource server during discovery: the POST probe answers 401 pointing at its
+// PRM, and the PRM document advertises the given authorization server and
+// scopes_supported. It issues no tokens — acquisition happens at the AS.
+func newPRMOnlyMCPServer(t *testing.T, asURL string, scopesSupported []string) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	var serverURL string
+	srv := httptest.NewServer(mux)
+	serverURL = srv.URL
+
+	mux.HandleFunc("/.well-known/oauth-protected-resource/mcp", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"resource":              serverURL + "/mcp",
+			"authorization_servers": []string{asURL},
+			"scopes_supported":      scopesSupported,
+		})
+	})
+	mux.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("WWW-Authenticate",
+			`Bearer resource_metadata="`+serverURL+`/.well-known/oauth-protected-resource/mcp"`)
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+	return srv
+}
+
+// scopeContains reports whether a space-separated OAuth scope string includes
+// the given scope token (RFC 6749 §3.3).
+func scopeContains(scope, want string) bool {
+	for _, s := range strings.Fields(scope) {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## What changes

`OAuthTokenSource` no longer pre-acquires its first token eagerly. It now defers the OAuth flow until a server challenge selects the scope, so the first authorization request carries the **per-operation** scope from `WWW-Authenticate` rather than the broad PRM `scopes_supported` catalog — matching RFC 6750 §3.1. Closes issue 818.

Before, when the discovery probe (`initialize`) wasn't gated, no challenge scope was seen and scope selection fell back to PRM `scopes_supported`. On a server that gates per-method (`initialize` open, `tools/list` requires `mcp:basic`), the client asked the AS for `mcp:profile` (PRM) first, then stepped up — the conformance fork's `scope-step-up-initial` check flagged this as a WARNING.

## Before / after

Server gates per method: `initialize` is open, `tools/list` requires `mcp:basic`, and the PRM advertises `scopes_supported = mcp:profile`.

```mermaid
sequenceDiagram
    participant C as Client transport
    participant TS as OAuthTokenSource
    participant AS as Authorization Server
    participant S as MCP server

    Note over C,S: BEFORE - eager acquisition picks the PRM scope
    C->>TS: Token
    TS->>S: discovery probe initialize - 200, no challenge
    TS->>AS: authorize scope=mcp:profile - PRM catalog, wrong
    AS-->>TS: token for mcp:profile
    C->>S: tools/list with Bearer mcp:profile
    S-->>C: 401 scope=mcp:basic
    C->>TS: TokenForScopes mcp:basic
    TS->>AS: authorize scope=mcp:basic
    Note over AS: AS already saw an over-scoped mcp:profile request

    Note over C,S: AFTER - lazy, the challenge selects the scope
    C->>TS: Token
    TS-->>C: ErrNoTokenYet
    C->>S: tools/list with no Authorization header
    S-->>C: 401 scope=mcp:basic
    C->>TS: TokenForScopes mcp:basic
    TS->>AS: authorize scope=mcp:basic - first and only request, right
    AS-->>TS: token for mcp:basic
    C->>S: tools/list with Bearer mcp:basic
    S-->>C: 200
```

## Reviewer's guide

Read in this order:
1. [core/auth.go](https://github.com/panyam/mcpkit/pull/820/files#diff-3e25dee8210000495ed39b87f0f2f4503034f791d0759f8c5c17f6a7b1ede783) — start here. New `ErrNoTokenYet` sentinel + its contract (lazy sources return it; transport treats it as skip-header).
2. [ext/auth/token_source.go](https://github.com/panyam/mcpkit/pull/820/files#diff-6d528a538fc48b723628904903959aba0d2a143b95b820af43ee6e8b3f45e523) — the `armed` gate in `Token()`, scope fallback now reads `info.PRM.ScopesSupported`, `TokenForScopes` arms, `Invalidate` leaves armed set.
3. [ext/auth/discovery.go](https://github.com/panyam/mcpkit/pull/820/files#diff-898de71e5ac9a31240de5205dac54889e5db5abe2fad3859075f8bab1e577b31) — `MCPAuthInfo.Scopes` removed; probe-scope capture and the PRM-fallback pin dropped.
4. [client/client.go](https://github.com/panyam/mcpkit/pull/820/files#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09) — `SetAuth` skip-header on `ErrNoTokenYet`; `OnUnauthorized` routes every scope-aware 401 through `TokenForScopes` (incl. scope-less).
5. [ext/auth/token_source_lazy_test.go](https://github.com/panyam/mcpkit/pull/820/files#diff-db47e042a2414de6194a0794be128583d4da94fdd7d815a0132261a8669f99a7) — acceptance: defers until armed, explicit-scopes bypass, challenge scope wins over PRM, PRM fallback when no challenge scope (uses oneauth's `testutil.NewTestAuthServer`).
6. [client/client_auth_retry_test.go](https://github.com/panyam/mcpkit/pull/820/files#diff-ede8379f7d17e8193f348da8416495cf9f781b50f94acc617e855529441f6359) — transport wiring: first request unauthenticated then armed on 401; scope-less 401 still arms.

Skim or skip: [ext/auth/discovery_test.go](https://github.com/panyam/mcpkit/pull/820/files#diff-af673ffc33161682cb6ff254ed2025cc14f9e2deee9bd3bc380537f112013a39) (assertions repointed to `info.PRM.ScopesSupported`), [ext/auth/refresh_flow_test.go](https://github.com/panyam/mcpkit/pull/820/files#diff-9a7496a1b10c8285b372d0aac143ba6de6c8e524de85c5c1338b620cbb1bb0b1) (seed helper pins explicit scopes to bypass the gate), [ext/auth/client_credentials.go](https://github.com/panyam/mcpkit/pull/820/files#diff-c24f6edc66944bad16c70b808c05bf9652eeafe7d0a07490610fefa0f02d2777) (one-line fallback source swap), [ext/auth/go.mod](https://github.com/panyam/mcpkit/pull/820/files#diff-3c7eea7bae0c98e4121ff2f0c27d6b3612e863db7c0863d7ea006b9184d57ed7) (test-only indirect dep from the oneauth test AS).

## Diff groups
- Production: `core/auth.go`, `ext/auth/token_source.go`, `ext/auth/discovery.go`, `ext/auth/client_credentials.go`, `client/client.go`
- Tests: `ext/auth/token_source_lazy_test.go`, `client/client_auth_retry_test.go`, `ext/auth/discovery_test.go`, `ext/auth/refresh_flow_test.go`
- Mechanical: `ext/auth/go.mod` / `go.sum`

## Decision log
- **Lazy acquisition over "probe a tool-requiring method during discovery"** — the issue's rejected alternative. Probing a fixed method (e.g. `tools/list`) hardcodes a target that may not exist and doesn't generalize to `resources/read` / `prompts/get` / future surfaces. Deferring to the real operation's 401 generalizes to every gated surface.
- **Dropped `MCPAuthInfo.Scopes` entirely** rather than splitting it into challenge-scope + PRM-scope fields. PRM `scopes_supported` already lives on `info.PRM`, so a separate computed field was redundant; per-operation scope now comes from the live challenge, not discovery.
- **`OnUnauthorized` routes scope-less 401s through `TokenForScopes` too** (dropped the `len(scopes) > 0` guard from PR 819). An empty merge is a no-op on the scope set but flips a lazy source out of its deferred state, so the retry acquires via the PRM fallback instead of looping on `ErrNoTokenYet`.
- **`Invalidate` leaves `armed` set** so an in-flight step-up retry acquires rather than re-deferring.

## Risk / blast radius
- Affects: every `OAuthTokenSource` consumer and the client auth-retry transport. `ClientCredentialsTokenSource` stays eager (fallback source swapped to `info.PRM.ScopesSupported`).
- **Public behavior change (intentional):** standalone `OAuthTokenSource.Token()` callers now get `ErrNoTokenYet` until armed by a challenge or until they set explicit `Scopes`. Documented on the type and `Token`.
- Be paranoid about: the empty-scope `TokenForScopes` arming path (scenario-2 PRM fallback) and the refresh-path tests (now pin explicit scopes to bypass the gate).
- Tests covering this: the two new test files above, plus full `ext/auth`, `core`, `client`, tests/e2e auth, and the conformance suites below.

## Before / after (observable)
Conformance fork `auth/scope-step-up` against the patched testclient:
- Before: `scope-step-up-initial` = **WARNING** (expectedScope `mcp:basic`, requestedScope `mcp:profile`)
- After: **24/24 passed, 0 warnings** — `scope-step-up-initial` = SUCCESS

`make testconfauth` (published suite, CI stage 8b): **264 passed, 0 failed**, 1 pre-existing baseline warning (`auth/basic-cimd`, unrelated). Scope scenarios `scope-from-www-authenticate`, `scope-from-scopes-supported`, `scope-omitted-when-undefined`, `scope-retry-limit` all clean.

## Out of scope (deliberately deferred)
- Making `ClientCredentialsTokenSource` lazy (separate concern; no eager-PRM bug there today).
- CLAUDE.md gotcha + scope-selection doc refresh → `/checkpoint` after merge.

Builds on PR 819 (the 401 `WWW-Authenticate` scope= retry path), now merged.

