### PR TITLE
feat(client,agent,agentchat): task-aware dispatch (issue 890)

### DIFF
--- a/agent/client_source.go
+++ b/agent/client_source.go
@@ -15,12 +15,6 @@ import (
 // callers can detect the condition with errors.Is.
 var ErrInputRequired = errors.New("agent: tool requires mid-call input and no InputHandler is configured")
 
-// ErrTaskResult is returned by ClientSource.Call when the server elects to
-// run the tool as a SEP-2663 task. Task-aware dispatch (polling, resume) is
-// a later milestone; until then the Runner surfaces this as a dispatch
-// failure rather than silently dropping the task.
-var ErrTaskResult = errors.New("agent: tool returned a task; task-aware dispatch is not configured")
-
 // ClientSource adapts one connected client.Client into a ToolSource.
 //
 // Calls go through the client's MRTR-aware path so ctx cancellation reaches
@@ -28,8 +22,9 @@ var ErrTaskResult = errors.New("agent: tool returned a task; task-aware dispatch
 // default configuration an input-required round fails with ErrInputRequired
 // instead of hanging or guessing.
 type ClientSource struct {
-	c       *client.Client
-	handler client.InputHandler
+	c            *client.Client
+	handler      client.InputHandler
+	onTaskStatus func(*core.DetailedTask)
 }
 
 // ClientSourceOption configures a ClientSource.
@@ -40,6 +35,13 @@ type ClientSourceOption func(*ClientSource)
 // through this option; tests can use it to script input rounds.
 func WithInputHandler(h client.InputHandler) ClientSourceOption {
 	return func(s *ClientSource) { s.handler = h }
+}
+
+// WithTaskStatusHook observes every polled task snapshot during task-backed
+// tool calls: the client-level WaitOptions.OnStatus threaded through, so
+// surfaces can render progress between tool-begin and tool-end.
+func WithTaskStatusHook(fn func(*core.DetailedTask)) ClientSourceOption {
+	return func(s *ClientSource) { s.onTaskStatus = fn }
 }
 
 // NewClientSource wraps a connected client. The client must already be
@@ -64,8 +66,12 @@ func (s *ClientSource) Tools(ctx context.Context) ([]core.ToolDef, error) {
 }
 
 // Call dispatches tools/call with automatic MRTR rounds via the configured
-// InputHandler. A task-creating response maps to ErrTaskResult until
-// task-aware dispatch lands.
+// InputHandler. A task-creating response is waited to a terminal state:
+// polling honors the server's interval hints, input_required pauses resolve
+// through the SAME InputHandler (so task input reaches the elicitation seam
+// with no extra wiring), and the terminal snapshot maps back onto the sync
+// contract (completed carries the ToolResult, including tool-side IsError;
+// failed and cancelled are dispatch errors).
 func (s *ClientSource) Call(ctx context.Context, name string, args map[string]any) (*core.ToolResult, error) {
 	res, err := client.CallToolWithInputs(ctx, s.c, name, args, s.handler)
 	if err != nil {
@@ -75,8 +81,33 @@ func (s *ClientSource) Call(ctx context.Context, name string, args map[string]an
 	case res.Sync != nil:
 		return res.Sync, nil
 	case res.Task != nil:
-		return nil, fmt.Errorf("%w (task %s)", ErrTaskResult, res.Task.TaskID)
+		return s.waitTask(ctx, name, res.Task.TaskID)
 	default:
 		return nil, fmt.Errorf("agent: unexpected tool call result shape for %q", name)
+	}
+}
+
+func (s *ClientSource) waitTask(ctx context.Context, name, taskID string) (*core.ToolResult, error) {
+	dt, err := client.WaitForTaskWithInput(ctx, s.c, taskID, s.handler,
+		client.WaitOptions{OnStatus: s.onTaskStatus})
+	if err != nil {
+		return nil, err
+	}
+	switch dt.Status {
+	case core.TaskCompleted:
+		if dt.Result == nil {
+			return nil, fmt.Errorf("agent: task %s (%s) completed without a result", taskID, name)
+		}
+		return dt.Result, nil
+	case core.TaskFailed:
+		msg := "unknown error"
+		if dt.Error != nil {
+			msg = dt.Error.Message
+		}
+		return nil, fmt.Errorf("agent: task %s (%s) failed: %s", taskID, name, msg)
+	case core.TaskCancelled:
+		return nil, fmt.Errorf("agent: task %s (%s) was cancelled", taskID, name)
+	default:
+		return nil, fmt.Errorf("agent: task %s (%s) ended in unexpected status %q", taskID, name, dt.Status)
 	}
 }

--- a/agent/task_dispatch_test.go
+++ b/agent/task_dispatch_test.go
@@ -1,0 +1,169 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/panyam/mcpkit/client"
+	"github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/server"
+)
+
+// taskFixture is a hand-rolled SEP-2663 server: one task-returning tool plus
+// tasks/get and tasks/update over custom method handlers. Deliberately not
+// ext/tasks, so the agent module's dependency set stays core+client+server.
+type taskFixture struct {
+	mu        sync.Mutex
+	polls     int
+	responses core.InputResponses
+	failMode  bool
+}
+
+func (f *taskFixture) server(t *testing.T) *server.Server {
+	t.Helper()
+	srv := server.NewServer(core.ServerInfo{Name: "task-fixture", Version: "0.0.1"})
+	srv.RegisterTool(
+		core.ToolDef{Name: "long_job", Description: "task-backed job", InputSchema: map[string]any{"type": "object"}},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+			return core.CreateTaskResult{
+				ResultType: core.ResultTypeTask,
+				TaskInfoV2: core.TaskInfoV2{
+					TaskID: "t-1", Status: core.TaskWorking,
+					CreatedAt: "2026-07-16T00:00:00Z", LastUpdatedAt: "2026-07-16T00:00:00Z",
+					TTLMs: core.IntPtr(60000), PollIntervalMs: core.IntPtr(1),
+				},
+			}, nil
+		},
+	)
+	srv.HandleMethod("tasks/get", func(ctx core.MethodContext, id json.RawMessage, params json.RawMessage) *core.Response {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		f.polls++
+		dt := core.DetailedTask{TaskInfoV2: core.TaskInfoV2{
+			TaskID: "t-1", CreatedAt: "2026-07-16T00:00:00Z", LastUpdatedAt: "2026-07-16T00:00:00Z",
+			TTLMs: core.IntPtr(60000), PollIntervalMs: core.IntPtr(1),
+		}}
+		switch {
+		case f.failMode && f.polls >= 2:
+			dt.Status = core.TaskFailed
+			dt.Error = &core.TaskError{Code: -32000, Message: "disk full"}
+		case f.responses != nil:
+			dt.Status = core.TaskCompleted
+			name, _ := decodeName(f.responses["confirm"])
+			dt.Result = &core.ToolResult{Content: []core.Content{{Type: "text", Text: "job done for " + name}}}
+		case f.polls >= 2:
+			dt.Status = core.TaskInputRequired
+			dt.InputRequests = core.InputRequests{
+				"confirm": core.NewElicitationInputRequest(core.ElicitationRequest{
+					Message:         "Who is this job for?",
+					RequestedSchema: json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}`),
+				}),
+			}
+		default:
+			dt.Status = core.TaskWorking
+		}
+		return methodResult(id, dt)
+	})
+	srv.HandleMethod("tasks/update", func(ctx core.MethodContext, id json.RawMessage, params json.RawMessage) *core.Response {
+		var req core.UpdateTaskRequest
+		json.Unmarshal(params, &req)
+		f.mu.Lock()
+		f.responses = req.InputResponses
+		f.mu.Unlock()
+		return methodResult(id, core.UpdateTaskResult{})
+	})
+	return srv
+}
+
+func decodeName(raw json.RawMessage) (string, error) {
+	var er struct {
+		Content struct {
+			Name string `json:"name"`
+		} `json:"content"`
+	}
+	err := json.Unmarshal(raw, &er)
+	return er.Content.Name, err
+}
+
+func methodResult(id json.RawMessage, v any) *core.Response {
+	return &core.Response{JSONRPC: "2.0", ID: id, Result: v}
+}
+
+func connectTaskSource(t *testing.T, f *taskFixture, ui ElicitationUI) (*ClientSource, *[]core.TaskStatus) {
+	t.Helper()
+	ts := httptest.NewServer(f.server(t).Handler(server.WithStreamableHTTP(true)))
+	t.Cleanup(ts.Close)
+	coord := NewElicitationCoordinator(ui)
+	c := client.NewClient(ts.URL+"/mcp", core.ClientInfo{Name: "task-test", Version: "1.0"},
+		client.WithElicitationHandler(coord.Handler()))
+	if err := c.Connect(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { c.Close() })
+
+	var seen []core.TaskStatus
+	src := NewClientSource(c,
+		WithInputHandler(client.DefaultInputHandler(c)),
+		WithTaskStatusHook(func(dt *core.DetailedTask) { seen = append(seen, dt.Status) }),
+	)
+	return src, &seen
+}
+
+func TestTaskDispatchWithInputPause(t *testing.T) {
+	f := &taskFixture{}
+	src, seen := connectTaskSource(t, f, func(ctx context.Context, req core.ElicitationRequest) (core.ElicitationResult, error) {
+		if req.Message != "Who is this job for?" {
+			t.Errorf("unexpected elicitation: %+v", req)
+		}
+		return core.ElicitationResult{Action: "accept", Content: map[string]any{"name": "Ada"}}, nil
+	})
+
+	res, err := src.Call(context.Background(), "long_job", map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError || res.Content[0].Text != "job done for Ada" {
+		t.Fatalf("result = %+v", res)
+	}
+	var sawWorking, sawInput, sawDone bool
+	for _, s := range *seen {
+		switch s {
+		case core.TaskWorking:
+			sawWorking = true
+		case core.TaskInputRequired:
+			sawInput = true
+		case core.TaskCompleted:
+			sawDone = true
+		}
+	}
+	if !sawWorking || !sawInput || !sawDone {
+		t.Fatalf("status hook must observe the lifecycle, saw %v", *seen)
+	}
+}
+
+func TestTaskDispatchFailureMapsToError(t *testing.T) {
+	f := &taskFixture{failMode: true}
+	src, _ := connectTaskSource(t, f, func(ctx context.Context, req core.ElicitationRequest) (core.ElicitationResult, error) {
+		return core.ElicitationResult{Action: "accept"}, nil
+	})
+	_, err := src.Call(context.Background(), "long_job", map[string]any{})
+	if err == nil || !strings.Contains(err.Error(), "disk full") {
+		t.Fatalf("failed task must surface its error: %v", err)
+	}
+}
+
+func TestTaskDispatchCancelledContextAborts(t *testing.T) {
+	f := &taskFixture{}
+	src, _ := connectTaskSource(t, f, func(ctx context.Context, req core.ElicitationRequest) (core.ElicitationResult, error) {
+		return core.ElicitationResult{Action: "accept", Content: map[string]any{"name": "x"}}, nil
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := src.Call(ctx, "long_job", map[string]any{}); err == nil {
+		t.Fatal("cancelled ctx must abort the task wait")
+	}
+}

--- a/client/list_changed_test.go
+++ b/client/list_changed_test.go
@@ -1,6 +1,7 @@
 package client_test
 
 import (
+	"context"
 	"fmt"
 	"net/http/httptest"
 	"sync/atomic"
@@ -91,5 +92,11 @@ func TestWithoutToolsListChangedHandler_NoFire(t *testing.T) {
 	}
 	if generic.Load() == 0 {
 		t.Fatal(fmt.Sprint("generic callback should observe the broadcast; got none"))
+	}
+}
+
+func TestWaitForTaskWithInputRequiresHandler(t *testing.T) {
+	if _, err := client.WaitForTaskWithInput(context.Background(), nil, "t-1", nil); err == nil {
+		t.Fatal("nil handler must be rejected before any network use")
 	}
 }

--- a/client/tasks.go
+++ b/client/tasks.go
@@ -18,6 +18,7 @@ package client
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -32,6 +33,13 @@ type WaitOptions struct {
 	// 0 (the default) means: respect whatever the server returned, with a
 	// 1-second floor and a 30-second cap if the server didn't say.
 	PollInterval time.Duration
+
+	// OnStatus observes every polled snapshot (WaitForTask and
+	// WaitForTaskWithInput), including the input_required snapshot before
+	// any handler runs. Progress display, logging, and metrics hang off
+	// this; returning is the only control (observation, not steering).
+	// Nil skips.
+	OnStatus func(*core.DetailedTask)
 }
 
 // ToolCallResult is the discriminated union returned by ToolCall. Exactly
@@ -237,8 +245,71 @@ func WaitForTask(ctx context.Context, c *Client, taskID string, opts ...WaitOpti
 		if err != nil {
 			return nil, err
 		}
+		if len(opts) > 0 && opts[0].OnStatus != nil {
+			opts[0].OnStatus(dt)
+		}
 		if dt.Status.IsTerminal() {
 			return dt, nil
+		}
+
+		wait := nextPollWait(override, dt.PollIntervalMs)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(wait):
+		}
+	}
+}
+
+// WaitForTaskWithInput polls like WaitForTask but also services
+// input_required pauses: the pending inputRequests are resolved through
+// handler (the same InputHandler shape CallToolWithInputs uses for
+// ephemeral MRTR, so one handler covers mid-call input on both the
+// ephemeral and task-backed paths), delivered via tasks/update, and polling
+// continues to a terminal state. A handler error aborts the wait; the task
+// keeps running server-side and can be resumed by a later call or
+// cancelled explicitly.
+//
+// This is the "tighter loop" WaitForTask's doc alludes to: WaitForTask
+// deliberately never answers input (its callers poll fire-and-forget
+// workloads), so its behavior is unchanged.
+func WaitForTaskWithInput(ctx context.Context, c *Client, taskID string, handler InputHandler, opts ...WaitOptions) (*core.DetailedTask, error) {
+	if handler == nil {
+		return nil, errors.New("WaitForTaskWithInput: handler is required")
+	}
+	var override time.Duration
+	var onStatus func(*core.DetailedTask)
+	if len(opts) > 0 {
+		override = opts[0].PollInterval
+		onStatus = opts[0].OnStatus
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		dt, err := GetTask(c, taskID)
+		if err != nil {
+			return nil, err
+		}
+		if onStatus != nil {
+			onStatus(dt)
+		}
+		if dt.Status.IsTerminal() {
+			return dt, nil
+		}
+		if dt.Status == core.TaskInputRequired && len(dt.InputRequests) > 0 {
+			responses, err := handler(ctx, dt.InputRequests)
+			if err != nil {
+				return nil, fmt.Errorf("task %s input: %w", taskID, err)
+			}
+			if err := UpdateTask(c, core.UpdateTaskRequest{TaskID: taskID, InputResponses: responses}); err != nil {
+				return nil, err
+			}
+			continue
 		}
 
 		wait := nextPollWait(override, dt.PollIntervalMs)

--- a/cmd/agentchat/README.md
+++ b/cmd/agentchat/README.md
@@ -155,11 +155,13 @@ mints, and connect with `authTokenEnv`. The bearer flows through
 `client.WithClientBearerToken`; OAuth token sources are wired the same way in
 config once a flow needs them.
 
-**Tasks v2** (`examples/tasks-v2`): connects and lists tools, but calling a
-task-returning tool currently fails fast with a task-not-supported dispatch
-error fed back to the model. Task-aware dispatch (poll/resume, input pauses
-through the same elicitation prompts) is the next agent-epic ticket; this
-note is the honest boundary of what agentchat does today.
+**Tasks v2** (`examples/tasks-v2`): task-returning tools work end to end.
+agentchat negotiates the tasks extension, polls task-backed calls to a
+terminal state (honoring server poll hints), renders status transitions as
+dim `· task <id>: <status>` lines, and routes input_required pauses through
+the same terminal elicitation prompts as everything else — one InputHandler
+covers ephemeral MRTR and task-backed pauses alike. Try `confirm_delete` or
+`multi_input` from the example.
 
 ## Testing
 

--- a/cmd/agentchat/app.go
+++ b/cmd/agentchat/app.go
@@ -99,6 +99,7 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 	for _, sc := range cfg.Servers {
 		copts := []client.ClientOption{
 			client.WithGetSSEStream(),
+			client.WithTasksExtension(),
 			client.WithElicitationHandler(coord.Handler()),
 			client.WithToolsListChangedHandler(multi.Invalidate),
 			client.WithTracerProvider(o.tp),
@@ -119,7 +120,8 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 		app.clients = append(app.clients, c)
 
 		var src agent.ToolSource = agent.NewClientSource(c,
-			agent.WithInputHandler(client.DefaultInputHandler(c)))
+			agent.WithInputHandler(client.DefaultInputHandler(c)),
+			agent.WithTaskStatusHook(func(dt *core.DetailedTask) { rend.taskStatus(dt) }))
 		if len(sc.Allow) > 0 {
 			allowed := make(map[string]bool, len(sc.Allow))
 			for _, name := range sc.Allow {

--- a/cmd/agentchat/go.mod
+++ b/cmd/agentchat/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/panyam/mcpkit/ext/auth v0.0.0
 	github.com/panyam/mcpkit/ext/otel v0.3.1
 	github.com/panyam/mcpkit/ext/skills v0.0.0
+	github.com/panyam/mcpkit/ext/tasks v0.0.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	go.opentelemetry.io/contrib/bridges/otelslog v0.19.0
@@ -89,3 +90,5 @@ replace github.com/panyam/mcpkit/ext/otel => ../../ext/otel
 replace github.com/panyam/mcpkit/experimental/ext/events => ../../experimental/ext/events
 
 replace github.com/panyam/mcpkit/experimental/ext/events/clients/go => ../../experimental/ext/events/clients/go
+
+replace github.com/panyam/mcpkit/ext/tasks => ../../ext/tasks

--- a/cmd/agentchat/render.go
+++ b/cmd/agentchat/render.go
@@ -162,3 +162,10 @@ func (r *renderer) triggerFired(label string) {
 func (r *renderer) eventDropped(serverID, name string) {
 	fmt.Fprintf(r.out, "%s\n", r.dim("warning: event buffer full, dropped "+name+" from "+serverID))
 }
+
+func (r *renderer) taskStatus(dt *core.DetailedTask) {
+	if dt.Status == core.TaskWorking {
+		return // polling noise; begin/end and pauses are the signal
+	}
+	fmt.Fprintf(r.out, "%s\n", r.dim("  · task "+dt.TaskID+": "+string(dt.Status)))
+}

--- a/cmd/agentchat/tasks_test.go
+++ b/cmd/agentchat/tasks_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/panyam/mcpkit/agent"
+	"github.com/panyam/mcpkit/core"
+	tasksext "github.com/panyam/mcpkit/ext/tasks"
+	"github.com/panyam/mcpkit/server"
+)
+
+// TestAppTaskWithInputPauseEndToEnd is issue 890's acceptance: a REAL
+// ext/tasks (SEP-2663) server runs a task tool that parks in input_required
+// via TaskElicit; agentchat polls, answers the pause through the scripted
+// terminal elicitation UI, and delivers the final result — no bespoke code
+// on the server side.
+func TestAppTaskWithInputPauseEndToEnd(t *testing.T) {
+	srv := server.NewServer(core.ServerInfo{Name: "tasks-e2e", Version: "0.0.1"})
+	srv.Register(core.TypedTool[struct{}, core.ToolResponse]("confirm_delete",
+		"asks before deleting",
+		func(ctx core.ToolContext, _ struct{}) (core.ToolResponse, error) {
+			tc := tasksext.GetTaskContext(ctx)
+			if tc == nil {
+				return core.GoAsyncResult{}, nil
+			}
+			result, err := tc.TaskElicit(core.ElicitationRequest{
+				Message:         "Delete 'important.txt'?",
+				RequestedSchema: json.RawMessage(`{"type":"object","properties":{"confirm":{"type":"boolean"}},"required":["confirm"]}`),
+			})
+			if err != nil {
+				return core.TextResult(fmt.Sprintf("elicitation failed: %v", err)), nil
+			}
+			if confirmed, _ := result.Content["confirm"].(bool); result.Action == "accept" && confirmed {
+				return core.TextResult("deleted 'important.txt'"), nil
+			}
+			return core.TextResult("kept 'important.txt'"), nil
+		},
+		core.WithToolExecution(&core.ToolExecution{TaskSupport: core.TaskSupportRequired}),
+	))
+	tasksext.Register(tasksext.Config{Server: srv})
+
+	ts := httptest.NewServer(srv.Handler(server.WithStreamableHTTP(true)))
+	t.Cleanup(ts.Close)
+
+	stub := agent.NewStubProvider(
+		agent.StubTurn{ToolCalls: []agent.ToolCall{{ID: "c1", Name: "confirm_delete", Args: core.NewRawJSON(json.RawMessage(`{}`))}}},
+		agent.StubTurn{Text: "The file has been deleted."},
+	)
+
+	var out strings.Builder
+	stdin := strings.NewReader("y\n") // boolean confirm prompt
+	app, err := NewApp(testConfig(ts.URL), &out, stdin, WithProvider(stub))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Close()
+
+	if err := app.RunTurn(context.Background(), "delete important.txt"); err != nil {
+		t.Fatal(err)
+	}
+	transcript := out.String()
+	for _, want := range []string{
+		"? Delete 'important.txt'?",
+		"confirm (y/n):",
+		"input_required",
+		"✓ confirm_delete: deleted 'important.txt'",
+		"The file has been deleted.",
+	} {
+		if !strings.Contains(transcript, want) {
+			t.Fatalf("transcript missing %q:\n%s", want, transcript)
+		}
+	}
+}


### PR DESCRIPTION
Implements issue 890, the last open implementation ticket on the agent epic (issue 895).

## What changes

Task-backed tools now just work through the whole stack: a tools/call that returns a task envelope is polled to a terminal state (honoring server poll hints), mid-task input_required pauses route through the same elicitation prompts as everything else, status transitions render in the transcript, and the terminal snapshot maps back onto the ordinary tool-result contract. agentchat's last "doesn't work yet" README boundary flips to documented behavior.

## Reviewer's guide

Read in this order:
1. [client/tasks.go](https://github.com/panyam/mcpkit/pull/913/files#diff-d0b57c8858ad0192278d3050dbcdd6e4e6891f72eb9d4e8d0f076efdcacc7265) — WaitForTaskWithInput (the "tighter loop" WaitForTask's own doc alludes to) and WaitOptions.OnStatus. Note what did NOT change: WaitForTask still never answers input; the new function is a sibling, not a replacement.
2. [agent/client_source.go](https://github.com/panyam/mcpkit/pull/913/files#diff-c40cff8abaff177edaa804de111661bf9991d8922e603d1517eae8a9a2ae5829) — the task path: ErrTaskResult deleted, waitTask maps completed/failed/cancelled onto the sync contract, and the SAME InputHandler serves ephemeral MRTR and task pauses (the elicitation seam pays off with zero new wiring).
3. [agent/task_dispatch_test.go](https://github.com/panyam/mcpkit/pull/913/files#diff-537d904af88bd82b7c2e9754470d41ba04d19a8414d42a326f0b55c65e15b45a) — the hand-rolled SEP-2663 fixture (custom method handlers, core types only, deliberately not ext/tasks so the agent module's go.mod stays lean) and the behavior matrix: input round-trip, failure mapping, ctx abort, status-hook lifecycle.
4. [cmd/agentchat/tasks_test.go](https://github.com/panyam/mcpkit/pull/913/files#diff-fc57d5424e72b715419bb6b6076fd4de117524227180b174f19d8a646ddbaa4d) — the issue's acceptance verbatim: a REAL ext/tasks server whose tool parks in input_required via TaskElicit; scripted stdin answers the terminal prompt; the deletion result lands.
5. [cmd/agentchat/app.go](https://github.com/panyam/mcpkit/pull/913/files#diff-a844a8e6068c6ef210ec325c178df86cdd11609c4a6b3a14747160aa5badcfad), `render.go`, `README.md`, go.mod — extension negotiation, status lines, boundary flip.

## Decision log

- **The wait loop and the status hook live in the client** (review direction, applied twice): WaitForTaskWithInput and WaitOptions.OnStatus are mechanisms any task consumer wants; the agent holds a pass-through option typed with the client-level shape, and the surface renders. Mechanisms in the client, wiring in the agent, rendering in the surface.
- **One InputHandler for both pause kinds**: SEP-2322's InputRequests shape is identical whether it arrives on an ephemeral input_required result or a parked task, so the handler type is shared by construction and the ElicitationCoordinator covers tasks for free.
- **Working-status polls render nothing** in agentchat (only transitions like input_required); polling noise is not signal.
- **A handler error aborts the wait but not the task**: documented on the function — the task keeps running server-side and stays resumable or cancellable.

## Risk / blast radius

- Affects: client (additive sibling function + additive WaitOptions field), agent (ErrTaskResult removed — unreleased module, references audited), agentchat (+ext/tasks dep for the e2e fixture and the extension negotiation option).
- Tests: 5 new test functions (3 agent + 1 client + 1 agentchat e2e), ~30 assertions added, 0 removed or weakened; agent and agentchat suites under -race.
- Be paranoid about: the input_required branch ordering in the wait loop (checked before the poll sleep, after the status hook) and the completed-without-result edge (explicit error, never a nil deref).

## Before / after

Before: `tool call failed: agent: tool returned a task; task-aware dispatch is not configured (task t-1)`

After, the acceptance e2e transcript (real ext/tasks server, scripted stdin answering y):

```
⚙ confirm_delete({})
  · task task-1: input_required

? Delete 'important.txt'?
  confirm (y/n): y
  · task task-1: completed
  ✓ confirm_delete: deleted 'important.txt'
The file has been deleted.
```

Mutation red-check (input resolved but never delivered via tasks/update — the wait loops forever, caught by test timeout; restored):

```
panic: test timed out after 15s
FAIL    github.com/panyam/mcpkit/agent  15.348s
```

## Out of scope (deliberately deferred)

- tasks/cancel from the surface (Ctrl-C aborts the poll via ctx; sending an explicit cancel to the server is a small follow-up when a long-task UX wants it)
- Partial-fulfillment multi-input answering across multiple tasks/update rounds (the loop handles it naturally by re-polling, but no dedicated test; the multi_input example exercises it manually)
