### PR TITLE
feat(agentchat): oauth login auth type + /mcp login action (closes 1116, 907)

### DIFF
--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -38,6 +38,11 @@ type App struct {
 	group       *client.Group
 	serverTools *agent.MultiSource
 
+	// oauthSources holds the interactive (oauth) token source per server id, so
+	// LoginServer can force a fresh browser login. Only oauth-typed servers have
+	// an entry; its presence is what CanLogin reports.
+	oauthSources map[string]loginSource
+
 	// tp is the tracer provider, held so the ready-observer can load a late
 	// server's skills with the same instrumentation as the boot path.
 	tp core.TracerProvider
@@ -235,7 +240,7 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 
 	multi := agent.NewMultiSource()
 	app := &App{cfg: cfg, sources: multi, observers: observers, replOut: out, bgTasks: map[string]*client.BackgroundTask{}, subs: map[string]*subscription{}, store: o.store,
-		tp: o.tp, skillBlocks: map[string]string{}, skillCatalog: map[string][]catalogSkill{}}
+		tp: o.tp, skillBlocks: map[string]string{}, skillCatalog: map[string][]catalogSkill{}, oauthSources: map[string]loginSource{}}
 	for _, sc := range cfg.Servers {
 		app.serverOrder = append(app.serverOrder, sc.ID)
 	}
@@ -281,13 +286,16 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 			client.WithToolsListChangedHandler(multi.Invalidate),
 			client.WithTracerProvider(o.tp),
 		}
-		authOpt, err := authOption(sc)
+		authOpt, loginSrc, err := authOption(sc)
 		if err != nil {
 			app.Close()
 			return nil, err
 		}
 		if authOpt != nil {
 			copts = append(copts, authOpt)
+		}
+		if loginSrc != nil {
+			app.oauthSources[sc.ID] = loginSrc
 		}
 		c := client.NewClient(sc.URL, core.ClientInfo{Name: "agentchat", Version: "0.1"}, copts...)
 		app.clients = append(app.clients, c)
@@ -508,6 +516,30 @@ func (a *App) ServerTools(ctx context.Context, id string) (defs []core.ToolDef, 
 		return nil, false, nil
 	}
 	return a.sources.SourceTools(ctx, id)
+}
+
+// loginSource is the subset of an interactive OAuth token source the host needs
+// to force a fresh login: dropping the cached token so the client's next
+// connect re-runs the browser authorization-code flow. *extauth.OAuthTokenSource
+// satisfies it.
+type loginSource interface{ Invalidate() }
+
+// canLogin reports whether an interactive (oauth) auth type is configured for
+// the server, so a surface knows when to offer the login action.
+func (a *App) canLogin(id string) bool { return a.oauthSources[id] != nil }
+
+// LoginServer forces a fresh interactive login for an oauth-configured server:
+// it drops any cached token and reconnects, so the client's next connect runs
+// the browser authorization-code flow again. A server without an interactive
+// (oauth) auth type, or an unknown id, is a no-op — canLogin / the server
+// status CanLogin flag tells a surface when to offer it.
+func (a *App) LoginServer(id string) {
+	src := a.oauthSources[id]
+	if src == nil {
+		return
+	}
+	src.Invalidate()
+	a.ReconnectServer(id)
 }
 
 // ReconnectServer forces the named MCP server to attempt connecting again: it

--- a/agent/host/auth.go
+++ b/agent/host/auth.go
@@ -9,22 +9,47 @@ import (
 )
 
 // authOption maps a server's AuthConfig onto the client option that carries
