### PR TITLE
feat(agent/store): durable ToolResultStore backends (redis + gorm blob)

### DIFF
--- a/agent/store/gorm/toolresult.go
+++ b/agent/store/gorm/toolresult.go
@@ -1,0 +1,143 @@
+package gormstore
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+
+	"github.com/panyam/mcpkit/agent"
+	"github.com/panyam/mcpkit/core"
+)
+
+// DefaultToolResultTable is the table a ToolResultStore uses when
+// WithToolResultTableName is not set.
+const DefaultToolResultTable = "agent_tool_results"
+
+// toolResultRow is one offloaded result, JSON-encoded. StoredAt anchors
+// retention (see PruneExpired). The table name is resolved at runtime
+// via db.Table so a deployment can point the store at a table of its
+// choosing inside an existing database.
+type toolResultRow struct {
+	Ref      string    `gorm:"primaryKey"`
+	Body     string    `gorm:"type:jsonb;not null"`
+	StoredAt time.Time `gorm:"not null;index"`
+}
+
+// ToolResultStore is the durable GORM backend for agent.ToolResultStore
+// (Postgres or SQLite). One row per ref in a configurable table, so it
+// drops into an already-running database alongside other tables or
+// stands alone. Retention is a caller-driven GC sweep (PruneExpired over
+// a WithToolResultRetention window); eviction is safe because the
+// interface's unknown-ref contract degrades gracefully at read time.
+type ToolResultStore struct {
+	db        *gorm.DB
+	table     string
+	retention time.Duration
+}
+
+var _ agent.ToolResultStore = (*ToolResultStore)(nil)
+
+type toolResultConfig struct {
+	skipAutoMigrate bool
+	table           string
+	retention       time.Duration
+}
+
+// ToolResultOption customizes a ToolResultStore. Distinct from the
+// RunStore Option type so the two stores' options never mix.
+type ToolResultOption func(*toolResultConfig)
+
+// WithToolResultTableName points the store at a specific table, so it can
+// live inside an existing schema next to unrelated tables. Empty keeps
+// DefaultToolResultTable.
+func WithToolResultTableName(name string) ToolResultOption {
+	return func(c *toolResultConfig) {
+		if name != "" {
+			c.table = name
+		}
+	}
+}
+
+// WithoutToolResultAutoMigrate disables the AutoMigrate call at
+// construction, for deployments whose schema is managed out of band.
+func WithoutToolResultAutoMigrate() ToolResultOption {
+	return func(c *toolResultConfig) { c.skipAutoMigrate = true }
+}
+
+// WithToolResultRetention sets the age past which PruneExpired deletes a
+// stored result. Zero (the default) means keep forever (PruneExpired is
+// then a no-op). Retention is caller-driven: the store does not run a
+// background sweeper, so a host or operator calls PruneExpired on its own
+// cadence.
+func WithToolResultRetention(window time.Duration) ToolResultOption {
+	return func(c *toolResultConfig) { c.retention = window }
+}
+
+// NewToolResultStore returns a store over db, running AutoMigrate for the
+// results table unless WithoutToolResultAutoMigrate is passed. The db
+// handle is shared, not owned.
+func NewToolResultStore(db *gorm.DB, opts ...ToolResultOption) (*ToolResultStore, error) {
+	cfg := &toolResultConfig{table: DefaultToolResultTable}
+	for _, o := range opts {
+		o(cfg)
+	}
+	if !cfg.skipAutoMigrate {
+		if err := db.Table(cfg.table).AutoMigrate(&toolResultRow{}); err != nil {
+			return nil, fmt.Errorf("gormstore: automigrate tool results: %w", err)
+		}
+	}
+	return &ToolResultStore{db: db, table: cfg.table, retention: cfg.retention}, nil
+}
+
+// PutToolResult implements agent.ToolResultStore. Storing the same ref
+// twice upserts; callers never reuse a ref.
+func (s *ToolResultStore) PutToolResult(ctx context.Context, req agent.PutToolResultRequest) (agent.PutToolResultResponse, error) {
+	body, err := json.Marshal(req.Result)
+	if err != nil {
+		return agent.PutToolResultResponse{}, fmt.Errorf("gormstore: encoding tool result: %w", err)
+	}
+	row := toolResultRow{Ref: req.Ref, Body: string(body), StoredAt: time.Now().UTC()}
+	err = s.db.WithContext(ctx).Table(s.table).
+		Clauses(clause.OnConflict{Columns: []clause.Column{{Name: "ref"}}, UpdateAll: true}).
+		Create(&row).Error
+	if err != nil {
+		return agent.PutToolResultResponse{}, err
+	}
+	return agent.PutToolResultResponse{}, nil
+}
+
+// GetToolResult implements agent.ToolResultStore. A missing row (never
+// stored, or pruned) is Found=false, not an error.
+func (s *ToolResultStore) GetToolResult(ctx context.Context, req agent.GetToolResultRequest) (agent.GetToolResultResponse, error) {
+	var row toolResultRow
+	err := s.db.WithContext(ctx).Table(s.table).First(&row, "ref = ?", req.Ref).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return agent.GetToolResultResponse{}, nil
+	}
+	if err != nil {
+		return agent.GetToolResultResponse{}, err
+	}
+	var result core.ToolResult
+	if err := json.Unmarshal([]byte(row.Body), &result); err != nil {
+		return agent.GetToolResultResponse{}, fmt.Errorf("gormstore: corrupt tool result %q: %w", req.Ref, err)
+	}
+	return agent.GetToolResultResponse{Result: result, Found: true}, nil
+}
+
+// PruneExpired deletes results older than the WithToolResultRetention
+// window and returns how many rows it removed. A no-op (0, nil) when no
+// retention window is configured. Call it on a cadence a host or cron
+// owns; the store never sweeps on its own.
+func (s *ToolResultStore) PruneExpired(ctx context.Context) (int, error) {
+	if s.retention <= 0 {
+		return 0, nil
+	}
+	cutoff := time.Now().UTC().Add(-s.retention)
+	res := s.db.WithContext(ctx).Table(s.table).Where("stored_at < ?", cutoff).Delete(&toolResultRow{})
+	return int(res.RowsAffected), res.Error
+}

