### PR TITLE
feat(agent): tool-result offloading — OffloadingSource + ToolResultStore + read_tool_result

### DIFF
--- a/agent/offloading_source.go
+++ b/agent/offloading_source.go
@@ -1,0 +1,244 @@
+package agent
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+// ReadToolResultName is the reserved tool name OffloadingSource injects
+// so the model can fetch an offloaded result. A wrapped source that also
+// exposes this name is shadowed by the offloader's handler.
+const ReadToolResultName = "read_tool_result"
+
+// DefaultOffloadThreshold is the model-visible size (bytes of flattened
+// result text) at or above which a successful tool result is offloaded.
+// 4 KB keeps ordinary results inline while catching the file dumps and
+// long stdout that actually bloat context.
+const DefaultOffloadThreshold = 4096
+
+// DefaultOffloadPreview is how many leading characters of the flattened
+// result the stub carries inline, so the model can often act without a
+// read_tool_result round-trip at all.
+const DefaultOffloadPreview = 400
+
+// defaultReadLimit bounds a read_tool_result window when the caller does
+// not set limit — large enough to be useful, small enough to stay a
+// window rather than re-inlining the whole payload.
+const defaultReadLimit = 4000
+
+// OffloadConfig tunes an OffloadingSource. The zero value is usable
+// (default threshold and preview); only Store is required and is set by
+// the constructor, not here.
+type OffloadConfig struct {
+	// Threshold is the offload cutoff in bytes of flattened result text.
+	// Zero means DefaultOffloadThreshold. Results below it inline
+	// unchanged.
+	Threshold int
+
+	// PreviewLen is the leading-character count the stub carries. Zero
+	// means DefaultOffloadPreview.
+	PreviewLen int
+
+	// PerToolThreshold overrides Threshold for named tools. A present
+	// entry with value <= 0 pins that tool to never offload (always
+	// inline), whatever its size — the escape hatch for a tool whose
+	// full output the model must always see verbatim.
+	PerToolThreshold map[string]int
+}
+
+// OffloadingSource wraps a ToolSource so that large successful tool
+// results are stored out of band and replaced in the conversation by a
+// compact stub, with a read_tool_result tool for fetching the detail on
+// demand (the "just in time context" pattern). It composes exactly like
+// FilterSource: put it around the aggregate MultiSource and hand the
+// result to the Runner. No Runner change — the stub is a normal
+// ToolResult, so the RoleTool message, the tool-end event, and the
+// persisted log all carry the stub, keeping the log faithful to what the
+// model actually saw.
+//
+// Only successful results are offloaded: IsError results stay inline
+// (errors are usually short, and truncating one is worse than carrying
+// it). The stored blob keeps the full result including StructuredContent;
+// the stub is text-only.
+type OffloadingSource struct {
+	src   ToolSource
+	store ToolResultStore
+	cfg   OffloadConfig
+	read  *FuncSource
+}
+
+// readToolResultArgs is the read_tool_result input. Offset/Limit take a
+// character window over the flattened result; Pattern greps it line by
+// line (a Go regexp) — querying *into* a huge output, which is where the
+// win is, rather than paging the whole thing back.
+type readToolResultArgs struct {
+	Ref     string `json:"ref"`
+	Offset  int    `json:"offset,omitempty"`
+	Limit   int    `json:"limit,omitempty"`
+	Pattern string `json:"pattern,omitempty"`
+}
+
+// NewOffloadingSource wraps src, offloading over-threshold results into
+// store. Store is required; a nil store panics at construction rather
+// than silently dropping results at call time.
+func NewOffloadingSource(src ToolSource, store ToolResultStore, cfg OffloadConfig) *OffloadingSource {
+	if store == nil {
+		panic("agent: NewOffloadingSource requires a non-nil ToolResultStore")
+	}
+	if cfg.Threshold == 0 {
+		cfg.Threshold = DefaultOffloadThreshold
+	}
+	if cfg.PreviewLen == 0 {
+		cfg.PreviewLen = DefaultOffloadPreview
+	}
+	o := &OffloadingSource{src: src, store: store, cfg: cfg, read: NewFuncSource()}
+	// Registration cannot fail for a fresh FuncSource with one unique
+	// name; ignore the error to keep the constructor total.
+	_ = AddFunc(o.read, ReadToolResultName,
+		"Fetch a previously offloaded tool result by its ref. Give offset+limit for a character window, or pattern (a regular expression) to return only matching lines. Refs appear in tool-result stubs like [tool result 52KB, stored as res:ab12].",
+		o.readToolResult)
+	return o
+}
+
+// Tools lists the wrapped source's tools plus read_tool_result. The read
+// tool is always offered while offloading is active, since a stub can
+// appear on any call.
+func (o *OffloadingSource) Tools(ctx context.Context) ([]core.ToolDef, error) {
+	defs, err := o.src.Tools(ctx)
+	if err != nil {
+		return nil, err
+	}
+	readDefs, _ := o.read.Tools(ctx)
+	return append(defs, readDefs...), nil
+}
+
+// Call routes read_tool_result to the offloader's own handler and every
+// other name to the wrapped source, offloading the result when it is a
+// successful over-threshold payload.
+func (o *OffloadingSource) Call(ctx context.Context, name string, args map[string]any) (*core.ToolResult, error) {
+	if name == ReadToolResultName {
+		return o.read.Call(ctx, name, args)
+	}
+	res, err := o.src.Call(ctx, name, args)
+	if err != nil || res == nil {
+		return res, err
+	}
+	return o.maybeOffload(ctx, name, res)
+}
+
+// maybeOffload stores an over-threshold successful result and returns the
+// stub; otherwise it returns the result unchanged.
+func (o *OffloadingSource) maybeOffload(ctx context.Context, name string, res *core.ToolResult) (*core.ToolResult, error) {
+	if res.IsError {
+		return res, nil
+	}
+	threshold := o.cfg.Threshold
+	if t, ok := o.cfg.PerToolThreshold[name]; ok {
+		if t <= 0 {
+			return res, nil // pinned inline
+		}
+		threshold = t
+	}
+	text := toolResultText(res)
+	if len(text) < threshold {
+		return res, nil
+	}
+	ref, err := newResultRef()
+	if err != nil {
+		// Minting failed (no entropy): fall back to inlining rather than
+		// losing the result. Rare enough not to warrant a louder path.
+		return res, nil
+	}
+	if _, err := o.store.PutToolResult(ctx, PutToolResultRequest{Ref: ref, Result: *res}); err != nil {
+		return nil, fmt.Errorf("agent: offloading %q result: %w", name, err)
+	}
+	return &core.ToolResult{
+		Content: []core.Content{{Type: "text", Text: o.stub(ref, text)}},
+	}, nil
+}
+
+// stub renders the model-visible placeholder that replaces an offloaded
+// result: size, ref, a leading preview, and the retrieval instruction.
+func (o *OffloadingSource) stub(ref, text string) string {
+	preview := text
+	truncated := false
+	if len(preview) > o.cfg.PreviewLen {
+		preview = preview[:o.cfg.PreviewLen]
+		truncated = true
+	}
+	ellipsis := ""
+	if truncated {
+		ellipsis = "…"
+	}
+	return fmt.Sprintf("[tool result %dB, stored as %s]\npreview: %s%s\ncall %s(ref=%q) for the full output — add offset+limit for a window or pattern to grep.",
+		len(text), ref, preview, ellipsis, ReadToolResultName, ref)
+}
+
+// readToolResult serves a window or grep over an offloaded result. An
+// unknown ref is a graceful (non-error) answer, since a stub can outlive
+// its blob once a backend evicts it.
+func (o *OffloadingSource) readToolResult(ctx context.Context, in readToolResultArgs) (string, error) {
+	resp, err := o.store.GetToolResult(ctx, GetToolResultRequest{Ref: in.Ref})
+	if err != nil {
+		return "", fmt.Errorf("reading tool result %q: %w", in.Ref, err)
+	}
+	if !resp.Found {
+		return fmt.Sprintf("tool result %q is no longer available (expired or evicted); re-run the tool if you still need it.", in.Ref), nil
+	}
+	text := toolResultText(&resp.Result)
+
+	if in.Pattern != "" {
+		re, err := regexp.Compile(in.Pattern)
+		if err != nil {
+			return "", fmt.Errorf("invalid pattern %q: %w", in.Pattern, err)
+		}
+		var matches []string
+		for _, line := range strings.Split(text, "\n") {
+			if re.MatchString(line) {
+				matches = append(matches, line)
+			}
+		}
+		if len(matches) == 0 {
+			return fmt.Sprintf("no lines in %s match %q.", in.Ref, in.Pattern), nil
+		}
+		return strings.Join(matches, "\n"), nil
+	}
+
+	offset := in.Offset
+	if offset < 0 {
+		offset = 0
+	}
+	if offset >= len(text) {
+		return fmt.Sprintf("offset %d is past the end of %s (%d chars).", offset, in.Ref, len(text)), nil
+	}
+	limit := in.Limit
+	if limit <= 0 {
+		limit = defaultReadLimit
+	}
+	end := offset + limit
+	if end > len(text) {
+		end = len(text)
+	}
+	window := text[offset:end]
+	if end < len(text) {
+		window += fmt.Sprintf("\n… (%d more chars; call again with offset=%d)", len(text)-end, end)
+	}
+	return window, nil
+}
+
+// newResultRef mints an opaque, collision-resistant ref for a stored
+// result. 4 random bytes (8 hex chars) is ample within one store's
+// lifetime; the store never relies on ref structure.
+func newResultRef() (string, error) {
+	var b [4]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return "res:" + hex.EncodeToString(b[:]), nil
+}

