### PR TITLE
core: RawJSON parse-once wrapper + share trace-middleware _meta parses (issue 733 slice 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@ targeted spec version.
   for external `QuotaStore` implementors (experimental surface). (issue 774)
 
 ### Added / Fixed
+- **`core.RawJSON`** — a typed, parse-once wrapper for JSON-RPC raw values
+  (params / `_meta` / …) with `Bind` / `Meta` / `Field` helpers; wire-transparent
+  (round-trips identically to `json.RawMessage`). First slice of issue 733; the
+  trace middleware now shares one parse across its `_meta` readers (trace
+  context / baggage / tracelink) — ~3× faster + ~3× less alloc on large
+  `tools/call` payloads. The `Request.Params` type flip is a later slice.
 - **Panic recovery in library goroutines** — a panic in a tool/background
   goroutine is recovered and surfaced as an error instead of crashing the host
   process. (issue 420)

--- a/core/baggage.go
+++ b/core/baggage.go
@@ -118,16 +118,24 @@ func InjectBaggage(meta map[string]any, b Baggage) {
 // fails the same structural validation as ExtractBaggage. Mirror of
 // ExtractTraceContextFromParams.
 func ExtractBaggageFromParams(params json.RawMessage) Baggage {
-	if len(params) == 0 {
+	m := NewRawJSON(params)
+	return ExtractBaggageFromRawJSON(&m)
+}
+
+// ExtractBaggageFromRawJSON is the RawJSON form of ExtractBaggageFromParams
+// (issue 733) — reads `_meta.baggage` through the message's parse-once spine so
+// it shares the parse of params with the trace-context and tracelink readers in
+// the trace middleware.
+func ExtractBaggageFromRawJSON(m *RawJSON) Baggage {
+	meta, ok := m.Meta()
+	if !ok {
 		return ""
 	}
-	var envelope struct {
-		Meta map[string]any `json:"_meta"`
-	}
-	if err := json.Unmarshal(params, &envelope); err != nil {
+	var metaMap map[string]any
+	if err := meta.Bind(&metaMap); err != nil {
 		return ""
 	}
-	return ExtractBaggage(envelope.Meta)
+	return ExtractBaggage(metaMap)
 }
 
 // InjectBaggageIntoParams returns a params value with

--- a/core/rawjson.go
+++ b/core/rawjson.go
@@ -1,0 +1,121 @@
+package core
+
+import (
+	"encoding/json"
+	"sync"
+)
+
+// RawJSON wraps a JSON-RPC raw value (params, result, _meta, ...) with a
+// parse-once cache and typed helpers. It replaces bare json.RawMessage at read
+// sites so callers stop re-implementing json.Unmarshal plumbing and repeated
+// middleware reads share a single parse of the bytes (issue 733).
+//
+// It is wire-transparent: MarshalJSON returns exactly the bytes it holds and
+// UnmarshalJSON captures them, so RawJSON round-trips identically to
+// json.RawMessage and preserves the opaque-forwarding property the JSON-RPC
+// envelope relies on.
+//
+// Typed decode is the intended primary path:
+//
+//	var in MyInput
+//	req.Params.Bind(&in)          // whole value into a known shape (handler path)
+//	meta, ok := req.Params.Meta() // the _meta sub-object, parsed once
+//	meta.Bind(&myMeta)
+//
+// Field is a dynamic escape hatch for genuinely-dynamic keys (e.g. _meta
+// extension fields nobody has a struct for) — prefer a typed Bind where a
+// struct exists; string-keyed access trades away compile-time safety.
+//
+// The zero value is a usable empty/absent value. Construct from bytes with
+// NewRawJSON. The lazy spine is built on first Field/Meta call and cached;
+// reads on a single RawJSON are not yet safe for concurrent goroutines (the
+// dispatch/middleware chain reads sequentially per request) — that hardens
+// when Request.Params flips to RawJSON (issue 733 slice 3).
+type RawJSON struct {
+	raw  json.RawMessage
+	lazy *rawJSONLazy
+}
+
+type rawJSONLazy struct {
+	once  sync.Once
+	spine map[string]json.RawMessage
+	err   error
+}
+
+// NewRawJSON wraps raw bytes. The bytes are not copied; callers must not mutate
+// them afterward (same contract as json.RawMessage).
+func NewRawJSON(raw json.RawMessage) RawJSON {
+	return RawJSON{raw: raw, lazy: &rawJSONLazy{}}
+}
+
+// object parses and caches the top-level JSON object once. Returns a nil spine
+// (no error) for an absent value, and an error when the value is not a JSON
+// object — Field/Meta treat both as "no field".
+func (m *RawJSON) object() (map[string]json.RawMessage, error) {
+	if m.lazy == nil {
+		m.lazy = &rawJSONLazy{}
+	}
+	m.lazy.once.Do(func() {
+		if len(m.raw) == 0 {
+			return
+		}
+		m.lazy.err = json.Unmarshal(m.raw, &m.lazy.spine)
+	})
+	return m.lazy.spine, m.lazy.err
+}
+
+// Field returns the top-level value for key as a sub-RawJSON. ok is false when
+// key is absent or the value is not a JSON object. The top-level spine is
+// parsed once and cached, so a large sibling value (e.g. a multi-MB
+// `arguments`) is scanned only once and never generically materialized — only
+// the returned sub-value is parsed, and only if the caller reads it.
+func (m *RawJSON) Field(key string) (RawJSON, bool) {
+	obj, err := m.object()
+	if err != nil || obj == nil {
+		return RawJSON{}, false
+	}
+	v, ok := obj[key]
+	if !ok {
+		return RawJSON{}, false
+	}
+	return RawJSON{raw: v, lazy: &rawJSONLazy{}}, true
+}
+
+// Meta returns the `_meta` object as a sub-RawJSON — sugar for Field("_meta"),
+// the dominant metadata-reader pattern (SEP-414 / 2575 / 2243 / 2322).
+func (m *RawJSON) Meta() (RawJSON, bool) { return m.Field("_meta") }
+
+// Bind decodes the whole raw value into v — the typed / handler path. A nil or
+// empty value is a no-op that leaves v unchanged (an absent params does not
+// error).
+func (m RawJSON) Bind(v any) error {
+	if len(m.raw) == 0 {
+		return nil
+	}
+	return json.Unmarshal(m.raw, v)
+}
+
+// Raw returns the underlying bytes as a view — do NOT mutate. Empty (nil) for
+// an absent value.
+func (m RawJSON) Raw() json.RawMessage { return m.raw }
+
+// Len is the byte length of the raw value, O(1). Useful for a transport-level
+// max-size guard; not used for any internal branching.
+func (m RawJSON) Len() int { return len(m.raw) }
+
+// MarshalJSON returns the raw bytes verbatim (wire-transparent), "null" when
+// empty — matching json.RawMessage.
+func (m RawJSON) MarshalJSON() ([]byte, error) {
+	if len(m.raw) == 0 {
+		return []byte("null"), nil
+	}
+	return m.raw, nil
+}
+
+// UnmarshalJSON captures a copy of b (the json package may reuse the slice) and
+// resets the parse cache.
+func (m *RawJSON) UnmarshalJSON(b []byte) error {
+	m.raw = append(m.raw[:0], b...)
+	m.lazy = &rawJSONLazy{}
+	return nil
+}

--- a/core/rawjson_bench_test.go
+++ b/core/rawjson_bench_test.go
@@ -1,0 +1,48 @@
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// Issue 733 slice 1: the trace middleware reads three _meta fields per
+// tools/call (trace context, baggage, tracelink). These benchmarks compare the
+// old per-field parse (3 full scans of params) against the shared RawJSON (one
+// spine scan), across arguments payload sizes — the win grows with the blob
+// that sits next to _meta on the wire.
+//
+//	go test ./core/ -run '^$' -bench TraceExtract -benchmem
+
+func benchParams(argBytes int) json.RawMessage {
+	blob := strings.Repeat("x", argBytes)
+	return json.RawMessage(fmt.Sprintf(
+		`{"name":"echo","arguments":{"blob":%q},"_meta":{"traceparent":"00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"}}`,
+		blob))
+}
+
+func BenchmarkTraceExtract(b *testing.B) {
+	for _, sz := range []int{0, 1 << 10, 1 << 20} {
+		params := benchParams(sz)
+
+		b.Run(fmt.Sprintf("perField/args=%dKB", sz>>10), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_ = ExtractTraceContextFromParams(params)
+				_ = ExtractBaggageFromParams(params)
+				_ = ExtractTraceLinkFromParams(params)
+			}
+		})
+
+		b.Run(fmt.Sprintf("sharedRawJSON/args=%dKB", sz>>10), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				m := NewRawJSON(params)
+				_ = ExtractTraceContextFromRawJSON(&m)
+				_ = ExtractBaggageFromRawJSON(&m)
+				_ = ExtractTraceLinkFromRawJSON(&m)
+			}
+		})
+	}
+}

