### PR TITLE
feat(agent/host): pre-turn recall auto-injection — closes semantic recall (issue 940, PR 2/2)

### DIFF
--- a/agent/host/config.go
+++ b/agent/host/config.go
@@ -119,11 +119,36 @@ type MemoryConfig struct {
 	// token proxy), dropping the oldest kept notes until it fits. Zero means
 	// no length cap. Only meaningful with InjectSummary.
 	SummaryMaxChars int `json:"summaryMaxChars,omitempty"`
+
+	// InjectRecall, when true, injects the notes RELEVANT to the current
+	// user message as a RoleSystem message before each turn, so the model
+	// "just knows" what matters without a recall call — the auto-push (RAG)
+	// half of semantic recall. Complementary to InjectSummary (ambient,
+	// recency-budgeted): a deployment usually picks one. Backend-agnostic,
+	// but only useful with a relevance-ranking store (a semantic store);
+	// over the substring default it injects notes literally containing the
+	// query words.
+	InjectRecall bool `json:"injectRecall,omitempty"`
+
+	// RecallTopK caps how many relevant notes InjectRecall injects. Zero
+	// uses the agent default (5).
+	RecallTopK int `json:"recallTopK,omitempty"`
+
+	// RecallMinScore drops recalled notes scoring below it (the poison guard
+	// — a semantic store scores every note, so a floor keeps low-TopK recall
+	// from injecting the least-irrelevant notes when nothing truly matches).
+	// Zero means no floor.
+	RecallMinScore float64 `json:"recallMinScore,omitempty"`
 }
 
 // summaryOptions maps the host config onto the agent-layer budget.
 func (c *MemoryConfig) summaryOptions() agent.SummaryOptions {
 	return agent.SummaryOptions{MaxItems: c.SummaryMaxItems, MaxChars: c.SummaryMaxChars}
+}
+
+// recallOptions maps the host config onto the agent-layer recall budget.
+func (c *MemoryConfig) recallOptions() agent.RecallOptions {
+	return agent.RecallOptions{TopK: c.RecallTopK, MinScore: c.RecallMinScore}
 }
 
 // OffloadConfig is the host's view of tool-result offloading; it maps to

--- a/agent/host/memory.go
+++ b/agent/host/memory.go
@@ -53,17 +53,39 @@ func (a *App) registerMemory(multi *agent.MultiSource, store agent.MemoryStore) 
 // never fail a turn. Caller holds turnMu and has already appended the user
 // message to a.history.
 func (a *App) withMemorySummaryLocked(ctx context.Context) []agent.Message {
-	if a.memory == nil || a.cfg.Memory == nil || !a.cfg.Memory.InjectSummary {
-		return a.history
-	}
-	summary, err := a.memory.Summary(ctx, a.cfg.Memory.summaryOptions())
-	if err != nil || summary == "" {
+	if a.memory == nil || a.cfg.Memory == nil {
 		return a.history
 	}
 	n := len(a.history)
-	msgs := make([]agent.Message, 0, n+1)
+	if n == 0 {
+		return a.history
+	}
+
+	// Two independent memory-injection producers, each self-capping and each
+	// a RoleSystem message woven in just before the current user message.
+	// Recall (relevant to this turn) sits closest to the user message — most
+	// salient; the summary (ambient scratchpad) precedes it. Neither is
+	// written into a.history (transient — see the RunTurn note).
+	var blocks []string
+	if a.cfg.Memory.InjectSummary {
+		if s, err := a.memory.Summary(ctx, a.cfg.Memory.summaryOptions()); err == nil && s != "" {
+			blocks = append(blocks, s)
+		}
+	}
+	if a.cfg.Memory.InjectRecall {
+		if r, err := a.memory.RecallRelevant(ctx, a.history[n-1].Text, a.cfg.Memory.recallOptions()); err == nil && r != "" {
+			blocks = append(blocks, r)
+		}
+	}
+	if len(blocks) == 0 {
+		return a.history
+	}
+
+	msgs := make([]agent.Message, 0, n+len(blocks))
 	msgs = append(msgs, a.history[:n-1]...)
-	msgs = append(msgs, agent.Message{Role: agent.RoleSystem, Text: summary})
+	for _, b := range blocks {
+		msgs = append(msgs, agent.Message{Role: agent.RoleSystem, Text: b})
+	}
 	msgs = append(msgs, a.history[n-1])
 	return msgs
 }

--- a/agent/host/memory_test.go
+++ b/agent/host/memory_test.go
@@ -163,6 +163,45 @@ func TestAppMemorySummaryBudget(t *testing.T) {
 	}
 }
 
