### PR TITLE
feat(examples/kitchen-sink): decouple MCP server lifecycle from the agent

### DIFF
--- a/CONSTRAINTS.md
+++ b/CONSTRAINTS.md
@@ -99,3 +99,24 @@ Adopters deploying mcpkit at N>1 MUST either:
 The full architecture (Pattern B, NotificationRelay seam, NotificationRelayReceiver routing, per-surface end-to-end flows, scenario walkthroughs) is in `docs/MULTI_REPLICA.md`. Issue 755 tracks the work.
 
 **Verify:** there is no automated check today — the constraint is documented to prevent silent breakage, not enforced at build time. Adopters running N>1 should verify their wiring matches one of the recipes in `docs/MULTI_REPLICA.md` § Configuration recipes.
+
+## C6: MCP server lifecycle is decoupled from the agent
+
+The agent (`agent/host` and the surfaces built on it, e.g. `cmd/agentchat`) is a **pure MCP client**. It connects to servers by URL and does not own their process lifecycle: it MUST NOT spawn, supervise, restart, or kill the MCP servers it talks to. Bringing servers up and down is an operator/launcher concern — a `just servers-up` recipe, docker, systemd — not something the agent process does as a side effect of starting or stopping.
+
+The rule prevents two failure modes:
+
+- **Lifetime coupling**: if the launcher boots the servers as children of the agent (and traps-kills them on exit), restarting the chat kills the servers and vice versa. Decoupled, servers survive chat restarts — you can reconnect a fresh agent to already-running servers, which is also how every real MCP client (Claude Code, Cursor) treats remote servers.
+- **Boot coupling**: one unreachable server should not take the whole agent down. The target is that the agent connects asynchronously and degrades per-server (a down server shows as failed/paused/needs-login), rather than fail-fast aborting boot.
+
+The reference decoupling is `examples/agents/kitchen-sink`: `servers.sh` (`just servers-up` / `servers-down` / `servers`) owns the server processes; `run.sh` only *checks* the ports and points at `servers-up` if any are down — it never boots or kills them.
+
+Sanctioned exception: the client's stdio transport (`client.CommandTransport`) owns the subprocess it speaks to — that is the standard, opt-in, per-connection ownership every MCP client has for `command`-style servers (the `.mcp.json` shape). It lives in `client/`, is chosen explicitly, and is not the host spawning servers behind the user's back. The host wiring for it (a `ServerConfig.command` surface) is a deferred follow-up, not a violation.
+
+**Note:** the async graceful-degrade half of this constraint is a target, not yet implemented — `NewApp` today still connects synchronously and fail-fast. The enforced half is: the host does not manage server *processes*.
+
+**Verify:** the host must not spawn or kill processes. Must print nothing:
+
+```bash
+grep -rn 'os/exec\|exec\.Command\|\.Process\b\|syscall\.\(Kill\|Exec\)\|StartProcess' agent/host/ --include='*.go' | grep -v '_test.go'
+```

--- a/examples/agents/kitchen-sink/.gitignore
+++ b/examples/agents/kitchen-sink/.gitignore
@@ -1,3 +1,7 @@
 # Runtime-config overlay: mutable picks (/provider, /approve) persisted by
 # --persist-config. Machine-local, merged over kitchen-sink.json at startup.
 kitchen-sink.local.json
+
+# MCP server process state: built binaries, PID files, and logs written by
+# servers.sh (just servers-up). Machine-local, never committed.
+.servers/

--- a/examples/agents/kitchen-sink/Makefile
+++ b/examples/agents/kitchen-sink/Makefile
@@ -41,13 +41,13 @@ export ACTIVE SESSION_STORE SESSION OFFLOAD_THRESHOLD EMBED_MODEL EMBED_URL EMBE
        EMBED_API_KEY_ENV COMPACT_TOKENS EXPORTER OTLP_ENDPOINT UI \
        PG_HOST PG_PORT PG_DB PG_USER
 
-.PHONY: check preflight run demo note allup alldown up obs-up psql mem server build
+.PHONY: check preflight run demo note allup alldown up obs-up psql mem servers-up servers-down servers build
 
 check: ## Probe every backend; print bring-up instructions for what's missing.
 	@bash preflight.sh
 preflight: check
 
