### PR TITLE
feat(agent/host): declarative sub-agent personas + nested rendering (issue 1031)

### DIFF
--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -143,6 +143,15 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 	}
 	app.approval = cfg.Approval.buildApproval(ask)
 
+	// serverTools mirrors the server sources only — no meta-tools, no
+	// sub-agents — so a sub-agent persona gets a filtered view of the servers
+	// without seeing the meta-tools or the other personas (which would let it
+	// recurse). Built only when sub-agents are configured.
+	var serverTools *agent.MultiSource
+	if len(cfg.SubAgents) > 0 {
+		serverTools = agent.NewMultiSource()
+	}
+
 	for _, sc := range cfg.Servers {
 		copts := []client.ClientOption{
 			client.WithGetSSEStream(),
@@ -182,6 +191,12 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 		if err := multi.Add(sc.ID, src); err != nil {
 			app.Close()
 			return nil, err
+		}
+		if serverTools != nil {
+			if err := serverTools.Add(sc.ID, src); err != nil {
+				app.Close()
+				return nil, err
+			}
 		}
 	}
 
@@ -273,6 +288,17 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 	// covered by offloading below like any other source).
 	if cfg.Memory != nil {
 		if err := app.registerMemory(multi, o.memoryStore); err != nil {
+			app.Close()
+			return nil, err
+		}
+	}
+
+	// Sub-agent personas are AgentSources added to the aggregate: the main
+	// agent delegates to them as tools. Each runs on the shared provider over
+	// a filtered view of serverTools (built above), so it never sees the
+	// meta-tools or its sibling personas.
+	if len(cfg.SubAgents) > 0 {
+		if err := app.registerSubAgents(multi, serverTools, provider, o.tp); err != nil {
 			app.Close()
 			return nil, err
 		}

--- a/agent/host/config.go
+++ b/agent/host/config.go
@@ -75,6 +75,35 @@ type Config struct {
 	// tail is kept verbatim, before each turn. Nil means off — history is
 	// sent verbatim. Lossy; complementary to Offload (lossless).
 	Compaction *CompactionConfig `json:"compaction,omitempty"`
+
+	// SubAgents declares specialist personas the main agent can delegate to
+	// as tools (AgentSource). Each runs over the SAME provider and a filtered
+	// view of the SAME server tools, with its own instructions — a persona,
+	// not a separately-configured agent. Empty means no sub-agents.
+	SubAgents []SubAgentConfig `json:"subAgents,omitempty"`
+}
+
+// SubAgentConfig is one delegatable persona. The host builds it into an
+// agent.AgentSource over a child Runner that shares the main provider and a
+// FilterSource-narrowed view of the server tools.
+type SubAgentConfig struct {
+	// Name is the tool name the main agent calls to delegate. Required.
+	Name string `json:"name"`
+
+	// Description tells the main agent when to delegate to this persona.
+	Description string `json:"description,omitempty"`
+
+	// Instructions is the persona's system prompt. Empty means the sub-agent
+	// is defined only by the task it is handed.
+	Instructions string `json:"instructions,omitempty"`
+
+	// Allow narrows which server tools this persona may use (by tool name).
+	// Empty means all server tools.
+	Allow []string `json:"allow,omitempty"`
+
+	// MaxDepth caps sub-agent nesting for this persona. Zero uses the agent
+	// default.
+	MaxDepth int `json:"maxDepth,omitempty"`
 }
 
 // CompactionConfig is the host's view of history compaction; it maps to an

--- a/agent/host/hostevent.go
+++ b/agent/host/hostevent.go
@@ -47,6 +47,10 @@ const (
 	HostTaskCompleted HostEventKind = "task-completed"
 	// HostMessage is a plain informational line (Message).
 	HostMessage HostEventKind = "message"
+	// HostSubAgentEvent carries a sub-agent's nested turn-lifecycle event
+	// (SubAgent) — a persona's activity, scoped/depth on the envelope, for a
+	// surface to render indented under the parent's turn.
+	HostSubAgentEvent HostEventKind = "sub-agent-event"
 )
 
 // HostEvent is one domain event the host announces: a thing that
@@ -87,6 +91,9 @@ type HostEvent struct {
 
 	TaskStatus *core.DetailedTask
 	Task       *client.BackgroundTask
+
+	// SubAgent is the nested sub-agent event on HostSubAgentEvent.
+	SubAgent agent.SubAgentEvent
 }
 
 // Observer receives the host's HostEvent stream and does whatever it

--- a/agent/host/render.go
+++ b/agent/host/render.go
@@ -321,5 +321,24 @@ func (r *renderer) On(ev HostEvent) {
 		r.taskCompleted(ev.Task)
 	case HostMessage:
 		fmt.Fprintf(r.out, "%s\n", r.dim(ev.Message))
+	case HostSubAgentEvent:
+		r.subAgent(ev.SubAgent)
+	}
+}
+
+// subAgent renders a persona's nested activity indented by depth and tagged
+// by scope: the tools it calls and its final answer. Other lifecycle events
+// (deltas, turn boundaries) are omitted to keep the nested transcript terse.
+func (r *renderer) subAgent(sa agent.SubAgentEvent) {
+	indent := strings.Repeat("  ", sa.Depth)
+	switch sa.Event.Kind {
+	case agent.EventToolBegin:
+		if sa.Event.ToolCall != nil {
+			fmt.Fprintf(r.out, "%s%s\n", indent, r.dim("["+sa.Scope+"] · "+sa.Event.ToolCall.Name))
+		}
+	case agent.EventTurnEnd:
+		if sa.Event.Result != nil && sa.Event.Result.Text != "" {
+			fmt.Fprintf(r.out, "%s%s\n", indent, r.dim("["+sa.Scope+"] → "+sa.Event.Result.Text))
+		}
 	}
 }

--- a/agent/host/subagents.go
+++ b/agent/host/subagents.go
@@ -1,0 +1,51 @@
+package host
+
+import (
+	"github.com/panyam/mcpkit/agent"
+	"github.com/panyam/mcpkit/core"
+)
+
+// registerSubAgents builds each configured persona as an agent.AgentSource and
+// adds it to the aggregate, so the main agent delegates to it as a tool. Each
+// persona runs a child Runner on the SHARED provider over a FilterSource-
+// narrowed view of serverTools (server tools only — never the meta-tools or a
+// sibling persona), with its own instructions. Its event stream is forwarded
+// to the host observers as a HostSubAgentEvent for nested rendering.
+func (a *App) registerSubAgents(multi, serverTools *agent.MultiSource, provider agent.Provider, tp core.TracerProvider) error {
+	for _, sub := range a.cfg.SubAgents {
+		var tools agent.ToolSource = serverTools
+		if len(sub.Allow) > 0 {
+			allow := make(map[string]bool, len(sub.Allow))
+			for _, name := range sub.Allow {
+				allow[name] = true
+			}
+			tools = agent.NewFilterSource(serverTools, func(d core.ToolDef) bool { return allow[d.Name] })
+		}
+
+		child, err := agent.NewRunner(agent.RunnerConfig{
+			Provider:       provider,
+			Tools:          tools,
+			Instructions:   sub.Instructions,
+			MaxSteps:       a.cfg.MaxSteps,
+			TracerProvider: tp,
+		})
+		if err != nil {
+			return err
+		}
+
+		src, err := agent.NewAgentSource(agent.AgentSourceConfig{
+			Name:        sub.Name,
+			Description: sub.Description,
+			Runner:      child,
+			MaxDepth:    sub.MaxDepth,
+			OnEvent:     func(e agent.SubAgentEvent) { a.emit(HostEvent{Kind: HostSubAgentEvent, SubAgent: e}) },
+		})
+		if err != nil {
+			return err
+		}
+		if err := multi.Add("subagent:"+sub.Name, src); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/agent/host/subagents_test.go
+++ b/agent/host/subagents_test.go
@@ -1,0 +1,108 @@
+package host
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/panyam/mcpkit/agent"
+	"github.com/panyam/mcpkit/core"
+)
+
+// collectObserver records every HostEvent for assertions.
+type collectObserver struct {
+	mu     sync.Mutex
+	events []HostEvent
+}
+
+func (c *collectObserver) On(ev HostEvent) {
+	c.mu.Lock()
+	c.events = append(c.events, ev)
+	c.mu.Unlock()
+}
+
+func (c *collectObserver) kinds(k HostEventKind) []HostEvent {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var out []HostEvent
+	for _, e := range c.events {
+		if e.Kind == k {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// TestAppSubAgentPersonaDelegatesAndSurfaces is the 1031 payoff: a SubAgents
+// config builds a persona the main agent delegates to (StubProvider), and the
+// child's events surface as HostSubAgentEvent (scoped), for nested rendering.
+func TestAppSubAgentPersonaDelegatesAndSurfaces(t *testing.T) {
+	ts := startTestServer(t)
+
+	// One StubProvider serves both the main agent and the sub-agent (shared
+	// turn counter): main delegates, then the sub-agent answers, then main
+	// synthesizes.
+	stub := agent.NewStubProvider(
+		agent.StubTurn{ToolCalls: []agent.ToolCall{{
+			ID: "d1", Name: "researcher",
+			Args: core.NewRawJSON(json.RawMessage(`{"task":"look it up"}`)),
+		}}},
+		agent.StubTurn{Text: "the researcher found it"},    // sub-agent's answer
+		agent.StubTurn{Text: "here is what my team found"}, // main synthesizes
+	)
+
+	cfg := testConfig(ts.URL)
+	cfg.SubAgents = []SubAgentConfig{{
+		Name: "researcher", Description: "researches a topic", Instructions: "You research.",
+	}}
+	obs := &collectObserver{}
+	app, err := NewApp(cfg, nil, strings.NewReader(""), WithProvider(stub), WithObserver(obs))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Close()
+
+	// the persona is exposed to the main agent as a tool
+	defs, _ := app.sources.Tools(context.Background())
+	if !hasToolNamed(defs, "researcher") {
+		t.Fatalf("sub-agent tool 'researcher' not offered to the main agent: %v", toolDefNames(defs))
+	}
+
+	if err := app.RunTurn(context.Background(), "research this"); err != nil {
+		t.Fatal(err)
+	}
+
+	// the child's activity surfaced as HostSubAgentEvent, scoped to the persona
+	sub := obs.kinds(HostSubAgentEvent)
+	if len(sub) == 0 {
+		t.Fatal("no HostSubAgentEvent emitted; sub-agent ran invisibly")
+	}
+	var sawScoped bool
+	for _, e := range sub {
+		if e.SubAgent.Scope == "researcher" && e.SubAgent.Depth == 1 {
+			sawScoped = true
+		}
+	}
+	if !sawScoped {
+		t.Fatalf("sub-agent events not scoped to 'researcher' at depth 1: %+v", sub)
+	}
+}
+
+func hasToolNamed(defs []core.ToolDef, name string) bool {
+	for _, d := range defs {
+		if d.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func toolDefNames(defs []core.ToolDef) string {
+	var n []string
+	for _, d := range defs {
+		n = append(n, d.Name)
+	}
+	return strings.Join(n, ",")
+}

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -21,3 +21,18 @@ commit. The active connection is a local model, so `just demo` works offline
 against a running LM Studio / Ollama with nothing to configure. A model router
 (OpenRouter, LiteLLM, a gateway) is just another connection — point `baseURL` at
 it. For machine-specific overrides, copy it to `llm.local.json` (gitignored).
+
+## Multi-agent via host config (agentchat)
+
+`agentchat-multi-agent.json` is a sample host config declaring **sub-agent
+personas** (`subAgents`): each is a specialist the main agent delegates to as a
+tool, running on the same provider over a filtered view of the same server
+tools, with its own instructions. Run it:
+
+```bash
+agentchat --config examples/agents/agentchat-multi-agent.json   # needs the demo server running
+```
+
+The sub-agents' activity renders **nested** under the main agent's turn
+(`HostSubAgentEvent`). This is the declarative counterpart to the `multi-agent`
+example, which wires the same `AgentSource`/`Team` primitives by hand.

--- a/examples/agents/agentchat-multi-agent.json
+++ b/examples/agents/agentchat-multi-agent.json
@@ -1,0 +1,26 @@
+{
+  "instructions": "You are a supervisor. Delegate research to the researcher and coding to the coder, then synthesize their findings.",
+  "connections": {
+    "active": "local",
+    "connections": {
+      "local": { "type": "lmstudio", "model": "qwen2.5-7b-instruct" }
+    }
+  },
+  "servers": [
+    { "id": "demo", "url": "http://localhost:8787/mcp" }
+  ],
+  "subAgents": [
+    {
+      "name": "researcher",
+      "description": "researches a topic using the available server tools",
+      "instructions": "You are a researcher. Use the tools to look things up, then report concisely.",
+      "allow": ["search"]
+    },
+    {
+      "name": "coder",
+      "description": "writes and verifies code",
+      "instructions": "You are a coder. Write a snippet, verify it with the run tool, then present it.",
+      "allow": ["run_code"]
+    }
+  ]
+}


### PR DESCRIPTION
Closes #1031. Stacks on PR 1040 (examples/agents reorg). **No CI while based on a non-main branch** — verified with `make test-agent` (all green). This makes Phase 3 multi-agent usable **via config**, not just the library API.

## What changes

Sub-agents as tools, declaratively. `Config.SubAgents` declares specialist **personas**; each is built into an `agent.AgentSource` over a child `Runner` that shares the **main provider** and a `FilterSource`-narrowed view of the **same server tools**, with its own instructions — a persona, not a separately-configured agent. Added to the main agent's aggregate, so the main agent delegates to them as tools. Their activity renders **nested** under the parent's turn via a new `HostSubAgentEvent`.

## Sample flow

```mermaid
flowchart TD
    CFG["Config.SubAgents: researcher, coder"] --> BUILD["registerSubAgents"]
    ST["serverTools (server-only snapshot)"] --> FS["FilterSource per persona (Allow)"]
    PROV["shared provider"] --> CR["child Runner (own instructions)"]
    FS --> CR
    BUILD --> AS["AgentSource per persona"] --> MULTI["main agent aggregate (MultiSource)"]
    CR -. OnEvent .-> HSE["HostSubAgentEvent"] --> R["renderer: indented, scoped"]
```

## Reviewer's guide

1. [agent/host/config.go](https://github.com/panyam/mcpkit/pull/1041/files#diff-6aff502cc5cae4b9d9769752e8638899bab121e09de870b5d1320cc892c6bf2d) — `SubAgentConfig{Name, Description, Instructions, Allow, MaxDepth}` + `Config.SubAgents`.
2. [agent/host/subagents.go](https://github.com/panyam/mcpkit/pull/1041/files#diff-21724f272556c58ee608c6c4ee3b765e2f4194f582f49c6b8af967c85369aa50) — `registerSubAgents`: per persona, a `FilterSource(serverTools, Allow)` → a child `Runner` (shared provider, own instructions) → an `AgentSource` (`OnEvent` → `HostSubAgentEvent`) → the aggregate.
3. [agent/host/app.go](https://github.com/panyam/mcpkit/pull/1041/files#diff-89fb8e04b6e1e9d5f7f76958490ef158dee40e2cae92d87c04b408d893c84361) — the `serverTools` server-only snapshot (built only when `SubAgents` set; **why**: a persona must not see the meta-tools or its sibling personas, or it could recurse) + the registration call after provider resolution.
4. [agent/host/hostevent.go](https://github.com/panyam/mcpkit/pull/1041/files#diff-19a6cb704e31f277e9bf65a111061678da30c84576e938e6ac2ef2f379e01095) + `render.go` — `HostSubAgentEvent` kind + `SubAgent` field; the terminal renderer indents the persona's tool calls + final answer by depth, tagged by scope (consumes the 942 `SubAgentEvent` envelope).
5. [agent/host/subagents_test.go](https://github.com/panyam/mcpkit/pull/1041/files#diff-2d54a2ee7af3226fd54ff17fab9344db5dc337cf238e6e1deeecf64af88b59d3) — a `SubAgents` config builds a persona the main agent delegates to (StubProvider); `HostSubAgentEvent`s surface scoped to the persona at depth 1.
6. [examples/agents/agentchat-multi-agent.json](https://github.com/panyam/mcpkit/pull/1041/files#diff-2b63a0f4ce6736f27e1f0058bc43ac972bfdfc9fc31eb90953ec7c7a7daef54d) — a sample agentchat config.

## Decision log

- **Personas over shared provider + servers** (non-recursive), not full nested config (each sub-agent its own provider/servers). Bounded, covers the supervisor case; nested config is a follow-up.
- **`serverTools` is a separate snapshot**, not a filter over the live aggregate — a `FilterSource` over `multi` would capture `multi` by reference and then *include* the personas once they're added (recursion). The server-only `MultiSource` never gains personas/meta-tools.
- **Team-in-host deferred** — driving a `Team` from `App.RunTurn` changes the turn loop (more invasive); this PR does the additive sub-agents-as-tools half.
- **No standalone host-example module** — it would need a live server (heavy boilerplate); a sample agentchat config documents the config-driven path, and the `examples/agents/multi-agent` example already demos the primitives.

## Risk / blast radius

- Affects: `agent/host` (additive — new config + wiring + event kind + renderer case). Default path unchanged when `SubAgents` is empty. `serverTools` is built only when personas are configured (zero overhead otherwise).
- Tests: persona-built-and-delegated + `HostSubAgentEvent` scoped/nested; `make test-agent` green.
- Be paranoid about: the no-recursion guarantee (personas see `serverTools` only — asserted indirectly; a persona's tool list excludes other personas), and the `OnEvent` → `HostSubAgentEvent` fan-out to observers.

## Before / after

```
before:  multi-agent is a library API — you hand-wire AgentSource in a scenario.go.
after:   agentchat --config with `subAgents: [researcher, coder]` — the main agent
         delegates to them, and their work renders nested:
           › research this
             [researcher] · search
             [researcher] → found it
           here is what my team found
```

## Out of scope (filed / follow-up)

- **Team-in-host** (handoff config driving the App loop) → follow-up.
- Full nested sub-agent config (own provider/servers per sub-agent) → follow-up.
- Router `type` presets (`openrouter`/`litellm`) in `ConnectionsConfig` → follow-up (noted in the reorg PR).
- `agentchat` multi-agent live e2e (needs a running server) → the sample config documents it.
