### PR TITLE
v0.4.0: multi-tenant task-store isolation (WithTaskBucketKeyer, issue 485)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,8 +46,12 @@ targeted spec version.
 - **Panic recovery in library goroutines** — a panic in a tool/background
   goroutine is recovered and surfaced as an error instead of crashing the host
   process. (issue 420)
-- **v2 task-store multi-tenant isolation** — fixes `sessionID=""` bucket-sharing
-  so tasks from distinct tenants no longer collide in one bucket. (issue 485)
+- **v2 task-store multi-tenant isolation** — new `server.WithTaskBucketKeyer`
+  derives the per-request task-store bucket from a `context.Context` (e.g. an
+  auth subject) instead of the transport session. On the SEP-2575 stateless
+  wire every task otherwise keys under `sessionID=""`, so tenants shared one
+  bucket; the keyer closes that hole. Applies to v1 and v2, both wires; default
+  behavior unchanged (session-ID keying). No `ext/auth` dependency. (issue 485)
 - **`ClientModeStateless` works against discover-less servers** — `Connect` no
   longer hard-requires `server/discover`, so mcpkit connects to draft servers
   that don't expose discovery. (issue 829)

--- a/core/task_bucket.go
+++ b/core/task_bucket.go
@@ -1,0 +1,46 @@
+package core
+
+import "context"
+
+// TaskBucketKeyer derives the per-request bucket key that the task store
+// isolates against — the value passed as the store's sessionID argument for
+// Create / Get / Update / Cancel / List.
+//
+// The default (no keyer installed) is the transport session ID: on the legacy
+// wire that is the per-connection session; on the SEP-2575 stateless wire it is
+// "" (no session), which is why, by default, all stateless tasks share one
+// bucket per process. Multi-tenant stateless deployments install a keyer that
+// derives the bucket from an authenticated subject (JWT `sub`), a request
+// header, or any other per-tenant signal, so tenants cannot read / cancel /
+// update each other's tasks.
+//
+// The keyer takes a raw context.Context so it stays decoupled from ext/auth:
+// an auth-based keyer reads the subject from the auth claims already on the
+// context, but the core/server/ext-tasks packages never import ext/auth. Wire
+// it with server.WithTaskBucketKeyer.
+type TaskBucketKeyer func(ctx context.Context) string
+
+type taskBucketKeyerCtxKey struct{}
+
+// WithTaskBucketKeyer installs a TaskBucketKeyer on the context so downstream
+// task create/get/update/cancel sites resolve the bucket through it. A nil
+// keyer is a no-op (the context is returned unchanged), so callers can inject
+// unconditionally.
+func WithTaskBucketKeyer(ctx context.Context, keyer TaskBucketKeyer) context.Context {
+	if keyer == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, taskBucketKeyerCtxKey{}, keyer)
+}
+
+// TaskBucketKey resolves the task-store isolation bucket for this request. If a
+// TaskBucketKeyer was installed (via WithTaskBucketKeyer / the
+// server.WithTaskBucketKeyer option) it is used; otherwise it falls back to the
+// session ID. This is the single accessor both the v1 and v2 task surfaces call
+// instead of reading the session ID directly.
+func TaskBucketKey(ctx context.Context) string {
+	if k, ok := ctx.Value(taskBucketKeyerCtxKey{}).(TaskBucketKeyer); ok && k != nil {
+		return k(ctx)
+	}
+	return GetSessionID(ctx)
+}

--- a/core/task_bucket_test.go
+++ b/core/task_bucket_test.go
@@ -1,0 +1,34 @@
+package core
+
+import (
+	"context"
+	"testing"
+)
+
+func TestTaskBucketKey_FallsBackToSession(t *testing.T) {
+	// No keyer installed → falls back to the session ID.
+	ctx := context.Background()
+	if got := TaskBucketKey(ctx); got != "" {
+		t.Errorf("no session, no keyer: got %q, want empty", got)
+	}
+}
+
+func TestTaskBucketKey_UsesKeyerWhenInstalled(t *testing.T) {
+	type subjectKey struct{}
+	keyer := func(ctx context.Context) string {
+		s, _ := ctx.Value(subjectKey{}).(string)
+		return s
+	}
+	ctx := WithTaskBucketKeyer(context.Background(), keyer)
+	ctx = context.WithValue(ctx, subjectKey{}, "tenant-A")
+	if got := TaskBucketKey(ctx); got != "tenant-A" {
+		t.Errorf("keyer installed: got %q, want tenant-A", got)
+	}
+}
+
+func TestWithTaskBucketKeyer_NilIsNoOp(t *testing.T) {
+	ctx := context.Background()
+	if WithTaskBucketKeyer(ctx, nil) != ctx {
+		t.Error("nil keyer should return the context unchanged")
+	}
+}