+// TestAppInjectsRelevantRecall is the 940 PR2 payoff: with InjectRecall on
+// and a semantic store, the model receives the note relevant to the user's
+// message as background context WITHOUT calling the recall tool — and the
+// injected block is transient (never written into a.history).
+func TestAppInjectsRelevantRecall(t *testing.T) {
+	ts := startTestServer(t)
+	stub := agent.NewStubProvider(agent.StubTurn{Text: "you use Go"})
+
+	store, err := agent.NewInMemorySemanticStore(agent.StubEmbedder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = store.PutMemory(context.Background(), agent.PutMemoryRequest{
+		Item: agent.MemoryItem{Key: "lang", Value: "my favorite programming language is Go"}})
+
+	cfg := testConfig(ts.URL)
+	cfg.Memory = &MemoryConfig{InjectRecall: true}
+	var out strings.Builder
+	app, err := NewApp(cfg, &out, strings.NewReader(""), WithProvider(stub), WithMemoryStore(store))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Close()
+
+	if err := app.RunTurn(context.Background(), "which programming language do i use?"); err != nil {
+		t.Fatal(err)
+	}
+
+	// the model saw the relevant note injected as context
+	msgs := stub.Requests()[0].Messages
+	if !hasSystemContaining(msgs, "Relevant to the current message") || !hasSystemContaining(msgs, "lang: my favorite") {
+		t.Fatalf("relevant recall was not injected into the model request: %+v", msgs)
+	}
+	// transient: the injected block is not persisted into history
+	if countSystemContaining(app.history, "Relevant to the current message") != 0 {
+		t.Fatal("recall injection must be transient, not written to a.history")
+	}
+}
+
 func hasSystemContaining(msgs []agent.Message, sub string) bool {
 	return countSystemContaining(msgs, sub) > 0
 }

--- a/agent/memory.go
+++ b/agent/memory.go
@@ -356,6 +356,53 @@ func (m *MemorySource) Summary(ctx context.Context, opts SummaryOptions) (string
 	return "Working memory (notes you saved earlier):\n" + renderMemories(items), nil
 }
 
+// DefaultRecallTopK bounds a relevance recall when RecallOptions.TopK is unset.
+const DefaultRecallTopK = 5
+
+// RecallOptions bounds a pre-turn relevance recall (RecallRelevant).
+type RecallOptions struct {
+	// TopK caps how many of the most-relevant notes are returned. Zero uses
+	// DefaultRecallTopK.
+	TopK int
+	// MinScore drops notes scoring below it — the poison guard: with a
+	// semantic store every note gets some cosine score, so without a floor a
+	// low-TopK recall would inject the least-irrelevant notes even when
+	// nothing is actually relevant. Zero means no floor (keep all TopK).
+	MinScore float64
+}
+
+// RecallRelevant queries the store for notes relevant to query and renders
+// them as a block a host can inject as a RoleSystem message before a turn.
+// Unlike Summary (ambient, recency-budgeted, the whole scratchpad), this is
+// targeted at the current turn: it surfaces what matters for what the user
+// just said. The store's relevance ranking does the work (cosine for a
+// semantic store, substring for the default), so this is backend-agnostic; it
+// returns "" when the query is empty or nothing clears MinScore.
+func (m *MemorySource) RecallRelevant(ctx context.Context, query string, opts RecallOptions) (string, error) {
+	if strings.TrimSpace(query) == "" {
+		return "", nil
+	}
+	topK := opts.TopK
+	if topK <= 0 {
+		topK = DefaultRecallTopK
+	}
+	resp, err := m.store.ListMemories(ctx, ListMemoriesRequest{Query: query, Limit: topK})
+	if err != nil {
+		return "", err
+	}
+	kept := make([]MemoryItem, 0, len(resp.Items))
+	for _, sm := range resp.Items {
+		if sm.Score < opts.MinScore {
+			continue
+		}
+		kept = append(kept, sm.Item)
+	}
+	if len(kept) == 0 {
+		return "", nil
+	}
+	return "Relevant to the current message (from your memory):\n" + renderMemories(kept), nil
+}
+
 // budgetMemories trims items (oldest-first) to opts, keeping the newest that
 // fit. MaxItems keeps the last N; MaxChars then drops from the front (oldest)
 // until the rendered length is within budget. The kept notes stay in

--- a/agent/semantic_memory_test.go
+++ b/agent/semantic_memory_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"strings"
 	"testing"
 )
 
