### PR TITLE
chore(kitchen-sink): servers-up foreground by default; add servers-up-bg

### DIFF
--- a/examples/agents/kitchen-sink/README.md
+++ b/examples/agents/kitchen-sink/README.md
@@ -32,7 +32,7 @@ flag, because it is a separate endpoint from the chat model.
 `kitchen-sink.json` connects to four servers, and the host is a **pure client**:
 it connects to them by URL, it does not manage them. Their lifecycle is
 decoupled from the agent (root `CONSTRAINTS.md` C6) — you start them once with
-`just servers-up` and they survive chat restarts. This mirrors an
+`just servers-up-bg` and they survive chat restarts. This mirrors an
 `.mcp.json`-style connect-list.
 
 | Server | Port | Serves | Why |
@@ -50,19 +50,19 @@ ride the approval ladder).
 Manage the servers independently of the chat:
 
 ```bash
-just servers-up            # start all four (detached), then tail logs; Ctrl+C leaves them running
-just servers-restart       # down then up (+ tail) — bounce them without two commands
-just servers-up-fg         # like servers-up, but Ctrl+C brings the servers DOWN
+just servers-up            # start + tail all four in the FOREGROUND; Ctrl+C brings them down
+just servers-up-bg         # start detached, no tail — they survive restarts (stop with servers-down)
+just servers-restart       # down then up (foreground + tail) — bounce them in one command
 just servers               # status: which are up
-just servers-up events     # start just one
+just servers-up-bg events  # start just one, detached
 just servers-down          # stop all
 ```
 
-`servers-up` and `servers-restart` tail the logs at the end so you can watch the
-servers come up; Ctrl+C stops watching and the detached servers keep running.
-Run `just run` (agentchat) in a **second** terminal — the inline TUI and the
-interleaved logs would fight for the same screen otherwise. (`servers-up-fg` is
-the ephemeral variant: Ctrl+C stops the servers too.)
+`servers-up` (and `servers-restart`) run the servers in the **foreground** and
+tail their logs, so this terminal owns them — Ctrl+C brings them down. Run
+`just run` (agentchat) in a **second** terminal (the inline TUI and the
+interleaved logs would fight for the same screen). For a fire-and-forget start
+that survives restarts and needs no dedicated terminal, use `servers-up-bg`.
 
 `just run` only *checks* these ports and tells you to `just servers-up` if any
 are down — it never boots or kills them. Having the agent spawn them from the
@@ -89,15 +89,19 @@ already owns stdio subprocess lifecycle, only the config surface is missing.
 Three layers, brought up separately (backends → MCP servers → agent):
 
 ```bash
-just allup      # postgres+pgvector + observability stacks
-just servers-up # the four MCP servers (independent of the chat)
-just check      # probe backends; prints how to fix whatever is down
-just run        # preflight, verify servers are up, launch agentchat (inline TUI)
-just note       # same, but the alt-screen notebook UI (scrollable, foldable cells)
+just allup        # postgres+pgvector + observability stacks
+just servers-up-bg # the four MCP servers, detached (independent of the chat)
+just check        # probe backends; prints how to fix whatever is down
+just run          # preflight, verify servers are up, launch agentchat (inline TUI)
+just note         # same, but the alt-screen notebook UI (scrollable, foldable cells)
 # ... chat, quit, `just run` again — the servers are still up ...
 just servers-down  # stop the MCP servers
 just alldown       # tear the stacks back down
 ```
+
+`servers-up-bg` here starts the servers detached so this same terminal can go on
+to `just run`. Prefer `just servers-up` in a dedicated terminal when you want to
+watch the server logs live (Ctrl+C there brings the servers down).
 
 `just run` fails fast if postgres is down (the config depends on it) or if any
 MCP server is unreachable (it tells you to `just servers-up`), and warns if

--- a/examples/agents/kitchen-sink/justfile
+++ b/examples/agents/kitchen-sink/justfile
@@ -97,15 +97,15 @@ mem:
 # These run independently of agentchat and survive chat restarts. `just run`
 # only checks they are up; it never starts or stops them.
 
-# Start the MCP servers (detached) + tail logs; Ctrl+C leaves them running. Or: `just servers-up demo`.
+# Start + tail the MCP servers in the FOREGROUND; Ctrl+C brings them down. Or: `just servers-up demo`.
 servers-up name="":
     @bash servers.sh up {{name}}
 
-# Like servers-up, but Ctrl+C brings the servers DOWN (foreground lifetime).
-servers-up-fg name="":
-    @bash servers.sh up-fg {{name}}
+# Start the servers detached (no tail); they survive restarts. Stop with servers-down.
+servers-up-bg name="":
+    @bash servers.sh up-bg {{name}}
 
-# Restart the servers (down then up), then tail their logs. Or one: `just servers-restart demo`.
+# Restart the servers (down then up), foreground + tail. Or one: `just servers-restart demo`.
 servers-restart name="":
     @bash servers.sh restart {{name}}
 

