### PR TITLE
feat(agent): tool-cancelled event kind

### DIFF
--- a/agent/events.go
+++ b/agent/events.go
@@ -12,7 +12,7 @@ type EventKind string
 // Event kinds, in the order a typical turn emits them. Thinking markers wrap
 // contiguous reasoning deltas within one step; tool events may interleave
 // across parallel calls of the same step, but tool-begin always precedes its
-// call's tool-end, tool-error, or tool-denied.
+// call's tool-end, tool-error, tool-denied, or tool-cancelled.
 const (
 	EventTurnBegin     EventKind = "turn-begin"
 	EventThinkingBegin EventKind = "thinking-begin"
@@ -23,6 +23,12 @@ const (
 	EventToolEnd       EventKind = "tool-end"
 	EventToolError     EventKind = "tool-error"
 	EventToolDenied    EventKind = "tool-denied"
+	// EventToolCancelled marks a call the user cancelled mid-flight via
+	// a TurnRequest Control. Distinct from tool-error (the tool did not
+	// fail; the user stopped it) so surfaces can render an interrupt
+	// differently from a failure. Reason carries the model-visible
+	// feedback text.
+	EventToolCancelled EventKind = "tool-cancelled"
 	EventTurnEnd       EventKind = "turn-end"
 	EventError         EventKind = "error"
 )
@@ -55,10 +61,11 @@ type Event struct {
 	// not an error value, so the event crosses wires unchanged.
 	Error string `json:"error,omitempty"`
 
-	// Reason is the human-readable justification on tool-denied: why the
-	// approval policy refused the call. Distinct from Error because a
-	// denial is a policy outcome, not a dispatch failure; the call never
-	// ran, so there is no ToolResult.
+	// Reason is the human-readable justification on tool-denied (why the
+	// approval policy refused the call) and tool-cancelled (the user
+	// stopped the call). Distinct from Error because both are outcomes
+	// of someone's decision, not dispatch failures; neither carries a
+	// ToolResult.
 	Reason string `json:"reason,omitempty"`
 
 	// Result is the completed turn on turn-end.

--- a/agent/host/render.go
+++ b/agent/host/render.go
@@ -62,6 +62,8 @@ func (r *renderer) handle(e agent.Event) {
 		fmt.Fprintf(r.out, "%s\n", r.dim("  ✗ "+e.ToolCall.Name+" failed: "+snippet(e.Error, 120)))
 	case agent.EventToolDenied:
 		fmt.Fprintf(r.out, "%s\n", r.dim("  ⃠ "+e.ToolCall.Name+" not permitted: "+snippet(e.Reason, 120)))
+	case agent.EventToolCancelled:
+		fmt.Fprintf(r.out, "%s\n", r.dim("  ◼ "+e.ToolCall.Name+" cancelled: "+snippet(e.Reason, 120)))
 	case agent.EventError:
 		r.breakLine()
 	}

--- a/agent/host/render_test.go
+++ b/agent/host/render_test.go
@@ -1,0 +1,28 @@
+package host
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/panyam/mcpkit/agent"
+)
+
+// TestRendererToolCancelledDistinctFromError pins that a user cancel
+// renders as an interrupt, not a failure.
+func TestRendererToolCancelledDistinctFromError(t *testing.T) {
+	var out strings.Builder
+	r := newRenderer(&out)
+	r.handle(agent.Event{
+		Kind:     agent.EventToolCancelled,
+		Step:     1,
+		ToolCall: &agent.ToolCall{ID: "c1", Name: "slow"},
+		Reason:   "cancelled by user",
+	})
+	got := out.String()
+	if !strings.Contains(got, "slow cancelled: cancelled by user") {
+		t.Fatalf("tool-cancelled render = %q", got)
+	}
+	if strings.Contains(got, "failed") {
+		t.Fatalf("tool-cancelled rendered as a failure: %q", got)
+	}
+}

--- a/agent/runner.go
+++ b/agent/runner.go
@@ -472,7 +472,7 @@ func (r *Runner) callTool(ctx context.Context, parent context.Context, step int,
 	cancelled := func() bool { return ctx.Err() != nil && parent.Err() == nil }
 	cancelledText := func() string {
 		span.SetAttribute("agent.tool.cancelled", "true")
-		emit(Event{Kind: EventToolError, Step: step, ToolCall: &call, Error: "cancelled by user"})
+		emit(Event{Kind: EventToolCancelled, Step: step, ToolCall: &call, Reason: "cancelled by user"})
 		return "cancelled by user"
 	}
 	failed := func(err error) string {

--- a/agent/runner_cancel_test.go
+++ b/agent/runner_cancel_test.go
@@ -48,7 +48,9 @@ func TestRunTurnControlCancelsOneCallTurnContinues(t *testing.T) {
 	)
 
 	control := make(chan Control, 1)
+	var events []Event
 	emit := func(e Event) {
+		events = append(events, e)
 		if e.Kind == EventToolBegin && e.ToolCall.ID == "c1" {
 			control <- Control{CallID: "c1"}
 		}
@@ -69,6 +71,25 @@ func TestRunTurnControlCancelsOneCallTurnContinues(t *testing.T) {
 	}
 	if got := toolMessage(t, res.Messages, "c2").Text; got != "fast done" {
 		t.Fatalf("sibling call was disturbed: %q", got)
+	}
+
+	cancelledEvents, errorEvents := 0, 0
+	for _, e := range events {
+		if e.ToolCall == nil || e.ToolCall.ID != "c1" {
+			continue
+		}
+		switch e.Kind {
+		case EventToolCancelled:
+			cancelledEvents++
+			if e.Reason != "cancelled by user" {
+				t.Fatalf("tool-cancelled Reason = %q", e.Reason)
+			}
+		case EventToolError, EventToolEnd:
+			errorEvents++
+		}
+	}
+	if cancelledEvents != 1 || errorEvents != 0 {
+		t.Fatalf("cancelled call emitted %d tool-cancelled and %d tool-error/tool-end events, want 1 and 0", cancelledEvents, errorEvents)
 	}
 }
 

--- a/agent/runner_test.go
+++ b/agent/runner_test.go
@@ -325,6 +325,7 @@ func TestRunnerEventKindsJSONRoundTrip(t *testing.T) {
 		{Kind: EventToolEnd, Step: 1, ToolCall: &ToolCall{ID: "c", Name: "n", Args: core.NewRawJSON(json.RawMessage(`{}`))}, ToolResult: &core.ToolResult{Content: []core.Content{{Type: "text", Text: "ok"}}}},
 		{Kind: EventToolError, Step: 1, ToolCall: &ToolCall{ID: "c", Name: "n", Args: core.NewRawJSON(json.RawMessage(`{}`))}, Error: "boom"},
 		{Kind: EventToolDenied, Step: 1, ToolCall: &ToolCall{ID: "c", Name: "n", Args: core.NewRawJSON(json.RawMessage(`{}`))}, Reason: "declined by user"},
+		{Kind: EventToolCancelled, Step: 1, ToolCall: &ToolCall{ID: "c", Name: "n", Args: core.NewRawJSON(json.RawMessage(`{}`))}, Reason: "cancelled by user"},
 		{Kind: EventTurnEnd, Result: &TurnResult{Text: "done", Steps: 1, Usage: Usage{InputTokens: 1, OutputTokens: 2}}},
 		{Kind: EventError, Error: "fatal"},
 	}


### PR DESCRIPTION
Closes #937. Top of the P1 stack: stacks on PR 958 (per-tool-call cancellation). **No CI while based on a non-main branch** — verified locally with `make test-agent` (all 8 sub-module runs green) plus `-race` on the touched paths.

## What changes

A per-call cancellation now emits its own event kind, `tool-cancelled`, instead of overloading `tool-error`. Surfaces can render a user interrupt distinctly from a tool failure; the host renderer shows `◼ <tool> cancelled: cancelled by user` where a failure shows `✗ <tool> failed: ...`.

## Reviewer's guide

Read in this order:
1. [agent/events.go](https://github.com/panyam/mcpkit/pull/959/files#diff-decf072b43cd6fba38445f5ab18d681fd6e933ca6b9e6bdf51d6bd95ac2977b7) — the new `EventToolCancelled` constant and the `Reason` field doc now covering both decision-outcome kinds (denied, cancelled).
2. [agent/runner.go](https://github.com/panyam/mcpkit/pull/959/files#diff-6d787b427ac08cd61669af7e34ff0b747c4264d20b31b21b681a2ec2c826d9f0) — one-line emit swap in `cancelledText` (tool-error/Error → tool-cancelled/Reason).
3. [agent/runner_test.go](https://github.com/panyam/mcpkit/pull/959/files#diff-ffe83771b6f02efdc6a2e9656bb6e78ecd3a3d187223e173d416979cb429ec34) — the A2 wire round-trip test gains the new kind (constraint A2: every kind must survive encoding/json).
4. [agent/runner_cancel_test.go](https://github.com/panyam/mcpkit/pull/959/files#diff-2cee355ea5e9499aef146c71d705967c292fc6b8590ddeebe7aacf7cdb840941) — the cancel-one test now also asserts exactly one `tool-cancelled` and zero `tool-error`/`tool-end` events for the cancelled call.
5. [agent/host/render.go](https://github.com/panyam/mcpkit/pull/959/files#diff-da3546e85434193f7b8b2df15f4f6d6df496b616b9e0b0b8c4299cd4576e044a) + [agent/host/render_test.go](https://github.com/panyam/mcpkit/pull/959/files#diff-50fa3906597449e69d5cae6454e95743166803ffdfa51912d65a494662c11239) — the renderer case and its pin.

## Decision log

- **Payload rides `Reason`, not `Error`**: a cancellation is the outcome of the user's decision, not a dispatch failure — the same distinction `tool-denied` already draws, and the reason `eval.NoError`-style scorers that key on error events won't miscount interrupts as failures.
- **Split from PR 958 rather than folded in**: the event vocabulary is the surfaces contract (A2); keeping the taxonomy change reviewable on its own means the cancellation mechanics PR stays behavior-only.

## Risk / blast radius

- Affects: event consumers. Purely additive kind — existing kinds and payloads unchanged; a wire consumer that switches on kind sees a new value only when a surface actually uses `TurnRequest.Control`. Assertions: ~10 added, 0 removed or weakened.
- Tests covering this: A2 round-trip, strengthened cancel test, renderer pin.

## Before / after

Transcript for the same cancelled call:
```
before:   ✗ slow failed: cancelled by user        # tool-error, indistinguishable from a crash
after:    ◼ slow cancelled: cancelled by user     # tool-cancelled, distinct render
```

## Out of scope (deliberately deferred)

- Surface wiring for sending Controls (agentchat Esc handling) — follow-up once a keybinding design exists
- An `eval` scorer for cancelled calls (mirroring `NotDenied`) — will file if eval suites start exercising Controls