-// it: a static bearer header, or a discovery-driven client-credentials token
-// source (PRM to AS resolution, caching, and refresh live in ext/auth). Nil
-// config means unauthenticated. Config validation has already checked env
-// presence; this only assembles.
-func authOption(sc ServerConfig) (client.ClientOption, error) {
+// it: a static bearer header, a discovery-driven client-credentials token
+// source, or an interactive authorization-code (oauth) token source (PRM to AS
+// resolution, PKCE, caching, and refresh all live in ext/auth). Nil config
+// means unauthenticated. For the oauth type it also returns the token source as
+// a loginSource so the host can force a fresh login later; the other types
+// return a nil loginSource. Config validation has already checked env presence;
+// this only assembles.
+func authOption(sc ServerConfig) (client.ClientOption, loginSource, error) {
 	if sc.Auth == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
 	switch sc.Auth.Type {
 	case "bearer":
-		return client.WithClientBearerToken(os.Getenv(sc.Auth.TokenEnv)), nil
+		return client.WithClientBearerToken(os.Getenv(sc.Auth.TokenEnv)), nil, nil
 	case "client-credentials":
-		return client.WithTokenSource(clientCredentialsSource(sc)), nil
+		return client.WithTokenSource(clientCredentialsSource(sc)), nil, nil
+	case "oauth":
+		src := oauthSource(sc)
+		return client.WithTokenSource(src), src, nil
 	default:
-		return nil, fmt.Errorf("agentchat: server %s: unsupported auth type %q", sc.ID, sc.Auth.Type)
+		return nil, nil, fmt.Errorf("agentchat: server %s: unsupported auth type %q", sc.ID, sc.Auth.Type)
 	}
+}
+
+// oauthSource builds the interactive authorization-code token source: it
+// self-registers via DCR when no client is pre-registered, else pins the
+// client from clientIdEnv (+ optional clientSecretEnv). Scopes stay empty by
+// default so acquisition follows the server's 401 WWW-Authenticate challenge.
+func oauthSource(sc ServerConfig) *extauth.OAuthTokenSource {
+	s := &extauth.OAuthTokenSource{
+		ServerURL:     sc.URL,
+		Scopes:        sc.Auth.Scopes,
+		AllowInsecure: sc.Auth.AllowInsecure,
+	}
+	if sc.Auth.ClientIDEnv != "" {
+		s.ClientID = os.Getenv(sc.Auth.ClientIDEnv)
+		s.ClientSecret = os.Getenv(sc.Auth.ClientSecretEnv)
+	} else {
+		s.EnableDCR = true
+	}
+	return s
 }
 
 func clientCredentialsSource(sc ServerConfig) *extauth.ClientCredentialsTokenSource {

--- a/agent/host/auth_test.go
+++ b/agent/host/auth_test.go
@@ -20,7 +20,9 @@ func TestAuthConfigValidation(t *testing.T) {
 		want string
 	}{
 		{"unknown type", AuthConfig{Type: "magic"}, nil, "unknown auth type"},
-		{"oauth not yet", AuthConfig{Type: "oauth"}, nil, "not implemented yet"},
+		{"oauth ok (DCR, no env)", AuthConfig{Type: "oauth"}, nil, ""},
+		{"oauth ok (pinned client)", AuthConfig{Type: "oauth", ClientIDEnv: "AC_OA"}, map[string]string{"AC_OA": "cid"}, ""},
+		{"oauth pinned env unset", AuthConfig{Type: "oauth", ClientIDEnv: "AC_OA_NOPE"}, nil, "is not set"},
 		{"bearer missing env name", AuthConfig{Type: "bearer"}, nil, "requires tokenEnv"},
 		{"bearer env unset", AuthConfig{Type: "bearer", TokenEnv: "AGENTCHAT_NO_SUCH"}, nil, "is not set"},
 		{"cc missing envs", AuthConfig{Type: "client-credentials"}, nil, "clientIdEnv and clientSecretEnv"},
@@ -108,7 +110,31 @@ func TestClientCredentialsWiring(t *testing.T) {
 	if len(src.Scopes) != 1 || src.Scopes[0] != "mcp:basic" || !src.AllowInsecure {
 		t.Fatalf("wiring: %+v", src)
 	}
-	if opt, err := authOption(sc); err != nil || opt == nil {
-		t.Fatalf("authOption: %v %v", opt, err)
+	if opt, ls, err := authOption(sc); err != nil || opt == nil || ls != nil {
+		t.Fatalf("authOption: opt=%v loginSource=%v err=%v", opt, ls, err)
+	}
+}
+
+func TestAuthOption_OAuthBuildsLoginSource(t *testing.T) {
+	t.Setenv("OA_CLIENT", "cid-123")
+	sc := ServerConfig{ID: "s", URL: "https://mcp.example.com/mcp", Auth: &AuthConfig{
+		Type:        "oauth",
+		ClientIDEnv: "OA_CLIENT",
+		Scopes:      []string{"mcp:read"},
+	}}
+	opt, ls, err := authOption(sc)
+	if err != nil || opt == nil || ls == nil {
+		t.Fatalf("authOption(oauth): opt=%v loginSource=%v err=%v", opt, ls, err)
+	}
+
+	// inspect the env-to-field wiring on the concrete source
+	src := oauthSource(sc)
+	if src.ServerURL != sc.URL || src.ClientID != "cid-123" || src.EnableDCR {
+		t.Fatalf("pinned-client wiring: %+v", src)
+	}
+	// no clientIdEnv → self-register via DCR
+	dcr := oauthSource(ServerConfig{URL: sc.URL, Auth: &AuthConfig{Type: "oauth"}})
+	if !dcr.EnableDCR || dcr.ClientID != "" {
+		t.Fatalf("DCR fallback wiring: %+v", dcr)
 	}
 }

--- a/agent/host/commands.go
+++ b/agent/host/commands.go
@@ -78,9 +78,19 @@ type CmdResult struct {
 	Approval       *agent.TieredApproval
 	Sessions       []agent.RunInfo
 	SessionsNote   string
-	Servers        []client.MemberStatus
+	Servers        []ServerStatus
 	ServerID       string // the server a CmdServerTools result scopes to
 	Quit           bool
+}
+
+// ServerStatus is one MCP server's state for the /mcp view: the client-layer
+// connection status plus the host-layer CanLogin (an interactive oauth auth
+// type is configured, so a needs-login server can be logged in). Kept a
+// host-layer struct because CanLogin is a config fact the client layer does not
+// carry.
+type ServerStatus struct {
+	client.MemberStatus
+	CanLogin bool
 }
 
 // Command is one slash command. Run receives the raw argument string
@@ -257,15 +267,25 @@ func (a *App) registerBuiltinCommands() {
 				}
 				return CmdResult{Kind: CmdServerTools, ServerID: id, Tools: defs}, nil
 			}
-			var st []client.MemberStatus
+			if id, ok := strings.CutPrefix(args, "login "); ok {
+				id = strings.TrimSpace(id)
+				if !a.canLogin(id) {
+					return CmdResult{Kind: CmdMessage, Message: "server " + id + " has no interactive (oauth) auth type to log in with"}, nil
+				}
+				a.LoginServer(id)
+				return CmdResult{Kind: CmdMessage, Message: "login started for " + id}, nil
+			}
+			var st []ServerStatus
 			if a.group != nil {
-				st = a.group.Status()
+				for _, ms := range a.group.Status() {
+					st = append(st, ServerStatus{MemberStatus: ms, CanLogin: a.canLogin(ms.ID)})
+				}
 			}
 			return CmdResult{Kind: CmdServers, Servers: st}, nil
 		},
 		Complete: func(prefix string) []string {
 			var out []string
-			for _, sub := range []string{"reconnect", "tools"} {
+			for _, sub := range []string{"reconnect", "tools", "login"} {
 				if strings.HasPrefix(sub, prefix) {
 					out = append(out, sub)
 				}

--- a/agent/host/commands_test.go
+++ b/agent/host/commands_test.go
@@ -240,6 +240,43 @@ func TestApp_DispatchServersListAliasAndReconnect(t *testing.T) {
 	}
 }
 
+type fakeLoginSource struct{ invalidated int }
+
+func (f *fakeLoginSource) Invalidate() { f.invalidated++ }
+
+func TestApp_LoginServer(t *testing.T) {
+	app, _ := newCmdApp(t)
+	fake := &fakeLoginSource{}
+	app.oauthSources["oauth-srv"] = fake
+
+	if !app.canLogin("oauth-srv") || app.canLogin("bare-srv") {
+		t.Fatalf("canLogin: oauth-srv=%v bare-srv=%v", app.canLogin("oauth-srv"), app.canLogin("bare-srv"))
+	}
+
+	// login on the configured server drops the cached token (Invalidate) then
+	// reconnects; the reconnect on an unknown group member is a harmless no-op.
+	app.LoginServer("oauth-srv")
+	if fake.invalidated != 1 {
+		t.Fatalf("LoginServer did not invalidate the token source (count=%d)", fake.invalidated)
+	}
+	// unknown / non-oauth server is a no-op (no panic, nothing to invalidate)
+	app.LoginServer("bare-srv")
+
+	// the /servers login command refuses a server with no interactive auth type
+	res, err := app.Dispatch(context.Background(), "/servers login bare-srv")
+	if err != nil || res.Kind != CmdMessage || !strings.Contains(res.Message, "no interactive") {
+		t.Fatalf("/servers login bare-srv = (%+v, %v)", res, err)
+	}
+	// and starts login for the configured one
+	res, err = app.Dispatch(context.Background(), "/servers login oauth-srv")
+	if err != nil || res.Kind != CmdMessage || !strings.Contains(res.Message, "login started") {
+		t.Fatalf("/servers login oauth-srv = (%+v, %v)", res, err)
+	}
+	if fake.invalidated != 2 {
+		t.Fatalf("command path did not invalidate (count=%d)", fake.invalidated)
+	}
+}
+
 func TestApp_SessionsNoStoreErrors(t *testing.T) {
 	ts := startTestServer(t)
 	var out strings.Builder

--- a/agent/host/config.go
+++ b/agent/host/config.go
@@ -433,8 +433,8 @@ type TriggerConfig struct {
 type AuthConfig struct {
 	// Type is "bearer" (static token), "client-credentials" (OAuth
 	// machine-to-machine via PRM/AS discovery), or "oauth"
-	// (authorization-code browser flow; not implemented yet, tracked in
-	// the agent epic).
+	// (authorization-code browser flow: PRM/AS discovery + PKCE, DCR when no
+	// client is pre-registered; the /mcp overlay's login action re-runs it).
 	Type string `json:"type"`
 
 	// TokenEnv names the env var holding the static bearer token.
@@ -477,9 +477,15 @@ func (a *AuthConfig) Validate() error {
 			}
 		}
 	case "oauth":
-		return fmt.Errorf("auth type oauth (authorization-code browser flow) is not implemented yet (tracked as mcpkit issue 907); use bearer or client-credentials")
+		// Authorization-code browser flow. No mandatory env: the client
+		// self-registers via DCR when no clientIdEnv is given, and the PKCE
+		// flow acquires interactively on the first 401. clientIdEnv (+ optional
+		// clientSecretEnv) pin a pre-registered client when set.
+		if a.ClientIDEnv != "" && os.Getenv(a.ClientIDEnv) == "" {
+			return fmt.Errorf("auth env %s is not set", a.ClientIDEnv)
+		}
 	default:
-		return fmt.Errorf("unknown auth type %q (want bearer or client-credentials)", a.Type)
+		return fmt.Errorf("unknown auth type %q (want bearer, client-credentials, or oauth)", a.Type)
 	}
 	return nil
 }

--- a/agent/host/render.go
+++ b/agent/host/render.go
@@ -87,7 +87,7 @@ func (r *renderer) approvalMode(p *agent.TieredApproval) {
 }
 
 // serverList renders /servers: each MCP server and its connection state.
-func (r *renderer) serverList(servers []client.MemberStatus) {
+func (r *renderer) serverList(servers []ServerStatus) {
 	if len(servers) == 0 {
 		fmt.Fprintf(r.out, "%s\n", r.dim("servers: none configured"))
 		return
@@ -96,6 +96,9 @@ func (r *renderer) serverList(servers []client.MemberStatus) {
 		line := fmt.Sprintf("  %-14s %s", s.ID, s.State)
 		if s.Required {
 			line += " (required)"
+		}
+		if s.CanLogin {
+			line += " (login available)"
 		}
 		if s.Err != nil {
 			line += ": " + s.Err.Error()

--- a/cmd/agentchat/overlay.go
+++ b/cmd/agentchat/overlay.go
@@ -289,8 +289,15 @@ func serversOverlay(res host.CmdResult) *overlayModel {
 			tools.Line = "/servers tools " + s.ID
 		}
 		actions = append(actions, tools)
+		// Login is offered on a needs-login server only when an interactive
+		// (oauth) auth type is configured for it; otherwise the action is
+		// disabled (there is nothing to trigger).
 		if s.State == client.StateNeedsLogin {
-			actions = append(actions, overlayAction{Key: "l", Label: "login"}) // n/a: follow-up
+			login := overlayAction{Key: "l", Label: "login"}
+			if s.CanLogin {
+				login.Line = "/servers login " + s.ID
+			}
+			actions = append(actions, login)
 		}
 		items = append(items, overlayItem{Label: s.ID, Detail: detail, Actions: actions})
 	}

--- a/cmd/agentchat/overlay_test.go
+++ b/cmd/agentchat/overlay_test.go
@@ -108,10 +108,10 @@ func TestOverlay_EmptyItemsOnlyEscActs(t *testing.T) {
 }
 
 func TestServersOverlay_ReconnectOnlyWhenStuck(t *testing.T) {
-	res := host.CmdResult{Kind: host.CmdServers, Servers: []client.MemberStatus{
-		{ID: "ready", State: client.StateReady},
-		{ID: "down", State: client.StateFailed, Err: errors.New("refused")},
-		{ID: "auth", State: client.StateNeedsLogin},
+	res := host.CmdResult{Kind: host.CmdServers, Servers: []host.ServerStatus{
+		{MemberStatus: client.MemberStatus{ID: "ready", State: client.StateReady}},
+		{MemberStatus: client.MemberStatus{ID: "down", State: client.StateFailed, Err: errors.New("refused")}},
+		{MemberStatus: client.MemberStatus{ID: "auth", State: client.StateNeedsLogin}, CanLogin: true},
 	}}
 	o := serversOverlay(res)
 
@@ -133,9 +133,9 @@ func TestServersOverlay_ReconnectOnlyWhenStuck(t *testing.T) {
 }
 
 func TestServersOverlay_ToolsActionOnlyWhenReady(t *testing.T) {
-	res := host.CmdResult{Kind: host.CmdServers, Servers: []client.MemberStatus{
-		{ID: "ready", State: client.StateReady},
-		{ID: "down", State: client.StateFailed},
+	res := host.CmdResult{Kind: host.CmdServers, Servers: []host.ServerStatus{
+		{MemberStatus: client.MemberStatus{ID: "ready", State: client.StateReady}},
+		{MemberStatus: client.MemberStatus{ID: "down", State: client.StateFailed}},
 	}}
 	o := serversOverlay(res)
 	if got := actionLine(o.items[0], "t"); got != "/servers tools ready" {
@@ -143,6 +143,20 @@ func TestServersOverlay_ToolsActionOnlyWhenReady(t *testing.T) {
 	}
 	if got := actionLine(o.items[1], "t"); got != "" {
 		t.Fatalf("failed tools action = %q, want disabled", got)
+	}
+}
+
+func TestServersOverlay_LoginActionGatedOnCanLogin(t *testing.T) {
+	res := host.CmdResult{Kind: host.CmdServers, Servers: []host.ServerStatus{
+		{MemberStatus: client.MemberStatus{ID: "oauth-srv", State: client.StateNeedsLogin}, CanLogin: true},
+		{MemberStatus: client.MemberStatus{ID: "bare-srv", State: client.StateNeedsLogin}, CanLogin: false},
+	}}
+	o := serversOverlay(res)
+	if got := actionLine(o.items[0], "l"); got != "/servers login oauth-srv" {
+		t.Fatalf("oauth server login action = %q, want /servers login oauth-srv", got)
+	}
+	if got := actionLine(o.items[1], "l"); got != "" {
+		t.Fatalf("non-oauth server login action = %q, want disabled", got)
 	}
 }
 


### PR DESCRIPTION
## What changes

Implement agentchat's interactive authorization-code (`oauth`) auth type and wire the `/mcp` overlay's login action to it (closes 1116 and 907). A server configured with `"auth": {"type": "oauth"}` gets an `ext/auth.OAuthTokenSource`: it self-registers via DCR when no client is pre-registered, and the PKCE browser flow acquires interactively on the first 401. When such a server is in `needs-login`, the overlay offers a functional `l login` action that forces a fresh browser login; the plain command is `/servers login <name>`.

Config validation previously rejected `oauth` as "not implemented yet"; it now accepts it. `App.Dispatch` stays data-only and `agent/host` gains no charm/lipgloss. The OAuth flow itself is `ext/auth`'s tested territory — agentchat owns only the env-to-field wiring and the invalidate-then-reconnect trigger.

## Reviewer's guide
Read in this order:
1. [agent/host/auth.go](https://github.com/panyam/mcpkit/pull/1120/files#diff-e26cea84c1f3e8fb9b881271ecdba4b6054cbc902ba56c0701cbeff1c9e9f4fc) — start here. The `oauth` case builds an `OAuthTokenSource` (DCR when no `clientIdEnv`, else a pinned client) and returns it as a `loginSource`; `authOption` now returns `(option, loginSource, error)`.
2. [agent/host/config.go](https://github.com/panyam/mcpkit/pull/1120/files#diff-6aff502cc5cae4b9d9769752e8638899bab121e09de870b5d1320cc892c6bf2d) — `oauth` validation (no mandatory env; a set `clientIdEnv` must resolve) + the updated `AuthConfig.Type` doc.
3. [agent/host/app.go](https://github.com/panyam/mcpkit/pull/1120/files#diff-89fb8e04b6e1e9d5f7f76958490ef158dee40e2cae92d87c04b408d893c84361) — `loginSource` interface, `oauthSources` map, and `App.LoginServer` (invalidate cached token + reconnect → next connect re-runs the flow).
4. [agent/host/commands.go](https://github.com/panyam/mcpkit/pull/1120/files#diff-d44c9aac08cff5c51623cc064ae8e0dbbef19ba85d048cf9996ed8f99b61ac39) — `ServerStatus{MemberStatus, CanLogin}`, the `/servers login <name>` subcommand, and building `CanLogin` from `canLogin`.
5. [cmd/agentchat/overlay.go](https://github.com/panyam/mcpkit/pull/1120/files#diff-bac1d9dab64a940d455f5503f797fa91421cd0b03a6f1533cededa8c62e7b3da) — the login action, enabled only when `CanLogin` and the server is `needs-login`.
6. Tests: [agent/host/auth_test.go](https://github.com/panyam/mcpkit/pull/1120/files#diff-5768b2ed6e9ca219bbebdd5ac0a511a91c781da87e163768fe007f0332f8a756) (oauth wiring + validation), [agent/host/commands_test.go](https://github.com/panyam/mcpkit/pull/1120/files#diff-ee8ed899f3699d7840668725caef91fafc4284eb488806cdc52575e85bbb27a0) (`LoginServer` + command path).

Skim or skip: [agent/host/render.go](https://github.com/panyam/mcpkit/pull/1120/files#diff-da3546e85434193f7b8b2df15f4f6d6df496b616b9e0b0b8c4299cd4576e044a) (adds a "login available" hint), [cmd/agentchat/overlay_test.go](https://github.com/panyam/mcpkit/pull/1120/files#diff-e176a613968475e6a55ad77685223e0a9dd91d6b2628b3e904b820d7dd177b72).

## Diff groups
- Production: `auth.go`, `config.go`, `app.go`, `commands.go`, `overlay.go`, `render.go`
- Tests: `auth_test.go`, `commands_test.go`, `overlay_test.go`

## How it works (login trigger)
```
server configured oauth → NewApp builds OAuthTokenSource, WithTokenSource(src),
                          stores src in app.oauthSources[id]
connect → 401 → transport DoWithAuthRetry → src.Token() → PKCE browser flow
        completed → ready ;  cancelled/failed → needs-login (parked)

overlay "l login" (only if CanLogin && needs-login) → dispatch "/servers login <id>"
  → App.LoginServer(id): src.Invalidate() (drop stale token) + Reconnect(id)
  → next connect re-runs Token() → fresh browser flow
```
`Invalidate` is what makes login a *fresh* auth (discard cached token), distinct from plain reconnect which may reuse a cached token.

## Decision log
- **DCR by default, pinned client optional.** Zero-config login (`{"type":"oauth"}`) self-registers via DCR; setting `clientIdEnv` (+ optional `clientSecretEnv`) pins a pre-registered client. Reuses the existing `AuthConfig` env fields, no new config surface.
- **`ServerStatus` is a host-layer struct, not a new `client.MemberStatus` field.** `CanLogin` is a config fact the client layer does not (and should not) carry, so the host wraps the client status rather than pushing auth-awareness down.
- **Login = Invalidate + Reconnect, reusing 1114's `Group.Reconnect`.** No new connection primitive; login is "force fresh auth then retry."
- **Scopes stay empty by default.** Acquisition follows the server's 401 `WWW-Authenticate` challenge (the lazy path `ext/auth` already implements), so a server that gates per-method works without pinning a broad scope up front.

## Risk / blast radius
- Affects: agentchat server auth (a new type; `bearer`/`client-credentials` unchanged), the `/mcp` overlay, the `/servers` command, and `CmdResult.Servers` (now `[]ServerStatus`).
- **Assertion change (not a weakening):** the `TestAuthConfigValidation` case that asserted `oauth` errors with "not implemented yet" now asserts it validates — the feature is implemented. New negative cases (pinned-env-unset) were added.
- Tests: `auth_test.go` (oauth builds a login source, DCR-vs-pinned wiring, validation matrix), `commands_test.go` (`LoginServer` invalidates + the command refuses a non-oauth server), `overlay_test.go` (login gated on `CanLogin`).
- Be paranoid about: the browser flow is not exercised in CI (it opens a real browser); coverage is the wiring (source built + installed, invalidate called, reconnect requested). An end-to-end login against a real AS is a manual/e2e check.

## Before / after

Before: `{"type":"oauth"}` failed config validation; a `needs-login` server could only be reconnected (which retries with whatever token exists), never freshly logged in.

After — a `needs-login` oauth server selected in the `/mcp` overlay (real rendered output):
```
╭─────────────────────────────────────────────────────────────────╮
│ MCP servers                                                     │
│   flights                  ready · required                     │
│ ▸ salesforce               needs-login                          │
│ enter reconnect · t tools (n/a) · l login · ↑↓ move · esc close │
╰─────────────────────────────────────────────────────────────────╯
```
`l` dispatches `/servers login salesforce` → fresh browser flow. A `needs-login` server with no oauth type shows `l login (n/a)`.

## Out of scope (deliberately deferred)
- End-to-end login against a live authorization server (Keycloak fixture) → manual/e2e; the browser flow can't run in unit CI.
- Retrofitting a token source onto a server that was NOT configured with an interactive auth type (would require rebuilding its client) → not supported; login requires the oauth type at boot.

## Note
Stacked on PR 1119 (issue 1117) since both touch `serversOverlay` / the servers command. Base is `feat/1117-per-server-tool-view`; retarget to `main` after 1119 merges. Stacked PRs off a non-main base do not trigger CI until retargeted — verified locally with the host + agentchat + agent suites.

