### PR TITLE
feat(agent): Runner multi-step tool loop + event taxonomy (issue 885)

### DIFF
--- a/agent/events.go
+++ b/agent/events.go
@@ -1,0 +1,59 @@
+package agent
+
+import (
+	"github.com/panyam/mcpkit/core"
+)
+
+// EventKind discriminates Event payloads. The vocabulary is the surfaces
+// contract from docs/AGENT_DESIGN.md: every kind is emitted in-process and
+// must project 1:1 onto a wire.
+type EventKind string
+
+// Event kinds, in the order a typical turn emits them. Thinking markers wrap
+// contiguous reasoning deltas within one step; tool events may interleave
+// across parallel calls of the same step, but tool-begin always precedes its
+// call's tool-end or tool-error.
+const (
+	EventTurnBegin     EventKind = "turn-begin"
+	EventThinkingBegin EventKind = "thinking-begin"
+	EventThinkingDelta EventKind = "thinking-delta"
+	EventThinkingEnd   EventKind = "thinking-end"
+	EventTextDelta     EventKind = "text-delta"
+	EventToolBegin     EventKind = "tool-begin"
+	EventToolEnd       EventKind = "tool-end"
+	EventToolError     EventKind = "tool-error"
+	EventTurnEnd       EventKind = "turn-end"
+	EventError         EventKind = "error"
+)
+
+// Event is one increment of a running turn, the payload surfaces consume
+// (constraint A2: JSON-tagged, stable kind, no Go-only fields). Events carry
+// no turn or session identity on purpose: in-process the emit closure is
+// scoped to one Run call, and wire layers wrap events in their own envelope
+// (session id, turn id, sequence) rather than the module pre-committing an
+// ID scheme.
+type Event struct {
+	Kind EventKind `json:"kind"`
+
+	// Step is the 1-based loop step for step-scoped kinds (deltas, tool
+	// events). Zero on turn-begin, turn-end, and error.
+	Step int `json:"step,omitempty"`
+
+	// Text carries the fragment for text-delta and thinking-delta.
+	Text string `json:"text,omitempty"`
+
+	// ToolCall identifies the call for tool-begin, tool-end, and
+	// tool-error.
+	ToolCall *ToolCall `json:"toolCall,omitempty"`
+
+	// ToolResult is the outcome on tool-end (including IsError results;
+	// tool-error is reserved for dispatch failures).
+	ToolResult *core.ToolResult `json:"toolResult,omitempty"`
+
+	// Error is the failure description on tool-error and error. A string,
+	// not an error value, so the event crosses wires unchanged.
+	Error string `json:"error,omitempty"`
+
+	// Result is the completed turn on turn-end.
+	Result *TurnResult `json:"result,omitempty"`
+}

