### PR TITLE
build(examples): justfile side of the examples orchestrator (#688 follow-up)

### DIFF
--- a/examples/justfile
+++ b/examples/justfile
@@ -1,0 +1,56 @@
+# examples/justfile — test orchestration for the examples tree (mirror of
+# examples/Makefile). The root justfile delegates here via `just test-examples`.
+#
+# Every recipe here is infra-free (no Docker/live services) so `just test` runs
+# in CI as-is. The events/discord + events/telegram suites moved here from
+# experimental/justfile (they test example apps, not the experimental library);
+# experimental/justfile keeps the old names as aliases.
+
+EXAMPLES_DIR := justfile_directory()
+
+# Run every infra-free example test
+test: test-agents-async test-agents-multi test-skills test-tasks-v2 test-common test-otel-stdout test-protogen test-events-kitchen-sink test-events-discord test-events-telegram test-whole-enchilada-event-server
+
+# agents/agent-async
+test-agents-async:
+    cd {{EXAMPLES_DIR}}/agents/agent-async && go test ./... -count=1 -timeout 60s
+
+# agents/multi-agent
+test-agents-multi:
+    cd {{EXAMPLES_DIR}}/agents/multi-agent && go test ./... -count=1 -timeout 60s
+
+# skills (agent scenario)
+test-skills:
+    cd {{EXAMPLES_DIR}}/skills && go test ./... -count=1 -timeout 60s -run TestAgentScenario
+
+# tasks-v2 (agent scenario)
+test-tasks-v2:
+    cd {{EXAMPLES_DIR}}/tasks-v2 && go test ./... -count=1 -timeout 60s -run TestAgentScenario
+
+# common (shared example helpers + otel setup)
+test-common:
+    cd {{EXAMPLES_DIR}}/common && go test ./... -count=1 -timeout 60s
+
+# otel/stdout smoke
+test-otel-stdout:
+    cd {{EXAMPLES_DIR}}/otel/stdout && go test ./... -count=1 -timeout 60s
+
+# protogen/bookservice
+test-protogen:
+    cd {{EXAMPLES_DIR}}/protogen/bookservice && go test ./... -count=1 -timeout 60s
+
+# events/kitchen-sink
+test-events-kitchen-sink:
+    cd {{EXAMPLES_DIR}}/events/kitchen-sink && go test ./... -count=1 -timeout 60s
+
+# whole-enchilada/events/event-server
+test-whole-enchilada-event-server:
+    cd {{EXAMPLES_DIR}}/whole-enchilada/events/event-server && go test ./... -count=1 -timeout 60s
+
+# events/discord (runner-agnostic script, shared with the Makefile)
+test-events-discord:
+    @bash {{EXAMPLES_DIR}}/../experimental/scripts/test-events-discord.sh
+
+# events/telegram
+test-events-telegram:
+    @bash {{EXAMPLES_DIR}}/../experimental/scripts/test-events-telegram.sh

--- a/experimental/justfile
+++ b/experimental/justfile
@@ -9,10 +9,10 @@
 # shared with the Makefile). The -pg / -real variants delegate to the
 # sub-module recipes that boot Docker containers.
 #
-# Two of the sub-suites live under `examples/events/` rather than
-# `experimental/`, but they're conceptually part of the experimental
-# events POC (they're demo apps consuming the experimental library), so
-# they're orchestrated here next to the library tests.
+# The discord/telegram example suites moved to examples/justfile (they test
+# example apps, not the experimental library — issue 688). The recipes below
+# are kept as aliases delegating there, so testall's per-suite timing (7a–7e)
+# and any CI script referencing the old names keep working.
 
 EXPERIMENTAL_DIR := justfile_directory()
 
@@ -44,12 +44,13 @@ test-events-stores-redis-real:
     just -f {{EXPERIMENTAL_DIR}}/ext/events/stores/redis/justfile testredis
 
 # Run experimental events Discord example tests
+# (alias) Discord example tests — moved to examples/justfile (issue 688)
 test-events-discord:
-    @bash {{EXPERIMENTAL_DIR}}/scripts/test-events-discord.sh
+    just -f {{EXPERIMENTAL_DIR}}/../examples/justfile test-events-discord
 
-# Run experimental events Telegram example tests
+# (alias) Telegram example tests — moved to examples/justfile (issue 688)
 test-events-telegram:
-    @bash {{EXPERIMENTAL_DIR}}/scripts/test-events-telegram.sh
+    just -f {{EXPERIMENTAL_DIR}}/../examples/justfile test-events-telegram
 
 # Show available recipes
 help:

--- a/justfile
+++ b/justfile
@@ -259,6 +259,10 @@ test-experimental:
     @bash experimental/scripts/test-events-discord.sh
     @bash experimental/scripts/test-events-telegram.sh
 
+# Run every infra-free example test (delegates to examples/justfile)
+test-examples:
+    just -f examples/justfile test
+
 # Run experimental ext/events library tests
 test-experimental-events:
     @bash experimental/scripts/test-events.sh


### PR DESCRIPTION
## What changes

#688 (merged) added `examples/Makefile` but not the justfile half — and justfiles are the primary runner since the migration. This mirrors it so `just` users get the same orchestrator.

## Reviewer's guide

1. [examples/justfile](https://github.com/panyam/mcpkit/pull/1075/files#diff-6d65d6c2df0c42e7b9fed55b65594037319f9f9211f07dc748b83f1bf738a8a6) — the `test` umbrella + per-example recipes (1:1 with `examples/Makefile`, infra-free so CI-safe).
2. [justfile](https://github.com/panyam/mcpkit/pull/1075/files#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1) — root `test-examples` recipe (`just -f examples/justfile test`).
3. [experimental/justfile](https://github.com/panyam/mcpkit/pull/1075/files#diff-a53c5b58663cf16afed08892e7217ae793651085f71edb4149928a96a8851968) — `test-events-discord`/`-telegram` become **aliases** delegating to [examples/justfile](https://github.com/panyam/mcpkit/pull/1075/files#diff-6d65d6c2df0c42e7b9fed55b65594037319f9f9211f07dc748b83f1bf738a8a6), mirroring the Makefile aliases; header note updated.

## Risk / blast radius

Additive + delegating; no test dropped. Verified: `just -f examples/justfile test` green, the experimental alias delegates (exit 0), `just test-examples` resolves.

## Out of scope

Same follow-ups noted on #688 (move the scripts under `examples/`; fold testall's stage map + the root `test-agent` hardcoded example steps into the orchestrator).
