### PR TITLE
feat(docker/backends): pgvector Postgres + host ports for the agent stack

### DIFF
--- a/docker/backends/README.md
+++ b/docker/backends/README.md
@@ -8,18 +8,38 @@ Shared backend services for mcpkit examples — identity, relational state, cach
 |---|---|---|---|
 | `mcpkit-keycloak` | `quay.io/keycloak/keycloak:26.0` | OAuth AS (3 tenant realms) | `8180` (admin UI + token endpoints) |
 | `mcpkit-keycloak-init` | `quay.io/keycloak/keycloak:26.0` | One-shot sidecar: master realm sslRequired=NONE | — (exits after init) |
-| `mcpkit-postgres` | `postgres:18-alpine` | Relational state (events: WebhookStore + EventBufferStore) | internal-only (5432) |
-| `mcpkit-redis` | `redis:7-alpine` | Cache + pub/sub (events: QuotaStore + Emitter) | internal-only (6379) |
+| `mcpkit-postgres` | `pgvector/pgvector:pg18` | Relational state (events: WebhookStore + EventBufferStore) **+ the agent stack**: durable gorm RunStore / ToolResultStore / MemoryStore, and the pgvector semantic MemoryStore | `5432` (host + network) |
+| `mcpkit-redis` | `redis:7-alpine` | Cache + pub/sub (events: QuotaStore + Emitter) **+ the agent stack**: redis RunStore / ToolResultStore / MemoryStore | `6379` (host + network) |
 
-Postgres and Redis are NOT host-port-mapped — they're reachable from any container on the `mcpkit` network by alias (`postgres:5432`, `redis:6379`). An example needing direct host access can either `docker exec` into the container or add a `ports:` block in a local override.
+Postgres and Redis are reachable both **on the `mcpkit` network** by alias (`postgres:5432`, `redis:6379`) for containerized examples, **and on `localhost`** (`5432` / `6379`) for examples run from the terminal (agentchat). Credentials are demo-only (`postgres/postgres`).
+
+Postgres runs the **pgvector** image, and a one-time init script (`init/01-agent.sql`, on a **fresh** volume only) creates the `vector` extension and a dedicated **`agent`** database. On an already-initialized `./data/postgres`, reset with `docker compose down -v` — or create the extension manually — to pick it up.
 
 ## Quick start
 
 ```
-cd docker/backends && just up       # bring the stack up
+cd docker/backends && just up       # bring the stack up (make up also works)
 open http://localhost:8180          # Keycloak admin UI (admin/admin)
 cd docker/backends && just down     # tear it down
 ```
