### PR TITLE
feat(ext/auth): CIMD client-id support in EnterpriseManagedTokenSource

### DIFF
--- a/ext/auth/enterprise_managed.go
+++ b/ext/auth/enterprise_managed.go
@@ -41,15 +41,27 @@ type EnterpriseManagedTokenSource struct {
 
 	// ClientSecret authenticates the MCP client at the AS via
 	// `client_secret_basic` (RFC 6749 §2.3.1) on the jwt-bearer grant
-	// request. Required.
+	// request. Required when ClientID is set (confidential client); leave
+	// empty when using ClientMetadataURL (public CIMD client).
 	ClientSecret string
+
+	// ClientMetadataURL is a CIMD (Client ID Metadata Document) URL
+	// (draft-ietf-oauth-client-id-metadata-document). When set and ClientID
+	// is empty, this URL is used as the client_id — a public client with no
+	// secret. This is the DCR-free client-identity path from ID-JAG draft §5:
+	// a globally-resolvable client_id the IdP can embed in the ID-JAG without
+	// the client having pre-registered at the MCP AS. ClientID
+	// (pre-registration) takes priority when both are set.
+	ClientMetadataURL string
 
 	// IdpClientID is the client identity sent on the IdP token exchange.
 	// SEP-990 §6.1 notes the IdP "needs to be aware of the MCP Client's
 	// client_id that it normally uses with the MCP Server"; this field
 	// names the client at the IdP, which may differ from ClientID above.
 	// Optional — empty falls back to the unauthenticated token-exchange
-	// path (AuthMethodNone), which the conformance fixture accepts.
+	// path (AuthMethodNone), which the conformance fixture accepts. When
+	// empty and ClientMetadataURL is set, the CIMD URL is used as the
+	// IdP-side client_id too, keeping one global identity across both stages.
 	IdpClientID string
 
 	// IdpIDToken is the signed ID token issued by the IdP for the user.
@@ -114,11 +126,8 @@ func (s *EnterpriseManagedTokenSource) ensureDiscoveredLocked() error {
 	if s.authInfo != nil {
 		return nil
 	}
-	if s.ClientID == "" {
-		return fmt.Errorf("EnterpriseManagedTokenSource: ClientID is required")
-	}
-	if s.ClientSecret == "" {
-		return fmt.Errorf("EnterpriseManagedTokenSource: ClientSecret is required")
+	if _, _, err := s.resolveClientID(); err != nil {
+		return err
 	}
 	if s.IdpIDToken == "" {
 		return fmt.Errorf("EnterpriseManagedTokenSource: IdpIDToken is required")
@@ -147,9 +156,44 @@ func (s *EnterpriseManagedTokenSource) ensureDiscoveredLocked() error {
 	return nil
 }
 
+// resolveClientID resolves the MCP client's identity at the MCP authorization
+// server, in priority order:
+//  1. Pre-registered ClientID (with ClientSecret) — a confidential client.
+//  2. ClientMetadataURL — a CIMD URL used as the client_id with no secret (a
+//     public client). Enables the DCR-free path in ID-JAG draft §5.
+//
+// Returns an error if neither is set, or if the CIMD URL is malformed. Mirrors
+// OAuthTokenSource.resolveClientID (minus DCR, which the EMA flow does not use).
+func (s *EnterpriseManagedTokenSource) resolveClientID() (clientID, clientSecret string, err error) {
+	if s.ClientID != "" {
+		if s.ClientSecret == "" {
+			return "", "", fmt.Errorf("EnterpriseManagedTokenSource: ClientSecret is required when ClientID is set")
+		}
+		return s.ClientID, s.ClientSecret, nil
+	}
+	if s.ClientMetadataURL != "" {
+		if err := client.ValidateCIMDURL(s.ClientMetadataURL); err != nil {
+			return "", "", fmt.Errorf("EnterpriseManagedTokenSource: invalid ClientMetadataURL: %w", err)
+		}
+		return s.ClientMetadataURL, "", nil
+	}
+	return "", "", fmt.Errorf("EnterpriseManagedTokenSource: client identity required — set ClientID (with ClientSecret) or ClientMetadataURL")
+}
+
 func (s *EnterpriseManagedTokenSource) refetchLocked() (string, error) {
 	asIssuer := s.authInfo.AuthorizationServers[0]
 	asTokenEndpoint := s.authInfo.ASMetadata.TokenEndpoint
+
+	clientID, clientSecret, err := s.resolveClientID()
+	if err != nil {
+		return "", err
+	}
+	// The IdP-side client_id defaults to the CIMD URL when IdpClientID is
+	// unset, so a single global client identity flows through both stages.
+	idpClientID := s.IdpClientID
+	if idpClientID == "" {
+		idpClientID = s.ClientMetadataURL
+	}
 
 	// Stage 1 — IdP RFC 8693 token exchange. ClientSecret/ClientAssertion
 	// are intentionally left empty: SEP-990 has the IdP authorize on the
@@ -160,7 +204,7 @@ func (s *EnterpriseManagedTokenSource) refetchLocked() (string, error) {
 
 	// oneauth 0.1.9 (#217): TokenExchange now takes (ctx, *TokenExchangeRequest).
 	exch, err := idp.TokenExchange(context.Background(), &client.TokenExchangeRequest{
-		ClientID:           s.IdpClientID,
+		ClientID:           idpClientID,
 		SubjectToken:       s.IdpIDToken,
 		SubjectTokenType:   "urn:ietf:params:oauth:token-type:id_token",
 		RequestedTokenType: "urn:ietf:params:oauth:token-type:id-jag",
@@ -174,8 +218,9 @@ func (s *EnterpriseManagedTokenSource) refetchLocked() (string, error) {
 		return "", fmt.Errorf("idp token exchange returned no access_token")
 	}
 
-	// Stage 2 — AS RFC 7523 §2.1 jwt-bearer grant. ClientSecret travels via
-	// client_secret_basic per the AS's advertised auth methods.
+	// Stage 2 — AS RFC 7523 §2.1 jwt-bearer grant. A pre-registered ClientID
+	// authenticates via client_secret_basic; a CIMD client sends client_id
+	// only (oneauth's SelectAuthMethod picks AuthMethodNone on empty secret).
 	as := client.NewAuthClient(asTokenEndpoint, nil,
 		client.WithASMetadata(&client.ASMetadata{
 			TokenEndpoint:            asTokenEndpoint,
@@ -183,8 +228,8 @@ func (s *EnterpriseManagedTokenSource) refetchLocked() (string, error) {
 		}))
 
 	cred, err := as.JwtBearerGrant(context.Background(), &client.JwtBearerGrantRequest{
-		ClientID:     s.ClientID,
-		ClientSecret: s.ClientSecret,
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
 		Assertion:    exch.AccessToken,
 	})
 	if err != nil {

--- a/ext/auth/enterprise_managed_test.go
+++ b/ext/auth/enterprise_managed_test.go
@@ -24,6 +24,7 @@ type asRequest struct {
 	grantType     string
 	assertion     string
 	authorization string
+	clientID      string
 }
 
 // enterpriseMockServers stands up two httptest.Servers — one for the IdP
@@ -103,6 +104,7 @@ func newEnterpriseMockServers(t *testing.T) *enterpriseMockServers {
 			grantType:     r.PostForm.Get("grant_type"),
 			assertion:     r.PostForm.Get("assertion"),
 			authorization: r.Header.Get("Authorization"),
+			clientID:      r.PostForm.Get("client_id"),
 		}
 		if m.asResponder != nil {
 			status, body := m.asResponder(m.lastAS)
@@ -217,6 +219,76 @@ func TestEnterpriseManagedTokenSource_IdpClientIDFlowsThrough(t *testing.T) {
 	}
 }
 
+// TestEnterpriseManagedTokenSource_CIMD_RoundTrip verifies the DCR-free path:
+// a CIMD client-id URL (no ClientID/ClientSecret) travels as client_id at both
+// the IdP exchange and the MCP AS grant, with no client secret (public client).
+func TestEnterpriseManagedTokenSource_CIMD_RoundTrip(t *testing.T) {
+	mock := newEnterpriseMockServers(t)
+	const cimd = "https://client.example.com/metadata.json"
+	ts := &EnterpriseManagedTokenSource{
+		ServerURL:         mock.mcpAndAS.URL + "/mcp",
+		ClientMetadataURL: cimd, // instead of ClientID/ClientSecret
+		IdpIDToken:        "idtoken12345abcdef",
+		IdpTokenEndpoint:  mock.idp.URL + "/token",
+		HTTPClient:        mock.mcpAndAS.Client(),
+		AllowInsecure:     true,
+	}
+	if _, err := ts.Token(); err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	// Stage 2 (MCP AS): CIMD URL is the client_id; no basic auth / secret.
+	if got := mock.lastAS.clientID; got != cimd {
+		t.Errorf("as client_id = %q, want %q", got, cimd)
+	}
+	if mock.lastAS.authorization != "" {
+		t.Errorf("as Authorization = %q, want empty (public CIMD client)", mock.lastAS.authorization)
+	}
+	// Stage 1 (IdP): CIMD URL flows through as the IdP-side client_id too
+	// (IdpClientID unset), keeping one global identity across both stages.
+	if got := mock.lastIdp.clientID; got != cimd {
+		t.Errorf("idp client_id = %q, want %q", got, cimd)
+	}
+}
+
+// TestEnterpriseManagedTokenSource_CIMD_PriorityAndValidation covers the
+// pre-registered-wins-over-CIMD precedence and CIMD URL validation.
+func TestEnterpriseManagedTokenSource_CIMD_PriorityAndValidation(t *testing.T) {
+	t.Run("pre-registered ClientID wins over CIMD", func(t *testing.T) {
+		mock := newEnterpriseMockServers(t)
+		ts := &EnterpriseManagedTokenSource{
+			ServerURL:         mock.mcpAndAS.URL + "/mcp",
+			ClientID:          "mcp-client",
+			ClientSecret:      "mcp-secret",
+			ClientMetadataURL: "https://client.example.com/metadata.json",
+			IdpIDToken:        "idtoken12345abcdef",
+			IdpTokenEndpoint:  mock.idp.URL + "/token",
+			HTTPClient:        mock.mcpAndAS.Client(),
+			AllowInsecure:     true,
+		}
+		if _, err := ts.Token(); err != nil {
+			t.Fatalf("Token: %v", err)
+		}
+		if !strings.HasPrefix(mock.lastAS.authorization, "Basic ") {
+			t.Errorf("as Authorization = %q, want Basic (ClientID takes priority over CIMD)", mock.lastAS.authorization)
+		}
+	})
+	t.Run("invalid CIMD URL", func(t *testing.T) {
+		mock := newEnterpriseMockServers(t)
+		ts := &EnterpriseManagedTokenSource{
+			ServerURL:         mock.mcpAndAS.URL + "/mcp",
+			ClientMetadataURL: "http://client.example.com/metadata.json", // not https
+			IdpIDToken:        "idtoken12345abcdef",
+			IdpTokenEndpoint:  mock.idp.URL + "/token",
+			HTTPClient:        mock.mcpAndAS.Client(),
+			AllowInsecure:     true,
+		}
+		_, err := ts.Token()
+		if err == nil || !strings.Contains(err.Error(), "ClientMetadataURL") {
+			t.Errorf("err = %v, want ClientMetadataURL validation error", err)
+		}
+	})
+}
+
 func TestEnterpriseManagedTokenSource_ValidationErrors(t *testing.T) {
 	mock := newEnterpriseMockServers(t)
 	base := EnterpriseManagedTokenSource{
@@ -233,7 +305,7 @@ func TestEnterpriseManagedTokenSource_ValidationErrors(t *testing.T) {
 		mut     func(*EnterpriseManagedTokenSource)
 		wantMsg string
 	}{
-		{"missing ClientID", func(s *EnterpriseManagedTokenSource) { s.ClientID = "" }, "ClientID is required"},
+		{"missing client identity", func(s *EnterpriseManagedTokenSource) { s.ClientID = "" }, "client identity required"},
 		{"missing ClientSecret", func(s *EnterpriseManagedTokenSource) { s.ClientSecret = "" }, "ClientSecret is required"},
 		{"missing IdpIDToken", func(s *EnterpriseManagedTokenSource) { s.IdpIDToken = "" }, "IdpIDToken is required"},
 		{"missing IdpTokenEndpoint", func(s *EnterpriseManagedTokenSource) { s.IdpTokenEndpoint = "" }, "IdpTokenEndpoint is required"},


### PR DESCRIPTION
## What changes

`EnterpriseManagedTokenSource` (the SEP-990 enterprise-managed auth / ID-JAG flow) can now present a **CIMD** (Client ID Metadata Document) URL as its client identity instead of a statically pre-registered `client_id` + secret. This is the DCR-free path described in ID-JAG draft §5: a globally-resolvable `client_id` URL the enterprise IdP can embed in the ID-JAG without the client having pre-registered at the MCP authorization server. Answers a live question in the enterprise-managed-auth interest group (Kevin Gao, Descope) and closes gap G1 tracked there.

## Reviewer's guide

Read in this order:

1. [ext/auth/enterprise_managed.go](https://github.com/panyam/mcpkit/pull/843/files#diff-6634b8e08a5db7dcc2c2b3031cbfb3d9338a20df245773c9a42435a11f8e898d) — start here. New `ClientMetadataURL` field + `resolveClientID` (pre-registered `ClientID`+secret → CIMD URL public client → error), mirroring `OAuthTokenSource.resolveClientID` minus DCR. `refetchLocked` resolves the client id once and defaults the IdP-side `client_id` to the CIMD URL so one identity crosses both stages.
2. [ext/auth/enterprise_managed_test.go](https://github.com/panyam/mcpkit/pull/843/files#diff-045799bb4fb8a56b38e1d7d587da7561d350fee5cb9d8e69595577218b20aa4c) — acceptance. CIMD round-trip (`client_id` at both the IdP exchange and the AS grant, no basic auth), pre-registered-wins-over-CIMD precedence, invalid-CIMD-URL rejection. Harness now captures the AS-side `client_id` form value.

## Decision log

- **CIMD flows through both stages, not just the AS grant.** When `IdpClientID` is unset, the CIMD URL also becomes the IdP-side `client_id`. §5's whole point is one global client identity the IdP and AS both resolve; splitting them reintroduces the mapping problem. Still overridable via `IdpClientID` for IdPs that key on a different id.
- **Pre-registration takes priority over CIMD** (matches `OAuthTokenSource`): if both `ClientID` and `ClientMetadataURL` are set, the confidential `ClientID` wins.
- **No oneauth change.** `buildTokenRequest` already runs `SelectAuthMethod(clientSecret, ...)`; an empty secret selects `AuthMethodNone` and sends `client_id` only. `client.ValidateCIMDURL` already exists. So the public-client wire behavior is inherited, not reimplemented.
- **DCR intentionally not added to the EMA source.** The EMA flow has no interactive registration step; CIMD is the DCR-free answer §5 calls for.

## Risk / blast radius

- **Affects**: `EnterpriseManagedTokenSource` only. Existing pre-registered `ClientID`+`ClientSecret` callers are unchanged — the confidential path is still first in `resolveClientID` and still uses `client_secret_basic`. Validation moved into `resolveClientID`; the only observable message change is the "no client identity" error (was "ClientID is required").
- **Tests**: `enterprise_managed_test.go` — +5 assertions, 1 changed (error-message expectation, same strength), 0 weakened. Full `ext/auth` suite green.
- **Be paranoid about**: the two-stage identity threading — confirm the CIMD URL lands as `client_id` at *both* the IdP exchange and the AS grant (covered by CIMD_RoundTrip), and that a pre-registered client still authenticates via basic auth (covered by the precedence test).

## Before / after

```
=== RUN   TestEnterpriseManagedTokenSource_CIMD_RoundTrip
--- PASS
=== RUN   TestEnterpriseManagedTokenSource_CIMD_PriorityAndValidation
    --- PASS  pre-registered ClientID wins over CIMD
    --- PASS  invalid CIMD URL
--- PASS
ok  github.com/panyam/mcpkit/ext/auth
```

## Out of scope (deliberately deferred)

- Real-IdP EMA integration test against Entra/Descope (needs a provider fixture; the interop-level proof) — gap G2 in enterprise-managed-auth-ig.
- Agent-vs-user `act` claim — blocked on upstream ext-auth#13 (gap G3).
- Pre-existing `copylocks` vet warnings in the `*_test.go` value-copy validation tables (not introduced here).

