### PR TITLE
feat(examples/kitchen-sink): seed eager+catalog skills and event injection

### DIFF
--- a/examples/agents/kitchen-sink/Makefile
+++ b/examples/agents/kitchen-sink/Makefile
@@ -1,7 +1,7 @@
 # kitchen-sink — every agent feature wired at once (Makefile mirror of the
 # justfile). Quick start:
 #   make allup     # postgres+pgvector and observability stacks
-#   make run       # preflight, boot the demo server, launch agentchat
+#   make run       # preflight, boot the demo + skills + events servers, launch agentchat
 #   make alldown   # tear the stacks back down
 #
 # Every store/endpoint is a variable: override on the CLI or via env,
@@ -47,7 +47,7 @@ check: ## Probe every backend; print bring-up instructions for what's missing.
 	@bash preflight.sh
 preflight: check
 
-run: ## Preflight, boot the demo server, launch agentchat with everything wired.
+run: ## Preflight, boot the four MCP servers (demo + eager/catalog skills + events), launch agentchat.
 	@bash run.sh
 demo: run
 

--- a/examples/agents/kitchen-sink/README.md
+++ b/examples/agents/kitchen-sink/README.md
@@ -18,10 +18,33 @@ line to the walkthrough.
 | Distributed tracing | `--exporter $EXPORTER --otlp-endpoint $OTLP_ENDPOINT` | OTel → Tempo/Grafana |
 | Sub-agent personas | `subAgents` in `kitchen-sink.json` | in-process child Runners |
 | Tool-call approval | `/approval` slash command in-session | — |
+| Skills, eager | `skillsMode: "eager"` on the `runbooks` server | skills-core MCP server (:8789) |
+| Skills, catalog | `skillsMode: "catalog"` on the `community` server | skills MCP server (:8790) + `load_skill` |
+| Event injection | `events` on the `events` server | events kitchen-sink MCP server (:8791) |
 
 The chat model comes from `kitchen-sink.json`'s `connections` block (local
 LM Studio by default, offline-friendly). Only the **embedder** is passed by
 flag, because it is a separate endpoint from the chat model.
+
+### The four MCP servers
+
+`kitchen-sink.json` connects to four servers, and the host is a **pure client**:
+it connects to them, it does not manage them, so the launcher boots them on the
+ports the config expects. This mirrors an `.mcp.json`-style connect-list.
+
+| Server | Port | Serves | Why |
+|---|---|---|---|
+| `demo` | 8788 | `greet`/`report`/`analyze` | offloading (`report` is large) + sub-agent tools |
+| `runbooks` | 8789 | one skill, **eager** | full skill body spliced into the system prompt at connect |
+| `community` | 8790 | three skills, **catalog** | names + descriptions only; bodies fetched on demand via `load_skill` |
+| `events` | 8791 | synthetic `chat.message` + `alert.fired` | the host auto-subscribes and injects occurrences into the turn |
+
+`runbooks` is eager and `community` is catalog on purpose: eager for the small,
+trusted skill set, catalog for the fuller one — the trust lever documented in
+`agent/host` (catalog gates each skill through the `load_skill` tool, so it can
+ride the approval ladder). Spawning these servers from the config instead of the
+launcher is a deferred follow-up (`ServerConfig.command`); today they connect by
+URL.
 
 ## Prerequisites
 
