### PR TITLE
feat(ext/auth): exercise AcceptedScopes OR-hierarchy in step-up-keycloak

### DIFF
--- a/core/typed_tool.go
+++ b/core/typed_tool.go
@@ -171,6 +171,21 @@ func WithToolRequiredScopes(scopes ...string) TypedToolOption {
 	return func(c *typedToolConfig) { c.requiredScopes = scopes }
 }
 
+// WithToolAcceptedScopes sets the AcceptedScopes OR-hierarchy escape hatch
+// on the generated ToolDef. When non-empty, the scope-check gate satisfaction
+// flips from "every RequiredScopes scope must be present" (AND) to "any
+// AcceptedScopes scope must be present" (OR). Supports declarative scope
+// hierarchies — a tool that nominally requires "repo:read" can additionally
+// accept "repo" without the caller needing to spell out the AND/OR logic.
+// Empty (default) preserves the AND-only behavior set by RequiredScopes.
+//
+// AcceptedScopes is gate-only: it never appears in the 403 WWW-Authenticate
+// challenge advertisement (which carries only RequiredScopes), keeping the
+// re-auth guidance least-privilege per SEP-2350.
+func WithToolAcceptedScopes(scopes ...string) TypedToolOption {
+	return func(c *typedToolConfig) { c.acceptedScopes = scopes }
+}
+
 // WithInputSchemaOverride replaces the reflection-derived input schema with a
 // caller-supplied schema. Use this when the tool's input shape needs JSON
 // Schema 2020-12 features that struct tags cannot express — for example

