### PR TITLE
examples/stateless: typed cart tools + document registration conventions

### DIFF
--- a/examples/CONVENTIONS.md
+++ b/examples/CONVENTIONS.md
@@ -513,6 +513,37 @@ logger := common.NewMCPLogger("[mcp] ",
 )
 ```
 
+### Tool registration style (issue 851)
+
+Prefer typed registration for tools with real inputs: define an input struct
+and register via `srv.Register(core.TextTool[In](...))` or
+`core.TypedTool[In, Out](...)`. mcpkit derives the JSON Schema from the struct
+tags and hands the handler a decoded, validated value — no hand-written
+`map[string]any` schema, no `req.Bind` / `json.Unmarshal(req.Arguments)`. Pick
+`Out` by what the handler returns: `string` (→ `TextTool`), `core.ToolResult`
+(sync with `IsError` / structured content), or `core.ToolResponse` (MRTR / task
+variants). `examples/getting-started` is the reference shape.
+
+Raw `srv.RegisterTool(core.ToolDef{...}, handler)` is still correct — do **not**
+force a conversion — in these cases:
+
+- **The handler needs the raw `core.ToolRequest`.** MRTR / task-composition
+  handlers (`examples/mrtr`, `examples/tasks-v2`'s `test_tool_with_task`) drive
+  `ctx.RequestInput` / `ctx.InputResponse` and return `core.ToolResponse`; a
+  typed input struct adds nothing.
+- **The schema needs JSON Schema features struct tags can't express** —
+  conditional `if/then/else`, `allOf`/`anyOf`, `$anchor`/`$ref`, or the
+  SEP-2356 `x-mcp-file` marker (`examples/file-inputs`). Use
+  `core.WithInputSchemaOverride(...)` with a typed handler, or stay raw.
+- **The tool is a conformance fixture whose wire schema is asserted.** Convert
+  to a typed handler but pin the exact schema with
+  `core.WithInputSchemaOverride(...)` — `TypedTool`'s reflected schema adds
+  `$schema` + `properties:{}`, which can drift an asserted `tools/list` shape.
+  `examples/stateless` does this; verify with the relevant `make testconf-*`.
+
+An empty-input tool (`struct{}`) gains nothing from typing beyond consistency;
+converting one is optional, not required.
+
 ---
 
 ## 3. walkthrough.go

--- a/examples/stateless/main.go
+++ b/examples/stateless/main.go
@@ -153,14 +153,13 @@ func newCartStore() server.HandleStore[Cart] {
 }
 
 func registerCartTools(srv *server.Server, carts server.HandleStore[Cart]) {
-	srv.RegisterTool(
-		core.ToolDef{
-			Name: "create_cart",
-			Description: "Create an empty shopping cart and return its handle id. " +
-				"SEP-2567: subsequent tools thread cart_id as a parameter.",
-			InputSchema: map[string]any{"type": "object"},
-		},
-		func(_ core.ToolContext, _ core.ToolRequest) (core.ToolResponse, error) {
+	// create_cart takes no input. The schema override keeps the exact
+	// {"type":"object"} the SEP-2575 conformance fixture asserts (TypedTool's
+	// reflected schema would add $schema + properties:{}).
+	srv.Register(core.TypedTool[struct{}, core.ToolResult]("create_cart",
+		"Create an empty shopping cart and return its handle id. "+
+			"SEP-2567: subsequent tools thread cart_id as a parameter.",
+		func(_ core.ToolContext, _ struct{}) (core.ToolResult, error) {
 			id := carts.Mint(Cart{}, 0)
 			out := map[string]any{"cart_id": id}
 			raw, _ := json.Marshal(out)
@@ -169,31 +168,19 @@ func registerCartTools(srv *server.Server, carts server.HandleStore[Cart]) {
 				StructuredContent: out,
 			}, nil
 		},
-	)
+		core.WithInputSchemaOverride(map[string]any{"type": "object"}),
+	))
 
-	srv.RegisterTool(
-		core.ToolDef{
-			Name:        "add_item",
-			Description: "Add an item to a cart. Updates the cart's running total in place.",
-			InputSchema: map[string]any{
-				"type": "object",
-				"properties": map[string]any{
-					"cart_id":  map[string]any{"type": "string"},
-					"sku":      map[string]any{"type": "string"},
-					"quantity": map[string]any{"type": "integer", "minimum": 1},
-				},
-				"required": []string{"cart_id", "sku", "quantity"},
-			},
-		},
-		func(_ core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
-			var args struct {
-				CartID   string `json:"cart_id"`
-				SKU      string `json:"sku"`
-				Quantity int    `json:"quantity"`
-			}
-			if err := json.Unmarshal(req.Arguments, &args); err != nil {
-				return core.ToolResult{}, fmt.Errorf("invalid arguments: %w", err)
-			}
+	type addItemInput struct {
+		CartID   string `json:"cart_id"`
+		SKU      string `json:"sku"`
+		Quantity int    `json:"quantity"`
+	}
+	// Schema pinned via override so the fixture's asserted wire shape
+	// (including quantity's minimum) is preserved byte-for-byte.
+	srv.Register(core.TypedTool[addItemInput, core.ToolResult]("add_item",
+		"Add an item to a cart. Updates the cart's running total in place.",
+		func(_ core.ToolContext, args addItemInput) (core.ToolResult, error) {
 			cart, ok := carts.Get(args.CartID)
 			if !ok {
 				return core.ToolResult{}, fmt.Errorf("unknown cart_id: %s", args.CartID)
@@ -223,25 +210,23 @@ func registerCartTools(srv *server.Server, carts server.HandleStore[Cart]) {
 				StructuredContent: out,
 			}, nil
 		},
-	)
-
-	srv.RegisterTool(
-		core.ToolDef{
-			Name:        "checkout",
-			Description: "Check out a cart and return an order id. Deletes the cart handle.",
-			InputSchema: map[string]any{
-				"type":       "object",
-				"properties": map[string]any{"cart_id": map[string]any{"type": "string"}},
-				"required":   []string{"cart_id"},
+		core.WithInputSchemaOverride(map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"cart_id":  map[string]any{"type": "string"},
+				"sku":      map[string]any{"type": "string"},
+				"quantity": map[string]any{"type": "integer", "minimum": 1},
 			},
-		},
-		func(_ core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
-			var args struct {
-				CartID string `json:"cart_id"`
-			}
-			if err := json.Unmarshal(req.Arguments, &args); err != nil {
-				return core.ToolResult{}, fmt.Errorf("invalid arguments: %w", err)
-			}
+			"required": []string{"cart_id", "sku", "quantity"},
+		}),
+	))
+
+	type checkoutInput struct {
+		CartID string `json:"cart_id"`
+	}
+	srv.Register(core.TypedTool[checkoutInput, core.ToolResult]("checkout",
+		"Check out a cart and return an order id. Deletes the cart handle.",
+		func(_ core.ToolContext, args checkoutInput) (core.ToolResult, error) {
 			cart, ok := carts.Get(args.CartID)
 			if !ok {
 				return core.ToolResult{}, fmt.Errorf("unknown cart_id: %s", args.CartID)
@@ -259,7 +244,12 @@ func registerCartTools(srv *server.Server, carts server.HandleStore[Cart]) {
 				StructuredContent: out,
 			}, nil
 		},
-	)
+		core.WithInputSchemaOverride(map[string]any{
+			"type":       "object",
+			"properties": map[string]any{"cart_id": map[string]any{"type": "string"}},
+			"required":   []string{"cart_id"},
+		}),
+	))
 }
 
 // ----- SEP-2575 diagnostic tools (conformance fixture) -----


### PR DESCRIPTION
Follow-up to PR 856 — the conformance-fixture half of the typed tool registration work (issue 851).

## What changed

- **examples/stateless** — `create_cart` / `add_item` / `checkout` now use `core.TypedTool[In, core.ToolResult]` + `srv.Register`. The typed input replaces the manual `json.Unmarshal(req.Arguments, …)`. Each pins its exact wire schema with `core.WithInputSchemaOverride` so the SEP-2575 conformance fixture's asserted `tools/list` shape stays byte-identical.
  - **Verified:** `make -C conformance testconf-stateless` → **30 pass / 0 fail**.
- **examples/CONVENTIONS.md** — new "Tool registration style" subsection documenting when to use typed registration and when raw `RegisterTool` is justified.

## Reassessment of the rest of the conformance tier

While doing this I found the conformance-fixture examples are already almost entirely typed or justified-raw — the issue 851 count over-counted "raw RegisterTool" sites by including registrations that shouldn't be converted:

| Example | Status |
|---|---|
| `auth`, `tasks` (v1) | already fully typed (`TextTool`/`TypedTool`) |
| `tasks-v2` | typed except `test_tool_with_task` — **justified-raw** (MRTR+task handler needs `core.ToolRequest`, returns `core.ToolResponse`) |
| `mrtr` | 8 **justified-raw** empty-input MRTR tools (ctx-driven handlers, conformance-pinned `{"type":"object"}`; typing adds noise, no benefit) |
| `skills`, `skills-core` | already typed via `TextTool` |
| `file-inputs` | **justified-raw** — SEP-2356 `x-mcp-file` marker (documented override exception) |
| `stateless` | **converted here** |

The "when raw is justified" rules are now written down in `CONVENTIONS.md` so this doesn't get relitigated. With stateless done, the typed-registration sweep for issue 851 is effectively complete; the remaining raw registrations are deliberate.
