### PR TITLE
feat(agent,client): tool-list lifecycle + context-aware routing (issues 901, 902)

### DIFF
--- a/agent/filter_source.go
+++ b/agent/filter_source.go
@@ -1,0 +1,55 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+// FilterSource wraps a ToolSource with a static allow/deny predicate: the
+// per-profile allowlist shape. Filtered tools disappear from both listing and
+// calling (a Call to a filtered name fails with ErrUnknownTool via the
+// listing check), so a filter is a real capability boundary, not a
+// presentation hint. For context-dependent narrowing use RunnerConfig.
+// Selector instead; FilterSource is for policy that never varies by
+// conversation.
+type FilterSource struct {
+	src  ToolSource
+	keep func(core.ToolDef) bool
+}
+
+// NewFilterSource wraps src, keeping only tools for which keep returns true.
+func NewFilterSource(src ToolSource, keep func(core.ToolDef) bool) *FilterSource {
+	return &FilterSource{src: src, keep: keep}
+}
+
+// Tools lists the underlying source minus filtered entries.
+func (f *FilterSource) Tools(ctx context.Context) ([]core.ToolDef, error) {
+	defs, err := f.src.Tools(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]core.ToolDef, 0, len(defs))
+	for _, d := range defs {
+		if f.keep(d) {
+			out = append(out, d)
+		}
+	}
+	return out, nil
+}
+
+// Call dispatches to the underlying source only when the name survives the
+// filter, so filtered tools cannot be invoked by guessing names.
+func (f *FilterSource) Call(ctx context.Context, name string, args map[string]any) (*core.ToolResult, error) {
+	defs, err := f.Tools(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, d := range defs {
+		if d.Name == name {
+			return f.src.Call(ctx, name, args)
+		}
+	}
+	return nil, fmt.Errorf("%w: %q (filtered)", ErrUnknownTool, name)
+}

--- a/agent/routing_test.go
+++ b/agent/routing_test.go
@@ -1,0 +1,183 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/panyam/mcpkit/client"
+	"github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/server"
+	"github.com/panyam/mcpkit/testutil"
+)
+
+func TestSelectorNarrowsOfferedTools(t *testing.T) {
+	src := NewFuncSource()
+	AddFunc(src, "relevant", "", func(ctx context.Context, _ struct{}) (string, error) { return "ok", nil })
+	AddFunc(src, "irrelevant", "", func(ctx context.Context, _ struct{}) (string, error) { return "no", nil })
+
+	stub := NewStubProvider(StubTurn{Text: "done"})
+	r, err := NewRunner(RunnerConfig{
+		Provider: stub,
+		Tools:    src,
+		Selector: func(ctx context.Context, history []Message, tools []core.ToolDef) ([]core.ToolDef, error) {
+			var out []core.ToolDef
+			for _, td := range tools {
+				if strings.Contains(history[len(history)-1].Text, td.Name) {
+					out = append(out, td)
+				}
+			}
+			return out, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Run(context.Background(), []Message{{Role: RoleUser, Text: "use the relevant tool"}}, nil); err != nil {
+		t.Fatal(err)
+	}
+	offered := stub.Requests()[0].Tools
+	if len(offered) != 1 || offered[0].Name != "relevant" {
+		t.Fatalf("selector must narrow by history, offered %v", toolNames(offered))
+	}
+}
+
+func TestSelectorErrorAbortsTurn(t *testing.T) {
+	src := NewFuncSource()
+	AddFunc(src, "x", "", func(ctx context.Context, _ struct{}) (string, error) { return "", nil })
+	boom := errors.New("selector broke")
+	r, _ := NewRunner(RunnerConfig{
+		Provider: NewStubProvider(StubTurn{Text: "unreached"}),
+		Tools:    src,
+		Selector: func(ctx context.Context, h []Message, tools []core.ToolDef) ([]core.ToolDef, error) {
+			return nil, boom
+		},
+	})
+	if _, err := r.Run(context.Background(), nil, nil); !errors.Is(err, boom) {
+		t.Fatalf("want selector error to abort, got %v", err)
+	}
+}
+
+func TestSelectorSeesFreshListEachStep(t *testing.T) {
+	src := NewFuncSource()
+	AddFunc(src, "t1", "", func(ctx context.Context, _ struct{}) (string, error) {
+		AddFunc(src, "t2", "", func(ctx context.Context, _ struct{}) (string, error) { return "2", nil })
+		return "1", nil
+	})
+	var perStep [][]string
+	stub := NewStubProvider(
+		StubTurn{ToolCalls: []ToolCall{{ID: "c1", Name: "t1", Args: json.RawMessage(`{}`)}}},
+		StubTurn{Text: "done"},
+	)
+	r, _ := NewRunner(RunnerConfig{
+		Provider: stub,
+		Tools:    src,
+		Selector: func(ctx context.Context, h []Message, tools []core.ToolDef) ([]core.ToolDef, error) {
+			perStep = append(perStep, toolNames(tools))
+			return tools, nil
+		},
+	})
+	if _, err := r.Run(context.Background(), nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	if len(perStep) != 2 || len(perStep[0]) != 1 || len(perStep[1]) != 2 {
+		t.Fatalf("selector must see the fresh list per step: %v", perStep)
+	}
+}
+
+func TestFilterSourceIsACapabilityBoundary(t *testing.T) {
+	src := NewFuncSource()
+	AddFunc(src, "allowed", "", func(ctx context.Context, _ struct{}) (string, error) { return "ok", nil })
+	AddFunc(src, "blocked", "", func(ctx context.Context, _ struct{}) (string, error) { return "secret", nil })
+
+	f := NewFilterSource(src, func(d core.ToolDef) bool { return d.Name != "blocked" })
+
+	tools, err := f.Tools(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fmt.Sprint(toolNames(tools)) != "[allowed]" {
+		t.Fatalf("tools = %v", toolNames(tools))
+	}
+	if _, err := f.Call(context.Background(), "allowed", map[string]any{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Call(context.Background(), "blocked", map[string]any{}); !errors.Is(err, ErrUnknownTool) {
+		t.Fatalf("filtered tool must not be callable by name-guessing, got %v", err)
+	}
+}
+
+func TestFilterSourceComposesUnderMultiSource(t *testing.T) {
+	src := NewFuncSource()
+	AddFunc(src, "a", "", func(ctx context.Context, _ struct{}) (string, error) { return "", nil })
+	AddFunc(src, "b", "", func(ctx context.Context, _ struct{}) (string, error) { return "", nil })
+	m := NewMultiSource()
+	m.Add("f", NewFilterSource(src, func(d core.ToolDef) bool { return d.Name == "a" }))
+	tools, err := m.Tools(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fmt.Sprint(toolNames(tools)) != "[a]" {
+		t.Fatalf("tools = %v", toolNames(tools))
+	}
+}
+
+func TestListChangedInvalidatesMultiSourceIndex(t *testing.T) {
+	srv := testutil.NewTestServer()
+	ts := httptest.NewServer(srv.Handler(server.WithStreamableHTTP(true)))
+	t.Cleanup(ts.Close)
+
+	m := NewMultiSource()
+	var fired atomic.Int32
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "inv-test", Version: "1.0"},
+		client.WithGetSSEStream(),
+		client.WithToolsListChangedHandler(func() {
+			fired.Add(1)
+			m.Invalidate()
+		}),
+	)
+	if err := c.Connect(); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+	if err := m.Add("srv", NewClientSource(c)); err != nil {
+		t.Fatal(err)
+	}
+
+	before, err := m.Tools(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if containsTool(before, "runtime_tool") {
+		t.Fatal("fixture assumption broken")
+	}
+
+	srv.RegisterTool(
+		core.ToolDef{Name: "runtime_tool", Description: "added later", InputSchema: map[string]any{"type": "object"}},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+			return core.TextResult("rt"), nil
+		},
+	)
+
+	deadline := time.Now().Add(3 * time.Second)
+	for fired.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(20 * time.Millisecond)
+	}
+	if fired.Load() == 0 {
+		t.Fatal("list_changed never reached the handler")
+	}
+
+	after, err := m.Tools(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !containsTool(after, "runtime_tool") {
+		t.Fatalf("Tools() must reflect the new tool after Invalidate (no Call-miss needed), got %v", toolNames(after))
+	}
+}

--- a/agent/runner.go
+++ b/agent/runner.go
@@ -36,7 +36,23 @@ type RunnerConfig struct {
 
 	// MaxSteps caps model calls per turn. Zero means DefaultMaxSteps.
 	MaxSteps int
+
+	// Selector, when non-nil, narrows the tools offered to the model each
+	// step. It runs on the freshly listed set with the full history, so
+	// context-aware routing (keyword, embedding, scored) plugs in here.
+	// Selectors must stay pure functions of (history, tools): any cache a
+	// selector keeps should key on tool-list content, never on time or
+	// notifications, so list-changed invalidation has exactly one source
+	// (the ToolSource layer). A selector error aborts the turn: it is a
+	// host configuration bug, not something the model can recover from.
+	Selector ToolSelector
 }
+
+// ToolSelector narrows the model-facing tool set for one step. Returning the
+// input slice unchanged (or nil selector) offers everything; returning an
+// empty slice offers no tools for that step. Names must be preserved
+// verbatim: Call routing still resolves against the underlying ToolSource.
+type ToolSelector func(ctx context.Context, history []Message, tools []core.ToolDef) ([]core.ToolDef, error)
 
 // Runner executes turns: the multi-step loop that streams the model,
 // dispatches its tool calls, feeds results back, and repeats until the model
@@ -90,6 +106,11 @@ func (r *Runner) Run(ctx context.Context, history []Message, emit func(Event)) (
 			var err error
 			if tools, err = r.cfg.Tools.Tools(ctx); err != nil {
 				return nil, r.fail(emit, fmt.Errorf("agent: listing tools: %w", err))
+			}
+			if r.cfg.Selector != nil {
+				if tools, err = r.cfg.Selector(ctx, msgs, tools); err != nil {
+					return nil, r.fail(emit, fmt.Errorf("agent: tool selector: %w", err))
+				}
 			}
 		}
 

--- a/client/client.go
+++ b/client/client.go
@@ -141,6 +141,17 @@ func WithNotificationCallback(fn func(method string, params any)) ClientOption {
 	return func(c *Client) { c.onNotify = fn }
 }
 
+// WithToolsListChangedHandler sets a dedicated callback for
+// notifications/tools/list_changed. Exists so cache-invalidation plumbing
+// (e.g. dropping a memoized tool index when the server registers or removes
+// tools at runtime) composes with, rather than consumes, the single generic
+// WithNotificationCallback: the notification is still delivered to the
+// generic callback afterward. The callback carries no payload because the
+// notification has none; re-list to observe the change.
+func WithToolsListChangedHandler(fn func()) ClientOption {
+	return func(c *Client) { c.toolsListChangedHandler = fn }
+}
+
 // WithGetSSEStream enables a background GET SSE stream on the Streamable HTTP
 // endpoint after Connect(). The stream receives server-initiated notifications
 // (list-changed, log messages, resource updates) that arrive outside POST
@@ -428,6 +439,10 @@ type Client struct {
 
 	// onContentChunk is an optional callback for streaming tool content chunks.
 	onContentChunk func(chunk core.ContentChunk)
+
+	// toolsListChangedHandler is an optional dedicated callback for
+	// notifications/tools/list_changed (see WithToolsListChangedHandler).
+	toolsListChangedHandler func()
 
 	// lastEventID tracks the most recent SSE event ID received from the server.
 	// Used to send Last-Event-ID header on reconnection for stream resumption.
@@ -840,7 +855,7 @@ func (c *Client) unwrapStreamableTransport() *streamableClientTransport {
 
 // needsNotifyAdapter returns true if any notification-intercepting handler is set.
 func (c *Client) needsNotifyAdapter() bool {
-	return c.onNotify != nil || c.onContentChunk != nil || c.elicitationCompleteHandler != nil
+	return c.onNotify != nil || c.onContentChunk != nil || c.elicitationCompleteHandler != nil || c.toolsListChangedHandler != nil
 }
 
 // makeNotifyAdapter creates a transport-level notification handler that
@@ -856,6 +871,11 @@ func (c *Client) makeNotifyAdapter() func(string, json.RawMessage) {
 				c.onContentChunk(chunk)
 				return // Don't also deliver to generic onNotify
 			}
+		}
+		// Intercept tools/list_changed for the dedicated handler.
+		if c.toolsListChangedHandler != nil && method == "notifications/tools/list_changed" {
+			c.toolsListChangedHandler()
+			// Still deliver to generic onNotify below.
 		}
 		// Intercept elicitation complete notifications (SEP-1036).
 		if c.elicitationCompleteHandler != nil && method == "notifications/elicitation/complete" {

--- a/client/list_changed_test.go
+++ b/client/list_changed_test.go
@@ -1,0 +1,95 @@
+package client_test
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/panyam/mcpkit/client"
+	core "github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/server"
+	"github.com/panyam/mcpkit/testutil"
+)
+
+// TestWithToolsListChangedHandler_DynamicRegistration proves the full chain:
+// runtime RegisterTool -> server broadcast -> dedicated client handler, with
+// the generic notification callback still receiving the same notification
+// (composability is the point of the dedicated option).
+func TestWithToolsListChangedHandler_DynamicRegistration(t *testing.T) {
+	srv := testutil.NewTestServer()
+	ts := httptest.NewServer(srv.Handler(server.WithStreamableHTTP(true)))
+	t.Cleanup(ts.Close)
+
+	var dedicated atomic.Int32
+	var generic atomic.Int32
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "lc-test", Version: "1.0"},
+		client.WithGetSSEStream(),
+		client.WithToolsListChangedHandler(func() { dedicated.Add(1) }),
+		client.WithNotificationCallback(func(method string, _ any) {
+			if method == "notifications/tools/list_changed" {
+				generic.Add(1)
+			}
+		}),
+	)
+	if err := c.Connect(); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+
+	srv.RegisterTool(
+		core.ToolDef{Name: "late_arrival", Description: "registered at runtime", InputSchema: map[string]any{"type": "object"}},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+			return core.TextResult("late"), nil
+		},
+	)
+
+	deadline := time.Now().Add(3 * time.Second)
+	for dedicated.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(20 * time.Millisecond)
+	}
+	if dedicated.Load() == 0 {
+		t.Fatal("dedicated handler never fired after runtime registration")
+	}
+	if generic.Load() == 0 {
+		t.Fatal("generic callback must still receive the notification")
+	}
+}
+
+// TestWithoutToolsListChangedHandler_NoFire is the red half: without the
+// option nothing invokes the dedicated path (guards against accidental
+// wiring through some other channel).
+func TestWithoutToolsListChangedHandler_NoFire(t *testing.T) {
+	srv := testutil.NewTestServer()
+	ts := httptest.NewServer(srv.Handler(server.WithStreamableHTTP(true)))
+	t.Cleanup(ts.Close)
+
+	var generic atomic.Int32
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "lc-test2", Version: "1.0"},
+		client.WithGetSSEStream(),
+		client.WithNotificationCallback(func(method string, _ any) {
+			if method == "notifications/tools/list_changed" {
+				generic.Add(1)
+			}
+		}),
+	)
+	if err := c.Connect(); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+
+	srv.RegisterTool(
+		core.ToolDef{Name: "late2", Description: "", InputSchema: map[string]any{"type": "object"}},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+			return core.TextResult("x"), nil
+		},
+	)
+	deadline := time.Now().Add(3 * time.Second)
+	for generic.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(20 * time.Millisecond)
+	}
+	if generic.Load() == 0 {
+		t.Fatal(fmt.Sprint("generic callback should observe the broadcast; got none"))
+	}
+}

