### PR TITLE
feat(client): Group — async connect + per-server state + backoff reconnect

### DIFF
--- a/client/group.go
+++ b/client/group.go
@@ -1,0 +1,337 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ConnState is the connection state of a Group member. It is the client-layer
+// half of the agent's per-server status (see docs/AGENT_SERVER_STATE.md): a
+// consumer (agent host, a script, cmd/testclient, a dashboard) reacts to
+// transitions to register/deregister capabilities and to render status.
+type ConnState int
+
+const (
+	// StateDisabled is a member that has been added but not yet started.
+	StateDisabled ConnState = iota
+	// StateConnecting is an in-flight connection attempt (initial or a retry).
+	StateConnecting
+	// StateReady is connected and initialized — capabilities are usable.
+	StateReady
+	// StateFailed is a connect failure that will be retried with backoff
+	// (network refusal, 5xx, EOF). Err holds the last failure.
+	StateFailed
+	// StateNeedsLogin is a 401/403 rejection: the member needs user action
+	// (login) and is NOT auto-retried, so a retry loop can't hammer the server.
+	StateNeedsLogin
+)
+
+// String renders a ConnState for status output.
+func (s ConnState) String() string {
+	switch s {
+	case StateDisabled:
+		return "disabled"
+	case StateConnecting:
+		return "connecting"
+	case StateReady:
+		return "ready"
+	case StateFailed:
+		return "failed"
+	case StateNeedsLogin:
+		return "needs-login"
+	default:
+		return "unknown"
+	}
+}
+
+// StateChange is delivered to a Group observer on every member transition.
+type StateChange struct {
+	ID    string
+	State ConnState
+	Err   error // set for StateFailed / StateNeedsLogin
+}
+
+// MemberStatus is an ordered snapshot entry from Group.Status, for rendering a
+// /servers-style view without racing the live state.
+type MemberStatus struct {
+	ID       string
+	State    ConnState
+	Err      error
+	Required bool
+}
+
+// classifyConnectErr maps a Connect error to the state it should produce. Auth
+// rejections (401/403) are terminal-until-user-action (StateNeedsLogin); every
+// other error is retryable (StateFailed), reusing the transient/terminal split
+// the reconnection path already draws — a "failed" member keeps retrying, which
+// is what lets a server that comes up late wire itself in.
+func classifyConnectErr(err error) ConnState {
+	var authErr *ClientAuthError
+	if errors.As(err, &authErr) {
+		return StateNeedsLogin
+	}
+	return StateFailed
+}
+
+type groupMember struct {
+	id       string
+	client   *Client
+	required bool
+
+	// guarded by Group.mu
+	state ConnState
+	err   error
+	ready chan struct{} // closed once, on first StateReady (for WaitRequired)
+}
+
+// Group manages the connection lifecycle of N clients: it connects them
+// concurrently, tracks per-member state, retries failed members with backoff,
+// and lets a caller block until the members it marked required are ready. It is
+// host-agnostic — the connection concern lives in client/ so any consumer can
+// hold a Group, while the reaction to a member becoming ready (registering its
+// tools/skills/events) stays with the consumer via an observer.
+//
+// A Group does not create the clients; the caller builds each Client and hands
+// it to Add. Close stops the retry loops and closes the member clients (the
+// Group owns their lifetime once Add is called).
+type Group struct {
+	mu      sync.Mutex
+	members map[string]*groupMember
+	order   []string
+
+	reqTimeout time.Duration
+	minBackoff time.Duration
+	maxBackoff time.Duration
+	observer   func(StateChange)
+
+	started bool
+	ctx     context.Context
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
+}
+
+// GroupOption configures a Group.
+type GroupOption func(*Group)
+
+// WithRequiredTimeout sets how long WaitRequired blocks before failing with the
+// required members that never reached ready. Default 30s; 0 means wait
+// indefinitely (the "hang until this server is up, however long it takes" case).
+func WithRequiredTimeout(d time.Duration) GroupOption {
+	return func(g *Group) { g.reqTimeout = d }
+}
+
+// WithGroupBackoff sets the exponential backoff bounds for retrying a failed
+// member. Defaults: 500ms to 30s.
+func WithGroupBackoff(min, max time.Duration) GroupOption {
+	return func(g *Group) { g.minBackoff, g.maxBackoff = min, max }
+}
+
+// WithObserver registers a callback invoked on every member state transition.
+// It is called from the member's own goroutine, so it may be invoked
+// concurrently for different members and must be safe for concurrent use; keep
+// it quick or hand off, since a slow observer stalls that member's loop.
+func WithObserver(fn func(StateChange)) GroupOption {
+	return func(g *Group) { g.observer = fn }
+}
+
+// NewGroup builds a Group. Add members, then Start.
+func NewGroup(opts ...GroupOption) *Group {
+	g := &Group{
+		members:    map[string]*groupMember{},
+		reqTimeout: 30 * time.Second,
+		minBackoff: 500 * time.Millisecond,
+		maxBackoff: 30 * time.Second,
+	}
+	for _, o := range opts {
+		o(g)
+	}
+	return g
+}
+
+// Add registers c under id. A required member blocks WaitRequired until it is
+// ready. Add must be called before Start; a duplicate id is ignored.
+func (g *Group) Add(id string, c *Client, required bool) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if _, ok := g.members[id]; ok {
+		return
+	}
+	g.members[id] = &groupMember{id: id, client: c, required: required, state: StateDisabled, ready: make(chan struct{})}
+	g.order = append(g.order, id)
+}
+
+// Start kicks off an async connect loop per member and returns immediately —
+// the caller is usable before any member is ready. Idempotent.
+func (g *Group) Start(ctx context.Context) {
+	g.mu.Lock()
+	if g.started {
+		g.mu.Unlock()
+		return
+	}
+	g.started = true
+	g.ctx, g.cancel = context.WithCancel(ctx)
+	members := make([]*groupMember, 0, len(g.order))
+	for _, id := range g.order {
+		members = append(members, g.members[id])
+	}
+	g.mu.Unlock()
+
+	for _, m := range members {
+		g.wg.Add(1)
+		go g.run(m)
+	}
+}
+
+// run is one member's connect-and-retry loop. On success it settles at
+// StateReady and stops (a live drop after ready is out of scope for phase 1 —
+// the client reconnects a dropped live connection internally). On an auth
+// rejection it settles at StateNeedsLogin and stops (no hammering). Any other
+// failure retries with exponential backoff until the context is cancelled.
+func (g *Group) run(m *groupMember) {
+	defer g.wg.Done()
+	backoff := g.minBackoff
+	for {
+		if g.ctx.Err() != nil {
+			return
+		}
+		g.set(m, StateConnecting, nil)
+		err := m.client.Connect()
+		if err == nil {
+			g.set(m, StateReady, nil)
+			return
+		}
+		state := classifyConnectErr(err)
+		g.set(m, state, err)
+		if state == StateNeedsLogin {
+			return
+		}
+		select {
+		case <-g.ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		if backoff *= 2; backoff > g.maxBackoff {
+			backoff = g.maxBackoff
+		}
+	}
+}
+
+// set records a transition and notifies the observer. It closes the member's
+// ready channel exactly once when it first reaches ready, which is what
+// WaitRequired waits on.
+func (g *Group) set(m *groupMember, s ConnState, err error) {
+	g.mu.Lock()
+	m.state, m.err = s, err
+	if s == StateReady {
+		select {
+		case <-m.ready: // already closed
+		default:
+			close(m.ready)
+		}
+	}
+	obs := g.observer
+	g.mu.Unlock()
+	if obs != nil {
+		obs(StateChange{ID: m.id, State: s, Err: err})
+	}
+}
+
+// WaitRequired blocks until every required member has reached ready, the
+// context is cancelled, or the required-timeout elapses (returning an error
+// naming the members that did not make it). With no required members it returns
+// immediately. A zero timeout waits indefinitely.
+func (g *Group) WaitRequired(ctx context.Context) error {
+	g.mu.Lock()
+	var reqs []*groupMember
+	for _, id := range g.order {
+		if m := g.members[id]; m.required {
+			reqs = append(reqs, m)
+		}
+	}
+	timeout := g.reqTimeout
+	g.mu.Unlock()
+
+	var deadline <-chan time.Time
+	if timeout > 0 {
+		t := time.NewTimer(timeout)
+		defer t.Stop()
+		deadline = t.C
+	}
+	for _, m := range reqs {
+		select {
+		case <-m.ready:
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline:
+			return fmt.Errorf("client: required servers not ready within %s: %s", timeout, g.notReadyRequired())
+		}
+	}
+	return nil
+}
+
+// notReadyRequired lists the ids of required members not yet ready, for the
+// WaitRequired timeout message.
+func (g *Group) notReadyRequired() string {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	var out []string
+	for _, id := range g.order {
+		m := g.members[id]
+		if m.required && m.state != StateReady {
+			out = append(out, fmt.Sprintf("%s(%s)", id, m.state))
+		}
+	}
+	return strings.Join(out, ", ")
+}
+
+// State returns a member's current state and whether the id is known.
+func (g *Group) State(id string) (ConnState, bool) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	m, ok := g.members[id]
+	if !ok {
+		return StateDisabled, false
+	}
+	return m.state, true
+}
+
+// Status returns an ordered snapshot of every member, for a /servers-style view.
+func (g *Group) Status() []MemberStatus {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	out := make([]MemberStatus, 0, len(g.order))
+	for _, id := range g.order {
+		m := g.members[id]
+		out = append(out, MemberStatus{ID: id, State: m.state, Err: m.err, Required: m.required})
+	}
+	return out
+}
+
+// Close stops the connect/retry loops and closes the member clients. It waits
+// for the per-member goroutines to exit. Safe to call more than once.
+func (g *Group) Close() error {
+	g.mu.Lock()
+	if g.cancel != nil {
+		g.cancel()
+	}
+	members := make([]*groupMember, 0, len(g.order))
+	for _, id := range g.order {
+		members = append(members, g.members[id])
+	}
+	g.mu.Unlock()
+
+	// Close the clients to abort any in-flight Connect (which takes no context),
+	// then wait for the goroutines to observe cancellation and exit.
+	var firstErr error
+	for _, m := range members {
+		if err := m.client.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	g.wg.Wait()
+	return firstErr
+}

--- a/client/group_internal_test.go
+++ b/client/group_internal_test.go
@@ -1,0 +1,22 @@
+package client
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestClassifyConnectErr(t *testing.T) {
+	if got := classifyConnectErr(&ClientAuthError{StatusCode: 401, Message: "nope"}); got != StateNeedsLogin {
+		t.Errorf("401 -> %v, want needs-login", got)
+	}
+	// a wrapped auth error still classifies as needs-login
+	wrapped := fmt.Errorf("connect: %w", &ClientAuthError{StatusCode: 403})
+	if got := classifyConnectErr(wrapped); got != StateNeedsLogin {
+		t.Errorf("wrapped 403 -> %v, want needs-login", got)
+	}
+	// anything else is retryable
+	if got := classifyConnectErr(errors.New("connection refused")); got != StateFailed {
+		t.Errorf("generic -> %v, want failed", got)
+	}
+}

--- a/client/group_test.go
+++ b/client/group_test.go
@@ -1,0 +1,139 @@
+package client_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/panyam/mcpkit/client"
+	"github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/server"
+	"github.com/panyam/mcpkit/testutil"
+)
+
+var ci = core.ClientInfo{Name: "group-test", Version: "1.0"}
+
+func testMCPServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	ts := httptest.NewServer(testutil.NewTestServer().Handler(server.WithStreamableHTTP(true)))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// a URL that refuses connections (port 1 is never listenable), so Connect fails
+// transiently and the member retries -> StateFailed.
+const refusedURL = "http://127.0.0.1:1/mcp"
+
+func waitState(t *testing.T, g *client.Group, id string, want client.ConnState, within time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		if s, ok := g.State(id); ok && s == want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	s, _ := g.State(id)
+	t.Fatalf("%s: state = %v, want %v within %s", id, s, want, within)
+}
+
+func TestGroup_ReadyAndWaitRequired(t *testing.T) {
+	ts := testMCPServer(t)
+	g := client.NewGroup(client.WithRequiredTimeout(5 * time.Second))
+	g.Add("a", client.NewClient(ts.URL+"/mcp", ci), true)
+	g.Start(context.Background())
+	defer g.Close()
+
+	if err := g.WaitRequired(context.Background()); err != nil {
+		t.Fatalf("WaitRequired: %v", err)
+	}
+	if s, _ := g.State("a"); s != client.StateReady {
+		t.Fatalf("state = %v, want ready", s)
+	}
+	st := g.Status()
+	if len(st) != 1 || st[0].ID != "a" || st[0].State != client.StateReady || !st[0].Required {
+		t.Fatalf("status = %+v", st)
+	}
+}
+
+func TestGroup_OptionalDownDoesNotBlockRequired(t *testing.T) {
+	ts := testMCPServer(t)
+	g := client.NewGroup(
+		client.WithRequiredTimeout(5*time.Second),
+		client.WithGroupBackoff(10*time.Millisecond, 50*time.Millisecond),
+	)
+	g.Add("up", client.NewClient(ts.URL+"/mcp", ci), true)     // required, works
+	g.Add("down", client.NewClient(refusedURL, ci), false)     // optional, refused
+	g.Start(context.Background())
+	defer g.Close()
+
+	// The required member being ready must not wait on the failing optional one.
+	if err := g.WaitRequired(context.Background()); err != nil {
+		t.Fatalf("WaitRequired blocked on the optional server: %v", err)
+	}
+	waitState(t, g, "down", client.StateFailed, 3*time.Second)
+}
+
+func TestGroup_WaitRequiredTimeout(t *testing.T) {
+	g := client.NewGroup(
+		client.WithRequiredTimeout(200*time.Millisecond),
+		client.WithGroupBackoff(10*time.Millisecond, 50*time.Millisecond),
+	)
+	g.Add("down", client.NewClient(refusedURL, ci), true) // required, never ready
+	g.Start(context.Background())
+	defer g.Close()
+
+	err := g.WaitRequired(context.Background())
+	if err == nil {
+		t.Fatal("WaitRequired should time out when a required server never becomes ready")
+	}
+	if !strings.Contains(err.Error(), "down") {
+		t.Errorf("timeout error should name the laggard, got: %v", err)
+	}
+}
+
+func TestGroup_ObserverSeesTransitions(t *testing.T) {
+	ts := testMCPServer(t)
+	var mu sync.Mutex
+	seen := map[client.ConnState]bool{}
+	g := client.NewGroup(
+		client.WithRequiredTimeout(5*time.Second),
+		client.WithObserver(func(sc client.StateChange) {
+			mu.Lock()
+			seen[sc.State] = true
+			mu.Unlock()
+		}),
+	)
+	g.Add("a", client.NewClient(ts.URL+"/mcp", ci), true)
+	g.Start(context.Background())
+	defer g.Close()
+
+	if err := g.WaitRequired(context.Background()); err != nil {
+		t.Fatalf("WaitRequired: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if !seen[client.StateConnecting] || !seen[client.StateReady] {
+		t.Errorf("observer missed transitions, saw: %v", seen)
+	}
+}
+
+// TestGroup_CloseIdempotent verifies Close stops the retry loops (no goroutine
+// leak / hang) even with a member that is still retrying, and is safe twice.
+func TestGroup_CloseIdempotent(t *testing.T) {
+	g := client.NewGroup(client.WithGroupBackoff(10*time.Millisecond, 50*time.Millisecond))
+	g.Add("down", client.NewClient(refusedURL, ci), false)
+	g.Start(context.Background())
+	waitState(t, g, "down", client.StateFailed, 3*time.Second)
+
+	done := make(chan struct{})
+	go func() { g.Close(); g.Close(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close hung (retry goroutine not stopped)")
+	}
+}


### PR DESCRIPTION
## What changes

Phase 1 of the async graceful-degrade server-state work (root `CONSTRAINTS.md` C6, design in `docs/AGENT_SERVER_STATE.md` / #1086): the client-layer connection-lifecycle primitive that the agent host will consume to boot despite down servers and show per-server status. **This PR is `client.Group` alone** — no host changes yet; `NewApp` still connects synchronously until the next PR wires it.

## Reviewer's guide
1. [client/group.go](https://github.com/panyam/mcpkit/pull/1087/files#diff-2823e25c587857631e2e1db1892c124e3a178790c0f345bfd2156a9f9f80019e) — start here. `ConnState` + the `Group` state machine. The load-bearing methods are `run` (connect → classify → backoff retry), `WaitRequired` (block on required members' ready), and `set` (transition + observer + ready-channel close).
2. [client/group_test.go](https://github.com/panyam/mcpkit/pull/1087/files#diff-09cb991c79c27ae000c3e0f98f56edbcaee9bc0be5f8bfd97fe9e02a5c6f436e) — acceptance: ready + `WaitRequired`, optional-down-doesn't-block-required, `WaitRequired` timeout names the laggard, observer sees transitions, `Close` doesn't hang a retrying member.
3. [client/group_internal_test.go](https://github.com/panyam/mcpkit/pull/1087/files#diff-2aee9bfcc1a768a3d6fe1391c86765b16a08eee617df93e5640d707527f9291a) — the pure `classifyConnectErr` split (401/403 → needs-login, else → failed).

## How it works
```
Add(id, client, required)  →  member{state: disabled}
Start(ctx)                 →  one goroutine per member:
    loop:
      state = connecting
      err = client.Connect()
      err == nil            → state = ready; close ready-chan; stop
      401/403 (ClientAuthError) → state = needs-login; stop (no hammering)
      else                  → state = failed; sleep backoff (exp, capped); retry
WaitRequired(ctx)          →  block on each required member's ready-chan,
                              until ready / ctx / timeout(30s def, 0=forever)
observer(StateChange)      →  fired on every transition (host registers here)
```

## Decision log
- **Lives in `client/`, not the host** — connection lifecycle is client-layer (a script / `cmd/testclient` / a dashboard would want it); the host consumes it and owns only the *reaction* (register tools/skills/events on ready). Per the agent-vs-client layering rule.
- **`WaitRequired` timeout: 30s default, `0` = indefinite** — the "hang until `atlassian` is up, however long it takes" case, while non-required servers connect in the background.
- **401/403 → `needs-login`, no auto-retry** — retrying an auth rejection just hammers the server; it waits for user action (phase 3 `/login`).
- **Ready is terminal for the loop in phase 1** — a live drop after ready isn't re-detected here (the client already reconnects a live connection internally); full drop→deregister is phase 2.
- **Reuses `ClientAuthError` / the existing transient split** rather than a new error taxonomy.

## Risk / blast radius
- Additive: one new file + tests in `client/`. No existing behavior changed, no new dependencies (stdlib only), no sub-module tidy.
- Concurrency: verified `-race` clean; `Close` is tested against a still-retrying member (no hang) and is idempotent.

## Out of scope (next PRs)
- **Host wiring** (#1086 phase 1 remainder): `NewApp` off its sync-fail-fast loop onto a `Group`, the `/servers` command, `ServerConfig.required`, register-on-ready.
- **Phase 2**: `RunnerConfig.InstructionsFunc` (dynamic system prompt for late eager skills), drop→deregister, `ErrNotAvailableNow` for calls to a non-ready server.
- **Phase 3**: interactive re-auth.
