### PR TITLE
feat(agent): AgentSource — agent-as-tool (issue 941, Phase 3 PR 1/3)

### DIFF
--- a/agent/agent_source.go
+++ b/agent/agent_source.go
@@ -1,0 +1,155 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync/atomic"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+// DefaultMaxAgentDepth bounds how deep a sub-agent call tree may nest when an
+// AgentSource is constructed without a MaxDepth — the runaway-recursion
+// backstop (an agent that keeps delegating to itself).
+const DefaultMaxAgentDepth = 3
+
+// AgentSource exposes a child Runner to a parent agent as a single tool: the
+// agent-as-tool pattern. Calling the tool runs the child over its OWN
+// isolated conversation (a fresh slice seeded with the task) and returns the
+// child's final text. Isolation is structural — a separate []Message — so the
+// Runner never changes; supervision falls out for free by putting several
+// AgentSources in a MultiSource (the existing aggregation, collision, and
+// Selector routing all apply).
+//
+// It implements ToolSource, so it drops into a RunnerConfig.Tools (directly or
+// via MultiSource) like any other source. A6: it is model-facing (a tool the
+// parent model calls), so it lives in agent/.
+type AgentSource struct {
+	cfg      AgentSourceConfig
+	def      core.ToolDef
+	maxDepth int
+}
+
+// AgentSourceConfig configures an AgentSource.
+type AgentSourceConfig struct {
+	// Name is the tool name the parent model sees and calls. Required.
+	Name string
+
+	// Description tells the parent model when to delegate to this sub-agent.
+	// Required.
+	Description string
+
+	// Runner is the child agent. Required. One Runner instance serves
+	// concurrent calls — Run is stateless over the history it is handed, so
+	// each call gets its own isolated slice without a per-call Runner.
+	Runner *Runner
+
+	// MaxDepth caps sub-agent nesting depth (this source's calls plus any
+	// deeper sub-agent calls the child makes). Zero uses DefaultMaxAgentDepth.
+	MaxDepth int
+}
+
+type agentTaskArgs struct {
+	// Task is the instruction handed to the sub-agent as its user turn.
+	Task string `json:"task"`
+}
+
+// NewAgentSource validates cfg and builds the tool definition. Name and
+// Runner are required.
+func NewAgentSource(cfg AgentSourceConfig) (*AgentSource, error) {
+	if cfg.Name == "" {
+		return nil, fmt.Errorf("agent: AgentSource requires a Name")
+	}
+	if cfg.Runner == nil {
+		return nil, fmt.Errorf("agent: AgentSource %q requires a Runner", cfg.Name)
+	}
+	var schema any
+	if err := json.Unmarshal(core.GenerateSchema[agentTaskArgs](), &schema); err != nil {
+		return nil, fmt.Errorf("agent: schema for AgentSource %q: %w", cfg.Name, err)
+	}
+	maxDepth := cfg.MaxDepth
+	if maxDepth <= 0 {
+		maxDepth = DefaultMaxAgentDepth
+	}
+	return &AgentSource{
+		cfg:      cfg,
+		def:      core.ToolDef{Name: cfg.Name, Description: cfg.Description, InputSchema: schema},
+		maxDepth: maxDepth,
+	}, nil
+}
+
+// Tools returns the single sub-agent tool.
+func (s *AgentSource) Tools(ctx context.Context) ([]core.ToolDef, error) {
+	return []core.ToolDef{s.def}, nil
+}
+
+// Call runs the child over an isolated conversation seeded with the task and
+// returns its final text. A child that errors or is refused by a guard
+// surfaces as an IsError result (fed back to the parent model, which can
+// react), not a dispatch error — only an unknown name is a dispatch error, so
+// the parent's turn never aborts on a sub-agent problem.
+func (s *AgentSource) Call(ctx context.Context, name string, args map[string]any) (*core.ToolResult, error) {
+	if name != s.cfg.Name {
+		return nil, fmt.Errorf("%w: %q", ErrUnknownTool, name)
+	}
+
+	// Depth guard: refuse before running when the tree is already too deep.
+	depth := agentDepth(ctx)
+	if depth >= s.maxDepth {
+		return errorToolResult(fmt.Sprintf("sub-agent %q refused: max depth %d reached", s.cfg.Name, s.maxDepth)), nil
+	}
+	// Aggregate call budget (optional, ctx-threaded, shared across the whole
+	// tree): bounds total sub-agent invocations regardless of shape.
+	if b := agentCallBudget(ctx); b != nil && b.Add(-1) < 0 {
+		return errorToolResult(fmt.Sprintf("sub-agent %q refused: call budget exhausted", s.cfg.Name)), nil
+	}
+
+	raw, err := json.Marshal(args)
+	if err != nil {
+		return nil, fmt.Errorf("agent: encode args for sub-agent %q: %w", s.cfg.Name, err)
+	}
+	var in agentTaskArgs
+	if err := json.Unmarshal(raw, &in); err != nil || strings.TrimSpace(in.Task) == "" {
+		return errorToolResult(fmt.Sprintf("sub-agent %q requires a non-empty 'task'", s.cfg.Name)), nil
+	}
+
+	childCtx := withAgentDepth(ctx, depth+1)
+	result, err := s.cfg.Runner.Run(childCtx, []Message{{Role: RoleUser, Text: in.Task}}, func(Event) {})
+	if err != nil {
+		return errorToolResult(fmt.Sprintf("sub-agent %q failed: %v", s.cfg.Name, err)), nil
+	}
+	return &core.ToolResult{Content: []core.Content{{Type: "text", Text: result.Text}}}, nil
+}
+
+type agentDepthKey struct{}
+type agentBudgetKey struct{}
+
+// withAgentDepth stamps the current sub-agent nesting depth on ctx; each
+// AgentSource increments it before running its child.
+func withAgentDepth(ctx context.Context, d int) context.Context {
+	return context.WithValue(ctx, agentDepthKey{}, d)
+}
+
+// agentDepth reads the current nesting depth (0 at the top level).
+func agentDepth(ctx context.Context) int {
+	d, _ := ctx.Value(agentDepthKey{}).(int)
+	return d
+}
+
+// WithAgentCallBudget caps the TOTAL number of sub-agent invocations allowed
+// under ctx, shared across the whole call tree (a shape-independent cost
+// guard, complementary to the per-source depth cap). Each AgentSource call
+// consumes one; when the budget is exhausted, further calls are refused with
+// an IsError result. Absent, only the depth cap applies.
+func WithAgentCallBudget(ctx context.Context, n int) context.Context {
+	var b atomic.Int64
+	b.Store(int64(n))
+	return context.WithValue(ctx, agentBudgetKey{}, &b)
+}
+
+func agentCallBudget(ctx context.Context) *atomic.Int64 {
+	b, _ := ctx.Value(agentBudgetKey{}).(*atomic.Int64)
+	return b
+}

