### PR TITLE
chore: small closeable items — data URI codec doc + skills WithMtimeChecks (issues 365, 576)

### DIFF
--- a/core/datauri.go
+++ b/core/datauri.go
@@ -16,6 +16,12 @@ import (
 // The plain (non-base64) data-URI form defined by RFC 2397 is intentionally
 // unsupported: the spec mandates base64 because file payloads are binary
 // and binary in URL-encoded form is wasteful and ambiguous.
+//
+// Durable across the SEP-2356 ↔ SEP-2631 reconciliation: this codec is
+// wire-shape-agnostic. In SEP-2356 the data URI is a plain string property;
+// in SEP-2631 the same encoding becomes the `inlineBase64` payload variant of
+// FileValue. The codec stays load-bearing regardless of which way the two
+// SEPs land, so it is not on a deprecation path (issue 365).
 
 // DataURIPrefix is the literal prefix that all data URIs share.
 const DataURIPrefix = "data:"
@@ -39,7 +45,8 @@ func IsDataURI(s string) bool {
 }
 
 // EncodeDataURI builds an RFC 2397 base64 data URI suitable for SEP-2356
-// file inputs. mediaType is embedded verbatim (e.g. "image/png"); pass an
+// file inputs — and, unchanged, for the SEP-2631 FileValue.inlineBase64
+// payload variant. mediaType is embedded verbatim (e.g. "image/png"); pass an
 // empty string to omit it (the consumer will assume text/plain;charset=US-ASCII
 // per RFC 2397). filename is optional; if non-empty it is percent-encoded
 // and emitted as a `name=` parameter.
@@ -57,9 +64,10 @@ func EncodeDataURI(data []byte, mediaType, filename string) string {
 }
 
 // DecodeDataURI parses an RFC 2397 base64 data URI as produced by
-// EncodeDataURI. Returns the decoded payload, the media type (with the
-// default substituted when omitted), and the decoded filename from any
-// `name=` parameter (empty when absent).
+// EncodeDataURI — covering both the SEP-2356 string form and the SEP-2631
+// FileValue.inlineBase64 payload. Returns the decoded payload, the media type
+// (with the default substituted when omitted), and the decoded filename from
+// any `name=` parameter (empty when absent).
 //
 // Non-base64 data URIs are rejected with ErrNonBase64DataURI; SEP-2356
 // requires the base64 form because payloads are binary.

--- a/ext/skills/indexer.go
+++ b/ext/skills/indexer.go
@@ -33,6 +33,11 @@ import (
 // mtime invalidation cannot run for that build and the cache reverts to
 // TTL-only freshness. With TTL also unset (zero), every Index() call
 // recomputes.
+//
+// WithMtimeChecks(false) disables the per-skill mtime comparison for a
+// backing where fs.Stat is expensive (an S3/HTTP-rooted fs.FS): the cache
+// then invalidates on TTL and explicit Provider.NotifyChanged only. See that
+// option for the tradeoff.
 type Indexer struct {
 	provider *Provider
 	cfg      indexerConfig
@@ -43,6 +48,10 @@ type Indexer struct {
 
 type indexerConfig struct {
 	ttl time.Duration
+	// mtimeChecks enables the per-skill fs.Stat mtime-comparison branch of
+	// isFresh. Default true; WithMtimeChecks(false) disables it for
+	// backings where fs.Stat is expensive (issue 576).
+	mtimeChecks bool
 }
 
 type cacheEntry struct {
@@ -69,13 +78,31 @@ func WithIndexerCacheTTL(d time.Duration) IndexerOption {
 	}
 }
 
+// WithMtimeChecks toggles the per-skill mtime-comparison branch of cache
+// invalidation. Default true: on every cache hit the Indexer fs.Stat's each
+// cataloged skill and recomputes when any mtime moved — cheap on local disk,
+// correct for edit-in-place workflows.
+//
+// Pass false for a backing where fs.Stat is expensive (an S3/HTTP-rooted
+// fs.FS, etc.), where the per-skill stat round-trip dominates the cache-hit
+// cost and defeats the point of caching. The cache then invalidates on TTL
+// (WithIndexerCacheTTL) and explicit Provider.NotifyChanged only. With mtime
+// checks off AND a zero TTL there is nothing to drive invalidation, so
+// Index() recomputes every call (the same fallback as a zero-ModTime fs.FS) —
+// pair WithMtimeChecks(false) with a non-zero TTL.
+func WithMtimeChecks(enabled bool) IndexerOption {
+	return func(c *indexerConfig) {
+		c.mtimeChecks = enabled
+	}
+}
+
 // NewIndexer constructs an Indexer that draws skills from provider.
 // The provider must already be populated (NewProvider returned without
 // error); subsequent changes to the provider's catalog are not picked
 // up here. Live mutation is the concern of ext/skills issue 564
 // (hot-reload).
 func NewIndexer(provider *Provider, opts ...IndexerOption) *Indexer {
-	idx := &Indexer{provider: provider}
+	idx := &Indexer{provider: provider, cfg: indexerConfig{mtimeChecks: true}}
 	for _, opt := range opts {
 		opt(&idx.cfg)
 	}
@@ -161,14 +188,12 @@ func (i *Indexer) isFresh() bool {
 	if i.cfg.ttl > 0 && time.Since(i.cached.builtAt) > i.cfg.ttl {
 		return false
 	}
-	if i.cfg.ttl == 0 && i.cached.noMtime {
-		// Zero TTL plus no mtime signal means we have nothing to drive
-		// invalidation off; recompute every call to avoid serving a
-		// permanently stale index.
-		return false
-	}
-	if i.cached.noMtime {
-		return true
+	// Mtime comparison is skipped when disabled by option (issue 576) or when
+	// the backing fs.FS reported no ModTime at build time. Either way the
+	// cache is TTL-only: fresh until the TTL elapses, or — with a zero TTL —
+	// recomputed every call, since nothing else drives invalidation.
+	if !i.cfg.mtimeChecks || i.cached.noMtime {
+		return i.cfg.ttl > 0
 	}
 	for _, skill := range i.provider.skills {
 		want, ok := i.cached.mtimes[skill.dirPath]

--- a/ext/skills/indexer_test.go
+++ b/ext/skills/indexer_test.go
@@ -486,3 +486,46 @@ func (c *countingFS) Stat(name string) (fs.FileInfo, error) {
 	atomic.AddInt32(&c.statCount, 1)
 	return fs.Stat(c.FS, name)
 }
+
+// TestIndexer_WithMtimeChecksDisabled_SkipsStatOnCacheHit is the issue-576
+// acceptance: with WithMtimeChecks(false) and a positive TTL, a cache hit
+// does not fs.Stat the cataloged skills — the point of the option for a
+// backing where stat is expensive.
+func TestIndexer_WithMtimeChecksDisabled_SkipsStatOnCacheHit(t *testing.T) {
+	cfs := &countingFS{FS: singleSkillMapFS(t, time.Unix(1_700_000_000, 0))}
+	p := mustProviderFromFS(t, cfs)
+
+	idx := skills.NewIndexer(p, skills.WithIndexerCacheTTL(time.Hour), skills.WithMtimeChecks(false))
+	if _, err := idx.Index(); err != nil {
+		t.Fatalf("Index #1: %v", err)
+	}
+	stats1 := atomic.LoadInt32(&cfs.statCount)
+
+	if _, err := idx.Index(); err != nil {
+		t.Fatalf("Index #2 (within TTL): %v", err)
+	}
+	if stats2 := atomic.LoadInt32(&cfs.statCount); stats2 != stats1 {
+		t.Errorf("WithMtimeChecks(false) cache hit still called fs.Stat: statCount %d -> %d", stats1, stats2)
+	}
+}
+
+// TestIndexer_MtimeChecksDefaultOn_StatsOnCacheHit pins the default: with
+// mtime checks on (the default), a cache hit does stat each skill to detect
+// in-place edits. Contrast with the disabled case above.
+func TestIndexer_MtimeChecksDefaultOn_StatsOnCacheHit(t *testing.T) {
+	cfs := &countingFS{FS: singleSkillMapFS(t, time.Unix(1_700_000_000, 0))}
+	p := mustProviderFromFS(t, cfs)
+
+	idx := skills.NewIndexer(p, skills.WithIndexerCacheTTL(time.Hour)) // mtime checks default on
+	if _, err := idx.Index(); err != nil {
+		t.Fatalf("Index #1: %v", err)
+	}
+	stats1 := atomic.LoadInt32(&cfs.statCount)
+
+	if _, err := idx.Index(); err != nil {
+		t.Fatalf("Index #2 (within TTL): %v", err)
+	}
+	if stats2 := atomic.LoadInt32(&cfs.statCount); stats2 == stats1 {
+		t.Errorf("default mtime checks: cache hit did not fs.Stat (expected mtime comparison), statCount stayed %d", stats1)
+	}
+}


### PR DESCRIPTION
Two small, self-contained items, one commit each.

## issue 365 — data URI codec doc (docs-only)

`core.EncodeDataURI` / `DecodeDataURI` / `IsDataURI` are wire-shape-agnostic: SEP-2356 uses the data URI as a plain string property, SEP-2631 as the `FileValue.inlineBase64` payload variant. The doc comments now position the codec against both SEPs so future "should we deprecate?" questions have a clear answer — it stays load-bearing regardless of how the SEP-2356 ↔ SEP-2631 reconciliation lands. No code change.

## issue 576 — skills `WithMtimeChecks(false)`

Indexer cache invalidation `fs.Stat`s each cataloged skill on every cache hit. For a network-backed `fs.FS` (S3/HTTP-rooted) that stat round-trip dominates the cache-hit cost and defeats caching.

- **`WithMtimeChecks(bool)`** — default `true` (today's behavior unchanged). When `false`, `isFresh` skips the mtime loop and the cache is TTL-only (plus explicit `Provider.NotifyChanged`). With mtime checks off **and** a zero TTL, `Index()` recomputes every call (same fallback a zero-ModTime `fs.FS` already has); doc-block says to pair it with a non-zero TTL.
- **Tests**: `WithMtimeChecks(false)` + 1h TTL does not `fs.Stat` on a cache hit (counting `fs.FS` asserts `statCount` unchanged); the default keeps stat-ing. Existing TTL + mtime tests stay green.

`go build` / `go test` / `go vet` green in `core` and `ext/skills`.

Closes issue 365. Closes issue 576.