### PR TITLE
feat(agent): RunStore interface + in-memory default

### DIFF
--- a/agent/runstore.go
+++ b/agent/runstore.go
@@ -1,0 +1,251 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"sync"
+	"time"
+)
+
+// RunStore is the persistence seam for runs: append-only logs of the
+// messages (and optionally events) a session accumulates across turns.
+// Surfaces persist TurnResult.Messages after each turn; resume is
+// LoadRun followed by Run over the loaded messages, and fork is ForkRun
+// followed by divergence — both cheap because the Runner is stateless
+// over history. The Runner itself never touches a RunStore.
+//
+// API shape follows the gRPC-style convention pinned in
+// stores/STORAGE_SEAMS.md:
+//
+//	Method(ctx context.Context, req XRequest) (XResponse, error)
+//
+// ctx threads cancellation, deadlines, and trace context.
+// Application-level state (Found, Created) lives on the response; error
+// is reserved for storage-layer failures (connection drops, corrupt
+// records). In particular, an unknown RunID is app-state (Found=false),
+// never an error.
+//
+// The interface and its in-memory default live in agent/ because every
+// method traffics in agent.Message / agent.Event: hosting them in the
+// root stores/ package would force a root→agent dependency (constraint
+// A6 corollary). Durable backends are sibling modules (agent/store/...)
+// so their dependencies stay out of this module.
+type RunStore interface {
+	CreateRun(ctx context.Context, req CreateRunRequest) (CreateRunResponse, error)
+	AppendMessages(ctx context.Context, req AppendMessagesRequest) (AppendMessagesResponse, error)
+	AppendEvents(ctx context.Context, req AppendEventsRequest) (AppendEventsResponse, error)
+	LoadRun(ctx context.Context, req LoadRunRequest) (LoadRunResponse, error)
+	ForkRun(ctx context.Context, req ForkRunRequest) (ForkRunResponse, error)
+}
+
+// Run is one persisted run: identity, fork lineage, and the append-only
+// logs. Messages is the conversation history a resume feeds back into
+// Runner.Run; Events is the optional replay/audit stream. Both element
+// types are wire-serializable by constraint A2, so Run itself marshals
+// cleanly through encoding/json — the property durable backends rely on.
+type Run struct {
+	ID string `json:"id"`
+
+	// ParentID is the run this one was forked from; empty for runs
+	// created directly.
+	ParentID string `json:"parentId,omitempty"`
+
+	CreatedAt time.Time `json:"createdAt"`
+
+	Messages []Message `json:"messages"`
+	Events   []Event   `json:"events,omitempty"`
+}
+
+// CreateRunRequest starts a new empty run. RunID is optional: empty asks
+// the store to generate a unique ID; non-empty claims a caller-chosen
+// name (a session name, a ticket ID). Claiming an ID that already exists
+// is not an overwrite — the store leaves the existing run intact and
+// reports Created=false.
+type CreateRunRequest struct {
+	RunID string
+}
+
+// CreateRunResponse carries the run's identity. Created is false when
+// the requested RunID already existed (the existing run is untouched);
+// stores always report Created=true for generated IDs.
+type CreateRunResponse struct {
+	RunID   string
+	Created bool
+}
+
+// AppendMessagesRequest appends messages to a run's log in order.
+// Callers pass exactly the entries a turn added (the user message plus
+// TurnResult.Messages) so the stored log threads the same way in-process
+// history does.
+type AppendMessagesRequest struct {
+	RunID    string
+	Messages []Message
+}
+
+// AppendMessagesResponse reports whether the run existed. Found=false
+// means nothing was written — the caller appended to a run it never
+// created (or one that was pruned), which is a caller bug to surface,
+// not a storage fault.
+type AppendMessagesResponse struct {
+	Found bool
+}
+
+// AppendEventsRequest appends events to a run's audit/replay log. The
+// event log is optional and independent of the message log: a store
+// accepts events for any existing run whether or not the surface also
+// persists messages.
+type AppendEventsRequest struct {
+	RunID  string
+	Events []Event
+}
+
+// AppendEventsResponse reports whether the run existed; Found=false
+// means nothing was written (see AppendMessagesResponse).
+type AppendEventsResponse struct {
+	Found bool
+}
+
+// LoadRunRequest fetches a run by ID.
+type LoadRunRequest struct {
+	RunID string
+}
+
+// LoadRunResponse carries the run when Found. The returned Run is the
+// caller's to keep: implementations return copies (or freshly decoded
+// values), never aliases into store-internal state, so mutating
+// Run.Messages cannot corrupt the log.
+type LoadRunResponse struct {
+	Run   Run
+	Found bool
+}
+
+// ForkRunRequest copies an existing run's logs into a new run so the
+// copy can diverge. NewRunID follows CreateRunRequest.RunID semantics:
+// empty generates a unique ID, non-empty claims a caller-chosen one.
+type ForkRunRequest struct {
+	RunID    string
+	NewRunID string
+}
+
+// ForkRunResponse identifies the fork. Found is false when the source
+// run does not exist; Created is false when NewRunID was claimed and
+// already existed (no copy happens). On success both are true and RunID
+// names the new run, whose ParentID records the lineage.
+type ForkRunResponse struct {
+	RunID   string
+	Found   bool
+	Created bool
+}
+
+// InMemoryRunStore is the default RunStore: a mutex-guarded map, useful
+// for tests and single-process sessions that only need in-lifetime
+// resume/fork. It is safe for concurrent use. Nothing survives process
+// exit — durable deployments swap in a sibling backend behind the same
+// interface.
+type InMemoryRunStore struct {
+	mu   sync.Mutex
+	runs map[string]*runEntry
+	seq  int
+}
+
+// runEntry consolidates one run's state (constraint C2: one entry struct
+// instead of parallel same-keyed maps).
+type runEntry struct {
+	parentID  string
+	createdAt time.Time
+	messages  []Message
+	events    []Event
+}
+
+// NewInMemoryRunStore returns an empty in-memory RunStore.
+func NewInMemoryRunStore() *InMemoryRunStore {
+	return &InMemoryRunStore{runs: map[string]*runEntry{}}
+}
+
+// CreateRun implements RunStore. Generated IDs are sequential
+// ("run-1", "run-2", ...) — deterministic on purpose, since an in-memory
+// store never shares an ID space across processes.
+func (s *InMemoryRunStore) CreateRun(ctx context.Context, req CreateRunRequest) (CreateRunResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	id := req.RunID
+	if id == "" {
+		s.seq++
+		id = fmt.Sprintf("run-%d", s.seq)
+	} else if _, ok := s.runs[id]; ok {
+		return CreateRunResponse{RunID: id, Created: false}, nil
+	}
+	s.runs[id] = &runEntry{createdAt: time.Now()}
+	return CreateRunResponse{RunID: id, Created: true}, nil
+}
+
+// AppendMessages implements RunStore.
+func (s *InMemoryRunStore) AppendMessages(ctx context.Context, req AppendMessagesRequest) (AppendMessagesResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	e, ok := s.runs[req.RunID]
+	if !ok {
+		return AppendMessagesResponse{Found: false}, nil
+	}
+	e.messages = append(e.messages, req.Messages...)
+	return AppendMessagesResponse{Found: true}, nil
+}
+
+// AppendEvents implements RunStore.
+func (s *InMemoryRunStore) AppendEvents(ctx context.Context, req AppendEventsRequest) (AppendEventsResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	e, ok := s.runs[req.RunID]
+	if !ok {
+		return AppendEventsResponse{Found: false}, nil
+	}
+	e.events = append(e.events, req.Events...)
+	return AppendEventsResponse{Found: true}, nil
+}
+
+// LoadRun implements RunStore. The returned Run's slices are clones, so
+// callers may append to or mutate them freely.
+func (s *InMemoryRunStore) LoadRun(ctx context.Context, req LoadRunRequest) (LoadRunResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	e, ok := s.runs[req.RunID]
+	if !ok {
+		return LoadRunResponse{}, nil
+	}
+	return LoadRunResponse{
+		Run: Run{
+			ID:        req.RunID,
+			ParentID:  e.parentID,
+			CreatedAt: e.createdAt,
+			Messages:  slices.Clone(e.messages),
+			Events:    slices.Clone(e.events),
+		},
+		Found: true,
+	}, nil
+}
+
+// ForkRun implements RunStore. The fork gets cloned logs, so parent and
+// fork diverge independently after the copy.
+func (s *InMemoryRunStore) ForkRun(ctx context.Context, req ForkRunRequest) (ForkRunResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	src, ok := s.runs[req.RunID]
+	if !ok {
+		return ForkRunResponse{}, nil
+	}
+	id := req.NewRunID
+	if id == "" {
+		s.seq++
+		id = fmt.Sprintf("run-%d", s.seq)
+	} else if _, exists := s.runs[id]; exists {
+		return ForkRunResponse{RunID: id, Found: true, Created: false}, nil
+	}
+	s.runs[id] = &runEntry{
+		parentID:  req.RunID,
+		createdAt: time.Now(),
+		messages:  slices.Clone(src.messages),
+		events:    slices.Clone(src.events),
+	}
+	return ForkRunResponse{RunID: id, Found: true, Created: true}, nil
+}

