### PR TITLE
feat(agent/eval): multi-turn scenarios + LongMemEval-derived cases (issue 974)

### DIFF
--- a/agent/eval/eval_test.go
+++ b/agent/eval/eval_test.go
@@ -107,6 +107,20 @@ func TestContains(t *testing.T) {
 	}
 }
 
+func TestNotContains(t *testing.T) {
+	res := runCase(t, nil, Case{Name: "nc"}, agent.StubTurn{Text: "your language is Rust"})
+	if s := NotContains("Go").Score(res); !s.Pass {
+		t.Fatalf("Go is absent, NotContains should pass: %+v", s)
+	}
+	if s := NotContains("Rust").Score(res); s.Pass {
+		t.Fatalf("Rust is present, NotContains should fail: %+v", s)
+	}
+	// a failed run (no turn) fails NotContains — there's no answer to trust
+	if s := NotContains("anything").Score(Result{}); s.Pass {
+		t.Fatalf("no-turn result should fail NotContains: %+v", s)
+	}
+}
+
 func TestToolCalledTrueAndFalse(t *testing.T) {
 	src := lookupSource(t)
 	res := runCase(t, src, Case{Name: "tc", Input: "get x"},

--- a/agent/eval/longmemeval/ATTRIBUTION.md
+++ b/agent/eval/longmemeval/ATTRIBUTION.md
@@ -13,10 +13,14 @@ the differentiator. We do **not** vendor the LongMemEval dataset: the cases in
 `cases.go` are original, short scenarios written to exercise the same skills
 against mcpkit's working-memory tools.
 
-If you extend this package by importing LongMemEval data directly, respect the
-upstream dataset's license and keep it out of the default test tree (behind
-the `eval_llm` build tag, downloaded on demand), the same way the live
-benchmark here requires an explicit endpoint to run.
+`SmokeScenarios()` is deliberately a coarse regression signal, not a
+published-comparable score. The rigorous bar is a follow-up **loader** that
+reads the downloaded LongMemEval dataset from an env path and adapts each
+question into an `eval.Scenario`, the same way the conformance suites point at
+an external checkout via `MCPCONFORMANCE_*_PATH`. If you add that loader,
+respect the upstream dataset's license and keep the data out of the default
+test tree (env-pathed, downloaded on demand), exactly as the live benchmark
+here requires an explicit endpoint to run.
 
 The companion sibling benchmarks named in issue 974 — BFCL relevance
 detection (exercises the approval gate via `NotDenied`) and tau-bench user

--- a/agent/eval/longmemeval/ATTRIBUTION.md
+++ b/agent/eval/longmemeval/ATTRIBUTION.md
@@ -1,0 +1,24 @@
+# Attribution
+
+The scenarios in this package are **hand-authored** by the mcpkit project, in
+the spirit of and adapting the task categories from **LongMemEval**:
+
+> LongMemEval: Benchmarking Chat Assistants on Long-Term Interactive Memory.
+> https://github.com/xiaowu0162/LongMemEval
+
+We borrow the *shape* of the benchmark — the five skill categories
+(information extraction, multi-session reasoning, knowledge updates, temporal
+reasoning, abstention) — and grade with our own `agent/eval` harness, which is
+the differentiator. We do **not** vendor the LongMemEval dataset: the cases in
+`cases.go` are original, short scenarios written to exercise the same skills
+against mcpkit's working-memory tools.
+
+If you extend this package by importing LongMemEval data directly, respect the
+upstream dataset's license and keep it out of the default test tree (behind
+the `eval_llm` build tag, downloaded on demand), the same way the live
+benchmark here requires an explicit endpoint to run.
+
+The companion sibling benchmarks named in issue 974 — BFCL relevance
+detection (exercises the approval gate via `NotDenied`) and tau-bench user
+simulation (exercises the elicitation / MRTR input loop) — are separate
+follow-ups and are not adapted here.

--- a/agent/eval/longmemeval/cases.go
+++ b/agent/eval/longmemeval/cases.go
@@ -1,17 +1,26 @@
-// Package longmemeval adapts a small, hand-written slice of long-term chat
-// memory scenarios, in the spirit of the LongMemEval benchmark, into the
-// agent/eval harness. It is the external quality yardstick for the Phase 2
-// memory work: compaction and recall fail silently (a missing or stale
-// memory yields a subtly worse answer, not an error), so a borrowed task set
-// graded by a model is the only honest measure that memory actually helps.
+// Package longmemeval provides fast, self-contained SMOKE scenarios for the
+// Phase 2 memory work, shaped after the LongMemEval benchmark's skill
+// categories. These are NOT the LongMemEval benchmark: they are a handful of
+// short, hand-authored conversations (2–5 turns), not the dataset's long
+// (~100k-token) histories, so they exercise the memory plumbing end-to-end
+// with a real model and no download — a regression signal, not a
+// published-comparable score.
 //
