### PR TITLE
core: spine-free RawJSON.Meta + Request.ParamsLazy, share the SEP-2575 _meta gate (issue 733 slice 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,13 @@ targeted spec version.
   trace middleware now shares one parse across its `_meta` readers (trace
   context / baggage / tracelink) — ~3× faster + ~3× less alloc on large
   `tools/call` payloads. The `Request.Params` type flip is a later slice.
+- **`core.Request.ParamsLazy()`** — a per-request cached `RawJSON` so every
+  metadata reader on one request shares a single parse (issue 733 slice 2).
+  `RawJSON.Meta()` now extracts only the `_meta` bytes (never copies a large
+  `arguments` sibling), and the SEP-2575 `_meta` gate + trace middleware read
+  through the shared cache: metadata-only decode stays flat-allocation
+  regardless of payload size, and trace + gate together scan params once (2×
+  faster at 1 MB). Additive — `Params` is still `json.RawMessage`.
 - **Panic recovery in library goroutines** — a panic in a tool/background
   goroutine is recovered and surfaced as an error instead of crashing the host
   process. (issue 420)

--- a/core/jsonrpc.go
+++ b/core/jsonrpc.go
@@ -13,6 +13,26 @@ type Request struct {
 	ID      json.RawMessage `json:"id"`
 	Method  string          `json:"method"`
 	Params  json.RawMessage `json:"params,omitempty"`
+
+	// paramsLazy caches the RawJSON view of Params so every reader on the same
+	// *Request shares one parse (issue 733). Unexported — ignored on the wire.
+	paramsLazy *RawJSON
+}
+
+// ParamsLazy returns a RawJSON view of Params, cached on the request. Every
+// caller on the same *Request shares the cache, so a dispatch path that reads
+// the metadata from several places (trace middleware, the SEP-2575 _meta gate,
+// routing-header validation) scans Params once instead of once per reader.
+//
+// Additive bridge ahead of the Params type flip (issue 733 slice 3): Params
+// stays json.RawMessage. Not safe for concurrent first-callers on one *Request;
+// the dispatch/middleware chain reads sequentially per request.
+func (r *Request) ParamsLazy() *RawJSON {
+	if r.paramsLazy == nil {
+		rj := NewRawJSON(r.Params)
+		r.paramsLazy = &rj
+	}
+	return r.paramsLazy
 }
 
 // Response is a JSON-RPC 2.0 response.

--- a/core/paramslazy_test.go
+++ b/core/paramslazy_test.go
@@ -1,0 +1,107 @@
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestRequest_ParamsLazy_SharesCache(t *testing.T) {
+	req := &Request{Params: json.RawMessage(`{"name":"x","_meta":{"a":1}}`)}
+	a := req.ParamsLazy()
+	b := req.ParamsLazy()
+	if a != b {
+		t.Fatal("ParamsLazy should return the same cached *RawJSON")
+	}
+	// Both readers see _meta through the one shared, cached extraction.
+	m1, ok1 := a.Meta()
+	m2, ok2 := b.Meta()
+	if !ok1 || !ok2 {
+		t.Fatal("_meta should resolve via the shared cache")
+	}
+	var v1, v2 map[string]any
+	m1.Bind(&v1)
+	m2.Bind(&v2)
+	if fmt.Sprint(v1) != fmt.Sprint(v2) {
+		t.Errorf("shared _meta mismatch: %v vs %v", v1, v2)
+	}
+}
+
+// TestRawJSON_MetaIsSpineFree asserts Meta resolves the _meta object without
+// depending on the top-level spine (Field) — the whole point of the slice-2
+// refinement is that a metadata-only reader never materializes a large
+// `arguments` sibling.
+func TestRawJSON_MetaIsSpineFree(t *testing.T) {
+	m := NewRawJSON([]byte(`{"arguments":{"blob":"xxxx"},"_meta":{"protocolVersion":"2025-11-25"}}`))
+	meta, ok := m.Meta()
+	if !ok {
+		t.Fatal("_meta missing")
+	}
+	var mm map[string]any
+	if err := meta.Bind(&mm); err != nil || mm["protocolVersion"] != "2025-11-25" {
+		t.Errorf("meta = %v err=%v", mm, err)
+	}
+	// The spine (lazy.spine) must NOT have been built by a Meta-only access.
+	if m.lazy != nil && m.lazy.spine != nil {
+		t.Error("Meta() built the spine; it should extract only _meta")
+	}
+}
+
+func TestRawJSON_MetaAbsentNullNonObject(t *testing.T) {
+	cases := map[string]string{
+		"absent":     `{"name":"x"}`,
+		"null":       `{"_meta":null}`,
+		"non-object": `[1,2,3]`,
+	}
+	for name, raw := range cases {
+		t.Run(name, func(t *testing.T) {
+			m := NewRawJSON([]byte(raw))
+			if _, ok := m.Meta(); ok {
+				t.Errorf("%s: Meta should report ok=false", name)
+			}
+		})
+	}
+}
+
+// BenchmarkDecodeRequestMeta shows the SEP-2575 _meta decode stays allocation-
+// light even with a large `arguments` sibling — proof Meta does not copy the
+// blob (a spine-based Meta would allocate ~len(arguments) here).
+func BenchmarkDecodeRequestMeta(b *testing.B) {
+	meta := `"_meta":{"io.modelcontextprotocol/protocolVersion":"2025-11-25","io.modelcontextprotocol/clientInfo":{"name":"c","version":"1"},"io.modelcontextprotocol/clientCapabilities":{}}`
+	for _, sz := range []int{0, 1 << 20} {
+		blob := strings.Repeat("x", sz)
+		params := json.RawMessage(fmt.Sprintf(`{"name":"echo","arguments":{"blob":%q},%s}`, blob, meta))
+		b.Run(fmt.Sprintf("args=%dKB", sz>>10), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				m := NewRawJSON(params)
+				_, _ = DecodeRequestMetaFromRawJSON(&m)
+			}
+		})
+	}
+}
+
+// BenchmarkSharedMetaReaders compares two readers (trace context + SEP-2575
+// gate) sharing one req.ParamsLazy() parse vs each scanning params itself.
+func BenchmarkSharedMetaReaders(b *testing.B) {
+	meta := `"_meta":{"traceparent":"00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01","io.modelcontextprotocol/protocolVersion":"2025-11-25","io.modelcontextprotocol/clientInfo":{"name":"c","version":"1"},"io.modelcontextprotocol/clientCapabilities":{}}`
+	blob := strings.Repeat("x", 1<<20)
+	params := json.RawMessage(fmt.Sprintf(`{"name":"echo","arguments":{"blob":%q},%s}`, blob, meta))
+
+	b.Run("unshared", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = ExtractTraceContextFromParams(params)
+			_, _ = DecodeRequestMeta(params)
+		}
+	})
+	b.Run("sharedParamsLazy", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			req := &Request{Params: params}
+			_ = ExtractTraceContextFromRawJSON(req.ParamsLazy())
+			_, _ = DecodeRequestMetaFromRawJSON(req.ParamsLazy())
+		}
+	})
+}

