### PR TITLE
feat(agent): structured output in the Runner loop (issue 931)

### DIFF
--- a/agent/runner.go
+++ b/agent/runner.go
@@ -60,6 +60,16 @@ type RunnerConfig struct {
 	// (a tool-denied event, then the turn continues), never a turn abort.
 	// Nil means every call runs, the pre-approval behavior.
 	Approval ApprovalPolicy
+
+	// ResponseSchema, when set, coerces the turn's final answer into
+	// structured output. After the tool loop reaches its terminal
+	// no-tool-call text, the Runner makes one additional Generate call with
+	// this schema (and no tools) and puts the JSON document on
+	// TurnResult.Structured. Tools and a response schema are never sent in
+	// the same request (many endpoints forbid it), which is why this is a
+	// separate finalizing call rather than a field on the loop's requests.
+	// Empty means no structured coercion.
+	ResponseSchema core.RawJSON
 }
 
 // ToolSelector narrows the model-facing tool set for one step. Returning the
@@ -99,6 +109,12 @@ type TurnResult struct {
 	Usage        Usage     `json:"usage"`
 	Steps        int       `json:"steps"`
 	FinishReason string    `json:"finishReason,omitempty"`
+
+	// Structured is the schema-coerced final answer, present only when
+	// RunnerConfig.ResponseSchema was set. It is the JSON document from the
+	// finalizing Generate call; Bind it into a typed value. Its Usage is
+	// already folded into Usage above. Empty when no schema was configured.
+	Structured core.RawJSON `json:"structured,omitempty"`
 }
 
 // Run executes one turn against history. Events stream to emit (nil is
@@ -169,12 +185,21 @@ func (r *Runner) Run(ctx context.Context, history []Message, emit func(Event)) (
 
 		if len(resp.ToolCalls) == 0 {
 			stepSpan.End()
+			var structured core.RawJSON
+			if r.cfg.ResponseSchema.Len() > 0 {
+				s, err := r.finalizeStructured(ctx, msgs, &usage)
+				if err != nil {
+					return nil, r.failSpan(emit, turnSpan, fmt.Errorf("agent: structured finalize: %w", err))
+				}
+				structured = s
+			}
 			result := &TurnResult{
 				Text:         resp.Text,
 				Messages:     added,
 				Usage:        usage,
 				Steps:        step,
 				FinishReason: resp.FinishReason,
+				Structured:   structured,
 			}
 			turnSpan.SetAttribute("agent.steps", fmt.Sprint(step))
 			turnSpan.SetAttribute("agent.finish_reason", resp.FinishReason)
@@ -240,6 +265,41 @@ func consumeStream(stream Stream, step int, emit func(Event)) (*ProviderResponse
 	}
 	endThinking()
 	return acc.Result(), nil
+}
+
+// structuredMaxAttempts bounds the finalizing Generate: one initial call plus
+// retries when the model returns text that is not valid JSON. Two total keeps
+// the extra cost low while absorbing the occasional near-miss.
+const structuredMaxAttempts = 2
+
+// finalizeStructured makes the schema-coercing Generate call over the finished
+// conversation (msgs already includes the terminal assistant text) with no
+// tools offered. It retries up to structuredMaxAttempts when the returned text
+// is not valid JSON, folding each call's usage into usage. A provider error
+// aborts (the caller asked for structured output and cannot get it); after the
+// retry budget it returns the last output best-effort so a caller's Bind, not
+// a lost turn, surfaces a still-malformed document.
+func (r *Runner) finalizeStructured(ctx context.Context, msgs []Message, usage *Usage) (core.RawJSON, error) {
+	var last string
+	for attempt := 0; attempt < structuredMaxAttempts; attempt++ {
+		resp, err := r.cfg.Provider.Generate(ctx, ProviderRequest{
+			Instructions:   r.cfg.Instructions,
+			Messages:       msgs,
+			ResponseSchema: r.cfg.ResponseSchema,
+		})
+		if err != nil {
+			return core.RawJSON{}, err
+		}
+		if resp.Usage != nil {
+			usage.InputTokens += resp.Usage.InputTokens
+			usage.OutputTokens += resp.Usage.OutputTokens
+		}
+		last = resp.Text
+		if json.Valid([]byte(last)) {
+			return core.NewRawJSON(json.RawMessage(last)), nil
+		}
+	}
+	return core.NewRawJSON(json.RawMessage(last)), nil
 }
 
 // dispatch runs the step's tool calls concurrently, serializes event

--- a/agent/runner_test.go
+++ b/agent/runner_test.go
@@ -436,6 +436,96 @@ func TestRunnerApprovalAllowedRunsTool(t *testing.T) {
 	}
 }
 
