### PR TITLE
feat(agent): Anthropic-native Provider (issue 930)

### DIFF
--- a/agent/anthropic_provider.go
+++ b/agent/anthropic_provider.go
@@ -1,0 +1,467 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/panyam/mcpkit/core"
+	ssehttp "github.com/panyam/servicekit/http"
+)
+
+// DefaultAnthropicVersion is the anthropic-version header sent when
+// AnthropicConfig.Version is empty. 2023-06-01 is the documented stable
+// Messages API version.
+const DefaultAnthropicVersion = "2023-06-01"
+
+// defaultAnthropicMaxTokens is the max_tokens sent when AnthropicConfig.MaxTokens
+// is not positive. The Anthropic Messages API requires max_tokens on every
+// request.
+const defaultAnthropicMaxTokens = 4096
+
+// structuredOutputToolName is the synthetic tool used to coerce structured
+// output on Generate: Anthropic has no response_format, so a forced tool whose
+// input_schema is the caller's ResponseSchema is the equivalent mechanism.
+const structuredOutputToolName = "structured_output"
+
+// AnthropicConfig configures the Anthropic Messages API endpoint.
+type AnthropicConfig struct {
+	// BaseURL is the API root. The provider appends "/v1/messages". Defaults
+	// to "https://api.anthropic.com" when empty.
+	BaseURL string
+
+	// APIKey is sent as the x-api-key header. Required against the real API;
+	// may be empty for a local mock.
+	APIKey string
+
+	// Model is the model identifier sent on every request (required). The
+	// caller supplies it; the provider hardcodes none.
+	Model string
+
+	// MaxTokens caps the completion length sent on every request. Defaults to
+	// 4096 when not positive; a per-request ProviderRequest.MaxTokens overrides
+	// it.
+	MaxTokens int
+
+	// Version is the anthropic-version header. Defaults to
+	// DefaultAnthropicVersion when empty.
+	Version string
+
+	// HTTPClient overrides http.DefaultClient. Set this for proxies, custom
+	// TLS, or timeouts (note: an overall client timeout also bounds streaming
+	// reads; prefer per-request ctx deadlines for streams).
+	HTTPClient *http.Client
+}
+
+// AnthropicProvider implements Provider over the Anthropic Messages API wire
+// with no SDK dependency (net/http plus servicekit's WHATWG-conformant SSE
+// reader). Safe for concurrent use.
+type AnthropicProvider struct {
+	cfg  AnthropicConfig
+	http *http.Client
+}
+
+// NewAnthropicProvider validates cfg and returns a provider. Model is required;
+// BaseURL, MaxTokens, and Version fall back to defaults.
+func NewAnthropicProvider(cfg AnthropicConfig) (*AnthropicProvider, error) {
+	if cfg.Model == "" {
+		return nil, fmt.Errorf("agent: AnthropicConfig requires Model")
+	}
+	if cfg.BaseURL == "" {
+		cfg.BaseURL = "https://api.anthropic.com"
+	}
+	if cfg.Version == "" {
+		cfg.Version = DefaultAnthropicVersion
+	}
+	if cfg.MaxTokens <= 0 {
+		cfg.MaxTokens = defaultAnthropicMaxTokens
+	}
+	hc := cfg.HTTPClient
+	if hc == nil {
+		hc = http.DefaultClient
+	}
+	return &AnthropicProvider{cfg: cfg, http: hc}, nil
+}
+
+// Stream implements Provider. Anthropic SSE events map onto the Delta taxonomy:
+// content_block_start(tool_use) → DeltaToolCallStart, text_delta → DeltaText,
+// input_json_delta → DeltaToolCallArgs, thinking_delta → DeltaReasoning,
+// message_delta → DeltaFinish + DeltaUsage. The stream ends with io.EOF after
+// message_stop.
+func (p *AnthropicProvider) Stream(ctx context.Context, req ProviderRequest) (Stream, error) {
+	body := p.buildBody(req, true)
+	resp, err := p.post(ctx, body)
+	if err != nil {
+		return nil, err
+	}
+	return &anthropicStream{ctx: ctx, body: resp.Body, events: ssehttp.NewSSEEventReader(resp.Body)}, nil
+}
+
+// Generate implements Provider with a non-streaming request. When
+// req.ResponseSchema is set, the request forces a synthetic tool whose
+// input_schema is the schema and the tool_use input is returned in
+// ProviderResponse.Text (Anthropic has no response_format).
+func (p *AnthropicProvider) Generate(ctx context.Context, req ProviderRequest) (*ProviderResponse, error) {
+	structured := req.ResponseSchema.Len() > 0
+	body := p.buildBody(req, false)
+	resp, err := p.post(ctx, body)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var full struct {
+		Content    []anthropicContentBlock `json:"content"`
+		StopReason string                  `json:"stop_reason"`
+		Usage      *anthropicUsage         `json:"usage"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&full); err != nil {
+		return nil, fmt.Errorf("agent: decode message: %w", err)
+	}
+
+	out := &ProviderResponse{FinishReason: full.StopReason}
+	var text, reason strings.Builder
+	for _, block := range full.Content {
+		switch block.Type {
+		case "text":
+			text.WriteString(block.Text)
+		case "thinking":
+			reason.WriteString(block.Thinking)
+		case "tool_use":
+			args := block.Input
+			if len(args) == 0 {
+				args = json.RawMessage("{}")
+			}
+			if structured && block.Name == structuredOutputToolName {
+				// Structured output surfaces in Text (mirrors the OpenAI
+				// response_format path), not as a tool call.
+				out.Text = string(args)
+				continue
+			}
+			out.ToolCalls = append(out.ToolCalls, ToolCall{ID: block.ID, Name: block.Name, Args: core.NewRawJSON(args)})
+		}
+	}
+	if out.Text == "" {
+		out.Text = text.String()
+	}
+	out.Reasoning = reason.String()
+	if full.Usage != nil {
+		out.Usage = &Usage{InputTokens: full.Usage.InputTokens, OutputTokens: full.Usage.OutputTokens}
+	}
+	return out, nil
+}
+
+func (p *AnthropicProvider) post(ctx context.Context, body map[string]any) (*http.Response, error) {
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("agent: encode request: %w", err)
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		strings.TrimSuffix(p.cfg.BaseURL, "/")+"/v1/messages", bytes.NewReader(raw))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("anthropic-version", p.cfg.Version)
+	if p.cfg.APIKey != "" {
+		httpReq.Header.Set("x-api-key", p.cfg.APIKey)
+	}
+	resp, err := p.http.Do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		defer resp.Body.Close()
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return nil, &ProviderError{StatusCode: resp.StatusCode, Body: string(msg)}
+	}
+	return resp, nil
+}
+
+// buildBody produces the Messages API request. Kept as one method so the
+// wire-shape test pins the exact JSON we emit.
+func (p *AnthropicProvider) buildBody(req ProviderRequest, stream bool) map[string]any {
+	msgs := make([]map[string]any, 0, len(req.Messages))
+	for _, m := range req.Messages {
+		switch m.Role {
+		case RoleUser:
+			msgs = append(msgs, map[string]any{
+				"role":    "user",
+				"content": []map[string]any{{"type": "text", "text": m.Text}},
+			})
+		case RoleAssistant:
+			content := make([]map[string]any, 0, len(m.ToolCalls)+1)
+			if m.Text != "" {
+				content = append(content, map[string]any{"type": "text", "text": m.Text})
+			}
+			for _, tc := range m.ToolCalls {
+				content = append(content, map[string]any{
+					"type":  "tool_use",
+					"id":    tc.ID,
+					"name":  tc.Name,
+					"input": rawToInput(tc.Args),
+				})
+			}
+			msgs = append(msgs, map[string]any{"role": "assistant", "content": content})
+		case RoleTool:
+			msgs = append(msgs, map[string]any{
+				"role": "user",
+				"content": []map[string]any{{
+					"type":        "tool_result",
+					"tool_use_id": m.ToolCallID,
+					"content":     m.Text,
+				}},
+			})
+		default:
+			// RoleSystem carries mcpkit injected-context messages that live
+			// mid-history. Anthropic has no inline system role in the messages
+			// array (system is a top-level string), so each such message maps
+			// to a plain user text turn.
+			msgs = append(msgs, map[string]any{
+				"role":    "user",
+				"content": []map[string]any{{"type": "text", "text": m.Text}},
+			})
+		}
+	}
+
+	maxTokens := p.cfg.MaxTokens
+	if req.MaxTokens > 0 {
+		maxTokens = req.MaxTokens
+	}
+	body := map[string]any{
+		"model":      p.cfg.Model,
+		"messages":   msgs,
+		"max_tokens": maxTokens,
+	}
+	if req.Instructions != "" {
+		body["system"] = req.Instructions
+	}
+	if req.Temperature != nil {
+		body["temperature"] = *req.Temperature
+	}
+
+	tools := make([]map[string]any, 0, len(req.Tools)+1)
+	for _, td := range req.Tools {
+		tools = append(tools, map[string]any{
+			"name":         td.Name,
+			"description":  td.Description,
+			"input_schema": td.InputSchema,
+		})
+	}
+
+	structured := !stream && req.ResponseSchema.Len() > 0
+	if structured {
+		var schema any
+		if req.ResponseSchema.Bind(&schema) == nil {
+			tools = append(tools, map[string]any{
+				"name":         structuredOutputToolName,
+				"description":  "Return the response as structured output conforming to the schema.",
+				"input_schema": schema,
+			})
+			body["tools"] = tools
+			body["tool_choice"] = map[string]any{"type": "tool", "name": structuredOutputToolName}
+		}
+	} else if len(tools) > 0 {
+		body["tools"] = tools
+		if tc := anthropicToolChoice(req.ToolChoice); tc != nil {
+			body["tool_choice"] = tc
+		}
+	}
+
+	if stream {
+		body["stream"] = true
+	}
+	return body
+}
+
+// rawToInput decodes a tool call's JSON arguments into the object Anthropic's
+// tool_use.input expects. An empty or unparseable value becomes an empty
+// object.
+func rawToInput(args core.RawJSON) any {
+	if args.Len() == 0 {
+		return map[string]any{}
+	}
+	var v any
+	if args.Bind(&v) != nil || v == nil {
+		return map[string]any{}
+	}
+	return v
+}
+
+// anthropicToolChoice renders the Anthropic tool_choice value, or nil when the
+// choice is the provider default (auto is implicit, so we omit it).
+func anthropicToolChoice(tc ToolChoice) any {
+	switch tc.Mode {
+	case "auto":
+		return map[string]any{"type": "auto"}
+	case "required":
+		return map[string]any{"type": "any"}
+	case "none":
+		return map[string]any{"type": "none"}
+	case "function":
+		return map[string]any{"type": "tool", "name": tc.Name}
+	default: // "" — provider default
+		return nil
+	}
+}
+
+type anthropicUsage struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
+}
+
+type anthropicContentBlock struct {
+	Type     string          `json:"type"`
+	Text     string          `json:"text"`
+	Thinking string          `json:"thinking"`
+	ID       string          `json:"id"`
+	Name     string          `json:"name"`
+	Input    json.RawMessage `json:"input"`
+}
+
+// anthropicSSE is one decoded SSE data payload. Anthropic events are dispatched
+// on the JSON "type" field (which duplicates the SSE "event:" name), so the
+// stream adapter never needs the event line.
+type anthropicSSE struct {
+	Type    string `json:"type"`
+	Index   int    `json:"index"`
+	Message *struct {
+		Usage *anthropicUsage `json:"usage"`
+	} `json:"message"`
+	ContentBlock *struct {
+		Type string `json:"type"`
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"content_block"`
+	Delta *struct {
+		Type        string `json:"type"`
+		Text        string `json:"text"`
+		PartialJSON string `json:"partial_json"`
+		Thinking    string `json:"thinking"`
+		StopReason  string `json:"stop_reason"`
+	} `json:"delta"`
+	Usage *anthropicUsage `json:"usage"`
+	Error *struct {
+		Type    string `json:"type"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+// anthropicStream adapts the SSE body to the Stream interface via servicekit's
+// WHATWG-conformant SSEEventReader. Recv keeps a small queue because one SSE
+// event can expand to several Deltas (message_delta carries both finish and
+// usage). inputTokens is captured at message_start and folded into the usage
+// delta emitted at message_delta.
+type anthropicStream struct {
+	ctx         context.Context
+	body        io.ReadCloser
+	events      *ssehttp.SSEEventReader
+	queue       []Delta
+	inputTokens int
+	done        bool
+}
+
+// Recv implements Stream.
+func (s *anthropicStream) Recv() (Delta, error) {
+	for {
+		if len(s.queue) > 0 {
+			d := s.queue[0]
+			s.queue = s.queue[1:]
+			return d, nil
+		}
+		if s.done {
+			return Delta{}, io.EOF
+		}
+		if err := s.ctx.Err(); err != nil {
+			return Delta{}, err
+		}
+		ev, err := s.events.ReadEvent()
+		if err != nil {
+			if ctxErr := s.ctx.Err(); ctxErr != nil {
+				return Delta{}, ctxErr
+			}
+			// A partial event can ride along with io.EOF; process it before
+			// surfacing EOF on the next call.
+			if !errors.Is(err, io.EOF) || ev.Data == "" {
+				return Delta{}, err
+			}
+			s.done = true
+		}
+		payload := strings.TrimSpace(ev.Data)
+		if payload == "" {
+			continue
+		}
+		var msg anthropicSSE
+		if err := json.Unmarshal([]byte(payload), &msg); err != nil {
+			return Delta{}, fmt.Errorf("agent: bad SSE event: %w", err)
+		}
+		if err := s.enqueue(msg); err != nil {
+			return Delta{}, err
+		}
+	}
+}
+
+func (s *anthropicStream) enqueue(msg anthropicSSE) error {
+	switch msg.Type {
+	case "message_start":
+		if msg.Message != nil && msg.Message.Usage != nil {
+			s.inputTokens = msg.Message.Usage.InputTokens
+		}
+	case "content_block_start":
+		if msg.ContentBlock != nil && msg.ContentBlock.Type == "tool_use" {
+			s.queue = append(s.queue, Delta{
+				Kind:       DeltaToolCallStart,
+				Index:      msg.Index,
+				ToolCallID: msg.ContentBlock.ID,
+				ToolName:   msg.ContentBlock.Name,
+			})
+		}
+	case "content_block_delta":
+		if msg.Delta == nil {
+			return nil
+		}
+		switch msg.Delta.Type {
+		case "text_delta":
+			if msg.Delta.Text != "" {
+				s.queue = append(s.queue, Delta{Kind: DeltaText, Text: msg.Delta.Text})
+			}
+		case "input_json_delta":
+			if msg.Delta.PartialJSON != "" {
+				s.queue = append(s.queue, Delta{Kind: DeltaToolCallArgs, Index: msg.Index, Text: msg.Delta.PartialJSON})
+			}
+		case "thinking_delta":
+			if msg.Delta.Thinking != "" {
+				s.queue = append(s.queue, Delta{Kind: DeltaReasoning, Text: msg.Delta.Thinking})
+			}
+		}
+	case "message_delta":
+		if msg.Delta != nil && msg.Delta.StopReason != "" {
+			s.queue = append(s.queue, Delta{Kind: DeltaFinish, FinishReason: msg.Delta.StopReason})
+		}
+		if msg.Usage != nil {
+			s.queue = append(s.queue, Delta{Kind: DeltaUsage, Usage: &Usage{
+				InputTokens:  s.inputTokens,
+				OutputTokens: msg.Usage.OutputTokens,
+			}})
+		}
+	case "message_stop":
+		s.done = true
+	case "error":
+		if msg.Error != nil {
+			return fmt.Errorf("agent: anthropic stream error (%s): %s", msg.Error.Type, msg.Error.Message)
+		}
+		return errors.New("agent: anthropic stream error")
+	}
+	// content_block_stop and ping carry no deltas.
+	return nil
+}
+
+// Close implements Stream.
+func (s *anthropicStream) Close() error {
+	return s.body.Close()
+}

--- a/agent/anthropic_provider_test.go
+++ b/agent/anthropic_provider_test.go
@@ -1,0 +1,394 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+func newTestAnthropic(t *testing.T, url string) *AnthropicProvider {
+	t.Helper()
+	p, err := NewAnthropicProvider(AnthropicConfig{BaseURL: url, Model: "claude-test", APIKey: "sk-test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// jsonEq compares two JSON documents by structure (key order independent).
+func jsonEq(t *testing.T, got []byte, want string) {
+	t.Helper()
+	var g, w any
+	if err := json.Unmarshal(got, &g); err != nil {
+		t.Fatalf("unmarshal got: %v (%s)", err, got)
+	}
+	if err := json.Unmarshal([]byte(want), &w); err != nil {
+		t.Fatalf("unmarshal want: %v", err)
+	}
+	if !reflect.DeepEqual(g, w) {
+		t.Fatalf("wire shape drift:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func collectDeltas(t *testing.T, s Stream) []Delta {
+	t.Helper()
+	var out []Delta
+	for {
+		d, err := s.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("recv: %v", err)
+		}
+		out = append(out, d)
+	}
+	return out
+}
+
+func TestAnthropicBuildBodyRolesAndTools(t *testing.T) {
+	temp := 0.2
+	p := newTestAnthropic(t, "http://unused")
+	body := p.buildBody(ProviderRequest{
+		Instructions: "be brief",
+		Messages: []Message{
+			{Role: RoleUser, Text: "hi"},
+			{Role: RoleAssistant, Text: "using tool", ToolCalls: []ToolCall{
+				{ID: "c1", Name: "echo", Args: core.NewRawJSON(json.RawMessage(`{"message":"x"}`))},
+			}},
+			{Role: RoleTool, ToolCallID: "c1", Text: "echo: x"},
+			{Role: RoleSystem, Text: "state changed"},
+		},
+		Tools:       []core.ToolDef{{Name: "echo", Description: "echoes", InputSchema: map[string]any{"type": "object"}}},
+		Temperature: &temp,
+		MaxTokens:   64,
+	}, true)
+
+	got, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `{
+		"model":"claude-test",
+		"max_tokens":64,
+		"system":"be brief",
+		"temperature":0.2,
+		"stream":true,
+		"messages":[
+			{"role":"user","content":[{"type":"text","text":"hi"}]},
+			{"role":"assistant","content":[
+				{"type":"text","text":"using tool"},
+				{"type":"tool_use","id":"c1","name":"echo","input":{"message":"x"}}
+			]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"c1","content":"echo: x"}]},
+			{"role":"user","content":[{"type":"text","text":"state changed"}]}
+		],
+		"tools":[{"name":"echo","description":"echoes","input_schema":{"type":"object"}}]
+	}`
+	jsonEq(t, got, want)
+}
+
+func TestAnthropicBuildBodyDefaultMaxTokensNoTools(t *testing.T) {
+	p := newTestAnthropic(t, "http://unused")
+	// No per-request MaxTokens, no tools, no instructions → config default
+	// max_tokens, no tools/tool_choice/system keys.
+	body := p.buildBody(ProviderRequest{Messages: []Message{{Role: RoleUser, Text: "hi"}}}, false)
+	if body["max_tokens"] != defaultAnthropicMaxTokens {
+		t.Fatalf("max_tokens = %v, want %d", body["max_tokens"], defaultAnthropicMaxTokens)
+	}
+	if _, ok := body["tools"]; ok {
+		t.Fatal("tools must be absent when none supplied")
+	}
+	if _, ok := body["tool_choice"]; ok {
+		t.Fatal("tool_choice must be absent when no tools")
+	}
+	if _, ok := body["system"]; ok {
+		t.Fatal("system must be absent when no instructions")
+	}
+	if _, ok := body["stream"]; ok {
+		t.Fatal("stream must be absent for Generate")
+	}
+}
+
+func TestAnthropicToolChoiceMapping(t *testing.T) {
+	p := newTestAnthropic(t, "http://unused")
+	tools := []core.ToolDef{{Name: "echo", InputSchema: map[string]any{"type": "object"}}}
+	cases := []struct {
+		choice ToolChoice
+		want   any // nil means the tool_choice key must be absent
+	}{
+		{ToolChoice{}, nil},
+		{ToolChoiceAuto, map[string]any{"type": "auto"}},
+		{ToolChoiceRequired, map[string]any{"type": "any"}},
+		{ToolChoiceNone, map[string]any{"type": "none"}},
+		{ToolChoiceFunc("echo"), map[string]any{"type": "tool", "name": "echo"}},
+	}
+	for _, c := range cases {
+		body := p.buildBody(ProviderRequest{
+			Messages:   []Message{{Role: RoleUser, Text: "hi"}},
+			Tools:      tools,
+			ToolChoice: c.choice,
+		}, true)
+		got, present := body["tool_choice"]
+		if c.want == nil {
+			if present {
+				t.Fatalf("choice %+v: tool_choice must be absent, got %v", c.choice, got)
+			}
+			continue
+		}
+		if !reflect.DeepEqual(got, c.want) {
+			t.Fatalf("choice %+v: tool_choice = %v, want %v", c.choice, got, c.want)
+		}
+	}
+}
+
+func TestAnthropicStreamTextFinishUsage(t *testing.T) {
+	ts := sseServer(t, nil,
+		`{"type":"message_start","message":{"usage":{"input_tokens":12,"output_tokens":1}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hel"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"lo"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":9}}`,
+		`{"type":"message_stop"}`,
+	)
+	defer ts.Close()
+
+	s, err := newTestAnthropic(t, ts.URL).Stream(context.Background(), ProviderRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	got := collectDeltas(t, s)
+	want := []Delta{
+		{Kind: DeltaText, Text: "Hel"},
+		{Kind: DeltaText, Text: "lo"},
+		{Kind: DeltaFinish, FinishReason: "end_turn"},
+		{Kind: DeltaUsage, Usage: &Usage{InputTokens: 12, OutputTokens: 9}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("delta sequence:\n got: %+v\nwant: %+v", got, want)
+	}
+
+	// The Accumulator folds the same stream into the completed response.
+	var acc Accumulator
+	for _, d := range got {
+		acc.Add(d)
+	}
+	res := acc.Result()
+	if res.Text != "Hello" || res.FinishReason != "end_turn" {
+		t.Fatalf("folded res = %+v", res)
+	}
+	if res.Usage == nil || res.Usage.InputTokens != 12 || res.Usage.OutputTokens != 9 {
+		t.Fatalf("usage = %+v", res.Usage)
+	}
+}
+
+func TestAnthropicStreamToolUse(t *testing.T) {
+	ts := sseServer(t, nil,
+		`{"type":"message_start","message":{"usage":{"input_tokens":5,"output_tokens":1}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"search"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"q\":"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"cats\"}"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":7}}`,
+		`{"type":"message_stop"}`,
+	)
+	defer ts.Close()
+
+	s, err := newTestAnthropic(t, ts.URL).Stream(context.Background(), ProviderRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	got := collectDeltas(t, s)
+	want := []Delta{
+		{Kind: DeltaToolCallStart, Index: 0, ToolCallID: "toolu_1", ToolName: "search"},
+		{Kind: DeltaToolCallArgs, Index: 0, Text: `{"q":`},
+		{Kind: DeltaToolCallArgs, Index: 0, Text: `"cats"}`},
+		{Kind: DeltaFinish, FinishReason: "tool_use"},
+		{Kind: DeltaUsage, Usage: &Usage{InputTokens: 5, OutputTokens: 7}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("delta sequence:\n got: %+v\nwant: %+v", got, want)
+	}
+
+	var acc Accumulator
+	for _, d := range got {
+		acc.Add(d)
+	}
+	res := acc.Result()
+	if len(res.ToolCalls) != 1 {
+		t.Fatalf("tool calls = %+v", res.ToolCalls)
+	}
+	call := res.ToolCalls[0]
+	if call.ID != "toolu_1" || call.Name != "search" || string(call.Args.Raw()) != `{"q":"cats"}` {
+		t.Fatalf("folded call = %+v args=%s", call, call.Args.Raw())
+	}
+	if res.FinishReason != "tool_use" {
+		t.Fatalf("finish = %q", res.FinishReason)
+	}
+}
+
+func TestAnthropicStreamThinking(t *testing.T) {
+	ts := sseServer(t, nil,
+		`{"type":"message_start","message":{"usage":{"input_tokens":3,"output_tokens":1}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"pondering"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"answer"}}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":4}}`,
+		`{"type":"message_stop"}`,
+	)
+	defer ts.Close()
+
+	s, err := newTestAnthropic(t, ts.URL).Stream(context.Background(), ProviderRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	res := drain(t, s)
+	if res.Reasoning != "pondering" || res.Text != "answer" {
+		t.Fatalf("res = %+v", res)
+	}
+}
+
+func TestAnthropicStreamHTTPError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(401)
+		io.WriteString(w, `{"type":"error","error":{"type":"authentication_error","message":"bad key"}}`)
+	}))
+	defer ts.Close()
+
+	_, err := newTestAnthropic(t, ts.URL).Stream(context.Background(), ProviderRequest{})
+	var perr *ProviderError
+	if !(err != nil) {
+		t.Fatal("want error")
+	}
+	if pe, ok := err.(*ProviderError); ok {
+		perr = pe
+	}
+	if perr == nil || perr.StatusCode != 401 {
+		t.Fatalf("want ProviderError 401, got %v", err)
+	}
+}
+
+func TestAnthropicHeaders(t *testing.T) {
+	var gotKey, gotVersion, gotType string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotKey = r.Header.Get("x-api-key")
+		gotVersion = r.Header.Get("anthropic-version")
+		gotType = r.Header.Get("Content-Type")
+		io.WriteString(w, `{"content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn"}`)
+	}))
+	defer ts.Close()
+
+	if _, err := newTestAnthropic(t, ts.URL).Generate(context.Background(), ProviderRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if gotKey != "sk-test" {
+		t.Fatalf("x-api-key = %q", gotKey)
+	}
+	if gotVersion != DefaultAnthropicVersion {
+		t.Fatalf("anthropic-version = %q", gotVersion)
+	}
+	if gotType != "application/json" {
+		t.Fatalf("content-type = %q", gotType)
+	}
+}
+
+func TestAnthropicGenerate(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, `{"content":[{"type":"text","text":"Hi there"}],"stop_reason":"end_turn","usage":{"input_tokens":8,"output_tokens":4}}`)
+	}))
+	defer ts.Close()
+
+	res, err := newTestAnthropic(t, ts.URL).Generate(context.Background(), ProviderRequest{
+		Messages: []Message{{Role: RoleUser, Text: "hi"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Text != "Hi there" || res.FinishReason != "end_turn" {
+		t.Fatalf("res = %+v", res)
+	}
+	if res.Usage == nil || res.Usage.InputTokens != 8 || res.Usage.OutputTokens != 4 {
+		t.Fatalf("usage = %+v", res.Usage)
+	}
+}
+
+func TestAnthropicGenerateToolCalls(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, `{"content":[{"type":"text","text":"let me"},{"type":"tool_use","id":"toolu_9","name":"go","input":{"x":1}}],"stop_reason":"tool_use"}`)
+	}))
+	defer ts.Close()
+
+	res, err := newTestAnthropic(t, ts.URL).Generate(context.Background(), ProviderRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Text != "let me" || res.FinishReason != "tool_use" {
+		t.Fatalf("res = %+v", res)
+	}
+	if len(res.ToolCalls) != 1 || res.ToolCalls[0].Name != "go" || string(res.ToolCalls[0].Args.Raw()) != `{"x":1}` {
+		t.Fatalf("tool calls = %+v", res.ToolCalls)
+	}
+}
+
+func TestAnthropicGenerateStructured(t *testing.T) {
+	var captured []byte
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured, _ = io.ReadAll(r.Body)
+		io.WriteString(w, `{"content":[{"type":"tool_use","id":"t","name":"structured_output","input":{"name":"trip"}}],"stop_reason":"tool_use","usage":{"input_tokens":5,"output_tokens":2}}`)
+	}))
+	defer ts.Close()
+
+	res, err := newTestAnthropic(t, ts.URL).Generate(context.Background(), ProviderRequest{
+		Messages:       []Message{{Role: RoleUser, Text: "name it"}},
+		ResponseSchema: core.NewRawJSON(json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}}}`)),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Structured output surfaces in Text, not as a tool call.
+	if res.Text != `{"name":"trip"}` {
+		t.Fatalf("structured text = %q", res.Text)
+	}
+	if len(res.ToolCalls) != 0 {
+		t.Fatalf("synthetic tool must not surface as a tool call: %+v", res.ToolCalls)
+	}
+	if res.Usage == nil || res.Usage.InputTokens != 5 {
+		t.Fatalf("usage = %+v", res.Usage)
+	}
+
+	// The request forces the synthetic tool via tool_choice.
+	var req map[string]any
+	if err := json.Unmarshal(captured, &req); err != nil {
+		t.Fatal(err)
+	}
+	tc, ok := req["tool_choice"].(map[string]any)
+	if !ok || tc["type"] != "tool" || tc["name"] != structuredOutputToolName {
+		t.Fatalf("tool_choice must force the synthetic tool, got %v", req["tool_choice"])
+	}
+	tools, ok := req["tools"].([]any)
+	if !ok || len(tools) != 1 {
+		t.Fatalf("tools = %v", req["tools"])
+	}
+	synth := tools[0].(map[string]any)
+	if synth["name"] != structuredOutputToolName {
+		t.Fatalf("synthetic tool = %v", synth)
+	}
+	if _, streaming := req["stream"]; streaming {
+		t.Fatal("Generate must not stream")
+	}
+}


### PR DESCRIPTION
Closes #930.

## Reviewer's guide

Read in this order:
1. [agent/anthropic_provider.go](https://github.com/panyam/mcpkit/pull/949/files#diff-71f597ba381303570d5ed1f9ac3f73f390236d1e6393ee0daf220757916a4e68) — start here. `buildBody` (role + tool_choice + structured-output mapping), `Stream`/`Generate`, and the SSE stream adapter's `Recv`.
2. [agent/anthropic_provider_test.go](https://github.com/panyam/mcpkit/pull/949/files#diff-f9d8a910e63ab10acebccd9d86322e536a3955f19639d75091368ec55059a80f) — acceptance: canned Anthropic SSE/JSON, asserts the exact `Delta` sequence and `Accumulator` fold.

The two decisions worth a close look: `RoleSystem` -> `user` mapping and structured-output-via-forced-tool (both in `buildBody`), covered in the sections below.


## What

Adds `agent/anthropic_provider.go`, a no-SDK translation layer over the Anthropic Messages API (`POST {BaseURL}/v1/messages`) implementing the existing `Provider` interface (`Stream` + `Generate`). It mirrors `openai_provider.go` exactly: `net/http` plus servicekit's WHATWG-conformant SSE reader, the same `buildBody` pattern, the same stream-adapter shape (`Recv`/`Close`), and the shared `ProviderError`. No LLM SDK dependency (constraint A1); no `fmt.Print`/`os.Stdout`/`log`/`slog.Default` in non-test code (A4); JSON-valued public fields stay on `core.RawJSON` (A5).

`AnthropicConfig{ BaseURL (default https://api.anthropic.com), APIKey, Model (required), MaxTokens (default 4096), Version (default 2023-06-01), HTTPClient }`. Headers: `x-api-key`, `anthropic-version`, `content-type`. The caller supplies `Model`; the provider hardcodes none.

## Wire-translation decisions

- `Instructions` -> top-level `system` string.
- `RoleUser` -> `{role:user, content:[{type:text}]}`; `RoleAssistant` (+optional text) + `ToolCalls` -> `tool_use` blocks (args decoded into the `input` object); `RoleTool` -> `{role:user, content:[{type:tool_result, tool_use_id, content}]}`.
- **`RoleSystem` -> a `user` text turn.** Anthropic's `system` is a single top-level string, and its messages array only accepts `user`/`assistant` roles — there is no inline system role mid-history. mcpkit's `RoleSystem` carries injected-context messages that live in the middle of the conversation, so each maps to a plain `user` text message (documented with a code comment at the mapping site). This is lossy in the sense that the model no longer sees it as system-authored, but it preserves the content and ordering, which is what injected context needs.
- `ToolChoice`: auto->`{type:auto}`, required->`{type:any}`, none->`{type:none}`, forced tool->`{type:tool,name}`; omitted when no tools or when the choice is the zero value.
- **Structured output** (`Generate` + `ResponseSchema`): Anthropic has no `response_format`, so this is implemented as a forced synthetic tool (`structured_output`) whose `input_schema` is the caller's schema, with `tool_choice:{type:tool,name:structured_output}`. The `tool_use` input is returned in `ProviderResponse.Text`, mirroring the OpenAI path (which puts the structured document in `Text`), and is not surfaced as a tool call.
- Streaming SSE (dispatched on the JSON `type` field, which duplicates the `event:` name): `message_start` captures input tokens; `content_block_start(tool_use)` -> `DeltaToolCallStart`; `text_delta` -> `DeltaText`; `input_json_delta` -> `DeltaToolCallArgs`; `thinking_delta` -> `DeltaReasoning`; `message_delta` -> `DeltaFinish` + `DeltaUsage` (folding the captured input tokens with the delta's output tokens); `message_stop` -> `io.EOF`. `error` events surface as a stream error.

## Caching / thinking — deferred (out of scope)

Prompt caching (`cache_control` breakpoints) and extended thinking (the `thinking` request field) both need provider-scoped configuration rather than neutral `ProviderRequest` fields. Per the issue's guidance to prefer shipping a solid core over a half-done caching layer, they are deferred to a follow-up. The current API drift also argues for deferral: `thinking:{type:enabled, budget_tokens}` now 400s on the current Opus/Sonnet models while older models still require it, so a single neutral option can't be correct across the `Model` values a caller might pass. This PR ships the core: `Stream` + `Generate` + tools + structured output.

## Tests

`agent/anthropic_provider_test.go` (11 tests): `buildBody` role + tool-choice mapping (incl. `RoleSystem`->user, `RoleTool` result, `RoleAssistant`-with-tool_use round-trip, all 5 `ToolChoice` variants, default max_tokens / no-tools / no-system omissions), header assertions, a text stream asserting the exact `Delta` sequence + `Accumulator` fold, a tool_use stream asserting the exact sequence + fold, a thinking stream, an HTTP-error case, `Generate` (text + usage), `Generate` with tool calls, and structured-output-via-forced-tool (asserts the forced `tool_choice`/synthetic tool on the request and that the result surfaces in `Text`).

## Verification

- `cd agent && go test ./... -count=1 -timeout 60s` — green
- `go vet ./...` — clean
- `gofmt -l` on both files — no output
- A1 (no LLM SDK import) / A4 (no process-global output) greps — clean
- `make test-agent` (all six agent modules) — green