### PR TITLE
feat(agent): tool-call approval / permission ladder (issue 929)

### DIFF
--- a/agent/approval.go
+++ b/agent/approval.go
@@ -1,0 +1,188 @@
+package agent
+
+import (
+	"context"
+	"sync"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+// ApprovalPolicy gates each tool call before it runs. The Runner consults it
+// in callTool, after argument binding and before ToolSource.Call; a nil
+// policy on RunnerConfig means every call runs (the pre-approval behavior).
+//
+// Approve may block to ask the user. It returns a decision, never a turn
+// abort: a refusal is fed back to the model as a tool result and the loop
+// continues, so an error from Approve is reserved for the policy itself
+// failing (for example, the ask UI could not present the prompt).
+type ApprovalPolicy interface {
+	Approve(ctx context.Context, req ApprovalRequest) (ApprovalDecision, error)
+}
+
+// ApprovalRequest describes the call a policy is deciding on. Args is the
+// model-supplied arguments object (core.RawJSON per A5, so a policy can Bind
+// for typed inspection without a second parse). ReadOnly reflects the tool's
+// readOnlyHint annotation, the signal the read-only-auto tier keys on; it is
+// false when the tool declares no such hint.
+type ApprovalRequest struct {
+	ToolName string
+	Args     core.RawJSON
+	ReadOnly bool
+}
+
+// ApprovalDecision is a policy's verdict. Allowed true runs the call. On a
+// refusal, Reason is surfaced to the model (as the tool result text) and to
+// surfaces (on the tool-denied event); an empty Reason gets a default.
+type ApprovalDecision struct {
+	Allowed bool
+	Reason  string
+}
+
+// ApprovalMode is the default disposition TieredApproval applies to a call
+// that no per-tool rule covers.
+type ApprovalMode int
+
+const (
+	// ModeAlwaysAsk asks for every uncovered call. The safe default.
+	ModeAlwaysAsk ApprovalMode = iota
+	// ModeReadOnlyAuto auto-allows calls whose tool declares readOnlyHint
+	// and asks for the rest. The "read-only → auto-edit" rung of the ladder.
+	ModeReadOnlyAuto
+	// ModeAlwaysAllow runs every uncovered call without asking (full-auto /
+	// "yolo"). Per-tool Deny rules still apply on top.
+	ModeAlwaysAllow
+)
+
+// ToolRule is the per-tool override that takes precedence over the mode.
+type ToolRule int
+
+const (
+	// RuleAsk forces an ask for this tool regardless of mode.
+	RuleAsk ToolRule = iota
+	// RuleAllow auto-allows this tool regardless of mode.
+	RuleAllow
+	// RuleDeny refuses this tool outright, without asking.
+	RuleDeny
+)
+
+// AskFunc presents a yes/no approval prompt and returns the user's choice.
+// ElicitationCoordinator.Confirm satisfies it, which is how the "ask" outcome
+// reuses the existing FIFO UI seam instead of introducing a second one. A nil
+// AskFunc makes every ask resolve to a refusal (fail-closed).
+type AskFunc func(ctx context.Context, req ApprovalRequest) (bool, error)
+
+// TieredApproval is the batteries-included ApprovalPolicy: a default mode, a
+// map of per-tool rules that override it, an optional ask seam, and an
+// optional session-scoped cache that remembers a tool the user approved so
+// later calls to it skip the prompt. Safe for concurrent use by the Runner's
+// parallel dispatch.
+type TieredApproval struct {
+	mode     ApprovalMode
+	rules    map[string]ToolRule
+	ask      AskFunc
+	remember bool
+
+	mu         sync.Mutex
+	remembered map[string]bool
+}
+
+// TieredOption configures a TieredApproval.
+type TieredOption func(*TieredApproval)
+
+// WithDefaultMode sets the disposition for calls no per-tool rule covers.
+// Without it, the mode is ModeAlwaysAsk.
+func WithDefaultMode(m ApprovalMode) TieredOption {
+	return func(t *TieredApproval) { t.mode = m }
+}
+
+// WithToolRule pins a per-tool override that wins over the mode. Call it once
+// per tool; a later rule for the same name replaces an earlier one.
+func WithToolRule(tool string, rule ToolRule) TieredOption {
+	return func(t *TieredApproval) { t.rules[tool] = rule }
+}
+
+// WithAsk supplies the seam that presents an approval prompt. Pass
+// coord.Confirm to route asks through the shared ElicitationCoordinator.
+func WithAsk(ask AskFunc) TieredOption {
+	return func(t *TieredApproval) { t.ask = ask }
+}
+
+// WithRememberApprovals turns on the session cache: once the user approves a
+// tool through an ask, subsequent calls to that same tool auto-allow for the
+// life of this policy. A denial is never remembered.
+func WithRememberApprovals(remember bool) TieredOption {
+	return func(t *TieredApproval) { t.remember = remember }
+}
+
+// NewTieredApproval builds a TieredApproval. With no options it asks for every
+// call and, lacking an AskFunc, refuses them all (fail-closed) — supply
+// WithAsk to make asking meaningful.
+func NewTieredApproval(opts ...TieredOption) *TieredApproval {
+	t := &TieredApproval{
+		mode:       ModeAlwaysAsk,
+		rules:      map[string]ToolRule{},
+		remembered: map[string]bool{},
+	}
+	for _, opt := range opts {
+		opt(t)
+	}
+	return t
+}
+
+// Approve applies, in order: a remembered approval, a per-tool rule, then the
+// default mode. An ask that the user accepts is remembered when the cache is
+// on. A refusal (rule Deny, an ask returning false, or an ask with no AskFunc
+// wired) yields Allowed:false with a Reason; the Runner feeds that back to the
+// model and continues the turn.
+func (t *TieredApproval) Approve(ctx context.Context, req ApprovalRequest) (ApprovalDecision, error) {
+	if t.remember {
+		t.mu.Lock()
+		ok := t.remembered[req.ToolName]
+		t.mu.Unlock()
+		if ok {
+			return ApprovalDecision{Allowed: true}, nil
+		}
+	}
+
+	if rule, ok := t.rules[req.ToolName]; ok {
+		switch rule {
+		case RuleAllow:
+			return ApprovalDecision{Allowed: true}, nil
+		case RuleDeny:
+			return ApprovalDecision{Reason: "denied by approval policy"}, nil
+		case RuleAsk:
+			return t.doAsk(ctx, req)
+		}
+	}
+
+	switch t.mode {
+	case ModeAlwaysAllow:
+		return ApprovalDecision{Allowed: true}, nil
+	case ModeReadOnlyAuto:
+		if req.ReadOnly {
+			return ApprovalDecision{Allowed: true}, nil
+		}
+		return t.doAsk(ctx, req)
+	default: // ModeAlwaysAsk
+		return t.doAsk(ctx, req)
+	}
+}
+
+func (t *TieredApproval) doAsk(ctx context.Context, req ApprovalRequest) (ApprovalDecision, error) {
+	if t.ask == nil {
+		return ApprovalDecision{Reason: "no approval UI available"}, nil
+	}
+	ok, err := t.ask(ctx, req)
+	if err != nil {
+		return ApprovalDecision{}, err
+	}
+	if !ok {
+		return ApprovalDecision{Reason: "declined by user"}, nil
+	}
+	if t.remember {
+		t.mu.Lock()
+		t.remembered[req.ToolName] = true
+		t.mu.Unlock()
+	}
+	return ApprovalDecision{Allowed: true}, nil
+}

--- a/agent/approval_test.go
+++ b/agent/approval_test.go
@@ -1,0 +1,158 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+// countingAsk returns an AskFunc that always answers `answer` and a pointer to
+// the number of times it was consulted, so a test can assert both the verdict
+// and whether the ask seam was reached at all.
+func countingAsk(answer bool) (AskFunc, *int) {
+	n := 0
+	return func(ctx context.Context, req ApprovalRequest) (bool, error) {
+		n++
+		return answer, nil
+	}, &n
+}
+
+func req(tool string, readOnly bool) ApprovalRequest {
+	return ApprovalRequest{ToolName: tool, ReadOnly: readOnly}
+}
+
+func TestTieredApprovalModes(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("always-allow skips the ask", func(t *testing.T) {
+		ask, n := countingAsk(false)
+		p := NewTieredApproval(WithDefaultMode(ModeAlwaysAllow), WithAsk(ask))
+		dec, err := p.Approve(ctx, req("write_file", false))
+		if err != nil || !dec.Allowed {
+			t.Fatalf("dec=%+v err=%v", dec, err)
+		}
+		if *n != 0 {
+			t.Fatalf("ask consulted %d times, want 0", *n)
+		}
+	})
+
+	t.Run("read-only-auto allows read-only without asking", func(t *testing.T) {
+		ask, n := countingAsk(false)
+		p := NewTieredApproval(WithDefaultMode(ModeReadOnlyAuto), WithAsk(ask))
+		dec, _ := p.Approve(ctx, req("list_files", true))
+		if !dec.Allowed || *n != 0 {
+			t.Fatalf("read-only should auto-allow: dec=%+v asks=%d", dec, *n)
+		}
+	})
+
+	t.Run("read-only-auto asks for mutating tools", func(t *testing.T) {
+		ask, n := countingAsk(true)
+		p := NewTieredApproval(WithDefaultMode(ModeReadOnlyAuto), WithAsk(ask))
+		dec, _ := p.Approve(ctx, req("delete_file", false))
+		if !dec.Allowed || *n != 1 {
+			t.Fatalf("mutating tool should ask: dec=%+v asks=%d", dec, *n)
+		}
+	})
+
+	t.Run("always-ask asks even for read-only", func(t *testing.T) {
+		ask, n := countingAsk(true)
+		p := NewTieredApproval(WithDefaultMode(ModeAlwaysAsk), WithAsk(ask))
+		if _, _ = p.Approve(ctx, req("list_files", true)); *n != 1 {
+			t.Fatalf("always-ask should consult ask for read-only too: asks=%d", *n)
+		}
+	})
+}
+
+func TestTieredApprovalRulesOverrideMode(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("deny rule refuses without asking", func(t *testing.T) {
+		ask, n := countingAsk(true)
+		p := NewTieredApproval(WithDefaultMode(ModeAlwaysAllow), WithToolRule("deploy", RuleDeny), WithAsk(ask))
+		dec, _ := p.Approve(ctx, req("deploy", false))
+		if dec.Allowed || dec.Reason == "" || *n != 0 {
+			t.Fatalf("deny rule should refuse silently: dec=%+v asks=%d", dec, *n)
+		}
+	})
+
+	t.Run("allow rule wins over always-ask", func(t *testing.T) {
+		ask, n := countingAsk(false)
+		p := NewTieredApproval(WithDefaultMode(ModeAlwaysAsk), WithToolRule("read_status", RuleAllow), WithAsk(ask))
+		dec, _ := p.Approve(ctx, req("read_status", false))
+		if !dec.Allowed || *n != 0 {
+			t.Fatalf("allow rule should auto-allow: dec=%+v asks=%d", dec, *n)
+		}
+	})
+
+	t.Run("ask rule wins over always-allow", func(t *testing.T) {
+		ask, n := countingAsk(true)
+		p := NewTieredApproval(WithDefaultMode(ModeAlwaysAllow), WithToolRule("send_email", RuleAsk), WithAsk(ask))
+		if _, _ = p.Approve(ctx, req("send_email", false)); *n != 1 {
+			t.Fatalf("ask rule should force a prompt even in yolo mode: asks=%d", *n)
+		}
+	})
+}
+
+func TestTieredApprovalRemembersApproval(t *testing.T) {
+	ctx := context.Background()
+	ask, n := countingAsk(true)
+	p := NewTieredApproval(WithDefaultMode(ModeAlwaysAsk), WithAsk(ask), WithRememberApprovals(true))
+
+	if dec, _ := p.Approve(ctx, req("send_email", false)); !dec.Allowed {
+		t.Fatal("first call should be allowed after the user approves")
+	}
+	if dec, _ := p.Approve(ctx, req("send_email", false)); !dec.Allowed {
+		t.Fatal("second call should be auto-allowed from the remember cache")
+	}
+	if *n != 1 {
+		t.Fatalf("ask consulted %d times, want 1 (second call cached)", *n)
+	}
+}
+
+func TestTieredApprovalDeclineAndNoUI(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("decline refuses with a reason and is not remembered", func(t *testing.T) {
+		ask, n := countingAsk(false)
+		p := NewTieredApproval(WithAsk(ask), WithRememberApprovals(true))
+		dec, _ := p.Approve(ctx, req("send_email", false))
+		if dec.Allowed || dec.Reason == "" {
+			t.Fatalf("decline should refuse with reason: %+v", dec)
+		}
+		if _, _ = p.Approve(ctx, req("send_email", false)); *n != 2 {
+			t.Fatalf("a declined tool must not be cached: asks=%d, want 2", *n)
+		}
+	})
+
+	t.Run("no ask wired fails closed", func(t *testing.T) {
+		p := NewTieredApproval() // ModeAlwaysAsk, no AskFunc
+		dec, err := p.Approve(ctx, req("anything", false))
+		if err != nil || dec.Allowed || dec.Reason == "" {
+			t.Fatalf("missing ask UI should refuse, not error: dec=%+v err=%v", dec, err)
+		}
+	})
+
+	t.Run("ask error propagates", func(t *testing.T) {
+		boom := errors.New("ui gone")
+		p := NewTieredApproval(WithAsk(func(context.Context, ApprovalRequest) (bool, error) { return false, boom }))
+		if _, err := p.Approve(ctx, req("x", false)); !errors.Is(err, boom) {
+			t.Fatalf("ask error should propagate, got %v", err)
+		}
+	})
+}
+
+func TestToolReadOnly(t *testing.T) {
+	tools := []core.ToolDef{
+		{Name: "list", Annotations: map[string]any{"readOnlyHint": true}},
+		{Name: "write", Annotations: map[string]any{"readOnlyHint": false}},
+		{Name: "plain"},
+	}
+	cases := map[string]bool{"list": true, "write": false, "plain": false, "unknown": false}
+	for name, want := range cases {
+		if got := toolReadOnly(tools, name); got != want {
+			t.Errorf("toolReadOnly(%q) = %v, want %v", name, got, want)
+		}
+	}
+}

--- a/agent/elicitation.go
+++ b/agent/elicitation.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"sync"
 
 	"github.com/panyam/mcpkit/client"
@@ -51,6 +52,28 @@ func NewElicitationCoordinator(ui ElicitationUI) *ElicitationCoordinator {
 // it on every client whose servers may elicit.
 func (c *ElicitationCoordinator) Handler() client.ElicitationHandler {
 	return c.present
+}
+
+// Confirm presents a yes/no prompt through the same FIFO seam as elicitation
+// and reports the user's choice. It is the general "ask the user to confirm"
+// primitive; the approval ladder wires it as its AskFunc (WithAsk(coord.Confirm))
+// so an approval prompt inherits the one-at-a-time serialization and never
+// stacks against a concurrent elicitation. Only an explicit accept with
+// confirm=true returns true; decline, cancel, or a missing/false field return
+// false. A non-nil error means the surface failed to present the prompt.
+func (c *ElicitationCoordinator) Confirm(ctx context.Context, message string) (bool, error) {
+	res, err := c.present(ctx, core.ElicitationRequest{
+		Message:         message,
+		RequestedSchema: json.RawMessage(`{"type":"object","properties":{"confirm":{"type":"boolean"}},"required":["confirm"]}`),
+	})
+	if err != nil {
+		return false, err
+	}
+	if res.Action != "accept" {
+		return false, nil
+	}
+	confirmed, _ := res.Content["confirm"].(bool)
+	return confirmed, nil
 }
 
 func (c *ElicitationCoordinator) present(ctx context.Context, req core.ElicitationRequest) (core.ElicitationResult, error) {

--- a/agent/events.go
+++ b/agent/events.go
@@ -12,7 +12,7 @@ type EventKind string
 // Event kinds, in the order a typical turn emits them. Thinking markers wrap
 // contiguous reasoning deltas within one step; tool events may interleave
 // across parallel calls of the same step, but tool-begin always precedes its
-// call's tool-end or tool-error.
+// call's tool-end, tool-error, or tool-denied.
 const (
 	EventTurnBegin     EventKind = "turn-begin"
 	EventThinkingBegin EventKind = "thinking-begin"
@@ -22,6 +22,7 @@ const (
 	EventToolBegin     EventKind = "tool-begin"
 	EventToolEnd       EventKind = "tool-end"
 	EventToolError     EventKind = "tool-error"
+	EventToolDenied    EventKind = "tool-denied"
 	EventTurnEnd       EventKind = "turn-end"
 	EventError         EventKind = "error"
 )
@@ -53,6 +54,12 @@ type Event struct {
 	// Error is the failure description on tool-error and error. A string,
 	// not an error value, so the event crosses wires unchanged.
 	Error string `json:"error,omitempty"`
+
+	// Reason is the human-readable justification on tool-denied: why the
+	// approval policy refused the call. Distinct from Error because a
+	// denial is a policy outcome, not a dispatch failure; the call never
+	// ran, so there is no ToolResult.
+	Reason string `json:"reason,omitempty"`
 
 	// Result is the completed turn on turn-end.
 	Result *TurnResult `json:"result,omitempty"`

--- a/agent/runner.go
+++ b/agent/runner.go
@@ -53,6 +53,13 @@ type RunnerConfig struct {
 	// (the ToolSource layer). A selector error aborts the turn: it is a
 	// host configuration bug, not something the model can recover from.
 	Selector ToolSelector
+
+	// Approval, when non-nil, gates each tool call before it runs: the
+	// Runner asks the policy in callTool, after argument binding and before
+	// ToolSource.Call. A refusal is fed back to the model as a tool result
+	// (a tool-denied event, then the turn continues), never a turn abort.
+	// Nil means every call runs, the pre-approval behavior.
+	Approval ApprovalPolicy
 }
 
 // ToolSelector narrows the model-facing tool set for one step. Returning the
@@ -177,7 +184,7 @@ func (r *Runner) Run(ctx context.Context, history []Message, emit func(Event)) (
 			return result, nil
 		}
 
-		toolMsgs := r.dispatch(stepCtx, step, resp.ToolCalls, emit)
+		toolMsgs := r.dispatch(stepCtx, step, resp.ToolCalls, tools, emit)
 		stepSpan.End()
 		if err := ctx.Err(); err != nil {
 			return nil, r.failSpan(emit, turnSpan, err)
@@ -238,7 +245,7 @@ func consumeStream(stream Stream, step int, emit func(Event)) (*ProviderResponse
 // dispatch runs the step's tool calls concurrently, serializes event
 // emission, and returns RoleTool messages in call order regardless of
 // completion order.
-func (r *Runner) dispatch(ctx context.Context, step int, calls []ToolCall, emit func(Event)) []Message {
+func (r *Runner) dispatch(ctx context.Context, step int, calls []ToolCall, tools []core.ToolDef, emit func(Event)) []Message {
 	results := make([]Message, len(calls))
 	var emitMu sync.Mutex
 	locked := func(ev Event) {
@@ -255,7 +262,7 @@ func (r *Runner) dispatch(ctx context.Context, step int, calls []ToolCall, emit 
 			toolCtx, toolSpan := r.cfg.TracerProvider.StartSpan(ctx, "agent.tool",
 				core.Attribute{Key: "agent.tool.name", Value: call.Name})
 			locked(Event{Kind: EventToolBegin, Step: step, ToolCall: &call})
-			text := r.callTool(toolCtx, step, call, locked, toolSpan)
+			text := r.callTool(toolCtx, step, call, tools, locked, toolSpan)
 			toolSpan.End()
 			results[i] = Message{Role: RoleTool, ToolCallID: call.ID, Text: text}
 		}(i, call)
@@ -264,9 +271,24 @@ func (r *Runner) dispatch(ctx context.Context, step int, calls []ToolCall, emit 
 	return results
 }
 
+// toolReadOnly reports whether the named tool declares the readOnlyHint
+// annotation in the step's offered set. It is the signal the read-only-auto
+// approval tier keys on; an unknown tool or an absent hint is treated as
+// not read-only (fail-safe: a tool that does not promise read-only gets the
+// stricter path).
+func toolReadOnly(tools []core.ToolDef, name string) bool {
+	for _, t := range tools {
+		if t.Name == name {
+			ro, _ := t.Annotations["readOnlyHint"].(bool)
+			return ro
+		}
+	}
+	return false
+}
+
 // callTool executes one call and renders the text fed back to the model.
 // Every failure shape becomes model-visible text rather than a turn abort.
-func (r *Runner) callTool(ctx context.Context, step int, call ToolCall, emit func(Event), span core.Span) string {
+func (r *Runner) callTool(ctx context.Context, step int, call ToolCall, tools []core.ToolDef, emit func(Event), span core.Span) string {
 	failed := func(err error) string {
 		span.RecordError(err)
 		emit(Event{Kind: EventToolError, Step: step, ToolCall: &call, Error: err.Error()})
@@ -276,6 +298,27 @@ func (r *Runner) callTool(ctx context.Context, step int, call ToolCall, emit fun
 	if r.cfg.Tools == nil {
 		return failed(fmt.Errorf("%w: %q (no tools offered)", ErrUnknownTool, call.Name))
 	}
+
+	if r.cfg.Approval != nil {
+		dec, err := r.cfg.Approval.Approve(ctx, ApprovalRequest{
+			ToolName: call.Name,
+			Args:     call.Args,
+			ReadOnly: toolReadOnly(tools, call.Name),
+		})
+		if err != nil {
+			return failed(fmt.Errorf("agent: approval policy for %q: %w", call.Name, err))
+		}
+		if !dec.Allowed {
+			reason := dec.Reason
+			if reason == "" {
+				reason = "denied by approval policy"
+			}
+			span.SetAttribute("agent.tool.denied", "true")
+			emit(Event{Kind: EventToolDenied, Step: step, ToolCall: &call, Reason: reason})
+			return "tool call not permitted: " + reason
+		}
+	}
+
 	args := map[string]any{}
 	if call.Args.Len() > 0 {
 		if err := call.Args.Bind(&args); err != nil {

--- a/agent/runner_test.go
+++ b/agent/runner_test.go
@@ -324,6 +324,7 @@ func TestRunnerEventKindsJSONRoundTrip(t *testing.T) {
 		{Kind: EventToolBegin, Step: 1, ToolCall: &ToolCall{ID: "c", Name: "n", Args: core.NewRawJSON(json.RawMessage(`{}`))}},
 		{Kind: EventToolEnd, Step: 1, ToolCall: &ToolCall{ID: "c", Name: "n", Args: core.NewRawJSON(json.RawMessage(`{}`))}, ToolResult: &core.ToolResult{Content: []core.Content{{Type: "text", Text: "ok"}}}},
 		{Kind: EventToolError, Step: 1, ToolCall: &ToolCall{ID: "c", Name: "n", Args: core.NewRawJSON(json.RawMessage(`{}`))}, Error: "boom"},
+		{Kind: EventToolDenied, Step: 1, ToolCall: &ToolCall{ID: "c", Name: "n", Args: core.NewRawJSON(json.RawMessage(`{}`))}, Reason: "declined by user"},
 		{Kind: EventTurnEnd, Result: &TurnResult{Text: "done", Steps: 1, Usage: Usage{InputTokens: 1, OutputTokens: 2}}},
 		{Kind: EventError, Error: "fatal"},
 	}
@@ -343,6 +344,95 @@ func TestRunnerEventKindsJSONRoundTrip(t *testing.T) {
 		if string(raw) != string(raw2) {
 			t.Fatalf("round-trip drift for %s: %s vs %s", e.Kind, raw, raw2)
 		}
+	}
+}
+
+// denyAll is an ApprovalPolicy that refuses every call with a fixed reason.
+type denyAll struct{ reason string }
+
+func (d denyAll) Approve(context.Context, ApprovalRequest) (ApprovalDecision, error) {
+	return ApprovalDecision{Reason: d.reason}, nil
+}
+
+func TestRunnerApprovalDeniedFeedsBackAndContinues(t *testing.T) {
+	called := false
+	src := NewFuncSource()
+	AddFunc(src, "send_email", "sends mail", func(ctx context.Context, in struct {
+		To string `json:"to"`
+	}) (string, error) {
+		called = true
+		return "sent", nil
+	})
+
+	stub := NewStubProvider(
+		StubTurn{ToolCalls: []ToolCall{{ID: "c1", Name: "send_email", Args: core.NewRawJSON(json.RawMessage(`{"to":"a@b.c"}`))}}},
+		StubTurn{Text: "I could not send it."},
+	)
+	emit, events := collectEvents()
+
+	r, err := NewRunner(RunnerConfig{Provider: stub, Tools: src, Approval: denyAll{reason: "declined by user"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := r.Run(context.Background(), []Message{{Role: RoleUser, Text: "email a@b.c"}}, emit)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if called {
+		t.Fatal("denied tool must not execute")
+	}
+	if res.Steps != 2 || res.Text != "I could not send it." {
+		t.Fatalf("turn should continue past the denial: %+v", res)
+	}
+
+	// The denial surfaces as a distinct event and as model-visible tool text.
+	want := []EventKind{EventTurnBegin, EventToolBegin, EventToolDenied, EventTextDelta, EventTurnEnd}
+	if fmt.Sprint(kinds(*events)) != fmt.Sprint(want) {
+		t.Fatalf("events = %v, want %v", kinds(*events), want)
+	}
+	var denied *Event
+	for i := range *events {
+		if (*events)[i].Kind == EventToolDenied {
+			denied = &(*events)[i]
+		}
+	}
+	if denied == nil || denied.Reason != "declined by user" || denied.ToolCall.Name != "send_email" {
+		t.Fatalf("tool-denied event = %+v", denied)
+	}
+	toolMsg := stub.Requests()[1].Messages[2]
+	if toolMsg.Role != RoleTool || !strings.Contains(toolMsg.Text, "not permitted") || !strings.Contains(toolMsg.Text, "declined by user") {
+		t.Fatalf("model-visible denial text = %+v", toolMsg)
+	}
+}
+
+func TestRunnerApprovalAllowedRunsTool(t *testing.T) {
+	called := false
+	src := NewFuncSource()
+	AddFunc(src, "read_status", "reads status", func(ctx context.Context, _ struct{}) (string, error) {
+		called = true
+		return "green", nil
+	})
+	stub := NewStubProvider(
+		StubTurn{ToolCalls: []ToolCall{{ID: "c1", Name: "read_status", Args: core.NewRawJSON(json.RawMessage(`{}`))}}},
+		StubTurn{Text: "Status is green."},
+	)
+	emit, events := collectEvents()
+
+	r, err := NewRunner(RunnerConfig{Provider: stub, Tools: src,
+		Approval: NewTieredApproval(WithDefaultMode(ModeAlwaysAllow))})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Run(context.Background(), []Message{{Role: RoleUser, Text: "status?"}}, emit); err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Fatal("allowed tool should execute")
+	}
+	want := []EventKind{EventTurnBegin, EventToolBegin, EventToolEnd, EventTextDelta, EventTurnEnd}
+	if fmt.Sprint(kinds(*events)) != fmt.Sprint(want) {
+		t.Fatalf("allowed path should reach tool-end: %v", kinds(*events))
 	}
 }
 


### PR DESCRIPTION
Closes #929.

## What changes

The Runner no longer necessarily auto-dispatches every tool call. A new optional `RunnerConfig.Approval` gates each call before it runs: per call the policy returns allow / ask / deny. A refusal is fed back to the model as a normal tool result and the turn continues (error-as-feedback, never an abort); an allow runs the call unchanged. `Approval` nil means the pre-approval behavior exactly, so existing callers are untouched.

`TieredApproval` is the batteries-included policy: a default mode (`AlwaysAsk` / `ReadOnlyAuto` / `AlwaysAllow`), per-tool rule overrides (`Allow` / `Ask` / `Deny`), an "ask" seam, and an optional session cache that remembers a tool the user approved. The read-only-auto tier keys on the tool's `readOnlyHint` annotation.

This is the first Phase 0 ticket of the agent SDK roadmap and the single most consistent feature across the surveyed coding agents.

## Reviewer's guide

Read in this order:
1. [agent/approval.go](https://github.com/panyam/mcpkit/pull/947/files#diff-11c4a6606bfa4e71640728dfdff9b37b317a21e7e704f5ed64763a11da5d6b71) — start here. The `ApprovalPolicy` interface + `TieredApproval` decision order (remembered → per-tool rule → mode).
2. [agent/runner.go](https://github.com/panyam/mcpkit/pull/947/files#diff-6d787b427ac08cd61669af7e34ff0b747c4264d20b31b21b681a2ec2c826d9f0) — the gate in `callTool` (before `Tools.Call`) and the `tools` threading through `dispatch` for the read-only signal.
3. [agent/elicitation.go](https://github.com/panyam/mcpkit/pull/947/files#diff-2d804aa4234f872c7df3e37d37027a7b9966b60f48c37986a311e040e8cf19e7) — the `Confirm` helper: how "ask" reuses the existing FIFO coordinator instead of a new UI seam.
4. [agent/events.go](https://github.com/panyam/mcpkit/pull/947/files#diff-decf072b43cd6fba38445f5ab18d681fd6e933ca6b9e6bdf51d6bd95ac2977b7) — the additive `EventToolDenied` kind + `Reason` field.
5. [agent/approval_test.go](https://github.com/panyam/mcpkit/pull/947/files#diff-102f8eb8075887e0623581710f1cfa3a5a454f03f566f6d3601d00e1cabc73c7) + [agent/runner_test.go](https://github.com/panyam/mcpkit/pull/947/files#diff-ffe83771b6f02efdc6a2e9656bb6e78ecd3a3d187223e173d416979cb429ec34) — unit + gate acceptance.

Skim or skip: the one-line `EventToolDenied` case added to the existing round-trip test.

## How it works (decision order)

```
Approve(req):
  if remember and remembered[req.ToolName]: return ALLOW
  if per-tool rule exists for req.ToolName:
     Allow -> ALLOW ; Deny -> DENY(reason) ; Ask -> ask()
  switch default mode:
     AlwaysAllow   -> ALLOW
     ReadOnlyAuto  -> req.ReadOnly ? ALLOW : ask()
     AlwaysAsk     -> ask()

ask():
  if no AskFunc wired -> DENY("no approval UI available")   # fail-closed
  ok = AskFunc(req)   # e.g. coordinator.Confirm
  if not ok -> DENY("declined by user")
  if remember -> remembered[req.ToolName] = true
  return ALLOW
```

The subtlety a reviewer should confirm: a missing per-tool rule must fall through to the mode, not be read as the zero-value `RuleAsk`. That is the `if rule, ok := t.rules[name]; ok` guard (a bug I caught in testing — without the comma-ok, every uncovered tool asked and the mode was dead code).

## Decision log

- **The gate lives in `callTool`, the policy is an interface on `RunnerConfig`.** The Runner stays ignorant of approval UI mechanics; it only asks a policy allow/deny. Wiring a coordinator into a concrete policy happens at the host layer.
- **"Ask" reuses `ElicitationCoordinator` via a new `Confirm` helper, no new UI seam.** An approval prompt is an elicitation; the coordinator's strict FIFO already prevents parallel dispatch from stacking N dialogs. The prompt is deliberately not an event (mirrors elicitation's absence from the event taxonomy).
- **Denial is a new `EventToolDenied` kind, not reused `EventToolError`.** A policy refusal is not a dispatch failure; a surface should render it distinctly. Added a `Reason` field rather than overloading `Error`.
- **Read-only signal comes from `readOnlyHint` annotations**, threaded from the step's already-listed tools into `dispatch`. No new source of truth.
- **`nil` Approval = today's behavior**, so the whole change is additive and backward compatible.

## Risk / blast radius

- Affects: `agent/` only. `dispatch`/`callTool` are private; the sole public surface additions are `RunnerConfig.Approval`, the `agent/approval.go` types, `EventToolDenied` + `Event.Reason`, and `ElicitationCoordinator.Confirm`.
- Tests: `agent/approval_test.go` (tiered policy, all modes/rules/remember/decline/no-UI/error paths + `toolReadOnly`), `agent/runner_test.go` (deny → model-visible + turn continues + tool never runs; allow → tool runs; round-trip for the new event). `make test-agent` green across all six agent modules.
- Be paranoid about: the concurrency of the remember-cache under parallel dispatch (guarded by a mutex); the fail-closed default when no `AskFunc` is wired.

## Before / after

Behavioral, an agent asked to send an email under a deny policy:

```
before (no approval gate):
  > email a@b.c
  ⚙ send_email({"to":"a@b.c"})
    ✓ send_email: sent          # the mail actually went out
  Done.

after (Approval refuses):
  > email a@b.c
  ⚙ send_email({"to":"a@b.c"})
    ⃠ send_email: not permitted (declined by user)   # tool never ran
  I could not send it.          # model told, turn continues
```

Gate placement in the loop:

```mermaid
flowchart LR
  model[model tool call] --> bind[bind args]
  bind --> gate{Approval?}
  gate -- "nil / allow" --> call[ToolSource.Call]
  gate -- "deny" --> denied[emit EventToolDenied<br/>feed 'not permitted' back]
  call --> emitEnd[emit EventToolEnd]
  denied --> loop[turn continues]
  emitEnd --> loop
```

## Out of scope (deliberately deferred)

- Host / agentchat wiring (config mode, terminal "approve?" prompt built on `coord.Confirm`, a `/yolo` toggle) — the immediate follow-up, keeps this PR to the agent primitive.
- Per-source rules (rules are per-tool-name today); `ApprovalRequest` can carry a source once the ToolSource exposes it.

