### PR TITLE
chore(kitchen-sink): servers-restart + servers-up tails logs

### DIFF
--- a/examples/agents/kitchen-sink/README.md
+++ b/examples/agents/kitchen-sink/README.md
@@ -50,16 +50,19 @@ ride the approval ladder).
 Manage the servers independently of the chat:
 
 ```bash
-just servers-up            # start all four (built to .servers/bin, run detached)
-just servers-up-fg         # start + tail all logs in the foreground (Ctrl+C stops them)
+just servers-up            # start all four (detached), then tail logs; Ctrl+C leaves them running
+just servers-restart       # down then up (+ tail) — bounce them without two commands
+just servers-up-fg         # like servers-up, but Ctrl+C brings the servers DOWN
 just servers               # status: which are up
 just servers-up events     # start just one
 just servers-down          # stop all
 ```
 
-Use `servers-up-fg` in one terminal to watch every server's logs live, and run
-`just run` (agentchat) in a second terminal — the inline TUI and the interleaved
-logs would fight for the same screen otherwise.
+`servers-up` and `servers-restart` tail the logs at the end so you can watch the
+servers come up; Ctrl+C stops watching and the detached servers keep running.
+Run `just run` (agentchat) in a **second** terminal — the inline TUI and the
+interleaved logs would fight for the same screen otherwise. (`servers-up-fg` is
+the ephemeral variant: Ctrl+C stops the servers too.)
 
 `just run` only *checks* these ports and tells you to `just servers-up` if any
 are down — it never boots or kills them. Having the agent spawn them from the

--- a/examples/agents/kitchen-sink/justfile
+++ b/examples/agents/kitchen-sink/justfile
@@ -97,14 +97,17 @@ mem:
 # These run independently of agentchat and survive chat restarts. `just run`
 # only checks they are up; it never starts or stops them.
 
-# Start all MCP servers the config connects to, or one: `just servers-up demo`.
+# Start the MCP servers (detached) + tail logs; Ctrl+C leaves them running. Or: `just servers-up demo`.
 servers-up name="":
     @bash servers.sh up {{name}}
 
-# Start the servers and tail their logs in the foreground (Ctrl+C stops them).
-# Run agentchat in a separate terminal. Or one: `just servers-up-fg demo`.
+# Like servers-up, but Ctrl+C brings the servers DOWN (foreground lifetime).
 servers-up-fg name="":
     @bash servers.sh up-fg {{name}}
+
+# Restart the servers (down then up), then tail their logs. Or one: `just servers-restart demo`.
+servers-restart name="":
+    @bash servers.sh restart {{name}}
 
 # Stop all MCP servers, or one: `just servers-down events`.
 servers-down name="":

--- a/examples/agents/kitchen-sink/servers.sh
+++ b/examples/agents/kitchen-sink/servers.sh
@@ -7,8 +7,9 @@
 # started here, survive agentchat restarts, and are torn down explicitly.
 #
 # Usage:
-#   servers.sh up      [name]   # build + start all servers detached (or just <name>)
-#   servers.sh up-fg   [name]   # start + tail logs in the foreground (Ctrl+C stops them)
+#   servers.sh up      [name]   # build + start detached, then tail logs (Ctrl+C leaves them up)
+#   servers.sh up-fg   [name]   # start + tail; Ctrl+C brings the servers DOWN
+#   servers.sh restart [name]   # down then up (+ tail)
 #   servers.sh down    [name]   # stop all (or just <name>)
 #   servers.sh status  [name]   # probe ports; show up/down
 #
@@ -88,23 +89,25 @@ status_one() {
 	if port_up "$port"; then echo "  [up]   $name :$port"; else echo "  [down] $name :$port"; fi
 }
 
