### PR TITLE
feat(agent/host): session-scope working memory by run id (1140)

### DIFF
--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	gocurrent "github.com/panyam/gocurrent"
 	"github.com/panyam/mcpkit/agent"
@@ -47,6 +48,10 @@ type App struct {
 	// server's skills with the same instrumentation as the boot path.
 	tp core.TracerProvider
 
+	// log is the operational slog logger (WithLogger; discards by default),
+	// held for construction-time and lifecycle warnings.
+	log *slog.Logger
+
 	// Skills load in the ready-observer (late servers too), so their prompt
 	// blocks and load_skill catalog are shared mutable state read live: the
 	// dynamic system prompt (buildInstructions -> RunnerConfig.InstructionsFunc)
@@ -74,9 +79,16 @@ type App struct {
 
 	// store and runID are the persistence seam (WithRunStore): runID is
 	// the run turns append to, created lazily on the first persisted
-	// turn or set by AttachRun / Resume / Fork. Guarded by turnMu.
+	// turn or set by AttachRun / Resume / Fork. Guarded by turnMu; write
+	// through setRunID so runIDAtomic stays in sync.
 	store agent.RunStore
 	runID string
+
+	// runIDAtomic mirrors runID for a lock-free read (currentRunID). The
+	// session-scoped memory namespace func reads it during a turn while
+	// turnMu is already held, so it must NOT go through RunID (which takes
+	// turnMu and would deadlock). Written under turnMu via setRunID.
+	runIDAtomic atomic.Value
 
 	// sessionsMu guards sessionsCursor, the paging position the /sessions
 	// picker remembers so "/sessions more" advances (the store cursor is
@@ -277,7 +289,7 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 
 	multi := agent.NewMultiSource()
 	app := &App{cfg: cfg, sources: multi, observers: observers, replOut: out, bgTasks: map[string]*client.BackgroundTask{}, subs: map[string]*subscription{}, store: o.store,
-		tp: o.tp, skillBlocks: map[string]string{}, skillCatalog: map[string][]catalogSkill{}, oauthSources: map[string]loginSource{}}
+		tp: o.tp, log: o.logger, skillBlocks: map[string]string{}, skillCatalog: map[string][]catalogSkill{}, oauthSources: map[string]loginSource{}}
 	for _, sc := range cfg.Servers {
 		app.serverOrder = append(app.serverOrder, sc.ID)
 	}

--- a/agent/host/config.go
+++ b/agent/host/config.go
@@ -168,6 +168,15 @@ type MemoryConfig struct {
 	// from injecting the least-irrelevant notes when nothing truly matches).
 	// Zero means no floor.
 	RecallMinScore float64 `json:"recallMinScore,omitempty"`
+
+	// SessionScoped, when true, namespaces working memory by the active run
+	// id, so each session (RunStore run) gets its own scratchpad and recall
+	// never crosses sessions — a /sessions resume or fork carries its own
+	// memory on a durable backend. Opt-in: the default is one shared
+	// scratchpad across all sessions, which is often the point of persistent
+	// memory. A no-op without a RunStore (the run id is always "", so every
+	// turn shares the default namespace).
+	SessionScoped bool `json:"sessionScoped,omitempty"`
 }
 
 // summaryOptions maps the host config onto the agent-layer budget.

--- a/agent/host/memory.go
+++ b/agent/host/memory.go
@@ -12,8 +12,10 @@ const memorySourceID = "memory"
 
 // WithMemoryStore supplies the backing store for working memory
 // (Config.Memory). Omitted, memory uses an in-memory store that dies with
-// the process; a durable, session-scoped backend is a follow-up. Ignored
-// when Config.Memory is nil.
+// the process; pass a durable one (agent/store/redis, agent/store/gorm) to
+// survive restarts. Per-session isolation is orthogonal — set
+// MemoryConfig.SessionScoped to namespace the store by run id. Ignored when
+// Config.Memory is nil.
 func WithMemoryStore(store agent.MemoryStore) AppOption {
 	return func(o *appOptions) { o.memoryStore = store }
 }
@@ -26,7 +28,17 @@ func (a *App) registerMemory(multi *agent.MultiSource, store agent.MemoryStore) 
 	if store == nil {
 		store = agent.NewInMemoryMemoryStore()
 	}
-	src, err := agent.NewMemorySource(store)
+	var opts []agent.MemorySourceOption
+	if a.cfg.Memory != nil && a.cfg.Memory.SessionScoped {
+		// currentRunID is lock-free: it runs during a turn while turnMu is
+		// already held (both the memory tools and the summary/recall injection),
+		// so RunID would deadlock here.
+		opts = append(opts, agent.WithMemoryNamespaceFunc(a.currentRunID))
+		if a.store == nil {
+			a.log.Warn("host: memory sessionScoped is set but no RunStore is configured; every session shares the default scratchpad (add WithRunStore / --session-store to isolate)")
+		}
+	}
+	src, err := agent.NewMemorySource(store, opts...)
 	if err != nil {
 		return err
 	}

--- a/agent/host/memory_session_scope_test.go
+++ b/agent/host/memory_session_scope_test.go
@@ -1,0 +1,147 @@
+package host
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/panyam/mcpkit/agent"
+	"github.com/panyam/mcpkit/core"
+)
+
+// TestCurrentRunIDLockFree is the deadlock regression for issue 1140: the
+// session-scoped memory namespace func runs inside a turn while turnMu is
+// already held, so currentRunID MUST read the run id without taking turnMu
+// (RunID would self-deadlock there).
+func TestCurrentRunIDLockFree(t *testing.T) {
+	ts := startTestServer(t)
+	store := agent.NewInMemoryRunStore()
+	var out strings.Builder
+	app, err := NewApp(testConfig(ts.URL), &out, strings.NewReader(""),
+		WithProvider(agent.NewStubProvider()), WithRunStore(store))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Close()
+	if err := app.AttachRun(context.Background(), "r1"); err != nil {
+		t.Fatal(err)
+	}
+
+	app.turnMu.Lock()
+	defer app.turnMu.Unlock()
+	done := make(chan string, 1)
+	go func() { done <- app.currentRunID() }()
+	select {
+	case got := <-done:
+		if got != "r1" {
+			t.Fatalf("currentRunID = %q, want r1", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("currentRunID blocked while turnMu was held — it must not take turnMu (1140 deadlock)")
+	}
+}
+
+// TestSessionScopedMemoryIsolatesByRun proves that with SessionScoped on, a
+// note remembered under one run id is invisible to another run: the store
+// partitions by run-id namespace and recall never crosses sessions.
+func TestSessionScopedMemoryIsolatesByRun(t *testing.T) {
+	ts := startTestServer(t)
+	stub := agent.NewStubProvider(
+		// run r1: remember lang=Go
+		agent.StubTurn{ToolCalls: []agent.ToolCall{{
+			ID: "c1", Name: agent.RememberToolName,
+			Args: core.NewRawJSON(json.RawMessage(`{"key":"lang","value":"Go"}`)),
+		}}},
+		agent.StubTurn{Text: "saved"},
+		// run r2: recall lang — should find nothing
+		agent.StubTurn{ToolCalls: []agent.ToolCall{{
+			ID: "c2", Name: agent.RecallToolName,
+			Args: core.NewRawJSON(json.RawMessage(`{"query":"lang"}`)),
+		}}},
+		agent.StubTurn{Text: "nothing stored"},
+	)
+	memStore := agent.NewInMemoryMemoryStore()
+	cfg := testConfig(ts.URL)
+	cfg.Memory = &MemoryConfig{SessionScoped: true}
+	var out strings.Builder
+	app, err := NewApp(cfg, &out, strings.NewReader(""),
+		WithProvider(stub), WithMemoryStore(memStore), WithRunStore(agent.NewInMemoryRunStore()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Close()
+	ctx := context.Background()
+
+	if err := app.AttachRun(ctx, "r1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.RunTurn(ctx, "remember my language is Go"); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.AttachRun(ctx, "r2"); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.RunTurn(ctx, "what is my language?"); err != nil {
+		t.Fatal(err)
+	}
+
+	// The store partitions by run id: r1 holds the note, r2 is empty.
+	r1, _ := memStore.ListMemories(ctx, agent.ListMemoriesRequest{Namespace: "r1"})
+	if len(r1.Items) != 1 || r1.Items[0].Item.Value != "Go" {
+		t.Fatalf("r1 namespace = %+v, want lang=Go", r1.Items)
+	}
+	r2, _ := memStore.ListMemories(ctx, agent.ListMemoriesRequest{Namespace: "r2"})
+	if len(r2.Items) != 0 {
+		t.Fatalf("r2 namespace should be empty (isolation), got %+v", r2.Items)
+	}
+
+	// And recall on r2 fed the model nothing containing the r1 value.
+	fed := toolMsgByID(t, stub.Requests()[3].Messages, "c2").Text
+	if strings.Contains(fed, "Go") {
+		t.Fatalf("recall on r2 leaked r1's note: %q", fed)
+	}
+}
+
+// TestSessionScopedOffSharesScratchpad guards the opt-in default: with
+// SessionScoped off, notes land in the shared default namespace regardless of
+// the active run, so switching sessions does not isolate memory.
+func TestSessionScopedOffSharesScratchpad(t *testing.T) {
+	ts := startTestServer(t)
+	stub := agent.NewStubProvider(
+		agent.StubTurn{ToolCalls: []agent.ToolCall{{
+			ID: "c1", Name: agent.RememberToolName,
+			Args: core.NewRawJSON(json.RawMessage(`{"key":"lang","value":"Go"}`)),
+		}}},
+		agent.StubTurn{Text: "saved"},
+	)
+	memStore := agent.NewInMemoryMemoryStore()
+	cfg := testConfig(ts.URL)
+	cfg.Memory = &MemoryConfig{} // SessionScoped defaults false
+	var out strings.Builder
+	app, err := NewApp(cfg, &out, strings.NewReader(""),
+		WithProvider(stub), WithMemoryStore(memStore), WithRunStore(agent.NewInMemoryRunStore()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Close()
+	ctx := context.Background()
+
+	if err := app.AttachRun(ctx, "r1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.RunTurn(ctx, "remember my language is Go"); err != nil {
+		t.Fatal(err)
+	}
+
+	// The note is in the shared default namespace, not partitioned by run id.
+	def, _ := memStore.ListMemories(ctx, agent.ListMemoriesRequest{Namespace: ""})
+	if len(def.Items) != 1 || def.Items[0].Item.Value != "Go" {
+		t.Fatalf("default namespace = %+v, want lang=Go (unscoped)", def.Items)
+	}
+	r1, _ := memStore.ListMemories(ctx, agent.ListMemoriesRequest{Namespace: "r1"})
+	if len(r1.Items) != 0 {
+		t.Fatalf("run-id namespace should be empty when SessionScoped is off, got %+v", r1.Items)
+	}
+}

--- a/agent/host/persistence.go
+++ b/agent/host/persistence.go
@@ -42,6 +42,27 @@ func (a *App) RunID() string {
 	return a.runID
 }
 
+// setRunID updates the active run id and its lock-free mirror together.
+// Caller holds turnMu (every write site does). Routing all four writers
+// (AttachRun, resumeLocked, Fork, ensureRunLocked) through here keeps
+// runIDAtomic from drifting out of sync with runID.
+func (a *App) setRunID(id string) {
+	a.runID = id
+	a.runIDAtomic.Store(id)
+}
+
+// currentRunID reads the active run id WITHOUT taking turnMu, so it is
+// safe to call from inside a turn (the memory namespace func runs while
+// RunTurn already holds turnMu — RunID would deadlock there). Returns ""
+// before any run is set, which the session-scoped namespace func maps to
+// the shared default scratchpad (the same as unscoped memory).
+func (a *App) currentRunID() string {
+	if v := a.runIDAtomic.Load(); v != nil {
+		return v.(string)
+	}
+	return ""
+}
+
 // AttachRun binds the session to runID with create-or-resume semantics:
 // an existing run's history is loaded and threaded (resume), an absent
 // one is created empty. This is the startup path for surfaces that name
@@ -58,7 +79,7 @@ func (a *App) AttachRun(ctx context.Context, runID string) error {
 		return fmt.Errorf("host: attaching run %q: %w", runID, err)
 	}
 	if resp.Created {
-		a.runID = resp.RunID
+		a.setRunID(resp.RunID)
 		a.history = nil
 		return nil
 	}
@@ -176,7 +197,7 @@ func (a *App) resumeLocked(ctx context.Context, runID string) error {
 		return fmt.Errorf("host: run %q not found", runID)
 	}
 	a.history = resp.Run.Messages
-	a.runID = runID
+	a.setRunID(runID)
 	return nil
 }
 
@@ -210,7 +231,7 @@ func (a *App) Fork(ctx context.Context, newRunID string, atMessage int) (string,
 	if atMessage > 0 {
 		return resp.RunID, a.resumeLocked(ctx, resp.RunID)
 	}
-	a.runID = resp.RunID
+	a.setRunID(resp.RunID)
 	return resp.RunID, nil
 }
 
@@ -224,7 +245,7 @@ func (a *App) ensureRunLocked(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("host: creating run: %w", err)
 	}
-	a.runID = resp.RunID
+	a.setRunID(resp.RunID)
 	a.emit(HostEvent{Kind: HostSessionChanged, RunID: resp.RunID})
 	return nil
 }

--- a/cmd/agentchat/main.go
+++ b/cmd/agentchat/main.go
@@ -214,6 +214,7 @@ func newRoot() (*cobra.Command, *viper.Viper) {
 	fl.Bool("memory-inject-recall", false, "with --memory, inject notes relevant to each user message before the turn (auto-recall; best with --memory-embed-model)")
 	fl.Int("memory-recall-top-k", 0, "with --memory-inject-recall, max relevant notes to inject (0 = default 5)")
 	fl.Float64("memory-recall-min-score", 0, "with --memory-inject-recall, drop recalled notes below this relevance score (0 = no floor)")
+	fl.Bool("memory-session-scoped", false, "with --memory, give each session (--session id) its own memory scratchpad so recall never crosses sessions (needs --session-store; default = one shared scratchpad)")
 	fl.Int("compact-tokens", 0, "compact history when its estimated token count exceeds N: summarize the head, keep a recent tail (0 = off)")
 	fl.Int("compact-keep-recent", 0, "with --compact-tokens, how many trailing messages to keep verbatim (0 = default 6)")
 	fl.String("exporter", "", "telemetry exporter: stdout | otlp | auto (empty = off)")
@@ -333,6 +334,7 @@ func runChat(v *viper.Viper) error {
 			InjectRecall:    v.GetBool("memory-inject-recall"),
 			RecallTopK:      v.GetInt("memory-recall-top-k"),
 			RecallMinScore:  v.GetFloat64("memory-recall-min-score"),
+			SessionScoped:   v.GetBool("memory-session-scoped"),
 		}
 		// A semantic store makes recall similarity-ranked instead of
 		// substring. The embedder is resolved from the --memory-embed-model


### PR DESCRIPTION
## What changes

Turns on **per-session working memory** in agentchat. PR 1139 (issue 1003) added the per-request `Namespace` seam and `MemorySource.WithMemoryNamespaceFunc`, but nothing supplied a namespace, so every session shared one scratchpad. This wires it: `MemoryConfig.SessionScoped` (opt-in) namespaces working memory by the active run id, so recall never crosses sessions and a `/sessions` resume or fork carries its own memory on a durable backend. Base branch behavior is unchanged when the flag is off (the default).

## The blocker, and how it's solved

The namespace func is `func() string`, evaluated **inside a turn while `turnMu` is held** — at two sites, not one: the memory tool calls (`runner.Run`) and the ambient summary/recall injection (`withMemorySummaryLocked`). `App.RunID()` takes `turnMu`, so a namespace func calling it re-enters the held lock and deadlocks.

Fix: a lock-free `currentRunID()` backed by an `atomic.Value` mirror of `runID`. All four `runID` writers route through one `setRunID(id)` so the mirror can never drift from the guarded field.

```
setRunID(id)         // caller holds turnMu (AttachRun, resumeLocked, Fork, ensureRunLocked)
   runID = id
   runIDAtomic.Store(id)

currentRunID()       // no lock — safe from inside a turn
   return runIDAtomic.Load() or ""

registerMemory:
   if cfg.Memory.SessionScoped:
      NewMemorySource(store, WithMemoryNamespaceFunc(currentRunID))
      if store(RunStore) == nil: warn (namespace is always "" → shared)
```

Ordering is favorable: `ensureRunLocked` sets the run id at the top of `RunTurn`, before memory is touched, so within a turn `currentRunID()` is already populated.

## Reviewer's guide

Read in this order:
1. [agent/host/persistence.go](https://github.com/panyam/mcpkit/pull/1150/files#diff-0eff5e5041fb67bd84e50d022d2c12f889b3a75f62e014198f357bb4b36d78ce) — start here. `setRunID` + `currentRunID` (the lock-free accessor + the WHY doc), and the four call sites now routed through `setRunID`.
2. [agent/host/memory.go](https://github.com/panyam/mcpkit/pull/1150/files#diff-2fa9e3fc7796e7e17ca21962b0f10cf32f1e7cc8b61a88abbfb519c350a97c62) — `registerMemory` passes `WithMemoryNamespaceFunc(a.currentRunID)` when `SessionScoped`; the no-RunStore warning.
3. [agent/host/memory_session_scope_test.go](https://github.com/panyam/mcpkit/pull/1150/files#diff-76ab1ebb52f7182cd193baf4ba380e1890647c9cd324f72bc1b2c9d17426726c) — acceptance: the deadlock guard, run isolation, and the opt-in default.
4. [agent/host/config.go](https://github.com/panyam/mcpkit/pull/1150/files#diff-6aff502cc5cae4b9d9769752e8638899bab121e09de870b5d1320cc892c6bf2d) — `MemoryConfig.SessionScoped` + its contract doc.
5. [agent/host/app.go](https://github.com/panyam/mcpkit/pull/1150/files#diff-89fb8e04b6e1e9d5f7f76958490ef158dee40e2cae92d87c04b408d893c84361) — the `runIDAtomic` + `log` fields and their assignment (mechanical).
6. [cmd/agentchat/main.go](https://github.com/panyam/mcpkit/pull/1150/files#diff-ce3956549c93b4983f18090136a2139c3c92d38408e923245f5e9ba628bcc98a) — `--memory-session-scoped` flag → config.

Skim or skip: nothing generated.

## Decision log

- **Atomic mirror over a second `RWMutex`** — the read is on the hot path (every memory tool call + every injection), and a lock-free read sidesteps any lock-ordering reasoning against `turnMu`. One `setRunID` keeps the two representations in sync so there's no drift risk.
- **Kept the seam `func() string`** (no ctx) — that shape shipped in 1139 deliberately; threading a per-turn ctx into a construction-time closure would churn the agent API. The atomic makes the closure's read safe without it.
- **Default off** — cross-session shared memory (one scratchpad that accumulates across all your sessions) is often the *point* of persistent memory, so isolation is opt-in.
- **No-op + warn without a RunStore** — with no run id, every turn namespaces to `""`, i.e. the shared scratchpad. A one-line warning at construction flags the likely misconfiguration (set `SessionScoped` but forgot `--session-store`) rather than silently doing nothing.

## Risk / blast radius

- **Affects:** `agent/host` run-id lifecycle (now writes through `setRunID`) and memory registration; agentchat gains one flag. No agent-layer or store change (the `Namespace` seam already exists).
- **Tests covering this:** `memory_session_scope_test.go` — deadlock guard (proven to fire when `currentRunID` is made to take `turnMu`), run isolation (red before the wiring: notes land in `""`), opt-in default. Full `agent/host` suite green under `-race`.
- **Be paranoid about:** the four `setRunID` sites — a missed one would leave the mirror stale and namespace memory to the wrong (or empty) run. Verified all four (`AttachRun`, `resumeLocked` which covers Resume + `atMessage>0` Fork, plain Fork, `ensureRunLocked`) route through it.

## Before / after

```
# agentchat, two sessions on a shared --session-store, model remembers "lang=Go" in s1

--- before (or --memory-session-scoped off) ---
$ agentchat --session s1 ... "remember my language is Go"
$ agentchat --session s2 ... "what is my language?"
recall → "Go"          # s2 sees s1's note; one shared scratchpad

--- after, with --memory-session-scoped ---
$ agentchat --session s1 ... "remember my language is Go"
$ agentchat --session s2 ... "what is my language?"
recall → (nothing)     # isolated; s1's note is in the r1 namespace only
```

## Out of scope (deliberately deferred)

- A Redis *semantic* (vector) memory backend is still a separate follow-up; durable semantic recall is the pgvector store's job today (noted in `docs/AGENT_MEMORY_FLOW.md`).

