### PR TITLE
feat(agentchat): --ui notebook alt-screen renderer with collapsible cells (#1001)

### DIFF
--- a/cmd/agentchat/README.md
+++ b/cmd/agentchat/README.md
@@ -86,7 +86,9 @@ terminal, else `plain`), `tui` (inline), `notebook` (alt-screen), or `plain`
   `esc`/`i` return to INS. `pgup`/`pgdn` and the mouse wheel scroll; in INS,
   `↑`/`↓` move within a multi-line prompt first, then recall history, then
   scroll the transcript. **Enter sends; `ctrl+j` inserts a newline** (also
-  `shift+enter` / `alt+enter` where the terminal supports them). The cost:
+  `shift+enter` / `alt+enter` where the terminal supports them); the prompt box
+  auto-grows with its line count up to `--notebook-max-lines` (default 20) and
+  shrinks back. The cost:
   alt-screen takes the whole screen, breaks native copy/paste + shell scroll,
   and clears on exit — which is why the inline `tui` stays the default.
 

--- a/cmd/agentchat/README.md
+++ b/cmd/agentchat/README.md
@@ -83,7 +83,10 @@ terminal, else `plain`), `tui` (inline), `notebook` (alt-screen), or `plain`
   transcript of **collapsible cells** (one per turn / command / info line). Two
   modes: **INS** (default) types into the input — `esc` enters **NAV**, where
   `↑↓`/`jk` move a cell cursor, `space` folds/unfolds, `g`/`G` jump to ends, and
-  `esc`/`i` return to INS. `pgup`/`pgdn` and the mouse wheel scroll. The cost:
+  `esc`/`i` return to INS. `pgup`/`pgdn` and the mouse wheel scroll; in INS,
+  `↑`/`↓` move within a multi-line prompt first, then recall history, then
+  scroll the transcript. **Enter sends; `ctrl+j` inserts a newline** (also
+  `shift+enter` / `alt+enter` where the terminal supports them). The cost:
   alt-screen takes the whole screen, breaks native copy/paste + shell scroll,
   and clears on exit — which is why the inline `tui` stays the default.
 

