### PR TITLE
build(examples): examples/Makefile orchestrator + move discord/telegram out of experimental (#688)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,6 +189,9 @@ test-experimental: ## Run all experimental POC tests
 	@bash experimental/scripts/test-events-discord.sh
 	@bash experimental/scripts/test-events-telegram.sh
 
+test-examples: ## Run every infra-free example test (delegates to examples/Makefile)
+	$(MAKE) -C examples test
+
 test-experimental-events: ## Run experimental ext/events library tests
 	@bash experimental/scripts/test-events.sh
 
@@ -416,5 +419,5 @@ setup: setup-tools setup-hooks ## Full development setup
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-18s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: build test test-race test-v cover cover-html cover-func cover-all test-auth test-ui test-skills test-mcpskills build-mcpskills test-mcpskills-walkthrough test-protogen test-e2e test-experimental test-apps-playwright test-apps-playwright-docker test-apps-playwright-all test-apps-playwright-docker-all refresh-visual-gallery release-audit-apps demo-app demo-upstream testkcl testkcl-auto testall test-report smoke smoke-wire verify-dual testconfall testconf testconfauth testconf-tasks testconf-tasks-v2 testconf-mrtr testconf-file-inputs testconf-auth-server testconf-elicitation testconf-skills testconf-external-checker refresh-conformance check-conformance-stale check-local-suites-stale check-snippets check-auth-markers refresh-apps-compat-report check-apps-compat-stale vet lint vulncheck seccheck secrets verify-submodule-deps audit ci ci-full serve serve-streamable serve-both tidy tidy-all bump-root collect-walkthroughs ghbuild ghserve ghdeploy tag tag-push setup-tools setup-hooks setup upkcl downkcl kcllogs build-bridge help
+.PHONY: build test test-examples test-race test-v cover cover-html cover-func cover-all test-auth test-ui test-skills test-mcpskills build-mcpskills test-mcpskills-walkthrough test-protogen test-e2e test-experimental test-apps-playwright test-apps-playwright-docker test-apps-playwright-all test-apps-playwright-docker-all refresh-visual-gallery release-audit-apps demo-app demo-upstream testkcl testkcl-auto testall test-report smoke smoke-wire verify-dual testconfall testconf testconfauth testconf-tasks testconf-tasks-v2 testconf-mrtr testconf-file-inputs testconf-auth-server testconf-elicitation testconf-skills testconf-external-checker refresh-conformance check-conformance-stale check-local-suites-stale check-snippets check-auth-markers refresh-apps-compat-report check-apps-compat-stale vet lint vulncheck seccheck secrets verify-submodule-deps audit ci ci-full serve serve-streamable serve-both tidy tidy-all bump-root collect-walkthroughs ghbuild ghserve ghdeploy tag tag-push setup-tools setup-hooks setup upkcl downkcl kcllogs build-bridge help
 .DEFAULT_GOAL := help

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,0 +1,64 @@
+# examples/Makefile — test orchestration for the examples tree.
+#
+# The repo Makefile delegates here via `make test-examples` (-> `make -C
+# examples test`). Mirrors conformance/Makefile: one `test` umbrella plus
+# per-example targets, each runnable directly from this directory.
+#
+# Every target here is infra-free (no Docker/live services) so `test` runs in
+# CI as-is. Examples that need containers or credentials to exercise fully
+# (auth/keycloak, whole-enchilada stacks) are covered by their own suites, not
+# this umbrella.
+#
+# The events/discord and events/telegram example tests moved here from
+# experimental/Makefile (they test example apps, not the experimental library);
+# experimental/Makefile keeps the old target names as aliases so testall and CI
+# scripts keep working.
+
+EXAMPLES_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
+.PHONY: test help \
+  test-agents-async test-agents-multi test-skills test-tasks-v2 \
+  test-common test-otel-stdout test-protogen \
+  test-events-kitchen-sink test-events-discord test-events-telegram \
+  test-whole-enchilada-event-server
+
+test: test-agents-async test-agents-multi test-skills test-tasks-v2 \
+      test-common test-otel-stdout test-protogen \
+      test-events-kitchen-sink test-events-discord test-events-telegram \
+      test-whole-enchilada-event-server ## Run every infra-free example test
+
+test-agents-async: ## agents/agent-async
+	cd $(EXAMPLES_DIR)/agents/agent-async && go test ./... -count=1 -timeout 60s
+
+test-agents-multi: ## agents/multi-agent
+	cd $(EXAMPLES_DIR)/agents/multi-agent && go test ./... -count=1 -timeout 60s
+
+test-skills: ## skills (agent scenario)
+	cd $(EXAMPLES_DIR)/skills && go test ./... -count=1 -timeout 60s -run TestAgentScenario
+
+test-tasks-v2: ## tasks-v2 (agent scenario)
+	cd $(EXAMPLES_DIR)/tasks-v2 && go test ./... -count=1 -timeout 60s -run TestAgentScenario
+
+test-common: ## common (shared example helpers + otel setup)
+	cd $(EXAMPLES_DIR)/common && go test ./... -count=1 -timeout 60s
+
+test-otel-stdout: ## otel/stdout smoke
+	cd $(EXAMPLES_DIR)/otel/stdout && go test ./... -count=1 -timeout 60s
+
+test-protogen: ## protogen/bookservice
+	cd $(EXAMPLES_DIR)/protogen/bookservice && go test ./... -count=1 -timeout 60s
+
+test-events-kitchen-sink: ## events/kitchen-sink
+	cd $(EXAMPLES_DIR)/events/kitchen-sink && go test ./... -count=1 -timeout 60s
+
+test-whole-enchilada-event-server: ## whole-enchilada/events/event-server
+	cd $(EXAMPLES_DIR)/whole-enchilada/events/event-server && go test ./... -count=1 -timeout 60s
+
+test-events-discord: ## events/discord (runner-agnostic script, shared with the justfile)
+	@bash $(EXAMPLES_DIR)/../experimental/scripts/test-events-discord.sh
+
+test-events-telegram: ## events/telegram
+	@bash $(EXAMPLES_DIR)/../experimental/scripts/test-events-telegram.sh
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-34s\033[0m %s\n", $$1, $$2}'

--- a/experimental/Makefile
+++ b/experimental/Makefile
@@ -9,10 +9,10 @@
 # shared with the justfile). The -pg / -real variants delegate to the
 # sub-module recipes that boot Docker containers.
 #
-# Two of the sub-suites live under `examples/events/` rather than
-# `experimental/`, but they're conceptually part of the experimental
-# events POC (they're demo apps consuming the experimental library), so
-# they're orchestrated here next to the library tests.
+# The discord/telegram example suites moved to examples/Makefile (they test
+# example apps, not the experimental library — issue 688). The targets below
+# are kept as aliases delegating there, so testall's per-suite timing
+# (7a–7e) and any CI script referencing the old names keep working.
 
 EXPERIMENTAL_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
@@ -38,11 +38,11 @@ test-events-stores-redis: ## Run Redis pubsub Emitter sub-module (miniredis; no 
 test-events-stores-redis-real: ## Run the Redis pubsub Emitter against a real Redis container (Docker)
 	$(MAKE) -C $(EXPERIMENTAL_DIR)/ext/events/stores/redis testredis
 
-test-events-discord: ## Run experimental events Discord example tests
-	@bash $(EXPERIMENTAL_DIR)/scripts/test-events-discord.sh
+test-events-discord: ## (alias) Discord example tests — moved to examples/Makefile
+	$(MAKE) -C $(EXPERIMENTAL_DIR)/../examples test-events-discord
 
-test-events-telegram: ## Run experimental events Telegram example tests
-	@bash $(EXPERIMENTAL_DIR)/scripts/test-events-telegram.sh
+test-events-telegram: ## (alias) Telegram example tests — moved to examples/Makefile
+	$(MAKE) -C $(EXPERIMENTAL_DIR)/../examples test-events-telegram
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-30s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
## What changes

Adds `examples/Makefile` as the test orchestrator for the examples tree (mirroring `conformance/Makefile`), moves the `events/discord` + `events/telegram` suites out of `experimental/Makefile` (they test example apps, not the experimental library), wires up example tests that had no orchestrator entry point, and adds a root `make test-examples` delegate (#688).

## Reviewer's guide

1. [examples/Makefile](https://github.com/panyam/mcpkit/pull/1072/files#diff-ae8bb09b4bbb919309d4c8bb8ffc46e031bf63b7274502171a183a4dc1138f53) — start here. One `test` umbrella + per-example targets, all **infra-free** so `test` runs in CI as-is.
2. [experimental/Makefile](https://github.com/panyam/mcpkit/pull/1072/files#diff-b67e077548afb7fbc286b76d36e98b2e69b9580843b390f2ee3a2395b3ff88d8) — `test-events-discord`/`-telegram` become **aliases** delegating to [examples/Makefile](https://github.com/panyam/mcpkit/pull/1072/files#diff-ae8bb09b4bbb919309d4c8bb8ffc46e031bf63b7274502171a183a4dc1138f53) (header note updated); keeps testall's per-suite timing + any CI script on the old names working.
3. [Makefile](https://github.com/panyam/mcpkit/pull/1072/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52) — root `test-examples` target + `.PHONY`.

## Decision log

- **Aliases, not a hard move**, for discord/telegram — testall records per-suite timing (7a–7e) via those target names, so delegating keeps everything green while relocating ownership.
- **Umbrella is infra-free only** — every target runs without Docker/live services (verified), so `make -C examples test` is CI-safe. Container/credential suites stay in their own paths.
- **Scripts stay in `experimental/scripts/`** (runner-agnostic, `REPO_ROOT`-relative) — the Makefile *targets* moved; relocating the scripts is a noted follow-up to avoid churn.

## Risk / blast radius

- **Additive + delegating** — no example test is dropped; the experimental umbrella and root `test-experimental` still run discord/telegram (through the alias / the unchanged scripts).
- **Be paranoid about:** the experimental alias path (`$(EXPERIMENTAL_DIR)/../examples`) and that testall's per-suite targets still resolve — both verified below.

## Before / after

```
before:  experimental/Makefile hosts test-events-discord/telegram (with an
         apology in its header); common/otel, events/kitchen-sink,
         whole-enchilada/event-server tests have no orchestrator entry point.

after:   $ make -C examples test          # 11 infra-free example suites, green
         $ make test-examples             # root delegate
         $ make -C experimental test-events-discord   # alias -> examples/, exit 0
```

Verified: `make -C examples test` green; the experimental alias delegates (exit 0); `make test-examples` resolves; `examples/common` tidy is already clean on main (the issue's go.mod-drift blocker was fixed since filing).

## Out of scope (deferred)

- Move the discord/telegram scripts themselves under `examples/scripts/`.
- Fold testall's stage map + the root `test-agent` hardcoded example steps into this orchestrator (touches the CI workflow's hardcoded steps — a separate, careful pass).

