### PR TITLE
feat(skills): bound resource-fetch size + cumulative byte budget (issue 867)

### DIFF
--- a/ext/skills/client.go
+++ b/ext/skills/client.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/panyam/mcpkit/client"
@@ -43,6 +44,12 @@ import (
 type Client struct {
 	mcp *client.Client
 	cfg clientConfig
+
+	// mu guards consumed, the running total charged against
+	// cfg.serverByteBudget. Kept separate from cfg (immutable after
+	// construction) because it is the one piece of mutable Client state.
+	mu       sync.Mutex
+	consumed int64
 }
 
 // NewClient builds a SEP-2640 host helper over the given mcpkit client.
@@ -53,12 +60,15 @@ type Client struct {
 //
 //   - WithTracerProvider — span emission around read methods + Activate
 //   - WithActivationHook — non-OTel telemetry callback fired from Activate
+//   - WithMaxResourceBytes — per-resource fetch-size cap (issue 867)
+//   - WithServerByteBudget — cumulative fetch-size budget (issue 867)
 //
-// With no options, the helper behaves identically to the pre-P7 shape:
-// zero overhead, no spans, no hook calls. NoopTracerProvider is the
-// default — call sites do not nil-check.
+// With no options, the helper behaves identically to the pre-P7 shape
+// aside from the per-resource size cap, which defaults to
+// DefaultMaxResourceBytes: zero telemetry overhead, no spans, no hook
+// calls. NoopTracerProvider is the default — call sites do not nil-check.
 func NewClient(mcp *client.Client, opts ...Option) *Client {
-	cfg := clientConfig{tp: core.NoopTracerProvider{}}
+	cfg := clientConfig{tp: core.NoopTracerProvider{}, maxResourceBytes: DefaultMaxResourceBytes}
 	for _, opt := range opts {
 		opt(&cfg)
 	}
@@ -159,7 +169,7 @@ func (c *Client) ReadSkillURI(ctx context.Context, uri string) ([]byte, error) {
 		span.RecordError(err)
 		return nil, fmt.Errorf("skills: read %s: %w", uri, err)
 	}
-	bytes, err := extractBytes(result.Contents, uri)
+	bytes, err := c.boundedBytes(result.Contents, uri)
 	if err != nil {
 		span.RecordError(err)
 		return nil, err
@@ -500,6 +510,62 @@ func isNotFoundErr(err error) bool {
 	}
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "not found") || strings.Contains(msg, "unknown resource")
+}
+
+// BytesConsumed reports the running total charged against the Client's
+// WithServerByteBudget across every skill:// read so far. Returns 0 when
+// no budget is configured or nothing has been read yet. Safe for
+// concurrent use.
+func (c *Client) BytesConsumed() int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.consumed
+}
+
+// boundedBytes extracts the served bytes from a resources/read result
+// while enforcing the per-resource size cap (WithMaxResourceBytes) and
+// the cumulative server byte budget (WithServerByteBudget).
+//
+// The per-resource size is bounded before a blob is base64-decoded: the
+// decoded length is at most DecodedLen(len(base64)) for a blob and the
+// raw string length for text, so an oversized payload is rejected
+// without incurring the decode (or a subsequent hash) allocation. On
+// success the actual decoded byte count is charged against the
+// cumulative budget.
+func (c *Client) boundedBytes(contents []core.ResourceReadContent, uri string) ([]byte, error) {
+	if len(contents) == 0 {
+		return nil, fmt.Errorf("skills: %s: empty contents", uri)
+	}
+	ct := contents[0]
+
+	var estimate int64
+	if ct.Blob != "" {
+		estimate = int64(base64.StdEncoding.DecodedLen(len(ct.Blob)))
+	} else {
+		estimate = int64(len(ct.Text))
+	}
+	if c.cfg.maxResourceBytes > 0 && estimate > c.cfg.maxResourceBytes {
+		return nil, fmt.Errorf("%w: %s is ~%d bytes, cap %d",
+			ErrResourceTooLarge, uri, estimate, c.cfg.maxResourceBytes)
+	}
+
+	bytes, err := extractBytes(contents, uri)
+	if err != nil {
+		return nil, err
+	}
+
+	if c.cfg.serverByteBudget > 0 {
+		c.mu.Lock()
+		total := c.consumed + int64(len(bytes))
+		if total > c.cfg.serverByteBudget {
+			c.mu.Unlock()
+			return nil, fmt.Errorf("%w: %s would push total to %d, budget %d",
+				ErrServerByteBudgetExceeded, uri, total, c.cfg.serverByteBudget)
+		}
+		c.consumed = total
+		c.mu.Unlock()
+	}
+	return bytes, nil
 }
 
 // extractBytes pulls the served bytes out of a ResourceResult's

--- a/ext/skills/client_options.go
+++ b/ext/skills/client_options.go
@@ -18,6 +18,58 @@ type Option func(*clientConfig)
 type clientConfig struct {
 	tp             core.TracerProvider
 	activationHook func(context.Context, ActivationEvent)
+
+	// maxResourceBytes caps the size of any single skill:// read. 0
+	// leaves the DefaultMaxResourceBytes default in place; a negative
+	// value disables the cap. See WithMaxResourceBytes.
+	maxResourceBytes int64
+
+	// serverByteBudget caps the cumulative bytes a Client fetches across
+	// all skill:// reads. 0 (the default) disables the budget. See
+	// WithServerByteBudget.
+	serverByteBudget int64
+}
+
+// DefaultMaxResourceBytes is the per-resource size cap the Client applies
+// to skill:// reads when no WithMaxResourceBytes option is supplied.
+// 10 MiB comfortably fits a SKILL.md and ordinary supporting files while
+// rejecting payloads engineered to exhaust memory at fetch time (WG
+// threat model T6, issue 867). It mirrors the archive extractor's own
+// DefaultArchiveMaxBytes cap, applied to the individual-file paths the
+// archive cap does not cover. Pass -1 to WithMaxResourceBytes to disable.
+const DefaultMaxResourceBytes int64 = 10 * 1024 * 1024
+
+// WithMaxResourceBytes sets the per-resource size cap for skill:// reads
+// (ReadSkillURI and everything that flows through it: ReadSkillManifest,
+// ReadSkillFile, ReadAndVerify). A read whose payload exceeds n is
+// rejected with ErrResourceTooLarge before a blob is base64-decoded, so
+// an oversized payload never incurs the decode or a subsequent hash
+// allocation.
+//
+// n <= 0 disables the cap (n == 0 is treated as "use the default" at
+// construction; pass -1 to explicitly remove the cap). Default is
+// DefaultMaxResourceBytes (10 MiB).
+//
+// Note: the underlying resources/read call still buffers the full
+// JSON-RPC response in memory before this cap is applied — bounding that
+// requires a streaming read on the core client. This option bounds the
+// decode + hash amplification and the retained bytes, which is the SDK
+// surface ext/skills controls.
+func WithMaxResourceBytes(n int64) Option {
+	return func(c *clientConfig) { c.maxResourceBytes = n }
+}
+
+// WithServerByteBudget sets a cumulative cap on the total bytes a Client
+// fetches across every skill:// read for its lifetime. Once the running
+// total plus the next read would exceed n, that read is rejected with
+// ErrServerByteBudgetExceeded. This bounds a directory walk that fetches
+// many individually-small supporting files past an aggregate ceiling,
+// which the per-resource cap alone does not catch.
+//
+// n <= 0 disables the budget (the default). Reads are charged their
+// decoded byte count; the running total is available via BytesConsumed.
+func WithServerByteBudget(n int64) Option {
+	return func(c *clientConfig) { c.serverByteBudget = n }
 }
 
 // WithTracerProvider opts the Client into SEP-414 P7 (#748) span

--- a/ext/skills/client_size_test.go
+++ b/ext/skills/client_size_test.go
@@ -1,0 +1,101 @@
+package skills_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/panyam/mcpkit/ext/skills"
+)
+
+// Issue 867: the individual-file read path (resources/read, reached via
+// ReadSkillURI and everything that flows through it) must bound a
+// fetched resource's size before decode, and enforce a cumulative
+// per-Client byte budget across a walk. These tests drive both caps
+// against a real Provider-backed server.
+
+const gitWorkflowURI = "skill://git-workflow/SKILL.md"
+
+func TestClient_ReadSkillURI_RejectsOversized(t *testing.T) {
+	// A cap smaller than the served SKILL.md must reject before decode.
+	sc, _ := connectSkillsClientWithClientOpts(t, "testdata/valid",
+		skills.WithMaxResourceBytes(16))
+	_, err := sc.ReadSkillURI(context.Background(), gitWorkflowURI)
+	if !errors.Is(err, skills.ErrResourceTooLarge) {
+		t.Fatalf("ReadSkillURI err = %v, want ErrResourceTooLarge", err)
+	}
+}
+
+func TestClient_ReadSkillURI_UnderCapSucceeds(t *testing.T) {
+	// A generous cap leaves ordinary reads working.
+	sc, _ := connectSkillsClientWithClientOpts(t, "testdata/valid",
+		skills.WithMaxResourceBytes(1<<20))
+	if _, err := sc.ReadSkillURI(context.Background(), gitWorkflowURI); err != nil {
+		t.Fatalf("ReadSkillURI under cap: %v", err)
+	}
+}
+
+func TestClient_MaxResourceBytes_NegativeDisablesCap(t *testing.T) {
+	// -1 removes the cap entirely (even a byte-sized default would reject
+	// nothing). Read the file to confirm the path stays open.
+	sc, _ := connectSkillsClientWithClientOpts(t, "testdata/valid",
+		skills.WithMaxResourceBytes(-1))
+	if _, err := sc.ReadSkillURI(context.Background(), gitWorkflowURI); err != nil {
+		t.Fatalf("ReadSkillURI with cap disabled: %v", err)
+	}
+}
+
+func TestClient_DefaultCapAllowsOrdinaryReads(t *testing.T) {
+	// The zero-option Client applies DefaultMaxResourceBytes, which must
+	// not reject a normal SKILL.md.
+	sc, _ := connectSkillsClient(t, "testdata/valid")
+	if _, err := sc.ReadSkillURI(context.Background(), gitWorkflowURI); err != nil {
+		t.Fatalf("ReadSkillURI under default cap: %v", err)
+	}
+}
+
+func TestClient_ServerByteBudget_ExceededAcrossReads(t *testing.T) {
+	data, err := os.ReadFile("testdata/valid/git-workflow/SKILL.md")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	n := int64(len(data))
+
+	// Budget fits exactly one read but not two.
+	sc, _ := connectSkillsClientWithClientOpts(t, "testdata/valid",
+		skills.WithServerByteBudget(n+5))
+	ctx := context.Background()
+
+	if _, err := sc.ReadSkillURI(ctx, gitWorkflowURI); err != nil {
+		t.Fatalf("first read within budget: %v", err)
+	}
+	if got := sc.BytesConsumed(); got != n {
+		t.Fatalf("BytesConsumed after first read = %d, want %d", got, n)
+	}
+
+	// Second read would push the total to 2n, over the n+5 budget.
+	_, err = sc.ReadSkillURI(ctx, gitWorkflowURI)
+	if !errors.Is(err, skills.ErrServerByteBudgetExceeded) {
+		t.Fatalf("second read err = %v, want ErrServerByteBudgetExceeded", err)
+	}
+	// A rejected read must not be charged.
+	if got := sc.BytesConsumed(); got != n {
+		t.Fatalf("BytesConsumed after rejected read = %d, want %d (rejection must not charge)", got, n)
+	}
+}
+
+func TestClient_ServerByteBudget_DisabledByDefault(t *testing.T) {
+	// With no budget option, BytesConsumed stays 0 and reads are
+	// unbounded in aggregate.
+	sc, _ := connectSkillsClient(t, "testdata/valid")
+	ctx := context.Background()
+	for i := 0; i < 3; i++ {
+		if _, err := sc.ReadSkillURI(ctx, gitWorkflowURI); err != nil {
+			t.Fatalf("read %d with budget disabled: %v", i, err)
+		}
+	}
+	if got := sc.BytesConsumed(); got != 0 {
+		t.Fatalf("BytesConsumed with budget disabled = %d, want 0", got)
+	}
+}

