### PR TITLE
feat(conformance): wire client suites into tier-check + testconf-client target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,17 @@ targeted spec version.
   for external `QuotaStore` implementors (experimental surface). (issue 774)
 
 ### Added / Fixed
+- **Client conformance wired into tier-check.** `scripts/refresh-conformance.sh`
+  now builds `cmd/testclient` and passes it via `--client-cmd`, so
+  `CONFORMANCE.md` scores the client scenario suites (Client: Core, Client:
+  Auth) alongside the server ones — previously reported as skipped 0/0. New
+  `testconf-client` target runs upstream's full client suite (core + auth +
+  backcompat + extensions + draft, the same set tier-check runs) against
+  `conformance/baseline.yml`. `cmd/testclient`'s best-effort fallback tool
+  call now synthesizes arguments from the tool's input schema instead of
+  sending empty args (fixes the `tools_call` scenario, which grades argument
+  types). Remaining client failures are extension/draft/backcompat categories,
+  annotated in `conformance/known-gaps.yaml`.
 - **`core.RawJSON`** — a typed, parse-once wrapper for JSON-RPC raw values
   (params / `_meta` / …) with `Bind` / `Meta` / `Field` helpers; wire-transparent
   (round-trips identically to `json.RawMessage`). This is the read-side type

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ just test-ui           # ext/ui sub-module
 just test-e2e          # E2E tests (auth + apps)
 just testconf          # MCP conformance suite (needs Node.js)
 just testconfauth      # Auth conformance (client OAuth)
+just testconf-client   # Full client conformance (core + auth + extensions) — same set tier-check --client-cmd runs
 just testconf-tasks    # Tasks v1 conformance (27 scenarios, local; 26 pass + 1 skip — v1 sampling push vs 2.0 SDK client)
 just testconf-tasks-v2 # SEP-2663 — upstream @ MCPCONFORMANCE_TASKS_V2_PATH + mcpkit-local stricter sentinel
 just testconf-mrtr     # SEP-2322 — upstream @ MCPCONFORMANCE_MRTR_PATH + mcpkit-local stricter sentinel

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -30,14 +30,14 @@ Needs Node.js 22+ and a clone of `modelcontextprotocol/conformance` at `../conf-
 ---
 
 <!-- begin:generated -->
-<!-- generated against upstream-conformance@794dcab99ed1ef2b89607be9999574140ea5c96e · protocol 2025-11-25 · regenerate via scripts/refresh-conformance.sh -->
+<!-- generated against upstream-conformance@da56f6631c83bec2b3b7e40a82f392ae360b790c · protocol 2025-11-25 · regenerate via scripts/refresh-conformance.sh -->
 
 ## Conformance Summary
 
 | Surface | Scenarios pass/total | Checks pass/fail |
 |---|---:|---:|
 | Server | 30/30 | 42/0 |
-| Client | 0/0 | 0/0 |
+| Client | 37/43 | 479/17 |
 
 ## mcpkit-local Conformance Suites
 
@@ -49,11 +49,13 @@ These suites exercise SEP-specific behavior beyond what upstream's tier-check co
 | `testconf-mrtr` | SEP-2322 MRTR | 8e | **PASS** | [`modelcontextprotocol/conformance@main`](https://github.com/modelcontextprotocol/conformance/tree/main) | — |
 | `testconf-file-inputs` | SEP-2356 File inputs | 8f | **PASS** | [`panyam/mcpconformance@pending`](https://github.com/panyam/mcpconformance/tree/pending) | — |
 | `testconf-auth-server` | MCP authz 2025-11-25 | 8g | **PASS** | [`panyam/mcpconformance@pending`](https://github.com/panyam/mcpconformance/tree/pending) | — |
-| `testconf-stateless` | SEP-2575 Stateless wire | - | **PASS**<sup>1</sup> | [`modelcontextprotocol/conformance@main`](https://github.com/modelcontextprotocol/conformance/tree/main) | — |
-| `testconf-skills` | SEP-2640 Skills | 8h | _INFO_<sup>2</sup> | [`panyam/mcpconformance@chore/sep-2640-yaml`](https://github.com/panyam/mcpconformance/tree/chore/sep-2640-yaml) | mcpkit 567 |
+| `testconf-client` | Client core + auth (full suite) | - | **PASS**<sup>1</sup> | [`modelcontextprotocol/conformance@main`](https://github.com/modelcontextprotocol/conformance/tree/main) | — |
+| `testconf-stateless` | SEP-2575 Stateless wire | - | **PASS**<sup>2</sup> | [`modelcontextprotocol/conformance@main`](https://github.com/modelcontextprotocol/conformance/tree/main) | — |
+| `testconf-skills` | SEP-2640 Skills | 8h | _INFO_<sup>3</sup> | [`panyam/mcpconformance@chore/sep-2640-yaml`](https://github.com/panyam/mcpconformance/tree/chore/sep-2640-yaml) | mcpkit 567 |
 
-<sup>1</sup> 30/30 as of upstream 0.2.0-alpha.9 (#376 fixed the former array-vs-object requiredCapabilities test).
-<sup>2</sup> Fixture spawns and runs cleanly. Fork-side Scenario classes blocked on WG iteration of sep-2640.yaml in panyam/mcpconformance PR 330.
+<sup>1</sup> Same scenario set tier-check's --client-cmd runs. Expected failures (extension + draft + backcompat categories, none tier-scored) live in conformance/baseline.yml.
+<sup>2</sup> 30/30 as of upstream 0.2.0-alpha.9 (#376 fixed the former array-vs-object requiredCapabilities test).
+<sup>3</sup> Fixture spawns and runs cleanly. Fork-side Scenario classes blocked on WG iteration of sep-2640.yaml in panyam/mcpconformance PR 330.
 
 ### Setup — clone the right worktree per suite
 
@@ -65,6 +67,7 @@ Each suite's Makefile target reads `MCPCONFORMANCE_*_PATH` to find its scenario 
 | `testconf-mrtr` | `MCPCONFORMANCE_MRTR_PATH` | `../conf-upstream-main` | `git clone -b main https://github.com/modelcontextprotocol/conformance.git ../conf-upstream-main` |
 | `testconf-file-inputs` | `MCPCONFORMANCE_FILE_INPUTS_PATH` | `../conf-pending` | `git clone -b pending https://github.com/panyam/mcpconformance.git ../conf-pending` |
 | `testconf-auth-server` | `MCPCONFORMANCE_AUTH_PATH` | `../conf-pending` | `git clone -b pending https://github.com/panyam/mcpconformance.git ../conf-pending` |