--- a/agent/store/gorm/toolresult_test.go
+++ b/agent/store/gorm/toolresult_test.go
@@ -1,0 +1,132 @@
+package gormstore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"gorm.io/gorm"
+
+	"github.com/panyam/mcpkit/agent"
+	"github.com/panyam/mcpkit/core"
+)
+
+func forEachToolResultBackend(t *testing.T, run func(t *testing.T, s *ToolResultStore, db *gorm.DB)) {
+	t.Helper()
+	t.Run("sqlite", func(t *testing.T) {
+		db := openSQLite(t)
+		run(t, newTRStore(t, db), db)
+	})
+	if dsn := postgresDSN(); dsn != "" {
+		t.Run("postgres", func(t *testing.T) {
+			db := openPostgres(t, dsn)
+			run(t, newTRStore(t, db), db)
+		})
+	}
+}
+
+func newTRStore(t *testing.T, db *gorm.DB, opts ...ToolResultOption) *ToolResultStore {
+	t.Helper()
+	s, err := NewToolResultStore(db, opts...)
+	if err != nil {
+		t.Fatalf("NewToolResultStore: %v", err)
+	}
+	return s
+}
+
+func trText(s string) core.ToolResult {
+	return core.ToolResult{Content: []core.Content{{Type: "text", Text: s}}}
+}
+
+func TestGormToolResultStore_PutGet(t *testing.T) {
+	forEachToolResultBackend(t, func(t *testing.T, s *ToolResultStore, _ *gorm.DB) {
+		ctx := context.Background()
+		if _, err := s.PutToolResult(ctx, agent.PutToolResultRequest{Ref: "res:a", Result: trText("payload")}); err != nil {
+			t.Fatalf("PutToolResult: %v", err)
+		}
+		resp, err := s.GetToolResult(ctx, agent.GetToolResultRequest{Ref: "res:a"})
+		if err != nil || !resp.Found {
+			t.Fatalf("GetToolResult = (%+v, %v)", resp, err)
+		}
+		if resp.Result.Content[0].Text != "payload" {
+			t.Fatalf("round-trip lost content: %+v", resp.Result)
+		}
+	})
+}
+
+func TestGormToolResultStore_UnknownRefIsAppState(t *testing.T) {
+	forEachToolResultBackend(t, func(t *testing.T, s *ToolResultStore, _ *gorm.DB) {
+		resp, err := s.GetToolResult(context.Background(), agent.GetToolResultRequest{Ref: "res:gone"})
+		if err != nil || resp.Found {
+			t.Fatalf("Get(unknown) = (%+v, %v), want Found=false, nil error", resp, err)
+		}
+	})
+}
+
+func TestGormToolResultStore_Upsert(t *testing.T) {
+	forEachToolResultBackend(t, func(t *testing.T, s *ToolResultStore, _ *gorm.DB) {
+		ctx := context.Background()
+		for _, v := range []string{"first", "second"} {
+			if _, err := s.PutToolResult(ctx, agent.PutToolResultRequest{Ref: "res:x", Result: trText(v)}); err != nil {
+				t.Fatalf("Put %q: %v", v, err)
+			}
+		}
+		resp, _ := s.GetToolResult(ctx, agent.GetToolResultRequest{Ref: "res:x"})
+		if resp.Result.Content[0].Text != "second" {
+			t.Fatalf("upsert did not overwrite: %+v", resp.Result)
+		}
+	})
+}
+
+func TestGormToolResultStore_PruneExpired(t *testing.T) {
+	forEachToolResultBackend(t, func(t *testing.T, s *ToolResultStore, db *gorm.DB) {
+		ctx := context.Background()
+		// no retention: prune is a no-op even for old rows
+		if n, err := s.PruneExpired(ctx); err != nil || n != 0 {
+			t.Fatalf("PruneExpired without retention = (%d, %v), want (0, nil)", n, err)
+		}
+
+		rs := newTRStore(t, db, WithToolResultRetention(time.Hour))
+		if _, err := rs.PutToolResult(ctx, agent.PutToolResultRequest{Ref: "res:old", Result: trText("stale")}); err != nil {
+			t.Fatalf("PutToolResult: %v", err)
+		}
+		if _, err := rs.PutToolResult(ctx, agent.PutToolResultRequest{Ref: "res:new", Result: trText("fresh")}); err != nil {
+			t.Fatalf("PutToolResult: %v", err)
+		}
+		// backdate one row past the window
+		if err := db.Table(DefaultToolResultTable).Where("ref = ?", "res:old").
+			Update("stored_at", time.Now().UTC().Add(-2*time.Hour)).Error; err != nil {
+			t.Fatalf("backdating: %v", err)
+		}
+
+		n, err := rs.PruneExpired(ctx)
+		if err != nil || n != 1 {
+			t.Fatalf("PruneExpired = (%d, %v), want (1, nil)", n, err)
+		}
+		if resp, _ := rs.GetToolResult(ctx, agent.GetToolResultRequest{Ref: "res:old"}); resp.Found {
+			t.Fatal("expired row survived prune")
+		}
+		if resp, _ := rs.GetToolResult(ctx, agent.GetToolResultRequest{Ref: "res:new"}); !resp.Found {
+			t.Fatal("in-window row was pruned")
+		}
+	})
+}
+
+func TestGormToolResultStore_CustomTableName(t *testing.T) {
+	forEachToolResultBackend(t, func(t *testing.T, _ *ToolResultStore, db *gorm.DB) {
+		ctx := context.Background()
+		s := newTRStore(t, db, WithToolResultTableName("custom_results"))
+		if _, err := s.PutToolResult(ctx, agent.PutToolResultRequest{Ref: "res:c", Result: trText("in custom table")}); err != nil {
+			t.Fatalf("PutToolResult: %v", err)
+		}
+		// the default-table store must NOT see it — proves the row landed
+		// in the custom table
+		def := newTRStore(t, db)
+		if resp, _ := def.GetToolResult(ctx, agent.GetToolResultRequest{Ref: "res:c"}); resp.Found {
+			t.Fatal("row written to custom table was visible in the default table")
+		}
+		if resp, _ := s.GetToolResult(ctx, agent.GetToolResultRequest{Ref: "res:c"}); !resp.Found {
+			t.Fatal("custom-table store could not read its own row")
+		}
+	})
+}

