### PR TITLE
feat(agent): async-control primitives — ToolChoice + runtime triggers (issue 916)

### DIFF
--- a/agent/background_test.go
+++ b/agent/background_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"sync"
 	"testing"
@@ -162,7 +163,12 @@ func TestBackgroundCancel(t *testing.T) {
 	case <-time.After(3 * time.Second):
 		t.Fatal("cancel must finish the handle")
 	}
-	if _, err := bt.Result(); err == nil {
-		t.Fatal("cancelled task must surface an error outcome")
+	// Cancel reaches Done two ways, both valid: the poll context cancels
+	// (context.Canceled) or the next tasks/get returns cancelled status
+	// (nil error, cancelled DetailedTask). Accept either.
+	dt, err := bt.Result()
+	cancelled := errors.Is(err, context.Canceled) || (dt != nil && dt.Status == core.TaskCancelled)
+	if !cancelled {
+		t.Fatalf("cancel must surface a cancellation outcome: dt=%+v err=%v", dt, err)
 	}
 }

--- a/agent/openai_provider.go
+++ b/agent/openai_provider.go
@@ -214,6 +214,11 @@ func (p *OpenAIProvider) buildBody(req ProviderRequest, stream bool) map[string]
 	if req.MaxTokens > 0 {
 		body["max_tokens"] = req.MaxTokens
 	}
+	if len(req.Tools) > 0 && !req.ToolChoice.IsZero() {
+		if tc := req.ToolChoice.wire(); tc != nil {
+			body["tool_choice"] = tc
+		}
+	}
 	if stream {
 		body["stream"] = true
 		body["stream_options"] = map[string]any{"include_usage": true}

--- a/agent/policy_test.go
+++ b/agent/policy_test.go
@@ -301,3 +301,38 @@ func TestSystemRoleReachesProviderWire(t *testing.T) {
 		t.Fatalf("system role wire shape:\n got %s\nwant %s", raw, want)
 	}
 }
+
+func TestTriggerRuntimeAddRemove(t *testing.T) {
+	clock := newClock()
+	tp := NewTriggerPolicy(TriggerPolicyConfig{now: clock.now})
+
+	// Nothing bound yet: no firing.
+	if tp.OnEvent(evt("s", "user.created", `{}`)) != nil {
+		t.Fatal("no binding should fire before Add")
+	}
+
+	tp.Add(TriggerBinding{Event: "user.created", Instructions: "send an email", Label: "emailer", Cooldown: time.Minute})
+	f := tp.OnEvent(evt("s", "user.created", `{}`))
+	if f == nil || f.Binding.Instructions != "send an email" {
+		t.Fatalf("runtime-added binding must fire: %+v", f)
+	}
+	if len(tp.Bindings()) != 1 {
+		t.Fatalf("bindings snapshot = %d", len(tp.Bindings()))
+	}
+
+	// Re-Add resets the spent slot (re-arm).
+	tp.Add(TriggerBinding{Event: "user.created", Instructions: "send an email", Label: "emailer"})
+	if tp.OnEvent(evt("s", "user.created", `{}`)) == nil {
+		t.Fatal("re-Add must reset the slot so it fires again")
+	}
+
+	if !tp.Remove("", "user.created", "emailer") {
+		t.Fatal("Remove must report success")
+	}
+	if tp.OnEvent(evt("s", "user.created", `{}`)) != nil {
+		t.Fatal("removed binding must not fire")
+	}
+	if tp.Remove("", "user.created", "emailer") {
+		t.Fatal("removing an absent binding must report false")
+	}
+}

