### PR TITLE
feat(agent): ElicitationCoordinator, one UI seam over both protocol inlets (issue 887)

### DIFF
--- a/agent/elicitation.go
+++ b/agent/elicitation.go
@@ -1,0 +1,109 @@
+package agent
+
+import (
+	"context"
+	"sync"
+
+	"github.com/panyam/mcpkit/client"
+	"github.com/panyam/mcpkit/core"
+)
+
+// ElicitationUI renders one elicitation to the user and returns their
+// answer. It is the single seam a surface implements: a terminal prompts
+// inline, a web host forwards over its wire, a test scripts responses.
+// Decline and cancel are results (ElicitationResult.Action), not errors;
+// an error means the surface itself failed to present the request.
+type ElicitationUI func(ctx context.Context, req core.ElicitationRequest) (core.ElicitationResult, error)
+
+// ElicitationCoordinator serializes elicitations from every connected server
+// onto one ElicitationUI: exactly one request is presented at a time, waiters
+// proceed in strict FIFO order, and a waiter whose ctx ends leaves the queue
+// without disturbing it. Use one coordinator per user session so parallel
+// tool calls (or multiple servers) never stack dialogs.
+//
+// Wiring covers both protocol inlets with one registration, because the
+// client routes MRTR input_required rounds through the same dispatcher as
+// real server-initiated requests:
+//
+//	coord := agent.NewElicitationCoordinator(ui)
+//	c := client.NewClient(url, info,
+//	    client.WithElicitationHandler(coord.Handler()))
+//	src := agent.NewClientSource(c,
+//	    agent.WithInputHandler(client.DefaultInputHandler(c)))
+//
+// With that, a legacy-wire server pushing elicitation/create and a
+// stateless-wire (or task) server returning input_required both land on the
+// same UI, serialized.
+type ElicitationCoordinator struct {
+	ui ElicitationUI
+
+	mu      sync.Mutex
+	busy    bool
+	waiters []chan struct{}
+}
+
+// NewElicitationCoordinator wraps ui with FIFO serialization.
+func NewElicitationCoordinator(ui ElicitationUI) *ElicitationCoordinator {
+	return &ElicitationCoordinator{ui: ui}
+}
+
+// Handler adapts the coordinator to the client's elicitation option. Register
+// it on every client whose servers may elicit.
+func (c *ElicitationCoordinator) Handler() client.ElicitationHandler {
+	return c.present
+}
+
+func (c *ElicitationCoordinator) present(ctx context.Context, req core.ElicitationRequest) (core.ElicitationResult, error) {
+	if err := c.acquire(ctx); err != nil {
+		return core.ElicitationResult{}, err
+	}
+	defer c.release()
+	return c.ui(ctx, req)
+}
+
+func (c *ElicitationCoordinator) acquire(ctx context.Context) error {
+	c.mu.Lock()
+	if !c.busy {
+		c.busy = true
+		c.mu.Unlock()
+		return nil
+	}
+	turn := make(chan struct{})
+	c.waiters = append(c.waiters, turn)
+	c.mu.Unlock()
+
+	select {
+	case <-turn:
+		return nil
+	case <-ctx.Done():
+		c.mu.Lock()
+		for i, w := range c.waiters {
+			if w == turn {
+				c.waiters = append(c.waiters[:i], c.waiters[i+1:]...)
+				c.mu.Unlock()
+				return ctx.Err()
+			}
+		}
+		// The baton was already handed to us; pass it on so the queue
+		// does not stall.
+		c.releaseLocked()
+		c.mu.Unlock()
+		return ctx.Err()
+	}
+}
+
+func (c *ElicitationCoordinator) release() {
+	c.mu.Lock()
+	c.releaseLocked()
+	c.mu.Unlock()
+}
+
+func (c *ElicitationCoordinator) releaseLocked() {
+	if len(c.waiters) > 0 {
+		next := c.waiters[0]
+		c.waiters = c.waiters[1:]
+		close(next)
+		return
+	}
+	c.busy = false
+}