-# up_fg starts the servers (reusing the reliable detached start + pidfiles) and
-# then tails all their logs in the FOREGROUND, so you can watch every server's
-# output live in one terminal. Ctrl+C stops the tail AND brings the servers down
-# — this window owns their lifetime, unlike the detached `up`. Run agentchat in a
-# SEPARATE terminal: its inline TUI and these interleaved logs would fight for the
-# same screen.
+# tail_logs follows the .log files of the current $names in the foreground.
+# -F follows across truncation/rotation and waits for a not-yet-created log (a
+# server still building); multiple files print a "==> name.log <==" header.
+tail_logs() {
+	local n logs=""
+	for n in $names; do logs="$logs $STATE/$n.log"; done
+	echo "==> tailing $(echo $names | wc -w | tr -d ' ') server log(s)"
+	# shellcheck disable=SC2086
+	tail -n +1 -F $logs
+}
+
+# up_fg starts the servers and tails their logs in the FOREGROUND, but Ctrl+C
+# brings the servers DOWN — this window owns their lifetime, unlike `up` (where
+# Ctrl+C only stops watching and the detached servers keep running).
 up_fg() {
 	local n
 	trap 'echo; echo "==> stopping servers (foreground window closed)"; for n in $names; do down_one "$n"; done; exit 0' INT TERM
 	for n in $names; do up_one "$n" || true; done
-	local logs=""
-	for n in $names; do logs="$logs $STATE/$n.log"; done
-	echo "==> tailing $(echo $names | wc -w | tr -d ' ') server log(s) — Ctrl+C stops them all"
-	# -F follows across truncation/rotation and waits for a not-yet-created log
-	# (a server still building); multiple files print a "==> name.log <==" header.
-	# shellcheck disable=SC2086
-	tail -n +1 -F $logs
+	tail_logs
 }
 
 cmd="${1:-status}"
@@ -112,10 +115,20 @@ target="${2:-}"
 names="$ORDER"
 [ -n "$target" ] && names="$target"
 
+# watch tails the logs after an up/restart when stdout is a terminal (Ctrl+C
+# stops watching; the detached servers keep running). Skipped for pipes/CI so a
+# non-interactive `up` stays fire-and-forget.
+watch_after_up() {
+	[ -t 1 ] || return 0
+	echo "==> servers running detached — Ctrl+C stops watching (they keep running)"
+	tail_logs
+}
+
 case "$cmd" in
-up)     for n in $names; do up_one "$n"; done ;;
-up-fg)  up_fg ;;
-down)   for n in $names; do down_one "$n"; done ;;
-status) echo "kitchen-sink MCP servers"; for n in $names; do status_one "$n"; done ;;
-*) echo "usage: servers.sh <up|up-fg|down|status> [name]" >&2; exit 2 ;;
+up)      for n in $names; do up_one "$n"; done; watch_after_up ;;
+up-fg)   up_fg ;;
+restart) for n in $names; do down_one "$n"; done; for n in $names; do up_one "$n"; done; watch_after_up ;;
+down)    for n in $names; do down_one "$n"; done ;;
+status)  echo "kitchen-sink MCP servers"; for n in $names; do status_one "$n"; done ;;
+*) echo "usage: servers.sh <up|up-fg|restart|down|status> [name]" >&2; exit 2 ;;
 esac


### PR DESCRIPTION
Dev-tooling ask while running kitchen-sink.

- **`just servers-restart`** — down then up (+ tail), so bouncing the servers is one command instead of `servers-down` + `servers-up`.
- **`just servers-up` now tails** the server logs after the detached start, so you can watch them come up. Guarded on a tty (`[ -t 1 ]`) so a piped/CI `up` stays fire-and-forget; Ctrl+C stops watching and the detached servers keep running.
- Factored `tail_logs` out of `up-fg`; `up-fg` keeps its distinct behavior (Ctrl+C brings the servers **down**).

Example scripts only. `bash -n` clean; `just --list` shows the new recipes.

## Before / after
```
before:  just servers-down && just servers-up   (two commands; up returns immediately, no logs)
after:   just servers-restart                   (one command, then tails)
         just servers-up                         (starts detached, then tails; Ctrl+C leaves them up)
```