### PR TITLE
feat(agent/host): redact TurnResult.Messages from the persisted turn-end event

### DIFF
--- a/agent/host/persistence.go
+++ b/agent/host/persistence.go
@@ -170,10 +170,33 @@ func NewPersistingEmit(store agent.RunStore, runID string, next func(agent.Event
 	return &PersistingEmit{store: store, runID: runID, next: next}
 }
 
-// Emit buffers the event and forwards it to the wrapped handler.
+// Emit forwards the event to the wrapped handler verbatim and buffers a
+// persistence copy. The two differ only for turn-end: the buffered copy
+// drops TurnResult.Messages (see redactForPersist), so live consumers
+// (renderers) still see the whole event while the event log does not
+// duplicate what the message log already holds.
 func (p *PersistingEmit) Emit(e agent.Event) {
-	p.buf = append(p.buf, e)
+	p.buf = append(p.buf, redactForPersist(e))
 	p.next(e)
+}
+
+// redactForPersist strips TurnResult.Messages from a turn-end event
+// before it lands in the persisted event log. The RunStore message log
+// is the authoritative copy of those messages; re-storing them inside
+// the turn-end event doubles the payload (and, with large tool results,
+// the offloaded stubs). Everything else on the TurnResult — Text, Usage,
+// Steps, FinishReason, Structured — stays for replay and audit. Non
+// turn-end events pass through unchanged. The original event and its
+// TurnResult are never mutated: the copy is shallow with Messages
+// nilled, so the live handler's view is untouched.
+func redactForPersist(e agent.Event) agent.Event {
+	if e.Kind != agent.EventTurnEnd || e.Result == nil {
+		return e
+	}
+	trimmed := *e.Result
+	trimmed.Messages = nil
+	e.Result = &trimmed
+	return e
 }
 
 // Flush appends the buffered events to the run and clears the buffer.

--- a/agent/host/persistence_test.go
+++ b/agent/host/persistence_test.go
@@ -337,3 +337,58 @@ func TestAppForkAtRewindsHistory(t *testing.T) {
 		t.Fatalf("fork lineage = (parent %q, forkPoint %d), want (%q, 2)", fork.Run.ParentID, fork.Run.ForkPoint, original)
 	}
 }
+
+func TestPersistingEmitRedactsTurnEndMessages(t *testing.T) {
+	ctx := context.Background()
+	store := agent.NewInMemoryRunStore()
+	created, err := store.CreateRun(ctx, agent.CreateRunRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var seen []agent.Event
+	pe := NewPersistingEmit(store, created.RunID, func(e agent.Event) { seen = append(seen, e) })
+
+	result := &agent.TurnResult{
+		Text:         "done",
+		Steps:        2,
+		FinishReason: "stop",
+		Messages: []agent.Message{
+			{Role: agent.RoleUser, Text: "hi"},
+			{Role: agent.RoleAssistant, Text: "done"},
+		},
+	}
+	pe.Emit(agent.Event{Kind: agent.EventTurnBegin})
+	pe.Emit(agent.Event{Kind: agent.EventTurnEnd, Result: result})
+	if err := pe.Flush(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// live consumer saw the full event, and the caller's TurnResult was
+	// not mutated
+	live := seen[len(seen)-1]
+	if live.Result == nil || len(live.Result.Messages) != 2 {
+		t.Fatalf("live handler did not see full messages: %+v", live.Result)
+	}
+	if len(result.Messages) != 2 {
+		t.Fatalf("redaction mutated the caller's TurnResult: %+v", result.Messages)
+	}
+
+	// persisted turn-end event dropped Messages but kept the rest
+	run, _ := store.LoadRun(ctx, agent.LoadRunRequest{RunID: created.RunID})
+	var end *agent.Event
+	for i := range run.Run.Events {
+		if run.Run.Events[i].Kind == agent.EventTurnEnd {
+			end = &run.Run.Events[i]
+		}
+	}
+	if end == nil || end.Result == nil {
+		t.Fatal("no persisted turn-end event with a result")
+	}
+	if len(end.Result.Messages) != 0 {
+		t.Fatalf("persisted turn-end still carries Messages: %+v", end.Result.Messages)
+	}
+	if end.Result.Text != "done" || end.Result.Steps != 2 || end.Result.FinishReason != "stop" {
+		t.Fatalf("redaction dropped non-message fields: %+v", end.Result)
+	}
+}


### PR DESCRIPTION
Closes #973. Based on `main`, standalone. The second half of the event-log dedup issue 966 started (tool-result payloads); this handles the turn-end message duplication.

## What changes

The `turn-end` event carries the whole `TurnResult`, whose `Messages` are exactly what the RunStore message log already stores — so persisting the event doubles that payload (and, with offloading, the offloaded stubs). `PersistingEmit` now buffers a copy of the turn-end event with `Messages` nilled while forwarding the full event to live consumers unchanged.

## Reviewer's guide

Read in this order:
1. [agent/host/persistence.go](https://github.com/panyam/mcpkit/pull/981/files#diff-0eff5e5041fb67bd84e50d022d2c12f889b3a75f62e014198f357bb4b36d78ce) — `Emit` now buffers `redactForPersist(e)`; the helper strips `TurnResult.Messages` from a turn-end event via a shallow copy (so the caller's `TurnResult` and the live handler's view are never mutated), keeping all other fields.
2. [agent/host/persistence_test.go](https://github.com/panyam/mcpkit/pull/981/files#diff-38b000bcaced1f93c8c897e0f6da51ec212ebccb119ad11b63750f2bb94431e6) — `TestPersistingEmitRedactsTurnEndMessages`: live handler sees full messages, caller's result unmutated, persisted event has empty Messages but keeps Text/Steps/FinishReason.

## Decision log

- **Redact the persisted copy, forward the live one whole.** Renderers and any live event consumer still get the complete `TurnResult` (they render the turn); only the durable copy trims. A shallow struct copy with `Messages = nil` avoids mutating the shared `TurnResult` the caller and renderer hold.
- **Keep the non-message fields.** Usage, Steps, FinishReason, Structured stay on the persisted turn-end so the event log remains useful for replay/audit without the message duplication.
- **Only turn-end.** No other event embeds `TurnResult`, so the helper is a no-op for everything else.

## Risk / blast radius

- Affects: `agent/host` `PersistingEmit` only. Message log is unchanged (still authoritative and complete); only the *event* log's turn-end entry shrinks.
- Tests: 1 new (redaction + no-mutation + field-preservation); existing persistence suite green; red-before-green verified. 0 assertions removed or weakened.
- Be paranoid about: the no-mutation guarantee (a consumer that kept a reference to `event.Result` must still see Messages — pinned by the test asserting `result.Messages` and the live event both intact).

## Before / after

Persisted `turn-end` event for a 2-message turn:
```
before:  {"kind":"turn-end","result":{"text":"done","steps":2,"messages":[{...},{...}]}}
after:   {"kind":"turn-end","result":{"text":"done","steps":2}}
         # the two messages live once, in the run's message log
```

## Out of scope

- Nothing deferred; this closes the event-log dedup pair (966 payload + 973 turn-end).
