### PR TITLE
feat(agent): eval / scorer harness (agent/eval)

### DIFF
--- a/agent/eval/eval.go
+++ b/agent/eval/eval.go
@@ -1,0 +1,151 @@
+// Package eval is a deterministic eval / scorer harness for agent turns. A
+// Case names one input; a Scorer grades what a Run produced (the TurnResult
+// plus the captured event stream); a Suite runs a set of Cases against a set
+// of Scorers and returns a structured report.
+//
+// The harness is model-and-turn-facing, so it lives in agent/ (constraint
+// A6): scorers read a *agent.TurnResult and an []agent.Event, both meaningless
+// without a Runner turn. It depends only on core/ and agent/, adds no
+// third-party dependency, and never prints (constraint A4) — a Suite returns a
+// SuiteReport that a test or CLI renders.
+//
+// The deterministic scorers (ExactMatch, Contains, ToolCalled, MaxSteps,
+// StepCount, NoError) need no network or live model: drive a Case with
+// agent.NewStubProvider for reproducible evals in CI. The LLM-as-judge scorer
+// lives behind the eval_llm build tag so the default build and CI path carry
+// no model requirement.
+package eval
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/panyam/mcpkit/agent"
+)
+
+// Case is one eval input: a name, the conversation to run, and any per-case
+// overrides applied on top of the base RunnerConfig. It is a plain struct so
+// callers can build tables of them inline.
+type Case struct {
+	// Name identifies the case in a report. Should be unique within a Suite.
+	Name string
+
+	// Input is a convenience seed: when History is empty and Input is
+	// non-empty, the turn runs against a single RoleUser message carrying
+	// Input. History takes precedence when both are set.
+	Input string
+
+	// History is the full input conversation, oldest first. Overrides Input.
+	History []agent.Message
+
+	// Tools overrides RunnerConfig.Tools for this case when non-nil, so a
+	// case can run under a tool surface tailored to what it exercises.
+	Tools agent.ToolSource
+
+	// Instructions overrides RunnerConfig.Instructions for this case when
+	// non-empty.
+	Instructions string
+
+	// MaxSteps overrides RunnerConfig.MaxSteps for this case when positive.
+	MaxSteps int
+}
+
+// history resolves the messages a Case runs against: History verbatim, else a
+// single user message from Input, else nil.
+func (c Case) history() []agent.Message {
+	if len(c.History) > 0 {
+		return c.History
+	}
+	if c.Input != "" {
+		return []agent.Message{{Role: agent.RoleUser, Text: c.Input}}
+	}
+	return nil
+}
+
+// Result is one scored run's transcript: the completed turn (nil when the run
+// failed before producing one), the captured event stream, and the run error
+// (nil on success). Scorers read these fields; NoError inspects Err and the
+// event stream, the text scorers read Turn.Text.
+type Result struct {
+	// Case is the input that produced this result.
+	Case Case
+
+	// Turn is the completed turn, or nil when Err is non-nil and the turn
+	// aborted before completion.
+	Turn *agent.TurnResult
+
+	// Events is every event the Runner emitted, in order.
+	Events []agent.Event
+
+	// Err is the run error: ctx cancellation, provider failure, or the step
+	// cap (wrapping agent.ErrMaxSteps). Tool failures do not appear here —
+	// the Runner feeds those back to the model, so they surface as
+	// tool-error / tool-end(IsError) events instead.
+	Err error
+}
+
+// Run executes one Case against a copy of cfg with the Case's overrides
+// applied, wiring an event collector, and packages the transcript into a
+// Result. The returned error is a harness-level failure (an invalid
+// RunnerConfig that NewRunner rejects); a turn that runs and fails carries its
+// error in Result.Err, not the returned error, so scorers can grade it.
+func Run(ctx context.Context, cfg agent.RunnerConfig, c Case) (Result, error) {
+	if c.Tools != nil {
+		cfg.Tools = c.Tools
+	}
+	if c.Instructions != "" {
+		cfg.Instructions = c.Instructions
+	}
+	if c.MaxSteps > 0 {
+		cfg.MaxSteps = c.MaxSteps
+	}
+
+	runner, err := agent.NewRunner(cfg)
+	if err != nil {
+		return Result{Case: c}, fmt.Errorf("eval: build runner for case %q: %w", c.Name, err)
+	}
+
+	var events []agent.Event
+	emit := func(e agent.Event) { events = append(events, e) }
+
+	turn, runErr := runner.Run(ctx, c.history(), emit)
+	return Result{Case: c, Turn: turn, Events: events, Err: runErr}, nil
+}
+
+// Transcript renders a Result as human-readable text: the final answer, the
+// step count, and the tool calls the turn made with their results. The
+// LLM-as-judge scorer feeds this to a model; it is also useful for logging a
+// failed case. Rendering only, no printing (constraint A4).
+func Transcript(r Result) string {
+	var b strings.Builder
+	if r.Turn != nil {
+		fmt.Fprintf(&b, "steps: %d\n", r.Turn.Steps)
+		if r.Turn.FinishReason != "" {
+			fmt.Fprintf(&b, "finish: %s\n", r.Turn.FinishReason)
+		}
+	}
+	if r.Err != nil {
+		fmt.Fprintf(&b, "run error: %v\n", r.Err)
+	}
+	for _, e := range r.Events {
+		switch e.Kind {
+		case agent.EventToolBegin:
+			if e.ToolCall != nil {
+				fmt.Fprintf(&b, "tool call: %s(%s)\n", e.ToolCall.Name, strings.TrimSpace(string(e.ToolCall.Args.Raw())))
+			}
+		case agent.EventToolEnd:
+			marker := "ok"
+			if e.ToolResult != nil && e.ToolResult.IsError {
+				marker = "error"
+			}
+			fmt.Fprintf(&b, "tool result (%s)\n", marker)
+		case agent.EventToolError:
+			fmt.Fprintf(&b, "tool dispatch error: %s\n", e.Error)
+		}
+	}
+	if r.Turn != nil {
+		fmt.Fprintf(&b, "answer: %s\n", r.Turn.Text)
+	}
+	return b.String()
+}

