### PR TITLE
fix(agent): sanitize provider tool names to the OpenAI/Anthropic name pattern

### DIFF
--- a/agent/anthropic_provider.go
+++ b/agent/anthropic_provider.go
@@ -99,7 +99,8 @@ func (p *AnthropicProvider) Stream(ctx context.Context, req ProviderRequest) (St
 	if err != nil {
 		return nil, err
 	}
-	return &anthropicStream{ctx: ctx, body: resp.Body, events: ssehttp.NewSSEEventReader(resp.Body)}, nil
+	_, safeToReal := toolNameMaps(req.Tools)
+	return &anthropicStream{ctx: ctx, body: resp.Body, events: ssehttp.NewSSEEventReader(resp.Body), nameMap: safeToReal}, nil
 }
 
 // Generate implements Provider with a non-streaming request. When
@@ -125,6 +126,7 @@ func (p *AnthropicProvider) Generate(ctx context.Context, req ProviderRequest) (
 	}
 
 	out := &ProviderResponse{FinishReason: full.StopReason}
+	_, safeToReal := toolNameMaps(req.Tools)
 	var text, reason strings.Builder
 	for _, block := range full.Content {
 		switch block.Type {
@@ -143,7 +145,7 @@ func (p *AnthropicProvider) Generate(ctx context.Context, req ProviderRequest) (
 				out.Text = string(args)
 				continue
 			}
-			out.ToolCalls = append(out.ToolCalls, ToolCall{ID: block.ID, Name: block.Name, Args: core.NewRawJSON(args)})
+			out.ToolCalls = append(out.ToolCalls, ToolCall{ID: block.ID, Name: realToolName(safeToReal, block.Name), Args: core.NewRawJSON(args)})
 		}
 	}
 	if out.Text == "" {
@@ -186,6 +188,7 @@ func (p *AnthropicProvider) post(ctx context.Context, body map[string]any) (*htt
 // buildBody produces the Messages API request. Kept as one method so the
 // wire-shape test pins the exact JSON we emit.
 func (p *AnthropicProvider) buildBody(req ProviderRequest, stream bool) map[string]any {
+	realToSafe, _ := toolNameMaps(req.Tools)
 	msgs := make([]map[string]any, 0, len(req.Messages))
 	for _, m := range req.Messages {
 		switch m.Role {
@@ -203,7 +206,7 @@ func (p *AnthropicProvider) buildBody(req ProviderRequest, stream bool) map[stri
 				content = append(content, map[string]any{
 					"type":  "tool_use",
 					"id":    tc.ID,
-					"name":  tc.Name,
+					"name":  safeToolName(realToSafe, tc.Name),
 					"input": rawToInput(tc.Args),
 				})
 			}
@@ -248,7 +251,7 @@ func (p *AnthropicProvider) buildBody(req ProviderRequest, stream bool) map[stri
 	tools := make([]map[string]any, 0, len(req.Tools)+1)
 	for _, td := range req.Tools {
 		tools = append(tools, map[string]any{
-			"name":         td.Name,
+			"name":         realToSafe[td.Name],
 			"description":  td.Description,
 			"input_schema": td.InputSchema,
 		})
@@ -268,7 +271,11 @@ func (p *AnthropicProvider) buildBody(req ProviderRequest, stream bool) map[stri
 		}
 	} else if len(tools) > 0 {
 		body["tools"] = tools
-		if tc := anthropicToolChoice(req.ToolChoice); tc != nil {
+		choice := req.ToolChoice
+		if choice.Mode == "function" {
+			choice.Name = safeToolName(realToSafe, choice.Name) // match the sanitized tools-list name
+		}
+		if tc := anthropicToolChoice(choice); tc != nil {
 			body["tool_choice"] = tc
 		}
 	}
@@ -364,6 +371,7 @@ type anthropicStream struct {
 	queue       []Delta
 	inputTokens int
 	done        bool
+	nameMap     map[string]string // safe→real tool name, to reverse sanitized names on tool_use blocks
 }
 
 // Recv implements Stream.
@@ -418,7 +426,7 @@ func (s *anthropicStream) enqueue(msg anthropicSSE) error {
 				Kind:       DeltaToolCallStart,
 				Index:      msg.Index,
 				ToolCallID: msg.ContentBlock.ID,
-				ToolName:   msg.ContentBlock.Name,
+				ToolName:   realToolName(s.nameMap, msg.ContentBlock.Name),
 			})
 		}
 	case "content_block_delta":

--- a/agent/anthropic_provider_test.go
+++ b/agent/anthropic_provider_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/panyam/mcpkit/core"
@@ -188,6 +189,39 @@ func TestAnthropicStreamTextFinishUsage(t *testing.T) {
 	}
 	if res.Usage == nil || res.Usage.InputTokens != 12 || res.Usage.OutputTokens != 9 {
 		t.Fatalf("usage = %+v", res.Usage)
+	}
+}
+
+func TestAnthropicToolNameSanitizedAndReversed(t *testing.T) {
+	var reqBody []byte
+	ts := sseServer(t, &reqBody,
+		`{"type":"message_start","message":{"usage":{"input_tokens":5,"output_tokens":1}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"weather_current"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":7}}`,
+		`{"type":"message_stop"}`,
+	)
+	defer ts.Close()
+
+	s, err := newTestAnthropic(t, ts.URL).Stream(context.Background(), ProviderRequest{
+		Tools: []core.ToolDef{{Name: "weather.current", InputSchema: map[string]any{"type": "object"}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	var acc Accumulator
+	for _, d := range collectDeltas(t, s) {
+		acc.Add(d)
+	}
+	res := acc.Result()
+
+	if !strings.Contains(string(reqBody), `"name":"weather_current"`) || strings.Contains(string(reqBody), "weather.current") {
+		t.Fatalf("tools-list name not sanitized in the request:\n%s", reqBody)
+	}
+	if len(res.ToolCalls) != 1 || res.ToolCalls[0].Name != "weather.current" {
+		t.Fatalf("tool call name not reversed on the response: %+v", res.ToolCalls)
 	}
 }
 

--- a/agent/openai_provider.go
+++ b/agent/openai_provider.go
@@ -77,7 +77,8 @@ func (p *OpenAIProvider) Stream(ctx context.Context, req ProviderRequest) (Strea
 	if err != nil {
 		return nil, err
 	}
-	return &openaiStream{ctx: ctx, body: resp.Body, events: ssehttp.NewSSEEventReader(resp.Body)}, nil
+	_, safeToReal := toolNameMaps(req.Tools)
+	return &openaiStream{ctx: ctx, body: resp.Body, events: ssehttp.NewSSEEventReader(resp.Body), nameMap: safeToReal}, nil
 }
 
 // Generate implements Provider with a non-streaming request. When
@@ -114,12 +115,13 @@ func (p *OpenAIProvider) Generate(ctx context.Context, req ProviderRequest) (*Pr
 		Reasoning:    choice.Message.ReasoningContent,
 		FinishReason: choice.FinishReason,
 	}
+	_, safeToReal := toolNameMaps(req.Tools)
 	for _, tc := range choice.Message.ToolCalls {
 		args := tc.Function.Arguments
 		if args == "" {
 			args = "{}"
 		}
-		out.ToolCalls = append(out.ToolCalls, ToolCall{ID: tc.ID, Name: tc.Function.Name, Args: core.NewRawJSON(json.RawMessage(args))})
+		out.ToolCalls = append(out.ToolCalls, ToolCall{ID: tc.ID, Name: realToolName(safeToReal, tc.Function.Name), Args: core.NewRawJSON(json.RawMessage(args))})
 	}
 	if full.Usage != nil {
 		out.Usage = &Usage{InputTokens: full.Usage.PromptTokens, OutputTokens: full.Usage.CompletionTokens}
@@ -156,6 +158,7 @@ func (p *OpenAIProvider) post(ctx context.Context, body map[string]any) (*http.R
 // buildBody produces the chat-completions request. Kept as one method so the
 // wire-shape test pins the exact JSON we emit.
 func (p *OpenAIProvider) buildBody(req ProviderRequest, stream bool) map[string]any {
+	realToSafe, _ := toolNameMaps(req.Tools)
 	msgs := make([]map[string]any, 0, len(req.Messages)+1)
 	if req.Instructions != "" {
 		msgs = append(msgs, map[string]any{"role": "system", "content": req.Instructions})
@@ -177,7 +180,7 @@ func (p *OpenAIProvider) buildBody(req ProviderRequest, stream bool) map[string]
 						"id":   tc.ID,
 						"type": "function",
 						"function": map[string]any{
-							"name":      tc.Name,
+							"name":      safeToolName(realToSafe, tc.Name),
 							"arguments": string(tc.Args.Raw()),
 						},
 					}
@@ -200,7 +203,7 @@ func (p *OpenAIProvider) buildBody(req ProviderRequest, stream bool) map[string]
 			tools[i] = map[string]any{
 				"type": "function",
 				"function": map[string]any{
-					"name":        td.Name,
+					"name":        realToSafe[td.Name],
 					"description": td.Description,
 					"parameters":  td.InputSchema,
 				},
@@ -215,7 +218,11 @@ func (p *OpenAIProvider) buildBody(req ProviderRequest, stream bool) map[string]
 		body["max_tokens"] = req.MaxTokens
 	}
 	if len(req.Tools) > 0 && !req.ToolChoice.IsZero() {
-		if tc := req.ToolChoice.wire(); tc != nil {
+		choice := req.ToolChoice
+		if choice.Mode == "function" {
+			choice.Name = safeToolName(realToSafe, choice.Name) // match the sanitized tools-list name
+		}
+		if tc := choice.wire(); tc != nil {
 			body["tool_choice"] = tc
 		}
 	}
@@ -275,6 +282,7 @@ type openaiStream struct {
 	queue   []Delta
 	started map[int]bool
 	done    bool
+	nameMap map[string]string // safe→real tool name, to reverse sanitized names on tool_call deltas
 }
 
 // Recv implements Stream.
@@ -346,7 +354,7 @@ func (s *openaiStream) enqueue(chunk oaChunk) {
 				Kind:       DeltaToolCallStart,
 				Index:      tc.Index,
 				ToolCallID: tc.ID,
-				ToolName:   tc.Function.Name,
+				ToolName:   realToolName(s.nameMap, tc.Function.Name),
 				Text:       tc.Function.Arguments,
 			})
 			continue

--- a/agent/provider_test.go
+++ b/agent/provider_test.go
@@ -81,6 +81,34 @@ func TestOpenAIRequestWireShape(t *testing.T) {
 	}
 }
 
+func TestOpenAIToolNameSanitizedAndReversed(t *testing.T) {
+	var reqBody []byte
+	ts := sseServer(t, &reqBody,
+		`{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"a1","function":{"name":"weather_current","arguments":"{}"}}]}}]}`,
+		`{"choices":[{"delta":{},"finish_reason":"tool_calls"}]}`,
+		`[DONE]`,
+	)
+	defer ts.Close()
+
+	s, err := newTestProvider(t, ts.URL).Stream(context.Background(), ProviderRequest{
+		Tools: []core.ToolDef{{Name: "weather.current", InputSchema: map[string]any{"type": "object"}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	res := drain(t, s)
+
+	// forward: the request carries the provider-safe name, never the raw dotted one
+	if !strings.Contains(string(reqBody), `"name":"weather_current"`) || strings.Contains(string(reqBody), "weather.current") {
+		t.Fatalf("tools-list name not sanitized in the request:\n%s", reqBody)
+	}
+	// reverse: the model's tool_call (safe name) maps back to the real tool name
+	if len(res.ToolCalls) != 1 || res.ToolCalls[0].Name != "weather.current" {
+		t.Fatalf("tool call name not reversed on the response: %+v", res.ToolCalls)
+	}
+}
+
 func TestOpenAIStreamTextFinishUsage(t *testing.T) {
 	ts := sseServer(t, nil,
 		`{"choices":[{"delta":{"content":"Hel"}}]}`,

--- a/agent/toolname.go
+++ b/agent/toolname.go
@@ -1,0 +1,89 @@
+package agent
+
+import (
+	"regexp"
+	"strconv"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+// Both OpenAI and Anthropic constrain a function/tool name to
+// ^[a-zA-Z0-9_-]{1,64}$. A connected MCP server may expose a tool whose name
+// violates it — a dot ("weather.current"), a slash, spaces, or more than 64
+// characters — and the provider then rejects the whole request with an HTTP 400
+// that aborts the turn. The provider sends a sanitized name on the wire and maps
+// the model's response back to the real name so dispatch still resolves.
+var invalidToolNameChars = regexp.MustCompile(`[^a-zA-Z0-9_-]+`)
+
+const maxToolNameLen = 64
+
+// sanitizeToolName maps an arbitrary tool name to one matching the provider
+// constraint ^[a-zA-Z0-9_-]{1,64}$: runs of invalid characters collapse to a
+// single "_", an empty result becomes "tool", and the result is truncated to 64
+// runes. It is deterministic per name and a no-op on an already-valid name;
+// cross-tool uniqueness is toolNameMaps' job.
+func sanitizeToolName(name string) string {
+	s := invalidToolNameChars.ReplaceAllString(name, "_")
+	if s == "" {
+		s = "tool"
+	}
+	return truncateToolName(s)
+}
+
+func truncateToolName(s string) string {
+	if len(s) > maxToolNameLen {
+		return s[:maxToolNameLen]
+	}
+	return s
+}
+
+// toolNameMaps builds a request's bijection between real tool names and the
+// provider-safe names actually put on the wire. It is deterministic in tools
+// order, so the request builder (real→safe) and the response parser (safe→real)
+// each derive the same maps from req.Tools with no shared state to thread. Two
+// names that sanitize to the same string are disambiguated with a numeric
+// suffix, so the mapping stays reversible.
+func toolNameMaps(tools []core.ToolDef) (realToSafe, safeToReal map[string]string) {
+	realToSafe = make(map[string]string, len(tools))
+	safeToReal = make(map[string]string, len(tools))
+	for _, td := range tools {
+		if _, seen := realToSafe[td.Name]; seen {
+			continue // duplicate real name: first mapping wins
+		}
+		safe := sanitizeToolName(td.Name)
+		for n := 2; ; n++ {
+			if _, taken := safeToReal[safe]; !taken {
+				break
+			}
+			suffix := "_" + strconv.Itoa(n)
+			base := sanitizeToolName(td.Name)
+			if len(base)+len(suffix) > maxToolNameLen {
+				base = base[:maxToolNameLen-len(suffix)]
+			}
+			safe = base + suffix
+		}
+		realToSafe[td.Name] = safe
+		safeToReal[safe] = td.Name
+	}
+	return
+}
+
+// safeToolName returns the wire name for a real tool name using the request map,
+// falling back to a direct sanitize for a name not in the current tool set (an
+// assistant history tool_call for a tool no longer offered) — the fallback keeps
+// the request valid even though that name will not be reversed.
+func safeToolName(realToSafe map[string]string, name string) string {
+	if s, ok := realToSafe[name]; ok {
+		return s
+	}
+	return sanitizeToolName(name)
+}
+
+// realToolName reverses a wire name from a model response back to the real tool
+// name, leaving unknown names (already-valid names map to themselves) untouched.
+func realToolName(safeToReal map[string]string, name string) string {
+	if r, ok := safeToReal[name]; ok {
+		return r
+	}
+	return name
+}

--- a/agent/toolname_test.go
+++ b/agent/toolname_test.go
@@ -1,0 +1,71 @@
+package agent
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+var validProviderToolName = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,64}$`)
+
+func TestSanitizeToolName(t *testing.T) {
+	cases := map[string]string{
+		"read_file":       "read_file",       // already valid → identity
+		"list-runs":       "list-runs",        // hyphen is allowed → identity
+		"weather.current": "weather_current",  // dot → _
+		"a/b:c d":         "a_b_c_d",           // a run of invalid chars → a single _
+		"":                "tool",              // empty → placeholder
+	}
+	for in, want := range cases {
+		if got := sanitizeToolName(in); got != want {
+			t.Errorf("sanitizeToolName(%q) = %q, want %q", in, got, want)
+		}
+	}
+	// over-length names are capped at 64 and stay valid
+	if got := sanitizeToolName(strings.Repeat("a", 80)); len(got) != 64 || !validProviderToolName.MatchString(got) {
+		t.Errorf("long name = %q (len %d), want 64 valid chars", got, len(got))
+	}
+}
+
+func TestToolNameMaps_RoundTripAndCollisions(t *testing.T) {
+	tools := []core.ToolDef{
+		{Name: "read_file"},        // valid
+		{Name: "weather.current"},  // → weather_current
+		{Name: "weather/current"},  // also → weather_current → must disambiguate
+	}
+	realToSafe, safeToReal := toolNameMaps(tools)
+
+	for _, td := range tools {
+		safe := realToSafe[td.Name]
+		if !validProviderToolName.MatchString(safe) {
+			t.Errorf("safe name %q (from %q) violates the provider pattern", safe, td.Name)
+		}
+		if safeToReal[safe] != td.Name {
+			t.Errorf("round-trip broke: %q → %q → %q", td.Name, safe, safeToReal[safe])
+		}
+	}
+	if realToSafe["read_file"] != "read_file" {
+		t.Errorf("a valid name should map to itself, got %q", realToSafe["read_file"])
+	}
+	if realToSafe["weather.current"] == realToSafe["weather/current"] {
+		t.Fatalf("colliding names must get distinct safe names, both = %q", realToSafe["weather.current"])
+	}
+}
+
+func TestRealAndSafeToolNameFallbacks(t *testing.T) {
+	realToSafe, safeToReal := toolNameMaps([]core.ToolDef{{Name: "foo.bar"}})
+	// a name not in the current tool set (history for a dropped tool) still
+	// serializes to a valid name, though it will not reverse
+	if got := safeToolName(realToSafe, "gone.tool"); got != "gone_tool" {
+		t.Errorf("fallback safe name = %q, want gone_tool", got)
+	}
+	// an unknown response name is returned unchanged (already-valid names, too)
+	if got := realToolName(safeToReal, "unmapped"); got != "unmapped" {
+		t.Errorf("unknown reverse = %q, want unmapped", got)
+	}
+	if got := realToolName(safeToReal, "foo_bar"); got != "foo.bar" {
+		t.Errorf("reverse of the mapped name = %q, want foo.bar", got)
+	}
+}


### PR DESCRIPTION
## What changes

A connected MCP server can expose a tool whose name violates the provider constraint `^[a-zA-Z0-9_-]{1,64}$` — a dot (`weather.current`), a slash, spaces, or more than 64 characters. Both providers sent `td.Name` raw, so the request was rejected with an HTTP 400 (`Invalid 'tools[N].function.name': string does not match pattern`) that aborted the entire turn.

The providers now send a sanitized, collision-resolved name on the wire and reverse the model's tool-call name back to the real one so the Runner still dispatches. A valid name maps to itself, so the wire shape is unchanged for the common case. Applied to both `OpenAIProvider` and `AnthropicProvider`.

## Reviewer's guide
1. [agent/toolname.go](https://github.com/panyam/mcpkit/pull/1129/files#diff-003658a718bdad1d47426ab9292ebdbdbe7f237964afd31d86e884fefaaa101c) — start here. `sanitizeToolName` (invalid runs → `_`, empty → `tool`, cap 64), `toolNameMaps` (deterministic real↔safe bijection with numeric-suffix collision resolution), and the `safeToolName`/`realToolName` accessors.
2. [agent/toolname_test.go](https://github.com/panyam/mcpkit/pull/1129/files#diff-c2604ac4a221b5811d5b907119473caa8d187d7ea9d22fb7b409aa049084a30b) — the contract: identity on valid names, dot/slash/space/length handling, round-trip, collision disambiguation, fallbacks.
3. [agent/openai_provider.go](https://github.com/panyam/mcpkit/pull/1129/files#diff-aa95603c3498519232b6a26863d823be62a5d05e94053dc57da95c458e875b3e) — apply: `realToSafe` in `buildBody` (tools list, assistant-history `tool_calls`, forced `tool_choice`), `safeToReal` reversal in `Generate` and the stream (`openaiStream.nameMap` + `enqueue`).
4. [agent/anthropic_provider.go](https://github.com/panyam/mcpkit/pull/1129/files#diff-71f597ba381303570d5ed1f9ac3f73f390236d1e6393ee0daf220757916a4e68) — the same across `buildBody` / `Generate` / `anthropicStream`.
5. [agent/provider_test.go](https://github.com/panyam/mcpkit/pull/1129/files#diff-9ef95f6fdefd509cecbfe470f4c5f9cd38c6456db33bb34e2191bb16c8b74738) + [agent/anthropic_provider_test.go](https://github.com/panyam/mcpkit/pull/1129/files#diff-f9d8a910e63ab10acebccd9d86322e536a3955f19639d75091368ec55059a80f) — one round-trip test each (`...ToolNameSanitizedAndReversed`): the request carries the safe name, the response's safe name reverses to the real one.

## How it works
```
buildBody(req):   realToSafe := toolNameMaps(req.Tools)     // deterministic in req.Tools order
                  tools[].name         = realToSafe[td.Name]
                  history tool_call.name = safeToolName(realToSafe, tc.Name)  // fallback-sanitize for a dropped tool
                  tool_choice(function).name = safeToolName(...)

response:         _, safeToReal := toolNameMaps(req.Tools)   // SAME map, re-derived, no threading
                  ToolCall.Name = realToolName(safeToReal, wireName)
```
Because the map is a pure function of `req.Tools`, the request builder and response parser derive identical maps independently — no state is carried between them (the stream is the one exception: it outlives the request, so it keeps a `nameMap` field).

## Decision log
- **Sanitize + reverse, not reject-with-error or fix-at-source.** A server owns its tool names; the provider must be robust to any of them. Rejecting would still abort the turn; fixing at the source can't cover third-party servers.
- **Deterministic map re-derived on both sides, not threaded.** `toolNameMaps` is pure in `req.Tools`, so forward and reverse agree without plumbing a map through the response path. Only the streaming struct (which outlives the call) carries it.
- **Collisions get a numeric suffix.** Two names that sanitize to the same string (`weather.current`, `weather/current`) would otherwise misroute; the suffix keeps the mapping bijective and reversible.
- **Both providers in one PR.** The constraint and the fix are identical; the shared helper makes each provider's diff small, and leaving one provider broken would be a known gap.

## Risk / blast radius
- Affects: every request/response through `OpenAIProvider` and `AnthropicProvider`. **Valid names are unchanged** (identity mapping) — existing wire-shape tests (`echo`) pass untouched.
- Tests: `toolname_test.go` (unit) + one round-trip per provider. Red-before-green confirmed by neutering `sanitizeToolName` (both round-trip tests + both unit tests fail).
- Be paranoid about: history tool_calls for a tool no longer offered (fallback-sanitized, stays valid, won't reverse — acceptable, the model won't call it again); Anthropic's `structured_output` synthetic tool (already valid → identity, structured-output detection still matches on the raw name).

## Before / after
```
BEFORE:  tools[3].function.name = "weather.current"  → HTTP 400, turn aborts
AFTER:   tools[3].function.name = "weather_current"  → 200; model calls
         "weather_current" → reversed to "weather.current" → dispatched
```

## Note
I could not pin the exact offending tool from the truncated 400 in the report, so this is the general fix for the whole class (any invalid char or >64 length, either provider). If you can share the full `tools[3].function.name` value, I'll add it as a named regression case — but the round-trip tests already cover the mechanism. Pairs with PR 1128 (the notebook wrapping that was hiding the full error).

