### PR TITLE
docs: tier-1 policy signals (SECURITY, DEPENDENCY_POLICY, ROADMAP, VERSIONING, dependabot)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directories:
+      - "/"
+      - "/ext/auth"
+      - "/ext/tasks"
+      - "/ext/ui"
+      - "/ext/otel"
+    schedule:
+      interval: weekly
+    groups:
+      go-deps:
+        patterns:
+          - "*"
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/DEPENDENCY_POLICY.md
+++ b/DEPENDENCY_POLICY.md
@@ -1,0 +1,20 @@
+# Dependency Policy
+
+## Philosophy
+
+The root module (`core/`, `server/`, `client/`) stays dependency-light. Heavier or opinionated dependencies (OAuth stacks, OTel SDK, ORMs, UI tooling) live in sub-modules with their own `go.mod`, so consumers only pull what they import.
+
+## Update cadence
+
+- Dependabot (`.github/dependabot.yml`) opens weekly update PRs for the root module, the `ext/*` sub-modules, and GitHub Actions.
+- Sub-modules not covered by Dependabot are swept manually with `make tidy-all`, which runs whenever `core/` imports change and before every release.
+- Cross-module pins are bumped in lock-step. For example, a `oneauth` bump touches all dependent modules in one PR so CI's module-resolution stays consistent.
+
+## Security updates
+
+- `make audit` runs govulncheck, gosec, and gitleaks; it runs in CI and before every tagged release.
+- A vulnerability in a dependency with a fix available is treated at the severity of the vulnerability itself: critical (CVSS 7.0+) within 7 days, others in the next regular release. See `SECURITY.md`.
+
+## Toolchain
+
+The two most recent Go releases are supported. The `go` directive in each `go.mod` states the minimum version.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,28 @@
+# Roadmap
+
+This roadmap tracks mcpkit's implementation of the MCP specification, per the [SDK tiering requirements](https://modelcontextprotocol.io/community/sdk-tiers). Work is tracked in GitHub issues; this file points at the durable entry points rather than duplicating them.
+
+## How work is tracked
+
+- **Per spec release:** a Release Tracker issue labeled `release:<date>` (currently issue 431 for the 2026-07-28 spec release) carries the live implementation status for every SEP in that release.
+- **Conformance posture:** `CONFORMANCE.md` (regenerated from upstream's tier-check) and `conformance/UPSTREAM_AUDIT.md` (mcpkit graded against every upstream scenario).
+- **Release notes and migrations:** `CHANGELOG.md` plus `docs/releases/vX.Y.Z.md`.
+
+## Current status
+
+All required (non-experimental) features of the current spec, including the optional sampling and elicitation capabilities, are implemented. Upstream conformance: 100% of applicable server scenarios (see `CONFORMANCE.md`).
+
+## Near-term
+
+- **Stable v0.4.0 release** shortly after the 2026-07-28 spec GA. The scope of the 0.4.0 bundle is in `CHANGELOG.md` and `docs/releases/v0.4.0.md`.
+- **Client conformance harness:** wire mcpkit's client into upstream tier-check's `--client-cmd` runner so the client scenario suites score alongside the server ones.
+- **Tier 1 process items:** issue-triage SLA hygiene and the tier-advancement request to the SDK Working Group.
+
+## Longer-term
+
+- **SEP-2577 removals:** Roots, Sampling, and Logging surfaces are deprecated with a 12-month annotation window; removal is tracked in issue 850 and lands no earlier than 2027.
+- **Extensions** (not required for any tier, tracked per-issue): Tasks v2, MCP Apps, OTel/SEP-414, Events, Skills.
+
+## Out of scope for spec tracking
+
+The agent SDK (`agent/`, `agent/host/`, `cmd/agentchat`) is a separate track above the protocol layer, with its own roadmap in `docs/AGENT_SDK_ROADMAP.md`. It is not part of the MCP specification surface and is versioned and released independently.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,4 +25,4 @@ All required (non-experimental) features of the current spec, including the opti
 
 ## Out of scope for spec tracking
 
-The agent SDK (`agent/`, `agent/host/`, `cmd/agentchat`) is a separate track above the protocol layer, with its own roadmap in `docs/AGENT_SDK_ROADMAP.md`. It is not part of the MCP specification surface and is versioned and released independently.
+The agent SDK (`agent/`, `agent/host/`, `cmd/agentchat`) is a separate track above the protocol layer, with its own roadmap in `docs/AGENT_SDK_ROADMAP.md`. It is not part of the MCP specification surface and is versioned and released independently. Because it sits above the protocol layer, it may be extracted into its own repository in the future if that better serves its independent cadence; such a move would not affect the protocol modules or their consumers.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Report vulnerabilities privately through [GitHub private vulnerability reporting](https://github.com/panyam/mcpkit/security/advisories/new) on this repository. If that is unavailable, email sri.panyam@gmail.com with "mcpkit security" in the subject.
+
+Do not open a public issue for a suspected vulnerability.
+
+## Response expectations
+
+- Acknowledgement and triage within 2 business days.
+- Critical issues (CVSS 7.0 or higher, or anything that breaks core MCP operations such as connection establishment, message exchange, or the tools/resources/prompts primitives) are fixed or mitigated within 7 days, tracked under the `P0` label once disclosed.
+- A fix ships as a patch release on the current release line, with the advisory published after the release is available.
+
+## Supported versions
+
+The latest tagged minor release line receives security fixes. Older lines are fixed only when a patch backports cleanly.
+
+## Scope
+
+The root module and all sub-modules in this repository (`agent/`, `ext/auth/`, `ext/tasks/`, `ext/ui/`, `ext/otel/`, `experimental/...`). Continuous checks run via `make audit` (govulncheck, gosec, gitleaks, race detector) and in CI.

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,21 @@
+# Versioning
+
+mcpkit follows [semantic versioning](https://semver.org). The root module and all releasable sub-modules are tagged in lock-step at the same version via `make tag-push V=vX.Y.Z` (see `RELEASING.md`), so a single version string identifies a consistent set across modules.
+
+## Release types
+
+- **Stable releases** (`vX.Y.Z`): production-ready, published as GitHub Releases with notes in `CHANGELOG.md` and `docs/releases/vX.Y.Z.md`.
+- **Pre-releases** (`vX.Y.Z-bN`): beta tags cut for announcements or early adopters. Not production-ready and not covered by the compatibility expectations below.
+
+## Breaking change policy
+
+While the project is pre-1.0, breaking API changes may land in minor releases. They are handled deliberately:
+
+- Breaking changes are batched into planned bundles (for example the 0.4.0 bundle) rather than scattered across releases. Each bundle's scope lives in `CHANGELOG.md` and a `docs/releases/` document with per-change migration recipes.
+- Patch releases (`Z` bumps) never break API.
+- Public surfaces slated for removal carry `// Deprecated:` annotations for at least 12 months before removal, with a pointer to the migration doc. Spec-driven deprecations (such as SEP-2577) additionally respect the spec's own deprecation window.
+- No release removes an MCP protocol capability while the targeted spec version still requires it.
+
+## Compatibility expectations
+
+Within a minor line, upgrading a patch version is always safe. Across minor versions, read the `[X.Y.0]` entry in `CHANGELOG.md` first; if the release is a breaking bundle, the entry links the migration doc.


### PR DESCRIPTION
## Summary

Adds the policy documents that upstream's `tier-check` scores as Tier 1 policy signals, closing the doc-side gaps from the scorecard run on 2026-07-22 (which flagged SECURITY.md, DEPENDENCY_POLICY.md, ROADMAP.md, VERSIONING.md, and dependabot/renovate config as missing).

- `SECURITY.md`: private vulnerability reporting path, triage and P0 response expectations aligned with the tiering SLAs, supported versions, audit tooling.
- `DEPENDENCY_POLICY.md`: dep-light root module philosophy, Dependabot cadence, manual `make tidy-all` sweep for uncovered sub-modules, lock-step cross-module pins, security-update SLA.
- `ROADMAP.md`: points at the durable tracking surfaces (release tracker issues, CONFORMANCE.md, CHANGELOG, docs/releases) per the tiering doc's roadmap requirement; near-term items: stable v0.4.0 after the 2026-07-28 spec GA, client conformance harness, tier-advancement request. Agent SDK explicitly called out as a separate non-spec track.
- `VERSIONING.md`: semver, lock-step sub-module tagging, pre-release `-bN` convention, breaking-bundle policy, 12-month deprecation window.
- `.github/dependabot.yml`: weekly grouped gomod updates for root + ext modules, plus github-actions.

Docs only, no code change.