### PR TITLE
feat(skills): pin supporting-file integrity with per-file digests (issue 866)

### DIFF
--- a/ext/skills/adversarial_test.go
+++ b/ext/skills/adversarial_test.go
@@ -39,9 +39,10 @@ import (
 //     name-collision, live-read-divergence, cumulative-budget) — these
 //     require a full HOST (approval persistence, cross-origin trust, unpack
 //     budgets); a consumer library cannot satisfy them alone.
-//   - adv-supporting-file-digest-swap — a KNOWN GAP in mcpkit (issue 839 /
-//     gap G13): the index digest covers SKILL.md only, so supporting files
-//     read via resources/read are unpinned. Asserted-as-gap below.
+//   - adv-supporting-file-digest-swap — COVERED as of issue 866: the
+//     Indexer pins every supporting file in IndexEntry.Files, and
+//     Client.ReadSkillFileVerified rejects a swapped file on read with
+//     ErrDigestMismatch. Asserted-as-covered below (was gap G13).
 func TestAdversarialCorpus_NonArchiveSlice(t *testing.T) {
 	// adv-content-rotation (Den D7) + the digest MUST at SEP line 204.
 	// Oracle: "A host that re-verifies MUST reject the rotated read — the
@@ -104,29 +105,40 @@ func TestAdversarialCorpus_NonArchiveSlice(t *testing.T) {
 		}
 	})
 
