### PR TITLE
examples: adopt common --wire selection across non-UI examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,9 @@ cover-all: ## Run coverage across root + all sub-modules, generate per-module HT
 smoke: ## Run smoke tests (starts test servers, tests both transports via curl)
 	bash scripts/smoke-test.sh
 
+smoke-wire: ## Boot each --wire example and assert wire selection took effect (issue 824)
+	bash scripts/smoke-wire.sh
+
 # Conformance shims — actual logic lives in conformance/Makefile.
 
 testconfall: ## Run base + auth conformance only (delegates to conformance/Makefile)
@@ -597,5 +600,5 @@ setup: setup-tools setup-hooks ## Full development setup
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-18s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: build test test-race test-v cover cover-html cover-func cover-all test-auth test-ui test-skills test-mcpskills build-mcpskills test-mcpskills-walkthrough test-protogen test-e2e test-experimental test-apps-playwright test-apps-playwright-docker test-apps-playwright-all test-apps-playwright-docker-all refresh-visual-gallery release-audit-apps demo-app demo-upstream testkcl testkcl-auto testall test-report smoke testconfall testconf testconfauth testconf-tasks testconf-tasks-v2 testconf-mrtr testconf-file-inputs testconf-auth-server testconf-elicitation testconf-skills refresh-conformance check-conformance-stale check-local-suites-stale refresh-apps-compat-report check-apps-compat-stale vet lint vulncheck seccheck secrets verify-submodule-deps audit ci ci-full serve serve-streamable serve-both tidy tidy-all bump-root collect-walkthroughs ghbuild ghserve ghdeploy tag tag-push setup-tools setup-hooks setup upkcl downkcl kcllogs build-bridge help
+.PHONY: build test test-race test-v cover cover-html cover-func cover-all test-auth test-ui test-skills test-mcpskills build-mcpskills test-mcpskills-walkthrough test-protogen test-e2e test-experimental test-apps-playwright test-apps-playwright-docker test-apps-playwright-all test-apps-playwright-docker-all refresh-visual-gallery release-audit-apps demo-app demo-upstream testkcl testkcl-auto testall test-report smoke smoke-wire testconfall testconf testconfauth testconf-tasks testconf-tasks-v2 testconf-mrtr testconf-file-inputs testconf-auth-server testconf-elicitation testconf-skills refresh-conformance check-conformance-stale check-local-suites-stale refresh-apps-compat-report check-apps-compat-stale vet lint vulncheck seccheck secrets verify-submodule-deps audit ci ci-full serve serve-streamable serve-both tidy tidy-all bump-root collect-walkthroughs ghbuild ghserve ghdeploy tag tag-push setup-tools setup-hooks setup upkcl downkcl kcllogs build-bridge help
 .DEFAULT_GOAL := help