--- a/cmd/agentchat/README.md
+++ b/cmd/agentchat/README.md
@@ -71,7 +71,23 @@ Word navigation is bound to both `ctrl+←/→` and `alt+←/→` (`alt+b`/`alt+
 need your terminal to send Option as Meta — the `ctrl+*` bindings work without
 it.
 
-## Telemetry and failover
+## Interfaces (`--ui`)
+
+`--ui` picks the surface: `auto` (default — the inline TUI when stdout is a
+terminal, else `plain`), `tui` (inline), `notebook` (alt-screen), or `plain`
+(a scriptable line REPL for pipes/CI).
+
+- **`tui`** (inline): finished output commits to the terminal's own scrollback,
+  so native scroll, copy/paste, and a transcript that survives exit all work.
+- **`notebook`** (alt-screen): a managed viewport with its own scroll and a
+  transcript of **collapsible cells** (one per turn / command / info line). Two
+  modes: **INS** (default) types into the input — `esc` enters **NAV**, where
+  `↑↓`/`jk` move a cell cursor, `space` folds/unfolds, `g`/`G` jump to ends, and
+  `esc`/`i` return to INS. `pgup`/`pgdn` and the mouse wheel scroll. The cost:
+  alt-screen takes the whole screen, breaks native copy/paste + shell scroll,
+  and clears on exit — which is why the inline `tui` stays the default.
+
+## Prompt editing keys (TUI)
 
 `--exporter` selects telemetry (`stdout`, `otlp`, `auto`; empty = off, zero
 overhead) and `--otlp-endpoint` points at a collector (default

--- a/cmd/agentchat/main.go
+++ b/cmd/agentchat/main.go
@@ -197,6 +197,7 @@ func newRoot() (*cobra.Command, *viper.Viper) {
 	fl.String("session-store", "", "session persistence backend: memory | sqlite://path.db | redis://host:port | postgres://user:pass@host:port/db (empty = off)")
 	fl.String("session", "", "session run ID to create or resume at startup (needs --session-store)")
 	fl.String("ui", "auto", "interface: auto (TUI when interactive) | tui (inline) | notebook (alt-screen, foldable cells) | plain")
+	fl.Int("notebook-max-lines", 20, "with --ui notebook, max rows the auto-growing prompt expands to")
 	fl.Int("offload-threshold", 0, "offload tool results at/over N bytes to a store, feeding the model a stub + read_tool_result (0 = off; blobs use --session-store's backend)")
 	fl.String("offload-dir", "", "store offloaded tool results as files under this directory (no server needed); overrides --session-store for blobs")
 	fl.Bool("memory", false, "enable working memory: remember/recall/forget tools the model manages across turns (in-memory store)")
@@ -345,7 +346,7 @@ func runChat(v *viper.Viper) error {
 	case "tui":
 		return runTUI(app, surface)
 	case "notebook":
-		return runNotebook(app, nbSurface)
+		return runNotebook(app, nbSurface, v.GetInt("notebook-max-lines"))
 	}
 
 	fmt.Printf("agentchat: %d server(s), model %s. /tools /history /quit; Ctrl-C cancels a turn.\n", len(cfg.Servers), cfg.Model.Model)

--- a/cmd/agentchat/main.go
+++ b/cmd/agentchat/main.go
@@ -196,7 +196,7 @@ func newRoot() (*cobra.Command, *viper.Viper) {
 	fl.String("active", "", "override the active chat connection at startup (a name in the config's connections; default = the config's active)")
 	fl.String("session-store", "", "session persistence backend: memory | sqlite://path.db | redis://host:port | postgres://user:pass@host:port/db (empty = off)")
 	fl.String("session", "", "session run ID to create or resume at startup (needs --session-store)")
-	fl.String("ui", "auto", "interface: auto (TUI when interactive) | tui | plain")
+	fl.String("ui", "auto", "interface: auto (TUI when interactive) | tui (inline) | notebook (alt-screen, foldable cells) | plain")
 	fl.Int("offload-threshold", 0, "offload tool results at/over N bytes to a store, feeding the model a stub + read_tool_result (0 = off; blobs use --session-store's backend)")
 	fl.String("offload-dir", "", "store offloaded tool results as files under this directory (no server needed); overrides --session-store for blobs")
 	fl.Bool("memory", false, "enable working memory: remember/recall/forget tools the model manages across turns (in-memory store)")
@@ -264,11 +264,16 @@ func runChat(v *viper.Viper) error {
 		host.WithTracerProvider(tp),
 		host.WithLogger(logger),
 	}
-	tuiMode := wantTUI(v.GetString("ui"))
+	mode := uiMode(v.GetString("ui"))
 	var surface *tuiObserver
-	if tuiMode {
+	var nbSurface *nbObserver
+	switch mode {
+	case "tui":
 		surface = newTUIObserver()
 		appOpts = append(appOpts, host.WithObserver(surface))
+	case "notebook":
+		nbSurface = newNBObserver()
+		appOpts = append(appOpts, host.WithObserver(nbSurface))
 	}
 	sessionStore := v.GetString("session-store")
 	store, err := buildRunStore(sessionStore)
@@ -336,8 +341,11 @@ func runChat(v *viper.Viper) error {
 		fmt.Printf("agentchat: session %s\n", session)
 	}
 
-	if tuiMode {
+	switch mode {
+	case "tui":
 		return runTUI(app, surface)
+	case "notebook":
+		return runNotebook(app, nbSurface)
 	}
 
 	fmt.Printf("agentchat: %d server(s), model %s. /tools /history /quit; Ctrl-C cancels a turn.\n", len(cfg.Servers), cfg.Model.Model)

--- a/cmd/agentchat/notebook.go
+++ b/cmd/agentchat/notebook.go
@@ -250,8 +250,20 @@ func (m notebookModel) updateInsert(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.recallHistory(-1) {
 			return m, nil
 		}
+		// No history to recall (and single-line input): scroll the transcript
+		// so the arrows always do something visible.
+		if !strings.Contains(m.ta.Value(), "\n") {
+			m.vp.ScrollUp(1)
+			m.atBottom = m.vp.AtBottom()
+			return m, nil
+		}
 	case tea.KeyDown:
 		if m.recallHistory(1) {
+			return m, nil
+		}
+		if !strings.Contains(m.ta.Value(), "\n") {
+			m.vp.ScrollDown(1)
+			m.atBottom = m.vp.AtBottom()
 			return m, nil
 		}
 	}
@@ -270,9 +282,9 @@ func (m notebookModel) View() string {
 func (m notebookModel) statusBar() string {
 	var hint string
 	if m.nav {
-		hint = "NAV  ↑↓/jk select · space fold · g/G ends · esc/i insert"
+		hint = "NAV  ↑↓/jk select · space fold · g/G ends · esc/i type"
 	} else {
-		hint = "INS  esc nav · pgup/pgdn scroll · /keys editing · enter send"
+		hint = "INS  type & enter · ↑↓ history then scroll · pgup/pgdn/wheel scroll · esc: fold cells"
 	}
 	if m.running {
 		hint = "working…  " + hint
@@ -299,7 +311,12 @@ func (m *notebookModel) refresh() {
 // then appends the in-flight turn.
 func (m notebookModel) renderCells() string {
 	var b strings.Builder
+	rule := m.hrule()
 	for i, c := range m.cells {
+		if i > 0 {
+			b.WriteString(rule)
+			b.WriteString("\n")
+		}
 		marker := "▾"
 		if c.collapsed {
 			marker = "▸"
@@ -319,10 +336,26 @@ func (m notebookModel) renderCells() string {
 		}
 	}
 	if m.live != "" {
+		if len(m.cells) > 0 {
+			b.WriteString(rule)
+			b.WriteString("\n")
+		}
 		b.WriteString("▾ assistant\n")
 		b.WriteString(indentBlock(m.live))
 	}
 	return b.String()
+}
+
+// hrule is a faint full-width horizontal delimiter drawn between cells.
+func (m notebookModel) hrule() string {
+	w := m.vp.Width
+	if w <= 0 {
+		w = m.width
+	}
+	if w <= 0 {
+		w = 40
+	}
+	return lipgloss.NewStyle().Faint(true).Render(strings.Repeat("─", w))
 }
 
 func indentBlock(s string) string {

--- a/cmd/agentchat/notebook.go
+++ b/cmd/agentchat/notebook.go
@@ -1,0 +1,407 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"sync"
+
+	"github.com/charmbracelet/bubbles/textarea"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/panyam/mcpkit/agent/host"
+)
+
+// The notebook surface (--ui notebook) is the opt-in alt-screen alternative to
+// the default inline TUI. It trades the inline surface's native terminal scroll
+// and copy/paste for what only a managed alt-screen can offer: a viewport with
+// its own scroll (fixing the inline-mode scrollback limitation), and a
+// transcript of collapsible cells. Like tui.go it is presentation only — every
+// action routes through the App (Dispatch / RunTurn / Commands).
+
+// nbCellMsg appends a finished cell (a boundary segment: an assistant turn, a
+// command result, an info line) to the notebook.
+type nbCellMsg nbCell
+
+// nbLiveMsg carries the growing in-flight turn (the not-yet-finished assistant
+// cell) so it renders live at the bottom.
+type nbLiveMsg string
+
+// nbCell is one collapsible block in the transcript.
+type nbCell struct {
+	label     string // "you" / "assistant" / "command" / "info" / "error"
+	body      string
+	collapsed bool
+}
+
+// nbObserver is the host.Observer for notebook mode. It reuses the terminal
+// renderer (so cell bodies format identically to the other surfaces) by
+// writing into a buffer, then splits the stream into cells at HostEvent
+// boundaries: the streaming turn (HostRunnerEvent) accumulates and renders live
+// until a non-runner event closes it into a labeled cell.
+type nbObserver struct {
+	mu   sync.Mutex
+	buf  *bytes.Buffer
+	term host.Observer
+	prog *tea.Program
+}
+
+func newNBObserver() *nbObserver {
+	buf := &bytes.Buffer{}
+	return &nbObserver{buf: buf, term: host.NewTerminalRenderer(buf)}
+}
+
+func (s *nbObserver) On(ev host.HostEvent) {
+	s.mu.Lock()
+	s.term.On(ev)
+	segment := s.buf.String()
+	boundary := isBoundary(ev.Kind)
+	if boundary {
+		s.buf.Reset()
+	}
+	prog := s.prog
+	s.mu.Unlock()
+	if prog == nil {
+		return
+	}
+	if boundary {
+		prog.Send(nbCellMsg{label: nbLabelFor(ev.Kind), body: strings.TrimRight(segment, "\n")})
+	} else {
+		prog.Send(nbLiveMsg(strings.TrimRight(segment, "\n")))
+	}
+}
+
+// nbLabelFor maps a boundary event kind to a cell label. The streaming turn
+// closes on HostTurnDone, so that is the "assistant" cell; failures are their
+// own error cell; commands and the rest are informational.
+func nbLabelFor(k host.HostEventKind) string {
+	switch k {
+	case host.HostTurnDone:
+		return "assistant"
+	case host.HostTurnFailed:
+		return "error"
+	case host.HostCommandResult:
+		return "command"
+	default:
+		return "info"
+	}
+}
+
+// notebookModel is the alt-screen bubbletea model: a scrollable viewport of
+// cells above an input, with two modes. Insert mode (default) types into the
+// input; Nav mode (Esc) moves a selection cursor over cells and folds them.
+type notebookModel struct {
+	app     *host.App
+	surface *nbObserver
+
+	vp    viewport.Model
+	ta    textarea.Model
+	cells []nbCell
+	live  string // the in-flight turn, always shown expanded at the bottom
+
+	nav      bool // false = insert, true = nav
+	sel      int  // selected cell index in nav mode
+	running  bool
+	atBottom bool // whether the viewport is scrolled to the end (for auto-follow)
+
+	history []string
+	histIdx int
+
+	width, height int
+	ready         bool
+}
+
+func newNotebookModel(app *host.App, surface *nbObserver) notebookModel {
+	m := notebookModel{app: app, surface: surface, ta: newPromptArea(), atBottom: true}
+	m.histIdx = 0
+	return m
+}
+
+func (m notebookModel) Init() tea.Cmd { return textarea.Blink }
+
+// chromeHeight is the rows the input + status bar consume; the viewport gets
+// the rest.
+const chromeHeight = 4
+
+func (m *notebookModel) layout() {
+	m.ta.SetWidth(m.width)
+	vpH := m.height - chromeHeight
+	if vpH < 1 {
+		vpH = 1
+	}
+	if !m.ready {
+		m.vp = viewport.New(m.width, vpH)
+		m.ready = true
+	} else {
+		m.vp.Width = m.width
+		m.vp.Height = vpH
+	}
+}
+
+func (m notebookModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width, m.height = msg.Width, msg.Height
+		m.layout()
+		m.refresh()
+		return m, nil
+
+	case nbLiveMsg:
+		m.live = string(msg)
+		m.refresh()
+		return m, nil
+
+	case nbCellMsg:
+		if msg.body != "" {
+			m.cells = append(m.cells, nbCell(msg))
+		}
+		m.live = ""
+		m.refresh()
+		return m, nil
+
+	case turnDoneMsg:
+		m.running = false
+		return m, nil
+
+	case tea.MouseMsg:
+		m.vp, _ = m.vp.Update(msg)
+		m.atBottom = m.vp.AtBottom()
+		return m, nil
+
+	case tea.KeyMsg:
+		if msg.Type == tea.KeyCtrlC {
+			return m, tea.Quit
+		}
+		if m.nav {
+			return m.updateNav(msg)
+		}
+		return m.updateInsert(msg)
+	}
+	var cmd tea.Cmd
+	m.ta, cmd = m.ta.Update(msg)
+	return m, cmd
+}
+
+// updateNav handles keys while the selection cursor is active: move the
+// selection, fold/unfold, jump to ends, or return to insert mode.
+func (m notebookModel) updateNav(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "i":
+		m.nav = false
+	case "up", "k":
+		if m.sel > 0 {
+			m.sel--
+		}
+	case "down", "j":
+		if m.sel < len(m.cells)-1 {
+			m.sel++
+		}
+	case "g":
+		m.sel = 0
+	case "G":
+		m.sel = len(m.cells) - 1
+	case " ", "enter":
+		if m.sel >= 0 && m.sel < len(m.cells) {
+			m.cells[m.sel].collapsed = !m.cells[m.sel].collapsed
+		}
+	case "pgup":
+		m.vp.HalfPageUp()
+	case "pgdown":
+		m.vp.HalfPageDown()
+	}
+	m.refresh()
+	return m, nil
+}
+
+// updateInsert handles keys while typing: submit, complete, history, scroll the
+// viewport, or enter nav mode; anything else edits the input.
+func (m notebookModel) updateInsert(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyEsc:
+		if len(m.cells) > 0 {
+			m.nav = true
+			m.sel = len(m.cells) - 1
+			m.refresh()
+		}
+		return m, nil
+	case tea.KeyEnter:
+		if m.running {
+			return m, nil
+		}
+		line := strings.TrimSpace(m.ta.Value())
+		if line == "" {
+			return m, nil
+		}
+		m.ta.Reset()
+		m.history = append(m.history, line)
+		m.histIdx = len(m.history)
+		return m.submit(line)
+	case tea.KeyTab:
+		tabComplete(&m.ta, m.app)
+		return m, nil
+	case tea.KeyPgUp, tea.KeyPgDown:
+		m.vp, _ = m.vp.Update(msg)
+		m.atBottom = m.vp.AtBottom()
+		return m, nil
+	case tea.KeyUp:
+		if m.recallHistory(-1) {
+			return m, nil
+		}
+	case tea.KeyDown:
+		if m.recallHistory(1) {
+			return m, nil
+		}
+	}
+	var cmd tea.Cmd
+	m.ta, cmd = m.ta.Update(msg)
+	return m, cmd
+}
+
+func (m notebookModel) View() string {
+	if !m.ready {
+		return "starting…"
+	}
+	return m.vp.View() + "\n" + m.statusBar() + "\n" + m.ta.View()
+}
+
+func (m notebookModel) statusBar() string {
+	var hint string
+	if m.nav {
+		hint = "NAV  ↑↓/jk select · space fold · g/G ends · esc/i insert"
+	} else {
+		hint = "INS  esc nav · pgup/pgdn scroll · /keys editing · enter send"
+	}
+	if m.running {
+		hint = "working…  " + hint
+	}
+	return lipgloss.NewStyle().Faint(true).Render(hint)
+}
+
+// refresh rebuilds the viewport content from the cells (+ the live turn) and,
+// when the view was already at the bottom, follows the new content down.
+func (m *notebookModel) refresh() {
+	if !m.ready {
+		return
+	}
+	follow := m.atBottom
+	m.vp.SetContent(m.renderCells())
+	if follow {
+		m.vp.GotoBottom()
+		m.atBottom = true
+	}
+}
+
+// renderCells lays out every cell (a fold marker + label header, and the
+// indented body unless collapsed), highlighting the selected cell in nav mode,
+// then appends the in-flight turn.
+func (m notebookModel) renderCells() string {
+	var b strings.Builder
+	for i, c := range m.cells {
+		marker := "▾"
+		if c.collapsed {
+			marker = "▸"
+		}
+		header := marker + " " + c.label
+		if c.collapsed {
+			header += " · " + snippet(firstLine(c.body), 70)
+		}
+		if m.nav && i == m.sel {
+			header = lipgloss.NewStyle().Reverse(true).Render(header)
+		}
+		b.WriteString(header)
+		b.WriteString("\n")
+		if !c.collapsed && c.body != "" {
+			b.WriteString(indentBlock(c.body))
+			b.WriteString("\n")
+		}
+	}
+	if m.live != "" {
+		b.WriteString("▾ assistant\n")
+		b.WriteString(indentBlock(m.live))
+	}
+	return b.String()
+}
+
+func indentBlock(s string) string {
+	lines := strings.Split(s, "\n")
+	for i, l := range lines {
+		lines[i] = "  " + l
+	}
+	return strings.Join(lines, "\n")
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
+// submit adds the user's line as a cell and runs it (command or turn) on a
+// goroutine, mirroring the inline TUI. /keys is a terminal-only cheatsheet.
+func (m notebookModel) submit(line string) (tea.Model, tea.Cmd) {
+	if line == "/keys" {
+		m.cells = append(m.cells, nbCell{label: "info", body: keyHelp()})
+		m.refresh()
+		return m, nil
+	}
+	m.cells = append(m.cells, nbCell{label: "you", body: line})
+	m.refresh()
+	m.running = true
+	app, surface := m.app, m.surface
+	ctx := context.Background()
+	if strings.HasPrefix(line, "/") {
+		go func() {
+			res, err := app.Dispatch(ctx, line)
+			switch {
+			case errors.Is(err, host.ErrUnknownCommand):
+				surface.On(host.HostEvent{Kind: host.HostTurnFailed, Err: "unknown command " + line})
+			case err != nil:
+				surface.On(host.HostEvent{Kind: host.HostTurnFailed, Err: err.Error()})
+			default:
+				surface.On(host.HostEvent{Kind: host.HostCommandResult, Command: res})
+				if res.Quit {
+					surface.prog.Quit()
+					return
+				}
+			}
+			surface.prog.Send(turnDoneMsg{})
+		}()
+	} else {
+		go func() {
+			_ = app.RunTurn(ctx, line)
+			surface.prog.Send(turnDoneMsg{})
+		}()
+	}
+	return m, nil
+}
+
+// recallHistory mirrors the inline TUI's history recall for the notebook input.
+func (m *notebookModel) recallHistory(dir int) bool {
+	if len(m.history) == 0 || strings.Contains(m.ta.Value(), "\n") {
+		return false
+	}
+	idx := m.histIdx + dir
+	if idx < 0 || idx > len(m.history) {
+		return false
+	}
+	m.histIdx = idx
+	if idx == len(m.history) {
+		m.ta.Reset()
+	} else {
+		m.ta.SetValue(m.history[idx])
+		m.ta.CursorEnd()
+	}
+	return true
+}
+
+// runNotebook starts the alt-screen notebook program with mouse support.
+func runNotebook(app *host.App, surface *nbObserver) error {
+	prog := tea.NewProgram(newNotebookModel(app, surface), tea.WithAltScreen(), tea.WithMouseCellMotion())
+	surface.prog = prog
+	_, err := prog.Run()
+	return err
+}

--- a/cmd/agentchat/notebook.go
+++ b/cmd/agentchat/notebook.go
@@ -197,6 +197,13 @@ func (m notebookModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.nav {
 			return m.updateNav(msg)
 		}
+		// Give the input its full height budget before the edit so the
+		// textarea's internal reposition only scrolls when content genuinely
+		// exceeds maxLines. Otherwise a just-inserted newline transiently
+		// over-scrolls (the old, smaller height is in effect during Update) and
+		// hides line 1 even though the grown box has room. relayout then shrinks
+		// the box back to the actual line count.
+		m.ta.SetHeight(m.maxLines)
 		nm, cmd := m.updateInsert(msg)
 		n := nm.(notebookModel)
 		n.relayout() // the input may have grown or shrunk a line

--- a/cmd/agentchat/notebook.go
+++ b/cmd/agentchat/notebook.go
@@ -247,25 +247,27 @@ func (m notebookModel) updateInsert(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.atBottom = m.vp.AtBottom()
 		return m, nil
 	case tea.KeyUp:
+		// Move within the prompt lines first; only at the top line do up-arrow
+		// history recall / transcript scroll kick in.
+		if m.ta.Line() > 0 {
+			break
+		}
 		if m.recallHistory(-1) {
 			return m, nil
 		}
-		// No history to recall (and single-line input): scroll the transcript
-		// so the arrows always do something visible.
-		if !strings.Contains(m.ta.Value(), "\n") {
-			m.vp.ScrollUp(1)
-			m.atBottom = m.vp.AtBottom()
-			return m, nil
-		}
+		m.vp.ScrollUp(1)
+		m.atBottom = m.vp.AtBottom()
+		return m, nil
 	case tea.KeyDown:
+		if m.ta.Line() < m.ta.LineCount()-1 {
+			break
+		}
 		if m.recallHistory(1) {
 			return m, nil
 		}
-		if !strings.Contains(m.ta.Value(), "\n") {
-			m.vp.ScrollDown(1)
-			m.atBottom = m.vp.AtBottom()
-			return m, nil
-		}
+		m.vp.ScrollDown(1)
+		m.atBottom = m.vp.AtBottom()
+		return m, nil
 	}
 	var cmd tea.Cmd
 	m.ta, cmd = m.ta.Update(msg)
@@ -284,7 +286,7 @@ func (m notebookModel) statusBar() string {
 	if m.nav {
 		hint = "NAV  ↑↓/jk select · space fold · g/G ends · esc/i type"
 	} else {
-		hint = "INS  type & enter · ↑↓ history then scroll · pgup/pgdn/wheel scroll · esc: fold cells"
+		hint = "INS  enter send · ctrl+j newline · ↑↓ prompt/history/scroll · pgup/pgdn/wheel · esc fold"
 	}
 	if m.running {
 		hint = "working…  " + hint

--- a/cmd/agentchat/notebook.go
+++ b/cmd/agentchat/notebook.go
@@ -110,25 +110,44 @@ type notebookModel struct {
 	history []string
 	histIdx int
 
+	maxLines      int // input auto-grows up to this many rows (0 = default)
 	width, height int
 	ready         bool
 }
 
-func newNotebookModel(app *host.App, surface *nbObserver) notebookModel {
-	m := notebookModel{app: app, surface: surface, ta: newPromptArea(), atBottom: true}
+// defaultNotebookMaxLines caps the auto-growing prompt when --notebook-max-lines
+// is unset.
+const defaultNotebookMaxLines = 20
+
+func newNotebookModel(app *host.App, surface *nbObserver, maxLines int) notebookModel {
+	if maxLines <= 0 {
+		maxLines = defaultNotebookMaxLines
+	}
+	m := notebookModel{app: app, surface: surface, ta: newPromptArea(), atBottom: true, maxLines: maxLines}
 	m.histIdx = 0
 	return m
 }
 
 func (m notebookModel) Init() tea.Cmd { return textarea.Blink }
 
-// chromeHeight is the rows the input + status bar consume; the viewport gets
-// the rest.
-const chromeHeight = 4
-
-func (m *notebookModel) layout() {
+// relayout recomputes the split between the input and the viewport. The input
+// auto-grows with its line count (1 line when empty, up to maxLines, shrinking
+// back), and the viewport takes the rest — so a long multi-line draft expands
+// the prompt while a short one keeps the transcript tall.
+func (m *notebookModel) relayout() {
+	if m.width == 0 {
+		return
+	}
+	ih := m.ta.LineCount()
+	if ih < 1 {
+		ih = 1
+	}
+	if ih > m.maxLines {
+		ih = m.maxLines
+	}
 	m.ta.SetWidth(m.width)
-	vpH := m.height - chromeHeight
+	m.ta.SetHeight(ih)
+	vpH := m.height - ih - 2 // status line + separator
 	if vpH < 1 {
 		vpH = 1
 	}
@@ -145,7 +164,7 @@ func (m notebookModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		m.width, m.height = msg.Width, msg.Height
-		m.layout()
+		m.relayout()
 		m.refresh()
 		return m, nil
 
@@ -178,7 +197,11 @@ func (m notebookModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.nav {
 			return m.updateNav(msg)
 		}
-		return m.updateInsert(msg)
+		nm, cmd := m.updateInsert(msg)
+		n := nm.(notebookModel)
+		n.relayout() // the input may have grown or shrunk a line
+		n.refresh()
+		return n, cmd
 	}
 	var cmd tea.Cmd
 	m.ta, cmd = m.ta.Update(msg)
@@ -434,8 +457,9 @@ func (m *notebookModel) recallHistory(dir int) bool {
 }
 
 // runNotebook starts the alt-screen notebook program with mouse support.
-func runNotebook(app *host.App, surface *nbObserver) error {
-	prog := tea.NewProgram(newNotebookModel(app, surface), tea.WithAltScreen(), tea.WithMouseCellMotion())
+// maxLines caps the auto-growing prompt.
+func runNotebook(app *host.App, surface *nbObserver, maxLines int) error {
+	prog := tea.NewProgram(newNotebookModel(app, surface, maxLines), tea.WithAltScreen(), tea.WithMouseCellMotion())
 	surface.prog = prog
 	_, err := prog.Run()
 	return err

--- a/cmd/agentchat/notebook_test.go
+++ b/cmd/agentchat/notebook_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/panyam/mcpkit/agent/host"
+)
+
+func send(m notebookModel, msg tea.Msg) notebookModel {
+	nm, _ := m.Update(msg)
+	return nm.(notebookModel)
+}
+
+func TestNBLabelFor(t *testing.T) {
+	cases := map[host.HostEventKind]string{
+		host.HostTurnDone:      "assistant",
+		host.HostTurnFailed:    "error",
+		host.HostCommandResult: "command",
+		host.HostSkillsLoaded:  "info",
+	}
+	for k, want := range cases {
+		if got := nbLabelFor(k); got != want {
+			t.Errorf("nbLabelFor(%v) = %q, want %q", k, got, want)
+		}
+	}
+}
+
+func TestNotebook_CellAppendedAndRendered(t *testing.T) {
+	m := newNotebookModel(nil, nil)
+	m = send(m, nbCellMsg{label: "assistant", body: "hi\nthere"})
+	if len(m.cells) != 1 {
+		t.Fatalf("cells = %d, want 1", len(m.cells))
+	}
+	out := m.renderCells()
+	if !strings.Contains(out, "▾ assistant") {
+		t.Fatalf("expanded header missing:\n%s", out)
+	}
+	if !strings.Contains(out, "  hi") || !strings.Contains(out, "  there") {
+		t.Fatalf("body not indented:\n%s", out)
+	}
+}
+
+func TestNotebook_FoldToggleInNav(t *testing.T) {
+	m := newNotebookModel(nil, nil)
+	m = send(m, nbCellMsg{label: "assistant", body: "long answer here"})
+	// Esc enters nav mode selecting the last cell.
+	m = send(m, tea.KeyMsg{Type: tea.KeyEsc})
+	if !m.nav || m.sel != 0 {
+		t.Fatalf("esc did not enter nav on last cell: nav=%v sel=%d", m.nav, m.sel)
+	}
+	// space folds the selected cell.
+	m = send(m, tea.KeyMsg{Type: tea.KeySpace})
+	if !m.cells[0].collapsed {
+		t.Fatal("space did not collapse the selected cell")
+	}
+	out := m.renderCells()
+	if !strings.Contains(out, "▸ assistant · long answer here") {
+		t.Fatalf("collapsed header/snippet wrong:\n%s", out)
+	}
+	// esc/i returns to insert.
+	m = send(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("i")})
+	if m.nav {
+		t.Fatal("i did not return to insert mode")
+	}
+}
+
+func TestNotebook_KeysCommandAddsInfoCell(t *testing.T) {
+	m := newNotebookModel(nil, nil)
+	nm, _ := m.submit("/keys")
+	m = nm.(notebookModel)
+	if len(m.cells) != 1 || m.cells[0].label != "info" {
+		t.Fatalf("/keys did not add an info cell: %+v", m.cells)
+	}
+	if !strings.Contains(m.cells[0].body, "ctrl+w") {
+		t.Fatalf("/keys cell body is not the cheatsheet:\n%s", m.cells[0].body)
+	}
+}
+
+func TestNotebook_LiveRendersAtBottom(t *testing.T) {
+	m := newNotebookModel(nil, nil)
+	m = send(m, nbLiveMsg("streaming answer"))
+	out := m.renderCells()
+	if !strings.Contains(out, "▾ assistant") || !strings.Contains(out, "  streaming answer") {
+		t.Fatalf("live turn not rendered:\n%s", out)
+	}
+}
+
+func TestUIMode(t *testing.T) {
+	for flag, want := range map[string]string{"plain": "plain", "tui": "tui", "notebook": "notebook"} {
+		if got := uiMode(flag); got != want {
+			t.Errorf("uiMode(%q) = %q, want %q", flag, got, want)
+		}
+	}
+	// auto under test (stdout not a char device) resolves to plain
+	if got := uiMode("auto"); got != "plain" {
+		t.Errorf("uiMode(auto) under test = %q, want plain", got)
+	}
+}
+
+func TestNotebook_EnterSubmitsAndViewRenders(t *testing.T) {
+	m := newNotebookModel(nil, nil)
+	m = send(m, tea.WindowSizeMsg{Width: 80, Height: 24}) // sets ready + viewport size
+	m.ta.SetValue("/keys")
+	m = send(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if len(m.cells) != 1 || m.cells[0].label != "info" {
+		t.Fatalf("Enter did not submit /keys into a cell: %+v", m.cells)
+	}
+	if !strings.Contains(m.View(), "delete previous word") {
+		t.Fatalf("submitted cheatsheet not visible in View():\n%s", m.View())
+	}
+}

--- a/cmd/agentchat/notebook_test.go
+++ b/cmd/agentchat/notebook_test.go
@@ -112,3 +112,33 @@ func TestNotebook_EnterSubmitsAndViewRenders(t *testing.T) {
 		t.Fatalf("submitted cheatsheet not visible in View():\n%s", m.View())
 	}
 }
+
+func TestNotebook_UpArrowScrollsWhenNoHistory(t *testing.T) {
+	m := newNotebookModel(nil, nil)
+	m = send(m, tea.WindowSizeMsg{Width: 60, Height: 8}) // small viewport (~4 rows)
+	// add enough content to overflow the viewport
+	for i := 0; i < 6; i++ {
+		m = send(m, nbCellMsg{label: "assistant", body: "line one\nline two\nline three"})
+	}
+	if !m.atBottom {
+		t.Fatal("should auto-follow to bottom after new cells")
+	}
+	// up-arrow with no history scrolls the transcript up (off the bottom)
+	m = send(m, tea.KeyMsg{Type: tea.KeyUp})
+	if m.atBottom {
+		t.Fatal("up-arrow did not scroll the transcript (still at bottom)")
+	}
+}
+
+func TestNotebook_RuleBetweenCells(t *testing.T) {
+	m := newNotebookModel(nil, nil)
+	m = send(m, tea.WindowSizeMsg{Width: 40, Height: 20})
+	m = send(m, nbCellMsg{label: "you", body: "hi"})
+	if strings.Contains(m.renderCells(), "─") {
+		t.Fatal("a single cell should have no delimiter")
+	}
+	m = send(m, nbCellMsg{label: "assistant", body: "hello"})
+	if !strings.Contains(m.renderCells(), "─") {
+		t.Fatalf("two cells should have a delimiter between them:\n%s", m.renderCells())
+	}
+}

--- a/cmd/agentchat/notebook_test.go
+++ b/cmd/agentchat/notebook_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
@@ -140,5 +141,40 @@ func TestNotebook_RuleBetweenCells(t *testing.T) {
 	m = send(m, nbCellMsg{label: "assistant", body: "hello"})
 	if !strings.Contains(m.renderCells(), "─") {
 		t.Fatalf("two cells should have a delimiter between them:\n%s", m.renderCells())
+	}
+}
+
+func TestPromptArea_NewlineOffEnter(t *testing.T) {
+	keys := newPromptArea().KeyMap.InsertNewline.Keys()
+	if !slices.Contains(keys, "ctrl+j") {
+		t.Fatalf("InsertNewline keys = %v, want ctrl+j", keys)
+	}
+	if slices.Contains(keys, "enter") {
+		t.Fatalf("InsertNewline still on enter (would break submit): %v", keys)
+	}
+}
+
+func TestNotebook_CtrlJInsertsNewline(t *testing.T) {
+	m := newNotebookModel(nil, nil)
+	m = send(m, tea.WindowSizeMsg{Width: 40, Height: 20})
+	m.ta.SetValue("abc")
+	m.ta.CursorEnd()
+	m = send(m, tea.KeyMsg{Type: tea.KeyCtrlJ})
+	if !strings.Contains(m.ta.Value(), "\n") {
+		t.Fatalf("ctrl+j did not insert a newline: %q", m.ta.Value())
+	}
+}
+
+func TestNotebook_UpMovesWithinPromptFirst(t *testing.T) {
+	m := newNotebookModel(nil, nil)
+	m = send(m, tea.WindowSizeMsg{Width: 40, Height: 20})
+	m.ta.SetValue("line1\nline2")
+	m.ta.CursorEnd()
+	if m.ta.Line() != 1 {
+		t.Fatalf("setup: cursor row = %d, want 1", m.ta.Line())
+	}
+	m = send(m, tea.KeyMsg{Type: tea.KeyUp}) // moves within prompt, not history/scroll
+	if m.ta.Line() != 0 {
+		t.Fatalf("up did not move the cursor up within the prompt: row = %d", m.ta.Line())
 	}
 }

--- a/cmd/agentchat/notebook_test.go
+++ b/cmd/agentchat/notebook_test.go
@@ -205,3 +205,19 @@ func TestNotebook_PromptAutoGrowsAndClamps(t *testing.T) {
 		t.Fatalf("after clearing, height = %d, want 1", h)
 	}
 }
+
+func TestNotebook_FirstPromptLineStaysVisible(t *testing.T) {
+	m := newNotebookModel(nil, nil, 20)
+	m = send(m, tea.WindowSizeMsg{Width: 40, Height: 30})
+	typ := func(s string) { m = send(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}) }
+	nl := func() { m = send(m, tea.KeyMsg{Type: tea.KeyCtrlJ}) }
+	typ("FIRSTLINE")
+	nl()
+	typ("second")
+	nl()
+	typ("third")
+	// within the maxLines budget, the first line must not have scrolled off
+	if !strings.Contains(m.ta.View(), "FIRSTLINE") {
+		t.Fatalf("first prompt line scrolled off within budget:\n%s", m.ta.View())
+	}
+}

--- a/cmd/agentchat/notebook_test.go
+++ b/cmd/agentchat/notebook_test.go
@@ -30,7 +30,7 @@ func TestNBLabelFor(t *testing.T) {
 }
 
 func TestNotebook_CellAppendedAndRendered(t *testing.T) {
-	m := newNotebookModel(nil, nil)
+	m := newNotebookModel(nil, nil, 20)
 	m = send(m, nbCellMsg{label: "assistant", body: "hi\nthere"})
 	if len(m.cells) != 1 {
 		t.Fatalf("cells = %d, want 1", len(m.cells))
@@ -45,7 +45,7 @@ func TestNotebook_CellAppendedAndRendered(t *testing.T) {
 }
 
 func TestNotebook_FoldToggleInNav(t *testing.T) {
-	m := newNotebookModel(nil, nil)
+	m := newNotebookModel(nil, nil, 20)
 	m = send(m, nbCellMsg{label: "assistant", body: "long answer here"})
 	// Esc enters nav mode selecting the last cell.
 	m = send(m, tea.KeyMsg{Type: tea.KeyEsc})
@@ -69,7 +69,7 @@ func TestNotebook_FoldToggleInNav(t *testing.T) {
 }
 
 func TestNotebook_KeysCommandAddsInfoCell(t *testing.T) {
-	m := newNotebookModel(nil, nil)
+	m := newNotebookModel(nil, nil, 20)
 	nm, _ := m.submit("/keys")
 	m = nm.(notebookModel)
 	if len(m.cells) != 1 || m.cells[0].label != "info" {
@@ -81,7 +81,7 @@ func TestNotebook_KeysCommandAddsInfoCell(t *testing.T) {
 }
 
 func TestNotebook_LiveRendersAtBottom(t *testing.T) {
-	m := newNotebookModel(nil, nil)
+	m := newNotebookModel(nil, nil, 20)
 	m = send(m, nbLiveMsg("streaming answer"))
 	out := m.renderCells()
 	if !strings.Contains(out, "▾ assistant") || !strings.Contains(out, "  streaming answer") {
@@ -102,7 +102,7 @@ func TestUIMode(t *testing.T) {
 }
 
 func TestNotebook_EnterSubmitsAndViewRenders(t *testing.T) {
-	m := newNotebookModel(nil, nil)
+	m := newNotebookModel(nil, nil, 20)
 	m = send(m, tea.WindowSizeMsg{Width: 80, Height: 24}) // sets ready + viewport size
 	m.ta.SetValue("/keys")
 	m = send(m, tea.KeyMsg{Type: tea.KeyEnter})
@@ -115,7 +115,7 @@ func TestNotebook_EnterSubmitsAndViewRenders(t *testing.T) {
 }
 
 func TestNotebook_UpArrowScrollsWhenNoHistory(t *testing.T) {
-	m := newNotebookModel(nil, nil)
+	m := newNotebookModel(nil, nil, 20)
 	m = send(m, tea.WindowSizeMsg{Width: 60, Height: 8}) // small viewport (~4 rows)
 	// add enough content to overflow the viewport
 	for i := 0; i < 6; i++ {
@@ -132,7 +132,7 @@ func TestNotebook_UpArrowScrollsWhenNoHistory(t *testing.T) {
 }
 
 func TestNotebook_RuleBetweenCells(t *testing.T) {
-	m := newNotebookModel(nil, nil)
+	m := newNotebookModel(nil, nil, 20)
 	m = send(m, tea.WindowSizeMsg{Width: 40, Height: 20})
 	m = send(m, nbCellMsg{label: "you", body: "hi"})
 	if strings.Contains(m.renderCells(), "─") {
@@ -155,7 +155,7 @@ func TestPromptArea_NewlineOffEnter(t *testing.T) {
 }
 
 func TestNotebook_CtrlJInsertsNewline(t *testing.T) {
-	m := newNotebookModel(nil, nil)
+	m := newNotebookModel(nil, nil, 20)
 	m = send(m, tea.WindowSizeMsg{Width: 40, Height: 20})
 	m.ta.SetValue("abc")
 	m.ta.CursorEnd()
@@ -166,7 +166,7 @@ func TestNotebook_CtrlJInsertsNewline(t *testing.T) {
 }
 
 func TestNotebook_UpMovesWithinPromptFirst(t *testing.T) {
-	m := newNotebookModel(nil, nil)
+	m := newNotebookModel(nil, nil, 20)
 	m = send(m, tea.WindowSizeMsg{Width: 40, Height: 20})
 	m.ta.SetValue("line1\nline2")
 	m.ta.CursorEnd()
@@ -176,5 +176,32 @@ func TestNotebook_UpMovesWithinPromptFirst(t *testing.T) {
 	m = send(m, tea.KeyMsg{Type: tea.KeyUp}) // moves within prompt, not history/scroll
 	if m.ta.Line() != 0 {
 		t.Fatalf("up did not move the cursor up within the prompt: row = %d", m.ta.Line())
+	}
+}
+
+func TestNotebook_PromptAutoGrowsAndClamps(t *testing.T) {
+	m := newNotebookModel(nil, nil, 4) // maxLines = 4
+	m = send(m, tea.WindowSizeMsg{Width: 40, Height: 30})
+	if h := m.ta.Height(); h != 1 {
+		t.Fatalf("empty prompt height = %d, want 1", h)
+	}
+	// add newlines with ctrl+j; the box grows with line count
+	m = send(m, tea.KeyMsg{Type: tea.KeyCtrlJ})
+	m = send(m, tea.KeyMsg{Type: tea.KeyCtrlJ})
+	if h := m.ta.Height(); h != 3 {
+		t.Fatalf("after 2 newlines height = %d, want 3", h)
+	}
+	// grow past the cap — clamps at maxLines
+	for i := 0; i < 10; i++ {
+		m = send(m, tea.KeyMsg{Type: tea.KeyCtrlJ})
+	}
+	if h := m.ta.Height(); h != 4 {
+		t.Fatalf("height should clamp at maxLines=4, got %d", h)
+	}
+	// clearing shrinks it back
+	m.ta.SetValue("")
+	m = send(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")})
+	if h := m.ta.Height(); h != 1 {
+		t.Fatalf("after clearing, height = %d, want 1", h)
 	}
 }

--- a/cmd/agentchat/tui.go
+++ b/cmd/agentchat/tui.go
@@ -92,7 +92,10 @@ type tuiModel struct {
 	pending string
 }
 
-func newTUIModel(app *host.App, surface *tuiObserver) tuiModel {
+// newPromptArea builds the shared input textarea used by both TUI surfaces
+// (inline and notebook): the readline keybindings (issue #1065 — Ctrl word-nav
+// so it works without Option-as-Meta) live here so both get them.
+func newPromptArea() textarea.Model {
 	ta := textarea.New()
 	ta.Placeholder = "message, or /command (Tab completes, ↑↓ history, /keys for editing keys)"
 	ta.Prompt = "› "
@@ -101,12 +104,15 @@ func newTUIModel(app *host.App, surface *tuiObserver) tuiModel {
 	// The default KeyMap binds word navigation to Meta only (alt+←/→, alt+b/f),
 	// which does nothing on terminals that don't send Option as Meta (the macOS
 	// default). Add the Ctrl variants so word motion works out of the box; the
-	// alt bindings stay for those who have Meta enabled. Everything else the
-	// user needs is already Ctrl-based (a/e/w/k/u) — see /keys.
+	// alt bindings stay for those who have Meta enabled.
 	ta.KeyMap.WordForward.SetKeys(append(ta.KeyMap.WordForward.Keys(), "ctrl+right")...)
 	ta.KeyMap.WordBackward.SetKeys(append(ta.KeyMap.WordBackward.Keys(), "ctrl+left")...)
 	ta.Focus()
-	m := tuiModel{app: app, surface: surface, ta: ta}
+	return ta
+}
+
+func newTUIModel(app *host.App, surface *tuiObserver) tuiModel {
+	m := tuiModel{app: app, surface: surface, ta: newPromptArea()}
 	m.histIdx = 0
 	return m
 }
@@ -243,31 +249,44 @@ func keyHelp() string {
 	}, "\n")
 }
 
-// completeTab completes a leading slash command against the registry: a
-// unique command-name match is inlined; an argument prefix is completed
-// via the command's Complete hook (providers, sessions, ...).
-func (m *tuiModel) completeTab() {
-	val := m.ta.Value()
+func (m *tuiModel) completeTab() { tabComplete(&m.ta, m.app) }
+
+// tabComplete completes a leading slash command against the registry: a
+// unique command-name match is inlined; an argument prefix is completed via
+// the command's Complete hook (providers, sessions, ...). Shared by both TUI
+// surfaces.
+func tabComplete(ta *textarea.Model, app *host.App) {
+	val := ta.Value()
 	if !strings.HasPrefix(val, "/") {
 		return
 	}
-	reg := m.app.Commands()
+	reg := app.Commands()
 	word, rest, hasArg := strings.Cut(val, " ")
 	if !hasArg {
 		// completing the command name
 		if names := reg.Match(word); len(names) == 1 {
-			m.ta.SetValue("/" + names[0] + " ")
-			m.ta.CursorEnd()
+			ta.SetValue("/" + names[0] + " ")
+			ta.CursorEnd()
 		}
 		return
 	}
 	// completing an argument
 	if cmd, ok := reg.Lookup(word); ok && cmd.Complete != nil {
 		if opts := cmd.Complete(strings.TrimSpace(rest)); len(opts) == 1 {
-			m.ta.SetValue(word + " " + opts[0])
-			m.ta.CursorEnd()
+			ta.SetValue(word + " " + opts[0])
+			ta.CursorEnd()
 		}
 	}
+}
+
+// snippet trims s to one line of at most n runes with an ellipsis, for
+// collapsed cell headers.
+func snippet(s string, n int) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
 }
 
 // recallHistory replaces the input with a previous/next submitted line.
@@ -295,20 +314,26 @@ func (m *tuiModel) recallHistory(dir int) bool {
 	return true
 }
 
-// wantTUI resolves the --ui flag: "tui"/"plain" force the mode; "auto"
-// (the default) picks the TUI only when stdout is an interactive
-// terminal, so piped or CI runs get the scriptable scanner REPL.
-func wantTUI(mode string) bool {
-	switch mode {
-	case "tui":
-		return true
-	case "plain":
-		return false
+// uiMode resolves the --ui flag to a concrete surface: "plain" (the scriptable
+// scanner REPL), "tui" (the default inline bubbletea surface), or "notebook"
+// (the opt-in alt-screen surface). "auto" (the default flag value) picks "tui"
+// when stdout is an interactive terminal and "plain" otherwise (pipes / CI).
+func uiMode(flag string) string {
+	switch flag {
+	case "plain", "tui", "notebook":
+		return flag
 	default:
 		fi, err := os.Stdout.Stat()
-		return err == nil && (fi.Mode()&os.ModeCharDevice) != 0
+		if err == nil && (fi.Mode()&os.ModeCharDevice) != 0 {
+			return "tui"
+		}
+		return "plain"
 	}
 }
+
+// wantTUI reports whether --ui resolves to an interactive bubbletea surface
+// (inline tui or notebook) rather than the plain REPL.
+func wantTUI(mode string) bool { return uiMode(mode) != "plain" }
 
 // runTUI starts the inline bubbletea program (no alt-screen): the input
 // and the live turn render at the bottom while finished segments commit to

--- a/cmd/agentchat/tui.go
+++ b/cmd/agentchat/tui.go
@@ -107,6 +107,11 @@ func newPromptArea() textarea.Model {
 	// alt bindings stay for those who have Meta enabled.
 	ta.KeyMap.WordForward.SetKeys(append(ta.KeyMap.WordForward.Keys(), "ctrl+right")...)
 	ta.KeyMap.WordBackward.SetKeys(append(ta.KeyMap.WordBackward.Keys(), "ctrl+left")...)
+	// Enter submits (both surfaces intercept it), so rebind "insert newline" off
+	// Enter and onto keys that reach the textarea. ctrl+j (keyLF) is the
+	// reliable one everywhere; shift+enter works only in terminals that
+	// disambiguate it (kitty keyboard protocol), alt+enter in most others.
+	ta.KeyMap.InsertNewline.SetKeys("ctrl+j", "shift+enter", "alt+enter")
 	ta.Focus()
 	return ta
 }
@@ -244,6 +249,7 @@ func keyHelp() string {
 		"  ctrl+w                delete previous word",
 		"  ctrl+k / ctrl+u       delete to end / start of line",
 		"  ctrl+home / ctrl+end  start / end of input",
+		"  ctrl+j               insert a newline (also shift+enter / alt+enter)",
 		"  ↑ / ↓  history    Tab  complete    Enter  send    ctrl+c  quit",
 		"  With Option-as-Meta on: alt+←/→ or alt+b/f word nav, alt+d delete-word-forward, alt+</> input ends.",
 	}, "\n")

--- a/examples/agents/kitchen-sink/Makefile
+++ b/examples/agents/kitchen-sink/Makefile
@@ -41,7 +41,7 @@ export ACTIVE SESSION_STORE SESSION OFFLOAD_THRESHOLD EMBED_MODEL EMBED_URL EMBE
        EMBED_API_KEY_ENV COMPACT_TOKENS EXPORTER OTLP_ENDPOINT UI \
        PG_HOST PG_PORT PG_DB PG_USER
 
-.PHONY: check preflight run demo allup alldown up obs-up psql mem server build
+.PHONY: check preflight run demo note allup alldown up obs-up psql mem server build
 
 check: ## Probe every backend; print bring-up instructions for what's missing.
 	@bash preflight.sh
@@ -50,6 +50,9 @@ preflight: check
 run: ## Preflight, boot the demo server, launch agentchat with everything wired.
 	@bash run.sh
 demo: run
+
+note: ## Same as run, but the alt-screen notebook UI (scrollable, foldable cells).
+	@UI=notebook bash run.sh
 
 allup: ## Bring up ALL stacks kitchen-sink can use (backends + observability).
 	cd ../../../docker/backends && $(MAKE) up

--- a/examples/agents/kitchen-sink/README.md
+++ b/examples/agents/kitchen-sink/README.md
@@ -43,7 +43,8 @@ flag, because it is a separate endpoint from the chat model.
 ```bash
 just allup      # postgres+pgvector + observability stacks (or: make allup)
 just check      # probe everything; prints how to fix whatever is down
-just run        # preflight, boot the demo MCP server, launch agentchat (TUI)
+just run        # preflight, boot the demo MCP server, launch agentchat (inline TUI)
+just note       # same, but the alt-screen notebook UI (scrollable, foldable cells)
 # ... chat ...
 just alldown    # tear the stacks back down
 ```

--- a/examples/agents/kitchen-sink/justfile
+++ b/examples/agents/kitchen-sink/justfile
@@ -61,6 +61,10 @@ run:
 # Alias for run.
 demo: run
 
+# Same as run, but the alt-screen notebook UI (scrollable, foldable cells).
+note:
+    @UI=notebook bash run.sh
+
 # Bring up ALL stacks kitchen-sink can use (backends + observability).
 allup:
     cd ../../../docker/backends && just up


### PR DESCRIPTION
## What changes

Adds `--ui notebook`, an opt-in alt-screen surface alongside `auto|tui|plain` (#1001). Where the inline `tui` relies on the terminal's native scrollback — which clips the transcript past the session banner (the #1066 symptom) — `notebook` runs an alt-screen bubbletea program with a **managed viewport that owns its own scroll**, and a transcript of **collapsible cells**. `tui` stays the default; notebook is opt-in because alt-screen takes the whole screen, breaks native copy/paste + shell scroll, and clears on exit.

## Reviewer's guide

1. [cmd/agentchat/notebook.go](https://github.com/panyam/mcpkit/pull/1069/files#diff-8a79677a206f62f0abeebce75abd2fbafac2dc1be85310113e702bebc42624b1) — start here. `nbObserver` (splits the HostEvent stream into labeled cells at boundaries, reusing `NewTerminalRenderer` for bodies), `notebookModel` (viewport + cells + input, two modes), `renderCells`, `updateNav`/`updateInsert`, `runNotebook`.
2. [cmd/agentchat/notebook_test.go](https://github.com/panyam/mcpkit/pull/1069/files#diff-12e612880a5d601118bba88764d9d1ff5815b9406c3ffb4e5a61ca6e9c4188a1) — acceptance: label mapping, cell append/render, fold toggle in NAV, `/keys` cell, live rendering, `uiMode`, and a `WindowSizeMsg→Enter→submit→View` path test.
3. [cmd/agentchat/tui.go](https://github.com/panyam/mcpkit/pull/1069/files#diff-0e29207287df07cecf17e04df9f99e726ae789983f7e3ce007bb6282029b4db6) — extracted `newPromptArea` (shared input + #1065 keybindings), `tabComplete`, `snippet`; new `uiMode` resolver (`wantTUI` now derives from it).
4. [cmd/agentchat/main.go](https://github.com/panyam/mcpkit/pull/1069/files#diff-ce3956549c93b4983f18090136a2139c3c92d38408e923245f5e9ba628bcc98a) — `--ui` gains `notebook`; wire the surface + `runNotebook`.
5. [cmd/agentchat/README.md](https://github.com/panyam/mcpkit/pull/1069/files#diff-ffb24bf0bf1787e7af2eee0cd297abb3635a9ad7720753f345e3abdd7a503592) — the Interfaces section.

## Decision log

- **Hand-rolled, not demokit's `notebook/`.** demokit's module is mature but built around its demo-runner paradigm (modes/docks/inputs, a private model); adapting HostEvents + textarea + slash-commands onto it is a big lift and adds an `mcpkit → demokit` dependency. Hand-rolling a focused `viewport` + cell list keeps the library repo dep-clean and matches `tui.go`'s "presentation only, all behavior via App" layering.
- **Cells at boundary granularity** (turn / command / info / error), each foldable. Tool calls render inside the assistant-turn body. Per-tool-call sub-cells are a deferred refinement.
- **Two modes (INS/NAV)** so a single always-focused input doesn't have to overload `↑↓`/`space` for both typing and cell nav. Esc toggles.
- **Auto-follow only when already at the bottom** — new output doesn't yank you down while you're scrolled up reading history.

## How it works

```
nbObserver.On(ev):                          # host goroutine
  render ev into buf (NewTerminalRenderer)
  if boundary(ev): send nbCellMsg{label(ev), buf}; reset buf
  else:            send nbLiveMsg(buf)       # streaming turn

notebookModel.Update:
  nbCellMsg -> append cell; refresh (follow if atBottom)
  nbLiveMsg -> set live;    refresh
  KeyMsg: NAV? updateNav (jk move sel, space fold, g/G ends, esc/i insert)
          else updateInsert (enter submit, tab complete, pgup/dn scroll, esc->nav)

renderCells: for each cell -> "▸/▾ label [· snippet]" + indented body (unless folded)
             + the live turn at the end
View: viewport.View() + statusBar(mode hints) + input
```

## Risk / blast radius

- **Additive and opt-in.** `tui`/`plain` unchanged; `wantTUI` refactored to derive from `uiMode` (existing `TestWantTUI` still green). No agent/host change.
- **Tests covering this:** the notebook_test suite above; plus a pty smoke confirmed the real program enters alt-screen and renders the status bar + fold markers.
- **Be paranoid about:** the INS/NAV key routing and the auto-follow gate (covered), and that `newPromptArea` extraction preserved the inline TUI's #1065 keybindings (shared now).

## Before / after

```
Scrolling:
  tui (inline):  transcript relies on terminal scrollback; clips past the
                 session banner (#1066)
  notebook:      viewport owns scroll — pgup/pgdn + mouse wheel page through the
                 whole transcript, independent of the shell

Folding:
  tui:           none
  notebook:      esc -> NAV, jk to a cell, space folds it to "▸ label · <snippet>"
```

## Out of scope (deferred)

- Per-tool-call sub-cells (fold each tool within a turn) — follow-up.
- Serializable HostEvent snapshots for a web surface — tracked separately (per the issue).

