### PR TITLE
examples/common: --wire flag for SEP-2575 wire selection

### DIFF
--- a/examples/CONVENTIONS.md
+++ b/examples/CONVENTIONS.md
@@ -225,6 +225,67 @@ path lights up in Grafana.
 `defaultExporter = "stdout"` because the example's whole purpose is
 showing traces. Every other example defaults to `""`.
 
+### Wire selection (SEP-2575)
+
+Examples pick the SEP-2575 wire from a single `--wire` flag rather than
+hand-rolling `stateless.ParseMode` / `client.ParseClientMode`. Register
+it next to the telemetry flags via `common.RegisterWireFlags(flag.CommandLine)`
+and thread the handle into `common.ServerConfig.Wire`. A walkthrough that
+doesn't call `flag.Parse` uses `common.WireFromArgs()` (mirrors
+`ExporterFromArgs`).
+
+`--wire` drives BOTH halves of a demo binary so the server and the
+walkthrough client agree on one knob:
+
+- `--wire=legacy` — server `ModeLegacyOnly` + client `ClientModeLegacyOnly`
+- `--wire=dual` — server `ModeDual` + client `ClientModeAdaptive` (dual is
+  the only asymmetric mapping: a Dual server speaks both wires, so the
+  client probes then falls back)
+- `--wire=stateless` — server `ModeStateless` + client `ClientModeStateless`
+- `--wire=""` (default) — make no selection; each side falls through to
+  `MCPKIT_STATELESS_MODE` / `MCPKIT_CLIENT_MODE` env or its package default
+  (server `ModeDual`, client `ClientModeLegacyOnly`)
+
+`--server-wire` / `--client-wire` override one side when a demo needs them
+decoupled. An unrecognized token logs a warning and falls through to the
+default rather than binding a surprising wire.
+
+Canonical wiring inside `serve()` (extends the telemetry setup above):
+
+```go
+func serve() {
+    addr := flag.String("addr", ":8080", "listen address")
+    tel := common.RegisterTelemetryFlags(flag.CommandLine)
+    wire := common.RegisterWireFlags(flag.CommandLine)
+    flag.CommandLine.Parse(demokit.FilterArgs(os.Args[1:],
+        demokit.BoolFlag("--serve"),
+        demokit.ValueFlag("--url"),
+    ))
+
+    // ... telemetry setup ...
+
+    if err := common.RunServer(common.ServerConfig{
+        Name:           "<example-name>",
+        Addr:           *addr,
+        TracerProvider: tp,
+        Wire:           wire, // applied after TransportOptions; CLI overrides hardcoded WithStatelessMode
+    }); err != nil {
+        log.Fatalf("ListenAndServe: %v", err)
+    }
+}
+```
+
+Like the telemetry flags, the `--wire` family passes through
+`demokit.FilterArgs` unstripped in `=` form (`--wire=stateless`). Only the
+space-separated form (`--wire stateless`) needs an explicit
+`demokit.ValueFlag("--wire")` in the filter list; most examples use the
+`=` form and skip it.
+
+`examples/stateless/` is the deliberate exception: it keeps its own
+`--mode` flag defaulting to `stateless` because the SEP-2575 conformance
+fixture drives it with no flag and needs the stateless wire by default,
+not the `ModeDual` fall-through `--wire=""` would give.
+
 #### Client-side wiring (walkthrough.go)
 
 Walkthroughs (runDemo) typically don't call `flag.Parse` — they rely

