### PR TITLE
feat(agent): per-tool-call cancellation via TurnRequest Control channel

### DIFF
--- a/agent/runner.go
+++ b/agent/runner.go
@@ -117,15 +117,33 @@ type TurnResult struct {
 	Structured core.RawJSON `json:"structured,omitempty"`
 }
 
-// Control steers a turn while it runs. Surfaces send Controls on
-// TurnRequest.Control; today the only steering is per-call cancellation
-// (the coding-agent "Esc cancels the call, not the session" behavior).
+// Control is the turn's steering envelope: surfaces send Controls on
+// TurnRequest.Control to steer a turn while it runs. Cancellation is the
+// first (currently only) verb, in two modes:
+//
+//   - Control{} — cancel ALL calls currently in flight, one send. The
+//     naive-Esc path: a surface needs no bookkeeping, three in-flight
+//     calls die from a single Control.
+//   - Control{CallID: id} — cancel exactly one call, identified by the
+//     ToolCall.ID the surface saw on that call's tool-begin event. For
+//     richer surfaces (a TUI with a row per running call).
+//
+// Either way the decision stays with the sender: surfaces already hold
+// the call inventory via tool-begin/tool-end events, and constraint A4
+// keeps decision callbacks out of the loop.
+//
+// Future steering verbs (pause, budget bumps, mid-turn priority hints)
+// extend this struct additively — a Kind discriminator plus verb fields,
+// with the zero Kind meaning cancel for compatibility — rather than new
+// channels or a handler registry. Mid-turn *content* (a "/btw" note for
+// the model) is deliberately not a Control: anything the model should
+// see routes through the injection path so it enters history as a
+// message, not a side effect.
 type Control struct {
-	// CallID names the in-flight tool call to cancel — the ToolCall.ID
-	// surfaces saw on that call's tool-begin event. Empty cancels every
-	// call currently in flight. An ID that is not in flight (already
-	// finished, or never dispatched) is a no-op, so racing a call's
-	// natural completion is safe.
+	// CallID names the in-flight tool call to cancel; empty cancels
+	// every call currently in flight. An ID that is not in flight
+	// (already finished, or never dispatched) is a no-op, so racing a
+	// call's natural completion is safe.
 	CallID string
 }
 

--- a/agent/runner.go
+++ b/agent/runner.go
@@ -117,15 +117,78 @@ type TurnResult struct {
 	Structured core.RawJSON `json:"structured,omitempty"`
 }
 
+// Control steers a turn while it runs. Surfaces send Controls on
+// TurnRequest.Control; today the only steering is per-call cancellation
+// (the coding-agent "Esc cancels the call, not the session" behavior).
+type Control struct {
+	// CallID names the in-flight tool call to cancel — the ToolCall.ID
+	// surfaces saw on that call's tool-begin event. Empty cancels every
+	// call currently in flight. An ID that is not in flight (already
+	// finished, or never dispatched) is a no-op, so racing a call's
+	// natural completion is safe.
+	CallID string
+}
+
+// TurnRequest consolidates RunTurn's inputs so the turn surface can grow
+// without breaking signatures (the same C2 shape RunnerConfig uses).
+type TurnRequest struct {
+	// History is the conversation so far; RunTurn clones it and returns
+	// only appended messages, exactly like Run.
+	History []Message
+
+	// Emit receives the turn's event stream. Nil is allowed; emit is
+	// never called concurrently.
+	Emit func(Event)
+
+	// Control, when non-nil, is drained for the whole turn. A Control
+	// cancels the targeted call's own context: the call fails fast
+	// (ClientSource.Call threads ctx to the wire, so MCP servers see a
+	// real cancellation), its result is fed back to the model as
+	// "cancelled by user", and the turn continues — unlike cancelling
+	// RunTurn's ctx, which aborts the whole turn. Send only while a
+	// turn is running: between turns nothing drains the channel, and a
+	// buffered cancel-all would hit the next turn's first dispatch.
+	Control <-chan Control
+}
+
 // Run executes one turn against history. Events stream to emit (nil is
 // allowed); emit is never called concurrently. Tool failures of every kind
 // (unknown tool, transport, bad args) are fed back to the model as
 // error-marked tool results and the loop continues; only ctx cancellation,
 // provider failure, or the step cap abort the turn. The returned error wraps
