### PR TITLE
feat(agent): ErrNotAvailableNow — a call to an unreachable server is a non-fatal miss

### DIFF
--- a/agent/events.go
+++ b/agent/events.go
@@ -29,6 +29,14 @@ const (
 	// differently from a failure. Reason carries the model-visible
 	// feedback text.
 	EventToolCancelled EventKind = "tool-cancelled"
+	// EventToolUnavailable marks a call whose backing server was not reachable
+	// (ErrNotAvailableNow): the tool exists but its server is down right now.
+	// Distinct from tool-error (nothing failed on the server; it just isn't
+	// there yet) so a surface can render it as a transient miss and evals keyed
+	// on Error don't count it. Reason carries the model-visible feedback text;
+	// the turn continues so the model can retry, route around it, or tell the
+	// user. See docs/AGENT_SERVER_STATE.md.
+	EventToolUnavailable EventKind = "tool-unavailable"
 	// EventCompaction marks that a Compactor rewrote the turn's history
 	// before the first model call (the head summarized, a recent tail kept
 	// verbatim). Emitted only when compaction actually fired; Compaction

--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -180,6 +180,9 @@ func (a *App) registerServerTools(sc ServerConfig, c *client.Client) {
 		}
 		src = agent.NewFilterSource(src, func(d core.ToolDef) bool { return allowed[d.Name] })
 	}
+	// Outermost: map an unreachable-server transport error on any call to a
+	// non-fatal ErrNotAvailableNow miss (docs/AGENT_SERVER_STATE.md).
+	src = newAvailabilitySource(src, sc.ID)
 	if err := a.sources.Add(sc.ID, src); err != nil {
 		a.emit(HostEvent{Kind: HostSessionWarn, Err: fmt.Sprintf("register tools for %s: %v", sc.ID, err)})
 		return

--- a/agent/host/availability.go
+++ b/agent/host/availability.go
@@ -1,0 +1,48 @@
+package host
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/panyam/mcpkit/agent"
+	"github.com/panyam/mcpkit/client"
+	"github.com/panyam/mcpkit/core"
+)
+
+// availabilitySource wraps a server's ToolSource so that a call which fails
+// because the server is unreachable right now — a transport error the client
+// could not heal by reconnecting — surfaces as agent.ErrNotAvailableNow with a
+// model-friendly message instead of a raw "connection refused". The Runner
+// turns ErrNotAvailableNow into a non-fatal EventToolUnavailable and the turn
+// continues (the model can retry, route around it, or tell the user).
+//
+// Tools() is delegated unchanged: the defs stay listed even while the server is
+// down (keep-the-defs, docs/AGENT_SERVER_STATE.md), so the model is not
+// surprised by a shrinking tool set mid-turn. This is the reactive half of
+// graceful degradation — a proactive health poll (marking a server down before
+// a call hits it) can be added later without changing this.
+type availabilitySource struct {
+	inner    agent.ToolSource
+	serverID string
+}
+
+func newAvailabilitySource(inner agent.ToolSource, serverID string) *availabilitySource {
+	return &availabilitySource{inner: inner, serverID: serverID}
+}
+
+func (s *availabilitySource) Tools(ctx context.Context) ([]core.ToolDef, error) {
+	return s.inner.Tools(ctx)
+}
+
+func (s *availabilitySource) Call(ctx context.Context, name string, args map[string]any) (*core.ToolResult, error) {
+	res, err := s.inner.Call(ctx, name, args)
+	// A transient (network-level) error means the server is unreachable: the
+	// client already tried to reconnect and could not. A tool that ran and
+	// failed reports via ToolResult.IsError (no error here), and a server-side
+	// JSON-RPC / 4xx error is not transient — both fall through unchanged.
+	if err != nil && client.IsTransientError(err) {
+		return nil, fmt.Errorf("%w: tool %q is temporarily unavailable — server %q is not reachable right now (%v); retry, use another approach, or tell the user",
+			agent.ErrNotAvailableNow, name, s.serverID, err)
+	}
+	return res, err
+}

