### PR TITLE
docs(site): auto-linkify, snippet-compile gate, mobile pass (issues 853/854)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -147,6 +147,10 @@ jobs:
           MCPCONFORMANCE_BASE_PATH: ${{ github.workspace }}/conf-upstream-main
         run: make check-conformance-stale
 
+      - name: Check Get Started snippets match the example
+        working-directory: mcpkit
+        run: make check-snippets
+
   apps-compat-report:
     # Mirrors conformance-report: regenerates conformance/apps/COMPAT.md
     # from umbrella tracking issue panyam/mcpkit#533 and fails if the

--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,9 @@ check-conformance-stale: check-local-suites-stale ## Fail if CONFORMANCE.md is s
 check-local-suites-stale: ## CI gate — fail if conformance/local-suites.yaml drifts from the Makefile (cases A/B/C)
 	uv run scripts/check_local_suites.py
 
+check-snippets: ## CI gate — fail if docs/GETTING_STARTED.md Go snippets drift from examples/getting-started/ (issue 853)
+	go run ./tools/check-snippets
+
 refresh-apps-compat-report: ## Regenerate conformance/apps/COMPAT.md from umbrella tracking issue (#533). Uses gh CLI.
 	./scripts/refresh-apps-compat-report.sh
 
@@ -618,5 +621,5 @@ setup: setup-tools setup-hooks ## Full development setup
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-18s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: build test test-race test-v cover cover-html cover-func cover-all test-auth test-ui test-skills test-mcpskills build-mcpskills test-mcpskills-walkthrough test-protogen test-e2e test-experimental test-apps-playwright test-apps-playwright-docker test-apps-playwright-all test-apps-playwright-docker-all refresh-visual-gallery release-audit-apps demo-app demo-upstream testkcl testkcl-auto testall test-report smoke smoke-wire verify-dual testconfall testconf testconfauth testconf-tasks testconf-tasks-v2 testconf-mrtr testconf-file-inputs testconf-auth-server testconf-elicitation testconf-skills testconf-external-checker refresh-conformance check-conformance-stale check-local-suites-stale refresh-apps-compat-report check-apps-compat-stale vet lint vulncheck seccheck secrets verify-submodule-deps audit ci ci-full serve serve-streamable serve-both tidy tidy-all bump-root collect-walkthroughs ghbuild ghserve ghdeploy tag tag-push setup-tools setup-hooks setup upkcl downkcl kcllogs build-bridge help
+.PHONY: build test test-race test-v cover cover-html cover-func cover-all test-auth test-ui test-skills test-mcpskills build-mcpskills test-mcpskills-walkthrough test-protogen test-e2e test-experimental test-apps-playwright test-apps-playwright-docker test-apps-playwright-all test-apps-playwright-docker-all refresh-visual-gallery release-audit-apps demo-app demo-upstream testkcl testkcl-auto testall test-report smoke smoke-wire verify-dual testconfall testconf testconfauth testconf-tasks testconf-tasks-v2 testconf-mrtr testconf-file-inputs testconf-auth-server testconf-elicitation testconf-skills testconf-external-checker refresh-conformance check-conformance-stale check-local-suites-stale check-snippets refresh-apps-compat-report check-apps-compat-stale vet lint vulncheck seccheck secrets verify-submodule-deps audit ci ci-full serve serve-streamable serve-both tidy tidy-all bump-root collect-walkthroughs ghbuild ghserve ghdeploy tag tag-push setup-tools setup-hooks setup upkcl downkcl kcllogs build-bridge help
 .DEFAULT_GOAL := help

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -57,7 +57,7 @@ func main() {
 		},
 	))
 
-	log.Println("listening on http://localhost:8787/mcp")
+	log.Println("getting-started server listening on http://localhost:8787/mcp")
 	if err := srv.Run(":8787"); err != nil { // Streamable HTTP
 		log.Fatal(err)
 	}

--- a/docs/site/main.go
+++ b/docs/site/main.go
@@ -105,7 +105,54 @@ func renderMarkdownFile(relPath string) template.HTML {
 		return ""
 	}
 	srcDir := path.Dir(filepath.ToSlash(filepath.Clean(relPath)))
