### PR TITLE
feat(agent): Provider interface + OpenAI-compatible streaming client + StubProvider (issue 884)

### DIFF
--- a/agent/go.mod
+++ b/agent/go.mod
@@ -2,7 +2,10 @@ module github.com/panyam/mcpkit/agent
 
 go 1.26.4
 
-require github.com/panyam/mcpkit v0.4.0-b2
+require (
+	github.com/panyam/mcpkit v0.4.0-b2
+	github.com/panyam/servicekit v0.1.2
+)
 
 require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
@@ -13,7 +16,6 @@ require (
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/panyam/gocurrent v0.1.1 // indirect
 	github.com/panyam/goutils v0.1.8 // indirect
-	github.com/panyam/servicekit v0.1.2 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect

--- a/agent/openai_provider.go
+++ b/agent/openai_provider.go
@@ -1,14 +1,16 @@
 package agent
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
+
+	ssehttp "github.com/panyam/servicekit/http"
 )
 
 // OpenAIConfig configures an OpenAI-compatible chat-completions endpoint
@@ -32,8 +34,8 @@ type OpenAIConfig struct {
 }
 
 // OpenAIProvider implements Provider over the OpenAI-compatible
-// chat-completions wire using only the standard library. Safe for concurrent
-// use.
+// chat-completions wire with no SDK dependency (net/http plus servicekit's
+// WHATWG-conformant SSE reader). Safe for concurrent use.
 type OpenAIProvider struct {
 	cfg  OpenAIConfig
 	http *http.Client
@@ -74,7 +76,7 @@ func (p *OpenAIProvider) Stream(ctx context.Context, req ProviderRequest) (Strea
 	if err != nil {
 		return nil, err
 	}
-	return &openaiStream{ctx: ctx, body: resp.Body, scanner: newSSEScanner(resp.Body)}, nil
+	return &openaiStream{ctx: ctx, body: resp.Body, events: ssehttp.NewSSEEventReader(resp.Body)}, nil
 }
 
 // Generate implements Provider with a non-streaming request. When
@@ -256,12 +258,14 @@ type oaChunk struct {
 	Usage *oaUsage `json:"usage"`
 }
 
-// openaiStream adapts the SSE body to the Stream interface. Recv keeps a
-// small queue because one SSE chunk can expand to several Deltas.
+// openaiStream adapts the SSE body to the Stream interface via servicekit's
+// WHATWG-conformant SSEEventReader (multi-line data joining, BOM stripping,
+// comment skipping). Recv keeps a small queue because one SSE event can
+// expand to several Deltas.
 type openaiStream struct {
 	ctx     context.Context
 	body    io.ReadCloser
-	scanner *bufio.Scanner
+	events  *ssehttp.SSEEventReader
 	queue   []Delta
 	started map[int]bool
 	done    bool
@@ -281,20 +285,22 @@ func (s *openaiStream) Recv() (Delta, error) {
 		if err := s.ctx.Err(); err != nil {
 			return Delta{}, err
 		}
-		if !s.scanner.Scan() {
-			if err := s.ctx.Err(); err != nil {
+		ev, err := s.events.ReadEvent()
+		if err != nil {
+			if ctxErr := s.ctx.Err(); ctxErr != nil {
+				return Delta{}, ctxErr
+			}
+			// A partial event can ride along with io.EOF; process it
+			// before surfacing EOF on the next call.
+			if !errors.Is(err, io.EOF) || ev.Data == "" {
 				return Delta{}, err
 			}
-			if err := s.scanner.Err(); err != nil {
-				return Delta{}, err
-			}
-			return Delta{}, io.EOF
+			s.done = true
 		}
-		line := strings.TrimSpace(s.scanner.Text())
-		if !strings.HasPrefix(line, "data:") {
+		payload := strings.TrimSpace(ev.Data)
+		if payload == "" {
 			continue
 		}
-		payload := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
 		if payload == "[DONE]" {
 			s.done = true
 			continue
@@ -351,10 +357,4 @@ func (s *openaiStream) enqueue(chunk oaChunk) {
 // Close implements Stream.
 func (s *openaiStream) Close() error {
 	return s.body.Close()
-}
-
-func newSSEScanner(r io.Reader) *bufio.Scanner {
-	sc := bufio.NewScanner(r)
-	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
-	return sc
 }

--- a/agent/openai_provider.go
+++ b/agent/openai_provider.go
@@ -1,0 +1,360 @@
+package agent
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// OpenAIConfig configures an OpenAI-compatible chat-completions endpoint
+// (OpenAI, lmstudio, vllm, LiteLLM-style proxies, gateways).
+type OpenAIConfig struct {
+	// BaseURL is the API root including any version prefix, e.g.
+	// "http://localhost:1234/v1". The provider appends "/chat/completions".
+	BaseURL string
+
+	// APIKey, when non-empty, is sent as a Bearer token. Local servers
+	// commonly need none.
+	APIKey string
+
+	// Model is the model identifier sent on every request.
+	Model string
+
+	// HTTPClient overrides http.DefaultClient. Set this for proxies,
+	// custom TLS, or timeouts (note: an overall client timeout also bounds
+	// streaming reads; prefer per-request ctx deadlines for streams).
+	HTTPClient *http.Client
+}
+
+// OpenAIProvider implements Provider over the OpenAI-compatible
+// chat-completions wire using only the standard library. Safe for concurrent
+// use.
+type OpenAIProvider struct {
+	cfg  OpenAIConfig
+	http *http.Client
+}
+
+// NewOpenAIProvider validates cfg and returns a provider. BaseURL and Model
+// are required.
+func NewOpenAIProvider(cfg OpenAIConfig) (*OpenAIProvider, error) {
+	if cfg.BaseURL == "" || cfg.Model == "" {
+		return nil, fmt.Errorf("agent: OpenAIConfig requires BaseURL and Model")
+	}
+	hc := cfg.HTTPClient
+	if hc == nil {
+		hc = http.DefaultClient
+	}
+	return &OpenAIProvider{cfg: cfg, http: hc}, nil
+}
+
+// ProviderError reports a non-2xx response from the model endpoint. The body
+// is included verbatim (truncated to 2 KB) because OpenAI-compatible servers
+// put the useful diagnostics there.
+type ProviderError struct {
+	StatusCode int
+	Body       string
+}
+
+// Error implements error.
+func (e *ProviderError) Error() string {
+	return fmt.Sprintf("agent: provider returned HTTP %d: %s", e.StatusCode, e.Body)
+}
+
+// Stream implements Provider. Deltas map 1:1 from SSE chunks; tool calls
+// arrive as DeltaToolCallStart followed by DeltaToolCallArgs fragments on the
+// same index. The stream ends with io.EOF after the servers [DONE] marker.
+func (p *OpenAIProvider) Stream(ctx context.Context, req ProviderRequest) (Stream, error) {
+	body := p.buildBody(req, true)
+	resp, err := p.post(ctx, body)
+	if err != nil {
+		return nil, err
+	}
+	return &openaiStream{ctx: ctx, body: resp.Body, scanner: newSSEScanner(resp.Body)}, nil
+}
+
+// Generate implements Provider with a non-streaming request. When
+// req.ResponseSchema is set, the request carries response_format json_schema
+// and the structured document is returned in ProviderResponse.Text.
+func (p *OpenAIProvider) Generate(ctx context.Context, req ProviderRequest) (*ProviderResponse, error) {
+	body := p.buildBody(req, false)
+	resp, err := p.post(ctx, body)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var full struct {
+		Choices []struct {
+			Message struct {
+				Content          string       `json:"content"`
+				ReasoningContent string       `json:"reasoning_content"`
+				ToolCalls        []oaToolCall `json:"tool_calls"`
+			} `json:"message"`
+			FinishReason string `json:"finish_reason"`
+		} `json:"choices"`
+		Usage *oaUsage `json:"usage"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&full); err != nil {
+		return nil, fmt.Errorf("agent: decode completion: %w", err)
+	}
+	if len(full.Choices) == 0 {
+		return nil, fmt.Errorf("agent: completion had no choices")
+	}
+	choice := full.Choices[0]
+	out := &ProviderResponse{
+		Text:         choice.Message.Content,
+		Reasoning:    choice.Message.ReasoningContent,
+		FinishReason: choice.FinishReason,
+	}
+	for _, tc := range choice.Message.ToolCalls {
+		args := tc.Function.Arguments
+		if args == "" {
+			args = "{}"
+		}
+		out.ToolCalls = append(out.ToolCalls, ToolCall{ID: tc.ID, Name: tc.Function.Name, Args: json.RawMessage(args)})
+	}
+	if full.Usage != nil {
+		out.Usage = &Usage{InputTokens: full.Usage.PromptTokens, OutputTokens: full.Usage.CompletionTokens}
+	}
+	return out, nil
+}
+
+func (p *OpenAIProvider) post(ctx context.Context, body map[string]any) (*http.Response, error) {
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("agent: encode request: %w", err)
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		strings.TrimSuffix(p.cfg.BaseURL, "/")+"/chat/completions", bytes.NewReader(raw))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	if p.cfg.APIKey != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+p.cfg.APIKey)
+	}
+	resp, err := p.http.Do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		defer resp.Body.Close()
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return nil, &ProviderError{StatusCode: resp.StatusCode, Body: string(msg)}
+	}
+	return resp, nil
+}
+
+// buildBody produces the chat-completions request. Kept as one method so the
+// wire-shape test pins the exact JSON we emit.
+func (p *OpenAIProvider) buildBody(req ProviderRequest, stream bool) map[string]any {
+	msgs := make([]map[string]any, 0, len(req.Messages)+1)
+	if req.Instructions != "" {
+		msgs = append(msgs, map[string]any{"role": "system", "content": req.Instructions})
+	}
+	for _, m := range req.Messages {
+		entry := map[string]any{"role": string(m.Role)}
+		switch m.Role {
+		case RoleTool:
+			entry["tool_call_id"] = m.ToolCallID
+			entry["content"] = m.Text
+		case RoleAssistant:
+			if m.Text != "" || len(m.ToolCalls) == 0 {
+				entry["content"] = m.Text
+			}
+			if len(m.ToolCalls) > 0 {
+				calls := make([]map[string]any, len(m.ToolCalls))
+				for i, tc := range m.ToolCalls {
+					calls[i] = map[string]any{
+						"id":   tc.ID,
+						"type": "function",
+						"function": map[string]any{
+							"name":      tc.Name,
+							"arguments": string(tc.Args),
+						},
+					}
+				}
+				entry["tool_calls"] = calls
+			}
+		default:
+			entry["content"] = m.Text
+		}
+		msgs = append(msgs, entry)
+	}
+
+	body := map[string]any{
+		"model":    p.cfg.Model,
+		"messages": msgs,
+	}
+	if len(req.Tools) > 0 {
+		tools := make([]map[string]any, len(req.Tools))
+		for i, td := range req.Tools {
+			tools[i] = map[string]any{
+				"type": "function",
+				"function": map[string]any{
+					"name":        td.Name,
+					"description": td.Description,
+					"parameters":  td.InputSchema,
+				},
+			}
+		}
+		body["tools"] = tools
+	}
+	if req.Temperature != nil {
+		body["temperature"] = *req.Temperature
+	}
+	if req.MaxTokens > 0 {
+		body["max_tokens"] = req.MaxTokens
+	}
+	if stream {
+		body["stream"] = true
+		body["stream_options"] = map[string]any{"include_usage": true}
+	} else if len(req.ResponseSchema) > 0 {
+		var schema any
+		if json.Unmarshal(req.ResponseSchema, &schema) == nil {
+			body["response_format"] = map[string]any{
+				"type": "json_schema",
+				"json_schema": map[string]any{
+					"name":   "response",
+					"schema": schema,
+				},
+			}
+		}
+	}
+	return body
+}
+
+type oaToolCall struct {
+	Index    int    `json:"index"`
+	ID       string `json:"id"`
+	Function struct {
+		Name      string `json:"name"`
+		Arguments string `json:"arguments"`
+	} `json:"function"`
+}
+
+type oaUsage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+}
+
+type oaChunk struct {
+	Choices []struct {
+		Delta struct {
+			Content          string       `json:"content"`
+			ReasoningContent string       `json:"reasoning_content"`
+			Reasoning        string       `json:"reasoning"`
+			ToolCalls        []oaToolCall `json:"tool_calls"`
+		} `json:"delta"`
+		FinishReason *string `json:"finish_reason"`
+	} `json:"choices"`
+	Usage *oaUsage `json:"usage"`
+}
+
+// openaiStream adapts the SSE body to the Stream interface. Recv keeps a
+// small queue because one SSE chunk can expand to several Deltas.
+type openaiStream struct {
+	ctx     context.Context
+	body    io.ReadCloser
+	scanner *bufio.Scanner
+	queue   []Delta
+	started map[int]bool
+	done    bool
+}
+
+// Recv implements Stream.
+func (s *openaiStream) Recv() (Delta, error) {
+	for {
+		if len(s.queue) > 0 {
+			d := s.queue[0]
+			s.queue = s.queue[1:]
+			return d, nil
+		}
+		if s.done {
+			return Delta{}, io.EOF
+		}
+		if err := s.ctx.Err(); err != nil {
+			return Delta{}, err
+		}
+		if !s.scanner.Scan() {
+			if err := s.ctx.Err(); err != nil {
+				return Delta{}, err
+			}
+			if err := s.scanner.Err(); err != nil {
+				return Delta{}, err
+			}
+			return Delta{}, io.EOF
+		}
+		line := strings.TrimSpace(s.scanner.Text())
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		payload := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if payload == "[DONE]" {
+			s.done = true
+			continue
+		}
+		var chunk oaChunk
+		if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
+			return Delta{}, fmt.Errorf("agent: bad SSE chunk: %w", err)
+		}
+		s.enqueue(chunk)
+	}
+}
+
+func (s *openaiStream) enqueue(chunk oaChunk) {
+	if chunk.Usage != nil {
+		s.queue = append(s.queue, Delta{Kind: DeltaUsage, Usage: &Usage{
+			InputTokens:  chunk.Usage.PromptTokens,
+			OutputTokens: chunk.Usage.CompletionTokens,
+		}})
+	}
+	if len(chunk.Choices) == 0 {
+		return
+	}
+	choice := chunk.Choices[0]
+	if choice.Delta.Content != "" {
+		s.queue = append(s.queue, Delta{Kind: DeltaText, Text: choice.Delta.Content})
+	}
+	if r := choice.Delta.ReasoningContent + choice.Delta.Reasoning; r != "" {
+		s.queue = append(s.queue, Delta{Kind: DeltaReasoning, Text: r})
+	}
+	for _, tc := range choice.Delta.ToolCalls {
+		if s.started == nil {
+			s.started = make(map[int]bool)
+		}
+		if !s.started[tc.Index] {
+			s.started[tc.Index] = true
+			s.queue = append(s.queue, Delta{
+				Kind:       DeltaToolCallStart,
+				Index:      tc.Index,
+				ToolCallID: tc.ID,
+				ToolName:   tc.Function.Name,
+				Text:       tc.Function.Arguments,
+			})
+			continue
+		}
+		if tc.Function.Arguments != "" {
+			s.queue = append(s.queue, Delta{Kind: DeltaToolCallArgs, Index: tc.Index, Text: tc.Function.Arguments})
+		}
+	}
+	if choice.FinishReason != nil && *choice.FinishReason != "" {
+		s.queue = append(s.queue, Delta{Kind: DeltaFinish, FinishReason: *choice.FinishReason})
+	}
+}
+
+// Close implements Stream.
+func (s *openaiStream) Close() error {
+	return s.body.Close()
+}
+
+func newSSEScanner(r io.Reader) *bufio.Scanner {
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	return sc
+}

--- a/agent/provider.go
+++ b/agent/provider.go
@@ -1,0 +1,208 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+// Role identifies who authored a Message.
+type Role string
+
+// Message roles. RoleTool carries a tool result back to the model and must
+// set ToolCallID; RoleAssistant messages may carry ToolCalls.
+const (
+	RoleUser      Role = "user"
+	RoleAssistant Role = "assistant"
+	RoleTool      Role = "tool"
+)
+
+// Message is one conversation entry in provider-neutral form. All fields are
+// JSON-tagged so histories can cross a wire unchanged (constraint A2).
+type Message struct {
+	Role Role `json:"role"`
+
+	// Text is the message content. Empty is legal for assistant messages
+	// that only carry tool calls.
+	Text string `json:"text,omitempty"`
+
+	// ToolCalls holds the calls an assistant message requested.
+	ToolCalls []ToolCall `json:"toolCalls,omitempty"`
+
+	// ToolCallID links a RoleTool message to the assistant ToolCall it
+	// answers.
+	ToolCallID string `json:"toolCallId,omitempty"`
+}
+
+// ToolCall is one model-requested tool invocation.
+type ToolCall struct {
+	// ID is the provider-assigned call identifier, echoed on the RoleTool
+	// result message.
+	ID string `json:"id"`
+	// Name is the tool name as listed to the model.
+	Name string `json:"name"`
+	// Args is the raw JSON arguments object.
+	Args json.RawMessage `json:"args"`
+}
+
+// ProviderRequest is one model call in provider-neutral form.
+type ProviderRequest struct {
+	// Instructions is the system prompt. Providers map it to their native
+	// system slot; it is not a Message so histories stay role-clean.
+	Instructions string `json:"instructions,omitempty"`
+
+	// Messages is the conversation so far, oldest first.
+	Messages []Message `json:"messages"`
+
+	// Tools lists what the model may call. Nil means no tools offered.
+	Tools []core.ToolDef `json:"tools,omitempty"`
+
+	// Temperature overrides the provider default when non-nil.
+	Temperature *float64 `json:"temperature,omitempty"`
+
+	// MaxTokens caps the completion length when positive.
+	MaxTokens int `json:"maxTokens,omitempty"`
+
+	// ResponseSchema, when set, asks Generate for structured output
+	// conforming to this JSON Schema. Ignored by Stream.
+	ResponseSchema json.RawMessage `json:"responseSchema,omitempty"`
+}
+
+// Usage reports token consumption for one model call.
+type Usage struct {
+	InputTokens  int `json:"inputTokens"`
+	OutputTokens int `json:"outputTokens"`
+}
+
+// DeltaKind discriminates Delta payloads.
+type DeltaKind string
+
+// Delta kinds. Tool calls stream as one DeltaToolCallStart (carrying ID and
+// Name) followed by any number of DeltaToolCallArgs fragments for the same
+// Index; there is no explicit end marker, the next start or the finish delta
+// closes the call (fold with Accumulator).
+const (
+	DeltaText          DeltaKind = "text"
+	DeltaReasoning     DeltaKind = "reasoning"
+	DeltaToolCallStart DeltaKind = "tool-call-start"
+	DeltaToolCallArgs  DeltaKind = "tool-call-args"
+	DeltaFinish        DeltaKind = "finish"
+	DeltaUsage         DeltaKind = "usage"
+)
+
+// Delta is one streamed increment of a model response. Wire-serializable by
+// design (constraint A2): surfaces may forward deltas verbatim.
+type Delta struct {
+	Kind DeltaKind `json:"kind"`
+
+	// Text carries the fragment for DeltaText, DeltaReasoning, and
+	// DeltaToolCallArgs.
+	Text string `json:"text,omitempty"`
+
+	// Index is the tool-call slot for DeltaToolCallStart and
+	// DeltaToolCallArgs; parallel calls interleave on distinct indexes.
+	Index int `json:"index,omitempty"`
+
+	// ToolCallID and ToolName are set on DeltaToolCallStart.
+	ToolCallID string `json:"toolCallId,omitempty"`
+	ToolName   string `json:"toolName,omitempty"`
+
+	// FinishReason is set on DeltaFinish ("stop", "tool_calls", ...,
+	// provider vocabulary passed through).
+	FinishReason string `json:"finishReason,omitempty"`
+
+	// Usage is set on DeltaUsage.
+	Usage *Usage `json:"usage,omitempty"`
+}
+
+// Stream delivers Deltas for one model call. Recv returns io.EOF after the
+// final delta. Close releases the underlying connection and is safe to call
+// at any point, including concurrently with Recv (which then returns an
+// error). Streams are single-consumer.
+type Stream interface {
+	Recv() (Delta, error)
+	Close() error
+}
+
+// ProviderResponse is a completed model call: the fold of a delta stream, or
+// the direct result of Generate.
+type ProviderResponse struct {
+	Text         string     `json:"text,omitempty"`
+	Reasoning    string     `json:"reasoning,omitempty"`
+	ToolCalls    []ToolCall `json:"toolCalls,omitempty"`
+	FinishReason string     `json:"finishReason,omitempty"`
+	Usage        *Usage     `json:"usage,omitempty"`
+}
+
+// Provider is the LLM seam. Implementations must be safe for concurrent use;
+// each Stream call is an independent model invocation.
+type Provider interface {
+	// Stream runs one model call and delivers the response incrementally.
+	Stream(ctx context.Context, req ProviderRequest) (Stream, error)
+
+	// Generate runs one model call to completion. When
+	// req.ResponseSchema is set, implementations request structured
+	// output conforming to it and return the JSON document in Text.
+	Generate(ctx context.Context, req ProviderRequest) (*ProviderResponse, error)
+}
+
+// Accumulator folds a delta stream into a ProviderResponse. Zero value is
+// ready to use. Not safe for concurrent use.
+type Accumulator struct {
+	resp    ProviderResponse
+	text    strings.Builder
+	reason  strings.Builder
+	argBufs map[int]*strings.Builder
+	calls   map[int]*ToolCall
+	order   []int
+}
+
+// Add folds one delta.
+func (a *Accumulator) Add(d Delta) {
+	switch d.Kind {
+	case DeltaText:
+		a.text.WriteString(d.Text)
+	case DeltaReasoning:
+		a.reason.WriteString(d.Text)
+	case DeltaToolCallStart:
+		if a.calls == nil {
+			a.calls = make(map[int]*ToolCall)
+			a.argBufs = make(map[int]*strings.Builder)
+		}
+		a.calls[d.Index] = &ToolCall{ID: d.ToolCallID, Name: d.ToolName}
+		a.argBufs[d.Index] = &strings.Builder{}
+		a.order = append(a.order, d.Index)
+		if d.Text != "" {
+			a.argBufs[d.Index].WriteString(d.Text)
+		}
+	case DeltaToolCallArgs:
+		if buf, ok := a.argBufs[d.Index]; ok {
+			buf.WriteString(d.Text)
+		}
+	case DeltaFinish:
+		a.resp.FinishReason = d.FinishReason
+	case DeltaUsage:
+		a.resp.Usage = d.Usage
+	}
+}
+
+// Result returns the folded response. Tool-call argument fragments are
+// joined in stream order; an empty argument buffer becomes the empty JSON
+// object so callers can always unmarshal Args.
+func (a *Accumulator) Result() *ProviderResponse {
+	out := a.resp
+	out.Text = a.text.String()
+	out.Reasoning = a.reason.String()
+	for _, idx := range a.order {
+		call := *a.calls[idx]
+		args := a.argBufs[idx].String()
+		if args == "" {
+			args = "{}"
+		}
+		call.Args = json.RawMessage(args)
+		out.ToolCalls = append(out.ToolCalls, call)
+	}
+	return &out
+}

--- a/agent/provider_test.go
+++ b/agent/provider_test.go
@@ -1,0 +1,333 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+func sseServer(t *testing.T, capture *[]byte, lines ...string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if capture != nil {
+			body, _ := io.ReadAll(r.Body)
+			*capture = body
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		fl := w.(http.Flusher)
+		for _, l := range lines {
+			fmt.Fprintf(w, "data: %s\n\n", l)
+			fl.Flush()
+		}
+	}))
+}
+
+func newTestProvider(t *testing.T, url string) *OpenAIProvider {
+	t.Helper()
+	p, err := NewOpenAIProvider(OpenAIConfig{BaseURL: url, Model: "test-model"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func drain(t *testing.T, s Stream) *ProviderResponse {
+	t.Helper()
+	var acc Accumulator
+	for {
+		d, err := s.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("recv: %v", err)
+		}
+		acc.Add(d)
+	}
+	return acc.Result()
+}
+
+func TestOpenAIRequestWireShape(t *testing.T) {
+	temp := 0.2
+	p := newTestProvider(t, "http://unused")
+	body := p.buildBody(ProviderRequest{
+		Instructions: "be brief",
+		Messages: []Message{
+			{Role: RoleUser, Text: "hi"},
+			{Role: RoleAssistant, ToolCalls: []ToolCall{{ID: "c1", Name: "echo", Args: json.RawMessage(`{"message":"x"}`)}}},
+			{Role: RoleTool, ToolCallID: "c1", Text: "echo: x"},
+		},
+		Tools:       []core.ToolDef{{Name: "echo", Description: "echoes", InputSchema: map[string]any{"type": "object"}}},
+		Temperature: &temp,
+		MaxTokens:   64,
+	}, true)
+
+	got, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `{"max_tokens":64,"messages":[{"content":"be brief","role":"system"},{"content":"hi","role":"user"},{"role":"assistant","tool_calls":[{"function":{"arguments":"{\"message\":\"x\"}","name":"echo"},"id":"c1","type":"function"}]},{"content":"echo: x","role":"tool","tool_call_id":"c1"}],"model":"test-model","stream":true,"stream_options":{"include_usage":true},"temperature":0.2,"tools":[{"function":{"description":"echoes","name":"echo","parameters":{"type":"object"}},"type":"function"}]}`
+	if string(got) != want {
+		t.Fatalf("wire shape drift:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestOpenAIStreamTextFinishUsage(t *testing.T) {
+	ts := sseServer(t, nil,
+		`{"choices":[{"delta":{"content":"Hel"}}]}`,
+		`{"choices":[{"delta":{"content":"lo"}}]}`,
+		`{"choices":[{"delta":{},"finish_reason":"stop"}]}`,
+		`{"choices":[],"usage":{"prompt_tokens":7,"completion_tokens":3}}`,
+		`[DONE]`,
+	)
+	defer ts.Close()
+
+	s, err := newTestProvider(t, ts.URL).Stream(context.Background(), ProviderRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	res := drain(t, s)
+	if res.Text != "Hello" || res.FinishReason != "stop" {
+		t.Fatalf("res = %+v", res)
+	}
+	if res.Usage == nil || res.Usage.InputTokens != 7 || res.Usage.OutputTokens != 3 {
+		t.Fatalf("usage = %+v", res.Usage)
+	}
+}
+
+func TestOpenAIStreamChunkedParallelToolCalls(t *testing.T) {
+	ts := sseServer(t, nil,
+		`{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"a1","function":{"name":"search","arguments":""}}]}}]}`,
+		`{"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"q\":"}}]}}]}`,
+		`{"choices":[{"delta":{"tool_calls":[{"index":1,"id":"b2","function":{"name":"zoom","arguments":"{}"}}]}}]}`,
+		`{"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"cats\"}"}}]}}]}`,
+		`{"choices":[{"delta":{},"finish_reason":"tool_calls"}]}`,
+		`[DONE]`,
+	)
+	defer ts.Close()
+
+	s, err := newTestProvider(t, ts.URL).Stream(context.Background(), ProviderRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	res := drain(t, s)
+
+	if len(res.ToolCalls) != 2 {
+		t.Fatalf("tool calls = %+v", res.ToolCalls)
+	}
+	if res.ToolCalls[0].ID != "a1" || res.ToolCalls[0].Name != "search" || string(res.ToolCalls[0].Args) != `{"q":"cats"}` {
+		t.Fatalf("call 0 assembly = %+v args=%s", res.ToolCalls[0], res.ToolCalls[0].Args)
+	}
+	if res.ToolCalls[1].ID != "b2" || string(res.ToolCalls[1].Args) != `{}` {
+		t.Fatalf("call 1 = %+v", res.ToolCalls[1])
+	}
+	if res.FinishReason != "tool_calls" {
+		t.Fatalf("finish = %q", res.FinishReason)
+	}
+}
+
+func TestOpenAIStreamReasoningDeltas(t *testing.T) {
+	ts := sseServer(t, nil,
+		`{"choices":[{"delta":{"reasoning_content":"thinking..."}}]}`,
+		`{"choices":[{"delta":{"content":"answer"}}]}`,
+		`{"choices":[{"delta":{},"finish_reason":"stop"}]}`,
+		`[DONE]`,
+	)
+	defer ts.Close()
+	s, _ := newTestProvider(t, ts.URL).Stream(context.Background(), ProviderRequest{})
+	defer s.Close()
+	res := drain(t, s)
+	if res.Reasoning != "thinking..." || res.Text != "answer" {
+		t.Fatalf("res = %+v", res)
+	}
+}
+
+func TestOpenAIStreamHTTPError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(401)
+		fmt.Fprint(w, `{"error":"bad key"}`)
+	}))
+	defer ts.Close()
+
+	_, err := newTestProvider(t, ts.URL).Stream(context.Background(), ProviderRequest{})
+	var perr *ProviderError
+	if !errors.As(err, &perr) || perr.StatusCode != 401 || !strings.Contains(perr.Body, "bad key") {
+		t.Fatalf("want ProviderError 401, got %v", err)
+	}
+}
+
+func TestOpenAIStreamCancelMidStream(t *testing.T) {
+	release := make(chan struct{})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fl := w.(http.Flusher)
+		fmt.Fprint(w, "data: {\"choices\":[{\"delta\":{\"content\":\"first\"}}]}\n\n")
+		fl.Flush()
+		<-release
+	}))
+	defer ts.Close()
+	defer close(release)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s, err := newTestProvider(t, ts.URL).Stream(ctx, ProviderRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	if d, err := s.Recv(); err != nil || d.Text != "first" {
+		t.Fatalf("first delta: %v %v", d, err)
+	}
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+	_, err = s.Recv()
+	if err == nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("want context.Canceled, got %v", err)
+	}
+}
+
+func TestOpenAIGenerateStructured(t *testing.T) {
+	var captured []byte
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured, _ = io.ReadAll(r.Body)
+		fmt.Fprint(w, `{"choices":[{"message":{"content":"{\"name\":\"trip\"}"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":2}}`)
+	}))
+	defer ts.Close()
+
+	res, err := newTestProvider(t, ts.URL).Generate(context.Background(), ProviderRequest{
+		Messages:       []Message{{Role: RoleUser, Text: "name it"}},
+		ResponseSchema: json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}}}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Text != `{"name":"trip"}` || res.Usage.InputTokens != 5 {
+		t.Fatalf("res = %+v", res)
+	}
+	var req map[string]any
+	json.Unmarshal(captured, &req)
+	rf, ok := req["response_format"].(map[string]any)
+	if !ok || rf["type"] != "json_schema" {
+		t.Fatalf("request must carry response_format json_schema, got %v", req["response_format"])
+	}
+	if _, streaming := req["stream"]; streaming {
+		t.Fatal("Generate must not stream")
+	}
+}
+
+func TestOpenAIGenerateToolCalls(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"choices":[{"message":{"content":"","tool_calls":[{"id":"t1","function":{"name":"go","arguments":"{\"x\":1}"}}]},"finish_reason":"tool_calls"}]}`)
+	}))
+	defer ts.Close()
+	res, err := newTestProvider(t, ts.URL).Generate(context.Background(), ProviderRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.ToolCalls) != 1 || res.ToolCalls[0].Name != "go" || string(res.ToolCalls[0].Args) != `{"x":1}` {
+		t.Fatalf("res = %+v", res)
+	}
+}
+
+func TestStubProviderScriptedThreeStepTurn(t *testing.T) {
+	stub := NewStubProvider(
+		StubTurn{ToolCalls: []ToolCall{{ID: "c1", Name: "get_cart", Args: json.RawMessage(`{}`)}}},
+		StubTurn{ToolCalls: []ToolCall{{ID: "c2", Name: "add_to_cart", Args: json.RawMessage(`{"item":"milk"}`)}}},
+		StubTurn{Text: "Added milk to your cart."},
+	)
+
+	var responses []*ProviderResponse
+	for i := 0; i < 3; i++ {
+		s, err := stub.Stream(context.Background(), ProviderRequest{Messages: []Message{{Role: RoleUser, Text: fmt.Sprintf("round %d", i)}}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		responses = append(responses, drain(t, s))
+	}
+
+	if responses[0].ToolCalls[0].Name != "get_cart" || responses[0].FinishReason != "tool_calls" {
+		t.Fatalf("turn 0 = %+v", responses[0])
+	}
+	if responses[1].ToolCalls[0].Name != "add_to_cart" {
+		t.Fatalf("turn 1 = %+v", responses[1])
+	}
+	if responses[2].Text != "Added milk to your cart." || responses[2].FinishReason != "stop" {
+		t.Fatalf("turn 2 = %+v", responses[2])
+	}
+	if got := len(stub.Requests()); got != 3 {
+		t.Fatalf("recorded requests = %d", got)
+	}
+	if _, err := stub.Stream(context.Background(), ProviderRequest{}); err == nil {
+		t.Fatal("want exhaustion error past the script")
+	}
+}
+
+func TestStubProviderGenerateAndErrTurn(t *testing.T) {
+	boom := errors.New("model down")
+	stub := NewStubProvider(
+		StubTurn{Text: "fold me"},
+		StubTurn{Err: boom},
+	)
+	res, err := stub.Generate(context.Background(), ProviderRequest{})
+	if err != nil || res.Text != "fold me" {
+		t.Fatalf("res=%+v err=%v", res, err)
+	}
+	if _, err := stub.Generate(context.Background(), ProviderRequest{}); !errors.Is(err, boom) {
+		t.Fatalf("want scripted error, got %v", err)
+	}
+}
+
+func TestDeltaKindsJSONRoundTrip(t *testing.T) {
+	deltas := []Delta{
+		{Kind: DeltaText, Text: "hi"},
+		{Kind: DeltaReasoning, Text: "hmm"},
+		{Kind: DeltaToolCallStart, Index: 2, ToolCallID: "id", ToolName: "n", Text: "{"},
+		{Kind: DeltaToolCallArgs, Index: 2, Text: "}"},
+		{Kind: DeltaFinish, FinishReason: "stop"},
+		{Kind: DeltaUsage, Usage: &Usage{InputTokens: 1, OutputTokens: 2}},
+	}
+	for _, d := range deltas {
+		raw, err := json.Marshal(d)
+		if err != nil {
+			t.Fatalf("marshal %s: %v", d.Kind, err)
+		}
+		var back Delta
+		if err := json.Unmarshal(raw, &back); err != nil {
+			t.Fatalf("unmarshal %s: %v", d.Kind, err)
+		}
+		raw2, err := json.Marshal(back)
+		if err != nil {
+			t.Fatalf("re-marshal %s: %v", d.Kind, err)
+		}
+		if string(raw) != string(raw2) {
+			t.Fatalf("round-trip drift for %s: %s vs %s", d.Kind, raw, raw2)
+		}
+	}
+}
+
+func TestAccumulatorEmptyArgsBecomeEmptyObject(t *testing.T) {
+	var acc Accumulator
+	acc.Add(Delta{Kind: DeltaToolCallStart, Index: 0, ToolCallID: "x", ToolName: "noargs"})
+	acc.Add(Delta{Kind: DeltaFinish, FinishReason: "tool_calls"})
+	res := acc.Result()
+	if string(res.ToolCalls[0].Args) != "{}" {
+		t.Fatalf("args = %q", res.ToolCalls[0].Args)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(res.ToolCalls[0].Args, &m); err != nil {
+		t.Fatalf("args must always unmarshal: %v", err)
+	}
+}

--- a/agent/provider_test.go
+++ b/agent/provider_test.go
@@ -331,3 +331,29 @@ func TestAccumulatorEmptyArgsBecomeEmptyObject(t *testing.T) {
 		t.Fatalf("args must always unmarshal: %v", err)
 	}
 }
+
+func TestOpenAIStreamSpecConformantSSE(t *testing.T) {
+	// Comment lines, a multi-line data event (spec joins with \n, legal
+	// JSON whitespace), and a keepalive blank event must all parse; the
+	// pre-servicekit line scanner mishandled the multi-line case.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fl := w.(http.Flusher)
+		io.WriteString(w, ": keepalive comment\n\n")
+		io.WriteString(w, "data: {\"choices\":[{\"delta\":\ndata: {\"content\":\"joined\"}}]}\n\n")
+		io.WriteString(w, "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n")
+		io.WriteString(w, "data: [DONE]\n\n")
+		fl.Flush()
+	}))
+	defer ts.Close()
+
+	s, err := newTestProvider(t, ts.URL).Stream(context.Background(), ProviderRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	res := drain(t, s)
+	if res.Text != "joined" || res.FinishReason != "stop" {
+		t.Fatalf("res = %+v", res)
+	}
+}

--- a/agent/stub_provider.go
+++ b/agent/stub_provider.go
@@ -1,0 +1,127 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
+)
+
+// StubTurn scripts one model call for StubProvider. Set Deltas to play a
+// stream verbatim, or set Text/ToolCalls/FinishReason and the turn is
+// composed into the canonical delta sequence (text, then
+// tool-call-start+args per call, then finish).
+type StubTurn struct {
+	Deltas       []Delta
+	Text         string
+	ToolCalls    []ToolCall
+	FinishReason string
+	// Err, when set, fails the call instead of playing anything.
+	Err error
+}
+
+// StubProvider is the deterministic Provider used by tests: it plays scripted
+// turns in order and records every request it receives. Safe for concurrent
+// use; turns are consumed in call order.
+type StubProvider struct {
+	mu       sync.Mutex
+	turns    []StubTurn
+	next     int
+	requests []ProviderRequest
+}
+
+// NewStubProvider returns a provider that plays turns in order and errors
+// when called past the script.
+func NewStubProvider(turns ...StubTurn) *StubProvider {
+	return &StubProvider{turns: turns}
+}
+
+// Requests returns a copy of every ProviderRequest received so far, in call
+// order. Use it to assert what the Runner actually sent the model.
+func (s *StubProvider) Requests() []ProviderRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]ProviderRequest, len(s.requests))
+	copy(out, s.requests)
+	return out
+}
+
+func (s *StubProvider) take(req ProviderRequest) (StubTurn, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.requests = append(s.requests, req)
+	if s.next >= len(s.turns) {
+		return StubTurn{}, fmt.Errorf("agent: stub provider exhausted after %d turns", len(s.turns))
+	}
+	t := s.turns[s.next]
+	s.next++
+	return t, nil
+}
+
+func (t StubTurn) deltas() []Delta {
+	if t.Deltas != nil {
+		return t.Deltas
+	}
+	var out []Delta
+	if t.Text != "" {
+		out = append(out, Delta{Kind: DeltaText, Text: t.Text})
+	}
+	for i, tc := range t.ToolCalls {
+		out = append(out, Delta{Kind: DeltaToolCallStart, Index: i, ToolCallID: tc.ID, ToolName: tc.Name, Text: string(tc.Args)})
+	}
+	reason := t.FinishReason
+	if reason == "" {
+		if len(t.ToolCalls) > 0 {
+			reason = "tool_calls"
+		} else {
+			reason = "stop"
+		}
+	}
+	return append(out, Delta{Kind: DeltaFinish, FinishReason: reason})
+}
+
+// Stream implements Provider.
+func (s *StubProvider) Stream(ctx context.Context, req ProviderRequest) (Stream, error) {
+	turn, err := s.take(req)
+	if err != nil {
+		return nil, err
+	}
+	if turn.Err != nil {
+		return nil, turn.Err
+	}
+	return &stubStream{deltas: turn.deltas()}, nil
+}
+
+// Generate implements Provider by folding the scripted turn.
+func (s *StubProvider) Generate(ctx context.Context, req ProviderRequest) (*ProviderResponse, error) {
+	turn, err := s.take(req)
+	if err != nil {
+		return nil, err
+	}
+	if turn.Err != nil {
+		return nil, turn.Err
+	}
+	var acc Accumulator
+	for _, d := range turn.deltas() {
+		acc.Add(d)
+	}
+	return acc.Result(), nil
+}
+
+type stubStream struct {
+	deltas []Delta
+	i      int
+}
+
+// Recv implements Stream.
+func (s *stubStream) Recv() (Delta, error) {
+	if s.i >= len(s.deltas) {
+		return Delta{}, io.EOF
+	}
+	d := s.deltas[s.i]
+	s.i++
+	return d, nil
+}
+
+// Close implements Stream.
+func (s *stubStream) Close() error { return nil }


### PR DESCRIPTION
Implements issue 884 (milestone 1 of the agent epic, issue 895). Parallel to the merged ToolSource PR; rebased onto the current agent branch.

## What changes

The LLM seam. `Provider` exposes `Stream` (incremental deltas: text, reasoning, tool-call start/args, finish, usage) and `Generate` (non-streaming, with JSON-schema structured output). One production implementation ships: OpenAI-compatible chat completions over the standard library (covers lmstudio, vllm, LiteLLM-style proxies, gateways). `StubProvider` plays scripted turns and records requests, making the upcoming Runner fully deterministic in CI with no network and no model.

## Reviewer's guide

Read in this order:
1. [agent/provider.go](https://github.com/panyam/mcpkit/pull/899/files#diff-a1383b85f643c0c6e93ffd7d81aefd65f427d24348ee2d60c8388c91694f3c5b) — the contract: request/message/delta types (all JSON-tagged per constraint A2), the Stream interface, and the Accumulator fold.
2. [agent/openai_provider.go](https://github.com/panyam/mcpkit/pull/899/files#diff-aa95603c3498519232b6a26863d823be62a5d05e94053dc57da95c458e875b3e) — the wire: buildBody (one method, pinned by the wire-shape test) and the SSE stream with cross-chunk tool-call assembly.
3. [agent/provider_test.go](https://github.com/panyam/mcpkit/pull/899/files#diff-9ef95f6fdefd509cecbfe470f4c5f9cd38c6456db33bb34e2191bb16c8b74738) — acceptance: exact request JSON golden, chunked parallel tool-call assembly, reasoning deltas, usage frames, HTTP error mapping, mid-stream cancellation, structured Generate, stub scripting, delta JSON round-trips.
4. [agent/stub_provider.go](https://github.com/panyam/mcpkit/pull/899/files#diff-c032868314315a39258ff50470b35c3f3adbb882824c25d51ef0d4b79f06d7f6) — the test backbone for every later milestone.

## How it works (pseudocode walkthrough)

```
Stream(req):
  POST /chat/completions {stream: true, stream_options: {include_usage}}
  for each SSE "data:" line:
    "[DONE]"            -> mark done (EOF after queue drains)
    chunk.usage         -> Delta{usage}
    delta.content       -> Delta{text}
    delta.reasoning*    -> Delta{reasoning}
    delta.tool_calls[i] -> first time index i seen: Delta{tool-call-start, id, name, first-args}
                           later chunks for i:      Delta{tool-call-args, fragment}
    finish_reason       -> Delta{finish}