--- a/agent/runstore_test.go
+++ b/agent/runstore_test.go
@@ -1,0 +1,255 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func mustCreate(t *testing.T, s RunStore, id string) string {
+	t.Helper()
+	resp, err := s.CreateRun(context.Background(), CreateRunRequest{RunID: id})
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	if !resp.Created {
+		t.Fatalf("CreateRun(%q): Created=false", id)
+	}
+	return resp.RunID
+}
+
+func mustLoad(t *testing.T, s RunStore, id string) Run {
+	t.Helper()
+	resp, err := s.LoadRun(context.Background(), LoadRunRequest{RunID: id})
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if !resp.Found {
+		t.Fatalf("LoadRun(%q): Found=false", id)
+	}
+	return resp.Run
+}
+
+func TestInMemoryRunStore_CreateAppendLoad(t *testing.T) {
+	ctx := context.Background()
+	s := NewInMemoryRunStore()
+
+	id := mustCreate(t, s, "")
+	if id == "" {
+		t.Fatal("generated RunID is empty")
+	}
+
+	turn1 := []Message{
+		{Role: RoleUser, Text: "hi"},
+		{Role: RoleAssistant, Text: "hello"},
+	}
+	turn2 := []Message{
+		{Role: RoleUser, Text: "list files"},
+		{Role: RoleAssistant, ToolCalls: []ToolCall{{ID: "c1", Name: "ls"}}},
+		{Role: RoleTool, ToolCallID: "c1", Text: "a.go"},
+		{Role: RoleAssistant, Text: "a.go"},
+	}
+	for _, msgs := range [][]Message{turn1, turn2} {
+		resp, err := s.AppendMessages(ctx, AppendMessagesRequest{RunID: id, Messages: msgs})
+		if err != nil {
+			t.Fatalf("AppendMessages: %v", err)
+		}
+		if !resp.Found {
+			t.Fatal("AppendMessages: Found=false for existing run")
+		}
+	}
+
+	run := mustLoad(t, s, id)
+	want := append(append([]Message{}, turn1...), turn2...)
+	if !reflect.DeepEqual(run.Messages, want) {
+		t.Fatalf("loaded messages mismatch:\n got %+v\nwant %+v", run.Messages, want)
+	}
+	if run.ID != id {
+		t.Fatalf("Run.ID = %q, want %q", run.ID, id)
+	}
+	if run.ParentID != "" {
+		t.Fatalf("Run.ParentID = %q, want empty for a direct run", run.ParentID)
+	}
+	if run.CreatedAt.IsZero() {
+		t.Fatal("Run.CreatedAt is zero")
+	}
+}
+
+func TestInMemoryRunStore_ExplicitAndDuplicateID(t *testing.T) {
+	ctx := context.Background()
+	s := NewInMemoryRunStore()
+
+	if got := mustCreate(t, s, "session-a"); got != "session-a" {
+		t.Fatalf("CreateRun kept explicit ID? got %q", got)
+	}
+	if _, err := s.AppendMessages(ctx, AppendMessagesRequest{
+		RunID: "session-a", Messages: []Message{{Role: RoleUser, Text: "x"}},
+	}); err != nil {
+		t.Fatalf("AppendMessages: %v", err)
+	}
+
+	dup, err := s.CreateRun(ctx, CreateRunRequest{RunID: "session-a"})
+	if err != nil {
+		t.Fatalf("duplicate CreateRun: %v", err)
+	}
+	if dup.Created {
+		t.Fatal("duplicate CreateRun reported Created=true")
+	}
+	if got := mustLoad(t, s, "session-a"); len(got.Messages) != 1 {
+		t.Fatalf("duplicate CreateRun clobbered the run: %d messages, want 1", len(got.Messages))
+	}
+}
+
+func TestInMemoryRunStore_UnknownRun(t *testing.T) {
+	ctx := context.Background()
+	s := NewInMemoryRunStore()
+
+	if resp, err := s.LoadRun(ctx, LoadRunRequest{RunID: "nope"}); err != nil || resp.Found {
+		t.Fatalf("LoadRun(unknown) = (%+v, %v), want Found=false, nil error", resp, err)
+	}
+	if resp, err := s.AppendMessages(ctx, AppendMessagesRequest{RunID: "nope"}); err != nil || resp.Found {
+		t.Fatalf("AppendMessages(unknown) = (%+v, %v), want Found=false, nil error", resp, err)
+	}
+	if resp, err := s.AppendEvents(ctx, AppendEventsRequest{RunID: "nope"}); err != nil || resp.Found {
+		t.Fatalf("AppendEvents(unknown) = (%+v, %v), want Found=false, nil error", resp, err)
+	}
+	if resp, err := s.ForkRun(ctx, ForkRunRequest{RunID: "nope"}); err != nil || resp.Found {
+		t.Fatalf("ForkRun(unknown) = (%+v, %v), want Found=false, nil error", resp, err)
+	}
+}
+
+func TestInMemoryRunStore_AppendEvents(t *testing.T) {
+	ctx := context.Background()
+	s := NewInMemoryRunStore()
+	id := mustCreate(t, s, "")
+
+	events := []Event{
+		{Kind: EventTurnBegin},
+		{Kind: EventTextDelta, Step: 1, Text: "hel"},
+		{Kind: EventTextDelta, Step: 1, Text: "lo"},
+	}
+	resp, err := s.AppendEvents(ctx, AppendEventsRequest{RunID: id, Events: events})
+	if err != nil || !resp.Found {
+		t.Fatalf("AppendEvents = (%+v, %v)", resp, err)
+	}
+	run := mustLoad(t, s, id)
+	if !reflect.DeepEqual(run.Events, events) {
+		t.Fatalf("loaded events mismatch:\n got %+v\nwant %+v", run.Events, events)
+	}
+}
+
+func TestInMemoryRunStore_ForkDiverges(t *testing.T) {
+	ctx := context.Background()
+	s := NewInMemoryRunStore()
+	id := mustCreate(t, s, "parent")
+	base := []Message{{Role: RoleUser, Text: "shared"}}
+	if _, err := s.AppendMessages(ctx, AppendMessagesRequest{RunID: id, Messages: base}); err != nil {
+		t.Fatalf("AppendMessages: %v", err)
+	}
+
+	fork, err := s.ForkRun(ctx, ForkRunRequest{RunID: id})
+	if err != nil {
+		t.Fatalf("ForkRun: %v", err)
+	}
+	if !fork.Found || !fork.Created || fork.RunID == "" || fork.RunID == id {
+		t.Fatalf("ForkRun = %+v", fork)
+	}
+
+	forked := mustLoad(t, s, fork.RunID)
+	if !reflect.DeepEqual(forked.Messages, base) {
+		t.Fatalf("fork did not copy the log: %+v", forked.Messages)
+	}
+	if forked.ParentID != id {
+		t.Fatalf("fork ParentID = %q, want %q", forked.ParentID, id)
+	}
+
+	if _, err := s.AppendMessages(ctx, AppendMessagesRequest{
+		RunID: fork.RunID, Messages: []Message{{Role: RoleUser, Text: "fork only"}},
+	}); err != nil {
+		t.Fatalf("AppendMessages(fork): %v", err)
+	}
+	if _, err := s.AppendMessages(ctx, AppendMessagesRequest{
+		RunID: id, Messages: []Message{{Role: RoleUser, Text: "parent only"}},
+	}); err != nil {
+		t.Fatalf("AppendMessages(parent): %v", err)
+	}
+
+	parent := mustLoad(t, s, id)
+	forked = mustLoad(t, s, fork.RunID)
+	if len(parent.Messages) != 2 || parent.Messages[1].Text != "parent only" {
+		t.Fatalf("parent log polluted: %+v", parent.Messages)
+	}
+	if len(forked.Messages) != 2 || forked.Messages[1].Text != "fork only" {
+		t.Fatalf("fork log polluted: %+v", forked.Messages)
+	}
+}
+
+func TestInMemoryRunStore_ForkExplicitIDCollision(t *testing.T) {
+	ctx := context.Background()
+	s := NewInMemoryRunStore()
+	mustCreate(t, s, "src")
+	mustCreate(t, s, "taken")
+
+	fork, err := s.ForkRun(ctx, ForkRunRequest{RunID: "src", NewRunID: "taken"})
+	if err != nil {
+		t.Fatalf("ForkRun: %v", err)
+	}
+	if !fork.Found || fork.Created {
+		t.Fatalf("ForkRun onto taken ID = %+v, want Found=true Created=false", fork)
+	}
+}
+
+func TestInMemoryRunStore_LoadReturnsCopies(t *testing.T) {
+	ctx := context.Background()
+	s := NewInMemoryRunStore()
+	id := mustCreate(t, s, "")
+	if _, err := s.AppendMessages(ctx, AppendMessagesRequest{
+		RunID: id, Messages: []Message{{Role: RoleUser, Text: "original"}},
+	}); err != nil {
+		t.Fatalf("AppendMessages: %v", err)
+	}
+
+	run := mustLoad(t, s, id)
+	run.Messages[0].Text = "mutated"
+	run.Messages = append(run.Messages, Message{Role: RoleUser, Text: "extra"})
+
+	again := mustLoad(t, s, id)
+	if len(again.Messages) != 1 || again.Messages[0].Text != "original" {
+		t.Fatalf("store state aliased by LoadRun result: %+v", again.Messages)
+	}
+}
+
+// TestRun_JSONRoundTrip pins the property durable backends rely on: a Run
+// (messages and events included) survives encoding/json unchanged, per
+// constraint A2.
+func TestRun_JSONRoundTrip(t *testing.T) {
+	run := Run{
+		ID:       "r1",
+		ParentID: "r0",
+		Messages: []Message{
+			{Role: RoleUser, Text: "hi"},
+			{Role: RoleAssistant, ToolCalls: []ToolCall{{ID: "c1", Name: "ls"}}},
+			{Role: RoleTool, ToolCallID: "c1", Text: "a.go"},
+		},
+		Events: []Event{
+			{Kind: EventTurnBegin},
+			{Kind: EventToolBegin, Step: 1, ToolCall: &ToolCall{ID: "c1", Name: "ls"}},
+		},
+	}
+	data, err := json.Marshal(run)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var back Run
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	data2, err := json.Marshal(back)
+	if err != nil {
+		t.Fatalf("re-marshal: %v", err)
+	}
+	if string(data) != string(data2) {
+		t.Fatalf("round-trip drift:\n got %s\nwant %s", data2, data)
+	}
+}


