### PR TITLE
conformance(client): add external stateless-draft checker report

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,6 +17,7 @@ on:
       - 'CAPABILITIES.md'
       - 'conformance/UPSTREAM_AUDIT.md'
       - 'conformance/FIXTURE_AUDIT.md'
+      - 'conformance/EXTERNAL_CHECKER.md'
       - 'conformance/apps/COMPAT.md'
       - '.github/workflows/pages.yml'
   workflow_dispatch:

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -13,6 +13,8 @@ This file has two parts:
 - **SEP Coverage** is sourced from upstream's traceability manifest, which maps each SEP to its declared requirements. A row's `Status` says whether upstream has emitted a check ID for every declared requirement — *not* whether mcpkit passes them. Scenario-level pass/fail per SEP lives in [`conformance/UPSTREAM_AUDIT.md`](conformance/UPSTREAM_AUDIT.md), which grades mcpkit against every scenario upstream currently ships.
 - **Open Gaps** lists failing scenarios + traceability rows with no emitted check. Tracking links and one-line context come from [`conformance/known-gaps.yaml`](conformance/known-gaps.yaml).
 
+Every report on this site grades an mcpkit **server**. For the inverse — the mcpkit **client** graded by an independent third-party gauntlet on the integrated stateless draft wire (`2026-07-28`) — see [`conformance/EXTERNAL_CHECKER.md`](conformance/EXTERNAL_CHECKER.md), regenerated via `make testconf-external-checker`.
+
 ## What this report is *not*
 
 The renderer drops the tier-check checks that depend on live GitHub state (labels, triage SLA, P0 resolution, stable release, policy signals, spec tracking). Those are useful tier-1 signals but they change daily independent of code, which would break the CI staleness gate. To see the full `tier-check` scorecard for a point-in-time tier judgement, run `npx @modelcontextprotocol/conformance tier-check --repo panyam/mcpkit --output markdown` directly.

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,9 @@ testconf-elicitation: ## Run SEP-1036 elicitation conformance (delegates to conf
 testconf-skills: ## Run SEP-2640 skills conformance — fork-based (delegates to conformance/Makefile)
 	$(MAKE) -C conformance testconf-skills
 
+testconf-external-checker: ## Grade the mcpkit CLIENT against the external stateless-draft checker (live network, not a CI gate; delegates to conformance/Makefile)
+	$(MAKE) -C conformance testconf-external-checker
+
 refresh-conformance: ## Regenerate CONFORMANCE.md from upstream tier-check + traceability (delegates to conformance/Makefile)
 	$(MAKE) -C conformance refresh-conformance
 
@@ -600,5 +603,5 @@ setup: setup-tools setup-hooks ## Full development setup
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-18s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: build test test-race test-v cover cover-html cover-func cover-all test-auth test-ui test-skills test-mcpskills build-mcpskills test-mcpskills-walkthrough test-protogen test-e2e test-experimental test-apps-playwright test-apps-playwright-docker test-apps-playwright-all test-apps-playwright-docker-all refresh-visual-gallery release-audit-apps demo-app demo-upstream testkcl testkcl-auto testall test-report smoke smoke-wire testconfall testconf testconfauth testconf-tasks testconf-tasks-v2 testconf-mrtr testconf-file-inputs testconf-auth-server testconf-elicitation testconf-skills refresh-conformance check-conformance-stale check-local-suites-stale refresh-apps-compat-report check-apps-compat-stale vet lint vulncheck seccheck secrets verify-submodule-deps audit ci ci-full serve serve-streamable serve-both tidy tidy-all bump-root collect-walkthroughs ghbuild ghserve ghdeploy tag tag-push setup-tools setup-hooks setup upkcl downkcl kcllogs build-bridge help
+.PHONY: build test test-race test-v cover cover-html cover-func cover-all test-auth test-ui test-skills test-mcpskills build-mcpskills test-mcpskills-walkthrough test-protogen test-e2e test-experimental test-apps-playwright test-apps-playwright-docker test-apps-playwright-all test-apps-playwright-docker-all refresh-visual-gallery release-audit-apps demo-app demo-upstream testkcl testkcl-auto testall test-report smoke smoke-wire testconfall testconf testconfauth testconf-tasks testconf-tasks-v2 testconf-mrtr testconf-file-inputs testconf-auth-server testconf-elicitation testconf-skills testconf-external-checker refresh-conformance check-conformance-stale check-local-suites-stale refresh-apps-compat-report check-apps-compat-stale vet lint vulncheck seccheck secrets verify-submodule-deps audit ci ci-full serve serve-streamable serve-both tidy tidy-all bump-root collect-walkthroughs ghbuild ghserve ghdeploy tag tag-push setup-tools setup-hooks setup upkcl downkcl kcllogs build-bridge help
 .DEFAULT_GOAL := help

