### PR TITLE
fix(examples/auth): drop forced stateless mode from step-up-keycloak

### DIFF
--- a/examples/auth/step-up-keycloak/main.go
+++ b/examples/auth/step-up-keycloak/main.go
@@ -47,7 +47,6 @@ import (
 	mcpcommon "github.com/panyam/mcpkit/examples/common"
 	"github.com/panyam/mcpkit/ext/auth"
 	"github.com/panyam/mcpkit/server"
-	"github.com/panyam/mcpkit/server/stateless"
 	oneauthclient "github.com/panyam/oneauth/client"
 )
 
@@ -125,11 +124,12 @@ func main() {
 			))
 		},
 		TransportOptions: []server.TransportOption{
-			// SEP-2575 stateless wire so the conformance scenario can hit
-			// tools/call directly without an initialize handshake or
-			// Mcp-Session-Id. Matches the wire mode PR 1624's reference
-			// impl uses when sessionIdGenerator is undefined.
-			server.WithStatelessMode(stateless.ModeStateless),
+			// Dual mode (default) so the scenario's legacy initialize +
+			// session-id handshake works. modelcontextprotocol/typescript-sdk
+			// PR 1624's transport does not yet support the SEP-2575
+			// stateless wire (protocolVersion 2026-07-28), so the
+			// conformance scenario speaks the legacy 2025-11-25 wire to
+			// stay interop-compatible across both SUTs.
 			server.WithMux(func(mux *http.ServeMux) {
 				auth.MountAuth(mux, auth.AuthConfig{
 					ResourceURI:          listenURL,


### PR DESCRIPTION
## What changes

Removes the forced `server.WithStatelessMode(stateless.ModeStateless)` from `examples/auth/step-up-keycloak/main.go`, reverting the example to mcpkit's default `Dual` mode (hybrid: accepts both legacy `2025-11-25` and SEP-2575 `2026-07-28` wires on the same URL).

## Why

The pin came from PR 819, where I expected the conformance scenario in `panyam/mcpconformance` PR 19 to drive the SUT over SEP-2575 stateless wire. After the scenario refactored to legacy wire (because `modelcontextprotocol/typescript-sdk` PR 1624 doesn't yet support `2026-07-28`), the forced `ModeStateless` pin rejected the scenario's legacy `initialize` handshake with a 404. Removing the override restores the hybrid behavior every demo SUT should have.

## Risk / blast radius

- One file, six lines. No other code path touches `WithStatelessMode` in this example.
- `tests/keycloak/step_up_test.go::TestKeycloak_StepUp_StatelessWire` continues to pin `ModeStateless` itself, so the stateless-wire regression coverage is unchanged.

## Verified

`panyam/mcpconformance` `scope-challenge` scenario against this SUT post-fix:
```
Passed: 8/8, 0 failed, 0 warnings
```

## Refs

- `panyam/mcpconformance` PR 19 — scope-challenge scenario (now legacy wire)
- `panyam/mcp-ts-sdk` demo/scope-challenge-keycloak branch — TypeScript-side SUT exercising PR 1624 against the same Keycloak fixture; same 8/8 pass