--- a/agent/offloading_source_test.go
+++ b/agent/offloading_source_test.go
@@ -1,0 +1,206 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+// scriptedSource is a ToolSource whose Call returns a fixed result, for
+// driving OffloadingSource without a real MCP server.
+type scriptedSource struct {
+	def    core.ToolDef
+	result core.ToolResult
+	err    error
+}
+
+func (s *scriptedSource) Tools(context.Context) ([]core.ToolDef, error) {
+	return []core.ToolDef{s.def}, nil
+}
+func (s *scriptedSource) Call(context.Context, string, map[string]any) (*core.ToolResult, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	r := s.result
+	return &r, nil
+}
+
+func newOffloader(t *testing.T, result core.ToolResult, cfg OffloadConfig) (*OffloadingSource, *InMemoryToolResultStore) {
+	t.Helper()
+	store := NewInMemoryToolResultStore()
+	src := &scriptedSource{def: core.ToolDef{Name: "dump"}, result: result}
+	return NewOffloadingSource(src, store, cfg), store
+}
+
+func callDump(t *testing.T, o *OffloadingSource) *core.ToolResult {
+	t.Helper()
+	res, err := o.Call(context.Background(), "dump", nil)
+	if err != nil {
+		t.Fatalf("Call(dump): %v", err)
+	}
+	return res
+}
+
+func TestOffloadingSource_SmallResultInlineUnchanged(t *testing.T) {
+	o, store := newOffloader(t, textResult("short"), OffloadConfig{Threshold: 100})
+	res := callDump(t, o)
+	if toolResultText(res) != "short" {
+		t.Fatalf("small result was altered: %q", toolResultText(res))
+	}
+	// nothing stored
+	if resp, _ := store.GetToolResult(context.Background(), GetToolResultRequest{Ref: "res:anything"}); resp.Found {
+		t.Fatal("small result should not have been offloaded")
+	}
+}
+
+func TestOffloadingSource_LargeResultStubbedAndStored(t *testing.T) {
+	big := strings.Repeat("x", 5000)
+	o, store := newOffloader(t, textResult(big), OffloadConfig{Threshold: 4096, PreviewLen: 20})
+	res := callDump(t, o)
+	stub := toolResultText(res)
+
+	if strings.Contains(stub, big) {
+		t.Fatal("stub still contains the full payload")
+	}
+	if !strings.Contains(stub, "5000B") || !strings.Contains(stub, ReadToolResultName) {
+		t.Fatalf("stub missing size or retrieval instruction: %q", stub)
+	}
+	// preview is bounded
+	if strings.Count(stub, "x") > 20+2 {
+		t.Fatalf("preview exceeded PreviewLen: %q", stub)
+	}
+
+	// the ref in the stub resolves to the full result
+	ref := extractRef(t, stub)
+	resp, err := store.GetToolResult(context.Background(), GetToolResultRequest{Ref: ref})
+	if err != nil || !resp.Found {
+		t.Fatalf("stored ref %q not found: %v", ref, err)
+	}
+	if toolResultText(&resp.Result) != big {
+		t.Fatal("stored result does not match the original payload")
+	}
+}
+
+// TestOffloadingSource_StubIsFaithful pins the log-fidelity property: the
+// bytes fed back to the model (the stub) are exactly what a persisted
+// RoleTool message would carry, so resume replays what the model saw.
+func TestOffloadingSource_StubIsFaithful(t *testing.T) {
+	o, _ := newOffloader(t, textResult(strings.Repeat("y", 5000)), OffloadConfig{})
+	res := callDump(t, o)
+	if res.IsError {
+		t.Fatal("stub marked IsError")
+	}
+	if len(res.Content) != 1 || res.Content[0].Type != "text" {
+		t.Fatalf("stub is not a single text content: %+v", res.Content)
+	}
+	if res.StructuredContent != nil {
+		t.Fatal("stub leaked structured content (should live in the blob only)")
+	}
+}
+
+func TestOffloadingSource_ErrorResultStaysInline(t *testing.T) {
+	big := strings.Repeat("z", 5000)
+	o, store := newOffloader(t, core.ToolResult{IsError: true, Content: []core.Content{{Type: "text", Text: big}}}, OffloadConfig{Threshold: 100})
+	res := callDump(t, o)
+	if !res.IsError || toolResultText(res) != big {
+		t.Fatal("error result was offloaded; errors must stay inline")
+	}
+	_ = store
+}
+
+func TestOffloadingSource_PerToolPinnedInline(t *testing.T) {
+	big := strings.Repeat("q", 5000)
+	o, _ := newOffloader(t, textResult(big), OffloadConfig{
+		Threshold:        100,
+		PerToolThreshold: map[string]int{"dump": 0},
+	})
+	if toolResultText(callDump(t, o)) != big {
+		t.Fatal("per-tool pin (threshold 0) should keep the result inline")
+	}
+}
+
+func TestOffloadingSource_ReadWindowAndGrep(t *testing.T) {
+	lines := []string{"alpha 1", "beta 2", "alpha 3", "gamma 4"}
+	payload := strings.Join(lines, "\n") + strings.Repeat(" tail", 2000)
+	o, _ := newOffloader(t, textResult(payload), OffloadConfig{Threshold: 100, PreviewLen: 10})
+	stub := toolResultText(callDump(t, o))
+	ref := extractRef(t, stub)
+
+	// grep
+	grep, err := o.Call(context.Background(), ReadToolResultName, map[string]any{"ref": ref, "pattern": "^alpha"})
+	if err != nil {
+		t.Fatalf("read grep: %v", err)
+	}
+	gt := toolResultText(grep)
+	if !strings.Contains(gt, "alpha 1") || !strings.Contains(gt, "alpha 3") || strings.Contains(gt, "beta") {
+		t.Fatalf("grep returned wrong lines: %q", gt)
+	}
+
+	// window
+	win, err := o.Call(context.Background(), ReadToolResultName, map[string]any{"ref": ref, "offset": float64(0), "limit": float64(5)})
+	if err != nil {
+		t.Fatalf("read window: %v", err)
+	}
+	wt := toolResultText(win)
+	if !strings.HasPrefix(wt, "alpha") || !strings.Contains(wt, "more chars") {
+		t.Fatalf("window did not return a bounded prefix with continuation: %q", wt)
+	}
+}
+
+func TestOffloadingSource_ReadUnknownRefGraceful(t *testing.T) {
+	o, _ := newOffloader(t, textResult("x"), OffloadConfig{})
+	res, err := o.Call(context.Background(), ReadToolResultName, map[string]any{"ref": "res:gone"})
+	if err != nil {
+		t.Fatalf("read unknown ref errored instead of degrading: %v", err)
+	}
+	if res.IsError {
+		t.Fatal("unknown ref should be a graceful non-error answer")
+	}
+	if !strings.Contains(toolResultText(res), "no longer available") {
+		t.Fatalf("unexpected graceful message: %q", toolResultText(res))
+	}
+}
+
+func TestOffloadingSource_ToolsIncludesReadTool(t *testing.T) {
+	o, _ := newOffloader(t, textResult("x"), OffloadConfig{})
+	defs, err := o.Tools(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var names []string
+	for _, d := range defs {
+		names = append(names, d.Name)
+	}
+	if !contains(names, "dump") || !contains(names, ReadToolResultName) {
+		t.Fatalf("Tools() = %v, want both dump and %s", names, ReadToolResultName)
+	}
+}
+
+func contains(ss []string, s string) bool {
+	for _, x := range ss {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}
+
+// extractRef pulls the "res:xxxx" token out of a stub.
+func extractRef(t *testing.T, stub string) string {
+	t.Helper()
+	i := strings.Index(stub, "res:")
+	if i < 0 {
+		t.Fatalf("no ref in stub: %q", stub)
+	}
+	end := i + 4
+	for end < len(stub) && isHexish(stub[end]) {
+		end++
+	}
+	return stub[i:end]
+}
+
+func isHexish(b byte) bool {
+	return (b >= '0' && b <= '9') || (b >= 'a' && b <= 'f')
+}

--- a/agent/toolresultstore.go
+++ b/agent/toolresultstore.go
@@ -1,0 +1,140 @@
+package agent
+
+import (
+	"container/list"
+	"context"
+	"sync"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+// ToolResultStore is the persistence seam for offloaded tool results:
+// full tool outputs an OffloadingSource stored out of band, keyed by a
+// ref, so the conversation carries only a compact stub and the model
+// fetches the detail on demand (read_tool_result). It is the "just in
+// time context" primitive — lossless, pay-on-lookup — complementary to
+// compaction, which is lossy and pays unconditionally.
+//
+// API shape follows the gRPC-style convention pinned in
+// stores/STORAGE_SEAMS.md: Method(ctx, req) (resp, error), app-state on
+// the response, error reserved for storage-layer faults. In particular
+// an unknown ref is app-state (Found=false), never an error — a stub
+// can legitimately outlive its blob once a backend evicts it, and
+// read_tool_result turns Found=false into a graceful "no longer
+// available" answer rather than a failure.
+//
+// The interface and its in-memory default live in agent/ because they
+// traffic in core.ToolResult and pair with the agent-only
+// OffloadingSource (A6). Durable backends are sibling modules
+// (agent/store/redis, agent/store/gorm), where retention is a
+// per-backend construction concern (native TTL, a GC sweep, an LRU cap)
+// — never part of this contract, which is exactly why the read path is
+// built to tolerate eviction.
+type ToolResultStore interface {
+	// PutToolResult stores a result and returns nothing beyond error.
+	// Refs are caller-assigned (OffloadingSource mints them) and
+	// treated as opaque; storing the same ref twice overwrites, but
+	// callers never reuse a ref, so that path is not relied upon.
+	PutToolResult(ctx context.Context, req PutToolResultRequest) (PutToolResultResponse, error)
+
+	// GetToolResult fetches a result by ref. Found=false means the ref
+	// is unknown (never stored, or evicted) — the caller's cue to
+	// degrade gracefully, not an error.
+	GetToolResult(ctx context.Context, req GetToolResultRequest) (GetToolResultResponse, error)
+}
+
+// PutToolResultRequest carries the ref and the full result to retain.
+type PutToolResultRequest struct {
+	Ref    string
+	Result core.ToolResult
+}
+
+// PutToolResultResponse is empty today; it exists so the method can grow
+// app-state (an assigned ref, a stored-bytes count) without a signature
+// break, per the gRPC-style convention.
+type PutToolResultResponse struct{}
+
+// GetToolResultRequest fetches by ref.
+type GetToolResultRequest struct {
+	Ref string
+}
+
+// GetToolResultResponse carries the result when Found. The returned
+// value is the caller's own copy; in-memory implementations return the
+// stored value (results are treated as immutable once stored, so no
+// clone is needed — OffloadingSource never mutates a stored result).
+type GetToolResultResponse struct {
+	Result core.ToolResult
+	Found  bool
+}
+
+// InMemoryToolResultStore is the default ToolResultStore: a
+// mutex-guarded map, safe for concurrent use. Nothing survives process
+// exit — durable deployments swap in a sibling backend behind the same
+// interface. An optional entry cap (WithMaxToolResults) evicts the
+// least-recently-stored ref when exceeded; the graceful read contract
+// makes that eviction safe. Default is unbounded.
+type InMemoryToolResultStore struct {
+	mu      sync.Mutex
+	results map[string]core.ToolResult
+	// order tracks insertion order for the LRU cap; front is oldest.
+	// nil when maxEntries == 0 (unbounded, no bookkeeping).
+	order      *list.List
+	elems      map[string]*list.Element
+	maxEntries int
+}
+
+// ToolResultStoreOption configures an InMemoryToolResultStore.
+type ToolResultStoreOption func(*InMemoryToolResultStore)
+
+// WithMaxToolResults caps the store at n stored results, evicting the
+// oldest when a Put would exceed n. Zero or negative means unbounded
+// (the default). Eviction is safe because read_tool_result degrades an
+// unknown ref to a "no longer available" answer rather than an error.
+func WithMaxToolResults(n int) ToolResultStoreOption {
+	return func(s *InMemoryToolResultStore) {
+		if n > 0 {
+			s.maxEntries = n
+			s.order = list.New()
+			s.elems = map[string]*list.Element{}
+		}
+	}
+}
+
+// NewInMemoryToolResultStore returns an empty in-memory store.
+func NewInMemoryToolResultStore(opts ...ToolResultStoreOption) *InMemoryToolResultStore {
+	s := &InMemoryToolResultStore{results: map[string]core.ToolResult{}}
+	for _, o := range opts {
+		o(s)
+	}
+	return s
+}
+
+// PutToolResult implements ToolResultStore.
+func (s *InMemoryToolResultStore) PutToolResult(ctx context.Context, req PutToolResultRequest) (PutToolResultResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.results[req.Ref]; !exists && s.order != nil {
+		s.elems[req.Ref] = s.order.PushBack(req.Ref)
+		for s.order.Len() > s.maxEntries {
+			oldest := s.order.Front()
+			ref := oldest.Value.(string)
+			s.order.Remove(oldest)
+			delete(s.elems, ref)
+			delete(s.results, ref)
+		}
+	}
+	s.results[req.Ref] = req.Result
+	return PutToolResultResponse{}, nil
+}
+
+// GetToolResult implements ToolResultStore.
+func (s *InMemoryToolResultStore) GetToolResult(ctx context.Context, req GetToolResultRequest) (GetToolResultResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	res, ok := s.results[req.Ref]
+	if !ok {
+		return GetToolResultResponse{}, nil
+	}
+	return GetToolResultResponse{Result: res, Found: true}, nil
+}

--- a/agent/toolresultstore_test.go
+++ b/agent/toolresultstore_test.go
@@ -1,0 +1,69 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+func textResult(s string) core.ToolResult {
+	return core.ToolResult{Content: []core.Content{{Type: "text", Text: s}}}
+}
+
+func TestInMemoryToolResultStore_PutGet(t *testing.T) {
+	ctx := context.Background()
+	s := NewInMemoryToolResultStore()
+
+	if _, err := s.PutToolResult(ctx, PutToolResultRequest{Ref: "res:a", Result: textResult("hello")}); err != nil {
+		t.Fatalf("PutToolResult: %v", err)
+	}
+	resp, err := s.GetToolResult(ctx, GetToolResultRequest{Ref: "res:a"})
+	if err != nil || !resp.Found {
+		t.Fatalf("GetToolResult = (%+v, %v)", resp, err)
+	}
+	if toolResultText(&resp.Result) != "hello" {
+		t.Fatalf("stored result = %q", toolResultText(&resp.Result))
+	}
+}
+
+func TestInMemoryToolResultStore_UnknownRefIsAppState(t *testing.T) {
+	resp, err := NewInMemoryToolResultStore().GetToolResult(context.Background(), GetToolResultRequest{Ref: "res:nope"})
+	if err != nil || resp.Found {
+		t.Fatalf("Get(unknown) = (%+v, %v), want Found=false, nil error", resp, err)
+	}
+}
+
+func TestInMemoryToolResultStore_MaxEntriesEvictsOldest(t *testing.T) {
+	ctx := context.Background()
+	s := NewInMemoryToolResultStore(WithMaxToolResults(2))
+
+	for _, ref := range []string{"res:1", "res:2", "res:3"} {
+		if _, err := s.PutToolResult(ctx, PutToolResultRequest{Ref: ref, Result: textResult(ref)}); err != nil {
+			t.Fatalf("Put %s: %v", ref, err)
+		}
+	}
+
+	if resp, _ := s.GetToolResult(ctx, GetToolResultRequest{Ref: "res:1"}); resp.Found {
+		t.Fatal("res:1 should have been evicted as the oldest")
+	}
+	for _, ref := range []string{"res:2", "res:3"} {
+		if resp, _ := s.GetToolResult(ctx, GetToolResultRequest{Ref: ref}); !resp.Found {
+			t.Fatalf("%s should still be present under the cap", ref)
+		}
+	}
+}
+
+func TestInMemoryToolResultStore_UnboundedByDefault(t *testing.T) {
+	ctx := context.Background()
+	s := NewInMemoryToolResultStore()
+	for i := 0; i < 50; i++ {
+		ref := "res:" + string(rune('a'+i%26)) + string(rune('0'+i/26))
+		if _, err := s.PutToolResult(ctx, PutToolResultRequest{Ref: ref, Result: textResult(ref)}); err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+	}
+	if resp, _ := s.GetToolResult(ctx, GetToolResultRequest{Ref: "res:a0"}); !resp.Found {
+		t.Fatal("first entry evicted despite unbounded default")
+	}
+}


### PR DESCRIPTION
Closes #966. Phase 2 opener (memory), based on `main` so it has CI directly. Lossless and self-contained — no Runner change, `agent/`-only.

## What changes

Large successful tool results no longer bloat the conversation forever. `OffloadingSource` wraps a `ToolSource` (exactly like `FilterSource`); when a result crosses a byte threshold it stores the full payload out of band in a `ToolResultStore` and returns a compact **stub** in its place, plus a `read_tool_result` tool so the model fetches detail on demand (a character window, or a regex grep *into* the output). This is the just-in-time-context pattern: lossless and pay-on-lookup, complementary to compaction (lossy, pays unconditionally) which comes later in Phase 2.

## Reviewer's guide

Read in this order:
1. [agent/toolresultstore.go](https://github.com/panyam/mcpkit/pull/970/files#diff-2c84031c38fbaba78ee728ddf79ccee089c7f9e728ca268ca40b1781bd7e6cdd) — the seam: `ToolResultStore` interface (`Put`/`Get`, gRPC-style, A6 doc explaining why retention is deliberately *not* in the contract) + `InMemoryToolResultStore` with an optional `WithMaxToolResults` LRU cap.
2. [agent/offloading_source.go](https://github.com/panyam/mcpkit/pull/970/files#diff-f42a399860113a8eb11efcbacfad7822909504b9860301fb2beb86495002d9c3) — the wrapper. `Call` routing (read tool vs delegate), `maybeOffload` (the threshold/store/stub decision), `stub` formatting, and `readToolResult` (window / grep / graceful-expired).
3. [agent/offloading_source_test.go](https://github.com/panyam/mcpkit/pull/970/files#diff-4f865964f2e04cb89be9220c48d3e07c3cb9036fd5e3fdc5fe9d0f7df29944a9) — small-inline, large-stubbed-and-stored, **stub-is-faithful** (the fidelity pin), error-stays-inline, per-tool pin, window+grep, unknown-ref-graceful.
4. [agent/toolresultstore_test.go](https://github.com/panyam/mcpkit/pull/970/files#diff-47e7dd94a44abfda915e5584b187d5b755ba84816ffc85ad673878626eba0eee) — put/get, unknown-ref app-state, LRU eviction, unbounded default.

## How it works

```
OffloadingSource.Call(name, args):
  if name == read_tool_result -> serve window/grep from store (below)
  res = wrapped.Call(...)
  if res.IsError -> inline (errors stay visible)
  threshold = perTool[name] (0 => pinned inline) else default 4KB
  text = toolResultText(res)                 # exactly what enters context
  if len(text) < threshold -> inline unchanged
  ref = "res:" + random
  store.Put(ref, full res)                   # blob keeps StructuredContent too
  return ToolResult{ text: stub(ref, preview) }   # <- becomes the RoleTool msg + tool-end event

read_tool_result(ref, offset?, limit?, pattern?):
  r = store.Get(ref)
  if !found -> "no longer available (expired or evicted)"  # IsError:false, model re-plans
  text = toolResultText(r)
  pattern set -> return regex-matching lines
  else -> text[offset : offset+limit] (+ "N more chars, offset=..." continuation)
```

## Decision log

- **Stub replaces the returned `ToolResult`**, so it propagates to the RoleTool message, the tool-end event, and the persisted log for free — the log stays faithful to what the model actually saw (pinned by `StubIsFaithful`). This also delivers the event-log dedup the issue wanted, with no PersistingEmit change.
- **Retention is not in the interface.** Each backend owns its own eviction (redis TTL, gorm GC sweep, in-memory LRU); the contract only promises `Get(unknown) => Found=false`, and `read_tool_result` degrades that to a graceful answer. That read contract is *what makes any retention policy safe* — the answer to "can retention be customizable" is "yes, because the interface never commits to one."
- **Success-only.** `IsError` results stay inline: errors are usually short and truncating one is worse than carrying it.
- **In-memory store only this PR.** Durable redis/gorm backends (which unlock fork-blob-sharing and cross-restart refs) are a mechanical follow-up, mirroring how the RunStore backends followed its interface. Delivers in-session context-bloat reduction now.
- **Ref is `res:<random>`, not `res:<callID>`** — the `ToolSource.Call` signature doesn't carry the call ID; a random opaque ref is all the store needs.

## Risk / blast radius

- Affects: nothing until a host wraps its sources with `OffloadingSource` (opt-in; host wiring is the next PR). Zero change to the Runner, existing sources, or any current behavior.
- Tests: 12 new (8 offloading, 4 store); red-before-green verified on the offload path. `make test-agent` green (9/9). 0 assertions removed or weakened.
- Be paranoid about: the fidelity property (stub == persisted RoleTool text), and the grace path (a stub must never turn into a hard error when its blob is gone).

## Before / after

Model-visible RoleTool text for a 5 KB file dump:
```
before:  <5000 chars of file contents, in context for the rest of the session>
after:   [tool result 5000B, stored as res:a3f2c1]
         preview: package main\n\nimport (\n  "fmt"…
         call read_tool_result(ref="res:a3f2c1") for the full output — add offset+limit for a window or pattern to grep.
```

## Out of scope (deliberately deferred, will file after merge)

- Durable backends `agent/store/redis` + `agent/store/gorm` (blob key/table, `WithKeyPrefix`/`WithTableName` so it slots into an existing DB) — the fork-blob-sharing win lands here
- `agent/host` `Config.Offload` wiring + agentchat flag
- `turn-end` `Result.Messages` redaction (the other half of event-log dedup)
- LongMemEval-derived eval bar for the memory phase
