### PR TITLE
examples: typed tool registration (non-conformance examples)

### DIFF
--- a/examples/elicitation/main.go
+++ b/examples/elicitation/main.go
@@ -372,29 +372,18 @@ func serve() {
 		TracerProvider: tp,
 		Wire:           wire,
 		Register: func(srv *server.Server) {
-			srv.RegisterTool(
-				core.ToolDef{
-					Name:        "access_protected_resource",
-					Description: "Access a protected resource. Requires user approval via URL consent flow on first call.",
-					InputSchema: json.RawMessage(`{
-						"type": "object",
-						"properties": {
-							"resourceId": {"type": "string", "description": "Resource to access"}
-						}
-					}`),
-				},
-				func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
-					var args struct {
-						ResourceID string `json:"resourceId"`
+			type accessInput struct {
+				ResourceID string `json:"resourceId,omitempty" jsonschema:"description=Resource to access"`
+			}
+			srv.Register(core.TextTool[accessInput]("access_protected_resource", "Access a protected resource. Requires user approval via URL consent flow on first call.",
+				func(ctx core.ToolContext, input accessInput) (string, error) {
+					rid := input.ResourceID
+					if rid == "" {
+						rid = "default-resource"
 					}
-					json.Unmarshal(req.Arguments, &args)
-					if args.ResourceID == "" {
-						args.ResourceID = "default-resource"
-					}
-					return core.TextResult(fmt.Sprintf(
-						"Access granted to resource %q (approved via consent)", args.ResourceID)), nil
+					return fmt.Sprintf("Access granted to resource %q (approved via consent)", rid), nil
 				},
-			)
+			))
 			srv.UseMiddleware(consentMiddleware(consent, listenURL))
 		},
 		TransportOptions: []server.TransportOption{

--- a/examples/fine-grained-auth/main.go
+++ b/examples/fine-grained-auth/main.go
@@ -956,96 +956,62 @@ func docPath(docID string) string {
 // --- Tool registration ---
 
 func registerTools(srv *server.Server) {
-	srv.RegisterTool(
-		core.ToolDef{
-			Name:           "read_document",
-			Description:    "Read a document from the document store. Requires tools-read scope.",
-			RequiredScopes: []string{scopeRead},
-			InputSchema: json.RawMessage(`{
-				"type": "object",
-				"properties": {
-					"docId": {"type": "string", "description": "Document ID (seeds: doc-001, doc-123, doc-456)"}
-				}
-			}`),
-		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
-			var args struct {
-				DocID string `json:"docId"`
+	type readDocInput struct {
+		DocID string `json:"docId,omitempty" jsonschema:"description=Document ID (seeds doc-001 / doc-123 / doc-456)"`
+	}
+	srv.Register(core.TypedTool[readDocInput, core.ToolResult]("read_document",
+		"Read a document from the document store. Requires tools-read scope.",
+		func(ctx core.ToolContext, input readDocInput) (core.ToolResult, error) {
+			docID := input.DocID
+			if docID == "" {
+				docID = "doc-001"
 			}
-			json.Unmarshal(req.Arguments, &args)
-			if args.DocID == "" {
-				args.DocID = "doc-001"
-			}
-			body, err := os.ReadFile(docPath(args.DocID))
+			body, err := os.ReadFile(docPath(docID))
 			if err != nil {
 				if os.IsNotExist(err) {
 					return core.ErrorResult(fmt.Sprintf(
-						"document %q not found in %s", args.DocID, docDir)), nil
+						"document %q not found in %s", docID, docDir)), nil
 				}
-				return core.ErrorResult(fmt.Sprintf("read %q: %v", args.DocID, err)), nil
+				return core.ErrorResult(fmt.Sprintf("read %q: %v", docID, err)), nil
 			}
-			return core.TextResult(fmt.Sprintf("[%s] %s", args.DocID, body)), nil
+			return core.TextResult(fmt.Sprintf("[%s] %s", docID, body)), nil
 		},
-	)
+		core.WithToolRequiredScopes(scopeRead),
+	))
 
-	srv.RegisterTool(
-		core.ToolDef{
-			Name:           "update_document",
-			Description:    "Write content to a document in the store. Requires tools-call scope.",
-			RequiredScopes: []string{scopeCall},
-			InputSchema: json.RawMessage(`{
-				"type": "object",
-				"properties": {
-					"docId":   {"type": "string", "description": "Document ID (will be created if it doesn't exist)"},
-					"content": {"type": "string", "description": "New content"}
-				},
-				"required": ["docId", "content"]
-			}`),
-		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
-			var args struct {
-				DocID   string `json:"docId"`
-				Content string `json:"content"`
-			}
-			json.Unmarshal(req.Arguments, &args)
-			path := docPath(args.DocID)
-			if err := os.WriteFile(path, []byte(args.Content), 0o644); err != nil {
-				return core.ErrorResult(fmt.Sprintf("write %q: %v", args.DocID, err)), nil
+	type updateDocInput struct {
+		DocID   string `json:"docId" jsonschema:"description=Document ID (created if it doesn't exist),required"`
+		Content string `json:"content" jsonschema:"description=New content,required"`
+	}
+	srv.Register(core.TypedTool[updateDocInput, core.ToolResult]("update_document",
+		"Write content to a document in the store. Requires tools-call scope.",
+		func(ctx core.ToolContext, input updateDocInput) (core.ToolResult, error) {
+			path := docPath(input.DocID)
+			if err := os.WriteFile(path, []byte(input.Content), 0o644); err != nil {
+				return core.ErrorResult(fmt.Sprintf("write %q: %v", input.DocID, err)), nil
 			}
 			return core.TextResult(fmt.Sprintf(
 				"Document %q updated (%d bytes written to %s).",
-				args.DocID, len(args.Content), path)), nil
+				input.DocID, len(input.Content), path)), nil
 		},
-	)
+		core.WithToolRequiredScopes(scopeCall),
+	))
 
-	srv.RegisterTool(
-		core.ToolDef{
-			Name:        "initiate_payment",
-			Description: "Initiate a payment. Requires an RAR-bound token with payment_initiation authorization_details (UC3).",
-			// Authorization is checked by paymentAuthorizationMiddleware (registered
-			// alongside scope middleware in serve()). Handler runs only on success.
-			InputSchema: json.RawMessage(`{
-				"type": "object",
-				"properties": {
-					"amount":   {"type": "string", "description": "Payment amount"},
-					"currency": {"type": "string", "description": "Currency code (e.g., EUR, USD)"},
-					"payee":    {"type": "string", "description": "Payee name"}
-				},
-				"required": ["amount", "currency", "payee"]
-			}`),
-		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
-			var args struct {
-				Amount   string `json:"amount"`
-				Currency string `json:"currency"`
-				Payee    string `json:"payee"`
-			}
-			json.Unmarshal(req.Arguments, &args)
-			return core.TextResult(fmt.Sprintf(
+	// initiate_payment: authorization is checked by paymentAuthorizationMiddleware
+	// (registered alongside scope middleware in serve()). Handler runs only on success.
+	type paymentInput struct {
+		Amount   string `json:"amount" jsonschema:"description=Payment amount,required"`
+		Currency string `json:"currency" jsonschema:"description=Currency code (e.g. EUR / USD),required"`
+		Payee    string `json:"payee" jsonschema:"description=Payee name,required"`
+	}
+	srv.Register(core.TextTool[paymentInput]("initiate_payment",
+		"Initiate a payment. Requires an RAR-bound token with payment_initiation authorization_details (UC3).",
+		func(ctx core.ToolContext, input paymentInput) (string, error) {
+			return fmt.Sprintf(
 				"Payment of %s %s to %s initiated successfully.",
-				args.Amount, args.Currency, args.Payee)), nil
+				input.Amount, input.Currency, input.Payee), nil
 		},
-	)
+	))
 }
 
 // paymentAuthorizationMiddleware short-circuits tools/call for initiate_payment

--- a/examples/host/01-apphost/WALKTHROUGH.md
+++ b/examples/host/01-apphost/WALKTHROUGH.md
@@ -1,0 +1,127 @@
+# AppHost — Host-Side App Management
+
+Demonstrates AppHost mediating between an MCP server and an app bridge with bidirectional tool calls.
+
+## What you'll learn
+
+- **Create MCP server with tools** — The server provides two tools: echo (returns input) and time (returns current time).
+- **Connect client to server via in-process transport** — The client connects without HTTP — using InProcessTransport for direct dispatch.
+- **Create InProcessAppBridge with app-provided tools** — The bridge simulates an MCP App (iframe). It registers two tools that the host/model can call directly.
+- **Create AppHost and wire everything together** — AppHost wires up bidirectional routing and fetches the initial app tool list.
+- **ListAllTools — aggregated server + app tools** — ListAllTools merges tools from the MCP server and the app bridge into a single list.
+- **CallAppTool — host invokes an app-provided tool** — The host calls a tool registered by the app. The bridge dispatches to the Go handler.
+- **App calls server tool via bridge → AppHost → Client** — The app calls a server-side tool through the bridge. AppHost forwards to the MCP server via the Client.
+- **Dynamic registration — app adds a tool at runtime** — The app registers a new tool after startup. AppHost detects the change and refreshes its cache.
+
+## Flow
+
+```mermaid
+sequenceDiagram
+    participant Srv as MCP Server
+    participant Client as MCP Client
+    participant Host as AppHost
+    participant Bridge as InProcessAppBridge
+
+    Note over Srv,Bridge: Step 1: Create MCP server with tools
+    Srv->>Srv: RegisterTool("server_echo")
+    Srv->>Srv: RegisterTool("server_time")
+
+    Note over Srv,Bridge: Step 2: Connect client to server via in-process transport
+    Client->>Srv: initialize
+    Srv-->>Client: capabilities, serverInfo
+
+    Note over Srv,Bridge: Step 3: Create InProcessAppBridge with app-provided tools
+    Bridge->>Bridge: RegisterTool("app_greet")
+    Bridge->>Bridge: RegisterTool("app_counter")
+
+    Note over Srv,Bridge: Step 4: Create AppHost and wire everything together
+    Host->>Bridge: SetRequestHandler (app→host)
+    Host->>Bridge: SetNotificationHandler (list_changed)
+    Host->>Bridge: Start()
+    Host->>Bridge: Send(tools/list) — initial fetch
+    Bridge-->>Host: {tools: [app_greet, app_counter]}
+
+    Note over Srv,Bridge: Step 5: ListAllTools — aggregated server + app tools
+    Host->>Client: ListTools() — server tools
+    Client-->>Host: [server_echo, server_time]
+    Host->>Bridge: cached app tools
+    Bridge-->>Host: [app_greet, app_counter]
+
+    Note over Srv,Bridge: Step 6: CallAppTool — host invokes an app-provided tool
+    Host->>Bridge: Send(tools/call, {name: "app_greet", args: {name: "World"}})
+    Bridge-->>Host: ToolResult {text: "Hello, World!"}
+
+    Note over Srv,Bridge: Step 7: App calls server tool via bridge → AppHost → Client
+    Bridge->>Host: SendToHost(tools/call, {name: "server_echo"})
+    Host->>Client: Call(tools/call, params)
+    Client->>Srv: JSON-RPC tools/call
+    Srv-->>Client: ToolResult
+    Client-->>Host: CallResult
+    Host-->>Bridge: Response
+
+    Note over Srv,Bridge: Step 8: Dynamic registration — app adds a tool at runtime
+    Bridge->>Bridge: RegisterTool("app_dice")
+    Bridge->>Host: notifications/tools/list_changed
+    Host->>Bridge: Send(tools/list) — refresh
+    Bridge-->>Host: {tools: [app_greet, app_counter, app_dice]}
+```
+
+## Steps
+
+### Step 1: Create MCP server with tools
+
+> **References:** [MCP Specification](https://spec.modelcontextprotocol.io)
+
+The server provides two tools: echo (returns input) and time (returns current time).
+
+### Step 2: Connect client to server via in-process transport
+
+The client connects without HTTP — using InProcessTransport for direct dispatch.
+
+### Step 3: Create InProcessAppBridge with app-provided tools
+
+> **References:** [MCP Apps Extension](https://modelcontextprotocol.io/extensions/apps/overview)
+
+The bridge simulates an MCP App (iframe). It registers two tools that the host/model can call directly.
+
+### Step 4: Create AppHost and wire everything together
+
+AppHost wires up bidirectional routing and fetches the initial app tool list.
+
+### Step 5: ListAllTools — aggregated server + app tools
+
+ListAllTools merges tools from the MCP server and the app bridge into a single list.
+
+### Step 6: CallAppTool — host invokes an app-provided tool
+
+The host calls a tool registered by the app. The bridge dispatches to the Go handler.
+
+### Step 7: App calls server tool via bridge → AppHost → Client
+
+The app calls a server-side tool through the bridge. AppHost forwards to the MCP server via the Client.
+
+### Step 8: Dynamic registration — app adds a tool at runtime
+
+The app registers a new tool after startup. AppHost detects the change and refreshes its cache.
+
+### Cleanup
+
+AppHost.Close() closes the bridge. The caller closes the Client separately.
+In a real application, you'd defer these in the appropriate scope.
+
+## References
+
+- [MCP Specification](https://spec.modelcontextprotocol.io)
+- [MCP Apps Extension](https://modelcontextprotocol.io/extensions/apps/overview)
+
+## Run it
+
+```bash
+go run ./examples/host/01-apphost/
+```
+
+Pass `--non-interactive` to skip pauses:
+
+```bash
+go run ./examples/host/01-apphost/ --non-interactive
+```

--- a/examples/host/01-apphost/main.go
+++ b/examples/host/01-apphost/main.go
@@ -71,22 +71,19 @@ func main() {
 		Run(func(_ demokit.StepContext) *demokit.StepResult {
 			srv = server.NewServer(core.ServerInfo{Name: "demo-server", Version: "1.0"})
 
-			srv.RegisterTool(
-				core.ToolDef{Name: "server_echo", Description: "Echo back the input", InputSchema: map[string]any{
-					"type": "object", "properties": map[string]any{"msg": map[string]any{"type": "string"}},
-				}},
-				func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
-					var args struct{ Msg string `json:"msg"` }
-					req.Bind(&args)
-					return core.TextResult("echo: " + args.Msg), nil
+			type echoInput struct {
+				Msg string `json:"msg,omitempty" jsonschema:"description=Message to echo back"`
+			}
+			srv.Register(core.TextTool[echoInput]("server_echo", "Echo back the input",
+				func(ctx core.ToolContext, input echoInput) (string, error) {
+					return "echo: " + input.Msg, nil
 				},
-			)
-			srv.RegisterTool(
-				core.ToolDef{Name: "server_time", Description: "Get current time", InputSchema: map[string]any{"type": "object"}},
-				func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
-					return core.TextResult(time.Now().Format(time.RFC3339)), nil
+			))
+			srv.Register(core.TextTool[struct{}]("server_time", "Get current time",
+				func(ctx core.ToolContext, _ struct{}) (string, error) {
+					return time.Now().Format(time.RFC3339), nil
 				},
-			)
+			))
 			fmt.Println("  Server created with 2 tools: server_echo, server_time")
 			return nil
 		})

--- a/examples/host/02-multi-server/WALKTHROUGH.md
+++ b/examples/host/02-multi-server/WALKTHROUGH.md
@@ -1,0 +1,126 @@
+# Multi-Server Registry
+
+Demonstrates ServerRegistry managing 3 MCP servers with tool aggregation, collision resolution, and app bridge integration.
+
+## What you'll learn
+
+- **Create 3 MCP servers with overlapping tools** — Weather and Calendar both have a 'get_info' tool — this will cause a collision in the registry.
+- **Create ServerRegistry with ToolResolver and CollisionHandler** — The resolver picks a server based on args. The collision handler logs when ambiguity is detected.
+- **Add all 3 servers — collision detected** — When calendar is added, the registry detects that 'get_info' now exists in both weather and calendar.
+- **AllTools — aggregated tool list with routing metadata** — Returns all tools from all servers. Each tool has clean name + ServerID metadata.
+- **CallTool (unambiguous) — routes directly** — get_forecast exists only in weather — no resolver needed, routes directly.
+- **CallTool (ambiguous) — resolver invoked** — get_info is ambiguous (weather + calendar). The resolver sees {source: "calendar"} and picks calendar.
+- **CallToolOn — explicit routing bypasses resolver** — CallToolOn routes directly to the specified server. No resolver involved.
+- **Remove server — tools disappear from index** — After removing clock, get_time is no longer available.
+- **AddWithBridge — server with app-provided tools** — Re-adds clock with an app bridge that provides an extra tool. Both server and app tools appear in AllTools.
+
+## Flow
+
+```mermaid
+sequenceDiagram
+    participant Reg as ServerRegistry
+    participant W as Weather Server
+    participant C as Calendar Server
+    participant K as Clock Server
+    participant Br as App Bridge
+
+    Note over Reg,Br: Step 1: Create 3 MCP servers with overlapping tools
+    W->>W: get_forecast, get_alerts, get_info
+    C->>C: list_events, create_event, get_info
+    K->>K: get_time
+
+    Note over Reg,Br: Step 2: Create ServerRegistry with ToolResolver and CollisionHandler
+    Reg->>Reg: WithToolResolver(arg-based routing)
+    Reg->>Reg: WithCollisionHandler(log collisions)
+
+    Note over Reg,Br: Step 3: Add all 3 servers — collision detected
+    Reg->>W: Add("weather", weatherClient)
+    Reg->>C: Add("calendar", calendarClient)
+    Reg->>K: Add("clock", clockClient)
+
+    Note over Reg,Br: Step 4: AllTools — aggregated tool list with routing metadata
+    Reg->>Reg: AllTools()
+
+    Note over Reg,Br: Step 5: CallTool (unambiguous) — routes directly
+    Reg->>W: CallTool("get_forecast")
+    W-->>Reg: ToolResult
+
+    Note over Reg,Br: Step 6: CallTool (ambiguous) — resolver invoked
+    Reg->>Reg: CallTool("get_info", {source: "calendar"})
+    Reg->>Reg: Resolver picks calendar
+    Reg->>C: tools/call
+    C-->>Reg: ToolResult
+
+    Note over Reg,Br: Step 7: CallToolOn — explicit routing bypasses resolver
+    Reg->>W: CallToolOn("weather", "get_info")
+    W-->>Reg: ToolResult
+
+    Note over Reg,Br: Step 8: Remove server — tools disappear from index
+    Reg->>K: Remove("clock")
+
+    Note over Reg,Br: Step 9: AddWithBridge — server with app-provided tools
+    Reg->>K: AddWithBridge("clock-v2", client, bridge)
+    Br->>Br: RegisterTool("app_stopwatch")
+```
+
+## Steps
+
+### Step 1: Create 3 MCP servers with overlapping tools
+
+> **References:** [MCP Specification](https://spec.modelcontextprotocol.io)
+
+Weather and Calendar both have a 'get_info' tool — this will cause a collision in the registry.
+
+### Step 2: Create ServerRegistry with ToolResolver and CollisionHandler
+
+> **References:** [mcpkit APPS_HOST.md](https://github.com/panyam/mcpkit/blob/main/docs/APPS_HOST.md)
+
+The resolver picks a server based on args. The collision handler logs when ambiguity is detected.
+
+### Step 3: Add all 3 servers — collision detected
+
+When calendar is added, the registry detects that 'get_info' now exists in both weather and calendar.
+
+### Step 4: AllTools — aggregated tool list with routing metadata
+
+Returns all tools from all servers. Each tool has clean name + ServerID metadata.
+
+### Step 5: CallTool (unambiguous) — routes directly
+
+get_forecast exists only in weather — no resolver needed, routes directly.
+
+### Step 6: CallTool (ambiguous) — resolver invoked
+
+get_info is ambiguous (weather + calendar). The resolver sees {source: "calendar"} and picks calendar.
+
+### Step 7: CallToolOn — explicit routing bypasses resolver
+
+CallToolOn routes directly to the specified server. No resolver involved.
+
+### Step 8: Remove server — tools disappear from index
+
+After removing clock, get_time is no longer available.
+
+### Step 9: AddWithBridge — server with app-provided tools
+
+> **References:** [MCP Apps Extension](https://modelcontextprotocol.io/extensions/apps/overview)
+
+Re-adds clock with an app bridge that provides an extra tool. Both server and app tools appear in AllTools.
+
+## References
+
+- [MCP Specification](https://spec.modelcontextprotocol.io)
+- [mcpkit APPS_HOST.md](https://github.com/panyam/mcpkit/blob/main/docs/APPS_HOST.md)
+- [MCP Apps Extension](https://modelcontextprotocol.io/extensions/apps/overview)
+
+## Run it
+
+```bash
+go run ./examples/host/02-multi-server/
+```
+
+Pass `--non-interactive` to skip pauses:
+
+```bash
+go run ./examples/host/02-multi-server/ --non-interactive
+```

--- a/examples/host/02-multi-server/main.go
+++ b/examples/host/02-multi-server/main.go
@@ -66,12 +66,11 @@ func main() {
 		srv := server.NewServer(core.ServerInfo{Name: name, Version: "1.0"})
 		for tName, desc := range tools {
 			n := tName
-			srv.RegisterTool(
-				core.ToolDef{Name: n, Description: desc, InputSchema: map[string]any{"type": "object"}},
-				func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
-					return core.TextResult(fmt.Sprintf("[%s] %s: ok", name, n)), nil
+			srv.Register(core.TextTool[struct{}](n, desc,
+				func(ctx core.ToolContext, _ struct{}) (string, error) {
+					return fmt.Sprintf("[%s] %s: ok", name, n), nil
 				},
-			)
+			))
 		}
 		xport := server.NewInProcessTransport(srv)
 		c := client.NewClient("memory://", core.ClientInfo{Name: "registry-demo", Version: "1.0"},

--- a/examples/list-ttl/main.go
+++ b/examples/list-ttl/main.go
@@ -94,16 +94,11 @@ func serve() {
 		Options:        extraOpts,
 		Wire:           wire,
 		Register: func(srv *server.Server) {
-			srv.RegisterTool(
-				core.ToolDef{
-					Name:        "ping",
-					Description: "Returns 'pong'",
-					InputSchema: map[string]any{"type": "object"},
+			srv.Register(core.TextTool[struct{}]("ping", "Returns 'pong'",
+				func(ctx core.ToolContext, _ struct{}) (string, error) {
+					return "pong", nil
 				},
-				func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
-					return core.TextResult("pong"), nil
-				},
-			)
+			))
 
 			srv.RegisterResource(
 				core.ResourceDef{

--- a/examples/otel/stdout/WALKTHROUGH.md
+++ b/examples/otel/stdout/WALKTHROUGH.md
@@ -1,6 +1,6 @@
 # MCP SEP-414 — OpenTelemetry Trace Context Propagation
 
-Walks through SEP-414 in stdout-exporter mode (no external stack required). Both sides — server (`make serve`) and walkthrough (`make demo`) — print spans as pretty JSON on their respective terminals. The looping "Explore trace shapes" step lets you A/B four distinct tool calls; matching TraceIDs across the two terminals is the SEP-414 wire stitching client and server into a single distributed trace. Run with `EXPORTER=otlp` after `cd docker/observability && make up` to ship spans to Grafana instead.
+Walks through SEP-414 in stdout-exporter mode (no external stack required). Both sides — server (`make serve`) and walkthrough (`make demo`) — print spans as pretty JSON on their respective terminals. The looping "Explore trace shapes" step lets you A/B four distinct tool calls; matching TraceIDs across the two terminals is the SEP-414 wire stitching client and server into a single distributed trace. Run with `EXPORTER=otlp` after `make -C docker up` to ship spans to Grafana instead.
 
 ## What you'll learn
 

--- a/examples/otel/stdout/main.go
+++ b/examples/otel/stdout/main.go
@@ -175,27 +175,14 @@ func serve() {
 // All four are intentionally trivial so the demo's value lives in
 // the span shape, not the tool surface.
 func registerDemoTools(srv *server.Server) {
-	srv.RegisterTool(
-		core.ToolDef{
-			Name:        "echo",
-			Description: "Returns the message argument unchanged. Baseline span shape — single-RPC trace, no surprises.",
-			InputSchema: map[string]any{
-				"type": "object",
-				"properties": map[string]any{
-					"message": map[string]any{
-						"type":        "string",
-						"description": "Text to echo back.",
-					},
-				},
-			},
-		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
-			var args struct {
-				Message string `json:"message"`
-			}
-			_ = req.Bind(&args)
-			if args.Message == "" {
-				args.Message = "ok"
+	type echoInput struct {
+		Message string `json:"message,omitempty" jsonschema:"description=Text to echo back"`
+	}
+	srv.Register(core.TextTool[echoInput]("echo", "Returns the message argument unchanged. Baseline span shape — single-RPC trace, no surprises.",
+		func(ctx core.ToolContext, input echoInput) (string, error) {
+			msg := input.Message
+			if msg == "" {
+				msg = "ok"
 			}
 			// Demonstration of issue 668's log↔trace pivot: the
 			// otelslog bridge reads the active span via ctx and
@@ -203,59 +190,35 @@ func registerDemoTools(srv *server.Server) {
 			// Loki panel in Grafana, click the resulting log line's
 			// `traceID` field — Grafana jumps to the matching Tempo
 			// trace and renders this dispatch span as the root.
-			slog.InfoContext(ctx, "echo tool invoked", "message", args.Message)
-			return core.TextResult(args.Message), nil
+			slog.InfoContext(ctx, "echo tool invoked", "message", msg)
+			return msg, nil
 		},
-	)
+	))
 
-	srv.RegisterTool(
-		core.ToolDef{
-			Name:        "slow_echo",
-			Description: "Sleeps 750ms then echoes. Span duration is visible in Tempo's trace view.",
-			InputSchema: map[string]any{
-				"type":       "object",
-				"properties": map[string]any{},
-			},
-		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+	srv.Register(core.TextTool[struct{}]("slow_echo", "Sleeps 750ms then echoes. Span duration is visible in Tempo's trace view.",
+		func(ctx core.ToolContext, _ struct{}) (string, error) {
 			time.Sleep(750 * time.Millisecond)
-			return core.TextResult("slow_echo: slept 750ms"), nil
+			return "slow_echo: slept 750ms", nil
 		},
-	)
+	))
 
-	srv.RegisterTool(
-		core.ToolDef{
-			Name:        "failing_tool",
-			Description: "Returns ToolResult{IsError: true}. Span carries mcp.tool.is_error=\"true\" — renders red in Grafana.",
-			InputSchema: map[string]any{
-				"type":       "object",
-				"properties": map[string]any{},
-			},
-		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+	srv.Register(core.TypedTool[struct{}, core.ToolResult]("failing_tool", "Returns ToolResult{IsError: true}. Span carries mcp.tool.is_error=\"true\" — renders red in Grafana.",
+		func(ctx core.ToolContext, _ struct{}) (core.ToolResult, error) {
 			return core.ToolResult{
 				IsError: true,
 				Content: []core.Content{{Type: "text", Text: "simulated tool failure"}},
 			}, nil
 		},
-	)
+	))
 
-	srv.RegisterTool(
-		core.ToolDef{
-			Name:        "count_tool",
-			Description: "Calls ctx.Progress 3 times. Parent span's notifications fan out as outbound spans with _meta.traceparent stamped.",
-			InputSchema: map[string]any{
-				"type":       "object",
-				"properties": map[string]any{},
-			},
-		},
-		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+	srv.Register(core.TextTool[struct{}]("count_tool", "Calls ctx.Progress 3 times. Parent span's notifications fan out as outbound spans with _meta.traceparent stamped.",
+		func(ctx core.ToolContext, _ struct{}) (string, error) {
 			for i := 1; i <= 3; i++ {
 				ctx.Progress(float64(i), 3, fmt.Sprintf("step %d/3", i))
 			}
-			return core.TextResult("count_tool: emitted 3 progress notifications"), nil
+			return "count_tool: emitted 3 progress notifications", nil
 		},
-	)
+	))
 }
 
 // tempoExploreURL builds a Grafana Explore deep link pre-filtered to


### PR DESCRIPTION
Part of issue 851 — migrate examples from hand-written `core.ToolDef{InputSchema: map[string]any{...}}` + `req.Bind` to typed `core.TextTool[In]` / `core.TypedTool[In, Out]` + `srv.Register`.

## This PR: the non-conformance examples (safe tier)

These examples are **not** spawned as conformance fixtures, so changing their tool schemas can't affect the conformance suites:

- **list-ttl** — `ping`
- **otel/stdout** — `echo` (typed input), `slow_echo`, `failing_tool` (`ToolResult`), `count_tool`
- **host/01-apphost** — `server_echo`, `server_time` (the `ui.InProcessAppBridge` app tools keep their map-handler API — different signature)
- **host/02-multi-server** — the per-name loop tools
- **elicitation** — `access_protected_resource`
- **fine-grained-auth** — `read_document` / `update_document` (`TypedTool[In, core.ToolResult]`, scope gating preserved via `core.WithToolRequiredScopes`), `initiate_payment`

Each builds (`go build ./...`) and its `WALKTHROUGH.md` was regenerated (`go run . --doc md`). `otel/stdout`'s e2e test still passes.

## Deferred: the conformance-fixture examples

`auth`, `tasks`, `tasks-v2`, `mrtr`, `stateless`, `file-inputs`, `skills` are spawned by `conformance/Makefile` and their tool schemas are asserted by the suites. `core.TypedTool[struct{}]` emits `{"$schema":…,"properties":{},"type":"object"}` — **not** the hand-written `{"type":"object"}` — so those conversions can drift the wire schema. They need converting with `WithInputSchemaOverride(map[string]any{"type":"object"})` where the schema must stay byte-identical, each gated behind `make testconf-*`. Tracked in issue 851; `file-inputs` stays the documented `x-mcp-file` override exception.
