### PR TITLE
docs(conformance): split local-suites table by scenario ownership

### DIFF
--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -41,16 +41,27 @@ Needs Node.js 22+ and a clone of `modelcontextprotocol/conformance` at `../conf-
 
 ## mcpkit-local Conformance Suites
 
-These suites exercise SEP-specific behavior beyond what upstream's tier-check covers. Each is wired into `just testall` as a separate stage and may show as PASS, FAIL, INFO (informational, not gating), or SKIP. INFO typically means "work in flight" — see the Tracking column. The Source column links to the branch the scenarios live on; per-suite env vars and default checkout paths are listed below the table.
+These suites exercise SEP-specific behavior beyond what upstream's tier-check covers. Each is wired into `just testall` as a separate stage and may show as PASS, FAIL, INFO (informational, not gating), or SKIP. INFO typically means "work in flight" — see the Tracking column. The Source column links to the branch the scenarios live on; per-suite env vars and default checkout paths are listed below the tables.
+
+### Upstream-scenario suites
+
+_Scenarios owned and maintained in `modelcontextprotocol/conformance`; mcpkit supplies only the fixture under test._
 
 | Suite | Covers | Stage | Status | Source | Tracking |
 |---|---|:---:|:---:|---|---|
 | `testconf-tasks-v2` | SEP-2663 Tasks v2 | 8d | **PASS** | [`modelcontextprotocol/conformance@main`](https://github.com/modelcontextprotocol/conformance/tree/main) | — |
 | `testconf-mrtr` | SEP-2322 MRTR | 8e | **PASS** | [`modelcontextprotocol/conformance@main`](https://github.com/modelcontextprotocol/conformance/tree/main) | — |
-| `testconf-file-inputs` | SEP-2356 File inputs | 8f | **PASS** | [`panyam/mcpconformance@pending`](https://github.com/panyam/mcpconformance/tree/pending) | — |
-| `testconf-auth-server` | MCP authz 2025-11-25 | 8g | **PASS** | [`panyam/mcpconformance@pending`](https://github.com/panyam/mcpconformance/tree/pending) | — |
 | `testconf-client` | Client core + auth (full suite) | - | **PASS**<sup>1</sup> | [`modelcontextprotocol/conformance@main`](https://github.com/modelcontextprotocol/conformance/tree/main) | — |
 | `testconf-stateless` | SEP-2575 Stateless wire | - | **PASS**<sup>2</sup> | [`modelcontextprotocol/conformance@main`](https://github.com/modelcontextprotocol/conformance/tree/main) | — |
+
+### mcpkit-authored suites
+
+_Scenarios authored by this project, typically in the `panyam/mcpconformance` fork while the SEP they cover is still in flight upstream. They assert what the spec says, not what mcpkit does, but they have not been through upstream review._
+
+| Suite | Covers | Stage | Status | Source | Tracking |
+|---|---|:---:|:---:|---|---|
+| `testconf-file-inputs` | SEP-2356 File inputs | 8f | **PASS** | [`panyam/mcpconformance@pending`](https://github.com/panyam/mcpconformance/tree/pending) | — |
+| `testconf-auth-server` | MCP authz 2025-11-25 | 8g | **PASS** | [`panyam/mcpconformance@pending`](https://github.com/panyam/mcpconformance/tree/pending) | — |
 | `testconf-skills` | SEP-2640 Skills | 8h | _INFO_<sup>3</sup> | [`panyam/mcpconformance@chore/sep-2640-yaml`](https://github.com/panyam/mcpconformance/tree/chore/sep-2640-yaml) | mcpkit 567 |
 
 <sup>1</sup> Same scenario set tier-check's --client-cmd runs. Expected failures (extension + draft + backcompat categories, none tier-scored) live in conformance/baseline.yml.

--- a/tools/conformance-report/src/render.ts
+++ b/tools/conformance-report/src/render.ts
@@ -156,44 +156,76 @@ function renderLocalSuites(input: RenderInput): string[] {
   }
   const lines: string[] = [];
   lines.push(
-    'These suites exercise SEP-specific behavior beyond what upstream\'s tier-check covers. Each is wired into `just testall` as a separate stage and may show as PASS, FAIL, INFO (informational, not gating), or SKIP. INFO typically means "work in flight" — see the Tracking column. The Source column links to the branch the scenarios live on; per-suite env vars and default checkout paths are listed below the table.'
+    'These suites exercise SEP-specific behavior beyond what upstream\'s tier-check covers. Each is wired into `just testall` as a separate stage and may show as PASS, FAIL, INFO (informational, not gating), or SKIP. INFO typically means "work in flight" — see the Tracking column. The Source column links to the branch the scenarios live on; per-suite env vars and default checkout paths are listed below the tables.'
   );
-  lines.push('');
-  lines.push('| Suite | Covers | Stage | Status | Source | Tracking |');
-  lines.push('|---|---|:---:|:---:|---|---|');
   const footnotes: string[] = [];
-  for (const s of suites) {
-    let statusCell: string;
-    switch (s.status) {
-      case 'PASS':
-        statusCell = '**PASS**';
-        break;
-      case 'FAIL':
-        statusCell = '**FAIL**';
-        break;
-      case 'INFO':
-        statusCell = '_INFO_';
-        break;
-      case 'SKIP':
-        statusCell = '_SKIP_';
-        break;
+  const pushTable = (subset: typeof suites) => {
+    lines.push('| Suite | Covers | Stage | Status | Source | Tracking |');
+    lines.push('|---|---|:---:|:---:|---|---|');
+    for (const s of subset) {
+      let statusCell: string;
+      switch (s.status) {
+        case 'PASS':
+          statusCell = '**PASS**';
+          break;
+        case 'FAIL':
+          statusCell = '**FAIL**';
+          break;
+        case 'INFO':
+          statusCell = '_INFO_';
+          break;
+        case 'SKIP':
+          statusCell = '_SKIP_';
+          break;
+      }
+      if (s.note) {
+        const idx = footnotes.length + 1;
+        statusCell = `${statusCell}<sup>${idx}</sup>`;
+        footnotes.push(`<sup>${idx}</sup> ${s.note}`);
+      }
+      let sourceCell: string;
+      if (s.source) {
+        const url = `https://github.com/${s.source.repo}/tree/${s.source.branch}`;
+        sourceCell = `[\`${s.source.repo}@${s.source.branch}\`](${url})`;
+      } else {
+        sourceCell = '—';
+      }
+      const tracking = s.tracking ? s.tracking : '—';
+      lines.push(
+        `| \`${s.suite}\` | ${s.sep} | ${s.stage} | ${statusCell} | ${sourceCell} | ${tracking} |`
+      );
     }