-run: ## Preflight, boot the four MCP servers (demo + eager/catalog skills + events), launch agentchat.
+run: ## Preflight, verify the MCP servers are up (make servers-up), launch agentchat.
 	@bash run.sh
 demo: run
 
@@ -76,8 +76,18 @@ psql: ## Open a psql shell on the agent DB.
 mem: ## Show the durable semantic-memory rows.
 	docker exec mcpkit-postgres psql -U $(PG_USER) -d $(PG_DB) -c "select namespace, key, created_at from agent_memories order by created_at;"
 
-server: ## Boot just the demo MCP server (:8788).
-	cd server && go run .
+# --- MCP servers (lifecycle decoupled from the agent; root CONSTRAINTS.md) ---
+# Run independently of agentchat and survive chat restarts. `make run` only
+# checks they are up. Optional NAME targets one server: `make servers-up NAME=demo`.
+
+servers-up: ## Start all MCP servers the config connects to (NAME=<one> for just one).
+	@bash servers.sh up $(NAME)
+
+servers-down: ## Stop all MCP servers (NAME=<one> for just one).
+	@bash servers.sh down $(NAME)
+
+servers: ## Show which MCP servers are up (NAME=<one> for just one).
+	@bash servers.sh status $(NAME)
 
 build: ## Build the demo server (compile check).
 	cd server && go build ./...

--- a/examples/agents/kitchen-sink/README.md
+++ b/examples/agents/kitchen-sink/README.md
@@ -30,8 +30,10 @@ flag, because it is a separate endpoint from the chat model.
 ### The four MCP servers
 
 `kitchen-sink.json` connects to four servers, and the host is a **pure client**:
-it connects to them, it does not manage them, so the launcher boots them on the
-ports the config expects. This mirrors an `.mcp.json`-style connect-list.
+it connects to them by URL, it does not manage them. Their lifecycle is
+decoupled from the agent (root `CONSTRAINTS.md` C6) — you start them once with
+`just servers-up` and they survive chat restarts. This mirrors an
+`.mcp.json`-style connect-list.
 
 | Server | Port | Serves | Why |
 |---|---|---|---|
@@ -43,9 +45,21 @@ ports the config expects. This mirrors an `.mcp.json`-style connect-list.
 `runbooks` is eager and `community` is catalog on purpose: eager for the small,
 trusted skill set, catalog for the fuller one — the trust lever documented in
 `agent/host` (catalog gates each skill through the `load_skill` tool, so it can
-ride the approval ladder). Spawning these servers from the config instead of the
-launcher is a deferred follow-up (`ServerConfig.command`); today they connect by
-URL.
+ride the approval ladder).
+
+Manage the servers independently of the chat:
+
+```bash
+just servers-up            # start all four (built to .servers/bin, run detached)
+just servers               # status: which are up
+just servers-up events     # start just one
+just servers-down          # stop all
+```
+
+`just run` only *checks* these ports and tells you to `just servers-up` if any
+are down — it never boots or kills them. Having the agent spawn them from the
+config (`ServerConfig.command`, stdio) is a deferred follow-up; the client
+already owns stdio subprocess lifecycle, only the config surface is missing.
 
 ## Prerequisites
 
@@ -64,18 +78,22 @@ URL.
 
 ## Quick start
 
+Three layers, brought up separately (backends → MCP servers → agent):
+
 ```bash
 just allup      # postgres+pgvector + observability stacks (or: make allup)
-just check      # probe everything; prints how to fix whatever is down
-just run        # preflight, boot the four MCP servers, launch agentchat (inline TUI)
+just servers-up # the four MCP servers (independent of the chat)
+just check      # probe backends; prints how to fix whatever is down
+just run        # preflight, verify servers are up, launch agentchat (inline TUI)
 just note       # same, but the alt-screen notebook UI (scrollable, foldable cells)
-# ... chat ...
-just alldown    # tear the stacks back down
+# ... chat, quit, `just run` again — the servers are still up ...
+just servers-down  # stop the MCP servers
+just alldown       # tear the stacks back down
 ```
 