--- a/core/rawjson_test.go
+++ b/core/rawjson_test.go
@@ -1,0 +1,110 @@
+package core
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestRawJSON_FieldAndMeta(t *testing.T) {
+	m := NewRawJSON([]byte(`{"name":"greet","arguments":{"x":1},"_meta":{"traceparent":"tp"}}`))
+
+	name, ok := m.Field("name")
+	if !ok {
+		t.Fatal("name field missing")
+	}
+	var s string
+	if err := name.Bind(&s); err != nil || s != "greet" {
+		t.Errorf("name = %q err=%v, want greet", s, err)
+	}
+
+	meta, ok := m.Meta()
+	if !ok {
+		t.Fatal("_meta missing")
+	}
+	tp, ok := meta.Field("traceparent")
+	if !ok {
+		t.Fatal("traceparent missing in _meta")
+	}
+	var tps string
+	tp.Bind(&tps)
+	if tps != "tp" {
+		t.Errorf("traceparent = %q, want tp", tps)
+	}
+
+	if _, ok := m.Field("absent"); ok {
+		t.Error("absent field should report ok=false")
+	}
+}
+
+func TestRawJSON_AbsentAndNonObject(t *testing.T) {
+	// Absent value: Meta/Field false, Bind no-op.
+	var empty RawJSON
+	if _, ok := empty.Meta(); ok {
+		t.Error("zero-value Meta should be false")
+	}
+	var v map[string]any
+	if err := empty.Bind(&v); err != nil {
+		t.Errorf("Bind on empty should be a no-op, got %v", err)
+	}
+	if v != nil {
+		t.Errorf("Bind on empty should leave v unchanged, got %v", v)
+	}
+
+	// Non-object raw: Field/Meta false (not a hard error).
+	arr := NewRawJSON([]byte(`[1,2,3]`))
+	if _, ok := arr.Meta(); ok {
+		t.Error("Meta on a JSON array should be false")
+	}
+	if _, ok := arr.Field("x"); ok {
+		t.Error("Field on a JSON array should be false")
+	}
+	// ...but Bind into the right shape still works.
+	var nums []int
+	if err := arr.Bind(&nums); err != nil || len(nums) != 3 {
+		t.Errorf("Bind array = %v err=%v", nums, err)
+	}
+}
+
+func TestRawJSON_WireTransparent(t *testing.T) {
+	// Marshalling a struct that embeds RawJSON must produce byte-identical
+	// output to json.RawMessage, and unmarshalling captures verbatim.
+	type env struct {
+		Params RawJSON `json:"params"`
+	}
+	in := []byte(`{"params":{"name":"x","_meta":{"a":1}}}`)
+	var e env
+	if err := json.Unmarshal(in, &e); err != nil {
+		t.Fatal(err)
+	}
+	out, err := json.Marshal(e)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != string(in) {
+		t.Errorf("round-trip changed bytes:\n in=%s\nout=%s", in, out)
+	}
+
+	// Absent params marshals to null, matching json.RawMessage.
+	out, _ = json.Marshal(env{})
+	if string(out) != `{"params":null}` {
+		t.Errorf("empty RawJSON marshaled to %s, want {\"params\":null}", out)
+	}
+}
+
+func TestRawJSON_ParsesSpineOnce(t *testing.T) {
+	// Two Field reads must not re-parse the top level — assert by mutating the
+	// raw out from under it after the first read; the cached spine wins.
+	m := NewRawJSON([]byte(`{"a":"1","b":"2"}`))
+	a, _ := m.Field("a")
+	m.raw = []byte(`{"a":"changed"}`) // simulate a re-parse would see different bytes
+	b, ok := m.Field("b")             // must still resolve from the cached spine
+	if !ok {
+		t.Fatal("b should still be found in the cached spine after raw mutation")
+	}
+	var av, bv string
+	a.Bind(&av)
+	b.Bind(&bv)
+	if av != "1" || bv != "2" {
+		t.Errorf("cached spine not used: a=%q b=%q, want 1/2", av, bv)
+	}
+}