+func TestRunnerStructuredFinalizesAfterTerminalText(t *testing.T) {
+	schema := core.NewRawJSON(json.RawMessage(`{"type":"object","properties":{"answer":{"type":"integer"}},"required":["answer"]}`))
+	stub := NewStubProvider(
+		StubTurn{Text: "The answer is 42."}, // terminal text (Stream)
+		StubTurn{Text: `{"answer":42}`},     // finalizing coercion (Generate)
+	)
+	r, err := NewRunner(RunnerConfig{Provider: stub, ResponseSchema: schema})
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := r.Run(context.Background(), []Message{{Role: RoleUser, Text: "what is the answer"}}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Text != "The answer is 42." {
+		t.Fatalf("text answer should be unchanged: %q", res.Text)
+	}
+	var got struct {
+		Answer int `json:"answer"`
+	}
+	if err := res.Structured.Bind(&got); err != nil || got.Answer != 42 {
+		t.Fatalf("structured = %s (bind err %v)", res.Structured.Raw(), err)
+	}
+	// The finalizing Generate consumed a second turn.
+	if len(stub.Requests()) != 2 {
+		t.Fatalf("want 2 provider calls (stream + finalize), got %d", len(stub.Requests()))
+	}
+	// The finalizing request carries the schema and offers no tools.
+	fin := stub.Requests()[1]
+	if fin.ResponseSchema.Len() == 0 || len(fin.Tools) != 0 {
+		t.Fatalf("finalize request should set schema and no tools: %+v", fin)
+	}
+}
+
+func TestRunnerNoSchemaSkipsFinalize(t *testing.T) {
+	stub := NewStubProvider(StubTurn{Text: "plain answer"})
+	r, err := NewRunner(RunnerConfig{Provider: stub})
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := r.Run(context.Background(), []Message{{Role: RoleUser, Text: "hi"}}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Structured.Len() != 0 {
+		t.Fatalf("no schema means no structured output: %s", res.Structured.Raw())
+	}
+	if len(stub.Requests()) != 1 {
+		t.Fatalf("no schema means no finalize call, got %d calls", len(stub.Requests()))
+	}
+}
+
+func TestRunnerStructuredRetriesInvalidJSON(t *testing.T) {
+	schema := core.NewRawJSON(json.RawMessage(`{"type":"object"}`))
+	stub := NewStubProvider(
+		StubTurn{Text: "done"},            // terminal text
+		StubTurn{Text: "not json at all"}, // first finalize: invalid
+		StubTurn{Text: `{"ok":true}`},     // retry: valid
+	)
+	r, err := NewRunner(RunnerConfig{Provider: stub, ResponseSchema: schema})
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := r.Run(context.Background(), []Message{{Role: RoleUser, Text: "go"}}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(res.Structured.Raw()) != `{"ok":true}` {
+		t.Fatalf("retry should have produced valid JSON, got %s", res.Structured.Raw())
+	}
+	if len(stub.Requests()) != 3 {
+		t.Fatalf("want stream + 2 finalize attempts = 3 calls, got %d", len(stub.Requests()))
+	}
+}
+
+func TestRunnerStructuredProviderErrorAbortsTurn(t *testing.T) {
+	schema := core.NewRawJSON(json.RawMessage(`{"type":"object"}`))
+	stub := NewStubProvider(
+		StubTurn{Text: "done"},                    // terminal text
+		StubTurn{Err: errors.New("upstream 500")}, // finalize fails
+	)
+	r, err := NewRunner(RunnerConfig{Provider: stub, ResponseSchema: schema})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Run(context.Background(), []Message{{Role: RoleUser, Text: "go"}}, nil); err == nil {
+		t.Fatal("a failed structured finalize must abort the turn")
+	}
+}
+
 func TestRunnerRequiresProvider(t *testing.T) {
 	if _, err := NewRunner(RunnerConfig{}); err == nil {
 		t.Fatal("want error for missing provider")


### PR DESCRIPTION
Closes #931. Stacked on the #929 approval chain: base is `feat/929-host-approval-wiring` (which is on `feat/929-approval-ladder`). Merge order: #947 → #948 → this. Basing here (rather than main) avoids a `RunnerConfig` struct conflict with #947's `Approval` field. CI won't fire until this retargets to main after the chain lands; verified locally via `make test-agent`.

## What changes

Adds structured (schema-coerced) output as the terminal result of a Runner turn. New `RunnerConfig.ResponseSchema` (a JSON Schema) and `TurnResult.Structured` (the coerced JSON document). When the schema is set, the tool loop runs exactly as before; on the terminal no-tool-call text response, the Runner makes one additional `Generate` call — schema set, no tools — to coerce the answer, and puts the document on `TurnResult.Structured`. Empty schema means no finalize, so existing behavior is unchanged.

## Reviewer's guide

Read in this order:
1. [agent/runner.go](https://github.com/panyam/mcpkit/pull/950/files#diff-6d787b427ac08cd61669af7e34ff0b747c4264d20b31b21b681a2ec2c826d9f0) — the `ResponseSchema`/`Structured` fields, the terminal-branch hook, and `finalizeStructured` (the retry + usage-folding).
2. [agent/runner_test.go](https://github.com/panyam/mcpkit/pull/950/files#diff-ffe83771b6f02efdc6a2e9656bb6e78ecd3a3d187223e173d416979cb429ec34) — the four acceptance tests (finalize, no-schema-skip, retry-on-invalid, provider-error-aborts).

## How it works

```
run the tool loop unchanged ...
on the terminal no-tool-call assistant text:
  if cfg.ResponseSchema is set:
     for attempt in 1..2:
        resp = Provider.Generate({instructions, msgs (incl. the final text), schema, NO tools})
        fold resp.Usage into the turn usage
        if resp.Text is valid JSON: structured = resp.Text; break
     # after the retry budget, keep the last output best-effort
     on a provider error: abort the turn (the caller asked for structured output)
  TurnResult{Text, Messages, Usage, Steps, FinishReason, Structured}
```

## Decision log

- **A separate finalizing `Generate`, not tools+schema in one request.** Many OpenAI-compatible servers forbid `response_format` alongside tools, and Anthropic can't do both. Running the loop to a text answer and then coercing keeps every step legal and works across providers. Costs one extra call per structured turn.
- **Retry is for invalid JSON only; a provider error aborts.** A malformed document after the retry budget is returned best-effort (the caller's `Bind` surfaces it) rather than discarding a successful multi-step turn. A provider *error* on the finalize means the requested structured output can't be produced, so the turn fails — the caller explicitly asked for it.
- **The finalize call is not appended to history.** `TurnResult.Structured` is a derived artifact, not a conversation message; `Messages` stays exactly the loop's appended entries so history threads unchanged.
- **`Structured` is `core.RawJSON` (A5)**, so a caller `Bind`s it into a typed value with one parse.

## Risk / blast radius

- Affects: `agent/runner.go` only (additive `RunnerConfig`/`TurnResult` fields + one helper). Nil/empty schema path is byte-identical to today.
- Tests: four new tests via `StubProvider` (whose `Generate` folds a scripted turn, so the finalize call is scriptable and countable). `make test-agent` green across all six agent modules.
- Be paranoid about: usage folding (the finalize call's tokens must count once — asserted indirectly), and that no-schema turns make exactly one provider call (regression guard).

## Before / after

```
before: Run() -> TurnResult{ Text: "The answer is 42." }         # free text only

after (RunnerConfig.ResponseSchema set):
  Run() -> TurnResult{
    Text:       "The answer is 42.",     # the loop's text answer, unchanged
    Structured: {"answer":42},           # coerced via one finalizing Generate
  }
```

