### PR TITLE
refactor(agent): extract the shared SSE Recv loop from the two providers (952)

### DIFF
--- a/agent/anthropic_provider.go
+++ b/agent/anthropic_provider.go
@@ -100,7 +100,9 @@ func (p *AnthropicProvider) Stream(ctx context.Context, req ProviderRequest) (St
 		return nil, err
 	}
 	_, safeToReal := toolNameMaps(req.Tools)
-	return &anthropicStream{ctx: ctx, body: resp.Body, events: ssehttp.NewSSEEventReader(resp.Body), nameMap: safeToReal}, nil
+	st := &anthropicStream{nameMap: safeToReal}
+	st.sseStream = sseStream{ctx: ctx, body: resp.Body, events: ssehttp.NewSSEEventReader(resp.Body), decode: st.decode}
+	return st, nil
 }
 
 // Generate implements Provider with a non-streaming request. When
@@ -365,56 +367,24 @@ type anthropicSSE struct {
 // usage). inputTokens is captured at message_start and folded into the usage
 // delta emitted at message_delta.
 type anthropicStream struct {
-	ctx         context.Context
-	body        io.ReadCloser
-	events      *ssehttp.SSEEventReader
-	queue       []Delta
+	sseStream
 	inputTokens int
-	done        bool
 	nameMap     map[string]string // safe→real tool name, to reverse sanitized names on tool_use blocks
 }
 
-// Recv implements Stream.
-func (s *anthropicStream) Recv() (Delta, error) {
-	for {
-		if len(s.queue) > 0 {
-			d := s.queue[0]
-			s.queue = s.queue[1:]
-			return d, nil
-		}
-		if s.done {
-			return Delta{}, io.EOF
-		}
-		if err := s.ctx.Err(); err != nil {
-			return Delta{}, err
-		}
-		ev, err := s.events.ReadEvent()
-		if err != nil {
-			if ctxErr := s.ctx.Err(); ctxErr != nil {
-				return Delta{}, ctxErr
-			}
-			// A partial event can ride along with io.EOF; process it before
-			// surfacing EOF on the next call.
-			if !errors.Is(err, io.EOF) || ev.Data == "" {
-				return Delta{}, err
-			}
-			s.done = true
-		}
-		payload := strings.TrimSpace(ev.Data)
-		if payload == "" {
-			continue
-		}
-		var msg anthropicSSE
-		if err := json.Unmarshal([]byte(payload), &msg); err != nil {
-			return Delta{}, fmt.Errorf("agent: bad SSE event: %w", err)
-		}
-		if err := s.enqueue(msg); err != nil {
-			return Delta{}, err
-		}
+// decode unmarshals one Anthropic SSE event and expands it into Deltas.
+func (s *anthropicStream) decode(payload string) ([]Delta, bool, error) {
+	var msg anthropicSSE
+	if err := json.Unmarshal([]byte(payload), &msg); err != nil {
+		return nil, false, fmt.Errorf("agent: bad SSE event: %w", err)
 	}
+	return s.eventDeltas(msg)
 }
 
-func (s *anthropicStream) enqueue(msg anthropicSSE) error {
+// eventDeltas maps one typed Anthropic event to Deltas, tracking input tokens
+// across the message so the final usage delta carries both counts. "message_stop"
+// ends the stream; an "error" event surfaces as a decode error.
+func (s *anthropicStream) eventDeltas(msg anthropicSSE) ([]Delta, bool, error) {
 	switch msg.Type {
 	case "message_start":
 		if msg.Message != nil && msg.Message.Usage != nil {
@@ -422,54 +392,51 @@ func (s *anthropicStream) enqueue(msg anthropicSSE) error {
 		}
 	case "content_block_start":
 		if msg.ContentBlock != nil && msg.ContentBlock.Type == "tool_use" {
-			s.queue = append(s.queue, Delta{
+			return []Delta{{
 				Kind:       DeltaToolCallStart,
 				Index:      msg.Index,
 				ToolCallID: msg.ContentBlock.ID,
 				ToolName:   realToolName(s.nameMap, msg.ContentBlock.Name),
-			})
+			}}, false, nil
 		}
 	case "content_block_delta":
 		if msg.Delta == nil {
-			return nil
+			return nil, false, nil
 		}
 		switch msg.Delta.Type {
 		case "text_delta":
 			if msg.Delta.Text != "" {
-				s.queue = append(s.queue, Delta{Kind: DeltaText, Text: msg.Delta.Text})
+				return []Delta{{Kind: DeltaText, Text: msg.Delta.Text}}, false, nil
 			}
 		case "input_json_delta":
 			if msg.Delta.PartialJSON != "" {
-				s.queue = append(s.queue, Delta{Kind: DeltaToolCallArgs, Index: msg.Index, Text: msg.Delta.PartialJSON})
+				return []Delta{{Kind: DeltaToolCallArgs, Index: msg.Index, Text: msg.Delta.PartialJSON}}, false, nil
 			}
 		case "thinking_delta":
 			if msg.Delta.Thinking != "" {
-				s.queue = append(s.queue, Delta{Kind: DeltaReasoning, Text: msg.Delta.Thinking})
+				return []Delta{{Kind: DeltaReasoning, Text: msg.Delta.Thinking}}, false, nil
 			}
 		}
 	case "message_delta":
+		var out []Delta
 		if msg.Delta != nil && msg.Delta.StopReason != "" {
-			s.queue = append(s.queue, Delta{Kind: DeltaFinish, FinishReason: msg.Delta.StopReason})
+			out = append(out, Delta{Kind: DeltaFinish, FinishReason: msg.Delta.StopReason})
 		}
 		if msg.Usage != nil {
-			s.queue = append(s.queue, Delta{Kind: DeltaUsage, Usage: &Usage{
+			out = append(out, Delta{Kind: DeltaUsage, Usage: &Usage{
 				InputTokens:  s.inputTokens,
 				OutputTokens: msg.Usage.OutputTokens,
 			}})
 		}
+		return out, false, nil
 	case "message_stop":
-		s.done = true
+		return nil, true, nil
 	case "error":
 		if msg.Error != nil {
-			return fmt.Errorf("agent: anthropic stream error (%s): %s", msg.Error.Type, msg.Error.Message)
+			return nil, false, fmt.Errorf("agent: anthropic stream error (%s): %s", msg.Error.Type, msg.Error.Message)
 		}
-		return errors.New("agent: anthropic stream error")
+		return nil, false, errors.New("agent: anthropic stream error")
 	}
 	// content_block_stop and ping carry no deltas.
-	return nil
-}
-
-// Close implements Stream.
-func (s *anthropicStream) Close() error {
-	return s.body.Close()
+	return nil, false, nil
 }

--- a/agent/openai_provider.go
+++ b/agent/openai_provider.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -78,7 +77,9 @@ func (p *OpenAIProvider) Stream(ctx context.Context, req ProviderRequest) (Strea
 		return nil, err
 	}
 	_, safeToReal := toolNameMaps(req.Tools)
-	return &openaiStream{ctx: ctx, body: resp.Body, events: ssehttp.NewSSEEventReader(resp.Body), nameMap: safeToReal}, nil
+	st := &openaiStream{nameMap: safeToReal}
+	st.sseStream = sseStream{ctx: ctx, body: resp.Body, events: ssehttp.NewSSEEventReader(resp.Body), decode: st.decode}
+	return st, nil
 }
 
 // Generate implements Provider with a non-streaming request. When
@@ -276,73 +277,44 @@ type oaChunk struct {
 // comment skipping). Recv keeps a small queue because one SSE event can
 // expand to several Deltas.
 type openaiStream struct {
-	ctx     context.Context
-	body    io.ReadCloser
-	events  *ssehttp.SSEEventReader
-	queue   []Delta
+	sseStream
 	started map[int]bool
-	done    bool
 	nameMap map[string]string // safe→real tool name, to reverse sanitized names on tool_call deltas
 }
 
-// Recv implements Stream.
-func (s *openaiStream) Recv() (Delta, error) {
-	for {
-		if len(s.queue) > 0 {
-			d := s.queue[0]
-			s.queue = s.queue[1:]
-			return d, nil
-		}
-		if s.done {
-			return Delta{}, io.EOF
-		}
-		if err := s.ctx.Err(); err != nil {
-			return Delta{}, err
-		}
-		ev, err := s.events.ReadEvent()
-		if err != nil {
-			if ctxErr := s.ctx.Err(); ctxErr != nil {
-				return Delta{}, ctxErr
-			}
-			// A partial event can ride along with io.EOF; process it
-			// before surfacing EOF on the next call.
-			if !errors.Is(err, io.EOF) || ev.Data == "" {
-				return Delta{}, err
-			}
-			s.done = true
-		}
-		payload := strings.TrimSpace(ev.Data)
-		if payload == "" {
-			continue
-		}
-		if payload == "[DONE]" {
-			s.done = true
-			continue
-		}
-		var chunk oaChunk
-		if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
-			return Delta{}, fmt.Errorf("agent: bad SSE chunk: %w", err)
-		}
-		s.enqueue(chunk)
+// decode turns one SSE data payload into Deltas. The "[DONE]" sentinel ends the
+// stream; otherwise the chunk is unmarshalled and expanded via chunkDeltas.
+func (s *openaiStream) decode(payload string) ([]Delta, bool, error) {
+	if payload == "[DONE]" {
+		return nil, true, nil
 	}
+	var chunk oaChunk
+	if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
+		return nil, false, fmt.Errorf("agent: bad SSE chunk: %w", err)
+	}
+	return s.chunkDeltas(chunk), false, nil
 }
 
-func (s *openaiStream) enqueue(chunk oaChunk) {
+// chunkDeltas expands one chat-completions chunk into Deltas. It keeps the
+// per-index started map so a tool call's first fragment is a DeltaToolCallStart
+// and the rest are DeltaToolCallArgs.
+func (s *openaiStream) chunkDeltas(chunk oaChunk) []Delta {
+	var out []Delta
 	if chunk.Usage != nil {
-		s.queue = append(s.queue, Delta{Kind: DeltaUsage, Usage: &Usage{
+		out = append(out, Delta{Kind: DeltaUsage, Usage: &Usage{
 			InputTokens:  chunk.Usage.PromptTokens,
 			OutputTokens: chunk.Usage.CompletionTokens,
 		}})
 	}
 	if len(chunk.Choices) == 0 {
-		return
+		return out
 	}
 	choice := chunk.Choices[0]
 	if choice.Delta.Content != "" {
-		s.queue = append(s.queue, Delta{Kind: DeltaText, Text: choice.Delta.Content})
+		out = append(out, Delta{Kind: DeltaText, Text: choice.Delta.Content})
 	}
 	if r := choice.Delta.ReasoningContent + choice.Delta.Reasoning; r != "" {
-		s.queue = append(s.queue, Delta{Kind: DeltaReasoning, Text: r})
+		out = append(out, Delta{Kind: DeltaReasoning, Text: r})
 	}
 	for _, tc := range choice.Delta.ToolCalls {
 		if s.started == nil {
@@ -350,7 +322,7 @@ func (s *openaiStream) enqueue(chunk oaChunk) {
 		}
 		if !s.started[tc.Index] {
 			s.started[tc.Index] = true
-			s.queue = append(s.queue, Delta{
+			out = append(out, Delta{
 				Kind:       DeltaToolCallStart,
 				Index:      tc.Index,
 				ToolCallID: tc.ID,
@@ -360,15 +332,11 @@ func (s *openaiStream) enqueue(chunk oaChunk) {
 			continue
 		}
 		if tc.Function.Arguments != "" {
-			s.queue = append(s.queue, Delta{Kind: DeltaToolCallArgs, Index: tc.Index, Text: tc.Function.Arguments})
+			out = append(out, Delta{Kind: DeltaToolCallArgs, Index: tc.Index, Text: tc.Function.Arguments})
 		}
 	}
 	if choice.FinishReason != nil && *choice.FinishReason != "" {
-		s.queue = append(s.queue, Delta{Kind: DeltaFinish, FinishReason: *choice.FinishReason})
+		out = append(out, Delta{Kind: DeltaFinish, FinishReason: *choice.FinishReason})
 	}
-}
-
-// Close implements Stream.
-func (s *openaiStream) Close() error {
-	return s.body.Close()
+	return out
 }

--- a/agent/sse_stream.go
+++ b/agent/sse_stream.go
@@ -1,0 +1,78 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+
+	ssehttp "github.com/panyam/servicekit/http"
+)
+
+// sseStream is the shared read loop for the streaming providers. Both the
+// OpenAI and Anthropic streams landed as near-identical Recv() bodies — queue
+// drain, done check, ctx cancellation, ReadEvent, the subtle partial-event-
+// riding-EOF handling, TrimSpace — differing only in how one SSE data payload
+// decodes into Deltas. Consolidating the loop here removes that bug-drift risk;
+// each provider embeds sseStream and supplies its own decode.
+type sseStream struct {
+	ctx    context.Context
+	body   io.ReadCloser
+	events *ssehttp.SSEEventReader
+	queue  []Delta
+	done   bool
+
+	// decode turns one non-empty, trimmed SSE data payload into zero or more
+	// Deltas. done=true ends the stream on the provider's terminal sentinel
+	// (OpenAI's "[DONE]", Anthropic's "message_stop"); a decode error surfaces
+	// from Recv. It may keep per-stream state across calls (OpenAI's tool-call
+	// index map), so it is a closure/method bound to the concrete stream.
+	decode func(payload string) (deltas []Delta, done bool, err error)
+}
+
+// Recv implements Stream. It returns queued Deltas one at a time, reading and
+// decoding the next SSE event only when the queue is empty. A partial event can
+// ride along with io.EOF; it is decoded before EOF is surfaced on the next
+// call. A cancelled context takes precedence over a read error.
+func (s *sseStream) Recv() (Delta, error) {
+	for {
+		if len(s.queue) > 0 {
+			d := s.queue[0]
+			s.queue = s.queue[1:]
+			return d, nil
+		}
+		if s.done {
+			return Delta{}, io.EOF
+		}
+		if err := s.ctx.Err(); err != nil {
+			return Delta{}, err
+		}
+		ev, err := s.events.ReadEvent()
+		if err != nil {
+			if ctxErr := s.ctx.Err(); ctxErr != nil {
+				return Delta{}, ctxErr
+			}
+			// A partial event can ride along with io.EOF; process it before
+			// surfacing EOF on the next call.
+			if !errors.Is(err, io.EOF) || ev.Data == "" {
+				return Delta{}, err
+			}
+			s.done = true
+		}
+		payload := strings.TrimSpace(ev.Data)
+		if payload == "" {
+			continue
+		}
+		deltas, done, derr := s.decode(payload)
+		if derr != nil {
+			return Delta{}, derr
+		}
+		if done {
+			s.done = true
+		}
+		s.queue = append(s.queue, deltas...)
+	}
+}
+
+// Close implements Stream: it closes the underlying response body.
+func (s *sseStream) Close() error { return s.body.Close() }

--- a/agent/sse_stream_test.go
+++ b/agent/sse_stream_test.go
@@ -1,0 +1,72 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	ssehttp "github.com/panyam/servicekit/http"
+)
+
+func newTestSSEStream(ctx context.Context, data string, decode func(string) ([]Delta, bool, error)) *sseStream {
+	r := io.NopCloser(strings.NewReader(data))
+	return &sseStream{ctx: ctx, body: r, events: ssehttp.NewSSEEventReader(r), decode: decode}
+}
+
+// TestSSEStream_DoneSentinelStopsBeforeLaterEvents pins the shared loop: a
+// decode returning done=true ends the stream, so events after the sentinel are
+// never decoded, and Recv then returns io.EOF.
+func TestSSEStream_DoneSentinelStopsBeforeLaterEvents(t *testing.T) {
+	s := newTestSSEStream(context.Background(),
+		"data: one\n\ndata: two\n\ndata: STOP\n\ndata: three\n\n",
+		func(p string) ([]Delta, bool, error) {
+			if p == "STOP" {
+				return nil, true, nil
+			}
+			return []Delta{{Kind: DeltaText, Text: p}}, false, nil
+		})
+
+	got := collectDeltas(t, s)
+	if len(got) != 2 || got[0].Text != "one" || got[1].Text != "two" {
+		t.Fatalf("deltas after the done sentinel leaked: %+v", got)
+	}
+}
+
+// TestSSEStream_EmptyPayloadSkipped pins that a blank data line yields no delta
+// and does not end the stream.
+func TestSSEStream_EmptyPayloadSkipped(t *testing.T) {
+	s := newTestSSEStream(context.Background(),
+		"data: \n\ndata: hi\n\n",
+		func(p string) ([]Delta, bool, error) { return []Delta{{Kind: DeltaText, Text: p}}, false, nil })
+	got := collectDeltas(t, s)
+	if len(got) != 1 || got[0].Text != "hi" {
+		t.Fatalf("empty payload not skipped: %+v", got)
+	}
+}
+
+// TestSSEStream_DecodeErrorSurfaces pins that a decode error is returned from
+// Recv (not swallowed).
+func TestSSEStream_DecodeErrorSurfaces(t *testing.T) {
+	boom := errors.New("bad chunk")
+	s := newTestSSEStream(context.Background(),
+		"data: x\n\n",
+		func(string) ([]Delta, bool, error) { return nil, false, boom })
+	if _, err := s.Recv(); !errors.Is(err, boom) {
+		t.Fatalf("Recv err = %v, want the decode error", err)
+	}
+}
+
+// TestSSEStream_ContextCancelTakesPrecedence pins that a cancelled context ends
+// Recv with the context error rather than decoding further.
+func TestSSEStream_ContextCancelTakesPrecedence(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	s := newTestSSEStream(ctx,
+		"data: x\n\n",
+		func(string) ([]Delta, bool, error) { return []Delta{{Kind: DeltaText, Text: "x"}}, false, nil })
+	if _, err := s.Recv(); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Recv err = %v, want context.Canceled", err)
+	}
+}


### PR DESCRIPTION
## What changes

Pure internal refactor: the OpenAI and Anthropic streaming providers landed as **byte-identical `Recv()` loops** — queue drain, done check, `ctx.Err()`, `events.ReadEvent()`, the subtle partial-event-riding-EOF handling, `TrimSpace` — differing only in how one SSE data payload decodes into `Delta`s. Two copies of that subtle loop are a bug-drift risk (issue 952).

The loop moves to a shared `sseStream` parameterized by a `decode` func; each provider embeds it and keeps only its own decode. No public API change (the stream types are unexported) and no behavior change.

## Reviewer's guide
1. [agent/sse_stream.go](https://github.com/panyam/mcpkit/pull/1131/files#diff-9ce16633c81c94596d2788b05d335218b7322f03f4678344f3209780be17a34d) — start here. The shared `sseStream` (embedded fields + `Recv` + `Close`) and the `decode func(payload string) (deltas []Delta, done bool, err error)` seam.
2. [agent/openai_provider.go](https://github.com/panyam/mcpkit/pull/1131/files#diff-aa95603c3498519232b6a26863d823be62a5d05e94053dc57da95c458e875b3e) — `openaiStream` embeds `sseStream`; `enqueue` → `chunkDeltas` (returns `[]Delta`, keeps the `started` index map); `decode` handles the `[DONE]` sentinel; `Stream()` wires it.
3. [agent/anthropic_provider.go](https://github.com/panyam/mcpkit/pull/1131/files#diff-71f597ba381303570d5ed1f9ac3f73f390236d1e6393ee0daf220757916a4e68) — `anthropicStream` embeds `sseStream`; `enqueue` → `eventDeltas` (returns `[]Delta` + `done` for `message_stop` + `err` for an `error` event); `decode` unmarshals; `Stream()` wires it.
4. [agent/sse_stream_test.go](https://github.com/panyam/mcpkit/pull/1131/files#diff-0bda8d16d6c5c2d916ac1e070e75d17a059b67a671818361287f13783256eec8) — new focused coverage for the shared loop (done sentinel, empty payload, decode error, ctx cancel).

Skim: the existing `provider_test.go` / `anthropic_provider_test.go` are unchanged — that they still pass is the refactor's proof.

## Decision log
- **`decode` returns `[]Delta` instead of appending to a shared queue.** Keeps the shared loop the sole owner of the queue; each provider's decode is a pure-ish mapping (still mutating its own per-stream state like OpenAI's `started` map, captured as a method).
- **`done` is a decode return, not a per-provider sentinel string in the loop.** OpenAI's `[DONE]` and Anthropic's `message_stop` both collapse to `done=true` from decode; the loop stays provider-agnostic.
- **Left per-provider: `buildBody`, the chunk/event decode, `Generate` response parse.** Per the issue — that's where the providers genuinely diverge; forcing them behind one abstraction would be config-object soup.

## Risk / blast radius
- Affects: both streaming providers' internals only. No exported symbol changed; `agent/host` and `cmd/agentchat` build unchanged.
- Tests: existing stream tests pin the Delta sequences (unchanged — behavior proof); 4 new `sseStream` tests cover the shared loop centrally. Added assertions: ~4 tests; weakened: 0.
- Be paranoid about: the partial-event-riding-EOF path (unchanged from the originals, now single-sourced) and OpenAI's tool-call `started` state living on the concrete stream (still per-stream, captured by the `decode` method).

## Before / after
```mermaid
flowchart LR
  subgraph Before
    A[openaiStream.Recv<br/>~35 lines] --> D1[oaChunk decode]
    B[anthropicStream.Recv<br/>~35 lines] --> D2[anthropicSSE decode]
  end
  subgraph After
    R[sseStream.Recv<br/>one loop] --> DEC[decode func]
    DEC -.-> D1b[openaiStream.decode / chunkDeltas]
    DEC -.-> D2b[anthropicStream.decode / eventDeltas]
  end
```

## Out of scope
- The `post()` helper (the issue notes it as optional) — left duplicated; it is short and low-risk.

