### PR TITLE
fix(agentchat): status line must not read RunID() under turnMu

### DIFF
--- a/cmd/agentchat/notebook.go
+++ b/cmd/agentchat/notebook.go
@@ -172,6 +172,7 @@ type notebookModel struct {
 	maxLines      int      // input auto-grows up to this many rows (0 = default)
 	usage         usageMsg // last turn's tokens, for the status line
 	window        int      // context window for the "N% left" gauge (0 = off)
+	session       string   // cached RunID for the status line (refreshed off the render path)
 	width, height int
 	ready         bool
 }
@@ -186,6 +187,10 @@ func newNotebookModel(app *host.App, surface *nbObserver, maxLines, window int) 
 	}
 	m := notebookModel{app: app, surface: surface, ta: newPromptArea(), atBottom: true, maxLines: maxLines, window: window}
 	m.histIdx = 0
+	if app != nil {
+		// Safe here: construction runs before the first turn, so turnMu is free.
+		m.session = app.RunID()
+	}
 	return m
 }
 
@@ -244,6 +249,11 @@ func (m notebookModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case turnDoneMsg:
 		m.running = false
+		// The turn (or dispatched command) has fully returned, so turnMu is
+		// free and a session-changing command like /sessions has landed.
+		if m.app != nil {
+			m.session = m.app.RunID()
+		}
 		return m, nil
 
 	case usageMsg:
@@ -387,7 +397,7 @@ func (m notebookModel) statusBar() string {
 		hint = "working…  " + hint
 	}
 	// Two-line status: the persistent model/session/context line, then keys.
-	return lipgloss.NewStyle().Faint(true).Render(statusLine(m.app, m.usage, m.window) + "\n" + hint)
+	return lipgloss.NewStyle().Faint(true).Render(statusLine(m.app, m.session, m.usage, m.window) + "\n" + hint)
 }
 
 // refresh rebuilds the viewport content from the cells (+ the live turn) and,

--- a/cmd/agentchat/tui.go
+++ b/cmd/agentchat/tui.go
@@ -37,11 +37,17 @@ type usageMsg struct{ in, out int }
 // plus a "N% context left" gauge when a context window is configured (issue
 // 1063 D1/D2). Kept out of the transcript — it lives only in the managed live
 // region so it is never committed to scrollback.
