### PR TITLE
feat(agent/host): events wire in late via the ready-observer

### DIFF
--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -64,6 +64,7 @@ type App struct {
 	metaTools bool
 	turnMu    sync.Mutex
 	emitMu    sync.Mutex // serializes emit so concurrent server-connect events don't race the renderer
+	evCtx     context.Context // subscription lifetime ctx; the ready-observer subscribes late servers on it
 	eventStop context.CancelFunc
 
 	// store and runID are the persistence seam (WithRunStore): runID is
@@ -265,6 +266,7 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 		if ch.State == client.StateReady {
 			app.registerServerTools(serverByID[ch.ID], clientByID[ch.ID])
 			app.onServerSkills(serverByID[ch.ID], clientByID[ch.ID])
+			app.onServerEvents(serverByID[ch.ID])
 		}
 	}
 	app.group = client.NewGroup(client.WithObserver(onState))
@@ -290,6 +292,19 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 		clientByID[sc.ID] = c
 		app.group.Add(sc.ID, c, sc.Required)
 	}
+	// The event infrastructure (fanIn + subscription ctx) must exist before the
+	// servers connect, so the ready-observer can subscribe a server's event
+	// streams the moment it connects — late servers included. The consumer
+	// goroutine starts later, once the Runner exists; streams buffer until then.
+	app.metaTools = cfg.MetaTools || len(cfg.Triggers) > 0
+	for _, sc := range cfg.Servers {
+		app.metaTools = app.metaTools || len(sc.Events) > 0
+	}
+	if app.metaTools {
+		app.evCtx, app.eventStop = context.WithCancel(context.Background())
+		app.fanIn = gocurrent.NewFanIn[agent.IncomingEvent]()
+	}
+
 	app.group.Start(context.Background())
 	// Block only for the servers marked required; the rest keep connecting in
 	// the background and register via the observer as they become ready.
@@ -363,10 +378,6 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 		Logger:   o.logger,
 	})
 