### PR DESCRIPTION
Closes #933. Part of the P1 persistence stack (bottom PR; \`p1/934-runstore-redis\` stacks on this).

## What changes

Adds the persistence keystone for the agent SDK: a `RunStore` interface in `agent/runstore.go` plus a mutex-guarded in-memory default. A run is an append-only log of the messages (and optionally events) a session accumulates across turns. Surfaces persist `TurnResult.Messages` after each turn; resume is `LoadRun` then `Run` over the loaded messages; fork is `ForkRun` then diverge. The Runner itself is untouched — it stays stateless over history, which is what makes resume and fork free.

## Reviewer's guide

Read in this order:
1. [agent/runstore.go](https://github.com/panyam/mcpkit/pull/955/files#diff-f2ebdb590e8817d70dfdc21e0169cecb55b6a3131172a87aaa59e57301ed2643) — the whole change. Interface + request/response types first (the contract and its doc comments are the review surface), then `InMemoryRunStore` at the bottom (mechanical map+mutex).
2. [agent/runstore_test.go](https://github.com/panyam/mcpkit/pull/955/files#diff-a7fccb32fb12f046dbbb204300691f6fdbac684000e05f8bcd759e96261366b0) — acceptance: create/append/load round-trip, fork divergence, unknown-run app-state semantics, load-returns-copies isolation, and a JSON round-trip pin for durable backends.

## Decision log

- **gRPC-style req/resp per method** over positional args: follows the convention pinned in `stores/STORAGE_SEAMS.md` and `stores/quota.go`, so the Redis sibling and any SQL backend implement an identical shape. App-state (`Found`, `Created`) lives on responses; error is reserved for storage faults. An unknown RunID is `Found=false`, never an error.
- **Interface lives in `agent/`, not root `stores/`**: every method traffics in `agent.Message`/`agent.Event`, so hosting it in `stores/` would force a root→agent dependency (A6 corollary, quoted in the issue).
- **`CreateRun` with an existing explicit ID reports `Created=false` and leaves the run intact** rather than erroring or overwriting: callers claiming session names need collision detection, not data loss.
- **Sequential generated IDs (`run-1`, `run-2`)** in the in-memory store: deterministic and test-friendly; an in-memory store never shares an ID space across processes. Durable backends generate their own collision-free IDs.
- **Per-turn durability only**: mid-turn replay needs tool-call idempotency the module can't guarantee for arbitrary MCP servers; deferred per the roadmap.

## Risk / blast radius

- Purely additive: no existing symbol changes, no Runner changes, nothing imports the new API yet (host wiring is PR for issue 935, two up the stack).
- Tests covering this: `agent/runstore_test.go` (8 tests). `make test-agent` green across all five sub-modules.
- Be paranoid about: aliasing — `LoadRun`/`ForkRun` must clone slices so callers and forks can't corrupt the store's log (`TestInMemoryRunStore_LoadReturnsCopies`, `TestInMemoryRunStore_ForkDiverges` pin this).

## Out of scope (deliberately deferred)

- Redis backend → #934 (next PR in the stack)
- Host persist/resume/fork wiring → #935
- Mid-turn replay / event-log-based resume → later opt-in per `docs/AGENT_SDK_ROADMAP.md` §D
