### PR TITLE
feat(agentchat): sub-agent tree gutter + compact tool header (1063 B4)

### DIFF
--- a/agent/host/render.go
+++ b/agent/host/render.go
@@ -364,19 +364,34 @@ func (r *renderer) On(ev HostEvent) {
 	}
 }
 
-// subAgent renders a persona's nested activity indented by depth and tagged
-// by scope: the tools it calls and its final answer. Other lifecycle events
-// (deltas, turn boundaries) are omitted to keep the nested transcript terse.
+// gutter renders a dim border-left tree indent for a sub-agent at the given
+// depth (1 = top-level persona, 2 = nested), so delegation reads as a tree
+// rather than flat two-space indentation (issue 1063 B4).
+func (r *renderer) gutter(depth int) string {
+	if depth < 1 {
+		return ""
+	}
+	return r.dim(strings.Repeat("│ ", depth))
+}
+
+// subAgent renders a persona's nested activity under a border-left gutter keyed
+// to depth and tagged by scope: the tools it calls (name + compact args) and
+// its final answer. Other lifecycle events (deltas, turn boundaries) are
+// omitted to keep the nested transcript terse.
 func (r *renderer) subAgent(sa agent.SubAgentEvent) {
-	indent := strings.Repeat("  ", sa.Depth)
+	g := r.gutter(sa.Depth)
 	switch sa.Event.Kind {
 	case agent.EventToolBegin:
-		if sa.Event.ToolCall != nil {
-			fmt.Fprintf(r.out, "%s%s\n", indent, r.dim("["+sa.Scope+"] · "+sa.Event.ToolCall.Name))
+		if tc := sa.Event.ToolCall; tc != nil {
+			line := "[" + sa.Scope + "] · " + tc.Name
+			if args := compactJSON(tc.Args); args != "" && args != "{}" {
+				line += "(" + args + ")"
+			}
+			fmt.Fprintf(r.out, "%s%s\n", g, r.dim(line))
 		}
 	case agent.EventTurnEnd:
 		if sa.Event.Result != nil && sa.Event.Result.Text != "" {
-			fmt.Fprintf(r.out, "%s%s\n", indent, r.dim("["+sa.Scope+"] → "+sa.Event.Result.Text))
+			fmt.Fprintf(r.out, "%s%s\n", g, r.dim("["+sa.Scope+"] → "+snippet(sa.Event.Result.Text, 200)))
 		}
 	}
 }

--- a/agent/host/render_test.go
+++ b/agent/host/render_test.go
@@ -1,11 +1,39 @@
 package host
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
 	"github.com/panyam/mcpkit/agent"
+	"github.com/panyam/mcpkit/core"
 )
+
+// TestRendererSubAgentGutter pins the border-left tree gutter (issue 1063 B4):
+// depth drives the number of gutter segments, the scope is tagged, and a tool
+// call shows name + compact args.
+func TestRendererSubAgentGutter(t *testing.T) {
+	var out strings.Builder
+	r := newRenderer(&out)
+	r.plain = true // strip ANSI so the gutter glyph is asserted directly
+
+	r.subAgent(agent.SubAgentEvent{Scope: "research", Depth: 1, Event: agent.Event{
+		Kind:     agent.EventToolBegin,
+		ToolCall: &agent.ToolCall{Name: "grep", Args: core.NewRawJSON(json.RawMessage(`{"q":"retry"}`))},
+	}})
+	r.subAgent(agent.SubAgentEvent{Scope: "research/inner", Depth: 2, Event: agent.Event{
+		Kind:   agent.EventTurnEnd,
+		Result: &agent.TurnResult{Text: "found 3"},
+	}})
+
+	got := out.String()
+	if !strings.Contains(got, "│ [research] · grep(") || !strings.Contains(got, `"q":"retry"`) {
+		t.Fatalf("depth-1 gutter/tool line wrong:\n%q", got)
+	}
+	if !strings.Contains(got, "│ │ [research/inner] → found 3") {
+		t.Fatalf("depth-2 line should carry two gutter segments:\n%q", got)
+	}
+}
 
 // TestRendererToolCancelledDistinctFromError pins that a user cancel
 // renders as an interrupt, not a failure.

