### PR TITLE
feat(agent/host): two-tier skills loading — catalog mode + load_skill tool (#910)

### DIFF
--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -207,17 +207,25 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 	}
 
 	instructions := cfg.Instructions
+	var skillCatalog []catalogSkill
 	for i, sc := range cfg.Servers {
 		if sc.Skills != nil && !*sc.Skills {
 			continue
 		}
-		block, err := loadSkillsBlock(app.clients[i], sc.ID, app.emit, o.tp)
+		block, cat, err := loadSkillsForServer(app.clients[i], sc.ID, sc.SkillsMode, app.emit, o.tp)
 		if err != nil {
 			app.Close()
 			return nil, err
 		}
 		if block != "" {
 			instructions += "\n\n" + block
+		}
+		skillCatalog = append(skillCatalog, cat...)
+	}
+	if len(skillCatalog) > 0 {
+		if err := app.registerLoadSkill(multi, skillCatalog); err != nil {
+			app.Close()
+			return nil, err
 		}
 	}
 

--- a/agent/host/config.go
+++ b/agent/host/config.go
@@ -353,6 +353,14 @@ type ServerConfig struct {
 	// false opts out even when the server advertises skills.
 	Skills *bool `json:"skills,omitempty"`
 
+	// SkillsMode selects how enabled skills enter context: "eager" (full
+	// SKILL.md bodies in the system prompt), "catalog" (only name +
+	// description; bodies fetched on demand via the load_skill tool), or ""
+	// (auto — eager below a small skill count, catalog at/above). Progressive
+	// disclosure keeps a large skill set from bloating every request. Ignored
+	// when Skills is false.
+	SkillsMode string `json:"skillsMode,omitempty"`
+
 	// Events lists the event streams to open on this server. Each event
 	// feeds the injection policy (and any trigger bindings that match).
 	Events []EventConfig `json:"events,omitempty"`

--- a/agent/host/skills.go
+++ b/agent/host/skills.go
@@ -3,28 +3,82 @@ package host
 import (
 	"context"
 	"fmt"
+	"strings"
 
+	"github.com/panyam/mcpkit/agent"
 	"github.com/panyam/mcpkit/client"
 	"github.com/panyam/mcpkit/core"
 	skills "github.com/panyam/mcpkit/ext/skills"
 )
 
-// loadSkillsBlock fetches and digest-verifies a server's skills and renders
-// the instructions section. Servers without the skills capability return the
-// empty string silently; verified failures (digest mismatch, unreadable
-// skill) are warned to the transcript and excluded, never injected. An index
-// that cannot be fetched at all is a startup error: the server advertised
-// skills and the host could not honor them, which the user should see before
-// conversing, not during.
-func loadSkillsBlock(c *client.Client, serverID string, emit func(HostEvent), tp core.TracerProvider) (string, error) {
+// defaultCatalogThreshold is the skill count at/above which auto mode ("")
+// switches a server from eager full-body injection to the catalog + load_skill
+// two-tier scheme, so a large skill set doesn't bloat every request.
+const defaultCatalogThreshold = 10
+
+// skillLoaderSourceID is the MultiSource id the on-demand load_skill tool
+// registers under (distinct from any per-server id).
+const skillLoaderSourceID = "skills-loader"
+
+// catalogSkill pairs a catalog-mode server's skills client with one index entry,
+// so the load_skill tool can ReadAndVerify that skill's body on demand.
+type catalogSkill struct {
+	serverID string
+	client   *skills.Client
+	entry    skills.IndexEntry
+}
+
+// resolveSkillsMode maps the config mode to "eager" or "catalog". An explicit
+// value wins; "" auto-selects by skill-md count against defaultCatalogThreshold.
+func resolveSkillsMode(mode string, idx skills.Index) string {
+	switch mode {
+	case "eager", "catalog":
+		return mode
+	default:
+		n := 0
+		for _, e := range idx.Skills {
+			if e.Type == skills.SkillTypeSkillMD {
+				n++
+			}
+		}
+		if n >= defaultCatalogThreshold {
+			return "catalog"
+		}
+		return "eager"
+	}
+}
+
+// loadSkillsForServer fetches a server's skill index and returns the system-
+// prompt block plus, in catalog mode, the entries the load_skill tool serves.
+// Servers without the skills capability return empty silently; a fetchable
+// index that fails is a startup error (the server advertised skills and the
+// host could not honor them). Eager mode injects full bodies (digest-verified;
+// per-skill failures warn and are excluded); catalog mode injects only
+// name+description and defers bodies to load_skill.
+func loadSkillsForServer(c *client.Client, serverID, mode string, emit func(HostEvent), tp core.TracerProvider) (string, []catalogSkill, error) {
 	sc := skills.NewClient(c, skills.WithTracerProvider(tp))
 	if !sc.SupportsSkills() {
-		return "", nil
+		return "", nil, nil
 	}
-	loaded, err := sc.LoadAll(context.Background())
+	idx, err := sc.ListSkills(context.Background())
 	if err != nil {
-		return "", fmt.Errorf("agentchat: skills index from %s: %w", serverID, err)
+		return "", nil, fmt.Errorf("agentchat: skills index from %s: %w", serverID, err)
 	}
+
+	if resolveSkillsMode(mode, idx) == "catalog" {
+		var cat []catalogSkill
+		for _, e := range idx.Skills {
+			if e.Type == skills.SkillTypeSkillMD {
+				cat = append(cat, catalogSkill{serverID: serverID, client: sc, entry: e})
+			}
+		}
+		if len(cat) > 0 {
+			emit(HostEvent{Kind: HostSkillsLoaded, ServerID: serverID, Loaded: len(cat)})
+		}
+		return skills.CatalogBlock(idx), cat, nil
+	}
+
+	loaded := sc.LoadIndex(context.Background(), idx)
 	var ok int
 	for _, ls := range loaded {
 		if ls.Err != nil {
@@ -36,5 +90,39 @@ func loadSkillsBlock(c *client.Client, serverID string, emit func(HostEvent), tp
 	if ok > 0 || len(loaded) > 0 {
 		emit(HostEvent{Kind: HostSkillsLoaded, ServerID: serverID, Loaded: ok, Skipped: len(loaded) - ok})
 	}
-	return skills.InstructionsBlock(loaded), nil
+	return skills.InstructionsBlock(loaded), nil, nil
+}
+
+type loadSkillArgs struct {
+	// Name is the skill's name as shown in the skills catalog.
+	Name string `json:"name"`
+}
+
+// registerLoadSkill adds a load_skill(name) tool over the catalog-mode skills,
+// so a name+description catalog expands to full instructions only for the
+// skills a conversation actually uses. The handler ReadAndVerifies the body
+// (laziness never bypasses digest verification; the activation hook fires so
+// hosts learn which skills earn their tokens). An unknown name is an app-state
+// result, not an error, so the model can recover.
+func (a *App) registerLoadSkill(multi *agent.MultiSource, catalog []catalogSkill) error {
+	fs := agent.NewFuncSource()
+	err := agent.AddFunc(fs, "load_skill",
+		"Read the full instructions for a named skill (from the skills catalog) before using it.",
+		func(ctx context.Context, in loadSkillArgs) (string, error) {
+			name := strings.TrimSpace(in.Name)
+			for _, cs := range catalog {
+				if cs.entry.Name == name || cs.entry.URL == name {
+					res, err := cs.client.ReadAndVerify(ctx, cs.entry.URL, cs.entry.Digest)
+					if err != nil {
+						return "", err
+					}
+					return string(res.Bytes), nil
+				}
+			}
+			return "no skill named " + name + " — use a name from the skills catalog", nil
+		})
+	if err != nil {
+		return err
+	}
+	return multi.Add(skillLoaderSourceID, fs)
 }

--- a/agent/host/skills_test.go
+++ b/agent/host/skills_test.go
@@ -1,0 +1,60 @@
+package host
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/panyam/mcpkit/agent"
+	skills "github.com/panyam/mcpkit/ext/skills"
+)
+
+func TestResolveSkillsMode(t *testing.T) {
+	small := skills.NewIndex(skills.IndexEntry{Type: skills.SkillTypeSkillMD, Name: "a"})
+	var entries []skills.IndexEntry
+	for i := 0; i < defaultCatalogThreshold; i++ {
+		entries = append(entries, skills.IndexEntry{Type: skills.SkillTypeSkillMD, Name: fmt.Sprintf("s%d", i)})
+	}
+	big := skills.NewIndex(entries...)
+
+	if resolveSkillsMode("", small) != "eager" {
+		t.Fatal("auto below threshold should be eager")
+	}
+	if resolveSkillsMode("", big) != "catalog" {
+		t.Fatal("auto at/above threshold should be catalog")
+	}
+	if resolveSkillsMode("catalog", small) != "catalog" {
+		t.Fatal("explicit catalog should win over auto")
+	}
+	if resolveSkillsMode("eager", big) != "eager" {
+		t.Fatal("explicit eager should win over auto")
+	}
+}
+
+func TestRegisterLoadSkill(t *testing.T) {
+	app := &App{}
+	multi := agent.NewMultiSource()
+	catalog := []catalogSkill{{serverID: "s", entry: skills.IndexEntry{Name: "alpha", URL: "skill://a/SKILL.md"}}}
+	if err := app.registerLoadSkill(multi, catalog); err != nil {
+		t.Fatal(err)
+	}
+	tools, _ := multi.Tools(context.Background())
+	found := false
+	for _, td := range tools {
+		if td.Name == "load_skill" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("load_skill tool not registered: %+v", tools)
+	}
+	// unknown name is app-state (no server call, no error)
+	res, err := multi.Call(context.Background(), "load_skill", map[string]any{"name": "nope"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res == nil || !strings.Contains(resultText(res), "no skill named nope") {
+		t.Fatalf("unknown skill: %+v", res)
+	}
+}

--- a/cmd/agentchat/README.md
+++ b/cmd/agentchat/README.md
@@ -226,11 +226,14 @@ booleans y/n, required fields re-prompt):
 Each assumes a local OpenAI-compatible model on `localhost:1234`.
 
 **Skills server** (`examples/skills`, port 18099 per its README): start the
-fixture, then `go run . --model <m> --url http://localhost:18099/mcp`. The
-skills *tools* surface works today; automatic skill discovery and prompt
-injection (fetching `skill://index.json` and honoring SKILL.md) lands with
-the skills-consumption ticket in the agent epic and will change what the
-model knows, not what it can call.
+fixture, then `go run . --model <m> --url http://localhost:18099/mcp`. A
+server's SKILL.md skills are discovered and (digest-verified) enter the system
+prompt. A per-server `"skillsMode"` in the config picks how: `"eager"`
+injects full bodies, `"catalog"` injects only name + description and exposes a
+`load_skill(name)` tool that fetches (and verifies) a body on demand, and `""`
+auto-selects (eager for a few skills, catalog once a server advertises many —
+progressive disclosure keeps a large skill set off every request). `"skills":
+false` opts a server out entirely.
 
 **Auth example** (`examples/auth`): start its server, export the token it
 mints, and connect with `authTokenEnv`. The bearer flows through

--- a/ext/skills/load.go
+++ b/ext/skills/load.go
@@ -66,6 +66,37 @@ func (c *Client) LoadIndex(ctx context.Context, idx Index) []LoadedSkill {
 // all-failed batch renders to the empty string so callers can append the
 // result unconditionally. Ordering follows the input, which LoadAll already
 // made deterministic.
+// CatalogBlock renders a compact catalog of a server's skills — one line per
+// skill-md entry (name + description), the two-tier alternative to
+// InstructionsBlock's full-body injection (issue 910). It tells the model what
+// skills exist for roughly a tenth of the tokens; the body is fetched on demand
+// via a host load_skill tool. Archive entries are omitted (host-decided
+// extraction, like InstructionsBlock). Returns "" when there are no skill-md
+// entries.
+func CatalogBlock(idx Index) string {
+	var b strings.Builder
+	for _, e := range idx.Skills {
+		if e.Type != SkillTypeSkillMD {
+			continue
+		}
+		name := e.Name
+		if name == "" {
+			name = e.URL
+		}
+		if e.Description != "" {
+			fmt.Fprintf(&b, "- %s: %s\n", name, e.Description)
+		} else {
+			fmt.Fprintf(&b, "- %s\n", name)
+		}
+	}
+	if b.Len() == 0 {
+		return ""
+	}
+	return "## Skills (catalog)\n\nThese skills are available. Call load_skill(name) to read a skill's full instructions before using it.\n\n" + b.String()
+}
+
+// InstructionsBlock renders the full SKILL.md body of every successfully loaded
+// skill for eager injection into the system prompt.
 func InstructionsBlock(loaded []LoadedSkill) string {
 	var b strings.Builder
 	for _, ls := range loaded {

--- a/ext/skills/load_test.go
+++ b/ext/skills/load_test.go
@@ -87,3 +87,27 @@ func TestInstructionsBlockExcludesFailuresAndIsDeterministic(t *testing.T) {
 		t.Fatalf("empty batch must render empty, got %q", got)
 	}
 }
+
+func TestCatalogBlock(t *testing.T) {
+	idx := skills.NewIndex(
+		skills.IndexEntry{Type: skills.SkillTypeSkillMD, Name: "alpha", Description: "does alpha", URL: "skill://a/SKILL.md"},
+		skills.IndexEntry{Type: skills.SkillTypeSkillMD, Name: "beta", URL: "skill://b/SKILL.md"},
+		skills.IndexEntry{Type: skills.SkillTypeArchive, Name: "arch", Description: "a pack", URL: "skill://z.zip"},
+	)
+	block := skills.CatalogBlock(idx)
+	if !strings.Contains(block, "## Skills (catalog)") || !strings.Contains(block, "load_skill") {
+		t.Fatalf("catalog header/hint missing:\n%s", block)
+	}
+	if !strings.Contains(block, "- alpha: does alpha") {
+		t.Fatalf("named+described skill missing:\n%s", block)
+	}
+	if !strings.Contains(block, "- beta\n") {
+		t.Fatalf("description-less skill should still list:\n%s", block)
+	}
+	if strings.Contains(block, "arch") {
+		t.Fatalf("archive entries must be excluded from the catalog:\n%s", block)
+	}
+	if got := skills.CatalogBlock(skills.NewIndex()); got != "" {
+		t.Fatalf("empty index catalog = %q, want \"\"", got)
+	}
+}


### PR DESCRIPTION
> **Stacked on #1072** (base `feat/688-examples-makefile`). No file overlap with #688 — it just branches off it so I could keep building. CI won't run until the base is `main`; verified locally. Retarget to `main` after #1072 merges.

## What changes

Eager full-body skill injection is right for a handful of skills and wrong at scale (50 skills × ~100 tokens re-sent on every model call of every turn). Adds **progressive disclosure** (#910): a **catalog** mode injects only each skill's name + description, and a host-local **`load_skill(name)`** tool fetches (and digest-verifies) a skill's full body on demand.

## Reviewer's guide

1. [ext/skills/load.go](https://github.com/panyam/mcpkit/pull/1073/files#diff-f7772c33e3f5d5565c9152a415ac07304e15a2ed41c286959129ab69b011b291) — start here. `CatalogBlock(index)` (the name+description block, sibling of `InstructionsBlock`).
2. [agent/host/skills.go](https://github.com/panyam/mcpkit/pull/1073/files#diff-e306a404daf114302a7d1eb19616a1d7d8fbb9ee27b78f1e2b237c0f2384dff7) — `loadSkillsForServer` (fetch index → eager or catalog), `resolveSkillsMode` (auto threshold), `registerLoadSkill` (the `load_skill` FuncSource).
3. [agent/host/app.go](https://github.com/panyam/mcpkit/pull/1073/files#diff-89fb8e04b6e1e9d5f7f76958490ef158dee40e2cae92d87c04b408d893c84361) — the `NewApp` skills loop now collects catalog entries and registers one `load_skill` tool.
4. [agent/host/config.go](https://github.com/panyam/mcpkit/pull/1073/files#diff-6aff502cc5cae4b9d9769752e8638899bab121e09de870b5d1320cc892c6bf2d) — `ServerConfig.SkillsMode`.
5. Tests: [ext/skills/load_test.go](https://github.com/panyam/mcpkit/pull/1073/files#diff-bc0aa82074e9a144e1cbc7a7115856c66ae2c19815aceade7229d76af050c3c5) (CatalogBlock), [agent/host/skills_test.go](https://github.com/panyam/mcpkit/pull/1073/files#diff-72993d6ca3bd4300a608562572e588505f92ce00df269faec6e13ba2e053a9e7) (resolveSkillsMode + load_skill registration/unknown-name).

## How it works

```
per skills-enabled server:
  idx = ListSkills()                       # index only, no bodies
  mode = SkillsMode or auto(count ≥ threshold ? catalog : eager)
  eager:   LoadIndex(idx) -> InstructionsBlock (full bodies in system prompt)   # unchanged
  catalog: CatalogBlock(idx) -> system prompt (name+desc); collect entries

if any catalog entries:
  register one load_skill(name) tool over all catalog-mode servers:
    find entry by name -> ReadAndVerify(url, digest) -> return body as tool result
    unknown name -> "no skill named …" (app-state, not an error)
```

## Decision log

- **Per-server `skillsMode` (+ auto default), not the `SkillsPolicy` hook** — config-drivable from agentchat/kitchen-sink; the hook (for embedders) can be added later and they coexist (per the issue).
- **Body via tool-result history, not re-injected into the prompt** — the issue is explicit: skills live in the system prompt, and swinging it turn-to-turn is prompt-cache-hostile. Connect-time policy + the model pulling bodies covers the dynamic half.
- **One `load_skill` tool across all catalog servers** — searches by name; registered under a distinct `skills-loader` MultiSource id to avoid per-server id collision.
- **Digest verification is never skipped** — `load_skill` uses `ReadAndVerify`, so laziness doesn't weaken the SEP-2640 integrity guarantee; the activation hook fires so hosts learn which skills earn their tokens.

## Risk / blast radius

- **Backward-compatible default** — with `skillsMode` unset and few skills, behavior is unchanged (eager). Catalog only kicks in above the threshold or when explicitly set.
- **Tests**: CatalogBlock rendering, mode resolution, tool registration + unknown-name path. The full `load_skill`→`ReadAndVerify`→body path over a live skills server is exercised manually / by ext/skills' own `ReadAndVerify` tests (no host-level skills fixture exists yet — noted).
- **Be paranoid about:** name collisions across servers in catalog mode (first match wins) and that eager mode is byte-for-byte unchanged.

## Before / after

```
before:  every skill's full SKILL.md body → system prompt, every server, every request

after:   skillsMode "catalog" (or auto, many skills):
           ## Skills (catalog)
           - code-review: review a diff for correctness…
           - deploy: cut a release…
         + load_skill("deploy") → returns deploy's SKILL.md body (verified) into tool history
         (bodies enter context only for skills a conversation uses)
```

## Out of scope (deferred, per the issue's open points)

- `SkillsPolicy func(index)(inject, catalog)` connect-time hook for embedders.
- Per-conversation caching of activated bodies (avoid re-fetch once loaded).
- Catalog line token-cost hints; `skillsAllow` hard filtering (rides `LoadIndex`).
- A host-level skills-server test fixture for the full load_skill integration path.