--- a/agent/store/redis/toolresult.go
+++ b/agent/store/redis/toolresult.go
@@ -1,0 +1,93 @@
+package redisstore
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+
+	"github.com/panyam/mcpkit/agent"
+	"github.com/panyam/mcpkit/core"
+)
+
+// DefaultToolResultKeyPrefix namespaces every key a ToolResultStore
+// writes, kept distinct from the RunStore prefix so both can share one
+// Redis without collision.
+const DefaultToolResultKeyPrefix = "mcpkit.agent.toolresult"
+
+// ToolResultStore is the durable Redis backend for agent.ToolResultStore:
+// one key per ref (<prefix>:<ref>) holding the JSON-encoded
+// core.ToolResult. Retention is native Redis TTL (WithToolResultTTL);
+// the default is no expiry. Eviction is always safe because the
+// interface's unknown-ref contract (Found=false) is what read_tool_result
+// turns into a graceful "no longer available" answer.
+type ToolResultStore struct {
+	client *redis.Client
+	prefix string
+	ttl    time.Duration
+}
+
+var _ agent.ToolResultStore = (*ToolResultStore)(nil)
+
+// ToolResultOption customizes a ToolResultStore. Distinct from the
+// RunStore Option type so the two stores' options never mix.
+type ToolResultOption func(*ToolResultStore)
+
+// WithToolResultKeyPrefix overrides DefaultToolResultKeyPrefix.
+func WithToolResultKeyPrefix(prefix string) ToolResultOption {
+	return func(s *ToolResultStore) { s.prefix = prefix }
+}
+
+// WithToolResultTTL sets a per-entry expiry: every stored result lives
+// this long, then Redis evicts it and a later read degrades gracefully.
+// Zero (the default) means no expiry — results persist until the DB is
+// cleared. A session store on a shared Redis usually wants a TTL sized
+// to how long a stub might be referenced.
+func WithToolResultTTL(ttl time.Duration) ToolResultOption {
+	return func(s *ToolResultStore) { s.ttl = ttl }
+}
+
+// NewToolResultStore returns a store over the given client. The client is
+// shared, not owned: Close it wherever it was constructed.
+func NewToolResultStore(client *redis.Client, opts ...ToolResultOption) *ToolResultStore {
+	s := &ToolResultStore{client: client, prefix: DefaultToolResultKeyPrefix}
+	for _, o := range opts {
+		o(s)
+	}
+	return s
+}
+
+func (s *ToolResultStore) key(ref string) string { return s.prefix + ":" + ref }
+
+// PutToolResult implements agent.ToolResultStore. Storing the same ref
+// twice overwrites (and refreshes the TTL); callers never reuse a ref.
+func (s *ToolResultStore) PutToolResult(ctx context.Context, req agent.PutToolResultRequest) (agent.PutToolResultResponse, error) {
+	body, err := json.Marshal(req.Result)
+	if err != nil {
+		return agent.PutToolResultResponse{}, fmt.Errorf("redisstore: encoding tool result: %w", err)
+	}
+	if err := s.client.Set(ctx, s.key(req.Ref), body, s.ttl).Err(); err != nil {
+		return agent.PutToolResultResponse{}, err
+	}
+	return agent.PutToolResultResponse{}, nil
+}
+
+// GetToolResult implements agent.ToolResultStore. A missing key (never
+// stored, or TTL-evicted) is Found=false, not an error.
+func (s *ToolResultStore) GetToolResult(ctx context.Context, req agent.GetToolResultRequest) (agent.GetToolResultResponse, error) {
+	body, err := s.client.Get(ctx, s.key(req.Ref)).Result()
+	if errors.Is(err, redis.Nil) {
+		return agent.GetToolResultResponse{}, nil
+	}
+	if err != nil {
+		return agent.GetToolResultResponse{}, err
+	}
+	var result core.ToolResult
+	if err := json.Unmarshal([]byte(body), &result); err != nil {
+		return agent.GetToolResultResponse{}, fmt.Errorf("redisstore: corrupt tool result %q: %w", req.Ref, err)
+	}
+	return agent.GetToolResultResponse{Result: result, Found: true}, nil
+}

