### PR TITLE
fix(client): emit Mcp-Name for task ops on the stateless wire

### DIFF
--- a/client/tasks.go
+++ b/client/tasks.go
@@ -69,16 +69,6 @@ func (r *ToolCallResult) IsInputRequired() bool {
 	return r != nil && r.InputRequired != nil
 }
 
-// --- Wire-format params ---
-
-type tasksGetParams struct {
-	TaskID string `json:"taskId"`
-}
-
-type tasksCancelParams struct {
-	TaskID string `json:"taskId"`
-}
-
 // --- Polymorphic tools/call ---
 
 // ToolCall invokes a tool, transparently handling both the sync ToolResult
@@ -139,7 +129,11 @@ func parseToolCallResult(raw json.RawMessage) (*ToolCallResult, error) {
 // safe to call as often as needed; servers gate this method on the
 // io.modelcontextprotocol/tasks extension being negotiated.
 func GetTask(c *Client, taskID string) (*core.DetailedTask, error) {
-	resp, err := c.Call("tasks/get", tasksGetParams{TaskID: taskID})
+	// Map (not a typed struct) so core.DeriveMcpName can read taskId and
+	// emit the Mcp-Name routing header the server requires for task ops on
+	// the SEP-2575 stateless wire (no session to route by). Same reason
+	// ToolCall passes a map. See core.DeriveMcpName.
+	resp, err := c.Call("tasks/get", map[string]any{"taskId": taskID})
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +156,14 @@ func UpdateTask(c *Client, req core.UpdateTaskRequest) error {
 	if req.TaskID == "" {
 		return fmt.Errorf("UpdateTask: missing TaskID")
 	}
-	if _, err := c.Call("tasks/update", req); err != nil {
+	// Map form so DeriveMcpName can read taskId for the Mcp-Name header
+	// (see GetTask). inputResponses is included only when non-empty to
+	// mirror the struct's `omitempty`.
+	params := map[string]any{"taskId": req.TaskID}
+	if len(req.InputResponses) > 0 {
+		params["inputResponses"] = req.InputResponses
+	}
+	if _, err := c.Call("tasks/update", params); err != nil {
 		return err
 	}
 	return nil
@@ -172,7 +173,7 @@ func UpdateTask(c *Client, req core.UpdateTaskRequest) error {
 // response is an empty ack per SEP-2663 (no task state). Issue GetTask if
 // you need to observe the resulting "cancelled" status.
 func CancelTask(c *Client, taskID string) error {
-	if _, err := c.Call("tasks/cancel", tasksCancelParams{TaskID: taskID}); err != nil {
+	if _, err := c.Call("tasks/cancel", map[string]any{"taskId": taskID}); err != nil {
 		return err
 	}
 	return nil

--- a/core/sep2243.go
+++ b/core/sep2243.go
@@ -48,11 +48,19 @@ const McpMethodHeader = "Mcp-Method"
 const McpNameHeader = "Mcp-Name"
 
 // DeriveMcpName extracts the [McpNameHeader] value from a JSON-RPC params
-// payload for the three methods that carry a routable name/URI: tools/call
-// (params.name), prompts/get (params.name), and resources/read (params.uri).
+// payload for the methods that carry a routable identifier: tools/call and
+// prompts/get (params.name), resources/read (params.uri), and the SEP-2663
+// task methods tasks/get, tasks/update, tasks/cancel (params.taskId).
 // Returns "" for any other method or when the field is missing / non-string
 // — callers should skip emitting Mcp-Name in that case (server-side
 // fail-closed will reject mismatches).
+//
+// This MUST mirror the server's body-side derivation (the producer and the
+// validator have to agree on which field names the routable value): see
+// server header validation's per-method name extraction. The task cases
+// matter on the SEP-2575 stateless wire — there is no session to route task
+// operations by, so the server requires Mcp-Name: <taskId> and the client
+// must supply it.
 //
 // params is the Go value the producer holds — typically `map[string]any`
 // or `map[string]string`. Other shapes (structs, json.RawMessage) return
@@ -67,6 +75,8 @@ func DeriveMcpName(method string, params any) string {
 		return mcpParamsStringField(params, "name")
 	case "resources/read":
 		return mcpParamsStringField(params, "uri")
+	case "tasks/get", "tasks/update", "tasks/cancel":
+		return mcpParamsStringField(params, "taskId")
 	}
 	return ""
 }

--- a/core/sep2243_test.go
+++ b/core/sep2243_test.go
@@ -302,6 +302,14 @@ func TestDeriveMcpName(t *testing.T) {
 		{"nil-params", "tools/call", nil, ""},
 		{"name-not-string", "tools/call", map[string]any{"name": 42}, ""},
 		{"empty-name", "tools/call", map[string]any{"name": ""}, ""},
+		// SEP-2663 task methods route on taskId. The client task helpers
+		// MUST pass a map (not a typed struct) for this to fire — required
+		// for Mcp-Name on the stateless wire where there's no session to
+		// route task ops by.
+		{"tasks-get-taskid", "tasks/get", map[string]any{"taskId": "tsk_1"}, "tsk_1"},
+		{"tasks-update-taskid", "tasks/update", map[string]any{"taskId": "tsk_2"}, "tsk_2"},
+		{"tasks-cancel-taskid", "tasks/cancel", map[string]any{"taskId": "tsk_3"}, "tsk_3"},
+		{"tasks-get-no-taskid", "tasks/get", map[string]any{}, ""},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			got := DeriveMcpName(tc.method, tc.params)


### PR DESCRIPTION
## What changes
Fixes SEP-2663 task operations (`tasks/get` / `tasks/update` / `tasks/cancel`) failing over the SEP-2575 **stateless** wire with `-32020 Mcp-Name header is required but missing`. They worked on the legacy wire (the session covered routing) but broke on the stateless wire, where there is no session and the server requires the `Mcp-Name: <taskId>` routing header.

Two gaps combined to drop the header:
1. `core.DeriveMcpName` (the client's single source for the `Mcp-Name` value) had cases for `tools/call` / `prompts/get` / `resources/read` but **none for the task methods**.
2. The client task helpers passed **typed structs** (`tasksGetParams{TaskID}`), which the map-only name-deriver can't read, so even with a case it would have come up empty. `ToolCall` already passes a map, which is why tools never hit this.

## Reviewer's guide
1. [core/sep2243.go](https://github.com/panyam/mcpkit/pull/832/files#diff-5eb51c7e54a250f7c5f86aa08fb29f010c7cf0ccf0f179eb8d27a5c399cf823a) — `DeriveMcpName` gains `tasks/get|update|cancel -> taskId`, mirroring the server's body-side requirement in `server/header_validation.go`.
2. [client/tasks.go](https://github.com/panyam/mcpkit/pull/832/files#diff-d0b57c8858ad0192278d3050dbcdd6e4e6891f72eb9d4e8d0f076efdcacc7265) — `GetTask` / `UpdateTask` / `CancelTask` now pass `map[string]any` params (the same pre-parsed shape `ToolCall` uses) so the name derives with **no extra serialization**. The now-dead `tasksGetParams` / `tasksCancelParams` structs are removed.
3. [core/sep2243_test.go](https://github.com/panyam/mcpkit/pull/832/files#diff-d5fa2f78b0a443ee711d69ad0a0df7c19399e075b6f08d6c07f920bf969c9f11) — regression cases for the three task methods.

## Decision log
- Passed maps from the helpers rather than adding a marshal fallback in `DeriveMcpName`. A fallback would re-serialize the payload on every `tasks/get` poll just to recover `taskId`; maps avoid that and match the existing `ToolCall` convention. This is also forward-compatible with the planned pre-parsed-payload work (params already in parsed form -> field read directly, single wire serialization).
- `UpdateTask` builds its map explicitly and includes `inputResponses` only when non-empty, mirroring the struct's `omitempty`.

## Risk / blast radius
- Client task call path only. `Mcp-Name` is now also set on the **legacy** wire for task ops; the server validates it equals the body `taskId`, which it does by construction, so no legacy behavior change (verified: tasks-v2 walkthrough clean on both wires).
- tasks-v1 is unchanged (deprecated; not targeted for the stateless wire).

## Before / after
`examples/tasks-v2` walkthrough, non-interactive, both wires:
- before: legacy 0 errors / **stateless 5x `-32020 Mcp-Name ... missing`**
- after:  legacy 0 errors / **stateless 0 errors**

## How this was found
Surfaced by a dual-mode example audit (issue 478): driving the tasks-v2 walkthrough over `--wire=stateless`. Conformance never caught it because `testconf-tasks-v2` runs the task scenarios on the legacy wire and `testconf-stateless` uses the cart fixture (no task ops), so task-ops x stateless was an untested combination. The audit harness + doc land separately in the issue 478 PR.

