### PR TITLE
feat(agent,agentchat): injection + trigger policies over events, generic pipeline primitives (issues 893, 894)

### DIFF
--- a/agent/incoming_event.go
+++ b/agent/incoming_event.go
@@ -1,0 +1,38 @@
+package agent
+
+import (
+	"time"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+// IncomingEvent is the neutral event shape the policy engines consume,
+// deliberately decoupled from any delivery mechanism: the events extension's
+// stream, a webhook receiver, or a future page-bridge source all adapt into
+// it. Wire-serializable per constraints A2/A5 (RawJSON payload) so wire
+// surfaces can forward events verbatim.
+type IncomingEvent struct {
+	// Server identifies the source connection (the MultiSource id in
+	// agentchat's wiring).
+	Server string `json:"server"`
+
+	// Name is the event name as declared in events/list.
+	Name string `json:"name"`
+
+	// ID is the delivery's event id, when the source provides one.
+	ID string `json:"id,omitempty"`
+
+	// Cursor is the replay cursor for cursored sources, empty otherwise.
+	Cursor string `json:"cursor,omitempty"`
+
+	// Time is when the host received the event (not the server's
+	// timestamp; policies window on receipt time so an injected clock
+	// governs tests).
+	Time time.Time `json:"time"`
+
+	// Data is the payload.
+	Data core.RawJSON `json:"data"`
+
+	// Meta is the occurrence-level _meta, opaque.
+	Meta map[string]any `json:"meta,omitempty"`
+}

--- a/agent/injection.go
+++ b/agent/injection.go
@@ -1,0 +1,338 @@
+package agent
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// MetaKeyContextHint is the vendor _meta key on an events/list EventDef that
+// carries a ContextHint (see docs/AGENT_DESIGN.md, vendor prefix section).
+// Advisory per the context-hints SEP draft: hosts MAY ignore it, and host
+// configuration overrides it.
+const MetaKeyContextHint = "io.github.panyam.mcpkit/context-hint"
+
+// ContextHint declares how an event's occurrences should reach the model.
+// The shape mirrors the context-hints SEP draft one-for-one.
+type ContextHint struct {
+	// Priority orders injection under the budget: critical, high,
+	// medium (default), low.
+	Priority string `json:"priority,omitempty"`
+
+	// Aggregate coalesces bursts before injection.
+	Aggregate *AggregateHint `json:"aggregate,omitempty"`
+
+	// Template renders the payload as context: {{field}} substitutes
+	// top-level payload fields (deliberately no logic; hosts wanting
+	// more render themselves). Empty uses the default rendering.
+	Template string `json:"template,omitempty"`
+
+	// Retention: "turn" (default; injected once) or "session" (the
+	// latest occurrence re-injects every turn until superseded).
+	Retention string `json:"retention,omitempty"`
+
+	// Sensitivity: "public" (default), "personal", "restricted".
+	// Restricted events are dropped unless the consent gate approves.
+	Sensitivity string `json:"sensitivity,omitempty"`
+}
+
+// AggregateHint is ContextHint's coalescing sub-shape.
+type AggregateHint struct {
+	WindowMs int            `json:"windowMs"`
+	Strategy WindowStrategy `json:"strategy,omitempty"`
+}
+
+// InjectionConfig assembles an InjectionPolicy.
+type InjectionConfig struct {
+	// Hints maps event name to its ContextHint. Entries here override
+	// server-advertised hints (host config wins over vendor _meta).
+	Hints map[string]ContextHint
+
+	// Filters and Transforms run before buffering, in order: the
+	// developer seam for dropping or rewriting events regardless of
+	// hints.
+	Filters    []func(IncomingEvent) bool
+	Transforms []func(IncomingEvent) (IncomingEvent, bool)
+
+	// Merge is the combiner for merge-strategy windows. Nil uses
+	// ShallowMergeJSON.
+	Merge func(acc, next IncomingEvent) IncomingEvent
+
+	// MaxPerDrain caps how many rendered entries one Drain returns
+	// (highest priority first). Zero means DefaultMaxPerDrain.
+	MaxPerDrain int
+
+	// Consent gates sensitive events. Nil allows public and personal
+	// and drops restricted; a non-nil gate decides everything except
+	// public, which always passes.
+	Consent func(hint ContextHint, ev IncomingEvent) bool
+
+	// now is injectable for tests; nil means time.Now.
+	now func() time.Time
+}
+
+// DefaultMaxPerDrain bounds injected entries per turn when unconfigured.
+const DefaultMaxPerDrain = 16
+
+// InjectedContext is one rendered entry ready to join the model's context.
+type InjectedContext struct {
+	Event    IncomingEvent
+	Text     string
+	Priority string
+}
+
+// InjectionPolicy is the host half of the context-hints SEP draft: it
+// buffers incoming events (per-event aggregation windows), renders them, and
+// releases them in priority order under a budget when the host drains before
+// a turn. Safe for concurrent Ingest against one Drain (the wiring's event
+// goroutine vs the turn path).
+type InjectionPolicy struct {
+	cfg InjectionConfig
+
+	mu      sync.Mutex
+	windows map[string]Stage[IncomingEvent]
+	pending []IncomingEvent
+	session map[string]IncomingEvent
+	sessOrd []string
+	dropped int
+}
+
+// NewInjectionPolicy builds the policy.
+func NewInjectionPolicy(cfg InjectionConfig) *InjectionPolicy {
+	if cfg.MaxPerDrain <= 0 {
+		cfg.MaxPerDrain = DefaultMaxPerDrain
+	}
+	if cfg.Merge == nil {
+		cfg.Merge = ShallowMergeJSON
+	}
+	if cfg.now == nil {
+		cfg.now = time.Now
+	}
+	return &InjectionPolicy{cfg: cfg, windows: map[string]Stage[IncomingEvent]{}, session: map[string]IncomingEvent{}}
+}
+
+// HintFromMeta extracts a server-advertised ContextHint from an events/list
+// EventDef _meta map. Second return reports presence. Malformed hints are
+// ignored (advisory data never breaks the host).
+func HintFromMeta(meta map[string]any) (ContextHint, bool) {
+	raw, ok := meta[MetaKeyContextHint]
+	if !ok {
+		return ContextHint{}, false
+	}
+	m, ok := raw.(map[string]any)
+	if !ok {
+		return ContextHint{}, false
+	}
+	var h ContextHint
+	if v, ok := m["priority"].(string); ok {
+		h.Priority = v
+	}
+	if v, ok := m["template"].(string); ok {
+		h.Template = v
+	}
+	if v, ok := m["retention"].(string); ok {
+		h.Retention = v
+	}
+	if v, ok := m["sensitivity"].(string); ok {
+		h.Sensitivity = v
+	}
+	if agg, ok := m["aggregate"].(map[string]any); ok {
+		ah := &AggregateHint{}
+		if w, ok := agg["windowMs"].(float64); ok {
+			ah.WindowMs = int(w)
+		}
+		if s, ok := agg["strategy"].(string); ok {
+			ah.Strategy = WindowStrategy(s)
+		}
+		h.Aggregate = ah
+	}
+	return h, true
+}
+
+// SetHint installs (or overrides) the hint for an event name at runtime,
+// e.g. from events/list discovery. Host-config entries passed at
+// construction still win: SetHint is a no-op for names already configured.
+func (p *InjectionPolicy) SetHint(name string, h ContextHint) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if _, configured := p.cfg.Hints[name]; configured {
+		return
+	}
+	if p.cfg.Hints == nil {
+		p.cfg.Hints = map[string]ContextHint{}
+	}
+	p.cfg.Hints[name] = h
+}
+
+func (p *InjectionPolicy) hint(name string) ContextHint {
+	return p.cfg.Hints[name]
+}
+
+// Ingest feeds one event through the developer stages and into its
+// aggregation window (or straight to pending when the hint has none).
+func (p *InjectionPolicy) Ingest(ev IncomingEvent) {
+	for _, f := range p.cfg.Filters {
+		if !f(ev) {
+			return
+		}
+	}
+	for _, tr := range p.cfg.Transforms {
+		var keep bool
+		if ev, keep = tr(ev); !keep {
+			return
+		}
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	now := p.cfg.now()
+	h := p.hint(ev.Name)
+	if h.Aggregate == nil || h.Aggregate.WindowMs <= 0 {
+		p.buffer(ev, h)
+		return
+	}
+	w, ok := p.windows[ev.Name]
+	if !ok {
+		w = Window(time.Duration(h.Aggregate.WindowMs)*time.Millisecond, h.Aggregate.Strategy,
+			func(e IncomingEvent) string { return e.Server + "/" + e.Name },
+			p.cfg.Merge)
+		p.windows[ev.Name] = w
+	}
+	for _, released := range w.Push(now, ev) {
+		p.buffer(released, h)
+	}
+}
+
+func (p *InjectionPolicy) buffer(ev IncomingEvent, h ContextHint) {
+	if h.Retention == "session" {
+		key := ev.Server + "/" + ev.Name
+		if _, seen := p.session[key]; !seen {
+			p.sessOrd = append(p.sessOrd, key)
+		}
+		p.session[key] = ev
+		return
+	}
+	p.pending = append(p.pending, ev)
+}
+
+// Drain flushes expired windows and returns rendered entries in priority
+// order under the budget. Turn-retention entries leave the buffer;
+// session-retention entries re-drain every call until superseded. Entries
+// beyond the budget stay buffered for the next drain; restricted events
+// denied by the consent gate are counted and dropped.
+func (p *InjectionPolicy) Drain() []InjectedContext {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	now := p.cfg.now()
+
+	for name, w := range p.windows {
+		for _, released := range w.Flush(now) {
+			p.buffer(released, p.hint(name))
+		}
+	}
+
+	type cand struct {
+		ev      IncomingEvent
+		session bool
+	}
+	cands := make([]cand, 0, len(p.pending)+len(p.session))
+	for _, key := range p.sessOrd {
+		cands = append(cands, cand{ev: p.session[key], session: true})
+	}
+	for _, ev := range p.pending {
+		cands = append(cands, cand{ev: ev})
+	}
+
+	// Consent-gate first, then order by priority, THEN apply the budget:
+	// the budget must never be consumed by low-priority arrivals while
+	// higher-priority entries wait.
+	type ranked struct {
+		cand
+		priority string
+	}
+	rankedCands := make([]ranked, 0, len(cands))
+	for _, c := range cands {
+		h := p.hint(c.ev.Name)
+		if !p.consentLocked(h, c.ev) {
+			p.dropped++
+			continue
+		}
+		rankedCands = append(rankedCands, ranked{cand: c, priority: priorityOrDefault(h.Priority)})
+	}
+	sort.SliceStable(rankedCands, func(i, j int) bool {
+		return priorityRank(rankedCands[i].priority) < priorityRank(rankedCands[j].priority)
+	})
+
+	var out []InjectedContext
+	p.pending = p.pending[:0]
+	for _, rc := range rankedCands {
+		if len(out) >= p.cfg.MaxPerDrain {
+			if !rc.session {
+				p.pending = append(p.pending, rc.ev)
+			}
+			continue
+		}
+		out = append(out, InjectedContext{Event: rc.ev, Text: renderEvent(rc.ev, p.hint(rc.ev.Name)), Priority: rc.priority})
+	}
+	return out
+}
+
+// Dropped reports how many events the consent gate has refused so far.
+func (p *InjectionPolicy) Dropped() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.dropped
+}
+
+func (p *InjectionPolicy) consentLocked(h ContextHint, ev IncomingEvent) bool {
+	sensitivity := h.Sensitivity
+	if sensitivity == "" || sensitivity == "public" {
+		return true
+	}
+	if p.cfg.Consent != nil {
+		return p.cfg.Consent(h, ev)
+	}
+	return sensitivity == "personal"
+}
+
+func priorityOrDefault(p string) string {
+	if p == "" {
+		return "medium"
+	}
+	return p
+}
+
+func priorityRank(p string) int {
+	switch p {
+	case "critical":
+		return 0
+	case "high":
+		return 1
+	case "medium":
+		return 2
+	default:
+		return 3
+	}
+}
+
+var templateField = regexp.MustCompile(`\{\{([a-zA-Z0-9_.-]+)\}\}`)
+
+// renderEvent renders one event as context text: the hint template with
+// {{field}} substitution from top-level payload fields, or the default
+// "event <name> from <server>: <payload>" line.
+func renderEvent(ev IncomingEvent, h ContextHint) string {
+	if h.Template == "" {
+		return fmt.Sprintf("event %s from %s: %s", ev.Name, ev.Server, strings.TrimSpace(string(ev.Data.Raw())))
+	}
+	return templateField.ReplaceAllStringFunc(h.Template, func(m string) string {
+		field := templateField.FindStringSubmatch(m)[1]
+		v, ok := ev.Data.Field(field)
+		if !ok {
+			return m
+		}
+		return strings.Trim(string(v.Raw()), `"`)
+	})
+}