-	app.metaTools = cfg.MetaTools || len(cfg.Triggers) > 0
-	for _, sc := range cfg.Servers {
-		app.metaTools = app.metaTools || len(sc.Events) > 0
-	}
 	if app.metaTools {
 		if err := app.registerMetaTools(multi); err != nil {
 			app.Close()
@@ -440,16 +451,12 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 	app.runner = runner
 	app.registerBuiltinCommands()
 
-	if app.metaTools {
-		evCtx, cancel := context.WithCancel(context.Background())
-		app.eventStop = cancel
-		app.fanIn = gocurrent.NewFanIn[agent.IncomingEvent]()
-		if err := app.startEventStreams(evCtx); err != nil {
-			cancel()
-			app.Close()
-			return nil, err
-		}
-		go app.consumeEvents(evCtx)
+	// The fanIn + subscription ctx were built before the servers connected, and
+	// the ready-observer has been subscribing each server's event streams; now
+	// that the Runner exists, start the consumer that drains them into the
+	// injection/trigger policies.
+	if app.metaTools && app.fanIn != nil {
+		go app.consumeEvents(app.evCtx)
 	}
 	return app, nil
 }

--- a/agent/host/events.go
+++ b/agent/host/events.go
@@ -8,34 +8,28 @@ import (
 	"time"
 
 	"github.com/panyam/mcpkit/agent"
-	"github.com/panyam/mcpkit/client"
 	"github.com/panyam/mcpkit/core"
 	"github.com/panyam/mcpkit/experimental/ext/events"
 )
 
-// startEventStreams opens one events/stream per configured event. Each
-// stream delivers on its own buffered channel (eventsclient.StreamChan, the
-// mechanism half living in the client SDK), gets a per-stream adapter
-// goroutine tagging occurrences with the server id, and merges into one
-// consumer feed via gocurrent's FanIn. Per-stream buffers isolate
-// backpressure: one noisy stream drops its own events (warned), never a
-// sibling's.
-func (a *App) startEventStreams(ctx context.Context) error {
-	for _, sc := range a.cfg.Servers {
-		// Boot snapshot: only subscribe servers ready by now. A server that
-		// connects later gets its tools (via the Group observer) but not its
-		// event streams until a restart — late-event wiring is the follow-up
-		// (docs/AGENT_SERVER_STATE.md phase 2).
-		if s, ok := a.group.State(sc.ID); !ok || s != client.StateReady {
-			continue
-		}
-		for _, ec := range sc.Events {
-			if _, err := a.openSubscription(ctx, sc.ID, ec.Name); err != nil {
-				return fmt.Errorf("agentchat: events/stream %s on %s: %w", ec.Name, sc.ID, err)
-			}
+// onServerEvents opens one events/stream per configured event on a server that
+// just became ready. Each stream delivers on its own buffered channel
+// (eventsclient.StreamChan), gets a per-stream adapter goroutine tagging
+// occurrences with the server id, and merges into one consumer feed via
+// gocurrent's FanIn. Per-stream buffers isolate backpressure: one noisy stream
+// drops its own events (warned), never a sibling's.
+func (a *App) onServerEvents(sc ServerConfig) {
+	if a.fanIn == nil || len(sc.Events) == 0 {
+		return
+	}
+	// Called from the ready-observer, so a server that connects after boot has
+	// its event streams subscribed with no restart. openSubscription is
+	// idempotent (dedup by server:name), and a failure degrades to a warning.
+	for _, ec := range sc.Events {
+		if _, err := a.openSubscription(a.evCtx, sc.ID, ec.Name); err != nil {
+			a.emit(HostEvent{Kind: HostSessionWarn, Err: fmt.Sprintf("events/stream %s on %s: %v", ec.Name, sc.ID, err)})
 		}
 	}
-	return nil
 }
 
 // consumeEvents is the single goroutine that owns the policy pipeline:


### PR DESCRIPTION
> Stacked on #1089 (late skills) → #1088 (Option 1). Retarget down the stack as each merges. Verified locally: full `agent/host` (`-race`) + `cmd/agentchat` green.

## What changes

The last capability that was still a boot snapshot. A server that connects **after boot** now gets its **event streams** subscribed with no restart — completing "tools + skills + events all wire in late."

## Reviewer's guide
1. [agent/host/app.go](https://github.com/panyam/mcpkit/pull/1090/files#diff-89fb8e04b6e1e9d5f7f76958490ef158dee40e2cae92d87c04b408d893c84361) — the event `fanIn` + subscription ctx are now built **before** `Group.Start` (they used to be built late), so the ready-observer can subscribe on `→ready`. The consumer goroutine still starts after the Runner is built (streams buffer until then). The `metaTools` computation moved up with it.
2. [agent/host/events.go](https://github.com/panyam/mcpkit/pull/1090/files#diff-e7ce4393ed239044155c221a65a7d106cfa899090f1da0fcc2be88231a4aa1d1) — `startEventStreams` (boot snapshot gated on ready) → `onServerEvents(sc)`, called from the observer per ready server.

## How it works
```
before Group.Start:  if events/triggers configured -> build fanIn + evCtx
observer, server → ready:  onServerEvents(sc) -> openSubscription(evCtx, id, name)  # idempotent
after the Runner is built:  go consumeEvents(evCtx)   # drains buffered streams into injection/triggers
```
Subscription only needs `fanIn` (not the injection policy or the Runner), and `openSubscription` dedups by `server:name`, so subscribing early — and again from the observer for a late server — is safe. No occurrences are lost: streams buffer until the consumer starts.

## Decision log
- **Build `fanIn` before connect, start the consumer after the Runner.** Subscription and consumption have different dependencies: subscription needs only the fanIn, consumption needs the injection/trigger policies and the Runner (for proactive turns). Splitting them is what lets the observer subscribe a server the instant it connects while proactive turns still can't fire before the Runner exists.
- **No handoff race.** Because subscription moved entirely into the observer (no parallel boot-snapshot path), there's no window where a server is subscribed twice or missed.

## Risk / blast radius
- The event-infra ordering in `NewApp` — the existing events E2E tests (`TestAppEventsInjectionAndTriggerEndToEnd`, `TestControlPlaneSubscribeTriggerAct`, meta-tool subscribe/unsubscribe) pass unchanged through the reordered path, and the suite is `-race` clean.

## Out of scope (remaining follow-up)
- Drop → deregister + `ErrNotAvailableNow` for a call to a non-ready server (needs Group live-drop detection).
- Phase 3 interactive re-auth.
