### PR TITLE
feat(core)!: flip Request.Params to RawJSON (issue 733 slice 3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,36 @@ examples/apps/compat/*/.test-results/
 # scratch only, the docker run mounts them into the container.
 .tmp-fixture-linux-amd64-*
 /discord_tracking
+
+# cmd + docs-site tool binaries (`go build .` output).
+cmd/mcpskills/mcpskills
+docs/site/site
+
+# apps/compat fixture binaries. `go build .` produces a bare dir-name
+# binary; each fixture's local .gitignore only covered the `-demo`
+# Makefile output, so the bare name slipped through. List them here.
+examples/apps/compat/basic-preact/basic-preact
+examples/apps/compat/basic-react/basic-react
+examples/apps/compat/basic-solid/basic-solid
+examples/apps/compat/basic-svelte/basic-svelte
+examples/apps/compat/basic-vanillajs/basic-vanillajs
+examples/apps/compat/basic-vue/basic-vue
+examples/apps/compat/budget-allocator/budget-allocator
+examples/apps/compat/cohort-heatmap/cohort-heatmap
+examples/apps/compat/customer-segmentation/customer-segmentation
+examples/apps/compat/debug-server/debug-server
+examples/apps/compat/integration/integration
+examples/apps/compat/map/map
+examples/apps/compat/pdf-server/pdf-server
+examples/apps/compat/quickstart/quickstart
+examples/apps/compat/scenario-modeler/scenario-modeler
+examples/apps/compat/shadertoy/shadertoy
+examples/apps/compat/sheet-music/sheet-music
+examples/apps/compat/system-monitor/system-monitor
+examples/apps/compat/threejs/threejs
+examples/apps/compat/transcript/transcript
+examples/apps/compat/wiki-explorer/wiki-explorer
+
+# other example `go build .` outputs
+examples/mcpskills-walkthrough/mcpskills-walkthrough
+examples/otel/stdout/stdout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,17 +55,15 @@ targeted spec version.
 ### Added / Fixed
 - **`core.RawJSON`** — a typed, parse-once wrapper for JSON-RPC raw values
   (params / `_meta` / …) with `Bind` / `Meta` / `Field` helpers; wire-transparent
-  (round-trips identically to `json.RawMessage`). First slice of issue 733; the
-  trace middleware now shares one parse across its `_meta` readers (trace
-  context / baggage / tracelink) — ~3× faster + ~3× less alloc on large
-  `tools/call` payloads. The `Request.Params` type flip is a later slice.
-- **`core.Request.ParamsLazy()`** — a per-request cached `RawJSON` so every
-  metadata reader on one request shares a single parse (issue 733 slice 2).
-  `RawJSON.Meta()` now extracts only the `_meta` bytes (never copies a large
-  `arguments` sibling), and the SEP-2575 `_meta` gate + trace middleware read
-  through the shared cache: metadata-only decode stays flat-allocation
-  regardless of payload size, and trace + gate together scan params once (2×
-  faster at 1 MB). Additive — `Params` is still `json.RawMessage`.
+  (round-trips identically to `json.RawMessage`). This is the read-side type
+  behind the `Request.Params` flip above (issue 733). Every metadata reader on
+  one request shares a single parse: the trace middleware's `_meta` readers
+  (trace context / baggage / tracelink) and the SEP-2575 `_meta` gate now read
+  through one cached parse instead of each re-scanning params. `Meta()` extracts
+  only the `_meta` bytes and never copies a large `arguments` sibling, so
+  metadata-only decode stays flat-allocation regardless of payload size —
+  ~3× faster + ~3× less alloc on large `tools/call` payloads, and trace + gate
+  together scan params once (2× faster at 1 MB).
 - **Panic recovery in library goroutines** — a panic in a tool/background
   goroutine is recovered and surfaced as an error instead of crashing the host
   process. (issue 420)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ also preserves conformance against the deprecated-but-in-spec features on the
 targeted spec version.
 
 ### Breaking
+- **`core.Request.Params` is now `core.RawJSON`** (was `json.RawMessage`) —
+  issue 733 slice 3, the final slice of the params-handling change. Read it with
+  `req.Params.Bind(&typed)` / `.Meta()` / `.Field(key)` and the raw bytes with
+  `req.Params.Raw()`; construct with `core.NewRawJSON(bytes)` or
+  `core.MarshalRawJSON(v)`. A notification is still a `Request` with no ID, so
+  its params flip too. Wire output is byte-identical — `Request.MarshalJSON`
+  preserves param omission (JSON-RPC forbids `"params":null`). The transitional
+  `ParamsLazy()` bridge is removed (`req.Params` *is* the cached parse now).
+  Breaking for anyone constructing or reading `core.Request.Params` directly.
 - **conformant-by-default** — safe-default SEP options flip from opt-in to
   opt-out. `server.NewServer(info)` now emits the SEP-2549 cache-control hints
   by default: list responses (tools/prompts/resources/templates) carry

--- a/client/client.go
+++ b/client/client.go
@@ -926,7 +926,7 @@ func (c *Client) dispatchServerRequest(ctx context.Context, req *core.Request) *
 			return core.NewErrorResponse(req.ID, core.ErrCodeMethodNotFound, "sampling not supported")
 		}
 		var params core.CreateMessageRequest
-		if err := json.Unmarshal(req.Params, &params); err != nil {
+		if err := req.Params.Bind(&params); err != nil {
 			return core.NewErrorResponse(req.ID, core.ErrCodeInvalidParams, "invalid sampling params: "+err.Error())
 		}
 		result, err := c.samplingHandler(ctx, params)
@@ -940,7 +940,7 @@ func (c *Client) dispatchServerRequest(ctx context.Context, req *core.Request) *
 			return core.NewErrorResponse(req.ID, core.ErrCodeMethodNotFound, "elicitation not supported")
 		}
 		var params core.ElicitationRequest
-		if err := json.Unmarshal(req.Params, &params); err != nil {
+		if err := req.Params.Bind(&params); err != nil {
 			return core.NewErrorResponse(req.ID, core.ErrCodeInvalidParams, "invalid elicitation params: "+err.Error())
 		}
 		// Reject URL mode if client didn't declare URL support.
@@ -1638,7 +1638,7 @@ func (c *Client) doRawCall(method string, params any, cc *CallContext) (*rpcResp
 		Method:  method,
 	}
 	if wrapped != nil {
-		req.Params, _ = json.Marshal(wrapped)
+		req.Params, _ = core.MarshalRawJSON(wrapped)
 	}
 	data, _ := json.Marshal(req)
 	return c.transport.callWithContext(method, data, cc)
@@ -1656,7 +1656,7 @@ func (c *Client) notifyMethod(method string, params any) error {
 		Method:  method,
 	}
 	if params != nil {
-		req.Params, _ = json.Marshal(params)
+		req.Params, _ = core.MarshalRawJSON(params)
 	}
 	data, _ := json.Marshal(req)
 

--- a/client/client_reconnect.go
+++ b/client/client_reconnect.go
@@ -104,7 +104,7 @@ func (c *Client) reconnect() error {
 		ID:      marshalID(c.nextRequestID()),
 		Method:  "initialize",
 	}
-	initReq.Params, _ = json.Marshal(initializeParams{
+	initReq.Params, _ = core.MarshalRawJSON(initializeParams{
 		ProtocolVersion: "2025-11-25",
 		Capabilities:    core.ClientCapabilities{},
 		ClientInfo:      c.info,

--- a/client/mrtr.go
+++ b/client/mrtr.go
@@ -193,7 +193,7 @@ func DefaultInputHandler(c *Client) InputHandler {
 func dispatchMRTRInputRequest(ctx context.Context, c *Client, req core.InputRequest) (json.RawMessage, error) {
 	synth := &core.Request{
 		Method: req.Method,
-		Params: req.Params,
+		Params: core.NewRawJSON(req.Params),
 		ID:     json.RawMessage(`"mrtr"`),
 	}
 	resp := c.HandleServerRequestWithContext(ctx, synth)

--- a/client/mrtr_test.go
+++ b/client/mrtr_test.go
@@ -232,8 +232,8 @@ func (m *mrtrParamsCaptureMiddleware) middleware() server.Middleware {
 		if req.Method == "tools/call" {
 			m.mu.Lock()
 			// Copy so any later mutation doesn't bleed into our snapshot.
-			cp := make(json.RawMessage, len(req.Params))
-			copy(cp, req.Params)
+			cp := make(json.RawMessage, req.Params.Len())
+			copy(cp, req.Params.Raw())
 			m.rounds = append(m.rounds, cp)
 			m.mu.Unlock()
 		}

--- a/client/stateless_test.go
+++ b/client/stateless_test.go
@@ -167,7 +167,7 @@ func (f *fakeMCPServer) start() (*httptest.Server, string) {
 		body, _ := io.ReadAll(r.Body)
 		var req core.Request
 		_ = json.Unmarshal(body, &req)
-		status, resBody := f.handler(req.Method, req.Params)
+		status, resBody := f.handler(req.Method, req.Params.Raw())
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(status)
 		w.Write(resBody)
@@ -323,7 +323,7 @@ func TestClient_StatelessWire_SendsMetaAndHeader(t *testing.T) {
 		_ = json.Unmarshal(body, &req)
 		seen = append(seen, observed{
 			method: req.Method,
-			params: req.Params,
+			params: req.Params.Raw(),
 			header: r.Header.Get(core.HTTPProtocolVersionHeader),
 		})
 		switch req.Method {

--- a/client/stdio_transport.go
+++ b/client/stdio_transport.go
@@ -195,7 +195,7 @@ func (t *StdioTransport) readLoop() {
 		if req.IsNotification() {
 			// Server-to-client notification.
 			if t.notifyHandler != nil {
-				t.notifyHandler(req.Method, req.Params)
+				t.notifyHandler(req.Method, req.Params.Raw())
 			}
 			continue
 		}

--- a/client/trace_middleware.go
+++ b/client/trace_middleware.go
@@ -149,12 +149,12 @@ func traceMiddleware(c *Client, tp core.TracerProvider) ClientMiddleware {
 //	defer span.End()
 //	// ... dispatch as usual; record outcome via recordInboundOutcome
 func traceInboundDispatch(tp core.TracerProvider, ctx context.Context, req *core.Request) (context.Context, core.Span) {
-	tc := core.ExtractTraceContextFromParams(req.Params)
+	tc := core.ExtractTraceContextFromParams(req.Params.Raw())
 	ctx = core.WithTraceContext(ctx, tc)
 	// W3C Baggage on inbound server-to-client requests follows the
 	// same shape: read once from `_meta.baggage`, attach via ctx so
 	// the handler can see it via core.BaggageFromContext.
-	bg := core.ExtractBaggageFromParams(req.Params)
+	bg := core.ExtractBaggageFromParams(req.Params.Raw())
 	ctx = core.WithBaggage(ctx, bg)
 	attrs := []core.Attribute{
 		{Key: "mcp.method", Value: req.Method},

--- a/client/trace_middleware_test.go
+++ b/client/trace_middleware_test.go
@@ -312,7 +312,7 @@ func TestClientTrace_InboundExtractsTraceparent(t *testing.T) {
 	)
 
 	params := json.RawMessage(`{"maxTokens":16,"_meta":{"traceparent":"` + tpInbound + `"}}`)
-	req := &core.Request{ID: json.RawMessage(`1`), Method: "sampling/createMessage", Params: params}
+	req := &core.Request{ID: json.RawMessage(`1`), Method: "sampling/createMessage", Params: core.NewRawJSON(params)}
 	resp := c.HandleServerRequestWithContext(context.Background(), req)
 
 	require.NotNil(t, resp)
@@ -335,7 +335,7 @@ func TestClientTrace_InboundWithoutTraceparent_FreshTrace(t *testing.T) {
 		}),
 	)
 
-	req := &core.Request{ID: json.RawMessage(`1`), Method: "roots/list", Params: json.RawMessage(`{}`)}
+	req := &core.Request{ID: json.RawMessage(`1`), Method: "roots/list", Params: core.NewRawJSON(json.RawMessage(`{}`))}
 	resp := c.HandleServerRequestWithContext(context.Background(), req)
 	require.NotNil(t, resp)
 	require.Nil(t, resp.Error)
@@ -355,7 +355,7 @@ func TestClientTrace_InboundMalformedTraceparent_DropsSilently(t *testing.T) {
 	)
 
 	params := json.RawMessage(`{"_meta":{"traceparent":"not-a-real-traceparent","tracestate":"vendor=x"}}`)
-	req := &core.Request{ID: json.RawMessage(`1`), Method: "roots/list", Params: params}
+	req := &core.Request{ID: json.RawMessage(`1`), Method: "roots/list", Params: core.NewRawJSON(params)}
 	resp := c.HandleServerRequestWithContext(context.Background(), req)
 	require.NotNil(t, resp)
 	require.Nil(t, resp.Error)
@@ -375,7 +375,7 @@ func TestClientTrace_InboundHandlerError_RecordsErrorCode(t *testing.T) {
 	)
 
 	params := json.RawMessage(`{"maxTokens":1,"_meta":{"traceparent":"` + tpInbound + `"}}`)
-	req := &core.Request{ID: json.RawMessage(`1`), Method: "sampling/createMessage", Params: params}
+	req := &core.Request{ID: json.RawMessage(`1`), Method: "sampling/createMessage", Params: core.NewRawJSON(params)}
 	resp := c.HandleServerRequestWithContext(context.Background(), req)
 	require.NotNil(t, resp)
 	require.NotNil(t, resp.Error)
@@ -392,7 +392,7 @@ func TestClientTrace_InboundUnknownMethod_RecordsMethodNotFound(t *testing.T) {
 		WithTracerProvider(tp),
 	)
 
-	req := &core.Request{ID: json.RawMessage(`1`), Method: "wat/wat", Params: json.RawMessage(`{}`)}
+	req := &core.Request{ID: json.RawMessage(`1`), Method: "wat/wat", Params: core.NewRawJSON(json.RawMessage(`{}`))}
 	resp := c.HandleServerRequestWithContext(context.Background(), req)
 	require.NotNil(t, resp)
 	require.NotNil(t, resp.Error)
@@ -450,7 +450,7 @@ func TestClientTrace_InboundExtractsBaggageOntoCtx(t *testing.T) {
 	)
 
 	params := json.RawMessage(`{"maxTokens":16,"_meta":{"traceparent":"` + tpInbound + `","baggage":"userId=bob"}}`)
-	req := &core.Request{ID: json.RawMessage(`1`), Method: "sampling/createMessage", Params: params}
+	req := &core.Request{ID: json.RawMessage(`1`), Method: "sampling/createMessage", Params: core.NewRawJSON(params)}
 	resp := c.HandleServerRequestWithContext(context.Background(), req)
 	require.NotNil(t, resp)
 	require.Nil(t, resp.Error)

--- a/core/jsonrpc.go
+++ b/core/jsonrpc.go
@@ -7,32 +7,30 @@ import (
 
 // JSON-RPC 2.0 types for MCP protocol communication.
 
-// Request is a JSON-RPC 2.0 request envelope.
+// Request is a JSON-RPC 2.0 request envelope. A notification is a Request with
+// no ID (see IsNotification).
+//
+// Params is a RawJSON (issue 733): read it with req.Params.Bind(&typed) /
+// req.Params.Meta() / req.Params.Field(key), and the raw bytes with
+// req.Params.Raw(). Every reader on one *Request shares a single parse.
 type Request struct {
 	JSONRPC string          `json:"jsonrpc"`
 	ID      json.RawMessage `json:"id"`
 	Method  string          `json:"method"`
-	Params  json.RawMessage `json:"params,omitempty"`
-
-	// paramsLazy caches the RawJSON view of Params so every reader on the same
-	// *Request shares one parse (issue 733). Unexported — ignored on the wire.
-	paramsLazy *RawJSON
+	Params  RawJSON         `json:"params,omitempty"`
 }
 
-// ParamsLazy returns a RawJSON view of Params, cached on the request. Every
-// caller on the same *Request shares the cache, so a dispatch path that reads
-// the metadata from several places (trace middleware, the SEP-2575 _meta gate,
-// routing-header validation) scans Params once instead of once per reader.
-//
-// Additive bridge ahead of the Params type flip (issue 733 slice 3): Params
-// stays json.RawMessage. Not safe for concurrent first-callers on one *Request;
-// the dispatch/middleware chain reads sequentially per request.
-func (r *Request) ParamsLazy() *RawJSON {
-	if r.paramsLazy == nil {
-		rj := NewRawJSON(r.Params)
-		r.paramsLazy = &rj
-	}
-	return r.paramsLazy
+// MarshalJSON emits params only when non-empty. RawJSON is a struct, so the
+// `omitempty` tag cannot omit it, and JSON-RPC forbids `"params":null` (params,
+// if present, MUST be an array or object). Wire output is byte-identical to the
+// old json.RawMessage field.
+func (r Request) MarshalJSON() ([]byte, error) {
+	return MarshalJSON(struct {
+		JSONRPC string          `json:"jsonrpc"`
+		ID      json.RawMessage `json:"id"`
+		Method  string          `json:"method"`
+		Params  json.RawMessage `json:"params,omitempty"`
+	}{r.JSONRPC, r.ID, r.Method, r.Params.Raw()})
 }
 
 // Response is a JSON-RPC 2.0 response.

--- a/core/logging_transport_test.go
+++ b/core/logging_transport_test.go
@@ -98,7 +98,7 @@ func TestLoggingTransport_LogBodiesIncludesJSON(t *testing.T) {
 
 	_, err := lt.Call(context.Background(), &Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "tools/call",
-		Params: json.RawMessage(`{"name":"echo"}`),
+		Params: NewRawJSON(json.RawMessage(`{"name":"echo"}`)),
 	})
 	require.NoError(t, err)
 
@@ -121,7 +121,7 @@ func TestLoggingTransport_NoBodiesByDefault(t *testing.T) {
 
 	_, err := lt.Call(context.Background(), &Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "tools/call",
-		Params: json.RawMessage(`{"name":"echo"}`),
+		Params: NewRawJSON(json.RawMessage(`{"name":"echo"}`)),
 	})
 	require.NoError(t, err)
 

--- a/core/paramslazy_test.go
+++ b/core/paramslazy_test.go
@@ -8,9 +8,9 @@ import (
 )
 
 func TestRequest_ParamsLazy_SharesCache(t *testing.T) {
-	req := &Request{Params: json.RawMessage(`{"name":"x","_meta":{"a":1}}`)}
-	a := req.ParamsLazy()
-	b := req.ParamsLazy()
+	req := &Request{Params: NewRawJSON(json.RawMessage(`{"name":"x","_meta":{"a":1}}`))}
+	a := &req.Params
+	b := &req.Params
 	if a != b {
 		t.Fatal("ParamsLazy should return the same cached *RawJSON")
 	}
@@ -83,7 +83,7 @@ func BenchmarkDecodeRequestMeta(b *testing.B) {
 }
 
 // BenchmarkSharedMetaReaders compares two readers (trace context + SEP-2575
-// gate) sharing one req.ParamsLazy() parse vs each scanning params itself.
+// gate) sharing one &req.Params parse vs each scanning params itself.
 func BenchmarkSharedMetaReaders(b *testing.B) {
 	meta := `"_meta":{"traceparent":"00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01","io.modelcontextprotocol/protocolVersion":"2025-11-25","io.modelcontextprotocol/clientInfo":{"name":"c","version":"1"},"io.modelcontextprotocol/clientCapabilities":{}}`
 	blob := strings.Repeat("x", 1<<20)
@@ -99,9 +99,9 @@ func BenchmarkSharedMetaReaders(b *testing.B) {
 	b.Run("sharedParamsLazy", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			req := &Request{Params: params}
-			_ = ExtractTraceContextFromRawJSON(req.ParamsLazy())
-			_, _ = DecodeRequestMetaFromRawJSON(req.ParamsLazy())
+			req := &Request{Params: NewRawJSON(params)}
+			_ = ExtractTraceContextFromRawJSON(&req.Params)
+			_, _ = DecodeRequestMetaFromRawJSON(&req.Params)
 		}
 	})
 }

--- a/core/rawjson.go
+++ b/core/rawjson.go
@@ -62,6 +62,16 @@ func NewRawJSON(raw json.RawMessage) RawJSON {
 	return RawJSON{raw: raw, lazy: &rawJSONLazy{}}
 }
 
+// MarshalRawJSON marshals v to JSON and wraps the result as a RawJSON —
+// convenience for assigning a typed value to a Request.Params field.
+func MarshalRawJSON(v any) (RawJSON, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return RawJSON{}, err
+	}
+	return NewRawJSON(b), nil
+}
+
 // object parses and caches the top-level JSON object once. Returns a nil spine
 // (no error) for an absent value, and an error when the value is not a JSON
 // object — Field/Meta treat both as "no field".

--- a/core/rawjson.go
+++ b/core/rawjson.go
@@ -27,10 +27,12 @@ import (
 // struct exists; string-keyed access trades away compile-time safety.
 //
 // The zero value is a usable empty/absent value. Construct from bytes with
-// NewRawJSON. The lazy spine is built on first Field/Meta call and cached;
-// reads on a single RawJSON are not yet safe for concurrent goroutines (the
-// dispatch/middleware chain reads sequentially per request) — that hardens
-// when Request.Params flips to RawJSON (issue 733 slice 3).
+// NewRawJSON. The lazy spine is built on first Field/Meta call and cached.
+// Reads on a RawJSON constructed via NewRawJSON or decoded via UnmarshalJSON
+// (both allocate the lazy holder up front) are safe for concurrent goroutines —
+// the cache is guarded by sync.Once. The one unguarded case is the zero value's
+// first lazy initialization; construct via NewRawJSON before sharing a value
+// across goroutines.
 type RawJSON struct {
 	raw  json.RawMessage
 	lazy *rawJSONLazy

--- a/core/stateless.go
+++ b/core/stateless.go
@@ -94,7 +94,7 @@ func DecodeRequestMeta(rawParams json.RawMessage) (*RequestMeta, error) {
 // (issue 733). It reads the SEP-2575 per-request `_meta` envelope through the
 // message's cached, spine-free Meta() — so on a request whose metadata is also
 // read elsewhere (trace middleware) the params are scanned once, and a large
-// `arguments` sibling is never copied. Prefer this via req.ParamsLazy() on the
+// `arguments` sibling is never copied. Prefer this via &req.Params on the
 // dispatch path.
 func DecodeRequestMetaFromRawJSON(m *RawJSON) (*RequestMeta, error) {
 	meta, ok := m.Meta()

--- a/examples/elicitation/main.go
+++ b/examples/elicitation/main.go
@@ -414,7 +414,7 @@ func consentMiddleware(store *consentStore, baseURL string) server.Middleware {
 				AuthzContextID string `json:"io.modelcontextprotocol/authorization-context-id"`
 			} `json:"_meta"`
 		}
-		if err := json.Unmarshal(req.Params, &envelope); err != nil {
+		if err := req.Params.Bind(&envelope); err != nil {
 			return next(ctx, req)
 		}
 

--- a/examples/fine-grained-auth/main.go
+++ b/examples/fine-grained-auth/main.go
@@ -1034,7 +1034,7 @@ func paymentAuthorizationMiddleware() server.Middleware {
 				Payee    string `json:"payee"`
 			} `json:"arguments"`
 		}
-		if err := json.Unmarshal(req.Params, &envelope); err != nil {
+		if err := req.Params.Bind(&envelope); err != nil {
 			return next(ctx, req)
 		}
 		if envelope.Name != "initiate_payment" {

--- a/experimental/ext/events/delivery_status_test.go
+++ b/experimental/ext/events/delivery_status_test.go
@@ -61,7 +61,7 @@ func dispatchSubscribeForStatus(t *testing.T, srv *server.Server, callbackURL, s
 	raw, err := json.Marshal(params)
 	require.NoError(t, err)
 	resp, err := srv.Dispatch(context.Background(), &core.Request{
-		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "events/subscribe", Params: raw,
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "events/subscribe", Params: core.NewRawJSON(raw),
 	})
 	require.NoError(t, err)
 	require.Nil(t, resp.Error, "expected success; got %+v", resp.Error)

--- a/experimental/ext/events/emit_targeted_test.go
+++ b/experimental/ext/events/emit_targeted_test.go
@@ -159,7 +159,7 @@ func TestEmitToSubscription_Push_RoutesToOneStream(t *testing.T) {
 		defer close(streamDone)
 		_, _ = srv.Dispatch(streamCtx, &core.Request{
 			JSONRPC: "2.0", ID: json.RawMessage(`100`),
-			Method: "events/stream", Params: rawReq,
+			Method: "events/stream", Params: core.NewRawJSON(rawReq),
 		})
 	}()
 
@@ -244,7 +244,7 @@ func TestEmitToSubscription_Webhook_RoutesToOneTarget(t *testing.T) {
 		raw, _ := json.Marshal(body)
 		resp, err := srv.Dispatch(context.Background(), &core.Request{
 			JSONRPC: "2.0", ID: json.RawMessage(`1`),
-			Method: "events/subscribe", Params: raw,
+			Method: "events/subscribe", Params: core.NewRawJSON(raw),
 		})
 		require.NoError(t, err)
 		require.Nil(t, resp.Error, "subscribe failed: %+v", resp.Error)
@@ -281,7 +281,7 @@ func TestEmitToSubscription_Webhook_RoutesToOneTarget(t *testing.T) {
 	})
 	resp, err := srv.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`2`),
-		Method: "events/unsubscribe", Params: unsubBody,
+		Method: "events/unsubscribe", Params: core.NewRawJSON(unsubBody),
 	})
 	require.NoError(t, err)
 	require.Nil(t, resp.Error)
@@ -340,7 +340,7 @@ func TestEmitToSubscription_Webhook_RefreshKeepsSameID(t *testing.T) {
 		raw, _ := json.Marshal(subParams)
 		resp, err := srv.Dispatch(context.Background(), &core.Request{
 			JSONRPC: "2.0", ID: json.RawMessage(`1`),
-			Method: "events/subscribe", Params: raw,
+			Method: "events/subscribe", Params: core.NewRawJSON(raw),
 		})
 		require.NoError(t, err)
 		require.Nil(t, resp.Error)

--- a/experimental/ext/events/identity_handler_test.go
+++ b/experimental/ext/events/identity_handler_test.go
@@ -51,7 +51,7 @@ func buildAuthGateStackWithOpts(t *testing.T, unsafeAnon string, extra ...Webhoo
 	})
 	initParams := json.RawMessage(`{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)
 	resp, err := srv.Dispatch(context.Background(), &core.Request{
-		JSONRPC: "2.0", ID: json.RawMessage(`0`), Method: "initialize", Params: initParams,
+		JSONRPC: "2.0", ID: json.RawMessage(`0`), Method: "initialize", Params: core.NewRawJSON(initParams),
 	})
 	require.NoError(t, err)
 	require.Nil(t, resp.Error)
@@ -67,7 +67,7 @@ func dispatchSubscribe(t *testing.T, srv *server.Server, params map[string]any) 
 	raw, err := json.Marshal(params)
 	require.NoError(t, err)
 	resp, err := srv.Dispatch(context.Background(), &core.Request{
-		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "events/subscribe", Params: raw,
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "events/subscribe", Params: core.NewRawJSON(raw),
 	})
 	require.NoError(t, err)
 	return resp
@@ -205,7 +205,7 @@ func TestUnsubscribe_ByTuple(t *testing.T) {
 	rawUnsub, err := json.Marshal(unsubParams)
 	require.NoError(t, err)
 	unsubResp, err := srv.Dispatch(context.Background(), &core.Request{
-		JSONRPC: "2.0", ID: json.RawMessage(`2`), Method: "events/unsubscribe", Params: rawUnsub,
+		JSONRPC: "2.0", ID: json.RawMessage(`2`), Method: "events/unsubscribe", Params: core.NewRawJSON(rawUnsub),
 	})
 	require.NoError(t, err)
 	require.Nil(t, unsubResp.Error)

--- a/experimental/ext/events/lifecycle_test.go
+++ b/experimental/ext/events/lifecycle_test.go
@@ -157,7 +157,7 @@ func (f *lifecycleFixture) dispatch(method string, params map[string]any) *core.
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  method,
-		Params:  raw,
+		Params:  core.NewRawJSON(raw),
 	})
 	require.NoError(f.t, err)
 	return resp
@@ -446,7 +446,7 @@ func TestLifecycle_Push_OpenCloseFiresHooksOnce(t *testing.T) {
 			JSONRPC: "2.0",
 			ID:      json.RawMessage(`2`),
 			Method:  "events/stream",
-			Params:  rawReq,
+			Params:  core.NewRawJSON(rawReq),
 		})
 	}()
 
@@ -492,7 +492,7 @@ func TestLifecycle_Push_OnSubscribeError_RejectsStream(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`3`),
 		Method:  "events/stream",
-		Params:  rawReq,
+		Params:  core.NewRawJSON(rawReq),
 	})
 	require.NoError(t, err)
 	require.NotNil(t, resp.Error)
@@ -579,7 +579,7 @@ func TestLifecycle_Poll_OnSubscribeError_Rejects(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`4`),
 		Method:  "events/poll",
-		Params:  raw,
+		Params:  core.NewRawJSON(raw),
 	})
 	require.NoError(t, err)
 	require.NotNil(t, resp.Error, "poll on_subscribe error should surface via JSON-RPC error")
@@ -629,7 +629,7 @@ func TestLifecycle_Webhook_ConcurrentSubscribe_FiresOnce(t *testing.T) {
 				JSONRPC: "2.0",
 				ID:      idRaw,
 				Method:  "events/subscribe",
-				Params:  raw,
+				Params:  core.NewRawJSON(raw),
 			})
 			if derr != nil || (resp != nil && resp.Error != nil) {
 				fails.Add(1)

--- a/experimental/ext/events/match_transform_test.go
+++ b/experimental/ext/events/match_transform_test.go
@@ -269,7 +269,7 @@ func TestMatchTransform_Webhook_MatchAndTransformPerTarget(t *testing.T) {
 		raw, _ := json.Marshal(body)
 		resp, err := srv.Dispatch(context.Background(), &core.Request{
 			JSONRPC: "2.0", ID: json.RawMessage(`1`),
-			Method: "events/subscribe", Params: raw,
+			Method: "events/subscribe", Params: core.NewRawJSON(raw),
 		})
 		require.NoError(t, err)
 		require.Nil(t, resp.Error, "subscribe failed: %+v", resp.Error)
@@ -374,7 +374,7 @@ func TestMatchTransform_Webhook_FiltersByEventName(t *testing.T) {
 	raw, _ := json.Marshal(body)
 	resp, err := srv.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`),
-		Method: "events/subscribe", Params: raw,
+		Method: "events/subscribe", Params: core.NewRawJSON(raw),
 	})
 	require.NoError(t, err)
 	require.Nil(t, resp.Error)
@@ -418,7 +418,7 @@ func TestMatchTransform_Poll_AppliesPerCall(t *testing.T) {
 		raw, _ := json.Marshal(body)
 		resp, err := srv.Dispatch(context.Background(), &core.Request{
 			JSONRPC: "2.0", ID: json.RawMessage(`1`),
-			Method: "events/poll", Params: raw,
+			Method: "events/poll", Params: core.NewRawJSON(raw),
 		})
 		require.NoError(t, err)
 		require.Nil(t, resp.Error, "poll failed: %+v", resp.Error)
@@ -511,7 +511,7 @@ func TestMatchTransform_CrossModeParity(t *testing.T) {
 	})
 	resp, err := srv.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`),
-		Method: "events/subscribe", Params: subBody,
+		Method: "events/subscribe", Params: core.NewRawJSON(subBody),
 	})
 	require.NoError(t, err)
 	require.Nil(t, resp.Error)
@@ -548,7 +548,7 @@ func TestMatchTransform_CrossModeParity(t *testing.T) {
 	})
 	resp, err = srv.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`2`),
-		Method: "events/poll", Params: pollBody,
+		Method: "events/poll", Params: core.NewRawJSON(pollBody),
 	})
 	require.NoError(t, err)
 	w, ok := resp.Result.(pollResultWire)

--- a/experimental/ext/events/poll_lease_test.go
+++ b/experimental/ext/events/poll_lease_test.go
@@ -360,7 +360,7 @@ func finishInitHandshake(t *testing.T, srv *server.Server) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`0`),
 		Method:  "initialize",
-		Params:  initParams,
+		Params:  core.NewRawJSON(initParams),
 	})
 	require.NoError(t, err)
 	require.Nil(t, resp.Error, "initialize should succeed; got %+v", resp.Error)
@@ -385,7 +385,7 @@ func dispatchPoll(t *testing.T, srv *server.Server, name string, params map[stri
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "events/poll",
-		Params:  raw,
+		Params:  core.NewRawJSON(raw),
 	})
 	require.NoError(t, err)
 	require.Nil(t, resp.Error, "events/poll returned error: %+v", resp.Error)

--- a/experimental/ext/events/quota_test.go
+++ b/experimental/ext/events/quota_test.go
@@ -138,7 +138,7 @@ func TestQuota_Webhook_RejectsThirdSubscribe(t *testing.T) {
 		raw, _ := json.Marshal(body)
 		resp, err := srv.Dispatch(context.Background(), &core.Request{
 			JSONRPC: "2.0", ID: json.RawMessage(`1`),
-			Method: "events/subscribe", Params: raw,
+			Method: "events/subscribe", Params: core.NewRawJSON(raw),
 		})
 		require.NoError(t, err)
 		return resp
@@ -191,7 +191,7 @@ func TestQuota_Webhook_UnsubscribeReleases(t *testing.T) {
 	})
 	resp, err := srv.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`),
-		Method: "events/subscribe", Params: subBody,
+		Method: "events/subscribe", Params: core.NewRawJSON(subBody),
 	})
 	require.NoError(t, err)
 	require.Nil(t, resp.Error)
@@ -201,7 +201,7 @@ func TestQuota_Webhook_UnsubscribeReleases(t *testing.T) {
 	// new sub — quota count must not double.
 	resp, err = srv.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`2`),
-		Method: "events/subscribe", Params: subBody,
+		Method: "events/subscribe", Params: core.NewRawJSON(subBody),
 	})
 	require.NoError(t, err)
 	require.Nil(t, resp.Error)
@@ -215,7 +215,7 @@ func TestQuota_Webhook_UnsubscribeReleases(t *testing.T) {
 	})
 	resp, err = srv.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`3`),
-		Method: "events/unsubscribe", Params: unsubBody,
+		Method: "events/unsubscribe", Params: core.NewRawJSON(unsubBody),
 	})
 	require.NoError(t, err)
 	require.Nil(t, resp.Error)
@@ -260,7 +260,7 @@ func TestQuota_Webhook_TTLPruneReleases(t *testing.T) {
 		})
 		resp, err := srv.Dispatch(context.Background(), &core.Request{
 			JSONRPC: "2.0", ID: json.RawMessage(`1`),
-			Method: "events/subscribe", Params: body,
+			Method: "events/subscribe", Params: core.NewRawJSON(body),
 		})
 		require.NoError(t, err)
 		return resp
@@ -313,7 +313,7 @@ func TestQuota_Webhook_OnSubscribeErrorReleases(t *testing.T) {
 	})
 	resp, err := srv.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`),
-		Method: "events/subscribe", Params: body,
+		Method: "events/subscribe", Params: core.NewRawJSON(body),
 	})
 	require.NoError(t, err)
 	require.NotNil(t, resp.Error, "on_subscribe error should reject")
@@ -350,7 +350,7 @@ func TestQuota_Push_RejectsOverCap(t *testing.T) {
 				JSONRPC: "2.0",
 				ID:      json.RawMessage([]byte{'"', 's', byte('0' + idx), '"'}),
 				Method:  "events/stream",
-				Params:  rawReq,
+				Params:  core.NewRawJSON(rawReq),
 			})
 			if resp != nil && resp.Error != nil {
 				errCh <- errors.New(resp.Error.Message)
@@ -418,7 +418,7 @@ func TestQuota_Poll_RejectsOverCap(t *testing.T) {
 		})
 		resp, err := srv.Dispatch(context.Background(), &core.Request{
 			JSONRPC: "2.0", ID: json.RawMessage(`1`),
-			Method: "events/poll", Params: body,
+			Method: "events/poll", Params: core.NewRawJSON(body),
 		})
 		require.NoError(t, err)
 		return resp
@@ -494,7 +494,7 @@ func TestQuota_OnSubscribeNeverFiresWhenAtCap(t *testing.T) {
 		})
 		resp, err := srv.Dispatch(context.Background(), &core.Request{
 			JSONRPC: "2.0", ID: json.RawMessage(`1`),
-			Method: "events/subscribe", Params: body,
+			Method: "events/subscribe", Params: core.NewRawJSON(body),
 		})
 		require.NoError(t, err)
 		return resp

--- a/experimental/ext/events/secret_validation_test.go
+++ b/experimental/ext/events/secret_validation_test.go
@@ -243,7 +243,7 @@ func buildSecretValidationStack(t *testing.T) *server.Server {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`0`),
 		Method:  "initialize",
-		Params:  initParams,
+		Params:  core.NewRawJSON(initParams),
 	})
 	require.NoError(t, err)
 	require.Nil(t, resp.Error, "initialize should succeed; got %+v", resp.Error)
@@ -268,7 +268,7 @@ func callSubscribeHandler(t *testing.T, params map[string]any) *core.Response {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "events/subscribe",
-		Params:  raw,
+		Params:  core.NewRawJSON(raw),
 	})
 	require.NoError(t, err)
 	return resp
@@ -283,7 +283,7 @@ func callUnsubscribeHandler(t *testing.T, params map[string]any) *core.Response 
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "events/unsubscribe",
-		Params:  raw,
+		Params:  core.NewRawJSON(raw),
 	})
 	require.NoError(t, err)
 	return resp

--- a/experimental/ext/events/spec_alignment_2026_06_15_test.go
+++ b/experimental/ext/events/spec_alignment_2026_06_15_test.go
@@ -89,7 +89,7 @@ func TestPoll_WireShape_UsesArgumentsNotParams(t *testing.T) {
 	raw, err := json.Marshal(body)
 	require.NoError(t, err)
 	resp, err := srv.Dispatch(context.Background(), &core.Request{
-		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "events/poll", Params: raw,
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "events/poll", Params: core.NewRawJSON(raw),
 	})
 	require.NoError(t, err)
 	require.Nil(t, resp.Error, "events/poll with arguments MUST be accepted")
@@ -125,7 +125,7 @@ func TestUnsubscribe_WireShape_UsesArgumentsNotParams(t *testing.T) {
 	raw, err := json.Marshal(unsubBody)
 	require.NoError(t, err)
 	resp, err := srv.Dispatch(context.Background(), &core.Request{
-		JSONRPC: "2.0", ID: json.RawMessage(`2`), Method: "events/unsubscribe", Params: raw,
+		JSONRPC: "2.0", ID: json.RawMessage(`2`), Method: "events/unsubscribe", Params: core.NewRawJSON(raw),
 	})
 	require.NoError(t, err)
 	require.Nil(t, resp.Error, "events/unsubscribe with arguments MUST be accepted")

--- a/experimental/ext/events/stream_routing_test.go
+++ b/experimental/ext/events/stream_routing_test.go
@@ -48,7 +48,7 @@ func newStreamRoutingStack(t *testing.T, sources []EventSource, heartbeat time.D
 
 	initParams := json.RawMessage(`{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)
 	resp, err := transport.Call(context.Background(), &core.Request{
-		JSONRPC: "2.0", ID: json.RawMessage(`0`), Method: "initialize", Params: initParams,
+		JSONRPC: "2.0", ID: json.RawMessage(`0`), Method: "initialize", Params: core.NewRawJSON(initParams),
 	})
 	require.NoError(t, err)
 	require.Nil(t, resp.Error)
@@ -71,7 +71,7 @@ func (s *streamRoutingStack) startStreamID(t *testing.T, callID json.RawMessage,
 	done := make(chan streamResult, 1)
 	go func() {
 		resp, err := s.transport.Call(ctx, &core.Request{
-			JSONRPC: "2.0", ID: callID, Method: "events/stream", Params: rawParams,
+			JSONRPC: "2.0", ID: callID, Method: "events/stream", Params: core.NewRawJSON(rawParams),
 		})
 		done <- streamResult{resp: resp, err: err}
 	}()

--- a/experimental/ext/events/stream_test.go
+++ b/experimental/ext/events/stream_test.go
@@ -71,7 +71,7 @@ func newStreamTestStack(t *testing.T, unsafeAnon string, opts ...streamStackOpti
 	// Initialize the session so handlers will dispatch.
 	initParams := json.RawMessage(`{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)
 	resp, err := transport.Call(context.Background(), &core.Request{
-		JSONRPC: "2.0", ID: json.RawMessage(`0`), Method: "initialize", Params: initParams,
+		JSONRPC: "2.0", ID: json.RawMessage(`0`), Method: "initialize", Params: core.NewRawJSON(initParams),
 	})
 	require.NoError(t, err)
 	require.Nil(t, resp.Error)
@@ -129,7 +129,7 @@ func (s *streamTestStack) startStream(t *testing.T, params map[string]any) *runn
 	done := make(chan streamResult, 1)
 	go func() {
 		resp, err := s.transport.Call(ctx, &core.Request{
-			JSONRPC: "2.0", ID: json.RawMessage(`42`), Method: "events/stream", Params: rawParams,
+			JSONRPC: "2.0", ID: json.RawMessage(`42`), Method: "events/stream", Params: core.NewRawJSON(rawParams),
 		})
 		done <- streamResult{resp: resp, err: err}
 	}()

--- a/experimental/ext/events/ttl_negotiation_test.go
+++ b/experimental/ext/events/ttl_negotiation_test.go
@@ -43,7 +43,7 @@ func subscribeWithTTL(t *testing.T, srv *server.Server, ttlMsJSON string) map[st
 
 	resp, err := srv.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "events/subscribe",
-		Params: json.RawMessage(body),
+		Params: core.NewRawJSON(json.RawMessage(body)),
 	})
 	require.NoError(t, err)
 	require.Nil(t, resp.Error, "subscribe failed: %+v", resp.Error)
@@ -175,7 +175,7 @@ func TestRefreshBefore_WireShape_NullSerialisesAsJSONNull(t *testing.T) {
 		`","secret":"` + generateSecret() + `"}}`
 	resp, err := srvAdapter(srv).Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "events/subscribe",
-		Params: json.RawMessage(body),
+		Params: core.NewRawJSON(json.RawMessage(body)),
 	})
 	require.NoError(t, err)
 	require.Nil(t, resp.Error)
@@ -247,7 +247,7 @@ func TestCanonicalKey_IndependentOfTTLMs(t *testing.T) {
 		body += `}`
 		resp, err := srvAdapter(srv).Dispatch(context.Background(), &core.Request{
 			JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "events/subscribe",
-			Params: json.RawMessage(body),
+			Params: core.NewRawJSON(json.RawMessage(body)),
 		})
 		require.NoError(t, err)
 		require.Nil(t, resp.Error)

--- a/experimental/ext/events/wire_shape_test.go
+++ b/experimental/ext/events/wire_shape_test.go
@@ -109,7 +109,7 @@ func TestPoll_FlatRequestShape(t *testing.T) {
 	})
 	require.NoError(t, err)
 	resp, err := srv.Dispatch(context.Background(), &core.Request{
-		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "events/poll", Params: rawReq,
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "events/poll", Params: core.NewRawJSON(rawReq),
 	})
 	require.NoError(t, err)
 	require.Nil(t, resp.Error, "flat top-level shape must be accepted; got %+v", resp.Error)
@@ -129,7 +129,7 @@ func TestPoll_RejectsLegacyWrapper(t *testing.T) {
 	})
 	require.NoError(t, err)
 	resp, err := srv.Dispatch(context.Background(), &core.Request{
-		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "events/poll", Params: rawReq,
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "events/poll", Params: core.NewRawJSON(rawReq),
 	})
 	require.NoError(t, err)
 	require.NotNil(t, resp.Error, "legacy wrapper must be rejected, not silently parsed as empty")
@@ -201,7 +201,7 @@ func TestPoll_MaxAgeFiltersOldEvents(t *testing.T) {
 		"maxAge": 5,
 	})
 	resp, err := srv.Dispatch(context.Background(), &core.Request{
-		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "events/poll", Params: rawReq,
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "events/poll", Params: core.NewRawJSON(rawReq),
 	})
 	require.NoError(t, err)
 	require.Nil(t, resp.Error)
@@ -241,7 +241,7 @@ func TestPoll_MaxAgeZeroMeansNoFilter(t *testing.T) {
 		// maxAge intentionally omitted
 	})
 	resp, err := srv.Dispatch(context.Background(), &core.Request{
-		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "events/poll", Params: rawReq,
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "events/poll", Params: core.NewRawJSON(rawReq),
 	})
 	require.NoError(t, err)
 	require.Nil(t, resp.Error)
@@ -280,7 +280,7 @@ func buildPollFilterStack(t *testing.T) (*server.Server, *YieldingSource[fakeFil
 	})
 	initParams := json.RawMessage(`{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)
 	resp, err := srv.Dispatch(context.Background(), &core.Request{
-		JSONRPC: "2.0", ID: json.RawMessage(`0`), Method: "initialize", Params: initParams,
+		JSONRPC: "2.0", ID: json.RawMessage(`0`), Method: "initialize", Params: core.NewRawJSON(initParams),
 	})
 	require.NoError(t, err)
 	require.Nil(t, resp.Error)

--- a/ext/auth/scope_middleware.go
+++ b/ext/auth/scope_middleware.go
@@ -2,7 +2,6 @@ package auth
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 
 	"github.com/panyam/mcpkit/core"
@@ -121,7 +120,7 @@ func NewToolScopeMiddleware(lookup ToolDefLookup, opts ...ToolScopeOption) serve
 		var params struct {
 			Name string `json:"name"`
 		}
-		if err := json.Unmarshal(req.Params, &params); err != nil {
+		if err := req.Params.Bind(&params); err != nil {
 			// Malformed params — let the dispatcher handle the parse error.
 			return next(ctx, req)
 		}

--- a/ext/auth/scope_middleware_test.go
+++ b/ext/auth/scope_middleware_test.go
@@ -52,7 +52,7 @@ func TestToolScopeMiddleware_403WithWWWAuth(t *testing.T) {
 	req := &core.Request{
 		ID:     json.RawMessage(`1`),
 		Method: "tools/call",
-		Params: json.RawMessage(`{"name":"update_doc"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"name":"update_doc"}`)),
 	}
 
 	resp, err := mw(ctx, req, next)
@@ -85,7 +85,7 @@ func TestToolScopeMiddleware_PassThroughWhenSufficient(t *testing.T) {
 	req := &core.Request{
 		ID:     json.RawMessage(`1`),
 		Method: "tools/call",
-		Params: json.RawMessage(`{"name":"update_doc"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"name":"update_doc"}`)),
 	}
 
 	resp, err := mw(ctx, req, next)
@@ -109,7 +109,7 @@ func TestToolScopeMiddleware_NonToolsCallPassesThrough(t *testing.T) {
 	req := &core.Request{
 		ID:     json.RawMessage(`1`),
 		Method: "resources/read",
-		Params: json.RawMessage(`{"uri":"test://x"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"uri":"test://x"}`)),
 	}
 
 	_, err := mw(context.Background(), req, next)
@@ -132,7 +132,7 @@ func TestToolScopeMiddleware_UnknownToolPassesThrough(t *testing.T) {
 	req := &core.Request{
 		ID:     json.RawMessage(`1`),
 		Method: "tools/call",
-		Params: json.RawMessage(`{"name":"does_not_exist"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"name":"does_not_exist"}`)),
 	}
 
 	_, err := mw(withClaims(context.Background()), req, next)
@@ -158,7 +158,7 @@ func TestToolScopeMiddleware_NoRequiredScopesPassesThrough(t *testing.T) {
 	req := &core.Request{
 		ID:     json.RawMessage(`1`),
 		Method: "tools/call",
-		Params: json.RawMessage(`{"name":"public_tool"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"name":"public_tool"}`)),
 	}
 
 	_, err := mw(context.Background(), req, next)
@@ -184,7 +184,7 @@ func TestToolScopeMiddleware_AllRequiredScopesChecked(t *testing.T) {
 	req := &core.Request{
 		ID:     json.RawMessage(`1`),
 		Method: "tools/call",
-		Params: json.RawMessage(`{"name":"sensitive"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"name":"sensitive"}`)),
 	}
 
 	_, err := mw(ctx, req, next)
@@ -225,7 +225,7 @@ func TestToolScopeMiddleware_AcceptedScopesHierarchyPasses(t *testing.T) {
 	req := &core.Request{
 		ID:     json.RawMessage(`1`),
 		Method: "tools/call",
-		Params: json.RawMessage(`{"name":"read_repo"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"name":"read_repo"}`)),
 	}
 
 	_, err := mw(ctx, req, next)
@@ -257,7 +257,7 @@ func TestToolScopeMiddleware_AcceptedScopesEmptyFallsBackToAND(t *testing.T) {
 	req := &core.Request{
 		ID:     json.RawMessage(`1`),
 		Method: "tools/call",
-		Params: json.RawMessage(`{"name":"update_doc"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"name":"update_doc"}`)),
 	}
 
 	_, err := mw(ctx, req, next)
@@ -291,7 +291,7 @@ func TestToolScopeMiddleware_AcceptedScopesDeniedAdvertisesRequiredOnly(t *testi
 	req := &core.Request{
 		ID:     json.RawMessage(`1`),
 		Method: "tools/call",
-		Params: json.RawMessage(`{"name":"read_repo"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"name":"read_repo"}`)),
 	}
 
 	_, err := mw(ctx, req, next)
@@ -324,7 +324,7 @@ func TestToolScopeMiddleware_IncludeGrantedScopesOffByDefault(t *testing.T) {
 	req := &core.Request{
 		ID:     json.RawMessage(`1`),
 		Method: "tools/call",
-		Params: json.RawMessage(`{"name":"update_doc"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"name":"update_doc"}`)),
 	}
 
 	_, err := mw(ctx, req, next)
@@ -356,7 +356,7 @@ func TestToolScopeMiddleware_IncludeGrantedScopesUnionsInChallenge(t *testing.T)
 	req := &core.Request{
 		ID:     json.RawMessage(`1`),
 		Method: "tools/call",
-		Params: json.RawMessage(`{"name":"update_doc"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"name":"update_doc"}`)),
 	}
 
 	_, err := mw(ctx, req, next)
@@ -389,7 +389,7 @@ func TestToolScopeMiddleware_IncludeGrantedScopesEmptyGrantedSameAsOff(t *testin
 	req := &core.Request{
 		ID:     json.RawMessage(`1`),
 		Method: "tools/call",
-		Params: json.RawMessage(`{"name":"update_doc"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"name":"update_doc"}`)),
 	}
 
 	_, err := mw(ctx, req, next)

--- a/ext/otel/provider_test.go
+++ b/ext/otel/provider_test.go
@@ -234,7 +234,7 @@ func TestEndToEnd_ServerWithTracerProvider(t *testing.T) {
 	initParams := `{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"t","version":"1.0"}}`
 	_, err := srv.Dispatch(context.Background(), &core.Request{
 		ID: json.RawMessage(`1`), Method: "initialize",
-		Params: json.RawMessage(initParams),
+		Params: core.NewRawJSON(json.RawMessage(initParams)),
 	})
 	require.NoError(t, err)
 	_, _ = srv.Dispatch(context.Background(), &core.Request{Method: "notifications/initialized"})
@@ -244,7 +244,7 @@ func TestEndToEnd_ServerWithTracerProvider(t *testing.T) {
 	toolParams := `{"name":"echo","_meta":{"traceparent":"00-` + parentTID + `-` + parentSID + `-01"}}`
 	_, err = srv.Dispatch(context.Background(), &core.Request{
 		ID: json.RawMessage(`2`), Method: "tools/call",
-		Params: json.RawMessage(toolParams),
+		Params: core.NewRawJSON(json.RawMessage(toolParams)),
 	})
 	require.NoError(t, err)
 

--- a/ext/skills/provider.go
+++ b/ext/skills/provider.go
@@ -3,7 +3,6 @@ package skills
 import (
 	"context"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"io"
 	"io/fs"
@@ -625,7 +624,7 @@ func skillURIValidationMiddleware(ctx context.Context, req *core.Request, next s
 	var envelope struct {
 		URI string `json:"uri"`
 	}
-	if err := json.Unmarshal(req.Params, &envelope); err != nil {
+	if err := req.Params.Bind(&envelope); err != nil {
 		return next(ctx, req)
 	}
 	if !strings.HasPrefix(envelope.URI, Scheme+"://") {

--- a/ext/tasks/tasks.go
+++ b/ext/tasks/tasks.go
@@ -446,7 +446,7 @@ func taskV2Middleware(reg *server.Registry, rt *v2TaskRuntime, cfg Config) serve
 				ClientCapabilitiesRaw json.RawMessage `json:"io.modelcontextprotocol/clientCapabilities,omitempty"`
 			} `json:"_meta,omitempty"`
 		}
-		if err := json.Unmarshal(req.Params, &envelope); err != nil {
+		if err := req.Params.Bind(&envelope); err != nil {
 			return next(ctx, req)
 		}
 

--- a/ext/ui/app_host.go
+++ b/ext/ui/app_host.go
@@ -130,7 +130,7 @@ func (h *AppHost) CallAppTool(ctx context.Context, name string, args map[string]
 
 	resp, err := h.bridge.Send(ctx, &core.Request{
 		Method: "tools/call",
-		Params: params,
+		Params: core.NewRawJSON(params),
 	})
 	if err != nil {
 		return nil, err
@@ -215,7 +215,7 @@ func (h *AppHost) handleAppRequest(ctx context.Context, req *core.Request) *core
 	// was wired on the iframe side this returns zero and the span emits
 	// with no parent — same shape as auth running outside a traced
 	// dispatch.
-	tc := core.ExtractTraceContextFromParams(req.Params)
+	tc := core.ExtractTraceContextFromParams(req.Params.Raw())
 	if !tc.IsZero() {
 		ctx = core.WithTraceContext(ctx, tc)
 	}
@@ -224,7 +224,7 @@ func (h *AppHost) handleAppRequest(ctx context.Context, req *core.Request) *core
 	)
 	defer span.End()
 
-	callResult, err := h.client.Call(req.Method, json.RawMessage(req.Params))
+	callResult, err := h.client.Call(req.Method, req.Params.Raw())
 	if err != nil {
 		span.RecordError(err)
 		return &core.Response{

--- a/ext/ui/app_host_test.go
+++ b/ext/ui/app_host_test.go
@@ -135,7 +135,7 @@ func TestAppHost_HandleAppRequest_ToolCall(t *testing.T) {
 	req := &core.Request{
 		Method: "tools/call",
 		ID:     json.RawMessage(`42`),
-		Params: json.RawMessage(`{"name":"server_tool","arguments":{"x":1}}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"name":"server_tool","arguments":{"x":1}}`)),
 	}
 
 	// Verify the request handler receives the right method.
@@ -147,7 +147,7 @@ func TestAppHost_HandleAppRequest_ToolCall(t *testing.T) {
 			t.Errorf("method = %q, want tools/call", req.Method)
 		}
 		var params map[string]any
-		json.Unmarshal(req.Params, &params)
+		req.Params.Bind(&params)
 		if params["name"] != "server_tool" {
 			t.Errorf("tool name = %v, want server_tool", params["name"])
 		}
@@ -157,7 +157,7 @@ func TestAppHost_HandleAppRequest_ToolCall(t *testing.T) {
 		return &core.Response{ID: req.ID, Result: json.RawMessage(result)}
 	})
 
-	resp, err := bridge.SendToHost(context.Background(), req.Method, json.RawMessage(req.Params))
+	resp, err := bridge.SendToHost(context.Background(), req.Method, req.Params.Raw())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ext/ui/in_process_bridge.go
+++ b/ext/ui/in_process_bridge.go
@@ -112,7 +112,7 @@ func (b *InProcessAppBridge) handleToolsCall(req *core.Request) (*core.Response,
 		Name      string         `json:"name"`
 		Arguments map[string]any `json:"arguments"`
 	}
-	if err := json.Unmarshal(req.Params, &params); err != nil {
+	if err := req.Params.Bind(&params); err != nil {
 		return &core.Response{
 			ID:    req.ID,
 			Error: &core.Error{Code: core.ErrCodeInvalidParams, Message: fmt.Sprintf("invalid params: %v", err)},
@@ -165,7 +165,7 @@ func (b *InProcessAppBridge) SendToHost(ctx context.Context, method string, para
 
 	resp := handler(ctx, &core.Request{
 		Method: method,
-		Params: raw,
+		Params: core.NewRawJSON(raw),
 	})
 	return resp, nil
 }

--- a/ext/ui/in_process_bridge_test.go
+++ b/ext/ui/in_process_bridge_test.go
@@ -126,7 +126,7 @@ func TestBridge_Send_ToolsCall(t *testing.T) {
 	resp, err := b.Send(context.Background(), &core.Request{
 		Method: "tools/call",
 		ID:     json.RawMessage(`2`),
-		Params: params,
+		Params: core.NewRawJSON(params),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -155,7 +155,7 @@ func TestBridge_Send_UnknownTool(t *testing.T) {
 	resp, err := b.Send(context.Background(), &core.Request{
 		Method: "tools/call",
 		ID:     json.RawMessage(`3`),
-		Params: params,
+		Params: core.NewRawJSON(params),
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/server/auth_integration_test.go
+++ b/server/auth_integration_test.go
@@ -197,7 +197,7 @@ func TestExtensionRegistration(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      []byte(`1`),
 		Method:  "initialize",
-		Params:  []byte(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1"}}`),
+		Params:  core.NewRawJSON([]byte(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1"}}`)),
 	})
 	if dErr != nil {
 		t.Fatalf("dispatch transport error: %v", dErr)

--- a/server/completion_integration_test.go
+++ b/server/completion_integration_test.go
@@ -25,7 +25,7 @@ func TestCompletionComplete(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "completion/complete",
-		Params:  json.RawMessage(`{"ref":{"type":"ref/prompt","name":"my-prompt"},"argument":{"name":"arg1","value":"v"}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"ref":{"type":"ref/prompt","name":"my-prompt"},"argument":{"name":"arg1","value":"v"}}`)),
 	})
 
 	if resp == nil {
@@ -60,7 +60,7 @@ func TestCompletionCompleteNoHandler(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "completion/complete",
-		Params:  json.RawMessage(`{"ref":{"type":"ref/prompt","name":"unregistered"},"argument":{"name":"arg","value":""}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"ref":{"type":"ref/prompt","name":"unregistered"},"argument":{"name":"arg","value":""}}`)),
 	})
 
 	if resp == nil {
@@ -93,7 +93,7 @@ func TestCompletionCompleteBeforeInit(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "completion/complete",
-		Params:  json.RawMessage(`{"ref":{"type":"ref/prompt","name":"x"},"argument":{"name":"a","value":""}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"ref":{"type":"ref/prompt","name":"x"},"argument":{"name":"a","value":""}}`)),
 	})
 
 	if resp == nil {
@@ -118,7 +118,7 @@ func TestCompletionCapability(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "initialize",
-		Params:  json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)),
 	})
 
 	var result map[string]any
@@ -144,7 +144,7 @@ func TestCompletionCompleteResourceRef(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "completion/complete",
-		Params:  json.RawMessage(`{"ref":{"type":"ref/resource","uri":"file:///{path}"},"argument":{"name":"path","value":"/"}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"ref":{"type":"ref/resource","uri":"file:///{path}"},"argument":{"name":"path","value":"/"}}`)),
 	})
 
 	if resp.Error != nil {
@@ -170,7 +170,7 @@ func TestCompletionCompleteBadParams(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "completion/complete",
-		Params:  json.RawMessage(`not json`),
+		Params:  core.NewRawJSON(json.RawMessage(`not json`)),
 	})
 
 	if resp.Error == nil {
@@ -204,7 +204,7 @@ func TestCompletionMaxItems(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "completion/complete",
-		Params:  json.RawMessage(`{"ref":{"type":"ref/prompt","name":"big-prompt"},"argument":{"name":"x","value":""}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"ref":{"type":"ref/prompt","name":"big-prompt"},"argument":{"name":"x","value":""}}`)),
 	})
 
 	if resp.Error != nil {
@@ -244,7 +244,7 @@ func TestCompletionUnderLimit(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "completion/complete",
-		Params:  json.RawMessage(`{"ref":{"type":"ref/prompt","name":"small-prompt"},"argument":{"name":"x","value":""}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"ref":{"type":"ref/prompt","name":"small-prompt"},"argument":{"name":"x","value":""}}`)),
 	})
 
 	if resp.Error != nil {

--- a/server/concurrency_test.go
+++ b/server/concurrency_test.go
@@ -50,7 +50,7 @@ func TestConcurrentRequestsGetCorrectResponses(t *testing.T) {
 				JSONRPC: "2.0",
 				ID:      json.RawMessage(fmt.Sprintf(`%d`, idx+100)),
 				Method:  "tools/call",
-				Params:  params,
+				Params:  core.NewRawJSON(params),
 			})
 			results[idx] = resp
 		}(i)
@@ -93,7 +93,7 @@ func TestDuplicateRequestIDRejected(t *testing.T) {
 			JSONRPC: "2.0",
 			ID:      json.RawMessage(`"dup-id"`),
 			Method:  "tools/call",
-			Params:  json.RawMessage(`{"name":"slow"}`),
+			Params:  core.NewRawJSON(json.RawMessage(`{"name":"slow"}`)),
 		})
 	}()
 
@@ -105,7 +105,7 @@ func TestDuplicateRequestIDRejected(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`"dup-id"`),
 		Method:  "tools/call",
-		Params:  json.RawMessage(`{"name":"slow"}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"name":"slow"}`)),
 	})
 
 	require.NotNil(t, secondResp)

--- a/server/decode_bench_test.go
+++ b/server/decode_bench_test.go
@@ -49,7 +49,7 @@ func BenchmarkToolsCallDispatch(b *testing.B) {
 			name := fmt.Sprintf("schema=%v/args=%dKB", schema, sz>>10)
 			b.Run(name, func(b *testing.B) {
 				d := benchDispatcher(b, schema)
-				req := &core.Request{JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "tools/call", Params: benchToolsParams(sz)}
+				req := &core.Request{JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "tools/call", Params: core.NewRawJSON(benchToolsParams(sz))}
 				b.ReportAllocs()
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {

--- a/server/detach_integration_test.go
+++ b/server/detach_integration_test.go
@@ -64,14 +64,14 @@ func TestDetach_ToolSurvivesPerToolTimeout(t *testing.T) {
 
 	postJSONRPC(t, postURL, &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage("1"), Method: "initialize",
-		Params: json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"0"}}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"0"}}`)),
 	})
 	// Skip reading init response.
 	postJSONRPC(t, postURL, &core.Request{JSONRPC: "2.0", Method: "notifications/initialized"})
 
 	postJSONRPC(t, postURL, &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage("2"), Method: "tools/call",
-		Params: json.RawMessage(`{"name":"slow_detached","arguments":{}}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"name":"slow_detached","arguments":{}}`)),
 	})
 
 	// Wait for tool to finish.
@@ -130,13 +130,13 @@ func TestDetach_NonDetachedToolCancelledByTimeout(t *testing.T) {
 
 	postJSONRPC(t, postURL, &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage("1"), Method: "initialize",
-		Params: json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"0"}}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"0"}}`)),
 	})
 	postJSONRPC(t, postURL, &core.Request{JSONRPC: "2.0", Method: "notifications/initialized"})
 
 	postJSONRPC(t, postURL, &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage("2"), Method: "tools/call",
-		Params: json.RawMessage(`{"name":"slow_normal","arguments":{}}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"name":"slow_normal","arguments":{}}`)),
 	})
 
 	time.Sleep(300 * time.Millisecond)
@@ -181,7 +181,7 @@ func TestStreamableHTTP_DetachedToolPreservesRetryHint(t *testing.T) {
 	// Initialize.
 	initBody, _ := json.Marshal(&core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage("1"), Method: "initialize",
-		Params: json.RawMessage(`{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"t","version":"0"}}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"t","version":"0"}}`)),
 	})
 	resp, _ := http.Post(ts.URL+"/mcp", "application/json", strings.NewReader(string(initBody)))
 	sessionID := resp.Header.Get("Mcp-Session-Id")
@@ -208,7 +208,7 @@ func TestStreamableHTTP_DetachedToolPreservesRetryHint(t *testing.T) {
 	// POST tools/call.
 	callBody, _ := json.Marshal(&core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage("2"), Method: "tools/call",
-		Params: json.RawMessage(`{"name":"combo_tool","arguments":{}}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"name":"combo_tool","arguments":{}}`)),
 	})
 	postReq, _ := http.NewRequest("POST", ts.URL+"/mcp", strings.NewReader(string(callBody)))
 	postReq.Header.Set("Content-Type", "application/json")

--- a/server/devex_test.go
+++ b/server/devex_test.go
@@ -124,7 +124,7 @@ func TestStructuredContentInDispatch(t *testing.T) {
 	)
 
 	// Initialize
-	initReq := &core.Request{ID: json.RawMessage(`1`), Method: "initialize", Params: json.RawMessage(`{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)}
+	initReq := &core.Request{ID: json.RawMessage(`1`), Method: "initialize", Params: core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`))}
 	srv.Dispatch(context.Background(), initReq)
 	srv.Dispatch(context.Background(), &core.Request{Method: "notifications/initialized"})
 
@@ -132,7 +132,7 @@ func TestStructuredContentInDispatch(t *testing.T) {
 	resp, _ := srv.Dispatch(context.Background(), &core.Request{
 		ID:     json.RawMessage(`2`),
 		Method: "tools/call",
-		Params: json.RawMessage(`{"name":"structured"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"name":"structured"}`)),
 	})
 
 	require.NotNil(t, resp)

--- a/server/dispatch.go
+++ b/server/dispatch.go
@@ -379,14 +379,14 @@ func (d *Dispatcher) Dispatch(ctx context.Context, req *core.Request) (resp *cor
 
 	switch req.Method {
 	case "initialize":
-		return d.handleInitialize(id, req.Params)
+		return d.handleInitialize(id, req.Params.Raw())
 
 	case "notifications/initialized", "initialized":
 		d.initialized = true
 		return nil
 
 	case "notifications/cancelled":
-		d.handleCancelled(req.Params)
+		d.handleCancelled(req.Params.Raw())
 		return nil
 
 	case "notifications/roots/list_changed":
@@ -413,7 +413,7 @@ func (d *Dispatcher) Dispatch(ctx context.Context, req *core.Request) (resp *cor
 		// The version gate is resolved via protocol_features.go so all
 		// version-gated behavior lives in one table.
 		if d.protocolFeatures().StatelessMetaRequired && !d.allowLegacyOnDraft {
-			if _, err := core.DecodeRequestMetaFromRawJSON(req.ParamsLazy()); err != nil {
+			if _, err := core.DecodeRequestMetaFromRawJSON(&req.Params); err != nil {
 				field := "io.modelcontextprotocol/protocolVersion"
 				if mve, ok := err.(*core.MetaValidationError); ok && mve.Field != "_meta" {
 					field = "io.modelcontextprotocol/" + mve.Field
@@ -437,30 +437,30 @@ func (d *Dispatcher) Dispatch(ctx context.Context, req *core.Request) (resp *cor
 
 		switch req.Method {
 		case "tools/list":
-			return d.handleToolsList(id, req.Params)
+			return d.handleToolsList(id, req.Params.Raw())
 		case "tools/call":
-			return d.handleToolsCall(ctx, id, req.Params)
+			return d.handleToolsCall(ctx, id, req.Params.Raw())
 		case "resources/list":
-			return d.handleResourcesList(id, req.Params)
+			return d.handleResourcesList(id, req.Params.Raw())
 		case "resources/read":
-			return d.handleResourcesRead(ctx, id, req.Params)
+			return d.handleResourcesRead(ctx, id, req.Params.Raw())
 		case "resources/templates/list":
-			return d.handleResourcesTemplatesList(id, req.Params)
+			return d.handleResourcesTemplatesList(id, req.Params.Raw())
 		case "resources/subscribe":
-			return d.handleResourcesSubscribe(id, req.Params)
+			return d.handleResourcesSubscribe(id, req.Params.Raw())
 		case "resources/unsubscribe":
-			return d.handleResourcesUnsubscribe(id, req.Params)
+			return d.handleResourcesUnsubscribe(id, req.Params.Raw())
 		case "prompts/list":
-			return d.handlePromptsList(id, req.Params)
+			return d.handlePromptsList(id, req.Params.Raw())
 		case "prompts/get":
-			return d.handlePromptsGet(ctx, id, req.Params)
+			return d.handlePromptsGet(ctx, id, req.Params.Raw())
 		case "logging/setLevel":
-			return d.handleLoggingSetLevel(id, req.Params)
+			return d.handleLoggingSetLevel(id, req.Params.Raw())
 		case "completion/complete":
-			return d.handleCompletionComplete(ctx, id, req.Params)
+			return d.handleCompletionComplete(ctx, id, req.Params.Raw())
 		default:
 			if h, ok := d.customHandlers[req.Method]; ok {
-				return h(core.NewMethodContext(ctx), id, req.Params)
+				return h(core.NewMethodContext(ctx), id, req.Params.Raw())
 			}
 			return core.NewErrorResponse(id, core.ErrCodeMethodNotFound, "method not found: "+req.Method)
 		}

--- a/server/dispatch_test.go
+++ b/server/dispatch_test.go
@@ -18,7 +18,7 @@ func initDispatcher(d *Dispatcher) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`0`),
 		Method:  "initialize",
-		Params:  json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)),
 	})
 	d.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0",
@@ -66,7 +66,7 @@ func TestDispatchInitialize(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "initialize",
-		Params:  json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)),
 	})
 
 	if resp == nil {
@@ -168,7 +168,7 @@ func TestDispatchToolsCall(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`3`),
 		Method:  "tools/call",
-		Params:  json.RawMessage(`{"name":"echo","arguments":{"message":"hello"}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"name":"echo","arguments":{"message":"hello"}}`)),
 	})
 
 	if resp == nil {
@@ -251,7 +251,7 @@ func TestDispatchToolsCall_HandlerReturnsTypedVariants(t *testing.T) {
 				JSONRPC: "2.0",
 				ID:      json.RawMessage(`9`),
 				Method:  "tools/call",
-				Params:  json.RawMessage(`{"name":"typed_variant","arguments":{}}`),
+				Params:  core.NewRawJSON(json.RawMessage(`{"name":"typed_variant","arguments":{}}`)),
 			})
 			if resp == nil || resp.Error != nil {
 				t.Fatalf("unexpected error: %+v", resp)
@@ -276,7 +276,7 @@ func TestDispatchToolsCallUnknown(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`4`),
 		Method:  "tools/call",
-		Params:  json.RawMessage(`{"name":"nonexistent","arguments":{}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"name":"nonexistent","arguments":{}}`)),
 	})
 
 	if resp == nil {
@@ -296,7 +296,7 @@ func TestDispatchToolsCallBadParams(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`5`),
 		Method:  "tools/call",
-		Params:  json.RawMessage(`not json`),
+		Params:  core.NewRawJSON(json.RawMessage(`not json`)),
 	})
 
 	if resp == nil {
@@ -362,7 +362,7 @@ func TestDispatchToolsCallHandlerError(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`10`),
 		Method:  "tools/call",
-		Params:  json.RawMessage(`{"name":"failing","arguments":{}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"name":"failing","arguments":{}}`)),
 	})
 
 	if resp == nil {
@@ -431,7 +431,7 @@ func TestDispatchInitializeVersion2025(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "initialize",
-		Params:  json.RawMessage(`{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)),
 	})
 
 	if resp == nil {
@@ -464,7 +464,7 @@ func TestDispatchInitializeUnsupportedVersion(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "initialize",
-		Params:  json.RawMessage(`{"protocolVersion":"1999-01-01","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"protocolVersion":"1999-01-01","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)),
 	})
 
 	if resp == nil {
@@ -497,7 +497,7 @@ func TestDispatchInitializeMissingProtocolVersion(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "initialize",
-		Params:  json.RawMessage(`{"capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)),
 	})
 	if resp == nil || resp.Error == nil {
 		t.Fatalf("expected error for missing protocolVersion, got %+v", resp)
@@ -537,7 +537,7 @@ func TestDispatchInitializeStoresClientInfo(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "initialize",
-		Params:  json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{"roots":{"listChanged":true}},"clientInfo":{"name":"my-client","version":"2.0"}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{"roots":{"listChanged":true}},"clientInfo":{"name":"my-client","version":"2.0"}}`)),
 	})
 
 	if d.clientInfo.Name != "my-client" {
@@ -567,7 +567,7 @@ func TestDispatchBeforeInitialized(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "initialize",
-		Params:  json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)),
 	})
 
 	resp := d.Dispatch(context.Background(), &core.Request{
@@ -602,7 +602,7 @@ func TestDispatchToolsCallBeforeAnyInit(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "tools/call",
-		Params:  json.RawMessage(`{"name":"echo","arguments":{}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"name":"echo","arguments":{}}`)),
 	})
 
 	if resp == nil {
@@ -644,7 +644,7 @@ func TestDispatchLoggingSetLevel(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`10`),
 		Method:  "logging/setLevel",
-		Params:  json.RawMessage(`{"level":"warning"}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"level":"warning"}`)),
 	})
 
 	if resp == nil {
@@ -675,7 +675,7 @@ func TestDispatchLoggingSetLevelAllLevels(t *testing.T) {
 				JSONRPC: "2.0",
 				ID:      json.RawMessage(`1`),
 				Method:  "logging/setLevel",
-				Params:  json.RawMessage(`{"level":"` + level + `"}`),
+				Params:  core.NewRawJSON(json.RawMessage(`{"level":"` + level + `"}`)),
 			})
 			if resp.Error != nil {
 				t.Fatalf("logging/setLevel(%q) failed: %s", level, resp.Error.Message)
@@ -692,7 +692,7 @@ func TestDispatchLoggingSetLevelInvalid(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`11`),
 		Method:  "logging/setLevel",
-		Params:  json.RawMessage(`{"level":"trace"}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"level":"trace"}`)),
 	})
 
 	if resp == nil {
@@ -714,7 +714,7 @@ func TestDispatchLoggingSetLevelBeforeInit(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "logging/setLevel",
-		Params:  json.RawMessage(`{"level":"info"}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"level":"info"}`)),
 	})
 
 	if resp == nil {
@@ -737,7 +737,7 @@ func TestDispatchLoggingCapability(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "initialize",
-		Params:  json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)),
 	})
 
 	if resp.Error != nil {
@@ -776,7 +776,7 @@ func TestDispatchToolsCallWithProgressToken(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "tools/call",
-		Params:  json.RawMessage(`{"name":"progress_tool","arguments":{},"_meta":{"progressToken":"my-token"}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"name":"progress_tool","arguments":{},"_meta":{"progressToken":"my-token"}}`)),
 	})
 
 	if gotToken != "my-token" {
@@ -802,7 +802,7 @@ func TestDispatchToolsCallWithoutProgressToken(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "tools/call",
-		Params:  json.RawMessage(`{"name":"no_progress","arguments":{}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"name":"no_progress","arguments":{}}`)),
 	})
 
 	if gotToken != nil {
@@ -995,7 +995,7 @@ func TestInitializeWithClientExtensions(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "initialize",
-		Params: json.RawMessage(`{
+		Params: core.NewRawJSON(json.RawMessage(`{
 			"protocolVersion": "2024-11-05",
 			"capabilities": {
 				"extensions": {
@@ -1005,7 +1005,7 @@ func TestInitializeWithClientExtensions(t *testing.T) {
 				}
 			},
 			"clientInfo": {"name": "test-client", "version": "1.0"}
-		}`),
+		}`)),
 	})
 	if resp.Error != nil {
 		t.Fatalf("initialize error: %s", resp.Error.Message)

--- a/server/dynamic_test.go
+++ b/server/dynamic_test.go
@@ -96,7 +96,7 @@ func TestRemoveTool(t *testing.T) {
 	// Tool works
 	resp := d.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "tools/call",
-		Params: json.RawMessage(`{"name":"ephemeral"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"name":"ephemeral"}`)),
 	})
 	if resp.Error != nil {
 		t.Fatalf("tool call before removal failed: %s", resp.Error.Message)
@@ -116,7 +116,7 @@ func TestRemoveTool(t *testing.T) {
 	// tools/call should fail
 	resp = d.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`3`), Method: "tools/call",
-		Params: json.RawMessage(`{"name":"ephemeral"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"name":"ephemeral"}`)),
 	})
 	if resp.Error == nil {
 		t.Fatal("tool call after removal should fail")
@@ -233,7 +233,7 @@ func TestRemoveResource(t *testing.T) {
 
 	resp := d.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "resources/read",
-		Params: json.RawMessage(`{"uri":"test://temp"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"uri":"test://temp"}`)),
 	})
 	if resp.Error == nil {
 		t.Fatal("resources/read should fail after removal")
@@ -303,7 +303,7 @@ func TestRemovePrompt(t *testing.T) {
 
 	resp := d.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "prompts/get",
-		Params: json.RawMessage(`{"name":"temp-prompt"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"name":"temp-prompt"}`)),
 	})
 	if resp.Error == nil {
 		t.Fatal("prompts/get should fail after removal")
@@ -393,7 +393,7 @@ func TestListChangedCapabilityAdvertised(t *testing.T) {
 		t.Helper()
 		resp := d.Dispatch(context.Background(), &core.Request{
 			JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "initialize",
-			Params: json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`),
+			Params: core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)),
 		})
 		raw, _ := core.MarshalJSON(resp.Result)
 		var result struct {

--- a/server/exec_test.go
+++ b/server/exec_test.go
@@ -152,7 +152,7 @@ func TestToolExec_RegisterAndDispatch(t *testing.T) {
 
 	resp := d.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "tools/call",
-		Params: json.RawMessage(`{"name":"greet"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"name":"greet"}`)),
 	})
 	if resp.Error != nil {
 		t.Fatalf("tools/call failed: %s", resp.Error.Message)

--- a/server/file_validation_test.go
+++ b/server/file_validation_test.go
@@ -152,7 +152,7 @@ func TestFileInputCapGating_StripsKeywordWithoutCap(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "initialize",
-		Params:  json.RawMessage(`{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)),
 	}
 	resp, _ := srv.Dispatch(context.Background(), initReq)
 	require.Nil(t, resp.Error, "initialize should succeed")
@@ -206,7 +206,7 @@ func TestFileInputCapGating_PreservesKeywordWithCap(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "initialize",
-		Params:  json.RawMessage(`{"protocolVersion":"2025-11-25","capabilities":{"fileInputs":{}},"clientInfo":{"name":"test","version":"1.0"}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2025-11-25","capabilities":{"fileInputs":{}},"clientInfo":{"name":"test","version":"1.0"}}`)),
 	}
 	resp, _ := srv.Dispatch(context.Background(), initReq)
 	require.Nil(t, resp.Error, "initialize should succeed")

--- a/server/header_validation.go
+++ b/server/header_validation.go
@@ -51,7 +51,7 @@ func extractRoutingName(req *core.Request) (field, value string, ok bool) {
 		var p struct {
 			Name string `json:"name"`
 		}
-		if err := json.Unmarshal(req.Params, &p); err != nil {
+		if err := req.Params.Bind(&p); err != nil {
 			return "name", "", true
 		}
 		return "name", p.Name, true
@@ -59,7 +59,7 @@ func extractRoutingName(req *core.Request) (field, value string, ok bool) {
 		var p struct {
 			URI string `json:"uri"`
 		}
-		if err := json.Unmarshal(req.Params, &p); err != nil {
+		if err := req.Params.Bind(&p); err != nil {
 			return "uri", "", true
 		}
 		return "uri", p.URI, true
@@ -70,7 +70,7 @@ func extractRoutingName(req *core.Request) (field, value string, ok bool) {
 		var p struct {
 			Name string `json:"name"`
 		}
-		if err := json.Unmarshal(req.Params, &p); err != nil {
+		if err := req.Params.Bind(&p); err != nil {
 			return "name", "", true
 		}
 		return "name", p.Name, true
@@ -80,7 +80,7 @@ func extractRoutingName(req *core.Request) (field, value string, ok bool) {
 		var p struct {
 			TaskID string `json:"taskId"`
 		}
-		if err := json.Unmarshal(req.Params, &p); err != nil {
+		if err := req.Params.Bind(&p); err != nil {
 			return "taskId", "", true
 		}
 		return "taskId", p.TaskID, true

--- a/server/header_validation_integration_test.go
+++ b/server/header_validation_integration_test.go
@@ -53,7 +53,7 @@ func initDraftSession(t *testing.T, url string) string {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "initialize",
-		Params:  json.RawMessage(`{"protocolVersion":"2026-07-28","capabilities":{},"clientInfo":{"name":"draft-test","version":"1.0"}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2026-07-28","capabilities":{},"clientInfo":{"name":"draft-test","version":"1.0"}}`)),
 	})
 	if err != nil {
 		t.Fatalf("initialize POST failed: %v", err)
@@ -174,7 +174,7 @@ func TestHeaderValidation_DraftSession_MismatchedToolName(t *testing.T) {
 
 	resp, err := postWithHeaders(ts.URL+"/mcp", sessionID,
 		&core.Request{JSONRPC: "2.0", ID: json.RawMessage(`2`), Method: "tools/call",
-			Params: json.RawMessage(`{"name":"echo","arguments":{"message":"hi"}}`)},
+			Params: core.NewRawJSON(json.RawMessage(`{"name":"echo","arguments":{"message":"hi"}}`))},
 		map[string]string{"Mcp-Method": "tools/call", "Mcp-Name": "wrong_tool"})
 	if err != nil {
 		t.Fatalf("POST: %v", err)

--- a/server/header_validation_test.go
+++ b/server/header_validation_test.go
@@ -16,7 +16,7 @@ func makeReq(t *testing.T, method string, params any) *core.Request {
 		if err != nil {
 			t.Fatalf("marshal params: %v", err)
 		}
-		r.Params = raw
+		r.Params = core.NewRawJSON(raw)
 	}
 	return r
 }

--- a/server/method_handler_test.go
+++ b/server/method_handler_test.go
@@ -27,7 +27,7 @@ func TestCustomMethod_Dispatch(t *testing.T) {
 	testutil.InitHandshake(srv)
 	resp, _ := srv.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`99`), Method: "custom/echo",
-		Params: json.RawMessage(`{"msg":"hello"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"msg":"hello"}`)),
 	})
 	require.NotNil(t, resp)
 	require.Nil(t, resp.Error)

--- a/server/metrics_middleware.go
+++ b/server/metrics_middleware.go
@@ -117,7 +117,7 @@ func newMetricsMiddleware(mp core.MeterProvider) Middleware {
 		var toolName string
 		var start time.Time
 		if isToolCall {
-			toolName = parseToolCallName(req.Params)
+			toolName = parseToolCallName(req.Params.Raw())
 			start = time.Now()
 		}
 

--- a/server/metrics_middleware_test.go
+++ b/server/metrics_middleware_test.go
@@ -222,7 +222,7 @@ func TestMetrics_NonToolCall_SkipsToolMetrics(t *testing.T) {
 	req := &core.Request{
 		ID:     json.RawMessage(`1`),
 		Method: "tools/list",
-		Params: json.RawMessage(`{}`),
+		Params: core.NewRawJSON(json.RawMessage(`{}`)),
 	}
 	_, err := srv.dispatchWithNotifyAndRequest(srv.dispatcher, context.Background(), nil, nil, nil, req)
 	require.NoError(t, err)
@@ -300,7 +300,7 @@ func TestMetrics_TransportError_RecordsInternalErrorCode(t *testing.T) {
 	transportErr := errors.New("simulated transport error")
 	resp, err := mw(context.Background(), &core.Request{
 		Method: "tools/call",
-		Params: json.RawMessage(`{"name":"x"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"name":"x"}`)),
 	}, func(context.Context, *core.Request) (*core.Response, error) {
 		return nil, transportErr
 	})

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -167,7 +167,7 @@ func ToolCallLogger(logger *log.Logger) Middleware {
 		var params struct {
 			Name string `json:"name"`
 		}
-		_ = json.Unmarshal(req.Params, &params)
+		_ = req.Params.Bind(&params)
 
 		resp, err := next(ctx, req)
 

--- a/server/middleware_test.go
+++ b/server/middleware_test.go
@@ -38,14 +38,14 @@ func TestMiddleware_SeesAllRequests(t *testing.T) {
 	)
 
 	// Initialize
-	initReq := &core.Request{ID: json.RawMessage(`1`), Method: "initialize", Params: json.RawMessage(`{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)}
+	initReq := &core.Request{ID: json.RawMessage(`1`), Method: "initialize", Params: core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`))}
 	srv.Dispatch(context.Background(), initReq)
 
 	// Initialized notification
 	srv.Dispatch(context.Background(), &core.Request{Method: "notifications/initialized"})
 
 	// Tool call
-	toolReq := &core.Request{ID: json.RawMessage(`2`), Method: "tools/call", Params: json.RawMessage(`{"name":"echo"}`)}
+	toolReq := &core.Request{ID: json.RawMessage(`2`), Method: "tools/call", Params: core.NewRawJSON(json.RawMessage(`{"name":"echo"}`))}
 	srv.Dispatch(context.Background(), toolReq)
 
 	assert.Contains(t, methods, "initialize")
@@ -75,7 +75,7 @@ func TestMiddleware_ChainOrder(t *testing.T) {
 	srv := NewServer(core.ServerInfo{Name: "mw-test", Version: "1.0"},
 		WithMiddleware(mw1, mw2))
 
-	initReq := &core.Request{ID: json.RawMessage(`1`), Method: "initialize", Params: json.RawMessage(`{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)}
+	initReq := &core.Request{ID: json.RawMessage(`1`), Method: "initialize", Params: core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`))}
 	srv.Dispatch(context.Background(), initReq)
 
 	// mw1 is outermost: runs before mw2 on request, after mw2 on response
@@ -109,12 +109,12 @@ func TestMiddleware_ShortCircuit(t *testing.T) {
 	)
 
 	// Initialize first
-	initReq := &core.Request{ID: json.RawMessage(`1`), Method: "initialize", Params: json.RawMessage(`{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)}
+	initReq := &core.Request{ID: json.RawMessage(`1`), Method: "initialize", Params: core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`))}
 	srv.Dispatch(context.Background(), initReq)
 	srv.Dispatch(context.Background(), &core.Request{Method: "notifications/initialized"})
 
 	// Tool call should be blocked
-	toolReq := &core.Request{ID: json.RawMessage(`2`), Method: "tools/call", Params: json.RawMessage(`{"name":"echo"}`)}
+	toolReq := &core.Request{ID: json.RawMessage(`2`), Method: "tools/call", Params: core.NewRawJSON(json.RawMessage(`{"name":"echo"}`))}
 	resp, err := srv.Dispatch(context.Background(), toolReq)
 	require.NoError(t, err)
 
@@ -144,7 +144,7 @@ func TestMiddleware_AccessContext(t *testing.T) {
 
 	// Use dispatchWithNotify to go through the middleware chain with claims
 	claims := &core.Claims{Subject: "test-user", Scopes: []string{"read"}}
-	initReq := &core.Request{ID: json.RawMessage(`1`), Method: "initialize", Params: json.RawMessage(`{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)}
+	initReq := &core.Request{ID: json.RawMessage(`1`), Method: "initialize", Params: core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`))}
 	d := srv.dispatcher
 	srv.dispatchWithNotify(d, context.Background(), claims, nil, initReq)
 
@@ -177,12 +177,12 @@ func TestMiddleware_ToolTimeoutPreserved(t *testing.T) {
 	)
 
 	// Initialize
-	initReq := &core.Request{ID: json.RawMessage(`1`), Method: "initialize", Params: json.RawMessage(`{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)}
+	initReq := &core.Request{ID: json.RawMessage(`1`), Method: "initialize", Params: core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`))}
 	srv.Dispatch(context.Background(), initReq)
 	srv.Dispatch(context.Background(), &core.Request{Method: "notifications/initialized"})
 
 	// Tool call should timeout
-	toolReq := &core.Request{ID: json.RawMessage(`2`), Method: "tools/call", Params: json.RawMessage(`{"name":"slow"}`)}
+	toolReq := &core.Request{ID: json.RawMessage(`2`), Method: "tools/call", Params: core.NewRawJSON(json.RawMessage(`{"name":"slow"}`))}
 	resp, err := srv.Dispatch(context.Background(), toolReq)
 	require.NoError(t, err)
 
@@ -200,7 +200,7 @@ func TestLoggingMiddleware(t *testing.T) {
 	srv := NewServer(core.ServerInfo{Name: "mw-test", Version: "1.0"},
 		WithMiddleware(LoggingMiddleware(logger)))
 
-	initReq := &core.Request{ID: json.RawMessage(`1`), Method: "initialize", Params: json.RawMessage(`{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)}
+	initReq := &core.Request{ID: json.RawMessage(`1`), Method: "initialize", Params: core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`))}
 	srv.Dispatch(context.Background(), initReq)
 
 	output := buf.String()

--- a/server/prompt_integration_test.go
+++ b/server/prompt_integration_test.go
@@ -92,7 +92,7 @@ func TestPromptsGetSimple(t *testing.T) {
 	d := testPromptDispatcher()
 	resp := d.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "prompts/get",
-		Params: json.RawMessage(`{"name":"simple"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"name":"simple"}`)),
 	})
 	if resp.Error != nil {
 		t.Fatalf("error: %s", resp.Error.Message)
@@ -113,7 +113,7 @@ func TestPromptsGetWithArgs(t *testing.T) {
 	d := testPromptDispatcher()
 	resp := d.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "prompts/get",
-		Params: json.RawMessage(`{"name":"greet","arguments":{"name":"World"}}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"name":"greet","arguments":{"name":"World"}}`)),
 	})
 	if resp.Error != nil {
 		t.Fatalf("error: %s", resp.Error.Message)
@@ -131,7 +131,7 @@ func TestPromptsGetUnknown(t *testing.T) {
 	d := testPromptDispatcher()
 	resp := d.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "prompts/get",
-		Params: json.RawMessage(`{"name":"nonexistent"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"name":"nonexistent"}`)),
 	})
 	if resp.Error == nil {
 		t.Fatal("expected error for unknown prompt")
@@ -147,7 +147,7 @@ func TestPromptsCapabilities(t *testing.T) {
 	d := testPromptDispatcher()
 	resp := d.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "initialize",
-		Params: json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)),
 	})
 	var result map[string]any
 	resp.ResultAs(&result)

--- a/server/prompt_schema_test.go
+++ b/server/prompt_schema_test.go
@@ -89,7 +89,7 @@ func TestPromptsGetPassesTypedArguments(t *testing.T) {
 
 	resp := d.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "prompts/get",
-		Params: json.RawMessage(`{"name":"q","arguments":{"limit":42,"verbose":true}}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"name":"q","arguments":{"limit":42,"verbose":true}}`)),
 	})
 	if resp.Error != nil {
 		t.Fatalf("error: %s", resp.Error.Message)

--- a/server/recover_test.go
+++ b/server/recover_test.go
@@ -24,7 +24,7 @@ func Test_Issue420_PanicHandlerReturnsError(t *testing.T) {
 
 	resp := d.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "tools/call",
-		Params: json.RawMessage(`{"name":"boom","arguments":{}}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"name":"boom","arguments":{}}`)),
 	})
 	if resp == nil || resp.Error == nil {
 		t.Fatalf("expected an error response from a panicking handler, got %+v", resp)
@@ -51,7 +51,7 @@ func Test_Issue420_PanicNotificationNoResponse(t *testing.T) {
 	// tools/call with no ID (notification shape) — panic must recover to nil.
 	resp := d.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", Method: "tools/call",
-		Params: json.RawMessage(`{"name":"boom","arguments":{}}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"name":"boom","arguments":{}}`)),
 	})
 	if resp != nil {
 		t.Errorf("expected nil for a panicking notification, got %+v", resp)

--- a/server/registry_overwrite_test.go
+++ b/server/registry_overwrite_test.go
@@ -140,7 +140,7 @@ func TestAddResourceTemplate_OverwriteUpdatesHandler(t *testing.T) {
 
 	resp := d.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "resources/read",
-		Params: json.RawMessage(`{"uri":"test://items/42"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"uri":"test://items/42"}`)),
 	})
 	if resp.Error != nil {
 		t.Fatalf("resources/read failed: %s", resp.Error.Message)

--- a/server/reinit_test.go
+++ b/server/reinit_test.go
@@ -16,7 +16,7 @@ func Test_Issue421_DuplicateInitializeRejected(t *testing.T) {
 
 	first := d.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "initialize",
-		Params: json.RawMessage(`{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"alice","version":"1.0"}}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"alice","version":"1.0"}}`)),
 	})
 	if first == nil || first.Error != nil {
 		t.Fatalf("first initialize should succeed, got %+v", first)
@@ -29,7 +29,7 @@ func Test_Issue421_DuplicateInitializeRejected(t *testing.T) {
 	// Second initialize: different version + different client identity.
 	second := d.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`2`), Method: "initialize",
-		Params: json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"mallory","version":"9.9"}}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"mallory","version":"9.9"}}`)),
 	})
 	if second == nil || second.Error == nil || second.Error.Code != core.ErrCodeInvalidRequest {
 		t.Fatalf("expected -32600 InvalidRequest on duplicate initialize, got %+v", second)
@@ -51,11 +51,11 @@ func Test_Issue421_ReinitializeAllowedWithOption(t *testing.T) {
 
 	d.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "initialize",
-		Params: json.RawMessage(`{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"alice","version":"1.0"}}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"alice","version":"1.0"}}`)),
 	})
 	second := d.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`2`), Method: "initialize",
-		Params: json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"alice2","version":"2.0"}}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"alice2","version":"2.0"}}`)),
 	})
 	if second == nil || second.Error != nil {
 		t.Fatalf("re-initialize should succeed with allowReinitialize, got %+v", second)

--- a/server/resource_integration_test.go
+++ b/server/resource_integration_test.go
@@ -87,7 +87,7 @@ func TestResourcesRead(t *testing.T) {
 	d := testResourceDispatcher()
 	resp := d.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "resources/read",
-		Params: json.RawMessage(`{"uri":"test://doc"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"uri":"test://doc"}`)),
 	})
 	if resp.Error != nil {
 		t.Fatalf("error: %s", resp.Error.Message)
@@ -107,7 +107,7 @@ func TestResourcesReadBinary(t *testing.T) {
 	d := testResourceDispatcher()
 	resp := d.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "resources/read",
-		Params: json.RawMessage(`{"uri":"test://binary"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"uri":"test://binary"}`)),
 	})
 	if resp.Error != nil {
 		t.Fatalf("error: %s", resp.Error.Message)
@@ -125,7 +125,7 @@ func TestResourcesReadUnknown(t *testing.T) {
 	d := testResourceDispatcher()
 	resp := d.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "resources/read",
-		Params: json.RawMessage(`{"uri":"test://nonexistent"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"uri":"test://nonexistent"}`)),
 	})
 	if resp.Error == nil {
 		t.Fatal("expected error for unknown resource")
@@ -163,7 +163,7 @@ func TestResourcesTemplateRead(t *testing.T) {
 	d := testResourceDispatcher()
 	resp := d.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "resources/read",
-		Params: json.RawMessage(`{"uri":"test://items/42"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"uri":"test://items/42"}`)),
 	})
 	if resp.Error != nil {
 		t.Fatalf("error: %s", resp.Error.Message)
@@ -182,7 +182,7 @@ func TestResourcesCapabilities(t *testing.T) {
 	// Re-initialize to check capabilities (testResourceDispatcher already initializes)
 	resp := d.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "initialize",
-		Params: json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)),
 	})
 	var result map[string]any
 	resp.ResultAs(&result)
@@ -220,7 +220,7 @@ func TestResourcesSubscribe(t *testing.T) {
 	d, _ := testSubscriptionDispatcher()
 	resp := d.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "resources/subscribe",
-		Params: json.RawMessage(`{"uri":"test://doc"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"uri":"test://doc"}`)),
 	})
 	if resp.Error != nil {
 		t.Fatalf("resources/subscribe error: %s", resp.Error.Message)
@@ -239,12 +239,12 @@ func TestResourcesUnsubscribe(t *testing.T) {
 	// Subscribe first
 	d.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "resources/subscribe",
-		Params: json.RawMessage(`{"uri":"test://doc"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"uri":"test://doc"}`)),
 	})
 	// Unsubscribe
 	resp := d.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`2`), Method: "resources/unsubscribe",
-		Params: json.RawMessage(`{"uri":"test://doc"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"uri":"test://doc"}`)),
 	})
 	if resp.Error != nil {
 		t.Fatalf("resources/unsubscribe error: %s", resp.Error.Message)
@@ -269,7 +269,7 @@ func TestResourcesSubscribeNotInitialized(t *testing.T) {
 	// Do NOT call initDispatcher — session is not initialized
 	resp := d.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "resources/subscribe",
-		Params: json.RawMessage(`{"uri":"test://doc"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"uri":"test://doc"}`)),
 	})
 	if resp.Error == nil {
 		t.Fatal("expected error for subscribe before initialization")
@@ -285,7 +285,7 @@ func TestResourcesSubscribeCapabilities(t *testing.T) {
 	d, _ := testSubscriptionDispatcher()
 	resp := d.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "initialize",
-		Params: json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)),
 	})
 	var result map[string]any
 	resp.ResultAs(&result)
@@ -309,7 +309,7 @@ func TestResourcesSubscribeCapabilitiesDisabled(t *testing.T) {
 	d := testResourceDispatcher() // uses default dispatcher without subscriptions
 	resp := d.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "initialize",
-		Params: json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)),
 	})
 	var result map[string]any
 	resp.ResultAs(&result)
@@ -348,7 +348,7 @@ func TestResourcesSubscribeNotification(t *testing.T) {
 	// Subscribe
 	resp := d.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "resources/subscribe",
-		Params: json.RawMessage(`{"uri":"test://doc"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"uri":"test://doc"}`)),
 	})
 	if resp.Error != nil {
 		t.Fatalf("subscribe error: %s", resp.Error.Message)
@@ -391,13 +391,13 @@ func TestResourcesUnsubscribeStopsNotification(t *testing.T) {
 	// Subscribe
 	d.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "resources/subscribe",
-		Params: json.RawMessage(`{"uri":"test://doc"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"uri":"test://doc"}`)),
 	})
 
 	// Unsubscribe
 	d.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`2`), Method: "resources/unsubscribe",
-		Params: json.RawMessage(`{"uri":"test://doc"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"uri":"test://doc"}`)),
 	})
 
 	// Trigger — should NOT deliver
@@ -450,11 +450,11 @@ func TestResourcesSubscribeMultipleSessions(t *testing.T) {
 	// Both subscribe
 	d1.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "resources/subscribe",
-		Params: json.RawMessage(`{"uri":"test://shared"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"uri":"test://shared"}`)),
 	})
 	d2.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "resources/subscribe",
-		Params: json.RawMessage(`{"uri":"test://shared"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"uri":"test://shared"}`)),
 	})
 
 	// Trigger
@@ -510,7 +510,7 @@ func TestResourcesReadMeta(t *testing.T) {
 	// Resource with _meta
 	resp := d.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "resources/read",
-		Params: json.RawMessage(`{"uri":"ui://app/view"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"uri":"ui://app/view"}`)),
 	})
 	if resp.Error != nil {
 		t.Fatalf("error: %s", resp.Error.Message)
@@ -553,7 +553,7 @@ func TestResourcesReadMeta(t *testing.T) {
 	// Resource without _meta
 	resp2 := d.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`2`), Method: "resources/read",
-		Params: json.RawMessage(`{"uri":"test://plain"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"uri":"test://plain"}`)),
 	})
 	if resp2.Error != nil {
 		t.Fatalf("error: %s", resp2.Error.Message)

--- a/server/resource_notify_test.go
+++ b/server/resource_notify_test.go
@@ -76,14 +76,14 @@ func TestNotifyResourceUpdatedFromHandler(t *testing.T) {
 	// d1 subscribes to "test://res". d2 does not.
 	d1.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "resources/subscribe",
-		Params: json.RawMessage(`{"uri":"test://res"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"uri":"test://res"}`)),
 	})
 
 	// Call the tool via d1's dispatch context. The tool handler calls
 	// core.NotifyResourceUpdated(ctx, "test://res").
 	resp, dErr := srv.dispatchWith(d1, context.Background(), nil, &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`2`), Method: "tools/call",
-		Params: json.RawMessage(`{"name":"mutate","arguments":{}}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"name":"mutate","arguments":{}}`)),
 	})
 	if dErr != nil {
 		t.Fatalf("dispatch transport error: %v", dErr)

--- a/server/roots_test.go
+++ b/server/roots_test.go
@@ -150,7 +150,7 @@ func newRootsHarness(t *testing.T, clientRootsCap bool) *rootsHarness {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`0`),
 		Method:  "initialize",
-		Params:  paramsRaw,
+		Params:  core.NewRawJSON(paramsRaw),
 	})
 	require.NoError(t, err)
 	require.NotNil(t, initResp)

--- a/server/roots_timeout_test.go
+++ b/server/roots_timeout_test.go
@@ -64,7 +64,7 @@ func TestRoots_CustomFetchTimeout(t *testing.T) {
 	})
 	initResp, err := xport.Call(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`0`), Method: "initialize",
-		Params: paramsRaw,
+		Params: core.NewRawJSON(paramsRaw),
 	})
 	require.NoError(t, err)
 	require.Nil(t, initResp.Error)

--- a/server/schema_validation_test.go
+++ b/server/schema_validation_test.go
@@ -30,7 +30,7 @@ func newSchemaTestServer(t *testing.T, opts ...server.Option) *server.Server {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "initialize",
-		Params:  json.RawMessage(`{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)),
 	}
 	resp, _ := srv.Dispatch(context.Background(), initReq)
 	require.Nil(t, resp.Error, "initialize should succeed")
@@ -56,7 +56,7 @@ func callTool(t *testing.T, srv *server.Server, name string, args any) *core.Res
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`2`),
 		Method:  "tools/call",
-		Params:  params,
+		Params:  core.NewRawJSON(params),
 	}
 	resp, _ := srv.Dispatch(context.Background(), req)
 	return resp
@@ -74,7 +74,7 @@ func getPrompt(t *testing.T, srv *server.Server, name string, args map[string]an
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`3`),
 		Method:  "prompts/get",
-		Params:  params,
+		Params:  core.NewRawJSON(params),
 	}
 	resp, _ := srv.Dispatch(context.Background(), req)
 	return resp
@@ -243,7 +243,7 @@ func TestToolValidateNullArguments(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`4`),
 		Method:  "tools/call",
-		Params:  json.RawMessage(`{"name":"noargs","arguments":null}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"name":"noargs","arguments":null}`)),
 	}
 	resp, _ := srv.Dispatch(context.Background(), req)
 	require.Nil(t, resp.Error, "null arguments should validate against object schema")

--- a/server/server_subscription_caps_test.go
+++ b/server/server_subscription_caps_test.go
@@ -27,7 +27,7 @@ func subscribeReq(id int, uri string) *core.Request {
 	params, _ := json.Marshal(struct {
 		URI string `json:"uri"`
 	}{URI: uri})
-	return &core.Request{JSONRPC: "2.0", ID: idRaw, Method: "resources/subscribe", Params: params}
+	return &core.Request{JSONRPC: "2.0", ID: idRaw, Method: "resources/subscribe", Params: core.NewRawJSON(params)}
 }
 
 func unsubscribeReq(id int, uri string) *core.Request {
@@ -35,7 +35,7 @@ func unsubscribeReq(id int, uri string) *core.Request {
 	params, _ := json.Marshal(struct {
 		URI string `json:"uri"`
 	}{URI: uri})
-	return &core.Request{JSONRPC: "2.0", ID: idRaw, Method: "resources/unsubscribe", Params: params}
+	return &core.Request{JSONRPC: "2.0", ID: idRaw, Method: "resources/unsubscribe", Params: core.NewRawJSON(params)}
 }
 
 func makeCapTestServer(t *testing.T, opts ...Option) *Server {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -20,7 +20,7 @@ func initServer(srv *Server) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`0`),
 		Method:  "initialize",
-		Params:  json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)),
 	})
 	srv.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0",
@@ -42,7 +42,7 @@ func TestServerDispatch(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "tools/call",
-		Params:  json.RawMessage(`{"name":"greet","arguments":{}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"name":"greet","arguments":{}}`)),
 	})
 	if dErr != nil {
 		t.Fatalf("dispatch transport error: %v", dErr)
@@ -80,7 +80,7 @@ func TestServerToolTimeout(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "tools/call",
-		Params:  json.RawMessage(`{"name":"slow","arguments":{}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"name":"slow","arguments":{}}`)),
 	})
 	if dErr != nil {
 		t.Fatalf("dispatch transport error: %v", dErr)

--- a/server/session_timeout_test.go
+++ b/server/session_timeout_test.go
@@ -113,7 +113,7 @@ func TestSessionTimeoutPausesDuringActiveRequest(t *testing.T) {
 	// Call slow tool — takes 300ms, timeout is 50ms
 	resp, err := streamablePost(ts.URL+"/mcp", sessionID, &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "tools/call",
-		Params: json.RawMessage(`{"name":"slow"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"name":"slow"}`)),
 	})
 	if err != nil {
 		t.Fatalf("slow tool call failed: %v", err)

--- a/server/sse_resumption_test.go
+++ b/server/sse_resumption_test.go
@@ -76,7 +76,7 @@ func initializeSSESession(t *testing.T, postURL string, reader *gohttp.SSEEventR
 	t.Helper()
 	resp, err := postJSON(postURL, &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "initialize",
-		Params: json.RawMessage(`{"protocolVersion":"2024-11-05","clientInfo":{"name":"test","version":"1.0"}}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2024-11-05","clientInfo":{"name":"test","version":"1.0"}}`)),
 	})
 	if err != nil {
 		t.Fatalf("initialize POST failed: %v", err)
@@ -140,7 +140,7 @@ func TestSSESessionGracePeriod(t *testing.T) {
 	// Make a tool call WITHOUT re-initializing — proves session state survived.
 	postJSON(postURL2, &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`10`), Method: "tools/call",
-		Params: json.RawMessage(`{"name":"echo","arguments":{"message":"after-reconnect"}}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"name":"echo","arguments":{"message":"after-reconnect"}}`)),
 	})
 	ev, err := readSSEEvent(reader2)
 	if err != nil {
@@ -231,7 +231,7 @@ func TestSSELastEventIDReplay(t *testing.T) {
 	// Make a tool call to generate events with IDs.
 	postJSON(postURL, &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`10`), Method: "tools/call",
-		Params: json.RawMessage(`{"name":"echo","arguments":{"message":"stored-event"}}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"name":"echo","arguments":{"message":"stored-event"}}`)),
 	})
 	readSSEEvent(reader) // consume tool response
 

--- a/server/sse_retry_test.go
+++ b/server/sse_retry_test.go
@@ -85,7 +85,7 @@ func TestSSE_EmitRetryHintReachesClient(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage("1"),
 		Method:  "initialize",
-		Params:  json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"0"}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"0"}}`)),
 	})
 	if _, err := readSSEEventWithRetry(reader); err != nil {
 		t.Fatalf("read init response: %v", err)
@@ -99,7 +99,7 @@ func TestSSE_EmitRetryHintReachesClient(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage("2"),
 		Method:  "tools/call",
-		Params:  json.RawMessage(`{"name":"long_running","arguments":{}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"name":"long_running","arguments":{}}`)),
 	})
 
 	// Read until we see retry: 30000. SendRetry emits a bare event (no
@@ -142,7 +142,7 @@ func TestSSE_EmitRetryHintNoOpOnNonSSEPath(t *testing.T) {
 	initDispatcher(d)
 	resp := d.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage("1"), Method: "tools/call",
-		Params: json.RawMessage(`{"name":"t","arguments":{}}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"name":"t","arguments":{}}`)),
 	})
 	if resp.Error != nil {
 		t.Fatalf("unexpected error: %s", resp.Error.Message)

--- a/server/stateless/dispatch.go
+++ b/server/stateless/dispatch.go
@@ -78,7 +78,7 @@ func (d *Dispatcher) Dispatch(ctx context.Context, req *core.Request) (*core.Res
 	}
 
 	// Every other method requires a valid _meta envelope.
-	meta, err := core.DecodeRequestMetaFromRawJSON(req.ParamsLazy())
+	meta, err := core.DecodeRequestMetaFromRawJSON(&req.Params)
 	if err != nil {
 		// MetaValidationError carries the specific missing field for diagnostics.
 		return core.NewErrorResponse(id, core.ErrCodeInvalidParams, err.Error()), nil
@@ -124,21 +124,21 @@ func (d *Dispatcher) Dispatch(ctx context.Context, req *core.Request) (*core.Res
 	case "server/discover":
 		return d.handleDiscover(id), nil
 	case "tools/list":
-		return d.handleToolsList(id, req.Params), nil
+		return d.handleToolsList(id, req.Params.Raw()), nil
 	case "tools/call":
-		return d.handleToolsCall(ctx, id, req.Params)
+		return d.handleToolsCall(ctx, id, req.Params.Raw())
 	case "resources/list":
-		return d.handleResourcesList(id, req.Params), nil
+		return d.handleResourcesList(id, req.Params.Raw()), nil
 	case "resources/read":
-		return d.handleResourcesRead(ctx, id, req.Params), nil
+		return d.handleResourcesRead(ctx, id, req.Params.Raw()), nil
 	case "resources/templates/list":
-		return d.handleResourcesTemplatesList(id, req.Params), nil
+		return d.handleResourcesTemplatesList(id, req.Params.Raw()), nil
 	case "prompts/list":
-		return d.handlePromptsList(id, req.Params), nil
+		return d.handlePromptsList(id, req.Params.Raw()), nil
 	case "prompts/get":
-		return d.handlePromptsGet(ctx, id, req.Params)
+		return d.handlePromptsGet(ctx, id, req.Params.Raw())
 	case "completion/complete":
-		return d.handleCompletionComplete(ctx, id, req.Params), nil
+		return d.handleCompletionComplete(ctx, id, req.Params.Raw()), nil
 	default:
 		// Any other method (custom JSON-RPC verbs registered via
 		// Server.HandleMethod — events/poll, events/list,

--- a/server/stateless/dispatch_autherror_test.go
+++ b/server/stateless/dispatch_autherror_test.go
@@ -29,7 +29,7 @@ func TestDispatch_MiddlewareAuthErrorPropagates(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage("1"),
 		Method:  "tools/call",
-		Params:  validMetaParams(t),
+		Params:  core.NewRawJSON(validMetaParams(t)),
 	}
 	resp, err := d.Dispatch(context.Background(), req)
 
@@ -64,7 +64,7 @@ func TestDispatch_MiddlewareAuthErrorPropagatesForCustomMethod(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage("2"),
 		Method:  "events/poll",
-		Params:  validMetaParams(t),
+		Params:  core.NewRawJSON(validMetaParams(t)),
 	}
 	resp, err := d.Dispatch(context.Background(), req)
 

--- a/server/stateless/dispatch_test.go
+++ b/server/stateless/dispatch_test.go
@@ -101,7 +101,7 @@ func TestDispatch_RemovedMethodReturns32601(t *testing.T) {
 				JSONRPC: "2.0",
 				ID:      json.RawMessage("1"),
 				Method:  method,
-				Params:  validMetaParams(t),
+				Params:  core.NewRawJSON(validMetaParams(t)),
 			}
 			resp, _ := d.Dispatch(context.Background(), req)
 			if resp == nil || resp.Error == nil {
@@ -124,7 +124,7 @@ func TestDispatch_MissingMetaReturns32602(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage("2"),
 		Method:  "tools/list",
-		Params:  json.RawMessage(`{}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{}`)),
 	}
 	resp, _ := d.Dispatch(context.Background(), req)
 	if resp == nil || resp.Error == nil {
@@ -152,7 +152,7 @@ func TestDispatch_UnsupportedVersionReturns32022(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage("3"),
 		Method:  "tools/list",
-		Params:  bad,
+		Params:  core.NewRawJSON(bad),
 	}
 	resp, _ := d.Dispatch(context.Background(), req)
 	if resp == nil || resp.Error == nil {
@@ -207,14 +207,14 @@ func TestDispatch_ResourcesReadAppliesReadCacheDefaults(t *testing.T) {
 			JSONRPC: "2.0",
 			ID:      json.RawMessage("9"),
 			Method:  "resources/read",
-			Params: json.RawMessage(`{
+			Params: core.NewRawJSON(json.RawMessage(`{
 				"uri": "file://x",
 				"_meta": {
 					"io.modelcontextprotocol/protocolVersion": "2026-07-28",
 					"io.modelcontextprotocol/clientInfo": {"name": "c", "version": "1"},
 					"io.modelcontextprotocol/clientCapabilities": {}
 				}
-			}`),
+			}`)),
 		}
 	}
 	decode := func(t *testing.T, resp *core.Response) core.ResourceResult {
@@ -273,7 +273,7 @@ func TestDispatch_ServerDiscoverShape(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage("4"),
 		Method:  "server/discover",
-		Params:  validMetaParams(t),
+		Params:  core.NewRawJSON(validMetaParams(t)),
 	}
 	resp, _ := d.Dispatch(context.Background(), req)
 	if resp == nil || resp.Error != nil {
@@ -330,7 +330,7 @@ func TestDispatch_ToolsCallMissingCapReturns32003(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage("5"),
 		Method:  "tools/call",
-		Params:  params,
+		Params:  core.NewRawJSON(params),
 	}
 	resp, _ := d.Dispatch(context.Background(), req)
 	if resp == nil || resp.Error == nil {
@@ -360,7 +360,7 @@ func TestDispatch_UnknownMethodReturns32601(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage("6"),
 		Method:  "frobnicate",
-		Params:  validMetaParams(t),
+		Params:  core.NewRawJSON(validMetaParams(t)),
 	}
 	resp, _ := d.Dispatch(context.Background(), req)
 	if resp == nil || resp.Error == nil || resp.Error.Code != core.ErrCodeMethodNotFound {

--- a/server/stateless/handlers.go
+++ b/server/stateless/handlers.go
@@ -57,7 +57,7 @@ func (d *Dispatcher) handleToolsCall(ctx context.Context, id json.RawMessage, pa
 		JSONRPC: "2.0",
 		ID:      id,
 		Method:  "tools/call",
-		Params:  params,
+		Params:  core.NewRawJSON(params),
 	}
 	if resp, err, ok := d.Backend.InvokeWithMiddleware(ctx, req); ok {
 		return resp, err
@@ -194,7 +194,7 @@ func (d *Dispatcher) handlePromptsGet(ctx context.Context, id json.RawMessage, p
 		JSONRPC: "2.0",
 		ID:      id,
 		Method:  "prompts/get",
-		Params:  params,
+		Params:  core.NewRawJSON(params),
 	}
 	if resp, err, ok := d.Backend.InvokeWithMiddleware(ctx, req); ok {
 		return resp, err

--- a/server/stateless/loglevel_gate_test.go
+++ b/server/stateless/loglevel_gate_test.go
@@ -92,7 +92,7 @@ func TestRequestMeta_LogLevelThreadingExposedToHandlers(t *testing.T) {
 				JSONRPC: "2.0",
 				ID:      json.RawMessage("1"),
 				Method:  "tools/call",
-				Params:  params,
+				Params:  core.NewRawJSON(params),
 			}
 			resp, _ := d.Dispatch(context.Background(), req)
 			if resp == nil || resp.Error != nil {

--- a/server/stateless_backend.go
+++ b/server/stateless_backend.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -260,7 +259,7 @@ func (b *statelessBackend) InvokeWithMiddleware(ctx context.Context, req *core.R
 			return b.callPromptForStateless(ctx, req), nil
 		default:
 			if h, ok := b.s.dispatcher.customHandlers[req.Method]; ok {
-				return h(core.NewMethodContext(ctx), req.ID, req.Params), nil
+				return h(core.NewMethodContext(ctx), req.ID, req.Params.Raw()), nil
 			}
 			return core.NewErrorResponse(req.ID, core.ErrCodeMethodNotFound,
 				"method not found: "+req.Method), nil
@@ -305,7 +304,7 @@ func (b *statelessBackend) InvokeWithMiddleware(ctx context.Context, req *core.R
 // upstream of this call so we don't re-validate here.
 func (b *statelessBackend) callToolForStateless(ctx context.Context, req *core.Request) *core.Response {
 	var env toolsCallEnvelope
-	if err := json.Unmarshal(req.Params, &env); err != nil {
+	if err := req.Params.Bind(&env); err != nil {
 		return core.NewErrorResponse(req.ID, core.ErrCodeInvalidParams,
 			"invalid tools/call params: "+err.Error())
 	}
@@ -394,7 +393,7 @@ func (b *statelessBackend) callToolForStateless(ctx context.Context, req *core.R
 // exercises it.
 func (b *statelessBackend) callPromptForStateless(ctx context.Context, req *core.Request) *core.Response {
 	var env promptsGetEnvelope
-	if err := json.Unmarshal(req.Params, &env); err != nil {
+	if err := req.Params.Bind(&env); err != nil {
 		return core.NewErrorResponse(req.ID, core.ErrCodeInvalidParams,
 			"invalid prompts/get params: "+err.Error())
 	}

--- a/server/stateless_detect.go
+++ b/server/stateless_detect.go
@@ -79,7 +79,7 @@ func detectWireKind(r *http.Request, body []byte, req *core.Request, mode statel
 	}
 
 	// Signal 3: params._meta carries a protocolVersion (stateless envelope).
-	if hasStatelessMetaProtocolVersion(req.Params) {
+	if hasStatelessMetaProtocolVersion(req.Params.Raw()) {
 		return wireStateless
 	}
 

--- a/server/streamable_retry_test.go
+++ b/server/streamable_retry_test.go
@@ -50,7 +50,7 @@ func TestStreamableHTTP_EmitRetryHintReachesGetSSEStream(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage("1"),
 		Method:  "initialize",
-		Params:  json.RawMessage(`{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"t","version":"0"}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"t","version":"0"}}`)),
 	}
 	initBody, _ := json.Marshal(initReq)
 	resp, err := http.Post(ts.URL+"/mcp", "application/json", strings.NewReader(string(initBody)))
@@ -96,7 +96,7 @@ func TestStreamableHTTP_EmitRetryHintReachesGetSSEStream(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage("2"),
 		Method:  "tools/call",
-		Params:  json.RawMessage(`{"name":"slow_tool","arguments":{}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"name":"slow_tool","arguments":{}}`)),
 	}
 	callBody, _ := json.Marshal(callReq)
 	postReq, _ := http.NewRequest("POST", ts.URL+"/mcp", strings.NewReader(string(callBody)))
@@ -152,7 +152,7 @@ func TestStreamableHTTP_EmitRetryHintNoOpWithoutGetStream(t *testing.T) {
 	// Initialize.
 	initBody, _ := json.Marshal(&core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage("1"), Method: "initialize",
-		Params: json.RawMessage(`{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"t","version":"0"}}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"t","version":"0"}}`)),
 	})
 	resp, _ := http.Post(ts.URL+"/mcp", "application/json", strings.NewReader(string(initBody)))
 	sessionID := resp.Header.Get("Mcp-Session-Id")
@@ -170,7 +170,7 @@ func TestStreamableHTTP_EmitRetryHintNoOpWithoutGetStream(t *testing.T) {
 	// Use JSON Accept so the response is synchronous.
 	callBody, _ := json.Marshal(&core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage("2"), Method: "tools/call",
-		Params: json.RawMessage(`{"name":"hint_tool","arguments":{}}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"name":"hint_tool","arguments":{}}`)),
 	})
 	postReq, _ := http.NewRequest("POST", ts.URL+"/mcp", strings.NewReader(string(callBody)))
 	postReq.Header.Set("Content-Type", "application/json")

--- a/server/streamable_stateless.go
+++ b/server/streamable_stateless.go
@@ -39,7 +39,7 @@ func (t *streamableTransport) handleStatelessPost(w http.ResponseWriter, r *http
 	// (some clients only stamp _meta); _meta-only is fine. Mismatch
 	// when both are present → -32020 HeaderMismatch.
 	if hdrVer := r.Header.Get(mcpProtocolVersionHeader); hdrVer != "" {
-		metaVer := peekMetaProtocolVersion(req.Params)
+		metaVer := peekMetaProtocolVersion(req.Params.Raw())
 		if mismatchResp := statelessVersionMismatch(id, hdrVer, metaVer); mismatchResp != nil {
 			writeStatelessResponse(w, mismatchResp)
 			return
@@ -187,7 +187,7 @@ func (t *streamableTransport) handleStatelessPostSSE(w http.ResponseWriter, r *h
 
 	// Header / _meta version cross-check (mirrored from handleStatelessPost).
 	if hdrVer := r.Header.Get(mcpProtocolVersionHeader); hdrVer != "" {
-		metaVer := peekMetaProtocolVersion(req.Params)
+		metaVer := peekMetaProtocolVersion(req.Params.Raw())
 		if mismatchResp := statelessVersionMismatch(req.ID, hdrVer, metaVer); mismatchResp != nil {
 			writeHeaderMismatch(w, mismatchResp)
 			return

--- a/server/streamable_stateless_test.go
+++ b/server/streamable_stateless_test.go
@@ -343,7 +343,7 @@ func TestStatelessRouting_DetectionPriorities(t *testing.T) {
 				p, _ := json.Marshal(validMetaParams())
 				params = p
 			}
-			req := &core.Request{Method: c.method, Params: params}
+			req := &core.Request{Method: c.method, Params: core.NewRawJSON(params)}
 			got := detectWireKind(r, nil, req, stateless.ModeDual)
 			if got != c.want {
 				t.Errorf("detectWireKind = %v, want %v", got, c.want)

--- a/server/streamable_subscriptions.go
+++ b/server/streamable_subscriptions.go
@@ -234,7 +234,7 @@ func (t *streamableTransport) handleStatelessSubscribe(w http.ResponseWriter, r 
 
 	// Header / _meta cross-check (same precedence as handleStatelessPost).
 	if hdrVer := r.Header.Get(mcpProtocolVersionHeader); hdrVer != "" {
-		metaVer := peekMetaProtocolVersion(req.Params)
+		metaVer := peekMetaProtocolVersion(req.Params.Raw())
 		if resp := statelessVersionMismatch(id, hdrVer, metaVer); resp != nil {
 			writeStatelessResponse(w, resp)
 			return
@@ -242,14 +242,14 @@ func (t *streamableTransport) handleStatelessSubscribe(w http.ResponseWriter, r 
 	}
 
 	// _meta envelope validation.
-	if _, err := core.DecodeRequestMeta(req.Params); err != nil {
+	if _, err := core.DecodeRequestMetaFromRawJSON(&req.Params); err != nil {
 		writeStatelessResponse(w, core.NewErrorResponse(id, core.ErrCodeInvalidParams, err.Error()))
 		return
 	}
 
 	// Filter decode.
 	var params stateless.SubscribeParams
-	if err := json.Unmarshal(req.Params, &params); err != nil {
+	if err := req.Params.Bind(&params); err != nil {
 		writeStatelessResponse(w, core.NewErrorResponse(id, core.ErrCodeInvalidParams,
 			"invalid subscriptions/listen params: "+err.Error()))
 		return

--- a/server/streamable_transport.go
+++ b/server/streamable_transport.go
@@ -552,7 +552,7 @@ func (t *streamableTransport) handleInitialize(w http.ResponseWriter, r *http.Re
 		var bp struct {
 			ProtocolVersion string `json:"protocolVersion"`
 		}
-		if err := json.Unmarshal(req.Params, &bp); err == nil && bp.ProtocolVersion != "" && bp.ProtocolVersion != hdrVer {
+		if err := req.Params.Bind(&bp); err == nil && bp.ProtocolVersion != "" && bp.ProtocolVersion != hdrVer {
 			http.Error(w, fmt.Sprintf(
 				"MCP-Protocol-Version header (%s) does not match initialize body protocolVersion (%s)",
 				hdrVer, bp.ProtocolVersion), http.StatusBadRequest)
@@ -583,7 +583,7 @@ func (t *streamableTransport) handleInitialize(w http.ResponseWriter, r *http.Re
 
 	// Success: create session and return with Mcp-Session-Id.
 	// Check if client suggested a session ID via _suggestedSessionId.
-	sessionID := t.resolveSessionID(req.Params)
+	sessionID := t.resolveSessionID(req.Params.Raw())
 	dispatcher.sessionID = sessionID
 	// Bind authenticated principal to session — prevents hijacking.
 	// Uses the encoded form (Tenant + "/" + Subject) so two realms

--- a/server/streamable_transport_test.go
+++ b/server/streamable_transport_test.go
@@ -66,7 +66,7 @@ func streamableInit(t *testing.T, url string) string {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "initialize",
-		Params:  json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)),
 	})
 	if err != nil {
 		t.Fatalf("initialize POST failed: %v", err)
@@ -113,7 +113,7 @@ func TestStreamableInitAndToolCall(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`2`),
 		Method:  "tools/call",
-		Params:  json.RawMessage(`{"name":"echo","arguments":{"message":"hello"}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"name":"echo","arguments":{"message":"hello"}}`)),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -149,7 +149,7 @@ func TestStreamableInitReturnsSessionID(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "initialize",
-		Params:  json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -389,7 +389,7 @@ func TestStreamableAuthRequired(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "initialize",
-		Params:  json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -415,7 +415,7 @@ func TestStreamableMaxSessions(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "initialize",
-		Params:  json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -486,7 +486,7 @@ func TestStreamableCustomPrefix(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "initialize",
-		Params:  json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -533,7 +533,7 @@ func streamableInitWithLogging(t *testing.T, url string) string {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`99`),
 		Method:  "logging/setLevel",
-		Params:  json.RawMessage(`{"level":"debug"}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"level":"debug"}`)),
 	})
 	if err != nil {
 		t.Fatalf("logging/setLevel failed: %v", err)
@@ -589,7 +589,7 @@ func TestStreamableSSEResponse(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "tools/call",
-		Params:  json.RawMessage(`{"name":"log_tool","arguments":{}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"name":"log_tool","arguments":{}}`)),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -636,7 +636,7 @@ func TestStreamableSSEFallback(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "tools/call",
-		Params:  json.RawMessage(`{"name":"log_tool","arguments":{}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"name":"log_tool","arguments":{}}`)),
 	})
 	httpReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/mcp", bytes.NewReader(body))
 	httpReq.Header.Set("Content-Type", "application/json")
@@ -671,7 +671,7 @@ func TestStreamableSSENotificationOrder(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "tools/call",
-		Params:  json.RawMessage(`{"name":"log_tool","arguments":{}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"name":"log_tool","arguments":{}}`)),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -717,7 +717,7 @@ func TestStreamableSSENoNotifications(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "tools/call",
-		Params:  json.RawMessage(`{"name":"echo","arguments":{}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"name":"echo","arguments":{}}`)),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -748,7 +748,7 @@ func TestStreamableDNSRebindingRejectsInvalidOrigin(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "initialize",
-		Params:  json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)),
 	})
 	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/mcp", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -778,7 +778,7 @@ func TestStreamableDNSRebindingAcceptsLocalhost(t *testing.T) {
 				JSONRPC: "2.0",
 				ID:      json.RawMessage(`1`),
 				Method:  "initialize",
-				Params:  json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`),
+				Params:  core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)),
 			})
 			req, _ := http.NewRequest(http.MethodPost, ts.URL+"/mcp", bytes.NewReader(body))
 			req.Header.Set("Content-Type", "application/json")

--- a/server/tasks_v1.go
+++ b/server/tasks_v1.go
@@ -194,7 +194,7 @@ func taskMiddleware(reg *Registry, rt *taskRuntime, cfg TasksConfigV1) Middlewar
 				ProgressToken any `json:"progressToken"`
 			} `json:"_meta"`
 		}
-		if err := json.Unmarshal(req.Params, &envelope); err != nil {
+		if err := req.Params.Bind(&envelope); err != nil {
 			return next(ctx, req) // let dispatch handle the parse error
 		}
 

--- a/server/trace_middleware.go
+++ b/server/trace_middleware.go
@@ -153,8 +153,8 @@ func traceMiddleware(tp core.TracerProvider) Middleware {
 	return func(ctx context.Context, req *core.Request, next MiddlewareFunc) (*core.Response, error) {
 		// Shared per-request RawJSON: every _meta reader below (trace context,
 		// baggage, tracelink) and the dispatch-path SEP-2575 gate scan Params
-		// once via req.ParamsLazy() instead of once per reader (issue 733).
-		params := req.ParamsLazy()
+		// once via &req.Params instead of once per reader (issue 733).
+		params := &req.Params
 
 		tc := core.ExtractTraceContextFromRawJSON(params)
 		if tc.IsZero() {
@@ -182,7 +182,7 @@ func traceMiddleware(tp core.TracerProvider) Middleware {
 			attrs = append(attrs, core.Attribute{Key: "mcp.session.id", Value: sid})
 		}
 		if req.Method == "tools/call" {
-			if name := parseToolCallName(req.Params); name != "" {
+			if name := parseToolCallName(req.Params.Raw()); name != "" {
 				attrs = append(attrs, core.Attribute{Key: "mcp.tool.name", Value: name})
 			}
 		}
@@ -197,7 +197,7 @@ func traceMiddleware(tp core.TracerProvider) Middleware {
 		// unambiguous from the URI alone; non-manifest URIs surface as
 		// `mcp.skill.uri` only.
 		if req.Method == "resources/read" || req.Method == "resources/directory/read" {
-			if uri := parseResourceReadURI(req.Params); uri != "" {
+			if uri := parseResourceReadURI(req.Params.Raw()); uri != "" {
 				attrs = append(attrs, core.Attribute{Key: "mcp.resource.uri", Value: uri})
 				if path, file, ok := decomposeSkillURI(uri); ok {
 					attrs = append(attrs, core.Attribute{Key: "mcp.skill.uri", Value: uri})

--- a/server/trace_middleware_test.go
+++ b/server/trace_middleware_test.go
@@ -142,7 +142,7 @@ func dispatchToolsCall(t *testing.T, srv *Server, ctx context.Context, params st
 	req := &core.Request{
 		ID:     json.RawMessage(`1`),
 		Method: "tools/call",
-		Params: json.RawMessage(params),
+		Params: core.NewRawJSON(json.RawMessage(params)),
 	}
 	return srv.dispatchWithNotifyAndRequest(srv.dispatcher, ctx, nil, notify, request, req)
 }
@@ -321,7 +321,7 @@ func dispatchResourcesRead(t *testing.T, srv *Server, ctx context.Context, param
 	req := &core.Request{
 		ID:     json.RawMessage(`1`),
 		Method: "resources/read",
-		Params: json.RawMessage(params),
+		Params: core.NewRawJSON(json.RawMessage(params)),
 	}
 	return srv.dispatchWithNotifyAndRequest(srv.dispatcher, ctx, nil, nil, nil, req)
 }

--- a/server/transport_test.go
+++ b/server/transport_test.go
@@ -157,7 +157,7 @@ func TestSSEInitAndToolCall(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "initialize",
-		Params:  json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -201,7 +201,7 @@ func TestSSEInitAndToolCall(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`2`),
 		Method:  "tools/call",
-		Params:  json.RawMessage(`{"name":"echo","arguments":{"message":"hello"}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"name":"echo","arguments":{"message":"hello"}}`)),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -272,7 +272,7 @@ func TestSSENotification(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "initialize",
-		Params:  json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -516,7 +516,7 @@ func TestSSELoggingNotification(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`1`),
 		Method:  "initialize",
-		Params:  json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -542,7 +542,7 @@ func TestSSELoggingNotification(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`2`),
 		Method:  "logging/setLevel",
-		Params:  json.RawMessage(`{"level":"debug"}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"level":"debug"}`)),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -558,7 +558,7 @@ func TestSSELoggingNotification(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`3`),
 		Method:  "tools/call",
-		Params:  json.RawMessage(`{"name":"log_emitter","arguments":{}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"name":"log_emitter","arguments":{}}`)),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -655,7 +655,7 @@ func TestSSELoggingFilteredByLevel(t *testing.T) {
 	// Init handshake
 	resp, _ := postJSON(postURL, &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "initialize",
-		Params: json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)),
 	})
 	resp.Body.Close()
 	readSSEEvent(reader) // consume init response
@@ -666,7 +666,7 @@ func TestSSELoggingFilteredByLevel(t *testing.T) {
 	// Set level to error (high threshold)
 	resp, _ = postJSON(postURL, &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`2`), Method: "logging/setLevel",
-		Params: json.RawMessage(`{"level":"error"}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"level":"error"}`)),
 	})
 	resp.Body.Close()
 	readSSEEvent(reader) // consume setLevel response
@@ -674,7 +674,7 @@ func TestSSELoggingFilteredByLevel(t *testing.T) {
 	// Call tool that emits debug (should be filtered)
 	resp, _ = postJSON(postURL, &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`3`), Method: "tools/call",
-		Params: json.RawMessage(`{"name":"debug_logger","arguments":{}}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"name":"debug_logger","arguments":{}}`)),
 	})
 	resp.Body.Close()
 
@@ -732,7 +732,7 @@ func TestSSEProgressNotification(t *testing.T) {
 	// Initialize
 	resp, _ := postJSON(postURL, &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "initialize",
-		Params: json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)),
 	})
 	resp.Body.Close()
 	readSSEEvent(reader)
@@ -743,7 +743,7 @@ func TestSSEProgressNotification(t *testing.T) {
 	// Call tool with progress token
 	resp, _ = postJSON(postURL, &core.Request{
 		JSONRPC: "2.0", ID: json.RawMessage(`2`), Method: "tools/call",
-		Params: json.RawMessage(`{"name":"progress_tool","arguments":{},"_meta":{"progressToken":"test-token"}}`),
+		Params: core.NewRawJSON(json.RawMessage(`{"name":"progress_tool","arguments":{},"_meta":{"progressToken":"test-token"}}`)),
 	})
 	resp.Body.Close()
 

--- a/testutil/testserver.go
+++ b/testutil/testserver.go
@@ -109,7 +109,7 @@ func InitHandshake(d interface {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`0`),
 		Method:  "initialize",
-		Params:  json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`),
+		Params:  core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`)),
 	})
 	d.Dispatch(context.Background(), &core.Request{
 		JSONRPC: "2.0",
@@ -124,13 +124,13 @@ func ToolCallRequest(name string, args map[string]any) *core.Request {
 		params["arguments"] = args
 	}
 	raw, _ := json.Marshal(params)
-	return &core.Request{JSONRPC: "2.0", ID: json.RawMessage(`99`), Method: "tools/call", Params: raw}
+	return &core.Request{JSONRPC: "2.0", ID: json.RawMessage(`99`), Method: "tools/call", Params: core.NewRawJSON(raw)}
 }
 
 // ResourceReadRequest builds a JSON-RPC resources/read request for direct dispatch testing.
 func ResourceReadRequest(uri string) *core.Request {
 	raw, _ := json.Marshal(map[string]string{"uri": uri})
-	return &core.Request{JSONRPC: "2.0", ID: json.RawMessage(`99`), Method: "resources/read", Params: raw}
+	return &core.Request{JSONRPC: "2.0", ID: json.RawMessage(`99`), Method: "resources/read", Params: core.NewRawJSON(raw)}
 }
 
 // PromptGetRequest builds a JSON-RPC prompts/get request for direct dispatch testing.
@@ -140,7 +140,7 @@ func PromptGetRequest(name string, args map[string]string) *core.Request {
 		params["arguments"] = args
 	}
 	raw, _ := json.Marshal(params)
-	return &core.Request{JSONRPC: "2.0", ID: json.RawMessage(`99`), Method: "prompts/get", Params: raw}
+	return &core.Request{JSONRPC: "2.0", ID: json.RawMessage(`99`), Method: "prompts/get", Params: core.NewRawJSON(raw)}
 }
 
 // ForAllTransports runs fn as a subtest against all 4 MCP transport types:


### PR DESCRIPTION
## What changes

Final slice of issue 733. `core.Request.Params` flips from `json.RawMessage`
to `core.RawJSON` — the typed, parse-once wrapper landed in slices 1–2 (PRs 868,
869). A notification is a `Request` with no ID, so its params flip too. The
transitional `ParamsLazy()` bridge is removed; `req.Params` **is** the cached
parse now.

This is the ergonomics payoff of 733: handlers read params through
`req.Params.Bind(&typed)` / `.Meta()` / `.Field(key)` instead of hand-rolling
`json.Unmarshal` plumbing, and every metadata reader on one request shares a
single parse instead of each re-scanning the bytes. Wire output is
byte-identical — `Request.MarshalJSON` preserves param omission (JSON-RPC
forbids `"params":null`).

Breaking for anyone constructing or reading `core.Request.Params` directly.
This is a deliberate 0.4.0 breaking-bundle item; mcpkit has no external clients
to migrate.

## Reviewer's guide

Read in this order:
1. [core/jsonrpc.go](https://github.com/panyam/mcpkit/pull/870/files#diff-f9f4f09be0f88717867046128a5e4338f60aaea6764fda9b9a6c95c4089797f4) — start here. The field flip + new `Request.MarshalJSON` (preserves param omission) + removed `paramsLazy`/`ParamsLazy()`.
2. [core/rawjson.go](https://github.com/panyam/mcpkit/pull/870/files#diff-e9e6118a172aee7cb2583cce6f5baa0bb34bfd27cbab66ceb4fa116fad46de3e) — the `RawJSON` type (unchanged since slice 2; godoc reconciled to drop the now-done "slice 3" forward-ref).
3. [core/stateless.go](https://github.com/panyam/mcpkit/pull/870/files#diff-9a68784d645de8b02f898afae78118cfc63d9fe94dc4fc920c564a7cf3127fac), `core/trace.go`, `core/baggage.go` — `*FromRawJSON` readers the dispatch/trace path calls; `*FromParams` route through them.
4. [server/dispatch.go](https://github.com/panyam/mcpkit/pull/870/files#diff-7640bcbef23148a16e477c63c7092f0ba89780f5278a9d6ba6ed513d62f68a92) — dispatch feeds internal handlers `req.Params.Raw()` (they keep `json.RawMessage`); the SEP-2575 gate reads `DecodeRequestMetaFromRawJSON(&req.Params)`.
5. [CHANGELOG.md](https://github.com/panyam/mcpkit/pull/870/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed) — Breaking entry + reconciled Added entry.

Skim or skip: the remaining ~110 files are mechanical construction/read-site swaps (`json.RawMessage(x)` → `core.NewRawJSON(x)` at construction; `json.Unmarshal(req.Params, …)` → `req.Params.Bind(…)` at read). Compiler-driven — every site the compiler flagged, nothing else.

## Decision log
- **Custom `Request.MarshalJSON` instead of `omitempty`.** `RawJSON` is a struct, so `omitempty` can't omit it — a nil-params request would serialize `"params":null`, which JSON-RPC forbids. The marshaler projects to an anonymous struct with `json.RawMessage` + `omitempty` to restore byte-identical output.
- **Internal handlers keep `json.RawMessage`.** Only the public `Request.Params` surface flips; `d.handleXxx(id, bytes)` signatures stay on `json.RawMessage` via `req.Params.Raw()`. Keeps the blast radius at the type boundary.
- **Consolidated the CHANGELOG slice narrative.** The interim `ParamsLazy()` entry described an API that no longer ships in 0.4.0; folded its perf win into the end-state RawJSON entry.

## Risk / blast radius
- Affects: every caller constructing or reading `core.Request.Params` (root + all submodules).
- Tests covering this: 60 test files migrated; **0 test functions added or removed** (mechanical). `core/rawjson` unit + benchmark suite, `server` dispatch/trace/stateless suites all green.
- Be paranoid about: the wire-omission property (covered by round-trip assertions), and the stateless `_meta` gate reading through the shared parse.

## Before / after

Read path, handler-side:
```go
// before
var in MyInput
json.Unmarshal(req.Params, &in)

// after
var in MyInput
req.Params.Bind(&in)
```

Wire output — byte-identical (verified by round-trip):
```
{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{...}}   // params present
{"jsonrpc":"2.0","id":1,"method":"tools/list"}                  // params omitted, not null
```

## Out of scope
- SEP-2577 Roots/Sampling/Logging removal — deferred to a later release (issue 850).
- `examples/apps/react/server` build break — pre-existing on main (stale #486/#487 ABI), unrelated to this flip.

