### PR TITLE
feat(agentchat): status line — model · session · context-budget gauge (#1063 D1/D2)

### DIFF
--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -458,6 +458,16 @@ func (a *App) Providers() (names []string, active string) {
 	return a.connections.Names(), a.connections.Active()
 }
 
+// ModelLabel is the human-facing name of the active model for a status line:
+// the active connection name when a ConnectionRegistry is configured, else the
+// single-model identifier.
+func (a *App) ModelLabel() string {
+	if _, active := a.Providers(); active != "" {
+		return active
+	}
+	return a.cfg.Model.Model
+}
+
 // SwitchProvider makes name the active chat provider for subsequent
 // turns. An unknown name or a build failure leaves the current provider
 // in place (the error says which). The swap takes effect on the next

--- a/cmd/agentchat/README.md
+++ b/cmd/agentchat/README.md
@@ -51,6 +51,16 @@ startup when a named variable is unset. A per-server `allow` list is a
 capability boundary (a FilterSource): tools outside it are neither offered to
 the model nor callable.
 
+## Status line
+
+Both TUI surfaces show a persistent status line (kept in the managed live
+region, never committed to scrollback): `model <active> · session <id> · ctx
+<in>↑ <out>↓ tok`, where the token counts come from the last turn's streamed
+`Usage`. Pass `--context-window <tokens>` to add a `N% context left` gauge
+(context exhaustion is the top silent failure). This is the first slice of the
+TUI layout track (#1063 D1/D2); collapsible tool cells (B4) already shipped with
+`--ui notebook`.
+
 ## Prompt editing keys (TUI)
 
 The input line supports readline-style editing. `/keys` prints this cheatsheet

--- a/cmd/agentchat/main.go
+++ b/cmd/agentchat/main.go
@@ -198,6 +198,7 @@ func newRoot() (*cobra.Command, *viper.Viper) {
 	fl.String("session", "", "session run ID to create or resume at startup (needs --session-store)")
 	fl.String("ui", "auto", "interface: auto (TUI when interactive) | tui (inline) | notebook (alt-screen, foldable cells) | plain")
 	fl.Int("notebook-max-lines", 20, "with --ui notebook, max rows the auto-growing prompt expands to")
+	fl.Int("context-window", 0, "model context window in tokens; enables a 'N% context left' gauge in the status line (0 = show token counts only)")
 	fl.Int("offload-threshold", 0, "offload tool results at/over N bytes to a store, feeding the model a stub + read_tool_result (0 = off; blobs use --session-store's backend)")
 	fl.String("offload-dir", "", "store offloaded tool results as files under this directory (no server needed); overrides --session-store for blobs")
 	fl.Bool("memory", false, "enable working memory: remember/recall/forget tools the model manages across turns (in-memory store)")
@@ -342,11 +343,12 @@ func runChat(v *viper.Viper) error {
 		fmt.Printf("agentchat: session %s\n", session)
 	}
 
+	window := v.GetInt("context-window")
 	switch mode {
 	case "tui":
-		return runTUI(app, surface)
+		return runTUI(app, surface, window)
 	case "notebook":
-		return runNotebook(app, nbSurface, v.GetInt("notebook-max-lines"))
+		return runNotebook(app, nbSurface, v.GetInt("notebook-max-lines"), window)
 	}
 
 	fmt.Printf("agentchat: %d server(s), model %s. /tools /history /quit; Ctrl-C cancels a turn.\n", len(cfg.Servers), cfg.Model.Model)

--- a/cmd/agentchat/notebook.go
+++ b/cmd/agentchat/notebook.go
@@ -126,6 +126,9 @@ func (s *nbObserver) render(ev host.HostEvent) []tea.Msg {
 		s.term.On(ev)
 		msgs = append(msgs, nbCellMsg{label: nbLabelFor(ev.Kind), body: seg()})
 		s.buf.Reset()
+		if ev.Kind == host.HostTurnDone && ev.Result != nil {
+			msgs = append(msgs, usageMsg{in: ev.Result.Usage.InputTokens, out: ev.Result.Usage.OutputTokens})
+		}
 	}
 	return msgs
 }
@@ -166,7 +169,9 @@ type notebookModel struct {
 	history []string
 	histIdx int
 
-	maxLines      int // input auto-grows up to this many rows (0 = default)
+	maxLines      int      // input auto-grows up to this many rows (0 = default)
+	usage         usageMsg // last turn's tokens, for the status line
+	window        int      // context window for the "N% left" gauge (0 = off)
 	width, height int
 	ready         bool
 }
@@ -175,11 +180,11 @@ type notebookModel struct {
 // is unset.
 const defaultNotebookMaxLines = 20
 
-func newNotebookModel(app *host.App, surface *nbObserver, maxLines int) notebookModel {
+func newNotebookModel(app *host.App, surface *nbObserver, maxLines, window int) notebookModel {
 	if maxLines <= 0 {
 		maxLines = defaultNotebookMaxLines
 	}
-	m := notebookModel{app: app, surface: surface, ta: newPromptArea(), atBottom: true, maxLines: maxLines}
+	m := notebookModel{app: app, surface: surface, ta: newPromptArea(), atBottom: true, maxLines: maxLines, window: window}
 	m.histIdx = 0
 	return m
 }
@@ -203,7 +208,7 @@ func (m *notebookModel) relayout() {
 	}
 	m.ta.SetWidth(m.width)
 	m.ta.SetHeight(ih)
-	vpH := m.height - ih - 2 // status line + separator
+	vpH := m.height - ih - 3 // 2-line status + separator
 	if vpH < 1 {
 		vpH = 1
 	}
@@ -239,6 +244,10 @@ func (m notebookModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case turnDoneMsg:
 		m.running = false
+		return m, nil
+
+	case usageMsg:
+		m.usage = msg
 		return m, nil
 
 	case tea.MouseMsg:
@@ -372,12 +381,13 @@ func (m notebookModel) statusBar() string {
 	if m.nav {
 		hint = "NAV  ↑↓/jk select · space fold · g/G ends · esc/i type"
 	} else {
-		hint = "INS  enter send · ctrl+j newline · ↑↓ prompt/history/scroll · pgup/pgdn/wheel · esc fold"
+		hint = "INS  enter send · ctrl+j newline · ↑↓ scroll · esc fold"
 	}
 	if m.running {
 		hint = "working…  " + hint
 	}
-	return lipgloss.NewStyle().Faint(true).Render(hint)
+	// Two-line status: the persistent model/session/context line, then keys.
+	return lipgloss.NewStyle().Faint(true).Render(statusLine(m.app, m.usage, m.window) + "\n" + hint)
 }
 
 // refresh rebuilds the viewport content from the cells (+ the live turn) and,
@@ -521,8 +531,8 @@ func (m *notebookModel) recallHistory(dir int) bool {
 
 // runNotebook starts the alt-screen notebook program with mouse support.
 // maxLines caps the auto-growing prompt.
-func runNotebook(app *host.App, surface *nbObserver, maxLines int) error {
-	prog := tea.NewProgram(newNotebookModel(app, surface, maxLines), tea.WithAltScreen(), tea.WithMouseCellMotion())
+func runNotebook(app *host.App, surface *nbObserver, maxLines, window int) error {
+	prog := tea.NewProgram(newNotebookModel(app, surface, maxLines, window), tea.WithAltScreen(), tea.WithMouseCellMotion())
 	surface.prog = prog
 	_, err := prog.Run()
 	return err

--- a/cmd/agentchat/notebook_test.go
+++ b/cmd/agentchat/notebook_test.go
@@ -31,7 +31,7 @@ func TestNBLabelFor(t *testing.T) {
 }
 
 func TestNotebook_CellAppendedAndRendered(t *testing.T) {
-	m := newNotebookModel(nil, nil, 20)
+	m := newNotebookModel(nil, nil, 20, 0)
 	m = send(m, nbCellMsg{label: "assistant", body: "hi\nthere"})
 	if len(m.cells) != 1 {
 		t.Fatalf("cells = %d, want 1", len(m.cells))
@@ -46,7 +46,7 @@ func TestNotebook_CellAppendedAndRendered(t *testing.T) {
 }
 
 func TestNotebook_FoldToggleInNav(t *testing.T) {
-	m := newNotebookModel(nil, nil, 20)
+	m := newNotebookModel(nil, nil, 20, 0)
 	m = send(m, nbCellMsg{label: "assistant", body: "long answer here"})
 	// Esc enters nav mode selecting the last cell.
 	m = send(m, tea.KeyMsg{Type: tea.KeyEsc})
@@ -70,7 +70,7 @@ func TestNotebook_FoldToggleInNav(t *testing.T) {
 }
 
 func TestNotebook_KeysCommandAddsInfoCell(t *testing.T) {
-	m := newNotebookModel(nil, nil, 20)
+	m := newNotebookModel(nil, nil, 20, 0)
 	nm, _ := m.submit("/keys")
 	m = nm.(notebookModel)
 	if len(m.cells) != 1 || m.cells[0].label != "info" {
@@ -82,7 +82,7 @@ func TestNotebook_KeysCommandAddsInfoCell(t *testing.T) {
 }
 
 func TestNotebook_LiveRendersAtBottom(t *testing.T) {
-	m := newNotebookModel(nil, nil, 20)
+	m := newNotebookModel(nil, nil, 20, 0)
 	m = send(m, nbLiveMsg("streaming answer"))
 	out := m.renderCells()
 	if !strings.Contains(out, "▾ assistant") || !strings.Contains(out, "  streaming answer") {
@@ -103,7 +103,7 @@ func TestUIMode(t *testing.T) {
 }
 
 func TestNotebook_EnterSubmitsAndViewRenders(t *testing.T) {
-	m := newNotebookModel(nil, nil, 20)
+	m := newNotebookModel(nil, nil, 20, 0)
 	m = send(m, tea.WindowSizeMsg{Width: 80, Height: 24}) // sets ready + viewport size
 	m.ta.SetValue("/keys")
 	m = send(m, tea.KeyMsg{Type: tea.KeyEnter})
@@ -116,7 +116,7 @@ func TestNotebook_EnterSubmitsAndViewRenders(t *testing.T) {
 }
 
 func TestNotebook_UpArrowScrollsWhenNoHistory(t *testing.T) {
-	m := newNotebookModel(nil, nil, 20)
+	m := newNotebookModel(nil, nil, 20, 0)
 	m = send(m, tea.WindowSizeMsg{Width: 60, Height: 8}) // small viewport (~4 rows)
 	// add enough content to overflow the viewport
 	for i := 0; i < 6; i++ {
@@ -133,7 +133,7 @@ func TestNotebook_UpArrowScrollsWhenNoHistory(t *testing.T) {
 }
 
 func TestNotebook_RuleBetweenCells(t *testing.T) {
-	m := newNotebookModel(nil, nil, 20)
+	m := newNotebookModel(nil, nil, 20, 0)
 	m = send(m, tea.WindowSizeMsg{Width: 40, Height: 20})
 	m = send(m, nbCellMsg{label: "you", body: "hi"})
 	if strings.Contains(m.renderCells(), "─") {
@@ -156,7 +156,7 @@ func TestPromptArea_NewlineOffEnter(t *testing.T) {
 }
 
 func TestNotebook_CtrlJInsertsNewline(t *testing.T) {
-	m := newNotebookModel(nil, nil, 20)
+	m := newNotebookModel(nil, nil, 20, 0)
 	m = send(m, tea.WindowSizeMsg{Width: 40, Height: 20})
 	m.ta.SetValue("abc")
 	m.ta.CursorEnd()
@@ -167,7 +167,7 @@ func TestNotebook_CtrlJInsertsNewline(t *testing.T) {
 }
 
 func TestNotebook_UpMovesWithinPromptFirst(t *testing.T) {
-	m := newNotebookModel(nil, nil, 20)
+	m := newNotebookModel(nil, nil, 20, 0)
 	m = send(m, tea.WindowSizeMsg{Width: 40, Height: 20})
 	m.ta.SetValue("line1\nline2")
 	m.ta.CursorEnd()
@@ -181,7 +181,7 @@ func TestNotebook_UpMovesWithinPromptFirst(t *testing.T) {
 }
 
 func TestNotebook_PromptAutoGrowsAndClamps(t *testing.T) {
-	m := newNotebookModel(nil, nil, 4) // maxLines = 4
+	m := newNotebookModel(nil, nil, 4, 0) // maxLines = 4
 	m = send(m, tea.WindowSizeMsg{Width: 40, Height: 30})
 	if h := m.ta.Height(); h != 1 {
 		t.Fatalf("empty prompt height = %d, want 1", h)
@@ -208,7 +208,7 @@ func TestNotebook_PromptAutoGrowsAndClamps(t *testing.T) {
 }
 
 func TestNotebook_FirstPromptLineStaysVisible(t *testing.T) {
-	m := newNotebookModel(nil, nil, 20)
+	m := newNotebookModel(nil, nil, 20, 0)
 	m = send(m, tea.WindowSizeMsg{Width: 40, Height: 30})
 	typ := func(s string) { m = send(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}) }
 	nl := func() { m = send(m, tea.KeyMsg{Type: tea.KeyCtrlJ}) }

--- a/cmd/agentchat/status_test.go
+++ b/cmd/agentchat/status_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatStatus(t *testing.T) {
+	// model + session always shown; empty session -> "no session"
+	base := formatStatus("gpt-5.1", "", usageMsg{}, 0)
+	if !strings.Contains(base, "model gpt-5.1") || !strings.Contains(base, "session no session") {
+		t.Fatalf("base status wrong: %q", base)
+	}
+	// tokens appear once a turn has usage
+	withTok := formatStatus("m", "sess-1", usageMsg{in: 1200, out: 80}, 0)
+	if !strings.Contains(withTok, "1200↑ 80↓") || !strings.Contains(withTok, "session sess-1") {
+		t.Fatalf("token status wrong: %q", withTok)
+	}
+	// gauge only when a window is configured
+	if strings.Contains(withTok, "ctx left") {
+		t.Fatalf("no window should mean no gauge: %q", withTok)
+	}
+	gauge := formatStatus("m", "s", usageMsg{in: 2000}, 8000)
+	if !strings.Contains(gauge, "75% ctx left") { // (8000-2000)/8000
+		t.Fatalf("gauge wrong: %q", gauge)
+	}
+	// over-budget clamps at 0, never negative
+	over := formatStatus("m", "s", usageMsg{in: 9000}, 8000)
+	if !strings.Contains(over, "0% ctx left") {
+		t.Fatalf("over-budget should clamp to 0%%: %q", over)
+	}
+}

--- a/cmd/agentchat/tui.go
+++ b/cmd/agentchat/tui.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 	"sync"
@@ -27,6 +28,41 @@ type commitMsg string
 // turnDoneMsg re-enables input after a dispatched command or a turn
 // finishes on its goroutine.
 type turnDoneMsg struct{}
+
+// usageMsg carries the finished turn's token usage so the status line can show
+// a live context gauge. Sent by the observers on HostTurnDone.
+type usageMsg struct{ in, out int }
+
+// statusLine renders the persistent status: model · session · last-turn tokens,
+// plus a "N% context left" gauge when a context window is configured (issue
+// 1063 D1/D2). Kept out of the transcript — it lives only in the managed live
+// region so it is never committed to scrollback.
+func statusLine(app *host.App, u usageMsg, window int) string {
+	if app == nil {
+		return ""
+	}
+	return formatStatus(app.ModelLabel(), app.RunID(), u, window)
+}
+
+// formatStatus is the pure status-line renderer (model · session · tokens ·
+// gauge), split out so it is testable without a live App.
+func formatStatus(model, session string, u usageMsg, window int) string {
+	if session == "" {
+		session = "no session"
+	}
+	parts := []string{"model " + model, "session " + session}
+	if u.in > 0 || u.out > 0 {
+		parts = append(parts, fmt.Sprintf("ctx %d↑ %d↓ tok", u.in, u.out))
+	}
+	if window > 0 && u.in > 0 {
+		left := 100 * (window - u.in) / window
+		if left < 0 {
+			left = 0
+		}
+		parts = append(parts, fmt.Sprintf("%d%% ctx left", left))
+	}
+	return strings.Join(parts, " · ")
+}
 
 // tuiObserver is the host.Observer the App renders through in inline TUI
 // mode. It forwards each HostEvent to the built-in terminal renderer
@@ -68,6 +104,9 @@ func (s *tuiObserver) On(ev host.HostEvent) {
 	if prog == nil {
 		return
 	}
+	if ev.Kind == host.HostTurnDone && ev.Result != nil {
+		prog.Send(usageMsg{in: ev.Result.Usage.InputTokens, out: ev.Result.Usage.OutputTokens})
+	}
 	if boundary {
 		prog.Send(commitMsg(segment))
 	} else {
@@ -90,6 +129,8 @@ type tuiModel struct {
 	histIdx int // len(history) == "not navigating"
 	running bool
 	pending string
+	usage   usageMsg // last turn's tokens, for the status line
+	window  int      // context window for the "N% left" gauge (0 = off)
 }
 
 // newPromptArea builds the shared input textarea used by both TUI surfaces
@@ -116,8 +157,8 @@ func newPromptArea() textarea.Model {
 	return ta
 }
 
-func newTUIModel(app *host.App, surface *tuiObserver) tuiModel {
-	m := tuiModel{app: app, surface: surface, ta: newPromptArea()}
+func newTUIModel(app *host.App, surface *tuiObserver, window int) tuiModel {
+	m := tuiModel{app: app, surface: surface, ta: newPromptArea(), window: window}
 	m.histIdx = 0
 	return m
 }
@@ -144,6 +185,10 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case turnDoneMsg:
 		m.running = false
+		return m, nil
+
+	case usageMsg:
+		m.usage = msg
 		return m, nil
 
 	case tea.KeyMsg:
@@ -189,9 +234,9 @@ func (m tuiModel) View() string {
 		b.WriteString(strings.TrimRight(m.pending, "\n"))
 		b.WriteString("\n")
 	}
-	status := "ready"
+	status := statusLine(m.app, m.usage, m.window)
 	if m.running {
-		status = "working…"
+		status = "working… · " + status
 	}
 	b.WriteString(lipgloss.NewStyle().Faint(true).Render(status))
 	b.WriteString("\n")
@@ -345,8 +390,8 @@ func wantTUI(mode string) bool { return uiMode(mode) != "plain" }
 // and the live turn render at the bottom while finished segments commit to
 // the terminal's own scrollback. The surface is wired to the program so
 // host events stream in as the model renders.
-func runTUI(app *host.App, surface *tuiObserver) error {
-	prog := tea.NewProgram(newTUIModel(app, surface))
+func runTUI(app *host.App, surface *tuiObserver, window int) error {
+	prog := tea.NewProgram(newTUIModel(app, surface, window))
 	surface.prog = prog
 	_, err := prog.Run()
 	return err

--- a/cmd/agentchat/tui_test.go
+++ b/cmd/agentchat/tui_test.go
@@ -79,7 +79,7 @@ func TestIsBoundary(t *testing.T) {
 }
 
 func TestUpdateLiveThenCommit(t *testing.T) {
-	m := newTUIModel(nil, nil)
+	m := newTUIModel(nil, nil, 0)
 
 	// a live segment lands in the pending region, not scrollback
 	next, _ := m.Update(liveMsg("thinking…"))
@@ -111,7 +111,7 @@ func TestUpdateLiveThenCommit(t *testing.T) {
 }
 
 func TestUpdateTurnDoneClearsRunning(t *testing.T) {
-	m := newTUIModel(nil, nil)
+	m := newTUIModel(nil, nil, 0)
 	m.running = true
 	next, _ := m.Update(turnDoneMsg{})
 	if next.(tuiModel).running {
@@ -170,7 +170,7 @@ func TestCompleteTab(t *testing.T) {
 func TestKeyMap_WordNavHasCtrlArrows(t *testing.T) {
 	// newTUIModel only stores app/surface; nil is fine for inspecting the
 	// configured textarea KeyMap.
-	m := newTUIModel(nil, nil)
+	m := newTUIModel(nil, nil, 0)
 	fwd := m.ta.KeyMap.WordForward.Keys()
 	back := m.ta.KeyMap.WordBackward.Keys()
 	if !slices.Contains(fwd, "ctrl+right") {
@@ -195,7 +195,7 @@ func TestKeyHelp_ListsBindings(t *testing.T) {
 }
 
 func TestKeyMap_CtrlRightMovesByWord(t *testing.T) {
-	m := newTUIModel(nil, nil)
+	m := newTUIModel(nil, nil, 0)
 	m.ta.SetValue("one two three")
 	m.ta.CursorStart()
 	if col := m.ta.LineInfo().ColumnOffset; col != 0 {


### PR DESCRIPTION
> **Stacked on #1073** (base `feat/910-skills-catalog`). No file overlap with #910/#688 — it just branches off the chain. CI won't run until the base is `main`; verified locally. Retarget to `main` as the chain merges.

## What changes

The first concrete slice of the TUI layout design track (#1063): a **persistent status line** on both surfaces — `model <active> · session <id> · ctx <in>↑ <out>↓ tok` — wired from the streamed per-turn `Usage`, plus an optional **`N% context left` gauge** (`--context-window`). Context exhaustion is the #1 silent failure; this makes it visible. (Collapsible tool cells, checklist item B4, already shipped with `--ui notebook`.)

## Reviewer's guide

1. [cmd/agentchat/tui.go](https://github.com/panyam/mcpkit/pull/1074/files#diff-0e29207287df07cecf17e04df9f99e726ae789983f7e3ce007bb6282029b4db6) — `statusLine(app, usage, window)` + the pure, tested `formatStatus`; `usageMsg`; the inline `View` status line; the observer sends `usageMsg` on `HostTurnDone`.
2. [cmd/agentchat/status_test.go](https://github.com/panyam/mcpkit/pull/1074/files#diff-cd9e8386d0adf14f3b208376059df121ffaf60c79d18023cef15c011b5bff63a) — `formatStatus` (model/session/tokens/gauge/clamp).
3. [cmd/agentchat/notebook.go](https://github.com/panyam/mcpkit/pull/1074/files#diff-8a79677a206f62f0abeebce75abd2fbafac2dc1be85310113e702bebc42624b1) — the notebook status bar becomes two lines (status + key hints); viewport height adjusted; observer sends `usageMsg`.
4. [agent/host/app.go](https://github.com/panyam/mcpkit/pull/1074/files#diff-89fb8e04b6e1e9d5f7f76958490ef158dee40e2cae92d87c04b408d893c84361) — `ModelLabel()` accessor.
5. [cmd/agentchat/main.go](https://github.com/panyam/mcpkit/pull/1074/files#diff-ce3956549c93b4983f18090136a2139c3c92d38408e923245f5e9ba628bcc98a) — `--context-window` flag, threaded to both surfaces.

## Decision log

- **Status stays in the managed live region, never `Println`'d** (checklist A3/D1) — committing model/cost/session into scrollback pollutes copy/paste and duplicates on resize.
- **`ModelLabel()` on `App`** (not surface-local) — a future web surface wants the same; it prefers the active connection name, falling back to the single-model id.
- **`formatStatus` split out pure** — a full `App` is heavy to build in a unit test; the token/gauge/clamp logic is the part worth pinning.
- **Gauge is opt-in via `--context-window`** — mcpkit has no per-model context-window table, so absent a configured window we show raw token counts rather than guess a %.

## Risk / blast radius

- **Additive, both surfaces**; `plain` mode unchanged. Nil-app-safe (`statusLine` returns "" so the existing render tests pass).
- **Tests**: `formatStatus`; existing tui/notebook tests still green.

## Before / after

```
before (inline status):   ready
after:                    model openai-5.1 · session kitchen-sink · ctx 1240↑ 86↓ tok
after (--context-window 200000):
                          model openai-5.1 · session kitchen-sink · ctx 1240↑ 86↓ tok · 99% ctx left
notebook status bar (2 lines):
   model … · session … · ctx …
   INS  enter send · ctrl+j newline · ↑↓ scroll · esc fold
```

## Out of scope (the rest of #1063's checklist)

- Buffer-then-commit + Glamour-at-commit markdown (B1/B2); `key.Binding` + `help` bar (C2); AdaptiveColor/`NO_COLOR` polish (E); grapheme-width + BT v2 cellbuf (F2/B3); overlay dialogs (A4/C3). Each is its own follow-up under the track.

