### PR TITLE
demo(whole-enchilada): enable store-minted cursors on the event-server (issue 833)

### DIFF
--- a/examples/whole-enchilada/events/docker-compose.yaml
+++ b/examples/whole-enchilada/events/docker-compose.yaml
@@ -172,6 +172,15 @@ services:
       # "stale cursor truncates" walkthrough beat doesn't need an hour
       # of patience.
       POSTGRES_BUFFER_TTL: ${POSTGRES_BUFFER_TTL:-10m}
+      # EVENTS_STORE_MINT_CURSORS — cross-replica cursor consistency
+      # (issue 833). On by default: the Postgres buffer store assigns each
+      # event's cursor from its own write sequence, so the N replicas
+      # writing chat.message (round-robined by `make inject`) get globally
+      # monotone, collision-free cursors and events/poll resume is gap-free
+      # across replicas. Set to false to fall back to per-replica in-process
+      # counters and watch the collision (cursor "5" minted on every
+      # replica) — the teaching contrast for the walkthrough.
+      EVENTS_STORE_MINT_CURSORS: ${EVENTS_STORE_MINT_CURSORS:-true}
     # `--exporter=auto` means best-effort OTLP with Noop fallback when
     # the collector is unreachable. common.RegisterTelemetryFlags
     # doesn't read EXPORTER from env, so we wire it via the CLI flag;
@@ -303,6 +312,15 @@ services:
       # "stale cursor truncates" walkthrough beat doesn't need an hour
       # of patience.
       POSTGRES_BUFFER_TTL: ${POSTGRES_BUFFER_TTL:-10m}
+      # EVENTS_STORE_MINT_CURSORS — cross-replica cursor consistency
+      # (issue 833). On by default: the Postgres buffer store assigns each
+      # event's cursor from its own write sequence, so the N replicas
+      # writing chat.message (round-robined by `make inject`) get globally
+      # monotone, collision-free cursors and events/poll resume is gap-free
+      # across replicas. Set to false to fall back to per-replica in-process
+      # counters and watch the collision (cursor "5" minted on every
+      # replica) — the teaching contrast for the walkthrough.
+      EVENTS_STORE_MINT_CURSORS: ${EVENTS_STORE_MINT_CURSORS:-true}
     # `--exporter=auto` means best-effort OTLP with Noop fallback when
     # the collector is unreachable. common.RegisterTelemetryFlags
     # doesn't read EXPORTER from env, so we wire it via the CLI flag;
@@ -434,6 +452,15 @@ services:
       # "stale cursor truncates" walkthrough beat doesn't need an hour
       # of patience.
       POSTGRES_BUFFER_TTL: ${POSTGRES_BUFFER_TTL:-10m}
+      # EVENTS_STORE_MINT_CURSORS — cross-replica cursor consistency
+      # (issue 833). On by default: the Postgres buffer store assigns each
+      # event's cursor from its own write sequence, so the N replicas
+      # writing chat.message (round-robined by `make inject`) get globally
+      # monotone, collision-free cursors and events/poll resume is gap-free
+      # across replicas. Set to false to fall back to per-replica in-process
+      # counters and watch the collision (cursor "5" minted on every
+      # replica) — the teaching contrast for the walkthrough.
+      EVENTS_STORE_MINT_CURSORS: ${EVENTS_STORE_MINT_CURSORS:-true}
     # `--exporter=auto` means best-effort OTLP with Noop fallback when
     # the collector is unreachable. common.RegisterTelemetryFlags
     # doesn't read EXPORTER from env, so we wire it via the CLI flag;

--- a/examples/whole-enchilada/events/event-server/postgres.go
+++ b/examples/whole-enchilada/events/event-server/postgres.go
@@ -118,6 +118,16 @@ func configurePostgresBackend() *postgresBackend {
 			bufferOpts = append(bufferOpts, gormstore.WithBufferTTL(ttl))
 		}
 	}
+	// Store-minted cursors (issue 833): the demo round-robins `make inject`
+	// across N event-server replicas writing the SAME source, so the
+	// per-replica InProcess cursor counters would each start at 1 and
+	// collide — cross-replica poll-resume would see duplicates/gaps. Let
+	// the shared Postgres buffer store assign globally-monotone cursors on
+	// write instead. On by default (the demo's whole point); set
+	// EVENTS_STORE_MINT_CURSORS=false to observe the per-replica collision.
+	if strings.ToLower(strings.TrimSpace(os.Getenv("EVENTS_STORE_MINT_CURSORS"))) != "false" {
+		bufferOpts = append(bufferOpts, gormstore.WithProvideCursors())
+	}
 	bufferStore, err := gormstore.NewEventBufferStore(db, bufferOpts...)
 	if err != nil {
 		log.Fatalf("gormstore.NewEventBufferStore: %v", err)

--- a/examples/whole-enchilada/events/tools/gen-compose/compose.tmpl
+++ b/examples/whole-enchilada/events/tools/gen-compose/compose.tmpl
@@ -179,6 +179,15 @@ services:
       # "stale cursor truncates" walkthrough beat doesn't need an hour
       # of patience.
       POSTGRES_BUFFER_TTL: ${POSTGRES_BUFFER_TTL:-10m}
+      # EVENTS_STORE_MINT_CURSORS — cross-replica cursor consistency
+      # (issue 833). On by default: the Postgres buffer store assigns each
+      # event's cursor from its own write sequence, so the N replicas
+      # writing chat.message (round-robined by `make inject`) get globally
+      # monotone, collision-free cursors and events/poll resume is gap-free
+      # across replicas. Set to false to fall back to per-replica in-process
+      # counters and watch the collision (cursor "5" minted on every
+      # replica) — the teaching contrast for the walkthrough.
+      EVENTS_STORE_MINT_CURSORS: ${EVENTS_STORE_MINT_CURSORS:-true}
     # `--exporter=auto` means best-effort OTLP with Noop fallback when
     # the collector is unreachable. common.RegisterTelemetryFlags
     # doesn't read EXPORTER from env, so we wire it via the CLI flag;


### PR DESCRIPTION
> **Stacked on #876** (issue 833). Base is `feat/833-cursor-provider` because `gormstore.WithProvideCursors` ships there. Review/merge #876 first; this then retargets to main.

## Why

The demo round-robins `make inject` across N event-server replicas writing the **same** source, so the per-replica `InProcessCursors` counters each start at 1 and collide — cross-replica `events/poll` resume sees duplicates/gaps. This is the exact scenario #833 is about, and the one the whole-enchilada "cross-replica cursor durability / resume gap-free" claim depends on.

## What

Wire `gormstore.WithProvideCursors()` into the event-server's buffer-store construction (`postgres.go`), so the shared Postgres store assigns globally-monotone cursors from its write sequence.

- **On by default** — the demo's whole point is gap-free cross-replica resume.
- `EVENTS_STORE_MINT_CURSORS=false` disables it, so an operator can observe the per-replica collision for contrast (a nice teaching beat).

One-line change plus its comment; `go build` / `go vet` green (gormstore resolves to the local #876 code via the module's replace directive).

## Follow-up (not here)

A walkthrough beat that drives inject across replicas and shows gap-free resume live is a larger, separate change — worth doing once this and #876 land.