--- a/examples/common/runserver.go
+++ b/examples/common/runserver.go
@@ -55,6 +55,15 @@ type ServerConfig struct {
 	// WithStatelessMode, WithSSE, WithEventStore, etc.
 	TransportOptions []server.TransportOption
 
+	// Wire, when non-nil, applies --wire / --server-wire selection
+	// (from RegisterWireFlags or WireFromArgs) to the transport. It is
+	// applied AFTER TransportOptions so the CLI flag overrides any
+	// hardcoded WithStatelessMode. When no wire flag was passed the
+	// helper appends nothing and the server keeps its
+	// MCPKIT_STATELESS_MODE / stateless.DefaultMode wire. nil disables
+	// the feature entirely (the pre-Wire behavior).
+	Wire *WireFlags
+
 	// TracerProvider, when non-nil, wires SEP-414 trace middleware
 	// into the server via server.WithTracerProvider. Pass the result
 	// of commonotel.SetupTelemetry directly — it's already wrapped
@@ -129,5 +138,10 @@ func RunServer(cfg ServerConfig) error {
 	log.Printf("[%s] listening on %s", cfg.Name, cfg.Addr)
 
 	transportOpts := append([]server.TransportOption{server.WithStreamableHTTP(true)}, cfg.TransportOptions...)
+	if cfg.Wire != nil {
+		if opt, ok := cfg.Wire.ServerTransportOption(); ok {
+			transportOpts = append(transportOpts, opt)
+		}
+	}
 	return srv.ListenAndServe(transportOpts...)
 }

--- a/examples/common/wire_flag.go
+++ b/examples/common/wire_flag.go
@@ -1,0 +1,178 @@
+package common
+
+// Uniform --wire flag for SEP-2575 wire-mode selection across mcpkit
+// example binaries. An example author registers the flag once and the
+// helper resolves it into the right server.TransportOption and/or
+// client.ClientOption, so examples stop hand-rolling
+// stateless.ParseMode / client.ParseClientMode plumbing.
+//
+// SEP-2575 ships two wires on one URL (legacy session wire + stateless
+// wire); SEP-2567 ("Sessionless MCP") is the application-layer
+// counterpart. Examples should be runnable on either wire from a single
+// CLI knob so the on-ramp doesn't bake one wire in.
+//
+// Precedence per side stays consistent with the rest of mcpkit:
+// explicit flag > MCPKIT_STATELESS_MODE / MCPKIT_CLIENT_MODE env >
+// package default (stateless.DefaultMode / client.DefaultClientMode).
+// When --wire (and the per-side overrides) are empty the helper appends
+// nothing, leaving the env/default fall-through untouched.
+
+import (
+	"flag"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/panyam/mcpkit/client"
+	"github.com/panyam/mcpkit/server"
+	"github.com/panyam/mcpkit/server/stateless"
+)
+
+// WireFlags holds the wire-selection flag values. The primary --wire
+// drives BOTH halves of a demo binary (server and client) via a sensible
+// pairing; --server-wire / --client-wire override one side when a demo
+// genuinely needs them decoupled.
+//
+// Pairing applied by --wire:
+//
+//	--wire=legacy     server ModeLegacyOnly  + client ClientModeLegacyOnly
+//	--wire=dual       server ModeDual        + client ClientModeAdaptive
+//	--wire=stateless  server ModeStateless   + client ClientModeStateless
+//
+// dual is the only value that maps asymmetrically: a Dual server speaks
+// both wires, so the client side pairs to Adaptive (probe then fall
+// back), not a nonexistent "dual" client mode.
+type WireFlags struct {
+	// Wire is the primary --wire value: "" | legacy | dual | stateless.
+	// "" means "make no selection" — both sides fall through to their
+	// env var / package default.
+	Wire *string
+
+	// ServerWire is the --server-wire override: "" | legacy | dual |
+	// stateless. Beats Wire for the server side only.
+	ServerWire *string
+
+	// ClientWire is the --client-wire override: "" | legacy | adaptive |
+	// stateless. Beats Wire for the client side only.
+	ClientWire *string
+}
+
+// RegisterWireFlags wires --wire / --server-wire / --client-wire onto fs.
+// Call before flag.Parse. Mirrors RegisterTelemetryFlags.
+//
+// The flag names MUST be registered as demokit.ValueFlag in any binary
+// that filters os.Args through demokit.FilterArgs, so they survive the
+// filter — see examples/CONVENTIONS.md §Wire selection.
+func RegisterWireFlags(fs *flag.FlagSet) *WireFlags {
+	return &WireFlags{
+		Wire:       fs.String("wire", "", `wire mode for both halves: "" (env/default) | legacy | dual | stateless (dual pairs client to adaptive)`),
+		ServerWire: fs.String("server-wire", "", "override server wire only: legacy | dual | stateless (beats --wire)"),
+		ClientWire: fs.String("client-wire", "", "override client wire only: legacy | adaptive | stateless (beats --wire)"),
+	}
+}
+
+// WireFromArgs scans os.Args for --wire / --server-wire / --client-wire
+// without calling flag.Parse. Mirrors ExporterFromArgs, for walkthroughs
+// (runDemo) that don't otherwise parse flags. Returns a *WireFlags whose
+// pointers are locally allocated so call sites resolve it identically to
+// the RegisterWireFlags return.
+//
+// Recognized argv shapes (space- or =-separated):
+//
+//	--wire=stateless   --server-wire dual   --client-wire=adaptive
+func WireFromArgs() *WireFlags {
+	wire, serverWire, clientWire := "", "", ""
+	args := os.Args[1:]
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case a == "--wire" && i+1 < len(args):
+			wire = args[i+1]
+			i++
+		case strings.HasPrefix(a, "--wire="):
+			wire = strings.TrimPrefix(a, "--wire=")
+		case a == "--server-wire" && i+1 < len(args):
+			serverWire = args[i+1]
+			i++
+		case strings.HasPrefix(a, "--server-wire="):
+			serverWire = strings.TrimPrefix(a, "--server-wire=")
+		case a == "--client-wire" && i+1 < len(args):
+			clientWire = args[i+1]
+			i++
+		case strings.HasPrefix(a, "--client-wire="):
+			clientWire = strings.TrimPrefix(a, "--client-wire=")
+		}
+	}
+	return &WireFlags{Wire: &wire, ServerWire: &serverWire, ClientWire: &clientWire}
+}
+
+// serverToken resolves the effective server wire token: --server-wire if
+// set, else --wire, else "".
+func (w *WireFlags) serverToken() string {
+	if s := deref(w.ServerWire); s != "" {
+		return s
+	}
+	return deref(w.Wire)
+}
+
+// clientToken resolves the effective client wire token: --client-wire if
+// set, else the client-equivalent of --wire (dual maps to adaptive),
+// else "".
+func (w *WireFlags) clientToken() string {
+	if s := deref(w.ClientWire); s != "" {
+		return s
+	}
+	switch strings.ToLower(strings.TrimSpace(deref(w.Wire))) {
+	case "":
+		return ""
+	case "dual":
+		return "adaptive"
+	default:
+		return deref(w.Wire) // legacy / stateless map 1:1
+	}
+}
+
+// ServerTransportOption resolves the server wire into
+// server.WithStatelessMode. ok=true only when a wire was explicitly
+// selected; ok=false (with a nil option) means "make no selection" so
+// the caller appends nothing and the server keeps its env/default wire.
+//
+// An unrecognized token logs a warning and returns ok=false rather than
+// binding a surprising mode — a CLI typo falls through to the default
+// instead of silently flipping the wire.
+func (w *WireFlags) ServerTransportOption() (server.TransportOption, bool) {
+	tok := w.serverToken()
+	if tok == "" {
+		return nil, false
+	}
+	mode, parsed := stateless.ParseMode(tok)
+	if !parsed {
+		log.Printf("[common] ignoring unrecognized wire %q for server (want legacy|dual|stateless)", tok)
+		return nil, false
+	}
+	return server.WithStatelessMode(mode), true
+}
+
+// ClientOption resolves the client wire into client.WithClientMode.
+// ok=true only when a wire was explicitly selected; ok=false (nil
+// option) means the client keeps its env/default mode. Unrecognized
+// tokens warn and fall through, matching ServerTransportOption.
+func (w *WireFlags) ClientOption() (client.ClientOption, bool) {
+	tok := w.clientToken()
+	if tok == "" {
+		return nil, false
+	}
+	mode, parsed := client.ParseClientMode(tok)
+	if !parsed {
+		log.Printf("[common] ignoring unrecognized wire %q for client (want legacy|adaptive|stateless)", tok)
+		return nil, false
+	}
+	return client.WithClientMode(mode), true
+}
+
+func deref(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}

