### PR TITLE
examples: README maturity status + Next steps (issue 851 §2/§3)

### DIFF
--- a/examples/CONVENTIONS.md
+++ b/examples/CONVENTIONS.md
@@ -743,17 +743,34 @@ Pick whichever the example actually needs — both are first-class.
 
 ## 5. README.md
 
-Hand-curated narrative. Required sections (in order):
+Hand-curated narrative. The READMEs render on the docs site as the
+examples/tutorials track (issue 508), so they should read as tutorials, not
+just reference. Required sections (in order):
 
 1. **Title + one-paragraph what-this-is**
-2. **Quick Start** — the exact two commands a reader runs (typically
+2. **Status line** — a one-line blockquote directly under the title stating
+   maturity and the spec it tracks, so a reader sees at a glance whether the
+   feature is stable or experimental (mcpkit ships several draft SEPs ahead of
+   the spec — say so). Format:
+   - Stable, merged SEP: `> **Stable** — implements [SEP-N](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/N) (<Name>), merged into the MCP spec.`
+   - Experimental / draft SEP: `> ⚠ **Experimental** — tracks [SEP-N](.../pull/N) (<Name>), a draft SEP. Wire format may change.`
+   - Core / no numbered SEP: `> **Stable** — MCP base protocol (<area>).`
+
+   The SEP PR is the canonical spec-and-discussion venue (don't invent a Discord
+   invite; the repo has none). Use `modelcontextprotocol/modelcontextprotocol/pull/N`,
+   not the old `.../specification/...` path.
+3. **Quick Start** — the exact two commands a reader runs (typically
    `make serve` in one terminal, `make demo` in another).
-3. **What it demonstrates** — bullet list mapping to the demokit steps.
-4. **Architecture** — Mermaid block-or-sequence diagram if the example has
+4. **What it demonstrates** — bullet list mapping to the demokit steps.
+5. **Architecture** — Mermaid block-or-sequence diagram if the example has
    non-trivial topology (separate processes, webhook callbacks, MCP Apps
    bridge).
-5. **Where to look in the code** — bullet list of `path/file.go:symbol`
+6. **Where to look in the code** — bullet list of `path/file.go:symbol`
    pointers, mirroring the closing `Section()` in `walkthrough.go`.
+7. **Next steps** — 1-3 links pointing the reader onward: the most related
+   example(s) and the canonical design/migration doc. Use repo-relative links
+   (`../other-example/`) so they resolve both on GitHub and on the rendered
+   site.
 
 Optional: "What's still pending" (phase tracker), "Setup — getting an API
 token", "Make targets" (only if the Makefile has more than the baseline four).

--- a/examples/apps/README.md
+++ b/examples/apps/README.md
@@ -1,5 +1,7 @@
 # MCP Apps Examples
 
+> **Stable** — MCP Apps extension (`ext/ui`). Needs a host with Apps/iframe support (see below).
+
 Servers exposing **MCP Apps** — interactive HTML/JS UIs that an MCP host renders inside an iframe. The host and app communicate bidirectionally via the App Bridge (postMessage protocol).
 
 > ⚠ **MCP Apps require a host that supports the Apps extension.** [MCPJam](https://mcpjam.com) is the easiest way to test these locally — it's a browser-based MCP host with iframe support. Claude Desktop / VS Code do not yet render MCP Apps.
@@ -65,3 +67,8 @@ See [`docs/APPS_DESIGN.md`](../../docs/APPS_DESIGN.md) for the full architecture
 - [App Bridge JS source](../../ext/ui/assets/) — the JS shipped to the app iframe
 - [`docs/APPS_HOST.md`](../../docs/APPS_HOST.md) — implementing your own MCP App host
 - [`examples/host/01-apphost`](../host/01-apphost/) — `AppHost` walkthrough (Go-side host implementation)
+
+## Next steps
+
+- [Host-side AppHost APIs](../host/01-apphost/)
+- [MCP Apps design](../../docs/APPS_DESIGN.md)

--- a/examples/auth/README.md
+++ b/examples/auth/README.md
@@ -1,5 +1,7 @@
 # Auth Examples
 
+> **Stable** — MCP authorization (base spec): JWT/JWKS validation, Protected Resource Metadata, OAuth discovery, DCR.
+
 MCP servers demonstrating mcpkit's auth capabilities. No external dependencies — no Docker, no Keycloak. Each example spins up an in-process authorization server.
 
 > **🚀 [Skip to the guided walkthrough →](WALKTHROUGH.md)** — 8-step demokit walkthrough with sequence diagram covering public discovery, JWT/JWKS, scope step-up (403 + WWW-Authenticate), and session binding. Run it with `make serve` + `make demo`.
@@ -68,3 +70,8 @@ See `mcp.json` for a ready-to-use multi-server configuration, or for the unified
 - `tests/e2e/` — E2E auth integration tests
 - `tests/keycloak/` — Keycloak interop tests (real OIDC)
 
+
+## Next steps
+
+- [Fine-grained authorization (scope step-up, RAR)](../fine-grained-auth/)
+- [Auth design & spec compliance](../../ext/auth/docs/DESIGN.md)

--- a/examples/elicitation/README.md
+++ b/examples/elicitation/README.md
@@ -1,6 +1,6 @@
 # URL Elicitation — Consent Approval Flow (UC1)
 
-> ⚠ **EXPERIMENTAL** — Tracks [SEP-2643](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2643) (Structured Authorization Denials), currently a draft. Wire format may change as the SEP evolves.
+> ⚠ **Experimental** — Tracks [SEP-2643](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2643) (Structured Authorization Denials), currently a draft. Wire format may change as the SEP evolves.
 
 A scripted MCP host walking through the **UC1 consent approval flow**: a tool call gets denied with a JSON-RPC `-32042` (URLElicitationRequired) carrying a consent URL; the host opens the URL in a browser; the user approves; the server pushes a `notifications/elicitation/complete` notification over SSE; the host auto-retries with the `authorizationContextId` and gets the result.
 
@@ -37,3 +37,8 @@ See [WALKTHROUGH.md](WALKTHROUGH.md) for the full sequence diagram and step-by-s
 
 - CORS is applied via `server.WithHandlerWrap(cors)` so it covers `/mcp` plus the `/approve` route registered through `server.WithMux`. Browser-based MCP hosts (MCPJam) need `Mcp-Session-Id` in both Allow- and Expose-Headers; the canonical CORS configuration lives in this example's `serve()` block.
 - The walkthrough's "Approve" button click is a real human-in-the-loop step; CI runs would need either a headless browser or a synthetic `POST /approve?ctx=...`.
+
+## Next steps
+
+- [Fine-grained auth — UC2 + UC3 of the same SEP](../fine-grained-auth/)
+- [MRTR — the underlying input_required round-trip](../mrtr/)

--- a/examples/events/discord/README.md
+++ b/examples/events/discord/README.md
@@ -1,5 +1,7 @@
 # Discord Events Example
 
+> ⚠ **Experimental** — MCP Events, a draft extension ([spec](https://github.com/modelcontextprotocol/experimental-ext-triggers-events/pull/1)), built on [experimental/ext/events](../../../experimental/ext/events/). Wire format may change.
+
 Reference server demonstrating the [MCP Events spec](https://github.com/modelcontextprotocol/experimental-ext-triggers-events/pull/1) with Discord as the event source. Built on the [`experimental/ext/events`](../../../experimental/ext/events/) library.
 
 Companion to the [Telegram example](../telegram/) — shows the events library handles structurally different payloads (Discord has nested author objects, embeds, threads, mentions vs Telegram's flat text model).
@@ -187,3 +189,8 @@ The events package itself depends only on `core.Claims` (the abstract auth contr
 | `make poll` | Python polling loop (default 5s interval, override: `INTERVAL=10`) |
 
 The Python clients (`make list / listen / webhook / poll`) are convenient for ad-hoc poking. The walkthrough above (`make demo`) is the canonical tour. Both share the [`events_client.py`](../../../experimental/ext/events/clients/python/events_client.py) helper.
+
+## Next steps
+
+- [Telegram events — same protocol, different source](../telegram/)
+- [Events library](../../../experimental/ext/events/)

--- a/examples/events/telegram/README.md
+++ b/examples/events/telegram/README.md
@@ -1,5 +1,7 @@
 # Telegram Events Example
 
+> ⚠ **Experimental** — MCP Events, a draft extension ([spec](https://github.com/modelcontextprotocol/experimental-ext-triggers-events/pull/1)), built on [experimental/ext/events](../../../experimental/ext/events/). Wire format may change.
+
 Reference server demonstrating the [MCP Events spec](https://github.com/modelcontextprotocol/experimental-ext-triggers-events/pull/1) with Telegram as the event source. Built on the [`experimental/ext/events`](../../../experimental/ext/events/) library.
 
 Companion to [Clare Liguori's TypeScript implementation](https://github.com/modelcontextprotocol/experimental-ext-triggers-events/tree/main/telegram-reference-server). Also a lighter mirror of the [discord-events demo](../discord/) — same protocol, different bot SDK.
@@ -126,3 +128,8 @@ Server logs which posture is active at startup.
 | `make poll` | Python polling loop (default 5s interval, override: `INTERVAL=10`) |
 
 All Python clients share the [`events_client.py`](../../../experimental/ext/events/clients/python/events_client.py) helper.
+
+## Next steps
+
+- [Discord events — same protocol, different source](../discord/)
+- [Events library](../../../experimental/ext/events/)

--- a/examples/file-inputs/README.md
+++ b/examples/file-inputs/README.md
@@ -1,5 +1,7 @@
 # SEP-2356 File Inputs — Data URI File Arguments
 
+> ⚠ **Experimental** — tracks [SEP-2356](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2356) (File Inputs), a draft SEP. Wire format may change.
+
 Demonstrates the `x-mcp-file` JSON Schema extension: a server marks string
 properties of `format: "uri"` as file pickers, the client encodes the
 selected file as an RFC 2397 base64 data URI
@@ -136,3 +138,8 @@ This example exercises Phase 1.1 (types) + 1.2 (data URIs) + a starter
   boilerplate.
 - **2.x** — `mcp.selectFile()` in the MCP Apps bridge so an in-iframe app
   can prompt the user for a file and forward the data URI to a tool.
+
+## Next steps
+
+- [Elicitation — another client-interaction flow](../elicitation/)
+- [MRTR — the input_required round-trip](../mrtr/)

--- a/examples/fine-grained-auth/README.md
+++ b/examples/fine-grained-auth/README.md
@@ -1,6 +1,6 @@
 # Fine-Grained Authorization — Scope Step-Up (UC2) + Ephemeral Credentials (UC3)
 
-> ⚠ **EXPERIMENTAL** — Tracks [SEP-2643](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2643) (Structured Authorization Denials), currently a draft. UC2 + UC3 demonstrated end-to-end. Wire format may change as the SEP evolves.
+> ⚠ **Experimental** — Tracks [SEP-2643](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2643) (Structured Authorization Denials), currently a draft. UC2 + UC3 demonstrated end-to-end. Wire format may change as the SEP evolves.
 
 A scripted MCP host walking through two of the SEP-2643 use cases:
 
@@ -45,3 +45,8 @@ See [WALKTHROUGH.md](WALKTHROUGH.md) for the full sequence diagram and step-by-s
 - CORS for browser-based MCP hosts is applied via `server.WithHandlerWrap(cors)` so it covers `/mcp` plus the `auth.MountAuth` routes plus `/demo/bootstrap` uniformly. Same pattern as `examples/elicitation/`.
 - The walkthrough's "no user interaction" assumption is **demo only**. A real banking host would prompt the user to confirm the payment amount/payee before requesting the RAR-bound token.
 - The custom `isError=true` and `tool=` color rules on the demo server logger are passed as variadic extras to `common.NewMCPLogger` — they layer on top of the canonical 5-rule set without re-declaring it.
+
+## Next steps
+
+- [Elicitation — UC1 of the same SEP](../elicitation/)
+- [Auth basics](../auth/)

--- a/examples/host/01-apphost/README.md
+++ b/examples/host/01-apphost/README.md
@@ -1,5 +1,7 @@
 # AppHost — Host-Side App Management
 
+> **Stable** — MCP Apps host-side APIs (`ext/ui`: AppHost).
+
 Demonstrates AppHost mediating between an MCP server and an app bridge with bidirectional tool calls.
 
 ## What you'll learn
@@ -132,3 +134,8 @@ go run ./examples/host/01-apphost/ --non-interactive
 - **Step 6**: CallAppTool returns "Hello, World!" and counter increments to 2
 - **Step 7**: App calls server_echo, result includes "echo: from the app"
 - **Step 8**: After dynamic registration, 3 app tools listed (app_greet, app_counter, app_dice)
+
+## Next steps
+
+- [Multi-server registry](../02-multi-server/)
+- [MCP Apps (the iframe UIs a host renders)](../../apps/)

--- a/examples/host/02-multi-server/README.md
+++ b/examples/host/02-multi-server/README.md
@@ -1,5 +1,7 @@
 # Multi-Server Registry
 
+> **Stable** — MCP Apps host-side APIs (`ext/ui`: ServerRegistry).
+
 Demonstrates ServerRegistry managing 3 MCP servers with tool aggregation, collision resolution, and app bridge integration.
 
 ## What you'll learn
@@ -134,3 +136,8 @@ go run ./examples/host/02-multi-server/ --non-interactive
 - **Step 7**: CallToolOn routes to weather regardless of resolver
 - **Step 8**: After removing clock, `get_time` returns "unknown tool" error
 - **Step 9**: After AddWithBridge, 8 tools listed including `app_stopwatch` (source=app)
+
+## Next steps
+
+- [AppHost basics](../01-apphost/)
+- [MCP Apps](../../apps/)

--- a/examples/list-ttl/README.md
+++ b/examples/list-ttl/README.md
@@ -1,5 +1,7 @@
 # SEP-2549 List TTL — Cache Hints on List and Read Results
 
+> **Stable** — implements [SEP-2549](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2549) (List TTL), merged into the MCP spec.
+
 Demonstrates the SEP-2549 cache hints — `ttlMs` (integer milliseconds) and
 `cacheScope` (`public`/`private`) — that an MCP server attaches to every
 paginated list response (`tools/list`, `prompts/list`, `resources/list`,
@@ -7,7 +9,7 @@ paginated list response (`tools/list`, `prompts/list`, `resources/list`,
 cache the registered surface between `notifications/list_changed` instead
 of re-fetching on every poll.
 
-Spec: [SEP-2549](https://github.com/modelcontextprotocol/specification/pull/2549).
+Spec: [SEP-2549](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2549).
 Migration notes: [docs/LIST_TTL_MIGRATION.md](../../docs/LIST_TTL_MIGRATION.md).
 
 ## ttlMs contract
@@ -91,4 +93,8 @@ test run. Drive it via `make testconf-list-ttl` from the repo root.
 | Client helpers | [`client.ListToolsPage`](../../client/iterators.go) and siblings, [`client.ReadResourceFull`](../../client/client.go) |
 | Migration guide | [`docs/LIST_TTL_MIGRATION.md`](../../docs/LIST_TTL_MIGRATION.md) |
 | Conformance | [SEP-2549 scenarios on panyam/mcpconformance `pending`](https://github.com/panyam/mcpconformance/tree/pending/src/scenarios/server/list-ttl) — drive via `make testconf-list-ttl` |
-| SEP | [SEP-2549 spec PR](https://github.com/modelcontextprotocol/specification/pull/2549) |
+| SEP | [SEP-2549 spec PR](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2549) |
+
+## Next steps
+
+- [List TTL migration notes](../../docs/LIST_TTL_MIGRATION.md)

--- a/examples/mrtr/README.md
+++ b/examples/mrtr/README.md
@@ -1,5 +1,7 @@
 # SEP-2322 MRTR — Ephemeral InputRequiredResult Round-Trips
 
+> **Stable** — implements [SEP-2322](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2322) (MRTR), merged into the MCP spec.
+
 Demonstrates the SEP-2322 ephemeral Multi Round-Trip Requests pattern:
 the server returns `InputRequiredResult{inputRequests, requestState}`
 when it needs more input from the client; the client resolves each
@@ -84,3 +86,8 @@ testconf-mrtr` from the repo root.
 | Single dispatcher | [`client.HandleServerRequestWithContext`](../../client/client.go) — same switch handles real server-initiated requests AND MRTR-synthesized ones |
 | Conformance | [panyam/mcpconformance — `src/scenarios/server/mrtr/`](https://github.com/panyam/mcpconformance/tree/feat/tasks-mrtr-extension/src/scenarios/server/mrtr) (upstream Draft PR modelcontextprotocol/conformance#262); local sentinel: [`conformance/mrtr/`](../../conformance/mrtr/) |
 | SEP | [SEP-2322 spec PR](https://github.com/modelcontextprotocol/specification/pull/2322) |
+
+## Next steps
+
+- [Tasks v2 — reuses the same input_required envelope](../tasks-v2/)
+- [MRTR tutorial](../../docs/MRTR_TUTORIAL.md)

--- a/examples/otel/stdout/README.md
+++ b/examples/otel/stdout/README.md
@@ -1,5 +1,7 @@
 # examples/otel/stdout — SEP-414 Trace Context Propagation
 
+> **Stable** — implements SEP-414 (OpenTelemetry trace context). See [docs/SEP_414_OTEL.md](../../../docs/SEP_414_OTEL.md).
+
 Interactive demokit walkthrough showing how to wire OpenTelemetry
 tracing into BOTH sides of an MCP exchange using the
 [`ext/otel`](../../../ext/otel/) adapter — `server.WithTracerProvider`
@@ -121,3 +123,8 @@ surface is unchanged. Polished walkthroughs for Jaeger and OTLP live in
 SEP-414 P5 on [issue 312][issue].
 
 [issue]: https://github.com/panyam/mcpkit/issues/312
+
+## Next steps
+
+- [SEP-414 tracing design](../../../docs/SEP_414_OTEL.md)
+- [Events — another trace-propagation surface](../../events/discord/)

--- a/examples/protogen/bookservice/README.md
+++ b/examples/protogen/bookservice/README.md
@@ -1,5 +1,7 @@
 # BookService — protoc-gen-go-mcp Example
 
+> ⚠ **Experimental** — build-time codegen (`experimental/ext/protogen`), not a wire protocol.
+
 End-to-end example demonstrating all three MCP primitives generated from proto annotations.
 
 ## MCPKit Features Used
@@ -101,3 +103,8 @@ Or in `.claude/settings.json`:
   }
 }
 ```
+
+## Next steps
+
+- [Getting started](../../getting-started/)
+- [protogen design](../../../experimental/ext/protogen/docs/DESIGN.md)

--- a/examples/skills-core/README.md
+++ b/examples/skills-core/README.md
@@ -1,5 +1,7 @@
 # examples/skills-core
 
+> ⚠ **Experimental** — the minimal [SEP-2640](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640) (Skills) shape, a draft SEP. Wire format may change.
+
 The **minimal** SEP-2640 shape: a skills file served over MCP's Resources
 primitive, plus tool handling, consumed load-on-demand. This is the
 scoped-down core the Skills Over MCP Working Group blessed at its
@@ -61,3 +63,7 @@ disk. That invariant is enforced by `TestNoCodeExecutionSurface` in the
 
 See [`WALKTHROUGH.md`](WALKTHROUGH.md) for the generated step-by-step (run
 `make readme` to regenerate).
+
+## Next steps
+
+- [Skills — the full surface (archives, remote, fsnotify)](../skills/)

--- a/examples/skills/README.md
+++ b/examples/skills/README.md
@@ -1,5 +1,7 @@
 # examples/skills
 
+> ⚠ **Experimental** — tracks [SEP-2640](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640) (Skills), a draft SEP. Wire format may change.
+
 End-to-end example for SEP-2640 (Skills extension): a mcpkit server that
 exposes Agent Skills under the `skill://` URI scheme, plus a demokit
 walkthrough that drives a host against it.
@@ -115,3 +117,7 @@ classes are tracked under mcpkit#567.
 - SEP-2640: <https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640>
 - Agent Skills specification: <https://agentskills.io/specification>
 - Working group: skills-over-mcp-wg
+
+## Next steps
+
+- [Skills — the minimal core shape](../skills-core/)

--- a/examples/stateless/README.md
+++ b/examples/stateless/README.md
@@ -1,5 +1,7 @@
 # examples/stateless — SEP-2575 stateless wire + SEP-2567 handle pattern
 
+> **Stable** — implements [SEP-2575](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2575) (stateless wire) + the [SEP-2567](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2567) handle pattern.
+
 > **SEP-2577 deprecation note**: this example uses `core.EmitLog(...)`, which is deprecated per SEP-2577 (scheduled for removal in mcpkit v0.4). The code still works on v0.3.x. See [`docs/SEP_2577_DEPRECATIONS.md`](../../docs/SEP_2577_DEPRECATIONS.md) for the migration story.
 
 A single mcpkit server that demonstrates two complementary draft SEPs:
@@ -61,3 +63,8 @@ A scripted demokit walkthrough that drives the cart story end-to-end is intentio
 - The server runs in `stateless.ModeStateless` by default (conformance suite wants a pure stateless surface). `--mode=dual` opens the legacy wire alongside.
 - `HandleStore[Cart]` is the interface; the default `NewHandleStore[Cart](...)` returns the in-memory impl. Persistent backends (Redis etc.) for cross-replica deployments are tracked in `mcpkit#471` — they drop in without changing tool-handler call sites.
 - `add_item` uses `HandleStore.Put(cart_id, ...)` to update in place so the client's handle stays stable across rounds (the SEP-2567 happy path).
+
+## Next steps
+
+- [MRTR — input gathering on the stateless wire](../mrtr/)
+- [SEP-2567 handle pattern](../../docs/SEP_2567_HANDLES.md)

--- a/examples/tasks-v2/README.md
+++ b/examples/tasks-v2/README.md
@@ -1,5 +1,7 @@
 # MCP Tasks v2 (SEP-2663) — Server-Directed Async + MRTR
 
+> **Stable** — implements [SEP-2663](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2663) (Tasks v2), merged into the MCP spec.
+
 Server-side implementation of the v2 Tasks extension. v2 inverts v1's client-driven model: the *server* decides when to create a task, and clients call `tools/call` normally with no task hint.
 
 > **🚀 [Skip to the guided walkthrough →](WALKTHROUGH.md)** — 8-step demokit walkthrough covering the full v2 surface: extension negotiation, polymorphic `tools/call`, inlined results, the new `tasks/update` MRTR loop, ack-only cancel, and tool-vs-protocol error semantics. Run it with `make serve` + `make demo`.
@@ -69,3 +71,8 @@ See [WALKTHROUGH.md](WALKTHROUGH.md) for the full step-by-step description and s
 - Client helpers: [`client/tasks.go`](../../client/tasks.go) (`ToolCall`, `GetTask`, `WaitForTask`, `UpdateTask`, `CancelTask`)
 - Conformance scenarios: [panyam/mcpconformance — `src/scenarios/server/tasks/`](https://github.com/panyam/mcpconformance/tree/feat/tasks-mrtr-extension/src/scenarios/server/tasks)
 - Local sentinel for mcpkit-stricter scenarios: [`conformance/tasks-v2/`](../../conformance/tasks-v2/)
+
+## Next steps
+
+- [MRTR — the input_required envelope tasks v2 reuses](../mrtr/)
+- [Tasks tutorial](../../docs/TASKS_TUTORIAL.md)

--- a/examples/tasks/README.md
+++ b/examples/tasks/README.md
@@ -1,5 +1,7 @@
 # Tasks Example Server
 
+> **Stable (frozen)** — MCP Tasks v1 (spec 2025-11-25). Superseded by [tasks-v2](../tasks-v2/) ([SEP-2663](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2663)) for new work.
+
 > **SEP-2577 deprecation note**: this example demonstrates `TaskContext.TaskSample(...)`, which is deprecated per SEP-2577 (scheduled for removal in mcpkit v0.4). The code still works on v0.3.x. See [`docs/SEP_2577_DEPRECATIONS.md`](../../docs/SEP_2577_DEPRECATIONS.md) for the migration story.
 
 Demonstrates MCP Tasks (spec 2025-11-25) — async tool execution with lifecycle tracking.
@@ -566,3 +568,8 @@ Create a task and send progress notifications from the tool handler.
 | `../../client/tasks_v1.go` | v1 client helpers: GetTaskV1, ToolCallAsTaskV1, etc. |
 | `../../docs/TASKS_V2_MIGRATION.md` | v1 → v2 migration guide (current canonical doc) |
 
+
+## Next steps
+
+- [Tasks v2 — the canonical async model](../tasks-v2/)
+- [v1 → v2 migration](../../docs/TASKS_V2_MIGRATION.md)


### PR DESCRIPTION
Completes **§2 (READMEs as tutorials)** and **§3 (maturity / spec signaling)** of issue 851. Since these READMEs now render on the docs site as the examples/tutorials track, this makes them read as tutorials and shows mcpkit's ahead-of-the-spec posture at a glance.

## §3 — maturity + spec

A consistent one-line status blockquote under each gallery example's title:

- **Stable, merged SEP:** `> **Stable** — implements [SEP-N](…/pull/N) (<Name>), merged into the MCP spec.`
- **Experimental, draft SEP:** `> ⚠ **Experimental** — tracks [SEP-N](…/pull/N) (<Name>), a draft SEP. Wire format may change.`
- **Core:** `> **Stable** — MCP base protocol (<area>).`

The SEP PR is the canonical spec-and-discussion venue — the repo has no Discord invite, so I didn't invent one (per the §3 ask, this is where the feature is designed). Also normalized the two examples that already had banners (`elicitation`, `fine-grained-auth`) and fixed `list-ttl`'s stale `…/specification/…` SEP URL to `…/modelcontextprotocol/…` (verified the canonical one resolves).

## §2 — next-step links

A curated **Next steps** section on each gallery example (related example(s) + the canonical design/migration doc), using repo-relative links so they resolve both on GitHub and on the rendered site.

## Convention

`examples/CONVENTIONS.md` §5 now requires the status line and Next steps, with the format spelled out, so new examples follow suit.

## Verification

- 18 gallery examples updated; `docs/site` builds clean and the status line + Next steps render (spot-checked `examples/skills-core` — the ⚠ Experimental blockquote and Next steps show correctly).
- Idempotent scripts (skip if a marker / Next steps already present), so re-runs are safe.

With this, issue 851 is fully addressed (§1 typed registration landed in #856/#857).
