### PR TITLE
feat(agentchat): interactive /mcp + /sessions overlay widget

### DIFF
--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -496,6 +496,18 @@ func (a *App) Close() {
 	}
 }
 
+// ReconnectServer forces the named MCP server to attempt connecting again: it
+// wakes a failed server that is sleeping between backoff retries and un-parks a
+// needs-login server (the caller has since logged in). A ready or unknown
+// server is a no-op. It is the data-only capability behind the /servers
+// reconnect command and the interactive /mcp overlay's reconnect action; the
+// surface renders the resulting state transitions from the group observer.
+func (a *App) ReconnectServer(id string) {
+	if a.group != nil {
+		a.group.Reconnect(id)
+	}
+}
+
 // RunTurn executes one user input, rendering events as they stream. History
 // threads across turns; a cancelled or failed turn leaves history at its
 // pre-turn state (and persists nothing) so the next attempt is clean.

--- a/agent/host/commands.go
+++ b/agent/host/commands.go
@@ -236,13 +236,32 @@ func (a *App) registerBuiltinCommands() {
 			return CmdResult{Kind: CmdApproval, Approval: a.approval}, nil
 		}})
 
-	r.Register(&Command{Name: "servers", Help: "list MCP servers and their connection state",
-		Run: func(context.Context, string) (CmdResult, error) {
+	r.Register(&Command{Name: "servers", Aliases: []string{"mcp"}, Help: "list MCP servers and their state; /servers reconnect <name> retries a failed/needs-login one",
+		Run: func(_ context.Context, args string) (CmdResult, error) {
+			if id, ok := strings.CutPrefix(args, "reconnect "); ok {
+				id = strings.TrimSpace(id)
+				a.ReconnectServer(id)
+				return CmdResult{Kind: CmdMessage, Message: "reconnect requested for " + id}, nil
+			}
 			var st []client.MemberStatus
 			if a.group != nil {
 				st = a.group.Status()
 			}
 			return CmdResult{Kind: CmdServers, Servers: st}, nil
+		},
+		Complete: func(prefix string) []string {
+			var out []string
+			if strings.HasPrefix("reconnect", prefix) {
+				out = append(out, "reconnect")
+			}
+			if a.group != nil {
+				for _, st := range a.group.Status() {
+					if strings.HasPrefix(st.ID, prefix) {
+						out = append(out, st.ID)
+					}
+				}
+			}
+			return out
 		}})
 
 	r.Register(&Command{Name: "session", Help: "show the active session id",

--- a/agent/host/commands_test.go
+++ b/agent/host/commands_test.go
@@ -186,6 +186,44 @@ func TestApp_DispatchSessionsListAndSwitch(t *testing.T) {
 	}
 }
 
+func TestApp_DispatchServersListAliasAndReconnect(t *testing.T) {
+	ctx := context.Background()
+	app, _ := newCmdApp(t)
+
+	// /servers lists the connected members; the /mcp alias resolves to the same.
+	list, err := app.Dispatch(ctx, "/servers")
+	if err != nil || list.Kind != CmdServers {
+		t.Fatalf("/servers = (%+v, %v)", list, err)
+	}
+	if len(list.Servers) == 0 {
+		t.Fatalf("/servers listed no members, want the configured server")
+	}
+	id := list.Servers[0].ID
+	alias, err := app.Dispatch(ctx, "/mcp")
+	if err != nil || alias.Kind != CmdServers || len(alias.Servers) != len(list.Servers) {
+		t.Fatalf("/mcp alias = (%+v, %v)", alias, err)
+	}
+
+	// reconnect subcommand is a data-only ack; on a ready member it is a no-op
+	// (proven at the client layer) but must not error here.
+	rc, err := app.Dispatch(ctx, "/servers reconnect "+id)
+	if err != nil || rc.Kind != CmdMessage || !strings.Contains(rc.Message, id) {
+		t.Fatalf("/servers reconnect = (%+v, %v)", rc, err)
+	}
+
+	// completer offers the reconnect subcommand and the member id.
+	cmd, ok := app.Commands().Lookup("servers")
+	if !ok || cmd.Complete == nil {
+		t.Fatal("servers command has no completer")
+	}
+	if got := cmd.Complete("rec"); len(got) != 1 || got[0] != "reconnect" {
+		t.Fatalf("Complete(rec) = %v, want [reconnect]", got)
+	}
+	if got := cmd.Complete(id[:1]); len(got) == 0 {
+		t.Fatalf("Complete(%q) offered no server id", id[:1])
+	}
+}
+
 func TestApp_SessionsNoStoreErrors(t *testing.T) {
 	ts := startTestServer(t)
 	var out strings.Builder

--- a/client/group.go
+++ b/client/group.go
@@ -82,6 +82,12 @@ type groupMember struct {
 	client   *Client
 	required bool
 
+	// reconnect wakes the member's run loop to attempt connecting immediately —
+	// either short-circuiting a failed member's backoff sleep or un-parking a
+	// needs-login member. Buffered (cap 1) so a wake is never lost to a
+	// not-currently-selecting loop and a redundant wake is simply dropped.
+	reconnect chan struct{}
+
 	// guarded by Group.mu
 	state   ConnState
 	err     error
@@ -181,7 +187,7 @@ func (g *Group) Add(id string, c *Client, required bool) {
 	if _, ok := g.members[id]; ok {
 		return
 	}
-	g.members[id] = &groupMember{id: id, client: c, required: required, state: StateDisabled, ready: make(chan struct{}), settled: make(chan struct{})}
+	g.members[id] = &groupMember{id: id, client: c, required: required, state: StateDisabled, reconnect: make(chan struct{}, 1), ready: make(chan struct{}), settled: make(chan struct{})}
 	g.order = append(g.order, id)
 }
 
@@ -210,8 +216,10 @@ func (g *Group) Start(ctx context.Context) {
 // run is one member's connect-and-retry loop. On success it settles at
 // StateReady and stops (a live drop after ready is out of scope for phase 1 —
 // the client reconnects a dropped live connection internally). On an auth
-// rejection it settles at StateNeedsLogin and stops (no hammering). Any other
-// failure retries with exponential backoff until the context is cancelled.
+// rejection it settles at StateNeedsLogin and parks — it does NOT auto-retry
+// (no hammering), but a Reconnect wakes it (the user has since logged in). Any
+// other failure retries with exponential backoff, which a Reconnect can
+// short-circuit; the loop runs until the context is cancelled.
 func (g *Group) run(m *groupMember) {
 	defer g.wg.Done()
 	backoff := g.minBackoff
@@ -237,16 +245,51 @@ func (g *Group) run(m *groupMember) {
 		state := classifyConnectErr(err)
 		g.set(m, state, err)
 		if state == StateNeedsLogin {
-			return
+			// Park until a Reconnect (post-login) or Close. No backoff timer —
+			// an auth rejection won't clear on its own, so retrying would only
+			// hammer the server.
+			select {
+			case <-g.ctx.Done():
+				return
+			case <-m.reconnect:
+				backoff = g.minBackoff
+			}
+			continue
 		}
 		select {
 		case <-g.ctx.Done():
 			return
+		case <-m.reconnect:
+			// Forced retry now — reset the backoff so the next failure starts
+			// from the floor again.
+			backoff = g.minBackoff
 		case <-time.After(backoff):
+			if backoff *= 2; backoff > g.maxBackoff {
+				backoff = g.maxBackoff
+			}
 		}
-		if backoff *= 2; backoff > g.maxBackoff {
-			backoff = g.maxBackoff
-		}
+	}
+}
+
+// Reconnect forces a stuck member to attempt connecting again now: it wakes a
+// failed member that is sleeping between backoff retries, and un-parks a
+// needs-login member (the caller has since logged in) whose loop is otherwise
+// idle. A ready member (nothing to reconnect — a live drop is handled by the
+// client internally), an in-flight connecting member, an unknown id, and a
+// not-yet-started or closing Group are all no-ops. Safe for concurrent and
+// repeated use — a redundant wake is dropped.
+func (g *Group) Reconnect(id string) {
+	g.mu.Lock()
+	m, ok := g.members[id]
+	if !ok || !g.started || g.ctx == nil || g.ctx.Err() != nil || m.state == StateReady || m.state == StateConnecting {
+		g.mu.Unlock()
+		return
+	}
+	wake := m.reconnect
+	g.mu.Unlock()
+	select {
+	case wake <- struct{}{}:
+	default:
 	}
 }
 

--- a/client/group_test.go
+++ b/client/group_test.go
@@ -2,9 +2,11 @@ package client_test
 
 import (
 	"context"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -166,6 +168,107 @@ func TestGroup_CloseRacingConnect(t *testing.T) {
 		case <-time.After(5 * time.Second):
 			t.Fatalf("iteration %d: httptest.Server.Close blocked — Connect raced Close and leaked", i)
 		}
+	}
+}
+
+// gatedServer wraps the real MCP handler behind an atomic gate: while the gate
+// is closed it returns downStatus (401 → needs-login, 5xx → failed), and once
+// opened it serves MCP normally. It is the reconnection-path fixture — a member
+// gets stuck, the gate opens, and Reconnect must recover it.
+func gatedServer(t *testing.T, downStatus int) (*httptest.Server, *atomic.Bool) {
+	t.Helper()
+	real := testutil.NewTestServer().Handler(server.WithStreamableHTTP(true))
+	var up atomic.Bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !up.Load() {
+			w.WriteHeader(downStatus)
+			return
+		}
+		real.ServeHTTP(w, r)
+	}))
+	t.Cleanup(ts.Close)
+	return ts, &up
+}
+
+// TestGroup_ReconnectFromNeedsLogin is the primary reconnect path: a 401 parks
+// the member at needs-login with no auto-retry; after the operator "logs in"
+// (the gate opens) Reconnect un-parks it and it reaches ready. Without
+// Reconnect a parked member would never retry, so reaching ready proves the
+// wake works.
+func TestGroup_ReconnectFromNeedsLogin(t *testing.T) {
+	ts, up := gatedServer(t, http.StatusUnauthorized)
+	g := client.NewGroup(client.WithGroupBackoff(10*time.Millisecond, 50*time.Millisecond))
+	g.Add("a", client.NewClient(ts.URL+"/mcp", ci), false)
+	g.Start(context.Background())
+	defer g.Close()
+
+	waitState(t, g, "a", client.StateNeedsLogin, 3*time.Second)
+	// Parked: it must NOT climb out on its own.
+	time.Sleep(150 * time.Millisecond)
+	if s, _ := g.State("a"); s != client.StateNeedsLogin {
+		t.Fatalf("needs-login member auto-retried (state=%v); it should park until Reconnect", s)
+	}
+
+	up.Store(true)
+	g.Reconnect("a")
+	waitState(t, g, "a", client.StateReady, 3*time.Second)
+}
+
+// TestGroup_ReconnectWakesBackoff proves Reconnect short-circuits a failed
+// member's backoff sleep. The backoff is pinned to 30s, so without a wake the
+// member would not retry within the test window; Reconnect makes it retry now
+// and reach ready.
+func TestGroup_ReconnectWakesBackoff(t *testing.T) {
+	ts, up := gatedServer(t, http.StatusServiceUnavailable)
+	g := client.NewGroup(client.WithGroupBackoff(30*time.Second, 30*time.Second))
+	g.Add("a", client.NewClient(ts.URL+"/mcp", ci), false)
+	g.Start(context.Background())
+	defer g.Close()
+
+	waitState(t, g, "a", client.StateFailed, 3*time.Second)
+	up.Store(true)
+	g.Reconnect("a")
+	waitState(t, g, "a", client.StateReady, 3*time.Second)
+}
+
+// TestGroup_ReconnectReadyIsNoop verifies Reconnect on a ready member does not
+// trigger a fresh connect (a live drop is the client's concern, not the
+// Group's) — no new StateConnecting transition fires and the member stays
+// ready.
+func TestGroup_ReconnectReadyIsNoop(t *testing.T) {
+	ts := testMCPServer(t)
+	var mu sync.Mutex
+	connects := 0
+	g := client.NewGroup(
+		client.WithRequiredTimeout(5*time.Second),
+		client.WithObserver(func(sc client.StateChange) {
+			if sc.State == client.StateConnecting {
+				mu.Lock()
+				connects++
+				mu.Unlock()
+			}
+		}),
+	)
+	g.Add("a", client.NewClient(ts.URL+"/mcp", ci), true)
+	g.Start(context.Background())
+	defer g.Close()
+	if err := g.WaitRequired(context.Background()); err != nil {
+		t.Fatalf("WaitRequired: %v", err)
+	}
+
+	mu.Lock()
+	before := connects
+	mu.Unlock()
+	g.Reconnect("a")
+	time.Sleep(150 * time.Millisecond)
+	mu.Lock()
+	after := connects
+	mu.Unlock()
+	if after != before {
+		t.Fatalf("Reconnect on a ready member forced a reconnect (connecting transitions %d→%d)", before, after)
+	}
+	if s, _ := g.State("a"); s != client.StateReady {
+		t.Fatalf("state = %v, want ready", s)
 	}
 }
 

--- a/cmd/agentchat/notebook.go
+++ b/cmd/agentchat/notebook.go
@@ -224,7 +224,8 @@ type notebookModel struct {
 
 	keys    appKeys
 	help    help.Model
-	showAll bool // ? toggled the full-help view
+	overlay *overlayModel // non-nil while an interactive dialog (/mcp, /sessions) is open
+	showAll bool          // ? toggled the full-help view
 
 	nav      bool // false = insert, true = nav
 	sel      int  // selected cell index in nav mode
@@ -328,6 +329,14 @@ func (m notebookModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.usage = msg
 		return m, nil
 
+	case openOverlayMsg:
+		m.overlay = msg.ov
+		if m.overlay != nil {
+			m.overlay.setWidth(m.width)
+			m.ta.Blur()
+		}
+		return m, nil
+
 	case tea.MouseMsg:
 		m.vp, _ = m.vp.Update(msg)
 		m.atBottom = m.vp.AtBottom()
@@ -336,6 +345,20 @@ func (m notebookModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		if msg.Type == tea.KeyCtrlC {
 			return m, tea.Quit
+		}
+		// An open dialog owns the keyboard until it acts or dismisses.
+		if m.overlay != nil {
+			out := m.overlay.handleKey(msg)
+			switch {
+			case out.Dismiss:
+				m.overlay = nil
+				m.ta.Focus()
+			case out.Line != "":
+				m.overlay = nil
+				m.ta.Focus()
+				return m.submit(out.Line)
+			}
+			return m, nil
 		}
 		if m.nav {
 			return m.updateNav(msg)
@@ -462,6 +485,10 @@ func (m notebookModel) View() string {
 	if !m.ready {
 		return "starting…"
 	}
+	// An open dialog renders between the transcript and the input.
+	if m.overlay != nil {
+		return m.vp.View() + "\n" + m.overlay.View() + "\n" + m.ta.View()
+	}
 	return m.vp.View() + "\n" + m.statusBar() + "\n" + m.ta.View()
 }
 
@@ -587,6 +614,8 @@ func (m notebookModel) submit(line string) (tea.Model, tea.Cmd) {
 				surface.On(host.HostEvent{Kind: host.HostTurnFailed, Err: "unknown command " + line})
 			case err != nil:
 				surface.On(host.HostEvent{Kind: host.HostTurnFailed, Err: err.Error()})
+			case overlayFor(res) != nil:
+				surface.prog.Send(openOverlayMsg{ov: overlayFor(res)})
 			default:
 				surface.On(host.HostEvent{Kind: host.HostCommandResult, Command: res})
 				if res.Quit {

--- a/cmd/agentchat/notebook.go
+++ b/cmd/agentchat/notebook.go
@@ -224,8 +224,8 @@ type notebookModel struct {
 
 	keys    appKeys
 	help    help.Model
-	overlay *overlayModel // non-nil while an interactive dialog (/mcp, /sessions) is open
-	showAll bool          // ? toggled the full-help view
+	modalHost // an open interactive dialog (/mcp, /sessions) as the focused layer
+	showAll bool // ? toggled the full-help view
 
 	nav      bool // false = insert, true = nav
 	sel      int  // selected cell index in nav mode
@@ -330,11 +330,8 @@ func (m notebookModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case openOverlayMsg:
-		m.overlay = msg.ov
-		if m.overlay != nil {
-			m.overlay.setWidth(m.width)
-			m.ta.Blur()
-		}
+		m.open(msg.ov, m.width)
+		m.ta.Blur()
 		return m, nil
 
 	case tea.MouseMsg:
@@ -347,16 +344,13 @@ func (m notebookModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		}
 		// An open dialog owns the keyboard until it acts or dismisses.
-		if m.overlay != nil {
-			out := m.overlay.handleKey(msg)
-			switch {
-			case out.Dismiss:
-				m.overlay = nil
+		if m.active() {
+			line, open := m.route(msg)
+			if !open {
 				m.ta.Focus()
-			case out.Line != "":
-				m.overlay = nil
-				m.ta.Focus()
-				return m.submit(out.Line)
+			}
+			if line != "" {
+				return m.submit(line)
 			}
 			return m, nil
 		}
@@ -486,8 +480,8 @@ func (m notebookModel) View() string {
 		return "starting…"
 	}
 	// An open dialog renders between the transcript and the input.
-	if m.overlay != nil {
-		return m.vp.View() + "\n" + m.overlay.View() + "\n" + m.ta.View()
+	if m.active() {
+		return m.vp.View() + "\n" + m.view(m.ta.View())
 	}
 	return m.vp.View() + "\n" + m.statusBar() + "\n" + m.ta.View()
 }

--- a/cmd/agentchat/overlay.go
+++ b/cmd/agentchat/overlay.go
@@ -1,0 +1,278 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/panyam/mcpkit/agent/host"
+	"github.com/panyam/mcpkit/client"
+)
+
+// overlayAction is one action offered on the selected overlay row. Key is the
+// single key that triggers it in addition to Enter for the primary action (the
+// action whose Key is ""); Label names it in the footer. Line is the App
+// command the surface dispatches when the action fires — an empty Line marks
+// the action unavailable (rendered dimmed), the seam a not-yet-built capability
+// (per-server login, per-server tool view) slots into without a widget change.
+type overlayAction struct {
+	Key   string
+	Label string
+	Line  string
+}
+
+// overlayItem is one selectable row: a label, a dimmed detail (state, message
+// count), and the actions available on it.
+type overlayItem struct {
+	Label   string
+	Detail  string
+	Actions []overlayAction
+}
+
+// overlayOutcome is what handleKey reports back to the host surface: dismiss the
+// overlay, dispatch a command Line (and close), or neither (key consumed, stay
+// open). Keeping the surface as the dispatcher is what keeps App.Dispatch
+// data-only — the overlay yields a command string, it does not call the host.
+type overlayOutcome struct {
+	Dismiss bool
+	Line    string
+}
+
+// overlayModel is the reusable interactive dialog rendered in the bottom region
+// of a TUI surface (issue 1095): a titled, selectable list with per-row keyed
+// actions, Enter for the primary action and Esc to dismiss. It is
+// surface-agnostic — both the inline TUI and the notebook embed one and route
+// keys to handleKey while it is open — and content-agnostic: /mcp, the
+// /sessions picker, and future dialogs build one from a CmdResult. Rendering
+// stays here in the surface; the host stays data-only.
+type overlayModel struct {
+	title   string
+	items   []overlayItem
+	cursor  int
+	top     int // first visible row (scroll offset)
+	width   int
+	maxRows int // visible-row cap; the list scrolls past it
+}
+
+// newOverlay builds an overlay with a bounded visible window (long lists
+// scroll). An empty item list is valid — the overlay renders a placeholder and
+// only Esc acts.
+func newOverlay(title string, items []overlayItem) *overlayModel {
+	return &overlayModel{title: title, items: items, maxRows: 10}
+}
+
+// setWidth fans the surface width to the overlay so its box reflows on resize.
+func (o *overlayModel) setWidth(w int) { o.width = w }
+
+// move shifts the selection by d (clamped), keeping the cursor inside the
+// visible window by scrolling top as needed.
+func (o *overlayModel) move(d int) {
+	if len(o.items) == 0 {
+		return
+	}
+	o.cursor += d
+	if o.cursor < 0 {
+		o.cursor = 0
+	}
+	if o.cursor >= len(o.items) {
+		o.cursor = len(o.items) - 1
+	}
+	if o.cursor < o.top {
+		o.top = o.cursor
+	}
+	if o.cursor >= o.top+o.maxRows {
+		o.top = o.cursor - o.maxRows + 1
+	}
+}
+
+// primary returns the selected row's Enter action (the one with Key == "").
+func (o *overlayModel) primary() (overlayAction, bool) {
+	if len(o.items) == 0 {
+		return overlayAction{}, false
+	}
+	for _, a := range o.items[o.cursor].Actions {
+		if a.Key == "" {
+			return a, true
+		}
+	}
+	return overlayAction{}, false
+}
+
+// handleKey advances the overlay for one keypress and reports the outcome:
+// Esc dismisses; Up/Down (or k/j, Ctrl+P/N) move; Enter fires the primary
+// action; any other key that matches a secondary action's Key on the selected
+// row fires that action. An action with an empty Line is unavailable and does
+// nothing.
+func (o *overlayModel) handleKey(msg tea.KeyMsg) overlayOutcome {
+	switch msg.String() {
+	case "esc":
+		return overlayOutcome{Dismiss: true}
+	case "up", "k", "ctrl+p":
+		o.move(-1)
+	case "down", "j", "ctrl+n":
+		o.move(1)
+	case "enter":
+		if a, ok := o.primary(); ok && a.Line != "" {
+			return overlayOutcome{Line: a.Line}
+		}
+	default:
+		if len(o.items) > 0 {
+			for _, a := range o.items[o.cursor].Actions {
+				if a.Key != "" && a.Key == msg.String() && a.Line != "" {
+					return overlayOutcome{Line: a.Line}
+				}
+			}
+		}
+	}
+	return overlayOutcome{}
+}
+
+// View renders the overlay as a bordered panel: the title, the visible window
+// of rows (the selected row highlighted, its available actions in a footer),
+// and a dim key hint. Dynamic height — the box grows with the visible rows.
+func (o *overlayModel) View() string {
+	dim := lipgloss.NewStyle().Faint(true)
+	sel := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("6"))
+	var b strings.Builder
+	b.WriteString(sel.Render(o.title))
+	b.WriteString("\n")
+
+	if len(o.items) == 0 {
+		b.WriteString(dim.Render("  (nothing to show)"))
+		b.WriteString("\n")
+	} else {
+		end := o.top + o.maxRows
+		if end > len(o.items) {
+			end = len(o.items)
+		}
+		if o.top > 0 {
+			b.WriteString(dim.Render("  ↑ more"))
+			b.WriteString("\n")
+		}
+		for i := o.top; i < end; i++ {
+			it := o.items[i]
+			row := fmt.Sprintf("%-24s %s", it.Label, dim.Render(it.Detail))
+			if i == o.cursor {
+				b.WriteString(sel.Render("▸ " + row))
+			} else {
+				b.WriteString("  " + row)
+			}
+			b.WriteString("\n")
+		}
+		if end < len(o.items) {
+			b.WriteString(dim.Render("  ↓ more"))
+			b.WriteString("\n")
+		}
+	}
+
+	b.WriteString(dim.Render(o.footer()))
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		Padding(0, 1).
+		Render(b.String())
+}
+
+// footer lists the keys: the selected row's actions plus the always-present
+// navigation and dismiss hints. Unavailable actions (empty Line) are shown so
+// the user sees the capability exists but is dimmed by the whole-footer style.
+func (o *overlayModel) footer() string {
+	var acts []string
+	if len(o.items) > 0 {
+		for _, a := range o.items[o.cursor].Actions {
+			k := a.Key
+			if k == "" {
+				k = "enter"
+			}
+			label := a.Label
+			if a.Line == "" {
+				label += " (n/a)"
+			}
+			acts = append(acts, k+" "+label)
+		}
+	}
+	acts = append(acts, "↑↓ move", "esc close")
+	return strings.Join(acts, " · ")
+}
+
+// serversOverlay builds the interactive /mcp (alias /servers) view from a
+// CmdServers result: one row per MCP server, its connection state as the
+// detail, and a reconnect action on any failed or needs-login server. Login and
+// per-server tool view are shown as unavailable pending their capability
+// (deferred follow-ups).
+func serversOverlay(res host.CmdResult) *overlayModel {
+	items := make([]overlayItem, 0, len(res.Servers))
+	for _, s := range res.Servers {
+		detail := s.State.String()
+		if s.Required {
+			detail += " · required"
+		}
+		if s.Err != nil {
+			detail += " · " + s.Err.Error()
+		}
+		var actions []overlayAction
+		if canReconnect(s.State) {
+			actions = append(actions, overlayAction{Label: "reconnect", Line: "/servers reconnect " + s.ID})
+		} else {
+			actions = append(actions, overlayAction{Label: "reconnect"}) // n/a for ready/connecting
+		}
+		if s.State == client.StateNeedsLogin {
+			actions = append(actions, overlayAction{Key: "l", Label: "login"}) // n/a: follow-up
+		}
+		items = append(items, overlayItem{Label: s.ID, Detail: detail, Actions: actions})
+	}
+	return newOverlay("MCP servers", items)
+}
+
+// canReconnect reports whether a reconnect action is meaningful for a state: a
+// failed (backoff) or needs-login (parked) server, not a ready or in-flight one.
+func canReconnect(s client.ConnState) bool {
+	return s == client.StateFailed || s == client.StateNeedsLogin
+}
+
+// sessionsOverlay builds the interactive /sessions picker from a CmdSessions
+// result: one row per persisted run, message count and lineage as the detail,
+// the active run marked, and Enter to resume it. This is the reusability proof
+// for the widget (issue 1095) — resume works today, so the picker is fully
+// functional.
+func sessionsOverlay(res host.CmdResult) *overlayModel {
+	items := make([]overlayItem, 0, len(res.Sessions))
+	active := -1
+	for i, s := range res.Sessions {
+		detail := fmt.Sprintf("%d msg", s.MessageCount)
+		if s.ID == res.RunID {
+			detail += " · active"
+			active = i
+		}
+		if s.ParentID != "" {
+			detail += fmt.Sprintf(" · forked from %s @%d", s.ParentID, s.ForkPoint)
+		}
+		items = append(items, overlayItem{
+			Label:   s.ID,
+			Detail:  detail,
+			Actions: []overlayAction{{Label: "resume", Line: "/resume " + s.ID}},
+		})
+	}
+	o := newOverlay("sessions", items)
+	if active >= 0 {
+		o.cursor = active
+		o.move(0) // clamp the scroll window onto the active row
+	}
+	return o
+}
+
+// overlayFor converts a command result into the overlay that presents it, or
+// nil when the result is not an interactive-picker shape. Centralizes the
+// surface's "which CmdKinds open an overlay" decision so both TUI surfaces
+// share it.
+func overlayFor(res host.CmdResult) *overlayModel {
+	switch res.Kind {
+	case host.CmdServers:
+		return serversOverlay(res)
+	case host.CmdSessions:
+		return sessionsOverlay(res)
+	default:
+		return nil
+	}
+}

--- a/cmd/agentchat/overlay.go
+++ b/cmd/agentchat/overlay.go
@@ -40,6 +40,71 @@ type overlayOutcome struct {
 	Line    string
 }
 
+// focusLayer is a modal component that temporarily owns the keyboard above a
+// surface's base view: it consumes keys and renders itself. The overlay is the
+// only implementation today; the seam is what lets both TUI surfaces share the
+// open/route/dismiss glue instead of each special-casing *overlayModel. The
+// fuller model — base view and overlay as peer layers routed uniformly — is the
+// focus-management design-track item (issue 1063 C4).
+type focusLayer interface {
+	handleKey(tea.KeyMsg) overlayOutcome
+	setWidth(int)
+	View() string
+}
+
+// modalHost is the shared state a surface needs to carry an optional modal
+// layer. Both TUI models embed one, so "is a modal open, route keys to it,
+// close it" is defined once here rather than branched per surface. It holds
+// only the layer (a pointer, safe across the value-copies bubbletea makes each
+// Update); blurring/focusing the input stays with the surface that owns it.
+type modalHost struct {
+	layer focusLayer
+}
+
+// active reports whether a modal layer currently owns the keyboard.
+func (h *modalHost) active() bool { return h.layer != nil }
+
+// open installs l as the active modal and sizes it to the surface width. The
+// caller blurs its own input after this.
+func (h *modalHost) open(l focusLayer, width int) {
+	h.layer = l
+	if l != nil {
+		l.setWidth(width)
+	}
+}
+
+// setWidth reflows the active layer on resize; a no-op when none is open.
+func (h *modalHost) setWidth(w int) {
+	if h.layer != nil {
+		h.layer.setWidth(w)
+	}
+}
+
+// route feeds one key to the active modal and reports the command line to
+// dispatch (empty unless an action fired) and whether the modal stays open. On
+// close it clears the layer; the caller refocuses its own input when open is
+// false.
+func (h *modalHost) route(msg tea.KeyMsg) (line string, open bool) {
+	out := h.layer.handleKey(msg)
+	switch {
+	case out.Dismiss:
+		h.layer = nil
+		return "", false
+	case out.Line != "":
+		h.layer = nil
+		return out.Line, false
+	default:
+		return "", true
+	}
+}
+
+// view composes the modal above the surface's base region (passed in, since the
+// base differs per surface: the input alone for the inline TUI, the viewport
+// plus input for the notebook).
+func (h *modalHost) view(base string) string {
+	return h.layer.View() + "\n" + base
+}
+
 // overlayModel is the reusable interactive dialog rendered in the bottom region
 // of a TUI surface (issue 1095): a titled, selectable list with per-row keyed
 // actions, Enter for the primary action and Esc to dismiss. It is

--- a/cmd/agentchat/overlay_test.go
+++ b/cmd/agentchat/overlay_test.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/panyam/mcpkit/agent"
+	"github.com/panyam/mcpkit/agent/host"
+	"github.com/panyam/mcpkit/client"
+)
+
+func kmsg(s string) tea.KeyMsg {
+	switch s {
+	case "enter":
+		return tea.KeyMsg{Type: tea.KeyEnter}
+	case "esc":
+		return tea.KeyMsg{Type: tea.KeyEsc}
+	case "up":
+		return tea.KeyMsg{Type: tea.KeyUp}
+	case "down":
+		return tea.KeyMsg{Type: tea.KeyDown}
+	default:
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+	}
+}
+
+func TestOverlay_EscDismisses(t *testing.T) {
+	o := newOverlay("t", []overlayItem{{Label: "a"}})
+	if out := o.handleKey(kmsg("esc")); !out.Dismiss {
+		t.Fatalf("esc = %+v, want Dismiss", out)
+	}
+}
+
+func TestOverlay_MoveClampsAndScrolls(t *testing.T) {
+	items := make([]overlayItem, 25)
+	for i := range items {
+		items[i] = overlayItem{Label: string(rune('a' + i))}
+	}
+	o := newOverlay("t", items) // maxRows 10
+
+	o.move(-1) // clamp at top
+	if o.cursor != 0 || o.top != 0 {
+		t.Fatalf("up at top: cursor=%d top=%d", o.cursor, o.top)
+	}
+	for i := 0; i < 12; i++ {
+		o.move(1)
+	}
+	if o.cursor != 12 {
+		t.Fatalf("cursor = %d, want 12", o.cursor)
+	}
+	if o.cursor < o.top || o.cursor >= o.top+o.maxRows {
+		t.Fatalf("cursor %d outside window [%d,%d)", o.cursor, o.top, o.top+o.maxRows)
+	}
+	for i := 0; i < 50; i++ {
+		o.move(1) // clamp at bottom
+	}
+	if o.cursor != len(items)-1 {
+		t.Fatalf("cursor = %d, want %d", o.cursor, len(items)-1)
+	}
+}
+
+func TestOverlay_EnterFiresPrimary(t *testing.T) {
+	o := newOverlay("t", []overlayItem{
+		{Label: "a", Actions: []overlayAction{{Label: "go", Line: "/resume a"}}},
+	})
+	if out := o.handleKey(kmsg("enter")); out.Line != "/resume a" {
+		t.Fatalf("enter = %+v, want Line /resume a", out)
+	}
+}
+
+func TestOverlay_SecondaryKeyFires(t *testing.T) {
+	o := newOverlay("t", []overlayItem{
+		{Label: "a", Actions: []overlayAction{
+			{Label: "reconnect", Line: "/servers reconnect a"},
+			{Key: "l", Label: "login", Line: "/login a"},
+		}},
+	})
+	if out := o.handleKey(kmsg("l")); out.Line != "/login a" {
+		t.Fatalf("l = %+v, want Line /login a", out)
+	}
+}
+
+func TestOverlay_DisabledActionDoesNothing(t *testing.T) {
+	o := newOverlay("t", []overlayItem{
+		{Label: "a", Actions: []overlayAction{{Label: "reconnect"}}}, // empty Line = n/a
+	})
+	if out := o.handleKey(kmsg("enter")); out != (overlayOutcome{}) {
+		t.Fatalf("enter on disabled primary = %+v, want no-op", out)
+	}
+}
+
+func TestOverlay_EmptyItemsOnlyEscActs(t *testing.T) {
+	o := newOverlay("t", nil)
+	if out := o.handleKey(kmsg("enter")); out != (overlayOutcome{}) {
+		t.Fatalf("enter on empty = %+v, want no-op", out)
+	}
+	if out := o.handleKey(kmsg("j")); out != (overlayOutcome{}) {
+		t.Fatalf("j on empty = %+v, want no-op", out)
+	}
+	if out := o.handleKey(kmsg("esc")); !out.Dismiss {
+		t.Fatal("esc on empty should dismiss")
+	}
+	_ = o.View() // must not panic on an empty list
+}
+
+func TestServersOverlay_ReconnectOnlyWhenStuck(t *testing.T) {
+	res := host.CmdResult{Kind: host.CmdServers, Servers: []client.MemberStatus{
+		{ID: "ready", State: client.StateReady},
+		{ID: "down", State: client.StateFailed, Err: errors.New("refused")},
+		{ID: "auth", State: client.StateNeedsLogin},
+	}}
+	o := serversOverlay(res)
+
+	// ready: reconnect present but unavailable (empty Line)
+	if got := primaryLine(o.items[0]); got != "" {
+		t.Fatalf("ready primary line = %q, want empty (n/a)", got)
+	}
+	// failed + needs-login: reconnect is the primary action
+	if got := primaryLine(o.items[1]); got != "/servers reconnect down" {
+		t.Fatalf("failed primary = %q", got)
+	}
+	if got := primaryLine(o.items[2]); got != "/servers reconnect auth" {
+		t.Fatalf("needs-login primary = %q", got)
+	}
+	// the error surfaces in the detail
+	if !strings.Contains(o.items[1].Detail, "refused") {
+		t.Fatalf("failed detail = %q, want the error", o.items[1].Detail)
+	}
+}
+
+func TestSessionsOverlay_ResumeAndActiveCursor(t *testing.T) {
+	res := host.CmdResult{Kind: host.CmdSessions, RunID: "s2", Sessions: []agent.RunInfo{
+		{ID: "s1", MessageCount: 3},
+		{ID: "s2", MessageCount: 5},
+	}}
+	o := sessionsOverlay(res)
+	if o.cursor != 1 {
+		t.Fatalf("cursor = %d, want 1 (the active run)", o.cursor)
+	}
+	if got := primaryLine(o.items[1]); got != "/resume s2" {
+		t.Fatalf("resume line = %q", got)
+	}
+	if !strings.Contains(o.items[1].Detail, "active") {
+		t.Fatalf("active row not marked: %q", o.items[1].Detail)
+	}
+}
+
+func TestOverlayFor_OnlyInteractiveKinds(t *testing.T) {
+	if overlayFor(host.CmdResult{Kind: host.CmdServers}) == nil {
+		t.Fatal("CmdServers should open an overlay")
+	}
+	if overlayFor(host.CmdResult{Kind: host.CmdSessions}) == nil {
+		t.Fatal("CmdSessions should open an overlay")
+	}
+	if overlayFor(host.CmdResult{Kind: host.CmdMessage, Message: "hi"}) != nil {
+		t.Fatal("CmdMessage should not open an overlay")
+	}
+}
+
+// primaryLine is the test helper for the selected row's Enter action line.
+func primaryLine(it overlayItem) string {
+	for _, a := range it.Actions {
+		if a.Key == "" {
+			return a.Line
+		}
+	}
+	return ""
+}

--- a/cmd/agentchat/tui.go
+++ b/cmd/agentchat/tui.go
@@ -221,8 +221,8 @@ type tuiModel struct {
 	ta      textarea.Model
 	keys    appKeys
 	help    help.Model
-	overlay *overlayModel // non-nil while an interactive dialog (/mcp, /sessions) is open
-	showAll bool          // ? toggled the full-help view
+	modalHost // an open interactive dialog (/mcp, /sessions) as the focused layer
+	showAll bool // ? toggled the full-help view
 	history []string
 	histIdx int // len(history) == "not navigating"
 	running bool
@@ -275,17 +275,12 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.surface != nil {
 			m.surface.setWidth(msg.Width)
 		}
-		if m.overlay != nil {
-			m.overlay.setWidth(msg.Width)
-		}
+		m.setWidth(msg.Width) // reflow the modal layer if one is open
 		return m, nil
 
 	case openOverlayMsg:
-		m.overlay = msg.ov
-		if m.overlay != nil {
-			m.overlay.setWidth(m.ta.Width())
-			m.ta.Blur() // focus goes to the overlay
-		}
+		m.open(msg.ov, m.ta.Width())
+		m.ta.Blur() // focus goes to the overlay
 		return m, nil
 
 	case liveMsg:
@@ -320,16 +315,13 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		// While a dialog is open it owns the keyboard (focus routing): navigate,
 		// act (which dispatches a command line and closes), or dismiss.
-		if m.overlay != nil {
-			out := m.overlay.handleKey(msg)
-			switch {
-			case out.Dismiss:
-				m.overlay = nil
+		if m.active() {
+			line, open := m.route(msg)
+			if !open {
 				m.ta.Focus()
-			case out.Line != "":
-				m.overlay = nil
-				m.ta.Focus()
-				return m.submit(out.Line)
+			}
+			if line != "" {
+				return m.submit(line)
 			}
 			return m, nil
 		}
@@ -380,10 +372,8 @@ func (m tuiModel) View() string {
 		b.WriteString("\n")
 	}
 	// An open dialog takes over the managed region above the input.
-	if m.overlay != nil {
-		b.WriteString(m.overlay.View())
-		b.WriteString("\n")
-		b.WriteString(m.ta.View())
+	if m.active() {
+		b.WriteString(m.view(m.ta.View()))
 		return b.String()
 	}
 	status := statusLine(m.app, m.session, m.usage, m.window)

--- a/cmd/agentchat/tui.go
+++ b/cmd/agentchat/tui.go
@@ -36,6 +36,12 @@ type turnDoneMsg struct{}
 // a live context gauge. Sent by the observers on HostTurnDone.
 type usageMsg struct{ in, out int }
 
+// openOverlayMsg opens an interactive overlay (the /mcp server panel, the
+// /sessions picker) in the bottom region instead of committing the command's
+// result to scrollback. Sent from the dispatch goroutine when a command returns
+// an interactive-picker shape (issue 1095).
+type openOverlayMsg struct{ ov *overlayModel }
+
 // statusLine renders the persistent status: model · session · last-turn tokens,
 // plus a "N% context left" gauge when a context window is configured (issue
 // 1063 D1/D2). Kept out of the transcript — it lives only in the managed live
@@ -215,7 +221,8 @@ type tuiModel struct {
 	ta      textarea.Model
 	keys    appKeys
 	help    help.Model
-	showAll bool // ? toggled the full-help view
+	overlay *overlayModel // non-nil while an interactive dialog (/mcp, /sessions) is open
+	showAll bool          // ? toggled the full-help view
 	history []string
 	histIdx int // len(history) == "not navigating"
 	running bool
@@ -268,6 +275,17 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.surface != nil {
 			m.surface.setWidth(msg.Width)
 		}
+		if m.overlay != nil {
+			m.overlay.setWidth(msg.Width)
+		}
+		return m, nil
+
+	case openOverlayMsg:
+		m.overlay = msg.ov
+		if m.overlay != nil {
+			m.overlay.setWidth(m.ta.Width())
+			m.ta.Blur() // focus goes to the overlay
+		}
 		return m, nil
 
 	case liveMsg:
@@ -296,9 +314,26 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyMsg:
-		switch {
-		case key.Matches(msg, m.keys.Quit):
+		// Ctrl+C always quits, even with an overlay open.
+		if key.Matches(msg, m.keys.Quit) {
 			return m, tea.Quit
+		}
+		// While a dialog is open it owns the keyboard (focus routing): navigate,
+		// act (which dispatches a command line and closes), or dismiss.
+		if m.overlay != nil {
+			out := m.overlay.handleKey(msg)
+			switch {
+			case out.Dismiss:
+				m.overlay = nil
+				m.ta.Focus()
+			case out.Line != "":
+				m.overlay = nil
+				m.ta.Focus()
+				return m.submit(out.Line)
+			}
+			return m, nil
+		}
+		switch {
 		case key.Matches(msg, m.keys.Help) && m.ta.Value() == "":
 			// `?` toggles full help only on an empty prompt, so it stays typeable
 			// mid-message.
@@ -344,6 +379,13 @@ func (m tuiModel) View() string {
 		b.WriteString(strings.TrimRight(m.pending, "\n"))
 		b.WriteString("\n")
 	}
+	// An open dialog takes over the managed region above the input.
+	if m.overlay != nil {
+		b.WriteString(m.overlay.View())
+		b.WriteString("\n")
+		b.WriteString(m.ta.View())
+		return b.String()
+	}
 	status := statusLine(m.app, m.session, m.usage, m.window)
 	if m.running {
 		status = "working… · " + status
@@ -380,6 +422,10 @@ func (m tuiModel) submit(line string) (tea.Model, tea.Cmd) {
 				surface.On(host.HostEvent{Kind: host.HostTurnFailed, Err: "unknown command " + line})
 			case err != nil:
 				surface.On(host.HostEvent{Kind: host.HostTurnFailed, Err: err.Error()})
+			case overlayFor(res) != nil:
+				// An interactive-picker result (/mcp, /sessions) opens a dialog in
+				// the bottom region rather than committing to scrollback.
+				surface.prog.Send(openOverlayMsg{ov: overlayFor(res)})
 			default:
 				surface.On(host.HostEvent{Kind: host.HostCommandResult, Command: res})
 				if res.Quit {

--- a/cmd/agentchat/tui_test.go
+++ b/cmd/agentchat/tui_test.go
@@ -118,6 +118,38 @@ func TestUpdateLiveThenCommit(t *testing.T) {
 	}
 }
 
+func TestOverlayOpenRouteDismiss(t *testing.T) {
+	m := newTUIModel(nil, nil, 0)
+	ov := newOverlay("sessions", []overlayItem{
+		{Label: "s1", Actions: []overlayAction{{Label: "resume", Line: "/resume s1"}}},
+		{Label: "s2", Actions: []overlayAction{{Label: "resume", Line: "/resume s2"}}},
+	})
+
+	// opening the overlay renders it in the managed frame and blurs the input
+	next, _ := m.Update(openOverlayMsg{ov: ov})
+	m = next.(tuiModel)
+	if m.overlay == nil {
+		t.Fatal("openOverlayMsg should set the overlay")
+	}
+	if !strings.Contains(m.View(), "sessions") {
+		t.Fatal("overlay title should render in the view")
+	}
+
+	// keys route to the overlay (down moves the selection), not the textarea
+	next, _ = m.Update(kmsg("down"))
+	m = next.(tuiModel)
+	if m.overlay.cursor != 1 {
+		t.Fatalf("down should move the overlay cursor, got %d", m.overlay.cursor)
+	}
+
+	// esc dismisses and refocuses the input
+	next, _ = m.Update(kmsg("esc"))
+	m = next.(tuiModel)
+	if m.overlay != nil {
+		t.Fatal("esc should dismiss the overlay")
+	}
+}
+
 func TestUpdateTurnDoneClearsRunning(t *testing.T) {
 	m := newTUIModel(nil, nil, 0)
 	m.running = true

--- a/cmd/agentchat/tui_test.go
+++ b/cmd/agentchat/tui_test.go
@@ -128,8 +128,8 @@ func TestOverlayOpenRouteDismiss(t *testing.T) {
 	// opening the overlay renders it in the managed frame and blurs the input
 	next, _ := m.Update(openOverlayMsg{ov: ov})
 	m = next.(tuiModel)
-	if m.overlay == nil {
-		t.Fatal("openOverlayMsg should set the overlay")
+	if !m.active() {
+		t.Fatal("openOverlayMsg should set the overlay as the focused layer")
 	}
 	if !strings.Contains(m.View(), "sessions") {
 		t.Fatal("overlay title should render in the view")
@@ -138,14 +138,14 @@ func TestOverlayOpenRouteDismiss(t *testing.T) {
 	// keys route to the overlay (down moves the selection), not the textarea
 	next, _ = m.Update(kmsg("down"))
 	m = next.(tuiModel)
-	if m.overlay.cursor != 1 {
-		t.Fatalf("down should move the overlay cursor, got %d", m.overlay.cursor)
+	if got := m.layer.(*overlayModel).cursor; got != 1 {
+		t.Fatalf("down should move the overlay cursor, got %d", got)
 	}
 
 	// esc dismisses and refocuses the input
 	next, _ = m.Update(kmsg("esc"))
 	m = next.(tuiModel)
-	if m.overlay != nil {
+	if m.active() {
 		t.Fatal("esc should dismiss the overlay")
 	}
 }


### PR DESCRIPTION
## What changes

Typing `/mcp` (a new alias of `/servers`) or `/sessions` in agentchat now opens an interactive dialog in the bottom region instead of printing a static list to scrollback. The dialog is a selectable list with per-row actions: Enter acts, Esc dismisses, ↑↓/j/k move. It is one reusable widget shared by both TUI surfaces (inline `tui` and `notebook`) and both consumers, so it also becomes the interactive `/sessions` picker and the base for future dialogs (closes issue 1095; advances the overlay/scroll-select items in the TUI design track, issue 1063).

The server view's reconnect action is functional: a new `client.Group.Reconnect` wakes a failed member that is sleeping between backoff retries and un-parks a needs-login member (whose loop otherwise idles with no auto-retry). Session resume works today, so the `/sessions` picker is fully functional. Per-server login and per-server tool view are shown as unavailable pending their capability.

The host layer stays data-only: `App.Dispatch` still returns a `CmdResult`, the overlay yields a command line the surface dispatches, and `agent/host` gains no charm/lipgloss dependency (the widget lives entirely in `cmd/agentchat`).

## Reviewer's guide
Read in this order:
1. [client/group.go](https://github.com/panyam/mcpkit/pull/1114/files#diff-2823e25c587857631e2e1db1892c124e3a178790c0f345bfd2156a9f9f80019e) — start here. The `Reconnect` method plus the `run` loop change: needs-login now parks on the wake channel instead of returning, and the backoff select gains a wake case.
2. [client/group_test.go](https://github.com/panyam/mcpkit/pull/1114/files#diff-09cb991c79c27ae000c3e0f98f56edbcaee9bc0be5f8bfd97fe9e02a5c6f436e) — acceptance for the above (needs-login recovers after Reconnect; a pinned-30s backoff is short-circuited; ready is a no-op).
3. [cmd/agentchat/overlay.go](https://github.com/panyam/mcpkit/pull/1114/files#diff-bac1d9dab64a940d455f5503f797fa91421cd0b03a6f1533cededa8c62e7b3da) — the reusable widget: `overlayModel` (handleKey/move/View) plus the `serversOverlay`/`sessionsOverlay`/`overlayFor` builders that turn a `CmdResult` into a dialog.
4. [cmd/agentchat/overlay_test.go](https://github.com/panyam/mcpkit/pull/1114/files#diff-e176a613968475e6a55ad77685223e0a9dd91d6b2628b3e904b820d7dd177b72) — widget behavior (nav/scroll, primary/secondary/disabled actions, empty list, both builders).
5. [agent/host/commands.go](https://github.com/panyam/mcpkit/pull/1114/files#diff-d44c9aac08cff5c51623cc064ae8e0dbbef19ba85d048cf9996ed8f99b61ac39) + [agent/host/app.go](https://github.com/panyam/mcpkit/pull/1114/files#diff-89fb8e04b6e1e9d5f7f76958490ef158dee40e2cae92d87c04b408d893c84361) — the `/mcp` alias, the `reconnect <name>` subcommand + completer, and the data-only `App.ReconnectServer` pass-through.
6. [cmd/agentchat/tui.go](https://github.com/panyam/mcpkit/pull/1114/files#diff-0e29207287df07cecf17e04df9f99e726ae789983f7e3ce007bb6282029b4db6) + [cmd/agentchat/notebook.go](https://github.com/panyam/mcpkit/pull/1114/files#diff-8a79677a206f62f0abeebce75abd2fbafac2dc1be85310113e702bebc42624b1) — surface wiring: open on an interactive-picker result, route keys to the overlay while open (focus management), render it above the input.

Skim or skip: [agent/host/commands_test.go](https://github.com/panyam/mcpkit/pull/1114/files#diff-ee8ed899f3699d7840668725caef91fafc4284eb488806cdc52575e85bbb27a0), [cmd/agentchat/tui_test.go](https://github.com/panyam/mcpkit/pull/1114/files#diff-68ccb7754cb7a3e92c63ccecf5613cb252fcae31e66f524e2ab680a096069bc3) (straight-line coverage of the wiring).

## How it works (the reconnect state machine)
```
run loop per member:
  connect
    ok            -> ready, return (live-drop reconnect is the client's job)
    auth (401/403)-> needs-login, PARK: select { ctx.Done -> return; wake -> retry }
    other         -> failed, select { ctx.Done -> return; wake -> retry now; backoff timer -> retry }

Group.Reconnect(id):
  ready | connecting | unknown | not-started -> no-op
  else -> non-blocking send on the member's buffered wake channel
```
A failed member is already looping (sleeping in backoff); the wake short-circuits the sleep. A needs-login member used to return from `run` entirely; it now parks on the same wake channel so a post-login Reconnect resumes it without relaunching a goroutine (no looping-flag race).

## Decision log
- **Parked needs-login instead of relaunching the goroutine.** The alternative (return on needs-login, relaunch `run` on Reconnect) has a race: `run` returns before a `looping` flag clears, so a Reconnect in that window is lost. Parking on the wake channel removes the flag and the race; the parked goroutine costs nothing and exits on `ctx.Done`.
- **Login/tool actions ship disabled, not omitted.** They render with an `(n/a)` hint so the capability is discoverable, and slot in with no widget change once their backing lands. Per-server login is the ext/auth OAuth flow (overlaps issue 907); per-server tool view needs new host plumbing. Both deferred rather than expanding this PR.
- **Overlay is a surface concern.** The presentation decision (which `CmdKind`s open a dialog) lives in `overlayFor` in `cmd/agentchat`, keeping `App.Dispatch` data-only so a future web surface renders the same `CmdResult` as a side panel.

## Risk / blast radius
- Affects: `client.Group` connection lifecycle (all consumers: agent host, cmd/testclient, scripts) and the two agentchat TUI surfaces. `agent/host` command set gains an alias + subcommand.
- Behavior change in `Group`: a needs-login member's goroutine now stays parked until Close instead of returning. Close still unblocks it via `ctx.Done`; verified by the existing close/idempotent tests plus the new reconnect tests.
- Tests covering this: `client/group_test.go` (3 new), `cmd/agentchat/overlay_test.go` (10), `cmd/agentchat/tui_test.go` (open/route/dismiss), `agent/host/commands_test.go` (alias + reconnect + completer).
- Be paranoid about: the parked-goroutine lifecycle under Close, and key focus routing while the overlay is open (Ctrl+C must still quit; other keys must not reach the textarea).

## Before / after

Before: `/servers` and `/sessions` print a static dim list to scrollback; no selection, no actions.

After (`/mcp`, real rendered output):
```
╭────────────────────────────────────────────────────────╮
│ MCP servers                                            │
│ ▸ flights                  ready · required            │
│   loyalty                  failed · connection refused │
│   support                  needs-login                 │
│ enter reconnect (n/a) · ↑↓ move · esc close            │
╰────────────────────────────────────────────────────────╯
```
(on `loyalty`/`support`, Enter reads `reconnect`; on `flights` it is `(n/a)`.)

After (`/sessions`, real rendered output):
```
╭───────────────────────────────────────────────────────────╮
│ sessions                                                  │
│   run-a1                   12 msg                         │
│ ▸ run-b2                   4 msg · active                 │
│   run-c3                   30 msg · forked from run-a1 @6 │
│ enter resume · ↑↓ move · esc close                        │
╰───────────────────────────────────────────────────────────╯
```

## Out of scope (deliberately deferred)
- Per-server login action (ext/auth OAuth flow; overlaps issue 907) — will file a follow-up.
- Per-server tool view in the overlay — will file a follow-up.

