### PR TITLE
feat(auth): 2025-03-26 legacy OAuth discovery fallback (issue 451)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,18 @@ targeted spec version.
   for external `QuotaStore` implementors (experimental surface). (issue 774)
 
 ### Added / Fixed
+- **2025-03-26 legacy OAuth discovery fallback (issue 451, reversed wontfix).**
+  `ext/auth.DiscoverMCPAuth` now falls back to the 2025-03-26 authorization
+  spec's discovery shape when the server publishes no Protected Resource
+  Metadata: AS metadata at the origin's `oauth-authorization-server`
+  well-known path, then the legacy default endpoints (`/authorize`, `/token`,
+  `/register` at the origin). Reached only on a definitive 404 at both RFC
+  9728 PRM locations — any other PRM failure still errors, so a modern
+  server's flow cannot be downgraded, and a `WWW-Authenticate`-advertised PRM
+  URL never falls back. New `MCPAuthInfo.LegacyDiscovery` field; `PRM` is nil
+  on this path (nil-guard added to `ClientCredentialsTokenSource`). Flips the
+  two `auth/2025-03-26-*` conformance scenarios to pass: Client: Auth
+  aggregate 16/16.
 - **Client conformance wired into tier-check.** `scripts/refresh-conformance.sh`
   now builds `cmd/testclient` and passes it via `--client-cmd`, so
   `CONFORMANCE.md` scores the client scenario suites (Client: Core, Client:

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -500,10 +500,10 @@ _None._
 
 | Scenario | Surface | Checks fail/pass | Tracking |
 |---|---|---:|---|
-| `auth/authorization-server-migration` | client | 1/2 | no tracking issue yet — Draft category, not tier-scored. Client does not yet re-register when the PRM's authorization server changes. |
+| `auth/authorization-server-migration` | client | 1/2 | https://github.com/panyam/mcpkit/issues/1100 — Draft category, not tier-scored. Client does not re-register when the PRM's authorization server changes; reopened gap from issue 500 cluster D. |
 | `auth/dpop` | client | 3/9 | https://github.com/panyam/mcpkit/issues/803 — Extension category, not tier-scored. SEP-1932 DPoP deferred until the spec exits draft. |
 | `auth/dpop-nonce` | client | 5/9 | https://github.com/panyam/mcpkit/issues/803 — Extension category, not tier-scored. SEP-1932 DPoP server-required-nonce variant. |
-| `auth/wif-jwt-bearer` | client | 1/10 | no tracking issue yet — Extension category, not tier-scored. RFC 7523 JWT bearer grant via workload identity federation, not implemented. |
+| `auth/wif-jwt-bearer` | client | 1/10 | https://github.com/panyam/mcpkit/issues/1101 — Extension category, not tier-scored. RFC 7523 JWT bearer grant via workload identity federation, not implemented. |
 
 ### Declared requirements with no emitted check
 

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -37,7 +37,7 @@ Needs Node.js 22+ and a clone of `modelcontextprotocol/conformance` at `../conf-
 | Surface | Scenarios pass/total | Checks pass/fail |
 |---|---:|---:|
 | Server | 30/30 | 42/0 |
-| Client | 37/43 | 479/17 |
+| Client | 39/43 | 506/10 |
 
 ## mcpkit-local Conformance Suites
 
@@ -500,8 +500,6 @@ _None._
 
 | Scenario | Surface | Checks fail/pass | Tracking |
 |---|---|---:|---|
-| `auth/2025-03-26-oauth-endpoint-fallback` | client | 3/0 | https://github.com/panyam/mcpkit/issues/451 — Wontfix — 2025-03-26 OAuth-endpoint root fallback removed by spec in 2025-06-18. mcpkit targets 2025-11-25+; see ext/auth/docs/DESIGN.md for the policy. |
-| `auth/2025-03-26-oauth-metadata-backcompat` | client | 4/0 | https://github.com/panyam/mcpkit/issues/451 — Wontfix — rootless OAuth metadata removed by spec in 2025-06-18. See ext/auth/docs/DESIGN.md. |
 | `auth/authorization-server-migration` | client | 1/2 | no tracking issue yet — Draft category, not tier-scored. Client does not yet re-register when the PRM's authorization server changes. |
 | `auth/dpop` | client | 3/9 | https://github.com/panyam/mcpkit/issues/803 — Extension category, not tier-scored. SEP-1932 DPoP deferred until the spec exits draft. |
 | `auth/dpop-nonce` | client | 5/9 | https://github.com/panyam/mcpkit/issues/803 — Extension category, not tier-scored. SEP-1932 DPoP server-required-nonce variant. |

--- a/conformance/baseline.yml
+++ b/conformance/baseline.yml
@@ -35,15 +35,10 @@ client:
   # Required — CIMD (warning: not using Client ID Metadata Documents yet)
   - auth/basic-cimd                         # Client ID Metadata Document flow (warning)
 
-  # 2025-03-26 spec backcompat — wontfix per #451. Both scenarios test
-  # the auth flow shapes the spec removed in 2025-06-18 (rootless OAuth
-  # metadata, fallback to OAuth-standard endpoints when no metadata
-  # endpoints exist). mcpkit targets 2025-11-25 + 2026-07-28; servers
-  # stuck on 2025-03-26 hit a clear "PRM endpoint missing" error from
-  # ext/auth/discovery.go that points at the spec gap. See
-  # ext/auth/docs/DESIGN.md "Supported spec versions" for the policy.
-  - auth/2025-03-26-oauth-endpoint-fallback # legacy OAuth-endpoint root fallback (#451 wontfix)
-  - auth/2025-03-26-oauth-metadata-backcompat # legacy rootless OAuth metadata (#451 wontfix)
+  # 2025-03-26 spec backcompat now passes — legacy discovery fallback
+  # implemented in ext/auth/discovery.go (issue 451, option a). See
+  # ext/auth/docs/DESIGN.md "Supported spec versions" for the ladder +
+  # the no-downgrade rule.
 
   # --- Full client suite (testconf-client, --suite all) ---
   # Everything below is extension or draft category upstream — none of these

--- a/conformance/known-gaps.yaml
+++ b/conformance/known-gaps.yaml
@@ -21,12 +21,6 @@ scenarios:
   "server-stateless":
     issue: "upstream conformance test bug"
     note: "ServerRejectsUndeclaredCapability checks requiredCapabilities as string-array but SEP-2575 schema says object — mcpkit follows schema. Tracked in CLAUDE.md gotchas."
-  "auth/2025-03-26-oauth-endpoint-fallback":
-    issue: "https://github.com/panyam/mcpkit/issues/451"
-    note: "Wontfix — 2025-03-26 OAuth-endpoint root fallback removed by spec in 2025-06-18. mcpkit targets 2025-11-25+; see ext/auth/docs/DESIGN.md for the policy."
-  "auth/2025-03-26-oauth-metadata-backcompat":
-    issue: "https://github.com/panyam/mcpkit/issues/451"
-    note: "Wontfix — rootless OAuth metadata removed by spec in 2025-06-18. See ext/auth/docs/DESIGN.md."
   "auth/dpop":
     issue: "https://github.com/panyam/mcpkit/issues/803"
     note: "Extension category, not tier-scored. SEP-1932 DPoP deferred until the spec exits draft."

--- a/conformance/known-gaps.yaml
+++ b/conformance/known-gaps.yaml
@@ -28,11 +28,11 @@ scenarios:
     issue: "https://github.com/panyam/mcpkit/issues/803"
     note: "Extension category, not tier-scored. SEP-1932 DPoP server-required-nonce variant."
   "auth/wif-jwt-bearer":
-    issue: "no tracking issue yet"
+    issue: "https://github.com/panyam/mcpkit/issues/1101"
     note: "Extension category, not tier-scored. RFC 7523 JWT bearer grant via workload identity federation, not implemented."
   "auth/authorization-server-migration":
-    issue: "no tracking issue yet"
-    note: "Draft category, not tier-scored. Client does not yet re-register when the PRM's authorization server changes."
+    issue: "https://github.com/panyam/mcpkit/issues/1100"
+    note: "Draft category, not tier-scored. Client does not re-register when the PRM's authorization server changes; reopened gap from issue 500 cluster D."
 
 checks:
   "sep-2243-server-not-expect-null":

--- a/ext/auth/client_credentials.go
+++ b/ext/auth/client_credentials.go
@@ -140,7 +140,7 @@ func (s *ClientCredentialsTokenSource) ensureSourceLocked() error {
 	}
 
 	scopes := s.Scopes
-	if len(scopes) == 0 {
+	if len(scopes) == 0 && info.PRM != nil {
 		scopes = info.PRM.ScopesSupported
 	}
 

--- a/ext/auth/discovery.go
+++ b/ext/auth/discovery.go
@@ -43,6 +43,17 @@ type MCPAuthInfo struct {
 
 	// ASMetadata is the discovered authorization server metadata.
 	ASMetadata *client.ASMetadata
+
+	// LegacyDiscovery reports that discovery fell back to the
+	// 2025-03-26 authorization spec's shape: the server published no
+	// Protected Resource Metadata (definitive 404 at both RFC 9728
+	// well-known locations), so the MCP server origin itself is treated
+	// as the authorization server. On this path PRM is nil and
+	// AuthorizationServers holds the bare origin. ASMetadata is either
+	// the document served at the origin's oauth-authorization-server
+	// well-known path or, when that is also absent, the legacy spec's
+	// default endpoints (/authorize, /token, /register at the origin).
+	LegacyDiscovery bool
 }
 
 // ProtectedResourceMetadata is the JSON structure served by the PRM endpoint (RFC 9728).
@@ -165,6 +176,16 @@ func DiscoverMCPAuth(serverURL string, opts ...DiscoverOption) (*MCPAuthInfo, er
 			if err != nil {
 				return nil, fmt.Errorf("fetch PRM (root): %w", err)
 			}
+			if prmResp.StatusCode == http.StatusNotFound {
+				// Definitive 404 at both RFC 9728 locations: the server
+				// predates PRM, so take the 2025-03-26 legacy discovery
+				// path. Reached only from here — any non-404 PRM failure
+				// (5xx, network error) aborts below instead, so a modern
+				// server's flow cannot be downgraded by a transient PRM
+				// failure, and a header-advertised resource_metadata URL
+				// (the branch above) never falls back at all.
+				return discoverLegacy(httpClient, u)
+			}
 		}
 
 		if prmResp.StatusCode != http.StatusOK {
@@ -224,6 +245,57 @@ func DiscoverMCPAuth(serverURL string, opts ...DiscoverOption) (*MCPAuthInfo, er
 		return nil, fmt.Errorf("discover AS metadata for %s: %w", issuer, err)
 	}
 	info.ASMetadata = asMeta
+
+	return info, nil
+}
+
+// discoverLegacy resolves auth configuration per the 2025-03-26
+// authorization spec, which predates RFC 9728 PRM: the MCP server origin
+// is the authorization server. AS metadata is fetched from the origin's
+// oauth-authorization-server well-known path; a definitive 404 there
+// falls through to the legacy spec's default endpoint paths at the
+// origin. Any other failure (5xx, network error, malformed JSON) is an
+// error — the same no-downgrade rule the caller applies to PRM.
+func discoverLegacy(httpClient *http.Client, u *url.URL) (*MCPAuthInfo, error) {
+	origin := u.Scheme + "://" + u.Host
+	info := &MCPAuthInfo{
+		AuthorizationServers: []string{origin},
+		LegacyDiscovery:      true,
+	}
+
+	metaURL := origin + "/.well-known/oauth-authorization-server"
+	resp, err := httpClient.Get(metaURL)
+	if err != nil {
+		return nil, fmt.Errorf("fetch legacy AS metadata: %w", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("read legacy AS metadata: %w", err)
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var meta client.ASMetadata
+		if err := json.Unmarshal(body, &meta); err != nil {
+			return nil, fmt.Errorf("parse legacy AS metadata: %w", err)
+		}
+		info.ASMetadata = &meta
+	case http.StatusNotFound:
+		// S256 is stamped on the synthesized document because the C11/C12
+		// "refuse when code_challenge_methods_supported is absent" rule
+		// guards a *served* metadata document; there is none here, and the
+		// 2025-03-26 spec required PKCE of its authorization servers.
+		info.ASMetadata = &client.ASMetadata{
+			Issuer:                        origin,
+			AuthorizationEndpoint:         origin + "/authorize",
+			TokenEndpoint:                 origin + "/token",
+			RegistrationEndpoint:          origin + "/register",
+			CodeChallengeMethodsSupported: []string{"S256"},
+		}
+	default:
+		return nil, fmt.Errorf("legacy AS metadata endpoint returned %d", resp.StatusCode)
+	}
 
 	return info, nil
 }

--- a/ext/auth/discovery_test.go
+++ b/ext/auth/discovery_test.go
@@ -412,19 +412,150 @@ func TestDiscoverMCPAuth_PRMResourceEmpty_Accepts(t *testing.T) {
 
 // TestDiscoverMCPAuth_NoPRM verifies that DiscoverMCPAuth returns an error
 // when both path-based and root well-known URIs return 404.
-func TestDiscoverMCPAuth_NoPRM(t *testing.T) {
+func TestDiscoverMCPAuth_NoPRM_LegacyDefaultEndpoints(t *testing.T) {
+	// A server with no PRM and no AS metadata is the 2025-03-26
+	// endpoint-fallback shape: discovery synthesizes the legacy default
+	// endpoints at the origin instead of erroring.
 	mux := http.NewServeMux()
 	mux.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("WWW-Authenticate", `Bearer`)
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 	})
-	// No PRM endpoints at all
 
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 
+	info, err := DiscoverMCPAuth(srv.URL+"/mcp", WithHTTPClient(srv.Client()))
+	if err != nil {
+		t.Fatalf("DiscoverMCPAuth: %v", err)
+	}
+	if !info.LegacyDiscovery {
+		t.Error("expected LegacyDiscovery to be set")
+	}
+	if info.PRM != nil {
+		t.Error("expected nil PRM on the legacy path")
+	}
+	if got, want := info.ASMetadata.AuthorizationEndpoint, srv.URL+"/authorize"; got != want {
+		t.Errorf("AuthorizationEndpoint = %q, want %q", got, want)
+	}
+	if got, want := info.ASMetadata.TokenEndpoint, srv.URL+"/token"; got != want {
+		t.Errorf("TokenEndpoint = %q, want %q", got, want)
+	}
+	if got, want := info.ASMetadata.RegistrationEndpoint, srv.URL+"/register"; got != want {
+		t.Errorf("RegistrationEndpoint = %q, want %q", got, want)
+	}
+	if got, want := len(info.AuthorizationServers), 1; got != want || info.AuthorizationServers[0] != srv.URL {
+		t.Errorf("AuthorizationServers = %v, want [%s]", info.AuthorizationServers, srv.URL)
+	}
+	if err := ValidatePKCES256(info.ASMetadata); err != nil {
+		t.Errorf("synthesized metadata must pass the PKCE gate: %v", err)
+	}
+}
+
+func TestDiscoverMCPAuth_Legacy_ASMetadataAtRoot(t *testing.T) {
+	// The 2025-03-26 metadata-backcompat shape: no PRM, but AS metadata
+	// at the origin's oauth-authorization-server well-known path. The
+	// advertised endpoints must win over the synthesized defaults.
+	mux := http.NewServeMux()
+	var srvURL string
+	mux.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("WWW-Authenticate", `Bearer`)
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	})
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                 srvURL,
+			"authorization_endpoint": srvURL + "/oauth/authorize",
+			"token_endpoint":         srvURL + "/oauth/token",
+			"registration_endpoint":  srvURL + "/oauth/register",
+		})
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	srvURL = srv.URL
+
+	info, err := DiscoverMCPAuth(srv.URL+"/mcp", WithHTTPClient(srv.Client()))
+	if err != nil {
+		t.Fatalf("DiscoverMCPAuth: %v", err)
+	}
+	if !info.LegacyDiscovery {
+		t.Error("expected LegacyDiscovery to be set")
+	}
+	if got, want := info.ASMetadata.AuthorizationEndpoint, srv.URL+"/oauth/authorize"; got != want {
+		t.Errorf("AuthorizationEndpoint = %q, want %q", got, want)
+	}
+	if got, want := info.ASMetadata.TokenEndpoint, srv.URL+"/oauth/token"; got != want {
+		t.Errorf("TokenEndpoint = %q, want %q", got, want)
+	}
+	if got, want := info.ASMetadata.RegistrationEndpoint, srv.URL+"/oauth/register"; got != want {
+		t.Errorf("RegistrationEndpoint = %q, want %q", got, want)
+	}
+}
+
+func TestDiscoverMCPAuth_NoLegacyFallbackOnPRMServerError(t *testing.T) {
+	// The downgrade guard: only a definitive 404 at both PRM locations
+	// enters the legacy path. A 5xx (transient failure, misbehaving
+	// proxy, attacker-induced error) must abort discovery, and no legacy
+	// well-known or default-endpoint request may be made.
+	for _, tc := range []struct {
+		name          string
+		pathBasedCode int
+		rootCode      int
+	}{
+		{"path-based 500", http.StatusInternalServerError, http.StatusNotFound},
+		{"root 500 after path 404", http.StatusNotFound, http.StatusInternalServerError},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			legacyProbed := false
+			mux := http.NewServeMux()
+			mux.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("WWW-Authenticate", `Bearer`)
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+			})
+			mux.HandleFunc("/.well-known/oauth-protected-resource/mcp", func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "nope", tc.pathBasedCode)
+			})
+			mux.HandleFunc("/.well-known/oauth-protected-resource", func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "nope", tc.rootCode)
+			})
+			mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
+				legacyProbed = true
+				http.Error(w, "should not be reached", http.StatusNotFound)
+			})
+
+			srv := httptest.NewServer(mux)
+			t.Cleanup(srv.Close)
+
+			_, err := DiscoverMCPAuth(srv.URL+"/mcp", WithHTTPClient(srv.Client()))
+			if err == nil {
+				t.Fatal("expected error on PRM server error, got legacy fallback")
+			}
+			if legacyProbed {
+				t.Error("legacy AS metadata endpoint was probed despite PRM server error")
+			}
+		})
+	}
+}
+
+func TestDiscoverMCPAuth_NoLegacyFallbackWhenHeaderAdvertisesPRM(t *testing.T) {
+	// A WWW-Authenticate resource_metadata link marks the server as
+	// modern: a failing fetch of that URL must error, never fall back
+	// to legacy discovery.
+	mux := http.NewServeMux()
+	var srvURL string
+	mux.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("WWW-Authenticate", `Bearer resource_metadata="`+srvURL+`/.well-known/oauth-protected-resource/mcp"`)
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	})
+	// The advertised PRM URL 404s; nothing else is served.
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	srvURL = srv.URL
+
 	_, err := DiscoverMCPAuth(srv.URL+"/mcp", WithHTTPClient(srv.Client()))
 	if err == nil {
-		t.Fatal("expected error when no PRM endpoint exists")
+		t.Fatal("expected error when the header-advertised PRM URL fails")
 	}
 }

--- a/ext/auth/docs/DESIGN.md
+++ b/ext/auth/docs/DESIGN.md
@@ -6,16 +6,17 @@ MCPKit implements the MCP Authorization specification (draft, based on OAuth 2.1
 
 ## Supported spec versions
 
-mcpkit targets the **2025-11-25 MCP Authorization spec** and the in-flight **2026-07-28** draft. The auth-flow shapes from the **2025-03-26 spec** (rootless OAuth metadata, OAuth-endpoint root fallback when no metadata endpoints exist) are intentionally **not supported** — those shapes were removed by the spec itself in 2025-06-18, and implementing them would mean carrying deprecated code paths indefinitely for a tiny pool of servers that haven't tracked the spec for more than a year.
+mcpkit targets the **2025-11-25 MCP Authorization spec** and the in-flight **2026-07-28** draft, and additionally supports the **2025-03-26 spec's** legacy discovery shapes as a client-side fallback (issue 451, reversed from an earlier wontfix: the TypeScript SDK carries the same fallback, the tier-check conformance suite scores it, and deployed pre-PRM servers are still common enough to matter).
 
-Concretely:
+The discovery ladder in `ext/auth/discovery.go`:
 
-- mcpkit's client **requires a PRM endpoint** (`/.well-known/oauth-protected-resource{path}` or `/.well-known/oauth-protected-resource`). If PRM is missing, `ext/auth/discovery.go` returns a clear `PRM endpoint returned 404` error — that error is the actionable signal that the server is on the deprecated spec.
-- The OAuth-endpoint root fallback (`/authorize`, `/token`, `/register` at server root without metadata discovery) is also unsupported. Same rationale: spec removed it; mcpkit doesn't carry it.
+1. `WWW-Authenticate` `resource_metadata` link, when the 401 provides one.
+2. PRM well-known probes: path-based, then root (`/.well-known/oauth-protected-resource{path}`, then bare).
+3. **Legacy (2025-03-26) fallback**, reached only when both PRM probes return a definitive **404**: fetch AS metadata at the origin's `/.well-known/oauth-authorization-server`; if that too is 404, synthesize the legacy default endpoints (`/authorize`, `/token`, `/register` at the origin, with S256 stamped so the PKCE gate passes on our own synthesized document). The result carries `MCPAuthInfo.LegacyDiscovery = true` and a nil `PRM`.
 
-The conformance audit's two `auth/2025-03-26-*` scenarios live in `conformance/baseline.yml` as expected-failures and in `conformance/known-gaps.yaml` with this rationale + a tracking link to #451. The upstream audit report (`conformance/UPSTREAM_AUDIT.md`) still shows them as `partial`; that's correct — we don't pass them, and that's intentional.
+The no-downgrade rule is load-bearing: any non-404 PRM outcome (5xx, network error) aborts discovery instead of falling back, and a header-advertised `resource_metadata` URL never falls back at all. A modern server's auth flow cannot be walked down to endpoint-guessing by inducing a transient PRM failure. `TestDiscoverMCPAuth_NoLegacyFallbackOnPRMServerError` and `TestDiscoverMCPAuth_NoLegacyFallbackWhenHeaderAdvertisesPRM` pin this.
 
-Note: this is distinct from MCP **protocol version** negotiation. mcpkit's `server.supportedProtocolVersions` includes `2024-11-05`, `2025-03-26`, `2025-11-25`, and `2026-07-28` — clients on the older protocol version still negotiate successfully. The thing that's unsupported is the *auth-flow shape* the 2025-03-26 spec mandated, which is independent of the protocol version field.
+Note: this is distinct from MCP **protocol version** negotiation. mcpkit's `server.supportedProtocolVersions` includes `2024-11-05`, `2025-03-26`, `2025-11-25`, and `2026-07-28` — the protocol version field and the auth-flow shape are independent axes. The server side serves PRM only; the legacy shapes are client-side fallback, not something mcpkit servers emit.
 
 ## Design Principles
 


### PR DESCRIPTION
## What changes

Reverses issue 451's wontfix (option b) to implement (option a). `ext/auth.DiscoverMCPAuth` gains the 2025-03-26 legacy discovery fallback: when the server publishes no Protected Resource Metadata (definitive 404 at both RFC 9728 well-known locations), the client fetches AS metadata at the origin's `oauth-authorization-server` well-known path, and when that too is absent, uses the legacy spec's default endpoints (`/authorize`, `/token`, `/register` at the origin). Everything downstream (DCR, PKCE, token exchange) is the existing machinery, unchanged. Both `auth/2025-03-26-*` conformance scenarios flip to pass; tier-check's Client: Auth aggregate goes from 14/16 (88%) to 16/16 (100%), removing `client_conformance` from the Tier 1 blockers.

Stacked on PR 1098 (base is `feat/client-conformance-tier-check`) because it edits the baseline/known-gaps files that PR introduced. No CI fires until the base merges (workflow triggers on main only); verified locally — see Testing. Carries "Closes issue 451" semantics via the stack: close 451 when this reaches main.

## Reviewer's guide

Read in this order:
1. [ext/auth/discovery.go](https://github.com/panyam/mcpkit/pull/1099/files#diff-898de71e5ac9a31240de5205dac54889e5db5abe2fad3859075f8bab1e577b31) — start here. The 404-gated entry into `discoverLegacy` and the new function itself; the no-downgrade comment states the rule.
2. [ext/auth/discovery_test.go](https://github.com/panyam/mcpkit/pull/1099/files#diff-af673ffc33161682cb6ff254ed2025cc14f9e2deee9bd3bc380537f112013a39) — acceptance: two legacy-shape tests, two no-downgrade guard tests, and `TestDiscoverMCPAuth_NoPRM` rewritten from expect-error to expect-legacy-fallback (the deliberate behavior flip of this PR).
3. [ext/auth/client_credentials.go](https://github.com/panyam/mcpkit/pull/1099/files#diff-c24f6edc66944bad16c70b808c05bf9652eeafe7d0a07490610fefa0f02d2777) — one-line nil-guard; `info.PRM` is nil on the legacy path.
4. [ext/auth/docs/DESIGN.md](https://github.com/panyam/mcpkit/pull/1099/files#diff-03a5078f128c638aca27e780bfd0c762d7a6122a8867f7df0c519ffb23c54698) — the spec-versions policy rewritten for the new ladder.
5. [conformance/baseline.yml](https://github.com/panyam/mcpkit/pull/1099/files#diff-0bf2c40c9b3652a5564a2ae0433f3ef2bcfe8b65280907a930c2897972b7f0a2) + [conformance/known-gaps.yaml](https://github.com/panyam/mcpkit/pull/1099/files#diff-bcd01920bd187fabe66d67bfeb497d62d841a9e3389985aac55b32955b6d2a30) — the two legacy entries removed (stale-entry guard would fail otherwise).

Skim or skip: [CONFORMANCE.md](https://github.com/panyam/mcpkit/pull/1099/files#diff-d647b61d5d64e4801ec167193f4f207eb71d12b4ec92d5f08b2867673481b9de) (regenerated), [CHANGELOG.md](https://github.com/panyam/mcpkit/pull/1099/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed).

## How it works

```
probe 401 -> WWW-Authenticate has resource_metadata?
  yes -> fetch it; any failure = error (never legacy)
  no  -> PRM path-based well-known
           404 -> PRM root well-known
                    404 -> LEGACY: GET {origin}/.well-known/oauth-authorization-server
                             200 -> use served metadata
                             404 -> synthesize {origin}/authorize|token|register (+S256)
                             else -> error
                    else-non-200 -> error   // no downgrade on 5xx
           else-non-200 -> error            // no downgrade on 5xx
```

## Decision log

- **Fallback only on double-404.** A 5xx or network error on PRM aborts discovery. Otherwise an attacker who can induce a transient PRM failure could walk a modern server's flow down to endpoint-guessing. Two tests pin this, including one asserting the legacy well-known endpoint is never even probed.
- **S256 stamped on the synthesized metadata.** `ValidatePKCES256` implements the modern C11/C12 "refuse when code_challenge_methods_supported is absent" rule, which guards a served document; the synthesized document isn't served by anyone, and the 2025-03-26 spec required PKCE of its AS. Without the stamp the endpoint-fallback flow dies before the token request (found during scenario debugging).
- **Direct GET instead of oneauth `DiscoverAS`** for the legacy metadata fetch: DiscoverAS's error doesn't distinguish 404 (fall through to defaults) from transport failure (abort), and that distinction is the security boundary here.
- **No oneauth bump.** `CodeChallengeMethodsSupported` exists in the pinned v0.1.31; bumping to v0.1.35 would trigger the 8-module lock-step sweep — separate PR if wanted.

## Risk / blast radius

- Affects: `ext/auth` clients only (discovery path). Servers unchanged — mcpkit servers still serve PRM only.
- Behavior change: `DiscoverMCPAuth` against a server with no PRM now succeeds with legacy endpoints instead of returning `PRM endpoint returned 404`. Callers that relied on that error to detect old servers can check `MCPAuthInfo.LegacyDiscovery`.
- Tests: full `ext/auth` suite green; assertion audit: ~28 assertions added, 0 removed or weakened except the deliberate inversion of `TestDiscoverMCPAuth_NoPRM` (1 expect-error replaced by 7 positive assertions).
- Be paranoid about: the nil-PRM propagation — `token_source.go` already guarded, `client_credentials.go` guarded in this PR; anything else reading `info.PRM` unguarded would panic on legacy servers.

## Before / after

Upstream conformance scenarios (local run, 2026-07-22):

| Scenario | before | after |
|---|---|---|
| `auth/2025-03-26-oauth-metadata-backcompat` | FAIL (0 passed / 4 failed) | PASS 16/16 checks |
| `auth/2025-03-26-oauth-endpoint-fallback` | FAIL (0 passed / 3 failed) | PASS |
| tier-check Client: Auth aggregate | 14/16 (88%), `client_conformance` blocker | 16/16 (100%), blocker gone |

## Out of scope (deliberately deferred)

- auth/dpop + auth/dpop-nonce (extension, issue 803), auth/wif-jwt-bearer and auth/authorization-server-migration (extension/draft, untracked) — the remaining 4 client failures, all non-tier-scoring.
- oneauth v0.1.31 → v0.1.35 bump (8-module lock-step sweep).