@@ -84,6 +85,40 @@ func TestInMemorySemanticStore_Delete(t *testing.T) {
 func TestInMemorySemanticStore_NilEmbedder(t *testing.T) {
 	if _, err := NewInMemorySemanticStore(nil); err == nil {
 		t.Fatal("nil embedder should error")
+	}
+}
+
+func TestRecallRelevant(t *testing.T) {
+	m, err := NewMemorySource(seedSemantic(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	// relevant query surfaces the matching note as an injectable block
+	block, err := m.RecallRelevant(ctx, "which programming language do i like", RecallOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(block, "lang:") || !strings.Contains(block, "Relevant") {
+		t.Fatalf("recall block did not surface the language note:\n%s", block)
+	}
+
+	// TopK caps the rendered notes
+	block, _ = m.RecallRelevant(ctx, "programming language", RecallOptions{TopK: 1})
+	if strings.Count(block, "\n- ") != 0 && strings.Count(block, "- ") != 1 {
+		t.Fatalf("TopK=1 should render one note; got:\n%s", block)
+	}
+
+	// a MinScore above every hit's score admits nothing -> empty block
+	block, _ = m.RecallRelevant(ctx, "which programming language do i like", RecallOptions{MinScore: 2})
+	if block != "" {
+		t.Fatalf("MinScore above all scores should inject nothing; got:\n%s", block)
+	}
+
+	// empty query injects nothing
+	if block, _ := m.RecallRelevant(ctx, "  ", RecallOptions{}); block != "" {
+		t.Fatalf("empty query should inject nothing; got %q", block)
 	}
 }
 

--- a/cmd/agentchat/main.go
+++ b/cmd/agentchat/main.go
@@ -162,6 +162,9 @@ func newRoot() (*cobra.Command, *viper.Viper) {
 	fl.String("memory-embed-model", "", "with --memory, use semantic recall: embedding model for the memory store (empty = substring match)")
 	fl.String("memory-embed-url", "http://localhost:1234/v1", "OpenAI-compatible /embeddings endpoint for --memory-embed-model")
 	fl.String("memory-embed-api-key-env", "", "env var holding the embeddings API key")
+	fl.Bool("memory-inject-recall", false, "with --memory, inject notes relevant to each user message before the turn (auto-recall; best with --memory-embed-model)")
+	fl.Int("memory-recall-top-k", 0, "with --memory-inject-recall, max relevant notes to inject (0 = default 5)")
+	fl.Float64("memory-recall-min-score", 0, "with --memory-inject-recall, drop recalled notes below this relevance score (0 = no floor)")
 	fl.Int("compact-tokens", 0, "compact history when its estimated token count exceeds N: summarize the head, keep a recent tail (0 = off)")
 	fl.Int("compact-keep-recent", 0, "with --compact-tokens, how many trailing messages to keep verbatim (0 = default 6)")
 	fl.String("exporter", "", "telemetry exporter: stdout | otlp | auto (empty = off)")
@@ -241,6 +244,9 @@ func runChat(v *viper.Viper) error {
 			InjectSummary:   v.GetBool("memory-inject-summary"),
 			SummaryMaxItems: v.GetInt("memory-summary-max-items"),
 			SummaryMaxChars: v.GetInt("memory-summary-max-chars"),
+			InjectRecall:    v.GetBool("memory-inject-recall"),
+			RecallTopK:      v.GetInt("memory-recall-top-k"),
+			RecallMinScore:  v.GetFloat64("memory-recall-min-score"),
 		}
 		// A semantic store makes recall similarity-ranked instead of
 		// substring; without an embed model, memory stays the in-memory


### PR DESCRIPTION
Closes #940. PR 2 of 2 (PR 1 = #1017, merged). Based on `main`, CI runs. This is the auto-push half of semantic recall and the last piece of the memory phase.

## What changes

Before each turn, the host embeds the user's message, retrieves the **top-k relevant** notes over a `MinScore` floor, and injects them as a `RoleSystem` block — so the model receives the context that matters for what the user just said **without calling the `recall` tool** (the RAG "retrieve-then-inject" pattern). Recall is a note the model sees but the user never typed: `"Relevant to the current message: - lang: ..."`.

It's a distinct, self-capping injection step — the reason `InjectionPolicy` became `EventInjectionPolicy`. Memory injection now weaves **two** independent producers before the user message: the ambient `Summary` (recency-budgeted, from 1011) and this relevance `Recall` (this-turn, similarity-ranked). A deployment usually picks one; both are transient (never written to `a.history`, per 1010).

## Reviewer's guide

Read in this order:
1. [agent/memory.go](https://github.com/panyam/mcpkit/pull/1025/files#diff-8b2c5e582714e8b1e26ebd2e85b95f45417d39de02b30621f3715dab3b347f05) — `MemorySource.RecallRelevant(query, RecallOptions{TopK, MinScore})`: queries the store for relevance (`ListMemories(Query, Limit=k)`), drops sub-`MinScore` hits, renders a block. **Backend-agnostic** — the store's ranking does the work (cosine for a semantic store, substring for the default); `MinScore` is the poison guard (a semantic store scores every note, so without a floor a low-k recall injects the least-irrelevant notes when nothing truly matches).
2. [agent/host/memory.go](https://github.com/panyam/mcpkit/pull/1025/files#diff-2fa9e3fc7796e7e17ca21962b0f10cf32f1e7cc8b61a88abbfb519c350a97c62) — the generalized `withMemorySummaryLocked`: collects the summary and recall blocks (each optional, each self-capping) and weaves them in just before the current user message, recall closest (most salient). Still transient.
3. [agent/host/memory_test.go](https://github.com/panyam/mcpkit/pull/1025/files#diff-e005969fe5c233a0078d9e7ff785c7d6cf4d8767cc6e81c39351b5849a075f43) — `TestAppInjectsRelevantRecall`: seed a semantic store, ask a relevant question, assert the model request carries the relevant note as `RoleSystem` context **and** that it's not persisted to history.
4. [agent/semantic_memory_test.go](https://github.com/panyam/mcpkit/pull/1025/files#diff-21daca3e7f89499a9ed597c6478713f3fcf7955ab17401c3da401ada8e32744e) — `TestRecallRelevant`: block content, `TopK` cap, `MinScore` floor, empty-query no-op.
5. [agent/host/config.go](https://github.com/panyam/mcpkit/pull/1025/files#diff-6aff502cc5cae4b9d9769752e8638899bab121e09de870b5d1320cc892c6bf2d) + [cmd/agentchat/main.go](https://github.com/panyam/mcpkit/pull/1025/files#diff-ce3956549c93b4983f18090136a2139c3c92d38408e923245f5e9ba628bcc98a) — `Config.Memory.InjectRecall/RecallTopK/RecallMinScore` and the `--memory-inject-recall` / `-top-k` / `-min-score` flags.

## How it works

```
RunTurn: a.history += userMsg
         turnMsgs = withMemory(a.history):
             blocks = []
             if InjectSummary: blocks += Summary(recency budget)          # ambient
             if InjectRecall:  blocks += RecallRelevant(userMsg.Text)      # relevant-to-this-turn
                                 -> ListMemories(query, Limit=TopK)
                                    drop score < MinScore                  # poison guard
             turnMsgs = history[:last] + blocks + userMsg                  # transient
         Run(turnMsgs)   # a.history and RunStore never see the blocks
```

## Decision log

- **Its own step, not routed through `EventInjectionPolicy`.** Recall is a query result, not an event (no name/hint/window). Same `RoleSystem` output shape, separate producer — which is exactly why we renamed the event policy. A global budget across events + summary + recall is the deferred arbiter (issue 1024).
- **`MinScore` is the poison guard.** The most important recall knob: a semantic store returns a score for every note, so `TopK` alone would always inject *something*. The floor keeps recall silent when nothing is actually relevant.
- **Backend-agnostic by construction.** `RecallRelevant` calls `ListMemories(Query, Limit)` — works over the substring store too (injects notes containing the query words). Best with a semantic store, but not coupled to one.
- **Summary and Recall coexist but are usually either/or** — two points on the "how much memory reaches the turn" spectrum (ambient push vs relevant push). Config allows both; a deployment picks.

## Risk / blast radius

- Affects: `agent/` (one method), `agent/host` (generalized injection + config), `cmd/agentchat` (3 flags). Default path unchanged: `InjectRecall` is off by default, and with no semantic store recall degrades to substring.
- Tests: agent-layer `RecallRelevant` (content/TopK/MinScore/empty) + the host auto-recall payoff (injected + transient); the existing summary/transient/budget tests still pass. `make test-agent` green.
- Be paranoid about: injection ordering (recall closest to the user message), transience (asserted not in `a.history`), and that `MinScore` actually gates (a too-low floor over-injects — that's the poisoning failure mode).

## Before / after

```
store has {lang: "my favorite programming language is Go"}, user: "which language do i use?"

before (recall tool only):  model must decide to call recall(query) to get the fact
after  (--memory-inject-recall):
   model request includes, before the user turn:
     [system] Relevant to the current message (from your memory):
              - lang: my favorite programming language is Go
   the model answers "you use Go" with no tool call
```

## Out of scope (filed)

- Unified injection budget across events + summary + recall → #1024 (needs a cross-source priority currency).
- Durable pgvector semantic store → #1019 · Scorer/Reranker (multi-signal) → #1020 · distillation write path → #1022 · metrics seam → #1023 · faster cosine → #1018.
