### PR TITLE
feat(agent/host): SystemPromptBuilder — composable per-turn system prompt (1091)

### DIFF
--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -103,6 +103,11 @@ type App struct {
 	// through (Dispatch / Commands). Built in NewApp.
 	commands *CommandRegistry
 
+	// promptBuilder assembles the per-turn system prompt from ordered sections
+	// (base instructions + per-server skills by default; customizable via
+	// WithSystemPromptBuilder). Wired as RunnerConfig.InstructionsFunc.
+	promptBuilder *SystemPromptBuilder
+
 	// overlay persists mutable config picks (active connection, approval
 	// mode) back to a local-overlay file when WithConfigOverlay is set; nil
 	// means runtime changes are session-only.
@@ -124,6 +129,16 @@ type appOptions struct {
 	providerBuilder ProviderBuilder
 	observers       []Observer
 	configPath      string
+	promptMutate    func(*SystemPromptBuilder)
+}
+
+// WithSystemPromptBuilder customizes per-turn system-prompt assembly. The
+// mutator receives the default builder (base instructions, then per-server skill
+// blocks) after it is assembled in NewApp, so a caller can reorder sections,
+// insert profile/domain-guide sections, or replace Sections wholesale. It runs
+// once at construction; the resulting builder's Build runs each turn.
+func WithSystemPromptBuilder(mutate func(*SystemPromptBuilder)) AppOption {
+	return func(o *appOptions) { o.promptMutate = mutate }
 }
 
 // WithProvider overrides the OpenAI-compatible provider built from config.
@@ -431,13 +446,19 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 		runnerTools = agent.NewOffloadingSource(multi, store, cfg.Offload.toAgent())
 	}
 
+	// The default system prompt is base instructions followed by the connected
+	// servers' skill blocks; both are recomputed each turn so a late-connecting
+	// server's skills appear without a restart. WithSystemPromptBuilder can
+	// reorder or extend it.
+	app.promptBuilder = app.defaultPromptBuilder()
+	if o.promptMutate != nil {
+		o.promptMutate(app.promptBuilder)
+	}
+
 	runnerCfg := agent.RunnerConfig{
-		Provider: provider,
-		Tools:    runnerTools,
-		// Dynamic system prompt: cfg.Instructions plus the eager/catalog blocks
-		// of the currently-connected servers, recomputed each turn so a
-		// late-connecting server's skills appear without a restart.
-		InstructionsFunc: app.buildInstructions,
+		Provider:         provider,
+		Tools:            runnerTools,
+		InstructionsFunc: app.promptBuilder.Build,
 		MaxSteps:         cfg.MaxSteps,
 		TracerProvider:   o.tp,
 	}

