### PR TITLE
feat(agent): MultiSource memoization + same-source dedupe + ErrUnknownTool (897 follow-up)

### DIFF
--- a/agent/func_source.go
+++ b/agent/func_source.go
@@ -85,7 +85,7 @@ func (s *FuncSource) Call(ctx context.Context, name string, args map[string]any)
 	fn, ok := s.handlers[name]
 	s.mu.RUnlock()
 	if !ok {
-		return nil, fmt.Errorf("agent: unknown tool %q", name)
+		return nil, fmt.Errorf("%w: %q", ErrUnknownTool, name)
 	}
 	return fn(ctx, args)
 }

--- a/agent/multi_source.go
+++ b/agent/multi_source.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -42,6 +43,11 @@ type MultiSource struct {
 	sources     map[string]ToolSource
 	resolver    Resolver
 	onCollision func(name string, sourceIDs []string)
+
+	// index memoizes the gathered claims. Invalidated by Add, Remove, and
+	// Invalidate; refreshed lazily by Tools and by Call on a name miss.
+	index      map[string][]ToolOwner
+	indexOrder []string
 }
 
 // MultiOption configures a MultiSource.
@@ -83,7 +89,17 @@ func (m *MultiSource) Add(id string, src ToolSource) error {
 	}
 	m.sources[id] = src
 	m.order = append(m.order, id)
+	m.index = nil
 	return nil
+}
+
+// Invalidate drops the memoized tool index; the next Tools or Call gathers
+// fresh lists from every source. Wire this to tools/list_changed
+// notifications when the embedding host tracks them.
+func (m *MultiSource) Invalidate() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.index = nil
 }
 
 // Remove drops a source. Unknown ids are a no-op.
@@ -100,16 +116,17 @@ func (m *MultiSource) Remove(id string) {
 			break
 		}
 	}
+	m.index = nil
 }
 
 // Tools returns the merged, deduplicated model-facing list: unique names
 // as-is (source order preserved), collisions replaced by qualified names for
 // every claimant.
 func (m *MultiSource) Tools(ctx context.Context) ([]core.ToolDef, error) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
