### PR TITLE
feat(agent/host): async graceful-degrade server connection (phase 1)

### DIFF
--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -31,6 +31,13 @@ type App struct {
 	replOut   io.Writer // terminal REPL draws its own prompt here
 	failover  *agent.FailoverProvider
 
+	// group owns the MCP server connection lifecycle (async connect, per-server
+	// state, backoff reconnect); its observer registers a server's tools when it
+	// becomes ready. serverTools mirrors the server sources for sub-agent
+	// personas. See docs/AGENT_SERVER_STATE.md.
+	group       *client.Group
+	serverTools *agent.MultiSource
+
 	injection *agent.EventInjectionPolicy
 	triggers  *agent.TriggerPolicy
 	approval  *agent.TieredApproval
@@ -42,6 +49,7 @@ type App struct {
 	subs      map[string]*subscription
 	metaTools bool
 	turnMu    sync.Mutex
+	emitMu    sync.Mutex // serializes emit so concurrent server-connect events don't race the renderer
 	eventStop context.CancelFunc
 
 	// store and runID are the persistence seam (WithRunStore): runID is
@@ -134,6 +142,49 @@ func WithConfigOverlay(configPath string) AppOption {
 	return func(o *appOptions) { o.configPath = configPath }
 }
 
+// registerServerTools wraps a now-ready server's client as a ToolSource (with
+// its per-server allow filter) and adds it to the aggregate and, when
+// sub-agents are configured, the sub-agent view. It is called from the
+// connection Group's observer on StateReady — possibly concurrently for
+// several servers — so it relies on MultiSource.Add being safe for concurrent
+// use. A registration failure degrades to a warning, never a crash.
+func (a *App) registerServerTools(sc ServerConfig, c *client.Client) {
+	if c == nil {
+		return
+	}
+	var src agent.ToolSource = agent.NewClientSource(c,
+		agent.WithInputHandler(client.DefaultInputHandler(c)),
+		agent.WithTaskStatusHook(func(dt *core.DetailedTask) { a.emit(HostEvent{Kind: HostTaskStatus, TaskStatus: dt}) }),
+		agent.WithTaskGrace(a.cfg.taskGrace()),
+		agent.WithTaskDetachHook(a.onTaskDetach),
+		agent.WithTaskCompletionHook(func(bt *client.BackgroundTask) { a.onTaskComplete(sc.ID, bt) }))
+	if len(sc.Allow) > 0 {
+		allowed := make(map[string]bool, len(sc.Allow))
+		for _, name := range sc.Allow {
+			allowed[name] = true
+		}
+		src = agent.NewFilterSource(src, func(d core.ToolDef) bool { return allowed[d.Name] })
+	}
+	if err := a.sources.Add(sc.ID, src); err != nil {
+		a.emit(HostEvent{Kind: HostSessionWarn, Err: fmt.Sprintf("register tools for %s: %v", sc.ID, err)})
+		return
+	}
+	if a.serverTools != nil {
+		_ = a.serverTools.Add(sc.ID, src)
+	}
+	// A late-added source changes the tool list; clear any cached aggregate so
+	// the next turn sees the new tools.
+	a.sources.Invalidate()
+}
+
+// errString renders an error for a HostEvent's Err field, empty for nil.
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
 // NewApp connects every configured server and assembles the agent. The
 // returned App owns the client connections; call Close when done.
 func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, error) {
@@ -146,6 +197,12 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 	}
 	if o.logger == nil {
 		o.logger = slog.New(slog.DiscardHandler)
+	}
+	// A nil writer is a valid "discard output" request: the default renderer and
+	// the terminal elicitation UI both write to it, and servers now emit
+	// state-change events during construction, so a nil here would panic.
+	if out == nil {
+		out = io.Discard
 	}
 
 	observers := o.observers
@@ -174,11 +231,24 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 	// sub-agents — so a sub-agent persona gets a filtered view of the servers
 	// without seeing the meta-tools or the other personas (which would let it
 	// recurse). Built only when sub-agents are configured.
-	var serverTools *agent.MultiSource
 	if len(cfg.SubAgents) > 0 {
-		serverTools = agent.NewMultiSource()
+		app.serverTools = agent.NewMultiSource()
 	}
 
+	// Build one client per server and hand it to the connection Group, which
+	// connects them asynchronously and calls the observer as each transitions.
+	// A server's tools register the moment it becomes ready (registerServerTools),
+	// so a server that is down at boot — or comes up late — wires its tools in
+	// without blocking or failing the agent. Required servers block boot below.
+	serverByID := make(map[string]ServerConfig, len(cfg.Servers))
+	clientByID := make(map[string]*client.Client, len(cfg.Servers))
+	onState := func(ch client.StateChange) {
+		app.emit(HostEvent{Kind: HostServerStateChanged, ServerID: ch.ID, ServerState: ch.State.String(), Err: errString(ch.Err)})
+		if ch.State == client.StateReady {
+			app.registerServerTools(serverByID[ch.ID], clientByID[ch.ID])
+		}
+	}
+	app.group = client.NewGroup(client.WithObserver(onState))
 	for _, sc := range cfg.Servers {
 		copts := []client.ClientOption{
 			client.WithGetSSEStream(),
@@ -196,41 +266,35 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 			copts = append(copts, authOpt)
 		}
 		c := client.NewClient(sc.URL, core.ClientInfo{Name: "agentchat", Version: "0.1"}, copts...)
-		if err := c.Connect(); err != nil {
-			app.Close()
-			return nil, fmt.Errorf("agentchat: connect %s (%s): %w", sc.ID, sc.URL, err)
-		}
 		app.clients = append(app.clients, c)
-
-		var src agent.ToolSource = agent.NewClientSource(c,
-			agent.WithInputHandler(client.DefaultInputHandler(c)),
-			agent.WithTaskStatusHook(func(dt *core.DetailedTask) { app.emit(HostEvent{Kind: HostTaskStatus, TaskStatus: dt}) }),
-			agent.WithTaskGrace(cfg.taskGrace()),
-			agent.WithTaskDetachHook(app.onTaskDetach),
-			agent.WithTaskCompletionHook(func(bt *client.BackgroundTask) { app.onTaskComplete(sc.ID, bt) }))
-		if len(sc.Allow) > 0 {
-			allowed := make(map[string]bool, len(sc.Allow))
-			for _, name := range sc.Allow {
-				allowed[name] = true
-			}
-			src = agent.NewFilterSource(src, func(d core.ToolDef) bool { return allowed[d.Name] })
-		}
-		if err := multi.Add(sc.ID, src); err != nil {
-			app.Close()
-			return nil, err
-		}
-		if serverTools != nil {
-			if err := serverTools.Add(sc.ID, src); err != nil {
-				app.Close()
-				return nil, err
-			}
-		}
+		serverByID[sc.ID] = sc
+		clientByID[sc.ID] = c
+		app.group.Add(sc.ID, c, sc.Required)
 	}
+	app.group.Start(context.Background())
+	// Block only for the servers marked required; the rest keep connecting in
+	// the background and register via the observer as they become ready.
+	if err := app.group.WaitRequired(context.Background()); err != nil {
+		app.Close()
+		return nil, fmt.Errorf("agentchat: %w", err)
+	}
+	// Wait for the initial connect round to settle (bounded) so reachable
+	// servers are ready and their tools/skills registered before the first
+	// turn; a down server fails fast and does not block, and a slow one wires
+	// in later via the observer.
+	_ = app.group.WaitSettled(context.Background())
 
+	// Skills are a boot snapshot: only servers ready by now contribute their
+	// eager blocks / catalog. A server that connects later gets its tools (via
+	// the observer) but not its skills until a restart — late-skill wiring is
+	// the follow-up (docs/AGENT_SERVER_STATE.md phase 2).
 	instructions := cfg.Instructions
 	var skillCatalog []catalogSkill
 	for i, sc := range cfg.Servers {
 		if sc.Skills != nil && !*sc.Skills {
+			continue
+		}
+		if s, _ := app.group.State(sc.ID); s != client.StateReady {
 			continue
 		}
 		block, cat, err := loadSkillsForServer(app.clients[i], sc.ID, sc.SkillsMode, sc.SkillsAllow, app.emit, o.tp)
@@ -333,7 +397,7 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 	// a filtered view of serverTools (built above), so it never sees the
 	// meta-tools or its sibling personas.
 	if len(cfg.SubAgents) > 0 {
-		if err := app.registerSubAgents(multi, serverTools, provider, o.tp); err != nil {
+		if err := app.registerSubAgents(multi, app.serverTools, provider, o.tp); err != nil {
 			app.Close()
 			return nil, err
 		}
@@ -414,8 +478,16 @@ func (a *App) Close() {
 		bt.Cancel()
 	}
 	a.tasksMu.Unlock()
-	for _, c := range a.clients {
-		c.Close()
+	// The Group owns the server connections' lifecycle: closing it stops the
+	// connect/retry goroutines and closes the member clients. Fall back to
+	// closing clients directly only if the Group was never built (an early
+	// construction error).
+	if a.group != nil {
+		a.group.Close()
+	} else {
+		for _, c := range a.clients {
+			c.Close()
+		}
 	}
 }
 
@@ -506,8 +578,13 @@ func (a *App) SwitchProvider(name string) error {
 }
 
 // emit fans a host event out to every registered observer. Fire-and-forget:
-// observers render, trace, or push it; none reply.
+// observers render, trace, or push it; none reply. Serialized: the async server
+// connections (Group observer), the turn goroutine, and event goroutines all
+// emit, so the lock keeps a not-inherently-concurrent observer (the terminal
+// renderer writing to one io.Writer) from racing.
 func (a *App) emit(ev HostEvent) {
+	a.emitMu.Lock()
+	defer a.emitMu.Unlock()
 	for _, o := range a.observers {
 		o.On(ev)
 	}

--- a/agent/host/app_test.go
+++ b/agent/host/app_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/panyam/mcpkit/agent"
 	"github.com/panyam/mcpkit/client"
@@ -63,6 +64,28 @@ func TestAppBootsWithDownOptionalServer(t *testing.T) {
 	}
 	if len(res.Servers) != 2 {
 		t.Fatalf("/servers = %d entries, want 2", len(res.Servers))
+	}
+}
+
+// TestAppCloseDoesNotHang is the host-level regression for the close hang: with
+// a ready server (open SSE stream) AND a down server (a background retry loop),
+// app.Close must tear both down promptly, not block. A generous deadline turns
+// a hang into a fast, clear failure instead of a whole-suite timeout.
+func TestAppCloseDoesNotHang(t *testing.T) {
+	ts := startTestServer(t)
+	cfg := testConfig(ts.URL)
+	cfg.Servers = append(cfg.Servers, ServerConfig{ID: "down", URL: "http://127.0.0.1:1/mcp"})
+
+	app, err := NewApp(cfg, io.Discard, strings.NewReader(""), WithProvider(agent.NewStubProvider(agent.StubTurn{Text: "hi"})))
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan struct{})
+	go func() { app.Close(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+		t.Fatal("app.Close hung")
 	}
 }
 

--- a/agent/host/app_test.go
+++ b/agent/host/app_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/panyam/mcpkit/agent"
+	"github.com/panyam/mcpkit/client"
 	"github.com/panyam/mcpkit/core"
 	skills "github.com/panyam/mcpkit/ext/skills"
 	"github.com/panyam/mcpkit/server"
@@ -32,6 +33,54 @@ func testConfig(url string) *Config {
 	return &Config{
 		Model:   ModelConfig{BaseURL: "http://unused", Model: "stub"},
 		Servers: []ServerConfig{{ID: "test", URL: url + "/mcp"}},
+	}
+}
+
+// TestAppBootsWithDownOptionalServer is the graceful-degrade acceptance: a down
+// optional server must not fail boot; the reachable server is ready, the down
+// one is not, and /servers lists both (docs/AGENT_SERVER_STATE.md).
+func TestAppBootsWithDownOptionalServer(t *testing.T) {
+	ts := startTestServer(t)
+	cfg := testConfig(ts.URL)
+	cfg.Servers = append(cfg.Servers, ServerConfig{ID: "down", URL: "http://127.0.0.1:1/mcp"})
+
+	var out strings.Builder
+	app, err := NewApp(cfg, &out, strings.NewReader(""), WithProvider(agent.NewStubProvider(agent.StubTurn{Text: "hi"})))
+	if err != nil {
+		t.Fatalf("boot must not fail on a down optional server: %v", err)
+	}
+	defer app.Close()
+
+	if s, _ := app.group.State("test"); s != client.StateReady {
+		t.Fatalf("reachable server state = %v, want ready", s)
+	}
+	if s, _ := app.group.State("down"); s == client.StateReady {
+		t.Fatalf("down server should not be ready, got %v", s)
+	}
+	res, err := app.Dispatch(context.Background(), "/servers")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Servers) != 2 {
+		t.Fatalf("/servers = %d entries, want 2", len(res.Servers))
+	}
+}
+
+// TestAppRequiredServerReadyAfterBoot verifies a required server is connected by
+// the time NewApp returns (WaitRequired blocked for it).
+func TestAppRequiredServerReadyAfterBoot(t *testing.T) {
+	ts := startTestServer(t)
+	cfg := testConfig(ts.URL)
+	cfg.Servers[0].Required = true
+
+	var out strings.Builder
+	app, err := NewApp(cfg, &out, strings.NewReader(""), WithProvider(agent.NewStubProvider(agent.StubTurn{Text: "hi"})))
+	if err != nil {
+		t.Fatalf("boot with a reachable required server: %v", err)
+	}
+	defer app.Close()
+	if s, _ := app.group.State("test"); s != client.StateReady {
+		t.Fatalf("required server must be ready after boot, got %v", s)
 	}
 }
 

--- a/agent/host/auth_test.go
+++ b/agent/host/auth_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/panyam/mcpkit/agent"
+	"github.com/panyam/mcpkit/client"
 	"github.com/panyam/mcpkit/server"
 	"github.com/panyam/mcpkit/testutil"
 )
@@ -72,9 +73,18 @@ func TestBearerAuthReachesTheWire(t *testing.T) {
 	}
 	app.Close()
 
+	// Without the bearer, the guarded server rejects the connection. Under
+	// graceful degradation (docs/AGENT_SERVER_STATE.md) this no longer fails
+	// boot — the agent starts and the server surfaces as not-ready (401 ->
+	// needs-login), which is how we know the un-bearered request was refused.
 	cfg.Servers[0].Auth = nil
-	if _, err := NewApp(cfg, &out, strings.NewReader(""), WithProvider(agent.NewStubProvider())); err == nil {
-		t.Fatal("connect without bearer must fail against the guarded server")
+	app2, err := NewApp(cfg, &out, strings.NewReader(""), WithProvider(agent.NewStubProvider()))
+	if err != nil {
+		t.Fatalf("without bearer, boot should still succeed gracefully: %v", err)
+	}
+	defer app2.Close()
+	if s, _ := app2.group.State(cfg.Servers[0].ID); s == client.StateReady {
+		t.Fatalf("un-bearered connection to the guarded server must not be ready, got %v", s)
 	}
 }
 

--- a/agent/host/commands.go
+++ b/agent/host/commands.go
@@ -50,6 +50,8 @@ const (
 	CmdTasks CmdKind = "tasks"
 	// CmdApproval reports the approval policy (Approval; nil = gate off).
 	CmdApproval CmdKind = "approval"
+	// CmdServers lists the MCP servers and their connection state (Servers).
+	CmdServers CmdKind = "servers"
 	// CmdQuit signals the loop to exit (Quit true).
 	CmdQuit CmdKind = "quit"
 )
@@ -74,6 +76,7 @@ type CmdResult struct {
 	Approval       *agent.TieredApproval
 	Sessions       []agent.RunInfo
 	SessionsNote   string
+	Servers        []client.MemberStatus
 	Quit           bool
 }
 
@@ -231,6 +234,15 @@ func (a *App) registerBuiltinCommands() {
 				})
 			}
 			return CmdResult{Kind: CmdApproval, Approval: a.approval}, nil
