### PR TITLE
feat(agent): sub-agent event nesting — SubAgentEvent envelope (issue 942, Phase 3 PR 2/3)

### DIFF
--- a/agent/agent_source.go
+++ b/agent/agent_source.go
@@ -49,6 +49,30 @@ type AgentSourceConfig struct {
 	// MaxDepth caps sub-agent nesting depth (this source's calls plus any
 	// deeper sub-agent calls the child makes). Zero uses DefaultMaxAgentDepth.
 	MaxDepth int
+
+	// OnEvent, when set, receives the child's event stream wrapped in a
+	// SubAgentEvent envelope (scope + depth + the flat Event), so a surface
+	// can render the sub-agent's turn nested under the parent's. Nil drops
+	// the child's events (the sub-agent runs invisibly). Wire OnEvent on
+	// every AgentSource in a tree to the same sink and the scope/depth
+	// disambiguate nested runs.
+	OnEvent func(SubAgentEvent)
+}
+
+// SubAgentEvent is the envelope that carries a sub-agent's event to the
+// parent surface. The scope and depth live on the envelope, NOT on Event, so
+// Event stays flat and wire-serializable (constraint A2): a surface adds
+// sub-agent framing without the core event vocabulary growing a nesting
+// field.
+type SubAgentEvent struct {
+	// Scope is the slash-joined sub-agent path, e.g. "researcher" at the top
+	// level or "researcher/summarizer" one level deeper.
+	Scope string
+	// Depth is the nesting depth: 1 for a top-level sub-agent, 2 for a
+	// sub-agent it spawns, and so on.
+	Depth int
+	// Event is the child's event, unchanged.
+	Event Event
 }
 
 type agentTaskArgs struct {
@@ -115,8 +139,20 @@ func (s *AgentSource) Call(ctx context.Context, name string, args map[string]any
 		return errorToolResult(fmt.Sprintf("sub-agent %q requires a non-empty 'task'", s.cfg.Name)), nil
 	}
 
-	childCtx := withAgentDepth(ctx, depth+1)
-	result, err := s.cfg.Runner.Run(childCtx, []Message{{Role: RoleUser, Text: in.Task}}, func(Event) {})
+	// Extend both ctx threads for the child: depth (guards) and scope (the
+	// path this sub-agent's events are tagged with).
+	childScope := s.cfg.Name
+	if parent := agentScope(ctx); parent != "" {
+		childScope = parent + "/" + s.cfg.Name
+	}
+	childCtx := withAgentScope(withAgentDepth(ctx, depth+1), childScope)
+
+	emit := func(Event) {}
+	if s.cfg.OnEvent != nil {
+		childDepth := depth + 1
+		emit = func(e Event) { s.cfg.OnEvent(SubAgentEvent{Scope: childScope, Depth: childDepth, Event: e}) }
+	}
+	result, err := s.cfg.Runner.Run(childCtx, []Message{{Role: RoleUser, Text: in.Task}}, emit)
 	if err != nil {
 		return errorToolResult(fmt.Sprintf("sub-agent %q failed: %v", s.cfg.Name, err)), nil
 	}
@@ -125,6 +161,20 @@ func (s *AgentSource) Call(ctx context.Context, name string, args map[string]any
 
 type agentDepthKey struct{}
 type agentBudgetKey struct{}
+type agentScopeKey struct{}
+
+// withAgentScope stamps the slash-joined sub-agent path on ctx so a nested
+// AgentSource can prefix its own name and tag its child's events with the
+// full path.
+func withAgentScope(ctx context.Context, scope string) context.Context {
+	return context.WithValue(ctx, agentScopeKey{}, scope)
+}
+
+// agentScope reads the current sub-agent path ("" at the top level).
+func agentScope(ctx context.Context) string {
+	s, _ := ctx.Value(agentScopeKey{}).(string)
+	return s
+}
 
 // withAgentDepth stamps the current sub-agent nesting depth on ctx; each
 // AgentSource increments it before running its child.

--- a/agent/agent_source_test.go
+++ b/agent/agent_source_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/panyam/mcpkit/core"
@@ -117,6 +118,70 @@ func TestAgentSource_CallBudget(t *testing.T) {
 	res, _ := as.Call(ctx, "b", map[string]any{"task": "go"})
 	if !res.IsError || !strings.Contains(res.Content[0].Text, "budget") {
 		t.Fatalf("second call over budget = %+v, want an IsError budget refusal", res)
+	}
+}
+
+func TestAgentSource_EventNesting(t *testing.T) {
+	var mu sync.Mutex
+	var got []SubAgentEvent
+	sink := func(e SubAgentEvent) { mu.Lock(); got = append(got, e); mu.Unlock() }
+
+	as, _ := NewAgentSource(AgentSourceConfig{
+		Name: "worker", Description: "w", Runner: childRunner(t, StubTurn{Text: "done"}), OnEvent: sink})
+
+	if _, err := as.Call(context.Background(), "worker", map[string]any{"task": "go"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) == 0 {
+		t.Fatal("no sub-agent events forwarded")
+	}
+	// every forwarded event carries scope + depth on the envelope (Event stays flat)
+	for _, ev := range got {
+		if ev.Scope != "worker" || ev.Depth != 1 {
+			t.Fatalf("envelope scope/depth = %q/%d, want worker/1", ev.Scope, ev.Depth)
+		}
+	}
+	if got[0].Event.Kind != EventTurnBegin {
+		t.Fatalf("first forwarded event = %v, want the child's turn-begin", got[0].Event.Kind)
+	}
+}
+
+// TestAgentSource_NestedEventScope proves scopes compose down a tree: a
+// sub-agent that spawns another sub-agent yields depth-2 events tagged with
+// the joined path, all reaching one shared sink.
+func TestAgentSource_NestedEventScope(t *testing.T) {
+	var mu sync.Mutex
+	var got []SubAgentEvent
+	sink := func(e SubAgentEvent) { mu.Lock(); got = append(got, e); mu.Unlock() }
+
+	inner, _ := NewAgentSource(AgentSourceConfig{
+		Name: "inner", Description: "i", Runner: childRunner(t, StubTurn{Text: "deep"}), OnEvent: sink})
+	innerTools := NewMultiSource()
+	if err := innerTools.Add("inner-src", inner); err != nil {
+		t.Fatal(err)
+	}
+	outerChild, _ := NewRunner(RunnerConfig{Tools: innerTools, Provider: NewStubProvider(
+		StubTurn{ToolCalls: []ToolCall{{ID: "c1", Name: "inner", Args: core.NewRawJSON(json.RawMessage(`{"task":"dig"}`))}}},
+		StubTurn{Text: "outer done"},
+	)})
+	outer, _ := NewAgentSource(AgentSourceConfig{
+		Name: "outer", Description: "o", Runner: outerChild, OnEvent: sink})
+
+	if _, err := outer.Call(context.Background(), "outer", map[string]any{"task": "start"}); err != nil {
+		t.Fatal(err)
+	}
+
+	var sawOuter, sawInner bool
+	for _, ev := range got {
+		if ev.Scope == "outer" && ev.Depth == 1 {
+			sawOuter = true
+		}
+		if ev.Scope == "outer/inner" && ev.Depth == 2 {
+			sawInner = true
+		}
+	}
+	if !sawOuter || !sawInner {
+		t.Fatalf("nested scopes missing: sawOuter=%v sawInner=%v", sawOuter, sawInner)
 	}
 }
 


### PR DESCRIPTION
Closes #942. Phase 3 PR 2 of 3, stacks conceptually on #941 (AgentSource, merged). Based on `main`, CI runs. This is the one subtlety of the agent-as-tool model — surfacing the child's stream.

## What changes

A sub-agent's event stream now reaches the parent surface, **scoped**, when `AgentSourceConfig.OnEvent` is set: the child Runner's `emit` forwards each event wrapped in a `SubAgentEvent{Scope, Depth, Event}`. The scope and depth live on the **envelope**, not on `Event`, so `Event` stays flat and wire-serializable (**constraint A2**) — a surface adds sub-agent framing without the core event vocabulary growing a nesting field. Nil `OnEvent` keeps the PR-1 behavior (child runs invisibly).

## Reviewer's guide

Read in this order:
1. [agent/agent_source.go](https://github.com/panyam/mcpkit/pull/1029/files#diff-cb9651df111cfad72b6d4ca30ae061405bedefa4b107cd0a6d36cd53a089bb8d) — `SubAgentEvent` envelope + `OnEvent` config; the forwarding `emit` in `Call` (wraps each child event with the scope/depth); `withAgentScope`/`agentScope` ctx helpers (scope is threaded like depth, so nested sub-agents compose the path).
2. [agent/agent_source_test.go](https://github.com/panyam/mcpkit/pull/1029/files#diff-66d311d108a64c88261a91b9a0fc9a485f537513290911d12aec516b562995dc) — `EventNesting` (single level: scope=name, depth=1, the child's turn-begin makes it through) and `NestedEventScope` (a sub-agent spawning a sub-agent yields depth-2 events tagged `outer/inner`, all to one sink — proving the ctx threads through the Runner's tool dispatch).

## How it works

```
AgentSource "outer".Call(ctx):
  childScope = join(agentScope(ctx), "outer")           # "" -> "outer"; "a" -> "a/outer"
  childCtx   = withScope(withDepth(ctx, d+1), childScope)
  emit(e)    = OnEvent(SubAgentEvent{childScope, d+1, e})  # envelope; Event unchanged
  child.Run(childCtx, [task], emit)
    └─ if the child calls another AgentSource "inner", it reads scope="outer",
       depth=1 off childCtx and tags ITS child "outer/inner", depth 2.
```

## Decision log

- **Envelope, not `Event` fields** (as prescribed): a `SubAgentEvent{Scope, Depth, Event}` wrapper keeps `Event` flat and wire-serializable (A2). Adding a `ParentScope` field to `Event` would pollute every event and break the "events project 1:1 onto a wire" contract.
- **Scope is ctx-threaded like depth** — so a nested `AgentSource` composes the full path (`outer/inner`) with no explicit plumbing; wire the same sink on every source in a tree and scope+depth disambiguate.
- **Per-source `OnEvent`, not a global bus** — each `AgentSource` reports its own child's events; a host wires the same sink onto every source it builds. Keeps the source self-contained.

## Risk / blast radius

- Affects: `agent/agent_source.go` only (additive — a new config field + envelope type; `Call` gains the forwarding emit). Nil `OnEvent` is byte-for-byte the PR-1 path.
- Tests: single-level scope/depth, nested composed scope; `make test-agent` green.
- Be paranoid about: the scope composition across the Runner boundary (the nested test proves ctx threads through `Tools.Call`), and A2 — `Event` gains nothing.

## Before / after

```
before (#941):  sub-agent runs invisibly; parent surface sees only the tool result.
after (OnEvent set):
   SubAgentEvent{Scope:"researcher",           Depth:1, Event: turn-begin}
   SubAgentEvent{Scope:"researcher",           Depth:1, Event: tool-begin(search)}
   SubAgentEvent{Scope:"researcher/summarizer",Depth:2, Event: turn-begin}   # nested
   ...a surface renders these indented under the parent's turn.
```

## Out of scope

- **Host/agentchat rendering** of `SubAgentEvent` (a `HostSubAgentEvent` observer kind + indented transcript): deferred until the host gains multi-agent config — most naturally with #943 (Team/Orchestrator) or a follow-up. The mechanism ships here; the surface consumes it later.
- Handoff (transfer control) → #943, PR 3.

## Sample flow

```mermaid
sequenceDiagram
    participant PR as Parent Runner
    participant AS as AgentSource
    participant CR as Child Runner
    participant SK as Surface (OnEvent)
    PR->>AS: Call(name, {task})
    AS->>CR: Run(history=[task], emit=wrap)
    Note over AS,SK: emit(e) = OnEvent(SubAgentEvent{scope, depth, e})
    CR-->>SK: SubAgentEvent{scope, depth:1, turn-begin}
    CR-->>SK: SubAgentEvent{scope, depth:1, tool-begin}
    CR-->>SK: SubAgentEvent{scope, depth:1, turn-end}
    CR-->>AS: TurnResult{Text}
    AS-->>PR: ToolResult{Text}
```

Nested sub-agents compose the scope path (`outer/inner`, depth 2) and report to the same sink; `Event` stays wire-flat (A2), scope/depth ride the envelope.