### PR TITLE
v0.4.0: conformant-by-default SEP-2549 cache-control hints (issue 496)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,16 @@ targeted spec version.
 
 ### Breaking
 - **conformant-by-default** — safe-default SEP options flip from opt-in to
-  opt-out. Servers built with `server.NewServer(info)` now emit spec-conformant
-  defaults for options where a semantically-equivalent zero-value exists
-  (SEP-2549 list/read cache hints). New `server.WithoutXxx()` opt-outs for the
-  rare divergence. (issue 496)
+  opt-out. `server.NewServer(info)` now emits the SEP-2549 cache-control hints
+  by default: list responses (tools/prompts/resources/templates) carry
+  `ttlMs: 0` + `cacheScope: "public"`; `resources/read` carries `ttlMs: 0` +
+  `cacheScope: "private"` (conservative — read content often varies per user).
+  `ttlMs: 0` is "immediately stale", the same effective behavior as omitting the
+  field but present so the SEP-2549 MUST check passes. Handlers still override
+  per-read. New `server.WithoutListCacheControl()` /
+  `server.WithoutReadResourceCacheControl()` opt-outs restore omission.
+  *Behavior change:* list/read responses that previously omitted these fields
+  now include them. (issue 496)
 - **`server/stateless` collapsed into `server/`** — the sibling package and its
   standalone `Dispatcher` are gone; a single `server.Dispatcher` branches by
   wire internally. Import-path breaking for anyone importing `server/stateless`.

