### PR TITLE
feat(agent/host): Team handoff config in the App loop + kitchen-sink demo (1042)

### DIFF
--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -23,8 +23,16 @@ import (
 // parsing and signal handling. Construct with NewApp, converse with RunTurn
 // (one input, one rendered turn) or REPL (interactive loop).
 type App struct {
-	cfg       *Config
-	runner    *agent.Runner
+	cfg    *Config
+	runner *agent.Runner
+
+	// team drives the conversation as a handoff Team (Config.Team) instead of
+	// the single runner. activeTeamAgent is the persisted active member, so
+	// control stays where it was transferred across user turns. Both zero in
+	// single-agent mode. Guarded by turnMu.
+	team            *agent.Team
+	activeTeamAgent string
+
 	sources   *agent.MultiSource
 	clients   []*client.Client
 	history   []agent.Message
@@ -257,6 +265,9 @@ func errString(err error) string {
 // NewApp connects every configured server and assembles the agent. The
 // returned App owns the client connections; call Close when done.
 func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, error) {
+	if err := validateTeamExclusive(cfg); err != nil {
+		return nil, err
+	}
 	var o appOptions
 	for _, opt := range opts {
 		opt(&o)
@@ -307,7 +318,7 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 	// sub-agents — so a sub-agent or fan-out persona gets a filtered view of the
 	// servers without seeing the meta-tools or the other personas (which would
 	// let it recurse). Built only when personas are configured.
-	if len(cfg.SubAgents) > 0 || len(cfg.FanOut) > 0 {
+	if len(cfg.SubAgents) > 0 || len(cfg.FanOut) > 0 || cfg.Team != nil {
 		app.serverTools = agent.NewMultiSource()
 	}
 
@@ -474,6 +485,18 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 			app.Close()
 			return nil, err
 		}
+	}
+
+	// Team mode: a handoff Team drives RunTurn instead of the single runner.
+	// Validated mutually exclusive with the single-agent features above.
+	if cfg.Team != nil {
+		team, err := app.buildTeam(app.serverTools, provider, o.tp, o.mp)
+		if err != nil {
+			app.Close()
+			return nil, err
+		}
+		app.team = team
+		app.activeTeamAgent = team.StartAgent()
 	}
 
 	// Offloading wraps the whole aggregate, so one read_tool_result and
@@ -644,9 +667,23 @@ func (a *App) RunTurn(ctx context.Context, input string) error {
 	}
 
 	// The memory summary is woven into the per-turn slice only, never into
-	// a.history — see withMemorySummaryLocked.
+	// a.history — see withMemorySummaryLocked (a no-op in team mode, which has
+	// no memory).
 	turnMsgs := a.withMemorySummaryLocked(ctx)
-	result, err := a.runner.Run(ctx, turnMsgs, emit)
+	var result *agent.TurnResult
+	var err error
+	if a.team != nil {
+		// Team mode: the active member (persisted across turns) drives the turn,
+		// looping handoffs internally; result.Messages spans every hop. Persist
+		// the ending active agent so control stays transferred next turn.
+		var active string
+		result, active, err = a.team.RunTurn(ctx, turnMsgs, a.activeTeamAgent, emit)
+		if err == nil {
+			a.activeTeamAgent = active
+		}
+	} else {
+		result, err = a.runner.Run(ctx, turnMsgs, emit)
+	}
 	if err != nil {
 		a.history = a.history[:len(a.history)-1]
 		a.emit(HostEvent{Kind: HostTurnFailed, Err: err.Error()})

--- a/agent/host/config.go
+++ b/agent/host/config.go
@@ -87,6 +87,12 @@ type Config struct {
 	// concurrently, receiving one aggregated result (agent.FanOutSource).
 	// Empty means no fan-out tools.
 	FanOut []FanOutGroupConfig `json:"fanOut,omitempty"`
+
+	// Team, when set, drives the conversation as a handoff Team (agent.Team)
+	// instead of the single main agent — control transfers between members and
+	// persists across user turns. Mutually exclusive with SubAgents, FanOut, and
+	// Memory (NewApp errors if combined). Nil means single-agent mode.
+	Team *HostTeamConfig `json:"team,omitempty"`
 }
 
 // SubAgentConfig is one delegatable persona. The host builds it into an
@@ -126,6 +132,36 @@ type FanOutGroupConfig struct {
 
 	// Members are the personas the task is broadcast to. At least one required.
 	Members []SubAgentConfig `json:"members,omitempty"`
+}
+
+// HostTeamConfig declares a handoff Team that drives the whole conversation
+// instead of the single main agent (agent.Team). Control transfers between
+// members and stays where it was transferred across user turns. Setting Team
+// replaces the single-agent loop, so it may NOT be combined with SubAgents,
+// FanOut, or Memory on the main agent (NewApp errors); team members are
+// serverTools-only personas.
+type HostTeamConfig struct {
+	// Members are the agents. At least one; Start must name one.
+	Members []TeamMemberConfig `json:"members,omitempty"`
+
+	// Start is the agent that receives a conversation's first turn. Required.
+	Start string `json:"start"`
+
+	// MaxHandoffs caps transfers within one user turn. Zero uses the agent
+	// default.
+	MaxHandoffs int `json:"maxHandoffs,omitempty"`
+}
+
+// TeamMemberConfig is one Team agent: a persona (SubAgentConfig — shared
+// provider, serverTools filtered by Allow, own instructions) plus the members
+// it may hand off to.
+type TeamMemberConfig struct {
+	SubAgentConfig
+
+	// HandoffTo lists the member names this agent may transfer control to. Each
+	// becomes a transfer_to_<name> tool offered only to this agent. Empty means
+	// a terminal agent that must answer rather than transfer.
+	HandoffTo []string `json:"handoffTo,omitempty"`
 }
 
 // CompactionConfig is the host's view of history compaction; it maps to an

--- a/agent/host/hostevent.go
+++ b/agent/host/hostevent.go
@@ -55,6 +55,10 @@ const (
 	// (ServerID, ServerState; Err on failed/needs-login) — the async
 	// graceful-degrade surface (see docs/AGENT_SERVER_STATE.md).
 	HostServerStateChanged HostEventKind = "server-state-changed"
+	// HostHandoff reports a Team transferring control from one agent to another
+	// (From, To) — Config.Team only. The active agent changes, so a surface
+	// renders "→ handed off to <To>" and can update which agent is answering.
+	HostHandoff HostEventKind = "handoff"
 )
 
 // HostEvent is one domain event the host announces: a thing that
@@ -99,6 +103,11 @@ type HostEvent struct {
 
 	// SubAgent is the nested sub-agent event on HostSubAgentEvent.
 	SubAgent agent.SubAgentEvent
+
+	// From and To name the agents on HostHandoff (the transfer source and the
+	// new active agent).
+	From string
+	To   string
 }
 
 // Observer receives the host's HostEvent stream and does whatever it

--- a/agent/host/render.go
+++ b/agent/host/render.go
@@ -385,6 +385,8 @@ func (r *renderer) On(ev HostEvent) {
 		r.serverState(ev.ServerID, ev.ServerState, ev.Err)
 	case HostSubAgentEvent:
 		r.subAgent(ev.SubAgent)
+	case HostHandoff:
+		fmt.Fprintf(r.out, "%s\n", r.dim("→ handed off to "+ev.To))
 	}
 }
 

--- a/agent/host/subagents.go
+++ b/agent/host/subagents.go
@@ -41,23 +41,7 @@ func (a *App) registerSubAgents(multi, serverTools *agent.MultiSource, provider 
 // by registerSubAgents and registerFanOut so the two build personas identically
 // — including the serverTools-only rule that keeps a child memory-free (A7).
 func (a *App) buildPersonaSource(sub SubAgentConfig, serverTools *agent.MultiSource, provider agent.Provider, tp core.TracerProvider, mp core.MeterProvider) (*agent.AgentSource, error) {
-	var tools agent.ToolSource = serverTools
-	if len(sub.Allow) > 0 {
-		allow := make(map[string]bool, len(sub.Allow))
-		for _, name := range sub.Allow {
-			allow[name] = true
-		}
-		tools = agent.NewFilterSource(serverTools, func(d core.ToolDef) bool { return allow[d.Name] })
-	}
-
-	child, err := agent.NewRunner(agent.RunnerConfig{
-		Provider:       provider,
-		Tools:          tools,
-		Instructions:   sub.Instructions,
-		MaxSteps:       a.cfg.MaxSteps,
-		TracerProvider: tp,
-		MeterProvider:  mp,
-	})
+	child, err := agent.NewRunner(a.personaRunnerConfig(sub, serverTools, provider, tp, mp))
 	if err != nil {
 		return nil, err
 	}
@@ -69,6 +53,31 @@ func (a *App) buildPersonaSource(sub SubAgentConfig, serverTools *agent.MultiSou
 		MaxDepth:    sub.MaxDepth,
 		OnEvent:     func(e agent.SubAgentEvent) { a.emit(HostEvent{Kind: HostSubAgentEvent, SubAgent: e}) },
 	})
+}
+
+// personaRunnerConfig builds the RunnerConfig shared by every persona shape
+// (sub-agent, fan-out member, team member): the child runs on the SHARED
+// provider over a serverTools-only view (Allow-narrowed), with its own
+// instructions — the serverTools-only rule keeping a child memory-free (A7).
+// Team needs the RunnerConfig (it builds the Runner itself, merging handoff
+// tools); the others wrap it in an AgentSource.
+func (a *App) personaRunnerConfig(sub SubAgentConfig, serverTools *agent.MultiSource, provider agent.Provider, tp core.TracerProvider, mp core.MeterProvider) agent.RunnerConfig {
+	var tools agent.ToolSource = serverTools
+	if len(sub.Allow) > 0 {
+		allow := make(map[string]bool, len(sub.Allow))
+		for _, name := range sub.Allow {
+			allow[name] = true
+		}
+		tools = agent.NewFilterSource(serverTools, func(d core.ToolDef) bool { return allow[d.Name] })
+	}
+	return agent.RunnerConfig{
+		Provider:       provider,
+		Tools:          tools,
+		Instructions:   sub.Instructions,
+		MaxSteps:       a.cfg.MaxSteps,
+		TracerProvider: tp,
+		MeterProvider:  mp,
+	}
 }
 
 // registerFanOut builds each configured fan-out group as an agent.FanOutSource

--- a/agent/host/team.go
+++ b/agent/host/team.go
@@ -1,0 +1,60 @@
+package host
+
+import (
+	"fmt"
+
+	"github.com/panyam/mcpkit/agent"
+	"github.com/panyam/mcpkit/core"
+)
+
+// buildTeam assembles the handoff Team (Config.Team) from persona members over
+// the shared provider + serverTools, wiring OnHandoff to a HostHandoff event so
+// a surface can render the control transfer. Each member is built like a
+// sub-agent (serverTools-only, memory-free per A7) with its handoff tools merged
+// in by agent.NewTeam. The returned Team drives RunTurn instead of the single
+// Runner; activeTeamAgent is seeded to Start.
+func (a *App) buildTeam(serverTools *agent.MultiSource, provider agent.Provider, tp core.TracerProvider, mp core.MeterProvider) (*agent.Team, error) {
+	tc := a.cfg.Team
+	members := make([]agent.TeamMember, 0, len(tc.Members))
+	for _, m := range tc.Members {
+		members = append(members, agent.TeamMember{
+			Name:      m.Name,
+			Config:    a.personaRunnerConfig(m.SubAgentConfig, serverTools, provider, tp, mp),
+			HandoffTo: m.HandoffTo,
+		})
+	}
+	return agent.NewTeam(agent.TeamConfig{
+		Members:     members,
+		Start:       tc.Start,
+		MaxHandoffs: tc.MaxHandoffs,
+		OnHandoff:   func(from, to string) { a.emit(HostEvent{Kind: HostHandoff, From: from, To: to}) },
+	})
+}
+
+// validateTeamExclusive rejects a Team combined with the single-agent-only
+// features. Team replaces the main agent's loop, so its per-runner facilities
+// (memory, sub-agents, fan-out) have no single agent to attach to; integrating
+// them into team members is a deferred follow-up. Fail loud rather than
+// silently ignore a configured feature.
+func validateTeamExclusive(cfg *Config) error {
+	if cfg.Team == nil {
+		return nil
+	}
+	var conflicts []string
+	if len(cfg.SubAgents) > 0 {
+		conflicts = append(conflicts, "subAgents")
+	}
+	if len(cfg.FanOut) > 0 {
+		conflicts = append(conflicts, "fanOut")
+	}
+	if cfg.Memory != nil {
+		conflicts = append(conflicts, "memory")
+	}
+	if len(conflicts) > 0 {
+		return fmt.Errorf("host: team mode cannot be combined with %v (team replaces the single main agent; those attach to it)", conflicts)
+	}
+	if len(cfg.Team.Members) == 0 {
+		return fmt.Errorf("host: team requires at least one member")
+	}
+	return nil
+}

--- a/agent/host/team_test.go
+++ b/agent/host/team_test.go
@@ -1,0 +1,108 @@
+package host
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/panyam/mcpkit/agent"
+	"github.com/panyam/mcpkit/core"
+)
+
+func transferCall(id, target string) agent.StubTurn {
+	return agent.StubTurn{ToolCalls: []agent.ToolCall{{
+		ID: id, Name: "transfer_to_" + target, Args: core.NewRawJSON(json.RawMessage(`{}`)),
+	}}}
+}
+
+// TestAppTeamDrivesRunTurnWithHandoff is the 1042 payoff: a Config.Team drives
+// RunTurn (not the single runner), a transfer fires a HostHandoff event, and the
+// active agent persists across user turns — turn 2 starts from the specialist,
+// not the triage Start.
+func TestAppTeamDrivesRunTurnWithHandoff(t *testing.T) {
+	ts := startTestServer(t)
+
+	// One StubProvider serves both members. Turn 1: triage transfers (then its
+	// own follow-up text — the Runner continues its turn after the tool call),
+	// specialist answers. Turn 2: specialist answers directly.
+	stub := agent.NewStubProvider(
+		transferCall("t1", "specialist"),
+		agent.StubTurn{Text: "connecting you"},
+		agent.StubTurn{Text: "specialist: here is turn one"},
+		agent.StubTurn{Text: "specialist: here is turn two"},
+	)
+
+	cfg := testConfig(ts.URL)
+	cfg.Team = &HostTeamConfig{
+		Start: "triage",
+		Members: []TeamMemberConfig{
+			{SubAgentConfig: SubAgentConfig{Name: "triage", Instructions: "route the user"}, HandoffTo: []string{"specialist"}},
+			{SubAgentConfig: SubAgentConfig{Name: "specialist", Instructions: "answer in depth"}},
+		},
+	}
+	obs := &collectObserver{}
+	app, err := NewApp(cfg, nil, strings.NewReader(""), WithProvider(stub), WithObserver(obs))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Close()
+
+	if app.team == nil || app.activeTeamAgent != "triage" {
+		t.Fatalf("team not wired / active not seeded to Start: team=%v active=%q", app.team != nil, app.activeTeamAgent)
+	}
+
+	// turn 1: triage hands off to the specialist, which answers.
+	if err := app.RunTurn(context.Background(), "I have a billing question"); err != nil {
+		t.Fatal(err)
+	}
+	if app.activeTeamAgent != "specialist" {
+		t.Fatalf("after handoff, active agent should persist as specialist, got %q", app.activeTeamAgent)
+	}
+	handoffs := obs.kinds(HostHandoff)
+	if len(handoffs) != 1 || handoffs[0].From != "triage" || handoffs[0].To != "specialist" {
+		t.Fatalf("expected one triage->specialist HostHandoff, got %+v", handoffs)
+	}
+
+	// turn 2: starts from the persisted specialist — the triage provider turns
+	// are already consumed, so if turn 2 restarted at triage it would misroute.
+	triageReqs := len(stub.Requests())
+	if err := app.RunTurn(context.Background(), "one more thing"); err != nil {
+		t.Fatal(err)
+	}
+	if app.activeTeamAgent != "specialist" {
+		t.Fatalf("turn 2 active should stay specialist, got %q", app.activeTeamAgent)
+	}
+	// exactly one more model call happened on turn 2 (the specialist), and no new
+	// handoff fired.
+	if n := len(stub.Requests()) - triageReqs; n != 1 {
+		t.Fatalf("turn 2 should be one specialist call, got %d model calls", n)
+	}
+	if n := len(obs.kinds(HostHandoff)); n != 1 {
+		t.Fatalf("turn 2 must not hand off again, total handoffs = %d", n)
+	}
+}
+
+// TestAppTeamRejectsSingleAgentFeatures guards the mutual-exclusivity contract:
+// team mode replaces the single agent, so combining it with memory / sub-agents
+// / fan-out is a construction error, not a silent drop.
+func TestAppTeamRejectsSingleAgentFeatures(t *testing.T) {
+	ts := startTestServer(t)
+	team := &HostTeamConfig{Start: "a", Members: []TeamMemberConfig{{SubAgentConfig: SubAgentConfig{Name: "a"}}}}
+
+	cases := map[string]func(*Config){
+		"memory":    func(c *Config) { c.Memory = &MemoryConfig{} },
+		"subAgents": func(c *Config) { c.SubAgents = []SubAgentConfig{{Name: "s"}} },
+		"fanOut":    func(c *Config) { c.FanOut = []FanOutGroupConfig{{Name: "f", Members: []SubAgentConfig{{Name: "m"}}}} },
+	}
+	for name, mut := range cases {
+		t.Run(name, func(t *testing.T) {
+			cfg := testConfig(ts.URL)
+			cfg.Team = team
+			mut(cfg)
+			if _, err := NewApp(cfg, nil, strings.NewReader(""), WithProvider(agent.NewStubProvider())); err == nil {
+				t.Fatalf("team + %s should be rejected at construction", name)
+			}
+		})
+	}
+}

--- a/agent/team.go
+++ b/agent/team.go
@@ -161,47 +161,76 @@ func buildTransferSource(from string, targets []string, members map[string]bool)
 	return fs, nil
 }
 
-// Run drives the conversation: the Start agent runs over the input, and each
-// time an agent transfers, the Team swaps the active agent and continues over
-// the carried-forward history until an agent answers without transferring (the
-// final result) or the handoff cap is hit (ErrMaxHandoffs). All agents share
-// one history (handoff transfers context); each brings its own instructions.
-// emit receives every agent's events; OnHandoff marks the transitions.
+// StartAgent is the member that receives the first turn — the seam a host uses
+// to initialize its persisted active agent before the first RunTurn.
+func (t *Team) StartAgent() string { return t.start }
+
+// Run drives a single-shot conversation from the Start agent over one input,
+// looping handoffs until an agent answers without transferring (the final
+// result) or the cap is hit (ErrMaxHandoffs). It is the convenience wrapper over
+// RunTurn for callers that do not thread history or persist the active agent.
 func (t *Team) Run(ctx context.Context, input string, emit func(Event)) (*TurnResult, error) {
+	result, _, err := t.RunTurn(ctx, []Message{{Role: RoleUser, Text: input}}, "", emit)
+	return result, err
+}
+
+// RunTurn drives one user turn over the carried history: the active agent (or
+// Start when active is "") runs, and each transfer swaps the active agent and
+// continues over the SAME history, until an agent answers without transferring
+// or the handoff cap is hit (ErrMaxHandoffs). All agents share the history
+// (handoff transfers context); each brings its own instructions.
+//
+// It returns the final result whose Messages hold EVERY message appended across
+// all hops this turn (so a caller threads them into its own history as one
+// turn), plus the agent active at the end. Persist that name and pass it back
+// as active next turn so control stays where it was transferred, rather than
+// re-starting from Start — the transfer-control (not re-route) semantic.
+//
+// emit receives every agent's events; OnHandoff marks the transitions. An
+// unknown active name is treated as Start (the caller's persisted value can lag
+// a config change without erroring).
+func (t *Team) RunTurn(ctx context.Context, history []Message, active string, emit func(Event)) (*TurnResult, string, error) {
 	if emit == nil {
 		emit = func(Event) {}
 	}
 	sig := &handoffSignal{}
 	ctx = withHandoffSignal(ctx, sig)
 
-	history := []Message{{Role: RoleUser, Text: input}}
-	active := t.members[t.start]
+	current, ok := t.members[active]
+	if !ok {
+		current = t.members[t.start]
+	}
+	work := append([]Message(nil), history...)
+	var appended []Message
 	handoffs := 0
 	for {
-		result, err := active.runner.Run(ctx, history, emit)
+		result, err := current.runner.Run(ctx, work, emit)
 		if err != nil {
-			return nil, err
+			return nil, current.name, err
 		}
-		history = append(history, result.Messages...)
+		work = append(work, result.Messages...)
+		appended = append(appended, result.Messages...)
 
 		target := sig.take()
 		if target == "" {
-			return result, nil
+			result.Messages = appended
+			return result, current.name, nil
 		}
 		next, ok := t.members[target]
 		if !ok {
 			// The transfer tools only offer real members, so this is
 			// unreachable; treat a stray target as "no transfer".
-			return result, nil
+			result.Messages = appended
+			return result, current.name, nil
 		}
 		if handoffs >= t.maxHandoffs {
-			return nil, fmt.Errorf("%w (%d) starting from %q", ErrMaxHandoffs, t.maxHandoffs, t.start)
+			return nil, current.name, fmt.Errorf("%w (%d) starting from %q", ErrMaxHandoffs, t.maxHandoffs, current.name)
 		}
 		handoffs++
 		if t.onHandoff != nil {
-			t.onHandoff(active.name, target)
+			t.onHandoff(current.name, target)
 		}
-		active = next
+		current = next
 	}
 }
 

--- a/agent/team_test.go
+++ b/agent/team_test.go
@@ -139,3 +139,55 @@ func TestTeam_Validation(t *testing.T) {
 		}
 	}
 }