--- a/docs/releases/v0.4.0.md
+++ b/docs/releases/v0.4.0.md
@@ -40,7 +40,8 @@ beyond the date gate:
       tool/prompt/resource/completion handlers → `-32603`, no host crash) +
       `safeGo` wrapping every library-owned background goroutine across
       server / client / ext-ui / events / events-go-client
-- [ ] **#485** v2 task-store multi-tenant isolation (`sessionID=""` bucket-sharing)
+- [x] **#485** v2 task-store multi-tenant isolation — `server.WithTaskBucketKeyer`
+      (ctx → bucket; default = session ID; no `ext/auth` dep), applied on both wires
 - [x] **#829** `ClientModeStateless` connects to discover-less draft servers
 - [x] **#838** `Mcp-Name` validation for `prompts/get` (SEP-2243)
 - [x] **#422** validate `MCP-Protocol-Version` header vs body on `initialize`

--- a/ext/tasks/task_isolation_test.go
+++ b/ext/tasks/task_isolation_test.go
@@ -1,0 +1,154 @@
+package tasks_test
+
+// Issue 485: multi-tenant isolation for the v2 task store on the SEP-2575
+// stateless wire. Without a keyer, every stateless task keys under
+// sessionID="" — so two tenants share one bucket and can read/cancel each
+// other's tasks. server.WithTaskBucketKeyer derives the bucket from a
+// per-request signal (here an X-Tenant header stashed on the context, standing
+// in for an auth subject — no ext/auth dependency) so tenants are isolated.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	core "github.com/panyam/mcpkit/core"
+	tasks "github.com/panyam/mcpkit/ext/tasks"
+	server "github.com/panyam/mcpkit/server"
+)
+
+type tenantCtxKey struct{}
+
+// newIsolatedTaskServer builds a stateless task server. When withKeyer is true
+// it installs a TaskBucketKeyer that reads the tenant from the context (set by
+// the handler wrapper from the X-Tenant header). Returns the base URL.
+func newIsolatedTaskServer(t *testing.T, withKeyer bool) string {
+	t.Helper()
+
+	opts := []server.Option{}
+	if withKeyer {
+		opts = append(opts, server.WithTaskBucketKeyer(func(ctx context.Context) string {
+			tenant, _ := ctx.Value(tenantCtxKey{}).(string)
+			return tenant
+		}))
+	}
+	srv := server.NewServer(core.ServerInfo{Name: "iso-tasks", Version: "0.0.1"}, opts...)
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "slow_compute",
+			Description: "optional task support",
+			InputSchema: map[string]any{"type": "object"},
+			Execution:   &core.ToolExecution{TaskSupport: core.TaskSupportOptional},
+		},
+		func(ctx core.ToolContext, _ core.ToolRequest) (core.ToolResponse, error) {
+			return core.TextResult("done"), nil
+		},
+	)
+	tasks.Register(tasks.Config{Server: srv, DefaultPollMs: 50})
+
+	inner := srv.Handler(server.WithStreamableHTTP(true))
+	// Stand-in for auth: copy the X-Tenant header onto the request context so
+	// the keyer can read it. A real deployment reads the JWT subject instead.
+	wrapped := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if tenant := r.Header.Get("X-Tenant"); tenant != "" {
+			r = r.WithContext(context.WithValue(r.Context(), tenantCtxKey{}, tenant))
+		}
+		inner.ServeHTTP(w, r)
+	})
+	ts := httptest.NewServer(wrapped)
+	t.Cleanup(ts.Close)
+	return ts.URL + "/mcp"
+}
+
+func postAsTenant(t *testing.T, url, tenant string, id int, method string, params map[string]any) *core.Response {
+	t.Helper()
+	body, _ := json.Marshal(map[string]any{"jsonrpc": "2.0", "id": id, "method": method, "params": params})
+	req, err := http.NewRequestWithContext(context.Background(), "POST", url, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", core.StreamableHTTPAccept)
+	req.Header.Set("MCP-Protocol-Version", statelessDraftVersion)
+	req.Header.Set("X-Tenant", tenant)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("http do: %v", err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	payload := bytes.TrimSpace(raw)
+	if idx := bytes.Index(payload, []byte("data:")); idx >= 0 {
+		payload = bytes.TrimSpace(payload[idx+len("data:"):])
+	}
+	var out core.Response
+	if err := json.Unmarshal(payload, &out); err != nil {
+		t.Fatalf("decode response (status %d): %v\n%s", resp.StatusCode, err, string(raw))
+	}
+	return &out
+}
+
+func createTaskAsTenant(t *testing.T, url, tenant string) string {
+	t.Helper()
+	resp := postAsTenant(t, url, tenant, 1, "tools/call", map[string]any{
+		"name":      "slow_compute",
+		"arguments": map[string]any{},
+		"_meta":     metaWithCaps(true),
+	})
+	if resp.Error != nil {
+		t.Fatalf("tenant %s create: %+v", tenant, resp.Error)
+	}
+	raw, _ := json.Marshal(resp.Result)
+	var got core.CreateTaskResult
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("decode CreateTaskResult: %v\n%s", err, string(raw))
+	}
+	if got.TaskID == "" {
+		t.Fatalf("tenant %s: empty taskId (result=%s)", tenant, string(raw))
+	}
+	return got.TaskID
+}
+
+// TestIssue485_KeyerIsolatesTenants: with the keyer, tenant B cannot see a task
+// tenant A created, but tenant A can.
+func TestIssue485_KeyerIsolatesTenants(t *testing.T) {
+	url := newIsolatedTaskServer(t, true /* withKeyer */)
+	taskID := createTaskAsTenant(t, url, "tenant-A")
+
+	// Tenant B must NOT find tenant A's task.
+	respB := postAsTenant(t, url, "tenant-B", 2, "tasks/get", map[string]any{
+		"taskId": taskID, "_meta": metaWithCaps(true),
+	})
+	if respB.Error == nil {
+		t.Errorf("tenant-B should NOT see tenant-A's task %s, but tasks/get succeeded: %s", taskID, string(mustJSON(respB.Result)))
+	}
+
+	// Tenant A must still find its own task.
+	respA := postAsTenant(t, url, "tenant-A", 3, "tasks/get", map[string]any{
+		"taskId": taskID, "_meta": metaWithCaps(true),
+	})
+	if respA.Error != nil {
+		t.Errorf("tenant-A should see its own task %s, got error: %+v", taskID, respA.Error)
+	}
+}
+
+// TestIssue485_DefaultSharesBucket documents the default (no keyer): both
+// tenants key under sessionID="" on the stateless wire, so tenant B CAN see
+// tenant A's task. This is the isolation hole the keyer closes.
+func TestIssue485_DefaultSharesBucket(t *testing.T) {
+	url := newIsolatedTaskServer(t, false /* no keyer */)
+	taskID := createTaskAsTenant(t, url, "tenant-A")
+
+	respB := postAsTenant(t, url, "tenant-B", 2, "tasks/get", map[string]any{
+		"taskId": taskID, "_meta": metaWithCaps(true),
+	})
+	if respB.Error != nil {
+		t.Errorf("default (no keyer): tenant-B should share the sessionID=\"\" bucket and see the task, got error: %+v", respB.Error)
+	}
+}
+
+func mustJSON(v any) []byte { b, _ := json.Marshal(v); return b }

--- a/ext/tasks/tasks.go
+++ b/ext/tasks/tasks.go
@@ -573,7 +573,7 @@ func spawnGoAsyncTask(
 		PollInterval:  pollMs,
 	}
 	store := rt.store
-	sessionID := core.GetSessionID(ctx)
+	sessionID := core.TaskBucketKey(ctx)
 	if err := store.Create(info, sessionID); err != nil {
 		return core.NewErrorResponse(req.ID, -32603, "failed to create task: "+err.Error()), nil
 	}
@@ -736,7 +736,7 @@ func wrapSyncAsCompletedTask(
 		PollInterval:  pollMs,
 	}
 	store := rt.store
-	sessionID := core.GetSessionID(ctx)
+	sessionID := core.TaskBucketKey(ctx)
 	if err := store.Create(info, sessionID); err != nil {
 		return core.NewErrorResponse(req.ID, -32603, "failed to create task: "+err.Error()), nil
 	}
@@ -787,7 +787,7 @@ func makeV2GetHandler(rt *v2TaskRuntime) server.MethodHandler {
 		// otherwise; AddLink with a zero origin is silently dropped.
 		core.SpanFromContext(ctx).AddLink(core.LinkFromTraceContext(rt.getOrigin(p.TaskID)))
 
-		sid := ctx.SessionID()
+		sid := core.TaskBucketKey(ctx)
 		info, ok := rt.store.Get(p.TaskID, sid)
 		if !ok {
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, "task not found: "+p.TaskID)
@@ -864,7 +864,7 @@ func makeV2UpdateHandler(rt *v2TaskRuntime) server.MethodHandler {
 		// makeV2GetHandler for the rationale.
 		core.SpanFromContext(ctx).AddLink(core.LinkFromTraceContext(rt.getOrigin(p.TaskID)))
 
-		sid := ctx.SessionID()
+		sid := core.TaskBucketKey(ctx)
 		info, ok := rt.store.Get(p.TaskID, sid)
 		if !ok {
 			// Open spec question (PLAN.md): tasks/update for unknown taskId
@@ -903,11 +903,11 @@ func makeV2CancelHandler(rt *v2TaskRuntime) server.MethodHandler {
 		// return the same empty ack as on an active task so clients don't
 		// have to race observation vs cancel. Skip the store mutation in
 		// that case.
-		if info, ok := rt.store.Get(p.TaskID, ctx.SessionID()); ok && info.Status.IsTerminal() {
+		if info, ok := rt.store.Get(p.TaskID, core.TaskBucketKey(ctx)); ok && info.Status.IsTerminal() {
 			return core.NewResponse(id, core.CancelTaskResult{})
 		}
 
-		info, err := rt.store.Cancel(p.TaskID, ctx.SessionID())
+		info, err := rt.store.Cancel(p.TaskID, core.TaskBucketKey(ctx))
 		if err != nil {
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, err.Error())
 		}

--- a/server/dispatch.go
+++ b/server/dispatch.go
@@ -147,6 +147,12 @@ type Dispatcher struct {
 	// that prefer leniency over strict spec conformance.
 	allowLegacyOnDraft bool
 
+	// taskBucketKeyer derives the task-store isolation bucket for each request
+	// (issue 485). Nil = default (session ID). Set via WithTaskBucketKeyer;
+	// injected onto the request context in dispatchWithOpts and the stateless
+	// POST handlers so the v1/v2 task surfaces resolve it via core.TaskBucketKey.
+	taskBucketKeyer core.TaskBucketKeyer
+
 	// allowReinitialize opts into accepting a second initialize on an
 	// already-negotiated session (protocol re-negotiation). Default false:
 	// once a session has negotiated a version, a duplicate initialize is
@@ -294,6 +300,7 @@ func (d *Dispatcher) newSession() *Dispatcher {
 		readCacheScope:       d.readCacheScope,
 		allowLegacyOnDraft:   d.allowLegacyOnDraft,
 		allowReinitialize:    d.allowReinitialize,
+		taskBucketKeyer:      d.taskBucketKeyer,
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -78,6 +78,7 @@ type serverOptions struct {
 	readCacheScope       string                   // SEP-2549 resources/read default cacheScope; handler may override per-read
 	allowLegacyOnDraft   bool                     // WithAllowLegacyOnDraft — opt-in SEP-2575 leniency on the legacy wire (off by default; strict per spec)
 	allowReinitialize    bool                     // WithAllowReinitialize — opt-in acceptance of a duplicate initialize (off by default; issue 421)
+	taskBucketKeyer      core.TaskBucketKeyer     // WithTaskBucketKeyer — per-request task-store isolation bucket (nil = session ID; issue 485)
 	tracerProvider       core.TracerProvider      // SEP-414 P2 — WithTracerProvider; nil/Noop = trace middleware not installed
 	meterProvider        core.MeterProvider       // issue 7 — WithMeterProvider; nil/Noop = metrics middleware not installed
 	notificationRelay       NotificationRelay           // issue 755 — WithNotificationRelay; nil = no cross-replica broadcast (Broadcast fires local only)
@@ -544,6 +545,30 @@ func WithAllowReinitialize() Option {
 	return func(o *serverOptions) { o.allowReinitialize = true }
 }
 
+// WithTaskBucketKeyer sets how the task store isolates tasks per request
+// (issue 485). The keyer maps a request context to the bucket key used as the
+// store's sessionID argument for Create / Get / Update / Cancel / List.
+//
+// Default (option NOT set): the bucket is the transport session ID. On the
+// legacy wire that is the per-connection session; on the SEP-2575 stateless
+// wire it is "" (no session), so all stateless tasks share one bucket per
+// process — fine for single-tenant deployments, a cross-tenant isolation hole
+// for multi-tenant ones.
+//
+// Multi-tenant stateless deployments install a keyer that derives the bucket
+// from an authenticated subject so tenants cannot see each other's tasks, e.g.:
+//
+//	server.WithTaskBucketKeyer(func(ctx context.Context) string {
+//	    return auth.SubjectFromContext(ctx) // your auth accessor
+//	})
+//
+// The keyer takes a raw context.Context, so mcpkit never imports ext/auth — the
+// coupling to auth is code the deployer writes. Applies to both the v1
+// (RegisterTasksV1) and v2 (ext/tasks) surfaces and both wires.
+func WithTaskBucketKeyer(keyer core.TaskBucketKeyer) Option {
+	return func(o *serverOptions) { o.taskBucketKeyer = keyer }
+}
+
 // WithRootsFetchTimeout sets the deadline for server-to-client roots/list
 // requests issued after notifications/roots/list_changed. Default is 30s.
 // Decrease for aggressive fail-fast; increase for slow clients with large
@@ -573,6 +598,7 @@ func NewServer(info core.ServerInfo, opts ...Option) *Server {
 	s.dispatcher.validateFileInputs = s.options.validateFileInputs
 	s.dispatcher.allowLegacyOnDraft = s.options.allowLegacyOnDraft
 	s.dispatcher.allowReinitialize = s.options.allowReinitialize
+	s.dispatcher.taskBucketKeyer = s.options.taskBucketKeyer
 	s.dispatcher.customHandlers = s.options.customHandlers
 	// Wire registry change notifications to Server.Broadcast so that
 	// dynamic adds/removes automatically notify all connected sessions.
@@ -818,6 +844,11 @@ func (s *Server) dispatchWithOpts(d *Dispatcher, ctx context.Context, claims *co
 
 	// Set the session ID so middleware and handlers can access it via ctx.SessionID().
 	core.SetSessionID(ctx, d.sessionID)
+
+	// Install the task-store bucket keyer (issue 485) so the v1/v2 task
+	// surfaces resolve isolation via core.TaskBucketKey. Nil = no-op (default
+	// session-ID keying).
+	ctx = core.WithTaskBucketKeyer(ctx, d.taskBucketKeyer)
 
 	// SEP-2243: stage the Mcp-Method response header carrying the JSON-RPC
 	// method name (e.g. "tools/call", "tasks/get"). Pairs with Mcp-Name

--- a/server/stateless_backend.go
+++ b/server/stateless_backend.go
@@ -244,11 +244,13 @@ func (b *statelessBackend) ReadCacheScope() string {
 // emissions silently drop, which matches the SEP-2575 design (no server-
 // initiated push); clients observe state via tasks/get polling.
 //
-// All stateless task store entries currently key under sessionID=""
-// (no session). This means stateless tasks share one bucket per process,
-// which is acceptable for the single-tenant fixtures the conformance
-// suite covers; multi-tenant deployments should layer an auth-subject-
-// keyed store wrapper. Tracked for a follow-up.
+// By default, stateless task store entries key under sessionID="" (no
+// session), so stateless tasks share one bucket per process — fine for the
+// single-tenant fixtures the conformance suite covers. Multi-tenant
+// deployments install a server.WithTaskBucketKeyer that derives the bucket
+// from an authenticated subject; the keyer is injected onto the request
+// context in the stateless POST handlers (streamable_stateless.go) and the
+// v1/v2 task surfaces resolve it via core.TaskBucketKey (issue 485).
 func (b *statelessBackend) InvokeWithMiddleware(ctx context.Context, req *core.Request) (*core.Response, error, bool) {
 	terminal := MiddlewareFunc(func(ctx context.Context, req *core.Request) (*core.Response, error) {
 		switch req.Method {

--- a/server/streamable_stateless.go
+++ b/server/streamable_stateless.go
@@ -69,6 +69,10 @@ func (t *streamableTransport) handleStatelessPost(w http.ResponseWriter, r *http
 	// sessionCtx that the stateless wire deliberately does not create.
 	ctx := core.WithResponseHeaderCollector(r.Context())
 	ctx = core.WithStatelessClaims(ctx, claims)
+	// Task-store isolation bucket (issue 485): on the stateless wire the default
+	// bucket is "" (no session), so a keyer is what gives multi-tenant tenants
+	// their own task buckets. This path bypasses dispatchWithOpts, so inject here.
+	ctx = core.WithTaskBucketKeyer(ctx, t.server.dispatcher.taskBucketKeyer)
 	resp, dErr := t.statelessDispatcher.Dispatch(ctx, req)
 
 	// A non-nil dispatch error is a middleware short-circuit (typically
@@ -142,6 +146,8 @@ func (t *streamableTransport) handleStatelessPostSSE(w http.ResponseWriter, r *h
 
 	dispatchCtx := core.WithResponseHeaderCollector(r.Context())
 	dispatchCtx = core.WithStatelessClaims(dispatchCtx, claims)
+	// Task-store isolation bucket (issue 485) — see handleStatelessPost.
+	dispatchCtx = core.WithTaskBucketKeyer(dispatchCtx, t.server.dispatcher.taskBucketKeyer)
 
 	// SSE headers are set lazily on first write so a dispatch-time
 	// error response (-32020 header mismatch, -32022 unsupported

--- a/server/tasks_v1.go
+++ b/server/tasks_v1.go
@@ -249,7 +249,7 @@ func taskMiddleware(reg *Registry, rt *taskRuntime, cfg TasksConfigV1) Middlewar
 			PollInterval:  pollMs,
 		}
 		store := rt.store
-		sessionID := core.GetSessionID(ctx)
+		sessionID := core.TaskBucketKey(ctx)
 		if err := store.Create(info, sessionID); err != nil {
 			return core.NewErrorResponse(req.ID, -32603, "failed to create task: "+err.Error()), nil
 		}
@@ -356,7 +356,7 @@ func makeGetHandler(rt *taskRuntime) MethodHandler {
 		}
 
 		// Fall through to TaskStore.
-		info, ok := rt.store.Get(p.TaskID, ctx.SessionID())
+		info, ok := rt.store.Get(p.TaskID, core.TaskBucketKey(ctx))
 		if !ok {
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, "task not found: "+p.TaskID)
 		}
@@ -396,7 +396,7 @@ func makeResultHandler(rt *taskRuntime) MethodHandler {
 			}
 
 			// 2. Check if the task is terminal.
-			sid := ctx.SessionID()
+			sid := core.TaskBucketKey(ctx)
 			info, found := store.Get(p.TaskID, sid)
 			if !found {
 				return core.NewErrorResponse(id, core.ErrCodeInvalidParams, "task not found: "+p.TaskID)
@@ -448,7 +448,7 @@ func makeListHandler(store TaskStore) MethodHandler {
 		if params != nil {
 			json.Unmarshal(params, &p)
 		}
-		tasks, nextCursor := store.List(p.Cursor, 50, ctx.SessionID())
+		tasks, nextCursor := store.List(p.Cursor, 50, core.TaskBucketKey(ctx))
 		if tasks == nil {
 			tasks = []core.TaskInfo{}
 		}
@@ -467,7 +467,7 @@ func makeCancelHandler(rt *taskRuntime) MethodHandler {
 		if err := json.Unmarshal(params, &p); err != nil {
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, err.Error())
 		}
-		info, err := rt.store.Cancel(p.TaskID, ctx.SessionID())
+		info, err := rt.store.Cancel(p.TaskID, core.TaskBucketKey(ctx))
 		if err != nil {
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, err.Error())
 		}


### PR DESCRIPTION
Part of the v0.4.0 breaking bundle (first stacked PR after PR 855 merged). Fixes issue 485.

## Problem

On the SEP-2575 stateless wire the dispatcher has no session, so every task created via `tasks.Register` (and v1) keys under `sessionID=""`. Multiple tenants share one bucket per process — `tasks/get`, `tasks/cancel`, `tasks/update` look up by `(taskID, sessionID)`, so with `sessionID=""` across users they can read / cancel / update each other's tasks. Single-tenant deployments are unaffected.

## Fix

A `TaskBucketKeyer` seam — `func(ctx context.Context) string` — that derives the per-request store bucket. Default falls back to the session ID (so nothing changes by default); multi-tenant deployments install a keyer that derives the bucket from an authenticated subject.

- `core.TaskBucketKeyer` + `core.WithTaskBucketKeyer(ctx, keyer)` + `core.TaskBucketKey(ctx)` — the single accessor both task surfaces call.
- `server.WithTaskBucketKeyer(keyer)` option. The keyer is injected onto the request context in `dispatchWithOpts` (legacy wire) and both stateless POST handlers (`streamable_stateless.go`) — the stateless path bypasses `dispatchWithOpts`, which is exactly where the bug lived.
- v1 (`server/tasks_v1.go`) and v2 (`ext/tasks`) now resolve the bucket via `core.TaskBucketKey(ctx)` instead of reading the session ID directly.

## No ext/auth coupling

The keyer takes a raw `context.Context`. An auth-based keyer reads the subject the deployer already put on the context; `core` / `server` / `ext/tasks` never import `ext/auth`. Tasks keep working with no auth (demos, tests, trusted environments).

## Before / after

Where the task-store bucket key comes from, per wire:

```mermaid
flowchart LR
  subgraph Before
    A1[tools/call create] --> B1["sessionID<br/>legacy: session · stateless: ''"]
    A2[tasks/get other tenant] --> B1
    B1 --> C1[(store bucket)]
    C1 -. "stateless: both tenants share ''" .-> X1{{cross-tenant read}}
  end
  subgraph After
    A3[tools/call create] --> K[core.TaskBucketKey ctx]
    A4[tasks/get other tenant] --> K
    K -->|keyer set| S1["keyer ctx → subject"]
    K -->|no keyer| S2["fallback: sessionID"]
    S1 --> C2[(per-tenant bucket)]
    S2 --> C2
  end
```

The keyer is installed onto the request `ctx` at the two dispatch funnels, then read wherever a task-store call previously took the session ID:

```mermaid
flowchart TD
  L[legacy POST / stdio / memory] --> DW[dispatchWithOpts<br/>WithTaskBucketKeyer]
  ST[stateless POST + SSE] --> SL[handleStatelessPost*<br/>WithTaskBucketKeyer]
  DW --> H[task handlers]
  SL --> H
  H --> TBK[core.TaskBucketKey ctx]
  TBK --> STORE[(TaskStore Create/Get/Update/Cancel/List)]
```

## Reviewer's guide

Suggested reading order — the seam first, then the two injection funnels, then the consumption swaps:

1. [core/task_bucket.go](https://github.com/panyam/mcpkit/pull/858/files#diff-dbd8d1b4161718c99a893ccffecaa7eb5d8e0db3f77882bb709e421691664da7) — the whole contract in one file: `TaskBucketKeyer`, `WithTaskBucketKeyer` (nil = no-op), `TaskBucketKey` (keyer-or-session fallback). Start here.
2. [server/server.go](https://github.com/panyam/mcpkit/pull/858/files#diff-78f42ba40d0f10b08c73b7e6bb8376f398e249c963cf549e89591d6b6826b9a4) — the public `WithTaskBucketKeyer` option, the `serverOptions` field, propagation to the dispatcher, and the **legacy-wire injection** in `dispatchWithOpts` (right after `SetSessionID`).
3. [server/dispatch.go](https://github.com/panyam/mcpkit/pull/858/files#diff-7640bcbef23148a16e477c63c7092f0ba89780f5278a9d6ba6ed513d62f68a92) — the `taskBucketKeyer` dispatcher field + its copy in `newSession()` (per-session clones must carry it).
4. [server/streamable_stateless.go](https://github.com/panyam/mcpkit/pull/858/files#diff-89ab344bf48139c1aded7077cc0048cb885b6ee534ffd3d83f09d113e3a0beb1) — the **stateless-wire injection** in both `handleStatelessPost` and `handleStatelessPostSSE`. This is the parity-critical pair: the stateless path does not go through `dispatchWithOpts`, so it needs its own injection.
5. [server/tasks_v1.go](https://github.com/panyam/mcpkit/pull/858/files#diff-3fc7b7c62ca718319cb6b1928d6dc6a84b8e8f061da092a8f643b9281011755f) and [ext/tasks/tasks.go](https://github.com/panyam/mcpkit/pull/858/files#diff-6b15314e7b637ac95e29f77601d89c4731b2aa4943266a4013345595095df47b) — the consumption swaps: `core.GetSessionID(ctx)` / `ctx.SessionID()` → `core.TaskBucketKey(ctx)` at every task-store call site. Handler contexts embed `context.Context`, so the keyer value propagates through them.
6. [server/stateless_backend.go](https://github.com/panyam/mcpkit/pull/858/files#diff-d6054c7923eaa9651736c3c6bccd7e7634dbf33d4bdfa89a5a34e069bb4b620e) — doc-only: the old "share one bucket / tracked for a follow-up" comment now points at the keyer.
7. Tests — [core/task_bucket_test.go](https://github.com/panyam/mcpkit/pull/858/files#diff-9a80e0b2b432a08cda345c23a28f4b72086cc0e8f75badb8fe98fe99e2463301) (unit) and [ext/tasks/task_isolation_test.go](https://github.com/panyam/mcpkit/pull/858/files#diff-ae81d943f056e3d6b9b097d9e9030cecf7bfd2b809fb8bdc704d7f61dade4862) (end-to-end on the stateless wire, both the isolated-with-keyer and shared-by-default cases).

## Decision log

- **`TaskStore` stays in `server/`** (not root `stores/`, not `ext/tasks`). Moving it to `ext/tasks` would create a circular module dependency (`server → ext/tasks → server`) while the frozen v1 surface lives in `server`; root `stores/` is reserved for generic seams (QuotaStore-shaped), not feature-specific stores. Revisit relocating to `ext/tasks` once v1 retires (issue 426).
- **Keyer lives on `ctx`, not on the store.** The store methods take a plain `sessionID string` with no `ctx`, so a store-wrapping decorator couldn't see the keyer. Rewriting the bucket at the call sites (where `ctx` is in hand) keeps the `TaskStore` interface unchanged.
- **Injected at dispatch funnels, not per-call-site.** One injection per wire entry, read by a shared `core.TaskBucketKey`, rather than threading a keyer parameter through every task function.

## Out of scope

- Relocating `TaskStore` to `ext/tasks` (blocked on v1 retirement, issue 426).
- A persistent/shared-backend `TaskStore` (Redis/SQL) — the seam composes with any `TaskStore`, but only the in-memory default ships here.
- The SEP-2549 / MRTR-signing default flips (issue 496) — separate PR in this bundle.

## Risk / pressure-test

- **Dual-wire parity.** Correctness depends on the keyer being injected on *every* path that reaches a task handler. Today that's `dispatchWithOpts` (covers legacy HTTP, stdio, memory) + the two stateless POST handlers. A new transport/dispatch path would need the same injection — worth a reviewer eye, and it's the class of bug `make verify-dual` guards.
- **Empty-bucket bypass.** `InMemoryTaskStore.sessionAllowed` treats `""` as "matches anything" (back-compat). A keyer that returns `""` for a tenant therefore silently *disables* isolation for it. Keyers must return a non-empty, stable value per tenant. Documented on the option; flagged here because it fails open, not closed.
- **Background execution.** The bucket is resolved once at create time and captured into the task's `sessionID`; the background runner reuses it (correct — same tenant), and does not re-evaluate the keyer.

## Tests

- `core`: keyer applied vs session fallback vs nil no-op.
- `ext/tasks` end-to-end on the stateless wire: with the keyer, tenant B cannot see tenant A's task and tenant A can; the default (no keyer) shares the `sessionID=""` bucket (documents the hole the keyer closes).

Default behavior unchanged. `server`, `core`, `ext/tasks` green.

