### PR TITLE
feat(agent/host): wire tool-result offloading (Config.Offload) + agentchat flag

### DIFF
--- a/agent/host/README.md
+++ b/agent/host/README.md
@@ -37,7 +37,13 @@ stay out of the lean `agent/` module.
 - `WithRunStore(store)` — session persistence. Every completed turn's messages
   and event stream append to a run in the store (`agent.NewInMemoryRunStore`
   for in-process resume/fork; `agent/store/redis` or `agent/store/gorm` —
-  Postgres, or a serverless SQLite file — for restart-surviving sessions). `App.AttachRun` names or resumes a session at startup;
+  Postgres, or a serverless SQLite file — for restart-surviving sessions).
+- `WithToolResultStore(store)` — backing store for tool-result offloading
+  (`Config.Offload`). Over-threshold results are stored out of band and the
+  model gets a compact stub plus a `read_tool_result` tool; omit the option and
+  offloading uses an in-memory store, pass a durable one for blobs that survive
+  restarts. `Config.Offload` (nil = off) sets the byte threshold, preview
+  length, and per-tool overrides. `App.AttachRun` names or resumes a session at startup;
   `App.Resume` and `App.Fork` switch runs mid-session (`/resume <id>`,
   `/fork [id]`, `/session` in the REPL). A failed or cancelled turn persists
   nothing; persistence failures degrade to a rendered warning, never a turn

--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -47,6 +47,10 @@ type App struct {
 	// turn or set by AttachRun / Resume / Fork. Guarded by turnMu.
 	store agent.RunStore
 	runID string
+
+	// toolResultStore backs tool-result offloading when Config.Offload
+	// is set; nil when offloading is off.
+	toolResultStore agent.ToolResultStore
 }
 
 // AppOption customizes construction. The provider override exists so tests
@@ -54,11 +58,12 @@ type App struct {
 type AppOption func(*appOptions)
 
 type appOptions struct {
-	provider agent.Provider
-	ui       agent.ElicitationUI
-	tp       core.TracerProvider
-	logger   *slog.Logger
-	store    agent.RunStore
+	provider        agent.Provider
+	ui              agent.ElicitationUI
+	tp              core.TracerProvider
+	logger          *slog.Logger
+	store           agent.RunStore
+	toolResultStore agent.ToolResultStore
 }
 
 // WithProvider overrides the OpenAI-compatible provider built from config.
@@ -225,9 +230,23 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 		}
 	}
 
