### PR TITLE
feat(agent/host): per-server skillsAllow hard filter (#910 follow-up)

### DIFF
--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -212,7 +212,7 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 		if sc.Skills != nil && !*sc.Skills {
 			continue
 		}
-		block, cat, err := loadSkillsForServer(app.clients[i], sc.ID, sc.SkillsMode, app.emit, o.tp)
+		block, cat, err := loadSkillsForServer(app.clients[i], sc.ID, sc.SkillsMode, sc.SkillsAllow, app.emit, o.tp)
 		if err != nil {
 			app.Close()
 			return nil, err

--- a/agent/host/config.go
+++ b/agent/host/config.go
@@ -361,6 +361,14 @@ type ServerConfig struct {
 	// when Skills is false.
 	SkillsMode string `json:"skillsMode,omitempty"`
 
+	// SkillsAllow, when non-empty, restricts this server to the named skills
+	// (by skill Name), a hard capability boundary rather than a display
+	// preference. The fetched index is narrowed to the allowed entries before
+	// anything else, so both the injected block (eager or catalog) and the
+	// load_skill tool only ever see allowed skills. Nil or empty means every
+	// skill the server advertises. This is the skills analog of Allow.
+	SkillsAllow []string `json:"skillsAllow,omitempty"`
+
 	// Events lists the event streams to open on this server. Each event
 	// feeds the injection policy (and any trigger bindings that match).
 	Events []EventConfig `json:"events,omitempty"`

--- a/agent/host/skills.go
+++ b/agent/host/skills.go
@@ -48,14 +48,40 @@ func resolveSkillsMode(mode string, idx skills.Index) string {
 	}
 }
 
+// filterSkillsAllow narrows an index to only the entries whose Name is in the
+// allow list, a hard capability boundary applied before mode resolution so both
+// the injected block and the load_skill tool see only allowed skills. An empty
+// (or nil) allow list is a passthrough that returns the index unchanged. The
+// match is exact by Name and covers every entry type, though only skill-md
+// entries reach the model downstream. Original entry order is preserved.
+func filterSkillsAllow(idx skills.Index, allow []string) skills.Index {
+	if len(allow) == 0 {
+		return idx
+	}
+	want := make(map[string]struct{}, len(allow))
+	for _, name := range allow {
+		want[name] = struct{}{}
+	}
+	var kept []skills.IndexEntry
+	for _, e := range idx.Skills {
+		if _, ok := want[e.Name]; ok {
+			kept = append(kept, e)
+		}
+	}
+	return skills.NewIndex(kept...)
+}
+
 // loadSkillsForServer fetches a server's skill index and returns the system-
 // prompt block plus, in catalog mode, the entries the load_skill tool serves.
 // Servers without the skills capability return empty silently; a fetchable
 // index that fails is a startup error (the server advertised skills and the
-// host could not honor them). Eager mode injects full bodies (digest-verified;
-// per-skill failures warn and are excluded); catalog mode injects only
-// name+description and defers bodies to load_skill.
-func loadSkillsForServer(c *client.Client, serverID, mode string, emit func(HostEvent), tp core.TracerProvider) (string, []catalogSkill, error) {
+// host could not honor them). When skillsAllow is non-empty the index is
+// narrowed to those skills first, so every downstream step (mode resolution,
+// eager bodies, catalog, load_skill) operates on the allowed set only. Eager
+// mode injects full bodies (digest-verified; per-skill failures warn and are
+// excluded); catalog mode injects only name+description and defers bodies to
+// load_skill.
+func loadSkillsForServer(c *client.Client, serverID, mode string, skillsAllow []string, emit func(HostEvent), tp core.TracerProvider) (string, []catalogSkill, error) {
 	sc := skills.NewClient(c, skills.WithTracerProvider(tp))
 	if !sc.SupportsSkills() {
 		return "", nil, nil
@@ -64,6 +90,7 @@ func loadSkillsForServer(c *client.Client, serverID, mode string, emit func(Host
 	if err != nil {
 		return "", nil, fmt.Errorf("agentchat: skills index from %s: %w", serverID, err)
 	}
+	idx = filterSkillsAllow(idx, skillsAllow)
 
 	if resolveSkillsMode(mode, idx) == "catalog" {
 		var cat []catalogSkill

--- a/agent/host/skills_test.go
+++ b/agent/host/skills_test.go
@@ -32,6 +32,61 @@ func TestResolveSkillsMode(t *testing.T) {
 	}
 }
 
+func TestFilterSkillsAllow(t *testing.T) {
+	idx := skills.NewIndex(
+		skills.IndexEntry{Type: skills.SkillTypeSkillMD, Name: "alpha"},
+		skills.IndexEntry{Type: skills.SkillTypeSkillMD, Name: "beta"},
+		skills.IndexEntry{Type: skills.SkillTypeSkillMD, Name: "gamma"},
+	)
+
+	names := func(i skills.Index) []string {
+		var out []string
+		for _, e := range i.Skills {
+			out = append(out, e.Name)
+		}
+		return out
+	}
+	eq := func(got, want []string) bool {
+		if len(got) != len(want) {
+			return false
+		}
+		for i := range got {
+			if got[i] != want[i] {
+				return false
+			}
+		}
+		return true
+	}
+
+	// empty allow is a passthrough (all skills, unchanged)
+	if got := names(filterSkillsAllow(idx, nil)); !eq(got, []string{"alpha", "beta", "gamma"}) {
+		t.Fatalf("nil allow should passthrough, got %v", got)
+	}
+	if got := names(filterSkillsAllow(idx, []string{})); !eq(got, []string{"alpha", "beta", "gamma"}) {
+		t.Fatalf("empty allow should passthrough, got %v", got)
+	}
+
+	// subset keeps only allowed names, in original order (not allow order)
+	if got := names(filterSkillsAllow(idx, []string{"gamma", "alpha"})); !eq(got, []string{"alpha", "gamma"}) {
+		t.Fatalf("subset should keep allowed in index order, got %v", got)
+	}
+
+	// unknown names in allow are no-ops
+	if got := names(filterSkillsAllow(idx, []string{"beta", "nope", "missing"})); !eq(got, []string{"beta"}) {
+		t.Fatalf("unknown allow names should be ignored, got %v", got)
+	}
+
+	// allow that matches nothing yields an empty skill set
+	if got := names(filterSkillsAllow(idx, []string{"nope"})); len(got) != 0 {
+		t.Fatalf("no matches should yield empty index, got %v", got)
+	}
+
+	// the schema URI survives the rebuild
+	if filterSkillsAllow(idx, []string{"alpha"}).Schema != idx.Schema {
+		t.Fatal("filtered index should keep the index schema URI")
+	}
+}
+
 func TestRegisterLoadSkill(t *testing.T) {
 	app := &App{}
 	multi := agent.NewMultiSource()


### PR DESCRIPTION
## What changes

Adds a per-server `skillsAllow []string` (JSON `skillsAllow`) hard allowlist to `ServerConfig`. When non-empty, a server's fetched skill index is narrowed to only the entries whose `Name` is in the list, right after `ListSkills` and before mode resolution, so both the injected system-prompt block (eager or catalog) and the `load_skill` tool only ever see allowed skills. Empty or nil means every advertised skill (today's behavior, unchanged). This is the skills analog of the existing per-server tool `Allow` capability boundary, and a deferred follow-up to issue 910 (two-tier skills loading, already closed).

## Reviewer's guide

1. `agent/host/config.go` — new `ServerConfig.SkillsAllow []string` field with a doc comment that mirrors the `Allow` tone (a capability boundary, not a display preference). Sits next to `Skills` and `SkillsMode`.
2. `agent/host/skills.go` — new pure helper `filterSkillsAllow(idx skills.Index, allow []string) skills.Index`: empty/nil allow returns the index unchanged; otherwise it rebuilds the index (`skills.NewIndex`) to keep only entries whose `Name` is in the allow set, preserving original entry order. `loadSkillsForServer` gains a `skillsAllow []string` parameter and calls the helper immediately after `sc.ListSkills`, so every downstream step (`resolveSkillsMode`, eager bodies, catalog collection, `load_skill`) operates on the filtered index.
3. `agent/host/app.go` — the `NewApp` loop passes `sc.SkillsAllow` into the widened `loadSkillsForServer` call.
4. `agent/host/skills_test.go` — `TestFilterSkillsAllow` unit-tests the helper directly (no server fixture needed): empty/nil passthrough, subset keeps only allowed names in index order, unknown allow names are no-ops, an all-miss allow yields an empty set, and the schema URI survives the rebuild.

## Decision log

- **Filter before mode resolution, not after.** Narrowing the index first means `resolveSkillsMode`'s auto threshold counts only allowed skills, and catalog collection plus `load_skill` inherit the boundary for free. No branch touches an excluded skill.
- **Match by `Name`, exact, across all entry types.** The allowlist keys on skill `Name`. Archive entries carry names too, but only skill-md entries reach the model downstream, so the filter is written generically and documented as such rather than special-casing skill-md.
- **Rebuild via `skills.NewIndex` rather than mutating `idx.Skills`.** Keeps the schema URI intact and avoids aliasing the caller's slice.
- **Extract a pure helper.** `loadSkillsForServer` needs a live skills server and has no test fixture (see `agent/host/skills_test.go`, which tests `resolveSkillsMode` and `registerLoadSkill` without a server). The pure `filterSkillsAllow` is the testable unit; the loader just calls it.

## Risk / blast radius

Low, additive. Empty/nil `SkillsAllow` is the default and preserves current behavior exactly; the filter only engages when an operator sets the list. Change is confined to `agent/host`; no protocol surface, no `ext/skills` change. `go vet` clean; `agent/host` and `ext/skills` test suites green.

## Before / after

Config:

```json
{
  "servers": [
    {
      "id": "docs",
      "url": "http://localhost:8099/mcp",
      "skillsAllow": ["pdf-forms", "spreadsheet-macros"]
    }
  ]
}
```

Before: the server advertises 12 skills; all 12 flow into mode resolution, the injected block, and (in catalog mode) `load_skill`.

After: only `pdf-forms` and `spreadsheet-macros` survive the fetch. The model's system prompt block and the `load_skill` catalog contain exactly those two; the other ten are invisible to the model, the same way an out-of-`Allow` tool is.

## Out of scope

The other issue 910 follow-ups are deliberately not touched here: a `SkillsPolicy` hook, per-conversation skill-body caching, and a byte-based (rather than count-based) catalog threshold.
