### PR TITLE
feat(agent): thinking-hint stream parser — inline <think> to reasoning deltas (#989)

### DIFF
--- a/agent/host/connections.go
+++ b/agent/host/connections.go
@@ -81,9 +81,10 @@ type ConnectionConfig struct {
 	Dim int `json:"dim,omitempty"`
 
 	// ThinkingHint describes how this model delimits inline reasoning, for
-	// models that emit it in the text stream (e.g. <think>…</think>).
-	// Carried through the registry; the stream parser that acts on it is a
-	// follow-up (issue 989) — for now it is metadata.
+	// models that emit it in the text stream (e.g. <think>…</think>). When
+	// set, DefaultProviderBuilder wraps the provider so the delimited text is
+	// re-tagged as reasoning (agent.NewThinkingProvider). A nil hint or empty
+	// CloseTag leaves the provider unwrapped.
 	ThinkingHint *ThinkingHint `json:"thinkingHint,omitempty"`
 }
 
@@ -133,18 +134,31 @@ func DefaultProviderBuilder(conn ConnectionConfig) (agent.Provider, error) {
 	if conn.APIKeyEnv != "" {
 		key = os.Getenv(conn.APIKeyEnv)
 	}
+	var p agent.Provider
 	if conn.Type == "anthropic" {
-		return agent.NewAnthropicProvider(agent.AnthropicConfig{
+		p, err = agent.NewAnthropicProvider(agent.AnthropicConfig{
+			BaseURL: base,
+			Model:   conn.Model,
+			APIKey:  key,
+		})
+	} else {
+		p, err = agent.NewOpenAIProvider(agent.OpenAIConfig{
 			BaseURL: base,
 			Model:   conn.Model,
 			APIKey:  key,
 		})
 	}
-	return agent.NewOpenAIProvider(agent.OpenAIConfig{
-		BaseURL: base,
-		Model:   conn.Model,
-		APIKey:  key,
-	})
+	if err != nil {
+		return nil, err
+	}
+	// A ThinkingHint activates the inline-reasoning parser: a model that emits
+	// "<think>…</think>" in its text stream gets that content re-tagged as
+	// reasoning, so the surface renders it as thinking. Inert when CloseTag is
+	// empty (NewThinkingProvider returns p unwrapped).
+	if h := conn.ThinkingHint; h != nil {
+		p = agent.NewThinkingProvider(p, h.OpenTag, h.CloseTag)
+	}
+	return p, nil
 }
 
 // BuildEmbedder builds an agent.Embedder from an embedder connection, the

--- a/agent/host/connections_test.go
+++ b/agent/host/connections_test.go
@@ -130,6 +130,29 @@ func TestResolveBaseURL(t *testing.T) {
 	}
 }
 
+// TestThinkingHintWrapsProvider pins that a ThinkingHint on a connection makes
+// DefaultProviderBuilder wrap the provider in the inline-reasoning parser, and
+// that no hint leaves it unwrapped.
+func TestThinkingHintWrapsProvider(t *testing.T) {
+	plain, err := DefaultProviderBuilder(ConnectionConfig{Type: "lmstudio", Model: "m"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := plain.(*agent.OpenAIProvider); !ok {
+		t.Fatalf("no hint should be the bare provider, got %T", plain)
+	}
+	hinted, err := DefaultProviderBuilder(ConnectionConfig{
+		Type: "lmstudio", Model: "m",
+		ThinkingHint: &ThinkingHint{OpenTag: "<think>", CloseTag: "</think>"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := hinted.(*agent.OpenAIProvider); ok {
+		t.Fatal("a ThinkingHint should wrap the provider, but got the bare *agent.OpenAIProvider")
+	}
+}
+
 // TestRouterPresets_BuildOpenAIWire pins that the router types build the
 // OpenAI-wire provider (they are gateways, not a native provider).
 func TestRouterPresets_BuildOpenAIWire(t *testing.T) {

--- a/agent/host/render.go
+++ b/agent/host/render.go
@@ -41,10 +41,14 @@ func (r *renderer) handle(e agent.Event) {
 	switch e.Kind {
 	case agent.EventThinkingBegin:
 		r.breakLine()
-		fmt.Fprint(r.out, r.dim("· thinking "))
+		r.thinking = true
+		fmt.Fprint(r.out, r.dim("· thinking: "))
 	case agent.EventThinkingDelta:
-		fmt.Fprint(r.out, r.dim("."))
+		// Stream the reasoning text itself (dimmed), so a reasoning model's
+		// chain-of-thought is readable — not a row of dots.
+		fmt.Fprint(r.out, r.dim(e.Text))
 	case agent.EventThinkingEnd:
+		r.thinking = false
 		fmt.Fprintln(r.out)
 	case agent.EventTextDelta:
 		r.thinking = false

--- a/agent/host/render_thinking_test.go
+++ b/agent/host/render_thinking_test.go
@@ -1,0 +1,34 @@
+package host
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/panyam/mcpkit/agent"
+)
+
+// TestRenderer_ThinkingStreamsText pins that reasoning deltas render as the
+// reasoning text (dimmed), not a row of dots — so a reasoning model's
+// chain-of-thought is readable in plain and TUI output.
+func TestRenderer_ThinkingStreamsText(t *testing.T) {
+	os.Setenv("NO_COLOR", "1") // strip ANSI so we assert on plain text
+	defer os.Unsetenv("NO_COLOR")
+	var b strings.Builder
+	r := newRenderer(&b)
+	r.handle(agent.Event{Kind: agent.EventThinkingBegin})
+	r.handle(agent.Event{Kind: agent.EventThinkingDelta, Text: "weigh option A "})
+	r.handle(agent.Event{Kind: agent.EventThinkingDelta, Text: "vs option B"})
+	r.handle(agent.Event{Kind: agent.EventThinkingEnd})
+	r.handle(agent.Event{Kind: agent.EventTextDelta, Text: "Go with A."})
+	out := b.String()
+	if !strings.Contains(out, "· thinking:") {
+		t.Fatalf("missing thinking header: %q", out)
+	}
+	if !strings.Contains(out, "weigh option A vs option B") {
+		t.Fatalf("reasoning text not streamed: %q", out)
+	}
+	if !strings.Contains(out, "Go with A.") {
+		t.Fatalf("answer missing: %q", out)
+	}
+}

--- a/agent/thinking_stream.go
+++ b/agent/thinking_stream.go
@@ -1,0 +1,205 @@
+package agent
+
+import (
+	"context"
+	"io"
+	"strings"
+)
+
+// NewThinkingProvider wraps p so inline reasoning that a model emits in its
+// text stream — delimited by openTag/closeTag, e.g. "<think>…</think>" — is
+// re-emitted as DeltaReasoning instead of DeltaText. That is all the Runner
+// needs: its consumeStream already turns DeltaReasoning into
+// thinking-begin/delta/end events, so a surface renders the reasoning
+// distinctly with no Runner change.
+//
+// openTag empty means reasoning starts at the stream head and runs until the
+// first closeTag (the "no open tag" models that stream reasoning first, then
+// the answer). closeTag empty makes the hint inert: p is returned unwrapped,
+// since without a terminator there is nothing to delimit.
+//
+// The transform is delimiter-boundary safe: a tag split across two provider
+// deltas (a "<thi" / "nk>" boundary) is buffered and matched whole. Native
+// DeltaReasoning from a provider that already separates reasoning passes
+// through untouched — the parser only reinterprets DeltaText.
+func NewThinkingProvider(p Provider, openTag, closeTag string) Provider {
+	if closeTag == "" {
+		return p
+	}
+	return &thinkingProvider{inner: p, open: openTag, close: closeTag}
+}
+
+type thinkingProvider struct {
+	inner       Provider
+	open, close string
+}
+
+// Stream wraps the inner stream so DeltaText carrying reasoning delimiters is
+// re-split into DeltaText / DeltaReasoning.
+func (t *thinkingProvider) Stream(ctx context.Context, req ProviderRequest) (Stream, error) {
+	s, err := t.inner.Stream(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return &thinkingStream{inner: s, p: newThinkParser(t.open, t.close)}, nil
+}
+
+// Generate splits inline reasoning out of the completed Text into Reasoning,
+// so the non-streaming path stays consistent with Stream.
+func (t *thinkingProvider) Generate(ctx context.Context, req ProviderRequest) (*ProviderResponse, error) {
+	resp, err := t.inner.Generate(ctx, req)
+	if err != nil || resp == nil {
+		return resp, err
+	}
+	p := newThinkParser(t.open, t.close)
+	var text, reason strings.Builder
+	for _, d := range append(p.feed(resp.Text), p.flush()...) {
+		if d.Kind == DeltaReasoning {
+			reason.WriteString(d.Text)
+		} else {
+			text.WriteString(d.Text)
+		}
+	}
+	resp.Text = text.String()
+	if r := reason.String(); r != "" {
+		if resp.Reasoning != "" {
+			resp.Reasoning += r
+		} else {
+			resp.Reasoning = r
+		}
+	}
+	return resp, nil
+}
+
+// thinkingStream reinterprets an inner stream's DeltaText through a
+// thinkParser, queuing the parser's output deltas so Recv can hand them out
+// one at a time.
+type thinkingStream struct {
+	inner Stream
+	p     *thinkParser
+	queue []Delta
+	done  bool
+}
+
+// Recv implements Stream: it pulls from the queue, refilling from the inner
+// stream (feeding DeltaText through the parser, flushing then forwarding any
+// non-text delta) until a delta is available or the inner stream ends.
+func (s *thinkingStream) Recv() (Delta, error) {
+	for len(s.queue) == 0 {
+		if s.done {
+			return Delta{}, io.EOF
+		}
+		d, err := s.inner.Recv()
+		if err == io.EOF {
+			s.done = true
+			s.queue = append(s.queue, s.p.flush()...)
+			continue
+		}
+		if err != nil {
+			return Delta{}, err
+		}
+		if d.Kind == DeltaText {
+			s.queue = append(s.queue, s.p.feed(d.Text)...)
+			continue
+		}
+		// A non-text delta ends the current text run: flush any held
+		// partial-tag bytes (as the current mode) before forwarding it, so
+		// ordering is preserved.
+		s.queue = append(s.queue, s.p.flush()...)
+		s.queue = append(s.queue, d)
+	}
+	d := s.queue[0]
+	s.queue = s.queue[1:]
+	return d, nil
+}
+
+// Close implements Stream.
+func (s *thinkingStream) Close() error { return s.inner.Close() }
+
+// thinkParser is the stateful delimiter machine. It holds a small buffer so a
+// tag straddling two feeds is matched whole, and toggles inThink each time it
+// crosses a boundary. Emit mode is reasoning while inThink, text otherwise.
+type thinkParser struct {
+	open, close string
+	inThink     bool
+	buf         string
+}
+
+// newThinkParser starts inThink when openTag is empty (reasoning-from-head
+// models); otherwise it starts in text mode looking for openTag.
+func newThinkParser(open, close string) *thinkParser {
+	return &thinkParser{open: open, close: close, inThink: open == ""}
+}
+
+// feed processes the next text fragment and returns the reinterpreted deltas.
+func (p *thinkParser) feed(s string) []Delta {
+	p.buf += s
+	var out []Delta
+	for {
+		tag := p.open
+		if p.inThink {
+			tag = p.close
+		}
+		// No tag to look for (empty openTag after leaving a think block):
+		// the rest is plain text, nothing more to split.
+		if tag == "" {
+			out = appendNonEmpty(out, p.emit(p.buf))
+			p.buf = ""
+			break
+		}
+		if idx := strings.Index(p.buf, tag); idx >= 0 {
+			out = appendNonEmpty(out, p.emit(p.buf[:idx]))
+			p.buf = p.buf[idx+len(tag):]
+			p.inThink = !p.inThink
+			continue
+		}
+		// No full tag: emit everything except a suffix that could be the
+		// start of the tag, and hold that suffix for the next feed.
+		keep := prefixOverlap(p.buf, tag)
+		out = appendNonEmpty(out, p.emit(p.buf[:len(p.buf)-keep]))
+		p.buf = p.buf[len(p.buf)-keep:]
+		break
+	}
+	return out
+}
+
+// flush emits whatever is buffered (at stream end or before a non-text
+// delta) as the current mode; buffered bytes are literal content by then.
+func (p *thinkParser) flush() []Delta {
+	if p.buf == "" {
+		return nil
+	}
+	d := p.emit(p.buf)
+	p.buf = ""
+	return []Delta{d}
+}
+
+func (p *thinkParser) emit(text string) Delta {
+	if p.inThink {
+		return Delta{Kind: DeltaReasoning, Text: text}
+	}
+	return Delta{Kind: DeltaText, Text: text}
+}
+
+func appendNonEmpty(out []Delta, d Delta) []Delta {
+	if d.Text == "" {
+		return out
+	}
+	return append(out, d)
+}
+
+// prefixOverlap returns the length of the longest suffix of s that is a
+// (strict) prefix of tag — the partial-tag tail to hold back. Zero when no
+// suffix could begin the tag.
+func prefixOverlap(s, tag string) int {
+	max := len(tag) - 1
+	if len(s) < max {
+		max = len(s)
+	}
+	for k := max; k > 0; k-- {
+		if strings.HasPrefix(tag, s[len(s)-k:]) {
+			return k
+		}
+	}
+	return 0
+}

--- a/agent/thinking_stream_test.go
+++ b/agent/thinking_stream_test.go
@@ -1,0 +1,176 @@
+package agent
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+)
+
+// feedAll runs chunks through a parser and returns the concatenated text and
+// reasoning (robust to how the parser splits deltas across the boundary).
+func feedAll(open, close string, chunks ...string) (text, reason string) {
+	p := newThinkParser(open, close)
+	var t, r strings.Builder
+	emit := func(ds []Delta) {
+		for _, d := range ds {
+			if d.Kind == DeltaReasoning {
+				r.WriteString(d.Text)
+			} else {
+				t.WriteString(d.Text)
+			}
+		}
+	}
+	for _, c := range chunks {
+		emit(p.feed(c))
+	}
+	emit(p.flush())
+	return t.String(), r.String()
+}
+
+func TestThinkParser_BasicSplit(t *testing.T) {
+	text, reason := feedAll("<think>", "</think>", "hello <think>weighing options</think> world")
+	if text != "hello  world" {
+		t.Fatalf("text = %q", text)
+	}
+	if reason != "weighing options" {
+		t.Fatalf("reason = %q", reason)
+	}
+}
+
+func TestThinkParser_TagStraddlesChunks(t *testing.T) {
+	// Every tag is split across a chunk boundary — the boundary-safe case.
+	text, reason := feedAll("<think>", "</think>",
+		"answer: <thi", "nk>because rea", "sons</thi", "nk>42")
+	if text != "answer: 42" {
+		t.Fatalf("text = %q", text)
+	}
+	if reason != "because reasons" {
+		t.Fatalf("reason = %q", reason)
+	}
+}
+
+func TestThinkParser_EmptyOpenTag(t *testing.T) {
+	// No open tag: reasoning runs from the head until closeTag, then text.
+	text, reason := feedAll("", "</think>", "step one, step two</think>the answer is 5")
+	if text != "the answer is 5" {
+		t.Fatalf("text = %q", text)
+	}
+	if reason != "step one, step two" {
+		t.Fatalf("reason = %q", reason)
+	}
+}
+
+func TestThinkParser_MultipleBlocks(t *testing.T) {
+	text, reason := feedAll("<think>", "</think>",
+		"a<think>r1</think>b<think>r2</think>c")
+	if text != "abc" {
+		t.Fatalf("text = %q", text)
+	}
+	if reason != "r1r2" {
+		t.Fatalf("reason = %q", reason)
+	}
+}
+
+func TestThinkParser_NoTags(t *testing.T) {
+	text, reason := feedAll("<think>", "</think>", "just a plain answer")
+	if text != "just a plain answer" || reason != "" {
+		t.Fatalf("text=%q reason=%q", text, reason)
+	}
+}
+
+type fakeStream struct {
+	deltas []Delta
+	i      int
+}
+
+func (f *fakeStream) Recv() (Delta, error) {
+	if f.i >= len(f.deltas) {
+		return Delta{}, io.EOF
+	}
+	d := f.deltas[f.i]
+	f.i++
+	return d, nil
+}
+func (f *fakeStream) Close() error { return nil }
+
+type fakeProvider struct {
+	stream *fakeStream
+	resp   *ProviderResponse
+}
+
+func (p *fakeProvider) Stream(context.Context, ProviderRequest) (Stream, error) {
+	return p.stream, nil
+}
+func (p *fakeProvider) Generate(context.Context, ProviderRequest) (*ProviderResponse, error) {
+	return p.resp, nil
+}
+
+func TestThinkingStream_ReinterpretsAndPreservesOtherDeltas(t *testing.T) {
+	inner := &fakeStream{deltas: []Delta{
+		{Kind: DeltaText, Text: "ok <thi"},
+		{Kind: DeltaText, Text: "nk>hmm</think>done"},
+		{Kind: DeltaToolCallStart, Text: "", ToolCallID: "c1", ToolName: "search"},
+		{Kind: DeltaFinish, FinishReason: "tool_calls"},
+	}}
+	p := NewThinkingProvider(&fakeProvider{stream: inner}, "<think>", "</think>")
+	s, err := p.Stream(context.Background(), ProviderRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var text, reason string
+	var sawToolStart, sawFinish bool
+	for {
+		d, err := s.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		switch d.Kind {
+		case DeltaText:
+			text += d.Text
+		case DeltaReasoning:
+			reason += d.Text
+		case DeltaToolCallStart:
+			sawToolStart = true
+			if d.ToolName != "search" {
+				t.Fatalf("tool name = %q", d.ToolName)
+			}
+		case DeltaFinish:
+			sawFinish = true
+		}
+	}
+	if text != "ok done" {
+		t.Fatalf("text = %q", text)
+	}
+	if reason != "hmm" {
+		t.Fatalf("reason = %q", reason)
+	}
+	if !sawToolStart || !sawFinish {
+		t.Fatalf("non-text deltas dropped: toolStart=%v finish=%v", sawToolStart, sawFinish)
+	}
+}
+
+func TestThinkingProvider_GenerateSplitsReasoning(t *testing.T) {
+	inner := &fakeProvider{resp: &ProviderResponse{Text: "prefix <think>deliberation</think>final"}}
+	p := NewThinkingProvider(inner, "<think>", "</think>")
+	resp, err := p.Generate(context.Background(), ProviderRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Text != "prefix final" {
+		t.Fatalf("text = %q", resp.Text)
+	}
+	if resp.Reasoning != "deliberation" {
+		t.Fatalf("reasoning = %q", resp.Reasoning)
+	}
+}
+
+func TestNewThinkingProvider_InertWhenNoCloseTag(t *testing.T) {
+	inner := &fakeProvider{}
+	if got := NewThinkingProvider(inner, "<think>", ""); got != Provider(inner) {
+		t.Fatal("empty closeTag should return the inner provider unwrapped")
+	}
+}

--- a/examples/agents/kitchen-sink/README.md
+++ b/examples/agents/kitchen-sink/README.md
@@ -87,6 +87,11 @@ Gemini). You can also swap chat models mid-session with `/provider`.
    then trigger a tool and approve/deny it.
 5. **Traces.** With the observability stack up, open Grafana at
    http://localhost:3000 and find the trace for a turn (service `agentchat`).
+6. **Reasoning display.** `/provider local-thinker` switches to a local reasoning
+   model (deepseek-r1 via LM Studio on :1234). Its inline `<think>…</think>` is
+   re-tagged as reasoning by the connection's `thinkingHint` and streamed dimmed
+   under a `· thinking:` line. Cloud OpenAI/Gemini models don't emit inline
+   reasoning, so this only shows with a reasoning model + a `thinkingHint`.
 
 ## Inspecting state
 

--- a/examples/agents/kitchen-sink/kitchen-sink.json
+++ b/examples/agents/kitchen-sink/kitchen-sink.json
@@ -9,6 +9,7 @@
       "gemini-embed": { "type": "gemini", "model": "text-embedding-004", "dim": 768, "apiKeyEnv": "GEMINI_API_KEY" },
 
       "local":  { "type": "lmstudio", "model": "qwen2.5-7b-instruct" },
+      "local-thinker": { "type": "lmstudio", "model": "deepseek-r1-distill-llama-8b", "thinkingHint": { "openTag": "<think>", "closeTag": "</think>" } },
       "ollama": { "type": "ollama", "model": "llama3.1" },
 
       "openai-5.1":      { "type": "openai", "model": "gpt-5.1", "apiKeyEnv": "OPENAI_API_KEY" },

--- a/examples/agents/kitchen-sink/kitchen-sink.json
+++ b/examples/agents/kitchen-sink/kitchen-sink.json
@@ -1,7 +1,7 @@
 {
   "instructions": "You are a capable assistant with access to MCP tools and two specialist sub-agents (researcher, analyst). Use working memory to remember durable facts the user tells you, delegate research/analysis to the sub-agents when it helps, and keep answers concise.",
   "connections": {
-    "active": "openai-5.1",
+    "active": "deepseek-r1",
     "embedder": "openai-embed",
     "connections": {
 
@@ -10,7 +10,10 @@
 
       "local":  { "type": "lmstudio", "model": "qwen2.5-7b-instruct" },
       "local-thinker": { "type": "lmstudio", "model": "deepseek-r1-distill-llama-8b", "thinkingHint": { "openTag": "<think>", "closeTag": "</think>" } },
+      "r1-qwen-7b": { "type": "lmstudio", "model": "deepseek-r1-distill-qwen-7b", "thinkingHint": { "openTag": "<think>", "closeTag": "</think>" } },
       "ollama": { "type": "ollama", "model": "llama3.1" },
+
+      "deepseek-r1": { "baseUrl": "https://api.deepseek.com", "model": "deepseek-reasoner", "apiKeyEnv": "DEEPSEEK_API_KEY" },
 
       "openai-5.1":      { "type": "openai", "model": "gpt-5.1", "apiKeyEnv": "OPENAI_API_KEY" },
       "openai-5.1-mini": { "type": "openai", "model": "gpt-5.1-mini", "apiKeyEnv": "OPENAI_API_KEY" },


### PR DESCRIPTION
## What changes

Makes the inert `ConnectionConfig.ThinkingHint` live (#989). Local reasoning models (deepseek-r1, qwen-thinking, …) emit their reasoning **inline in the text stream** as `<think>…</think>` rather than as a separate reasoning field, so today it renders as raw text. `NewThinkingProvider` wraps a `Provider` so that delimited text is re-emitted as `DeltaReasoning`. The Runner's `consumeStream` already maps `DeltaReasoning` → thinking-begin/delta/end events, so a surface renders reasoning distinctly **with no Runner change**.

## Reviewer's guide

Read in this order:
1. [agent/thinking_stream.go](https://github.com/panyam/mcpkit/pull/1064/files#diff-56935bcd09b3b90d1254720a6a86fbe751e58f08bb6233c3511aecb827def38a) — start here. `thinkParser` (the delimiter state machine + boundary-safe buffering), `thinkingStream` (re-splits `DeltaText`, passes other deltas through), `thinkingProvider` (wraps `Stream` + `Generate`), `NewThinkingProvider`.
2. [agent/thinking_stream_test.go](https://github.com/panyam/mcpkit/pull/1064/files#diff-bf0cf5f279b01c191cb0e9b85f5a83611ba913d8135a5a81eb4d4038496a040f) — acceptance: basic split, **tag straddling chunk boundaries**, empty-open-tag (reasoning-from-head), multiple blocks, stream wrapper preserving tool-call/finish deltas, `Generate` splitting.
3. [agent/host/connections.go](https://github.com/panyam/mcpkit/pull/1064/files#diff-40587e49ead8267db133543c03987833f30f87ec17039242f6d4397802b11c6e) — `DefaultProviderBuilder` wraps the provider when the connection has a `ThinkingHint`; the field doc updated from "follow-up" to live.
4. [agent/host/connections_test.go](https://github.com/panyam/mcpkit/pull/1064/files#diff-1c89e3a97c6cf4e11077a67b4b3d5cdd70fa267f389852ab1163420d61c08915) — the hint activates the wrapper.

## How it works

```
thinkParser (per model call), starts inThink = (openTag == ""):
  feed(fragment):
    buf += fragment
    loop:
      tag = inThink ? closeTag : openTag
      if tag == "": emit(buf) as current mode; clear; stop      # empty openTag, post-close: rest is text
      if buf contains tag at idx:
        emit(buf[:idx]) as current mode; drop through tag; toggle inThink; continue
      else:
        keep = longest suffix of buf that is a prefix of tag     # a possible split tag
        emit(buf[:-keep]) as current mode; hold buf[-keep:]; stop
  flush(): emit whatever is buffered as current mode              # at EOF / before a non-text delta

emit mode: DeltaReasoning while inThink, else DeltaText
```

The stream wrapper queues the parser's output deltas; `Recv` hands them out one at a time and forwards non-text deltas (tool calls, finish, native reasoning) unchanged, flushing the held partial-tag buffer first so ordering is preserved.

## Decision log

- **Provider wrapper, not a Runner change.** The Runner already emits thinking events from `DeltaReasoning`; re-tagging at the provider boundary reuses that machinery and keeps the Runner a pure function. The hint is a connection concept, so the host wires it in `DefaultProviderBuilder`.
- **Boundary-safe by buffering a partial-tag tail** (`prefixOverlap`) — a `<think>` split as `"<thi"` + `"nk>"` across two SSE deltas is the common case and must not leak raw.
- **Empty `openTag` = reasoning from the head; empty `closeTag` = inert** (returns the provider unwrapped) — matches the documented `ThinkingHint` semantics.
- **`Generate` split too**, so the non-streaming path is consistent (reasoning moves from `Text` to `Reasoning`).

## Risk / blast radius

- **Opt-in and additive** — only connections that declare a `ThinkingHint` are wrapped; every other provider is byte-for-byte unchanged. Native-`DeltaReasoning` providers (Anthropic thinking) pass through untouched.
- **Be paranoid about:** the chunk-boundary buffering (covered by `TestThinkParser_TagStraddlesChunks`) and delta ordering around tool calls (`TestThinkingStream_ReinterpretsAndPreservesOtherDeltas`).

## Before / after

```
Provider stream: DeltaText "answer: " · DeltaText "<think>" · DeltaText "reasons" · DeltaText "</think>42"

before (hint inert):  all DeltaText  ->  TUI prints "answer: <think>reasons</think>42" verbatim
after  (hint live):   DeltaText "answer: " · DeltaReasoning "reasons" · DeltaText "42"
                      ->  Runner fires ThinkingBegin/Delta/End; TUI renders "reasons" as thinking
```

Exercised end to end by the playground's `local-thinker` connection (`examples/playground/playground.json`), which already declares `thinkingHint: {openTag:"<think>", closeTag:"</think>"}` — no config change needed.

## Out of scope

- Native provider reasoning (Anthropic `thinking_delta`) — already handled in the provider, untouched here.

