### PR TITLE
fix(skills-core): install the demo renderer so --tui works

### DIFF
--- a/examples/skills-core/walkthrough.go
+++ b/examples/skills-core/walkthrough.go
@@ -207,6 +207,7 @@ for _, e := range idx.Skills {
 			return nil
 		})
 
+	common.SetupRenderer(demo)
 	demo.Execute()
 }
 


### PR DESCRIPTION
Follow-up to PR 840.

`examples/skills-core` called `demo.Execute()` without `common.SetupRenderer(demo)`, so demokit fell back to the plain renderer — `make demo` (`go run . --tui`) never showed the TUI. Every other non-UI example (including `examples/skills`) calls `SetupRenderer` right before `Execute`; it selects the tui / notebook renderer from `demokit.Mode()` and registers the web renderer.

One line added, matching the canonical pattern. Doc output (`WALKTHROUGH.md`) is unaffected — `SetupRenderer` only touches interactive rendering.

## Testing
- `go build ./...` clean
- `WALKTHROUGH.md` regenerates identically (renderer wiring doesn't affect doc mode)
- Note: verifying the rendered TUI needs a real terminal; the wiring is now identical to the working `examples/skills`.