--- a/agent/eval/eval_test.go
+++ b/agent/eval/eval_test.go
@@ -183,6 +183,30 @@ func TestNoErrorCatchesDispatchError(t *testing.T) {
 	}
 }
 
+func TestNotDeniedCatchesDenialButNoErrorIgnoresIt(t *testing.T) {
+	// A tool-denied transcript: the approval policy blocked "deploy". The Runner
+	// emits tool-begin then tool-denied (no tool-end, no error).
+	denied := Result{Events: []agent.Event{
+		{Kind: agent.EventToolBegin, ToolCall: &agent.ToolCall{Name: "deploy"}},
+		{Kind: agent.EventToolDenied, ToolCall: &agent.ToolCall{Name: "deploy"}, Reason: "declined by user"},
+	}}
+	if s := NotDenied().Score(denied); s.Pass {
+		t.Fatalf("NotDenied must fail when a tool was blocked: %+v", s)
+	}
+	if d := NotDenied().Score(denied).Detail; !strings.Contains(d, "deploy") || !strings.Contains(d, "declined by user") {
+		t.Fatalf("detail should name the denied tool and reason: %q", d)
+	}
+	// The crux: a denial is a policy outcome, not an error, so NoError ignores it.
+	if s := NoError().Score(denied); !s.Pass {
+		t.Fatalf("NoError must not treat a policy denial as an error: %+v", s)
+	}
+
+	clean := Result{Events: []agent.Event{{Kind: agent.EventToolEnd, ToolCall: &agent.ToolCall{Name: "read"}}}}
+	if s := NotDenied().Score(clean); !s.Pass {
+		t.Fatalf("NotDenied must pass when nothing was denied: %+v", s)
+	}
+}
+
 func TestSuiteAggregate(t *testing.T) {
 	src := lookupSource(t)
 	// Two cases x two scorers. Case A passes both; case B fails ExactMatch.

--- a/agent/eval/eval_test.go
+++ b/agent/eval/eval_test.go
@@ -1,0 +1,278 @@
+package eval
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/panyam/mcpkit/agent"
+	"github.com/panyam/mcpkit/core"
+)
+
+// lookupSource builds a FuncSource with one "lookup" tool that echoes its key,
+// plus an always-failing "boom" tool for the error paths.
+func lookupSource(t *testing.T) *agent.FuncSource {
+	t.Helper()
+	src := agent.NewFuncSource()
+	if err := agent.AddFunc(src, "lookup", "looks up a key", func(ctx context.Context, in struct {
+		Key string `json:"key"`
+	}) (string, error) {
+		return "value-for-" + in.Key, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.AddFunc(src, "boom", "always fails", func(ctx context.Context, _ struct{}) (string, error) {
+		return "", errors.New("kaput")
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return src
+}
+
+func toolCallTurn(id, name, args string) agent.StubTurn {
+	return agent.StubTurn{ToolCalls: []agent.ToolCall{
+		{ID: id, Name: name, Args: core.NewRawJSON(json.RawMessage(args))},
+	}}
+}
+
+// runCase is a small helper: build a stub-backed config and run one case.
+func runCase(t *testing.T, src agent.ToolSource, c Case, turns ...agent.StubTurn) Result {
+	t.Helper()
+	cfg := agent.RunnerConfig{Provider: agent.NewStubProvider(turns...), Tools: src}
+	res, err := Run(context.Background(), cfg, c)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	return res
+}
+
+func TestRunSeedsInputAndCapturesTranscript(t *testing.T) {
+	res := runCase(t, nil, Case{Name: "greet", Input: "hi"},
+		agent.StubTurn{Text: "Hello there"})
+	if res.Err != nil {
+		t.Fatalf("run error: %v", res.Err)
+	}
+	if res.Turn == nil || res.Turn.Text != "Hello there" {
+		t.Fatalf("turn = %+v", res.Turn)
+	}
+	if len(res.Events) == 0 || res.Events[0].Kind != agent.EventTurnBegin {
+		t.Fatalf("events not captured: %+v", res.Events)
+	}
+}
+
+func TestRunHistoryOverridesInput(t *testing.T) {
+	cfg := agent.RunnerConfig{Provider: agent.NewStubProvider(agent.StubTurn{Text: "ok"})}
+	c := Case{
+		Name:    "hist",
+		Input:   "ignored",
+		History: []agent.Message{{Role: agent.RoleUser, Text: "from history"}},
+	}
+	if _, err := Run(context.Background(), cfg, c); err != nil {
+		t.Fatal(err)
+	}
+	// Provider recorded the seeded history verbatim.
+	stub := cfg.Provider.(*agent.StubProvider)
+	got := stub.Requests()[0].Messages[0].Text
+	if got != "from history" {
+		t.Fatalf("history not used: %q", got)
+	}
+}
+
+func TestRunReportsHarnessErrorForMissingProvider(t *testing.T) {
+	_, err := Run(context.Background(), agent.RunnerConfig{}, Case{Name: "x"})
+	if err == nil {
+		t.Fatal("want harness error for missing provider")
+	}
+}
+
+func TestExactMatch(t *testing.T) {
+	res := runCase(t, nil, Case{Name: "em"}, agent.StubTurn{Text: "42"})
+	if s := ExactMatch("42").Score(res); !s.Pass || s.Value != 1.0 {
+		t.Fatalf("pass case: %+v", s)
+	}
+	if s := ExactMatch("43").Score(res); s.Pass {
+		t.Fatalf("fail case should not pass: %+v", s)
+	}
+}
+
+func TestContains(t *testing.T) {
+	res := runCase(t, nil, Case{Name: "c"}, agent.StubTurn{Text: "the answer is 42 today"})
+	if s := Contains("answer is 42").Score(res); !s.Pass {
+		t.Fatalf("pass case: %+v", s)
+	}
+	if s := Contains("nope").Score(res); s.Pass {
+		t.Fatalf("fail case should not pass: %+v", s)
+	}
+}
+
+func TestToolCalledTrueAndFalse(t *testing.T) {
+	src := lookupSource(t)
+	res := runCase(t, src, Case{Name: "tc", Input: "get x"},
+		toolCallTurn("c1", "lookup", `{"key":"x"}`),
+		agent.StubTurn{Text: "value-for-x"},
+	)
+	if s := ToolCalled("lookup").Score(res); !s.Pass {
+		t.Fatalf("lookup was called: %+v", s)
+	}
+	if s := ToolCalled("nonexistent").Score(res); s.Pass {
+		t.Fatalf("uncalled tool should not pass: %+v", s)
+	}
+	if !strings.Contains(ToolCalled("lookup").Score(res).Detail, "1 time") {
+		t.Fatalf("detail should report count: %q", ToolCalled("lookup").Score(res).Detail)
+	}
+}
+
+func TestMaxStepsAndStepCount(t *testing.T) {
+	src := lookupSource(t)
+	res := runCase(t, src, Case{Name: "steps", Input: "get x"},
+		toolCallTurn("c1", "lookup", `{"key":"x"}`),
+		agent.StubTurn{Text: "done"},
+	) // two steps: one tool call, one text
+	if s := MaxSteps(2).Score(res); !s.Pass {
+		t.Fatalf("MaxSteps(2) should pass at 2 steps: %+v", s)
+	}
+	if s := MaxSteps(1).Score(res); s.Pass {
+		t.Fatalf("MaxSteps(1) should fail at 2 steps: %+v", s)
+	}
+	if s := StepCount(2).Score(res); !s.Pass {
+		t.Fatalf("StepCount(2) should pass: %+v", s)
+	}
+	if s := StepCount(3).Score(res); s.Pass {
+		t.Fatalf("StepCount(3) should fail: %+v", s)
+	}
+}
+
+func TestNoErrorCleanRun(t *testing.T) {
+	src := lookupSource(t)
+	res := runCase(t, src, Case{Name: "clean", Input: "get x"},
+		toolCallTurn("c1", "lookup", `{"key":"x"}`),
+		agent.StubTurn{Text: "ok"},
+	)
+	if s := NoError().Score(res); !s.Pass {
+		t.Fatalf("clean run should pass NoError: %+v", s)
+	}
+}
+
+func TestNoErrorCatchesToolErrorResult(t *testing.T) {
+	src := lookupSource(t)
+	// "boom" runs and returns an IsError result -> tool-end(IsError), not a
+	// dispatch error; NoError must still fail.
+	res := runCase(t, src, Case{Name: "boom", Input: "explode"},
+		toolCallTurn("c1", "boom", `{}`),
+		agent.StubTurn{Text: "noted"},
+	)
+	s := NoError().Score(res)
+	if s.Pass {
+		t.Fatalf("NoError should catch an IsError tool result: %+v", s)
+	}
+	if !strings.Contains(s.Detail, "boom") {
+		t.Fatalf("detail should name the failing tool: %q", s.Detail)
+	}
+}
+
+func TestNoErrorCatchesDispatchError(t *testing.T) {
+	// Unknown tool -> tool-error dispatch event; loop continues but NoError fails.
+	res := runCase(t, agent.NewFuncSource(), Case{Name: "unknown", Input: "x"},
+		toolCallTurn("c1", "ghost", `{}`),
+		agent.StubTurn{Text: "recovered"},
+	)
+	if s := NoError().Score(res); s.Pass {
+		t.Fatalf("NoError should catch a dispatch error: %+v", s)
+	}
+}
+
+func TestSuiteAggregate(t *testing.T) {
+	src := lookupSource(t)
+	// Two cases x two scorers. Case A passes both; case B fails ExactMatch.
+	suite := Suite{
+		Config: agent.RunnerConfig{
+			Provider: agent.NewStubProvider(
+				// case A: one tool call then the exact answer
+				toolCallTurn("c1", "lookup", `{"key":"x"}`),
+				agent.StubTurn{Text: "value-for-x"},
+				// case B: a plain wrong answer
+				agent.StubTurn{Text: "wrong"},
+			),
+			Tools: src,
+		},
+		Cases: []Case{
+			{Name: "A-uses-tool", Input: "get x"},
+			{Name: "B-wrong-answer", Input: "guess"},
+		},
+		Scorers: []Scorer{
+			ExactMatch("value-for-x"),
+			NoError(),
+		},
+	}
+
+	report := suite.Run(context.Background())
+	if report.Total != 2 || report.Passed != 1 || report.Failed != 1 {
+		t.Fatalf("aggregate = %+v", report)
+	}
+	if report.Pass() {
+		t.Fatal("suite with a failing case should not Pass()")
+	}
+
+	byName := map[string]CaseReport{}
+	for _, c := range report.Cases {
+		byName[c.Case] = c
+	}
+	if !byName["A-uses-tool"].Pass {
+		t.Fatalf("case A should pass: %+v", byName["A-uses-tool"])
+	}
+	if byName["B-wrong-answer"].Pass {
+		t.Fatalf("case B should fail: %+v", byName["B-wrong-answer"])
+	}
+	// Each case carries one score per scorer.
+	if len(byName["A-uses-tool"].Scores) != 2 {
+		t.Fatalf("expected 2 scores per case, got %+v", byName["A-uses-tool"].Scores)
+	}
+
+	// Report renders without printing and mentions both cases.
+	rendered := report.String()
+	if !strings.Contains(rendered, "A-uses-tool") || !strings.Contains(rendered, "1/2 cases passed") {
+		t.Fatalf("report render:\n%s", rendered)
+	}
+}
+
+func TestSuiteRecordsHarnessErrorPerCase(t *testing.T) {
+	// No provider -> every case fails to build; the suite records RunErr and
+	// keeps going rather than aborting.
+	suite := Suite{
+		Config:  agent.RunnerConfig{},
+		Cases:   []Case{{Name: "a"}, {Name: "b"}},
+		Scorers: []Scorer{NoError()},
+	}
+	report := suite.Run(context.Background())
+	if report.Failed != 2 || report.Passed != 0 {
+		t.Fatalf("aggregate = %+v", report)
+	}
+	for _, c := range report.Cases {
+		if c.RunErr == "" || c.Pass {
+			t.Fatalf("case %q should carry a run error and fail: %+v", c.Case, c)
+		}
+	}
+}
+
+func TestSuiteReportJSONRoundTrips(t *testing.T) {
+	report := SuiteReport{
+		Total: 1, Passed: 1,
+		Cases: []CaseReport{{
+			Case: "x", Pass: true,
+			Scores: []Score{{Name: "ExactMatch", Pass: true, Value: 1.0, Detail: "ok"}},
+		}},
+	}
+	raw, err := json.Marshal(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var back SuiteReport
+	if err := json.Unmarshal(raw, &back); err != nil {
+		t.Fatal(err)
+	}
+	if back.Passed != 1 || len(back.Cases) != 1 || back.Cases[0].Scores[0].Name != "ExactMatch" {
+		t.Fatalf("round-trip drift: %+v", back)
+	}
+}

--- a/agent/eval/judge.go
+++ b/agent/eval/judge.go
@@ -1,0 +1,63 @@
+//go:build eval_llm
+
+// This file is excluded from the default build and CI path: the LLM-as-judge
+// scorer needs a live Provider (a real model), so it sits behind the eval_llm
+// build tag alongside its test. The default deterministic scorers carry no
+// model or network requirement. Build or test it with: go test -tags eval_llm ./...
+
+package eval
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/panyam/mcpkit/agent"
+	"github.com/panyam/mcpkit/core"
+)
+
+// judgeVerdict is the structured grade the judge model returns.
+type judgeVerdict struct {
+	Pass   bool    `json:"pass"`
+	Score  float64 `json:"score"`
+	Reason string  `json:"reason"`
+}
+
+// Judge grades a Result by asking a model to evaluate the rendered transcript
+// against rubric. It is the LLM-as-judge scorer: non-deterministic, requiring
+// a live Provider, hence build-tagged off the default path. The model is asked
+// for a structured {pass, score, reason} verdict via ResponseSchema.
+//
+// The Scorer interface carries no context, so the judge grades under
+// context.Background(); wrap the provider with a timeout if you need to bound
+// it. Any transport, decode, or empty-response failure yields a failing Score
+// carrying the reason, so a broken judge fails loudly rather than silently
+// passing a case.
+func Judge(provider agent.Provider, rubric string) Scorer {
+	schema := core.NewRawJSON(json.RawMessage(core.GenerateSchema[judgeVerdict]()))
+	return scorerFunc(func(r Result) Score {
+		req := agent.ProviderRequest{
+			Instructions: "You are a strict evaluator. Grade the agent transcript against the " +
+				"rubric. Respond only with the JSON verdict: pass (bool), score (0..1), reason (string).",
+			Messages: []agent.Message{{
+				Role: agent.RoleUser,
+				Text: fmt.Sprintf("Rubric:\n%s\n\nTranscript:\n%s", rubric, Transcript(r)),
+			}},
+			ResponseSchema: schema,
+		}
+
+		resp, err := provider.Generate(context.Background(), req)
+		if err != nil {
+			return boolScore("Judge", false, "judge model error: "+err.Error())
+		}
+		if resp == nil || resp.Text == "" {
+			return boolScore("Judge", false, "judge returned no verdict")
+		}
+
+		var v judgeVerdict
+		if err := json.Unmarshal([]byte(resp.Text), &v); err != nil {
+			return boolScore("Judge", false, "judge verdict was not valid JSON: "+err.Error())
+		}
+		return Score{Name: "Judge", Pass: v.Pass, Value: v.Score, Detail: v.Reason}
+	})
+}

--- a/agent/eval/judge_test.go
+++ b/agent/eval/judge_test.go
@@ -1,0 +1,40 @@
+//go:build eval_llm
+
+package eval
+
+import (
+	"testing"
+
+	"github.com/panyam/mcpkit/agent"
+)
+
+// TestJudgeParsesVerdict drives the LLM-judge scorer with a StubProvider
+// scripted to return a JSON verdict, so the build-tagged path stays testable
+// without a live model. Run with: go test -tags eval_llm ./...
+func TestJudgeParsesVerdict(t *testing.T) {
+	stub := agent.NewStubProvider(agent.StubTurn{
+		Text: `{"pass": true, "score": 0.9, "reason": "answer matches the rubric"}`,
+	})
+	res := runCase(t, nil, Case{Name: "judge", Input: "hi"}, agent.StubTurn{Text: "Hello there"})
+	// Re-point Run's result at a fresh transcript is unnecessary; grade it.
+	s := Judge(stub, "The answer must greet the user.").Score(res)
+	if !s.Pass || s.Value != 0.9 || s.Detail != "answer matches the rubric" {
+		t.Fatalf("verdict = %+v", s)
+	}
+}
+
+func TestJudgeFailsOnBadJSON(t *testing.T) {
+	stub := agent.NewStubProvider(agent.StubTurn{Text: "not json"})
+	res := Result{Turn: &agent.TurnResult{Text: "whatever"}}
+	if s := Judge(stub, "rubric").Score(res); s.Pass {
+		t.Fatalf("non-JSON verdict should fail: %+v", s)
+	}
+}
+
+func TestJudgeFailsOnProviderError(t *testing.T) {
+	stub := agent.NewStubProvider() // exhausted immediately -> Generate errors
+	res := Result{Turn: &agent.TurnResult{Text: "whatever"}}
+	if s := Judge(stub, "rubric").Score(res); s.Pass {
+		t.Fatalf("provider error should fail: %+v", s)
+	}
+}

--- a/agent/eval/scorer.go
+++ b/agent/eval/scorer.go
@@ -128,3 +128,24 @@ func NoError() Scorer {
 		return boolScore("NoError", true, "no run, dispatch, or tool errors")
 	})
 }
+
+// NotDenied passes when no tool call was blocked by an approval policy. A
+// denial is deliberately not an error (the Runner emits a distinct tool-denied
+// event, not tool-error), so NoError ignores it; this scorer is the separate
+// check for evals that assert the model never attempted a gated tool. Compose
+// with NoError when a case must be both clean and unblocked.
+func NotDenied() Scorer {
+	return scorerFunc(func(r Result) Score {
+		for _, e := range r.Events {
+			if e.Kind == agent.EventToolDenied {
+				name := ""
+				if e.ToolCall != nil {
+					name = e.ToolCall.Name
+				}
+				return boolScore("NotDenied", false,
+					fmt.Sprintf("tool %q denied: %s", name, e.Reason))
+			}
+		}
+		return boolScore("NotDenied", true, "no tool calls were denied")
+	})
+}

--- a/agent/eval/scorer.go
+++ b/agent/eval/scorer.go
@@ -1,0 +1,130 @@
+package eval
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/panyam/mcpkit/agent"
+)
+
+// Score is one scorer's verdict on a Result. Value is a normalized score in
+// [0,1] where 1.0 is a full pass; the deterministic scorers emit 1.0 or 0.0,
+// while a graded scorer (the LLM judge) may report an intermediate value. Pass
+// is the boolean the Suite aggregates. Detail is the human-readable specifics.
+type Score struct {
+	Name   string  `json:"name"`
+	Pass   bool    `json:"pass"`
+	Value  float64 `json:"value"`
+	Detail string  `json:"detail,omitempty"`
+}
+
+// Scorer grades a Result. Implementations must be pure functions of the
+// Result and safe for concurrent use; the deterministic ones read no state.
+type Scorer interface {
+	Score(Result) Score
+}
+
+// scorerFunc adapts a plain function to the Scorer interface.
+type scorerFunc func(Result) Score
+
+func (f scorerFunc) Score(r Result) Score { return f(r) }
+
+// boolScore builds a pass/fail Score with Value 1.0 or 0.0.
+func boolScore(name string, ok bool, detail string) Score {
+	v := 0.0
+	if ok {
+		v = 1.0
+	}
+	return Score{Name: name, Pass: ok, Value: v, Detail: detail}
+}
+
+// ExactMatch passes when the final turn text equals want exactly.
+func ExactMatch(want string) Scorer {
+	return scorerFunc(func(r Result) Score {
+		if r.Turn == nil {
+			return boolScore("ExactMatch", false, "no turn result (run failed)")
+		}
+		got := r.Turn.Text
+		return boolScore("ExactMatch", got == want, fmt.Sprintf("want %q, got %q", want, got))
+	})
+}
+
+// Contains passes when the final turn text contains substr.
+func Contains(substr string) Scorer {
+	return scorerFunc(func(r Result) Score {
+		if r.Turn == nil {
+			return boolScore("Contains", false, "no turn result (run failed)")
+		}
+		got := r.Turn.Text
+		return boolScore("Contains", strings.Contains(got, substr),
+			fmt.Sprintf("want substring %q in %q", substr, got))
+	})
+}
+
+// ToolCalled passes when the turn requested the named tool at least once. It
+// scans the event stream for tool-begin (emitted for every dispatched call,
+// including ones that later error or are denied), so it reports intent to call
+// regardless of the call's outcome.
+func ToolCalled(name string) Scorer {
+	return scorerFunc(func(r Result) Score {
+		count := 0
+		for _, e := range r.Events {
+			if e.Kind == agent.EventToolBegin && e.ToolCall != nil && e.ToolCall.Name == name {
+				count++
+			}
+		}
+		return boolScore("ToolCalled", count > 0,
+			fmt.Sprintf("tool %q called %d time(s)", name, count))
+	})
+}
+
+// MaxSteps passes when the turn used at most n steps.
+func MaxSteps(n int) Scorer {
+	return scorerFunc(func(r Result) Score {
+		if r.Turn == nil {
+			return boolScore("MaxSteps", false, "no turn result (run failed)")
+		}
+		steps := r.Turn.Steps
+		return boolScore("MaxSteps", steps <= n, fmt.Sprintf("steps=%d, cap=%d", steps, n))
+	})
+}
+
+// StepCount passes when the turn used exactly n steps.
+func StepCount(n int) Scorer {
+	return scorerFunc(func(r Result) Score {
+		if r.Turn == nil {
+			return boolScore("StepCount", false, "no turn result (run failed)")
+		}
+		steps := r.Turn.Steps
+		return boolScore("StepCount", steps == n, fmt.Sprintf("steps=%d, want=%d", steps, n))
+	})
+}
+
+// NoError passes when the run itself succeeded and no tool failed: no run
+// error, no error event, no tool dispatch error, and no tool result marked
+// IsError. It catches the failure shapes the Runner folds back into the
+// conversation (which never abort the turn) as well as a hard run error.
+func NoError() Scorer {
+	return scorerFunc(func(r Result) Score {
+		if r.Err != nil {
+			return boolScore("NoError", false, "run error: "+r.Err.Error())
+		}
+		for _, e := range r.Events {
+			switch e.Kind {
+			case agent.EventError:
+				return boolScore("NoError", false, "error event: "+e.Error)
+			case agent.EventToolError:
+				return boolScore("NoError", false, "tool dispatch error: "+e.Error)
+			case agent.EventToolEnd:
+				if e.ToolResult != nil && e.ToolResult.IsError {
+					name := ""
+					if e.ToolCall != nil {
+						name = e.ToolCall.Name
+					}
+					return boolScore("NoError", false, fmt.Sprintf("tool %q reported an error", name))
+				}
+			}
+		}
+		return boolScore("NoError", true, "no run, dispatch, or tool errors")
+	})
+}

--- a/agent/eval/suite.go
+++ b/agent/eval/suite.go
@@ -1,0 +1,114 @@
+package eval
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/panyam/mcpkit/agent"
+)
+
+// Suite runs each Case against every Scorer and folds the verdicts into a
+// SuiteReport. Config is the base RunnerConfig; each Case may override its
+// tool surface, instructions, or step cap on top of it.
+type Suite struct {
+	// Config is the base RunnerConfig shared by every case (Provider is
+	// required). Per-case overrides in Case are layered on a copy.
+	Config agent.RunnerConfig
+
+	// Cases is the set of inputs to evaluate.
+	Cases []Case
+
+	// Scorers is the set of graders applied to every case's Result.
+	Scorers []Scorer
+}
+
+// CaseReport is one case's outcome: the per-scorer verdicts and whether the
+// case passed overall (every scorer passed and the run built cleanly).
+type CaseReport struct {
+	Case   string  `json:"case"`
+	Scores []Score `json:"scores"`
+	Pass   bool    `json:"pass"`
+	// RunErr is set when the harness could not build the runner for this
+	// case (an invalid config); when set, no scorers ran and Pass is false.
+	RunErr string `json:"runErr,omitempty"`
+}
+
+// SuiteReport is the aggregate: one CaseReport per case plus pass/fail counts.
+type SuiteReport struct {
+	Cases  []CaseReport `json:"cases"`
+	Passed int          `json:"passed"`
+	Failed int          `json:"failed"`
+	Total  int          `json:"total"`
+}
+
+// Pass reports whether every case passed.
+func (r SuiteReport) Pass() bool { return r.Failed == 0 }
+
+// Run evaluates every case against every scorer and returns the report. It
+// does not stop on a failing case; a per-case harness failure (bad config) is
+// recorded in that case's RunErr and the suite continues. Ctx cancellation
+// surfaces per case via the Runner (recorded in scores through NoError, or in
+// RunErr for a build failure) rather than aborting the whole suite.
+func (s Suite) Run(ctx context.Context) SuiteReport {
+	report := SuiteReport{Total: len(s.Cases)}
+	for _, c := range s.Cases {
+		cr := CaseReport{Case: c.Name, Pass: true}
+
+		res, err := Run(ctx, s.Config, c)
+		if err != nil {
+			cr.RunErr = err.Error()
+			cr.Pass = false
+			report.Cases = append(report.Cases, cr)
+			report.Failed++
+			continue
+		}
+
+		for _, sc := range s.Scorers {
+			verdict := sc.Score(res)
+			cr.Scores = append(cr.Scores, verdict)
+			if !verdict.Pass {
+				cr.Pass = false
+			}
+		}
+		if len(s.Scorers) == 0 {
+			cr.Pass = false
+		}
+
+		report.Cases = append(report.Cases, cr)
+		if cr.Pass {
+			report.Passed++
+		} else {
+			report.Failed++
+		}
+	}
+	return report
+}
+
+// String renders the report as a plain-text table. It returns the string; it
+// does not print (constraint A4) — a test or CLI writes it. The format is
+// stable enough to eyeball, not a machine contract (marshal the report as JSON
+// for that).
+func (r SuiteReport) String() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "eval suite: %d/%d cases passed\n", r.Passed, r.Total)
+	for _, c := range r.Cases {
+		status := "PASS"
+		if !c.Pass {
+			status = "FAIL"
+		}
+		fmt.Fprintf(&b, "  [%s] %s\n", status, c.Case)
+		if c.RunErr != "" {
+			fmt.Fprintf(&b, "      run error: %s\n", c.RunErr)
+			continue
+		}
+		for _, sc := range c.Scores {
+			mark := "ok"
+			if !sc.Pass {
+				mark = "x "
+			}
+			fmt.Fprintf(&b, "      %s %-12s %.2f  %s\n", mark, sc.Name, sc.Value, sc.Detail)
+		}
+	}
+	return b.String()
+}


