### PR TITLE
feat(agent/host): persist / resume / fork session wiring

### DIFF
--- a/agent/host/README.md
+++ b/agent/host/README.md
@@ -34,6 +34,14 @@ stay out of the lean `agent/` module.
   `OpenAIProvider` for a real model).
 - `WithTracerProvider(tp)` — SEP-414 tracing.
 - `WithLogger(l)` — structured logging.
+- `WithRunStore(store)` — session persistence. Every completed turn's messages
+  and event stream append to a run in the store (`agent.NewInMemoryRunStore`
+  for in-process resume/fork, `agent/store/redis` for restart-surviving
+  sessions). `App.AttachRun` names or resumes a session at startup;
+  `App.Resume` and `App.Fork` switch runs mid-session (`/resume <id>`,
+  `/fork [id]`, `/session` in the REPL). A failed or cancelled turn persists
+  nothing; persistence failures degrade to a rendered warning, never a turn
+  failure.
 
 ## Testing
 

--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -41,6 +41,12 @@ type App struct {
 	metaTools bool
 	turnMu    sync.Mutex
 	eventStop context.CancelFunc
+
+	// store and runID are the persistence seam (WithRunStore): runID is
+	// the run turns append to, created lazily on the first persisted
+	// turn or set by AttachRun / Resume / Fork. Guarded by turnMu.
+	store agent.RunStore
+	runID string
 }
 
 // AppOption customizes construction. The provider override exists so tests
@@ -52,6 +58,7 @@ type appOptions struct {
 	ui       agent.ElicitationUI
 	tp       core.TracerProvider
 	logger   *slog.Logger
+	store    agent.RunStore
 }
 
 // WithProvider overrides the OpenAI-compatible provider built from config.
@@ -100,7 +107,7 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 	coord := agent.NewElicitationCoordinator(ui)
 
 	multi := agent.NewMultiSource()