--- a/agent/provider.go
+++ b/agent/provider.go
@@ -73,9 +73,61 @@ type ProviderRequest struct {
 	// MaxTokens caps the completion length when positive.
 	MaxTokens int `json:"maxTokens,omitempty"`
 
+	// ToolChoice biases tool calling for this request. Empty is the
+	// provider default ("auto"). Use ToolChoiceRequired to force some
+	// tool call, ToolChoiceNone to forbid, or ToolChoiceFunc(name) to
+	// force a specific tool. Pairs with RunnerConfig.Selector (narrow the
+	// set) to steer a proactive or injected turn toward acting rather than
+	// only replying. Support varies across OpenAI-compatible servers; a
+	// server that ignores it degrades to "auto".
+	ToolChoice ToolChoice `json:"toolChoice,omitempty"`
+
 	// ResponseSchema, when set, asks Generate for structured output
 	// conforming to this JSON Schema. Ignored by Stream.
 	ResponseSchema core.RawJSON `json:"responseSchema,omitempty"`
+}
+
+// ToolChoice is the request-level tool-calling bias. The zero value ("")
+// means the provider default (auto). It marshals to the OpenAI-compatible
+// wire form: the bare strings "auto"/"required"/"none", or the
+// {type:function, function:{name}} object for a forced tool.
+type ToolChoice struct {
+	// Mode is "", "auto", "required", "none", or "function".
+	Mode string `json:"mode,omitempty"`
+	// Name is the forced tool for Mode == "function".
+	Name string `json:"name,omitempty"`
+}
+
+// ToolChoiceAuto lets the model decide (the default; same as the zero value).
+var ToolChoiceAuto = ToolChoice{Mode: "auto"}
+
+// ToolChoiceRequired forces the model to call some tool.
+var ToolChoiceRequired = ToolChoice{Mode: "required"}
+
+// ToolChoiceNone forbids tool calls for this request.
+var ToolChoiceNone = ToolChoice{Mode: "none"}
+
+// ToolChoiceFunc forces the model to call the named tool.
+func ToolChoiceFunc(name string) ToolChoice { return ToolChoice{Mode: "function", Name: name} }
+
+// IsZero reports whether no choice was set (provider default applies).
+func (tc ToolChoice) IsZero() bool { return tc.Mode == "" }
+
+// wire renders the OpenAI-compatible tool_choice value, or nil when unset.
+func (tc ToolChoice) wire() any {
+	switch tc.Mode {
+	case "", "auto":
+		if tc.Mode == "" {
+			return nil
+		}
+		return "auto"
+	case "required", "none":
+		return tc.Mode
+	case "function":
+		return map[string]any{"type": "function", "function": map[string]any{"name": tc.Name}}
+	default:
+		return nil
+	}
 }
 
 // Usage reports token consumption for one model call.

