### PR TITLE
feat(agent/host): paged + searchable session picker (#1000)

### DIFF
--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -50,6 +50,12 @@ type App struct {
 	store agent.RunStore
 	runID string
 
+	// sessionsMu guards sessionsCursor, the paging position the /sessions
+	// picker remembers so "/sessions more" advances (the store cursor is
+	// opaque, so the host holds where the last page ended).
+	sessionsMu     sync.Mutex
+	sessionsCursor string
+
 	// toolResultStore backs tool-result offloading when Config.Offload
 	// is set; nil when offloading is off.
 	toolResultStore agent.ToolResultStore

--- a/agent/host/commands.go
+++ b/agent/host/commands.go
@@ -2,6 +2,7 @@ package host
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"strings"
 
@@ -9,6 +10,22 @@ import (
 	"github.com/panyam/mcpkit/client"
 	"github.com/panyam/mcpkit/core"
 )
+
+// sessionsResult builds the CmdSessions result for the /sessions picker: the
+// runs on this page, the active run, and a footer note.
+func sessionsResult(a *App, runs []agent.RunInfo, note string) CmdResult {
+	return CmdResult{Kind: CmdSessions, Sessions: runs, RunID: a.RunID(), SessionsNote: note}
+}
+
+// sessionsFooter is the hint under a page of sessions: how many showed and how
+// to page / search / resume.
+func sessionsFooter(shown int, hasMore bool, _ string) string {
+	f := fmt.Sprintf("%d shown", shown)
+	if hasMore {
+		f += " · /sessions more for older"
+	}
+	return f + " · /sessions find <text> to search · /sessions <id> to resume"
+}
 
 // CmdKind tags a CmdResult so a surface renders it without re-parsing.
 // One kind per distinct command output shape.
@@ -56,6 +73,7 @@ type CmdResult struct {
 	Tasks          []*client.BackgroundTask
 	Approval       *agent.TieredApproval
 	Sessions       []agent.RunInfo
+	SessionsNote   string
 	Quit           bool
 }
 
@@ -216,26 +234,51 @@ func (a *App) registerBuiltinCommands() {
 			return CmdResult{Kind: CmdSession, RunID: a.RunID()}, nil
 		}})
 
