### PR TITLE
docs(roadmap): oh-my-pi coding-agent re-survey (§4a)

### DIFF
--- a/docs/AGENT_SDK_ROADMAP.md
+++ b/docs/AGENT_SDK_ROADMAP.md
@@ -2,7 +2,7 @@
 
 **What this is.** A living assessment of the mcpkit `agent/` host layer against (a) general agent
 frameworks (Mastra, Eino, Genkit-Go, langchaingo, swarmgo, agno-Go) and (b) real coding-agent loops
-(Claude Code, Cursor, Gemini CLI, aider, Codex, OpenCode). The first edition (below the fold) framed
+(Claude Code, Cursor, Gemini CLI, aider, Codex, OpenCode, and the Pi / oh-my-pi line). The first edition (below the fold) framed
 these as "what would it take to build a complete agent SDK." **Most of that roadmap has now shipped**
 — this edition re-baselines to *where we actually stand* and *what is genuinely still missing*,
 distinguishing **tracked** gaps (open issues) from **untracked** ones.
@@ -33,6 +33,15 @@ guardrails** (#1052: prompt-injection spotlighting #1058). The items the previou
 **promoted to tracked phase children** — see §5a. Nothing identified is left untracked (the two opt-in
 Phase-7 extensions are now filed as #1060/#1061). Beyond the phases, a rich refinement backlog on the
 shipped primitives remains (mostly tracked).
+
+**Coding-agent re-survey (2026-07).** A pass over the strongest current open coding agent, oh-my-pi
+(`can1357/oh-my-pi`, a TS+Rust batteries-included fork of Pi), confirms the picture and surfaces two
+genuinely new **agent-layer** primitives we lack — **mid-turn stream-rule steering** (#1147) and a
+**critic/observer model role** (#1148) — now filed. The rest of that product's moat (hash-anchored edit
+format, LSP-in-writes, DAP, a ~55k-LoC in-process Rust tool core, browser) is the **coding-surface**
+layer we deliberately scope to a coding agent built *on* `agent/`, not `agent/` itself (#1059). It is
+the clearest evidence yet that #1059 is a real decision, and that harness/tool quality is a first-order
+differentiator. See §4.
 
 ---
 
@@ -103,6 +112,54 @@ lifecycle **hooks** (PreToolUse/PostToolUse), **sandboxing** of tool execution, 
 **LSP-in-loop**, and a soft **tool-call budget gate**. These are coding-*surface* features; whether
 they belong in `agent/` or in a coding-agent built on it is a scoping decision (see §5).
 
+### 4a. The coding-agent field, re-surveyed against oh-my-pi
+
+Two related things share the name. **Pi** (pi.dev, `@earendil-works/pi-coding-agent`, `badlogic/pi-mono`,
+Mario Zechner / Earendil Inc.) is the *minimal upstream* harness — "many agent harnesses but this one is
+yours," four modes (TUI/print/RPC/SDK), tree-structured history, mid-session steering — and it
+**deliberately omits MCP, sub-agents, permission popups, plan mode, todos, and background bash**, leaving
+them as extension points. **oh-my-pi** (`can1357/oh-my-pi`, Can Bölük) is a TS+Rust, batteries-included
+**fork** that *adds* exactly what Pi omits — MCP, 32 tools, subagents, LSP/DAP, the hash-anchored edit
+format, a ~55k-LoC Rust core — and is currently the most feature-complete *open* coding-agent surface.
+
+The pairing is instructive for us in two ways. First, **Pi is the closer philosophical peer to
+`agent/`** (a lean, embeddable, extension-first harness with the same four surfaces), while oh-my-pi is
+precisely the *coding agent built on top* — the #1059 shape. Second, **mcpkit is already ahead of
+upstream Pi on MCP-native operation and sub-agents**: Pi omits both by design; the fork had to bolt them
+on, and MCP is one integration among many rather than the native fabric. So the comparison below is
+really against oh-my-pi *the product*, on the coding-agent axis (Claude Code / Cursor), not against a
+Mastra/Eino-style library.
+
+oh-my-pi's explicit thesis — *the harness, not the model, decides* — is worth taking seriously: it
+reports multi-fold first-attempt-edit and token-efficiency lifts on the *same weights* purely from a
+better edit format and tool ergonomics. That validates our tool-layer investment, but it also draws the
+line sharply: **`agent/` ships no tool implementations at all** (it is the SDK substrate), so most of
+what makes that product good is the coding-*surface* layer we scope to #1059.
+
+Mapping its surface onto our status and the A6 layering line:
+
+| oh-my-pi capability | Nature | mcpkit `agent/` status |
+|---|---|---|
+| Hash-anchored edit format (content-hash anchors, stale-anchor reject) | coding-surface | out of SDK scope → **#1059** (the SDK has no edit tool; a coding agent built on it would) |
+| LSP-in-writes (rename via `willRenameFiles`), DAP debugger, AST edits | coding-surface | out of scope → **#1059** |
+| ~55k-LoC in-process Rust core (ripgrep/glob/shell/PTY/AST, no fork-exec) | coding-surface / perf | out of scope → **#1059**; `agent/` is provider+loop, transport-agnostic by design |
+| Browser / computer-use, web_search, GitHub-as-filesystem, `://` resource schemes | coding-surface | out of scope → tool authoring on top of the SDK |
+| **Mid-turn stream-rule steering** (regex/AST over the *output* stream → abort → inject rule → retry within the turn; fired-state survives compaction) | **agent-layer** | **not shipped → newly filed #1147.** Our injection is turn-boundary only; the delta scanner (#989) is the hook |
+| **Critic/observer model** (second model on its own context reviews each turn, injects graded steering: aside/concern/blocker; cannot approve/deny) | **agent-layer** | **not shipped → newly filed #1148.** Composable on Observer #992 + AgentSource #941 + Control #936, but not a role yet |
+| Deterministic image-frame compaction ("snapcompact" — renders discarded history to per-model-sized PNG frames to exploit image-token billing) | agent-layer (novel) | we have `SummarizingCompactor` (#939); this is an exotic provider-billing optimization, noted under compaction depth #1006/#1007, not a parity gap |
+| Subagents: agent-as-tool with **schema-validated structured results** (3-level schema precedence), per-agent model/tool/depth, peer **hub** for inter-agent messaging | agent-layer | **at rough parity behind tracked gaps** — AgentSource #941, per-Runner provider, MaxDepth/budget; structured I/O + fan-out #1033; peer messaging ≈ upward-signals #1036 |
+| Memory: pluggable SQLite backends, first-turn recall injection, periodic retain, **offline cross-session consolidation into a "mental model" loaded on turn 1**, polyphonic (vector/graph/fact/temporal) recall | agent-layer | **at rough parity behind tracked gaps** — MemorySource #938, semantic recall #940/#1019, injection #1011; consolidation = auto-distillation #1022; multi-signal recall = reranker #1020; durable backends #1003 |
+| Provider routing: per-role models, path-scoped model sets, fallback chains, round-robin credentials | agent-layer | **they ship what we have tracked** — only `FailoverProvider` today; per-role/path routing is #991, presets #1044 |
+| ACP surface (editor-drivable), RPC (NDJSON stdio), collab live-share | surface | ACP is a notable coding-surface integration we do not have; collab is out of scope |
+
+**Reading of it.** On the *loop* primitives — memory, compaction, multi-agent, structured output — we
+are at or behind-by-a-tracked-issue, not behind in kind. Two real agent-layer gaps came out of the pass
+(#1147, #1148) and are filed. Everything else that makes the product impressive is coding-surface or
+provider-routing-we-have-scheduled. The strategic signal is not "we are behind on the SDK"; it is that
+**the coding-surface layer (#1059) is where a large share of end-user value lives**, and a product-grade
+coding agent on top of `agent/` is the thing that would actually compete — the SDK is necessary but not
+sufficient.
+
 ---
 
 ## 5. What's still missing
@@ -139,6 +196,10 @@ they belong in `agent/` or in a coding-agent built on it is a scoping decision (
 - **Eval:** external eval/conformance adapter seam #1015 (see §6), real LongMemEval loader #1014.
 - **Ops:** RunStore retention/GC #999, large/binary tool results #980/#979,
   thinking-hint stream parser #989, session-picker paging #1000. (OTel metrics seam #1023 shipped.)
+- **Mid-turn steering & critique (from the coding-agent re-survey, §4a):** stream-rule steering —
+  scan the output stream, abort/inject/retry within the turn #1147 (builds on the #989 scanner); a
+  first-class critic/observer model role that injects graded steering #1148 (composable on Observer
+  #992 + AgentSource #941 + Control #936). Both are agent-layer, A6-clean.
 
 ### 5b. Untracked (no issue yet)
 
@@ -146,7 +207,9 @@ Nothing. The six gaps this section previously listed — logprob exposure, gramm
 sampling/vote helper, the prompt-injection guardrail, the `FailoverProvider` quality-score trigger, and
 the coding-surface scoping call — are now tracked phase children (Phases 5–7 and #1059; see §5a), and
 the two Phase-7 extensions (AgentDojo eval suite #1060, constitutional critique gate #1061) have been
-filed. Everything identified is tracked; new gaps get filed as they surface.
+filed. The 2026-07 coding-agent re-survey (§4a) surfaced two further agent-layer gaps — mid-turn
+stream-rule steering and a critic/observer model role — and they were filed on discovery as #1147 and
+#1148. Everything identified is tracked; new gaps get filed as they surface.
 
 ---
 


### PR DESCRIPTION
## What changes

A docs-only update to `docs/AGENT_SDK_ROADMAP.md`: a re-survey of the strongest current open coding agent, oh-my-pi (a TS+Rust batteries-included fork of Pi), against `agent/`.

- Folds the Pi / oh-my-pi line into the intro's coding-agent list.
- Adds a "Coding-agent re-survey (2026-07)" callout under §1.
- Adds §4a with a capability-by-capability mapping table, tagging each row as agent-layer vs coding-surface against the A6 layering line.

## Findings recorded

- Two genuinely new **agent-layer** gaps came out of the pass and are filed: mid-turn stream-rule steering (1147) and a critic/observer model role (1148).
- Everything else in that product's moat (hash-anchored edit format, LSP-in-writes, DAP, the ~55k-LoC Rust tool core, browser) is the **coding-surface** layer scoped to a coding agent built on `agent/`, tracked as 1059.
- Strategic reading: on the loop primitives (memory, compaction, multi-agent, structured output) mcpkit is at or behind-by-a-tracked-issue, not behind in kind; the coding-surface layer is where the end-user value concentrates.

## Reviewer's guide

Single file, prose + one table. Read [docs/AGENT_SDK_ROADMAP.md](https://github.com/panyam/mcpkit/pull/1149/files#diff-b47a95c62c074f4804e598fe49dae1ba6dac14d094a3821bd3211222a3570501) §1 callout and §4a. No code, no behavior change.