--- a/cmd/testserver/main.go
+++ b/cmd/testserver/main.go
@@ -55,17 +55,14 @@ func main() {
 		// for a conformance testserver — production deployments would
 		// inject the key via environment or secret manager.
 		server.WithRequestStateSigning([]byte("testserver-conformance-key-32-bytes-min"), 0),
-		// SEP-2549 caching hints. The upstream `caching` conformance
-		// scenario verifies that tools/list, prompts/list, resources/list,
-		// resources/templates/list, AND resources/read responses ALL carry
-		// `ttlMs` (non-negative int) + `cacheScope` ("public" | "private").
-		// 60s is the same default the existing examples/list-ttl fixture
-		// uses; public scope is correct for tools/prompts/resources lists
-		// because the catalog doesn't vary per caller. resources/read
-		// content frequently does, so its default is private — handlers
-		// can still override per-read via ResourceResult.CacheScope.
-		server.WithListCacheControl(60_000, core.CacheScopePublic),
-		server.WithReadResourceCacheControl(60_000, core.CacheScopePrivate),
+		// SEP-2549 caching hints are NOT wired explicitly here. Since issue 496
+		// (conformant-by-default), NewServer emits list `ttlMs:0`/`public` and
+		// resources/read `ttlMs:0`/`private` on its own, so the upstream
+		// `caching` scenario (which checks every list + resources/read response
+		// carries a valid `ttlMs` + `cacheScope`) passes against a plain,
+		// unconfigured server. Leaving the options off is deliberate: it makes
+		// the conformance suite the proof of the default, not of a hand-wired
+		// fixture. Handlers can still override per-read via ResourceResult.
 	)
 	// Enable HTTP-level request logging if VERBOSE is set
 	if os.Getenv("VERBOSE") == "1" {

--- a/docs/releases/v0.4.0.md
+++ b/docs/releases/v0.4.0.md
@@ -27,8 +27,10 @@ beyond the date gate:
 ## Scope (confirmed)
 
 ### Breaking (this cut)
-- [ ] **#496** conformant-by-default — flip safe-default SEP options ON (opt-out),
-      add `server.WithoutXxx()` escapes. Document each default that changed.
+- [x] **#496** conformant-by-default — SEP-2549 list + `resources/read`
+      cache-control hints emit by default (list `ttlMs:0`/`public`, read
+      `ttlMs:0`/`private`); `server.WithoutListCacheControl()` /
+      `server.WithoutReadResourceCacheControl()` opt out.
 - [ ] **#493** collapse `server/stateless` into `server/` (single `Dispatcher`).
       Import-path break — migration note in the release body.
 - [x] **#774** lift `QuotaStore` to root `stores/`, rename `EventName` → `Key`

--- a/server/list_ttl_test.go
+++ b/server/list_ttl_test.go
@@ -20,7 +20,11 @@ func TestWithListTTLMs_AppliesToAllFourEndpoints(t *testing.T) {
 		wantPresent bool
 		wantTTL     float64
 	}{
-		{"unset omits ttlMs", nil, false, 0},
+		// Conformant-by-default (issue 496): with no option the server now emits
+		// an explicit ttlMs:0 (was: omitted). WithoutListCacheControl restores
+		// omission; a negative WithListTTLMs also omits.
+		{"default surfaces explicit immediately-stale", nil, true, 0},
+		{"opt-out omits ttlMs", []Option{WithoutListCacheControl()}, false, 0},
 		{"positive surfaces value", []Option{WithListTTLMs(300000)}, true, 300000},
 		{"zero surfaces explicit immediately-stale", []Option{WithListTTLMs(0)}, true, 0},
 		{"negative treated as unset", []Option{WithListTTLMs(-1)}, false, 0},
@@ -154,6 +158,42 @@ func TestReadResource_ServerDefaultCacheControl(t *testing.T) {
 	if m["cacheScope"] != core.CacheScopePrivate {
 		t.Errorf("cacheScope = %v, want %q; raw=%s", m["cacheScope"], core.CacheScopePrivate, res.Raw)
 	}
+}
+
+// TestReadResource_ConformantDefault verifies conformant-by-default (issue 496):
+// with no option, resources/read emits ttlMs:0 + cacheScope:private, and
+// WithoutReadResourceCacheControl restores omission of both fields.
+func TestReadResource_ConformantDefault(t *testing.T) {
+	t.Run("default surfaces ttlMs0 + private", func(t *testing.T) {
+		c := newReadTTLClient(t, nil, "")
+		res, err := c.Call("resources/read", map[string]any{"uri": "file:///fixture"})
+		if err != nil {
+			t.Fatalf("resources/read: %v", err)
+		}
+		var m map[string]any
+		json.Unmarshal(res.Raw, &m)
+		if ttl, ok := m["ttlMs"].(float64); !ok || ttl != 0 {
+			t.Errorf("default ttlMs = %v, want explicit 0; raw=%s", m["ttlMs"], res.Raw)
+		}
+		if m["cacheScope"] != core.CacheScopePrivate {
+			t.Errorf("default cacheScope = %v, want %q; raw=%s", m["cacheScope"], core.CacheScopePrivate, res.Raw)
+		}
+	})
+	t.Run("opt-out omits both", func(t *testing.T) {
+		c := newReadTTLClient(t, nil, "", WithoutReadResourceCacheControl())
+		res, err := c.Call("resources/read", map[string]any{"uri": "file:///fixture"})
+		if err != nil {
+			t.Fatalf("resources/read: %v", err)
+		}
+		var m map[string]any
+		json.Unmarshal(res.Raw, &m)
+		if _, ok := m["ttlMs"]; ok {
+			t.Errorf("opt-out should omit ttlMs; raw=%s", res.Raw)
+		}
+		if _, ok := m["cacheScope"]; ok {
+			t.Errorf("opt-out should omit cacheScope; raw=%s", res.Raw)
+		}
+	})
 }
 
 // TestReadResource_HandlerOverridesCacheControl verifies a resource handler

--- a/server/server.go
+++ b/server/server.go
@@ -453,6 +453,31 @@ func WithReadResourceCacheControl(ttlMs int, scope string) Option {
 	}
 }
 
+// WithoutListCacheControl turns OFF the conformant-by-default SEP-2549 list
+// cache hints (issue 496), so tools/list, prompts/list, resources/list, and
+// resources/templates/list responses omit both ttlMs and cacheScope. Use this
+// only if you deliberately want no cache-control hint on list responses; most
+// servers should keep the default (ttlMs:0, scope:public) or set explicit
+// values with WithListCacheControl.
+func WithoutListCacheControl() Option {
+	return func(o *serverOptions) {
+		o.listTTLMs = nil
+		o.listCacheScope = ""
+	}
+}
+
+// WithoutReadResourceCacheControl turns OFF the conformant-by-default SEP-2549
+// resources/read cache hints (issue 496), so read responses omit both ttlMs and
+// cacheScope unless a handler sets them per-read. Prefer keeping the default
+// (ttlMs:0, scope:private) or setting explicit values with
+// WithReadResourceCacheControl.
+func WithoutReadResourceCacheControl() Option {
+	return func(o *serverOptions) {
+		o.readTTLMs = nil
+		o.readCacheScope = ""
+	}
+}
+
 // WithSchemaValidation toggles call-time JSON Schema validation of tool
 // arguments and prompt arguments against their declared schemas. When
 // enabled (the default), the dispatcher validates incoming arguments
@@ -584,6 +609,22 @@ func NewServer(info core.ServerInfo, opts ...Option) *Server {
 	s := &Server{
 		dispatcher: NewDispatcher(info),
 	}
+	// Conformant-by-default (issue 496): seed the SEP-2549 cache-control hints
+	// that have a safe, semantically-equivalent zero value BEFORE applying user
+	// options, so servers are spec-conformant on the SEP-2549 MUST parts without
+	// the caller having to know the option exists. ttlMs:0 = "immediately stale"
+	// (same effective behavior as omitting the field, but present so the
+	// conformance check passes); list scope defaults public, read scope defaults
+	// private (conservative — resources/read often varies per authenticated
+	// user). Callers override with WithList/ReadResourceCacheControl or turn the
+	// hints off entirely with WithoutList/ReadResourceCacheControl.
+	listTTLDefault := 0
+	readTTLDefault := 0
+	s.options.listTTLMs = &listTTLDefault
+	s.options.listCacheScope = core.CacheScopePublic
+	s.options.readTTLMs = &readTTLDefault
+	s.options.readCacheScope = core.CacheScopePrivate
+
 	for _, opt := range opts {
 		opt(&s.options)
 	}


### PR DESCRIPTION
Part of the v0.4.0 breaking bundle (stacked after issue 485 / PR 858, now merged). Implements issue 496.

## What changes

`server.NewServer(info)` now emits the SEP-2549 cache-control hints **by default**, instead of only when the caller wired the option. These are the options where a safe, semantically-equivalent zero value exists:

| Surface | New default |
|---|---|
| `tools/list`, `prompts/list`, `resources/list`, `resources/templates/list` | `ttlMs: 0`, `cacheScope: "public"` |
| `resources/read` | `ttlMs: 0`, `cacheScope: "private"` |

`ttlMs: 0` means "immediately stale" — the same effective behavior as omitting the field, but the field is now *present*, which is what the SEP-2549 MUST check looks for. `resources/read` defaults to `private` because read content often varies per authenticated user.

**Behavior change:** list / read responses that previously omitted `ttlMs` and `cacheScope` now include them. The point of the change: a server is SEP-2549-conformant out of the box, instead of only if the author knew to call `WithListCacheControl`. This closes the gap behind issue 495 (the conformance driver had to hand-wire the option).

Opt back out with `server.WithoutListCacheControl()` / `server.WithoutReadResourceCacheControl()`.

## Before / after

```mermaid
flowchart LR
  subgraph Before
    N1[NewServer, no option] --> O1["list/read responses<br/>omit ttlMs + cacheScope"]
    O1 --> F1{{SEP-2549 MUST check fails}}
  end
  subgraph After
    N2[NewServer, no option] --> S[seed defaults<br/>before user options]
    S --> O2["list: ttlMs0 + public<br/>read: ttlMs0 + private"]
    O2 --> F2{{SEP-2549 passes}}
    N3["WithoutList/ReadResourceCacheControl"] --> O3[fields omitted again]
  end
```

## Reviewer's guide

1. [server/server.go](https://github.com/panyam/mcpkit/pull/859/files#diff-78f42ba40d0f10b08c73b7e6bb8376f398e249c963cf549e89591d6b6826b9a4) — the whole change is here:
   - **The seed block in `NewServer`**, placed *before* the `for _, opt := range opts` loop so user options (`WithListCacheControl`, `WithListTTLMs`, `WithReadResourceCacheControl`) and the new opt-outs override it. This ordering is the crux — read it first.
   - **`WithoutListCacheControl` / `WithoutReadResourceCacheControl`** — the opt-outs, which nil the fields the seed set.
2. [server/list_ttl_test.go](https://github.com/panyam/mcpkit/pull/859/files#diff-8b4d9cdd086431af0be39be759f12a1830cf91bf2947998fbcecfb976e9bc8b3) — the default case flips from "unset omits ttlMs" to "default surfaces explicit ttlMs:0", plus a new `WithoutListCacheControl` omit case and a `resources/read` conformant-default + opt-out pair.
3. [CHANGELOG.md](https://github.com/panyam/mcpkit/pull/859/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed) / [docs/releases/v0.4.0.md](https://github.com/panyam/mcpkit/pull/859/files#diff-cc6c3bfba5bcf2cc3f21d3ec65e88903995340ce868bf250198a921f6068dd4d) — the documented behavior change.

## Decision log

- **Seed-before-options, not a post-hoc default.** Seeding into `serverOptions` before the option loop means existing `WithList*` / `WithReadResourceCacheControl` calls override for free and the opt-outs are plain options — no "was this explicitly set?" tracking bool.
- **Only the two safe flips.** Per the issue's table, options without a safe zero value stay opt-in: request-state signing (needs a key), subscriptions, tool timeout, listen address. This PR flips only SEP-2549 list + read cache-control.
- **read defaults to `private`.** Conservative: a public default could let a shared cache serve one user's resource content to another. Handlers set `public` per-read when the content is caller-independent.

## Out of scope

- The MRTR request-state-signing "loud warning when unsigned" idea from the issue — no safe default exists (a key is required), so it stays opt-in; the warning is a separate follow-up.

## Risk / pressure-test

- **apps/compat strict `tools/list` parity (DOCKER-gated).** `make test-apps-playwright-docker` diffs mcpkit's `tools/list` against upstream's TS reference server and enforces everything except `$schema` / `additionalProperties`. mcpkit now emits `ttlMs` / `cacheScope` on `tools/list`; if the upstream reference omits them, that strict check will flag drift. Not run in unit tests. Follow-up if it trips: extend the drift filter to ignore the SEP-2549 fields, or confirm upstream emits them too. Flagging so it's a deliberate call, not a surprise.
- **Base conformance.** Confirmed: the upstream `caching` scenario is 7/7 against the default server (see Tests). SEP-2549 hints are spec-allowed on list/read, so the base suite is unaffected.

## Tests

- **Conformance (the proof of the default):** `cmd/testserver` no longer wires the cache options explicitly, so the upstream `modelcontextprotocol/conformance@main` `caching` scenario now grades a plain `NewServer`. It passes **7/7** — all four list endpoints + `resources/read` carry `ttlMs` + `cacheScope`, and the `sep-2549-ttl-non-negative` check accepts `ttlMs:0`. This makes the conformance suite validate the *default*, not a hand-wired fixture (closes the gap where the suite only ever tested the explicit-option path).
- **Unit:** `server` + `core` green. list-TTL suite updated for the new default; new `resources/read` default + opt-out coverage.