-	r.Register(&Command{Name: "sessions", Help: "list persisted sessions; /sessions <id> switches",
+	r.Register(&Command{Name: "sessions", Help: "list recent sessions; 'more' pages, 'find <text>' searches, '<id>' resumes",
 		Run: func(ctx context.Context, args string) (CmdResult, error) {
-			if args != "" {
+			args = strings.TrimSpace(args)
+			switch {
+			case args == "":
+				page, err := a.SessionsPage(ctx, "")
+				if err != nil {
+					return CmdResult{}, err
+				}
+				return sessionsResult(a, page.Runs, sessionsFooter(len(page.Runs), page.HasMore, "")), nil
+			case args == "more":
+				page, err := a.PageMore(ctx)
+				if err != nil {
+					return CmdResult{}, err
+				}
+				if len(page.Runs) == 0 {
+					return CmdResult{Kind: CmdMessage, Message: "no more sessions"}, nil
+				}
+				return sessionsResult(a, page.Runs, sessionsFooter(len(page.Runs), page.HasMore, "")), nil
+			case strings.HasPrefix(args, "find "):
+				q := strings.TrimSpace(strings.TrimPrefix(args, "find "))
+				infos, err := a.SearchSessions(ctx, q)
+				if err != nil {
+					return CmdResult{}, err
+				}
+				return sessionsResult(a, infos, fmt.Sprintf("%d match(es) for %q", len(infos), q)), nil
+			default:
+				// resume by id
 				if err := a.Resume(ctx, args); err != nil {
 					return CmdResult{}, err
 				}
 				return CmdResult{Kind: CmdSession, RunID: args}, nil
 			}
-			infos, err := a.Sessions(ctx)
-			if err != nil {
-				return CmdResult{}, err
-			}
-			return CmdResult{Kind: CmdSessions, Sessions: infos, RunID: a.RunID()}, nil
 		},
 		Complete: func(prefix string) []string {
+			var out []string
+			for _, sub := range []string{"more", "find"} {
+				if strings.HasPrefix(sub, prefix) {
+					out = append(out, sub)
+				}
+			}
 			infos, err := a.Sessions(context.Background())
 			if err != nil {
-				return nil
+				return out
 			}
-			var out []string
 			for _, r := range infos {
 				if strings.HasPrefix(r.ID, prefix) {
 					out = append(out, r.ID)

--- a/agent/host/persistence.go
+++ b/agent/host/persistence.go
@@ -3,6 +3,7 @@ package host
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/panyam/mcpkit/agent"
 )
@@ -64,19 +65,93 @@ func (a *App) AttachRun(ctx context.Context, runID string) error {
 	return a.resumeLocked(ctx, runID)
 }
 
-// Sessions lists the persisted runs newest-first (the /sessions picker),
-// or an error when no RunStore is configured. It returns the first page;
-// a surface that needs more pages the store's cursor via ListRuns
-// directly.
+// Sessions lists the first page of persisted runs newest-first (the
+// /sessions picker), or an error when no RunStore is configured. It is the
+// first-page shim over SessionsPage; a surface that pages calls SessionsPage.
 func (a *App) Sessions(ctx context.Context) ([]agent.RunInfo, error) {
+	page, err := a.SessionsPage(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+	return page.Runs, nil
+}
+
+// SessionPage is one page of the session picker: the runs on this page and
+// HasMore reporting whether another page exists (the underlying cursor is
+// remembered on the App so the next SessionsPage("") advance-from-last works
+// via the /sessions "more" flow — callers page by empty cursor for the first
+// page, then let the host thread its remembered cursor).
+type SessionPage struct {
+	Runs    []agent.RunInfo
+	HasMore bool
+}
+
+// SessionsPage returns one page of runs newest-first (gorm / in-memory order
+// recency for free; redis SCAN is unordered — see the runstore docs). An empty
+// cursor starts from the most recent; any other value continues a prior page.
+// The response's next cursor is remembered on the App so PageMore advances
+// without the surface handling the opaque cursor. Errors when no RunStore is
+// configured.
+func (a *App) SessionsPage(ctx context.Context, cursor string) (SessionPage, error) {
+	if a.store == nil {
+		return SessionPage{}, fmt.Errorf("host: no RunStore configured")
+	}
+	resp, err := a.store.ListRuns(ctx, agent.ListRunsRequest{Cursor: cursor})
+	if err != nil {
+		return SessionPage{}, fmt.Errorf("host: listing sessions: %w", err)
+	}
+	a.sessionsMu.Lock()
+	a.sessionsCursor = resp.NextCursor
+	a.sessionsMu.Unlock()
+	return SessionPage{Runs: resp.Runs, HasMore: resp.NextCursor != ""}, nil
+}
+
+// PageMore returns the next page after the last SessionsPage call (the
+// /sessions "more" flow), or an empty page when there is nothing more.
+func (a *App) PageMore(ctx context.Context) (SessionPage, error) {
+	a.sessionsMu.Lock()
+	cursor := a.sessionsCursor
+	a.sessionsMu.Unlock()
+	if cursor == "" {
+		return SessionPage{}, nil
+	}
+	return a.SessionsPage(ctx, cursor)
+}
+
+// maxSessionSearchScan bounds SearchSessions: id-substring search has no
+// store-side filter, so the host walks pages — capped so a huge run set can't
+// turn a search into an unbounded scan. Content search is a future index.
+const maxSessionSearchScan = 1000
+
+// SearchSessions returns runs whose ID contains query (case-insensitive),
+// newest-first, walking pages up to maxSessionSearchScan runs. The scan is
+// bounded, so a match past the cap is not found — a deliberate limit until a
+// real search index exists.
+func (a *App) SearchSessions(ctx context.Context, query string) ([]agent.RunInfo, error) {
 	if a.store == nil {
 		return nil, fmt.Errorf("host: no RunStore configured")
 	}
-	resp, err := a.store.ListRuns(ctx, agent.ListRunsRequest{})
-	if err != nil {
-		return nil, fmt.Errorf("host: listing sessions: %w", err)
+	q := strings.ToLower(query)
+	var out []agent.RunInfo
+	cursor := ""
+	scanned := 0
+	for scanned < maxSessionSearchScan {
+		resp, err := a.store.ListRuns(ctx, agent.ListRunsRequest{Cursor: cursor})
+		if err != nil {
+			return nil, fmt.Errorf("host: searching sessions: %w", err)
+		}
+		for _, r := range resp.Runs {
+			scanned++
+			if strings.Contains(strings.ToLower(r.ID), q) {
+				out = append(out, r)
+			}
+		}
+		if resp.NextCursor == "" {
+			break
+		}
+		cursor = resp.NextCursor
 	}
-	return resp.Runs, nil
+	return out, nil
 }
 
 // Resume switches the session to an existing run: its persisted

--- a/agent/host/render.go
+++ b/agent/host/render.go
@@ -276,6 +276,9 @@ func (r *renderer) command(res CmdResult) {
 		r.session(res.RunID)
 	case CmdSessions:
 		r.sessions(res.Sessions, res.RunID)
+		if res.SessionsNote != "" {
+			fmt.Fprintf(r.out, "%s\n", r.dim(res.SessionsNote))
+		}
 	case CmdTools:
 		r.toolList(res.Tools)
 	case CmdHistory:

--- a/agent/host/session_picker_test.go
+++ b/agent/host/session_picker_test.go
@@ -1,0 +1,92 @@
+package host
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/panyam/mcpkit/agent"
+)
+
+func seedRuns(t *testing.T, store agent.RunStore, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		if _, err := store.CreateRun(context.Background(), agent.CreateRunRequest{RunID: fmt.Sprintf("run-%03d", i)}); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestSessionsPage_ThreadsCursor(t *testing.T) {
+	store := agent.NewInMemoryRunStore()
+	seedRuns(t, store, 120)
+	app := newPersistedApp(t, store, agent.NewStubProvider(), &strings.Builder{})
+	ctx := context.Background()
+
+	p1, err := app.SessionsPage(ctx, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(p1.Runs) != agent.DefaultListRunsLimit || !p1.HasMore {
+		t.Fatalf("page1: %d runs hasMore=%v", len(p1.Runs), p1.HasMore)
+	}
+	p2, _ := app.PageMore(ctx)
+	if len(p2.Runs) != agent.DefaultListRunsLimit || !p2.HasMore {
+		t.Fatalf("page2: %d runs hasMore=%v", len(p2.Runs), p2.HasMore)
+	}
+	if p1.Runs[0].ID == p2.Runs[0].ID {
+		t.Fatal("page2 repeats page1 (cursor not threaded)")
+	}
+	p3, _ := app.PageMore(ctx)
+	if len(p3.Runs) != 20 || p3.HasMore {
+		t.Fatalf("page3: %d runs hasMore=%v, want 20 and last", len(p3.Runs), p3.HasMore)
+	}
+	if p4, _ := app.PageMore(ctx); len(p4.Runs) != 0 {
+		t.Fatalf("page after exhaustion: %d runs, want 0", len(p4.Runs))
+	}
+}
+
+func TestSearchSessions_FiltersById(t *testing.T) {
+	store := agent.NewInMemoryRunStore()
+	seedRuns(t, store, 30)
+	app := newPersistedApp(t, store, agent.NewStubProvider(), &strings.Builder{})
+	got, err := app.SearchSessions(context.Background(), "RUN-01") // case-insensitive
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 10 { // run-010..run-019
+		t.Fatalf("search run-01 = %d matches, want 10", len(got))
+	}
+}
+
+func TestSessionsCommand_Routing(t *testing.T) {
+	store := agent.NewInMemoryRunStore()
+	seedRuns(t, store, 60)
+	app := newPersistedApp(t, store, agent.NewStubProvider(), &strings.Builder{})
+	ctx := context.Background()
+
+	res, err := app.Dispatch(ctx, "/sessions")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Kind != CmdSessions || len(res.Sessions) != agent.DefaultListRunsLimit {
+		t.Fatalf("/sessions: kind=%v n=%d", res.Kind, len(res.Sessions))
+	}
+	if !strings.Contains(res.SessionsNote, "more") {
+		t.Fatalf("footer should offer 'more': %q", res.SessionsNote)
+	}
+	if res2, _ := app.Dispatch(ctx, "/sessions more"); res2.Kind != CmdSessions || len(res2.Sessions) != 10 {
+		t.Fatalf("/sessions more: kind=%v n=%d, want 10", res2.Kind, len(res2.Sessions))
+	}
+	if res3, _ := app.Dispatch(ctx, "/sessions find run-02"); res3.Kind != CmdSessions || len(res3.Sessions) != 10 {
+		t.Fatalf("/sessions find run-02: n=%d, want 10", len(res3.Sessions))
+	}
+	res4, err := app.Dispatch(ctx, "/sessions run-005")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res4.Kind != CmdSession || res4.RunID != "run-005" {
+		t.Fatalf("/sessions run-005 (resume): kind=%v runID=%q", res4.Kind, res4.RunID)
+	}
+}

--- a/cmd/agentchat/README.md
+++ b/cmd/agentchat/README.md
@@ -191,6 +191,11 @@ In the REPL: `/tools` lists the merged tool index, `/history` the
 conversation, `/health` the failover snapshot, `/quit` exits; Ctrl-C cancels the in-flight turn. During an
 elicitation, `/d` declines and `/c` cancels.
 
+`/sessions` shows recent persisted sessions (newest-first), with `/sessions
+more` to page older ones, `/sessions find <text>` to search by id, and
+`/sessions <id>` to resume. (Recency is free on the gorm/sqlite and in-memory
+stores; a redis store's SCAN order is unsorted — see the runstore docs.)
+
 ## What a session looks like
 
 ```


### PR DESCRIPTION
## What changes

`/sessions` used to show only the first `ListRuns` page (~50) and dead-end. It now pages and searches: recent-first by default, `/sessions more` to load older, `/sessions find <text>` to search by id, `/sessions <id>` to resume (unchanged) — #1000.

## Reviewer's guide

1. [agent/host/persistence.go](https://github.com/panyam/mcpkit/pull/1070/files#diff-0eff5e5041fb67bd84e50d022d2c12f889b3a75f62e014198f357bb4b36d78ce) — start here. `SessionsPage(ctx, cursor)` threads the store cursor (remembering `NextCursor` on the App), `PageMore` advances it, `SearchSessions` filters ids across pages up to a bounded scan. `Sessions()` is now the first-page shim.
2. [agent/host/session_picker_test.go](https://github.com/panyam/mcpkit/pull/1070/files#diff-c283702f777018846916f10af69bf4e7efa152ea39ccf709241c807c1d3a182d) — acceptance: cursor threading across 3 pages + exhaustion, case-insensitive id search, `/sessions` subcommand routing.
3. [agent/host/commands.go](https://github.com/panyam/mcpkit/pull/1070/files#diff-d44c9aac08cff5c51623cc064ae8e0dbbef19ba85d048cf9996ed8f99b61ac39) — the `/sessions` subcommand parse (bare / `more` / `find <text>` / `<id>`) + footer + tab-completion.
4. [agent/host/render.go](https://github.com/panyam/mcpkit/pull/1070/files#diff-da3546e85434193f7b8b2df15f4f6d6df496b616b9e0b0b8c4299cd4576e044a) — prints the `SessionsNote` footer under the list.
5. [agent/host/app.go](https://github.com/panyam/mcpkit/pull/1070/files#diff-89fb8e04b6e1e9d5f7f76958490ef158dee40e2cae92d87c04b408d893c84361) — the remembered `sessionsCursor` field.

Skim: [cmd/agentchat/README.md](https://github.com/panyam/mcpkit/pull/1070/files#diff-ffb24bf0bf1787e7af2eee0cd297abb3635a9ad7720753f345e3abdd7a503592).

## How it works

```
SessionsPage(cursor):  resp = store.ListRuns({Cursor: cursor}); app.sessionsCursor = resp.NextCursor
                       -> {Runs, HasMore: NextCursor != ""}
PageMore():            SessionsPage(app.sessionsCursor)  (empty cursor -> empty page)
SearchSessions(q):     walk pages (cursor) up to maxSessionSearchScan, keep ids containing q (ci)

/sessions          -> SessionsPage("")     + footer "N shown · more · find · resume"
/sessions more     -> PageMore()
/sessions find X   -> SearchSessions(X)
/sessions <id>     -> Resume(id)           (unchanged)
```

## Decision log

- **Explicit subcommands** (`more` / `find <text>` / `<id>`) rather than overloading one arg — keeps "resume by id" unambiguous while adding paging/search.
- **Cursor remembered on the App**, not surfaced to the caller — the store cursor is opaque, so `more` advances host-side; a surface just sends `/sessions more`.
- **Search walks pages, bounded by `maxSessionSearchScan`** — there's no store-side id filter, and an unbounded scan on a huge run set would hang. Content search waits for a real index.
- **Interactive scroll-select overlay picker deferred** → that's the TUI design track (#1063); this delivers the host paging/search core + the flat-command UX.

## Risk / blast radius

- **Additive**: `SessionsPage`/`PageMore`/`SearchSessions` are new; `Sessions()` keeps its signature (now a shim). No RunStore-interface change. The renderer only gains a footer line.
- **Tests covering this**: the session_picker suite (paging/exhaustion/search/routing); existing session tests unchanged.
- **Be paranoid about**: redis SCAN is unordered, so "recent-first" is only true on gorm/in-memory — documented on the store; a redis picker at scale needs a sorted index (noted, tracked separately in the issue).

## Before / after

```
before:  /sessions           -> first ~50 runs, then nothing (dead end)

after:   /sessions           -> 50 recent
                                 50 shown · /sessions more for older · /sessions find <text> to search · /sessions <id> to resume
         /sessions more      -> next 50 (older)
         /sessions find abc  -> 3 match(es) for "abc"
         /sessions <id>      -> resume
```

## Out of scope (deferred)

- Interactive scroll-select overlay picker → TUI design track #1063.
- Content search (by message text) → needs a search index; id-substring only for now.
- Redis sorted-index for recency at scale → tracked in the issue.

