### PR TITLE
feat(agent): Message.Timestamp, stamped at the RunStore boundary

### DIFF
--- a/agent/provider.go
+++ b/agent/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"strings"
+	"time"
 
 	"github.com/panyam/mcpkit/core"
 )
@@ -40,6 +41,14 @@ type Message struct {
 	// ToolCallID links a RoleTool message to the assistant ToolCall it
 	// answers.
 	ToolCallID string `json:"toolCallId,omitempty"`
+
+	// Timestamp records when the message was said. Zero means unstamped;
+	// RunStore implementations stamp zero-Timestamp messages with their
+	// own clock on AppendMessages, and a caller-set non-zero value wins
+	// (a surface can stamp the user message at keypress). Providers
+	// never map this field into request bodies — it is session metadata,
+	// not model input.
+	Timestamp time.Time `json:"timestamp,omitzero"`
 }
 
 // ToolCall is one model-requested tool invocation.

--- a/agent/runstore.go
+++ b/agent/runstore.go
@@ -78,6 +78,12 @@ type CreateRunResponse struct {
 // Callers pass exactly the entries a turn added (the user message plus
 // TurnResult.Messages) so the stored log threads the same way in-process
 // history does.
+//
+// Stamping rule: implementations set Message.Timestamp to their own
+// clock for every appended message whose Timestamp is zero, and
+// preserve non-zero values verbatim (caller wins — a surface can stamp
+// the user message at keypress). One boundary, one rule: code that
+// constructs messages never needs to remember to stamp.
 type AppendMessagesRequest struct {
 	RunID    string
 	Messages []Message
@@ -180,7 +186,8 @@ func (s *InMemoryRunStore) CreateRun(ctx context.Context, req CreateRunRequest) 
 	return CreateRunResponse{RunID: id, Created: true}, nil
 }
 
-// AppendMessages implements RunStore.
+// AppendMessages implements RunStore, stamping zero Timestamps per the
+// AppendMessagesRequest rule.
 func (s *InMemoryRunStore) AppendMessages(ctx context.Context, req AppendMessagesRequest) (AppendMessagesResponse, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -188,7 +195,14 @@ func (s *InMemoryRunStore) AppendMessages(ctx context.Context, req AppendMessage
 	if !ok {
 		return AppendMessagesResponse{Found: false}, nil
 	}
+	start := len(e.messages)
 	e.messages = append(e.messages, req.Messages...)
+	now := time.Now()
+	for i := start; i < len(e.messages); i++ {
+		if e.messages[i].Timestamp.IsZero() {
+			e.messages[i].Timestamp = now
+		}
+	}
 	return AppendMessagesResponse{Found: true}, nil
 }
 

--- a/agent/runstore_test.go
+++ b/agent/runstore_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"reflect"
+	"slices"
+	"strings"
 	"testing"
+	"time"
 )
 
 func mustCreate(t *testing.T, s RunStore, id string) string {
@@ -62,7 +65,7 @@ func TestInMemoryRunStore_CreateAppendLoad(t *testing.T) {
 
 	run := mustLoad(t, s, id)
 	want := append(append([]Message{}, turn1...), turn2...)
-	if !reflect.DeepEqual(run.Messages, want) {
+	if !reflect.DeepEqual(stripStamps(t, run.Messages), want) {
 		t.Fatalf("loaded messages mismatch:\n got %+v\nwant %+v", run.Messages, want)
 	}
 	if run.ID != id {
@@ -157,7 +160,7 @@ func TestInMemoryRunStore_ForkDiverges(t *testing.T) {
 	}
 
 	forked := mustLoad(t, s, fork.RunID)
-	if !reflect.DeepEqual(forked.Messages, base) {
+	if !reflect.DeepEqual(stripStamps(t, forked.Messages), base) {
 		t.Fatalf("fork did not copy the log: %+v", forked.Messages)
 	}
 	if forked.ParentID != id {
@@ -252,4 +255,59 @@ func TestRun_JSONRoundTrip(t *testing.T) {
 	if string(data) != string(data2) {
 		t.Fatalf("round-trip drift:\n got %s\nwant %s", data2, data)
 	}
+}
+
+func TestInMemoryRunStore_StampsTimestamps(t *testing.T) {
+	ctx := context.Background()
+	s := NewInMemoryRunStore()
+	id := mustCreate(t, s, "")
+
+	pre := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	if _, err := s.AppendMessages(ctx, AppendMessagesRequest{RunID: id, Messages: []Message{
+		{Role: RoleUser, Text: "unstamped"},
+		{Role: RoleAssistant, Text: "pre-stamped", Timestamp: pre},
+	}}); err != nil {
+		t.Fatalf("AppendMessages: %v", err)
+	}
+
+	run := mustLoad(t, s, id)
+	if run.Messages[0].Timestamp.IsZero() {
+		t.Fatal("store did not stamp the unstamped message")
+	}
+	if !run.Messages[1].Timestamp.Equal(pre) {
+		t.Fatalf("caller-set timestamp clobbered: %v, want %v", run.Messages[1].Timestamp, pre)
+	}
+}
+
+// TestMessageTimestampOmittedWhenZero pins wire cleanliness: unstamped
+// messages (the shape providers see mid-turn) carry no timestamp key.
+func TestMessageTimestampOmittedWhenZero(t *testing.T) {
+	raw, err := json.Marshal(Message{Role: RoleUser, Text: "hi"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), "timestamp") {
+		t.Fatalf("zero Timestamp leaked onto the wire: %s", raw)
+	}
+	stamped, err := json.Marshal(Message{Role: RoleUser, Text: "hi", Timestamp: time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(stamped), `"timestamp":"2026-07-01T12:00:00Z"`) {
+		t.Fatalf("stamped Timestamp missing from wire form: %s", stamped)
+	}
+}
+
+// stripStamps asserts every message got stamped, then zeroes the field
+// so structural comparisons stay exact on everything else.
+func stripStamps(t *testing.T, msgs []Message) []Message {
+	t.Helper()
+	out := slices.Clone(msgs)
+	for i := range out {
+		if out[i].Timestamp.IsZero() {
+			t.Fatalf("message %d not stamped: %+v", i, out[i])
+		}
+		out[i].Timestamp = time.Time{}
+	}
+	return out
 }

--- a/agent/store/gorm/runstore.go
+++ b/agent/store/gorm/runstore.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"gorm.io/gorm"
@@ -151,12 +152,21 @@ func appendRows[T any](tx *gorm.DB, runID string, values []T, insert func(tx *go
 	return true, insert(tx, runID, bodies)
 }
 
-// AppendMessages implements agent.RunStore.
+// AppendMessages implements agent.RunStore, stamping zero Timestamps
+// per the agent.AppendMessagesRequest rule before encoding, so the
+// stamp lives inside the stored JSON body and forks copy it for free.
 func (s *RunStore) AppendMessages(ctx context.Context, req agent.AppendMessagesRequest) (agent.AppendMessagesResponse, error) {
+	msgs := slices.Clone(req.Messages)
+	now := time.Now().UTC()
+	for i := range msgs {
+		if msgs[i].Timestamp.IsZero() {
+			msgs[i].Timestamp = now
+		}
+	}
 	var found bool
 	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var err error
-		found, err = appendRows(tx, req.RunID, req.Messages, func(tx *gorm.DB, runID string, bodies []string) error {
+		found, err = appendRows(tx, req.RunID, msgs, func(tx *gorm.DB, runID string, bodies []string) error {
 			rows := make([]runMessageRow, len(bodies))
 			for i, b := range bodies {
 				rows[i] = runMessageRow{RunID: runID, Body: b}

--- a/agent/store/gorm/runstore_test.go
+++ b/agent/store/gorm/runstore_test.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
+	"time"
 
 	"gorm.io/driver/postgres"
 	"gorm.io/driver/sqlite"
@@ -185,7 +187,7 @@ func TestGormRunStore_CreateAppendLoad(t *testing.T) {
 
 		run := mustLoad(t, s, id)
 		want := append(append([]agent.Message{}, turn1...), turn2...)
-		assertMessagesEqual(t, run.Messages, want)
+		assertMessagesEqual(t, stripStamps(t, run.Messages), want)
 		if run.ID != id || run.ParentID != "" {
 			t.Fatalf("Run identity = (%q, parent %q), want (%q, \"\")", run.ID, run.ParentID, id)
 		}
@@ -278,7 +280,7 @@ func TestGormRunStore_ForkDiverges(t *testing.T) {
 		}
 
 		forked := mustLoad(t, s, fork.RunID)
-		assertMessagesEqual(t, forked.Messages, base)
+		assertMessagesEqual(t, stripStamps(t, forked.Messages), base)
 		if forked.ParentID != id {
 			t.Fatalf("fork ParentID = %q, want %q", forked.ParentID, id)
 		}
@@ -338,7 +340,7 @@ func TestGormRunStore_ForkPreservesLongOrder(t *testing.T) {
 		if err != nil {
 			t.Fatalf("ForkRun: %v", err)
 		}
-		assertMessagesEqual(t, mustLoad(t, s, fork.RunID).Messages, want)
+		assertMessagesEqual(t, stripStamps(t, mustLoad(t, s, fork.RunID).Messages), want)
 	})
 }
 
@@ -366,4 +368,41 @@ func TestGormRunStore_SurvivesReopen(t *testing.T) {
 	if len(run.Messages) != 1 || run.Messages[0].Text != "persisted" {
 		t.Fatalf("run did not survive reopen: %+v", run.Messages)
 	}
+}
+
+func TestGormRunStore_StampsTimestamps(t *testing.T) {
+	forEachBackend(t, func(t *testing.T, s *RunStore) {
+		ctx := context.Background()
+		id := mustCreate(t, s, "")
+
+		pre := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+		if _, err := s.AppendMessages(ctx, agent.AppendMessagesRequest{RunID: id, Messages: []agent.Message{
+			{Role: agent.RoleUser, Text: "unstamped"},
+			{Role: agent.RoleAssistant, Text: "pre-stamped", Timestamp: pre},
+		}}); err != nil {
+			t.Fatalf("AppendMessages: %v", err)
+		}
+
+		run := mustLoad(t, s, id)
+		if run.Messages[0].Timestamp.IsZero() {
+			t.Fatal("store did not stamp the unstamped message")
+		}
+		if !run.Messages[1].Timestamp.Equal(pre) {
+			t.Fatalf("caller-set timestamp clobbered: %v, want %v", run.Messages[1].Timestamp, pre)
+		}
+	})
+}
+
+// stripStamps asserts every message got stamped, then zeroes the field
+// so the wire-form comparisons stay exact on everything else.
+func stripStamps(t *testing.T, msgs []agent.Message) []agent.Message {
+	t.Helper()
+	out := slices.Clone(msgs)
+	for i := range out {
+		if out[i].Timestamp.IsZero() {
+			t.Fatalf("message %d not stamped: %+v", i, out[i])
+		}
+		out[i].Timestamp = time.Time{}
+	}
+	return out
 }

--- a/agent/store/redis/runstore.go
+++ b/agent/store/redis/runstore.go
@@ -25,6 +25,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -159,9 +160,18 @@ func appendJSON[T any](ctx context.Context, s *RunStore, id, part string, values
 	return true, nil
 }
 
-// AppendMessages implements agent.RunStore.
+// AppendMessages implements agent.RunStore, stamping zero Timestamps
+// per the agent.AppendMessagesRequest rule before encoding, so the
+// stamp lives inside the stored JSON body and forks copy it for free.
 func (s *RunStore) AppendMessages(ctx context.Context, req agent.AppendMessagesRequest) (agent.AppendMessagesResponse, error) {
-	found, err := appendJSON(ctx, s, req.RunID, "messages", req.Messages)
+	msgs := slices.Clone(req.Messages)
+	now := time.Now().UTC()
+	for i := range msgs {
+		if msgs[i].Timestamp.IsZero() {
+			msgs[i].Timestamp = now
+		}
+	}
+	found, err := appendJSON(ctx, s, req.RunID, "messages", msgs)
 	return agent.AppendMessagesResponse{Found: found}, err
 }
 

--- a/agent/store/redis/runstore_test.go
+++ b/agent/store/redis/runstore_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"slices"
 	"testing"
+	"time"
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/redis/go-redis/v9"
@@ -90,7 +92,7 @@ func TestRedisRunStore_CreateAppendLoad(t *testing.T) {
 
 	run := mustLoad(t, s, id)
 	want := append(append([]agent.Message{}, turn1...), turn2...)
-	assertMessagesEqual(t, run.Messages, want)
+	assertMessagesEqual(t, stripStamps(t, run.Messages), want)
 	if run.ID != id || run.ParentID != "" {
 		t.Fatalf("Run identity = (%q, parent %q), want (%q, \"\")", run.ID, run.ParentID, id)
 	}
@@ -201,7 +203,7 @@ func TestRedisRunStore_ForkDiverges(t *testing.T) {
 	}
 
 	forked := mustLoad(t, s, fork.RunID)
-	assertMessagesEqual(t, forked.Messages, base)
+	assertMessagesEqual(t, stripStamps(t, forked.Messages), base)
 	if forked.ParentID != id {
 		t.Fatalf("fork ParentID = %q, want %q", forked.ParentID, id)
 	}
@@ -285,4 +287,40 @@ func TestRedisRunStore_KeyPrefixIsolation(t *testing.T) {
 	if resp, err := b.CreateRun(ctx, agent.CreateRunRequest{RunID: "shared-name"}); err != nil || !resp.Created {
 		t.Fatalf("prefix isolation broken: CreateRun = (%+v, %v)", resp, err)
 	}
+}
+
+func TestRedisRunStore_StampsTimestamps(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	id := mustCreate(t, s, "")
+
+	pre := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	if _, err := s.AppendMessages(ctx, agent.AppendMessagesRequest{RunID: id, Messages: []agent.Message{
+		{Role: agent.RoleUser, Text: "unstamped"},
+		{Role: agent.RoleAssistant, Text: "pre-stamped", Timestamp: pre},
+	}}); err != nil {
+		t.Fatalf("AppendMessages: %v", err)
+	}
+
+	run := mustLoad(t, s, id)
+	if run.Messages[0].Timestamp.IsZero() {
+		t.Fatal("store did not stamp the unstamped message")
+	}
+	if !run.Messages[1].Timestamp.Equal(pre) {
+		t.Fatalf("caller-set timestamp clobbered: %v, want %v", run.Messages[1].Timestamp, pre)
+	}
+}
+
+// stripStamps asserts every message got stamped, then zeroes the field
+// so the wire-form comparisons stay exact on everything else.
+func stripStamps(t *testing.T, msgs []agent.Message) []agent.Message {
+	t.Helper()
+	out := slices.Clone(msgs)
+	for i := range out {
+		if out[i].Timestamp.IsZero() {
+			t.Fatalf("message %d not stamped: %+v", i, out[i])
+		}
+		out[i].Timestamp = time.Time{}
+	}
+	return out
 }


### PR DESCRIPTION
Closes #964. Stacks on PR 961 (gorm backend) — the stamping covers all three store backends, so it needs the gorm module. Retarget to main after 961 merges. **No CI while based on a non-main branch** — verified locally with `make test-agent` (all 9 sub-module runs green).

## What changes

`agent.Message` gains an optional `Timestamp`, and the three RunStore backends stamp it at the append boundary: any message appended with a zero Timestamp gets the store's clock; a caller-set non-zero value is preserved verbatim (a surface can stamp the user message at keypress). Unstamped messages serialize with no `timestamp` key at all (`omitzero`), so mid-turn provider traffic is byte-identical to before.

## Reviewer's guide

Read in this order:
1. [agent/provider.go](https://github.com/panyam/mcpkit/pull/967/files#diff-a1383b85f643c0c6e93ffd7d81aefd65f427d24348ee2d60c8388c91694f3c5b) — the field and its contract doc (who stamps, who wins, why providers never see it).
2. [agent/runstore.go](https://github.com/panyam/mcpkit/pull/967/files#diff-f2ebdb590e8817d70dfdc21e0169cecb55b6a3131172a87aaa59e57301ed2643) — the stamping rule pinned on `AppendMessagesRequest` (one boundary, one rule) and the in-memory implementation.
3. [agent/store/redis/runstore.go](https://github.com/panyam/mcpkit/pull/967/files#diff-b9f1c76ec08cf9411daf9fa0b9d8bbf81eca4a8a4702de0a3cca1220f7cdad44) + [agent/store/gorm/runstore.go](https://github.com/panyam/mcpkit/pull/967/files#diff-5bbef7160565ce4fb2c227190f57eec12777484327dfba6fb1621f831a222a0c) — the same stamp-before-encode loop in each backend's `AppendMessages`.
4. Tests — one stamping test per backend (unstamped gets stamped, caller-set survives), `TestMessageTimestampOmittedWhenZero` (wire cleanliness), and the pre-existing load/fork comparisons now run through `stripStamps`, which *asserts* every loaded message is stamped before comparing the rest.

## Decision log

- **Stamp inside the JSON body, not a schema column**: the issue sketched a `created_at` column; stamping the field *before* encoding is strictly simpler — zero schema change, all backends get it identically, forks copy timestamps for free, and Postgres can still query it (`body->>'timestamp'`). A column can be added later if an indexed time query ever matters.
- **Stores stamp, not the Runner or host**: every message-constructing path (runner, injection, triggers, tests) would otherwise need to remember; half-stamped histories are worse than none.
- **`omitzero`, not `omitempty`**: `omitempty` does not omit a zero `time.Time`, which would have stamped `0001-01-01...` onto every provider-bound message.
- **Events not stamped**: they stream live and surfaces stamp on receipt; persisted-event timestamps can follow when a replay UI needs them.

## Risk / blast radius

- Affects: the `Message` wire shape (additive, omitted when zero — A2 round-trip and provider payloads unchanged for unstamped messages) and the three `AppendMessages` implementations.
- Tests: 4 new; existing comparisons strengthened (each loaded message now must be stamped), 0 assertions removed or weakened.
- Be paranoid about: any consumer doing exact-JSON comparison of *loaded* histories (the stamp is new data there — that's the point), and `slices.Clone` shallow-copy in the stores (fine: `Timestamp` is a value field; `ToolCalls` sharing is unchanged from before).

## Before / after

Loaded run body, same conversation:
```
before:  {"role":"user","text":"hi"}
after:   {"role":"user","text":"hi","timestamp":"2026-07-17T15:09:46.234Z"}
```
Provider-bound (in-turn, unstamped) messages: byte-identical before and after.

## Out of scope (deliberately deferred)

- Persisted event timestamps → noted in issue 964
- Fork-at-point / ForkedAt → issue 962 (next PR, stacks on this)
- Indexed time queries (schema column) → only if a consumer needs them