--- a/core/trace.go
+++ b/core/trace.go
@@ -339,16 +339,25 @@ func InjectTraceContext(meta map[string]any, tc TraceContext) {
 // (tools/call's `name`/`arguments`, prompts/get's `name`, ...) — all of
 // them carry the same `_meta` shape per the MCP spec.
 func ExtractTraceContextFromParams(params json.RawMessage) TraceContext {
-	if len(params) == 0 {
+	m := NewRawJSON(params)
+	return ExtractTraceContextFromRawJSON(&m)
+}
+
+// ExtractTraceContextFromRawJSON is the RawJSON form of
+// ExtractTraceContextFromParams (issue 733). It reads `_meta.traceparent` /
+// `tracestate` through the message's parse-once spine, so a middleware that
+// also reads other `_meta` fields (baggage, tracelink) shares a single parse
+// of params instead of decoding the whole envelope again per field.
+func ExtractTraceContextFromRawJSON(m *RawJSON) TraceContext {
+	meta, ok := m.Meta()
+	if !ok {
 		return TraceContext{}
 	}
-	var envelope struct {
-		Meta map[string]any `json:"_meta"`
-	}
-	if err := json.Unmarshal(params, &envelope); err != nil {
+	var metaMap map[string]any
+	if err := meta.Bind(&metaMap); err != nil {
 		return TraceContext{}
 	}
-	return ExtractTraceContext(envelope.Meta)
+	return ExtractTraceContext(metaMap)
 }
 
 // InjectTraceContextIntoParams returns a params value with `_meta.traceparent`
@@ -425,19 +434,24 @@ func InjectTraceContextIntoParams(params any, tc TraceContext) any {
 //
 // Defensive: never panics on malformed input.
 func ExtractTraceLinkFromParams(params json.RawMessage) TraceContext {
-	if len(params) == 0 {
+	m := NewRawJSON(params)
+	return ExtractTraceLinkFromRawJSON(&m)
+}
+
+// ExtractTraceLinkFromRawJSON is the RawJSON form of ExtractTraceLinkFromParams
+// (issue 733) — reads `_meta.io.modelcontextprotocol/tracelink` through the
+// message's parse-once spine, sharing the parse with the other `_meta` readers
+// in the trace middleware.
+func ExtractTraceLinkFromRawJSON(m *RawJSON) TraceContext {
+	meta, ok := m.Meta()
+	if !ok {
 		return TraceContext{}
 	}
-	var envelope struct {
-		Meta map[string]any `json:"_meta"`
-	}
-	if err := json.Unmarshal(params, &envelope); err != nil {
+	var metaMap map[string]any
+	if err := meta.Bind(&metaMap); err != nil {
 		return TraceContext{}
 	}
-	if envelope.Meta == nil {
-		return TraceContext{}
-	}
-	tp, _ := envelope.Meta[MetaKeyTraceLink].(string)
+	tp, _ := metaMap[MetaKeyTraceLink].(string)
 	if !isValidTraceparent(tp) {
 		return TraceContext{}
 	}

--- a/server/decode_bench_test.go
+++ b/server/decode_bench_test.go
@@ -1,0 +1,80 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	core "github.com/panyam/mcpkit/core"
+)
+
+// Issue 489: quantify how much of a tools/call dispatch is re-scanning
+// req.Params. These benchmarks measure the dispatcher path (handleToolsCall +
+// schema validation) across arguments payload sizes, plus the cost of a single
+// peek-decode of the same params as the per-scan unit. Run:
+//
+//	go test ./server/ -run '^$' -bench 'ToolsCallDispatch|SinglePeekDecode' -benchmem
+
+func benchToolsParams(argBytes int) json.RawMessage {
+	blob := strings.Repeat("x", argBytes)
+	return json.RawMessage(fmt.Sprintf(
+		`{"name":"echo","arguments":{"blob":%q},"_meta":{"io.modelcontextprotocol/protocolVersion":"2025-11-25"}}`,
+		blob))
+}
+
+func benchDispatcher(tb testing.TB, schema bool) *Dispatcher {
+	tb.Helper()
+	d := NewDispatcher(core.ServerInfo{Name: "b", Version: "1"})
+	def := core.ToolDef{Name: "echo", Description: "echo"}
+	if schema {
+		def.InputSchema = map[string]any{"type": "object"}
+	}
+	d.RegisterTool(def, func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+		return core.TextResult("ok"), nil
+	})
+	if !schema {
+		d.skipSchemaValidation = true
+	}
+	initDispatcher(d)
+	return d
+}
+
+var benchSizes = []int{0, 1 << 10, 64 << 10, 1 << 20} // 0, 1KB, 64KB, 1MB
+
+func BenchmarkToolsCallDispatch(b *testing.B) {
+	for _, schema := range []bool{false, true} {
+		for _, sz := range benchSizes {
+			name := fmt.Sprintf("schema=%v/args=%dKB", schema, sz>>10)
+			b.Run(name, func(b *testing.B) {
+				d := benchDispatcher(b, schema)
+				req := &core.Request{JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "tools/call", Params: benchToolsParams(sz)}
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					_ = d.Dispatch(context.Background(), req)
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkSinglePeekDecode is the per-scan unit: one json.Unmarshal of the
+// same params into a peek struct (what each middleware site does). Dividing a
+// dispatch's cost delta by this gives the effective re-scan count.
+func BenchmarkSinglePeekDecode(b *testing.B) {
+	for _, sz := range benchSizes {
+		b.Run(fmt.Sprintf("args=%dKB", sz>>10), func(b *testing.B) {
+			params := benchToolsParams(sz)
+			var p struct {
+				Name string `json:"name"`
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = json.Unmarshal(params, &p)
+			}
+		})
+	}
+}

--- a/server/trace_middleware.go
+++ b/server/trace_middleware.go
@@ -151,7 +151,13 @@ func WithTracerProvider(tp core.TracerProvider) Option {
 // non-Noop provider.
 func traceMiddleware(tp core.TracerProvider) Middleware {
 	return func(ctx context.Context, req *core.Request, next MiddlewareFunc) (*core.Response, error) {
-		tc := core.ExtractTraceContextFromParams(req.Params)
+		// One RawJSON over req.Params, shared across every _meta reader below
+		// (trace context, baggage, tracelink). The top-level spine is parsed
+		// once — a large `arguments` sibling is scanned once, not once per
+		// reader (issue 733).
+		params := core.NewRawJSON(req.Params)
+
+		tc := core.ExtractTraceContextFromRawJSON(&params)
 		if tc.IsZero() {
 			tc = core.TraceContextFromContext(ctx)
 		}
@@ -163,7 +169,7 @@ func traceMiddleware(tp core.TracerProvider) Middleware {
 		// two are independent W3C standards (SEP-2028 § Predefined
 		// Groups), so an absent baggage value does not affect the
 		// trace context resolution.
-		bg := core.ExtractBaggageFromParams(req.Params)
+		bg := core.ExtractBaggageFromRawJSON(&params)
 		if bg.IsZero() {
 			bg = core.BaggageFromContext(ctx)
 		}
@@ -220,7 +226,7 @@ func traceMiddleware(tp core.TracerProvider) Middleware {
 		// stitching the logical operation across separate W3C traces.
 		// Zero / malformed tracelink is silently dropped — AddLink on
 		// the noop / invalid path is a no-op (CAS-guarded wrapper).
-		if linkTC := core.ExtractTraceLinkFromParams(req.Params); !linkTC.IsZero() {
+		if linkTC := core.ExtractTraceLinkFromRawJSON(&params); !linkTC.IsZero() {
 			span.AddLink(core.LinkFromTraceContext(linkTC))
 		}
 


### PR DESCRIPTION
First slice of issue 733 (the `RawJSON` umbrella). Introduces the primitive and proves the win on the trace middleware; **additive, no wire change, no behavior change** — the breaking `Request.Params` flip is a later slice.

## What changes

`core.RawJSON` — a wire-transparent, parse-once wrapper over a JSON-RPC raw value (`params`, `_meta`, …) with typed helpers. Middleware that reads several `_meta` fields off the same `params` now shares **one** parse instead of decoding the whole envelope per field.

The concrete site: `server.traceMiddleware` read `req.Params` for `_meta` **three times** per `tools/call` — trace context, baggage, tracelink. It now builds one `RawJSON` and shares it.

## Before / after (benchmark — `BenchmarkTraceExtract`)

3 per-field parses → 1 shared spine, across `arguments` payload sizes:

| args | per-field (before) | shared `RawJSON` (after) | speedup |
|---|---|---|---|
| 0 KB  | 6.5 µs / 4.5 KB / 81 allocs | 3.7 µs / 2.8 KB / 49 allocs | 1.7× |
| 1 KB  | 21.4 µs / 7.9 KB | 8.7 µs / 4.0 KB | 2.5× |
| 1 MB  | **15.1 ms / 3.17 MB** | **5.1 ms / 1.06 MB** | **2.9×, ~3× less alloc** |

The win grows with the blob sitting next to `_meta`: each old parse scans the whole `arguments`; the shared spine scans it once. Faster even on tiny `_meta` (the shared spine avoids re-decoding `_meta` into a fresh map three times).

```mermaid
flowchart LR
  subgraph Before
    P[req.Params] --> A[ExtractTraceContextFromParams<br/>parse #1]
    P --> B[ExtractBaggageFromParams<br/>parse #2]
    P --> C[ExtractTraceLinkFromParams<br/>parse #3]
  end
  subgraph After
    P2[req.Params] --> RJ[NewRawJSON<br/>spine parsed once]
    RJ --> A2[...FromRawJSON]
    RJ --> B2[...FromRawJSON]
    RJ --> C2[...FromRawJSON]
  end
```

## Reviewer's guide

1. [core/rawjson.go](https://github.com/panyam/mcpkit/pull/868/files#diff-e9e6118a172aee7cb2583cce6f5baa0bb34bfd27cbab66ceb4fa116fad46de3e) — the whole primitive. `RawJSON{ raw, lazy }`; `object()` parses the top-level spine once (`map[string]json.RawMessage`, **not** `map[string]any` — a generic parse would materialize a multi-MB `arguments`; see the issue-489 measurement in the #733 thread). `Field`/`Meta` (cached spine), `Bind` (typed, the primary path), `MarshalJSON`/`UnmarshalJSON` (wire-transparent). Start here.
2. [core/rawjson_test.go](https://github.com/panyam/mcpkit/pull/868/files#diff-1a6f66b43bbc750b2fade4c0d54644bc7c1e5c738bc2380b7f585a0f2454d777) — semantics: Field/Meta/Bind, absent + non-object (→ `ok=false`, not a hard error), wire round-trip byte-identical, parse-once (cache used after the raw is mutated out from under it).
3. [core/trace.go](https://github.com/panyam/mcpkit/pull/868/files#diff-acb99666fd2aacc85eaf8e433236a74d28959ca5e1e0d5e14913cdd5fb9e81c0) + [core/baggage.go](https://github.com/panyam/mcpkit/pull/868/files#diff-ae3835c16b19548cf369505dbde6e6220c34a246ead6683ab7ff14adddd4715a) — the `*FromRawJSON` siblings; the existing `*FromParams` are kept and routed through a fresh `RawJSON` (back-compat, identical semantics).
4. [server/trace_middleware.go](https://github.com/panyam/mcpkit/pull/868/files#diff-7e0ee26d4d523ebdecda4da033cb2f40c364eb05edb5f41b1d90d76fd374546e) — the payoff: one `params := core.NewRawJSON(req.Params)` shared across the three `_meta` reads.
5. Benchmarks: [core/rawjson_bench_test.go](https://github.com/panyam/mcpkit/pull/868/files#diff-61388574fd9644b1ef50312151ba276721c4bce056a494ed60c11f422f620181) (the before/after above) and [server/decode_bench_test.go](https://github.com/panyam/mcpkit/pull/868/files#diff-2786e1f35132e21c311afcafeb0ab6f23ac78b2940b7568ac81df9697601ae62) (the dispatch-path baseline from the issue-489 measurement).

## Decision log

- **`map[string]json.RawMessage` spine, not `map[string]any`.** A generic parse of a params with a multi-MB `arguments` would allocate megabytes and regress the current 240 B peek path; the raw-message spine keeps sub-values raw (measured — #733 thread).
- **Typed `Bind` is the primary API; `Field` is the escape hatch.** Kept the surface small and typed-first so this doesn't drift into stringly-typed dict navigation.
- **Kept `*FromParams`.** Existing callers (`ext/ui`, client trace middleware) are unchanged; they route through `RawJSON` internally so there's one implementation.

## Risk / blast radius

- **Additive.** No public signature removed; no wire bytes changed (`RawJSON` round-trips identically to `json.RawMessage` — test asserts byte-equality). `Request.Params` is still `json.RawMessage`.
- **Semantics parity** for the three converted readers: nil/absent → zero, non-object → zero, missing `_meta` → zero (matched the old `json.Unmarshal(&{Meta})` outcomes; covered by existing trace/baggage tests, all green).
- Pressure-test: concurrency. A single `RawJSON`'s lazy spine isn't goroutine-safe yet; today the middleware/dispatch chain reads `params` sequentially per request, so this is fine — it hardens when `Request.Params` flips to `RawJSON` (slice 3), called out in the type's doc.

## Out of scope (later slices)

- Migrate the remaining `_meta` readers (SEP-2575 client caps, SEP-2243 routing, SEP-2322 requestState) to `msg.Meta().Bind` — slice 2.
- Flip `core.Request.Params` (and likely `Result`) to `RawJSON` — the breaking change, slice 3, at the 0.4.0 boundary.
- Zero-copy sub-slice views (avoid the ~60 µs/MB copy) — later internal swap behind the same API.