--- a/agent/store/redis/toolresult_test.go
+++ b/agent/store/redis/toolresult_test.go
@@ -1,0 +1,81 @@
+package redisstore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+
+	"github.com/panyam/mcpkit/agent"
+	"github.com/panyam/mcpkit/core"
+)
+
+func newTestToolResultStore(t *testing.T, opts ...ToolResultOption) (*ToolResultStore, *miniredis.Miniredis) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { client.Close() })
+	return NewToolResultStore(client, opts...), mr
+}
+
+func trText(s string) core.ToolResult {
+	return core.ToolResult{Content: []core.Content{{Type: "text", Text: s}}}
+}
+
+func TestRedisToolResultStore_PutGet(t *testing.T) {
+	ctx := context.Background()
+	s, _ := newTestToolResultStore(t)
+
+	if _, err := s.PutToolResult(ctx, agent.PutToolResultRequest{Ref: "res:a", Result: trText("payload")}); err != nil {
+		t.Fatalf("PutToolResult: %v", err)
+	}
+	resp, err := s.GetToolResult(ctx, agent.GetToolResultRequest{Ref: "res:a"})
+	if err != nil || !resp.Found {
+		t.Fatalf("GetToolResult = (%+v, %v)", resp, err)
+	}
+	if resp.Result.Content[0].Text != "payload" {
+		t.Fatalf("round-trip lost content: %+v", resp.Result)
+	}
+}
+
+func TestRedisToolResultStore_UnknownRefIsAppState(t *testing.T) {
+	s, _ := newTestToolResultStore(t)
+	resp, err := s.GetToolResult(context.Background(), agent.GetToolResultRequest{Ref: "res:gone"})
+	if err != nil || resp.Found {
+		t.Fatalf("Get(unknown) = (%+v, %v), want Found=false, nil error", resp, err)
+	}
+}
+
+func TestRedisToolResultStore_TTLExpires(t *testing.T) {
+	ctx := context.Background()
+	s, mr := newTestToolResultStore(t, WithToolResultTTL(time.Minute))
+
+	if _, err := s.PutToolResult(ctx, agent.PutToolResultRequest{Ref: "res:t", Result: trText("x")}); err != nil {
+		t.Fatalf("PutToolResult: %v", err)
+	}
+	if resp, _ := s.GetToolResult(ctx, agent.GetToolResultRequest{Ref: "res:t"}); !resp.Found {
+		t.Fatal("result missing before TTL elapsed")
+	}
+	mr.FastForward(2 * time.Minute)
+	if resp, err := s.GetToolResult(ctx, agent.GetToolResultRequest{Ref: "res:t"}); err != nil || resp.Found {
+		t.Fatalf("Get after TTL = (%+v, %v), want Found=false", resp, err)
+	}
+}
+
+func TestRedisToolResultStore_KeyPrefixIsolation(t *testing.T) {
+	ctx := context.Background()
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer client.Close()
+
+	a := NewToolResultStore(client, WithToolResultKeyPrefix("tenant-a"))
+	b := NewToolResultStore(client, WithToolResultKeyPrefix("tenant-b"))
+	if _, err := a.PutToolResult(ctx, agent.PutToolResultRequest{Ref: "res:shared", Result: trText("a")}); err != nil {
+		t.Fatalf("PutToolResult: %v", err)
+	}
+	if resp, _ := b.GetToolResult(ctx, agent.GetToolResultRequest{Ref: "res:shared"}); resp.Found {
+		t.Fatal("prefix isolation broken: b saw a's ref")
+	}
+}