--- a/agent/runner.go
+++ b/agent/runner.go
@@ -1,0 +1,264 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"slices"
+	"sync"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+// DefaultMaxSteps bounds a turn when RunnerConfig.MaxSteps is zero. Eight
+// model calls is generous for real workflows; hitting it usually means the
+// model is looping on a failing tool.
+const DefaultMaxSteps = 8
+
+// ErrMaxSteps is returned (wrapped) by Run when the model keeps requesting
+// tool calls past the step cap. Check with errors.Is.
+var ErrMaxSteps = errors.New("agent: max steps exceeded")
+
+// RunnerConfig assembles a Runner.
+type RunnerConfig struct {
+	// Provider is the LLM. Required.
+	Provider Provider
+
+	// Tools is the tool surface offered to the model. Optional: nil means
+	// the model is offered no tools and any hallucinated call fails back
+	// into the conversation.
+	Tools ToolSource
+
+	// Instructions is the system prompt sent on every step.
+	Instructions string
+
+	// MaxSteps caps model calls per turn. Zero means DefaultMaxSteps.
+	MaxSteps int
+}
+
+// Runner executes turns: the multi-step loop that streams the model,
+// dispatches its tool calls, feeds results back, and repeats until the model
+// answers in text. Safe for concurrent use; each Run call is an independent
+// turn.
+type Runner struct {
+	cfg RunnerConfig
+}
+
+// NewRunner validates cfg and returns a Runner.
+func NewRunner(cfg RunnerConfig) (*Runner, error) {
+	if cfg.Provider == nil {
+		return nil, fmt.Errorf("agent: RunnerConfig requires a Provider")
+	}
+	if cfg.MaxSteps <= 0 {
+		cfg.MaxSteps = DefaultMaxSteps
+	}
+	return &Runner{cfg: cfg}, nil
+}
+
+// TurnResult is the completed turn. Messages holds exactly the entries the
+// turn appended (assistant messages and tool results, in order), so callers
+// thread history as append(history, result.Messages...).
+type TurnResult struct {
+	Text         string    `json:"text,omitempty"`
+	Messages     []Message `json:"messages"`
+	Usage        Usage     `json:"usage"`
+	Steps        int       `json:"steps"`
+	FinishReason string    `json:"finishReason,omitempty"`
+}
+
+// Run executes one turn against history. Events stream to emit (nil is
+// allowed); emit is never called concurrently. Tool failures of every kind
+// (unknown tool, transport, bad args) are fed back to the model as
+// error-marked tool results and the loop continues; only ctx cancellation,
+// provider failure, or the step cap abort the turn. The returned error wraps
+// ErrMaxSteps when the cap was hit.
+func (r *Runner) Run(ctx context.Context, history []Message, emit func(Event)) (*TurnResult, error) {
+	if emit == nil {
+		emit = func(Event) {}
+	}
+	emit(Event{Kind: EventTurnBegin})
+
+	msgs := slices.Clone(history)
+	var added []Message
+	var usage Usage
+
+	for step := 1; step <= r.cfg.MaxSteps; step++ {
+		var tools []core.ToolDef
+		if r.cfg.Tools != nil {
+			var err error
+			if tools, err = r.cfg.Tools.Tools(ctx); err != nil {
+				return nil, r.fail(emit, fmt.Errorf("agent: listing tools: %w", err))
+			}
+		}
+
+		stream, err := r.cfg.Provider.Stream(ctx, ProviderRequest{
+			Instructions: r.cfg.Instructions,
+			Messages:     msgs,
+			Tools:        tools,
+		})
+		if err != nil {
+			return nil, r.fail(emit, err)
+		}
+		resp, err := consumeStream(stream, step, emit)
+		stream.Close()
+		if err != nil {
+			return nil, r.fail(emit, err)
+		}
+		if resp.Usage != nil {
+			usage.InputTokens += resp.Usage.InputTokens
+			usage.OutputTokens += resp.Usage.OutputTokens
+		}
+
+		assistant := Message{Role: RoleAssistant, Text: resp.Text, ToolCalls: resp.ToolCalls}
+		msgs = append(msgs, assistant)
+		added = append(added, assistant)
+
+		if len(resp.ToolCalls) == 0 {
+			result := &TurnResult{
+				Text:         resp.Text,
+				Messages:     added,
+				Usage:        usage,
+				Steps:        step,
+				FinishReason: resp.FinishReason,
+			}
+			emit(Event{Kind: EventTurnEnd, Result: result})
+			return result, nil
+		}
+
+		toolMsgs := r.dispatch(ctx, step, resp.ToolCalls, emit)
+		if err := ctx.Err(); err != nil {
+			return nil, r.fail(emit, err)
+		}
+		msgs = append(msgs, toolMsgs...)
+		added = append(added, toolMsgs...)
+	}
+
+	return nil, r.fail(emit, fmt.Errorf("%w (%d steps)", ErrMaxSteps, r.cfg.MaxSteps))
+}
+
+func (r *Runner) fail(emit func(Event), err error) error {
+	emit(Event{Kind: EventError, Error: err.Error()})
+	return err
+}
+
+// consumeStream folds one model call, emitting deltas as they arrive.
+// Thinking markers wrap contiguous reasoning: begin before the first
+// reasoning delta, end when the step moves on to text, tool calls, or
+// completes.
+func consumeStream(stream Stream, step int, emit func(Event)) (*ProviderResponse, error) {
+	var acc Accumulator
+	thinking := false
+	endThinking := func() {
+		if thinking {
+			emit(Event{Kind: EventThinkingEnd, Step: step})
+			thinking = false
+		}
+	}
+	for {
+		d, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		acc.Add(d)
+		switch d.Kind {
+		case DeltaReasoning:
+			if !thinking {
+				emit(Event{Kind: EventThinkingBegin, Step: step})
+				thinking = true
+			}
+			emit(Event{Kind: EventThinkingDelta, Step: step, Text: d.Text})
+		case DeltaText:
+			endThinking()
+			emit(Event{Kind: EventTextDelta, Step: step, Text: d.Text})
+		case DeltaToolCallStart:
+			endThinking()
+		}
+	}
+	endThinking()
+	return acc.Result(), nil
+}
+
+// dispatch runs the step's tool calls concurrently, serializes event
+// emission, and returns RoleTool messages in call order regardless of
+// completion order.
+func (r *Runner) dispatch(ctx context.Context, step int, calls []ToolCall, emit func(Event)) []Message {
+	results := make([]Message, len(calls))
+	var emitMu sync.Mutex
+	locked := func(ev Event) {
+		emitMu.Lock()
+		emit(ev)
+		emitMu.Unlock()
+	}
+
+	var wg sync.WaitGroup
+	for i, call := range calls {
+		wg.Add(1)
+		go func(i int, call ToolCall) {
+			defer wg.Done()
+			locked(Event{Kind: EventToolBegin, Step: step, ToolCall: &call})
+			text := r.callTool(ctx, step, call, locked)
+			results[i] = Message{Role: RoleTool, ToolCallID: call.ID, Text: text}
+		}(i, call)
+	}
+	wg.Wait()
+	return results
+}
+
+// callTool executes one call and renders the text fed back to the model.
+// Every failure shape becomes model-visible text rather than a turn abort.
+func (r *Runner) callTool(ctx context.Context, step int, call ToolCall, emit func(Event)) string {
+	failed := func(err error) string {
+		emit(Event{Kind: EventToolError, Step: step, ToolCall: &call, Error: err.Error()})
+		return fmt.Sprintf("tool call failed: %v", err)
+	}
+
+	if r.cfg.Tools == nil {
+		return failed(fmt.Errorf("%w: %q (no tools offered)", ErrUnknownTool, call.Name))
+	}
+	args := map[string]any{}
+	if len(call.Args) > 0 {
+		if err := json.Unmarshal(call.Args, &args); err != nil {
+			return failed(fmt.Errorf("agent: tool %q arguments are not a JSON object: %w", call.Name, err))
+		}
+	}
+	res, err := r.cfg.Tools.Call(ctx, call.Name, args)
+	if err != nil {
+		return failed(err)
+	}
+	emit(Event{Kind: EventToolEnd, Step: step, ToolCall: &call, ToolResult: res})
+	text := toolResultText(res)
+	if res.IsError {
+		return "tool reported an error: " + text
+	}
+	return text
+}
+
+// toolResultText flattens a tool result for the model: text content items
+// joined by newlines, falling back to marshaled structured content, then to
+// a neutral placeholder so the model always receives something parseable.
+func toolResultText(res *core.ToolResult) string {
+	var parts []string
+	for _, c := range res.Content {
+		if c.Type == "text" && c.Text != "" {
+			parts = append(parts, c.Text)
+		}
+	}
+	if len(parts) > 0 {
+		out := parts[0]
+		for _, p := range parts[1:] {
+			out += "\n" + p
+		}
+		return out
+	}
+	if res.StructuredContent != nil {
+		if raw, err := json.Marshal(res.StructuredContent); err == nil {
+			return string(raw)
+		}
+	}
+	return "(empty result)"
+}