--- a/examples/auth/bearer/main.go
+++ b/examples/auth/bearer/main.go
@@ -17,6 +17,7 @@ import (
 
 func main() {
 	addr := flag.String("addr", ":8081", "listen address")
+	wire := mcpcommon.RegisterWireFlags(flag.CommandLine)
 	flag.Parse()
 
 	log.Printf("Token: my-secret-token")
@@ -26,6 +27,7 @@ func main() {
 		Name:    "auth-bearer",
 		Version: "1.0",
 		Addr:    *addr,
+		Wire:    wire,
 		Options: []server.Option{
 			server.WithBearerToken("my-secret-token"),
 		},

--- a/examples/auth/jwt/main.go
+++ b/examples/auth/jwt/main.go
@@ -21,6 +21,7 @@ import (
 
 func main() {
 	addr := flag.String("addr", ":8082", "listen address")
+	wire := mcpcommon.RegisterWireFlags(flag.CommandLine)
 	flag.Parse()
 
 	env := common.NewEnv([]string{"read", "write"})
@@ -41,6 +42,7 @@ func main() {
 		Name:    "auth-jwt",
 		Version: "1.0",
 		Addr:    *addr,
+		Wire:    wire,
 		Options: []server.Option{
 			server.WithAuth(validator),
 		},

--- a/examples/auth/main.go
+++ b/examples/auth/main.go
@@ -464,6 +464,7 @@ resp, _ := http.DefaultClient.Do(req) // resp.StatusCode == 403`),
 func serve() {
 	addr := flag.String("addr", ":8080", "listen address")
 	tel := common.RegisterTelemetryFlags(flag.CommandLine)
+	wire := common.RegisterWireFlags(flag.CommandLine)
 	flag.CommandLine.Parse(demokit.FilterArgs(os.Args[1:],
 		demokit.BoolFlag("--serve"),
 		demokit.ValueFlag("--url"),
@@ -525,6 +526,7 @@ func serve() {
 		Addr:           *addr,
 		Logger:         logger,
 		TracerProvider: tp,
+		Wire:           wire,
 		Options: []server.Option{
 			server.WithAuth(validator),
 			server.WithPublicMethods("initialize", "notifications/initialized", "tools/list", "prompts/list", "ping"),

--- a/examples/auth/public-discovery/main.go
+++ b/examples/auth/public-discovery/main.go
@@ -21,6 +21,7 @@ import (
 
 func main() {
 	addr := flag.String("addr", ":8085", "listen address")
+	wire := mcpcommon.RegisterWireFlags(flag.CommandLine)
 	flag.Parse()
 
 	env := common.NewEnv([]string{"read"})
@@ -45,6 +46,7 @@ func main() {
 		Name:    "auth-public-discovery",
 		Version: "1.0",
 		Addr:    *addr,
+		Wire:    wire,
 		Options: []server.Option{
 			server.WithAuth(validator),
 			server.WithPublicMethods("initialize", "notifications/initialized", "tools/list", "prompts/list", "ping"),

--- a/examples/auth/scopes/main.go
+++ b/examples/auth/scopes/main.go
@@ -21,6 +21,7 @@ import (
 
 func main() {
 	addr := flag.String("addr", ":8083", "listen address")
+	wire := mcpcommon.RegisterWireFlags(flag.CommandLine)
 	flag.Parse()
 
 	env := common.NewEnv([]string{"read", "write", "admin"})
@@ -46,6 +47,7 @@ func main() {
 		Name:    "auth-scopes",
 		Version: "1.0",
 		Addr:    *addr,
+		Wire:    wire,
 		Options: []server.Option{
 			server.WithAuth(validator),
 		},

--- a/examples/auth/session-binding/main.go
+++ b/examples/auth/session-binding/main.go
@@ -21,6 +21,7 @@ import (
 
 func main() {
 	addr := flag.String("addr", ":8084", "listen address")
+	wire := mcpcommon.RegisterWireFlags(flag.CommandLine)
 	flag.Parse()
 
 	env := common.NewEnv([]string{"read"})
@@ -45,6 +46,7 @@ func main() {
 		Name:    "auth-session-binding",
 		Version: "1.0",
 		Addr:    *addr,
+		Wire:    wire,
 		Options: []server.Option{
 			server.WithAuth(validator),
 		},

--- a/examples/auth/step-up-keycloak/main.go
+++ b/examples/auth/step-up-keycloak/main.go
@@ -70,6 +70,7 @@ func main() {
 	addr := flag.String("addr", ":3020", "listen address")
 	kcURL := flag.String("keycloak-url", envOr("KEYCLOAK_URL", defaultKeycloakURL), "Keycloak base URL")
 	realm := flag.String("realm", envOr("KC_REALM", defaultRealm), "Keycloak realm name")
+	wire := mcpcommon.RegisterWireFlags(flag.CommandLine)
 	flag.Parse()
 
 	realmURL := fmt.Sprintf("%s/realms/%s", *kcURL, *realm)
@@ -109,6 +110,7 @@ func main() {
 		Name:    "step-up-keycloak",
 		Version: "0.1.0-experimental",
 		Addr:    *addr,
+		Wire:    wire,
 		Options: []server.Option{
 			server.WithAuth(validator),
 		},

--- a/examples/auth/unified/main.go
+++ b/examples/auth/unified/main.go
@@ -23,6 +23,7 @@ import (
 
 func main() {
 	addr := flag.String("addr", ":8080", "listen address")
+	wire := mcpcommon.RegisterWireFlags(flag.CommandLine)
 	flag.Parse()
 
 	env := common.NewEnv([]string{"read", "write", "admin"})
@@ -60,6 +61,7 @@ func main() {
 		Name:    "auth-unified",
 		Version: "1.0",
 		Addr:    *addr,
+		Wire:    wire,
 		Options: []server.Option{
 			server.WithAuth(validator),
 			server.WithPublicMethods("initialize", "notifications/initialized", "tools/list", "prompts/list", "ping"),

--- a/examples/elicitation/main.go
+++ b/examples/elicitation/main.go
@@ -193,9 +193,9 @@ var rpcErr *client.RPCError
 if errors.As(err, &rpcErr) {
     var data struct {
         Authorization struct {
-            AuthorizationContextID string ` + "`json:\"authorizationContextId\"`" + `
-        } ` + "`json:\"authorization\"`" + `
-        Elicitations []struct{ URL string ` + "`json:\"url\"`" + ` } ` + "`json:\"elicitations\"`" + `
+            AuthorizationContextID string `+"`json:\"authorizationContextId\"`"+`
+        } `+"`json:\"authorization\"`"+`
+        Elicitations []struct{ URL string `+"`json:\"url\"`"+` } `+"`json:\"elicitations\"`"+`
     }
     raw, _ := json.Marshal(rpcErr.Data)
     json.Unmarshal(raw, &data)
@@ -335,6 +335,7 @@ func openBrowser(url string) {
 func serve() {
 	addr := flag.String("addr", ":8080", "listen address")
 	tel := common.RegisterTelemetryFlags(flag.CommandLine)
+	wire := common.RegisterWireFlags(flag.CommandLine)
 	flag.CommandLine.Parse(demokit.FilterArgs(os.Args[1:],
 		demokit.BoolFlag("--serve"),
 		demokit.ValueFlag("--url"),
@@ -369,6 +370,7 @@ func serve() {
 		Addr:           *addr,
 		Logger:         logger,
 		TracerProvider: tp,
+		Wire:           wire,
 		Register: func(srv *server.Server) {
 			srv.RegisterTool(
 				core.ToolDef{

--- a/examples/events/kitchen-sink/main.go
+++ b/examples/events/kitchen-sink/main.go
@@ -60,14 +60,15 @@ func serve() {
 	alertEvery := flag.Duration("alert-every", defaultAlertEvery, "synthetic alert feeder cadence")
 	presenceEvery := flag.Duration("presence-every", defaultPresenceEvery, "synthetic presence feeder cadence")
 	tel := common.RegisterTelemetryFlags(flag.CommandLine)
+	wire := common.RegisterWireFlags(flag.CommandLine)
+	// FilterArgs STRIPS the flags listed here. Strip only the --serve
+	// dispatch flag (main() consumes it via os.Args; flag.Parse would
+	// otherwise error on it). The example's own flags (--addr,
+	// --chat-every, --wire, --exporter, ...) must NOT be stripped — they
+	// reach flag.Parse via the `--flag=value` form. (They were all
+	// previously stripped here, which silently disabled --addr.)
 	flag.CommandLine.Parse(demokit.FilterArgs(os.Args[1:],
 		demokit.BoolFlag("--serve"),
-		demokit.ValueFlag("--addr"),
-		demokit.ValueFlag("--chat-every"),
-		demokit.ValueFlag("--alert-every"),
-		demokit.ValueFlag("--presence-every"),
-		demokit.ValueFlag("--exporter"),
-		demokit.ValueFlag("--otlp-endpoint"),
 	))
 
 	// SEP-414 P6 observability wiring (issue 667). Default selector
@@ -95,14 +96,18 @@ func serve() {
 
 	log.Printf("[server] kitchen-sink listening on %s (MCP at /mcp; /inject for deterministic events)", *addr)
 
-	if err := wired.srv.ListenAndServe(
+	transportOpts := []server.TransportOption{
 		server.WithStreamableHTTP(true),
 		server.WithSSE(true),
 		server.WithEventStore(gohttp.NewMemoryEventStore(eventStoreCap)),
 		server.WithMux(func(mux *http.ServeMux) {
 			mux.HandleFunc("POST /inject", injectHandlerFor(wired))
 		}),
-	); err != nil {
+	}
+	if opt, ok := wire.ServerTransportOption(); ok {
+		transportOpts = append(transportOpts, opt)
+	}
+	if err := wired.srv.ListenAndServe(transportOpts...); err != nil {
 		log.Fatalf("ListenAndServe: %v", err)
 	}
 }

--- a/examples/events/kitchen-sink/walkthrough.go
+++ b/examples/events/kitchen-sink/walkthrough.go
@@ -34,6 +34,7 @@ func runDemo() {
 	serverURL := common.ServerURL()
 	mcpURL := serverURL + "/mcp"
 	injectURL := serverURL + "/inject"
+	wire := common.WireFromArgs()
 
 	demo := demokit.New("MCP Events — kitchen-sink (per-subscription showcase)").
 		Dir("events/kitchen-sink").
@@ -73,7 +74,11 @@ func runDemo() {
 		DashedArrow("Server", "Host", "serverInfo + capabilities").
 		Note("Vanilla MCP initialize. The events extension declares no new capability; events/* methods are registered server-side via the library.").
 		Run(func(_ demokit.StepContext) *demokit.StepResult {
-			c = client.NewClient(mcpURL, core.ClientInfo{Name: "kitchen-sink-host", Version: "1.0"})
+			var opts []client.ClientOption
+			if opt, ok := wire.ClientOption(); ok {
+				opts = append(opts, opt)
+			}
+			c = client.NewClient(mcpURL, core.ClientInfo{Name: "kitchen-sink-host", Version: "1.0"}, opts...)
 			if err := c.Connect(); err != nil {
 				fmt.Printf("    ERROR: %v\n    Start the server with: make serve\n", err)
 			} else {

--- a/examples/file-inputs/main.go
+++ b/examples/file-inputs/main.go
@@ -45,6 +45,7 @@ func main() {
 func serve() {
 	addr := flag.String("addr", ":8080", "listen address")
 	tel := common.RegisterTelemetryFlags(flag.CommandLine)
+	wire := common.RegisterWireFlags(flag.CommandLine)
 	flag.CommandLine.Parse(demokit.FilterArgs(os.Args[1:],
 		demokit.BoolFlag("--serve"),
 		demokit.ValueFlag("--url"),
@@ -78,6 +79,7 @@ func serve() {
 		Name:           "file-inputs-demo",
 		Addr:           *addr,
 		TracerProvider: tp,
+		Wire:           wire,
 		Options: []server.Option{
 			// MCP Apps extension powers the in-iframe file picker apps
 			// registered in apps.go (SEP-2356 Phase 2.1).

--- a/examples/file-inputs/walkthrough.go
+++ b/examples/file-inputs/walkthrough.go
@@ -35,9 +35,9 @@ var fixtureAppendixPDF []byte
 //go:embed testdata/README.txt
 var fixtureREADME []byte
 
-
 func runDemo() {
 	serverURL := common.ServerURL()
+	wire := common.WireFromArgs()
 
 	tel := common.ExporterFromArgs()
 	tp, shutdown, err := commonotel.SetupClientTelemetry(context.Background(),
@@ -85,10 +85,16 @@ func runDemo() {
 		DashedArrow("Server", "Host", "serverInfo + capabilities").
 		Note("`client.NewClient(...)` + `client.WithFileInputs()` + `Connect()`. The `WithFileInputs` option advertises `capabilities.fileInputs={}` on the wire — without it, the server would strip `x-mcp-file` from every tool's inputSchema (per SEP-2356 cap-gating). The next step inspects the raw response to confirm the keyword survives.").
 		Run(func(ctx demokit.StepContext) *demokit.StepResult {
-			c = client.NewClient(serverURL+"/mcp",
-				core.ClientInfo{Name: "file-inputs-host", Version: "1.0"},
+			opts := []client.ClientOption{
 				client.WithFileInputs(),
 				client.WithTracerProvider(tp),
+			}
+			if opt, ok := wire.ClientOption(); ok {
+				opts = append(opts, opt)
+			}
+			c = client.NewClient(serverURL+"/mcp",
+				core.ClientInfo{Name: "file-inputs-host", Version: "1.0"},
+				opts...,
 			)
 			if err := c.Connect(); err != nil {
 				fmt.Printf("    ERROR: %v\n    Start the server with: make serve\n", err)
@@ -523,5 +529,3 @@ func flagValue(name string) string {
 	}
 	return ""
 }
-
-

--- a/examples/fine-grained-auth/main.go
+++ b/examples/fine-grained-auth/main.go
@@ -682,6 +682,7 @@ func requestToken(b bootstrapInfo, scopes []string, authzDetails []map[string]an
 func serve() {
 	addr := flag.String("addr", ":8080", "listen address")
 	tel := common.RegisterTelemetryFlags(flag.CommandLine)
+	wire := common.RegisterWireFlags(flag.CommandLine)
 	flag.CommandLine.Parse(demokit.FilterArgs(os.Args[1:],
 		demokit.BoolFlag("--serve"),
 		demokit.ValueFlag("--url"),
@@ -761,6 +762,7 @@ func serve() {
 		Addr:           *addr,
 		Logger:         logger,
 		TracerProvider: tp,
+		Wire:           wire,
 		Options: []server.Option{
 			server.WithAuth(validator),
 			server.WithMiddleware(server.ToolCallLogger(logger)),
@@ -1158,4 +1160,3 @@ func nestedString(m map[string]any, path ...string) (string, bool) {
 	s, ok := cur.(string)
 	return s, ok
 }
-

--- a/examples/list-ttl/walkthrough.go
+++ b/examples/list-ttl/walkthrough.go
@@ -15,6 +15,7 @@ import (
 
 func runDemo() {
 	serverURL := common.ServerURL()
+	wire := common.WireFromArgs()
 
 	tel := common.ExporterFromArgs()
 	tp, shutdown, err := commonotel.SetupClientTelemetry(context.Background(),
@@ -87,9 +88,15 @@ echo "SID=$SID"`).Default(),
 if err := c.Connect(); err != nil { /* server not up — run: make serve */ }`),
 		).
 		Run(func(ctx demokit.StepContext) (result *demokit.StepResult) {
+			opts := []client.ClientOption{
+				client.WithTracerProvider(tp),
+			}
+			if opt, ok := wire.ClientOption(); ok {
+				opts = append(opts, opt)
+			}
 			c = client.NewClient(serverURL+"/mcp",
 				core.ClientInfo{Name: "list-ttl-host", Version: "1.0"},
-				client.WithTracerProvider(tp),
+				opts...,
 			)
 			if err := c.Connect(); err != nil {
 				fmt.Printf("    ERROR: %v\n    Start the server with: make serve\n", err)

--- a/examples/mrtr/main.go
+++ b/examples/mrtr/main.go
@@ -25,7 +25,7 @@
 //   - test_incomplete_result_multiple_inputs (A5) multiple inputRequests in one round
 //   - test_incomplete_result_multi_round     (A6) two rounds of elicitation
 //   - test_incomplete_result_elicitation     (A7) graceful handling when client
-//                                                 sends a wrong inputResponses key
+//     sends a wrong inputResponses key
 //
 // The MRTR loop is server-driven and stateless: the server returns
 // InputRequiredResult{inputRequests, requestState}; the client retries the
@@ -66,6 +66,7 @@ func serve() {
 	addr := flag.String("addr", ":8080", "listen address")
 	signingKey := flag.String("signing-key", "mrtr-demo-signing-key", "HMAC key for requestState signing (empty = plaintext mode)")
 	tel := common.RegisterTelemetryFlags(flag.CommandLine)
+	wire := common.RegisterWireFlags(flag.CommandLine)
 	flag.CommandLine.Parse(demokit.FilterArgs(os.Args[1:],
 		demokit.BoolFlag("--serve"),
 		demokit.ValueFlag("--url"),
@@ -90,6 +91,7 @@ func serve() {
 		Name:           "mrtr-demo",
 		Addr:           *addr,
 		TracerProvider: tp,
+		Wire:           wire,
 		Options:        extraOpts,
 		Register: func(srv *server.Server) {
 			registerMRTRTools(srv)
@@ -357,17 +359,17 @@ func multiRoundTool(ctx core.ToolContext, req core.ToolRequest) (core.ToolRespon
 // mrtrTaskCompositionTool walks two distinct phases that meet at the GoAsync
 // sentinel:
 //
-//   Phase 1 (synchronous, no TaskContext):
-//     - If user_name hasn't been answered yet → return InputRequiredResult via
-//       ctx.RequestInput. taskV2Middleware sees IncompleteResult and lets it
-//       through; the client sees a normal MRTR InputRequiredResult.
-//     - Once user_name is present → return ToolResult{GoAsync: true}.
-//       taskV2Middleware mints a fresh task and spawns the continuation.
+//	Phase 1 (synchronous, no TaskContext):
+//	  - If user_name hasn't been answered yet → return InputRequiredResult via
+//	    ctx.RequestInput. taskV2Middleware sees IncompleteResult and lets it
+//	    through; the client sees a normal MRTR InputRequiredResult.
+//	  - Once user_name is present → return ToolResult{GoAsync: true}.
+//	    taskV2Middleware mints a fresh task and spawns the continuation.
 //
-//   Phase 2 (in the continuation goroutine, TaskContext attached):
-//     - Detect the TaskContext, do the "expensive" work, return a normal
-//       ToolResult. taskV2Middleware stores it as the task's terminal result;
-//       the client retrieves it via tasks/get.
+//	Phase 2 (in the continuation goroutine, TaskContext attached):
+//	  - Detect the TaskContext, do the "expensive" work, return a normal
+//	    ToolResult. taskV2Middleware stores it as the task's terminal result;
+//	    the client retrieves it via tasks/get.
 //
 // Per SEP-2663 spec separation rules:
 //   - MRTR requestState is NOT carried into the task's requestState (the task

--- a/examples/mrtr/walkthrough.go
+++ b/examples/mrtr/walkthrough.go
@@ -15,6 +15,7 @@ import (
 
 func runDemo() {
 	serverURL := common.ServerURL()
+	wire := common.WireFromArgs()
 
 	tel := common.ExporterFromArgs()
 	tp, shutdown, err := commonotel.SetupClientTelemetry(context.Background(),
@@ -91,8 +92,7 @@ c := client.NewClient(serverURL+"/mcp",
 if err := c.Connect(); err != nil { /* server not up — run: make serve */ }`),
 		).
 		Run(func(ctx demokit.StepContext) (result *demokit.StepResult) {
-			c = client.NewClient(serverURL+"/mcp",
-				core.ClientInfo{Name: "mrtr-demo-host", Version: "1.0"},
+			opts := []client.ClientOption{
 				client.WithElicitationHandler(func(ctx context.Context, req core.ElicitationRequest) (core.ElicitationResult, error) {
 					// Canned answer — accepts and returns Alice for any name elicitation.
 					return core.ElicitationResult{
@@ -112,6 +112,13 @@ if err := c.Connect(); err != nil { /* server not up — run: make serve */ }`),
 					return []core.Root{{URI: "file:///demo/root", Name: "Demo Root"}}, nil
 				}),
 				client.WithTracerProvider(tp),
+			}
+			if opt, ok := wire.ClientOption(); ok {
+				opts = append(opts, opt)
+			}
+			c = client.NewClient(serverURL+"/mcp",
+				core.ClientInfo{Name: "mrtr-demo-host", Version: "1.0"},
+				opts...,
 			)
 			if err := c.Connect(); err != nil {
 				fmt.Printf("    ERROR: %v\n    Start the server with: make serve\n", err)

--- a/examples/skills/main.go
+++ b/examples/skills/main.go
@@ -74,10 +74,10 @@ func serve() {
 	sourceExtra := flag.String("extra", "",
 		"comma-separated ad-hoc sub-mounts for --source=multi, format prefix:./path (e.g. science:./scienceskills,math:./mathskills)")
 	tel := common.RegisterTelemetryFlags(flag.CommandLine)
+	wire := common.RegisterWireFlags(flag.CommandLine)
 	flag.CommandLine.Parse(demokit.FilterArgs(os.Args[1:],
-		demokit.BoolFlag("--serve"),  // dual-mode dispatch; override demokit's value-form default
-		demokit.ValueFlag("--url"),   // walkthrough-side flag; strip from serve args
-		demokit.ValueFlag("--wire"),  // walkthrough-side flag; strip from serve args
+		demokit.BoolFlag("--serve"), // dual-mode dispatch; override demokit's value-form default
+		demokit.ValueFlag("--url"),  // walkthrough-side flag; strip from serve args
 	))
 
 	tp, shutdown, err := commonotel.SetupTelemetry(context.Background(),
@@ -132,6 +132,7 @@ func serve() {
 		Addr:           *addr,
 		LogPrefix:      "[skills] ",
 		TracerProvider: tp,
+		Wire:           wire,
 		Register: func(srv *server.Server) {
 			provider.RegisterWith(srv)
 			registerRefreshTool(srv, provider)
@@ -167,4 +168,3 @@ func registerRefreshTool(srv *server.Server, provider *skills.Provider) {
 	)
 	srv.RegisterTool(tool.ToolDef, tool.Handler)
 }
-

--- a/examples/tasks-v2/main.go
+++ b/examples/tasks-v2/main.go
@@ -45,6 +45,7 @@ func main() {
 func serve() {
 	addr := flag.String("addr", ":8080", "listen address")
 	tel := common.RegisterTelemetryFlags(flag.CommandLine)
+	wire := common.RegisterWireFlags(flag.CommandLine)
 	flag.CommandLine.Parse(demokit.FilterArgs(os.Args[1:],
 		demokit.BoolFlag("--serve"),
 		demokit.ValueFlag("--url"),
@@ -75,6 +76,7 @@ func serve() {
 		Name:           "tasks-v2-demo",
 		Addr:           *addr,
 		TracerProvider: tp,
+		Wire:           wire,
 		Register: func(srv *server.Server) {
 			registerTasksV2DemoTools(srv)
 		},
@@ -241,11 +243,11 @@ func registerTasksV2DemoTools(srv *server.Server) {
 			}
 
 			var (
-				wg          sync.WaitGroup
-				nameRes     core.ElicitationResult
-				confirmRes  core.ElicitationResult
-				nameErr     error
-				confirmErr  error
+				wg         sync.WaitGroup
+				nameRes    core.ElicitationResult
+				confirmRes core.ElicitationResult
+				nameErr    error
+				confirmErr error
 			)
 			wg.Add(2)
 			go func() {

--- a/examples/tasks-v2/walkthrough.go
+++ b/examples/tasks-v2/walkthrough.go
@@ -17,6 +17,7 @@ import (
 
 func runDemo() {
 	serverURL := common.ServerURL()
+	wire := common.WireFromArgs()
 
 	tel := common.ExporterFromArgs()
 	tp, shutdown, err := commonotel.SetupClientTelemetry(context.Background(),
@@ -94,8 +95,7 @@ if err := c.Connect(); err != nil { panic(err) }
 _ = c.ServerSupportsExtension(core.TasksExtensionID) // true once negotiated`),
 		).
 		Run(func(ctx demokit.StepContext) (result *demokit.StepResult) {
-			c = client.NewClient(serverURL+"/mcp",
-				core.ClientInfo{Name: "tasks-v2-host", Version: "1.0"},
+			opts := []client.ClientOption{
 				client.WithGetSSEStream(),
 				client.WithTasksExtension(),
 				client.WithNotificationCallback(func(method string, params any) {
@@ -104,6 +104,13 @@ _ = c.ServerSupportsExtension(core.TasksExtensionID) // true once negotiated`),
 					}
 				}),
 				client.WithTracerProvider(tp),
+			}
+			if opt, ok := wire.ClientOption(); ok {
+				opts = append(opts, opt)
+			}
+			c = client.NewClient(serverURL+"/mcp",
+				core.ClientInfo{Name: "tasks-v2-host", Version: "1.0"},
+				opts...,
 			)
 			if err := c.Connect(); err != nil {
 				fmt.Printf("    ERROR: %v\n    Start the server with: make serve\n", err)

--- a/examples/tasks/main.go
+++ b/examples/tasks/main.go
@@ -44,6 +44,7 @@ func main() {
 func serve() {
 	addr := flag.String("addr", ":8080", "listen address")
 	tel := common.RegisterTelemetryFlags(flag.CommandLine)
+	wire := common.RegisterWireFlags(flag.CommandLine)
 	flag.CommandLine.Parse(demokit.FilterArgs(os.Args[1:],
 		demokit.BoolFlag("--serve"),
 		demokit.ValueFlag("--url"),
@@ -74,6 +75,7 @@ func serve() {
 		Name:           "tasks-demo",
 		Addr:           *addr,
 		TracerProvider: tp,
+		Wire:           wire,
 		Register:       registerAll,
 	}); err != nil {
 		log.Fatal(err)

--- a/examples/tasks/walkthrough.go
+++ b/examples/tasks/walkthrough.go
@@ -16,6 +16,7 @@ import (
 
 func runDemo() {
 	serverURL := common.ServerURL()
+	wire := common.WireFromArgs()
 
 	tel := common.ExporterFromArgs()
 	tp, shutdown, err := commonotel.SetupClientTelemetry(context.Background(),
@@ -90,8 +91,7 @@ if err := c.Connect(); err != nil { panic(err) }
 tools, _ := c.ListTools(ctx.Ctx) // each tool carries Execution.TaskSupport metadata`),
 		).
 		Run(func(ctx demokit.StepContext) (result *demokit.StepResult) {
-			c = client.NewClient(serverURL+"/mcp",
-				core.ClientInfo{Name: "tasks-demo-host", Version: "1.0"},
+			opts := []client.ClientOption{
 				client.WithGetSSEStream(),
 				client.WithNotificationCallback(func(method string, params any) {
 					// Show progress notifications inline while we poll.
@@ -100,6 +100,13 @@ tools, _ := c.ListTools(ctx.Ctx) // each tool carries Execution.TaskSupport meta
 					}
 				}),
 				client.WithTracerProvider(tp),
+			}
+			if opt, ok := wire.ClientOption(); ok {
+				opts = append(opts, opt)
+			}
+			c = client.NewClient(serverURL+"/mcp",
+				core.ClientInfo{Name: "tasks-demo-host", Version: "1.0"},
+				opts...,
 			)
 			if err := c.Connect(); err != nil {
 				fmt.Printf("    ERROR: %v\n    Start the server with: make serve\n", err)

--- a/scripts/smoke-wire.sh
+++ b/scripts/smoke-wire.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Smoke test for the examples/common --wire selection (issue 824).
+#
+# For each --wire-enabled example, boots it twice and asserts the wire
+# selection actually reached the transport:
+#   --wire=stateless  -> legacy `initialize` POST returns HTTP 404
+#                        (initialize is a removed method on the SEP-2575
+#                        stateless wire; the dispatcher 404s it)
+#   default (no flag) -> legacy `initialize` POST returns HTTP 200
+#                        (ModeDual still serves the legacy handshake)
+#
+# This guards the mechanical sweep against regression: a broken Wire
+# wiring would leave both modes at 200 (flag ignored) or both at 404.
+#
+# Examples needing external infra (Keycloak) are listed in SKIP with a
+# reason and printed, never silently dropped — their --wire wiring is
+# covered by `go build` in CI, just not booted here.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+PORT=18300
+PASS=0
+FAIL=0
+# When set, the probe uses this token instead of grepping the server log
+# (for examples whose token comes from an external AS, e.g. Keycloak).
+EXPLICIT_TOKEN=""
+
+# Track the currently-booted example so an interrupt (Ctrl-C / SIGTERM)
+# doesn't orphan a server holding a port. Cleanup runs on normal exit
+# AND on signal.
+CHILD_PID=""
+cleanup() {
+	[ -n "$CHILD_PID" ] && kill "$CHILD_PID" 2>/dev/null
+	[ -n "$CHILD_PID" ] && wait "$CHILD_PID" 2>/dev/null
+	rm -rf "$TMP"
+}
+trap cleanup EXIT INT TERM
+
+INIT='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"smoke","version":"1"}}}'
+
+# check <name> <dir> <build-pkg> <serve|direct> [extra args...]
+#   serve  -> invoke with `--serve --addr=:PORT` (dual-mode dispatch examples)
+#   direct -> invoke with `-addr=:PORT` (always-serve examples, e.g. auth subs)
+check() {
+	local name="$1" dir="$2" pkg="$3" style="$4"
+	shift 4
+	local extra=("$@")
+	local bin="$TMP/$name"
+
+	if ! (cd "$ROOT/$dir" && go build -o "$bin" "$pkg") 2>"$TMP/$name.build"; then
+		echo "BUILD FAIL $name"
+		sed 's/^/    /' "$TMP/$name.build"
+		FAIL=$((FAIL + 1))
+		return
+	fi
+
+	local mode want
+	for mode in stateless default; do
+		PORT=$((PORT + 1))
+		local addr=":$PORT"
+		local args=()
+		[ "$style" = serve ] && args+=("--serve")
+		args+=("--addr=$addr" ${extra[@]+"${extra[@]}"})
+		[ "$mode" = stateless ] && args+=("--wire=stateless")
+
+		"$bin" "${args[@]}" >"$TMP/$name.$mode.log" 2>&1 &
+		local pid=$!
+		CHILD_PID=$pid
+
+		# Readiness probe hits "/" (fast 404), NOT "/mcp" — a GET to /mcp
+		# opens a long-lived SSE stream that would hang the probe.
+		local up=""
+		for _ in $(seq 1 60); do
+			if curl -s -m 1 -o /dev/null "http://localhost$addr/" 2>/dev/null; then up=1; break; fi
+			kill -0 "$pid" 2>/dev/null || break
+			sleep 0.1
+		done
+
+		# Auth examples gate `initialize` behind a bearer token, so an
+		# unauthenticated probe gets 401 on BOTH wires and can't observe
+		# the flip. They print a token at startup — grab it (a "Bearer
+		# <tok>" line, else a bare JWT) and authenticate the probe so the
+		# wire flip becomes visible (200 dual / 404 stateless).
+		local auth=()
+		local tok="$EXPLICIT_TOKEN"
+		if [ -z "$tok" ]; then
+			# Prefer a real JWT (jwt/scopes/session-binding mint these).
+			# Fall back to a Bearer token whose char class excludes '<'
+			# '>' so the help line "...Authorization: Bearer <token>):"
+			# some examples print doesn't get grabbed as the literal
+			# placeholder (bearer example prints a static token).
+			tok=$(grep -oE 'eyJ[A-Za-z0-9_.-]+' "$TMP/$name.$mode.log" 2>/dev/null | head -1)
+			[ -z "$tok" ] && tok=$(grep -oE 'Bearer [A-Za-z0-9._-]+' "$TMP/$name.$mode.log" 2>/dev/null | head -1 | awk '{print $2}')
+		fi
+		[ -n "$tok" ] && auth=(-H "Authorization: Bearer $tok")
+
+		local code="dead"
+		if [ -n "$up" ]; then
+			code=$(curl -s -m 5 -o /dev/null -w '%{http_code}' -X POST "http://localhost$addr/mcp" \
+				-H 'content-type: application/json' -H 'Mcp-Session-Id: smoke' \
+				${auth[@]+"${auth[@]}"} -d "$INIT")
+		fi
+		kill "$pid" 2>/dev/null
+		wait "$pid" 2>/dev/null
+		CHILD_PID=""
+
+		[ "$mode" = stateless ] && want=404 || want=200
+		if [ "$code" = "$want" ]; then
+			echo "ok   $name [$mode] initialize=$code"
+			PASS=$((PASS + 1))
+		else
+			echo "FAIL $name [$mode] initialize=$code want=$want  (log: $TMP/$name.$mode.log)"
+			sed 's/^/    /' "$TMP/$name.$mode.log" | tail -4
+			FAIL=$((FAIL + 1))
+		fi
+	done
+}
+
+echo "=== wire-selection smoke (issue 824) ==="
+
+# Plain examples — unauthenticated `initialize` reaches the dispatcher.
+check tasks         examples/tasks               .                  serve
+check tasks-v2      examples/tasks-v2            .                  serve
+check mrtr          examples/mrtr                .                  serve
+check file-inputs   examples/file-inputs         .                  serve
+check list-ttl      examples/list-ttl            .                  serve
+check elicitation   examples/elicitation         .                  serve
+check skills        examples/skills              .                  serve "--skills=$ROOT/examples/skills/skills"
+check kitchen-sink  examples/events/kitchen-sink .                  serve
+
+# Auth examples — the probe picks up the token each prints at startup.
+# auth-demo / public-discovery / unified allow an anonymous initialize;
+# jwt / bearer / scopes / session-binding gate it (token-authenticated).
+check auth-demo     examples/auth         .                  serve
+check auth-pubdisc  examples/auth         ./public-discovery direct
+check auth-unified  examples/auth         ./unified          direct
+check auth-jwt      examples/auth         ./jwt              direct
+check auth-bearer   examples/auth         ./bearer           direct
+check auth-scopes   examples/auth         ./scopes           direct
+check auth-sessbind examples/auth         ./session-binding  direct
+
+# step-up-keycloak needs a live Keycloak (it discovers the realm at boot).
+# Run it ONLY when Keycloak is already up — never bring it up here. Mint a
+# client-credentials token from the test realm to authenticate the probe.
+KC_PORT="${KC_PORT:-8180}"
+KC_REALM="${KC_REALM:-mcpkit-test}"
+KC_REALM_URL="http://localhost:$KC_PORT/realms/$KC_REALM"
+if curl -sf -m 2 -o /dev/null "$KC_REALM_URL" 2>/dev/null; then
+	EXPLICIT_TOKEN=$(curl -s -m 5 -X POST "$KC_REALM_URL/protocol/openid-connect/token" \
+		-d grant_type=client_credentials \
+		-d client_id=mcp-confidential \
+		-d client_secret=mcp-test-secret-for-confidential 2>/dev/null \
+		| grep -oE '"access_token":"[^"]+"' | sed 's/.*:"//; s/"$//')
+	if [ -n "$EXPLICIT_TOKEN" ]; then
+		echo "(keycloak up on :$KC_PORT — minted client-credentials token)"
+		check auth-step-up-kc examples/auth ./step-up-keycloak direct
+	else
+		echo "SKIP auth-step-up-kc — keycloak up but client-credentials token fetch failed"
+	fi
+	EXPLICIT_TOKEN=""
+else
+	echo "SKIP auth-step-up-kc — Keycloak not running on :$KC_PORT (start it with: make upkcl)"
+fi
+
+echo
+echo "SKIPPED (--wire wiring covered by 'go build'; not booted here):"
+echo "  fine-grained-auth"
+echo "    — initialize is auth-gated and serve() prints no static token (a real"
+echo "      token needs an OAuth flow against the AS), so the probe can't authenticate."
+
+echo
+echo "=== wire smoke: $PASS pass / $FAIL fail ==="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## What changes
Adopts the `examples/common` `--wire` selector (added in PR 826) across the non-UI examples, so SEP-2575 wire mode is a uniform CLI knob instead of per-example hand-rolling. Each converted server gains `--wire` (legacy | dual | stateless) via `common.RegisterWireFlags` + the `ServerConfig.Wire` field; the walkthroughs that build a real client thread `common.WireFromArgs().ClientOption()` so the demo client honors the same flag. A new `make smoke-wire` boots each converted example and asserts the wire selection actually reached the transport.

Two non-mechanical pieces ride along:
- **events/kitchen-sink flag fix.** It was registering its own serve flags (`--addr`, `--exporter`, etc.) in `demokit.FilterArgs`, which *strips* them before `flag.Parse` — so `--addr` was silently dead (always bound `:8080`). Reduced to stripping only the `--serve` dispatch flag, which restores `--addr`/`--exporter` and makes `--wire` work there too.
- **token-aware smoke.** Auth examples gate `initialize`, so the smoke grabs the bearer/JWT token each prints at startup to authenticate the probe and observe the wire flip.

This PR adds the **knob**, not stateless correctness. `--wire=stateless` on the push-based examples (mrtr, elicitation) and the auth family exposes already-tracked gaps (MRTR-on-stateless, partial stateless auth middleware). The behavioral audit is issue 478; this is the mechanical flag adoption from issue 824.

## Reviewer's guide
Read in this order:
1. [scripts/smoke-wire.sh](https://github.com/panyam/mcpkit/pull/828/files#diff-c2dab0d6cadc82394ead3a612c7e8a106942a338f02ac8232087720cd3605ea1) — start here. The acceptance harness: boots each example on `--wire=stateless` (asserts legacy `initialize` -> 404) and default (asserts 200), authenticating the auth examples via their printed token. step-up-keycloak runs only when Keycloak is already up (mints a client-credentials token from the test realm); it skips cleanly otherwise, never bringing KC up. Defines exactly what "wire selection works" means. One documented skip: fine-grained-auth (no static token).
2. [examples/events/kitchen-sink/main.go](https://github.com/panyam/mcpkit/pull/828/files#diff-00227e3ff7d30e48422daed74f9cb228708d8e8ce9c7294358114d64c21173ac) — the FilterArgs fix (real bug: stripped its own flags) plus the manual `ListenAndServe` wire wiring (it doesn't use `common.RunServer`; all four transport options preserved).
3. [examples/list-ttl/walkthrough.go](https://github.com/panyam/mcpkit/pull/828/files#diff-3965429a5ee7a8f3a5eb694c9375c86d764eb71e48fa3ffb410684f18a8d059a) — representative client-side edit: `WireFromArgs()` + threading `ClientOption()` into the executed `client.NewClient`.
4. [examples/tasks/main.go](https://github.com/panyam/mcpkit/pull/828/files#diff-afb90cb7ac0e1de0166e72d0c4945dda9b993efd078f5a8e8dcc598aa00a1b00) — representative standard server edit (`RegisterWireFlags` + `Wire: wire`). The other RunServer-based servers follow this shape.
5. [examples/skills/main.go](https://github.com/panyam/mcpkit/pull/828/files#diff-5b14977a06843ef8ea751a41d80e1cd9eb927a784069536cf93b0857dc9261fc) — server gets the uniform knob; its walkthrough is deliberately left on its richer interactive client-wire selector (`demokit.Choice`), so `WireFromArgs` is NOT threaded there (would double-set `WithClientMode`).

Skim or skip: the remaining `auth/*` sub-example `main.go` edits (mechanical, identical 2-line change each), [Makefile](https://github.com/panyam/mcpkit/pull/828/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52) (one target + `.PHONY`).

## Decision log
- Single `--wire` drives both halves (server mode + paired client mode), `dual` maps the client to `adaptive`; `--server-wire`/`--client-wire` override per side. (Design from PR 826.)
- `examples/stateless` keeps its own `--mode` flag: the SEP-2575 conformance fixture boots it with no flag and needs a stateless default, not the `ModeDual` fall-through `--wire=""` gives.
- `examples/skills` walkthrough keeps its interactive client selector; only its server gets `--wire`.
- Smoke authenticates auth examples (grabs the printed token) rather than skipping them — proves `--wire` works through the auth stack. fine-grained-auth is skipped (its token needs a live OAuth flow, no static token at startup).
- No `demokit.ValueFlag("--wire")` added to FilterArgs — the `=` form survives the filter (matches the merged list-ttl convention).

## Risk / blast radius
- Affects: example binaries only. No library code. Every example resolves `examples/common` via a local `replace`, so no version bumps.
- Default behavior unchanged: with no `--wire`, every server stays on its env/`DefaultMode` wire (`ModeDual`), every client on `ClientModeLegacyOnly`. The smoke's "default -> 200" leg guards this.
- Be paranoid about: kitchen-sink's `FilterArgs` reduction (did it strip anything the demo relied on? — only `--serve`, which is still stripped) and its manual `ListenAndServe` transport-option preservation.

## Verification
`make smoke-wire` — 15 booted examples (16 when Keycloak is up), all green (stateless -> 404, default -> 200). Every touched module builds; all changed files gofmt-clean.

## Out of scope (deliberately deferred)
- Behavioral correctness of each example on the stateless wire -> issue 478.
- Persistent HandleStore backends -> issue 471. Principal-bound handles -> issue 823.