--- a/agent/policy_test.go
+++ b/agent/policy_test.go
@@ -1,0 +1,303 @@
+package agent
+
+import (
+	"encoding/json"
+
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+func evt(server, name, payload string) IncomingEvent {
+	return IncomingEvent{Server: server, Name: name, Data: core.NewRawJSON(json.RawMessage(payload))}
+}
+
+type fakeClock struct{ t time.Time }
+
+func (c *fakeClock) now() time.Time          { return c.t }
+func (c *fakeClock) advance(d time.Duration) { c.t = c.t.Add(d) }
+
+func newClock() *fakeClock {
+	return &fakeClock{t: time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)}
+}
+
+func TestInjectionMergeWindowCoalescesBurst(t *testing.T) {
+	clock := newClock()
+	p := NewInjectionPolicy(InjectionConfig{
+		Hints: map[string]ContextHint{
+			"cart.changed": {Aggregate: &AggregateHint{WindowMs: 2000, Strategy: WindowMerge},
+				Template: "cart has {{count}} items"},
+		},
+		now: clock.now,
+	})
+
+	p.Ingest(evt("grocery", "cart.changed", `{"count":1}`))
+	p.Ingest(evt("grocery", "cart.changed", `{"count":2}`))
+	p.Ingest(evt("grocery", "cart.changed", `{"count":3}`))
+
+	if got := p.Drain(); len(got) != 0 {
+		t.Fatalf("window must hold the burst until expiry, got %v", got)
+	}
+	clock.advance(3 * time.Second)
+	got := p.Drain()
+	if len(got) != 1 || got[0].Text != "cart has 3 items" {
+		t.Fatalf("burst must coalesce to one entry with merged fields: %+v", got)
+	}
+	if len(p.Drain()) != 0 {
+		t.Fatal("turn retention: drained entries must not repeat")
+	}
+}
+
+func TestInjectionDebounceRestartsWindow(t *testing.T) {
+	clock := newClock()
+	p := NewInjectionPolicy(InjectionConfig{
+		Hints: map[string]ContextHint{
+			"typing": {Aggregate: &AggregateHint{WindowMs: 1000, Strategy: WindowDebounce}},
+		},
+		now: clock.now,
+	})
+	p.Ingest(evt("s", "typing", `{"n":1}`))
+	clock.advance(800 * time.Millisecond)
+	p.Ingest(evt("s", "typing", `{"n":2}`))
+	clock.advance(800 * time.Millisecond)
+	if got := p.Drain(); len(got) != 0 {
+		t.Fatalf("debounce must restart on each event, got %+v", got)
+	}
+	clock.advance(300 * time.Millisecond)
+	if got := p.Drain(); len(got) != 1 || !strings.Contains(got[0].Text, `"n":2`) {
+		t.Fatalf("quiet gap must release the last event: %+v", got)
+	}
+}
+
+func TestInjectionPriorityOrderAndBudget(t *testing.T) {
+	clock := newClock()
+	p := NewInjectionPolicy(InjectionConfig{
+		Hints: map[string]ContextHint{
+			"low.ev":  {Priority: "low"},
+			"crit.ev": {Priority: "critical"},
+			"high.ev": {Priority: "high"},
+		},
+		MaxPerDrain: 2,
+		now:         clock.now,
+	})
+	p.Ingest(evt("s", "low.ev", `{}`))
+	p.Ingest(evt("s", "crit.ev", `{}`))
+	p.Ingest(evt("s", "high.ev", `{}`))
+
+	got := p.Drain()
+	if len(got) != 2 || got[0].Event.Name != "crit.ev" || got[1].Event.Name != "high.ev" {
+		t.Fatalf("priority order under budget broken: %+v", got)
+	}
+	rest := p.Drain()
+	if len(rest) != 1 || rest[0].Event.Name != "low.ev" {
+		t.Fatalf("over-budget entries must carry to the next drain: %+v", rest)
+	}
+}
+
+func TestInjectionSensitivityGate(t *testing.T) {
+	clock := newClock()
+	consented := false
+	p := NewInjectionPolicy(InjectionConfig{
+		Hints: map[string]ContextHint{
+			"secret.ev": {Sensitivity: "restricted"},
+			"pers.ev":   {Sensitivity: "personal"},
+		},
+		now: clock.now,
+	})
+	p.Ingest(evt("s", "secret.ev", `{}`))
+	p.Ingest(evt("s", "pers.ev", `{}`))
+	got := p.Drain()
+	if len(got) != 1 || got[0].Event.Name != "pers.ev" {
+		t.Fatalf("default gate: personal passes, restricted drops: %+v", got)
+	}
+	if p.Dropped() != 1 {
+		t.Fatalf("dropped count = %d", p.Dropped())
+	}
+
+	p2 := NewInjectionPolicy(InjectionConfig{
+		Hints:   map[string]ContextHint{"secret.ev": {Sensitivity: "restricted"}},
+		Consent: func(h ContextHint, ev IncomingEvent) bool { consented = true; return true },
+		now:     clock.now,
+	})
+	p2.Ingest(evt("s", "secret.ev", `{}`))
+	if got := p2.Drain(); len(got) != 1 || !consented {
+		t.Fatalf("consent gate must decide restricted: %+v consented=%v", got, consented)
+	}
+}
+
+func TestInjectionSessionRetentionReinjectsLatest(t *testing.T) {
+	clock := newClock()
+	p := NewInjectionPolicy(InjectionConfig{
+		Hints: map[string]ContextHint{"loc": {Retention: "session", Template: "at {{city}}"}},
+		now:   clock.now,
+	})
+	p.Ingest(evt("s", "loc", `{"city":"Paris"}`))
+	if got := p.Drain(); len(got) != 1 || got[0].Text != "at Paris" {
+		t.Fatalf("first drain: %+v", got)
+	}
+	if got := p.Drain(); len(got) != 1 || got[0].Text != "at Paris" {
+		t.Fatalf("session retention must re-inject: %+v", got)
+	}
+	p.Ingest(evt("s", "loc", `{"city":"Rome"}`))
+	if got := p.Drain(); len(got) != 1 || got[0].Text != "at Rome" {
+		t.Fatalf("newer occurrence must supersede: %+v", got)
+	}
+}
+
+func TestInjectionDeveloperStagesAndHintFromMeta(t *testing.T) {
+	clock := newClock()
+	type cart struct {
+		Count int    `json:"count"`
+		User  string `json:"user"`
+	}
+	p := NewInjectionPolicy(InjectionConfig{
+		Filters: []func(IncomingEvent) bool{
+			TypedFilter(func(c cart) bool { return c.Count > 0 }),
+		},
+		Transforms: []func(IncomingEvent) (IncomingEvent, bool){
+			TypedTransform(func(c cart) (cart, bool) { c.User = "[redacted]"; return c, true }),
+		},
+		now: clock.now,
+	})
+	p.Ingest(evt("s", "cart.changed", `{"count":0,"user":"alice"}`))
+	p.Ingest(evt("s", "cart.changed", `{"count":2,"user":"alice"}`))
+	got := p.Drain()
+	if len(got) != 1 {
+		t.Fatalf("typed filter must drop count=0: %+v", got)
+	}
+	if !strings.Contains(got[0].Text, "[redacted]") || strings.Contains(got[0].Text, "alice") {
+		t.Fatalf("typed transform must redact: %s", got[0].Text)
+	}
+
+	hint, ok := HintFromMeta(map[string]any{
+		MetaKeyContextHint: map[string]any{
+			"priority":  "high",
+			"template":  "cart: {{count}}",
+			"aggregate": map[string]any{"windowMs": float64(1500), "strategy": "merge"},
+		},
+	})
+	if !ok || hint.Priority != "high" || hint.Aggregate == nil || hint.Aggregate.WindowMs != 1500 || hint.Aggregate.Strategy != WindowMerge {
+		t.Fatalf("HintFromMeta = %+v ok=%v", hint, ok)
+	}
+	p.SetHint("cart.changed", hint)
+	p.Ingest(evt("s", "cart.changed", `{"count":5,"user":"x"}`))
+	if got := p.Drain(); len(got) != 0 {
+		t.Fatalf("meta hint's window must now buffer: %+v", got)
+	}
+	clock.advance(2 * time.Second)
+	if got := p.Drain(); len(got) != 1 || got[0].Text != "cart: 5" {
+		t.Fatalf("meta hint template must render: %+v", got)
+	}
+}
+
+func TestTriggerSlotMachine(t *testing.T) {
+	clock := newClock()
+	tp := NewTriggerPolicy(TriggerPolicyConfig{
+		Bindings: []TriggerBinding{{
+			Event:        "cart.changed",
+			Filter:       TypedFilter(func(c struct{ Count int }) bool { return c.Count >= 2 }),
+			Instructions: "Offer a recipe.",
+			Label:        "recipe-pitch",
+			Cooldown:     time.Minute,
+		}},
+		now: clock.now,
+	})
+
+	if tp.OnEvent(evt("g", "cart.changed", `{"Count":1}`)) != nil {
+		t.Fatal("filter must suppress below threshold")
+	}
+	f := tp.OnEvent(evt("g", "cart.changed", `{"Count":2}`))
+	if f == nil || f.Binding.Label != "recipe-pitch" {
+		t.Fatalf("first qualifying event must fire: %+v", f)
+	}
+	for i := 0; i < 3; i++ {
+		if tp.OnEvent(evt("g", "cart.changed", `{"Count":5}`)) != nil {
+			t.Fatal("spent slot must stay quiet")
+		}
+	}
+
+	tp.NotifyEngagement()
+	if tp.OnEvent(evt("g", "cart.changed", `{"Count":5}`)) != nil {
+		t.Fatal("engagement alone must not re-arm before cooldown")
+	}
+	clock.advance(2 * time.Minute)
+	if tp.OnEvent(evt("g", "cart.changed", `{"Count":5}`)) == nil {
+		t.Fatal("engagement plus cooldown must re-arm")
+	}
+
+	clock2 := newClock()
+	tp2 := NewTriggerPolicy(TriggerPolicyConfig{
+		Bindings: []TriggerBinding{{Event: "e", Label: "l", Cooldown: time.Millisecond}},
+		Budget:   1,
+		now:      clock2.now,
+	})
+	if tp2.OnEvent(evt("s", "e", `{}`)) == nil {
+		t.Fatal("first firing within budget")
+	}
+	tp2.NotifyEngagement()
+	clock2.advance(time.Second)
+	if tp2.OnEvent(evt("s", "e", `{}`)) != nil {
+		t.Fatal("budget must cap firings even when re-armed")
+	}
+	if tp2.Firings() != 1 {
+		t.Fatalf("firings = %d", tp2.Firings())
+	}
+}
+
+func TestTriggerConsentGate(t *testing.T) {
+	declined := 0
+	tp := NewTriggerPolicy(TriggerPolicyConfig{
+		Bindings: []TriggerBinding{{Event: "e", Label: "l"}},
+		Consent:  func(TriggerBinding, IncomingEvent) bool { declined++; return false },
+	})
+	if tp.OnEvent(evt("s", "e", `{}`)) != nil {
+		t.Fatal("declined consent must suppress")
+	}
+	if declined != 1 || tp.Firings() != 0 {
+		t.Fatalf("declined=%d firings=%d", declined, tp.Firings())
+	}
+}
+
+func TestGenericWindowIsPromotable(t *testing.T) {
+	// The stages are generic machinery: prove they work on a non-event
+	// type (the promotability contract from the design discussion).
+	clock := newClock()
+	w := Window[int](time.Second, WindowMerge, func(int) string { return "k" }, func(a, b int) int { return a + b })
+	w.Push(clock.t, 1)
+	w.Push(clock.t, 2)
+	w.Push(clock.t, 3)
+	if got := w.Flush(clock.t.Add(2 * time.Second)); len(got) != 1 || got[0] != 6 {
+		t.Fatalf("generic merge window = %v", got)
+	}
+
+	pipe := NewPipeline[int](
+		Filter(func(n int) bool { return n%2 == 0 }),
+		Transform(func(n int) (int, bool) { return n * 10, true }),
+	)
+	if got := pipe.Push(clock.t, 4); len(got) != 1 || got[0] != 40 {
+		t.Fatalf("generic pipeline = %v", got)
+	}
+	if got := pipe.Push(clock.t, 3); got != nil {
+		t.Fatalf("filter must drop odd: %v", got)
+	}
+}
+
+func TestSystemRoleReachesProviderWire(t *testing.T) {
+	p, err := NewOpenAIProvider(OpenAIConfig{BaseURL: "http://unused", Model: "m"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := p.buildBody(ProviderRequest{
+		Messages: []Message{
+			{Role: RoleSystem, Text: "event cart.changed from grocery: 3 items"},
+			{Role: RoleUser, Text: "what changed?"},
+		},
+	}, false)
+	raw, _ := json.Marshal(body["messages"])
+	want := `[{"content":"event cart.changed from grocery: 3 items","role":"system"},{"content":"what changed?","role":"user"}]`
+	if string(raw) != want {
+		t.Fatalf("system role wire shape:\n got %s\nwant %s", raw, want)
+	}
+}

--- a/agent/provider.go
+++ b/agent/provider.go
@@ -17,6 +17,12 @@ const (
 	RoleUser      Role = "user"
 	RoleAssistant Role = "assistant"
 	RoleTool      Role = "tool"
+	// RoleSystem carries injected context (events, trigger instructions)
+	// into the conversation; providers map it to their native system
+	// slot. Distinct from ProviderRequest.Instructions, which is the
+	// static prompt: RoleSystem messages live in history and thread
+	// across turns like any other message.
+	RoleSystem Role = "system"
 )
 
 // Message is one conversation entry in provider-neutral form. All fields are

--- a/agent/stages.go
+++ b/agent/stages.go
@@ -1,0 +1,239 @@
+package agent
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+// Stage is one step of an event pipeline, generic over the event type so the
+// machinery is promotable to any consumer (webhook receivers, page bridges)
+// unchanged: nothing here knows about MCP or the model. Push feeds one event
+// and returns whatever the stage releases now; Flush releases anything whose
+// window has expired by now. Stateless stages return their result from Push
+// and nil from Flush. Stages are not safe for concurrent use; drive each
+// pipeline from one goroutine (the policies do).
+type Stage[E any] interface {
+	Push(now time.Time, ev E) []E
+	Flush(now time.Time) []E
+}
+
+// Pipeline chains stages: each event Pushed cascades through every stage in
+// order, and Flush cascades expirations the same way.
+type Pipeline[E any] struct {
+	stages []Stage[E]
+}
+
+// NewPipeline builds a pipeline from stages, applied in order.
+func NewPipeline[E any](stages ...Stage[E]) *Pipeline[E] {
+	return &Pipeline[E]{stages: stages}
+}
+
+// Push cascades ev through the stages.
+func (p *Pipeline[E]) Push(now time.Time, ev E) []E {
+	events := []E{ev}
+	for _, s := range p.stages {
+		var next []E
+		for _, e := range events {
+			next = append(next, s.Push(now, e)...)
+		}
+		events = next
+		if len(events) == 0 {
+			return nil
+		}
+	}
+	return events
+}
+
+// Flush cascades window expirations: stage i's flushed events still traverse
+// stages i+1..n before release.
+func (p *Pipeline[E]) Flush(now time.Time) []E {
+	var out []E
+	for i, s := range p.stages {
+		for _, e := range s.Flush(now) {
+			events := []E{e}
+			for _, later := range p.stages[i+1:] {
+				var next []E
+				for _, ev := range events {
+					next = append(next, later.Push(now, ev)...)
+				}
+				events = next
+			}
+			out = append(out, events...)
+		}
+	}
+	return out
+}
+
+// Filter keeps events for which fn returns true.
+func Filter[E any](fn func(E) bool) Stage[E] { return filterStage[E]{fn: fn} }
+
+type filterStage[E any] struct{ fn func(E) bool }
+
+func (s filterStage[E]) Push(_ time.Time, ev E) []E {
+	if s.fn(ev) {
+		return []E{ev}
+	}
+	return nil
+}
+func (s filterStage[E]) Flush(time.Time) []E { return nil }
+
+// Transform rewrites events; returning false drops the event.
+func Transform[E any](fn func(E) (E, bool)) Stage[E] { return transformStage[E]{fn: fn} }
+
+type transformStage[E any] struct{ fn func(E) (E, bool) }
+
+func (s transformStage[E]) Push(_ time.Time, ev E) []E {
+	if out, keep := s.fn(ev); keep {
+		return []E{out}
+	}
+	return nil
+}
+func (s transformStage[E]) Flush(time.Time) []E { return nil }
+
+// WindowStrategy selects how a Window coalesces a burst.
+type WindowStrategy string
+
+// Window strategies, matching the context-hint vocabulary: last-wins keeps
+// only the newest event per key, merge folds the burst through a combiner,
+// debounce releases only after the key has been quiet for the window.
+const (
+	WindowLastWins WindowStrategy = "last-wins"
+	WindowMerge    WindowStrategy = "merge"
+	WindowDebounce WindowStrategy = "debounce"
+)
+
+// Window buffers events per key and releases per strategy when the window
+// expires. For last-wins and merge the window opens at the FIRST event of a
+// burst (bounded latency); for debounce every event restarts the window
+// (quiet-gap semantics). merge folds with the supplied combiner; nil merge
+// falls back to last-wins behavior.
+func Window[E any](d time.Duration, strategy WindowStrategy, key func(E) string, merge func(acc, next E) E) Stage[E] {
+	return &windowStage[E]{d: d, strategy: strategy, key: key, merge: merge, buckets: map[string]*bucket[E]{}}
+}
+
+type bucket[E any] struct {
+	acc      E
+	deadline time.Time
+}
+
+type windowStage[E any] struct {
+	d        time.Duration
+	strategy WindowStrategy
+	key      func(E) string
+	merge    func(acc, next E) E
+	buckets  map[string]*bucket[E]
+	order    []string
+}
+
+func (s *windowStage[E]) Push(now time.Time, ev E) []E {
+	k := s.key(ev)
+	b, ok := s.buckets[k]
+	if !ok {
+		b = &bucket[E]{acc: ev, deadline: now.Add(s.d)}
+		s.buckets[k] = b
+		s.order = append(s.order, k)
+		return nil
+	}
+	if s.strategy == WindowMerge && s.merge != nil {
+		b.acc = s.merge(b.acc, ev)
+	} else {
+		b.acc = ev
+	}
+	if s.strategy == WindowDebounce {
+		b.deadline = now.Add(s.d)
+	}
+	return nil
+}
+
+func (s *windowStage[E]) Flush(now time.Time) []E {
+	var out []E
+	remaining := s.order[:0]
+	for _, k := range s.order {
+		b := s.buckets[k]
+		if !now.Before(b.deadline) {
+			out = append(out, b.acc)
+			delete(s.buckets, k)
+			continue
+		}
+		remaining = append(remaining, k)
+	}
+	s.order = remaining
+	return out
+}
+
+// TypedFilter adapts a payload-typed predicate onto IncomingEvent: the
+// payload is Bound once; events whose payload does not decode as T do not
+// match. Use for filters that inspect fields with compile-time safety.
+func TypedFilter[T any](fn func(T) bool) func(IncomingEvent) bool {
+	return func(ev IncomingEvent) bool {
+		var v T
+		if err := ev.Data.Bind(&v); err != nil {
+			return false
+		}
+		return fn(v)
+	}
+}
+
+// TypedTransform adapts a payload-typed rewrite onto IncomingEvent; the
+// returned payload is re-marshaled into Data. Undecodable payloads pass
+// through unchanged (a transform must not silently eat events it cannot
+// read).
+func TypedTransform[T any](fn func(T) (T, bool)) func(IncomingEvent) (IncomingEvent, bool) {
+	return func(ev IncomingEvent) (IncomingEvent, bool) {
+		var v T
+		if err := ev.Data.Bind(&v); err != nil {
+			return ev, true
+		}
+		out, keep := fn(v)
+		if !keep {
+			return ev, false
+		}
+		raw, err := json.Marshal(out)
+		if err != nil {
+			return ev, true
+		}
+		ev.Data = core.NewRawJSON(raw)
+		return ev, true
+	}
+}
+
+// MergeWith adapts a payload-typed combiner into an IncomingEvent merge for
+// Window's merge strategy: both payloads are Bound as T, folded, and the
+// result re-marshaled onto the newer event's envelope. If either payload
+// does not decode, the newer event wins (never fabricate data).
+func MergeWith[T any](merge func(acc, next T) T) func(acc, next IncomingEvent) IncomingEvent {
+	return func(acc, next IncomingEvent) IncomingEvent {
+		var a, n T
+		if acc.Data.Bind(&a) != nil || next.Data.Bind(&n) != nil {
+			return next
+		}
+		raw, err := json.Marshal(merge(a, n))
+		if err != nil {
+			return next
+		}
+		next.Data = core.NewRawJSON(raw)
+		return next
+	}
+}
+
+// ShallowMergeJSON is the default combiner for merge windows on
+// IncomingEvent when no typed combiner is supplied: a shallow JSON-object
+// merge where the newer event's fields win. Non-object payloads fall back
+// to last-wins.
+func ShallowMergeJSON(acc, next IncomingEvent) IncomingEvent {
+	var a, n map[string]json.RawMessage
+	if acc.Data.Bind(&a) != nil || next.Data.Bind(&n) != nil {
+		return next
+	}
+	for k, v := range n {
+		a[k] = v
+	}
+	raw, err := json.Marshal(a)
+	if err != nil {
+		return next
+	}
+	next.Data = core.NewRawJSON(raw)
+	return next
+}

--- a/agent/triggers.go
+++ b/agent/triggers.go
@@ -1,0 +1,178 @@
+package agent
+
+import (
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// MetaKeyTrigger is the vendor _meta key on an events/list EventDef carrying
+// a server-suggested trigger binding. Server-advertised triggers are
+// suggestions only: the host decides whether to install them, and every
+// firing is mediated by TriggerPolicy regardless of origin (the triggers SEP
+// draft's stance: the server signals, the host owns the turn).
+const MetaKeyTrigger = "io.github.panyam.mcpkit/trigger"
+
+// DefaultTriggerCooldown gates re-arming when a binding does not set its own.
+const DefaultTriggerCooldown = 5 * time.Minute
+
+// DefaultTriggerBudget caps proactive firings per policy lifetime when
+// unconfigured.
+const DefaultTriggerBudget = 10
+
+// TriggerBinding declares one event-to-turn binding.
+type TriggerBinding struct {
+	// Server and Event select which incoming events match. Empty Server
+	// matches any source.
+	Server string
+	Event  string
+
+	// Filter further narrows matches. Nil matches all occurrences.
+	Filter func(IncomingEvent) bool
+
+	// Instructions seed the proactive turn (the trigger's "why you are
+	// being invoked" prompt).
+	Instructions string
+
+	// Label names the binding in transcripts, logs, and slot state.
+	Label string
+
+	// Cooldown is this binding's re-arm floor. Zero means
+	// DefaultTriggerCooldown.
+	Cooldown time.Duration
+}
+
+// TriggerFiring is an approved proactive-turn request: the host runs it
+// however it runs turns.
+type TriggerFiring struct {
+	Binding TriggerBinding
+	Event   IncomingEvent
+}
+
+// TriggerPolicyConfig assembles a TriggerPolicy.
+type TriggerPolicyConfig struct {
+	Bindings []TriggerBinding
+
+	// Budget caps total firings for this policy's lifetime (a session,
+	// in agentchat's wiring). Zero means DefaultTriggerBudget.
+	Budget int
+
+	// Consent, when non-nil, approves each firing after the slot and
+	// budget checks. The hook for "ask the user once per binding" UX.
+	Consent func(TriggerBinding, IncomingEvent) bool
+
+	// Logger records firings and suppressions (nil discards, per A4).
+	Logger *slog.Logger
+
+	// now is injectable for tests; nil means time.Now.
+	now func() time.Time
+}
+
+// TriggerPolicy is the anti-nag mediation layer between events and
+// proactive turns, the CIP playbook's Tier-1 slot machine ported: one slot
+// per binding, OPEN to SPENT on fire, re-armed only when BOTH a user
+// engagement arrived after the firing AND the binding's cooldown elapsed.
+// This is a deterministic approximation of the original's LLM engagement
+// signal (positive-engagement detection is a documented future upgrade).
+// Safe for concurrent use.
+type TriggerPolicy struct {
+	cfg TriggerPolicyConfig
+
+	mu      sync.Mutex
+	slots   map[string]*triggerSlot
+	firings int
+}
+
+type triggerSlot struct {
+	spentAt time.Time
+	engaged bool
+	spent   bool
+}
+
+// NewTriggerPolicy builds the policy.
+func NewTriggerPolicy(cfg TriggerPolicyConfig) *TriggerPolicy {
+	if cfg.Budget <= 0 {
+		cfg.Budget = DefaultTriggerBudget
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = slog.New(slog.DiscardHandler)
+	}
+	if cfg.now == nil {
+		cfg.now = time.Now
+	}
+	slots := make(map[string]*triggerSlot, len(cfg.Bindings))
+	for _, b := range cfg.Bindings {
+		slots[slotKey(b)] = &triggerSlot{}
+	}
+	return &TriggerPolicy{cfg: cfg, slots: slots}
+}
+
+func slotKey(b TriggerBinding) string { return b.Server + "/" + b.Event + "/" + b.Label }
+
+// OnEvent evaluates ev against every binding and returns at most one
+// approved firing (first matching OPEN binding wins), or nil when nothing
+// fires. Suppressions (spent slot, budget, consent) are logged, not
+// surfaced: servers get no backpressure channel by design.
+func (t *TriggerPolicy) OnEvent(ev IncomingEvent) *TriggerFiring {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	now := t.cfg.now()
+
+	for _, b := range t.cfg.Bindings {
+		if b.Event != ev.Name || (b.Server != "" && b.Server != ev.Server) {
+			continue
+		}
+		if b.Filter != nil && !b.Filter(ev) {
+			continue
+		}
+		slot := t.slots[slotKey(b)]
+		if slot.spent {
+			cooldown := b.Cooldown
+			if cooldown <= 0 {
+				cooldown = DefaultTriggerCooldown
+			}
+			if !slot.engaged || now.Before(slot.spentAt.Add(cooldown)) {
+				t.cfg.Logger.Debug("trigger suppressed: slot spent",
+					"label", b.Label, "engaged", slot.engaged)
+				continue
+			}
+			slot.spent = false
+		}
+		if t.firings >= t.cfg.Budget {
+			t.cfg.Logger.Warn("trigger suppressed: budget exhausted",
+				"label", b.Label, "budget", t.cfg.Budget)
+			return nil
+		}
+		if t.cfg.Consent != nil && !t.cfg.Consent(b, ev) {
+			t.cfg.Logger.Info("trigger suppressed: consent declined", "label", b.Label)
+			continue
+		}
+		slot.spent = true
+		slot.spentAt = now
+		slot.engaged = false
+		t.firings++
+		t.cfg.Logger.Info("trigger fired", "label", b.Label, "event", ev.Name, "firings", t.firings)
+		return &TriggerFiring{Binding: b, Event: ev}
+	}
+	return nil
+}
+
+// NotifyEngagement records that the user engaged (sent a message) after any
+// pending firing: half of every spent slot's re-arm condition, the other
+// half being its cooldown.
+func (t *TriggerPolicy) NotifyEngagement() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for _, s := range t.slots {
+		if s.spent {
+			s.engaged = true
+		}
+	}
+}
+
+// Firings reports how many proactive turns this policy has approved.
+func (t *TriggerPolicy) Firings() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.firings
+}

--- a/cmd/agentchat/README.md
+++ b/cmd/agentchat/README.md
@@ -66,6 +66,35 @@ the primary retries the backup once, the primary is benched for a cooldown,
 and transitions are logged. A stream that already produced output is never
 silently replayed. `/health` shows the current snapshot.
 
+## Events, injected context, and triggers
+
+Configure event streams per server and the host consumes them through two
+policies (both live in the agent module and are fully pluggable for
+embedders):
+
+```json
+"servers": [{ "id": "grocery", "url": "...",
+  "events": [{ "name": "cart.changed",
+    "hint": { "priority": "high",
+              "aggregate": { "windowMs": 2000, "strategy": "merge" },
+              "template": "the cart now holds {{count}} items" } }] }],
+"triggers": [{ "event": "cart.changed",
+  "filter": { "count": "2" },
+  "instructions": "The cart changed. Offer one recipe suggestion.",
+  "label": "recipe-pitch", "cooldownSec": 300 }]
+```
+
+Injection: occurrences buffer per hint (merge, last-wins, or debounce
+windows), render via the template, and join the conversation as system
+messages at the next turn, priority-ordered under a budget; sensitive events
+gate on consent. Host config hints override server-advertised ones (the
+vendor context-hint on events/list).
+
+Triggers: a matching event starts a proactive turn (marked with its label),
+mediated by the anti-nag policy: one firing per binding until the user
+engages AND the cooldown passes, with a session budget on top. Servers can
+suggest triggers; the host decides.
+
 ## Auth modes
 
 `auth.type` selects among the client auth modes MCP supports:

--- a/cmd/agentchat/app.go
+++ b/cmd/agentchat/app.go
@@ -8,10 +8,12 @@ import (
 	"log/slog"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/panyam/mcpkit/agent"
 	"github.com/panyam/mcpkit/client"
 	"github.com/panyam/mcpkit/core"
+	eventsclient "github.com/panyam/mcpkit/experimental/ext/events/clients/go"
 )
 
 // App is agentchat's testable core: everything the binary does minus flag
@@ -25,6 +27,13 @@ type App struct {
 	history  []agent.Message
 	renderer *renderer
 	failover *agent.FailoverProvider
+
+	injection *agent.InjectionPolicy
+	triggers  *agent.TriggerPolicy
+	events    chan agent.IncomingEvent
+	streams   []*eventsclient.StreamCall
+	turnMu    sync.Mutex
+	eventStop context.CancelFunc
 }
 
 // AppOption customizes construction. The provider override exists so tests
@@ -174,6 +183,13 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 		app.failover = fo
 	}
 