--- a/agent/agent_source_test.go
+++ b/agent/agent_source_test.go
@@ -1,0 +1,139 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+func childRunner(t *testing.T, turns ...StubTurn) *Runner {
+	t.Helper()
+	r, err := NewRunner(RunnerConfig{Provider: NewStubProvider(turns...)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return r
+}
+
+func TestAgentSource_DelegatesAndIsolates(t *testing.T) {
+	ctx := context.Background()
+	childStub := NewStubProvider(StubTurn{Text: "the child answer"})
+	child, _ := NewRunner(RunnerConfig{Provider: childStub})
+	as, err := NewAgentSource(AgentSourceConfig{Name: "researcher", Description: "does research", Runner: child})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// the tool is exposed under its name
+	defs, _ := as.Tools(ctx)
+	if len(defs) != 1 || defs[0].Name != "researcher" {
+		t.Fatalf("Tools = %+v, want one 'researcher'", defs)
+	}
+
+	res, err := as.Call(ctx, "researcher", map[string]any{"task": "find the answer"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError || res.Content[0].Text != "the child answer" {
+		t.Fatalf("call = %+v, want the child's final text", res)
+	}
+
+	// isolation: the child saw ONLY the task, not any parent history
+	got := childStub.Requests()[0].Messages
+	if len(got) != 1 || got[0].Role != RoleUser || got[0].Text != "find the answer" {
+		t.Fatalf("child history = %+v, want just the task (isolated)", got)
+	}
+}
+
+// TestAgentSource_Supervision drives a coordinator Runner whose tools are a
+// MultiSource of two AgentSources — the "supervision falls out for free"
+// claim, no new code.
+func TestAgentSource_Supervision(t *testing.T) {
+	ctx := context.Background()
+	calc, _ := NewAgentSource(AgentSourceConfig{
+		Name: "calc", Description: "arithmetic", Runner: childRunner(t, StubTurn{Text: "42"})})
+	poet, _ := NewAgentSource(AgentSourceConfig{
+		Name: "poet", Description: "verse", Runner: childRunner(t, StubTurn{Text: "a haiku"})})
+
+	tools := NewMultiSource()
+	if err := tools.Add("calc-agent", calc); err != nil {
+		t.Fatal(err)
+	}
+	if err := tools.Add("poet-agent", poet); err != nil {
+		t.Fatal(err)
+	}
+
+	coordStub := NewStubProvider(
+		StubTurn{ToolCalls: []ToolCall{{ID: "c1", Name: "calc", Args: core.NewRawJSON(json.RawMessage(`{"task":"2+2"}`))}}},
+		StubTurn{Text: "the sub-agent said 42"},
+	)
+	coord, _ := NewRunner(RunnerConfig{Provider: coordStub, Tools: tools})
+
+	result, err := coord.Run(ctx, []Message{{Role: RoleUser, Text: "add two and two"}}, func(Event) {})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Text != "the sub-agent said 42" {
+		t.Fatalf("coordinator final = %q", result.Text)
+	}
+	// the child's answer came back as the calc tool result
+	fed := coordStub.Requests()[1].Messages
+	var sawChild bool
+	for _, m := range fed {
+		if m.Role == RoleTool && strings.Contains(m.Text, "42") {
+			sawChild = true
+		}
+	}
+	if !sawChild {
+		t.Fatal("child answer did not return to the coordinator as a tool result")
+	}
+}
+
+func TestAgentSource_DepthCap(t *testing.T) {
+	as, _ := NewAgentSource(AgentSourceConfig{
+		Name: "deep", Description: "d", Runner: childRunner(t, StubTurn{Text: "x"}), MaxDepth: 2})
+
+	// at depth 2 (== MaxDepth) the call is refused before running
+	res, err := as.Call(withAgentDepth(context.Background(), 2), "deep", map[string]any{"task": "go"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError || !strings.Contains(res.Content[0].Text, "max depth") {
+		t.Fatalf("depth cap = %+v, want an IsError max-depth refusal", res)
+	}
+}
+
+func TestAgentSource_CallBudget(t *testing.T) {
+	as, _ := NewAgentSource(AgentSourceConfig{
+		Name: "b", Description: "d", Runner: childRunner(t, StubTurn{Text: "1"}, StubTurn{Text: "2"})})
+	ctx := WithAgentCallBudget(context.Background(), 1)
+
+	if res, _ := as.Call(ctx, "b", map[string]any{"task": "go"}); res.IsError {
+		t.Fatalf("first call within budget should succeed: %+v", res)
+	}
+	res, _ := as.Call(ctx, "b", map[string]any{"task": "go"})
+	if !res.IsError || !strings.Contains(res.Content[0].Text, "budget") {
+		t.Fatalf("second call over budget = %+v, want an IsError budget refusal", res)
+	}
+}
+
+func TestAgentSource_MissingTaskAndValidation(t *testing.T) {
+	as, _ := NewAgentSource(AgentSourceConfig{Name: "x", Description: "d", Runner: childRunner(t, StubTurn{Text: "ok"})})
+	if res, _ := as.Call(context.Background(), "x", map[string]any{}); !res.IsError {
+		t.Fatal("missing task should be an IsError result")
+	}
+	// unknown name is a dispatch error, not a result
+	if _, err := as.Call(context.Background(), "nope", map[string]any{"task": "y"}); err == nil {
+		t.Fatal("unknown tool name should be a dispatch error")
+	}
+
+	if _, err := NewAgentSource(AgentSourceConfig{Name: "x"}); err == nil {
+		t.Fatal("missing Runner should error")
+	}
+	if _, err := NewAgentSource(AgentSourceConfig{Runner: childRunner(t, StubTurn{Text: "z"})}); err == nil {
+		t.Fatal("missing Name should error")
+	}
+}


### PR DESCRIPTION
Closes #941. Phase 3 (multi-agent) PR 1 of 3. Based on `main`, CI runs. PRs 2 (event nesting, #942) and 3 (Team/Orchestrator handoff, #943) stack on this.

## What changes

A sub-agent is **a child `Runner` exposed to a parent as a tool**. `AgentSource` implements `ToolSource`; calling the tool runs the child over its **own isolated conversation** (a fresh slice seeded with the task) and returns the child's final text. Isolation is structural (a separate `[]Message`), so **the Runner never changes** — and supervision falls out for free: put several `AgentSource`s in a `MultiSource` and a coordinator Runner routes across them with the existing aggregation/collision/Selector machinery.

## Reviewer's guide

Read in this order:
1. [agent/agent_source.go](https://github.com/panyam/mcpkit/pull/1028/files#diff-cb9651df111cfad72b6d4ca30ae061405bedefa4b107cd0a6d36cd53a089bb8d) — `AgentSource` (`ToolSource` impl): the `{task}` tool def, `Call` (depth + budget guards → decode task → `child.Run` over `[]Message{{RoleUser, task}}` → return final text). Guards are ctx-threaded (`agentDepth` / `WithAgentCallBudget`), so they scope naturally to the call tree with no shared mutable state and no Runner change.
2. [agent/agent_source_test.go](https://github.com/panyam/mcpkit/pull/1028/files#diff-66d311d108a64c88261a91b9a0fc9a485f537513290911d12aec516b562995dc) — delegate + **isolation** (child sees only the task, not parent history), **supervision** (a `MultiSource` of two AgentSources under a coordinator), **depth cap**, **call budget**, validation.

## How it works

```
parent Runner's tool loop calls AgentSource "researcher" with {task}:
  if agentDepth(ctx) >= MaxDepth:         return IsError("max depth")      # recursion backstop
  if callBudget(ctx) exhausted:           return IsError("budget")         # tree-wide cost cap
  child.Run(withAgentDepth(ctx, d+1), [{RoleUser, task}], noop)            # isolated slice
  return ToolResult{ child.TurnResult.Text }                              # answer flows back as the tool result
```

## Decision log

- **Child is a `*Runner` instance, not a factory** — `Run` is stateless over the history it's handed, so one instance serves concurrent calls, each with its own slice. No per-call Runner state exists to justify a factory.
- **Guards are ctx-threaded, not a shared `*Budget` object** — depth (`agentDepth`) and an optional aggregate call budget (`WithAgentCallBudget`) live on ctx, so they scope to the call tree automatically and there's no global mutable state to wire everywhere.
- **A refused/failed child is an `IsError` result, not a dispatch error** — the parent model sees "sub-agent failed/refused" and can react; only an unknown tool name aborts (per the `ToolSource` contract). A sub-agent problem never kills the parent turn.
- **Aggregate cap is call-count, not step/token** — bounding total sub-agent invocations is enforceable entirely in `AgentSource` (no Runner change), which keeps the "nothing in the Runner changes" promise. A finer step/token budget across the tree needs Runner cooperation → follow-up.
- **Task input is `{task: string}`** (MVP); structured sub-agent I/O is a follow-up.

## Risk / blast radius

- Affects: `agent/` only — one new `ToolSource` impl. Nothing else changes; no existing behavior touched.
- Tests: delegate/isolation, supervision-via-MultiSource, depth cap, call budget, validation. `make test-agent` green.
- Be paranoid about: isolation (the child must not see parent history — asserted on the child provider's `Requests`), and the guards firing as `IsError` (never a panic or unbounded recursion).

## Before / after

```
before:  one Runner, one flat tool set.
after:   coordinator Runner
           └─ Tools = MultiSource
                ├─ AgentSource "calc"  → child Runner (isolated)
                └─ AgentSource "poet"  → child Runner (isolated)
         the coordinator delegates a subtask, gets the child's text back as a tool result.
```

## Out of scope (this stack)

- **Sub-agent event nesting** (child's stream surfaced to the parent, scoped on an envelope not new `Event` fields) → #942, PR 2. Child events are dropped for now.
- **Handoff** (transfer control, don't return — a `Team`/`Orchestrator` above the Runner) → #943, PR 3.
- Aggregate step/token budget across the tree; structured sub-agent I/O; parallel fan-out; an `examples/` walkthrough → will file.
