### PR TITLE
feat(agent): working memory — MemorySource remember/recall/forget (issue 938)

### DIFF
--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -22,14 +22,14 @@ import (
 // parsing and signal handling. Construct with NewApp, converse with RunTurn
 // (one input, one rendered turn) or REPL (interactive loop).
 type App struct {
-	cfg      *Config
-	runner   *agent.Runner
-	sources  *agent.MultiSource
-	clients  []*client.Client
-	history  []agent.Message
+	cfg       *Config
+	runner    *agent.Runner
+	sources   *agent.MultiSource
+	clients   []*client.Client
+	history   []agent.Message
 	observers []Observer
-	replOut  io.Writer // terminal REPL draws its own prompt here
-	failover *agent.FailoverProvider
+	replOut   io.Writer // terminal REPL draws its own prompt here
+	failover  *agent.FailoverProvider
 
 	injection *agent.InjectionPolicy
 	triggers  *agent.TriggerPolicy
@@ -54,6 +54,11 @@ type App struct {
 	// is set; nil when offloading is off.
 	toolResultStore agent.ToolResultStore
 
+	// memory is the working-memory source when Config.Memory is set; nil
+	// when memory is off. Held so RunTurn can inject its summary and the
+	// /memory command can list it.
+	memory *agent.MemorySource
+
 	// connections + providerSwitch are the runtime provider-switch seam
 	// (Config.Connections): the Runner holds the switch, /provider swaps
 	// its underlying. Both nil when Connections is not configured.
@@ -76,6 +81,7 @@ type appOptions struct {
 	logger          *slog.Logger
 	store           agent.RunStore
 	toolResultStore agent.ToolResultStore
+	memoryStore     agent.MemoryStore
 	providerBuilder ProviderBuilder
 	observers       []Observer
 }
@@ -262,6 +268,16 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 		}
 	}
 
+	// Working memory is a leaf source added to the aggregate, so its
+	// remember/recall/forget tools sit alongside the server tools (and are
+	// covered by offloading below like any other source).
+	if cfg.Memory != nil {
+		if err := app.registerMemory(multi, o.memoryStore); err != nil {
+			app.Close()
+			return nil, err
+		}
+	}
+
 	// Offloading wraps the whole aggregate, so one read_tool_result and
 	// one store cover every server's tools. The stub it substitutes is a
 	// normal ToolResult, so the transcript and persisted log see exactly
@@ -342,6 +358,7 @@ func (a *App) RunTurn(ctx context.Context, input string) error {
 	defer a.turnMu.Unlock()
 	a.triggers.NotifyEngagement()
 	a.drainInjectionLocked()
+	a.injectMemoryLocked(ctx)
 	userMsg := agent.Message{Role: agent.RoleUser, Text: input}
 	a.history = append(a.history, userMsg)
 
@@ -380,7 +397,6 @@ func (a *App) Tools(ctx context.Context) error {
 	a.emit(HostEvent{Kind: HostCommandResult, Command: CmdResult{Kind: CmdTools, Tools: defs}})
 	return nil
 }
-
 
 // Providers returns the configured connection names and the active one,
 // or (nil, "") when no connection registry is configured. Structured so a

--- a/agent/host/commands.go
+++ b/agent/host/commands.go
@@ -174,6 +174,21 @@ func (a *App) registerBuiltinCommands() {
 			return CmdResult{Kind: CmdHistory, Messages: a.history}, nil
 		}})
 
