### PR TITLE
feat(agentchat): per-server tool view in the /mcp overlay (1117)

### DIFF
--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -496,6 +496,20 @@ func (a *App) Close() {
 	}
 }
 
+// ServerTools returns the tools exposed by a single connected MCP server, in
+// that server's own (unqualified) naming — the data behind the /mcp overlay's
+// per-server tool view. found is false for an unknown or not-yet-ready server
+// id (app state, not an error). Each server's source is registered in the
+// aggregate under its own id, so looking it up by that id returns only that
+// server's tools (respecting its Allow filter) and never the meta-tools or
+// sub-agents registered under other ids.
+func (a *App) ServerTools(ctx context.Context, id string) (defs []core.ToolDef, found bool, err error) {
+	if a.sources == nil {
+		return nil, false, nil
+	}
+	return a.sources.SourceTools(ctx, id)
+}
+
 // ReconnectServer forces the named MCP server to attempt connecting again: it
 // wakes a failed server that is sleeping between backoff retries and un-parks a
 // needs-login server (the caller has since logged in). A ready or unknown

--- a/agent/host/commands.go
+++ b/agent/host/commands.go
@@ -52,6 +52,8 @@ const (
 	CmdApproval CmdKind = "approval"
 	// CmdServers lists the MCP servers and their connection state (Servers).
 	CmdServers CmdKind = "servers"
+	// CmdServerTools lists one server's own tools (Tools + ServerID = which).
+	CmdServerTools CmdKind = "server-tools"
 	// CmdQuit signals the loop to exit (Quit true).
 	CmdQuit CmdKind = "quit"
 )
@@ -77,6 +79,7 @@ type CmdResult struct {
 	Sessions       []agent.RunInfo
 	SessionsNote   string
 	Servers        []client.MemberStatus
+	ServerID       string // the server a CmdServerTools result scopes to
 	Quit           bool
 }
 
@@ -236,12 +239,23 @@ func (a *App) registerBuiltinCommands() {
 			return CmdResult{Kind: CmdApproval, Approval: a.approval}, nil
 		}})
 
