### PR TITLE
docs(whole-enchilada): refresh events README to match the demo's current spotlight

### DIFF
--- a/examples/whole-enchilada/events/README.md
+++ b/examples/whole-enchilada/events/README.md
@@ -1,30 +1,29 @@
 # whole-enchilada — production-shape MCP Events demo
 
-Multi-tier reference deployment for the [MCP Events extension](https://github.com/modelcontextprotocol/experimental-ext-triggers-events) built on mcpkit. Stages plug onto the same compose graph; this leaf currently ships **stage 1**.
+Multi-tier reference deployment for the [MCP Events extension](https://github.com/modelcontextprotocol/experimental-ext-triggers-events) built on mcpkit. It runs nginx + N event-server replicas + Keycloak + Postgres + Redis on one compose graph.
 
 ```
-Host  ──[MCP / SSE]──>  Nginx  ──>  Event-server  <──[HTTP /events/<name>/inject]──  Push-server
-                                          │
-                                          └──[webhook POST]──>  Your receivers  (host-run `make webhook`)
+Host ─[MCP]→ Nginx ─→ Event-server (N replicas) ←[HTTP /events/<name>/inject]─ producers
+   │                       │  ├─ streaming push (events/stream, response-as-SSE)
+   │←── streaming push ────┘  ├─ webhook POST (Standard Webhooks signature)
+   │←── webhook POST ─────────┘  └─ poll (events/poll — ad-hoc)
+                                Postgres (buffer + webhook store)   Redis (pub/sub fan-out + global caps)
 ```
 
-## What stage 1 ships
+## What the demo spotlights
 
-- **Compose graph** (`docker-compose.yaml`) with nginx + N event-server replicas. Webhook and stream subscribers run as host processes (`make webhook` / `make streamer`), not compose services.
-- **Templated** — `make gen-compose N=<n>` regenerates the compose YAML and nginx config for arbitrary replica counts.
-- **DNS naming convention** — every service answers a `*.whole-enchilada` hostname both inside the compose network and (with `make hosts-install`) from the host shell / browser. See "Hostname routing" below.
-- **All three delivery modes** work end-to-end: poll, push (SSE), webhook.
-- **In-memory stores** — restart wipes state. Stage 3 plugs in Postgres + Redis.
+Two **push delivery surfaces** are the headline; polling is available for ad-hoc/operator use but is not the narrative.
 
-## What stage 2 adds
+- **Streaming push** — `make streamer`: a long-running `events/stream` subscriber over the **SEP-2575 stateless wire**. The open POST response carries `notifications/events/event` frames as SSE (response-as-SSE, issue 753), so nginx round-robins freely across replicas and no per-session push channel is needed.
+- **Webhook** — `make webhook`: HTTP POST delivery with a Standard Webhooks signature, plus the full lifecycle (client `ttlMs` suggestion clamped to the server envelope, `refreshBefore`, 410-abandon / 500-retry-then-suspend, and failure-based GC of no-expiry subs).
+- **Poll** — `make poller`: an `events/poll` subscriber, kept for ad-hoc operator use and to show cursor durability (any replica reads the same Postgres buffer, with bounded TTL replay).
+- **Per-tenant isolation** via Keycloak introspection: three realms (`asgard`, `babylon`, `camelot`), a `MultiRealmIntrospectionValidator` that accepts a token if any realm says active, and per-event tenant tags so delivery is scoped to `Claims.Tenant`. One terminal per tenant makes the isolation visible — an event for one tenant does not show up on the other two.
+- **Synchronously revocable tokens** — signing a user out in Keycloak kills that tenant's live subscribers within `OAUTH_CACHE_TTL`; the demo's headline win over plain JWT.
+- **Cross-replica delivery** (N=3 by default) — a Redis pub/sub bus fans every yielded event to every replica's local delivery loop, so killing a replica mid-stream doesn't drop delivery on the survivors; subscription caps are enforced globally (Redis Lua-atomic INCR-with-check).
+- **Durable stores** — Postgres-backed event buffer + `WebhookStore` and Redis bus. State survives a rolling restart of the event-server tier (both finite-TTL and no-expiry webhook subs persist).
+- **Operator-controlled source topology** — `evctl sources add/rm` attaches a real upstream source (Discord) to specific replicas at runtime; a `events.topology` meta-source stream unifies the per-replica view.
 
-- **Keycloak as the OAuth AS**, pinned to `quay.io/keycloak/keycloak:26.0`. Three realms pre-imported on first start: `asgard`, `babylon`, `camelot`. Admin UI at <http://localhost:8180/admin/> (`admin` / `admin`).
-- **Multi-realm introspection on the event-server.** The new `MultiRealmIntrospectionValidator` fans every bearer token out to all three realms' `/introspect` endpoints and accepts the token if any realm says active. Tenant comes from whichever realm validated, encoded as `<realm>/<sub>` into `core.Claims.Subject` (PR 692).
-- **Per-event tenant tagging.** `ChatMessageData` / `PresenceChangedData` now carry a `Tenant` field; the push-server rotates events across tenants by default. The event-server's `tenantMatchFunc` only delivers events to subscribers whose `Claims.Tenant` matches — cross-tenant isolation is enforced at delivery time.
-- **Demo-only client secrets**, pre-baked in the committed realm JSONs at `keycloak/realms/`. See `keycloak/README.md` for the bring-your-own-client recipe.
-- **Three tenants**, not two, so isolation is visually obvious: with one terminal per tenant the demo can show events for one tenant *not* showing up on the other two.
-
-Subsequent stages still in flight: stage-3 wires the GORM stores from PR 685 (multi-replica state survives restart); stage-4 polishes push survival, the WG-announcement artifact, and revocation walkthrough docs.
+The `keycloak/realms/` JSONs ship demo-only client secrets; see `keycloak/README.md` for the bring-your-own-client recipe.
 
 ## Quickstart
 
@@ -37,16 +36,16 @@ go install github.com/panyam/oneauth/cmd/oneauth@v0.1.19
 Bring up the stack:
 
 ```bash
-make up           # docker compose up -d with N=1, M=1 (+ Keycloak in stage 2). Add BUILD=true to force a fresh docker rebuild.
-make demo              # interactive walkthrough (TUI) — pure narrative; press Enter between Steps
+make up           # docker compose up -d with N=3 event-server replicas + Keycloak + Postgres + Redis. Add BUILD=true to force a fresh docker rebuild.
+make demo         # interactive walkthrough (TUI) — pure narrative; press Enter between Steps
 make test         # non-interactive walkthrough (CI / scripting)
 make down         # tear down
 ```
 
-Scale replicas:
+Override the replica count (default N=3):
 
 ```bash
-make up N=3   # 3 event-server replicas (synthetic producers are operator-run via `make drive-chat` / `make drive-presence`)
+make up N=5   # 5 event-server replicas (synthetic producers are operator-run via `make drive-chat` / `make drive-presence`)
 ```
 
 Local in-process tests (no Docker):
@@ -57,52 +56,35 @@ make unittest          # event-server e2e tests — includes 8 tenant-isolation 
 
 The `unittest` suite verifies (1) tagged events deliver only to matching tenants, (2) untagged events still deliver to all, (3) interleaved cross-tenant events don't leak — using an in-process fake `token-as-tenant` validator. `make test` (the walkthrough run against the live Docker stack) adds the Keycloak interop layer on top.
 
-## Stage-2 4-terminal interactive demo
+## Interactive multi-terminal demo
 
-Once `make up` is running, open multiple terminals to see per-tenant isolation in action. Each terminal authenticates as a single tenant via Keycloak and prints what it sees.
-
-**Acquire all six tokens upfront in your shell** — the per-window `make poller` / `make webhook` invocations consume them as env vars:
-
-```bash
-export TOKEN_POLLER_TENANT_A=$(make newtoken TENANT=A)
-export TOKEN_POLLER_TENANT_B=$(make newtoken TENANT=B)
-export TOKEN_POLLER_TENANT_C=$(make newtoken TENANT=C)
-export TOKEN_WEBHOOK_TENANT_A=$(make newtoken TENANT=A)
-export TOKEN_WEBHOOK_TENANT_B=$(make newtoken TENANT=B)
-export TOKEN_WEBHOOK_TENANT_C=$(make newtoken TENANT=C)
-```
-
-Each `make newtoken` opens a browser to the realm's login page. Use the seeded test users: `alice` / `bob` / `carol` (passwords match usernames). The realms also ship with `user{a,b,c}{1..5}` for parameterized testing.
-
-For scripted/CI use: `make newtoken-ci TENANT=A USER=usera1 PASSWORD=usera1` (ROPC; deprecated by OAuth 2.1 but supported).
-
-Once exported, open six terminals:
+Once `make up` is running, open a terminal per tenant to see per-tenant isolation in action. The headline is the **two push surfaces** — three streaming subscribers and three webhook receivers, one tenant each. Each `make streamer` / `make webhook` logs in on demand (`USERNAME=<user>` opens a browser to that realm's login page), so no upfront token juggling. Seeded users: `alice` (asgard/A), `bob` (babylon/B), `carol` (camelot/C) — passwords match usernames; the realms also ship `user{a,b,c}{1..5}`.
 
 ```bash
 # T1 — keep this running
 make up
 
-# T2 — Asgard poller. Browser opens for login as alice@asgard (alice/alice).
-TA=$(make newtoken TENANT=A)
-make poller TENANT=A TOKEN=$TA
+# T2/T3/T4 — one streaming push subscriber per tenant (events/stream, response-as-SSE)
+make streamer TENANT=A USERNAME=alice
+make streamer TENANT=B USERNAME=bob
+make streamer TENANT=C USERNAME=carol
 
-# T3 — Babylon poller (different terminal). Login as bob@babylon.
-TB=$(make newtoken TENANT=B)
-make poller TENANT=B TOKEN=$TB
+# T5/T6/T7 — one webhook receiver per tenant
+make webhook TENANT=A USERNAME=alice
+make webhook TENANT=B USERNAME=bob
+make webhook TENANT=C USERNAME=carol
 
-# T4 — Asgard webhook receiver.
-make webhook TENANT=A TOKEN=$TA
-
-# T5 — Babylon webhook receiver.
-make webhook TENANT=B TOKEN=$TB
-
-# T6 — Inject events from the host. Only the matching tenant's terminals print.
+# T8 — inject one event per tenant; only the matching tenant's two windows print
 make inject TENANT=A EVENT=chat.message TEXT="hi from A"
 make inject TENANT=B EVENT=chat.message TEXT="hi from B"
 make inject TENANT=C EVENT=presence.changed USER=carol STATE=online
 ```
 
-`make up` brings the stack up silent — no events flow until you run `make drive-chat` (and / or `make drive-presence`) in sibling windows. The drivers rotate tenant tags round-robin across A/B/C; leave the pollers running and watch each tenant's window light up in turn. Tune the cadence with `EVERY=200ms` (high-volume mode) or restrict to one tenant with `TENANTS=asgard`.
+`make up` brings the stack up silent — no events flow until you inject (single deliberate events, above) or run the synthetic drivers `make drive-chat` / `make drive-presence` in sibling windows. The drivers rotate tenant tags round-robin across A/B/C; leave the subscribers running and watch each tenant's windows light up in turn. Tune with `EVERY=200ms` (high-volume) or restrict to one tenant with `TENANTS=asgard`.
+
+For scripted/CI use, swap the browser login for ROPC: `make newtoken-ci TENANT=A USER=usera1 PASSWORD=usera1` (ROPC; deprecated by OAuth 2.1 but supported), then pass `TOKEN=<bearer>`.
+
+**Poll mode (ad-hoc).** `make poller TENANT=A USERNAME=alice` runs an `events/poll` subscriber. It's not part of the headline narrative — the push surfaces are — but it's handy for operator spot-checks and for showing cursor durability: `START_CURSOR=<N>` resumes from the shared Postgres buffer (bounded by its TTL), so any replica serves the same replay.
 
 ### Revocation walkthrough (the load-bearing demo step)
 
@@ -110,10 +92,10 @@ The introspection-based auth has *synchronously revocable* tokens — the demo's
 
 1. Open <http://localhost:8180/admin/master/console/#/asgard/users>, login as `admin` / `admin`.
 2. Click user `alice` → **Sessions** tab → **Sign out**.
-3. Within `OAUTH_CACHE_TTL` seconds (default 5s), Asgard's poller + webhook terminals die with `-32012 Forbidden`.
+3. Within `OAUTH_CACHE_TTL` seconds (default 5s), Asgard's streaming + webhook terminals die with `-32012 Forbidden` — revocation fires across both push surfaces uniformly.
 4. Babylon + Camelot terminals stay alive — revocation is per-realm, isolation holds.
 
-This is the operator-facing flow a real production admin would use; nothing in the demo "fakes" the revocation. Re-acquire a token (`make newtoken TENANT=A`) and the subscribers reconnect.
+This is the operator-facing flow a real production admin would use; nothing in the demo "fakes" the revocation. Log back in (`make streamer TENANT=A USERNAME=alice`) and the subscriber reconnects.
 
 ## Observability (traces in Grafana)
 
@@ -163,8 +145,6 @@ make up
 
 The event-server's `tryEnableAuth()` picks up `OAUTH_ISSUER` and fetches JWKS from `<issuer>/protocol/openid-connect/certs`. Tokens signed by your IdP are validated locally; no callback to your AS per request. **Trade-off:** revocation is no longer synchronously visible — tokens stay valid until they expire (the JWT-vs-introspection trade-off; see `ext/auth/introspection_validator.go` doc for context).
 
-## What stage 2 adds
-
 ## Architecture
 
 ### Tiers
@@ -181,7 +161,7 @@ Webhook and stream **subscribers** are not a compose tier. The demo runs them as
 
 1. A producer (host driver via `make inject` / `make drive-chat`, or in production the `push-server` via `eventsclient.Pusher.PushNamed("chat.message", data)`) POSTs to `http://event-server.whole-enchilada/events/chat.message/inject`.
 2. `event-server`'s `events.HTTPSource[ChatMessageData]` handler decodes and yields into the library's `YieldingSource`.
-3. The library fans out: stream subscribers receive the event via SSE on `events/stream`, webhook subscribers get an HTTP POST with a Standard Webhooks signature, poll subscribers see it on their next `events/poll`.
+3. The library fans out: streaming subscribers receive the event as an SSE frame on their open `events/stream` response, webhook subscribers get an HTTP POST with a Standard Webhooks signature; an ad-hoc poll subscriber would see it on its next `events/poll`.
 4. Each host-run subscriber (`make webhook` / `make streamer`) verifies the signature and logs the payload.
 
 ### Cross-replica delivery (why N>1 works)
@@ -253,15 +233,9 @@ curl http://pusher.whole-enchilada/status                       # any push-serve
 
 **From inside a container**, the same names just work — Docker's embedded DNS resolves the network aliases.
 
-## Future stages (planned, not in this PR)
+## Build history
 
-| Stage | What it adds | Issue |
-|---|---|---|
-| 2 | Keycloak realm + tenant-scoped subscribe + multi-tenant routing on nginx. | #637 |
-| 3 | Postgres-backed Cursor/Webhook/Quota stores. Redis EventBus. Cross-replica fanout (verified by killing a replica mid-stream). | #639 |
-| 4 | Admin frontend. M push-servers driven by admin-configured source bindings. OTel collector + Jaeger + Grafana + Loki + Mimir. Push survival walkthrough. | #638 |
-
-The directory layout and the `*.whole-enchilada` naming convention are forward-compatible — later stages add services without restructuring.
+The demo grew in stages, all now shipped: Keycloak realms + tenant-scoped delivery (issue 637), Postgres-backed buffer/webhook/quota stores + Redis bus + cross-replica fanout (issue 639), and the admin source-topology + observability + push-survival layer (issue 638). The `*.whole-enchilada` naming convention and directory layout stayed forward-compatible throughout — new services slotted in without restructuring.
 
 ## Layout
 
@@ -270,11 +244,14 @@ whole-enchilada/
 ├── docker-compose.yaml     # GENERATED (committed default: N=3)
 ├── nginx/nginx.conf        # GENERATED
 ├── tools/gen-compose/      # Template + Go renderer
-├── event-server/           # MCP Events server, HTTPSource consumer
+├── event-server/           # MCP Events server, HTTPSource consumer, source-topology admin
 ├── push-server/            # Synthetic feeders + Pusher client (reference; demo uses host drivers)
-├── webhook/, streamer/, poller/, inject/, drivers/  # host-run subscribers + producers
+├── streamer/, webhook/     # host-run PUSH subscribers (the headline surfaces)
+├── poller/                 # host-run poll subscriber (ad-hoc / cursor-durability)
+├── evctl/                  # operator CLI — runtime source topology (evctl sources add/rm)
+├── inject/, drivers/       # host-run producers
 ├── walkthrough/            # demokit walkthrough binary
-├── Makefile                # demo-up / test / demo-down / gen-compose
+├── Makefile                # up / test / down / gen-compose
 ├── README.md               # this file
 └── WALKTHROUGH.md          # GENERATED by `make readme`
 ```


### PR DESCRIPTION
Docs-only. The `examples/whole-enchilada/events` README had drifted from what the demo (and its `WALKTHROUGH.md`) actually spotlight.

## What was stale → fixed
- **Delivery modes.** "All three delivery modes: poll, push (SSE), webhook" as co-equals → the two **push surfaces** (streaming via `make streamer` = `events/stream` response-as-SSE, and webhook) are the headline; **poll (`make poller`) is demoted to ad-hoc/operator use** + cursor-durability — matching the walkthrough, where poll is step 5, not the narrative.
- **Storage.** "In-memory stores — restart wipes state. Stage 3 plugs in Postgres + Redis" → Postgres + Redis are **wired** (GORM `WebhookStore` restart-survival, Redis pub/sub fan-out, Lua-atomic global caps).
- **Stage framing.** "ships stage 1" + a "future stages 2/3/4" table (all shipped) → a current "What the demo spotlights" list + a short build-history note. Removed a duplicate empty `## What stage 2 adds` header.
- **Interactive demo section.** Rewritten streamer-first (3 streaming + 3 webhook subscribers via `USERNAME=` on-demand login); dropped the six-upfront-`TOKEN_POLLER/WEBHOOK` dance. Revocation step now says streaming+webhook.
- **Quickstart.** `make up` is N=3 (was N=1) with Keycloak/Postgres/Redis always up.
- Added `evctl` source-topology + `events.topology` meta-source to the spotlight + layout.

## Terminology note (for the reviewer)
The streaming subscription is **response-as-SSE over the SEP-2575 stateless wire** (issue 753), not literally WebSockets. The only WebSocket in the system is the push-server's **upstream Discord source**. I kept the README precise on this rather than calling the subscriber transport "WebSocket."

Ground truth cross-checked against `walkthrough/walkthrough.go` + the generated `WALKTHROUGH.md` and the Makefile targets (`poller`/`streamer`/`webhook`, `N ?= 3`). No code changes; `WALKTHROUGH.md` is generated and already current.

https://claude.ai/code/session_01WNa3gC7M5HNzyQm9FCPyvK