+	r.Register(&Command{Name: "memory", Help: "show working memory (the model's remember/recall scratchpad)",
+		Run: func(ctx context.Context, _ string) (CmdResult, error) {
+			if a.memory == nil {
+				return msg("working memory is off (enable with Config.Memory)")
+			}
+			summary, err := a.memory.Summary(ctx)
+			if err != nil {
+				return CmdResult{}, err
+			}
+			if summary == "" {
+				return msg("working memory is empty")
+			}
+			return msg(summary)
+		}})
+
 	r.Register(&Command{Name: "health", Help: "show model failover state",
 		Run: func(context.Context, string) (CmdResult, error) {
 			return CmdResult{Kind: CmdHealth, Failover: a.failover}, nil

--- a/agent/host/config.go
+++ b/agent/host/config.go
@@ -62,6 +62,24 @@ type Config struct {
 	// supplied by the surface via WithToolResultStore (in-memory when
 	// omitted), the same split as WithRunStore.
 	Offload *OffloadConfig `json:"offload,omitempty"`
+
+	// Memory enables model-managed working memory: a remember/recall/forget
+	// scratchpad the model reads and writes across turns. Nil means off.
+	// The backing MemoryStore is supplied by the surface via
+	// WithMemoryStore (in-memory when omitted), the same split as
+	// WithRunStore and WithToolResultStore.
+	Memory *MemoryConfig `json:"memory,omitempty"`
+}
+
+// MemoryConfig is the host's view of working memory. Its presence enables
+// the MemorySource; the fields tune how memory reaches the turn.
+type MemoryConfig struct {
+	// InjectSummary, when true, prepends a summary of the current
+	// scratchpad as a RoleSystem message before each turn, so the model
+	// stays aware of what it saved without a recall call. It costs tokens
+	// proportional to the scratchpad size, so it is opt-in; when false the
+	// model still reaches memory through the recall tool on demand.
+	InjectSummary bool `json:"injectSummary,omitempty"`
 }
 
 // OffloadConfig is the host's view of tool-result offloading; it maps to

--- a/agent/host/memory.go
+++ b/agent/host/memory.go
@@ -1,0 +1,54 @@
+package host
+
+import (
+	"context"
+
+	"github.com/panyam/mcpkit/agent"
+)
+
+// memorySourceID is the MultiSource id the working-memory tools register
+// under, alongside the "host" meta-tools and the per-server ids.
+const memorySourceID = "memory"
+
+// WithMemoryStore supplies the backing store for working memory
+// (Config.Memory). Omitted, memory uses an in-memory store that dies with
+// the process; a durable, session-scoped backend is a follow-up. Ignored
+// when Config.Memory is nil.
+func WithMemoryStore(store agent.MemoryStore) AppOption {
+	return func(o *appOptions) { o.memoryStore = store }
+}
+
+// registerMemory builds the MemorySource over store (in-memory when nil)
+// and adds it to multi so its remember/recall/forget tools reach the model.
+// The source is held on the App for summary injection and the /memory
+// command.
+func (a *App) registerMemory(multi *agent.MultiSource, store agent.MemoryStore) error {
+	if store == nil {
+		store = agent.NewInMemoryMemoryStore()
+	}
+	src, err := agent.NewMemorySource(store)
+	if err != nil {
+		return err
+	}
+	if err := multi.Add(memorySourceID, src); err != nil {
+		return err
+	}
+	a.memory = src
+	return nil
+}
+
+// injectMemoryLocked prepends the working-memory summary as a RoleSystem
+// message when Config.Memory.InjectSummary is on, so the model stays aware
+// of its scratchpad without a recall call. A summary error is non-fatal —
+// memory awareness is best-effort and must never fail a turn. Caller holds
+// turnMu.
+func (a *App) injectMemoryLocked(ctx context.Context) {
+	if a.memory == nil || a.cfg.Memory == nil || !a.cfg.Memory.InjectSummary {
+		return
+	}
+	summary, err := a.memory.Summary(ctx)
+	if err != nil || summary == "" {
+		return
+	}
+	a.history = append(a.history, agent.Message{Role: agent.RoleSystem, Text: summary})
+}

--- a/agent/host/memory_test.go
+++ b/agent/host/memory_test.go
@@ -1,0 +1,131 @@
+package host
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/panyam/mcpkit/agent"
+	"github.com/panyam/mcpkit/core"
+)
+
+func memoryConfig(url string, injectSummary bool) *Config {
+	c := testConfig(url)
+	c.Memory = &MemoryConfig{InjectSummary: injectSummary}
+	return c
+}
+
+// TestAppWorkingMemoryAcrossTurns is the StubProvider eval for issue 938:
+// the model remembers a fact on one turn and recalls it on a later turn,
+// proving the scratchpad survives across turns through the tools seam.
+func TestAppWorkingMemoryAcrossTurns(t *testing.T) {
+	ts := startTestServer(t)
+	stub := agent.NewStubProvider(
+		// turn 1: the model saves a note
+		agent.StubTurn{ToolCalls: []agent.ToolCall{{
+			ID: "c1", Name: agent.RememberToolName,
+			Args: core.NewRawJSON(json.RawMessage(`{"key":"lang","value":"Go"}`)),
+		}}},
+		agent.StubTurn{Text: "saved"},
+		// turn 2 (a later RunTurn): the model recalls it
+		agent.StubTurn{ToolCalls: []agent.ToolCall{{
+			ID: "c2", Name: agent.RecallToolName,
+			Args: core.NewRawJSON(json.RawMessage(`{"query":"lang"}`)),
+		}}},
+		agent.StubTurn{Text: "it is Go"},
+	)
+	store := agent.NewInMemoryMemoryStore()
+	var out strings.Builder
+	app, err := NewApp(memoryConfig(ts.URL, false), &out, strings.NewReader(""),
+		WithProvider(stub), WithMemoryStore(store))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Close()
+
+	if err := app.RunTurn(context.Background(), "remember my language is Go"); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.RunTurn(context.Background(), "what is my language?"); err != nil {
+		t.Fatal(err)
+	}
+
+	// the recall tool result fed back on the 4th model call carries the value.
+	// request[3].Messages holds the full history, so match the recall call by
+	// its id (c2) rather than taking the first RoleTool (the earlier remember).
+	fed := toolMsgByID(t, stub.Requests()[3].Messages, "c2").Text
+	if !strings.Contains(fed, "Go") {
+		t.Fatalf("recall did not return the stored value; tool message = %q", fed)
+	}
+
+	// and the store actually holds it
+	got, _ := store.ListMemories(context.Background(), agent.ListMemoriesRequest{})
+	if len(got.Items) != 1 || got.Items[0].Key != "lang" || got.Items[0].Value != "Go" {
+		t.Fatalf("store = %+v, want lang=Go", got.Items)
+	}
+}
+
+func TestAppMemorySummaryInjection(t *testing.T) {
+	ts := startTestServer(t)
+	script := func() *agent.StubProvider {
+		return agent.NewStubProvider(
+			agent.StubTurn{ToolCalls: []agent.ToolCall{{
+				ID: "c1", Name: agent.RememberToolName,
+				Args: core.NewRawJSON(json.RawMessage(`{"key":"lang","value":"Go"}`)),
+			}}},
+			agent.StubTurn{Text: "saved"},
+			agent.StubTurn{Text: "second turn reply"},
+		)
+	}
+
+	const marker = "Working memory"
+
+	// injection ON: the second turn's first model call carries a RoleSystem summary
+	on := script()
+	var out strings.Builder
+	appOn, err := NewApp(memoryConfig(ts.URL, true), &out, strings.NewReader(""), WithProvider(on))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer appOn.Close()
+	_ = appOn.RunTurn(context.Background(), "remember Go")
+	_ = appOn.RunTurn(context.Background(), "anything new?")
+	if !hasSystemContaining(on.Requests()[2].Messages, marker) {
+		t.Fatalf("InjectSummary on: expected a RoleSystem %q message on the second turn", marker)
+	}
+
+	// injection OFF (default): no summary is injected
+	off := script()
+	var out2 strings.Builder
+	appOff, err := NewApp(memoryConfig(ts.URL, false), &out2, strings.NewReader(""), WithProvider(off))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer appOff.Close()
+	_ = appOff.RunTurn(context.Background(), "remember Go")
+	_ = appOff.RunTurn(context.Background(), "anything new?")
+	if hasSystemContaining(off.Requests()[2].Messages, marker) {
+		t.Fatal("InjectSummary off: no memory summary should be injected")
+	}
+}
+
+func toolMsgByID(t *testing.T, msgs []agent.Message, id string) agent.Message {
+	t.Helper()
+	for _, m := range msgs {
+		if m.Role == agent.RoleTool && m.ToolCallID == id {
+			return m
+		}
+	}
+	t.Fatalf("no RoleTool message with id %q in %+v", id, msgs)
+	return agent.Message{}
+}
+
+func hasSystemContaining(msgs []agent.Message, sub string) bool {
+	for _, m := range msgs {
+		if m.Role == agent.RoleSystem && strings.Contains(m.Text, sub) {
+			return true
+		}
+	}
+	return false
+}

--- a/agent/memory.go
+++ b/agent/memory.go
@@ -1,0 +1,324 @@
+package agent
+
+import (
+	"container/list"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+// Reserved tool names MemorySource exposes so the model can manage its own
+// working memory — a scratchpad it reads and writes across turns.
+const (
+	RememberToolName = "remember"
+	RecallToolName   = "recall"
+	ForgetToolName   = "forget"
+)
+
+// MemoryItem is one note in working memory: a short labeled value the model
+// chose to keep. Key is the model-chosen (or auto-assigned) label used to
+// recall or forget it; Value is the content; CreatedAt is when it was
+// stored, used only for stable ordering in listings and the summary.
+type MemoryItem struct {
+	Key       string    `json:"key"`
+	Value     string    `json:"value"`
+	CreatedAt time.Time `json:"createdAt,omitzero"`
+}
+
+// MemoryStore is the persistence seam for working memory. It pairs with the
+// agent-only MemorySource (the model-facing tools), so it lives in agent/
+// and traffics in MemoryItem (A6 — same rationale as ToolResultStore and
+// RunStore: a model-facing type keeps the seam out of root stores/).
+//
+// API shape follows the gRPC-style convention in stores/STORAGE_SEAMS.md:
+// Method(ctx, req) (resp, error); app-state travels on the response, error
+// is reserved for storage-layer faults. In particular, forgetting an
+// unknown key is app-state (Deleted=false), never an error — the model may
+// forget a key it never stored, and that is a normal "nothing to do"
+// answer, not a failure.
+//
+// ListMemories carries an optional Query. The contract is loose on purpose:
+// return the items relevant to Query, all items when Query is empty. The
+// in-memory default interprets relevance as a substring match; a future
+// semantic backend (issue 940) interprets the same Query as a similarity
+// search without changing the tool surface the model sees.
+type MemoryStore interface {
+	// PutMemory upserts an item by Key. Storing an existing Key overwrites
+	// its Value and keeps its original listing position, so an update does
+	// not reorder the scratchpad.
+	PutMemory(ctx context.Context, req PutMemoryRequest) (PutMemoryResponse, error)
+
+	// ListMemories returns items relevant to req.Query (all items when
+	// Query is empty), oldest first.
+	ListMemories(ctx context.Context, req ListMemoriesRequest) (ListMemoriesResponse, error)
+
+	// DeleteMemory removes an item by Key. Deleted reports whether a
+	// matching item existed; an unknown Key is Deleted=false, not an error.
+	DeleteMemory(ctx context.Context, req DeleteMemoryRequest) (DeleteMemoryResponse, error)
+}
+
+// PutMemoryRequest carries the item to store. A zero CreatedAt is stamped
+// with the store clock at Put time (caller-set wins, mirroring
+// Message.Timestamp).
+type PutMemoryRequest struct {
+	Item MemoryItem
+}
+
+// PutMemoryResponse is empty today; it exists so the method can grow
+// app-state without a signature break, per the gRPC-style convention.
+type PutMemoryResponse struct{}
+
+// ListMemoriesRequest filters by Query (empty means all).
+type ListMemoriesRequest struct {
+	Query string
+}
+
+// ListMemoriesResponse carries the matching items, oldest first.
+type ListMemoriesResponse struct {
+	Items []MemoryItem
+}
+
+// DeleteMemoryRequest identifies the item to forget by Key.
+type DeleteMemoryRequest struct {
+	Key string
+}
+
+// DeleteMemoryResponse reports whether an item was actually removed.
+type DeleteMemoryResponse struct {
+	Deleted bool
+}
+
+// InMemoryMemoryStore is the default MemoryStore: a mutex-guarded map with
+// stable insertion ordering, safe for concurrent use. Nothing survives
+// process exit — a durable, session-scoped backend is a sibling-module
+// follow-up (mirroring the ToolResultStore redis/gorm arc). An optional
+// entry cap (WithMaxMemories) evicts the oldest item when exceeded.
+type InMemoryMemoryStore struct {
+	mu    sync.Mutex
+	items map[string]MemoryItem
+	// order tracks insertion order so listings and the summary are
+	// deterministic regardless of CreatedAt tie-breaks; front is oldest.
+	order      *list.List
+	elems      map[string]*list.Element
+	maxEntries int
+}
+
+// MemoryStoreOption configures an InMemoryMemoryStore.
+type MemoryStoreOption func(*InMemoryMemoryStore)
+
+// WithMaxMemories caps the store at n items, evicting the oldest when a Put
+// of a new key would exceed n. Zero or negative means unbounded (the
+// default).
+func WithMaxMemories(n int) MemoryStoreOption {
+	return func(s *InMemoryMemoryStore) {
+		if n > 0 {
+			s.maxEntries = n
+		}
+	}
+}
+
+// NewInMemoryMemoryStore returns an empty in-memory store.
+func NewInMemoryMemoryStore(opts ...MemoryStoreOption) *InMemoryMemoryStore {
+	s := &InMemoryMemoryStore{
+		items: map[string]MemoryItem{},
+		order: list.New(),
+		elems: map[string]*list.Element{},
+	}
+	for _, o := range opts {
+		o(s)
+	}
+	return s
+}
+
+// PutMemory implements MemoryStore.
+func (s *InMemoryMemoryStore) PutMemory(ctx context.Context, req PutMemoryRequest) (PutMemoryResponse, error) {
+	item := req.Item
+	if item.CreatedAt.IsZero() {
+		item.CreatedAt = time.Now()
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.items[item.Key]; !exists {
+		s.elems[item.Key] = s.order.PushBack(item.Key)
+		for s.maxEntries > 0 && s.order.Len() > s.maxEntries {
+			oldest := s.order.Front()
+			key := oldest.Value.(string)
+			s.order.Remove(oldest)
+			delete(s.elems, key)
+			delete(s.items, key)
+		}
+	}
+	s.items[item.Key] = item
+	return PutMemoryResponse{}, nil
+}
+
+// ListMemories implements MemoryStore: substring match on key or value
+// (case-insensitive), oldest first.
+func (s *InMemoryMemoryStore) ListMemories(ctx context.Context, req ListMemoriesRequest) (ListMemoriesResponse, error) {
+	q := strings.ToLower(req.Query)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []MemoryItem
+	for e := s.order.Front(); e != nil; e = e.Next() {
+		item := s.items[e.Value.(string)]
+		if q == "" || strings.Contains(strings.ToLower(item.Key), q) || strings.Contains(strings.ToLower(item.Value), q) {
+			out = append(out, item)
+		}
+	}
+	return ListMemoriesResponse{Items: out}, nil
+}
+
+// DeleteMemory implements MemoryStore.
+func (s *InMemoryMemoryStore) DeleteMemory(ctx context.Context, req DeleteMemoryRequest) (DeleteMemoryResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.items[req.Key]; !ok {
+		return DeleteMemoryResponse{Deleted: false}, nil
+	}
+	delete(s.items, req.Key)
+	if e, ok := s.elems[req.Key]; ok {
+		s.order.Remove(e)
+		delete(s.elems, req.Key)
+	}
+	return DeleteMemoryResponse{Deleted: true}, nil
+}
+
+// MemorySource is working memory as a ToolSource: it exposes remember,
+// recall, and forget tools over a MemoryStore, so the model manages its own
+// scratchpad through ordinary tool calls. It is a leaf source (like
+// FuncSource, not a wrapper like OffloadingSource) — a host adds it to its
+// MultiSource alongside the server sources.
+//
+// Summary renders the current scratchpad for optional pre-turn injection,
+// keeping the model aware of what it has stored without a recall call every
+// turn. Injection is the host's job (through its existing InjectionPolicy
+// path); MemorySource only supplies the text, so the Runner never changes.
+type MemorySource struct {
+	store MemoryStore
+	fs    *FuncSource
+}
+
+type rememberArgs struct {
+	// Key is the label to store under. Optional — a stable key lets you
+	// update or forget the note later; if omitted, one is assigned.
+	Key string `json:"key,omitempty"`
+	// Value is the content to remember.
+	Value string `json:"value"`
+}
+
+type recallArgs struct {
+	// Query filters notes by substring of key or value. Omit to list all.
+	Query string `json:"query,omitempty"`
+}
+
+type forgetArgs struct {
+	// Key is the label of the note to delete.
+	Key string `json:"key"`
+}
+
+// NewMemorySource builds a MemorySource over store and registers its three
+// tools. The store is required.
+func NewMemorySource(store MemoryStore) (*MemorySource, error) {
+	m := &MemorySource{store: store, fs: NewFuncSource()}
+	if err := AddFunc(m.fs, RememberToolName,
+		"Save a note to your working memory so you can recall it on a later turn. Provide a short key to label it (optional; used to update or forget it later) and the value to store.",
+		m.remember); err != nil {
+		return nil, err
+	}
+	if err := AddFunc(m.fs, RecallToolName,
+		"Read from your working memory. Optionally pass a query to filter notes by a substring of the key or value; omit it to list everything you have stored.",
+		m.recall); err != nil {
+		return nil, err
+	}
+	if err := AddFunc(m.fs, ForgetToolName,
+		"Delete a note from your working memory by its key.",
+		m.forget); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+func (m *MemorySource) remember(ctx context.Context, in rememberArgs) (string, error) {
+	key := strings.TrimSpace(in.Key)
+	if key == "" {
+		key = "mem-" + randHex(4)
+	}
+	if _, err := m.store.PutMemory(ctx, PutMemoryRequest{Item: MemoryItem{Key: key, Value: in.Value}}); err != nil {
+		return "", err
+	}
+	return "remembered: " + key, nil
+}
+
+func (m *MemorySource) recall(ctx context.Context, in recallArgs) (string, error) {
+	resp, err := m.store.ListMemories(ctx, ListMemoriesRequest{Query: in.Query})
+	if err != nil {
+		return "", err
+	}
+	if len(resp.Items) == 0 {
+		if in.Query == "" {
+			return "working memory is empty", nil
+		}
+		return "no memories match " + in.Query, nil
+	}
+	return renderMemories(resp.Items), nil
+}
+
+func (m *MemorySource) forget(ctx context.Context, in forgetArgs) (string, error) {
+	resp, err := m.store.DeleteMemory(ctx, DeleteMemoryRequest{Key: in.Key})
+	if err != nil {
+		return "", err
+	}
+	if !resp.Deleted {
+		return "no memory with key " + in.Key, nil
+	}
+	return "forgot: " + in.Key, nil
+}
+
+// Tools implements ToolSource by delegating to the internal FuncSource.
+func (m *MemorySource) Tools(ctx context.Context) ([]core.ToolDef, error) {
+	return m.fs.Tools(ctx)
+}
+
+// Call implements ToolSource by delegating to the internal FuncSource.
+func (m *MemorySource) Call(ctx context.Context, name string, args map[string]any) (*core.ToolResult, error) {
+	return m.fs.Call(ctx, name, args)
+}
+
+// Summary renders the current working memory as a block a host can inject
+// as a RoleSystem message before a turn. It returns "" when memory is empty
+// so the host injects nothing.
+func (m *MemorySource) Summary(ctx context.Context) (string, error) {
+	resp, err := m.store.ListMemories(ctx, ListMemoriesRequest{})
+	if err != nil {
+		return "", err
+	}
+	if len(resp.Items) == 0 {
+		return "", nil
+	}
+	return "Working memory (notes you saved earlier):\n" + renderMemories(resp.Items), nil
+}
+
+func renderMemories(items []MemoryItem) string {
+	var b strings.Builder
+	for i, it := range items {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		b.WriteString("- ")
+		b.WriteString(it.Key)
+		b.WriteString(": ")
+		b.WriteString(it.Value)
+	}
+	return b.String()
+}
+
+func randHex(n int) string {
+	buf := make([]byte, n)
+	_, _ = rand.Read(buf)
+	return hex.EncodeToString(buf)
+}

--- a/agent/memory_test.go
+++ b/agent/memory_test.go
@@ -1,0 +1,190 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestInMemoryMemoryStore_CRUD(t *testing.T) {
+	ctx := context.Background()
+	s := NewInMemoryMemoryStore()
+
+	if _, err := s.PutMemory(ctx, PutMemoryRequest{Item: MemoryItem{Key: "a", Value: "alpha"}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.PutMemory(ctx, PutMemoryRequest{Item: MemoryItem{Key: "b", Value: "beta"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	// stamped a zero CreatedAt
+	got, _ := s.ListMemories(ctx, ListMemoriesRequest{})
+	if len(got.Items) != 2 {
+		t.Fatalf("list = %d items, want 2", len(got.Items))
+	}
+	if got.Items[0].Key != "a" || got.Items[1].Key != "b" {
+		t.Fatalf("list order = %q,%q, want a,b (oldest first)", got.Items[0].Key, got.Items[1].Key)
+	}
+	if got.Items[0].CreatedAt.IsZero() {
+		t.Fatal("PutMemory should stamp a zero CreatedAt")
+	}
+}
+
+func TestInMemoryMemoryStore_UpdateKeepsPosition(t *testing.T) {
+	ctx := context.Background()
+	s := NewInMemoryMemoryStore()
+	_, _ = s.PutMemory(ctx, PutMemoryRequest{Item: MemoryItem{Key: "a", Value: "alpha"}})
+	_, _ = s.PutMemory(ctx, PutMemoryRequest{Item: MemoryItem{Key: "b", Value: "beta"}})
+	// overwrite a — must not move it to the back
+	_, _ = s.PutMemory(ctx, PutMemoryRequest{Item: MemoryItem{Key: "a", Value: "alpha2"}})
+
+	got, _ := s.ListMemories(ctx, ListMemoriesRequest{})
+	if len(got.Items) != 2 || got.Items[0].Key != "a" || got.Items[0].Value != "alpha2" {
+		t.Fatalf("update reordered or lost the value: %+v", got.Items)
+	}
+}
+
+func TestInMemoryMemoryStore_QueryFilter(t *testing.T) {
+	ctx := context.Background()
+	s := NewInMemoryMemoryStore()
+	_, _ = s.PutMemory(ctx, PutMemoryRequest{Item: MemoryItem{Key: "lang", Value: "Go"}})
+	_, _ = s.PutMemory(ctx, PutMemoryRequest{Item: MemoryItem{Key: "editor", Value: "vim"}})
+
+	// match on value, case-insensitive
+	got, _ := s.ListMemories(ctx, ListMemoriesRequest{Query: "go"})
+	if len(got.Items) != 1 || got.Items[0].Key != "lang" {
+		t.Fatalf("query 'go' = %+v, want just lang", got.Items)
+	}
+	// match on key
+	got, _ = s.ListMemories(ctx, ListMemoriesRequest{Query: "edit"})
+	if len(got.Items) != 1 || got.Items[0].Key != "editor" {
+		t.Fatalf("query 'edit' = %+v, want just editor", got.Items)
+	}
+}
+
+func TestInMemoryMemoryStore_DeleteUnknownIsAppState(t *testing.T) {
+	ctx := context.Background()
+	s := NewInMemoryMemoryStore()
+	resp, err := s.DeleteMemory(ctx, DeleteMemoryRequest{Key: "nope"})
+	if err != nil {
+		t.Fatalf("deleting an unknown key must be app-state, got error: %v", err)
+	}
+	if resp.Deleted {
+		t.Fatal("Deleted should be false for an unknown key")
+	}
+
+	_, _ = s.PutMemory(ctx, PutMemoryRequest{Item: MemoryItem{Key: "a", Value: "alpha"}})
+	resp, _ = s.DeleteMemory(ctx, DeleteMemoryRequest{Key: "a"})
+	if !resp.Deleted {
+		t.Fatal("Deleted should be true after removing a stored key")
+	}
+	got, _ := s.ListMemories(ctx, ListMemoriesRequest{})
+	if len(got.Items) != 0 {
+		t.Fatalf("after delete, list = %d, want 0", len(got.Items))
+	}
+}
+
+func TestInMemoryMemoryStore_MaxEvictsOldest(t *testing.T) {
+	ctx := context.Background()
+	s := NewInMemoryMemoryStore(WithMaxMemories(2))
+	_, _ = s.PutMemory(ctx, PutMemoryRequest{Item: MemoryItem{Key: "a", Value: "1"}})
+	_, _ = s.PutMemory(ctx, PutMemoryRequest{Item: MemoryItem{Key: "b", Value: "2"}})
+	_, _ = s.PutMemory(ctx, PutMemoryRequest{Item: MemoryItem{Key: "c", Value: "3"}})
+
+	got, _ := s.ListMemories(ctx, ListMemoriesRequest{})
+	if len(got.Items) != 2 || got.Items[0].Key != "b" || got.Items[1].Key != "c" {
+		t.Fatalf("cap evict = %+v, want b,c (a evicted)", got.Items)
+	}
+}
+
+func TestMemorySource_RememberRecallForget(t *testing.T) {
+	ctx := context.Background()
+	m, err := NewMemorySource(NewInMemoryMemoryStore())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// the three tools are exposed
+	defs, _ := m.Tools(ctx)
+	names := map[string]bool{}
+	for _, d := range defs {
+		names[d.Name] = true
+	}
+	for _, want := range []string{RememberToolName, RecallToolName, ForgetToolName} {
+		if !names[want] {
+			t.Fatalf("tool %q not exposed; have %v", want, names)
+		}
+	}
+
+	// remember with an explicit key
+	res, err := m.Call(ctx, RememberToolName, map[string]any{"key": "lang", "value": "Go"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError || !strings.Contains(res.Content[0].Text, "lang") {
+		t.Fatalf("remember = %+v", res)
+	}
+
+	// recall it back
+	res, _ = m.Call(ctx, RecallToolName, map[string]any{"query": "go"})
+	if res.IsError || !strings.Contains(res.Content[0].Text, "Go") {
+		t.Fatalf("recall = %+v, want the stored value", res)
+	}
+
+	// forget it
+	res, _ = m.Call(ctx, ForgetToolName, map[string]any{"key": "lang"})
+	if res.IsError || !strings.Contains(res.Content[0].Text, "forgot") {
+		t.Fatalf("forget = %+v", res)
+	}
+
+	// recall now empty
+	res, _ = m.Call(ctx, RecallToolName, map[string]any{})
+	if res.IsError || !strings.Contains(res.Content[0].Text, "empty") {
+		t.Fatalf("recall after forget = %+v, want empty", res)
+	}
+}
+
+func TestMemorySource_RememberAutoKey(t *testing.T) {
+	ctx := context.Background()
+	m, _ := NewMemorySource(NewInMemoryMemoryStore())
+	res, _ := m.Call(ctx, RememberToolName, map[string]any{"value": "no key given"})
+	if res.IsError || !strings.Contains(res.Content[0].Text, "mem-") {
+		t.Fatalf("auto-key remember = %+v, want a mem- key", res)
+	}
+}
+
+func TestMemorySource_ForgetUnknownIsNotError(t *testing.T) {
+	ctx := context.Background()
+	m, _ := NewMemorySource(NewInMemoryMemoryStore())
+	res, err := m.Call(ctx, ForgetToolName, map[string]any{"key": "ghost"})
+	if err != nil {
+		t.Fatalf("forget unknown should not be a dispatch error: %v", err)
+	}
+	if res.IsError {
+		t.Fatal("forget unknown should be a normal model-visible result, not IsError")
+	}
+	if !strings.Contains(res.Content[0].Text, "no memory") {
+		t.Fatalf("forget unknown = %q", res.Content[0].Text)
+	}
+}
+
+func TestMemorySource_Summary(t *testing.T) {
+	ctx := context.Background()
+	m, _ := NewMemorySource(NewInMemoryMemoryStore())
+
+	// empty memory injects nothing
+	sum, err := m.Summary(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sum != "" {
+		t.Fatalf("empty summary = %q, want empty string", sum)
+	}
+
+	_, _ = m.Call(ctx, RememberToolName, map[string]any{"key": "lang", "value": "Go"})
+	_, _ = m.Call(ctx, RememberToolName, map[string]any{"key": "os", "value": "darwin"})
+	sum, _ = m.Summary(ctx)
+	if !strings.Contains(sum, "lang: Go") || !strings.Contains(sum, "os: darwin") {
+		t.Fatalf("summary = %q, want both notes", sum)
+	}
+}

--- a/cmd/agentchat/main.go
+++ b/cmd/agentchat/main.go
@@ -155,6 +155,8 @@ func newRoot() (*cobra.Command, *viper.Viper) {
 	fl.String("ui", "auto", "interface: auto (TUI when interactive) | tui | plain")
 	fl.Int("offload-threshold", 0, "offload tool results at/over N bytes to a store, feeding the model a stub + read_tool_result (0 = off; blobs use --session-store's backend)")
 	fl.String("offload-dir", "", "store offloaded tool results as files under this directory (no server needed); overrides --session-store for blobs")
+	fl.Bool("memory", false, "enable working memory: remember/recall/forget tools the model manages across turns (in-memory store)")
+	fl.Bool("memory-inject-summary", false, "with --memory, prepend a summary of the scratchpad before each turn (costs tokens; off = recall on demand)")
 	fl.String("exporter", "", "telemetry exporter: stdout | otlp | auto (empty = off)")
 	fl.String("otlp-endpoint", "", "OTLP gRPC endpoint (default localhost:4317)")
 	if err := v.BindPFlags(fl); err != nil {
@@ -225,6 +227,10 @@ func runChat(v *viper.Viper) error {
 		if trStore != nil {
 			appOpts = append(appOpts, host.WithToolResultStore(trStore))
 		}
+	}
+
+	if v.GetBool("memory") {
+		cfg.Memory = &host.MemoryConfig{InjectSummary: v.GetBool("memory-inject-summary")}
 	}
 
 	app, err := host.NewApp(cfg, os.Stdout, os.Stdin, appOpts...)

--- a/docs/AGENT_MEMORY_FLOW.md
+++ b/docs/AGENT_MEMORY_FLOW.md
@@ -82,6 +82,27 @@ The stores are the easy 20% (they look like `RunStore`). The other 80% is policy
 - **RAG today.** The shift is from "pre-baked top-k every turn" to *retrieval as a tool the agent calls* (the Tools path). Large context windows plus offloading erode classic RAG; it still wins when the corpus is larger than the context window, or for freshness, citations, and cost.
 - **Offloading (issue 966).** Extends the *episodic* layer with on-demand reads (`read_tool_result`). Lossless and pay-per-lookup — it shrinks how much the lossy layers ever have to guess, which is why it is the right opener before full memory.
 
+## Prior art & interface extensibility
+
+Working memory's `remember` / `recall` / `forget` verbs are not idiosyncratic — they are the **agent-self-edited** camp of memory design, done minimally. Two camps exist:
+
+- **Model-managed** (ours): the agent decides what to keep by calling tools. Letta/MemGPT (`core_memory_append` / `archival_memory_insert` / `archival_memory_search`), LangChain LangMem (`manage_memory` + `search_memory`).
+- **Pipeline-managed**: a background LLM step extracts and consolidates facts from the raw conversation; the agent never explicitly remembers. Mem0 (`add()` runs an ADD/UPDATE/DELETE/NOOP decision internally), Zep (temporal knowledge-graph extraction). This is the **write path** above (Extract → Consolidate), complementary to the tool surface, not a replacement.
+
+Primitives other systems expose, and where each lands for us:
+
+| Primitive | Who | Our plan |
+|---|---|---|
+| Semantic `search` with a relevance **score** (vs substring list) | Mem0, LangGraph `BaseStore.search`, Letta archival, Zep | Issue 940. `ListMemoriesRequest` already carries `Query`; a `Score` on the returned items is the only add. |
+| **Namespace / scope** (`user_id`, `agent_id`, `run_id`, session) | Near-universal — LangGraph hierarchical namespaces, Mem0 scoping, Letta per-agent | Issue 1003. The most-standard thing we don't yet have; a `Namespace` field on the request structs. |
+| Explicit **`update` / supersede** as a distinct op | Mem0, LangMem | Covered as upsert-by-key today; consolidation is the pipeline camp — defer. |
+| **`history(id)`** — how a fact changed over time | Mem0, Zep (bi-temporal) | Nice-to-have for the knowledge-update category; not now. |
+| **Tiered**: in-context core blocks vs archival | Letta/MemGPT, Mastra (markdown profile) | `InjectSummary` is "core-lite"; editable core blocks are a bigger design — defer. |
+| Memory-as-**filesystem** (`view` / `create` / `str_replace`) | Anthropic memory tool (2025 beta) | This is our offloading / `FileToolResultStore` direction, a different substrate than the working-memory scratchpad. |
+| Configurable tool **names** (vs fixed `remember`/`recall`/`forget`) | competitors use fixed names + namespacing | YAGNI. Names are exported constants; a variadic `NewMemorySource(store, opts...)` with a name-prefix option is non-breaking to add when a second in-agent MemorySource or prompt-tuning actually needs it. `MultiSource` already collision-qualifies names, so it isn't needed for aggregation. |
+
+**Why none of this forces a change to the first cut:** the `MemoryStore` seam uses the gRPC-style req/resp struct convention. `Namespace`, `Score`, a `GetMemory` point-read, `DeleteAll` — all land as new struct fields or new methods without breaking the interface or any backend (same reason `PutMemoryResponse` is an empty struct). The store starts minimal on purpose and grows additively into the primitives above.
+
 ## Sequencing (roadmap §A)
 
 issue 966 offloading → working memory + `MemorySource` → compaction (`SummarizingCompactor`) → embedder / vectorstore recall wired into injection.


### PR DESCRIPTION
Closes #938. First capability of Phase 2 memory (roadmap `docs/AGENT_SDK_ROADMAP.md` §A; design `docs/AGENT_MEMORY_FLOW.md`). Based on `main`, so CI runs.

## What changes

The model gets a **working-memory scratchpad** it manages across turns through three tools: `remember(key?, value)`, `recall(query?)`, `forget(key)`. It's a first-class `MemorySource` — a leaf `ToolSource` (like `FuncSource`, not a wrapper like `OffloadingSource`) over a `MemoryStore` seam with an in-memory default. Optionally, a per-turn summary of the scratchpad is injected as a `RoleSystem` message so the model stays aware of what it saved without a recall call. No Runner change — memory reaches the turn through seams that already exist (tools + injection), so `Run(ctx, history, emit)` is untouched.

agentchat exposes it via `--memory` (in-memory) and `--memory-inject-summary`, plus a `/memory` command that lists the scratchpad.

## Reviewer's guide

Read in this order:
1. [agent/memory.go](https://github.com/panyam/mcpkit/pull/1004/files#diff-8b2c5e582714e8b1e26ebd2e85b95f45417d39de02b30621f3715dab3b347f05) — start here. `MemoryStore` seam (gRPC-style req/resp; unknown-key delete is app-state, not error — same contract shape as `ToolResultStore`/`RunStore`), `InMemoryMemoryStore` (stable insertion order, optional cap), and `MemorySource` (internal `FuncSource` for the 3 tools + a `Summary` accessor the host injects).
2. [agent/memory_test.go](https://github.com/panyam/mcpkit/pull/1004/files#diff-25e512dfbc950f08648fca86f06d25c6304e75c4edee64f8f66009055f243360) — acceptance for the seam + source: CRUD, update-keeps-position, query filter, unknown-key app-state, cap eviction, tool round-trips, auto-key, summary rendering.
3. [agent/host/memory.go](https://github.com/panyam/mcpkit/pull/1004/files#diff-2fa9e3fc7796e7e17ca21962b0f10cf32f1e7cc8b61a88abbfb519c350a97c62) — `WithMemoryStore` option, `registerMemory` (adds the source to the aggregate `MultiSource`), `injectMemoryLocked` (opt-in summary, best-effort — never fails a turn).
4. [agent/host/memory_test.go](https://github.com/panyam/mcpkit/pull/1004/files#diff-e005969fe5c233a0078d9e7ff785c7d6cf4d8767cc6e81c39351b5849a075f43) — the **StubProvider eval**: the model remembers on one turn and recalls on a later turn; plus the summary-injection gating (on vs off).
5. [agent/host/app.go](https://github.com/panyam/mcpkit/pull/1004/files#diff-89fb8e04b6e1e9d5f7f76958490ef158dee40e2cae92d87c04b408d893c84361), `config.go`, `commands.go`, [cmd/agentchat/main.go](https://github.com/panyam/mcpkit/pull/1004/files#diff-ce3956549c93b4983f18090136a2139c3c92d38408e923245f5e9ba628bcc98a) — wiring: `Config.Memory`, the register call, the `RunTurn` injection hook, `/memory`, and the CLI flags.

## How it works

```
remember(key, value)  -> MemoryStore.PutMemory   (auto-key "mem-xxxx" if key omitted; upsert keeps position)
recall(query?)        -> MemoryStore.ListMemories (substring match on key|value; "" = all)
forget(key)           -> MemoryStore.DeleteMemory (unknown key -> "no memory with key…", not IsError)
Summary(ctx)          -> "Working memory:\n- k: v\n…"  or ""  (host injects as RoleSystem pre-turn if InjectSummary)

host RunTurn:  drainInjection -> injectMemory(if on) -> append user msg -> Run  (memory wraps the loop, never inside it)
```

## Decision log

- **Summary via a host-called accessor (`MemorySource.Summary`), not a Runner-aware interface.** The host injects it through its existing `drainInjectionLocked` path. Alt (teach the Runner to recognize a memory source) rejected — it breaks the "Run is stateless over history" bet that makes resume/fork/compaction compose.
- **`recall` does substring matching.** Honest in-memory default; composes forward — a later semantic `MemoryStore` (issue 940) reinterprets the same `Query` as a similarity search with no change to the tool surface. That's why `Query` lives in the store request, not the source.
- **In-memory, single-namespace, process-scoped store.** Durable + session-scoped backends (redis TTL, gorm table) deferred to issue 1003, mirroring exactly how tool-result offloading grew its backends.
- **`MemorySource` composes a `FuncSource` internally** — reuses `AddFunc` schema generation and the IsError-on-handler-error contract instead of reimplementing `ToolSource`.
- **`MemoryStore` lives in `agent/`, not root `stores/`** — it traffics in `MemoryItem` (model-facing) and pairs with the agent-only `MemorySource` (A6 corollary, same as `ToolResultStore`/`RunStore`).

## Risk / blast radius

- Affects: `agent/` (new file), `agent/host/` (additive wiring), `cmd/agentchat/` (two flags). All existing behavior is unchanged when `Config.Memory` is nil (the default) — no assertion in the suite was touched or weakened.
- Tests covering this: 9 agent-layer + 2 host-layer (incl. the two-turn StubProvider eval and the injection on/off gating). `make test-agent` green (agent, host, agentchat, examples).
- Be paranoid about: the summary-injection ordering in `RunTurn` (after `drainInjectionLocked`, before the user message), and that `forget` of an unknown key is a normal model-visible result (not `IsError`, not a dispatch error) so a model that guesses a key doesn't derail the turn.

## Before / after

Working memory across two turns (StubProvider-scripted, from the eval):

```
before (no memory):
  turn 1  user: "remember my language is Go"   -> model has no way to persist it
  turn 2  user: "what is my language?"          -> model cannot answer; the fact is gone

after (--memory):
  turn 1  remember(key=lang, value=Go)  -> "remembered: lang"
  turn 2  recall(query=lang)            -> "- lang: Go"        (survives across turns)

  /memory ->  Working memory (notes you saved earlier):
              - lang: Go
```

## Out of scope (deliberately deferred)

- Durable + session-scoped `MemoryStore` backends (redis, gorm) → issue 1003
- Semantic recall (`Embedder` + `VectorStore`, upgrades `recall` matching) → issue 940
- `SummarizingCompactor` (consumes this + the episodic log) → issue 939
- LongMemEval-derived eval Case once the harness lands → issue 974
- Roadmap / memory-flow doc updates → post-merge `/checkpoint`

## Prior art (added on review)

`docs/AGENT_MEMORY_FLOW.md` now carries a prior-art survey: where `remember`/`recall`/`forget` sits (agent-self-edited vs pipeline-managed camps), the primitives competitors expose (semantic search + relevance score, namespace/scope, update/history, tiered core blocks, memory-as-filesystem), and why the gRPC-style req/resp convention makes each an additive `MemoryStore` change rather than an interface break. Tool-name configurability is recorded as YAGNI (names are exported constants; a variadic option is non-breaking later). Follow-ups updated: 1003 (namespace/scope field), 940 (relevance Score on results).