+		}})
+
+	r.Register(&Command{Name: "servers", Help: "list MCP servers and their connection state",
+		Run: func(context.Context, string) (CmdResult, error) {
+			var st []client.MemberStatus
+			if a.group != nil {
+				st = a.group.Status()
+			}
+			return CmdResult{Kind: CmdServers, Servers: st}, nil
 		}})
 
 	r.Register(&Command{Name: "session", Help: "show the active session id",

--- a/agent/host/config.go
+++ b/agent/host/config.go
@@ -348,6 +348,14 @@ type ServerConfig struct {
 	// (a FilterSource capability boundary, not a display preference).
 	Allow []string `json:"allow,omitempty"`
 
+	// Required makes boot block until this server is connected: NewApp waits
+	// for it (up to the required-timeout) instead of returning while it is
+	// still connecting. Use it for a server the agent is useless without.
+	// Non-required servers (the default) connect in the background and never
+	// block boot — the agent is usable immediately and their tools wire in as
+	// they become ready. See docs/AGENT_SERVER_STATE.md.
+	Required bool `json:"required,omitempty"`
+
 	// Skills controls SEP-2640 skill loading for this server. Nil or true
 	// auto-detects (servers without the capability are skipped silently);
 	// false opts out even when the server advertises skills.

--- a/agent/host/events.go
+++ b/agent/host/events.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/panyam/mcpkit/agent"
+	"github.com/panyam/mcpkit/client"
 	"github.com/panyam/mcpkit/core"
 	"github.com/panyam/mcpkit/experimental/ext/events"
 )
@@ -21,6 +22,13 @@ import (
 // sibling's.
 func (a *App) startEventStreams(ctx context.Context) error {
 	for _, sc := range a.cfg.Servers {
+		// Boot snapshot: only subscribe servers ready by now. A server that
+		// connects later gets its tools (via the Group observer) but not its
+		// event streams until a restart — late-event wiring is the follow-up
+		// (docs/AGENT_SERVER_STATE.md phase 2).
+		if s, ok := a.group.State(sc.ID); !ok || s != client.StateReady {
+			continue
+		}
 		for _, ec := range sc.Events {
 			if _, err := a.openSubscription(ctx, sc.ID, ec.Name); err != nil {
 				return fmt.Errorf("agentchat: events/stream %s on %s: %w", ec.Name, sc.ID, err)

--- a/agent/host/hostevent.go
+++ b/agent/host/hostevent.go
@@ -51,6 +51,10 @@ const (
 	// (SubAgent) — a persona's activity, scoped/depth on the envelope, for a
 	// surface to render indented under the parent's turn.
 	HostSubAgentEvent HostEventKind = "sub-agent-event"
+	// HostServerStateChanged reports an MCP server's connection state changing
+	// (ServerID, ServerState; Err on failed/needs-login) — the async
+	// graceful-degrade surface (see docs/AGENT_SERVER_STATE.md).
+	HostServerStateChanged HostEventKind = "server-state-changed"
 )
 
 // HostEvent is one domain event the host announces: a thing that
@@ -83,11 +87,12 @@ type HostEvent struct {
 	Label       string
 	Message     string
 
-	ServerID  string
-	URI       string
-	EventName string
-	Loaded    int
-	Skipped   int
+	ServerID    string
+	ServerState string // ConnState on HostServerStateChanged
+	URI         string
+	EventName   string
+	Loaded      int
+	Skipped     int
 
 	TaskStatus *core.DetailedTask
 	Task       *client.BackgroundTask

--- a/agent/host/render.go
+++ b/agent/host/render.go
@@ -84,6 +84,33 @@ func (r *renderer) approvalMode(p *agent.TieredApproval) {
 	fmt.Fprintf(r.out, "%s\n", r.dim("approval: "+approvalModeName(p.DefaultMode())))
 }
 
+// serverList renders /servers: each MCP server and its connection state.
+func (r *renderer) serverList(servers []client.MemberStatus) {
+	if len(servers) == 0 {
+		fmt.Fprintf(r.out, "%s\n", r.dim("servers: none configured"))
+		return
+	}
+	for _, s := range servers {
+		line := fmt.Sprintf("  %-14s %s", s.ID, s.State)
+		if s.Required {
+			line += " (required)"
+		}
+		if s.Err != nil {
+			line += ": " + s.Err.Error()
+		}
+		fmt.Fprintf(r.out, "%s\n", r.dim(line))
+	}
+}
+
+// serverState renders one HostServerStateChanged transition.
+func (r *renderer) serverState(id, state, errMsg string) {
+	line := "server " + id + ": " + state
+	if errMsg != "" {
+		line += " (" + errMsg + ")"
+	}
+	fmt.Fprintf(r.out, "%s\n", r.dim(line))
+}
+
 func (r *renderer) breakLine() {
 	if r.midText {
 		fmt.Fprintln(r.out)
@@ -289,6 +316,8 @@ func (r *renderer) command(res CmdResult) {
 		r.taskList(res.Tasks)
 	case CmdApproval:
 		r.approvalMode(res.Approval)
+	case CmdServers:
+		r.serverList(res.Servers)
 	case CmdQuit:
 		// nothing to render; the loop exits
 	}
@@ -328,6 +357,8 @@ func (r *renderer) On(ev HostEvent) {
 		r.taskCompleted(ev.Task)
 	case HostMessage:
 		fmt.Fprintf(r.out, "%s\n", r.dim(ev.Message))
+	case HostServerStateChanged:
+		r.serverState(ev.ServerID, ev.ServerState, ev.Err)
 	case HostSubAgentEvent:
 		r.subAgent(ev.SubAgent)
 	}

--- a/client/group.go
+++ b/client/group.go
@@ -83,9 +83,19 @@ type groupMember struct {
 	required bool
 
 	// guarded by Group.mu
-	state ConnState
-	err   error
-	ready chan struct{} // closed once, on first StateReady (for WaitRequired)
+	state   ConnState
+	err     error
+	ready   chan struct{} // closed once, on first StateReady (for WaitRequired)
+	settled chan struct{} // closed once, when the first connect attempt completes (for WaitSettled)
+}
+
+// closeOnce closes ch if it is not already closed. The caller holds Group.mu.
+func closeOnce(ch chan struct{}) {
+	select {
+	case <-ch:
+	default:
+		close(ch)
+	}
 }
 
 // Group manages the connection lifecycle of N clients: it connects them
@@ -103,10 +113,11 @@ type Group struct {
 	members map[string]*groupMember
 	order   []string
 
-	reqTimeout time.Duration
-	minBackoff time.Duration
-	maxBackoff time.Duration
-	observer   func(StateChange)
+	reqTimeout    time.Duration
+	settleTimeout time.Duration
+	minBackoff    time.Duration
+	maxBackoff    time.Duration
+	observer      func(StateChange)
 
 	started bool
 	ctx     context.Context
@@ -130,6 +141,15 @@ func WithGroupBackoff(min, max time.Duration) GroupOption {
 	return func(g *Group) { g.minBackoff, g.maxBackoff = min, max }
 }
 
+// WithSettleTimeout caps how long WaitSettled waits for the initial connect
+// round. Default 10s; 0 waits indefinitely. Reachable servers settle in well
+// under this (a ready connect or a fast refusal); only a server that accepts
+// the socket but never completes the handshake hits the cap, and then it just
+// wires in late instead of blocking boot.
+func WithSettleTimeout(d time.Duration) GroupOption {
+	return func(g *Group) { g.settleTimeout = d }
+}
+
 // WithObserver registers a callback invoked on every member state transition.
 // It is called from the member's own goroutine, so it may be invoked
 // concurrently for different members and must be safe for concurrent use; keep
@@ -141,10 +161,11 @@ func WithObserver(fn func(StateChange)) GroupOption {
 // NewGroup builds a Group. Add members, then Start.
 func NewGroup(opts ...GroupOption) *Group {
 	g := &Group{
-		members:    map[string]*groupMember{},
-		reqTimeout: 30 * time.Second,
-		minBackoff: 500 * time.Millisecond,
-		maxBackoff: 30 * time.Second,
+		members:       map[string]*groupMember{},
+		reqTimeout:    30 * time.Second,
+		settleTimeout: 10 * time.Second,
+		minBackoff:    500 * time.Millisecond,
+		maxBackoff:    30 * time.Second,
 	}
 	for _, o := range opts {
 		o(g)
@@ -160,7 +181,7 @@ func (g *Group) Add(id string, c *Client, required bool) {
 	if _, ok := g.members[id]; ok {
 		return
 	}
-	g.members[id] = &groupMember{id: id, client: c, required: required, state: StateDisabled, ready: make(chan struct{})}
+	g.members[id] = &groupMember{id: id, client: c, required: required, state: StateDisabled, ready: make(chan struct{}), settled: make(chan struct{})}
 	g.order = append(g.order, id)
 }
 
@@ -200,6 +221,15 @@ func (g *Group) run(m *groupMember) {
 		}
 		g.set(m, StateConnecting, nil)
 		err := m.client.Connect()
+		// If the group is closing, a Connect that just succeeded left an open
+		// connection that Close's earlier client.Close could not see (it raced
+		// this in-flight Connect). Close it here so it doesn't leak past Close.
+		if g.ctx.Err() != nil {
+			if err == nil {
+				m.client.Close()
+			}
+			return
+		}
 		if err == nil {
 			g.set(m, StateReady, nil)
 			return
@@ -226,18 +256,23 @@ func (g *Group) run(m *groupMember) {
 func (g *Group) set(m *groupMember, s ConnState, err error) {
 	g.mu.Lock()
 	m.state, m.err = s, err
-	if s == StateReady {
-		select {
-		case <-m.ready: // already closed
-		default:
-			close(m.ready)
-		}
-	}
 	obs := g.observer
 	g.mu.Unlock()
+
+	// Fire the observer first (it registers a ready server's capabilities),
+	// THEN signal ready/settled — so a WaitRequired / WaitSettled caller
+	// observes the server as usable (tools registered), not merely connected.
 	if obs != nil {
 		obs(StateChange{ID: m.id, State: s, Err: err})
 	}
+	g.mu.Lock()
+	if s == StateReady {
+		closeOnce(m.ready)
+	}
+	if s != StateConnecting { // first non-connecting state = first attempt done
+		closeOnce(m.settled)
+	}
+	g.mu.Unlock()
 }
 
 // WaitRequired blocks until every required member has reached ready, the
@@ -268,6 +303,40 @@ func (g *Group) WaitRequired(ctx context.Context) error {
 			return ctx.Err()
 		case <-deadline:
 			return fmt.Errorf("client: required servers not ready within %s: %s", timeout, g.notReadyRequired())
+		}
+	}
+	return nil
+}
+
+// WaitSettled blocks until every member's first connect attempt has completed
+// (reached ready, failed, or needs-login), the context is cancelled, or the
+// settle-timeout elapses. Unlike WaitRequired, a timeout is NOT an error: it
+// just means some server is still on its first attempt, and it will register
+// via the observer when it finishes. This is the bounded initial-connect round
+// a caller waits for so reachable servers are ready-and-registered at boot
+// while a down server (fast failure) does not block.
+func (g *Group) WaitSettled(ctx context.Context) error {
+	g.mu.Lock()
+	members := make([]*groupMember, 0, len(g.order))
+	for _, id := range g.order {
+		members = append(members, g.members[id])
+	}
+	timeout := g.settleTimeout
+	g.mu.Unlock()
+
+	var deadline <-chan time.Time
+	if timeout > 0 {
+		t := time.NewTimer(timeout)
+		defer t.Stop()
+		deadline = t.C
+	}
+	for _, m := range members {
+		select {
+		case <-m.settled:
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline:
+			return nil
 		}
 	}
 	return nil

--- a/client/group_test.go
+++ b/client/group_test.go
@@ -121,6 +121,54 @@ func TestGroup_ObserverSeesTransitions(t *testing.T) {
 	}
 }
 
+// TestGroup_CloseReleasesConnections is the regression for the hang where a
+// ready member's connection (its GET SSE stream) leaked past Close, blocking
+// httptest.Server.Close forever. The server is closed explicitly (not via
+// Cleanup) so a leak shows up as a blocked Close, not a silent goroutine leak.
+func TestGroup_CloseReleasesConnections(t *testing.T) {
+	// NOT t.Cleanup: we close it ourselves to time it.
+	ts := httptest.NewServer(testutil.NewTestServer().Handler(server.WithStreamableHTTP(true)))
+	g := client.NewGroup(client.WithRequiredTimeout(5 * time.Second))
+	g.Add("a", client.NewClient(ts.URL+"/mcp", ci), true)
+	g.Start(context.Background())
+	if err := g.WaitRequired(context.Background()); err != nil { // ensure ready (SSE open)
+		t.Fatalf("WaitRequired: %v", err)
+	}
+	g.Close()
+
+	done := make(chan struct{})
+	go func() { ts.Close(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("httptest.Server.Close blocked — Group.Close leaked a connection")
+	}
+}
+
+// TestGroup_CloseRacingConnect is start/close churn coverage: closing
+// immediately after Start (looped) exercises the path where Connect and Close
+// overlap. Each iteration's server must close without blocking. The narrow
+// in-flight window makes it a stress check, not a deterministic reproduction —
+// the reliable regression for the leak is TestGroup_CloseReleasesConnections
+// and, at the host level, TestAppCloseDoesNotHang.
+func TestGroup_CloseRacingConnect(t *testing.T) {
+	for i := 0; i < 30; i++ {
+		ts := httptest.NewServer(testutil.NewTestServer().Handler(server.WithStreamableHTTP(true)))
+		g := client.NewGroup(client.WithGroupBackoff(time.Millisecond, 5*time.Millisecond))
+		g.Add("a", client.NewClient(ts.URL+"/mcp", ci), false)
+		g.Start(context.Background())
+		g.Close() // races the in-flight Connect
+
+		done := make(chan struct{})
+		go func() { ts.Close(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("iteration %d: httptest.Server.Close blocked — Connect raced Close and leaked", i)
+		}
+	}
+}
+
 // TestGroup_CloseIdempotent verifies Close stops the retry loops (no goroutine
 // leak / hang) even with a member that is still retrying, and is safe twice.
 func TestGroup_CloseIdempotent(t *testing.T) {


### PR DESCRIPTION
## What changes

The agent no longer fail-fasts when a server is down. `NewApp` boots regardless, surfaces each server's state (`ready`/`failed`/`needs-login`), and wires a server's tools in the moment it connects — matching how real MCP clients (Claude Code, Cursor) behave. Phase 1 of the async graceful-degrade work (root `CONSTRAINTS.md` C6, design in `docs/AGENT_SERVER_STATE.md`). Builds on `client.Group` (#1087). **Option 2 (late skills/events wiring) stacks on this.**

## Reviewer's guide
1. [agent/host/app.go](https://github.com/panyam/mcpkit/pull/1088/files#diff-89fb8e04b6e1e9d5f7f76958490ef158dee40e2cae92d87c04b408d893c84361) — start here. `NewApp` replaces the synchronous fail-fast connect loop with `Group.Add` → `Start` → `WaitRequired` → `WaitSettled`; `registerServerTools` (the ready-observer that adds a server's tools); the `emit` serialization + nil-`out` guard; `Close` via the Group.
2. [agent/host/app_test.go](https://github.com/panyam/mcpkit/pull/1088/files#diff-adb435e0bb9377caf15474e795e422de5222a62d0f4f1af8af093bdf1d6bb6ce) — acceptance: `TestAppBootsWithDownOptionalServer` (down optional doesn't fail boot; `/servers` lists both) and `TestAppRequiredServerReadyAfterBoot`.
3. [client/group.go](https://github.com/panyam/mcpkit/pull/1088/files#diff-2823e25c587857631e2e1db1892c124e3a178790c0f345bfd2156a9f9f80019e) — `WaitSettled` + settle-timeout, the close-race guard (a `Connect` that completes during `Close` closes its own client so the SSE stream can't leak), and the `set` reorder (signal ready/settled **after** the observer registers tools).
4. `agent/host/{config,hostevent,commands,render,events}.go` — `ServerConfig.Required`, `HostServerStateChanged`, `/servers`, the renderers, and the `startEventStreams` ready-gate.
5. [agent/host/auth_test.go](https://github.com/panyam/mcpkit/pull/1088/files#diff-5768b2ed6e9ca219bbebdd5ac0a511a91c781da87e163768fe007f0332f8a756) — the one behavior-change assertion (a rejected connection no longer fails boot).

## How it works
```
NewApp:
  build clients, group.Add(id, client, required)
  group.Start(bg)                    # connect all concurrently
  group.WaitRequired(bg)             # block only for required servers (30s / 0=forever)
  group.WaitSettled(bg)              # bounded initial round (10s cap): reachable servers
                                     #   ready+registered; a down one already failed fast
  skills/events = snapshot of servers ready by now
observer (per server, on StateReady):
  registerServerTools(...)           # tools wire in — late servers too, no restart
```
The Runner reads the tool `MultiSource` live, so a server that connects after boot adds its tools for the next turn with no restart. Skills (eager into the static system prompt) and events (need the `fanIn` infra built late in `NewApp`) stay a boot snapshot here; making them late-seamless is the stacked Option-2 PR.

## Decision log
- **Boot waits for a bounded initial round (`WaitSettled`, 10s cap), not "return instantly."** Reachable servers settle in well under a second (a ready connect or a fast refusal), so the agent is usable immediately in practice, while tools are actually ready at the first turn. Only a server that accepts the socket but hangs the handshake hits the cap — and then it wires in late rather than blocking. This also keeps the existing "server ready after NewApp" test contract.
- **`required` blocks boot; everything else is background.** `WaitRequired` (30s default, `0` = wait forever) is the "hang until `atlassian` is up" lever.
- **Tools late via the observer; skills + events boot-snapshot.** Tools are the low-risk late-seamless win (the `MultiSource` is concurrency-safe and read live). Skills/events depend on the static system prompt and the late-built event infra, so they land in Option 2 with the dynamic-prompt work.
- **`emit` serialized + nil-`out` → `io.Discard`.** Concurrent server-connect events (parallel connects) would race the terminal renderer's single writer; the renderer now fires during construction, so a nil writer would panic.
- **Rejected connection = graceful not-ready, not a boot failure** (the deliberate contract change).

## Risk / blast radius
- The agent bootstrap path — heavily tested. Full `agent/host`, `client`, `cmd/agentchat`, and both agent examples pass; `agent/host` and `client` verified `-race` clean (the observer/`emit` concurrency was the risk area, and the close-race guard fixes a real hang where `httptest.Server.Close` blocked on a leaked SSE stream).
- No new dependencies; no sub-module tidy.

## Before / after
```
# before: one down server aborts the whole agent
$ agentchat --config with-a-down-server.json
agentchat: connect atlassian (...): dial tcp: connection refused   # exit 1

# after: boots; /servers shows state; the down one retries in the background
$ agentchat --config with-a-down-server.json
> /servers
  demo           ready
  atlassian      failed: dial tcp ... connection refused
```

## Out of scope (stacked / later)
- **Option 2 (stacked on this):** catalog skills + events wire in late; `RunnerConfig.InstructionsFunc` dynamic system prompt for late eager skills; drop→deregister; `ErrNotAvailableNow` for a call to a non-ready server.
- Phase 3: interactive re-auth (`needs-login` → `/login`).
- A configurable required/settle timeout surface (flags/config) — defaults only here.
