### PR TITLE
feat(agent/host): ConnectionRegistry + config + runtime /provider switch

### DIFF
--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -51,6 +51,12 @@ type App struct {
 	// toolResultStore backs tool-result offloading when Config.Offload
 	// is set; nil when offloading is off.
 	toolResultStore agent.ToolResultStore
+
+	// connections + providerSwitch are the runtime provider-switch seam
+	// (Config.Connections): the Runner holds the switch, /provider swaps
+	// its underlying. Both nil when Connections is not configured.
+	connections    *ConnectionRegistry
+	providerSwitch *providerSwitch
 }
 
 // AppOption customizes construction. The provider override exists so tests
@@ -64,6 +70,7 @@ type appOptions struct {
 	logger          *slog.Logger
 	store           agent.RunStore
 	toolResultStore agent.ToolResultStore
+	providerBuilder ProviderBuilder
 }
 
 // WithProvider overrides the OpenAI-compatible provider built from config.
@@ -178,6 +185,21 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 	}
 
 	provider := o.provider
+	if provider == nil && cfg.Connections != nil {
+		reg, err := NewConnectionRegistry(cfg.Connections, o.providerBuilder)
+		if err != nil {
+			app.Close()
+			return nil, err
+		}
+		active, err := reg.ActiveProvider()
+		if err != nil {
+			app.Close()
+			return nil, err
+		}
+		app.connections = reg
+		app.providerSwitch = newProviderSwitch(active)
+		provider = app.providerSwitch
+	}
 	if provider == nil {
 		var err error
 		provider, err = agent.NewOpenAIProvider(agent.OpenAIConfig{
@@ -359,6 +381,32 @@ func (a *App) setApprovalMode(arg string) {
 	a.renderer.approvalMode(a.approval)
 }
 
+// Providers returns the configured connection names and the active one,
+// or (nil, "") when no connection registry is configured. Structured so a
+// surface (REPL, TUI, web) renders it however it likes.
+func (a *App) Providers() (names []string, active string) {
+	if a.connections == nil {
+		return nil, ""
+	}
+	return a.connections.Names(), a.connections.Active()
+}
+
+// SwitchProvider makes name the active chat provider for subsequent
+// turns. An unknown name or a build failure leaves the current provider
+// in place (the error says which). The swap takes effect on the next
+// model call; a turn already streaming finishes on its original provider.
+func (a *App) SwitchProvider(name string) error {
+	if a.connections == nil {
+		return fmt.Errorf("host: no connections configured")
+	}
+	p, err := a.connections.SetActive(name)
+	if err != nil {
+		return err
+	}
+	a.providerSwitch.set(p)
+	return nil
+}
+
 // REPL runs the interactive loop until EOF or /quit. turnCtx wraps each
 // turn so the caller's signal handling can cancel the in-flight turn
 // without killing the loop.
@@ -390,6 +438,15 @@ func (a *App) REPL(ctx context.Context, in io.Reader, turnCtx func() (context.Co
 			a.renderer.approvalMode(a.approval)
 		case strings.HasPrefix(line, "/approve "):
 			a.setApprovalMode(strings.TrimPrefix(line, "/approve "))
+		case line == "/provider":
+			a.renderer.providers(a.Providers())
+		case strings.HasPrefix(line, "/provider "):
+			name := strings.TrimSpace(strings.TrimPrefix(line, "/provider "))
+			if err := a.SwitchProvider(name); err != nil {
+				a.renderer.turnFailed(err)
+			} else {
+				a.renderer.providers(a.Providers())
+			}
 		case line == "/session":
 			a.renderer.session(a.RunID())
 		case strings.HasPrefix(line, "/resume "):

--- a/agent/host/config.go
+++ b/agent/host/config.go
@@ -49,6 +49,12 @@ type Config struct {
 	// with "ask" prompts routed through the terminal elicitation UI.
 	Approval *ApprovalConfig `json:"approval,omitempty"`
 
+	// Connections is a named registry of model connections with one
+	// active. When set it supersedes Model for the chat provider and
+	// enables runtime /provider switching; Model stays as the
+	// single-connection quick-start path. See ConnectionsConfig.
+	Connections *ConnectionsConfig `json:"connections,omitempty"`
+
 	// Offload configures tool-result offloading. Nil means off: tool
 	// results flow into the conversation verbatim. Set it to store
 	// over-threshold results out of band and hand the model a compact

--- a/agent/host/connections.go
+++ b/agent/host/connections.go
@@ -1,0 +1,263 @@
+package host
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"sync"
+
+	"github.com/panyam/mcpkit/agent"
+)
+
+// ConnectionsConfig is a named registry of model connections with one
+// active, the shape a playground config carries so the user can switch
+// models at runtime (/provider). It supersedes Config.Model for the chat
+// provider when set; Model stays as the single-connection quick-start.
+//
+// The same registry is the seam later roles draw from: /embedder and
+// /judgelm (epic 983) pick an active connection for their role from this
+// one set — connections are model endpoints, roles are assignments over
+// them.
+type ConnectionsConfig struct {
+	// Active names the connection used for the chat provider at startup.
+	// Must be a key in Connections.
+	Active string `json:"active"`
+
+	// Connections maps a caller-chosen name to its endpoint + model.
+	Connections map[string]ConnectionConfig `json:"connections"`
+}
+
+// ConnectionConfig is one model endpoint. Type resolves to a base URL via
+// the built-in table (lmstudio / openai / ollama); BaseURL overrides it
+// for anything else. Exactly one of a known Type or a BaseURL must
+// resolve, or construction fails.
+type ConnectionConfig struct {
+	// Type names a built-in endpoint profile ("lmstudio", "openai",
+	// "ollama"). Optional when BaseURL is set.
+	Type string `json:"type,omitempty"`
+
+	// BaseURL is the API root including any version prefix, e.g.
+	// "http://localhost:1234/v1". Overrides Type's default.
+	BaseURL string `json:"baseUrl,omitempty"`
+
+	// Model is the model identifier sent on every request. Required.
+	Model string `json:"model"`
+
+	// APIKeyEnv names the environment variable holding the bearer key.
+	// Empty means unauthenticated (local endpoints).
+	APIKeyEnv string `json:"apiKeyEnv,omitempty"`
+
+	// ThinkingHint describes how this model delimits inline reasoning, for
+	// models that emit it in the text stream (e.g. <think>…</think>).
+	// Carried through the registry; the stream parser that acts on it is a
+	// follow-up (issue 989) — for now it is metadata.
+	ThinkingHint *ThinkingHint `json:"thinkingHint,omitempty"`
+}
+
+// ThinkingHint delimits a model's inline reasoning. An empty OpenTag
+// means reasoning starts at the stream head and runs until CloseTag (the
+// "no open tag" models); an empty CloseTag means the hint is inert.
+type ThinkingHint struct {
+	OpenTag  string `json:"openTag,omitempty"`
+	CloseTag string `json:"closeTag,omitempty"`
+}
+
+// connectionBaseURLs maps a built-in Type to its default API root. Local
+// runtimes and the OpenAI cloud; anything else sets BaseURL explicitly.
+var connectionBaseURLs = map[string]string{
+	"lmstudio": "http://localhost:1234/v1",
+	"openai":   "https://api.openai.com/v1",
+	"ollama":   "http://localhost:11434/v1",
+}
+
+// ProviderBuilder builds a Provider from a resolved connection. Injected
+// for tests (a builder that returns StubProviders); DefaultProviderBuilder
+// is the real OpenAI-compatible path.
+type ProviderBuilder func(ConnectionConfig) (agent.Provider, error)
+
+// DefaultProviderBuilder builds an OpenAI-compatible provider, resolving
+// the base URL from BaseURL or the Type table and the key from APIKeyEnv.
+func DefaultProviderBuilder(conn ConnectionConfig) (agent.Provider, error) {
+	base, err := resolveBaseURL(conn)
+	if err != nil {
+		return nil, err
+	}
+	var key string
+	if conn.APIKeyEnv != "" {
+		key = os.Getenv(conn.APIKeyEnv)
+	}
+	return agent.NewOpenAIProvider(agent.OpenAIConfig{
+		BaseURL: base,
+		Model:   conn.Model,
+		APIKey:  key,
+	})
+}
+
+// resolveBaseURL returns the endpoint root: BaseURL wins, else the Type
+// table, else an error naming the fix.
+func resolveBaseURL(conn ConnectionConfig) (string, error) {
+	if conn.BaseURL != "" {
+		return conn.BaseURL, nil
+	}
+	if base, ok := connectionBaseURLs[conn.Type]; ok {
+		return base, nil
+	}
+	if conn.Type == "" {
+		return "", fmt.Errorf("host: connection needs a baseUrl or a known type (%s)", knownTypes())
+	}
+	return "", fmt.Errorf("host: unknown connection type %q (set baseUrl, or use one of %s)", conn.Type, knownTypes())
+}
+
+func knownTypes() string {
+	ts := make([]string, 0, len(connectionBaseURLs))
+	for t := range connectionBaseURLs {
+		ts = append(ts, t)
+	}
+	sort.Strings(ts)
+	out := ""
+	for i, t := range ts {
+		if i > 0 {
+			out += ", "
+		}
+		out += t
+	}
+	return out
+}
+
+// ConnectionRegistry holds the named connections, the active one, and a
+// cache of built providers. Safe for concurrent use: SetActive and
+// provider() are the runtime-switch surface. Providers are built lazily
+// and cached, so switching back to a used connection is instant.
+type ConnectionRegistry struct {
+	mu     sync.Mutex
+	conns  map[string]ConnectionConfig
+	names  []string // sorted, stable listing order
+	active string
+	build  ProviderBuilder
+	cache  map[string]agent.Provider
+}
+
+// NewConnectionRegistry validates cfg (Active must name a connection,
+// every connection must resolve a base URL) and returns the registry. A
+// nil build uses DefaultProviderBuilder. Providers are not built here —
+// the first Provider/SetActive call builds the active one, so a
+// misconfigured non-active connection does not fail startup.
+func NewConnectionRegistry(cfg *ConnectionsConfig, build ProviderBuilder) (*ConnectionRegistry, error) {
+	if cfg == nil || len(cfg.Connections) == 0 {
+		return nil, fmt.Errorf("host: connections config is empty")
+	}
+	if build == nil {
+		build = DefaultProviderBuilder
+	}
+	names := make([]string, 0, len(cfg.Connections))
+	for name, conn := range cfg.Connections {
+		if conn.Model == "" {
+			return nil, fmt.Errorf("host: connection %q has no model", name)
+		}
+		if _, err := resolveBaseURL(conn); err != nil {
+			return nil, fmt.Errorf("host: connection %q: %w", name, err)
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	active := cfg.Active
+	if active == "" {
+		return nil, fmt.Errorf("host: connections config needs an active connection")
+	}
+	if _, ok := cfg.Connections[active]; !ok {
+		return nil, fmt.Errorf("host: active connection %q is not defined", active)
+	}
+	return &ConnectionRegistry{
+		conns:  cfg.Connections,
+		names:  names,
+		active: active,
+		build:  build,
+		cache:  map[string]agent.Provider{},
+	}, nil
+}
+
+// Names lists the connection names in stable sorted order.
+func (r *ConnectionRegistry) Names() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.names...)
+}
+
+// Active returns the name of the active connection.
+func (r *ConnectionRegistry) Active() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.active
+}
+
+// provider returns the built provider for name, building and caching on
+// first use. Caller holds r.mu.
+func (r *ConnectionRegistry) providerLocked(name string) (agent.Provider, error) {
+	if p, ok := r.cache[name]; ok {
+		return p, nil
+	}
+	p, err := r.build(r.conns[name])
+	if err != nil {
+		return nil, fmt.Errorf("host: building provider %q: %w", name, err)
+	}
+	r.cache[name] = p
+	return p, nil
+}
+
+// ActiveProvider builds (or returns the cached) provider for the active
+// connection.
+func (r *ConnectionRegistry) ActiveProvider() (agent.Provider, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.providerLocked(r.active)
+}
+
+// SetActive switches the active connection and returns its provider. An
+// unknown name is an error and leaves the active connection unchanged; a
+// build failure likewise leaves the previous active in place, so a failed
+// switch never strands the session without a provider.
+func (r *ConnectionRegistry) SetActive(name string) (agent.Provider, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.conns[name]; !ok {
+		return nil, fmt.Errorf("host: unknown connection %q", name)
+	}
+	p, err := r.providerLocked(name)
+	if err != nil {
+		return nil, err
+	}
+	r.active = name
+	return p, nil
+}
+
+// providerSwitch is an agent.Provider whose underlying provider can be
+// swapped at runtime. The Runner holds one of these, so /provider never
+// rebuilds the Runner; a swap takes effect on the next model call (an
+// in-flight stream finishes on the provider it started with).
+type providerSwitch struct {
+	mu sync.RWMutex
+	p  agent.Provider
+}
+
+func newProviderSwitch(p agent.Provider) *providerSwitch { return &providerSwitch{p: p} }
+
+func (s *providerSwitch) set(p agent.Provider) {
+	s.mu.Lock()
+	s.p = p
+	s.mu.Unlock()
+}
+
+func (s *providerSwitch) current() agent.Provider {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.p
+}
+
+func (s *providerSwitch) Stream(ctx context.Context, req agent.ProviderRequest) (agent.Stream, error) {
+	return s.current().Stream(ctx, req)
+}
+
+func (s *providerSwitch) Generate(ctx context.Context, req agent.ProviderRequest) (*agent.ProviderResponse, error) {
+	return s.current().Generate(ctx, req)
+}

--- a/agent/host/connections_test.go
+++ b/agent/host/connections_test.go
@@ -1,0 +1,181 @@
+package host
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/panyam/mcpkit/agent"
+)
+
+func twoConn() *ConnectionsConfig {
+	return &ConnectionsConfig{
+		Active: "local",
+		Connections: map[string]ConnectionConfig{
+			"local": {Type: "lmstudio", Model: "qwen"},
+			"cloud": {Type: "openai", Model: "gpt-5", APIKeyEnv: "OPENAI_KEY"},
+		},
+	}
+}
+
+// namedStub is a StubProvider tagged with the connection name it was
+// built for, so a test can assert which connection is active.
+type namedStub struct {
+	*agent.StubProvider
+	name string
+}
+
+func stubBuilder(t *testing.T) ProviderBuilder {
+	// maps model -> connection name for the twoConn fixture
+	byModel := map[string]string{"qwen": "local", "gpt-5": "cloud"}
+	return func(c ConnectionConfig) (agent.Provider, error) {
+		name := byModel[c.Model]
+		return &namedStub{StubProvider: agent.NewStubProvider(agent.StubTurn{Text: "reply from " + name}), name: name}, nil
+	}
+}
+
+func TestConnectionRegistry_LoadAndActive(t *testing.T) {
+	reg, err := NewConnectionRegistry(twoConn(), stubBuilder(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := reg.Names(); len(got) != 2 || got[0] != "cloud" || got[1] != "local" {
+		t.Fatalf("Names() = %v, want sorted [cloud local]", got)
+	}
+	if reg.Active() != "local" {
+		t.Fatalf("Active() = %q, want local", reg.Active())
+	}
+	p, err := reg.ActiveProvider()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.(*namedStub).name != "local" {
+		t.Fatalf("active provider is %q, want local", p.(*namedStub).name)
+	}
+}
+
+func TestConnectionRegistry_SetActiveAndCache(t *testing.T) {
+	reg, err := NewConnectionRegistry(twoConn(), stubBuilder(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, _ := reg.ActiveProvider()
+
+	p, err := reg.SetActive("cloud")
+	if err != nil {
+		t.Fatalf("SetActive: %v", err)
+	}
+	if p.(*namedStub).name != "cloud" || reg.Active() != "cloud" {
+		t.Fatalf("SetActive(cloud) did not switch: active=%q provider=%q", reg.Active(), p.(*namedStub).name)
+	}
+	// unknown name leaves active unchanged
+	if _, err := reg.SetActive("nope"); err == nil {
+		t.Fatal("SetActive(unknown) succeeded, want error")
+	}
+	if reg.Active() != "cloud" {
+		t.Fatalf("failed SetActive changed active to %q", reg.Active())
+	}
+	// switching back returns the SAME cached instance
+	back, _ := reg.SetActive("local")
+	if back != first {
+		t.Fatal("SetActive did not return the cached provider on revisit")
+	}
+}
+
+func TestConnectionRegistry_ValidationErrors(t *testing.T) {
+	cases := map[string]*ConnectionsConfig{
+		"no active":        {Connections: map[string]ConnectionConfig{"a": {Type: "lmstudio", Model: "m"}}},
+		"active undefined": {Active: "b", Connections: map[string]ConnectionConfig{"a": {Type: "lmstudio", Model: "m"}}},
+		"no model":         {Active: "a", Connections: map[string]ConnectionConfig{"a": {Type: "lmstudio"}}},
+		"unknown type":     {Active: "a", Connections: map[string]ConnectionConfig{"a": {Type: "bogus", Model: "m"}}},
+		"empty":            {Active: "a"},
+	}
+	for name, cfg := range cases {
+		if _, err := NewConnectionRegistry(cfg, stubBuilder(t)); err == nil {
+			t.Fatalf("%s: NewConnectionRegistry succeeded, want error", name)
+		}
+	}
+}
+
+func TestResolveBaseURL(t *testing.T) {
+	if u, _ := resolveBaseURL(ConnectionConfig{Type: "lmstudio"}); u != "http://localhost:1234/v1" {
+		t.Fatalf("lmstudio base = %q", u)
+	}
+	if u, _ := resolveBaseURL(ConnectionConfig{Type: "lmstudio", BaseURL: "http://x/v1"}); u != "http://x/v1" {
+		t.Fatalf("BaseURL should override type, got %q", u)
+	}
+	if _, err := resolveBaseURL(ConnectionConfig{Model: "m"}); err == nil {
+		t.Fatal("no type and no baseUrl should error")
+	}
+}
+
+// TestConnectionsConfigJSON pins the llm.json-inspired shape decodes.
+func TestConnectionsConfigJSON(t *testing.T) {
+	raw := `{
+      "active": "local",
+      "connections": {
+        "local": {"type": "lmstudio", "model": "qwen"},
+        "think": {"type": "lmstudio", "model": "deepseek",
+                  "thinkingHint": {"openTag": "<think>", "closeTag": "</think>"}}
+      }
+    }`
+	var c ConnectionsConfig
+	if err := json.Unmarshal([]byte(raw), &c); err != nil {
+		t.Fatal(err)
+	}
+	if c.Active != "local" || len(c.Connections) != 2 {
+		t.Fatalf("decoded wrong: %+v", c)
+	}
+	if h := c.Connections["think"].ThinkingHint; h == nil || h.OpenTag != "<think>" {
+		t.Fatalf("thinkingHint not decoded: %+v", c.Connections["think"])
+	}
+}
+
+func TestApp_ProviderSwitchAtRuntime(t *testing.T) {
+	ts := startTestServer(t)
+	cfg := testConfig(ts.URL)
+	cfg.Connections = twoConn()
+
+	var out strings.Builder
+	app, err := NewApp(cfg, &out, strings.NewReader(""), WithProviderBuilder(stubBuilder(t)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Close()
+
+	names, active := app.Providers()
+	if len(names) != 2 || active != "local" {
+		t.Fatalf("Providers() = (%v, %q)", names, active)
+	}
+
+	if err := app.SwitchProvider("cloud"); err != nil {
+		t.Fatalf("SwitchProvider: %v", err)
+	}
+	if _, active := app.Providers(); active != "cloud" {
+		t.Fatalf("active after switch = %q, want cloud", active)
+	}
+	// the Runner now streams from the cloud provider
+	if err := app.RunTurn(context.Background(), "hi"); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "reply from cloud") {
+		t.Fatalf("turn did not use the switched provider:\n%s", out.String())
+	}
+}
+
+func TestApp_NoConnectionsProvidersEmpty(t *testing.T) {
+	ts := startTestServer(t)
+	var out strings.Builder
+	app, err := NewApp(testConfig(ts.URL), &out, strings.NewReader(""), WithProvider(agent.NewStubProvider()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Close()
+	if names, active := app.Providers(); names != nil || active != "" {
+		t.Fatalf("Providers() without registry = (%v, %q), want empty", names, active)
+	}
+	if err := app.SwitchProvider("x"); err == nil {
+		t.Fatal("SwitchProvider without registry succeeded, want error")
+	}
+}

--- a/agent/host/persistence.go
+++ b/agent/host/persistence.go
@@ -24,6 +24,14 @@ func WithToolResultStore(store agent.ToolResultStore) AppOption {
 	return func(o *appOptions) { o.toolResultStore = store }
 }
 
+// WithProviderBuilder overrides how Config.Connections entries are turned
+// into providers. Tests inject a builder returning StubProviders;
+// production uses DefaultProviderBuilder (OpenAI-compatible). Ignored when
+// Connections is nil or WithProvider is set.
+func WithProviderBuilder(b ProviderBuilder) AppOption {
+	return func(o *appOptions) { o.providerBuilder = b }
+}
+
 // RunID returns the active persisted run, or "" when persistence is off
 // or no run has been attached or created yet (the first turn creates
 // one lazily).

--- a/agent/host/render.go
+++ b/agent/host/render.go
@@ -225,3 +225,17 @@ func (r *renderer) session(runID string) {
 func (r *renderer) sessionWarn(err error) {
 	fmt.Fprintf(r.out, "%s\n", r.dim("session: persistence degraded: "+err.Error()))
 }
+
+func (r *renderer) providers(names []string, active string) {
+	if len(names) == 0 {
+		fmt.Fprintf(r.out, "%s\n", r.dim("providers: none configured (using the single --model)"))
+		return
+	}
+	for _, n := range names {
+		marker := "  "
+		if n == active {
+			marker = "▸ "
+		}
+		fmt.Fprintf(r.out, "%s\n", r.dim(marker+n))
+	}
+}


### PR DESCRIPTION
Closes #984. First PR of the agentchat playground epic (#983). Host-side only, on the existing scanner REPL — no TUI yet, fully offline-testable. Based on `main`.

## What changes

`agent/host` gains a named-connection registry so agentchat can carry several model connections and switch between them at runtime with `/provider`, instead of the single `--model`. `Config.Connections` (llm.json-inspired: an `active` name + a `connections` map) supersedes `Config.Model` for the chat provider when present; `Model` stays as the single-connection quick-start. The switch is surface-agnostic — `Providers()` / `SwitchProvider()` return structured data the REPL renders, and the same methods will drive the future TUI and web surfaces.

## Reviewer's guide

Read in this order:
1. [agent/host/connections.go](https://github.com/panyam/mcpkit/pull/990/files#diff-40587e49ead8267db133543c03987833f30f87ec17039242f6d4397802b11c6e) — the whole feature: config types (`ConnectionsConfig` / `ConnectionConfig` / `ThinkingHint`), the `Type`→base-URL table + `resolveBaseURL`, `ConnectionRegistry` (lazy build + cache, `SetActive` leaves the old active in place on failure), and the `providerSwitch` indirection.
2. [agent/host/app.go](https://github.com/panyam/mcpkit/pull/990/files#diff-89fb8e04b6e1e9d5f7f76958490ef158dee40e2cae92d87c04b408d893c84361) — the NewApp wiring (registry path when `Connections != nil`, else the unchanged single-provider path), `App.Providers()` / `App.SwitchProvider()`, and the `/provider` REPL command.
3. [agent/host/connections_test.go](https://github.com/panyam/mcpkit/pull/990/files#diff-1c89e3a97c6cf4e11077a67b4b3d5cdd70fa267f389852ab1163420d61c08915) — registry load/active/cache, `SetActive` failure-leaves-active, validation errors, JSON shape, and the end-to-end `App_ProviderSwitchAtRuntime` (a turn after `/provider cloud` streams from the switched provider).
4. [agent/host/config.go](https://github.com/panyam/mcpkit/pull/990/files#diff-6aff502cc5cae4b9d9769752e8638899bab121e09de870b5d1320cc892c6bf2d), `persistence.go` (the `WithProviderBuilder` test seam), `render.go` — small wiring.

## Decision log

- **`providerSwitch` indirection over rebuilding the Runner.** A swap sets the switch's underlying provider under a mutex; the Runner holds the switch and never rebuilds. A turn already streaming finishes on its original provider; the swap takes effect on the next model call — the right UX and no rebuild races (proactive event-turns can run concurrently).
- **Registry path is additive, gated on `Config.Connections != nil`.** Every existing config (single `Model`, optional `Backup`/failover) is byte-for-byte unchanged; `WithProvider` (tests) still wins.
- **Lazy build + cache.** Only the active connection builds at startup, so a misconfigured non-active connection doesn't fail launch; switching back to a used connection is instant and returns the same instance (pinned by the cache test).
- **`SetActive` leaves the previous active in place on unknown-name or build failure** — a failed `/provider` never strands the session without a provider.
- **`ThinkingHint` carried but inert.** The registry stores it; the inline-`<think>`-tag stream parser is #989 (it needs cross-chunk stateful parsing, its own focused change). Descoped to keep this PR the registry keystone.
- **llm.json-*inspired*, not byte-compatible.** mcpkit camelCase tags (`type`/`baseUrl`/`apiKeyEnv`/`thinkingHint`) rather than the reference file's `connection`/`api-Key`/`thinking-hint`; a verbatim llm.json importer could be a follow-up if you want to drop your file in directly.

## Risk / blast radius

- Affects: `agent/host` only; agentchat gains `/provider` for free (host REPL). Nothing changes unless a config sets `Connections`.
- Tests: 7 new; existing host suite green; red-before-green verified on the runtime switch. `make test-agent` 9/9. 0 assertions removed or weakened.
- Be paranoid about: the switch taking effect mid-session (documented: next model call), and the additive gating (no-Connections path must be identical — `App_NoConnectionsProvidersEmpty` pins the empty surface).

## Before / after

```
# config with two connections, active "local":
> /provider
  ▸ local
    cloud
> /provider cloud
    local
  ▸ cloud
> what model are you?          # this turn streams from the "cloud" connection
```
Before this PR agentchat had one `--model` for the whole session; `/provider` did not exist.

## Out of scope (deliberately deferred — epic #983)

- Structured render/event seam + command registry → #985
- `RunStore.ListRuns` + `/sessions` → #986
- bubbletea TUI (input, history, scrollback, **tab-autocomplete slash palette**) → #987
- `make pg` + example config → #988
- thinking-hint inline-tag parser → #989
- `/embedder` and `/judgelm` roles over this same registry → land with the Embedder seam (Phase 2 recall) and the eval judge (#974)
