### PR TITLE
test(agent/host): oauth login flow e2e + WithBrowserOpener seam (1123)

### DIFF
--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -130,6 +130,15 @@ type appOptions struct {
 	observers       []Observer
 	configPath      string
 	promptMutate    func(*SystemPromptBuilder)
+	browserOpener   func(string) error
+}
+
+// WithBrowserOpener overrides how the interactive (oauth) auth type opens the
+// authorization URL. Nil (the default) uses the platform browser. A headless or
+// kiosk deployment injects its own launcher; a test injects a scripted
+// redirect-follower so the authorization-code flow runs without a real browser.
+func WithBrowserOpener(fn func(string) error) AppOption {
+	return func(o *appOptions) { o.browserOpener = fn }
 }
 
 // WithSystemPromptBuilder customizes per-turn system-prompt assembly. The
@@ -301,7 +310,7 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 			client.WithToolsListChangedHandler(multi.Invalidate),
 			client.WithTracerProvider(o.tp),
 		}
-		authOpt, loginSrc, err := authOption(sc)
+		authOpt, loginSrc, err := authOption(sc, o.browserOpener)
 		if err != nil {
 			app.Close()
 			return nil, err

--- a/agent/host/auth.go
+++ b/agent/host/auth.go
@@ -16,7 +16,7 @@ import (
 // a loginSource so the host can force a fresh login later; the other types
 // return a nil loginSource. Config validation has already checked env presence;
 // this only assembles.
-func authOption(sc ServerConfig) (client.ClientOption, loginSource, error) {
+func authOption(sc ServerConfig, opener func(string) error) (client.ClientOption, loginSource, error) {
 	if sc.Auth == nil {
 		return nil, nil, nil
 	}
@@ -26,7 +26,7 @@ func authOption(sc ServerConfig) (client.ClientOption, loginSource, error) {
 	case "client-credentials":
 		return client.WithTokenSource(clientCredentialsSource(sc)), nil, nil
 	case "oauth":
-		src := oauthSource(sc)
+		src := oauthSource(sc, opener)
 		return client.WithTokenSource(src), src, nil
 	default:
 		return nil, nil, fmt.Errorf("agentchat: server %s: unsupported auth type %q", sc.ID, sc.Auth.Type)
@@ -37,11 +37,15 @@ func authOption(sc ServerConfig) (client.ClientOption, loginSource, error) {
 // self-registers via DCR when no client is pre-registered, else pins the
 // client from clientIdEnv (+ optional clientSecretEnv). Scopes stay empty by
 // default so acquisition follows the server's 401 WWW-Authenticate challenge.
-func oauthSource(sc ServerConfig) *extauth.OAuthTokenSource {
+// opener overrides how the authorization URL is opened; nil uses the platform
+// default browser (WithBrowserOpener injects a custom one — a headless launcher
+// or, in tests, a scripted redirect-follower).
+func oauthSource(sc ServerConfig, opener func(string) error) *extauth.OAuthTokenSource {
 	s := &extauth.OAuthTokenSource{
 		ServerURL:     sc.URL,
 		Scopes:        sc.Auth.Scopes,
 		AllowInsecure: sc.Auth.AllowInsecure,
+		OpenBrowser:   opener,
 	}
 	if sc.Auth.ClientIDEnv != "" {
 		s.ClientID = os.Getenv(sc.Auth.ClientIDEnv)

--- a/agent/host/auth_test.go
+++ b/agent/host/auth_test.go
@@ -110,7 +110,7 @@ func TestClientCredentialsWiring(t *testing.T) {
 	if len(src.Scopes) != 1 || src.Scopes[0] != "mcp:basic" || !src.AllowInsecure {
 		t.Fatalf("wiring: %+v", src)
 	}
-	if opt, ls, err := authOption(sc); err != nil || opt == nil || ls != nil {
+	if opt, ls, err := authOption(sc, nil); err != nil || opt == nil || ls != nil {
 		t.Fatalf("authOption: opt=%v loginSource=%v err=%v", opt, ls, err)
 	}
 }
@@ -122,18 +122,18 @@ func TestAuthOption_OAuthBuildsLoginSource(t *testing.T) {
 		ClientIDEnv: "OA_CLIENT",
 		Scopes:      []string{"mcp:read"},
 	}}
-	opt, ls, err := authOption(sc)
+	opt, ls, err := authOption(sc, nil)
 	if err != nil || opt == nil || ls == nil {
 		t.Fatalf("authOption(oauth): opt=%v loginSource=%v err=%v", opt, ls, err)
 	}
 
 	// inspect the env-to-field wiring on the concrete source
-	src := oauthSource(sc)
+	src := oauthSource(sc, nil)
 	if src.ServerURL != sc.URL || src.ClientID != "cid-123" || src.EnableDCR {
 		t.Fatalf("pinned-client wiring: %+v", src)
 	}
 	// no clientIdEnv → self-register via DCR
-	dcr := oauthSource(ServerConfig{URL: sc.URL, Auth: &AuthConfig{Type: "oauth"}})
+	dcr := oauthSource(ServerConfig{URL: sc.URL, Auth: &AuthConfig{Type: "oauth"}}, nil)
 	if !dcr.EnableDCR || dcr.ClientID != "" {
 		t.Fatalf("DCR fallback wiring: %+v", dcr)
 	}

--- a/agent/host/go.mod
+++ b/agent/host/go.mod
@@ -11,9 +11,11 @@ require (
 	github.com/panyam/mcpkit/ext/auth v0.0.0
 	github.com/panyam/mcpkit/ext/skills v0.0.0
 	github.com/panyam/mcpkit/ext/tasks v0.0.0
+	github.com/panyam/oneauth v0.1.36
 )
 
 require (
+	github.com/alexedwards/scs/v2 v2.8.0 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
@@ -24,7 +26,6 @@ require (
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/invopop/jsonschema v0.14.0 // indirect
 	github.com/panyam/goutils v0.1.8 // indirect
-	github.com/panyam/oneauth v0.1.36 // indirect
 	github.com/panyam/servicekit v0.1.2 // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/agent/host/oauth_login_e2e_test.go
+++ b/agent/host/oauth_login_e2e_test.go
@@ -1,0 +1,179 @@
+package host
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/panyam/mcpkit/agent"
+	"github.com/panyam/mcpkit/core"
+	extauth "github.com/panyam/mcpkit/ext/auth"
+	"github.com/panyam/mcpkit/server"
+	oneauthclient "github.com/panyam/oneauth/client"
+	"github.com/panyam/oneauth/testutil"
+)
+
+// authGatedServer stands up a oneauth test authorization server (which
+// auto-approves the PKCE authorization-code flow) plus an mcpkit MCP server that
+// validates the AS's JWTs and advertises PRM + a 401 challenge. Together they
+// let the agentchat oauth auth type discover the AS and complete a real login
+// against it — no browser, no Docker. Returns the MCP server URL (base, no /mcp).
+func authGatedServer(t *testing.T) string {
+	t.Helper()
+
+	// Delegating handler: the auth middleware needs the server URL, which is
+	// only known after httptest allocates it.
+	var handler http.Handler
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if handler == nil {
+			http.Error(w, "not ready", http.StatusServiceUnavailable)
+			return
+		}
+		handler.ServeHTTP(w, r)
+	}))
+	t.Cleanup(ts.Close)
+
+	as := testutil.NewTestAuthServer(t,
+		testutil.WithAuthorizeEnabled(true),
+		testutil.WithAuthorizeAutoApproveSubject("kitchen-user"),
+		testutil.WithScopes([]string{"mcp:basic"}),
+		testutil.WithAudience(ts.URL),
+	)
+
+	validator := extauth.NewJWTValidator(extauth.JWTConfig{
+		JWKSURL:             as.JWKSURL(),
+		Issuer:              as.Issuer(),
+		Audience:            ts.URL,
+		ResourceMetadataURL: ts.URL + "/.well-known/oauth-protected-resource/mcp",
+		AllScopes:           []string{"mcp:basic"},
+	})
+	validator.Start()
+	t.Cleanup(validator.Stop)
+
+	srv := server.NewServer(
+		core.ServerInfo{Name: "oauth-login-e2e", Version: "0.1.0"},
+		server.WithAuth(validator),
+		server.WithExtension(extauth.AuthExtension{}),
+	)
+	srv.RegisterTool(
+		core.ToolDef{
+			Name:        "whoami",
+			Description: "returns the authenticated subject (no scope required)",
+			InputSchema: json.RawMessage(`{"type":"object"}`),
+		},
+		func(ctx core.ToolContext, _ core.ToolRequest) (core.ToolResponse, error) {
+			sub := ""
+			if c := core.AuthClaims(ctx); c != nil {
+				sub = c.Subject
+			}
+			return core.TextResult("hello " + sub), nil
+		},
+	)
+
+	mux := http.NewServeMux()
+	mcpHandler := srv.Handler(server.WithStreamableHTTP(true))
+	mux.Handle("/mcp", mcpHandler)
+	mux.Handle("/mcp/", mcpHandler)
+	extauth.MountAuth(mux, extauth.AuthConfig{
+		ResourceURI:          ts.URL,
+		AuthorizationServers: []string{as.URL()},
+		ScopesSupported:      []string{"mcp:basic"},
+		MCPPath:              "/mcp",
+	})
+	handler = mux
+	return ts.URL
+}
+
+func waitServerState(t *testing.T, app *App, id, want string, within time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	var last string
+	for time.Now().Before(deadline) {
+		res, err := app.Dispatch(context.Background(), "/servers")
+		if err == nil {
+			for _, s := range res.Servers {
+				if s.ID == id {
+					last = s.State.String()
+					if last == want {
+						return
+					}
+				}
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("server %q did not reach %q within %s (last=%q)", id, want, within, last)
+}
+
+// TestOAuthLoginFlowE2E is the end-to-end acceptance for issue 1123: an
+// agentchat server configured with the interactive oauth auth type, driven
+// through the real PKCE authorization-code flow against oneauth's test AS. The
+// first login attempt is dismissed (opener errors), so the server parks at
+// needs-login; App.LoginServer (the /mcp overlay's login action) forces a fresh
+// flow that completes, the server reaches ready, and its tool becomes callable
+// with the acquired token.
+func TestOAuthLoginFlowE2E(t *testing.T) {
+	mcpURL := authGatedServer(t)
+
+	var mu sync.Mutex
+	attempts := 0
+	// The browser opener: the first call (initial connect) fails as if the user
+	// dismissed the login; later calls complete the flow by following the AS's
+	// redirects (the test AS auto-approves), as a headless browser stand-in.
+	opener := func(authURL string) error {
+		mu.Lock()
+		attempts++
+		n := attempts
+		mu.Unlock()
+		if n == 1 {
+			return errors.New("simulated: user dismissed the login")
+		}
+		return oneauthclient.FollowRedirects(nil)(authURL)
+	}
+
+	// Pin a public client id (the test AS accepts an arbitrary public client for
+	// the PKCE flow) rather than DCR, which the test AS does not serve.
+	t.Setenv("OAUTH_E2E_CLIENT", "test-cli")
+	cfg := testConfig(mcpURL) // one server at mcpURL+"/mcp", id "test"
+	cfg.Servers[0].Auth = &AuthConfig{Type: "oauth", ClientIDEnv: "OAUTH_E2E_CLIENT", AllowInsecure: true}
+
+	var out strings.Builder
+	app, err := NewApp(cfg, &out, strings.NewReader(""),
+		WithProvider(agent.NewStubProvider()),
+		WithBrowserOpener(opener))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Close()
+
+	id := cfg.Servers[0].ID
+
+	// initial connect: the dismissed login leaves the server at needs-login
+	waitServerState(t, app, id, "needs-login", 15*time.Second)
+
+	// the /mcp login action: force a fresh flow, which now completes
+	app.LoginServer(id)
+	waitServerState(t, app, id, "ready", 15*time.Second)
+
+	// the authed connection is real: the server's tool lists with the token
+	defs, found, err := app.ServerTools(context.Background(), id)
+	if err != nil || !found {
+		t.Fatalf("ServerTools after login: found=%v err=%v", found, err)
+	}
+	if len(defs) != 1 || defs[0].Name != "whoami" {
+		t.Fatalf("expected the whoami tool after login, got %+v", defs)
+	}
+
+	mu.Lock()
+	got := attempts
+	mu.Unlock()
+	if got < 2 {
+		t.Fatalf("login did not re-run the browser flow (opener attempts=%d, want >=2)", got)
+	}
+}


### PR DESCRIPTION
## What changes

End-to-end acceptance for agentchat's interactive `oauth` auth type and `App.LoginServer` (the `/mcp` overlay's login action), driven through the **real PKCE authorization-code flow** against oneauth's in-process test authorization server — no browser, no Docker, runs in normal CI (issue 1123, option A).

Adds one small production seam — `WithBrowserOpener` — that injects how the oauth auth type opens the authorization URL, so a test can substitute a scripted redirect-follower for the platform browser.

## Reviewer's guide
1. [agent/host/auth.go](https://github.com/panyam/mcpkit/pull/1136/files#diff-e26cea84c1f3e8fb9b881271ecdba4b6054cbc902ba56c0701cbeff1c9e9f4fc) — start here. `oauthSource` now sets `OpenBrowser` from an injected opener; `authOption` threads it.
2. [agent/host/app.go](https://github.com/panyam/mcpkit/pull/1136/files#diff-89fb8e04b6e1e9d5f7f76958490ef158dee40e2cae92d87c04b408d893c84361) — the `WithBrowserOpener(func(string) error)` option + `appOptions.browserOpener`, wired into the per-server client build.
3. [agent/host/oauth_login_e2e_test.go](https://github.com/panyam/mcpkit/pull/1136/files#diff-6e20241748bf2d65b3e60e1699f6161532b5d730ccfe38a7ae5299c7fe943c21) — `authGatedServer` (oneauth test AS + a JWT-validating mcpkit server with PRM + 401) and `TestOAuthLoginFlowE2E` (the needs-login → login → ready → tool-call acceptance).
4. [agent/host/go.mod](https://github.com/panyam/mcpkit/pull/1136/files#diff-17b979ed30050ebd0770bcff5dd3333d0dd701d7fc6b3547170e71266f4e920d) — `oneauth` promoted to a direct dep (test uses `oneauth/testutil` + `oneauth/client`).

Skim: [agent/host/auth_test.go](https://github.com/panyam/mcpkit/pull/1136/files#diff-5768b2ed6e9ca219bbebdd5ac0a511a91c781da87e163768fe007f0332f8a756) (mechanical — existing calls gain a `nil` opener arg).

## How it works (the flow the test drives)
```
App boot: oauth server connects → 401 → source arms → Token() → OpenBrowser(authURL)
          [attempt 1: opener returns error, "user dismissed"] → ClientAuthError → needs-login

App.LoginServer(id):  src.Invalidate() + Reconnect
          → connect → 401 → Token() → OpenBrowser(authURL)
          [attempt 2: FollowRedirects auto-approves via the test AS] → code → token
          → retry initialize with token → 200 → ready

assert: server state == ready; App.ServerTools lists "whoami" (real authed MCP call);
        opener called >= 2 (the flow actually re-ran, not a stub)
```

## Decision log
- **Injected opener seam, not a test-only global.** `WithBrowserOpener` is a real config seam (headless/kiosk deployments want a custom launcher too); tests reuse it, so no test-only hooks in production code.
- **Stateful opener (fail-then-succeed) to exercise the login action.** With a working opener, the *initial* connect completes the flow and the server never sits at needs-login — so the login action wouldn't be tested. Failing the first attempt parks it at needs-login, and `LoginServer` drives the real recovery.
- **Pinned public client id, not DCR.** The oneauth test AS accepts an arbitrary public client for the PKCE flow but does not serve dynamic client registration, so the test sets `clientIdEnv` (matches how the ext/auth lazy-token tests wire it).
- **oneauth test AS, not Keycloak.** Same `OAuthTokenSource`/`LoginServer` path, in-process, CI-friendly. Keycloak (real IdP, Docker-gated) is the optional fidelity follow-up.

## Risk / blast radius
- Affects: `agent/host` (a new additive option + the oauth source now honors an opener; default `nil` = platform browser, unchanged behavior). No protocol/provider change.
- Tests: `TestOAuthLoginFlowE2E` (new, in-process, no Docker). Existing `auth_test.go` unchanged in intent (added `nil` args). Added assertions: the e2e; weakened: 0.
- Be paranoid about: the flow is exercised via `oneauth/testutil` (in-process) — the real browser path is not run in CI (that's the platform default, unchanged); coverage is the seam + the AS-round-trip.

## Out of scope (follow-up)
- **Keycloak-fixture variant (option B)** — same test against the real Keycloak IdP, where the redirect-follower must POST Keycloak's HTML login form; Docker-gated `skipIfKeycloakNotRunning`. Will file as a follow-up.