-	// Coverage disclosure — keeps this mapping honest. The one known gap is
-	// asserted so a future fix flags the disclosure as stale.
-	t.Run("coverage-disclosure", func(t *testing.T) {
-		// adv-supporting-file-digest-swap (Den B1) — KNOWN GAP (issue 839 /
-		// G13). The index carries ONE digest per entry (SKILL.md), so
-		// supporting files fetched via resources/read are not integrity-
-		// pinned. Assert the shape that makes the gap real: an index entry
-		// exposes a single Digest field and no per-supporting-file digests.
+	// adv-supporting-file-digest-swap (Den B1) — COVERED as of issue 866.
+	// The Indexer pins every supporting file in IndexEntry.Files, and
+	// Client.ReadSkillFileVerified rejects a swapped file on read. This was
+	// gap G13; the assertion now proves coverage so a regression flags it.
+	t.Run("supporting-file-digest-swap", func(t *testing.T) {
 		sc, _ := connectSkillsClient(t, "testdata/valid")
 		idx, err := sc.ListSkills(context.Background())
 		if err != nil {
 			t.Fatalf("ListSkills: %v", err)
 		}
-		entry, ok := idx.Lookup("skill://git-workflow/SKILL.md")
+		entry, ok := idx.Lookup(pdfManifestURI)
 		if !ok {
-			t.Fatal("git-workflow not in index")
+			t.Fatal("pdf-processing not in index")
 		}
-		if entry.Digest == "" {
-			t.Fatal("expected a SKILL.md digest on the entry")
+		pins := entry.FileDigests()
+		if len(pins) == 0 {
+			t.Fatal("expected supporting-file pins under _meta; gap G13 has regressed")
 		}
-		t.Logf("KNOWN GAP adv-supporting-file-digest-swap (G13): IndexEntry.Digest pins SKILL.md only; "+
-			"supporting files are unpinned. entry=%q digest=%s", entry.URL, entry.Digest)
+		manifest, err := sc.ReadSkillManifest(context.Background(), pdfManifestURI)
+		if err != nil {
+			t.Fatalf("ReadSkillManifest: %v", err)
+		}
+		// Point the pin at a divergent digest to model a swapped supporting
+		// file. The re-verifying host MUST reject the read.
+		tampered := withTamperedPin(entry, pins[0].Path, "sha256:"+strings.Repeat("0", 64))
+		_, err = sc.ReadSkillFileVerified(context.Background(), tampered, manifest, pins[0].Path)
+		if !errors.Is(err, skills.ErrDigestMismatch) {
+			t.Fatalf("swapped supporting file err = %v, want ErrDigestMismatch", err)
+		}
+	})
 
+	// Coverage disclosure — keeps this mapping honest for the cases mcpkit
+	// intentionally does not cover in this slice.
+	t.Run("coverage-disclosure", func(t *testing.T) {
 		t.Log("OUT OF SLICE (archive, deferred per discussion 2994; covered in archive_test.go): " +
 			"adv-archive-traversal, adv-archive-symlink-escape, adv-archive-hardlink-escape, " +
 			"adv-decompression-bomb, adv-archive-setuid, adv-archive-non-regular, adv-cumulative-budget, " +

--- a/ext/skills/client.go
+++ b/ext/skills/client.go
@@ -323,6 +323,59 @@ func (c *Client) ReadSkillFile(ctx context.Context, manifest *SkillManifest, rel
 	return c.ReadSkillURI(ctx, resolved.String())
 }
 
+// ReadSkillFileVerified resolves relPath against the manifest's skill
+// root, reads it, and verifies the served bytes against the per-file
+// digest pinned in the entry's supporting-file pins (issue 866). It is the integrity-checked
+// counterpart to ReadSkillFile: use it for supporting files a re-
+// verifying host must not trust unverified (scripts, templates,
+// referenced docs), so a swapped file is rejected on read.
+//
+// entry is the IndexEntry for the skill (from ListSkills + Index.Lookup),
+// which carries the supporting-file pins mcpkit's Indexer writes under
+// MetaKeyFileDigests (read via entry.FileDigest). The lookup key is the
+// file's path relative to the skill root, derived from the resolved URI
+// so that "./x", "a/../b", and percent-encoded forms all match the
+// canonical pin.
+//
+// Errors:
+//   - ErrSupportingFileUnpinned when the entry carries no pin for the
+//     resolved path (secure default — no silent unverified fallback).
+//   - ErrDigestMismatch when the served bytes do not match the pin; per
+//     SEP-2640 the host MUST NOT use the bytes.
+//
+// On success returns a ReadResult with DigestVerified=true.
+func (c *Client) ReadSkillFileVerified(ctx context.Context, entry IndexEntry, manifest *SkillManifest, relPath string) (*ReadResult, error) {
+	if manifest == nil {
+		return nil, fmt.Errorf("skills: ReadSkillFileVerified: nil manifest")
+	}
+	root, err := ParseURI(manifest.URI)
+	if err != nil {
+		return nil, fmt.Errorf("skills: ReadSkillFileVerified: re-parse manifest URI: %w", err)
+	}
+	resolved, err := ResolveRelative(root, relPath)
+	if err != nil {
+		return nil, fmt.Errorf("skills: resolve %q against %s: %w", relPath, manifest.URI, err)
+	}
+	key := skillRelPath(root, resolved)
+	digest, ok := entry.FileDigest(key)
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", ErrSupportingFileUnpinned, key)
+	}
+	return c.ReadAndVerify(ctx, resolved.String(), digest)
+}
+
+// skillRelPath returns the resolved file's path relative to the skill
+// root — the canonical key the supporting-file pins use. ResolveRelative
+// guarantees resolved.AllSegments is prefixed by root.SkillPath and lands
+// strictly below the skill directory, so the suffix is the in-skill
+// relative path.
+func skillRelPath(root, resolved URIParts) string {
+	if len(resolved.AllSegments) <= len(root.SkillPath) {
+		return ""
+	}
+	return strings.Join(resolved.AllSegments[len(root.SkillPath):], "/")
+}
+
 // ReadResult is the typed return from ReadAndVerify. Bytes carries the
 // served content; DigestVerified is true when the SHA-256 over Bytes
 // equals the expected digest the caller supplied.

--- a/ext/skills/client_supporting_digest_test.go
+++ b/ext/skills/client_supporting_digest_test.go
@@ -1,0 +1,177 @@
+package skills_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/panyam/mcpkit/ext/skills"
+)
+
+// Issue 866: supporting files (everything under a skill directory except
+// SKILL.md) must be integrity-pinned so a re-verifying host can detect a
+// swapped file fetched via resources/read (WG threat model B1). The
+// Indexer pins them in IndexEntry.Files; Client.ReadSkillFileVerified
+// checks the served bytes against the pin on read.
+
+const pdfManifestURI = "skill://pdf-processing/SKILL.md"
+
+// withTamperedPin returns a copy of entry whose supporting-file pin for
+// path is replaced with digest, modelling a swapped supporting file. The
+// pins round-trip through FileDigests()/MetaKeyFileDigests so the copy is
+// independent of the original's _meta map.
+func withTamperedPin(entry skills.IndexEntry, path, digest string) skills.IndexEntry {
+	files := append([]skills.FileDigest(nil), entry.FileDigests()...)
+	for i := range files {
+		if files[i].Path == path {
+			files[i].Digest = digest
+		}
+	}
+	tampered := entry
+	tampered.Meta = map[string]any{skills.MetaKeyFileDigests: files}
+	return tampered
+}
+
+func pdfEntry(t *testing.T, sc *skills.Client) skills.IndexEntry {
+	t.Helper()
+	idx, err := sc.ListSkills(context.Background())
+	if err != nil {
+		t.Fatalf("ListSkills: %v", err)
+	}
+	entry, ok := idx.Lookup(pdfManifestURI)
+	if !ok {
+		t.Fatalf("pdf-processing not in index")
+	}
+	return entry
+}
+
+func TestIndexEntry_Files_Populated(t *testing.T) {
+	sc, _ := connectSkillsClient(t, "testdata/valid")
+	entry := pdfEntry(t, sc)
+
+	// testdata/valid/pdf-processing has two supporting files:
+	// references/FORMS.md and scripts/extract.py. SKILL.md is pinned by
+	// the entry Digest, not repeated in the supporting-file pins. Pins
+	// live under a namespaced _meta key, read via FileDigests().
+	want := map[string]bool{"references/FORMS.md": true, "scripts/extract.py": true}
+	files := entry.FileDigests()
+	if len(files) != len(want) {
+		t.Fatalf("FileDigests count = %d, want %d: %+v", len(files), len(want), files)
+	}
+	for _, f := range files {
+		if !want[f.Path] {
+			t.Errorf("unexpected pinned path %q", f.Path)
+		}
+		if !strings.HasPrefix(f.Digest, "sha256:") || len(f.Digest) != len("sha256:")+64 {
+			t.Errorf("path %q digest not sha256:{64-hex}: %q", f.Path, f.Digest)
+		}
+		if f.Path == "SKILL.md" {
+			t.Errorf("SKILL.md must not appear in supporting-file pins (pinned by entry Digest)")
+		}
+	}
+	if _, ok := entry.FileDigest("scripts/extract.py"); !ok {
+		t.Errorf("FileDigest lookup miss for a pinned path")
+	}
+	if _, ok := entry.FileDigest("nope.txt"); ok {
+		t.Errorf("FileDigest lookup hit for an unpinned path")
+	}
+}
+
+func TestIndexEntry_Files_OffMode(t *testing.T) {
+	// With SupportingDigestsOff the index pins SKILL.md only, so no
+	// supporting-file pins are emitted and a verified read has nothing to
+	// check against.
+	sc, _ := connectSkillsClient(t, "testdata/valid",
+		skills.WithSupportingFileDigests(skills.SupportingDigestsOff))
+	entry := pdfEntry(t, sc)
+	if entry.Digest == "" {
+		t.Errorf("SKILL.md digest should still be pinned in off mode")
+	}
+	if got := entry.FileDigests(); len(got) != 0 {
+		t.Errorf("off mode should emit no supporting-file pins, got %+v", got)
+	}
+	manifest, err := sc.ReadSkillManifest(context.Background(), pdfManifestURI)
+	if err != nil {
+		t.Fatalf("ReadSkillManifest: %v", err)
+	}
+	_, err = sc.ReadSkillFileVerified(context.Background(), entry, manifest, "scripts/extract.py")
+	if !errors.Is(err, skills.ErrSupportingFileUnpinned) {
+		t.Fatalf("off-mode verified read err = %v, want ErrSupportingFileUnpinned", err)
+	}
+}
+
+func TestClient_ReadSkillFileVerified_Match(t *testing.T) {
+	sc, _ := connectSkillsClient(t, "testdata/valid")
+	entry := pdfEntry(t, sc)
+	manifest, err := sc.ReadSkillManifest(context.Background(), pdfManifestURI)
+	if err != nil {
+		t.Fatalf("ReadSkillManifest: %v", err)
+	}
+
+	res, err := sc.ReadSkillFileVerified(context.Background(), entry, manifest, "scripts/extract.py")
+	if err != nil {
+		t.Fatalf("ReadSkillFileVerified: %v", err)
+	}
+	if !res.DigestVerified {
+		t.Errorf("DigestVerified = false, want true for a matching pin")
+	}
+	if len(res.Bytes) == 0 {
+		t.Errorf("expected supporting-file bytes, got none")
+	}
+}
+
+func TestClient_ReadSkillFileVerified_SwapRejected(t *testing.T) {
+	sc, _ := connectSkillsClient(t, "testdata/valid")
+	entry := pdfEntry(t, sc)
+	manifest, err := sc.ReadSkillManifest(context.Background(), pdfManifestURI)
+	if err != nil {
+		t.Fatalf("ReadSkillManifest: %v", err)
+	}
+
+	// Model a swap: the pin says one thing, the served bytes are
+	// different. We hold the served bytes fixed (real provider) and point
+	// the pin at a divergent digest — verification compares served-hash
+	// against the pin and must reject either way the divergence arises.
+	tampered := withTamperedPin(entry, "scripts/extract.py", "sha256:"+strings.Repeat("0", 64))
+
+	_, err = sc.ReadSkillFileVerified(context.Background(), tampered, manifest, "scripts/extract.py")
+	if !errors.Is(err, skills.ErrDigestMismatch) {
+		t.Fatalf("ReadSkillFileVerified err = %v, want ErrDigestMismatch", err)
+	}
+}
+
+func TestClient_ReadSkillFileVerified_Unpinned(t *testing.T) {
+	sc, _ := connectSkillsClient(t, "testdata/valid")
+	entry := pdfEntry(t, sc)
+	manifest, err := sc.ReadSkillManifest(context.Background(), pdfManifestURI)
+	if err != nil {
+		t.Fatalf("ReadSkillManifest: %v", err)
+	}
+
+	// A path with no pin must not silently fall back to an unverified read.
+	_, err = sc.ReadSkillFileVerified(context.Background(), entry, manifest, "references/UNLISTED.md")
+	if !errors.Is(err, skills.ErrSupportingFileUnpinned) {
+		t.Fatalf("ReadSkillFileVerified for unpinned path err = %v, want ErrSupportingFileUnpinned", err)
+	}
+}
+
+func TestClient_ReadSkillFileVerified_PathNormalization(t *testing.T) {
+	sc, _ := connectSkillsClient(t, "testdata/valid")
+	entry := pdfEntry(t, sc)
+	manifest, err := sc.ReadSkillManifest(context.Background(), pdfManifestURI)
+	if err != nil {
+		t.Fatalf("ReadSkillManifest: %v", err)
+	}
+
+	// "./scripts/../scripts/extract.py" canonicalizes to the pinned path,
+	// so the pin lookup must resolve from the canonical URI, not the raw
+	// relative reference.
+	res, err := sc.ReadSkillFileVerified(context.Background(), entry, manifest, "./scripts/../scripts/extract.py")
+	if err != nil {
+		t.Fatalf("ReadSkillFileVerified with non-canonical relPath: %v", err)
+	}
+	if !res.DigestVerified {
+		t.Errorf("DigestVerified = false, want true after path canonicalization")
+	}
+}

--- a/ext/skills/client_test.go
+++ b/ext/skills/client_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -140,7 +141,7 @@ func TestClient_Index_Lookup_Miss(t *testing.T) {
 	if ok {
 		t.Errorf("Lookup hit for unknown URL, got %+v", entry)
 	}
-	if entry != (skills.IndexEntry{}) {
+	if !reflect.DeepEqual(entry, skills.IndexEntry{}) {
 		t.Errorf("miss should return zero IndexEntry, got %+v", entry)
 	}
 }

--- a/ext/skills/errors.go
+++ b/ext/skills/errors.go
@@ -74,6 +74,14 @@ var (
 	// extractor's ErrArchiveTooLarge (WG threat model T6, issue 867).
 	ErrResourceTooLarge = errors.New("skills: resource exceeds max size")
 
+	// ErrSupportingFileUnpinned is returned by Client.ReadSkillFileVerified
+	// when the index entry carries no per-file digest for the requested
+	// supporting file (issue 866). It is a secure-by-default signal: a host
+	// that asked to verify a file against its pin, but found none, should
+	// not silently fall back to an unverified read. Hosts that want a
+	// best-effort read of an unpinned file call ReadSkillFile directly.
+	ErrSupportingFileUnpinned = errors.New("skills: supporting file not pinned in index")
+
 	// ErrServerByteBudgetExceeded is returned when a Client's cumulative
 	// fetched-byte total would exceed the budget set via
 	// WithServerByteBudget. The budget spans every ReadSkillURI-path read

--- a/ext/skills/indexer.go
+++ b/ext/skills/indexer.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/fs"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -186,16 +187,57 @@ func (i *Indexer) isFresh() bool {
 }
 
 // skillMtime returns the mtime the cache uses to drive invalidation for
-// the given skill. In file mode the cache invalidates on changes to
-// SKILL.md only because the entry digest is over SKILL.md bytes alone.
-// In archive mode the digest is over the packed archive, so any file
-// in the skill's subtree contributes; the max mtime across the subtree
-// is what we track.
+// the given skill. In file mode the cache tracks SKILL.md's mtime; in
+// archive mode it tracks the subtree max mtime because the digest is over
+// the packed archive.
+//
+// Note (issue 866): file mode now also pins supporting-file digests in
+// the entry's supporting-file pins, which the SKILL.md mtime does not cover. A supporting
+// file that changes without a SKILL.md touch is therefore refreshed on
+// the TTL boundary (or via the push-based NotifyChanged path, issue 795),
+// not the instant its mtime moves — the same best-effort staleness window
+// SKILL.md content already had. Walking the whole subtree on every cache
+// hit to close that window would defeat the cache; it is intentionally
+// out of scope here.
 func (i *Indexer) skillMtime(skill *skillEntry) (time.Time, error) {
 	if i.provider.cfg.archiveMode != ArchiveFormatUnknown {
 		return subtreeMaxMtime(i.provider.cfg.fsys, skill.dirPath)
 	}
 	return mtimeOf(i.provider.cfg.fsys, manifestPath(skill.dirPath))
+}
+
+// supportingFileDigests walks a skill-md skill's directory and returns a
+// sorted, per-file SHA-256 pin for every regular file except SKILL.md.
+// Paths are relative to the skill directory (forward-slash), matching the
+// relative references Client.ReadSkillFile resolves against the manifest
+// root. Non-regular entries (symlinks, devices) are skipped — a skill is
+// data delivered over resource primitives, and only regular file bytes
+// are servable and pinnable.
+func (i *Indexer) supportingFileDigests(skillDir string) ([]FileDigest, error) {
+	var files []FileDigest
+	err := fs.WalkDir(i.provider.cfg.fsys, skillDir, func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() || !d.Type().IsRegular() {
+			return nil
+		}
+		rel := strings.TrimPrefix(p, skillDir+"/")
+		if rel == ManifestFilename {
+			return nil // pinned by the entry's own Digest
+		}
+		raw, err := fs.ReadFile(i.provider.cfg.fsys, p)
+		if err != nil {
+			return fmt.Errorf("skills: read %s for digest: %w", p, err)
+		}
+		files = append(files, FileDigest{Path: rel, Digest: digestOf(raw)})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(files, func(a, b int) bool { return files[a].Path < files[b].Path })
+	return files, nil
 }
 
 func subtreeMaxMtime(fsys fs.FS, root string) (time.Time, error) {
@@ -230,6 +272,7 @@ func (i *Indexer) build() (Index, map[string]time.Time, bool, error) {
 			entryType   SkillType
 			entryURL    string
 			digestBytes []byte
+			files       []FileDigest
 		)
 
 		if i.provider.cfg.archiveMode != ArchiveFormatUnknown {
@@ -249,15 +292,33 @@ func (i *Indexer) build() (Index, map[string]time.Time, bool, error) {
 			entryType = SkillTypeSkillMD
 			entryURL = skillManifestURI(skill.uriSegs)
 			digestBytes = raw
+			// Pin every supporting file so a re-verifying host can detect a
+			// swap on a resources/read fetch (issue 866), unless the operator
+			// selected SupportingDigestsOff for strict spec-only output.
+			// Archive entries skip this: the archive is integrity-checked as
+			// a unit.
+			if i.provider.cfg.supportingDigests == SupportingDigestsPerFile {
+				files, err = i.supportingFileDigests(skill.dirPath)
+				if err != nil {
+					return Index{}, nil, false, err
+				}
+			}
 		}
 
-		entries = append(entries, IndexEntry{
+		entry := IndexEntry{
 			Type:        entryType,
 			Name:        skill.fm.Name,
 			Description: skill.fm.Description,
 			URL:         entryURL,
 			Digest:      digestOf(digestBytes),
-		})
+		}
+		// Carry supporting-file pins under a reverse-domain _meta key so they
+		// cannot collide with a top-level field the SEP may later define
+		// (issues 780 / 839).
+		if len(files) > 0 {
+			entry.Meta = map[string]any{MetaKeyFileDigests: files}
+		}
+		entries = append(entries, entry)
 
 		mtime, err := i.skillMtime(skill)
 		if err != nil {

--- a/ext/skills/provider_options.go
+++ b/ext/skills/provider_options.go
@@ -25,6 +25,41 @@ type providerConfig struct {
 	fsWatcherEnabled     bool
 	fsWatcherIgnore      []string
 	fsWatcherErrHandler  func(error)
+	supportingDigests    SupportingDigestMode
+}
+
+// SupportingDigestMode selects how a Provider pins the integrity of a
+// skill's supporting files (every regular file under the skill directory
+// except SKILL.md) in its index. The supporting-file digest shape is
+// still undecided in the SEP (issues 780 / 839), so mcpkit makes the
+// strategy selectable rather than committing to one on the wire.
+type SupportingDigestMode int
+
+const (
+	// SupportingDigestsPerFile pins each supporting file with its own
+	// SHA-256, carried under MetaKeyFileDigests in the entry's _meta. A
+	// host verifies a single file on read via Client.ReadSkillFileVerified
+	// without fetching the whole skill. This is the default and closes WG
+	// threat B1 (issue 866).
+	SupportingDigestsPerFile SupportingDigestMode = iota
+
+	// SupportingDigestsOff pins SKILL.md only (via IndexEntry.Digest),
+	// matching today's spec text exactly. Supporting files carry no pin, so
+	// ReadSkillFileVerified returns ErrSupportingFileUnpinned for them. Use
+	// this for strict spec-only index output until the SEP clarifies.
+	SupportingDigestsOff
+)
+
+// WithSupportingFileDigests selects the supporting-file integrity strategy
+// (see SupportingDigestMode). Default is SupportingDigestsPerFile.
+//
+// The pins live under a reverse-domain _meta key, so they never collide
+// with a top-level field the SEP may later define; when the SEP settles on
+// a shape mcpkit maps to it (issue 780). Until then this option lets an
+// operator emit strict spec-only output (SupportingDigestsOff) or keep the
+// per-file hardening (the default).
+func WithSupportingFileDigests(mode SupportingDigestMode) ProviderOption {
+	return func(c *providerConfig) { c.supportingDigests = mode }
 }
 
 // WithFS supplies the io/fs.FS that the Provider walks for skills. The

--- a/ext/skills/types.go
+++ b/ext/skills/types.go
@@ -1,6 +1,7 @@
 package skills
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -52,6 +53,75 @@ type IndexEntry struct {
 	Description string    `json:"description"`
 	URL         string    `json:"url"`
 	Digest      string    `json:"digest,omitempty"`
+
+	// Meta carries opt-in, reverse-domain-namespaced extension metadata per
+	// the MCP _meta convention. mcpkit uses MetaKeyFileDigests to pin
+	// supporting-file integrity (issue 866). Placing the pins under _meta,
+	// rather than a top-level field, keeps them from colliding with any
+	// field a future SEP revision may add to the entry — the supporting-
+	// file digest shape is still spec-undecided (issues 780 / 839). When
+	// the SEP settles, mcpkit maps to whatever shape it defines. Read the
+	// pins with FileDigests / FileDigest.
+	Meta map[string]any `json:"_meta,omitempty"`
+}
+
+// MetaKeyFileDigests is the reverse-domain _meta key under an IndexEntry
+// that carries the entry's supporting-file integrity pins as a
+// []FileDigest (issue 866). Namespaced so it cannot collide with a
+// top-level field a future SEP revision may define for the same purpose.
+const MetaKeyFileDigests = MetaPrefix + "file-digests"
+
+// FileDigest pins one supporting file within a skill-md skill to a
+// SHA-256 digest (issue 866). Path is the file's path relative to the
+// skill directory, forward-slash separated — the same relative reference
+// Client.ReadSkillFile resolves against the manifest root (e.g.
+// "references/GUIDE.md"). SKILL.md is pinned by IndexEntry.Digest and is
+// never repeated here.
+type FileDigest struct {
+	Path   string `json:"path"`
+	Digest string `json:"digest"`
+}
+
+// FileDigests returns the supporting-file pins carried under
+// MetaKeyFileDigests in the entry's _meta, or nil when none are present
+// (the server pinned SKILL.md only, or ran with WithSupportingFileDigests
+// set to SupportingDigestsOff). It handles both a freshly-built entry
+// (typed []FileDigest value) and a JSON-decoded one (generic []any), so
+// it works on both the serving and consuming sides.
+func (e IndexEntry) FileDigests() []FileDigest {
+	if e.Meta == nil {
+		return nil
+	}
+	raw, ok := e.Meta[MetaKeyFileDigests]
+	if !ok {
+		return nil
+	}
+	if fds, ok := raw.([]FileDigest); ok {
+		return fds
+	}
+	b, err := json.Marshal(raw)
+	if err != nil {
+		return nil
+	}
+	var fds []FileDigest
+	if err := json.Unmarshal(b, &fds); err != nil {
+		return nil
+	}
+	return fds
+}
+
+// FileDigest returns the pinned SHA-256 for the supporting file at the
+// given skill-directory-relative path, and whether a pin exists. The
+// path is matched exactly against the canonical shape the Indexer writes
+// (clean, forward-slash, relative to the skill root — the same shape
+// ResolveRelative produces from a manifest URI + relative reference).
+func (e IndexEntry) FileDigest(relPath string) (string, bool) {
+	for _, f := range e.FileDigests() {
+		if f.Path == relPath {
+			return f.Digest, true
+		}
+	}
+	return "", false
 }
 
 // Validate checks the per-type field requirements from SEP-2640's index

--- a/ext/skills/types_test.go
+++ b/ext/skills/types_test.go
@@ -3,6 +3,7 @@ package skills_test
 import (
 	"encoding/json"
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -101,7 +102,7 @@ func TestIndexEntry_RoundTrip(t *testing.T) {
 		t.Fatalf("round-trip lost entries: %d → %d", len(orig.Skills), len(second.Skills))
 	}
 	for i := range orig.Skills {
-		if orig.Skills[i] != second.Skills[i] {
+		if !reflect.DeepEqual(orig.Skills[i], second.Skills[i]) {
 			t.Errorf("entry %d: round-trip mismatch\n  orig = %#v\n  new  = %#v", i, orig.Skills[i], second.Skills[i])
 		}
 	}


### PR DESCRIPTION
## Why

The non-archive index pinned `SKILL.md` only (`IndexEntry.Digest`). Supporting files fetched via `resources/read` (scripts, templates, referenced docs) carried no digest, so a re-verifying host could not detect a **swapped supporting file**. This is threat **B1** in the WG threat model (`experimental-ext-skills#108`, fixture `adv-supporting-file-digest-swap`), asserted as gap **G13** in `adversarial_test.go`.

## What

Per-file digests (the shape chosen in the design discussion for this issue):

- **`IndexEntry.Files []FileDigest{Path, Digest}`** — the Indexer walks each skill-md skill's directory and pins every regular file except `SKILL.md`, keyed by skill-root-relative path (matching `ReadSkillFile` resolution). Archive entries skip it (integrity-checked as a unit). Symlinks/devices are not pinned.
- **`Client.ReadSkillFileVerified(entry, manifest, relPath)`** — resolves the file, looks up its pin (canonicalizing the path via the resolved URI so `./x` and `a/../b` match), verifies the served bytes. Rejects a swap on read with `ErrDigestMismatch`; returns `ErrSupportingFileUnpinned` when no pin exists, so a re-verifying host never silently falls back to an unverified read.

Per-file (not whole-skill) digests were chosen so a single file verifies at read time without fetching the whole skill — fits the lazy read model and the byte-cap work from PR 872.

## Notes

- **Cache freshness**: file-mode invalidation still tracks `SKILL.md` mtime, so a supporting file that changes without a `SKILL.md` touch refreshes on the TTL boundary or via the push path (issue 795), not instantly — the same window `SKILL.md` content already had. Walking the whole subtree on every cache hit would defeat the cache (guarded by `TestIndexer_CacheTTL_*`); documented on `skillMtime`.
- The `files` field is not reverse-domain-namespaced pending the upstream index-format decision (issue 780); mcpkit ships its own pin and reads whatever the SEP settles on.

## Test

Flips `adversarial_test.go` from gap G13 to **covered** (`supporting-file-digest-swap` subtest). New `client_supporting_digest_test.go`: Files populated + shape, verified-read match, swap rejected (`ErrDigestMismatch`), unpinned rejected (`ErrSupportingFileUnpinned`), path-normalization. Existing `==` comparisons on `IndexEntry` migrated to `reflect.DeepEqual` (slice field). `go test ./... && go vet ./...` green in `ext/skills`; `examples/skills` vet green.

Closes issue #866 