-	app := &App{cfg: cfg, sources: multi, renderer: rend, bgTasks: map[string]*client.BackgroundTask{}, subs: map[string]*subscription{}}
+	app := &App{cfg: cfg, sources: multi, renderer: rend, bgTasks: map[string]*client.BackgroundTask{}, subs: map[string]*subscription{}, store: o.store}
 	// The approval "ask" prompt rides the same FIFO seam as elicitation, so a
 	// gated tool call never stacks a dialog against a concurrent elicitation.
 	ask := func(ctx context.Context, req agent.ApprovalRequest) (bool, error) {
@@ -277,20 +284,37 @@ func (a *App) Close() {
 
 // RunTurn executes one user input, rendering events as they stream. History
 // threads across turns; a cancelled or failed turn leaves history at its
-// pre-turn state so the next attempt is clean.
+// pre-turn state (and persists nothing) so the next attempt is clean.
 func (a *App) RunTurn(ctx context.Context, input string) error {
 	a.turnMu.Lock()
 	defer a.turnMu.Unlock()
 	a.triggers.NotifyEngagement()
 	a.drainInjectionLocked()
-	a.history = append(a.history, agent.Message{Role: agent.RoleUser, Text: input})
-	result, err := a.runner.Run(ctx, a.history, a.renderer.handle)
+	userMsg := agent.Message{Role: agent.RoleUser, Text: input}
+	a.history = append(a.history, userMsg)
+
+	emit := a.renderer.handle
+	var pe *PersistingEmit
+	if a.store != nil {
+		if err := a.ensureRunLocked(ctx); err != nil {
+			a.history = a.history[:len(a.history)-1]
+			a.renderer.turnFailed(err)
+			return err
+		}
+		pe = NewPersistingEmit(a.store, a.runID, emit)
+		emit = pe.Emit
+	}
+
+	result, err := a.runner.Run(ctx, a.history, emit)
 	if err != nil {
 		a.history = a.history[:len(a.history)-1]
 		a.renderer.turnFailed(err)
 		return err
 	}
 	a.history = append(a.history, result.Messages...)
+	if pe != nil {
+		a.persistTurnLocked(ctx, append([]agent.Message{userMsg}, result.Messages...), pe)
+	}
 	a.renderer.turnDone(result)
 	return nil
 }
@@ -347,6 +371,23 @@ func (a *App) REPL(ctx context.Context, in io.Reader, turnCtx func() (context.Co
 			a.renderer.approvalMode(a.approval)
 		case strings.HasPrefix(line, "/approve "):
 			a.setApprovalMode(strings.TrimPrefix(line, "/approve "))
+		case line == "/session":
+			a.renderer.session(a.RunID())
+		case strings.HasPrefix(line, "/resume "):
+			id := strings.TrimSpace(strings.TrimPrefix(line, "/resume "))
+			if err := a.Resume(ctx, id); err != nil {
+				a.renderer.turnFailed(err)
+			} else {
+				a.renderer.session(id)
+			}
+		case line == "/fork" || strings.HasPrefix(line, "/fork "):
+			id := strings.TrimSpace(strings.TrimPrefix(line, "/fork"))
+			forkID, err := a.Fork(ctx, id)
+			if err != nil {
+				a.renderer.turnFailed(err)
+			} else {
+				a.renderer.session(forkID)
+			}
 		default:
 			tctx, cancel := turnCtx()
 			a.RunTurn(tctx, line)

--- a/agent/host/persistence.go
+++ b/agent/host/persistence.go
@@ -1,0 +1,181 @@
+package host
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/panyam/mcpkit/agent"
+)
+
+// WithRunStore enables session persistence: every completed turn's
+// messages (and its event stream) are appended to a run in store, so a
+// surface can resume or fork the session later — across process
+// restarts when the store is durable. Nil (the default) keeps the
+// pre-persistence behavior: history lives only in memory.
+func WithRunStore(store agent.RunStore) AppOption {
+	return func(o *appOptions) { o.store = store }
+}
+
+// RunID returns the active persisted run, or "" when persistence is off
+// or no run has been attached or created yet (the first turn creates
+// one lazily).
+func (a *App) RunID() string {
+	a.turnMu.Lock()
+	defer a.turnMu.Unlock()
+	return a.runID
+}
+
+// AttachRun binds the session to runID with create-or-resume semantics:
+// an existing run's history is loaded and threaded (resume), an absent
+// one is created empty. This is the startup path for surfaces that name
+// sessions ("continue yesterday's run-x or start it fresh"); for a
+// must-exist switch mid-session, use Resume.
+func (a *App) AttachRun(ctx context.Context, runID string) error {
+	a.turnMu.Lock()
+	defer a.turnMu.Unlock()
+	if a.store == nil {
+		return fmt.Errorf("host: no RunStore configured")
+	}
+	resp, err := a.store.CreateRun(ctx, agent.CreateRunRequest{RunID: runID})
+	if err != nil {
+		return fmt.Errorf("host: attaching run %q: %w", runID, err)
+	}
+	if resp.Created {
+		a.runID = resp.RunID
+		a.history = nil
+		return nil
+	}
+	return a.resumeLocked(ctx, runID)
+}
+
+// Resume switches the session to an existing run: its persisted
+// messages replace the in-memory history and subsequent turns append to
+// it. An unknown runID is an error (nothing changes), so a typo cannot
+// silently start an empty session — use AttachRun for create-or-resume.
+func (a *App) Resume(ctx context.Context, runID string) error {
+	a.turnMu.Lock()
+	defer a.turnMu.Unlock()
+	if a.store == nil {
+		return fmt.Errorf("host: no RunStore configured")
+	}
+	return a.resumeLocked(ctx, runID)
+}
+
+func (a *App) resumeLocked(ctx context.Context, runID string) error {
+	resp, err := a.store.LoadRun(ctx, agent.LoadRunRequest{RunID: runID})
+	if err != nil {
+		return fmt.Errorf("host: loading run %q: %w", runID, err)
+	}
+	if !resp.Found {
+		return fmt.Errorf("host: run %q not found", runID)
+	}
+	a.history = resp.Run.Messages
+	a.runID = runID
+	return nil
+}
+
+// Fork copies the current run's log into a new run (newRunID empty asks
+// the store to generate one) and switches the session to the copy: the
+// in-memory history is already the shared prefix, so the fork diverges
+// from the next turn on while the original run stays untouched.
+func (a *App) Fork(ctx context.Context, newRunID string) (string, error) {
+	a.turnMu.Lock()
+	defer a.turnMu.Unlock()
+	if a.store == nil {
+		return "", fmt.Errorf("host: no RunStore configured")
+	}
+	if a.runID == "" {
+		return "", fmt.Errorf("host: no active run to fork (run at least one turn first)")
+	}
+	resp, err := a.store.ForkRun(ctx, agent.ForkRunRequest{RunID: a.runID, NewRunID: newRunID})
+	if err != nil {
+		return "", fmt.Errorf("host: forking run %q: %w", a.runID, err)
+	}
+	if !resp.Found {
+		return "", fmt.Errorf("host: run %q not found", a.runID)
+	}
+	if !resp.Created {
+		return "", fmt.Errorf("host: run %q already exists", newRunID)
+	}
+	a.runID = resp.RunID
+	return resp.RunID, nil
+}
+
+// ensureRunLocked lazily creates the session's run before the first
+// persisted turn. Caller holds turnMu.
+func (a *App) ensureRunLocked(ctx context.Context) error {
+	if a.runID != "" {
+		return nil
+	}
+	resp, err := a.store.CreateRun(ctx, agent.CreateRunRequest{})
+	if err != nil {
+		return fmt.Errorf("host: creating run: %w", err)
+	}
+	a.runID = resp.RunID
+	a.renderer.session(resp.RunID)
+	return nil
+}
+
+// persistTurnLocked appends the completed turn (user message + appended
+// messages) and flushes the teed event stream. Persistence failures are
+// rendered as warnings, not turn failures: the turn already succeeded
+// and the in-memory session stays usable; only durability degraded.
+// Caller holds turnMu.
+func (a *App) persistTurnLocked(ctx context.Context, msgs []agent.Message, pe *PersistingEmit) {
+	resp, err := a.store.AppendMessages(ctx, agent.AppendMessagesRequest{RunID: a.runID, Messages: msgs})
+	if err != nil {
+		a.renderer.sessionWarn(err)
+	} else if !resp.Found {
+		a.renderer.sessionWarn(fmt.Errorf("run %q disappeared from the store", a.runID))
+	}
+	if err := pe.Flush(ctx); err != nil {
+		a.renderer.sessionWarn(err)
+	}
+}
+
+// PersistingEmit tees a Runner event stream into a RunStore event log.
+// Use its Emit as the emit argument to Runner.Run (wrapping the
+// surface's own handler), then Flush once the turn completes. Events
+// buffer in memory and land in one AppendEvents call per turn — the
+// per-turn durability grain — rather than one store round-trip per
+// text delta. Not safe for concurrent use, which matches the Runner's
+// guarantee that emit is never called concurrently.
+type PersistingEmit struct {
+	store agent.RunStore
+	runID string
+	next  func(agent.Event)
+	buf   []agent.Event
+}
+
+// NewPersistingEmit wraps next (nil is allowed) for the given run.
+func NewPersistingEmit(store agent.RunStore, runID string, next func(agent.Event)) *PersistingEmit {
+	if next == nil {
+		next = func(agent.Event) {}
+	}
+	return &PersistingEmit{store: store, runID: runID, next: next}
+}
+
+// Emit buffers the event and forwards it to the wrapped handler.
+func (p *PersistingEmit) Emit(e agent.Event) {
+	p.buf = append(p.buf, e)
+	p.next(e)
+}
+
+// Flush appends the buffered events to the run and clears the buffer.
+// A run the store does not know is reported as an error here (unlike
+// the raw AppendEvents Found=false) because by construction the caller
+// created the run before the turn began.
+func (p *PersistingEmit) Flush(ctx context.Context) error {
+	if len(p.buf) == 0 {
+		return nil
+	}
+	resp, err := p.store.AppendEvents(ctx, agent.AppendEventsRequest{RunID: p.runID, Events: p.buf})
+	if err != nil {
+		return err
+	}
+	if !resp.Found {
+		return fmt.Errorf("host: run %q disappeared from the store", p.runID)
+	}
+	p.buf = nil
+	return nil
+}

--- a/agent/host/persistence_test.go
+++ b/agent/host/persistence_test.go
@@ -1,0 +1,292 @@
+package host
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/panyam/mcpkit/agent"
+)
+
+func newPersistedApp(t *testing.T, store agent.RunStore, stub *agent.StubProvider, out *strings.Builder) *App {
+	t.Helper()
+	ts := startTestServer(t)
+	app, err := NewApp(testConfig(ts.URL), out, strings.NewReader(""), WithProvider(stub), WithRunStore(store))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(app.Close)
+	return app
+}
+
+func TestAppPersistsTurns(t *testing.T) {
+	ctx := context.Background()
+	store := agent.NewInMemoryRunStore()
+	stub := agent.NewStubProvider(
+		agent.StubTurn{Text: "first answer"},
+		agent.StubTurn{Text: "second answer"},
+	)
+	var out strings.Builder
+	app := newPersistedApp(t, store, stub, &out)
+
+	if got := app.RunID(); got != "" {
+		t.Fatalf("RunID before first turn = %q, want empty (lazy create)", got)
+	}
+	if err := app.RunTurn(ctx, "one"); err != nil {
+		t.Fatal(err)
+	}
+	runID := app.RunID()
+	if runID == "" {
+		t.Fatal("RunID empty after a persisted turn")
+	}
+	if !strings.Contains(out.String(), "session: "+runID) {
+		t.Fatalf("transcript missing session line:\n%s", out.String())
+	}
+	if err := app.RunTurn(ctx, "two"); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := store.LoadRun(ctx, agent.LoadRunRequest{RunID: runID})
+	if err != nil || !resp.Found {
+		t.Fatalf("LoadRun = (%+v, %v)", resp, err)
+	}
+	msgs := resp.Run.Messages
+	if len(msgs) != 4 {
+		t.Fatalf("persisted %d messages, want 4: %+v", len(msgs), msgs)
+	}
+	for i, want := range []string{"one", "first answer", "two", "second answer"} {
+		if msgs[i].Text != want {
+			t.Fatalf("persisted message %d = %q, want %q", i, msgs[i].Text, want)
+		}
+	}
+
+	kinds := map[agent.EventKind]bool{}
+	for _, e := range resp.Run.Events {
+		kinds[e.Kind] = true
+	}
+	for _, want := range []agent.EventKind{agent.EventTurnBegin, agent.EventTextDelta, agent.EventTurnEnd} {
+		if !kinds[want] {
+			t.Fatalf("persisted event log missing %s: %+v", want, resp.Run.Events)
+		}
+	}
+}
+
+func TestAppResumeThreadsPersistedHistory(t *testing.T) {
+	ctx := context.Background()
+	store := agent.NewInMemoryRunStore()
+
+	var out1 strings.Builder
+	app1 := newPersistedApp(t, store, agent.NewStubProvider(agent.StubTurn{Text: "remembered"}), &out1)
+	if err := app1.RunTurn(ctx, "fact"); err != nil {
+		t.Fatal(err)
+	}
+	runID := app1.RunID()
+	app1.Close()
+
+	stub2 := agent.NewStubProvider(agent.StubTurn{Text: "recalled"})
+	var out2 strings.Builder
+	app2 := newPersistedApp(t, store, stub2, &out2)
+	if err := app2.Resume(ctx, runID); err != nil {
+		t.Fatal(err)
+	}
+	if err := app2.RunTurn(ctx, "what did I say?"); err != nil {
+		t.Fatal(err)
+	}
+
+	msgs := stub2.Requests()[0].Messages
+	if len(msgs) != 3 || msgs[0].Text != "fact" || msgs[1].Text != "remembered" || msgs[2].Text != "what did I say?" {
+		t.Fatalf("resumed model request did not thread persisted history: %+v", msgs)
+	}
+
+	resp, _ := store.LoadRun(ctx, agent.LoadRunRequest{RunID: runID})
+	if len(resp.Run.Messages) != 4 {
+		t.Fatalf("resumed turn did not append to the run: %d messages, want 4", len(resp.Run.Messages))
+	}
+}
+
+func TestAppResumeUnknownRunLeavesSessionIntact(t *testing.T) {
+	ctx := context.Background()
+	store := agent.NewInMemoryRunStore()
+	stub := agent.NewStubProvider(agent.StubTurn{Text: "answer"})
+	var out strings.Builder
+	app := newPersistedApp(t, store, stub, &out)
+	if err := app.RunTurn(ctx, "one"); err != nil {
+		t.Fatal(err)
+	}
+	runID := app.RunID()
+
+	if err := app.Resume(ctx, "no-such-run"); err == nil {
+		t.Fatal("Resume(unknown) succeeded, want error")
+	}
+	if got := app.RunID(); got != runID {
+		t.Fatalf("failed Resume switched the run: %q, want %q", got, runID)
+	}
+	if len(app.history) != 2 {
+		t.Fatalf("failed Resume mutated history: %+v", app.history)
+	}
+}
+
+func TestAppForkDiverges(t *testing.T) {
+	ctx := context.Background()
+	store := agent.NewInMemoryRunStore()
+	stub := agent.NewStubProvider(
+		agent.StubTurn{Text: "shared"},
+		agent.StubTurn{Text: "fork only"},
+	)
+	var out strings.Builder
+	app := newPersistedApp(t, store, stub, &out)
+	if err := app.RunTurn(ctx, "base"); err != nil {
+		t.Fatal(err)
+	}
+	original := app.RunID()
+
+	forkID, err := app.Fork(ctx, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if forkID == original || app.RunID() != forkID {
+		t.Fatalf("Fork = %q (active %q), original %q", forkID, app.RunID(), original)
+	}
+	if err := app.RunTurn(ctx, "diverge"); err != nil {
+		t.Fatal(err)
+	}
+
+	orig, _ := store.LoadRun(ctx, agent.LoadRunRequest{RunID: original})
+	fork, _ := store.LoadRun(ctx, agent.LoadRunRequest{RunID: forkID})
+	if len(orig.Run.Messages) != 2 {
+		t.Fatalf("original run polluted by fork turn: %+v", orig.Run.Messages)
+	}
+	if len(fork.Run.Messages) != 4 || fork.Run.Messages[3].Text != "fork only" {
+		t.Fatalf("fork did not accumulate the divergent turn: %+v", fork.Run.Messages)
+	}
+	if fork.Run.ParentID != original {
+		t.Fatalf("fork ParentID = %q, want %q", fork.Run.ParentID, original)
+	}
+}
+
+func TestAppForkWithoutRunErrors(t *testing.T) {
+	store := agent.NewInMemoryRunStore()
+	stub := agent.NewStubProvider()
+	var out strings.Builder
+	app := newPersistedApp(t, store, stub, &out)
+	if _, err := app.Fork(context.Background(), ""); err == nil {
+		t.Fatal("Fork with no active run succeeded, want error")
+	}
+}
+
+func TestAppAttachRunCreateOrResume(t *testing.T) {
+	ctx := context.Background()
+	store := agent.NewInMemoryRunStore()
+
+	var out1 strings.Builder
+	app1 := newPersistedApp(t, store, agent.NewStubProvider(agent.StubTurn{Text: "day one"}), &out1)
+	if err := app1.AttachRun(ctx, "daily"); err != nil {
+		t.Fatal(err)
+	}
+	if app1.RunID() != "daily" {
+		t.Fatalf("AttachRun(new) RunID = %q", app1.RunID())
+	}
+	if err := app1.RunTurn(ctx, "note this"); err != nil {
+		t.Fatal(err)
+	}
+	app1.Close()
+
+	stub2 := agent.NewStubProvider(agent.StubTurn{Text: "day two"})
+	var out2 strings.Builder
+	app2 := newPersistedApp(t, store, stub2, &out2)
+	if err := app2.AttachRun(ctx, "daily"); err != nil {
+		t.Fatal(err)
+	}
+	if err := app2.RunTurn(ctx, "continue"); err != nil {
+		t.Fatal(err)
+	}
+	msgs := stub2.Requests()[0].Messages
+	if len(msgs) != 3 || msgs[0].Text != "note this" {
+		t.Fatalf("AttachRun(existing) did not resume history: %+v", msgs)
+	}
+}
+
+func TestAppFailedTurnPersistsNothing(t *testing.T) {
+	ctx := context.Background()
+	store := agent.NewInMemoryRunStore()
+	stub := agent.NewStubProvider(
+		agent.StubTurn{Text: "ok"},
+		agent.StubTurn{Err: errors.New("model down")},
+	)
+	var out strings.Builder
+	app := newPersistedApp(t, store, stub, &out)
+	if err := app.RunTurn(ctx, "one"); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.RunTurn(ctx, "two"); err == nil {
+		t.Fatal("second turn succeeded, want provider error")
+	}
+
+	resp, _ := store.LoadRun(ctx, agent.LoadRunRequest{RunID: app.RunID()})
+	if len(resp.Run.Messages) != 2 {
+		t.Fatalf("failed turn leaked into the run: %+v", resp.Run.Messages)
+	}
+}
+
+func TestAppWithoutStoreSessionMethodsError(t *testing.T) {
+	ts := startTestServer(t)
+	var out strings.Builder
+	app, err := NewApp(testConfig(ts.URL), &out, strings.NewReader(""), WithProvider(agent.NewStubProvider()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Close()
+
+	ctx := context.Background()
+	if err := app.Resume(ctx, "x"); err == nil {
+		t.Fatal("Resume without store succeeded")
+	}
+	if err := app.AttachRun(ctx, "x"); err == nil {
+		t.Fatal("AttachRun without store succeeded")
+	}
+	if _, err := app.Fork(ctx, ""); err == nil {
+		t.Fatal("Fork without store succeeded")
+	}
+	if got := app.RunID(); got != "" {
+		t.Fatalf("RunID without store = %q", got)
+	}
+}
+
+func TestPersistingEmitFlush(t *testing.T) {
+	ctx := context.Background()
+	store := agent.NewInMemoryRunStore()
+	created, err := store.CreateRun(ctx, agent.CreateRunRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var forwarded []agent.Event
+	pe := NewPersistingEmit(store, created.RunID, func(e agent.Event) { forwarded = append(forwarded, e) })
+	pe.Emit(agent.Event{Kind: agent.EventTurnBegin})
+	pe.Emit(agent.Event{Kind: agent.EventTextDelta, Step: 1, Text: "hi"})
+	if len(forwarded) != 2 {
+		t.Fatalf("wrapped handler saw %d events, want 2", len(forwarded))
+	}
+
+	if err := pe.Flush(ctx); err != nil {
+		t.Fatal(err)
+	}
+	resp, _ := store.LoadRun(ctx, agent.LoadRunRequest{RunID: created.RunID})
+	if len(resp.Run.Events) != 2 {
+		t.Fatalf("flushed %d events, want 2", len(resp.Run.Events))
+	}
+	if err := pe.Flush(ctx); err != nil {
+		t.Fatalf("empty re-Flush: %v", err)
+	}
+	resp, _ = store.LoadRun(ctx, agent.LoadRunRequest{RunID: created.RunID})
+	if len(resp.Run.Events) != 2 {
+		t.Fatalf("re-Flush duplicated events: %d", len(resp.Run.Events))
+	}
+
+	missing := NewPersistingEmit(store, "gone", nil)
+	missing.Emit(agent.Event{Kind: agent.EventTurnBegin})
+	if err := missing.Flush(ctx); err == nil {
+		t.Fatal("Flush against a missing run succeeded, want error")
+	}
+}

--- a/agent/host/render.go
+++ b/agent/host/render.go
@@ -211,3 +211,15 @@ func (r *renderer) taskList(tasks []*client.BackgroundTask) {
 		fmt.Fprintf(r.out, "  %-12s %-20s %-16s %s\n", bt.TaskID, bt.Tool, bt.Status(), time.Since(bt.StartedAt).Round(time.Second))
 	}
 }
+
+func (r *renderer) session(runID string) {
+	if runID == "" {
+		fmt.Fprintf(r.out, "%s\n", r.dim("session: persistence off (no RunStore configured or no turn yet)"))
+		return
+	}
+	fmt.Fprintf(r.out, "%s\n", r.dim("session: "+runID))
+}
+
+func (r *renderer) sessionWarn(err error) {
+	fmt.Fprintf(r.out, "%s\n", r.dim("session: persistence degraded: "+err.Error()))
+}

--- a/cmd/agentchat/go.mod
+++ b/cmd/agentchat/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/panyam/mcpkit v0.4.0-b2
 	github.com/panyam/mcpkit/agent/host v0.0.0
 	github.com/panyam/mcpkit/ext/otel v0.3.1
+	github.com/redis/go-redis/v9 v9.7.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	go.opentelemetry.io/contrib/bridges/otelslog v0.19.0
@@ -18,6 +19,8 @@ require (
 	go.opentelemetry.io/otel/sdk/log v0.20.0
 	go.opentelemetry.io/otel/trace v1.44.0
 )
+
+require github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 
 require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
@@ -39,7 +42,8 @@ require (
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/panyam/gocurrent v0.1.1 // indirect
 	github.com/panyam/goutils v0.1.8 // indirect
-	github.com/panyam/mcpkit/agent v0.0.0 // indirect
+	github.com/panyam/mcpkit/agent v0.0.0
+	github.com/panyam/mcpkit/agent/store/redis v0.0.0
 	github.com/panyam/mcpkit/experimental/ext/events v0.0.0 // indirect
 	github.com/panyam/mcpkit/experimental/ext/events/clients/go v0.0.0 // indirect
 	github.com/panyam/mcpkit/ext/auth v0.0.0 // indirect
@@ -94,3 +98,5 @@ replace github.com/panyam/mcpkit/experimental/ext/events/clients/go => ../../exp
 replace github.com/panyam/mcpkit/ext/tasks => ../../ext/tasks
 
 replace github.com/panyam/mcpkit/agent/host => ../../agent/host
+
+replace github.com/panyam/mcpkit/agent/store/redis => ../../agent/store/redis

--- a/cmd/agentchat/go.sum
+++ b/cmd/agentchat/go.sum
@@ -1,7 +1,13 @@
 github.com/alexedwards/scs/v2 v2.8.0 h1:h31yUYoycPuL0zt14c0gd+oqxfRwIj6SOjHdKRZxhEw=
 github.com/alexedwards/scs/v2 v2.8.0/go.mod h1:ToaROZxyKukJKT/xLcVQAChi5k6+Pn1Gvmdl7h3RRj8=
+github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e2uP9jiw=
+github.com/alicebob/miniredis/v2 v2.38.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
+github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
+github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
+github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
+github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
@@ -11,6 +17,8 @@ github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/fernet/fernet-go v0.0.0-20240119011108-303da6aec611 h1:JwYtKJ/DVEoIA5dH45OEU7uoryZY/gjd/BQiwwAOImM=
@@ -63,6 +71,8 @@ github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/redis/go-redis/v9 v9.7.0 h1:HhLSs+B6O021gwzl+locl0zEDnyNkxMtf/Z3NNBMa9E=
+github.com/redis/go-redis/v9 v9.7.0/go.mod h1:f6zhXITC7JUJIlPEiBOTXxJgPLdZcA93GewI7inzyWw=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -91,6 +101,8 @@ github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/
 github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/contrib/bridges/otelslog v0.19.0 h1:5RgvxieNq9tS3ewrV1vnODvbHPfKUIJcYtF9Cvz+6aQ=

--- a/cmd/agentchat/main.go
+++ b/cmd/agentchat/main.go
@@ -12,11 +12,35 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/redis/go-redis/v9"
+
+	"github.com/panyam/mcpkit/agent"
 	"github.com/panyam/mcpkit/agent/host"
+	redisstore "github.com/panyam/mcpkit/agent/store/redis"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
+
+// buildRunStore maps --session-store to a backend: "" is persistence
+// off, "memory" gives in-process resume/fork (dies with the process),
+// "redis://host:port" gives restart-surviving sessions.
+func buildRunStore(spec string) (agent.RunStore, error) {
+	switch {
+	case spec == "":
+		return nil, nil
+	case spec == "memory":
+		return agent.NewInMemoryRunStore(), nil
+	case strings.HasPrefix(spec, "redis://"):
+		addr := strings.TrimPrefix(spec, "redis://")
+		if addr == "" {
+			return nil, fmt.Errorf("agentchat: --session-store redis:// needs host:port")
+		}
+		return redisstore.New(redis.NewClient(&redis.Options{Addr: addr})), nil
+	default:
+		return nil, fmt.Errorf("agentchat: unknown --session-store %q (want memory or redis://host:port)", spec)
+	}
+}
 
 const version = "0.1.0"
 
@@ -48,6 +72,8 @@ func newRoot() (*cobra.Command, *viper.Viper) {
 	fl.String("api-key-env", "", "env var holding the model API key")
 	fl.String("instructions", "You are a helpful assistant with access to tools.", "system prompt (when no config)")
 	fl.Int("max-steps", 0, "max model calls per turn (0 = default)")
+	fl.String("session-store", "", "session persistence backend: memory | redis://host:port (empty = off)")
+	fl.String("session", "", "session run ID to create or resume at startup (needs --session-store)")
 	fl.String("exporter", "", "telemetry exporter: stdout | otlp | auto (empty = off)")
 	fl.String("otlp-endpoint", "", "OTLP gRPC endpoint (default localhost:4317)")
 	if err := v.BindPFlags(fl); err != nil {
@@ -90,14 +116,33 @@ func runChat(v *viper.Viper) error {
 	}
 	defer logShutdown(context.Background())
 
-	app, err := host.NewApp(cfg, os.Stdout, os.Stdin,
+	appOpts := []host.AppOption{
 		host.WithTracerProvider(tp),
 		host.WithLogger(logger),
-	)
+	}
+	store, err := buildRunStore(v.GetString("session-store"))
+	if err != nil {
+		return err
+	}
+	if store != nil {
+		appOpts = append(appOpts, host.WithRunStore(store))
+	}
+
+	app, err := host.NewApp(cfg, os.Stdout, os.Stdin, appOpts...)
 	if err != nil {
 		return err
 	}
 	defer app.Close()
+
+	if session := v.GetString("session"); session != "" {
+		if store == nil {
+			return fmt.Errorf("agentchat: --session needs --session-store")
+		}
+		if err := app.AttachRun(ctx, session); err != nil {
+			return err
+		}
+		fmt.Printf("agentchat: session %s\n", session)
+	}
 
 	fmt.Printf("agentchat: %d server(s), model %s. /tools /history /quit; Ctrl-C cancels a turn.\n", len(cfg.Servers), cfg.Model.Model)
 


### PR DESCRIPTION
Closes #935. Part of the P1 persistence stack: stacks on PR 956 (Redis backend), which stacks on PR 955 (RunStore interface). **No CI while based on a non-main branch** — verified locally with `make test-agent` (all 8 sub-module runs green).

## What changes

Sessions can now survive process restarts. `host.WithRunStore(store)` opts the App into persistence: every completed turn's messages append to a run at the existing history-append site, and the turn's event stream tees into the run's event log via the new `PersistingEmit` helper. `App.AttachRun` (create-or-resume), `App.Resume` (must exist), and `App.Fork` switch runs; the REPL grows `/session`, `/resume <id>`, `/fork [id]`. `cmd/agentchat` adds the terminal-specific knobs: `--session-store memory|redis://host:port` and `--session <id>`.

## Reviewer's guide

Read in this order:
1. [agent/host/persistence.go](https://github.com/panyam/mcpkit/pull/957/files#diff-0eff5e5041fb67bd84e50d022d2c12f889b3a75f62e014198f357bb4b36d78ce) — the new surface: `WithRunStore`, `AttachRun`/`Resume`/`Fork`, `ensureRunLocked` (lazy run creation), `persistTurnLocked` (warn-don't-fail semantics), `PersistingEmit`.
2. [agent/host/app.go](https://github.com/panyam/mcpkit/pull/957/files#diff-89fb8e04b6e1e9d5f7f76958490ef158dee40e2cae92d87c04b408d893c84361) — the wiring: two new App fields, the RunTurn delta (persist after success, nothing on failure), and the three REPL commands.
3. [agent/host/persistence_test.go](https://github.com/panyam/mcpkit/pull/957/files#diff-38b000bcaced1f93c8c897e0f6da51ec212ebccb119ad11b63750f2bb94431e6) — acceptance: persisted-turn shape, resume threading history into the next model request, fork divergence, failed-turn-persists-nothing, no-store error paths, PersistingEmit unit tests.
4. [cmd/agentchat/main.go](https://github.com/panyam/mcpkit/pull/957/files#diff-ce3956549c93b4983f18090136a2139c3c92d38408e923245f5e9ba628bcc98a) — `buildRunStore` flag mapping and startup `AttachRun`.
5. [agent/host/render.go](https://github.com/panyam/mcpkit/pull/957/files#diff-da3546e85434193f7b8b2df15f4f6d6df496b616b9e0b0b8c4299cd4576e044a), [agent/host/README.md](https://github.com/panyam/mcpkit/pull/957/files#diff-4153913af46cb4575aee6ce1d40794e2089a248e74666353ba408cd20d677254) — cosmetic: session render lines, docs.

Skim or skip: [cmd/agentchat/go.mod](https://github.com/panyam/mcpkit/pull/957/files#diff-381fb1fac52fdbe31f9784e2443c827670debb660fdab2fb056f41d478492c49) / `go.sum` (adds the `agent/store/redis` + go-redis deps).

## How it works

```
RunTurn(ctx, input):
  history += user message
  if store configured:
      ensure run exists (lazy CreateRun on first turn; renders "session: run-x")
      emit = PersistingEmit(store, runID, renderer.handle)   # buffers + forwards
  result, err = runner.Run(ctx, history, emit)
  if err: roll back history, persist NOTHING (store log stays at pre-turn state)
  history += result.Messages
  AppendMessages(user message + result.Messages)   # per-turn durability grain
  PersistingEmit.Flush                             # one AppendEvents per turn
  persistence errors -> rendered warning, turn still succeeds

Resume  = LoadRun -> history replaced -> next turns append to that run
Fork    = ForkRun (store copies the log) -> switch runID; in-memory history
          is already the shared prefix, so divergence is free
```

## Decision log

- **Persistence wraps `Run`, never enters the Runner** — the roadmap invariant. The Runner stays stateless over history; the host owns the append site, so it owns the persist site.
- **Buffer events, flush once per turn** instead of one store round-trip per text delta: matches the per-turn durability grain; a mid-turn crash loses that turn's events exactly like it loses its messages.
- **Persistence failures warn instead of failing the turn**: the turn already succeeded and rendered; only durability degraded. Failing would throw away a good answer because Redis blinked.
- **`AttachRun` (create-or-resume) and `Resume` (must-exist) are separate methods**: a typo in `/resume` must not silently start an empty session; a surface's startup path wants idempotent naming.
- **`--session-store`/`--session` construct the backend in `cmd/agentchat`, not in host config**: a RunStore is a Go value, not config data; the surface picks the backend (a web-chat would inject its own), keeping `agent/host` free of the go-redis dependency.

## Risk / blast radius

- Affects: `agent/host` (App gains two fields + REPL commands; RunTurn path changes only when a store is configured — nil store is byte-for-byte the old behavior), `cmd/agentchat` (new flags, new deps).
- Tests covering this: 9 new tests in `persistence_test.go`; existing host suite (transcript, history-threading, approval, events) unchanged and green — 0 assertions removed or weakened, ~60 added.
- Be paranoid about: the failed-turn rollback interplay (history rollback existed; the new invariant is the store log also stays clean — `TestAppFailedTurnPersistsNothing`), and lock discipline (`RunID` takes turnMu; everything else is `*Locked` or takes it once).

## Before / after

```
$ agentchat --config chat.json --session-store redis://localhost:6379 --session standup
agentchat: session standup
> what did we decide yesterday?          # history loaded from Redis, model sees it
> /fork experiment                       # session: experiment — original untouched
> /session                               # session: experiment
```
Before this PR, every agentchat process started from an empty history and `/resume`, `/fork`, `/session`, `--session-store`, `--session` did not exist.

## Out of scope (deliberately deferred)

- Mid-turn resume (replaying the event log into a partial turn) — needs tool-call idempotency, roadmap §D
- Run listing/browsing (`/sessions` needs a `ListRuns` store method) — will file when a surface asks for it
- Config-file (as opposed to flag) session settings in agentchat