Accumulator.Add folds deltas; Result() joins arg fragments per index in
stream order and coerces empty args to "{}" so Args always unmarshals.
```

The one thing a reviewer would pause on: there is no explicit tool-call-end delta. OpenAI's wire has none; the next start or the finish delta closes a call, and the Accumulator is the canonical folder (documented on the DeltaKind constants).

## Decision log

- **No OpenAI Go SDK; net/http + servicekit's SSEEventReader**: the needed surface is one endpoint plus SSE; SDK churn is real; constraint A1 exists to keep the provider dep-surface minimal. SSE parsing reuses servicekit/http.SSEEventReader (WHATWG-conformant: multi-line data joining, BOM, comments, partial-event-on-EOF), already in the dependency graph via mcpkit/client; a review question caught that the first cut hand-rolled a line scanner that mishandled multi-line data. Anthropic-native, if ever needed, is a new file behind the same interface.
- **Instructions as a request field, not a Message**: keeps histories role-clean and lets providers map to their native system slot.
- **Generate is a separate non-streaming call** rather than Stream+fold: structured output (response_format json_schema) is only meaningful non-streaming, and utility calls (naming, summaries) want the simpler path.
- **Usage normalized to InputTokens/OutputTokens** rather than provider vocabulary, so surfaces and telemetry never parse provider-specific shapes.

## Risk / blast radius

- Affects: only the `agent/` sub-module; one new direct require (servicekit, already indirect via client).
- Tests covering this: 13 new test functions, ~48 assertions added, 0 removed or weakened anywhere.
- Be paranoid about: SSE chunk-assembly edge cases across servers (some emit the id only on the first fragment, some repeat names); the started-index map is the guard, and the mutation red-check below proves the test bites. Also the wire-shape golden will intentionally fail on any request-emission change; that is its job.

## Before / after

Before (agent branch): no Provider in the package.

After:

```
$ go test ./... -count=1
ok      github.com/panyam/mcpkit/agent  0.680s
```

Mutation red-check (started-index tracking disabled deliberately, then restored):

```
--- FAIL: TestOpenAIStreamChunkedParallelToolCalls
FAIL    github.com/panyam/mcpkit/agent  0.646s
```

## Out of scope (deliberately deferred)

- Runner loop consuming Provider + ToolSource → issue 885
- Failover/backup provider wrapper + health → issue 892
- Live-endpoint interop (lmstudio walkthrough) → issue 888 (agentchat)
- Anthropic-native provider → when a concrete need lands

https://claude.ai/code/session_01Y5cyvuPoFb6xKZ5hmHYDNQ