-`just run` fails fast if postgres is down (the config depends on it) and warns
-if observability or the embedder are missing (chat still works; those features
-degrade).
+`just run` fails fast if postgres is down (the config depends on it) or if any
+MCP server is unreachable (it tells you to `just servers-up`), and warns if
+observability or the embedder are missing (chat still works; those degrade).
 
 ### Run against real providers
 
@@ -178,9 +196,9 @@ live at the top of the `justfile` / `Makefile`.
   `just check` tells you to reset: `cd docker/backends && just down && rm -rf data/postgres && just up`.
 - **Ports:** demo `:8788` (playground owns `:8787`), skills-core/eager `:8789`,
   skills/catalog `:8790`, events `:8791`, postgres `:5432`, OTLP `:4317`,
-  Grafana `:3000`. The four MCP servers are booted by `run.sh`; their logs go to
-  `$LOG_DIR/kitchen-sink-<name>.log` (default `$TMPDIR`) so they don't clobber
-  the TUI. `tail -f` one to watch a server.
+  Grafana `:3000`. The four MCP servers are managed by `just servers-up` /
+  `servers.sh` (not `run.sh`); their binaries, PID files, and logs live under
+  `.servers/` (gitignored). `tail -f .servers/<name>.log` to watch a server.
 
 ## Extending
 

--- a/examples/agents/kitchen-sink/justfile
+++ b/examples/agents/kitchen-sink/justfile
@@ -54,8 +54,7 @@ check:
 # Alias for check.
 preflight: check
 
-# Preflight, boot the four MCP servers (demo + eager/catalog skills + events),
-# then launch agentchat with everything wired.
+# Preflight backends + verify MCP servers are up (just servers-up), launch agentchat.
 run:
     @bash run.sh
 
@@ -94,9 +93,21 @@ psql:
 mem:
     docker exec mcpkit-postgres psql -U {{PG_USER}} -d {{PG_DB}} -c "select namespace, key, created_at from agent_memories order by created_at;"
 
-# Boot just the demo MCP server in the foreground (:8788).
-server:
-    cd server && go run .
+# --- MCP servers (lifecycle decoupled from the agent; root CONSTRAINTS.md) ---
+# These run independently of agentchat and survive chat restarts. `just run`
+# only checks they are up; it never starts or stops them.
+
+# Start all MCP servers the config connects to, or one: `just servers-up demo`.
+servers-up name="":
+    @bash servers.sh up {{name}}
+
+# Stop all MCP servers, or one: `just servers-down events`.
+servers-down name="":
+    @bash servers.sh down {{name}}
+
+# Show which MCP servers are up (or one: `just servers demo`).
+servers name="":
+    @bash servers.sh status {{name}}
 
 # Build the demo server (compile check).
 build:

--- a/examples/agents/kitchen-sink/run.sh
+++ b/examples/agents/kitchen-sink/run.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-# Launch the kitchen-sink demo: preflight the backends, boot the demo MCP
-# server, then start agentchat with every feature wired — durable postgres
-# sessions, tool-result offloading, semantic pgvector memory, compaction,
-# OTel traces, and two sub-agent personas (from kitchen-sink.json).
+# Launch the kitchen-sink demo: preflight the backends, verify the MCP servers
+# are up (started separately via `just servers-up`), then start agentchat with
+# every feature wired — durable postgres sessions, tool-result offloading,
+# semantic pgvector memory, compaction, OTel traces, and two sub-agent personas
+# (from kitchen-sink.json).
 #
 # Every knob is an env var with a Make/just default, so `just run` and
 # `SESSION=foo EMBED_DIM=1536 just run` both work. The chat model comes from
@@ -30,42 +31,29 @@ UI="${UI:-tui}"
 
 bash "$DIR/preflight.sh"
 
