### PR TITLE
feat(agentchat): dialog stack for nested-overlay back-nav (1063 C4)

### DIFF
--- a/cmd/agentchat/notebook.go
+++ b/cmd/agentchat/notebook.go
@@ -330,8 +330,15 @@ func (m notebookModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case openOverlayMsg:
-		m.open(msg.ov, m.width)
+		m.push(msg.ov, m.width) // nests above the current overlay, if any
 		m.ta.Blur()
+		return m, nil
+
+	case closeOverlaysMsg:
+		if m.active() {
+			m.clear()
+			m.ta.Focus()
+		}
 		return m, nil
 
 	case tea.MouseMsg:
@@ -343,14 +350,19 @@ func (m notebookModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.Type == tea.KeyCtrlC {
 			return m, tea.Quit
 		}
-		// An open dialog owns the keyboard until it acts or dismisses.
+		// An open dialog owns the keyboard: Esc pops one level (back to the
+		// parent overlay or the prompt); an action dispatches a line whose result
+		// nests a new overlay or closes the stack.
 		if m.active() {
-			line, open := m.route(msg)
-			if !open {
-				m.ta.Focus()
-			}
-			if line != "" {
-				return m.submit(line)
+			out := m.top().handleKey(msg)
+			switch {
+			case out.Dismiss:
+				m.pop()
+				if !m.active() {
+					m.ta.Focus()
+				}
+			case out.Line != "":
+				return m.submit(out.Line)
 			}
 			return m, nil
 		}
@@ -611,6 +623,7 @@ func (m notebookModel) submit(line string) (tea.Model, tea.Cmd) {
 			case overlayFor(res) != nil:
 				surface.prog.Send(openOverlayMsg{ov: overlayFor(res)})
 			default:
+				surface.prog.Send(closeOverlaysMsg{})
 				surface.On(host.HostEvent{Kind: host.HostCommandResult, Command: res})
 				if res.Quit {
 					surface.prog.Quit()

--- a/cmd/agentchat/overlay.go
+++ b/cmd/agentchat/overlay.go
@@ -52,57 +52,61 @@ type focusLayer interface {
 	View() string
 }
 
-// modalHost is the shared state a surface needs to carry an optional modal
-// layer. Both TUI models embed one, so "is a modal open, route keys to it,
-// close it" is defined once here rather than branched per surface. It holds
-// only the layer (a pointer, safe across the value-copies bubbletea makes each
-// Update); blurring/focusing the input stays with the surface that owns it.
+// modalHost is the shared state a surface needs to carry a stack of modal
+// layers. Both TUI models embed one, so "is a modal open, route keys to the top
+// one, push a nested one, pop back to the parent" is defined once here rather
+// than branched per surface. A stack (not a single layer) is what gives nested
+// overlays back-navigation: opening the tools view from the servers overlay
+// pushes, and Esc pops back to the servers overlay instead of dropping to the
+// input (issue 1063 C4). The layers are pointers, safe across the value-copies
+// bubbletea makes each Update; blurring/focusing the input stays with the
+// surface that owns it.
 type modalHost struct {
-	layer focusLayer
+	stack []focusLayer
 }
 
-// active reports whether a modal layer currently owns the keyboard.
-func (h *modalHost) active() bool { return h.layer != nil }
+// active reports whether any modal layer currently owns the keyboard.
+func (h *modalHost) active() bool { return len(h.stack) > 0 }
 
-// open installs l as the active modal and sizes it to the surface width. The
-// caller blurs its own input after this.
-func (h *modalHost) open(l focusLayer, width int) {
-	h.layer = l
-	if l != nil {
-		l.setWidth(width)
+// top is the focused layer — the one keys route to and that renders. Only call
+// when active.
+func (h *modalHost) top() focusLayer { return h.stack[len(h.stack)-1] }
+
+// push opens l as a nested modal above the current one (or the first modal when
+// the stack is empty), sized to the surface width. The caller blurs its input.
+func (h *modalHost) push(l focusLayer, width int) {
+	if l == nil {
+		return
+	}
+	l.setWidth(width)
+	h.stack = append(h.stack, l)
+}
+
+// pop closes the top modal, revealing its parent (or the input when the stack
+// empties). A no-op on an empty stack.
+func (h *modalHost) pop() {
+	if n := len(h.stack); n > 0 {
+		h.stack = h.stack[:n-1]
 	}
 }
 
-// setWidth reflows the active layer on resize; a no-op when none is open.
+// clear closes the whole stack at once — the "an action completed, return to
+// the prompt" path (e.g. resuming a session).
+func (h *modalHost) clear() { h.stack = nil }
+
+// setWidth reflows every layer on resize, not just the top, so a parent revealed
+// by a later pop is already sized. A no-op when the stack is empty.
 func (h *modalHost) setWidth(w int) {
-	if h.layer != nil {
-		h.layer.setWidth(w)
+	for _, l := range h.stack {
+		l.setWidth(w)
 	}
 }
 
-// route feeds one key to the active modal and reports the command line to
-// dispatch (empty unless an action fired) and whether the modal stays open. On
-// close it clears the layer; the caller refocuses its own input when open is
-// false.
-func (h *modalHost) route(msg tea.KeyMsg) (line string, open bool) {
-	out := h.layer.handleKey(msg)
-	switch {
-	case out.Dismiss:
-		h.layer = nil
-		return "", false
-	case out.Line != "":
-		h.layer = nil
-		return out.Line, false
-	default:
-		return "", true
-	}
-}
-
-// view composes the modal above the surface's base region (passed in, since the
-// base differs per surface: the input alone for the inline TUI, the viewport
-// plus input for the notebook).
+// view composes the top modal above the surface's base region (passed in, since
+// the base differs per surface: the input alone for the inline TUI, the
+// viewport plus input for the notebook).
 func (h *modalHost) view(base string) string {
-	return h.layer.View() + "\n" + base
+	return h.top().View() + "\n" + base
 }
 
 // overlayModel is the reusable interactive dialog rendered in the bottom region

--- a/cmd/agentchat/overlay_test.go
+++ b/cmd/agentchat/overlay_test.go
@@ -28,6 +28,35 @@ func kmsg(s string) tea.KeyMsg {
 	}
 }
 
+func TestModalHost_StackPushPopClear(t *testing.T) {
+	var h modalHost
+	a := newOverlay("a", nil)
+	b := newOverlay("b", nil)
+	if h.active() {
+		t.Fatal("empty stack should be inactive")
+	}
+	h.push(a, 40)
+	h.push(b, 40)
+	if !h.active() || h.top() != b {
+		t.Fatalf("top should be b, got %v", h.top())
+	}
+	h.pop()
+	if h.top() != a {
+		t.Fatal("pop should reveal the parent (a)")
+	}
+	// setWidth fans to every layer, not just the top, so a revealed parent is sized
+	h.push(b, 40)
+	h.setWidth(77)
+	if a.width != 77 || b.width != 77 {
+		t.Fatalf("setWidth should reach all layers: a=%d b=%d", a.width, b.width)
+	}
+	h.clear()
+	if h.active() {
+		t.Fatal("clear should empty the whole stack")
+	}
+	h.pop() // no-op on empty, must not panic
+}
+
 func TestOverlay_EscDismisses(t *testing.T) {
 	o := newOverlay("t", []overlayItem{{Label: "a"}})
 	if out := o.handleKey(kmsg("esc")); !out.Dismiss {

--- a/cmd/agentchat/tui.go
+++ b/cmd/agentchat/tui.go
@@ -38,9 +38,16 @@ type usageMsg struct{ in, out int }
 
 // openOverlayMsg opens an interactive overlay (the /mcp server panel, the
 // /sessions picker) in the bottom region instead of committing the command's
-// result to scrollback. Sent from the dispatch goroutine when a command returns
-// an interactive-picker shape (issue 1095).
+// result to scrollback. It pushes onto the dialog stack, so an overlay opened
+// from within another overlay nests above it (issue 1095, 1063 C4). Sent from
+// the dispatch goroutine when a command returns an interactive-picker shape.
 type openOverlayMsg struct{ ov *overlayModel }
+
+// closeOverlaysMsg closes the whole dialog stack and returns focus to the
+// prompt. Sent from the dispatch goroutine when an overlay action produced a
+// non-overlay result (e.g. resuming a session): the dialog's job is done, so it
+// dismisses rather than leaving a stale stack. A no-op when nothing is open.
+type closeOverlaysMsg struct{}
 
 // statusLine renders the persistent status: model · session · last-turn tokens,
 // plus a "N% context left" gauge when a context window is configured (issue
@@ -279,8 +286,17 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case openOverlayMsg:
-		m.open(msg.ov, m.ta.Width())
-		m.ta.Blur() // focus goes to the overlay
+		m.push(msg.ov, m.ta.Width()) // nests above the current overlay, if any
+		m.ta.Blur()                  // focus goes to the overlay
+		return m, nil
+
+	case closeOverlaysMsg:
+		// A non-overlay command result closes the whole dialog stack and returns
+		// focus to the prompt. A no-op when nothing is open.
+		if m.active() {
+			m.clear()
+			m.ta.Focus()
+		}
 		return m, nil
 
 	case liveMsg:
@@ -314,14 +330,19 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		}
 		// While a dialog is open it owns the keyboard (focus routing): navigate,
-		// act (which dispatches a command line and closes), or dismiss.
+		// dismiss (Esc pops one level, back to the parent overlay or the prompt),
+		// or act (dispatch a command line; the result nests a new overlay or
+		// closes the stack — handled in submit / the dispatch goroutine).
 		if m.active() {
-			line, open := m.route(msg)
-			if !open {
-				m.ta.Focus()
-			}
-			if line != "" {
-				return m.submit(line)
+			out := m.top().handleKey(msg)
+			switch {
+			case out.Dismiss:
+				m.pop()
+				if !m.active() {
+					m.ta.Focus()
+				}
+			case out.Line != "":
+				return m.submit(out.Line)
 			}
 			return m, nil
 		}
@@ -413,10 +434,15 @@ func (m tuiModel) submit(line string) (tea.Model, tea.Cmd) {
 			case err != nil:
 				surface.On(host.HostEvent{Kind: host.HostTurnFailed, Err: err.Error()})
 			case overlayFor(res) != nil:
-				// An interactive-picker result (/mcp, /sessions) opens a dialog in
-				// the bottom region rather than committing to scrollback.
+				// An interactive-picker result (/mcp, /sessions, per-server tools)
+				// opens a dialog — pushed onto the stack, so a result triggered from
+				// within an overlay nests above it (issue 1063 C4).
 				surface.prog.Send(openOverlayMsg{ov: overlayFor(res)})
 			default:
+				// A non-overlay result: if the command came from an open overlay
+				// (its action fired), the dialog's job is done — close the stack.
+				// A no-op when nothing is open.
+				surface.prog.Send(closeOverlaysMsg{})
 				surface.On(host.HostEvent{Kind: host.HostCommandResult, Command: res})
 				if res.Quit {
 					surface.prog.Quit()

--- a/cmd/agentchat/tui_test.go
+++ b/cmd/agentchat/tui_test.go
@@ -138,7 +138,7 @@ func TestOverlayOpenRouteDismiss(t *testing.T) {
 	// keys route to the overlay (down moves the selection), not the textarea
 	next, _ = m.Update(kmsg("down"))
 	m = next.(tuiModel)
-	if got := m.layer.(*overlayModel).cursor; got != 1 {
+	if got := m.top().(*overlayModel).cursor; got != 1 {
 		t.Fatalf("down should move the overlay cursor, got %d", got)
 	}
 
@@ -147,6 +147,53 @@ func TestOverlayOpenRouteDismiss(t *testing.T) {
 	m = next.(tuiModel)
 	if m.active() {
 		t.Fatal("esc should dismiss the overlay")
+	}
+}
+
+func TestOverlayStackNestedBackNav(t *testing.T) {
+	m := newTUIModel(nil, nil, 0)
+	servers := newOverlay("MCP servers", []overlayItem{{Label: "flights"}})
+	next, _ := m.Update(openOverlayMsg{ov: servers})
+	m = next.(tuiModel)
+
+	// nest a tools overlay on top of the servers overlay
+	tools := newOverlay("tools · flights", []overlayItem{{Label: "search"}})
+	next, _ = m.Update(openOverlayMsg{ov: tools})
+	m = next.(tuiModel)
+	if !strings.Contains(m.View(), "tools · flights") {
+		t.Fatal("the pushed (top) overlay should render")
+	}
+
+	// esc pops back to the parent overlay, NOT down to the input
+	next, _ = m.Update(kmsg("esc"))
+	m = next.(tuiModel)
+	if !m.active() {
+		t.Fatal("esc from a nested overlay should return to the parent, not close the stack")
+	}
+	if !strings.Contains(m.View(), "MCP servers") {
+		t.Fatal("after popping the tools overlay, the servers overlay should be revealed")
+	}
+
+	// esc again pops the last overlay, returning to the prompt
+	next, _ = m.Update(kmsg("esc"))
+	m = next.(tuiModel)
+	if m.active() {
+		t.Fatal("esc from the last overlay should close to the input")
+	}
+}
+
+func TestOverlayStackCloseAll(t *testing.T) {
+	m := newTUIModel(nil, nil, 0)
+	next, _ := m.Update(openOverlayMsg{ov: newOverlay("a", nil)})
+	m = next.(tuiModel)
+	next, _ = m.Update(openOverlayMsg{ov: newOverlay("b", nil)})
+	m = next.(tuiModel)
+
+	// a non-overlay action result closes the entire stack at once
+	next, _ = m.Update(closeOverlaysMsg{})
+	m = next.(tuiModel)
+	if m.active() {
+		t.Fatal("closeOverlaysMsg should clear the whole dialog stack")
 	}
 }
 


### PR DESCRIPTION
## What changes

An overlay opened from within another overlay now **nests** instead of replacing it, and Esc pops back to the parent rather than dropping to the prompt (issue 1063 C4). This completes the tools-from-servers flow deferred in PR 1119: on the `/mcp` servers overlay, `t` pushes the per-server tools view; Esc returns to the servers list, Esc again returns to the input. `modalHost` grows from a single `layer` to a `stack []focusLayer`; routing becomes uniform across both TUI surfaces. Overlays render identically — only the Esc/close navigation changes. Surface-only, no `agent/host` change, no new deps.

## Reviewer's guide
Read in this order:
1. [cmd/agentchat/overlay.go](https://github.com/panyam/mcpkit/pull/1124/files#diff-bac1d9dab64a940d455f5503f797fa91421cd0b03a6f1533cededa8c62e7b3da) — start here. `modalHost` is now a `stack []focusLayer`: `push`/`pop`/`clear`/`top`/`active`, `setWidth` fans to every layer (a revealed parent is pre-sized), `view` renders the top.
2. [cmd/agentchat/overlay_test.go](https://github.com/panyam/mcpkit/pull/1124/files#diff-e176a613968475e6a55ad77685223e0a9dd91d6b2628b3e904b820d7dd177b72) — `TestModalHost_StackPushPopClear` (push/pop/clear + setWidth-fans-to-all).
3. [cmd/agentchat/tui.go](https://github.com/panyam/mcpkit/pull/1124/files#diff-0e29207287df07cecf17e04df9f99e726ae789983f7e3ce007bb6282029b4db6) — the routing: `openOverlayMsg` pushes, new `closeOverlaysMsg` clears, Esc pops (refocus input only when the stack empties), the dispatch goroutine sends `closeOverlaysMsg` on a non-overlay result.
4. [cmd/agentchat/tui_test.go](https://github.com/panyam/mcpkit/pull/1124/files#diff-68ccb7754cb7a3e92c63ccecf5613cb252fcae31e66f524e2ab680a096069bc3) — `TestOverlayStackNestedBackNav` (the acceptance: Esc from a nested overlay reveals its parent) + `TestOverlayStackCloseAll`.
5. [cmd/agentchat/notebook.go](https://github.com/panyam/mcpkit/pull/1124/files#diff-8a79677a206f62f0abeebce75abd2fbafac2dc1be85310113e702bebc42624b1) — the same routing wiring for the notebook surface.

## How it works (the push/pop/close rule)
```
Esc                       -> pop() one level; refocus input only if the stack is now empty
action fires a Line       -> dispatch it; the async result decides:
    result opens overlay  -> openOverlayMsg  -> push()  (nests above the source overlay)
    result is anything else -> closeOverlaysMsg -> clear() (whole stack; back to the prompt)
```
The input is blurred whenever the stack is non-empty, so a command can only be typed with no overlay open — that removes any "fresh vs nested" ambiguity: `openOverlayMsg` always pushes (onto an empty stack for a top-level `/mcp`, onto the parent for a nested `t`).

## Decision log
- **Kept `if m.active()` rather than making the base view a `focusLayer`.** The base's key handling (submit / history / tab-complete) doesn't fit the overlay `handleKey → {Dismiss, Line}` outcome shape, so routing it through the interface is churn with no behavior gain. The stack gives uniform routing *among modals*; the base staying the substrate is honest. Full base-as-layer stays on the 1063 checklist.
- **`push` always, `closeOverlays` on non-overlay results.** Because the input is blurred while a modal is open, every `openOverlayMsg` is unambiguously a nest; a non-overlay action (resume, reconnect) means "the dialog's job is done", so the stack clears.
- **`setWidth` fans to all layers, not just the top.** A parent revealed by a later pop is already sized to the current width (no reflow flash on pop).

## Risk / blast radius
- Affects: the two agentchat TUI surfaces' overlay routing only. `focusLayer` interface unchanged; `agent/host` untouched.
- Tests: `overlay_test.go` (stack mechanics), `tui_test.go` (nested back-nav + close-all). Red-before-green confirmed — the nested test fails when `push` is reverted to single-layer replace.
- Be paranoid about: the blurred-input invariant (a command can't be typed mid-overlay, which is what makes "push always" correct); Ctrl+C still quits with a stack open.

## Before / after (Esc from the tools overlay)
```
BEFORE (single layer)                    AFTER (stack)
/mcp -> servers overlay                  /mcp -> servers overlay
  t  -> tools REPLACES servers             t  -> tools PUSHED above servers
 Esc -> input (servers lost)             Esc -> back to servers overlay
                                         Esc -> input
```

```mermaid
stateDiagram-v2
    [*] --> Input
    Input --> Servers: /mcp
    Servers --> Tools: t (push)
    Tools --> Servers: Esc (pop)
    Servers --> Input: Esc (pop, stack empty)
    Servers --> Input: resume/reconnect (closeOverlays)
```

## Out of scope (deliberately deferred, still on the 1063 checklist)
- Dimmed-base compositing (A4) — float the overlay over a dimmed notebook viewport via `lipgloss.Place`.
- Base view as a `focusLayer` (remove `if m.active()`) — judged low-value churn.

## Note
The E1–E3 accessibility batch (AdaptiveColor / NO_COLOR / glyph) is in flight in a parallel session and also touches `cmd/agentchat/overlay.go` (the `View` styling). This PR only restructures `modalHost` (struct + methods), so any overlap should be a small resolvable conflict in `overlay.go`.

