### PR TITLE
fix(agentchat): notebook surface — ctrl+o raw, wrapping, coalesced streaming, verbatim thinking, foreground servers

### DIFF
--- a/cmd/agentchat/go.mod
+++ b/cmd/agentchat/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v0.10.0
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
+	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/muesli/termenv v0.16.0
 	github.com/panyam/mcpkit v0.4.0-b3
 	github.com/panyam/mcpkit/agent/host v0.0.0
@@ -34,7 +35,6 @@ require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
-	github.com/charmbracelet/x/ansi v0.11.7 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/exp/slice v0.0.0-20250327172914-2fdc97757edf // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect

--- a/cmd/agentchat/keys.go
+++ b/cmd/agentchat/keys.go
@@ -19,6 +19,7 @@ type appKeys struct {
 	Complete key.Binding
 	History  key.Binding
 	Help     key.Binding
+	Raw      key.Binding
 	Quit     key.Binding
 
 	// notebook NAV mode
@@ -37,6 +38,7 @@ func newAppKeys() appKeys {
 		Complete: key.NewBinding(key.WithKeys("tab"), key.WithHelp("tab", "complete")),
 		History:  key.NewBinding(key.WithKeys("up", "down"), key.WithHelp("↑↓", "history")),
 		Help:     key.NewBinding(key.WithKeys("?"), key.WithHelp("?", "help")),
+		Raw:      key.NewBinding(key.WithKeys("ctrl+o"), key.WithHelp("ctrl+o", "raw markdown")),
 		Quit:     key.NewBinding(key.WithKeys("ctrl+c"), key.WithHelp("ctrl+c", "quit")),
 
 		Select: key.NewBinding(key.WithKeys("up", "down", "k", "j"), key.WithHelp("↑↓/jk", "select")),
@@ -55,14 +57,14 @@ func (k appKeys) insertBar() []key.Binding {
 }
 
 func (k appKeys) navBar() []key.Binding {
-	return []key.Binding{k.Select, k.Fold, k.Ends, k.Insert, k.Help}
+	return []key.Binding{k.Select, k.Fold, k.Ends, k.Raw, k.Insert, k.Help}
 }
 
 // fullHelp groups every surface binding for the `?` view.
 func (k appKeys) fullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		{k.Send, k.Newline, k.Complete},
-		{k.History, k.Help, k.Quit},
+		{k.History, k.Raw, k.Help, k.Quit},
 		{k.Nav, k.Select, k.Fold, k.Ends, k.Insert, k.Scroll},
 	}
 }
@@ -97,6 +99,14 @@ func renderKeyHelp() string {
 		"  NAV   cell selection. i or esc returns to INS; the NAV keys above",
 		"        (↑↓/jk select, space fold, g/G ends, pgup/dn scroll) act only here.",
 		"  The inline surface (--ui tui) has no modes; it is always in INS.",
+	}, "\n"))
+	b.WriteString("\n\nctrl+o (raw markdown):\n")
+	b.WriteString(strings.Join([]string{
+		"  notebook  toggles the whole transcript between rich (glamour) and raw",
+		"            markdown, in place — for copying source, not rendered text.",
+		"  inline    dumps the last assistant reply as raw markdown to scrollback",
+		"            (committed output can't be re-rendered); use --ui notebook for",
+		"            the in-place whole-session toggle.",
 	}, "\n"))
 	return b.String()
 }

--- a/cmd/agentchat/notebook.go
+++ b/cmd/agentchat/notebook.go
@@ -13,6 +13,7 @@ import (
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/panyam/mcpkit/agent"
 	"github.com/panyam/mcpkit/agent/host"
@@ -577,7 +578,7 @@ func (m notebookModel) renderCells() string {
 			if c.rendered != "" && !m.raw {
 				display = c.rendered
 			}
-			b.WriteString(indentBlock(display))
+			b.WriteString(indentBlock(wrapCell(display, m.contentWidth())))
 			b.WriteString("\n")
 		}
 	}
@@ -587,13 +588,15 @@ func (m notebookModel) renderCells() string {
 			b.WriteString("\n")
 		}
 		b.WriteString("▾ assistant\n")
