### PR TITLE
feat: make pg playground + example config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,9 @@ check-apps-compat-stale: refresh-apps-compat-report ## Fail if conformance/apps/
 		exit 1 \
 	)
 
+pg: ## Playground: boot the demo MCP server + launch agentchat's TUI (needs a local OpenAI-compatible model; see examples/playground/README.md)
+	bash scripts/playground.sh
+
 test-agent: ## Run agent sub-module tests
 	cd agent && go test ./... -count=1 -timeout 30s
 	cd agent/store/redis && go test ./... -count=1 -timeout 60s

--- a/agent/host/config.go
+++ b/agent/host/config.go
@@ -350,8 +350,12 @@ func LoadConfig(path string) (*Config, error) {
 
 // Validate enforces the invariants the app relies on.
 func (c *Config) Validate() error {
-	if c.Model.BaseURL == "" || c.Model.Model == "" {
-		return fmt.Errorf("model.baseUrl and model.model are required")
+	// A connections registry supersedes Model for the chat provider, so
+	// Model is only required when no connections are configured.
+	if c.Connections == nil {
+		if c.Model.BaseURL == "" || c.Model.Model == "" {
+			return fmt.Errorf("model.baseUrl and model.model are required (or set a connections block)")
+		}
 	}
 	seen := map[string]bool{}
 	for i, s := range c.Servers {

--- a/agent/host/config_test.go
+++ b/agent/host/config_test.go
@@ -1,0 +1,21 @@
+package host
+
+import "testing"
+
+func TestConfigValidate_ConnectionsSupersedeModel(t *testing.T) {
+	// connections-only config is valid without a Model block
+	c := &Config{
+		Connections: &ConnectionsConfig{
+			Active:      "local",
+			Connections: map[string]ConnectionConfig{"local": {Type: "lmstudio", Model: "m"}},
+		},
+		Servers: []ServerConfig{{ID: "s", URL: "http://x/mcp"}},
+	}
+	if err := c.Validate(); err != nil {
+		t.Fatalf("connections-only config should validate: %v", err)
+	}
+	empty := &Config{Servers: []ServerConfig{{ID: "s", URL: "http://x/mcp"}}}
+	if err := empty.Validate(); err == nil {
+		t.Fatal("config with neither model nor connections should error")
+	}
+}

--- a/examples/playground/README.md
+++ b/examples/playground/README.md
@@ -1,0 +1,33 @@
+# agentchat playground
+
+One command to feel the mcpkit agent SDK: `make pg` from the repo root boots a
+demo MCP server (`examples/getting-started/server`, a `greet` tool on
+`:8787`) and launches `agentchat` in its TUI, wired to a local model, a
+SQLite session store, and a filesystem offload dir.
+
+```bash
+make pg
+```
+
+## What you need
+
+A local OpenAI-compatible model endpoint. The bundled `playground.json`
+assumes [LM Studio](https://lmstudio.ai) on its default `http://localhost:1234/v1`
+with a model named `qwen2.5-7b-instruct` loaded. Edit `connections` in
+`playground.json` to match what you have (or point `type`/`baseUrl` at Ollama,
+vLLM, or any OpenAI-compatible server). `/provider` in the TUI switches between
+the configured connections at runtime.
+
+## What to try in the TUI
+
+- Type a message. Ask it to `greet` someone — watch the live tool call.
+- `↑` / `↓` recall previous inputs; the input box is editable and cursor-traversable.
+- `/` then `Tab` completes slash commands; `/provider `<Tab> cycles connections,
+  `/sessions `<Tab> cycles saved sessions.
+- `/fork` branches the conversation; `/sessions` lists saved sessions and switches;
+  `/resume <id>` reopens one. Sessions persist to the SQLite file, so they survive
+  restarts.
+- Large tool outputs are offloaded to `~/.agentchat/pg-blobs/` and replaced by a
+  stub the model can query with `read_tool_result`.
+
+`--ui plain` (or piping) falls back to the line-based REPL.

--- a/examples/playground/playground.json
+++ b/examples/playground/playground.json
@@ -1,0 +1,17 @@
+{
+  "instructions": "You are a helpful assistant with access to tools. Be concise.",
+  "connections": {
+    "active": "local",
+    "connections": {
+      "local": { "type": "lmstudio", "model": "qwen2.5-7b-instruct" },
+      "local-thinker": {
+        "type": "lmstudio",
+        "model": "deepseek-r1-distill-llama-8b",
+        "thinkingHint": { "openTag": "<think>", "closeTag": "</think>" }
+      }
+    }
+  },
+  "servers": [
+    { "id": "demo", "url": "http://localhost:8787/mcp" }
+  ]
+}

--- a/scripts/playground.sh
+++ b/scripts/playground.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Playground launcher (make pg): boots the getting-started demo MCP server
+# and launches agentchat's TUI wired to it. Needs a local OpenAI-compatible
+# model; see examples/playground/README.md.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DATA="${AGENTCHAT_PG_DIR:-$HOME/.agentchat}"
+mkdir -p "$DATA" "$DATA/pg-blobs"
+
+echo "==> booting demo MCP server (getting-started 'greet') on :8787"
+( cd "$ROOT/examples/getting-started" && go run ./server ) &
+SERVER_PID=$!
+trap 'kill "$SERVER_PID" 2>/dev/null || true' EXIT
+
+for _ in $(seq 1 30); do
+	if curl -s -o /dev/null http://localhost:8787/mcp 2>/dev/null; then break; fi
+	sleep 0.5
+done
+
+echo "==> launching agentchat playground (TUI). Edit examples/playground/playground.json for your model."
+cd "$ROOT/cmd/agentchat"
+go run . \
+	--config "$ROOT/examples/playground/playground.json" \
+	--session-store "sqlite://$DATA/pg.db" \
+	--offload-dir "$DATA/pg-blobs" \
+	--offload-threshold 4096 \
+	--ui tui


### PR DESCRIPTION
Closes #988. Part of epic #983 (PR6, the last). Stacks on PR 997 (TUI) → 996 → 995 → 993. **No CI while based on a non-main branch** — verified with `make test-agent` (9/9), both binaries compile, and the example config loads through `host.LoadConfig`.

## What changes

`make pg` — one command to feel the SDK. It boots the getting-started demo MCP server (a `greet` tool on `:8787`) and launches agentchat's TUI wired to it, with a bundled connections config, a SQLite session store, and a filesystem offload dir. A fresh clone is one command (plus a local model) away from driving sessions, fork/rewind, provider switching, and offloading live.

## Reviewer's guide

Read in this order:
1. [examples/playground/playground.json](https://github.com/panyam/mcpkit/pull/998/files#diff-289ac934858630d22c947317d8b41ce6f8a541252752e8ae4b3cb33b3faa8e18) — the bundled config: a `connections` block (llm.json shape, lmstudio default + a thinking-hint example) and the demo server. No `Model` block — it relies on the Validate fix below.
2. [examples/playground/README.md](https://github.com/panyam/mcpkit/pull/998/files#diff-0036a623f4327e869d5403d97a05b7e08b0b517419276e3cc2ca9b4b0fccb039) — what you need (a local OpenAI-compatible model) and what to try in the TUI.
3. [scripts/playground.sh](https://github.com/panyam/mcpkit/pull/998/files#diff-22563f659ffc7bd79174d7192b18ad0e6378d16035fdd4d4f7795029027a2090) — boot the demo server (background, `trap`-cleaned), wait for `:8787`, launch agentchat with `--session-store sqlite`, `--offload-dir`, `--ui tui`.
4. [agent/host/config.go](https://github.com/panyam/mcpkit/pull/998/files#diff-6aff502cc5cae4b9d9769752e8638899bab121e09de870b5d1320cc892c6bf2d) — `Validate` no longer requires `Model` when a `connections` block is present (the example config is connections-only).
5. [Makefile](https://github.com/panyam/mcpkit/pull/998/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52) — the `pg` target.

## Decision log

- **Reuse `examples/getting-started/server`** as the demo rather than a new bundled server — it is the repo's simplest real MCP server (one `greet` tool), already maintained, and gives a live tool call to watch.
- **`scripts/playground.sh`, not inline Makefile** — background-process + cleanup is fragile in a recipe; a script with `trap ... EXIT` kills the server reliably when the TUI exits.
- **Config `Validate` fix ships here** because the connections-only example is the first config to exercise it — `Model` is genuinely optional once `connections` supersedes it (pinned by a new test).
- **Model name is a placeholder** (`qwen2.5-7b-instruct`); the README says to edit it, and `/provider` switches at runtime — the one thing that depends on the operator's machine, called out rather than guessed.

## Risk / blast radius

- Affects: new files + one `Validate` branch + a Makefile target. No behavior change to existing configs (Model-based configs validate exactly as before).
- Tests: 1 new (connections-only validates, neither errors); example config load verified; `make test-agent` 9/9. 0 assertions removed.
- Be paranoid about: the script's server-readiness wait (curl poll on `:8787`, 15s budget) and that `make pg` needs a local model the operator supplies — documented, and the non-model commands (`/provider`, `/tools`, `/sessions`) work without one.

## Before / after

```
before:  assemble it yourself — boot a server, find a model, remember 5 flags
after:   make pg
         → demo MCP server on :8787
         → agentchat TUI: sessions (sqlite), offloading (files), /provider switching
         (edit examples/playground/playground.json for your model)
```

## Out of scope

- Nothing deferred — this closes the playground epic's build-out. Remaining epic tails are follow-ups already filed: serializable UIEvent snapshots (#994), thinking-hint parser (#989), provider routing policy (#991), concurrent per-session state (#986 thread), teatest golden frames.
