### PR TITLE
feat(auth): inline spec markers + drift gate for AUTH_SPEC_COVERAGE (issue 504)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,9 @@ check-local-suites-stale: ## CI gate — fail if conformance/local-suites.yaml d
 check-snippets: ## CI gate — fail if docs/GETTING_STARTED.md Go snippets drift from examples/getting-started/ (issue 853)
 	go run ./tools/check-snippets
 
+check-auth-markers: ## Fail if an AUTH_SPEC_COVERAGE.md clause lacks its inline ext/auth marker (issue 504)
+	go run ./tools/check-auth-markers
+
 refresh-apps-compat-report: ## Regenerate conformance/apps/COMPAT.md from umbrella tracking issue (#533). Uses gh CLI.
 	./scripts/refresh-apps-compat-report.sh
 
@@ -621,5 +624,5 @@ setup: setup-tools setup-hooks ## Full development setup
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-18s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: build test test-race test-v cover cover-html cover-func cover-all test-auth test-ui test-skills test-mcpskills build-mcpskills test-mcpskills-walkthrough test-protogen test-e2e test-experimental test-apps-playwright test-apps-playwright-docker test-apps-playwright-all test-apps-playwright-docker-all refresh-visual-gallery release-audit-apps demo-app demo-upstream testkcl testkcl-auto testall test-report smoke smoke-wire verify-dual testconfall testconf testconfauth testconf-tasks testconf-tasks-v2 testconf-mrtr testconf-file-inputs testconf-auth-server testconf-elicitation testconf-skills testconf-external-checker refresh-conformance check-conformance-stale check-local-suites-stale check-snippets refresh-apps-compat-report check-apps-compat-stale vet lint vulncheck seccheck secrets verify-submodule-deps audit ci ci-full serve serve-streamable serve-both tidy tidy-all bump-root collect-walkthroughs ghbuild ghserve ghdeploy tag tag-push setup-tools setup-hooks setup upkcl downkcl kcllogs build-bridge help
+.PHONY: build test test-race test-v cover cover-html cover-func cover-all test-auth test-ui test-skills test-mcpskills build-mcpskills test-mcpskills-walkthrough test-protogen test-e2e test-experimental test-apps-playwright test-apps-playwright-docker test-apps-playwright-all test-apps-playwright-docker-all refresh-visual-gallery release-audit-apps demo-app demo-upstream testkcl testkcl-auto testall test-report smoke smoke-wire verify-dual testconfall testconf testconfauth testconf-tasks testconf-tasks-v2 testconf-mrtr testconf-file-inputs testconf-auth-server testconf-elicitation testconf-skills testconf-external-checker refresh-conformance check-conformance-stale check-local-suites-stale check-snippets check-auth-markers refresh-apps-compat-report check-apps-compat-stale vet lint vulncheck seccheck secrets verify-submodule-deps audit ci ci-full serve serve-streamable serve-both tidy tidy-all bump-root collect-walkthroughs ghbuild ghserve ghdeploy tag tag-push setup-tools setup-hooks setup upkcl downkcl kcllogs build-bridge help
 .DEFAULT_GOAL := help

--- a/ext/auth/dcr.go
+++ b/ext/auth/dcr.go
@@ -11,12 +11,19 @@ type ClientRegistrationRequest = client.ClientRegistrationRequest
 type ClientRegistrationResponse = client.ClientRegistrationResponse
 
 // RegisterClient is re-exported from oneauth/client. Performs RFC 7591
-// Dynamic Client Registration against the given endpoint.
+// Dynamic Client Registration against the given endpoint. RFC 7591 §3.2.1 —
+// the registration response carries the assigned client_id (and, for
+// confidential clients, client_secret), which the token source then uses;
+// oneauth parses the response, mcpkit consumes the client_id.
 var RegisterClient = client.RegisterClient
 
 // DefaultClientRegistration returns a sensible default DCR request for an MCP client.
 // This remains in mcpkit because the defaults are MCP-specific (client name,
 // redirect URIs, grant types, auth method, application_type).
+//
+// RFC 7591 §2 — the client metadata fields sent on the registration request
+// (redirect_uris, grant_types, response_types, token_endpoint_auth_method,
+// application_type, client_name).
 //
 // ApplicationType is set to "native" per SEP-837: MCP clients are CLI/SDK
 // (installed) clients, not web-server-hosted clients.