--- a/examples/auth/step-up-keycloak/main.go
+++ b/examples/auth/step-up-keycloak/main.go
@@ -56,6 +56,7 @@ const (
 	scopeToolsRead     = "tools-read"
 	scopeToolsCall     = "tools-call"
 	scopeAdminWrite    = "admin-write"
+	scopeAdmin         = "admin"
 )
 
 func envOr(k, def string) string {
@@ -86,7 +87,7 @@ func main() {
 	jwksURI := asMeta.JWKSURI
 
 	listenURL := fmt.Sprintf("http://localhost%s", *addr)
-	allScopes := []string{scopeToolsRead, scopeToolsCall, scopeAdminWrite}
+	allScopes := []string{scopeToolsRead, scopeToolsCall, scopeAdminWrite, scopeAdmin}
 
 	prmURL := listenURL + "/.well-known/oauth-protected-resource/mcp"
 	validator := auth.NewJWTValidator(auth.JWTConfig{
@@ -112,12 +113,21 @@ func main() {
 			server.WithAuth(validator),
 		},
 		Register: func(srv *server.Server) {
+			// admin_call demonstrates the SEP-2350 OR-hierarchy: a caller
+			// satisfies the gate by holding ANY scope in AcceptedScopes, even
+			// if the literal admin-write scope is absent. The hierarchy here
+			// is "admin covers admin-write", a canonical OAuth-scope-hierarchy
+			// idiom. The 403 challenge still advertises requiredScopes only
+			// (never accepted-parents) per the least-privilege rule, which
+			// is what the scope-challenge-www-authenticate-accepted-not-leaked
+			// conformance check asserts.
 			srv.Register(core.TextTool[struct{}]("admin_call",
-				"Requires admin-write scope. Returns ok when scope is sufficient; otherwise the scope middleware returns HTTP 403 with WWW-Authenticate before this handler runs.",
+				"Requires admin-write scope. The OR-hierarchy on AcceptedScopes lets a token with the parent admin scope satisfy the gate too.",
 				func(_ core.ToolContext, _ struct{}) (string, error) {
 					return "admin_call: ok", nil
 				},
 				core.WithToolRequiredScopes(scopeAdminWrite),
+				core.WithToolAcceptedScopes(scopeAdminWrite, scopeAdmin),
 			))
 			srv.UseMiddleware(auth.NewToolScopeMiddleware(srv.Registry(),
 				auth.WithResourceMetadataURL(prmURL),

--- a/tests/keycloak/realm.json
+++ b/tests/keycloak/realm.json
@@ -18,7 +18,7 @@
       "redirectUris": ["http://localhost:*", "http://127.0.0.1:*"],
       "webOrigins": ["*"],
       "defaultClientScopes": ["openid", "email", "profile"],
-      "optionalClientScopes": ["tools-read", "tools-call", "admin-write"],
+      "optionalClientScopes": ["tools-read", "tools-call", "admin-write", "admin"],
       "protocolMappers": [
         {
           "name": "subject",
@@ -75,6 +75,13 @@
     },
     {
       "name": "admin-write",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true"
+      }
+    },
+    {
+      "name": "admin",
       "protocol": "openid-connect",
       "attributes": {
         "include.in.token.scope": "true"


### PR DESCRIPTION
## What changes

Three-line change that flips one conformance scenario check from SKIPPED to SUCCESS, demonstrating mcpkit#742's `AcceptedScopes` OR-hierarchy end-to-end against a real Keycloak realm.

1. `core/typed_tool.go`: add `WithToolAcceptedScopes(...)` typed-tool option. `mcpkit#742` added the `AcceptedScopes` field on `core.ToolDef` and the `acceptedScopes` field on `typedToolConfig`, but missed the `With*` setter. Callers had to drop into the raw struct to populate it, which is awkward next to `WithToolRequiredScopes`. One-line addition.
2. `examples/auth/step-up-keycloak/main.go`: declare `admin` as the OR-hierarchy parent of `admin-write` on the scope-gated tool via the new option. A token carrying just `admin` now satisfies the gate via the OR escape hatch even though the literal required scope is `admin-write`.
3. `tests/keycloak/realm.json`: add `admin` as a new optional client scope on `mcp-confidential`, so Keycloak can issue tokens whose `scope` claim contains the OR-hierarchy parent. Two-entry diff (one in the client's `optionalClientScopes` list, one in the `clientScopes` array).

## Reviewer's guide

Three small file edits, no architectural surprises:

1. `core/typed_tool.go` — new `WithToolAcceptedScopes` follows the exact shape of the existing `WithToolRequiredScopes` immediately above it. Doc comment explains the gate-only contract (`accepted` never appears in the 403 challenge — least-privilege).
2. `examples/auth/step-up-keycloak/main.go` — adds the `scopeAdmin` const and the `core.WithToolAcceptedScopes(scopeAdminWrite, scopeAdmin)` option on the existing `admin_call` tool. Also bumps `allScopes` for the PRM advertisement.
3. `tests/keycloak/realm.json` — adds the `admin` client scope, matching the existing `admin-write` entry pattern. Backward-compatible (existing tokens still validate).

## Risk / blast radius

- `core/typed_tool.go`: pure addition, no existing callers touched. `make test` (core) passes.
- `examples/auth/step-up-keycloak/main.go`: example-only, no production code path.
- `tests/keycloak/realm.json`: realm-config-only. Existing `tests/keycloak/*_test.go` continue to pass — they reference `tools-read`, `tools-call`, `admin-write` which remain unchanged. Adding `admin` is additive.

## Before / after

Before (mcpkit on `main`):
```
scope-challenge-accepted-or-hierarchy                SKIPPED  (operator didn't enable features.acceptedScopes)
scope-challenge-www-authenticate-accepted-not-leaked SKIPPED  (same)
Passed: 8/8, 0 failed, 0 warnings
```

After (this PR + conf-auth scenario context with `features.acceptedScopes: true` + a third Keycloak token with the `admin` parent scope):
```
scope-challenge-accepted-or-hierarchy                SUCCESS  (admin token satisfies the gate via AcceptedScopes)
scope-challenge-www-authenticate-accepted-not-leaked SKIPPED  (scenario design — the leak property is still verified by scope-required-only against the first 403)
Passed: 9/9, 0 failed, 0 warnings
```

Same scenario passes 9/9 against the TypeScript SDK's PR 1624 reference impl (`panyam/mc-ts-sdk:demo/scope-challenge-keycloak`), confirming cross-SDK wire-shape parity on the OR-hierarchy feature.

## Out of scope

- The `accepted-not-leaked` check stays SKIPPED until the scenario gets a small refactor to assert the property against the first 403 (which is the natural source of truth for "accepted set not leaked into challenge advertisement"). Follow-up on `panyam/mcpconformance` PR 19 if it comes up.
- `WithToolAcceptedScopes` is a typed-tool option only. Equivalent setter for the raw `srv.RegisterTool(ToolDef{...})` path is not needed since that path already exposes the `AcceptedScopes` field directly.

## Refs

- mcpkit#742 (closed) — added the `AcceptedScopes` field on `core.ToolDef` and the `typedToolConfig.acceptedScopes` storage; this PR adds the missing public setter to complete the typed-tool API surface.
- mcpkit#819 (closed) — the step-up-keycloak example this PR extends.
- panyam/mcpconformance PR 19 — defines the conformance scenario this PR's changes are validated against.
- modelcontextprotocol/typescript-sdk PR 1624 — the reference impl whose OR-hierarchy feature this PR demonstrates mcpkit ships interop-compatibly.