### PR DESCRIPTION
Closes #971. Stacks on PR 970 (the offloading primitive + `ToolResultStore` interface); `p2/972-host-offload` stacks on this. **No CI while based on a non-main branch** — verified locally with `make test-agent` (9/9) plus `make testpg` against a real Postgres 15 container.

## What changes

Offloaded tool-result blobs can now be durable: a `ToolResultStore` implementation in each existing sibling module. This makes the fork win from PR 970 real — because stored results are immutable, a durable store lets `ForkRun` copy only the small stub-carrying message rows while the heavy payloads are shared by reference, never duplicated.

## Reviewer's guide

Read in this order:
1. [agent/store/redis/toolresult.go](https://github.com/panyam/mcpkit/pull/975/files#diff-9a2134ac7b1e8a4c8beb10f206a8ba1c467ce1885bdd2aec38ec49fad9b7f5af) — one key per ref, `WithToolResultTTL` (native Redis expiry, default none), `WithToolResultKeyPrefix`.
2. [agent/store/gorm/toolresult.go](https://github.com/panyam/mcpkit/pull/975/files#diff-0ce6b6aa7f8bc181158bbaa81079df5e79420d5dbe3e5c5ac661daf254e8efdb) — one row per ref in a **configurable table** (`WithToolResultTableName`, resolved via `db.Table` so it drops into an existing schema), `PruneExpired` over a `WithToolResultRetention` window (caller-driven, no background sweeper), `WithoutToolResultAutoMigrate`.
3. [agent/store/redis/toolresult_test.go](https://github.com/panyam/mcpkit/pull/975/files#diff-feec5997305f4dfe5d8689179f37240d6d2d7a2021ec6a30c6f6126378abaa3b) — put/get, unknown-ref app-state, TTL expiry (miniredis FastForward), key-prefix isolation.
4. [agent/store/gorm/toolresult_test.go](https://github.com/panyam/mcpkit/pull/975/files#diff-368164b05310ac58232015f4c0476c9cad91f424269fcddf9e37f7dfd2ca93ca) — same over the sqlite/postgres matrix, plus upsert, `PruneExpired`, and custom-table isolation (a row in the custom table is invisible to a default-table store).

## Decision log

- **Retention stays out of the interface, native per backend.** Redis gets TTL (the substrate's own primitive); gorm gets a `PruneExpired` sweep the host/operator drives. The interface only promises `Get(unknown) => Found=false`, which `read_tool_result` degrades gracefully — so any eviction policy is safe. This is the direct answer to "can retention be customizable": yes, because nothing commits to one.
- **Gorm retention is caller-driven `PruneExpired`, not a background goroutine.** A store owning a sweeper goroutine means owning its lifecycle (who stops it?). Exposing `PruneExpired(ctx) (deleted, err)` keeps the store stateless and testable; the host or a cron calls it.
- **Configurable table via `db.Table(name)`**, not a static `TableName()` method — that's what lets one store target `agent_tool_results` and another target a custom table in the same DB, which the `CustomTableName` test pins.
- **Separate `ToolResultOption` type per module** (not reusing the RunStore `Option`) so the two stores' options never mix at a call site.

## Risk / blast radius

- Purely additive: new files in two existing modules; nothing imports them yet (host wiring is PR 972, next in the stack). RunStore code untouched.
- Tests: 9 new (4 redis, 5 gorm × sqlite+postgres); red-before-green verified on TTL and prune. 0 assertions removed or weakened.
- Be paranoid about: the `db.Table` threading (every gorm op must carry it, or a custom table silently falls back to the default — the isolation test guards this), and jsonb-on-sqlite (stored as text, same as the RunStore backend).

## Before / after

```
PR 970:  ToolResultStore interface + in-memory only
           → offloaded blobs die with the process; ForkRun still cheap
             but refs don't survive restart
this PR:  + redisstore.NewToolResultStore(client, WithToolResultTTL(1h))
         + gormstore.NewToolResultStore(db, WithToolResultTableName("results"))
           → blobs survive restarts; immutable, shared-by-ref across forks
```

## Out of scope (deliberately deferred)

- `agent/host` `Config.Offload` wiring that constructs one of these from `--session-store` → #972 (next in the stack)
- A host-driven cadence for calling gorm `PruneExpired` → part of #972's wiring
