### PR TITLE
feat(agent/host): skills wire in late — dynamic prompt + live load_skill catalog

### DIFF
--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -38,6 +38,20 @@ type App struct {
 	group       *client.Group
 	serverTools *agent.MultiSource
 
+	// tp is the tracer provider, held so the ready-observer can load a late
+	// server's skills with the same instrumentation as the boot path.
+	tp core.TracerProvider
+
+	// Skills load in the ready-observer (late servers too), so their prompt
+	// blocks and load_skill catalog are shared mutable state read live: the
+	// dynamic system prompt (buildInstructions -> RunnerConfig.InstructionsFunc)
+	// and the load_skill tool. serverOrder keeps assembly deterministic.
+	skillsMu     sync.Mutex
+	skillBlocks  map[string]string        // serverID -> system-prompt block (eager bodies or catalog listing)
+	skillCatalog map[string][]catalogSkill // serverID -> catalog entries for load_skill
+	serverOrder  []string
+	loadSkillReg bool // load_skill registered once, lazily, on the first catalog skill
+
 	injection *agent.EventInjectionPolicy
 	triggers  *agent.TriggerPolicy
 	approval  *agent.TieredApproval
@@ -216,7 +230,11 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 	coord := agent.NewElicitationCoordinator(elicUI)
 
 	multi := agent.NewMultiSource()
-	app := &App{cfg: cfg, sources: multi, observers: observers, replOut: out, bgTasks: map[string]*client.BackgroundTask{}, subs: map[string]*subscription{}, store: o.store}
+	app := &App{cfg: cfg, sources: multi, observers: observers, replOut: out, bgTasks: map[string]*client.BackgroundTask{}, subs: map[string]*subscription{}, store: o.store,
+		tp: o.tp, skillBlocks: map[string]string{}, skillCatalog: map[string][]catalogSkill{}}
+	for _, sc := range cfg.Servers {
+		app.serverOrder = append(app.serverOrder, sc.ID)
+	}
 	if o.configPath != "" {
 		app.overlay = &configOverlay{path: overlayPathFor(o.configPath)}
 	}
@@ -246,6 +264,7 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 		app.emit(HostEvent{Kind: HostServerStateChanged, ServerID: ch.ID, ServerState: ch.State.String(), Err: errString(ch.Err)})
 		if ch.State == client.StateReady {
 			app.registerServerTools(serverByID[ch.ID], clientByID[ch.ID])
+			app.onServerSkills(serverByID[ch.ID], clientByID[ch.ID])
 		}
 	}
 	app.group = client.NewGroup(client.WithObserver(onState))
@@ -279,40 +298,13 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 		return nil, fmt.Errorf("agentchat: %w", err)
 	}
 	// Wait for the initial connect round to settle (bounded) so reachable
-	// servers are ready and their tools/skills registered before the first
+	// servers are ready and their tools + skills registered before the first
 	// turn; a down server fails fast and does not block, and a slow one wires
-	// in later via the observer.
+	// in later via the observer. Skills (eager blocks + the load_skill catalog)
+	// are loaded in the ready-observer (onServerSkills) into shared state that
+	// the dynamic system prompt (buildInstructions) and load_skill read live, so
+	// a server that connects after boot contributes its skills on the next turn.
 	_ = app.group.WaitSettled(context.Background())
-
-	// Skills are a boot snapshot: only servers ready by now contribute their
-	// eager blocks / catalog. A server that connects later gets its tools (via
-	// the observer) but not its skills until a restart — late-skill wiring is
-	// the follow-up (docs/AGENT_SERVER_STATE.md phase 2).
-	instructions := cfg.Instructions
-	var skillCatalog []catalogSkill
-	for i, sc := range cfg.Servers {
-		if sc.Skills != nil && !*sc.Skills {
-			continue
-		}
-		if s, _ := app.group.State(sc.ID); s != client.StateReady {
-			continue
-		}
-		block, cat, err := loadSkillsForServer(app.clients[i], sc.ID, sc.SkillsMode, sc.SkillsAllow, app.emit, o.tp)
-		if err != nil {
-			app.Close()
-			return nil, err
-		}
-		if block != "" {
-			instructions += "\n\n" + block
-		}
-		skillCatalog = append(skillCatalog, cat...)
-	}
-	if len(skillCatalog) > 0 {
-		if err := app.registerLoadSkill(multi, skillCatalog); err != nil {
-			app.Close()
-			return nil, err
-		}
-	}
 
 	provider := o.provider
 	if provider == nil && cfg.Connections != nil {
@@ -418,11 +410,14 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 	}
 
 	runnerCfg := agent.RunnerConfig{
-		Provider:       provider,
-		Tools:          runnerTools,
-		Instructions:   instructions,
-		MaxSteps:       cfg.MaxSteps,
-		TracerProvider: o.tp,
+		Provider: provider,
+		Tools:    runnerTools,
+		// Dynamic system prompt: cfg.Instructions plus the eager/catalog blocks
+		// of the currently-connected servers, recomputed each turn so a
+		// late-connecting server's skills appear without a restart.
+		InstructionsFunc: app.buildInstructions,
+		MaxSteps:         cfg.MaxSteps,
+		TracerProvider:   o.tp,
 	}
 	// Only set Approval when a policy exists: a nil *TieredApproval boxed in
 	// the interface would read as non-nil and gate every call to a deny.