-	r.Register(&Command{Name: "servers", Aliases: []string{"mcp"}, Help: "list MCP servers and their state; /servers reconnect <name> retries a failed/needs-login one",
-		Run: func(_ context.Context, args string) (CmdResult, error) {
+	r.Register(&Command{Name: "servers", Aliases: []string{"mcp"}, Help: "list MCP servers and their state; /servers reconnect <name> retries one; /servers tools <name> lists one server's tools",
+		Run: func(ctx context.Context, args string) (CmdResult, error) {
 			if id, ok := strings.CutPrefix(args, "reconnect "); ok {
 				id = strings.TrimSpace(id)
 				a.ReconnectServer(id)
 				return CmdResult{Kind: CmdMessage, Message: "reconnect requested for " + id}, nil
+			}
+			if id, ok := strings.CutPrefix(args, "tools "); ok {
+				id = strings.TrimSpace(id)
+				defs, found, err := a.ServerTools(ctx, id)
+				if err != nil {
+					return CmdResult{}, err
+				}
+				if !found {
+					return CmdResult{Kind: CmdMessage, Message: "no ready server named " + id}, nil
+				}
+				return CmdResult{Kind: CmdServerTools, ServerID: id, Tools: defs}, nil
 			}
 			var st []client.MemberStatus
 			if a.group != nil {
@@ -251,8 +265,10 @@ func (a *App) registerBuiltinCommands() {
 		},
 		Complete: func(prefix string) []string {
 			var out []string
-			if strings.HasPrefix("reconnect", prefix) {
-				out = append(out, "reconnect")
+			for _, sub := range []string{"reconnect", "tools"} {
+				if strings.HasPrefix(sub, prefix) {
+					out = append(out, sub)
+				}
 			}
 			if a.group != nil {
 				for _, st := range a.group.Status() {

--- a/agent/host/commands_test.go
+++ b/agent/host/commands_test.go
@@ -211,13 +211,29 @@ func TestApp_DispatchServersListAliasAndReconnect(t *testing.T) {
 		t.Fatalf("/servers reconnect = (%+v, %v)", rc, err)
 	}
 
-	// completer offers the reconnect subcommand and the member id.
+	// tools subcommand scopes to one server; an unknown server is app state.
+	tv, err := app.Dispatch(ctx, "/servers tools "+id)
+	if err != nil || tv.Kind != CmdServerTools || tv.ServerID != id {
+		t.Fatalf("/servers tools = (%+v, %v)", tv, err)
+	}
+	if len(tv.Tools) == 0 {
+		t.Fatalf("/servers tools listed no tools for %q", id)
+	}
+	miss, err := app.Dispatch(ctx, "/servers tools nope")
+	if err != nil || miss.Kind != CmdMessage {
+		t.Fatalf("/servers tools nope = (%+v, %v), want a CmdMessage", miss, err)
+	}
+
+	// completer offers the subcommands and the member id.
 	cmd, ok := app.Commands().Lookup("servers")
 	if !ok || cmd.Complete == nil {
 		t.Fatal("servers command has no completer")
 	}
 	if got := cmd.Complete("rec"); len(got) != 1 || got[0] != "reconnect" {
 		t.Fatalf("Complete(rec) = %v, want [reconnect]", got)
+	}
+	if got := cmd.Complete("to"); len(got) != 1 || got[0] != "tools" {
+		t.Fatalf("Complete(to) = %v, want [tools]", got)
 	}
 	if got := cmd.Complete(id[:1]); len(got) == 0 {
 		t.Fatalf("Complete(%q) offered no server id", id[:1])

--- a/agent/host/render.go
+++ b/agent/host/render.go
@@ -320,6 +320,9 @@ func (r *renderer) command(res CmdResult) {
 		r.approvalMode(res.Approval)
 	case CmdServers:
 		r.serverList(res.Servers)
+	case CmdServerTools:
+		fmt.Fprintf(r.out, "%s\n", r.dim("tools on "+res.ServerID))
+		r.toolList(res.Tools)
 	case CmdQuit:
 		// nothing to render; the loop exits
 	}

--- a/agent/multi_source.go
+++ b/agent/multi_source.go
@@ -154,6 +154,22 @@ func (m *MultiSource) Tools(ctx context.Context) ([]core.ToolDef, error) {
 	return out, nil
 }
 
+// SourceTools returns the tools of the single source registered under id, in
+// that source's own (unqualified) naming — the per-source view a caller uses to
+// show "what does server X expose", distinct from the merged Tools list where
+// colliding names are qualified. found is false for an unknown id (app state,
+// not an error); err is only a real listing failure from that source.
+func (m *MultiSource) SourceTools(ctx context.Context, id string) (defs []core.ToolDef, found bool, err error) {
+	m.mu.RLock()
+	src, ok := m.sources[id]
+	m.mu.RUnlock()
+	if !ok {
+		return nil, false, nil
+	}
+	defs, err = src.Tools(ctx)
+	return defs, true, err
+}
+
 // Call dispatches by bare or qualified name. Resolution order: exact unique
 // bare name; qualified "sourceID_name"; ambiguous bare name via Resolver.
 // A name miss against the memoized index triggers exactly one fresh gather

--- a/agent/toolsource_test.go
+++ b/agent/toolsource_test.go
@@ -60,6 +60,32 @@ func TestMultiSourceMergesUniqueNames(t *testing.T) {
 	}
 }
 
+func TestMultiSourceSourceTools(t *testing.T) {
+	m := NewMultiSource()
+	m.Add("alpha", &fakeSource{defs: defsNamed("one", "two")})
+	m.Add("beta", &fakeSource{defs: defsNamed("three")})
+
+	// one source's own (unqualified) tools
+	defs, found, err := m.SourceTools(context.Background(), "alpha")
+	if err != nil || !found {
+		t.Fatalf("SourceTools(alpha) = (found=%v, err=%v)", found, err)
+	}
+	if got := toolNames(defs); fmt.Sprint(got) != fmt.Sprint([]string{"one", "two"}) {
+		t.Fatalf("alpha tools = %v", got)
+	}
+
+	// unknown id is app state, not an error
+	if _, found, err := m.SourceTools(context.Background(), "nope"); found || err != nil {
+		t.Fatalf("SourceTools(nope) = (found=%v, err=%v), want (false, nil)", found, err)
+	}
+
+	// a listing failure from the source surfaces as an error
+	m.Add("boom", &fakeSource{listErr: errors.New("down")})
+	if _, found, err := m.SourceTools(context.Background(), "boom"); !found || err == nil {
+		t.Fatalf("SourceTools(boom) = (found=%v, err=%v), want (true, err)", found, err)
+	}
+}
+
 func TestMultiSourceCollisionQualifiesAllClaimants(t *testing.T) {
 	var notified []string
 	m := NewMultiSource(WithCollisionNotify(func(name string, ids []string) {

--- a/cmd/agentchat/overlay.go
+++ b/cmd/agentchat/overlay.go
@@ -282,6 +282,13 @@ func serversOverlay(res host.CmdResult) *overlayModel {
 		} else {
 			actions = append(actions, overlayAction{Label: "reconnect"}) // n/a for ready/connecting
 		}
+		// Tools are listable only once the server is ready (its catalog is
+		// registered); otherwise the action is shown disabled.
+		tools := overlayAction{Key: "t", Label: "tools"}
+		if s.State == client.StateReady {
+			tools.Line = "/servers tools " + s.ID
+		}
+		actions = append(actions, tools)
 		if s.State == client.StateNeedsLogin {
 			actions = append(actions, overlayAction{Key: "l", Label: "login"}) // n/a: follow-up
 		}
@@ -327,6 +334,18 @@ func sessionsOverlay(res host.CmdResult) *overlayModel {
 	return o
 }
 
+// toolsOverlay builds the read-only per-server tool list opened from the /mcp
+// overlay's tools action (issue 1117): one row per tool (name + description),
+// no actions — Esc closes back to the input. Opening it replaces the servers
+// overlay; a back-to-parent stack is the focus-model follow-up (issue 1063 C4).
+func toolsOverlay(res host.CmdResult) *overlayModel {
+	items := make([]overlayItem, 0, len(res.Tools))
+	for _, t := range res.Tools {
+		items = append(items, overlayItem{Label: t.Name, Detail: t.Description})
+	}
+	return newOverlay("tools · "+res.ServerID, items)
+}
+
 // overlayFor converts a command result into the overlay that presents it, or
 // nil when the result is not an interactive-picker shape. Centralizes the
 // surface's "which CmdKinds open an overlay" decision so both TUI surfaces
@@ -337,6 +356,8 @@ func overlayFor(res host.CmdResult) *overlayModel {
 		return serversOverlay(res)
 	case host.CmdSessions:
 		return sessionsOverlay(res)
+	case host.CmdServerTools:
+		return toolsOverlay(res)
 	default:
 		return nil
 	}

--- a/cmd/agentchat/overlay_test.go
+++ b/cmd/agentchat/overlay_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/panyam/mcpkit/agent"
 	"github.com/panyam/mcpkit/agent/host"
 	"github.com/panyam/mcpkit/client"
+	"github.com/panyam/mcpkit/core"
 )
 
 func kmsg(s string) tea.KeyMsg {
@@ -131,6 +132,41 @@ func TestServersOverlay_ReconnectOnlyWhenStuck(t *testing.T) {
 	}
 }
 
+func TestServersOverlay_ToolsActionOnlyWhenReady(t *testing.T) {
+	res := host.CmdResult{Kind: host.CmdServers, Servers: []client.MemberStatus{
+		{ID: "ready", State: client.StateReady},
+		{ID: "down", State: client.StateFailed},
+	}}
+	o := serversOverlay(res)
+	if got := actionLine(o.items[0], "t"); got != "/servers tools ready" {
+		t.Fatalf("ready tools action = %q, want /servers tools ready", got)
+	}
+	if got := actionLine(o.items[1], "t"); got != "" {
+		t.Fatalf("failed tools action = %q, want disabled", got)
+	}
+}
+
+func TestToolsOverlay_ListsToolsReadOnly(t *testing.T) {
+	res := host.CmdResult{Kind: host.CmdServerTools, ServerID: "flights", Tools: []core.ToolDef{
+		{Name: "search", Description: "find flights"},
+		{Name: "book", Description: "book a seat"},
+	}}
+	o := toolsOverlay(res)
+	if len(o.items) != 2 || o.items[0].Label != "search" {
+		t.Fatalf("tools overlay items = %+v", o.items)
+	}
+	// read-only: no actions, so Enter is a no-op and Esc dismisses
+	if out := o.handleKey(kmsg("enter")); out != (overlayOutcome{}) {
+		t.Fatalf("enter on a read-only tool row = %+v, want no-op", out)
+	}
+	if out := o.handleKey(kmsg("esc")); !out.Dismiss {
+		t.Fatal("esc should dismiss the tools overlay")
+	}
+	if overlayFor(res) == nil {
+		t.Fatal("CmdServerTools should open an overlay")
+	}
+}
+
 func TestSessionsOverlay_ResumeAndActiveCursor(t *testing.T) {
 	res := host.CmdResult{Kind: host.CmdSessions, RunID: "s2", Sessions: []agent.RunInfo{
 		{ID: "s1", MessageCount: 3},
@@ -162,8 +198,14 @@ func TestOverlayFor_OnlyInteractiveKinds(t *testing.T) {
 
 // primaryLine is the test helper for the selected row's Enter action line.
 func primaryLine(it overlayItem) string {
+	return actionLine(it, "")
+}
+
+// actionLine returns the Line of the row's action bound to key (or "" for the
+// primary/Enter action); empty when absent or disabled.
+func actionLine(it overlayItem, key string) string {
 	for _, a := range it.Actions {
-		if a.Key == "" {
+		if a.Key == key {
 			return a.Line
 		}
 	}


### PR DESCRIPTION
## What changes

Each ready server row in the `/mcp` overlay gains a `t` action that opens a read-only list of that server's own tools (issue 1117). This fills the tool-view slot the overlay reserved when it shipped in PR 1114. On a non-ready server the action is shown disabled.

The backing capability is data-only: a new `MultiSource.SourceTools` returns a single source's unqualified tool list, `App.ServerTools` reads it by the server's own id, and `/servers tools <name>` returns a `CmdServerTools` result the surface renders as an overlay (the plain REPL prints it). No new dependencies, no charm/lipgloss in `agent/host`.

## Reviewer's guide
Read in this order:
1. [agent/multi_source.go](https://github.com/panyam/mcpkit/pull/1119/files#diff-49e8e5b153ea9a7a286eb82e1eb7d4c0565a6e81db15aa44417f1a7236f6f06d) — start here. `SourceTools(ctx, id)`: one source's own tools; unknown id is `found=false` (app state), err is only a real listing failure.
2. [agent/toolsource_test.go](https://github.com/panyam/mcpkit/pull/1119/files#diff-ca90ce7de1d3630b728ec6294a04f150ecbbe3d8f42d650751b2ee1fc8290f85) — acceptance (one source's tools, unknown id, listing error).
3. [agent/host/app.go](https://github.com/panyam/mcpkit/pull/1119/files#diff-89fb8e04b6e1e9d5f7f76958490ef158dee40e2cae92d87c04b408d893c84361) — `App.ServerTools`: looks the server up by its own id in the aggregate, so it returns only that server's tools (respecting its `Allow` filter), never meta-tools/sub-agents registered under other ids.
4. [agent/host/commands.go](https://github.com/panyam/mcpkit/pull/1119/files#diff-d44c9aac08cff5c51623cc064ae8e0dbbef19ba85d048cf9996ed8f99b61ac39) — `/servers tools <name>` subcommand + `CmdServerTools` kind + completer.
5. [cmd/agentchat/overlay.go](https://github.com/panyam/mcpkit/pull/1119/files#diff-bac1d9dab64a940d455f5503f797fa91421cd0b03a6f1533cededa8c62e7b3da) — the `t` action in `serversOverlay` (ready-only), `toolsOverlay`, and the `overlayFor` case.
6. [agent/host/render.go](https://github.com/panyam/mcpkit/pull/1119/files#diff-da3546e85434193f7b8b2df15f4f6d6df496b616b9e0b0b8c4299cd4576e044a) — plain-REPL rendering of `CmdServerTools`.

Skim or skip: [agent/host/commands_test.go](https://github.com/panyam/mcpkit/pull/1119/files#diff-ee8ed899f3699d7840668725caef91fafc4284eb488806cdc52575e85bbb27a0), [cmd/agentchat/overlay_test.go](https://github.com/panyam/mcpkit/pull/1119/files#diff-e176a613968475e6a55ad77685223e0a9dd91d6b2628b3e904b820d7dd177b72) (straight-line coverage).

## Decision log
- **Query the aggregate by server id, not the sub-agent `serverTools` mirror.** `serverTools` is only built when sub-agents are configured; the aggregate `sources` always exists and registers each server's source under the server's own id, so a keyed lookup returns exactly that server's tools with no meta-tool bleed.
- **Distinct `CmdServerTools` kind, not reuse `CmdTools`.** `/tools` (merged set) still prints; only the scoped per-server result opens an overlay, so `overlayFor` stays unambiguous and `/tools` is untouched.
- **Tools action is ready-only.** A server's catalog registers on ready; before that there is nothing to list, so the action is disabled rather than erroring.

## Risk / blast radius
- Affects: `agent.MultiSource` (additive read method — all consumers), the agentchat `/mcp` overlay, the `/servers` command.
- Tests: `agent/toolsource_test.go` (SourceTools), `agent/host/commands_test.go` (tools subcommand + completer), `cmd/agentchat/overlay_test.go` (tools action ready-only, read-only tools overlay).
- Be paranoid about: a server id that collides with a meta-tool/sub-agent source id — ids are distinct by construction (server ids forbid underscores; meta/sub-agent sources use their own ids), so the keyed lookup can't cross them.

## Before / after

Before: no way to see one server's tools; `/tools` lists the merged set across all servers.

After — the `/mcp` overlay's `t` action on a ready server (real rendered output):
```
╭────────────────────────────────────────────────────────╮
│ MCP servers                                            │
│ ▸ flights                  ready · required            │
│   loyalty                  failed · connection refused │
│ enter reconnect (n/a) · t tools · ↑↓ move · esc close  │
╰────────────────────────────────────────────────────────╯
```
`t` on `flights` opens:
```
╭───────────────────────────────────────────────────────────╮
│ tools · flights                                           │
│ ▸ search_flights           find flights by route and date │
│   hold_seat                hold a seat for 15 minutes     │
│   book_flight              confirm and pay                │
│ ↑↓ move · esc close                                       │
╰───────────────────────────────────────────────────────────╯
```

## Out of scope (deliberately deferred)
- Back-to-parent overlay stack (Esc from tools returns to the servers overlay) → the focus-model work, issue 1063 C4. Today Esc closes to the input.
- Per-server login action → PR B (issue 1116, closes 907).

