### PR TITLE
feat(events): pluggable cursor provenance for multi-writer consistency (issue 833)

### DIFF
--- a/experimental/ext/events/README.md
+++ b/experimental/ext/events/README.md
@@ -26,6 +26,20 @@ Sources come in two flavors:
 
 Use cursorless for ephemeral state where replay carries no value (typing indicators, presence, current readings). Use cursored for messages, alerts, audit logs, etc.
 
+## Cursor provenance — single vs multi-writer (issue 833)
+
+A cursored event's `cursor` orders it within its source; `events/poll` returns events strictly after a client's last-seen cursor, so gap-free resume across a reconnect needs cursors that are **monotone and unique across every writer of that source**. Who mints the cursor is pluggable:
+
+| Provenance | Wire it with | Use when |
+|---|---|---|
+| **In-process** (default) | nothing — `InProcessCursors` per source | single writer per source. Zero deps, but each process counts from 1 and resets on restart, so N replicas writing one source **collide**. |
+| **Shared counter** | `WithCursorProvider(events.NewRedisCursors(incr, ""))` | multiple replicas write one source and you have Redis. A shared `INCR` per source — cross-replica, restart-safe. |
+| **Store-minted** | a buffer store that implements `CursorProvidingStore` (e.g. `gormstore.NewEventBufferStore(db, gormstore.WithProvideCursors())`) | you already share a durable buffer store. The store assigns the cursor from its own write sequence on `Append` — mcpkit mints nothing, one round trip. |
+
+Precedence per source: an explicit `WithCursorProvider` wins; otherwise a cursor-providing store mints on write; otherwise `InProcessCursors`. Bring your own by implementing `events.CursorProvider` (`Next(ctx, source) (string, error)` — must return a monotone base-10 integer).
+
+The default is unchanged: with no store and no provider, cursors count `1, 2, 3` per source exactly as before.
+
 ## Quickstart — `YieldingSource`
 
 ```go

--- a/experimental/ext/events/README.md
+++ b/experimental/ext/events/README.md
@@ -33,7 +33,7 @@ A cursored event's `cursor` orders it within its source; `events/poll` returns e
 | Provenance | Wire it with | Use when |
 |---|---|---|
 | **In-process** (default) | nothing — `InProcessCursors` per source | single writer per source. Zero deps, but each process counts from 1 and resets on restart, so N replicas writing one source **collide**. |
-| **Shared counter** | `WithCursorProvider(events.NewRedisCursors(incr, ""))` | multiple replicas write one source and you have Redis. A shared `INCR` per source — cross-replica, restart-safe. |
+| **Shared counter** | `WithCursorProvider(events.NewInt64IncrCursors(incr, ""))` | multiple replicas write one source. `incr` is any `Incrementer` (a Redis `INCR`, a SQL sequence, etc.); shared across replicas it is cross-replica + restart-safe. A ready-made Redis adapter can live in `stores/redis`. |
 | **Store-minted** | a buffer store that implements `CursorProvidingStore` (e.g. `gormstore.NewEventBufferStore(db, gormstore.WithProvideCursors())`) | you already share a durable buffer store. The store assigns the cursor from its own write sequence on `Append` — mcpkit mints nothing, one round trip. |
 
 Precedence per source: an explicit `WithCursorProvider` wins; otherwise a cursor-providing store mints on write; otherwise `InProcessCursors`. Bring your own by implementing `events.CursorProvider` (`Next(ctx, source) (string, error)` — must return a monotone base-10 integer).

--- a/experimental/ext/events/cursor.go
+++ b/experimental/ext/events/cursor.go
@@ -19,7 +19,8 @@ import (
 // same source mint colliding cursors (issue 833). Swap in a provider that
 // is monotone across writers when a source has more than one:
 //
-//   - RedisCursors — a shared INCR counter (cross-replica, restart-safe).
+//   - Int64IncrCursors — a shared atomic-increment counter, e.g. a Redis
+//     INCR (cross-replica, restart-safe).
 //   - a cursor-providing EventBufferStore — see CursorProvidingStore,
 //     where the store assigns the cursor from its own global sequence on
 //     write, so mcpkit mints nothing.
@@ -41,8 +42,9 @@ type CursorProvider interface {
 //
 // It is correct only for a single writer per source: the counter lives in
 // one process and resets to 1 on restart, so two replicas writing the
-// same source mint colliding cursors. Use RedisCursors or a
-// cursor-providing store for multi-writer sources (issue 833).
+// same source mint colliding cursors. Use Int64IncrCursors (a shared
+// counter) or a cursor-providing store for multi-writer sources (issue
+// 833).
 type InProcessCursors struct {
 	mu       sync.Mutex
 	counters map[string]*atomic.Int64
@@ -68,40 +70,44 @@ func (p *InProcessCursors) Next(_ context.Context, source string) (string, error
 	return strconv.FormatInt(c.Add(1), 10), nil
 }
 
-// RedisIncr is the minimal contract RedisCursors needs from a Redis
-// client: an atomic INCR that returns the new value. go-redis's
-// (*redis.Client).Incr satisfies it through a one-line adapter, so core
-// events takes no dependency on any Redis client.
-type RedisIncr interface {
+// Incrementer is the minimal contract Int64IncrCursors needs from a
+// shared counter backend: an atomic increment of a named key that returns
+// the new value. It is deliberately backend-neutral — a Redis INCR, a SQL
+// sequence, an etcd counter, or any store with atomic increment satisfies
+// it — so core events takes no dependency on any particular client.
+// go-redis's (*redis.Client).Incr adapts to it in one line; a ready-made
+// Redis adapter can live in stores/redis.
+type Incrementer interface {
 	Incr(ctx context.Context, key string) (int64, error)
 }
 
-// RedisCursors is a CursorProvider backed by a shared Redis INCR counter,
-// one key per source. It is monotone and unique across every replica
-// sharing the Redis instance, and survives process restarts, so it fixes
-// the multi-writer / restart collision InProcessCursors has (issue 833)
+// Int64IncrCursors is a CursorProvider backed by a shared atomic-increment
+// counter (an Incrementer), one key per source. When the backing counter
+// is shared across replicas (e.g. a Redis INCR), it is monotone and unique
+// across every writer and survives process restarts — fixing the
+// multi-writer / restart collision InProcessCursors has (issue 833)
 // without requiring a cursor-providing store.
-type RedisCursors struct {
-	incr   RedisIncr
+type Int64IncrCursors struct {
+	incr   Incrementer
 	prefix string
 }
 
-// DefaultRedisCursorPrefix is the key prefix RedisCursors uses when none
+// DefaultCursorKeyPrefix is the key prefix Int64IncrCursors uses when none
 // is supplied. The per-source key is prefix + source.
-const DefaultRedisCursorPrefix = "events:cursor:"
+const DefaultCursorKeyPrefix = "events:cursor:"
 
-// NewRedisCursors returns a Redis-backed CursorProvider. keyPrefix is
-// prepended to the source name to form the counter key; empty uses
-// DefaultRedisCursorPrefix.
-func NewRedisCursors(incr RedisIncr, keyPrefix string) *RedisCursors {
+// NewInt64IncrCursors returns a CursorProvider that mints cursors from the
+// given Incrementer. keyPrefix is prepended to the source name to form the
+// counter key; empty uses DefaultCursorKeyPrefix.
+func NewInt64IncrCursors(incr Incrementer, keyPrefix string) *Int64IncrCursors {
 	if keyPrefix == "" {
-		keyPrefix = DefaultRedisCursorPrefix
+		keyPrefix = DefaultCursorKeyPrefix
 	}
-	return &RedisCursors{incr: incr, prefix: keyPrefix}
+	return &Int64IncrCursors{incr: incr, prefix: keyPrefix}
 }
 
-// Next returns INCR(prefix+source) as a base-10 string.
-func (p *RedisCursors) Next(ctx context.Context, source string) (string, error) {
+// Next returns Incr(prefix+source) as a base-10 string.
+func (p *Int64IncrCursors) Next(ctx context.Context, source string) (string, error) {
 	n, err := p.incr.Incr(ctx, p.prefix+source)
 	if err != nil {
 		return "", err

--- a/experimental/ext/events/cursor.go
+++ b/experimental/ext/events/cursor.go
@@ -1,0 +1,136 @@
+package events
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"sync/atomic"
+)
+
+// CursorProvider mints the monotone cursor for a yielded event. The
+// cursor orders an event within its source: events/poll returns events
+// whose cursor is strictly greater than a client's last-seen cursor, so
+// for gap-free resume across a reconnect the values MUST be monotonically
+// increasing and unique across every writer of that source.
+//
+// The default provider (InProcessCursors) is a per-source in-memory
+// counter — correct and zero-overhead for a single writer, but each
+// process starts at 1 and resets on restart, so N replicas writing the
+// same source mint colliding cursors (issue 833). Swap in a provider that
+// is monotone across writers when a source has more than one:
+//
+//   - RedisCursors — a shared INCR counter (cross-replica, restart-safe).
+//   - a cursor-providing EventBufferStore — see CursorProvidingStore,
+//     where the store assigns the cursor from its own global sequence on
+//     write, so mcpkit mints nothing.
+//
+// Wire a provider per source with WithCursorProvider. Precedence in
+// YieldingSource: an explicitly-set provider wins; otherwise a
+// cursor-providing store wins; otherwise InProcessCursors.
+type CursorProvider interface {
+	// Next returns the next cursor for source. Implementations MUST make
+	// it monotone and unique across all concurrent writers of that
+	// source. The returned string is compared numerically downstream, so
+	// it must be a base-10 integer.
+	Next(ctx context.Context, source string) (string, error)
+}
+
+// InProcessCursors is the default CursorProvider: a per-source in-memory
+// atomic counter. It reproduces the historical YieldingSource behavior
+// (each source counts 1, 2, 3, … independently) with zero dependencies.
+//
+// It is correct only for a single writer per source: the counter lives in
+// one process and resets to 1 on restart, so two replicas writing the
+// same source mint colliding cursors. Use RedisCursors or a
+// cursor-providing store for multi-writer sources (issue 833).
+type InProcessCursors struct {
+	mu       sync.Mutex
+	counters map[string]*atomic.Int64
+}
+
+// NewInProcessCursors returns an empty in-process cursor provider. A
+// fresh one is installed as the default on every YieldingSource that does
+// not set WithCursorProvider.
+func NewInProcessCursors() *InProcessCursors {
+	return &InProcessCursors{counters: make(map[string]*atomic.Int64)}
+}
+
+// Next returns the next per-source counter value as a base-10 string,
+// starting at "1" for a source's first event.
+func (p *InProcessCursors) Next(_ context.Context, source string) (string, error) {
+	p.mu.Lock()
+	c, ok := p.counters[source]
+	if !ok {
+		c = &atomic.Int64{}
+		p.counters[source] = c
+	}
+	p.mu.Unlock()
+	return strconv.FormatInt(c.Add(1), 10), nil
+}
+
+// RedisIncr is the minimal contract RedisCursors needs from a Redis
+// client: an atomic INCR that returns the new value. go-redis's
+// (*redis.Client).Incr satisfies it through a one-line adapter, so core
+// events takes no dependency on any Redis client.
+type RedisIncr interface {
+	Incr(ctx context.Context, key string) (int64, error)
+}
+
+// RedisCursors is a CursorProvider backed by a shared Redis INCR counter,
+// one key per source. It is monotone and unique across every replica
+// sharing the Redis instance, and survives process restarts, so it fixes
+// the multi-writer / restart collision InProcessCursors has (issue 833)
+// without requiring a cursor-providing store.
+type RedisCursors struct {
+	incr   RedisIncr
+	prefix string
+}
+
+// DefaultRedisCursorPrefix is the key prefix RedisCursors uses when none
+// is supplied. The per-source key is prefix + source.
+const DefaultRedisCursorPrefix = "events:cursor:"
+
+// NewRedisCursors returns a Redis-backed CursorProvider. keyPrefix is
+// prepended to the source name to form the counter key; empty uses
+// DefaultRedisCursorPrefix.
+func NewRedisCursors(incr RedisIncr, keyPrefix string) *RedisCursors {
+	if keyPrefix == "" {
+		keyPrefix = DefaultRedisCursorPrefix
+	}
+	return &RedisCursors{incr: incr, prefix: keyPrefix}
+}
+
+// Next returns INCR(prefix+source) as a base-10 string.
+func (p *RedisCursors) Next(ctx context.Context, source string) (string, error) {
+	n, err := p.incr.Incr(ctx, p.prefix+source)
+	if err != nil {
+		return "", err
+	}
+	return strconv.FormatInt(n, 10), nil
+}
+
+// CursorProvidingStore is an optional capability an EventBufferStore MAY
+// implement to mint cursors itself on write, from its own global write
+// sequence (issue 833). It is queried by type assertion, so existing and
+// third-party EventBufferStore implementations that do not implement it
+// keep working unchanged — they are simply treated as non-providing and
+// the configured CursorProvider mints instead.
+//
+// The capability is per-source: a single store instance may back many
+// sources, and only some may sit on a backend with a usable sequence
+// (e.g. one SQL table has an autoincrement column, another does not). The
+// runtime queries ProvidesCursor(source) once per source at registration.
+//
+// When ProvidesCursor(source) is true, YieldingSource calls Append with a
+// nil Event.Cursor for that source; the store assigns the cursor and
+// returns it in AppendEventResponse.Cursor. The store-assigned value is
+// then stamped onto the event before it is buffered locally and fanned
+// out. Because the cursor is not known until the write completes, the
+// store-minted path fans out after Append (the we-mint providers stamp
+// before Append and fan out immediately).
+type CursorProvidingStore interface {
+	// ProvidesCursor reports whether this store assigns cursors on write
+	// for the named source. Must be cheap and side-effect-free (a
+	// capability declaration from the store's own config, not a query).
+	ProvidesCursor(source string) bool
+}

--- a/experimental/ext/events/cursor_test.go
+++ b/experimental/ext/events/cursor_test.go
@@ -1,0 +1,175 @@
+package events
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInProcessCursors_PerSourceMonotone(t *testing.T) {
+	p := NewInProcessCursors()
+	ctx := context.Background()
+	// Each source counts independently, starting at 1.
+	for _, src := range []string{"a", "b"} {
+		for want := 1; want <= 3; want++ {
+			got, err := p.Next(ctx, src)
+			require.NoError(t, err)
+			assert.Equal(t, strconv.Itoa(want), got, "source %s", src)
+		}
+	}
+}
+
+// fakeIncr is a minimal in-memory RedisIncr for RedisCursors.
+type fakeIncr struct {
+	mu   sync.Mutex
+	vals map[string]int64
+	keys []string
+}
+
+func (f *fakeIncr) Incr(_ context.Context, key string) (int64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.vals == nil {
+		f.vals = map[string]int64{}
+	}
+	f.vals[key]++
+	f.keys = append(f.keys, key)
+	return f.vals[key], nil
+}
+
+func TestRedisCursors_UsesPrefixedKeyAndIsMonotone(t *testing.T) {
+	incr := &fakeIncr{}
+	p := NewRedisCursors(incr, "")
+	ctx := context.Background()
+	c1, err := p.Next(ctx, "chat.message")
+	require.NoError(t, err)
+	c2, err := p.Next(ctx, "chat.message")
+	require.NoError(t, err)
+	assert.Equal(t, "1", c1)
+	assert.Equal(t, "2", c2)
+	assert.Equal(t, DefaultRedisCursorPrefix+"chat.message", incr.keys[0])
+}
+
+// TestCursorMintingStore_MultiWriterGapFree is the #833 fix: N YieldingSources
+// for the SAME source share one cursor-minting store — the whole-enchilada
+// topology where `make inject` round-robins across N replicas. With the store
+// assigning cursors on write, every event gets a globally-unique, strictly-
+// increasing cursor, so events/poll resume is gap-free across writers. (The
+// sibling TestYieldingSource_EventIDsUniqueAcrossSources documents the
+// collision the per-replica InProcess default has.)
+func TestCursorMintingStore_MultiWriterGapFree(t *testing.T) {
+	const replicas, perReplica = 4, 25
+	store := NewCursorMintingInMemoryStore(0)
+	def := EventDef{Name: "chat.message"}
+	ctx := context.Background()
+
+	var yields []func(context.Context, map[string]string) error
+	for r := 0; r < replicas; r++ {
+		_, y := NewYieldingSource[map[string]string](def, WithEventBufferStore(store))
+		yields = append(yields, y)
+	}
+	for i := 0; i < replicas*perReplica; i++ {
+		require.NoError(t, yields[i%replicas](ctx, map[string]string{"k": "v"}))
+	}
+
+	resp, err := store.Poll(ctx, PollEventsRequest{SourceName: def.Name, Cursor: "", Limit: 10_000})
+	require.NoError(t, err)
+	require.Len(t, resp.Events, replicas*perReplica)
+
+	seen := make(map[string]bool, len(resp.Events))
+	var prev int64
+	for i, e := range resp.Events {
+		require.NotNil(t, e.Cursor, "store-minted event must carry a cursor")
+		assert.False(t, seen[*e.Cursor], "duplicate cursor across replicas: %s", *e.Cursor)
+		seen[*e.Cursor] = true
+		n, err := strconv.ParseInt(*e.Cursor, 10, 64)
+		require.NoError(t, err)
+		if i > 0 {
+			assert.Greater(t, n, prev, "cursors must be strictly increasing")
+		}
+		prev = n
+	}
+
+	// Resume from a mid cursor returns exactly the strictly-later tail.
+	midEvents := resp.Events[:10]
+	midCursor := *midEvents[len(midEvents)-1].Cursor
+	tail, err := store.Poll(ctx, PollEventsRequest{SourceName: def.Name, Cursor: midCursor, Limit: 10_000})
+	require.NoError(t, err)
+	assert.Len(t, tail.Events, replicas*perReplica-10, "resume must be gap-free with no dupes")
+}
+
+// TestCursorMintingStore_SurvivesWriterRestart covers the other half of #833:
+// the per-replica InProcess counter resets to 1 on restart and collides with
+// already-buffered events. A cursor-minting store outlives any single writer,
+// so a fresh source instance (a restarted replica) keeps minting strictly
+// after the existing high-water mark.
+func TestCursorMintingStore_SurvivesWriterRestart(t *testing.T) {
+	store := NewCursorMintingInMemoryStore(0)
+	def := EventDef{Name: "chat.message"}
+	ctx := context.Background()
+
+	_, y1 := NewYieldingSource[map[string]string](def, WithEventBufferStore(store))
+	for i := 0; i < 5; i++ {
+		require.NoError(t, y1(ctx, map[string]string{"k": "v"}))
+	}
+	before, err := store.Latest(ctx, LatestCursorRequest{SourceName: def.Name})
+	require.NoError(t, err)
+	high, _ := strconv.ParseInt(before.Cursor, 10, 64)
+
+	// Restart: a new source instance, same durable store.
+	_, y2 := NewYieldingSource[map[string]string](def, WithEventBufferStore(store))
+	require.NoError(t, y2(ctx, map[string]string{"k": "v2"}))
+
+	after, err := store.Latest(ctx, LatestCursorRequest{SourceName: def.Name})
+	require.NoError(t, err)
+	n, _ := strconv.ParseInt(after.Cursor, 10, 64)
+	assert.Greater(t, n, high, "post-restart cursor must exceed the pre-restart high-water mark, not reset")
+}
+
+// fixedProvider mints from a recognizable high base so a test can tell a
+// provider-minted cursor apart from a store-minted one.
+type fixedProvider struct{ n atomic.Int64 }
+
+func (p *fixedProvider) Next(_ context.Context, _ string) (string, error) {
+	return strconv.FormatInt(1000+p.n.Add(1), 10), nil
+}
+
+// TestYield_ExplicitProviderWinsOverProvidingStore verifies the precedence: an
+// explicitly-set CursorProvider mints even when the store could provide.
+func TestYield_ExplicitProviderWinsOverProvidingStore(t *testing.T) {
+	store := NewCursorMintingInMemoryStore(0)
+	def := EventDef{Name: "chat.message"}
+	ctx := context.Background()
+
+	src, y := NewYieldingSource[fakePayload](def,
+		WithEventBufferStore(store),
+		WithCursorProvider(&fixedProvider{}),
+	)
+	require.NoError(t, y(ctx, fakePayload{Msg: "a"}))
+	require.NoError(t, y(ctx, fakePayload{Msg: "b"}))
+
+	pr := src.Poll("", 10)
+	require.Len(t, pr.Events, 2)
+	// 1001/1002 from the provider, not 1/2 the store would have assigned.
+	assert.Equal(t, "1001", pr.Events[0].CursorStr())
+	assert.Equal(t, "1002", pr.Events[1].CursorStr())
+}
+
+// TestYield_DefaultInProcessCursorsUnchanged pins the historical behavior: with
+// no store and no explicit provider, cursors count 1, 2, 3 per source.
+func TestYield_DefaultInProcessCursorsUnchanged(t *testing.T) {
+	src, y := NewYieldingSource[fakePayload](EventDef{Name: "fake"})
+	ctx := context.Background()
+	require.NoError(t, y(ctx, fakePayload{Msg: "a"}))
+	require.NoError(t, y(ctx, fakePayload{Msg: "b"}))
+
+	pr := src.Poll("", 10)
+	require.Len(t, pr.Events, 2)
+	assert.Equal(t, "1", pr.Events[0].CursorStr())
+	assert.Equal(t, "2", pr.Events[1].CursorStr())
+}

--- a/experimental/ext/events/cursor_test.go
+++ b/experimental/ext/events/cursor_test.go
@@ -24,7 +24,8 @@ func TestInProcessCursors_PerSourceMonotone(t *testing.T) {
 	}
 }
 
-// fakeIncr is a minimal in-memory RedisIncr for RedisCursors.
+// fakeIncr is a minimal in-memory Incrementer (models a shared counter
+// such as a Redis INCR).
 type fakeIncr struct {
 	mu   sync.Mutex
 	vals map[string]int64
@@ -42,9 +43,9 @@ func (f *fakeIncr) Incr(_ context.Context, key string) (int64, error) {
 	return f.vals[key], nil
 }
 
-func TestRedisCursors_UsesPrefixedKeyAndIsMonotone(t *testing.T) {
+func TestInt64IncrCursors_UsesPrefixedKeyAndIsMonotone(t *testing.T) {
 	incr := &fakeIncr{}
-	p := NewRedisCursors(incr, "")
+	p := NewInt64IncrCursors(incr, "")
 	ctx := context.Background()
 	c1, err := p.Next(ctx, "chat.message")
 	require.NoError(t, err)
@@ -52,7 +53,7 @@ func TestRedisCursors_UsesPrefixedKeyAndIsMonotone(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "1", c1)
 	assert.Equal(t, "2", c2)
-	assert.Equal(t, DefaultRedisCursorPrefix+"chat.message", incr.keys[0])
+	assert.Equal(t, DefaultCursorKeyPrefix+"chat.message", incr.keys[0])
 }
 
 // TestCursorMintingStore_MultiWriterGapFree is the #833 fix: N YieldingSources

--- a/experimental/ext/events/event_buffer_store.go
+++ b/experimental/ext/events/event_buffer_store.go
@@ -2,7 +2,9 @@ package events
 
 import (
 	"context"
+	"strconv"
 	"sync"
+	"sync/atomic"
 )
 
 // EventBufferStore is the storage seam behind YieldingSource's poll
@@ -79,9 +81,18 @@ type AppendEventRequest struct {
 	Event      Event
 }
 
-// AppendEventResponse is empty today; reserved for future fields
-// like SequenceNo or AppendedAt that backends may want to surface.
-type AppendEventResponse struct{}
+// AppendEventResponse carries the cursor the store assigned to the event,
+// when the store mints cursors on write (see CursorProvidingStore, issue
+// 833). It is empty for stores that store the caller's cursor verbatim —
+// the historical behavior — so existing implementations that return
+// AppendEventResponse{} are unaffected.
+type AppendEventResponse struct {
+	// Cursor is the store-assigned cursor for the just-appended event.
+	// Populated only when the store minted it (the caller passed a nil
+	// Event.Cursor and the store provides cursors for the source);
+	// empty when the caller supplied the cursor.
+	Cursor string
+}
 
 // PollEventsRequest carries the (source, cursor, limit) tuple.
 // Cursor=="" means "start from now". Limit<=0 is treated as 1 to
@@ -153,6 +164,15 @@ type InMemoryEventBufferStore struct {
 	mu      sync.RWMutex
 	buffers map[string]*ringBuffer
 	maxSize int
+
+	// mintCursors opts the store into assigning cursors on write for a
+	// nil Event.Cursor (CursorProvidingStore, issue 833). Off by default
+	// so the store's historical verbatim-cursor behavior is unchanged.
+	// When on, seq is the global monotone allocator; a source-partitioned
+	// subset of a global monotone sequence is itself monotone, so
+	// per-source poll-resume stays gap-free.
+	mintCursors bool
+	seq         atomic.Int64
 }
 
 type ringBuffer struct {
@@ -163,11 +183,32 @@ type ringBuffer struct {
 
 // NewInMemoryEventBufferStore returns an in-memory store with the
 // given per-source max size. Max<=0 means "unbounded" — never evict.
+// Cursors are stored verbatim (the caller's CursorProvider mints them).
 func NewInMemoryEventBufferStore(maxSize int) *InMemoryEventBufferStore {
 	return &InMemoryEventBufferStore{
 		buffers: make(map[string]*ringBuffer),
 		maxSize: maxSize,
 	}
+}
+
+// NewCursorMintingInMemoryStore returns an in-memory store that assigns
+// cursors on write from a shared global counter (CursorProvidingStore,
+// issue 833). N YieldingSources for the same source that share one such
+// store get globally-unique, monotone cursors — the multi-writer topology
+// a shared Postgres buffer store provides in production, in a single
+// process for tests and single-node fan-in deployments.
+func NewCursorMintingInMemoryStore(maxSize int) *InMemoryEventBufferStore {
+	s := NewInMemoryEventBufferStore(maxSize)
+	s.mintCursors = true
+	return s
+}
+
+// ProvidesCursor reports whether this store mints cursors on write. It is
+// the CursorProvidingStore capability (issue 833); true only for a store
+// built with NewCursorMintingInMemoryStore. The in-memory store either
+// mints for every source or none, so source is ignored.
+func (s *InMemoryEventBufferStore) ProvidesCursor(string) bool {
+	return s.mintCursors
 }
 
 func (s *InMemoryEventBufferStore) ringFor(source string) *ringBuffer {
@@ -185,8 +226,17 @@ func (s *InMemoryEventBufferStore) ringFor(source string) *ringBuffer {
 func (s *InMemoryEventBufferStore) Append(_ context.Context, req AppendEventRequest) (AppendEventResponse, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	ev := req.Event
+	var assigned string
+	if s.mintCursors && ev.Cursor == nil {
+		// Assign from the shared global counter. A copy of the string is
+		// taken so the stored event's Cursor pointer is independent.
+		assigned = strconv.FormatInt(s.seq.Add(1), 10)
+		c := assigned
+		ev.Cursor = &c
+	}
 	r := s.ringFor(req.SourceName)
-	r.events = append(r.events, req.Event)
+	r.events = append(r.events, ev)
 	if s.maxSize > 0 && len(r.events) > s.maxSize {
 		dropped := r.events[0]
 		r.events = r.events[1:]
@@ -195,7 +245,7 @@ func (s *InMemoryEventBufferStore) Append(_ context.Context, req AppendEventRequ
 			r.hasMinSeen = true
 		}
 	}
-	return AppendEventResponse{}, nil
+	return AppendEventResponse{Cursor: assigned}, nil
 }
 
 // Poll returns the slice of events whose cursor is strictly greater
@@ -343,5 +393,8 @@ func parseCursor(s string) (int64, bool) {
 	return n, true
 }
 
-// Compile-time check.
-var _ EventBufferStore = (*InMemoryEventBufferStore)(nil)
+// Compile-time checks.
+var (
+	_ EventBufferStore     = (*InMemoryEventBufferStore)(nil)
+	_ CursorProvidingStore = (*InMemoryEventBufferStore)(nil)
+)

--- a/experimental/ext/events/stores/gorm/event_buffer_cursor_test.go
+++ b/experimental/ext/events/stores/gorm/event_buffer_cursor_test.go
@@ -1,0 +1,102 @@
+package gormstore
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/panyam/mcpkit/experimental/ext/events"
+)
+
+// TestEventBufferStore_ProvideCursors covers the issue-833 store-minted
+// path: with WithProvideCursors, Append assigns a globally-monotone cursor
+// from sequence_no for a nil Event.Cursor, and Poll/Latest/Truncate all
+// project and filter on it. This is the multi-writer topology — N replicas
+// each Append with a nil cursor, the DB sequence keeps them unique and
+// ordered.
+func TestEventBufferStore_ProvideCursors(t *testing.T) {
+	db := openSQLite(t)
+	s, err := NewEventBufferStore(db, WithProvideCursors())
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	cps, ok := s.(events.CursorProvidingStore)
+	require.True(t, ok, "store must implement CursorProvidingStore")
+	require.True(t, cps.ProvidesCursor("chat.message"))
+
+	// N writers append with a nil cursor; the store mints each one.
+	var cursors []string
+	for i := 0; i < 6; i++ {
+		resp, err := s.Append(ctx, events.AppendEventRequest{
+			SourceName: "chat.message",
+			Event:      events.Event{EventID: fmt.Sprintf("e%d", i), Timestamp: "t", Cursor: nil},
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, resp.Cursor, "store must mint a cursor for a nil Event.Cursor")
+		cursors = append(cursors, resp.Cursor)
+	}
+
+	// Unique + strictly increasing.
+	seen := make(map[string]bool, len(cursors))
+	var prev int64
+	for i, c := range cursors {
+		assert.False(t, seen[c], "duplicate minted cursor: %s", c)
+		seen[c] = true
+		n, err := strconv.ParseInt(c, 10, 64)
+		require.NoError(t, err)
+		if i > 0 {
+			assert.Greater(t, n, prev)
+		}
+		prev = n
+	}
+
+	// Poll from the start returns all six with the minted cursors stamped.
+	resp, err := s.Poll(ctx, events.PollEventsRequest{SourceName: "chat.message", Cursor: "", Limit: 100})
+	require.NoError(t, err)
+	require.Len(t, resp.Events, 6)
+	for i, e := range resp.Events {
+		require.NotNil(t, e.Cursor, "polled event must carry the projected cursor")
+		assert.Equal(t, cursors[i], *e.Cursor)
+	}
+
+	// Gap-free resume: from cursors[2] we get exactly the strictly-later tail.
+	tail, err := s.Poll(ctx, events.PollEventsRequest{SourceName: "chat.message", Cursor: cursors[2], Limit: 100})
+	require.NoError(t, err)
+	assert.Len(t, tail.Events, 3)
+
+	// Latest projects the last minted cursor.
+	lat, err := s.Latest(ctx, events.LatestCursorRequest{SourceName: "chat.message"})
+	require.NoError(t, err)
+	assert.Equal(t, cursors[5], lat.Cursor)
+
+	// Truncate filters on the effective (sequence_no) cursor: <= cursors[1]
+	// drops the first two.
+	rm, err := s.Truncate(ctx, events.TruncateEventsRequest{SourceName: "chat.message", BeforeCursor: cursors[1]})
+	require.NoError(t, err)
+	assert.Equal(t, 2, rm.Removed)
+}
+
+// TestEventBufferStore_DefaultDoesNotProvideCursors pins the default: without
+// WithProvideCursors the store advertises no cursor capability and stores the
+// caller's cursor verbatim (a nil cursor yields an empty AppendEventResponse).
+func TestEventBufferStore_DefaultDoesNotProvideCursors(t *testing.T) {
+	db := openSQLite(t)
+	s, err := NewEventBufferStore(db)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	cps, ok := s.(events.CursorProvidingStore)
+	require.True(t, ok, "store always implements the method")
+	assert.False(t, cps.ProvidesCursor("x"), "default store must not provide cursors")
+
+	resp, err := s.Append(ctx, events.AppendEventRequest{
+		SourceName: "x",
+		Event:      events.Event{EventID: "e", Timestamp: "t", Cursor: nil},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, resp.Cursor, "verbatim store must not mint a cursor")
+}

--- a/experimental/ext/events/stores/gorm/event_buffer_store.go
+++ b/experimental/ext/events/stores/gorm/event_buffer_store.go
@@ -36,6 +36,12 @@ type eventBufferRow struct {
 // pluralization rules; operators reading psql expect `event_buffer`.
 func (eventBufferRow) TableName() string { return "event_buffer" }
 
+// Compile-time capability checks.
+var (
+	_ events.EventBufferStore     = (*eventBufferStore)(nil)
+	_ events.CursorProvidingStore = (*eventBufferStore)(nil)
+)
+
 // eventBufferStore is the GORM-backed events.EventBufferStore impl.
 // Concurrency safety comes from the database (Postgres autoincrement
 // is atomic; SQLite serializes the whole transaction). Per-source
@@ -44,6 +50,13 @@ func (eventBufferRow) TableName() string { return "event_buffer" }
 type eventBufferStore struct {
 	db  *gorm.DB
 	ttl time.Duration
+
+	// provideCursors mints cursors on write from sequence_no rather than
+	// storing the caller's cursor verbatim (issue 833). When set, the
+	// store implements events.CursorProvidingStore and, for every source
+	// it backs, sequence_no is the effective cursor everywhere (Append
+	// returns it, Poll/Latest/Recent/Truncate filter and project on it).
+	provideCursors bool
 }
 
 // NewEventBufferStore returns a GORM-backed EventBufferStore. The
@@ -66,18 +79,31 @@ func NewEventBufferStore(db *gorm.DB, opts ...Option) (events.EventBufferStore, 
 			return nil, err
 		}
 	}
-	return &eventBufferStore{db: db, ttl: cfg.bufferTTL}, nil
+	return &eventBufferStore{db: db, ttl: cfg.bufferTTL, provideCursors: cfg.provideCursors}, nil
 }
 
-// Append inserts the event with expires_at = NOW() + ttl. The
-// caller's Event.Cursor is stored verbatim — the YieldingSource's
-// atomic counter is the authoritative monotone-per-source source of
-// cursor values; the DB just persists what the caller produced. The
-// sequence_no column is autoincrement-assigned by the DB and serves
-// as a stable PK + insertion-order tiebreaker; it's not visible on
-// the wire.
+// ProvidesCursor reports whether this store mints cursors on write. It is
+// the events.CursorProvidingStore capability (issue 833), enabled by
+// WithProvideCursors. One table, one sequence — the store mints for every
+// source it backs, so source is ignored.
+func (s *eventBufferStore) ProvidesCursor(string) bool { return s.provideCursors }
+
+// Append inserts the event with expires_at = NOW() + ttl.
 //
-// Required Event fields: EventID, Cursor (non-nil), Timestamp.
+// Cursor provenance depends on the store's mode (issue 833):
+//   - Default (verbatim): the caller's Event.Cursor is stored as-is —
+//     the YieldingSource's CursorProvider is the authoritative source of
+//     cursor values. Required Event fields: EventID, Cursor (non-nil),
+//     Timestamp.
+//   - WithProvideCursors (store-minted): the caller passes a nil
+//     Event.Cursor and the DB-assigned sequence_no becomes the cursor,
+//     returned in AppendEventResponse.Cursor. sequence_no is populated on
+//     the same INSERT (RETURNING / LastInsertId), so no extra round trip.
+//     The verbatim cursor column is left empty for these rows; the read
+//     paths project sequence_no as the cursor.
+//
+// The sequence_no column is autoincrement-assigned by the DB and serves
+// as the stable PK + insertion-order key in both modes.
 func (s *eventBufferStore) Append(ctx context.Context, req events.AppendEventRequest) (events.AppendEventResponse, error) {
 	payload, err := json.Marshal(req.Event)
 	if err != nil {
@@ -98,6 +124,14 @@ func (s *eventBufferStore) Append(ctx context.Context, req events.AppendEventReq
 	if err := s.db.WithContext(ctx).Create(&row).Error; err != nil {
 		return events.AppendEventResponse{}, err
 	}
+	// Store-minted cursor (issue 833): when this store provides cursors
+	// and the caller left Cursor nil, the DB-assigned sequence_no (now
+	// populated on row by GORM's RETURNING / LastInsertId — same round
+	// trip) IS the cursor. The verbatim cursor column stays empty for
+	// these rows; Poll/Latest/Recent project sequence_no as the cursor.
+	if s.provideCursors && req.Event.Cursor == nil {
+		return events.AppendEventResponse{Cursor: strconv.FormatInt(row.SequenceNo, 10)}, nil
+	}
 	return events.AppendEventResponse{}, nil
 }
 
@@ -117,31 +151,31 @@ func (s *eventBufferStore) Poll(ctx context.Context, req events.PollEventsReques
 	}
 	c, _ := strconv.ParseInt(req.Cursor, 10, 64)
 
+	// Effective cursor column: sequence_no when this store mints cursors
+	// (issue 833), else the numeric cast of the verbatim cursor column.
+	// Both are monotone in insert order, so filter-by-cursor stays
+	// consistent with order-by-sequence_no in either mode.
+	cursorExpr := "CAST(cursor AS INTEGER)"
+	if s.provideCursors {
+		cursorExpr = "sequence_no"
+	}
+
 	// Truncated check: requested cursor < oldest surviving cursor for
-	// this source. We use MIN over the cursor column (numerically) —
-	// not sequence_no — so the floor reflects what's wire-visible.
+	// this source, so the floor reflects what's wire-visible.
 	var oldest sql_NullInt64
 	if c > 0 {
 		if err := s.db.WithContext(ctx).
 			Model(&eventBufferRow{}).
 			Where("source_name = ?", req.SourceName).
-			Select("MIN(CAST(cursor AS BIGINT)) as v").
+			Select("MIN(" + cursorExpr + ") as v").
 			Scan(&oldest).Error; err != nil {
-			// SQLite doesn't have BIGINT; fall back to INTEGER.
-			if err := s.db.WithContext(ctx).
-				Model(&eventBufferRow{}).
-				Where("source_name = ?", req.SourceName).
-				Select("MIN(CAST(cursor AS INTEGER)) as v").
-				Scan(&oldest).Error; err != nil {
-				return events.PollEventsResponse{}, err
-			}
+			return events.PollEventsResponse{}, err
 		}
 	}
 
 	var rows []eventBufferRow
-	// CAST in the WHERE so the comparison is numeric.
 	if err := s.db.WithContext(ctx).
-		Where("source_name = ? AND CAST(cursor AS INTEGER) > ?", req.SourceName, c).
+		Where("source_name = ? AND "+cursorExpr+" > ?", req.SourceName, c).
 		Order("sequence_no ASC").
 		Limit(limit).
 		Find(&rows).Error; err != nil {
@@ -154,8 +188,14 @@ func (s *eventBufferStore) Poll(ctx context.Context, req events.PollEventsReques
 		if err := json.Unmarshal(r.Payload, &ev); err != nil {
 			return events.PollEventsResponse{}, err
 		}
+		eff := s.effectiveCursor(r)
+		// Store-minted events were persisted with a nil cursor; stamp the
+		// projected sequence_no cursor onto the wire event.
+		if ev.Cursor == nil || s.provideCursors {
+			ev.Cursor = &eff
+		}
 		out.Events = append(out.Events, ev)
-		out.NextCursor = r.Cursor
+		out.NextCursor = eff
 	}
 
 	// No events matched but the source has some — NextCursor = Latest.
@@ -177,6 +217,16 @@ func (s *eventBufferStore) Poll(ctx context.Context, req events.PollEventsReques
 	return out, nil
 }
 
+// effectiveCursor is the cursor a row projects on the wire: sequence_no
+// when this store mints cursors (issue 833), else the verbatim cursor
+// column.
+func (s *eventBufferStore) effectiveCursor(r eventBufferRow) string {
+	if s.provideCursors {
+		return strconv.FormatInt(r.SequenceNo, 10)
+	}
+	return r.Cursor
+}
+
 // Latest returns the source's most recent cursor. Empty when source
 // has no rows.
 func (s *eventBufferStore) Latest(ctx context.Context, req events.LatestCursorRequest) (events.LatestCursorResponse, error) {
@@ -192,7 +242,7 @@ func (s *eventBufferStore) Latest(ctx context.Context, req events.LatestCursorRe
 	if err != nil {
 		return events.LatestCursorResponse{}, err
 	}
-	return events.LatestCursorResponse{Cursor: row.Cursor}, nil
+	return events.LatestCursorResponse{Cursor: s.effectiveCursor(row)}, nil
 }
 
 // Recent returns the most recent N events for the source, oldest-first
@@ -216,6 +266,9 @@ func (s *eventBufferStore) Recent(ctx context.Context, req events.RecentEventsRe
 		if err := json.Unmarshal(r.Payload, &ev); err != nil {
 			return events.RecentEventsResponse{}, err
 		}
+		if eff := s.effectiveCursor(r); ev.Cursor == nil || s.provideCursors {
+			ev.Cursor = &eff
+		}
 		out[len(rows)-1-i] = ev
 	}
 	return events.RecentEventsResponse{Events: out}, nil
@@ -231,7 +284,13 @@ func (s *eventBufferStore) Truncate(ctx context.Context, req events.TruncateEven
 		if err != nil {
 			return events.TruncateEventsResponse{}, err
 		}
-		q = q.Where("CAST(cursor AS INTEGER) <= ?", c)
+		// Filter on the effective cursor column: sequence_no when the
+		// store mints cursors (issue 833), else the verbatim cursor.
+		if s.provideCursors {
+			q = q.Where("sequence_no <= ?", c)
+		} else {
+			q = q.Where("CAST(cursor AS INTEGER) <= ?", c)
+		}
 	}
 	result := q.Delete(&eventBufferRow{})
 	if result.Error != nil {

--- a/experimental/ext/events/stores/gorm/options.go
+++ b/experimental/ext/events/stores/gorm/options.go
@@ -8,6 +8,7 @@ type Option func(*config)
 type config struct {
 	skipAutoMigrate bool
 	bufferTTL       time.Duration
+	provideCursors  bool
 }
 
 // defaultBufferTTL is the per-event retention window for
@@ -43,4 +44,25 @@ func WithBufferTTL(ttl time.Duration) Option {
 			c.bufferTTL = ttl
 		}
 	}
+}
+
+// WithProvideCursors makes the store assign cursors on write from its
+// database sequence (the sequence_no autoincrement), advertising the
+// CursorProvidingStore capability (issue 833). A YieldingSource wired to
+// this store then leaves Event.Cursor nil and the store stamps a
+// globally-monotone cursor on Append — so N replicas writing the same
+// source get gap-free, collision-free cursors without a shared in-process
+// counter or Redis.
+//
+// Off by default: without it, the store persists the caller's cursor
+// verbatim (the historical behavior), and cursor minting stays with the
+// YieldingSource's CursorProvider. Turning it on is a cursor-provenance
+// change — existing cursor values are per-replica, new ones are the DB
+// sequence — so enable it on a fresh deployment or accept that in-flight
+// clients re-subscribe (which the Truncated signal already handles).
+//
+// The store mints for every source it backs (one table, one sequence),
+// so the per-source ProvidesCursor argument is ignored here.
+func WithProvideCursors() Option {
+	return func(c *config) { c.provideCursors = true }
 }

--- a/experimental/ext/events/yield.go
+++ b/experimental/ext/events/yield.go
@@ -188,8 +188,8 @@ func WithEventBufferStore(s EventBufferStore) YieldingOption {
 // WithCursorProvider sets the CursorProvider that mints this source's
 // cursors (issue 833). The default is a fresh InProcessCursors — a
 // per-source in-memory counter, correct for a single writer. Pass
-// RedisCursors (shared INCR) or any CursorProvider for a source written
-// by multiple replicas.
+// Int64IncrCursors (a shared counter, e.g. Redis INCR) or any
+// CursorProvider for a source written by multiple replicas.
 //
 // Precedence: an explicit provider set here always wins. Without it, a
 // cursor-providing bufferStore (CursorProvidingStore) mints on write;

--- a/experimental/ext/events/yield.go
+++ b/experimental/ext/events/yield.go
@@ -23,10 +23,12 @@ const (
 type YieldingOption func(*yieldingConfig)
 
 type yieldingConfig struct {
-	maxSize         int
-	cursorless      bool
-	subscriberBuf   int
-	bufferStore     EventBufferStore
+	maxSize           int
+	cursorless        bool
+	subscriberBuf     int
+	bufferStore       EventBufferStore
+	cursorProvider    CursorProvider
+	cursorProviderSet bool
 }
 
 // SubscriberEvent flows on the channel returned by YieldingSource.Subscribe.
@@ -183,6 +185,25 @@ func WithEventBufferStore(s EventBufferStore) YieldingOption {
 	}
 }
 
+// WithCursorProvider sets the CursorProvider that mints this source's
+// cursors (issue 833). The default is a fresh InProcessCursors — a
+// per-source in-memory counter, correct for a single writer. Pass
+// RedisCursors (shared INCR) or any CursorProvider for a source written
+// by multiple replicas.
+//
+// Precedence: an explicit provider set here always wins. Without it, a
+// cursor-providing bufferStore (CursorProvidingStore) mints on write;
+// failing that, InProcessCursors. A nil provider is ignored (keeps the
+// default) so the option is safe to call unconditionally.
+func WithCursorProvider(p CursorProvider) YieldingOption {
+	return func(c *yieldingConfig) {
+		if p != nil {
+			c.cursorProvider = p
+			c.cursorProviderSet = true
+		}
+	}
+}
+
 // WithoutCursors marks the source as cursorless: events are emitted with
 // `cursor: null` on the wire, the source does not buffer events, and
 // events/poll always returns empty. Use for ephemeral-state sources where
@@ -248,13 +269,26 @@ func NewYieldingSource[Data any](def EventDef, opts ...YieldingOption) (*Yieldin
 		def.Cursorless = true
 	}
 
+	cursorProvider := cfg.cursorProvider
+	if cursorProvider == nil {
+		cursorProvider = NewInProcessCursors()
+	}
 	s := &YieldingSource[Data]{
-		def:           def,
-		maxSize:       cfg.maxSize,
-		cursorless:    cfg.cursorless,
-		subscriberBuf: cfg.subscriberBuf,
-		bufferStore:   cfg.bufferStore,
-		tp:            core.NoopTracerProvider{},
+		def:            def,
+		maxSize:        cfg.maxSize,
+		cursorless:     cfg.cursorless,
+		subscriberBuf:  cfg.subscriberBuf,
+		bufferStore:    cfg.bufferStore,
+		cursorProvider: cursorProvider,
+		tp:             core.NoopTracerProvider{},
+	}
+	// Precedence (issue 833): an explicit CursorProvider wins; otherwise a
+	// cursor-providing store mints on write for this source; otherwise the
+	// InProcessCursors default above. Resolved once here, not per yield.
+	if !cfg.cursorProviderSet && !cfg.cursorless {
+		if cps, ok := s.bufferStore.(CursorProvidingStore); ok && cps.ProvidesCursor(def.Name) {
+			s.storeMintsCursor = true
+		}
 	}
 	yield := func(ctx context.Context, data Data) error {
 		return s.yield(ctx, data)
@@ -295,7 +329,15 @@ type YieldingSource[Data any] struct {
 	maxSize       int
 	cursorless    bool
 	subscriberBuf int
-	seq           atomic.Int64
+
+	// cursorProvider mints the cursor in the we-mint path (issue 833).
+	// Defaults to a fresh InProcessCursors (the historical per-source
+	// atomic counter). storeMintsCursor, computed once at construction,
+	// is true when the bufferStore assigns cursors itself for this
+	// source AND no explicit provider was set — then yield leaves
+	// Event.Cursor nil and the store stamps it on Append.
+	cursorProvider   CursorProvider
+	storeMintsCursor bool
 
 	mu          sync.RWMutex
 	entries     []yieldedEntry[Data]
@@ -733,15 +775,21 @@ func (s *YieldingSource[Data]) yield(ctx context.Context, data Data) error {
 		return fmt.Errorf("yield: marshal: %w", err)
 	}
 
-	seq := s.seq.Add(1)
 	event := Event{
 		EventID:   newEventID(),
 		Name:      s.def.Name,
 		Timestamp: now.Format(time.RFC3339),
 		Data:      raw,
 	}
-	if !s.cursorless {
-		cursor := strconv.FormatInt(seq, 10)
+	// Cursor provenance (issue 833): we-mint via the CursorProvider before
+	// the write, unless a cursor-providing store assigns it on Append (in
+	// which case Event.Cursor stays nil here and is stamped from the
+	// Append response below). Cursorless sources carry no cursor at all.
+	if !s.cursorless && !s.storeMintsCursor {
+		cursor, err := s.cursorProvider.Next(ctx, s.def.Name)
+		if err != nil {
+			return fmt.Errorf("yield: mint cursor: %w", err)
+		}
 		event.Cursor = &cursor
 	}
 
@@ -767,27 +815,36 @@ func (s *YieldingSource[Data]) yield(ctx context.Context, data Data) error {
 		}
 	}
 	if !s.cursorless {
-		// Only buffer when cursored — cursorless sources don't support
-		// poll-side replay, so retaining events would just waste memory.
-		s.entries = append(s.entries, yieldedEntry[Data]{data: data, event: event})
-		if len(s.entries) > s.maxSize {
-			s.entries = s.entries[len(s.entries)-s.maxSize:]
-		}
 		// Mirror to the cross-replica buffer store (issue 727) when
 		// configured. The dual-write is cheap for the in-memory case
 		// and load-bearing for cross-replica deployments where
 		// Poll() must answer consistently regardless of which
 		// replica handles it. Errors are logged but don't fail the
 		// yield — local subscribers still see the event via the
-		// in-memory ring above.
+		// in-memory ring below.
+		//
+		// Append runs BEFORE the local ring append (issue 833): in the
+		// store-minted path the cursor isn't known until the write
+		// returns, so we stamp Event.Cursor from the response and only
+		// then buffer/fan out the fully-cursored event.
 		if s.bufferStore != nil {
-			if _, err := s.bufferStore.Append(ctx, AppendEventRequest{
+			resp, err := s.bufferStore.Append(ctx, AppendEventRequest{
 				SourceName: s.def.Name, Event: event,
-			}); err != nil {
+			})
+			if err != nil {
 				// TODO: surface via a Logger option once we add one.
 				// For now silent — yield should not block on store errors.
 				_ = err
+			} else if s.storeMintsCursor && resp.Cursor != "" {
+				c := resp.Cursor
+				event.Cursor = &c
 			}
+		}
+		// Only buffer when cursored — cursorless sources don't support
+		// poll-side replay, so retaining events would just waste memory.
+		s.entries = append(s.entries, yieldedEntry[Data]{data: data, event: event})
+		if len(s.entries) > s.maxSize {
+			s.entries = s.entries[len(s.entries)-s.maxSize:]
 		}
 	}
 	// Snapshot subscribers under the lock, then drop the lock before


### PR DESCRIPTION
## Why

`YieldingSource` minted each event's cursor from a per-instance in-process atomic counter. In a multi-replica deployment where writes for one source round-robin across N replicas (the whole-enchilada topology), every replica counts from 1 independently, so cursors **collide**, and a counter **resets to 0 on restart**. `events/poll` resume is therefore not gap-free across replicas or restarts. (EventID uniqueness was fixed separately; cursors need *ordering*, not just uniqueness.)

## Design (built collaboratively — see thread)

Cursor minting becomes a pluggable seam with three provenances, chosen **per source**:

| Provenance | Wire it with | Notes |
|---|---|---|
| **In-process** (default) | `InProcessCursors` | historical per-source counter, **no behavior change** |
| **Shared counter** | `WithCursorProvider(NewRedisCursors(incr, ""))` | shared `INCR`, cross-replica + restart-safe; over a minimal `RedisIncr` contract so core events stays dep-free |
| **Store-minted** | a store implementing `CursorProvidingStore` (`gormstore.WithProvideCursors()`) | store assigns from its own write sequence on `Append` — one round trip, mcpkit mints nothing |

- **`CursorProvider`** interface (`Next(ctx, source) (string, error)`).
- **`CursorProvidingStore`** is an *optional* capability (`ProvidesCursor(source) bool`), queried by type assertion — existing/third-party `EventBufferStore` impls are unaffected. Per-source, so one store can mint for some sources and not others.
- Additive **`AppendEventResponse.Cursor`**, populated only by store-minting stores.
- **Precedence per source**: explicit provider > cursor-providing store > `InProcessCursors`. Resolved once at construction.
- `yield` reorders so `Append` runs before the local ring append — the store-assigned cursor is stamped before buffering/fanout. The we-mint path is unchanged (stamp before Append, fan out immediately).

### gorm store

`WithProvideCursors()` mints from the existing `sequence_no` autoincrement, populated on the **same INSERT** (RETURNING / LastInsertId) — no extra round trip. For minting sources `sequence_no` is the effective cursor everywhere (Append returns it; Poll/Latest/Recent/Truncate filter and project on it); the verbatim `cursor` column stays empty. **Off by default** — verbatim behavior and existing cursor values unchanged unless opted in.

## Tests

- Multi-writer gap-free resume + writer-restart survival (in-memory minting store — the #833 acceptance case: N YieldingSources sharing one store).
- Precedence (explicit provider beats a providing store); default InProcess unchanged (`1,2,3`); `RedisCursors` key + monotonicity.
- gorm store-minted Append/Poll/Latest/Truncate + default-off.

Core events, gorm, redis, memory modules all `go test`/`go vet` green.

Closes issue 833.

https://claude.ai/code/session_01PAT6AvpFqzrurThGZniHZv