### PR TITLE
feat(agentchat/notebook): per-tool-call cells (fold each tool within a turn)

### DIFF
--- a/cmd/agentchat/README.md
+++ b/cmd/agentchat/README.md
@@ -80,7 +80,9 @@ terminal, else `plain`), `tui` (inline), `notebook` (alt-screen), or `plain`
 - **`tui`** (inline): finished output commits to the terminal's own scrollback,
   so native scroll, copy/paste, and a transcript that survives exit all work.
 - **`notebook`** (alt-screen): a managed viewport with its own scroll and a
-  transcript of **collapsible cells** (one per turn / command / info line). Two
+  transcript of **collapsible cells** — the assistant text, each tool call
+  (parallel calls group into one), and command / info lines each fold on their
+  own. Two
   modes: **INS** (default) types into the input — `esc` enters **NAV**, where
   `↑↓`/`jk` move a cell cursor, `space` folds/unfolds, `g`/`G` jump to ends, and
   `esc`/`i` return to INS. `pgup`/`pgdn` and the mouse wheel scroll; in INS,

--- a/cmd/agentchat/notebook.go
+++ b/cmd/agentchat/notebook.go
@@ -12,6 +12,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/panyam/mcpkit/agent"
 	"github.com/panyam/mcpkit/agent/host"
 )
 