-# The config connects to four MCP servers (kitchen-sink.json):
-#   demo      :8788  greet/report/analyze (offloading + sub-agent tools)
-#   runbooks  :8789  skills-core, EAGER   (full skill bodies in the prompt)
-#   community :8790  skills,      CATALOG (bodies fetched on demand via load_skill)
-#   events    :8791  synthetic chat.message + alert.fired (feed injection)
-# The host is a pure client — it CONNECTS to these, it does not manage them, so
-# the launcher boots them here on the ports the config expects. Each server's
-# logs go to their own file: their stdout/stderr (and mcpkit's per-connection
-# SSE logging) would otherwise clobber agentchat's inline TUI input region.
-# Tail one in another window to watch it: tail -f "$LOG_DIR/kitchen-sink-<name>.log".
-LOG_DIR="${LOG_DIR:-${TMPDIR:-/tmp}}"
-SERVER_PIDS=()
-trap 'for p in "${SERVER_PIDS[@]:-}"; do kill "$p" 2>/dev/null || true; done' EXIT
-
-# boot_server <label> <workdir> <port> <run-cmd...>
-# Boots a server in the background with its logs redirected, then waits for the
-# port via a TCP probe — NOT an HTTP GET: a GET to /mcp opens the server's SSE
-# stream and never returns, so a curl-based check would hang the launch forever.
-boot_server() {
-	local label="$1" workdir="$2" port="$3"; shift 3
-	local log="$LOG_DIR/kitchen-sink-$label.log"
-	echo "==> booting $label on :$port (logs -> $log)"
-	( cd "$workdir" && "$@" ) >"$log" 2>&1 &
-	SERVER_PIDS+=("$!")
-	for _ in $(seq 1 60); do
-		(exec 3<>"/dev/tcp/localhost/$port") 2>/dev/null && { exec 3>&-; return 0; }
-		sleep 0.5
-	done
-	echo "!! $label did not come up on :$port — see $log" >&2
-	return 1
-}
-
-boot_server demo      "$DIR/server"                       8788 go run .
-boot_server runbooks  "$ROOT/examples/skills-core"        8789 go run . --serve --addr=:8789
-boot_server community "$ROOT/examples/skills"             8790 go run . --serve --addr=:8790
-boot_server events    "$ROOT/examples/events/kitchen-sink" 8791 go run . --serve --addr=:8791
+# The agent does NOT manage the MCP servers (root CONSTRAINTS.md: server
+# lifecycle is decoupled from the agent). They are brought up independently
+# with `just servers-up` and survive chat restarts. Here we only CHECK the four
+# ports the config expects and, if any are down, point the operator at the
+# command to start them — rather than booting (and killing) them ourselves.
+down=""
+for probe in demo:8788 runbooks:8789 community:8790 events:8791; do
+	name="${probe%%:*}"; port="${probe##*:}"
+	# The probe opens (and closes) fd 3 inside a subshell; its exit status is
+	# the connect result. Don't close fd 3 in this shell — it was never opened
+	# here, so `exec 3>&-` would error and falsely flag the server down.
+	if ! (exec 3<>"/dev/tcp/localhost/$port") 2>/dev/null; then
+		down="$down $name(:$port)"
+	fi
+done
+if [ -n "$down" ]; then
+	echo "MCP server(s) not reachable:$down" >&2
+	echo "  -> start them first:  just servers-up      (they run independently of the chat)" >&2
+	echo "     or just one:        just servers-up demo" >&2
+	# Until the agent connects asynchronously (idea 2), a down server fails the
+	# launch, so stop here with a clear message instead of an opaque connect error.
+	exit 1
+fi
 
 echo "==> launching agentchat (session=$SESSION, store=$SESSION_STORE)"
 cd "$ROOT/cmd/agentchat"

