### PR TITLE
feat(agent/host): slash-command registry with structured CmdResult

### DIFF
--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -3,6 +3,7 @@ package host
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -57,6 +58,10 @@ type App struct {
 	// its underlying. Both nil when Connections is not configured.
 	connections    *ConnectionRegistry
 	providerSwitch *providerSwitch
+
+	// commands is the slash-command registry every surface dispatches
+	// through (Dispatch / Commands). Built in NewApp.
+	commands *CommandRegistry
 }
 
 // AppOption customizes construction. The provider override exists so tests
@@ -284,6 +289,7 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 		return nil, err
 	}
 	app.runner = runner
+	app.registerBuiltinCommands()
 
 	if app.metaTools {
 		evCtx, cancel := context.WithCancel(context.Background())
@@ -370,16 +376,6 @@ func (a *App) Tools(ctx context.Context) error {
 	return nil
 }
 
-// setApprovalMode handles "/approve <mode>": it flips the live policy's
-// default disposition. A no-op with a note when approval is not configured.
-func (a *App) setApprovalMode(arg string) {
-	if a.approval == nil {
-		a.renderer.approvalMode(nil)
-		return
-	}
-	a.approval.SetDefaultMode(parseApprovalMode(arg))
-	a.renderer.approvalMode(a.approval)
-}
 
 // Providers returns the configured connection names and the active one,
 // or (nil, "") when no connection registry is configured. Structured so a
@@ -420,49 +416,17 @@ func (a *App) REPL(ctx context.Context, in io.Reader, turnCtx func() (context.Co
 		line := strings.TrimSpace(scanner.Text())
 		switch {
 		case line == "":
-		case line == "/quit" || line == "/exit":
-			return nil
-		case line == "/tools":
-			if err := a.Tools(ctx); err != nil {
-				a.renderer.turnFailed(err)
-			}
-		case line == "/history":
-			a.renderer.history(a.history)
-		case line == "/health":
-			a.renderer.health(a.failover)
-		case line == "/tasks":
-			a.renderer.taskList(a.snapshotTasks())
-		case strings.HasPrefix(line, "/tasks cancel "):
-			a.cancelTask(strings.TrimPrefix(line, "/tasks cancel "))
-		case line == "/approve":
-			a.renderer.approvalMode(a.approval)
-		case strings.HasPrefix(line, "/approve "):
-			a.setApprovalMode(strings.TrimPrefix(line, "/approve "))
-		case line == "/provider":
-			a.renderer.providers(a.Providers())
-		case strings.HasPrefix(line, "/provider "):
-			name := strings.TrimSpace(strings.TrimPrefix(line, "/provider "))
-			if err := a.SwitchProvider(name); err != nil {
+		case strings.HasPrefix(line, "/"):
+			res, err := a.Dispatch(ctx, line)
+			if errors.Is(err, ErrUnknownCommand) {
+				a.renderer.turnFailed(fmt.Errorf("unknown command %q (try /tools, /provider, /session, /quit)", line))
+			} else if err != nil {
 				a.renderer.turnFailed(err)
 			} else {
-				a.renderer.providers(a.Providers())
-			}
-		case line == "/session":
-			a.renderer.session(a.RunID())
-		case strings.HasPrefix(line, "/resume "):
-			id := strings.TrimSpace(strings.TrimPrefix(line, "/resume "))
-			if err := a.Resume(ctx, id); err != nil {
-				a.renderer.turnFailed(err)
-			} else {
-				a.renderer.session(id)
-			}
-		case line == "/fork" || strings.HasPrefix(line, "/fork "):
-			id := strings.TrimSpace(strings.TrimPrefix(line, "/fork"))
-			forkID, err := a.Fork(ctx, id, 0)
-			if err != nil {
-				a.renderer.turnFailed(err)
-			} else {
-				a.renderer.session(forkID)
+				a.renderer.command(res)
+				if res.Quit {
+					return nil
+				}
 			}
 		default:
 			tctx, cancel := turnCtx()

--- a/agent/host/app_test.go
+++ b/agent/host/app_test.go
@@ -273,7 +273,11 @@ func TestAppApprovalRuntimeToggle(t *testing.T) {
 	}
 	defer app.Close()
 
-	app.setApprovalMode("allow")
+	if res, err := app.Dispatch(context.Background(), "/approve allow"); err != nil {
+		t.Fatal(err)
+	} else {
+		app.renderer.command(res)
+	}
 	if app.approval.DefaultMode() != agent.ModeAlwaysAllow {
 		t.Fatalf("runtime toggle did not take: %v", app.approval.DefaultMode())
 	}
@@ -288,7 +292,11 @@ func TestAppApprovalRuntimeToggle(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer app2.Close()
-	app2.setApprovalMode("allow")
+	if res, err := app2.Dispatch(context.Background(), "/approve allow"); err != nil {
+		t.Fatal(err)
+	} else {
+		app2.renderer.command(res)
+	}
 	if !strings.Contains(out2.String(), "approval: off") {
 		t.Fatalf("no-policy toggle should say off:\n%s", out2.String())
 	}

--- a/agent/host/commands.go
+++ b/agent/host/commands.go
@@ -1,0 +1,240 @@
+package host
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/panyam/mcpkit/agent"
+	"github.com/panyam/mcpkit/client"
+	"github.com/panyam/mcpkit/core"
+)
+
+// CmdKind tags a CmdResult so a surface renders it without re-parsing.
+// One kind per distinct command output shape.
+type CmdKind string
+
+const (
+	// CmdMessage is a plain informational or confirmation line (Message).
+	CmdMessage CmdKind = "message"
+	// CmdProviders lists model connections (Providers + ActiveProvider).
+	CmdProviders CmdKind = "providers"
+	// CmdSession reports the active run id (RunID; empty = persistence off).
+	CmdSession CmdKind = "session"
+	// CmdTools lists the merged tool set (Tools).
+	CmdTools CmdKind = "tools"
+	// CmdHistory dumps the conversation so far (Messages).
+	CmdHistory CmdKind = "history"
+	// CmdHealth reports provider failover state (Failover; nil = no backup).
+	CmdHealth CmdKind = "health"
+	// CmdTasks lists background tasks (Tasks).
+	CmdTasks CmdKind = "tasks"
+	// CmdApproval reports the approval policy (Approval; nil = gate off).
+	CmdApproval CmdKind = "approval"
+	// CmdQuit signals the loop to exit (Quit true).
+	CmdQuit CmdKind = "quit"
+)
+
+// CmdResult is the structured outcome of a command, rendered by the
+// surface (terminal today, a web client later) rather than printed by the
+// command. Only the fields for the result's Kind are set. Keeping command
+// output as data — not io.Writer prints — is what lets every surface reuse
+// one command set (the web-version unlock; see the render-seam follow-up
+// issue 992, which folds these into the unified UIEvent stream).
+type CmdResult struct {
+	Kind    CmdKind
+	Message string
+
+	Providers      []string
+	ActiveProvider string
+	RunID          string
+	Tools          []core.ToolDef
+	Messages       []agent.Message
+	Failover       *agent.FailoverProvider
+	Tasks          []*client.BackgroundTask
+	Approval       *agent.TieredApproval
+	Quit           bool
+}
+
+// Command is one slash command. Run receives the raw argument string
+// (everything after the command word, trimmed) and returns a structured
+// result. Complete, when set, offers argument completions for a prefix —
+// the seam the TUI tab-palette (issue 987) drives; nil means no argument
+// completion.
+type Command struct {
+	Name     string
+	Aliases  []string
+	Help     string
+	Run      func(ctx context.Context, args string) (CmdResult, error)
+	Complete func(prefix string) []string
+}
+
+// CommandRegistry holds the slash commands a surface dispatches. It is the
+// single source of the command set: the REPL, the future TUI palette, and
+// a web dispatcher all read from one registry, so a new command registered
+// once appears on every surface.
+type CommandRegistry struct {
+	cmds  map[string]*Command // keyed by name and every alias
+	names []string            // canonical names, registration order
+}
+
+// NewCommandRegistry returns an empty registry.
+func NewCommandRegistry() *CommandRegistry {
+	return &CommandRegistry{cmds: map[string]*Command{}}
+}
+
+// Register adds c under its name and aliases. A duplicate name/alias
+// overwrites — last registration wins — so a surface can shadow a default.
+func (r *CommandRegistry) Register(c *Command) {
+	if _, seen := r.cmds[c.Name]; !seen {
+		r.names = append(r.names, c.Name)
+	}
+	r.cmds[c.Name] = c
+	for _, a := range c.Aliases {
+		r.cmds[a] = c
+	}
+}
+
+// Lookup resolves a command by name or alias (the leading "/" stripped).
+func (r *CommandRegistry) Lookup(name string) (*Command, bool) {
+	c, ok := r.cmds[strings.TrimPrefix(name, "/")]
+	return c, ok
+}
+
+// Names returns the canonical command names in registration order.
+func (r *CommandRegistry) Names() []string {
+	return append([]string(nil), r.names...)
+}
+
+// Match returns the canonical names beginning with prefix (the "/" is
+// optional), sorted — the command-name completion the TUI palette uses.
+func (r *CommandRegistry) Match(prefix string) []string {
+	prefix = strings.TrimPrefix(prefix, "/")
+	var out []string
+	for _, n := range r.names {
+		if strings.HasPrefix(n, prefix) {
+			out = append(out, n)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Dispatch parses a "/name args" line, looks the command up, and runs it.
+// A line that is not a known command returns (CmdResult{}, ErrUnknownCommand)
+// so the caller can distinguish "not a command, treat as a turn" from a
+// command that failed.
+func (a *App) Dispatch(ctx context.Context, line string) (CmdResult, error) {
+	line = strings.TrimSpace(line)
+	word, args, _ := strings.Cut(line, " ")
+	cmd, ok := a.commands.Lookup(word)
+	if !ok {
+		return CmdResult{}, ErrUnknownCommand
+	}
+	return cmd.Run(ctx, strings.TrimSpace(args))
+}
+
+// Commands exposes the registry so a surface can list commands or drive
+// tab-completion.
+func (a *App) Commands() *CommandRegistry { return a.commands }
+
+// ErrUnknownCommand is returned by Dispatch when the line is not a
+// registered command (so the caller treats it as a conversational turn,
+// not an error to surface).
+var ErrUnknownCommand = errUnknownCommand{}
+
+type errUnknownCommand struct{}
+
+func (errUnknownCommand) Error() string { return "host: unknown command" }
+
+// registerBuiltinCommands populates the registry with the standard slash
+// commands, each binding an App method and returning a structured result.
+// Surface-agnostic: no rendering happens here.
+func (a *App) registerBuiltinCommands() {
+	r := NewCommandRegistry()
+	msg := func(s string) (CmdResult, error) { return CmdResult{Kind: CmdMessage, Message: s}, nil }
+
+	r.Register(&Command{Name: "quit", Aliases: []string{"exit"}, Help: "exit agentchat",
+		Run: func(context.Context, string) (CmdResult, error) { return CmdResult{Kind: CmdQuit, Quit: true}, nil }})
+
+	r.Register(&Command{Name: "tools", Help: "list the merged tool set",
+		Run: func(ctx context.Context, _ string) (CmdResult, error) {
+			defs, err := a.sources.Tools(ctx)
+			if err != nil {
+				return CmdResult{}, err
+			}
+			return CmdResult{Kind: CmdTools, Tools: defs}, nil
+		}})
+
+	r.Register(&Command{Name: "history", Help: "show the conversation so far",
+		Run: func(context.Context, string) (CmdResult, error) {
+			return CmdResult{Kind: CmdHistory, Messages: a.history}, nil
+		}})
+
+	r.Register(&Command{Name: "health", Help: "show model failover state",
+		Run: func(context.Context, string) (CmdResult, error) {
+			return CmdResult{Kind: CmdHealth, Failover: a.failover}, nil
+		}})
+
+	r.Register(&Command{Name: "tasks", Help: "list background tasks; /tasks cancel <id>",
+		Run: func(_ context.Context, args string) (CmdResult, error) {
+			if id, ok := strings.CutPrefix(args, "cancel "); ok {
+				a.cancelTask(strings.TrimSpace(id))
+				return msg("cancel requested for " + strings.TrimSpace(id))
+			}
+			return CmdResult{Kind: CmdTasks, Tasks: a.snapshotTasks()}, nil
+		}})
+
+	r.Register(&Command{Name: "approve", Help: "show or set approval mode (allow | read-only-auto | ask)",
+		Run: func(_ context.Context, args string) (CmdResult, error) {
+			if args != "" && a.approval != nil {
+				a.approval.SetDefaultMode(parseApprovalMode(args))
+			}
+			return CmdResult{Kind: CmdApproval, Approval: a.approval}, nil
+		}})
+
+	r.Register(&Command{Name: "session", Help: "show the active session id",
+		Run: func(context.Context, string) (CmdResult, error) {
+			return CmdResult{Kind: CmdSession, RunID: a.RunID()}, nil
+		}})
+
+	r.Register(&Command{Name: "resume", Help: "switch to an existing session: /resume <id>",
+		Run: func(ctx context.Context, args string) (CmdResult, error) {
+			if err := a.Resume(ctx, args); err != nil {
+				return CmdResult{}, err
+			}
+			return CmdResult{Kind: CmdSession, RunID: args}, nil
+		}})
+
+	r.Register(&Command{Name: "fork", Help: "fork the current session: /fork [new-id]",
+		Run: func(ctx context.Context, args string) (CmdResult, error) {
+			id, err := a.Fork(ctx, args, 0)
+			if err != nil {
+				return CmdResult{}, err
+			}
+			return CmdResult{Kind: CmdSession, RunID: id}, nil
+		}})
+
+	r.Register(&Command{Name: "provider", Help: "list or switch model connections: /provider [name]",
+		Run: func(_ context.Context, args string) (CmdResult, error) {
+			if args != "" {
+				if err := a.SwitchProvider(args); err != nil {
+					return CmdResult{}, err
+				}
+			}
+			names, active := a.Providers()
+			return CmdResult{Kind: CmdProviders, Providers: names, ActiveProvider: active}, nil
+		},
+		Complete: func(prefix string) []string {
+			names, _ := a.Providers()
+			var out []string
+			for _, n := range names {
+				if strings.HasPrefix(n, prefix) {
+					out = append(out, n)
+				}
+			}
+			return out
+		}})
+
+	a.commands = r
+}

--- a/agent/host/commands_test.go
+++ b/agent/host/commands_test.go
@@ -1,0 +1,151 @@
+package host
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/panyam/mcpkit/agent"
+)
+
+func TestCommandRegistry_RegisterLookupMatch(t *testing.T) {
+	r := NewCommandRegistry()
+	r.Register(&Command{Name: "provider", Run: nil})
+	r.Register(&Command{Name: "quit", Aliases: []string{"exit"}})
+
+	if _, ok := r.Lookup("provider"); !ok {
+		t.Fatal("Lookup(provider) failed")
+	}
+	if _, ok := r.Lookup("/exit"); !ok {
+		t.Fatal("Lookup by alias with leading slash failed")
+	}
+	if _, ok := r.Lookup("nope"); ok {
+		t.Fatal("Lookup(nope) should fail")
+	}
+	// Match: prefix "p" and "q" (aliases excluded from canonical names)
+	if got := r.Match("p"); len(got) != 1 || got[0] != "provider" {
+		t.Fatalf("Match(p) = %v", got)
+	}
+	if got := r.Match("/qu"); len(got) != 1 || got[0] != "quit" {
+		t.Fatalf("Match(/qu) = %v", got)
+	}
+	if names := r.Names(); len(names) != 2 {
+		t.Fatalf("Names() = %v, want 2 canonical", names)
+	}
+}
+
+func newCmdApp(t *testing.T) (*App, *strings.Builder) {
+	t.Helper()
+	ts := startTestServer(t)
+	cfg := testConfig(ts.URL)
+	cfg.Connections = twoConn()
+	var out strings.Builder
+	app, err := NewApp(cfg, &out, strings.NewReader(""),
+		WithProviderBuilder(stubBuilder(t)), WithRunStore(agent.NewInMemoryRunStore()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(app.Close)
+	return app, &out
+}
+
+func TestApp_DispatchUnknownCommand(t *testing.T) {
+	app, _ := newCmdApp(t)
+	if _, err := app.Dispatch(context.Background(), "/bogus"); !errors.Is(err, ErrUnknownCommand) {
+		t.Fatalf("Dispatch(/bogus) err = %v, want ErrUnknownCommand", err)
+	}
+}
+
+func TestApp_DispatchProviderListAndSwitch(t *testing.T) {
+	ctx := context.Background()
+	app, _ := newCmdApp(t)
+
+	res, err := app.Dispatch(ctx, "/provider")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Kind != CmdProviders || res.ActiveProvider != "local" || len(res.Providers) != 2 {
+		t.Fatalf("/provider = %+v", res)
+	}
+	res, err = app.Dispatch(ctx, "/provider cloud")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.ActiveProvider != "cloud" {
+		t.Fatalf("/provider cloud active = %q", res.ActiveProvider)
+	}
+	// a bad connection name is a command error, not a crash
+	if _, err := app.Dispatch(ctx, "/provider nope"); err == nil {
+		t.Fatal("/provider nope should error")
+	}
+}
+
+func TestApp_DispatchSessionResumeFork(t *testing.T) {
+	ctx := context.Background()
+	app, _ := newCmdApp(t)
+
+	// a turn creates the run so /session has something to report
+	if err := app.RunTurn(ctx, "one"); err != nil {
+		t.Fatal(err)
+	}
+	sess, err := app.Dispatch(ctx, "/session")
+	if err != nil || sess.Kind != CmdSession || sess.RunID == "" {
+		t.Fatalf("/session = (%+v, %v)", sess, err)
+	}
+	fork, err := app.Dispatch(ctx, "/fork")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fork.Kind != CmdSession || fork.RunID == "" || fork.RunID == sess.RunID {
+		t.Fatalf("/fork = %+v (should be a new run id)", fork)
+	}
+	// resume back to the original
+	if _, err := app.Dispatch(ctx, "/resume "+sess.RunID); err != nil {
+		t.Fatalf("/resume: %v", err)
+	}
+	if got := app.RunID(); got != sess.RunID {
+		t.Fatalf("resume left run at %q, want %q", got, sess.RunID)
+	}
+}
+
+func TestApp_DispatchToolsAndQuit(t *testing.T) {
+	ctx := context.Background()
+	app, _ := newCmdApp(t)
+
+	tools, err := app.Dispatch(ctx, "/tools")
+	if err != nil || tools.Kind != CmdTools {
+		t.Fatalf("/tools = (%+v, %v)", tools, err)
+	}
+	q, err := app.Dispatch(ctx, "/quit")
+	if err != nil || !q.Quit || q.Kind != CmdQuit {
+		t.Fatalf("/quit = (%+v, %v)", q, err)
+	}
+}
+
+// TestApp_ProviderCompleter pins the argument-completion seam the TUI
+// palette (issue 987) will drive.
+func TestApp_ProviderCompleter(t *testing.T) {
+	app, _ := newCmdApp(t)
+	cmd, ok := app.Commands().Lookup("provider")
+	if !ok || cmd.Complete == nil {
+		t.Fatal("provider command has no completer")
+	}
+	if got := cmd.Complete("cl"); len(got) != 1 || got[0] != "cloud" {
+		t.Fatalf("Complete(cl) = %v, want [cloud]", got)
+	}
+}
+
+// TestApp_REPLDispatchesCommands drives the real REPL loop over scripted
+// input to prove commands still work end to end after the migration.
+func TestApp_REPLDispatchesCommands(t *testing.T) {
+	app, out := newCmdApp(t)
+	in := strings.NewReader("/provider\n/provider cloud\n/quit\n")
+	if err := app.REPL(context.Background(), in, nil); err != nil {
+		t.Fatal(err)
+	}
+	s := out.String()
+	if !strings.Contains(s, "local") || !strings.Contains(s, "cloud") {
+		t.Fatalf("REPL did not render provider list/switch:\n%s", s)
+	}
+}

--- a/agent/host/render.go
+++ b/agent/host/render.go
@@ -239,3 +239,29 @@ func (r *renderer) providers(names []string, active string) {
 		fmt.Fprintf(r.out, "%s\n", r.dim(marker+n))
 	}
 }
+
+// command renders a CmdResult by dispatching to the shape-specific
+// renderer for its Kind — the terminal implementation of the structured
+// command output (a web surface would serialize the CmdResult instead).
+func (r *renderer) command(res CmdResult) {
+	switch res.Kind {
+	case CmdMessage:
+		fmt.Fprintf(r.out, "%s\n", r.dim(res.Message))
+	case CmdProviders:
+		r.providers(res.Providers, res.ActiveProvider)
+	case CmdSession:
+		r.session(res.RunID)
+	case CmdTools:
+		r.toolList(res.Tools)
+	case CmdHistory:
+		r.history(res.Messages)
+	case CmdHealth:
+		r.health(res.Failover)
+	case CmdTasks:
+		r.taskList(res.Tasks)
+	case CmdApproval:
+		r.approvalMode(res.Approval)
+	case CmdQuit:
+		// nothing to render; the loop exits
+	}
+}


### PR DESCRIPTION
Part of epic #983 (PR2). Closes the **command-registry half** of #985; the render/event seam (the io.Writer→UIEvent rewrite) is split to #992 to keep each PR reviewable. Based on `main`.

## What changes

The slash commands move out of the REPL's hardcoded `switch` into a surface-agnostic `CommandRegistry`. Each command's handler returns a **structured `CmdResult`** (a tagged union of the command outputs) instead of printing — so the terminal REPL, the future bubbletea palette, and a future web dispatcher all drive one command set. `App.Dispatch(line)` parses/looks-up/runs; `App.Commands()` exposes the registry (`Names`/`Match`/`Lookup` + per-command `Complete`) — the seam the tab-autocomplete palette (#987) plugs into.

## Reviewer's guide

Read in this order:
1. [agent/host/commands.go](https://github.com/panyam/mcpkit/pull/993/files#diff-d44c9aac08cff5c51623cc064ae8e0dbbef19ba85d048cf9996ed8f99b61ac39) — the whole feature: `CmdResult`/`CmdKind` (the structured outputs), `Command`/`CommandRegistry` (register/lookup/match + `Complete`), `App.Dispatch` + `ErrUnknownCommand`, and `registerBuiltinCommands` (the migrated command set — each binds an App method, returns data, renders nothing).
2. [agent/host/app.go](https://github.com/panyam/mcpkit/pull/993/files#diff-89fb8e04b6e1e9d5f7f76958490ef158dee40e2cae92d87c04b408d893c84361) — the REPL loop, now `read → Dispatch → renderer.command(res)` (was a ~50-line `switch`); the `commands` field + `registerBuiltinCommands()` call in NewApp.
3. [agent/host/render.go](https://github.com/panyam/mcpkit/pull/993/files#diff-da3546e85434193f7b8b2df15f4f6d6df496b616b9e0b0b8c4299cd4576e044a) — `renderer.command(res)`: the terminal's switch on `CmdKind` → the existing shape renderers. This is the one place that knows how to draw a `CmdResult`; a web surface serializes it instead.
4. [agent/host/commands_test.go](https://github.com/panyam/mcpkit/pull/993/files#diff-ee8ed899f3699d7840668725caef91fafc4284eb488806cdc52575e85bbb27a0) — registry register/lookup/match, per-command dispatch (provider list/switch, session/resume/fork, tools/quit), the completer seam, and `REPLDispatchesCommands` (the real loop over scripted input).

## Decision log

- **Handlers return data (`CmdResult`), not prints.** That's the web-version unlock: a command's logic is reusable by any surface because it doesn't touch io.Writer. The terminal `renderer.command` is the only terminal-specific piece.
- **Split render seam to #992.** Rewriting the ~20 `*renderer` io.Writer methods into a `UIEvent` stream is a large, separable concern. Doing it here would bury the command-registry change in a sprawling diff. The two non-serializable `CmdResult` fields (health `*FailoverProvider`, `[]*BackgroundTask`) become serializable snapshots there.
- **`Complete` hook on `Command` now, TUI later.** `/provider` ships a real completer (connection names); the tab-palette UI that calls it is #987. Wiring the seam now means the palette is pure UI later.
- **`ErrUnknownCommand` sentinel** so the REPL distinguishes "not a command → treat as a turn" from a command that failed. (In the REPL a leading `/` that isn't known is surfaced as an error with a hint, rather than sent to the model.)
- **Removed the dead private `setApprovalMode`** (its two test call sites migrated to `Dispatch("/approve …")`); `App.Tools` stays (exported).

## Risk / blast radius

- Affects: `agent/host` REPL + command handling. Every existing command behaves the same (pinned by the migrated `setApprovalMode` tests + the new per-command dispatch tests + the end-to-end `REPLDispatchesCommands`). No agentchat CLI change.
- Tests: 8 new; existing host suite green; red-before-green verified on the dispatch path. `make test-agent` 9/9. Assertions: ~30 added, 0 removed (2 test call sites rewritten to the new dispatch, same assertions).
- Be paranoid about: the `/tasks cancel <id>` sub-command parsing (now `args == "cancel …"` inside the handler) and that an unknown `/command` no longer silently becomes a turn.

## Before / after

```
BEFORE  REPL: 50-line switch { case "/tools": …; case "/provider ": …; … }  (io.Writer prints inline)
AFTER   REPL: line → Dispatch(line) → CmdResult → renderer.command(res)
        commands live in one registry; /provider<Tab> completer ready; web reuses Dispatch
```

## Out of scope (deliberately deferred — epic #983)

- Render/event seam (io.Writer → UIEvent stream) → #992
- `RunStore.ListRuns` + `/sessions` + the N-session model → #986
- bubbletea TUI + tab-autocomplete palette (drives `Match`/`Complete`) → #987