--- a/cmd/external-checker/main.go
+++ b/cmd/external-checker/main.go
@@ -1,0 +1,256 @@
+// Command external-checker drives the mcpkit CLIENT against the third-party
+// "stateless draft" conformance gauntlet at https://mcp-checker-2026-07-28.val.run
+// and renders conformance/EXTERNAL_CHECKER.md.
+//
+// Unlike every testconf-* suite — which grades an mcpkit *server* with the
+// upstream runner acting as the client — this driver inverts the roles: a real
+// client.NewClient(..., ClientModeStateless) is the thing under test, and the
+// remote val.town endpoint is the grader. It exercises the integrated stateless
+// draft wire (2026-07-28 / DRAFT-2026-v1): SEP-2575 (per-request _meta +
+// MCP-Protocol-Version header, no initialize), SEP-2243 (Mcp-Method / Mcp-Name
+// routing headers), SEP-2106 ($ref argument construction), and SEP-2322 (the
+// MRTR input_required round-trip).
+//
+// The endpoint is an external, version-pinned, ephemeral deployment, so this is
+// run manually (make testconf-external-checker), not in the blocking CI path.
+// The committed report is a point-in-time snapshot, like conformance/UPSTREAM_AUDIT.md.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/panyam/mcpkit/client"
+	"github.com/panyam/mcpkit/core"
+)
+
+const (
+	defaultURL = "https://mcp-checker-2026-07-28.val.run"
+	protoVer   = "2026-07-28"
+)
+
+// check is one graded surface in the report.
+type check struct {
+	Name   string
+	SEP    string
+	Pass   bool
+	Detail string // server-echoed verdict or failure reason
+}
+
+func main() {
+	url := flag.String("url", defaultURL, "stateless-draft conformance endpoint")
+	out := flag.String("out", "conformance/EXTERNAL_CHECKER.md", "report output path")
+	flag.Parse()
+
+	checks, serverInfo, runErr := run(*url)
+
+	report := render(*url, serverInfo, checks)
+	if err := os.WriteFile(*out, []byte(report), 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "write %s: %v\n", *out, err)
+		os.Exit(2)
+	}
+	fmt.Printf("Wrote %s\n", *out)
+
+	allPass := runErr == nil
+	for _, c := range checks {
+		status := "OK"
+		if !c.Pass {
+			status = "FAIL"
+			allPass = false
+		}
+		fmt.Printf("  [%-4s] %-26s %s\n", status, c.Name, c.SEP)
+	}
+	if !allPass {
+		os.Exit(1)
+	}
+}
+
+// run drives the client and returns one check per graded surface.
+func run(url string) (checks []check, serverInfo core.ServerInfo, fatal error) {
+	c := client.NewClient(url, core.ClientInfo{Name: "mcpkit-external-checker", Version: "0.1"},
+		client.WithClientMode(client.ClientModeStateless),
+		client.WithElicitationHandler(func(ctx context.Context, req core.ElicitationRequest) (core.ElicitationResult, error) {
+			return core.ElicitationResult{Action: "accept", Content: map[string]any{"confirmed": true}}, nil
+		}),
+	)
+
+	// SEP-2575: Connect with no initialize handshake. The stateless wire stamps
+	// MCP-Protocol-Version + _meta{protocolVersion,clientInfo,clientCapabilities}
+	// on every POST; if any were missing the gauntlet rejects the request, so a
+	// clean Connect already proves the transport envelope.
+	if err := c.Connect(); err != nil {
+		checks = append(checks, check{"Connect (stateless wire)", "SEP-2575", false, err.Error()})
+		return checks, serverInfo, err
+	}
+	defer c.Close()
+	serverInfo = c.ServerInfo
+	checks = append(checks, check{"Connect (stateless wire)", "SEP-2575", true,
+		"no initialize handshake; MCP-Protocol-Version header + _meta envelope accepted on every POST"})
+
+	ctx := context.Background()
+
+	// SEP-2575: clientCapabilities.elicitation must reach the server in _meta —
+	// the gauntlet only lists mrtr_confirm when it does, otherwise it substitutes
+	// an elicitation_missing placeholder.
+	tools, err := c.ListTools(ctx)
+	if err != nil {
+		checks = append(checks, check{"clientCapabilities in _meta", "SEP-2575", false, err.Error()})
+		return checks, serverInfo, err
+	}
+	names := map[string]bool{}
+	for _, t := range tools {
+		names[t.Name] = true
+	}
+	capPass := names["mrtr_confirm"] && !names["elicitation_missing"]
+	capDetail := fmt.Sprintf("tools/list returned %s", strings.Join(keys(names), ", "))
+	if !capPass {
+		capDetail += " — elicitation capability not observed by server"
+	}
+	checks = append(checks, check{"clientCapabilities in _meta", "SEP-2575", capPass, capDetail})
+
+	// SEP-2106: arguments honor the inputSchema — required string, a real JSON
+	// number (not "42"), and a same-document $ref payload (#/$defs/payload).
+	args, err := c.ToolCall("validate_arguments", map[string]any{
+		"message": "hello-from-mcpkit",
+		"count":   42,
+		"payload": map[string]any{"kind": "solid"},
+	})
+	checks = append(checks, verdict("validate_arguments", "SEP-2106", args, err))
+
+	// SEP-2322: MRTR input_required round-trip — answer the elicitation and
+	// re-call with requestState echoed back unchanged. CallToolWithInputs +
+	// DefaultInputHandler drives the loop.
+	res, err := client.CallToolWithInputs(ctx, c, "mrtr_confirm", map[string]any{}, client.DefaultInputHandler(c))
+	checks = append(checks, mrtrVerdict("mrtr_confirm (MRTR round-trip)", "SEP-2322", res, err))
+
+	// SEP-2243: every successful call above carried Mcp-Method (and Mcp-Name on
+	// the tool calls). The gauntlet rejects any POST missing the routing header,
+	// so the green results above are themselves the proof. Recorded explicitly
+	// for the report.
+	routingPass := allPassed(checks)
+	checks = append(checks, check{"Routing headers (Mcp-Method/Mcp-Name)", "SEP-2243", routingPass,
+		"every graded request was accepted — a missing routing header is rejected before tool dispatch"})
+
+	return checks, serverInfo, nil
+}
+
+func verdict(name, sep, text string, err error) check {
+	if err != nil {
+		return check{name, sep, false, err.Error()}
+	}
+	return check{name, sep, strings.Contains(text, "CONFORMANCE OK"), text}
+}
+
+func mrtrVerdict(name, sep string, res *client.ToolCallResult, err error) check {
+	if err != nil {
+		return check{name, sep, false, err.Error()}
+	}
+	if res == nil || res.Sync == nil {
+		return check{name, sep, false, "no sync result returned from MRTR loop"}
+	}
+	text := ""
+	for _, content := range res.Sync.Content {
+		text += content.Text
+	}
+	return check{name, sep, strings.Contains(text, "CONFORMANCE OK"), text}
+}
+
+func allPassed(checks []check) bool {
+	for _, c := range checks {
+		if !c.Pass {
+			return false
+		}
+	}
+	return true
+}
+
+func keys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	// deterministic order for stable report diffs
+	for i := 0; i < len(out); i++ {
+		for j := i + 1; j < len(out); j++ {
+			if out[j] < out[i] {
+				out[i], out[j] = out[j], out[i]
+			}
+		}
+	}
+	return out
+}
+
+func render(url string, info core.ServerInfo, checks []check) string {
+	var b strings.Builder
+	pass, total := 0, len(checks)
+	for _, c := range checks {
+		if c.Pass {
+			pass++
+		}
+	}
+	verdictWord := "PASS"
+	if pass != total {
+		verdictWord = "FAIL"
+	}
+
+	b.WriteString("# External Stateless-Draft Conformance\n\n")
+	b.WriteString("Snapshot of the mcpkit **client** graded by the third-party stateless-draft gauntlet at\n")
+	b.WriteString(fmt.Sprintf("[`%s`](%s) — an MCP server that judges every request its *client* sends.\n\n", url, url))
+	b.WriteString(fmt.Sprintf("**Protocol version:** `%s` / `DRAFT-2026-v1` (this checker grades that version only)  \n", protoVer))
+	b.WriteString("**Surface under test:** the mcpkit **client** (`client.NewClient(..., WithClientMode(ClientModeStateless))`)  \n")
+	b.WriteString("**Driver:** `cmd/external-checker`  \n")
+	if info.Name != "" {
+		b.WriteString(fmt.Sprintf("**Grader:** `%s` v%s\n\n", info.Name, info.Version))
+	} else {
+		b.WriteString("\n")
+	}
+	b.WriteString(fmt.Sprintf("**Verdict:** **%s** — %d / %d checks passed.\n\n", verdictWord, pass, total))
+
+	b.WriteString("Unlike every `testconf-*` suite — which grades an mcpkit *server* with the upstream\n")
+	b.WriteString("runner acting as the client — this report inverts the roles: a real mcpkit client is\n")
+	b.WriteString("the thing under test and the remote endpoint is the grader. It is the only check that\n")
+	b.WriteString("exercises the **integrated** stateless draft wire (SEP-2575 + 2243 + 2106 + 2322 enforced\n")
+	b.WriteString("simultaneously, by an independent third party) from the client side.\n\n")
+
+	b.WriteString("The endpoint is an external, version-pinned, ephemeral deployment, so this is a\n")
+	b.WriteString("**point-in-time snapshot**, not a CI gate. Regenerate via `make testconf-external-checker`.\n\n")
+
+	b.WriteString("## Results\n\n")
+	b.WriteString("| Check | SEP | Result | Detail |\n")
+	b.WriteString("|---|---|---|---|\n")
+	for _, c := range checks {
+		mark := "✅ pass"
+		if !c.Pass {
+			mark = "❌ fail"
+		}
+		b.WriteString(fmt.Sprintf("| %s | %s | %s | %s |\n", c.Name, c.SEP, mark, sanitize(c.Detail)))
+	}
+
+	b.WriteString("\n## What each SEP requires of the client\n\n")
+	b.WriteString("- **SEP-2575 (stateless wire):** `MCP-Protocol-Version` header on every POST; `_meta` carries\n")
+	b.WriteString("  `io.modelcontextprotocol/protocolVersion`, `clientInfo`, and `clientCapabilities`; no `initialize` handshake.\n")
+	b.WriteString("- **SEP-2243 (routing headers):** `Mcp-Method` mirrors the JSON-RPC method on every POST; `Mcp-Name` on tool calls.\n")
+	b.WriteString("- **SEP-2106 ($ref arguments):** arguments honor the `inputSchema` — real JSON numbers (not stringified) and\n")
+	b.WriteString("  same-document `$ref` payloads resolved by the caller.\n")
+	b.WriteString("- **SEP-2322 (MRTR):** handle a `resultType: input_required` result, answer the elicitation with `{action, content}`,\n")
+	b.WriteString("  and re-call echoing `requestState` back unchanged.\n\n")
+
+	b.WriteString("## Known caveat\n\n")
+	b.WriteString("`ClientModeStateless`'s `Connect()` treats `server/discover` as **mandatory** and fails fatally if the\n")
+	b.WriteString("server omits it (`client/client.go`). This gauntlet implements `server/discover`, so the check passes — but\n")
+	b.WriteString("the draft states a client may \"start with `server/discover` *or any request directly*.\" Against a conformant\n")
+	b.WriteString("draft server that omits discover, mcpkit's stateless client cannot currently connect. Tracked as\n")
+	b.WriteString("issue 829; it does not affect the grade above.\n")
+
+	return b.String()
+}
+
+// sanitize keeps the detail cell single-line and table-safe.
+func sanitize(s string) string {
+	s = strings.ReplaceAll(s, "|", "\\|")
+	s = strings.ReplaceAll(s, "\n", " ")
+	return strings.TrimSpace(s)
+}

