### PR TITLE
feat(agent/host): openrouter + litellm router type presets (#1044)

### DIFF
--- a/agent/host/connections.go
+++ b/agent/host/connections.go
@@ -55,9 +55,11 @@ func (c *ConnectionsConfig) EmbedderConnection() (ConnectionConfig, bool) {
 // resolve, or construction fails.
 type ConnectionConfig struct {
 	// Type names a built-in endpoint profile ("lmstudio", "openai",
-	// "ollama", "gemini", "anthropic"). All but "anthropic" speak the OpenAI
-	// wire; "anthropic" uses the native Messages-API provider (x-api-key
-	// auth, /v1/messages). Optional when BaseURL is set.
+	// "ollama", "gemini", "anthropic", "openrouter", "litellm"). All but
+	// "anthropic" speak the OpenAI wire; "anthropic" uses the native
+	// Messages-API provider (x-api-key auth, /v1/messages). "openrouter" and
+	// "litellm" are model-router gateways (set BaseURL to override the
+	// litellm proxy's local default). Optional when BaseURL is set.
 	Type string `json:"type,omitempty"`
 
 	// BaseURL is the API root including any version prefix, e.g.
@@ -93,18 +95,23 @@ type ThinkingHint struct {
 	CloseTag string `json:"closeTag,omitempty"`
 }
 
-// connectionBaseURLs maps a built-in Type to its default API root. Local
-// runtimes, the OpenAI cloud, Gemini's OpenAI-compatible endpoint, and
-// Anthropic; anything else sets BaseURL explicitly. Every type here is
-// OpenAI-wire EXCEPT "anthropic", which DefaultProviderBuilder routes to the
-// native Messages-API provider (see below) — the base still resolves here so
-// registry validation and BaseURL overrides work uniformly.
+// connectionBaseURLs maps a built-in Type to its default API root: local
+// runtimes, the OpenAI cloud, Gemini's OpenAI-compatible endpoint, Anthropic,
+// and the OpenAI-wire model routers (OpenRouter cloud, LiteLLM proxy).
+// Anything else sets BaseURL explicitly. Every type here is OpenAI-wire EXCEPT
+// "anthropic", which DefaultProviderBuilder routes to the native Messages-API
+// provider (see below) — the base still resolves here so registry validation
+// and BaseURL overrides work uniformly. A router is just a connection whose
+// base URL is the gateway; "litellm" defaults to the proxy's local port and is
+// typically overridden with BaseURL for a hosted deployment.
 var connectionBaseURLs = map[string]string{
-	"lmstudio":  "http://localhost:1234/v1",
-	"openai":    "https://api.openai.com/v1",
-	"ollama":    "http://localhost:11434/v1",
-	"gemini":    "https://generativelanguage.googleapis.com/v1beta/openai",
-	"anthropic": "https://api.anthropic.com",
+	"lmstudio":   "http://localhost:1234/v1",
+	"openai":     "https://api.openai.com/v1",
+	"ollama":     "http://localhost:11434/v1",
+	"gemini":     "https://generativelanguage.googleapis.com/v1beta/openai",
+	"anthropic":  "https://api.anthropic.com",
+	"openrouter": "https://openrouter.ai/api/v1",
+	"litellm":    "http://localhost:4000/v1",
 }
 
 // ProviderBuilder builds a Provider from a resolved connection. Injected

--- a/agent/host/connections_test.go
+++ b/agent/host/connections_test.go
@@ -118,6 +118,30 @@ func TestResolveBaseURL(t *testing.T) {
 	if u, _ := resolveBaseURL(ConnectionConfig{Type: "anthropic"}); u != "https://api.anthropic.com" {
 		t.Fatalf("anthropic base = %q", u)
 	}
+	if u, _ := resolveBaseURL(ConnectionConfig{Type: "openrouter"}); u != "https://openrouter.ai/api/v1" {
+		t.Fatalf("openrouter base = %q", u)
+	}
+	if u, _ := resolveBaseURL(ConnectionConfig{Type: "litellm"}); u != "http://localhost:4000/v1" {
+		t.Fatalf("litellm base = %q", u)
+	}
+	// a router connection can override the preset base (hosted litellm)
+	if u, _ := resolveBaseURL(ConnectionConfig{Type: "litellm", BaseURL: "https://gw.example/v1"}); u != "https://gw.example/v1" {
+		t.Fatalf("litellm BaseURL override = %q", u)
+	}
+}
+
+// TestRouterPresets_BuildOpenAIWire pins that the router types build the
+// OpenAI-wire provider (they are gateways, not a native provider).
+func TestRouterPresets_BuildOpenAIWire(t *testing.T) {
+	for _, typ := range []string{"openrouter", "litellm"} {
+		p, err := DefaultProviderBuilder(ConnectionConfig{Type: typ, Model: "m"})
+		if err != nil {
+			t.Fatalf("%s build: %v", typ, err)
+		}
+		if _, ok := p.(*agent.OpenAIProvider); !ok {
+			t.Fatalf("%s built %T, want *agent.OpenAIProvider", typ, p)
+		}
+	}
 }
 
 // TestDefaultProviderBuilder_ProviderType pins that only "anthropic" routes to

--- a/examples/agents/llm.json
+++ b/examples/agents/llm.json
@@ -26,7 +26,8 @@
       "anthropic-sonnet": { "type": "anthropic", "model": "claude-sonnet-5", "apiKeyEnv": "ANTHROPIC_API_KEY" },
       "anthropic-haiku":  { "type": "anthropic", "model": "claude-haiku-4-5-20251001", "apiKeyEnv": "ANTHROPIC_API_KEY" },
 
-      "router": { "baseURL": "https://openrouter.ai/api/v1", "model": "anthropic/claude-sonnet-4", "apiKeyEnv": "OPENROUTER_API_KEY" }
+      "openrouter": { "type": "openrouter", "model": "anthropic/claude-sonnet-4", "apiKeyEnv": "OPENROUTER_API_KEY" },
+      "litellm":    { "type": "litellm", "model": "gpt-4o", "apiKeyEnv": "LITELLM_API_KEY" }
     }
   }
 }