--- a/agent/toolchoice_test.go
+++ b/agent/toolchoice_test.go
@@ -1,0 +1,73 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+func TestToolChoiceWireForms(t *testing.T) {
+	p := &OpenAIProvider{cfg: OpenAIConfig{BaseURL: "http://x", Model: "m"}}
+	tools := []core.ToolDef{{Name: "t", Description: "d", InputSchema: map[string]any{"type": "object"}}}
+
+	cases := []struct {
+		choice ToolChoice
+		want   string // JSON of the tool_choice value, or "" if absent
+	}{
+		{ToolChoice{}, ""},
+		{ToolChoiceAuto, `"auto"`},
+		{ToolChoiceRequired, `"required"`},
+		{ToolChoiceNone, `"none"`},
+		{ToolChoiceFunc("send_email"), `{"function":{"name":"send_email"},"type":"function"}`},
+	}
+	for _, tc := range cases {
+		body := p.buildBody(ProviderRequest{Tools: tools, ToolChoice: tc.choice}, false)
+		got, present := body["tool_choice"]
+		if tc.want == "" {
+			if present {
+				t.Fatalf("choice %+v must emit no tool_choice, got %v", tc.choice, got)
+			}
+			continue
+		}
+		raw, _ := json.Marshal(got)
+		if string(raw) != tc.want {
+			t.Fatalf("choice %+v wire = %s, want %s", tc.choice, raw, tc.want)
+		}
+	}
+}
+
+func TestToolChoiceOmittedWithoutTools(t *testing.T) {
+	p := &OpenAIProvider{cfg: OpenAIConfig{BaseURL: "http://x", Model: "m"}}
+	body := p.buildBody(ProviderRequest{ToolChoice: ToolChoiceRequired}, false)
+	if _, present := body["tool_choice"]; present {
+		t.Fatal("tool_choice must be omitted when no tools are offered")
+	}
+}
+
+func TestToolChoiceReachesTheWire(t *testing.T) {
+	var captured map[string]any
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&captured)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.(http.Flusher).Flush()
+		w.Write([]byte("data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n"))
+	}))
+	defer ts.Close()
+	p, _ := NewOpenAIProvider(OpenAIConfig{BaseURL: ts.URL, Model: "m"})
+	s, err := p.Stream(context.Background(), ProviderRequest{
+		Tools:      []core.ToolDef{{Name: "x", InputSchema: map[string]any{"type": "object"}}},
+		ToolChoice: ToolChoiceFunc("x"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.Close()
+	tc, ok := captured["tool_choice"].(map[string]any)
+	if !ok || tc["type"] != "function" {
+		t.Fatalf("streamed tool_choice = %v", captured["tool_choice"])
+	}
+}

--- a/agent/triggers.go
+++ b/agent/triggers.go
@@ -78,9 +78,10 @@ type TriggerPolicyConfig struct {
 type TriggerPolicy struct {
 	cfg TriggerPolicyConfig
 
-	mu      sync.Mutex
-	slots   map[string]*triggerSlot
-	firings int
+	mu       sync.Mutex
+	bindings []TriggerBinding
+	slots    map[string]*triggerSlot
+	firings  int
 }
 
 type triggerSlot struct {
@@ -101,10 +102,60 @@ func NewTriggerPolicy(cfg TriggerPolicyConfig) *TriggerPolicy {
 		cfg.now = time.Now
 	}
 	slots := make(map[string]*triggerSlot, len(cfg.Bindings))
+	bindings := make([]TriggerBinding, 0, len(cfg.Bindings))
 	for _, b := range cfg.Bindings {
 		slots[slotKey(b)] = &triggerSlot{}
+		bindings = append(bindings, b)
 	}
-	return &TriggerPolicy{cfg: cfg, slots: slots}
+	return &TriggerPolicy{cfg: cfg, bindings: bindings, slots: slots}
+}
+
+// Add installs a binding at runtime — the seam a create_trigger meta-tool
+// uses so the model can set up a standing behavior through conversation.
+// A binding whose slotKey already exists replaces it and resets its slot
+// (re-arming the behavior). Safe for concurrent use with OnEvent.
+func (t *TriggerPolicy) Add(b TriggerBinding) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	key := slotKey(b)
+	if _, exists := t.slots[key]; exists {
+		for i := range t.bindings {
+			if slotKey(t.bindings[i]) == key {
+				t.bindings[i] = b
+				break
+			}
+		}
+	} else {
+		t.bindings = append(t.bindings, b)
+	}
+	t.slots[key] = &triggerSlot{}
+}
+
+// Remove deletes the binding with the given server/event/label (the slotKey
+// components). Unknown bindings are a no-op. Returns whether one was removed.
+func (t *TriggerPolicy) Remove(server, event, label string) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	key := slotKey(TriggerBinding{Server: server, Event: event, Label: label})
+	if _, exists := t.slots[key]; !exists {
+		return false
+	}
+	delete(t.slots, key)
+	for i := range t.bindings {
+		if slotKey(t.bindings[i]) == key {
+			t.bindings = append(t.bindings[:i], t.bindings[i+1:]...)
+			break
+		}
+	}
+	return true
+}
+
+// Bindings returns a snapshot of the installed bindings (for list_triggers
+// surfaces).
+func (t *TriggerPolicy) Bindings() []TriggerBinding {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return append([]TriggerBinding(nil), t.bindings...)
 }
 
 func slotKey(b TriggerBinding) string { return b.Server + "/" + b.Event + "/" + b.Label }
@@ -118,7 +169,7 @@ func (t *TriggerPolicy) OnEvent(ev IncomingEvent) *TriggerFiring {
 	defer t.mu.Unlock()
 	now := t.cfg.now()
 
-	for _, b := range t.cfg.Bindings {
+	for _, b := range t.bindings {
 		if b.Event != ev.Name || (b.Server != "" && b.Server != ev.Server) {
 			continue
 		}

--- a/docs/AGENT_DESIGN.md
+++ b/docs/AGENT_DESIGN.md
@@ -79,6 +79,15 @@ The purity rule that keeps the lifecycle single-sourced: selectors are pure func
 
 The generic stages (Stage[E], Filter, Transform, Window) are deliberately synchronous, caller-driven, and clock-injected: the policies drain at turn boundaries under the host's own locking, and every windowing test runs on a fake clock. gocurrent already ships the asynchronous complement (Pipeline[T] channel components, Mapper, Broadcast filters, Reducer with FlushPeriod), and the two compose without adaptation: async pre-processing can feed InjectionPolicy.Ingest from a gocurrent component's output channel. The pushdown position, settled 2026-07-16: when a second consumer of the synchronous stages appears, they graduate INTO gocurrent as a new surface (renamed; gocurrent.Pipeline already means the channel component), never replace it, and the agent module re-imports. Until then they live here to avoid cross-repo release ordering for a single consumer.
 
+### Async control plane
+
+Two primitives let the model steer asynchronous operations (events and tasks) through conversation rather than only config:
+
+- `ProviderRequest.ToolChoice` biases tool calling for a request (auto / required / none / a forced tool). Paired with `RunnerConfig.Selector` (narrow the offered set), a proactive or injected turn can be steered toward *acting* — e.g. a trigger firing "send an email" can offer only the email tool and force a call. Renders to the OpenAI-compatible `tool_choice`; a server that ignores it degrades to auto.
+- `TriggerPolicy.Add` / `Remove` / `Bindings` mutate bindings at runtime. This is the seam a `create_trigger` host meta-tool uses so the model can install a standing behavior ("when users are created, send an email") mid-conversation. Because task completions are already `task.completed` events (see background tasks), the same runtime binding serves "notify on build done" and "email on user_created" alike.
+
+The host meta-tools that expose these to the model (`subscribe_events`, `create_trigger`, `list_tasks`, `cancel_task`, ...) are surface-level `FuncSource` registrations, not agent API — the model's control plane is host-local tools over the client mechanisms and these agent policies.
+
 ### Policy hooks
 
 Two seams, both no-op by default:


### PR DESCRIPTION
First of two PRs for letting the model steer async operations (events + tasks) through conversation. This is the agent-module foundation; the host meta-tools + demo example follow in issue 917.

## What changes

Two additions that make a proactive or injected turn able to *act*, and let the model install standing behaviors at runtime: `ProviderRequest.ToolChoice` (bias/force tool calls) and `TriggerPolicy.Add`/`Remove`/`Bindings` (mutate trigger bindings at runtime, not just at construction).

## Reviewer's guide

1. [agent/provider.go](https://github.com/panyam/mcpkit/pull/918/files#diff-a1383b85f643c0c6e93ffd7d81aefd65f427d24348ee2d60c8388c91694f3c5b) — the ToolChoice type (auto/required/none/forced-func) and its wire() rendering.
2. [agent/openai_provider.go](https://github.com/panyam/mcpkit/pull/918/files#diff-aa95603c3498519232b6a26863d823be62a5d05e94053dc57da95c458e875b3e) — tool_choice emitted only when tools are offered.
3. [agent/triggers.go](https://github.com/panyam/mcpkit/pull/918/files#diff-31fbf33129473581024f927aafc2aceb2ffce9e9daf4bf2a7b6de7612dad6152) — Add/Remove/Bindings over a now-mutable binding slice; OnEvent iterates it.
4. [agent/toolchoice_test.go](https://github.com/panyam/mcpkit/pull/918/files#diff-55615eaef4138a78a17bdb961e860ba4ab0510f3bcbb5068710e73ab299cf4dd), [agent/policy_test.go](https://github.com/panyam/mcpkit/pull/918/files#diff-52ea94a567dc7195fe8cd13af59d3f3cbb4558bfd6b6c73aba6e8f53080289f0) (TestTriggerRuntimeAddRemove) — acceptance.
5. [docs/AGENT_DESIGN.md](https://github.com/panyam/mcpkit/pull/918/files#diff-bdf045ebd871d9f6b81fe4602a8effef64194a2d15951e35ce3b0f79989db1d2) — the async control plane section.

## Decision log

- **ToolChoice as a small struct, not a raw string**: the wire has two shapes (bare enum vs forced-function object); a struct with a `wire()` renderer keeps call sites typed (`ToolChoiceFunc("x")`) and the marshaling in one place, pinned by a golden test.
- **Omit tool_choice when no tools offered**: `tool_choice: required` with an empty tools array is a wire error on strict servers; guarding on `len(Tools) > 0` is defensive.
- **Runtime Add resets the slot**: re-adding a binding label re-arms it (the natural "the model set this up again" semantics), rather than being a no-op or erroring.
- **Meta-tools are NOT in this PR**: exposing these to the model is host-level FuncSource wiring (issue 917), per the layering rule — the agent provides the runtime seam, the surface provides the tools.

## Risk / blast radius

- Affects: agent module only; both additions are additive (new optional field, new methods). No behavior change for existing callers (zero-value ToolChoice = provider default; construction-time bindings unchanged).
- Tests: 4 new test functions, ~20 assertions added, 0 removed; both mutation-checked (dropped tool_choice; OnEvent ignoring runtime adds). Plus a flaky-test fix (see below). Suite run 12x for stability.
- Drive-by: **fixed flaky TestBackgroundCancel** (pre-existing, from the background-task work). Cancel reaches Done two valid ways — the poll context cancelling (context.Canceled) or the next tasks/get returning cancelled status (nil error, cancelled DetailedTask) — and the test wrongly asserted only the error path. Now accepts either; 12x stable.

## Before / after

Before: a triggered "send an email" turn offers every tool and the model may just chat; triggers are fixed at startup.

After:
```go
// steer a proactive turn toward acting
runner with Selector -> [send_email], ProviderRequest.ToolChoice = ToolChoiceFunc("send_email")
// model installs a standing behavior mid-conversation
triggerPolicy.Add(TriggerBinding{Event: "user.created", Instructions: "send an email", Label: "emailer"})
```

Mutation red-checks (both restored):
```
--- FAIL: TestToolChoiceWireForms        (tool_choice dropped)
--- FAIL: TestTriggerRuntimeAddRemove     (OnEvent ignores runtime adds)
```

## Out of scope (issue 917)

- subscribe_events / unsubscribe / create_trigger / list_tasks / cancel_task meta-tools (host FuncSource)
- host-local-async pattern (ack + goroutine + inject)
- the make agent example driving the Msg-1/2/3 transcript against a StubProvider
