### PR TITLE
feat(agent/host): wire the approval ladder into the host (issue 929 follow-up)

### DIFF
--- a/agent/approval.go
+++ b/agent/approval.go
@@ -129,19 +129,34 @@ func NewTieredApproval(opts ...TieredOption) *TieredApproval {
 	return t
 }
 
+// SetDefaultMode changes the default mode at runtime (the seam a host's
+// "/approve <mode>" or "/yolo" command uses). Concurrency-safe against calls
+// in flight; per-tool rules and the remember-cache are unaffected.
+func (t *TieredApproval) SetDefaultMode(m ApprovalMode) {
+	t.mu.Lock()
+	t.mode = m
+	t.mu.Unlock()
+}
+
+// DefaultMode reports the current default mode.
+func (t *TieredApproval) DefaultMode() ApprovalMode {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.mode
+}
+
 // Approve applies, in order: a remembered approval, a per-tool rule, then the
 // default mode. An ask that the user accepts is remembered when the cache is
 // on. A refusal (rule Deny, an ask returning false, or an ask with no AskFunc
 // wired) yields Allowed:false with a Reason; the Runner feeds that back to the
 // model and continues the turn.
 func (t *TieredApproval) Approve(ctx context.Context, req ApprovalRequest) (ApprovalDecision, error) {
-	if t.remember {
-		t.mu.Lock()
-		ok := t.remembered[req.ToolName]
-		t.mu.Unlock()
-		if ok {
-			return ApprovalDecision{Allowed: true}, nil
-		}
+	t.mu.Lock()
+	mode := t.mode
+	remembered := t.remember && t.remembered[req.ToolName]
+	t.mu.Unlock()
+	if remembered {
+		return ApprovalDecision{Allowed: true}, nil
 	}
 
 	if rule, ok := t.rules[req.ToolName]; ok {
@@ -155,7 +170,7 @@ func (t *TieredApproval) Approve(ctx context.Context, req ApprovalRequest) (Appr
 		}
 	}
 
-	switch t.mode {
+	switch mode {
 	case ModeAlwaysAllow:
 		return ApprovalDecision{Allowed: true}, nil
 	case ModeReadOnlyAuto:

--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -31,6 +31,7 @@ type App struct {
 
 	injection *agent.InjectionPolicy
 	triggers  *agent.TriggerPolicy
+	approval  *agent.TieredApproval
 	fanIn     *gocurrent.FanIn[agent.IncomingEvent]
 	streams   []*eventsclient.StreamCall
 	tasksMu   sync.Mutex
@@ -100,6 +101,12 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 
 	multi := agent.NewMultiSource()
 	app := &App{cfg: cfg, sources: multi, renderer: rend, bgTasks: map[string]*client.BackgroundTask{}, subs: map[string]*subscription{}}
+	// The approval "ask" prompt rides the same FIFO seam as elicitation, so a
+	// gated tool call never stacks a dialog against a concurrent elicitation.
+	ask := func(ctx context.Context, req agent.ApprovalRequest) (bool, error) {
+		return coord.Confirm(ctx, approvalPrompt(req))
+	}
+	app.approval = cfg.Approval.buildApproval(ask)
 
 	for _, sc := range cfg.Servers {
 		copts := []client.ClientOption{
@@ -211,13 +218,19 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 		}
 	}
 
-	runner, err := agent.NewRunner(agent.RunnerConfig{
+	runnerCfg := agent.RunnerConfig{
 		Provider:       provider,
 		Tools:          multi,
 		Instructions:   instructions,
 		MaxSteps:       cfg.MaxSteps,
 		TracerProvider: o.tp,
-	})
+	}
+	// Only set Approval when a policy exists: a nil *TieredApproval boxed in
+	// the interface would read as non-nil and gate every call to a deny.
+	if app.approval != nil {
+		runnerCfg.Approval = app.approval
+	}
+	runner, err := agent.NewRunner(runnerCfg)
 	if err != nil {
 		app.Close()
 		return nil, err
@@ -292,6 +305,17 @@ func (a *App) Tools(ctx context.Context) error {
 	return nil
 }
 
+// setApprovalMode handles "/approve <mode>": it flips the live policy's
+// default disposition. A no-op with a note when approval is not configured.
+func (a *App) setApprovalMode(arg string) {
+	if a.approval == nil {
+		a.renderer.approvalMode(nil)
+		return
+	}
+	a.approval.SetDefaultMode(parseApprovalMode(arg))
+	a.renderer.approvalMode(a.approval)
+}
+
 // REPL runs the interactive loop until EOF or /quit. turnCtx wraps each
 // turn so the caller's signal handling can cancel the in-flight turn
 // without killing the loop.
@@ -319,6 +343,10 @@ func (a *App) REPL(ctx context.Context, in io.Reader, turnCtx func() (context.Co
 			a.renderer.taskList(a.snapshotTasks())
 		case strings.HasPrefix(line, "/tasks cancel "):
 			a.cancelTask(strings.TrimPrefix(line, "/tasks cancel "))
+		case line == "/approve":
+			a.renderer.approvalMode(a.approval)
+		case strings.HasPrefix(line, "/approve "):
+			a.setApprovalMode(strings.TrimPrefix(line, "/approve "))
 		default:
 			tctx, cancel := turnCtx()
 			a.RunTurn(tctx, line)

--- a/agent/host/app_test.go
+++ b/agent/host/app_test.go
@@ -196,6 +196,104 @@ func TestREPLCommandsAndQuit(t *testing.T) {
 	}
 }
 
+func TestAppApprovalDenyRuleBlocksTool(t *testing.T) {
+	ts := startTestServer(t)
+	cfg := testConfig(ts.URL)
+	cfg.Approval = &ApprovalConfig{Rules: map[string]string{"echo": "deny"}}
+
+	stub := agent.NewStubProvider(
+		agent.StubTurn{ToolCalls: []agent.ToolCall{{ID: "c1", Name: "echo", Args: core.NewRawJSON(json.RawMessage(`{"message":"hi"}`))}}},
+		agent.StubTurn{Text: "I was not allowed to echo."},
+	)
+	var out strings.Builder
+	app, err := NewApp(cfg, &out, strings.NewReader(""), WithProvider(stub))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Close()
+
+	if err := app.RunTurn(context.Background(), "echo hi"); err != nil {
+		t.Fatal(err)
+	}
+	transcript := out.String()
+	if !strings.Contains(transcript, "⃠ echo not permitted") {
+		t.Fatalf("transcript missing denial line:\n%s", transcript)
+	}
+	if strings.Contains(transcript, "✓ echo:") {
+		t.Fatalf("denied tool must not run:\n%s", transcript)
+	}
+	// The model is told and the turn continues to its text answer.
+	toolMsg := stub.Requests()[1].Messages[2]
+	if toolMsg.Role != agent.RoleTool || !strings.Contains(toolMsg.Text, "not permitted") {
+		t.Fatalf("model-visible denial missing: %+v", toolMsg)
+	}
+	if !strings.Contains(transcript, "I was not allowed to echo.") {
+		t.Fatalf("turn should continue after denial:\n%s", transcript)
+	}
+}
+
+func TestAppApprovalAskApproves(t *testing.T) {
+	ts := startTestServer(t)
+	cfg := testConfig(ts.URL)
+	cfg.Approval = &ApprovalConfig{Mode: "ask"}
+
+	stub := agent.NewStubProvider(
+		agent.StubTurn{ToolCalls: []agent.ToolCall{{ID: "c1", Name: "echo", Args: core.NewRawJSON(json.RawMessage(`{"message":"hi"}`))}}},
+		agent.StubTurn{Text: "The server said: echo: hi"},
+	)
+	var out strings.Builder
+	// The approval prompt is a boolean "confirm" elicitation; "y" accepts it.
+	app, err := NewApp(cfg, &out, strings.NewReader("y\n"), WithProvider(stub))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Close()
+
+	if err := app.RunTurn(context.Background(), "echo hi"); err != nil {
+		t.Fatal(err)
+	}
+	transcript := out.String()
+	for _, want := range []string{`Allow tool call "echo"`, "✓ echo: echo: hi", "The server said: echo: hi"} {
+		if !strings.Contains(transcript, want) {
+			t.Fatalf("transcript missing %q:\n%s", want, transcript)
+		}
+	}
+}
+
+func TestAppApprovalRuntimeToggle(t *testing.T) {
+	ts := startTestServer(t)
+
+	// With a policy configured, /approve reports and changes the mode.
+	cfg := testConfig(ts.URL)
+	cfg.Approval = &ApprovalConfig{Mode: "ask"}
+	var out strings.Builder
+	app, err := NewApp(cfg, &out, strings.NewReader(""), WithProvider(agent.NewStubProvider(agent.StubTurn{Text: "x"})))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Close()
+
+	app.setApprovalMode("allow")
+	if app.approval.DefaultMode() != agent.ModeAlwaysAllow {
+		t.Fatalf("runtime toggle did not take: %v", app.approval.DefaultMode())
+	}
+	if !strings.Contains(out.String(), "approval: allow") {
+		t.Fatalf("toggle should render new mode:\n%s", out.String())
+	}
+
+	// Without a policy, /approve is a no-op that reports the gate is off.
+	var out2 strings.Builder
+	app2, err := NewApp(testConfig(ts.URL), &out2, strings.NewReader(""), WithProvider(agent.NewStubProvider(agent.StubTurn{Text: "x"})))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app2.Close()
+	app2.setApprovalMode("allow")
+	if !strings.Contains(out2.String(), "approval: off") {
+		t.Fatalf("no-policy toggle should say off:\n%s", out2.String())
+	}
+}
+
 func TestConfigLoadingAndValidation(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "cfg.json")

--- a/agent/host/config.go
+++ b/agent/host/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/panyam/mcpkit/agent"
@@ -41,6 +42,103 @@ type Config struct {
 	// and a transcript line; /tasks manages running tasks). Zero uses the
 	// 10s default; negative disables detaching (wait inline forever).
 	TaskGraceSec int `json:"taskGraceSec,omitempty"`
+
+	// Approval configures the tool-call permission ladder. Nil means the
+	// gate is off: every tool call the model makes runs (the pre-approval
+	// behavior). Set it to gate calls behind a mode and per-tool rules,
+	// with "ask" prompts routed through the terminal elicitation UI.
+	Approval *ApprovalConfig `json:"approval,omitempty"`
+}
+
+// ApprovalConfig is the host's view of the agent approval ladder. It maps to
+// an agent.TieredApproval whose "ask" outcome is presented through the same
+// terminal UI as elicitation (via ElicitationCoordinator.Confirm).
+type ApprovalConfig struct {
+	// Mode is the default disposition for calls no rule covers: "ask"
+	// (default), "read-only-auto" (auto-allow tools that declare the
+	// readOnlyHint annotation, ask for the rest), or "allow" (run
+	// everything, "yolo"). An unknown value falls back to "ask".
+	Mode string `json:"mode,omitempty"`
+
+	// Rules pins per-tool overrides that win over Mode: tool name ->
+	// "allow" | "ask" | "deny". Unknown rule values are ignored.
+	Rules map[string]string `json:"rules,omitempty"`
+
+	// Remember caches a tool the user approved so later calls to it skip the
+	// prompt for the life of the session.
+	Remember bool `json:"remember,omitempty"`
+}
+
+// approvalPrompt renders the yes/no question shown when a tool call needs
+// approval. The args are trimmed so a large payload does not flood the prompt.
+func approvalPrompt(req agent.ApprovalRequest) string {
+	args := strings.TrimSpace(string(req.Args.Raw()))
+	if len(args) > 200 {
+		args = args[:200] + "…"
+	}
+	if args == "" || args == "{}" {
+		return fmt.Sprintf("Allow tool call %q?", req.ToolName)
+	}
+	return fmt.Sprintf("Allow tool call %q with %s?", req.ToolName, args)
+}
+
+// parseApprovalMode maps a config string to an agent mode, defaulting to ask.
+func parseApprovalMode(s string) agent.ApprovalMode {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "allow", "yolo", "auto", "full-auto":
+		return agent.ModeAlwaysAllow
+	case "read-only-auto", "readonly", "read-only", "auto-edit":
+		return agent.ModeReadOnlyAuto
+	default:
+		return agent.ModeAlwaysAsk
+	}
+}
+
+// approvalModeName is the inverse of parseApprovalMode for display.
+func approvalModeName(m agent.ApprovalMode) string {
+	switch m {
+	case agent.ModeAlwaysAllow:
+		return "allow"
+	case agent.ModeReadOnlyAuto:
+		return "read-only-auto"
+	default:
+		return "ask"
+	}
+}
+
+// parseToolRule maps a config rule string to an agent rule; ok is false for an
+// unrecognized value so the caller can skip it.
+func parseToolRule(s string) (agent.ToolRule, bool) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "allow":
+		return agent.RuleAllow, true
+	case "deny":
+		return agent.RuleDeny, true
+	case "ask":
+		return agent.RuleAsk, true
+	default:
+		return 0, false
+	}
+}
+
+// buildApproval turns the config into a live policy whose ask seam presents
+// through the shared elicitation coordinator. Returns nil when no approval is
+// configured (the Runner then runs every call).
+func (c *ApprovalConfig) buildApproval(confirm agent.AskFunc) *agent.TieredApproval {
+	if c == nil {
+		return nil
+	}
+	opts := []agent.TieredOption{
+		agent.WithDefaultMode(parseApprovalMode(c.Mode)),
+		agent.WithAsk(confirm),
+		agent.WithRememberApprovals(c.Remember),
+	}
+	for tool, r := range c.Rules {
+		if rule, ok := parseToolRule(r); ok {
+			opts = append(opts, agent.WithToolRule(tool, rule))
+		}
+	}
+	return agent.NewTieredApproval(opts...)
 }
 
 // taskGrace resolves the configured grace window.

--- a/agent/host/render.go
+++ b/agent/host/render.go
@@ -60,9 +60,21 @@ func (r *renderer) handle(e agent.Event) {
 		fmt.Fprintf(r.out, "%s\n", r.dim("  "+status+" "+e.ToolCall.Name+": "+snippet(resultText(e.ToolResult), 100)))
 	case agent.EventToolError:
 		fmt.Fprintf(r.out, "%s\n", r.dim("  ✗ "+e.ToolCall.Name+" failed: "+snippet(e.Error, 120)))
+	case agent.EventToolDenied:
+		fmt.Fprintf(r.out, "%s\n", r.dim("  ⃠ "+e.ToolCall.Name+" not permitted: "+snippet(e.Reason, 120)))
 	case agent.EventError:
 		r.breakLine()
 	}
+}
+
+// approvalMode reports the host's current approval disposition (the /approve
+// command). A nil policy means the gate is off (every call runs).
+func (r *renderer) approvalMode(p *agent.TieredApproval) {
+	if p == nil {
+		fmt.Fprintf(r.out, "%s\n", r.dim("approval: off (every tool call runs)"))
+		return
+	}
+	fmt.Fprintf(r.out, "%s\n", r.dim("approval: "+approvalModeName(p.DefaultMode())))
 }
 
 func (r *renderer) breakLine() {

--- a/agent/runner.go
+++ b/agent/runner.go
@@ -60,6 +60,16 @@ type RunnerConfig struct {
 	// (a tool-denied event, then the turn continues), never a turn abort.
 	// Nil means every call runs, the pre-approval behavior.
 	Approval ApprovalPolicy
+
+	// ResponseSchema, when set, coerces the turn's final answer into
+	// structured output. After the tool loop reaches its terminal
+	// no-tool-call text, the Runner makes one additional Generate call with
+	// this schema (and no tools) and puts the JSON document on
+	// TurnResult.Structured. Tools and a response schema are never sent in
+	// the same request (many endpoints forbid it), which is why this is a
+	// separate finalizing call rather than a field on the loop's requests.
+	// Empty means no structured coercion.
+	ResponseSchema core.RawJSON
 }
 
 // ToolSelector narrows the model-facing tool set for one step. Returning the
@@ -99,6 +109,12 @@ type TurnResult struct {
 	Usage        Usage     `json:"usage"`
 	Steps        int       `json:"steps"`
 	FinishReason string    `json:"finishReason,omitempty"`
+
+	// Structured is the schema-coerced final answer, present only when
+	// RunnerConfig.ResponseSchema was set. It is the JSON document from the
+	// finalizing Generate call; Bind it into a typed value. Its Usage is
+	// already folded into Usage above. Empty when no schema was configured.
+	Structured core.RawJSON `json:"structured,omitempty"`
 }
 
 // Run executes one turn against history. Events stream to emit (nil is
@@ -169,12 +185,21 @@ func (r *Runner) Run(ctx context.Context, history []Message, emit func(Event)) (
 
 		if len(resp.ToolCalls) == 0 {
 			stepSpan.End()
+			var structured core.RawJSON
+			if r.cfg.ResponseSchema.Len() > 0 {
+				s, err := r.finalizeStructured(ctx, msgs, &usage)
+				if err != nil {
+					return nil, r.failSpan(emit, turnSpan, fmt.Errorf("agent: structured finalize: %w", err))
+				}
+				structured = s
+			}
 			result := &TurnResult{
 				Text:         resp.Text,
 				Messages:     added,
 				Usage:        usage,
 				Steps:        step,
 				FinishReason: resp.FinishReason,
+				Structured:   structured,
 			}
 			turnSpan.SetAttribute("agent.steps", fmt.Sprint(step))
 			turnSpan.SetAttribute("agent.finish_reason", resp.FinishReason)
@@ -240,6 +265,41 @@ func consumeStream(stream Stream, step int, emit func(Event)) (*ProviderResponse
 	}
 	endThinking()
 	return acc.Result(), nil
+}
+
+// structuredMaxAttempts bounds the finalizing Generate: one initial call plus
+// retries when the model returns text that is not valid JSON. Two total keeps
+// the extra cost low while absorbing the occasional near-miss.
+const structuredMaxAttempts = 2
+
+// finalizeStructured makes the schema-coercing Generate call over the finished
+// conversation (msgs already includes the terminal assistant text) with no
+// tools offered. It retries up to structuredMaxAttempts when the returned text
+// is not valid JSON, folding each call's usage into usage. A provider error
+// aborts (the caller asked for structured output and cannot get it); after the
+// retry budget it returns the last output best-effort so a caller's Bind, not
+// a lost turn, surfaces a still-malformed document.
+func (r *Runner) finalizeStructured(ctx context.Context, msgs []Message, usage *Usage) (core.RawJSON, error) {
+	var last string
+	for attempt := 0; attempt < structuredMaxAttempts; attempt++ {
+		resp, err := r.cfg.Provider.Generate(ctx, ProviderRequest{
+			Instructions:   r.cfg.Instructions,
+			Messages:       msgs,
+			ResponseSchema: r.cfg.ResponseSchema,
+		})
+		if err != nil {
+			return core.RawJSON{}, err
+		}
+		if resp.Usage != nil {
+			usage.InputTokens += resp.Usage.InputTokens
+			usage.OutputTokens += resp.Usage.OutputTokens
+		}
+		last = resp.Text
+		if json.Valid([]byte(last)) {
+			return core.NewRawJSON(json.RawMessage(last)), nil
+		}
+	}
+	return core.NewRawJSON(json.RawMessage(last)), nil
 }
 
 // dispatch runs the step's tool calls concurrently, serializes event

--- a/agent/runner_test.go
+++ b/agent/runner_test.go
@@ -436,6 +436,96 @@ func TestRunnerApprovalAllowedRunsTool(t *testing.T) {
 	}
 }
 
+func TestRunnerStructuredFinalizesAfterTerminalText(t *testing.T) {
+	schema := core.NewRawJSON(json.RawMessage(`{"type":"object","properties":{"answer":{"type":"integer"}},"required":["answer"]}`))
+	stub := NewStubProvider(
+		StubTurn{Text: "The answer is 42."}, // terminal text (Stream)
+		StubTurn{Text: `{"answer":42}`},     // finalizing coercion (Generate)
+	)
+	r, err := NewRunner(RunnerConfig{Provider: stub, ResponseSchema: schema})
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := r.Run(context.Background(), []Message{{Role: RoleUser, Text: "what is the answer"}}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Text != "The answer is 42." {
+		t.Fatalf("text answer should be unchanged: %q", res.Text)
+	}
+	var got struct {
+		Answer int `json:"answer"`
+	}
+	if err := res.Structured.Bind(&got); err != nil || got.Answer != 42 {
+		t.Fatalf("structured = %s (bind err %v)", res.Structured.Raw(), err)
+	}
+	// The finalizing Generate consumed a second turn.
+	if len(stub.Requests()) != 2 {
+		t.Fatalf("want 2 provider calls (stream + finalize), got %d", len(stub.Requests()))
+	}
+	// The finalizing request carries the schema and offers no tools.
+	fin := stub.Requests()[1]
+	if fin.ResponseSchema.Len() == 0 || len(fin.Tools) != 0 {
+		t.Fatalf("finalize request should set schema and no tools: %+v", fin)
+	}
+}
+
+func TestRunnerNoSchemaSkipsFinalize(t *testing.T) {
+	stub := NewStubProvider(StubTurn{Text: "plain answer"})
+	r, err := NewRunner(RunnerConfig{Provider: stub})
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := r.Run(context.Background(), []Message{{Role: RoleUser, Text: "hi"}}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Structured.Len() != 0 {
+		t.Fatalf("no schema means no structured output: %s", res.Structured.Raw())
+	}
+	if len(stub.Requests()) != 1 {
+		t.Fatalf("no schema means no finalize call, got %d calls", len(stub.Requests()))
+	}
+}
+
+func TestRunnerStructuredRetriesInvalidJSON(t *testing.T) {
+	schema := core.NewRawJSON(json.RawMessage(`{"type":"object"}`))
+	stub := NewStubProvider(
+		StubTurn{Text: "done"},            // terminal text
+		StubTurn{Text: "not json at all"}, // first finalize: invalid
+		StubTurn{Text: `{"ok":true}`},     // retry: valid
+	)
+	r, err := NewRunner(RunnerConfig{Provider: stub, ResponseSchema: schema})
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := r.Run(context.Background(), []Message{{Role: RoleUser, Text: "go"}}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(res.Structured.Raw()) != `{"ok":true}` {
+		t.Fatalf("retry should have produced valid JSON, got %s", res.Structured.Raw())
+	}
+	if len(stub.Requests()) != 3 {
+		t.Fatalf("want stream + 2 finalize attempts = 3 calls, got %d", len(stub.Requests()))
+	}
+}
+
+func TestRunnerStructuredProviderErrorAbortsTurn(t *testing.T) {
+	schema := core.NewRawJSON(json.RawMessage(`{"type":"object"}`))
+	stub := NewStubProvider(
+		StubTurn{Text: "done"},                    // terminal text
+		StubTurn{Err: errors.New("upstream 500")}, // finalize fails
+	)
+	r, err := NewRunner(RunnerConfig{Provider: stub, ResponseSchema: schema})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Run(context.Background(), []Message{{Role: RoleUser, Text: "go"}}, nil); err == nil {
+		t.Fatal("a failed structured finalize must abort the turn")
+	}
+}
+
 func TestRunnerRequiresProvider(t *testing.T) {
 	if _, err := NewRunner(RunnerConfig{}); err == nil {
 		t.Fatal("want error for missing provider")


### PR DESCRIPTION
Closes #931 (the structured-output work from #950 was merged into this branch, so it now rides here to main).

Stacked on #947 (the agent approval primitive). Review/merge that first; this PR's base is `feat/929-approval-ladder`, so its diff will shrink to just the host changes once #947 lands.

## What changes

Wires the tool-call approval ladder into the host application core so a configured host actually gates tool calls and prompts the user, instead of the primitive sitting unused.

- **Config-driven.** `Config.Approval` (`ApprovalConfig{ Mode, Rules, Remember }`) builds an `agent.TieredApproval`. `Mode` is `ask` (default) / `read-only-auto` / `allow`; `Rules` pins per-tool `allow`/`ask`/`deny`. Nil `Approval` keeps the gate off, so every existing host and example is unchanged.
- **"Ask" reuses the terminal UI.** The ask seam is `ElicitationCoordinator.Confirm`, so an approval prompt renders through the same line-prompt UI as elicitation and inherits its strict-FIFO serialization (no stacked dialogs under parallel dispatch).
- **Runtime toggle.** A `/approve [mode]` REPL command reports and flips the live mode (`/approve allow` is the "yolo" switch). Backed by a new concurrency-safe `TieredApproval.SetDefaultMode`.
- **Denial is visible.** The renderer now surfaces the `tool-denied` event in the transcript.

## Reviewer's guide

Read in this order:
1. [agent/host/config.go](https://github.com/panyam/mcpkit/pull/948/files#diff-6aff502cc5cae4b9d9769752e8638899bab121e09de870b5d1320cc892c6bf2d) — `ApprovalConfig`, the mode/rule string parsers, `buildApproval` (the ask-seam adapter and the nil-means-off contract), and `approvalPrompt`.
2. [agent/host/app.go](https://github.com/panyam/mcpkit/pull/948/files#diff-89fb8e04b6e1e9d5f7f76958490ef158dee40e2cae92d87c04b408d893c84361) — where the policy is built (right after the coordinator) and set on the Runner (only when non-nil, to avoid the boxed-nil-interface trap), plus the `/approve` command and `setApprovalMode`.
3. [agent/host/app_test.go](https://github.com/panyam/mcpkit/pull/948/files#diff-adb435e0bb9377caf15474e795e422de5222a62d0f4f1af8af093bdf1d6bb6ce) — deny-rule blocks the tool, ask-approves runs it, runtime toggle.
4. [agent/approval.go](https://github.com/panyam/mcpkit/pull/948/files#diff-11c4a6606bfa4e71640728dfdff9b37b317a21e7e704f5ed64763a11da5d6b71) — the one agent-module addition: guarded `SetDefaultMode`/`DefaultMode` (rest of the file is #947).
5. [agent/host/render.go](https://github.com/panyam/mcpkit/pull/948/files#diff-da3546e85434193f7b8b2df15f4f6d6df496b616b9e0b0b8c4299cd4576e044a) — the `tool-denied` transcript line + `/approve` status.

## Decision log

- **`nil Approval` = gate off.** Preserves every existing host/example (they auto-run tools). Approval is strictly opt-in.
- **The ask seam is an adapter over `coord.Confirm`, not a second UI.** `AskFunc` takes an `ApprovalRequest`; `Confirm` takes a message; `approvalPrompt` bridges them. This is why an approval prompt looks and serializes exactly like an elicitation.
- **Set `RunnerConfig.Approval` only when non-nil.** A nil `*TieredApproval` boxed into the interface reads as non-nil and would gate every call to a deny. Guarded explicitly.
- **`SetDefaultMode` guards the mode with the existing mutex.** Runtime toggling races the Runner's parallel dispatch reading the mode, so both sides now take the lock.

## Risk / blast radius

- Affects: `agent/host` (new config, wiring, REPL command, render) and one additive method in `agent/approval.go`. No public signature changes; `Config.Approval` is a new optional field.
- Tests: `agent/host/app_test.go` (deny/ask/toggle end-to-end via StubProvider + scripted stdin). `make test-agent` green across all six agent modules.
- Be paranoid about: the boxed-nil-interface guard (covered by every existing no-approval test staying green), and the mode-mutation race (guarded).

## Before / after

`make agent`-style host run with `Config.Approval = {mode: ask}`, user declines:

```
before (no approval wiring):
  > email the team
  ⚙ send_email({"to":"team@co"})
    ✓ send_email: sent

after:
  > email the team
  ? Allow tool call "send_email" with {"to":"team@co"}?  [y/N]  n
  ⚙ send_email({"to":"team@co"})
    ⃠ send_email not permitted: declined by user
  I held off on sending that.
```

## Out of scope (deliberately deferred)

- Per-source rules (rules are per-tool-name); waits on the ToolSource exposing a source id on the call.
- A config example / docs pass for the new `approval` block → follow-up.