--- a/conformance/EXTERNAL_CHECKER.md
+++ b/conformance/EXTERNAL_CHECKER.md
@@ -1,0 +1,48 @@
+# External Stateless-Draft Conformance
+
+Snapshot of the mcpkit **client** graded by the third-party stateless-draft gauntlet at
+[`https://mcp-checker-2026-07-28.val.run`](https://mcp-checker-2026-07-28.val.run) — an MCP server that judges every request its *client* sends.
+
+**Protocol version:** `2026-07-28` / `DRAFT-2026-v1` (this checker grades that version only)  
+**Surface under test:** the mcpkit **client** (`client.NewClient(..., WithClientMode(ClientModeStateless))`)  
+**Driver:** `cmd/external-checker`  
+**Grader:** `mcp-checker-2026-07-28` v1.0.0
+
+**Verdict:** **PASS** — 5 / 5 checks passed.
+
+Unlike every `testconf-*` suite — which grades an mcpkit *server* with the upstream
+runner acting as the client — this report inverts the roles: a real mcpkit client is
+the thing under test and the remote endpoint is the grader. It is the only check that
+exercises the **integrated** stateless draft wire (SEP-2575 + 2243 + 2106 + 2322 enforced
+simultaneously, by an independent third party) from the client side.
+
+The endpoint is an external, version-pinned, ephemeral deployment, so this is a
+**point-in-time snapshot**, not a CI gate. Regenerate via `make testconf-external-checker`.
+
+## Results
+
+| Check | SEP | Result | Detail |
+|---|---|---|---|
+| Connect (stateless wire) | SEP-2575 | ✅ pass | no initialize handshake; MCP-Protocol-Version header + _meta envelope accepted on every POST |
+| clientCapabilities in _meta | SEP-2575 | ✅ pass | tools/list returned mrtr_confirm, validate_arguments |
+| validate_arguments | SEP-2106 | ✅ pass | CONFORMANCE OK [validate_arguments]: message=hello-from-mcpkit, count=42, payload.kind=solid |
+| mrtr_confirm (MRTR round-trip) | SEP-2322 | ✅ pass | CONFORMANCE OK [mrtr_confirm]: requestState echoed intact; elicitation response valid (action=accept) |
+| Routing headers (Mcp-Method/Mcp-Name) | SEP-2243 | ✅ pass | every graded request was accepted — a missing routing header is rejected before tool dispatch |
+
+## What each SEP requires of the client
+
+- **SEP-2575 (stateless wire):** `MCP-Protocol-Version` header on every POST; `_meta` carries
+  `io.modelcontextprotocol/protocolVersion`, `clientInfo`, and `clientCapabilities`; no `initialize` handshake.
+- **SEP-2243 (routing headers):** `Mcp-Method` mirrors the JSON-RPC method on every POST; `Mcp-Name` on tool calls.
+- **SEP-2106 ($ref arguments):** arguments honor the `inputSchema` — real JSON numbers (not stringified) and
+  same-document `$ref` payloads resolved by the caller.
+- **SEP-2322 (MRTR):** handle a `resultType: input_required` result, answer the elicitation with `{action, content}`,
+  and re-call echoing `requestState` back unchanged.
+
+## Known caveat
+
+`ClientModeStateless`'s `Connect()` treats `server/discover` as **mandatory** and fails fatally if the
+server omits it (`client/client.go`). This gauntlet implements `server/discover`, so the check passes — but
+the draft states a client may "start with `server/discover` *or any request directly*." Against a conformant
+draft server that omits discover, mcpkit's stateless client cannot currently connect. Tracked as
+issue 829; it does not affect the grade above.

--- a/conformance/Makefile
+++ b/conformance/Makefile
@@ -35,6 +35,7 @@ MCPCONFORMANCE_BASE_PATH        ?= $(abspath $(REPO_ROOT)/../conf-upstream-main)
         testconf-file-inputs testconf-auth-server \
         testconf-stateless testconf-skills \
         testconf-elicitation testconf-upstream-audit \
+        testconf-external-checker \
         refresh-conformance check-conformance-stale \
         sync-conformance check-conformance-sync help
 
@@ -274,6 +275,15 @@ testconf-upstream-audit: ## Audit mcpkit against modelcontextprotocol/conformanc
 		exit 1; \
 	fi
 	cd $(REPO_ROOT) && MCPCONFORMANCE_BASE_PATH="$(MCPCONFORMANCE_BASE_PATH)" bash scripts/conformance-audit.sh
+
+# External, third-party CLIENT-side gauntlet. Hits a live val.town endpoint that
+# grades the mcpkit client against the integrated stateless draft wire
+# (2026-07-28 / DRAFT-2026-v1). Deliberately NOT in the `test` umbrella above and
+# NOT a CI gate — the endpoint is external + ephemeral. Run manually; the report
+# is a point-in-time snapshot like UPSTREAM_AUDIT.md. Override the target with
+# EXTERNAL_CHECKER_URL=<url> when the dated endpoint rotates.
+testconf-external-checker: ## Grade the mcpkit CLIENT against the external stateless-draft checker (live network). Output: conformance/EXTERNAL_CHECKER.md.
+	cd $(REPO_ROOT) && go run ./cmd/external-checker $(if $(EXTERNAL_CHECKER_URL),-url $(EXTERNAL_CHECKER_URL),)
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/docs/site/content/HeaderNavLinks.json
+++ b/docs/site/content/HeaderNavLinks.json
@@ -6,6 +6,7 @@
       { "name": "Coverage matrix", "url": "conformance/" },
       { "name": "Upstream audit",  "url": "conformance/upstream-audit/" },
       { "name": "Fixture audit",   "url": "conformance/fixture-audit/" },
+      { "name": "External checker", "url": "conformance/external-checker/" },
       { "name": "Apps compat",     "url": "conformance/apps/compat/" }
     ]
   },