-		b.WriteString(indentBlock(m.live))
+		b.WriteString(indentBlock(wrapCell(m.live, m.contentWidth())))
 	}
 	return b.String()
 }
 
-// hrule is a faint full-width horizontal delimiter drawn between cells.
-func (m notebookModel) hrule() string {
+// contentWidth is the viewport width the transcript renders into (falling back
+// to the last window width, then a floor), the single width both the hrule and
+// cell wrapping measure against.
+func (m notebookModel) contentWidth() int {
 	w := m.vp.Width
 	if w <= 0 {
 		w = m.width
@@ -601,7 +604,26 @@ func (m notebookModel) hrule() string {
 	if w <= 0 {
 		w = 40
 	}
-	return lipgloss.NewStyle().Faint(true).Render(strings.Repeat("─", w))
+	return w
+}
+
+// hrule is a faint full-width horizontal delimiter drawn between cells.
+func (m notebookModel) hrule() string {
+	return lipgloss.NewStyle().Faint(true).Render(strings.Repeat("─", m.contentWidth()))
+}
+
+// wrapCell soft-wraps a cell body to the viewport width before it is indented,
+// so wide lines (a long error, unwrapped tool output, raw JSON) stay inside the
+// viewport instead of being clipped at the right edge — the viewport does not
+// wrap on its own. ansi.Wrap preserves styling, is grapheme-width aware, and
+// hard-breaks tokens longer than the width (JSON with no spaces). The width is
+// reduced by the two-space indent indentBlock adds.
+func wrapCell(s string, width int) string {
+	w := width - 2
+	if w < 1 {
+		w = 1
+	}
+	return ansi.Wrap(s, w, "")
 }
 
 func indentBlock(s string) string {

--- a/cmd/agentchat/notebook.go
+++ b/cmd/agentchat/notebook.go
@@ -228,6 +228,7 @@ type notebookModel struct {
 	showAll bool // ? toggled the full-help view
 
 	nav      bool // false = insert, true = nav
+	raw      bool // ctrl+o: show cells as raw markdown, not glamour-rendered (1083)
 	sel      int  // selected cell index in nav mode
 	running  bool
 	atBottom bool // whether the viewport is scrolled to the end (for auto-follow)
@@ -364,6 +365,13 @@ func (m notebookModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case out.Line != "":
 				return m.submit(out.Line)
 			}
+			return m, nil
+		}
+		// ctrl+o toggles the whole transcript between rich and raw markdown, in
+		// place (issue 1083) — works in both INS and NAV modes.
+		if key.Matches(msg, m.keys.Raw) {
+			m.raw = !m.raw
+			m.refresh()
 			return m, nil
 		}
 		if m.nav {
@@ -507,6 +515,9 @@ func (m notebookModel) statusBar() string {
 	} else {
 		hint = "INS  " + m.help.ShortHelpView(m.keys.insertBar())
 	}
+	if m.raw {
+		hint = "RAW  " + hint
+	}
 	if m.running {
 		hint = "working…  " + hint
 	}
@@ -561,7 +572,9 @@ func (m notebookModel) renderCells() string {
 		b.WriteString("\n")
 		if !c.collapsed && c.body != "" {
 			display := c.body
-			if c.rendered != "" {
+			// ctrl+o (m.raw) shows raw markdown for copy fidelity; otherwise the
+			// glamour-rendered form when there is one (issue 1083).
+			if c.rendered != "" && !m.raw {
 				display = c.rendered
 			}
 			b.WriteString(indentBlock(display))

--- a/cmd/agentchat/notebook.go
+++ b/cmd/agentchat/notebook.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/key"
@@ -33,6 +34,17 @@ type nbCellMsg nbCell
 // nbLiveMsg carries the growing in-flight turn (the not-yet-finished assistant
 // cell) so it renders live at the bottom.
 type nbLiveMsg string
+
+// liveFlushMsg is the debounce tick that re-renders the viewport for the
+// accumulated live text. Streaming sends one nbLiveMsg per token, and each
+// re-renders the whole transcript; doing that per token starves keystroke
+// render frames, so the model coalesces them behind this tick (the "alternate
+// keystrokes swallowed while streaming" report).
+type liveFlushMsg struct{}
+
+// liveFlushInterval caps live re-renders during streaming (~25 fps): smooth to
+// read, slow enough that typing stays responsive.
+const liveFlushInterval = 40 * time.Millisecond
 
 // nbCell is one collapsible block in the transcript. rendered holds the
 // glamour-formatted body for assistant cells (issue 1063 B2); body stays the
@@ -158,9 +170,23 @@ func (s *nbObserver) render(ev host.HostEvent) []tea.Msg {
 			s.openTools++
 		}
 
+		// Reasoning renders as its own verbatim cell. The terminal renderer dims it
+		// with ANSI; folded into the glamoured assistant prose, glamour garbles the
+		// escape codes into literal "[2m" text (glamour must never see ANSI). So cut
+		// the prose so far at begin, close a verbatim "thinking" cell at end.
+		if re.Kind == agent.EventThinkingBegin {
+			if txt := seg(); txt != "" {
+				msgs = append(msgs, s.cell("assistant", txt))
+			}
+			s.buf.Reset()
+		}
+
 		s.term.On(ev) // render this event into buf
 
 		switch re.Kind {
+		case agent.EventThinkingEnd:
+			msgs = append(msgs, s.cell("thinking", seg())) // verbatim: cell() only glamours "assistant"
+			s.buf.Reset()
 		case agent.EventToolEnd, agent.EventToolError, agent.EventToolDenied, agent.EventToolCancelled, agent.EventToolUnavailable:
 			if s.openTools > 0 {
 				s.openTools--
@@ -228,11 +254,12 @@ type notebookModel struct {
 	modalHost // an open interactive dialog (/mcp, /sessions) as the focused layer
 	showAll bool // ? toggled the full-help view
 
-	nav      bool // false = insert, true = nav
-	raw      bool // ctrl+o: show cells as raw markdown, not glamour-rendered (1083)
-	sel      int  // selected cell index in nav mode
-	running  bool
-	atBottom bool // whether the viewport is scrolled to the end (for auto-follow)
+	nav           bool // false = insert, true = nav
+	raw           bool // ctrl+o: show cells as raw markdown, not glamour-rendered (1083)
+	sel           int  // selected cell index in nav mode
+	running       bool
+	atBottom      bool // whether the viewport is scrolled to the end (for auto-follow)
+	liveScheduled bool // a liveFlushMsg tick is pending (coalesces per-token renders)
 
 	history []string
 	histIdx int
@@ -306,7 +333,18 @@ func (m notebookModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case nbLiveMsg:
+		// Coalesce per-token updates: record the latest live text but debounce the
+		// (whole-transcript) re-render behind a single pending tick, so streaming
+		// does not starve keystroke render frames.
 		m.live = string(msg)
+		if m.liveScheduled {
+			return m, nil
+		}
+		m.liveScheduled = true
+		return m, tea.Tick(liveFlushInterval, func(time.Time) tea.Msg { return liveFlushMsg{} })
+
+	case liveFlushMsg:
+		m.liveScheduled = false
 		m.refresh()
 		return m, nil
 

--- a/cmd/agentchat/notebook_test.go
+++ b/cmd/agentchat/notebook_test.go
@@ -355,6 +355,73 @@ func turnDoneEv() host.HostEvent {
 	return host.HostEvent{Kind: host.HostTurnDone, Result: &agent.TurnResult{Steps: 1}}
 }
 
+func TestNBObserver_ThinkingIsSeparateVerbatimCell(t *testing.T) {
+	cells := nbCollectCells(
+		runnerEv(agent.Event{Kind: agent.EventThinkingBegin}),
+		runnerEv(agent.Event{Kind: agent.EventThinkingDelta, Text: "pondering"}),
+		runnerEv(agent.Event{Kind: agent.EventThinkingEnd}),
+		runnerEv(agent.Event{Kind: agent.EventTextDelta, Text: "the answer"}),
+		turnDoneEv(),
+	)
+	var thinking, assistant *nbCell
+	for i := range cells {
+		switch cells[i].label {
+		case "thinking":
+			thinking = &cells[i]
+		case "assistant":
+			assistant = &cells[i]
+		}
+	}
+	if thinking == nil {
+		t.Fatalf("expected a separate 'thinking' cell, got %+v", cells)
+	}
+	if !strings.Contains(thinking.body, "pondering") {
+		t.Fatalf("thinking cell should carry the reasoning verbatim: %q", thinking.body)
+	}
+	if thinking.rendered != "" {
+		t.Fatalf("thinking cell must be verbatim (never glamoured): %q", thinking.rendered)
+	}
+	if assistant == nil {
+		t.Fatalf("expected an assistant cell, got %+v", cells)
+	}
+	// the bug: reasoning (dim ANSI) must not leak into the glamoured prose, where
+	// glamour would garble the escape codes into literal "[2m" text
+	if strings.Contains(assistant.body, "pondering") || strings.Contains(assistant.rendered, "pondering") {
+		t.Fatalf("thinking leaked into the assistant cell: body=%q rendered=%q", assistant.body, assistant.rendered)
+	}
+}
+
+func TestNotebook_LiveRendersCoalesced(t *testing.T) {
+	m := newNotebookModel(nil, nil, 20, 0)
+	m = send(m, tea.WindowSizeMsg{Width: 40, Height: 20})
+
+	// the first live update schedules a flush tick and does NOT render yet
+	nm, cmd := m.Update(nbLiveMsg("streaming one"))
+	m = nm.(notebookModel)
+	if !m.liveScheduled || cmd == nil {
+		t.Fatal("first live update should schedule a flush tick")
+	}
+	if strings.Contains(m.vp.View(), "streaming one") {
+		t.Fatalf("live text should not render before the flush tick:\n%s", m.vp.View())
+	}
+
+	// a second update while a flush is pending coalesces (no second tick)
+	nm, cmd2 := m.Update(nbLiveMsg("streaming two"))
+	m = nm.(notebookModel)
+	if cmd2 != nil {
+		t.Fatal("a coalesced live update should not schedule another tick")
+	}
+
+	// the flush renders the latest text and clears the pending schedule
+	m = send(m, liveFlushMsg{})
+	if m.liveScheduled {
+		t.Fatal("flush should clear the pending schedule")
+	}
+	if !strings.Contains(m.vp.View(), "streaming two") {
+		t.Fatalf("flush should render the latest live text:\n%s", m.vp.View())
+	}
+}
+
 func TestNBObserver_ToolBecomesOwnCell(t *testing.T) {
 	cells := nbCollectCells(
 		runnerEv(agent.Event{Kind: agent.EventTextDelta, Text: "greeting you"}),

--- a/cmd/agentchat/notebook_test.go
+++ b/cmd/agentchat/notebook_test.go
@@ -45,6 +45,30 @@ func TestNotebook_CellAppendedAndRendered(t *testing.T) {
 	}
 }
 
+func TestNotebook_CtrlOTogglesRawMarkdown(t *testing.T) {
+	m := newNotebookModel(nil, nil, 20, 0)
+	m = send(m, tea.WindowSizeMsg{Width: 40, Height: 20})
+	m = send(m, nbCellMsg{label: "assistant", body: "- raw item", rendered: "• styled item"})
+
+	// default: rich (glamour-rendered) body
+	if out := m.renderCells(); !strings.Contains(out, "• styled item") || strings.Contains(out, "- raw item") {
+		t.Fatalf("default should render rich:\n%s", out)
+	}
+	// ctrl+o toggles to raw markdown in place
+	m = send(m, tea.KeyMsg{Type: tea.KeyCtrlO})
+	if out := m.renderCells(); !strings.Contains(out, "- raw item") || strings.Contains(out, "• styled item") {
+		t.Fatalf("after ctrl+o should show raw:\n%s", out)
+	}
+	if !strings.Contains(m.statusBar(), "RAW") {
+		t.Fatal("raw mode should show a RAW indicator in the status bar")
+	}
+	// ctrl+o again flips back to rich
+	m = send(m, tea.KeyMsg{Type: tea.KeyCtrlO})
+	if out := m.renderCells(); !strings.Contains(out, "• styled item") {
+		t.Fatalf("second ctrl+o should return to rich:\n%s", out)
+	}
+}
+
 func TestNotebook_RenderedBodyDisplayedRawUsedForSnippet(t *testing.T) {
 	m := newNotebookModel(nil, nil, 20, 0)
 	m = send(m, tea.WindowSizeMsg{Width: 40, Height: 20})

--- a/cmd/agentchat/notebook_test.go
+++ b/cmd/agentchat/notebook_test.go
@@ -6,10 +6,25 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/panyam/mcpkit/agent"
 	"github.com/panyam/mcpkit/agent/host"
 )
+
+func TestNotebook_WrapsWideLinesToViewport(t *testing.T) {
+	m := newNotebookModel(nil, nil, 20, 0)
+	m = send(m, tea.WindowSizeMsg{Width: 30, Height: 20})
+	// long prose (wraps on spaces) plus an unbreakable token (must hard-break)
+	long := strings.Repeat("word ", 40) + strings.Repeat("x", 80)
+	m = send(m, nbCellMsg{label: "error", body: long})
+
+	for _, line := range strings.Split(m.renderCells(), "\n") {
+		if w := ansi.StringWidth(line); w > 30 {
+			t.Fatalf("line exceeds the viewport width 30 (got %d): %q", w, line)
+		}
+	}
+}
 
 func send(m notebookModel, msg tea.Msg) notebookModel {
 	nm, _ := m.Update(msg)

--- a/cmd/agentchat/tui.go
+++ b/cmd/agentchat/tui.go
@@ -110,6 +110,7 @@ type tuiObserver struct {
 	renderMD func(string) string // == md.render; swapped in tests
 	blocks   []segBlock          // the current turn's committed blocks
 	prose    strings.Builder     // the open assistant-prose run (raw markdown)
+	lastRaw  string              // raw markdown of the last committed assistant turn (ctrl+o, 1083)
 }
 
 // segBlock is one span of a committed turn: assistant prose (raw markdown,
@@ -136,6 +137,29 @@ func (s *tuiObserver) flushProse() {
 		s.blocks = append(s.blocks, segBlock{prose: true, text: s.prose.String()})
 		s.prose.Reset()
 	}
+}
+
+// rawProse joins the raw markdown of the prose blocks (assistant text), skipping
+// meta blocks (tool lines, the turn footer) — the source a ctrl+o dump reprints
+// so it copies as real markdown, not glamour's rendered text.
+func rawProse(blocks []segBlock) string {
+	var out []string
+	for _, b := range blocks {
+		if b.prose {
+			if t := strings.TrimRight(b.text, "\n"); t != "" {
+				out = append(out, t)
+			}
+		}
+	}
+	return strings.Join(out, "\n")
+}
+
+// rawDump returns the raw markdown of the last committed assistant turn (empty
+// before any turn), for the inline ctrl+o copy-fidelity dump (issue 1083).
+func (s *tuiObserver) rawDump() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastRaw
 }
 
 // renderBlocks builds the committed segment: prose blocks through glamour,
@@ -194,6 +218,12 @@ func (s *tuiObserver) fold(ev host.HostEvent) []tea.Msg {
 		s.flushProse()
 		if tail := live[before:]; tail != "" {
 			s.blocks = append(s.blocks, segBlock{text: tail})
+		}
+		// Capture this turn's raw assistant markdown (prose blocks only, tool /
+		// footer meta excluded) for the ctrl+o raw dump (issue 1083); a turn with
+		// no prose (a bare command result) leaves the previous dump in place.
+		if raw := rawProse(s.blocks); raw != "" {
+			s.lastRaw = raw
 		}
 		commit := s.renderBlocks()
 		s.blocks = nil
@@ -352,6 +382,11 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// mid-message.
 			m.showAll = !m.showAll
 			return m, nil
+		case key.Matches(msg, m.keys.Raw):
+			// ctrl+o dumps the last assistant turn as raw markdown to scrollback:
+			// inline commits are immutable, so we reprint the source rather than
+			// re-render in place (the in-place toggle is notebook mode). Issue 1083.
+			return m, m.dumpRaw()
 		case key.Matches(msg, m.keys.Send):
 			if m.running {
 				return m, nil
@@ -458,6 +493,24 @@ func (m tuiModel) submit(line string) (tea.Model, tea.Cmd) {
 		}()
 	}
 	return m, nil
+}
+
+// dumpRaw prints the last assistant turn's raw markdown to scrollback so it can
+// be copied as source (glamour-rendered scrollback copies as bullets/no-fences).
+// Returns nil (no-op) when there is nothing committed yet. A hint points at the
+// notebook surface for the in-place whole-session toggle, which inline's
+// immutable scrollback cannot offer. Issue 1083.
+func (m tuiModel) dumpRaw() tea.Cmd {
+	if m.surface == nil {
+		return nil
+	}
+	raw := m.surface.rawDump()
+	if raw == "" {
+		return nil
+	}
+	dim := lipgloss.NewStyle().Faint(true)
+	header := dim.Render("── raw markdown (last reply · --ui notebook toggles the whole session) ──")
+	return tea.Println(header + "\n" + raw)
 }
 
 func (m *tuiModel) completeTab() { tabComplete(&m.ta, m.app) }

--- a/cmd/agentchat/tui_test.go
+++ b/cmd/agentchat/tui_test.go
@@ -388,6 +388,51 @@ func TestTUIObserver_GlamoursProseKeepsToolLinesVerbatim(t *testing.T) {
 	}
 }
 
+func TestTUIObserver_RawDumpIsProseOnly(t *testing.T) {
+	obs := newTUIObserver(true)
+	obs.renderMD = stubMD
+	if obs.rawDump() != "" {
+		t.Fatal("rawDump should be empty before any turn is committed")
+	}
+
+	_ = tuiCommit(obs,
+		runnerEv(agent.Event{Kind: agent.EventTextDelta, Text: "- item one"}),
+		runnerEv(agent.Event{Kind: agent.EventToolBegin, ToolCall: &agent.ToolCall{Name: "greet"}}),
+		runnerEv(agent.Event{Kind: agent.EventToolEnd, ToolCall: &agent.ToolCall{Name: "greet"}}),
+		runnerEv(agent.Event{Kind: agent.EventTextDelta, Text: "- item two"}),
+		turnDoneEv(),
+	)
+	raw := obs.rawDump()
+	if !strings.Contains(raw, "- item one") || !strings.Contains(raw, "- item two") {
+		t.Fatalf("rawDump should carry both raw prose runs: %q", raw)
+	}
+	if strings.Contains(raw, "MD{") {
+		t.Fatalf("rawDump must be raw markdown, not glamoured: %q", raw)
+	}
+	if strings.Contains(raw, "greet") {
+		t.Fatalf("rawDump must exclude tool/meta lines: %q", raw)
+	}
+}
+
+func TestTUIModel_CtrlORawDump(t *testing.T) {
+	obs := newTUIObserver(true)
+	obs.renderMD = stubMD
+	m := newTUIModel(nil, obs, 0)
+
+	// no committed turn yet → ctrl+o is a no-op
+	if _, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlO}); cmd != nil {
+		t.Fatal("ctrl+o with nothing committed should be a no-op")
+	}
+	// after a turn commits, ctrl+o returns a Println command (the raw dump)
+	_ = tuiCommit(obs,
+		runnerEv(agent.Event{Kind: agent.EventTextDelta, Text: "hello"}),
+		turnDoneEv(),
+	)
+	if _, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlO}); cmd == nil {
+		t.Fatal("ctrl+o after a committed turn should return a Println command")
+	}
+}
+
 func TestTUIObserver_TextOnlyTurnIsGlamoured(t *testing.T) {
 	obs := newTUIObserver(true)
 	obs.renderMD = stubMD

--- a/examples/agents/kitchen-sink/justfile
+++ b/examples/agents/kitchen-sink/justfile
@@ -101,6 +101,11 @@ mem:
 servers-up name="":
     @bash servers.sh up {{name}}
 
+# Start the servers and tail their logs in the foreground (Ctrl+C stops them).
+# Run agentchat in a separate terminal. Or one: `just servers-up-fg demo`.
+servers-up-fg name="":
+    @bash servers.sh up-fg {{name}}
+
 # Stop all MCP servers, or one: `just servers-down events`.
 servers-down name="":
     @bash servers.sh down {{name}}

--- a/examples/agents/kitchen-sink/servers.sh
+++ b/examples/agents/kitchen-sink/servers.sh
@@ -7,7 +7,8 @@
 # started here, survive agentchat restarts, and are torn down explicitly.
 #
 # Usage:
-#   servers.sh up      [name]   # build + start all servers (or just <name>)
+#   servers.sh up      [name]   # build + start all servers detached (or just <name>)
+#   servers.sh up-fg   [name]   # start + tail logs in the foreground (Ctrl+C stops them)
 #   servers.sh down    [name]   # stop all (or just <name>)
 #   servers.sh status  [name]   # probe ports; show up/down
 #
@@ -87,6 +88,25 @@ status_one() {
 	if port_up "$port"; then echo "  [up]   $name :$port"; else echo "  [down] $name :$port"; fi
 }
 
+# up_fg starts the servers (reusing the reliable detached start + pidfiles) and
+# then tails all their logs in the FOREGROUND, so you can watch every server's
+# output live in one terminal. Ctrl+C stops the tail AND brings the servers down
+# — this window owns their lifetime, unlike the detached `up`. Run agentchat in a
+# SEPARATE terminal: its inline TUI and these interleaved logs would fight for the
+# same screen.
+up_fg() {
+	local n
+	trap 'echo; echo "==> stopping servers (foreground window closed)"; for n in $names; do down_one "$n"; done; exit 0' INT TERM
+	for n in $names; do up_one "$n" || true; done
+	local logs=""
+	for n in $names; do logs="$logs $STATE/$n.log"; done
+	echo "==> tailing $(echo $names | wc -w | tr -d ' ') server log(s) — Ctrl+C stops them all"
+	# -F follows across truncation/rotation and waits for a not-yet-created log
+	# (a server still building); multiple files print a "==> name.log <==" header.
+	# shellcheck disable=SC2086
+	tail -n +1 -F $logs
+}
+
 cmd="${1:-status}"
 target="${2:-}"
 names="$ORDER"
@@ -94,7 +114,8 @@ names="$ORDER"
 
 case "$cmd" in
 up)     for n in $names; do up_one "$n"; done ;;
+up-fg)  up_fg ;;
 down)   for n in $names; do down_one "$n"; done ;;
 status) echo "kitchen-sink MCP servers"; for n in $names; do status_one "$n"; done ;;
-*) echo "usage: servers.sh <up|down|status> [name]" >&2; exit 2 ;;
+*) echo "usage: servers.sh <up|up-fg|down|status> [name]" >&2; exit 2 ;;
 esac


### PR DESCRIPTION
## What changes

A batch of `agentchat` notebook-surface improvements and fixes, several found while running the kitchen-sink demo. All surface-only (`cmd/agentchat` + the kitchen-sink example) — no `agent/host` or provider change.

1. **`ctrl+o` raw markdown** (issue 1083) — glamour-rendered output copies as rendered text (`•` bullets, no fences); `ctrl+o` toggles the notebook transcript between rich and raw in place (a `RAW` indicator shows), and dumps the last reply's raw markdown to scrollback on the inline surface (immutable scrollback can't toggle in place).
2. **Wide-line wrapping** — the `bubbles/viewport` clips horizontally, so a wide line (a long error, raw JSON) was truncated at the right edge. Cell bodies now soft-wrap to the viewport width (`ansi.Wrap`, grapheme-aware, hard-breaks long tokens).
3. **Coalesced live renders** — streaming sent one `nbLiveMsg` per token, each re-rendering the whole transcript, which starved keystroke render frames: every other typed char's frame lost to a streaming frame, so input looked like it dropped alternating characters until streaming ended. Live renders are now debounced behind a ~40ms tick (~25fps), so typing stays responsive.
4. **Reasoning as a verbatim cell** — thinking is dimmed with ANSI; folded into the glamoured assistant prose, glamour garbled the escape codes into literal `[2m` text. Thinking now gets its own verbatim, foldable cell so glamour never sees the ANSI.
5. **`just servers-up-fg`** — start the kitchen-sink MCP servers and tail all logs in the foreground (Ctrl+C stops them); run agentchat in a separate terminal.

## Reviewer's guide
1. [cmd/agentchat/keys.go](https://github.com/panyam/mcpkit/pull/1128/files#diff-e83752496ec9cc063a573fedefb2237ad2f177671926491e0fc11d9b372aa076) — the `Raw` (`ctrl+o`) binding + help.
2. [cmd/agentchat/notebook.go](https://github.com/panyam/mcpkit/pull/1128/files#diff-8a79677a206f62f0abeebce75abd2fbafac2dc1be85310113e702bebc42624b1) — start here for the notebook changes: `raw` toggle, `wrapCell`/`contentWidth`, the coalesced `nbLiveMsg`/`liveFlushMsg` handlers, and the `thinking` verbatim cell in `nbObserver.render`.
3. [cmd/agentchat/tui.go](https://github.com/panyam/mcpkit/pull/1128/files#diff-0e29207287df07cecf17e04df9f99e726ae789983f7e3ce007bb6282029b4db6) — the inline `ctrl+o` raw dump (`tuiObserver.lastRaw` / `rawProse` / `dumpRaw`).
4. [cmd/agentchat/notebook_test.go](https://github.com/panyam/mcpkit/pull/1128/files#diff-12e612880a5d601118bba88764d9d1ff5815b9406c3ffb4e5a61ca6e9c4188a1) + `tui_test.go` — acceptance: `TestNotebook_CtrlOTogglesRawMarkdown`, `TestNotebook_WrapsWideLinesToViewport`, `TestNotebook_LiveRendersCoalesced`, `TestNBObserver_ThinkingIsSeparateVerbatimCell`, plus the inline raw-dump tests.
5. [examples/agents/kitchen-sink/servers.sh](https://github.com/panyam/mcpkit/pull/1128/files#diff-adcb420b51a3545537334b5280ec02c282355564bd40e5288187e6d7402dd251) + `justfile` — `up-fg` / `servers-up-fg`.

## Decision log
- **Coalesce, don't chase per-token renders.** The chars were never lost — only their frames were starved by the streaming re-render flood. Debouncing at ~25fps fixes input latency without visibly slowing streaming.
- **Thinking = its own cell, not ANSI-stripped prose.** Stripping ANSI would let glamour markdown-render the reasoning as if it were the answer; a separate verbatim cell keeps it dim, correct, and foldable — matching how the inline surface already treats it as a meta block.
- **`ctrl+o` differs per surface.** Notebook toggles in place (managed viewport, like Claude Code's transcript viewer); inline dumps the last reply (native scrollback is immutable). Verified Claude Code's `ctrl+o` is a managed transcript viewer, which maps to notebook mode.
- **Foreground servers = start-detached + `tail -F`.** Reuses the reliable pid/pidfile machinery; a piped foreground job would make `$!` the pipe tail and leak the server on teardown.

## Risk / blast radius
- Affects: the two agentchat TUI surfaces' rendering + input, and the kitchen-sink example scripts. No `agent/host`, no protocol, no provider.
- Tests: red-before-green confirmed for the wrap, coalesce, and thinking fixes (the neutered thinking test reproduces the literal `[2m` garble). No assertions weakened.
- Be paranoid about: the first live token now waits one ~40ms tick before showing (imperceptible); a turn whose reasoning interleaves with tools produces multiple thinking cells (correct, each foldable).

## Before / after (notebook)
```
WIDE LINE — before: clipped        after: wrapped to width
INPUT     — before: A, ABC, ABCDE  after: A, AB, ABC, ABCD, ABCDE (responsive)
THINKING  — before: [2m· thinking:[0m[2mpondering[0m  (literal escape codes)
            after:  ▾ thinking
                      · thinking: pondering      (dim, verbatim, foldable)
```

## Closes / supersedes
- Closes 1083 (`ctrl+o` raw markdown).
- Supersedes PR 1127 (closed — its branch was the base this one was accidentally cut from, so its commit is already here).

## Note
Independent of PR 1129 (provider tool-name sanitization). The wrapping fix (2) is what makes the full HTTP 400 error from 1129's bug readable in the notebook.

