### PR TITLE
feat(agentchat): ctrl+o raw markdown for copy fidelity (1083)

### DIFF
--- a/cmd/agentchat/keys.go
+++ b/cmd/agentchat/keys.go
@@ -19,6 +19,7 @@ type appKeys struct {
 	Complete key.Binding
 	History  key.Binding
 	Help     key.Binding
+	Raw      key.Binding
 	Quit     key.Binding
 
 	// notebook NAV mode
@@ -37,6 +38,7 @@ func newAppKeys() appKeys {
 		Complete: key.NewBinding(key.WithKeys("tab"), key.WithHelp("tab", "complete")),
 		History:  key.NewBinding(key.WithKeys("up", "down"), key.WithHelp("↑↓", "history")),
 		Help:     key.NewBinding(key.WithKeys("?"), key.WithHelp("?", "help")),
+		Raw:      key.NewBinding(key.WithKeys("ctrl+o"), key.WithHelp("ctrl+o", "raw markdown")),
 		Quit:     key.NewBinding(key.WithKeys("ctrl+c"), key.WithHelp("ctrl+c", "quit")),
 
 		Select: key.NewBinding(key.WithKeys("up", "down", "k", "j"), key.WithHelp("↑↓/jk", "select")),
@@ -55,14 +57,14 @@ func (k appKeys) insertBar() []key.Binding {
 }
 
 func (k appKeys) navBar() []key.Binding {
-	return []key.Binding{k.Select, k.Fold, k.Ends, k.Insert, k.Help}
+	return []key.Binding{k.Select, k.Fold, k.Ends, k.Raw, k.Insert, k.Help}
 }
 
 // fullHelp groups every surface binding for the `?` view.
 func (k appKeys) fullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		{k.Send, k.Newline, k.Complete},
-		{k.History, k.Help, k.Quit},
+		{k.History, k.Raw, k.Help, k.Quit},
 		{k.Nav, k.Select, k.Fold, k.Ends, k.Insert, k.Scroll},
 	}
 }
@@ -97,6 +99,14 @@ func renderKeyHelp() string {
 		"  NAV   cell selection. i or esc returns to INS; the NAV keys above",
 		"        (↑↓/jk select, space fold, g/G ends, pgup/dn scroll) act only here.",
 		"  The inline surface (--ui tui) has no modes; it is always in INS.",
+	}, "\n"))
+	b.WriteString("\n\nctrl+o (raw markdown):\n")
+	b.WriteString(strings.Join([]string{
+		"  notebook  toggles the whole transcript between rich (glamour) and raw",
+		"            markdown, in place — for copying source, not rendered text.",
+		"  inline    dumps the last assistant reply as raw markdown to scrollback",
+		"            (committed output can't be re-rendered); use --ui notebook for",
+		"            the in-place whole-session toggle.",
 	}, "\n"))
 	return b.String()
 }