+
+// TestTeam_RunTurnPersistsActiveAgent covers the host-facing entry point: after
+// a handoff on turn 1 (triage -> specialist), turn 2 starts from the PERSISTED
+// specialist (not Start), and the returned Messages hold every hop this turn.
+func TestTeam_RunTurnPersistsActiveAgent(t *testing.T) {
+	// triage: turn 1 transfers; it must NOT be asked again on turn 2.
+	triage := NewStubProvider(transferCall("c1", "specialist"), StubTurn{Text: "connecting"})
+	// specialist: answers turn 1, then answers turn 2 directly.
+	specialist := NewStubProvider(StubTurn{Text: "answer one"}, StubTurn{Text: "answer two"})
+
+	team, err := NewTeam(TeamConfig{
+		Start: "triage",
+		Members: []TeamMember{
+			{Name: "triage", Config: RunnerConfig{Provider: triage}, HandoffTo: []string{"specialist"}},
+			{Name: "specialist", Config: RunnerConfig{Provider: specialist}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	// turn 1: from Start; triage hands to specialist which answers.
+	history := []Message{{Role: RoleUser, Text: "help"}}
+	res1, active1, err := team.RunTurn(ctx, history, "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if active1 != "specialist" || res1.Text != "answer one" {
+		t.Fatalf("turn 1: active=%q text=%q, want specialist/answer one", active1, res1.Text)
+	}
+	// all hops appended: triage's transfer turn (assistant + tool msg) AND the
+	// specialist's answer — more than just the specialist's own messages.
+	if len(res1.Messages) < 3 {
+		t.Fatalf("turn 1 messages should span both agents' hops, got %d: %+v", len(res1.Messages), res1.Messages)
+	}
+	history = append(history, res1.Messages...)
+	triageBefore := len(triage.Requests())
+
+	// turn 2: from the persisted specialist — triage is not consulted again.
+	history = append(history, Message{Role: RoleUser, Text: "follow up"})
+	res2, active2, err := team.RunTurn(ctx, history, active1, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if active2 != "specialist" || res2.Text != "answer two" {
+		t.Fatalf("turn 2: active=%q text=%q, want specialist/answer two (started from persisted agent)", active2, res2.Text)
+	}
+	if n := len(triage.Requests()); n != triageBefore {
+		t.Fatalf("triage was consulted again on turn 2 (%d -> %d); it must start from the persisted specialist, not Start", triageBefore, n)
+	}
+}

--- a/docs/AGENT_COMPOSITION.md
+++ b/docs/AGENT_COMPOSITION.md
@@ -148,7 +148,13 @@ flowchart TB
 ```
 
 - **Team (built)** uses a shared thread and swaps which stateless Runner reads
-  it — the minimal concrete handoff.
+  it — the minimal concrete handoff. Host-wired via `Config.Team` (1042):
+  `App.RunTurn` drives `Team.RunTurn` instead of the single Runner, and the
+  **active agent persists across user turns** (control stays transferred, it does
+  not re-route from Start each turn). Team mode replaces the single main agent,
+  so it is mutually exclusive with that agent's memory / sub-agents / fan-out
+  (integrating those into team members is deferred). `OnHandoff` surfaces as a
+  `HostHandoff` event; demoed in `examples/agents/kitchen-sink` (`just team`).
 - **The general form** gives each agent its *own persistent context* and makes
   transfer an **injection** into the target (the actor / message-passing
   idiom mcpkit already leans toward via triggers + events). More general —
@@ -237,6 +243,11 @@ Decision captured in issue 1151; enforced by constraint A7.
 returns their results aggregated in member order; the parallel-ensemble
 primitive, reusing `AgentSource` for per-member depth/budget/scope, host-wired
 as `Config.FanOut` and demoed in `examples/agents/kitchen-sink`).
+
+**Team-in-host (1042):** `Config.Team` drives the App loop; active agent
+persists across turns; `HostHandoff` event; `just team` demo. Mutually exclusive
+with the single-agent features (deferred: integrating memory/offloading into
+team members).
 
 **Deferred, mapped to the axes:**
 

--- a/examples/agents/kitchen-sink/README.md
+++ b/examples/agents/kitchen-sink/README.md
@@ -178,6 +178,28 @@ Gemini). You can also swap chat models mid-session with `/provider`.
     flag still wins (`ACTIVE=anthropic-opus just run` overrides the overlay for
     that run).
 
+## Handoff team (a second topology)
+
+The walkthrough above runs **one** main agent with sub-agents, fan-out, and
+memory attached to it. **Handoff** is the other multi-agent shape: control
+*transfers* between agents instead of one agent delegating. Because a team
+replaces the single main agent, it is a separate config (`kitchen-sink-team.json`)
+and its own recipe:
+
+```bash
+just team       # triage router -> billing / technical specialists (notebook UI)
+```
+
+Ask a billing question (*"I was double charged, can I get a refund?"*). The
+**triage** agent transfers you to **billing** — you'll see the `→ handed off to
+billing` line — and billing answers. Now ask a technical follow-up (*"also, the
+export button throws a 500"*); billing transfers you to **technical**. The
+**active agent persists across turns**: your next message goes straight to
+whoever holds the conversation, not back through triage. `MaxHandoffs` bounds
+ping-pong. (Team mode is mutually exclusive with the main agent's memory /
+sub-agents / fan-out — those attach to a single agent; agentchat errors if you
+combine them.)
+
 ## Inspecting state
 
 ```bash

--- a/examples/agents/kitchen-sink/justfile
+++ b/examples/agents/kitchen-sink/justfile
@@ -65,6 +65,12 @@ demo: run
 note:
     @UI=notebook bash run.sh
 
+# Handoff-Team topology (kitchen-sink-team.json): a triage router transfers you
+# to a billing or technical specialist; the active agent persists across turns.
+# Notebook UI so the handoff and the active agent are easy to see.
+team:
+    @CONFIG="{{justfile_directory()}}/kitchen-sink-team.json" MEMORY=0 UI=notebook bash run.sh
+
 # Bring up ALL stacks kitchen-sink can use (backends + observability).
 allup:
     cd ../../../docker/backends && just up

--- a/examples/agents/kitchen-sink/kitchen-sink-team.json
+++ b/examples/agents/kitchen-sink/kitchen-sink-team.json
@@ -1,0 +1,153 @@
+{
+  "instructions": "Team mode: this conversation is driven by a handoff Team (see the 'team' block); the top-level instructions are unused.",
+  "connections": {
+    "active": "deepseek-r1",
+    "embedder": "openai-embed",
+    "connections": {
+      "openai-embed": {
+        "type": "openai",
+        "model": "text-embedding-3-small",
+        "dim": 1536,
+        "apiKeyEnv": "OPENAI_API_KEY"
+      },
+      "gemini-embed": {
+        "type": "gemini",
+        "model": "text-embedding-004",
+        "dim": 768,
+        "apiKeyEnv": "GEMINI_API_KEY"
+      },
+      "local": {
+        "type": "lmstudio",
+        "model": "qwen2.5-7b-instruct"
+      },
+      "local-thinker": {
+        "type": "lmstudio",
+        "model": "deepseek-r1-distill-llama-8b",
+        "thinkingHint": {
+          "openTag": "<think>",
+          "closeTag": "</think>"
+        }
+      },
+      "r1-qwen-7b": {
+        "type": "lmstudio",
+        "model": "deepseek-r1-distill-qwen-7b",
+        "thinkingHint": {
+          "openTag": "<think>",
+          "closeTag": "</think>"
+        }
+      },
+      "ollama": {
+        "type": "ollama",
+        "model": "llama3.1"
+      },
+      "deepseek-r1": {
+        "baseUrl": "https://api.deepseek.com",
+        "model": "deepseek-reasoner",
+        "apiKeyEnv": "DEEPSEEK_API_KEY"
+      },
+      "openai-5.1": {
+        "type": "openai",
+        "model": "gpt-5.1",
+        "apiKeyEnv": "OPENAI_API_KEY"
+      },
+      "openai-5.1-mini": {
+        "type": "openai",
+        "model": "gpt-5.1-mini",
+        "apiKeyEnv": "OPENAI_API_KEY"
+      },
+      "openai-5": {
+        "type": "openai",
+        "model": "gpt-5",
+        "apiKeyEnv": "OPENAI_API_KEY"
+      },
+      "openai-4o": {
+        "type": "openai",
+        "model": "gpt-4o",
+        "apiKeyEnv": "OPENAI_API_KEY"
+      },
+      "openai-4o-mini": {
+        "type": "openai",
+        "model": "gpt-4o-mini",
+        "apiKeyEnv": "OPENAI_API_KEY"
+      },
+      "openai-o3": {
+        "type": "openai",
+        "model": "o3",
+        "apiKeyEnv": "OPENAI_API_KEY"
+      },
+      "gemini-3-pro": {
+        "type": "gemini",
+        "model": "gemini-3-pro",
+        "apiKeyEnv": "GEMINI_API_KEY"
+      },
+      "gemini-3-flash": {
+        "type": "gemini",
+        "model": "gemini-3-flash",
+        "apiKeyEnv": "GEMINI_API_KEY"
+      },
+      "gemini-2.5-pro": {
+        "type": "gemini",
+        "model": "gemini-2.5-pro",
+        "apiKeyEnv": "GEMINI_API_KEY"
+      },
+      "gemini-2.5-flash": {
+        "type": "gemini",
+        "model": "gemini-2.5-flash",
+        "apiKeyEnv": "GEMINI_API_KEY"
+      },
+      "gemini-2.0-flash": {
+        "type": "gemini",
+        "model": "gemini-2.0-flash",
+        "apiKeyEnv": "GEMINI_API_KEY"
+      },
+      "anthropic-opus": {
+        "type": "anthropic",
+        "model": "claude-opus-4-8",
+        "apiKeyEnv": "ANTHROPIC_API_KEY"
+      },
+      "anthropic-sonnet": {
+        "type": "anthropic",
+        "model": "claude-sonnet-5",
+        "apiKeyEnv": "ANTHROPIC_API_KEY"
+      },
+      "anthropic-haiku": {
+        "type": "anthropic",
+        "model": "claude-haiku-4-5-20251001",
+        "apiKeyEnv": "ANTHROPIC_API_KEY"
+      }
+    }
+  },
+  "servers": [
+    {
+      "id": "demo",
+      "url": "http://localhost:8788/mcp"
+    }
+  ],
+  "team": {
+    "start": "triage",
+    "members": [
+      {
+        "name": "triage",
+        "instructions": "You are a front-desk triage agent. Greet the user in one line, decide whether their request is about BILLING (refunds, charges, invoices) or TECHNICAL support (bugs, errors, how-to), and immediately transfer to that specialist using the matching transfer tool. Do not try to resolve the request yourself.",
+        "handoffTo": [
+          "billing",
+          "technical"
+        ]
+      },
+      {
+        "name": "billing",
+        "instructions": "You are the billing specialist. Handle refunds, charges, and invoices concisely. If the user later raises a technical issue, transfer to the technical agent.",
+        "handoffTo": [
+          "technical"
+        ]
+      },
+      {
+        "name": "technical",
+        "instructions": "You are the technical support specialist. Handle bugs, errors, and how-to questions concisely. If the user later raises a billing issue, transfer to the billing agent.",
+        "handoffTo": [
+          "billing"
+        ]
+      }
+    ]
+  }
+}

--- a/examples/agents/kitchen-sink/run.sh
+++ b/examples/agents/kitchen-sink/run.sh
@@ -55,20 +55,25 @@ if [ -n "$down" ]; then
 	exit 1
 fi
 
-echo "==> launching agentchat (session=$SESSION, store=$SESSION_STORE)"
+# CONFIG selects the agent topology: the default single-agent kitchen-sink, or
+# kitchen-sink-team.json (handoff Team). MEMORY=0 drops the memory flags — team
+# mode is mutually exclusive with working memory.
+CONFIG="${CONFIG:-$DIR/kitchen-sink.json}"
+MEMORY="${MEMORY:-1}"
+echo "==> launching agentchat (config=$(basename "$CONFIG"), session=$SESSION, store=$SESSION_STORE)"
 cd "$ROOT/cmd/agentchat"
 args=(
-	--config "$DIR/kitchen-sink.json"
+	--config "$CONFIG"
 	--persist-config
 	--session-store "$SESSION_STORE"
 	--session "$SESSION"
 	--offload-threshold "$OFFLOAD_THRESHOLD"
-	--memory --memory-inject-recall
 	--compact-tokens "$COMPACT_TOKENS"
 	--exporter "$EXPORTER"
 	--otlp-endpoint "$OTLP_ENDPOINT"
 	--ui "$UI"
 )
+[ "$MEMORY" = "1" ] && args+=(--memory --memory-inject-recall)
 [ -n "$ACTIVE" ] && args+=(--active "$ACTIVE")
 # Only override the config's embedder role when EMBED_MODEL is set.
 if [ -n "$EMBED_MODEL" ]; then


### PR DESCRIPTION
## What changes

Wires the handoff `Team` (943) into the host loop: `Config.Team` drives the conversation instead of the single main agent. Control **transfers** between members (triage → billing → technical) rather than one agent delegating, and the active agent **persists across user turns** — the transfer-control semantic, not re-route-from-Start-each-turn. Demoed in `examples/agents/kitchen-sink` via `just team`.

## Reviewer's guide

Read in this order:
1. [agent/team.go](https://github.com/panyam/mcpkit/pull/1156/files#diff-ecc8523fab2cb54248822322542d9194c8e2f9436ce81b71cd07d422edebc7ea) — start here. New `Team.RunTurn(ctx, history, active) → (result, active, err)`: runs the active member (or Start) over the carried history, loops handoffs, returns **all-hops messages** + the ending active agent. `Team.Run` now delegates to it (behavior-preserving).
2. [agent/team_test.go](https://github.com/panyam/mcpkit/pull/1156/files#diff-b1e079492f9b20d890a2861696c46a81012528d28a2868eda668d21ea9c79248) — the persistence acceptance: turn 2 starts from the persisted specialist, not Start.
3. [agent/host/app.go](https://github.com/panyam/mcpkit/pull/1156/files#diff-89fb8e04b6e1e9d5f7f76958490ef158dee40e2cae92d87c04b408d893c84361) — the `RunTurn` branch (team vs single runner) + `activeTeamAgent` persistence + the mutual-exclusivity validation call.
4. [agent/host/team.go](https://github.com/panyam/mcpkit/pull/1156/files#diff-64d0de2282508335f96858811789313fd128095e71202292423189f417326131) — `buildTeam` + `validateTeamExclusive`.
5. [agent/host/team_test.go](https://github.com/panyam/mcpkit/pull/1156/files#diff-b7f1da08d2e8d2f21975cf82714af55fe56916035d19f8be5662716bee8cd975) — host acceptance: handoff drives RunTurn, `HostHandoff` fires, active persists, single-agent-features rejected.
6. `agent/host/{config,hostevent,render,subagents}.go` — config type, `HostHandoff` event, `→ handed off to X` render, and the `personaRunnerConfig` extraction shared by sub-agent / fan-out / team member building.

Skim or skip: `examples/agents/kitchen-sink/*` (demo config, recipe, README), [docs/AGENT_COMPOSITION.md](https://github.com/panyam/mcpkit/pull/1156/files#diff-eb4e08c1812047fd2e31f27bd4879fe7c4ab94690580b2e559203992cb5fea0b).

## How it works

```
App.RunTurn(input):
  append user msg to a.history
  turnMsgs = a.history                      # memory injection is a no-op in team mode
  if a.team != nil:
    result, active, err = a.team.RunTurn(ctx, turnMsgs, a.activeTeamAgent, emit)
    a.activeTeamAgent = active              # <-- control stays where it was transferred
  else:
    result, err = a.runner.Run(ctx, turnMsgs, emit)
  a.history += result.Messages              # result.Messages spans every handoff hop

Team.RunTurn(history, active):
  current = members[active] or Start
  loop:
    result = current.runner.Run(history)    # a member's full multi-step turn
    history += result.Messages; appended += result.Messages
    target = handoffSignal.take()
    if no target: return {result, Messages: appended}, current   # final answer
    current = members[target]; fire OnHandoff; enforce MaxHandoffs
```

The one subtlety a reviewer would pause on: a member runs its *whole* multi-step turn (it may call the transfer tool and then emit follow-up text) before the Team checks the handoff signal, so the transferring agent can consume more than one provider turn — the test's before/after request count accounts for that.

## Decision log

- **History-aware `Team.RunTurn` on the agent layer, not a re-implemented loop in the host.** Keeps the one handoff loop in `team.go`; the host only threads `a.history` + `a.activeTeamAgent`.
- **Active agent persists** (sticky), the Swarm semantic — "transfer control" means it stays transferred. Re-triage-every-turn would be routing (the 1044 story), not handoff.
- **Team is a distinct top-level mode**, mutually exclusive with the single agent's memory / sub-agents / fan-out (validated, not silently dropped) — those attach to one agent, and team members are their own Runners. Integrating them into members is deferred.
- **Demo as a sibling config** (`kitchen-sink-team.json` + `just team`), not folded into `kitchen-sink.json`, precisely because team mode *replaces* the single-agent config the main file exercises.

## Risk / blast radius

- **Affects:** `agent.Team` (additive method; `Run` delegates, existing tests assert `.Text` only), `agent/host` (new mode gated behind `Config.Team`; single-agent path unchanged when `Team == nil`).
- **Latent-bug-adjacent:** `serverTools` init now also fires for `Team` (same class as the fan-out fix).
- **Tests:** agent `RunTurn` persistence; host handoff-drives-RunTurn + active-persists-across-turns + exclusivity rejection; full `agent` + `agent/host` green under `-race`. Team-branch proven to have teeth (forcing the single-runner path fails the handoff test).
- **Be paranoid about:** the all-hops `result.Messages` — dropping intermediate agents' messages would corrupt the persisted history; the agent test asserts the span is > the last agent's own messages.

## Before / after

```
before: Config gave you one main agent (+ sub-agents / fan-out / memory).
        No way to transfer control; a "router" persona stayed in the loop
        every turn.

after (just team):
  you> I was double charged, can I get a refund?
  → handed off to billing
  billing> ...refund handled...
  you> also the export button throws a 500
  → handed off to technical
  technical> ...            # active agent persisted: this went straight to
                            # billing→technical, not back through triage
```

## Out of scope (deferred on 1042)

- Per-team-member memory / offloading / compaction.
- Team + single-agent-feature coexistence (the "outer agent" model).
- Structured handoff context beyond the shared history.

