### PR TITLE
feat(auth): JWTBearerTokenSource — RFC 7523 WIF grant (issue 1101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,16 @@ targeted spec version.
   for external `QuotaStore` implementors (experimental surface). (issue 774)
 
 ### Added / Fixed
+- **`auth.JWTBearerTokenSource` — RFC 7523 JWT-bearer grant for workload
+  identity federation (SEP-1933, issue 1101).** A `core.TokenSource` for
+  workloads whose identity is attested out-of-band: the caller supplies the
+  signed assertion (static or via `AssertionProvider` for rotating platform
+  credentials) and the source exchanges it at the discovered AS with
+  `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer`, no browser and no
+  client secret. Scope step-up via `TokenForScopes`; a failed exchange is
+  surfaced verbatim with no self-retry or grant fallback per RFC 7523. Flips
+  the `auth/wif-jwt-bearer` conformance extension scenario to pass (12/12
+  checks).
 - **2025-03-26 legacy OAuth discovery fallback (issue 451, reversed wontfix).**
   `ext/auth.DiscoverMCPAuth` now falls back to the 2025-03-26 authorization
   spec's discovery shape when the server publishes no Protected Resource

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -37,7 +37,7 @@ Needs Node.js 22+ and a clone of `modelcontextprotocol/conformance` at `../conf-
 | Surface | Scenarios pass/total | Checks pass/fail |
 |---|---:|---:|
 | Server | 30/30 | 42/0 |
-| Client | 39/43 | 506/10 |
+| Client | 40/43 | 508/9 |
 
 ## mcpkit-local Conformance Suites
 
@@ -514,7 +514,6 @@ _None._
 | `auth/authorization-server-migration` | client | 1/2 | https://github.com/panyam/mcpkit/issues/1100 — Draft category, not tier-scored. Client does not re-register when the PRM's authorization server changes; reopened gap from issue 500 cluster D. |
 | `auth/dpop` | client | 3/9 | https://github.com/panyam/mcpkit/issues/803 — Extension category, not tier-scored. SEP-1932 DPoP deferred until the spec exits draft. |
 | `auth/dpop-nonce` | client | 5/9 | https://github.com/panyam/mcpkit/issues/803 — Extension category, not tier-scored. SEP-1932 DPoP server-required-nonce variant. |
-| `auth/wif-jwt-bearer` | client | 1/10 | https://github.com/panyam/mcpkit/issues/1101 — Extension category, not tier-scored. RFC 7523 JWT bearer grant via workload identity federation, not implemented. |
 
 ### Declared requirements with no emitted check
 

--- a/cmd/testclient/main.go
+++ b/cmd/testclient/main.go
@@ -228,6 +228,7 @@ type conformanceContext struct {
 	IdpIDToken       string         `json:"idp_id_token"`
 	IdpIssuer        string         `json:"idp_issuer"`
 	IdpTokenEndpoint string         `json:"idp_token_endpoint"`
+	ValidJwt         string         `json:"valid_jwt"`
 	ToolCalls        []toolCallSpec `json:"toolCalls"`
 }
 
@@ -247,6 +248,15 @@ type toolCallSpec struct {
 // to keep DCR scenarios with no pre-registered credentials on the
 // OAuthTokenSource fast path without spurious PRM/AS round trips.
 func pickTokenSource(serverURL string, ctx conformanceContext) core.TokenSource {
+	if ctx.ValidJwt != "" {
+		log.Println("Step 2: ctx has valid_jwt → JWTBearerTokenSource (RFC 7523 WIF)")
+		return &auth.JWTBearerTokenSource{
+			ServerURL:     serverURL,
+			ClientID:      ctx.ClientID,
+			Assertion:     ctx.ValidJwt,
+			AllowInsecure: true,
+		}
+	}
 	if ctx.IdpIDToken != "" && ctx.IdpTokenEndpoint != "" {
 		log.Println("Step 2: ctx has idp_id_token + idp_token_endpoint → EnterpriseManagedTokenSource (SEP-990)")
 		return &auth.EnterpriseManagedTokenSource{

--- a/conformance/baseline.yml
+++ b/conformance/baseline.yml
@@ -48,8 +48,6 @@ client:
   - auth/dpop                               # DPoP proof on token request + resource calls
   - auth/dpop-nonce                         # DPoP with server-required nonce
 
-  # Extension — workload identity federation, not implemented
-  - auth/wif-jwt-bearer                     # RFC 7523 JWT bearer grant via WIF
 
   # Draft — informational, not tier-scored
   - auth/authorization-server-migration     # re-registration when the PRM's AS changes

--- a/conformance/known-gaps.yaml
+++ b/conformance/known-gaps.yaml
@@ -27,9 +27,6 @@ scenarios:
   "auth/dpop-nonce":
     issue: "https://github.com/panyam/mcpkit/issues/803"
     note: "Extension category, not tier-scored. SEP-1932 DPoP server-required-nonce variant."
-  "auth/wif-jwt-bearer":
-    issue: "https://github.com/panyam/mcpkit/issues/1101"
-    note: "Extension category, not tier-scored. RFC 7523 JWT bearer grant via workload identity federation, not implemented."
   "auth/authorization-server-migration":
     issue: "https://github.com/panyam/mcpkit/issues/1100"
     note: "Draft category, not tier-scored. Client does not re-register when the PRM's authorization server changes; reopened gap from issue 500 cluster D."

--- a/docs/site/static/conformance/badge.json
+++ b/docs/site/static/conformance/badge.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"MCP conformance","message":"server 30/30 · client 39/43","color":"brightgreen"}
+{"schemaVersion":1,"label":"MCP conformance","message":"server 30/30 · client 40/43","color":"brightgreen"}

--- a/ext/auth/jwt_bearer.go
+++ b/ext/auth/jwt_bearer.go
@@ -1,0 +1,184 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/panyam/oneauth/client"
+)
+
+// JWTBearerTokenSource implements core.TokenSource for the RFC 7523 §2.1
+// JWT-bearer authorization grant (SEP-1933 workload identity federation).
+// Use when the MCP client is a workload whose identity is attested by a
+// trusted issuer out-of-band — a Kubernetes projected service-account
+// token, a cloud metadata-service credential, or an upstream IdP-minted
+// JWT — and the authorization server exchanges that assertion directly
+// for an access token. No browser, no consent screen, no client secret:
+// the assertion IS the grant.
+//
+// This is the authorization GRANT (`assertion` form field), distinct from
+// the private_key_jwt client-authentication method (`client_assertion`)
+// that ClientCredentialsTokenSource's PrivateKeyPEM variant uses.
+//
+// PRM discovery and AS metadata resolution follow the same MCP chain as
+// the other sources in this package; the token exchange is delegated to
+// oneauth's AuthClient.JwtBearerGrant.
+type JWTBearerTokenSource struct {
+	// ServerURL is the MCP server URL (used for PRM discovery).
+	ServerURL string
+
+	// ClientID identifies the workload at the AS. Required.
+	ClientID string
+
+	// Assertion is a static signed JWT presented as the grant. Use for
+	// assertions whose lifetime exceeds the process (tests, short-lived
+	// jobs). Exactly one of Assertion / AssertionProvider must be set.
+	Assertion string
+
+	// AssertionProvider returns a fresh assertion per token request. Use
+	// when the platform rotates the workload credential (e.g. a projected
+	// service-account token file): the provider is consulted on every
+	// fetch, so an expired cached assertion is never replayed.
+	AssertionProvider func() (string, error)
+
+	// Scopes to request. If empty, inherits from PRM scopes_supported.
+	Scopes []string
+
+	// HTTPClient overrides the discovery and token-request HTTP client.
+	// Useful in tests with httptest.Server.
+	HTTPClient *http.Client
+
+	// AllowInsecure permits http:// AS endpoints. Required for the
+	// conformance mock AS; production deployments should leave this false
+	// so AS HTTPS is enforced.
+	AllowInsecure bool
+
+	// ASMetadataStore caches AS metadata across discovery calls when
+	// multiple sources target the same AS.
+	ASMetadataStore client.ASMetadataStore
+
+	mu       sync.Mutex
+	authInfo *MCPAuthInfo
+	auth     *client.AuthClient
+	scopes   []string
+	cred     *client.ServerCredential
+}
+
+// Token returns a cached access token while it remains valid, or performs
+// a JWT-bearer grant exchange for a fresh one. Implements core.TokenSource.
+// A failed exchange returns the AS's error verbatim and caches nothing —
+// per RFC 7523 the client must not retry or fall back to another grant on
+// its own; the next call re-attempts only because the caller asked again.
+func (s *JWTBearerTokenSource) Token() (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.tokenLocked()
+}
+
+// TokenForScopes merges the requested scopes into the configured set,
+// drops the cached credential, and exchanges a fresh assertion. Implements
+// core.ScopeAwareTokenSource so the client transport can step up scope
+// after a 403 with insufficient_scope.
+func (s *JWTBearerTokenSource) TokenForScopes(scopes []string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := s.ensureLocked(); err != nil {
+		return "", err
+	}
+	merged := append([]string{}, s.scopes...)
+	for _, sc := range scopes {
+		found := false
+		for _, have := range merged {
+			if have == sc {
+				found = true
+				break
+			}
+		}
+		if !found {
+			merged = append(merged, sc)
+		}
+	}
+	s.scopes = merged
+	s.cred = nil
+	return s.tokenLocked()
+}
+
+func (s *JWTBearerTokenSource) tokenLocked() (string, error) {
+	if err := s.ensureLocked(); err != nil {
+		return "", err
+	}
+	if s.cred != nil && (s.cred.ExpiresAt.IsZero() || time.Now().Before(s.cred.ExpiresAt)) {
+		return s.cred.AccessToken, nil
+	}
+
+	assertion := s.Assertion
+	if s.AssertionProvider != nil {
+		var err error
+		assertion, err = s.AssertionProvider()
+		if err != nil {
+			return "", fmt.Errorf("assertion provider: %w", err)
+		}
+	}
+
+	cred, err := s.auth.JwtBearerGrant(context.Background(), &client.JwtBearerGrantRequest{
+		ClientID:  s.ClientID,
+		Assertion: assertion,
+		Scope:     s.scopes,
+	})
+	if err != nil {
+		return "", fmt.Errorf("jwt-bearer grant: %w", err)
+	}
+	s.cred = cred
+	return cred.AccessToken, nil
+}
+
+func (s *JWTBearerTokenSource) ensureLocked() error {
+	if s.auth != nil {
+		return nil
+	}
+
+	if s.ClientID == "" {
+		return fmt.Errorf("JWTBearerTokenSource: ClientID is required")
+	}
+	if s.Assertion == "" && s.AssertionProvider == nil {
+		return fmt.Errorf("JWTBearerTokenSource: Assertion or AssertionProvider is required")
+	}
+	if s.Assertion != "" && s.AssertionProvider != nil {
+		return fmt.Errorf("JWTBearerTokenSource: Assertion and AssertionProvider are mutually exclusive")
+	}
+
+	var opts []DiscoverOption
+	if s.HTTPClient != nil {
+		opts = append(opts, WithHTTPClient(s.HTTPClient))
+	}
+	if s.ASMetadataStore != nil {
+		opts = append(opts, WithASMetadataStore(s.ASMetadataStore))
+	}
+	info, err := DiscoverMCPAuth(s.ServerURL, opts...)
+	if err != nil {
+		return fmt.Errorf("MCP auth discovery: %w", err)
+	}
+
+	if !s.AllowInsecure {
+		if err := client.ValidateHTTPS(info.ASMetadata); err != nil {
+			return err
+		}
+	}
+
+	s.authInfo = info
+	s.scopes = s.Scopes
+	if len(s.scopes) == 0 && info.PRM != nil {
+		s.scopes = info.PRM.ScopesSupported
+	}
+
+	authOpts := []client.ClientOption{client.WithASMetadata(info.ASMetadata)}
+	if s.HTTPClient != nil {
+		authOpts = append(authOpts, client.WithHTTPClient(s.HTTPClient))
+	}
+	s.auth = client.NewAuthClient(info.AuthorizationServers[0], nil, authOpts...)
+	return nil
+}

--- a/ext/auth/jwt_bearer_test.go
+++ b/ext/auth/jwt_bearer_test.go
@@ -1,0 +1,170 @@
+package auth
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+type jwtBearerMock struct {
+	srv           *httptest.Server
+	tokenRequests []url.Values
+	tokenStatus   int
+	tokenError    string
+}
+
+func newJWTBearerMock(t *testing.T) *jwtBearerMock {
+	t.Helper()
+	m := &jwtBearerMock{tokenStatus: http.StatusOK}
+	mux := http.NewServeMux()
+	var srvURL string
+	mux.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("WWW-Authenticate", `Bearer resource_metadata="`+srvURL+`/.well-known/oauth-protected-resource/mcp"`)
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	})
+	mux.HandleFunc("/.well-known/oauth-protected-resource/mcp", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"resource":              srvURL + "/mcp",
+			"authorization_servers": []string{srvURL},
+			"scopes_supported":      []string{"wif.read"},
+		})
+	})
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                                srvURL,
+			"token_endpoint":                        srvURL + "/token",
+			"grant_types_supported":                 []string{"urn:ietf:params:oauth:grant-type:jwt-bearer"},
+			"token_endpoint_auth_methods_supported": []string{"none"},
+			"code_challenge_methods_supported":      []string{"S256"},
+		})
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		r.ParseForm()
+		m.tokenRequests = append(m.tokenRequests, r.PostForm)
+		if m.tokenStatus != http.StatusOK {
+			w.WriteHeader(m.tokenStatus)
+			json.NewEncoder(w).Encode(map[string]any{"error": m.tokenError})
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "wif-token-" + string(rune('0'+len(m.tokenRequests))),
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	})
+	m.srv = httptest.NewServer(mux)
+	srvURL = m.srv.URL
+	t.Cleanup(m.srv.Close)
+	return m
+}
+
+func TestJWTBearerTokenSource_GrantShape(t *testing.T) {
+	m := newJWTBearerMock(t)
+	s := &JWTBearerTokenSource{
+		ServerURL:     m.srv.URL + "/mcp",
+		ClientID:      "wif-client",
+		Assertion:     "signed.workload.jwt",
+		HTTPClient:    m.srv.Client(),
+		AllowInsecure: true,
+	}
+
+	tok, err := s.Token()
+	if err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	if tok == "" {
+		t.Fatal("empty token")
+	}
+	if got := len(m.tokenRequests); got != 1 {
+		t.Fatalf("token requests = %d, want 1", got)
+	}
+	form := m.tokenRequests[0]
+	if got, want := form.Get("grant_type"), "urn:ietf:params:oauth:grant-type:jwt-bearer"; got != want {
+		t.Errorf("grant_type = %q, want %q", got, want)
+	}
+	if got, want := form.Get("assertion"), "signed.workload.jwt"; got != want {
+		t.Errorf("assertion = %q, want %q", got, want)
+	}
+	if got := form.Get("client_id"); got != "wif-client" {
+		t.Errorf("client_id = %q, want wif-client", got)
+	}
+	if got := form.Get("scope"); !strings.Contains(got, "wif.read") {
+		t.Errorf("scope = %q, want PRM scopes_supported inherited", got)
+	}
+
+	// Second call must serve from cache, not re-exchange.
+	if _, err := s.Token(); err != nil {
+		t.Fatalf("cached Token: %v", err)
+	}
+	if got := len(m.tokenRequests); got != 1 {
+		t.Errorf("token requests after cached call = %d, want 1", got)
+	}
+}
+
+func TestJWTBearerTokenSource_TokenForScopes(t *testing.T) {
+	m := newJWTBearerMock(t)
+	s := &JWTBearerTokenSource{
+		ServerURL:     m.srv.URL + "/mcp",
+		ClientID:      "wif-client",
+		Assertion:     "signed.workload.jwt",
+		HTTPClient:    m.srv.Client(),
+		AllowInsecure: true,
+	}
+	if _, err := s.Token(); err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	if _, err := s.TokenForScopes([]string{"wif.write"}); err != nil {
+		t.Fatalf("TokenForScopes: %v", err)
+	}
+	if got := len(m.tokenRequests); got != 2 {
+		t.Fatalf("token requests = %d, want 2", got)
+	}
+	scope := m.tokenRequests[1].Get("scope")
+	if !strings.Contains(scope, "wif.read") || !strings.Contains(scope, "wif.write") {
+		t.Errorf("step-up scope = %q, want merged wif.read + wif.write", scope)
+	}
+}
+
+func TestJWTBearerTokenSource_GrantErrorSurfacedNotRetried(t *testing.T) {
+	m := newJWTBearerMock(t)
+	m.tokenStatus = http.StatusBadRequest
+	m.tokenError = "invalid_grant"
+	s := &JWTBearerTokenSource{
+		ServerURL:     m.srv.URL + "/mcp",
+		ClientID:      "wif-client",
+		Assertion:     "expired.workload.jwt",
+		HTTPClient:    m.srv.Client(),
+		AllowInsecure: true,
+	}
+	_, err := s.Token()
+	if err == nil {
+		t.Fatal("expected error from invalid_grant")
+	}
+	if got := len(m.tokenRequests); got != 1 {
+		t.Errorf("token requests = %d, want exactly 1 (no self-retry)", got)
+	}
+}
+
+func TestJWTBearerTokenSource_ConfigValidation(t *testing.T) {
+	cases := []struct {
+		name string
+		src  *JWTBearerTokenSource
+	}{
+		{"missing client id", &JWTBearerTokenSource{ServerURL: "http://x/mcp", Assertion: "a"}},
+		{"missing assertion", &JWTBearerTokenSource{ServerURL: "http://x/mcp", ClientID: "c"}},
+		{"both assertion forms", &JWTBearerTokenSource{
+			ServerURL: "http://x/mcp", ClientID: "c", Assertion: "a",
+			AssertionProvider: func() (string, error) { return "b", nil },
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := tc.src.Token(); err == nil {
+				t.Fatal("expected config error")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What changes

New `auth.JWTBearerTokenSource`: a `core.TokenSource` for the RFC 7523 §2.1 JWT-bearer authorization grant (SEP-1933 workload identity federation). A workload whose identity is attested out-of-band (Kubernetes projected SA token, cloud metadata credential, upstream IdP JWT) presents that assertion directly at the AS for an access token — no browser, no client secret. The upstream `auth/wif-jwt-bearer` conformance extension scenario flips from 10 pass / 1 fail to **12/12**, taking the client suite to 40/43 (remaining: the two SEP-1932 DPoP scenarios and AS-migration).

Not a pushdown: oneauth's `AuthClient.JwtBearerGrant` primitive has shipped since v0.1.5 and is inside the current pin. This is pure mcpkit integration.

## Reviewer's guide

Read in this order:
1. [ext/auth/jwt_bearer.go](https://github.com/panyam/mcpkit/pull/1112/files#diff-82a1ddf5e78c2ccce83d1290d08a0a02cc77d669978ebe3a8f746a3f1bf28f57) — the token source. Note the grant-vs-client-auth distinction in the type doc (`assertion` grant here vs `client_assertion` auth in ClientCredentialsTokenSource's PrivateKeyPEM variant), and the no-self-retry contract on `Token`.
2. [ext/auth/jwt_bearer_test.go](https://github.com/panyam/mcpkit/pull/1112/files#diff-38e586e996beb17875d3623726c19d4aa784695da8fc6566b097f2239cc93885) — acceptance: wire-shape of the grant form (grant_type/assertion/client_id/scope), cache behavior, scope step-up merge, error surfaced with exactly one token request, config validation.
3. [cmd/testclient/main.go](https://github.com/panyam/mcpkit/pull/1112/files#diff-bc7a02b2751e1c671ee37f491a72c42030bf2566f6d0496f30ae2a0ab19ffaae) — dispatch: scenario context `valid_jwt` selects the new source, first in the ladder.
4. [conformance/baseline.yml](https://github.com/panyam/mcpkit/pull/1112/files#diff-0bf2c40c9b3652a5564a2ae0433f3ef2bcfe8b65280907a930c2897972b7f0a2) + [conformance/known-gaps.yaml](https://github.com/panyam/mcpkit/pull/1112/files#diff-bcd01920bd187fabe66d67bfeb497d62d841a9e3389985aac55b32955b6d2a30) — WIF entries removed (stale-entry guard would fail otherwise).

Skim or skip: [CONFORMANCE.md](https://github.com/panyam/mcpkit/pull/1112/files#diff-d647b61d5d64e4801ec167193f4f207eb71d12b4ec92d5f08b2867673481b9de) + [docs/site/static/conformance/badge.json](https://github.com/panyam/mcpkit/pull/1112/files#diff-49faaf06817a8cde19a148d12c5fc59201a86543e145606a6c36c15a5695f943) (regenerated, client 39/43 → 40/43), [CHANGELOG.md](https://github.com/panyam/mcpkit/pull/1112/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed), `cmd/testclient/go.sum` (tidy).

## Decision log

- **Mirrors `ClientCredentialsTokenSource`'s structure** (lazy discovery under a mutex, same field vocabulary: HTTPClient/AllowInsecure/ASMetadataStore, PRM scopes_supported fallback) so the ext/auth token-source family stays uniform.
- **`AssertionProvider` alongside static `Assertion`**: real WIF credentials rotate (projected SA token files); the provider is consulted per exchange so an expired cached assertion is never replayed. The conformance scenario uses the static form. Mutually exclusive, validated.
- **AuthClient constructed with `WithASMetadata(info.ASMetadata)`** so the discovered token endpoint is authoritative — no second discovery inside oneauth.
- **No failure caching**: RFC 7523 forbids self-retry and grant fallback; the source makes exactly one exchange per caller request and surfaces the AS error verbatim. The scenario's no-retry and grant-fallback checks (WARNING-emitting) stay silent because the transport's auth path performs a single acquisition per 401.

## Risk / blast radius

- Additive: new type in ext/auth + one dispatch branch in testclient. No existing surface changed.
- Tests: 4 new test functions (~15 assertions added, 0 removed or weakened); full `ext/auth` suite green; `go vet` clean for the new files (two pre-existing copylocks warnings in neighboring test files are untouched).
- Red-before-green: the acceptance red was the live scenario (`WifGrantType` FAILURE, client presented the wrong grant type); green verified against the same scenario after.
- Be paranoid about: the scope-merge in `TokenForScopes` (dedup by linear scan — fine at OAuth scope cardinalities) and `ExpiresAt.IsZero()` treated as non-expiring.

## Before / after

```
before: ✗ auth/wif-jwt-bearer: 10 passed, 1 failed   (WifGrantType: expected jwt-bearer, got client_credentials)
after:  ✓ auth/wif-jwt-bearer: Passed: 12/12, 0 failed, 0 warnings
badge:  server 30/30 · client 39/43  →  server 30/30 · client 40/43
```

## Out of scope

- auth/dpop + auth/dpop-nonce (SEP-1932 draft, issue 803) and auth/authorization-server-migration (issue 1100) — the three remaining non-scored client failures.
- Close issue 1101 manually on merge (repo convention: close as fix goes green, no auto-close links).