--- a/examples/agents/kitchen-sink/servers.sh
+++ b/examples/agents/kitchen-sink/servers.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Manage the kitchen-sink MCP servers INDEPENDENTLY of the agent.
+#
+# CONSTRAINT (root CONSTRAINTS.md): the agent is a pure MCP client — it connects
+# to servers by URL and does not own their process lifecycle. Bringing servers
+# up and down is this launcher's job, not the agent's. So these servers are
+# started here, survive agentchat restarts, and are torn down explicitly.
+#
+# Usage:
+#   servers.sh up      [name]   # build + start all servers (or just <name>)
+#   servers.sh down    [name]   # stop all (or just <name>)
+#   servers.sh status  [name]   # probe ports; show up/down
+#
+# Each server is built to .servers/bin/<name> and run detached (the PID is the
+# server itself — a `go run` wrapper would orphan its child on kill). PIDs and
+# logs live under .servers/ (gitignored).
+set -uo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$DIR/../../.." && pwd)"
+STATE="$DIR/.servers"
+mkdir -p "$STATE/bin"
+
+# The server table. bash 3.2 (macOS system bash) has no associative arrays, so
+# a case function maps name -> "workdir|port|run-args". Keep in sync with the
+# server entries in kitchen-sink.json.
+ORDER="demo runbooks community events"
+server_spec() {
+	case "$1" in
+	demo)      echo "$DIR/server|8788|" ;;
+	runbooks)  echo "$ROOT/examples/skills-core|8789|--serve --addr=:8789" ;;
+	community) echo "$ROOT/examples/skills|8790|--serve --addr=:8790" ;;
+	events)    echo "$ROOT/examples/events/kitchen-sink|8791|--serve --addr=:8791" ;;
+	*) return 1 ;;
+	esac
+}
+
+port_up() { # port -> 0 if something is listening
+	(exec 3<>"/dev/tcp/localhost/$1") 2>/dev/null && { exec 3>&-; return 0; }
+	return 1
+}
+
+up_one() {
+	local name="$1" spec dir port args
+	spec="$(server_spec "$name")" || { echo "!! unknown server: $name" >&2; return 1; }
+	IFS='|' read -r dir port args <<<"$spec"
+	if port_up "$port"; then echo "  [up]   $name :$port (already running)"; return 0; fi
+	local bin="$STATE/bin/$name" log="$STATE/$name.log" pidf="$STATE/$name.pid"
+	echo "==> building $name"
+	( cd "$dir" && go build -o "$bin" . ) || { echo "!! build $name failed" >&2; return 1; }
+	echo "==> starting $name on :$port (log -> $log)"
+	# Detach so it outlives this shell AND the agent. `exec nohup` collapses the
+	# subshell -> nohup -> binary chain onto ONE pid, so $! is the server itself
+	# (a plain `nohup bin &` would record the wrapper's pid and orphan the real
+	# process on `down`). $args is unquoted so "--serve --addr=:PORT" word-splits
+	# (empty for demo). nohup ignores SIGHUP so it survives the launching shell.
+	( cd "$dir" && exec nohup "$bin" $args >"$log" 2>&1 ) &
+	echo $! >"$pidf"
+	local i
+	for i in $(seq 1 60); do
+		port_up "$port" && { echo "  [up]   $name :$port"; return 0; }
+		sleep 0.5
+	done
+	echo "!! $name did not come up on :$port — see $log" >&2
+	return 1
+}
+
+down_one() {
+	# Split declarations: bash 3.2 + `set -u` errors if one `local` both declares
+	# name and expands $name in the same statement.
+	local name="$1"
+	local pidf="$STATE/$name.pid"
+	local pid=""
+	if [ -f "$pidf" ]; then
+		pid="$(cat "$pidf")"
+		if kill "$pid" 2>/dev/null; then echo "  [down] $name (pid $pid)"; else echo "  [--]   $name (pid $pid not running)"; fi
+		rm -f "$pidf"
+	else
+		echo "  [--]   $name (no pidfile; not started by this script)"
+	fi
+}
+
+status_one() {
+	local name="$1" spec dir port args
+	spec="$(server_spec "$name")" || { echo "!! unknown server: $name" >&2; return 1; }
+	IFS='|' read -r dir port args <<<"$spec"
+	if port_up "$port"; then echo "  [up]   $name :$port"; else echo "  [down] $name :$port"; fi
+}
+
+cmd="${1:-status}"
+target="${2:-}"
+names="$ORDER"
+[ -n "$target" ] && names="$target"
+
+case "$cmd" in
+up)     for n in $names; do up_one "$n"; done ;;
+down)   for n in $names; do down_one "$n"; done ;;
+status) echo "kitchen-sink MCP servers"; for n in $names; do status_one "$n"; done ;;
+*) echo "usage: servers.sh <up|down|status> [name]" >&2; exit 2 ;;
+esac


### PR DESCRIPTION
> Stacked on #1081 (config overlay), which is stacked on #1079 (merged). Base is `feat/config-overlay-persistence` to avoid a `run.sh`/`README.md` conflict with #1081; retarget to `main` once #1081 merges. No Go code — CI is not meaningful here; verified by running `servers.sh` and the `run.sh` readiness check locally.