+| `testconf-client` | `MCPCONFORMANCE_CLIENT_PATH` | `../conf-upstream-main` | `git clone -b main https://github.com/modelcontextprotocol/conformance.git ../conf-upstream-main` |
 | `testconf-stateless` | `MCPCONFORMANCE_STATELESS_PATH` | `../conf-upstream-main` | `git clone -b main https://github.com/modelcontextprotocol/conformance.git ../conf-upstream-main` |
 | `testconf-skills` | `MCPCONFORMANCE_SKILLS_PATH` | `../conf-skills` | `git clone -b chore/sep-2640-yaml https://github.com/panyam/mcpconformance.git ../conf-skills` |
 
@@ -97,7 +100,7 @@ Per-SEP breakdown of upstream traceability — what is exercised, what is intent
 
 **Tested (1)**
 
-- [`sep-837-application-type-present`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-837.yaml)
+- [`sep-837-application-type-present`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-837.yaml)
 
 <a id="sep-837-excluded"></a>
 
@@ -122,7 +125,7 @@ _None._
 
 **Tested (1)**
 
-- [`sep-2106-no-network-ref-deref`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2106.yaml)
+- [`sep-2106-no-network-ref-deref`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2106.yaml)
 
 <a id="sep-2106-excluded"></a>
 
@@ -147,8 +150,8 @@ _None._
 
 **Tested (2)**
 
-- [`sep-2164-no-empty-contents`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2164.yaml)
-- [`sep-2164-error-code`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2164.yaml)
+- [`sep-2164-no-empty-contents`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2164.yaml)
+- [`sep-2164-error-code`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2164.yaml)
 
 <a id="sep-2164-excluded"></a>
 
@@ -170,7 +173,7 @@ _None._
 
 **Tested (1)**
 
-- [`sep-2207-client-metadata-grant-types`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2207.yaml)
+- [`sep-2207-client-metadata-grant-types`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2207.yaml)
 
 <a id="sep-2207-excluded"></a>
 
@@ -194,24 +197,24 @@ _None._
 
 **Tested (18)**
 
-- [`sep-2243-client-includes-standard-headers`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2243.yaml)
-- [`sep-2243-header-name-case-insensitive`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2243.yaml)
-- [`sep-2243-server-reject-invalid-headers`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2243.yaml)
-- [`sep-2243-server-reject-error-code`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2243.yaml)
-- [`sep-2243-client-supports-custom-headers`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2243.yaml)
-- [`sep-2243-client-mirrors-designated-params`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2243.yaml)
-- [`sep-2243-x-mcp-header-not-empty`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2243.yaml)
-- [`sep-2243-x-mcp-header-charset`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2243.yaml)
-- [`sep-2243-x-mcp-header-unique`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2243.yaml)
-- [`sep-2243-x-mcp-header-primitive-only`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2243.yaml)
-- [`sep-2243-client-reject-invalid-tool`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2243.yaml)
-- [`sep-2243-client-encode-values`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2243.yaml)
-- [`sep-2243-client-base64-unsafe`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2243.yaml)
-- [`sep-2243-server-decode-base64`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2243.yaml)
-- [`sep-2243-client-omit-null`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2243.yaml)
-- [`sep-2243-server-reject-invalid-param-chars`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2243.yaml)
-- [`sep-2243-server-validate-param-match`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2243.yaml)
-- [`sep-2243-server-reject-param-mismatch`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2243.yaml)
+- [`sep-2243-client-includes-standard-headers`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2243.yaml)
+- [`sep-2243-header-name-case-insensitive`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2243.yaml)
+- [`sep-2243-server-reject-invalid-headers`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2243.yaml)
+- [`sep-2243-server-reject-error-code`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2243.yaml)
+- [`sep-2243-client-supports-custom-headers`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2243.yaml)
+- [`sep-2243-client-mirrors-designated-params`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2243.yaml)
+- [`sep-2243-x-mcp-header-not-empty`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2243.yaml)
+- [`sep-2243-x-mcp-header-charset`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2243.yaml)
+- [`sep-2243-x-mcp-header-unique`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2243.yaml)
+- [`sep-2243-x-mcp-header-primitive-only`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2243.yaml)
+- [`sep-2243-client-reject-invalid-tool`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2243.yaml)
+- [`sep-2243-client-encode-values`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2243.yaml)
+- [`sep-2243-client-base64-unsafe`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2243.yaml)
+- [`sep-2243-server-decode-base64`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2243.yaml)
+- [`sep-2243-client-omit-null`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2243.yaml)
+- [`sep-2243-server-reject-invalid-param-chars`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2243.yaml)
+- [`sep-2243-server-validate-param-match`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2243.yaml)
+- [`sep-2243-server-reject-param-mismatch`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2243.yaml)
 
 <a id="sep-2243-excluded"></a>
 
@@ -228,8 +231,8 @@ _None._
 
 **Untested (2)**
 
-- [`sep-2243-server-not-expect-null`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2243.yaml) — Parameter value is null or omitted: Server MUST NOT expect the header.
-- [`sep-2243-server-reject-missing-required`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2243.yaml) — Required parameter is omitted: Server MUST reject with JSON-RPC error.
+- [`sep-2243-server-not-expect-null`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2243.yaml) — Parameter value is null or omitted: Server MUST NOT expect the header.
+- [`sep-2243-server-reject-missing-required`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2243.yaml) — Required parameter is omitted: Server MUST reject with JSON-RPC error.
 
 ### SEP-2260
 
@@ -270,23 +273,23 @@ _None._
 
 **Tested (17)**
 