-// ErrMaxSteps when the cap was hit.
+// ErrMaxSteps when the cap was hit. Run is shorthand for RunTurn without
+// mid-turn controls.
 func (r *Runner) Run(ctx context.Context, history []Message, emit func(Event)) (*TurnResult, error) {
+	return r.RunTurn(ctx, TurnRequest{History: history, Emit: emit})
+}
+
+// RunTurn executes one turn with the full request surface: Run's
+// contract plus mid-turn Controls (per-call cancellation). See
+// TurnRequest for the semantics of each field.
+func (r *Runner) RunTurn(ctx context.Context, req TurnRequest) (*TurnResult, error) {
+	history, emit := req.History, req.Emit
 	if emit == nil {
 		emit = func(Event) {}
+	}
+
+	var reg *callCancels
+	if req.Control != nil {
+		reg = &callCancels{cancels: map[string]context.CancelFunc{}}
+		stop := make(chan struct{})
+		defer close(stop)
+		go func() {
+			for {
+				select {
+				case c, ok := <-req.Control:
+					if !ok {
+						return
+					}
+					reg.cancel(c.CallID)
+				case <-stop:
+					return
+				}
+			}
+		}()
 	}
 	ctx, turnSpan := r.cfg.TracerProvider.StartSpan(ctx, "agent.turn")
 	defer turnSpan.End()
@@ -209,7 +272,7 @@ func (r *Runner) Run(ctx context.Context, history []Message, emit func(Event)) (
 			return result, nil
 		}
 
-		toolMsgs := r.dispatch(stepCtx, step, resp.ToolCalls, tools, emit)
+		toolMsgs := r.dispatch(stepCtx, step, resp.ToolCalls, tools, emit, reg)
 		stepSpan.End()
 		if err := ctx.Err(); err != nil {
 			return nil, r.failSpan(emit, turnSpan, err)
@@ -302,10 +365,48 @@ func (r *Runner) finalizeStructured(ctx context.Context, msgs []Message, usage *
 	return core.NewRawJSON(json.RawMessage(last)), nil
 }
 
+// callCancels tracks the in-flight tool calls of one turn so the
+// control listener can cancel a specific call's context. Entries live
+// from just before a call's tool-begin to just after it returns.
+type callCancels struct {
+	mu      sync.Mutex
+	cancels map[string]context.CancelFunc
+}
+
+func (g *callCancels) add(id string, cancel context.CancelFunc) {
+	g.mu.Lock()
+	g.cancels[id] = cancel
+	g.mu.Unlock()
+}
+
+func (g *callCancels) remove(id string) {
+	g.mu.Lock()
+	delete(g.cancels, id)
+	g.mu.Unlock()
+}
+
+// cancel fires the named call's cancel func, or every in-flight one when
+// id is empty. Unknown ids are a no-op.
+func (g *callCancels) cancel(id string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if id == "" {
+		for _, c := range g.cancels {
+			c()
+		}
+		return
+	}
+	if c, ok := g.cancels[id]; ok {
+		c()
+	}
+}
+
 // dispatch runs the step's tool calls concurrently, serializes event
 // emission, and returns RoleTool messages in call order regardless of
-// completion order.
-func (r *Runner) dispatch(ctx context.Context, step int, calls []ToolCall, tools []core.ToolDef, emit func(Event)) []Message {
+// completion order. When reg is non-nil each call runs under its own
+// child context registered by call ID, so a Control can cancel one call
+// without touching its siblings or the turn.
+func (r *Runner) dispatch(ctx context.Context, step int, calls []ToolCall, tools []core.ToolDef, emit func(Event), reg *callCancels) []Message {
 	results := make([]Message, len(calls))
 	var emitMu sync.Mutex
 	locked := func(ev Event) {
@@ -319,10 +420,20 @@ func (r *Runner) dispatch(ctx context.Context, step int, calls []ToolCall, tools
 		wg.Add(1)
 		go func(i int, call ToolCall) {
 			defer wg.Done()
-			toolCtx, toolSpan := r.cfg.TracerProvider.StartSpan(ctx, "agent.tool",
+			callCtx := ctx
+			if reg != nil {
+				var cancel context.CancelFunc
+				callCtx, cancel = context.WithCancel(ctx)
+				reg.add(call.ID, cancel)
+				defer func() {
+					reg.remove(call.ID)
+					cancel()
+				}()
+			}
+			toolCtx, toolSpan := r.cfg.TracerProvider.StartSpan(callCtx, "agent.tool",
 				core.Attribute{Key: "agent.tool.name", Value: call.Name})
 			locked(Event{Kind: EventToolBegin, Step: step, ToolCall: &call})
-			text := r.callTool(toolCtx, step, call, tools, locked, toolSpan)
+			text := r.callTool(toolCtx, ctx, step, call, tools, locked, toolSpan)
 			toolSpan.End()
 			results[i] = Message{Role: RoleTool, ToolCallID: call.ID, Text: text}
 		}(i, call)
@@ -348,8 +459,26 @@ func toolReadOnly(tools []core.ToolDef, name string) bool {
 
 // callTool executes one call and renders the text fed back to the model.
 // Every failure shape becomes model-visible text rather than a turn abort.
-func (r *Runner) callTool(ctx context.Context, step int, call ToolCall, tools []core.ToolDef, emit func(Event), span core.Span) string {
+// ctx is the call's own (possibly Control-cancellable) context; parent is
+// the step's. The two diverging — ctx cancelled while parent is live —
+// identifies a per-call cancellation, which feeds back as "cancelled by
+// user" so the model knows the user, not the tool, stopped the call.
+func (r *Runner) callTool(ctx context.Context, parent context.Context, step int, call ToolCall, tools []core.ToolDef, emit func(Event), span core.Span) string {
+	// cancelled identifies a per-call cancellation: this call's ctx is
+	// done while the step's is live. Checked on every outcome shape —
+	// a transport surfaces a cancelled call as an error, an in-process
+	// source as an IsError result, and a tool racing the cancel may
+	// even return success; the user's cancel wins over all three.
+	cancelled := func() bool { return ctx.Err() != nil && parent.Err() == nil }
+	cancelledText := func() string {
+		span.SetAttribute("agent.tool.cancelled", "true")
+		emit(Event{Kind: EventToolError, Step: step, ToolCall: &call, Error: "cancelled by user"})
+		return "cancelled by user"
+	}
 	failed := func(err error) string {
+		if cancelled() {
+			return cancelledText()
+		}
 		span.RecordError(err)
 		emit(Event{Kind: EventToolError, Step: step, ToolCall: &call, Error: err.Error()})
 		return fmt.Sprintf("tool call failed: %v", err)
@@ -388,6 +517,9 @@ func (r *Runner) callTool(ctx context.Context, step int, call ToolCall, tools []
 	res, err := r.cfg.Tools.Call(ctx, call.Name, args)
 	if err != nil {
 		return failed(err)
+	}
+	if cancelled() {
+		return cancelledText()
 	}
 	span.SetAttribute("agent.tool.is_error", fmt.Sprint(res.IsError))
 	emit(Event{Kind: EventToolEnd, Step: step, ToolCall: &call, ToolResult: res})

--- a/agent/runner_cancel_test.go
+++ b/agent/runner_cancel_test.go
@@ -1,0 +1,173 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// cancelHarness wires a runner over a blocking "slow" tool and an
+// immediate "fast" tool, so tests can steer per-call cancellation
+// deterministically: slow only returns when its ctx is cancelled.
+func cancelHarness(t *testing.T, turns ...StubTurn) (*Runner, *FuncSource) {
+	t.Helper()
+	src := NewFuncSource()
+	if err := AddFunc(src, "slow", "blocks until cancelled", func(ctx context.Context, in struct{}) (string, error) {
+		<-ctx.Done()
+		return "", ctx.Err()
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddFunc(src, "fast", "returns immediately", func(ctx context.Context, in struct{}) (string, error) {
+		return "fast done", nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	r, err := NewRunner(RunnerConfig{Provider: NewStubProvider(turns...), Tools: src})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return r, src
+}
+
+func toolMessage(t *testing.T, msgs []Message, callID string) Message {
+	t.Helper()
+	for _, m := range msgs {
+		if m.Role == RoleTool && m.ToolCallID == callID {
+			return m
+		}
+	}
+	t.Fatalf("no RoleTool message for call %q in %+v", callID, msgs)
+	return Message{}
+}
+
+func TestRunTurnControlCancelsOneCallTurnContinues(t *testing.T) {
+	r, _ := cancelHarness(t,
+		StubTurn{ToolCalls: []ToolCall{{ID: "c1", Name: "slow"}, {ID: "c2", Name: "fast"}}},
+		StubTurn{Text: "wrapped up"},
+	)
+
+	control := make(chan Control, 1)
+	emit := func(e Event) {
+		if e.Kind == EventToolBegin && e.ToolCall.ID == "c1" {
+			control <- Control{CallID: "c1"}
+		}
+	}
+	res, err := r.RunTurn(context.Background(), TurnRequest{
+		History: []Message{{Role: RoleUser, Text: "go"}},
+		Emit:    emit,
+		Control: control,
+	})
+	if err != nil {
+		t.Fatalf("RunTurn: %v (a per-call cancel must not abort the turn)", err)
+	}
+	if res.Text != "wrapped up" || res.Steps != 2 {
+		t.Fatalf("turn did not continue past the cancel: %+v", res)
+	}
+	if got := toolMessage(t, res.Messages, "c1").Text; got != "cancelled by user" {
+		t.Fatalf("cancelled call fed back %q, want \"cancelled by user\"", got)
+	}
+	if got := toolMessage(t, res.Messages, "c2").Text; got != "fast done" {
+		t.Fatalf("sibling call was disturbed: %q", got)
+	}
+}
+
+func TestRunTurnControlEmptyIDCancelsAllInFlight(t *testing.T) {
+	r, _ := cancelHarness(t,
+		StubTurn{ToolCalls: []ToolCall{{ID: "c1", Name: "slow"}, {ID: "c2", Name: "slow"}}},
+		StubTurn{Text: "after cancel-all"},
+	)
+
+	control := make(chan Control, 1)
+	begins := 0
+	emit := func(e Event) {
+		if e.Kind == EventToolBegin {
+			begins++
+			if begins == 2 {
+				control <- Control{}
+			}
+		}
+	}
+	res, err := r.RunTurn(context.Background(), TurnRequest{
+		History: []Message{{Role: RoleUser, Text: "go"}},
+		Emit:    emit,
+		Control: control,
+	})
+	if err != nil {
+		t.Fatalf("RunTurn: %v", err)
+	}
+	for _, id := range []string{"c1", "c2"} {
+		if got := toolMessage(t, res.Messages, id).Text; got != "cancelled by user" {
+			t.Fatalf("call %s fed back %q, want \"cancelled by user\"", id, got)
+		}
+	}
+	if res.Text != "after cancel-all" {
+		t.Fatalf("turn did not continue: %+v", res)
+	}
+}
+
+func TestRunTurnControlUnknownCallIDIsNoOp(t *testing.T) {
+	r, _ := cancelHarness(t,
+		StubTurn{ToolCalls: []ToolCall{{ID: "c1", Name: "fast"}}},
+		StubTurn{Text: "fine"},
+	)
+
+	control := make(chan Control, 1)
+	emit := func(e Event) {
+		if e.Kind == EventToolBegin {
+			control <- Control{CallID: "never-dispatched"}
+		}
+	}
+	res, err := r.RunTurn(context.Background(), TurnRequest{
+		History: []Message{{Role: RoleUser, Text: "go"}},
+		Emit:    emit,
+		Control: control,
+	})
+	if err != nil {
+		t.Fatalf("RunTurn: %v", err)
+	}
+	if got := toolMessage(t, res.Messages, "c1").Text; got != "fast done" {
+		t.Fatalf("stray Control disturbed an unrelated call: %q", got)
+	}
+}
+
+// TestRunTurnCtxCancelStillAbortsTurn pins the coarse-grained behavior:
+// cancelling RunTurn's own ctx aborts the whole turn (per-call Controls
+// are the only continue-after-cancel path).
+func TestRunTurnCtxCancelStillAbortsTurn(t *testing.T) {
+	r, _ := cancelHarness(t,
+		StubTurn{ToolCalls: []ToolCall{{ID: "c1", Name: "slow"}}},
+		StubTurn{Text: "unreachable"},
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	emit := func(e Event) {
+		if e.Kind == EventToolBegin {
+			cancel()
+		}
+	}
+	_, err := r.RunTurn(ctx, TurnRequest{
+		History: []Message{{Role: RoleUser, Text: "go"}},
+		Emit:    emit,
+		Control: make(chan Control),
+	})
+	if err == nil {
+		t.Fatal("RunTurn survived its own ctx being cancelled")
+	}
+	if !strings.Contains(err.Error(), "context canceled") {
+		t.Fatalf("unexpected abort error: %v", err)
+	}
+}
+
+// TestRunDelegatesToRunTurn pins that the legacy signature is a pure
+// shim: same result shape, no Control plumbing required.
+func TestRunDelegatesToRunTurn(t *testing.T) {
+	r, _ := cancelHarness(t, StubTurn{Text: "plain"})
+	res, err := r.Run(context.Background(), []Message{{Role: RoleUser, Text: "hi"}}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Text != "plain" || len(res.Messages) != 1 {
+		t.Fatalf("Run via RunTurn returned %+v", res)
+	}
+}


### PR DESCRIPTION
Closes #936. Part of the P1 stack: stacks on PR 957 (host persistence) for sequential review, though it is logically independent of the RunStore work; `p1/937-tool-cancelled-event` stacks on this. **No CI while based on a non-main branch** — verified locally with `make test-agent` (all 8 sub-module runs green) plus `go test -race` on the new paths.

## What changes

Interrupt granularity moves from whole-turn to per-tool-call — the coding-agent "Esc cancels the call, not the session" behavior. New `Runner.RunTurn(ctx, TurnRequest)` carries a `Control <-chan Control`; sending `Control{CallID: "c1"}` cancels exactly that in-flight call (empty CallID cancels all in flight). The cancelled call feeds `"cancelled by user"` back to the model as its `RoleTool` result and **the turn continues**. Cancelling RunTurn's own ctx still aborts the whole turn, unchanged. The existing `Run` signature delegates to `RunTurn`, so nothing breaks.

## Reviewer's guide

Read in this order:
1. [agent/runner.go](https://github.com/panyam/mcpkit/pull/958/files#diff-6d787b427ac08cd61669af7e34ff0b747c4264d20b31b21b681a2ec2c826d9f0) — top: `Control` + `TurnRequest` types and the `Run` → `RunTurn` delegation with the turn-scoped control listener. Middle: `callCancels` registry + the `dispatch` delta (per-call child ctx, registered before tool-begin). Bottom: `callTool`'s `cancelled()` / `cancelledText()` — the subtlest part, see below.
2. [agent/runner_cancel_test.go](https://github.com/panyam/mcpkit/pull/958/files#diff-2cee355ea5e9499aef146c71d705967c292fc6b8590ddeebe7aacf7cdb840941) — acceptance: cancel-one-continue, cancel-all, unknown-ID no-op, whole-turn ctx abort preserved, Run-as-shim.

## How it works

```
RunTurn:
  if Control != nil: spawn one turn-scoped listener goroutine
      (drains Control until turn end; Control{id} -> registry.cancel(id))
  loop unchanged; dispatch gets the registry

dispatch (per call goroutine):
  child ctx = WithCancel(step ctx); registry.add(call.ID, cancel)  # BEFORE tool-begin emits
  run callTool under child ctx; registry.remove on return

callTool:
  cancelled() = child ctx done AND step ctx live     # distinguishes per-call cancel from turn abort
  checked on EVERY outcome shape:
    - Tools.Call error        (transports surface cancellation as error)
    - IsError tool result     (in-process FuncSource wraps handler errors)
    - success                 (tool raced the cancel and won; user intent still wins)
  -> feeds "cancelled by user" as the RoleTool text, turn continues
```

## Decision log

- **Consolidated `TurnRequest` instead of a new `Run` parameter**: C2 shape; the turn surface can grow (deadlines, budgets) without another signature break. `Run` stays as a pure shim.
- **Turn-scoped listener, not per-dispatch**: Controls sent while the model is streaming (no calls in flight) are drained and dropped instead of sitting buffered and killing the *next* step's first call. The remaining footgun (sending between turns) is documented on `TurnRequest.Control`.
- **Registry entries added before the call's `tool-begin` emits**: a surface reacting to tool-begin with an immediate cancel can never race an unregistered call.
- **Cancellation checked on all three outcome shapes** — this was caught red-by-test: `FuncSource` converts a handler's `ctx.Err()` into an `IsError` result, not a `Call` error, so an error-path-only check silently missed in-process tools.
- **User cancel wins over a raced success**: predictable Esc semantics; the alternative (deliver the result if it beat the cancel by a nanosecond) makes cancellation outcome-dependent.
- **Real MCP-level cancellation comes free**: the child ctx threads through `ClientSource.Call`'s existing ctx-to-wire path, so remote servers see the cancellation.

## Risk / blast radius

- Affects: `agent/runner.go` only. Zero-overhead when `Control` is nil (no child ctx, no goroutine) — the `Run` path is behaviorally identical, pinned by the whole pre-existing runner suite passing untouched (0 assertions removed or weakened).
- Tests covering this: 5 new tests, run under `-race -count=3` as well.
- Be paranoid about: the `cancelled()` predicate (`ctx.Err() != nil && parent.Err() == nil`) — if the turn ctx dies mid-call, `parent.Err() != nil` routes to the normal abort path, which `TestRunTurnCtxCancelStillAbortsTurn` pins; and listener lifetime (`defer close(stop)` before the loop can leak sends? No — senders use buffered channels; the listener just stops draining at turn end, which is the documented contract).

## Out of scope (deliberately deferred)

- Distinct `tool-cancelled` event kind → #937 (next PR in the stack; this PR emits `tool-error` with `"cancelled by user"`)
- Surface wiring (agentchat Esc handling) — follows once #937 gives surfaces a distinct event to render
- Other Control verbs (pause, budget) — TurnRequest is the extension point