--- a/agent/runner_test.go
+++ b/agent/runner_test.go
@@ -1,0 +1,368 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+func collectEvents() (func(Event), *[]Event) {
+	var events []Event
+	return func(e Event) { events = append(events, e) }, &events
+}
+
+func kinds(events []Event) []EventKind {
+	out := make([]EventKind, len(events))
+	for i, e := range events {
+		out[i] = e.Kind
+	}
+	return out
+}
+
+func newRunner(t *testing.T, p Provider, src ToolSource) *Runner {
+	t.Helper()
+	r, err := NewRunner(RunnerConfig{Provider: p, Tools: src, Instructions: "be helpful"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return r
+}
+
+func TestRunnerSingleStepText(t *testing.T) {
+	stub := NewStubProvider(StubTurn{Deltas: []Delta{
+		{Kind: DeltaText, Text: "Hello "},
+		{Kind: DeltaText, Text: "there"},
+		{Kind: DeltaFinish, FinishReason: "stop"},
+	}})
+	emit, events := collectEvents()
+
+	res, err := newRunner(t, stub, nil).Run(context.Background(), []Message{{Role: RoleUser, Text: "hi"}}, emit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Text != "Hello there" || res.Steps != 1 || res.FinishReason != "stop" {
+		t.Fatalf("result = %+v", res)
+	}
+	want := []EventKind{EventTurnBegin, EventTextDelta, EventTextDelta, EventTurnEnd}
+	if fmt.Sprint(kinds(*events)) != fmt.Sprint(want) {
+		t.Fatalf("events = %v, want %v", kinds(*events), want)
+	}
+	if len(res.Messages) != 1 || res.Messages[0].Role != RoleAssistant {
+		t.Fatalf("messages = %+v", res.Messages)
+	}
+	if reqs := stub.Requests(); len(reqs[0].Tools) != 0 || reqs[0].Instructions != "be helpful" {
+		t.Fatalf("request = %+v", reqs[0])
+	}
+}
+
+func TestRunnerMultiStepToolLoopThreadsHistory(t *testing.T) {
+	src := NewFuncSource()
+	AddFunc(src, "lookup", "looks up", func(ctx context.Context, in struct {
+		Key string `json:"key"`
+	}) (string, error) {
+		return "value-for-" + in.Key, nil
+	})
+
+	stub := NewStubProvider(
+		StubTurn{ToolCalls: []ToolCall{{ID: "c1", Name: "lookup", Args: json.RawMessage(`{"key":"x"}`)}}},
+		StubTurn{Text: "The value is value-for-x."},
+	)
+	emit, events := collectEvents()
+
+	res, err := newRunner(t, stub, src).Run(context.Background(), []Message{{Role: RoleUser, Text: "get x"}}, emit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Steps != 2 || res.Text != "The value is value-for-x." {
+		t.Fatalf("result = %+v", res)
+	}
+
+	want := []EventKind{EventTurnBegin, EventToolBegin, EventToolEnd, EventTextDelta, EventTurnEnd}
+	if fmt.Sprint(kinds(*events)) != fmt.Sprint(want) {
+		t.Fatalf("events = %v, want %v", kinds(*events), want)
+	}
+
+	reqs := stub.Requests()
+	second := reqs[1].Messages
+	if len(second) != 3 {
+		t.Fatalf("second request messages = %+v", second)
+	}
+	if second[1].Role != RoleAssistant || len(second[1].ToolCalls) != 1 {
+		t.Fatalf("assistant threading = %+v", second[1])
+	}
+	if second[2].Role != RoleTool || second[2].ToolCallID != "c1" || second[2].Text != "value-for-x" {
+		t.Fatalf("tool threading = %+v", second[2])
+	}
+	if len(res.Messages) != 3 {
+		t.Fatalf("added messages = %d, want 3", len(res.Messages))
+	}
+	if reqs[1].Tools[0].Name != "lookup" {
+		t.Fatalf("tools must be re-listed per step, got %+v", reqs[1].Tools)
+	}
+}
+
+func TestRunnerParallelToolCallsRendezvous(t *testing.T) {
+	first := make(chan struct{})
+	second := make(chan struct{})
+	src := NewFuncSource()
+	AddFunc(src, "a", "", func(ctx context.Context, _ struct{}) (string, error) {
+		close(first)
+		select {
+		case <-second:
+			return "a-done", nil
+		case <-time.After(2 * time.Second):
+			return "", errors.New("tool a never saw tool b start: dispatch is serial")
+		}
+	})
+	AddFunc(src, "b", "", func(ctx context.Context, _ struct{}) (string, error) {
+		close(second)
+		select {
+		case <-first:
+			return "b-done", nil
+		case <-time.After(2 * time.Second):
+			return "", errors.New("tool b never saw tool a start: dispatch is serial")
+		}
+	})
+
+	stub := NewStubProvider(
+		StubTurn{ToolCalls: []ToolCall{
+			{ID: "c1", Name: "a", Args: json.RawMessage(`{}`)},
+			{ID: "c2", Name: "b", Args: json.RawMessage(`{}`)},
+		}},
+		StubTurn{Text: "both done"},
+	)
+
+	res, err := newRunner(t, stub, src).Run(context.Background(), nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	toolMsgs := res.Messages[1:3]
+	if toolMsgs[0].ToolCallID != "c1" || toolMsgs[0].Text != "a-done" {
+		t.Fatalf("call-order threading broken: %+v", toolMsgs)
+	}
+	if toolMsgs[1].ToolCallID != "c2" || toolMsgs[1].Text != "b-done" {
+		t.Fatalf("call-order threading broken: %+v", toolMsgs)
+	}
+}
+
+func TestRunnerDispatchErrorFedToModel(t *testing.T) {
+	stub := NewStubProvider(
+		StubTurn{ToolCalls: []ToolCall{{ID: "c1", Name: "no_such_tool", Args: json.RawMessage(`{}`)}}},
+		StubTurn{Text: "recovered"},
+	)
+	emit, events := collectEvents()
+
+	res, err := newRunner(t, stub, NewFuncSource()).Run(context.Background(), nil, emit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Text != "recovered" {
+		t.Fatalf("loop must continue past dispatch errors, got %+v", res)
+	}
+	var sawToolError bool
+	for _, e := range *events {
+		if e.Kind == EventToolError && strings.Contains(e.Error, "no_such_tool") {
+			sawToolError = true
+		}
+		if e.Kind == EventToolEnd {
+			t.Fatalf("dispatch failure must not emit tool-end: %+v", e)
+		}
+	}
+	if !sawToolError {
+		t.Fatalf("missing tool-error event: %v", kinds(*events))
+	}
+	toolMsg := stub.Requests()[1].Messages[1]
+	if toolMsg.Role != RoleTool || !strings.Contains(toolMsg.Text, "tool call failed") {
+		t.Fatalf("model must see the failure: %+v", toolMsg)
+	}
+}
+
+func TestRunnerIsErrorResultIsToolEndNotToolError(t *testing.T) {
+	src := NewFuncSource()
+	AddFunc(src, "flaky", "", func(ctx context.Context, _ struct{}) (string, error) {
+		return "", errors.New("kaput")
+	})
+	stub := NewStubProvider(
+		StubTurn{ToolCalls: []ToolCall{{ID: "c1", Name: "flaky", Args: json.RawMessage(`{}`)}}},
+		StubTurn{Text: "noted"},
+	)
+	emit, events := collectEvents()
+
+	if _, err := newRunner(t, stub, src).Run(context.Background(), nil, emit); err != nil {
+		t.Fatal(err)
+	}
+	var sawEnd bool
+	for _, e := range *events {
+		if e.Kind == EventToolError {
+			t.Fatalf("IsError result must be tool-end, got tool-error: %+v", e)
+		}
+		if e.Kind == EventToolEnd {
+			sawEnd = true
+			if e.ToolResult == nil || !e.ToolResult.IsError {
+				t.Fatalf("tool-end must carry the IsError result: %+v", e)
+			}
+		}
+	}
+	if !sawEnd {
+		t.Fatal("missing tool-end event")
+	}
+	toolMsg := stub.Requests()[1].Messages[1]
+	if !strings.Contains(toolMsg.Text, "tool reported an error") || !strings.Contains(toolMsg.Text, "kaput") {
+		t.Fatalf("model must see the error marker: %+v", toolMsg)
+	}
+}
+
+func TestRunnerStepCap(t *testing.T) {
+	loop := StubTurn{ToolCalls: []ToolCall{{ID: "c", Name: "spin", Args: json.RawMessage(`{}`)}}}
+	stub := NewStubProvider(loop, loop, loop)
+	src := NewFuncSource()
+	AddFunc(src, "spin", "", func(ctx context.Context, _ struct{}) (string, error) { return "again", nil })
+
+	r, err := NewRunner(RunnerConfig{Provider: stub, Tools: src, MaxSteps: 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+	emit, events := collectEvents()
+	_, err = r.Run(context.Background(), nil, emit)
+	if !errors.Is(err, ErrMaxSteps) {
+		t.Fatalf("want ErrMaxSteps, got %v", err)
+	}
+	last := (*events)[len(*events)-1]
+	if last.Kind != EventError || !strings.Contains(last.Error, "max steps") {
+		t.Fatalf("last event = %+v", last)
+	}
+}
+
+type blockingStream struct{ ctx context.Context }
+
+func (b *blockingStream) Recv() (Delta, error) {
+	<-b.ctx.Done()
+	return Delta{}, b.ctx.Err()
+}
+func (b *blockingStream) Close() error { return nil }
+
+type blockingProvider struct{}
+
+func (blockingProvider) Stream(ctx context.Context, req ProviderRequest) (Stream, error) {
+	return &blockingStream{ctx: ctx}, nil
+}
+func (blockingProvider) Generate(ctx context.Context, req ProviderRequest) (*ProviderResponse, error) {
+	return nil, errors.New("unused")
+}
+
+func TestRunnerCancellationAborts(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+	emit, events := collectEvents()
+	_, err := newRunner(t, blockingProvider{}, nil).Run(ctx, nil, emit)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("want context.Canceled, got %v", err)
+	}
+	last := (*events)[len(*events)-1]
+	if last.Kind != EventError {
+		t.Fatalf("last event = %+v", last)
+	}
+}
+
+func TestRunnerThinkingMarkers(t *testing.T) {
+	stub := NewStubProvider(StubTurn{Deltas: []Delta{
+		{Kind: DeltaReasoning, Text: "hmm "},
+		{Kind: DeltaReasoning, Text: "ok"},
+		{Kind: DeltaText, Text: "answer"},
+		{Kind: DeltaFinish, FinishReason: "stop"},
+	}})
+	emit, events := collectEvents()
+	if _, err := newRunner(t, stub, nil).Run(context.Background(), nil, emit); err != nil {
+		t.Fatal(err)
+	}
+	want := []EventKind{EventTurnBegin, EventThinkingBegin, EventThinkingDelta, EventThinkingDelta, EventThinkingEnd, EventTextDelta, EventTurnEnd}
+	if fmt.Sprint(kinds(*events)) != fmt.Sprint(want) {
+		t.Fatalf("events = %v, want %v", kinds(*events), want)
+	}
+}
+
+func TestRunnerUsageAggregation(t *testing.T) {
+	src := NewFuncSource()
+	AddFunc(src, "t", "", func(ctx context.Context, _ struct{}) (string, error) { return "ok", nil })
+	stub := NewStubProvider(
+		StubTurn{Deltas: []Delta{
+			{Kind: DeltaToolCallStart, Index: 0, ToolCallID: "c1", ToolName: "t", Text: "{}"},
+			{Kind: DeltaFinish, FinishReason: "tool_calls"},
+			{Kind: DeltaUsage, Usage: &Usage{InputTokens: 10, OutputTokens: 5}},
+		}},
+		StubTurn{Deltas: []Delta{
+			{Kind: DeltaText, Text: "done"},
+			{Kind: DeltaFinish, FinishReason: "stop"},
+			{Kind: DeltaUsage, Usage: &Usage{InputTokens: 20, OutputTokens: 7}},
+		}},
+	)
+	res, err := newRunner(t, stub, src).Run(context.Background(), nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Usage.InputTokens != 30 || res.Usage.OutputTokens != 12 {
+		t.Fatalf("usage = %+v", res.Usage)
+	}
+}
+
+func TestRunnerEventKindsJSONRoundTrip(t *testing.T) {
+	events := []Event{
+		{Kind: EventTurnBegin},
+		{Kind: EventThinkingBegin, Step: 1},
+		{Kind: EventThinkingDelta, Step: 1, Text: "hmm"},
+		{Kind: EventThinkingEnd, Step: 1},
+		{Kind: EventTextDelta, Step: 1, Text: "hi"},
+		{Kind: EventToolBegin, Step: 1, ToolCall: &ToolCall{ID: "c", Name: "n", Args: json.RawMessage(`{}`)}},
+		{Kind: EventToolEnd, Step: 1, ToolCall: &ToolCall{ID: "c", Name: "n", Args: json.RawMessage(`{}`)}, ToolResult: &core.ToolResult{Content: []core.Content{{Type: "text", Text: "ok"}}}},
+		{Kind: EventToolError, Step: 1, ToolCall: &ToolCall{ID: "c", Name: "n", Args: json.RawMessage(`{}`)}, Error: "boom"},
+		{Kind: EventTurnEnd, Result: &TurnResult{Text: "done", Steps: 1, Usage: Usage{InputTokens: 1, OutputTokens: 2}}},
+		{Kind: EventError, Error: "fatal"},
+	}
+	for _, e := range events {
+		raw, err := json.Marshal(e)
+		if err != nil {
+			t.Fatalf("marshal %s: %v", e.Kind, err)
+		}
+		var back Event
+		if err := json.Unmarshal(raw, &back); err != nil {
+			t.Fatalf("unmarshal %s: %v", e.Kind, err)
+		}
+		raw2, err := json.Marshal(back)
+		if err != nil {
+			t.Fatalf("re-marshal %s: %v", e.Kind, err)
+		}
+		if string(raw) != string(raw2) {
+			t.Fatalf("round-trip drift for %s: %s vs %s", e.Kind, raw, raw2)
+		}
+	}
+}
+
+func TestRunnerRequiresProvider(t *testing.T) {
+	if _, err := NewRunner(RunnerConfig{}); err == nil {
+		t.Fatal("want error for missing provider")
+	}
+}
+
+func TestToolResultTextFallbacks(t *testing.T) {
+	multi := &core.ToolResult{Content: []core.Content{{Type: "text", Text: "a"}, {Type: "text", Text: "b"}}}
+	if got := toolResultText(multi); got != "a\nb" {
+		t.Fatalf("multi-text = %q", got)
+	}
+	structured := &core.ToolResult{StructuredContent: map[string]any{"n": 1}}
+	if got := toolResultText(structured); got != `{"n":1}` {
+		t.Fatalf("structured = %q", got)
+	}
+	empty := &core.ToolResult{}
+	if got := toolResultText(empty); got != "(empty result)" {
+		t.Fatalf("empty = %q", got)
+	}
+}

--- a/agent/sanity_test.go
+++ b/agent/sanity_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestModuleWiring guards the sub-module seam itself: it fails if the replace
 // directive or go.sum drifts out of sync with the root module (the documented
-// failure mode for mcpkit sub-modules). The JSON round-trip also anchors
-// constraint A2 until the Runner event taxonomy lands and carries it properly.
+// failure mode for mcpkit sub-modules). Constraint A2 is carried by the event
+// and delta round-trip tests in runner_test.go and provider_test.go.
 func TestModuleWiring(t *testing.T) {
 	res := core.ToolResult{Content: []core.Content{{Type: "text", Text: "ok"}}}
 

--- a/docs/AGENT_DESIGN.md
+++ b/docs/AGENT_DESIGN.md
@@ -27,24 +27,32 @@ Dependency rule: `agent/` depends on `core/` and `client/` (and may depend on ot
 ### Provider
 
 ```go
-// Sketch, finalized in the provider ticket (issue 884).
+// As built (issue 884).
 type Provider interface {
-    // Stream runs one model call. Deltas arrive on the returned stream:
-    // text, reasoning, tool-call start/args/end, finish, usage.
-    Stream(ctx context.Context, req Request) (Stream, error)
-    // Generate is the non-streaming call used for utility work
-    // (structured output, naming, summaries).
-    Generate(ctx context.Context, req Request) (Response, error)
+    // Stream runs one model call. Deltas: text, reasoning, tool-call
+    // start/args (no end marker; the Accumulator folds), finish, usage.
+    Stream(ctx context.Context, req ProviderRequest) (Stream, error)
+    // Generate is the non-streaming call used for utility work; with
+    // ProviderRequest.ResponseSchema set it requests structured output.
+    Generate(ctx context.Context, req ProviderRequest) (*ProviderResponse, error)
 }
 ```
 
-One production implementation ships first: OpenAI-compatible chat completions, which covers lmstudio, vllm, LiteLLM-style proxies, and gateways. A `StubProvider` plays back scripted turns for deterministic tests. Failover wraps Provider (a Provider that fronts a main and a backup) so the Runner never knows about it.
+One production implementation ships first: OpenAI-compatible chat completions, which covers lmstudio, vllm, LiteLLM-style proxies, and gateways (net/http plus servicekit's WHATWG-conformant SSE reader; no SDK dependency). A `StubProvider` plays back scripted turns for deterministic tests. Failover wraps Provider (a Provider that fronts a main and a backup) so the Runner never knows about it.
+
+**Why chat completions and not the Responses-style API**: chat completions is the lingua franca of the compat zoo (Responses support there is partial, experimental, or a translation layer), and its statelessness is architecturally load-bearing for us: the host owns conversation history (the module's whole premise), tools come from MCP rather than the model platform, and failover only works when any endpoint can accept a full request cold. The one known exception trendline is gpt-oss/harmony reasoning fidelity on vllm, where Responses is native; if that matters someday it becomes a second implementation behind the same interface.
 
 ### Runner
 
-The loop: given (instructions, Provider, ToolSource, history), call the model, dispatch tool calls (parallel where independent), append results, repeat until final text, bounded by a step cap and ctx cancellation. Tool handler errors become tool-result errors fed back to the model, not loop aborts.
+As built (issue 885):
 
-The Runner emits typed events (see Surfaces): turn-begin, thinking-begin/delta/end, text-delta, tool-begin/end/error, elicitation-request, turn-end, error.
+```go
+func (r *Runner) Run(ctx context.Context, history []Message, emit func(Event)) (*TurnResult, error)
+```
+
+The loop: stream the model, dispatch its tool calls in parallel goroutines (emission serialized, RoleTool messages appended in call order), feed results back, repeat until a no-tool-call response, bounded by MaxSteps (default 8) and ctx cancellation. Every tool failure shape (unknown tool, transport, bad args, IsError results) is fed back to the model as model-visible text, never a loop abort; only cancellation, provider failure, or the step cap end a turn early. `TurnResult.Messages` holds exactly the appended entries so callers thread history with one append.
+
+Event kinds: turn-begin, thinking-begin/-delta/-end, text-delta, tool-begin, tool-end (includes IsError results), tool-error (dispatch failures only), turn-end, error. Events carry no turn or session identity: in-process the emit closure is already turn-scoped, and wire layers wrap events in their own envelope (session id, turn id, sequence), keeping the module out of the ID-scheme business and the event stream deterministic. The elicitation-request kind joins the taxonomy with the milestone 2 elicitation seam (issue 887).
 
 ### ToolSource
 


### PR DESCRIPTION
Implements issue 885, closing milestone 1 of the agent epic (issue 895). With this, Provider + ToolSource + Runner compose into a working agent loop, fully deterministic under the StubProvider.

## What changes

The core loop and the surfaces contract. `Run(ctx, history, emit)` streams the model, dispatches its tool calls in parallel, feeds results back, and repeats until the model answers in text. The emitted `Event` stream (turn-begin, thinking markers, text deltas, tool lifecycle, turn-end, error) is the contract every surface (CLI, web, native) consumes, JSON-serializable end to end.

## Reviewer's guide

Read in this order:
1. [agent/events.go](https://github.com/panyam/mcpkit/pull/900/files#diff-decf072b43cd6fba38445f5ab18d681fd6e933ca6b9e6bdf51d6bd95ac2977b7) — the taxonomy and its two deliberate absences: no turn/session identity (wire envelopes own that; keeps the stream deterministic) and no elicitation-request yet (issue 887 adds it).
2. [agent/runner.go](https://github.com/panyam/mcpkit/pull/900/files#diff-6d787b427ac08cd61669af7e34ff0b747c4264d20b31b21b681a2ec2c826d9f0) — the loop. Key contracts: every tool failure is model-visible text, never an abort; tool-error means dispatch failure while IsError results ride tool-end; RoleTool messages append in call order regardless of completion order; TurnResult.Messages enables one-append history threading.
3. [agent/runner_test.go](https://github.com/panyam/mcpkit/pull/900/files#diff-ffe83771b6f02efdc6a2e9656bb6e78ecd3a3d187223e173d416979cb429ec34) — the behavior matrix: threading, parallel rendezvous, error recovery, step cap, cancellation, thinking markers, usage aggregation, event round-trips.
4. [docs/AGENT_DESIGN.md](https://github.com/panyam/mcpkit/pull/900/files#diff-bdf045ebd871d9f6b81fe4602a8effef64194a2d15951e35ce3b0f79989db1d2) — sketches replaced with as-built signatures, plus the chat-completions-vs-Responses rationale from design review.

Skim or skip: [agent/sanity_test.go](https://github.com/panyam/mcpkit/pull/900/files#diff-4d462cd43df284d92599c42847861d26dadfd31800a1360a1c52dd8303db93f3) (comment retirement only).

## How it works (pseudocode walkthrough)

```
Run(history, emit):
  emit turn-begin
  msgs = clone(history)
  for step in 1..MaxSteps:
    tools = Tools.Tools()            # re-listed per step; memoized MultiSource makes this cheap
    resp  = fold(Provider.Stream({instructions, msgs, tools}))
            # while folding: reasoning deltas wrapped in thinking-begin/end, text-delta passthrough
    append assistant(resp.text, resp.toolCalls) to msgs
    if no toolCalls: emit turn-end; return TurnResult
    parallel for each call:          # emission mutex-serialized
      emit tool-begin
      ok  -> emit tool-end;   text = flatten(result)   ("tool reported an error: ..." when IsError)
      err -> emit tool-error; text = "tool call failed: ..."
    append RoleTool messages in CALL order (not completion order)
  emit error; return ErrMaxSteps
```

The subtle bit a reviewer would pause on: dispatch failures deliberately continue the loop. The model can self-correct a hallucinated tool name or malformed args, and MaxSteps bounds the damage; only cancellation, provider failure, or the cap abort a turn.

## Decision log

- **No turn IDs in events**: in-process, the emit closure is already turn-scoped; on the wire, identity belongs to the session envelope (sessionId/turnId/seq wrapping the event), exactly how the prior internal system's wire layer worked. Also keeps the Runner free of randomness, so stub tests compare exact event sequences. Identity is additive later; removing it wouldn't be.
- **emit callback over a channel**: synchronous, never called concurrently (documented), trivially bridged to any transport by the caller.
- **Tools re-listed per step** rather than once per turn: list_changed mid-turn becomes visible, and the memoized MultiSource makes it a map read. The client-side notification hook for MultiSource.Invalidate does not exist yet; follow-up issue filed.
- **MaxSteps default 8** (vs the client's MRTR default of 16): a step here is a full model call, not an input round; looping models should fail fast.

## Risk / blast radius

- Affects: only the `agent/` sub-module; no dependency changes.
- Tests covering this: 13 new test functions, ~55 assertions added, 0 removed or weakened (one comment updated in sanity_test.go, no assertion changes). Suite also run under -race for the parallel dispatch path.
- Be paranoid about: emission ordering under parallel dispatch (mutex-serialized, rendezvous-tested) and the thinking-marker state machine when reasoning interleaves with tool-call deltas.

## Before / after

Before (agent branch): Provider and ToolSource exist but nothing composes them.

After, the full loop under test:

```
$ go test ./... -count=1
ok      github.com/panyam/mcpkit/agent  0.609s
$ go test -race ./... -count=1
ok      github.com/panyam/mcpkit/agent  1.710s
```

Mutation red-checks (step cap unbounded; call-order threading reversed; both restored):

```
--- FAIL: TestRunnerStepCap
--- FAIL: TestRunnerParallelToolCallsRendezvous
```

## Out of scope (deliberately deferred)

- Elicitation seam + elicitation-request event kind → issue 887
- Task-envelope polling on ErrTaskResult → issue 890
- Trace spans around turn/step → issue 891
- client-side tools/list_changed handler for MultiSource.Invalidate → follow-up issue (filed alongside this PR)


