### PR TITLE
feat(agent): Team/Orchestrator handoff (issue 943, Phase 3 PR 3/3)

### DIFF
--- a/agent/team.go
+++ b/agent/team.go
@@ -1,0 +1,256 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+// DefaultMaxHandoffs bounds how many times a Team may transfer control before
+// giving up — the ping-pong backstop (two agents that keep handing the
+// conversation back and forth).
+const DefaultMaxHandoffs = 8
+
+// ErrMaxHandoffs is returned by Team.Run when the handoff cap is exceeded.
+var ErrMaxHandoffs = errors.New("agent: max handoffs exceeded")
+
+// Team runs a set of named agents that transfer control to one another —
+// handoff, the one composition mode that does NOT fit agent-as-tool
+// (AgentSource). Where a sub-agent is called and returns an answer, a handoff
+// transfers the whole conversation to a specialist and does not come back: the
+// active agent runs, and if it calls a transfer_to_<name> tool, the Team swaps
+// the active agent and continues over the SAME (carried-forward) history. The
+// Runner is unaware it was swapped — the transfer is a tool it happened to
+// call, intercepted above it.
+//
+// A6: model-facing (agents + transfer tools), so it lives in agent/.
+type Team struct {
+	members     map[string]*teamMember
+	order       []string
+	start       string
+	maxHandoffs int
+	onHandoff   func(from, to string)
+}
+
+type teamMember struct {
+	name   string
+	runner *Runner
+}
+
+// TeamMember declares one agent in a Team and which other agents it may hand
+// off to.
+type TeamMember struct {
+	// Name identifies the agent and forms its transfer tool (transfer_to_<Name>
+	// on any teammate allowed to reach it). Required, unique within the Team.
+	Name string
+
+	// Config is the agent's RunnerConfig (provider, instructions, its own
+	// tools). The Team merges the transfer tools in; the agent's own Tools are
+	// preserved. Required.
+	Config RunnerConfig
+
+	// HandoffTo lists the names this agent may transfer to. Each becomes a
+	// transfer_to_<name> tool offered only to this agent. Empty means a
+	// terminal agent that must answer rather than hand off. Every name must be
+	// another member.
+	HandoffTo []string
+}
+
+// TeamConfig assembles a Team.
+type TeamConfig struct {
+	// Members are the agents. At least one; Start must name one of them.
+	Members []TeamMember
+
+	// Start is the agent that receives the first turn. Required.
+	Start string
+
+	// MaxHandoffs caps transfers before Run gives up with ErrMaxHandoffs.
+	// Zero uses DefaultMaxHandoffs.
+	MaxHandoffs int
+
+	// OnHandoff, when set, is called on each transfer (from, to) — the seam a
+	// surface renders "→ handed off to X" through.
+	OnHandoff func(from, to string)
+}
+
+// NewTeam validates cfg and builds each agent's Runner with its transfer tools
+// merged in. It errors on a missing/duplicate member name, an unknown Start,
+// or a HandoffTo naming a non-member.
+func NewTeam(cfg TeamConfig) (*Team, error) {
+	if len(cfg.Members) == 0 {
+		return nil, fmt.Errorf("agent: Team needs at least one member")
+	}
+	names := make(map[string]bool, len(cfg.Members))
+	for _, m := range cfg.Members {
+		if m.Name == "" {
+			return nil, fmt.Errorf("agent: Team member with empty Name")
+		}
+		if names[m.Name] {
+			return nil, fmt.Errorf("agent: Team has duplicate member %q", m.Name)
+		}
+		names[m.Name] = true
+	}
+	if !names[cfg.Start] {
+		return nil, fmt.Errorf("agent: Team Start %q is not a member", cfg.Start)
+	}
+
+	t := &Team{
+		members:     make(map[string]*teamMember, len(cfg.Members)),
+		start:       cfg.Start,
+		maxHandoffs: cfg.MaxHandoffs,
+		onHandoff:   cfg.OnHandoff,
+	}
+	if t.maxHandoffs <= 0 {
+		t.maxHandoffs = DefaultMaxHandoffs
+	}
+
+	for _, m := range cfg.Members {
+		mc := m.Config
+		if len(m.HandoffTo) > 0 {
+			transfers, err := buildTransferSource(m.Name, m.HandoffTo, names)
+			if err != nil {
+				return nil, err
+			}
+			if mc.Tools == nil {
+				mc.Tools = transfers
+			} else {
+				multi := NewMultiSource()
+				if err := multi.Add("base", mc.Tools); err != nil {
+					return nil, fmt.Errorf("agent: Team %q tools: %w", m.Name, err)
+				}
+				if err := multi.Add("handoff", transfers); err != nil {
+					return nil, fmt.Errorf("agent: Team %q handoff tools: %w", m.Name, err)
+				}
+				mc.Tools = multi
+			}
+		}
+		runner, err := NewRunner(mc)
+		if err != nil {
+			return nil, fmt.Errorf("agent: Team member %q: %w", m.Name, err)
+		}
+		t.members[m.Name] = &teamMember{name: m.Name, runner: runner}
+		t.order = append(t.order, m.Name)
+	}
+	return t, nil
+}
+
+// buildTransferSource makes the transfer_to_<target> tools for one agent. Each
+// records the requested target on the ctx handoff signal and acks; the Team
+// reads the signal after the agent's turn.
+func buildTransferSource(from string, targets []string, members map[string]bool) (*FuncSource, error) {
+	fs := NewFuncSource()
+	for _, target := range targets {
+		if !members[target] {
+			return nil, fmt.Errorf("agent: Team member %q hands off to unknown member %q", from, target)
+		}
+		target := target
+		if err := AddFunc(fs, "transfer_to_"+target,
+			"Hand off the conversation to the "+target+" agent. Call this to transfer control; do not also answer.",
+			func(ctx context.Context, _ struct{}) (string, error) {
+				if sig := handoffSignalFrom(ctx); sig != nil {
+					sig.set(target)
+				}
+				return "Transferring to " + target + ".", nil
+			}); err != nil {
+			return nil, err
+		}
+	}
+	return fs, nil
+}
+
+// Run drives the conversation: the Start agent runs over the input, and each
+// time an agent transfers, the Team swaps the active agent and continues over
+// the carried-forward history until an agent answers without transferring (the
+// final result) or the handoff cap is hit (ErrMaxHandoffs). All agents share
+// one history (handoff transfers context); each brings its own instructions.
+// emit receives every agent's events; OnHandoff marks the transitions.
+func (t *Team) Run(ctx context.Context, input string, emit func(Event)) (*TurnResult, error) {
+	if emit == nil {
+		emit = func(Event) {}
+	}
+	sig := &handoffSignal{}
+	ctx = withHandoffSignal(ctx, sig)
+
+	history := []Message{{Role: RoleUser, Text: input}}
+	active := t.members[t.start]
+	handoffs := 0
+	for {
+		result, err := active.runner.Run(ctx, history, emit)
+		if err != nil {
+			return nil, err
+		}
+		history = append(history, result.Messages...)
+
+		target := sig.take()
+		if target == "" {
+			return result, nil
+		}
+		next, ok := t.members[target]
+		if !ok {
+			// The transfer tools only offer real members, so this is
+			// unreachable; treat a stray target as "no transfer".
+			return result, nil
+		}
+		if handoffs >= t.maxHandoffs {
+			return nil, fmt.Errorf("%w (%d) starting from %q", ErrMaxHandoffs, t.maxHandoffs, t.start)
+		}
+		handoffs++
+		if t.onHandoff != nil {
+			t.onHandoff(active.name, target)
+		}
+		active = next
+	}
+}
+
+// ToolDefs exposes the merged tool set each member offers, for inspection
+// (which agents can hand off where). Keyed by member name.
+func (t *Team) ToolDefs(ctx context.Context) (map[string][]core.ToolDef, error) {
+	out := make(map[string][]core.ToolDef, len(t.members))
+	for name, m := range t.members {
+		if m.runner.cfg.Tools == nil {
+			continue
+		}
+		defs, err := m.runner.cfg.Tools.Tools(ctx)
+		if err != nil {
+			return nil, err
+		}
+		out[name] = defs
+	}
+	return out, nil
+}
+
+type handoffKey struct{}
+
+// handoffSignal is the per-Run channel between a transfer tool and the Team
+// loop, threaded on ctx so concurrent Team.Run calls never share it.
+type handoffSignal struct {
+	mu     sync.Mutex
+	target string
+}
+
+func (h *handoffSignal) set(t string) {
+	h.mu.Lock()
+	h.target = t
+	h.mu.Unlock()
+}
+
+// take reads and clears the pending target, so each round starts fresh.
+func (h *handoffSignal) take() string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	t := h.target
+	h.target = ""
+	return t
+}
+
+func withHandoffSignal(ctx context.Context, sig *handoffSignal) context.Context {
+	return context.WithValue(ctx, handoffKey{}, sig)
+}
+
+func handoffSignalFrom(ctx context.Context) *handoffSignal {
+	sig, _ := ctx.Value(handoffKey{}).(*handoffSignal)
+	return sig
+}