### PR DESCRIPTION
**Update:** now that #929 (approval ladder) merged to main, this branch merges main and adds a **`NotDenied`** scorer. Design call: a policy denial is deliberately *not* an error (the Runner emits a distinct `tool-denied` event, not `tool-error`), so `NoError` keeps ignoring it and `NotDenied` is the separate, composable check for "the model never attempted a gated tool." A test pins that `NoError` ignores a denial while `NotDenied` catches it. Scorer list is now 7 deterministic + 1 tagged judge.

---

## What changes

Adds `agent/eval/`, a deterministic eval / scorer harness for agent turns, in the existing `agent/` module (no new go.mod, no new third-party dependency). A `Case` names one eval input, a `Scorer` grades what a run produced, and a `Suite` runs a set of cases against a set of scorers and returns a structured report. Six deterministic scorers ship in the default build; an LLM-as-judge scorer sits behind the `eval_llm` build tag, off the default CI path, so the harness carries no model or network requirement unless you opt in.

The point (from the agent SDK roadmap): a deterministic eval harness is the scarcest capability in the Go agent ecosystem, and standing it up early gives every later agent phase regression coverage. It reuses `agent.StubProvider` (deterministic model), `TurnResult`, and the captured `emit` event stream as the transcript to score.

## Reviewer's guide

