### PR TITLE
docs(sep-2577): correct deprecation messages — removal deferred out of 0.4

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -76,7 +76,7 @@ func WithTokenSource(ts core.TokenSource) ClientOption {
 // SamplingHandler handles a server-to-client sampling/createMessage request.
 // The client performs LLM inference and returns the result.
 //
-// Deprecated: per SEP-2577, scheduled for removal in v0.4. See docs/SEP_2577_DEPRECATIONS.md.
+// Deprecated: per SEP-2577. Retained in 0.4; removal deferred to a future release (~2027 at the earliest, issue 850). See docs/SEP_2577_DEPRECATIONS.md.
 type SamplingHandler func(context.Context, core.CreateMessageRequest) (core.CreateMessageResult, error)
 
 // ElicitationHandler handles a server-to-client elicitation/create request.
@@ -94,13 +94,13 @@ type ElicitationCompleteHandler func(context.Context, core.ElicitationCompletePa
 // RootsHandler handles a server-to-client roots/list request.
 // The client returns its current filesystem roots.
 //
-// Deprecated: per SEP-2577, scheduled for removal in v0.4. See docs/SEP_2577_DEPRECATIONS.md.
+// Deprecated: per SEP-2577. Retained in 0.4; removal deferred to a future release (~2027 at the earliest, issue 850). See docs/SEP_2577_DEPRECATIONS.md.
 type RootsHandler func(context.Context) ([]core.Root, error)
 
 // WithSamplingHandler registers a handler for server-to-client sampling requests.
 // When set, the client advertises the "sampling" capability during initialization.
 //
-// Deprecated: per SEP-2577, scheduled for removal in v0.4. See docs/SEP_2577_DEPRECATIONS.md.
+// Deprecated: per SEP-2577. Retained in 0.4; removal deferred to a future release (~2027 at the earliest, issue 850). See docs/SEP_2577_DEPRECATIONS.md.
 func WithSamplingHandler(h SamplingHandler) ClientOption {
 	return func(c *Client) { c.samplingHandler = h }
 }
@@ -130,7 +130,7 @@ func WithElicitationCompleteHandler(h ElicitationCompleteHandler) ClientOption {
 // during initialization, enabling the server to fetch the client's filesystem roots
 // after receiving a notifications/roots/list_changed notification.
 //
-// Deprecated: per SEP-2577, scheduled for removal in v0.4. See docs/SEP_2577_DEPRECATIONS.md.
+// Deprecated: per SEP-2577. Retained in 0.4; removal deferred to a future release (~2027 at the earliest, issue 850). See docs/SEP_2577_DEPRECATIONS.md.
 func WithRootsHandler(h RootsHandler) ClientOption {
 	return func(c *Client) { c.rootsHandler = h }
 }
@@ -982,7 +982,7 @@ func (c *Client) dispatchServerRequest(ctx context.Context, req *core.Request) *
 // to the server. Call this after the client's filesystem roots have changed
 // so the server can re-fetch the current list via a roots/list request.
 //
-// Deprecated: per SEP-2577, scheduled for removal in v0.4. See docs/SEP_2577_DEPRECATIONS.md.
+// Deprecated: per SEP-2577. Retained in 0.4; removal deferred to a future release (~2027 at the earliest, issue 850). See docs/SEP_2577_DEPRECATIONS.md.
 func (c *Client) NotifyRootsChanged() error {
 	return c.notifyMethod("notifications/roots/list_changed", nil)
 }

--- a/core/handler_context.go
+++ b/core/handler_context.go
@@ -240,7 +240,7 @@ func (bc BaseContext) Baggage() Baggage {
 
 // EmitLog sends a log notification at the given severity level.
 //
-// Deprecated: per SEP-2577, scheduled for removal in v0.4. See docs/SEP_2577_DEPRECATIONS.md.
+// Deprecated: per SEP-2577. Retained in 0.4; removal deferred to a future release (~2027 at the earliest, issue 850). See docs/SEP_2577_DEPRECATIONS.md.
 func (bc BaseContext) EmitLog(level LogLevel, logger string, data any) {
 	if bc.sc == nil || bc.sc.notify == nil || bc.sc.logLevel == nil {
 		return
@@ -280,7 +280,7 @@ func (bc BaseContext) SessionID() string {
 // The client retries the same tools/call; the handler reads the answer
 // via ctx.InputResponse("draft-summary") + core.DecodeSamplingInputResponse.
 //
-// Deprecated: per SEP-2577, scheduled for removal in v0.4. See docs/SEP_2577_DEPRECATIONS.md.
+// Deprecated: per SEP-2577. Retained in 0.4; removal deferred to a future release (~2027 at the earliest, issue 850). See docs/SEP_2577_DEPRECATIONS.md.
 func (bc BaseContext) Sample(req CreateMessageRequest) (CreateMessageResult, error) {
 	if bc.sc == nil || bc.sc.request == nil {
 		return CreateMessageResult{}, ErrNoRequestFunc
@@ -470,14 +470,14 @@ func (bc BaseContext) NotifyResourceUpdated(uri string) {
 // IsPathAllowed reports whether the given file path falls within the
 // session's enforced roots.
 //
-// Deprecated: per SEP-2577, scheduled for removal in v0.4. See docs/SEP_2577_DEPRECATIONS.md.
+// Deprecated: per SEP-2577. Retained in 0.4; removal deferred to a future release (~2027 at the earliest, issue 850). See docs/SEP_2577_DEPRECATIONS.md.
 func (bc BaseContext) IsPathAllowed(path string) bool {
 	return IsPathAllowed(bc.Context, path)
 }
 
 // AllowedRoots returns the current enforced roots for the session.
 //
-// Deprecated: per SEP-2577, scheduled for removal in v0.4. See docs/SEP_2577_DEPRECATIONS.md.
+// Deprecated: per SEP-2577. Retained in 0.4; removal deferred to a future release (~2027 at the earliest, issue 850). See docs/SEP_2577_DEPRECATIONS.md.
 func (bc BaseContext) AllowedRoots() []string {
 	return AllowedRoots(bc.Context)
 }

--- a/core/logging.go
+++ b/core/logging.go
@@ -6,12 +6,12 @@ import "context"
 // Used with logging/setLevel to control the minimum level of log notifications
 // sent to the client, and with EmitLog to specify the severity of a message.
 //
-// Deprecated: per SEP-2577, scheduled for removal in v0.4. See docs/SEP_2577_DEPRECATIONS.md.
+// Deprecated: per SEP-2577. Retained in 0.4; removal deferred to a future release (~2027 at the earliest, issue 850). See docs/SEP_2577_DEPRECATIONS.md.
 type LogLevel int
 
 // MCP log severity levels.
 //
-// Deprecated: per SEP-2577, scheduled for removal in v0.4. See docs/SEP_2577_DEPRECATIONS.md.
+// Deprecated: per SEP-2577. Retained in 0.4; removal deferred to a future release (~2027 at the earliest, issue 850). See docs/SEP_2577_DEPRECATIONS.md.
 const (
 	LogDebug     LogLevel = iota // debug: detailed debugging information
 	LogInfo                      // info: general informational messages
@@ -49,7 +49,7 @@ func (l LogLevel) String() string {
 // ParseLogLevel converts a string to a LogLevel.
 // Returns the level and true on success, or (LogDebug, false) for unknown strings.
 //
-// Deprecated: per SEP-2577, scheduled for removal in v0.4. See docs/SEP_2577_DEPRECATIONS.md.
+// Deprecated: per SEP-2577. Retained in 0.4; removal deferred to a future release (~2027 at the earliest, issue 850). See docs/SEP_2577_DEPRECATIONS.md.
 func ParseLogLevel(s string) (LogLevel, bool) {
 	l, ok := logLevelNames[s]
 	return l, ok
@@ -57,7 +57,7 @@ func ParseLogLevel(s string) (LogLevel, bool) {
 
 // LogMessage is the params payload for a notifications/message notification.
 //
-// Deprecated: per SEP-2577, scheduled for removal in v0.4. See docs/SEP_2577_DEPRECATIONS.md.
+// Deprecated: per SEP-2577. Retained in 0.4; removal deferred to a future release (~2027 at the earliest, issue 850). See docs/SEP_2577_DEPRECATIONS.md.
 type LogMessage struct {
 	Level  string `json:"level"`
 	Logger string `json:"logger,omitempty"`
@@ -78,7 +78,7 @@ type LogMessage struct {
 //	    return mcpkit.TextResult("done"), nil
 //	}
 //
-// Deprecated: per SEP-2577, scheduled for removal in v0.4. See docs/SEP_2577_DEPRECATIONS.md.
+// Deprecated: per SEP-2577. Retained in 0.4; removal deferred to a future release (~2027 at the earliest, issue 850). See docs/SEP_2577_DEPRECATIONS.md.
 func EmitLog(ctx context.Context, level LogLevel, logger string, data any) {
 	sc := sessionFromContext(ctx)
 	if sc == nil || sc.notify == nil || sc.logLevel == nil {

--- a/core/mrtr.go
+++ b/core/mrtr.go
@@ -151,7 +151,7 @@ func (r InputRequiredResult) MarshalJSON() ([]byte, error) {
 // dispatch path will surface that as a client-side validation error so
 // the round trip still terminates rather than hanging.
 //
-// Deprecated: per SEP-2577, scheduled for removal in v0.4. See docs/SEP_2577_DEPRECATIONS.md.
+// Deprecated: per SEP-2577. Retained in 0.4; removal deferred to a future release (~2027 at the earliest, issue 850). See docs/SEP_2577_DEPRECATIONS.md.
 func NewSamplingInputRequest(req CreateMessageRequest) InputRequest {
 	raw, _ := MarshalJSON(req)
 	return InputRequest{
@@ -184,7 +184,7 @@ func NewElicitationInputRequest(req ElicitationRequest) InputRequest {
 // stay on the common path. Used by the SEP-2322
 // `input-required-result-basic-list-roots` conformance scenario.
 //
-// Deprecated: per SEP-2577, scheduled for removal in v0.4. See docs/SEP_2577_DEPRECATIONS.md.
+// Deprecated: per SEP-2577. Retained in 0.4; removal deferred to a future release (~2027 at the earliest, issue 850). See docs/SEP_2577_DEPRECATIONS.md.
 func NewListRootsInputRequest() InputRequest {
 	return InputRequest{
 		Method: "roots/list",
@@ -197,7 +197,7 @@ func NewListRootsInputRequest() InputRequest {
 // Used on the second tools/call round after the client has answered
 // the sampling request.
 //
-// Deprecated: per SEP-2577, scheduled for removal in v0.4. See docs/SEP_2577_DEPRECATIONS.md.
+// Deprecated: per SEP-2577. Retained in 0.4; removal deferred to a future release (~2027 at the earliest, issue 850). See docs/SEP_2577_DEPRECATIONS.md.
 func DecodeSamplingInputResponse(raw json.RawMessage) (CreateMessageResult, error) {
 	var out CreateMessageResult
 	if err := json.Unmarshal(raw, &out); err != nil {
@@ -220,7 +220,7 @@ func DecodeElicitationInputResponse(raw json.RawMessage) (ElicitationResult, err
 // RootsListResult — symmetric with NewListRootsInputRequest. Used on the
 // second tools/call round after the client has reported its current roots.
 //
-// Deprecated: per SEP-2577, scheduled for removal in v0.4. See docs/SEP_2577_DEPRECATIONS.md.
+// Deprecated: per SEP-2577. Retained in 0.4; removal deferred to a future release (~2027 at the earliest, issue 850). See docs/SEP_2577_DEPRECATIONS.md.
 func DecodeListRootsInputResponse(raw json.RawMessage) (RootsListResult, error) {
 	var out RootsListResult
 	if err := json.Unmarshal(raw, &out); err != nil {

--- a/core/protocol.go
+++ b/core/protocol.go
@@ -77,7 +77,7 @@ type Root struct {
 
 // RootsListResult is the response to a roots/list server-to-client request.
 //
-// Deprecated: per SEP-2577, scheduled for removal in v0.4. See docs/SEP_2577_DEPRECATIONS.md.
+// Deprecated: per SEP-2577. Retained in 0.4; removal deferred to a future release (~2027 at the earliest, issue 850). See docs/SEP_2577_DEPRECATIONS.md.
 type RootsListResult struct {
 	Roots []Root `json:"roots"`
 }

--- a/core/roots_allowed.go
+++ b/core/roots_allowed.go
@@ -33,7 +33,7 @@ import (
 // allows "/workspace/src/main.go" but NOT "/workspace-other/y". Both
 // the root and the path are cleaned via filepath.Clean before comparison.
 //
-// Deprecated: per SEP-2577, scheduled for removal in v0.4. See docs/SEP_2577_DEPRECATIONS.md.
+// Deprecated: per SEP-2577. Retained in 0.4; removal deferred to a future release (~2027 at the earliest, issue 850). See docs/SEP_2577_DEPRECATIONS.md.
 func IsPathAllowed(ctx context.Context, path string) bool {
 	sc := sessionFromContext(ctx)
 	if sc == nil || sc.allowedRoots == nil {
@@ -58,7 +58,7 @@ func IsPathAllowed(ctx context.Context, path string) bool {
 // snapshot from the allowed-roots function — it may change on the next
 // call if client roots update.
 //
-// Deprecated: per SEP-2577, scheduled for removal in v0.4. See docs/SEP_2577_DEPRECATIONS.md.
+// Deprecated: per SEP-2577. Retained in 0.4; removal deferred to a future release (~2027 at the earliest, issue 850). See docs/SEP_2577_DEPRECATIONS.md.
 func AllowedRoots(ctx context.Context) []string {
 	sc := sessionFromContext(ctx)
 	if sc == nil || sc.allowedRoots == nil {
@@ -72,7 +72,7 @@ func AllowedRoots(ctx context.Context) []string {
 // the computed root set during session setup. Must be called AFTER
 // ContextWithSession.
 //
-// Deprecated: per SEP-2577, scheduled for removal in v0.4. See docs/SEP_2577_DEPRECATIONS.md.
+// Deprecated: per SEP-2577. Retained in 0.4; removal deferred to a future release (~2027 at the earliest, issue 850). See docs/SEP_2577_DEPRECATIONS.md.
 func SetAllowedRoots(ctx context.Context, fn func() []string) context.Context {
 	if sc := sessionFromContext(ctx); sc != nil {
 		sc.allowedRoots = fn

--- a/core/sampling.go
+++ b/core/sampling.go
@@ -8,12 +8,12 @@ import (
 
 // Sentinel errors for sampling.
 //
-// Deprecated: per SEP-2577, scheduled for removal in v0.4. See docs/SEP_2577_DEPRECATIONS.md.
+// Deprecated: per SEP-2577. Retained in 0.4; removal deferred to a future release (~2027 at the earliest, issue 850). See docs/SEP_2577_DEPRECATIONS.md.
 var ErrSamplingNotSupported = errors.New("client does not support sampling")
 
 // SamplingMessage is a single message in a sampling/createMessage request.
 //
-// Deprecated: per SEP-2577, scheduled for removal in v0.4. See docs/SEP_2577_DEPRECATIONS.md.
+// Deprecated: per SEP-2577. Retained in 0.4; removal deferred to a future release (~2027 at the earliest, issue 850). See docs/SEP_2577_DEPRECATIONS.md.
 type SamplingMessage struct {
 	Role    string  `json:"role"`
 	Content Content `json:"content"`
@@ -38,7 +38,7 @@ func (m *SamplingMessage) UnmarshalJSON(data []byte) error {
 
 // ModelHint provides hints about which model the server prefers for sampling.
 //
-// Deprecated: per SEP-2577, scheduled for removal in v0.4. See docs/SEP_2577_DEPRECATIONS.md.
+// Deprecated: per SEP-2577. Retained in 0.4; removal deferred to a future release (~2027 at the earliest, issue 850). See docs/SEP_2577_DEPRECATIONS.md.
 type ModelHint struct {
 	Name string `json:"name,omitempty"`
 }
@@ -46,7 +46,7 @@ type ModelHint struct {
 // ModelPreferences describes the server's preferences for model selection
 // when the client performs LLM sampling.
 //
-// Deprecated: per SEP-2577, scheduled for removal in v0.4. See docs/SEP_2577_DEPRECATIONS.md.
+// Deprecated: per SEP-2577. Retained in 0.4; removal deferred to a future release (~2027 at the earliest, issue 850). See docs/SEP_2577_DEPRECATIONS.md.
 type ModelPreferences struct {
 	Hints                []ModelHint `json:"hints,omitempty"`
 	CostPriority         *float64   `json:"costPriority,omitempty"`
@@ -57,7 +57,7 @@ type ModelPreferences struct {
 // SamplingMeta holds protocol-level metadata for a sampling request.
 // Serialized as "_meta" in the sampling/createMessage params.
 //
-// Deprecated: per SEP-2577, scheduled for removal in v0.4. See docs/SEP_2577_DEPRECATIONS.md.
+// Deprecated: per SEP-2577. Retained in 0.4; removal deferred to a future release (~2027 at the earliest, issue 850). See docs/SEP_2577_DEPRECATIONS.md.
 type SamplingMeta struct {
 	// UI contains MCP Apps presentation metadata.
 	// When set, the host can associate the sampling request with a UI resource.
@@ -72,7 +72,7 @@ type SamplingMeta struct {
 // CreateMessageRequest is the params for a sampling/createMessage server-to-client request.
 // The server sends this to ask the client to perform LLM inference.
 //
-// Deprecated: per SEP-2577, scheduled for removal in v0.4. See docs/SEP_2577_DEPRECATIONS.md.
+// Deprecated: per SEP-2577. Retained in 0.4; removal deferred to a future release (~2027 at the earliest, issue 850). See docs/SEP_2577_DEPRECATIONS.md.
 type CreateMessageRequest struct {
 	Messages         []SamplingMessage `json:"messages"`
 	SystemPrompt     string            `json:"systemPrompt,omitempty"`
@@ -87,7 +87,7 @@ type CreateMessageRequest struct {
 
 // CreateMessageResult is the client's response to a sampling/createMessage request.
 //
-// Deprecated: per SEP-2577, scheduled for removal in v0.4. See docs/SEP_2577_DEPRECATIONS.md.
+// Deprecated: per SEP-2577. Retained in 0.4; removal deferred to a future release (~2027 at the earliest, issue 850). See docs/SEP_2577_DEPRECATIONS.md.
 type CreateMessageResult struct {
 	Model      string  `json:"model"`
 	StopReason string  `json:"stopReason,omitempty"`
@@ -135,7 +135,7 @@ func (r *CreateMessageResult) UnmarshalJSON(data []byte) error {
 //	    return mcpkit.TextResult(result.Content.Text), nil
 //	}
 //
-// Deprecated: per SEP-2577, scheduled for removal in v0.4. See docs/SEP_2577_DEPRECATIONS.md.
+// Deprecated: per SEP-2577. Retained in 0.4; removal deferred to a future release (~2027 at the earliest, issue 850). See docs/SEP_2577_DEPRECATIONS.md.
 func Sample(ctx context.Context, req CreateMessageRequest) (CreateMessageResult, error) {
 	sc := sessionFromContext(ctx)
 	if sc == nil || sc.request == nil {

--- a/core/slog_handler.go
+++ b/core/slog_handler.go
@@ -21,7 +21,7 @@ import (
 //	    ...
 //	}
 //
-// Deprecated: per SEP-2577, scheduled for removal in v0.4. See docs/SEP_2577_DEPRECATIONS.md.
+// Deprecated: per SEP-2577. Retained in 0.4; removal deferred to a future release (~2027 at the earliest, issue 850). See docs/SEP_2577_DEPRECATIONS.md.
 type MCPLogHandler struct {
 	sc     *sessionCtx
 	logger string       // MCP "logger" field in notifications/message
@@ -32,7 +32,7 @@ type MCPLogHandler struct {
 
 // MCPLogHandlerOptions configures NewMCPLogHandler.
 //
-// Deprecated: per SEP-2577, scheduled for removal in v0.4. See docs/SEP_2577_DEPRECATIONS.md.
+// Deprecated: per SEP-2577. Retained in 0.4; removal deferred to a future release (~2027 at the earliest, issue 850). See docs/SEP_2577_DEPRECATIONS.md.
 type MCPLogHandlerOptions struct {
 	// Logger is the MCP logger name sent in the "logger" field of
 	// notifications/message. Defaults to "" (empty).
@@ -51,7 +51,7 @@ type MCPLogHandlerOptions struct {
 // If ctx has no session (e.g., called outside a handler), the handler is
 // a safe no-op — Enabled() returns false for all levels.
 //
-// Deprecated: per SEP-2577, scheduled for removal in v0.4. See docs/SEP_2577_DEPRECATIONS.md.
+// Deprecated: per SEP-2577. Retained in 0.4; removal deferred to a future release (~2027 at the earliest, issue 850). See docs/SEP_2577_DEPRECATIONS.md.
 func NewMCPLogHandler(ctx context.Context, opts *MCPLogHandlerOptions) *MCPLogHandler {
 	h := &MCPLogHandler{sc: sessionFromContext(ctx)}
 	if opts != nil {
@@ -157,7 +157,7 @@ func (h *MCPLogHandler) buildData(record slog.Record) any {
 //	slog.LevelError  (8)  → LogError
 //	> slog.LevelError      → LogCritical
 //
-// Deprecated: per SEP-2577, scheduled for removal in v0.4. See docs/SEP_2577_DEPRECATIONS.md.
+// Deprecated: per SEP-2577. Retained in 0.4; removal deferred to a future release (~2027 at the earliest, issue 850). See docs/SEP_2577_DEPRECATIONS.md.
 func SlogToMCPLevel(level slog.Level) LogLevel {
 	switch {
 	case level < slog.LevelInfo:
@@ -181,7 +181,7 @@ func SlogToMCPLevel(level slog.Level) LogLevel {
 //	LogError            → slog.LevelError
 //	LogCritical+        → slog.LevelError + 4
 //
-// Deprecated: per SEP-2577, scheduled for removal in v0.4. See docs/SEP_2577_DEPRECATIONS.md.
+// Deprecated: per SEP-2577. Retained in 0.4; removal deferred to a future release (~2027 at the earliest, issue 850). See docs/SEP_2577_DEPRECATIONS.md.
 func MCPToSlogLevel(level LogLevel) slog.Level {
 	switch level {
 	case LogDebug:

--- a/docs/SEP_2577_DEPRECATIONS.md
+++ b/docs/SEP_2577_DEPRECATIONS.md
@@ -2,11 +2,11 @@
 
 [SEP-2577](https://github.com/modelcontextprotocol/specification/pull/2577) lands in the MCP 2026-07-28 RC (locked 2026-05-21). It puts three protocol features on a deprecation path: **Roots**, **Sampling**, and **Logging**. mcpkit is on the 12-month annotation-only path — every existing call still works at runtime; godoc `// Deprecated:` blocks fire `staticcheck SA1019` (and any IDE that consumes it) at call sites so consumers see the warning the moment they upgrade.
 
-**Removal target:** mcpkit v0.4. v0.3.x (the 2026-07-28 RC line) keeps the surfaces fully functional alongside the deprecation comments. Until v0.4 cuts, *no behavior changes*.
+**Removal target:** a future major release, no earlier than the spec window below (~2027). Removal was **deferred out of 0.4** (tracked in issue 850): 0.4 keeps the surfaces fully functional alongside the deprecation comments, so *no behavior changes* at the 0.4 cut. Removing them at 0.4 would break mcpkit's own 12-month annotation window (closes ~2027-05-21) and drop it below 100% conformance / Tier-1 while the features remain in the targeted spec version.
 
 ## TL;DR
 
-| Feature | mcpkit surface | Status in v0.3.x | What to do |
+| Feature | mcpkit surface | Status in 0.4.x | What to do |
 |---|---|---|---|
 | Roots | `WithAllowedRoots`, `IsPathAllowed`, `RootsListResult`, `WithRootsHandler`, `NotifyRootsChanged` | works, deprecated | move root-list semantics into application-level resource conventions; see [Roots replacement](#roots) |
 | Sampling | `Sample`, `CreateMessageRequest`, `SamplingMessage`, `ModelPreferences`, `WithSamplingHandler`, `TaskSample` | works, deprecated | bring your own LLM client; see [Sampling replacement](#sampling) |
@@ -24,9 +24,9 @@ The MCP working group's framing (paraphrased from SEP-2577 discussion): **Roots*
 | 2026-05-31 | mcpkit annotation pass lands (this doc + `Deprecated:` blocks) |
 | 2026-07-28 | MCP 2026-07-28 GA — features remain in the spec but flagged deprecated |
 | 2027-05-21 | 12-month annotation window minimum closes |
-| mcpkit v0.4 | mcpkit removes the deprecated symbols (no earlier than the spec window above) |
+| a future major release (≥ 2027) | mcpkit removes the deprecated symbols — no earlier than the spec window above. Deferred out of 0.4 (issue 850). |
 
-If the spec window extends, mcpkit's v0.4 cut follows it — the deprecation doc is the source of truth, not a calendar date.
+Removal was **deferred out of 0.4**: 0.4 keeps the surfaces working, and removing them earlier would break the annotation window above and drop mcpkit below Tier-1 while the features are still in the targeted spec version. If the spec window extends, mcpkit's removal follows it — the deprecation doc is the source of truth, not a calendar date.
 
 ## Affected symbols
 
@@ -40,7 +40,7 @@ If the spec window extends, mcpkit's v0.4 cut follows it — the deprecation doc
 | `core.BaseContext.IsPathAllowed(path) bool` | Same. |
 | `core.RootsListResult` | No replacement — the `roots/list` server-to-client request is the thing being deprecated. |
 | `core.DecodeListRootsInputResponse` | MRTR helper for the deprecated `roots/list` flow; remove when the MRTR composition no longer needs roots input. |
-| `client.RootsHandler`, `client.WithRootsHandler(h)` | Host wires filesystem permissions itself; mcpkit's client no longer needs to negotiate them after v0.4. |
+| `client.RootsHandler`, `client.WithRootsHandler(h)` | Host wires filesystem permissions itself; mcpkit's client no longer needs to negotiate them after removal. |
 | `(*client.Client).NotifyRootsChanged()` | No replacement — `roots/list_changed` is part of the deprecated surface. |
 
 **Migration sketch:** Move from *"server asks client which paths are allowed"* (Roots) to *"application bakes in its own filesystem capability before construction."* For tools that legitimately need user-scoped file access, model that as a resource or as an explicit tool argument, not as a protocol-level negotiation.
@@ -54,7 +54,7 @@ If the spec window extends, mcpkit's v0.4 cut follows it — the deprecation doc
 | `core.CreateMessageRequest`, `core.SamplingMessage`, `core.ModelPreferences`, `core.CreateMessageResult` | No replacement at the protocol surface — these wire types disappear. Application-level model abstractions replace them. |
 | `core.NewSamplingInputRequest(req)`, `core.DecodeSamplingInputResponse` | MRTR helpers for the deprecated sampling-in-MRTR flow. |
 | `(*server.TaskContext).TaskSample(req) (CreateMessageResult, error)` | Same as `Sample()` — task continuations should hold their own LLM client. |
-| `client.SamplingHandler`, `client.WithSamplingHandler(h)` | After v0.4, the host's LLM client and the MCP client are separately wired — no protocol negotiation. |
+| `client.SamplingHandler`, `client.WithSamplingHandler(h)` | After removal, the host's LLM client and the MCP client are separately wired — no protocol negotiation. |
 
 **Migration sketch:** Most tools that previously did `ctx.Sample(...)` were really asking *"call the host's LLM with this prompt."* Pass that LLM client into the server constructor; tools call it directly. mcpkit's role narrows to tool dispatch + transport; sampling stops being a wire-level concept.
 
@@ -72,6 +72,6 @@ If the spec window extends, mcpkit's v0.4 cut follows it — the deprecation doc
 
 ## Notes for mcpkit contributors
 
-- `// Deprecated:` blocks are per Go convention: blank-line-separated paragraph starting with `Deprecated:`. `staticcheck -checks SA1019` enforces no internal call sites accidentally regress to *new* uses of the deprecated symbols — current call sites are grandfathered through v0.3.x but should be tracked so v0.4 removal is mechanical.
-- Examples (`examples/mrtr`, `examples/apps/*`, `examples/stateless`, `examples/tasks`) still demo the deprecated surfaces — they're working illustrations of how the API behaves in v0.3.x. Each affected example carries a README banner pointing here. After v0.4 cut, the examples migrate or get retired with the symbols they demo.
+- `// Deprecated:` blocks are per Go convention: blank-line-separated paragraph starting with `Deprecated:`. `staticcheck -checks SA1019` enforces no internal call sites accidentally regress to *new* uses of the deprecated symbols — current call sites are grandfathered through 0.4.x but should be tracked so the eventual removal is mechanical.
+- Examples (`examples/mrtr`, `examples/apps/*`, `examples/stateless`, `examples/tasks`) still demo the deprecated surfaces — they're working illustrations of how the API behaves in 0.4.x. Each affected example carries a README banner pointing here. After the removal cut, the examples migrate or get retired with the symbols they demo.
 - The deprecation surfaces are wire-level: this doc does **not** deprecate `slog` integration as a general pattern, only mcpkit's MCP-protocol bridge for it. Same with model-client wiring — only the protocol-mediated path is leaving.

--- a/server/server.go
+++ b/server/server.go
@@ -532,7 +532,7 @@ func WithFileInputValidation() Option {
 
 // WithAllowedRoots restricts tool cwd to the given directory prefixes.
 //
-// Deprecated: per SEP-2577, scheduled for removal in v0.4. See docs/SEP_2577_DEPRECATIONS.md.
+// Deprecated: per SEP-2577. Retained in 0.4; removal deferred to a future release (~2027 at the earliest, issue 850). See docs/SEP_2577_DEPRECATIONS.md.
 func WithAllowedRoots(roots ...string) Option {
 	return func(o *serverOptions) { o.allowedRoots = roots }
 }
@@ -631,7 +631,7 @@ func WithSupportedVersions(versions ...string) Option {
 // Decrease for aggressive fail-fast; increase for slow clients with large
 // root enumerations (monorepos, network mounts). Issue #198.
 //
-// Deprecated: per SEP-2577, scheduled for removal in v0.4. See docs/SEP_2577_DEPRECATIONS.md.
+// Deprecated: per SEP-2577. Retained in 0.4; removal deferred to a future release (~2027 at the earliest, issue 850). See docs/SEP_2577_DEPRECATIONS.md.
 func WithRootsFetchTimeout(d time.Duration) Option {
 	return func(o *serverOptions) { o.rootsFetchTimeout = d }
 }

--- a/server/task_session.go
+++ b/server/task_session.go
@@ -131,7 +131,7 @@ func (tc *TaskContext) TaskElicit(req core.ElicitationRequest) (core.Elicitation
 //
 // Status transitions: working → input_required → working.
 //
-// Deprecated: per SEP-2577, scheduled for removal in v0.4. See docs/SEP_2577_DEPRECATIONS.md.
+// Deprecated: per SEP-2577. Retained in 0.4; removal deferred to a future release (~2027 at the earliest, issue 850). See docs/SEP_2577_DEPRECATIONS.md.
 func (tc *TaskContext) TaskSample(req core.CreateMessageRequest) (core.CreateMessageResult, error) {
 	if req.Meta == nil {
 		req.Meta = &core.SamplingMeta{}


### PR DESCRIPTION
## Why

The `// Deprecated:` blocks on the SEP-2577 Roots / Sampling / Logging surfaces (and the MRTR input-request helpers) said *"scheduled for removal in v0.4"*. That's stale: removal was **deferred out of 0.4** (issue 850). 0.4 keeps every surface working with no behavior change; removing them at 0.4 would break mcpkit's own 12-month annotation window (closes ~2027-05-21) and drop it below 100% conformance / Tier-1 while the features are still in the targeted spec version.

The warning fires via `staticcheck SA1019` and IDEs at every call site, so the wrong version claim actively misleads anyone who upgrades.

## What

- Swept all **38** occurrences across `core/`, `server/`, `client/` to a version-neutral, accurate message:
  > `per SEP-2577. Retained in 0.4; removal deferred to a future release (~2027 at the earliest, issue 850). See docs/SEP_2577_DEPRECATIONS.md.`
- Reconciled `docs/SEP_2577_DEPRECATIONS.md` (the pointer target, which had the same stale framing): removal target, timeline table row, and the scattered "after v0.4" / "v0.3.x" phrasings now describe a deferred, version-neutral removal.

Comment + doc only. No behavior change; `go build ./core/... ./server/... ./client/...` green.

## Note (pre-existing, not touched)

`gofmt -l` flags unrelated struct-tag alignment drift in 5 of these files (e.g. `core/sampling.go` `ModelPreferences`). That drift is **pre-existing on main**, not from this sweep, so I left it out to keep the diff comment-only. Easy separate `gofmt -w` cleanup if wanted.

https://claude.ai/code/session_01PAT6AvpFqzrurThGZniHZv