### PR TITLE
docs/site: rewrite repo-relative links at render time (fix ~390 dead links)

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -135,7 +135,7 @@ Or add it to Claude Desktop / VS Code MCP settings:
 
 You have a working server and client. Now reach for the batteries:
 
-- **[Guides](../guides/)** — task-oriented how-tos: transports, auth (JWT / OAuth /
+- **[Guides](../guides/transports/)** — task-oriented how-tos: transports, auth (JWT / OAuth /
   DCR), long-running tasks, interactive apps, tracing, deployment.
 - **[Examples](../examples/)** — 20+ runnable, guided walkthroughs. This is where the
   draft-SEP batteries are shown end to end.

--- a/docs/TASKS_V2_MIGRATION.md
+++ b/docs/TASKS_V2_MIGRATION.md
@@ -251,6 +251,6 @@ SEP-2322's `core.InputRequiredResult.RequestState` (the MRTR multi-round-trip su
 - SEP-2322 (MRTR base types): https://github.com/modelcontextprotocol/specification/pull/2322
 - SEP-2575 (per-request capabilities): pattern adopted from spec discussion
 - SEP-2243 (Mcp-Name HTTP header): adopted from spec discussion
-- Implementation plan + open questions: [`PLAN.md`](../PLAN.md)
+- Implementation plan + open questions: [`SEP_2663_TASKS_CONFORMANCE_PLAN.md`](SEP_2663_TASKS_CONFORMANCE_PLAN.md)
 - v2 example walkthrough: [`examples/tasks-v2/WALKTHROUGH.md`](../examples/tasks-v2/WALKTHROUGH.md)
 - v2 conformance suite: [panyam/mcpconformance — `src/scenarios/server/tasks/`](https://github.com/panyam/mcpconformance/tree/feat/tasks-mrtr-extension/src/scenarios/server/tasks) (8 ClientScenario classes / ~33 internal checks; upstream Draft PR modelcontextprotocol/conformance#262). Local sentinel for mcpkit-stricter scenarios: [`conformance/tasks-v2/`](../conformance/tasks-v2/).

--- a/docs/site/Makefile
+++ b/docs/site/Makefile
@@ -18,6 +18,7 @@ GH_REMOTE_URL ?= $(shell git -C ../.. config --get remote.origin.url)
 
 build:
 	@echo "Building mcpkit docs site..."
+	@rm -rf dist   # purge stale output so removed pages never linger in a deploy
 	MCPKIT_DOCS_ENV=production go run . -build
 	@cp -R static dist/docs/static
 	@cd ../.. && uv run scripts/collect_walkthroughs.py

--- a/docs/site/main.go
+++ b/docs/site/main.go
@@ -16,11 +16,14 @@ import (
 	"flag"
 	"fmt"
 	"html/template"
+	"io/fs"
 	"log"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 
 	s3 "github.com/panyam/s3gen"
 	"github.com/yuin/goldmark"
@@ -101,8 +104,128 @@ func renderMarkdownFile(relPath string) template.HTML {
 		log.Printf("docs/site: render %s: %v", relPath, err)
 		return ""
 	}
-	return template.HTML(buf.String())
+	srcDir := path.Dir(filepath.ToSlash(filepath.Clean(relPath)))
+	return template.HTML(rewriteRepoLinks(buf.String(), srcDir))
 }
+
+// The source-of-truth markdown carries repo-relative links (./other.md,
+// ../examples/x/main.go, ../../docs/Y.md) written for GitHub. On the rendered
+// site those don't resolve — the site doesn't mirror the repo layout and hosts
+// no source files. rewriteRepoLinks fixes each relative href/src at render time:
+//   - a doc that has its own site page  -> that page's site URL
+//   - any other existing repo file/dir  -> GitHub source URL (raw host for <img>)
+//   - a site-only relative link (../guides/, ../examples/) or external/anchor -> left as-is
+// See sourceToSite for how the doc→page map is derived.
+
+// repoTreeBase / rawBase mirror repoBlobBase for directory and raw-image links.
+var (
+	repoRootURL  = strings.TrimSuffix(repoBlobBase, "/blob/main/")
+	repoTreeBase = repoRootURL + "/tree/main/"
+	rawBase      = strings.Replace(repoRootURL, "github.com", "raw.githubusercontent.com", 1) + "/main/"
+)
+
+// sourceToSite maps a repo-relative markdown path (a wrapper's `source:` front
+// matter) to the site URL that renders it, so links to a doc that has its own
+// page land on-site instead of on GitHub. Built lazily from the content/
+// wrappers on first render (after cwd is docs/site).
+var (
+	s2sOnce sync.Once
+	s2sMap  map[string]string
+)
+
+var frontMatterSource = regexp.MustCompile(`(?m)^source:\s*"?([^"\n]+?)"?\s*$`)
+
+func sourceToSite() map[string]string {
+	s2sOnce.Do(func() {
+		m := map[string]string{}
+		_ = filepath.WalkDir("content", func(p string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() || !strings.HasSuffix(p, ".html") {
+				return nil
+			}
+			data, rerr := os.ReadFile(p)
+			if rerr != nil {
+				return nil
+			}
+			mt := frontMatterSource.FindSubmatch(data)
+			if mt == nil {
+				return nil
+			}
+			src := path.Clean(strings.TrimSpace(string(mt[1])))
+			rel, _ := filepath.Rel("content", p)
+			rel = filepath.ToSlash(rel)
+			var sitePath string
+			if path.Base(rel) == "index.html" {
+				sitePath = path.Dir(rel)
+			} else {
+				sitePath = strings.TrimSuffix(rel, ".html")
+			}
+			url := sitePathPrefix + "/"
+			if sitePath != "" && sitePath != "." {
+				url += sitePath + "/"
+			}
+			m[src] = url
+			return nil
+		})
+		s2sMap = m
+	})
+	return s2sMap
+}
+
+var hrefOrSrc = regexp.MustCompile(`(href|src)="([^"]*)"`)
+
+func rewriteRepoLinks(html, srcDir string) string {
+	if srcDir == "." {
+		srcDir = ""
+	}
+	return hrefOrSrc.ReplaceAllStringFunc(html, func(match string) string {
+		mt := hrefOrSrc.FindStringSubmatch(match)
+		attr, u := mt[1], mt[2]
+		switch {
+		case u == "",
+			strings.HasPrefix(u, "http://"), strings.HasPrefix(u, "https://"),
+			strings.HasPrefix(u, "mailto:"), strings.HasPrefix(u, "//"),
+			strings.HasPrefix(u, "#"), strings.HasPrefix(u, "/"),
+			strings.HasPrefix(u, "data:"):
+			return match
+		}
+		frag := ""
+		if i := strings.IndexAny(u, "#?"); i >= 0 {
+			frag, u = u[i:], u[:i]
+		}
+		if u == "" {
+			return match
+		}
+		target := path.Clean(path.Join(srcDir, u))
+		if target == ".." || strings.HasPrefix(target, "../") {
+			return match // escapes repo root — leave alone
+		}
+		// (a) doc with its own site page.
+		if site, ok := sourceToSite()[target]; ok {
+			return attr + `="` + site + frag + `"`
+		}
+		// (b) directory whose README has a site page.
+		if site, ok := sourceToSite()[path.Join(target, "README.md")]; ok {
+			return attr + `="` + site + frag + `"`
+		}
+		// (c) an existing repo file/dir — point at the real source on GitHub.
+		info, err := os.Stat(filepath.Join(repoRoot, filepath.FromSlash(target)))
+		if err != nil {
+			return match // not a repo path — a site-only relative link; leave it.
+		}
+		if attr == "src" {
+			return attr + `="` + rawBase + target + frag + `"`
+		}
+		if info.IsDir() {
+			return attr + `="` + repoTreeBase + target + frag + `"`
+		}
+		return attr + `="` + repoBlobBase + target + frag + `"`
+	})
+}
+
+// sitePathPrefix is the site's URL base. Kept as a const (not read off Site)
+// so the link rewriter can reference it without an initialization cycle
+// through Site's CommonFuncMap.
+const sitePathPrefix = "/mcpkit"
 
 // repoBlobBase is the GitHub blob URL prefix (…/blob/main/), read from
 // content/SiteMetadata.json so the repo lives in one place. gitfile builds
@@ -169,7 +292,7 @@ var markdown = goldmark.New(
 var Site = &s3.Site{
 	OutputDir:   "./dist/docs",
 	ContentRoot: "./content",
-	PathPrefix:  "/mcpkit",
+	PathPrefix:  sitePathPrefix,
 	TemplateFolders: []string{
 		"./templates",
 	},

--- a/examples/elicitation/README.md
+++ b/examples/elicitation/README.md
@@ -30,7 +30,7 @@ See [WALKTHROUGH.md](WALKTHROUGH.md) for the full sequence diagram and step-by-s
 
 - Walkthrough steps + denial parsing: [`main.go`](main.go) (the `runDemo` block)
 - Consent middleware + store + `/approve` handler: [`main.go`](main.go) (after `serve()`)
-- SEP-2643 wire constants: [`core.MetaKeyAuthorizationContextID`](../../core/meta.go) and the `-32042` URLElicitationRequired error code
+- SEP-2643 wire constants: [`core.MetaKeyAuthorizationContextID`](../../core/authorization_denial_experimental.go) and the `-32042` URLElicitationRequired error code
 - Companion: [`examples/fine-grained-auth/`](../fine-grained-auth/) — UC2 (scope step-up) + UC3 (RAR per-payment credentials)
 
 ## Notes

--- a/examples/tasks-v2/README.md
+++ b/examples/tasks-v2/README.md
@@ -66,7 +66,7 @@ See [WALKTHROUGH.md](WALKTHROUGH.md) for the full step-by-step description and s
 ## Where to look in the code
 
 - v1 example: [`examples/tasks/`](../tasks/)
-- Server library: [`server/tasks_v2.go`](../../server/tasks_v2.go)
+- Server library: [`ext/tasks/tasks.go`](../../ext/tasks/tasks.go)
 - Wire types: [`core/task_v2.go`](../../core/task_v2.go)
 - Client helpers: [`client/tasks.go`](../../client/tasks.go) (`ToolCall`, `GetTask`, `WaitForTask`, `UpdateTask`, `CancelTask`)
 - Conformance scenarios: [panyam/mcpconformance — `src/scenarios/server/tasks/`](https://github.com/panyam/mcpconformance/tree/feat/tasks-mrtr-extension/src/scenarios/server/tasks)


### PR DESCRIPTION
Makes the docs site announce-ready by fixing broken internal links. A crawl of the built site found **~390 broken internal links across 43 pages** — enough to undercut a launch.

## Cause

The source-of-truth markdown (concepts tutorials, guides, example READMEs, design docs) carries **repo-relative links** written for GitHub — `./bringup.md`, `../examples/mrtr/main.go`, `../../docs/TASKS_TUTORIAL.md`. Rendered on the site they don't resolve: the site doesn't mirror the repo's file layout and hosts no `.go`/`.ts` source. The launch-critical surfaces (nav, landing, Get Started) were already fine; the breakage was in the *rendered content* cross-links.

## Fix

`renderMarkdownFile` now rewrites each relative `href`/`src` against the source file's repo directory, three ways:

- **a doc that has its own site page → that page's site URL** (concept→concept, example README→guide stay on-site; the doc→page map is derived once from the `content/` wrappers' `source:` front matter)
- **any other existing repo file/dir → GitHub source URL** (raw host for `<img>`)
- **a site-only relative link (`../guides/`, `../examples/`) or external/anchor → left unchanged**

`PathPrefix` moved to a const to avoid an init cycle through `Site`'s `CommonFuncMap`.

Also fixed 4 genuinely-broken source links the crawl surfaced (wrong paths in elicitation / tasks-v2 READMEs, `TASKS_V2_MIGRATION`, and the Get Started Guides link), and made `make build` purge stale `dist` so removed pages never linger in a deploy (that stale-artifact behavior is what made the first count look worse than it was).

## Result

Clean build reports **0 broken internal links** (was ~390). Spot-checked routing:
- concept `./bringup.md` → `/mcpkit/concepts/bringup/` (on-site)
- guide `../examples/mrtr/main.go` → GitHub blob
- Get Started `../examples/` → `/mcpkit/examples/` (on-site)
- example → `ext/auth` DESIGN → `/mcpkit/guides/auth/` (on-site)

Closes the dead-link item in #854. With this in, the site is good to launch/announce.