--- a/examples/agents/kitchen-sink/run.sh
+++ b/examples/agents/kitchen-sink/run.sh
@@ -48,8 +48,8 @@ for probe in demo:8788 runbooks:8789 community:8790 events:8791; do
 done
 if [ -n "$down" ]; then
 	echo "MCP server(s) not reachable:$down" >&2
-	echo "  -> start them first:  just servers-up      (they run independently of the chat)" >&2
-	echo "     or just one:        just servers-up demo" >&2
+	echo "  -> start them first:  just servers-up-bg   (detached, so this terminal can run the chat)" >&2
+	echo "     or watch logs:     just servers-up      (foreground, in a separate terminal)" >&2
 	# Until the agent connects asynchronously (idea 2), a down server fails the
 	# launch, so stop here with a clear message instead of an opaque connect error.
 	exit 1

--- a/examples/agents/kitchen-sink/servers.sh
+++ b/examples/agents/kitchen-sink/servers.sh
@@ -7,9 +7,9 @@
 # started here, survive agentchat restarts, and are torn down explicitly.
 #
 # Usage:
-#   servers.sh up      [name]   # build + start detached, then tail logs (Ctrl+C leaves them up)
-#   servers.sh up-fg   [name]   # start + tail; Ctrl+C brings the servers DOWN
-#   servers.sh restart [name]   # down then up (+ tail)
+#   servers.sh up      [name]   # start + tail in the FOREGROUND (Ctrl+C brings them down)
+#   servers.sh up-bg   [name]   # start detached, no tail (fire-and-forget; survives restarts)
+#   servers.sh restart [name]   # down then up (foreground + tail)
 #   servers.sh down    [name]   # stop all (or just <name>)
 #   servers.sh status  [name]   # probe ports; show up/down
 #
@@ -100,14 +100,22 @@ tail_logs() {
 	tail -n +1 -F $logs
 }
 
-# up_fg starts the servers and tails their logs in the FOREGROUND, but Ctrl+C
-# brings the servers DOWN — this window owns their lifetime, unlike `up` (where
-# Ctrl+C only stops watching and the detached servers keep running).
-up_fg() {
+# start_fg is the default `up`: start the servers (reliable detached start +
+# pidfiles) and tail their logs in the FOREGROUND. Ctrl+C brings the servers
+# DOWN — this window owns their lifetime. Run agentchat in a SEPARATE terminal.
+start_fg() {
 	local n
-	trap 'echo; echo "==> stopping servers (foreground window closed)"; for n in $names; do down_one "$n"; done; exit 0' INT TERM
+	trap 'echo; echo "==> stopping servers (window closed)"; for n in $names; do down_one "$n"; done; exit 0' INT TERM
 	for n in $names; do up_one "$n" || true; done
 	tail_logs
+}
+
+# start_bg starts the servers detached and returns immediately (no tail). The
+# servers keep running after this command exits and survive agentchat restarts;
+# stop them with `down`. Use this to fire-and-forget or from a script.
+start_bg() {
+	local n
+	for n in $names; do up_one "$n"; done
 }
 
 cmd="${1:-status}"
@@ -115,20 +123,11 @@ target="${2:-}"
 names="$ORDER"
 [ -n "$target" ] && names="$target"
 
-# watch tails the logs after an up/restart when stdout is a terminal (Ctrl+C
-# stops watching; the detached servers keep running). Skipped for pipes/CI so a
-# non-interactive `up` stays fire-and-forget.
-watch_after_up() {
-	[ -t 1 ] || return 0
-	echo "==> servers running detached — Ctrl+C stops watching (they keep running)"
-	tail_logs
-}
-
 case "$cmd" in
-up)      for n in $names; do up_one "$n"; done; watch_after_up ;;
-up-fg)   up_fg ;;
-restart) for n in $names; do down_one "$n"; done; for n in $names; do up_one "$n"; done; watch_after_up ;;
+up)      start_fg ;;
+up-bg)   start_bg ;;
+restart) for n in $names; do down_one "$n"; done; start_fg ;;
 down)    for n in $names; do down_one "$n"; done ;;
 status)  echo "kitchen-sink MCP servers"; for n in $names; do status_one "$n"; done ;;
-*) echo "usage: servers.sh <up|up-fg|restart|down|status> [name]" >&2; exit 2 ;;
+*) echo "usage: servers.sh <up|up-bg|restart|down|status> [name]" >&2; exit 2 ;;
 esac


### PR DESCRIPTION
Follow-up to the earlier servers ergonomics change.

- **`just servers-up` is now foreground** (start + tail; Ctrl+C brings the servers down — the terminal owns their lifetime). This is the common interactive flow: watch the servers come up.
- **New `just servers-up-bg`** — start detached, no tail (fire-and-forget; survives agentchat restarts, stop with `servers-down`).
- Dropped the now-redundant `servers-up-fg` (it was `up` foreground; that is `servers-up` now).
- The quick-start and the `run.sh` "servers are down" hint use `servers-up-bg`, so a single terminal can start the servers and go on to `just run`.

Example scripts only; `bash -n` clean, `just --list` shows the recipes.