@@ -43,7 +66,7 @@ flag, because it is a separate endpoint from the chat model.
 ```bash
 just allup      # postgres+pgvector + observability stacks (or: make allup)
 just check      # probe everything; prints how to fix whatever is down
-just run        # preflight, boot the demo MCP server, launch agentchat (inline TUI)
+just run        # preflight, boot the four MCP servers, launch agentchat (inline TUI)
 just note       # same, but the alt-screen notebook UI (scrollable, foldable cells)
 # ... chat ...
 just alldown    # tear the stacks back down
@@ -93,6 +116,22 @@ Gemini). You can also swap chat models mid-session with `/provider`.
    re-tagged as reasoning by the connection's `thinkingHint` and streamed dimmed
    under a `· thinking:` line. Cloud OpenAI/Gemini models don't emit inline
    reasoning, so this only shows with a reasoning model + a `thinkingHint`.
+7. **Eager skills.** The `runbooks` server's skill is spliced into the system
+   prompt at connect. Ask it to do what that skill covers (the skills-core
+   `commit-helper` skill formats commit messages): *"Format a commit for a bug
+   fix in the auth module."* The model follows the skill's guidance with no tool
+   round-trip — the body was already in context.
+8. **Catalog skills.** The `community` server is catalog mode, so only skill
+   names + descriptions are in the prompt. Ask about one of its skills (*"Use the
+   git-workflow skill to help me rebase."*). The model first calls `load_skill`
+   to fetch that body (a tool call you'll see in the transcript), then acts on
+   it. Turn on `/approval ask` first and you'll be prompted before the skill
+   loads — catalog skills ride the tool-approval ladder.
+9. **Event injection.** The `events` server emits synthetic `chat.message` and
+   `alert.fired` every few seconds; the host subscribes at startup and injects
+   them ahead of your next turn. After a short pause, ask: *"Anything happen
+   while I was away?"* — the injected occurrences are in context, so the model
+   can summarize them.
 
 ## Inspecting state
 
@@ -128,8 +167,11 @@ live at the top of the `justfile` / `Makefile`.
 - **The `agent` DB + `vector` extension are created on a fresh postgres volume
   only.** If you started the backends stack before this feature existed,
   `just check` tells you to reset: `cd docker/backends && just down && rm -rf data/postgres && just up`.
-- **Ports:** demo server `:8788` (playground owns `:8787`), postgres `:5432`,
-  OTLP `:4317`, Grafana `:3000`.
+- **Ports:** demo `:8788` (playground owns `:8787`), skills-core/eager `:8789`,
+  skills/catalog `:8790`, events `:8791`, postgres `:5432`, OTLP `:4317`,
+  Grafana `:3000`. The four MCP servers are booted by `run.sh`; their logs go to
+  `$LOG_DIR/kitchen-sink-<name>.log` (default `$TMPDIR`) so they don't clobber
+  the TUI. `tail -f` one to watch a server.
 
 ## Extending
 

--- a/examples/agents/kitchen-sink/justfile
+++ b/examples/agents/kitchen-sink/justfile
@@ -2,7 +2,7 @@
 #
 # Quick start:
 #   just allup     # bring up postgres+pgvector and the observability stack
-#   just run       # preflight, boot the demo server, launch agentchat
+#   just run       # preflight, boot the demo + skills + events servers, launch agentchat
 #   just alldown   # tear the stacks back down
 #
 # Every store/endpoint below is a variable: override on the CLI or via env,
@@ -54,7 +54,8 @@ check:
 # Alias for check.
 preflight: check
 
-# Preflight, boot the demo server, launch agentchat with everything wired.
+# Preflight, boot the four MCP servers (demo + eager/catalog skills + events),
+# then launch agentchat with everything wired.
 run:
     @bash run.sh
 

--- a/examples/agents/kitchen-sink/kitchen-sink.json
+++ b/examples/agents/kitchen-sink/kitchen-sink.json
@@ -34,7 +34,11 @@
     }
   },
   "servers": [
-    { "id": "demo", "url": "http://localhost:8788/mcp" }
+    { "id": "demo",      "url": "http://localhost:8788/mcp" },
+    { "id": "runbooks",  "url": "http://localhost:8789/mcp", "skillsMode": "eager" },
+    { "id": "community", "url": "http://localhost:8790/mcp", "skillsMode": "catalog" },
+    { "id": "events",    "url": "http://localhost:8791/mcp",
+      "events": [ { "name": "chat.message" }, { "name": "alert.fired" } ] }
   ],
   "subAgents": [
     {

--- a/examples/agents/kitchen-sink/run.sh
+++ b/examples/agents/kitchen-sink/run.sh
@@ -30,23 +30,42 @@ UI="${UI:-tui}"
 
 bash "$DIR/preflight.sh"
 
-# Redirect the demo server's logs to a file — its stdout/stderr (and mcpkit's
-# per-connection SSE logging) share this terminal with agentchat's inline TUI
-# and would clobber the input region otherwise. Tail it in another window to
-# watch tool calls: tail -f "$SERVER_LOG".
-SERVER_LOG="${SERVER_LOG:-${TMPDIR:-/tmp}/kitchen-sink-server.log}"
-echo "==> booting kitchen-sink demo server on :8788 (logs -> $SERVER_LOG)"
-( cd "$DIR/server" && go run . ) >"$SERVER_LOG" 2>&1 &
-SERVER_PID=$!
-trap 'kill "$SERVER_PID" 2>/dev/null || true' EXIT
+# The config connects to four MCP servers (kitchen-sink.json):
+#   demo      :8788  greet/report/analyze (offloading + sub-agent tools)
+#   runbooks  :8789  skills-core, EAGER   (full skill bodies in the prompt)
+#   community :8790  skills,      CATALOG (bodies fetched on demand via load_skill)
+#   events    :8791  synthetic chat.message + alert.fired (feed injection)
+# The host is a pure client — it CONNECTS to these, it does not manage them, so
+# the launcher boots them here on the ports the config expects. Each server's
+# logs go to their own file: their stdout/stderr (and mcpkit's per-connection
+# SSE logging) would otherwise clobber agentchat's inline TUI input region.
+# Tail one in another window to watch it: tail -f "$LOG_DIR/kitchen-sink-<name>.log".
+LOG_DIR="${LOG_DIR:-${TMPDIR:-/tmp}}"
+SERVER_PIDS=()
+trap 'for p in "${SERVER_PIDS[@]:-}"; do kill "$p" 2>/dev/null || true; done' EXIT
 
-# Wait for the port to accept connections via a TCP probe — NOT an HTTP GET.
-# A GET to /mcp opens the server's SSE stream and never returns, so a
-# curl-based check would hang the readiness loop (and the launch) forever.
-for _ in $(seq 1 60); do
-	(exec 3<>/dev/tcp/localhost/8788) 2>/dev/null && { exec 3>&-; break; }
-	sleep 0.5
-done
+# boot_server <label> <workdir> <port> <run-cmd...>
+# Boots a server in the background with its logs redirected, then waits for the
+# port via a TCP probe — NOT an HTTP GET: a GET to /mcp opens the server's SSE
+# stream and never returns, so a curl-based check would hang the launch forever.
+boot_server() {
+	local label="$1" workdir="$2" port="$3"; shift 3
+	local log="$LOG_DIR/kitchen-sink-$label.log"
+	echo "==> booting $label on :$port (logs -> $log)"
+	( cd "$workdir" && "$@" ) >"$log" 2>&1 &
+	SERVER_PIDS+=("$!")
+	for _ in $(seq 1 60); do
+		(exec 3<>"/dev/tcp/localhost/$port") 2>/dev/null && { exec 3>&-; return 0; }
+		sleep 0.5
+	done
+	echo "!! $label did not come up on :$port — see $log" >&2
+	return 1
+}
+
+boot_server demo      "$DIR/server"                       8788 go run .
+boot_server runbooks  "$ROOT/examples/skills-core"        8789 go run . --serve --addr=:8789
+boot_server community "$ROOT/examples/skills"             8790 go run . --serve --addr=:8790
+boot_server events    "$ROOT/examples/events/kitchen-sink" 8791 go run . --serve --addr=:8791
 
 echo "==> launching agentchat (session=$SESSION, store=$SESSION_STORE)"
 cd "$ROOT/cmd/agentchat"


### PR DESCRIPTION
## What changes

The kitchen-sink harness advertised itself as "every agent feature wired at once" but had no skills and no events — its config connected to a single demo server (`greet`/`report`/`analyze`). This turns it into a four-server connect-list so it actually demonstrates **skills in both modes** and **event injection**, alongside the sessions/offloading/memory/compaction/tracing/sub-agents it already wired. No library change — config + launcher + docs.

## Reviewer's guide
1. [examples/agents/kitchen-sink/kitchen-sink.json](https://github.com/panyam/mcpkit/pull/1079/files#diff-613a756047a90e7dceae2a92468ffd872aa635011d08e72fc3f71a791757d94c) — start here. Three new `servers[]` entries: `runbooks` (eager), `community` (catalog), `events` (subscribes `chat.message` + `alert.fired`).
2. [examples/agents/kitchen-sink/run.sh](https://github.com/panyam/mcpkit/pull/1079/files#diff-2bddbe5c136c0ba080a2f14842ebbb769ebc00c0b071cd9997a338e35bb1ae04) — the load-bearing change. A `boot_server` helper boots the four servers on the ports the config expects (per-server log redirect, TCP-probe readiness, cleanup trap).
3. [examples/agents/kitchen-sink/README.md](https://github.com/panyam/mcpkit/pull/1079/files#diff-0cd2779408f292df1c83ceb77be3f10cf860d8ad3a06c76c7bce7deabd9cc4ba) — the "four MCP servers" table + three walkthrough beats (eager skill, catalog skill via `load_skill`, event injection).
4. `justfile` / `Makefile` — comment updates only.

## How it works
The host is a **pure client** — it connects to MCP servers, it does not manage them. So the config declares the four servers by URL, and the launcher boots them on the matching ports (same pattern the demo server already used). At startup `NewApp` connects each server, `loadSkillsForServer` injects the eager block / builds the catalog + `load_skill` tool, and `startEventStreams` opens the configured subscriptions and feeds the injection policy.

```
demo      :8788  greet/report/analyze     (offloading + sub-agent tools)
runbooks  :8789  skills-core,  eager       (1 skill body → system prompt)
community :8790  skills,       catalog     (3 skills → names only; load_skill fetches bodies)
events    :8791  chat.message + alert.fired (host auto-subscribes → injection)
```

## Decision log
- **Reuse the existing example servers** (`skills-core`, `skills`, `events/kitchen-sink`) over baking skills/events into the demo server. Eager needs one server and catalog another (`skillsMode` is per-server), so two skills endpoints are required anyway; separate servers are also a truer picture (two trust domains, not one process pretending).
- **Eager on `runbooks`, catalog on `community`** deliberately mirrors the trust lever documented in `agent/host` — eager for the small trusted set, catalog (gated via `load_skill` + approval ladder) for the fuller, less-trusted one.
- **Connect-only, no host-managed spawning.** The host stays a pure client; the launcher boots the servers. Spawning servers from the config (`ServerConfig.command` + stdio) is a deferred follow-up.

## Risk / blast radius
- Example-only. No library/module code touched, no test suite affected (kitchen-sink reuses `cmd/agentchat` and has no Go of its own besides its demo server, unchanged here).
- `run.sh` now boots four `go run` processes instead of one — slower first start (four compiles), cleaned up on exit via the trap.

## Before / after
Booting all four servers and starting agentchat against the config (`--active local --session-store memory --ui plain`, `/tools` then `/quit`):
```
skills: 1 loaded from runbooks
skills: 3 loaded from community
agentchat: 4 server(s) ...
  ... format_commit ...        (runbooks skill's tool)
  load_skill                   (catalog fetch)
  subscribe_events / list_subscriptions / create_trigger ...   (events → meta-tools)
— 16 tool(s)
```
Events server log confirms the startup subscription: `MCP events/stream ok`. agentchat exits 0, no warnings. Before this change the config connected to one server and none of the above existed.

## Out of scope (deferred follow-ups)
- Host-managed server spawning from config (`ServerConfig.command`/`args` + `CommandTransport`, stdio entrypoints on the example servers) — the client already owns stdio subprocess lifecycle; only the config surface is missing.
- The `kitchen-sink.local.json` runtime-config overlay (persist `/provider` and `/approve` picks across restarts) — separate host-layer PR.
