### PR TITLE
feat(stateless): SEP-2575 final-revision _meta identity alignment (spec PR 3002)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,19 @@ targeted spec version.
   for external `QuotaStore` implementors (experimental surface). (issue 774)
 
 ### Added / Fixed
+- **SEP-2575 final-revision `_meta` identity alignment (spec PR 3002).**
+  `clientInfo` in the per-request `_meta` envelope is now optional on the
+  stateless wire: requests that omit it are served instead of rejected with
+  `-32602` (clients SHOULD still send it, and mcpkit's client does). Servers
+  now stamp `_meta["io.modelcontextprotocol/serverInfo"]` on every stateless
+  success result via new `core.InjectServerInfoIntoResult` (caller-set values
+  win; error responses are not stamped), restoring the server identity the
+  removed `initialize` handshake used to carry. *Wire change:* `serverInfo`
+  moved out of the `server/discover` result body into the result `_meta`;
+  `client.DiscoverResult` reads the `_meta` form first and falls back to the
+  pre-3002 body field, so older draft servers keep working. New
+  `core.MetaKeyServerInfo` and `core.ResultMeta`. Both fields are
+  self-reported and unverified, for display/logging/debugging only.
 - **`core.RawJSON`** — a typed, parse-once wrapper for JSON-RPC raw values
   (params / `_meta` / …) with `Bind` / `Meta` / `Field` helpers; wire-transparent
   (round-trips identically to `json.RawMessage`). This is the read-side type

--- a/client/stateless.go
+++ b/client/stateless.go
@@ -86,6 +86,13 @@ func (c *Client) adaptiveProbe() (result *DiscoverResult, fallback bool, err err
 	if err := json.Unmarshal(resp.Result, &dr); err != nil {
 		return nil, false, fmt.Errorf("server/discover returned malformed result: %w", err)
 	}
+	// Spec PR 3002 moved server identity from the result body to
+	// _meta[io.modelcontextprotocol/serverInfo]. Prefer the _meta form;
+	// the body field remains as a decode fallback for servers built
+	// against the pre-3002 draft shape.
+	if dr.Meta.ServerInfo != nil {
+		dr.ServerInfo = *dr.Meta.ServerInfo
+	}
 	return &dr, false, nil
 }
 
@@ -100,7 +107,16 @@ func (c *Client) adaptiveProbe() (result *DiscoverResult, fallback bool, err err
 type DiscoverResult struct {
 	SupportedVersions []string                `json:"supportedVersions"`
 	Capabilities      core.ServerCapabilities `json:"capabilities"`
-	ServerInfo        core.ServerInfo         `json:"serverInfo"`
+
+	// ServerInfo is the server's self-reported identity. Since spec
+	// PR 3002 it arrives in _meta[io.modelcontextprotocol/serverInfo]
+	// (see Meta); adaptiveProbe copies it here so callers keep one
+	// stable accessor. The json tag doubles as a decode fallback for
+	// pre-3002 servers that still emit it in the result body.
+	ServerInfo core.ServerInfo `json:"serverInfo"`
+
+	// Meta carries the result-side _meta envelope (spec PR 3002).
+	Meta core.ResultMeta `json:"_meta"`
 }
 
 // UnsupportedDiscoverError is returned by Client.Discover() when the

--- a/client/stateless_test.go
+++ b/client/stateless_test.go
@@ -186,12 +186,15 @@ func TestClient_AdaptiveAgainstStatelessServer(t *testing.T) {
 			saw[method]++
 			switch method {
 			case "server/discover":
+				// Spec PR 3002 shape: server identity in the result _meta.
 				body, _ := json.Marshal(map[string]any{
 					"jsonrpc": "2.0", "id": 1,
 					"result": map[string]any{
 						"supportedVersions": []string{core.DraftProtocolVersion2026V1},
 						"capabilities":      map[string]any{},
-						"serverInfo":        map[string]any{"name": "stateless", "version": "0.0.1"},
+						"_meta": map[string]any{
+							core.MetaKeyServerInfo: map[string]any{"name": "stateless", "version": "0.0.1"},
+						},
 					},
 				})
 				return 200, body
@@ -217,6 +220,39 @@ func TestClient_AdaptiveAgainstStatelessServer(t *testing.T) {
 	}
 	if saw["server/discover"] != 1 {
 		t.Errorf("expected 1 server/discover, got %d", saw["server/discover"])
+	}
+}
+
+// TestClient_DiscoverBodyServerInfoFallback verifies compatibility with a
+// server built against the pre-PR-3002 draft shape, which emits serverInfo
+// in the discover result body instead of _meta. The client still captures
+// the identity.
+func TestClient_DiscoverBodyServerInfoFallback(t *testing.T) {
+	fake := &fakeMCPServer{
+		handler: func(method string, _ json.RawMessage) (int, []byte) {
+			if method == "server/discover" {
+				body, _ := json.Marshal(map[string]any{
+					"jsonrpc": "2.0", "id": 1,
+					"result": map[string]any{
+						"supportedVersions": []string{core.DraftProtocolVersion2026V1},
+						"capabilities":      map[string]any{},
+						"serverInfo":        map[string]any{"name": "pre-3002", "version": "0.0.1"},
+					},
+				})
+				return 200, body
+			}
+			return 500, []byte(`{"jsonrpc":"2.0","error":{"code":-32603,"message":"unexpected"}}`)
+		},
+	}
+	ts, url := fake.start()
+	defer ts.Close()
+
+	c := NewClient(url, core.ClientInfo{Name: "t", Version: "1"}, WithClientMode(ClientModeAdaptive))
+	if err := c.Connect(); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	if c.ServerInfo.Name != "pre-3002" {
+		t.Errorf("ServerInfo.Name = %q, want %q (body fallback)", c.ServerInfo.Name, "pre-3002")
 	}
 }
 

--- a/core/stateless.go
+++ b/core/stateless.go
@@ -26,11 +26,20 @@ import (
 var SupportedStatelessVersions = []string{DraftProtocolVersion2026V1}
 
 // SEP-2575 _meta envelope keys. Carried inside the params._meta object on
-// every stateless request; missing any of the three triggers -32602.
+// every stateless request; a missing protocolVersion or clientCapabilities
+// triggers -32602. clientInfo is a SHOULD since spec PR 3002 — servers MUST
+// serve requests that omit it.
 const (
 	MetaKeyProtocolVersion    = "io.modelcontextprotocol/protocolVersion"
 	MetaKeyClientInfo         = "io.modelcontextprotocol/clientInfo"
 	MetaKeyClientCapabilities = "io.modelcontextprotocol/clientCapabilities"
+
+	// MetaKeyServerInfo is the result-side identity field (spec PR 3002).
+	// Servers SHOULD set it in every result's _meta so clients retain the
+	// server identity that the initialize handshake used to carry before
+	// SEP-2575 removed it. Self-reported and unverified — for display,
+	// logging, and debugging only; never for behavior or security decisions.
+	MetaKeyServerInfo = "io.modelcontextprotocol/serverInfo"
 
 	// MetaKeyLogLevel is the per-request log-level opt-in. Absent ⇒ no
 	// notifications/message frames may be emitted for this request.
@@ -53,8 +62,13 @@ const HTTPProtocolVersionHeader = "MCP-Protocol-Version"
 // malformed envelope produces a typed *MetaValidationError that the
 // dispatcher translates into a -32602 / HTTP 400 response.
 type RequestMeta struct {
-	ProtocolVersion    string             `json:"io.modelcontextprotocol/protocolVersion"`
-	ClientInfo         *ClientInfo        `json:"io.modelcontextprotocol/clientInfo"`
+	ProtocolVersion string `json:"io.modelcontextprotocol/protocolVersion"`
+
+	// ClientInfo identifies the client software. Optional since spec
+	// PR 3002 (clients SHOULD send it; servers MUST NOT require it) —
+	// nil when the request omitted the field. Self-reported and
+	// unverified: display/logging/debugging only.
+	ClientInfo         *ClientInfo         `json:"io.modelcontextprotocol/clientInfo"`
 	ClientCapabilities *ClientCapabilities `json:"io.modelcontextprotocol/clientCapabilities"`
 
 	// LogLevel is set when the client opts in to log frames for this
@@ -67,7 +81,7 @@ type RequestMeta struct {
 // -32602 + HTTP 400 at the transport boundary.
 type MetaValidationError struct {
 	// Field names the missing/invalid envelope component for diagnostics:
-	// "_meta", "protocolVersion", "clientInfo", or "clientCapabilities".
+	// "_meta", "protocolVersion", or "clientCapabilities".
 	Field string
 }
 
@@ -79,9 +93,10 @@ func (e *MetaValidationError) Error() string {
 }
 
 // DecodeRequestMeta extracts the SEP-2575 _meta envelope from raw params.
-// Returns a typed *MetaValidationError when the envelope is absent or any
-// required sub-field (protocolVersion, clientInfo, clientCapabilities) is
-// missing; the dispatcher maps these to -32602 / HTTP 400.
+// Returns a typed *MetaValidationError when the envelope is absent or a
+// required sub-field (protocolVersion, clientCapabilities) is missing; the
+// dispatcher maps these to -32602 / HTTP 400. clientInfo is not required
+// (spec PR 3002) — RequestMeta.ClientInfo is nil when the request omits it.
 //
 // An absent params (empty raw) is treated as "missing _meta" — the wire
 // requires _meta on every stateless request.
@@ -108,13 +123,70 @@ func DecodeRequestMetaFromRawJSON(m *RawJSON) (*RequestMeta, error) {
 	if rm.ProtocolVersion == "" {
 		return nil, &MetaValidationError{Field: "protocolVersion"}
 	}
-	if rm.ClientInfo == nil {
-		return nil, &MetaValidationError{Field: "clientInfo"}
-	}
 	if rm.ClientCapabilities == nil {
 		return nil, &MetaValidationError{Field: "clientCapabilities"}
 	}
 	return &rm, nil
+}
+
+// ResultMeta is the SEP-2575 result-side _meta shape (spec PR 3002's
+// ResultMetaObject). Currently carries only the optional server identity;
+// decode a result's _meta into this to read it.
+type ResultMeta struct {
+	// ServerInfo identifies the server software that produced the
+	// response. Servers SHOULD set it on every result. Self-reported
+	// and unverified — display/logging/debugging only; clients SHOULD
+	// NOT use it to change behavior or for security decisions.
+	ServerInfo *ServerInfo `json:"io.modelcontextprotocol/serverInfo,omitempty"`
+}
+
+// InjectServerInfoIntoResult returns result with
+// _meta[MetaKeyServerInfo] set to info, implementing the spec PR 3002
+// SHOULD that servers identify themselves on every response. Existing
+// _meta keys are preserved, and a caller-set serverInfo wins (mirroring
+// the InjectTraceContextIntoParams convention). Returns the input
+// unchanged when result is not a JSON object (no MCP result is), when
+// info is empty, or on any marshal failure — stamping is best-effort
+// decoration, never a dispatch error.
+//
+// The returned value is a json.RawMessage when stamping occurred; the
+// transport serializes it verbatim.
+func InjectServerInfoIntoResult(result any, info ServerInfo) any {
+	if info.Name == "" && info.Version == "" {
+		return result
+	}
+	raw, err := MarshalJSON(result)
+	if err != nil {
+		return result
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil || obj == nil {
+		return result
+	}
+	meta := map[string]json.RawMessage{}
+	if existing, ok := obj["_meta"]; ok {
+		if err := json.Unmarshal(existing, &meta); err != nil {
+			return result
+		}
+		if _, present := meta[MetaKeyServerInfo]; present {
+			return result
+		}
+	}
+	infoRaw, err := json.Marshal(info)
+	if err != nil {
+		return result
+	}
+	meta[MetaKeyServerInfo] = infoRaw
+	metaRaw, err := json.Marshal(meta)
+	if err != nil {
+		return result
+	}
+	obj["_meta"] = metaRaw
+	out, err := json.Marshal(obj)
+	if err != nil {
+		return result
+	}
+	return json.RawMessage(out)
 }
 
 // UnsupportedProtocolVersionData is the structured error payload returned

--- a/core/stateless_test.go
+++ b/core/stateless_test.go
@@ -55,14 +55,6 @@ func TestDecodeRequestMeta_MissingRequiredSubfields(t *testing.T) {
 			"protocolVersion",
 		},
 		{
-			"missing clientInfo",
-			`{
-				"io.modelcontextprotocol/protocolVersion":"2026-07-28",
-				"io.modelcontextprotocol/clientCapabilities":{}
-			}`,
-			"clientInfo",
-		},
-		{
 			"missing clientCapabilities",
 			`{
 				"io.modelcontextprotocol/protocolVersion":"2026-07-28",
@@ -87,6 +79,99 @@ func TestDecodeRequestMeta_MissingRequiredSubfields(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestDecodeRequestMeta_ClientInfoOptional locks the spec PR 3002 demotion:
+// a request whose _meta omits clientInfo MUST decode cleanly (clientInfo is
+// a SHOULD, never a rejection), with RequestMeta.ClientInfo left nil.
+func TestDecodeRequestMeta_ClientInfoOptional(t *testing.T) {
+	params := []byte(`{
+		"_meta": {
+			"io.modelcontextprotocol/protocolVersion": "2026-07-28",
+			"io.modelcontextprotocol/clientCapabilities": {}
+		}
+	}`)
+	meta, err := DecodeRequestMeta(params)
+	if err != nil {
+		t.Fatalf("clientInfo-less envelope rejected: %v", err)
+	}
+	if meta.ClientInfo != nil {
+		t.Errorf("ClientInfo = %+v, want nil for omitted field", meta.ClientInfo)
+	}
+}
+
+func TestInjectServerInfoIntoResult(t *testing.T) {
+	info := ServerInfo{Name: "srv", Version: "1.0"}
+
+	readMeta := func(t *testing.T, result any) *ServerInfo {
+		t.Helper()
+		raw, err := MarshalJSON(result)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var probe struct {
+			Meta ResultMeta `json:"_meta"`
+		}
+		if err := json.Unmarshal(raw, &probe); err != nil {
+			t.Fatal(err)
+		}
+		return probe.Meta.ServerInfo
+	}
+
+	t.Run("stamps plain object result", func(t *testing.T) {
+		out := InjectServerInfoIntoResult(map[string]any{"tools": []any{}}, info)
+		si := readMeta(t, out)
+		if si == nil || si.Name != "srv" || si.Version != "1.0" {
+			t.Errorf("serverInfo = %+v, want srv/1.0", si)
+		}
+	})
+
+	t.Run("preserves existing _meta keys", func(t *testing.T) {
+		out := InjectServerInfoIntoResult(map[string]any{
+			"_meta": map[string]any{"vendor/x": "y"},
+		}, info)
+		raw, _ := MarshalJSON(out)
+		var probe struct {
+			Meta map[string]json.RawMessage `json:"_meta"`
+		}
+		if err := json.Unmarshal(raw, &probe); err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := probe.Meta["vendor/x"]; !ok {
+			t.Errorf("existing _meta key dropped: %s", raw)
+		}
+		if _, ok := probe.Meta[MetaKeyServerInfo]; !ok {
+			t.Errorf("serverInfo not stamped alongside existing keys: %s", raw)
+		}
+	})
+
+	t.Run("caller-set serverInfo wins", func(t *testing.T) {
+		out := InjectServerInfoIntoResult(map[string]any{
+			"_meta": map[string]any{
+				MetaKeyServerInfo: map[string]any{"name": "custom", "version": "9"},
+			},
+		}, info)
+		si := readMeta(t, out)
+		if si == nil || si.Name != "custom" {
+			t.Errorf("serverInfo = %+v, want caller-set custom", si)
+		}
+	})
+
+	t.Run("empty info is a no-op", func(t *testing.T) {
+		in := map[string]any{"a": 1}
+		out := InjectServerInfoIntoResult(in, ServerInfo{})
+		if si := readMeta(t, out); si != nil {
+			t.Errorf("serverInfo = %+v, want none for empty identity", si)
+		}
+	})
+
+	t.Run("non-object result unchanged", func(t *testing.T) {
+		out := InjectServerInfoIntoResult([]string{"a"}, info)
+		raw, _ := MarshalJSON(out)
+		if string(raw) != `["a"]` {
+			t.Errorf("non-object result mutated: %s", raw)
+		}
+	})
 }
 
 // TestClientCaps_StatelessWire verifies that ctx.ClientCaps() returns the

--- a/server/stateless/discover.go
+++ b/server/stateless/discover.go
@@ -13,8 +13,12 @@ import (
 //	{
 //	  "supportedVersions": ["2026-07-28"],
 //	  "capabilities":      { ...ServerCapabilities... },
-//	  "serverInfo":        { "name": "...", "version": "..." }
+//	  "_meta": { "io.modelcontextprotocol/serverInfo": { "name": "...", "version": "..." } }
 //	}
+//
+// Server identity moved from the result body to _meta in spec PR 3002;
+// the _meta stamp is applied centrally by Dispatch, like every other
+// stateless result.
 //
 // Per the spec, clients MAY call server/discover up front to negotiate
 // version + capability shape, OR call any other RPC inline and handle
@@ -22,7 +26,6 @@ import (
 type DiscoverResult struct {
 	SupportedVersions []string                `json:"supportedVersions"`
 	Capabilities      core.ServerCapabilities `json:"capabilities"`
-	ServerInfo        core.ServerInfo         `json:"serverInfo"`
 }
 
 // handleDiscover assembles the discover response from the backend. The
@@ -32,6 +35,5 @@ func (d *Dispatcher) handleDiscover(id json.RawMessage) *core.Response {
 	return core.NewResponse(id, DiscoverResult{
 		SupportedVersions: d.Backend.SupportedVersions(),
 		Capabilities:      d.Backend.Capabilities(),
-		ServerInfo:        d.Backend.ServerInfo(),
 	})
 }

--- a/server/stateless/dispatch.go
+++ b/server/stateless/dispatch.go
@@ -63,7 +63,21 @@ var removedLegacyMethods = map[string]struct{}{
 // correct HTTP status (e.g. 403) + WWW-Authenticate header — so the stateless
 // wire matches the legacy wire's auth signaling instead of folding it into a
 // generic -32603 body (issue 815). When err is non-nil the *core.Response is nil.
+//
+// Every success result is stamped with _meta[io.modelcontextprotocol/serverInfo]
+// (spec PR 3002 SHOULD — the stateless wire has no initialize handshake to
+// carry server identity). Error responses are not stamped: the schema puts
+// ResultMetaObject on Result only.
 func (d *Dispatcher) Dispatch(ctx context.Context, req *core.Request) (*core.Response, error) {
+	resp, err := d.dispatch(ctx, req)
+	if err == nil && resp != nil && resp.Error == nil {
+		resp.Result = core.InjectServerInfoIntoResult(resp.Result, d.Backend.ServerInfo())
+	}
+	return resp, err
+}
+
+// dispatch is the unstamped routing core of Dispatch.
+func (d *Dispatcher) dispatch(ctx context.Context, req *core.Request) (*core.Response, error) {
 	id := req.ID
 	if id == nil {
 		id = json.RawMessage("null")

--- a/server/stateless/dispatch_test.go
+++ b/server/stateless/dispatch_test.go
@@ -281,18 +281,79 @@ func TestDispatch_ServerDiscoverShape(t *testing.T) {
 	}
 
 	raw, _ := json.Marshal(resp.Result)
-	var result DiscoverResult
+	var result struct {
+		DiscoverResult
+		Meta core.ResultMeta `json:"_meta"`
+	}
 	if err := json.Unmarshal(raw, &result); err != nil {
 		t.Fatalf("discover result did not decode: %v", err)
 	}
 	if len(result.SupportedVersions) == 0 {
 		t.Errorf("SupportedVersions empty")
 	}
-	if result.ServerInfo.Name != "test" {
-		t.Errorf("ServerInfo.Name = %q, want %q", result.ServerInfo.Name, "test")
+	// Spec PR 3002: server identity lives in the result _meta, not the body.
+	if result.Meta.ServerInfo == nil || result.Meta.ServerInfo.Name != "test" {
+		t.Errorf("_meta serverInfo = %+v, want name %q", result.Meta.ServerInfo, "test")
 	}
 	if result.Capabilities.Tools == nil || !result.Capabilities.Tools.ListChanged {
 		t.Errorf("Capabilities not echoed correctly: %+v", result.Capabilities)
+	}
+}
+
+// TestDispatch_ClientInfoOptional locks the spec PR 3002 demotion at the
+// dispatcher level: a request whose _meta omits clientInfo MUST be served,
+// not rejected with -32602 (conformance check
+// sep-2575-request-meta-client-info-optional).
+func TestDispatch_ClientInfoOptional(t *testing.T) {
+	d := New(&fakeBackend{info: core.ServerInfo{Name: "test", Version: "1"}})
+	req := &core.Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage("7"),
+		Method:  "tools/list",
+		Params: core.NewRawJSON(json.RawMessage(`{
+			"_meta": {
+				"io.modelcontextprotocol/protocolVersion": "2026-07-28",
+				"io.modelcontextprotocol/clientCapabilities": {}
+			}
+		}`)),
+	}
+	resp, err := d.Dispatch(context.Background(), req)
+	if err != nil {
+		t.Fatalf("dispatch error: %v", err)
+	}
+	if resp == nil || resp.Error != nil {
+		t.Fatalf("clientInfo-less request rejected: %+v", resp)
+	}
+}
+
+// TestDispatch_StampsServerInfoOnEveryResult verifies the spec PR 3002
+// SHOULD: every success result — not just server/discover — carries the
+// server identity in _meta[io.modelcontextprotocol/serverInfo].
+func TestDispatch_StampsServerInfoOnEveryResult(t *testing.T) {
+	d := New(&fakeBackend{info: core.ServerInfo{Name: "test", Version: "2.0"}})
+	for _, method := range []string{"tools/list", "resources/list", "prompts/list"} {
+		t.Run(method, func(t *testing.T) {
+			req := &core.Request{
+				JSONRPC: "2.0",
+				ID:      json.RawMessage("8"),
+				Method:  method,
+				Params:  core.NewRawJSON(validMetaParams(t)),
+			}
+			resp, err := d.Dispatch(context.Background(), req)
+			if err != nil || resp == nil || resp.Error != nil {
+				t.Fatalf("dispatch failed: resp=%+v err=%v", resp, err)
+			}
+			raw, _ := core.MarshalJSON(resp.Result)
+			var probe struct {
+				Meta core.ResultMeta `json:"_meta"`
+			}
+			if err := json.Unmarshal(raw, &probe); err != nil {
+				t.Fatalf("result did not decode: %v", err)
+			}
+			if probe.Meta.ServerInfo == nil || probe.Meta.ServerInfo.Name != "test" || probe.Meta.ServerInfo.Version != "2.0" {
+				t.Errorf("_meta serverInfo = %+v, want test/2.0 (result=%s)", probe.Meta.ServerInfo, raw)
+			}
+		})
 	}
 }
 

--- a/server/streamable_stateless_test.go
+++ b/server/streamable_stateless_test.go
@@ -130,15 +130,19 @@ func TestStatelessRouting_DualMode_ServerDiscoverHits200(t *testing.T) {
 	}
 	// Result is a map after unmarshal; verify the shape.
 	raw, _ := json.Marshal(r.Result)
-	var dr stateless.DiscoverResult
+	var dr struct {
+		stateless.DiscoverResult
+		Meta core.ResultMeta `json:"_meta"`
+	}
 	if err := json.Unmarshal(raw, &dr); err != nil {
 		t.Fatalf("decode DiscoverResult: %v", err)
 	}
 	if len(dr.SupportedVersions) == 0 || dr.SupportedVersions[0] != draftVersion {
 		t.Errorf("SupportedVersions = %v, want first=%q", dr.SupportedVersions, draftVersion)
 	}
-	if dr.ServerInfo.Name != "stateless-test" {
-		t.Errorf("ServerInfo.Name = %q, want stateless-test", dr.ServerInfo.Name)
+	// Spec PR 3002: server identity lives in the result _meta, not the body.
+	if dr.Meta.ServerInfo == nil || dr.Meta.ServerInfo.Name != "stateless-test" {
+		t.Errorf("_meta serverInfo = %+v, want name stateless-test", dr.Meta.ServerInfo)
 	}
 }
 


### PR DESCRIPTION
## Summary

Aligns mcpkit's SEP-2575 stateless wire with the final-revision `_meta` identity changes from spec PR 3002 (plain-text reference: `modelcontextprotocol/modelcontextprotocol` PR 3002).

- `clientInfo` in the per-request `_meta` envelope is now optional. Requests that omit it are served instead of rejected with `-32602`. Clients SHOULD still send it, and mcpkit's client does.
- Servers stamp `_meta["io.modelcontextprotocol/serverInfo"]` on every stateless success result via the new `core.InjectServerInfoIntoResult`. Caller-set values win, and error responses are not stamped. This restores the server identity the removed `initialize` handshake used to carry.
- Wire change: `serverInfo` moved out of the `server/discover` result body into the result `_meta`. `client.DiscoverResult` reads the `_meta` form first and falls back to the pre-3002 body field, so older draft servers keep working.
- New surface: `core.MetaKeyServerInfo`, `core.ResultMeta`, `core.InjectServerInfoIntoResult`.

Both identity fields are self-reported and unverified, for display, logging, and debugging only.

## Testing

- `go test ./core/... ./client/... ./server/...` green (includes new coverage in `core/stateless_test.go`, `client/stateless_test.go`, `server/stateless/dispatch_test.go`, `server/streamable_stateless_test.go`).