--- a/agent/host/skills.go
+++ b/agent/host/skills.go
@@ -131,13 +131,15 @@ type loadSkillArgs struct {
 // (laziness never bypasses digest verification; the activation hook fires so
 // hosts learn which skills earn their tokens). An unknown name is an app-state
 // result, not an error, so the model can recover.
-func (a *App) registerLoadSkill(multi *agent.MultiSource, catalog []catalogSkill) error {
+func (a *App) registerLoadSkill(multi *agent.MultiSource) error {
 	fs := agent.NewFuncSource()
 	err := agent.AddFunc(fs, "load_skill",
 		"Read the full instructions for a named skill (from the skills catalog) before using it.",
 		func(ctx context.Context, in loadSkillArgs) (string, error) {
 			name := strings.TrimSpace(in.Name)
-			for _, cs := range catalog {
+			// Read the catalog live: catalog servers can connect after boot, so
+			// the set grows as they become ready.
+			for _, cs := range a.allCatalogSkills() {
 				if cs.entry.Name == name || cs.entry.URL == name {
 					res, err := cs.client.ReadAndVerify(ctx, cs.entry.URL, cs.entry.Digest)
 					if err != nil {
@@ -152,4 +154,69 @@ func (a *App) registerLoadSkill(multi *agent.MultiSource, catalog []catalogSkill
 		return err
 	}
 	return multi.Add(skillLoaderSourceID, fs)
+}
+
+// onServerSkills loads a ready server's skills into the shared state the dynamic
+// system prompt and load_skill read live. Called from the connection Group's
+// ready-observer, so a server that connects after boot contributes its skills
+// on the next turn. A load failure degrades to a warning, never a crash.
+func (a *App) onServerSkills(sc ServerConfig, c *client.Client) {
+	if c == nil || (sc.Skills != nil && !*sc.Skills) {
+		return
+	}
+	block, cat, err := loadSkillsForServer(c, sc.ID, sc.SkillsMode, sc.SkillsAllow, a.emit, a.tp)
+	if err != nil {
+		a.emit(HostEvent{Kind: HostSessionWarn, Err: fmt.Sprintf("load skills for %s: %v", sc.ID, err)})
+		return
+	}
+	a.skillsMu.Lock()
+	if block != "" {
+		a.skillBlocks[sc.ID] = block
+	}
+	if len(cat) > 0 {
+		a.skillCatalog[sc.ID] = cat
+	}
+	// Register load_skill lazily, once, on the first catalog skill — so it never
+	// appears when no server offers catalog skills.
+	registerLoader := len(cat) > 0 && !a.loadSkillReg
+	if registerLoader {
+		a.loadSkillReg = true
+	}
+	a.skillsMu.Unlock()
+
+	if registerLoader {
+		if err := a.registerLoadSkill(a.sources); err != nil {
+			a.emit(HostEvent{Kind: HostSessionWarn, Err: fmt.Sprintf("register load_skill: %v", err)})
+		}
+	}
+	// The system prompt (dynamic) and tool list changed; clear any cache.
+	a.sources.Invalidate()
+}
+
+// buildInstructions is the dynamic system prompt: cfg.Instructions followed by
+// the prompt block of every currently-connected server, in config order. Set as
+// RunnerConfig.InstructionsFunc, so it is recomputed each turn and a late
+// server's skills land on the next turn.
+func (a *App) buildInstructions(context.Context) string {
+	a.skillsMu.Lock()
+	defer a.skillsMu.Unlock()
+	s := a.cfg.Instructions
+	for _, id := range a.serverOrder {
+		if block := a.skillBlocks[id]; block != "" {
+			s += "\n\n" + block
+		}
+	}
+	return s
+}
+
+// allCatalogSkills flattens every connected server's catalog entries, in config
+// order, for the load_skill lookup.
+func (a *App) allCatalogSkills() []catalogSkill {
+	a.skillsMu.Lock()
+	defer a.skillsMu.Unlock()
+	var out []catalogSkill
+	for _, id := range a.serverOrder {
+		out = append(out, a.skillCatalog[id]...)
+	}
+	return out
 }

--- a/agent/host/skills_test.go
+++ b/agent/host/skills_test.go
@@ -87,11 +87,55 @@ func TestFilterSkillsAllow(t *testing.T) {
 	}
 }
 
+// TestBuildInstructions covers the dynamic system prompt: base instructions
+// plus each connected server's block, in config order, skipping empties. This
+// is what makes a late server's eager skills appear on the next turn.
+func TestBuildInstructions(t *testing.T) {
+	a := &App{
+		cfg:         &Config{Instructions: "base"},
+		skillBlocks: map[string]string{"s1": "block1", "s2": "block2"},
+		serverOrder: []string{"s1", "s2"},
+	}
+	if got := a.buildInstructions(context.Background()); got != "base\n\nblock1\n\nblock2" {
+		t.Fatalf("got %q", got)
+	}
+	// order follows serverOrder, not map iteration
+	a.serverOrder = []string{"s2", "s1"}
+	if got := a.buildInstructions(context.Background()); got != "base\n\nblock2\n\nblock1" {
+		t.Fatalf("order must follow serverOrder: %q", got)
+	}
+	// a server with no block yet is skipped
+	a.skillBlocks = map[string]string{"s1": "only1"}
+	a.serverOrder = []string{"s1", "s2"}
+	if got := a.buildInstructions(context.Background()); got != "base\n\nonly1" {
+		t.Fatalf("empty block must be skipped: %q", got)
+	}
+}
+
+// TestAllCatalogSkills covers the live load_skill catalog: every connected
+// server's entries flattened in config order.
+func TestAllCatalogSkills(t *testing.T) {
+	a := &App{
+		skillCatalog: map[string][]catalogSkill{
+			"s1": {{serverID: "s1", entry: skills.IndexEntry{Name: "a"}}},
+			"s2": {{serverID: "s2", entry: skills.IndexEntry{Name: "b"}}},
+		},
+		serverOrder: []string{"s1", "s2"},
+	}
+	got := a.allCatalogSkills()
+	if len(got) != 2 || got[0].entry.Name != "a" || got[1].entry.Name != "b" {
+		t.Fatalf("flatten order wrong: %+v", got)
+	}
+}
+
 func TestRegisterLoadSkill(t *testing.T) {
-	app := &App{}
+	app := &App{
+		skillBlocks:  map[string]string{},
+		skillCatalog: map[string][]catalogSkill{"s": {{serverID: "s", entry: skills.IndexEntry{Name: "alpha", URL: "skill://a/SKILL.md"}}}},
+		serverOrder:  []string{"s"},
+	}
 	multi := agent.NewMultiSource()
-	catalog := []catalogSkill{{serverID: "s", entry: skills.IndexEntry{Name: "alpha", URL: "skill://a/SKILL.md"}}}
-	if err := app.registerLoadSkill(multi, catalog); err != nil {
+	if err := app.registerLoadSkill(multi); err != nil {
 		t.Fatal(err)
 	}
 	tools, _ := multi.Tools(context.Background())

--- a/agent/runner.go
+++ b/agent/runner.go
@@ -41,6 +41,13 @@ type RunnerConfig struct {
 	// context — instead of being frozen at construction. Recomputed per turn
 	// (not per step), so the prompt is stable within a turn and a provider
 	// cache only breaks when the value actually changes.
+	//
+	// It is per-Runner: each Runner is built from its own RunnerConfig, so a
+	// sub-agent's Runner has its own InstructionsFunc (or none) — different
+	// runners can produce different prompts. The func captures whatever context
+	// it needs (e.g. the host's set of connected servers, its own tool view) via
+	// closure; the Runner is deliberately NOT passed, which would be circular
+	// (the Runner holds this config). The ctx is for cancellation/deadline only.
 	InstructionsFunc func(context.Context) string
 
 	// MaxSteps caps model calls per turn. Zero means DefaultMaxSteps.

--- a/agent/runner.go
+++ b/agent/runner.go
@@ -34,6 +34,15 @@ type RunnerConfig struct {
 	// Instructions is the system prompt sent on every step.
 	Instructions string
 
+	// InstructionsFunc, when non-nil, is called once at the top of each turn to
+	// compute that turn's system prompt, overriding the static Instructions. It
+	// lets the prompt track dynamic state — the set of currently-connected
+	// servers whose eager skills belong in the prompt, the date, injected
+	// context — instead of being frozen at construction. Recomputed per turn
+	// (not per step), so the prompt is stable within a turn and a provider
+	// cache only breaks when the value actually changes.
+	InstructionsFunc func(context.Context) string
+
 	// MaxSteps caps model calls per turn. Zero means DefaultMaxSteps.
 	MaxSteps int
 
@@ -225,6 +234,13 @@ func (r *Runner) RunTurn(ctx context.Context, req TurnRequest) (*TurnResult, err
 	defer turnSpan.End()
 	emit(Event{Kind: EventTurnBegin})
 
+	// The system prompt is resolved once per turn (dynamic when InstructionsFunc
+	// is set), then reused across this turn's steps.
+	turnInstructions := r.cfg.Instructions
+	if r.cfg.InstructionsFunc != nil {
+		turnInstructions = r.cfg.InstructionsFunc(ctx)
+	}
+
 	msgs := slices.Clone(history)
 	if r.cfg.Compactor != nil {
 		before := len(msgs)
@@ -263,7 +279,7 @@ func (r *Runner) RunTurn(ctx context.Context, req TurnRequest) (*TurnResult, err
 		stepSpan.SetAttribute("agent.tools.offered", fmt.Sprint(len(tools)))
 
 		stream, err := r.cfg.Provider.Stream(stepCtx, ProviderRequest{
-			Instructions: r.cfg.Instructions,
+			Instructions: turnInstructions,
 			Messages:     msgs,
 			Tools:        tools,
 		})
@@ -292,7 +308,7 @@ func (r *Runner) RunTurn(ctx context.Context, req TurnRequest) (*TurnResult, err
 			stepSpan.End()
 			var structured core.RawJSON
 			if r.cfg.ResponseSchema.Len() > 0 {
-				s, err := r.finalizeStructured(ctx, msgs, &usage)
+				s, err := r.finalizeStructured(ctx, turnInstructions, msgs, &usage)
 				if err != nil {
 					return nil, r.failSpan(emit, turnSpan, fmt.Errorf("agent: structured finalize: %w", err))
 				}
@@ -384,11 +400,11 @@ const structuredMaxAttempts = 2
 // aborts (the caller asked for structured output and cannot get it); after the
 // retry budget it returns the last output best-effort so a caller's Bind, not
 // a lost turn, surfaces a still-malformed document.
-func (r *Runner) finalizeStructured(ctx context.Context, msgs []Message, usage *Usage) (core.RawJSON, error) {
+func (r *Runner) finalizeStructured(ctx context.Context, instructions string, msgs []Message, usage *Usage) (core.RawJSON, error) {
 	var last string
 	for attempt := 0; attempt < structuredMaxAttempts; attempt++ {
 		resp, err := r.cfg.Provider.Generate(ctx, ProviderRequest{
-			Instructions:   r.cfg.Instructions,
+			Instructions:   instructions,
 			Messages:       msgs,
 			ResponseSchema: r.cfg.ResponseSchema,
 		})

--- a/agent/runner_test.go
+++ b/agent/runner_test.go
@@ -34,6 +34,38 @@ func newRunner(t *testing.T, p Provider, src ToolSource) *Runner {
 	return r
 }
 
+// TestRunnerInstructionsFuncPerTurn verifies InstructionsFunc overrides the
+// static Instructions and is recomputed each turn (the dynamic system prompt
+// that lets late-connecting servers' eager skills appear on the next turn).
+func TestRunnerInstructionsFuncPerTurn(t *testing.T) {
+	stub := NewStubProvider(StubTurn{Text: "a"}, StubTurn{Text: "b"})
+	turn := 0
+	r, err := NewRunner(RunnerConfig{
+		Provider:     stub,
+		Instructions: "static",
+		InstructionsFunc: func(context.Context) string {
+			turn++
+			return fmt.Sprintf("dynamic-%d", turn)
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.Run(context.Background(), []Message{{Role: RoleUser, Text: "one"}}, nil)
+	r.Run(context.Background(), []Message{{Role: RoleUser, Text: "two"}}, nil)
+
+	reqs := stub.Requests()
+	if len(reqs) != 2 {
+		t.Fatalf("want 2 requests, got %d", len(reqs))
+	}
+	if reqs[0].Instructions != "dynamic-1" {
+		t.Errorf("turn 1 instructions = %q, want dynamic-1 (func overrides static)", reqs[0].Instructions)
+	}
+	if reqs[1].Instructions != "dynamic-2" {
+		t.Errorf("turn 2 instructions = %q, want dynamic-2 (recomputed per turn)", reqs[1].Instructions)
+	}
+}
+
 func TestRunnerSingleStepText(t *testing.T) {
 	stub := NewStubProvider(StubTurn{Deltas: []Delta{
 		{Kind: DeltaText, Text: "Hello "},


### PR DESCRIPTION
> Stacked on #1088 (Option 1). Base is `feat/host-async-servers`, so CI does not run until #1088 merges and this retargets to `main`. Verified locally: `agent`, `agent/host` (`-race`), and `cmd/agentchat` all green.

## What changes

Option 2 of the async server work: a server that connects **after boot** now contributes its skills with no restart. Where #1088 wires a late server's *tools* in via the ready-observer, this does the same for *skills* — both eager (into the system prompt) and catalog (into `load_skill`).

## Reviewer's guide
1. [agent/runner.go](https://github.com/panyam/mcpkit/pull/1089/files#diff-6d787b427ac08cd61669af7e34ff0b747c4264d20b31b21b681a2ec2c826d9f0) — start here. `RunnerConfig.InstructionsFunc`: called once at the top of each turn to compute that turn's system prompt, overriding the static `Instructions`. This is the primitive that lets a late server's eager skills enter an already-running conversation (the baked-once `Instructions` couldn't). Threaded through the step loop + structured-finalize.
2. [agent/host/skills.go](https://github.com/panyam/mcpkit/pull/1089/files#diff-e306a404daf114302a7d1eb19616a1d7d8fbb9ee27b78f1e2b237c0f2384dff7) — `onServerSkills` (loads a ready server's skills into shared state, from the ready-observer), `buildInstructions` (the dynamic prompt), `allCatalogSkills` (the live catalog), and `registerLoadSkill` reading the catalog live + registered lazily-once.
3. [agent/host/app.go](https://github.com/panyam/mcpkit/pull/1089/files#diff-89fb8e04b6e1e9d5f7f76958490ef158dee40e2cae92d87c04b408d893c84361) — the boot-snapshot skills loop is gone; the observer calls `onServerSkills` on ready, and `RunnerConfig.InstructionsFunc = app.buildInstructions`.
4. Tests: [agent/runner_test.go](https://github.com/panyam/mcpkit/pull/1089/files#diff-ffe83771b6f02efdc6a2e9656bb6e78ecd3a3d187223e173d416979cb429ec34) (InstructionsFunc recomputes per turn), [agent/host/skills_test.go](https://github.com/panyam/mcpkit/pull/1089/files#diff-72993d6ca3bd4300a608562572e588505f92ce00df269faec6e13ba2e053a9e7) (`buildInstructions`/`allCatalogSkills` assembly, updated `load_skill`).

## How it works
```
observer, on a server → ready:
  registerServerTools(...)                    # tools (from #1088)
  onServerSkills(...):
    block, catalog = loadSkillsForServer(...)
    skillBlocks[id]  = block                  # eager bodies OR catalog listing
    skillCatalog[id] = catalog                # catalog-mode entries
    register load_skill once (first catalog skill)

each turn:
  InstructionsFunc() = cfg.Instructions + join(skillBlocks in config order)
load_skill(name):
  search allCatalogSkills() live              # grows as catalog servers connect
```

## Decision log
- **Dynamic system prompt over demoting eager skills to injected context** — a dynamic prompt is a generally useful primitive (date, injected context), and keeps eager skills at full system-prompt authority. Recomputed per turn (not per step), so the provider cache only breaks when the connected-server set actually changes.
- **`load_skill` registered lazily, once, on the first catalog skill** — it never appears when no server offers catalog skills, and it survives late catalog servers because it reads `allCatalogSkills()` live rather than closing over a fixed slice.
- **Events stay a boot snapshot** — event subscription needs the `fanIn` infra built late in `NewApp`, so late-event wiring is a separate follow-up (it's not a skills concern).

## Risk / blast radius
- `agent/runner.go` is a core path — the InstructionsFunc change is additive (nil `InstructionsFunc` = today's static behavior exactly) and the full agent suite passes. Host skills wiring verified `-race` clean.

## Before / after
```
# a catalog server that was down at boot comes up mid-session
before: its skills never appear until you restart the agent
after:  next turn, its catalog lines are in the prompt and load_skill can fetch them
```

## Out of scope
- Late **events** (needs the `fanIn` reorder) — follow-up.
- Drop → deregister + `ErrNotAvailableNow` for a call to a non-ready server — follow-up.
- Phase 3 interactive re-auth.