--- a/core/rawjson.go
+++ b/core/rawjson.go
@@ -40,6 +40,20 @@ type rawJSONLazy struct {
 	once  sync.Once
 	spine map[string]json.RawMessage
 	err   error
+
+	// _meta is cached separately from the spine: Meta extracts only the
+	// _meta bytes so it never copies a large sibling `arguments` value, which
+	// the spine (map[string]json.RawMessage) would. See Meta.
+	metaOnce sync.Once
+	meta     RawJSON
+	metaOK   bool
+}
+
+func (m *RawJSON) ensureLazy() *rawJSONLazy {
+	if m.lazy == nil {
+		m.lazy = &rawJSONLazy{}
+	}
+	return m.lazy
 }
 
 // NewRawJSON wraps raw bytes. The bytes are not copied; callers must not mutate
@@ -52,16 +66,14 @@ func NewRawJSON(raw json.RawMessage) RawJSON {
 // (no error) for an absent value, and an error when the value is not a JSON
 // object — Field/Meta treat both as "no field".
 func (m *RawJSON) object() (map[string]json.RawMessage, error) {
-	if m.lazy == nil {
-		m.lazy = &rawJSONLazy{}
-	}
-	m.lazy.once.Do(func() {
+	lz := m.ensureLazy()
+	lz.once.Do(func() {
 		if len(m.raw) == 0 {
 			return
 		}
-		m.lazy.err = json.Unmarshal(m.raw, &m.lazy.spine)
+		lz.err = json.Unmarshal(m.raw, &lz.spine)
 	})
-	return m.lazy.spine, m.lazy.err
+	return lz.spine, lz.err
 }
 
 // Field returns the top-level value for key as a sub-RawJSON. ok is false when
@@ -81,9 +93,37 @@ func (m *RawJSON) Field(key string) (RawJSON, bool) {
 	return RawJSON{raw: v, lazy: &rawJSONLazy{}}, true
 }
 
-// Meta returns the `_meta` object as a sub-RawJSON — sugar for Field("_meta"),
-// the dominant metadata-reader pattern (SEP-414 / 2575 / 2243 / 2322).
-func (m *RawJSON) Meta() (RawJSON, bool) { return m.Field("_meta") }
+// Meta returns the `_meta` object as a sub-RawJSON, ok=false when absent, null,
+// or non-object — the dominant metadata-reader pattern (SEP-414 / 2575 / 2243 /
+// 2322).
+//
+// Unlike Field, Meta does NOT build the full spine: it extracts only the
+// `_meta` bytes via a targeted probe, so it scans the value once but never
+// copies a large sibling `arguments` blob (which the spine's
+// map[string]json.RawMessage would). The result is cached, so many readers on
+// one message share a single scan. This keeps the common metadata-only path —
+// including the SEP-2575 stateless gate that runs on every request — as cheap
+// as a hand-rolled `_meta` probe, plus caching.
+func (m *RawJSON) Meta() (RawJSON, bool) {
+	lz := m.ensureLazy()
+	lz.metaOnce.Do(func() {
+		if len(m.raw) == 0 {
+			return
+		}
+		var probe struct {
+			Meta json.RawMessage `json:"_meta"`
+		}
+		if err := json.Unmarshal(m.raw, &probe); err != nil {
+			return
+		}
+		if len(probe.Meta) == 0 || string(probe.Meta) == "null" {
+			return
+		}
+		lz.meta = NewRawJSON(probe.Meta)
+		lz.metaOK = true
+	})
+	return lz.meta, lz.metaOK
+}
 
 // Bind decodes the whole raw value into v — the typed / handler path. A nil or
 // empty value is a no-op that leaves v unchanged (an absent params does not

--- a/core/stateless.go
+++ b/core/stateless.go
@@ -86,32 +86,35 @@ func (e *MetaValidationError) Error() string {
 // An absent params (empty raw) is treated as "missing _meta" — the wire
 // requires _meta on every stateless request.
 func DecodeRequestMeta(rawParams json.RawMessage) (*RequestMeta, error) {
-	if len(rawParams) == 0 {
+	m := NewRawJSON(rawParams)
+	return DecodeRequestMetaFromRawJSON(&m)
+}
+
+// DecodeRequestMetaFromRawJSON is the RawJSON form of DecodeRequestMeta
+// (issue 733). It reads the SEP-2575 per-request `_meta` envelope through the
+// message's cached, spine-free Meta() — so on a request whose metadata is also
+// read elsewhere (trace middleware) the params are scanned once, and a large
+// `arguments` sibling is never copied. Prefer this via req.ParamsLazy() on the
+// dispatch path.
+func DecodeRequestMetaFromRawJSON(m *RawJSON) (*RequestMeta, error) {
+	meta, ok := m.Meta()
+	if !ok {
 		return nil, &MetaValidationError{Field: "_meta"}
 	}
-	var probe struct {
-		Meta json.RawMessage `json:"_meta"`
-	}
-	if err := json.Unmarshal(rawParams, &probe); err != nil {
+	var rm RequestMeta
+	if err := meta.Bind(&rm); err != nil {
 		return nil, &MetaValidationError{Field: "_meta"}
 	}
-	if len(probe.Meta) == 0 || string(probe.Meta) == "null" {
-		return nil, &MetaValidationError{Field: "_meta"}
-	}
-	var meta RequestMeta
-	if err := json.Unmarshal(probe.Meta, &meta); err != nil {
-		return nil, &MetaValidationError{Field: "_meta"}
-	}
-	if meta.ProtocolVersion == "" {
+	if rm.ProtocolVersion == "" {
 		return nil, &MetaValidationError{Field: "protocolVersion"}
 	}
-	if meta.ClientInfo == nil {
+	if rm.ClientInfo == nil {
 		return nil, &MetaValidationError{Field: "clientInfo"}
 	}
-	if meta.ClientCapabilities == nil {
+	if rm.ClientCapabilities == nil {
 		return nil, &MetaValidationError{Field: "clientCapabilities"}
 	}
-	return &meta, nil
+	return &rm, nil
 }
 
 // UnsupportedProtocolVersionData is the structured error payload returned

--- a/server/dispatch.go
+++ b/server/dispatch.go
@@ -413,7 +413,7 @@ func (d *Dispatcher) Dispatch(ctx context.Context, req *core.Request) (resp *cor
 		// The version gate is resolved via protocol_features.go so all
 		// version-gated behavior lives in one table.
 		if d.protocolFeatures().StatelessMetaRequired && !d.allowLegacyOnDraft {
-			if _, err := core.DecodeRequestMeta(req.Params); err != nil {
+			if _, err := core.DecodeRequestMetaFromRawJSON(req.ParamsLazy()); err != nil {
 				field := "io.modelcontextprotocol/protocolVersion"
 				if mve, ok := err.(*core.MetaValidationError); ok && mve.Field != "_meta" {
 					field = "io.modelcontextprotocol/" + mve.Field

--- a/server/stateless/dispatch.go
+++ b/server/stateless/dispatch.go
@@ -78,7 +78,7 @@ func (d *Dispatcher) Dispatch(ctx context.Context, req *core.Request) (*core.Res
 	}
 
 	// Every other method requires a valid _meta envelope.
-	meta, err := core.DecodeRequestMeta(req.Params)
+	meta, err := core.DecodeRequestMetaFromRawJSON(req.ParamsLazy())
 	if err != nil {
 		// MetaValidationError carries the specific missing field for diagnostics.
 		return core.NewErrorResponse(id, core.ErrCodeInvalidParams, err.Error()), nil

--- a/server/trace_middleware.go
+++ b/server/trace_middleware.go
@@ -151,13 +151,12 @@ func WithTracerProvider(tp core.TracerProvider) Option {
 // non-Noop provider.
 func traceMiddleware(tp core.TracerProvider) Middleware {
 	return func(ctx context.Context, req *core.Request, next MiddlewareFunc) (*core.Response, error) {
-		// One RawJSON over req.Params, shared across every _meta reader below
-		// (trace context, baggage, tracelink). The top-level spine is parsed
-		// once — a large `arguments` sibling is scanned once, not once per
-		// reader (issue 733).
-		params := core.NewRawJSON(req.Params)
+		// Shared per-request RawJSON: every _meta reader below (trace context,
+		// baggage, tracelink) and the dispatch-path SEP-2575 gate scan Params
+		// once via req.ParamsLazy() instead of once per reader (issue 733).
+		params := req.ParamsLazy()
 
-		tc := core.ExtractTraceContextFromRawJSON(&params)
+		tc := core.ExtractTraceContextFromRawJSON(params)
 		if tc.IsZero() {
 			tc = core.TraceContextFromContext(ctx)
 		}
@@ -169,7 +168,7 @@ func traceMiddleware(tp core.TracerProvider) Middleware {
 		// two are independent W3C standards (SEP-2028 § Predefined
 		// Groups), so an absent baggage value does not affect the
 		// trace context resolution.
-		bg := core.ExtractBaggageFromRawJSON(&params)
+		bg := core.ExtractBaggageFromRawJSON(params)
 		if bg.IsZero() {
 			bg = core.BaggageFromContext(ctx)
 		}
@@ -226,7 +225,7 @@ func traceMiddleware(tp core.TracerProvider) Middleware {
 		// stitching the logical operation across separate W3C traces.
 		// Zero / malformed tracelink is silently dropped — AddLink on
 		// the noop / invalid path is a no-op (CAS-guarded wrapper).
-		if linkTC := core.ExtractTraceLinkFromRawJSON(&params); !linkTC.IsZero() {
+		if linkTC := core.ExtractTraceLinkFromRawJSON(params); !linkTC.IsZero() {
 			span.AddLink(core.LinkFromTraceContext(linkTC))
 		}
 


### PR DESCRIPTION
Slice 2 of issue 733, on top of slice 1 (#868, merged). **Still additive** — `Request.Params` stays `json.RawMessage`; no wire change, no behavior change. Extends the shared-parse from the trace middleware to the whole dispatch-path metadata surface.

## What changes

Two moves, one of which fixes a real trap slice 1 didn't hit:

1. **`RawJSON.Meta()` is now spine-free.** Slice 1's `Meta()` went through the full spine (`map[string]json.RawMessage`), which copies *every* top-level value — including a multi-MB `arguments`. That's fine when several readers amortize it (the trace path), but it would **regress the single-`_meta`-reader hot path** (the SEP-2575 stateless gate with tracing off — the common production case) by copying `arguments` for nothing. `Meta()` now extracts *only* the `_meta` bytes via a targeted probe, cached — so a metadata-only read scans once and never materializes the blob.
2. **`Request.ParamsLazy()`** caches a `RawJSON` on the request, so every metadata reader on one `*Request` shares a single parse. The SEP-2575 `_meta` gate (legacy + stateless dispatch) and the trace middleware now read through it.

## Before / after (benchmarks)

**No single-reader regression** — `DecodeRequestMeta` allocation is flat regardless of `arguments` size (a spine-based `Meta` would allocate ~`len(arguments)`):

| `arguments` | B/op | allocs/op |
|---|---|---|
| 0 KB  | 1064 B | 20 |
| 1 MB  | **1064 B** | 20 |

**Shared win** — trace context + SEP-2575 gate, `1 MB` arguments:

| | ns/op | B/op |
|---|---|---|
| unshared (2 scans) | 6.79 ms | 3144 B |
| `req.ParamsLazy()` (1 scan) | **3.40 ms** | 2448 B |

```mermaid
flowchart LR
  subgraph Before
    R[req.Params] --> T[trace middleware<br/>scan #1]
    R --> G[SEP-2575 _meta gate<br/>scan #2]
  end
  subgraph After
    R2[req.Params] --> PL[req.ParamsLazy<br/>scanned once, _meta cached]
    PL --> T2[trace middleware]
    PL --> G2[SEP-2575 gate]
  end
```

## Reviewer's guide

1. [core/rawjson.go](https://github.com/panyam/mcpkit/pull/869/files#diff-e9e6118a172aee7cb2583cce6f5baa0bb34bfd27cbab66ceb4fa116fad46de3e) — `Meta()` rewritten to a targeted `_meta` probe cached in `rawJSONLazy.meta` (separate from the `Field` spine); `ensureLazy` extracted. `Field(other)` still uses the spine — you only pay the copy if you read a non-`_meta` top-level value. Start here.
2. [core/jsonrpc.go](https://github.com/panyam/mcpkit/pull/869/files#diff-f9f4f09be0f88717867046128a5e4338f60aaea6764fda9b9a6c95c4089797f4) — `Request.paramsLazy` (unexported, wire-ignored) + `ParamsLazy()`. It's a pointer-behind-pointer, so `Request` stays copy-safe (no `copylocks`; `go vet` clean).
3. [core/stateless.go](https://github.com/panyam/mcpkit/pull/869/files#diff-9a68784d645de8b02f898afae78118cfc63d9fe94dc4fc920c564a7cf3127fac) — `DecodeRequestMetaFromRawJSON`; `DecodeRequestMeta` routes through it (identical validation + error fields).
4. [server/dispatch.go](https://github.com/panyam/mcpkit/pull/869/files#diff-7640bcbef23148a16e477c63c7092f0ba89780f5278a9d6ba6ed513d62f68a92), [server/stateless/dispatch.go](https://github.com/panyam/mcpkit/pull/869/files#diff-1b101922de172cda20b6a044eae5a4fc36b2dce82e136a566765bae575a42b20), [server/trace_middleware.go](https://github.com/panyam/mcpkit/pull/869/files#diff-7e0ee26d4d523ebdecda4da033cb2f40c364eb05edb5f41b1d90d76fd374546e) — the three readers now use `req.ParamsLazy()`.
5. [core/paramslazy_test.go](https://github.com/panyam/mcpkit/pull/869/files#diff-afad51ea85ed211778bc2c6c00bc9045528ae03936de03f6649c8b613a3db1d6) — shared-cache, spine-free `Meta` (asserts the spine is NOT built by a `Meta`-only read), absent/null/non-object, and the two benchmarks above.

## Decision log

- **`Meta()` skips the spine on purpose.** The spine copies siblings; `_meta` readers don't want the `arguments` copy. Splitting `Meta` (targeted probe) from `Field` (spine) makes the metadata path strictly ≥ the old hand-rolled probe — single-reader = same, multi-reader = one scan instead of N — and never worse.
- **`ParamsLazy()` not a field-type flip.** Additive bridge; the breaking `Request.Params` → `RawJSON` change is slice 3, at the 0.4.0 boundary.

## Risk / blast radius

- **Additive.** No public signature removed, no wire bytes changed. `DecodeRequestMeta` keeps its exact semantics (empty/null/absent `_meta` → `_meta` error; missing sub-fields → the specific field error) — covered by the existing stateless + conformance tests, all green.
- Pressure-test: concurrency. `ParamsLazy()`'s nil-init and `RawJSON`'s lazy caches assume sequential per-request reads (true on the dispatch/middleware chain today); documented, and hardens with the slice-3 flip.

## Out of scope (later slices)

- Migrate the remaining top-level readers (SEP-2243 routing-header `name`/`uri`, SEP-2322 MRTR envelope) — they read top-level fields (spine), a smaller/separate win; follow-up.
- Flip `core.Request.Params` (and likely `Result`) to `RawJSON` — the breaking change, slice 3.
- Zero-copy sub-slice views — later internal swap behind the same API.