--- a/agent/team_test.go
+++ b/agent/team_test.go
@@ -1,0 +1,141 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+func transferCall(id, target string) StubTurn {
+	return StubTurn{ToolCalls: []ToolCall{{ID: id, Name: "transfer_to_" + target, Args: core.NewRawJSON(json.RawMessage(`{}`))}}}
+}
+
+func TestTeam_Handoff(t *testing.T) {
+	var handoffs [][2]string
+	// triage transfers to specialist, then the specialist answers.
+	triage := NewStubProvider(transferCall("c1", "specialist"), StubTurn{Text: "let me connect you"})
+	specialist := NewStubProvider(StubTurn{Text: "the specialist answer"})
+
+	team, err := NewTeam(TeamConfig{
+		Start: "triage",
+		Members: []TeamMember{
+			{Name: "triage", Config: RunnerConfig{Provider: triage}, HandoffTo: []string{"specialist"}},
+			{Name: "specialist", Config: RunnerConfig{Provider: specialist}},
+		},
+		OnHandoff: func(from, to string) { handoffs = append(handoffs, [2]string{from, to}) },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := team.Run(context.Background(), "help me", func(Event) {})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// the specialist produced the final answer
+	if result.Text != "the specialist answer" {
+		t.Fatalf("final = %q, want the specialist's answer", result.Text)
+	}
+	// exactly one transfer, triage -> specialist
+	if len(handoffs) != 1 || handoffs[0] != [2]string{"triage", "specialist"} {
+		t.Fatalf("handoffs = %v, want [triage->specialist]", handoffs)
+	}
+	// context carried across: the specialist saw the original user message + triage's turn
+	sawUser := false
+	for _, m := range specialist.Requests()[0].Messages {
+		if m.Role == RoleUser && m.Text == "help me" {
+			sawUser = true
+		}
+	}
+	if !sawUser {
+		t.Fatal("handoff did not carry the conversation to the specialist")
+	}
+}
+
+func TestTeam_NoHandoffReturnsDirectly(t *testing.T) {
+	solo := NewStubProvider(StubTurn{Text: "answered directly"})
+	team, _ := NewTeam(TeamConfig{
+		Start:   "solo",
+		Members: []TeamMember{{Name: "solo", Config: RunnerConfig{Provider: solo}}},
+	})
+	result, err := team.Run(context.Background(), "hi", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Text != "answered directly" {
+		t.Fatalf("no-handoff final = %q", result.Text)
+	}
+}
+
+// TestTeam_TransferToolOnlyForAllowedAgents verifies the transfer tool is
+// offered only to agents with a HandoffTo, and only for allowed targets.
+func TestTeam_TransferToolOnlyForAllowedAgents(t *testing.T) {
+	team, _ := NewTeam(TeamConfig{
+		Start: "a",
+		Members: []TeamMember{
+			{Name: "a", Config: RunnerConfig{Provider: NewStubProvider()}, HandoffTo: []string{"b"}},
+			{Name: "b", Config: RunnerConfig{Provider: NewStubProvider()}},
+		},
+	})
+	defs, err := team.ToolDefs(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// a can transfer_to_b; b (terminal) offers no transfer tools
+	if !hasToolNamed(defs["a"], "transfer_to_b") {
+		t.Fatalf("agent a should offer transfer_to_b; got %v", toolNames(defs["a"]))
+	}
+	if len(defs["b"]) != 0 {
+		t.Fatalf("terminal agent b should offer no tools; got %v", toolNames(defs["b"]))
+	}
+}
+
+func hasToolNamed(defs []core.ToolDef, name string) bool {
+	for _, d := range defs {
+		if d.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func TestTeam_MaxHandoffsBoundsPingPong(t *testing.T) {
+	// a and b hand off to each other forever; the cap stops it.
+	a := NewStubProvider(transferCall("1", "b"), StubTurn{Text: "x"}, transferCall("2", "b"), StubTurn{Text: "x"})
+	b := NewStubProvider(transferCall("1", "a"), StubTurn{Text: "x"}, transferCall("2", "a"), StubTurn{Text: "x"})
+	team, _ := NewTeam(TeamConfig{
+		Start:       "a",
+		MaxHandoffs: 2,
+		Members: []TeamMember{
+			{Name: "a", Config: RunnerConfig{Provider: a}, HandoffTo: []string{"b"}},
+			{Name: "b", Config: RunnerConfig{Provider: b}, HandoffTo: []string{"a"}},
+		},
+	})
+	_, err := team.Run(context.Background(), "loop", nil)
+	if !errors.Is(err, ErrMaxHandoffs) {
+		t.Fatalf("a transfer loop should hit ErrMaxHandoffs, got %v", err)
+	}
+}
+
+func TestTeam_Validation(t *testing.T) {
+	stub := func() *StubProvider { return NewStubProvider(StubTurn{Text: "x"}) }
+	cases := []struct {
+		name string
+		cfg  TeamConfig
+	}{
+		{"no members", TeamConfig{Start: "a"}},
+		{"unknown start", TeamConfig{Start: "z", Members: []TeamMember{{Name: "a", Config: RunnerConfig{Provider: stub()}}}}},
+		{"duplicate name", TeamConfig{Start: "a", Members: []TeamMember{
+			{Name: "a", Config: RunnerConfig{Provider: stub()}}, {Name: "a", Config: RunnerConfig{Provider: stub()}}}}},
+		{"handoff to unknown", TeamConfig{Start: "a", Members: []TeamMember{
+			{Name: "a", Config: RunnerConfig{Provider: stub()}, HandoffTo: []string{"ghost"}}}}},
+	}
+	for _, c := range cases {
+		if _, err := NewTeam(c.cfg); err == nil {
+			t.Fatalf("%s: expected a construction error", c.name)
+		}
+	}
+}


### PR DESCRIPTION
Closes #943. Phase 3 PR 3 of 3, stacked on #942 (event nesting) → #941 (AgentSource, merged). **No CI while based on a non-main branch** — verified locally with `make test-agent` (all green). Closes epic #927 when the stack reaches main (carries `Closes #943`; retarget to main after 942 merges).

## What changes

**Handoff** — transfer control between agents rather than call-and-return, the one composition mode that doesn't fit agent-as-tool (`AgentSource`). A `Team` runs the active agent; if it calls a `transfer_to_<name>` tool, the Team swaps the active agent and continues over the **same carried-forward history**. The `Runner` is unaware it was swapped — the transfer is a tool it happened to call, intercepted above it (the OpenAI-Swarm handoff model).

## Reviewer's guide

Read in this order:
1. [agent/team.go](https://github.com/panyam/mcpkit/pull/1030/files#diff-ecc8523fab2cb54248822322542d9194c8e2f9436ce81b71cd07d422edebc7ea) — `Team` + `TeamMember{Name, Config, HandoffTo}`; `NewTeam` (merges `transfer_to_X` tools into each member's `RunnerConfig` only for allowed targets, validates the handoff graph); `Run` (the loop: active agent runs → if a transfer was signaled, swap + continue → else final answer; `MaxHandoffs` bounds ping-pong); the per-Run ctx `handoffSignal` (the transfer tool sets it, the loop reads it — so concurrent `Run`s never share state).
2. [agent/team_test.go](https://github.com/panyam/mcpkit/pull/1030/files#diff-b1e079492f9b20d890a2861696c46a81012528d28a2868eda668d21ea9c79248) — handoff (specialist answers, context carried across, `OnHandoff` fires), no-handoff-returns-directly, transfer-tools-only-for-allowed-agents, `MaxHandoffs` bounds a ping-pong loop (`ErrMaxHandoffs`), construction validation.

## How it works

```
Team.Run(input):
  sig = &handoffSignal{}; ctx = withHandoffSignal(ctx, sig)   # per-Run, concurrency-safe
  history = [user(input)]; active = Start
  loop:
    result = active.Runner.Run(ctx, history, emit)            # agent's whole turn; may call transfer_to_X
    history += result.Messages                                # shared context, carried forward
    target = sig.take()
    if target == "":  return result                          # answered without transferring -> final
    if handoffs >= MaxHandoffs:  return ErrMaxHandoffs        # ping-pong backstop
    handoffs++; OnHandoff(active, target); active = members[target]
```

The `transfer_to_X` tool (a `FuncSource` the Team injects per member) records `X` on the ctx signal and acks; the agent, having called it, ends its turn, and the Team switches.

## Decision log

- **Transfer via tools intercepted above the Runner**, not a new Runner return type — keeps the Runner unaware and reuses the existing tool loop. Swarm-style; the model calls `transfer_to_specialist`, the Team acts on it.
- **Shared history across the swap** (contrast `AgentSource`, which isolates) — handoff *transfers the conversation*; each agent brings its own `Instructions` but sees the whole thread. That's the definitional difference between handoff and agent-as-tool.
- **Transfer signal on ctx, per-Run** — concurrent `Team.Run` calls never share the pending-target; the tool handler is stateless (reads the signal off ctx).
- **Transfer tools only for allowed targets** (per-member `HandoffTo`); terminal agents get none and must answer. The handoff graph is validated at construction.
- **`MaxHandoffs` bounds ping-pong** — two agents that keep transferring to each other fail loudly with `ErrMaxHandoffs` instead of hanging.

## Risk / blast radius

- Affects: `agent/` only (new `Team` type). No existing behavior touched; `Runner` unchanged.
- Tests: handoff + context-carry + OnHandoff, terminal-agent tool visibility, ping-pong cap, validation. `make test-agent` green.
- Be paranoid about: the shared-history semantics (each agent sees the full thread — asserted), and the cap firing before an unbounded loop.

## Before / after

```
before:  AgentSource — call a sub-agent, get an answer back (isolated).
after:   Team — triage receives the turn, calls transfer_to_specialist,
         the specialist takes over the SAME conversation and answers.
         triage ──transfer_to_specialist──▶ specialist ──▶ final answer
         (OnHandoff: triage → specialist)
```

## Out of scope (filed as follow-ups)

- Host/agentchat multi-agent config + rendering (the `SubAgentEvent` sink from #942, a `Team` config in `agent/host`, an `examples/` walkthrough).
- Per-agent event tagging on `Team` (events currently forward to one `emit`; `OnHandoff` marks transitions).
- Aggregate step/token budget across the whole tree; structured sub-agent I/O; parallel fan-out.

## Sample flow

```mermaid
sequenceDiagram
    participant U as User
    participant T as Team
    participant TR as triage
    participant BL as billing
    U->>T: Run("I need a refund")
    T->>TR: Run(history=[user])
    TR->>TR: calls transfer_to_billing (sets ctx signal)
    TR-->>T: turn ends; signal = billing
    Note over T: swap active agent, SAME history carried forward
    T->>BL: Run(history=[user, triage msgs])
    BL-->>T: "refunded"
    T-->>U: "refunded" (final)
```

Contrast AgentSource (call-and-return, isolated history): a Team transfers control and does not come back — the specialist inherits the whole thread. Ping-pong is bounded by MaxHandoffs.