--- a/cmd/agentchat/notebook.go
+++ b/cmd/agentchat/notebook.go
@@ -127,6 +127,15 @@ func (s *nbObserver) render(ev host.HostEvent) []tea.Msg {
 	var msgs []tea.Msg
 	seg := func() string { return strings.TrimRight(s.buf.String(), "\n") }
 
+	if ev.Kind == host.HostSubAgentEvent {
+		// Nested sub-agent activity accumulates into the currently open cell (the
+		// ⚙ delegation tool cell during a sub-agent call), so its tree-gutter
+		// lines nest inside that cell instead of spawning separate info cells
+		// (issue 1063 B4).
+		s.term.On(ev)
+		return append(msgs, nbLiveMsg(seg()))
+	}
+
 	if ev.Kind == host.HostRunnerEvent {
 		re := ev.RunnerEvent
 		// A tool-begin cuts the accumulated text into its own assistant cell

--- a/cmd/agentchat/notebook_test.go
+++ b/cmd/agentchat/notebook_test.go
@@ -256,6 +256,40 @@ func runnerEv(e agent.Event) host.HostEvent {
 	return host.HostEvent{Kind: host.HostRunnerEvent, RunnerEvent: e}
 }
 
+// TestNBObserver_SubAgentNestsInDelegationCell pins the B4 gutter/flat choice:
+// a sub-agent's activity accumulates into the open ⚙ delegation tool cell
+// rather than spawning its own info cells.
+func TestNBObserver_SubAgentNestsInDelegationCell(t *testing.T) {
+	subEv := func(e agent.Event) host.HostEvent {
+		return host.HostEvent{Kind: host.HostSubAgentEvent, SubAgent: agent.SubAgentEvent{Scope: "research", Depth: 1, Event: e}}
+	}
+	cells := nbCollectCells(
+		runnerEv(agent.Event{Kind: agent.EventToolBegin, ToolCall: &agent.ToolCall{Name: "research"}}),
+		subEv(agent.Event{Kind: agent.EventToolBegin, ToolCall: &agent.ToolCall{Name: "grep"}}),
+		subEv(agent.Event{Kind: agent.EventTurnEnd, Result: &agent.TurnResult{Text: "found 3"}}),
+		runnerEv(agent.Event{Kind: agent.EventToolEnd, ToolCall: &agent.ToolCall{Name: "research"}}),
+		turnDoneEv(),
+	)
+	var tool *nbCell
+	for i := range cells {
+		if strings.HasPrefix(cells[i].label, "⚙") {
+			tool = &cells[i]
+		}
+	}
+	if tool == nil {
+		t.Fatalf("no ⚙ delegation cell, got %+v", cells)
+	}
+	if !strings.Contains(tool.body, "[research] · grep") || !strings.Contains(tool.body, "[research] → found 3") {
+		t.Fatalf("sub-agent activity did not nest in the delegation cell:\n%q", tool.body)
+	}
+	// and it did NOT leak into standalone info cells
+	for _, c := range cells {
+		if c.label == "info" && strings.Contains(c.body, "[research]") {
+			t.Fatalf("sub-agent line leaked into a separate info cell: %+v", c)
+		}
+	}
+}
+
 func turnDoneEv() host.HostEvent {
 	return host.HostEvent{Kind: host.HostTurnDone, Result: &agent.TurnResult{Steps: 1}}
 }

--- a/cmd/agentchat/tui.go
+++ b/cmd/agentchat/tui.go
@@ -142,10 +142,12 @@ func (s *tuiObserver) renderBlocks() string {
 }
 
 // isBoundary reports whether an event closes a scrollback segment. Every
-// discrete event commits immediately; only the streaming turn
-// (HostRunnerEvent) accumulates live until a non-runner event closes it.
+// discrete event commits immediately; the streaming turn (HostRunnerEvent) and
+// nested sub-agent activity (HostSubAgentEvent) accumulate live so the
+// sub-agent's tree-gutter lines nest under the main turn instead of committing
+// as fragmented separate blocks (issue 1063 B4).
 func isBoundary(k host.HostEventKind) bool {
-	return k != host.HostRunnerEvent
+	return k != host.HostRunnerEvent && k != host.HostSubAgentEvent
 }
 
 func (s *tuiObserver) On(ev host.HostEvent) {

--- a/cmd/agentchat/tui_test.go
+++ b/cmd/agentchat/tui_test.go
@@ -69,9 +69,12 @@ func TestRecallHistoryEmpty(t *testing.T) {
 }
 
 func TestIsBoundary(t *testing.T) {
-	// the streaming turn accumulates live; everything else closes a segment
-	if isBoundary(host.HostRunnerEvent) {
-		t.Fatal("HostRunnerEvent should stream live, not commit")
+	// the streaming turn + nested sub-agent activity accumulate live; every
+	// other event closes a segment
+	for _, k := range []host.HostEventKind{host.HostRunnerEvent, host.HostSubAgentEvent} {
+		if isBoundary(k) {
+			t.Fatalf("kind %v should stream live, not commit", k)
+		}
 	}
 	for _, k := range []host.HostEventKind{
 		host.HostTurnDone, host.HostTurnFailed, host.HostCommandResult,


### PR DESCRIPTION
> **Stacked on #1094 (C2).** Base is `feat/1063-c2-keybindings`, so this PR's diff shows only the B4 changes. Per the repo's stacked-PR rule a non-`main` base gets no CI — verified locally with `go test` on `agent/host` + `cmd/agentchat`; I'll retarget to `main` once C2 merges to fire checks.

## What changes

Nested sub-agent activity now renders under a dim **border-left tree gutter** (`│ ` per depth) tagged by scope, with the tool line carrying **name + compact args**, so a persona delegating to tools reads as a tree instead of flat two-space indentation. This is item **B4** of the TUI layout track (issue 1063).

Both surfaces now **stream** sub-agent events into the active turn instead of fragmenting it:
- **inline** — `HostSubAgentEvent` is no longer a commit boundary, so the gutter lines accumulate into the main turn block and commit together (previously each sub-agent event committed as its own fragment).
- **notebook** — sub-agent events accumulate into the open `⚙` delegation tool cell (the *gutter/flat* choice), instead of spawning separate `info` cells. Folding the delegation cell hides its whole sub-tree.

The inline surface can't collapse committed scrollback, so "collapsible tool cells" there is out of scope by construction (same constraint as B1/B2); the notebook already folds them.

## Reviewer's guide

Read in this order:
1. [agent/host/render.go](https://github.com/panyam/mcpkit/pull/1097/files#diff-da3546e85434193f7b8b2df15f4f6d6df496b616b9e0b0b8c4299cd4576e044a) — start here. `gutter(depth)` + `subAgent()` using it; the tool line now appends compact args. This is the shared terminal renderer both surfaces reuse.
2. [cmd/agentchat/tui.go](https://github.com/panyam/mcpkit/pull/1097/files#diff-0e29207287df07cecf17e04df9f99e726ae789983f7e3ce007bb6282029b4db6) — `isBoundary` now treats `HostSubAgentEvent` as non-boundary (streams into the turn block).
3. [cmd/agentchat/notebook.go](https://github.com/panyam/mcpkit/pull/1097/files#diff-8a79677a206f62f0abeebce75abd2fbafac2dc1be85310113e702bebc42624b1) — `nbObserver.render` routes `HostSubAgentEvent` into the current cell buffer.
4. [agent/host/render_test.go](https://github.com/panyam/mcpkit/pull/1097/files#diff-50fa3906597449e69d5cae6454e95743166803ffdfa51912d65a494662c11239), [cmd/agentchat/notebook_test.go](https://github.com/panyam/mcpkit/pull/1097/files#diff-12e612880a5d601118bba88764d9d1ff5815b9406c3ffb4e5a61ca6e9c4188a1), `tui_test.go` — acceptance for the gutter, the nesting, and the boundary change.

## Decision log

- **Gutter/flat, not a nested cell tree.** Confirmed with the user via a rendered preview: the sub-agent's inner activity nests as gutter lines *inside* the one delegation cell, rather than each sub-tool becoming its own foldable child cell. The latter would require the notebook to model a cell tree (parent/child + per-node fold) — a much larger refactor for marginal gain, since folding the delegation cell already hides the sub-tree.
- **Gutter lives in `agent/host/render.go`** because that's the shared terminal renderer both surfaces drive; no new type crosses a module boundary, so `agent/CONSTRAINTS.md` A6 is unaffected.
- **Stream sub-agent events into the turn** (both surfaces) rather than committing each separately — otherwise the gutter lines fragment the transcript (inline) or scatter into info cells (notebook).

## Risk / blast radius

- Affects: `agent/host` (terminal renderer, used by the plain REPL + both TUI surfaces) and `cmd/agentchat`. No core/client changes, no new dependency.
- Tests: `TestRendererSubAgentGutter`, `TestNBObserver_SubAgentNestsInDelegationCell`, updated `TestIsBoundary`; full `agent/host` + `cmd/agentchat` suites pass.
- Be paranoid about: the inline `isBoundary` change — a sub-agent event mid-turn must not prematurely commit; and that a sub-agent event outside a tool call (shouldn't happen) still renders sanely.

## Before / after

Inline committed block — main agent delegates to a `research` persona that runs `grep` + `read_file` (dim styling shown as plain here):

```
before (flat indent, fragmented commits):
  Let me ask the research agent.
  [research] · grep
  [research] · read_file
  [research] → found 3 matches

after (tree gutter, one committed turn, args shown):
  Let me ask the research agent.
⚙ research()
│ [research] · grep({"q":"retry"})
│ [research] · read_file({"path":"config.go"})
│ [research] → found 3 matches
  ✓ research:
— 2 step(s), … tokens
```

Depth nests: a depth-2 sub-agent (a persona calling a persona) renders `│ │ [outer/inner] → …`.

```mermaid
flowchart TB
  subgraph after [After]
    T["⚙ research (delegation cell / turn block)"]
    T --> G1["│ [research] · grep(args)"]
    T --> G2["│ [research] · read_file(args)"]
    T --> G3["│ [research] → result"]
  end
  subgraph before [Before]
    A["⚙ research"]
    B1["[research] · grep  (own fragment/info cell)"]
    B2["[research] · read_file  (own fragment/info cell)"]
    B3["[research] → result  (own fragment/info cell)"]
  end
```

## Out of scope (deferred, same track — issue 1063)

- AdaptiveColor + `--no-color` (E), grapheme-width (F2), resize reflow (F1).
- Foldable per-sub-tool child cells in the notebook (the nested-cell-tree option we deliberately did not take).