--- a/agent/host/prompt.go
+++ b/agent/host/prompt.go
@@ -1,0 +1,53 @@
+package host
+
+import (
+	"context"
+	"strings"
+)
+
+// PromptSection contributes one section of the per-turn system prompt. Returning
+// "" omits the section (no stray blank lines). Sections run every turn, so a
+// section may read live/dynamic state (late-connecting servers' skills, memory).
+type PromptSection interface {
+	Section(ctx context.Context) string
+}
+
+// PromptSectionFunc adapts a plain function to PromptSection (like
+// http.HandlerFunc adapts a function to http.Handler).
+type PromptSectionFunc func(ctx context.Context) string
+
+// Section implements PromptSection.
+func (f PromptSectionFunc) Section(ctx context.Context) string { return f(ctx) }
+
+// SystemPromptBuilder assembles the system prompt from ordered sections. It is
+// the host-layer composition over the Runner's low-level InstructionsFunc hook:
+// Build runs each turn and joins the non-empty sections, so prompt assembly is
+// composable — reorder, insert profile/domain-guide sections, or replace the
+// section list — instead of being hard-coded. The default builder mirrors the
+// previous fixed assembly (base instructions, then per-server skill blocks in
+// config order); WithSystemPromptBuilder lets a caller customize it.
+type SystemPromptBuilder struct {
+	Sections []PromptSection
+}
+
+// Build joins every non-empty section in order, separated by a blank line, and
+// runs each turn (wired as RunnerConfig.InstructionsFunc). A section that
+// returns "" contributes nothing, so empty base instructions or a server with
+// no skills leave no blank gap.
+func (b *SystemPromptBuilder) Build(ctx context.Context) string {
+	var parts []string
+	for _, s := range b.Sections {
+		if p := strings.Trim(s.Section(ctx), "\n"); p != "" {
+			parts = append(parts, p)
+		}
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+// Append adds a section after the existing ones.
+func (b *SystemPromptBuilder) Append(s PromptSection) { b.Sections = append(b.Sections, s) }
+
+// Prepend adds a section before the existing ones.
+func (b *SystemPromptBuilder) Prepend(s PromptSection) {
+	b.Sections = append([]PromptSection{s}, b.Sections...)
+}

--- a/agent/host/prompt_test.go
+++ b/agent/host/prompt_test.go
@@ -1,0 +1,65 @@
+package host
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/panyam/mcpkit/agent"
+)
+
+func sec(s string) PromptSection { return PromptSectionFunc(func(context.Context) string { return s }) }
+
+func TestSystemPromptBuilder_JoinsNonEmptyInOrder(t *testing.T) {
+	b := &SystemPromptBuilder{Sections: []PromptSection{sec("first"), sec(""), sec("third")}}
+	if got := b.Build(context.Background()); got != "first\n\nthird" {
+		t.Fatalf("Build = %q, want the non-empty sections joined by a blank line", got)
+	}
+}
+
+func TestSystemPromptBuilder_AppendPrepend(t *testing.T) {
+	b := &SystemPromptBuilder{Sections: []PromptSection{sec("mid")}}
+	b.Append(sec("last"))
+	b.Prepend(sec("head"))
+	if got := b.Build(context.Background()); got != "head\n\nmid\n\nlast" {
+		t.Fatalf("Build = %q, want head/mid/last", got)
+	}
+}
+
+func TestSystemPromptBuilder_AllEmptyIsEmpty(t *testing.T) {
+	b := &SystemPromptBuilder{Sections: []PromptSection{sec(""), sec("\n")}}
+	if got := b.Build(context.Background()); got != "" {
+		t.Fatalf("Build = %q, want empty when every section is blank", got)
+	}
+}
+
+// TestSystemPromptBuilder_TrimsSurroundingNewlines pins that a section's own
+// leading/trailing newlines don't produce extra blank lines in the join.
+func TestSystemPromptBuilder_TrimsSurroundingNewlines(t *testing.T) {
+	b := &SystemPromptBuilder{Sections: []PromptSection{sec("\na\n"), sec("b")}}
+	if got := b.Build(context.Background()); got != "a\n\nb" {
+		t.Fatalf("Build = %q, want a\\n\\nb", got)
+	}
+}
+
+// TestWithSystemPromptBuilder_MutatesDefault pins the customization seam: the
+// mutator receives the assembled default builder and can insert a section that
+// then appears in Build's output alongside the base instructions.
+func TestWithSystemPromptBuilder_MutatesDefault(t *testing.T) {
+	ts := startTestServer(t)
+	var out strings.Builder
+	app, err := NewApp(testConfig(ts.URL), &out, strings.NewReader(""),
+		WithProvider(agent.NewStubProvider(agent.StubTurn{Text: "hi"})),
+		WithSystemPromptBuilder(func(b *SystemPromptBuilder) {
+			b.Prepend(sec("DOMAIN GUIDE"))
+		}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Close()
+
+	got := app.promptBuilder.Build(context.Background())
+	if !strings.HasPrefix(got, "DOMAIN GUIDE") {
+		t.Fatalf("prepended section missing from the built prompt:\n%s", got)
+	}
+}

--- a/agent/host/skills.go
+++ b/agent/host/skills.go
@@ -193,20 +193,31 @@ func (a *App) onServerSkills(sc ServerConfig, c *client.Client) {
 	a.sources.Invalidate()
 }
 
-// buildInstructions is the dynamic system prompt: cfg.Instructions followed by
-// the prompt block of every currently-connected server, in config order. Set as
-// RunnerConfig.InstructionsFunc, so it is recomputed each turn and a late
-// server's skills land on the next turn.
-func (a *App) buildInstructions(context.Context) string {
+// skillsSection is the skills part of the dynamic system prompt: the prompt
+// block of every currently-connected server, in config order, joined by a blank
+// line. It is one section of the SystemPromptBuilder (after the base
+// instructions), recomputed each turn so a late server's skills land on the next
+// turn.
+func (a *App) skillsSection(context.Context) string {
 	a.skillsMu.Lock()
 	defer a.skillsMu.Unlock()
-	s := a.cfg.Instructions
+	var blocks []string
 	for _, id := range a.serverOrder {
 		if block := a.skillBlocks[id]; block != "" {
-			s += "\n\n" + block
+			blocks = append(blocks, block)
 		}
 	}
-	return s
+	return strings.Join(blocks, "\n\n")
+}
+
+// defaultPromptBuilder assembles the standard system prompt: the base
+// instructions, then the per-server skill blocks. NewApp wires this (after
+// applying any WithSystemPromptBuilder mutator) as RunnerConfig.InstructionsFunc.
+func (a *App) defaultPromptBuilder() *SystemPromptBuilder {
+	return &SystemPromptBuilder{Sections: []PromptSection{
+		PromptSectionFunc(func(context.Context) string { return a.cfg.Instructions }),
+		PromptSectionFunc(a.skillsSection),
+	}}
 }
 
 // allCatalogSkills flattens every connected server's catalog entries, in config

--- a/agent/host/skills_test.go
+++ b/agent/host/skills_test.go
@@ -87,7 +87,7 @@ func TestFilterSkillsAllow(t *testing.T) {
 	}
 }
 
-// TestBuildInstructions covers the dynamic system prompt: base instructions
+// TestBuildInstructions covers the default system prompt: base instructions
 // plus each connected server's block, in config order, skipping empties. This
 // is what makes a late server's eager skills appear on the next turn.
 func TestBuildInstructions(t *testing.T) {
@@ -96,18 +96,20 @@ func TestBuildInstructions(t *testing.T) {
 		skillBlocks: map[string]string{"s1": "block1", "s2": "block2"},
 		serverOrder: []string{"s1", "s2"},
 	}
-	if got := a.buildInstructions(context.Background()); got != "base\n\nblock1\n\nblock2" {
+	build := func() string { return a.defaultPromptBuilder().Build(context.Background()) }
+
+	if got := build(); got != "base\n\nblock1\n\nblock2" {
 		t.Fatalf("got %q", got)
 	}
 	// order follows serverOrder, not map iteration
 	a.serverOrder = []string{"s2", "s1"}
-	if got := a.buildInstructions(context.Background()); got != "base\n\nblock2\n\nblock1" {
+	if got := build(); got != "base\n\nblock2\n\nblock1" {
 		t.Fatalf("order must follow serverOrder: %q", got)
 	}
 	// a server with no block yet is skipped
 	a.skillBlocks = map[string]string{"s1": "only1"}
 	a.serverOrder = []string{"s1", "s2"}
-	if got := a.buildInstructions(context.Background()); got != "base\n\nonly1" {
+	if got := build(); got != "base\n\nonly1" {
 		t.Fatalf("empty block must be skipped: %q", got)
 	}
 }


### PR DESCRIPTION
## What changes

The main agent's system prompt was hard-coded in `App.buildInstructions` — `cfg.Instructions` followed by each connected server's skill block, in config order — with no control over ordering, placement, section headers, or mixing in other dynamic content (issue 1091, raised in the PR 1089 review).

Promote it to a composable `SystemPromptBuilder`: an ordered list of `PromptSection`s, each contributing a section, joined per turn by `Build` (wired as `RunnerConfig.InstructionsFunc`, so late-connecting servers' skills still appear live). The default builder mirrors the old assembly exactly; `WithSystemPromptBuilder` lets a caller reorder, insert profile/domain-guide sections, or replace the section list.

## Reviewer's guide
1. [agent/host/prompt.go](https://github.com/panyam/mcpkit/pull/1132/files#diff-576516171bf4969c3b0c501901b30db61d3d9eb28c0c6e3fab529f7c375458dd) — start here. `PromptSection` / `PromptSectionFunc` (the http.HandlerFunc-style adapter), `SystemPromptBuilder` (`Sections` + `Build` joining non-empty sections by a blank line, + `Append`/`Prepend`).
2. [agent/host/skills.go](https://github.com/panyam/mcpkit/pull/1132/files#diff-e306a404daf114302a7d1eb19616a1d7d8fbb9ee27b78f1e2b237c0f2384dff7) — `buildInstructions` → `skillsSection` (the per-server blocks, same logic) + `defaultPromptBuilder` (base instructions + skills), shared by NewApp and the test so they can't drift.
3. [agent/host/app.go](https://github.com/panyam/mcpkit/pull/1132/files#diff-89fb8e04b6e1e9d5f7f76958490ef158dee40e2cae92d87c04b408d893c84361) — `NewApp` assembles the default builder, applies any `WithSystemPromptBuilder` mutator, and wires `promptBuilder.Build` as `InstructionsFunc`; the `WithSystemPromptBuilder` option.
4. [agent/host/prompt_test.go](https://github.com/panyam/mcpkit/pull/1132/files#diff-9acc63b34f59cc9a4129e985b9eda8097dd064cb45747cb9dbdd7932e4de7dd7) + `skills_test.go` — builder semantics (order, empties, newline trim, Append/Prepend), the mutator wiring, and the unchanged `TestBuildInstructions` assertions.

## Decision log
- **A mutator option, not a replacement setter.** The default sections are App-bound (skills read `a.skillBlocks`/`a.serverOrder`), so `WithSystemPromptBuilder(func(*SystemPromptBuilder))` hands the caller the assembled default to tweak — reorder, `Prepend` a domain guide, or replace `Sections` — rather than forcing them to reconstruct the App-internal sections.
- **`InstructionsFunc` stays the low-level Runner hook.** `SystemPromptBuilder` is host-layer composition on top; the Runner is unchanged.
- **`Build` trims each section's surrounding newlines but not spaces.** Matches the old `block != ""` check (a whitespace-only block was included before too); the newline trim just avoids double blank lines in the join.

## Risk / blast radius
- Affects: host-layer system-prompt assembly only. No Runner, provider, or protocol change.
- **Behavior-preserving:** `TestBuildInstructions` keeps its exact expected outputs (now via `defaultPromptBuilder().Build`). One intentional micro-improvement — an *empty* base no longer emits leading blank lines (the old code unconditionally prepended `\n\n` per block); the common non-empty-base output is byte-identical.
- Tests: builder unit tests + the mutator wiring (red-before-green confirmed by neutering the mutator call). Added assertions: ~5; weakened: 0.

## Before / after
```
BEFORE  buildInstructions: cfg.Instructions + "\n\n" + block per server (fixed)
AFTER   SystemPromptBuilder{ [base, skills, ...custom] }.Build  (composable, same default output)
```

## Out of scope (the seam for follow-ups)
- Concrete extra strategies from the issue: `ProfileGuidesBuilder` / `DomainSpecificBuilder` sections, and composing memory summary/recall here instead of as `RoleSystem` messages. The interface + option land now; these are additive.

## Note
**Stacked on PR 1131 (issue 952)** — base is `refactor/952-shared-sse-stream`. They're independent (1091 is `agent/host`, 952 is `agent`, no shared files), so retarget to `main` after 1131 merges. Stacked PRs off a non-main base don't run CI until retargeted; verified locally (host + agent + agentchat build, full host suite green).