### PR DESCRIPTION
## What changes

Adds `openrouter` and `litellm` as connection **type presets** (issue #1044). A model router is just an OpenAI-wire connection whose base URL is the gateway, so a connection can now say `{type: openrouter, model: ...}` with no explicit `baseUrl`. Extends the same `connectionBaseURLs` table that already presets lmstudio/openai/ollama/gemini/anthropic.

## Reviewer's guide

1. [agent/host/connections.go](https://github.com/panyam/mcpkit/pull/1062/files#diff-40587e49ead8267db133543c03987833f30f87ec17039242f6d4397802b11c6e) — two entries in `connectionBaseURLs` (`openrouter` → `https://openrouter.ai/api/v1`, `litellm` → `http://localhost:4000/v1`) + the `Type` doc. Both are OpenAI-wire, so `DefaultProviderBuilder`'s existing OpenAI path builds them — no provider branch (only `anthropic` diverges).
2. [agent/host/connections_test.go](https://github.com/panyam/mcpkit/pull/1062/files#diff-1c89e3a97c6cf4e11077a67b4b3d5cdd70fa267f389852ab1163420d61c08915) — base-URL resolution for both, the litellm `BaseURL` override (hosted proxy), and that both build `*agent.OpenAIProvider`.
3. [examples/agents/llm.json](https://github.com/panyam/mcpkit/pull/1062/files#diff-67d6a59bdbcb801f02c9f7484af2831241d06c217db84c895141191954f9af89) — the old `baseUrl`-based `router` entry becomes typed `openrouter` + `litellm` connections.

## Decision log

- **`litellm` defaults to the proxy's local port** (`:4000/v1`) since LiteLLM is self-hosted and has no canonical URL; override with `BaseURL` for a hosted deployment (test covers this).
- **No provider branch** — routers speak the OpenAI wire, so they reuse the OpenAI builder. Only `anthropic` needs the native-provider branch.

## Risk / blast radius

- Additive: two map entries + doc + one example config. No interface change; existing types untouched. Covered by `agent/host` tests.

## Before / after

```
resolveBaseURL({type: "openrouter"})  ->  https://openrouter.ai/api/v1   (was: error "unknown type")
resolveBaseURL({type: "litellm"})     ->  http://localhost:4000/v1        (was: error)
DefaultProviderBuilder(openrouter/litellm)  ->  *agent.OpenAIProvider
```

Complements the per-turn routing policy (#991), which selects *among* connections; this makes a router connection a one-liner.

