### PR TITLE
fix(server/stateless): run SEP-2356 file-input validation on the stateless wire

### DIFF
--- a/server/file_validation_stateless_test.go
+++ b/server/file_validation_stateless_test.go
@@ -1,0 +1,69 @@
+package server
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/server/stateless"
+)
+
+// TestFileInputValidation_StatelessWire verifies SEP-2356 file-input
+// validation runs on the SEP-2575 stateless tools/call path, in parity
+// with the legacy dispatch. Regression for the gap where
+// callToolForStateless skipped validation entirely, letting size/MIME
+// violations reach the handler instead of returning -32602.
+func TestFileInputValidation_StatelessWire(t *testing.T) {
+	s, url, teardown := newStatelessTestServerWithOpts(t, stateless.ModeStateless, WithFileInputValidation())
+	defer teardown()
+
+	maxSize := 1024
+	if err := s.Registry().AddTool(
+		core.ToolDef{
+			Name: "upload_image",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"image": core.FileInputProperty(core.FileInputDescriptor{
+						Accept:  []string{"image/*"},
+						MaxSize: &maxSize,
+					}),
+				},
+				"required": []string{"image"},
+			},
+		},
+		func(_ core.ToolContext, _ core.ToolRequest) (core.ToolResponse, error) {
+			return core.TextResult("handler reached"), nil
+		},
+	); err != nil {
+		t.Fatalf("AddTool: %v", err)
+	}
+
+	// 2 KiB image against a 1 KiB cap — must be rejected before the handler.
+	uri := core.EncodeDataURI(make([]byte, 2048), "image/png", "big.png")
+	resp := postStatelessJSON(t, url, map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+		"params": map[string]any{
+			"name":      "upload_image",
+			"arguments": map[string]any{"image": uri},
+			"_meta": map[string]any{
+				"io.modelcontextprotocol/protocolVersion":    draftVersion,
+				"io.modelcontextprotocol/clientInfo":         map[string]any{"name": "t", "version": "1"},
+				"io.modelcontextprotocol/clientCapabilities": map[string]any{},
+			},
+		},
+	}, map[string]string{mcpProtocolVersionHeader: draftVersion})
+
+	r := decode(t, resp)
+	if r.Error == nil || r.Error.Code != core.ErrCodeInvalidParams {
+		t.Fatalf("expected -32602 file_too_large, got %+v", r.Error)
+	}
+	dataRaw, _ := json.Marshal(r.Error.Data)
+	var data core.FileTooLargeData
+	if err := json.Unmarshal(dataRaw, &data); err != nil {
+		t.Fatalf("unmarshal error data: %v", err)
+	}
+	if data.Reason != core.FileInputReasonTooLarge || data.Field != "image" {
+		t.Fatalf("unexpected error data: %+v", data)
+	}
+}

--- a/server/stateless_backend.go
+++ b/server/stateless_backend.go
@@ -297,10 +297,20 @@ func (b *statelessBackend) callToolForStateless(ctx context.Context, req *core.R
 		return core.NewErrorResponse(req.ID, core.ErrCodeInvalidParams,
 			"invalid tools/call params: "+err.Error())
 	}
-	_, handler, ok := b.Tool(env.Name)
+	def, handler, ok := b.Tool(env.Name)
 	if !ok {
 		return core.NewErrorResponse(req.ID, core.ErrCodeInvalidParams,
 			"unknown tool: "+env.Name)
+	}
+
+	// SEP-2356 file-input validation parity with the legacy dispatch path
+	// (Dispatcher.handleToolsCall). Without this the SEP-2575 stateless wire
+	// skips size/MIME enforcement entirely and invalid file args reach the
+	// handler — same -32602 + structured `data` contract on both wires.
+	if b.s.dispatcher.validateFileInputs {
+		if resp := b.s.dispatcher.validateFileInputArgs(req.ID, def.InputSchema, env.Arguments); resp != nil {
+			return resp
+		}
 	}
 
 	// SEP-2322: verify the echoed requestState (rejects tampered or expired


### PR DESCRIPTION
## What changes
Fixes SEP-2356 file-input validation silently not running on the SEP-2575 **stateless** wire. `callToolForStateless` skipped the size/MIME enforcement that the legacy dispatch (`Dispatcher.handleToolsCall`) runs, so on the stateless wire an oversized or wrong-type file arg bypassed the validator and reached the handler instead of returning `-32602`. Now both wires apply the same validation behind the same `WithFileInputValidation()` flag.

## Reviewer's guide
1. [server/stateless_backend.go](https://github.com/panyam/mcpkit/pull/834/files#diff-d6054c7923eaa9651736c3c6bccd7e7634dbf33d4bdfa89a5a34e069bb4b620e) — in `callToolForStateless`, capture the tool def and run `validateFileInputArgs(id, def.InputSchema, args)` before the handler, gated on `validateFileInputs` (a direct mirror of the legacy gate at `dispatch.go:589`).
2. [server/file_validation_stateless_test.go](https://github.com/panyam/mcpkit/pull/834/files#diff-4bac792db18b05dee0da2b01d4f55b258428b74ef4fa5d2dd2b2796a3f11b70f) — regression: drives a 2 KiB image against a 1 KiB cap over the stateless wire and asserts `-32602` + `file_too_large`. Red without the fix (returns no error), green with it.

## Decision log
- Reused the existing `Dispatcher.validateFileInputArgs` rather than duplicating logic — same `-32602` + structured `data` contract on both wires, which the SEP-2356 conformance scenarios pin.

## Risk / blast radius
- Stateless tools/call path only; no change to the legacy wire or to servers without `WithFileInputValidation()`. The flag default is off (unchanged).
- Verified: `examples/file-inputs` walkthrough now runs clean on both wires (was 3x `expected an RPC error, got none` on stateless).

## How this was found
Same dual-mode example audit (issue 478) as the task-routing fix (PR 832): driving the file-inputs walkthrough over `--wire=stateless`. Conformance didn't catch it because the stateless suite uses the cart fixture (no file inputs) and the file-inputs suite runs on the legacy wire — file-inputs x stateless was untested. Second of the same class of "dispatch feature not mirrored in the stateless backend" gaps.