Read in this order:

1. [agent/eval/eval.go](https://github.com/panyam/mcpkit/pull/951/files#diff-090aff95fa88a2398dd76df7a77ca6edc49f615c17573a720bffa923905d00f5) — `Case`, `Result`, the `Run(ctx, cfg, Case)` helper (applies per-case overrides, wires an event collector, packages the transcript), and `Transcript` rendering.
2. [agent/eval/scorer.go](https://github.com/panyam/mcpkit/pull/951/files#diff-cd975322b47b6b351f30ae49030e339a542cff41f17fb85a90b94f88e43a0258) — the `Score` struct, the `Scorer` interface, and the six deterministic scorer constructors.
3. [agent/eval/suite.go](https://github.com/panyam/mcpkit/pull/951/files#diff-236e1f933e767632862b288ebb89999b07288b63932524829d2daeede7c747f3) — `Suite`, `SuiteReport` / `CaseReport`, the `Run` aggregation, and non-printing `String()` rendering.
4. [agent/eval/judge.go](https://github.com/panyam/mcpkit/pull/951/files#diff-ed39686b38be1c02503eb2ccb193dbe8fac0cfd871165ca4b6c925ed2dca8dbf) — the `//go:build eval_llm` LLM-as-judge scorer over the `agent.Provider` seam.
5. [agent/eval/eval_test.go](https://github.com/panyam/mcpkit/pull/951/files#diff-a8022f439ea86c222f41b7cdb73f31a0edd2b3e9abad12335650512657aa370b) — StubProvider-driven coverage of every scorer (pass + fail), the Suite aggregate, and harness-error handling.
6. [agent/eval/judge_test.go](https://github.com/panyam/mcpkit/pull/951/files#diff-1f881d1daf6eb3e329a4ddcc478c23b1cec22a1ecec82542024933da1ff08f85) — build-tagged judge test (excluded from default CI).

## Decision log

- **`Run` takes `agent.RunnerConfig`, not a prebuilt `*agent.Runner`.** A `Case` can override the tool surface, instructions, and step cap, and a built Runner holds its config privately, so the config-in form is what lets per-case overrides work. `Run` builds the Runner internally.
- **Two error channels.** `Run` returns `(Result, error)` where the outer error is a harness-level failure (an invalid config `NewRunner` rejects); a turn that runs and fails carries its error in `Result.Err` so scorers (notably `NoError`) can grade it. This mirrors the Runner's own contract: tool failures never abort a turn, they fold back into the transcript.
- **`Suite.Run` returns just `SuiteReport`, no error.** A per-case harness failure is recorded in that case's `RunErr` and the suite keeps going, so one bad case does not abort the run. There is nothing suite-level to bubble.
- **No printing (constraint A4).** The package returns the report; `SuiteReport.String()` renders a plain-text table via `fmt.Fprintf` into a builder, and a test or CLI writes it. `Score.Value` is a normalized [0,1] score (1.0 = pass) so a graded judge fits the same shape.
- **Judge behind a build tag.** The LLM-as-judge scorer and its test both carry `//go:build eval_llm`, so `go test ./...` (no tags) compiles and passes with no model. The judge uses only the `agent.Provider` seam (no LLM SDK import anywhere), keeping constraint A1 intact.
- **Lives in `agent/` (constraint A6).** Scorers read a `*agent.TurnResult` and `[]agent.Event`, both meaningless without a Runner turn, so this is model-and-turn-facing and correctly sits in `agent/`, not `client/`.

## Risk / blast radius

Additive only: one new leaf package under `agent/`. No existing file changes, no API changes to `agent/`, no new dependency. The default build/test path gains no model or network requirement (judge is tag-gated). Nothing imports the new package yet, so blast radius is limited to the new files.

## How it works

`Run` clones the base `RunnerConfig`, applies the `Case`'s overrides, builds a Runner, and runs the turn with an `emit` closure that appends every `agent.Event` to a slice. The resulting `Result{Turn, Events, Err}` is the transcript. Each `Scorer.Score(Result)` inspects that transcript: text scorers read `Turn.Text`, `ToolCalled` scans the event stream for `tool-begin` of the named tool, `MaxSteps`/`StepCount` read `Turn.Steps`, and `NoError` checks `Result.Err` plus the stream for error events and `IsError` tool results. `Suite.Run` folds one `Score` per (case, scorer) into a `SuiteReport` with a pass/fail aggregate.

Closes #932.