### PR TITLE
feat(ext/auth): parse scp scope claim + provider-neutral step-up SUT

### DIFF
--- a/examples/auth/step-up-keycloak/README.md
+++ b/examples/auth/step-up-keycloak/README.md
@@ -1,5 +1,7 @@
 # step-up-keycloak
 
+> **Deprecated.** Superseded by the provider-neutral [`../step-up`](../step-up), which takes `-issuer`/`-audience` and validates the same wire shape against any authorization server (Keycloak, Okta, Entra, ...). For Keycloak: `go run ./examples/auth/step-up -issuer http://localhost:8180/realms/mcpkit-test`. This directory stays through v0.3.x for the in-flight review and is slated for removal in a later release.
+
 **Experimental.** SEP-2350 server-side scope-challenge demo running against a Keycloak realm.
 
 An experimental Go SDK exercising the same conformance scenario the TypeScript reference implementation in [`modelcontextprotocol/typescript-sdk` PR 1624](https://github.com/modelcontextprotocol/typescript-sdk/pull/1624) is being validated against. The canonical end-to-end runbook lives in [`panyam/mcpconformance`](https://github.com/panyam/mcpconformance/pull/19) under `examples/auth-fixtures/keycloak/README.md` on the `feat/sep-2350-server-scope-challenge` branch. This README is the mcpkit-side runbook for the same flow.

--- a/examples/auth/step-up-keycloak/main.go
+++ b/examples/auth/step-up-keycloak/main.go
@@ -1,5 +1,14 @@
 // Example: SEP-2350 step-up auth against Keycloak.
 //
+// Deprecated: superseded by the provider-neutral examples/auth/step-up, which
+// takes -issuer/-audience and validates the same wire shape against any AS
+// (Keycloak, Okta, Entra, ...). For Keycloak, run:
+//
+//	go run ./examples/auth/step-up -issuer http://localhost:8180/realms/mcpkit-test
+//
+// This directory stays as-is through v0.3.x for the in-flight review and is
+// slated for removal in a later release.
+//
 // Experimental. SEP-2350 (client-side scope accumulation in step-up
 // authorization) is merged into the spec, but the server-side reference
 // implementation in modelcontextprotocol/typescript-sdk PR 1624 is still under

--- a/examples/auth/step-up/Makefile
+++ b/examples/auth/step-up/Makefile
@@ -1,0 +1,20 @@
+PORT ?= 3021
+# Defaults to a local Keycloak realm (free, hermetic). For Okta:
+#   source .../okta.env && make run ISSUER="$$OKTA_ISSUER" AUDIENCE=api://default
+ISSUER ?= http://localhost:8180/realms/mcpkit-test
+# AUDIENCE: empty for Keycloak; api://default for Okta's default custom AS.
+AUDIENCE ?=
+
+.PHONY: help run build clean
+
+help: ## Show available targets
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+run: ## Start the SUT against $(ISSUER) (expects the AS reachable)
+	go run . -addr :$(PORT) -issuer "$(ISSUER)" -audience "$(AUDIENCE)"
+
+build: ## Compile the SUT to ./step-up-sut
+	go build -o step-up-sut .
+
+clean: ## Remove built binary
+	rm -f step-up-sut

--- a/examples/auth/step-up/README.md
+++ b/examples/auth/step-up/README.md
@@ -1,0 +1,53 @@
+# step-up
+
+**Experimental.** Provider-neutral SEP-2350 server-side scope-challenge SUT.
+
+The SEP-2350 scope-challenge wire shape is provider-blind: HTTP 403 +
+`WWW-Authenticate: Bearer error="insufficient_scope", scope="...", resource_metadata="..."`
+(RFC 6750 §3.1) plus RFC 9728 PRM discovery. No part of the server knows or
+cares which authorization server minted the token, so a single SUT validates
+the flow against any RFC-compliant AS. Point `-issuer` at Keycloak, Okta,
+Entra, WorkOS, Descope, etc.
+
+Supersedes the provider-named `../step-up-keycloak` (deprecated).
+
+## What it shows
+
+mcpkit's `ext/auth.NewToolScopeMiddleware` emits the SEP-2350 + RFC 6750 §3.1
+wire shape any spec-conformant server must:
+
+- HTTP 403 with the `WWW-Authenticate` challenge when the bearer token lacks
+  `admin-write`. The handler never runs; the middleware short-circuits.
+- A 2xx when the same call is retried with a sufficiently-scoped token.
+
+`ext/auth.JWTValidator` reads scopes from whichever claim shape the IdP emits —
+`scope` (space-delimited string, Keycloak/RFC 6749), `scopes` (array, oneauth),
+or `scp` (array, Okta/Azure/Entra).
+
+## Run
+
+Against Keycloak (audience unset):
+
+```bash
+go run ./examples/auth/step-up -issuer http://localhost:8180/realms/mcpkit-test
+```
+
+Against Okta (custom AS sets `aud`, so pass `-audience`):
+
+```bash
+# provision + mint tokens from the Okta fixture first:
+#   panyam/mcpconformance examples/auth-fixtures/okta (make provision)
+source <mcpconformance>/examples/auth-fixtures/okta/okta.env
+go run ./examples/auth/step-up -issuer "$OKTA_ISSUER" -audience api://default
+```
+
+Flags: `-addr` (default `:3021`), `-issuer` (defaults to the local Keycloak realm
+`http://localhost:8180/realms/mcpkit-test`; override via `-issuer` or `$MCP_ISSUER`),
+`-audience` (default empty = not validated; Okta needs `api://default`).
+
+## Driving the conformance scenario
+
+The per-provider fixtures (token provisioning + the `MCP_CONFORMANCE_CONTEXT`
+blob) live in `panyam/mcpconformance` under `examples/auth-fixtures/<provider>`.
+Start this SUT against a provider's issuer, mint that provider's context, and
+run the scope-challenge scenario against `http://localhost:3021/mcp`.

--- a/examples/auth/step-up/main.go
+++ b/examples/auth/step-up/main.go
@@ -1,0 +1,160 @@
+// Example: SEP-2350 step-up auth against any OAuth2 authorization server.
+//
+// Experimental. Provider-neutral successor to step-up-keycloak: the SEP-2350
+// scope-challenge wire shape is provider-blind (RFC 6750 Section 3.1 + RFC 9728
+// PRM discovery), so a single SUT validates it against any RFC-compliant AS.
+// Point -issuer at Keycloak, Okta, Entra, WorkOS, Descope, etc. Provider
+// specifics (token provisioning, scope minting) live in the per-provider
+// fixtures under panyam/mcpconformance examples/auth-fixtures/<provider>.
+//
+// What this does:
+//
+//   - Discovers the authorization server at -issuer via oneauth's RFC 8414 +
+//     OIDC-fallback path.
+//   - Validates access tokens regardless of which claim shape the IdP uses for
+//     scopes (scope string, scopes array, scp array) — handled by
+//     ext/auth.JWTValidator.
+//   - Registers one scope-gated tool, admin_call, requiring admin-write.
+//   - Installs auth.NewToolScopeMiddleware so an under-scoped tools/call
+//     returns HTTP 403 + WWW-Authenticate Bearer insufficient_scope per
+//     RFC 6750 Section 3.1, instead of reaching the handler.
+//   - Publishes Protected Resource Metadata at
+//     /.well-known/oauth-protected-resource/mcp pointing at the AS.
+//
+// Runbook: README.md alongside this file. The scope-challenge conformance
+// scenario + per-provider fixtures live in panyam/mcpconformance.
+//
+// Run (Keycloak):
+//
+//	go run ./examples/auth/step-up \
+//	    -issuer http://localhost:8180/realms/mcpkit-test
+//
+// Run (Okta — sets aud on client_credentials, so pass -audience):
+//
+//	source <mcpconformance>/examples/auth-fixtures/okta/okta.env
+//	go run ./examples/auth/step-up -issuer "$OKTA_ISSUER" -audience api://default
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/panyam/mcpkit/core"
+	mcpcommon "github.com/panyam/mcpkit/examples/common"
+	"github.com/panyam/mcpkit/ext/auth"
+	"github.com/panyam/mcpkit/server"
+	oneauthclient "github.com/panyam/oneauth/client"
+)
+
+const (
+	// defaultIssuer points at a local Keycloak realm — free, hermetic, no cloud
+	// account. Override -issuer for Okta/Entra/etc. (see README).
+	defaultIssuer   = "http://localhost:8180/realms/mcpkit-test"
+	scopeToolsRead  = "tools-read"
+	scopeToolsCall  = "tools-call"
+	scopeAdminWrite = "admin-write"
+	scopeAdmin      = "admin"
+)
+
+func envOr(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}
+
+func main() {
+	addr := flag.String("addr", ":3021", "listen address")
+	issuerFlag := flag.String("issuer", envOr("MCP_ISSUER", defaultIssuer),
+		"authorization server issuer URL; defaults to a local Keycloak realm. For Okta: https://<tenant>.okta.com/oauth2/default")
+	audience := flag.String("audience", envOr("MCP_AUDIENCE", ""),
+		"expected aud claim on access tokens (empty = skip; Okta needs api://default, Keycloak leaves it unset)")
+	wire := mcpcommon.RegisterWireFlags(flag.CommandLine)
+	flag.Parse()
+
+	if *issuerFlag == "" {
+		log.Fatal("issuer required: set -issuer or MCP_ISSUER")
+	}
+
+	// AS discovery via oneauth — RFC 8414 with path insertion + OIDC fallback,
+	// which both Keycloak realms and Okta custom authorization servers serve.
+	// Keeps the example aligned with "oneauth is the strategic destination for
+	// MCP auth."
+	asMeta, err := oneauthclient.DiscoverAS(*issuerFlag)
+	if err != nil {
+		log.Fatalf("AS discovery failed against %s: %v", *issuerFlag, err)
+	}
+	issuer := asMeta.Issuer
+	jwksURI := asMeta.JWKSURI
+
+	listenURL := fmt.Sprintf("http://localhost%s", *addr)
+	allScopes := []string{scopeToolsRead, scopeToolsCall, scopeAdminWrite, scopeAdmin}
+
+	prmURL := listenURL + "/.well-known/oauth-protected-resource/mcp"
+	validator := auth.NewJWTValidator(auth.JWTConfig{
+		JWKSURL:             jwksURI,
+		Issuer:              issuer,
+		Audience:            *audience,
+		ResourceMetadataURL: prmURL,
+		AllScopes:           allScopes,
+	})
+	validator.Start()
+	defer validator.Stop()
+
+	log.Printf("step-up: serving %s/mcp", listenURL)
+	log.Printf("  AS issuer:  %s", issuer)
+	log.Printf("  JWKS URI:   %s", jwksURI)
+	if *audience != "" {
+		log.Printf("  audience:   %s", *audience)
+	} else {
+		log.Printf("  audience:   (unset — aud not validated)")
+	}
+	log.Printf("  scope-gated tool: admin_call requires '%s'", scopeAdminWrite)
+
+	cfg := mcpcommon.ServerConfig{
+		Name:    "step-up",
+		Version: "0.1.0-experimental",
+		Addr:    *addr,
+		Wire:    wire,
+		Options: []server.Option{
+			server.WithAuth(validator),
+		},
+		Register: func(srv *server.Server) {
+			// admin_call demonstrates the SEP-2350 OR-hierarchy: a caller
+			// satisfies the gate by holding ANY scope in AcceptedScopes, even
+			// if the literal admin-write scope is absent. The 403 challenge
+			// still advertises requiredScopes only (never accepted-parents)
+			// per the least-privilege rule.
+			srv.Register(core.TextTool[struct{}]("admin_call",
+				"Requires admin-write scope. The OR-hierarchy on AcceptedScopes lets a token with the parent admin scope satisfy the gate too.",
+				func(_ core.ToolContext, _ struct{}) (string, error) {
+					return "admin_call: ok", nil
+				},
+				core.WithToolRequiredScopes(scopeAdminWrite),
+				core.WithToolAcceptedScopes(scopeAdminWrite, scopeAdmin),
+			))
+			srv.UseMiddleware(auth.NewToolScopeMiddleware(srv.Registry(),
+				auth.WithResourceMetadataURL(prmURL),
+			))
+		},
+		TransportOptions: []server.TransportOption{
+			// Dual mode (default) so the scenario's legacy initialize +
+			// session-id handshake works, matching the TS PR 1624 SUT which
+			// speaks the 2025-11-25 wire.
+			server.WithMux(func(mux *http.ServeMux) {
+				auth.MountAuth(mux, auth.AuthConfig{
+					ResourceURI:          listenURL,
+					AuthorizationServers: []string{issuer},
+					ScopesSupported:      allScopes,
+					MCPPath:              "/mcp",
+				})
+			}),
+		},
+	}
+	if err := mcpcommon.RunServer(cfg); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/ext/auth/jwt_validator.go
+++ b/ext/auth/jwt_validator.go
@@ -253,18 +253,20 @@ func (v *JWTValidator) Validate(r *http.Request) error {
 		return v.unauthorized("missing subject")
 	}
 
-	// Extract scopes — handle both formats:
+	// Extract scopes — handle the formats different IdPs emit:
 	//   "scopes": ["read", "write"]  (oneauth array format)
-	//   "scope": "read write"        (Keycloak/RFC 6749 space-delimited string)
+	//   "scp":    ["read", "write"]  (Okta / Azure AD / Entra array format)
+	//   "scope":  "read write"        (Keycloak / RFC 6749 space-delimited string)
+	//   "scp":    "read write"        (some IdPs emit scp as a space-delimited string)
 	var scopes []string
-	if scopesRaw, ok := mapClaims["scopes"].([]any); ok {
-		for _, s := range scopesRaw {
-			if str, ok := s.(string); ok {
-				scopes = append(scopes, str)
-			}
-		}
-	} else if scopeStr, ok := mapClaims["scope"].(string); ok && scopeStr != "" {
-		scopes = strings.Fields(scopeStr)
+	if arr := stringArrayClaim(mapClaims["scopes"]); arr != nil {
+		scopes = arr
+	} else if arr := stringArrayClaim(mapClaims["scp"]); arr != nil {
+		scopes = arr
+	} else if s := scopeStr(mapClaims["scope"]); s != "" {
+		scopes = strings.Fields(s)
+	} else if s := scopeStr(mapClaims["scp"]); s != "" {
+		scopes = strings.Fields(s)
 	}
 
 	// Check required scopes
@@ -280,6 +282,7 @@ func (v *JWTValidator) Validate(r *http.Request) error {
 	standardClaims := map[string]bool{
 		"sub": true, "iss": true, "aud": true, "exp": true,
 		"iat": true, "nbf": true, "jti": true, "type": true, "scopes": true,
+		"scope": true, "scp": true,
 	}
 	customClaims := make(map[string]any)
 	for k, v := range mapClaims {
@@ -437,6 +440,30 @@ func (v *JWTValidator) unauthorized(msg string) *mcpcore.AuthError {
 		Message:         msg,
 		WWWAuthenticate: WWWAuth401(v.ResourceMetadataURL, v.AllScopes...),
 	}
+}
+
+// stringArrayClaim returns the claim as a []string when it is a JSON array of
+// strings (the "scopes" / "scp" array shape oneauth, Okta, and Azure/Entra
+// emit), or nil when the claim is absent or not a string array.
+func stringArrayClaim(raw any) []string {
+	arr, ok := raw.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(arr))
+	for _, s := range arr {
+		if str, ok := s.(string); ok {
+			out = append(out, str)
+		}
+	}
+	return out
+}
+
+// scopeStr returns the claim as a string when it is one (the space-delimited
+// "scope" / "scp" shape Keycloak and RFC 6749 issuers emit), else "".
+func scopeStr(raw any) string {
+	s, _ := raw.(string)
+	return s
 }
 
 // Start begins background JWKS key refresh. Call this once at startup.

--- a/ext/auth/jwt_validator_scopes_test.go
+++ b/ext/auth/jwt_validator_scopes_test.go
@@ -1,0 +1,97 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStringArrayClaim covers the array-shaped scope claim parsing
+// (oneauth "scopes", Okta/Azure/Entra "scp").
+func TestStringArrayClaim(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  any
+		want []string
+	}{
+		{"nil", nil, nil},
+		{"string not array", "read write", nil},
+		{"array of strings", []any{"read", "write"}, []string{"read", "write"}},
+		{"empty array", []any{}, []string{}},
+		{"mixed types skips non-strings", []any{"read", 42, "write"}, []string{"read", "write"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, stringArrayClaim(tc.raw))
+		})
+	}
+}
+
+// TestScopeStr covers the space-delimited string scope claim
+// (Keycloak/RFC 6749 "scope", some IdPs' "scp").
+func TestScopeStr(t *testing.T) {
+	assert.Equal(t, "read write", scopeStr("read write"))
+	assert.Equal(t, "", scopeStr(nil))
+	assert.Equal(t, "", scopeStr([]any{"read"}))
+}
+
+// TestJWTValidator_ScopeClaimShapes proves the validator extracts scopes from
+// every IdP claim format end-to-end (signed token -> JWKS -> RequiredScopes
+// gate). The Okta "scp" array is the case that motivated the change: without
+// it an Okta-issued token parses to zero scopes and every gated call 403s.
+func TestJWTValidator_ScopeClaimShapes(t *testing.T) {
+	cases := []struct {
+		name       string
+		claimSetup func(jwt.MapClaims)
+	}{
+		{"scopes array (oneauth)", func(c jwt.MapClaims) { c["scopes"] = []string{"admin-write"} }},
+		{"scp array (Okta/Entra)", func(c jwt.MapClaims) { c["scp"] = []string{"admin-write"} }},
+		{"scope string (Keycloak)", func(c jwt.MapClaims) { c["scope"] = "tools-read admin-write" }},
+		{"scp string", func(c jwt.MapClaims) { c["scp"] = "admin-write" }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			jwksURL, issuer, token, cleanup := setupTestJWKSClaims(t, func(c jwt.MapClaims) {
+				c["sub"] = "alice"
+				tc.claimSetup(c)
+			})
+			defer cleanup()
+
+			v := NewJWTValidator(JWTConfig{
+				JWKSURL:        jwksURL,
+				Issuer:         issuer,
+				Audience:       "https://mcp.test",
+				RequiredScopes: []string{"admin-write"},
+			})
+			r := requestWithActiveSpan(token, nil)
+			// A token carrying admin-write in any claim shape must satisfy the
+			// RequiredScopes gate — i.e. Validate returns no error.
+			require.NoError(t, v.Validate(r), "admin-write should satisfy the gate for %s", tc.name)
+
+			claims := v.Claims(r)
+			require.NotNil(t, claims)
+			assert.Contains(t, claims.Scopes, "admin-write")
+		})
+	}
+}
+
+// TestJWTValidator_ScopeClaimPrecedence documents that "scopes" wins over
+// "scp" when both are present, matching the extraction order.
+func TestJWTValidator_ScopeClaimPrecedence(t *testing.T) {
+	jwksURL, issuer, token, cleanup := setupTestJWKSClaims(t, func(c jwt.MapClaims) {
+		c["sub"] = "alice"
+		c["scopes"] = []string{"admin-write"}
+		c["scp"] = []string{"tools-read"}
+	})
+	defer cleanup()
+
+	v := NewJWTValidator(JWTConfig{JWKSURL: jwksURL, Issuer: issuer, Audience: "https://mcp.test"})
+	r := requestWithActiveSpan(token, nil)
+	require.NoError(t, v.Validate(r))
+
+	claims := v.Claims(r)
+	require.NotNil(t, claims)
+	assert.Equal(t, []string{"admin-write"}, claims.Scopes, "scopes claim takes precedence over scp")
+}

