### PR TITLE
fix(agent/host): inject working-memory summary transiently (issue 1010)

### DIFF
--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -358,7 +358,6 @@ func (a *App) RunTurn(ctx context.Context, input string) error {
 	defer a.turnMu.Unlock()
 	a.triggers.NotifyEngagement()
 	a.drainInjectionLocked()
-	a.injectMemoryLocked(ctx)
 	userMsg := agent.Message{Role: agent.RoleUser, Text: input}
 	a.history = append(a.history, userMsg)
 
@@ -374,7 +373,10 @@ func (a *App) RunTurn(ctx context.Context, input string) error {
 		emit = pe.Emit
 	}
 
-	result, err := a.runner.Run(ctx, a.history, emit)
+	// The memory summary is woven into the per-turn slice only, never into
+	// a.history — see withMemorySummaryLocked.
+	turnMsgs := a.withMemorySummaryLocked(ctx)
+	result, err := a.runner.Run(ctx, turnMsgs, emit)
 	if err != nil {
 		a.history = a.history[:len(a.history)-1]
 		a.emit(HostEvent{Kind: HostTurnFailed, Err: err.Error()})

--- a/agent/host/memory.go
+++ b/agent/host/memory.go
@@ -37,18 +37,33 @@ func (a *App) registerMemory(multi *agent.MultiSource, store agent.MemoryStore) 
 	return nil
 }
 
-// injectMemoryLocked prepends the working-memory summary as a RoleSystem
-// message when Config.Memory.InjectSummary is on, so the model stays aware
-// of its scratchpad without a recall call. A summary error is non-fatal —
-// memory awareness is best-effort and must never fail a turn. Caller holds
-// turnMu.
-func (a *App) injectMemoryLocked(ctx context.Context) {
+// withMemorySummaryLocked returns the messages for this turn, weaving the
+// working-memory summary in as a RoleSystem message just before the current
+// (last) user message when Config.Memory.InjectSummary is on.
+//
+// The summary is a stateful snapshot of current memory, re-rendered every
+// turn, so it is injected TRANSIENTLY: it goes into the returned slice for
+// this one model call and is never written into a.history. That keeps the
+// durable conversation (and the persisted RunStore log) free of stacked,
+// mostly-identical snapshots — the opposite of drainInjectionLocked, which
+// appends because each event is drained exactly once.
+//
+// When memory is off or empty it returns a.history unchanged (no copy). A
+// summary error is non-fatal — memory awareness is best-effort and must
+// never fail a turn. Caller holds turnMu and has already appended the user
+// message to a.history.
+func (a *App) withMemorySummaryLocked(ctx context.Context) []agent.Message {
 	if a.memory == nil || a.cfg.Memory == nil || !a.cfg.Memory.InjectSummary {
-		return
+		return a.history
 	}
 	summary, err := a.memory.Summary(ctx)
 	if err != nil || summary == "" {
-		return
+		return a.history
 	}
-	a.history = append(a.history, agent.Message{Role: agent.RoleSystem, Text: summary})
+	n := len(a.history)
+	msgs := make([]agent.Message, 0, n+1)
+	msgs = append(msgs, a.history[:n-1]...)
+	msgs = append(msgs, agent.Message{Role: agent.RoleSystem, Text: summary})
+	msgs = append(msgs, a.history[n-1])
+	return msgs
 }

--- a/agent/host/memory_test.go
+++ b/agent/host/memory_test.go
@@ -122,10 +122,58 @@ func toolMsgByID(t *testing.T, msgs []agent.Message, id string) agent.Message {
 }
 
 func hasSystemContaining(msgs []agent.Message, sub string) bool {
+	return countSystemContaining(msgs, sub) > 0
+}
+
+func countSystemContaining(msgs []agent.Message, sub string) int {
+	n := 0
 	for _, m := range msgs {
 		if m.Role == agent.RoleSystem && strings.Contains(m.Text, sub) {
-			return true
+			n++
 		}
 	}
-	return false
+	return n
+}
+
+// TestMemorySummaryIsTransient proves the injected summary never lands in the
+// persistent history and never accumulates: over three turns with a fact
+// remembered on turn 1, a.history holds zero summaries and every later turn's
+// model request carries exactly one (not a growing stack).
+func TestMemorySummaryIsTransient(t *testing.T) {
+	ts := startTestServer(t)
+	stub := agent.NewStubProvider(
+		// turn 1: remember, then reply
+		agent.StubTurn{ToolCalls: []agent.ToolCall{{
+			ID: "c1", Name: agent.RememberToolName,
+			Args: core.NewRawJSON(json.RawMessage(`{"key":"lang","value":"Go"}`)),
+		}}},
+		agent.StubTurn{Text: "saved"},
+		// turns 2 and 3: plain replies — each should see exactly one summary
+		agent.StubTurn{Text: "reply2"},
+		agent.StubTurn{Text: "reply3"},
+	)
+	var out strings.Builder
+	app, err := NewApp(memoryConfig(ts.URL, true), &out, strings.NewReader(""), WithProvider(stub))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Close()
+
+	for _, in := range []string{"remember Go", "and?", "still there?"} {
+		if err := app.RunTurn(context.Background(), in); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	const marker = "Working memory"
+	// the durable history never carries a summary
+	if n := countSystemContaining(app.history, marker); n != 0 {
+		t.Fatalf("a.history holds %d summary messages, want 0 (must be transient)", n)
+	}
+	// turns 2 and 3 (requests[2], [3]) each carry exactly one — no accumulation
+	for _, i := range []int{2, 3} {
+		if n := countSystemContaining(stub.Requests()[i].Messages, marker); n != 1 {
+			t.Fatalf("request[%d] carried %d summaries, want exactly 1", i, n)
+		}
+	}
 }


### PR DESCRIPTION
Closes #1010. Based on `main` (working memory from PR 1004 is merged), so CI runs. First of two memory-injection follow-ups; PR for issue 1011 (budget the summary) stacks on this.

## What changes

`Config.Memory.InjectSummary` used to append the summary to the **persistent** `a.history` every turn. Because `MemorySource.Summary()` re-renders the whole scratchpad each time, snapshots stacked up in history and in the RunStore log — all re-sent to the model. A memory summary is a stateful **snapshot**, not an event, so it's now injected **transiently**: woven into the per-turn message slice handed to `Runner.Run` (a `RoleSystem` message just before the current user message) and never written into `a.history`.

## Reviewer's guide

Read in this order:
1. [agent/host/memory.go](https://github.com/panyam/mcpkit/pull/1012/files#diff-2fa9e3fc7796e7e17ca21962b0f10cf32f1e7cc8b61a88abbfb519c350a97c62) — `injectMemoryLocked` (mutated history) becomes `withMemorySummaryLocked` (returns the per-turn slice; `a.history` untouched). Doc comment contrasts it with `drainInjectionLocked` (events are drained once, so appending is correct there; a snapshot re-appended every turn is not).
2. [agent/host/app.go](https://github.com/panyam/mcpkit/pull/1012/files#diff-89fb8e04b6e1e9d5f7f76958490ef158dee40e2cae92d87c04b408d893c84361) — `RunTurn` drops the pre-append inject call and instead builds `turnMsgs := a.withMemorySummaryLocked(ctx)` right before `Run`; persistence still uses `userMsg + result.Messages` (no summary).
3. [agent/host/memory_test.go](https://github.com/panyam/mcpkit/pull/1012/files#diff-e005969fe5c233a0078d9e7ff785c7d6cf4d8767cc6e81c39351b5849a075f43) — `TestMemorySummaryIsTransient`: three turns, a fact remembered on turn 1; asserts `a.history` holds **zero** summaries and turns 2 & 3 each carry **exactly one** (no accumulation). Red on the old append-to-history code.

## How it works

```
before:  RunTurn: injectMemory -> a.history += summary   # persisted, re-sent, stacks every turn
         turn 3 history: [sum-v1, user1, ..., sum-v2, ..., sum-v3, user3]

after:   RunTurn: a.history += userMsg
         turnMsgs = a.history[:last] + summary + userMsg  # transient, this call only
         Run(turnMsgs); persist(userMsg + result)         # a.history and RunStore stay summary-free
```

## Decision log

- **Transient over dedup-on-append.** Could instead strip the previous summary before appending a new one, but a snapshot simply doesn't belong in the durable log at all — keeping it out of `a.history` also keeps the RunStore clean, consistent with the Phase-1 event-log dedup work (issue 973).
- **Positioned just before the current user message** (not at the very front): most salient as "here's what you know, now answer this," and it mirrors where injected context already sits relative to the turn.

## Risk / blast radius

- Affects: `agent/host` only; `InjectSummary` is opt-in and off by default, so the default path is unchanged. The failure path (`a.history[:len-1]` popping the user message on error) is now simpler — the summary was never in `a.history` to pop.
- Tests: the new transient test (zero-in-history, one-per-request) plus the existing on/off injection test still pass.
- Be paranoid about: message ordering (summary must land immediately before the current user message), and that a summary error stays non-fatal (returns `a.history` unchanged).

## Before / after

```
InjectSummary on, 3 turns, "lang: Go" remembered on turn 1:

before:  a.history  -> contains 2 stacked summary snapshots (turns 2,3)
         turn-3 model request -> 2 summaries
after:   a.history  -> 0 summaries
         turn-3 model request -> exactly 1 (current) summary
```

## Out of scope (deliberately deferred)

- Budgeting / prioritizing the summary (max items/chars, recency) → issue 1011, next in this stack.
- Relevance-filtered injection via semantic recall → issue 940.