## What changes

Idea 1 of the "server lifecycle is decoupled from the agent" direction. `run.sh` was booting the four MCP servers as children of the launcher and trap-killing them when agentchat exits — so restarting the chat killed the servers. This splits the two concerns and codifies the rule as a constraint.

## Reviewer's guide
1. [CONSTRAINTS.md](https://github.com/panyam/mcpkit/pull/1082/files#diff-f2043ef583480706f62a74d47dae3d7ae2402f1b42cff01383b08fe8b37fdf3b) — **start here.** New **C6: MCP server lifecycle is decoupled from the agent** (the rule, the two failure modes, the sanctioned `client.CommandTransport` exception, and a grep `Verify`).
2. [examples/agents/kitchen-sink/servers.sh](https://github.com/panyam/mcpkit/pull/1082/files#diff-adcb420b51a3545537334b5280ec02c282355564bd40e5288187e6d7402dd251) — the new lifecycle owner: `up`/`down`/`status`, all or one. Builds each server to `.servers/bin/<name>` and runs it detached.
3. [examples/agents/kitchen-sink/run.sh](https://github.com/panyam/mcpkit/pull/1082/files#diff-2bddbe5c136c0ba080a2f14842ebbb769ebc00c0b071cd9997a338e35bb1ae04) — now only *checks* the four ports and points at `just servers-up` if any are down; the `boot_server` loop and the trap-kill are gone.
4. `justfile` / `Makefile` — `servers-up` / `servers-down` / `servers` recipes.
5. `README.md` — three-layer quick start (backends → servers → agent) + a servers-management block.

## How it works
```
just servers-up   -> servers.sh builds .servers/bin/<name>, runs it detached
                     (survives the shell AND agentchat), TCP-probes readiness
just run          -> run.sh CHECKS the four ports; if any down, prints
                     "just servers-up" and stops. Never boots or kills servers.
chat, quit, just run again  -> servers still up; a fresh agent reconnects.
just servers-down -> kills the servers by pidfile.
```

## Decision log
- **`servers.sh` not per-server justfile recipes**: the manager needs a build step, detached launch, pidfile bookkeeping, and a TCP probe — one script keeps that in one place, and the justfile/Makefile are thin wrappers (mirrors the existing `run.sh`/`preflight.sh` split).
- **`run.sh` fails (not warns) if a server is down**: until the agent connects asynchronously (idea 2), a down server makes `NewApp` fail-fast anyway — a clean "run just servers-up" beats an opaque connect error. This flips to warn-and-proceed when idea 2 lands.
- **Build-to-binary + `exec nohup`**: `go run` orphans its compiled child on kill; building to a binary and `exec nohup`-ing it collapses the pid chain so the pidfile records the real server.
- **Constraint now, async later**: C6 documents the async graceful-degrade target but only enforces the process-ownership half, which is what this PR establishes. `NewApp` is still synchronous fail-fast (idea 2).

## Risk / blast radius
- `examples/agents/kitchen-sink` only, plus a doc-level constraint. No library code.
- Verified locally: `servers.sh up/down/status` (pidfile matches the actual listener; `down` frees the port), and the `run.sh` readiness loop under bash (passes when up, reports the down set otherwise).

## Before / after
```
# before: chat and servers share a lifetime
just run            # boots 4 servers as children + launches chat; quitting chat kills them

# after: independent lifetimes
just servers-up     # 4 servers, detached
just run            # connects; quit + `just run` again -> servers still up
just servers-down   # explicit teardown
```

## Portability gotchas handled (macOS system bash is 3.2)
- No associative arrays → a `case`-function server table.
- `set -u` errors on same-statement declare+expand (`local name=$1 pidf=$STATE/$name.pid`) → split locals.
- The port probe uses a subshell's exit status; it does not `exec 3>&-` in a shell that never opened fd 3 (that errored and falsely flagged servers down).

## Out of scope
- **Idea 2** (async, graceful-degrade connection in `NewApp`; per-server status like Claude Code's failed/paused/needs-login) — its own host-layer PR, needs a short design note first (the eager-skills-at-boot tension).
- Host-managed spawning from config (`ServerConfig.command` + stdio).