--- a/agent/host/availability_test.go
+++ b/agent/host/availability_test.go
@@ -1,0 +1,49 @@
+package host
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/panyam/mcpkit/agent"
+	"github.com/panyam/mcpkit/core"
+)
+
+type fakeSource struct {
+	result *core.ToolResult
+	err    error
+}
+
+func (f *fakeSource) Tools(context.Context) ([]core.ToolDef, error) { return nil, nil }
+func (f *fakeSource) Call(context.Context, string, map[string]any) (*core.ToolResult, error) {
+	return f.result, f.err
+}
+
+func TestAvailabilitySource(t *testing.T) {
+	// A transient (network) error means the server is unreachable -> map to a
+	// non-fatal ErrNotAvailableNow naming the server.
+	s := newAvailabilitySource(&fakeSource{err: io.EOF}, "atlassian")
+	_, err := s.Call(context.Background(), "create_issue", nil)
+	if !errors.Is(err, agent.ErrNotAvailableNow) {
+		t.Fatalf("transient error should map to ErrNotAvailableNow, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "atlassian") || !strings.Contains(err.Error(), "create_issue") {
+		t.Fatalf("message should name the server and tool: %v", err)
+	}
+
+	// A non-transient error (server said no) passes through unchanged.
+	s = newAvailabilitySource(&fakeSource{err: errors.New("bad request")}, "atlassian")
+	if _, err := s.Call(context.Background(), "x", nil); errors.Is(err, agent.ErrNotAvailableNow) {
+		t.Fatalf("non-transient error must NOT map to ErrNotAvailableNow: %v", err)
+	}
+
+	// A successful call (including a tool-side IsError result) passes through.
+	want := &core.ToolResult{IsError: true}
+	s = newAvailabilitySource(&fakeSource{result: want}, "atlassian")
+	got, err := s.Call(context.Background(), "x", nil)
+	if err != nil || got != want {
+		t.Fatalf("success/IsError result must pass through: got=%v err=%v", got, err)
+	}
+}

--- a/agent/host/render.go
+++ b/agent/host/render.go
@@ -69,6 +69,8 @@ func (r *renderer) handle(e agent.Event) {
 		fmt.Fprintf(r.out, "%s\n", r.dim("  ⃠ "+e.ToolCall.Name+" not permitted: "+snippet(e.Reason, 120)))
 	case agent.EventToolCancelled:
 		fmt.Fprintf(r.out, "%s\n", r.dim("  ◼ "+e.ToolCall.Name+" cancelled: "+snippet(e.Reason, 120)))
+	case agent.EventToolUnavailable:
+		fmt.Fprintf(r.out, "%s\n", r.dim("  ⊘ "+e.ToolCall.Name+" unavailable: "+snippet(e.Reason, 120)))
 	case agent.EventError:
 		r.breakLine()
 	}

--- a/agent/runner.go
+++ b/agent/runner.go
@@ -21,6 +21,15 @@ const DefaultMaxSteps = 8
 // tool calls past the step cap. Check with errors.Is.
 var ErrMaxSteps = errors.New("agent: max steps exceeded")
 
+// ErrNotAvailableNow is returned by a ToolSource.Call when the tool exists but
+// its backing server is unreachable right now (as opposed to the tool failing).
+// The Runner treats it as a NON-FATAL miss: it emits EventToolUnavailable and
+// feeds the wrapped error's message back to the model, and the turn continues.
+// Wrap it with a descriptive message (fmt.Errorf("%w: ...", ErrNotAvailableNow,
+// ...)) so the model learns which server and can retry, route around it, or
+// tell the user. See docs/AGENT_SERVER_STATE.md.
+var ErrNotAvailableNow = errors.New("agent: tool source not available now")
+
 // RunnerConfig assembles a Runner.
 type RunnerConfig struct {
 	// Provider is the LLM. Required.
@@ -581,6 +590,14 @@ func (r *Runner) callTool(ctx context.Context, parent context.Context, step int,
 	}
 	res, err := r.cfg.Tools.Call(ctx, call.Name, args)
 	if err != nil {
+		// A tool whose server is unreachable right now is a non-fatal miss, not
+		// a failure: the model is told and the turn continues (mirrors denial /
+		// cancellation). Reason (not Error) so error-keyed scorers don't count it.
+		if errors.Is(err, ErrNotAvailableNow) && !cancelled() {
+			span.SetAttribute("agent.tool.unavailable", "true")
+			emit(Event{Kind: EventToolUnavailable, Step: step, ToolCall: &call, Reason: err.Error()})
+			return err.Error()
+		}
 		return failed(err)
 	}
 	if cancelled() {

--- a/agent/runner_test.go
+++ b/agent/runner_test.go
@@ -250,6 +250,57 @@ func TestRunnerIsErrorResultIsToolEndNotToolError(t *testing.T) {
 	}
 }
 
+// unavailableSource returns ErrNotAvailableNow from Call — a server that's
+// unreachable right now (distinct from a tool that ran and failed, which
+// reports via IsError, and which FuncSource would convert to a result).
+type unavailableSource struct{}
+
+func (unavailableSource) Tools(context.Context) ([]core.ToolDef, error) {
+	return []core.ToolDef{{Name: "remote"}}, nil
+}
+func (unavailableSource) Call(context.Context, string, map[string]any) (*core.ToolResult, error) {
+	return nil, fmt.Errorf("%w: server atlassian is down", ErrNotAvailableNow)
+}
+
+func TestRunnerToolUnavailableIsNonFatal(t *testing.T) {
+	stub := NewStubProvider(
+		StubTurn{ToolCalls: []ToolCall{{ID: "c1", Name: "remote", Args: core.NewRawJSON(json.RawMessage(`{}`))}}},
+		StubTurn{Text: "noted, I'll try later"},
+	)
+	r, err := NewRunner(RunnerConfig{Provider: stub, Tools: unavailableSource{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	emit, events := collectEvents()
+	res, err := r.Run(context.Background(), nil, emit)
+	if err != nil {
+		t.Fatalf("unavailable tool must not fail the turn: %v", err)
+	}
+	if res.Text != "noted, I'll try later" {
+		t.Fatalf("turn must continue past the unavailable call, got %+v", res)
+	}
+	var sawUnavailable bool
+	for _, e := range *events {
+		if e.Kind == EventToolError {
+			t.Fatalf("unavailable must be tool-unavailable, not tool-error: %+v", e)
+		}
+		if e.Kind == EventToolUnavailable {
+			sawUnavailable = true
+			if e.Error != "" || e.Reason == "" {
+				t.Fatalf("must carry Reason not Error: %+v", e)
+			}
+		}
+	}
+	if !sawUnavailable {
+		t.Fatalf("missing tool-unavailable event: %v", kinds(*events))
+	}
+	// the model sees the miss and can adapt
+	toolMsg := stub.Requests()[1].Messages[1]
+	if toolMsg.Role != RoleTool || !strings.Contains(toolMsg.Text, "server atlassian is down") {
+		t.Fatalf("model must see the unavailable message: %+v", toolMsg)
+	}
+}
+
 func TestRunnerStepCap(t *testing.T) {
 	loop := StubTurn{ToolCalls: []ToolCall{{ID: "c", Name: "spin", Args: core.NewRawJSON(json.RawMessage(`{}`))}}}
 	stub := NewStubProvider(loop, loop, loop)

--- a/cmd/agentchat/notebook.go
+++ b/cmd/agentchat/notebook.go
@@ -149,7 +149,7 @@ func (s *nbObserver) render(ev host.HostEvent) []tea.Msg {
 		s.term.On(ev) // render this event into buf
 
 		switch re.Kind {
-		case agent.EventToolEnd, agent.EventToolError, agent.EventToolDenied, agent.EventToolCancelled:
+		case agent.EventToolEnd, agent.EventToolError, agent.EventToolDenied, agent.EventToolCancelled, agent.EventToolUnavailable:
 			if s.openTools > 0 {
 				s.openTools--
 			}

--- a/docs/AGENT_SERVER_STATE.md
+++ b/docs/AGENT_SERVER_STATE.md
@@ -72,28 +72,34 @@ gracefully.** The tool set does not shrink mid-turn — the model keeps seeing t
 knew about, so it is not surprised. Calls that land while the server is down are handled
 below.
 
-## Tool calls to a non-Ready server
+## Tool calls to a non-Ready server (SHIPPED, reactive)
 
-Because tool defs stay registered, the model can call a tool whose server is not `Ready`.
-Rather than a hard failure or an indefinite block:
+Because tool defs stay registered, the model can call a tool whose server is unreachable.
+The implementation is **reactive**, not a proactive pre-call gate — and deliberately so:
+`client.Client` **auto-reconnects transparently** (`retryWithReconnect`) and exposes no
+disconnect signal, so a live drop is not cleanly observable before a call. A blip heals
+itself; only a persistent failure surfaces, and it surfaces exactly where it matters — when
+a call is actually made.
 
-- **Default — model-visible miss.** The dispatch short-circuits with an **`ErrNotAvailableNow`**
-  sentinel (recognized before the call reaches the disconnected client) and feeds back a
-  **non-fatal** `ToolResult` naming the server and its state — e.g. "tool `create_issue` is
-  unavailable: server `atlassian` is not connected (needs-login); retry, route around it, or
-  tell the user." A distinct **`EventToolUnavailable`** carries `Reason` + state (NOT `Error`,
-  so error-keyed eval scorers don't miscount — the same care taken for `EventToolDenied` /
-  `EventToolCancelled`). The turn continues; the model adapts. This is the same
-  "non-fatal tool outcome → model-visible → continue" family as approval-denial and
-  cancellation.
-- **Narrow exception — bounded wait for `Connecting`.** If the server is mid-connect (the
-  common first-turn boot race, where the model calls a tool before an async server finished
-  connecting), the dispatch does a short **capped** wait for `Ready` before falling through
-  to the miss. Never wait on `Failed` / `NeedsLogin` / `Disabled` — they won't resolve
-  without action, so blocking is pointless.
+- **Model-visible miss.** Each server's source is wrapped by `availabilitySource` (in the
+  host). When a call returns a **transient (network-level) error** — the client tried to
+  reconnect and could not — the wrapper maps it to **`agent.ErrNotAvailableNow`** with a
+  message naming the server and tool ("tool `create_issue` is temporarily unavailable —
+  server `atlassian` is not reachable right now; retry, use another approach, or tell the
+  user"). The Runner recognizes the sentinel, emits a distinct **`EventToolUnavailable`**
+  carrying `Reason` (NOT `Error`, so error-keyed eval scorers don't miscount — the same care
+  as `EventToolDenied` / `EventToolCancelled`), and feeds the message back. The turn
+  continues; the model adapts. Same "non-fatal tool outcome → model-visible → continue"
+  family as approval-denial and cancellation. A tool that *ran* and failed (`IsError` result)
+  or a server-side JSON-RPC / 4xx error is not transient and falls through unchanged.
 
 **Rejected:** blocking the turn indefinitely (queue-and-wait) — it couples turn latency to
 reconnect timing and hangs on servers that may never come up.
+
+**Deferred (not needed yet):** a proactive health poll that marks a server down *before* a
+call hits it (so `/servers` reflects a drop eagerly) and the bounded-wait-for-`Connecting`
+window. These compose additively on top of the reactive path — a `Group` health-poll option
+would feed the same status + retry, and the `availabilitySource` stays as-is.
 
 ## `client.Group` (client-layer primitive)
 
@@ -149,14 +155,16 @@ blocks of currently-`Ready` servers.
 
 ## Phasing
 
-1. **Async connect + state + `/servers` + graceful boot + per-server `required`.**
-   `client.Group` lands here. Eager skills at boot: a `required` eager server blocks boot
-   (baked as today); a non-required eager server that is down is simply absent until phase 2.
-   Flips C6's noted target toward done.
-2. **Seamless late integration.** `RunnerConfig.InstructionsFunc` + host recompute of eager
-   blocks from the Ready-set; reconnect/de-register of tools/catalog-skills/events. A
-   returning server wires in with no restart.
-3. **Interactive re-auth** (`NeedsLogin` → `/login`).
+1. **Async connect + state + `/servers` + graceful boot + per-server `required`.** SHIPPED
+   (`client.Group`). Flips C6's noted target toward done.
+2. **Seamless late integration.** SHIPPED. `RunnerConfig.InstructionsFunc` + host recompute of
+   eager/catalog blocks from the ready-set (skills), ready-observer subscription (events), and
+   the reactive `ErrNotAvailableNow` miss for a call to an unreachable server. A returning
+   server wires its tools/skills/events back in with no restart.
+3. **Interactive re-auth** (`NeedsLogin` → `/login`). Not started.
+
+Deferred (additive, not blocking): a proactive `Group` health poll (eager `/servers`
+drop status + bounded-wait-for-`Connecting`); `SystemPromptBuilder` (issue 1091).
 
 ## Resolved
 


### PR DESCRIPTION
## What changes

The phase-2 remainder of the async server work (`docs/AGENT_SERVER_STATE.md`). When the model calls a tool whose backing server is **unreachable right now**, it now gets a clear, model-visible miss and the turn **continues** — "tool `create_issue` is temporarily unavailable — server `atlassian` is not reachable right now; retry, use another approach, or tell the user" — instead of a raw "connection refused". The model adapts; when the server comes back it re-registers with no restart (from #1088–#1090).

## Reactive, by design
`client.Client` **auto-reconnects transparently** and exposes no disconnect signal, so a live drop isn't cleanly observable *before* a call — a blip heals itself, and only a *persistent* failure surfaces, exactly where it matters: at call time. So this is reactive (catch the transport error) rather than a proactive pre-call gate. This does **not** block adding a proactive health poll later — it composes additively.

## Reviewer's guide
1. [agent/runner.go](https://github.com/panyam/mcpkit/pull/1092/files#diff-6d787b427ac08cd61669af7e34ff0b747c4264d20b31b21b681a2ec2c826d9f0) — start here. `ErrNotAvailableNow` sentinel + the `callTool` branch: on that error, emit `EventToolUnavailable` (carries `Reason`, not `Error`, like `EventToolDenied`) and feed the message back; the turn continues.
2. [agent/host/availability.go](https://github.com/panyam/mcpkit/pull/1092/files#diff-07b8c76f74103ef4506de07c8488547770720b9c3bac7586046b58c2844eb254) — `availabilitySource` wraps each server's source: a **transient (network)** call error → `ErrNotAvailableNow` naming the server + tool. A tool that *ran* and failed (`IsError`) or a server-side 4xx/JSON-RPC error is not transient and falls through unchanged. `Tools()` is delegated (keep-the-defs — no mid-turn shrink).
3. [agent/host/app.go](https://github.com/panyam/mcpkit/pull/1092/files#diff-89fb8e04b6e1e9d5f7f76958490ef158dee40e2cae92d87c04b408d893c84361) — wraps the per-server source (outermost) in `registerServerTools`.
4. Tests: [agent/runner_test.go](https://github.com/panyam/mcpkit/pull/1092/files#diff-ffe83771b6f02efdc6a2e9656bb6e78ecd3a3d187223e173d416979cb429ec34) (unavailable → `EventToolUnavailable`, turn continues, model sees the message), [agent/host/availability_test.go](https://github.com/panyam/mcpkit/pull/1092/files#diff-370c2ef6138d6d36cd9d6d423649e65c217121d7fac456a675e93b48f666d75f) (transient maps, non-transient/IsError pass through).
5. `render.go` / `notebook.go` — render the new event.

## Decision log
- **Reactive over proactive.** The client heals transient drops itself; polling would fight it and add traffic. Detect at call time via the transient-error check (reuses `client.IsTransientError`), which is also why the wrapper lives in the host (agent can't import client).
- **`IsError` results and server-side errors pass through.** Only a network-level failure means "unreachable" — a tool that ran and reported an error, or a 4xx, is a real result/failure, not unavailability.
- **`EventToolUnavailable` carries `Reason`, not `Error`** — so `eval.NoError`-style scorers don't miscount a transient miss as a failure (same care as denial/cancellation).

## Risk / blast radius
- `agent/runner.go` core path — the branch is additive (only triggers on the new sentinel; existing errors still go through `failed`). Full `agent`, `agent/host` (`-race`), `cmd/agentchat` green; vet clean.

## Before / after
```
# a server goes down, the model calls one of its tools
before:  ✗ create_issue failed: Post "...": dial tcp: connection refused
after:   ⊘ create_issue unavailable: tool "create_issue" is temporarily unavailable —
             server "atlassian" is not reachable right now; retry, use another approach, or tell the user
# ...and the turn continues; the model can adapt.
```

## Out of scope (deferred, additive)
- Proactive `Group` health poll (eager `/servers` drop status + bounded-wait-for-`Connecting`).
- Phase 3 interactive re-auth (`needs-login` → `/login`).
- `SystemPromptBuilder` (#1091).
