### PR TITLE
feat(agent/host): persist runtime config picks to a local overlay

### DIFF
--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -74,6 +74,11 @@ type App struct {
 	// commands is the slash-command registry every surface dispatches
 	// through (Dispatch / Commands). Built in NewApp.
 	commands *CommandRegistry
+
+	// overlay persists mutable config picks (active connection, approval
+	// mode) back to a local-overlay file when WithConfigOverlay is set; nil
+	// means runtime changes are session-only.
+	overlay *configOverlay
 }
 
 // AppOption customizes construction. The provider override exists so tests
@@ -90,6 +95,7 @@ type appOptions struct {
 	memoryStore     agent.MemoryStore
 	providerBuilder ProviderBuilder
 	observers       []Observer
+	configPath      string
 }
 
 // WithProvider overrides the OpenAI-compatible provider built from config.
@@ -114,6 +120,18 @@ func WithTracerProvider(tp core.TracerProvider) AppOption {
 // routes here. Nil discards.
 func WithLogger(l *slog.Logger) AppOption {
 	return func(o *appOptions) { o.logger = l }
+}
+
+// WithConfigOverlay enables runtime-config persistence: mutable picks changed
+// via slash commands (the /provider active connection and the /approve mode)
+// are written back to the sibling local-overlay file derived from configPath
+// (kitchen-sink.json -> kitchen-sink.local.json), so they survive a restart
+// once the launcher loads the config with LoadConfigWithOverlay. configPath is
+// the base config path, not the overlay path. Without this option the picks are
+// session-only. A persist failure degrades to a warning, never a failed
+// command (mirrors the RunStore persistence contract).
+func WithConfigOverlay(configPath string) AppOption {
+	return func(o *appOptions) { o.configPath = configPath }
 }
 
 // NewApp connects every configured server and assembles the agent. The
@@ -142,6 +160,9 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 
 	multi := agent.NewMultiSource()
 	app := &App{cfg: cfg, sources: multi, observers: observers, replOut: out, bgTasks: map[string]*client.BackgroundTask{}, subs: map[string]*subscription{}, store: o.store}
+	if o.configPath != "" {
+		app.overlay = &configOverlay{path: overlayPathFor(o.configPath)}
+	}
 	// The approval "ask" prompt rides the same FIFO seam as elicitation, so a
 	// gated tool call never stacks a dialog against a concurrent elicitation.
 	ask := func(ctx context.Context, req agent.ApprovalRequest) (bool, error) {

--- a/agent/host/commands.go
+++ b/agent/host/commands.go
@@ -224,7 +224,11 @@ func (a *App) registerBuiltinCommands() {
 	r.Register(&Command{Name: "approve", Help: "show or set approval mode (allow | read-only-auto | ask)",
 		Run: func(_ context.Context, args string) (CmdResult, error) {
 			if args != "" && a.approval != nil {
-				a.approval.SetDefaultMode(parseApprovalMode(args))
+				mode := parseApprovalMode(args)
+				a.approval.SetDefaultMode(mode)
+				a.persistOverlay("approval mode", func(o *configOverlay) error {
+					return o.setApprovalMode(approvalModeName(mode))
+				})
 			}
 			return CmdResult{Kind: CmdApproval, Approval: a.approval}, nil
 		}})
@@ -310,6 +314,9 @@ func (a *App) registerBuiltinCommands() {
 				if err := a.SwitchProvider(args); err != nil {
 					return CmdResult{}, err
 				}
+				a.persistOverlay("provider", func(o *configOverlay) error {
+					return o.setActiveConnection(args)
+				})
 			}
 			names, active := a.Providers()
 			return CmdResult{Kind: CmdProviders, Providers: names, ActiveProvider: active}, nil

--- a/agent/host/config.go
+++ b/agent/host/config.go
@@ -492,6 +492,42 @@ func LoadConfig(path string) (*Config, error) {
 	return &cfg, nil
 }
 
+// LoadConfigWithOverlay loads the base config, then merges the sibling
+// local-overlay file (overlayPathFor) over it when that file exists, then
+// validates. This is the read side of runtime-config persistence: the overlay
+// carries only the mutable picks a slash command changed (active connection,
+// approval mode), written by WithConfigOverlay.
+//
+// The merge is deliberately a second json.Unmarshal into the same struct, so
+// the semantics are the standard library's, pinned by tests: a scalar present
+// in the overlay overrides the base, a map merges by key (base entries the
+// overlay omits survive), a slice present in the overlay REPLACES the base
+// slice wholesale, and a key the overlay omits is left untouched. That last
+// rule is what lets a one-line overlay (just active) leave servers and
+// connections intact.
+func LoadConfigWithOverlay(path string) (*Config, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var cfg Config
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return nil, fmt.Errorf("agentchat: parse %s: %w", path, err)
+	}
+	overlay := overlayPathFor(path)
+	if oraw, err := os.ReadFile(overlay); err == nil {
+		if err := json.Unmarshal(oraw, &cfg); err != nil {
+			return nil, fmt.Errorf("agentchat: parse %s: %w", overlay, err)
+		}
+	} else if !os.IsNotExist(err) {
+		return nil, err
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("agentchat: %s: %w", path, err)
+	}
+	return &cfg, nil
+}
+
 // Validate enforces the invariants the app relies on.
 func (c *Config) Validate() error {
 	// A connections registry supersedes Model for the chat provider, so

--- a/agent/host/overlay.go
+++ b/agent/host/overlay.go
@@ -1,0 +1,91 @@
+package host
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// overlayPathFor derives the writable local-overlay path beside a base config:
+// kitchen-sink.json -> kitchen-sink.local.json. The overlay holds only the
+// mutable picks a user changes at runtime (active connection, approval mode),
+// kept separate from the hand-authored base so writing it back never clobbers
+// the base file's formatting or unrelated keys. A path with no extension gets
+// ".local" appended.
+func overlayPathFor(configPath string) string {
+	ext := filepath.Ext(configPath)
+	return strings.TrimSuffix(configPath, ext) + ".local" + ext
+}
+
+// configOverlay persists mutable config picks to a sparse JSON file that is
+// merged over the base config on the next load (later wins, via
+// LoadConfigWithOverlay). Only the keys a slash command changes are written,
+// so the file stays a small delta rather than a full config copy. Safe for
+// concurrent use.
+type configOverlay struct {
+	path string
+	mu   sync.Mutex
+}
+
+// mutate read-modify-writes the sparse overlay map atomically (temp + rename).
+// A missing file starts from an empty map, so the first write creates it; a
+// corrupt overlay is overwritten rather than treated as fatal (it only ever
+// holds regenerable runtime picks).
+func (o *configOverlay) mutate(fn func(map[string]any)) error {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	m := map[string]any{}
+	if raw, err := os.ReadFile(o.path); err == nil {
+		_ = json.Unmarshal(raw, &m)
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	fn(m)
+	out, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	out = append(out, '\n')
+	tmp := o.path + ".tmp"
+	if err := os.WriteFile(tmp, out, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, o.path)
+}
+
+// ensureObj fetches-or-creates a nested JSON object under key, so a write to
+// connections.active leaves any sibling keys the overlay already holds intact.
+func ensureObj(m map[string]any, key string) map[string]any {
+	c, _ := m[key].(map[string]any)
+	if c == nil {
+		c = map[string]any{}
+		m[key] = c
+	}
+	return c
+}
+
+// setActiveConnection persists {"connections":{"active":name}}.
+func (o *configOverlay) setActiveConnection(name string) error {
+	return o.mutate(func(m map[string]any) { ensureObj(m, "connections")["active"] = name })
+}
+
+// setApprovalMode persists {"approval":{"mode":mode}}.
+func (o *configOverlay) setApprovalMode(mode string) error {
+	return o.mutate(func(m map[string]any) { ensureObj(m, "approval")["mode"] = mode })
+}
+
+// persistOverlay applies save to the config overlay when one is configured,
+// degrading a write failure to a warning event rather than failing the command
+// the user just ran (mirrors the RunStore persistence contract). A no-op when
+// WithConfigOverlay was not set.
+func (a *App) persistOverlay(what string, save func(*configOverlay) error) {
+	if a.overlay == nil {
+		return
+	}
+	if err := save(a.overlay); err != nil {
+		a.emit(HostEvent{Kind: HostSessionWarn, Err: fmt.Sprintf("could not persist %s to %s: %v", what, a.overlay.path, err)})
+	}
+}

--- a/agent/host/overlay_test.go
+++ b/agent/host/overlay_test.go
@@ -1,0 +1,203 @@
+package host
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/panyam/mcpkit/agent"
+)
+
+func TestOverlayPathFor(t *testing.T) {
+	cases := map[string]string{
+		"kitchen-sink.json": "kitchen-sink.local.json",
+		"/a/b/config.json":  "/a/b/config.local.json",
+		"noext":             "noext.local",
+		"/tmp/x.yaml":       "/tmp/x.local.yaml",
+	}
+	for in, want := range cases {
+		if got := overlayPathFor(in); got != want {
+			t.Errorf("overlayPathFor(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+const baseConfigJSON = `{
+  "connections": {
+    "active": "local",
+    "connections": {
+      "local": {"type": "lmstudio", "model": "m"},
+      "cloud": {"type": "openai", "model": "m", "apiKeyEnv": "K"}
+    }
+  },
+  "servers": [{"id": "demo", "url": "http://localhost:8788/mcp"}],
+  "instructions": "base instructions"
+}`
+
+// writeBase writes the base config to a temp dir and returns its path.
+func writeBase(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	base := filepath.Join(dir, "kitchen-sink.json")
+	if err := os.WriteFile(base, []byte(baseConfigJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return base
+}
+
+// TestLoadConfigWithOverlay_MergeSemantics pins the contract the whole feature
+// rests on: a sparse overlay overrides the scalars it names, preserves the maps
+// and slices it omits, and adds nested objects — so a one-line "active" change
+// never wipes servers or the connections catalog.
+func TestLoadConfigWithOverlay_MergeSemantics(t *testing.T) {
+	base := writeBase(t)
+	overlay := overlayPathFor(base)
+	if err := os.WriteFile(overlay, []byte(`{"connections":{"active":"cloud"},"approval":{"mode":"ask"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfigWithOverlay(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Connections.Active != "cloud" {
+		t.Errorf("active = %q, want overlay's cloud", cfg.Connections.Active)
+	}
+	if len(cfg.Connections.Connections) != 2 {
+		t.Errorf("connections map = %d entries, want 2 (base map preserved, not replaced by the sparse overlay)", len(cfg.Connections.Connections))
+	}
+	if len(cfg.Servers) != 1 || cfg.Servers[0].ID != "demo" {
+		t.Errorf("servers = %+v, want the base [demo] (overlay omits servers, so they survive)", cfg.Servers)
+	}
+	if cfg.Approval == nil || approvalModeName(parseApprovalMode(cfg.Approval.Mode)) != "ask" {
+		t.Errorf("approval = %+v, want mode ask from the overlay", cfg.Approval)
+	}
+	if cfg.Instructions != "base instructions" {
+		t.Errorf("instructions = %q, want base (overlay omits it)", cfg.Instructions)
+	}
+}
+
+// TestLoadConfigWithOverlay_SliceReplaceWhenPresent pins the other half of the
+// contract: a slice the overlay DOES carry replaces the base slice wholesale
+// (json semantics), so this is a deliberate, documented behavior not an accident.
+func TestLoadConfigWithOverlay_SliceReplaceWhenPresent(t *testing.T) {
+	base := writeBase(t)
+	overlay := overlayPathFor(base)
+	if err := os.WriteFile(overlay, []byte(`{"servers":[{"id":"other","url":"http://localhost:9999/mcp"}]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadConfigWithOverlay(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Servers) != 1 || cfg.Servers[0].ID != "other" {
+		t.Errorf("servers = %+v, want the overlay's [other] (present slice replaces)", cfg.Servers)
+	}
+}
+
+func TestLoadConfigWithOverlay_NoOverlayFile(t *testing.T) {
+	base := writeBase(t)
+	cfg, err := LoadConfigWithOverlay(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Connections.Active != "local" {
+		t.Errorf("active = %q, want base local (no overlay present)", cfg.Connections.Active)
+	}
+}
+
+// TestConfigOverlay_WriteBackRoundTrip is the end-to-end acceptance: writing a
+// pick through the overlay and reloading gets it back, both picks coexist in a
+// sparse file, and the base catalog survives.
+func TestConfigOverlay_WriteBackRoundTrip(t *testing.T) {
+	base := writeBase(t)
+	o := &configOverlay{path: overlayPathFor(base)}
+
+	if err := o.setActiveConnection("cloud"); err != nil {
+		t.Fatal(err)
+	}
+	if err := o.setApprovalMode("ask"); err != nil {
+		t.Fatal(err)
+	}
+
+	// The overlay file holds only the two picks, sparsely.
+	raw, err := os.ReadFile(o.path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatal(err)
+	}
+	if got := m["connections"].(map[string]any)["active"]; got != "cloud" {
+		t.Errorf("overlay connections.active = %v, want cloud", got)
+	}
+	if got := m["approval"].(map[string]any)["mode"]; got != "ask" {
+		t.Errorf("overlay approval.mode = %v, want ask (second write must not clobber the first)", got)
+	}
+	if _, hasServers := m["servers"]; hasServers {
+		t.Error("overlay must stay sparse — it should not contain servers")
+	}
+
+	// Reloading merges the picks over the base.
+	cfg, err := LoadConfigWithOverlay(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Connections.Active != "cloud" || len(cfg.Connections.Connections) != 2 {
+		t.Errorf("reload: active=%q conns=%d, want cloud with the 2-entry base catalog intact", cfg.Connections.Active, len(cfg.Connections.Connections))
+	}
+}
+
+// TestDispatchPersistsPicksToOverlay wires the whole path: /provider and
+// /approve dispatched through the App write their picks to the overlay when
+// WithConfigOverlay is set, so a real slash command (not just the writer)
+// persists.
+func TestDispatchPersistsPicksToOverlay(t *testing.T) {
+	baseDir := t.TempDir()
+	basePath := filepath.Join(baseDir, "kitchen-sink.json")
+	cfg := &Config{
+		Connections: &ConnectionsConfig{
+			Active: "local",
+			Connections: map[string]ConnectionConfig{
+				"local": {Type: "lmstudio", Model: "m"},
+				"cloud": {Type: "openai", Model: "m", APIKeyEnv: "K"},
+			},
+		},
+		Approval: &ApprovalConfig{Mode: "allow"},
+	}
+	build := func(ConnectionConfig) (agent.Provider, error) { return agent.NewStubProvider(), nil }
+	app, err := NewApp(cfg, io.Discard, strings.NewReader(""),
+		WithProviderBuilder(build), WithConfigOverlay(basePath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Close()
+
+	ctx := context.Background()
+	if _, err := app.Dispatch(ctx, "/provider cloud"); err != nil {
+		t.Fatalf("/provider cloud: %v", err)
+	}
+	if _, err := app.Dispatch(ctx, "/approve ask"); err != nil {
+		t.Fatalf("/approve ask: %v", err)
+	}
+
+	raw, err := os.ReadFile(overlayPathFor(basePath))
+	if err != nil {
+		t.Fatalf("overlay not written: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatal(err)
+	}
+	if got := m["connections"].(map[string]any)["active"]; got != "cloud" {
+		t.Errorf("/provider did not persist: connections.active = %v", got)
+	}
+	if got := m["approval"].(map[string]any)["mode"]; got != "ask" {
+		t.Errorf("/approve did not persist: approval.mode = %v", got)
+	}
+}

--- a/cmd/agentchat/main.go
+++ b/cmd/agentchat/main.go
@@ -194,6 +194,7 @@ func newRoot() (*cobra.Command, *viper.Viper) {
 	fl.String("instructions", "You are a helpful assistant with access to tools.", "system prompt (when no config)")
 	fl.Int("max-steps", 0, "max model calls per turn (0 = default)")
 	fl.String("active", "", "override the active chat connection at startup (a name in the config's connections; default = the config's active)")
+	fl.Bool("persist-config", false, "persist runtime picks (/provider, /approve) to a sibling <config>.local.json overlay, merged over the base config on the next start (needs --config)")
 	fl.String("session-store", "", "session persistence backend: memory | sqlite://path.db | redis://host:port | postgres://user:pass@host:port/db (empty = off)")
 	fl.String("session", "", "session run ID to create or resume at startup (needs --session-store)")
 	fl.String("ui", "auto", "interface: auto (TUI when interactive) | tui (inline) | notebook (alt-screen, foldable cells) | plain")
@@ -223,8 +224,11 @@ func newRoot() (*cobra.Command, *viper.Viper) {
 }
 
 func runChat(v *viper.Viper) error {
+	configPath := v.GetString("config")
+	persistConfig := v.GetBool("persist-config") && configPath != ""
 	cfg, err := buildConfig(
-		v.GetString("config"),
+		configPath,
+		persistConfig,
 		v.GetStringSlice("url"),
 		v.GetString("base-url"),
 		v.GetString("model"),
@@ -265,6 +269,9 @@ func runChat(v *viper.Viper) error {
 	appOpts := []host.AppOption{
 		host.WithTracerProvider(tp),
 		host.WithLogger(logger),
+	}
+	if persistConfig {
+		appOpts = append(appOpts, host.WithConfigOverlay(configPath))
 	}
 	mode := uiMode(v.GetString("ui"))
 	var surface *tuiObserver
@@ -380,8 +387,13 @@ func main() {
 
 // buildConfig merges the config file with quick-start settings: a config
 // file wins for everything it specifies; url/model cover the no-file case.
-func buildConfig(path string, urls []string, baseURL, model, apiKeyEnv, instructions string, maxSteps int) (*host.Config, error) {
+func buildConfig(path string, persist bool, urls []string, baseURL, model, apiKeyEnv, instructions string, maxSteps int) (*host.Config, error) {
 	if path != "" {
+		if persist {
+			// Merge the sibling <config>.local.json overlay (the runtime picks
+			// persisted by /provider and /approve) over the base config.
+			return host.LoadConfigWithOverlay(path)
+		}
 		return host.LoadConfig(path)
 	}
 	if len(urls) == 0 || model == "" {

--- a/cmd/agentchat/main_test.go
+++ b/cmd/agentchat/main_test.go
@@ -30,10 +30,10 @@ func TestEnvOverridesFlagDefaults(t *testing.T) {
 // TestBuildConfigRequiresModelOrConfig pins the CLI's quick-start guard
 // (moved here from the host config test when App core was extracted).
 func TestBuildConfigRequiresModelOrConfig(t *testing.T) {
-	if _, err := buildConfig("", nil, "b", "", "", "", 0); err == nil {
+	if _, err := buildConfig("", false, nil, "b", "", "", "", 0); err == nil {
 		t.Fatal("want error when neither config nor url/model given")
 	}
-	cfg, err := buildConfig("", []string{"http://x/mcp"}, "b", "m", "", "sys", 0)
+	cfg, err := buildConfig("", false, []string{"http://x/mcp"}, "b", "m", "", "sys", 0)
 	if err != nil || len(cfg.Servers) != 1 || cfg.Model.Model != "m" {
 		t.Fatalf("valid quick-start config: %+v %v", cfg, err)
 	}

--- a/examples/agents/kitchen-sink/.gitignore
+++ b/examples/agents/kitchen-sink/.gitignore
@@ -1,0 +1,3 @@
+# Runtime-config overlay: mutable picks (/provider, /approve) persisted by
+# --persist-config. Machine-local, merged over kitchen-sink.json at startup.
+kitchen-sink.local.json

--- a/examples/agents/kitchen-sink/README.md
+++ b/examples/agents/kitchen-sink/README.md
@@ -21,6 +21,7 @@ line to the walkthrough.
 | Skills, eager | `skillsMode: "eager"` on the `runbooks` server | skills-core MCP server (:8789) |
 | Skills, catalog | `skillsMode: "catalog"` on the `community` server | skills MCP server (:8790) + `load_skill` |
 | Event injection | `events` on the `events` server | events kitchen-sink MCP server (:8791) |
+| Runtime-config persistence | `--persist-config` in `run.sh` | `kitchen-sink.local.json` overlay (gitignored) |
 
 The chat model comes from `kitchen-sink.json`'s `connections` block (local
 LM Studio by default, offline-friendly). Only the **embedder** is passed by
@@ -132,6 +133,14 @@ Gemini). You can also swap chat models mid-session with `/provider`.
    them ahead of your next turn. After a short pause, ask: *"Anything happen
    while I was away?"* — the injected occurrences are in context, so the model
    can summarize them.
+10. **Config persistence.** `run.sh` passes `--persist-config`. Switch models
+    with `/provider openai-5.1` (or set an approval mode with `/approve ask`) and
+    those picks are written to `kitchen-sink.local.json` (gitignored). Quit and
+    `just run` again: it comes back on your last-picked provider, not the
+    config's default. The overlay is a sparse delta merged over
+    `kitchen-sink.json` at startup, so it never touches the base file; a launch
+    flag still wins (`ACTIVE=anthropic-opus just run` overrides the overlay for
+    that run).
 
 ## Inspecting state
 

--- a/examples/agents/kitchen-sink/run.sh
+++ b/examples/agents/kitchen-sink/run.sh
@@ -71,6 +71,7 @@ echo "==> launching agentchat (session=$SESSION, store=$SESSION_STORE)"
 cd "$ROOT/cmd/agentchat"
 args=(
 	--config "$DIR/kitchen-sink.json"
+	--persist-config
 	--session-store "$SESSION_STORE"
 	--session "$SESSION"
 	--offload-threshold "$OFFLOAD_THRESHOLD"


### PR DESCRIPTION
> Stacked on #1079 (kitchen-sink seeding). Base is `feat/kitchen-sink-seed-skills-events`, so CI does not run until #1079 merges and this retargets to `main`. Verified locally (`just test-agent`-equivalent: `agent/host` + `cmd/agentchat` suites green).

## What changes

Slash-command changes to config-worthy state — the `/provider` active connection and the `/approve` mode — were session-only. Restart and you were back on `kitchen-sink.json`'s defaults. This adds an **opt-in write-back overlay** so those picks survive a restart, exactly the persistence idea from the design thread.

## Reviewer's guide
1. [agent/host/overlay.go](https://github.com/panyam/mcpkit/pull/1081/files#diff-99a4bb2972ba0e2643100107785b474d5dfab38e2c257620ee189190fa961398) — start here. `overlayPathFor` (base → `<stem>.local.json`), the sparse `configOverlay` writer (read-modify-write a map, atomic temp+rename), and `App.persistOverlay` (degrade-to-warning).
2. [agent/host/config.go](https://github.com/panyam/mcpkit/pull/1081/files#diff-6aff502cc5cae4b9d9769752e8638899bab121e09de870b5d1320cc892c6bf2d) — `LoadConfigWithOverlay`: base then a second `json.Unmarshal` of the overlay into the same struct. **This is the whole merge — read the doc comment for the contract.**
3. [agent/host/overlay_test.go](https://github.com/panyam/mcpkit/pull/1081/files#diff-e1234ad8410a93f33223980c46f74020c38edb5975a2e86877702e21ba60be30) — the acceptance. Pins the merge contract (scalar override, map-merge, slice-replace-when-present, omitted-key-preserved) and the `/provider`+`/approve`→overlay write path through `Dispatch`.
4. [agent/host/commands.go](https://github.com/panyam/mcpkit/pull/1081/files#diff-d44c9aac08cff5c51623cc064ae8e0dbbef19ba85d048cf9996ed8f99b61ac39) — the two persist hooks.
5. [agent/host/app.go](https://github.com/panyam/mcpkit/pull/1081/files#diff-89fb8e04b6e1e9d5f7f76958490ef158dee40e2cae92d87c04b408d893c84361) — `WithConfigOverlay` option + wiring.
6. [cmd/agentchat/main.go](https://github.com/panyam/mcpkit/pull/1081/files#diff-ce3956549c93b4983f18090136a2139c3c92d38408e923245f5e9ba628bcc98a) — `--persist-config` flag: gates overlay load (`LoadConfigWithOverlay`) and write-back (`WithConfigOverlay`).
7. `examples/agents/kitchen-sink/` — turns it on (`run.sh --persist-config`, gitignored overlay, README beat).

## How it works
```
load:   base = json.Unmarshal(kitchen-sink.json)
        json.Unmarshal(kitchen-sink.local.json, &base)   # later wins, per-key
/provider cloud:  overlay["connections"]["active"] = "cloud"; atomic write
/approve ask:     overlay["approval"]["mode"]       = "ask";  atomic write
next start:       base + overlay  ->  active=cloud, approval=ask
```
The merge is deliberately stdlib `json.Unmarshal`-into-existing-struct, not a hand-rolled engine: a scalar present in the overlay overrides, a map merges by key (base entries the overlay omits survive), a slice present in the overlay replaces wholesale, and an omitted key is left untouched. That last rule is what lets a one-line `active` overlay leave `servers` and the `connections` catalog intact.

## Decision log
- **Overlay file, not writing back into the base config.** Writing `kitchen-sink.json` in place would clobber formatting/comments and interleave machine-written with hand-authored keys. The overlay is gitignored and sparse (only mutated keys), like `llm.local.json`.
- **No `ConfigStore` interface / DB backend.** We agreed to keep it simple: two layers (base + local file). The interface + DB backend is a deferred follow-up for the hosted/web surface — the `ApprovalRequest`-carries-`Args` style seam means it lands additively later, no decision debt now.
- **`--persist-config` gates everything** (default off = today's behavior byte-for-byte). Avoids surprising a plain `agentchat --config x.json` user with an unexpected `x.local.json`.
- **Precedence flag > overlay > base.** `--active` is applied after the overlay merge, so a launch flag still wins for that run.
- **Persist failure degrades to a warning**, never fails the command the user just ran (mirrors the RunStore persistence contract).

## Risk / blast radius
- Host + agentchat. When `--persist-config` is off (every existing invocation), nothing changes: `LoadConfig` and no `WithConfigOverlay`.
- Tests: `agent/host/overlay_test.go` (merge contract + write-back + `Dispatch` persist), plus the existing `main_test.go` buildConfig-signature update.
- Be paranoid about the merge's slice semantics — a present slice replaces; the test pins both directions.

## Before / after
```
# before: switch model, restart -> back to config default
$ /provider cloud   ... /quit ;  just run
model local ...

# after (--persist-config): the pick sticks
$ /provider cloud   ... /quit
# writes kitchen-sink.local.json: {"connections":{"active":"cloud"}}
$ just run
model cloud ...     # reloaded from the overlay; ACTIVE=... still overrides
```
Verified end-to-end via agentchat with a server-less config: run 1 wrote `{"connections":{"active":"cloud"}}`, run 2 reloaded and `/provider` marked `▸ cloud` active.

## Out of scope (deferred)
- `ConfigStore` interface + DB-backed config (for a hosted/web surface).
- Host-managed server spawning from config (`ServerConfig.command`).
