### PR TITLE
feat(agent): fork from an earlier point + ForkPoint lineage

### DIFF
--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -382,7 +382,7 @@ func (a *App) REPL(ctx context.Context, in io.Reader, turnCtx func() (context.Co
 			}
 		case line == "/fork" || strings.HasPrefix(line, "/fork "):
 			id := strings.TrimSpace(strings.TrimPrefix(line, "/fork"))
-			forkID, err := a.Fork(ctx, id)
+			forkID, err := a.Fork(ctx, id, 0)
 			if err != nil {
 				a.renderer.turnFailed(err)
 			} else {

--- a/agent/host/persistence.go
+++ b/agent/host/persistence.go
@@ -75,10 +75,14 @@ func (a *App) resumeLocked(ctx context.Context, runID string) error {
 }
 
 // Fork copies the current run's log into a new run (newRunID empty asks
-// the store to generate one) and switches the session to the copy: the
-// in-memory history is already the shared prefix, so the fork diverges
-// from the next turn on while the original run stays untouched.
-func (a *App) Fork(ctx context.Context, newRunID string) (string, error) {
+// the store to generate one) and switches the session to the copy,
+// which diverges from the next turn on while the original stays
+// untouched. atMessage positive forks from an earlier point — only the
+// first atMessage messages carry over (checkpoint/rewind), and the
+// in-memory history rewinds to match by reloading the fork; zero or
+// negative forks the whole log, and history is already the shared
+// prefix so no reload is needed.
+func (a *App) Fork(ctx context.Context, newRunID string, atMessage int) (string, error) {
 	a.turnMu.Lock()
 	defer a.turnMu.Unlock()
 	if a.store == nil {
@@ -87,7 +91,7 @@ func (a *App) Fork(ctx context.Context, newRunID string) (string, error) {
 	if a.runID == "" {
 		return "", fmt.Errorf("host: no active run to fork (run at least one turn first)")
 	}
-	resp, err := a.store.ForkRun(ctx, agent.ForkRunRequest{RunID: a.runID, NewRunID: newRunID})
+	resp, err := a.store.ForkRun(ctx, agent.ForkRunRequest{RunID: a.runID, NewRunID: newRunID, AtMessage: atMessage})
 	if err != nil {
 		return "", fmt.Errorf("host: forking run %q: %w", a.runID, err)
 	}
@@ -96,6 +100,9 @@ func (a *App) Fork(ctx context.Context, newRunID string) (string, error) {
 	}
 	if !resp.Created {
 		return "", fmt.Errorf("host: run %q already exists", newRunID)
+	}
+	if atMessage > 0 {
+		return resp.RunID, a.resumeLocked(ctx, resp.RunID)
 	}
 	a.runID = resp.RunID
 	return resp.RunID, nil

--- a/agent/host/persistence_test.go
+++ b/agent/host/persistence_test.go
@@ -141,7 +141,7 @@ func TestAppForkDiverges(t *testing.T) {
 	}
 	original := app.RunID()
 
-	forkID, err := app.Fork(ctx, "")
+	forkID, err := app.Fork(ctx, "", 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -170,7 +170,7 @@ func TestAppForkWithoutRunErrors(t *testing.T) {
 	stub := agent.NewStubProvider()
 	var out strings.Builder
 	app := newPersistedApp(t, store, stub, &out)
-	if _, err := app.Fork(context.Background(), ""); err == nil {
+	if _, err := app.Fork(context.Background(), "", 0); err == nil {
 		t.Fatal("Fork with no active run succeeded, want error")
 	}
 }
@@ -245,7 +245,7 @@ func TestAppWithoutStoreSessionMethodsError(t *testing.T) {
 	if err := app.AttachRun(ctx, "x"); err == nil {
 		t.Fatal("AttachRun without store succeeded")
 	}
-	if _, err := app.Fork(ctx, ""); err == nil {
+	if _, err := app.Fork(ctx, "", 0); err == nil {
 		t.Fatal("Fork without store succeeded")
 	}
 	if got := app.RunID(); got != "" {
@@ -288,5 +288,52 @@ func TestPersistingEmitFlush(t *testing.T) {
 	missing.Emit(agent.Event{Kind: agent.EventTurnBegin})
 	if err := missing.Flush(ctx); err == nil {
 		t.Fatal("Flush against a missing run succeeded, want error")
+	}
+}
+
+func TestAppForkAtRewindsHistory(t *testing.T) {
+	ctx := context.Background()
+	store := agent.NewInMemoryRunStore()
+	stub := agent.NewStubProvider(
+		agent.StubTurn{Text: "first answer"},
+		agent.StubTurn{Text: "second answer"},
+		agent.StubTurn{Text: "divergent answer"},
+	)
+	var out strings.Builder
+	app := newPersistedApp(t, store, stub, &out)
+	if err := app.RunTurn(ctx, "one"); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.RunTurn(ctx, "two"); err != nil {
+		t.Fatal(err)
+	}
+	original := app.RunID()
+
+	forkID, err := app.Fork(ctx, "", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(app.history) != 2 {
+		t.Fatalf("Fork at 2 left history at %d messages, want rewind to 2: %+v", len(app.history), app.history)
+	}
+	if err := app.RunTurn(ctx, "diverge"); err != nil {
+		t.Fatal(err)
+	}
+
+	req := stub.Requests()[2].Messages
+	if len(req) != 3 || req[0].Text != "one" || req[1].Text != "first answer" || req[2].Text != "diverge" {
+		t.Fatalf("post-rewind model request = %+v, want first turn + diverge", req)
+	}
+
+	orig, _ := store.LoadRun(ctx, agent.LoadRunRequest{RunID: original})
+	if len(orig.Run.Messages) != 4 {
+		t.Fatalf("original run mutated by fork-at: %d messages, want 4", len(orig.Run.Messages))
+	}
+	fork, _ := store.LoadRun(ctx, agent.LoadRunRequest{RunID: forkID})
+	if len(fork.Run.Messages) != 4 || fork.Run.Messages[2].Text != "diverge" {
+		t.Fatalf("fork run = %+v, want 2 copied + 2 divergent", fork.Run.Messages)
+	}
+	if fork.Run.ForkPoint != 2 || fork.Run.ParentID != original {
+		t.Fatalf("fork lineage = (parent %q, forkPoint %d), want (%q, 2)", fork.Run.ParentID, fork.Run.ForkPoint, original)
 	}
 }

--- a/agent/runstore.go
+++ b/agent/runstore.go
@@ -59,6 +59,15 @@ type Run struct {
 	// created directly.
 	ParentID string `json:"parentId,omitempty"`
 
+	// ForkPoint is the number of ParentID's messages this run was
+	// forked with — the fork position as a backend-neutral message
+	// count (never a timestamp: the fork's wall-clock moment is this
+	// run's CreatedAt; never a storage sequence value either). Zero for
+	// runs created directly. Lineage metadata for surfaces (rewind
+	// pickers, history UIs): nothing reconstructs history from it,
+	// since every run owns its full copy.
+	ForkPoint int `json:"forkPoint,omitempty"`
+
 	CreatedAt time.Time `json:"createdAt"`
 
 	Messages []Message `json:"messages"`
@@ -148,16 +157,32 @@ type LoadRunResponse struct {
 type ForkRunRequest struct {
 	RunID    string
 	NewRunID string
+
+	// AtMessage forks from an earlier point: a positive value copies
+	// only the first AtMessage messages (checkpoint/rewind semantics);
+	// zero or negative copies everything, today's behavior. A value at
+	// or beyond the source's length clamps to a full copy. The source's
+	// length is observed when the fork starts; appends racing the fork
+	// land after the cut.
+	//
+	// Event-log handling: the audit stream is not sliceable by message
+	// index, so a partial fork copies NO events — only a full copy
+	// carries the event log across. The fork's message log is complete
+	// either way, which is all resume needs.
+	AtMessage int
 }
 
 // ForkRunResponse identifies the fork. Found is false when the source
 // run does not exist; Created is false when NewRunID was claimed and
-// already existed (no copy happens). On success both are true and RunID
-// names the new run, whose ParentID records the lineage.
+// already existed (no copy happens). On success both are true, RunID
+// names the new run (ParentID records the lineage), and ForkPoint is
+// the message count actually copied — the resolved fork position after
+// clamping, also persisted on the fork's Run.
 type ForkRunResponse struct {
-	RunID   string
-	Found   bool
-	Created bool
+	RunID     string
+	Found     bool
+	Created   bool
+	ForkPoint int
 }
 
 // InMemoryRunStore is the default RunStore: a mutex-guarded map, useful
@@ -175,6 +200,7 @@ type InMemoryRunStore struct {
 // instead of parallel same-keyed maps).
 type runEntry struct {
 	parentID  string
+	forkPoint int
 	createdAt time.Time
 	messages  []Message
 	events    []Event
@@ -247,6 +273,7 @@ func (s *InMemoryRunStore) LoadRun(ctx context.Context, req LoadRunRequest) (Loa
 		Run: Run{
 			ID:        req.RunID,
 			ParentID:  e.parentID,
+			ForkPoint: e.forkPoint,
 			CreatedAt: e.createdAt,
 			Messages:  slices.Clone(e.messages),
 			Events:    slices.Clone(e.events),
@@ -256,7 +283,8 @@ func (s *InMemoryRunStore) LoadRun(ctx context.Context, req LoadRunRequest) (Loa
 }
 
 // ForkRun implements RunStore. The fork gets cloned logs, so parent and
-// fork diverge independently after the copy.
+// fork diverge independently after the copy; see ForkRunRequest for the
+// AtMessage cut and event-log semantics.
 func (s *InMemoryRunStore) ForkRun(ctx context.Context, req ForkRunRequest) (ForkRunResponse, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -271,11 +299,20 @@ func (s *InMemoryRunStore) ForkRun(ctx context.Context, req ForkRunRequest) (For
 	} else if _, exists := s.runs[id]; exists {
 		return ForkRunResponse{RunID: id, Found: true, Created: false}, nil
 	}
+	n := len(src.messages)
+	if req.AtMessage > 0 && req.AtMessage < n {
+		n = req.AtMessage
+	}
+	var events []Event
+	if n == len(src.messages) {
+		events = slices.Clone(src.events)
+	}
 	s.runs[id] = &runEntry{
 		parentID:  req.RunID,
+		forkPoint: n,
 		createdAt: time.Now(),
-		messages:  slices.Clone(src.messages),
-		events:    slices.Clone(src.events),
+		messages:  slices.Clone(src.messages[:n]),
+		events:    events,
 	}
-	return ForkRunResponse{RunID: id, Found: true, Created: true}, nil
+	return ForkRunResponse{RunID: id, Found: true, Created: true, ForkPoint: n}, nil
 }

--- a/agent/runstore_test.go
+++ b/agent/runstore_test.go
@@ -311,3 +311,62 @@ func stripStamps(t *testing.T, msgs []Message) []Message {
 	}
 	return out
 }
+
+func TestInMemoryRunStore_ForkAtPoint(t *testing.T) {
+	ctx := context.Background()
+	s := NewInMemoryRunStore()
+	id := mustCreate(t, s, "")
+	msgs := []Message{
+		{Role: RoleUser, Text: "m0"},
+		{Role: RoleAssistant, Text: "m1"},
+		{Role: RoleUser, Text: "m2"},
+		{Role: RoleAssistant, Text: "m3"},
+	}
+	if _, err := s.AppendMessages(ctx, AppendMessagesRequest{RunID: id, Messages: msgs}); err != nil {
+		t.Fatalf("AppendMessages: %v", err)
+	}
+	if _, err := s.AppendEvents(ctx, AppendEventsRequest{RunID: id, Events: []Event{{Kind: EventTurnBegin}}}); err != nil {
+		t.Fatalf("AppendEvents: %v", err)
+	}
+
+	partial, err := s.ForkRun(ctx, ForkRunRequest{RunID: id, AtMessage: 2})
+	if err != nil || !partial.Found || !partial.Created {
+		t.Fatalf("partial ForkRun = (%+v, %v)", partial, err)
+	}
+	if partial.ForkPoint != 2 {
+		t.Fatalf("partial ForkPoint = %d, want 2", partial.ForkPoint)
+	}
+	run := mustLoad(t, s, partial.RunID)
+	if len(run.Messages) != 2 || run.Messages[1].Text != "m1" {
+		t.Fatalf("partial fork messages = %+v, want first 2", run.Messages)
+	}
+	if run.ForkPoint != 2 || run.ParentID != id {
+		t.Fatalf("partial fork lineage = (parent %q, forkPoint %d)", run.ParentID, run.ForkPoint)
+	}
+	if len(run.Events) != 0 {
+		t.Fatalf("partial fork copied events: %+v", run.Events)
+	}
+
+	clamped, err := s.ForkRun(ctx, ForkRunRequest{RunID: id, AtMessage: 99})
+	if err != nil {
+		t.Fatalf("clamped ForkRun: %v", err)
+	}
+	if clamped.ForkPoint != 4 {
+		t.Fatalf("clamped ForkPoint = %d, want 4", clamped.ForkPoint)
+	}
+	run = mustLoad(t, s, clamped.RunID)
+	if len(run.Messages) != 4 || len(run.Events) != 1 {
+		t.Fatalf("clamped fork = %d messages / %d events, want full copy", len(run.Messages), len(run.Events))
+	}
+
+	full, err := s.ForkRun(ctx, ForkRunRequest{RunID: id})
+	if err != nil {
+		t.Fatalf("full ForkRun: %v", err)
+	}
+	if full.ForkPoint != 4 {
+		t.Fatalf("full ForkPoint = %d, want 4", full.ForkPoint)
+	}
+	if run = mustLoad(t, s, full.RunID); len(run.Events) != 1 {
+		t.Fatalf("full fork dropped events: %+v", run.Events)
+	}
+}

--- a/agent/store/gorm/runstore.go
+++ b/agent/store/gorm/runstore.go
@@ -254,6 +254,24 @@ func (s *RunStore) LoadRun(ctx context.Context, req agent.LoadRunRequest) (agent
 // transaction, so the fork is an exact cut of the source at commit
 // time. See agent.ForkRunRequest for the AtMessage and event-log
 // semantics.
+//
+// The transaction is for crash atomicity, NOT locking: nothing here
+// takes row locks on the source (no FOR UPDATE; INSERT ... SELECT's
+// read side is AccessShare), so appends to the source never wait on a
+// fork. Races don't need the transaction either — a racing append gets
+// a seq above every existing row, and the seq-ordered LIMIT copies a
+// deterministic prefix, so it lands cleanly after the cut. What the
+// transaction buys is the RunStore all-or-nothing contract: a crash
+// mid-fork rolls back to nothing (no claim row over a partial copy for
+// a retry to trust), and two replicas retrying the same NewRunID
+// resolve to one complete fork plus one clean Created=false. The
+// lock-free alternative (copy first, claim last, DELETE stale rows on
+// retry) can satisfy the crash case but costs an extra statement,
+// makes statement ORDER a correctness invariant, and leaves concurrent
+// same-ID retries able to interleave each other's half-written copies
+// — the transaction closes all three for free, so we use the
+// database's native atomicity primitive, mirroring the Redis backend's
+// choice of its native primitive (the atomic Lua script).
 func (s *RunStore) ForkRun(ctx context.Context, req agent.ForkRunRequest) (agent.ForkRunResponse, error) {
 	var resp agent.ForkRunResponse
 	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {

--- a/agent/store/gorm/runstore.go
+++ b/agent/store/gorm/runstore.go
@@ -21,6 +21,7 @@ import (
 type runRow struct {
 	ID        string    `gorm:"primaryKey"`
 	ParentID  string    `gorm:"index"`
+	ForkPoint int       `gorm:"not null;default:0"`
 	CreatedAt time.Time `gorm:"not null"`
 }
 
@@ -239,6 +240,7 @@ func (s *RunStore) LoadRun(ctx context.Context, req agent.LoadRunRequest) (agent
 		Run: agent.Run{
 			ID:        row.ID,
 			ParentID:  row.ParentID,
+			ForkPoint: row.ForkPoint,
 			CreatedAt: row.CreatedAt,
 			Messages:  messages,
 			Events:    events,
@@ -247,9 +249,11 @@ func (s *RunStore) LoadRun(ctx context.Context, req agent.LoadRunRequest) (agent
 	}, nil
 }
 
-// ForkRun implements agent.RunStore. The whole fork — source check, new
-// run claim, and both log copies — runs in one transaction, so the fork
-// is an exact cut of the source at commit time.
+// ForkRun implements agent.RunStore. The whole fork — source check,
+// cut-point resolution, new run claim, and the log copies — runs in one
+// transaction, so the fork is an exact cut of the source at commit
+// time. See agent.ForkRunRequest for the AtMessage and event-log
+// semantics.
 func (s *RunStore) ForkRun(ctx context.Context, req agent.ForkRunRequest) (agent.ForkRunResponse, error) {
 	var resp agent.ForkRunResponse
 	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
@@ -261,9 +265,18 @@ func (s *RunStore) ForkRun(ctx context.Context, req agent.ForkRunRequest) (agent
 			return nil
 		}
 
+		var srcLen int64
+		if err := tx.Table("agent_run_messages").Where("run_id = ?", req.RunID).Count(&srcLen).Error; err != nil {
+			return err
+		}
+		n := int(srcLen)
+		if req.AtMessage > 0 && req.AtMessage < n {
+			n = req.AtMessage
+		}
+
 		id := req.NewRunID
 		if id != "" {
-			won, err := claimRun(tx, runRow{ID: id, ParentID: req.RunID, CreatedAt: time.Now().UTC()})
+			won, err := claimRun(tx, runRow{ID: id, ParentID: req.RunID, ForkPoint: n, CreatedAt: time.Now().UTC()})
 			if err != nil {
 				return err
 			}
@@ -276,7 +289,7 @@ func (s *RunStore) ForkRun(ctx context.Context, req agent.ForkRunRequest) (agent
 				if id, err = newRunID(); err != nil {
 					return err
 				}
-				won, err := claimRun(tx, runRow{ID: id, ParentID: req.RunID, CreatedAt: time.Now().UTC()})
+				won, err := claimRun(tx, runRow{ID: id, ParentID: req.RunID, ForkPoint: n, CreatedAt: time.Now().UTC()})
 				if err != nil {
 					return err
 				}
@@ -286,15 +299,23 @@ func (s *RunStore) ForkRun(ctx context.Context, req agent.ForkRunRequest) (agent
 			}
 		}
 
-		for _, table := range []string{"agent_run_messages", "agent_run_events"} {
+		if n > 0 {
 			if err := tx.Exec(
-				fmt.Sprintf("INSERT INTO %s (run_id, body) SELECT ?, body FROM %s WHERE run_id = ? ORDER BY seq", table, table),
+				"INSERT INTO agent_run_messages (run_id, body) SELECT ?, body FROM agent_run_messages WHERE run_id = ? ORDER BY seq LIMIT ?",
+				id, req.RunID, n,
+			).Error; err != nil {
+				return err
+			}
+		}
+		if n == int(srcLen) {
+			if err := tx.Exec(
+				"INSERT INTO agent_run_events (run_id, body) SELECT ?, body FROM agent_run_events WHERE run_id = ? ORDER BY seq",
 				id, req.RunID,
 			).Error; err != nil {
 				return err
 			}
 		}
-		resp = agent.ForkRunResponse{RunID: id, Found: true, Created: true}
+		resp = agent.ForkRunResponse{RunID: id, Found: true, Created: true, ForkPoint: n}
 		return nil
 	})
 	return resp, err

--- a/agent/store/gorm/runstore_test.go
+++ b/agent/store/gorm/runstore_test.go
@@ -406,3 +406,46 @@ func stripStamps(t *testing.T, msgs []agent.Message) []agent.Message {
 	}
 	return out
 }
+
+func TestGormRunStore_ForkAtPoint(t *testing.T) {
+	forEachBackend(t, func(t *testing.T, s *RunStore) {
+		ctx := context.Background()
+		id := mustCreate(t, s, "")
+		msgs := []agent.Message{
+			{Role: agent.RoleUser, Text: "m0"},
+			{Role: agent.RoleAssistant, Text: "m1"},
+			{Role: agent.RoleUser, Text: "m2"},
+			{Role: agent.RoleAssistant, Text: "m3"},
+		}
+		if _, err := s.AppendMessages(ctx, agent.AppendMessagesRequest{RunID: id, Messages: msgs}); err != nil {
+			t.Fatalf("AppendMessages: %v", err)
+		}
+		if _, err := s.AppendEvents(ctx, agent.AppendEventsRequest{RunID: id, Events: []agent.Event{{Kind: agent.EventTurnBegin}}}); err != nil {
+			t.Fatalf("AppendEvents: %v", err)
+		}
+
+		partial, err := s.ForkRun(ctx, agent.ForkRunRequest{RunID: id, AtMessage: 2})
+		if err != nil || !partial.Found || !partial.Created || partial.ForkPoint != 2 {
+			t.Fatalf("partial ForkRun = (%+v, %v), want Created with ForkPoint 2", partial, err)
+		}
+		run := mustLoad(t, s, partial.RunID)
+		if len(run.Messages) != 2 || run.Messages[1].Text != "m1" {
+			t.Fatalf("partial fork messages = %+v, want first 2", run.Messages)
+		}
+		if run.ForkPoint != 2 || run.ParentID != id {
+			t.Fatalf("partial fork lineage = (parent %q, forkPoint %d)", run.ParentID, run.ForkPoint)
+		}
+		if len(run.Events) != 0 {
+			t.Fatalf("partial fork copied events: %+v", run.Events)
+		}
+
+		clamped, err := s.ForkRun(ctx, agent.ForkRunRequest{RunID: id, AtMessage: 99})
+		if err != nil || clamped.ForkPoint != 4 {
+			t.Fatalf("clamped ForkRun = (%+v, %v), want ForkPoint 4", clamped, err)
+		}
+		run = mustLoad(t, s, clamped.RunID)
+		if len(run.Messages) != 4 || len(run.Events) != 1 {
+			t.Fatalf("clamped fork = %d messages / %d events, want full copy", len(run.Messages), len(run.Events))
+		}
+	})
+}

--- a/agent/store/redis/runstore.go
+++ b/agent/store/redis/runstore.go
@@ -285,6 +285,17 @@ const (
 // actually committed and Created=false reports the existing, complete
 // fork (confirm lineage via LoadRun ParentID).
 //
+// The script is Redis's native atomicity primitive, chosen over the
+// lock-free alternative (copy lists first, SETNX meta last, DEL stale
+// lists on retry) for the same reasons the gorm backend uses a
+// transaction: claim-last makes statement order a correctness
+// invariant, needs an extra cleanup step per retry, and lets two
+// concurrent forks of the same NewRunID interleave each other's
+// half-written copies. Unlike the gorm transaction (MVCC, non-
+// blocking), a Redis script does briefly serialize the server — the
+// price of Redis having only one atomicity primitive; fork frequency
+// and session-sized logs keep it negligible.
+//
 // Cluster caveat: the script touches both runs' keys, which a Redis
 // Cluster may place in different slots. A session store is assumed to
 // run against a single node or replicated setup; cluster deployments

--- a/agent/store/redis/runstore.go
+++ b/agent/store/redis/runstore.go
@@ -76,6 +76,7 @@ func New(client *redis.Client, opts ...Option) *RunStore {
 // runMeta is the JSON body of the meta key.
 type runMeta struct {
 	ParentID  string    `json:"parentId,omitempty"`
+	ForkPoint int       `json:"forkPoint,omitempty"`
 	CreatedAt time.Time `json:"createdAt"`
 }
 
@@ -226,6 +227,7 @@ func (s *RunStore) LoadRun(ctx context.Context, req agent.LoadRunRequest) (agent
 		Run: agent.Run{
 			ID:        req.RunID,
 			ParentID:  meta.ParentID,
+			ForkPoint: meta.ForkPoint,
 			CreatedAt: meta.CreatedAt,
 			Messages:  messages,
 			Events:    events,
@@ -247,16 +249,24 @@ func (s *RunStore) LoadRun(ctx context.Context, req agent.LoadRunRequest) (agent
 //
 //	4 dstMeta, 5 dstMessages, 6 dstEvents
 //
-// ARGV: 1 dst meta JSON. Returns 0 = source missing, 1 = target
+// ARGV: 1 dst meta JSON, 2 message-copy bound (copy the first n
+// messages; 0 copies none), 3 copy-events flag ("1" copies the whole
+// event log, anything else skips it — partial forks carry no events,
+// see agent.ForkRunRequest). Returns 0 = source missing, 1 = target
 // already claimed, 2 = committed.
 const forkScript = `
 if redis.call('EXISTS', KEYS[1]) == 0 then return 0 end
 if redis.call('EXISTS', KEYS[4]) == 1 then return 1 end
 redis.call('DEL', KEYS[5], KEYS[6])
-local msgs = redis.call('LRANGE', KEYS[2], 0, -1)
-for i = 1, #msgs do redis.call('RPUSH', KEYS[5], msgs[i]) end
-local evts = redis.call('LRANGE', KEYS[3], 0, -1)
-for i = 1, #evts do redis.call('RPUSH', KEYS[6], evts[i]) end
+local n = tonumber(ARGV[2])
+if n > 0 then
+  local msgs = redis.call('LRANGE', KEYS[2], 0, n - 1)
+  for i = 1, #msgs do redis.call('RPUSH', KEYS[5], msgs[i]) end
+end
+if ARGV[3] == '1' then
+  local evts = redis.call('LRANGE', KEYS[3], 0, -1)
+  for i = 1, #evts do redis.call('RPUSH', KEYS[6], evts[i]) end
+end
 redis.call('SET', KEYS[4], ARGV[1])
 return 2
 `
@@ -280,7 +290,22 @@ const (
 // run against a single node or replicated setup; cluster deployments
 // need hash-tagged prefixes to co-locate keys.
 func (s *RunStore) ForkRun(ctx context.Context, req agent.ForkRunRequest) (agent.ForkRunResponse, error) {
-	body, err := json.Marshal(runMeta{ParentID: req.RunID, CreatedAt: time.Now().UTC()})
+	// The cut point is resolved against the source length observed here;
+	// the script copies exactly the first n messages, so appends racing
+	// the fork land after the cut (agent.ForkRunRequest semantics).
+	srcLen, err := s.client.LLen(ctx, s.key(req.RunID, "messages")).Result()
+	if err != nil {
+		return agent.ForkRunResponse{}, err
+	}
+	n := int(srcLen)
+	if req.AtMessage > 0 && req.AtMessage < n {
+		n = req.AtMessage
+	}
+	copyEvents := "0"
+	if n == int(srcLen) {
+		copyEvents = "1"
+	}
+	body, err := json.Marshal(runMeta{ParentID: req.RunID, ForkPoint: n, CreatedAt: time.Now().UTC()})
 	if err != nil {
 		return agent.ForkRunResponse{}, fmt.Errorf("redisstore: encoding run meta: %w", err)
 	}
@@ -290,7 +315,7 @@ func (s *RunStore) ForkRun(ctx context.Context, req agent.ForkRunRequest) (agent
 			s.key(req.RunID, "meta"), s.key(req.RunID, "messages"), s.key(req.RunID, "events"),
 			s.key(id, "meta"), s.key(id, "messages"), s.key(id, "events"),
 		}
-		return s.client.Eval(ctx, forkScript, keys, string(body)).Int64()
+		return s.client.Eval(ctx, forkScript, keys, string(body), n, copyEvents).Int64()
 	}
 
 	id := req.NewRunID
@@ -305,7 +330,7 @@ func (s *RunStore) ForkRun(ctx context.Context, req agent.ForkRunRequest) (agent
 		case forkTargetClaimed:
 			return agent.ForkRunResponse{RunID: id, Found: true, Created: false}, nil
 		}
-		return agent.ForkRunResponse{RunID: id, Found: true, Created: true}, nil
+		return agent.ForkRunResponse{RunID: id, Found: true, Created: true, ForkPoint: n}, nil
 	}
 	for {
 		if id, err = newRunID(); err != nil {
@@ -319,7 +344,7 @@ func (s *RunStore) ForkRun(ctx context.Context, req agent.ForkRunRequest) (agent
 		case forkSourceMissing:
 			return agent.ForkRunResponse{}, nil
 		case forkCommitted:
-			return agent.ForkRunResponse{RunID: id, Found: true, Created: true}, nil
+			return agent.ForkRunResponse{RunID: id, Found: true, Created: true, ForkPoint: n}, nil
 		}
 	}
 }

--- a/agent/store/redis/runstore_test.go
+++ b/agent/store/redis/runstore_test.go
@@ -397,3 +397,45 @@ func TestRedisRunStore_ListKeysWithoutMetaAreInvisible(t *testing.T) {
 		t.Fatalf("ForkRun(ghost) = (%+v, %v), want invisible", resp, err)
 	}
 }
+
+func TestRedisRunStore_ForkAtPoint(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	id := mustCreate(t, s, "")
+	msgs := []agent.Message{
+		{Role: agent.RoleUser, Text: "m0"},
+		{Role: agent.RoleAssistant, Text: "m1"},
+		{Role: agent.RoleUser, Text: "m2"},
+		{Role: agent.RoleAssistant, Text: "m3"},
+	}
+	if _, err := s.AppendMessages(ctx, agent.AppendMessagesRequest{RunID: id, Messages: msgs}); err != nil {
+		t.Fatalf("AppendMessages: %v", err)
+	}
+	if _, err := s.AppendEvents(ctx, agent.AppendEventsRequest{RunID: id, Events: []agent.Event{{Kind: agent.EventTurnBegin}}}); err != nil {
+		t.Fatalf("AppendEvents: %v", err)
+	}
+
+	partial, err := s.ForkRun(ctx, agent.ForkRunRequest{RunID: id, AtMessage: 2})
+	if err != nil || !partial.Found || !partial.Created || partial.ForkPoint != 2 {
+		t.Fatalf("partial ForkRun = (%+v, %v), want Created with ForkPoint 2", partial, err)
+	}
+	run := mustLoad(t, s, partial.RunID)
+	if len(run.Messages) != 2 || run.Messages[1].Text != "m1" {
+		t.Fatalf("partial fork messages = %+v, want first 2", run.Messages)
+	}
+	if run.ForkPoint != 2 || run.ParentID != id {
+		t.Fatalf("partial fork lineage = (parent %q, forkPoint %d)", run.ParentID, run.ForkPoint)
+	}
+	if len(run.Events) != 0 {
+		t.Fatalf("partial fork copied events: %+v", run.Events)
+	}
+
+	clamped, err := s.ForkRun(ctx, agent.ForkRunRequest{RunID: id, AtMessage: 99})
+	if err != nil || clamped.ForkPoint != 4 {
+		t.Fatalf("clamped ForkRun = (%+v, %v), want ForkPoint 4", clamped, err)
+	}
+	run = mustLoad(t, s, clamped.RunID)
+	if len(run.Messages) != 4 || len(run.Events) != 1 {
+		t.Fatalf("clamped fork = %d messages / %d events, want full copy", len(run.Messages), len(run.Events))
+	}
+}


### PR DESCRIPTION
Closes #962. Top of the persistence follow-up chain: stacks on PR 967 (timestamps), which stacks on PR 961 (gorm backend). **This branch also merges in PR 965's atomic-fork commits** (the Redis fork-at-point extends 965's Lua script), so until 965 merges to main this PR's diff shows those commits too — review only the top two commits here (`Merge branch p1/963-fork-atomicity` + the fork-at-point commit); the rest collapse as 961/965/967 merge. **No CI while based on a non-main branch** — verified locally with `make test-agent` (all 9 sub-module runs) plus `make testpg` against a real Postgres 15 container.

## What changes

`ForkRun` can now cut at an earlier point: `ForkRunRequest.AtMessage = N` forks with only the first N messages (checkpoint/rewind semantics), and every fork records `ForkPoint` — the message count actually copied — on the `Run`, the `ForkRunResponse`, and each backend's lineage row. `host.Fork` gains the position argument and rewinds the in-memory history to match when cutting early. Zero/negative `AtMessage` is today's full copy, byte-for-byte.

## Reviewer's guide

Read in this order:
1. [agent/runstore.go](https://github.com/panyam/mcpkit/pull/968/files#diff-f2ebdb590e8817d70dfdc21e0169cecb55b6a3131172a87aaa59e57301ed2643) — the contract: `AtMessage` semantics (clamping, cut-observed-at-start, partial-forks-copy-no-events and why), `Run.ForkPoint` (count, not a timestamp — see decision log), `ForkRunResponse.ForkPoint`; then the in-memory implementation.
2. [agent/store/redis/runstore.go](https://github.com/panyam/mcpkit/pull/968/files#diff-b9f1c76ec08cf9411daf9fa0b9d8bbf81eca4a8a4702de0a3cca1220f7cdad44) — the Lua script gains a copy bound + events flag as ARGV; the cut point resolves from LLEN at fork initiation; `ForkPoint` rides the meta JSON.
3. [agent/store/gorm/runstore.go](https://github.com/panyam/mcpkit/pull/968/files#diff-5bbef7160565ce4fb2c227190f57eec12777484327dfba6fb1621f831a222a0c) — cut resolved by COUNT inside the fork transaction (so it is exact, not observed-at-start like Redis), `LIMIT n` on the message copy, `fork_point` column on `agent_runs`.
4. [agent/host/persistence.go](https://github.com/panyam/mcpkit/pull/968/files#diff-0eff5e5041fb67bd84e50d022d2c12f889b3a75f62e014198f357bb4b36d78ce) + [agent/host/app.go](https://github.com/panyam/mcpkit/pull/968/files#diff-89fb8e04b6e1e9d5f7f76958490ef158dee40e2cae92d87c04b408d893c84361) — `Fork(ctx, id, atMessage)`; partial forks reload the fork so history rewinds; REPL `/fork` passes 0.
5. Tests — `ForkAtPoint` per backend (partial cut, clamp, full-copy events) and `TestAppForkAtRewindsHistory` (the end-to-end rewind: fork at 2, next turn's model request contains exactly the first turn + the divergent input, original run untouched).

## Decision log

- **`ForkPoint`, not the issue's `ForkedAt`**: "-At" reads as a timestamp — review discussion confirmed the ambiguity directly. The fork's wall-clock moment is already the fork run's `CreatedAt`; this field is a position (message count), backend-neutral, never a storage seq.
- **Partial forks copy no events**: the audit stream has no reliable mapping from message index to event range (events interleave across parallel tool calls). A truncated-but-wrong event log is worse than an absent one; the message log is complete either way, which is all resume needs.
- **Cut point resolved at fork initiation (Redis) vs inside the tx (gorm)**: gorm gets the exact cut for free; Redis reads LLEN before the script so racing appends land after the cut — same observable semantics, documented on the request type.
- **`host.Fork` signature change** (`atMessage` param) rather than a new method: pre-1.0 module, one call site (REPL), and a second `ForkAt` method would drift.
- **Rewind = reload the fork** (`resumeLocked`) instead of slicing in-memory history: one code path owns "history matches the store", and it is the same path `/resume` already exercises.

## Risk / blast radius

- Affects: `ForkRun` in all three backends (the `AtMessage=0` path is the pre-existing behavior, pinned by every pre-existing fork test passing unchanged), `host.Fork` callers (signature).
- Tests: 4 new tests; existing fork suites (divergence, collision, retry-convergence, planted-garbage, atomicity) all green untouched. `agent_runs` gains a `fork_point` column — fresh-deploys-only convention, no migration recipe.
- Be paranoid about: the events-only-on-full-copy rule at the clamp boundary (`AtMessage=99` on a 4-message run IS a full copy and does carry events — tested), and the Redis LLEN-then-script window (documented, benign: fork-at-observed-length).

## Before / after

```
run standup: [m0 user] [m1 asst] [m2 user] [m3 asst]

before:  ForkRun{RunID: standup}                    -> copy of all 4, always
after:   ForkRun{RunID: standup, AtMessage: 2}      -> [m0, m1], ForkPoint=2, no events
         ForkRun{RunID: standup}                    -> all 4, ForkPoint=4, events copied
         host: /rewind flow = Fork(ctx, "", 2) then next turn diverges from m1
```

## Out of scope (deliberately deferred)

- REPL syntax for the position (`/fork @N`) — issue 962 left it TBD; the host API carries the capability
- Fork-at-a-timestamp (needs message timestamps as the picker input — PR 967 below this provides them; a surface can map time -> index and pass AtMessage)
- Event-log slicing for partial forks — revisit if a replay UI needs it