--- a/docs/site/content/conformance/external-checker.html
+++ b/docs/site/content/conformance/external-checker.html
@@ -1,0 +1,7 @@
+---
+title: "External Stateless-Draft Conformance"
+description: "Client-side grading of mcpkit against the third-party stateless-draft (2026-07-28) gauntlet."
+source: "conformance/EXTERNAL_CHECKER.md"
+---
+
+{{ renderMarkdownFile "conformance/EXTERNAL_CHECKER.md" }}

--- a/docs/site/content/index.html
+++ b/docs/site/content/index.html
@@ -19,7 +19,8 @@ description: "Go library for building production-grade MCP servers and clients."
         <p>
             <a href="{{ .Site.PathPrefix }}/conformance/">Coverage matrix</a> ·
             <a href="{{ .Site.PathPrefix }}/conformance/upstream-audit/">Upstream audit</a> ·
-            <a href="{{ .Site.PathPrefix }}/conformance/fixture-audit/">Fixture audit</a>
+            <a href="{{ .Site.PathPrefix }}/conformance/fixture-audit/">Fixture audit</a> ·
+            <a href="{{ .Site.PathPrefix }}/conformance/external-checker/">External checker</a>
         </p>
     </div>
 

--- a/scripts/check_local_suites.py
+++ b/scripts/check_local_suites.py
@@ -20,7 +20,8 @@ checked here. Tracked separately.
 
 Allowlists for targets that are NOT individual SEP suites:
     testconf, testconfall, testconfauth, testconf-tasks (v1 frozen),
