### PR TITLE
docs(agent/host): document the skills trust model (eager vs catalog)

### DIFF
--- a/agent/host/README.md
+++ b/agent/host/README.md
@@ -51,6 +51,19 @@ stay out of the lean `agent/` module.
   nothing; persistence failures degrade to a rendered warning, never a turn
   failure.
 
+## Skills trust model
+
+Skills are data, not code (`ext/skills` is enforced no-exec), so the risk a
+skills server carries is context-poisoning, not side effects. `ServerConfig.SkillsMode`
+is the trust lever. `"eager"` splices full skill bodies into the system prompt
+at connect time with no per-skill gate — reserve it for servers you trust.
+`"catalog"` is the safer default for a lower-trust server: a skill enters
+context only when the model calls `load_skill`, which is an ordinary tool, so it
+flows through the approval ladder (set `Approval.Rules["load_skill"] = "ask"` to
+confirm each activation — the prompt names the requested skill). The fetched
+body lands in tool history rather than the system prompt, so it carries less
+authority. See the `SkillsMode` godoc in `config.go`.
+
 ## Testing
 
 Fully offline: real in-process mcpkit servers plus a scripted `StubProvider` plus

--- a/agent/host/config.go
+++ b/agent/host/config.go
@@ -359,6 +359,18 @@ type ServerConfig struct {
 	// (auto — eager below a small skill count, catalog at/above). Progressive
 	// disclosure keeps a large skill set from bloating every request. Ignored
 	// when Skills is false.
+	//
+	// Mode is also the trust lever for a lower-trust skills server. Skills are
+	// data, not code (ext/skills is enforced no-exec), so the risk they carry
+	// is context-poisoning: a skill body is text the model reads as guidance.
+	// "eager" splices that text into the system prompt at connect time, with no
+	// per-skill gate. "catalog" is the safer default for a server you do not
+	// fully trust: a skill enters context only when the model calls load_skill,
+	// and load_skill is an ordinary tool, so it flows through the same approval
+	// ladder as every other call (set Approval.Rules["load_skill"] = "ask" to
+	// confirm each activation; the prompt shows the requested skill name). The
+	// fetched body also lands in tool history rather than the system prompt, so
+	// it carries less authority. Reserve "eager" for servers you trust.
 	SkillsMode string `json:"skillsMode,omitempty"`
 
 	// Events lists the event streams to open on this server. Each event


### PR DESCRIPTION
## What changes

Documents `ServerConfig.SkillsMode` as the trust lever for a skills server, closing the practical gap discussed while triaging the deferred `#910` `SkillsPolicy` hook. No code change — godoc on `SkillsMode` plus a short README section.

## Why

Skills are data, not code (`ext/skills` is enforced no-exec), so the risk a skills server carries is context-poisoning, not side effects. The existing knobs already cover per-skill gating — but only in catalog mode, and that wasn't written down anywhere a config author would find it:
- `"eager"` splices full skill bodies into the system prompt at connect time, no per-skill gate. Trust-on-connect.
- `"catalog"` gates activation: a skill enters context only when the model calls `load_skill`, which is an ordinary tool and so flows through the approval ladder. `Approval.Rules["load_skill"] = "ask"` confirms each activation and the prompt names the skill. The body also lands in tool history (lower authority) rather than the system prompt.

## Decision log
- Documented the existing behavior rather than building the `SkillsPolicy` connect-time hook. Catalog mode + tool approval already covers per-skill gating; the hook's remaining niche is a load-time gate for eager mode, which stays deferred (`#910` follow-up). No decision debt — `ApprovalRequest` already carries `Args`, so an args-keyed remember or an `"ask"` disposition on a future hook are additive.

## Risk / blast radius
- Docs only. No behavior change.

## Out of scope
- The `SkillsPolicy` connect-time hook and args-keyed per-skill approval remember — deferred `#910` follow-ups.