--- a/ext/skills/errors.go
+++ b/ext/skills/errors.go
@@ -64,6 +64,23 @@ var (
 	// directoryRead: true. Returning a typed error from the pre-call
 	// guard keeps the contract explicit at the call site.
 	ErrDirectoryReadNotSupported = errors.New("skills: server does not advertise the directoryRead capability")
+
+	// ErrResourceTooLarge is returned by the Client read path when a
+	// fetched resource exceeds the per-resource size cap configured via
+	// WithMaxResourceBytes (default DefaultMaxResourceBytes). The size is
+	// bounded before a blob is base64-decoded, so an oversized payload is
+	// rejected without incurring the decode (or a subsequent hash)
+	// allocation. This is the individual-file counterpart to the archive
+	// extractor's ErrArchiveTooLarge (WG threat model T6, issue 867).
+	ErrResourceTooLarge = errors.New("skills: resource exceeds max size")
+
+	// ErrServerByteBudgetExceeded is returned when a Client's cumulative
+	// fetched-byte total would exceed the budget set via
+	// WithServerByteBudget. The budget spans every ReadSkillURI-path read
+	// (manifest, supporting file, ReadAndVerify) on that Client, so a walk
+	// that fetches many individually-small files is still bounded past an
+	// aggregate ceiling. Disabled by default; opt in per Client.
+	ErrServerByteBudgetExceeded = errors.New("skills: server byte budget exceeded")
 )
 
 // Index validation errors.


