### PR TITLE
fix(client): send MCP-Protocol-Version header on the adaptive/stateless probe (issue 1100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,16 @@ targeted spec version.
   for external `QuotaStore` implementors (experimental surface). (issue 774)
 
 ### Added / Fixed
+- **Adaptive-probe protocol-version header (SEP-2575).** The
+  `ClientModeAdaptive` / `ClientModeStateless` `server/discover` probe now
+  carries the `MCP-Protocol-Version` HTTP header matching its
+  `_meta.protocolVersion`. The header was previously attached only after the
+  client flipped to the stateless wire, so a compliant stateless-only server
+  (which MUST reject headerless requests) rejected the probe itself and
+  adaptive mode could never connect. Surfaced by the SEP-2352
+  `auth/authorization-server-migration` conformance scenario, which now
+  passes 3/3 — the AS-change re-registration machinery (issue 500 cluster D)
+  was already correct once the wire connected. (issue 1100)
 - **`auth.JWTBearerTokenSource` — RFC 7523 JWT-bearer grant for workload
   identity federation (SEP-1933, issue 1101).** A `core.TokenSource` for
   workloads whose identity is attested out-of-band: the caller supplies the

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -37,7 +37,7 @@ Needs Node.js 22+ and a clone of `modelcontextprotocol/conformance` at `../conf-
 | Surface | Scenarios pass/total | Checks pass/fail |
 |---|---:|---:|
 | Server | 30/30 | 42/0 |
-| Client | 40/43 | 508/9 |
+| Client | 41/43 | 537/8 |
 
 ## mcpkit-local Conformance Suites
 
@@ -511,7 +511,6 @@ _None._
 
 | Scenario | Surface | Checks fail/pass | Tracking |
 |---|---|---:|---|
-| `auth/authorization-server-migration` | client | 1/2 | https://github.com/panyam/mcpkit/issues/1100 — Draft category, not tier-scored. Client does not re-register when the PRM's authorization server changes; reopened gap from issue 500 cluster D. |
 | `auth/dpop` | client | 3/9 | https://github.com/panyam/mcpkit/issues/803 — Extension category, not tier-scored. SEP-1932 DPoP deferred until the spec exits draft. |
 | `auth/dpop-nonce` | client | 5/9 | https://github.com/panyam/mcpkit/issues/803 — Extension category, not tier-scored. SEP-1932 DPoP server-required-nonce variant. |
 

--- a/client/stateless.go
+++ b/client/stateless.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -50,7 +51,18 @@ func (c *Client) adaptiveProbe() (result *DiscoverResult, fallback bool, err err
 	params := map[string]any{
 		"_meta": c.buildRequestMeta(),
 	}
-	resp, callErr := c.rawCall("server/discover", params)
+	// The transport only auto-attaches MCP-Protocol-Version once
+	// useStatelessWire is set, but the probe runs before that flip — and
+	// a compliant SEP-2575 server MUST reject headerless requests. Carry
+	// the header explicitly, matching _meta.protocolVersion, so strict
+	// stateless-only servers classify instead of 400ing the probe.
+	cc := &CallContext{
+		Context: context.Background(),
+		Headers: map[string]string{
+			core.HTTPProtocolVersionHeader: c.getNegotiatedVersion(),
+		},
+	}
+	resp, callErr := c.rawCallWithContext("server/discover", params, cc)
 	if callErr != nil {
 		// Transport-level failure (network, TLS) — propagate up. The
 		// caller does not attempt fallback for these; a broken

--- a/client/stateless_test.go
+++ b/client/stateless_test.go
@@ -475,3 +475,58 @@ func TestClient_4xxJSONRPCErrorParsed(t *testing.T) {
 		t.Errorf("error message = %q, want containing 'bad version'", err.Error())
 	}
 }
+
+func TestAdaptiveProbe_SendsProtocolVersionHeader(t *testing.T) {
+	// A compliant SEP-2575 server MUST reject requests without the
+	// MCP-Protocol-Version header. The adaptive probe runs before the
+	// client flips useStatelessWire, so the header must be attached
+	// explicitly or adaptive mode can never connect to a strict
+	// stateless-only server (upstream auth/authorization-server-migration
+	// mock is exactly this shape).
+	var sawHeader string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			ID     any    `json:"id"`
+			Method string `json:"method"`
+		}
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &req)
+		if req.Method != "server/discover" {
+			http.Error(w, "unexpected method "+req.Method, http.StatusBadRequest)
+			return
+		}
+		sawHeader = r.Header.Get("MCP-Protocol-Version")
+		if sawHeader == "" {
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(map[string]any{
+				"jsonrpc": "2.0", "id": req.ID,
+				"error": map[string]any{"code": -32020, "message": "Missing MCP-Protocol-Version header"},
+			})
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0", "id": req.ID,
+			"result": map[string]any{
+				"supportedVersions": []string{core.DraftProtocolVersion2026V1},
+				"capabilities":      map[string]any{},
+				"_meta": map[string]any{
+					core.MetaKeyServerInfo: map[string]any{"name": "strict-stateless", "version": "1.0"},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, core.ClientInfo{Name: "t", Version: "1"},
+		WithClientMode(ClientModeAdaptive))
+	if err := c.Connect(); err != nil {
+		t.Fatalf("adaptive Connect against strict stateless server: %v", err)
+	}
+	defer c.Close()
+	if sawHeader == "" {
+		t.Fatal("probe request carried no MCP-Protocol-Version header")
+	}
+	if got, want := c.ServerInfo.Name, "strict-stateless"; got != want {
+		t.Errorf("ServerInfo.Name = %q, want %q", got, want)
+	}
+}

--- a/cmd/testclient/main.go
+++ b/cmd/testclient/main.go
@@ -20,6 +20,7 @@ import (
 	"log"
 	"os"
 	"slices"
+	"strings"
 
 	"github.com/panyam/mcpkit/client"
 	"github.com/panyam/mcpkit/core"
@@ -76,19 +77,44 @@ func main() {
 	// Step 1: Try connecting without auth first.
 	// Some conformance scenarios don't require auth, or the server accepts
 	// initialize but returns 403 on subsequent requests (scope step-up).
+	//
+	// Wire selection: legacy first (matches the library default and every
+	// pre-SEP-2575 mock). If the server rejects the legacy handshake with
+	// the stateless signature (-32020 missing MCP-Protocol-Version), pin
+	// ClientModeStateless and reconnect — deliberately NOT blanket
+	// Adaptive, which sends a server/discover probe that confuses the
+	// older legacy mocks in this same suite.
+	newConformanceClient := func(stateless bool, extra ...client.ClientOption) *client.Client {
+		opts := []client.ClientOption{
+			client.WithClientLogging(log.Default()),
+			client.WithElicitationHandler(conformanceElicitationHandler),
+			// Open a background GET SSE so server-to-client requests
+			// (elicitation/create, sampling/createMessage) sent on the
+			// session-wide stream by SDK-conformant servers reach us.
+			// Without this, scenarios that drive elicitation via
+			// StreamableHTTPServerTransport hang waiting on the wrong stream.
+			client.WithGetSSEStream(),
+		}
+		if stateless {
+			opts = append(opts, client.WithClientMode(client.ClientModeStateless))
+		}
+		opts = append(opts, extra...)
+		return client.NewClient(serverURL,
+			core.ClientInfo{Name: "mcpkit-testclient", Version: "0.1.0"}, opts...)
+	}
+	statelessWire := false
 	log.Println("Step 1: Trying direct connect (no auth)...")
-	noAuthClient := client.NewClient(serverURL,
-		core.ClientInfo{Name: "mcpkit-testclient", Version: "0.1.0"},
-		client.WithClientLogging(log.Default()),
-		client.WithElicitationHandler(conformanceElicitationHandler),
-		// Open a background GET SSE so server-to-client requests
-		// (elicitation/create, sampling/createMessage) sent on the
-		// session-wide stream by SDK-conformant servers reach us.
-		// Without this, scenarios that drive elicitation via
-		// StreamableHTTPServerTransport hang waiting on the wrong stream.
-		client.WithGetSSEStream())
+	noAuthClient := newConformanceClient(false)
+	connectErr := noAuthClient.Connect()
+	if connectErr != nil && strings.Contains(connectErr.Error(), "MCP-Protocol-Version") {
+		log.Println("Legacy handshake rejected with stateless signature — reconnecting on the SEP-2575 wire")
+		statelessWire = true
+		noAuthClient.Close()
+		noAuthClient = newConformanceClient(true)
+		connectErr = noAuthClient.Connect()
+	}
 
-	if err := noAuthClient.Connect(); err == nil {
+	if err := connectErr; err == nil {
 		// Connected without auth — verify session works
 		tools, err := noAuthClient.ListTools(context.Background())
 		if err == nil {
@@ -139,13 +165,7 @@ func main() {
 
 	// Step 3: Connect with auth token.
 	log.Println("Step 3: MCP initialize with OAuth token...")
-	c := client.NewClient(serverURL,
-		core.ClientInfo{Name: "mcpkit-testclient", Version: "0.1.0"},
-		client.WithTokenSource(ts),
-		client.WithClientLogging(log.Default()),
-		client.WithElicitationHandler(conformanceElicitationHandler),
-		client.WithGetSSEStream(),
-	)
+	c := newConformanceClient(statelessWire, client.WithTokenSource(ts))
 
 	if err := c.Connect(); err != nil {
 		log.Fatalf("MCP connect: %v", err)

--- a/conformance/baseline.yml
+++ b/conformance/baseline.yml
@@ -50,5 +50,4 @@ client:
 
 
   # Draft — informational, not tier-scored
-  - auth/authorization-server-migration     # re-registration when the PRM's AS changes
   - auth/offline-access-scope               # offline_access request (warning: not requested)

--- a/conformance/known-gaps.yaml
+++ b/conformance/known-gaps.yaml
@@ -27,9 +27,6 @@ scenarios:
   "auth/dpop-nonce":
     issue: "https://github.com/panyam/mcpkit/issues/803"
     note: "Extension category, not tier-scored. SEP-1932 DPoP server-required-nonce variant."
-  "auth/authorization-server-migration":
-    issue: "https://github.com/panyam/mcpkit/issues/1100"
-    note: "Draft category, not tier-scored. Client does not re-register when the PRM's authorization server changes; reopened gap from issue 500 cluster D."
 
 checks:
   "sep-2243-server-not-expect-null":

--- a/docs/site/static/conformance/badge.json
+++ b/docs/site/static/conformance/badge.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"MCP conformance","message":"server 30/30 · client 40/43","color":"brightgreen"}
+{"schemaVersion":1,"label":"MCP conformance","message":"server 30/30 · client 41/43","color":"brightgreen"}


### PR DESCRIPTION
## What changes

A one-line-class client-library bug turned out to be the entire root cause of the failing SEP-2352 `auth/authorization-server-migration` check: the `server/discover` probe runs before the client flips `useStatelessWire`, and the transport only attaches the `MCP-Protocol-Version` header after that flip — so a compliant SEP-2575 stateless-only server (which MUST reject headerless requests) rejected the probe itself, and adaptive mode could never connect to a strict stateless server. The probe now carries the header explicitly, matching its `_meta.protocolVersion`.

With the wire able to connect, the AS-change re-registration machinery from issue 500 cluster D works end-to-end unmodified: the scenario passes **31/31**, including the previously-failing `sep-2352-reregister-on-as-change`. Client suite: 40/43 → **41/43** (537/8 checks); the only remaining failures are the two SEP-1932-gated DPoP scenarios.

## Reviewer's guide

Read in this order:
1. [client/stateless.go](https://github.com/panyam/mcpkit/pull/1113/files#diff-c095a06bc0f1fa5239aedc79840fd85cdd3dfc10886bcee46b7e6d35eaa978c6) — the fix: `adaptiveProbe` switches to `rawCallWithContext` with a `CallContext` carrying the header. The comment states the ordering constraint (probe precedes the wire flip).
2. [client/stateless_test.go](https://github.com/panyam/mcpkit/pull/1113/files#diff-e38d77a970a17c0ec5721a78e295be3d9fd6e4bf0020a4d45feb8a075f53ce4f) — acceptance: a strict stateless mock that 400s headerless `server/discover` exactly like the upstream scenario's mock; red before the fix with the identical error string.
3. [cmd/testclient/main.go](https://github.com/panyam/mcpkit/pull/1113/files#diff-bc7a02b2751e1c671ee37f491a72c42030bf2566f6d0496f30ae2a0ab19ffaae) — driver wire selection: legacy-first, retry pinned to `ClientModeStateless` on the -32020 missing-header signature. The `newConformanceClient` closure dedupes the two construction sites.
4. [conformance/baseline.yml](https://github.com/panyam/mcpkit/pull/1113/files#diff-0bf2c40c9b3652a5564a2ae0433f3ef2bcfe8b65280907a930c2897972b7f0a2) + [conformance/known-gaps.yaml](https://github.com/panyam/mcpkit/pull/1113/files#diff-bcd01920bd187fabe66d67bfeb497d62d841a9e3389985aac55b32955b6d2a30) — migration entries removed.

Skim or skip: [CONFORMANCE.md](https://github.com/panyam/mcpkit/pull/1113/files#diff-d647b61d5d64e4801ec167193f4f207eb71d12b4ec92d5f08b2867673481b9de) + badge (regenerated), [CHANGELOG.md](https://github.com/panyam/mcpkit/pull/1113/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed).

## Decision log

- **Verify-then-fix paid off**: the suspected gap (missing re-discovery trigger in ext/auth) did not exist — `OAuthTokenSource` re-discovers on the post-migration 401 and the `dcrAS` comparison drops credentials and re-registers correctly. Zero ext/auth changes in this PR.
- **testclient uses signature-based stateless retry, NOT blanket `ClientModeAdaptive`**: tried Adaptive first and it regressed `tools_call`, `elicitation-sep1034-client-defaults`, and `auth/scope-step-up` — the probe request confuses legacy mocks, which is exactly why the library default stayed `ClientModeLegacyOnly` (SEP-2575 asymmetric-defaults decision). The -32020 missing-header error is the unambiguous stateless-server signature.
- The header value tracks `getNegotiatedVersion()` so the retry-with-downgrade flow stays consistent between header and `_meta`.

## Risk / blast radius

- `client/` root module: affects only `ClientModeAdaptive` / `ClientModeStateless` probes — the legacy default path is untouched. The pre-fix behavior (probe without header) violated SEP-2575, so any server that accepted it before still accepts the header.
- Tests: 1 new client test (4 assertions); full root suite + full 43-scenario client conformance suite green; `go vet` clean. 0 assertions removed or weakened.
- Be paranoid about: the substring match in testclient's stateless-signature detection ("MCP-Protocol-Version" in the connect error) — driver-only heuristic, not library behavior.

## Before / after

```
before: ✗ auth/authorization-server-migration: 2 passed, 1 failed
        client log: initialize failed: HTTP 400 -32020 Missing MCP-Protocol-Version header
        (OAuth flow never started; sep-2352-reregister-on-as-change FAILURE)

after:  ✓ auth/authorization-server-migration: Passed: 31/31, 0 failed, 0 warnings
        sep-2352-reregister-on-as-change SUCCESS — DCR observed at AS₂ after PRM flip
badge:  server 30/30 · client 40/43  →  server 30/30 · client 41/43
```

## Out of scope

- auth/dpop + auth/dpop-nonce — the last two client failures, gated on SEP-1932 leaving draft (issue 803).
- Close issue 1100 manually on merge (also worth a note on closed issue 500: cluster D's implementation was correct all along).