-	return template.HTML(rewriteRepoLinks(buf.String(), srcDir))
+	out := rewriteRepoLinks(buf.String(), srcDir)
+	out = linkifyRepoPaths(out)
+	return template.HTML(out)
+}
+
+// inlineCodeSpan matches an inline <code>…</code>, capturing any immediately
+// preceding <a …> so code that is already a link (markdown link with code
+// text) is left alone. goldmark renders block code as <pre><code class=…>
+// with nested highlight spans, so [^<]+ (no nested tags) only ever matches
+// inline spans, never a code block.
+var inlineCodeSpan = regexp.MustCompile(`(<a\b[^>]*>)?<code>([^<]+)</code>`)
+
+// repoPathChars restricts auto-linkify candidates to path-shaped tokens.
+var repoPathChars = regexp.MustCompile(`^[A-Za-z0-9._/-]+$`)
+
+// linkifyRepoPaths turns inline code that names a real repository file
+// (e.g. `server/server.go` or `core/tool.go:445`) into a link to its source
+// on GitHub — the shape gitfile produces, discovered automatically in
+// rendered prose. False positives are guarded by requiring both a directory
+// separator AND that the path resolves to an actual file in the checkout, so
+// ordinary inline code (`context.Background()`, `--flag`, a bare `Makefile`)
+// is never touched. Directories are skipped (too easily confused with prose
+// like "the auth/ layer"); already-linked code is skipped.
+func linkifyRepoPaths(htmlStr string) string {
+	return inlineCodeSpan.ReplaceAllStringFunc(htmlStr, func(match string) string {
+		m := inlineCodeSpan.FindStringSubmatch(match)
+		if m[1] != "" {
+			return match // already inside an <a>
+		}
+		raw := m[2]
+		p, line := raw, ""
+		if lm := gitLineSuffix.FindStringSubmatch(raw); lm != nil {
+			p, line = lm[1], lm[2]
+		}
+		if !strings.Contains(p, "/") || !repoPathChars.MatchString(p) {
+			return match
+		}
+		info, err := os.Stat(filepath.Join(repoRoot, filepath.FromSlash(p)))
+		if err != nil || info.IsDir() {
+			return match // only link real files
+		}
+		target, display := p, p
+		if line != "" {
+			target, display = p+"#L"+line, p+":"+line
+		}
+		return fmt.Sprintf(`<a href="%s"><code>%s</code></a>`,
+			template.HTMLEscapeString(repoBlobBase+target), template.HTMLEscapeString(display))
+	})
 }
 
 // The source-of-truth markdown carries repo-relative links (./other.md,

--- a/docs/site/static/css/main.css
+++ b/docs/site/static/css/main.css
@@ -416,8 +416,40 @@ pre.has-copy:hover .copy-btn,
 
 /* Responsive */
 @media (max-width: 800px) {
-    .page { grid-template-columns: 1fr; }
-    .sidebar { position: static; max-height: none; }
+    .page {
+        grid-template-columns: 1fr;
+        gap: 1.25rem;
+    }
+    /* Sidebar stacks above the content; un-stick it and set it off with a
+       rule so the section nav reads as its own block. */
+    .sidebar {
+        position: static;
+        max-height: none;
+        overflow-y: visible;
+        padding-bottom: 1.25rem;
+        border-bottom: 1px solid var(--border);
+    }
     .pillars { grid-template-columns: 1fr; }
-    .top-nav { display: none; }
+    /* The stacked sidebar carries the section nav, so the duplicate top-nav
+       section links are hidden — but keep GitHub and the theme toggle
+       reachable (the toggle lives in the top nav). */
+    .top-nav { gap: 0.9rem; }
+    .top-nav-link:not(.external) { display: none; }
+    /* Wide tables scroll within their own box instead of forcing the page
+       to scroll sideways. */
+    .content table {
+        display: block;
+        width: max-content;
+        max-width: 100%;
+        overflow-x: auto;
+    }
+}
+
+@media (max-width: 560px) {
+    .page { padding: 1rem; }
+    .site-header-inner,
+    .site-footer-inner { padding-left: 1rem; padding-right: 1rem; }
+    .content { max-width: 100%; }
+    .hero h1 { font-size: 1.9rem; }
+    .hero-tagline { font-size: 1rem; }
 }