@@ -47,6 +48,13 @@ type nbObserver struct {
 	buf  *bytes.Buffer
 	term host.Observer
 	prog *tea.Program
+
+	// openTools/toolLabel track the current tool cell: a turn is split so each
+	// tool call (or a parallel batch) folds on its own, with the text before/
+	// after as separate assistant cells. openTools counts in-flight calls so
+	// concurrent tool-begins group into one cell.
+	openTools int
+	toolLabel string
 }
 
 func newNBObserver() *nbObserver {
@@ -55,23 +63,71 @@ func newNBObserver() *nbObserver {
 }
 
 func (s *nbObserver) On(ev host.HostEvent) {
+	msgs := s.render(ev)
 	s.mu.Lock()
-	s.term.On(ev)
-	segment := s.buf.String()
-	boundary := isBoundary(ev.Kind)
-	if boundary {
-		s.buf.Reset()
-	}
 	prog := s.prog
 	s.mu.Unlock()
 	if prog == nil {
 		return
 	}
-	if boundary {
-		prog.Send(nbCellMsg{label: nbLabelFor(ev.Kind), body: strings.TrimRight(segment, "\n")})
-	} else {
-		prog.Send(nbLiveMsg(strings.TrimRight(segment, "\n")))
+	for _, m := range msgs {
+		prog.Send(m)
 	}
+}
+
+// render folds one HostEvent into the tea messages the model should receive
+// (cells committed at boundaries, live updates in between). Separated from On
+// so tests can assert the cell split without a running program.
+func (s *nbObserver) render(ev host.HostEvent) []tea.Msg {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var msgs []tea.Msg
+	seg := func() string { return strings.TrimRight(s.buf.String(), "\n") }
+
+	if ev.Kind == host.HostRunnerEvent {
+		re := ev.RunnerEvent
+		// A tool-begin cuts the accumulated text into its own assistant cell
+		// (the first begin of a batch), then the tool renders into a fresh
+		// buffer that a matching tool-end flushes as a ⚙ cell.
+		if re.Kind == agent.EventToolBegin {
+			if s.openTools == 0 {
+				if txt := seg(); txt != "" {
+					msgs = append(msgs, nbCellMsg{label: "assistant", body: txt})
+				}
+				s.buf.Reset()
+				s.toolLabel = "⚙"
+				if re.ToolCall != nil {
+					s.toolLabel = "⚙ " + re.ToolCall.Name
+				}
+			} else {
+				s.toolLabel = "⚙ tools"
+			}
+			s.openTools++
+		}
+
+		s.term.On(ev) // render this event into buf
+
+		switch re.Kind {
+		case agent.EventToolEnd, agent.EventToolError, agent.EventToolDenied, agent.EventToolCancelled:
+			if s.openTools > 0 {
+				s.openTools--
+			}
+			if s.openTools == 0 {
+				msgs = append(msgs, nbCellMsg{label: s.toolLabel, body: seg()})
+				s.buf.Reset()
+			} else {
+				msgs = append(msgs, nbLiveMsg(seg()))
+			}
+		default:
+			msgs = append(msgs, nbLiveMsg(seg()))
+		}
+	} else {
+		// non-runner event = a discrete boundary (turn done, command, info)
+		s.term.On(ev)
+		msgs = append(msgs, nbCellMsg{label: nbLabelFor(ev.Kind), body: seg()})
+		s.buf.Reset()
+	}
+	return msgs
 }
 
 // nbLabelFor maps a boundary event kind to a cell label. The streaming turn

--- a/cmd/agentchat/notebook_test.go
+++ b/cmd/agentchat/notebook_test.go
@@ -7,6 +7,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/panyam/mcpkit/agent"
 	"github.com/panyam/mcpkit/agent/host"
 )
 
@@ -219,5 +220,80 @@ func TestNotebook_FirstPromptLineStaysVisible(t *testing.T) {
 	// within the maxLines budget, the first line must not have scrolled off
 	if !strings.Contains(m.ta.View(), "FIRSTLINE") {
 		t.Fatalf("first prompt line scrolled off within budget:\n%s", m.ta.View())
+	}
+}
+
+func nbCollectCells(evs ...host.HostEvent) []nbCell {
+	obs := newNBObserver()
+	var cells []nbCell
+	for _, ev := range evs {
+		for _, m := range obs.render(ev) {
+			if c, ok := m.(nbCellMsg); ok {
+				cells = append(cells, nbCell(c))
+			}
+		}
+	}
+	return cells
+}
+
+func runnerEv(e agent.Event) host.HostEvent {
+	return host.HostEvent{Kind: host.HostRunnerEvent, RunnerEvent: e}
+}
+
+func turnDoneEv() host.HostEvent {
+	return host.HostEvent{Kind: host.HostTurnDone, Result: &agent.TurnResult{Steps: 1}}
+}
+
+func TestNBObserver_ToolBecomesOwnCell(t *testing.T) {
+	cells := nbCollectCells(
+		runnerEv(agent.Event{Kind: agent.EventTextDelta, Text: "greeting you"}),
+		runnerEv(agent.Event{Kind: agent.EventToolBegin, ToolCall: &agent.ToolCall{Name: "greet"}}),
+		runnerEv(agent.Event{Kind: agent.EventToolEnd, ToolCall: &agent.ToolCall{Name: "greet"}}),
+		runnerEv(agent.Event{Kind: agent.EventTextDelta, Text: "all done"}),
+		turnDoneEv(),
+	)
+	if len(cells) != 3 {
+		t.Fatalf("want 3 cells (text / tool / text), got %d: %+v", len(cells), cells)
+	}
+	if cells[0].label != "assistant" || !strings.Contains(cells[0].body, "greeting you") {
+		t.Fatalf("cell 0 = %+v, want assistant text-before-tool", cells[0])
+	}
+	if cells[1].label != "⚙ greet" || !strings.Contains(cells[1].body, "greet") {
+		t.Fatalf("cell 1 = %+v, want its own ⚙ greet cell", cells[1])
+	}
+	if cells[2].label != "assistant" || !strings.Contains(cells[2].body, "all done") {
+		t.Fatalf("cell 2 = %+v, want trailing assistant cell", cells[2])
+	}
+}
+
+func TestNBObserver_TextOnlyTurnIsOneCell(t *testing.T) {
+	cells := nbCollectCells(
+		runnerEv(agent.Event{Kind: agent.EventTextDelta, Text: "just a plain answer"}),
+		turnDoneEv(),
+	)
+	if len(cells) != 1 || cells[0].label != "assistant" {
+		t.Fatalf("text-only turn should be one assistant cell, got %+v", cells)
+	}
+}
+
+func TestNBObserver_ParallelToolsGroupIntoOneCell(t *testing.T) {
+	cells := nbCollectCells(
+		runnerEv(agent.Event{Kind: agent.EventToolBegin, ToolCall: &agent.ToolCall{Name: "A"}}),
+		runnerEv(agent.Event{Kind: agent.EventToolBegin, ToolCall: &agent.ToolCall{Name: "B"}}),
+		runnerEv(agent.Event{Kind: agent.EventToolEnd, ToolCall: &agent.ToolCall{Name: "A"}}),
+		runnerEv(agent.Event{Kind: agent.EventToolEnd, ToolCall: &agent.ToolCall{Name: "B"}}),
+		turnDoneEv(),
+	)
+	var tool *nbCell
+	for i := range cells {
+		if strings.HasPrefix(cells[i].label, "⚙") {
+			tool = &cells[i]
+		}
+	}
+	if tool == nil || tool.label != "⚙ tools" {
+		t.Fatalf("parallel tools should be one '⚙ tools' cell, got %+v", cells)
+	}
+	if !strings.Contains(tool.body, "A") || !strings.Contains(tool.body, "B") {
+		t.Fatalf("batch cell should contain both tools: %q", tool.body)
 	}
 }


### PR DESCRIPTION
> **Stacked on #1070** (base `feat/1000-session-picker`). No file overlap with #1000 (this is `cmd/agentchat/notebook.go` only); it just branched off it. CI won't run until the base is `main` — verified locally with `just test-agent`. Retarget to `main` after #1070 merges.

## What changes

In `--ui notebook`, an assistant turn was one cell (text + all its tool calls in the body). Now it splits into **per-tool-call cells**: the text before/after a tool is its own `assistant` cell, and each tool call folds independently — so a noisy or large tool result (e.g. an offloaded `report`) collapses on its own. Follow-up to the notebook renderer (#1069, deferred item).

## Reviewer's guide

1. [cmd/agentchat/notebook.go](https://github.com/panyam/mcpkit/pull/1071/files#diff-8a79677a206f62f0abeebce75abd2fbafac2dc1be85310113e702bebc42624b1) — `nbObserver.render` (extracted from `On` so it's testable): cuts a cell at each tool boundary using an `openTools` counter.
2. [cmd/agentchat/notebook_test.go](https://github.com/panyam/mcpkit/pull/1071/files#diff-12e612880a5d601118bba88764d9d1ff5815b9406c3ffb4e5a61ca6e9c4188a1) — text/tool/text → 3 cells; text-only → 1 (unchanged); parallel tools → one batch cell.

## How it works

```
render(HostRunnerEvent):
  ToolBegin, openTools 0→1:  flush accumulated text as an 'assistant' cell; label = "⚙ <name>"
  ToolBegin, openTools ≥1:   label = "⚙ tools"   (parallel batch)
  openTools++
  render event into buf
  ToolEnd/Error/Denied/Cancelled: openTools--
     if openTools == 0: flush buf as the ⚙ cell     else: live update
  other (text/thinking): live update
non-runner event (turn-done / command / info): flush buf as a labeled cell (unchanged)
```

## Decision log

- **`openTools` counter** rather than a flag — the Runner parallelizes tool calls in one step, so begins/ends interleave; counting keeps a clean batch boundary and groups a concurrent batch into one `⚙ tools` cell (correct — they ran together).
- **Extract `render()` from `On()`** so tests assert the cell split without a running bubbletea program (`On` sends to `prog`).
- **Observer-only change** — the cell model, `notebookModel`, and `renderCells` are untouched; they already render an arbitrary cell list.

## Risk / blast radius

- **Notebook-only**; the inline `tui`/`plain` surfaces are unaffected (`nbObserver` is notebook-specific). Non-tool turns render identically (one cell).
- **Tests**: the three NBObserver cases; existing notebook tests unchanged.

## Before / after

```
turn: "let me look that up" → report(topic) → "here's the summary"

before:  ▾ assistant
           let me look that up
           ⚙ report(topic)
             ✓ report: <12KB…>
           here's the summary          ← all one cell; can't fold just the tool

after:   ▾ assistant  · let me look that up
         ────────────────────────────
         ▸ ⚙ report  · ✓ report: <12KB…>   ← folds on its own
         ────────────────────────────
         ▾ assistant  · here's the summary
```

## Out of scope

- Interactive scroll-select overlay picker → TUI design track #1063.