-// These scenarios are hand-authored in the categories LongMemEval defines
-// (information extraction, multi-session reasoning, knowledge updates,
-// temporal reasoning, abstention). The upstream dataset is NOT vendored —
-// see ATTRIBUTION.md. The case table and its deterministic assertions live
-// in the default build so they are unit-testable for well-formedness;
-// running them against a live model (with an LLM judge for the fuzzy
-// categories) is behind the eval_llm build tag in live_test.go.
+// Why a smoke layer at all: memory fails silently (a missing or stale memory
+// yields a subtly worse answer, not an error), so even a coarse model-graded
+// check is worth having in a form that runs with zero external data.
+//
+// The rigorous bar — the actual LongMemEval dataset adapted through this same
+// agent/eval harness — is a follow-up loader that reads the downloaded
+// dataset from an env path (the dataset is NOT vendored; see ATTRIBUTION.md),
+// the same convention the conformance suites use for external test data. That
+// loader, plus a general eval/benchmark adapter seam so the harness can point
+// at many external suites, is where comparable numbers come from.
+//
+// The scenario table and its deterministic assertions live in the default
+// build so they are unit-testable for well-formedness; running them against a
+// live model (with an LLM judge for the fuzzy categories) is behind the
+// eval_llm build tag in live_test.go.
 package longmemeval
 
 import (
@@ -56,9 +65,11 @@ type MemCase struct {
 	MustNot []string
 }
 
-// Cases returns the adapted scenario set, one per category as a first slice.
-// Each is memory-enabled so the model manages the fact through its tools.
-func Cases() []MemCase {
+// SmokeScenarios returns the illustrative smoke set, one short scenario per
+// category. Each is memory-enabled so the model manages the fact through its
+// tools. These are a plumbing regression signal, not the LongMemEval
+// benchmark — see the package doc.
+func SmokeScenarios() []MemCase {
 	scenario := func(name string, turns ...string) eval.Scenario {
 		return eval.Scenario{Name: name, Turns: turns, Memory: true, Instructions: memoryInstructions}
 	}

--- a/agent/eval/longmemeval/cases.go
+++ b/agent/eval/longmemeval/cases.go
@@ -1,0 +1,126 @@
+// Package longmemeval adapts a small, hand-written slice of long-term chat
+// memory scenarios, in the spirit of the LongMemEval benchmark, into the
+// agent/eval harness. It is the external quality yardstick for the Phase 2
+// memory work: compaction and recall fail silently (a missing or stale
+// memory yields a subtly worse answer, not an error), so a borrowed task set
+// graded by a model is the only honest measure that memory actually helps.
+//
+// These scenarios are hand-authored in the categories LongMemEval defines
+// (information extraction, multi-session reasoning, knowledge updates,
+// temporal reasoning, abstention). The upstream dataset is NOT vendored —
+// see ATTRIBUTION.md. The case table and its deterministic assertions live
+// in the default build so they are unit-testable for well-formedness;
+// running them against a live model (with an LLM judge for the fuzzy
+// categories) is behind the eval_llm build tag in live_test.go.
+package longmemeval
+
+import (
+	"github.com/panyam/mcpkit/agent/eval"
+)
+
+// Category names the LongMemEval-style skill a case exercises.
+type Category string
+
+const (
+	// CatExtraction — recall a fact stated earlier in one conversation.
+	CatExtraction Category = "extraction"
+	// CatMultiSession — synthesize facts stated across separate sessions.
+	CatMultiSession Category = "multi-session"
+	// CatKnowledgeUpdate — a fact was superseded; the latest value must win.
+	CatKnowledgeUpdate Category = "knowledge-update"
+	// CatTemporal — reason about the order or timing of remembered facts.
+	CatTemporal Category = "temporal"
+	// CatAbstention — a fact was never stated; the model must not invent one.
+	CatAbstention Category = "abstention"
+)
+
+// memoryInstructions steer the model to actually use its scratchpad — the
+// point of the benchmark is the memory tools, not the context window.
+const memoryInstructions = "You have a working memory with remember, recall, and forget tools. " +
+	"Save durable facts the user tells you, and recall them before answering questions about earlier turns. " +
+	"If you were never told something, say you do not know rather than guessing."
+
+// MemCase is one memory scenario plus how to grade its final answer:
+// deterministic substring checks (Must / MustNot) where the expected token
+// is unambiguous, and a Rubric for the LLM judge where it is not.
+type MemCase struct {
+	Category Category
+	Scenario eval.Scenario
+	// Rubric grades the final answer via the LLM judge (fuzzy categories).
+	// Empty skips the judge.
+	Rubric string
+	// Must requires each substring in the final answer (deterministic).
+	Must []string
+	// MustNot forbids each substring in the final answer (deterministic) —
+	// the supersede and abstention checks.
+	MustNot []string
+}
+
+// Cases returns the adapted scenario set, one per category as a first slice.
+// Each is memory-enabled so the model manages the fact through its tools.
+func Cases() []MemCase {
+	scenario := func(name string, turns ...string) eval.Scenario {
+		return eval.Scenario{Name: name, Turns: turns, Memory: true, Instructions: memoryInstructions}
+	}
+	return []MemCase{
+		{
+			Category: CatExtraction,
+			Scenario: scenario("extraction-workplace",
+				"My name is Ada and I work at Analytical Engines Inc.",
+				"By the way, my primary language is Go.",
+				"Where do I work?"),
+			Must:   []string{"Analytical Engines"},
+			Rubric: "The answer must state that the user works at Analytical Engines Inc.",
+		},
+		{
+			Category: CatMultiSession,
+			Scenario: scenario("multisession-dog-breed",
+				"[Session 1] I adopted a dog last month and named her Pixel.",
+				"[Session 2, weeks later] Pixel turned out to be a border collie.",
+				"What breed is my dog?"),
+			Must:   []string{"border collie"},
+			Rubric: "The answer must identify the user's dog Pixel as a border collie, joining facts from two sessions.",
+		},
+		{
+			Category: CatKnowledgeUpdate,
+			Scenario: scenario("update-editor",
+				"My favorite code editor is Sublime Text.",
+				"Actually, I switched to VS Code last week and love it.",
+				"Which editor do I use now?"),
+			Must:    []string{"VS Code"},
+			MustNot: []string{"Sublime"},
+			Rubric:  "The answer must say VS Code (the updated value) and must not claim the user still uses Sublime Text.",
+		},
+		{
+			Category: CatTemporal,
+			Scenario: scenario("temporal-cities",
+				"In 2019 I was living in Berlin.",
+				"In 2022 I moved to Tokyo.",
+				"Which of those two cities did I live in earliest?"),
+			Must:   []string{"Berlin"},
+			Rubric: "The answer must say Berlin, reasoning that 2019 is earlier than 2022.",
+		},
+		{
+			Category: CatAbstention,
+			Scenario: scenario("abstention-sister",
+				"My name is Ada and I have a younger sister.",
+				"What is my sister's name?"),
+			MustNot: []string{"Analytical"}, // must not bleed an unrelated remembered token
+			Rubric:  "The user never gave their sister's name. The answer must acknowledge it does not know and must NOT invent a name.",
+		},
+	}
+}
+
+// Deterministic returns the substring scorers for a case (Must → Contains,
+// MustNot → NotContains). These run without a model, so they are the CI-safe
+// regression layer; the LLM judge (Rubric) is the periodic quality layer.
+func (c MemCase) Deterministic() []eval.Scorer {
+	var out []eval.Scorer
+	for _, s := range c.Must {
+		out = append(out, eval.Contains(s))
+	}
+	for _, s := range c.MustNot {
+		out = append(out, eval.NotContains(s))
+	}
+	return out
+}

--- a/agent/eval/longmemeval/cases_test.go
+++ b/agent/eval/longmemeval/cases_test.go
@@ -3,7 +3,7 @@ package longmemeval
 import "testing"
 
 func TestCasesWellFormed(t *testing.T) {
-	cases := Cases()
+	cases := SmokeScenarios()
 	if len(cases) == 0 {
 		t.Fatal("no cases")
 	}
@@ -41,7 +41,7 @@ func TestCasesWellFormed(t *testing.T) {
 }
 
 func TestDeterministicScorers(t *testing.T) {
-	for _, c := range Cases() {
+	for _, c := range SmokeScenarios() {
 		got := len(c.Deterministic())
 		if want := len(c.Must) + len(c.MustNot); got != want {
 			t.Fatalf("%q: Deterministic() = %d scorers, want %d", c.Scenario.Name, got, want)

--- a/agent/eval/longmemeval/cases_test.go
+++ b/agent/eval/longmemeval/cases_test.go
@@ -1,0 +1,50 @@
+package longmemeval
+
+import "testing"
+
+func TestCasesWellFormed(t *testing.T) {
+	cases := Cases()
+	if len(cases) == 0 {
+		t.Fatal("no cases")
+	}
+	seen := map[string]bool{}
+	cats := map[Category]bool{}
+	for _, c := range cases {
+		name := c.Scenario.Name
+		if name == "" {
+			t.Fatal("case with empty scenario name")
+		}
+		if seen[name] {
+			t.Fatalf("duplicate scenario name %q", name)
+		}
+		seen[name] = true
+		cats[c.Category] = true
+
+		if len(c.Scenario.Turns) < 2 {
+			t.Fatalf("%q: a memory scenario needs at least a setup turn and a question", name)
+		}
+		if !c.Scenario.Memory {
+			t.Fatalf("%q: memory scenarios must enable Memory", name)
+		}
+		// every case must be gradeable: a deterministic assertion or a rubric
+		if len(c.Must) == 0 && len(c.MustNot) == 0 && c.Rubric == "" {
+			t.Fatalf("%q: no way to grade (no Must/MustNot and no Rubric)", name)
+		}
+	}
+
+	// the first slice covers all five LongMemEval categories
+	for _, want := range []Category{CatExtraction, CatMultiSession, CatKnowledgeUpdate, CatTemporal, CatAbstention} {
+		if !cats[want] {
+			t.Fatalf("category %q not covered", want)
+		}
+	}
+}
+
+func TestDeterministicScorers(t *testing.T) {
+	for _, c := range Cases() {
+		got := len(c.Deterministic())
+		if want := len(c.Must) + len(c.MustNot); got != want {
+			t.Fatalf("%q: Deterministic() = %d scorers, want %d", c.Scenario.Name, got, want)
+		}
+	}
+}

--- a/agent/eval/longmemeval/live_test.go
+++ b/agent/eval/longmemeval/live_test.go
@@ -1,0 +1,76 @@
+//go:build eval_llm
+
+// Live benchmark: runs the adapted LongMemEval scenarios against a real
+// model and grades them (deterministic substring checks plus an LLM judge
+// for the fuzzy categories). It is excluded from the default build and CI —
+// it needs a live provider — and reports a pass rate rather than gating,
+// since memory quality is statistical. Run with:
+//
+//	LONGMEMEVAL_BASE_URL=http://localhost:1234/v1 LONGMEMEVAL_MODEL=your-model \
+//	  go test -tags eval_llm ./agent/eval/longmemeval/ -run TestLive -v
+package longmemeval
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/panyam/mcpkit/agent"
+	"github.com/panyam/mcpkit/agent/eval"
+)
+
+// liveProvider builds a provider from the LONGMEMEVAL_* env, skipping the
+// test when no endpoint is configured so a bare `go test -tags eval_llm`
+// stays green.
+func liveProvider(t *testing.T) agent.Provider {
+	baseURL := os.Getenv("LONGMEMEVAL_BASE_URL")
+	model := os.Getenv("LONGMEMEVAL_MODEL")
+	if baseURL == "" || model == "" {
+		t.Skip("set LONGMEMEVAL_BASE_URL and LONGMEMEVAL_MODEL to run the live memory benchmark")
+	}
+	p, err := agent.NewOpenAIProvider(agent.OpenAIConfig{
+		BaseURL: baseURL,
+		Model:   model,
+		APIKey:  os.Getenv(os.Getenv("LONGMEMEVAL_API_KEY_ENV")),
+	})
+	if err != nil {
+		t.Fatalf("build provider: %v", err)
+	}
+	return p
+}
+
+func TestLiveLongMemEval(t *testing.T) {
+	provider := liveProvider(t)
+	ctx := context.Background()
+
+	var passed, total int
+	for _, c := range Cases() {
+		results, err := eval.RunScenario(ctx, agent.RunnerConfig{Provider: provider}, c.Scenario)
+		if err != nil {
+			t.Fatalf("%s: harness error: %v", c.Scenario.Name, err)
+		}
+		final := eval.Final(results)
+
+		casePass := true
+		for _, s := range c.Deterministic() {
+			if sc := s.Score(final); !sc.Pass {
+				casePass = false
+				t.Logf("[%s] %s FAIL: %s", c.Category, c.Scenario.Name, sc.Detail)
+			}
+		}
+		if c.Rubric != "" {
+			if sc := eval.Judge(provider, c.Rubric).Score(final); !sc.Pass {
+				casePass = false
+				t.Logf("[%s] %s JUDGE FAIL (%.2f): %s", c.Category, c.Scenario.Name, sc.Value, sc.Detail)
+			}
+		}
+
+		total++
+		if casePass {
+			passed++
+			t.Logf("[%s] %s PASS", c.Category, c.Scenario.Name)
+		}
+	}
+	// Report, do not gate — the benchmark's job is to surface the pass rate.
+	t.Logf("LongMemEval-derived pass rate: %d/%d", passed, total)
+}

--- a/agent/eval/longmemeval/live_test.go
+++ b/agent/eval/longmemeval/live_test.go
@@ -44,7 +44,7 @@ func TestLiveLongMemEval(t *testing.T) {
 	ctx := context.Background()
 
 	var passed, total int
-	for _, c := range Cases() {
+	for _, c := range SmokeScenarios() {
 		results, err := eval.RunScenario(ctx, agent.RunnerConfig{Provider: provider}, c.Scenario)
 		if err != nil {
 			t.Fatalf("%s: harness error: %v", c.Scenario.Name, err)

--- a/agent/eval/scenario.go
+++ b/agent/eval/scenario.go
@@ -27,10 +27,21 @@ type Scenario struct {
 	Turns []string
 
 	// Memory, when true, gives the run a working-memory scratchpad (a
-	// MemorySource over a fresh in-memory store) merged with any base Tools,
-	// so the model can remember/recall across the turns. The store is fresh
-	// per RunScenario call — scenarios never share memory.
+	// MemorySource) merged with any base Tools, so the model can
+	// remember/recall across the turns. The backing store is NewMemoryStore
+	// when set, else a fresh in-memory default. The store is built once per
+	// RunScenario call — scenarios never share memory.
 	Memory bool
+
+	// NewMemoryStore builds the MemoryStore backing this scenario's working
+	// memory. Nil uses the in-memory default. Set it to grade a different
+	// backend (redis, gorm, a future semantic store) through the same
+	// scenarios — the whole point of an eval harness is comparing impls. It
+	// is a factory, not a value, so each RunScenario gets its own store and
+	// scenarios in a suite never cross-contaminate; a caller that WANTS
+	// shared state across scenarios can close over one store and return it.
+	// A non-nil NewMemoryStore implies Memory.
+	NewMemoryStore func() (agent.MemoryStore, error)
 
 	// Tools is the base tool surface, merged under the memory tools when
 	// Memory is set. Nil offers only the memory tools (or none, when Memory
@@ -65,8 +76,15 @@ func RunScenario(ctx context.Context, cfg agent.RunnerConfig, s Scenario) ([]Res
 	if s.Tools != nil {
 		cfg.Tools = s.Tools
 	}
-	if s.Memory {
-		mem, err := agent.NewMemorySource(agent.NewInMemoryMemoryStore())
+	if s.Memory || s.NewMemoryStore != nil {
+		store := agent.MemoryStore(agent.NewInMemoryMemoryStore())
+		if s.NewMemoryStore != nil {
+			var err error
+			if store, err = s.NewMemoryStore(); err != nil {
+				return nil, fmt.Errorf("eval: scenario %q memory store: %w", s.Name, err)
+			}
+		}
+		mem, err := agent.NewMemorySource(store)
 		if err != nil {
 			return nil, fmt.Errorf("eval: scenario %q memory: %w", s.Name, err)
 		}

--- a/agent/eval/scenario.go
+++ b/agent/eval/scenario.go
@@ -1,0 +1,117 @@
+package eval
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/panyam/mcpkit/agent"
+)
+
+// Scenario is a multi-turn eval input: a sequence of user turns that share
+// one conversation and (optionally) one working-memory scratchpad, run in
+// order. It is what the single-turn Case cannot express — memory evals
+// (LongMemEval and kin) build up facts across turns and sessions, then ask
+// a question, so the thing under test is whether earlier turns survive into
+// a later answer.
+//
+// RunScenario threads history across turns and keeps one MemorySource for
+// the whole run, so a fact remembered on turn 1 is recallable on turn 5.
+// The last turn is the one a Scorer grades; earlier turns are setup.
+type Scenario struct {
+	// Name identifies the scenario in a report. Should be unique in a Suite.
+	Name string
+
+	// Turns are the user inputs, oldest first. Each runs as one agent turn
+	// against the accumulated history; the final turn's Result is the graded
+	// one.
+	Turns []string
+
+	// Memory, when true, gives the run a working-memory scratchpad (a
+	// MemorySource over a fresh in-memory store) merged with any base Tools,
+	// so the model can remember/recall across the turns. The store is fresh
+	// per RunScenario call — scenarios never share memory.
+	Memory bool
+
+	// Tools is the base tool surface, merged under the memory tools when
+	// Memory is set. Nil offers only the memory tools (or none, when Memory
+	// is false).
+	Tools agent.ToolSource
+
+	// Instructions overrides RunnerConfig.Instructions for this scenario
+	// when non-empty.
+	Instructions string
+
+	// MaxSteps overrides RunnerConfig.MaxSteps per turn when positive.
+	MaxSteps int
+}
+
+// RunScenario executes s against a copy of cfg with the scenario's overrides
+// applied, running each turn in order and threading history plus a shared
+// working-memory source across them. It returns one Result per turn (the
+// last is the graded turn); the returned error is a harness-level failure
+// (an invalid RunnerConfig), while a turn that runs and fails carries its
+// error in that turn's Result.Err.
+//
+// A single Runner is built and reused for every turn: the Runner is
+// stateless over the history it is handed, so reuse is what makes the shared
+// MemorySource (held in cfg.Tools) persist across turns.
+func RunScenario(ctx context.Context, cfg agent.RunnerConfig, s Scenario) ([]Result, error) {
+	if s.Instructions != "" {
+		cfg.Instructions = s.Instructions
+	}
+	if s.MaxSteps > 0 {
+		cfg.MaxSteps = s.MaxSteps
+	}
+	if s.Tools != nil {
+		cfg.Tools = s.Tools
+	}
+	if s.Memory {
+		mem, err := agent.NewMemorySource(agent.NewInMemoryMemoryStore())
+		if err != nil {
+			return nil, fmt.Errorf("eval: scenario %q memory: %w", s.Name, err)
+		}
+		if cfg.Tools == nil {
+			cfg.Tools = mem
+		} else {
+			multi := agent.NewMultiSource()
+			if err := multi.Add("base", cfg.Tools); err != nil {
+				return nil, fmt.Errorf("eval: scenario %q tools: %w", s.Name, err)
+			}
+			if err := multi.Add("memory", mem); err != nil {
+				return nil, fmt.Errorf("eval: scenario %q memory: %w", s.Name, err)
+			}
+			cfg.Tools = multi
+		}
+	}
+
+	runner, err := agent.NewRunner(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("eval: build runner for scenario %q: %w", s.Name, err)
+	}
+
+	var history []agent.Message
+	results := make([]Result, 0, len(s.Turns))
+	for i, input := range s.Turns {
+		history = append(history, agent.Message{Role: agent.RoleUser, Text: input})
+
+		var events []agent.Event
+		emit := func(e agent.Event) { events = append(events, e) }
+
+		turn, runErr := runner.Run(ctx, history, emit)
+		// Each turn is named "<scenario>#<n>" so a per-turn Result is
+		// traceable back to its position in the scenario.
+		c := Case{Name: fmt.Sprintf("%s#%d", s.Name, i+1), Input: input}
+		results = append(results, Result{Case: c, Turn: turn, Events: events, Err: runErr})
+		if turn != nil {
+			history = append(history, turn.Messages...)
+		}
+	}
+	return results, nil
+}
+
+// Final returns the last turn's Result — the graded turn of a scenario. It
+// panics on an empty slice (a scenario always has at least one turn), so a
+// scorer can write Final(results) without a length dance.
+func Final(results []Result) Result {
+	return results[len(results)-1]
+}

--- a/agent/eval/scenario_test.go
+++ b/agent/eval/scenario_test.go
@@ -3,6 +3,7 @@ package eval
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -57,6 +58,54 @@ func TestRunScenarioThreadsMemoryAcrossTurns(t *testing.T) {
 		t.Fatal("second turn did not see the first turn's history; threading is broken")
 	}
 }
+
+// TestRunScenarioUsesInjectedStore proves NewMemoryStore is honored, so the
+// harness can grade a specific MemoryStore impl (redis, gorm, semantic)
+// through the same scenarios rather than always the in-memory default.
+func TestRunScenarioUsesInjectedStore(t *testing.T) {
+	stub := agent.NewStubProvider(
+		agent.StubTurn{ToolCalls: []agent.ToolCall{{
+			ID: "c1", Name: agent.RememberToolName,
+			Args: core.NewRawJSON(json.RawMessage(`{"key":"lang","value":"Go"}`)),
+		}}},
+		agent.StubTurn{Text: "saved"},
+	)
+
+	// hand RunScenario a store we hold a reference to (via the factory), then
+	// assert the remember landed in THAT store — not a hidden default.
+	injected := agent.NewInMemoryMemoryStore()
+	built := 0
+	_, err := RunScenario(context.Background(), agent.RunnerConfig{Provider: stub},
+		Scenario{
+			Name:           "injected",
+			Turns:          []string{"remember my language is Go"},
+			NewMemoryStore: func() (agent.MemoryStore, error) { built++; return injected, nil },
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if built != 1 {
+		t.Fatalf("factory built %d times, want exactly 1 per RunScenario", built)
+	}
+	got, _ := injected.ListMemories(context.Background(), agent.ListMemoriesRequest{})
+	if len(got.Items) != 1 || got.Items[0].Value != "Go" {
+		t.Fatalf("injected store = %+v, want the scenario to have used it", got.Items)
+	}
+}
+
+func TestRunScenarioMemoryStoreErrorIsHarnessError(t *testing.T) {
+	_, err := RunScenario(context.Background(), agent.RunnerConfig{Provider: agent.NewStubProvider()},
+		Scenario{
+			Name:           "bad-store",
+			Turns:          []string{"hi"},
+			NewMemoryStore: func() (agent.MemoryStore, error) { return nil, errFactory },
+		})
+	if err == nil {
+		t.Fatal("a store-factory error should surface as a harness error")
+	}
+}
+
+var errFactory = fmt.Errorf("boom")
 
 func TestRunScenarioReportsHarnessError(t *testing.T) {
 	// no Provider -> NewRunner rejects -> harness-level error, not a Result

--- a/agent/eval/scenario_test.go
+++ b/agent/eval/scenario_test.go
@@ -1,0 +1,83 @@
+package eval
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/panyam/mcpkit/agent"
+	"github.com/panyam/mcpkit/core"
+)
+
+// TestRunScenarioThreadsMemoryAcrossTurns is the deterministic plumbing
+// test for the multi-turn harness: a fact remembered on turn 1 is recalled
+// and answered on turn 2, proving history + the shared MemorySource thread
+// across turns without a live model.
+func TestRunScenarioThreadsMemoryAcrossTurns(t *testing.T) {
+	stub := agent.NewStubProvider(
+		// scenario turn 1: remember
+		agent.StubTurn{ToolCalls: []agent.ToolCall{{
+			ID: "c1", Name: agent.RememberToolName,
+			Args: core.NewRawJSON(json.RawMessage(`{"key":"lang","value":"Go"}`)),
+		}}},
+		agent.StubTurn{Text: "saved"},
+		// scenario turn 2: recall, then answer
+		agent.StubTurn{ToolCalls: []agent.ToolCall{{
+			ID: "c2", Name: agent.RecallToolName,
+			Args: core.NewRawJSON(json.RawMessage(`{"query":"lang"}`)),
+		}}},
+		agent.StubTurn{Text: "your language is Go"},
+	)
+
+	results, err := RunScenario(context.Background(), agent.RunnerConfig{Provider: stub},
+		Scenario{Name: "recall", Turns: []string{"remember my language is Go", "what is my language?"}, Memory: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("got %d turn results, want 2", len(results))
+	}
+
+	// the graded (final) turn answers from recalled memory
+	final := Final(results)
+	if final.Turn == nil || !strings.Contains(final.Turn.Text, "Go") {
+		t.Fatalf("final answer = %+v, want it to contain the recalled value", final.Turn)
+	}
+
+	// turn 2's first model call saw turn 1's history (threading)
+	secondTurnReq := stub.Requests()[2]
+	var sawRemember bool
+	for _, m := range secondTurnReq.Messages {
+		if m.Role == agent.RoleTool && strings.Contains(m.Text, "remembered") {
+			sawRemember = true
+		}
+	}
+	if !sawRemember {
+		t.Fatal("second turn did not see the first turn's history; threading is broken")
+	}
+}
+
+func TestRunScenarioReportsHarnessError(t *testing.T) {
+	// no Provider -> NewRunner rejects -> harness-level error, not a Result
+	_, err := RunScenario(context.Background(), agent.RunnerConfig{},
+		Scenario{Name: "bad", Turns: []string{"hi"}})
+	if err == nil {
+		t.Fatal("expected a harness error for a missing provider")
+	}
+}
+
+func TestRunScenarioWithoutMemory(t *testing.T) {
+	stub := agent.NewStubProvider(
+		agent.StubTurn{Text: "one"},
+		agent.StubTurn{Text: "two"},
+	)
+	results, err := RunScenario(context.Background(), agent.RunnerConfig{Provider: stub},
+		Scenario{Name: "plain", Turns: []string{"a", "b"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 2 || Final(results).Turn.Text != "two" {
+		t.Fatalf("plain scenario = %+v", results)
+	}
+}

--- a/agent/eval/scorer.go
+++ b/agent/eval/scorer.go
@@ -61,6 +61,22 @@ func Contains(substr string) Scorer {
 	})
 }
 
+// NotContains passes when the final turn text does NOT contain substr. It is
+// the abstention / knowledge-supersede check: a memory eval asserts the model
+// did not surface a stale fact (the old value after an update) or did not
+// hallucinate a specific it was never told. A failed run (no turn) fails the
+// scorer — there is no answer to trust.
+func NotContains(substr string) Scorer {
+	return scorerFunc(func(r Result) Score {
+		if r.Turn == nil {
+			return boolScore("NotContains", false, "no turn result (run failed)")
+		}
+		got := r.Turn.Text
+		return boolScore("NotContains", !strings.Contains(got, substr),
+			fmt.Sprintf("want substring %q absent from %q", substr, got))
+	})
+}
+
 // ToolCalled passes when the turn requested the named tool at least once. It
 // scans the event stream for tool-begin (emitted for every dispatched call,
 // including ones that later error or are denied), so it reports intent to call


### PR DESCRIPTION
Closes #974. Stacks on PR 1004 (working memory). **No CI while based on a non-main branch** — verified locally with `make test-agent` (all green); run `go test ./agent/eval/...` and `go test -tags eval_llm ./agent/eval/...`. First half of the memory-eval stack; PR for issue 939 (compaction) stacks on this and is graded by this harness.

## What changes

The eval harness gains a **multi-turn** runner so it can host long-term memory benchmarks. Today `eval.Run` executes one turn; LongMemEval is inherently multi-turn (accrue facts across a conversation, then ask a question), so `eval.Scenario` + `RunScenario` thread history and one shared `MemorySource` across a sequence of turns and return one `Result` per turn (the last is graded). A new `agent/eval/longmemeval` package adapts a first slice of scenarios across the five LongMemEval categories.

Memory fails **silently** — a missing or stale fact yields a subtly worse answer, not an error — so this is graded by a model, not a unit assertion. The case data and deterministic substring checks live in the default build (unit-tested); the live benchmark (LLM judge, real model) is behind the `eval_llm` tag and **reports a pass rate rather than gating**.

## Reviewer's guide

Read in this order:
1. [agent/eval/scenario.go](https://github.com/panyam/mcpkit/pull/1005/files#diff-15d979caa88ef936a299ec1b3bddc53d32d9ebab9fee6d208d340167d16ea20f) — start here. `Scenario` + `RunScenario`: one `Runner` reused across turns (it's stateless over the history it's handed, which is what lets the shared `MemorySource` persist), history threaded, memory merged with any base tools. `Final` returns the graded turn.
2. [agent/eval/scenario_test.go](https://github.com/panyam/mcpkit/pull/1005/files#diff-6a83134e42fac3a48490784253aa433cb2225dfabe5810b065e47e1c177bf4c4) — deterministic acceptance: remember on turn 1, recall-and-answer on turn 2, with history threading asserted (no live model).
3. [agent/eval/longmemeval/cases.go](https://github.com/panyam/mcpkit/pull/1005/files#diff-24bb9a5bd58877151bc512849c5670edd1f84ebcc1d2afa6d92a5fbdb3626d6c) — the adapted case table: `MemCase` (scenario + `Must`/`MustNot` + `Rubric`), `Cases()` (one per category), `Deterministic()` (substring scorers).
4. [agent/eval/longmemeval/cases_test.go](https://github.com/panyam/mcpkit/pull/1005/files#diff-17a274ebdaa53632be37745158c5624bc5c837e8fa2b0af075dcf156642e100c) — well-formedness (all five categories covered, every case gradeable) — runs in the default build.
5. [agent/eval/longmemeval/live_test.go](https://github.com/panyam/mcpkit/pull/1005/files#diff-8ac7250929832e53a5b04e93c0b1fb918663ee03c356a12f073de8cdc488f257) (`//go:build eval_llm`) — the live benchmark; skips without `LONGMEMEVAL_BASE_URL`/`_MODEL`.
6. [agent/eval/scorer.go](https://github.com/panyam/mcpkit/pull/1005/files#diff-cd975322b47b6b351f30ae49030e339a542cff41f17fb85a90b94f88e43a0258) / `eval_test.go` — the new `NotContains` scorer (abstention / supersede) + its test.
7. [agent/eval/longmemeval/ATTRIBUTION.md](https://github.com/panyam/mcpkit/pull/1005/files#diff-ab6b47e4f76b4989c6326394e1a37c275d26dad6975aec1ff1835e75903408a2) — dataset is NOT vendored; cases are hand-authored.

## How it works

```
RunScenario(cfg, {turns, memory}):
  if memory: cfg.Tools = merge(cfg.Tools, MemorySource over fresh store)   # one store for the whole scenario
  runner = NewRunner(cfg)                                                   # built once, reused per turn
  history = []
  for input in turns:
    history += RoleUser(input)
    turn = runner.Run(history)          # shared MemorySource persists facts across turns
    results += Result{turn}
    history += turn.Messages
  return results                        # Final(results) = the graded turn

grade (live, eval_llm):  deterministic Must/MustNot  +  Judge(rubric)  ->  pass rate, not a gate
```

## Decision log

- **Case data + deterministic grading in the default build, live run behind `eval_llm`.** The table's well-formedness and the substring checks are unit-testable with no model; only the fuzzy/judge run needs an endpoint. Mirrors the existing `Judge` split.
- **One `Runner` reused across a scenario's turns**, not one per turn. The Runner is stateless over the history it's given, so reuse is exactly what makes the shared `MemorySource` (held in `cfg.Tools`) carry a fact from turn 1 to turn N.
- **Live benchmark reports, does not gate.** Memory quality is statistical; a hard per-case `t.Fatal` on a model miss would make the benchmark brittle. It logs per-case verdicts and an aggregate pass rate; only a harness error fails the test.
- **Dataset not vendored.** Hand-authored scenarios in the LongMemEval categories; `ATTRIBUTION.md` records the provenance and the rule for anyone importing upstream data later.

## Risk / blast radius

- Affects: `agent/eval/` only (new files + one additive scorer). Nothing outside eval imports this; no existing assertion touched.
- Tests: scenario threading (deterministic), case well-formedness (all categories), `NotContains` (pass/fail/no-turn), plus the tagged live path compiles and skips cleanly.
- Be paranoid about: the memory-merge branch in `RunScenario` (base tools + memory under a `MultiSource`), and that the live test truly skips (not fails) without env.

## Before / after

```
before:  eval.Run(cfg, Case{Input})           -> one turn, one answer graded
         (no way to express "remember across turns, then ask")

after:   eval.RunScenario(cfg, Scenario{
           Turns: ["I switched to VS Code", "which editor do I use now?"],
           Memory: true,
         })                                    -> N turns, shared memory, Final() graded
         longmemeval.Cases()                   -> 5 categories, deterministic + judge
```

## Out of scope (deliberately deferred)

- The compaction scenario (a run long enough to force compaction, asserting the key fact survives) → PR for issue 939, next in this stack.
- BFCL relevance (`NotDenied`) + tau-bench user-sim sibling benchmarks → filed follow-ups (noted in ATTRIBUTION.md).
- Doc/roadmap updates → post-merge `/checkpoint`.

## Review updates

- **Pluggable store in `RunScenario`** — added `Scenario.NewMemoryStore` (a store factory), so the harness can grade any `MemoryStore` impl (redis, gorm, a future semantic store) through the same scenarios instead of always the in-memory default. Called once per run so suites never cross-contaminate. Tests: injected-store-is-used + factory-error-is-harness-error.
- **Honest labeling** — the hand-written cases are now `SmokeScenarios()`, documented as a fast self-contained regression signal shaped after the benchmark categories, NOT the dataset (short turns vs ~100k-token histories). Package/ATTRIBUTION docs point at the real path.
- **Follow-ups filed**: 1014 (real LongMemEval dataset loader — external data via env path, adapter in code, the conformance-suite convention), 1015 (a general pluggable eval/benchmark adapter seam so the harness can point at many external suites: LongMemEval, LoCoMo, BFCL, tau-bench).