### PR TITLE
feat(agentchat): centralize keys in key.Binding + help bar (1063 C2)

### DIFF
--- a/cmd/agentchat/README.md
+++ b/cmd/agentchat/README.md
@@ -61,7 +61,14 @@ region, never committed to scrollback): `model <active> · session <id> · ctx
 TUI layout track (#1063 D1/D2); collapsible tool cells (B4) already shipped with
 `--ui notebook`.
 
-## Prompt editing keys (TUI)
+## Keys & help (TUI)
+
+Both surfaces show a one-line help bar under the status line (`enter send · tab
+complete · ↑↓ history · ? help · ctrl+c quit`). Press **`?`** on an empty prompt
+to expand the full key list (in the notebook's NAV mode, `?` always toggles).
+The bar, the `?` view, and the `/keys` cheatsheet are all generated from one
+`key.Binding` set, so they can't drift from the keys the surface actually
+handles (#1063 C2).
 
 The input line supports readline-style editing. `/keys` prints this cheatsheet
 in-session.

--- a/cmd/agentchat/keys.go
+++ b/cmd/agentchat/keys.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/bubbles/key"
+)
+
+// appKeys centralizes the surface-level key bindings — the ones the models act
+// on before handing the event to the textarea. The one-line help bar, the
+// notebook status hints, the `?` full-help view, and the /keys cheatsheet all
+// render from these bindings, so the documented keys can never drift from the
+// handled keys (issue 1063 C2). The inline surface matches events against these
+// bindings directly (key.Matches), making them the single source of truth for
+// both behavior and help.
+type appKeys struct {
+	Send     key.Binding
+	Newline  key.Binding
+	Complete key.Binding
+	History  key.Binding
+	Help     key.Binding
+	Quit     key.Binding
+
+	// notebook NAV mode
+	Select key.Binding
+	Fold   key.Binding
+	Ends   key.Binding
+	Insert key.Binding
+	Nav    key.Binding
+	Scroll key.Binding
+}
+
+func newAppKeys() appKeys {
+	return appKeys{
+		Send:     key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "send")),
+		Newline:  key.NewBinding(key.WithKeys("ctrl+j"), key.WithHelp("ctrl+j", "newline")),
+		Complete: key.NewBinding(key.WithKeys("tab"), key.WithHelp("tab", "complete")),
+		History:  key.NewBinding(key.WithKeys("up", "down"), key.WithHelp("↑↓", "history")),
+		Help:     key.NewBinding(key.WithKeys("?"), key.WithHelp("?", "help")),
+		Quit:     key.NewBinding(key.WithKeys("ctrl+c"), key.WithHelp("ctrl+c", "quit")),
+
+		Select: key.NewBinding(key.WithKeys("up", "down", "k", "j"), key.WithHelp("↑↓/jk", "select")),
+		Fold:   key.NewBinding(key.WithKeys(" ", "enter"), key.WithHelp("space", "fold")),
+		Ends:   key.NewBinding(key.WithKeys("g", "G"), key.WithHelp("g/G", "ends")),
+		Insert: key.NewBinding(key.WithKeys("esc", "i"), key.WithHelp("esc/i", "type")),
+		Nav:    key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "select cells")),
+		Scroll: key.NewBinding(key.WithKeys("pgup", "pgdown"), key.WithHelp("pgup/dn", "scroll")),
+	}
+}
+
+// insertBar is the one-line help shown while typing (inline surface + notebook
+// INS mode); navBar is the notebook NAV mode line.
+func (k appKeys) insertBar() []key.Binding {
+	return []key.Binding{k.Send, k.Complete, k.History, k.Help, k.Quit}
+}
+
+func (k appKeys) navBar() []key.Binding {
+	return []key.Binding{k.Select, k.Fold, k.Ends, k.Insert, k.Help}
+}
+
+// fullHelp groups every surface binding for the `?` view.
+func (k appKeys) fullHelp() [][]key.Binding {
+	return [][]key.Binding{
+		{k.Send, k.Newline, k.Complete},
+		{k.History, k.Help, k.Quit},
+		{k.Nav, k.Select, k.Fold, k.Ends, k.Insert, k.Scroll},
+	}
+}
+
+// renderKeyHelp is the /keys cheatsheet. The surface-keys section is generated
+// from the bindings above (so it never drifts); the prompt-editing section is
+// the readline keys the bubbles textarea owns, whose descriptions the textarea
+// does not carry, so they stay hand-written here.
+func renderKeyHelp() string {
+	var b strings.Builder
+	b.WriteString("Surface keys:\n")
+	for _, grp := range newAppKeys().fullHelp() {
+		for _, bnd := range grp {
+			h := bnd.Help()
+			b.WriteString("  " + padRight(h.Key, 12) + h.Desc + "\n")
+		}
+	}
+	b.WriteString("\nPrompt editing (readline):\n")
+	b.WriteString(strings.Join([]string{
+		"  ← / →       char back / forward",
+		"  ctrl+← / →  word back / forward",
+		"  ctrl+a / e  start / end of line   (also Home / End)",
+		"  ctrl+w      delete previous word",
+		"  ctrl+k / u  delete to end / start of line",
+		"  ctrl+j      insert a newline (also shift+enter / alt+enter)",
+		"  With Option-as-Meta on: alt+←/→ or alt+b/f word nav, alt+d delete-word-forward.",
+	}, "\n"))
+	return b.String()
+}
+
+func padRight(s string, n int) string {
+	if len([]rune(s)) >= n {
+		return s + " "
+	}
+	return s + strings.Repeat(" ", n-len([]rune(s)))
+}

--- a/cmd/agentchat/keys.go
+++ b/cmd/agentchat/keys.go
@@ -83,12 +83,20 @@ func renderKeyHelp() string {
 	b.WriteString("\nPrompt editing (readline):\n")
 	b.WriteString(strings.Join([]string{
 		"  ← / →       char back / forward",
+		"  ↑ / ↓       recall history on a single-line prompt; move line to line in a multi-line prompt",
 		"  ctrl+← / →  word back / forward",
 		"  ctrl+a / e  start / end of line   (also Home / End)",
 		"  ctrl+w      delete previous word",
 		"  ctrl+k / u  delete to end / start of line",
 		"  ctrl+j      insert a newline (also shift+enter / alt+enter)",
 		"  With Option-as-Meta on: alt+←/→ or alt+b/f word nav, alt+d delete-word-forward.",
+	}, "\n"))
+	b.WriteString("\n\nNotebook modes (--ui notebook):\n")
+	b.WriteString(strings.Join([]string{
+		"  INS   typing (default). esc enters NAV.",
+		"  NAV   cell selection. i or esc returns to INS; the NAV keys above",
+		"        (↑↓/jk select, space fold, g/G ends, pgup/dn scroll) act only here.",
+		"  The inline surface (--ui tui) has no modes; it is always in INS.",
 	}, "\n"))
 	return b.String()
 }

--- a/cmd/agentchat/keys_test.go
+++ b/cmd/agentchat/keys_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// TestKeys_MatchHandledKeys pins the bindings to the literal keys the models
+// act on, so a rewire that changes behavior also changes the help.
+func TestKeys_MatchHandledKeys(t *testing.T) {
+	k := newAppKeys()
+	cases := []struct {
+		name string
+		msg  tea.KeyMsg
+		bind key.Binding
+	}{
+		{"send", tea.KeyMsg{Type: tea.KeyEnter}, k.Send},
+		{"complete", tea.KeyMsg{Type: tea.KeyTab}, k.Complete},
+		{"quit", tea.KeyMsg{Type: tea.KeyCtrlC}, k.Quit},
+		{"help", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("?")}, k.Help},
+		{"history-up", tea.KeyMsg{Type: tea.KeyUp}, k.History},
+		{"fold", tea.KeyMsg{Type: tea.KeySpace}, k.Fold},
+	}
+	for _, c := range cases {
+		if !key.Matches(c.msg, c.bind) {
+			t.Errorf("%s: key.Matches(%q) = false", c.name, c.msg.String())
+		}
+	}
+}
+
+// TestKeys_HelpBarsHaveText guards that every binding shown in a help bar
+// carries a key + description, so nothing renders blank.
+func TestKeys_HelpBarsHaveText(t *testing.T) {
+	k := newAppKeys()
+	for _, group := range [][]key.Binding{k.insertBar(), k.navBar()} {
+		for _, b := range group {
+			h := b.Help()
+			if h.Key == "" || h.Desc == "" {
+				t.Errorf("help bar binding missing text: key=%q desc=%q", h.Key, h.Desc)
+			}
+		}
+	}
+}
+
+// TestRenderKeyHelp_NoDriftFromBindings is the C2 contract: the /keys cheatsheet
+// is generated from the same bindings, so every surface binding's key literal
+// appears in it. A binding added or renamed without updating help fails here.
+func TestRenderKeyHelp_NoDriftFromBindings(t *testing.T) {
+	out := renderKeyHelp()
+	for _, group := range newAppKeys().fullHelp() {
+		for _, b := range group {
+			key := b.Help().Key
+			if !strings.Contains(out, key) {
+				t.Errorf("renderKeyHelp() missing binding key %q:\n%s", key, out)
+			}
+		}
+	}
+}
+
+func TestTUI_QuestionMarkTogglesHelpOnlyWhenEmpty(t *testing.T) {
+	qmark := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("?")}
+
+	// empty prompt: `?` toggles the full-help view
+	m := newTUIModel(nil, nil, 0)
+	nm, _ := m.Update(qmark)
+	m = nm.(tuiModel)
+	if !m.showAll {
+		t.Fatal("`?` on an empty prompt should toggle full help on")
+	}
+	nm, _ = m.Update(qmark)
+	if nm.(tuiModel).showAll {
+		t.Fatal("`?` again should toggle full help off")
+	}
+
+	// non-empty prompt: `?` is a literal character, help stays off
+	m2 := newTUIModel(nil, nil, 0)
+	m2.ta.SetValue("hi")
+	nm2, _ := m2.Update(qmark)
+	m2 = nm2.(tuiModel)
+	if m2.showAll {
+		t.Fatal("`?` while typing should not toggle help")
+	}
+	if !strings.Contains(m2.ta.Value(), "?") {
+		t.Fatalf("`?` while typing should be inserted, got %q", m2.ta.Value())
+	}
+}
+
+func TestNotebook_QuestionMarkTogglesHelp(t *testing.T) {
+	qmark := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("?")}
+	m := newNotebookModel(nil, nil, 20, 0)
+	m = send(m, tea.WindowSizeMsg{Width: 40, Height: 20})
+
+	// insert mode, empty prompt: toggles
+	m = send(m, qmark)
+	if !m.showAll {
+		t.Fatal("`?` on empty prompt (INS) should toggle full help")
+	}
+	// nav mode: `?` always toggles (no typing there)
+	m.showAll = false
+	m = send(m, nbCellMsg{label: "you", body: "x"}) // give nav a cell to select
+	m = send(m, tea.KeyMsg{Type: tea.KeyEsc})       // enter NAV
+	if !m.nav {
+		t.Fatal("esc should enter NAV")
+	}
+	m = send(m, qmark)
+	if !m.showAll {
+		t.Fatal("`?` in NAV should toggle full help")
+	}
+}

--- a/cmd/agentchat/notebook.go
+++ b/cmd/agentchat/notebook.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/textarea"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
@@ -211,6 +213,10 @@ type notebookModel struct {
 	cells []nbCell
 	live  string // the in-flight turn, always shown expanded at the bottom
 
+	keys    appKeys
+	help    help.Model
+	showAll bool // ? toggled the full-help view
+
 	nav      bool // false = insert, true = nav
 	sel      int  // selected cell index in nav mode
 	running  bool
@@ -235,7 +241,7 @@ func newNotebookModel(app *host.App, surface *nbObserver, maxLines, window int) 
 	if maxLines <= 0 {
 		maxLines = defaultNotebookMaxLines
 	}
-	m := notebookModel{app: app, surface: surface, ta: newPromptArea(), atBottom: true, maxLines: maxLines, window: window}
+	m := notebookModel{app: app, surface: surface, ta: newPromptArea(), keys: newAppKeys(), help: help.New(), atBottom: true, maxLines: maxLines, window: window}
 	m.histIdx = 0
 	if app != nil {
 		// Safe here: construction runs before the first turn, so turnMu is free.
@@ -346,29 +352,33 @@ func (m notebookModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // updateNav handles keys while the selection cursor is active: move the
 // selection, fold/unfold, jump to ends, or return to insert mode.
 func (m notebookModel) updateNav(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	switch msg.String() {
-	case "esc", "i":
+	switch {
+	case key.Matches(msg, m.keys.Help):
+		m.showAll = !m.showAll
+	case key.Matches(msg, m.keys.Insert):
 		m.nav = false
-	case "up", "k":
-		if m.sel > 0 {
+	case key.Matches(msg, m.keys.Select):
+		if s := msg.String(); (s == "up" || s == "k") && m.sel > 0 {
 			m.sel--
-		}
-	case "down", "j":
-		if m.sel < len(m.cells)-1 {
+		} else if (s == "down" || s == "j") && m.sel < len(m.cells)-1 {
 			m.sel++
 		}
-	case "g":
-		m.sel = 0
-	case "G":
-		m.sel = len(m.cells) - 1
-	case " ", "enter":
+	case key.Matches(msg, m.keys.Ends):
+		if msg.String() == "g" {
+			m.sel = 0
+		} else {
+			m.sel = len(m.cells) - 1
+		}
+	case key.Matches(msg, m.keys.Fold):
 		if m.sel >= 0 && m.sel < len(m.cells) {
 			m.cells[m.sel].collapsed = !m.cells[m.sel].collapsed
 		}
-	case "pgup":
-		m.vp.HalfPageUp()
-	case "pgdown":
-		m.vp.HalfPageDown()
+	case key.Matches(msg, m.keys.Scroll):
+		if msg.String() == "pgup" {
+			m.vp.HalfPageUp()
+		} else {
+			m.vp.HalfPageDown()
+		}
 	}
 	m.refresh()
 	return m, nil
@@ -377,6 +387,13 @@ func (m notebookModel) updateNav(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 // updateInsert handles keys while typing: submit, complete, history, scroll the
 // viewport, or enter nav mode; anything else edits the input.
 func (m notebookModel) updateInsert(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	// `?` toggles full help only on an empty prompt, so it stays typeable
+	// mid-message. (In NAV mode there is no typing, so `?` always toggles.)
+	if key.Matches(msg, m.keys.Help) && m.ta.Value() == "" {
+		m.showAll = !m.showAll
+		m.refresh()
+		return m, nil
+	}
 	switch msg.Type {
 	case tea.KeyEsc:
 		if len(m.cells) > 0 {
@@ -441,10 +458,12 @@ func (m notebookModel) View() string {
 
 func (m notebookModel) statusBar() string {
 	var hint string
-	if m.nav {
-		hint = "NAV  ↑↓/jk select · space fold · g/G ends · esc/i type"
+	if m.showAll {
+		hint = m.help.FullHelpView(m.keys.fullHelp())
+	} else if m.nav {
+		hint = "NAV  " + m.help.ShortHelpView(m.keys.navBar())
 	} else {
-		hint = "INS  enter send · ctrl+j newline · ↑↓ scroll · esc fold"
+		hint = "INS  " + m.help.ShortHelpView(m.keys.insertBar())
 	}
 	if m.running {
 		hint = "working…  " + hint
@@ -542,7 +561,7 @@ func firstLine(s string) string {
 // goroutine, mirroring the inline TUI. /keys is a terminal-only cheatsheet.
 func (m notebookModel) submit(line string) (tea.Model, tea.Cmd) {
 	if line == "/keys" {
-		m.cells = append(m.cells, nbCell{label: "info", body: keyHelp()})
+		m.cells = append(m.cells, nbCell{label: "info", body: renderKeyHelp()})
 		m.refresh()
 		return m, nil
 	}

--- a/cmd/agentchat/tui.go
+++ b/cmd/agentchat/tui.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/textarea"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -209,6 +211,9 @@ type tuiModel struct {
 	app     *host.App
 	surface *tuiObserver
 	ta      textarea.Model
+	keys    appKeys
+	help    help.Model
+	showAll bool // ? toggled the full-help view
 	history []string
 	histIdx int // len(history) == "not navigating"
 	running bool
@@ -243,7 +248,7 @@ func newPromptArea() textarea.Model {
 }
 
 func newTUIModel(app *host.App, surface *tuiObserver, window int) tuiModel {
-	m := tuiModel{app: app, surface: surface, ta: newPromptArea(), window: window}
+	m := tuiModel{app: app, surface: surface, ta: newPromptArea(), keys: newAppKeys(), help: help.New(), window: window}
 	m.histIdx = 0
 	if app != nil {
 		// Safe here: construction runs before the first turn, so turnMu is free.
@@ -289,10 +294,15 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyMsg:
-		switch msg.Type {
-		case tea.KeyCtrlC:
+		switch {
+		case key.Matches(msg, m.keys.Quit):
 			return m, tea.Quit
-		case tea.KeyEnter:
+		case key.Matches(msg, m.keys.Help) && m.ta.Value() == "":
+			// `?` toggles full help only on an empty prompt, so it stays typeable
+			// mid-message.
+			m.showAll = !m.showAll
+			return m, nil
+		case key.Matches(msg, m.keys.Send):
 			if m.running {
 				return m, nil
 			}
@@ -304,15 +314,16 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.history = append(m.history, line)
 			m.histIdx = len(m.history)
 			return m.submit(line)
-		case tea.KeyTab:
+		case key.Matches(msg, m.keys.Complete):
 			m.completeTab()
 			return m, nil
-		case tea.KeyUp:
-			if m.recallHistory(-1) {
-				return m, nil
+		case key.Matches(msg, m.keys.History):
+			// up/down recall history; a miss falls through to cursor motion
+			dir := -1
+			if msg.String() == "down" {
+				dir = 1
 			}
-		case tea.KeyDown:
-			if m.recallHistory(1) {
+			if m.recallHistory(dir) {
 				return m, nil
 			}
 		}
@@ -337,6 +348,12 @@ func (m tuiModel) View() string {
 	}
 	b.WriteString(lipgloss.NewStyle().Faint(true).Render(status))
 	b.WriteString("\n")
+	if m.showAll {
+		b.WriteString(m.help.FullHelpView(m.keys.fullHelp()))
+	} else {
+		b.WriteString(m.help.ShortHelpView(m.keys.insertBar()))
+	}
+	b.WriteString("\n")
 	b.WriteString(m.ta.View())
 	return b.String()
 }
@@ -348,7 +365,7 @@ func (m tuiModel) submit(line string) (tea.Model, tea.Cmd) {
 	// /keys is a terminal-only cheatsheet (prompt editing is a TUI concern, so
 	// it is not a surface-agnostic host command); print it without a turn.
 	if line == "/keys" {
-		return m, tea.Println(keyHelp())
+		return m, tea.Println(renderKeyHelp())
 	}
 	m.running = true
 	app, surface := m.app, m.surface
@@ -377,24 +394,6 @@ func (m tuiModel) submit(line string) (tea.Model, tea.Cmd) {
 		}()
 	}
 	return m, nil
-}
-
-// keyHelp is the /keys cheatsheet: the prompt-editing bindings, grouped by
-// what works without a Meta key (the top rows) versus what needs the
-// terminal's Option-as-Meta (the alt-* bindings).
-func keyHelp() string {
-	return strings.Join([]string{
-		"Prompt editing keys:",
-		"  ← / →                 char back / forward",
-		"  ctrl+← / ctrl+→       word back / forward",
-		"  ctrl+a / ctrl+e       start / end of line   (also Home / End)",
-		"  ctrl+w                delete previous word",
-		"  ctrl+k / ctrl+u       delete to end / start of line",
-		"  ctrl+home / ctrl+end  start / end of input",
-		"  ctrl+j               insert a newline (also shift+enter / alt+enter)",
-		"  ↑ / ↓  history    Tab  complete    Enter  send    ctrl+c  quit",
-		"  With Option-as-Meta on: alt+←/→ or alt+b/f word nav, alt+d delete-word-forward, alt+</> input ends.",
-	}, "\n")
 }
 
 func (m *tuiModel) completeTab() { tabComplete(&m.ta, m.app) }

--- a/cmd/agentchat/tui_test.go
+++ b/cmd/agentchat/tui_test.go
@@ -190,11 +190,11 @@ func TestKeyMap_WordNavHasCtrlArrows(t *testing.T) {
 	}
 }
 
-func TestKeyHelp_ListsBindings(t *testing.T) {
-	h := keyHelp()
-	for _, want := range []string{"ctrl+← / ctrl+→", "ctrl+a / ctrl+e", "ctrl+w", "ctrl+k / ctrl+u", "Option-as-Meta"} {
+func TestRenderKeyHelp_ListsEditingBindings(t *testing.T) {
+	h := renderKeyHelp()
+	for _, want := range []string{"ctrl+←", "ctrl+a / e", "ctrl+w", "ctrl+k / u", "Option-as-Meta"} {
 		if !strings.Contains(h, want) {
-			t.Fatalf("keyHelp() missing %q:\n%s", want, h)
+			t.Fatalf("renderKeyHelp() missing %q:\n%s", want, h)
 		}
 	}
 }


### PR DESCRIPTION
## What changes

Both interactive agentchat surfaces now render a **one-line help bar** under the status line and expand a **full key list on `?`**, all generated from a single `key.Binding` set (`appKeys`). The inline surface matches key events against those bindings (`key.Matches`) rather than scattered `tea.Key*` literals, so the documented keys can't drift from the keys actually handled. This is item **C2** of the TUI layout track (issue 1063).

`?` toggles full help only on an **empty prompt** (so it stays typeable mid-message); the notebook's NAV mode has no typing, so `?` always toggles there.

## Reviewer's guide

Read in this order:
1. [cmd/agentchat/keys.go](https://github.com/panyam/mcpkit/pull/1094/files#diff-e83752496ec9cc063a573fedefb2237ad2f177671926491e0fc11d9b372aa076) — start here. `appKeys` (the binding set), the `insertBar`/`navBar`/`fullHelp` help slices, and `renderKeyHelp` (the `/keys` cheatsheet: surface keys generated from bindings, readline keys hand-written since the textarea carries no help text).
2. [cmd/agentchat/tui.go](https://github.com/panyam/mcpkit/pull/1094/files#diff-0e29207287df07cecf17e04df9f99e726ae789983f7e3ce007bb6282029b4db6) — the inline `Update` KeyMsg switch rewired to `key.Matches`; `?` toggle; `View` renders the bar / full help via `bubbles/help`.
3. [cmd/agentchat/notebook.go](https://github.com/panyam/mcpkit/pull/1094/files#diff-8a79677a206f62f0abeebce75abd2fbafac2dc1be85310113e702bebc42624b1) — `updateNav` rewired to `key.Matches`; `?` toggle in `updateInsert`; `statusBar` generated from bindings.
4. [cmd/agentchat/keys_test.go](https://github.com/panyam/mcpkit/pull/1094/files#diff-c365d31b7ce9c04e5ac4bfb836a38f25c49e31f48d92d09a53946e7042f29976) — acceptance: bindings match handled keys, help bars carry text, the no-drift contract, and the `?`-gating behavior.

Skim or skip: `README.md`, `tui_test.go` (one test renamed `keyHelp`→`renderKeyHelp`).

## Decision log

- **`?` empty-prompt gate** over a dedicated key (e.g. `ctrl+g`): `?` matches the common TUI convention and stays discoverable; the only cost is you can't *start* a message with a literal `?` (type a space first). Confirmed with the user.
- **Bindings drive behavior on the inline surface** (`key.Matches`), not just help — that's what makes "no drift" real rather than cosmetic. The notebook NAV switch is likewise rewired; the notebook INS path keeps its `msg.Type` switch (Enter/Tab/Up/Down have viewport-scroll fall-through semantics not worth reshaping), with the bar still generated from the same bindings.
- **Readline keys stay hand-written** in `renderKeyHelp` — the bubbles textarea's KeyMap bindings carry no help descriptions, so generating them would render blank. The no-drift guard covers the surface keys, which is where drift actually happened.

## Risk / blast radius

- Affects: `cmd/agentchat` only (its own go.mod), no host/core changes, no new dependency (`bubbles/key` + `bubbles/help` ship inside the already-imported `bubbles`).
- Tests covering this: `keys_test.go` (new) + the existing key tests (`TestKeyMap_*`, `TestRecallHistory`, notebook nav tests) all still pass — the rewire preserves every prior key behavior.
- Be paranoid about: the history up/down fall-through (a recall miss must still reach the textarea for cursor motion), and that `?` on a non-empty prompt inserts a literal `?` rather than toggling.

## Before / after

**Inline surface** — before: status line only, no key hints. After: a generated help bar.

```
before:  model stub · session no session
         › ▏

after:   model stub · session no session
         enter send · tab complete · ↑↓ history · ? help · ctrl+c quit
         › ▏
```

**`?` full help (either surface):**

```
enter  send        ↑↓     history    esc     select cells
ctrl+j newline     ?      help       ↑↓/jk   select
tab    complete    ctrl+c quit       space   fold
                                     g/G     ends
                                     esc/i   type
                                     pgup/dn scroll
```

**Notebook status bar** — before: hand-written hint strings that could drift. After: the same generated bars (`NAV …` / `INS …`).

```
before (hard-coded):  INS  enter send · ctrl+j newline · ↑↓ scroll · esc fold
after (generated):    INS  enter send · tab complete · ↑↓ history · ? help · ctrl+c quit
                      NAV  ↑↓/jk select · space fold · g/G ends · esc/i type · ? help
```

## Out of scope (deferred, same track — issue 1063)

- B4 collapsible tool-call + sub-agent tree gutter — the stacked follow-up PR on top of this one.
- AdaptiveColor + `--no-color` (E), grapheme-width (F2), resize reflow (F1).