+	app.injection = agent.NewInjectionPolicy(agent.InjectionConfig{Hints: hintOverrides(cfg)})
+	app.triggers = agent.NewTriggerPolicy(agent.TriggerPolicyConfig{
+		Bindings: buildTriggerBindings(cfg.Triggers),
+		Logger:   o.logger,
+	})
+	app.events = make(chan agent.IncomingEvent, 256)
+
 	runner, err := agent.NewRunner(agent.RunnerConfig{
 		Provider:       provider,
 		Tools:          multi,
@@ -186,11 +202,32 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 		return nil, err
 	}
 	app.runner = runner
+
+	hasEvents := false
+	for _, sc := range cfg.Servers {
+		hasEvents = hasEvents || len(sc.Events) > 0
+	}
+	if hasEvents {
+		evCtx, cancel := context.WithCancel(context.Background())
+		app.eventStop = cancel
+		if err := app.startEventStreams(evCtx); err != nil {
+			cancel()
+			app.Close()
+			return nil, err
+		}
+		go app.consumeEvents(evCtx)
+	}
 	return app, nil
 }
 
-// Close disconnects every server.
+// Close stops event streams and disconnects every server.
 func (a *App) Close() {
+	if a.eventStop != nil {
+		a.eventStop()
+	}
+	for _, s := range a.streams {
+		s.Stop()
+	}
 	for _, c := range a.clients {
 		c.Close()
 	}
@@ -200,6 +237,10 @@ func (a *App) Close() {
 // threads across turns; a cancelled or failed turn leaves history at its
 // pre-turn state so the next attempt is clean.
 func (a *App) RunTurn(ctx context.Context, input string) error {
+	a.turnMu.Lock()
+	defer a.turnMu.Unlock()
+	a.triggers.NotifyEngagement()
+	a.drainInjectionLocked()
 	a.history = append(a.history, agent.Message{Role: agent.RoleUser, Text: input})
 	result, err := a.runner.Run(ctx, a.history, a.renderer.handle)
 	if err != nil {

--- a/cmd/agentchat/app.go
+++ b/cmd/agentchat/app.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 
+	gocurrent "github.com/panyam/gocurrent"
 	"github.com/panyam/mcpkit/agent"
 	"github.com/panyam/mcpkit/client"
 	"github.com/panyam/mcpkit/core"
@@ -30,7 +31,7 @@ type App struct {
 
 	injection *agent.InjectionPolicy
 	triggers  *agent.TriggerPolicy
-	events    chan agent.IncomingEvent
+	fanIn     *gocurrent.FanIn[agent.IncomingEvent]
 	streams   []*eventsclient.StreamCall
 	turnMu    sync.Mutex
 	eventStop context.CancelFunc
@@ -188,7 +189,6 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 		Bindings: buildTriggerBindings(cfg.Triggers),
 		Logger:   o.logger,
 	})
-	app.events = make(chan agent.IncomingEvent, 256)
 
 	runner, err := agent.NewRunner(agent.RunnerConfig{
 		Provider:       provider,
@@ -210,6 +210,7 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 	if hasEvents {
 		evCtx, cancel := context.WithCancel(context.Background())
 		app.eventStop = cancel
+		app.fanIn = gocurrent.NewFanIn[agent.IncomingEvent]()
 		if err := app.startEventStreams(evCtx); err != nil {
 			cancel()
 			app.Close()
@@ -227,6 +228,9 @@ func (a *App) Close() {
 	}
 	for _, s := range a.streams {
 		s.Stop()
+	}
+	if a.fanIn != nil {
+		a.fanIn.Stop()
 	}
 	for _, c := range a.clients {
 		c.Close()

--- a/cmd/agentchat/config.go
+++ b/cmd/agentchat/config.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+
+	"github.com/panyam/mcpkit/agent"
 )
 
 // Config is agentchat's JSON configuration. Secrets are never inlined:
@@ -22,6 +24,10 @@ type Config struct {
 
 	// Servers lists the MCP servers to connect.
 	Servers []ServerConfig `json:"servers"`
+
+	// Triggers lists proactive-turn bindings over the configured event
+	// streams.
+	Triggers []TriggerConfig `json:"triggers,omitempty"`
 }
 
 // ModelConfig points at an OpenAI-compatible chat-completions endpoint.
@@ -67,6 +73,44 @@ type ServerConfig struct {
 	// auto-detects (servers without the capability are skipped silently);
 	// false opts out even when the server advertises skills.
 	Skills *bool `json:"skills,omitempty"`
+
+	// Events lists the event streams to open on this server. Each event
+	// feeds the injection policy (and any trigger bindings that match).
+	Events []EventConfig `json:"events,omitempty"`
+}
+
+// EventConfig subscribes one event name and optionally overrides its
+// context hint (host config wins over the server-advertised _meta hint).
+type EventConfig struct {
+	Name string `json:"name"`
+
+	// Hint overrides how occurrences reach the model (priority,
+	// aggregation window, template, retention, sensitivity).
+	Hint *agent.ContextHint `json:"hint,omitempty"`
+}
+
+// TriggerConfig declares one proactive-turn binding, mediated by the
+// anti-nag policy (one firing per binding until user engagement plus the
+// cooldown, session budget on top).
+type TriggerConfig struct {
+	// Server and Event select the stream; Server empty matches any.
+	Server string `json:"server,omitempty"`
+	Event  string `json:"event"`
+
+	// Filter is a set of top-level payload field equality checks (all
+	// must match). The config-file rendition of the code-level filter
+	// hook; embedders wanting richer predicates use the agent package
+	// directly.
+	Filter map[string]string `json:"filter,omitempty"`
+
+	// Instructions seed the proactive turn.
+	Instructions string `json:"instructions"`
+
+	// Label names the binding in transcripts and logs.
+	Label string `json:"label"`
+
+	// CooldownSec is the re-arm floor in seconds (0 = default 300).
+	CooldownSec int `json:"cooldownSec,omitempty"`
 }
 
 // AuthConfig selects one of the client auth modes MCP supports. Secrets are

--- a/cmd/agentchat/events.go
+++ b/cmd/agentchat/events.go
@@ -13,40 +13,41 @@ import (
 	eventsclient "github.com/panyam/mcpkit/experimental/ext/events/clients/go"
 )
 
-// startEventStreams opens one events/stream per configured event and feeds
-// occurrences into the app's event channel. Stream callbacks must not block
-// (they run on the per-call SSE reader), so they only convert and enqueue;
-// the app's consumer goroutine runs the policies. A full channel drops the
-// event with a transcript warning: backpressure must never stall the SSE
-// reader, and the injection policy's windows make individual losses benign.
+// startEventStreams opens one events/stream per configured event. Each
+// stream delivers on its own buffered channel (eventsclient.StreamChan, the
+// mechanism half living in the client SDK), gets a per-stream adapter
+// goroutine tagging occurrences with the server id, and merges into one
+// consumer feed via gocurrent's FanIn. Per-stream buffers isolate
+// backpressure: one noisy stream drops its own events (warned), never a
+// sibling's.
 func (a *App) startEventStreams(ctx context.Context) error {
 	for i, sc := range a.cfg.Servers {
 		for _, ec := range sc.Events {
 			serverID := sc.ID
-			opts := eventsclient.StreamOptions{
-				EventName: ec.Name,
-				OnEvent: func(ev eventsclientEvent) {
-					in := adaptEvent(serverID, ev)
-					select {
-					case a.events <- in:
-					default:
-						a.renderer.eventDropped(serverID, in.Name)
-					}
+			eventName := ec.Name
+			ch, call, err := eventsclient.StreamChan(ctx, a.clients[i], eventsclient.ChanStreamOptions{
+				EventName: eventName,
+				OnDrop: func(events.Event) {
+					a.renderer.eventDropped(serverID, eventName)
 				},
-			}
-			call, err := eventsclient.Stream(ctx, a.clients[i], opts)
+			})
 			if err != nil {
-				return fmt.Errorf("agentchat: events/stream %s on %s: %w", ec.Name, serverID, err)
+				return fmt.Errorf("agentchat: events/stream %s on %s: %w", eventName, serverID, err)
 			}
 			a.streams = append(a.streams, call)
+
+			adapted := make(chan agent.IncomingEvent, 16)
+			go func() {
+				defer close(adapted)
+				for ev := range ch {
+					adapted <- adaptEvent(serverID, ev)
+				}
+			}()
+			a.fanIn.Add(adapted)
 		}
 	}
 	return nil
 }
-
-// eventsclientEvent aliases the wire event type so adaptEvent's signature
-// stays readable.
-type eventsclientEvent = events.Event
 
 // consumeEvents is the single goroutine that owns the policy pipeline:
 // ingest into injection, evaluate triggers, and run approved proactive
@@ -57,7 +58,7 @@ func (a *App) consumeEvents(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
-		case ev, ok := <-a.events:
+		case ev, ok := <-a.fanIn.OutputChan():
 			if !ok {
 				return
 			}
@@ -139,7 +140,7 @@ func hintOverrides(cfg *Config) map[string]agent.ContextHint {
 	return out
 }
 
-func adaptEvent(serverID string, ev eventsclientEvent) agent.IncomingEvent {
+func adaptEvent(serverID string, ev events.Event) agent.IncomingEvent {
 	return agent.IncomingEvent{
 		Server: serverID,
 		Name:   ev.Name,

--- a/cmd/agentchat/events.go
+++ b/cmd/agentchat/events.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/panyam/mcpkit/agent"
+	"github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/experimental/ext/events"
+	eventsclient "github.com/panyam/mcpkit/experimental/ext/events/clients/go"
+)
+
+// startEventStreams opens one events/stream per configured event and feeds
+// occurrences into the app's event channel. Stream callbacks must not block
+// (they run on the per-call SSE reader), so they only convert and enqueue;
+// the app's consumer goroutine runs the policies. A full channel drops the
+// event with a transcript warning: backpressure must never stall the SSE
+// reader, and the injection policy's windows make individual losses benign.
+func (a *App) startEventStreams(ctx context.Context) error {
+	for i, sc := range a.cfg.Servers {
+		for _, ec := range sc.Events {
+			serverID := sc.ID
+			opts := eventsclient.StreamOptions{
+				EventName: ec.Name,
+				OnEvent: func(ev eventsclientEvent) {
+					in := adaptEvent(serverID, ev)
+					select {
+					case a.events <- in:
+					default:
+						a.renderer.eventDropped(serverID, in.Name)
+					}
+				},
+			}
+			call, err := eventsclient.Stream(ctx, a.clients[i], opts)
+			if err != nil {
+				return fmt.Errorf("agentchat: events/stream %s on %s: %w", ec.Name, serverID, err)
+			}
+			a.streams = append(a.streams, call)
+		}
+	}
+	return nil
+}
+
+// eventsclientEvent aliases the wire event type so adaptEvent's signature
+// stays readable.
+type eventsclientEvent = events.Event
+
+// consumeEvents is the single goroutine that owns the policy pipeline:
+// ingest into injection, evaluate triggers, and run approved proactive
+// turns (serialized against user turns by the turn mutex inside
+// runProactiveTurn).
+func (a *App) consumeEvents(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ev, ok := <-a.events:
+			if !ok {
+				return
+			}
+			a.injection.Ingest(ev)
+			if firing := a.triggers.OnEvent(ev); firing != nil {
+				a.runProactiveTurn(ctx, firing)
+			}
+		}
+	}
+}
+
+// runProactiveTurn executes a trigger firing as a full turn: the binding's
+// instructions enter history as a system message (alongside any drained
+// event context), the model responds, and the transcript marks the turn
+// with the binding's label.
+func (a *App) runProactiveTurn(ctx context.Context, firing *agent.TriggerFiring) {
+	a.turnMu.Lock()
+	defer a.turnMu.Unlock()
+	a.renderer.triggerFired(firing.Binding.Label)
+	a.history = append(a.history, agent.Message{Role: agent.RoleSystem, Text: firing.Binding.Instructions})
+	a.drainInjectionLocked()
+	result, err := a.runner.Run(ctx, a.history, a.renderer.handle)
+	if err != nil {
+		a.renderer.turnFailed(err)
+		return
+	}
+	a.history = append(a.history, result.Messages...)
+	a.renderer.turnDone(result)
+	a.renderer.prompt()
+}
+
+// drainInjectionLocked moves pending injected context into history as
+// system messages. Caller holds turnMu.
+func (a *App) drainInjectionLocked() {
+	for _, inj := range a.injection.Drain() {
+		a.history = append(a.history, agent.Message{Role: agent.RoleSystem, Text: inj.Text})
+	}
+}
+
+// buildTriggerBindings converts config bindings into policy bindings,
+// rendering the equality filter against top-level payload fields.
+func buildTriggerBindings(cfgs []TriggerConfig) []agent.TriggerBinding {
+	out := make([]agent.TriggerBinding, 0, len(cfgs))
+	for _, tc := range cfgs {
+		b := agent.TriggerBinding{
+			Server:       tc.Server,
+			Event:        tc.Event,
+			Instructions: tc.Instructions,
+			Label:        tc.Label,
+			Cooldown:     time.Duration(tc.CooldownSec) * time.Second,
+		}
+		if len(tc.Filter) > 0 {
+			want := tc.Filter
+			b.Filter = func(ev agent.IncomingEvent) bool {
+				for field, expect := range want {
+					v, ok := ev.Data.Field(field)
+					if !ok || strings.Trim(string(v.Raw()), `"`) != expect {
+						return false
+					}
+				}
+				return true
+			}
+		}
+		out = append(out, b)
+	}
+	return out
+}
+
+// hintOverrides collects the per-event hint overrides from config.
+func hintOverrides(cfg *Config) map[string]agent.ContextHint {
+	out := map[string]agent.ContextHint{}
+	for _, sc := range cfg.Servers {
+		for _, ec := range sc.Events {
+			if ec.Hint != nil {
+				out[ec.Name] = *ec.Hint
+			}
+		}
+	}
+	return out
+}
+
+func adaptEvent(serverID string, ev eventsclientEvent) agent.IncomingEvent {
+	return agent.IncomingEvent{
+		Server: serverID,
+		Name:   ev.Name,
+		ID:     ev.EventID,
+		Cursor: ev.CursorStr(),
+		Time:   time.Now(),
+		Data:   core.NewRawJSON(json.RawMessage(ev.Data)),
+		Meta:   ev.Meta,
+	}
+}

--- a/cmd/agentchat/events_test.go
+++ b/cmd/agentchat/events_test.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/panyam/mcpkit/agent"
+	"github.com/panyam/mcpkit/experimental/ext/events"
+	"github.com/panyam/mcpkit/server"
+	"github.com/panyam/mcpkit/testutil"
+	"net/http/httptest"
+)
+
+type syncWriter struct {
+	mu sync.Mutex
+	b  strings.Builder
+}
+
+func (w *syncWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.b.Write(p)
+}
+
+func (w *syncWriter) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.b.String()
+}
+
+type cartData struct {
+	Count int `json:"count"`
+}
+
+func startEventsServer(t *testing.T) (*httptest.Server, func(context.Context, cartData) error) {
+	t.Helper()
+	srv := testutil.NewTestServer()
+	src, yield := events.NewYieldingSource[cartData](events.EventDef{
+		Name:        "cart.changed",
+		Description: "cart contents changed",
+	})
+	events.Register(events.Config{
+		Sources:                  []events.EventSource{src},
+		Server:                   srv,
+		UnsafeAnonymousPrincipal: "agentchat-test",
+	})
+	ts := httptest.NewServer(srv.Handler(server.WithStreamableHTTP(true)))
+	t.Cleanup(ts.Close)
+	return ts, yield
+}
+
+func waitFor(t *testing.T, out *syncWriter, want string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if strings.Contains(out.String(), want) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %q in transcript:\n%s", want, out.String())
+}
+
+func TestAppEventsInjectionAndTriggerEndToEnd(t *testing.T) {
+	ts, yield := startEventsServer(t)
+
+	cfg := testConfig(ts.URL)
+	cfg.Instructions = "base"
+	cfg.Servers[0].Events = []EventConfig{{
+		Name: "cart.changed",
+		Hint: &agent.ContextHint{
+			Aggregate: &agent.AggregateHint{WindowMs: 300, Strategy: agent.WindowMerge},
+			Template:  "the cart now holds {{count}} items",
+		},
+	}}
+	cfg.Triggers = []TriggerConfig{{
+		Event:        "cart.changed",
+		Filter:       map[string]string{"count": "2"},
+		Instructions: "The user's cart changed. Offer exactly one recipe suggestion.",
+		Label:        "recipe-pitch",
+		CooldownSec:  3600,
+	}}
+
+	stub := agent.NewStubProvider(
+		agent.StubTurn{Text: "How about pasta tonight?"},
+		agent.StubTurn{Text: "Your cart has 3 items."},
+	)
+	out := &syncWriter{}
+	app, err := NewApp(cfg, out, strings.NewReader(""), WithProvider(stub))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Close()
+
+	// A qualifying event fires the trigger exactly once.
+	if err := yield(context.Background(), cartData{Count: 2}); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, out, "· trigger: recipe-pitch")
+	waitFor(t, out, "How about pasta tonight?")
+
+	proactive := stub.Requests()[0]
+	var sawInstr bool
+	for _, m := range proactive.Messages {
+		if m.Role == agent.RoleSystem && strings.Contains(m.Text, "Offer exactly one recipe suggestion") {
+			sawInstr = true
+		}
+	}
+	if !sawInstr {
+		t.Fatalf("proactive turn must carry the binding instructions as a system message: %+v", proactive.Messages)
+	}
+
+	// More qualifying events: the spent slot stays quiet (anti-nag).
+	yield(context.Background(), cartData{Count: 2})
+	yield(context.Background(), cartData{Count: 2})
+	time.Sleep(400 * time.Millisecond)
+	if n := strings.Count(out.String(), "· trigger: recipe-pitch"); n != 1 {
+		t.Fatalf("spent slot must not re-fire, got %d pitches:\n%s", n, out.String())
+	}
+
+	// The burst coalesced in the merge window and injects on the next
+	// user turn as one system message.
+	yield(context.Background(), cartData{Count: 3})
+	time.Sleep(400 * time.Millisecond)
+	if err := app.RunTurn(context.Background(), "what's in my cart?"); err != nil {
+		t.Fatal(err)
+	}
+	userReq := stub.Requests()[1]
+	var injected []string
+	for _, m := range userReq.Messages {
+		if m.Role == agent.RoleSystem && strings.Contains(m.Text, "cart now holds") {
+			injected = append(injected, m.Text)
+		}
+	}
+	if len(injected) != 1 || !strings.Contains(injected[0], "3 items") {
+		t.Fatalf("burst must inject as ONE coalesced system message with the latest count: %v\nall: %+v", injected, userReq.Messages)
+	}
+}
+
+func TestAppEventsWithoutHintsDegradesToRawInjection(t *testing.T) {
+	ts, yield := startEventsServer(t)
+	cfg := testConfig(ts.URL)
+	cfg.Servers[0].Events = []EventConfig{{Name: "cart.changed"}}
+
+	stub := agent.NewStubProvider(agent.StubTurn{Text: "ok"})
+	out := &syncWriter{}
+	app, err := NewApp(cfg, out, strings.NewReader(""), WithProvider(stub))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Close()
+
+	yield(context.Background(), cartData{Count: 7})
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		app.turnMu.Lock()
+		app.drainInjectionLocked()
+		n := len(app.history)
+		app.turnMu.Unlock()
+		if n > 0 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	app.turnMu.Lock()
+	defer app.turnMu.Unlock()
+	if len(app.history) == 0 || app.history[0].Role != agent.RoleSystem ||
+		!strings.Contains(app.history[0].Text, `event cart.changed from test`) {
+		t.Fatalf("hintless event must inject raw, immediately: %+v", app.history)
+	}
+}

--- a/cmd/agentchat/go.mod
+++ b/cmd/agentchat/go.mod
@@ -3,6 +3,7 @@ module github.com/panyam/mcpkit/cmd/agentchat
 go 1.26.4
 
 require (
+	github.com/panyam/gocurrent v0.1.1
 	github.com/panyam/mcpkit v0.4.0-b2
 	github.com/panyam/mcpkit/agent v0.0.0
 	github.com/panyam/mcpkit/experimental/ext/events v0.0.0
@@ -41,7 +42,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/invopop/jsonschema v0.13.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
-	github.com/panyam/gocurrent v0.1.1 // indirect
 	github.com/panyam/goutils v0.1.8 // indirect
 	github.com/panyam/oneauth v0.1.31 // indirect
 	github.com/panyam/servicekit v0.1.2 // indirect

--- a/cmd/agentchat/go.mod
+++ b/cmd/agentchat/go.mod
@@ -5,6 +5,8 @@ go 1.26.4
 require (
 	github.com/panyam/mcpkit v0.4.0-b2
 	github.com/panyam/mcpkit/agent v0.0.0
+	github.com/panyam/mcpkit/experimental/ext/events v0.0.0
+	github.com/panyam/mcpkit/experimental/ext/events/clients/go v0.0.0
 	github.com/panyam/mcpkit/ext/auth v0.0.0
 	github.com/panyam/mcpkit/ext/otel v0.3.1
 	github.com/panyam/mcpkit/ext/skills v0.0.0
@@ -26,6 +28,7 @@ require (
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fernet/fernet-go v0.0.0-20240119011108-303da6aec611 // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
@@ -43,12 +46,14 @@ require (
 	github.com/panyam/oneauth v0.1.31 // indirect
 	github.com/panyam/servicekit v0.1.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
+	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
@@ -80,3 +85,7 @@ replace github.com/panyam/mcpkit/ext/auth => ../../ext/auth
 replace github.com/panyam/mcpkit/ext/skills => ../../ext/skills
 
 replace github.com/panyam/mcpkit/ext/otel => ../../ext/otel
+
+replace github.com/panyam/mcpkit/experimental/ext/events => ../../experimental/ext/events
+
+replace github.com/panyam/mcpkit/experimental/ext/events/clients/go => ../../experimental/ext/events/clients/go

--- a/cmd/agentchat/render.go
+++ b/cmd/agentchat/render.go
@@ -154,3 +154,11 @@ func (r *renderer) health(f *agent.FailoverProvider) {
 	}
 	fmt.Fprintf(r.out, "%s\n", r.dim(line))
 }
+
+func (r *renderer) triggerFired(label string) {
+	fmt.Fprintf(r.out, "\n%s\n", r.dim("· trigger: "+label))
+}
+
+func (r *renderer) eventDropped(serverID, name string) {
+	fmt.Fprintf(r.out, "%s\n", r.dim("warning: event buffer full, dropped "+name+" from "+serverID))
+}

--- a/docs/AGENT_DESIGN.md
+++ b/docs/AGENT_DESIGN.md
@@ -75,6 +75,10 @@ Two narrowing mechanisms with distinct roles (issues 901/902):
 
 The purity rule that keeps the lifecycle single-sourced: selectors are pure functions of (history, freshly listed tools). Invalidation has exactly one channel: notifications/tools/list_changed -> client.WithToolsListChangedHandler -> MultiSource.Invalidate, after which per-step re-listing picks up the change. A caching selector keys on tool-list content, never on time or notifications. Searchable/deferred tools (a search_tools meta-tool exposing schemas on demand) remain future work.
 
+### Event pipeline primitives and gocurrent
+
+The generic stages (Stage[E], Filter, Transform, Window) are deliberately synchronous, caller-driven, and clock-injected: the policies drain at turn boundaries under the host's own locking, and every windowing test runs on a fake clock. gocurrent already ships the asynchronous complement (Pipeline[T] channel components, Mapper, Broadcast filters, Reducer with FlushPeriod), and the two compose without adaptation: async pre-processing can feed InjectionPolicy.Ingest from a gocurrent component's output channel. The pushdown position, settled 2026-07-16: when a second consumer of the synchronous stages appears, they graduate INTO gocurrent as a new surface (renamed; gocurrent.Pipeline already means the channel component), never replace it, and the agent module re-imports. Until then they live here to avoid cross-repo release ordering for a single consumer.
+
 ### Policy hooks
 
 Two seams, both no-op by default:

--- a/experimental/ext/events/clients/go/stream_chan.go
+++ b/experimental/ext/events/clients/go/stream_chan.go
@@ -1,0 +1,63 @@
+package eventsclient
+
+import (
+	"context"
+
+	"github.com/panyam/mcpkit/client"
+	"github.com/panyam/mcpkit/experimental/ext/events"
+)
+
+// ChanStreamOptions configures StreamChan.
+type ChanStreamOptions struct {
+	// EventName is the source to stream. Required.
+	EventName string
+
+	// Buffer sizes the delivery channel (default 64). When the consumer
+	// falls behind and the buffer fills, events are dropped through
+	// OnDrop rather than blocking: the SSE reader that produces them
+	// must never stall on a slow consumer.
+	Buffer int
+
+	// OnDrop observes events discarded on a full buffer. Nil discards
+	// silently.
+	OnDrop func(events.Event)
+
+	// Cursor and Arguments pass through to the underlying stream call.
+	Cursor    *string
+	Arguments map[string]any
+}
+
+// StreamChan opens an events/stream call and delivers occurrences on a
+// channel instead of a callback: the mechanism half of event consumption,
+// so hosts compose channels (fan-in, mappers, pipelines) rather than
+// nesting callbacks. The channel closes when the stream ends (Stop, ctx
+// cancellation, or server termination).
+func StreamChan(ctx context.Context, sess *client.Client, opts ChanStreamOptions) (<-chan events.Event, *StreamCall, error) {
+	buf := opts.Buffer
+	if buf <= 0 {
+		buf = 64
+	}
+	ch := make(chan events.Event, buf)
+	call, err := Stream(ctx, sess, StreamOptions{
+		EventName: opts.EventName,
+		Cursor:    opts.Cursor,
+		Arguments: opts.Arguments,
+		OnEvent: func(ev events.Event) {
+			select {
+			case ch <- ev:
+			default:
+				if opts.OnDrop != nil {
+					opts.OnDrop(ev)
+				}
+			}
+		},
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	go func() {
+		<-call.Done()
+		close(ch)
+	}()
+	return ch, call, nil
+}


### PR DESCRIPTION
Implements issues 893 and 894 together, completing milestone 4 of the agent epic (issue 895). These are the payoff tickets: the working reference implementations behind the context-hints and triggers SEP drafts in docs/cip/.

## What changes

Connected servers' events now reach the model on the host's terms. An InjectionPolicy buffers occurrences per event (merge / last-wins / debounce windows), renders them (template or raw), and releases them as system messages in priority order under a budget with a consent gate for sensitive data. A TriggerPolicy turns qualifying events into proactive agent turns, mediated by the anti-nag slot machine: one firing per binding until the user engages AND a cooldown passes, session budget on top. In agentchat: config-driven event streams, hints, and trigger bindings; a proactive turn renders with its label.

## Reviewer's guide

Read in this order:
1. [agent/stages.go](https://github.com/panyam/mcpkit/pull/912/files#diff-8857194cfc87fe75755a6c90093ac1804f84b7b01ab1681dba73220c15261a8c) — the layering decision from design review: Stage[E]/Pipeline[E]/Filter/Transform/Window are generic, zero-MCP-import machinery (promotable to any consumer unchanged); TypedFilter/TypedTransform/MergeWith are the payload-typed hooks.
2. [agent/injection.go](https://github.com/panyam/mcpkit/pull/912/files#diff-8b587a886a9fbe60e4d6832e7b3253a8ad5bee98ce0059ae49bc0951e4d28bd0) — ContextHint (the SEP draft shape one-for-one), vendor _meta extraction with host-config override, and Drain, where the budget applies AFTER priority ordering.
3. [agent/triggers.go](https://github.com/panyam/mcpkit/pull/912/files#diff-31fbf33129473581024f927aafc2aceb2ffce9e9daf4bf2a7b6de7612dad6152) — the slot machine: spent-until-engagement-plus-cooldown, budget, consent, suppressions logged never surfaced.
4. [agent/policy_test.go](https://github.com/panyam/mcpkit/pull/912/files#diff-52ea94a567dc7195fe8cd13af59d3f3cbb4558bfd6b6c73aba6e8f53080289f0) — the behavior matrix: every window strategy under an injected clock, priority/budget, sensitivity/consent, session retention, typed stages, meta hints, slot machine, generic-promotability proof (the stages run on plain ints).
5. [cmd/agentchat/events.go](https://github.com/panyam/mcpkit/pull/912/files#diff-641e4c58ede73640daed02271e97997f2225e7ceba94928f7c66cabeff7c27a6) + `events_test.go` — stream wiring (non-blocking callbacks, single consumer goroutine, turn mutex) and the grocery-acceptance e2e against a real yielding-source server.
6. [agent/incoming_event.go](https://github.com/panyam/mcpkit/pull/912/files#diff-78b14745fcec2418b20ac675f0d571791c2e6f7f14f9440991013a273ef0f3ee), [cmd/agentchat/config.go](https://github.com/panyam/mcpkit/pull/912/files#diff-ed86469b1226f1822576088ed7b29a408a1166a890d198ec5ef81cdd18a2dbde), `render.go`, `README.md` — the neutral event shape and config surface.

## Diff groups

- Policy engines + primitives (agent): stages.go, injection.go, triggers.go, incoming_event.go, provider.go (RoleSystem)
- Wiring (agentchat): events.go, app.go, config.go, render.go
- Tests: policy_test.go, events_test.go

## How it works (pseudocode walkthrough)

```
event arrives (stream callback, must not block):
  adapt -> enqueue (full buffer: drop + warn; windows make losses benign)

consumer goroutine:
  injection.Ingest(ev):
    developer Filters/Transforms -> hint lookup (config beats _meta)
    -> window per event name (merge folds, last-wins replaces,
       debounce restarts the deadline) or straight to pending
  triggers.OnEvent(ev):
    match binding -> slot OPEN? budget? consent? -> SPENT + firing
  firing -> proactive turn under the turn mutex:
    history += RoleSystem(binding.instructions) + drained context
    run the Runner as usual, label the transcript

any turn (user or proactive):
  NotifyEngagement (user turns) -> drain:
    flush expired windows -> consent-gate -> SORT BY PRIORITY ->
    apply budget (overflow carries; session-retention re-injects
    latest until superseded) -> RoleSystem messages
```

The line a reviewer would pause on: Drain sorts before budgeting. The first cut budgeted in arrival order and the test caught low-priority arrivals starving critical entries; the fix is load-bearing and pinned.

## Decision log

- **Policies in agent, mechanisms generic** (design review with the user): injection and triggers are host concepts (context budget, prompts, turns, engagement) and stay in the host layer per the SEP drafts' own doctrine; the pipeline primitives are generic machinery with a named promotion path (eventsclient or gocurrent) once a second consumer exists, proven by testing them on plain ints.
- **RoleSystem as the injection carrier**: drained context and trigger instructions enter history as system messages, exactly CIP's semantics; providers map the role through the existing default branch (wire shape pinned by test, zero provider changes).
- **Deterministic anti-nag approximation**: re-arm = engagement AND cooldown, a faithful port of the playbook's Tier-1 slots with the LLM positive-engagement signal documented as the future upgrade rather than half-built.
- **Streams, not webhooks, not plain notifications**: events/stream rides the MCP connection per-call (no public callback URL), and the events extension carries names/schemas/cursors that bare notifications lack — the corrections section of the gap analysis, applied.
- **Full event buffer drops with a warning** instead of blocking: the SSE reader must never stall; windows make individual losses benign, and the warning keeps it honest.

## Review follow-ups (folded)

- **Consumption mechanism pushed down + FanIn adopted** (review questions): eventsclient gains StreamChan (channel-based delivery with per-stream buffering and drop-with-callback), and agentchat merges per-stream adapted channels through gocurrent's FanIn instead of a shared hand-rolled channel. Per-stream buffers isolate backpressure; the drop warning is now per stream. The listen/consume mechanism lives in the client SDK, composition in the host, policy in the agent — the layering rule applied once more.
- **Topology**: one mcpkit client per server, one events/stream call per event on that shared session (per-call notify hooks give stream isolation without extra connections).
- **gocurrent relationship documented** in AGENT_DESIGN.md: the synchronous clock-injected stages here are the complement of gocurrent's async channel components; they compose today, and the stages graduate into gocurrent (renamed) on a second consumer.

## Risk / blast radius

- Affects: agent module (all additive) and cmd/agentchat (new deps: experimental events + its Go client + gocurrent, agentchat only; eventsclient gains StreamChan — the agent module gained zero dependencies).
- Tests: 12 new test functions (9 agent + 3 wiring/e2e... 10+2), ~85 assertions added, 0 removed or weakened; both suites under -race (the e2e exercises the real stream goroutines).
- Be paranoid about: Drain's carry semantics (overflow returns to pending, session entries never do), the turn mutex covering both proactive and user turns, and window Flush cascading through later pipeline stages.

## Before / after

Before: events reach the client and stop; proactive behavior requires a bespoke engine.

After, the e2e transcript (real server, real stream, scripted model):

```
· trigger: recipe-pitch
How about pasta tonight?
— 1 step(s), 0 in / 0 out tokens
> what's in my cart?
Your cart has 3 items.
```

With the model's actual context (asserted): the proactive turn carries the binding instructions as a system message; the user turn carries exactly ONE coalesced system message, "the cart now holds 3 items", from a three-event burst. Two more qualifying events after the pitch: zero additional pitches.

Mutation red-checks (slot never spends; debounce never restarts — both restored):

```
--- FAIL: TestTriggerSlotMachine
--- FAIL: TestInjectionDebounceRestartsWindow
```

## Out of scope (deliberately deferred)

- Batch elicitation coordination → issue 904 (the window machinery it wanted now exists; noted there after merge)
- LLM-based positive-engagement signal → documented on TriggerPolicy as the upgrade path
- Server-advertised trigger auto-install (MetaKeyTrigger is defined; agentchat installs config bindings only — hosts decide)
- Pipeline-primitive promotion to eventsclient/gocurrent → on the second consumer
- events/list _meta hint auto-discovery in agentchat (SetHint exists; wiring it needs an events/list call per server — small follow-up)