--- a/ext/auth/discovery.go
+++ b/ext/auth/discovery.go
@@ -88,10 +88,15 @@ func WithASMetadataStore(s client.ASMetadataStore) DiscoverOption {
 //  3. If no resource_metadata in header, try well-known URIs
 //  4. Fetch PRM document
 //  5. Extract authorization_servers and scopes_supported
-//  6. Discover AS metadata via oneauth DiscoverAS (RFC 8414 + OIDC fallback)
+//  6. Discover AS metadata via oneauth DiscoverAS (RFC 8414 §3 well-known
+//     AS-metadata URL + OIDC fallback)
 //
 // Per MCP spec (2025-11-25): clients MUST support both WWW-Authenticate and
 // well-known URI discovery. Must use resource_metadata from header when present.
+//
+// MCP-Auth §2.3 — the client MUST try the WWW-Authenticate resource_metadata
+// link first and fall back to the well-known URI (steps 2-3); scope selection
+// prefers WWW-Authenticate over PRM scopes_supported.
 func DiscoverMCPAuth(serverURL string, opts ...DiscoverOption) (*MCPAuthInfo, error) {
 	cfg := &discoverConfig{}
 	for _, opt := range opts {
@@ -133,7 +138,7 @@ func DiscoverMCPAuth(serverURL string, opts ...DiscoverOption) (*MCPAuthInfo, er
 	}
 
 	// Step 3: If no resource_metadata from header, try well-known URIs.
-	// Per RFC 9728: the well-known path is /.well-known/oauth-protected-resource
+	// RFC 9728 §3.1 — the PRM well-known path is /.well-known/oauth-protected-resource
 	// with the resource's path appended. E.g., for http://host/mcp:
 	//   path-based: http://host/.well-known/oauth-protected-resource/mcp
 	//   root:       http://host/.well-known/oauth-protected-resource
@@ -195,7 +200,8 @@ func DiscoverMCPAuth(serverURL string, opts ...DiscoverOption) (*MCPAuthInfo, er
 		return nil, err
 	}
 
-	// Step 4: Extract authorization_servers from PRM
+	// Step 4: Extract authorization_servers from PRM (RFC 9728 §3.2 — the PRM
+	// document's authorization_servers array; at least one AS is required).
 	info.AuthorizationServers = info.PRM.AuthorizationServers
 	if len(info.AuthorizationServers) == 0 {
 		return nil, fmt.Errorf("PRM has no authorization_servers")

--- a/ext/auth/docs/DESIGN.md
+++ b/ext/auth/docs/DESIGN.md
@@ -371,6 +371,25 @@ client := mcpkit.NewClient(serverURL, info,
 
 Source: https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization
 
+### Inline spec-marker convention (issue 504)
+
+Every ext/auth site that implements a spec-mandated clause carries an inline
+comment citing the clause, in one of three forms:
+
+- `// RFC NNNN §X.Y — …` for a consumed RFC (7591 DCR, 8414 AS metadata,
+  8707 resource indicators, 9068 JWT access tokens, 9207 iss, 9728 PRM, …)
+- `// MCP-Auth §X.Y — …` for the MCP authorization spec (§C6-style checklist
+  letters allowed)
+- `// SEP-NNNN — …` for an MCP SEP
+
+The markers travel with the code, so `grep -rE "// (RFC|MCP-Auth|SEP-) [0-9]"
+ext/auth/` reconstructs the clause→site mapping that
+[`conformance/AUTH_SPEC_COVERAGE.md`](../../../conformance/AUTH_SPEC_COVERAGE.md)
+records by `file:line` (which drifts). `make check-auth-markers` asserts that
+every matrix row citing an ext/auth site has its inline marker — so the matrix
+stays honest as the code moves. When you add a matrix row, add the marker;
+when you touch a spec-mandated site, cite the clause inline.
+
 ### Server-side (MCP server as OAuth resource server)
 
 | # | Requirement | Status | Notes |

--- a/ext/auth/iss_validator.go
+++ b/ext/auth/iss_validator.go
@@ -36,7 +36,12 @@ var ErrIssMismatch = errors.New("RFC 9207 iss does not match authorization serve
 var ErrIssMissing = errors.New("RFC 9207 iss missing despite authorization server advertising support")
 
 // validateIss applies the RFC 9207 §2.4 client-side validation rule
-// against an `iss` query parameter received on an OAuth callback.
+// against an `iss` query parameter received on an OAuth callback. This is
+// the mcpkit-side implementation of SEP-2468 (client iss comparison): the
+// four rules below map one-to-one onto the SEP-2468 conformance scenarios
+// (compare-iss-supported, reject-missing-iss, compare-iss-unadvertised,
+// proceed-no-iss), and the comparison is exact-string with no normalization
+// (sep-2468-client-no-normalization).
 // Wired into OAuthTokenSource via the oneauth BrowserLoginRequest
 // OnCallback hook (since oneauth#235 surfaces but does not enforce);
 // kept package-private because the only consumer today is the token

--- a/ext/auth/jwt_validator.go
+++ b/ext/auth/jwt_validator.go
@@ -221,6 +221,10 @@ func (v *JWTValidator) Validate(r *http.Request) error {
 		return v.unauthorized("invalid claims")
 	}
 
+	// RFC 9068 §2.2 — JWT access-token validation: the issuer (iss) and
+	// audience (aud) registered claims MUST match the expected values. The
+	// exp and nbf claims (RFC 7519 §4.1.4 / §4.1.5) are enforced by jwt.Parse
+	// above, which rejects an expired or not-yet-valid token before this point.
 	// Verify issuer
 	if v.issuer != "" {
 		if iss, _ := mapClaims["iss"].(string); iss != v.issuer {

--- a/ext/auth/token_source.go
+++ b/ext/auth/token_source.go
@@ -337,7 +337,7 @@ func (s *OAuthTokenSource) Token() (string, error) {
 		ClientID:                 clientID,
 		ClientSecret:             clientSecret,
 		Scopes:                   scopes,
-		Resource:                 s.ServerURL, // RFC 8707: bind token to this MCP server
+		Resource:                 s.ServerURL, // RFC 8707 §2: send the resource parameter to bind the token to this MCP server
 		OpenBrowser:              s.OpenBrowser,
 		OnCallback: func(_ context.Context, p client.CallbackParams) error {
 			return validateIss(p.Iss, expectedIssuer, asAdvertisedSupport)
@@ -494,6 +494,9 @@ func (s *OAuthTokenSource) Close() error {
 // the new AS. Without this, the client would silently present AS₁'s
 // client_id to AS₂, which the upstream `sep-2352-no-reuse-on-as-change`
 // check rejects as a security violation.
+// MCP-Auth §C6 — client registration priority: a pre-registered ClientID
+// wins over a CIMD ClientMetadataURL, which wins over Dynamic Client
+// Registration. resolveClientID walks the three in that fixed order.
 func (s *OAuthTokenSource) resolveClientID() (clientID, clientSecret string, err error) {
 	// 1. Pre-registered
 	if s.ClientID != "" {

--- a/tools/check-auth-markers/main.go
+++ b/tools/check-auth-markers/main.go
@@ -1,0 +1,201 @@
+// Command check-auth-markers keeps the ext/auth spec-coverage matrix
+// self-verifying (issue 504).
+//
+// conformance/AUTH_SPEC_COVERAGE.md maps each spec clause (MUST / SHOULD /
+// MAY) to the ext/auth site that implements it. That file:line link drifts
+// as code moves. This tool asserts the inverse, drift-proof invariant: for
+// every matrix row whose implementation cell cites an ext/auth non-test
+// file, that file carries an inline `// <clause>` marker citing the same
+// clause. The markers travel with the code, so `grep -rE "// (RFC|MCP-Auth|
+// SEP-)"` over ext/auth reconstructs the matrix's clause→site mapping.
+//
+// Matching is line-independent (file + clause, not file:line) and tolerant:
+// an RFC clause matches when the file has a comment naming that RFC number
+// and section; a SEP clause matches on the SEP number. Run via
+// `make check-auth-markers`.
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+const matrixPath = "conformance/AUTH_SPEC_COVERAGE.md"
+
+// clause is a normalized spec citation extracted from the matrix.
+type clause struct {
+	raw  string // human-readable, e.g. "RFC 8707 §2"
+	kind string // "RFC" | "SEP" | "MCP-Auth"
+	num  string // RFC/SEP number, or "" for MCP-Auth
+	sec  string // section, e.g. "2", "3.1", "C6", "2.3"
+}
+
+var (
+	reHeading    = regexp.MustCompile(`^#{2,3}\s+(.+)`)
+	reSectionRFC = regexp.MustCompile(`RFC (\d+)`)
+	reSectionSEP = regexp.MustCompile(`SEP-(\d+)`)
+	reFullRFC    = regexp.MustCompile(`RFC (\d+) §([0-9.]+)`)
+	reFullSEP    = regexp.MustCompile(`SEP-(\d+)`)
+	reScenSEP    = regexp.MustCompile(`sep-(\d+)-`)
+	reFullMCP    = regexp.MustCompile(`MCP-Auth §([0-9.A-Za-z]+)`)
+	reLeadingSec = regexp.MustCompile(`^§([0-9.A-Za-z]+)`)
+	reExtAuth    = regexp.MustCompile(`ext/auth/(\w+)\.go`)
+)
+
+// parseClause resolves the row's clause cell (which may be section-relative)
+// against the current section spec into a full clause. Returns ok=false when
+// the cell carries no recognizable citation.
+func parseClause(cell, sectionKind, sectionNum string) (clause, bool) {
+	if m := reFullRFC.FindStringSubmatch(cell); m != nil {
+		return clause{raw: m[0], kind: "RFC", num: m[1], sec: m[2]}, true
+	}
+	if m := reFullMCP.FindStringSubmatch(cell); m != nil {
+		return clause{raw: m[0], kind: "MCP-Auth", sec: m[1]}, true
+	}
+	if m := reScenSEP.FindStringSubmatch(cell); m != nil {
+		return clause{raw: "SEP-" + m[1], kind: "SEP", num: m[1]}, true
+	}
+	if m := reFullSEP.FindStringSubmatch(cell); m != nil {
+		return clause{raw: "SEP-" + m[1], kind: "SEP", num: m[1]}, true
+	}
+	// Section-relative §X — combine with the current section heading.
+	if m := reLeadingSec.FindStringSubmatch(cell); m != nil && sectionKind != "" {
+		switch sectionKind {
+		case "RFC":
+			return clause{raw: fmt.Sprintf("RFC %s §%s", sectionNum, m[1]), kind: "RFC", num: sectionNum, sec: m[1]}, true
+		case "SEP":
+			return clause{raw: "SEP-" + sectionNum, kind: "SEP", num: sectionNum}, true
+		case "MCP-Auth":
+			return clause{raw: "MCP-Auth §" + m[1], kind: "MCP-Auth", sec: m[1]}, true
+		}
+	}
+	return clause{}, false
+}
+
+// requirement pairs a clause with the ext/auth file that must carry its marker.
+type requirement struct {
+	file   string // e.g. "token_source.go"
+	clause clause
+}
+
+func parseMatrix() ([]requirement, error) {
+	f, err := os.Open(matrixPath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var reqs []requirement
+	seen := map[string]bool{}
+	var sectionKind, sectionNum string
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 1024*1024), 1024*1024)
+	for sc.Scan() {
+		line := sc.Text()
+		if h := reHeading.FindStringSubmatch(line); h != nil {
+			t := h[1]
+			switch {
+			case reSectionRFC.MatchString(t):
+				sectionKind, sectionNum = "RFC", reSectionRFC.FindStringSubmatch(t)[1]
+			case reSectionSEP.MatchString(t):
+				sectionKind, sectionNum = "SEP", reSectionSEP.FindStringSubmatch(t)[1]
+			case strings.Contains(t, "MCP Authorization"):
+				sectionKind, sectionNum = "MCP-Auth", ""
+			}
+			continue
+		}
+		if !strings.HasPrefix(line, "| ") || strings.Contains(line, "---") {
+			continue
+		}
+		cells := strings.Split(strings.Trim(strings.TrimSpace(line), "|"), "|")
+		if len(cells) < 2 {
+			continue
+		}
+		clauseCell := strings.TrimSpace(cells[0])
+		implCell := strings.TrimSpace(cells[1])
+		if clauseCell == "" || clauseCell == "Clause" {
+			continue
+		}
+		cl, ok := parseClause(clauseCell, sectionKind, sectionNum)
+		if !ok {
+			continue
+		}
+		for _, m := range reExtAuth.FindAllStringSubmatch(implCell, -1) {
+			file := m[1] + ".go"
+			if strings.HasSuffix(m[1], "_test") {
+				continue
+			}
+			key := file + "|" + cl.raw
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			reqs = append(reqs, requirement{file: file, clause: cl})
+		}
+	}
+	return reqs, sc.Err()
+}
+
+// fileHasClause reports whether an inline // comment in ext/auth/<file>
+// cites the clause. RFC: names the RFC number and the section; SEP: names
+// the SEP number; MCP-Auth: names the section (e.g. §C6, §2.3).
+func fileHasClause(file string, cl clause) (bool, error) {
+	data, err := os.ReadFile("ext/auth/" + file)
+	if err != nil {
+		return false, err
+	}
+	for line := range strings.SplitSeq(string(data), "\n") {
+		i := strings.Index(line, "//")
+		if i < 0 {
+			continue
+		}
+		c := line[i:]
+		switch cl.kind {
+		case "RFC":
+			if strings.Contains(c, "RFC "+cl.num) && strings.Contains(c, "§"+cl.sec) {
+				return true, nil
+			}
+		case "SEP":
+			if strings.Contains(c, "SEP-"+cl.num) {
+				return true, nil
+			}
+		case "MCP-Auth":
+			if strings.Contains(c, "§"+cl.sec) {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+func main() {
+	reqs, err := parseMatrix()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "check-auth-markers: %v\n", err)
+		os.Exit(2)
+	}
+	var missing []requirement
+	for _, r := range reqs {
+		ok, err := fileHasClause(r.file, r.clause)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "check-auth-markers: %v\n", err)
+			os.Exit(2)
+		}
+		if !ok {
+			missing = append(missing, r)
+		}
+	}
+	if len(missing) > 0 {
+		fmt.Printf("MISSING inline spec markers for %d matrix clause(s):\n", len(missing))
+		for _, r := range missing {
+			fmt.Printf("  ext/auth/%s  needs a // comment citing  %s\n", r.file, r.clause.raw)
+		}
+		fmt.Fprintf(os.Stderr, "\nAUTH_SPEC_COVERAGE.md cites these ext/auth sites, but the code carries no inline\n"+
+			"marker for the clause. Add a `// %s` comment at the impl site (issue 504).\n", "<clause>")
+		os.Exit(1)
+	}
+	fmt.Printf("check-auth-markers: all %d matrix-cited ext/auth clauses carry inline markers.\n", len(reqs))
+}


### PR DESCRIPTION
## What changes

`conformance/AUTH_SPEC_COVERAGE.md` (issue 503) maps each auth spec clause to the `ext/auth` site that implements it by `file:line` — a link that silently drifts as code moves. This puts the citation **inline at the code** (where it travels with the implementation) and adds a gate that keeps the matrix and the code in sync. Comment-only in `ext/auth`; no behavior change.

Scope: **Approach B (matrix-anchored)** — annotate every ext/auth site the matrix tracks + the field-level MUSTs the issue calls out, ship the drift gate as a local `make` target, document the convention. (Full every-function sweep and CI-wiring are deliberate follow-ups.)

## Reviewer's guide

Read in this order:
1. `tools/check-auth-markers/main.go` — start here. The gate: parses the matrix, resolves section-relative §refs against the section heading, asserts each ext/auth-citing row has a matching inline marker.
2. `ext/auth/discovery.go`, `token_source.go`, `dcr.go`, `iss_validator.go`, `jwt_validator.go` — the inline markers (comment-only).
3. `ext/auth/docs/DESIGN.md` — the documented convention.
4. `Makefile` — `make check-auth-markers` target.

## How it works (the gate)

```
for each line in AUTH_SPEC_COVERAGE.md:
    if "## RFC N" / "## SEP-N" / "## MCP Authorization" heading:
        remember it as the current section spec
    if table row:
        clause = explicit "RFC N §X" / "SEP-N" in the row
                 ELSE section-relative "§X" resolved against the current section
        for each ext/auth/<file>.go (non-test) cited in the impl cell:
            require (file, clause)
for each required (file, clause):
    assert some // comment in that file names the RFC number+section (or SEP number)
exit 1 listing any misses
```
Matching is **line-independent** (file + clause, not file:line), so it survives the code movement that breaks the matrix's own `file:line` links — which is the whole point.

## Decision log
- **Marker matches on clause, not line.** A `file:line` gate would re-break on every edit; the inline marker replaces the fragile line number.
- **Local `make` target, not CI (yet).** Avoids a red gate churning while the marker set settles; CI wiring is a one-line follow-up.
- **Approach B over a full every-function sweep.** Annotates every *tracked* clause + the issue's field-level MUSTs; the issue itself flags the full touch-everything sweep as maybe-not-worth-the-cost.

## Before / after

```
# before
$ make check-auth-markers
MISSING inline spec markers for 9 matrix clause(s):
  ext/auth/discovery.go  needs a // comment citing  MCP-Auth §2.3
  ext/auth/dcr.go        needs a // comment citing  RFC 7591 §2
  ... (7 more)
exit 1

# after
$ make check-auth-markers
check-auth-markers: all 13 matrix-cited ext/auth clauses carry inline markers.
exit 0

# grep now reconstructs the clause list (DoD)
$ grep -rhoE "RFC [0-9]+ §[0-9.]+|MCP-Auth §[0-9.A-Za-z]+|SEP-[0-9]+" ext/auth/*.go | sort -u
  → 30+ distinct clauses across RFC 7591/8414/8707/9068/9207/9728 + SEPs
```

## Out of scope (deferred)
- Wire the gate into CI (`test.yml`) — follow-up once markers settle.
- Full "every public function" annotation sweep (Approach A).
- Pre-existing `copylocks` vet warnings in ext/auth test files — unrelated; can file separately.

Closes issue 504.

https://claude.ai/code/session_01PAT6AvpFqzrurThGZniHZv