### PR TITLE
feat(agent/host): gemini + anthropic connection types

### DIFF
--- a/agent/host/connections.go
+++ b/agent/host/connections.go
@@ -34,7 +34,9 @@ type ConnectionsConfig struct {
 // resolve, or construction fails.
 type ConnectionConfig struct {
 	// Type names a built-in endpoint profile ("lmstudio", "openai",
-	// "ollama"). Optional when BaseURL is set.
+	// "ollama", "gemini", "anthropic"). All but "anthropic" speak the OpenAI
+	// wire; "anthropic" uses the native Messages-API provider (x-api-key
+	// auth, /v1/messages). Optional when BaseURL is set.
 	Type string `json:"type,omitempty"`
 
 	// BaseURL is the API root including any version prefix, e.g.
@@ -64,11 +66,17 @@ type ThinkingHint struct {
 }
 
 // connectionBaseURLs maps a built-in Type to its default API root. Local
-// runtimes and the OpenAI cloud; anything else sets BaseURL explicitly.
+// runtimes, the OpenAI cloud, Gemini's OpenAI-compatible endpoint, and
+// Anthropic; anything else sets BaseURL explicitly. Every type here is
+// OpenAI-wire EXCEPT "anthropic", which DefaultProviderBuilder routes to the
+// native Messages-API provider (see below) — the base still resolves here so
+// registry validation and BaseURL overrides work uniformly.
 var connectionBaseURLs = map[string]string{
-	"lmstudio": "http://localhost:1234/v1",
-	"openai":   "https://api.openai.com/v1",
-	"ollama":   "http://localhost:11434/v1",
+	"lmstudio":  "http://localhost:1234/v1",
+	"openai":    "https://api.openai.com/v1",
+	"ollama":    "http://localhost:11434/v1",
+	"gemini":    "https://generativelanguage.googleapis.com/v1beta/openai",
+	"anthropic": "https://api.anthropic.com",
 }
 
 // ProviderBuilder builds a Provider from a resolved connection. Injected
@@ -76,8 +84,11 @@ var connectionBaseURLs = map[string]string{
 // is the real OpenAI-compatible path.
 type ProviderBuilder func(ConnectionConfig) (agent.Provider, error)
 
-// DefaultProviderBuilder builds an OpenAI-compatible provider, resolving
-// the base URL from BaseURL or the Type table and the key from APIKeyEnv.
+// DefaultProviderBuilder builds the provider for a connection: the native
+// Anthropic Messages-API provider when Type is "anthropic", otherwise an
+// OpenAI-wire provider (lmstudio / openai / ollama / gemini / any BaseURL).
+// The base URL resolves from BaseURL or the Type table and the key from
+// APIKeyEnv.
 func DefaultProviderBuilder(conn ConnectionConfig) (agent.Provider, error) {
 	base, err := resolveBaseURL(conn)
 	if err != nil {
@@ -86,6 +97,13 @@ func DefaultProviderBuilder(conn ConnectionConfig) (agent.Provider, error) {
 	var key string
 	if conn.APIKeyEnv != "" {
 		key = os.Getenv(conn.APIKeyEnv)
+	}
+	if conn.Type == "anthropic" {
+		return agent.NewAnthropicProvider(agent.AnthropicConfig{
+			BaseURL: base,
+			Model:   conn.Model,
+			APIKey:  key,
+		})
 	}
 	return agent.NewOpenAIProvider(agent.OpenAIConfig{
 		BaseURL: base,

--- a/agent/host/connections_test.go
+++ b/agent/host/connections_test.go
@@ -112,6 +112,32 @@ func TestResolveBaseURL(t *testing.T) {
 	if _, err := resolveBaseURL(ConnectionConfig{Model: "m"}); err == nil {
 		t.Fatal("no type and no baseUrl should error")
 	}
+	if u, _ := resolveBaseURL(ConnectionConfig{Type: "gemini"}); u != "https://generativelanguage.googleapis.com/v1beta/openai" {
+		t.Fatalf("gemini base = %q", u)
+	}
+	if u, _ := resolveBaseURL(ConnectionConfig{Type: "anthropic"}); u != "https://api.anthropic.com" {
+		t.Fatalf("anthropic base = %q", u)
+	}
+}
+
+// TestDefaultProviderBuilder_ProviderType pins that only "anthropic" routes to
+// the native Messages-API provider; every other type (gemini included) builds
+// the OpenAI-wire provider.
+func TestDefaultProviderBuilder_ProviderType(t *testing.T) {
+	anth, err := DefaultProviderBuilder(ConnectionConfig{Type: "anthropic", Model: "claude-sonnet-5"})
+	if err != nil {
+		t.Fatalf("anthropic build: %v", err)
+	}
+	if _, ok := anth.(*agent.AnthropicProvider); !ok {
+		t.Fatalf("anthropic type built %T, want *agent.AnthropicProvider", anth)
+	}
+	gem, err := DefaultProviderBuilder(ConnectionConfig{Type: "gemini", Model: "gemini-2.5-flash"})
+	if err != nil {
+		t.Fatalf("gemini build: %v", err)
+	}
+	if _, ok := gem.(*agent.OpenAIProvider); !ok {
+		t.Fatalf("gemini type built %T, want *agent.OpenAIProvider", gem)
+	}
 }
 
 // TestConnectionsConfigJSON pins the llm.json-inspired shape decodes.

--- a/examples/agents/llm.json
+++ b/examples/agents/llm.json
@@ -5,6 +5,8 @@
       "local":  { "type": "lmstudio", "model": "qwen2.5-7b-instruct" },
       "ollama": { "type": "ollama", "model": "llama3.1" },
       "cloud":  { "type": "openai", "model": "gpt-4o", "apiKeyEnv": "OPENAI_API_KEY" },
+      "gemini": { "type": "gemini", "model": "gemini-2.5-flash", "apiKeyEnv": "GEMINI_API_KEY" },
+      "anthropic": { "type": "anthropic", "model": "claude-sonnet-5", "apiKeyEnv": "ANTHROPIC_API_KEY" },
       "router": { "baseURL": "https://openrouter.ai/api/v1", "model": "anthropic/claude-sonnet-4", "apiKeyEnv": "OPENROUTER_API_KEY" }
     }
   }


### PR DESCRIPTION
## What changes

Adds two named connection types to the host connection registry so `llm.json` (and any `ConnectionsConfig`) can target **Gemini** and **Anthropic**:

- **`gemini`** — OpenAI-wire against Google's OpenAI-compatible endpoint (`https://generativelanguage.googleapis.com/v1beta/openai`). A plain base-URL preset; the existing OpenAI path builds it.
- **`anthropic`** — routes to the **native `AnthropicProvider`** (`x-api-key` auth, `/v1/messages`), not the OpenAI builder. This closes a real gap: the purpose-built Messages-API provider was previously unreachable from config, since `DefaultProviderBuilder` only ever built OpenAI-wire providers.

`examples/agents/llm.json` gains `gemini` and `anthropic` connections (keys via `apiKeyEnv` only; `active` stays `local` so `just demo` runs offline).

## Reviewer's guide

1. [agent/host/connections.go](https://github.com/panyam/mcpkit/pull/1055/files#diff-40587e49ead8267db133543c03987833f30f87ec17039242f6d4397802b11c6e) — start here. `connectionBaseURLs` gains the two bases; `DefaultProviderBuilder` branches on `Type == "anthropic"` → `agent.NewAnthropicProvider`, else the OpenAI path (gemini included).
2. [agent/host/connections_test.go](https://github.com/panyam/mcpkit/pull/1055/files#diff-1c89e3a97c6cf4e11077a67b4b3d5cdd70fa267f389852ab1163420d61c08915) — acceptance: base-URL resolution for both types, and that `anthropic` builds `*agent.AnthropicProvider` while `gemini` builds `*agent.OpenAIProvider`.
3. [examples/agents/llm.json](https://github.com/panyam/mcpkit/pull/1055/files#diff-67d6a59bdbcb801f02c9f7484af2831241d06c217db84c895141191954f9af89) — the two new connections.

## Decision log

- **`anthropic` uses the native provider, not Anthropic's OpenAI-compat shim.** The repo already ships `AnthropicProvider` (native Messages API, `x-api-key`); routing config-selected Anthropic through the OpenAI builder would bypass it. One `Type` branch makes it reachable — the right home for the choice, since the registry is the provider seam.
- **`gemini` stays OpenAI-wire.** Google's endpoint is genuinely OpenAI-compatible, so it needs only a base-URL preset — no provider branch.
- **Base URLs live in the one table.** Both resolve via `connectionBaseURLs`, so registry validation and `baseUrl` overrides behave identically for every type; `anthropic` is the only entry whose builder diverges (documented inline).
- **`active` kept `local`.** llm.json's convention is an offline default so `just demo` works with no keys; per-machine cloud selection belongs in the gitignored `llm.local.json`.

## Risk / blast radius

- **Additive.** New map entries + one builder branch. Existing types (lmstudio/openai/ollama/router) are unchanged; no interface change.
- **Be paranoid about:** the `anthropic` branch keys off `Type` exactly; a `baseUrl`-only connection with no type still builds OpenAI-wire (unchanged). Gemini/Anthropic model ids in llm.json are examples — override per use.

## Before / after

```
# DefaultProviderBuilder(ConnectionConfig{...})
type: "anthropic"  ->  *agent.AnthropicProvider   (was: error "unknown connection type")
type: "gemini"     ->  *agent.OpenAIProvider @ .../v1beta/openai   (was: error)
type: "openai"     ->  *agent.OpenAIProvider        (unchanged)
```

## Out of scope

- Threading `thinkingHint` / Anthropic caching+thinking (issue 953) through the registry.
- A `maxTokens` knob on `ConnectionConfig` (the native provider defaults to 4096).