+
+Observability (Grafana / Tempo / OTel collector / Mimir) is a **separate**
+compose — bring it up from [`docker/observability/`](../observability/) with its
+own `just up` / `make up`. Both join the shared `mcpkit` network.
+
+## The agent stack — wiring agentchat / agent examples
+
+With this stack up, point the agent knobs at it (all from the host, terminal-run):
+
+| Agent knob | Value against this stack |
+|---|---|
+| Sessions (RunStore) | `--session-store postgres://postgres:postgres@localhost:5432/agent` — or `redis://localhost:6379` |
+| Tool-result offloading | `--offload-threshold 4096` (blobs share `--session-store`'s backend) |
+| Semantic memory | `--memory --memory-embed-model <model>` + the pgvector `MemoryStore` (issue 1019) against the `agent` DB |
+| Traces | `--exporter otlp --otlp-endpoint localhost:4317` (needs `docker/observability` up) |
+
+sqlite (`--session-store sqlite://path.db`) needs none of this — the Postgres
+path is for the durable/multi-replica story and for exercising pgvector.
 
 ## Reaching these from an example
 

--- a/docker/backends/README.md
+++ b/docker/backends/README.md
@@ -8,10 +8,10 @@ Shared backend services for mcpkit examples — identity, relational state, cach
 |---|---|---|---|
 | `mcpkit-keycloak` | `quay.io/keycloak/keycloak:26.0` | OAuth AS (3 tenant realms) | `8180` (admin UI + token endpoints) |
 | `mcpkit-keycloak-init` | `quay.io/keycloak/keycloak:26.0` | One-shot sidecar: master realm sslRequired=NONE | — (exits after init) |
-| `mcpkit-postgres` | `pgvector/pgvector:pg18` | Relational state (events: WebhookStore + EventBufferStore) **+ the agent stack**: durable gorm RunStore / ToolResultStore / MemoryStore, and the pgvector semantic MemoryStore | `5432` (host + network) |
-| `mcpkit-redis` | `redis:7-alpine` | Cache + pub/sub (events: QuotaStore + Emitter) **+ the agent stack**: redis RunStore / ToolResultStore / MemoryStore | `6379` (host + network) |
+| `mcpkit-postgres` | `pgvector/pgvector:pg18` | Relational state (events: WebhookStore + EventBufferStore) **+ the agent stack**: durable gorm RunStore / ToolResultStore / MemoryStore, and the pgvector semantic MemoryStore | `127.0.0.1:5432` (loopback + network) |
+| `mcpkit-redis` | `redis:7-alpine` | Cache + pub/sub (events: QuotaStore + Emitter) **+ the agent stack**: redis RunStore / ToolResultStore / MemoryStore | `127.0.0.1:6379` (loopback + network) |
 
-Postgres and Redis are reachable both **on the `mcpkit` network** by alias (`postgres:5432`, `redis:6379`) for containerized examples, **and on `localhost`** (`5432` / `6379`) for examples run from the terminal (agentchat). Credentials are demo-only (`postgres/postgres`).
+Postgres and Redis are reachable both **on the `mcpkit` network** by alias (`postgres:5432`, `redis:6379`) for containerized examples, **and on `localhost`** (`127.0.0.1:5432` / `127.0.0.1:6379`, loopback-only) for examples run from the terminal (agentchat) — not exposed off-host. Credentials are demo-only (`postgres/postgres`).
 
 Postgres runs the **pgvector** image, and a one-time init script (`init/01-agent.sql`, on a **fresh** volume only) creates the `vector` extension and a dedicated **`agent`** database. On an already-initialized `./data/postgres`, reset with `docker compose down -v` — or create the extension manually — to pick it up.
 

--- a/docker/backends/docker-compose.yml
+++ b/docker/backends/docker-compose.yml
@@ -131,11 +131,12 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: events
-    # Published to the host so examples run from the terminal (agentchat
-    # --session-store postgres://postgres:postgres@localhost:5432/agent) reach
-    # it without joining the mcpkit network. Demo-only credentials.
+    # Published to the host (loopback only) so examples run from the terminal
+    # (agentchat --session-store postgres://postgres:postgres@localhost:5432/agent)
+    # reach it without joining the mcpkit network. Bound to 127.0.0.1 so the
+    # demo-credential DB is NOT reachable off-host (LAN/WiFi).
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     expose:
       - "5432"
     healthcheck:
@@ -169,10 +170,11 @@ services:
     container_name: mcpkit-redis
     restart: unless-stopped
     command: ["redis-server", "--appendonly", "yes", "--dir", "/data"]
-    # Published to the host for terminal-run examples
-    # (agentchat --session-store redis://localhost:6379).
+    # Published to the host (loopback only) for terminal-run examples
+    # (agentchat --session-store redis://localhost:6379). Bound to 127.0.0.1 so
+    # the unauthenticated cache is NOT reachable off-host.
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
     expose:
       - "6379"
     healthcheck:

--- a/docker/backends/docker-compose.yml
+++ b/docker/backends/docker-compose.yml
@@ -120,13 +120,22 @@ services:
   # posture; production overrides via DSN env on each consumer.
   # -------------------------------------------------------------------
   postgres:
-    image: postgres:18-alpine
+    # pgvector image (PG18 + the `vector` extension) so the durable agent
+    # backends (gorm RunStore / ToolResultStore / MemoryStore) and the pgvector
+    # semantic MemoryStore work against this instance directly. Same PG major
+    # as before, so an existing ./data/postgres volume stays valid.
+    image: pgvector/pgvector:pg18
     container_name: mcpkit-postgres
     restart: unless-stopped
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: events
+    # Published to the host so examples run from the terminal (agentchat
+    # --session-store postgres://postgres:postgres@localhost:5432/agent) reach
+    # it without joining the mcpkit network. Demo-only credentials.
+    ports:
+      - "5432:5432"
     expose:
       - "5432"
     healthcheck:
@@ -140,6 +149,10 @@ services:
     # https://github.com/docker-library/postgres/issues/37
     volumes:
       - ./data/postgres:/var/lib/postgresql
+      # Runs ONCE on a fresh volume: creates the `vector` extension + an
+      # `agent` DB. An already-initialized ./data/postgres will NOT re-run it —
+      # `docker compose down -v` (or a manual CREATE EXTENSION) to pick it up.
+      - ./init:/docker-entrypoint-initdb.d:ro
     networks:
       mcpkit:
         aliases:
@@ -156,6 +169,10 @@ services:
     container_name: mcpkit-redis
     restart: unless-stopped
     command: ["redis-server", "--appendonly", "yes", "--dir", "/data"]
+    # Published to the host for terminal-run examples
+    # (agentchat --session-store redis://localhost:6379).
+    ports:
+      - "6379:6379"
     expose:
       - "6379"
     healthcheck:

--- a/docker/backends/init/01-agent.sql
+++ b/docker/backends/init/01-agent.sql
@@ -1,0 +1,16 @@
+-- Runs once, on a fresh Postgres volume, as the postgres superuser against the
+-- default DB (events). Sets up what the agent stack needs:
+--   * the pgvector `vector` extension (semantic MemoryStore, issue 1019)
+--   * a dedicated `agent` DB for the durable agent backends (RunStore /
+--     ToolResultStore / MemoryStore), separate from the events lib's `events` DB
+-- with the extension available in both.
+--
+-- NOTE: /docker-entrypoint-initdb.d scripts run ONLY when the data directory is
+-- empty. On an already-initialized ./data/postgres this file is skipped — reset
+-- with `docker compose down -v`, or create the extension manually.
+
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE DATABASE agent;
+\connect agent
+CREATE EXTENSION IF NOT EXISTS vector;


### PR DESCRIPTION
Devex/observability prep before Phase 4: make the shared backends stack have everything the agent stack needs. Based on `main`, CI runs. Docker/docs only — no Go code.

## What changes

The shared `docker/backends` Postgres becomes **pgvector-enabled** and both it and Redis are **published to the host**, so the durable agent backends and the (upcoming) pgvector semantic memory work directly, and terminal-run examples reach them on `localhost`.

- **postgres**: image `postgres:18-alpine` → **`pgvector/pgvector:pg18`** (same PG major, so an existing `./data/postgres` volume stays valid). `init/01-agent.sql` (runs once, on a fresh volume) creates the **`vector`** extension and a dedicated **`agent`** DB, with the extension in both.
- **host ports**: publish `5432` + `6379` so `agentchat --session-store postgres://…@localhost:5432/agent` / `redis://localhost:6379` work from the terminal (demo-only creds).
- **README**: an agent-stack **knob→endpoint** table, the pgvector + init-on-fresh-volume caveat, and a pointer that observability stays its **own** compose (its own `just up`/`make up`).

## Sample flow

```mermaid
flowchart LR
    AC["agentchat / agent examples (host)"]
    AC -->|"--session-store postgres://…@localhost:5432/agent"| PG[("mcpkit-postgres<br/>pgvector/pgvector:pg18")]
    AC -->|"--session-store redis://localhost:6379 · --offload"| RD[("mcpkit-redis")]
    AC -->|"--memory-embed-* + pgvector MemoryStore (1019)"| PG
    AC -->|"--exporter otlp → localhost:4317"| OBS["docker/observability<br/>(separate compose)"]
    INIT["init/01-agent.sql (fresh volume)"] -.->|"CREATE EXTENSION vector; CREATE DATABASE agent"| PG
```

## Decision log

- **`pgvector/pgvector:pg18`, not a downgrade to pg17 or a custom build** — the `pg18` tag exists, so we keep the PG major (no `./data` break) and get the official, maintained image. (Debian-based vs the old alpine; irrelevant for a dev backend.)
- **Host-published `5432`/`6379`** — the whole point is terminal-run examples; the stack is already demo-only creds, so `localhost` exposure is the expected dev posture. Still network-aliased for containerized examples.
- **Observability stays a separate compose** — matches the existing two-compose split (backends vs observability); no combined "stack up" target, each has its own `just up`/`make up`.
- **`agent` DB separate from `events`** — the events lib owns `events`; the agent backends get their own DB.

## Risk / blast radius

- `docker/backends` only; no library code. The `init/` script runs **only on a fresh volume** — an existing `./data/postgres` needs `docker compose down -v` (or a manual `CREATE EXTENSION vector`) to pick up pgvector + the `agent` DB. Called out prominently in the compose comment and README.
- **Verified live**: a throwaway `pgvector/pgvector:pg18` container ran the init script and `SELECT extname FROM pg_extension` returned `vector` in the `agent` DB (no touching real data).

## Before / after

```
before:  postgres:18-alpine, internal-only — no vector extension; host examples can't reach it.
after:   pgvector/pgvector:pg18 on localhost:5432 with `vector` + an `agent` DB;
         redis on localhost:6379. agentchat --session-store postgres://…@localhost:5432/agent works.
```

## Out of scope (follow-up)

- **pgvector semantic `MemoryStore`** (#1019) — this PR provides the DB; the store itself is the next build.
- Metrics dashboards in observability — wait for the metrics seam (#1023).