+	// Offloading wraps the whole aggregate, so one read_tool_result and
+	// one store cover every server's tools. The stub it substitutes is a
+	// normal ToolResult, so the transcript and persisted log see exactly
+	// what the model saw.
+	var runnerTools agent.ToolSource = multi
+	if cfg.Offload != nil {
+		store := o.toolResultStore
+		if store == nil {
+			store = agent.NewInMemoryToolResultStore()
+		}
+		app.toolResultStore = store
+		runnerTools = agent.NewOffloadingSource(multi, store, cfg.Offload.toAgent())
+	}
+
 	runnerCfg := agent.RunnerConfig{
 		Provider:       provider,
-		Tools:          multi,
+		Tools:          runnerTools,
 		Instructions:   instructions,
 		MaxSteps:       cfg.MaxSteps,
 		TracerProvider: o.tp,

--- a/agent/host/config.go
+++ b/agent/host/config.go
@@ -48,6 +48,40 @@ type Config struct {
 	// behavior). Set it to gate calls behind a mode and per-tool rules,
 	// with "ask" prompts routed through the terminal elicitation UI.
 	Approval *ApprovalConfig `json:"approval,omitempty"`
+
+	// Offload configures tool-result offloading. Nil means off: tool
+	// results flow into the conversation verbatim. Set it to store
+	// over-threshold results out of band and hand the model a compact
+	// stub plus a read_tool_result tool. The backing ToolResultStore is
+	// supplied by the surface via WithToolResultStore (in-memory when
+	// omitted), the same split as WithRunStore.
+	Offload *OffloadConfig `json:"offload,omitempty"`
+}
+
+// OffloadConfig is the host's view of tool-result offloading; it maps to
+// an agent.OffloadConfig. Its presence enables offloading.
+type OffloadConfig struct {
+	// ThresholdBytes is the model-visible size at or above which a
+	// successful result is offloaded. Zero uses the agent default
+	// (4 KB).
+	ThresholdBytes int `json:"thresholdBytes,omitempty"`
+
+	// PreviewLen is how many leading characters the stub carries inline.
+	// Zero uses the agent default.
+	PreviewLen int `json:"previewLen,omitempty"`
+
+	// PerTool overrides ThresholdBytes for named tools; a value <= 0
+	// pins that tool to never offload (always inline).
+	PerTool map[string]int `json:"perTool,omitempty"`
+}
+
+// toAgent maps the host config onto the agent-layer OffloadConfig.
+func (c *OffloadConfig) toAgent() agent.OffloadConfig {
+	return agent.OffloadConfig{
+		Threshold:        c.ThresholdBytes,
+		PreviewLen:       c.PreviewLen,
+		PerToolThreshold: c.PerTool,
+	}
 }
 
 // ApprovalConfig is the host's view of the agent approval ladder. It maps to

--- a/agent/host/offload_test.go
+++ b/agent/host/offload_test.go
@@ -1,0 +1,106 @@
+package host
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/panyam/mcpkit/agent"
+	"github.com/panyam/mcpkit/core"
+)
+
+func offloadConfig(url string) *Config {
+	c := testConfig(url)
+	c.Offload = &OffloadConfig{ThresholdBytes: 1024, PreviewLen: 30}
+	return c
+}
+
+func toolMsg(t *testing.T, msgs []agent.Message) agent.Message {
+	t.Helper()
+	for _, m := range msgs {
+		if m.Role == agent.RoleTool {
+			return m
+		}
+	}
+	t.Fatalf("no RoleTool message in %+v", msgs)
+	return agent.Message{}
+}
+
+func TestAppOffloadsLargeToolResult(t *testing.T) {
+	ts := startTestServer(t)
+	big := strings.Repeat("x", 4000)
+	stub := agent.NewStubProvider(
+		agent.StubTurn{ToolCalls: []agent.ToolCall{{
+			ID: "c1", Name: "echo", Args: core.NewRawJSON(json.RawMessage(`{"message":"` + big + `"}`)),
+		}}},
+		agent.StubTurn{Text: "done"},
+	)
+	store := agent.NewInMemoryToolResultStore()
+	var out strings.Builder
+	app, err := NewApp(offloadConfig(ts.URL), &out, strings.NewReader(""),
+		WithProvider(stub), WithToolResultStore(store))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Close()
+
+	if err := app.RunTurn(context.Background(), "go"); err != nil {
+		t.Fatal(err)
+	}
+
+	// the result fed back to the model on the second call is the stub
+	fed := toolMsg(t, stub.Requests()[1].Messages).Text
+	if strings.Contains(fed, big) {
+		t.Fatal("full payload leaked into the conversation; offloading did not fire")
+	}
+	if !strings.Contains(fed, "stored as res:") || !strings.Contains(fed, agent.ReadToolResultName) {
+		t.Fatalf("tool message is not an offload stub: %q", fed)
+	}
+
+	// read_tool_result is offered to the model
+	var offered bool
+	for _, d := range stub.Requests()[0].Tools {
+		if d.Name == agent.ReadToolResultName {
+			offered = true
+		}
+	}
+	if !offered {
+		t.Fatal("read_tool_result was not offered to the model")
+	}
+
+	// the blob is retrievable and complete
+	ref := fed[strings.Index(fed, "res:"):]
+	ref = ref[:strings.IndexFunc(ref, func(r rune) bool { return r == ']' || r == '\n' || r == ' ' })]
+	resp, err := store.GetToolResult(context.Background(), agent.GetToolResultRequest{Ref: ref})
+	if err != nil || !resp.Found {
+		t.Fatalf("offloaded blob %q not in store: %v", ref, err)
+	}
+	if !strings.Contains(resp.Result.Content[0].Text, big) {
+		t.Fatal("stored blob does not contain the full payload")
+	}
+}
+
+func TestAppNoOffloadWhenDisabled(t *testing.T) {
+	ts := startTestServer(t)
+	big := strings.Repeat("y", 4000)
+	stub := agent.NewStubProvider(
+		agent.StubTurn{ToolCalls: []agent.ToolCall{{
+			ID: "c1", Name: "echo", Args: core.NewRawJSON(json.RawMessage(`{"message":"` + big + `"}`)),
+		}}},
+		agent.StubTurn{Text: "done"},
+	)
+	var out strings.Builder
+	// testConfig has no Offload -> results flow verbatim
+	app, err := NewApp(testConfig(ts.URL), &out, strings.NewReader(""), WithProvider(stub))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Close()
+	if err := app.RunTurn(context.Background(), "go"); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(toolMsg(t, stub.Requests()[1].Messages).Text, big) {
+		t.Fatal("result was altered though offloading is off")
+	}
+}