-    if (s.note) {
-      const idx = footnotes.length + 1;
-      statusCell = `${statusCell}<sup>${idx}</sup>`;
-      footnotes.push(`<sup>${idx}</sup> ${s.note}`);
-    }
-    let sourceCell: string;
-    if (s.source) {
-      const url = `https://github.com/${s.source.repo}/tree/${s.source.branch}`;
-      sourceCell = `[\`${s.source.repo}@${s.source.branch}\`](${url})`;
-    } else {
-      sourceCell = '—';
-    }
-    const tracking = s.tracking ? s.tracking : '—';
+  };
+  // Split by scenario ownership so a reader can tell at a glance which
+  // results are graded by upstream-maintained scenarios versus scenarios
+  // this project authored (usually in the panyam/mcpconformance fork while
+  // a SEP is still in flight upstream). A suite with no source block is
+  // mcpkit-authored by definition.
+  const upstreamSuites = suites.filter(
+    (s) => s.source?.repo === 'modelcontextprotocol/conformance'
+  );
+  const forkSuites = suites.filter(
+    (s) => s.source?.repo !== 'modelcontextprotocol/conformance'
+  );
+  if (upstreamSuites.length > 0) {
+    lines.push('');
+    lines.push('### Upstream-scenario suites');
+    lines.push('');
     lines.push(
-      `| \`${s.suite}\` | ${s.sep} | ${s.stage} | ${statusCell} | ${sourceCell} | ${tracking} |`
+      '_Scenarios owned and maintained in `modelcontextprotocol/conformance`; mcpkit supplies only the fixture under test._'
     );
+    lines.push('');
+    pushTable(upstreamSuites);
+  }
+  if (forkSuites.length > 0) {
+    lines.push('');
+    lines.push('### mcpkit-authored suites');
+    lines.push('');
+    lines.push(
+      '_Scenarios authored by this project, typically in the `panyam/mcpconformance` fork while the SEP they cover is still in flight upstream. They assert what the spec says, not what mcpkit does, but they have not been through upstream review._'
+    );
+    lines.push('');
+    pushTable(forkSuites);
   }
   if (footnotes.length > 0) {
     lines.push('');

--- a/tools/conformance-report/test/fixtures/expected.md
+++ b/tools/conformance-report/test/fixtures/expected.md
@@ -10,7 +10,11 @@
 
 ## mcpkit-local Conformance Suites
 
-These suites exercise SEP-specific behavior beyond what upstream's tier-check covers. Each is wired into `just testall` as a separate stage and may show as PASS, FAIL, INFO (informational, not gating), or SKIP. INFO typically means "work in flight" — see the Tracking column. The Source column links to the branch the scenarios live on; per-suite env vars and default checkout paths are listed below the table.
+These suites exercise SEP-specific behavior beyond what upstream's tier-check covers. Each is wired into `just testall` as a separate stage and may show as PASS, FAIL, INFO (informational, not gating), or SKIP. INFO typically means "work in flight" — see the Tracking column. The Source column links to the branch the scenarios live on; per-suite env vars and default checkout paths are listed below the tables.
+
+### mcpkit-authored suites
+
+_Scenarios authored by this project, typically in the `panyam/mcpconformance` fork while the SEP they cover is still in flight upstream. They assert what the spec says, not what mcpkit does, but they have not been through upstream review._
 
 | Suite | Covers | Stage | Status | Source | Tracking |
 |---|---|:---:|:---:|---|---|


### PR DESCRIPTION
## What changes

The "mcpkit-local Conformance Suites" table in CONFORMANCE.md (and the published conformance page) mixed suites whose scenarios are owned upstream in `modelcontextprotocol/conformance` with suites this project authored in the `panyam/mcpconformance` fork. It now renders two tables under explicit headings: **Upstream-scenario suites** (tasks-v2, MRTR, client, stateless) and **mcpkit-authored suites** (file-inputs, auth-server, skills), each with a one-line note on what the grouping means for review weight.

## Reviewer's guide

Read in this order:
1. [tools/conformance-report/src/render.ts](https://github.com/panyam/mcpkit/pull/1110/files#diff-6bb2e05fa1f26aafff697dbeaebb958d4e1614720f307ffa950b0f788660a3b3) — the split in renderLocalSuites: rows extracted into a pushTable closure, suites partitioned on `source.repo === 'modelcontextprotocol/conformance'` (a suite with no source block counts as mcpkit-authored by definition). Footnote numbering stays continuous across both tables.
2. [tools/conformance-report/test/fixtures/expected.md](https://github.com/panyam/mcpkit/pull/1110/files#diff-06b3d748db08438a537091e5dcc1ce630ca132812f75e04fdfb8150566bb5892) — golden regenerated; the fixture set has only fork suites, so it shows the single-group rendering path.
3. [CONFORMANCE.md](https://github.com/panyam/mcpkit/pull/1110/files#diff-d647b61d5d64e4801ec167193f4f207eb71d12b4ec92d5f08b2867673481b9de) — the re-rendered real report showing both groups.

## Risk / blast radius

- Renderer + generated doc only. Renderer unit tests 9/9; the golden update is the deliberate expectation change for this PR (no assertions weakened).
- The CI staleness gate re-renders on every PR, so any drift between renderer and committed report fails loudly.