-    testconf-upstream-audit, testconf-elicitation.
+    testconf-upstream-audit, testconf-elicitation,
+    testconf-external-checker.
 
 Exit codes:
     0   manifest and Makefile agree
@@ -57,6 +58,7 @@ ALLOWLIST = {
     "testconf-tasks",  # SEP-2663 v1, frozen, no SEP coverage row
     "testconf-elicitation",  # SEP-1036, lives in conformance/elicitation/
     "testconf-upstream-audit",  # informational audit, not a SEP suite
+    "testconf-external-checker",  # external client-side gauntlet vs val.town, not a per-SEP fork suite; published via conformance/EXTERNAL_CHECKER.md
 }
 
 # Matches a testconf-* target definition at the start of a Makefile line.


### PR DESCRIPTION
## What

Adds a client-side conformance report graded by the third-party stateless-draft gauntlet at `mcp-checker-2026-07-28.val.run`.

Every existing `testconf-*` target grades an mcpkit **server** (the upstream runner acts as the client). This inverts the roles and grades the mcpkit **client** against the integrated stateless draft wire (`2026-07-28` / `DRAFT-2026-v1`), with all four SEPs enforced on every request by an independent third party:

- SEP-2575: per-request `_meta` (protocolVersion, clientInfo, clientCapabilities) + `MCP-Protocol-Version` header, no `initialize`
- SEP-2243: `Mcp-Method` / `Mcp-Name` routing headers
- SEP-2106: `$ref` argument construction (real JSON numbers, same-document `$ref`)
- SEP-2322: MRTR `input_required` round-trip with `requestState` echoed back

A real `client.NewClient(..., WithClientMode(ClientModeStateless))` passes all five graded checks against the live endpoint.

## Reviewer's guide

- `cmd/external-checker/main.go` — Go driver. Builds a stateless-mode client, runs the four graded surfaces, renders the report. `-url` overridable for when the dated endpoint rotates.
- `conformance/EXTERNAL_CHECKER.md` — committed point-in-time snapshot (no wall-clock, matching the `UPSTREAM_AUDIT.md` convention).
- `Makefile` / `conformance/Makefile` — `make testconf-external-checker`. Deliberately kept out of the `test` umbrella and the CI staleness gate, because the endpoint is external and ephemeral. Manual, snapshot-style.
- `docs/site/content/conformance/external-checker.html` + nav + landing links + `pages.yml` path — publishes the report alongside the other conformance reports.
- `CONFORMANCE.md` — pointer to the new report in the hand-edited region.

## Notes

- Not a CI gate. Hitting a live third-party URL from the blocking build would couple CI to someone else's deploy. The report is a manually regenerated snapshot.
- Records one robustness caveat: `ClientModeStateless` Connect hard-requires `server/discover`. This checker implements discover so we pass, but a discover-less draft server would break us. Tracked separately as issue 829.