-- [`sep-2322-result-type-included`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2322.yaml)
-- [`sep-2322-default-result-type-complete`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2322.yaml)
-- [`sep-2322-not-on-unsupported-requests`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2322.yaml)
-- [`sep-2322-elicitation-incomplete`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2322.yaml)
-- [`sep-2322-sampling-incomplete`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2322.yaml)
-- [`sep-2322-list-roots-incomplete`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2322.yaml)
-- [`sep-2322-reject-tampered-state`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2322.yaml)
-- [`sep-2322-request-state-incomplete`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2322.yaml)
-- [`sep-2322-respect-client-capabilities`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2322.yaml)
-- [`sep-2322-client-request-state-echoed`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2322.yaml)
-- [`sep-2322-client-no-state-omitted`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2322.yaml)
-- [`sep-2322-client-jsonrpc-id-different`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2322.yaml)
-- [`sep-2322-client-parallel-isolation`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2322.yaml)
-- [`sep-2322-validate-input-responses`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2322.yaml)
-- [`sep-2322-error-on-protocol-error`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2322.yaml)
-- [`sep-2322-ignore-unexpected-params`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2322.yaml)
-- [`sep-2322-missing-response-rerequests`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2322.yaml)
+- [`sep-2322-result-type-included`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2322.yaml)
+- [`sep-2322-default-result-type-complete`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2322.yaml)
+- [`sep-2322-not-on-unsupported-requests`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2322.yaml)
+- [`sep-2322-elicitation-incomplete`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2322.yaml)
+- [`sep-2322-sampling-incomplete`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2322.yaml)
+- [`sep-2322-list-roots-incomplete`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2322.yaml)
+- [`sep-2322-reject-tampered-state`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2322.yaml)
+- [`sep-2322-request-state-incomplete`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2322.yaml)
+- [`sep-2322-respect-client-capabilities`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2322.yaml)
+- [`sep-2322-client-request-state-echoed`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2322.yaml)
+- [`sep-2322-client-no-state-omitted`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2322.yaml)
+- [`sep-2322-client-jsonrpc-id-different`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2322.yaml)
+- [`sep-2322-client-parallel-isolation`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2322.yaml)
+- [`sep-2322-validate-input-responses`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2322.yaml)
+- [`sep-2322-error-on-protocol-error`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2322.yaml)
+- [`sep-2322-ignore-unexpected-params`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2322.yaml)
+- [`sep-2322-missing-response-rerequests`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2322.yaml)
 
 <a id="sep-2322-excluded"></a>
 
@@ -323,7 +326,7 @@ _None._
 
 **Tested (1)**
 
-- [`sep-2350-scope-union-on-reauth`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2350.yaml)
+- [`sep-2350-scope-union-on-reauth`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2350.yaml)
 
 <a id="sep-2350-excluded"></a>
 
@@ -346,9 +349,9 @@ _None._
 
 **Tested (3)**
 
-- [`sep-2352-no-cross-as-credential-reuse`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2352.yaml)
-- [`sep-2352-no-reuse-on-as-change`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2352.yaml)
-- [`sep-2352-reregister-on-as-change`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2352.yaml)
+- [`sep-2352-no-cross-as-credential-reuse`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2352.yaml)
+- [`sep-2352-no-reuse-on-as-change`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2352.yaml)
+- [`sep-2352-reregister-on-as-change`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2352.yaml)
 
 <a id="sep-2352-excluded"></a>
 
@@ -372,12 +375,12 @@ _None._
 
 **Tested (6)**
 
-- [`sep-2468-client-validate-metadata-issuer`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2468.yaml)
-- [`sep-2468-client-compare-iss-supported`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2468.yaml)
-- [`sep-2468-client-reject-missing-iss`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2468.yaml)
-- [`sep-2468-client-compare-iss-unadvertised`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2468.yaml)
-- [`sep-2468-client-proceed-no-iss`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2468.yaml)
-- [`sep-2468-client-no-normalization`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2468.yaml)
+- [`sep-2468-client-validate-metadata-issuer`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2468.yaml)
+- [`sep-2468-client-compare-iss-supported`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2468.yaml)
+- [`sep-2468-client-reject-missing-iss`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2468.yaml)
+- [`sep-2468-client-compare-iss-unadvertised`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2468.yaml)
+- [`sep-2468-client-proceed-no-iss`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2468.yaml)
+- [`sep-2468-client-no-normalization`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2468.yaml)
 
 <a id="sep-2468-excluded"></a>
 
@@ -401,13 +404,13 @@ _None._
 
 **Tested (7)**
 
-- [`sep-2549-tools-list-caching-hints`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2549.yaml)
-- [`sep-2549-prompts-list-caching-hints`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2549.yaml)
-- [`sep-2549-resources-list-caching-hints`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2549.yaml)
-- [`sep-2549-resources-templates-list-caching-hints`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2549.yaml)
-- [`sep-2549-resources-read-caching-hints`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2549.yaml)
-- [`sep-2549-ttl-non-negative`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2549.yaml)
-- [`sep-2549-cache-scope-valid`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2549.yaml)
+- [`sep-2549-tools-list-caching-hints`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2549.yaml)
+- [`sep-2549-prompts-list-caching-hints`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2549.yaml)
+- [`sep-2549-resources-list-caching-hints`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2549.yaml)
+- [`sep-2549-resources-templates-list-caching-hints`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2549.yaml)
+- [`sep-2549-resources-read-caching-hints`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2549.yaml)
+- [`sep-2549-ttl-non-negative`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2549.yaml)
+- [`sep-2549-cache-scope-valid`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2549.yaml)
 
 <a id="sep-2549-excluded"></a>
 
@@ -441,28 +444,28 @@ _None._
 
 **Tested (22)**
 