--- a/examples/common/wire_flag_test.go
+++ b/examples/common/wire_flag_test.go
@@ -1,0 +1,116 @@
+package common
+
+import "testing"
+
+func strp(s string) *string { return &s }
+
+func TestWireFlags_TokenResolution(t *testing.T) {
+	cases := []struct {
+		name                   string
+		wf                     WireFlags
+		wantServer, wantClient string
+	}{
+		{
+			name:       "empty falls through both sides",
+			wf:         WireFlags{Wire: strp(""), ServerWire: strp(""), ClientWire: strp("")},
+			wantServer: "",
+			wantClient: "",
+		},
+		{
+			name:       "legacy pairs 1:1",
+			wf:         WireFlags{Wire: strp("legacy"), ServerWire: strp(""), ClientWire: strp("")},
+			wantServer: "legacy",
+			wantClient: "legacy",
+		},
+		{
+			name:       "stateless pairs 1:1",
+			wf:         WireFlags{Wire: strp("stateless"), ServerWire: strp(""), ClientWire: strp("")},
+			wantServer: "stateless",
+			wantClient: "stateless",
+		},
+		{
+			name:       "dual maps client to adaptive",
+			wf:         WireFlags{Wire: strp("dual"), ServerWire: strp(""), ClientWire: strp("")},
+			wantServer: "dual",
+			wantClient: "adaptive",
+		},
+		{
+			name:       "DUAL is case-insensitive for the client mapping",
+			wf:         WireFlags{Wire: strp("DUAL"), ServerWire: strp(""), ClientWire: strp("")},
+			wantServer: "DUAL",
+			wantClient: "adaptive",
+		},
+		{
+			name:       "server override beats primary",
+			wf:         WireFlags{Wire: strp("stateless"), ServerWire: strp("legacy"), ClientWire: strp("")},
+			wantServer: "legacy",
+			wantClient: "stateless",
+		},
+		{
+			name:       "client override beats primary (incl dual mapping)",
+			wf:         WireFlags{Wire: strp("dual"), ServerWire: strp(""), ClientWire: strp("stateless")},
+			wantServer: "dual",
+			wantClient: "stateless",
+		},
+		{
+			name:       "nil pointers resolve to empty",
+			wf:         WireFlags{},
+			wantServer: "",
+			wantClient: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.wf.serverToken(); got != tc.wantServer {
+				t.Errorf("serverToken() = %q, want %q", got, tc.wantServer)
+			}
+			if got := tc.wf.clientToken(); got != tc.wantClient {
+				t.Errorf("clientToken() = %q, want %q", got, tc.wantClient)
+			}
+		})
+	}
+}
+
+func TestWireFlags_Options(t *testing.T) {
+	// Selected wire yields an option.
+	wf := WireFlags{Wire: strp("stateless")}
+	if opt, ok := wf.ServerTransportOption(); !ok || opt == nil {
+		t.Errorf("ServerTransportOption() for stateless = (%v,%v), want non-nil,true", opt, ok)
+	}
+	if opt, ok := wf.ClientOption(); !ok || opt == nil {
+		t.Errorf("ClientOption() for stateless = (%v,%v), want non-nil,true", opt, ok)
+	}
+
+	// Empty wire selects nothing (fall through to env/default).
+	empty := WireFlags{}
+	if opt, ok := empty.ServerTransportOption(); ok || opt != nil {
+		t.Errorf("ServerTransportOption() for empty = (%v,%v), want nil,false", opt, ok)
+	}
+	if opt, ok := empty.ClientOption(); ok || opt != nil {
+		t.Errorf("ClientOption() for empty = (%v,%v), want nil,false", opt, ok)
+	}
+
+	// Unrecognized token warns and falls through.
+	bad := WireFlags{Wire: strp("bogus")}
+	if _, ok := bad.ServerTransportOption(); ok {
+		t.Errorf("ServerTransportOption() for bogus = ok=true, want false")
+	}
+	if _, ok := bad.ClientOption(); ok {
+		t.Errorf("ClientOption() for bogus = ok=true, want false")
+	}
+}
+
+func TestWireFromArgs(t *testing.T) {
+	// WireFromArgs reads os.Args; this just verifies the parser shape on
+	// a synthetic slice would resolve. Since WireFromArgs scans os.Args
+	// directly, cover the resolution via a constructed WireFlags instead
+	// (the scan logic mirrors ExporterFromArgs, exercised by its own
+	// test). Here we assert the default (no relevant args) is empty.
+	wf := WireFromArgs()
+	if got := wf.serverToken(); got != "" {
+		t.Errorf("WireFromArgs with no wire args: serverToken() = %q, want empty", got)
+	}
+	if got := wf.clientToken(); got != "" {
+		t.Errorf("WireFromArgs with no wire args: clientToken() = %q, want empty", got)
+	}
+}

