### PR TITLE
docs(site): dark mode, copy buttons, concepts overview, README examples link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Production-grade MCP (Model Context Protocol) server and client library for Go.
 [![License](https://img.shields.io/github/license/panyam/mcpkit)](LICENSE)
 [![GitHub stars](https://img.shields.io/github/stars/panyam/mcpkit?style=social)](https://github.com/panyam/mcpkit/stargazers)
 
-**[Docs site](https://panyam.github.io/mcpkit/)** · **[Conformance report](https://panyam.github.io/mcpkit/conformance/)** · **[Capabilities](https://panyam.github.io/mcpkit/capabilities/)** · **[Changelog](CHANGELOG.md)** · **[Quick Start](#quick-start)**
+**[Docs site](https://panyam.github.io/mcpkit/)** · **[Examples](https://panyam.github.io/mcpkit/examples/)** · **[Conformance report](https://panyam.github.io/mcpkit/conformance/)** · **[Capabilities](https://panyam.github.io/mcpkit/capabilities/)** · **[Changelog](CHANGELOG.md)** · **[Quick Start](#quick-start)**
 
 ## Quick Start
 
@@ -95,6 +95,7 @@ make test-apps-playwright  # ext-apps Playwright suite (needs Node.js)
 
 | Doc | What |
 |-----|------|
+| [Examples gallery](https://panyam.github.io/mcpkit/examples/) | Runnable, batteries-included examples (auth, tasks, apps, tracing, events, skills) — each a guided two-terminal walkthrough. Source under [`examples/`](examples/) |
 | [CHANGELOG.md](CHANGELOG.md) | Release notes (Keep a Changelog / SemVer); fuller write-ups in [`docs/releases/`](docs/releases/) |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | How to build, test, and contribute |
 | [CLAUDE.md](CLAUDE.md) | Quick reference: commands, package structure, gotchas |

--- a/docs/site/content/HeaderNavLinks.json
+++ b/docs/site/content/HeaderNavLinks.json
@@ -31,8 +31,9 @@
   },
   {
     "name": "Concepts",
-    "url": "concepts/bringup/",
+    "url": "concepts/",
     "children": [
+      { "name": "Overview",              "url": "concepts/" },
       { "name": "Bring-up",              "url": "concepts/bringup/" },
       { "name": "Transport mechanics",   "url": "concepts/transport-mechanics/" },
       { "name": "Notifications",         "url": "concepts/notifications/" },

--- a/docs/site/content/concepts/index.html
+++ b/docs/site/content/concepts/index.html
@@ -1,0 +1,56 @@
+---
+title: "Concepts"
+description: "Deep dives into how mcpkit implements the MCP protocol — session bring-up, transports, notifications, the request lifecycle, extension surfaces, reverse calls, MRTR, tracing, and events."
+---
+
+<section class="hero">
+    <h1>Concepts</h1>
+    <p class="hero-tagline">Nine deep dives into how mcpkit implements the protocol — not API reference, but the "why it works this way" behind each surface. Read them in order for a full tour, or jump to the one you need.</p>
+</section>
+
+<section class="pillars">
+    <div class="pillar">
+        <h3><a href="{{ .Site.PathPrefix }}/concepts/bringup/">Bring-up</a></h3>
+        <p>Session establishment: transport, auth, version negotiation, capabilities, and the initialized handshake.</p>
+    </div>
+
+    <div class="pillar">
+        <h3><a href="{{ .Site.PathPrefix }}/concepts/transport-mechanics/">Transport mechanics</a></h3>
+        <p>How the streamable-HTTP and stdio transports move requests, responses, and server-initiated pushes.</p>
+    </div>
+
+    <div class="pillar">
+        <h3><a href="{{ .Site.PathPrefix }}/concepts/notifications/">Notifications</a></h3>
+        <p>The six notification families, their direction and capability gates, and per-session fan-out.</p>
+    </div>
+
+    <div class="pillar">
+        <h3><a href="{{ .Site.PathPrefix }}/concepts/request-anatomy/">Anatomy of a request</a></h3>
+        <p>The end-to-end journey of a request through mcpkit's dispatch pipeline, step by step.</p>
+    </div>
+
+    <div class="pillar">
+        <h3><a href="{{ .Site.PathPrefix }}/concepts/extension-mechanisms/">Extension mechanisms</a></h3>
+        <p>The four extension surfaces and how mcpkit organizes core / ext / experimental.</p>
+    </div>
+
+    <div class="pillar">
+        <h3><a href="{{ .Site.PathPrefix }}/concepts/reverse-call/">Reverse calls</a></h3>
+        <p>Server-initiated sampling, elicitation, and roots/list — and how the handler context gates them.</p>
+    </div>
+
+    <div class="pillar">
+        <h3><a href="{{ .Site.PathPrefix }}/concepts/mrtr/">MRTR internals</a></h3>
+        <p>The InputRequiredResult envelope, signed requestState, and the client auto-loop.</p>
+    </div>
+
+    <div class="pillar">
+        <h3><a href="{{ .Site.PathPrefix }}/concepts/tracing/">Tracing</a></h3>
+        <p>W3C trace context across the MCP wire — off by default, zero-overhead when unconfigured.</p>
+    </div>
+
+    <div class="pillar">
+        <h3><a href="{{ .Site.PathPrefix }}/concepts/events/">Events</a></h3>
+        <p>The experimental cross-replica events bus: push, poll, webhooks, and trace propagation.</p>
+    </div>
+</section>

--- a/docs/site/static/css/main.css
+++ b/docs/site/static/css/main.css
@@ -15,6 +15,39 @@
     --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", "Inter", system-ui, sans-serif;
 }
 
+/* Dark theme. The color tokens above thread through the whole sheet via
+   var(--...), so overriding them here re-themes everything. Two triggers:
+   the OS preference when the visitor hasn't chosen (:not([data-theme]))
+   and an explicit toggle ([data-theme="dark"]); [data-theme="light"]
+   always pins the light defaults above. */
+@media (prefers-color-scheme: dark) {
+    :root:not([data-theme]) {
+        --fg: #e8e8e6;
+        --fg-muted: #b2b2af;
+        --fg-faint: #868682;
+        --bg: #16171a;
+        --bg-soft: #1e1f23;
+        --bg-code: #1c1d21;
+        --border: #2e2f34;
+        --link: #7ba3e0;
+        --link-hover: #a9c4ef;
+        --accent: #e8843c;
+    }
+}
+
+:root[data-theme="dark"] {
+    --fg: #e8e8e6;
+    --fg-muted: #b2b2af;
+    --fg-faint: #868682;
+    --bg: #16171a;
+    --bg-soft: #1e1f23;
+    --bg-code: #1c1d21;
+    --border: #2e2f34;
+    --link: #7ba3e0;
+    --link-hover: #a9c4ef;
+    --accent: #e8843c;
+}
+
 * { box-sizing: border-box; }
 
 html, body {
@@ -54,6 +87,68 @@ pre code {
     background: transparent;
     padding: 0;
 }
+
+/* Copy button (added by the copy-button script in BasePage.html) */
+pre.has-copy {
+    position: relative;
+}
+
+.copy-btn {
+    position: absolute;
+    top: 0.4rem;
+    right: 0.4rem;
+    padding: 0.15rem 0.5rem;
+    font: inherit;
+    font-size: 0.75rem;
+    color: var(--fg-muted);
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.12s ease, color 0.12s ease;
+}
+
+pre.has-copy:hover .copy-btn,
+.copy-btn:focus-visible {
+    opacity: 1;
+}
+
+.copy-btn:hover {
+    color: var(--fg);
+    border-color: var(--fg-faint);
+}
+
+/* Dark-mode toggle in the header. The icon reflects the current theme:
+   sun in light, moon in dark. Default (no data-theme) follows the OS. */
+.theme-toggle {
+    background: none;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    color: var(--fg-muted);
+    cursor: pointer;
+    padding: 0.2rem 0.45rem;
+    font-size: 0.95rem;
+    line-height: 1;
+}
+
+.theme-toggle:hover {
+    color: var(--fg);
+    border-color: var(--fg-faint);
+}
+
+.theme-toggle-dark { display: none; }
+.theme-toggle-light { display: inline; }
+
+@media (prefers-color-scheme: dark) {
+    :root:not([data-theme]) .theme-toggle-light { display: none; }
+    :root:not([data-theme]) .theme-toggle-dark { display: inline; }
+}
+
+:root[data-theme="dark"] .theme-toggle-light { display: none; }
+:root[data-theme="dark"] .theme-toggle-dark { display: inline; }
+:root[data-theme="light"] .theme-toggle-light { display: inline; }
+:root[data-theme="light"] .theme-toggle-dark { display: none; }
 
 /* Header */
 .site-header {

--- a/docs/site/templates/BasePage.html
+++ b/docs/site/templates/BasePage.html
@@ -7,6 +7,15 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <!-- Apply the saved theme before first paint to avoid a flash. No
+         saved choice = leave unset so the CSS @media(prefers-color-scheme)
+         follows the OS. -->
+    <script>
+      try {
+        const t = localStorage.getItem('theme');
+        if (t === 'dark' || t === 'light') document.documentElement.dataset.theme = t;
+      } catch {}
+    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="{{ if .FrontMatter.description }}{{ .FrontMatter.description }}{{ else }}{{ (json "SiteMetadata.json" "siteDescription") }}{{ end }}">
     <title>{{ if .FrontMatter.title }}{{ .FrontMatter.title }} · {{ end }}{{ (json "SiteMetadata.json" "siteName") }}</title>
@@ -44,6 +53,51 @@
         mermaid.initialize({ startOnLoad: false, securityLevel: 'strict' });
         await mermaid.run();
       }
+    </script>
+
+    <!--
+      Copy buttons: add a "Copy" control to every code block. Mermaid
+      fences are excluded (they render to <pre class="mermaid"> above, and
+      language-mermaid is filtered here regardless of ordering). Vanilla,
+      dependency-free — same pattern as the mermaid loader.
+    -->
+    <script>
+      document.querySelectorAll('pre > code:not(.language-mermaid)').forEach((code) => {
+        const pre = code.parentElement;
+        pre.classList.add('has-copy');
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'copy-btn';
+        btn.textContent = 'Copy';
+        btn.setAttribute('aria-label', 'Copy code to clipboard');
+        btn.addEventListener('click', async () => {
+          try {
+            await navigator.clipboard.writeText(code.textContent);
+            btn.textContent = 'Copied';
+          } catch {
+            btn.textContent = 'Failed';
+          }
+          setTimeout(() => { btn.textContent = 'Copy'; }, 1500);
+        });
+        pre.appendChild(btn);
+      });
+    </script>
+
+    <!-- Dark-mode toggle: flip the effective theme and persist it. The
+         head script applies the saved choice before paint. -->
+    <script>
+      (function () {
+        const btn = document.querySelector('.theme-toggle');
+        if (!btn) return;
+        btn.addEventListener('click', () => {
+          const root = document.documentElement;
+          const current = root.dataset.theme ||
+            (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+          const next = current === 'dark' ? 'light' : 'dark';
+          root.dataset.theme = next;
+          try { localStorage.setItem('theme', next); } catch {}
+        });
+      })();
     </script>
 </body>
 </html>

--- a/docs/site/templates/Header.html
+++ b/docs/site/templates/Header.html
@@ -11,6 +11,10 @@
             <a class="top-nav-link" href="{{ $Site.PathPrefix }}/{{ .url }}">{{ .name }}</a>
             {{ end }}
             <a class="top-nav-link external" href="{{ (json "SiteMetadata.json" "repository") }}">GitHub</a>
+            <button type="button" class="theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">
+                <span class="theme-toggle-light">☀</span>
+                <span class="theme-toggle-dark">☾</span>
+            </button>
         </nav>
     </div>
 </header>


### PR DESCRIPTION
Easy, self-contained polish from the docs-site follow-ups (issues 853 / 854). No build-dep or CI changes; `make build` clean.

## Done

**#853**
- **Dark mode** — a dark override of the existing CSS custom properties. Follows `prefers-color-scheme` when the visitor hasn't chosen, and an explicit `[data-theme]` toggle otherwise. Header toggle button (☀ / ☾) + a tiny anti-FOUC `<head>` script that applies the saved choice before first paint, so no flash. The color tokens already threaded through the whole sheet via `var(--…)`, so this re-themes everything.
- **Code-block copy buttons** — dependency-free script in `BasePage.html` adding a Copy control to every `pre > code` (mermaid fences excluded regardless of script ordering), revealed on hover. Same pattern as the existing mermaid loader.

**#854**
- **Concepts overview page** — `content/concepts/index.html` ties the nine deep-dives together with one-line summaries; the Concepts nav now lands on the overview (was landing directly on `bringup`), with an "Overview" child.
- **README examples link** — Examples-gallery pointer in the top-nav quick links and the Documentation table.

## Verification

Built the site; confirmed the toggle button, all three inline scripts (anti-FOUC / copy / toggle handler), and the dark CSS blocks land in the generated HTML/CSS, and the concepts overview renders with all nine links. Dark-mode and copy-button *appearance* is worth an eyeball in a browser — the mechanics are in place.

## Not in this PR (left open on 853 / 854)

Client-side search (Pagefind — build dep), snippet-compile CI gate, filename auto-linkify (false-positive risk); mobile-layout pass (visual iteration), dead-intra-link rewriter, `make run` dev-server panic (upstream s3gen), demokit players. These each need a browser loop, CI wiring, or upstream digging — deliberately deferred.

Partial progress on both issues; they stay open for the remaining boxes.

https://claude.ai/code/session_01PAT6AvpFqzrurThGZniHZv