-	claims, orderNames, err := m.gatherLocked(ctx)
+	claims, orderNames, err := m.indexLocked(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -139,19 +156,41 @@ func (m *MultiSource) Tools(ctx context.Context) ([]core.ToolDef, error) {
 
 // Call dispatches by bare or qualified name. Resolution order: exact unique
 // bare name; qualified "sourceID_name"; ambiguous bare name via Resolver.
+// A name miss against the memoized index triggers exactly one fresh gather
+// before failing, so tools registered after the last listing stay reachable.
 func (m *MultiSource) Call(ctx context.Context, name string, args map[string]any) (*core.ToolResult, error) {
-	m.mu.RLock()
-	claims, _, err := m.gatherLocked(ctx)
+	m.mu.Lock()
+	claims, _, err := m.indexLocked(ctx)
 	if err != nil {
-		m.mu.RUnlock()
+		m.mu.Unlock()
 		return nil, err
 	}
 	src, bare, resolveErr := m.resolveLocked(claims, name, args)
-	m.mu.RUnlock()
+	if errors.Is(resolveErr, ErrUnknownTool) {
+		m.index = nil
+		if claims, _, err = m.indexLocked(ctx); err == nil {
+			src, bare, resolveErr = m.resolveLocked(claims, name, args)
+		}
+	}
+	m.mu.Unlock()
 	if resolveErr != nil {
 		return nil, resolveErr
 	}
 	return src.Call(ctx, bare, args)
+}
+
+// indexLocked returns the memoized claims index, gathering it if absent.
+// Caller must hold the write lock.
+func (m *MultiSource) indexLocked(ctx context.Context) (map[string][]ToolOwner, []string, error) {
+	if m.index != nil {
+		return m.index, m.indexOrder, nil
+	}
+	claims, orderNames, err := m.gatherLocked(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	m.index, m.indexOrder = claims, orderNames
+	return claims, orderNames, nil
 }
 
 func (m *MultiSource) resolveLocked(claims map[string][]ToolOwner, name string, args map[string]any) (ToolSource, string, error) {
@@ -185,7 +224,7 @@ func (m *MultiSource) resolveLocked(claims map[string][]ToolOwner, name string, 
 			}
 		}
 	}
-	return nil, "", fmt.Errorf("agent: unknown tool %q", name)
+	return nil, "", fmt.Errorf("%w: %q", ErrUnknownTool, name)
 }
 
 func (m *MultiSource) gatherLocked(ctx context.Context) (map[string][]ToolOwner, []string, error) {
@@ -196,7 +235,15 @@ func (m *MultiSource) gatherLocked(ctx context.Context) (map[string][]ToolOwner,
 		if err != nil {
 			return nil, nil, fmt.Errorf("agent: listing tools from source %q: %w", id, err)
 		}
+	defs:
 		for _, def := range defs {
+			// A source repeating a name is a source bug; keep the first
+			// definition so qualification never emits duplicate names.
+			for _, o := range claims[def.Name] {
+				if o.SourceID == id {
+					continue defs
+				}
+			}
 			if _, seen := claims[def.Name]; !seen {
 				orderNames = append(orderNames, def.Name)
 			}

--- a/agent/toolsource.go
+++ b/agent/toolsource.go
@@ -2,9 +2,16 @@ package agent
 
 import (
 	"context"
+	"errors"
 
 	"github.com/panyam/mcpkit/core"
 )
+
+// ErrUnknownTool is wrapped by ToolSource implementations when a Call names
+// a tool the source does not have. Aggregators use it to distinguish a
+// stale-index miss (worth one refresh) from a definitive dispatch failure;
+// the Runner uses it to feed a not-found back to the model.
+var ErrUnknownTool = errors.New("agent: unknown tool")
 
 // ToolSource is the Runner's view of callable tools, whatever their origin:
 // a connected MCP server, a host-local function, or an aggregation of other
@@ -13,7 +20,10 @@ import (
 type ToolSource interface {
 	// Tools returns the definitions the model should see. The returned
 	// slice is a snapshot; implementations decide their own caching and
-	// refresh policy. Every returned name must be callable via Call.
+	// refresh policy. Every returned name must be callable via Call, and
+	// names within one source must be unique (aggregators treat a
+	// repeated name from the same source as one claim, first definition
+	// wins; only cross-source collisions get disambiguation).
 	Tools(ctx context.Context) ([]core.ToolDef, error)
 
 	// Call dispatches one tool invocation by name. A non-nil error means

--- a/agent/toolsource_test.go
+++ b/agent/toolsource_test.go
@@ -339,3 +339,65 @@ func containsTool(defs []core.ToolDef, name string) bool {
 	}
 	return false
 }
+
+func TestMultiSourceSameSourceDuplicateNameKeepsFirst(t *testing.T) {
+	dup := &fakeSource{defs: []core.ToolDef{
+		{Name: "twin", Description: "first", InputSchema: map[string]any{"type": "object"}},
+		{Name: "twin", Description: "second", InputSchema: map[string]any{"type": "object"}},
+	}}
+	m := NewMultiSource()
+	m.Add("alpha", dup)
+	tools, err := m.Tools(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tools) != 1 || tools[0].Name != "twin" || tools[0].Description != "first" {
+		t.Fatalf("same-source duplicate must collapse to first definition, got %v", tools)
+	}
+	if _, err := m.Call(context.Background(), "twin", nil); err != nil {
+		t.Fatalf("bare call after dedupe: %v", err)
+	}
+}
+
+func TestMultiSourceMemoizesAndRefreshesOnMiss(t *testing.T) {
+	src := &countingSource{fakeSource: fakeSource{defs: defsNamed("one")}}
+	m := NewMultiSource()
+	m.Add("alpha", src)
+
+	m.Tools(context.Background())
+	m.Tools(context.Background())
+	if _, err := m.Call(context.Background(), "one", nil); err != nil {
+		t.Fatal(err)
+	}
+	if src.listCount != 1 {
+		t.Fatalf("index must be memoized across Tools+Call, listed %d times", src.listCount)
+	}
+
+	src.defs = defsNamed("one", "late")
+	if _, err := m.Call(context.Background(), "late", nil); err != nil {
+		t.Fatalf("miss must trigger one refresh: %v", err)
+	}
+	if src.listCount != 2 {
+		t.Fatalf("want exactly one refresh gather, listed %d times", src.listCount)
+	}
+
+	if _, err := m.Call(context.Background(), "nope", nil); !errors.Is(err, ErrUnknownTool) {
+		t.Fatalf("want ErrUnknownTool after refresh, got %v", err)
+	}
+
+	m.Invalidate()
+	m.Tools(context.Background())
+	if src.listCount != 4 {
+		t.Fatalf("Invalidate must force re-gather (plus the nope-miss refresh), listed %d times", src.listCount)
+	}
+}
+
+type countingSource struct {
+	fakeSource
+	listCount int
+}
+
+func (c *countingSource) Tools(ctx context.Context) ([]core.ToolDef, error) {
+	c.listCount++
+	return c.fakeSource.Tools(ctx)
+}


### PR DESCRIPTION
## What changes

Rescues the review follow-up commit that missed the PR 897 merge window (897's description already documents these changes; the code didn't land). One cherry-picked commit, no new work:

- MultiSource memoizes its claims index (previously every Call re-listed every source). Invalidated on Add/Remove/Invalidate; exactly one refresh gather on an unknown-name miss so late-registered tools stay reachable. Invalidate() is the hook for tools/list_changed wiring in the Runner ticket.
- Same-source duplicate tool names collapse to the first definition, so qualified naming can never emit duplicates.
- ErrUnknownTool exported sentinel, wrapped by FuncSource and MultiSource, used for miss classification.

## Reviewer's guide

1. [agent/multi_source.go](https://github.com/panyam/mcpkit/pull/898/files#diff-49e8e5b153ea9a7a286eb82e1eb7d4c0565a6e81db15aa44417f1a7236f6f06d) — index memoization + miss-refresh in Call.
2. [agent/toolsource_test.go](https://github.com/panyam/mcpkit/pull/898/files#diff-ca90ce7de1d3630b728ec6294a04f150ecbbe3d8f42d650751b2ee1fc8290f85) — countingSource proves memoize/refresh/invalidate cadence; same-source duplicate test.
3. [agent/toolsource.go](https://github.com/panyam/mcpkit/pull/898/files#diff-107bd4cc4275ced04db5f94f700093663cc10e2c8cc20b5db54dde76fc11ff2a), [agent/func_source.go](https://github.com/panyam/mcpkit/pull/898/files#diff-986885a5603e68f4df35d0e4b935366959a1e5c2a519d2a01bf8dc046d0b8860) — sentinel + contract note.

## Risk / blast radius

Tests: 2 new test functions on top of 897's 13; 0 assertions removed or weakened.