### PR DESCRIPTION
## Why

Size limits lived only in the archive extractor (`DefaultArchiveMaxBytes`). The individual-file read path — `resources/read` reached via `ReadSkillURI` and everything that flows through it (`ReadSkillManifest`, `ReadSkillFile`, `ReadAndVerify`) — was unbounded. A host that reads, base64-decodes, and hashes an untrusted server resource could be memory-exhausted at fetch time. This is threat **T6** in the WG threat model (`experimental-ext-skills#108`, fixtures `adv-oversized-payload` / `adv-walk-budget`). Pure SDK hardening, no spec dependency.

## What

Two client-side caps on `skills.Client`:

- **`WithMaxResourceBytes(n)`** — per-resource cap, default `DefaultMaxResourceBytes` (10 MiB, mirroring the archive cap). Size is bounded **before** a blob is base64-decoded (`DecodedLen(len(base64))` for blobs, raw length for text), so an oversized payload is rejected without the decode or a subsequent hash allocation. Pass `-1` to disable.
- **`WithServerByteBudget(n)`** — cumulative cap across every read on a Client, bounding a directory walk that fetches many individually-small files past an aggregate ceiling. Disabled by default; `BytesConsumed()` exposes the running total. A rejected read is not charged.

Typed sentinels `ErrResourceTooLarge` and `ErrServerByteBudgetExceeded` mirror `ErrArchiveTooLarge`. The provider-side walk stays over trusted local files, so the bound lives on the client read boundary.

## Scope notes / follow-ons

- The underlying `resources/read` still buffers the full JSON-RPC response before this cap applies — bounding that needs a streaming read on the core client.
- Honoring an advertised `Resource.size` before fetch needs a `Size` field on `core.ResourceDef` (not modeled today).

Both are noted in code as follow-ons.

## Test

New `client_size_test.go`: oversized rejection, under-cap success, `-1` disables, default cap allows ordinary reads, cumulative budget exceeded across reads (with rejected-read-not-charged assertion), budget disabled by default. `go test ./... && go vet ./...` green in `ext/skills`.

Closes issue 867.

https://claude.ai/code/session_01PAT6AvpFqzrurThGZniHZv