### PR TITLE
feat(agentchat): color accessibility (1063 E1/E2/E3)

### DIFF
--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -230,7 +230,7 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 
 	observers := o.observers
 	if len(observers) == 0 {
-		observers = []Observer{newRenderer(out)}
+		observers = []Observer{newRenderer(out, envColorEnabled())}
 	}
 	elicUI := o.ui
 	if elicUI == nil {

--- a/agent/host/hostevent.go
+++ b/agent/host/hostevent.go
@@ -129,5 +129,13 @@ func WithObserver(o Observer) AppOption {
 // NewTerminalRenderer returns the built-in terminal Observer — the ANSI
 // line renderer, writing to w. A TUI reuses it by pointing w at a buffer
 // and reading the formatted transcript back, rather than reimplementing
-// every event's formatting.
-func NewTerminalRenderer(w io.Writer) Observer { return newRenderer(w) }
+// every event's formatting. Color follows the environment (NO_COLOR / TERM);
+// use NewTerminalRendererColor to force the decision.
+func NewTerminalRenderer(w io.Writer) Observer { return newRenderer(w, envColorEnabled()) }
+
+// NewTerminalRendererColor is NewTerminalRenderer with an explicit color
+// decision, for a surface that has already resolved --no-color (or its own
+// precedence chain) and wants the ANSI dim styling suppressed accordingly.
+func NewTerminalRendererColor(w io.Writer, colorEnabled bool) Observer {
+	return newRenderer(w, colorEnabled)
+}

--- a/agent/host/render.go
+++ b/agent/host/render.go
@@ -17,7 +17,7 @@ import (
 
 // renderer maps the agent event stream onto the terminal, line-based so
 // interleaved tool events from parallel calls stay readable. ANSI styling is
-// suppressed with --plain or when NO_COLOR is set.
+// suppressed when the resolved color decision is off (see envColorEnabled).
 type renderer struct {
 	out      io.Writer
 	plain    bool
@@ -25,8 +25,24 @@ type renderer struct {
 	midText  bool
 }
 
-func newRenderer(out io.Writer) *renderer {
-	return &renderer{out: out, plain: os.Getenv("NO_COLOR") != ""}
+// newRenderer builds a terminal renderer. colorEnabled=false renders every
+// line plain (no ANSI dim), for a --no-color / NO_COLOR / dumb-terminal caller.
+func newRenderer(out io.Writer, colorEnabled bool) *renderer {
+	return &renderer{out: out, plain: !colorEnabled}
+}
+
+// envColorEnabled resolves the color decision from the environment alone: off
+// when NO_COLOR is present (any value, per no-color.org) or the terminal is
+// TERM=dumb, on otherwise. It is the surface-agnostic default; a CLI layers its
+// own --no-color flag on top and threads the result via NewTerminalRendererColor.
+func envColorEnabled() bool {
+	if _, ok := os.LookupEnv("NO_COLOR"); ok {
+		return false
+	}
+	if os.Getenv("TERM") == "dumb" {
+		return false
+	}
+	return true
 }
 
 func (r *renderer) dim(s string) string {

--- a/agent/host/render_test.go
+++ b/agent/host/render_test.go
@@ -2,6 +2,7 @@ package host
 
 import (
 	"encoding/json"
+	"os"
 	"strings"
 	"testing"
 
@@ -14,8 +15,7 @@ import (
 // call shows name + compact args.
 func TestRendererSubAgentGutter(t *testing.T) {
 	var out strings.Builder
-	r := newRenderer(&out)
-	r.plain = true // strip ANSI so the gutter glyph is asserted directly
+	r := newRenderer(&out, false) // color off strips ANSI so the gutter glyph is asserted directly
 
 	r.subAgent(agent.SubAgentEvent{Scope: "research", Depth: 1, Event: agent.Event{
 		Kind:     agent.EventToolBegin,
@@ -35,11 +35,53 @@ func TestRendererSubAgentGutter(t *testing.T) {
 	}
 }
 
+// TestEnvColorEnabled pins the surface-agnostic env decision (issue 1063 E2):
+// NO_COLOR present (any value) or TERM=dumb turns color off; a normal terminal
+// keeps it on.
+func TestEnvColorEnabled(t *testing.T) {
+	cases := []struct {
+		name       string
+		noColorSet bool
+		noColorVal string
+		term       string
+		want       bool
+	}{
+		{"normal terminal", false, "", "xterm-256color", true},
+		{"NO_COLOR=1", true, "1", "xterm-256color", false},
+		{"NO_COLOR empty still off", true, "", "xterm-256color", false},
+		{"TERM=dumb", false, "", "dumb", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if c.noColorSet {
+				t.Setenv("NO_COLOR", c.noColorVal)
+			} else {
+				os.Unsetenv("NO_COLOR")
+			}
+			t.Setenv("TERM", c.term)
+			if got := envColorEnabled(); got != c.want {
+				t.Fatalf("envColorEnabled() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// TestRendererColorOffStripsANSI pins that a color-off renderer emits no ANSI
+// escapes, the property --no-color / NO_COLOR / TERM=dumb all resolve to.
+func TestRendererColorOffStripsANSI(t *testing.T) {
+	var out strings.Builder
+	r := newRenderer(&out, false)
+	r.turnDone(&agent.TurnResult{Steps: 1})
+	if strings.Contains(out.String(), "\x1b[") {
+		t.Fatalf("color-off render leaked ANSI: %q", out.String())
+	}
+}
+
 // TestRendererToolCancelledDistinctFromError pins that a user cancel
 // renders as an interrupt, not a failure.
 func TestRendererToolCancelledDistinctFromError(t *testing.T) {
 	var out strings.Builder
-	r := newRenderer(&out)
+	r := newRenderer(&out, false)
 	r.handle(agent.Event{
 		Kind:     agent.EventToolCancelled,
 		Step:     1,

--- a/agent/host/render_thinking_test.go
+++ b/agent/host/render_thinking_test.go
@@ -1,7 +1,6 @@
 package host
 
 import (
-	"os"
 	"strings"
 	"testing"
 
@@ -12,10 +11,8 @@ import (
 // reasoning text (dimmed), not a row of dots — so a reasoning model's
 // chain-of-thought is readable in plain and TUI output.
 func TestRenderer_ThinkingStreamsText(t *testing.T) {
-	os.Setenv("NO_COLOR", "1") // strip ANSI so we assert on plain text
-	defer os.Unsetenv("NO_COLOR")
 	var b strings.Builder
-	r := newRenderer(&b)
+	r := newRenderer(&b, false) // color off strips ANSI so we assert on plain text
 	r.handle(agent.Event{Kind: agent.EventThinkingBegin})
 	r.handle(agent.Event{Kind: agent.EventThinkingDelta, Text: "weigh option A "})
 	r.handle(agent.Event{Kind: agent.EventThinkingDelta, Text: "vs option B"})

--- a/cmd/agentchat/color.go
+++ b/cmd/agentchat/color.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+)
+
+// resolveColorEnabled decides whether the interactive surfaces emit color/ANSI
+// styling, honoring the precedence the TUI track calls for (issue 1063 E2):
+// the --no-color flag wins, then NO_COLOR (present at any value, per
+// no-color.org), then a dumb terminal (TERM=dumb). Absent all three, color is
+// on and termenv is left to auto-detect the profile so it degrades
+// truecolor→256→16→mono on its own.
+//
+// look is os.LookupEnv in production; tests pass a stub map so the precedence
+// is verifiable without mutating the process environment.
+func resolveColorEnabled(flagNoColor bool, look func(string) (string, bool)) bool {
+	if flagNoColor {
+		return false
+	}
+	if _, ok := look("NO_COLOR"); ok {
+		return false
+	}
+	if v, _ := look("TERM"); v == "dumb" {
+		return false
+	}
+	return true
+}
+
+// applyLipglossProfile pins lipgloss to a plain (Ascii) color profile when color
+// is disabled, so every Faint/Bold/Reverse/Foreground style across the overlay,
+// status line, and notebook cells renders as plain text deterministically. When
+// color is enabled it leaves the default renderer's auto-detected profile in
+// place, which is what gives termenv's truecolor→256→16→mono degradation for
+// free. Call once at startup, before any surface renders.
+func applyLipglossProfile(colorEnabled bool) {
+	if !colorEnabled {
+		lipgloss.SetColorProfile(termenv.Ascii)
+	}
+}
+
+// accentColor is the one true foreground color in the TUI (overlay title +
+// selected row). AdaptiveColor picks per terminal background (issue 1063 E1):
+// blue reads better on light terminals, cyan on dark. Both are 16-color-safe
+// ANSI indices, so the accent survives a low-capability terminal.
+var accentColor = lipgloss.AdaptiveColor{Light: "4", Dark: "6"}

--- a/cmd/agentchat/color_test.go
+++ b/cmd/agentchat/color_test.go
@@ -1,0 +1,32 @@
+package main
+
+import "testing"
+
+// TestResolveColorEnabled pins the E2 precedence: --no-color wins, then
+// NO_COLOR (present at any value), then TERM=dumb, else color is on.
+func TestResolveColorEnabled(t *testing.T) {
+	env := func(m map[string]string) func(string) (string, bool) {
+		return func(k string) (string, bool) { v, ok := m[k]; return v, ok }
+	}
+	cases := []struct {
+		name string
+		flag bool
+		vars map[string]string
+		want bool
+	}{
+		{"clean env is color-on", false, nil, true},
+		{"flag disables", true, nil, false},
+		{"flag beats a colorful env", true, map[string]string{"COLORTERM": "truecolor"}, false},
+		{"NO_COLOR present disables", false, map[string]string{"NO_COLOR": "1"}, false},
+		{"NO_COLOR empty still disables", false, map[string]string{"NO_COLOR": ""}, false},
+		{"TERM=dumb disables", false, map[string]string{"TERM": "dumb"}, false},
+		{"TERM=xterm keeps color", false, map[string]string{"TERM": "xterm-256color"}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := resolveColorEnabled(c.flag, env(c.vars)); got != c.want {
+				t.Fatalf("resolveColorEnabled(%v, %v) = %v, want %v", c.flag, c.vars, got, c.want)
+			}
+		})
+	}
+}

--- a/cmd/agentchat/go.mod
+++ b/cmd/agentchat/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v0.10.0
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
+	github.com/muesli/termenv v0.16.0
 	github.com/panyam/mcpkit v0.4.0-b3
 	github.com/panyam/mcpkit/agent/host v0.0.0
 	github.com/panyam/mcpkit/ext/otel v0.3.1
@@ -58,7 +59,6 @@ require (
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
-	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/pgvector/pgvector-go v0.4.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/cmd/agentchat/main.go
+++ b/cmd/agentchat/main.go
@@ -200,6 +200,7 @@ func newRoot() (*cobra.Command, *viper.Viper) {
 	fl.String("ui", "auto", "interface: auto (TUI when interactive) | tui (inline) | notebook (alt-screen, foldable cells) | plain")
 	fl.Int("notebook-max-lines", 20, "with --ui notebook, max rows the auto-growing prompt expands to")
 	fl.Int("context-window", 0, "model context window in tokens; enables a 'N% context left' gauge in the status line (0 = show token counts only)")
+	fl.Bool("no-color", false, "disable color/ANSI styling on every surface (also honored via NO_COLOR / TERM=dumb)")
 	fl.Int("offload-threshold", 0, "offload tool results at/over N bytes to a store, feeding the model a stub + read_tool_result (0 = off; blobs use --session-store's backend)")
 	fl.String("offload-dir", "", "store offloaded tool results as files under this directory (no server needed); overrides --session-store for blobs")
 	fl.Bool("memory", false, "enable working memory: remember/recall/forget tools the model manages across turns (in-memory store)")
@@ -274,15 +275,25 @@ func runChat(v *viper.Viper) error {
 		appOpts = append(appOpts, host.WithConfigOverlay(configPath))
 	}
 	mode := uiMode(v.GetString("ui"))
+	// One color decision (flag → NO_COLOR → TERM=dumb) drives every surface: the
+	// lipgloss profile for the overlay/status/notebook chrome, and the host's
+	// ANSI renderer + glamour via the observers below (issue 1063 E1/E2).
+	colorEnabled := resolveColorEnabled(v.GetBool("no-color"), os.LookupEnv)
+	applyLipglossProfile(colorEnabled)
 	var surface *tuiObserver
 	var nbSurface *nbObserver
 	switch mode {
 	case "tui":
-		surface = newTUIObserver()
+		surface = newTUIObserver(colorEnabled)
 		appOpts = append(appOpts, host.WithObserver(surface))
 	case "notebook":
-		nbSurface = newNBObserver()
+		nbSurface = newNBObserver(colorEnabled)
 		appOpts = append(appOpts, host.WithObserver(nbSurface))
+	default:
+		// The plain REPL uses the host's auto-created renderer; register a
+		// color-resolved one explicitly so --no-color reaches it too (the
+		// auto default follows only the environment).
+		appOpts = append(appOpts, host.WithObserver(host.NewTerminalRendererColor(os.Stdout, colorEnabled)))
 	}
 	sessionStore := v.GetString("session-store")
 	store, err := buildRunStore(sessionStore)

--- a/cmd/agentchat/markdown.go
+++ b/cmd/agentchat/markdown.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"os"
 	"strings"
 	"sync"
 
@@ -14,10 +13,11 @@ import (
 // mangles a half-written fenced code block and reflows on every call, so
 // streaming stays raw and the render happens once when the block closes.
 //
-// Rendering is disabled (raw passthrough) when NO_COLOR is set, matching the
-// plain-mode semantics in agent/host's terminal renderer; the plain REPL never
-// reaches this path at all. The underlying glamour TermRenderer is cached and
-// rebuilt only when the target width changes.
+// Rendering is disabled (raw passthrough) when color is off (the resolved
+// --no-color / NO_COLOR / dumb-terminal decision), matching the plain-mode
+// semantics in agent/host's terminal renderer; the plain REPL never reaches
+// this path at all. The underlying glamour TermRenderer is cached and rebuilt
+// only when the target width changes.
 type mdRenderer struct {
 	mu       sync.Mutex
 	disabled bool
@@ -25,8 +25,10 @@ type mdRenderer struct {
 	tr       *glamour.TermRenderer
 }
 
-func newMDRenderer() *mdRenderer {
-	return &mdRenderer{disabled: os.Getenv("NO_COLOR") != ""}
+// newMDRenderer builds the commit-time markdown renderer. colorEnabled=false
+// disables glamour styling so committed blocks pass through as raw markdown.
+func newMDRenderer(colorEnabled bool) *mdRenderer {
+	return &mdRenderer{disabled: !colorEnabled}
 }
 
 // setWidth updates the word-wrap width used for subsequent renders (fanned out

--- a/cmd/agentchat/markdown_test.go
+++ b/cmd/agentchat/markdown_test.go
@@ -5,6 +5,19 @@ import (
 	"testing"
 )
 
+// TestNewMDRenderer_ColorDecision pins that the color decision drives the
+// disabled gate (E2): color off = raw passthrough, color on = glamour renders.
+func TestNewMDRenderer_ColorDecision(t *testing.T) {
+	if got := newMDRenderer(false).render("# H"); got != "# H" {
+		t.Fatalf("color-off renderer should pass through raw: %q", got)
+	}
+	on := newMDRenderer(true)
+	on.setWidth(80)
+	if got := on.render("# H"); got == "# H" {
+		t.Fatalf("color-on renderer left markdown untouched: %q", got)
+	}
+}
+
 func TestMDRenderer_DisabledPassthrough(t *testing.T) {
 	r := &mdRenderer{disabled: true}
 	in := "# Heading\n\n- a\n- b"

--- a/cmd/agentchat/notebook.go
+++ b/cmd/agentchat/notebook.go
@@ -66,10 +66,10 @@ type nbObserver struct {
 	toolLabel string
 }
 
-func newNBObserver() *nbObserver {
+func newNBObserver(colorEnabled bool) *nbObserver {
 	buf := &bytes.Buffer{}
-	md := newMDRenderer()
-	return &nbObserver{buf: buf, term: host.NewTerminalRenderer(buf), md: md, renderMD: md.render}
+	md := newMDRenderer(colorEnabled)
+	return &nbObserver{buf: buf, term: host.NewTerminalRendererColor(buf, colorEnabled), md: md, renderMD: md.render}
 }
 
 // setWidth fans the terminal width to the markdown renderer so assistant cells
@@ -543,7 +543,14 @@ func (m notebookModel) renderCells() string {
 		if c.collapsed {
 			marker = "▸"
 		}
-		header := marker + " " + c.label
+		// A leading cursor column marks the nav selection with a glyph, not
+		// color/attribute alone, so the selected cell stays visible under
+		// NO_COLOR / a dumb terminal where Reverse is stripped (issue 1063 E3).
+		cursor := "  "
+		if m.nav && i == m.sel {
+			cursor = "▌ "
+		}
+		header := cursor + marker + " " + c.label
 		if c.collapsed {
 			header += " · " + snippet(firstLine(c.body), 70)
 		}

--- a/cmd/agentchat/notebook_test.go
+++ b/cmd/agentchat/notebook_test.go
@@ -61,6 +61,28 @@ func TestNotebook_RenderedBodyDisplayedRawUsedForSnippet(t *testing.T) {
 	}
 }
 
+// TestNotebook_NavSelectionHasGlyphCursor pins E3 (issue 1063): the nav
+// selection is marked by a leading glyph cursor, not Reverse video alone, so it
+// stays visible when color/attributes are stripped (NO_COLOR / dumb terminal).
+// The cursor sits inside the reverse-styled span, so asserting the glyph is
+// present also proves it survives the style being a no-op.
+func TestNotebook_NavSelectionHasGlyphCursor(t *testing.T) {
+	m := newNotebookModel(nil, nil, 20, 0)
+	m = send(m, nbCellMsg{label: "assistant", body: "one"})
+	m = send(m, nbCellMsg{label: "assistant", body: "two"})
+
+	before := m.renderCells()
+	if strings.Contains(before, "▌") {
+		t.Fatalf("insert mode should carry no selection cursor:\n%s", before)
+	}
+
+	m = send(m, tea.KeyMsg{Type: tea.KeyEsc}) // enter nav on the last cell
+	out := m.renderCells()
+	if !strings.Contains(out, "▌") {
+		t.Fatalf("nav selection missing glyph cursor:\n%s", out)
+	}
+}
+
 func TestNotebook_FoldToggleInNav(t *testing.T) {
 	m := newNotebookModel(nil, nil, 20, 0)
 	m = send(m, nbCellMsg{label: "assistant", body: "long answer here"})
@@ -240,7 +262,7 @@ func TestNotebook_FirstPromptLineStaysVisible(t *testing.T) {
 }
 
 func nbCollectCells(evs ...host.HostEvent) []nbCell {
-	obs := newNBObserver()
+	obs := newNBObserver(true)
 	var cells []nbCell
 	for _, ev := range evs {
 		for _, m := range obs.render(ev) {
@@ -317,7 +339,7 @@ func TestNBObserver_ToolBecomesOwnCell(t *testing.T) {
 }
 
 func TestNBObserver_AssistantCellsGlamouredToolCellsVerbatim(t *testing.T) {
-	obs := newNBObserver()
+	obs := newNBObserver(true)
 	obs.renderMD = func(s string) string { return "MD{" + s + "}" }
 	var cells []nbCell
 	for _, ev := range []host.HostEvent{

--- a/cmd/agentchat/overlay.go
+++ b/cmd/agentchat/overlay.go
@@ -203,7 +203,7 @@ func (o *overlayModel) handleKey(msg tea.KeyMsg) overlayOutcome {
 // and a dim key hint. Dynamic height — the box grows with the visible rows.
 func (o *overlayModel) View() string {
 	dim := lipgloss.NewStyle().Faint(true)
-	sel := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("6"))
+	sel := lipgloss.NewStyle().Bold(true).Foreground(accentColor)
 	var b strings.Builder
 	b.WriteString(sel.Render(o.title))
 	b.WriteString("\n")

--- a/cmd/agentchat/tui.go
+++ b/cmd/agentchat/tui.go
@@ -120,10 +120,10 @@ type segBlock struct {
 	text  string
 }
 
-func newTUIObserver() *tuiObserver {
+func newTUIObserver(colorEnabled bool) *tuiObserver {
 	buf := &bytes.Buffer{}
-	md := newMDRenderer()
-	return &tuiObserver{buf: buf, term: host.NewTerminalRenderer(buf), md: md, renderMD: md.render}
+	md := newMDRenderer(colorEnabled)
+	return &tuiObserver{buf: buf, term: host.NewTerminalRendererColor(buf, colorEnabled), md: md, renderMD: md.render}
 }
 
 // setWidth fans the terminal width to the markdown renderer so committed

--- a/cmd/agentchat/tui_test.go
+++ b/cmd/agentchat/tui_test.go
@@ -361,7 +361,7 @@ func tuiCommit(obs *tuiObserver, evs ...host.HostEvent) string {
 }
 
 func TestTUIObserver_GlamoursProseKeepsToolLinesVerbatim(t *testing.T) {
-	obs := newTUIObserver()
+	obs := newTUIObserver(true)
 	obs.renderMD = stubMD
 
 	commit := tuiCommit(obs,
@@ -389,7 +389,7 @@ func TestTUIObserver_GlamoursProseKeepsToolLinesVerbatim(t *testing.T) {
 }
 
 func TestTUIObserver_TextOnlyTurnIsGlamoured(t *testing.T) {
-	obs := newTUIObserver()
+	obs := newTUIObserver(true)
 	obs.renderMD = stubMD
 	commit := tuiCommit(obs,
 		runnerEv(agent.Event{Kind: agent.EventTextDelta, Text: "# Title"}),


### PR DESCRIPTION
## What changes

The agentchat TUI surfaces gain the color-accessibility group from the issue 1063 backlog (`§E`, the checklist's "AdaptiveColor + NO_COLOR/degradation + glyph-not-just-color" item). A single resolved color decision now drives every surface with an explicit precedence chain, one hardcoded color becomes an `AdaptiveColor`, and the notebook selection no longer depends on color/attribute alone.

- **E1** — the overlay selection foreground (the only hardcoded color in the TUI) becomes `lipgloss.AdaptiveColor{Light:"4",Dark:"6"}` (blue on light terminals, cyan on dark).
- **E2** — a `--no-color` flag plus a precedence chain (**flag → `NO_COLOR` → `TERM=dumb`**), threaded to all three color mechanisms (lipgloss chrome, the host raw-ANSI renderer, and glamour). When color is on, the lipgloss profile is left auto-detected so termenv degrades truecolor→256→16→mono on its own.
- **E3** — the notebook nav selection gains a leading glyph cursor (`▌`) so the selected cell stays visible when `Reverse` video is stripped under `NO_COLOR` / a dumb terminal. (The host renderer's tool-status glyphs ✓/✗/⚙/⊘ already satisfied E3.)

Rebased onto current `main` so it sits on top of the C4 overlay-stack merge (#1124); no interaction beyond the shared `overlay.go`/`notebook.go` files.

## Reviewer's guide
Read in this order:
1. [cmd/agentchat/color.go](https://github.com/panyam/mcpkit/pull/1125/files#diff-d7baab43b0bccb1a34f675378743809e05ae3f52ec699e164e2510c319ec862e) — start here. The pure `resolveColorEnabled` precedence function, `applyLipglossProfile` (Ascii-when-off), and the `accentColor` AdaptiveColor (E1).
2. [cmd/agentchat/color_test.go](https://github.com/panyam/mcpkit/pull/1125/files#diff-173bfff9796cb47491d74aacafa543c9c98b53bbddb2e7453dfa0f5b7737642b) — acceptance for the precedence table.
3. [agent/host/render.go](https://github.com/panyam/mcpkit/pull/1125/files#diff-da3546e85434193f7b8b2df15f4f6d6df496b616b9e0b0b8c4299cd4576e044a) — host renderer: `newRenderer(out, colorEnabled)` + the surface-agnostic `envColorEnabled` helper (`NO_COLOR` present or `TERM=dumb`).
4. [agent/host/hostevent.go](https://github.com/panyam/mcpkit/pull/1125/files#diff-19a6cb704e31f277e9bf65a111061678da30c84576e938e6ac2ef2f379e01095) — new `NewTerminalRendererColor(w, enabled)`; `NewTerminalRenderer` stays env-default.
5. [cmd/agentchat/main.go](https://github.com/panyam/mcpkit/pull/1125/files#diff-ce3956549c93b4983f18090136a2139c3c92d38408e923245f5e9ba628bcc98a) — resolve once, `applyLipglossProfile`, thread `colorEnabled` to the observers and the plain REPL renderer.
6. [cmd/agentchat/notebook.go](https://github.com/panyam/mcpkit/pull/1125/files#diff-8a79677a206f62f0abeebce75abd2fbafac2dc1be85310113e702bebc42624b1) — E3 glyph cursor on the nav selection.
7. [cmd/agentchat/notebook_test.go](https://github.com/panyam/mcpkit/pull/1125/files#diff-12e612880a5d601118bba88764d9d1ff5815b9406c3ffb4e5a61ca6e9c4188a1) — acceptance for the glyph cursor.
8. [agent/host/render_test.go](https://github.com/panyam/mcpkit/pull/1125/files#diff-50fa3906597449e69d5cae6454e95743166803ffdfa51912d65a494662c11239) — `envColorEnabled` table + color-off strips ANSI.
9. [cmd/agentchat/overlay.go](https://github.com/panyam/mcpkit/pull/1125/files#diff-bac1d9dab64a940d455f5503f797fa91421cd0b03a6f1533cededa8c62e7b3da), [cmd/agentchat/markdown.go](https://github.com/panyam/mcpkit/pull/1125/files#diff-801de37d09a0dfe451150ec5076417284f2ff765bf8446cf23c3e07c1e14cc7c), [cmd/agentchat/tui.go](https://github.com/panyam/mcpkit/pull/1125/files#diff-0e29207287df07cecf17e04df9f99e726ae789983f7e3ce007bb6282029b4db6) — mechanical threading (accent, `newMDRenderer(bool)`, observer arg).

Skim or skip: [cmd/agentchat/go.mod](https://github.com/panyam/mcpkit/pull/1125/files#diff-381fb1fac52fdbe31f9784e2443c827670debb660fdab2fb056f41d478492c49) (termenv indirect→direct), the constructor-arg-only edits in `tui_test.go`, `markdown_test.go`, `render_thinking_test.go`.

## How it works

```
resolveColorEnabled(flagNoColor, lookupEnv):
    if flagNoColor: return false          # --no-color wins
    if "NO_COLOR" present (any value): return false
    if TERM == "dumb": return false
    return true

startup (main):
    colorEnabled = resolveColorEnabled(--no-color, os.LookupEnv)
    applyLipglossProfile(colorEnabled)    # SetColorProfile(Ascii) only when off
    tui/notebook  -> newTUIObserver/newNBObserver(colorEnabled)
                       -> NewTerminalRendererColor(buf, colorEnabled)  # host ANSI
                       -> newMDRenderer(colorEnabled)                  # glamour
    plain         -> WithObserver(NewTerminalRendererColor(stdout, colorEnabled))
```

The host renderer's own default (`NewTerminalRenderer`, and the App auto-renderer) resolves color from the environment alone via `envColorEnabled` — it stays surface-agnostic; only the CLI knows about the `--no-color` flag and layers it on via `NewTerminalRendererColor`.

## Decision log
- **lipgloss `SetColorProfile(Ascii)` for the off path** rather than per-style guards: it strips text *attributes* (Faint/Bold/Reverse), not just Foreground, in one deterministic switch, and needs no plumbing into every `View()`.
- **Kept charm/lipgloss out of `agent/host`**: the host gains only env-standard (`NO_COLOR`/`TERM`) awareness and a raw-ANSI color-aware constructor, per the pinned layering (charm confined to `cmd/agentchat`).
- **`TERM=dumb` folded into the host env helper** (not just the CLI): it is a universal terminal-capability signal, so it belongs at the surface-agnostic layer alongside `NO_COLOR`.
- **Glyph cursor `▌` for the notebook selection** instead of a color: `Reverse`-only selection vanishes once attributes are stripped; the glyph sits inside the reverse span so it is additive when color is on.

## Risk / blast radius
- Affects: agentchat interactive surfaces (tui/notebook/plain) and the host terminal renderer's color gate. No protocol or agent-core behavior changes.
- `newRenderer` signature changed (unexported, host-internal); `NewTerminalRenderer` public API is unchanged (env-default), `NewTerminalRendererColor` is additive.
- Tests: `color_test.go`, `notebook_test.go` (glyph), `render_test.go` (env + ANSI-strip), `markdown_test.go` (color decision). +16 assertions, 0 removed/weakened.
- Be paranoid about: the plain-REPL path now registers an explicit `WithObserver` (suppressing the auto-renderer) — verify plain output is unchanged when color is on (it is: same renderer, resolved-on).

## Before / after

Host renderer driven with the same events, color on vs off (`cat -v` reveals the escapes). ANSI dim (`^[[2m…^[[0m`) is present with color and absent without; the glyphs (⚙ / ✓ / —) survive both, which is E3:

```
COLOR ON
^[[2m⚙ get_weather({"city":"SF"})^[[0m
^[[2m  ✓ get_weather: sunny, 72F^[[0m
^[[2m— 2 step(s), 340 in / 58 out tokens^[[0m

COLOR OFF  (--no-color / NO_COLOR / TERM=dumb)
⚙ get_weather({"city":"SF"})
  ✓ get_weather: sunny, 72F
— 2 step(s), 340 in / 58 out tokens
```

Notebook nav selection, before vs after (E3): before, the selected cell was `Reverse`-only and disappeared with attributes stripped; after, a `▌` cursor marks it regardless of color.

## Out of scope (deliberately deferred)
- B5 diff add/remove AdaptiveColor — no diff view exists in the TUI yet.
- C4/F2 residue (dimmed-base compositing, grapheme-aware width) — separate open 1063 checklist items.
- User-overridable theme files (crush/opencode style) — YAGNI until requested.
- Pre-existing gofmt drift in `notebook.go`/`tui.go`/`app.go` (the C4 `modalHost` embed alignment) left untouched to avoid scope creep; not introduced here.