--- a/agent/host/persistence.go
+++ b/agent/host/persistence.go
@@ -16,6 +16,14 @@ func WithRunStore(store agent.RunStore) AppOption {
 	return func(o *appOptions) { o.store = store }
 }
 
+// WithToolResultStore supplies the backing store for tool-result
+// offloading (Config.Offload). Omitted, offloading uses an in-memory
+// store; pass a durable one (agent/store/redis, agent/store/gorm) so
+// offloaded blobs survive restarts. Ignored when Config.Offload is nil.
+func WithToolResultStore(store agent.ToolResultStore) AppOption {
+	return func(o *appOptions) { o.toolResultStore = store }
+}
+
 // RunID returns the active persisted run, or "" when persistence is off
 // or no run has been attached or created yet (the first turn creates
 // one lazily).

--- a/cmd/agentchat/main.go
+++ b/cmd/agentchat/main.go
@@ -61,11 +61,59 @@ func buildRunStore(spec string) (agent.RunStore, error) {
 // transcript is the CLI's output; slow-query noise does not belong in
 // it) and wraps it in the RunStore.
 func openGormStore(dial gorm.Dialector) (agent.RunStore, error) {
-	db, err := gorm.Open(dial, &gorm.Config{Logger: gormlogger.Default.LogMode(gormlogger.Silent)})
+	db, err := openGormDB(dial)
 	if err != nil {
-		return nil, fmt.Errorf("agentchat: opening session store: %w", err)
+		return nil, err
 	}
 	return gormstore.New(db)
+}
+
+// openGormDB opens a GORM handle with SQL logging silenced, shared by the
+// run store and the tool-result store so a single --session-store spec
+// backs both on one connection.
+func openGormDB(dial gorm.Dialector) (*gorm.DB, error) {
+	db, err := gorm.Open(dial, &gorm.Config{Logger: gormlogger.Default.LogMode(gormlogger.Silent)})
+	if err != nil {
+		return nil, fmt.Errorf("agentchat: opening store: %w", err)
+	}
+	return db, nil
+}
+
+// buildToolResultStore maps --session-store to a ToolResultStore backend,
+// so offloaded blobs share the run store's backend: "" / "memory" give
+// the in-memory store (blobs die with the process), sqlite / redis /
+// postgres give restart-surviving blobs. Offloading itself is gated by
+// --offload-threshold, not this; a nil return means "use the host's
+// in-memory default".
+func buildToolResultStore(spec string) (agent.ToolResultStore, error) {
+	switch {
+	case spec == "" || spec == "memory":
+		return nil, nil
+	case strings.HasPrefix(spec, "redis://"):
+		addr := strings.TrimPrefix(spec, "redis://")
+		if addr == "" {
+			return nil, fmt.Errorf("agentchat: --session-store redis:// needs host:port")
+		}
+		return redisstore.NewToolResultStore(redis.NewClient(&redis.Options{Addr: addr})), nil
+	case strings.HasPrefix(spec, "sqlite://"):
+		path := strings.TrimPrefix(spec, "sqlite://")
+		if path == "" {
+			return nil, fmt.Errorf("agentchat: --session-store sqlite:// needs a file path")
+		}
+		db, err := openGormDB(sqlite.Open(path + "?_busy_timeout=5000"))
+		if err != nil {
+			return nil, err
+		}
+		return gormstore.NewToolResultStore(db)
+	case strings.HasPrefix(spec, "postgres://") || strings.HasPrefix(spec, "postgresql://"):
+		db, err := openGormDB(postgres.Open(spec))
+		if err != nil {
+			return nil, err
+		}
+		return gormstore.NewToolResultStore(db)
+	default:
+		return nil, fmt.Errorf("agentchat: unknown --session-store %q", spec)
+	}
 }
 
 const version = "0.1.0"
@@ -100,6 +148,7 @@ func newRoot() (*cobra.Command, *viper.Viper) {
 	fl.Int("max-steps", 0, "max model calls per turn (0 = default)")
 	fl.String("session-store", "", "session persistence backend: memory | sqlite://path.db | redis://host:port | postgres://user:pass@host:port/db (empty = off)")
 	fl.String("session", "", "session run ID to create or resume at startup (needs --session-store)")
+	fl.Int("offload-threshold", 0, "offload tool results at/over N bytes to a store, feeding the model a stub + read_tool_result (0 = off; blobs use --session-store's backend)")
 	fl.String("exporter", "", "telemetry exporter: stdout | otlp | auto (empty = off)")
 	fl.String("otlp-endpoint", "", "OTLP gRPC endpoint (default localhost:4317)")
 	if err := v.BindPFlags(fl); err != nil {
@@ -146,12 +195,24 @@ func runChat(v *viper.Viper) error {
 		host.WithTracerProvider(tp),
 		host.WithLogger(logger),
 	}
-	store, err := buildRunStore(v.GetString("session-store"))
+	sessionStore := v.GetString("session-store")
+	store, err := buildRunStore(sessionStore)
 	if err != nil {
 		return err
 	}
 	if store != nil {
 		appOpts = append(appOpts, host.WithRunStore(store))
+	}
+
+	if threshold := v.GetInt("offload-threshold"); threshold > 0 {
+		cfg.Offload = &host.OffloadConfig{ThresholdBytes: threshold}
+		trStore, err := buildToolResultStore(sessionStore)
+		if err != nil {
+			return err
+		}
+		if trStore != nil {
+			appOpts = append(appOpts, host.WithToolResultStore(trStore))
+		}
 	}
 
 	app, err := host.NewApp(cfg, os.Stdout, os.Stdin, appOpts...)

--- a/cmd/agentchat/session_store_test.go
+++ b/cmd/agentchat/session_store_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/panyam/mcpkit/agent"
+	"github.com/panyam/mcpkit/core"
 )
 
 func TestBuildRunStoreSpecs(t *testing.T) {
@@ -53,5 +54,40 @@ func TestBuildRunStoreSQLiteSurvivesReopen(t *testing.T) {
 	}
 	if len(resp.Run.Messages) != 1 || resp.Run.Messages[0].Text != "persisted" {
 		t.Fatalf("session did not survive reopen: %+v", resp.Run.Messages)
+	}
+}
+
+func TestBuildToolResultStoreSpecs(t *testing.T) {
+	// memory / empty -> nil (host uses its in-memory default)
+	for _, spec := range []string{"", "memory"} {
+		if s, err := buildToolResultStore(spec); err != nil || s != nil {
+			t.Fatalf("buildToolResultStore(%q) = (%v, %v), want (nil, nil)", spec, s, err)
+		}
+	}
+	for _, bad := range []string{"bogus", "sqlite://", "redis://"} {
+		if _, err := buildToolResultStore(bad); err == nil {
+			t.Fatalf("buildToolResultStore(%q) succeeded, want error", bad)
+		}
+	}
+}
+
+// TestBuildToolResultStoreSQLite pins that a sqlite spec yields a usable
+// durable blob store on a local file — the no-server offload path.
+func TestBuildToolResultStoreSQLite(t *testing.T) {
+	spec := "sqlite://" + filepath.Join(t.TempDir(), "blobs.db")
+	s, err := buildToolResultStore(spec)
+	if err != nil || s == nil {
+		t.Fatalf("buildToolResultStore(sqlite) = (%v, %v)", s, err)
+	}
+	ctx := context.Background()
+	if _, err := s.PutToolResult(ctx, agent.PutToolResultRequest{
+		Ref:    "res:a",
+		Result: core.ToolResult{Content: []core.Content{{Type: "text", Text: "payload"}}},
+	}); err != nil {
+		t.Fatalf("PutToolResult: %v", err)
+	}
+	resp, err := s.GetToolResult(ctx, agent.GetToolResultRequest{Ref: "res:a"})
+	if err != nil || !resp.Found {
+		t.Fatalf("GetToolResult = (%+v, %v)", resp, err)
 	}
 }


### PR DESCRIPTION
Closes #972. Top of the offloading stack: stacks on PR 975 (durable backends) → PR 970 (primitive). **No CI while based on a non-main branch** — verified with `make test-agent` (9/9).

## What changes

Tool-result offloading is now usable end-to-end from the host. `Config.Offload` (nil = off) opts a host in; `NewApp` wraps the aggregate `MultiSource` in an `OffloadingSource`, so one `read_tool_result` and one store cover every connected server's tools. agentchat exposes it as `--offload-threshold <bytes>`, reusing `--session-store` so a single backend spec (sqlite/redis/postgres) backs both runs and blobs on one connection.

## Reviewer's guide

Read in this order:
1. [agent/host/config.go](https://github.com/panyam/mcpkit/pull/976/files#diff-6aff502cc5cae4b9d9769752e8638899bab121e09de870b5d1320cc892c6bf2d) — `Config.Offload` + host `OffloadConfig` (byte threshold, preview, per-tool) and its `toAgent()` mapping. Mirrors `ApprovalConfig`.
2. [agent/host/app.go](https://github.com/panyam/mcpkit/pull/976/files#diff-89fb8e04b6e1e9d5f7f76958490ef158dee40e2cae92d87c04b408d893c84361) — the wrap: wrap `multi` only when `Config.Offload != nil`, default to an in-memory `ToolResultStore`, hand the wrapped source to the Runner. Nil-offload path is byte-for-byte unchanged.
3. [agent/host/persistence.go](https://github.com/panyam/mcpkit/pull/976/files#diff-0eff5e5041fb67bd84e50d022d2c12f889b3a75f62e014198f357bb4b36d78ce) — `WithToolResultStore` option (surface supplies the backend, like `WithRunStore`).
4. [agent/host/offload_test.go](https://github.com/panyam/mcpkit/pull/976/files#diff-29af1dd04627214c915b5621303af7f4faefcbc76560e96fd3a49565d0da74d0) — large result → the RoleTool message fed to the model is a stub, the blob is complete in the store, `read_tool_result` is offered; and offloading-off leaves results verbatim.
5. [cmd/agentchat/main.go](https://github.com/panyam/mcpkit/pull/976/files#diff-ce3956549c93b4983f18090136a2139c3c92d38408e923245f5e9ba628bcc98a) — `--offload-threshold` flag, `buildToolResultStore` (mirrors `buildRunStore`, shares `openGormDB`), wiring in `runChat`.
6. [cmd/agentchat/session_store_test.go](https://github.com/panyam/mcpkit/pull/976/files#diff-6081a6e484ed6da994bf6c9ef473afee4a28f6d81c1b8a73ad4c2ba5632618dd), [agent/host/README.md](https://github.com/panyam/mcpkit/pull/976/files#diff-4153913af46cb4575aee6ce1d40794e2089a248e74666353ba408cd20d677254) — spec coverage + docs.

## Decision log

- **Offloading wraps the *aggregate*, after meta-tool registration** — one store and one `read_tool_result` for all servers; meta-tool results are small and inline harmlessly.
- **`ToolResultStore` is a `WithToolResultStore` option, not built from `Config`** — a store is a Go value, not config data; the surface picks the backend (a web-chat injects its own), keeping `agent/host` free of a hard redis/gorm dependency. Same rationale as `WithRunStore`.
- **agentchat reuses `--session-store` for the blob backend** rather than a second flag — one connection, one operational knob; `--offload-threshold` is the only new surface. memory/empty → host's in-memory default (a nil return), so `--offload-threshold` works with no session store at all.
- **Default off.** `Config.Offload` nil means the Runner sees `multi` directly — no wrap, no `read_tool_result`, identical to today.

## Risk / blast radius

- Affects: `agent/host` (NewApp gains a conditional wrap + one field/option) and `cmd/agentchat` (one flag, one builder). Zero change when offloading is off, pinned by `TestAppNoOffloadWhenDisabled`.
- Tests: 2 host (offload fires end-to-end / stays off), 2 agentchat (spec table + sqlite round-trip); red-before-green verified on the host wrap. 0 assertions removed or weakened.
- Be paranoid about: the wrap sitting *outside* any per-server FilterSource but *around* the full MultiSource (so every tool's result is eligible and `read_tool_result` is global), and that the stub the model sees is exactly what the transcript/log persist.

## Before / after

```
$ agentchat --config chat.json --session-store sqlite://sessions.db --offload-threshold 4096
# a tool dumps 50KB:
> ⚙ read_file(path=big.log)
  ✓ read_file: [tool result 51203B, stored as res:9c2a] preview: 2026-01-02 …
# model calls read_tool_result(ref="res:9c2a", pattern="ERROR") to grep instead of re-reading
```
Before this PR, `Config.Offload`, `--offload-threshold`, and `WithToolResultStore` did not exist; large results sat in context for the whole session.

## Out of scope (deliberately deferred)

- A host-driven cadence for gorm `PruneExpired` (retention sweep) — worth a small follow-up once a deployment sets a retention window
- `turn-end` `Result.Messages` redaction → #973
- Showing `read_tool_result` in the `/tools` listing (it's offered to the model but `/tools` reads the unwrapped source) — cosmetic, can follow if wanted