--- a/examples/list-ttl/main.go
+++ b/examples/list-ttl/main.go
@@ -49,6 +49,7 @@ func serve() {
 	ttlMs := flag.Int("ttl-ms", -1, "cache TTL in milliseconds (negative = unset, 0 = immediately stale, positive = fresh for N ms)")
 	scope := flag.String("cache-scope", "", `SEP-2549 cacheScope: "public", "private", or "" to omit`)
 	tel := common.RegisterTelemetryFlags(flag.CommandLine)
+	wire := common.RegisterWireFlags(flag.CommandLine)
 	flag.CommandLine.Parse(demokit.FilterArgs(os.Args[1:],
 		demokit.BoolFlag("--serve"),
 		demokit.ValueFlag("--url"),
@@ -91,6 +92,7 @@ func serve() {
 		Addr:           *addr,
 		TracerProvider: tp,
 		Options:        extraOpts,
+		Wire:           wire,
 		Register: func(srv *server.Server) {
 			srv.RegisterTool(
 				core.ToolDef{


### PR DESCRIPTION
## What
Adds a single `--wire` flag to `examples/common` for SEP-2575 wire-mode selection, so examples stop hand-rolling `stateless.ParseMode` / `client.ParseClientMode` and pick the wire from one CLI knob. Mirrors the existing telemetry-flag pattern (`RegisterTelemetryFlags`).

## How it works
- `common.RegisterWireFlags(flag.CommandLine)` (serve paths) / `common.WireFromArgs()` (walkthroughs, mirrors `ExporterFromArgs`) return a `*WireFlags`.
- `ServerConfig.Wire` field on `RunServer` applies the selection, after `TransportOptions` so the CLI flag overrides any hardcoded `WithStatelessMode`.
- One `--wire` drives both halves of a demo binary so server and client agree:
  - `legacy` -> server `ModeLegacyOnly` + client `ClientModeLegacyOnly`
  - `dual` -> server `ModeDual` + client `ClientModeAdaptive` (only asymmetric mapping: a Dual server speaks both wires, so the client probes then falls back)
  - `stateless` -> server `ModeStateless` + client `ClientModeStateless`
  - `""` (default) -> no selection; each side falls through to its env var / package default
- `--server-wire` / `--client-wire` override one side. Unrecognized tokens warn and fall through rather than binding a surprising wire.

## Scope
Foundation + one converted example (`list-ttl`, thematically apt: list caching is what sessionlessness makes safe). The sweep across the remaining non-UI examples is tracked in issue 824, done alongside the issue 478 dual-mode behavioral audit (same files). `examples/stateless` deliberately keeps its own `--mode` flag: the SEP-2575 conformance fixture drives it with no flag and needs a stateless default, not the `ModeDual` fall-through `--wire=""` gives.

## Verification
- `go test ./` in `examples/common` (new table test covers token resolution, dual->adaptive mapping, override precedence, unrecognized-token fall-through).
- Smoke: `list-ttl --serve --wire=stateless` -> legacy `initialize` returns HTTP 404 (stateless rejects legacy methods); default (no `--wire`) -> `initialize` HTTP 200 (`ModeDual` unchanged, no regression).

## Reviewer's guide
- `examples/common/wire_flag.go` — the helper (flags, token resolution, option builders).
- `examples/common/runserver.go` — `ServerConfig.Wire` field + apply point.
- `examples/list-ttl/main.go` — the conversion (register + `Wire: wire`).
- `examples/CONVENTIONS.md` — new "Wire selection" section.

Part of the SEP-2567 / SEP-2575 `stateless` tracking set.