--- a/tools/check-snippets/main.go
+++ b/tools/check-snippets/main.go
@@ -1,0 +1,106 @@
+// Command check-snippets guards the Get Started guide's code against drift.
+//
+// docs/GETTING_STARTED.md embeds two Go snippets, each marked with a
+// `// server/main.go` or `// client/main.go` first line. Those snippets are
+// meant to be verbatim excerpts of examples/getting-started/{server,client}/
+// main.go — which compiles in the example module. This tool parses both the
+// doc snippet and the example source, drops comments, gofmt-normalizes, and
+// fails if the executable code differs. Comments may legitimately differ (the
+// doc is terser); the invariant is that the *code* a reader copies is the code
+// that actually compiles.
+//
+// Run via `make check-snippets`; wired into CI so a doc edit that diverges
+// from the example (or vice versa) fails the build. Mirrors the
+// conformance-staleness gate.
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"os"
+	"regexp"
+	"strings"
+)
+
+var (
+	blockRe  = regexp.MustCompile("(?s)```go\\r?\\n(.*?)\\r?\\n```")
+	markerRe = regexp.MustCompile(`^//\s*(server|client)/main\.go\b`)
+)
+
+// normalize parses Go source WITHOUT comments (default parser mode) and
+// re-prints it gofmt-style, so two files with identical code but different
+// comments/formatting compare equal.
+func normalize(src string) (string, error) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "", src, 0)
+	if err != nil {
+		return "", err
+	}
+	var buf bytes.Buffer
+	if err := format.Node(&buf, fset, f); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+func main() {
+	const doc = "docs/GETTING_STARTED.md"
+	data, err := os.ReadFile(doc)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "check-snippets: %v\n", err)
+		os.Exit(2)
+	}
+
+	// Collect doc snippets by their marker (server / client).
+	snippets := map[string]string{}
+	for _, m := range blockRe.FindAllStringSubmatch(string(data), -1) {
+		body := m[1]
+		first := strings.SplitN(strings.TrimSpace(body), "\n", 2)[0]
+		if mk := markerRe.FindStringSubmatch(strings.TrimSpace(first)); mk != nil {
+			snippets[mk[1]] = body
+		}
+	}
+
+	fail := false
+	for _, name := range []string{"server", "client"} {
+		block, ok := snippets[name]
+		if !ok {
+			fmt.Printf("MISSING: no `// %s/main.go` snippet found in %s\n", name, doc)
+			fail = true
+			continue
+		}
+		srcPath := fmt.Sprintf("examples/getting-started/%s/main.go", name)
+		src, err := os.ReadFile(srcPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "check-snippets: %v\n", err)
+			fail = true
+			continue
+		}
+		nDoc, errD := normalize(block)
+		if errD != nil {
+			fmt.Printf("DOES NOT COMPILE: the %s snippet in %s failed to parse: %v\n", name, doc, errD)
+			fail = true
+			continue
+		}
+		nSrc, errS := normalize(string(src))
+		if errS != nil {
+			fmt.Fprintf(os.Stderr, "check-snippets: parse %s: %v\n", srcPath, errS)
+			fail = true
+			continue
+		}
+		if nDoc != nSrc {
+			fmt.Printf("MISMATCH: %s %s snippet code differs from %s (comments aside).\n", doc, name, srcPath)
+			fail = true
+		}
+	}
+
+	if fail {
+		fmt.Fprintf(os.Stderr, "\nGet Started snippets are out of sync with the compiled example.\n"+
+			"Reconcile docs/GETTING_STARTED.md with examples/getting-started/ (the example is the compiled source of truth).\n")
+		os.Exit(1)
+	}
+	fmt.Println("check-snippets: Get Started snippets match examples/getting-started/ (comment-stripped code).")
+}


### PR DESCRIPTION
Second batch of docs-site polish, continuing from PR 878.

## #853

- **Filename auto-linkify** — a post-render pass (mirroring `rewriteRepoLinks`) wraps inline code that names a real repository file in a link to its GitHub source. False positives are guarded by requiring **both** a directory separator **and** that the path resolves on disk, so ordinary inline code (`context.Context`, `--flag`, a bare `Makefile`) is untouched; directories and already-linked code are skipped. Verified on a rendered page: `core/jsonrpc.go`, `server/dispatch.go` link; `context.Context` doesn't.
- **Snippet-compile gate** — `tools/check-snippets` parses the Go blocks in `docs/GETTING_STARTED.md` and the `examples/getting-started/` source, drops comments, gofmt-normalizes, and fails on divergence. Wired as `make check-snippets` + a CI step, mirroring the conformance-staleness gate. **It immediately caught a real drift** (the example's server log line had been updated but the doc snippet hadn't) — reconciled in this PR.

## #854

- **Mobile layout pass** — the existing `≤800px` block hid the *entire* top nav, which (since the dark-mode PR) also hid the theme toggle. Now it hides only the duplicated section links — the stacked sidebar carries those — and keeps GitHub + the toggle reachable. Adds a `≤560px` tighter-padding tier, a separator rule under the stacked sidebar, and horizontal scroll for wide tables. *(Appearance worth an eyeball at narrow widths; mechanics are in place.)*
- **Dead intra-README links** — verified **already resolved**: `renderMarkdownFile` already runs `rewriteRepoLinks`, so `CONVENTIONS.md` → GitHub source and on-site examples → site URLs. No change needed; noted so the box can be checked.

## Verification

`make check-snippets` green, `docs/site` build green, tool `go vet` green.

## Deferred (left open on 853/854)

- **Client-side search (Pagefind)** — an external build+CI dependency + search UI; deserves its own focused PR so CI provisioning can be tested carefully.
- **`make run` s3gen panic** — the crash is in the live-rebuild watcher path (not reproduced at startup in a probe); an upstream `github.com/panyam/s3gen` issue.
- **demokit players for batteries examples** — large, overlaps issue 851.

So #853 is down to just search; #854 to just the upstream panic + demokit-players (851).

https://claude.ai/code/session_01PAT6AvpFqzrurThGZniHZv