### PR TITLE
feat(agent): filesystem-backed ToolResultStore + agentchat --offload-dir

### DIFF
--- a/agent/host/README.md
+++ b/agent/host/README.md
@@ -42,8 +42,10 @@ stay out of the lean `agent/` module.
   (`Config.Offload`). Over-threshold results are stored out of band and the
   model gets a compact stub plus a `read_tool_result` tool; omit the option and
   offloading uses an in-memory store, pass a durable one for blobs that survive
-  restarts. `Config.Offload` (nil = off) sets the byte threshold, preview
-  length, and per-tool overrides. `App.AttachRun` names or resumes a session at startup;
+  restarts. Durable options: `agent/store/redis`, `agent/store/gorm`, or the
+  dependency-free `agent.NewFileToolResultStore(dir)` — the no-server local path
+  where blobs are files the agent can also read directly. `Config.Offload`
+  (nil = off) sets the byte threshold, preview length, and per-tool overrides. `App.AttachRun` names or resumes a session at startup;
   `App.Resume` and `App.Fork` switch runs mid-session (`/resume <id>`,
   `/fork [id]`, `/session` in the REPL). A failed or cancelled turn persists
   nothing; persistence failures degrade to a rendered warning, never a turn

--- a/agent/toolresultstore_fs.go
+++ b/agent/toolresultstore_fs.go
@@ -1,0 +1,113 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+// FileToolResultStore is a filesystem-backed ToolResultStore: one JSON
+// file per ref under a directory. It lives here in agent/ rather than a
+// sibling module because it is dependency-free (stdlib only) — the
+// sibling modules (agent/store/redis, agent/store/gorm) exist to isolate
+// heavy database dependencies, which this has none of.
+//
+// It is the natural store for a local or coding agent: no server to run,
+// durable across restarts for free, and the blobs are plain files the
+// agent can read with the file tools it already has (the "filesystem as
+// externalized memory" pattern). Blobs are immutable one-file-per-ref, so
+// forks share them by path with no copy, and retention is just deleting
+// old files.
+type FileToolResultStore struct {
+	dir string
+}
+
+var _ ToolResultStore = (*FileToolResultStore)(nil)
+
+// NewFileToolResultStore returns a store writing under dir, creating it
+// (and parents) if absent. The directory is the store's to own; point
+// two stores at the same dir only if you intend them to share blobs.
+func NewFileToolResultStore(dir string) (*FileToolResultStore, error) {
+	if dir == "" {
+		return nil, fmt.Errorf("agent: FileToolResultStore requires a directory")
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("agent: creating tool-result dir %q: %w", dir, err)
+	}
+	return &FileToolResultStore{dir: dir}, nil
+}
+
+// refToFilename maps a ref to a unique, cross-platform-safe filename.
+// Safe bytes pass through; every other byte (including the ':' in a
+// "res:..." ref, and the escape byte itself) becomes "_XX" hex. The
+// escaping is injective, so distinct refs never collide on one file.
+func refToFilename(ref string) string {
+	var b strings.Builder
+	for i := 0; i < len(ref); i++ {
+		c := ref[i]
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '.' {
+			b.WriteByte(c)
+		} else {
+			fmt.Fprintf(&b, "_%02x", c)
+		}
+	}
+	b.WriteString(".json")
+	return b.String()
+}
+
+func (s *FileToolResultStore) path(ref string) string {
+	return filepath.Join(s.dir, refToFilename(ref))
+}
+
+// PutToolResult implements ToolResultStore. The blob is written to a temp
+// file and renamed into place, so a crash mid-write never leaves a
+// partial blob a later read could trip on (rename is atomic within one
+// filesystem).
+func (s *FileToolResultStore) PutToolResult(ctx context.Context, req PutToolResultRequest) (PutToolResultResponse, error) {
+	body, err := json.Marshal(req.Result)
+	if err != nil {
+		return PutToolResultResponse{}, fmt.Errorf("agent: encoding tool result: %w", err)
+	}
+	final := s.path(req.Ref)
+	tmp, err := os.CreateTemp(s.dir, "put-*.tmp")
+	if err != nil {
+		return PutToolResultResponse{}, fmt.Errorf("agent: staging tool result: %w", err)
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(body); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return PutToolResultResponse{}, fmt.Errorf("agent: writing tool result: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return PutToolResultResponse{}, fmt.Errorf("agent: closing tool result: %w", err)
+	}
+	if err := os.Rename(tmpName, final); err != nil {
+		os.Remove(tmpName)
+		return PutToolResultResponse{}, fmt.Errorf("agent: committing tool result: %w", err)
+	}
+	return PutToolResultResponse{}, nil
+}
+
+// GetToolResult implements ToolResultStore. A missing file (never
+// stored, or deleted) is Found=false, not an error.
+func (s *FileToolResultStore) GetToolResult(ctx context.Context, req GetToolResultRequest) (GetToolResultResponse, error) {
+	body, err := os.ReadFile(s.path(req.Ref))
+	if os.IsNotExist(err) {
+		return GetToolResultResponse{}, nil
+	}
+	if err != nil {
+		return GetToolResultResponse{}, err
+	}
+	var result core.ToolResult
+	if err := json.Unmarshal(body, &result); err != nil {
+		return GetToolResultResponse{}, fmt.Errorf("agent: corrupt tool result %q: %w", req.Ref, err)
+	}
+	return GetToolResultResponse{Result: result, Found: true}, nil
+}

--- a/agent/toolresultstore_fs_test.go
+++ b/agent/toolresultstore_fs_test.go
@@ -1,0 +1,104 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestFileToolResultStore_PutGet(t *testing.T) {
+	ctx := context.Background()
+	s, err := NewFileToolResultStore(filepath.Join(t.TempDir(), "blobs"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.PutToolResult(ctx, PutToolResultRequest{Ref: "res:a1b2", Result: textResult("payload")}); err != nil {
+		t.Fatalf("PutToolResult: %v", err)
+	}
+	resp, err := s.GetToolResult(ctx, GetToolResultRequest{Ref: "res:a1b2"})
+	if err != nil || !resp.Found {
+		t.Fatalf("GetToolResult = (%+v, %v)", resp, err)
+	}
+	if toolResultText(&resp.Result) != "payload" {
+		t.Fatalf("round-trip lost content: %q", toolResultText(&resp.Result))
+	}
+}
+
+func TestFileToolResultStore_UnknownRefIsAppState(t *testing.T) {
+	s, err := NewFileToolResultStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := s.GetToolResult(context.Background(), GetToolResultRequest{Ref: "res:gone"})
+	if err != nil || resp.Found {
+		t.Fatalf("Get(unknown) = (%+v, %v), want Found=false, nil error", resp, err)
+	}
+}
+
+// TestFileToolResultStore_SurvivesReopen pins the local-agent value: a
+// second store over the same directory sees blobs the first wrote, with
+// no server involved.
+func TestFileToolResultStore_SurvivesReopen(t *testing.T) {
+	ctx := context.Background()
+	dir := filepath.Join(t.TempDir(), "blobs")
+
+	s1, err := NewFileToolResultStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s1.PutToolResult(ctx, PutToolResultRequest{Ref: "res:keep", Result: textResult("durable")}); err != nil {
+		t.Fatalf("PutToolResult: %v", err)
+	}
+
+	s2, err := NewFileToolResultStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := s2.GetToolResult(ctx, GetToolResultRequest{Ref: "res:keep"})
+	if err != nil || !resp.Found {
+		t.Fatalf("blob did not survive reopen: (%+v, %v)", resp, err)
+	}
+	if toolResultText(&resp.Result) != "durable" {
+		t.Fatalf("reopened blob wrong: %q", toolResultText(&resp.Result))
+	}
+}
+
+func TestFileToolResultStore_DeletedBlobIsGraceful(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	s, err := NewFileToolResultStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.PutToolResult(ctx, PutToolResultRequest{Ref: "res:tmp", Result: textResult("x")}); err != nil {
+		t.Fatalf("PutToolResult: %v", err)
+	}
+	// an operator (or retention sweep) deletes the file
+	if err := os.Remove(s.path("res:tmp")); err != nil {
+		t.Fatalf("removing blob: %v", err)
+	}
+	if resp, err := s.GetToolResult(ctx, GetToolResultRequest{Ref: "res:tmp"}); err != nil || resp.Found {
+		t.Fatalf("Get after delete = (%+v, %v), want Found=false", resp, err)
+	}
+}
+
+func TestRefToFilename_SafeAndInjective(t *testing.T) {
+	// the ':' in a minted ref is escaped, and no unsafe char leaks into
+	// the filename
+	name := refToFilename("res:ab12")
+	if name != "res_3aab12.json" {
+		t.Fatalf("refToFilename(res:ab12) = %q, want res_3aab12.json", name)
+	}
+	// distinct refs never collide, including refs that could alias under
+	// naive sanitization (":" vs "_3a")
+	if refToFilename("res:x") == refToFilename("res_3ax") {
+		t.Fatal("escaping is not injective: two refs collided on one filename")
+	}
+	for _, bad := range []rune{':', '/', '\\', ' ', '_'} {
+		if strings.ContainsRune(refToFilename(string(bad)), bad) && bad != '_' {
+			t.Fatalf("unsafe rune %q leaked into filename", bad)
+		}
+	}
+}

--- a/cmd/agentchat/main.go
+++ b/cmd/agentchat/main.go
@@ -79,13 +79,17 @@ func openGormDB(dial gorm.Dialector) (*gorm.DB, error) {
 	return db, nil
 }
 
-// buildToolResultStore maps --session-store to a ToolResultStore backend,
-// so offloaded blobs share the run store's backend: "" / "memory" give
-// the in-memory store (blobs die with the process), sqlite / redis /
-// postgres give restart-surviving blobs. Offloading itself is gated by
-// --offload-threshold, not this; a nil return means "use the host's
-// in-memory default".
-func buildToolResultStore(spec string) (agent.ToolResultStore, error) {
+// buildToolResultStore chooses the offload blob backend. A non-empty dir
+// wins: offloaded results become files under it, the no-server local path
+// (see agent.FileToolResultStore). Otherwise it maps --session-store so
+// blobs share the run store's backend: "" / "memory" give the in-memory
+// store (blobs die with the process), sqlite / redis / postgres give
+// restart-surviving blobs. A nil return means "use the host's in-memory
+// default".
+func buildToolResultStore(spec, dir string) (agent.ToolResultStore, error) {
+	if dir != "" {
+		return agent.NewFileToolResultStore(dir)
+	}
 	switch {
 	case spec == "" || spec == "memory":
 		return nil, nil
@@ -149,6 +153,7 @@ func newRoot() (*cobra.Command, *viper.Viper) {
 	fl.String("session-store", "", "session persistence backend: memory | sqlite://path.db | redis://host:port | postgres://user:pass@host:port/db (empty = off)")
 	fl.String("session", "", "session run ID to create or resume at startup (needs --session-store)")
 	fl.Int("offload-threshold", 0, "offload tool results at/over N bytes to a store, feeding the model a stub + read_tool_result (0 = off; blobs use --session-store's backend)")
+	fl.String("offload-dir", "", "store offloaded tool results as files under this directory (no server needed); overrides --session-store for blobs")
 	fl.String("exporter", "", "telemetry exporter: stdout | otlp | auto (empty = off)")
 	fl.String("otlp-endpoint", "", "OTLP gRPC endpoint (default localhost:4317)")
 	if err := v.BindPFlags(fl); err != nil {
@@ -206,7 +211,7 @@ func runChat(v *viper.Viper) error {
 
 	if threshold := v.GetInt("offload-threshold"); threshold > 0 {
 		cfg.Offload = &host.OffloadConfig{ThresholdBytes: threshold}
-		trStore, err := buildToolResultStore(sessionStore)
+		trStore, err := buildToolResultStore(sessionStore, v.GetString("offload-dir"))
 		if err != nil {
 			return err
 		}

--- a/cmd/agentchat/session_store_test.go
+++ b/cmd/agentchat/session_store_test.go
@@ -60,12 +60,12 @@ func TestBuildRunStoreSQLiteSurvivesReopen(t *testing.T) {
 func TestBuildToolResultStoreSpecs(t *testing.T) {
 	// memory / empty -> nil (host uses its in-memory default)
 	for _, spec := range []string{"", "memory"} {
-		if s, err := buildToolResultStore(spec); err != nil || s != nil {
+		if s, err := buildToolResultStore(spec, ""); err != nil || s != nil {
 			t.Fatalf("buildToolResultStore(%q) = (%v, %v), want (nil, nil)", spec, s, err)
 		}
 	}
 	for _, bad := range []string{"bogus", "sqlite://", "redis://"} {
-		if _, err := buildToolResultStore(bad); err == nil {
+		if _, err := buildToolResultStore(bad, ""); err == nil {
 			t.Fatalf("buildToolResultStore(%q) succeeded, want error", bad)
 		}
 	}
@@ -75,7 +75,7 @@ func TestBuildToolResultStoreSpecs(t *testing.T) {
 // durable blob store on a local file — the no-server offload path.
 func TestBuildToolResultStoreSQLite(t *testing.T) {
 	spec := "sqlite://" + filepath.Join(t.TempDir(), "blobs.db")
-	s, err := buildToolResultStore(spec)
+	s, err := buildToolResultStore(spec, "")
 	if err != nil || s == nil {
 		t.Fatalf("buildToolResultStore(sqlite) = (%v, %v)", s, err)
 	}
@@ -89,5 +89,25 @@ func TestBuildToolResultStoreSQLite(t *testing.T) {
 	resp, err := s.GetToolResult(ctx, agent.GetToolResultRequest{Ref: "res:a"})
 	if err != nil || !resp.Found {
 		t.Fatalf("GetToolResult = (%+v, %v)", resp, err)
+	}
+}
+
+// TestBuildToolResultStoreOffloadDir pins the no-server local path: a dir
+// yields a filesystem store regardless of --session-store.
+func TestBuildToolResultStoreOffloadDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "blobs")
+	s, err := buildToolResultStore("", dir) // no session store, dir wins
+	if err != nil || s == nil {
+		t.Fatalf("buildToolResultStore(dir) = (%v, %v)", s, err)
+	}
+	ctx := context.Background()
+	if _, err := s.PutToolResult(ctx, agent.PutToolResultRequest{
+		Ref:    "res:f",
+		Result: core.ToolResult{Content: []core.Content{{Type: "text", Text: "on disk"}}},
+	}); err != nil {
+		t.Fatalf("PutToolResult: %v", err)
+	}
+	if resp, _ := s.GetToolResult(ctx, agent.GetToolResultRequest{Ref: "res:f"}); !resp.Found {
+		t.Fatal("file store did not retain the blob")
 	}
 }


### PR DESCRIPTION
Closes #977. Tops the offloading stack (970 → 975 → 976 → this). Only truly depends on the `ToolResultStore` interface (970); bases on 976 for the agentchat wiring. **No CI while based on a non-main branch** — `make test-agent` green (9/9).

## What changes

A dependency-free `FileToolResultStore` — one JSON file per offloaded result under a directory. For a local or coding agent this is the natural store: no server to run, durable across restarts for free, and the blobs are plain files the agent can read with the file tools it already has. agentchat's `--offload-dir` routes blobs to it, so offloading works with no database at all.

## Reviewer's guide

Read in this order:
1. [agent/toolresultstore_fs.go](https://github.com/panyam/mcpkit/pull/978/files#diff-ae59a3e69dace174764894a1e072a32ded8dc8623b65693ac53183c344b8fc44) — `FileToolResultStore`; the package doc explains why it lives in `agent/` (dep-free, unlike the redis/gorm siblings). Note the temp-then-rename Put (crash safety) and `refToFilename` (injective escaping → safe cross-platform names).
2. [agent/toolresultstore_fs_test.go](https://github.com/panyam/mcpkit/pull/978/files#diff-988407afa213484c441b3ac0f21242870212378570b3971f6914d3d3de8c6617) — put/get, unknown-ref app-state, survives-reopen (the local-agent value), deleted-blob-graceful, and the escaping injectivity pin.
3. [cmd/agentchat/main.go](https://github.com/panyam/mcpkit/pull/978/files#diff-ce3956549c93b4983f18090136a2139c3c92d38408e923245f5e9ba628bcc98a) — `--offload-dir` flag; `buildToolResultStore(spec, dir)` where a non-empty dir wins.
4. [cmd/agentchat/session_store_test.go](https://github.com/panyam/mcpkit/pull/978/files#diff-6081a6e484ed6da994bf6c9ef473afee4a28f6d81c1b8a73ad4c2ba5632618dd), [agent/host/README.md](https://github.com/panyam/mcpkit/pull/978/files#diff-4153913af46cb4575aee6ce1d40794e2089a248e74666353ba408cd20d677254) — coverage + docs.

## Decision log

- **In `agent/`, not a sibling module.** The redis/gorm siblings exist to isolate heavy deps (go-redis, gorm+drivers). A filesystem store has none — stdlib only — so it belongs next to the in-memory default, and a coding agent gets it without pulling a sibling. Same rule: dep-free defaults in `agent/`, heavy backends in siblings.
- **Temp-then-rename Put.** A crash mid-write leaves a `.tmp`, never a half-written blob a read could trip on (rename is atomic within a filesystem). Blobs are immutable and refs unique, so no overwrite races.
- **Injective ref escaping** (`res:ab12` → `res_3aab12.json`): unsafe bytes including the `:` and the `_` escape byte itself become `_XX` hex, so distinct refs can never collide on one file — robust for any ref, not just the safe ones OffloadingSource mints.
- **`--offload-dir` overrides `--session-store` for blobs**, rather than a `file://` session-store scheme: a filesystem RunStore doesn't exist (runs need append/query), so overloading `--session-store` would be asymmetric. A dedicated flag is honest about what it backs.

## Risk / blast radius

- Purely additive: one new file in `agent/`, one new agentchat flag. Existing stores and behavior untouched.
- Tests: 5 fs + 1 agentchat; `make test-agent` green.
- Be paranoid about: the escaping injectivity (pinned) and the rename atomicity assumption (holds within one filesystem; `os.CreateTemp` uses the same dir so temp and final are always co-located).

## Before / after

```
$ agentchat --config chat.json --offload-threshold 4096 --offload-dir ~/.agentchat/blobs
# a 50KB file dump offloads to ~/.agentchat/blobs/res_3a9c2a.json
# the model reads a window via read_tool_result — or you cat the file yourself
```
No database, no server; the blob directory is inspectable with ordinary tools.

## Out of scope (deliberately deferred — see the two design questions below)

- **Binary tool results in offloading** — the store already retains binary (`core.ToolResult.Content.Data`), but the offload *trigger* measures only text and `read_tool_result` returns text windows; making binary offloading useful (size trigger + content-item / file-path retrieval) is a follow-up. The file store is what makes this ergonomic (a 50MB image becomes a real file to hand to an image tool).
- **Streaming / handle-based results** for 100s-of-MB outputs — needs streaming end-to-end (tool → client → source) or MCP resource links, not just a streaming `Put`; its own design investigation. The file store is the ideal first streaming backend (seek-based ranged reads instead of load-then-slice).
- A `WithFileRetention` sweep (delete old blobs) — trivial follow-up when a deployment needs it.