-func statusLine(app *host.App, u usageMsg, window int) string {
+//
+// session is passed in (cached by the surface model), NOT read live from
+// app.RunID(): RunID takes App.turnMu, which RunTurn holds for the whole turn,
+// so calling it from View() would block every render until the turn finished
+// and freeze the UI. ModelLabel only touches the connections mutex (never held
+// during a turn) so it stays a live read.
+func statusLine(app *host.App, session string, u usageMsg, window int) string {
 	if app == nil {
 		return ""
 	}
-	return formatStatus(app.ModelLabel(), app.RunID(), u, window)
+	return formatStatus(app.ModelLabel(), session, u, window)
 }
 
 // formatStatus is the pure status-line renderer (model · session · tokens ·
@@ -131,6 +137,7 @@ type tuiModel struct {
 	pending string
 	usage   usageMsg // last turn's tokens, for the status line
 	window  int      // context window for the "N% left" gauge (0 = off)
+	session string   // cached RunID for the status line (refreshed off the render path)
 }
 
 // newPromptArea builds the shared input textarea used by both TUI surfaces
@@ -160,6 +167,10 @@ func newPromptArea() textarea.Model {
 func newTUIModel(app *host.App, surface *tuiObserver, window int) tuiModel {
 	m := tuiModel{app: app, surface: surface, ta: newPromptArea(), window: window}
 	m.histIdx = 0
+	if app != nil {
+		// Safe here: construction runs before the first turn, so turnMu is free.
+		m.session = app.RunID()
+	}
 	return m
 }
 
@@ -185,6 +196,11 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case turnDoneMsg:
 		m.running = false
+		// The turn (or dispatched command) has fully returned, so turnMu is
+		// free and a session-changing command like /sessions has landed.
+		if m.app != nil {
+			m.session = m.app.RunID()
+		}
 		return m, nil
 
 	case usageMsg:
@@ -234,7 +250,7 @@ func (m tuiModel) View() string {
 		b.WriteString(strings.TrimRight(m.pending, "\n"))
 		b.WriteString("\n")
 	}
-	status := statusLine(m.app, m.usage, m.window)
+	status := statusLine(m.app, m.session, m.usage, m.window)
 	if m.running {
 		status = "working… · " + status
 	}

--- a/cmd/agentchat/tui_test.go
+++ b/cmd/agentchat/tui_test.go
@@ -1,10 +1,15 @@
 package main
 
 import (
+	"context"
+	"errors"
+	"io"
 	"net/http/httptest"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/charmbracelet/bubbles/textarea"
 	tea "github.com/charmbracelet/bubbletea"
@@ -192,6 +197,67 @@ func TestKeyHelp_ListsBindings(t *testing.T) {
 			t.Fatalf("keyHelp() missing %q:\n%s", want, h)
 		}
 	}
+}
+
+// blockingProvider holds a turn open inside the model call until release is
+// closed, so a test can observe the UI while App.turnMu is held by RunTurn.
+type blockingProvider struct {
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (p *blockingProvider) signalStarted() { p.once.Do(func() { close(p.started) }) }
+
+func (p *blockingProvider) Stream(ctx context.Context, req agent.ProviderRequest) (agent.Stream, error) {
+	p.signalStarted()
+	<-p.release
+	return nil, errors.New("blocking provider released")
+}
+
+func (p *blockingProvider) Generate(ctx context.Context, req agent.ProviderRequest) (*agent.ProviderResponse, error) {
+	p.signalStarted()
+	<-p.release
+	return nil, errors.New("blocking provider released")
+}
+
+// TestView_DoesNotBlockDuringTurn guards the #1074 regression: the status line
+// must render from a cached session, never from App.RunID() (which takes
+// turnMu, held by RunTurn for the whole turn). Before the fix, View() blocked
+// until the turn finished, freezing the UI on the first message.
+func TestView_DoesNotBlockDuringTurn(t *testing.T) {
+	prov := &blockingProvider{started: make(chan struct{}), release: make(chan struct{})}
+	cfg := &host.Config{
+		Model: host.ModelConfig{BaseURL: "http://unused", Model: "stub"},
+		Connections: &host.ConnectionsConfig{
+			Active:      "local",
+			Connections: map[string]host.ConnectionConfig{"local": {Type: "lmstudio", Model: "m"}},
+		},
+	}
+	build := func(host.ConnectionConfig) (agent.Provider, error) { return prov, nil }
+	app, err := host.NewApp(cfg, io.Discard, strings.NewReader(""), host.WithProviderBuilder(build))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Close()
+
+	m := newTUIModel(app, nil, 0)
+
+	turnDone := make(chan struct{})
+	go func() { _ = app.RunTurn(context.Background(), "hi"); close(turnDone) }()
+	<-prov.started // the turn now holds turnMu inside the provider
+
+	rendered := make(chan string, 1)
+	go func() { rendered <- m.View() }()
+	select {
+	case <-rendered: // View returned while the turn is in flight — the fix holds
+	case <-time.After(2 * time.Second):
+		close(prov.release)
+		t.Fatal("View() blocked during a turn — status line is reading RunID() under turnMu")
+	}
+
+	close(prov.release)
+	<-turnDone
 }
 
 func TestKeyMap_CtrlRightMovesByWord(t *testing.T) {


### PR DESCRIPTION
## What changes

The agentchat status line (PR 1074, `#1063` D1/D2) froze both TUI surfaces on the **first message**: the moment a turn started, the UI hung until the turn finished. Root cause: `statusLine` called `app.RunID()` on every `View()` render, and `RunID()` takes `App.turnMu` — which `RunTurn` holds for the *entire* turn. So the bubbletea render loop blocked on the mutex for the whole turn. This makes the status line render from a session id cached in the surface model instead, off the render path.

## Reviewer's guide
Read in this order:
1. [cmd/agentchat/tui.go](https://github.com/panyam/mcpkit/pull/1077/files#diff-0e29207287df07cecf17e04df9f99e726ae789983f7e3ce007bb6282029b4db6) — start here. `statusLine` now takes `session` as a param (only calls `app.ModelLabel()`, which touches the connections mutex, never `turnMu`). `tuiModel` gains a cached `session`, set at construction and refreshed on `turnDoneMsg`.
2. [cmd/agentchat/tui_test.go](https://github.com/panyam/mcpkit/pull/1077/files#diff-68ccb7754cb7a3e92c63ccecf5613cb252fcae31e66f524e2ab680a096069bc3) — `TestView_DoesNotBlockDuringTurn` is the acceptance: a blocking provider holds a turn open (so `turnMu` is held) and the test asserts `View()` still returns within 2s.
3. [cmd/agentchat/notebook.go](https://github.com/panyam/mcpkit/pull/1077/files#diff-8a79677a206f62f0abeebce75abd2fbafac2dc1be85310113e702bebc42624b1) — the same cache-session treatment for the notebook surface (`statusBar`).

## How it works
```
construct model:      session = app.RunID()      // safe — no turn in flight yet
turn-done message:    session = app.RunID()       // safe — turnMu released, /sessions may have swapped it
View() (hot path):    statusLine(app, m.session)  // reads cached field + ModelLabel(); never RunID()
```
Session id cannot change mid-turn, so a value cached at the last turn boundary is always correct for the status line.

## Decision log
- Fixed at the surface layer (cache in the model), not by changing `RunID()`'s locking. `RunID()`'s `turnMu` guard is correct for callers that need a consistent read against an in-flight turn; the bug was the render path calling a blocking accessor, not the accessor itself.
- Kept `app.ModelLabel()` live in `statusLine` — it only locks the connections mutex (held briefly by `SetActive`, never during a turn), so `/provider` switches stay reflected immediately with no caching needed.

## Risk / blast radius
- Affects: `cmd/agentchat` only (inline `--ui tui` + `--ui notebook`). No host/agent/library change.
- Tests covering this: `TestView_DoesNotBlockDuringTurn` (new, fails on the pre-fix code), plus the existing `formatStatus` unit tests.
- Be paranoid about: whether the cached session goes stale. It refreshes on every `turnDoneMsg`, which is emitted after both turns and dispatched commands (including `/sessions` resume and fork), so the status picks up a session swap on the next boundary.

## Before / after
```
# before: send first message in `just note`
> hi
[UI frozen — no input echo, no status update, until the whole turn completes]

# after
> hi
working… · model local · session <id> · ctx 1200↑ 80↓ tok   [renders live throughout the turn]
```

## Out of scope
- The `#910` skillsAllow follow-up ships separately as PR 1076.