--- a/agent/elicitation_test.go
+++ b/agent/elicitation_test.go
@@ -1,0 +1,290 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/panyam/mcpkit/client"
+	"github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/server"
+)
+
+func startServer(t *testing.T, srv *server.Server) *httptest.Server {
+	t.Helper()
+	ts := httptest.NewServer(srv.Handler(server.WithStreamableHTTP(true)))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func connectClient(t *testing.T, url string, opts ...client.ClientOption) *client.Client {
+	t.Helper()
+	c := client.NewClient(url+"/mcp", core.ClientInfo{Name: "agent-elicit-test", Version: "1.0"}, opts...)
+	if err := c.Connect(); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+	return c
+}
+
+func legacyElicitServer(t *testing.T) *server.Server {
+	t.Helper()
+	srv := server.NewServer(core.ServerInfo{Name: "legacy-elicit", Version: "0.0.1"})
+	srv.RegisterTool(
+		core.ToolDef{Name: "ask_name", Description: "asks for a name", InputSchema: map[string]any{"type": "object"}},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+			res, err := core.Elicit(ctx, core.ElicitationRequest{
+				Message:         "What is your name?",
+				RequestedSchema: json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}`),
+			})
+			if err != nil {
+				return core.ErrorResult("elicit failed: " + err.Error()), nil
+			}
+			if res.Action != "accept" {
+				return core.TextResult("user " + res.Action + "ed"), nil
+			}
+			name, _ := res.Content["name"].(string)
+			return core.TextResult("Hello, " + name + "!"), nil
+		},
+	)
+	return srv
+}
+
+func mrtrElicitServer(t *testing.T) *server.Server {
+	t.Helper()
+	srv := server.NewServer(core.ServerInfo{Name: "mrtr-elicit", Version: "0.0.1"})
+	srv.RegisterTool(
+		core.ToolDef{Name: "ask_name", Description: "asks for a name", InputSchema: map[string]any{"type": "object"}},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+			if !ctx.HasInputResponses() {
+				return ctx.RequestInput(core.InputRequests{
+					"user_name": core.NewElicitationInputRequest(core.ElicitationRequest{
+						Message:         "What is your name?",
+						RequestedSchema: json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}`),
+					}),
+				})
+			}
+			var er struct {
+				Action  string `json:"action"`
+				Content struct {
+					Name string `json:"name"`
+				} `json:"content"`
+			}
+			if err := json.Unmarshal(ctx.InputResponse("user_name"), &er); err != nil {
+				return core.ErrorResult("malformed elicitation response"), nil
+			}
+			return core.TextResult("Hello, " + er.Content.Name + "!"), nil
+		},
+	)
+	return srv
+}
+
+func acceptName(name string) ElicitationUI {
+	return func(ctx context.Context, req core.ElicitationRequest) (core.ElicitationResult, error) {
+		return core.ElicitationResult{Action: "accept", Content: map[string]any{"name": name}}, nil
+	}
+}
+
+func TestCoordinatorLegacyInlet(t *testing.T) {
+	var calls atomic.Int32
+	var seen core.ElicitationRequest
+	coord := NewElicitationCoordinator(func(ctx context.Context, req core.ElicitationRequest) (core.ElicitationResult, error) {
+		calls.Add(1)
+		seen = req
+		return acceptName("Alice")(ctx, req)
+	})
+
+	ts := startServer(t, legacyElicitServer(t))
+	c := connectClient(t, ts.URL, client.WithElicitationHandler(coord.Handler()))
+	src := NewClientSource(c)
+
+	res, err := src.Call(context.Background(), "ask_name", map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError || !strings.Contains(res.Content[0].Text, "Hello, Alice!") {
+		t.Fatalf("result = %+v", res)
+	}
+	if calls.Load() != 1 || seen.Message != "What is your name?" {
+		t.Fatalf("UI invocations = %d, seen = %+v", calls.Load(), seen)
+	}
+}
+
+func TestCoordinatorMRTRInlet(t *testing.T) {
+	var calls atomic.Int32
+	coord := NewElicitationCoordinator(func(ctx context.Context, req core.ElicitationRequest) (core.ElicitationResult, error) {
+		calls.Add(1)
+		return acceptName("Bob")(ctx, req)
+	})
+
+	ts := startServer(t, mrtrElicitServer(t))
+	c := connectClient(t, ts.URL, client.WithElicitationHandler(coord.Handler()))
+	src := NewClientSource(c, WithInputHandler(client.DefaultInputHandler(c)))
+
+	res, err := src.Call(context.Background(), "ask_name", map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError || !strings.Contains(res.Content[0].Text, "Hello, Bob!") {
+		t.Fatalf("result = %+v", res)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("UI invocations = %d", calls.Load())
+	}
+}
+
+func TestCoordinatorMRTRWithoutHandlerStillFailsFast(t *testing.T) {
+	ts := startServer(t, mrtrElicitServer(t))
+	c := connectClient(t, ts.URL)
+	src := NewClientSource(c)
+
+	_, err := src.Call(context.Background(), "ask_name", map[string]any{})
+	if !errors.Is(err, ErrInputRequired) {
+		t.Fatalf("want ErrInputRequired without a coordinator, got %v", err)
+	}
+}
+
+func TestCoordinatorDeclinePropagates(t *testing.T) {
+	coord := NewElicitationCoordinator(func(ctx context.Context, req core.ElicitationRequest) (core.ElicitationResult, error) {
+		return core.ElicitationResult{Action: "decline"}, nil
+	})
+	ts := startServer(t, legacyElicitServer(t))
+	c := connectClient(t, ts.URL, client.WithElicitationHandler(coord.Handler()))
+	src := NewClientSource(c)
+
+	res, err := src.Call(context.Background(), "ask_name", map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(res.Content[0].Text, "user declineed") {
+		t.Fatalf("decline must reach the tool as a result, got %+v", res)
+	}
+}
+
+func TestCoordinatorFIFOSerialization(t *testing.T) {
+	var active atomic.Int32
+	var order []string
+	firstEntered := make(chan struct{})
+	releaseFirst := make(chan struct{})
+
+	coord := NewElicitationCoordinator(func(ctx context.Context, req core.ElicitationRequest) (core.ElicitationResult, error) {
+		if active.Add(1) != 1 {
+			t.Error("overlapping elicitations")
+		}
+		if req.Message == "first" {
+			close(firstEntered)
+			<-releaseFirst
+		}
+		order = append(order, req.Message)
+		active.Add(-1)
+		return core.ElicitationResult{Action: "accept"}, nil
+	})
+
+	done := make(chan string, 3)
+	submit := func(msg string) {
+		go func() {
+			coord.present(context.Background(), core.ElicitationRequest{Message: msg})
+			done <- msg
+		}()
+	}
+
+	submit("first")
+	<-firstEntered
+	submit("second")
+	time.Sleep(30 * time.Millisecond)
+	submit("third")
+	time.Sleep(30 * time.Millisecond)
+	close(releaseFirst)
+
+	for i := 0; i < 3; i++ {
+		select {
+		case <-done:
+		case <-time.After(3 * time.Second):
+			t.Fatal("serialization deadlock")
+		}
+	}
+	if fmt.Sprint(order) != "[first second third]" {
+		t.Fatalf("FIFO order violated: %v", order)
+	}
+}
+
+func TestCoordinatorQueuedWaiterCancels(t *testing.T) {
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	coord := NewElicitationCoordinator(func(ctx context.Context, req core.ElicitationRequest) (core.ElicitationResult, error) {
+		if req.Message == "blocker" {
+			close(entered)
+			<-release
+		}
+		return core.ElicitationResult{Action: "accept"}, nil
+	})
+
+	go coord.present(context.Background(), core.ElicitationRequest{Message: "blocker"})
+	<-entered
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := coord.present(ctx, core.ElicitationRequest{Message: "queued"})
+		errCh <- err
+	}()
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	if err := <-errCh; !errors.Is(err, context.Canceled) {
+		t.Fatalf("queued waiter must observe cancellation, got %v", err)
+	}
+
+	close(release)
+	res, err := coord.present(context.Background(), core.ElicitationRequest{Message: "after"})
+	if err != nil || res.Action != "accept" {
+		t.Fatalf("queue must survive a cancelled waiter: %v %v", res, err)
+	}
+}
+
+func TestCoordinatorURLModePassthrough(t *testing.T) {
+	var seen core.ElicitationRequest
+	coord := NewElicitationCoordinator(func(ctx context.Context, req core.ElicitationRequest) (core.ElicitationResult, error) {
+		seen = req
+		return core.ElicitationResult{Action: "accept"}, nil
+	})
+
+	srv := server.NewServer(core.ServerInfo{Name: "url-elicit", Version: "0.0.1"})
+	srv.RegisterTool(
+		core.ToolDef{Name: "ask_url", Description: "url-mode elicit", InputSchema: map[string]any{"type": "object"}},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+			res, err := core.ElicitURL(ctx, core.ElicitationRequest{
+				Message:       "Complete sign-in in your browser",
+				Mode:          "url",
+				URL:           "https://example.test/signin",
+				ElicitationID: "e-1",
+			})
+			if err != nil {
+				return core.ErrorResult("elicit failed: " + err.Error()), nil
+			}
+			return core.TextResult("action=" + res.Action), nil
+		},
+	)
+	ts := startServer(t, srv)
+	c := connectClient(t, ts.URL,
+		client.WithElicitationHandler(coord.Handler()),
+		client.WithElicitationURLSupport(),
+	)
+	src := NewClientSource(c)
+
+	res, err := src.Call(context.Background(), "ask_url", map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(res.Content[0].Text, "action=accept") {
+		t.Fatalf("result = %+v", res)
+	}
+	if seen.Mode != "url" || seen.URL != "https://example.test/signin" || seen.ElicitationID != "e-1" {
+		t.Fatalf("url-mode request must reach the UI unmodified: %+v", seen)
+	}
+}

--- a/client/mrtr.go
+++ b/client/mrtr.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 
 	"github.com/panyam/mcpkit/core"
 )
@@ -168,8 +169,18 @@ func CallToolWithInputs(ctx context.Context, c *Client, name string, args any, h
 // in tests).
 func DefaultInputHandler(c *Client) InputHandler {
 	return func(ctx context.Context, reqs core.InputRequests) (core.InputResponses, error) {
+		// The SEP-2322 wire carries inputRequests as an unordered map, so
+		// there is no server-defined sequence to honor. Dispatch in sorted
+		// key order so multi-entry rounds present to the user (and to
+		// tests) deterministically instead of in Go map-iteration order.
+		keys := make([]string, 0, len(reqs))
+		for key := range reqs {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
 		out := make(core.InputResponses, len(reqs))
-		for key, req := range reqs {
+		for _, key := range keys {
+			req := reqs[key]
 			payload, err := dispatchMRTRInputRequest(ctx, c, req)
 			if err != nil {
 				return nil, fmt.Errorf("inputRequest %q (%s): %w", key, req.Method, err)

--- a/client/mrtr_test.go
+++ b/client/mrtr_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http/httptest"
 	"strings"
 	"sync"
@@ -460,4 +461,34 @@ func configureMiddleware(srv *server.Server, mw server.Middleware) *server.Serve
 	// post-construction. Verify that API exists.
 	srv.UseMiddleware(mw)
 	return srv
+}
+
+// TestDefaultInputHandler_DeterministicOrder pins sorted-key dispatch: the
+// SEP-2322 wire is an unordered map, so without an explicit sort a
+// multi-entry round presents in Go map-iteration order (different every run).
+func TestDefaultInputHandler_DeterministicOrder(t *testing.T) {
+	var presented []string
+	c, _ := connectMRTRClient(t, mrtrTestServer(t),
+		client.WithElicitationHandler(func(ctx context.Context, req core.ElicitationRequest) (core.ElicitationResult, error) {
+			presented = append(presented, req.Message)
+			return core.ElicitationResult{Action: "accept", Content: map[string]any{"name": "x"}}, nil
+		}),
+	)
+
+	reqs := core.InputRequests{}
+	keys := []string{"h", "c", "f", "a", "e", "b", "g", "d"}
+	for _, k := range keys {
+		reqs[k] = core.InputRequest{
+			Method: "elicitation/create",
+			Params: json.RawMessage(`{"message":"` + k + `"}`),
+		}
+	}
+
+	if _, err := client.DefaultInputHandler(c)(context.Background(), reqs); err != nil {
+		t.Fatal(err)
+	}
+	want := "[a b c d e f g h]"
+	if got := fmt.Sprint(presented); got != want {
+		t.Fatalf("dispatch order = %v, want %v", got, want)
+	}
 }

--- a/docs/AGENT_DESIGN.md
+++ b/docs/AGENT_DESIGN.md
@@ -52,7 +52,7 @@ func (r *Runner) Run(ctx context.Context, history []Message, emit func(Event)) (
 
 The loop: stream the model, dispatch its tool calls in parallel goroutines (emission serialized, RoleTool messages appended in call order), feed results back, repeat until a no-tool-call response, bounded by MaxSteps (default 8) and ctx cancellation. Every tool failure shape (unknown tool, transport, bad args, IsError results) is fed back to the model as model-visible text, never a loop abort; only cancellation, provider failure, or the step cap end a turn early. `TurnResult.Messages` holds exactly the appended entries so callers thread history with one append.
 
-Event kinds: turn-begin, thinking-begin/-delta/-end, text-delta, tool-begin, tool-end (includes IsError results), tool-error (dispatch failures only), turn-end, error. Events carry no turn or session identity: in-process the emit closure is already turn-scoped, and wire layers wrap events in their own envelope (session id, turn id, sequence), keeping the module out of the ID-scheme business and the event stream deterministic. The elicitation-request kind joins the taxonomy with the milestone 2 elicitation seam (issue 887).
+Event kinds: turn-begin, thinking-begin/-delta/-end, text-delta, tool-begin, tool-end (includes IsError results), tool-error (dispatch failures only), turn-end, error. Events carry no turn or session identity: in-process the emit closure is already turn-scoped, and wire layers wrap events in their own envelope (session id, turn id, sequence), keeping the module out of the ID-scheme business and the event stream deterministic. Elicitation deliberately does NOT appear in the taxonomy: the event stream is one-way, and elicitation is request/response. It rides the ElicitationUI callback seam (see Elicitation below); wire surfaces project that seam with their own request/response framing rather than faking it over events plus correlation IDs.
 
 ### ToolSource
 
@@ -89,6 +89,18 @@ Two rules keep that projection one-to-one:
 
 1. **Every Runner event type is wire-serializable from day one.** JSON tags, a stable `kind` discriminator, no Go-only payloads (channels, funcs, interfaces without concrete marshaling) in event fields. Enforced by a round-trip test (see `agent/CONSTRAINTS.md`).
 2. **The wire layer stays out of the module until it has two consumers.** The first web host builds the WebSocket mapping in its own package; when a second application needs it, the mapping is promoted into `agent/` (or a sibling package) as-is. This mirrors how the fire-and-forget-then-subscribe chat shape should work: submit returns an id immediately, the event stream carries the turn.
+
+## Elicitation: one UI seam, two protocol inlets
+
+A surface implements exactly one callback:
+
+```go
+type ElicitationUI func(ctx context.Context, req core.ElicitationRequest) (core.ElicitationResult, error)
+```
+
+`ElicitationCoordinator` wraps it with strict-FIFO serialization (one request presented at a time per user session, so parallel tool calls and multiple servers never stack dialogs; a waiter whose ctx ends leaves the queue cleanly). Registration is a single point because the client already unifies the wires: `client.WithElicitationHandler(coord.Handler())` covers legacy-wire server-initiated elicitation, and `client.DefaultInputHandler(c)` (as the ClientSource input handler) routes stateless-wire and task input_required rounds through the same registered handler.
+
+Consequence: **the agent does not care whether a server is stateful, stateless, or legacy.** Wire differences are absorbed at the client layer; per-server wire mode (client.WithClientMode) is host configuration, not agent code. Decline and cancel are results, not errors. URL-mode requests pass through the same UI when the client opts in via WithElicitationURLSupport.
 
 ## Vendor `_meta` prefix
 


### PR DESCRIPTION
Implements issue 887, opening milestone 2 of the agent epic (issue 895).

## What changes

Surfaces get exactly one callback to implement for user-input requests, regardless of how the server asks. `ElicitationUI` renders a request and returns the user's answer; `ElicitationCoordinator` serializes presentations (strict FIFO, one dialog at a time per session) and adapts onto the client. Because the client already routes MRTR input_required rounds through the same dispatcher as real server-initiated requests, one registration covers a legacy-wire server pushing elicitation/create, a stateless-wire server returning input_required, and (later) task input pauses — the agent is wire-mode agnostic by construction.

## Reviewer's guide

Read in this order:
1. [agent/elicitation.go](https://github.com/panyam/mcpkit/pull/903/files#diff-2d804aa4234f872c7df3e37d37027a7b9966b60f48c37986a311e040e8cf19e7) — the seam, the FIFO queue with ctx-aware waiters (note the baton-pass when a cancelled waiter was already signaled), and the two-inlet wiring recipe in the type doc.
2. [agent/elicitation_test.go](https://github.com/panyam/mcpkit/pull/903/files#diff-8a9b40268ec3e8afd62690ead7c75af9274c8c0b0174384999033f0610ed1bd7) — both inlets driven against real in-process servers: core.Elicit push (legacy) and ctx.RequestInput MRTR; plus FIFO order, overlap detection, queued-waiter cancellation, decline propagation, URL-mode passthrough.
3. [docs/AGENT_DESIGN.md](https://github.com/panyam/mcpkit/pull/903/files#diff-bdf045ebd871d9f6b81fe4602a8effef64194a2d15951e35ce3b0f79989db1d2) — new Elicitation section; retracts the previously planned elicitation event kind.

## Decision log

- **Root-module rider (client/mrtr.go)**: DefaultInputHandler now dispatches multi-entry InputRequests rounds in sorted key order. The SEP-2322 wire is an unordered map, so presentation order was Go map-iteration randomness; four elicitations in one round appeared in a different order every run. Sorted keys make it deterministic (the wire defines no sequence for a server to express; servers needing strict ordering should use one request per round). Behaviorally red-checked with a reverse-sort mutation.

- **No elicitation event kind** (corrects the design doc): the event stream is one-way; elicitation is request/response. Faking it over events plus correlation IDs is precisely the machinery this project replaces. Wire surfaces project the callback seam with their own request/response framing.
- **No bespoke MRTR adapter on the coordinator**: the plan had the coordinator decoding InputRequests itself; reading the client showed client.DefaultInputHandler already synthesizes input requests through HandleServerRequestWithContext, giving URL-mode gating and middleware uniformity for free. Reuse won; the coordinator only implements Handler().
- **Strict FIFO via an explicit waiter queue** rather than a mutex: fairness is part of the acceptance criteria, and Go mutexes only approximate it. A cancelled waiter that already received the baton passes it on, so the queue never stalls (tested).
- **Decline/cancel are results, not errors**: an ElicitationUI error means the surface failed to present, nothing else.

## Risk / blast radius

- Affects: the `agent/` sub-module plus one root-module fix (client DefaultInputHandler ordering) that rides this branch into the eventual agent-to-main merge.
- Tests covering this: 8 new test functions (7 agent + 1 client), ~28 assertions added, 0 removed or weakened. Suite run under -race (the FIFO and cancellation paths are concurrency-heavy).
- Be paranoid about: the acquire/cancel race (waiter signaled and cancelled simultaneously) — the baton-pass branch in acquire is the subtle line; TestCoordinatorQueuedWaiterCancels covers the surviving-queue property.

## Before / after

Before (agent branch): a server that elicits mid-tool-call fails with ErrInputRequired (ClientSource's fail-fast default).

After, both inlets against real servers:

```
$ go test -run TestCoordinator -count=1 ./...
ok      github.com/panyam/mcpkit/agent  1.055s
$ go test -race ./... -count=1
ok      github.com/panyam/mcpkit/agent  2.087s
```

Mutation red-check (FIFO handoff flipped to LIFO, then restored):

```
--- FAIL: TestCoordinatorFIFOSerialization
FAIL    github.com/panyam/mcpkit/agent  0.877s
```

## Out of scope (deliberately deferred)

- Terminal renderers for form/enum/confirm shapes → issue 888 (agentchat implements ElicitationUI)
- Task input_required pauses through this seam → issue 890
- Tool routing/selection → issue 902 (filed from PR 900 review feedback)
