### PR TITLE
feat(agent): semantic recall — Embedder seam + SemanticMemoryStore (issue 940, PR 1/2)

### DIFF
--- a/agent/embedder.go
+++ b/agent/embedder.go
@@ -1,0 +1,203 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"hash/fnv"
+	"math"
+	"net/http"
+	"strings"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+// Embedder turns text into dense vectors so memory can be recalled by
+// semantic similarity rather than substring match. It is the sibling of
+// Provider: an independently swappable seam (a hosted API, a local model, a
+// stub) that the rest of the agent depends on only through this interface.
+//
+// Embed returns exactly one vector per input text, in the same order, and
+// every vector an Embedder produces shares one dimensionality — callers may
+// rely on that to compare vectors from the same Embedder with
+// CosineSimilarity. Embedding different providers' vectors together is
+// meaningless; a store must be built and queried with the same Embedder.
+type Embedder interface {
+	Embed(ctx context.Context, texts []string) ([][]float32, error)
+}
+
+// CosineSimilarity returns the cosine of the angle between a and b, in
+// [-1, 1] (1 = identical direction). It returns 0 when either vector is zero
+// or the lengths differ — a degenerate comparison ranks last rather than
+// erroring, so a recall query never fails on a malformed vector.
+func CosineSimilarity(a, b []float32) float64 {
+	if len(a) != len(b) {
+		return 0
+	}
+	var dot, na, nb float64
+	for i := range a {
+		dot += float64(a[i]) * float64(b[i])
+		na += float64(a[i]) * float64(a[i])
+		nb += float64(b[i]) * float64(b[i])
+	}
+	if na == 0 || nb == 0 {
+		return 0
+	}
+	return dot / (math.Sqrt(na) * math.Sqrt(nb))
+}
+
+// OpenAIEmbedderConfig configures an OpenAIEmbedder.
+type OpenAIEmbedderConfig struct {
+	// BaseURL is the API root including any version prefix, e.g.
+	// "http://localhost:1234/v1". The embedder appends "/embeddings".
+	BaseURL string
+
+	// APIKey, when non-empty, is sent as a Bearer token. Local servers
+	// commonly need none.
+	APIKey string
+
+	// Model is the embedding model identifier sent on every request.
+	Model string
+
+	// HTTPClient overrides http.DefaultClient.
+	HTTPClient *http.Client
+
+	// TracerProvider opts the embedder into an agent.embed span per call
+	// (input count + model attributes). Nil or NoopTracerProvider means
+	// zero overhead, the repo-wide pattern.
+	TracerProvider core.TracerProvider
+}
+
+// OpenAIEmbedder is an Embedder over any OpenAI-compatible /embeddings
+// endpoint (OpenAI, LM Studio, Ollama, ...), using net/http directly with no
+// SDK dependency — the same no-SDK approach as OpenAIProvider.
+type OpenAIEmbedder struct {
+	cfg  OpenAIEmbedderConfig
+	http *http.Client
+	tp   core.TracerProvider
+}
+
+// NewOpenAIEmbedder validates cfg and returns the embedder. BaseURL and
+// Model are required.
+func NewOpenAIEmbedder(cfg OpenAIEmbedderConfig) (*OpenAIEmbedder, error) {
+	if cfg.BaseURL == "" || cfg.Model == "" {
+		return nil, fmt.Errorf("agent: OpenAIEmbedderConfig requires BaseURL and Model")
+	}
+	hc := cfg.HTTPClient
+	if hc == nil {
+		hc = http.DefaultClient
+	}
+	tp := cfg.TracerProvider
+	if tp == nil {
+		tp = core.NoopTracerProvider{}
+	}
+	return &OpenAIEmbedder{cfg: cfg, http: hc, tp: tp}, nil
+}
+
+type embeddingRequest struct {
+	Model string   `json:"model"`
+	Input []string `json:"input"`
+}
+
+type embeddingResponse struct {
+	Data []struct {
+		Index     int       `json:"index"`
+		Embedding []float32 `json:"embedding"`
+	} `json:"data"`
+}
+
+// Embed implements Embedder. It sends all texts in one request and returns
+// the vectors reordered to match the input order (the API echoes an index
+// per embedding, which need not be in request order).
+func (e *OpenAIEmbedder) Embed(ctx context.Context, texts []string) ([][]float32, error) {
+	ctx, span := e.tp.StartSpan(ctx, "agent.embed",
+		core.Attribute{Key: "agent.embed.count", Value: fmt.Sprint(len(texts))},
+		core.Attribute{Key: "agent.embed.model", Value: e.cfg.Model})
+	defer span.End()
+
+	if len(texts) == 0 {
+		return nil, nil
+	}
+
+	body, err := json.Marshal(embeddingRequest{Model: e.cfg.Model, Input: texts})
+	if err != nil {
+		span.RecordError(err)
+		return nil, fmt.Errorf("agent: encode embedding request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, e.cfg.BaseURL+"/embeddings", bytes.NewReader(body))
+	if err != nil {
+		span.RecordError(err)
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if e.cfg.APIKey != "" {
+		req.Header.Set("Authorization", "Bearer "+e.cfg.APIKey)
+	}
+
+	resp, err := e.http.Do(req)
+	if err != nil {
+		span.RecordError(err)
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		msg := new(bytes.Buffer)
+		_, _ = msg.ReadFrom(resp.Body)
+		err := &ProviderError{StatusCode: resp.StatusCode, Body: msg.String()}
+		span.RecordError(err)
+		return nil, err
+	}
+
+	var out embeddingResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		span.RecordError(err)
+		return nil, fmt.Errorf("agent: decode embedding response: %w", err)
+	}
+	if len(out.Data) != len(texts) {
+		err := fmt.Errorf("agent: embedding count mismatch: got %d for %d inputs", len(out.Data), len(texts))
+		span.RecordError(err)
+		return nil, err
+	}
+	vecs := make([][]float32, len(texts))
+	for _, d := range out.Data {
+		if d.Index < 0 || d.Index >= len(vecs) {
+			continue
+		}
+		vecs[d.Index] = d.Embedding
+	}
+	return vecs, nil
+}
+
+// DefaultStubEmbedderDim is the vector width StubEmbedder uses when its Dim
+// is unset.
+const DefaultStubEmbedderDim = 64
+
+// StubEmbedder is a deterministic, dependency-free Embedder for tests: it
+// projects each text into a fixed-width bag-of-words vector (each lowercased
+// token hashed into a bucket), so texts that share words produce similar
+// vectors and CosineSimilarity is meaningful. No model, no network, stable
+// across runs — the embedding counterpart of StubProvider.
+type StubEmbedder struct {
+	// Dim is the vector width. Zero uses DefaultStubEmbedderDim.
+	Dim int
+}
+
+// Embed implements Embedder.
+func (e StubEmbedder) Embed(ctx context.Context, texts []string) ([][]float32, error) {
+	dim := e.Dim
+	if dim <= 0 {
+		dim = DefaultStubEmbedderDim
+	}
+	out := make([][]float32, len(texts))
+	for i, t := range texts {
+		vec := make([]float32, dim)
+		for _, tok := range strings.Fields(strings.ToLower(t)) {
+			h := fnv.New32a()
+			_, _ = h.Write([]byte(tok))
+			vec[h.Sum32()%uint32(dim)]++
+		}
+		out[i] = vec
+	}
+	return out, nil
+}

--- a/agent/embedder.go
+++ b/agent/embedder.go
@@ -13,25 +13,18 @@ import (
 	"github.com/panyam/mcpkit/core"
 )
 
-// Embedder turns text into dense vectors so memory can be recalled by
-// semantic similarity rather than substring match. It is the sibling of
-// Provider: an independently swappable seam (a hosted API, a local model, a
-// stub) that the rest of the agent depends on only through this interface.
-//
-// Embed returns exactly one vector per input text, in the same order, and
-// every vector an Embedder produces shares one dimensionality — callers may
-// rely on that to compare vectors from the same Embedder with
-// CosineSimilarity. Embedding different providers' vectors together is
-// meaningless; a store must be built and queried with the same Embedder.
-type Embedder interface {
-	Embed(ctx context.Context, texts []string) ([][]float32, error)
-}
+// Embedding is a dense vector produced by an Embedder. A defined type (not a
+// bare []float32) so the comparison lives on it as a method and signatures
+// read in domain terms; every Embedding from one Embedder shares a
+// dimensionality, and comparing embeddings from different Embedders is
+// meaningless.
+type Embedding []float32
 
-// CosineSimilarity returns the cosine of the angle between a and b, in
-// [-1, 1] (1 = identical direction). It returns 0 when either vector is zero
-// or the lengths differ — a degenerate comparison ranks last rather than
-// erroring, so a recall query never fails on a malformed vector.
-func CosineSimilarity(a, b []float32) float64 {
+// Cosine returns the cosine of the angle between a and b, in [-1, 1] (1 =
+// identical direction). It returns 0 when either vector is zero or the
+// lengths differ — a degenerate comparison ranks last rather than erroring,
+// so a recall query never fails on a malformed vector.
+func (a Embedding) Cosine(b Embedding) float64 {
 	if len(a) != len(b) {
 		return 0
 	}
@@ -45,6 +38,17 @@ func CosineSimilarity(a, b []float32) float64 {
 		return 0
 	}
 	return dot / (math.Sqrt(na) * math.Sqrt(nb))
+}
+
+// Embedder turns text into Embeddings so memory can be recalled by semantic
+// similarity rather than substring match. It is the sibling of Provider: an
+// independently swappable seam (a hosted API, a local model, a stub) that the
+// rest of the agent depends on only through this interface.
+//
+// Embed returns exactly one Embedding per input text, in the same order. A
+// store must be built and queried with the same Embedder.
+type Embedder interface {
+	Embed(ctx context.Context, texts []string) ([]Embedding, error)
 }
 
 // OpenAIEmbedderConfig configures an OpenAIEmbedder.
@@ -103,14 +107,14 @@ type embeddingRequest struct {
 type embeddingResponse struct {
 	Data []struct {
 		Index     int       `json:"index"`
-		Embedding []float32 `json:"embedding"`
+		Embedding Embedding `json:"embedding"`
 	} `json:"data"`
 }
 
 // Embed implements Embedder. It sends all texts in one request and returns
-// the vectors reordered to match the input order (the API echoes an index
+// the embeddings reordered to match the input order (the API echoes an index
 // per embedding, which need not be in request order).
-func (e *OpenAIEmbedder) Embed(ctx context.Context, texts []string) ([][]float32, error) {
+func (e *OpenAIEmbedder) Embed(ctx context.Context, texts []string) ([]Embedding, error) {
 	ctx, span := e.tp.StartSpan(ctx, "agent.embed",
 		core.Attribute{Key: "agent.embed.count", Value: fmt.Sprint(len(texts))},
 		core.Attribute{Key: "agent.embed.model", Value: e.cfg.Model})
@@ -159,7 +163,7 @@ func (e *OpenAIEmbedder) Embed(ctx context.Context, texts []string) ([][]float32
 		span.RecordError(err)
 		return nil, err
 	}
-	vecs := make([][]float32, len(texts))
+	vecs := make([]Embedding, len(texts))
 	for _, d := range out.Data {
 		if d.Index < 0 || d.Index >= len(vecs) {
 			continue
@@ -184,14 +188,14 @@ type StubEmbedder struct {
 }
 
 // Embed implements Embedder.
-func (e StubEmbedder) Embed(ctx context.Context, texts []string) ([][]float32, error) {
+func (e StubEmbedder) Embed(ctx context.Context, texts []string) ([]Embedding, error) {
 	dim := e.Dim
 	if dim <= 0 {
 		dim = DefaultStubEmbedderDim
 	}
-	out := make([][]float32, len(texts))
+	out := make([]Embedding, len(texts))
 	for i, t := range texts {
-		vec := make([]float32, dim)
+		vec := make(Embedding, dim)
 		for _, tok := range strings.Fields(strings.ToLower(t)) {
 			h := fnv.New32a()
 			_, _ = h.Write([]byte(tok))

--- a/agent/embedder_test.go
+++ b/agent/embedder_test.go
@@ -5,18 +5,18 @@ import (
 	"testing"
 )
 
-func TestCosineSimilarity(t *testing.T) {
-	if got := CosineSimilarity([]float32{1, 0}, []float32{1, 0}); got != 1 {
+func TestCosine(t *testing.T) {
+	if got := (Embedding{1, 0}).Cosine(Embedding{1, 0}); got != 1 {
 		t.Fatalf("identical vectors = %v, want 1", got)
 	}
-	if got := CosineSimilarity([]float32{1, 0}, []float32{0, 1}); got != 0 {
+	if got := (Embedding{1, 0}).Cosine(Embedding{0, 1}); got != 0 {
 		t.Fatalf("orthogonal vectors = %v, want 0", got)
 	}
 	// mismatched length and zero vectors degrade to 0, never error
-	if got := CosineSimilarity([]float32{1, 2, 3}, []float32{1, 2}); got != 0 {
+	if got := (Embedding{1, 2, 3}).Cosine(Embedding{1, 2}); got != 0 {
 		t.Fatalf("mismatched length = %v, want 0", got)
 	}
-	if got := CosineSimilarity([]float32{0, 0}, []float32{1, 1}); got != 0 {
+	if got := (Embedding{0, 0}).Cosine(Embedding{1, 1}); got != 0 {
 		t.Fatalf("zero vector = %v, want 0", got)
 	}
 }
@@ -31,7 +31,7 @@ func TestStubEmbedderDeterministicAndMeaningful(t *testing.T) {
 	if len(a[0]) != DefaultStubEmbedderDim {
 		t.Fatalf("dim = %d, want %d", len(a[0]), DefaultStubEmbedderDim)
 	}
-	if CosineSimilarity(a[0], b[0]) != 1 {
+	if a[0].Cosine(b[0]) != 1 {
 		t.Fatal("same text should embed identically")
 	}
 
@@ -41,8 +41,8 @@ func TestStubEmbedderDeterministicAndMeaningful(t *testing.T) {
 		"the programming language i use",
 		"my dog is a border collie",
 	})
-	shared := CosineSimilarity(vecs[0], vecs[1])
-	disjoint := CosineSimilarity(vecs[0], vecs[2])
+	shared := vecs[0].Cosine(vecs[1])
+	disjoint := vecs[0].Cosine(vecs[2])
 	if shared <= disjoint {
 		t.Fatalf("shared-word similarity %.3f should exceed disjoint %.3f", shared, disjoint)
 	}

--- a/agent/embedder_test.go
+++ b/agent/embedder_test.go
@@ -1,0 +1,49 @@
+package agent
+
+import (
+	"context"
+	"testing"
+)
+
+func TestCosineSimilarity(t *testing.T) {
+	if got := CosineSimilarity([]float32{1, 0}, []float32{1, 0}); got != 1 {
+		t.Fatalf("identical vectors = %v, want 1", got)
+	}
+	if got := CosineSimilarity([]float32{1, 0}, []float32{0, 1}); got != 0 {
+		t.Fatalf("orthogonal vectors = %v, want 0", got)
+	}
+	// mismatched length and zero vectors degrade to 0, never error
+	if got := CosineSimilarity([]float32{1, 2, 3}, []float32{1, 2}); got != 0 {
+		t.Fatalf("mismatched length = %v, want 0", got)
+	}
+	if got := CosineSimilarity([]float32{0, 0}, []float32{1, 1}); got != 0 {
+		t.Fatalf("zero vector = %v, want 0", got)
+	}
+}
+
+func TestStubEmbedderDeterministicAndMeaningful(t *testing.T) {
+	e := StubEmbedder{}
+	ctx := context.Background()
+
+	// deterministic: same text -> same vector, fixed dimension
+	a, _ := e.Embed(ctx, []string{"the quick brown fox"})
+	b, _ := e.Embed(ctx, []string{"the quick brown fox"})
+	if len(a[0]) != DefaultStubEmbedderDim {
+		t.Fatalf("dim = %d, want %d", len(a[0]), DefaultStubEmbedderDim)
+	}
+	if CosineSimilarity(a[0], b[0]) != 1 {
+		t.Fatal("same text should embed identically")
+	}
+
+	// meaningful: shared words -> higher similarity than disjoint words
+	vecs, _ := e.Embed(ctx, []string{
+		"my favorite programming language",
+		"the programming language i use",
+		"my dog is a border collie",
+	})
+	shared := CosineSimilarity(vecs[0], vecs[1])
+	disjoint := CosineSimilarity(vecs[0], vecs[2])
+	if shared <= disjoint {
+		t.Fatalf("shared-word similarity %.3f should exceed disjoint %.3f", shared, disjoint)
+	}
+}

--- a/agent/eval/scenario_test.go
+++ b/agent/eval/scenario_test.go
@@ -88,7 +88,7 @@ func TestRunScenarioUsesInjectedStore(t *testing.T) {
 		t.Fatalf("factory built %d times, want exactly 1 per RunScenario", built)
 	}
 	got, _ := injected.ListMemories(context.Background(), agent.ListMemoriesRequest{})
-	if len(got.Items) != 1 || got.Items[0].Value != "Go" {
+	if len(got.Items) != 1 || got.Items[0].Item.Value != "Go" {
 		t.Fatalf("injected store = %+v, want the scenario to have used it", got.Items)
 	}
 }

--- a/agent/host/memory_test.go
+++ b/agent/host/memory_test.go
@@ -61,7 +61,7 @@ func TestAppWorkingMemoryAcrossTurns(t *testing.T) {
 
 	// and the store actually holds it
 	got, _ := store.ListMemories(context.Background(), agent.ListMemoriesRequest{})
-	if len(got.Items) != 1 || got.Items[0].Key != "lang" || got.Items[0].Value != "Go" {
+	if len(got.Items) != 1 || got.Items[0].Item.Key != "lang" || got.Items[0].Item.Value != "Go" {
 		t.Fatalf("store = %+v, want lang=Go", got.Items)
 	}
 }

--- a/agent/memory.go
+++ b/agent/memory.go
@@ -54,7 +54,12 @@ type MemoryStore interface {
 	PutMemory(ctx context.Context, req PutMemoryRequest) (PutMemoryResponse, error)
 
 	// ListMemories returns items relevant to req.Query (all items when
-	// Query is empty), oldest first.
+	// Query is empty), most-relevant first, capped at req.Limit. The "how"
+	// of relevance is the implementation's business — the substring default
+	// filters and returns Score 1, a semantic store ranks by embedding
+	// similarity, a pgvector backend does ANN — but the contract (ranked,
+	// scored, top-k) is the same, which is why recall never branches on the
+	// backend.
 	ListMemories(ctx context.Context, req ListMemoriesRequest) (ListMemoriesResponse, error)
 
 	// DeleteMemory removes an item by Key. Deleted reports whether a
@@ -73,14 +78,29 @@ type PutMemoryRequest struct {
 // app-state without a signature break, per the gRPC-style convention.
 type PutMemoryResponse struct{}
 
-// ListMemoriesRequest filters by Query (empty means all).
+// ListMemoriesRequest filters by Query (empty means all) and caps the result
+// at Limit (0 means no cap). Limit is the k of a top-k recall.
 type ListMemoriesRequest struct {
 	Query string
+	Limit int
 }
 
-// ListMemoriesResponse carries the matching items, oldest first.
+// ListMemoriesResponse carries the matching items, most-relevant first.
 type ListMemoriesResponse struct {
-	Items []MemoryItem
+	Items []ScoredMemory
+}
+
+// ScoredMemory pairs a stored MemoryItem with its per-query relevance Score.
+// Score is a property of the QUERY, not of the stored fact (the same item
+// scores differently against different queries), which is why it lives here
+// on the result and not on MemoryItem — that keeps MemoryItem the durable,
+// query-independent fact. A substring store returns 1 for a match; a
+// semantic store returns cosine similarity. Room to grow: a future
+// ranking/reranker stage can add per-signal provenance (similarity vs
+// recency vs importance) here without touching the store or the item.
+type ScoredMemory struct {
+	Item  MemoryItem
+	Score float64
 }
 
 // DeleteMemoryRequest identifies the item to forget by Key.
@@ -158,16 +178,20 @@ func (s *InMemoryMemoryStore) PutMemory(ctx context.Context, req PutMemoryReques
 }
 
 // ListMemories implements MemoryStore: substring match on key or value
-// (case-insensitive), oldest first.
+// (case-insensitive), oldest first, each match scored 1 (the substring
+// store has no graded relevance). Limit caps the count.
 func (s *InMemoryMemoryStore) ListMemories(ctx context.Context, req ListMemoriesRequest) (ListMemoriesResponse, error) {
 	q := strings.ToLower(req.Query)
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	var out []MemoryItem
+	var out []ScoredMemory
 	for e := s.order.Front(); e != nil; e = e.Next() {
+		if req.Limit > 0 && len(out) >= req.Limit {
+			break
+		}
 		item := s.items[e.Value.(string)]
 		if q == "" || strings.Contains(strings.ToLower(item.Key), q) || strings.Contains(strings.ToLower(item.Value), q) {
-			out = append(out, item)
+			out = append(out, ScoredMemory{Item: item, Score: 1})
 		}
 	}
 	return ListMemoriesResponse{Items: out}, nil
@@ -265,7 +289,17 @@ func (m *MemorySource) recall(ctx context.Context, in recallArgs) (string, error
 		}
 		return "no memories match " + in.Query, nil
 	}
-	return renderMemories(resp.Items), nil
+	return renderMemories(itemsOf(resp.Items)), nil
+}
+
+// itemsOf drops the per-query Score, yielding the bare stored items for
+// rendering or recency budgeting.
+func itemsOf(sms []ScoredMemory) []MemoryItem {
+	items := make([]MemoryItem, len(sms))
+	for i, sm := range sms {
+		items[i] = sm.Item
+	}
+	return items
 }
 
 func (m *MemorySource) forget(ctx context.Context, in forgetArgs) (string, error) {
@@ -315,7 +349,7 @@ func (m *MemorySource) Summary(ctx context.Context, opts SummaryOptions) (string
 	if err != nil {
 		return "", err
 	}
-	items := budgetMemories(resp.Items, opts)
+	items := budgetMemories(itemsOf(resp.Items), opts)
 	if len(items) == 0 {
 		return "", nil
 	}

--- a/agent/memory_test.go
+++ b/agent/memory_test.go
@@ -22,10 +22,10 @@ func TestInMemoryMemoryStore_CRUD(t *testing.T) {
 	if len(got.Items) != 2 {
 		t.Fatalf("list = %d items, want 2", len(got.Items))
 	}
-	if got.Items[0].Key != "a" || got.Items[1].Key != "b" {
-		t.Fatalf("list order = %q,%q, want a,b (oldest first)", got.Items[0].Key, got.Items[1].Key)
+	if got.Items[0].Item.Key != "a" || got.Items[1].Item.Key != "b" {
+		t.Fatalf("list order = %q,%q, want a,b (oldest first)", got.Items[0].Item.Key, got.Items[1].Item.Key)
 	}
-	if got.Items[0].CreatedAt.IsZero() {
+	if got.Items[0].Item.CreatedAt.IsZero() {
 		t.Fatal("PutMemory should stamp a zero CreatedAt")
 	}
 }
@@ -39,7 +39,7 @@ func TestInMemoryMemoryStore_UpdateKeepsPosition(t *testing.T) {
 	_, _ = s.PutMemory(ctx, PutMemoryRequest{Item: MemoryItem{Key: "a", Value: "alpha2"}})
 
 	got, _ := s.ListMemories(ctx, ListMemoriesRequest{})
-	if len(got.Items) != 2 || got.Items[0].Key != "a" || got.Items[0].Value != "alpha2" {
+	if len(got.Items) != 2 || got.Items[0].Item.Key != "a" || got.Items[0].Item.Value != "alpha2" {
 		t.Fatalf("update reordered or lost the value: %+v", got.Items)
 	}
 }
@@ -52,12 +52,12 @@ func TestInMemoryMemoryStore_QueryFilter(t *testing.T) {
 
 	// match on value, case-insensitive
 	got, _ := s.ListMemories(ctx, ListMemoriesRequest{Query: "go"})
-	if len(got.Items) != 1 || got.Items[0].Key != "lang" {
+	if len(got.Items) != 1 || got.Items[0].Item.Key != "lang" {
 		t.Fatalf("query 'go' = %+v, want just lang", got.Items)
 	}
 	// match on key
 	got, _ = s.ListMemories(ctx, ListMemoriesRequest{Query: "edit"})
-	if len(got.Items) != 1 || got.Items[0].Key != "editor" {
+	if len(got.Items) != 1 || got.Items[0].Item.Key != "editor" {
 		t.Fatalf("query 'edit' = %+v, want just editor", got.Items)
 	}
 }
@@ -92,7 +92,7 @@ func TestInMemoryMemoryStore_MaxEvictsOldest(t *testing.T) {
 	_, _ = s.PutMemory(ctx, PutMemoryRequest{Item: MemoryItem{Key: "c", Value: "3"}})
 
 	got, _ := s.ListMemories(ctx, ListMemoriesRequest{})
-	if len(got.Items) != 2 || got.Items[0].Key != "b" || got.Items[1].Key != "c" {
+	if len(got.Items) != 2 || got.Items[0].Item.Key != "b" || got.Items[1].Item.Key != "c" {
 		t.Fatalf("cap evict = %+v, want b,c (a evicted)", got.Items)
 	}
 }

--- a/agent/semantic_memory.go
+++ b/agent/semantic_memory.go
@@ -11,7 +11,7 @@ import (
 	"github.com/panyam/mcpkit/core"
 )
 
-// SemanticMemoryStore is a MemoryStore that recalls by embedding similarity
+// InMemorySemanticStore is a MemoryStore that recalls by embedding similarity
 // instead of substring match. It composes an Embedder (text -> vector) with
 // an in-process brute-force cosine index: PutMemory embeds the note and keeps
 // its vector; ListMemories embeds the query and returns items ranked by
@@ -28,13 +28,13 @@ import (
 // Concurrency: safe for concurrent use. Embedding happens outside the lock
 // (a network call for a hosted Embedder), so Put/List never hold the mutex
 // across I/O.
-type SemanticMemoryStore struct {
+type InMemorySemanticStore struct {
 	embedder Embedder
 	tp       core.TracerProvider
 
 	mu    sync.Mutex
 	items map[string]MemoryItem
-	vecs  map[string][]float32
+	vecs  map[string]Embedding
 	// order tracks insertion order for the Query-empty listing and the cap,
 	// mirroring InMemoryMemoryStore; front is oldest.
 	order      *list.List
@@ -42,13 +42,13 @@ type SemanticMemoryStore struct {
 	maxEntries int
 }
 
-// SemanticMemoryOption configures a SemanticMemoryStore.
-type SemanticMemoryOption func(*SemanticMemoryStore)
+// InMemorySemanticStoreOption configures a InMemorySemanticStore.
+type InMemorySemanticStoreOption func(*InMemorySemanticStore)
 
 // WithSemanticMaxMemories caps the store at n items, evicting the oldest when
 // a Put of a new key would exceed n. Zero or negative means unbounded.
-func WithSemanticMaxMemories(n int) SemanticMemoryOption {
-	return func(s *SemanticMemoryStore) {
+func WithSemanticMaxMemories(n int) InMemorySemanticStoreOption {
+	return func(s *InMemorySemanticStore) {
 		if n > 0 {
 			s.maxEntries = n
 		}
@@ -57,26 +57,26 @@ func WithSemanticMaxMemories(n int) SemanticMemoryOption {
 
 // WithSemanticTracerProvider opts the store into an agent.memory.recall span
 // per similarity query. Nil / NoopTracerProvider means zero overhead.
-func WithSemanticTracerProvider(tp core.TracerProvider) SemanticMemoryOption {
-	return func(s *SemanticMemoryStore) {
+func WithSemanticTracerProvider(tp core.TracerProvider) InMemorySemanticStoreOption {
+	return func(s *InMemorySemanticStore) {
 		if tp != nil {
 			s.tp = tp
 		}
 	}
 }
 
-// NewSemanticMemoryStore builds a semantic store over embedder. The embedder
+// NewInMemorySemanticStore builds a semantic store over embedder. The embedder
 // is required; every note and query is embedded with it, so a store must be
 // queried with the same Embedder it was built with.
-func NewSemanticMemoryStore(embedder Embedder, opts ...SemanticMemoryOption) (*SemanticMemoryStore, error) {
+func NewInMemorySemanticStore(embedder Embedder, opts ...InMemorySemanticStoreOption) (*InMemorySemanticStore, error) {
 	if embedder == nil {
-		return nil, fmt.Errorf("agent: SemanticMemoryStore needs an Embedder")
+		return nil, fmt.Errorf("agent: InMemorySemanticStore needs an Embedder")
 	}
-	s := &SemanticMemoryStore{
+	s := &InMemorySemanticStore{
 		embedder: embedder,
 		tp:       core.NoopTracerProvider{},
 		items:    map[string]MemoryItem{},
-		vecs:     map[string][]float32{},
+		vecs:     map[string]Embedding{},
 		order:    list.New(),
 		elems:    map[string]*list.Element{},
 	}
@@ -90,7 +90,7 @@ func NewSemanticMemoryStore(embedder Embedder, opts ...SemanticMemoryOption) (*S
 // and upserts it. Embedding is synchronous — a just-remembered fact is
 // immediately recallable; background/batch indexing of a distillation write
 // path is a separate concern.
-func (s *SemanticMemoryStore) PutMemory(ctx context.Context, req PutMemoryRequest) (PutMemoryResponse, error) {
+func (s *InMemorySemanticStore) PutMemory(ctx context.Context, req PutMemoryRequest) (PutMemoryResponse, error) {
 	item := req.Item
 	if item.CreatedAt.IsZero() {
 		item.CreatedAt = time.Now()
@@ -99,7 +99,7 @@ func (s *SemanticMemoryStore) PutMemory(ctx context.Context, req PutMemoryReques
 	if err != nil {
 		return PutMemoryResponse{}, fmt.Errorf("agent: embedding memory %q: %w", item.Key, err)
 	}
-	var vec []float32
+	var vec Embedding
 	if len(vecs) > 0 {
 		vec = vecs[0]
 	}
@@ -125,7 +125,7 @@ func (s *SemanticMemoryStore) PutMemory(ctx context.Context, req PutMemoryReques
 // ListMemories ranks items by cosine similarity to the query. An empty Query
 // returns all items oldest-first with Score 0 (the "list everything" path the
 // summary uses — there is no query to score against). Limit caps the result.
-func (s *SemanticMemoryStore) ListMemories(ctx context.Context, req ListMemoriesRequest) (ListMemoriesResponse, error) {
+func (s *InMemorySemanticStore) ListMemories(ctx context.Context, req ListMemoriesRequest) (ListMemoriesResponse, error) {
 	if req.Query == "" {
 		return s.listAll(req.Limit), nil
 	}
@@ -134,7 +134,7 @@ func (s *SemanticMemoryStore) ListMemories(ctx context.Context, req ListMemories
 	if err != nil {
 		return ListMemoriesResponse{}, fmt.Errorf("agent: embedding query: %w", err)
 	}
-	var qvec []float32
+	var qvec Embedding
 	if len(qvecs) > 0 {
 		qvec = qvecs[0]
 	}
@@ -147,7 +147,7 @@ func (s *SemanticMemoryStore) ListMemories(ctx context.Context, req ListMemories
 	scored := make([]ScoredMemory, 0, len(s.items))
 	for e := s.order.Front(); e != nil; e = e.Next() {
 		key := e.Value.(string)
-		scored = append(scored, ScoredMemory{Item: s.items[key], Score: CosineSimilarity(qvec, s.vecs[key])})
+		scored = append(scored, ScoredMemory{Item: s.items[key], Score: qvec.Cosine(s.vecs[key])})
 	}
 	s.mu.Unlock()
 
@@ -162,7 +162,7 @@ func (s *SemanticMemoryStore) ListMemories(ctx context.Context, req ListMemories
 	return ListMemoriesResponse{Items: scored}, nil
 }
 
-func (s *SemanticMemoryStore) listAll(limit int) ListMemoriesResponse {
+func (s *InMemorySemanticStore) listAll(limit int) ListMemoriesResponse {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	out := make([]ScoredMemory, 0, s.order.Len())
@@ -177,7 +177,7 @@ func (s *SemanticMemoryStore) listAll(limit int) ListMemoriesResponse {
 
 // DeleteMemory removes an item and its vector. An unknown key is
 // Deleted=false, not an error (same contract as the substring store).
-func (s *SemanticMemoryStore) DeleteMemory(ctx context.Context, req DeleteMemoryRequest) (DeleteMemoryResponse, error) {
+func (s *InMemorySemanticStore) DeleteMemory(ctx context.Context, req DeleteMemoryRequest) (DeleteMemoryResponse, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if _, ok := s.items[req.Key]; !ok {

--- a/agent/semantic_memory.go
+++ b/agent/semantic_memory.go
@@ -1,0 +1,193 @@
+package agent
+
+import (
+	"container/list"
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+// SemanticMemoryStore is a MemoryStore that recalls by embedding similarity
+// instead of substring match. It composes an Embedder (text -> vector) with
+// an in-process brute-force cosine index: PutMemory embeds the note and keeps
+// its vector; ListMemories embeds the query and returns items ranked by
+// cosine similarity, each carrying its Score. It implements the same
+// MemoryStore interface as the substring default, so swapping it in makes the
+// recall tool (and the summary) semantic with no change to the model-facing
+// surface — the "how" of retrieval stays behind the interface.
+//
+// The index is exact and O(n) per query, which is the right trade for a
+// working-memory-sized scratchpad (tens to hundreds of notes). Approximate
+// nearest-neighbor at scale is a durable-backend concern (a pgvector sibling
+// MemoryStore), not something to build into the in-process default.
+//
+// Concurrency: safe for concurrent use. Embedding happens outside the lock
+// (a network call for a hosted Embedder), so Put/List never hold the mutex
+// across I/O.
+type SemanticMemoryStore struct {
+	embedder Embedder
+	tp       core.TracerProvider
+
+	mu    sync.Mutex
+	items map[string]MemoryItem
+	vecs  map[string][]float32
+	// order tracks insertion order for the Query-empty listing and the cap,
+	// mirroring InMemoryMemoryStore; front is oldest.
+	order      *list.List
+	elems      map[string]*list.Element
+	maxEntries int
+}
+
+// SemanticMemoryOption configures a SemanticMemoryStore.
+type SemanticMemoryOption func(*SemanticMemoryStore)
+
+// WithSemanticMaxMemories caps the store at n items, evicting the oldest when
+// a Put of a new key would exceed n. Zero or negative means unbounded.
+func WithSemanticMaxMemories(n int) SemanticMemoryOption {
+	return func(s *SemanticMemoryStore) {
+		if n > 0 {
+			s.maxEntries = n
+		}
+	}
+}
+
+// WithSemanticTracerProvider opts the store into an agent.memory.recall span
+// per similarity query. Nil / NoopTracerProvider means zero overhead.
+func WithSemanticTracerProvider(tp core.TracerProvider) SemanticMemoryOption {
+	return func(s *SemanticMemoryStore) {
+		if tp != nil {
+			s.tp = tp
+		}
+	}
+}
+
+// NewSemanticMemoryStore builds a semantic store over embedder. The embedder
+// is required; every note and query is embedded with it, so a store must be
+// queried with the same Embedder it was built with.
+func NewSemanticMemoryStore(embedder Embedder, opts ...SemanticMemoryOption) (*SemanticMemoryStore, error) {
+	if embedder == nil {
+		return nil, fmt.Errorf("agent: SemanticMemoryStore needs an Embedder")
+	}
+	s := &SemanticMemoryStore{
+		embedder: embedder,
+		tp:       core.NoopTracerProvider{},
+		items:    map[string]MemoryItem{},
+		vecs:     map[string][]float32{},
+		order:    list.New(),
+		elems:    map[string]*list.Element{},
+	}
+	for _, o := range opts {
+		o(s)
+	}
+	return s, nil
+}
+
+// PutMemory embeds the note (key + value, so a recall query matches either)
+// and upserts it. Embedding is synchronous — a just-remembered fact is
+// immediately recallable; background/batch indexing of a distillation write
+// path is a separate concern.
+func (s *SemanticMemoryStore) PutMemory(ctx context.Context, req PutMemoryRequest) (PutMemoryResponse, error) {
+	item := req.Item
+	if item.CreatedAt.IsZero() {
+		item.CreatedAt = time.Now()
+	}
+	vecs, err := s.embedder.Embed(ctx, []string{item.Key + " " + item.Value})
+	if err != nil {
+		return PutMemoryResponse{}, fmt.Errorf("agent: embedding memory %q: %w", item.Key, err)
+	}
+	var vec []float32
+	if len(vecs) > 0 {
+		vec = vecs[0]
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.items[item.Key]; !exists {
+		s.elems[item.Key] = s.order.PushBack(item.Key)
+		for s.maxEntries > 0 && s.order.Len() > s.maxEntries {
+			oldest := s.order.Front()
+			key := oldest.Value.(string)
+			s.order.Remove(oldest)
+			delete(s.elems, key)
+			delete(s.items, key)
+			delete(s.vecs, key)
+		}
+	}
+	s.items[item.Key] = item
+	s.vecs[item.Key] = vec
+	return PutMemoryResponse{}, nil
+}
+
+// ListMemories ranks items by cosine similarity to the query. An empty Query
+// returns all items oldest-first with Score 0 (the "list everything" path the
+// summary uses — there is no query to score against). Limit caps the result.
+func (s *SemanticMemoryStore) ListMemories(ctx context.Context, req ListMemoriesRequest) (ListMemoriesResponse, error) {
+	if req.Query == "" {
+		return s.listAll(req.Limit), nil
+	}
+
+	qvecs, err := s.embedder.Embed(ctx, []string{req.Query})
+	if err != nil {
+		return ListMemoriesResponse{}, fmt.Errorf("agent: embedding query: %w", err)
+	}
+	var qvec []float32
+	if len(qvecs) > 0 {
+		qvec = qvecs[0]
+	}
+
+	_, span := s.tp.StartSpan(ctx, "agent.memory.recall",
+		core.Attribute{Key: "agent.memory.limit", Value: fmt.Sprint(req.Limit)})
+	defer span.End()
+
+	s.mu.Lock()
+	scored := make([]ScoredMemory, 0, len(s.items))
+	for e := s.order.Front(); e != nil; e = e.Next() {
+		key := e.Value.(string)
+		scored = append(scored, ScoredMemory{Item: s.items[key], Score: CosineSimilarity(qvec, s.vecs[key])})
+	}
+	s.mu.Unlock()
+
+	sort.SliceStable(scored, func(i, j int) bool { return scored[i].Score > scored[j].Score })
+	if req.Limit > 0 && len(scored) > req.Limit {
+		scored = scored[:req.Limit]
+	}
+	span.SetAttribute("agent.memory.candidates", fmt.Sprint(len(scored)))
+	if len(scored) > 0 {
+		span.SetAttribute("agent.memory.top_score", fmt.Sprintf("%.4f", scored[0].Score))
+	}
+	return ListMemoriesResponse{Items: scored}, nil
+}
+
+func (s *SemanticMemoryStore) listAll(limit int) ListMemoriesResponse {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]ScoredMemory, 0, s.order.Len())
+	for e := s.order.Front(); e != nil; e = e.Next() {
+		if limit > 0 && len(out) >= limit {
+			break
+		}
+		out = append(out, ScoredMemory{Item: s.items[e.Value.(string)]})
+	}
+	return ListMemoriesResponse{Items: out}
+}
+
+// DeleteMemory removes an item and its vector. An unknown key is
+// Deleted=false, not an error (same contract as the substring store).
+func (s *SemanticMemoryStore) DeleteMemory(ctx context.Context, req DeleteMemoryRequest) (DeleteMemoryResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.items[req.Key]; !ok {
+		return DeleteMemoryResponse{Deleted: false}, nil
+	}
+	delete(s.items, req.Key)
+	delete(s.vecs, req.Key)
+	if e, ok := s.elems[req.Key]; ok {
+		s.order.Remove(e)
+		delete(s.elems, req.Key)
+	}
+	return DeleteMemoryResponse{Deleted: true}, nil
+}

--- a/agent/semantic_memory_test.go
+++ b/agent/semantic_memory_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 )
 
-func seedSemantic(t *testing.T) *SemanticMemoryStore {
+func seedSemantic(t *testing.T) *InMemorySemanticStore {
 	t.Helper()
-	s, err := NewSemanticMemoryStore(StubEmbedder{})
+	s, err := NewInMemorySemanticStore(StubEmbedder{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -24,7 +24,7 @@ func seedSemantic(t *testing.T) *SemanticMemoryStore {
 	return s
 }
 
-func TestSemanticMemoryStore_RanksBySimilarity(t *testing.T) {
+func TestInMemorySemanticStore_RanksBySimilarity(t *testing.T) {
 	s := seedSemantic(t)
 	resp, err := s.ListMemories(context.Background(), ListMemoriesRequest{Query: "which programming language do i like"})
 	if err != nil {
@@ -43,7 +43,7 @@ func TestSemanticMemoryStore_RanksBySimilarity(t *testing.T) {
 	}
 }
 
-func TestSemanticMemoryStore_Limit(t *testing.T) {
+func TestInMemorySemanticStore_Limit(t *testing.T) {
 	s := seedSemantic(t)
 	resp, _ := s.ListMemories(context.Background(), ListMemoriesRequest{Query: "programming language", Limit: 2})
 	if len(resp.Items) != 2 {
@@ -51,7 +51,7 @@ func TestSemanticMemoryStore_Limit(t *testing.T) {
 	}
 }
 
-func TestSemanticMemoryStore_EmptyQueryListsAllOldestFirst(t *testing.T) {
+func TestInMemorySemanticStore_EmptyQueryListsAllOldestFirst(t *testing.T) {
 	s := seedSemantic(t)
 	resp, _ := s.ListMemories(context.Background(), ListMemoriesRequest{})
 	if len(resp.Items) != 3 {
@@ -65,7 +65,7 @@ func TestSemanticMemoryStore_EmptyQueryListsAllOldestFirst(t *testing.T) {
 	}
 }
 
-func TestSemanticMemoryStore_Delete(t *testing.T) {
+func TestInMemorySemanticStore_Delete(t *testing.T) {
 	s := seedSemantic(t)
 	ctx := context.Background()
 	if r, _ := s.DeleteMemory(ctx, DeleteMemoryRequest{Key: "editor"}); !r.Deleted {
@@ -81,8 +81,8 @@ func TestSemanticMemoryStore_Delete(t *testing.T) {
 	}
 }
 
-func TestSemanticMemoryStore_NilEmbedder(t *testing.T) {
-	if _, err := NewSemanticMemoryStore(nil); err == nil {
+func TestInMemorySemanticStore_NilEmbedder(t *testing.T) {
+	if _, err := NewInMemorySemanticStore(nil); err == nil {
 		t.Fatal("nil embedder should error")
 	}
 }

--- a/agent/semantic_memory_test.go
+++ b/agent/semantic_memory_test.go
@@ -1,0 +1,107 @@
+package agent
+
+import (
+	"context"
+	"testing"
+)
+
+func seedSemantic(t *testing.T) *SemanticMemoryStore {
+	t.Helper()
+	s, err := NewSemanticMemoryStore(StubEmbedder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	for _, it := range []MemoryItem{
+		{Key: "lang", Value: "my favorite programming language is Go"},
+		{Key: "editor", Value: "i edit code in vim every day"},
+		{Key: "pet", Value: "my dog is a border collie named Pixel"},
+	} {
+		if _, err := s.PutMemory(ctx, PutMemoryRequest{Item: it}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return s
+}
+
+func TestSemanticMemoryStore_RanksBySimilarity(t *testing.T) {
+	s := seedSemantic(t)
+	resp, err := s.ListMemories(context.Background(), ListMemoriesRequest{Query: "which programming language do i like"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Items) != 3 {
+		t.Fatalf("got %d items, want all 3 ranked", len(resp.Items))
+	}
+	// the language note shares the most words with the query -> ranks first
+	if resp.Items[0].Item.Key != "lang" {
+		t.Fatalf("top hit = %q (score %.3f), want lang", resp.Items[0].Item.Key, resp.Items[0].Score)
+	}
+	// ranked descending, and the top is more relevant than the tail
+	if resp.Items[0].Score <= resp.Items[2].Score {
+		t.Fatalf("not ranked by descending score: %.3f then %.3f", resp.Items[0].Score, resp.Items[2].Score)
+	}
+}
+
+func TestSemanticMemoryStore_Limit(t *testing.T) {
+	s := seedSemantic(t)
+	resp, _ := s.ListMemories(context.Background(), ListMemoriesRequest{Query: "programming language", Limit: 2})
+	if len(resp.Items) != 2 {
+		t.Fatalf("Limit=2 returned %d items", len(resp.Items))
+	}
+}
+
+func TestSemanticMemoryStore_EmptyQueryListsAllOldestFirst(t *testing.T) {
+	s := seedSemantic(t)
+	resp, _ := s.ListMemories(context.Background(), ListMemoriesRequest{})
+	if len(resp.Items) != 3 {
+		t.Fatalf("empty query = %d items, want all 3", len(resp.Items))
+	}
+	if resp.Items[0].Item.Key != "lang" || resp.Items[2].Item.Key != "pet" {
+		t.Fatalf("empty-query order = %q..%q, want lang..pet (oldest first)", resp.Items[0].Item.Key, resp.Items[2].Item.Key)
+	}
+	if resp.Items[0].Score != 0 {
+		t.Fatal("empty query has no relevance score; want 0")
+	}
+}
+
+func TestSemanticMemoryStore_Delete(t *testing.T) {
+	s := seedSemantic(t)
+	ctx := context.Background()
+	if r, _ := s.DeleteMemory(ctx, DeleteMemoryRequest{Key: "editor"}); !r.Deleted {
+		t.Fatal("delete of stored key should report Deleted")
+	}
+	resp, _ := s.ListMemories(ctx, ListMemoriesRequest{})
+	if len(resp.Items) != 2 {
+		t.Fatalf("after delete = %d items, want 2", len(resp.Items))
+	}
+	// unknown key is app-state, not an error (same contract as substring store)
+	if r, err := s.DeleteMemory(ctx, DeleteMemoryRequest{Key: "ghost"}); err != nil || r.Deleted {
+		t.Fatalf("delete unknown = (%v, %v), want (false, nil)", r.Deleted, err)
+	}
+}
+
+func TestSemanticMemoryStore_NilEmbedder(t *testing.T) {
+	if _, err := NewSemanticMemoryStore(nil); err == nil {
+		t.Fatal("nil embedder should error")
+	}
+}
+
+// TestSemanticRecallThroughMemorySource is the payoff: the recall tool is
+// semantic (similarity-ranked) with no change to the model-facing surface,
+// purely by swapping the MemoryStore behind MemorySource.
+func TestSemanticRecallThroughMemorySource(t *testing.T) {
+	m, err := NewMemorySource(seedSemantic(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := m.Call(context.Background(), RecallToolName, map[string]any{"query": "which programming language do i like"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// the most similar note (the language one) renders first
+	text := res.Content[0].Text
+	if len(text) < 6 || text[:6] != "- lang" {
+		t.Fatalf("semantic recall did not rank the language note first:\n%s", text)
+	}
+}

--- a/cmd/agentchat/main.go
+++ b/cmd/agentchat/main.go
@@ -255,7 +255,7 @@ func runChat(v *viper.Viper) error {
 			if err != nil {
 				return err
 			}
-			store, err := agent.NewSemanticMemoryStore(embedder, agent.WithSemanticTracerProvider(tp))
+			store, err := agent.NewInMemorySemanticStore(embedder, agent.WithSemanticTracerProvider(tp))
 			if err != nil {
 				return err
 			}

--- a/cmd/agentchat/main.go
+++ b/cmd/agentchat/main.go
@@ -159,6 +159,9 @@ func newRoot() (*cobra.Command, *viper.Viper) {
 	fl.Bool("memory-inject-summary", false, "with --memory, prepend a summary of the scratchpad before each turn (costs tokens; off = recall on demand)")
 	fl.Int("memory-summary-max-items", 0, "with --memory-inject-summary, cap the injected summary to the newest N notes (0 = all)")
 	fl.Int("memory-summary-max-chars", 0, "with --memory-inject-summary, cap the injected summary's length in characters (0 = no cap)")
+	fl.String("memory-embed-model", "", "with --memory, use semantic recall: embedding model for the memory store (empty = substring match)")
+	fl.String("memory-embed-url", "http://localhost:1234/v1", "OpenAI-compatible /embeddings endpoint for --memory-embed-model")
+	fl.String("memory-embed-api-key-env", "", "env var holding the embeddings API key")
 	fl.Int("compact-tokens", 0, "compact history when its estimated token count exceeds N: summarize the head, keep a recent tail (0 = off)")
 	fl.Int("compact-keep-recent", 0, "with --compact-tokens, how many trailing messages to keep verbatim (0 = default 6)")
 	fl.String("exporter", "", "telemetry exporter: stdout | otlp | auto (empty = off)")
@@ -238,6 +241,25 @@ func runChat(v *viper.Viper) error {
 			InjectSummary:   v.GetBool("memory-inject-summary"),
 			SummaryMaxItems: v.GetInt("memory-summary-max-items"),
 			SummaryMaxChars: v.GetInt("memory-summary-max-chars"),
+		}
+		// A semantic store makes recall similarity-ranked instead of
+		// substring; without an embed model, memory stays the in-memory
+		// substring default.
+		if em := v.GetString("memory-embed-model"); em != "" {
+			embedder, err := agent.NewOpenAIEmbedder(agent.OpenAIEmbedderConfig{
+				BaseURL:        v.GetString("memory-embed-url"),
+				Model:          em,
+				APIKey:         os.Getenv(v.GetString("memory-embed-api-key-env")),
+				TracerProvider: tp,
+			})
+			if err != nil {
+				return err
+			}
+			store, err := agent.NewSemanticMemoryStore(embedder, agent.WithSemanticTracerProvider(tp))
+			if err != nil {
+				return err
+			}
+			appOpts = append(appOpts, host.WithMemoryStore(store))
 		}
 	}
 


### PR DESCRIPTION
Part of #940 (semantic recall), PR 1 of 2. Based on `main`, CI runs. PR 2 adds pre-turn recall auto-injection; this PR makes the `recall` **tool** similarity-ranked and lays the seams.

## What changes

Recall by **embedding similarity** instead of substring match — and it happens entirely behind the existing `MemoryStore` interface, so the model-facing `recall` tool is unchanged; you just swap the store. A new `Embedder` seam (sibling to `Provider`) turns text into vectors; a `SemanticMemoryStore` composes it with a brute-force cosine index and returns results ranked by relevance.

The retrieval algorithm stays an implementation detail: substring store filters, semantic store ranks by cosine, a future pgvector backend does ANN — all through the same `ListMemories(Query, Limit=k) -> []ScoredMemory` signature. `recall` never branches on the backend.

## Reviewer's guide

Read in this order:
1. [agent/embedder.go](https://github.com/panyam/mcpkit/pull/1017/files#diff-2a75f4496b0a20efa12784be30e46336fc9cc29b2faf147338ab1d91872d2307) — the `Embedder` seam + `CosineSimilarity`; `OpenAIEmbedder` (no-SDK net/http `/embeddings`, `agent.embed` span) and the deterministic `StubEmbedder` (bag-of-words hashing — no model/network, so the whole semantic path is CI-testable).
2. [agent/memory.go](https://github.com/panyam/mcpkit/pull/1017/files#diff-8b2c5e582714e8b1e26ebd2e85b95f45417d39de02b30621f3715dab3b347f05) — the interface change: `ListMemoriesRequest.Limit` and results as `[]ScoredMemory`. **`Score` lives on the result, not on `MemoryItem`** — it's a per-query judgment, not a property of the stored fact; the doc comment spells out the room-to-grow (a reranker adding per-signal provenance) without touching the item.
3. [agent/semantic_memory.go](https://github.com/panyam/mcpkit/pull/1017/files#diff-38a3e1c1191ca2c47db41328417527108463299185726dd60104e73d54827dc1) — `SemanticMemoryStore`: `PutMemory` embeds+stores, `ListMemories` embeds the query and ranks by cosine (`agent.memory.recall` span); empty query lists all (the summary path); embedding happens outside the lock.
4. [agent/embedder_test.go](https://github.com/panyam/mcpkit/pull/1017/files#diff-1c8b039c772a5830808fdbc09da16fe8db3809b7758908f74d8a3a982e3b34fe) + [agent/semantic_memory_test.go](https://github.com/panyam/mcpkit/pull/1017/files#diff-21daca3e7f89499a9ed597c6478713f3fcf7955ab17401c3da401ada8e32744e) — acceptance: cosine edge cases, stub determinism + shared-words-rank-higher, similarity ranking, `Limit`, empty-query-lists-all, delete, and **semantic recall through `MemorySource`** (the payoff — recall ranks by similarity with no tool change).
5. [cmd/agentchat/main.go](https://github.com/panyam/mcpkit/pull/1017/files#diff-ce3956549c93b4983f18090136a2139c3c92d38408e923245f5e9ba628bcc98a) — `--memory-embed-model` / `-url` / `-api-key-env` build a semantic store through the existing `WithMemoryStore` seam.

Skim: the `.Items[i].Key` → `.Items[i].Item.Key` test migrations (mechanical, from the `ScoredMemory` return-type change).

## How it works

```
Embedder.Embed(texts) -> one vector per text (shared dim)

SemanticMemoryStore:
  PutMemory(item):   vec = Embed(key+" "+value); store item + vec        # sync, immediately recallable
  ListMemories(q,k): if q=="" -> list all, oldest-first, Score 0         # the summary path
                     else: qv = Embed(q)
                           score each item = CosineSimilarity(qv, vec)
                           sort desc, take k                              # top-k, each with Score

recall tool -> ListMemories(query) -> ranked ScoredMemory -> rendered    # same tool, semantic now
```

## Decision log

- **`ScoredMemory` result type, not `MemoryItem.Score`.** Score is per-query (the same fact scores differently against different queries), so it belongs on the ephemeral result, keeping `MemoryItem` the durable, query-independent fact. This is a small breaking change to the young `MemoryStore` return type — accepted deliberately (all consumers in-repo) to get the shape right before it calcifies; a future reranker adds per-signal provenance here, not on the item.
- **Retrieval lives behind `MemoryStore`, no separate `VectorStore` public seam.** `ListMemories(Query, Limit=k)` *is* the top-k method; each impl owns the "how" (substring / O(n) cosine / ANN). A standalone `VectorStore` primitive would earn nothing for memory; it's a follow-up if general document-RAG needs it.
- **Brute-force cosine in-core.** Exact and dependency-free, correct for a working-memory-sized scratchpad. ANN is a durable-backend (pgvector) concern.
- **Sync read + sync Put (embed inline).** A just-remembered fact is immediately recallable. Background/batch indexing (a distillation write path) is a separate follow-up; the "async write" concern is about bulk indexing, not a single `remember`.
- **`Embedder` stays its own seam** (swap OpenAI / Ollama / local without touching storage); every semantic store takes one.

## Risk / blast radius

- Affects: `agent/` (new files + `MemoryStore` return-type change), `agent/host` + `agent/eval` (mechanical test migration), `cmd/agentchat` (3 flags). Default path unchanged: no embed model = the substring store as before.
- Tests: 3 new test files' worth (cosine, embedder, semantic store, recall-through-source); no existing assertion weakened (reads migrated to `.Item`). `make test-agent` green.
- Be paranoid about: the `ScoredMemory` migration touching every `ListMemories` caller (grep confirms all updated); and that the `StubEmbedder` is naive bag-of-words (no stopword removal) — fine for tests, but it's why the test queries share content words with their targets.

## Before / after

```
recall("which programming language do i like"), scratchpad = {lang, editor, pet}:

before (substring store):  returns only notes literally containing the query text (often none)
after  (semantic store):   - lang: my favorite programming language is Go     (top, highest cosine)
                           - editor: ...
                           - pet: ...
                           ranked by similarity; same recall tool, no surface change
```

## Out of scope (deliberately deferred — will file on merge)

- Pre-turn recall **auto-injection** (embed the user turn, inject top-k over a threshold) → PR 2 of #940.
- Durable **pgvector `MemoryStore`** (ANN behind the same interface).
- A `Scorer`/`Reranker` seam (multi-signal: similarity + recency + importance) consuming `ScoredMemory`.
- Standalone `VectorStore` primitive for document-RAG.
- Async/batch distillation write path; a metrics seam; a live-embedder eval case.