-- [`sep-2575-client-populates-meta`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2575.yaml)
-- [`sep-2575-server-rejects-undeclared-capability`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2575.yaml)
-- [`sep-2575-missing-capability-http-400`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2575.yaml)
-- [`sep-2575-server-tags-subscription-id`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2575.yaml)
-- [`sep-2575-server-unsupported-version-error`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2575.yaml)
-- [`sep-2575-client-retry-supported-version`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2575.yaml)
-- [`sep-2575-server-implements-discover`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2575.yaml)
-- [`sep-2575-http-server-no-independent-requests-on-stream`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2575.yaml)
-- [`sep-2575-http-client-sends-version-header`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2575.yaml)
-- [`sep-2575-http-version-header-matches-meta`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2575.yaml)
-- [`sep-2575-http-server-header-mismatch-400`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2575.yaml)
-- [`sep-2575-http-server-unsupported-version-400`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2575.yaml)
-- [`sep-2575-http-server-method-not-found-404`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2575.yaml)
-- [`sep-2575-server-honors-notification-filter`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2575.yaml)
-- [`sep-2575-server-sends-subscription-ack`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2575.yaml)
-- [`sep-2575-client-declares-elicitation-capability`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2575.yaml)
-- [`sep-2575-client-declares-roots-capability`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2575.yaml)
-- [`sep-2575-client-declares-sampling-capability`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2575.yaml)
-- [`sep-2575-server-declares-prompts-in-discover`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2575.yaml)
-- [`sep-2575-server-sends-prompts-list-changed-on-subscription`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2575.yaml)
-- [`sep-2575-server-sends-tools-list-changed-on-subscription`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2575.yaml)
-- [`sep-2575-server-no-log-without-loglevel`](https://github.com/modelcontextprotocol/conformance/blob/794dcab99ed1ef2b89607be9999574140ea5c96e/src/seps/sep-2575.yaml)
+- [`sep-2575-client-populates-meta`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2575.yaml)
+- [`sep-2575-server-rejects-undeclared-capability`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2575.yaml)
+- [`sep-2575-missing-capability-http-400`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2575.yaml)
+- [`sep-2575-server-tags-subscription-id`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2575.yaml)
+- [`sep-2575-server-unsupported-version-error`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2575.yaml)
+- [`sep-2575-client-retry-supported-version`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2575.yaml)
+- [`sep-2575-server-implements-discover`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2575.yaml)
+- [`sep-2575-http-server-no-independent-requests-on-stream`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2575.yaml)
+- [`sep-2575-http-client-sends-version-header`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2575.yaml)
+- [`sep-2575-http-version-header-matches-meta`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2575.yaml)
+- [`sep-2575-http-server-header-mismatch-400`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2575.yaml)
+- [`sep-2575-http-server-unsupported-version-400`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2575.yaml)
+- [`sep-2575-http-server-method-not-found-404`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2575.yaml)
+- [`sep-2575-server-honors-notification-filter`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2575.yaml)
+- [`sep-2575-server-sends-subscription-ack`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2575.yaml)
+- [`sep-2575-client-declares-elicitation-capability`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2575.yaml)
+- [`sep-2575-client-declares-roots-capability`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2575.yaml)
+- [`sep-2575-client-declares-sampling-capability`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2575.yaml)
+- [`sep-2575-server-declares-prompts-in-discover`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2575.yaml)
+- [`sep-2575-server-sends-prompts-list-changed-on-subscription`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2575.yaml)
+- [`sep-2575-server-sends-tools-list-changed-on-subscription`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2575.yaml)
+- [`sep-2575-server-no-log-without-loglevel`](https://github.com/modelcontextprotocol/conformance/blob/da56f6631c83bec2b3b7e40a82f392ae360b790c/src/seps/sep-2575.yaml)
 
 <a id="sep-2575-excluded"></a>
 
@@ -492,6 +495,17 @@ _None._
 
 
 ## Open Gaps
+
+### Failing scenarios
+
+| Scenario | Surface | Checks fail/pass | Tracking |
+|---|---|---:|---|
+| `auth/2025-03-26-oauth-endpoint-fallback` | client | 3/0 | https://github.com/panyam/mcpkit/issues/451 — Wontfix — 2025-03-26 OAuth-endpoint root fallback removed by spec in 2025-06-18. mcpkit targets 2025-11-25+; see ext/auth/docs/DESIGN.md for the policy. |
+| `auth/2025-03-26-oauth-metadata-backcompat` | client | 4/0 | https://github.com/panyam/mcpkit/issues/451 — Wontfix — rootless OAuth metadata removed by spec in 2025-06-18. See ext/auth/docs/DESIGN.md. |
+| `auth/authorization-server-migration` | client | 1/2 | no tracking issue yet — Draft category, not tier-scored. Client does not yet re-register when the PRM's authorization server changes. |
+| `auth/dpop` | client | 3/9 | https://github.com/panyam/mcpkit/issues/803 — Extension category, not tier-scored. SEP-1932 DPoP deferred until the spec exits draft. |
+| `auth/dpop-nonce` | client | 5/9 | https://github.com/panyam/mcpkit/issues/803 — Extension category, not tier-scored. SEP-1932 DPoP server-required-nonce variant. |
+| `auth/wif-jwt-bearer` | client | 1/10 | no tracking issue yet — Extension category, not tier-scored. RFC 7523 JWT bearer grant via workload identity federation, not implemented. |
 
 ### Declared requirements with no emitted check
 

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,9 @@ testconf: ## Run MCP conformance test suite (delegates to conformance/Makefile)
 testconfauth: ## Run MCP Auth conformance suite (delegates to conformance/Makefile)
 	$(MAKE) -C conformance testconfauth
 
+testconf-client: ## Run full client conformance suite — core + auth + extensions (delegates to conformance/Makefile)
+	$(MAKE) -C conformance testconf-client
+
 testconf-tasks: ## Run MCP Tasks v1 conformance (delegates to conformance/Makefile)
 	$(MAKE) -C conformance testconf-tasks
 
@@ -419,5 +422,5 @@ setup: setup-tools setup-hooks ## Full development setup
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-18s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: build test test-examples test-race test-v cover cover-html cover-func cover-all test-auth test-ui test-skills test-mcpskills build-mcpskills test-mcpskills-walkthrough test-protogen test-e2e test-experimental test-apps-playwright test-apps-playwright-docker test-apps-playwright-all test-apps-playwright-docker-all refresh-visual-gallery release-audit-apps demo-app demo-upstream testkcl testkcl-auto testall test-report smoke smoke-wire verify-dual testconfall testconf testconfauth testconf-tasks testconf-tasks-v2 testconf-mrtr testconf-file-inputs testconf-auth-server testconf-elicitation testconf-skills testconf-external-checker refresh-conformance check-conformance-stale check-local-suites-stale check-snippets check-auth-markers refresh-apps-compat-report check-apps-compat-stale vet lint vulncheck seccheck secrets verify-submodule-deps audit ci ci-full serve serve-streamable serve-both tidy tidy-all bump-root collect-walkthroughs ghbuild ghserve ghdeploy tag tag-push setup-tools setup-hooks setup upkcl downkcl kcllogs build-bridge help
+.PHONY: build test test-examples test-race test-v cover cover-html cover-func cover-all test-auth test-ui test-skills test-mcpskills build-mcpskills test-mcpskills-walkthrough test-protogen test-e2e test-experimental test-apps-playwright test-apps-playwright-docker test-apps-playwright-all test-apps-playwright-docker-all refresh-visual-gallery release-audit-apps demo-app demo-upstream testkcl testkcl-auto testall test-report smoke smoke-wire verify-dual testconfall testconf testconfauth testconf-client testconf-tasks testconf-tasks-v2 testconf-mrtr testconf-file-inputs testconf-auth-server testconf-elicitation testconf-skills testconf-external-checker refresh-conformance check-conformance-stale check-local-suites-stale check-snippets check-auth-markers refresh-apps-compat-report check-apps-compat-stale vet lint vulncheck seccheck secrets verify-submodule-deps audit ci ci-full serve serve-streamable serve-both tidy tidy-all bump-root collect-walkthroughs ghbuild ghserve ghdeploy tag tag-push setup-tools setup-hooks setup upkcl downkcl kcllogs build-bridge help
 .DEFAULT_GOAL := help

--- a/cmd/testclient/args.go
+++ b/cmd/testclient/args.go
@@ -1,0 +1,61 @@
+package main
+
+// synthArgs builds a minimal argument map for a tool from its input schema so
+// best-effort fallback calls satisfy `required` instead of sending empty args
+// — conformance scenarios (e.g. tools_call) grade the argument types, not
+// just that a call happened. Placeholder per property: const > default >
+// first enum value > zero-ish value for the declared type.
+func synthArgs(schema any) map[string]any {
+	args := map[string]any{}
+	m, ok := schema.(map[string]any)
+	if !ok {
+		return args
+	}
+	props, _ := m["properties"].(map[string]any)
+	required, _ := m["required"].([]any)
+	for _, r := range required {
+		name, ok := r.(string)
+		if !ok {
+			continue
+		}
+		prop, _ := props[name].(map[string]any)
+		args[name] = placeholderFor(prop)
+	}
+	return args
+}
+
+func placeholderFor(prop map[string]any) any {
+	if prop == nil {
+		return "test"
+	}
+	if v, ok := prop["const"]; ok {
+		return v
+	}
+	if v, ok := prop["default"]; ok {
+		return v
+	}
+	if enum, ok := prop["enum"].([]any); ok && len(enum) > 0 {
+		return enum[0]
+	}
+	typ, _ := prop["type"].(string)
+	if typ == "" {
+		// JSON Schema allows "type": ["string", "null"] — use the first entry.
+		if types, ok := prop["type"].([]any); ok && len(types) > 0 {
+			typ, _ = types[0].(string)
+		}
+	}
+	switch typ {
+	case "number", "integer":
+		return 1
+	case "boolean":
+		return true
+	case "array":
+		return []any{}
+	case "object":
+		return synthArgs(prop)
+	case "null":
+		return nil
+	default:
+		return "test"
+	}
+}

--- a/cmd/testclient/args_test.go
+++ b/cmd/testclient/args_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSynthArgs(t *testing.T) {
+	cases := []struct {
+		name   string
+		schema any
+		want   map[string]any
+	}{
+		{
+			name: "required number and string",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"a": map[string]any{"type": "number"},
+					"b": map[string]any{"type": "string"},
+				},
+				"required": []any{"a", "b"},
+			},
+			want: map[string]any{"a": 1, "b": "test"},
+		},
+		{
+			name: "optional properties omitted",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"a": map[string]any{"type": "number"},
+					"b": map[string]any{"type": "string"},
+				},
+				"required": []any{"a"},
+			},
+			want: map[string]any{"a": 1},
+		},
+		{
+			name: "const default and enum win over type",
+			schema: map[string]any{
+				"properties": map[string]any{
+					"c": map[string]any{"type": "string", "const": "fixed"},
+					"d": map[string]any{"type": "number", "default": 42},
+					"e": map[string]any{"type": "string", "enum": []any{"x", "y"}},
+				},
+				"required": []any{"c", "d", "e"},
+			},
+			want: map[string]any{"c": "fixed", "d": 42, "e": "x"},
+		},
+		{
+			name: "boolean array object null",
+			schema: map[string]any{
+				"properties": map[string]any{
+					"f": map[string]any{"type": "boolean"},
+					"g": map[string]any{"type": "array"},
+					"h": map[string]any{
+						"type":       "object",
+						"properties": map[string]any{"inner": map[string]any{"type": "integer"}},
+						"required":   []any{"inner"},
+					},
+					"i": map[string]any{"type": "null"},
+				},
+				"required": []any{"f", "g", "h", "i"},
+			},
+			want: map[string]any{
+				"f": true,
+				"g": []any{},
+				"h": map[string]any{"inner": 1},
+				"i": nil,
+			},
+		},
+		{
+			name: "type union takes first entry",
+			schema: map[string]any{
+				"properties": map[string]any{
+					"j": map[string]any{"type": []any{"integer", "null"}},
+				},
+				"required": []any{"j"},
+			},
+			want: map[string]any{"j": 1},
+		},
+		{
+			name: "required without property definition",
+			schema: map[string]any{
+				"required": []any{"mystery"},
+			},
+			want: map[string]any{"mystery": "test"},
+		},
+		{
+			name:   "non-map schema",
+			schema: "not a schema",
+			want:   map[string]any{},
+		},
+		{
+			name:   "nil schema",
+			schema: nil,
+			want:   map[string]any{},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := synthArgs(tc.schema)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("synthArgs() = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/testclient/main.go
+++ b/cmd/testclient/main.go
@@ -97,15 +97,17 @@ func main() {
 				// Directed: scenario specified exact toolCalls to invoke.
 				driveToolCalls(noAuthClient, ctx.ToolCalls)
 			case len(tools) > 0:
-				// Fallback: best-effort call the first tool, no args.
-				// Mirrors the OAuth-success path so scenarios that don't
-				// direct toolCalls still exercise a tools/call request
-				// against the server (required by e.g. SEP-2243
-				// http-invalid-tool-headers, which grades whether the
-				// client calls the valid_tool the server advertises).
+				// Fallback: best-effort call the first tool with
+				// schema-synthesized args. Mirrors the OAuth-success path
+				// so scenarios that don't direct toolCalls still exercise
+				// a tools/call request against the server (required by
+				// e.g. SEP-2243 http-invalid-tool-headers, which grades
+				// whether the client calls the valid_tool the server
+				// advertises, and tools_call, which grades the argument
+				// types).
 				toolName := tools[0].Name
 				log.Printf("Calling tool %q (no-auth fallback)...", toolName)
-				if _, err := noAuthClient.ToolCall(toolName, map[string]any{}); err != nil {
+				if _, err := noAuthClient.ToolCall(toolName, synthArgs(tools[0].InputSchema)); err != nil {
 					log.Printf("tools/call %q: %v (may be expected)", toolName, err)
 				}
 			}
@@ -165,10 +167,11 @@ func main() {
 			// Directed: scenario specified exact toolCalls to invoke.
 			driveToolCalls(c, ctx.ToolCalls)
 		case len(tools) > 0:
-			// Fallback: best-effort call the first tool, no args.
+			// Fallback: best-effort call the first tool with
+			// schema-synthesized args.
 			toolName := tools[0].Name
 			log.Printf("Calling tool %q (default fallback)...", toolName)
-			if _, err := c.ToolCall(toolName, map[string]any{}); err != nil {
+			if _, err := c.ToolCall(toolName, synthArgs(tools[0].InputSchema)); err != nil {
 				log.Printf("tools/call %q: %v (may be expected)", toolName, err)
 			} else {
 				log.Printf("tools/call %q: ok", toolName)

--- a/conformance/Makefile
+++ b/conformance/Makefile
@@ -30,7 +30,7 @@ include $(CONFORMANCE_DIR)/path-defaults.mk
 # grade mcpkit against every scenario upstream currently ships.
 MCPCONFORMANCE_BASE_PATH        ?= $(abspath $(REPO_ROOT)/../conf-upstream-main)
 
-.PHONY: test testconf testconfauth \
+.PHONY: test testconf testconfauth testconf-client \
         testconf-tasks testconf-tasks-v2 testconf-mrtr \
         testconf-file-inputs testconf-auth-server \
         testconf-stateless testconf-skills \
@@ -44,13 +44,16 @@ MCPCONFORMANCE_BASE_PATH        ?= $(abspath $(REPO_ROOT)/../conf-upstream-main)
 # exist (each target fail-fasts with a remediation message if missing). Fair
 # game: contributors should have all conf-* sibling clones before pushing
 # anything that touches conformance surfaces.
-test: testconf testconfauth testconf-tasks testconf-tasks-v2 testconf-mrtr testconf-file-inputs testconf-auth-server testconf-stateless testconf-skills testconf-upstream-audit refresh-conformance ## Run all conformance suites (needs fork worktrees + conf-upstream-main)
+test: testconf testconfauth testconf-client testconf-tasks testconf-tasks-v2 testconf-mrtr testconf-file-inputs testconf-auth-server testconf-stateless testconf-skills testconf-upstream-audit refresh-conformance ## Run all conformance suites (needs fork worktrees + conf-upstream-main)
 
 testconf: ## Run MCP conformance test suite (requires Node.js/npx)
 	cd $(REPO_ROOT) && bash scripts/conformance-test.sh
 
 testconfauth: ## Run MCP Auth conformance suite (client-side, requires mcpkit/auth)
 	cd $(REPO_ROOT) && bash scripts/conformance-auth-test.sh
+
+testconf-client: ## Run full client conformance suite — core + auth + backcompat + extensions (auto-builds testclient)
+	@bash $(CONFORMANCE_DIR)/scripts/conf-client.sh
 
 testconf-tasks: ## Run MCP Tasks v1 conformance (builds + starts server, runs tests, tears down)
 	@bash $(CONFORMANCE_DIR)/scripts/conf-tasks.sh

--- a/conformance/baseline.yml
+++ b/conformance/baseline.yml
@@ -44,3 +44,18 @@ client:
   # ext/auth/docs/DESIGN.md "Supported spec versions" for the policy.
   - auth/2025-03-26-oauth-endpoint-fallback # legacy OAuth-endpoint root fallback (#451 wontfix)
   - auth/2025-03-26-oauth-metadata-backcompat # legacy rootless OAuth metadata (#451 wontfix)
+
+  # --- Full client suite (testconf-client, --suite all) ---
+  # Everything below is extension or draft category upstream — none of these
+  # count toward tier scoring (tier-check excludes 'extension' and draft tags).
+
+  # Extension — SEP-1932 DPoP, deferred until the spec exits draft (issue 803)
+  - auth/dpop                               # DPoP proof on token request + resource calls
+  - auth/dpop-nonce                         # DPoP with server-required nonce
+
+  # Extension — workload identity federation, not implemented
+  - auth/wif-jwt-bearer                     # RFC 7523 JWT bearer grant via WIF
+
+  # Draft — informational, not tier-scored
+  - auth/authorization-server-migration     # re-registration when the PRM's AS changes
+  - auth/offline-access-scope               # offline_access request (warning: not requested)

--- a/conformance/justfile
+++ b/conformance/justfile
@@ -42,7 +42,7 @@ default:
 # surfaces.
 
 # Run all conformance suites (needs fork worktrees + conf-upstream-main)
-test: testconf testconfauth testconf-tasks testconf-tasks-v2 testconf-mrtr testconf-file-inputs testconf-auth-server testconf-stateless testconf-skills testconf-upstream-audit refresh-conformance
+test: testconf testconfauth testconf-client testconf-tasks testconf-tasks-v2 testconf-mrtr testconf-file-inputs testconf-auth-server testconf-stateless testconf-skills testconf-upstream-audit refresh-conformance
 
 # Run MCP conformance test suite (requires Node.js/npx)
 testconf:
@@ -51,6 +51,10 @@ testconf:
 # Run MCP Auth conformance suite (client-side, requires mcpkit/auth)
 testconfauth:
     cd {{REPO_ROOT}} && bash scripts/conformance-auth-test.sh
+
+# Run full client conformance suite — core + auth + backcompat + extensions (auto-builds testclient)
+testconf-client:
+    @bash {{CONFORMANCE_DIR}}/scripts/conf-client.sh
 
 # Run MCP Tasks v1 conformance (builds + starts server, runs tests, tears down)
 testconf-tasks:

--- a/conformance/known-gaps.yaml
+++ b/conformance/known-gaps.yaml
@@ -21,12 +21,24 @@ scenarios:
   "server-stateless":
     issue: "upstream conformance test bug"
     note: "ServerRejectsUndeclaredCapability checks requiredCapabilities as string-array but SEP-2575 schema says object — mcpkit follows schema. Tracked in CLAUDE.md gotchas."
-  "2025-03-26-oauth-endpoint-fallback":
+  "auth/2025-03-26-oauth-endpoint-fallback":
     issue: "https://github.com/panyam/mcpkit/issues/451"
     note: "Wontfix — 2025-03-26 OAuth-endpoint root fallback removed by spec in 2025-06-18. mcpkit targets 2025-11-25+; see ext/auth/docs/DESIGN.md for the policy."
-  "2025-03-26-oauth-metadata-backcompat":
+  "auth/2025-03-26-oauth-metadata-backcompat":
     issue: "https://github.com/panyam/mcpkit/issues/451"
     note: "Wontfix — rootless OAuth metadata removed by spec in 2025-06-18. See ext/auth/docs/DESIGN.md."
+  "auth/dpop":
+    issue: "https://github.com/panyam/mcpkit/issues/803"
+    note: "Extension category, not tier-scored. SEP-1932 DPoP deferred until the spec exits draft."
+  "auth/dpop-nonce":
+    issue: "https://github.com/panyam/mcpkit/issues/803"
+    note: "Extension category, not tier-scored. SEP-1932 DPoP server-required-nonce variant."
+  "auth/wif-jwt-bearer":
+    issue: "no tracking issue yet"
+    note: "Extension category, not tier-scored. RFC 7523 JWT bearer grant via workload identity federation, not implemented."
+  "auth/authorization-server-migration":
+    issue: "no tracking issue yet"
+    note: "Draft category, not tier-scored. Client does not yet re-register when the PRM's authorization server changes."
 
 checks:
   "sep-2243-server-not-expect-null":

--- a/conformance/local-suites.yaml
+++ b/conformance/local-suites.yaml
@@ -70,6 +70,17 @@ suites:
       path_var: MCPCONFORMANCE_AUTH_PATH
       default_path: ../conf-pending
 
+  - suite: testconf-client
+    sep: Client core + auth (full suite)
+    stage: "-"
+    status: PASS
+    source:
+      repo: modelcontextprotocol/conformance
+      branch: main
+      path_var: MCPCONFORMANCE_CLIENT_PATH
+      default_path: ../conf-upstream-main
+    note: "Same scenario set tier-check's --client-cmd runs. Expected failures (extension + draft + backcompat categories, none tier-scored) live in conformance/baseline.yml."
+
   - suite: testconf-stateless
     sep: SEP-2575 Stateless wire
     stage: "-"

--- a/conformance/path-defaults.just
+++ b/conformance/path-defaults.just
@@ -8,6 +8,7 @@
 # imported. conformance/justfile sets it as absolute_path(justfile_directory() / "..").
 
 MCPCONFORMANCE_AUTH_PATH := env('MCPCONFORMANCE_AUTH_PATH', absolute_path(REPO_ROOT / '../conf-pending'))
+MCPCONFORMANCE_CLIENT_PATH := env('MCPCONFORMANCE_CLIENT_PATH', absolute_path(REPO_ROOT / '../conf-upstream-main'))
 MCPCONFORMANCE_FILE_INPUTS_PATH := env('MCPCONFORMANCE_FILE_INPUTS_PATH', absolute_path(REPO_ROOT / '../conf-pending'))
 MCPCONFORMANCE_MRTR_PATH := env('MCPCONFORMANCE_MRTR_PATH', absolute_path(REPO_ROOT / '../conf-upstream-main'))
 MCPCONFORMANCE_SKILLS_PATH := env('MCPCONFORMANCE_SKILLS_PATH', absolute_path(REPO_ROOT / '../conf-skills'))

--- a/conformance/path-defaults.mk
+++ b/conformance/path-defaults.mk
@@ -8,6 +8,7 @@
 # included. conformance/Makefile sets it as $(abspath $(CONFORMANCE_DIR)/..).
 
 MCPCONFORMANCE_AUTH_PATH        ?= $(abspath $(REPO_ROOT)/../conf-pending)
+MCPCONFORMANCE_CLIENT_PATH      ?= $(abspath $(REPO_ROOT)/../conf-upstream-main)
 MCPCONFORMANCE_FILE_INPUTS_PATH ?= $(abspath $(REPO_ROOT)/../conf-pending)
 MCPCONFORMANCE_MRTR_PATH        ?= $(abspath $(REPO_ROOT)/../conf-upstream-main)
 MCPCONFORMANCE_SKILLS_PATH      ?= $(abspath $(REPO_ROOT)/../conf-skills)

--- a/conformance/path-defaults.sh
+++ b/conformance/path-defaults.sh
@@ -10,6 +10,7 @@
 # otherwise falls back to the sibling conf-* worktree default.
 
 : "${MCPCONFORMANCE_AUTH_PATH:="$REPO_ROOT/../conf-pending"}"
+: "${MCPCONFORMANCE_CLIENT_PATH:="$REPO_ROOT/../conf-upstream-main"}"
 : "${MCPCONFORMANCE_FILE_INPUTS_PATH:="$REPO_ROOT/../conf-pending"}"
 : "${MCPCONFORMANCE_MRTR_PATH:="$REPO_ROOT/../conf-upstream-main"}"
 : "${MCPCONFORMANCE_SKILLS_PATH:="$REPO_ROOT/../conf-skills"}"

--- a/conformance/scripts/conf-client.sh
+++ b/conformance/scripts/conf-client.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Client conformance — drives cmd/testclient through upstream's full client
+# suite (core + auth + backcompat + extensions + draft), the same set
+# tier-check's --client-cmd runs. Expected failures live in
+# conformance/baseline.yml (client section); the upstream runner exits 0
+# only when nothing outside that list fails and no listed entry passes
+# (stale-entry guard).
+#
+# Runner-agnostic: the Makefile + justfile `testconf-client` recipes call
+# this directly. REPO_ROOT + MCPCONFORMANCE_CLIENT_PATH resolve via
+# _common.sh (path-defaults.sh); override the latter via env.
+set -u
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_common.sh"
+
+require_conf_dir MCPCONFORMANCE_CLIENT_PATH \
+    "Clone https://github.com/modelcontextprotocol/conformance there:" \
+    "  git clone https://github.com/modelcontextprotocol/conformance.git \$MCPCONFORMANCE_CLIENT_PATH" \
+    "Or set MCPCONFORMANCE_CLIENT_PATH=<path-to-clone>."
+
+echo "Building testclient..."
+(cd "${REPO_ROOT}/cmd/testclient" && go build -buildvcs=false -o "${REPO_ROOT}/bin/testclient" .) || exit 1
+
+if [ ! -f "${MCPCONFORMANCE_CLIENT_PATH}/dist/index.js" ]; then
+    echo "Building upstream conformance dist/ (npm install)..."
+    (cd "${MCPCONFORMANCE_CLIENT_PATH}" && npm install --silent) || exit 1
+fi
+
+OUT=$(mktemp -d -t conf-client.XXXXXX)
+(cd "${MCPCONFORMANCE_CLIENT_PATH}" && \
+    node dist/index.js client \
+        --command "${REPO_ROOT}/bin/testclient" \
+        --suite all \
+        --expected-failures "${REPO_ROOT}/conformance/baseline.yml" \
+        -o "$OUT")
+RC=$?
+echo "testconf-client: upstream runner exit $RC (artifacts: $OUT)"
+if [ $RC -ne 0 ]; then
+    echo "A scenario outside conformance/baseline.yml failed, or a listed entry now passes (stale entry — remove it)."
+fi
+exit $RC

--- a/justfile
+++ b/justfile
@@ -114,6 +114,10 @@ testconf:
 testconfauth:
     just -f conformance/justfile testconfauth
 
+# Run full client conformance suite — core + auth + extensions (delegates to conformance/justfile)
+testconf-client:
+    just -f conformance/justfile testconf-client
+
 # Run MCP Tasks v1 conformance (delegates to conformance/justfile)
 testconf-tasks:
     just -f conformance/justfile testconf-tasks

--- a/scripts/refresh-conformance.sh
+++ b/scripts/refresh-conformance.sh
@@ -54,6 +54,9 @@ fi
 echo "=== Building cmd/testserver ==="
 (cd "$REPO_ROOT" && go build -o "$WORK_DIR/testserver" ./cmd/testserver)
 
+echo "=== Building cmd/testclient ==="
+(cd "$REPO_ROOT/cmd/testclient" && go build -buildvcs=false -o "$WORK_DIR/testclient" .)
+
 # Kill any stale process on the port to avoid connecting to old code.
 if lsof -i ":$PORT" -t >/dev/null 2>&1; then
     echo "Killing stale process on port $PORT..."
@@ -107,6 +110,7 @@ echo "=== Running upstream tier-check --output json ==="
 (cd "$CONF_DIR" && node dist/index.js tier-check \
     --repo panyam/mcpkit \
     --conformance-server-url "http://localhost:$PORT/mcp" \
+    --client-cmd "$WORK_DIR/testclient" \
     --output json \
     > "$WORK_DIR/scorecard.json")
 


### PR DESCRIPTION
## What changes

Upstream tier-check previously reported mcpkit's client conformance as skipped (0/0) because our harness only passed `--conformance-server-url`. This PR wires `cmd/testclient` in via `--client-cmd`, fixes the one tier-scoring failure (`tools_call`), and adds a `testconf-client` target that runs the same full client scenario set tier-check runs. `CONFORMANCE.md` now scores Client: Core and Client: Auth alongside the server: 37/43 scenarios, 479 checks passing.

## Reviewer's guide

Read in this order:
1. [cmd/testclient/args.go](https://github.com/panyam/mcpkit/pull/1098/files#diff-5dc8e5934517e1e30167bff66d3e2b5bdb6c423d378d3a94662a02ded48a3112) — start here. Schema-driven argument synthesis for best-effort fallback tool calls (const > default > enum > by-type placeholder).
2. [cmd/testclient/args_test.go](https://github.com/panyam/mcpkit/pull/1098/files#diff-33cc4d58054af5cbf775bcdeb61dc514f64812b857f7cad03aa043f73d0825f0) — acceptance for the above (8 table cases).
3. [cmd/testclient/main.go](https://github.com/panyam/mcpkit/pull/1098/files#diff-bc7a02b2751e1c671ee37f491a72c42030bf2566f6d0496f30ae2a0ab19ffaae) — the two fallback call sites switch from empty args to `synthArgs(tools[0].InputSchema)`.
4. [conformance/scripts/conf-client.sh](https://github.com/panyam/mcpkit/pull/1098/files#diff-ea345578ace4eeda5d23f60e7cfba245d5fad461e45e986ea96f6c27a97c4ec3) — the new suite driver; follows the conf-stateless.sh pattern (_common.sh + require_conf_dir).
5. [conformance/baseline.yml](https://github.com/panyam/mcpkit/pull/1098/files#diff-0bf2c40c9b3652a5564a2ae0433f3ef2bcfe8b65280907a930c2897972b7f0a2) — expected failures for the full suite: extension (dpop, dpop-nonce, wif-jwt-bearer), draft (authorization-server-migration, offline-access-scope). None are tier-scored.
6. [conformance/known-gaps.yaml](https://github.com/panyam/mcpkit/pull/1098/files#diff-bcd01920bd187fabe66d67bfeb497d62d841a9e3389985aac55b32955b6d2a30) — annotations for the report; existing 451 entries renamed to the `auth/`-prefixed names tier-check actually reports (they were silently failing to join before).
7. [scripts/refresh-conformance.sh](https://github.com/panyam/mcpkit/pull/1098/files#diff-3775227d6d2846bfa2da31ff1ede031280bd0cfd0dcd9e74828cc013993aed1c) — builds testclient, passes `--client-cmd`.

Skim or skip: `conformance/path-defaults.{sh,mk,just}` (generated), [CONFORMANCE.md](https://github.com/panyam/mcpkit/pull/1098/files#diff-d647b61d5d64e4801ec167193f4f207eb71d12b4ec92d5f08b2867673481b9de) (regenerated), Makefile/justfile passthroughs, CHANGELOG/CLAUDE.md doc lines.

## Decision log

- New `conf-client.sh` instead of generalizing `conformance-auth-test.sh`: the auth script uses the published npx package while tier-check runs the local worktree; the new script pins to `MCPCONFORMANCE_CLIENT_PATH` (default `../conf-upstream-main`) so `testconf-client` and tier-check grade the identical scenario set. The auth script is untouched, so `testconfauth` behavior is unchanged.
- `synthArgs` fills only `required` properties: minimal valid call, no guesses about optional-arg semantics.
- Full suite runtime is ~1.3s, safely inside tier-check's hardcoded 120s client-run timeout.

## Risk / blast radius

- Affects: conformance harness + `cmd/testclient` only; no library code.
- Tests covering this: `cmd/testclient` unit tests; `testconf-client` end-to-end (baseline-gated, exit 0); `testconfauth` still green (auth path untouched); refresh-conformance regenerated deterministically twice.
- Be paranoid about: the baseline's stale-entry guard — if upstream promotes an extension scenario or one starts passing, the run fails loudly and the baseline needs the entry removed.

## Before / after

Tier-check scorecard (run locally, 2026-07-22):

| | before | after |
|---|---|---|
| Client: Core | skipped 0/0 | 4/4 (100%), 7/7 on 2026-07-28 draft |
| Client: Auth | skipped 0/0 | 14/14 on 2025-11-25, 3/3 on 2025-06-18; aggregate 14/16 (88%) |
| tools_call scenario | FAIL (ToolAddNumbers: tool called with empty args) | PASS |

## Out of scope (deliberately deferred)

- The aggregate Client: Auth 14/16 is dragged by the two 2025-03-26 backcompat scenarios (wontfix per issue 451). The published SDK tiering policy excludes legacy backcompat tests unless the SDK claims legacy support, but tier-check's scoring counts any date-versioned scenario. Needs an upstream question/PR on modelcontextprotocol/conformance rather than mcpkit code.
- auth/wif-jwt-bearer and auth/authorization-server-migration have no tracking issues yet (extension/draft categories, not tier-scored).
