### PR TITLE
v0.4.0: WithSupportedVersions per-server protocol version override (issue 419) + SEP-2243 close-out (issue 517)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,12 @@ targeted spec version.
   through a single `featuresForVersion` table (`server/protocol_features.go`)
   instead of scattered `negotiatedVersion == "..."` checks, so a new
   version-gated SEP is wired in one place across both wires.
+- **`server.WithSupportedVersions(...)`** — override the accepted protocol
+  versions per server so operators can drop older ones (e.g. refuse
+  `2024-11-05`). `initialize` negotiates within the configured set (requests
+  outside it get the set's preferred version); a post-init
+  `MCP-Protocol-Version` header outside the set is HTTP 400. The stateless wire
+  advertises its own draft-version set independently. (issue 419)
 
 ### Deprecated (unchanged in 0.4.0 — removal deferred)
 - SEP-2577 Roots / Sampling / Logging surfaces keep their `// Deprecated:`

--- a/client/client.go
+++ b/client/client.go
@@ -2102,6 +2102,11 @@ func (t *streamableClientTransport) postResponse(resp *core.Response) {
 	if err != nil {
 		return
 	}
+	// No SEP-2243 Mcp-Method header here (issue 517): this POST carries a
+	// JSON-RPC *response* to a server-to-client request, not a request method,
+	// so there is no method for a routing intermediary to key on. Whether a
+	// response should echo the originating request's method is an open SEP-2243
+	// question; until the spec settles it, no header is set.
 	buildReq := func() (*http.Request, error) {
 		req, err := http.NewRequest("POST", t.url, bytes.NewReader(raw))
 		if err != nil {
@@ -2467,6 +2472,10 @@ func (t *sseClientTransport) call(_ string, data []byte) (*rpcResponse, error) {
 	}
 }
 
+// notify ignores its method argument by design (issue 517): the legacy SSE
+// transport predates SEP-2243, and setting the Mcp-Method routing header on a
+// deprecated wire is not worth the risk of surprising legacy proxies. The
+// SEP-2243 routing headers are emitted on the Streamable HTTP transport only.
 func (t *sseClientTransport) notify(_ string, data []byte) error {
 	// Check if the background reader is already dead before POSTing.
 	select {

--- a/server/dispatch.go
+++ b/server/dispatch.go
@@ -147,6 +147,12 @@ type Dispatcher struct {
 	// that prefer leniency over strict spec conformance.
 	allowLegacyOnDraft bool
 
+	// configuredVersions overrides the package-level supportedProtocolVersions
+	// for this server when non-empty (issue 419). Set via WithSupportedVersions;
+	// read through protocolVersions() so negotiation, the MCP-Protocol-Version
+	// header check, and the discover advertise all see the operator's set.
+	configuredVersions []string
+
 	// taskBucketKeyer derives the task-store isolation bucket for each request
 	// (issue 485). Nil = default (session ID). Set via WithTaskBucketKeyer;
 	// injected onto the request context in dispatchWithOpts and the stateless
@@ -300,6 +306,7 @@ func (d *Dispatcher) newSession() *Dispatcher {
 		readCacheScope:       d.readCacheScope,
 		allowLegacyOnDraft:   d.allowLegacyOnDraft,
 		allowReinitialize:    d.allowReinitialize,
+		configuredVersions:   d.configuredVersions,
 		taskBucketKeyer:      d.taskBucketKeyer,
 	}
 }
@@ -482,10 +489,10 @@ func (d *Dispatcher) handleInitialize(id json.RawMessage, params json.RawMessage
 	if p.ProtocolVersion == "" {
 		return core.NewErrorResponseWithData(id, core.ErrCodeInvalidParams,
 			"missing required protocolVersion in initialize params",
-			map[string]any{"supported": supportedProtocolVersions})
+			map[string]any{"supported": d.protocolVersions()})
 	}
 
-	negotiated := negotiateProtocolVersion(p.ProtocolVersion)
+	negotiated := negotiateProtocolVersion(d.protocolVersions(), p.ProtocolVersion)
 
 	d.negotiatedVersion = negotiated
 	d.clientCaps = p.Capabilities

--- a/server/protocol_features.go
+++ b/server/protocol_features.go
@@ -10,27 +10,41 @@ import "github.com/panyam/mcpkit/core"
 // transport code. Centralizing keeps the legacy and stateless wires from
 // drifting (a recurring parity trap) and gives contributors one table to read.
 
+// protocolVersions returns the protocol versions this dispatcher accepts —
+// the operator-configured set (WithSupportedVersions) when non-empty, else the
+// package-level default. This is the single reader that negotiation, the
+// MCP-Protocol-Version header check, and the discover advertise consult, so a
+// per-server override applies uniformly (issue 419).
+func (d *Dispatcher) protocolVersions() []string {
+	if len(d.configuredVersions) > 0 {
+		return d.configuredVersions
+	}
+	return supportedProtocolVersions
+}
+
 // preferredProtocolVersion is the version the server offers when a client
 // requests one it does not support. Per the MCP version-negotiation handshake
 // this SHOULD be the latest version the server supports, which is the first
 // entry in supportedProtocolVersions.
-func preferredProtocolVersion() string {
-	return supportedProtocolVersions[0]
+func preferredProtocolVersion(versions []string) string {
+	return versions[0]
 }
 
 // negotiateProtocolVersion implements the MCP initialize version handshake
-// (spec 2025-03-26 §Version Negotiation): if the client's requested version is
-// supported, echo it back; otherwise respond with the server's preferred
-// (latest) supported version and let the client decide whether to proceed on
-// that version or disconnect. This replaces the older behavior of rejecting an
-// unsupported version outright.
-func negotiateProtocolVersion(requested string) string {
-	for _, sv := range supportedProtocolVersions {
+// (spec 2025-03-26 §Version Negotiation) over the given supported set: if the
+// client's requested version is in the set, echo it back; otherwise respond
+// with the set's preferred (first) version and let the client decide whether to
+// proceed on that version or disconnect. This replaces the older behavior of
+// rejecting an unsupported version outright. The set is the server's configured
+// versions (WithSupportedVersions) or the package default — see
+// Dispatcher.protocolVersions.
+func negotiateProtocolVersion(versions []string, requested string) string {
+	for _, sv := range versions {
 		if sv == requested {
 			return sv
 		}
 	}
-	return preferredProtocolVersion()
+	return preferredProtocolVersion(versions)
 }
 
 // ProtocolFeatures describes the version-gated behaviors active for a given

--- a/server/protocol_features_test.go
+++ b/server/protocol_features_test.go
@@ -9,17 +9,23 @@ import (
 func TestNegotiateProtocolVersion(t *testing.T) {
 	// A supported version is echoed back verbatim.
 	for _, sv := range supportedProtocolVersions {
-		if got := negotiateProtocolVersion(sv); got != sv {
+		if got := negotiateProtocolVersion(supportedProtocolVersions, sv); got != sv {
 			t.Errorf("negotiateProtocolVersion(%q) = %q, want echo", sv, got)
 		}
 	}
-	// An unsupported version falls back to the server's preferred (latest).
-	if got := negotiateProtocolVersion("1999-01-01"); got != supportedProtocolVersions[0] {
+	// An unsupported version falls back to the set's preferred (first).
+	if got := negotiateProtocolVersion(supportedProtocolVersions, "1999-01-01"); got != supportedProtocolVersions[0] {
 		t.Errorf("unsupported -> %q, want preferred %q", got, supportedProtocolVersions[0])
 	}
-	// Preferred is the first (latest) entry.
-	if preferredProtocolVersion() != supportedProtocolVersions[0] {
-		t.Errorf("preferred = %q, want %q", preferredProtocolVersion(), supportedProtocolVersions[0])
+	// Preferred is the first entry of the given set.
+	if preferredProtocolVersion(supportedProtocolVersions) != supportedProtocolVersions[0] {
+		t.Errorf("preferred = %q, want %q", preferredProtocolVersion(supportedProtocolVersions), supportedProtocolVersions[0])
+	}
+	// A configured subset negotiates within itself: an excluded version falls
+	// back to the subset's preferred, not the package default (issue 419).
+	subset := []string{"2025-11-25", "2025-03-26"}
+	if got := negotiateProtocolVersion(subset, "2024-11-05"); got != "2025-11-25" {
+		t.Errorf("subset negotiate(2024-11-05) = %q, want 2025-11-25", got)
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -79,6 +79,7 @@ type serverOptions struct {
 	allowLegacyOnDraft   bool                     // WithAllowLegacyOnDraft — opt-in SEP-2575 leniency on the legacy wire (off by default; strict per spec)
 	allowReinitialize    bool                     // WithAllowReinitialize — opt-in acceptance of a duplicate initialize (off by default; issue 421)
 	taskBucketKeyer      core.TaskBucketKeyer     // WithTaskBucketKeyer — per-request task-store isolation bucket (nil = session ID; issue 485)
+	supportedVersions    []string                 // WithSupportedVersions — per-server protocol version override (nil = package default; issue 419)
 	tracerProvider       core.TracerProvider      // SEP-414 P2 — WithTracerProvider; nil/Noop = trace middleware not installed
 	meterProvider        core.MeterProvider       // issue 7 — WithMeterProvider; nil/Noop = metrics middleware not installed
 	notificationRelay       NotificationRelay           // issue 755 — WithNotificationRelay; nil = no cross-replica broadcast (Broadcast fires local only)
@@ -594,6 +595,37 @@ func WithTaskBucketKeyer(keyer core.TaskBucketKeyer) Option {
 	return func(o *serverOptions) { o.taskBucketKeyer = keyer }
 }
 
+// WithSupportedVersions overrides, for this server only, the set of MCP
+// protocol versions accepted at initialize and on the MCP-Protocol-Version
+// header (issue 419). Pass the versions the server should support, newest
+// first — the first entry is the one the server offers when a client requests
+// a version outside the set.
+//
+// Default (option NOT set): the package-level default
+// (2026-07-28 / 2025-11-25 / 2025-03-26 / 2024-11-05). Operators use this to
+// drop older versions per deployment, e.g. refuse 2024-11-05:
+//
+//	server.WithSupportedVersions("2026-07-28", "2025-11-25", "2025-03-26")
+//
+// Behavior with the configured set:
+//   - initialize requesting a version in the set negotiates that version;
+//     requesting one outside the set negotiates the set's preferred (first)
+//     version, and the client proceeds on it or disconnects (MCP 2025-03-26
+//     §Version Negotiation — same as the default handshake, just over a
+//     narrower set).
+//   - a post-initialize MCP-Protocol-Version header carrying a version outside
+//     the set is rejected with HTTP 400.
+//
+// Passing an empty list is a no-op (the default set stays in effect); order is
+// preserved as given.
+func WithSupportedVersions(versions ...string) Option {
+	return func(o *serverOptions) {
+		if len(versions) > 0 {
+			o.supportedVersions = versions
+		}
+	}
+}
+
 // WithRootsFetchTimeout sets the deadline for server-to-client roots/list
 // requests issued after notifications/roots/list_changed. Default is 30s.
 // Decrease for aggressive fail-fast; increase for slow clients with large
@@ -640,6 +672,7 @@ func NewServer(info core.ServerInfo, opts ...Option) *Server {
 	s.dispatcher.allowLegacyOnDraft = s.options.allowLegacyOnDraft
 	s.dispatcher.allowReinitialize = s.options.allowReinitialize
 	s.dispatcher.taskBucketKeyer = s.options.taskBucketKeyer
+	s.dispatcher.configuredVersions = s.options.supportedVersions
 	s.dispatcher.customHandlers = s.options.customHandlers
 	// Wire registry change notifications to Server.Broadcast so that
 	// dynamic adds/removes automatically notify all connected sessions.

--- a/server/streamable_transport.go
+++ b/server/streamable_transport.go
@@ -361,7 +361,7 @@ func (t *streamableTransport) handlePost(w http.ResponseWriter, r *http.Request)
 	// some clients may send a different supported version than was negotiated.
 	if protoVer := r.Header.Get(mcpProtocolVersionHeader); protoVer != "" {
 		supported := false
-		for _, sv := range supportedProtocolVersions {
+		for _, sv := range dispatcher.protocolVersions() {
 			if protoVer == sv {
 				supported = true
 				break

--- a/server/supported_versions_test.go
+++ b/server/supported_versions_test.go
@@ -1,0 +1,112 @@
+package server_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/server"
+)
+
+// newVersionServer builds a Streamable HTTP server restricted to the given
+// protocol versions (issue 419) with one trivial tool so tools/list works.
+func newVersionServer(t *testing.T, versions ...string) *httptest.Server {
+	t.Helper()
+	srv := server.NewServer(core.ServerInfo{Name: "ver", Version: "1"}, server.WithSupportedVersions(versions...))
+	srv.RegisterTool(
+		core.ToolDef{Name: "noop", Description: "noop", InputSchema: map[string]any{"type": "object"}},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) { return core.TextResult("ok"), nil },
+	)
+	ts := httptest.NewServer(srv.Handler(server.WithStreamableHTTP(true), server.WithSSE(false)))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func postJSON(t *testing.T, url, body string, headers map[string]string) *http.Response {
+	t.Helper()
+	req, _ := http.NewRequest("POST", url, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	return resp
+}
+
+// Test_Issue419_InitializeNegotiatesWithinConfiguredSet: a server configured to
+// drop 2024-11-05 negotiates a client's 2024-11-05 request DOWN to the
+// configured preferred (2025-11-25), rather than echoing the excluded version.
+func Test_Issue419_InitializeNegotiatesWithinConfiguredSet(t *testing.T) {
+	ts := newVersionServer(t, "2025-11-25", "2025-03-26")
+	body := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"c","version":"1"}}}`
+	resp := postJSON(t, ts.URL+"/mcp", body, nil)
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+
+	var out struct {
+		Result struct {
+			ProtocolVersion string `json:"protocolVersion"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("decode (%s): %v", raw, err)
+	}
+	if out.Result.ProtocolVersion != "2025-11-25" {
+		t.Errorf("negotiated %q, want configured preferred 2025-11-25 (excluded 2024-11-05 should not be echoed); raw=%s",
+			out.Result.ProtocolVersion, raw)
+	}
+}
+
+// Test_Issue419_ConfiguredVersionNegotiatesAsIs: a client requesting a version
+// that IS in the configured set gets exactly that version.
+func Test_Issue419_ConfiguredVersionNegotiatesAsIs(t *testing.T) {
+	ts := newVersionServer(t, "2025-11-25", "2025-03-26")
+	body := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"c","version":"1"}}}`
+	resp := postJSON(t, ts.URL+"/mcp", body, nil)
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	var out struct {
+		Result struct {
+			ProtocolVersion string `json:"protocolVersion"`
+		} `json:"result"`
+	}
+	json.Unmarshal(raw, &out)
+	if out.Result.ProtocolVersion != "2025-03-26" {
+		t.Errorf("negotiated %q, want 2025-03-26 (in the configured set); raw=%s", out.Result.ProtocolVersion, raw)
+	}
+}
+
+// Test_Issue419_HeaderOutsideConfiguredSetRejected: after negotiating, a
+// post-initialize request whose MCP-Protocol-Version header carries a version
+// the server was configured to drop is rejected with HTTP 400.
+func Test_Issue419_HeaderOutsideConfiguredSetRejected(t *testing.T) {
+	ts := newVersionServer(t, "2025-11-25")
+	initBody := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"c","version":"1"}}}`
+	initResp := postJSON(t, ts.URL+"/mcp", initBody, nil)
+	sid := initResp.Header.Get("Mcp-Session-Id")
+	initResp.Body.Close()
+	if sid == "" {
+		t.Fatal("no session id from initialize")
+	}
+	// notifications/initialized to complete the handshake.
+	postJSON(t, ts.URL+"/mcp", `{"jsonrpc":"2.0","method":"notifications/initialized"}`, map[string]string{"Mcp-Session-Id": sid}).Body.Close()
+
+	// A post-init request carrying an excluded version in the header → 400.
+	resp := postJSON(t, ts.URL+"/mcp", `{"jsonrpc":"2.0","id":2,"method":"tools/list"}`, map[string]string{
+		"Mcp-Session-Id":       sid,
+		"MCP-Protocol-Version": "2024-11-05",
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		b, _ := io.ReadAll(resp.Body)
+		t.Errorf("want HTTP 400 for excluded MCP-Protocol-Version header, got %d; body=%s", resp.StatusCode, b)
+	}
+}


### PR DESCRIPTION
Part of the v0.4.0 track. Implements issue 419 and closes out issue 517.

## What changes

`server.WithSupportedVersions(...)` lets an operator restrict the MCP protocol versions a server accepts — e.g. drop `2024-11-05`. It slots directly onto the version-negotiation machinery that landed earlier this bundle (`server/protocol_features.go`), following the same `Option` pattern as `WithTaskBucketKeyer`. Default (unset) keeps the full package set.

Behavior with a configured set, consistent with the Gap-1 handshake (negotiate-down, not hard-reject):
- `initialize` requesting a version **in** the set → negotiates that version.
- `initialize` requesting a version **outside** the set → negotiates the set's **preferred** (first) version; the client proceeds on it or disconnects (MCP 2025-03-26 §Version Negotiation).
- a post-init `MCP-Protocol-Version` **header** outside the set → **HTTP 400**.

Issue 517 (SEP-2243 `Mcp-Method` coverage) is a close-out: its substantive item — `cmd/testclient` driving `resources/*` + `prompts/*` so the audit checks flip — already shipped (`http-standard-headers` audit row is **11 pass / 0 skip**). This PR documents the two intentional no-header sites so the remaining "gaps" are captured as decisions, and closes 517.

## Before / after

```mermaid
flowchart LR
  subgraph Before
    A1[initialize / header check] --> P1[package var<br/>supportedProtocolVersions]
    P1 --> R1[(fixed 4-version set,<br/>not per-server)]
  end
  subgraph After
    A2[initialize / header check] --> M[Dispatcher.protocolVersions]
    M -->|WithSupportedVersions set| C[operator set]
    M -->|unset| D[package default]
  end
```

## Reviewer's guide

Read in this order:
1. [server/server.go](https://github.com/panyam/mcpkit/pull/863/files#diff-78f42ba40d0f10b08c73b7e6bb8376f398e249c963cf549e89591d6b6826b9a4) — the `WithSupportedVersions` option (doc-comment spells out the negotiate-down vs 400 contract) + propagation to the dispatcher. Start here.
2. [server/dispatch.go](https://github.com/panyam/mcpkit/pull/863/files#diff-7640bcbef23148a16e477c63c7092f0ba89780f5278a9d6ba6ed513d62f68a92) — the new `configuredVersions` field, its `newSession()` clone, and the two call sites now reading `d.protocolVersions()` (negotiation + the `"supported"` error data).
3. [server/protocol_features.go](https://github.com/panyam/mcpkit/pull/863/files#diff-f08ce18af391b682e28dd8a742021572cdb5b9ae89460db51ff78adaf34735b2) — `protocolVersions()` helper + `negotiate/preferredProtocolVersion` now take the version list.
4. [server/streamable_transport.go](https://github.com/panyam/mcpkit/pull/863/files#diff-6d7a7857fa287633c986304e06b224dc7e95a8a8d770430f684717bb7d1543b4) — the post-init `MCP-Protocol-Version` header check reads the dispatcher's set (the 400 path).
5. [server/supported_versions_test.go](https://github.com/panyam/mcpkit/pull/863/files#diff-dc6e734cf5e888962578f682352c8916ba5ab9146de52fb36e3f7e7b88917e0f) — acceptance (red-before-green): drop-a-version negotiate-down, header→400, in-set as-is.
6. [client/client.go](https://github.com/panyam/mcpkit/pull/863/files#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09) — issue 517: rationale comments at `postResponse` + legacy SSE `notify` (why no `Mcp-Method`).

Skim: [server/protocol_features_test.go](https://github.com/panyam/mcpkit/pull/863/files#diff-f50615ce57535851df0f1f4f381bd6b180222783dc5d87af7075587241e3d0e6) (added a subset case).

## Decision log

- **Negotiate-down, not hard-reject.** #419's original acceptance text said reject excluded versions with `-32602`. That predates the Gap-1 handshake change (merged earlier this bundle), which made `initialize` negotiate to the preferred supported version per spec. Rejecting would re-introduce the non-spec behavior Gap-1 removed, so the configured set narrows *what the server offers*, and the client decides — the spec-correct shape. The hard reject stays only on the post-init header (which asserts an already-negotiated version).
- **Stateless wire untouched.** `WithSupportedVersions` governs the legacy `initialize` set only. The stateless wire advertises `core.SupportedStatelessVersions` (draft versions), a deliberately independent surface — dropping `2024-11-05` has no bearing on it.
- **#517 = document, not implement.** Items 1/2 (postResponse header, legacy SSE header) are intentional no-ops — item 1 is an open SEP-2243 spec question, item 2 is a deprecated wire. Documenting the rationale is the right close-out; setting the headers is out of scope.

## Risk / blast radius

- **Default path unchanged:** with no option, `protocolVersions()` returns the same package var, so negotiation, the header check, and the error data behave identically. Every existing server is unaffected.
- **Tests:** `server` + `core` green; new acceptance file; resolver unit test extended. Net assertions **+** (no existing assertion weakened).
- Pressure-test: the header-400 path (a client legitimately sending an older-but-now-excluded version gets 400 — intended, but operators should size their set to their clients).

## Out of scope

- Setting `Mcp-Method` on `postResponse` / legacy SSE (issue 517 items 1/2) — deferred as documented no-ops.
- Validating the version *strings* passed to `WithSupportedVersions` (unknown/typo versions) — kept a plain override; a typo just narrows the set.