--- a/docs/AGENT_DESIGN.md
+++ b/docs/AGENT_DESIGN.md
@@ -66,6 +66,15 @@ type ToolSource interface {
 
 Adapters: `ClientSource` (a single `client.Client`, MRTR-aware calls with a pluggable InputHandler), `FuncSource` (host-local typed functions via `core.GenerateSchema`), and `MultiSource` (aggregation). **Decision (issue 886): lift the registry pattern, do not depend on `ext/ui`.** ServerRegistry's value is client lifecycle plus apps-bridge management; ToolSource only needs the index shape, and aggregating ToolSources is strictly more general (it composes Func, Client, and any future registry adapter). Collision semantics mirror the registry: all claimants kept, a resolver callback for ambiguous bare-name calls, and the model-facing list exposes collisions only in qualified `sourceID_name` form so every tool stays reachable without duplicate names. A thin `RegistrySource` adapter over `ext/ui` lands with the apps integration, where the dependency belongs.
 
+### Tool routing
+
+Two narrowing mechanisms with distinct roles (issues 901/902):
+
+- `FilterSource` wraps any ToolSource with a static predicate: the per-profile allowlist shape, and a real capability boundary (filtered tools are neither listed nor callable).
+- `RunnerConfig.Selector` narrows per step with full history in hand: the context-aware routing seam (keyword, embedding, scored selection plug in here). Selection is presentation to the model, not a security boundary; the underlying source still routes calls.
+
+The purity rule that keeps the lifecycle single-sourced: selectors are pure functions of (history, freshly listed tools). Invalidation has exactly one channel: notifications/tools/list_changed -> client.WithToolsListChangedHandler -> MultiSource.Invalidate, after which per-step re-listing picks up the change. A caching selector keys on tool-list content, never on time or notifications. Searchable/deferred tools (a search_tools meta-tool exposing schemas on demand) remain future work.
+
 ### Policy hooks
 
 Two seams, both no-op by default:


### PR DESCRIPTION
Implements issues 901 and 902 together, deliberately: list-changed invalidation and tool routing are one lifecycle, and designing them separately risks two invalidation mechanisms that fight.

## What changes

Runtime tool changes now propagate cleanly to the agent (server registers a tool → one notification → memoized index drops → next step offers it), and hosts get two ways to narrow what the model sees: a static capability boundary (`FilterSource`) and a per-step, history-aware selector seam on the Runner (`RunnerConfig.Selector`) — the context-aware routing hook.

## Reviewer's guide

Read in this order:
1. [agent/runner.go](https://github.com/panyam/mcpkit/pull/905/files#diff-6d787b427ac08cd61669af7e34ff0b747c4264d20b31b21b681a2ec2c826d9f0) — the ToolSelector seam and its contract (pure function of history + fresh list; errors abort the turn; selection is presentation, not security).
2. [agent/filter_source.go](https://github.com/panyam/mcpkit/pull/905/files#diff-c767fb3f36a987f4e397a5e00386414e12c69850c8e57be6af0c4cd5af9d473d) — the static boundary: filtered tools are neither listed nor callable (name-guessing fails with ErrUnknownTool).
3. [client/client.go](https://github.com/panyam/mcpkit/pull/905/files#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09) — `WithToolsListChangedHandler`, a dedicated intercept mirroring the existing content-chunk/elicitation-complete precedent; still delivers to the generic callback.
4. [agent/routing_test.go](https://github.com/panyam/mcpkit/pull/905/files#diff-025176eaba5b55129ac0f59a863fe90a8148f8d0fc94a467bd1db24fd21191a2) — acceptance: history-driven narrowing (asserted on what the provider actually received), fresh-list-per-step, capability boundary, MultiSource composition, and the full invalidation chain against a live server (runtime RegisterTool → notification → Invalidate → Tools() refresh with no Call-miss).
5. [client/list_changed_test.go](https://github.com/panyam/mcpkit/pull/905/files#diff-c944b6e3a7a539baa10be601eb3070558779fcc04362834a583da690b1bd5372) — dedicated + generic handler composability, and the no-option red case.
6. [docs/AGENT_DESIGN.md](https://github.com/panyam/mcpkit/pull/905/files#diff-bdf045ebd871d9f6b81fe4602a8effef64194a2d15951e35ce3b0f79989db1d2) — the routing section with the purity rule.

## Decision log

- **Honest correction to issue 901's premise**: the client was never missing notification handling — `WithNotificationCallback` existed and I missed it when filing. What was missing is a *composable* dedicated hook, so invalidation plumbing doesn't consume the host's single generic callback. The new option follows the exact intercept pattern already in `makeNotifyAdapter`.
- **One invalidation channel, by rule**: list_changed → handler → `MultiSource.Invalidate()`; selectors stay pure functions of (history, current list) and any selector cache keys on list content. This is the interaction that justified one PR: routing must never grow its own invalidation path.
- **Filter vs Selector split**: FilterSource is policy that never varies by conversation (per-profile allowlists) and is enforced on Call; the Selector varies per step and is deliberately not a security boundary (the model only ever sees what it was offered, but routing resolution stays at the source).
- **Selector errors abort the turn** rather than falling back to all tools: a broken selector silently offering everything is the worst failure mode for exactly the deployments that need routing.

## Risk / blast radius

- Affects: `agent/` plus a root-module client addition (second root rider on the agent branch, after the DefaultInputHandler ordering fix).
- Tests: 8 new test functions (6 agent + 2 client), ~30 assertions added, 0 removed or weakened. Agent suite under -race.
- Be paranoid about: notification delivery path assumptions — the e2e tests rely on the GET SSE stream (`WithGetSSEStream`) for server-initiated notifications on streamable HTTP; hosts without any open stream will not receive list_changed and fall back to the Runner's per-step re-list + Call-miss refresh, which remains correct.

## Before / after

```mermaid
flowchart LR
    subgraph before [Before]
        S1[server registers tool at runtime] --> N1[notification broadcast]
        N1 -.->|no handler surface| X1[dropped]
        M1[MultiSource index] -->|stale until a Call-miss| R1[Runner step]
    end
    subgraph after [After]
        S2[server registers tool at runtime] --> N2[list_changed]
        N2 --> H2[WithToolsListChangedHandler]
        H2 --> I2[MultiSource.Invalidate]
        I2 --> T2["Tools() re-gathers"]
        T2 --> SEL2["Selector(history, tools)"]
        SEL2 --> R2[Runner step offers narrowed set]
    end
```

Test evidence, both mutation red-checks (selector bypassed; handler intercept severed — the invalidation e2e fails on timeout):

```
=== mutation 1: selector bypassed ===
FAIL    github.com/panyam/mcpkit/agent  0.693s
=== mutation 2: invalidation severed ===
FAIL    github.com/panyam/mcpkit/agent  3.667s
restored:
ok      github.com/panyam/mcpkit/agent  0.510s
ok      github.com/panyam/mcpkit/client 8.876s
```

## Out of scope (deliberately deferred)

- Searchable/deferred tools (search_tools meta-tool, on-demand schemas) → noted on issue 902 at close; needs mid-turn schema-surfacing design
- Resources/prompts list_changed siblings → same intercept shape when a consumer exists
- Embedding/LLM-scored selector implementations → host code on the seam; agentchat may grow a keyword one

https://claude.ai/code/session_01Y5cyvuPoFb6xKZ5hmHYDNQ