--- a/cmd/agentchat/notebook.go
+++ b/cmd/agentchat/notebook.go
@@ -228,6 +228,7 @@ type notebookModel struct {
 	showAll bool // ? toggled the full-help view
 
 	nav      bool // false = insert, true = nav
+	raw      bool // ctrl+o: show cells as raw markdown, not glamour-rendered (1083)
 	sel      int  // selected cell index in nav mode
 	running  bool
 	atBottom bool // whether the viewport is scrolled to the end (for auto-follow)
@@ -364,6 +365,13 @@ func (m notebookModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case out.Line != "":
 				return m.submit(out.Line)
 			}
+			return m, nil
+		}
+		// ctrl+o toggles the whole transcript between rich and raw markdown, in
+		// place (issue 1083) — works in both INS and NAV modes.
+		if key.Matches(msg, m.keys.Raw) {
+			m.raw = !m.raw
+			m.refresh()
 			return m, nil
 		}
 		if m.nav {
@@ -507,6 +515,9 @@ func (m notebookModel) statusBar() string {
 	} else {
 		hint = "INS  " + m.help.ShortHelpView(m.keys.insertBar())
 	}
+	if m.raw {
+		hint = "RAW  " + hint
+	}
 	if m.running {
 		hint = "working…  " + hint
 	}
@@ -561,7 +572,9 @@ func (m notebookModel) renderCells() string {
 		b.WriteString("\n")
 		if !c.collapsed && c.body != "" {
 			display := c.body
-			if c.rendered != "" {
+			// ctrl+o (m.raw) shows raw markdown for copy fidelity; otherwise the
+			// glamour-rendered form when there is one (issue 1083).
+			if c.rendered != "" && !m.raw {
 				display = c.rendered
 			}
 			b.WriteString(indentBlock(display))

--- a/cmd/agentchat/notebook_test.go
+++ b/cmd/agentchat/notebook_test.go
@@ -45,6 +45,30 @@ func TestNotebook_CellAppendedAndRendered(t *testing.T) {
 	}
 }
 
+func TestNotebook_CtrlOTogglesRawMarkdown(t *testing.T) {
+	m := newNotebookModel(nil, nil, 20, 0)
+	m = send(m, tea.WindowSizeMsg{Width: 40, Height: 20})
+	m = send(m, nbCellMsg{label: "assistant", body: "- raw item", rendered: "• styled item"})
+
+	// default: rich (glamour-rendered) body
+	if out := m.renderCells(); !strings.Contains(out, "• styled item") || strings.Contains(out, "- raw item") {
+		t.Fatalf("default should render rich:\n%s", out)
+	}
+	// ctrl+o toggles to raw markdown in place
+	m = send(m, tea.KeyMsg{Type: tea.KeyCtrlO})
+	if out := m.renderCells(); !strings.Contains(out, "- raw item") || strings.Contains(out, "• styled item") {
+		t.Fatalf("after ctrl+o should show raw:\n%s", out)
+	}
+	if !strings.Contains(m.statusBar(), "RAW") {
+		t.Fatal("raw mode should show a RAW indicator in the status bar")
+	}
+	// ctrl+o again flips back to rich
+	m = send(m, tea.KeyMsg{Type: tea.KeyCtrlO})
+	if out := m.renderCells(); !strings.Contains(out, "• styled item") {
+		t.Fatalf("second ctrl+o should return to rich:\n%s", out)
+	}
+}
+
 func TestNotebook_RenderedBodyDisplayedRawUsedForSnippet(t *testing.T) {
 	m := newNotebookModel(nil, nil, 20, 0)
 	m = send(m, tea.WindowSizeMsg{Width: 40, Height: 20})

--- a/cmd/agentchat/tui.go
+++ b/cmd/agentchat/tui.go
@@ -110,6 +110,7 @@ type tuiObserver struct {
 	renderMD func(string) string // == md.render; swapped in tests
 	blocks   []segBlock          // the current turn's committed blocks
 	prose    strings.Builder     // the open assistant-prose run (raw markdown)
+	lastRaw  string              // raw markdown of the last committed assistant turn (ctrl+o, 1083)
 }
 
 // segBlock is one span of a committed turn: assistant prose (raw markdown,
@@ -136,6 +137,29 @@ func (s *tuiObserver) flushProse() {
 		s.blocks = append(s.blocks, segBlock{prose: true, text: s.prose.String()})
 		s.prose.Reset()
 	}
+}
+
+// rawProse joins the raw markdown of the prose blocks (assistant text), skipping
+// meta blocks (tool lines, the turn footer) — the source a ctrl+o dump reprints
+// so it copies as real markdown, not glamour's rendered text.
+func rawProse(blocks []segBlock) string {
+	var out []string
+	for _, b := range blocks {
+		if b.prose {
+			if t := strings.TrimRight(b.text, "\n"); t != "" {
+				out = append(out, t)
+			}
+		}
+	}
+	return strings.Join(out, "\n")
+}
+
+// rawDump returns the raw markdown of the last committed assistant turn (empty
+// before any turn), for the inline ctrl+o copy-fidelity dump (issue 1083).
+func (s *tuiObserver) rawDump() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastRaw
 }
 
 // renderBlocks builds the committed segment: prose blocks through glamour,
@@ -194,6 +218,12 @@ func (s *tuiObserver) fold(ev host.HostEvent) []tea.Msg {
 		s.flushProse()
 		if tail := live[before:]; tail != "" {
 			s.blocks = append(s.blocks, segBlock{text: tail})
+		}
+		// Capture this turn's raw assistant markdown (prose blocks only, tool /
+		// footer meta excluded) for the ctrl+o raw dump (issue 1083); a turn with
+		// no prose (a bare command result) leaves the previous dump in place.
+		if raw := rawProse(s.blocks); raw != "" {
+			s.lastRaw = raw
 		}
 		commit := s.renderBlocks()
 		s.blocks = nil
@@ -352,6 +382,11 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// mid-message.
 			m.showAll = !m.showAll
 			return m, nil
+		case key.Matches(msg, m.keys.Raw):
+			// ctrl+o dumps the last assistant turn as raw markdown to scrollback:
+			// inline commits are immutable, so we reprint the source rather than
+			// re-render in place (the in-place toggle is notebook mode). Issue 1083.
+			return m, m.dumpRaw()
 		case key.Matches(msg, m.keys.Send):
 			if m.running {
 				return m, nil
@@ -458,6 +493,24 @@ func (m tuiModel) submit(line string) (tea.Model, tea.Cmd) {
 		}()
 	}
 	return m, nil
+}
+
+// dumpRaw prints the last assistant turn's raw markdown to scrollback so it can
+// be copied as source (glamour-rendered scrollback copies as bullets/no-fences).
+// Returns nil (no-op) when there is nothing committed yet. A hint points at the
+// notebook surface for the in-place whole-session toggle, which inline's
+// immutable scrollback cannot offer. Issue 1083.
+func (m tuiModel) dumpRaw() tea.Cmd {
+	if m.surface == nil {
+		return nil
+	}
+	raw := m.surface.rawDump()
+	if raw == "" {
+		return nil
+	}
+	dim := lipgloss.NewStyle().Faint(true)
+	header := dim.Render("── raw markdown (last reply · --ui notebook toggles the whole session) ──")
+	return tea.Println(header + "\n" + raw)
 }
 
 func (m *tuiModel) completeTab() { tabComplete(&m.ta, m.app) }

--- a/cmd/agentchat/tui_test.go
+++ b/cmd/agentchat/tui_test.go
@@ -388,6 +388,51 @@ func TestTUIObserver_GlamoursProseKeepsToolLinesVerbatim(t *testing.T) {
 	}
 }
 
+func TestTUIObserver_RawDumpIsProseOnly(t *testing.T) {
+	obs := newTUIObserver(true)
+	obs.renderMD = stubMD
+	if obs.rawDump() != "" {
+		t.Fatal("rawDump should be empty before any turn is committed")
+	}
+
+	_ = tuiCommit(obs,
+		runnerEv(agent.Event{Kind: agent.EventTextDelta, Text: "- item one"}),
+		runnerEv(agent.Event{Kind: agent.EventToolBegin, ToolCall: &agent.ToolCall{Name: "greet"}}),
+		runnerEv(agent.Event{Kind: agent.EventToolEnd, ToolCall: &agent.ToolCall{Name: "greet"}}),
+		runnerEv(agent.Event{Kind: agent.EventTextDelta, Text: "- item two"}),
+		turnDoneEv(),
+	)
+	raw := obs.rawDump()
+	if !strings.Contains(raw, "- item one") || !strings.Contains(raw, "- item two") {
+		t.Fatalf("rawDump should carry both raw prose runs: %q", raw)
+	}
+	if strings.Contains(raw, "MD{") {
+		t.Fatalf("rawDump must be raw markdown, not glamoured: %q", raw)
+	}
+	if strings.Contains(raw, "greet") {
+		t.Fatalf("rawDump must exclude tool/meta lines: %q", raw)
+	}
+}
+
+func TestTUIModel_CtrlORawDump(t *testing.T) {
+	obs := newTUIObserver(true)
+	obs.renderMD = stubMD
+	m := newTUIModel(nil, obs, 0)
+
+	// no committed turn yet → ctrl+o is a no-op
+	if _, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlO}); cmd != nil {
+		t.Fatal("ctrl+o with nothing committed should be a no-op")
+	}
+	// after a turn commits, ctrl+o returns a Println command (the raw dump)
+	_ = tuiCommit(obs,
+		runnerEv(agent.Event{Kind: agent.EventTextDelta, Text: "hello"}),
+		turnDoneEv(),
+	)
+	if _, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlO}); cmd == nil {
+		t.Fatal("ctrl+o after a committed turn should return a Println command")
+	}
+}
+
 func TestTUIObserver_TextOnlyTurnIsGlamoured(t *testing.T) {
 	obs := newTUIObserver(true)
 	obs.renderMD = stubMD


### PR DESCRIPTION
## What changes

`ctrl+o` gives back raw markdown so it can be copied as source. Glamour-rendered scrollback copies as *rendered* text (`•` bullets, stripped fences, width-padding), which is useless for pasting a code block back out. The mechanism differs per surface because the surfaces render differently:

- **notebook** (managed `viewport`): toggles the whole transcript between rich and raw **in place** — cells already store both `body` (raw) and `rendered` (glamour), so it just re-renders. A `RAW` indicator shows in the status bar. This is the faithful analog of Claude Code's transcript viewer (a managed, re-rendered pane).
- **inline** (native, immutable scrollback): committed output can't be re-rendered, so `ctrl+o` **dumps the last assistant reply's raw markdown** to scrollback (prose only — tool/footer meta excluded), with a hint pointing at `--ui notebook` for the in-place whole-session toggle.

Surface-only (`cmd/agentchat`); no `agent/host` change, no deps.

## Reviewer's guide
Read in this order:
1. [cmd/agentchat/keys.go](https://github.com/panyam/mcpkit/pull/1127/files#diff-e83752496ec9cc063a573fedefb2237ad2f177671926491e0fc11d9b372aa076) — start here. The centralized `Raw` binding (`ctrl+o`) + its help in `fullHelp`/`navBar`/the `/keys` cheatsheet (with the per-surface behavior note).
2. [cmd/agentchat/notebook.go](https://github.com/panyam/mcpkit/pull/1127/files#diff-8a79677a206f62f0abeebce75abd2fbafac2dc1be85310113e702bebc42624b1) — the `raw bool` toggle: the display branch uses `body` when `raw`, the `ctrl+o` handler (works in INS and NAV), the `RAW` status indicator.
3. [cmd/agentchat/notebook_test.go](https://github.com/panyam/mcpkit/pull/1127/files#diff-12e612880a5d601118bba88764d9d1ff5815b9406c3ffb4e5a61ca6e9c4188a1) — `TestNotebook_CtrlOTogglesRawMarkdown` (rich → raw → rich + indicator).
4. [cmd/agentchat/tui.go](https://github.com/panyam/mcpkit/pull/1127/files#diff-0e29207287df07cecf17e04df9f99e726ae789983f7e3ce007bb6282029b4db6) — the inline dump: `tuiObserver.lastRaw` captured at commit via `rawProse` (prose blocks only), `rawDump()`, and `tuiModel.dumpRaw()` (no-op before any turn).
5. [cmd/agentchat/tui_test.go](https://github.com/panyam/mcpkit/pull/1127/files#diff-68ccb7754cb7a3e92c63ccecf5613cb252fcae31e66f524e2ab680a096069bc3) — `TestTUIObserver_RawDumpIsProseOnly` + `TestTUIModel_CtrlORawDump`.

## Decision log
- **Two mechanisms, not one toggle.** Inline commits to native scrollback (for scroll/copy/tmux) which is immutable, so it can't re-render in place like the notebook can. Verified Claude Code's `ctrl+o` is a managed transcript *viewer* (in-place, re-rendered) — that maps to our notebook mode, not inline. So notebook gets the true toggle; inline gets a dump + a pointer to notebook.
- **Inline dumps the last reply, not the whole session.** The whole-session "show everything" experience *is* the managed-view feature, which notebook already provides. A whole-transcript inline dump would re-print the entire conversation below the rendered scrollback (unbounded, and not what a managed viewer does). Last-reply is the targeted copy helper.
- **Dump is prose-only.** Tool lines and the turn footer are terminal-formatted (ANSI) meta, not markdown a user wants as source, so `rawProse` keeps only the prose blocks.

## Risk / blast radius
- Affects: the two agentchat TUI surfaces' key handling + rendering only. No overlay/`focusLayer` change, no host change.
- Assertions: added 3 tests (notebook toggle, inline rawDump prose-only, inline ctrl+o no-op-then-Println); none weakened. Red-before-green confirmed by neutering the notebook `!m.raw` guard and the `rawProse` prose-only filter.
- Be paranoid about: `ctrl+o` reaching the textarea (it doesn't — intercepted in the model before `ta.Update`); the dump being a no-op before any turn commits.

## Before / after

Rendered scrollback (both surfaces, unchanged) copies as `•`/no-fences. After `ctrl+o`:

**inline — dumps the last reply raw (real captured output; the prior turn ran a `lint` tool, excluded):**
```
── raw markdown (last reply · --ui notebook toggles the whole session) ──
Use `os.WriteFile`:

```go
os.WriteFile("x.txt", data, 0644)
```
```

**notebook — in-place toggle (RAW shown in the status line):**
```
rich (default)                     after ctrl+o (RAW)
▾ assistant                        ▾ assistant
  Use os.WriteFile:                  Use `os.WriteFile`:
    os.WriteFile("x.txt"...)         ```go
                                     os.WriteFile("x.txt", data, 0644)
                                     ```
```

## Out of scope (deliberately deferred)
- Whole-session raw dump for inline → the managed-view "show everything" is `--ui notebook`; file a follow-up only if a concrete need surfaces.
- README prose for `ctrl+o` → folding into the next docs checkpoint (the `/keys` cheatsheet + help bar already document it in-app).

## Note
The `--ui notebook` in-place toggle matches Claude Code's transcript-viewer model (verified against code.claude.com/docs/en/keybindings); inline's dump is the compromise its immutable-scrollback tradeoff forces.

