### PR TITLE
fix(conformance): testconf-skills exits 0 on check failures (issue 613)

### DIFF
--- a/conformance/Makefile
+++ b/conformance/Makefile
@@ -201,7 +201,7 @@ testconf-auth-server: ## Run server-side auth conformance — fork-based scenari
 	wait $$PID 2>/dev/null; \
 	exit $$RC
 
-testconf-skills: ## Run SEP-2640 skills conformance — drives examples/skills via the fork's scenario runner. Scenarios land in a follow-up using the Scenario class primitives PR 8 introduced; this target wires the fixture spawn + URL today so the conf-side PR plugs in cleanly.
+testconf-skills: ## Run SEP-2640 skills conformance — informational (exit 0 regardless of check results while WG iterates sep-2640.yaml). Drives examples/skills via the fork's scenario runner. Scenarios land in a follow-up using the Scenario class primitives PR 8 introduced; this target wires the fixture spawn + URL today so the conf-side PR plugs in cleanly.
 	@if [ ! -d "$(MCPCONFORMANCE_SKILLS_PATH)" ]; then \
 		echo "MCPCONFORMANCE_SKILLS_PATH=$(MCPCONFORMANCE_SKILLS_PATH) does not exist."; \
 		echo "Clone https://github.com/panyam/mcpconformance there or set MCPCONFORMANCE_SKILLS_PATH=<path-to-clone>."; \
@@ -226,9 +226,15 @@ testconf-skills: ## Run SEP-2640 skills conformance — drives examples/skills v
 	kill $$PID 2>/dev/null; \
 	wait $$PID 2>/dev/null; \
 	if [ $$RC -ne 0 ]; then \
-		echo "testconf-skills: runner exited $$RC (artifacts in $$OUT)"; \
+		echo "==================================================================="; \
+		echo "testconf-skills: INFORMATIONAL — runner exited $$RC (artifacts in $$OUT)"; \
+		echo "This suite is INFO status in conformance/local-suites.yaml while the"; \
+		echo "fork-side Scenario classes iterate on sep-2640.yaml (mcpconformance"; \
+		echo "PR 330). The check failures are pre-existing input-required-result"; \
+		echo "(SEP-2567) gaps the skills runner also exercises, not new regressions."; \
+		echo "Exiting 0 so the umbrella reaches refresh-conformance. See issue 613."; \
+		echo "==================================================================="; \
 		tail -30 $$OUT/runner.log 2>/dev/null; \
-		exit $$RC; \
 	fi
 # Scenario class for SEP-2640 to be registered under the name
 # "sep-2640-skills" in the fork's src/scenarios/index.ts, mirroring how


### PR DESCRIPTION
## Why

`testconf-skills` is marked **INFO** in `conformance/local-suites.yaml` (fork-side Scenario classes blocked on WG iteration of `sep-2640.yaml`, mcpconformance PR 330), but the Makefile target exited non-zero when the runner reported check failures. That halted `make -C conformance test` before it reached `testconf-upstream-audit` and `refresh-conformance` — the 2026-06-05 refresh had to manually run the remaining two suites to regenerate `CONFORMANCE.md`.

The failures aren't skills-specific: they're pre-existing `input-required-result` (SEP-2567) checks the skills runner also exercises, not new regressions.

## What

Mirror the `testconf-upstream-audit` informational pattern on the `testconf-skills` target:

- Keep running the suite and print the artifact location.
- Exit 0 on runner check failures, with an INFO banner explaining the status.
- The missing-path setup guard still fails fast (a genuine setup error, not a check failure).

No change to `local-suites.yaml`. When the fork scenarios land and skills flips to PASS, flip both the YAML `status` and this exit semantics together, as the issue notes.

## Test

- `make -n testconf-skills` parses clean.
- Missing-path guard branch still exits non-zero (verified).

Closes issue 613.

https://claude.ai/code/session_01PAT6AvpFqzrurThGZniHZv