--- a/ext/auth/jwt_validator_trace_test.go
+++ b/ext/auth/jwt_validator_trace_test.go
@@ -34,10 +34,10 @@ type fakeSpan struct {
 	ended  bool
 }
 
-func (s *fakeSpan) End()                            { s.ended = true }
-func (s *fakeSpan) SetAttribute(k, v string)        { s.attrs[k] = v }
-func (s *fakeSpan) RecordError(err error)           { s.errors = append(s.errors, err) }
-func (s *fakeSpan) AddLink(mcpcore.Link)            {}
+func (s *fakeSpan) End()                     { s.ended = true }
+func (s *fakeSpan) SetAttribute(k, v string) { s.attrs[k] = v }
+func (s *fakeSpan) RecordError(err error)    { s.errors = append(s.errors, err) }
+func (s *fakeSpan) AddLink(mcpcore.Link)     {}
 
 type fakeTracerProvider struct {
 	mu    sync.Mutex
@@ -233,6 +233,17 @@ func TestJWTValidator_Trace_FullValidate_NoActiveSpan_StillEmitsJWKSChild(t *tes
 // per-test fixture self-contained — examples/auth/common can't be
 // imported (it depends on ext/auth — would be a cycle).
 func setupTestJWKS(t *testing.T, subject string, scopes []string) (jwksURL, issuer, token string, cleanup func()) {
+	return setupTestJWKSClaims(t, func(c jwt.MapClaims) {
+		c["sub"] = subject
+		c["scopes"] = scopes
+	})
+}
+
+// setupTestJWKSClaims is setupTestJWKS with full control over the token's
+// claim set (mutate receives the base claims — iss/aud/exp/iat prefilled — and
+// adds sub/scope-shape/etc). Lets tests mint tokens in each IdP's scope claim
+// format (scopes/scp array, scope/scp string) against a real JWKS.
+func setupTestJWKSClaims(t *testing.T, mutate func(jwt.MapClaims)) (jwksURL, issuer, token string, cleanup func()) {
 	t.Helper()
 
 	privPEM, pubPEM, err := utils.GenerateRSAKeyPair(2048)
@@ -272,13 +283,12 @@ func setupTestJWKS(t *testing.T, subject string, scopes []string) (jwksURL, issu
 	issuer = "https://test.example.com"
 
 	claims := jwt.MapClaims{
-		"iss":    issuer,
-		"aud":    "https://mcp.test",
-		"sub":    subject,
-		"exp":    time.Now().Add(time.Hour).Unix(),
-		"iat":    time.Now().Unix(),
-		"scopes": scopes,
+		"iss": issuer,
+		"aud": "https://mcp.test",
+		"exp": time.Now().Add(time.Hour).Unix(),
+		"iat": time.Now().Unix(),
 	}
+	mutate(claims)
 	jwtTok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
 	jwtTok.Header["kid"] = kid
 	token, err = jwtTok.SignedString(privKey)


### PR DESCRIPTION
## What changes

Extends the SEP-2350 server-side scope-challenge work to validate against **real Okta** in addition to Keycloak. The behavioral delta is in `ext/auth`: `JWTValidator` now reads OAuth scopes from the `scp` claim (Okta / Azure AD / Entra), not just `scope`/`scopes` — without it an Okta access token parses to zero scopes and a correctly-scoped call is wrongly rejected 403. The examples change collapses the per-provider step-up SUTs into one provider-neutral binary, since the scope-challenge wire shape is provider-blind.

## The flow this validates

```mermaid
sequenceDiagram
    participant C as MCP Client
    participant S as step-up SUT (mcpkit)
    participant AS as Authorization Server<br/>(Okta / Keycloak)
    C->>AS: client_credentials (scope: tools-read)
    AS-->>C: access token (under-scoped)
    C->>S: tools/call admin_call + Bearer <under-scoped>
    Note over S: JWTValidator extracts scopes from<br/>scp / scope / scopes claim
    S-->>C: 403 insufficient_scope<br/>WWW-Authenticate: Bearer scope="admin-write", resource_metadata=...
    C->>AS: client_credentials (scope: admin-write) — step-up
    AS-->>C: access token (sufficient)
    C->>S: tools/call admin_call + Bearer <sufficient>
    Note over S: scp=[admin-write] now parsed → gate passes
    S-->>C: 200 admin_call: ok
```

One SUT validates any RFC-compliant AS; only the fixture (token minting) is provider-specific:

```mermaid
sequenceDiagram
    participant Sc as Conformance scenario<br/>(scope-challenge)
    participant Fx as Fixture<br/>(make tokens-context)
    participant AS as AS (Okta OR Keycloak)
    participant S as step-up SUT<br/>(one binary, -issuer/-audience)
    Fx->>AS: mint insufficient / sufficient / acceptedHierarchy tokens
    Fx-->>Sc: MCP_CONFORMANCE_CONTEXT
    Sc->>S: drive 9 checks against SUT /mcp
    S-->>Sc: 9/9 SUCCESS
```

## Reviewer's guide

Read in this order:

1. [ext/auth/jwt_validator.go](https://github.com/panyam/mcpkit/pull/841/files#diff-e6c5bfccc6d222d3735a5835e709c9f8ad03ca99e4739143cbcc146154806a87) — start here. The fix: scope extraction now falls through `scopes` (array) → `scp` (array) → `scope` (string) → `scp` (string); new `stringArrayClaim`/`scopeStr` helpers; `scope`/`scp` added to the standard-claims skip set so they don't leak into custom claims.
2. [ext/auth/jwt_validator_scopes_test.go](https://github.com/panyam/mcpkit/pull/841/files#diff-e6e8de59b3784ca235d74931611446f09631b3110382ab03efe321d30532627e) — acceptance: table-driven helper tests + end-to-end validation that a token carrying `admin-write` in any claim shape clears the gate, plus a precedence test (`scopes` wins over `scp`).
3. [ext/auth/jwt_validator_trace_test.go](https://github.com/panyam/mcpkit/pull/841/files#diff-3901668eec67863f21ed4d454064d67d5e63ba7793158080588cf3f4afeeed85) — mechanical: `setupTestJWKS` refactored into `setupTestJWKSClaims` (non-breaking) so tests can mint tokens in each IdP's claim format.
4. [examples/auth/step-up/main.go](https://github.com/panyam/mcpkit/pull/841/files#diff-321580219d9b2e3b83d43929627dbb039b4d025f68f65fbeb0ffed2a19a1e18b) — the provider-neutral SUT. `-issuer`/`-audience` flags, defaults to a local Keycloak realm.
5. [examples/auth/step-up-keycloak/main.go](https://github.com/panyam/mcpkit/pull/841/files#diff-f5733274858681e28244e8a9477b223e7ce2eb2fb5e608638a9953d8da5ab850) — deprecation banner only; kept for the in-flight review.

Skim or skip: [examples/auth/step-up/README.md](https://github.com/panyam/mcpkit/pull/841/files#diff-5cd5d452681bf1b0272b9562fba50a0524a08d609aca16828d20dc486331d23c), [examples/auth/step-up/Makefile](https://github.com/panyam/mcpkit/pull/841/files#diff-32a32b85da836aad89a7f50f1af6e510ec1f28eeaa2f963beb6ce048943c4406), [examples/auth/step-up-keycloak/README.md](https://github.com/panyam/mcpkit/pull/841/files#diff-4ef44eed0fef359cbb0905107713ace428c7e7a1c7540dac6580e2ca82869104) (docs/runner).

## Decision log

- **Parse `scp` in the validator, rather than making adopters remap claims.** Okta/Azure/Entra emit scopes in `scp` per RFC 9068; handling it in-validator keeps mcpkit provider-agnostic out of the box.
- **Precedence `scopes` → `scp` → `scope`(str) → `scp`(str).** `scopes` (oneauth-native) stays first for back-compat; documented and locked by a precedence test.
- **One generic `step-up` SUT over per-provider binaries.** The 403/challenge wire shape (RFC 6750 §3.1 + RFC 9728) is provider-blind, so a per-provider SUT is ~140 LOC of duplication with no payoff. Provider specifics live in the fixtures.
- **Kept `step-up-keycloak` (deprecated) instead of deleting it.** It's referenced by the in-flight mcpconformance PR 19 review; removal deferred to a later release.
- **`step-up` defaults to Keycloak, not Okta.** Free, local, hermetic, no cloud account — keeps the example runnable by anyone.
- **Audience validated for Okta (`api://default`), unset for Keycloak.** Okta stamps `aud` on client_credentials tokens; Keycloak does not.

## Risk / blast radius

- **Affects:** every `JWTValidator` consumer (the scope-extraction path). New `scp` branches only add scope sources; existing `scopes`/`scope` behavior is unchanged (precedence keeps `scopes` first). `standardClaims` now also skips `scope`/`scp`, so a consumer that previously read `scope` out of `Claims.Extra` would no longer see it there — previously it leaked into `Extra`; this is arguably a fix, but flagging it.
- **Tests covering this:** `jwt_validator_scopes_test.go` (all claim shapes + precedence); existing trace tests still green after the helper refactor.
- **Be paranoid about:** the precedence order when a token carries more than one scope claim; the rare `scp`-as-string fallback; anyone downstream relying on `scope` appearing in `Claims.Extra`.

## Before / after

`scope-challenge` conformance scenario, one generic SUT, both providers:

| Provider | SUT | Result |
|---|---|---|
| Okta (real tenant, `default` custom AS) | `step-up -issuer $OKTA_ISSUER -audience api://default` | 9/9 SUCCESS |
| Keycloak (local docker fixture) | `step-up` (default issuer) | 9/9 SUCCESS |

The Okta fixture (provisioning + token minting) lives in the mcpconformance PR 19 branch under `examples/auth-fixtures/okta`.

## Out of scope (deliberately deferred)

- Env-gated Go integration test (Okta variant of `tests/keycloak/step_up_test.go`, skip-unless-`OKTA_*`).
- Multi-issuer simultaneous trust (a `JWTValidator` is single-issuer today) — separate feature, and undesirable for conformance where each run wants one deterministic AS.
- Running the TypeScript PR 1624 reference SUT against Okta for the cross-SDK half of the evidence.
- Descope fixture (next provider), with Entra/WorkOS as fallbacks.

