### PR TITLE
feat(agentchat): word-nav keybindings + /keys cheatsheet (#1065)

### DIFF
--- a/cmd/agentchat/README.md
+++ b/cmd/agentchat/README.md
@@ -51,6 +51,26 @@ startup when a named variable is unset. A per-server `allow` list is a
 capability boundary (a FilterSource): tools outside it are neither offered to
 the model nor callable.
 
+## Prompt editing keys (TUI)
+
+The input line supports readline-style editing. `/keys` prints this cheatsheet
+in-session.
+
+| Key | Action |
+|---|---|
+| `←` / `→` | char back / forward |
+| `ctrl+←` / `ctrl+→` | word back / forward |
+| `ctrl+a` / `ctrl+e` (or `Home` / `End`) | start / end of line |
+| `ctrl+w` | delete previous word |
+| `ctrl+k` / `ctrl+u` | delete to end / start of line |
+| `ctrl+home` / `ctrl+end` | start / end of input |
+| `↑` / `↓` | command history · `Tab` complete · `Enter` send · `ctrl+c` quit |
+
+Word navigation is bound to both `ctrl+←/→` and `alt+←/→` (`alt+b`/`alt+f`); the
+`alt+*` bindings (and `alt+d` delete-word-forward, `alt+<`/`alt+>` input ends)
+need your terminal to send Option as Meta — the `ctrl+*` bindings work without
+it.
+
 ## Telemetry and failover
 
 `--exporter` selects telemetry (`stdout`, `otlp`, `auto`; empty = off, zero

--- a/cmd/agentchat/tui.go
+++ b/cmd/agentchat/tui.go
@@ -94,10 +94,17 @@ type tuiModel struct {
 
 func newTUIModel(app *host.App, surface *tuiObserver) tuiModel {
 	ta := textarea.New()
-	ta.Placeholder = "message, or /command (Tab completes, ↑↓ history)"
+	ta.Placeholder = "message, or /command (Tab completes, ↑↓ history, /keys for editing keys)"
 	ta.Prompt = "› "
 	ta.ShowLineNumbers = false
 	ta.SetHeight(2)
+	// The default KeyMap binds word navigation to Meta only (alt+←/→, alt+b/f),
+	// which does nothing on terminals that don't send Option as Meta (the macOS
+	// default). Add the Ctrl variants so word motion works out of the box; the
+	// alt bindings stay for those who have Meta enabled. Everything else the
+	// user needs is already Ctrl-based (a/e/w/k/u) — see /keys.
+	ta.KeyMap.WordForward.SetKeys(append(ta.KeyMap.WordForward.Keys(), "ctrl+right")...)
+	ta.KeyMap.WordBackward.SetKeys(append(ta.KeyMap.WordBackward.Keys(), "ctrl+left")...)
 	ta.Focus()
 	m := tuiModel{app: app, surface: surface, ta: ta}
 	m.histIdx = 0
@@ -185,6 +192,11 @@ func (m tuiModel) View() string {
 // both on a goroutine so the UI stays responsive; the surface streams
 // segments back and the goroutine ends with turnDoneMsg.
 func (m tuiModel) submit(line string) (tea.Model, tea.Cmd) {
+	// /keys is a terminal-only cheatsheet (prompt editing is a TUI concern, so
+	// it is not a surface-agnostic host command); print it without a turn.
+	if line == "/keys" {
+		return m, tea.Println(keyHelp())
+	}
 	m.running = true
 	app, surface := m.app, m.surface
 	ctx := context.Background()
@@ -212,6 +224,23 @@ func (m tuiModel) submit(line string) (tea.Model, tea.Cmd) {
 		}()
 	}
 	return m, nil
+}
+
+// keyHelp is the /keys cheatsheet: the prompt-editing bindings, grouped by
+// what works without a Meta key (the top rows) versus what needs the
+// terminal's Option-as-Meta (the alt-* bindings).
+func keyHelp() string {
+	return strings.Join([]string{
+		"Prompt editing keys:",
+		"  ← / →                 char back / forward",
+		"  ctrl+← / ctrl+→       word back / forward",
+		"  ctrl+a / ctrl+e       start / end of line   (also Home / End)",
+		"  ctrl+w                delete previous word",
+		"  ctrl+k / ctrl+u       delete to end / start of line",
+		"  ctrl+home / ctrl+end  start / end of input",
+		"  ↑ / ↓  history    Tab  complete    Enter  send    ctrl+c  quit",
+		"  With Option-as-Meta on: alt+←/→ or alt+b/f word nav, alt+d delete-word-forward, alt+</> input ends.",
+	}, "\n")
 }
 
 // completeTab completes a leading slash command against the registry: a

--- a/cmd/agentchat/tui_test.go
+++ b/cmd/agentchat/tui_test.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/charmbracelet/bubbles/textarea"
+	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/panyam/mcpkit/agent"
 	"github.com/panyam/mcpkit/agent/host"
@@ -162,5 +164,46 @@ func TestCompleteTab(t *testing.T) {
 	m.completeTab()
 	if m.ta.Value() != "/provider " {
 		t.Fatalf("ambiguous arg changed input to %q", m.ta.Value())
+	}
+}
+
+func TestKeyMap_WordNavHasCtrlArrows(t *testing.T) {
+	// newTUIModel only stores app/surface; nil is fine for inspecting the
+	// configured textarea KeyMap.
+	m := newTUIModel(nil, nil)
+	fwd := m.ta.KeyMap.WordForward.Keys()
+	back := m.ta.KeyMap.WordBackward.Keys()
+	if !slices.Contains(fwd, "ctrl+right") {
+		t.Fatalf("WordForward keys = %v, want ctrl+right (word nav without Meta)", fwd)
+	}
+	if !slices.Contains(back, "ctrl+left") {
+		t.Fatalf("WordBackward keys = %v, want ctrl+left", back)
+	}
+	// the Meta bindings must survive the augmentation
+	if !slices.Contains(fwd, "alt+f") || !slices.Contains(back, "alt+b") {
+		t.Fatalf("alt word-nav bindings dropped: fwd=%v back=%v", fwd, back)
+	}
+}
+
+func TestKeyHelp_ListsBindings(t *testing.T) {
+	h := keyHelp()
+	for _, want := range []string{"ctrl+← / ctrl+→", "ctrl+a / ctrl+e", "ctrl+w", "ctrl+k / ctrl+u", "Option-as-Meta"} {
+		if !strings.Contains(h, want) {
+			t.Fatalf("keyHelp() missing %q:\n%s", want, h)
+		}
+	}
+}
+
+func TestKeyMap_CtrlRightMovesByWord(t *testing.T) {
+	m := newTUIModel(nil, nil)
+	m.ta.SetValue("one two three")
+	m.ta.CursorStart()
+	if col := m.ta.LineInfo().ColumnOffset; col != 0 {
+		t.Fatalf("cursor not at start: %d", col)
+	}
+	nm, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlRight})
+	after := nm.(tuiModel).ta.LineInfo().ColumnOffset
+	if after < 3 {
+		t.Fatalf("ctrl+right did not advance past the first word: col=%d", after)
 	}
 }


### PR DESCRIPTION
## What changes

Makes the agentchat TUI's prompt line navigable by word without a Meta key, and makes the editing bindings discoverable via `/keys` (#1065). The bubbles `textarea` already binds most readline keys (`ctrl+a/e/w/k/u`, `ctrl+←/→` after this), but its word navigation was **Meta-only** (`alt+←/→`, `alt+b/f`) — which does nothing on terminals that don't send Option as Meta (the macOS default), so it felt like there were no bindings at all.

## Reviewer's guide

1. [cmd/agentchat/tui.go](https://github.com/panyam/mcpkit/pull/1068/files#diff-0e29207287df07cecf17e04df9f99e726ae789983f7e3ce007bb6282029b4db6) — start here. `newTUIModel` augments `ta.KeyMap` (WordForward += `ctrl+right`, WordBackward += `ctrl+left`, keeping the alt bindings); `submit` intercepts `/keys` to print `keyHelp()`; the placeholder points at it.
2. [cmd/agentchat/tui_test.go](https://github.com/panyam/mcpkit/pull/1068/files#diff-68ccb7754cb7a3e92c63ccecf5613cb252fcae31e66f524e2ab680a096069bc3) — acceptance: the KeyMap carries `ctrl+←/→` (and still has `alt`), `keyHelp` lists the bindings, and a behavioral test drives `ctrl+right` through `Update` and asserts the cursor advances past the first word.
3. [cmd/agentchat/README.md](https://github.com/panyam/mcpkit/pull/1068/files#diff-ffb24bf0bf1787e7af2eee0cd297abb3635a9ad7720753f345e3abdd7a503592) — the "Prompt editing keys" table + the Option-as-Meta note.

## Decision log

- **Augment the default KeyMap, don't replace it.** The bubbles defaults are already a good readline set; replacing risks dropping working bindings. The only real gap is Meta-dependent word nav → add the Ctrl variants.
- **`ctrl+←/→` specifically** — the keys terminals send for word motion without Option-as-Meta. `ctrl+a/e/w/k/u` already worked; word nav was the hole.
- **`/keys` is intercepted in the TUI, not a host command.** Prompt editing is a terminal concern; a web surface wouldn't have `ctrl+w`, so it doesn't belong in the surface-agnostic `CommandRegistry`.
- **Meta bindings kept** — users who enable Option-as-Meta still get `alt+*` (and `alt+d`, `alt+</>`), documented in the README.

## Risk / blast radius

- **Additive and TUI-only.** No behavior change outside the input line; the plain REPL (line scanner) is untouched. `ctrl+c/enter/tab/↑↓` still handled by the outer switch, unshadowed.
- **Tests covering this:** KeyMap config + `keyHelp` contents + the `ctrl+right` word-motion behavioral test.

## Before / after

```
Terminal without Option-as-Meta (macOS default):
  before:  word navigation impossible (alt+←/→, alt+b/f send junk or nothing)
  after:   ctrl+← / ctrl+→ move by word

Discoverability:
  before:  bindings exist but nothing documents them
  after:   /keys prints the cheatsheet; placeholder hints at it; README table
```

`/keys` output:
```
Prompt editing keys:
  ← / →                 char back / forward
  ctrl+← / ctrl+→       word back / forward
  ctrl+a / ctrl+e       start / end of line   (also Home / End)
  ctrl+w                delete previous word
  ctrl+k / ctrl+u       delete to end / start of line
  ctrl+home / ctrl+end  start / end of input
  ↑ / ↓  history    Tab  complete    Enter  send    ctrl+c  quit
  With Option-as-Meta on: alt+←/→ or alt+b/f word nav, alt+d delete-word-forward, alt+</> input ends.
```

## Out of scope

- Alt-screen renderer with visible key hints / scroll fix → #1001 / #1066.

